### PR TITLE
Add opt-in crash telemetry and triage pipeline

### DIFF
--- a/.github/workflows/telemetry-triage.yml
+++ b/.github/workflows/telemetry-triage.yml
@@ -1,0 +1,35 @@
+name: Telemetry Triage
+
+on:
+  workflow_dispatch:
+    inputs:
+      from_time:
+        description: 'Query from this ISO-8601 UTC timestamp (leave blank to auto-detect from last run)'
+        required: false
+        default: ''
+      dry_run:
+        description: 'Dry run — print what would happen without creating issues'
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  triage:
+    name: Analyze crash reports and file issues
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      actions: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run triage
+        env:
+          APPINSIGHTS_API_KEY: ${{ secrets.APPINSIGHTS_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_WORKFLOW_REF: ${{ github.workflow_ref }}
+          FROM_TIME: ${{ inputs.from_time }}
+          DRY_RUN: ${{ inputs.dry_run && '1' || '0' }}
+        run: python tools/telemetry-triage/triage.py

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -47,6 +47,7 @@ if (args.Length == 0 || args.Any(a => a is "-h" or "--help"))
     Console.Error.WriteLine("                        <src-dir> ...   optional  when given, only codeunits actually");
     Console.Error.WriteLine("                                                  referenced in those dirs are emitted");
     Console.Error.WriteLine("  --guide               Print test-writing guide for AI coding agents");
+    Console.Error.WriteLine("  --no-telemetry        Disable crash reporting prompt on unexpected errors");
     Console.Error.WriteLine("  -h, --help            Show this help");
     Console.Error.WriteLine();
     Console.Error.WriteLine("Examples:");
@@ -70,6 +71,7 @@ if (args.Length == 0 || args.Any(a => a is "-h" or "--help"))
 
 // Parse arguments into PipelineOptions
 var options = new AlRunner.PipelineOptions();
+bool noTelemetry = false;
 
 int argIdx = 0;
 while (argIdx < args.Length)
@@ -159,6 +161,10 @@ while (argIdx < args.Length)
             options.Verbose = true;
             argIdx++;
             break;
+        case "--no-telemetry":
+            noTelemetry = true;
+            argIdx++;
+            break;
         case "--stubs":
             argIdx++;
             if (argIdx >= args.Length) { Console.Error.WriteLine("Error: --stubs requires a directory argument"); return 1; }
@@ -185,7 +191,17 @@ while (argIdx < args.Length)
 }
 
 var pipeline = new AlRunner.AlRunnerPipeline();
-var result = pipeline.Run(options);
+AlRunner.PipelineResult result;
+try
+{
+    result = pipeline.Run(options);
+}
+catch (Exception ex)
+{
+    await AlRunner.TelemetryReporter.TryReportAsync(ex, options.OutputJson, noTelemetry);
+    Console.Error.WriteLine($"Fatal: {ex.GetType().Name}: {ex.Message}");
+    return 2;
+}
 
 // Forward captured output to actual console
 if (!string.IsNullOrEmpty(result.StdOut))

--- a/AlRunner/TelemetryReporter.cs
+++ b/AlRunner/TelemetryReporter.cs
@@ -1,0 +1,191 @@
+using System.Reflection;
+using System.Text;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+
+namespace AlRunner;
+
+/// <summary>
+/// On-demand crash reporter. Prompts the user interactively before sending any data.
+/// Never fires in CI, server mode, --output-json mode, or non-interactive sessions.
+/// Only stack frames from AlRunner code are included — user AL source, file paths,
+/// and codeunit names are never transmitted.
+/// </summary>
+public static class TelemetryReporter
+{
+    // Application Insights connection string (write-only; no source data is ever sent)
+    private const string InstrumentationKey = "5b19680b-c4cd-4045-9e2c-df36d94d707a";
+    private const string IngestionEndpoint = "https://polandcentral-0.in.applicationinsights.azure.com/v2/track";
+    private const int PromptTimeoutSeconds = 30;
+
+    /// <summary>
+    /// Prompts the user to report an unexpected runner crash, then sends if they consent.
+    /// Safe to call in all contexts — skips silently when non-interactive or noTelemetry is set.
+    /// </summary>
+    public static async Task TryReportAsync(Exception ex, bool outputJson, bool noTelemetry)
+    {
+        if (noTelemetry) return;
+        if (!CanPromptUser(outputJson)) return;
+
+        var report = BuildReport(ex);
+        if (report == null) return;
+
+        Console.Error.WriteLine();
+        Console.Error.WriteLine("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+        Console.Error.WriteLine("  Unexpected runner error — would you like to report it?");
+        Console.Error.WriteLine("  This helps fix al-runner bugs proactively.");
+        Console.Error.WriteLine();
+        Console.Error.WriteLine("  What will be sent (no AL source code, no file paths):");
+        Console.Error.WriteLine($"    Exception : {report.ExceptionType}");
+        Console.Error.WriteLine($"    Message   : {report.ScrubbedMessage}");
+        Console.Error.WriteLine($"    Stack     : {report.FrameCount} runner frame(s)");
+        Console.Error.WriteLine($"    Version   : {report.RunnerVersion}  OS: {report.Os}");
+        Console.Error.WriteLine("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+
+        if (!PromptYesNoWithTimeout($"Send error report? [y/N] (auto-no in {PromptTimeoutSeconds}s): "))
+            return;
+
+        await SendAsync(report);
+        Console.Error.WriteLine("  ✓ Error report sent. Thank you!");
+    }
+
+    // ─── Internals ────────────────────────────────────────────────────────────
+
+    private record TelemetryReport(
+        string ExceptionType,
+        string ScrubbedMessage,
+        string StackText,
+        int FrameCount,
+        string RunnerVersion,
+        string Os);
+
+    private static bool CanPromptUser(bool outputJson) =>
+        !outputJson &&
+        !Console.IsInputRedirected &&
+        !Console.IsOutputRedirected &&
+        !Console.IsErrorRedirected &&
+        Environment.UserInteractive;
+
+    private static bool PromptYesNoWithTimeout(string prompt)
+    {
+        Console.Error.Write(prompt);
+        string? answer = null;
+        var thread = new Thread(() => answer = Console.ReadLine()) { IsBackground = true };
+        thread.Start();
+
+        if (!thread.Join(TimeSpan.FromSeconds(PromptTimeoutSeconds)))
+        {
+            Console.Error.WriteLine("\n  (Timed out — not sending)");
+            return false;
+        }
+
+        return answer?.Trim().Equals("y", StringComparison.OrdinalIgnoreCase) == true;
+    }
+
+    private static TelemetryReport? BuildReport(Exception ex)
+    {
+        // Unwrap TargetInvocationException wrappers
+        var inner = ex;
+        while (inner is TargetInvocationException tie && tie.InnerException != null)
+            inner = tie.InnerException;
+
+        // Skip AL-level errors — expected test failures, not runner bugs
+        if (inner.StackTrace?.Contains("AlDialog.Error") == true) return null;
+        if (inner is NotSupportedException) return null;
+
+        var frames = ExtractRunnerFrames(inner);
+        // No AlRunner frames = crash originated entirely in user-generated code, not our bug
+        if (frames.Count == 0) return null;
+
+        var version = Assembly.GetExecutingAssembly().GetName().Version;
+        var versionStr = version != null ? $"{version.Major}.{version.Minor}.{version.Build}" : "unknown";
+
+        return new TelemetryReport(
+            ExceptionType: inner.GetType().FullName ?? inner.GetType().Name,
+            ScrubbedMessage: ScrubMessage(inner.Message),
+            StackText: string.Join("\n", frames),
+            FrameCount: frames.Count,
+            RunnerVersion: versionStr,
+            Os: Environment.OSVersion.Platform.ToString().ToLowerInvariant());
+    }
+
+    /// <summary>Keep only stack frames originating from AlRunner code.</summary>
+    private static List<string> ExtractRunnerFrames(Exception ex)
+    {
+        if (ex.StackTrace == null) return new();
+
+        return ex.StackTrace
+            .Split('\n')
+            .Select(f => f.Trim())
+            .Where(f => !string.IsNullOrEmpty(f) && f.Contains("AlRunner."))
+            .Take(10)
+            .ToList();
+    }
+
+    /// <summary>
+    /// Strip file paths and other potentially sensitive tokens from exception messages.
+    /// </summary>
+    private static string ScrubMessage(string message)
+    {
+        // Remove Windows-style paths (C:\...)
+        message = Regex.Replace(message, @"[A-Za-z]:\\[^\s]+", "[path]");
+        // Remove Unix-style paths (/home/..., /var/..., etc.)
+        message = Regex.Replace(message, @"(/[\w.\-]+){2,}", "[path]");
+        // Truncate to 200 chars
+        return message.Length > 200 ? message[..200] + "…" : message;
+    }
+
+    private static async Task SendAsync(TelemetryReport report)
+    {
+        try
+        {
+            using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(10) };
+
+            var payload = new[]
+            {
+                new
+                {
+                    name = $"Microsoft.ApplicationInsights.{InstrumentationKey}.Exception",
+                    time = DateTime.UtcNow.ToString("o"),
+                    iKey = InstrumentationKey,
+                    tags = new Dictionary<string, string>
+                    {
+                        ["ai.cloud.role"] = "al-runner",
+                        ["ai.application.ver"] = report.RunnerVersion
+                    },
+                    data = new
+                    {
+                        baseType = "ExceptionData",
+                        baseData = new
+                        {
+                            ver = 2,
+                            exceptions = new[]
+                            {
+                                new
+                                {
+                                    typeName = report.ExceptionType,
+                                    message = report.ScrubbedMessage,
+                                    hasFullStack = report.FrameCount > 0,
+                                    stack = report.StackText
+                                }
+                            },
+                            properties = new Dictionary<string, string>
+                            {
+                                ["os"] = report.Os,
+                                ["runtime"] = $"net{Environment.Version.Major}.{Environment.Version.Minor}"
+                            }
+                        }
+                    }
+                }
+            };
+
+            var json = JsonSerializer.Serialize(payload);
+            var content = new StringContent(json, Encoding.UTF8, "application/json");
+            await http.PostAsync(IngestionEndpoint, content);
+        }
+        catch
+        {
+            // Network errors must never crash the tool
+        }
+    }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ All notable changes to this project are documented here. Format based on
 
 ## [Unreleased]
 
+### Added
+- **Opt-in crash telemetry** — When an unexpected .NET exception escapes the runner
+  pipeline, al-runner now prompts the user to send an anonymous error report to
+  Application Insights (Azure). The prompt only appears in interactive terminal
+  sessions (never in CI, server mode, or when output is redirected). A 30-second
+  timeout auto-answers "no" so no pipeline can ever hang. Only `AlRunner.*` stack
+  frames are included — user AL source, file paths, and codeunit names are never
+  transmitted. Use `--no-telemetry` to disable the prompt entirely.
+
 ### Fixed
 - **Duplicate `.app` packages no longer cause AL0275 "ambiguous reference" errors**
   — When the packages directory contains multiple copies of the same extension

--- a/tools/telemetry-triage/triage.py
+++ b/tools/telemetry-triage/triage.py
@@ -1,0 +1,304 @@
+#!/usr/bin/env python3
+"""
+telemetry-triage: Query Application Insights for al-runner crash reports,
+group them by exception type, and create/update GitHub Issues.
+
+Required environment variables:
+  APPINSIGHTS_API_KEY   Application Insights API key (read access)
+  GITHUB_TOKEN          GitHub token with issues:write permission
+  GITHUB_REPOSITORY     owner/repo (set automatically by Actions)
+  APPINSIGHTS_APP_ID    Application Insights application ID
+
+Optional:
+  FROM_TIME             ISO-8601 UTC timestamp to query from (overrides last-run detection)
+  DRY_RUN               Set to "1" to print what would happen without creating issues
+"""
+
+import json
+import os
+import re
+import sys
+import urllib.request
+import urllib.error
+from datetime import datetime, timezone, timedelta
+
+# ─── Config ───────────────────────────────────────────────────────────────────
+
+APP_ID       = os.environ.get("APPINSIGHTS_APP_ID", "3986aa86-ec55-4392-a3fc-0a8cac86a6d3")
+API_KEY      = os.environ["APPINSIGHTS_API_KEY"]
+GH_TOKEN     = os.environ["GITHUB_TOKEN"]
+GH_REPO      = os.environ["GITHUB_REPOSITORY"]   # e.g. "StefanMaron/BusinessCentral.AL.Runner"
+DRY_RUN      = os.environ.get("DRY_RUN", "0") == "1"
+
+AI_QUERY_URL = f"https://api.applicationinsights.io/v1/apps/{APP_ID}/query"
+GH_API_BASE  = "https://api.github.com"
+ISSUE_LABEL  = "telemetry"
+
+# ─── Helpers ──────────────────────────────────────────────────────────────────
+
+def http_get(url, headers):
+    req = urllib.request.Request(url, headers=headers)
+    with urllib.request.urlopen(req, timeout=30) as r:
+        return json.loads(r.read().decode())
+
+def http_post(url, headers, body):
+    data = json.dumps(body).encode()
+    headers = {**headers, "Content-Type": "application/json"}
+    req = urllib.request.Request(url, data=data, headers=headers, method="POST")
+    try:
+        with urllib.request.urlopen(req, timeout=30) as r:
+            return json.loads(r.read().decode())
+    except urllib.error.HTTPError as e:
+        print(f"  HTTP {e.code}: {e.read().decode()}", file=sys.stderr)
+        raise
+
+def gh_headers():
+    return {
+        "Authorization": f"Bearer {GH_TOKEN}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+
+# ─── Step 1: Determine time window ────────────────────────────────────────────
+
+def get_from_time() -> str:
+    """
+    Return ISO-8601 UTC timestamp to query from.
+    Priority: FROM_TIME env var > last successful run of this workflow > 24h ago.
+    """
+    if from_time_env := os.environ.get("FROM_TIME"):
+        print(f"Using FROM_TIME from environment: {from_time_env}")
+        return from_time_env
+
+    # Try to get the completion time of the last successful run of this workflow.
+    # GITHUB_WORKFLOW_REF has the form "owner/repo/.github/workflows/file.yml@refs/..."
+    workflow_file = os.environ.get("GITHUB_WORKFLOW_REF", "").split("@")[0].split("/")[-1]
+    if workflow_file:
+        try:
+            url = (
+                f"{GH_API_BASE}/repos/{GH_REPO}/actions/workflows/{workflow_file}/runs"
+                f"?conclusion=success&per_page=2"
+            )
+            data = http_get(url, gh_headers())
+            runs = data.get("workflow_runs", [])
+            # runs[0] is the most recent completed run; skip the current run if it
+            # appears (it won't — it's still in_progress when this step executes)
+            if runs:
+                last_time = runs[0]["updated_at"]
+                print(f"Last successful run completed at: {last_time}")
+                return last_time
+        except Exception as e:
+            print(f"Could not determine last run time: {e}", file=sys.stderr)
+
+    # Default: 24 hours ago
+    fallback = (datetime.now(timezone.utc) - timedelta(hours=24)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    print(f"Defaulting to 24h lookback: {fallback}")
+    return fallback
+
+# ─── Step 2: Query Application Insights ───────────────────────────────────────
+
+KQL = """
+exceptions
+| where timestamp > datetime({from_time})
+| where cloud_RoleName == "al-runner"
+| extend ver = tostring(customDimensions["ai.application.ver"])
+| extend os  = tostring(customDimensions["os"])
+| summarize
+    occurrences  = count(),
+    first_seen   = min(timestamp),
+    last_seen    = max(timestamp),
+    versions     = make_set(ver, 20),
+    os_list      = make_set(os, 10),
+    sample_stack = any(outerStackTrace),
+    sample_msg   = any(outerMessage)
+  by type
+| order by occurrences desc
+"""
+
+def query_telemetry(from_time: str) -> list[dict]:
+    kql = KQL.replace("{from_time}", from_time)
+    url = f"{AI_QUERY_URL}?query={urllib.request.quote(kql)}"
+    headers = {"x-api-key": API_KEY, "Accept": "application/json"}
+    print(f"Querying Application Insights from {from_time}…")
+    data = http_get(url, headers)
+
+    tables = data.get("tables", [])
+    if not tables:
+        return []
+
+    table = tables[0]
+    cols  = [c["name"] for c in table["columns"]]
+    rows  = []
+    for row in table["rows"]:
+        rows.append(dict(zip(cols, row)))
+    return rows
+
+# ─── Step 3: Interact with GitHub Issues ──────────────────────────────────────
+
+def ensure_label_exists():
+    url = f"{GH_API_BASE}/repos/{GH_REPO}/labels/{ISSUE_LABEL}"
+    try:
+        http_get(url, gh_headers())
+    except urllib.error.HTTPError as e:
+        if e.code == 404:
+            if DRY_RUN:
+                print(f"[DRY RUN] Would create label '{ISSUE_LABEL}'")
+                return
+            http_post(
+                f"{GH_API_BASE}/repos/{GH_REPO}/labels",
+                gh_headers(),
+                {"name": ISSUE_LABEL, "color": "d93f0b", "description": "Auto-reported crash from al-runner telemetry"},
+            )
+            print(f"Created label '{ISSUE_LABEL}'")
+        else:
+            raise
+
+def find_existing_issue(exception_type: str) -> dict | None:
+    """Search for an open issue whose title matches the exception type fingerprint."""
+    title_fragment = urllib.request.quote(f"[telemetry] {exception_type}")
+    url = f"{GH_API_BASE}/repos/{GH_REPO}/issues?state=open&labels={ISSUE_LABEL}&per_page=100"
+    try:
+        issues = http_get(url, gh_headers())
+        for issue in issues:
+            if issue.get("title", "").startswith(f"[telemetry] {exception_type}"):
+                return issue
+    except Exception as e:
+        print(f"  Warning: could not search issues: {e}", file=sys.stderr)
+    return None
+
+def build_issue_body(row: dict, from_time: str) -> str:
+    exc_type    = row.get("type", "Unknown")
+    sample_msg  = row.get("sample_msg", "")  or "(no message)"
+    sample_stk  = row.get("sample_stack", "") or "(no stack)"
+    occurrences = row.get("occurrences", 0)
+    first_seen  = row.get("first_seen", "")
+    last_seen   = row.get("last_seen", "")
+    versions    = row.get("versions", [])
+    os_list     = row.get("os_list", [])
+
+    ver_str = ", ".join(v for v in versions if v) or "unknown"
+    os_str  = ", ".join(o for o in os_list if o) or "unknown"
+
+    return f"""## Crash report: `{exc_type}`
+
+**Occurrences:** {occurrences}  
+**First seen:** {first_seen}  
+**Last seen:** {last_seen}  
+**Versions affected:** {ver_str}  
+**OS:** {os_str}  
+
+### Sample message
+
+```
+{sample_msg}
+```
+
+### Sample stack (runner frames only)
+
+```
+{sample_stk}
+```
+
+---
+*Automatically created by the telemetry triage workflow from Application Insights data since `{from_time}`.*  
+*Only `AlRunner.*` stack frames are collected — no AL source code or user file paths.*
+<!-- telemetry-fingerprint: {exc_type} -->
+"""
+
+def build_update_comment(row: dict, from_time: str) -> str:
+    exc_type    = row.get("type", "Unknown")
+    occurrences = row.get("occurrences", 0)
+    first_seen  = row.get("first_seen", "")
+    last_seen   = row.get("last_seen", "")
+    versions    = row.get("versions", [])
+    sample_msg  = row.get("sample_msg", "") or "(no message)"
+    sample_stk  = row.get("sample_stack", "") or "(no stack)"
+    ver_str     = ", ".join(v for v in versions if v) or "unknown"
+    now         = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    return f"""### Triage update — {now}
+
+**New occurrences since `{from_time}`:** {occurrences}  
+**First seen:** {first_seen} | **Last seen:** {last_seen}  
+**Versions:** {ver_str}  
+
+**Sample message:** `{sample_msg}`
+
+```
+{sample_stk}
+```
+"""
+
+def create_issue(row: dict, from_time: str):
+    exc_type = row.get("type", "Unknown")
+    title    = f"[telemetry] {exc_type}"
+    body     = build_issue_body(row, from_time)
+
+    if DRY_RUN:
+        print(f"  [DRY RUN] Would create issue: {title} ({row.get('occurrences')} occurrence(s))")
+        return
+
+    result = http_post(
+        f"{GH_API_BASE}/repos/{GH_REPO}/issues",
+        gh_headers(),
+        {"title": title, "body": body, "labels": [ISSUE_LABEL]},
+    )
+    print(f"  Created issue #{result['number']}: {title}")
+
+def update_issue(issue: dict, row: dict, from_time: str):
+    issue_number = issue["number"]
+    comment_body = build_update_comment(row, from_time)
+
+    if DRY_RUN:
+        print(f"  [DRY RUN] Would comment on issue #{issue_number}: {issue['title']} (+{row.get('occurrences')} occurrence(s))")
+        return
+
+    http_post(
+        f"{GH_API_BASE}/repos/{GH_REPO}/issues/{issue_number}/comments",
+        gh_headers(),
+        {"body": comment_body},
+    )
+    print(f"  Updated issue #{issue_number}: {issue['title']} (+{row.get('occurrences')} occurrence(s))")
+
+# ─── Main ─────────────────────────────────────────────────────────────────────
+
+def main():
+    from_time = get_from_time()
+    to_time   = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    print(f"Time window: {from_time} → {to_time}")
+    print()
+
+    rows = query_telemetry(from_time)
+    if not rows:
+        print("No exceptions found in the time window. Nothing to do.")
+        return
+
+    total_occurrences = sum(r.get("occurrences", 0) for r in rows)
+    print(f"Found {len(rows)} unique exception type(s), {total_occurrences} total occurrence(s).")
+    print()
+
+    ensure_label_exists()
+
+    created = 0
+    updated = 0
+
+    for row in rows:
+        exc_type = row.get("type", "Unknown")
+        count    = row.get("occurrences", 0)
+        print(f"  {exc_type} ({count}×)")
+
+        existing = find_existing_issue(exc_type)
+        if existing:
+            update_issue(existing, row, from_time)
+            updated += 1
+        else:
+            create_issue(row, from_time)
+            created += 1
+
+    print()
+    print(f"Done. Created {created} issue(s), updated {updated} issue(s).")
+    if DRY_RUN:
+        print("[DRY RUN] No changes were made.")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds anonymous crash reporting to al-runner and a GitHub Actions pipeline to triage those reports into issues automatically.

---

### Crash reporter (`TelemetryReporter.cs`)

When an unexpected .NET exception escapes the pipeline, al-runner prompts the user to send an anonymous report to Azure Application Insights.

**Privacy by design:**
- Only fires in interactive terminal sessions — never in CI, `--output-json` mode, `--server` mode, or when stdin/stdout is redirected
- 30-second timeout auto-answers **no** — no pipeline can ever hang
- Only `AlRunner.*` stack frames are included — user AL source, file paths, and codeunit names are never transmitted
- Expected errors (`NotSupportedException`, `AlDialog.Error`) are silently skipped
- `--no-telemetry` flag disables the prompt entirely

**What the prompt looks like:**
```
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  Unexpected runner error — would you like to report it?
  What will be sent (no AL source code, no file paths):
    Exception : System.NullReferenceException
    Message   : Object reference not set to an instance of an object
    Stack     : 3 runner frame(s)
    Version   : 0.1.0  OS: unix
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
Send error report? [y/N] (auto-no in 30s):
```

---

### Triage pipeline (`.github/workflows/telemetry-triage.yml` + `tools/telemetry-triage/triage.py`)

Manually triggered workflow that reads crash reports from Application Insights and files GitHub Issues automatically.

- **Time window**: auto-detects from last successful run of this workflow (falls back to 24h, or accepts a `FROM_TIME` override)
- **Grouping**: KQL groups by exception type with occurrence count, first/last seen, affected versions, and a sample stack
- **Deduplication**: searches existing open issues — creates a new issue for new crash types, adds a comment to existing ones when the same crash recurs
- **Dry run**: checkbox input to preview without creating anything

**Requires:** `APPINSIGHTS_API_KEY` repository secret (read-only Application Insights API key from Azure Portal → App Insights → Configure → API Access).

---

### Files changed

- `AlRunner/TelemetryReporter.cs` — new: detection, scrubbing, prompt with timeout, send
- `AlRunner/Program.cs` — wrap `pipeline.Run()` in try/catch, add `--no-telemetry` flag, update help
- `.github/workflows/telemetry-triage.yml` — manual workflow
- `tools/telemetry-triage/triage.py` — triage script (stdlib only, no extra deps)
- `CHANGELOG.md` — document the feature