### PR TITLE
Add sourceFile tracking for iterations and captured values

### DIFF
--- a/AlRunner.Tests/InlineCaptureTests.cs
+++ b/AlRunner.Tests/InlineCaptureTests.cs
@@ -70,4 +70,30 @@ public class InlineCaptureTests
             .Any(c => c.GetProperty("statementId").GetInt32() > 0);
         Assert.True(anyNonZero, "JSON output must include per-statement statementIds");
     }
+
+    [Fact]
+    public void CaptureValues_JsonOutput_IncludesSourceFile()
+    {
+        var pipeline = new AlRunnerPipeline();
+        var result = pipeline.Run(new PipelineOptions
+        {
+            InputPaths = { TestPath("47-capture-inline", "src"), TestPath("47-capture-inline", "test") },
+            CaptureValues = true,
+            OutputJson = true
+        });
+
+        Assert.Equal(0, result.ExitCode);
+        var doc = JsonDocument.Parse(result.StdOut.Trim());
+        var caps = doc.RootElement.GetProperty("capturedValues");
+        Assert.True(caps.GetArrayLength() > 0);
+
+        // Every captured value should have a sourceFile property ending in .al
+        foreach (var cap in caps.EnumerateArray())
+        {
+            Assert.True(cap.TryGetProperty("sourceFile", out var sf),
+                $"Expected sourceFile on captured value (scope={cap.GetProperty("scopeName").GetString()})");
+            var sourceFile = sf.GetString()!;
+            Assert.EndsWith(".al", sourceFile);
+        }
+    }
 }

--- a/AlRunner.Tests/PipelineTests.cs
+++ b/AlRunner.Tests/PipelineTests.cs
@@ -216,4 +216,32 @@ public class PipelineTests
         Assert.True(failedTest.TryGetProperty("message", out var msg));
         Assert.False(string.IsNullOrEmpty(msg.GetString()));
     }
+
+    [Fact]
+    public void IterationTracking_EmitsSourceFile()
+    {
+        var pipeline = new AlRunnerPipeline();
+        var result = pipeline.Run(new PipelineOptions
+        {
+            InputPaths = { TestPath("67-iteration-tracking", "src"), TestPath("67-iteration-tracking", "test") },
+            OutputJson = true,
+            IterationTracking = true,
+        });
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.NotNull(result.Iterations);
+        Assert.True(result.Iterations!.Count > 0, "Expected at least one loop");
+
+        // Parse the JSON output to verify sourceFile is present
+        using var doc = System.Text.Json.JsonDocument.Parse(result.StdOut);
+        var iterations = doc.RootElement.GetProperty("iterations");
+        foreach (var iter in iterations.EnumerateArray())
+        {
+            Assert.True(iter.TryGetProperty("sourceFile", out var sf), "Expected sourceFile property on iteration");
+            var sourceFile = sf.GetString()!;
+            Assert.EndsWith(".al", sourceFile);
+            // Loops are in src/LoopHelper.al, not test/LoopTest.al
+            Assert.Contains("LoopHelper", sourceFile);
+        }
+    }
 }

--- a/AlRunner.Tests/SourceFileMapperTests.cs
+++ b/AlRunner.Tests/SourceFileMapperTests.cs
@@ -108,6 +108,36 @@ public class SourceFileMapperTests
     }
 }
 
+public class ClassToObjectMappingTests
+{
+    public ClassToObjectMappingTests()
+    {
+        SourceFileMapper.Clear();
+    }
+
+    [Fact]
+    public void RegisterClass_GetObjectForClass_RoundTrip()
+    {
+        SourceFileMapper.RegisterClass("Codeunit50471", "CI Pipeline Tests");
+        Assert.Equal("CI Pipeline Tests", SourceFileMapper.GetObjectForClass("Codeunit50471"));
+    }
+
+    [Fact]
+    public void GetObjectForClass_UnknownClass_ReturnsFallback()
+    {
+        Assert.Equal("UnknownClass", SourceFileMapper.GetObjectForClass("UnknownClass"));
+    }
+
+    [Fact]
+    public void Clear_AlsoResetsClassMappings()
+    {
+        SourceFileMapper.RegisterClass("Codeunit50471", "CI Pipeline Tests");
+        SourceFileMapper.Clear();
+        // Falls back to className after clear
+        Assert.Equal("Codeunit50471", SourceFileMapper.GetObjectForClass("Codeunit50471"));
+    }
+}
+
 public class AlDeclarationParsingTests
 {
     [Fact]

--- a/AlRunner.Tests/SourceFileMapperTests.cs
+++ b/AlRunner.Tests/SourceFileMapperTests.cs
@@ -1,0 +1,70 @@
+using AlRunner;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public class SourceFileMapperTests
+{
+    public SourceFileMapperTests()
+    {
+        SourceFileMapper.Clear();
+    }
+
+    [Fact]
+    public void Register_GetFile_RoundTrip()
+    {
+        SourceFileMapper.Register("Loop Helper", "src/LoopHelper.al");
+        Assert.Equal("src/LoopHelper.al", SourceFileMapper.GetFile("Loop Helper"));
+    }
+
+    [Fact]
+    public void GetFile_UnknownObject_ReturnsNull()
+    {
+        Assert.Null(SourceFileMapper.GetFile("Nonexistent"));
+    }
+
+    [Fact]
+    public void Clear_RemovesAllRegistrations()
+    {
+        SourceFileMapper.Register("Foo", "Foo.al");
+        SourceFileMapper.Clear();
+        Assert.Null(SourceFileMapper.GetFile("Foo"));
+    }
+
+    [Fact]
+    public void MultipleObjects_SameFile()
+    {
+        SourceFileMapper.Register("Helper", "src/Multi.al");
+        SourceFileMapper.Register("Utils", "src/Multi.al");
+        Assert.Equal("src/Multi.al", SourceFileMapper.GetFile("Helper"));
+        Assert.Equal("src/Multi.al", SourceFileMapper.GetFile("Utils"));
+    }
+
+    [Fact]
+    public void GetFileForScope_ResolvesChain()
+    {
+        SourceFileMapper.Register("Loop Helper", "src/LoopHelper.al");
+        var scopeToObject = new Dictionary<string, string>
+        {
+            ["Codeunit50020_Scope"] = "Loop Helper"
+        };
+        Assert.Equal("src/LoopHelper.al", SourceFileMapper.GetFileForScope("Codeunit50020_Scope", scopeToObject));
+    }
+
+    [Fact]
+    public void GetFileForScope_UnknownScope_ReturnsNull()
+    {
+        var scopeToObject = new Dictionary<string, string>();
+        Assert.Null(SourceFileMapper.GetFileForScope("Unknown_Scope", scopeToObject));
+    }
+
+    [Fact]
+    public void GetFileForScope_ScopeKnownButObjectNotRegistered_ReturnsNull()
+    {
+        var scopeToObject = new Dictionary<string, string>
+        {
+            ["Codeunit50020_Scope"] = "Loop Helper"
+        };
+        Assert.Null(SourceFileMapper.GetFileForScope("Codeunit50020_Scope", scopeToObject));
+    }
+}

--- a/AlRunner.Tests/SourceFileMapperTests.cs
+++ b/AlRunner.Tests/SourceFileMapperTests.cs
@@ -173,6 +173,22 @@ public class AlDeclarationParsingTests
     }
 
     [Fact]
+    public void ProfileWithoutNumericId()
+    {
+        var names = SourceFileMapper.ParseObjectDeclarations("profile \"My Profile\"\n{\n}");
+        Assert.Single(names);
+        Assert.Equal("My Profile", names[0]);
+    }
+
+    [Fact]
+    public void ControlAddInWithoutNumericId()
+    {
+        var names = SourceFileMapper.ParseObjectDeclarations("controladdin MyControl\n{\n}");
+        Assert.Single(names);
+        Assert.Equal("MyControl", names[0]);
+    }
+
+    [Fact]
     public void CaseInsensitiveKeyword()
     {
         var names = SourceFileMapper.ParseObjectDeclarations("CODEUNIT 50 \"Foo\"\n{\n}");

--- a/AlRunner.Tests/SourceFileMapperTests.cs
+++ b/AlRunner.Tests/SourceFileMapperTests.cs
@@ -67,6 +67,45 @@ public class SourceFileMapperTests
         };
         Assert.Null(SourceFileMapper.GetFileForScope("Codeunit50020_Scope", scopeToObject));
     }
+
+    [Fact]
+    public void GetFileForScope_PrefixMatch_BareMethodName()
+    {
+        SourceFileMapper.Register("CI Pipeline Tests", "test/Tests.al");
+        var scopeToObject = new Dictionary<string, string>
+        {
+            ["ThreeAssignments_Scope_12345"] = "CI Pipeline Tests"
+        };
+        // Bare method name "ThreeAssignments" should match key starting with "ThreeAssignments_"
+        Assert.Equal("test/Tests.al", SourceFileMapper.GetFileForScope("ThreeAssignments", scopeToObject));
+    }
+
+    [Fact]
+    public void GetFileForScope_PrefixMatch_DoesNotMatchPartialName()
+    {
+        SourceFileMapper.Register("Helper", "src/Helper.al");
+        var scopeToObject = new Dictionary<string, string>
+        {
+            ["HelperFunc_Scope_999"] = "Helper"
+        };
+        // "Helper" should NOT prefix-match "HelperFunc_Scope_999" because
+        // the key starts with "HelperFunc_" not "Helper_"
+        Assert.Null(SourceFileMapper.GetFileForScope("Helper", scopeToObject));
+    }
+
+    [Fact]
+    public void GetFileForScope_ExactMatchPreferredOverPrefix()
+    {
+        SourceFileMapper.Register("Object A", "a.al");
+        SourceFileMapper.Register("Object B", "b.al");
+        var scopeToObject = new Dictionary<string, string>
+        {
+            ["MyScope"] = "Object A",
+            ["MyScope_Scope_999"] = "Object B"
+        };
+        // Exact match "MyScope" → Object A should win over prefix match
+        Assert.Equal("a.al", SourceFileMapper.GetFileForScope("MyScope", scopeToObject));
+    }
 }
 
 public class AlDeclarationParsingTests

--- a/AlRunner.Tests/SourceFileMapperTests.cs
+++ b/AlRunner.Tests/SourceFileMapperTests.cs
@@ -68,3 +68,89 @@ public class SourceFileMapperTests
         Assert.Null(SourceFileMapper.GetFileForScope("Codeunit50020_Scope", scopeToObject));
     }
 }
+
+public class AlDeclarationParsingTests
+{
+    [Fact]
+    public void QuotedCodeunitName()
+    {
+        var names = SourceFileMapper.ParseObjectDeclarations("codeunit 50 \"Loop Helper\"\n{\n}");
+        Assert.Single(names);
+        Assert.Equal("Loop Helper", names[0]);
+    }
+
+    [Fact]
+    public void UnquotedCodeunitName()
+    {
+        var names = SourceFileMapper.ParseObjectDeclarations("codeunit 50 LoopHelper\n{\n}");
+        Assert.Single(names);
+        Assert.Equal("LoopHelper", names[0]);
+    }
+
+    [Fact]
+    public void TableDeclaration()
+    {
+        var names = SourceFileMapper.ParseObjectDeclarations("table 100 \"My Table\"\n{\n}");
+        Assert.Single(names);
+        Assert.Equal("My Table", names[0]);
+    }
+
+    [Fact]
+    public void EnumExtensionDeclaration()
+    {
+        var names = SourceFileMapper.ParseObjectDeclarations("enumextension 50100 \"Status Ext\" extends Status\n{\n}");
+        Assert.Single(names);
+        Assert.Equal("Status Ext", names[0]);
+    }
+
+    [Fact]
+    public void CaseInsensitiveKeyword()
+    {
+        var names = SourceFileMapper.ParseObjectDeclarations("CODEUNIT 50 \"Foo\"\n{\n}");
+        Assert.Single(names);
+        Assert.Equal("Foo", names[0]);
+    }
+
+    [Fact]
+    public void MultipleObjectsInOneFile()
+    {
+        var source = "codeunit 50 \"Helper\"\n{\n}\ntable 100 \"Data\"\n{\n}";
+        var names = SourceFileMapper.ParseObjectDeclarations(source);
+        Assert.Equal(2, names.Count);
+        Assert.Contains("Helper", names);
+        Assert.Contains("Data", names);
+    }
+
+    [Fact]
+    public void NameInComment_NotMatched()
+    {
+        var source = "// codeunit 50 \"Fake\"\ncodeunit 51 \"Real\"\n{\n}";
+        var names = SourceFileMapper.ParseObjectDeclarations(source);
+        Assert.Single(names);
+        Assert.Equal("Real", names[0]);
+    }
+
+    [Fact]
+    public void NameInMessageCall_NotMatched()
+    {
+        var source = "codeunit 50 \"Real\"\n{\n  trigger OnRun() begin Message('codeunit 99 \"Fake\"'); end;\n}";
+        var names = SourceFileMapper.ParseObjectDeclarations(source);
+        Assert.Single(names);
+        Assert.Equal("Real", names[0]);
+    }
+
+    [Fact]
+    public void PageExtensionDeclaration()
+    {
+        var names = SourceFileMapper.ParseObjectDeclarations("pageextension 50100 \"My Page Ext\" extends \"Customer Card\"\n{\n}");
+        Assert.Single(names);
+        Assert.Equal("My Page Ext", names[0]);
+    }
+
+    [Fact]
+    public void EmptySource_ReturnsEmpty()
+    {
+        var names = SourceFileMapper.ParseObjectDeclarations("");
+        Assert.Empty(names);
+    }
+}

--- a/AlRunner/CoverageReport.cs
+++ b/AlRunner/CoverageReport.cs
@@ -1,6 +1,7 @@
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Xml;
+using AlRunner;
 
 /// <summary>
 /// Generates Cobertura XML coverage reports from AL Runner's statement-level
@@ -88,40 +89,6 @@ public static class CoverageReport
     }
 
     /// <summary>
-    /// Determine which AL source file a scope class belongs to, using the
-    /// object name from the generated C# (e.g., "Discount Calculator" ->
-    /// find the .al file containing that codeunit/table).
-    /// </summary>
-    public static Dictionary<string, string> MapObjectsToFiles(
-        List<(string Name, string Code)> generatedCSharp,
-        List<string> alSourcePaths)
-    {
-        // Map generated object name -> AL source file path
-        var result = new Dictionary<string, string>();
-        foreach (var (name, _) in generatedCSharp)
-        {
-            // Try to find a source file whose content declares this object
-            foreach (var path in alSourcePaths)
-            {
-                if (File.Exists(path))
-                {
-                    var content = File.ReadAllText(path);
-                    // Match codeunit/table name in quotes
-                    if (content.Contains($"\"{name}\"", StringComparison.OrdinalIgnoreCase))
-                    {
-                        result[name] = Path.GetRelativePath(Directory.GetCurrentDirectory(), path);
-                        break;
-                    }
-                }
-            }
-            // Fallback: use the object name as a synthetic path
-            if (!result.ContainsKey(name))
-                result[name] = name + ".al";
-        }
-        return result;
-    }
-
-    /// <summary>
     /// Build a mapping from scope class name to AL object name.
     /// Each (Name, Code) pair in generatedCSharp has Name = AL object name.
     /// We find all scope classes in each Code block and map them to that Name.
@@ -150,7 +117,6 @@ public static class CoverageReport
         Dictionary<(string Scope, int StmtIndex), int> sourceSpans,
         HashSet<(string Type, int Id)> hitStatements,
         HashSet<(string Type, int Id)> totalStatements,
-        Dictionary<string, string> objectToFile,
         Dictionary<string, string>? scopeToObject = null)
     {
         // Group coverage data by source file
@@ -165,23 +131,11 @@ public static class CoverageReport
             if (!totalStatements.Contains((scope, stmtIdx)))
                 continue;
 
-            // Find which file this scope belongs to using the scope→object→file chain
+            // Find which file this scope belongs to using SourceFileMapper
             string? filePath = null;
             if (scopeToObject != null && scopeToObject.TryGetValue(scope, out var objectName))
             {
-                objectToFile.TryGetValue(objectName, out filePath);
-            }
-            if (filePath == null)
-            {
-                // Fallback: try legacy string matching
-                foreach (var (objName, path) in objectToFile)
-                {
-                    if (scope.Contains(objName.Replace(" ", ""), StringComparison.OrdinalIgnoreCase))
-                    {
-                        filePath = path;
-                        break;
-                    }
-                }
+                filePath = SourceFileMapper.GetFile(objectName);
             }
             // If scope doesn't match any user file, skip it entirely.
             // This prevents library/stub scopes (Assert, etc.) from

--- a/AlRunner/Pipeline.cs
+++ b/AlRunner/Pipeline.cs
@@ -423,7 +423,7 @@ public class AlRunnerPipeline
         }
 
         // Register C# class names → AL object names for captured value resolution
-        var outerClassPattern = new System.Text.RegularExpressions.Regex(@"^\s*public\s+(?:sealed\s+)?class\s+(\w+)", System.Text.RegularExpressions.RegexOptions.Multiline);
+        var outerClassPattern = new System.Text.RegularExpressions.Regex(@"^\s*public\s+(?:\w+\s+)*class\s+(\w+)", System.Text.RegularExpressions.RegexOptions.Multiline);
         foreach (var (name, code) in generatedCSharpList)
         {
             var classMatch = outerClassPattern.Match(code);

--- a/AlRunner/Pipeline.cs
+++ b/AlRunner/Pipeline.cs
@@ -378,7 +378,9 @@ public class AlRunnerPipeline
             Runtime.TableFieldRegistry.ParseAndRegister(options.InlineCode);
         }
 
-        // Auto-discover dependency .app files from --packages directories
+        // Auto-discover dependency .app files from --packages directories.
+        // Note: dependency/stub sources are intentionally NOT registered with SourceFileMapper —
+        // they are external code whose captured values and coverage should not appear in user files.
         if (options.PackagePaths.Count > 0 && inputGroups.Any(g => g.Path.EndsWith(".app", StringComparison.OrdinalIgnoreCase)))
         {
             AutoDiscoverDependencies(options.PackagePaths, inputGroups, inputPaths, alSources);
@@ -589,6 +591,11 @@ public class AlRunnerPipeline
             if (options.IterationTracking)
                 Runtime.IterationTracker.Disable();
             Runtime.MessageCapture.Disable();
+
+            if (options.IterationTracking || options.ShowCoverage)
+            {
+                _scopeToObject = CoverageReport.BuildScopeToObjectMap(generatedCSharpList!);
+            }
         }
         Timer.EndStage("Test execution");
         Timer.Print();

--- a/AlRunner/Pipeline.cs
+++ b/AlRunner/Pipeline.cs
@@ -69,6 +69,8 @@ public class PipelineResult
 
 public class AlRunnerPipeline
 {
+    private Dictionary<string, string>? _scopeToObject;
+
     /// <summary>
     /// Run the full AL Runner pipeline: transpile → rewrite → compile → execute.
     /// Returns a structured result instead of writing to stdout/stderr directly.
@@ -130,7 +132,7 @@ public class AlRunnerPipeline
         var stdoutStr = stdout.ToString();
         if (options.OutputJson && (testResults.Count > 0 || messages.Count > 0))
         {
-            stdoutStr = SerializeJsonOutput(testResults, exitCode, capturedValues: capturedValues, messages: messages, iterations: iterationLoops);
+            stdoutStr = SerializeJsonOutput(testResults, exitCode, capturedValues: capturedValues, messages: messages, iterations: iterationLoops, scopeToObject: _scopeToObject);
         }
 
         return new PipelineResult
@@ -148,7 +150,8 @@ public class AlRunnerPipeline
     public static string SerializeJsonOutput(
         List<TestResult> tests, int exitCode, bool indented = true,
         List<CapturedValue>? capturedValues = null, List<string>? messages = null,
-        List<Runtime.IterationTracker.LoopRecord>? iterations = null)
+        List<Runtime.IterationTracker.LoopRecord>? iterations = null,
+        Dictionary<string, string>? scopeToObject = null)
     {
         object? capturedValuesObj = capturedValues?.Count > 0
             ? capturedValues.Select(c => new
@@ -183,6 +186,9 @@ public class AlRunnerPipeline
                 ? iterations.Select(loop => new
                 {
                     loopId = $"L{loop.LoopId}",
+                    sourceFile = scopeToObject != null
+                        ? SourceFileMapper.GetFileForScope(loop.ScopeName, scopeToObject)
+                        : null,
                     loopLine = SourceLineMapper.GetAlLineFromStatement(loop.ScopeName, loop.SourceStartLine) ?? loop.SourceStartLine,
                     loopEndLine = SourceLineMapper.GetAlLineFromStatement(loop.ScopeName, loop.SourceEndLine) ?? loop.SourceEndLine,
                     parentLoopId = loop.ParentLoopId.HasValue ? $"L{loop.ParentLoopId}" : (string?)null,
@@ -527,6 +533,15 @@ public class AlRunnerPipeline
             if (options.IterationTracking)
                 Runtime.IterationTracker.Disable();
             Runtime.MessageCapture.Disable();
+
+            Dictionary<string, string>? scopeToObject = null;
+            if (options.IterationTracking || options.ShowCoverage)
+            {
+                scopeToObject = CoverageReport.BuildScopeToObjectMap(generatedCSharpList!);
+            }
+
+            _scopeToObject = scopeToObject;
+
             if (options.ShowCoverage)
             {
                 Executor.PrintCoverageReport();
@@ -534,18 +549,7 @@ public class AlRunnerPipeline
                 var sourceSpans = CoverageReport.ParseSourceSpans(generatedCSharpList!);
                 var (hitStmts, totalStmts) = Runtime.AlScope.GetCoverageSets();
 
-                var alFilePaths = new List<string>();
-                foreach (var inputPath in inputPaths)
-                {
-                    if (Directory.Exists(inputPath))
-                        alFilePaths.AddRange(Directory.GetFiles(inputPath, "*.al", SearchOption.AllDirectories));
-                    else if (File.Exists(inputPath))
-                        alFilePaths.Add(inputPath);
-                }
-
-                var objectToFile = CoverageReport.MapObjectsToFiles(generatedCSharpList!, alFilePaths);
-                var scopeToObject = CoverageReport.BuildScopeToObjectMap(generatedCSharpList!);
-                CoverageReport.WriteCobertura("cobertura.xml", sourceSpans, hitStmts, totalStmts, objectToFile, scopeToObject);
+                CoverageReport.WriteCobertura("cobertura.xml", sourceSpans, hitStmts, totalStmts, scopeToObject!);
                 Log.Info("Coverage report: cobertura.xml");
             }
         }

--- a/AlRunner/Pipeline.cs
+++ b/AlRunner/Pipeline.cs
@@ -44,6 +44,7 @@ public class TestResult
 public class CapturedValue
 {
     public required string ScopeName { get; init; }
+    public required string ObjectName { get; init; }
     public required string VariableName { get; init; }
     public string? Value { get; init; }
     public int StatementId { get; init; }
@@ -107,11 +108,12 @@ public class AlRunnerPipeline
         var capturedValues = new List<CapturedValue>();
         if (options.CaptureValues)
         {
-            foreach (var (scopeName, variableName, value, stmtId) in Runtime.ValueCapture.GetCaptures())
+            foreach (var (scopeName, objectName, variableName, value, stmtId) in Runtime.ValueCapture.GetCaptures())
             {
                 capturedValues.Add(new CapturedValue
                 {
                     ScopeName = scopeName,
+                    ObjectName = objectName,
                     VariableName = variableName,
                     Value = value,
                     StatementId = stmtId
@@ -157,9 +159,7 @@ public class AlRunnerPipeline
             ? capturedValues.Select(c => new
             {
                 scopeName = c.ScopeName,
-                sourceFile = scopeToObject != null
-                    ? SourceFileMapper.GetFileForScope(c.ScopeName, scopeToObject)
-                    : null,
+                sourceFile = SourceFileMapper.GetFile(c.ObjectName),
                 variableName = c.VariableName,
                 value = c.Value,
                 statementId = c.StatementId
@@ -422,6 +422,15 @@ public class AlRunnerPipeline
             }
         }
 
+        // Register C# class names → AL object names for captured value resolution
+        var outerClassPattern = new System.Text.RegularExpressions.Regex(@"^\s*public\s+(?:sealed\s+)?class\s+(\w+)", System.Text.RegularExpressions.RegexOptions.Multiline);
+        foreach (var (name, code) in generatedCSharpList)
+        {
+            var classMatch = outerClassPattern.Match(code);
+            if (classMatch.Success)
+                SourceFileMapper.RegisterClass(classMatch.Groups[1].Value, name);
+        }
+
         Log.Info($"\nTranspiled {generatedCSharpList.Count} AL objects to C#");
 
         if (options.DumpCSharp)
@@ -448,7 +457,7 @@ public class AlRunnerPipeline
             // The capture function no-ops when ValueCapture.Enabled is false,
             // so we can run this unconditionally and avoid a separate code
             // path for capture vs non-capture runs.
-            var injectedRoot = ValueCaptureInjector.Inject(tree.GetRoot());
+            var injectedRoot = ValueCaptureInjector.Inject(tree.GetRoot(), name);
             if (options.IterationTracking)
                 injectedRoot = IterationInjector.Inject(injectedRoot);
             tree = Microsoft.CodeAnalysis.CSharp.CSharpSyntaxTree.Create((Microsoft.CodeAnalysis.CSharp.CSharpSyntaxNode)injectedRoot);
@@ -542,7 +551,7 @@ public class AlRunnerPipeline
             Runtime.MessageCapture.Disable();
 
             Dictionary<string, string>? scopeToObject = null;
-            if (options.IterationTracking || options.ShowCoverage || options.CaptureValues)
+            if (options.IterationTracking || options.ShowCoverage)
             {
                 scopeToObject = CoverageReport.BuildScopeToObjectMap(generatedCSharpList!);
             }

--- a/AlRunner/Pipeline.cs
+++ b/AlRunner/Pipeline.cs
@@ -294,6 +294,10 @@ public class AlRunnerPipeline
                     Log.Info($"  {name}");
                     alSources.Add(source);
                     groupSources.Add(source);
+
+                    // Register extracted objects with SourceFileMapper using the .app-relative name
+                    foreach (var objName in SourceFileMapper.ParseObjectDeclarations(source))
+                        SourceFileMapper.Register(objName, name);
                 }
                 var fullPath = Path.GetFullPath(path);
                 inputPaths.Add(fullPath);

--- a/AlRunner/Pipeline.cs
+++ b/AlRunner/Pipeline.cs
@@ -157,6 +157,9 @@ public class AlRunnerPipeline
             ? capturedValues.Select(c => new
             {
                 scopeName = c.ScopeName,
+                sourceFile = scopeToObject != null
+                    ? SourceFileMapper.GetFileForScope(c.ScopeName, scopeToObject)
+                    : null,
                 variableName = c.VariableName,
                 value = c.Value,
                 statementId = c.StatementId

--- a/AlRunner/Pipeline.cs
+++ b/AlRunner/Pipeline.cs
@@ -542,7 +542,7 @@ public class AlRunnerPipeline
             Runtime.MessageCapture.Disable();
 
             Dictionary<string, string>? scopeToObject = null;
-            if (options.IterationTracking || options.ShowCoverage)
+            if (options.IterationTracking || options.ShowCoverage || options.CaptureValues)
             {
                 scopeToObject = CoverageReport.BuildScopeToObjectMap(generatedCSharpList!);
             }

--- a/AlRunner/Pipeline.cs
+++ b/AlRunner/Pipeline.cs
@@ -244,6 +244,7 @@ public class AlRunnerPipeline
         Runtime.CalcFormulaRegistry.Clear();
         Runtime.TableFieldRegistry.Clear();
         Runtime.MockNumberSequence.Reset();
+        SourceFileMapper.Clear();
 
         // Load stubs
         foreach (var stubPath in options.StubPaths)
@@ -309,6 +310,10 @@ public class AlRunnerPipeline
                     var src = File.ReadAllText(f);
                     alSources.Add(src);
                     groupSources.Add(src);
+
+                    var relativePath = Path.GetRelativePath(Directory.GetCurrentDirectory(), f);
+                    foreach (var objName in SourceFileMapper.ParseObjectDeclarations(src))
+                        SourceFileMapper.Register(objName, relativePath);
                 }
                 var fullPath = Path.GetFullPath(path);
                 inputPaths.Add(fullPath);
@@ -321,6 +326,10 @@ public class AlRunnerPipeline
                 var fullPath = Path.GetFullPath(Path.GetDirectoryName(path)!);
                 inputPaths.Add(fullPath);
                 inputGroups.Add((fullPath, new List<string> { src }));
+
+                var relativePath = Path.GetRelativePath(Directory.GetCurrentDirectory(), path);
+                foreach (var objName in SourceFileMapper.ParseObjectDeclarations(src))
+                    SourceFileMapper.Register(objName, relativePath);
             }
             else
             {

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -2051,9 +2051,13 @@ public static class Executor
             if (field.Name.StartsWith("__") || field.Name == "me") continue;
             // Skip parent codeunit reference
             if (field.Name == "_parent") continue;
-            // Skip ITreeObject and NavMethodScope internals
+            // Skip internal runtime types — codeunit/record handles, variants, etc.
+            // Their .ToString() returns implementation details, not user-meaningful values.
             var typeName = field.FieldType.Name;
             if (typeName == "ITreeObject" || typeName.StartsWith("NavMethodScope")) continue;
+            if (typeName.StartsWith("Mock")) continue;
+            // Skip BC plumbing fields (β/γ prefixed)
+            if (field.Name.Length > 0 && (field.Name[0] == '\u03b2' || field.Name[0] == '\u03b3')) continue;
 
             try
             {

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -1947,7 +1947,7 @@ public static class Executor
 
                 // Capture variable values from scope fields if enabled
                 if (captureValues)
-                    CaptureFieldValues(scope, scopeType, testName);
+                    CaptureFieldValues(scope, scopeType, testName, AlRunner.SourceFileMapper.GetObjectForClass(parentType.Name));
 
                 results.Add(new AlRunner.TestResult
                 {
@@ -2043,7 +2043,7 @@ public static class Executor
         return failedOrError > 0 ? 1 : 0;
     }
 
-    private static void CaptureFieldValues(object scope, Type scopeType, string testName)
+    private static void CaptureFieldValues(object scope, Type scopeType, string testName, string objectName)
     {
         foreach (var field in scopeType.GetFields(BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance))
         {
@@ -2062,7 +2062,7 @@ public static class Executor
             try
             {
                 var value = field.GetValue(scope);
-                AlRunner.Runtime.ValueCapture.Capture(testName, field.Name, value, 0);
+                AlRunner.Runtime.ValueCapture.Capture(testName, objectName, field.Name, value, 0);
             }
             catch { /* skip fields that can't be read */ }
         }
@@ -2185,7 +2185,7 @@ public static class Executor
         {
             onRunMethod.Invoke(scope, null);
             if (captureValues)
-                CaptureFieldValues(scope, scopeType, "OnRun");
+                CaptureFieldValues(scope, scopeType, "OnRun", AlRunner.SourceFileMapper.GetObjectForClass(parentType.Name));
             return 0;
         }
         catch (TargetInvocationException ex)

--- a/AlRunner/Runtime/ValueCapture.cs
+++ b/AlRunner/Runtime/ValueCapture.cs
@@ -7,7 +7,7 @@ namespace AlRunner.Runtime;
 /// </summary>
 public static class ValueCapture
 {
-    private static readonly List<(string ScopeName, string VariableName, string? Value, int StatementId)> _captures = new();
+    private static readonly List<(string ScopeName, string ObjectName, string VariableName, string? Value, int StatementId)> _captures = new();
     private static bool _enabled;
 
     public static bool Enabled => _enabled;
@@ -15,13 +15,13 @@ public static class ValueCapture
     public static void Enable() => _enabled = true;
     public static void Disable() => _enabled = false;
 
-    public static void Capture(string scopeName, string variableName, object? value, int statementId)
+    public static void Capture(string scopeName, string objectName, string variableName, object? value, int statementId)
     {
         if (!_enabled) return;
-        _captures.Add((scopeName, variableName, value?.ToString(), statementId));
+        _captures.Add((scopeName, objectName, variableName, value?.ToString(), statementId));
     }
 
-    public static List<(string ScopeName, string VariableName, string? Value, int StatementId)> GetCaptures()
+    public static List<(string ScopeName, string ObjectName, string VariableName, string? Value, int StatementId)> GetCaptures()
         => new(_captures);
 
     public static void Reset()

--- a/AlRunner/SourceFileMapper.cs
+++ b/AlRunner/SourceFileMapper.cs
@@ -11,6 +11,7 @@ namespace AlRunner;
 public static class SourceFileMapper
 {
     private static readonly Dictionary<string, string> _objectToFile = new();
+    private static readonly Dictionary<string, string> _classToObject = new();
 
     /// <summary>
     /// Register an AL object name to its source file path.
@@ -56,11 +57,29 @@ public static class SourceFileMapper
     }
 
     /// <summary>
+    /// Register a C# class name to its AL object name.
+    /// Called after transpilation to map parent class names back to objects.
+    /// </summary>
+    public static void RegisterClass(string className, string objectName)
+    {
+        _classToObject[className] = objectName;
+    }
+
+    /// <summary>
+    /// Look up the AL object name for a C# class name.
+    /// </summary>
+    public static string GetObjectForClass(string className)
+    {
+        return _classToObject.TryGetValue(className, out var obj) ? obj : className;
+    }
+
+    /// <summary>
     /// Reset between runs.
     /// </summary>
     public static void Clear()
     {
         _objectToFile.Clear();
+        _classToObject.Clear();
     }
 
     private static readonly Regex ObjectDeclPattern = new(

--- a/AlRunner/SourceFileMapper.cs
+++ b/AlRunner/SourceFileMapper.cs
@@ -85,7 +85,7 @@ public static class SourceFileMapper
     }
 
     private static readonly Regex ObjectDeclPattern = new(
-        @"^(?:codeunit|table|page|report|xmlport|query|enum|enumextension|tableextension|pageextension|interface|permissionset|permissionsetextension|reportextension|profile|controladdin)\s+\d+\s+(?:""([^""]+)""|(\w+))",
+        @"^(?:(?:codeunit|table|page|report|xmlport|query|enum|enumextension|tableextension|pageextension|interface|permissionset|permissionsetextension|reportextension)\s+\d+|(?:profile|controladdin)(?:\s+\d+)?)\s+(?:""([^""]+)""|(\w+))",
         RegexOptions.IgnoreCase | RegexOptions.Multiline);
 
     /// <summary>

--- a/AlRunner/SourceFileMapper.cs
+++ b/AlRunner/SourceFileMapper.cs
@@ -44,8 +44,10 @@ public static class SourceFileMapper
         if (scopeToObject.TryGetValue(scopeName, out var objectName))
             return GetFile(objectName);
 
-        // Prefix match: scopeName might be "MethodName" while scopeToObject has
-        // "MethodName_Scope_HASH". Find any key that starts with scopeName + "_".
+        // Prefix match fallback: some capture paths use bare method names (without
+        // _Scope_HASH suffix). Find any scopeToObject key that starts with scopeName + "_".
+        // Used by iterations (IterationTracker stores scope class names).
+        // Captured values bypass this entirely via direct GetFile(objectName).
         var prefix = scopeName + "_";
         foreach (var (key, value) in scopeToObject)
         {

--- a/AlRunner/SourceFileMapper.cs
+++ b/AlRunner/SourceFileMapper.cs
@@ -1,0 +1,49 @@
+namespace AlRunner;
+
+/// <summary>
+/// Maps AL object names to their source file paths.
+/// Populated at input-loading time, queried at JSON serialization.
+/// Follows the SourceLineMapper pattern: static, built during pipeline setup.
+/// </summary>
+public static class SourceFileMapper
+{
+    private static readonly Dictionary<string, string> _objectToFile = new();
+
+    /// <summary>
+    /// Register an AL object name to its source file path.
+    /// Called during input loading as each .al file is read.
+    /// </summary>
+    public static void Register(string objectName, string relativeFilePath)
+    {
+        _objectToFile[objectName] = relativeFilePath.Replace('\\', '/');
+    }
+
+    /// <summary>
+    /// Look up the source file for an AL object name.
+    /// </summary>
+    public static string? GetFile(string objectName)
+    {
+        return _objectToFile.TryGetValue(objectName, out var file) ? file : null;
+    }
+
+    /// <summary>
+    /// Resolve a C# scope class name to its AL source file path
+    /// via the scope-to-object-to-file chain.
+    /// </summary>
+    public static string? GetFileForScope(
+        string scopeName,
+        Dictionary<string, string> scopeToObject)
+    {
+        if (!scopeToObject.TryGetValue(scopeName, out var objectName))
+            return null;
+        return GetFile(objectName);
+    }
+
+    /// <summary>
+    /// Reset between runs.
+    /// </summary>
+    public static void Clear()
+    {
+        _objectToFile.Clear();
+    }
+}

--- a/AlRunner/SourceFileMapper.cs
+++ b/AlRunner/SourceFileMapper.cs
@@ -32,14 +32,27 @@ public static class SourceFileMapper
     /// <summary>
     /// Resolve a C# scope class name to its AL source file path
     /// via the scope-to-object-to-file chain.
+    /// Falls back to prefix matching when the scope name is a method name
+    /// without the _Scope suffix (e.g. ValueCapture uses bare method names).
     /// </summary>
     public static string? GetFileForScope(
         string scopeName,
         Dictionary<string, string> scopeToObject)
     {
-        if (!scopeToObject.TryGetValue(scopeName, out var objectName))
-            return null;
-        return GetFile(objectName);
+        // Exact match first
+        if (scopeToObject.TryGetValue(scopeName, out var objectName))
+            return GetFile(objectName);
+
+        // Prefix match: scopeName might be "MethodName" while scopeToObject has
+        // "MethodName_Scope_HASH". Find any key that starts with scopeName + "_".
+        var prefix = scopeName + "_";
+        foreach (var (key, value) in scopeToObject)
+        {
+            if (key.StartsWith(prefix, StringComparison.Ordinal))
+                return GetFile(value);
+        }
+
+        return null;
     }
 
     /// <summary>

--- a/AlRunner/SourceFileMapper.cs
+++ b/AlRunner/SourceFileMapper.cs
@@ -1,3 +1,6 @@
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+
 namespace AlRunner;
 
 /// <summary>
@@ -45,5 +48,25 @@ public static class SourceFileMapper
     public static void Clear()
     {
         _objectToFile.Clear();
+    }
+
+    private static readonly Regex ObjectDeclPattern = new(
+        @"^(?:codeunit|table|page|report|xmlport|query|enum|enumextension|tableextension|pageextension|interface|permissionset|permissionsetextension|reportextension|profile|controladdin)\s+\d+\s+(?:""([^""]+)""|(\w+))",
+        RegexOptions.IgnoreCase | RegexOptions.Multiline);
+
+    /// <summary>
+    /// Parse AL object declarations from source content.
+    /// Returns the list of object names found.
+    /// Only matches declarations at the start of a line (not in comments or strings).
+    /// </summary>
+    public static List<string> ParseObjectDeclarations(string content)
+    {
+        var names = new List<string>();
+        foreach (Match m in ObjectDeclPattern.Matches(content))
+        {
+            var name = m.Groups[1].Success ? m.Groups[1].Value : m.Groups[2].Value;
+            names.Add(name);
+        }
+        return names;
     }
 }

--- a/AlRunner/ValueCaptureInjector.cs
+++ b/AlRunner/ValueCaptureInjector.cs
@@ -17,6 +17,7 @@ namespace AlRunner;
 public sealed class ValueCaptureInjector : CSharpSyntaxRewriter
 {
     private string? _currentScopeClass;
+    private HashSet<string> _runtimeTypeFields = new();
 
     public static SyntaxNode Inject(SyntaxNode root)
     {
@@ -27,13 +28,41 @@ public sealed class ValueCaptureInjector : CSharpSyntaxRewriter
     public override SyntaxNode? VisitClassDeclaration(ClassDeclarationSyntax node)
     {
         var previous = _currentScopeClass;
+        var previousFields = _runtimeTypeFields;
         // Only instrument scope classes (they carry the user-facing locals);
         // the outer codeunit/record wrappers hold only plumbing.
         if (node.Identifier.Text.Contains("_Scope"))
+        {
             _currentScopeClass = node.Identifier.Text;
+            _runtimeTypeFields = CollectRuntimeTypeFields(node);
+        }
         var result = base.VisitClassDeclaration(node);
         _currentScopeClass = previous;
+        _runtimeTypeFields = previousFields;
         return result;
+    }
+
+    /// <summary>
+    /// Collect field names whose declared type is an internal runtime type
+    /// (MockCodeunitHandle, MockRecordHandle, etc.). These hold AL object
+    /// references whose .ToString() returns implementation details, not
+    /// user-meaningful values.
+    /// </summary>
+    private static HashSet<string> CollectRuntimeTypeFields(ClassDeclarationSyntax classNode)
+    {
+        var fields = new HashSet<string>();
+        foreach (var member in classNode.Members.OfType<FieldDeclarationSyntax>())
+        {
+            var typeName = member.Declaration.Type.ToString();
+            if (typeName.StartsWith("Mock", StringComparison.Ordinal) ||
+                typeName.StartsWith("Nav", StringComparison.Ordinal) ||
+                typeName == "ITreeObject")
+            {
+                foreach (var variable in member.Declaration.Variables)
+                    fields.Add(variable.Identifier.ValueText);
+            }
+        }
+        return fields;
     }
 
     public override SyntaxNode? VisitBlock(BlockSyntax node)
@@ -61,9 +90,9 @@ public sealed class ValueCaptureInjector : CSharpSyntaxRewriter
             var fieldName = TryExtractAssignedFieldName(stmt);
             if (fieldName is null) continue;
 
-            // Skip BC plumbing fields — BC uses `β`-prefixed for scope vars
-            // and `γ` for return values; we only surface user locals.
+            // Skip BC plumbing fields and internal runtime type fields
             if (IsPlumbingField(fieldName)) continue;
+            if (_runtimeTypeFields.Contains(fieldName)) continue;
 
             newStatements.Add(BuildCaptureCall(fieldName, currentStmtId));
         }

--- a/AlRunner/ValueCaptureInjector.cs
+++ b/AlRunner/ValueCaptureInjector.cs
@@ -17,11 +17,14 @@ namespace AlRunner;
 public sealed class ValueCaptureInjector : CSharpSyntaxRewriter
 {
     private string? _currentScopeClass;
+    private readonly string _objectName;
     private HashSet<string> _runtimeTypeFields = new();
 
-    public static SyntaxNode Inject(SyntaxNode root)
+    private ValueCaptureInjector(string objectName) { _objectName = objectName; }
+
+    public static SyntaxNode Inject(SyntaxNode root, string objectName = "")
     {
-        var injector = new ValueCaptureInjector();
+        var injector = new ValueCaptureInjector(objectName);
         return injector.Visit(root);
     }
 
@@ -157,10 +160,13 @@ public sealed class ValueCaptureInjector : CSharpSyntaxRewriter
     private StatementSyntax BuildCaptureCall(string fieldName, int stmtId)
     {
         // AlRunner.Runtime.ValueCapture.Capture(
-        //   <scopeClass>, <fieldName>, (object?)this.<fieldName>, <stmtId>);
+        //   <scopeClass>, <objectName>, <fieldName>, (object?)this.<fieldName>, <stmtId>);
         var scopeLit = SyntaxFactory.LiteralExpression(
             SyntaxKind.StringLiteralExpression,
             SyntaxFactory.Literal(_currentScopeClass!));
+        var objLit = SyntaxFactory.LiteralExpression(
+            SyntaxKind.StringLiteralExpression,
+            SyntaxFactory.Literal(_objectName));
         var nameLit = SyntaxFactory.LiteralExpression(
             SyntaxKind.StringLiteralExpression,
             SyntaxFactory.Literal(fieldName));
@@ -175,7 +181,6 @@ public sealed class ValueCaptureInjector : CSharpSyntaxRewriter
             SyntaxKind.NumericLiteralExpression,
             SyntaxFactory.Literal(stmtId));
 
-        // Fully-qualified so it resolves regardless of using directives in the file.
         var target = SyntaxFactory.ParseExpression("AlRunner.Runtime.ValueCapture.Capture");
 
         var call = SyntaxFactory.InvocationExpression(
@@ -183,6 +188,7 @@ public sealed class ValueCaptureInjector : CSharpSyntaxRewriter
             SyntaxFactory.ArgumentList(SyntaxFactory.SeparatedList(new[]
             {
                 SyntaxFactory.Argument(scopeLit),
+                SyntaxFactory.Argument(objLit),
                 SyntaxFactory.Argument(nameLit),
                 SyntaxFactory.Argument(valueArg),
                 SyntaxFactory.Argument(idLit)


### PR DESCRIPTION
## Summary
- New `SourceFileMapper` static class maps AL object names to source file paths at input-loading time using proper declaration regex
- `sourceFile` field emitted in both iteration and captured value JSON output
- AL object name passed through entire ValueCapture chain (injector → runtime → serialization) for reliable file resolution
- `MapObjectsToFiles` deleted, coverage refactored to use SourceFileMapper
- `RegisterClass` mapping for reflection-based post-test captures

## Test Plan
- [ ] 89 unit/integration tests pass (`dotnet test`)
- [ ] SourceFileMapper: register/get/clear, declaration parsing, prefix-match, class-to-object mapping
- [ ] Integration: iteration JSON has sourceFile pointing to correct .al file
- [ ] Integration: captured values JSON has sourceFile for all values