### PR TITLE
fix: Skip RDLC layout generation + compilation gap telemetry

### DIFF
--- a/AlRunner.Tests/PipelineTests.cs
+++ b/AlRunner.Tests/PipelineTests.cs
@@ -329,4 +329,89 @@ namespace AlRunnerGenerated {
         // Full format shows at least "X passed, Y failed in N.Ns"
         Assert.Matches(@"\d+ passed, \d+ failed.*in \d+\.\d+s", result.StdOut);
     }
+
+    // ─── Compilation error deduplication ──────────────────────────────────────
+
+    [Fact]
+    public void DeduplicateCompilationErrors_GroupsByCSCodeAndType()
+    {
+        var errors = new List<string>
+        {
+            "Obj.cs(10,5): error CS1061: 'Report70400' does not contain a definition for 'amountDue'",
+            "Obj.cs(20,5): error CS1061: 'Report70400' does not contain a definition for 'Totals'",
+            "Obj.cs(30,5): error CS1061: 'Report70400' does not contain a definition for 'columnHead'",
+            "Obj.cs(40,5): error CS0103: The name 'privacyBlockedTxt' does not exist in the current context",
+        };
+
+        var grouped = TelemetryReporter.DeduplicateCompilationErrors(errors);
+
+        // CS1061 on 'Report70400' should be one group with count 3
+        var cs1061 = grouped.Single(g => g.Key == "CS1061 on 'Report70400'");
+        Assert.Equal(3, cs1061.Count);
+
+        // CS0103 on 'privacyBlockedTxt' should be a separate group with count 1
+        var cs0103 = grouped.Single(g => g.Key == "CS0103 on 'privacyBlockedTxt'");
+        Assert.Equal(1, cs0103.Count);
+        Assert.Contains("does not exist", cs0103.SampleMessage);
+    }
+
+    [Fact]
+    public void DeduplicateCompilationErrors_EmptyList()
+    {
+        var grouped = TelemetryReporter.DeduplicateCompilationErrors(new List<string>());
+        Assert.Empty(grouped);
+    }
+
+    [Fact]
+    public void DeduplicateCompilationErrors_OrderedByCountDescending()
+    {
+        var errors = new List<string>
+        {
+            "A.cs(1,1): error CS0103: The name 'x' does not exist in the current context",
+            "A.cs(2,1): error CS1061: 'Foo' does not contain a definition for 'bar'",
+            "A.cs(3,1): error CS1061: 'Foo' does not contain a definition for 'baz'",
+            "A.cs(4,1): error CS1061: 'Foo' does not contain a definition for 'qux'",
+        };
+
+        var grouped = TelemetryReporter.DeduplicateCompilationErrors(errors);
+
+        Assert.Equal(2, grouped.Count);
+        Assert.Equal("CS1061 on 'Foo'", grouped[0].Key); // 3× comes first
+        Assert.Equal(3, grouped[0].Count);
+        Assert.Equal("CS0103 on 'x'", grouped[1].Key);
+        Assert.Equal(1, grouped[1].Count);
+    }
+
+    // ─── Report dataset columns (RDLC skip) ─────────────────────────────────
+
+    [Fact]
+    public void ReportWithDatasetColumns_CompilesAndRuns()
+    {
+        var pipeline = new AlRunnerPipeline();
+        var result = pipeline.Run(new PipelineOptions
+        {
+            InputPaths = { TestPath("112-report-dataset-columns", "src"),
+                           TestPath("112-report-dataset-columns", "test") }
+        });
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains("4 passed", result.StdOut);
+    }
+
+    [Fact]
+    public void CompilationErrors_PopulatedOnFailure()
+    {
+        // Pipeline should populate CompilationErrors when Roslyn compilation fails.
+        // Use test 112 which compiles fine — verify CompilationErrors is null/empty on success.
+        var pipeline = new AlRunnerPipeline();
+        var result = pipeline.Run(new PipelineOptions
+        {
+            InputPaths = { TestPath("112-report-dataset-columns", "src"),
+                           TestPath("112-report-dataset-columns", "test") }
+        });
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.True(result.CompilationErrors == null || result.CompilationErrors.Count == 0,
+            "CompilationErrors should be null or empty on successful compilation");
+    }
 }

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -735,7 +735,9 @@ public static class AlTranspiler
             options: new CompilationOptions(
                 continueBuildOnError: true,
                 target: CompilationTarget.OnPrem,
-                generateOptions: CompilationGenerationOptions.All
+                // Exclude ReportLayout — the runner has no RDLC file system and
+                // GenerateRdlcLayout crashes with NullReferenceException.
+                generateOptions: CompilationGenerationOptions.Code | CompilationGenerationOptions.Navigation
             )
         );
 
@@ -868,7 +870,7 @@ public static class AlTranspiler
                     options: new CompilationOptions(
                         continueBuildOnError: true,
                         target: CompilationTarget.OnPrem,
-                        generateOptions: CompilationGenerationOptions.All
+                        generateOptions: CompilationGenerationOptions.Code | CompilationGenerationOptions.Navigation
                     ))
                     .WithReferenceLoader(refLoader)
                     .AddReferences(dedupedSpecs);
@@ -924,7 +926,7 @@ public static class AlTranspiler
                         options: new CompilationOptions(
                             continueBuildOnError: true,
                             target: CompilationTarget.OnPrem,
-                            generateOptions: CompilationGenerationOptions.All
+                            generateOptions: CompilationGenerationOptions.Code | CompilationGenerationOptions.Navigation
                         ))
                         .WithReferenceLoader(refLoader)
                         .AddReferences(filteredSpecs);

--- a/AlRunner/TelemetryReporter.cs
+++ b/AlRunner/TelemetryReporter.cs
@@ -105,13 +105,20 @@ public static class TelemetryReporter
                 Console.Error.WriteLine($"    … and {rewriterErrors.Count - 3} more");
         }
 
+        // Deduplicate compilation errors: group by CS code + first quoted token so that
+        // e.g. 74 CS1061 errors on Report70400 collapse into one line with a count.
+        List<(string Key, int Count, string SampleMessage)>? compilationGrouped = null;
         if (hasCompilationErrors)
         {
-            Console.Error.WriteLine($"  Compilation ({compilationErrors!.Count} error(s) — rewriter gap in C# output):");
-            foreach (var err in compilationErrors.Take(3))
-                Console.Error.WriteLine($"    × {ScrubMessage(err)}");
-            if (compilationErrors.Count > 3)
-                Console.Error.WriteLine($"    … and {compilationErrors.Count - 3} more");
+            compilationGrouped = DeduplicateCompilationErrors(compilationErrors!);
+            Console.Error.WriteLine($"  Compilation ({compilationGrouped.Count} unique error type(s) — rewriter gap in C# output):");
+            foreach (var (key, count, sample) in compilationGrouped.Take(5))
+            {
+                var display = count > 1 ? $"{key} ({count}×)" : $"{key}: {sample}";
+                Console.Error.WriteLine($"    × {ScrubMessage(display)}");
+            }
+            if (compilationGrouped.Count > 5)
+                Console.Error.WriteLine($"    … and {compilationGrouped.Count - 5} more unique error type(s)");
         }
 
         if (runtimeErrors.Count > 0)
@@ -146,17 +153,22 @@ public static class TelemetryReporter
             }
         }
 
-        // Send compilation failures (grouped as a single report for brevity)
-        if (hasCompilationErrors)
+        // Send each deduplicated compilation error group as its own telemetry report
+        // so the triage workflow can create separate issues per unique error type.
+        if (compilationGrouped != null)
         {
-            var report = new TelemetryReport(
-                ExceptionType: "AlRunner.CompilationGap",
-                ScrubbedMessage: string.Join("; ", compilationErrors!.Take(5).Select(ScrubMessage)),
-                StackText: "",
-                FrameCount: 0,
-                RunnerVersion: GetVersionString(),
-                Os: GetOsString());
-            await SendAsync(report);
+            foreach (var (key, count, sample) in compilationGrouped)
+            {
+                var msg = count > 1 ? $"{key} ({count}×)" : $"{key}: {sample}";
+                var report = new TelemetryReport(
+                    ExceptionType: "AlRunner.CompilationGap",
+                    ScrubbedMessage: ScrubMessage(msg),
+                    StackText: "",
+                    FrameCount: 0,
+                    RunnerVersion: GetVersionString(),
+                    Os: GetOsString());
+                await SendAsync(report);
+            }
         }
 
         // Send each unique runtime error (deduplicated by message)
@@ -171,6 +183,42 @@ public static class TelemetryReporter
     }
 
     // ─── Internals ────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Groups compilation error messages by CS error code + first single-quoted token.
+    /// E.g. 74 "CS1061: 'Report70400' does not contain…" errors collapse into one
+    /// group keyed "CS1061 on 'Report70400'" with count 74.
+    /// </summary>
+    public static List<(string Key, int Count, string SampleMessage)> DeduplicateCompilationErrors(
+        List<string> errors)
+    {
+        var singleQuoteRx = new Regex(@"'([^']+)'");
+        // Extract CS code from formatted error: "ObjectName.cs(line,col): error CS1061: ..."
+        var csCodeRx = new Regex(@"\berror (CS\d+):");
+
+        return errors
+            .GroupBy(err =>
+            {
+                var codeMatch = csCodeRx.Match(err);
+                var code = codeMatch.Success ? codeMatch.Groups[1].Value : "CS????";
+                // Extract first single-quoted token from the message portion (after "error CSxxxx: ")
+                var msgStart = codeMatch.Success ? codeMatch.Index + codeMatch.Length : 0;
+                var msgPortion = err[msgStart..];
+                var tokenMatch = singleQuoteRx.Match(msgPortion);
+                return tokenMatch.Success ? $"{code} on '{tokenMatch.Groups[1].Value}'" : code;
+            })
+            .Select(g =>
+            {
+                // For the sample message, extract just the diagnostic message (after "error CSxxxx: ")
+                var sample = g.First();
+                var codeMatch = csCodeRx.Match(sample);
+                if (codeMatch.Success)
+                    sample = sample[(codeMatch.Index + codeMatch.Length)..].TrimStart();
+                return (Key: g.Key, Count: g.Count(), SampleMessage: sample);
+            })
+            .OrderByDescending(g => g.Count)
+            .ToList();
+    }
 
     private record TelemetryReport(
         string ExceptionType,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,12 @@ All notable changes to this project are documented here. Format based on
 - **Telemetry covers all pipeline stages** — `TelemetryReporter.TryReportPipelineGapsAsync`
   now accepts and reports rewriter gaps (`RewriterErrors`) and compilation gaps
   (`CompilationErrors`) in addition to runtime gaps, all in a single combined prompt.
+- **Compilation error deduplication in telemetry** — Compilation errors are now
+  grouped by CS error code + target type before display and telemetry send. E.g.
+  74 CS1061 errors on `Report70400` collapse into one line `CS1061 on 'Report70400' (74×)`.
+  Each deduplicated group is sent as its own telemetry report (instead of one
+  joined blob), making the triage workflow able to create separate issues per
+  unique error type.
 
 ### Removed
 - **Dead `CompilationExcludedException` code** — The file-exclusion mechanism was
@@ -54,6 +60,15 @@ All notable changes to this project are documented here. Format based on
   the removed "iterative Roslyn retry" path.
 
 ### Fixed
+- **Skip RDLC report layout generation** — `Compilation.Emit()` now uses
+  `CompilationGenerationOptions.Code | Navigation` instead of `All`, skipping
+  RDLC layout generation that crashes with `NullReferenceException` in
+  `ReportRdlcUtilities.GenerateRdlcLayout` when running standalone. Report
+  objects still emit C# code for dataset columns and triggers.
+- **Telemetry triage KQL groups by message** — The triage workflow's KQL query
+  now groups by `type, outerMessage` instead of just `type`, so each unique
+  error message gets its own row instead of all `AlRunner.CompilationGap`
+  exceptions collapsing into a single row.
 - **`ALTransferFields` skips all PK fields** — When `initPrimaryKey=false`,
   `TransferFields` now skips all registered primary key fields instead of only
   field 1. Correctly handles composite primary keys. (#113)

--- a/tests/bucket-2/112-report-dataset-columns/src/Source.al
+++ b/tests/bucket-2/112-report-dataset-columns/src/Source.al
@@ -1,0 +1,47 @@
+// Report object with column elements in the dataset.
+// The runner should compile this with Code|Navigation (no RDLC layout)
+// and produce a stub class that doesn't crash at emit time.
+report 70400 "TestReportWithColumns"
+{
+    DefaultLayout = RDLC;
+    dataset
+    {
+        dataitem(TestCustomer; "Test Customer")
+        {
+            column(CustomerNo; "No.")
+            {
+            }
+            column(CustomerName; Name)
+            {
+            }
+        }
+    }
+}
+
+codeunit 50300 "Report Helper"
+{
+    procedure GetReportId(): Integer
+    begin
+        exit(Report::"TestReportWithColumns");
+    end;
+
+    procedure Add(a: Integer; b: Integer): Integer
+    begin
+        exit(a + b);
+    end;
+}
+
+table 50300 "Test Customer"
+{
+    fields
+    {
+        field(1; "No."; Code[20]) { }
+        field(2; Name; Text[100]) { }
+        field(3; City; Text[50]) { }
+    }
+
+    keys
+    {
+        key(PK; "No.") { Clustered = true; }
+    }
+}

--- a/tests/bucket-2/112-report-dataset-columns/test/TestReportDatasetColumns.al
+++ b/tests/bucket-2/112-report-dataset-columns/test/TestReportDatasetColumns.al
@@ -1,0 +1,49 @@
+codeunit 50301 "Test Report Dataset Columns"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    [Test]
+    procedure ReportIdIsResolvable()
+    var
+        Helper: Codeunit "Report Helper";
+    begin
+        // Positive: the report object compiles and its ID is accessible
+        Assert.AreNotEqual(0, Helper.GetReportId(), 'Report ID should be non-zero');
+    end;
+
+    [Test]
+    procedure HelperLogicWorks()
+    var
+        Helper: Codeunit "Report Helper";
+    begin
+        // Positive: codeunit logic compiled alongside report is functional
+        Assert.AreEqual(7, Helper.Add(3, 4), 'Expected 3+4=7');
+    end;
+
+    [Test]
+    procedure HelperLogicCatchesWrongResult()
+    var
+        Helper: Codeunit "Report Helper";
+    begin
+        // Negative: verify assertion detects incorrect values
+        asserterror Assert.AreEqual(99, Helper.Add(3, 4), 'Wrong sum');
+        Assert.ExpectedError('Assert.AreEqual failed');
+    end;
+
+    [Test]
+    procedure TableInsertAndRead()
+    var
+        Cust: Record "Test Customer";
+    begin
+        // Positive: table defined alongside report works
+        Cust."No." := 'C001';
+        Cust.Name := 'Contoso';
+        Cust.Insert(true);
+
+        Cust.Get('C001');
+        Assert.AreEqual('Contoso', Cust.Name, 'Customer name mismatch');
+    end;
+}

--- a/tools/telemetry-triage/triage.py
+++ b/tools/telemetry-triage/triage.py
@@ -116,7 +116,7 @@ exceptions
     os_list      = make_set(os, 10),
     sample_stack = any(tostring(details)),
     sample_msg   = any(outerMessage)
-  by type
+  by type, outerMessage
 | order by occurrences desc
 """
 


### PR DESCRIPTION
## What

**1. Skip RDLC layout generation during Emit**
Changed `CompilationGenerationOptions.All` to `Code | Navigation` in all three `Compilation.Create()` calls. This avoids a `NullReferenceException` in `ReportRdlcUtilities.GenerateRdlcLayout` when compiling AL projects containing report objects with `column` elements in the dataset. The RDLC layout generator requires a service-tier file system that doesn't exist in standalone mode.

Report C# code is still emitted — only the RDLC layout file generation is skipped. Reports with `column` elements compile normally and their helper procedures execute correctly.

**2. Compilation error deduplication in telemetry**
Compilation errors are now grouped by CS error code + target type before display and telemetry sending. E.g. 74 CS1061 errors on `Report70400` collapse into one line `CS1061 on 'Report70400' (74×)`. Each deduplicated group is sent as its own `AlRunner.CompilationGap` telemetry report instead of one joined blob, so the triage workflow can create separate issues per unique error type.

**3. Telemetry triage KQL fix**
The triage workflow KQL now groups by `type, outerMessage` instead of just `type`, so each unique error message gets its own row. Previously all `AlRunner.CompilationGap` exceptions were collapsed into a single row.

## Tests

- **AL test `112-report-dataset-columns`** (4 tests) — Report with `column` elements compiles and runs; helper procedures dispatch correctly; negative test proves logic is actually executed
- **C# tests in PipelineTests** (5 new tests):
  - `DeduplicateCompilationErrors_GroupsByCSCodeAndType` — 3 CS1061 on same type → 1 group
  - `DeduplicateCompilationErrors_EmptyList` — empty input → empty output
  - `DeduplicateCompilationErrors_OrderedByCountDescending` — highest count comes first
  - `ReportWithDatasetColumns_CompilesAndRuns` — end-to-end pipeline test
  - `CompilationErrors_PopulatedOnFailure` — CompilationErrors null/empty on success

All existing tests pass (181 C# tests, all bucket-1 AL suites).