### PR TITLE
fix: Triage workflow groups by root cause instead of per-error-row

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ lcov.info
 # Benchmark artifacts
 BenchmarkDotNet.Artifacts/
 publish-*/
+**/__pycache__/

--- a/AlRunner/TelemetryReporter.cs
+++ b/AlRunner/TelemetryReporter.cs
@@ -327,7 +327,7 @@ public static class TelemetryReporter
         // Remove Unix-style paths (/home/..., /var/..., etc.)
         message = Regex.Replace(message, @"(/[\w.\-]+){2,}", "[path]");
         // Truncate to 200 chars
-        return message.Length > 200 ? message[..200] + "…" : message;
+        return message.Length > 500 ? message[..500] + "…" : message;
     }
 
     private static async Task SendAsync(TelemetryReport report)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,17 @@ All notable changes to this project are documented here. Format based on
   now groups by `type, outerMessage` instead of just `type`, so each unique
   error message gets its own row instead of all `AlRunner.CompilationGap`
   exceptions collapsing into a single row.
+- **Telemetry triage root-cause aggregation** — The triage workflow now pre-
+  aggregates compilation gaps by root-cause pattern before sending to Copilot.
+  CS0103 label-like variables (`*Lbl`, `*Txt`, etc.) collapse into one group;
+  CS1061 errors on generated types (Report/Page/Extension) collapse by target;
+  CS1061 errors on mock types keep separate entries per missing method. Handles
+  scope-qualified type names (`Report70400.SomeScope` → `Report70400`) and
+  truncated telemetry messages gracefully. A safety cap aborts issue creation if
+  Copilot returns more than 15 new problems (likely a grouping failure).
+- **Telemetry message truncation limit** — `ScrubMessage` now truncates at 500
+  characters instead of 200, preserving full error context for long generated
+  type names like `ReportExtension50506.DtldCustLedgEntries_…`.
 - **`ALTransferFields` skips all PK fields** — When `initPrimaryKey=false`,
   `TransferFields` now skips all registered primary key fields instead of only
   field 1. Correctly handles composite primary keys. (#113)

--- a/tools/telemetry-triage/test_triage.py
+++ b/tools/telemetry-triage/test_triage.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python3
+"""Tests for the telemetry triage aggregation and body-building logic."""
+
+import sys
+import os
+import unittest
+
+# Set required env vars before importing triage (module-level config reads them)
+os.environ.setdefault("APPINSIGHTS_API_KEY", "test-key")
+os.environ.setdefault("GITHUB_TOKEN", "test-token")
+os.environ.setdefault("GITHUB_REPOSITORY", "test/repo")
+
+sys.path.insert(0, os.path.dirname(__file__))
+from triage import (
+    _classify_compilation_gap,
+    aggregate_by_root_cause,
+    build_body,
+)
+
+
+class TestClassifyCompilationGap(unittest.TestCase):
+    """Unit tests for _classify_compilation_gap()."""
+
+    # ── CS0103: label-like names merge into one bucket ──
+
+    def test_cs0103_lbl_suffix_groups(self):
+        msg = "CS0103 on 'periodCalculationRequiredLbl': The name 'periodCalculationRequiredLbl' does not exist"
+        self.assertEqual(_classify_compilation_gap(msg), "CS0103:label-vars")
+
+    def test_cs0103_txt_suffix_groups(self):
+        msg = "CS0103 on 'privacyBlockedTxt': The name 'privacyBlockedTxt' does not exist"
+        self.assertEqual(_classify_compilation_gap(msg), "CS0103:label-vars")
+
+    def test_cs0103_tok_suffix_groups(self):
+        msg = "CS0103 on 'separatorTok': The name 'separatorTok' does not exist"
+        self.assertEqual(_classify_compilation_gap(msg), "CS0103:label-vars")
+
+    def test_cs0103_msg_suffix_groups(self):
+        msg = "CS0103 on 'errorMsg': The name 'errorMsg' does not exist"
+        self.assertEqual(_classify_compilation_gap(msg), "CS0103:label-vars")
+
+    def test_cs0103_err_suffix_groups(self):
+        msg = "CS0103 on 'fieldErr': The name 'fieldErr' does not exist"
+        self.assertEqual(_classify_compilation_gap(msg), "CS0103:label-vars")
+
+    def test_cs0103_caption_suffix_groups(self):
+        msg = "CS0103 on 'myCaption': The name 'myCaption' does not exist"
+        self.assertEqual(_classify_compilation_gap(msg), "CS0103:label-vars")
+
+    # ── CS0103: non-label names stay individual ──
+
+    def test_cs0103_non_label_stays_individual(self):
+        msg = "CS0103 on 'myLocalVar': The name 'myLocalVar' does not exist"
+        self.assertEqual(_classify_compilation_gap(msg), "CS0103 on 'myLocalVar'")
+
+    # ── CS1061: generated types group by target ──
+
+    def test_cs1061_report_groups_by_target(self):
+        msg1 = "CS1061 on 'Report70400': 'Report70400' does not contain a definition for 'amountDue'"
+        msg2 = "CS1061 on 'Report70400': 'Report70400' does not contain a definition for 'columnHead'"
+        key1 = _classify_compilation_gap(msg1)
+        key2 = _classify_compilation_gap(msg2)
+        self.assertEqual(key1, key2)
+        self.assertEqual(key1, "CS1061 on 'Report70400'")
+
+    def test_cs1061_page_groups_by_target(self):
+        msg = "CS1061 on 'Page50100': 'Page50100' does not contain a definition for 'SomeField'"
+        self.assertEqual(_classify_compilation_gap(msg), "CS1061 on 'Page50100'")
+
+    def test_cs1061_report_extension_groups_by_base_target(self):
+        msg = ("CS1061 on 'ReportExtension50506.DtldCustLedgEntries_a45_OnBeforeAfterGetRecord_Scope': "
+               "'ReportExtension50506.DtldCustLedgEntries_a45_OnBeforeAfterGetRecord_Scope' "
+               "does not contain a definition for 'Pa…")
+        self.assertEqual(_classify_compilation_gap(msg), "CS1061 on 'ReportExtension50506'")
+
+    def test_cs1061_page_extension_groups_by_base_target(self):
+        msg = "CS1061 on 'PageExtension50100': 'PageExtension50100' does not contain a definition for 'SomeField'"
+        self.assertEqual(_classify_compilation_gap(msg), "CS1061 on 'PageExtension50100'")
+
+    def test_cs1061_table_extension_groups_by_base_target(self):
+        msg = "CS1061 on 'TableExtension50200': 'TableExtension50200' does not contain a definition for 'X'"
+        self.assertEqual(_classify_compilation_gap(msg), "CS1061 on 'TableExtension50200'")
+
+    # ── CS1061: mock types group by target + member ──
+
+    def test_cs1061_mock_splits_by_member(self):
+        msg1 = "CS1061 on 'MockRecordRef': 'MockRecordRef' does not contain a definition for 'ALFieldExists'"
+        msg2 = "CS1061 on 'MockRecordRef': 'MockRecordRef' does not contain a definition for 'ALSetTable'"
+        key1 = _classify_compilation_gap(msg1)
+        key2 = _classify_compilation_gap(msg2)
+        self.assertNotEqual(key1, key2)
+        self.assertEqual(key1, "CS1061:'MockRecordRef'.ALFieldExists")
+        self.assertEqual(key2, "CS1061:'MockRecordRef'.ALSetTable")
+
+    def test_cs1061_mock_instream(self):
+        msg = "CS1061 on 'MockInStream': 'MockInStream' does not contain a definition for 'ALRead'"
+        self.assertEqual(_classify_compilation_gap(msg), "CS1061:'MockInStream'.ALRead")
+
+    def test_cs1061_mock_truncated_member_falls_back_to_target(self):
+        """When member name is truncated (no closing quote), fall back to target-only."""
+        msg = "CS1061 on 'MockRecordRef': 'MockRecordRef' does not contain a definition for 'ALSomeVeryLongMethodNam…"
+        key = _classify_compilation_gap(msg)
+        # Should still extract the truncated member since _MEMBER_RE now handles …
+        self.assertEqual(key, "CS1061:'MockRecordRef'.ALSomeVeryLongMethodNam")
+
+    def test_cs1061_scope_qualified_report_strips_scope(self):
+        """Report70400.SomeTrigger_Scope → groups under Report70400."""
+        msg = "CS1061 on 'Report70400.OnAfterGetRecord_Scope': 'Report70400.OnAfterGetRecord_Scope' does not contain a definition for 'foo'"
+        self.assertEqual(_classify_compilation_gap(msg), "CS1061 on 'Report70400'")
+
+    # ── Other CS codes ──
+
+    def test_other_cs_code_groups_by_code_and_target(self):
+        msg = "CS0029 on 'NavText': Cannot implicitly convert type 'int' to 'NavText'"
+        self.assertEqual(_classify_compilation_gap(msg), "CS0029 on 'NavText'")
+
+    # ── Fallback for unparseable messages ──
+
+    def test_unparseable_message_uses_prefix(self):
+        msg = "Some completely unexpected error format that doesn't match"
+        key = _classify_compilation_gap(msg)
+        self.assertTrue(key.startswith("Some completely unexpected"))
+        self.assertTrue(len(key) <= 120)
+
+
+class TestAggregateByRootCause(unittest.TestCase):
+    """Integration tests for aggregate_by_root_cause()."""
+
+    def _make_gap(self, outer_message, occurrences=1):
+        return {
+            "type": "AlRunner.CompilationGap",
+            "outerMessage": outer_message,
+            "occurrences": occurrences,
+            "first_seen": "2024-01-01T00:00:00Z",
+            "last_seen": "2024-01-01T01:00:00Z",
+            "versions": ["0.1.0"],
+            "os_list": ["unix"],
+            "sample_msg": outer_message,
+            "sample_stack": "(stack)",
+        }
+
+    def test_label_vars_aggregate_into_one(self):
+        """20 different *Lbl CS0103 errors → 1 aggregated row."""
+        rows = [
+            self._make_gap(f"CS0103 on '{name}Lbl': The name '{name}Lbl' does not exist")
+            for name in ["aged", "current", "detail", "days", "over", "summary",
+                         "noLimit", "upTo", "dueDateShort", "dueDateFull",
+                         "transactionDateShort", "transactionDateFull",
+                         "documentDateShort", "documentDateFull",
+                         "agedCustomerBalances", "agedOverdueAmounts",
+                         "showOnlyOverdueBy", "onlyForDueDate",
+                         "amountsAreIn", "periodCalculationRequired"]
+        ]
+        result = aggregate_by_root_cause(rows)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["_group_key"], "CS0103:label-vars")
+        self.assertEqual(result[0]["distinct_errors"], 20)
+        self.assertEqual(result[0]["occurrences"], 20)
+        self.assertEqual(len(result[0]["_original_rows"]), 20)
+
+    def test_report_members_aggregate_by_target(self):
+        """Multiple CS1061 on Report70400 → 1 aggregated row."""
+        rows = [
+            self._make_gap("CS1061 on 'Report70400': 'Report70400' does not contain a definition for 'amountDue'", 3),
+            self._make_gap("CS1061 on 'Report70400': 'Report70400' does not contain a definition for 'columnHead'", 2),
+            self._make_gap("CS1061 on 'Report70400': 'Report70400' does not contain a definition for 'Totals'", 1),
+        ]
+        result = aggregate_by_root_cause(rows)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["_group_key"], "CS1061 on 'Report70400'")
+        self.assertEqual(result[0]["occurrences"], 6)
+        self.assertEqual(result[0]["distinct_errors"], 3)
+
+    def test_mock_methods_stay_split(self):
+        """Different missing methods on same mock type → separate rows."""
+        rows = [
+            self._make_gap("CS1061 on 'MockRecordRef': 'MockRecordRef' does not contain a definition for 'ALFieldExists'"),
+            self._make_gap("CS1061 on 'MockRecordRef': 'MockRecordRef' does not contain a definition for 'ALSetTable'"),
+        ]
+        result = aggregate_by_root_cause(rows)
+        self.assertEqual(len(result), 2)
+        keys = {r["_group_key"] for r in result}
+        self.assertIn("CS1061:'MockRecordRef'.ALFieldExists", keys)
+        self.assertIn("CS1061:'MockRecordRef'.ALSetTable", keys)
+
+    def test_non_gaps_pass_through(self):
+        """Non-CompilationGap rows pass through unchanged."""
+        rows = [
+            {"type": "System.NullReferenceException", "outerMessage": "NRE in something",
+             "occurrences": 5, "versions": [], "os_list": []},
+        ]
+        result = aggregate_by_root_cause(rows)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["type"], "System.NullReferenceException")
+        self.assertEqual(result[0]["_group_key"], "System.NullReferenceException")
+
+    def test_mixed_rows(self):
+        """Real-world mix: 20 labels + 3 Report members + 2 mock methods + 1 NRE → 5 rows."""
+        rows = []
+        for name in ["agedLbl", "currentLbl", "detailLbl", "daysLbl", "overLbl"]:
+            rows.append(self._make_gap(f"CS0103 on '{name}': The name '{name}' does not exist"))
+        rows.append(self._make_gap("CS0103 on 'privacyBlockedTxt': The name 'privacyBlockedTxt' does not exist"))
+        rows.append(self._make_gap("CS1061 on 'Report70400': ... 'amountDue'"))
+        rows.append(self._make_gap("CS1061 on 'Report70400': ... 'columnHead'"))
+        rows.append(self._make_gap("CS1061 on 'MockRecordRef': 'MockRecordRef' does not contain a definition for 'ALFieldExists'"))
+        rows.append(self._make_gap("CS1061 on 'MockFieldRef': 'MockFieldRef' does not contain a definition for 'ALSetTable'"))
+        rows.append({"type": "System.NullReferenceException", "outerMessage": "NRE",
+                      "occurrences": 1, "versions": [], "os_list": []})
+
+        result = aggregate_by_root_cause(rows)
+        keys = {r["_group_key"] for r in result}
+        self.assertEqual(keys, {
+            "CS0103:label-vars",
+            "CS1061 on 'Report70400'",
+            "CS1061:'MockRecordRef'.ALFieldExists",
+            "CS1061:'MockFieldRef'.ALSetTable",
+            "System.NullReferenceException",
+        })
+        self.assertEqual(len(result), 5)
+
+    def test_cs0103_non_label_stays_separate_from_labels(self):
+        """CS0103 on a non-label variable doesn't merge with label bucket."""
+        rows = [
+            self._make_gap("CS0103 on 'currentLbl': The name 'currentLbl' does not exist"),
+            self._make_gap("CS0103 on 'myLocalVar': The name 'myLocalVar' does not exist"),
+        ]
+        result = aggregate_by_root_cause(rows)
+        self.assertEqual(len(result), 2)
+        keys = {r["_group_key"] for r in result}
+        self.assertIn("CS0103:label-vars", keys)
+        self.assertIn("CS0103 on 'myLocalVar'", keys)
+
+
+class TestBuildBody(unittest.TestCase):
+    """Tests for build_body() with group-key matching."""
+
+    def _make_aggregated_row(self, group_key, original_rows):
+        return {
+            "type": "AlRunner.CompilationGap",
+            "_group_key": group_key,
+            "_original_rows": original_rows,
+        }
+
+    def _make_raw_row(self, outer_message, occurrences=1):
+        return {
+            "type": "AlRunner.CompilationGap",
+            "outerMessage": outer_message,
+            "occurrences": occurrences,
+            "first_seen": "2024-01-01T00:00:00Z",
+            "last_seen": "2024-01-01T01:00:00Z",
+            "versions": ["0.1.0"],
+            "os_list": ["unix"],
+            "sample_msg": outer_message,
+            "sample_stack": "(stack)",
+        }
+
+    def test_matches_by_group_key(self):
+        """build_body uses source_group_keys to match rows."""
+        r1 = self._make_raw_row("CS0103 on 'agedLbl': ...")
+        r2 = self._make_raw_row("CS0103 on 'currentLbl': ...")
+        agg = self._make_aggregated_row("CS0103:label-vars", [r1, r2])
+        other = self._make_aggregated_row("CS1061 on 'Report70400'", [
+            self._make_raw_row("CS1061 on 'Report70400': ... 'amountDue'"),
+        ])
+
+        problem = {"source_group_keys": ["CS0103:label-vars"]}
+        body = build_body(problem, [agg, other], "2024-01-01T00:00:00Z")
+
+        self.assertIn("agedLbl", body)
+        self.assertIn("currentLbl", body)
+        self.assertNotIn("amountDue", body)
+
+    def test_expands_original_rows(self):
+        """build_body shows each original row from an aggregated group."""
+        originals = [
+            self._make_raw_row(f"CS0103 on '{n}Lbl': ...")
+            for n in ["aged", "current", "detail"]
+        ]
+        agg = self._make_aggregated_row("CS0103:label-vars", originals)
+
+        problem = {"source_group_keys": ["CS0103:label-vars"]}
+        body = build_body(problem, [agg], "2024-01-01T00:00:00Z")
+
+        # Each original should produce its own section
+        self.assertEqual(body.count("### `AlRunner.CompilationGap`"), 3)
+
+    def test_fallback_to_source_exception_types(self):
+        """Backward compat: falls back to source_exception_types if no group keys."""
+        row = self._make_raw_row("some error")
+        row["type"] = "System.NRE"
+        row["_group_key"] = "System.NRE"
+        row["_original_rows"] = [row]
+
+        problem = {"source_exception_types": ["System.NRE"]}
+        body = build_body(problem, [row], "2024-01-01T00:00:00Z")
+
+        self.assertIn("some error", body)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/telemetry-triage/triage.py
+++ b/tools/telemetry-triage/triage.py
@@ -17,6 +17,7 @@ Optional:
 
 import json
 import os
+import re
 import sys
 import urllib.request
 import urllib.error
@@ -35,6 +36,7 @@ GH_API_BASE     = "https://api.github.com"
 GH_MODELS_URL   = "https://models.github.ai/inference/chat/completions"
 COPILOT_MODEL   = "openai/gpt-4o-mini"
 ISSUE_LABEL     = "telemetry"
+MAX_NEW_ISSUES  = 15
 
 # ─── HTTP helpers ─────────────────────────────────────────────────────────────
 
@@ -145,6 +147,113 @@ def query_telemetry(from_time: str) -> list[dict]:
         rows.append(r)
     return rows
 
+# ─── Step 2b: Pre-aggregate rows by root cause ────────────────────────────────
+
+_CS_CODE_RE = re.compile(r"(CS\d+) on '([^']+)'")
+_MEMBER_RE  = re.compile(r"does not contain a definition for '([^'…]+)")
+_LABEL_SUFFIX_RE = re.compile(r"(Lbl|Txt|Tok|Msg|Err|Caption)$", re.IGNORECASE)
+_GENERATED_TYPE_RE = re.compile(r"^(Report|Page|Query|XmlPort|Table)(Extension)?\d+")
+
+
+def _classify_compilation_gap(outer_message: str) -> str:
+    """Return a group key for a CompilationGap outerMessage.
+
+    Grouping rules:
+    - CS0103 on label-like names (*Lbl, *Txt, *Tok, *Msg, *Err, *Caption) → one bucket
+    - CS0103 on other names → keep individual
+    - CS1061 on generated types (Report70400, ReportExtension50506, Page50100, etc.)
+      → group by base target type (dot-prefix stripped: ``Report70400`` not
+      ``Report70400.SomeScope``)
+    - CS1061 on mock/runtime types → group by target type + missing member
+      (falls back to target-only if member is truncated)
+    - Other CS codes → group by CS code + target
+    """
+    m = _CS_CODE_RE.match(outer_message)
+    if not m:
+        return outer_message[:120]
+
+    cs_code, target = m.groups()
+
+    if cs_code == "CS0103":
+        if _LABEL_SUFFIX_RE.search(target):
+            return "CS0103:label-vars"
+        return f"CS0103 on '{target}'"
+
+    # For generated types, strip scope suffixes (e.g., Report70400.SomeScope → Report70400)
+    base_target = target.split(".")[0]
+
+    if cs_code == "CS1061":
+        if _GENERATED_TYPE_RE.match(base_target):
+            return f"CS1061 on '{base_target}'"
+        member_m = _MEMBER_RE.search(outer_message)
+        if member_m:
+            member = member_m.group(1)
+            return f"CS1061:'{base_target}'.{member}"
+        # Member name truncated or unparseable — group by target only
+        return f"CS1061 on '{base_target}'"
+
+    return f"{cs_code} on '{base_target}'"
+
+
+def aggregate_by_root_cause(rows: list[dict]) -> list[dict]:
+    """Pre-aggregate telemetry rows by root-cause pattern.
+
+    CompilationGap rows are grouped by the pattern extracted from outerMessage.
+    Other exception types pass through unchanged. Each aggregated row carries
+    ``_original_rows`` and ``_group_key`` for downstream matching.
+    """
+    non_gaps = []
+    gaps: dict[str, list[dict]] = {}
+
+    for r in rows:
+        if r.get("type") != "AlRunner.CompilationGap":
+            r["_group_key"] = r.get("type", "Unknown")
+            r["_original_rows"] = [r]
+            non_gaps.append(r)
+            continue
+
+        key = _classify_compilation_gap(r.get("outerMessage", "") or r.get("sample_msg", ""))
+        gaps.setdefault(key, []).append(r)
+
+    aggregated = []
+    for key, group_rows in gaps.items():
+        total_occ = sum(r.get("occurrences", 0) for r in group_rows)
+        all_versions: set[str] = set()
+        all_os: set[str] = set()
+        first_seen_vals: list[str] = []
+        last_seen_vals: list[str] = []
+
+        for r in group_rows:
+            all_versions.update(v for v in r.get("versions", []) if v)
+            all_os.update(o for o in r.get("os_list", []) if o)
+            if r.get("first_seen"):
+                first_seen_vals.append(r["first_seen"])
+            if r.get("last_seen"):
+                last_seen_vals.append(r["last_seen"])
+
+        example_msgs = [r.get("outerMessage", "") or r.get("sample_msg", "") for r in group_rows]
+        sample = "\n".join(example_msgs[:3])
+        if len(example_msgs) > 3:
+            sample += f"\n… and {len(example_msgs) - 3} more"
+
+        aggregated.append({
+            "type": "AlRunner.CompilationGap",
+            "outerMessage": key,
+            "occurrences": total_occ,
+            "distinct_errors": len(group_rows),
+            "first_seen": min(first_seen_vals) if first_seen_vals else "",
+            "last_seen": max(last_seen_vals) if last_seen_vals else "",
+            "versions": sorted(all_versions),
+            "os_list": sorted(all_os),
+            "sample_msg": sample,
+            "sample_stack": group_rows[0].get("sample_stack", ""),
+            "_group_key": key,
+            "_original_rows": group_rows,
+        })
+
+    return non_gaps + aggregated
+
+
 # ─── Step 3: Fetch existing issues for deduplication ──────────────────────────
 
 def fetch_all_open_issues() -> list[dict]:
@@ -172,24 +281,28 @@ SYSTEM_PROMPT = """You are a triage assistant for al-runner, a Business Central 
 al-runner transpiles AL source to C# and compiles it in-memory. It mocks BC runtime types (NavRecordHandle,
 NavInStream, NavOutStream, NavDialog, etc.) so tests can run without a BC service tier.
 
-Your job: given raw telemetry crash reports and a list of existing GitHub issues, extract every distinct
-technical problem and classify it.
+Your job: given PRE-AGGREGATED telemetry crash report groups and a list of existing GitHub issues,
+classify each group and decide whether it matches an existing issue.
+
+IMPORTANT: The telemetry rows have ALREADY been grouped by root cause before reaching you.
+Each row you see represents one root-cause group (possibly aggregating many individual errors).
+Do NOT split a single row into multiple problems. Treat each input row as exactly one problem.
 
 Known limitations (by design — do NOT file issues for these):
-- Report, XMLPort — not supported, by design
+- Report layout rendering, XMLPort I/O — not supported, by design
 - HTTP — not supported, by design
 - Events/subscribers — not supported, by design
 - Page variables other than TestPage — partially supported via MockFormHandle
 
 Rules:
-1. Extract one entry per distinct root cause (not one per exception type — a single exception can embed many problems).
+1. Each input row = one problem. Your output should have at most one entry per input row.
 2. For each problem, check the existing issues list. Match semantically, not just by keyword.
 3. If already tracked: set "existing_issue_number" to the issue number (integer).
 4. If genuinely new and actionable: set "existing_issue_number" to null.
 5. Skip known-by-design limitations entirely — do not include them at all.
 6. Titles must be concise and technical (under 80 chars). No "telemetry:" prefix.
 7. Do NOT generate a body — the script builds the body from raw telemetry data.
-8. Set "source_exception_types" to the list of exception type strings this problem came from.
+8. Set "source_group_keys" to the list of group_key strings this problem came from.
 
 Return ONLY valid JSON matching this schema (no markdown, no explanation):
 {
@@ -197,7 +310,7 @@ Return ONLY valid JSON matching this schema (no markdown, no explanation):
     {
       "title": "string",
       "existing_issue_number": null or integer,
-      "source_exception_types": ["string"]
+      "source_group_keys": ["string"]
     }
   ]
 }"""
@@ -210,15 +323,18 @@ def analyze_with_copilot(rows: list[dict], existing_issues: list[dict]) -> list[
         for i in existing_issues
     )
 
-    # For classification we only need the type + message + first ~1000 chars of stack
     summary_rows = []
     for r in rows:
-        summary_rows.append({
+        entry: dict = {
+            "group_key":   r.get("_group_key", r.get("type", "Unknown")),
             "type":        r.get("type"),
             "occurrences": r.get("occurrences"),
             "sample_msg":  r.get("sample_msg", "")[:1000],
             "sample_stack": r.get("sample_stack", "")[:1000],
-        })
+        }
+        if r.get("distinct_errors"):
+            entry["distinct_errors"] = r["distinct_errors"]
+        summary_rows.append(entry)
 
     user_content = f"""Existing open GitHub issues:
 {issues_summary}
@@ -254,22 +370,40 @@ Classify each distinct problem. Return JSON only."""
 
 
 def build_body(problem: dict, rows: list[dict], from_time: str) -> str:
-    """Build a structured issue/comment body from raw telemetry rows."""
+    """Build a structured issue/comment body from raw telemetry rows.
+
+    Matches rows to problems via ``source_group_keys`` (preferred) or falls back
+    to ``source_exception_types`` for backward compatibility.  When a matched row
+    carries ``_original_rows`` (from pre-aggregation), those originals are shown
+    so the issue body contains full detail.
+    """
+    source_keys  = set(problem.get("source_group_keys", []))
     source_types = set(problem.get("source_exception_types", []))
-    # Fall back to all rows if Copilot didn't populate source_exception_types
-    relevant = [r for r in rows if r.get("type") in source_types] if source_types else rows
+
+    if source_keys:
+        matched = [r for r in rows if r.get("_group_key") in source_keys]
+    elif source_types:
+        matched = [r for r in rows if r.get("type") in source_types]
+    else:
+        matched = rows
+
+    # Expand aggregated rows to their originals for detailed display
+    detail_rows: list[dict] = []
+    for r in matched:
+        originals = r.get("_original_rows", [r])
+        detail_rows.extend(originals)
 
     now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
     sections = [f"*Telemetry update — {now} | window: since `{from_time}`*\n"]
 
-    for r in relevant:
+    for r in detail_rows:
         exc_type    = r.get("type", "Unknown")
         occurrences = r.get("occurrences", 0)
         first_seen  = r.get("first_seen", "")
         last_seen   = r.get("last_seen", "")
         versions    = r.get("versions", [])
         os_list     = r.get("os_list", [])
-        sample_msg  = r.get("sample_msg", "") or "(no message)"
+        sample_msg  = r.get("outerMessage", "") or r.get("sample_msg", "") or "(no message)"
         sample_stack = r.get("sample_stack", "") or "(no stack)"
 
         ver_str = ", ".join(v for v in versions if v) or "unknown"
@@ -364,7 +498,10 @@ def main():
         return
 
     total = sum(r.get("occurrences", 0) for r in rows)
-    print(f"Found {len(rows)} exception type(s), {total} total occurrence(s).")
+    print(f"Found {len(rows)} exception row(s), {total} total occurrence(s).")
+
+    rows = aggregate_by_root_cause(rows)
+    print(f"Aggregated to {len(rows)} root-cause group(s).")
     print()
 
     existing_issues = fetch_all_open_issues()
@@ -376,8 +513,21 @@ def main():
         print("Copilot found no actionable new problems.")
         return
 
-    print(f"Copilot identified {len(problems)} problem(s):")
+    new_count = sum(1 for p in problems if not p.get("existing_issue_number"))
+    print(f"Copilot identified {len(problems)} problem(s) ({new_count} new):")
     print()
+
+    if new_count > MAX_NEW_ISSUES:
+        print(
+            f"ERROR: Copilot wants to create {new_count} new issues "
+            f"(limit is {MAX_NEW_ISSUES}). This likely indicates a grouping "
+            f"failure. Aborting — review the aggregation logic.",
+            file=sys.stderr,
+        )
+        for p in problems:
+            flag = "  EXISTING" if p.get("existing_issue_number") else "  NEW"
+            print(f"  {flag}: {p.get('title', '?')}")
+        sys.exit(1)
 
     ensure_label_exists()
 


### PR DESCRIPTION
## Problem

The previous triage run created **29 individual issues** (#138–#166) for what was really ~5 root causes. The workflow was treating each telemetry row (each unique `outerMessage`) as a separate problem.

Real root causes:
1. ~20 issues: CS0103 on report label variables (`*Lbl`, `*Txt`) — all the same gap
2. ~3 issues: CS1061 on `Report70400` — missing report members
3. ~3 issues: CS1061 on mock types — each a distinct missing method
4. 1 issue: `ALUploadIntoStream` not supported

## Solution

### Pre-aggregation by root-cause pattern (`triage.py`)

Added `aggregate_by_root_cause()` that groups CompilationGap rows before sending to Copilot:

| Pattern | Grouping rule | Example |
|---------|--------------|---------|
| CS0103 on `*Lbl`, `*Txt`, `*Tok`, `*Msg`, `*Err`, `*Caption` | All → one "label-vars" bucket | 20 label errors → 1 group |
| CS1061 on generated types (`Report*`, `Page*`, `*Extension*`) | Group by base target type | 5 Report70400 errors → 1 group |
| CS1061 on mock/runtime types | Keep per-member granularity | `MockRecordRef.ALFieldExists` ≠ `MockRecordRef.ALSetTable` |
| Other CS codes | Group by CS code + target | Keeps precision |

Scope-qualified names are stripped: `Report70400.OnAfterGetRecord_Scope` → `Report70400`.

### Additional fixes

- **Truncation limit** increased from 200→500 chars in `ScrubMessage` — long generated type names like `ReportExtension50506.DtldCustLedgEntries_…` were being cut off, breaking triage classification
- **Truncated message handling** — regex matches member names up to `…` for gracefully degraded grouping
- **Safety cap** — aborts with error if Copilot returns >15 new issues (signals a grouping failure)
- **Copilot prompt** — now says "each input row = one problem" (rows are pre-aggregated), uses `source_group_keys` instead of `source_exception_types`
- **`build_body`** — matches by group key, expands `_original_rows` for full detail

### Cleanup

- Closed all 29 spam issues (#138–#166) with explanatory comment
- Added `__pycache__/` to .gitignore

## Tests

- **27 Python unit tests** covering classification logic, aggregation, body building, truncated messages, extension types, and scope stripping
- **181 C# tests** still pass (ScrubMessage limit change)