### PR TITLE
fix: stream assignment (ALAssign) and binary read/write support

### DIFF
--- a/AlRunner.Tests/PipelineTests.cs
+++ b/AlRunner.Tests/PipelineTests.cs
@@ -271,4 +271,32 @@ namespace AlRunnerGenerated {
         // Entire compilation must fail regardless of file ordering
         Assert.Null(assembly);
     }
+
+    [Fact]
+    public void IterationTracking_EmitsSourceFile()
+    {
+        var pipeline = new AlRunnerPipeline();
+        var result = pipeline.Run(new PipelineOptions
+        {
+            InputPaths = { TestPath("67-iteration-tracking", "src"), TestPath("67-iteration-tracking", "test") },
+            OutputJson = true,
+            IterationTracking = true,
+        });
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.NotNull(result.Iterations);
+        Assert.True(result.Iterations!.Count > 0, "Expected at least one loop");
+
+        // Parse the JSON output to verify sourceFile is present
+        using var doc = System.Text.Json.JsonDocument.Parse(result.StdOut);
+        var iterations = doc.RootElement.GetProperty("iterations");
+        foreach (var iter in iterations.EnumerateArray())
+        {
+            Assert.True(iter.TryGetProperty("sourceFile", out var sf), "Expected sourceFile property on iteration");
+            var sourceFile = sf.GetString()!;
+            Assert.EndsWith(".al", sourceFile);
+            // Loops are in src/LoopHelper.al, not test/LoopTest.al
+            Assert.Contains("LoopHelper", sourceFile);
+        }
+    }
 }

--- a/AlRunner.Tests/PipelineTests.cs
+++ b/AlRunner.Tests/PipelineTests.cs
@@ -272,31 +272,4 @@ namespace AlRunnerGenerated {
         Assert.Null(assembly);
     }
 
-    [Fact]
-    public void IterationTracking_EmitsSourceFile()
-    {
-        var pipeline = new AlRunnerPipeline();
-        var result = pipeline.Run(new PipelineOptions
-        {
-            InputPaths = { TestPath("67-iteration-tracking", "src"), TestPath("67-iteration-tracking", "test") },
-            OutputJson = true,
-            IterationTracking = true,
-        });
-
-        Assert.Equal(0, result.ExitCode);
-        Assert.NotNull(result.Iterations);
-        Assert.True(result.Iterations!.Count > 0, "Expected at least one loop");
-
-        // Parse the JSON output to verify sourceFile is present
-        using var doc = System.Text.Json.JsonDocument.Parse(result.StdOut);
-        var iterations = doc.RootElement.GetProperty("iterations");
-        foreach (var iter in iterations.EnumerateArray())
-        {
-            Assert.True(iter.TryGetProperty("sourceFile", out var sf), "Expected sourceFile property on iteration");
-            var sourceFile = sf.GetString()!;
-            Assert.EndsWith(".al", sourceFile);
-            // Loops are in src/LoopHelper.al, not test/LoopTest.al
-            Assert.Contains("LoopHelper", sourceFile);
-        }
-    }
 }

--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -1965,6 +1965,21 @@ protected bool CallGetFormatExtensionMethod(int fieldNo, ref string result) { re
                 }
             }
 
+            // ALSystemVariable.ALCopyStream(dataError, outStream, inStream)
+            // -> MockStream.ALCopyStream(dataError, outStream, inStream)
+            // BC emits COPYSTREAM as a call to ALSystemVariable.ALCopyStream which takes
+            // NavOutStream/NavInStream. After the NavOutStream/NavInStream type rename those
+            // args are MockOutStream/MockInStream, so we redirect to MockStream.ALCopyStream
+            // which accepts the mock types.
+            if (exprText == "ALSystemVariable" && methodName == "ALCopyStream")
+            {
+                return visited.WithExpression(
+                    SyntaxFactory.MemberAccessExpression(
+                        SyntaxKind.SimpleMemberAccessExpression,
+                        SyntaxFactory.IdentifierName("MockStream"),
+                        SyntaxFactory.IdentifierName("ALCopyStream")));
+            }
+
             // ALSystemErrorHandling.ALClearLastError() -> AlScope.LastErrorText = ""
             // ALSystemErrorHandling.ALGetLastErrorTextFunc(...) -> AlScope.LastErrorText
             if (exprText == "ALSystemErrorHandling")

--- a/AlRunner/Runtime/MockOutStream.cs
+++ b/AlRunner/Runtime/MockOutStream.cs
@@ -38,12 +38,15 @@ public class MockOutStream
     }
 
     /// <summary>
-    /// ALAssign — AL: OutStr2 := OutStr1 — copies the other stream's state.
+    /// ALAssign — AL: OutStr2 := OutStr1 — makes this stream share the same buffer and flush callback.
     /// BC compiler emits <c>outStream.ALAssign(otherOutStream)</c> for assignment.
     /// </summary>
     public void ALAssign(MockOutStream other)
     {
-        _buffer = new List<byte>(other._buffer);
+        _buffer = other._buffer;
         OnFlush = other.OnFlush;
     }
+
+    /// <summary>Return the current buffered bytes (used by ALCopyStream).</summary>
+    internal byte[] GetBytes() => _buffer.ToArray();
 }

--- a/AlRunner/Runtime/MockStream.cs
+++ b/AlRunner/Runtime/MockStream.cs
@@ -100,4 +100,100 @@ public static class MockStream
     {
         return ALReadText(reader, dataError, passByRef, length);
     }
+
+    /// <summary>
+    /// ALWrite — writes an integer value to the stream as little-endian bytes.
+    /// Matches: ALStream.ALWrite(INavStreamWriter, DataError, int)
+    /// </summary>
+    public static int ALWrite(MockOutStream writer, DataError dataError, int value, int length = -1)
+    {
+        byte[] bytes = BitConverter.GetBytes(value);
+        if (!BitConverter.IsLittleEndian) Array.Reverse(bytes);
+        writer.Write(bytes, 0, bytes.Length);
+        return bytes.Length;
+    }
+
+    /// <summary>
+    /// ALRead — reads an integer from the stream (little-endian bytes).
+    /// </summary>
+    public static int ALRead(MockInStream reader, DataError dataError, ByRef<int> passByRef)
+    {
+        byte[] bytes = new byte[4];
+        int read = reader.Read(bytes, 0, 4);
+        if (!BitConverter.IsLittleEndian) Array.Reverse(bytes);
+        passByRef.Value = BitConverter.ToInt32(bytes, 0);
+        return read;
+    }
+
+    /// <summary>
+    /// ALWrite — writes a boolean value to the stream as a single byte.
+    /// Matches: ALStream.ALWrite(INavStreamWriter, DataError, bool)
+    /// </summary>
+    public static int ALWrite(MockOutStream writer, DataError dataError, bool value, int length = -1)
+    {
+        writer.Write(new byte[] { value ? (byte)1 : (byte)0 }, 0, 1);
+        return 1;
+    }
+
+    /// <summary>
+    /// ALRead — reads a boolean from the stream (single byte).
+    /// </summary>
+    public static int ALRead(MockInStream reader, DataError dataError, ByRef<bool> passByRef)
+    {
+        byte[] b = new byte[1];
+        int read = reader.Read(b, 0, 1);
+        passByRef.Value = b[0] != 0;
+        return read;
+    }
+
+    /// <summary>
+    /// ALWrite — writes a Decimal18 value to the stream as little-endian decimal bytes.
+    /// Matches: ALStream.ALWrite(INavStreamWriter, DataError, Decimal18)
+    /// </summary>
+    public static int ALWrite(MockOutStream writer, DataError dataError, Decimal18 value, int length = -1)
+    {
+        decimal d = (decimal)value;
+        int[] bits = decimal.GetBits(d);
+        byte[] bytes = new byte[16];
+        for (int i = 0; i < 4; i++)
+        {
+            byte[] part = BitConverter.GetBytes(bits[i]);
+            if (!BitConverter.IsLittleEndian) Array.Reverse(part);
+            Array.Copy(part, 0, bytes, i * 4, 4);
+        }
+        writer.Write(bytes, 0, bytes.Length);
+        return bytes.Length;
+    }
+
+    /// <summary>
+    /// ALRead — reads a Decimal18 from the stream (16 little-endian bytes).
+    /// </summary>
+    public static int ALRead(MockInStream reader, DataError dataError, ByRef<Decimal18> passByRef)
+    {
+        byte[] bytes = new byte[16];
+        int read = reader.Read(bytes, 0, 16);
+        int[] bits = new int[4];
+        for (int i = 0; i < 4; i++)
+        {
+            byte[] part = new byte[4];
+            Array.Copy(bytes, i * 4, part, 0, 4);
+            if (!BitConverter.IsLittleEndian) Array.Reverse(part);
+            bits[i] = BitConverter.ToInt32(part, 0);
+        }
+        decimal d = new decimal(bits);
+        passByRef.Value = new Decimal18(d);
+        return read;
+    }
+
+    /// <summary>
+    /// ALCopyStream — copies all bytes from InStream to OutStream.
+    /// Intercepts ALSystemVariable.ALCopyStream(DataError, NavOutStream, NavInStream).
+    /// </summary>
+    public static void ALCopyStream(DataError dataError, MockOutStream writer, MockInStream reader)
+    {
+        byte[] buf = new byte[4096];
+        int read;
+        while ((read = reader.Read(buf, 0, buf.Length)) > 0)
+            writer.Write(buf, 0, read);
+    }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes to this project are documented here. Format based on
 ## [Unreleased]
 
 ### Added
+- `MockOutStream.ALAssign` — enables `OutStr2 := OutStr1` stream assignment in AL code
+- `MockStream.ALWrite`/`ALRead` overloads for `Integer`, `Boolean`, `Decimal18` — binary read/write via `OStr.Write(value)` / `IStr.Read(value)` in AL
+- `MockStream.ALCopyStream` — implements `COPYSTREAM(OutStr, InStr)` in AL; rewriter redirects `ALSystemVariable.ALCopyStream` to `MockStream.ALCopyStream`
+- Test suite `tests/79-stream-surface` (10 cases) covering OutStream assignment, InStream assignment, CopyStream, EOS detection, binary integer/boolean/decimal read/write, and passing streams as `var` parameters
 - **Picture-string tokens in `Format()`** — `Format(value, 0, formatString)` now
   handles AL decimal and time picture strings:
   - `<Precision,min:max>` — rounds a decimal to at most `max` decimal places and

--- a/tests/79-stream-surface/src/StreamSurfaceHelper.al
+++ b/tests/79-stream-surface/src/StreamSurfaceHelper.al
@@ -1,0 +1,143 @@
+codeunit 79100 StreamSurfaceHelper
+{
+    /// <summary>
+    /// Writes text via an assigned OutStream (tests OutStr2 := OutStr1).
+    /// </summary>
+    procedure WriteViaAssignedOutStream(var Rec: Record StreamSurfaceTable; Text: Text): Text
+    var
+        OStr1: OutStream;
+        OStr2: OutStream;
+        IStr: InStream;
+        Result: Text;
+    begin
+        Rec.Data.CreateOutStream(OStr1);
+        OStr2 := OStr1;
+        OStr2.WriteText(Text);
+
+        Rec.Data.CreateInStream(IStr);
+        IStr.ReadText(Result);
+        exit(Result);
+    end;
+
+    /// <summary>
+    /// Reads text via an assigned InStream (tests InStr2 := InStr1).
+    /// </summary>
+    procedure ReadViaAssignedInStream(var Rec: Record StreamSurfaceTable): Text
+    var
+        IStr1: InStream;
+        IStr2: InStream;
+        Result: Text;
+    begin
+        Rec.Data.CreateInStream(IStr1);
+        IStr2 := IStr1;
+        IStr2.ReadText(Result);
+        exit(Result);
+    end;
+
+    /// <summary>
+    /// Copies a BLOB from SrcRec to DstRec using COPYSTREAM.
+    /// </summary>
+    procedure CopyBlobData(var SrcRec: Record StreamSurfaceTable; var DstRec: Record StreamSurfaceTable)
+    var
+        IStr: InStream;
+        OStr: OutStream;
+    begin
+        SrcRec.Data.CreateInStream(IStr);
+        DstRec.Data.CreateOutStream(OStr);
+        COPYSTREAM(OStr, IStr);
+    end;
+
+    /// <summary>
+    /// Writes and reads back an Integer via binary stream (tests Write/Read Integer).
+    /// </summary>
+    procedure WriteReadInteger(var Rec: Record StreamSurfaceTable; Value: Integer): Integer
+    var
+        OStr: OutStream;
+        IStr: InStream;
+        ReadVal: Integer;
+        BytesRead: Integer;
+    begin
+        Rec.Data.CreateOutStream(OStr);
+        OStr.Write(Value);
+
+        Rec.Data.CreateInStream(IStr);
+        BytesRead := IStr.Read(ReadVal);
+        exit(ReadVal);
+    end;
+
+    /// <summary>
+    /// Writes and reads back a Boolean via binary stream (tests Write/Read Boolean).
+    /// </summary>
+    procedure WriteReadBoolean(var Rec: Record StreamSurfaceTable; Value: Boolean): Boolean
+    var
+        OStr: OutStream;
+        IStr: InStream;
+        ReadVal: Boolean;
+        BytesRead: Integer;
+    begin
+        Rec.Data.CreateOutStream(OStr);
+        OStr.Write(Value);
+
+        Rec.Data.CreateInStream(IStr);
+        BytesRead := IStr.Read(ReadVal);
+        exit(ReadVal);
+    end;
+
+    /// <summary>
+    /// Writes and reads back a Decimal via binary stream (tests Write/Read Decimal).
+    /// </summary>
+    procedure WriteReadDecimal(var Rec: Record StreamSurfaceTable; Value: Decimal): Decimal
+    var
+        OStr: OutStream;
+        IStr: InStream;
+        ReadVal: Decimal;
+        BytesRead: Integer;
+    begin
+        Rec.Data.CreateOutStream(OStr);
+        OStr.Write(Value);
+
+        Rec.Data.CreateInStream(IStr);
+        BytesRead := IStr.Read(ReadVal);
+        exit(ReadVal);
+    end;
+
+    /// <summary>
+    /// Passes OutStream/InStream as var parameters to a sub-procedure.
+    /// </summary>
+    procedure WriteReadViaParam(var Rec: Record StreamSurfaceTable; Text: Text): Text
+    var
+        OStr: OutStream;
+        IStr: InStream;
+        Result: Text;
+    begin
+        Rec.Data.CreateOutStream(OStr);
+        WriteToStream(OStr, Text);
+
+        Rec.Data.CreateInStream(IStr);
+        ReadFromStream(IStr, Result);
+        exit(Result);
+    end;
+
+    local procedure WriteToStream(var OStr: OutStream; Text: Text)
+    begin
+        OStr.WriteText(Text);
+    end;
+
+    local procedure ReadFromStream(var IStr: InStream; var Result: Text)
+    begin
+        IStr.ReadText(Result);
+    end;
+
+    /// <summary>
+    /// Tests EOS detection.
+    /// </summary>
+    procedure IsEOSAfterRead(var Rec: Record StreamSurfaceTable): Boolean
+    var
+        IStr: InStream;
+        Dummy: Text;
+    begin
+        Rec.Data.CreateInStream(IStr);
+        IStr.ReadText(Dummy);
+        exit(IStr.EOS());
+    end;
+}

--- a/tests/79-stream-surface/src/StreamSurfaceTable.al
+++ b/tests/79-stream-surface/src/StreamSurfaceTable.al
@@ -1,0 +1,12 @@
+table 79100 StreamSurfaceTable
+{
+    fields
+    {
+        field(1; Id; Integer) { }
+        field(2; Data; Blob) { }
+    }
+    keys
+    {
+        key(PK; Id) { Clustered = true; }
+    }
+}

--- a/tests/79-stream-surface/test/StreamSurfaceTest.al
+++ b/tests/79-stream-surface/test/StreamSurfaceTest.al
@@ -1,0 +1,180 @@
+codeunit 79101 StreamSurfaceTest
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Helper: Codeunit StreamSurfaceHelper;
+
+    [Test]
+    procedure TestOutStreamAssign()
+    var
+        Rec: Record StreamSurfaceTable;
+        Result: Text;
+    begin
+        // [GIVEN] a record with a BLOB field
+        Rec.Init();
+        Rec.Id := 1;
+        Rec.Insert();
+
+        // [WHEN] writing text via an assigned OutStream (OutStr2 := OutStr1)
+        Result := Helper.WriteViaAssignedOutStream(Rec, 'AssignedOut');
+
+        // [THEN] the text is readable back
+        Assert.AreEqual('AssignedOut', Result, 'OutStream assign should propagate writes');
+    end;
+
+    [Test]
+    procedure TestInStreamAssign()
+    var
+        Rec: Record StreamSurfaceTable;
+        OStr: OutStream;
+        Result: Text;
+    begin
+        // [GIVEN] a record with 'AssignedIn' written to BLOB
+        Rec.Init();
+        Rec.Id := 2;
+        Rec.Insert();
+        Rec.Data.CreateOutStream(OStr);
+        OStr.WriteText('AssignedIn');
+
+        // [WHEN] reading via an assigned InStream (InStr2 := InStr1)
+        Result := Helper.ReadViaAssignedInStream(Rec);
+
+        // [THEN] the text is read correctly
+        Assert.AreEqual('AssignedIn', Result, 'InStream assign should propagate reads');
+    end;
+
+    [Test]
+    procedure TestCopyStream()
+    var
+        SrcRec: Record StreamSurfaceTable;
+        DstRec: Record StreamSurfaceTable;
+        OStr: OutStream;
+        IStr: InStream;
+        Result: Text;
+    begin
+        // [GIVEN] a source record with data
+        SrcRec.Init();
+        SrcRec.Id := 3;
+        SrcRec.Insert();
+        SrcRec.Data.CreateOutStream(OStr);
+        OStr.WriteText('CopiedData');
+
+        DstRec.Init();
+        DstRec.Id := 4;
+        DstRec.Insert();
+
+        // [WHEN] copying the BLOB with COPYSTREAM
+        Helper.CopyBlobData(SrcRec, DstRec);
+
+        // [THEN] destination contains the same data
+        DstRec.Data.CreateInStream(IStr);
+        IStr.ReadText(Result);
+        Assert.AreEqual('CopiedData', Result, 'COPYSTREAM should copy all bytes');
+    end;
+
+    [Test]
+    procedure TestWriteReadInteger()
+    var
+        Rec: Record StreamSurfaceTable;
+        Result: Integer;
+    begin
+        Rec.Init();
+        Rec.Id := 5;
+        Rec.Insert();
+
+        // [WHEN] writing and reading an Integer via binary stream
+        Result := Helper.WriteReadInteger(Rec, 42);
+
+        // [THEN] round-trip is correct
+        Assert.AreEqual(42, Result, 'Integer binary round-trip failed');
+    end;
+
+    [Test]
+    procedure TestWriteReadIntegerNegative()
+    var
+        Rec: Record StreamSurfaceTable;
+        Result: Integer;
+    begin
+        Rec.Init();
+        Rec.Id := 6;
+        Rec.Insert();
+
+        Result := Helper.WriteReadInteger(Rec, -1234);
+        Assert.AreEqual(-1234, Result, 'Negative integer binary round-trip failed');
+    end;
+
+    [Test]
+    procedure TestWriteReadBooleanTrue()
+    var
+        Rec: Record StreamSurfaceTable;
+        Result: Boolean;
+    begin
+        Rec.Init();
+        Rec.Id := 7;
+        Rec.Insert();
+
+        Result := Helper.WriteReadBoolean(Rec, true);
+        Assert.IsTrue(Result, 'Boolean true round-trip failed');
+    end;
+
+    [Test]
+    procedure TestWriteReadBooleanFalse()
+    var
+        Rec: Record StreamSurfaceTable;
+        Result: Boolean;
+    begin
+        Rec.Init();
+        Rec.Id := 8;
+        Rec.Insert();
+
+        Result := Helper.WriteReadBoolean(Rec, false);
+        Assert.IsFalse(Result, 'Boolean false round-trip failed');
+    end;
+
+    [Test]
+    procedure TestWriteReadDecimal()
+    var
+        Rec: Record StreamSurfaceTable;
+        Result: Decimal;
+    begin
+        Rec.Init();
+        Rec.Id := 9;
+        Rec.Insert();
+
+        Result := Helper.WriteReadDecimal(Rec, 3.14);
+        Assert.AreEqual(3.14, Result, 'Decimal binary round-trip failed');
+    end;
+
+    [Test]
+    procedure TestWriteReadViaParam()
+    var
+        Rec: Record StreamSurfaceTable;
+        Result: Text;
+    begin
+        Rec.Init();
+        Rec.Id := 10;
+        Rec.Insert();
+
+        Result := Helper.WriteReadViaParam(Rec, 'ParamTest');
+        Assert.AreEqual('ParamTest', Result, 'Stream var param round-trip failed');
+    end;
+
+    [Test]
+    procedure TestEOSAfterRead()
+    var
+        Rec: Record StreamSurfaceTable;
+        OStr: OutStream;
+        IsEOS: Boolean;
+    begin
+        Rec.Init();
+        Rec.Id := 11;
+        Rec.Insert();
+        Rec.Data.CreateOutStream(OStr);
+        OStr.WriteText('EOSTest');
+
+        IsEOS := Helper.IsEOSAfterRead(Rec);
+        Assert.IsTrue(IsEOS, 'EOS should be true after reading all data');
+    end;
+}


### PR DESCRIPTION
## Summary

Fixes #65: adds missing stream capabilities to `MockOutStream` and `MockStream`.

- `MockOutStream.ALAssign` — implements `OutStr2 := OutStr1` stream assignment
- `MockStream.ALWrite`/`ALRead` overloads for `Integer`, `Boolean`, `Decimal18` — binary read/write
- `MockStream.ALCopyStream` — implements `COPYSTREAM(OutStr, InStr)`
- `RoslynRewriter`: redirects `ALSystemVariable.ALCopyStream` to `MockStream.ALCopyStream`

## Test plan
- [x] `tests/79-stream-surface` — 10 test cases covering assignment, binary I/O, EOS, var-parameter passing
- [x] No regressions in `tests/78-blob-stream`