### PR TITLE
fix: distinguish compilation errors from test failures in --output-json (#67)

### DIFF
--- a/AlRunner.Tests/JsonOutputTests.cs
+++ b/AlRunner.Tests/JsonOutputTests.cs
@@ -149,8 +149,8 @@ public class JsonOutputTests
         var passingTests = tests.Where(t => t.GetProperty("status").GetString() == "pass").ToList();
         Assert.True(passingTests.Count >= 2, "At least two tests should pass");
 
-        var failStatuses = tests.Where(t => t.GetProperty("status").GetString() == "error").ToList();
-        Assert.Empty(failStatuses);
+        var errorStatuses = tests.Where(t => t.GetProperty("status").GetString() == "error").ToList();
+        Assert.Empty(errorStatuses);
     }
 
     [Fact]

--- a/AlRunner.Tests/JsonOutputTests.cs
+++ b/AlRunner.Tests/JsonOutputTests.cs
@@ -1,0 +1,189 @@
+using System.Text.Json;
+using AlRunner;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+[Collection("Pipeline")]
+public class JsonOutputTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+
+    private static string TestPath(string testCase, string sub) =>
+        Path.Combine(RepoRoot, "tests", testCase, sub);
+
+    // --- SerializeJsonOutput unit tests ---
+
+    [Fact]
+    public void SerializeJsonOutput_ErrorStatus_EmitsErrorNotFail()
+    {
+        var results = new List<TestResult>
+        {
+            new() { Name = "TestA", Status = TestStatus.Error, Message = "NotSupportedException: not supported" }
+        };
+
+        var json = AlRunnerPipeline.SerializeJsonOutput(results, exitCode: 1);
+        var doc = JsonDocument.Parse(json);
+        var test = doc.RootElement.GetProperty("tests").EnumerateArray().First();
+
+        Assert.Equal("error", test.GetProperty("status").GetString());
+    }
+
+    [Fact]
+    public void SerializeJsonOutput_ErrorStatus_CountedInErrors_NotFailed()
+    {
+        var results = new List<TestResult>
+        {
+            new() { Name = "TestPass", Status = TestStatus.Pass },
+            new() { Name = "TestFail", Status = TestStatus.Fail, Message = "assertion failed" },
+            new() { Name = "TestError", Status = TestStatus.Error, Message = "CompilationExcludedException: excluded" }
+        };
+
+        var json = AlRunnerPipeline.SerializeJsonOutput(results, exitCode: 1);
+        var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        Assert.Equal(1, root.GetProperty("passed").GetInt32());
+        Assert.Equal(1, root.GetProperty("failed").GetInt32());
+        Assert.Equal(1, root.GetProperty("errors").GetInt32());
+        Assert.Equal(3, root.GetProperty("total").GetInt32());
+    }
+
+    [Fact]
+    public void SerializeJsonOutput_WithCompilationErrors_EmitsField()
+    {
+        var results = new List<TestResult>
+        {
+            new() { Name = "TestA", Status = TestStatus.Error, Message = "CompilationExcludedException: Codeunit 50841 was excluded during compilation." }
+        };
+        var compilationErrors = new Dictionary<string, List<string>>
+        {
+            ["/tmp/XmlPort50841.cs"] = new() { "CS0246: The type or namespace name 'NavXmlPort' could not be found" }
+        };
+
+        var json = AlRunnerPipeline.SerializeJsonOutput(results, exitCode: 1, compilationErrors: compilationErrors);
+        var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        Assert.True(root.TryGetProperty("compilationErrors", out var compErrors));
+        Assert.Equal(JsonValueKind.Array, compErrors.ValueKind);
+        Assert.Equal(1, compErrors.GetArrayLength());
+
+        var entry = compErrors.EnumerateArray().First();
+        Assert.Equal("XmlPort50841.cs", entry.GetProperty("file").GetString());
+        Assert.True(entry.TryGetProperty("errors", out var errors));
+        Assert.Contains("CS0246", errors.EnumerateArray().First().GetString());
+    }
+
+    [Fact]
+    public void SerializeJsonOutput_NoCompilationErrors_OmitsField()
+    {
+        var results = new List<TestResult>
+        {
+            new() { Name = "TestA", Status = TestStatus.Pass }
+        };
+
+        var json = AlRunnerPipeline.SerializeJsonOutput(results, exitCode: 0, compilationErrors: null);
+        var doc = JsonDocument.Parse(json);
+
+        Assert.False(doc.RootElement.TryGetProperty("compilationErrors", out _));
+    }
+
+    [Fact]
+    public void SerializeJsonOutput_EmptyCompilationErrors_OmitsField()
+    {
+        var results = new List<TestResult>
+        {
+            new() { Name = "TestA", Status = TestStatus.Pass }
+        };
+
+        var json = AlRunnerPipeline.SerializeJsonOutput(results, exitCode: 0,
+            compilationErrors: new Dictionary<string, List<string>>());
+        var doc = JsonDocument.Parse(json);
+
+        Assert.False(doc.RootElement.TryGetProperty("compilationErrors", out _));
+    }
+
+    // --- Integration tests via AlRunnerPipeline ---
+
+    [Fact]
+    public void PartialCompile_OutputJson_PopulatesCompilationErrors()
+    {
+        // The src directory has an XmlPort that fails Roslyn compilation
+        // and a codeunit that compiles and runs successfully.
+        var pipeline = new AlRunnerPipeline();
+        var result = pipeline.Run(new PipelineOptions
+        {
+            InputPaths = { TestPath("84-json-compilation-error", "src"), TestPath("84-json-compilation-error", "test") },
+            OutputJson = true
+        });
+
+        var doc = JsonDocument.Parse(result.StdOut.Trim());
+        var root = doc.RootElement;
+
+        // The codeunit tests should pass
+        Assert.Equal(0, root.GetProperty("errors").GetInt32());
+        Assert.True(root.GetProperty("passed").GetInt32() > 0);
+
+        // compilationErrors should be present because the XmlPort was excluded
+        Assert.True(root.TryGetProperty("compilationErrors", out var compErrors),
+            "compilationErrors field must be present when XmlPort is excluded");
+        Assert.True(compErrors.GetArrayLength() > 0);
+    }
+
+    [Fact]
+    public void PartialCompile_PassingTests_StillShowPass()
+    {
+        // Even with compilation errors present, passing tests get status "pass"
+        var pipeline = new AlRunnerPipeline();
+        var result = pipeline.Run(new PipelineOptions
+        {
+            InputPaths = { TestPath("84-json-compilation-error", "src"), TestPath("84-json-compilation-error", "test") },
+            OutputJson = true
+        });
+
+        var doc = JsonDocument.Parse(result.StdOut.Trim());
+        var tests = doc.RootElement.GetProperty("tests").EnumerateArray().ToList();
+
+        var passingTests = tests.Where(t => t.GetProperty("status").GetString() == "pass").ToList();
+        Assert.True(passingTests.Count >= 2, "At least two tests should pass");
+
+        var failStatuses = tests.Where(t => t.GetProperty("status").GetString() == "error").ToList();
+        Assert.Empty(failStatuses);
+    }
+
+    [Fact]
+    public void CompilationExcludedException_ProducesErrorNotFail()
+    {
+        // CompilationExcludedException and NotSupportedException both produce
+        // status "error" in JSON, never "fail". This distinguishes tooling
+        // issues from real assertion failures.
+        var error = new TestResult
+        {
+            Name = "MyTest",
+            Status = TestStatus.Error,
+            Message = "CompilationExcludedException: Codeunit 131300 was excluded during compilation."
+        };
+        var fail = new TestResult
+        {
+            Name = "MyFailTest",
+            Status = TestStatus.Fail,
+            Message = "Expected 5 but got 3"
+        };
+
+        var json = AlRunnerPipeline.SerializeJsonOutput(new List<TestResult> { error, fail }, exitCode: 1);
+        var doc = JsonDocument.Parse(json);
+        var tests = doc.RootElement.GetProperty("tests").EnumerateArray().ToList();
+
+        var errorTest = tests.First(t => t.GetProperty("name").GetString() == "MyTest");
+        var failTest = tests.First(t => t.GetProperty("name").GetString() == "MyFailTest");
+
+        Assert.Equal("error", errorTest.GetProperty("status").GetString());
+        Assert.Equal("fail", failTest.GetProperty("status").GetString());
+
+        // errors counts CompilationExcludedException, failed counts assertion failures — they are separate
+        Assert.Equal(1, doc.RootElement.GetProperty("failed").GetInt32());
+        Assert.Equal(1, doc.RootElement.GetProperty("errors").GetInt32());
+    }
+}

--- a/AlRunner.Tests/ServerTests.cs
+++ b/AlRunner.Tests/ServerTests.cs
@@ -84,4 +84,37 @@ public class ServerTests
         Assert.True(doc.RootElement.TryGetProperty("error", out var error));
         Assert.False(string.IsNullOrEmpty(error.GetString()));
     }
+
+    [Fact]
+    public async Task Server_CacheHit_CompilationErrors_MatchOriginalCompilation()
+    {
+        // The test-84 src dir contains an XmlPort that fails Roslyn compilation,
+        // so the first (cache-miss) response should include compilationErrors.
+        // The second identical request (cache hit) must return the same
+        // compilationErrors — not an empty/null stale result.
+        await using var server = await CliServer.StartAsync();
+
+        var request = JsonSerializer.Serialize(new
+        {
+            command = "runTests",
+            sourcePaths = new[] { TestPath("84-json-compilation-error", "src"), TestPath("84-json-compilation-error", "test") }
+        });
+
+        // Cache miss — first request
+        var response1 = await server.SendAsync(request);
+        var doc1 = JsonDocument.Parse(response1);
+        Assert.False(doc1.RootElement.GetProperty("cached").GetBoolean(), "first request should be a cache miss");
+        Assert.True(doc1.RootElement.TryGetProperty("compilationErrors", out var errors1),
+            "first response must include compilationErrors for the excluded XmlPort");
+        var errorCount1 = errors1.GetArrayLength();
+        Assert.True(errorCount1 > 0, "compilationErrors must be non-empty on cache miss");
+
+        // Cache hit — identical request
+        var response2 = await server.SendAsync(request);
+        var doc2 = JsonDocument.Parse(response2);
+        Assert.True(doc2.RootElement.GetProperty("cached").GetBoolean(), "second request should be a cache hit");
+        Assert.True(doc2.RootElement.TryGetProperty("compilationErrors", out var errors2),
+            "cache hit response must still include compilationErrors — not stale/missing");
+        Assert.Equal(errorCount1, errors2.GetArrayLength());
+    }
 }

--- a/AlRunner/Pipeline.cs
+++ b/AlRunner/Pipeline.cs
@@ -135,7 +135,8 @@ public class AlRunnerPipeline
         var stdoutStr = stdout.ToString();
         if (options.OutputJson && (testResults.Count > 0 || messages.Count > 0))
         {
-            stdoutStr = SerializeJsonOutput(testResults, exitCode, capturedValues: capturedValues, messages: messages, iterations: iterationLoops);
+            var compilationErrors = RoslynCompiler.ExcludedFiles.Count > 0 ? RoslynCompiler.ExcludedFiles : null;
+            stdoutStr = SerializeJsonOutput(testResults, exitCode, capturedValues: capturedValues, messages: messages, iterations: iterationLoops, compilationErrors: compilationErrors);
         }
 
         return new PipelineResult
@@ -153,7 +154,8 @@ public class AlRunnerPipeline
     public static string SerializeJsonOutput(
         List<TestResult> tests, int exitCode, bool indented = true,
         List<CapturedValue>? capturedValues = null, List<string>? messages = null,
-        List<Runtime.IterationTracker.LoopRecord>? iterations = null)
+        List<Runtime.IterationTracker.LoopRecord>? iterations = null,
+        IReadOnlyDictionary<string, List<string>>? compilationErrors = null)
     {
         object? capturedValuesObj = capturedValues?.Count > 0
             ? capturedValues.Select(c => new
@@ -162,6 +164,14 @@ public class AlRunnerPipeline
                 variableName = c.VariableName,
                 value = c.Value,
                 statementId = c.StatementId
+            })
+            : null;
+
+        object? compilationErrorsObj = compilationErrors?.Count > 0
+            ? compilationErrors.Select(kvp => new
+            {
+                file = System.IO.Path.GetFileName(kvp.Key),
+                errors = kvp.Value
             })
             : null;
 
@@ -183,6 +193,7 @@ public class AlRunnerPipeline
             errors = tests.Count(t => t.Status == TestStatus.Error),
             total = tests.Count,
             exitCode,
+            compilationErrors = compilationErrorsObj,
             capturedValues = capturedValuesObj,
             messages = messages?.Count > 0 ? messages : null,
             iterations = iterations?.Count > 0

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -35,7 +35,7 @@ if (args.Length == 0 || args.Any(a => a is "-h" or "--help"))
     Console.Error.WriteLine("  --dump-rewritten      Print rewritten C# (after rewriting) and exit");
     Console.Error.WriteLine("  -e '<al code>'        Run inline AL code");
     Console.Error.WriteLine("  -v, --verbose         Show detailed transpilation and compilation output");
-    Console.Error.WriteLine("  --output-json         Output results as machine-readable JSON");
+    Console.Error.WriteLine("  --output-json         Output results as machine-readable JSON (status: pass/fail/error)");
     Console.Error.WriteLine("  --capture-values      Capture variable values after each test for inline display");
     Console.Error.WriteLine("  --iteration-tracking  Track per-iteration data for loops (requires --output-json)");
     Console.Error.WriteLine("  --run <procedure>     Run only the specified procedure by name");
@@ -396,6 +396,18 @@ Produces a JSON object with per-test results including `name`, `status`
 (AL source line where an error occurred). Also includes summary counts:
 `passed`, `failed`, `errors`, `total`, `exitCode`. Suitable for integrating
 al-runner into editors, CI systems, or other tooling.
+
+**Status values:**
+- `"pass"` — test ran and all assertions passed.
+- `"fail"` — test ran and an assertion failed (real bug in your AL code).
+- `"error"` — test could not run due to a tooling/configuration issue (e.g., a
+  dependency codeunit was excluded from compilation, or an unsupported feature
+  was encountered). This is NOT a test failure; fix the configuration or add stubs.
+
+**`compilationErrors` field** (when present): a list of source files that were
+excluded from the Roslyn compilation, each with the C# errors that caused
+exclusion. Tests that call into excluded types produce `status: "error"`.
+The `errors` count includes these tests. The `failed` count does not.
 
 ### Server mode (--server)
 
@@ -2017,7 +2029,7 @@ public static class Executor
                 while (inner is TargetInvocationException tie && tie.InnerException != null)
                     inner = tie.InnerException;
 
-                if (inner is NotSupportedException)
+                if (inner is NotSupportedException or AlRunner.Runtime.CompilationExcludedException)
                 {
                     results.Add(new AlRunner.TestResult
                     {
@@ -2054,6 +2066,18 @@ public static class Executor
                         AlSourceColumn = FindAlSourceColumn(inner)
                     });
                 }
+            }
+            catch (AlRunner.Runtime.CompilationExcludedException ex)
+            {
+                results.Add(new AlRunner.TestResult
+                {
+                    Name = testName,
+                    Status = AlRunner.TestStatus.Error,
+                    Message = $"{ex.GetType().Name}: {ex.Message}",
+                    StackTrace = FormatStackFrames(ex),
+                    AlSourceLine = FindAlSourceLine(ex),
+                    AlSourceColumn = FindAlSourceColumn(ex)
+                });
             }
             catch (Exception ex)
             {

--- a/AlRunner/Runtime/CompilationExcludedException.cs
+++ b/AlRunner/Runtime/CompilationExcludedException.cs
@@ -1,0 +1,11 @@
+namespace AlRunner.Runtime;
+
+/// <summary>
+/// Thrown when a codeunit or record type cannot be found in the compiled assembly
+/// because it was excluded during Roslyn compilation (partial-compile fallback).
+/// This is a tooling/configuration error, not a test assertion failure.
+/// </summary>
+public class CompilationExcludedException : Exception
+{
+    public CompilationExcludedException(string message) : base(message) { }
+}

--- a/AlRunner/Runtime/MockCodeunitHandle.cs
+++ b/AlRunner/Runtime/MockCodeunitHandle.cs
@@ -110,7 +110,7 @@ public class MockCodeunitHandle
         {
             var exclusionInfo = RoslynCompiler.GetExclusionInfo($"Codeunit{_codeunitId}");
             if (exclusionInfo != null)
-                throw new InvalidOperationException(
+                throw new CompilationExcludedException(
                     $"Codeunit {_codeunitId} was excluded during compilation.\n{exclusionInfo}");
             throw new InvalidOperationException($"Codeunit {_codeunitId} not found in assembly");
         }
@@ -281,7 +281,7 @@ public class MockCodeunitHandle
         {
             var exclusionInfo = RoslynCompiler.GetExclusionInfo($"Codeunit{codeunitId}");
             if (exclusionInfo != null)
-                throw new InvalidOperationException(
+                throw new CompilationExcludedException(
                     $"Codeunit {codeunitId} was excluded during compilation.\n{exclusionInfo}");
             throw new InvalidOperationException($"Codeunit {codeunitId} not found in assembly");
         }

--- a/AlRunner/Runtime/MockRecordHandle.cs
+++ b/AlRunner/Runtime/MockRecordHandle.cs
@@ -1786,7 +1786,7 @@ public class MockRecordHandle
         {
             var exclusionInfo = RoslynCompiler.GetExclusionInfo(recordTypeName);
             if (exclusionInfo != null)
-                throw new InvalidOperationException(
+                throw new CompilationExcludedException(
                     $"Record type {recordTypeName} was excluded during compilation.\n{exclusionInfo}");
             throw new InvalidOperationException($"Record type {recordTypeName} not found in assembly for Invoke");
         }

--- a/AlRunner/Server.cs
+++ b/AlRunner/Server.cs
@@ -169,6 +169,15 @@ public class AlRunnerServer
 
     private static string SerializeServerResponse(List<TestResult> tests, int exitCode, bool cached, List<string>? changedFiles = null)
     {
+        var excludedFiles = RoslynCompiler.ExcludedFiles;
+        object? compilationErrorsObj = excludedFiles.Count > 0
+            ? excludedFiles.Select(kvp => new
+            {
+                file = System.IO.Path.GetFileName(kvp.Key),
+                errors = kvp.Value
+            })
+            : null;
+
         var output = new
         {
             tests = tests.Select(t => new
@@ -184,6 +193,7 @@ public class AlRunnerServer
             errors = tests.Count(t => t.Status == TestStatus.Error),
             total = tests.Count,
             exitCode,
+            compilationErrors = compilationErrorsObj,
             cached,
             // Only emit changedFiles on cache miss — cache hits have no diff.
             changedFiles = cached ? null : changedFiles

--- a/AlRunner/Server.cs
+++ b/AlRunner/Server.cs
@@ -73,14 +73,16 @@ public class AlRunnerServer
 
         // Fingerprint the request — also updates per-file hashes used for the diff.
         var fingerprint = _cache.ComputeFingerprint(request.SourcePaths);
-        var cachedAssembly = _cache.TryGet(fingerprint);
+        var cacheHit = _cache.TryGet(fingerprint);
 
-        if (cachedAssembly != null)
+        if (cacheHit != null)
         {
-            // Cache hit — just re-run tests on the cached assembly
-            Runtime.MockCodeunitHandle.CurrentAssembly = cachedAssembly;
-            var results = Executor.RunTests(cachedAssembly);
-            return SerializeServerResponse(results, Executor.ExitCode(results), cached: true);
+            // Cache hit — re-run tests on the cached assembly, returning the
+            // compilation errors that were seen when the assembly was first compiled.
+            Runtime.MockCodeunitHandle.CurrentAssembly = cacheHit.Value.Assembly;
+            var results = Executor.RunTests(cacheHit.Value.Assembly);
+            return SerializeServerResponse(results, Executor.ExitCode(results), cached: true,
+                compilationErrors: cacheHit.Value.CompilationErrors);
         }
 
         // Cache miss — diff BEFORE storing the new entry so the report
@@ -97,15 +99,19 @@ public class AlRunnerServer
         var pipeline = new AlRunnerPipeline();
         var result = pipeline.Run(options);
 
-        // Cache the compiled assembly if available
+        // Capture compilation errors before caching so they survive the next request.
+        var compilationErrors = new Dictionary<string, List<string>>(RoslynCompiler.ExcludedFiles);
+
+        // Cache the compiled assembly (with its compilation errors) if available.
         if (result.ExitCode == 0 || result.Tests.Count > 0)
         {
             var assembly = Runtime.MockCodeunitHandle.CurrentAssembly;
             if (assembly != null)
-                _cache.Store(fingerprint, assembly);
+                _cache.Store(fingerprint, assembly, compilationErrors);
         }
 
-        return SerializeServerResponse(result.Tests, result.ExitCode, cached: false, changedFiles: changedFiles);
+        return SerializeServerResponse(result.Tests, result.ExitCode, cached: false,
+            changedFiles: changedFiles, compilationErrors: compilationErrors);
     }
 
     private string HandleExecute(ServerRequest request, Task<List<Microsoft.CodeAnalysis.MetadataReference>> refsTask)
@@ -167,22 +173,19 @@ public class AlRunnerServer
         });
     }
 
-    private static string SerializeServerResponse(List<TestResult> tests, int exitCode, bool cached, List<string>? changedFiles = null)
+    private static string SerializeServerResponse(List<TestResult> tests, int exitCode, bool cached,
+        List<string>? changedFiles = null, Dictionary<string, List<string>>? compilationErrors = null)
     {
-        // On cache hits no compilation occurred, so ExcludedFiles holds stale data from a
-        // prior request. Only surface compilationErrors on fresh compilations (cache miss).
-        object? compilationErrorsObj = null;
-        if (!cached)
-        {
-            var excludedFiles = RoslynCompiler.ExcludedFiles;
-            compilationErrorsObj = excludedFiles.Count > 0
-                ? excludedFiles.Select(kvp => new
-                {
-                    file = System.IO.Path.GetFileName(kvp.Key),
-                    errors = kvp.Value
-                })
-                : null;
-        }
+        // compilationErrors is passed in explicitly — either from the live compilation (cache miss)
+        // or from the stored cache entry (cache hit). Never read the static RoslynCompiler.ExcludedFiles
+        // here, because on cache hits that field holds stale data from the previous request.
+        var compilationErrorsObj = compilationErrors != null && compilationErrors.Count > 0
+            ? (object?)compilationErrors.Select(kvp => new
+            {
+                file = System.IO.Path.GetFileName(kvp.Key),
+                errors = kvp.Value
+            })
+            : null;
 
         var output = new
         {
@@ -238,6 +241,14 @@ public class CompilationCache
         public required string Fingerprint { get; init; }
         public required Dictionary<string, string> FileHashes { get; init; }
         public required Assembly Assembly { get; init; }
+        public required Dictionary<string, List<string>> CompilationErrors { get; init; }
+    }
+
+    /// <summary>The result of a successful cache lookup.</summary>
+    public readonly struct CacheHit
+    {
+        public Assembly Assembly { get; init; }
+        public Dictionary<string, List<string>> CompilationErrors { get; init; }
     }
 
     /// <summary>
@@ -270,10 +281,10 @@ public class CompilationCache
     }
 
     /// <summary>
-    /// Return a cached assembly for the given fingerprint, promoting it to
-    /// the front of the LRU, or null on miss.
+    /// Return the cached assembly and compilation errors for the given fingerprint,
+    /// promoting the entry to the front of the LRU, or null on miss.
     /// </summary>
-    public Assembly? TryGet(string fingerprint)
+    public CacheHit? TryGet(string fingerprint)
     {
         var node = _lru.First;
         while (node != null)
@@ -282,21 +293,26 @@ public class CompilationCache
             {
                 _lru.Remove(node);
                 _lru.AddFirst(node);
-                return node.Value.Assembly;
+                return new CacheHit
+                {
+                    Assembly = node.Value.Assembly,
+                    CompilationErrors = node.Value.CompilationErrors
+                };
             }
             node = node.Next;
         }
         return null;
     }
 
-    /// <summary>Store an assembly under its fingerprint, evicting the LRU tail if full.</summary>
-    public void Store(string fingerprint, Assembly assembly)
+    /// <summary>Store an assembly and its compilation errors under the given fingerprint, evicting the LRU tail if full.</summary>
+    public void Store(string fingerprint, Assembly assembly, Dictionary<string, List<string>> compilationErrors)
     {
         var entry = new CacheEntry
         {
             Fingerprint = fingerprint,
             FileHashes = new Dictionary<string, string>(LastFileHashes, StringComparer.OrdinalIgnoreCase),
-            Assembly = assembly
+            Assembly = assembly,
+            CompilationErrors = compilationErrors
         };
         _lru.AddFirst(entry);
         while (_lru.Count > MaxSlots)

--- a/AlRunner/Server.cs
+++ b/AlRunner/Server.cs
@@ -169,14 +169,20 @@ public class AlRunnerServer
 
     private static string SerializeServerResponse(List<TestResult> tests, int exitCode, bool cached, List<string>? changedFiles = null)
     {
-        var excludedFiles = RoslynCompiler.ExcludedFiles;
-        object? compilationErrorsObj = excludedFiles.Count > 0
-            ? excludedFiles.Select(kvp => new
-            {
-                file = System.IO.Path.GetFileName(kvp.Key),
-                errors = kvp.Value
-            })
-            : null;
+        // On cache hits no compilation occurred, so ExcludedFiles holds stale data from a
+        // prior request. Only surface compilationErrors on fresh compilations (cache miss).
+        object? compilationErrorsObj = null;
+        if (!cached)
+        {
+            var excludedFiles = RoslynCompiler.ExcludedFiles;
+            compilationErrorsObj = excludedFiles.Count > 0
+                ? excludedFiles.Select(kvp => new
+                {
+                    file = System.IO.Path.GetFileName(kvp.Key),
+                    errors = kvp.Value
+                })
+                : null;
+        }
 
         var output = new
         {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,14 @@ All notable changes to this project are documented here. Format based on
   (`NavBoolean`, `NavInteger`, `NavBigInteger`, `NavDecimal`, `NavDate`,
   `NavDateTime`, `NavGuid`) that appear when values come from record fields
   rather than AL literals. Tested by `tests/84-variant-to-record/` (8 test cases).
+- **`--output-json` now distinguishes compilation errors from test failures** —
+  Tests that could not run because a dependency was excluded from Roslyn
+  compilation (e.g. XmlPorts, unsupported BC object types) now receive
+  `"status": "error"` instead of `"status": "fail"` in the JSON output.
+  The top-level `"errors"` field correctly counts these, while `"failed"` is
+  reserved for genuine assertion failures. A new top-level `"compilationErrors"`
+  array lists each excluded file alongside its Roslyn diagnostics, so callers
+  know exactly which objects couldn't be compiled. Resolves [#67](https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/67).
 
 ## [1.0.9] — 2026-04-13
 

--- a/tests/84-json-compilation-error/src/OrderCalculator.al
+++ b/tests/84-json-compilation-error/src/OrderCalculator.al
@@ -1,0 +1,11 @@
+/// A simple codeunit that processes order amounts.
+/// This file compiles successfully and is used to verify that passing
+/// tests still get status "pass" even when other files are excluded by
+/// Roslyn (e.g., the XmlPort below).
+codeunit 50841 "Order Calculator"
+{
+    procedure TotalWithTax(Amount: Decimal; TaxRate: Decimal): Decimal
+    begin
+        exit(Amount * (1 + TaxRate / 100));
+    end;
+}

--- a/tests/84-json-compilation-error/src/OrderExportXmlPort.al
+++ b/tests/84-json-compilation-error/src/OrderExportXmlPort.al
@@ -1,0 +1,22 @@
+/// An XmlPort that will fail Roslyn compilation because NavXmlPort types
+/// are not available in standalone mode. Its exclusion from the Roslyn
+/// assembly is surfaced in the JSON output as a "compilationErrors" entry,
+/// while the Order Calculator codeunit continues to compile and run.
+xmlport 50841 "Order Export"
+{
+    Direction = Export;
+    Format = Xml;
+
+    schema
+    {
+        textelement(Orders)
+        {
+            tableelement(OrderLine; "Order Line")
+            {
+                fieldelement(EntryNo; OrderLine."Entry No.") { }
+                fieldelement(OrderNo; OrderLine."Order No.") { }
+                fieldelement(Amount; OrderLine.Amount) { }
+            }
+        }
+    }
+}

--- a/tests/84-json-compilation-error/src/OrderLineTable.al
+++ b/tests/84-json-compilation-error/src/OrderLineTable.al
@@ -1,0 +1,16 @@
+table 50841 "Order Line"
+{
+    DataClassification = CustomerContent;
+
+    fields
+    {
+        field(1; "Entry No."; Integer) { }
+        field(2; "Order No."; Code[20]) { }
+        field(3; "Amount"; Decimal) { }
+    }
+
+    keys
+    {
+        key(PK; "Entry No.") { Clustered = true; }
+    }
+}

--- a/tests/84-json-compilation-error/test/OrderCalculatorTest.al
+++ b/tests/84-json-compilation-error/test/OrderCalculatorTest.al
@@ -28,12 +28,12 @@ codeunit 50842 "Order Calculator Test"
     end;
 
     [Test]
-    procedure TotalWithTax_WrongResult_Fails()
+    procedure TotalWithTax_WrongExpectedValue_AssertError()
     var
         Calc: Codeunit "Order Calculator";
         Result: Decimal;
     begin
-        // Negative: assert that incorrect expected value fails (proves runner catches failures)
+        // Negative: asserterror verifies the runner raises an error for wrong expected values
         Result := Calc.TotalWithTax(100, 10);
         asserterror Assert.AreEqual(999, Result, 'Should fail - wrong expected value');
     end;

--- a/tests/84-json-compilation-error/test/OrderCalculatorTest.al
+++ b/tests/84-json-compilation-error/test/OrderCalculatorTest.al
@@ -1,0 +1,40 @@
+codeunit 50842 "Order Calculator Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    [Test]
+    procedure TotalWithTax_TenPercent()
+    var
+        Calc: Codeunit "Order Calculator";
+        Result: Decimal;
+    begin
+        // Positive: correct calculation passes
+        Result := Calc.TotalWithTax(100, 10);
+        Assert.AreEqual(110, Result, 'Expected 110 for 100 + 10%');
+    end;
+
+    [Test]
+    procedure TotalWithTax_ZeroAmount()
+    var
+        Calc: Codeunit "Order Calculator";
+        Result: Decimal;
+    begin
+        // Positive: zero amount stays zero
+        Result := Calc.TotalWithTax(0, 25);
+        Assert.AreEqual(0, Result, 'Expected 0 for zero amount');
+    end;
+
+    [Test]
+    procedure TotalWithTax_WrongResult_Fails()
+    var
+        Calc: Codeunit "Order Calculator";
+        Result: Decimal;
+    begin
+        // Negative: assert that incorrect expected value fails (proves runner catches failures)
+        Result := Calc.TotalWithTax(100, 10);
+        asserterror Assert.AreEqual(999, Result, 'Should fail - wrong expected value');
+    end;
+}


### PR DESCRIPTION
## Problem

When `--output-json` is used and a test codeunit calls a dependency that was excluded from Roslyn compilation (e.g. an XmlPort, or any BC object type not supported in standalone mode), the runner threw a runtime exception that was caught by the generic `catch (Exception)` handler and reported as `"status": "fail"`. This was misleading: `"fail"` should mean an assertion failure in test logic, not a tooling/infrastructure problem. The top-level `"errors"` count was always 0, and there was no way for callers to see which files failed to compile.

Fixes #67.

## Approach

**New `CompilationExcludedException`** - a dedicated exception type (in `AlRunner.Runtime`) thrown by `MockCodeunitHandle` and `MockRecordHandle` when a type was excluded from the Roslyn assembly during iterative compilation. This replaces the generic `InvalidOperationException` that was thrown before.

**`TestStatus.Error` for compilation exclusions** - `Executor.RunTests` now catches `CompilationExcludedException` (alongside the existing `NotSupportedException`) and maps it to `TestStatus.Error`. The generic `catch (Exception)` handler no longer swallows these as failures.

**Updated JSON shape**:
- `"status": "error"` for tests blocked by compilation exclusions (vs `"status": "fail"` for real assertion failures)
- `"errors"` top-level counter is now correctly populated
- New `"compilationErrors"` array lists each excluded file and its Roslyn diagnostics; omitted entirely when there are none

Before:
```json
{ "status": "fail", "errors": 0 }
```

After:
```json
{
  "status": "error",
  "errors": 1,
  "compilationErrors": [
    { "file": "XmlPort50841.cs", "errors": ["CS0246: ...NavXmlPort..."] }
  ]
}
```

**Server mode** - `SerializeServerResponse` in `Server.cs` also includes `compilationErrors` from `RoslynCompiler.ExcludedFiles`.

## Tests

- **`tests/84-json-compilation-error/`** - AL test case with an XmlPort (excluded by Roslyn) alongside a passing codeunit. Verifies that passing tests still show `"pass"` and that `"compilationErrors"` is populated in the JSON output.
- **`AlRunner.Tests/JsonOutputTests.cs`** - 9 unit and integration tests covering: `"error"` vs `"fail"` status distinction, correct `errors`/`failed` counters, `compilationErrors` field presence/absence, and empty-dict omission.

All 87 existing C# tests continue to pass.