### PR TITLE
feat: Event subscriber parameter forwarding, implicit DB events, BindSubscription

### DIFF
--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -297,7 +297,10 @@ test executor that needs no BC service tier, Docker, SQL Server, or license.
 - Query data access (Open/Read) — queries require the BC service tier (SQL views);
   use AL interfaces to inject query results for testing
 - HTTP / REST calls — inject via AL interface
-- Event subscribers — OnAfterModify, OnAfterInsert, etc. do not fire
+- Event subscribers — Custom IntegrationEvent/BusinessEvent dispatch works. Implicit
+  DB trigger events (OnBefore/AfterInsert/Modify/Delete/Validate) fire. Subscriber
+  parameters are forwarded. BindSubscription/UnbindSubscription work. Remaining gaps:
+  OnBefore/AfterRenameEvent not yet fired; ModifyAll/DeleteAll skip per-row events.
 - StrMenu is not supported
 - Filter groups (FilterGroup)
 
@@ -368,7 +371,7 @@ The runner compiles your stubs alongside the source. Conflicting symbol packages
 are excluded automatically.
 
 Step 5 — Iterate. If tests still fail at runtime with `NotSupportedException`,
-the codeunit uses an unsupported BC feature (Page, HTTP, events, etc.). Either:
+the codeunit uses an unsupported BC feature (Page, HTTP, etc.). Either:
 - Skip that codeunit (don't include it in your test run), or
 - Inject the dependency via an AL interface so the runner can use a mock.
 
@@ -564,7 +567,29 @@ fi
   a transpilation issue.
 - al-runner resets all in-memory tables between test methods — no cleanup needed.
 - If al-runner says FAIL, the failure is real. If it says PASS, the direct logic is
-  correct but implicit event side-effects are not tested (run the full BC pipeline).
+  correct. Note: ModifyAll/DeleteAll do not fire per-row events, and OnRename events
+  are not yet supported — the full BC pipeline catches these edge cases.
+
+### Event subscribers
+
+al-runner supports event subscribers for custom and implicit DB events:
+
+**Custom events** — `[IntegrationEvent]` and `[BusinessEvent]` publishers dispatch
+to `[EventSubscriber]` methods. Subscriber parameters (including `var` / `ByRef`)
+are forwarded and mutations propagate back to the publisher scope.
+
+**Implicit DB events** — `OnBeforeInsertEvent`, `OnAfterInsertEvent`,
+`OnBeforeModifyEvent`, `OnAfterModifyEvent`, `OnBeforeDeleteEvent`,
+`OnAfterDeleteEvent`, `OnBeforeValidateEvent`, `OnAfterValidateEvent` fire from
+record operations. The `Rec` and `xRec` references are passed to subscribers.
+
+**Manual binding** — Codeunits with `EventSubscriberInstance = Manual` only fire
+after `BindSubscription(Sub)`. Call `UnbindSubscription(Sub)` to stop. Bindings
+are reset between tests.
+
+**ConfirmHandler / MessageHandler / ModalPageHandler** — Supported via
+`HandlerRegistry` for test codeunits. Register handlers in the `[Test]` attribute's
+`HandlerFunctions` property.
 
 ### Reporting issues
 
@@ -2004,6 +2029,7 @@ public static class Executor
             AlRunner.Runtime.HandlerRegistry.Reset();
             AlRunner.Runtime.MockSession.Reset();
             AlRunner.Runtime.MockLanguage.Reset();
+            AlRunner.Runtime.EventSubscriberRegistry.ResetBindings();
 
             try
             {

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -297,10 +297,11 @@ test executor that needs no BC service tier, Docker, SQL Server, or license.
 - Query data access (Open/Read) — queries require the BC service tier (SQL views);
   use AL interfaces to inject query results for testing
 - HTTP / REST calls — inject via AL interface
-- Event subscribers — Custom IntegrationEvent/BusinessEvent dispatch works. Implicit
-  DB trigger events (OnBefore/AfterInsert/Modify/Delete/Validate) fire. Subscriber
-  parameters are forwarded. BindSubscription/UnbindSubscription work. Remaining gaps:
-  OnBefore/AfterRenameEvent not yet fired; ModifyAll/DeleteAll skip per-row events.
+- Event subscribers — Custom IntegrationEvent/BusinessEvent dispatch works with
+  IncludeSender support. Implicit DB trigger events (OnBefore/AfterInsert/Modify/
+  Delete/Validate) fire. Subscriber parameters are forwarded. BindSubscription/
+  UnbindSubscription work. Remaining gaps: OnBefore/AfterRenameEvent not yet fired;
+  ModifyAll/DeleteAll skip per-row events.
 - StrMenu is not supported
 - Filter groups (FilterGroup)
 
@@ -577,6 +578,10 @@ al-runner supports event subscribers for custom and implicit DB events:
 **Custom events** — `[IntegrationEvent]` and `[BusinessEvent]` publishers dispatch
 to `[EventSubscriber]` methods. Subscriber parameters (including `var` / `ByRef`)
 are forwarded and mutations propagate back to the publisher scope.
+
+**IncludeSender** — When `[IntegrationEvent(true, false)]` or `[BusinessEvent(true)]`
+is used, the publishing codeunit instance is passed as the first subscriber parameter
+(`sender: Codeunit "Publisher"`). Subscribers can read/write publisher state.
 
 **Implicit DB events** — `OnBeforeInsertEvent`, `OnAfterInsertEvent`,
 `OnBeforeModifyEvent`, `OnAfterModifyEvent`, `OnBeforeDeleteEvent`,

--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -2620,6 +2620,28 @@ public void ClearApplicationMemberVariables() { }
                 }
                 if (cuId.HasValue && eventName != null)
                 {
+                    // Check if the enclosing event method has [NavEvent(_, true, _)]
+                    // where the second argument (IncludeSender) is true.
+                    bool includeSender = false;
+                    if (enclosingMethod != null)
+                    {
+                        foreach (var attrList in enclosingMethod.AttributeLists)
+                        foreach (var attr in attrList.Attributes)
+                        {
+                            var simpleAttrName = GetSimpleAttributeName(attr);
+                            if (simpleAttrName is "NavEvent" or "NavEventAttribute")
+                            {
+                                if (attr.ArgumentList?.Arguments.Count >= 2)
+                                {
+                                    var secondArg = attr.ArgumentList.Arguments[1].Expression;
+                                    if (secondArg is LiteralExpressionSyntax lit &&
+                                        lit.IsKind(SyntaxKind.TrueLiteralExpression))
+                                        includeSender = true;
+                                }
+                            }
+                        }
+                    }
+
                     var argsList = new List<ArgumentSyntax>
                     {
                         SyntaxFactory.Argument(SyntaxFactory.LiteralExpression(
@@ -2629,6 +2651,21 @@ public void ClearApplicationMemberVariables() { }
                             SyntaxKind.StringLiteralExpression,
                             SyntaxFactory.Literal(eventName)))
                     };
+
+                    // When IncludeSender=true, prepend a MockCodeunitHandle wrapping
+                    // the publisher instance so subscribers receive it as their first arg.
+                    if (includeSender)
+                    {
+                        argsList.Add(SyntaxFactory.Argument(
+                            SyntaxFactory.InvocationExpression(
+                                SyntaxFactory.MemberAccessExpression(
+                                    SyntaxKind.SimpleMemberAccessExpression,
+                                    SyntaxFactory.IdentifierName("MockCodeunitHandle"),
+                                    SyntaxFactory.IdentifierName("FromInstance")),
+                                SyntaxFactory.ArgumentList(SyntaxFactory.SingletonSeparatedList(
+                                    SyntaxFactory.Argument(SyntaxFactory.ThisExpression()))))));
+                    }
+
                     // Forward the enclosing event method's parameters
                     if (enclosingMethod != null)
                     {

--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -47,8 +47,6 @@ public class RoslynRewriter : CSharpSyntaxRewriter
     {
         "ALCommit",   // ALDatabase.ALCommit() — SQL transaction commit, no-op standalone
         "ALSelectLatestVersion", // ALDatabase.ALSelectLatestVersion() — no-op standalone
-        "ALBindSubscription",   // ALSession.ALBindSubscription() — event binding, no-op standalone
-        "ALUnbindSubscription", // ALSession.ALUnbindSubscription() — event unbinding, no-op standalone
     };
 
     private static readonly HashSet<string> StripITreeObjectArgMethods = new(StringComparer.Ordinal)
@@ -175,20 +173,41 @@ public class RoslynRewriter : CSharpSyntaxRewriter
     public override SyntaxNode? VisitAttributeList(AttributeListSyntax node)
     {
         var kept = new SeparatedSyntaxList<AttributeSyntax>();
+        bool anyReplaced = false;
         foreach (var attr in node.Attributes)
         {
             var attrName = GetSimpleAttributeName(attr);
-            if (!BcAttributeNames.Contains(attrName))
+            if (attrName == "NavCodeunitOptions" && IsManualEventSubscriber(attr))
+            {
+                // Replace NavCodeunitOptions with ManualEventSubscriber marker
+                kept = kept.Add(SyntaxFactory.Attribute(
+                    SyntaxFactory.ParseName("AlRunner.Runtime.ManualEventSubscriber")));
+                anyReplaced = true;
+            }
+            else if (!BcAttributeNames.Contains(attrName))
                 kept = kept.Add(attr);
         }
 
         if (kept.Count == 0)
             return null; // remove entire attribute list
 
-        if (kept.Count == node.Attributes.Count)
+        if (!anyReplaced && kept.Count == node.Attributes.Count)
             return base.VisitAttributeList(node); // nothing changed
 
         return node.WithAttributes(kept);
+    }
+
+    /// <summary>
+    /// Check if a NavCodeunitOptions attribute indicates EventSubscriberInstance = Manual.
+    /// In generated C#: <c>[NavCodeunitOptions(NavCodeunitOptions.EventManualBinding, ...)]</c>
+    /// The first arg is a flags enum — <c>EventManualBinding</c> or a bitwise OR containing it.
+    /// </summary>
+    private static bool IsManualEventSubscriber(AttributeSyntax attr)
+    {
+        if (attr.ArgumentList == null || attr.ArgumentList.Arguments.Count == 0)
+            return false;
+        var firstArg = attr.ArgumentList.Arguments[0].Expression.ToString();
+        return firstArg.Contains("EventManualBinding");
     }
 
     private static string GetSimpleAttributeName(AttributeSyntax attr)
@@ -2549,21 +2568,49 @@ public void ClearApplicationMemberVariables() { }
                 return SyntaxFactory.EmptyStatement();
             }
 
+            // Rewrite ALSession.ALBindSubscription(DataError, target) → target.Bind()
+            // and ALSession.ALUnbindSubscription(DataError, target) → target.Unbind()
+            if (invocation.Expression is MemberAccessExpressionSyntax bindMa &&
+                (bindMa.Name.Identifier.Text == "ALBindSubscription" ||
+                 bindMa.Name.Identifier.Text == "ALUnbindSubscription") &&
+                invocation.ArgumentList.Arguments.Count >= 2)
+            {
+                var methodName = bindMa.Name.Identifier.Text == "ALBindSubscription" ? "Bind" : "Unbind";
+                // Second arg is the codeunit target — strip .Target if present
+                var targetExpr = invocation.ArgumentList.Arguments[1].Expression;
+                if (targetExpr is MemberAccessExpressionSyntax targetMa &&
+                    targetMa.Name.Identifier.Text == "Target")
+                    targetExpr = targetMa.Expression;
+                var call = SyntaxFactory.InvocationExpression(
+                    SyntaxFactory.MemberAccessExpression(
+                        SyntaxKind.SimpleMemberAccessExpression,
+                        targetExpr,
+                        SyntaxFactory.IdentifierName(methodName)),
+                    SyntaxFactory.ArgumentList());
+                return SyntaxFactory.ExpressionStatement(call);
+            }
+
             // `βscope.RunEvent()` dispatches event subscribers. Walk the
             // ancestor tree to recover the enclosing Codeunit<N> type and
             // the enclosing event method name, then rewrite the statement
             // to a direct call into AlCompat.FireEvent which consults the
             // subscriber registry built at runtime via reflection.
+            // Also forward the enclosing method's parameters so subscribers
+            // receive the publisher's actual ByRef<T> / value arguments.
             if (invocation.Expression is MemberAccessExpressionSyntax runEventMa &&
                 runEventMa.Name.Identifier.Text == "RunEvent" &&
                 invocation.ArgumentList.Arguments.Count == 0)
             {
                 int? cuId = null;
                 string? eventName = null;
+                MethodDeclarationSyntax? enclosingMethod = null;
                 foreach (var ancestor in node.Ancestors())
                 {
-                    if (eventName == null && ancestor is MethodDeclarationSyntax mdecl)
+                    if (enclosingMethod == null && ancestor is MethodDeclarationSyntax mdecl)
+                    {
                         eventName = mdecl.Identifier.Text;
+                        enclosingMethod = mdecl;
+                    }
                     if (ancestor is ClassDeclarationSyntax cdecl && cdecl.Identifier.Text.StartsWith("Codeunit"))
                     {
                         var idStr = cdecl.Identifier.Text.Substring("Codeunit".Length);
@@ -2573,20 +2620,28 @@ public void ClearApplicationMemberVariables() { }
                 }
                 if (cuId.HasValue && eventName != null)
                 {
+                    var argsList = new List<ArgumentSyntax>
+                    {
+                        SyntaxFactory.Argument(SyntaxFactory.LiteralExpression(
+                            SyntaxKind.NumericLiteralExpression,
+                            SyntaxFactory.Literal(cuId.Value))),
+                        SyntaxFactory.Argument(SyntaxFactory.LiteralExpression(
+                            SyntaxKind.StringLiteralExpression,
+                            SyntaxFactory.Literal(eventName)))
+                    };
+                    // Forward the enclosing event method's parameters
+                    if (enclosingMethod != null)
+                    {
+                        foreach (var param in enclosingMethod.ParameterList.Parameters)
+                            argsList.Add(SyntaxFactory.Argument(
+                                SyntaxFactory.IdentifierName(param.Identifier.Text)));
+                    }
                     var call = SyntaxFactory.InvocationExpression(
                         SyntaxFactory.MemberAccessExpression(
                             SyntaxKind.SimpleMemberAccessExpression,
                             SyntaxFactory.IdentifierName("AlCompat"),
                             SyntaxFactory.IdentifierName("FireEvent")),
-                        SyntaxFactory.ArgumentList(SyntaxFactory.SeparatedList(new[]
-                        {
-                            SyntaxFactory.Argument(SyntaxFactory.LiteralExpression(
-                                SyntaxKind.NumericLiteralExpression,
-                                SyntaxFactory.Literal(cuId.Value))),
-                            SyntaxFactory.Argument(SyntaxFactory.LiteralExpression(
-                                SyntaxKind.StringLiteralExpression,
-                                SyntaxFactory.Literal(eventName)))
-                        })));
+                        SyntaxFactory.ArgumentList(SyntaxFactory.SeparatedList(argsList)));
                     return SyntaxFactory.ExpressionStatement(call);
                 }
                 // Fallback: strip the call, same as before.

--- a/AlRunner/Runtime/AlScope.cs
+++ b/AlRunner/Runtime/AlScope.cs
@@ -369,13 +369,35 @@ public static class AlCompat
     /// <c>NavEventSubscriberAttribute</c> the first time FireEvent is
     /// called — later runs on the same assembly reuse the cache.
     /// </summary>
-    public static void FireEvent(int publisherCodeunitId, string eventName)
+    public static void FireEvent(int publisherId, string eventName, params object?[] eventArgs)
+    {
+        FireEvent(EventSubscriberRegistry.ObjectTypeCodeunit, publisherId, eventName, eventArgs);
+    }
+
+    /// <summary>
+    /// Fire an event, dispatching to all registered subscribers.
+    /// Manual subscribers are only dispatched if a matching instance is
+    /// currently bound via <see cref="EventSubscriberRegistry.Bind"/>.
+    /// </summary>
+    public static void FireEvent(int objectType, int publisherId, string eventName, params object?[] eventArgs)
     {
         var asm = MockCodeunitHandle.CurrentAssembly;
         if (asm == null) return;
-        var subs = EventSubscriberRegistry.GetSubscribers(asm, publisherCodeunitId, eventName);
-        foreach (var (ownerType, method) in subs)
+        var subs = EventSubscriberRegistry.GetSubscribers(asm, objectType, publisherId, eventName);
+        foreach (var sub in subs)
         {
+            var ownerType = sub.OwnerType;
+            var method = sub.Method;
+
+            // Manual subscribers: only fire if a bound instance exists
+            if (EventSubscriberRegistry.IsManualSubscriber(ownerType))
+            {
+                foreach (var boundInst in EventSubscriberRegistry.GetBoundInstances(ownerType))
+                    InvokeSubscriber(boundInst, method, eventArgs);
+                continue;
+            }
+
+            // Automatic subscribers: create a fresh instance
             object? instance;
             try
             {
@@ -386,17 +408,21 @@ public static class AlCompat
             }
             catch { continue; }
 
-            // Zero-arg call for now — subscribers that take Sender/Rec
-            // arguments get them filled with null. That matches BC's
-            // "best effort" stance for standalone event dispatch.
-            var parameters = method.GetParameters();
-            var args = new object?[parameters.Length];
-            try { method.Invoke(instance, args); }
-            catch (System.Reflection.TargetInvocationException tie)
-            {
-                if (tie.InnerException != null) throw tie.InnerException;
-                throw;
-            }
+            InvokeSubscriber(instance, method, eventArgs);
+        }
+    }
+
+    private static void InvokeSubscriber(object? instance, System.Reflection.MethodInfo method, object?[] eventArgs)
+    {
+        var parameters = method.GetParameters();
+        var args = new object?[parameters.Length];
+        for (int i = 0; i < args.Length && i < eventArgs.Length; i++)
+            args[i] = eventArgs[i];
+        try { method.Invoke(instance, args); }
+        catch (System.Reflection.TargetInvocationException tie)
+        {
+            if (tie.InnerException != null) throw tie.InnerException;
+            throw;
         }
     }
 

--- a/AlRunner/Runtime/EventSubscriberRegistry.cs
+++ b/AlRunner/Runtime/EventSubscriberRegistry.cs
@@ -106,8 +106,8 @@ public static class EventSubscriberRegistry
         var result = new Dictionary<(int, int, string), List<SubscriberEntry>>();
 
         // Detect manual subscriber types by checking for ManualEventSubscriber attribute
-        // (emitted by the rewriter to preserve EventSubscriberInstance = Manual)
-        var manualTypes = new HashSet<Type>();
+        // (emitted by the rewriter to preserve EventSubscriberInstance = Manual).
+        // Detected types are recorded directly in _manualSubscriberTypes during the scan.
 
         Type[] types;
         try { types = assembly.GetTypes(); }
@@ -122,7 +122,6 @@ public static class EventSubscriberRegistry
             {
                 if (attr.AttributeType.Name == "ManualEventSubscriberAttribute")
                 {
-                    manualTypes.Add(type);
                     _manualSubscriberTypes.Add(type);
                     break;
                 }

--- a/AlRunner/Runtime/EventSubscriberRegistry.cs
+++ b/AlRunner/Runtime/EventSubscriberRegistry.cs
@@ -3,17 +3,31 @@ using System.Reflection;
 namespace AlRunner.Runtime;
 
 /// <summary>
-/// Runtime index of <c>[NavEventSubscriber(ObjectType.CodeUnit, N, "EventName", …)]</c>
+/// Runtime index of <c>[NavEventSubscriber(ObjectType, N, "EventName", …)]</c>
 /// methods found in the loaded assembly. Populated lazily per assembly
 /// and consulted by <see cref="AlCompat.FireEvent"/> when a publisher's
-/// rewritten event-method body fires.
+/// rewritten event-method body fires, or by <see cref="MockRecordHandle"/>
+/// for implicit DB trigger events.
 /// </summary>
 public static class EventSubscriberRegistry
 {
-    private static readonly Dictionary<Assembly, Dictionary<(int PublisherId, string EventName), List<(Type OwnerType, MethodInfo Method)>>> _byAssembly = new();
+    // BC ObjectType enum constants
+    public const int ObjectTypeTable = 1;
+    public const int ObjectTypeCodeunit = 5;
 
-    public static IReadOnlyList<(Type OwnerType, MethodInfo Method)> GetSubscribers(
-        Assembly assembly, int publisherCodeunitId, string eventName)
+    // Subscriber index keyed by (ObjectType, ObjectId, EventName)
+    private static readonly Dictionary<Assembly, Dictionary<(int ObjectType, int ObjectId, string EventName), List<SubscriberEntry>>> _byAssembly = new();
+
+    // Manually-bound codeunit instances (for EventSubscriberInstance = Manual)
+    private static readonly List<object> _boundInstances = new();
+
+    // Codeunit types detected as Manual subscribers (populated during Build)
+    private static readonly HashSet<Type> _manualSubscriberTypes = new();
+
+    public record struct SubscriberEntry(Type OwnerType, MethodInfo Method);
+
+    public static IReadOnlyList<SubscriberEntry> GetSubscribers(
+        Assembly assembly, int objectType, int objectId, string eventName)
     {
         if (!_byAssembly.TryGetValue(assembly, out var map))
         {
@@ -21,19 +35,79 @@ public static class EventSubscriberRegistry
             _byAssembly[assembly] = map;
         }
 
-        return map.TryGetValue((publisherCodeunitId, eventName), out var list)
+        return map.TryGetValue((objectType, objectId, eventName), out var list)
             ? list
-            : Array.Empty<(Type, MethodInfo)>();
+            : Array.Empty<SubscriberEntry>();
+    }
+
+    /// <summary>Backward-compat overload — defaults to ObjectType.Codeunit.</summary>
+    public static IReadOnlyList<SubscriberEntry> GetSubscribers(
+        Assembly assembly, int publisherCodeunitId, string eventName)
+        => GetSubscribers(assembly, ObjectTypeCodeunit, publisherCodeunitId, eventName);
+
+    /// <summary>
+    /// Bind a manual subscriber instance. The instance's subscriber methods
+    /// will be dispatched until <see cref="Unbind"/> is called.
+    /// </summary>
+    public static void Bind(object instance)
+    {
+        _boundInstances.Add(instance);
+    }
+
+    /// <summary>
+    /// Unbind a previously-bound manual subscriber instance.
+    /// </summary>
+    public static void Unbind(object instance)
+    {
+        _boundInstances.Remove(instance);
+    }
+
+    /// <summary>
+    /// Returns true if the given type is a manual subscriber (EventSubscriberInstance = Manual).
+    /// </summary>
+    public static bool IsManualSubscriber(Type type)
+    {
+        // Ensure the assembly is scanned
+        var asm = type.Assembly;
+        if (!_byAssembly.ContainsKey(asm))
+        {
+            _byAssembly[asm] = Build(asm);
+        }
+        return _manualSubscriberTypes.Contains(type);
+    }
+
+    /// <summary>
+    /// Returns all currently-bound instances whose type matches the given type.
+    /// </summary>
+    public static IEnumerable<object> GetBoundInstances(Type subscriberType)
+    {
+        foreach (var inst in _boundInstances)
+            if (inst.GetType() == subscriberType)
+                yield return inst;
     }
 
     public static void Clear()
     {
         _byAssembly.Clear();
+        _boundInstances.Clear();
+        _manualSubscriberTypes.Clear();
     }
 
-    private static Dictionary<(int, string), List<(Type, MethodInfo)>> Build(Assembly assembly)
+    /// <summary>
+    /// Reset per-test state (bound instances) without clearing the assembly cache.
+    /// </summary>
+    public static void ResetBindings()
     {
-        var result = new Dictionary<(int, string), List<(Type, MethodInfo)>>();
+        _boundInstances.Clear();
+    }
+
+    private static Dictionary<(int, int, string), List<SubscriberEntry>> Build(Assembly assembly)
+    {
+        var result = new Dictionary<(int, int, string), List<SubscriberEntry>>();
+
+        // Detect manual subscriber types by checking for ManualEventSubscriber attribute
+        // (emitted by the rewriter to preserve EventSubscriberInstance = Manual)
+        var manualTypes = new HashSet<Type>();
 
         Type[] types;
         try { types = assembly.GetTypes(); }
@@ -42,12 +116,21 @@ public static class EventSubscriberRegistry
         foreach (var type in types)
         {
             if (type == null) continue;
+
+            // Check if this type has the ManualEventSubscriber marker attribute
+            foreach (var attr in type.GetCustomAttributesData())
+            {
+                if (attr.AttributeType.Name == "ManualEventSubscriberAttribute")
+                {
+                    manualTypes.Add(type);
+                    _manualSubscriberTypes.Add(type);
+                    break;
+                }
+            }
+
             foreach (var method in type.GetMethods(
                 BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static))
             {
-                // Inspect the attribute via CustomAttributeData so we can read
-                // the raw positional constructor arguments without caring
-                // about the runtime wrapper types (ApplicationObjectId etc.).
                 foreach (var data in method.GetCustomAttributesData())
                 {
                     if (data.AttributeType.Name != "NavEventSubscriberAttribute") continue;
@@ -56,9 +139,7 @@ public static class EventSubscriberRegistry
                     //   (ObjectType targetObjectType, int targetObjectNo,
                     //    string targetMethodName, [int memberId,]
                     //    string fieldName, EventSubscriberCallOptions callOptions)
-                    // The first int-typed arg is the ObjectType enum; we want
-                    // the *second* — targetObjectNo. The first string is the
-                    // target method name.
+                    int? objType = null;
                     int? objId = null;
                     string? evName = null;
                     int intSeen = 0;
@@ -67,18 +148,19 @@ public static class EventSubscriberRegistry
                         if (arg.Value is int i)
                         {
                             intSeen++;
+                            if (intSeen == 1) objType = i;
                             if (intSeen == 2 && objId is null) objId = i;
                             continue;
                         }
                         if (arg.Value is string s && evName is null) evName = s;
                     }
 
-                    if (objId == null || evName == null) continue;
+                    if (objType == null || objId == null || evName == null) continue;
 
-                    var key = (objId.Value, evName);
+                    var key = (objType.Value, objId.Value, evName);
                     if (!result.TryGetValue(key, out var list))
-                        result[key] = list = new List<(Type, MethodInfo)>();
-                    list.Add((type, method));
+                        result[key] = list = new List<SubscriberEntry>();
+                    list.Add(new SubscriberEntry(type, method));
                 }
             }
         }

--- a/AlRunner/Runtime/ManualEventSubscriberAttribute.cs
+++ b/AlRunner/Runtime/ManualEventSubscriberAttribute.cs
@@ -1,0 +1,10 @@
+namespace AlRunner.Runtime;
+
+/// <summary>
+/// Marker attribute emitted by the rewriter on codeunit classes that have
+/// <c>EventSubscriberInstance = Manual</c>. The original <c>NavCodeunitOptions</c>
+/// attribute is stripped; this lightweight replacement lets the
+/// <see cref="EventSubscriberRegistry"/> detect manual subscribers at runtime.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class)]
+public sealed class ManualEventSubscriberAttribute : Attribute { }

--- a/AlRunner/Runtime/MockCodeunitHandle.cs
+++ b/AlRunner/Runtime/MockCodeunitHandle.cs
@@ -61,6 +61,42 @@ public class MockCodeunitHandle
     }
 
     /// <summary>
+    /// Bind this codeunit as a manual event subscriber. The underlying
+    /// generated class instance is created (if needed) and registered so
+    /// its subscriber methods fire during event dispatch.
+    /// </summary>
+    public void Bind()
+    {
+        var assembly = CurrentAssembly ?? Assembly.GetExecutingAssembly();
+        var codeunitType = FindCodeunitType(assembly);
+        if (codeunitType == null) return;
+        EnsureInstance(codeunitType);
+        if (_codeunitInstance != null)
+            EventSubscriberRegistry.Bind(_codeunitInstance);
+    }
+
+    /// <summary>
+    /// Unbind a previously bound manual event subscriber instance.
+    /// </summary>
+    public void Unbind()
+    {
+        if (_codeunitInstance != null)
+            EventSubscriberRegistry.Unbind(_codeunitInstance);
+    }
+
+    /// <summary>
+    /// Lazily create the codeunit class instance and run InitializeComponent.
+    /// </summary>
+    private void EnsureInstance(Type codeunitType)
+    {
+        if (_codeunitInstance != null) return;
+        _codeunitInstance = System.Runtime.CompilerServices.RuntimeHelpers.GetUninitializedObject(codeunitType);
+        var initMethod = codeunitType.GetMethod("InitializeComponent",
+            BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance);
+        initMethod?.Invoke(_codeunitInstance, null);
+    }
+
+    /// <summary>
     /// Static factory matching the rewritten constructor pattern.
     /// </summary>
     public static MockCodeunitHandle Create(int codeunitId)
@@ -111,14 +147,7 @@ public class MockCodeunitHandle
             throw new InvalidOperationException($"Codeunit {_codeunitId} not found in assembly");
         }
 
-        // Lazily create codeunit instance and call InitializeComponent
-        if (_codeunitInstance == null)
-        {
-            _codeunitInstance = System.Runtime.CompilerServices.RuntimeHelpers.GetUninitializedObject(codeunitType);
-            var initMethod = codeunitType.GetMethod("InitializeComponent",
-                BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance);
-            initMethod?.Invoke(_codeunitInstance, null);
-        }
+        EnsureInstance(codeunitType);
 
         // Find the public method whose scope class name contains the memberId.
         // Scope classes are named like: ApplyDiscount_Scope_1351223168

--- a/AlRunner/Runtime/MockRecordHandle.cs
+++ b/AlRunner/Runtime/MockRecordHandle.cs
@@ -303,8 +303,8 @@ public class MockRecordHandle
         // Copy the SystemId back into the handle's field bag
         _fields[SystemIdFieldNo] = row[SystemIdFieldNo];
 
-        // Fire OnAfterInsertEvent(var Rec)
-        FireImplicitDbEvent("OnAfterInsertEvent", this);
+        // Fire OnAfterInsertEvent(var Rec, RunTrigger: Boolean)
+        FireImplicitDbEvent("OnAfterInsertEvent", this, runTrigger);
 
         return true;
     }
@@ -420,8 +420,8 @@ public class MockRecordHandle
             {
                 table[i] = new Dictionary<int, NavValue>(_fields);
 
-                // Fire OnAfterModifyEvent(var Rec, var xRec)
-                FireImplicitDbEvent("OnAfterModifyEvent", this, xRec);
+                // Fire OnAfterModifyEvent(var Rec, var xRec, RunTrigger: Boolean)
+                FireImplicitDbEvent("OnAfterModifyEvent", this, xRec, runTrigger);
                 return true;
             }
         }
@@ -615,8 +615,8 @@ public class MockRecordHandle
             {
                 table.RemoveAt(i);
 
-                // Fire OnAfterDeleteEvent(var Rec)
-                FireImplicitDbEvent("OnAfterDeleteEvent", this);
+                // Fire OnAfterDeleteEvent(var Rec, RunTrigger: Boolean)
+                FireImplicitDbEvent("OnAfterDeleteEvent", this, runTrigger);
                 return true;
             }
         }

--- a/AlRunner/Runtime/MockRecordHandle.cs
+++ b/AlRunner/Runtime/MockRecordHandle.cs
@@ -271,20 +271,15 @@ public class MockRecordHandle
     {
         var table = _tables[_tableId];
 
-        // Run the AL `trigger OnInsert()` body if requested. The generated
-        // Record<N> class overrides a protected OnInsert() that creates a
-        // scope and runs the trigger body against `this.Rec` — we reflect
-        // over it, create an instance whose field bag is this handle's
-        // bag, and invoke OnInsert() directly.
+        // Fire OnBeforeInsertEvent(var Rec, RunTrigger: Boolean)
+        // — always fires, regardless of runTrigger
+        FireImplicitDbEvent("OnBeforeInsertEvent", this, runTrigger);
+
+        // Run the AL `trigger OnInsert()` body if requested.
         if (runTrigger)
             TryFireRecordTrigger("OnInsert");
 
         // Always enforce primary-key uniqueness.
-        // GetPrimaryKeyFields() returns the registered composite PK when the table's
-        // AL source was parsed by TableFieldRegistry, or falls back to [1] (field 1)
-        // when no PK was registered (e.g. table from an external package or a table
-        // with no explicit keys{} block). BC implicitly uses field 1 as the PK for
-        // any table without a declared key, so the [1] fallback is always correct.
         var pkFields = GetPrimaryKeyFields();
         foreach (var existing in table)
         {
@@ -299,16 +294,17 @@ public class MockRecordHandle
 
         var row = new Dictionary<int, NavValue>(_fields);
 
-        // Auto-populate SystemId if not already set, so that ALGetBySystemId
-        // can find records inserted in standalone mode.
+        // Auto-populate SystemId if not already set
         if (!row.ContainsKey(SystemIdFieldNo) || (row[SystemIdFieldNo] is NavGuid g && g.ToGuid() == Guid.Empty))
             row[SystemIdFieldNo] = new NavGuid(Guid.NewGuid());
 
         table.Add(row);
 
-        // Copy the SystemId back into the handle's field bag so that
-        // reading Rec.SystemId after Insert() returns the generated value.
+        // Copy the SystemId back into the handle's field bag
         _fields[SystemIdFieldNo] = row[SystemIdFieldNo];
+
+        // Fire OnAfterInsertEvent(var Rec)
+        FireImplicitDbEvent("OnAfterInsertEvent", this);
 
         return true;
     }
@@ -376,17 +372,56 @@ public class MockRecordHandle
 
     private string TableName() => $"Record Table {_tableId}";
 
+    /// <summary>
+    /// Fire an implicit DB trigger event (OnBefore/AfterInsertEvent, etc.)
+    /// by dispatching through AlCompat.FireEvent with ObjectType.Table.
+    /// Subscribers registered via <c>[EventSubscriber(ObjectType::Table, ...)]</c>
+    /// will be invoked. These events always fire regardless of runTrigger —
+    /// runTrigger only controls AL trigger bodies.
+    /// </summary>
+    private void FireImplicitDbEvent(string eventName, params object?[] eventArgs)
+    {
+        AlCompat.FireEvent(EventSubscriberRegistry.ObjectTypeTable, _tableId, eventName, eventArgs);
+    }
+
+    /// <summary>
+    /// Create a snapshot of the current field bag (for xRec) before a mutation.
+    /// Returns a new MockRecordHandle sharing the same table store but with
+    /// a copy of the current field values.
+    /// </summary>
+    private MockRecordHandle SnapshotForXRec()
+    {
+        var xRec = new MockRecordHandle(_tableId);
+        foreach (var kv in _fields)
+            xRec._fields[kv.Key] = kv.Value;
+        return xRec;
+    }
+
     public bool ALModify(DataError errorLevel) => ALModify(errorLevel, false);
 
     public bool ALModify(DataError errorLevel, bool runTrigger)
     {
         var table = _tables[_tableId];
         var pkFields = GetPrimaryKeyFields();
+
+        // Capture xRec (snapshot before mutation) for event subscribers
+        var xRec = SnapshotForXRec();
+
+        // Fire OnBeforeModifyEvent(var Rec, var xRec, RunTrigger: Boolean)
+        FireImplicitDbEvent("OnBeforeModifyEvent", this, xRec, runTrigger);
+
+        // Run the AL `trigger OnModify()` body if requested
+        if (runTrigger)
+            TryFireRecordTrigger("OnModify");
+
         for (int i = 0; i < table.Count; i++)
         {
             if (RowMatchesPrimaryKey(table[i], _fields, pkFields))
             {
                 table[i] = new Dictionary<int, NavValue>(_fields);
+
+                // Fire OnAfterModifyEvent(var Rec, var xRec)
+                FireImplicitDbEvent("OnAfterModifyEvent", this, xRec);
                 return true;
             }
         }
@@ -566,11 +601,22 @@ public class MockRecordHandle
     {
         var table = _tables[_tableId];
         var pkFields = GetPrimaryKeyFields();
+
+        // Fire OnBeforeDeleteEvent(var Rec, RunTrigger: Boolean)
+        FireImplicitDbEvent("OnBeforeDeleteEvent", this, runTrigger);
+
+        // Run the AL `trigger OnDelete()` body if requested
+        if (runTrigger)
+            TryFireRecordTrigger("OnDelete");
+
         for (int i = 0; i < table.Count; i++)
         {
             if (RowMatchesPrimaryKey(table[i], _fields, pkFields))
             {
                 table.RemoveAt(i);
+
+                // Fire OnAfterDeleteEvent(var Rec)
+                FireImplicitDbEvent("OnAfterDeleteEvent", this);
                 return true;
             }
         }
@@ -793,13 +839,16 @@ public class MockRecordHandle
     // -----------------------------------------------------------------------
 
     /// <summary>
-    /// AL's VALIDATE(FieldNo, Value) — sets the field and would fire OnValidate trigger.
-    /// In standalone mode we just set the value since we don't have trigger infrastructure.
+    /// AL's VALIDATE(FieldNo, Value) — sets the field and fires OnValidate trigger.
+    /// Also fires implicit OnBefore/AfterValidateEvent for event subscribers.
     /// </summary>
     public void ALValidateSafe(int fieldNo, NavType expectedType, NavValue value)
     {
+        var xRec = SnapshotForXRec();
+        FireImplicitDbEvent("OnBeforeValidateEvent", this, xRec, fieldNo);
         _fields[fieldNo] = value;
         FireOnValidate(fieldNo);
+        FireImplicitDbEvent("OnAfterValidateEvent", this, xRec, fieldNo);
     }
 
     /// <summary>
@@ -808,7 +857,10 @@ public class MockRecordHandle
     /// </summary>
     public void ALValidateSafe(int fieldNo, NavType expectedType)
     {
+        var xRec = SnapshotForXRec();
+        FireImplicitDbEvent("OnBeforeValidateEvent", this, xRec, fieldNo);
         FireOnValidate(fieldNo);
+        FireImplicitDbEvent("OnAfterValidateEvent", this, xRec, fieldNo);
     }
 
     /// <summary>
@@ -816,8 +868,11 @@ public class MockRecordHandle
     /// </summary>
     public void ALValidate(DataError errorLevel, int fieldNo, NavType expectedType, NavValue value)
     {
+        var xRec = SnapshotForXRec();
+        FireImplicitDbEvent("OnBeforeValidateEvent", this, xRec, fieldNo);
         _fields[fieldNo] = value;
         FireOnValidate(fieldNo);
+        FireImplicitDbEvent("OnAfterValidateEvent", this, xRec, fieldNo);
     }
 
     /// <summary>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,8 +28,13 @@ All notable changes to this project are documented here. Format based on
   `(ObjectType, ObjectId, EventName)` to prevent table/codeunit ID collision.
   Supports both automatic and manual subscriber classification.
 - **New test suites**: `97-event-params` (2), `98-db-trigger-events` (5),
-  `99-validate-events` (3), `100-bind-subscription` (3), `101-multi-subscribers` (2)
-  — 15 new test cases total.
+  `99-validate-events` (3), `100-bind-subscription` (3), `101-multi-subscribers` (2),
+  `102-sender-pattern` (6), `103-before-db-events` (7), `104-xrec-behavior` (3),
+  `105-subscriber-error` (4) — 35 new test cases total.
+- **IncludeSender support** — `IntegrationEvent(true, false)` and
+  `BusinessEvent(true)` now correctly pass the publishing codeunit instance as
+  the first subscriber parameter via `MockCodeunitHandle.FromInstance(this)`.
+  Subscribers can read/write publisher state through the sender handle. (#116)
 
 ### Fixed
 - **`CS1503` in codeunits that call `HttpContent.WriteFrom(InStream)` or `HttpContent.ReadAs(var InStream)`** —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,31 @@ All notable changes to this project are documented here. Format based on
 
 ## [Unreleased]
 
+### Added
+- **Event subscriber parameter forwarding** — Publisher event arguments (`ByRef<T>`
+  and value parameters) are now forwarded from `βscope.RunEvent()` to subscriber
+  methods via positional matching. Subscribers that modify `var` parameters (e.g.
+  `var IsHandled: Boolean`) now write back correctly through shared `ByRef<T>`
+  references. (#116)
+- **Implicit DB trigger events** — `MockRecordHandle` now fires
+  `OnBeforeInsertEvent`/`OnAfterInsertEvent`, `OnBeforeModifyEvent`/`OnAfterModifyEvent`,
+  `OnBeforeDeleteEvent`/`OnAfterDeleteEvent` from `ALInsert`/`ALModify`/`ALDelete`, and
+  `OnBeforeValidateEvent`/`OnAfterValidateEvent` from `ALValidateSafe`/`ALValidate`.
+  Events fire regardless of `runTrigger` (matching BC behavior). xRec snapshots
+  are captured before mutations. (#116)
+- **BindSubscription / UnbindSubscription** — Manual event subscriber codeunits
+  (`EventSubscriberInstance = Manual` in AL) are now detected via
+  `[ManualEventSubscriber]` marker attribute emitted by the rewriter. The rewriter
+  rewrites `ALSession.ALBindSubscription()`/`ALUnbindSubscription()` to
+  `MockCodeunitHandle.Bind()`/`Unbind()`. Manual subscribers only fire when bound.
+  Bindings are reset between tests. (#116)
+- **`EventSubscriberRegistry` refactored** — Uses 3-tuple key
+  `(ObjectType, ObjectId, EventName)` to prevent table/codeunit ID collision.
+  Supports both automatic and manual subscriber classification.
+- **New test suites**: `97-event-params` (2), `98-db-trigger-events` (5),
+  `99-validate-events` (3), `100-bind-subscription` (3), `101-multi-subscribers` (2)
+  — 15 new test cases total.
+
 ### Fixed
 - **`CS1503` in codeunits that call `HttpContent.WriteFrom(InStream)` or `HttpContent.ReadAs(var InStream)`** —
   After the `NavInStream → MockInStream` type rename in the rewriter, calls to

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -338,13 +338,14 @@ test belongs in the full BC pipeline, not in the runner.
   in HTTP codeunits (those that don't actually call `HttpClient.Send()`) are fully
   testable. Developer must inject HTTP send via AL interface for unit-testable code.
 - **Events/subscribers** — Custom `[IntegrationEvent]`/`[BusinessEvent]` dispatch
-  works via `AlCompat.FireEvent()` + `EventSubscriberRegistry`. Subscriber
-  parameters are forwarded. Implicit DB trigger events (OnBefore/AfterInsert,
-  OnBefore/AfterModify, OnBefore/AfterDelete, OnBefore/AfterValidate) fire from
-  `MockRecordHandle`. `BindSubscription`/`UnbindSubscription` work for manual
-  subscriber codeunits. Remaining gaps: `OnBefore/AfterRenameEvent` not yet
-  fired; `ModifyAll`/`DeleteAll` do not fire per-row events; implicit event
-  publishers on table extension triggers not wired.
+  works via `AlCompat.FireEvent()` + `EventSubscriberRegistry`. `IncludeSender=true`
+  passes the publisher instance to subscribers via `MockCodeunitHandle.FromInstance()`.
+  Subscriber parameters are forwarded with `ByRef<T>` writeback. Implicit DB trigger
+  events (OnBefore/AfterInsert, OnBefore/AfterModify, OnBefore/AfterDelete,
+  OnBefore/AfterValidate) fire from `MockRecordHandle`. `BindSubscription`/
+  `UnbindSubscription` work for manual subscriber codeunits. Remaining gaps:
+  `OnBefore/AfterRenameEvent` not yet fired; `ModifyAll`/`DeleteAll` do not fire
+  per-row events; implicit event publishers on table extension triggers not wired.
 - **.app file loading** — NOT supported for test input. Always runs from AL source
   directories. Dependencies can be loaded from .app for symbol references only.
 - **Filter groups** (FilterGroup) — not tracked.
@@ -356,6 +357,10 @@ test belongs in the full BC pipeline, not in the runner.
 - **Codeunit OnRun with record parameter** — `RunCodeunit` only finds parameterless
   `OnRun()` methods. Codeunits whose OnRun trigger takes a record parameter (e.g.,
   `trigger OnRun(var Rec: Record "Job Queue Entry")`) will silently do nothing.
+- **ALInsert ignores DataError level** (#128) — `ALInsert()` always throws on
+  duplicate PK regardless of `errorLevel`. AL code like `if not Rec.Insert() then`
+  crashes instead of returning false. Other methods (`ALModify`, `ALGet`, etc.)
+  correctly respect `DataError.ThrowError` vs `DataError.Never`.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,6 +106,8 @@ These are the BC runtime types replaced in standalone mode:
 | `MockSession` | `ALSession.ALStartSession/ALStopSession/ALIsSessionActive`, `NavSession.Sleep` | StartSession dispatches codeunit synchronously via MockCodeunitHandle, returns true. StopSession/Sleep are no-ops. IsSessionActive returns false. |
 | `MockXmlPortHandle` | `NavXmlPortHandle` | XmlPort variable stub. Exposes Source/Destination properties and Import/Export instance methods (throw NotSupportedException). Static StaticImport/StaticExport for `XmlPort.Import/Export(portId, stream)` calls. Invoke() returns null. |
 | `MockQueryHandle` | `NavQueryHandle` / `NavQuery` | Query variable and base class stub. Close/SetFilter/SetRange/TopNumberOfRows are no-ops. Open/Read/SaveAsCsv/SaveAsXml/SaveAsJson/SaveAsExcel throw NotSupportedException. GetColumnValueSafe returns type defaults. Invoke() returns null. |
+| `EventSubscriberRegistry` | BC event infrastructure | Static registry mapping `(ObjectType, ObjectId, EventName)` to subscriber methods. Auto-discovers `[NavEventSubscriber]` attributes via reflection. Supports manual subscriber binding (Bind/Unbind) for `[ManualEventSubscriber]`-annotated codeunits. |
+| `ManualEventSubscriberAttribute` | `NavCodeunitOptions.EventManualBinding` | Marker attribute emitted by the rewriter on codeunit classes with `EventSubscriberInstance = Manual`. Detected by `EventSubscriberRegistry.Build()` to gate dispatch on `Bind()`. |
 
 ### MockRecordHandle capabilities
 
@@ -123,6 +125,8 @@ These are the BC runtime types replaced in standalone mode:
 - GetGlobalArrayVariable (typed MockArray for Code, Text, Integer, Decimal, Boolean)
 - ALFieldNo(fieldName) lookups (RegisterFieldName)
 - Cross-record table reset via `ResetAll()` between tests
+- Implicit DB trigger events: OnBefore/AfterInsert, OnBefore/AfterModify, OnBefore/AfterDelete, OnBefore/AfterValidate
+- xRec snapshot creation via `SnapshotForXRec()` for modify/delete/validate events
 
 ### Removed out-of-scope files
 
@@ -334,9 +338,13 @@ test belongs in the full BC pipeline, not in the runner.
   in HTTP codeunits (those that don't actually call `HttpClient.Send()`) are fully
   testable. Developer must inject HTTP send via AL interface for unit-testable code.
 - **Events/subscribers** — Custom `[IntegrationEvent]`/`[BusinessEvent]` dispatch
-  works via `AlCompat.FireEvent()` + `EventSubscriberRegistry`. However, implicit
-  DB trigger events (OnBefore/AfterInsert/Modify/Delete) are NOT fired, subscriber
-  parameters are not forwarded, and `BindSubscription`/`UnbindSubscription` are no-ops.
+  works via `AlCompat.FireEvent()` + `EventSubscriberRegistry`. Subscriber
+  parameters are forwarded. Implicit DB trigger events (OnBefore/AfterInsert,
+  OnBefore/AfterModify, OnBefore/AfterDelete, OnBefore/AfterValidate) fire from
+  `MockRecordHandle`. `BindSubscription`/`UnbindSubscription` work for manual
+  subscriber codeunits. Remaining gaps: `OnBefore/AfterRenameEvent` not yet
+  fired; `ModifyAll`/`DeleteAll` do not fire per-row events; implicit event
+  publishers on table extension triggers not wired.
 - **.app file loading** — NOT supported for test input. Always runs from AL source
   directories. Dependencies can be loaded from .app for symbol references only.
 - **Filter groups** (FilterGroup) — not tracked.
@@ -492,7 +500,34 @@ These have been implemented and are tested by the test suite:
     `x.Clear()` for non-NavComplexValue types. Tested by `tests/94-clear-field-value/`
     (6 test cases).
 
-## Remaining Gaps
+19. **Event subscriber parameter forwarding** (`AlRunner/RoslynRewriter.cs`,
+    `AlRunner/Runtime/AlScope.cs`) — Publisher event arguments (`ByRef<T>` and
+    value parameters) are forwarded from `βscope.RunEvent()` to subscriber
+    methods via positional matching. `AlCompat.FireEvent()` accepts
+    `params object?[] eventArgs` and passes them through to subscriber
+    invocations. This enables subscriber write-back through shared `ByRef<T>`
+    references. Tested by `tests/97-event-params/` (2 test cases) and
+    `tests/101-multi-subscribers/` (2 test cases).
+
+20. **Implicit DB trigger events** (`AlRunner/Runtime/MockRecordHandle.cs`) —
+    `MockRecordHandle` fires OnBefore/AfterInsertEvent, OnBefore/AfterModifyEvent,
+    OnBefore/AfterDeleteEvent from `ALInsert`/`ALModify`/`ALDelete`, and
+    OnBefore/AfterValidateEvent from `ALValidateSafe`/`ALValidate`. Events fire
+    regardless of `runTrigger` (matching BC behavior). xRec snapshots are created
+    via `SnapshotForXRec()` before mutations. Uses `EventSubscriberRegistry` with
+    3-tuple key `(ObjectType, ObjectId, EventName)` to prevent table/codeunit ID
+    collision. Tested by `tests/98-db-trigger-events/` (5 test cases) and
+    `tests/99-validate-events/` (3 test cases).
+
+21. **BindSubscription / UnbindSubscription** (`AlRunner/RoslynRewriter.cs`,
+    `AlRunner/Runtime/MockCodeunitHandle.cs`, `AlRunner/Runtime/EventSubscriberRegistry.cs`,
+    `AlRunner/Runtime/ManualEventSubscriberAttribute.cs`) — The rewriter detects
+    `NavCodeunitOptions.EventManualBinding` in `[NavCodeunitOptions]` and emits a
+    `[ManualEventSubscriber]` marker attribute. `ALSession.ALBindSubscription()` /
+    `ALUnbindSubscription()` are rewritten to `MockCodeunitHandle.Bind()` /
+    `Unbind()`. The `EventSubscriberRegistry` tracks bound instances and only
+    dispatches to manual subscribers when bound. Bindings are reset between tests.
+    Tested by `tests/100-bind-subscription/` (3 test cases).
 
 These are gaps that remain for full production use:
 
@@ -696,6 +731,8 @@ Follows the `BusinessCentral.AL.*` pattern:
 | `AlRunner/Runtime/MockSession.cs` | Session API stubs: StartSession (synchronous dispatch), StopSession, IsSessionActive, Sleep |
 | `AlRunner/Runtime/MockXmlPortHandle.cs` | XmlPort variable stub: Source/Destination properties, Import/Export (throw NotSupportedException), Invoke (returns null), StaticImport/StaticExport for static XmlPort.Import/Export calls |
 | `AlRunner/Runtime/MockQueryHandle.cs` | Query variable and base class stub: Close/SetFilter/SetRange/TopNumberOfRows no-ops, Open/Read/SaveAs throw NotSupportedException |
+| `AlRunner/Runtime/EventSubscriberRegistry.cs` | Event subscriber discovery + dispatch: 3-tuple key (ObjectType, ObjectId, EventName), manual binding support, auto/manual subscriber classification |
+| `AlRunner/Runtime/ManualEventSubscriberAttribute.cs` | Marker attribute for manual event subscriber codeunits (emitted by rewriter from NavCodeunitOptions.EventManualBinding) |
 | `AlRunner/stubs/LibraryAssert.al` | AL stub for codeunit 130 (auto-loaded for compilation) |
 | `AlRunner/stubs/LibraryVariableStorage.al` | AL stub for codeunit 131004 (auto-loaded for compilation) |
 | `tests/bucket-1/`, `tests/bucket-2/` | Test suites in buckets (each bucket = one al-runner invocation). `src/*.al` + `test/*.al` per suite. |

--- a/tests/bucket-2/100-bind-subscription/src/BindSubscription.al
+++ b/tests/bucket-2/100-bind-subscription/src/BindSubscription.al
@@ -1,0 +1,42 @@
+table 51001 "BS Counter"
+{
+    fields
+    {
+        field(1; PK; Integer) { }
+        field(2; CallCount; Integer) { }
+    }
+    keys { key(PK; PK) { Clustered = true; } }
+}
+
+codeunit 51001 "BS Publisher"
+{
+    [IntegrationEvent(false, false)]
+    procedure OnDoSomething()
+    begin
+    end;
+
+    procedure DoSomething()
+    begin
+        OnDoSomething();
+    end;
+}
+
+codeunit 51002 "BS Manual Subscriber"
+{
+    EventSubscriberInstance = Manual;
+
+    [EventSubscriber(ObjectType::Codeunit, Codeunit::"BS Publisher", 'OnDoSomething', '', true, true)]
+    local procedure HandleDoSomething()
+    var
+        C: Record "BS Counter";
+    begin
+        if not C.Get(1) then begin
+            C.PK := 1;
+            C.CallCount := 1;
+            C.Insert();
+        end else begin
+            C.CallCount += 1;
+            C.Modify();
+        end;
+    end;
+}

--- a/tests/bucket-2/100-bind-subscription/test/BindSubscriptionTest.al
+++ b/tests/bucket-2/100-bind-subscription/test/BindSubscriptionTest.al
@@ -1,0 +1,54 @@
+codeunit 51003 "BS Tests"
+{
+    Subtype = Test;
+    var
+        Assert: Codeunit Assert;
+
+    [Test]
+    procedure ManualSubscriberNotCalledBeforeBind()
+    var
+        Publisher: Codeunit "BS Publisher";
+        C: Record "BS Counter";
+    begin
+        // Negative: manual subscriber should NOT be called without BindSubscription
+        Publisher.DoSomething();
+        Assert.IsFalse(C.Get(1), 'Manual subscriber must NOT fire before BindSubscription');
+    end;
+
+    [Test]
+    procedure ManualSubscriberCalledAfterBind()
+    var
+        Publisher: Codeunit "BS Publisher";
+        Sub: Codeunit "BS Manual Subscriber";
+        C: Record "BS Counter";
+    begin
+        // Positive: after BindSubscription, the manual subscriber IS called
+        BindSubscription(Sub);
+        Publisher.DoSomething();
+        Assert.IsTrue(C.Get(1), 'Manual subscriber must fire after BindSubscription');
+        Assert.AreEqual(1, C.CallCount, 'Subscriber should have been called once');
+        UnbindSubscription(Sub);
+    end;
+
+    [Test]
+    procedure ManualSubscriberNotCalledAfterUnbind()
+    var
+        Publisher: Codeunit "BS Publisher";
+        Sub: Codeunit "BS Manual Subscriber";
+        C: Record "BS Counter";
+    begin
+        // Negative: after UnbindSubscription, the subscriber is NOT called again
+        BindSubscription(Sub);
+        Publisher.DoSomething();
+        UnbindSubscription(Sub);
+
+        // Counter is 1 from the first call
+        Assert.IsTrue(C.Get(1), 'Counter should exist from bound call');
+        Assert.AreEqual(1, C.CallCount, 'Counter should be 1 from bound call');
+
+        // Second call — subscriber should NOT fire
+        Publisher.DoSomething();
+        C.Get(1);
+        Assert.AreEqual(1, C.CallCount, 'Counter must still be 1 after unbind');
+    end;
+}

--- a/tests/bucket-2/101-multi-subscribers/src/MultiSubscribers.al
+++ b/tests/bucket-2/101-multi-subscribers/src/MultiSubscribers.al
@@ -1,0 +1,34 @@
+codeunit 51011 "MS Publisher"
+{
+    [IntegrationEvent(false, false)]
+    procedure OnDoCalc(var Value: Integer)
+    begin
+    end;
+
+    procedure DoCalc(BaseValue: Integer): Integer
+    var
+        Result: Integer;
+    begin
+        Result := BaseValue;
+        OnDoCalc(Result);
+        exit(Result);
+    end;
+}
+
+codeunit 51012 "MS Subscriber A"
+{
+    [EventSubscriber(ObjectType::Codeunit, Codeunit::"MS Publisher", 'OnDoCalc', '', true, true)]
+    local procedure HandleCalcA(var Value: Integer)
+    begin
+        Value += 10;
+    end;
+}
+
+codeunit 51013 "MS Subscriber B"
+{
+    [EventSubscriber(ObjectType::Codeunit, Codeunit::"MS Publisher", 'OnDoCalc', '', true, true)]
+    local procedure HandleCalcB(var Value: Integer)
+    begin
+        Value += 20;
+    end;
+}

--- a/tests/bucket-2/101-multi-subscribers/test/MultiSubscribersTest.al
+++ b/tests/bucket-2/101-multi-subscribers/test/MultiSubscribersTest.al
@@ -1,0 +1,32 @@
+codeunit 51014 "MS Tests"
+{
+    Subtype = Test;
+    var
+        Assert: Codeunit Assert;
+
+    [Test]
+    procedure BothSubscribersFireOnSameEvent()
+    var
+        Publisher: Codeunit "MS Publisher";
+        Result: Integer;
+    begin
+        // Positive: both subscriber A (+10) and subscriber B (+20)
+        // fire on the same event, so result = 5 + 10 + 20 = 35
+        Result := Publisher.DoCalc(5);
+        Assert.AreEqual(35, Result, 'Both subscribers should have modified the value');
+    end;
+
+    [Test]
+    procedure MultipleCallsFireBothSubscribersEachTime()
+    var
+        Publisher: Codeunit "MS Publisher";
+        Result: Integer;
+    begin
+        // Positive: calling twice fires both subscribers each time
+        Result := Publisher.DoCalc(0);
+        Assert.AreEqual(30, Result, 'First call: 0+10+20=30');
+
+        Result := Publisher.DoCalc(100);
+        Assert.AreEqual(130, Result, 'Second call: 100+10+20=130');
+    end;
+}

--- a/tests/bucket-2/102-sender-pattern/src/SenderPattern.al
+++ b/tests/bucket-2/102-sender-pattern/src/SenderPattern.al
@@ -1,0 +1,168 @@
+// Tests for IntegrationEvent(IncludeSender=true) and BusinessEvent(IncludeSender=true).
+// When IncludeSender is true, the subscriber receives the publishing codeunit instance
+// as its first parameter, enabling it to read/write publisher state.
+
+codeunit 59950 "SP Publisher"
+{
+    var
+        InternalState: Integer;
+
+    // IncludeSender = true: subscriber gets "sender: Codeunit" as first param
+    [IntegrationEvent(true, false)]
+    procedure OnAfterProcess(Result: Integer)
+    begin
+    end;
+
+    procedure SetState(NewState: Integer)
+    begin
+        InternalState := NewState;
+    end;
+
+    procedure GetState(): Integer
+    begin
+        exit(InternalState);
+    end;
+
+    procedure Process(Value: Integer): Integer
+    var
+        Result: Integer;
+    begin
+        Result := Value * 2;
+        InternalState := Result;
+        OnAfterProcess(Result);
+        exit(Result);
+    end;
+}
+
+codeunit 59951 "SP Subscriber"
+{
+    SingleInstance = true;
+    var
+        CapturedSenderState: Integer;
+        CapturedResult: Integer;
+        WasCalled: Boolean;
+
+    [EventSubscriber(ObjectType::Codeunit, Codeunit::"SP Publisher", OnAfterProcess, '', true, true)]
+    local procedure HandleAfterProcess(sender: Codeunit "SP Publisher"; Result: Integer)
+    begin
+        // Read state from the sender instance
+        CapturedSenderState := sender.GetState();
+        CapturedResult := Result;
+        WasCalled := true;
+    end;
+}
+
+// Second publisher using BusinessEvent(IncludeSender=true)
+codeunit 59952 "SP BizPublisher"
+{
+    var
+        OrderNo: Integer;
+
+    [BusinessEvent(true)]
+    procedure OnOrderPosted(PostedOrderNo: Integer)
+    begin
+    end;
+
+    procedure PostOrder(No: Integer)
+    begin
+        OrderNo := No;
+        OnOrderPosted(No);
+    end;
+
+    procedure GetOrderNo(): Integer
+    begin
+        exit(OrderNo);
+    end;
+}
+
+codeunit 59953 "SP BizSubscriber"
+{
+    SingleInstance = true;
+    var
+        ReceivedOrderNo: Integer;
+        SenderOrderNo: Integer;
+        WasCalled: Boolean;
+
+    [EventSubscriber(ObjectType::Codeunit, Codeunit::"SP BizPublisher", OnOrderPosted, '', true, true)]
+    local procedure HandleOrderPosted(sender: Codeunit "SP BizPublisher"; PostedOrderNo: Integer)
+    begin
+        ReceivedOrderNo := PostedOrderNo;
+        SenderOrderNo := sender.GetOrderNo();
+        WasCalled := true;
+    end;
+}
+
+// Third publisher: IncludeSender=true with var params (mixed pattern)
+codeunit 59954 "SP MixedPublisher"
+{
+    var
+        Tag: Text[50];
+
+    [IntegrationEvent(true, false)]
+    procedure OnBeforeValidate(var Value: Integer; var IsHandled: Boolean)
+    begin
+    end;
+
+    procedure SetTag(NewTag: Text[50])
+    begin
+        Tag := NewTag;
+    end;
+
+    procedure GetTag(): Text[50]
+    begin
+        exit(Tag);
+    end;
+
+    procedure Validate(var Value: Integer): Boolean
+    var
+        Handled: Boolean;
+    begin
+        Handled := false;
+        OnBeforeValidate(Value, Handled);
+        if Handled then
+            exit(true);
+        if Value < 0 then
+            exit(false);
+        exit(true);
+    end;
+}
+
+codeunit 59955 "SP MixedSubscriber"
+{
+    [EventSubscriber(ObjectType::Codeunit, Codeunit::"SP MixedPublisher", OnBeforeValidate, '', true, true)]
+    local procedure HandleBeforeValidate(sender: Codeunit "SP MixedPublisher"; var Value: Integer; var IsHandled: Boolean)
+    begin
+        // Sender with tag "override" forces value to 999
+        if sender.GetTag() = 'override' then begin
+            Value := 999;
+            IsHandled := true;
+        end;
+    end;
+}
+
+// Fourth publisher: IncludeSender=false as control (should still work)
+codeunit 59956 "SP NoSender Publisher"
+{
+    [IntegrationEvent(false, false)]
+    procedure OnSimpleEvent(Value: Integer)
+    begin
+    end;
+
+    procedure Fire(Value: Integer)
+    begin
+        OnSimpleEvent(Value);
+    end;
+}
+
+codeunit 59957 "SP NoSender Subscriber"
+{
+    SingleInstance = true;
+    var
+        ReceivedValue: Integer;
+
+    [EventSubscriber(ObjectType::Codeunit, Codeunit::"SP NoSender Publisher", OnSimpleEvent, '', true, true)]
+    local procedure HandleSimpleEvent(Value: Integer)
+    begin
+        ReceivedValue := Value;
+    end;
+}

--- a/tests/bucket-2/102-sender-pattern/test/SenderPatternTest.al
+++ b/tests/bucket-2/102-sender-pattern/test/SenderPatternTest.al
@@ -1,0 +1,87 @@
+codeunit 59958 "SP Tests"
+{
+    Subtype = Test;
+    var
+        Assert: Codeunit Assert;
+
+    [Test]
+    procedure IntegrationEventSenderReceived()
+    var
+        Publisher: Codeunit "SP Publisher";
+        Result: Integer;
+    begin
+        // Positive: IntegrationEvent(true, false) passes the sender instance.
+        // Subscriber reads sender.GetState() which publisher set to Value*2.
+        Result := Publisher.Process(21);
+        Assert.AreEqual(42, Result, 'Process should return Value*2');
+        // If sender dispatch works, the subscriber was called without crashing.
+        // The test proves the sender parameter is correctly forwarded.
+    end;
+
+    [Test]
+    procedure IntegrationEventSenderNotPassedCrashes()
+    var
+        Publisher: Codeunit "SP Publisher";
+    begin
+        // Negative: if sender is NOT passed, the subscriber receives the first
+        // event arg (Integer) where it expects MockCodeunitHandle, causing a
+        // type conversion error. This test proves sender IS passed.
+        // Without the fix, this entire test suite would crash.
+        Publisher.Process(1);
+        Assert.IsTrue(true, 'Should not crash — sender was forwarded correctly');
+    end;
+
+    [Test]
+    procedure BusinessEventSenderReceived()
+    var
+        Publisher: Codeunit "SP BizPublisher";
+    begin
+        // Positive: BusinessEvent(true) also passes sender.
+        Publisher.PostOrder(100);
+        // If sender dispatch works, no crash occurs.
+        Assert.AreEqual(100, Publisher.GetOrderNo(), 'Publisher should have set order no');
+    end;
+
+    [Test]
+    procedure SenderWithVarParamsModifiesValue()
+    var
+        Publisher: Codeunit "SP MixedPublisher";
+        Value: Integer;
+        Ok: Boolean;
+    begin
+        // Positive: sender + var params work together.
+        // Subscriber reads sender.GetTag() and when "override", sets Value=999.
+        Publisher.SetTag('override');
+        Value := 10;
+        Ok := Publisher.Validate(Value);
+        Assert.IsTrue(Ok, 'Validate should return true (handled by subscriber)');
+        Assert.AreEqual(999, Value, 'Subscriber should have overridden value to 999');
+    end;
+
+    [Test]
+    procedure SenderWithVarParamsNoOverride()
+    var
+        Publisher: Codeunit "SP MixedPublisher";
+        Value: Integer;
+        Ok: Boolean;
+    begin
+        // Negative: when sender.GetTag() is not "override", subscriber does nothing.
+        // Normal validation runs (Value >= 0 → true).
+        Publisher.SetTag('normal');
+        Value := 10;
+        Ok := Publisher.Validate(Value);
+        Assert.IsTrue(Ok, 'Validate should return true (positive value)');
+        Assert.AreEqual(10, Value, 'Value should be unchanged');
+    end;
+
+    [Test]
+    procedure NoSenderStillWorks()
+    var
+        Publisher: Codeunit "SP NoSender Publisher";
+    begin
+        // Control: IntegrationEvent(false, false) without sender still works.
+        // Ensures sender injection doesn't break non-sender events.
+        Publisher.Fire(77);
+        Assert.IsTrue(true, 'No-sender event should work unchanged');
+    end;
+}

--- a/tests/bucket-2/103-before-db-events/src/BeforeDbEvents.al
+++ b/tests/bucket-2/103-before-db-events/src/BeforeDbEvents.al
@@ -1,0 +1,105 @@
+// Tests for OnBefore* DB trigger events: OnBeforeInsertEvent, OnBeforeModifyEvent, OnBeforeDeleteEvent.
+// These fire BEFORE the database operation and before the table trigger.
+// Uses deterministic PKs per event type to avoid SingleInstance dependency.
+
+table 59960 "BDE Source"
+{
+    fields
+    {
+        field(1; PK; Integer) { }
+        field(2; Name; Text[100]) { }
+    }
+    keys { key(PK; PK) { Clustered = true; } }
+}
+
+table 59961 "BDE EventLog"
+{
+    fields
+    {
+        field(1; PK; Integer) { }
+        field(2; EventType; Text[50]) { }
+        field(3; RecName; Text[100]) { }
+        field(4; XRecName; Text[100]) { }
+    }
+    keys { key(PK; PK) { Clustered = true; } }
+}
+
+codeunit 59960 "BDE Subscriber"
+{
+    // Deterministic PKs: BeforeInsert=1, AfterInsert=2, BeforeModify=3,
+    // AfterModify=4, BeforeDelete=5, AfterDelete=6
+
+    [EventSubscriber(ObjectType::Table, Database::"BDE Source", OnBeforeInsertEvent, '', true, true)]
+    local procedure HandleBeforeInsert(var Rec: Record "BDE Source")
+    var
+        Log: Record "BDE EventLog";
+    begin
+        Log.PK := 1;
+        Log.EventType := 'BeforeInsert';
+        Log.RecName := Rec.Name;
+        if not Log.Insert() then
+            Log.Modify();
+    end;
+
+    [EventSubscriber(ObjectType::Table, Database::"BDE Source", OnAfterInsertEvent, '', true, true)]
+    local procedure HandleAfterInsert(var Rec: Record "BDE Source")
+    var
+        Log: Record "BDE EventLog";
+    begin
+        Log.PK := 2;
+        Log.EventType := 'AfterInsert';
+        Log.RecName := Rec.Name;
+        if not Log.Insert() then
+            Log.Modify();
+    end;
+
+    [EventSubscriber(ObjectType::Table, Database::"BDE Source", OnBeforeModifyEvent, '', true, true)]
+    local procedure HandleBeforeModify(var Rec: Record "BDE Source"; var xRec: Record "BDE Source")
+    var
+        Log: Record "BDE EventLog";
+    begin
+        Log.PK := 3;
+        Log.EventType := 'BeforeModify';
+        Log.RecName := Rec.Name;
+        Log.XRecName := xRec.Name;
+        if not Log.Insert() then
+            Log.Modify();
+    end;
+
+    [EventSubscriber(ObjectType::Table, Database::"BDE Source", OnAfterModifyEvent, '', true, true)]
+    local procedure HandleAfterModify(var Rec: Record "BDE Source"; var xRec: Record "BDE Source")
+    var
+        Log: Record "BDE EventLog";
+    begin
+        Log.PK := 4;
+        Log.EventType := 'AfterModify';
+        Log.RecName := Rec.Name;
+        Log.XRecName := xRec.Name;
+        if not Log.Insert() then
+            Log.Modify();
+    end;
+
+    [EventSubscriber(ObjectType::Table, Database::"BDE Source", OnBeforeDeleteEvent, '', true, true)]
+    local procedure HandleBeforeDelete(var Rec: Record "BDE Source")
+    var
+        Log: Record "BDE EventLog";
+    begin
+        Log.PK := 5;
+        Log.EventType := 'BeforeDelete';
+        Log.RecName := Rec.Name;
+        if not Log.Insert() then
+            Log.Modify();
+    end;
+
+    [EventSubscriber(ObjectType::Table, Database::"BDE Source", OnAfterDeleteEvent, '', true, true)]
+    local procedure HandleAfterDelete(var Rec: Record "BDE Source")
+    var
+        Log: Record "BDE EventLog";
+    begin
+        Log.PK := 6;
+        Log.EventType := 'AfterDelete';
+        Log.RecName := Rec.Name;
+        if not Log.Insert() then
+            Log.Modify();
+    end;
+}

--- a/tests/bucket-2/103-before-db-events/test/BeforeDbEventsTest.al
+++ b/tests/bucket-2/103-before-db-events/test/BeforeDbEventsTest.al
@@ -1,0 +1,133 @@
+codeunit 59962 "BDE Tests"
+{
+    Subtype = Test;
+    var
+        Assert: Codeunit Assert;
+
+    [Test]
+    procedure OnBeforeInsertEventFires()
+    var
+        Src: Record "BDE Source";
+        Log: Record "BDE EventLog";
+    begin
+        // Positive: OnBeforeInsertEvent fires when Insert() is called.
+        Src.PK := 1;
+        Src.Name := 'Alice';
+        Src.Insert();
+
+        Assert.IsTrue(Log.Get(1), 'OnBeforeInsertEvent should have fired (Log PK=1)');
+        Assert.AreEqual('BeforeInsert', Log.EventType, 'Event type should be BeforeInsert');
+        Assert.AreEqual('Alice', Log.RecName, 'Rec.Name should be passed to subscriber');
+    end;
+
+    [Test]
+    procedure OnBeforeModifyEventFires()
+    var
+        Src: Record "BDE Source";
+        Log: Record "BDE EventLog";
+    begin
+        // Positive: OnBeforeModifyEvent fires when Modify() is called.
+        Src.PK := 1;
+        Src.Name := 'Original';
+        Src.Insert();
+
+        Src.Name := 'Changed';
+        Src.Modify();
+
+        Assert.IsTrue(Log.Get(3), 'OnBeforeModifyEvent should have fired (Log PK=3)');
+        Assert.AreEqual('BeforeModify', Log.EventType, 'Event type should be BeforeModify');
+        Assert.AreEqual('Changed', Log.RecName, 'Rec.Name should be the new value');
+    end;
+
+    [Test]
+    procedure OnBeforeDeleteEventFires()
+    var
+        Src: Record "BDE Source";
+        Log: Record "BDE EventLog";
+    begin
+        // Positive: OnBeforeDeleteEvent fires when Delete() is called.
+        Src.PK := 1;
+        Src.Name := 'ToDelete';
+        Src.Insert();
+        Src.Delete();
+
+        Assert.IsTrue(Log.Get(5), 'OnBeforeDeleteEvent should have fired (Log PK=5)');
+        Assert.AreEqual('BeforeDelete', Log.EventType, 'Event type should be BeforeDelete');
+        Assert.AreEqual('ToDelete', Log.RecName, 'Rec.Name should be passed');
+    end;
+
+    [Test]
+    procedure InsertFiresBothBeforeAndAfter()
+    var
+        Src: Record "BDE Source";
+        BeforeLog: Record "BDE EventLog";
+        AfterLog: Record "BDE EventLog";
+    begin
+        // Positive: both OnBefore and OnAfter fire for Insert.
+        Src.PK := 1;
+        Src.Name := 'Both';
+        Src.Insert();
+
+        Assert.IsTrue(BeforeLog.Get(1), 'OnBeforeInsertEvent should have fired');
+        Assert.AreEqual('BeforeInsert', BeforeLog.EventType, 'Should be BeforeInsert');
+
+        Assert.IsTrue(AfterLog.Get(2), 'OnAfterInsertEvent should have fired');
+        Assert.AreEqual('AfterInsert', AfterLog.EventType, 'Should be AfterInsert');
+    end;
+
+    [Test]
+    procedure ModifyFiresBothBeforeAndAfter()
+    var
+        Src: Record "BDE Source";
+        BeforeLog: Record "BDE EventLog";
+        AfterLog: Record "BDE EventLog";
+    begin
+        Src.PK := 1;
+        Src.Name := 'Orig';
+        Src.Insert();
+
+        Src.Name := 'New';
+        Src.Modify();
+
+        Assert.IsTrue(BeforeLog.Get(3), 'OnBeforeModifyEvent should have fired');
+        Assert.AreEqual('BeforeModify', BeforeLog.EventType, 'Should be BeforeModify');
+
+        Assert.IsTrue(AfterLog.Get(4), 'OnAfterModifyEvent should have fired');
+        Assert.AreEqual('AfterModify', AfterLog.EventType, 'Should be AfterModify');
+    end;
+
+    [Test]
+    procedure DeleteFiresBothBeforeAndAfter()
+    var
+        Src: Record "BDE Source";
+        BeforeLog: Record "BDE EventLog";
+        AfterLog: Record "BDE EventLog";
+    begin
+        Src.PK := 1;
+        Src.Name := 'Del';
+        Src.Insert();
+        Src.Delete();
+
+        Assert.IsTrue(BeforeLog.Get(5), 'OnBeforeDeleteEvent should have fired');
+        Assert.AreEqual('BeforeDelete', BeforeLog.EventType, 'Should be BeforeDelete');
+
+        Assert.IsTrue(AfterLog.Get(6), 'OnAfterDeleteEvent should have fired');
+        Assert.AreEqual('AfterDelete', AfterLog.EventType, 'Should be AfterDelete');
+    end;
+
+    [Test]
+    procedure NoEventLogForUnsubscribedEvent()
+    var
+        Src: Record "BDE Source";
+        Log: Record "BDE EventLog";
+    begin
+        // Negative: only events with subscribers produce log entries.
+        Src.PK := 1;
+        Src.Name := 'Test';
+        Src.Insert();
+
+        // Log should only have BeforeInsert (PK=1) and AfterInsert (PK=2)
+        Log.SetRange(EventType, 'BeforeModify');
+        Assert.IsFalse(Log.FindFirst(), 'No Modify happened — no BeforeModify log');
+    end;
+}

--- a/tests/bucket-2/104-xrec-behavior/src/XRecBehavior.al
+++ b/tests/bucket-2/104-xrec-behavior/src/XRecBehavior.al
@@ -1,0 +1,63 @@
+// Tests for xRec behavior when modifying records from code (not from pages).
+// In BC, xRec from the code path has the SAME values as Rec (new values, not old).
+// This is a known BC quirk — xRec is only correctly populated from page triggers.
+// This test suite documents and verifies that behavior.
+// Uses deterministic PKs: BeforeModify=1, AfterModify=2
+
+table 59965 "XR Source"
+{
+    fields
+    {
+        field(1; PK; Integer) { }
+        field(2; Name; Text[100]) { }
+        field(3; Amount; Integer) { }
+    }
+    keys { key(PK; PK) { Clustered = true; } }
+}
+
+table 59966 "XR EventLog"
+{
+    fields
+    {
+        field(1; PK; Integer) { }
+        field(2; EventType; Text[50]) { }
+        field(3; RecName; Text[100]) { }
+        field(4; XRecName; Text[100]) { }
+        field(5; RecAmount; Integer) { }
+        field(6; XRecAmount; Integer) { }
+    }
+    keys { key(PK; PK) { Clustered = true; } }
+}
+
+codeunit 59965 "XR Subscriber"
+{
+    [EventSubscriber(ObjectType::Table, Database::"XR Source", OnBeforeModifyEvent, '', true, true)]
+    local procedure HandleBeforeModify(var Rec: Record "XR Source"; var xRec: Record "XR Source")
+    var
+        Log: Record "XR EventLog";
+    begin
+        Log.PK := 1;
+        Log.EventType := 'BeforeModify';
+        Log.RecName := Rec.Name;
+        Log.XRecName := xRec.Name;
+        Log.RecAmount := Rec.Amount;
+        Log.XRecAmount := xRec.Amount;
+        if not Log.Insert() then
+            Log.Modify();
+    end;
+
+    [EventSubscriber(ObjectType::Table, Database::"XR Source", OnAfterModifyEvent, '', true, true)]
+    local procedure HandleAfterModify(var Rec: Record "XR Source"; var xRec: Record "XR Source")
+    var
+        Log: Record "XR EventLog";
+    begin
+        Log.PK := 2;
+        Log.EventType := 'AfterModify';
+        Log.RecName := Rec.Name;
+        Log.XRecName := xRec.Name;
+        Log.RecAmount := Rec.Amount;
+        Log.XRecAmount := xRec.Amount;
+        if not Log.Insert() then
+            Log.Modify();
+    end;
+}

--- a/tests/bucket-2/104-xrec-behavior/test/XRecBehaviorTest.al
+++ b/tests/bucket-2/104-xrec-behavior/test/XRecBehaviorTest.al
@@ -1,0 +1,81 @@
+codeunit 59966 "XR Tests"
+{
+    Subtype = Test;
+    var
+        Assert: Codeunit Assert;
+
+    [Test]
+    procedure XRecFromCodeHasNewValues()
+    var
+        Src: Record "XR Source";
+        Log: Record "XR EventLog";
+    begin
+        // In BC, when modifying from code (Rec.Modify()), xRec has the SAME
+        // values as Rec (new values). This is a known BC behavior — xRec is
+        // only correctly populated with old values from page triggers.
+        Src.PK := 1;
+        Src.Name := 'Original';
+        Src.Amount := 100;
+        Src.Insert();
+
+        Src.Name := 'Changed';
+        Src.Amount := 200;
+        Src.Modify();
+
+        Assert.IsTrue(Log.Get(1), 'BeforeModify log should exist');
+        Assert.AreEqual('Changed', Log.RecName, 'Rec.Name should be new value');
+        // BC quirk: xRec from code has new values, not old
+        Assert.AreEqual('Changed', Log.XRecName, 'xRec.Name from code should equal Rec.Name');
+        Assert.AreEqual(200, Log.RecAmount, 'Rec.Amount should be new value');
+        Assert.AreEqual(200, Log.XRecAmount, 'xRec.Amount from code should equal Rec.Amount');
+    end;
+
+    [Test]
+    procedure XRecConsistentBetweenBeforeAndAfter()
+    var
+        Src: Record "XR Source";
+        BeforeLog: Record "XR EventLog";
+        AfterLog: Record "XR EventLog";
+    begin
+        // Both OnBefore and OnAfter should see the same xRec behavior.
+        Src.PK := 1;
+        Src.Name := 'Start';
+        Src.Amount := 50;
+        Src.Insert();
+
+        Src.Name := 'End';
+        Src.Amount := 150;
+        Src.Modify();
+
+        Assert.IsTrue(BeforeLog.Get(1), 'BeforeModify log should exist');
+        Assert.IsTrue(AfterLog.Get(2), 'AfterModify log should exist');
+
+        // Both events should see same xRec values (both = new values from code)
+        Assert.AreEqual(BeforeLog.XRecName, AfterLog.XRecName, 'xRec should be consistent');
+        Assert.AreEqual(BeforeLog.XRecAmount, AfterLog.XRecAmount, 'xRec.Amount should be consistent');
+    end;
+
+    [Test]
+    procedure XRecNameAndAmountBothMatchRec()
+    var
+        Src: Record "XR Source";
+        Log: Record "XR EventLog";
+    begin
+        // Verify that ALL fields in xRec match Rec (not just Name).
+        Src.PK := 1;
+        Src.Name := 'Alice';
+        Src.Amount := 999;
+        Src.Insert();
+
+        Src.Name := 'Bob';
+        Src.Amount := 42;
+        Src.Modify();
+
+        // Check AfterModify log (PK=2)
+        Assert.IsTrue(Log.Get(2), 'AfterModify log should exist');
+        Assert.AreEqual('Bob', Log.RecName, 'Rec.Name should be Bob');
+        Assert.AreEqual('Bob', Log.XRecName, 'xRec.Name should also be Bob (code path)');
+        Assert.AreEqual(42, Log.RecAmount, 'Rec.Amount should be 42');
+        Assert.AreEqual(42, Log.XRecAmount, 'xRec.Amount should also be 42 (code path)');
+    end;
+}

--- a/tests/bucket-2/105-subscriber-error/src/SubscriberError.al
+++ b/tests/bucket-2/105-subscriber-error/src/SubscriberError.al
@@ -1,0 +1,26 @@
+// Tests for subscriber error propagation and asserterror interception.
+// When a subscriber throws an error, it should propagate to the caller.
+// The caller can catch it with asserterror.
+
+codeunit 59970 "SE Publisher"
+{
+    [IntegrationEvent(false, false)]
+    procedure OnProcess(Value: Integer)
+    begin
+    end;
+
+    procedure Process(Value: Integer)
+    begin
+        OnProcess(Value);
+    end;
+}
+
+codeunit 59971 "SE ErrorSubscriber"
+{
+    [EventSubscriber(ObjectType::Codeunit, Codeunit::"SE Publisher", OnProcess, '', true, true)]
+    local procedure HandleProcess(Value: Integer)
+    begin
+        if Value < 0 then
+            Error('Negative value not allowed: %1', Value);
+    end;
+}

--- a/tests/bucket-2/105-subscriber-error/test/SubscriberErrorTest.al
+++ b/tests/bucket-2/105-subscriber-error/test/SubscriberErrorTest.al
@@ -1,0 +1,50 @@
+codeunit 59972 "SE Tests"
+{
+    Subtype = Test;
+    var
+        Assert: Codeunit Assert;
+
+    [Test]
+    procedure SubscriberErrorPropagates()
+    var
+        Publisher: Codeunit "SE Publisher";
+    begin
+        // Positive: subscriber error propagates to caller and can be caught.
+        asserterror Publisher.Process(-5);
+        Assert.ExpectedError('Negative value not allowed');
+    end;
+
+    [Test]
+    procedure SubscriberNoErrorOnValidInput()
+    var
+        Publisher: Codeunit "SE Publisher";
+    begin
+        // Positive: valid input doesn't trigger subscriber error.
+        Publisher.Process(10);
+        Assert.IsTrue(true, 'Should not throw on valid input');
+    end;
+
+    [Test]
+    procedure SubscriberErrorIncludesValue()
+    var
+        Publisher: Codeunit "SE Publisher";
+    begin
+        // Positive: error message includes the formatted value.
+        asserterror Publisher.Process(-42);
+        Assert.ExpectedError('-42');
+    end;
+
+    [Test]
+    procedure MultipleCallsIndependent()
+    var
+        Publisher: Codeunit "SE Publisher";
+    begin
+        // Positive: each call is independent — error on one doesn't affect next.
+        asserterror Publisher.Process(-1);
+        Assert.ExpectedError('Negative value not allowed');
+
+        // Next call with valid input should succeed
+        Publisher.Process(1);
+        Assert.IsTrue(true, 'Valid call after error should succeed');
+    end;
+}

--- a/tests/bucket-2/97-event-params/src/EventParams.al
+++ b/tests/bucket-2/97-event-params/src/EventParams.al
@@ -1,0 +1,30 @@
+codeunit 59701 "EP Publisher"
+{
+    [IntegrationEvent(false, false)]
+    procedure OnBeforeCalc(var Amount: Integer; var IsHandled: Boolean)
+    begin
+    end;
+
+    procedure CalcWithEvent(BaseAmount: Integer): Integer
+    var
+        Result: Integer;
+        Handled: Boolean;
+    begin
+        Result := BaseAmount;
+        Handled := false;
+        OnBeforeCalc(Result, Handled);
+        if Handled then
+            exit(Result);
+        exit(Result * 2);
+    end;
+}
+
+codeunit 59702 "EP Subscriber"
+{
+    [EventSubscriber(ObjectType::Codeunit, Codeunit::"EP Publisher", 'OnBeforeCalc', '', true, true)]
+    local procedure HandleBeforeCalc(var Amount: Integer; var IsHandled: Boolean)
+    begin
+        Amount := Amount + 100;
+        IsHandled := true;
+    end;
+}

--- a/tests/bucket-2/97-event-params/test/EventParamsTest.al
+++ b/tests/bucket-2/97-event-params/test/EventParamsTest.al
@@ -1,0 +1,33 @@
+codeunit 59703 "EP Tests"
+{
+    Subtype = Test;
+    var
+        Assert: Codeunit Assert;
+
+    [Test]
+    procedure SubscriberReceivesAndModifiesVarParams()
+    var
+        Publisher: Codeunit "EP Publisher";
+        Result: Integer;
+    begin
+        // Positive: subscriber receives var params and modifies them.
+        // Subscriber adds 100 to Amount and sets IsHandled=true,
+        // so CalcWithEvent returns Amount+100 instead of Amount*2.
+        Result := Publisher.CalcWithEvent(10);
+        Assert.AreEqual(110, Result, 'Subscriber should have added 100 and set IsHandled');
+    end;
+
+    [Test]
+    procedure SubscriberParamsNotForwardedMeansDoubling()
+    var
+        Publisher: Codeunit "EP Publisher";
+        Result: Integer;
+    begin
+        // Negative: if subscriber params were NOT forwarded (the old bug),
+        // IsHandled stays false and result would be 10*2=20.
+        // With params forwarded, result is 110.
+        // This test verifies the params are actually forwarded.
+        Result := Publisher.CalcWithEvent(5);
+        Assert.AreEqual(105, Result, 'Subscriber should have modified var params; got doubling instead');
+    end;
+}

--- a/tests/bucket-2/98-db-trigger-events/src/DbTriggerEvents.al
+++ b/tests/bucket-2/98-db-trigger-events/src/DbTriggerEvents.al
@@ -1,0 +1,69 @@
+table 59801 "DTE Source"
+{
+    fields
+    {
+        field(1; PK; Integer) { }
+        field(2; Name; Text[100]) { }
+    }
+    keys { key(PK; PK) { Clustered = true; } }
+}
+
+table 59802 "DTE Counter"
+{
+    fields
+    {
+        field(1; PK; Integer) { }
+        field(2; InsertCount; Integer) { }
+        field(3; ModifyCount; Integer) { }
+        field(4; DeleteCount; Integer) { }
+    }
+    keys { key(PK; PK) { Clustered = true; } }
+}
+
+codeunit 59801 "DTE Subscriber"
+{
+    [EventSubscriber(ObjectType::Table, Database::"DTE Source", OnAfterInsertEvent, '', true, true)]
+    local procedure OnAfterInsert(var Rec: Record "DTE Source")
+    var
+        C: Record "DTE Counter";
+    begin
+        if not C.Get(1) then begin
+            C.PK := 1;
+            C.InsertCount := 1;
+            C.Insert();
+        end else begin
+            C.InsertCount += 1;
+            C.Modify();
+        end;
+    end;
+
+    [EventSubscriber(ObjectType::Table, Database::"DTE Source", OnAfterModifyEvent, '', true, true)]
+    local procedure OnAfterModify(var Rec: Record "DTE Source"; var xRec: Record "DTE Source")
+    var
+        C: Record "DTE Counter";
+    begin
+        if not C.Get(1) then begin
+            C.PK := 1;
+            C.ModifyCount := 1;
+            C.Insert();
+        end else begin
+            C.ModifyCount += 1;
+            C.Modify();
+        end;
+    end;
+
+    [EventSubscriber(ObjectType::Table, Database::"DTE Source", OnAfterDeleteEvent, '', true, true)]
+    local procedure OnAfterDelete(var Rec: Record "DTE Source")
+    var
+        C: Record "DTE Counter";
+    begin
+        if not C.Get(1) then begin
+            C.PK := 1;
+            C.DeleteCount := 1;
+            C.Insert();
+        end else begin
+            C.DeleteCount += 1;
+            C.Modify();
+        end;
+    end;
+}

--- a/tests/bucket-2/98-db-trigger-events/test/DbTriggerEventsTest.al
+++ b/tests/bucket-2/98-db-trigger-events/test/DbTriggerEventsTest.al
@@ -1,0 +1,86 @@
+codeunit 59802 "DTE Tests"
+{
+    Subtype = Test;
+    var
+        Assert: Codeunit Assert;
+
+    [Test]
+    procedure OnAfterInsertEventFires()
+    var
+        Src: Record "DTE Source";
+        C: Record "DTE Counter";
+    begin
+        // Positive: inserting a record fires OnAfterInsertEvent subscriber
+        Src.PK := 1;
+        Src.Name := 'Test';
+        Src.Insert();
+
+        Assert.IsTrue(C.Get(1), 'Counter should exist after insert event');
+        Assert.AreEqual(1, C.InsertCount, 'Insert subscriber should have fired once');
+    end;
+
+    [Test]
+    procedure OnAfterModifyEventFires()
+    var
+        Src: Record "DTE Source";
+        C: Record "DTE Counter";
+    begin
+        // Positive: modifying a record fires OnAfterModifyEvent subscriber
+        Src.PK := 1;
+        Src.Name := 'Original';
+        Src.Insert();
+
+        Src.Name := 'Modified';
+        Src.Modify();
+
+        Assert.IsTrue(C.Get(1), 'Counter should exist after events');
+        Assert.AreEqual(1, C.ModifyCount, 'Modify subscriber should have fired once');
+    end;
+
+    [Test]
+    procedure OnAfterDeleteEventFires()
+    var
+        Src: Record "DTE Source";
+        C: Record "DTE Counter";
+    begin
+        // Positive: deleting a record fires OnAfterDeleteEvent subscriber
+        Src.PK := 1;
+        Src.Name := 'ToDelete';
+        Src.Insert();
+
+        Src.Delete();
+
+        Assert.IsTrue(C.Get(1), 'Counter should exist after events');
+        Assert.AreEqual(1, C.DeleteCount, 'Delete subscriber should have fired once');
+    end;
+
+    [Test]
+    procedure MultipleInsertsFireMultipleEvents()
+    var
+        Src: Record "DTE Source";
+        C: Record "DTE Counter";
+    begin
+        // Positive: each insert fires its own event
+        Src.PK := 1;
+        Src.Insert();
+        Src.PK := 2;
+        Src.Insert();
+        Src.PK := 3;
+        Src.Insert();
+
+        Assert.IsTrue(C.Get(1), 'Counter should exist');
+        Assert.AreEqual(3, C.InsertCount, 'Insert subscriber should have fired 3 times');
+    end;
+
+    [Test]
+    procedure NoEventWithoutSubscriber()
+    var
+        Src: Record "DTE Source";
+        C: Record "DTE Counter";
+    begin
+        // Negative: counter table should have no records when no operations
+        // were done on the source table. This proves the counter is reset
+        // between tests and only incremented by event subscribers.
+        Assert.IsFalse(C.Get(1), 'Counter should not exist without source operations');
+    end;
+}

--- a/tests/bucket-2/99-validate-events/src/ValidateEvents.al
+++ b/tests/bucket-2/99-validate-events/src/ValidateEvents.al
@@ -1,0 +1,64 @@
+table 59901 "VTE Source"
+{
+    fields
+    {
+        field(1; PK; Integer) { }
+        field(2; Amount; Decimal)
+        {
+            trigger OnValidate()
+            begin
+                // Normal trigger body — runs when runTrigger=true
+            end;
+        }
+    }
+    keys { key(PK; PK) { Clustered = true; } }
+}
+
+table 59902 "VTE Counter"
+{
+    fields
+    {
+        field(1; PK; Integer) { }
+        field(2; BeforeCount; Integer) { }
+        field(3; AfterCount; Integer) { }
+        field(4; LastFieldNo; Integer) { }
+    }
+    keys { key(PK; PK) { Clustered = true; } }
+}
+
+codeunit 59901 "VTE Subscriber"
+{
+    [EventSubscriber(ObjectType::Table, Database::"VTE Source", OnBeforeValidateEvent, '', true, true)]
+    local procedure OnBeforeValidate(var Rec: Record "VTE Source"; var xRec: Record "VTE Source"; CurrFieldNo: Integer)
+    var
+        C: Record "VTE Counter";
+    begin
+        if not C.Get(1) then begin
+            C.PK := 1;
+            C.BeforeCount := 1;
+            C.LastFieldNo := CurrFieldNo;
+            C.Insert();
+        end else begin
+            C.BeforeCount += 1;
+            C.LastFieldNo := CurrFieldNo;
+            C.Modify();
+        end;
+    end;
+
+    [EventSubscriber(ObjectType::Table, Database::"VTE Source", OnAfterValidateEvent, '', true, true)]
+    local procedure OnAfterValidate(var Rec: Record "VTE Source"; var xRec: Record "VTE Source"; CurrFieldNo: Integer)
+    var
+        C: Record "VTE Counter";
+    begin
+        if not C.Get(1) then begin
+            C.PK := 1;
+            C.AfterCount := 1;
+            C.LastFieldNo := CurrFieldNo;
+            C.Insert();
+        end else begin
+            C.AfterCount += 1;
+            C.LastFieldNo := CurrFieldNo;
+            C.Modify();
+        end;
+    end;
+}

--- a/tests/bucket-2/99-validate-events/test/ValidateEventsTest.al
+++ b/tests/bucket-2/99-validate-events/test/ValidateEventsTest.al
@@ -1,0 +1,48 @@
+codeunit 59902 "VTE Tests"
+{
+    Subtype = Test;
+    var
+        Assert: Codeunit Assert;
+
+    [Test]
+    procedure ValidateFieldFiresBeforeAndAfterEvents()
+    var
+        Src: Record "VTE Source";
+        C: Record "VTE Counter";
+    begin
+        // Positive: validating a field fires both OnBeforeValidate and OnAfterValidate
+        Src.PK := 1;
+        Src.Insert();
+
+        Src.Validate(Amount, 100.0);
+
+        Assert.IsTrue(C.Get(1), 'Counter should exist after validate events');
+        Assert.AreEqual(1, C.BeforeCount, 'OnBeforeValidate should have fired once');
+        Assert.AreEqual(1, C.AfterCount, 'OnAfterValidate should have fired once');
+    end;
+
+    [Test]
+    procedure ValidateEventReceivesCorrectFieldNo()
+    var
+        Src: Record "VTE Source";
+        C: Record "VTE Counter";
+    begin
+        // Positive: subscriber receives the correct CurrFieldNo
+        Src.PK := 1;
+        Src.Insert();
+
+        Src.Validate(Amount, 50.0);
+
+        Assert.IsTrue(C.Get(1), 'Counter should exist');
+        Assert.AreEqual(2, C.LastFieldNo, 'CurrFieldNo should be 2 (Amount field)');
+    end;
+
+    [Test]
+    procedure NoValidateEventWithoutValidateCall()
+    var
+        C: Record "VTE Counter";
+    begin
+        // Negative: no validate events fire without actual Validate call
+        Assert.IsFalse(C.Get(1), 'No counter should exist without validate');
+    end;
+}


### PR DESCRIPTION
## Summary

Closes #116 — implements three major event infrastructure features that were causing false-positive test results.

### 1. Event parameter forwarding
Publisher event arguments (`ByRef<T>` and value parameters) are now forwarded from `βscope.RunEvent()` to subscriber methods. Subscriber mutations to `var` parameters (e.g. `var IsHandled: Boolean`) propagate back correctly.

### 2. Implicit DB trigger events
`MockRecordHandle` now fires:
- `OnBefore/AfterInsertEvent` from `ALInsert`
- `OnBefore/AfterModifyEvent` from `ALModify`
- `OnBefore/AfterDeleteEvent` from `ALDelete`
- `OnBefore/AfterValidateEvent` from `ALValidateSafe`/`ALValidate`

Events fire regardless of `runTrigger` (matching BC behavior). xRec snapshots are captured before mutations.

### 3. BindSubscription / UnbindSubscription
- Rewriter detects `NavCodeunitOptions.EventManualBinding` and emits `[ManualEventSubscriber]` marker
- `ALBindSubscription`/`ALUnbindSubscription` rewritten to `MockCodeunitHandle.Bind()`/`Unbind()`
- Manual subscribers only fire when bound; bindings reset between tests

### Supporting changes
- `EventSubscriberRegistry` refactored to 3-tuple key `(ObjectType, ObjectId, EventName)` preventing table/codeunit ID collision
- `MockCodeunitHandle` gains `Bind()`/`Unbind()` + extracted `EnsureInstance()`
- `VisitAttributeList` bug fixed: replacement attrs no longer trigger unchanged-count shortcut

### Test coverage
15 new test cases across 5 suites:
| Suite | Tests | What it covers |
|-------|-------|----------------|
| 97-event-params | 2 | Publisher→subscriber parameter forwarding with ByRef |
| 98-db-trigger-events | 5 | OnAfterInsert/Modify/Delete implicit events |
| 99-validate-events | 3 | OnBefore/AfterValidateEvent with field numbers |
| 100-bind-subscription | 3 | Manual subscriber not-before-bind, after-bind, not-after-unbind |
| 101-multi-subscribers | 2 | Multiple subscribers on same event |

All 97 existing test suites pass with zero regressions.

### Remaining gaps (documented)
- `OnBefore/AfterRenameEvent` — not yet fired
- `ModifyAll`/`DeleteAll` — do not fire per-row events
- Table extension implicit event publishers — not wired