### PR TITLE
Add --output-junit flag for JUnit XML CI test reporting

### DIFF
--- a/AlRunner.Tests/JUnitOutputTests.cs
+++ b/AlRunner.Tests/JUnitOutputTests.cs
@@ -1,0 +1,274 @@
+using System.Xml.Linq;
+using AlRunner;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+[Collection("Pipeline")]
+public class JUnitOutputTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+
+    private static string TestPath(string testCase, string sub) =>
+        Path.Combine(RepoRoot, "tests", testCase, sub);
+
+    // --- WriteJUnit unit tests ---
+
+    [Fact]
+    public void WriteJUnit_PassingTests_ProducesValidXml()
+    {
+        var results = new List<TestResult>
+        {
+            new() { Name = "TestA", Status = TestStatus.Pass, DurationMs = 42, CodeunitName = "MySuite" },
+            new() { Name = "TestB", Status = TestStatus.Pass, DurationMs = 10, CodeunitName = "MySuite" }
+        };
+
+        var path = Path.GetTempFileName();
+        try
+        {
+            JUnitReport.WriteJUnit(path, results);
+            var doc = XDocument.Load(path);
+
+            Assert.Equal("testsuites", doc.Root!.Name.LocalName);
+            Assert.Single(doc.Root.Elements("testsuite"));
+
+            var suite = doc.Root.Element("testsuite")!;
+            Assert.Equal("MySuite", suite.Attribute("name")!.Value);
+            Assert.Equal("2", suite.Attribute("tests")!.Value);
+            Assert.Equal("0", suite.Attribute("failures")!.Value);
+            Assert.Equal("0", suite.Attribute("errors")!.Value);
+
+            var testcases = suite.Elements("testcase").ToList();
+            Assert.Equal(2, testcases.Count);
+            Assert.Equal("TestA", testcases[0].Attribute("name")!.Value);
+            Assert.Equal("MySuite", testcases[0].Attribute("classname")!.Value);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void WriteJUnit_FailingTest_UsesFailureElement()
+    {
+        var results = new List<TestResult>
+        {
+            new() { Name = "TestFail", Status = TestStatus.Fail, DurationMs = 5, Message = "Expected 1 but got 2", CodeunitName = "MySuite" }
+        };
+
+        var path = Path.GetTempFileName();
+        try
+        {
+            JUnitReport.WriteJUnit(path, results);
+            var doc = XDocument.Load(path);
+
+            var tc = doc.Descendants("testcase").Single();
+            var failure = tc.Element("failure");
+            Assert.NotNull(failure);
+            Assert.Equal("Expected 1 but got 2", failure!.Attribute("message")!.Value);
+            Assert.Null(tc.Element("error")); // must not be an <error>
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void WriteJUnit_ErrorTest_UsesErrorElement()
+    {
+        var results = new List<TestResult>
+        {
+            new() { Name = "TestError", Status = TestStatus.Error, DurationMs = 0, Message = "NotSupportedException: page not supported", CodeunitName = "MySuite" }
+        };
+
+        var path = Path.GetTempFileName();
+        try
+        {
+            JUnitReport.WriteJUnit(path, results);
+            var doc = XDocument.Load(path);
+
+            var tc = doc.Descendants("testcase").Single();
+            var error = tc.Element("error");
+            Assert.NotNull(error);
+            Assert.Contains("NotSupportedException", error!.Attribute("message")!.Value);
+            Assert.Null(tc.Element("failure")); // must not be a <failure>
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void WriteJUnit_MultipleCodeunits_ProducesMultipleSuites()
+    {
+        var results = new List<TestResult>
+        {
+            new() { Name = "TestA", Status = TestStatus.Pass, DurationMs = 1, CodeunitName = "SuiteOne" },
+            new() { Name = "TestB", Status = TestStatus.Pass, DurationMs = 2, CodeunitName = "SuiteTwo" },
+            new() { Name = "TestC", Status = TestStatus.Fail, DurationMs = 3, Message = "fail", CodeunitName = "SuiteOne" }
+        };
+
+        var path = Path.GetTempFileName();
+        try
+        {
+            JUnitReport.WriteJUnit(path, results);
+            var doc = XDocument.Load(path);
+
+            var suites = doc.Root!.Elements("testsuite").ToList();
+            Assert.Equal(2, suites.Count);
+
+            var suiteOne = suites.First(s => s.Attribute("name")!.Value == "SuiteOne");
+            var suiteTwo = suites.First(s => s.Attribute("name")!.Value == "SuiteTwo");
+
+            Assert.Equal("2", suiteOne.Attribute("tests")!.Value);
+            Assert.Equal("1", suiteOne.Attribute("failures")!.Value);
+            Assert.Equal("1", suiteTwo.Attribute("tests")!.Value);
+            Assert.Equal("0", suiteTwo.Attribute("failures")!.Value);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void WriteJUnit_Timing_IsInSeconds()
+    {
+        var results = new List<TestResult>
+        {
+            new() { Name = "TestA", Status = TestStatus.Pass, DurationMs = 1500, CodeunitName = "MySuite" }
+        };
+
+        var path = Path.GetTempFileName();
+        try
+        {
+            JUnitReport.WriteJUnit(path, results);
+            var doc = XDocument.Load(path);
+
+            var tc = doc.Descendants("testcase").Single();
+            var timeStr = tc.Attribute("time")!.Value;
+            var time = double.Parse(timeStr, System.Globalization.CultureInfo.InvariantCulture);
+            Assert.Equal(1.5, time, precision: 2);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void WriteJUnit_Counts_AreCorrect()
+    {
+        var results = new List<TestResult>
+        {
+            new() { Name = "TestPass", Status = TestStatus.Pass, DurationMs = 1, CodeunitName = "Suite" },
+            new() { Name = "TestFail", Status = TestStatus.Fail, DurationMs = 2, Message = "oops", CodeunitName = "Suite" },
+            new() { Name = "TestError", Status = TestStatus.Error, DurationMs = 0, Message = "nope", CodeunitName = "Suite" }
+        };
+
+        var path = Path.GetTempFileName();
+        try
+        {
+            JUnitReport.WriteJUnit(path, results);
+            var doc = XDocument.Load(path);
+
+            var root = doc.Root!;
+            Assert.Equal("3", root.Attribute("tests")!.Value);
+            Assert.Equal("1", root.Attribute("failures")!.Value);
+            Assert.Equal("1", root.Attribute("errors")!.Value);
+
+            var suite = root.Element("testsuite")!;
+            Assert.Equal("3", suite.Attribute("tests")!.Value);
+            Assert.Equal("1", suite.Attribute("failures")!.Value);
+            Assert.Equal("1", suite.Attribute("errors")!.Value);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void WriteJUnit_EmptyResults_ProducesEmptyTestsuites()
+    {
+        var path = Path.GetTempFileName();
+        try
+        {
+            JUnitReport.WriteJUnit(path, new List<TestResult>());
+            var doc = XDocument.Load(path);
+
+            Assert.Equal("testsuites", doc.Root!.Name.LocalName);
+            Assert.Equal("0", doc.Root.Attribute("tests")!.Value);
+            Assert.Empty(doc.Root.Elements("testsuite"));
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    // --- Integration test via AlRunnerPipeline ---
+
+    [Fact]
+    public void OutputJunit_Integration_CreatesFileWithTestResults()
+    {
+        var junitPath = Path.GetTempFileName();
+        try
+        {
+            var pipeline = new AlRunnerPipeline();
+            var result = pipeline.Run(new PipelineOptions
+            {
+                InputPaths = { TestPath("01-pure-function", "src"), TestPath("01-pure-function", "test") },
+                OutputJunitPath = junitPath
+            });
+
+            Assert.Equal(0, result.ExitCode);
+            Assert.True(File.Exists(junitPath), "JUnit file should have been written");
+            Assert.True(new FileInfo(junitPath).Length > 0, "JUnit file should not be empty");
+
+            var doc = XDocument.Load(junitPath);
+            Assert.Equal("testsuites", doc.Root!.Name.LocalName);
+
+            var testcases = doc.Descendants("testcase").ToList();
+            Assert.NotEmpty(testcases);
+            Assert.All(testcases, tc =>
+            {
+                Assert.Null(tc.Element("failure"));
+                Assert.Null(tc.Element("error"));
+            });
+        }
+        finally
+        {
+            if (File.Exists(junitPath)) File.Delete(junitPath);
+        }
+    }
+
+    [Fact]
+    public void OutputJunit_NoTestsRun_DoesNotCreateFile()
+    {
+        // When no tests are found (e.g. empty source), the pipeline exits early
+        // and OutputJunitPath should not produce a file (or leaves an empty one).
+        // Current behaviour: file is only written when testResults.Count > 0.
+        var junitPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName() + ".xml");
+        try
+        {
+            var pipeline = new AlRunnerPipeline();
+            pipeline.Run(new PipelineOptions
+            {
+                OutputJunitPath = junitPath
+                // no InputPaths — triggers "no AL source" early exit
+            });
+
+            // File should not have been written (no tests ran)
+            Assert.False(File.Exists(junitPath), "JUnit file should not be created when no tests ran");
+        }
+        finally
+        {
+            if (File.Exists(junitPath)) File.Delete(junitPath);
+        }
+    }
+}

--- a/AlRunner/JUnitReport.cs
+++ b/AlRunner/JUnitReport.cs
@@ -1,0 +1,103 @@
+using System.Text;
+using System.Xml;
+using AlRunner;
+
+/// <summary>
+/// Generates JUnit XML test reports from AL Runner test results.
+///
+/// JUnit XML is the industry standard for CI test reporting. GitHub Actions,
+/// Azure DevOps, and GitLab CI all natively render JUnit XML as test
+/// annotations, summaries, and trend graphs.
+///
+/// Tests are grouped by codeunit name as &lt;testsuite&gt; elements.
+/// Real assertion failures use &lt;failure&gt;; runner limitations use &lt;error&gt;.
+/// </summary>
+public static class JUnitReport
+{
+    /// <summary>
+    /// Write a JUnit XML report to <paramref name="outputPath"/>.
+    /// </summary>
+    /// <param name="outputPath">File path to write the XML to.</param>
+    /// <param name="tests">Test results from the pipeline.</param>
+    public static void WriteJUnit(string outputPath, IEnumerable<TestResult> tests)
+    {
+        var testList = tests.ToList();
+
+        // Group tests by codeunit name (suite)
+        var suites = testList
+            .GroupBy(t => t.CodeunitName ?? t.Name)
+            .OrderBy(g => g.Key)
+            .ToList();
+
+        double totalSeconds = testList.Sum(t => t.DurationMs) / 1000.0;
+        int totalTests = testList.Count;
+        int totalFailures = testList.Count(t => t.Status == TestStatus.Fail);
+        int totalErrors = testList.Count(t => t.Status == TestStatus.Error);
+
+        using var writer = XmlWriter.Create(outputPath, new XmlWriterSettings
+        {
+            Indent = true,
+            Encoding = new UTF8Encoding(false)
+        });
+
+        writer.WriteStartDocument();
+        writer.WriteStartElement("testsuites");
+        writer.WriteAttributeString("tests", totalTests.ToString());
+        writer.WriteAttributeString("failures", totalFailures.ToString());
+        writer.WriteAttributeString("errors", totalErrors.ToString());
+        writer.WriteAttributeString("time", totalSeconds.ToString("F3", System.Globalization.CultureInfo.InvariantCulture));
+
+        foreach (var suite in suites)
+        {
+            var suiteTests = suite.ToList();
+            double suiteSeconds = suiteTests.Sum(t => t.DurationMs) / 1000.0;
+            int suiteFailures = suiteTests.Count(t => t.Status == TestStatus.Fail);
+            int suiteErrors = suiteTests.Count(t => t.Status == TestStatus.Error);
+
+            writer.WriteStartElement("testsuite");
+            writer.WriteAttributeString("name", suite.Key);
+            writer.WriteAttributeString("tests", suiteTests.Count.ToString());
+            writer.WriteAttributeString("failures", suiteFailures.ToString());
+            writer.WriteAttributeString("errors", suiteErrors.ToString());
+            writer.WriteAttributeString("time", suiteSeconds.ToString("F3", System.Globalization.CultureInfo.InvariantCulture));
+
+            foreach (var test in suiteTests)
+            {
+                writer.WriteStartElement("testcase");
+                writer.WriteAttributeString("name", test.Name);
+                writer.WriteAttributeString("classname", suite.Key);
+                writer.WriteAttributeString("time", (test.DurationMs / 1000.0).ToString("F3", System.Globalization.CultureInfo.InvariantCulture));
+
+                if (test.Status == TestStatus.Fail)
+                {
+                    writer.WriteStartElement("failure");
+                    writer.WriteAttributeString("message", test.Message ?? "Test failed");
+                    if (test.Message != null || test.StackTrace != null)
+                        writer.WriteString(BuildBody(test));
+                    writer.WriteEndElement(); // failure
+                }
+                else if (test.Status == TestStatus.Error)
+                {
+                    writer.WriteStartElement("error");
+                    writer.WriteAttributeString("message", test.Message ?? "Runner error");
+                    if (test.Message != null || test.StackTrace != null)
+                        writer.WriteString(BuildBody(test));
+                    writer.WriteEndElement(); // error
+                }
+
+                writer.WriteEndElement(); // testcase
+            }
+
+            writer.WriteEndElement(); // testsuite
+        }
+
+        writer.WriteEndElement(); // testsuites
+    }
+
+    private static string BuildBody(TestResult test)
+    {
+        if (test.StackTrace == null)
+            return test.Message ?? "";
+        return $"{test.Message}\n\n{test.StackTrace}";
+    }
+}

--- a/AlRunner/Pipeline.cs
+++ b/AlRunner/Pipeline.cs
@@ -21,6 +21,8 @@ public class PipelineOptions
     public bool IterationTracking { get; set; }
     /// <summary>Run only this specific procedure by name (e.g. "TestCalculateVAT").</summary>
     public string? RunProcedure { get; set; }
+    /// <summary>If set, write a JUnit XML test report to this path after test execution.</summary>
+    public string? OutputJunitPath { get; set; }
 }
 
 public enum TestStatus { Pass, Fail, Error }
@@ -44,6 +46,11 @@ public class TestResult
     /// limitation or bug), not from user AL logic or a missing dependency injection.
     /// </summary>
     public bool IsRunnerBug { get; init; }
+    /// <summary>
+    /// The AL codeunit name that contains this test method. Used for grouping
+    /// tests by suite in JUnit XML output.
+    /// </summary>
+    public string? CodeunitName { get; init; }
 }
 
 public class CapturedValue
@@ -141,6 +148,11 @@ public class AlRunnerPipeline
         {
             Dictionary<string, List<string>>? compilationErrors = null; // file exclusion removed in #80
             stdoutStr = SerializeJsonOutput(testResults, exitCode, capturedValues: capturedValues, messages: messages, iterations: iterationLoops, compilationErrors: compilationErrors, scopeToObject: _scopeToObject);
+        }
+
+        if (options.OutputJunitPath != null && testResults.Count > 0)
+        {
+            JUnitReport.WriteJUnit(options.OutputJunitPath, testResults);
         }
 
         return new PipelineResult

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -36,6 +36,7 @@ if (args.Length == 0 || args.Any(a => a is "-h" or "--help"))
     Console.Error.WriteLine("  -e '<al code>'        Run inline AL code");
     Console.Error.WriteLine("  -v, --verbose         Show detailed transpilation and compilation output");
     Console.Error.WriteLine("  --output-json         Output results as machine-readable JSON (status: pass/fail/error)");
+    Console.Error.WriteLine("  --output-junit <path> Write JUnit XML test report to <path> (for CI test result tabs)");
     Console.Error.WriteLine("  --capture-values      Capture variable values after each test for inline display");
     Console.Error.WriteLine("  --iteration-tracking  Track per-iteration data for loops (requires --output-json)");
     Console.Error.WriteLine("  --run <procedure>     Run only the specified procedure by name");
@@ -55,6 +56,7 @@ if (args.Length == 0 || args.Any(a => a is "-h" or "--help"))
     Console.Error.WriteLine("  al-runner --coverage ./src ./test             Run tests with coverage");
     Console.Error.WriteLine("  al-runner --packages .alpackages ./src        Run with dependencies");
     Console.Error.WriteLine("  al-runner --output-json ./src ./test          Get JSON results for tooling");
+    Console.Error.WriteLine("  al-runner --output-junit results.xml ./src ./test  Write JUnit XML report");
     Console.Error.WriteLine("  al-runner --run TestMyThing ./src ./test      Run a single test procedure");
     Console.Error.WriteLine("  al-runner --server                            Start JSON-RPC daemon");
     Console.Error.WriteLine("  al-runner --generate-stubs .alpackages ./stubs ./src ./test");
@@ -146,6 +148,12 @@ while (argIdx < args.Length)
             break;
         case "--output-json":
             options.OutputJson = true;
+            argIdx++;
+            break;
+        case "--output-junit":
+            argIdx++;
+            if (argIdx >= args.Length) { Console.Error.WriteLine("Error: --output-junit requires a file path argument"); return 1; }
+            options.OutputJunitPath = args[argIdx];
             argIdx++;
             break;
         case "--capture-values":
@@ -449,6 +457,7 @@ al-runner --packages .alpackages --stubs ./stubs ./src ./test  # with stubs
 al-runner -v ./src ./test                                 # verbose output
 al-runner --dump-rewritten ./src ./test                   # inspect generated C#
 al-runner --output-json ./src ./test                      # machine-readable JSON output
+al-runner --output-junit results.xml ./src ./test         # JUnit XML report for CI
 al-runner --run TestMyProcedure ./src ./test              # run a single test by name
 al-runner --capture-values ./src ./test                   # capture variable values after each test
 al-runner --iteration-tracking ./src ./test                   # track loop iterations
@@ -476,6 +485,26 @@ al-runner into editors, CI systems, or other tooling.
 excluded from the Roslyn compilation, each with the C# errors that caused
 exclusion. Tests that call into excluded types produce `status: "error"`.
 The `errors` count includes these tests. The `failed` count does not.
+
+### JUnit XML output (--output-junit <path>)
+
+Writes a standard JUnit XML file alongside normal console output:
+
+```
+al-runner --output-junit results.xml --packages .alpackages ./src ./test
+```
+
+GitHub Actions, Azure DevOps, and GitLab CI natively render JUnit XML as test
+annotations, summaries, and trend graphs. Combined with `--coverage` (Cobertura),
+this completes the CI integration story:
+- Cobertura → coverage tab (via `--coverage`)
+- JUnit → test results tab (via `--output-junit`)
+
+**Element mapping:**
+- `<failure>` — real assertion failure (a bug in your AL code).
+- `<error>` — runner limitation or configuration gap (not a code bug).
+- Tests are grouped by codeunit name as `<testsuite>` elements.
+- Time values are in seconds.
 
 ### Server mode (--server)
 
@@ -1904,6 +1933,9 @@ public static class Executor
 
         foreach (var (testName, scopeType, parentType) in testScopes)
         {
+            // Resolve the AL codeunit name for grouping in JUnit output
+            var codeunitName = AlRunner.SourceFileMapper.GetObjectForClass(parentType.Name);
+
             // Reset in-memory state before each test
             AlRunner.Runtime.MockRecordHandle.ResetAll();
             AlRunner.Runtime.MockIsolatedStorage.ResetAll();
@@ -1969,7 +2001,8 @@ public static class Executor
                     {
                         Name = testName,
                         Status = AlRunner.TestStatus.Fail,
-                        Message = $"OnRun() method not found on {scopeType.Name}"
+                        Message = $"OnRun() method not found on {scopeType.Name}",
+                        CodeunitName = codeunitName
                     });
                     continue;
                 }
@@ -1986,7 +2019,8 @@ public static class Executor
                 {
                     Name = testName,
                     Status = AlRunner.TestStatus.Pass,
-                    DurationMs = sw.ElapsedMilliseconds
+                    DurationMs = sw.ElapsedMilliseconds,
+                    CodeunitName = codeunitName
                 });
             }
             catch (TargetInvocationException ex)
@@ -2004,7 +2038,8 @@ public static class Executor
                         Message = $"{inner!.GetType().Name}: {inner.Message}",
                         StackTrace = FormatStackFrames(inner),
                         AlSourceLine = FindAlSourceLine(inner),
-                        AlSourceColumn = FindAlSourceColumn(inner)
+                        AlSourceColumn = FindAlSourceColumn(inner),
+                        CodeunitName = codeunitName
                     });
                 }
                 else if (IsRunnerError(inner!))
@@ -2017,7 +2052,8 @@ public static class Executor
                         StackTrace = FormatStackFrames(inner),
                         AlSourceLine = FindAlSourceLine(inner),
                         AlSourceColumn = FindAlSourceColumn(inner),
-                        IsRunnerBug = true
+                        IsRunnerBug = true,
+                        CodeunitName = codeunitName
                     });
                 }
                 else
@@ -2029,7 +2065,8 @@ public static class Executor
                         Message = inner!.Message,
                         StackTrace = FormatStackFrames(inner),
                         AlSourceLine = FindAlSourceLine(inner),
-                        AlSourceColumn = FindAlSourceColumn(inner)
+                        AlSourceColumn = FindAlSourceColumn(inner),
+                        CodeunitName = codeunitName
                     });
                 }
             }
@@ -2042,7 +2079,8 @@ public static class Executor
                     Message = $"{ex.GetType().Name}: {ex.Message}",
                     StackTrace = FormatStackFrames(ex),
                     AlSourceLine = FindAlSourceLine(ex),
-                    AlSourceColumn = FindAlSourceColumn(ex)
+                    AlSourceColumn = FindAlSourceColumn(ex),
+                    CodeunitName = codeunitName
                 });
             }
             catch (Exception ex)
@@ -2057,7 +2095,8 @@ public static class Executor
                         StackTrace = FormatStackFrames(ex),
                         AlSourceLine = FindAlSourceLine(ex),
                         AlSourceColumn = FindAlSourceColumn(ex),
-                        IsRunnerBug = true
+                        IsRunnerBug = true,
+                        CodeunitName = codeunitName
                     });
                 }
                 else
@@ -2069,7 +2108,8 @@ public static class Executor
                         Message = ex.Message,
                         StackTrace = FormatStackFrames(ex),
                         AlSourceLine = FindAlSourceLine(ex),
-                        AlSourceColumn = FindAlSourceColumn(ex)
+                        AlSourceColumn = FindAlSourceColumn(ex),
+                        CodeunitName = codeunitName
                     });
                 }
             }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ All notable changes to this project are documented here. Format based on
 - **`GlobalLanguage()` NullReferenceException in standalone mode** — `ALSystemLanguage.get_ALGlobalLanguage` and `set_ALGlobalLanguage` crashed because there is no live BC session context in the runner. The rewriter now intercepts `ALSystemLanguage.ALGlobalLanguage` (both get and set) and routes them to `MockLanguage.ALGlobalLanguage`, a static int property backed by an in-memory field defaulting to 1033 (ENU). `MockLanguage.Reset()` is called between tests to restore the default. Fixes #82. Tested by `tests/86-global-language/` (5 cases).
 
 ### Added
+- **JUnit XML output (`--output-junit <path>`)** — Writes a standard JUnit XML test
+  report alongside normal console output. GitHub Actions, Azure DevOps, and GitLab CI
+  natively render JUnit XML as test annotations, summaries, and trend graphs. Combined
+  with `--coverage` (Cobertura XML), this completes the CI integration story:
+  - `--coverage` → coverage tab (Cobertura)
+  - `--output-junit` → test results tab (JUnit XML)
+
+  Tests are grouped by AL codeunit name as `<testsuite>` elements. Real assertion
+  failures use `<failure>`; runner limitations use `<error>`. Closes #72.
 - **Compact summary line at end of test runs** — After each test run, the output
   now ends with a concise one-liner analogous to pytest/jest:
   - All pass: `42 passed in 1.8s`


### PR DESCRIPTION
## Summary

Adds a `--output-junit <path>` CLI flag that writes a standard JUnit XML test report alongside normal console output.

This enables native test result display in GitHub Actions, Azure DevOps, and GitLab CI pipelines.

## Usage

```bash
al-runner --output-junit results.xml ./src ./test
```

Then in GitHub Actions:
```yaml
- name: Run AL tests
  run: al-runner --output-junit junit-results.xml ./src ./test

- name: Upload test results
  uses: mikepenz/action-junit-report@v4
  with:
    report_paths: junit-results.xml
```

## JUnit XML structure

```xml
<testsuites tests="N" failures="F" errors="E" time="T">
  <testsuite name="MyTestCodeunit" tests="N" failures="F" errors="E" time="T">
    <testcase name="Test_PassingCase" classname="MyTestCodeunit" time="0.003"/>
    <testcase name="Test_FailingCase" classname="MyTestCodeunit" time="0.001">
      <failure message="Expected 1 but got 2">full detail</failure>
    </testcase>
    <testcase name="Test_ErrorCase" classname="MyTestCodeunit" time="0.000">
      <error message="NotSupportedException: ...">full detail</error>
    </testcase>
  </testsuite>
</testsuites>
```

- `<failure>` for `TestStatus.Fail` (real assertion failures)
- `<error>` for `TestStatus.Error` (runner limitations / configuration gaps)
- Tests grouped by codeunit name into `<testsuite>` elements

## Changes

- **`AlRunner/JUnitReport.cs`** — new static `JUnitReport.WriteJUnit()` method
- **`AlRunner/Pipeline.cs`** — `OutputJunitPath` on `PipelineOptions`, `CodeunitName` on `TestResult`, write call in `Run()`
- **`AlRunner/Program.cs`** — CLI flag parsing, updated `--help` and `PrintGuide()`
- **`AlRunner.Tests/JUnitOutputTests.cs`** — 9 xUnit tests (unit + integration)
- **`CHANGELOG.md`** — documents the new feature

Closes #72