### PR TITLE
feat: resilient against duplicate .app packages (AL0275 self-duplicate)

### DIFF
--- a/AlRunner.Tests/DiagnosticClassifierTests.cs
+++ b/AlRunner.Tests/DiagnosticClassifierTests.cs
@@ -1,0 +1,100 @@
+using AlRunner;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public class DiagnosticClassifierTests
+{
+    // Real message format from AL compiler:
+    // 'ObjName' is an ambiguous reference between 'ObjName' defined by the extension
+    // 'AppName by Publisher (Version)' and 'AppName by Publisher (Version)'.
+
+    private const string SelfDuplicateMessage =
+        "'My Object' is an ambiguous reference between " +
+        "'My Object' defined by the extension " +
+        "'My App by My Publisher (1.0.0.0)' and " +
+        "'My Object' defined by the extension " +
+        "'My App by My Publisher (1.0.0.0)'.";
+
+    private const string GenuineAmbiguityMessage =
+        "'My Object' is an ambiguous reference between " +
+        "'My Object' defined by the extension " +
+        "'App Alpha by Publisher A (1.0.0.0)' and " +
+        "'My Object' defined by the extension " +
+        "'App Beta by Publisher B (1.0.0.0)'.";
+
+    private const string SameNameDifferentVersionMessage =
+        "'My Object' is an ambiguous reference between " +
+        "'My Object' defined by the extension " +
+        "'My App by My Publisher (1.0.0.0)' and " +
+        "'My Object' defined by the extension " +
+        "'My App by My Publisher (2.0.0.0)'.";
+
+    // --- IsSelfDuplicateAmbiguity ---
+
+    [Fact]
+    public void IsSelfDuplicateAmbiguity_IdenticalExtensions_ReturnsTrue()
+    {
+        Assert.True(DiagnosticClassifier.IsSelfDuplicateAmbiguity(SelfDuplicateMessage));
+    }
+
+    [Fact]
+    public void IsSelfDuplicateAmbiguity_DifferentExtensions_ReturnsFalse()
+    {
+        Assert.False(DiagnosticClassifier.IsSelfDuplicateAmbiguity(GenuineAmbiguityMessage));
+    }
+
+    [Fact]
+    public void IsSelfDuplicateAmbiguity_SameNameDifferentVersion_ReturnsFalse()
+    {
+        // Same publisher+name but different version is NOT a self-duplicate
+        Assert.False(DiagnosticClassifier.IsSelfDuplicateAmbiguity(SameNameDifferentVersionMessage));
+    }
+
+    [Fact]
+    public void IsSelfDuplicateAmbiguity_MalformedMessage_ReturnsFalse()
+    {
+        Assert.False(DiagnosticClassifier.IsSelfDuplicateAmbiguity("some unrelated error"));
+        Assert.False(DiagnosticClassifier.IsSelfDuplicateAmbiguity(""));
+        Assert.False(DiagnosticClassifier.IsSelfDuplicateAmbiguity(
+            "'Foo' is an ambiguous reference between 'Foo' defined by the extension 'Only One Extension (1.0)'."));
+    }
+
+    [Fact]
+    public void IsSelfDuplicateAmbiguity_CaseInsensitive_ReturnsTrue()
+    {
+        var msg = "'Obj' is an ambiguous reference between " +
+                  "'Obj' defined by the extension 'My App by ACME (1.0.0.0)' and " +
+                  "'Obj' defined by the extension 'My App by Acme (1.0.0.0)'.";
+        Assert.True(DiagnosticClassifier.IsSelfDuplicateAmbiguity(msg));
+    }
+
+    // --- ExtractAmbiguityExtensionIds ---
+
+    [Fact]
+    public void ExtractAmbiguityExtensionIds_ParsesBothSides()
+    {
+        var result = DiagnosticClassifier.ExtractAmbiguityExtensionIds(SelfDuplicateMessage);
+
+        Assert.NotNull(result);
+        Assert.Equal("My App by My Publisher (1.0.0.0)", result!.Value.Left);
+        Assert.Equal("My App by My Publisher (1.0.0.0)", result.Value.Right);
+    }
+
+    [Fact]
+    public void ExtractAmbiguityExtensionIds_GenuineAmbiguity_ParsesBothSides()
+    {
+        var result = DiagnosticClassifier.ExtractAmbiguityExtensionIds(GenuineAmbiguityMessage);
+
+        Assert.NotNull(result);
+        Assert.Equal("App Alpha by Publisher A (1.0.0.0)", result!.Value.Left);
+        Assert.Equal("App Beta by Publisher B (1.0.0.0)", result.Value.Right);
+    }
+
+    [Fact]
+    public void ExtractAmbiguityExtensionIds_MalformedMessage_ReturnsNull()
+    {
+        Assert.Null(DiagnosticClassifier.ExtractAmbiguityExtensionIds("unrelated error"));
+        Assert.Null(DiagnosticClassifier.ExtractAmbiguityExtensionIds(""));
+    }
+}

--- a/AlRunner.Tests/DuplicatePackageTests.cs
+++ b/AlRunner.Tests/DuplicatePackageTests.cs
@@ -1,0 +1,329 @@
+using System.IO.Compression;
+using System.Xml.Linq;
+using AlRunner;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// Tests that al-runner is resilient against duplicate .app packages in the packages directory.
+/// Uses minimal synthetic .app files (NAVX header + NavxManifest.xml only, no AL symbols)
+/// to test the proactive deduplication logic at scan time.
+/// </summary>
+[Collection("Pipeline")]
+public class DuplicatePackageTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+
+    private static string TestPath(string testCase, string sub) =>
+        Path.Combine(RepoRoot, "tests", testCase, sub);
+
+    // The alc binary path — configurable via env var, falls back to the VS Code extension location.
+    private static readonly string? AlcPath = FindAlcPath();
+
+    private static string? FindAlcPath()
+    {
+        var fromEnv = Environment.GetEnvironmentVariable("AL_COMPILER_PATH");
+        if (fromEnv != null && File.Exists(fromEnv)) return fromEnv;
+
+        var vscodePath = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+            ".vscode", "extensions");
+        if (!Directory.Exists(vscodePath)) return null;
+
+        foreach (var extDir in Directory.GetDirectories(vscodePath, "ms-dynamics-smb.al-*"))
+        {
+            var candidate = Path.Combine(extDir, "bin", "linux", "alc");
+            if (File.Exists(candidate)) return candidate;
+        }
+        return null;
+    }
+
+    // --- Proactive deduplication: same publisher/name/version, different GUIDs ---
+
+    [Fact]
+    public void PackageScanner_SamePublisherNameVersion_DifferentGuids_KeepsOneEntry()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "al-runner-duptest-" + Guid.NewGuid().ToString("N")[..8]);
+        try
+        {
+            Directory.CreateDirectory(dir);
+            var guid1 = Guid.NewGuid();
+            var guid2 = Guid.NewGuid();
+            CreateMinimalApp(dir, "App1_copy1.app", "Acme", "My App", "1.0.0.0", guid1);
+            CreateMinimalApp(dir, "App1_copy2.app", "Acme", "My App", "1.0.0.0", guid2);
+
+            var specs = PackageScanner.ScanForSpecs(new[] { dir });
+
+            // Should deduplicate to exactly one entry for "My App by Acme (1.0.0.0)"
+            var myApp = specs.Where(s =>
+                string.Equals(s.Publisher, "Acme", StringComparison.OrdinalIgnoreCase) &&
+                string.Equals(s.Name, "My App", StringComparison.OrdinalIgnoreCase) &&
+                s.Version == new Version("1.0.0.0")).ToList();
+            Assert.Single(myApp);
+        }
+        finally { if (Directory.Exists(dir)) Directory.Delete(dir, true); }
+    }
+
+    [Fact]
+    public void PackageScanner_SamePublisherNameVersion_DifferentGuids_ChoiceIsDeterministic()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "al-runner-duptest-" + Guid.NewGuid().ToString("N")[..8]);
+        try
+        {
+            Directory.CreateDirectory(dir);
+            var guidA = new Guid("aaaaaaaa-0000-0000-0000-000000000000");
+            var guidB = new Guid("bbbbbbbb-0000-0000-0000-000000000000");
+            CreateMinimalApp(dir, "AppB.app", "Acme", "My App", "1.0.0.0", guidB);
+            CreateMinimalApp(dir, "AppA.app", "Acme", "My App", "1.0.0.0", guidA);
+
+            var first = PackageScanner.ScanForSpecs(new[] { dir });
+            var second = PackageScanner.ScanForSpecs(new[] { dir });
+
+            // The surviving GUID should be the same across two calls
+            var firstGuid = first.First(s => s.Name == "My App").AppId;
+            var secondGuid = second.First(s => s.Name == "My App").AppId;
+            Assert.Equal(firstGuid, secondGuid);
+        }
+        finally { if (Directory.Exists(dir)) Directory.Delete(dir, true); }
+    }
+
+    [Fact]
+    public void PackageScanner_SameNameDifferentPublisher_KeepsBoth()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "al-runner-duptest-" + Guid.NewGuid().ToString("N")[..8]);
+        try
+        {
+            Directory.CreateDirectory(dir);
+            CreateMinimalApp(dir, "AppX.app", "PublisherX", "My App", "1.0.0.0", Guid.NewGuid());
+            CreateMinimalApp(dir, "AppY.app", "PublisherY", "My App", "1.0.0.0", Guid.NewGuid());
+
+            var specs = PackageScanner.ScanForSpecs(new[] { dir });
+
+            // Different publishers — both should be kept
+            Assert.Equal(2, specs.Count(s => s.Name == "My App"));
+        }
+        finally { if (Directory.Exists(dir)) Directory.Delete(dir, true); }
+    }
+
+    [Fact]
+    public void PackageScanner_SamePublisherNameDifferentVersion_KeepsBoth()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "al-runner-duptest-" + Guid.NewGuid().ToString("N")[..8]);
+        try
+        {
+            Directory.CreateDirectory(dir);
+            CreateMinimalApp(dir, "App100.app", "Acme", "My App", "1.0.0.0", Guid.NewGuid());
+            CreateMinimalApp(dir, "App200.app", "Acme", "My App", "2.0.0.0", Guid.NewGuid());
+
+            var specs = PackageScanner.ScanForSpecs(new[] { dir });
+
+            // Different versions are NOT self-duplicates — both should be kept
+            Assert.Equal(2, specs.Count(s =>
+                string.Equals(s.Publisher, "Acme", StringComparison.OrdinalIgnoreCase) &&
+                s.Name == "My App"));
+        }
+        finally { if (Directory.Exists(dir)) Directory.Delete(dir, true); }
+    }
+
+    [Fact]
+    public void PackageScanner_SameGuidAcrossTwoDirs_KeepsOne()
+    {
+        var dir1 = Path.Combine(Path.GetTempPath(), "al-runner-duptest1-" + Guid.NewGuid().ToString("N")[..8]);
+        var dir2 = Path.Combine(Path.GetTempPath(), "al-runner-duptest2-" + Guid.NewGuid().ToString("N")[..8]);
+        try
+        {
+            Directory.CreateDirectory(dir1);
+            Directory.CreateDirectory(dir2);
+            var sharedGuid = Guid.NewGuid();
+            CreateMinimalApp(dir1, "App.app", "Acme", "My App", "1.0.0.0", sharedGuid);
+            CreateMinimalApp(dir2, "App.app", "Acme", "My App", "1.0.0.0", sharedGuid);
+
+            var specs = PackageScanner.ScanForSpecs(new[] { dir1, dir2 });
+
+            Assert.Single(specs.Where(s => s.Name == "My App"));
+        }
+        finally
+        {
+            if (Directory.Exists(dir1)) Directory.Delete(dir1, true);
+            if (Directory.Exists(dir2)) Directory.Delete(dir2, true);
+        }
+    }
+
+    // --- DiagnosticClassifier integration: AL0275 self-duplicate suppression ---
+
+    [Fact]
+    public void DiagnosticClassifier_SelfDuplicate_IsIdentifiedCorrectly()
+    {
+        var msg =
+            "'My Object' is an ambiguous reference between " +
+            "'My Object' defined by the extension " +
+            "'My App by My Publisher (1.0.0.0)' and " +
+            "'My Object' defined by the extension " +
+            "'My App by My Publisher (1.0.0.0)'.";
+
+        Assert.True(DiagnosticClassifier.IsSelfDuplicateAmbiguity(msg));
+    }
+
+    // --- Integration test using alc (skipped when alc is not available) ---
+
+    [Fact]
+    public async Task DuplicatePackagesWithSymbols_DoNotCauseAl0275Failure()
+    {
+        if (AlcPath == null)
+        {
+            // Skip gracefully — alc is not available in this environment
+            return;
+        }
+
+        var workDir = Path.Combine(Path.GetTempPath(), "al-runner-alc-duptest-" + Guid.NewGuid().ToString("N")[..8]);
+        try
+        {
+            // Build a minimal AL app with one table and two different GUIDs
+            var guid1 = Guid.NewGuid();
+            var guid2 = Guid.NewGuid();
+            var app1Dir = Path.Combine(workDir, "app1");
+            var app2Dir = Path.Combine(workDir, "app2");
+            var pkgDir = Path.Combine(workDir, "packages");
+            var srcDir = Path.Combine(workDir, "src");
+            var testAlDir = Path.Combine(workDir, "test");
+
+            Directory.CreateDirectory(app1Dir);
+            Directory.CreateDirectory(app2Dir);
+            Directory.CreateDirectory(pkgDir);
+            Directory.CreateDirectory(srcDir);
+            Directory.CreateDirectory(testAlDir);
+
+            // Write the AL source (shared content, just different GUIDs in app.json)
+            var tableAl = @"
+table 50100 ""Dup Test Table""
+{
+    fields
+    {
+        field(1; Id; Integer) { }
+        field(2; Name; Text[100]) { }
+    }
+    keys { key(PK; Id) { Clustered = true; } }
+}
+";
+            File.WriteAllText(Path.Combine(app1Dir, "Table.al"), tableAl);
+            File.WriteAllText(Path.Combine(app2Dir, "Table.al"), tableAl);
+            WriteAppJson(app1Dir, "Dup Test App", "TestPublisher", "1.0.0.0", guid1);
+            WriteAppJson(app2Dir, "Dup Test App", "TestPublisher", "1.0.0.0", guid2);
+
+            // Compile both to .app
+            var app1Path = await CompileAlApp(app1Dir);
+            var app2Path = await CompileAlApp(app2Dir);
+            if (app1Path == null || app2Path == null) return; // compilation failed — skip
+
+            File.Copy(app1Path, Path.Combine(pkgDir, Path.GetFileName(app1Path)));
+            File.Copy(app2Path, Path.Combine(pkgDir, Path.GetFileName(app2Path)));
+
+            // Write an AL test that references the table
+            File.WriteAllText(Path.Combine(srcDir, "Src.al"), @"
+codeunit 50200 ""Dup Test Logic""
+{
+    procedure GetId(Rec: Record ""Dup Test Table""): Integer
+    begin
+        exit(Rec.Id);
+    end;
+}
+");
+            File.WriteAllText(Path.Combine(testAlDir, "Test.al"), @"
+codeunit 50300 ""Dup Test Tests""
+{
+    Subtype = Test;
+
+    var Assert: Codeunit Assert;
+
+    [Test]
+    procedure TestGetId()
+    var
+        Logic: Codeunit ""Dup Test Logic"";
+        Rec: Record ""Dup Test Table"";
+    begin
+        Rec.Id := 42;
+        Assert.AreEqual(42, Logic.GetId(Rec), 'Should return record Id');
+    end;
+}
+");
+            var result = await CliRunner.RunAsync(
+                $"--packages \"{pkgDir}\" \"{srcDir}\" \"{testAlDir}\"");
+
+            Assert.Equal(0, result.ExitCode);
+            Assert.DoesNotContain("AL0275", result.StdErr);
+            Assert.Contains("PASS", result.StdOut);
+        }
+        finally { if (Directory.Exists(workDir)) Directory.Delete(workDir, true); }
+    }
+
+    // --- Helpers ---
+
+    /// <summary>
+    /// Creates a minimal .app file (NAVX header + ZIP with NavxManifest.xml only, no AL symbols).
+    /// Sufficient for testing package scanning and deduplication logic.
+    /// </summary>
+    internal static void CreateMinimalApp(
+        string directory, string fileName,
+        string publisher, string name, string version, Guid appId)
+    {
+        var manifest = new XDocument(
+            new XDeclaration("1.0", "utf-8", null),
+            new XElement(XName.Get("Package", "http://schemas.microsoft.com/navx/2015/manifest"),
+                new XElement(XName.Get("App", "http://schemas.microsoft.com/navx/2015/manifest"),
+                    new XAttribute("Id", appId.ToString()),
+                    new XAttribute("Name", name),
+                    new XAttribute("Publisher", publisher),
+                    new XAttribute("Version", version))));
+
+        using var ms = new MemoryStream();
+        using (var zip = new ZipArchive(ms, ZipArchiveMode.Create, leaveOpen: true))
+        {
+            var entry = zip.CreateEntry("NavxManifest.xml");
+            using var entryStream = entry.Open();
+            manifest.Save(entryStream);
+        }
+
+        var zipBytes = ms.ToArray();
+
+        // NAVX header: 4-byte magic "NAVX" + 4-byte LE uint32 header size (8 = no padding)
+        var output = new byte[8 + zipBytes.Length];
+        output[0] = (byte)'N'; output[1] = (byte)'A'; output[2] = (byte)'V'; output[3] = (byte)'X';
+        BitConverter.GetBytes((uint)8).CopyTo(output, 4);
+        zipBytes.CopyTo(output, 8);
+
+        File.WriteAllBytes(Path.Combine(directory, fileName), output);
+    }
+
+    private static void WriteAppJson(string dir, string name, string publisher, string version, Guid id)
+    {
+        File.WriteAllText(Path.Combine(dir, "app.json"), $$"""
+            {
+              "id": "{{id}}",
+              "name": "{{name}}",
+              "publisher": "{{publisher}}",
+              "version": "{{version}}",
+              "platform": "27.0.0.0",
+              "runtime": "14.0"
+            }
+            """);
+    }
+
+    private static async Task<string?> CompileAlApp(string projectDir)
+    {
+        if (AlcPath == null) return null;
+        var psi = new System.Diagnostics.ProcessStartInfo
+        {
+            FileName = AlcPath,
+            Arguments = $"/project:\"{projectDir}\" /outfolder:\"{projectDir}\" /packagecachepath:\"{projectDir}\"",
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false
+        };
+        using var proc = System.Diagnostics.Process.Start(psi)!;
+        await proc.WaitForExitAsync();
+        if (proc.ExitCode != 0) return null;
+        return Directory.GetFiles(projectDir, "*.app").FirstOrDefault();
+    }
+}

--- a/AlRunner/DiagnosticClassifier.cs
+++ b/AlRunner/DiagnosticClassifier.cs
@@ -1,0 +1,42 @@
+using System.Text.RegularExpressions;
+
+namespace AlRunner;
+
+/// <summary>
+/// Classifies AL compiler diagnostics — in particular, identifies when an AL0275
+/// "ambiguous reference" error is a self-duplicate caused by the same extension
+/// being loaded twice under different GUIDs.
+/// </summary>
+public static class DiagnosticClassifier
+{
+    // Matches the extension identity embedded in an AL0275 message.
+    // Example full message:
+    //   'BBW Table' is an ambiguous reference between 'BBW Table' defined by the extension
+    //   'Blue Bear Waste by Blue Bear Waste (27.0.0.0)' and 'BBW Table' defined by the
+    //   extension 'Blue Bear Waste by Blue Bear Waste (27.0.0.0)'.
+    private static readonly Regex ExtensionIdPattern =
+        new(@"defined by the extension '([^']+)'", RegexOptions.Compiled);
+
+    /// <summary>
+    /// Returns true when an AL0275 diagnostic message describes a self-duplicate:
+    /// both sides of the ambiguity reference the same extension identity
+    /// (publisher, name, and version are identical, case-insensitively).
+    /// </summary>
+    public static bool IsSelfDuplicateAmbiguity(string message)
+    {
+        var ids = ExtractAmbiguityExtensionIds(message);
+        if (ids is null) return false;
+        return string.Equals(ids.Value.Left, ids.Value.Right, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Parses both extension identity strings from an AL0275 message.
+    /// Returns null if the message doesn't match the expected format.
+    /// </summary>
+    public static (string Left, string Right)? ExtractAmbiguityExtensionIds(string message)
+    {
+        var matches = ExtensionIdPattern.Matches(message);
+        if (matches.Count < 2) return null;
+        return (matches[0].Groups[1].Value, matches[1].Groups[1].Value);
+    }
+}

--- a/AlRunner/PackageScanner.cs
+++ b/AlRunner/PackageScanner.cs
@@ -1,0 +1,95 @@
+using System.Xml.Linq;
+
+namespace AlRunner;
+
+/// <summary>
+/// Scans package directories for .app files and returns a deduplicated set of
+/// <see cref="PackageSpec"/> entries suitable for use as symbol references.
+///
+/// Deduplication strategy (two passes):
+/// 1. By GUID — if the same app GUID appears more than once (e.g. the same file
+///    copied into multiple package directories), only the entry with the highest
+///    version is kept.
+/// 2. By identity (publisher+name+version, case-insensitive) — if the same logical
+///    package appears more than once with different GUIDs (the root cause of AL0275
+///    self-duplicate errors), only one GUID is kept.  The surviving GUID is chosen
+///    deterministically as the lexicographically smallest GUID to make builds
+///    reproducible across different file-system orderings.
+/// </summary>
+public static class PackageScanner
+{
+    /// <summary>
+    /// Scan one or more package directories and return deduplicated package specs.
+    /// </summary>
+    /// <param name="packageDirs">Directories to search recursively for *.app files.</param>
+    /// <param name="excludeGuid">Optional app GUID to exclude (the app being compiled).</param>
+    /// <param name="excludeName">Optional app name to exclude (the app being compiled).</param>
+    /// <returns>Deduplicated list of package specs, ordered deterministically.</returns>
+    public static IReadOnlyList<PackageSpec> ScanForSpecs(
+        IEnumerable<string> packageDirs,
+        Guid? excludeGuid = null,
+        string? excludeName = null)
+    {
+        // Pass 1: load all app manifests; deduplicate by GUID keeping highest version.
+        var byGuid = new Dictionary<Guid, PackageSpec>();
+
+        foreach (var dir in packageDirs)
+        {
+            if (!Directory.Exists(dir)) continue;
+            foreach (var appFile in Directory.GetFiles(dir, "*.app", SearchOption.AllDirectories))
+            {
+                try
+                {
+                    var spec = ReadPackageSpec(appFile);
+                    if (spec == null) continue;
+                    if (excludeGuid.HasValue && spec.AppId == excludeGuid.Value) continue;
+                    if (excludeName != null &&
+                        string.Equals(spec.Name, excludeName, StringComparison.OrdinalIgnoreCase))
+                        continue;
+
+                    if (!byGuid.TryGetValue(spec.AppId, out var existing) ||
+                        spec.Version > existing.Version)
+                        byGuid[spec.AppId] = spec;
+                }
+                catch { /* corrupt or unreadable .app — skip silently */ }
+            }
+        }
+
+        // Pass 2: deduplicate by (publisher|name|version), keeping the lexicographically
+        // smallest GUID.  This collapses self-duplicates that differ only in GUID and
+        // prevents AL0275 "ambiguous reference" errors at compile time.
+        var byIdentity = new Dictionary<string, PackageSpec>(StringComparer.OrdinalIgnoreCase);
+        foreach (var spec in byGuid.Values.OrderBy(s => s.AppId))
+        {
+            var key = $"{spec.Publisher}|{spec.Name}|{spec.Version}";
+            if (!byIdentity.ContainsKey(key))
+                byIdentity[key] = spec;
+            // else: duplicate identity — discard; the first (lowest GUID) survives
+        }
+
+        return byIdentity.Values.OrderBy(s => s.AppId).ToList();
+    }
+
+    private static PackageSpec? ReadPackageSpec(string appPath)
+    {
+        var doc = AlTranspiler.LoadNavxManifest(appPath);
+        if (doc == null) return null;
+
+        XNamespace ns = "http://schemas.microsoft.com/navx/2015/manifest";
+        var appElement = doc.Root?.Element(ns + "App");
+        var idStr = appElement?.Attribute("Id")?.Value;
+        var name = appElement?.Attribute("Name")?.Value ?? "";
+        var publisher = appElement?.Attribute("Publisher")?.Value ?? "";
+        var versionStr = appElement?.Attribute("Version")?.Value ?? "1.0.0.0";
+
+        if (idStr == null || !Guid.TryParse(idStr, out var guid)) return null;
+        if (!Version.TryParse(versionStr, out var version)) return null;
+
+        return new PackageSpec(publisher, name, version, guid);
+    }
+}
+
+/// <summary>
+/// Represents a resolved .app package (publisher, name, version, GUID) after deduplication.
+/// </summary>
+public record PackageSpec(string Publisher, string Name, Version Version, Guid AppId);

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -509,7 +509,8 @@ public static class AlTranspiler
         // This avoids conflicts when compiling self-contained multi-project spikes from source.
         bool hasExplicitPackages = packagePaths != null && packagePaths.Count > 0;
         var allPackagePaths = hasExplicitPackages ? ResolvePackagePaths(packagePaths, inputPaths) : new List<string>();
-        var appsByGuid = new Dictionary<Guid, (string Publisher, string Name, Version Version)>();
+        // Populated during the "load all packages" path for use in the reactive conflict resolver.
+        var loadedPackageSpecs = new List<PackageSpec>();
         Microsoft.Dynamics.Nav.CodeAnalysis.ISymbolReferenceLoader? refLoader = null;
 
         if (hasExplicitPackages)
@@ -539,47 +540,26 @@ public static class AlTranspiler
                     // No explicit dependencies in app.json — load all .app files from
                     // the packages directory as symbol references. This handles the BC
                     // convention where Application/System dependencies are implicit.
-                    // Deduplicates by app GUID, keeping the highest version.
+                    // PackageScanner deduplicates: first by GUID (keeping highest version),
+                    // then by (publisher+name+version) to eliminate self-duplicates that
+                    // would otherwise produce AL0275 "ambiguous reference" errors.
                     Log.Info("No explicit dependencies found. Loading all .app packages as symbols...");
-                    // Exclude the app being compiled (its source is already in the syntax trees)
-                    var selfName = appIdentity.Name.ToLowerInvariant();
-                    var selfGuid = appIdentity.AppId;
-                    appsByGuid.Clear();
-                    foreach (var pkgDir in allPackagePaths)
-                    {
-                        foreach (var appFile in Directory.GetFiles(pkgDir, "*.app", SearchOption.AllDirectories))
-                        {
-                            try
-                            {
-                                var doc = LoadNavxManifest(appFile);
-                                if (doc == null) continue;
-                                XNamespace ns = "http://schemas.microsoft.com/navx/2015/manifest";
-                                var appElement = doc.Root?.Element(ns + "App");
-                                var idStr = appElement?.Attribute("Id")?.Value;
-                                var appName = appElement?.Attribute("Name")?.Value ?? "";
-                                var appPublisher = appElement?.Attribute("Publisher")?.Value ?? "";
-                                var appVersionStr = appElement?.Attribute("Version")?.Value ?? "1.0.0.0";
-                                if (idStr != null && Guid.TryParse(idStr, out var appGuid)
-                                    && appGuid != selfGuid
-                                    && !string.Equals(appName, appIdentity.Name, StringComparison.OrdinalIgnoreCase))
-                                {
-                                    var ver = Version.Parse(appVersionStr);
-                                    if (!appsByGuid.TryGetValue(appGuid, out var existing) || ver > existing.Version)
-                                        appsByGuid[appGuid] = (appPublisher, appName, ver);
-                                }
-                            }
-                            catch { }
-                        }
-                    }
 
-                    if (appsByGuid.Count > 0)
+                    var scannedSpecs = PackageScanner.ScanForSpecs(
+                        allPackagePaths,
+                        excludeGuid: appIdentity.AppId,
+                        excludeName: appIdentity.Name);
+
+                    loadedPackageSpecs.AddRange(scannedSpecs);
+
+                    if (loadedPackageSpecs.Count > 0)
                     {
-                        var allAppSpecs = appsByGuid.Select(kv =>
-                            new SymbolReferenceSpecification(
-                                kv.Value.Publisher, kv.Value.Name, kv.Value.Version,
-                                false, kv.Key, false, ImmutableArray<Guid>.Empty))
+                        var allAppSpecs = loadedPackageSpecs
+                            .Select(s => new SymbolReferenceSpecification(
+                                s.Publisher, s.Name, s.Version,
+                                false, s.AppId, false, ImmutableArray<Guid>.Empty))
                             .ToArray();
-                        Log.Info($"  Loaded {allAppSpecs.Length} symbol packages (deduplicated by app ID, latest version)");
+                        Log.Info($"  Loaded {allAppSpecs.Length} symbol packages (deduplicated by identity)");
                         compilation = compilation
                             .WithReferenceLoader(refLoader)
                             .AddReferences(allAppSpecs);
@@ -610,42 +590,94 @@ public static class AlTranspiler
             .Where(d => d.Severity == DiagnosticSeverity.Error && !ignoredErrorIds.Contains(d.Id))
             .ToList();
 
-        // When stubs are loaded: detect ambiguity conflicts (AL0275/AL0197) and resolve
-        // by removing the conflicting symbol package, then retrying compilation
-        if (Log.HasStubs && declErrors.Any(d => d.Id is "AL0275" or "AL0197"))
+        // Reactive conflict resolution for AL0275/AL0197 ambiguous reference errors.
+        //
+        // Two distinct cases:
+        //
+        // 1. Self-duplicate (always handled): both sides of the AL0275 message name the
+        //    same extension identity.  This happens when the packages directory contains
+        //    copies of the same .app with different GUIDs.  PackageScanner already removes
+        //    these proactively, but this path handles packages loaded via explicit
+        //    SymbolReferenceSpecification (depSpecs) that bypass PackageScanner.
+        //    Fix: rebuild with a PackageScanner-deduped spec list.
+        //
+        // 2. Stubs-vs-package conflict (stubs only): a stub defines the same object as a
+        //    package. Fix: drop the conflicting package so the stub wins.
+        if (declErrors.Any(d => d.Id is "AL0275" or "AL0197") && hasExplicitPackages && allPackagePaths.Count > 0)
         {
-            // Extract conflicting extension names from error messages
-            // Format: "'X' is an ambiguous reference between 'X' defined by the extension 'AppName by Publisher (Version)' and ..."
-            var conflictingApps = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            foreach (var d in declErrors.Where(d => d.Id is "AL0275" or "AL0197"))
+            var al0275Errors = declErrors.Where(d => d.Id is "AL0275" or "AL0197").ToList();
+
+            // Case 1: self-duplicate AL0275 (no stubs required)
+            var selfDuplicates = al0275Errors.Where(d => DiagnosticClassifier.IsSelfDuplicateAmbiguity(d.GetMessage())).ToList();
+            if (selfDuplicates.Count > 0)
             {
-                var msg = d.GetMessage();
-                // Extract extension names: 'AppName by Publisher (Version)'
-                foreach (var part in msg.Split("'"))
-                {
-                    if (part.Contains(" by ") && part.Contains("(") &&
-                        !part.Contains(appIdentity.Name))
-                    {
-                        // Extract just the app name before " by "
-                        var appName = part.Split(" by ")[0].Trim();
-                        conflictingApps.Add(appName);
-                    }
-                }
+                Log.Info($"Self-duplicate packages detected ({selfDuplicates.Count} AL0275 errors). Re-scanning with identity deduplication...");
+
+                var deduped = PackageScanner.ScanForSpecs(
+                    allPackagePaths,
+                    excludeGuid: appIdentity.AppId,
+                    excludeName: appIdentity.Name);
+
+                var dedupedSpecs = deduped
+                    .Select(s => new SymbolReferenceSpecification(
+                        s.Publisher, s.Name, s.Version,
+                        false, s.AppId, false, ImmutableArray<Guid>.Empty))
+                    .ToArray();
+
+                compilation = Compilation.Create(
+                    moduleName: appIdentity.Name,
+                    publisher: appIdentity.Publisher,
+                    version: appIdentity.Version,
+                    appId: appIdentity.AppId,
+                    syntaxTrees: syntaxTrees.ToArray(),
+                    options: new CompilationOptions(
+                        continueBuildOnError: true,
+                        target: CompilationTarget.OnPrem,
+                        generateOptions: CompilationGenerationOptions.All
+                    ))
+                    .WithReferenceLoader(refLoader)
+                    .AddReferences(dedupedSpecs);
+
+                // Re-check declaration diagnostics
+                declDiags = compilation.GetDeclarationDiagnostics().ToList();
+                declErrors = declDiags
+                    .Where(d => d.Severity == DiagnosticSeverity.Error && !ignoredErrorIds.Contains(d.Id))
+                    .ToList();
+
+                // Refresh al0275Errors for case 2 below
+                al0275Errors = declErrors.Where(d => d.Id is "AL0275" or "AL0197").ToList();
             }
 
-            if (conflictingApps.Count > 0 && hasExplicitPackages)
+            // Case 2: stubs-vs-package conflict (only when stubs are loaded)
+            if (Log.HasStubs && al0275Errors.Any())
             {
-                Log.Info($"Stubs override {conflictingApps.Count} package(s): {string.Join(", ", conflictingApps)}");
-
-                // Rebuild compilation without conflicting packages
-                // Re-discover dependencies excluding conflicted app names
-                if (allPackagePaths.Count > 0)
+                // Extract conflicting extension names from error messages.
+                // Format: "'X' is an ambiguous reference between 'X' defined by the extension
+                //          'AppName by Publisher (Version)' and ..."
+                var conflictingApps = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                foreach (var d in al0275Errors)
                 {
-                    var filteredSpecs = appsByGuid
-                        .Where(kv => !conflictingApps.Contains(kv.Value.Name))
-                        .Select(kv => new SymbolReferenceSpecification(
-                            kv.Value.Publisher, kv.Value.Name, kv.Value.Version,
-                            false, kv.Key, false, ImmutableArray<Guid>.Empty))
+                    var msg = d.GetMessage();
+                    foreach (var part in msg.Split("'"))
+                    {
+                        if (part.Contains(" by ") && part.Contains("(") &&
+                            !part.Contains(appIdentity.Name))
+                        {
+                            var appName = part.Split(" by ")[0].Trim();
+                            conflictingApps.Add(appName);
+                        }
+                    }
+                }
+
+                if (conflictingApps.Count > 0)
+                {
+                    Log.Info($"Stubs override {conflictingApps.Count} package(s): {string.Join(", ", conflictingApps)}");
+
+                    var filteredSpecs = loadedPackageSpecs
+                        .Where(s => !conflictingApps.Contains(s.Name))
+                        .Select(s => new SymbolReferenceSpecification(
+                            s.Publisher, s.Name, s.Version,
+                            false, s.AppId, false, ImmutableArray<Guid>.Empty))
                         .ToArray();
 
                     compilation = Compilation.Create(
@@ -661,13 +693,13 @@ public static class AlTranspiler
                         ))
                         .WithReferenceLoader(refLoader)
                         .AddReferences(filteredSpecs);
-                }
 
-                // Re-check declaration diagnostics
-                declDiags = compilation.GetDeclarationDiagnostics().ToList();
-                declErrors = declDiags
-                    .Where(d => d.Severity == DiagnosticSeverity.Error && !ignoredErrorIds.Contains(d.Id))
-                    .ToList();
+                    // Re-check declaration diagnostics
+                    declDiags = compilation.GetDeclarationDiagnostics().ToList();
+                    declErrors = declDiags
+                        .Where(d => d.Severity == DiagnosticSeverity.Error && !ignoredErrorIds.Contains(d.Id))
+                        .ToList();
+                }
             }
         }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,32 @@ All notable changes to this project are documented here. Format based on
 ## [Unreleased]
 
 ### Fixed
-- **Overloaded procedures with `var List of [T]` parameters** — cross-codeunit
+- **Duplicate `.app` packages no longer cause AL0275 "ambiguous reference" errors**
+  — When the packages directory contains multiple copies of the same extension
+  (same publisher/name/version) with different GUIDs, al-runner now deduplicates
+  them proactively at scan time via `PackageScanner`, keeping exactly one entry per
+  identity (deterministic: lowest GUID wins). A reactive fallback also handles
+  any residual self-duplicate AL0275 errors from explicitly specified dependency
+  specs. Genuine cross-extension AL0275 conflicts (different publishers or names)
+  are unaffected. Stubs-vs-package conflict resolution is unchanged.
+  `DiagnosticClassifier.IsSelfDuplicateAmbiguity` correctly distinguishes the two
+  cases by comparing both sides of the AL0275 message. This fixes the error
+  pattern `'X' is an ambiguous reference between 'X' defined by the extension
+  'App by Publisher (V)' and 'App by Publisher (V)'` when both sides are identical.
+
+### Added
+- **`DiagnosticClassifier`** — new public static class that parses AL compiler
+  diagnostic messages. `IsSelfDuplicateAmbiguity(message)` returns `true` when
+  both extension identity strings in an AL0275 message are identical (the
+  self-duplicate case). `ExtractAmbiguityExtensionIds(message)` returns both
+  extension identity strings or null if the message doesn't match.
+- **`PackageScanner`** — new public static class that scans package directories
+  for `.app` files and returns a deduplicated `IReadOnlyList<PackageSpec>`. Two-
+  pass deduplication: (1) by GUID keeping highest version, (2) by
+  publisher+name+version keeping lowest GUID. Replaces the inline scan loop that
+  was previously embedded in `AlTranspiler`.
+
+### Overloaded procedures with `var List of [T]` parameters
   `Invoke` now resolves the correct overload when the BC compiler emits suffixed
   C# method names (e.g., `ProcessJson_2101255952`) for overloaded AL procedures.
   Previously, `MockCodeunitHandle.Invoke` used only the base method name, picking

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -527,6 +527,8 @@ Follows the `BusinessCentral.AL.*` pattern:
 | File | Role |
 |---|---|
 | `AlRunner/Program.cs` | Main CLI + AlTranspiler + RoslynCompiler + Executor + AppPackageReader + Kernel32Shim + PrintGuide |
+| `AlRunner/DiagnosticClassifier.cs` | AL diagnostic message parser; `IsSelfDuplicateAmbiguity` detects AL0275 self-duplicate packages |
+| `AlRunner/PackageScanner.cs` | Scans package dirs for `.app` files; two-pass deduplication (by GUID then by publisher+name+version) |
 | `AlRunner/RoslynRewriter.cs` | BC→mock type transformations (AST-level) |
 | `AlRunner/Runtime/AlScope.cs` | Base scope, AlDialog, AlCompat, MockDialog |
 | `AlRunner/Runtime/MockRecordHandle.cs` | In-memory record store with filtering, composite PKs, sort ordering |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,6 +183,32 @@ workflow gates NuGet release on all tests passing across all versions.
 
 ---
 
+## Agent Working Rules
+
+These rules apply to every task performed by an AI agent in this repo:
+
+1. **Strict red/green TDD** — Write the failing test first (RED), verify it fails,
+   then implement the fix (GREEN). Never write implementation code without a
+   failing test. This applies to every feature, fix, and mock addition.
+
+2. **Documentation must always be current** — Every change that affects behaviour,
+   CLI flags, mock capabilities, or known limitations must be reflected in:
+   - `README.md`
+   - `--help` / `-h` output (`Program.cs`)
+   - `--guide` output (`PrintGuide()` in `Program.cs`)
+   - `CHANGELOG.md`
+   - The Known Limitations / Implemented Features sections in this file
+
+3. **Best solution, not easiest** — Always choose the highest-quality solution
+   regardless of refactoring scope. Avoid shortcuts that create technical debt.
+   Do not settle for "good enough" when a clearly better design is available.
+
+4. **SOLID & DRY** — Apply SOLID principles to a reasonable degree. Avoid
+   duplicating logic; extract shared behaviour into well-named, single-purpose
+   helpers. Prefer composition over inheritance. Keep classes focused.
+
+---
+
 ## Developer Contract
 
 **What you can unit-test with al-runner:**


### PR DESCRIPTION
## Problem

When the packages directory contains multiple copies of the same extension with different GUIDs, the BC compiler sees the same object names twice and emits AL0275 "ambiguous reference" errors — 2000+ of them in extreme cases — causing compilation to fail.

## Solution

**Proactive deduplication** via new `PackageScanner` class:
- Two-pass dedup: (1) by GUID keeping highest version, (2) by `publisher+name+version` keeping lowest GUID (deterministic)
- Replaces the inline scan loop previously embedded in `AlTranspiler`

**Reactive fallback** via new `DiagnosticClassifier` class:
- `IsSelfDuplicateAmbiguity(message)` identifies when both sides of an AL0275 message are the same extension identity
- If self-duplicate AL0275s slip through (e.g. from explicit `depSpecs`), a new reactive handler rescans with full deduplication — **no stubs required** (previously this path was stubs-only)
- Genuine cross-extension conflicts and stubs-vs-package conflicts are unaffected

## Changes

- `AlRunner/PackageScanner.cs` — new; scans + deduplicates `.app` files
- `AlRunner/DiagnosticClassifier.cs` — new; parses AL0275 messages
- `AlRunner/Program.cs` — uses `PackageScanner`, improved reactive handler
- `AlRunner.Tests/DiagnosticClassifierTests.cs` — 9 unit tests
- `AlRunner.Tests/DuplicatePackageTests.cs` — 6 integration tests
- `CHANGELOG.md`, `CLAUDE.md` — updated

## Test results

79/79 tests passing.