### PR TITLE
feat: add BC 28.0 to test matrix; classify missing BC DLLs as runner limitations

### DIFF
--- a/.github/workflows/test-matrix.yml
+++ b/.github/workflows/test-matrix.yml
@@ -24,7 +24,7 @@ jobs:
         id: resolve
         run: |
           # Resolve short version prefixes to full versions via Microsoft's index
-          BC_PREFIXES="26.0 26.3 26.5 27.0 27.3 27.5"
+          BC_PREFIXES="26.0 26.3 26.5 27.0 27.3 27.5 28.0"
           VERSIONS="[]"
           for prefix in $BC_PREFIXES; do
             FULL=$(dotnet run --project tools/DownloadArtifacts -- resolve-version "$prefix" dummy 2>/dev/null)

--- a/AlRunner.Tests/RunnerErrorClassificationTests.cs
+++ b/AlRunner.Tests/RunnerErrorClassificationTests.cs
@@ -424,6 +424,87 @@ public class RunnerErrorClassificationTests
     }
 
     // ---------------------------------------------------------------------------
+    // IsMissingBcRuntimeDll — unit tests for the new classification helper
+    // ---------------------------------------------------------------------------
+
+    /// <summary>
+    /// FileNotFoundException with a BC assembly name in FileName is classified as a
+    /// runner limitation (missing BC runtime DLL), not a test assertion failure.
+    /// </summary>
+    [Theory]
+    [InlineData("Microsoft.Dynamics.Nav.Ncl.dll")]
+    [InlineData("Microsoft.BusinessCentral.Telemetry.Abstractions.dll")]
+    public void IsMissingBcRuntimeDll_FileNotFound_ByFileName_ReturnsTrue(string assemblyFile)
+    {
+        var ex = new System.IO.FileNotFoundException("The system cannot find the file.", assemblyFile);
+        Assert.True(Executor.IsMissingBcRuntimeDll(ex));
+    }
+
+    /// <summary>
+    /// FileNotFoundException whose Message (not FileName) contains a BC assembly name
+    /// is also classified — FileName is null when the CLR embeds the name in the message.
+    /// </summary>
+    [Fact]
+    public void IsMissingBcRuntimeDll_FileNotFound_ByMessage_ReturnsTrue()
+    {
+        var ex = new System.IO.FileNotFoundException(
+            "Could not load file or assembly 'Microsoft.BusinessCentral.Telemetry.Abstractions, Version=10.0.0.0'.");
+        Assert.True(Executor.IsMissingBcRuntimeDll(ex));
+    }
+
+    /// <summary>
+    /// FileNotFoundException for a non-BC assembly (e.g. user code missing a DLL) must
+    /// NOT be classified as a runner limitation.
+    /// </summary>
+    [Fact]
+    public void IsMissingBcRuntimeDll_FileNotFound_NonBcAssembly_ReturnsFalse()
+    {
+        var ex = new System.IO.FileNotFoundException("File not found.", "SomeUserLibrary.dll");
+        Assert.False(Executor.IsMissingBcRuntimeDll(ex));
+    }
+
+    /// <summary>
+    /// FileLoadException for a BC assembly (version conflict, strong-name failure, etc.)
+    /// is also classified as a runner limitation.
+    /// </summary>
+    [Fact]
+    public void IsMissingBcRuntimeDll_FileLoadException_BcAssembly_ReturnsTrue()
+    {
+        var ex = new System.IO.FileLoadException(
+            "Could not load file or assembly 'Microsoft.Dynamics.Nav.Types, Version=28.0.0.0'.",
+            "Microsoft.Dynamics.Nav.Types.dll");
+        Assert.True(Executor.IsMissingBcRuntimeDll(ex));
+    }
+
+    /// <summary>
+    /// AggregateException wrapping a BC FileNotFoundException must be classified as a
+    /// runner limitation via the recursive inner-exception traversal in IsRunnerError.
+    /// </summary>
+    [Fact]
+    public void IsRunnerError_AggregateException_WrappingBcFileNotFound_ReturnsTrue()
+    {
+        var inner = new System.IO.FileNotFoundException(
+            "Could not load file or assembly 'Microsoft.BusinessCentral.Telemetry.Abstractions'.",
+            "Microsoft.BusinessCentral.Telemetry.Abstractions.dll");
+        var agg = new AggregateException("One or more errors occurred.", inner);
+        Assert.True(Executor.IsRunnerError(agg));
+    }
+
+    /// <summary>
+    /// TypeInitializationException (InnerException path) wrapping a BC FileNotFoundException
+    /// must also be classified as a runner limitation.
+    /// </summary>
+    [Fact]
+    public void IsRunnerError_TypeInitializationException_WrappingBcFileNotFound_ReturnsTrue()
+    {
+        var inner = new System.IO.FileNotFoundException(
+            "Could not load file or assembly 'Microsoft.Dynamics.Nav.Ncl'.",
+            "Microsoft.Dynamics.Nav.Ncl.dll");
+        var outer = new TypeInitializationException("SomeNavType", inner);
+        Assert.True(Executor.IsRunnerError(outer));
+    }
+
+    // ---------------------------------------------------------------------------
     // Helpers
     // ---------------------------------------------------------------------------
 

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -2300,29 +2300,52 @@ public static class Executor
     /// These should be reported as <see cref="AlRunner.TestStatus.Error"/> with
     /// <see cref="AlRunner.TestResult.IsRunnerBug"/> = true.
     /// </summary>
-    private static bool IsRunnerError(Exception ex)
+    public static bool IsRunnerError(Exception ex)
     {
         if (ex is InvalidOperationException &&
             ex.StackTrace?.Contains("AlRunner.Runtime.Mock") == true)
             return true;
 
-        // Missing BC runtime DLL — not a test logic failure, it's a runner gap.
-        // Happens when a new BC version introduces a new assembly dependency that
-        // the artifact downloader has not yet been updated to fetch.
-        if (ex is System.IO.FileNotFoundException or System.IO.FileLoadException)
-        {
-            var msg = ex.Message;
-            if (msg.Contains("Microsoft.Dynamics.Nav.") ||
-                msg.Contains("Microsoft.BusinessCentral."))
-                return true;
-        }
+        if (IsMissingBcRuntimeDll(ex))
+            return true;
 
-        // Walk inner exceptions (e.g. TypeInitializationException wrapping FileNotFoundException)
+        // Walk InnerException (e.g. TypeInitializationException wrapping FileNotFoundException)
         if (ex.InnerException != null && IsRunnerError(ex.InnerException))
             return true;
 
+        // AggregateException can wrap multiple load failures.
+        if (ex is AggregateException agg)
+            foreach (var inner in agg.InnerExceptions)
+                if (inner != null && IsRunnerError(inner))
+                    return true;
+
+        // ReflectionTypeLoadException exposes nested loader failures via LoaderExceptions.
+        if (ex is ReflectionTypeLoadException rtle)
+            foreach (var loader in rtle.LoaderExceptions)
+                if (loader != null && IsRunnerError(loader))
+                    return true;
+
         return false;
     }
+
+    public static bool IsMissingBcRuntimeAssemblyName(string? value) =>
+        value?.Contains("Microsoft.Dynamics.Nav.", StringComparison.Ordinal) == true ||
+        value?.Contains("Microsoft.BusinessCentral.", StringComparison.Ordinal) == true;
+
+    /// <summary>
+    /// Returns true when the exception represents a missing BC runtime DLL.
+    /// Prefers the structured FileName property over the (potentially localised) Message.
+    /// </summary>
+    public static bool IsMissingBcRuntimeDll(Exception ex) => ex switch
+    {
+        System.IO.FileNotFoundException fnf =>
+            IsMissingBcRuntimeAssemblyName(fnf.FileName) ||
+            IsMissingBcRuntimeAssemblyName(fnf.Message),
+        System.IO.FileLoadException fle =>
+            IsMissingBcRuntimeAssemblyName(fle.FileName) ||
+            IsMissingBcRuntimeAssemblyName(fle.Message),
+        _ => false
+    };
 
     /// <summary>
     /// Get the AL source column from the last StmtHit that was executed before

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -2294,13 +2294,35 @@ public static class Executor
 
     /// <summary>
     /// Returns true when the exception originates from AlRunner.Runtime mock code,
+    /// or from a missing BC runtime DLL (FileNotFoundException / FileLoadException
+    /// for a Microsoft.Dynamics.Nav.* or Microsoft.BusinessCentral.* assembly),
     /// indicating a runner limitation rather than a user test logic failure.
     /// These should be reported as <see cref="AlRunner.TestStatus.Error"/> with
     /// <see cref="AlRunner.TestResult.IsRunnerBug"/> = true.
     /// </summary>
-    private static bool IsRunnerError(Exception ex) =>
-        ex is InvalidOperationException &&
-        ex.StackTrace?.Contains("AlRunner.Runtime.Mock") == true;
+    private static bool IsRunnerError(Exception ex)
+    {
+        if (ex is InvalidOperationException &&
+            ex.StackTrace?.Contains("AlRunner.Runtime.Mock") == true)
+            return true;
+
+        // Missing BC runtime DLL — not a test logic failure, it's a runner gap.
+        // Happens when a new BC version introduces a new assembly dependency that
+        // the artifact downloader has not yet been updated to fetch.
+        if (ex is System.IO.FileNotFoundException or System.IO.FileLoadException)
+        {
+            var msg = ex.Message;
+            if (msg.Contains("Microsoft.Dynamics.Nav.") ||
+                msg.Contains("Microsoft.BusinessCentral."))
+                return true;
+        }
+
+        // Walk inner exceptions (e.g. TypeInitializationException wrapping FileNotFoundException)
+        if (ex.InnerException != null && IsRunnerError(ex.InnerException))
+            return true;
+
+        return false;
+    }
 
     /// <summary>
     /// Get the AL source column from the last StmtHit that was executed before

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,21 @@ All notable changes to this project are documented here. Format based on
 ## [Unreleased]
 
 ### Fixed
+- **Missing BC runtime DLL classified as runner limitation** — `FileNotFoundException`
+  and `FileLoadException` for `Microsoft.Dynamics.Nav.*` or `Microsoft.BusinessCentral.*`
+  assemblies are now reported as ERROR (runner limitation, exit 2) instead of FAIL
+  (test assertion failure, exit 1). This correctly classifies missing BC runtime DLLs
+  (e.g. `Microsoft.BusinessCentral.Telemetry.Abstractions` introduced in BC 28) as
+  a runner gap rather than a code bug.
 - **Page without SourceTable compiles cleanly** — `SetSelectionFilter` no longer
   injects `this.Rec` into page classes that have no source table, fixing a CS1061
   Roslyn error for pages that only define helper procedures.
 
 ### Changed
+- **Test matrix extended to BC 28.0** — `28.0` added to the version prefix list in
+  `test-matrix.yml`. BC 28 introduced `Microsoft.BusinessCentral.Telemetry.Abstractions`
+  as a new runtime dependency not yet fetched by the artifact downloader; one test
+  (`SingleArgValidateFiresTrigger`) shows as a runner limitation (ERROR) on BC 28 only.
 - **Vision reframe** — project rationale updated from "pure-logic codeunits only"
   to broad AL language compatibility. Docs, guide, and limitations page updated to
   reflect that unsupported AL constructs are gaps to fix, not design boundaries.


### PR DESCRIPTION
## Summary

- **BC 28.0 added to test matrix** — `28.0` added to `BC_PREFIXES` in `test-matrix.yml`. Resolves to `28.0.46665.48948` via the version resolver.
- **Missing BC runtime DLL → runner limitation** — `IsRunnerError()` now returns `true` for `FileNotFoundException`/`FileLoadException` whose message names a `Microsoft.Dynamics.Nav.*` or `Microsoft.BusinessCentral.*` assembly. These are correctly reported as `ERROR` (exit 2, runner limitation) rather than `FAIL` (exit 1, test assertion failure).

## Background

BC 28.0 introduced `Microsoft.BusinessCentral.Telemetry.Abstractions` as a new runtime dependency of `NavDiagnostics.SendExceptionTag`. This DLL is not present in the `ServiceTier/.../Service/` path fetched by the artifact downloader, so one test (`SingleArgValidateFiresTrigger` in `44-single-arg-validate`) hits it on BC 28 only.

Before this fix: the test showed as **FAIL** (exit 1), blocking CI.  
After this fix: the test shows as **ERROR — runner limitation** (exit 2), tolerated by the existing `[ $exit_code -eq 2 ] || exit $exit_code` guard in CI.

Local test run against BC 28.0 (`$BC_SERVICE_TIER_PATH` set):
```
164 passed in bucket-1
305 passed, 1 blocked (runner limitation) in bucket-2
```
No real test failures. All other BC versions (26.0–27.5) unaffected.

## Follow-up

The `Microsoft.BusinessCentral.Telemetry.Abstractions.dll` is not in the `Service/` directory of the BC artifact. Its path in the artifact ZIP needs to be determined (requires internet access to scan the ZIP's central directory) and the downloader updated to fetch it. Once that's done, the one blocked test on BC 28 will become a full PASS.