### PR TITLE
feat: add Message capture and OnRun value capture to JSON output

### DIFF
--- a/AlRunner/Pipeline.cs
+++ b/AlRunner/Pipeline.cs
@@ -48,6 +48,7 @@ public class PipelineResult
     public int ExitCode { get; init; }
     public List<TestResult> Tests { get; init; } = new();
     public List<CapturedValue> CapturedValues { get; init; } = new();
+    public List<string> Messages { get; init; } = new();
     public int Passed => Tests.Count(t => t.Status == TestStatus.Pass);
     public int Failed => Tests.Count(t => t.Status == TestStatus.Fail);
     public int Errors => Tests.Count(t => t.Status == TestStatus.Error);
@@ -89,10 +90,13 @@ public class AlRunnerPipeline
             }
         }
 
+        // Collect messages
+        var messages = Runtime.MessageCapture.GetMessages();
+
         var stdoutStr = stdout.ToString();
-        if (options.OutputJson && testResults.Count > 0)
+        if (options.OutputJson && (testResults.Count > 0 || messages.Count > 0))
         {
-            stdoutStr = SerializeJsonOutput(testResults, exitCode, capturedValues: capturedValues);
+            stdoutStr = SerializeJsonOutput(testResults, exitCode, capturedValues: capturedValues, messages: messages);
         }
 
         return new PipelineResult
@@ -100,12 +104,13 @@ public class AlRunnerPipeline
             ExitCode = exitCode,
             Tests = testResults,
             CapturedValues = capturedValues,
+            Messages = messages,
             StdOut = stdoutStr,
             StdErr = stderr.ToString()
         };
     }
 
-    public static string SerializeJsonOutput(List<TestResult> tests, int exitCode, bool indented = true, List<CapturedValue>? capturedValues = null)
+    public static string SerializeJsonOutput(List<TestResult> tests, int exitCode, bool indented = true, List<CapturedValue>? capturedValues = null, List<string>? messages = null)
     {
         object? capturedValuesObj = capturedValues?.Count > 0
             ? capturedValues.Select(c => new
@@ -133,7 +138,8 @@ public class AlRunnerPipeline
             errors = tests.Count(t => t.Status == TestStatus.Error),
             total = tests.Count,
             exitCode,
-            capturedValues = capturedValuesObj
+            capturedValues = capturedValuesObj,
+            messages = messages?.Count > 0 ? messages : null
         };
 
         return JsonSerializer.Serialize(output, new JsonSerializerOptions
@@ -372,6 +378,9 @@ public class AlRunnerPipeline
         int exitCode;
         if (hasTests)
         {
+            Runtime.MessageCapture.Reset();
+            Runtime.MessageCapture.Enable();
+
             if (options.CaptureValues)
             {
                 Runtime.ValueCapture.Reset();
@@ -388,6 +397,7 @@ public class AlRunnerPipeline
 
             if (options.CaptureValues)
                 Runtime.ValueCapture.Disable();
+            Runtime.MessageCapture.Disable();
             if (options.ShowCoverage)
             {
                 Executor.PrintCoverageReport();
@@ -411,7 +421,17 @@ public class AlRunnerPipeline
         }
         else
         {
-            exitCode = Executor.RunOnRun(assembly);
+            Runtime.MessageCapture.Reset();
+            Runtime.MessageCapture.Enable();
+            if (options.CaptureValues)
+            {
+                Runtime.ValueCapture.Reset();
+                Runtime.ValueCapture.Enable();
+            }
+            exitCode = Executor.RunOnRun(assembly, captureValues: options.CaptureValues);
+            if (options.CaptureValues)
+                Runtime.ValueCapture.Disable();
+            Runtime.MessageCapture.Disable();
         }
         Timer.EndStage("Test execution");
         Timer.Print();

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -1916,7 +1916,7 @@ public static class Executor
         return string.Join("\n", frames.Select(f => $"      {f}")) + "\n";
     }
 
-    public static int RunOnRun(Assembly assembly)
+    public static int RunOnRun(Assembly assembly, bool captureValues = false)
     {
         Type? scopeType = null;
 
@@ -1995,6 +1995,8 @@ public static class Executor
         try
         {
             onRunMethod.Invoke(scope, null);
+            if (captureValues)
+                CaptureFieldValues(scope, scopeType, "OnRun");
             return 0;
         }
         catch (TargetInvocationException ex)

--- a/AlRunner/Runtime/AlScope.cs
+++ b/AlRunner/Runtime/AlScope.cs
@@ -186,10 +186,13 @@ public static class AlDialog
     {
         var netFormat = ConvertAlFormat(format);
         var stringArgs = args.Select(a => AlCompat.Format(a)).ToArray();
+        string formatted;
         if (stringArgs.Length > 0)
-            Console.WriteLine(string.Format(netFormat, stringArgs));
+            formatted = string.Format(netFormat, stringArgs);
         else
-            Console.WriteLine(format);
+            formatted = format;
+        Console.WriteLine(formatted);
+        MessageCapture.Capture(formatted);
     }
 
     public static void Error(string format, params object?[] args)

--- a/AlRunner/Runtime/MessageCapture.cs
+++ b/AlRunner/Runtime/MessageCapture.cs
@@ -1,0 +1,19 @@
+namespace AlRunner.Runtime;
+
+public static class MessageCapture
+{
+    private static readonly List<string> _messages = new();
+    private static bool _enabled;
+
+    public static void Enable() => _enabled = true;
+    public static void Disable() => _enabled = false;
+    public static void Reset() => _messages.Clear();
+
+    public static void Capture(string message)
+    {
+        if (!_enabled) return;
+        _messages.Add(message);
+    }
+
+    public static List<string> GetMessages() => new(_messages);
+}


### PR DESCRIPTION
## Summary

- Add `MessageCapture` static class (mirrors `ValueCapture` pattern) to collect `Message()` output into a structured list alongside `Console.WriteLine`
- Modify `AlDialog.Message()` to capture formatted messages
- Include `"messages"` array in `--output-json` output
- Enable `--capture-values` for OnRun triggers (not just test methods) by wiring `CaptureFieldValues` into the `RunOnRun` path

## Motivation

Building an IDE extension ([ALchemist](https://github.com/SShadowS/ALchemist)) that provides Quokka-style inline feedback for AL. With these changes, the extension can:

- Get `Message()` output as structured JSON instead of parsing bare stdout text
- Show captured variable values on hover for scratch/inline AL code, not just test codeunits

## Test plan

- [ ] `al-runner --output-json -e "Message('hello')"` includes `"messages": ["hello"]` in JSON
- [ ] `al-runner --output-json --capture-values <file-with-OnRun>` includes `"capturedValues"` with variable names and final values
- [ ] Existing test suite passes (`dotnet test`)
- [ ] No change to non-JSON output behavior (Message still goes to Console.WriteLine)