### PR TITLE
Add summary line at end of test runs

### DIFF
--- a/AlRunner.Tests/PipelineTests.cs
+++ b/AlRunner.Tests/PipelineTests.cs
@@ -299,4 +299,34 @@ namespace AlRunnerGenerated {
             Assert.Contains("LoopHelper", sourceFile);
         }
     }
+
+    [Fact]
+    public void SummaryLine_AllPass_ShowsCompactFormat()
+    {
+        var pipeline = new AlRunnerPipeline();
+        var result = pipeline.Run(new PipelineOptions
+        {
+            InputPaths = { TestPath("01-pure-function", "src"), TestPath("01-pure-function", "test") }
+        });
+
+        Assert.Equal(0, result.ExitCode);
+        // Compact format: "X passed in N.Ns" — no "failed" or "blocked" on a clean run
+        Assert.Matches(@"\d+ passed in \d+\.\d+s", result.StdOut);
+        Assert.DoesNotContain("failed", result.StdOut);
+        Assert.DoesNotContain("blocked", result.StdOut);
+    }
+
+    [Fact]
+    public void SummaryLine_WithFailure_ShowsFullFormat()
+    {
+        var pipeline = new AlRunnerPipeline();
+        var result = pipeline.Run(new PipelineOptions
+        {
+            InputPaths = { TestPath("06-intentional-failure", "src"), TestPath("06-intentional-failure", "test") }
+        });
+
+        Assert.NotEqual(0, result.ExitCode);
+        // Full format: "X passed, Y failed, Z blocked (runner limitation) in N.Ns"
+        Assert.Matches(@"\d+ passed, \d+ failed, \d+ blocked \(runner limitation\) in \d+\.\d+s", result.StdOut);
+    }
 }

--- a/AlRunner.Tests/PipelineTests.cs
+++ b/AlRunner.Tests/PipelineTests.cs
@@ -326,7 +326,7 @@ namespace AlRunnerGenerated {
         });
 
         Assert.NotEqual(0, result.ExitCode);
-        // Full format: "X passed, Y failed, Z blocked (runner limitation) in N.Ns"
-        Assert.Matches(@"\d+ passed, \d+ failed, \d+ blocked \(runner limitation\) in \d+\.\d+s", result.StdOut);
+        // Full format shows at least "X passed, Y failed in N.Ns"
+        Assert.Matches(@"\d+ passed, \d+ failed.*in \d+\.\d+s", result.StdOut);
     }
 }

--- a/AlRunner.Tests/RunnerErrorClassificationTests.cs
+++ b/AlRunner.Tests/RunnerErrorClassificationTests.cs
@@ -137,6 +137,85 @@ public class RunnerErrorClassificationTests
         Assert.Contains("github.com/StefanMaron/BusinessCentral.AL.Runner/issues", output);
     }
 
+    [Fact]
+    public void PrintResults_SummaryLine_AllPass_ShowsCompactFormat()
+    {
+        var tests = new List<TestResult>
+        {
+            new() { Name = "TestA", Status = TestStatus.Pass, DurationMs = 5 },
+            new() { Name = "TestB", Status = TestStatus.Pass, DurationMs = 3 },
+        };
+
+        var captured = new System.IO.StringWriter();
+        var prev = Console.Out;
+        Console.SetOut(captured);
+        try { Executor.PrintResults(tests, totalMs: 100); }
+        finally { Console.SetOut(prev); }
+
+        var output = captured.ToString();
+        Assert.Matches(@"2 passed in 0\.1s", output);
+        Assert.DoesNotContain("failed", output);
+        Assert.DoesNotContain("blocked", output);
+    }
+
+    [Fact]
+    public void PrintResults_SummaryLine_WithBlockedTests_ShowsBlockedFormat()
+    {
+        var tests = new List<TestResult>
+        {
+            new() { Name = "TestPass", Status = TestStatus.Pass },
+            new() { Name = "TestBlocked", Status = TestStatus.Error, IsRunnerBug = true, Message = "Not supported" },
+        };
+
+        var captured = new System.IO.StringWriter();
+        var prev = Console.Out;
+        Console.SetOut(captured);
+        try { Executor.PrintResults(tests, totalMs: 2500); }
+        finally { Console.SetOut(prev); }
+
+        var output = captured.ToString();
+        Assert.Contains("1 passed, 0 failed, 1 blocked (runner limitation) in 2.5s", output);
+    }
+
+    [Fact]
+    public void PrintResults_SummaryLine_WithFailures_ShowsFullFormat()
+    {
+        var tests = new List<TestResult>
+        {
+            new() { Name = "TestPass", Status = TestStatus.Pass },
+            new() { Name = "TestFail", Status = TestStatus.Fail, Message = "assertion failed" },
+            new() { Name = "TestBlocked", Status = TestStatus.Error, IsRunnerBug = true },
+        };
+
+        var captured = new System.IO.StringWriter();
+        var prev = Console.Out;
+        Console.SetOut(captured);
+        try { Executor.PrintResults(tests, totalMs: 1800); }
+        finally { Console.SetOut(prev); }
+
+        var output = captured.ToString();
+        Assert.Contains("1 passed, 1 failed, 1 blocked (runner limitation) in 1.8s", output);
+    }
+
+    [Fact]
+    public void PrintResults_SummaryLine_NoElapsedTime_OmitsTimeClause()
+    {
+        var tests = new List<TestResult>
+        {
+            new() { Name = "TestA", Status = TestStatus.Pass },
+        };
+
+        var captured = new System.IO.StringWriter();
+        var prev = Console.Out;
+        Console.SetOut(captured);
+        try { Executor.PrintResults(tests); }
+        finally { Console.SetOut(prev); }
+
+        var output = captured.ToString();
+        Assert.Contains("1 passed", output);
+        Assert.DoesNotContain(" in ", output);
+    }
+
     // ---------------------------------------------------------------------------
     // ExitCode() differentiation tests
     // ---------------------------------------------------------------------------

--- a/AlRunner.Tests/RunnerErrorClassificationTests.cs
+++ b/AlRunner.Tests/RunnerErrorClassificationTests.cs
@@ -174,7 +174,7 @@ public class RunnerErrorClassificationTests
         finally { Console.SetOut(prev); }
 
         var output = captured.ToString();
-        Assert.Contains("1 passed, 0 failed, 1 blocked (runner limitation) in 2.5s", output);
+        Assert.Contains("1 passed, 1 blocked (runner limitation) in 2.5s", output);
     }
 
     [Fact]

--- a/AlRunner.Tests/SourceFileMapperTests.cs
+++ b/AlRunner.Tests/SourceFileMapperTests.cs
@@ -3,6 +3,7 @@ using Xunit;
 
 namespace AlRunner.Tests;
 
+[Collection("Pipeline")]
 public class SourceFileMapperTests
 {
     public SourceFileMapperTests()
@@ -108,6 +109,7 @@ public class SourceFileMapperTests
     }
 }
 
+[Collection("Pipeline")]
 public class ClassToObjectMappingTests
 {
     public ClassToObjectMappingTests()

--- a/AlRunner/Pipeline.cs
+++ b/AlRunner/Pipeline.cs
@@ -555,12 +555,14 @@ public class AlRunnerPipeline
                 Runtime.IterationTracker.Enable();
             }
 
+            var runSw = System.Diagnostics.Stopwatch.StartNew();
             var results = Executor.RunTests(assembly, captureValues: options.CaptureValues, runProcedure: options.RunProcedure);
+            runSw.Stop();
             testResults.AddRange(results);
             if (results.Count == 0 && options.RunProcedure != null)
                 stderr.WriteLine($"Error: Procedure '{options.RunProcedure}' not found in the generated code.");
             if (!options.OutputJson)
-                Executor.PrintResults(results);
+                Executor.PrintResults(results, runSw.ElapsedMilliseconds);
             exitCode = Executor.ExitCode(results);
 
             if (options.CaptureValues)

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -2077,7 +2077,7 @@ public static class Executor
     }
 
     /// <summary>Print human-readable test results to console.</summary>
-    public static void PrintResults(List<AlRunner.TestResult> results)
+    public static void PrintResults(List<AlRunner.TestResult> results, long totalMs = 0)
     {
         foreach (var r in results)
         {
@@ -2105,9 +2105,13 @@ public static class Executor
 
         var passed = results.Count(r => r.Status == AlRunner.TestStatus.Pass);
         var failed = results.Count(r => r.Status == AlRunner.TestStatus.Fail);
-        var errors = results.Count(r => r.Status == AlRunner.TestStatus.Error);
+        var blocked = results.Count(r => r.Status == AlRunner.TestStatus.Error);
+        var timeStr = totalMs > 0 ? $" in {totalMs / 1000.0:0.0}s" : "";
         Console.WriteLine();
-        Console.WriteLine($"Results: {passed} passed, {failed} failed, {errors} errors, {passed + failed + errors} total");
+        if (failed == 0 && blocked == 0)
+            Console.WriteLine($"{passed} passed{timeStr}");
+        else
+            Console.WriteLine($"{passed} passed, {failed} failed, {blocked} blocked (runner limitation){timeStr}");
     }
 
     /// <summary>

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -2077,7 +2077,7 @@ public static class Executor
     }
 
     /// <summary>Print human-readable test results to console.</summary>
-    public static void PrintResults(List<AlRunner.TestResult> results, long totalMs = 0)
+    public static void PrintResults(List<AlRunner.TestResult> results, long? totalMs = null)
     {
         foreach (var r in results)
         {
@@ -2105,13 +2105,15 @@ public static class Executor
 
         var passed = results.Count(r => r.Status == AlRunner.TestStatus.Pass);
         var failed = results.Count(r => r.Status == AlRunner.TestStatus.Fail);
-        var blocked = results.Count(r => r.Status == AlRunner.TestStatus.Error);
-        var timeStr = totalMs > 0 ? $" in {totalMs / 1000.0:0.0}s" : "";
+        var blocked = results.Count(r => r.Status == AlRunner.TestStatus.Error && r.IsRunnerBug);
+        var errors = results.Count(r => r.Status == AlRunner.TestStatus.Error && !r.IsRunnerBug);
+        var timeStr = totalMs.HasValue ? $" in {totalMs.Value / 1000.0:0.0}s" : "";
+        var parts = new System.Collections.Generic.List<string> { $"{passed} passed" };
+        if (failed > 0) parts.Add($"{failed} failed");
+        if (blocked > 0) parts.Add($"{blocked} blocked (runner limitation)");
+        if (errors > 0) parts.Add($"{errors} errors");
         Console.WriteLine();
-        if (failed == 0 && blocked == 0)
-            Console.WriteLine($"{passed} passed{timeStr}");
-        else
-            Console.WriteLine($"{passed} passed, {failed} failed, {blocked} blocked (runner limitation){timeStr}");
+        Console.WriteLine(string.Join(", ", parts) + timeStr);
     }
 
     /// <summary>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ All notable changes to this project are documented here. Format based on
 ## [Unreleased]
 
 ### Added
+- **Compact summary line at end of test runs** — After each test run, the output
+  now ends with a concise one-liner analogous to pytest/jest:
+  - All pass: `42 passed in 1.8s`
+  - With failures: `9 passed, 2 failed, 3 blocked (runner limitation) in 1.8s`
+  - With setup errors: `9 passed, 1 errors in 0.3s`
+  Only non-zero counts are shown. Runner-limitation errors (`IsRunnerBug=true`) are
+  labelled `blocked (runner limitation)`; other errors are labelled `errors`.
+  Elapsed time is always included when timing is available. Closes #71.
 - **`sourceFile` field on iterations and captured values** — The `--output-json`
   iteration and captured-value records now include a `sourceFile` property with the
   path to the AL file that contains the loop or variable. A new `SourceFileMapper`


### PR DESCRIPTION
Closes #71

## Changes

Replaces the verbose `Results: X passed, Y failed, Z errors, N total` line with a concise, pytest-style summary:

**Clean run:**
```
42 passed in 1.8s
```

**Run with issues:**
```
9 passed, 2 failed, 3 blocked (runner limitation) in 1.8s
```

## What changed

- **`Executor.PrintResults`** — accepts optional `totalMs` param; prints compact format when all pass, full format with issues; renames "errors" → "blocked (runner limitation)"
- **`Pipeline.cs`** — adds `Stopwatch` around `RunTests()` and passes elapsed ms to `PrintResults`
- **4 new unit tests** in `RunnerErrorClassificationTests.cs` — compact format, blocked format, failures format, no-time clause
- **2 new integration tests** in `PipelineTests.cs` — verifies actual pipeline output for passing and failing runs