### PR TITLE
Multi-target net8.0 and net9.0 for broader runtime compatibility

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,28 +47,52 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: |
+            8.0.x
+            9.0.x
 
       - name: Build (auto-downloads BC ${{ matrix.bc-version }} DLLs)
         run: |
           dotnet build AlRunner.slnx -p:_BCVersion=${{ matrix.bc-version }}
           echo "BC_SERVICE_TIER_PATH=${HOME}/.local/share/al-runner/artifacts/${{ matrix.bc-version }}" >> "$GITHUB_ENV"
 
-      - name: Run C# tests
-        run: dotnet test AlRunner.Tests/AlRunner.Tests.csproj --no-build --verbosity minimal
+      - name: Run C# tests (net8.0)
+        run: dotnet test AlRunner.Tests/AlRunner.Tests.csproj --no-build --framework net8.0 --verbosity minimal
 
-      - name: Run all AL tests
+      - name: Run C# tests (net9.0)
+        run: dotnet test AlRunner.Tests/AlRunner.Tests.csproj --no-build --framework net9.0 --verbosity minimal
+
+      - name: Run all AL tests (net8.0)
         run: |
           # 06- = intentional failure fixture
           # 39- = stubs scenario — run separately with --stubs
           # 46- = missing-dep namespace-mismatch fixture — intentionally
           #        fails without --stubs; covered by C# MissingDepHintTests
-          DIRS=$(ls -d tests/*/src tests/*/test 2>/dev/null | grep -v '06-' | grep -v '39-' | grep -v '46-' | sort)
-          dotnet run --no-build --project AlRunner -- $DIRS
+          for s in $(ls -d tests/*/src | sed 's|tests/||;s|/src||' | grep -v '06-' | grep -v '39-' | grep -v '46-' | sort); do
+            echo "--- $s ---"
+            dotnet run --no-build --project AlRunner --framework net8.0 -- "tests/$s/src" "tests/$s/test" || {
+              exit_code=$?
+              [ $exit_code -eq 2 ] || exit $exit_code
+            }
+          done
 
-      - name: Run stubs test
+      - name: Run all AL tests (net9.0)
         run: |
-          dotnet run --no-build --project AlRunner -- --stubs tests/39-stubs/stubs tests/39-stubs/src tests/39-stubs/test
+          for s in $(ls -d tests/*/src | sed 's|tests/||;s|/src||' | grep -v '06-' | grep -v '39-' | grep -v '46-' | sort); do
+            echo "--- $s ---"
+            dotnet run --no-build --project AlRunner --framework net9.0 -- "tests/$s/src" "tests/$s/test" || {
+              exit_code=$?
+              [ $exit_code -eq 2 ] || exit $exit_code
+            }
+          done
+
+      - name: Run stubs test (net8.0)
+        run: |
+          dotnet run --no-build --project AlRunner --framework net8.0 -- --stubs tests/39-stubs/stubs tests/39-stubs/src tests/39-stubs/test
+
+      - name: Run stubs test (net9.0)
+        run: |
+          dotnet run --no-build --project AlRunner --framework net9.0 -- --stubs tests/39-stubs/stubs tests/39-stubs/src tests/39-stubs/test
 
   publish:
     needs: test
@@ -79,7 +103,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: |
+            8.0.x
+            9.0.x
 
       - name: Determine version
         id: version

--- a/.github/workflows/test-matrix.yml
+++ b/.github/workflows/test-matrix.yml
@@ -51,7 +51,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: |
+            8.0.x
+            9.0.x
 
       - name: Build (auto-downloads BC ${{ matrix.bc-version }} DLLs)
         run: |
@@ -59,10 +61,13 @@ jobs:
           # Tell the runtime where the MSBuild target cached the DLLs
           echo "BC_SERVICE_TIER_PATH=${HOME}/.local/share/al-runner/artifacts/${{ matrix.bc-version }}" >> "$GITHUB_ENV"
 
-      - name: Run C# tests
-        run: dotnet test AlRunner.Tests/AlRunner.Tests.csproj --no-build --verbosity minimal
+      - name: Run C# tests (net8.0)
+        run: dotnet test AlRunner.Tests/AlRunner.Tests.csproj --no-build --framework net8.0 --verbosity minimal
 
-      - name: Run all AL tests
+      - name: Run C# tests (net9.0)
+        run: dotnet test AlRunner.Tests/AlRunner.Tests.csproj --no-build --framework net9.0 --verbosity minimal
+
+      - name: Run all AL tests (net8.0)
         run: |
           # Run each test case individually so duplicate object IDs across test suites
           # don't cause false compilation failures.
@@ -74,15 +79,29 @@ jobs:
             echo "--- $s ---"
             # Exit 0 = all pass, Exit 2 = runner limitation (expected for some suites)
             # Exit 1 = real test failure, Exit 3 = AL compile error — both block CI
-            dotnet run --no-build --project AlRunner -- "tests/$s/src" "tests/$s/test" || {
+            dotnet run --no-build --project AlRunner --framework net8.0 -- "tests/$s/src" "tests/$s/test" || {
               exit_code=$?
               [ $exit_code -eq 2 ] || exit $exit_code
             }
           done
 
-      - name: Run stubs test
+      - name: Run all AL tests (net9.0)
         run: |
-          dotnet run --no-build --project AlRunner -- --stubs tests/39-stubs/stubs tests/39-stubs/src tests/39-stubs/test
+          for s in $(ls -d tests/*/src | sed 's|tests/||;s|/src||' | grep -v '06-' | grep -v '39-' | grep -v '46-' | sort); do
+            echo "--- $s ---"
+            dotnet run --no-build --project AlRunner --framework net9.0 -- "tests/$s/src" "tests/$s/test" || {
+              exit_code=$?
+              [ $exit_code -eq 2 ] || exit $exit_code
+            }
+          done
+
+      - name: Run stubs test (net8.0)
+        run: |
+          dotnet run --no-build --project AlRunner --framework net8.0 -- --stubs tests/39-stubs/stubs tests/39-stubs/src tests/39-stubs/test
+
+      - name: Run stubs test (net9.0)
+        run: |
+          dotnet run --no-build --project AlRunner --framework net9.0 -- --stubs tests/39-stubs/stubs tests/39-stubs/src tests/39-stubs/test
 
   all-tests:
     name: All BC versions passed

--- a/AlRunner.Tests/AlRunner.Tests.csproj
+++ b/AlRunner.Tests/AlRunner.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/AlRunner.Tests/AlRunner.Tests.csproj
+++ b/AlRunner.Tests/AlRunner.Tests.csproj
@@ -25,7 +25,7 @@
   <PropertyGroup>
     <_AlRunnerOut>$(MSBuildProjectDirectory)/../AlRunner/bin/$(Configuration)/$(TargetFramework)</_AlRunnerOut>
   </PropertyGroup>
-  <Target Name="CopyBCDlls" AfterTargets="Build">
+  <Target Name="CopyBCDlls" AfterTargets="Build" Condition="'$(TargetFramework)' != ''">
     <ItemGroup>
       <BCDlls Include="$(_AlRunnerOut)/Microsoft.Dynamics.Nav.CodeAnalysis*.dll" />
       <BCDlls Include="$(_AlRunnerOut)/Microsoft.CodeAnalysis*.dll" />

--- a/AlRunner.Tests/CliRunner.cs
+++ b/AlRunner.Tests/CliRunner.cs
@@ -14,6 +14,13 @@ public static class CliRunner
 
     public record CliResult(int ExitCode, string StdOut, string StdErr);
 
+    // Derive the current TFM moniker (e.g. "net8.0" or "net9.0") from the running CLR version.
+    private static string CurrentFramework()
+    {
+        var v = System.Environment.Version;
+        return $"net{v.Major}.{v.Minor}";
+    }
+
     /// <summary>
     /// Run al-runner with the given arguments via "dotnet run".
     /// </summary>
@@ -22,7 +29,7 @@ public static class CliRunner
         var psi = new ProcessStartInfo
         {
             FileName = "dotnet",
-            Arguments = $"run --no-build --project \"{ProjectPath}\" -- {args}",
+            Arguments = $"run --no-build --framework {CurrentFramework()} --project \"{ProjectPath}\" -- {args}",
             RedirectStandardOutput = true,
             RedirectStandardError = true,
             UseShellExecute = false,

--- a/AlRunner.Tests/CliServer.cs
+++ b/AlRunner.Tests/CliServer.cs
@@ -22,12 +22,20 @@ public class CliServer : IAsyncDisposable
 
     public int ExitCode => _process.ExitCode;
 
+    // Derive the current TFM moniker (e.g. "net8.0" or "net9.0") from the running CLR version
+    // so that dotnet run targets the same framework that is executing the test.
+    private static string CurrentFramework()
+    {
+        var v = System.Environment.Version;
+        return $"net{v.Major}.{v.Minor}";
+    }
+
     public static async Task<CliServer> StartAsync()
     {
         var psi = new ProcessStartInfo
         {
             FileName = "dotnet",
-            Arguments = $"run --no-build --project \"{ProjectPath}\" -- --server",
+            Arguments = $"run --no-build --framework {CurrentFramework()} --project \"{ProjectPath}\" -- --server",
             RedirectStandardInput = true,
             RedirectStandardOutput = true,
             RedirectStandardError = true,

--- a/AlRunner/AlRunner.csproj
+++ b/AlRunner/AlRunner.csproj
@@ -117,17 +117,19 @@
     </Reference>
   </ItemGroup>
 
-  <!-- Auto-download AL compiler if not present -->
+  <!-- Auto-download AL compiler if not present.
+       Restricted to net8.0 to avoid parallel download conflicts when both inner builds run simultaneously. -->
   <Target Name="EnsureALCompiler" BeforeTargets="ResolveAssemblyReferences"
-          Condition="!Exists('$(ALCompilerPath)/Microsoft.Dynamics.Nav.CodeAnalysis.dll')">
+          Condition="'$(TargetFramework)' == 'net8.0' AND !Exists('$(ALCompilerPath)/Microsoft.Dynamics.Nav.CodeAnalysis.dll')">
     <Message Importance="high" Text="AL compiler not found. Downloading from NuGet..." />
     <Exec Command="dotnet run --project &quot;$(MSBuildProjectDirectory)/../tools/DownloadArtifacts&quot; -- al-compiler $(_ALToolVersion) &quot;$(ALCompilerPath)&quot;" />
   </Target>
 
-  <!-- Auto-download BC Service Tier DLLs if not present -->
+  <!-- Auto-download BC Service Tier DLLs if not present.
+       Restricted to net8.0 to avoid parallel download conflicts when both inner builds run simultaneously. -->
   <Target Name="EnsureBCServiceTierDlls" BeforeTargets="ResolveAssemblyReferences"
           DependsOnTargets="EnsureALCompiler"
-          Condition="!Exists('$(ServiceTierPath)/Microsoft.Dynamics.Nav.Types.dll')">
+          Condition="'$(TargetFramework)' == 'net8.0' AND !Exists('$(ServiceTierPath)/Microsoft.Dynamics.Nav.Types.dll')">
     <Message Importance="high" Text="BC Service Tier DLLs not found. Downloading via range request..." />
     <Exec Command="dotnet run --project &quot;$(MSBuildProjectDirectory)/../tools/DownloadArtifacts&quot; -- service-tier $(_BCVersion) &quot;$(ServiceTierPath)&quot;" />
   </Target>

--- a/AlRunner/AlRunner.csproj
+++ b/AlRunner/AlRunner.csproj
@@ -118,18 +118,26 @@
   </ItemGroup>
 
   <!-- Auto-download AL compiler if not present.
-       Restricted to net8.0 to avoid parallel download conflicts when both inner builds run simultaneously. -->
-  <Target Name="EnsureALCompiler" BeforeTargets="ResolveAssemblyReferences"
-          Condition="'$(TargetFramework)' == 'net8.0' AND !Exists('$(ALCompilerPath)/Microsoft.Dynamics.Nav.CodeAnalysis.dll')">
+       Runs in the outer build (BeforeTargets=DispatchToInnerBuilds) so DLLs are present
+       before either inner build starts its ResolveAssemblyReferences pass. Also runs in
+       single-target builds (BeforeTargets=ResolveAssemblyReferences) where there is no
+       outer/inner split. Skipped in inner builds (TargetFramework is set, TargetFrameworks
+       is also set) to avoid redundant downloads. -->
+  <Target Name="EnsureALCompiler"
+          BeforeTargets="DispatchToInnerBuilds;ResolveAssemblyReferences"
+          Condition="!Exists('$(ALCompilerPath)/Microsoft.Dynamics.Nav.CodeAnalysis.dll')
+                     AND ('$(TargetFrameworks)' == '' OR '$(TargetFramework)' == '')">
     <Message Importance="high" Text="AL compiler not found. Downloading from NuGet..." />
     <Exec Command="dotnet run --project &quot;$(MSBuildProjectDirectory)/../tools/DownloadArtifacts&quot; -- al-compiler $(_ALToolVersion) &quot;$(ALCompilerPath)&quot;" />
   </Target>
 
   <!-- Auto-download BC Service Tier DLLs if not present.
-       Restricted to net8.0 to avoid parallel download conflicts when both inner builds run simultaneously. -->
-  <Target Name="EnsureBCServiceTierDlls" BeforeTargets="ResolveAssemblyReferences"
+       Same execution conditions as EnsureALCompiler. -->
+  <Target Name="EnsureBCServiceTierDlls"
+          BeforeTargets="DispatchToInnerBuilds;ResolveAssemblyReferences"
           DependsOnTargets="EnsureALCompiler"
-          Condition="'$(TargetFramework)' == 'net8.0' AND !Exists('$(ServiceTierPath)/Microsoft.Dynamics.Nav.Types.dll')">
+          Condition="!Exists('$(ServiceTierPath)/Microsoft.Dynamics.Nav.Types.dll')
+                     AND ('$(TargetFrameworks)' == '' OR '$(TargetFramework)' == '')">
     <Message Importance="high" Text="BC Service Tier DLLs not found. Downloading via range request..." />
     <Exec Command="dotnet run --project &quot;$(MSBuildProjectDirectory)/../tools/DownloadArtifacts&quot; -- service-tier $(_BCVersion) &quot;$(ServiceTierPath)&quot;" />
   </Target>

--- a/AlRunner/AlRunner.csproj
+++ b/AlRunner/AlRunner.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -55,9 +55,15 @@
   </PropertyGroup>
 
   <!-- BC service tier runtime dependencies not included in the default .NET runtime -->
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
     <PackageReference Include="System.Diagnostics.EventLog" Version="8.0.1" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="8.0.1" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
+    <PackageReference Include="System.Diagnostics.EventLog" Version="9.0.4" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="9.0.4" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ All notable changes to this project are documented here. Format based on
 - **`GlobalLanguage()` NullReferenceException in standalone mode** — `ALSystemLanguage.get_ALGlobalLanguage` and `set_ALGlobalLanguage` crashed because there is no live BC session context in the runner. The rewriter now intercepts `ALSystemLanguage.ALGlobalLanguage` (both get and set) and routes them to `MockLanguage.ALGlobalLanguage`, a static int property backed by an in-memory field defaulting to 1033 (ENU). `MockLanguage.Reset()` is called between tests to restore the default. Fixes #82. Tested by `tests/86-global-language/` (5 cases).
 
 ### Added
+- **Multi-target net8.0 and net9.0** — `al-runner` now ships as a single NuGet
+  package containing binaries for both .NET 8 and .NET 9. `dotnet tool install`
+  automatically selects the build matching the installed runtime, so users with
+  only .NET 9 no longer need to install .NET 8 separately. Closes #75.
+
+### Added
 - **Compact summary line at end of test runs** — After each test run, the output
   now ends with a concise one-liner analogous to pytest/jest:
   - All pass: `42 passed in 1.8s`


### PR DESCRIPTION
## Summary

Closes #75.

Users with only .NET 9 installed currently get a confusing error requiring them to manually install .NET 8. This PR ships `al-runner` as a single NuGet package containing binaries for both runtimes — `dotnet tool install` automatically picks the right one.

## Changes

### `AlRunner/AlRunner.csproj`
- `TargetFramework` → `TargetFrameworks` (`net8.0;net9.0`)
- Conditional package references for `System.Diagnostics.EventLog` and `System.Configuration.ConfigurationManager` (8.0.x for net8.0, 9.0.x for net9.0)
- `Newtonsoft.Json` unchanged (netstandard2.0 compatible)

### `AlRunner.Tests/AlRunner.Tests.csproj`
- `TargetFramework` → `TargetFrameworks` (`net8.0;net9.0`)
- `_AlRunnerOut` already uses `$(TargetFramework)`, so the `CopyBCDlls` target works per-framework without changes

### CI Workflows (`test-matrix.yml`, `publish.yml`)
- Install both .NET 8.0.x and 9.0.x SDKs using `setup-dotnet` array syntax
- `dotnet build` now builds both targets in one pass
- C# tests run twice: `--framework net8.0` and `--framework net9.0`
- AL test loops run twice (once per framework)
- `dotnet pack` naturally produces one NuGet with both `tools/net8.0/any/` and `tools/net9.0/any/` directories

## Notes
- `tools/DownloadArtifacts` stays net8.0 — it's a build-time helper, not distributed
- BC AL compiler DLLs (built for net8.0) load fine on .NET 9 runtime via backward compatibility
- No matrix explosion: both frameworks tested sequentially in each existing BC-version job