### PR TITLE
Runner error reclassification, pipeline gap telemetry, and tests

### DIFF
--- a/AlRunner.Tests/RunnerErrorClassificationTests.cs
+++ b/AlRunner.Tests/RunnerErrorClassificationTests.cs
@@ -1,0 +1,139 @@
+using System.Text.Json;
+using AlRunner;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// Tests for runner-error classification: distinguishing user logic failures (FAIL)
+/// from runner limitations (ERROR + IsRunnerBug=true).
+///
+/// Full end-to-end coverage of IsRunnerBug=true requires a package-based scenario
+/// (codeunit available as symbol reference but not compiled into the assembly).
+/// The detection component is verified here via direct MockCodeunitHandle invocation.
+/// </summary>
+[Collection("Pipeline")]
+public class RunnerErrorClassificationTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+
+    private static string TestPath(string testCase, string sub) =>
+        Path.Combine(RepoRoot, "tests", testCase, sub);
+
+    /// <summary>
+    /// Verifies the detection component: MockCodeunitHandle throws the specific
+    /// InvalidOperationException that Executor.IsRunnerError() recognises, with
+    /// the right message and "AlRunner.Runtime.Mock" in the stack trace.
+    /// </summary>
+    [Fact]
+    public void MockCodeunitHandle_UnknownId_ThrowsClassifiableException()
+    {
+        var handle = new AlRunner.Runtime.MockCodeunitHandle(99999);
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            handle.Invoke(0, Array.Empty<object>()));
+
+        Assert.Contains("99999", ex.Message);
+        Assert.Contains("not found in assembly", ex.Message);
+        // IsRunnerError() checks for this frame — must be present.
+        Assert.Contains("AlRunner.Runtime.Mock", ex.StackTrace ?? "");
+    }
+
+    /// <summary>
+    /// Regular assertion failures (user logic wrong) must NOT be classified as
+    /// runner bugs. IsRunnerBug must stay false for plain Fail outcomes.
+    /// </summary>
+    [Fact]
+    public void PipelineResult_AssertFail_IsRunnerBugFalse()
+    {
+        var pipeline = new AlRunnerPipeline();
+        var result = pipeline.Run(new PipelineOptions
+        {
+            InputPaths = { TestPath("06-intentional-failure", "src"), TestPath("06-intentional-failure", "test") }
+        });
+
+        Assert.NotEqual(0, result.ExitCode);
+        var failedTests = result.Tests.Where(t => t.Status == TestStatus.Fail).ToList();
+        Assert.NotEmpty(failedTests);
+        Assert.All(failedTests, t => Assert.False(t.IsRunnerBug,
+            $"'{t.Name}' is a user logic failure — IsRunnerBug must be false"));
+    }
+
+    /// <summary>
+    /// Passing tests must have IsRunnerBug = false (the zero value / default).
+    /// </summary>
+    [Fact]
+    public void PipelineResult_TestPass_IsRunnerBugFalse()
+    {
+        var pipeline = new AlRunnerPipeline();
+        var result = pipeline.Run(new PipelineOptions
+        {
+            InputPaths = { TestPath("01-pure-function", "src"), TestPath("01-pure-function", "test") }
+        });
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.All(result.Tests.Where(t => t.Status == TestStatus.Pass),
+            t => Assert.False(t.IsRunnerBug,
+                $"'{t.Name}' passed — IsRunnerBug must not be set"));
+    }
+
+    /// <summary>
+    /// JSON output must include isRunnerBug:true for runner-limitation errors.
+    /// Verified via SerializeJsonOutput directly since triggering IsRunnerBug=true
+    /// end-to-end requires a package-based scenario.
+    /// </summary>
+    [Fact]
+    public void JsonOutput_IsRunnerBugTrue_AppearsInJson()
+    {
+        var tests = new List<TestResult>
+        {
+            new() { Name = "TestRunnerBug",   Status = TestStatus.Error, IsRunnerBug = true,  Message = "Codeunit 99999 not found in assembly" },
+            new() { Name = "TestUserFail",    Status = TestStatus.Fail,  IsRunnerBug = false, Message = "Expected 1, got 2" },
+            new() { Name = "TestPass",        Status = TestStatus.Pass }
+        };
+
+        var json = AlRunnerPipeline.SerializeJsonOutput(tests, exitCode: 1, indented: false);
+        using var doc = JsonDocument.Parse(json);
+        var testsArr = doc.RootElement.GetProperty("tests").EnumerateArray().ToList();
+
+        // Runner-bug error: isRunnerBug must be true
+        var runnerBugTest = testsArr.First(t => t.GetProperty("name").GetString() == "TestRunnerBug");
+        Assert.Equal("error", runnerBugTest.GetProperty("status").GetString());
+        Assert.True(runnerBugTest.GetProperty("isRunnerBug").GetBoolean());
+
+        // User assertion failure: isRunnerBug must be absent (null → omitted)
+        var userFailTest = testsArr.First(t => t.GetProperty("name").GetString() == "TestUserFail");
+        Assert.Equal("fail", userFailTest.GetProperty("status").GetString());
+        Assert.False(userFailTest.TryGetProperty("isRunnerBug", out _),
+            "isRunnerBug should be omitted (null) when false to keep JSON clean");
+
+        // Pass: isRunnerBug must be absent
+        var passTest = testsArr.First(t => t.GetProperty("name").GetString() == "TestPass");
+        Assert.Equal("pass", passTest.GetProperty("status").GetString());
+        Assert.False(passTest.TryGetProperty("isRunnerBug", out _));
+    }
+
+    /// <summary>
+    /// Output for runner-bug errors must contain the runner-limitation hint with
+    /// the GitHub issues link. Verified via PrintResults on a synthetic result set.
+    /// </summary>
+    [Fact]
+    public void PrintResults_IsRunnerBugTrue_OutputContainsHint()
+    {
+        var tests = new List<TestResult>
+        {
+            new() { Name = "TestMissing", Status = TestStatus.Error, IsRunnerBug = true, Message = "Codeunit 99999 not found in assembly" }
+        };
+
+        var captured = new System.IO.StringWriter();
+        var prev = Console.Out;
+        Console.SetOut(captured);
+        try { Executor.PrintResults(tests); }
+        finally { Console.SetOut(prev); }
+
+        var output = captured.ToString();
+        Assert.Contains("ERROR", output);
+        Assert.Contains("Runner limitation", output);
+        Assert.Contains("github.com/StefanMaron/BusinessCentral.AL.Runner/issues", output);
+    }
+}

--- a/AlRunner/Pipeline.cs
+++ b/AlRunner/Pipeline.cs
@@ -39,6 +39,11 @@ public class TestResult
     /// tests or when the underlying source-span lacks column info).
     /// </summary>
     public int? AlSourceColumn { get; init; }
+    /// <summary>
+    /// True when the error originates from AlRunner.Runtime mock code (a runner
+    /// limitation or bug), not from user AL logic or a missing dependency injection.
+    /// </summary>
+    public bool IsRunnerBug { get; init; }
 }
 
 public class CapturedValue

--- a/AlRunner/Pipeline.cs
+++ b/AlRunner/Pipeline.cs
@@ -175,7 +175,8 @@ public class AlRunnerPipeline
                 message = t.Message,
                 stackTrace = t.StackTrace?.TrimEnd(),
                 alSourceLine = t.AlSourceLine,
-                alSourceColumn = t.AlSourceColumn
+                alSourceColumn = t.AlSourceColumn,
+                isRunnerBug = t.IsRunnerBug ? (bool?)true : null
             }),
             passed = tests.Count(t => t.Status == TestStatus.Pass),
             failed = tests.Count(t => t.Status == TestStatus.Fail),

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -2139,18 +2139,18 @@ public static class Executor
     {
         if (excludedFiles.Count == 0) return;
 
-        Console.WriteLine();
-        Console.WriteLine($"WARN  {excludedFiles.Count} source file(s) excluded from compilation (rewriter gap):");
+        Console.Error.WriteLine();
+        Console.Error.WriteLine($"WARN  {excludedFiles.Count} source file(s) excluded from compilation (rewriter gap):");
         foreach (var (file, errors) in excludedFiles.Take(5))
         {
             var shortName = Path.GetFileNameWithoutExtension(file);
             foreach (var err in errors.Take(2))
-                Console.WriteLine($"      {shortName}: {err}");
+                Console.Error.WriteLine($"      {shortName}: {err}");
         }
         if (excludedFiles.Count > 5)
-            Console.WriteLine($"      … and {excludedFiles.Count - 5} more. Run with -v for the full list.");
-        Console.WriteLine($"      ⚑ Runner limitation — these may cause ERROR results above.");
-        Console.WriteLine($"        File an issue: https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues");
+            Console.Error.WriteLine($"      … and {excludedFiles.Count - 5} more. Run with -v for the full list.");
+        Console.Error.WriteLine($"      ⚑ Runner limitation — these may cause ERROR results above.");
+        Console.Error.WriteLine($"        File an issue: https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues");
     }
 
     private static void CaptureFieldValues(object scope, Type scopeType, string testName)

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -209,6 +209,9 @@ if (!string.IsNullOrEmpty(result.StdOut))
 if (!string.IsNullOrEmpty(result.StdErr))
     Console.Error.Write(result.StdErr);
 
+// Report runner-originated errors via telemetry (interactive only, with timeout)
+await AlRunner.TelemetryReporter.TryReportTestErrorsAsync(result.Tests, options.OutputJson, noTelemetry);
+
 return result.ExitCode;
 
 void PrintGuide()
@@ -2022,6 +2025,19 @@ public static class Executor
                         AlSourceColumn = FindAlSourceColumn(inner)
                     });
                 }
+                else if (IsRunnerError(inner!))
+                {
+                    results.Add(new AlRunner.TestResult
+                    {
+                        Name = testName,
+                        Status = AlRunner.TestStatus.Error,
+                        Message = inner!.Message,
+                        StackTrace = FormatStackFrames(inner),
+                        AlSourceLine = FindAlSourceLine(inner),
+                        AlSourceColumn = FindAlSourceColumn(inner),
+                        IsRunnerBug = true
+                    });
+                }
                 else
                 {
                     results.Add(new AlRunner.TestResult
@@ -2037,15 +2053,31 @@ public static class Executor
             }
             catch (Exception ex)
             {
-                results.Add(new AlRunner.TestResult
+                if (IsRunnerError(ex))
                 {
-                    Name = testName,
-                    Status = AlRunner.TestStatus.Fail,
-                    Message = ex.Message,
-                    StackTrace = FormatStackFrames(ex),
-                    AlSourceLine = FindAlSourceLine(ex),
-                    AlSourceColumn = FindAlSourceColumn(ex)
-                });
+                    results.Add(new AlRunner.TestResult
+                    {
+                        Name = testName,
+                        Status = AlRunner.TestStatus.Error,
+                        Message = ex.Message,
+                        StackTrace = FormatStackFrames(ex),
+                        AlSourceLine = FindAlSourceLine(ex),
+                        AlSourceColumn = FindAlSourceColumn(ex),
+                        IsRunnerBug = true
+                    });
+                }
+                else
+                {
+                    results.Add(new AlRunner.TestResult
+                    {
+                        Name = testName,
+                        Status = AlRunner.TestStatus.Fail,
+                        Message = ex.Message,
+                        StackTrace = FormatStackFrames(ex),
+                        AlSourceLine = FindAlSourceLine(ex),
+                        AlSourceColumn = FindAlSourceColumn(ex)
+                    });
+                }
             }
         }
 
@@ -2070,7 +2102,10 @@ public static class Executor
                 case AlRunner.TestStatus.Error:
                     Console.WriteLine($"ERROR {r.Name}");
                     if (r.Message != null) Console.WriteLine($"      {r.Message}");
-                    Console.WriteLine($"      Inject this dependency via an AL interface.");
+                    if (r.IsRunnerBug)
+                        Console.WriteLine($"      ⚑ Runner limitation — update al-runner or file an issue at https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues");
+                    else
+                        Console.WriteLine($"      Inject this dependency via an AL interface.");
                     if (r.StackTrace != null) Console.Write(r.StackTrace);
                     break;
             }
@@ -2123,6 +2158,16 @@ public static class Executor
         var (typeName, stmtId) = lastHit.Value;
         return SourceLineMapper.GetAlLineFromStatement(typeName, stmtId);
     }
+
+    /// <summary>
+    /// Returns true when the exception originates from AlRunner.Runtime mock code,
+    /// indicating a runner limitation rather than a user test logic failure.
+    /// These should be reported as <see cref="AlRunner.TestStatus.Error"/> with
+    /// <see cref="AlRunner.TestResult.IsRunnerBug"/> = true.
+    /// </summary>
+    private static bool IsRunnerError(Exception ex) =>
+        ex is InvalidOperationException &&
+        ex.StackTrace?.Contains("AlRunner.Runtime.Mock") == true;
 
     /// <summary>
     /// Get the AL source column from the last StmtHit that was executed before

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -209,8 +209,12 @@ if (!string.IsNullOrEmpty(result.StdOut))
 if (!string.IsNullOrEmpty(result.StdErr))
     Console.Error.Write(result.StdErr);
 
-// Report runner-originated errors via telemetry (interactive only, with timeout)
-await AlRunner.TelemetryReporter.TryReportTestErrorsAsync(result.Tests, options.OutputJson, noTelemetry);
+// Print compilation gap warnings after test output so they're visible
+Executor.PrintCompilationGaps(RoslynCompiler.ExcludedFiles);
+
+// Report all pipeline gaps (compilation exclusions + runtime errors) via telemetry
+await AlRunner.TelemetryReporter.TryReportPipelineGapsAsync(
+    result.Tests, RoslynCompiler.ExcludedFiles, options.OutputJson, noTelemetry);
 
 return result.ExitCode;
 
@@ -2124,6 +2128,29 @@ public static class Executor
         if (results.Count == 0) return 1;
         var failedOrError = results.Count(r => r.Status != AlRunner.TestStatus.Pass);
         return failedOrError > 0 ? 1 : 0;
+    }
+
+    /// <summary>
+    /// Prints a visible warning block for any AL source files that were excluded
+    /// from Roslyn compilation due to rewriter gaps. Called after test output so
+    /// the user sees the reason behind any "not found in assembly" errors above.
+    /// </summary>
+    public static void PrintCompilationGaps(Dictionary<string, List<string>> excludedFiles)
+    {
+        if (excludedFiles.Count == 0) return;
+
+        Console.WriteLine();
+        Console.WriteLine($"WARN  {excludedFiles.Count} source file(s) excluded from compilation (rewriter gap):");
+        foreach (var (file, errors) in excludedFiles.Take(5))
+        {
+            var shortName = Path.GetFileNameWithoutExtension(file);
+            foreach (var err in errors.Take(2))
+                Console.WriteLine($"      {shortName}: {err}");
+        }
+        if (excludedFiles.Count > 5)
+            Console.WriteLine($"      … and {excludedFiles.Count - 5} more. Run with -v for the full list.");
+        Console.WriteLine($"      ⚑ Runner limitation — these may cause ERROR results above.");
+        Console.WriteLine($"        File an issue: https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues");
     }
 
     private static void CaptureFieldValues(object scope, Type scopeType, string testName)

--- a/AlRunner/TelemetryReporter.cs
+++ b/AlRunner/TelemetryReporter.cs
@@ -50,48 +50,101 @@ public static class TelemetryReporter
     }
 
     /// <summary>
-    /// After a test run, prompts the user to report any runner-originated errors
-    /// (IsRunnerBug = true). Groups duplicates, shows a single prompt, then sends.
-    /// Safe to call in all contexts — skips silently when non-interactive or noTelemetry is set.
+    /// After a test run, collects ALL pipeline gaps — Roslyn compilation exclusions
+    /// (rewriter misses) and runtime runner-bug errors — shows a single combined prompt,
+    /// and sends everything in one batch if the user consents.
+    ///
+    /// Compilation gaps: files excluded during iterative Roslyn retry because the
+    /// BC-generated C# couldn't compile, indicating the rewriter doesn't handle some
+    /// AL pattern yet.
+    ///
+    /// Runtime gaps: tests that ended with TestStatus.Error + IsRunnerBug = true,
+    /// indicating a missing mock or dispatch path in AlRunner.Runtime.
+    ///
+    /// Safe to call in all contexts — skips silently when non-interactive or noTelemetry.
     /// </summary>
-    public static async Task TryReportTestErrorsAsync(
-        List<TestResult> tests, bool outputJson, bool noTelemetry)
+    public static async Task TryReportPipelineGapsAsync(
+        List<TestResult> tests,
+        Dictionary<string, List<string>> compilationGaps,
+        bool outputJson,
+        bool noTelemetry)
     {
         if (noTelemetry) return;
         if (!CanPromptUser(outputJson)) return;
 
-        var runnerErrors = tests
+        var runtimeErrors = tests
             .Where(t => t.Status == TestStatus.Error && t.IsRunnerBug)
             .ToList();
-        if (runnerErrors.Count == 0) return;
 
-        var grouped = runnerErrors
+        var compGapCount = compilationGaps.Count;
+
+        if (runtimeErrors.Count == 0 && compGapCount == 0) return;
+
+        var runtimeGrouped = runtimeErrors
             .GroupBy(t => t.Message ?? "")
             .Select(g => (Message: g.Key, Count: g.Count(), Sample: g.First()))
             .ToList();
 
         Console.Error.WriteLine();
         Console.Error.WriteLine("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
-        Console.Error.WriteLine($"  {runnerErrors.Count} runner limitation(s) encountered — report them?");
-        Console.Error.WriteLine("  Reporting helps improve al-runner support for more AL patterns.");
+        Console.Error.WriteLine("  Runner limitations encountered — report them?");
+        Console.Error.WriteLine("  Reporting helps improve al-runner support proactively.");
         Console.Error.WriteLine();
         Console.Error.WriteLine("  What will be sent (no AL source code, no file paths):");
-        foreach (var (msg, count, _) in grouped.Take(3))
-            Console.Error.WriteLine($"    × {ScrubMessage(msg)}{(count > 1 ? $" ({count}×)" : "")}");
-        if (grouped.Count > 3)
-            Console.Error.WriteLine($"    … and {grouped.Count - 3} more unique error(s)");
+
+        if (compGapCount > 0)
+        {
+            Console.Error.WriteLine($"  Compilation ({compGapCount} file(s) excluded — rewriter gaps):");
+            foreach (var (file, errors) in compilationGaps.Take(3))
+            {
+                var shortName = Path.GetFileNameWithoutExtension(file);
+                var firstErr = errors.Count > 0 ? ScrubMessage(errors[0]) : "unknown error";
+                Console.Error.WriteLine($"    × {shortName}: {firstErr}");
+            }
+            if (compGapCount > 3)
+                Console.Error.WriteLine($"    … and {compGapCount - 3} more file(s)");
+        }
+
+        if (runtimeErrors.Count > 0)
+        {
+            Console.Error.WriteLine($"  Runtime ({runtimeErrors.Count} test(s) — missing mock/dispatch):");
+            foreach (var (msg, count, _) in runtimeGrouped.Take(3))
+                Console.Error.WriteLine($"    × {ScrubMessage(msg)}{(count > 1 ? $" ({count}×)" : "")}");
+            if (runtimeGrouped.Count > 3)
+                Console.Error.WriteLine($"    … and {runtimeGrouped.Count - 3} more unique error(s)");
+        }
+
         Console.Error.WriteLine($"    Version : {GetVersionString()}  OS: {GetOsString()}");
         Console.Error.WriteLine("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
 
         if (!PromptYesNoWithTimeout($"Send error report? [y/N] (auto-no in {PromptTimeoutSeconds}s): "))
             return;
 
-        foreach (var error in runnerErrors)
+        // Send compilation gaps as a batch event
+        if (compGapCount > 0)
         {
-            var report = BuildTestErrorReport(error);
+            var gapMessages = compilationGaps
+                .SelectMany(kv => kv.Value.Select(err => $"{Path.GetFileNameWithoutExtension(kv.Key)}: {err}"))
+                .Take(20)
+                .ToList();
+            var compReport = new TelemetryReport(
+                ExceptionType: "AlRunner.CompilationGap",
+                ScrubbedMessage: ScrubMessage($"{compGapCount} file(s) excluded: " + string.Join("; ", gapMessages.Take(3))),
+                StackText: string.Join("\n", gapMessages),
+                FrameCount: gapMessages.Count,
+                RunnerVersion: GetVersionString(),
+                Os: GetOsString());
+            await SendAsync(compReport);
+        }
+
+        // Send each unique runtime error (deduplicated by message)
+        foreach (var (_, _, sample) in runtimeGrouped)
+        {
+            var report = BuildTestErrorReport(sample);
             if (report != null)
                 await SendAsync(report);
         }
+
         Console.Error.WriteLine("  ✓ Error report sent. Thank you!");
     }
 
@@ -164,7 +217,7 @@ public static class TelemetryReporter
             .ToList() ?? new List<string>();
 
         return new TelemetryReport(
-            ExceptionType: "System.InvalidOperationException",
+            ExceptionType: "AlRunner.RuntimeGap",
             ScrubbedMessage: ScrubMessage(result.Message ?? ""),
             StackText: string.Join("\n", frames),
             FrameCount: frames.Count,

--- a/AlRunner/TelemetryReporter.cs
+++ b/AlRunner/TelemetryReporter.cs
@@ -124,7 +124,7 @@ public static class TelemetryReporter
         if (compGapCount > 0)
         {
             var gapMessages = compilationGaps
-                .SelectMany(kv => kv.Value.Select(err => $"{Path.GetFileNameWithoutExtension(kv.Key)}: {err}"))
+                .SelectMany(kv => kv.Value.Select(err => $"{Path.GetFileNameWithoutExtension(kv.Key)}: {ScrubMessage(err)}"))
                 .Take(20)
                 .ToList();
             var compReport = new TelemetryReport(

--- a/AlRunner/TelemetryReporter.cs
+++ b/AlRunner/TelemetryReporter.cs
@@ -49,6 +49,52 @@ public static class TelemetryReporter
         Console.Error.WriteLine("  ✓ Error report sent. Thank you!");
     }
 
+    /// <summary>
+    /// After a test run, prompts the user to report any runner-originated errors
+    /// (IsRunnerBug = true). Groups duplicates, shows a single prompt, then sends.
+    /// Safe to call in all contexts — skips silently when non-interactive or noTelemetry is set.
+    /// </summary>
+    public static async Task TryReportTestErrorsAsync(
+        List<TestResult> tests, bool outputJson, bool noTelemetry)
+    {
+        if (noTelemetry) return;
+        if (!CanPromptUser(outputJson)) return;
+
+        var runnerErrors = tests
+            .Where(t => t.Status == TestStatus.Error && t.IsRunnerBug)
+            .ToList();
+        if (runnerErrors.Count == 0) return;
+
+        var grouped = runnerErrors
+            .GroupBy(t => t.Message ?? "")
+            .Select(g => (Message: g.Key, Count: g.Count(), Sample: g.First()))
+            .ToList();
+
+        Console.Error.WriteLine();
+        Console.Error.WriteLine("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+        Console.Error.WriteLine($"  {runnerErrors.Count} runner limitation(s) encountered — report them?");
+        Console.Error.WriteLine("  Reporting helps improve al-runner support for more AL patterns.");
+        Console.Error.WriteLine();
+        Console.Error.WriteLine("  What will be sent (no AL source code, no file paths):");
+        foreach (var (msg, count, _) in grouped.Take(3))
+            Console.Error.WriteLine($"    × {ScrubMessage(msg)}{(count > 1 ? $" ({count}×)" : "")}");
+        if (grouped.Count > 3)
+            Console.Error.WriteLine($"    … and {grouped.Count - 3} more unique error(s)");
+        Console.Error.WriteLine($"    Version : {GetVersionString()}  OS: {GetOsString()}");
+        Console.Error.WriteLine("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+
+        if (!PromptYesNoWithTimeout($"Send error report? [y/N] (auto-no in {PromptTimeoutSeconds}s): "))
+            return;
+
+        foreach (var error in runnerErrors)
+        {
+            var report = BuildTestErrorReport(error);
+            if (report != null)
+                await SendAsync(report);
+        }
+        Console.Error.WriteLine("  ✓ Error report sent. Thank you!");
+    }
+
     // ─── Internals ────────────────────────────────────────────────────────────
 
     private record TelemetryReport(
@@ -97,17 +143,43 @@ public static class TelemetryReporter
         // No AlRunner frames = crash originated entirely in user-generated code, not our bug
         if (frames.Count == 0) return null;
 
-        var version = Assembly.GetExecutingAssembly().GetName().Version;
-        var versionStr = version != null ? $"{version.Major}.{version.Minor}.{version.Build}" : "unknown";
-
         return new TelemetryReport(
             ExceptionType: inner.GetType().FullName ?? inner.GetType().Name,
             ScrubbedMessage: ScrubMessage(inner.Message),
             StackText: string.Join("\n", frames),
             FrameCount: frames.Count,
-            RunnerVersion: versionStr,
-            Os: Environment.OSVersion.Platform.ToString().ToLowerInvariant());
+            RunnerVersion: GetVersionString(),
+            Os: GetOsString());
     }
+
+    private static TelemetryReport? BuildTestErrorReport(TestResult result)
+    {
+        if (result.StackTrace == null && result.Message == null) return null;
+
+        var frames = result.StackTrace?
+            .Split('\n')
+            .Select(f => f.Trim())
+            .Where(f => !string.IsNullOrEmpty(f) && f.Contains("AlRunner."))
+            .Take(10)
+            .ToList() ?? new List<string>();
+
+        return new TelemetryReport(
+            ExceptionType: "System.InvalidOperationException",
+            ScrubbedMessage: ScrubMessage(result.Message ?? ""),
+            StackText: string.Join("\n", frames),
+            FrameCount: frames.Count,
+            RunnerVersion: GetVersionString(),
+            Os: GetOsString());
+    }
+
+    private static string GetVersionString()
+    {
+        var version = Assembly.GetExecutingAssembly().GetName().Version;
+        return version != null ? $"{version.Major}.{version.Minor}.{version.Build}" : "unknown";
+    }
+
+    private static string GetOsString() =>
+        Environment.OSVersion.Platform.ToString().ToLowerInvariant();
 
     /// <summary>Keep only stack frames originating from AlRunner code.</summary>
     private static List<string> ExtractRunnerFrames(Exception ex)


### PR DESCRIPTION
Follow-up to #61 (crash telemetry foundation). Covers the remaining work: correct error classification, unified gap reporting, and tests.

## Changes

**Error reclassification** (`Pipeline.cs`, `Program.cs`)
- Runner-originated failures ("Codeunit X not found in assembly", etc.) now show as `ERROR` instead of `FAIL`
- `FAIL` = test assertion failed (user's code is wrong)
- `ERROR` = runner couldn't execute (runner limitation) → shows _"⚑ Runner limitation — update al-runner or file an issue"_ hint with GitHub link
- `IsRunnerBug` field added to `TestResult` and `--output-json` output (`isRunnerBug: true` when set, omitted otherwise)

**Unified pipeline gap telemetry** (`TelemetryReporter.cs`)
- Two App Insights event types: `AlRunner.CompilationGap` (Roslyn exclusions) and `AlRunner.RuntimeGap` (mock dispatch failures)
- Compilation exclusions also printed as a visible `WARN` block after test results
- Both gap types combined into a single consent prompt

**Tests** (`AlRunner.Tests/RunnerErrorClassificationTests.cs`)
- `MockCodeunitHandle_UnknownId_ThrowsClassifiableException` — detection component throws the exact exception that `IsRunnerError()` classifies
- `PipelineResult_AssertFail_IsRunnerBugFalse` — regression guard: user failures stay as `Fail`
- `PipelineResult_TestPass_IsRunnerBugFalse` — passing tests unaffected
- `JsonOutput_IsRunnerBugTrue_AppearsInJson` — `isRunnerBug:true` in JSON for runner errors, absent for pass/fail
- `PrintResults_IsRunnerBugTrue_OutputContainsHint` — "⚑ Runner limitation" hint + GitHub link appears in stdout