### PR TITLE
Deduplicate repeated error blocks in test output (#70)

### DIFF
--- a/AlRunner.Tests/RunnerErrorClassificationTests.cs
+++ b/AlRunner.Tests/RunnerErrorClassificationTests.cs
@@ -290,4 +290,162 @@ public class RunnerErrorClassificationTests
         Assert.Equal(1, result.ExitCode);
         Assert.Contains(result.Tests, t => t.Status == TestStatus.Fail);
     }
+
+    // ---------------------------------------------------------------------------
+    // PrintResults deduplication tests (issue #70)
+    // ---------------------------------------------------------------------------
+
+    /// <summary>
+    /// When multiple tests share the same error message, the message should appear
+    /// exactly once in the output (as a WARN block), not repeated per test.
+    /// Each individual ERROR line should be compact — just the test name + "(blocked)".
+    /// </summary>
+    [Fact]
+    public void PrintResults_RepeatedErrorMessage_MessageShownOnceAsWarn()
+    {
+        var sharedMessage = "CompilationExcludedException: Codeunit 50123 was excluded during compilation.";
+        var tests = new List<TestResult>
+        {
+            new() { Name = "Test1", Status = TestStatus.Error, Message = sharedMessage },
+            new() { Name = "Test2", Status = TestStatus.Error, Message = sharedMessage },
+            new() { Name = "Test3", Status = TestStatus.Error, Message = sharedMessage },
+        };
+
+        var output = CaptureStdOut(() => Executor.PrintResults(tests));
+
+        // Message should appear exactly once (in the WARN block)
+        var msgOccurrences = CountOccurrences(output, sharedMessage);
+        Assert.True(msgOccurrences == 1, $"Expected message to appear exactly once, but found {msgOccurrences} occurrence(s):\n{output}");
+
+        // Should have a WARN prefix for the summary
+        Assert.Contains("WARN", output);
+
+        // Each test should still have an ERROR line
+        Assert.Contains("ERROR Test1", output);
+        Assert.Contains("ERROR Test2", output);
+        Assert.Contains("ERROR Test3", output);
+
+        // The individual ERROR lines should be compact (contain "blocked")
+        Assert.Contains("(blocked)", output);
+    }
+
+    /// <summary>
+    /// With verbose=true, full details are printed per test (old behavior, no deduplication).
+    /// </summary>
+    [Fact]
+    public void PrintResults_RepeatedErrorMessage_Verbose_ShowsFullDetailsPerTest()
+    {
+        var sharedMessage = "CompilationExcludedException: Codeunit 50123 was excluded during compilation.";
+        var tests = new List<TestResult>
+        {
+            new() { Name = "Test1", Status = TestStatus.Error, Message = sharedMessage },
+            new() { Name = "Test2", Status = TestStatus.Error, Message = sharedMessage },
+        };
+
+        var output = CaptureStdOut(() => Executor.PrintResults(tests, verbose: true));
+
+        // With verbose, message appears once per test (not deduplicated)
+        var msgOccurrences = CountOccurrences(output, sharedMessage);
+        Assert.True(msgOccurrences == 2, $"Expected message to appear once per test (2 times) in verbose mode, but found {msgOccurrences}:\n{output}");
+
+        // Should NOT have WARN prefix in verbose mode
+        Assert.DoesNotContain("WARN", output);
+    }
+
+    /// <summary>
+    /// A single test with a unique error message should still print full details
+    /// (no WARN block, no compact line — unchanged behavior).
+    /// </summary>
+    [Fact]
+    public void PrintResults_UniqueErrorMessage_FullDetailsShown()
+    {
+        var uniqueMessage = "NotSupportedException: Page 50100 is not supported.";
+        var tests = new List<TestResult>
+        {
+            new() { Name = "TestA", Status = TestStatus.Error, Message = uniqueMessage, IsRunnerBug = true },
+        };
+
+        var output = CaptureStdOut(() => Executor.PrintResults(tests));
+
+        // Message should appear in output
+        Assert.Contains(uniqueMessage, output);
+        Assert.Contains("ERROR TestA", output);
+
+        // Should NOT have WARN prefix (no deduplication for unique errors)
+        Assert.DoesNotContain("WARN", output);
+
+        // ERROR line should NOT be compact — no "(blocked)" suffix when unique
+        Assert.DoesNotContain("(blocked)", output);
+    }
+
+    /// <summary>
+    /// Tests with different messages should each still show their own full details.
+    /// No WARN block should be shown.
+    /// </summary>
+    [Fact]
+    public void PrintResults_DifferentErrorMessages_NoDeduplication()
+    {
+        var tests = new List<TestResult>
+        {
+            new() { Name = "Test1", Status = TestStatus.Error, Message = "Error message A", IsRunnerBug = true },
+            new() { Name = "Test2", Status = TestStatus.Error, Message = "Error message B", IsRunnerBug = true },
+        };
+
+        var output = CaptureStdOut(() => Executor.PrintResults(tests));
+
+        Assert.Contains("Error message A", output);
+        Assert.Contains("Error message B", output);
+        Assert.DoesNotContain("WARN", output);
+        Assert.DoesNotContain("(blocked)", output);
+    }
+
+    /// <summary>
+    /// FAIL tests should never be deduplicated — each failure is unique and must
+    /// always show its full message.
+    /// </summary>
+    [Fact]
+    public void PrintResults_RepeatedFailMessage_NeverDeduplicated()
+    {
+        var sharedMessage = "Expected 1, got 2";
+        var tests = new List<TestResult>
+        {
+            new() { Name = "Test1", Status = TestStatus.Fail, Message = sharedMessage },
+            new() { Name = "Test2", Status = TestStatus.Fail, Message = sharedMessage },
+        };
+
+        var output = CaptureStdOut(() => Executor.PrintResults(tests));
+
+        // Each FAIL should show its message (2 occurrences expected)
+        var msgOccurrences = CountOccurrences(output, sharedMessage);
+        Assert.True(msgOccurrences == 2, $"Expected fail message to appear once per test, got {msgOccurrences}:\n{output}");
+
+        // Should NOT have WARN prefix (no deduplication for failures)
+        Assert.DoesNotContain("WARN", output);
+    }
+
+    // ---------------------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------------------
+
+    private static string CaptureStdOut(Action action)
+    {
+        var captured = new System.IO.StringWriter();
+        var prev = Console.Out;
+        Console.SetOut(captured);
+        try { action(); }
+        finally { Console.SetOut(prev); }
+        return captured.ToString();
+    }
+
+    private static int CountOccurrences(string text, string pattern)
+    {
+        int count = 0;
+        int index = 0;
+        while ((index = text.IndexOf(pattern, index, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            index += pattern.Length;
+        }
+        return count;
+    }
 }

--- a/AlRunner/Pipeline.cs
+++ b/AlRunner/Pipeline.cs
@@ -562,7 +562,7 @@ public class AlRunnerPipeline
             if (results.Count == 0 && options.RunProcedure != null)
                 stderr.WriteLine($"Error: Procedure '{options.RunProcedure}' not found in the generated code.");
             if (!options.OutputJson)
-                Executor.PrintResults(results, runSw.ElapsedMilliseconds);
+                Executor.PrintResults(results, runSw.ElapsedMilliseconds, options.Verbose);
             exitCode = Executor.ExitCode(results);
 
             if (options.CaptureValues)

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -2079,8 +2079,29 @@ public static class Executor
     }
 
     /// <summary>Print human-readable test results to console.</summary>
-    public static void PrintResults(List<AlRunner.TestResult> results, long? totalMs = null)
+    public static void PrintResults(List<AlRunner.TestResult> results, long? totalMs = null, bool verbose = false)
     {
+        // Deduplicate repeated error messages: show each unique message once as a WARN block,
+        // then print compact "ERROR TestName (blocked)" lines for affected tests.
+        // Only active in non-verbose mode; verbose falls back to full per-test detail.
+        var dedupMessages = new HashSet<string>();
+        if (!verbose)
+        {
+            var errorMessageCounts = results
+                .Where(r => r.Status == AlRunner.TestStatus.Error && r.Message != null)
+                .GroupBy(r => r.Message!)
+                .Where(g => g.Count() >= 2)
+                .ToDictionary(g => g.Key, g => g.Count());
+
+            foreach (var (msg, count) in errorMessageCounts)
+            {
+                dedupMessages.Add(msg);
+                Console.WriteLine($"WARN  {msg}");
+                Console.WriteLine($"      ({count} tests blocked — use -v for per-test details)");
+                Console.WriteLine();
+            }
+        }
+
         foreach (var r in results)
         {
             switch (r.Status)
@@ -2094,13 +2115,20 @@ public static class Executor
                     if (r.StackTrace != null) Console.Write(r.StackTrace);
                     break;
                 case AlRunner.TestStatus.Error:
-                    Console.WriteLine($"ERROR {r.Name}");
-                    if (r.Message != null) Console.WriteLine($"      {r.Message}");
-                    if (r.IsRunnerBug)
-                        Console.WriteLine($"      ⚑ Runner limitation — update al-runner or file an issue at https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues");
+                    if (!verbose && r.Message != null && dedupMessages.Contains(r.Message))
+                    {
+                        Console.WriteLine($"ERROR {r.Name} (blocked)");
+                    }
                     else
-                        Console.WriteLine($"      Inject this dependency via an AL interface.");
-                    if (r.StackTrace != null) Console.Write(r.StackTrace);
+                    {
+                        Console.WriteLine($"ERROR {r.Name}");
+                        if (r.Message != null) Console.WriteLine($"      {r.Message}");
+                        if (r.IsRunnerBug)
+                            Console.WriteLine($"      ⚑ Runner limitation — update al-runner or file an issue at https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues");
+                        else
+                            Console.WriteLine($"      Inject this dependency via an AL interface.");
+                        if (r.StackTrace != null) Console.Write(r.StackTrace);
+                    }
                     break;
             }
         }


### PR DESCRIPTION
## Problem

When many tests are blocked by the same runner limitation (e.g., 66 codeunits all failing with `CompilationExcludedException`), `PrintResults` previously repeated the identical error message block once per test — generating hundreds of lines of noise.

## Solution

Modify `Executor.PrintResults` to deduplicate repeated error messages:
- If the same `Error` message appears ≥ 2 times, print it **once** as a `WARN` block with a count
- Print each affected test as a compact `ERROR TestName (blocked)` line
- With `-v` / `--verbose`, fall back to the old full per-test detail output
- Single/unique errors still show full detail (unchanged behavior)
- `FAIL` tests are never deduplicated

## Before / After

**Before** (66 blocked tests, same error = 198 lines of noise):
```
ERROR Test1
      CompilationExcludedException: Codeunit 50123 was excluded during compilation.
      Inject this dependency via an AL interface.
ERROR Test2
      ...× 66
```

**After** (3 + 66 lines):
```
WARN  CompilationExcludedException: Codeunit 50123 was excluded during compilation.
      (66 tests blocked — use -v for per-test details)

ERROR Test1 (blocked)
ERROR Test2 (blocked)
...
```

## Changes

- `AlRunner/Program.cs` — `Executor.PrintResults`: added `bool verbose = false` param + deduplication logic
- `AlRunner/Pipeline.cs` — passes `options.Verbose` to `PrintResults`
- `AlRunner.Tests/RunnerErrorClassificationTests.cs` — 5 new tests covering all deduplication scenarios

Closes #70