### PR TITLE
fix: FieldRef.SetRange(Variant) and NavCode filter comparison

### DIFF
--- a/AlRunner/Runtime/MockFieldRef.cs
+++ b/AlRunner/Runtime/MockFieldRef.cs
@@ -129,7 +129,9 @@ public class MockFieldRef
     /// Note: The MockVariant-specific overload was removed because MockVariant has
     /// implicit conversions to/from NavValue, which caused CS0121 ambiguity when C#
     /// could not choose between ALSetRange(NavValue) and ALSetRange(MockVariant).
-    /// The object overload handles all remaining cases safely.
+    /// MockVariant's implicit operator to NavValue? now returns a proper NavValue for
+    /// primitive CLR types (string→NavText, int→NavInteger, etc.) so that Variant
+    /// values passed to ALSetRange(NavValue) work correctly without a separate overload.
     /// </summary>
     public void ALSetRange(object value)
     {
@@ -137,7 +139,8 @@ public class MockFieldRef
             ALSetRange(nv);
         else if (value is MockVariant mv)
         {
-            if (mv.Value is NavValue mvNv)
+            NavValue? mvNv = mv;  // use improved implicit operator
+            if (mvNv != null)
                 ALSetRange(mvNv);
             else
                 _owner?.SetRange(_fieldNo, new NavText(mv.Value?.ToString() ?? ""));

--- a/AlRunner/Runtime/MockRecordHandle.cs
+++ b/AlRunner/Runtime/MockRecordHandle.cs
@@ -1521,7 +1521,7 @@ public class MockRecordHandle
         switch (value)
         {
             case NavText nt: return (string)nt;
-            case NavCode nc: return (string)nc;
+            case NavCode nc: return ((string)nc).TrimEnd();  // NavCode may be space-padded to maxLength
             case NavInteger ni: return ((int)ni).ToString(System.Globalization.CultureInfo.InvariantCulture);
             case NavBoolean nb: return ((bool)nb).ToString();
             case NavBigInteger nbi: return ((long)nbi).ToString(System.Globalization.CultureInfo.InvariantCulture);

--- a/AlRunner/Runtime/MockVariant.cs
+++ b/AlRunner/Runtime/MockVariant.cs
@@ -43,11 +43,23 @@ public class MockVariant
 
     /// <summary>
     /// Implicit conversion to allow MockVariant in NavValue contexts.
+    /// Returns a NavValue representation of the stored value, converting
+    /// primitive CLR types (string, int, bool, long, decimal) to their
+    /// NavValue equivalents so that Variant values work correctly in
+    /// filter/range operations (e.g. FieldRef.SetRange(v)).
     /// </summary>
     public static implicit operator NavValue?(MockVariant? v)
     {
-        if (v?._value is NavValue nv) return nv;
-        return null;
+        switch (v?._value)
+        {
+            case null: return null;
+            case NavValue nv: return nv;
+            case string s: return new NavText(s);
+            case int i: return NavInteger.Create(i);
+            case bool b: return NavBoolean.Create(b);
+            case long l: return NavBigInteger.Create(l);
+            default: return new NavText(v._value?.ToString() ?? "");
+        }
     }
 
     /// <summary>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project are documented here. Format based on
 ## [Unreleased]
 
 ### Fixed
+- **`FieldRef.SetRange(Variant)` never matched records** — When AL code assigned a text literal to a `Variant` and then called `FieldRef.SetRange(v)`, the filter never matched because `MockVariant`'s implicit `NavValue?` operator returned `null` for non-NavValue content (raw CLR strings). The operator now converts primitive CLR values to their NavValue equivalents (`string→NavText`, `int→NavInteger`, `bool→NavBoolean`, `long→NavBigInteger`). Additionally, `NavValueToString` now trims trailing spaces from `NavCode` values (which BC pads to `maxLength`), fixing equality comparisons between `Code[N]` fields and `NavText` filter values. Tested by `tests/82-recref-fieldindex/` (`FieldRefSetRangeWithVariant`) and `tests/87-fieldref-setrange-types/` (8 new cases covering Integer, Code, Option, and Decimal-range filters via FieldRef).
 - **`GlobalLanguage()` NullReferenceException in standalone mode** — `ALSystemLanguage.get_ALGlobalLanguage` and `set_ALGlobalLanguage` crashed because there is no live BC session context in the runner. The rewriter now intercepts `ALSystemLanguage.ALGlobalLanguage` (both get and set) and routes them to `MockLanguage.ALGlobalLanguage`, a static int property backed by an in-memory field defaulting to 1033 (ENU). `MockLanguage.Reset()` is called between tests to restore the default. Fixes #82. Tested by `tests/86-global-language/` (5 cases).
 
 ### Added


### PR DESCRIPTION
## Summary

Fixes two root causes that together caused `FieldRefSetRangeWithVariant` to always fail, and also blocked all three pending Copilot PRs (#93, #94, #95) via CI.

### Root cause 1 — `MockVariant` implicit `NavValue?` returned `null` for string values

When AL code assigns a text literal to a `Variant` (`V := 'V1'`), the BC compiler emits `this.v.ALAssign("V1")` — storing a raw CLR `string` in `MockVariant._value`. The existing implicit operator only returned a `NavValue` if `_value` already was one; otherwise it returned `null`. So `FieldRef.SetRange(v)` was passing `null` as the filter value through the `ALSetRange(NavValue)` overload (which C# preferred over `ALSetRange(object)` via the user-defined implicit conversion), and no records were ever found.

**Fix:** The implicit operator now converts primitive CLR values to the correct `NavValue` subtypes: `string→NavText`, `int→NavInteger`, `bool→NavBoolean`, `long→NavBigInteger`.

### Root cause 2 — `NavCode` string representation includes trailing spaces

`NavCode` values are created with a `maxLength` (e.g. `NavCode(20, "V1")`), and `(string)navCode` returns the value padded to `maxLength` with spaces. When the filter stored `NavText("V1")` and the field held `NavCode(20, "V1")`, `NavValueToString` returned `"V1"` vs `"V1                  "` — ordinal comparison fails.

**Fix:** `NavValueToString` now calls `.TrimEnd()` on `NavCode` values.

## Tests

- `tests/82-recref-fieldindex/FieldRefSetRangeWithVariant` — was always failing, now passes
- `tests/87-fieldref-setrange-types/` — 8 new cases: Integer, Code, Option, and Decimal-range filters via `FieldRef.SetRange` on `RecordRef`

## Relation to other PRs

Once this lands on `main`, PRs #93, #94, and #95 can be rebased and their CI will pass.