### PR TITLE
fix: honor DataError level in ALInsert and ALDelete

### DIFF
--- a/AlRunner/Runtime/MockRecordHandle.cs
+++ b/AlRunner/Runtime/MockRecordHandle.cs
@@ -279,16 +279,18 @@ public class MockRecordHandle
         if (runTrigger)
             TryFireRecordTrigger("OnInsert");
 
-        // Always enforce primary-key uniqueness.
+        // Enforce primary-key uniqueness.
         var pkFields = GetPrimaryKeyFields();
         foreach (var existing in table)
         {
             if (RowMatchesPrimaryKey(existing, _fields, pkFields))
             {
-                throw new Exception(
-                    $"The {TableName()} already exists. Identification fields and values: " +
-                    string.Join(", ", pkFields.Select(f =>
-                        $"{f}='{(_fields.TryGetValue(f, out var v) ? NavValueToString(v) : "")}'")));
+                if (errorLevel == DataError.ThrowError)
+                    throw new Exception(
+                        $"The {TableName()} already exists. Identification fields and values: " +
+                        string.Join(", ", pkFields.Select(f =>
+                            $"{f}='{(_fields.TryGetValue(f, out var v) ? NavValueToString(v) : "")}'")));
+                return false;
             }
         }
 
@@ -620,6 +622,11 @@ public class MockRecordHandle
                 return true;
             }
         }
+        if (errorLevel == DataError.ThrowError)
+            throw new Exception(
+                $"The {TableName()} does not exist. Identification fields and values: " +
+                string.Join(", ", pkFields.Select(f =>
+                    $"{f}='{(_fields.TryGetValue(f, out var v) ? NavValueToString(v) : "")}'")));
         return false;
     }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this project are documented here. Format based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), versioning follows
 [SemVer](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **`ALInsert` honors `DataError` level** — `MockRecordHandle.ALInsert()` now
+  checks the `errorLevel` parameter before throwing on duplicate primary key.
+  When AL code captures the return value (`if not Rec.Insert() then …`), the
+  BC compiler passes `DataError.Never` and the method returns `false` instead
+  of throwing. Previously it always threw regardless of error level. (#128)
+- **`ALDelete` throws on missing record** — `MockRecordHandle.ALDelete()` now
+  throws when the record does not exist and `errorLevel` is `DataError.ThrowError`
+  (i.e. the return value is not captured in AL). Previously it silently returned
+  `false` regardless of error level. (#128)
+
+### Added
+- **New test suite**: `106-dataerror-suppress` — 21 tests covering `DataError`
+  error-suppression behavior for Insert, Delete, Modify, Get, FindFirst,
+  FindLast, FindSet, and the real-world `if not Insert() then Modify()` pattern.
+
 ## [1.0.13] - 2026-04-14
 
 ### Added

--- a/tests/bucket-2/106-dataerror-suppress/src/DataErrorTable.al
+++ b/tests/bucket-2/106-dataerror-suppress/src/DataErrorTable.al
@@ -1,0 +1,9 @@
+table 59400 "DataError Probe"
+{
+    fields
+    {
+        field(1; "Entry No."; Integer) { }
+        field(2; Description; Text[50]) { }
+    }
+    keys { key(PK; "Entry No.") { Clustered = true; } }
+}

--- a/tests/bucket-2/106-dataerror-suppress/test/DataErrorTests.al
+++ b/tests/bucket-2/106-dataerror-suppress/test/DataErrorTests.al
@@ -1,0 +1,366 @@
+codeunit 59401 "DataError Suppress Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    // -----------------------------------------------------------------------
+    // INSERT: capturing return value should suppress the error
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure InsertDuplicateWithReturnDoesNotThrow()
+    var
+        R: Record "DataError Probe";
+        Ok: Boolean;
+    begin
+        // [GIVEN] A record already exists
+        R."Entry No." := 1;
+        R.Description := 'First';
+        R.Insert();
+
+        // [WHEN] Inserting a duplicate and capturing the return value
+        R.Description := 'Duplicate';
+        Ok := R.Insert();
+
+        // [THEN] Should return false, not throw
+        Assert.IsFalse(Ok, 'Insert of duplicate PK should return false when return captured');
+    end;
+
+    [Test]
+    procedure InsertDuplicateWithoutReturnThrows()
+    var
+        R: Record "DataError Probe";
+        Second: Record "DataError Probe";
+    begin
+        // [GIVEN] A record already exists
+        R."Entry No." := 1;
+        R.Insert();
+
+        // [WHEN] Inserting a duplicate without capturing the return value
+        asserterror begin
+            Second."Entry No." := 1;
+            Second.Insert();
+        end;
+
+        // [THEN] Should have thrown an error
+        Assert.ExpectedError('already exists');
+    end;
+
+    [Test]
+    procedure InsertUniqueWithReturnReturnsTrue()
+    var
+        R: Record "DataError Probe";
+        Ok: Boolean;
+    begin
+        // [WHEN] Inserting a unique record and capturing the return value
+        R."Entry No." := 1;
+        Ok := R.Insert();
+
+        // [THEN] Should return true
+        Assert.IsTrue(Ok, 'Insert of unique record should return true');
+    end;
+
+    // -----------------------------------------------------------------------
+    // DELETE: not capturing return value should throw when record missing
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure DeleteMissingWithReturnDoesNotThrow()
+    var
+        R: Record "DataError Probe";
+        Ok: Boolean;
+    begin
+        // [GIVEN] No records exist
+        // [WHEN] Deleting a non-existing record and capturing the return value
+        R."Entry No." := 999;
+        Ok := R.Delete();
+
+        // [THEN] Should return false, not throw
+        Assert.IsFalse(Ok, 'Delete of missing record should return false when return captured');
+    end;
+
+    [Test]
+    procedure DeleteMissingWithoutReturnThrows()
+    var
+        R: Record "DataError Probe";
+    begin
+        // [GIVEN] No records exist
+        // [WHEN] Deleting a non-existing record without capturing the return value
+        R."Entry No." := 999;
+        asserterror R.Delete();
+
+        // [THEN] Should have thrown an error
+        Assert.ExpectedError('does not exist');
+    end;
+
+    [Test]
+    procedure DeleteExistingReturnsTrue()
+    var
+        R: Record "DataError Probe";
+        Ok: Boolean;
+    begin
+        // [GIVEN] A record exists
+        R."Entry No." := 1;
+        R.Insert();
+
+        // [WHEN] Deleting the existing record
+        Ok := R.Delete();
+
+        // [THEN] Should return true
+        Assert.IsTrue(Ok, 'Delete of existing record should return true');
+    end;
+
+    // -----------------------------------------------------------------------
+    // MODIFY: verify existing errorLevel handling is correct
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure ModifyMissingWithReturnDoesNotThrow()
+    var
+        R: Record "DataError Probe";
+        Ok: Boolean;
+    begin
+        // [GIVEN] No records exist
+        // [WHEN] Modifying a non-existing record and capturing the return value
+        R."Entry No." := 999;
+        Ok := R.Modify();
+
+        // [THEN] Should return false, not throw
+        Assert.IsFalse(Ok, 'Modify of missing record should return false when return captured');
+    end;
+
+    [Test]
+    procedure ModifyMissingWithoutReturnThrows()
+    var
+        R: Record "DataError Probe";
+    begin
+        // [GIVEN] No records exist
+        // [WHEN] Modifying a non-existing record without capturing the return value
+        R."Entry No." := 999;
+        asserterror R.Modify();
+
+        // [THEN] Should have thrown an error
+        Assert.ExpectedError('Record not found');
+    end;
+
+    // -----------------------------------------------------------------------
+    // GET: verify existing errorLevel handling is correct
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure GetMissingWithReturnDoesNotThrow()
+    var
+        R: Record "DataError Probe";
+        Ok: Boolean;
+    begin
+        // [GIVEN] No records exist
+        // [WHEN] Getting a non-existing record and capturing the return value
+        Ok := R.Get(999);
+
+        // [THEN] Should return false, not throw
+        Assert.IsFalse(Ok, 'Get of missing record should return false when return captured');
+    end;
+
+    [Test]
+    procedure GetMissingWithoutReturnThrows()
+    var
+        R: Record "DataError Probe";
+    begin
+        // [GIVEN] No records exist
+        // [WHEN] Getting a non-existing record without capturing the return value
+        asserterror R.Get(999);
+
+        // [THEN] Should have thrown an error
+        Assert.ExpectedError('not found');
+    end;
+
+    // -----------------------------------------------------------------------
+    // FINDFIRST: verify existing errorLevel handling is correct
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure FindFirstEmptyWithReturnDoesNotThrow()
+    var
+        R: Record "DataError Probe";
+        Ok: Boolean;
+    begin
+        // [GIVEN] No records exist
+        // [WHEN] Finding first on empty table and capturing return
+        Ok := R.FindFirst();
+
+        // [THEN] Should return false, not throw
+        Assert.IsFalse(Ok, 'FindFirst on empty table should return false when return captured');
+    end;
+
+    [Test]
+    procedure FindFirstEmptyWithoutReturnThrows()
+    var
+        R: Record "DataError Probe";
+    begin
+        // [GIVEN] No records exist
+        // [WHEN] Finding first on empty table without capturing return
+        asserterror R.FindFirst();
+
+        // [THEN] Should have thrown an error
+        Assert.ExpectedError('No records in table');
+    end;
+
+    // -----------------------------------------------------------------------
+    // FINDLAST: verify existing errorLevel handling is correct
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure FindLastEmptyWithReturnDoesNotThrow()
+    var
+        R: Record "DataError Probe";
+        Ok: Boolean;
+    begin
+        // [GIVEN] No records exist
+        // [WHEN] Finding last on empty table and capturing return
+        Ok := R.FindLast();
+
+        // [THEN] Should return false, not throw
+        Assert.IsFalse(Ok, 'FindLast on empty table should return false when return captured');
+    end;
+
+    [Test]
+    procedure FindLastEmptyWithoutReturnThrows()
+    var
+        R: Record "DataError Probe";
+    begin
+        // [GIVEN] No records exist
+        // [WHEN] Finding last on empty table without capturing return
+        asserterror R.FindLast();
+
+        // [THEN] Should have thrown an error
+        Assert.ExpectedError('No records in table');
+    end;
+
+    // -----------------------------------------------------------------------
+    // FINDSET: verify existing errorLevel handling is correct
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure FindSetEmptyWithReturnDoesNotThrow()
+    var
+        R: Record "DataError Probe";
+        Ok: Boolean;
+    begin
+        // [GIVEN] No records exist
+        // [WHEN] FindSet on empty table and capturing return
+        Ok := R.FindSet();
+
+        // [THEN] Should return false, not throw
+        Assert.IsFalse(Ok, 'FindSet on empty table should return false when return captured');
+    end;
+
+    [Test]
+    procedure FindSetEmptyWithoutReturnThrows()
+    var
+        R: Record "DataError Probe";
+    begin
+        // [GIVEN] No records exist
+        // [WHEN] FindSet on empty table without capturing return
+        asserterror R.FindSet();
+
+        // [THEN] Should have thrown an error
+        Assert.ExpectedError('No records in table');
+    end;
+
+    // -----------------------------------------------------------------------
+    // Insert-or-Modify pattern (real-world pattern from issue)
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure InsertOrModifyPattern()
+    var
+        R: Record "DataError Probe";
+    begin
+        // [GIVEN] First insert works
+        R."Entry No." := 1;
+        R.Description := 'Original';
+        R.Insert();
+
+        // [WHEN] Using the defensive "if not Insert() then Modify()" pattern
+        R.Description := 'Updated';
+        if not R.Insert() then
+            R.Modify();
+
+        // [THEN] Record should have the updated description
+        R.Get(1);
+        Assert.AreEqual('Updated', R.Description, 'Insert-or-Modify should have updated the description');
+    end;
+
+    // -----------------------------------------------------------------------
+    // RunTrigger overload coverage (Insert(true)/Delete(true))
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure InsertDuplicateWithRunTriggerAndReturnDoesNotThrow()
+    var
+        R: Record "DataError Probe";
+        Ok: Boolean;
+    begin
+        // [GIVEN] A record already exists
+        R."Entry No." := 1;
+        R.Insert(true);
+
+        // [WHEN] Inserting a duplicate with RunTrigger=true and capturing return
+        R.Description := 'Dup';
+        Ok := R.Insert(true);
+
+        // [THEN] Should return false, not throw
+        Assert.IsFalse(Ok, 'Insert(true) of duplicate PK should return false when return captured');
+    end;
+
+    [Test]
+    procedure InsertDuplicateWithRunTriggerWithoutReturnThrows()
+    var
+        R: Record "DataError Probe";
+        Second: Record "DataError Probe";
+    begin
+        // [GIVEN] A record already exists
+        R."Entry No." := 1;
+        R.Insert(true);
+
+        // [WHEN] Inserting a duplicate with RunTrigger=true without capturing return
+        asserterror begin
+            Second."Entry No." := 1;
+            Second.Insert(true);
+        end;
+
+        // [THEN] Should have thrown an error
+        Assert.ExpectedError('already exists');
+    end;
+
+    [Test]
+    procedure DeleteMissingWithRunTriggerAndReturnDoesNotThrow()
+    var
+        R: Record "DataError Probe";
+        Ok: Boolean;
+    begin
+        // [GIVEN] No records exist
+        // [WHEN] Deleting a non-existing record with RunTrigger=true and capturing return
+        R."Entry No." := 999;
+        Ok := R.Delete(true);
+
+        // [THEN] Should return false, not throw
+        Assert.IsFalse(Ok, 'Delete(true) of missing record should return false when return captured');
+    end;
+
+    [Test]
+    procedure DeleteMissingWithRunTriggerWithoutReturnThrows()
+    var
+        R: Record "DataError Probe";
+    begin
+        // [GIVEN] No records exist
+        // [WHEN] Deleting a non-existing record with RunTrigger=true without capturing return
+        R."Entry No." := 999;
+        asserterror R.Delete(true);
+
+        // [THEN] Should have thrown an error
+        Assert.ExpectedError('does not exist');
+    end;
+}


### PR DESCRIPTION
## Problem

Fixes #128

`MockRecordHandle.ALInsert()` always threw on duplicate primary key regardless of the `errorLevel` parameter. In AL, when the return value is captured (`if not Rec.Insert() then …`), the BC compiler passes `DataError.Never` so the operation should return `false` instead of throwing.

Conversely, `MockRecordHandle.ALDelete()` never threw when the record was not found — it always returned `false` even when `errorLevel` was `DataError.ThrowError` (return value not captured).

## Scope

Audited all record operations that support the `[Ok := ]` optional return value pattern in AL:

| Method | Status |
|---|---|
| `ALInsert` | **Fixed** — now checks `errorLevel` before throwing on duplicate PK |
| `ALDelete` | **Fixed** — now throws when record missing and `errorLevel == ThrowError` |
| `ALModify` | ✅ Already correct |
| `ALGet` | ✅ Already correct |
| `ALGetBySystemId` | ✅ Already correct |
| `ALFind` | ✅ Already correct |
| `ALFindFirst/Last/Set` | ✅ Already correct (delegates to ALFind) |
| `ALRename` | ⚠️ Fundamentally broken stub — tracked separately |
| `Codeunit.Run` | ✅ Already correct (uses `DataError.TrapError`) |

## Changes

- `MockRecordHandle.ALInsert`: wrap throw in `if (errorLevel == DataError.ThrowError)`, return `false` otherwise
- `MockRecordHandle.ALDelete`: add throw when record not found and `errorLevel == DataError.ThrowError`
- New test suite `106-dataerror-suppress` — 21 tests covering Insert, Delete, Modify, Get, FindFirst, FindLast, FindSet, RunTrigger overloads, and the real-world `if not Insert() then Modify()` pattern

## Testing

All 100 test suites pass (0 failures).