### PR TITLE
feat: add Notification, BigText, TaskScheduler & DataTransfer mocks (closes #121)

### DIFF
--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -302,6 +302,14 @@ test executor that needs no BC service tier, Docker, SQL Server, or license.
 - Query variables — declaring Query variables compiles; Close/SetFilter/SetRange/
   TopNumberOfRows are no-ops; Open/Read/SaveAs throw NotSupportedException.
   Inject query dependencies via an AL interface for unit-testable code.
+- Notification — Message, Send, Recall, SetData/GetData/HasData, AddAction, Id, Scope.
+  Send/Recall are no-ops; data store is in-memory; Id auto-generates a Guid.
+- BigText — uses the real BC NavBigText type. AddText, GetSubText, TextPos, Length
+  all work as-is (no session dependency). Note: TextPos is 1-based in AL.
+- TaskScheduler — CreateTask (dispatches codeunit synchronously, returns Guid),
+  TaskExists (returns false), CancelTask (no-op), SetTaskReady (no-op)
+- DataTransfer — SetTables, AddFieldValue, AddConstantValue, AddJoin, AddSourceFilter,
+  CopyFields, CopyRows (all no-ops; requires real database for actual transfer)
 
 ### What al-runner does NOT support
 

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -304,10 +304,12 @@ test executor that needs no BC service tier, Docker, SQL Server, or license.
   Inject query dependencies via an AL interface for unit-testable code.
 - Notification — Message, Send, Recall, SetData/GetData/HasData, AddAction, Id, Scope.
   Send/Recall are no-ops; data store is in-memory; Id auto-generates a Guid.
+  Note: [SendNotificationHandler] dispatch is NOT implemented; use direct Notification methods.
 - BigText — uses the real BC NavBigText type. AddText, GetSubText, TextPos, Length
   all work as-is (no session dependency). Note: TextPos is 1-based in AL.
-- TaskScheduler — CreateTask (dispatches codeunit synchronously, returns Guid),
-  TaskExists (returns false), CancelTask (no-op), SetTaskReady (no-op)
+- TaskScheduler — CreateTask (dispatches codeunit synchronously, invokes
+  failureCodeunitId on exception, returns Guid), TaskExists (returns false),
+  CancelTask (no-op), SetTaskReady (no-op)
 - DataTransfer — SetTables, AddFieldValue, AddConstantValue, AddJoin, AddSourceFilter,
   CopyFields, CopyRows (all no-ops; requires real database for actual transfer)
 

--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -1100,6 +1100,18 @@ public void ClearApplicationMemberVariables() { }
         if (text == "NavTextBuilder")
             return node.WithIdentifier(SyntaxFactory.Identifier("MockTextBuilder"));
 
+        // NavNotification -> MockNotification
+        // NavNotification.ALSend/ALRecall/ALAddAction require NavSession and the BC
+        // service tier. MockNotification stores state locally and makes I/O calls no-ops.
+        if (text == "NavNotification")
+            return node.WithIdentifier(SyntaxFactory.Identifier("MockNotification"));
+
+        // NavDataTransfer -> MockDataTransfer
+        // NavDataTransfer constructor loads Microsoft.Dynamics.Nav.CodeAnalysis at runtime.
+        // MockDataTransfer stores config but CopyRows/CopyFields are no-ops.
+        if (text == "NavDataTransfer")
+            return node.WithIdentifier(SyntaxFactory.Identifier("MockDataTransfer"));
+
         // NavEventScope -> object (event scope type used for static fields)
         // Use PredefinedType to emit the C# keyword "object" properly, avoiding
         // namespace resolution issues where "object" as an IdentifierName fails.
@@ -1870,6 +1882,20 @@ public void ClearApplicationMemberVariables() { }
                         SyntaxKind.SimpleMemberAccessExpression,
                         SyntaxFactory.IdentifierName("MockSession"),
                         SyntaxFactory.IdentifierName("Sleep")));
+            }
+
+            // ALTaskScheduler.ALCreateTask/ALTaskExists/ALCancelTask/ALSetTaskReady -> MockTaskScheduler
+            // TaskScheduler APIs require the BC service tier. MockTaskScheduler dispatches
+            // CreateTask synchronously via MockCodeunitHandle (same pattern as MockSession).
+            if (exprText == "ALTaskScheduler" &&
+                (methodName == "ALCreateTask" || methodName == "ALTaskExists" ||
+                 methodName == "ALCancelTask" || methodName == "ALSetTaskReady"))
+            {
+                return visited.WithExpression(
+                    SyntaxFactory.MemberAccessExpression(
+                        SyntaxKind.SimpleMemberAccessExpression,
+                        SyntaxFactory.IdentifierName("MockTaskScheduler"),
+                        SyntaxFactory.IdentifierName(methodName)));
             }
 
             // ALCompiler.ToSecretText(navText) -> AlCompat.ToSecretText(navText)

--- a/AlRunner/Runtime/MockDataTransfer.cs
+++ b/AlRunner/Runtime/MockDataTransfer.cs
@@ -1,0 +1,61 @@
+namespace AlRunner.Runtime;
+
+using Microsoft.Dynamics.Nav.Runtime;
+using Microsoft.Dynamics.Nav.Types;
+
+/// <summary>
+/// In-memory replacement for NavDataTransfer.
+/// NavDataTransfer requires Microsoft.Dynamics.Nav.CodeAnalysis at runtime.
+/// This mock stores the configuration but CopyRows/CopyFields are no-ops —
+/// real bulk data transfer requires the BC database engine.
+/// </summary>
+public class MockDataTransfer
+{
+    private int _sourceTableId;
+    private int _targetTableId;
+    private readonly List<(int SourceFieldId, int TargetFieldId)> _fieldMappings = new();
+    private readonly List<(object Value, int TargetFieldId)> _constantValues = new();
+
+    /// <summary>Set source and target table IDs.</summary>
+    public void ALSetTables(int sourceTableId, int targetTableId)
+    {
+        _sourceTableId = sourceTableId;
+        _targetTableId = targetTableId;
+    }
+
+    /// <summary>Map a source field to a target field.</summary>
+    public void ALAddFieldValue(int sourceFieldId, int targetFieldId)
+    {
+        _fieldMappings.Add((sourceFieldId, targetFieldId));
+    }
+
+    /// <summary>Set a constant value for a target field.</summary>
+    public void ALAddConstantValue(object value, int targetFieldId)
+    {
+        _constantValues.Add((value, targetFieldId));
+    }
+
+    /// <summary>Add a join condition. No-op in standalone mode.</summary>
+    public void ALAddJoin(int sourceFieldId, int targetFieldId)
+    {
+        // No-op: join conditions stored but not enforced
+    }
+
+    /// <summary>Add a source filter. No-op in standalone mode.</summary>
+    public void ALAddSourceFilter(int sourceFieldId, string filterExpression)
+    {
+        // No-op
+    }
+
+    /// <summary>Copy field values from source to target. No-op in standalone mode.</summary>
+    public void ALCopyFields()
+    {
+        // No-op: requires real database
+    }
+
+    /// <summary>Copy rows from source to target. No-op in standalone mode.</summary>
+    public void ALCopyRows()
+    {
+        // No-op: requires real database
+    }
+}

--- a/AlRunner/Runtime/MockNotification.cs
+++ b/AlRunner/Runtime/MockNotification.cs
@@ -1,0 +1,79 @@
+namespace AlRunner.Runtime;
+
+using Microsoft.Dynamics.Nav.Runtime;
+using Microsoft.Dynamics.Nav.Types;
+
+/// <summary>
+/// In-memory replacement for NavNotification.
+/// NavNotification.ALSend/ALRecall/ALAddAction require NavSession and the BC service
+/// tier. This mock stores all state locally and makes Send/Recall/AddAction no-ops.
+/// SetData/GetData/HasData use an in-memory dictionary.
+/// </summary>
+public class MockNotification
+{
+    private readonly Dictionary<string, string> _data = new();
+    private readonly List<(string Caption, int CodeunitId, string MethodName)> _actions = new();
+
+    /// <summary>Auto-generated Id, assigned on construction (matches BC behavior).</summary>
+    public Guid ALId { get; set; } = Guid.NewGuid();
+
+    /// <summary>Notification message text.</summary>
+    public string ALMessage { get; set; } = string.Empty;
+
+    /// <summary>Notification scope (LocalScope or GlobalScope). Stored but not enforced.</summary>
+    public NotificationScope ALScope { get; set; } = NotificationScope.LocalScope;
+
+    /// <summary>Send — no-op in standalone mode (no UI to display to).</summary>
+    public void ALSend(DataError errorLevel)
+    {
+        // No-op: standalone mode has no notification UI.
+    }
+
+    /// <summary>Send without DataError parameter.</summary>
+    public void ALSend()
+    {
+        // No-op
+    }
+
+    /// <summary>Recall — no-op in standalone mode.</summary>
+    public void ALRecall(DataError errorLevel)
+    {
+        // No-op
+    }
+
+    /// <summary>Recall without DataError parameter.</summary>
+    public void ALRecall()
+    {
+        // No-op
+    }
+
+    /// <summary>Store a key-value pair on the notification.</summary>
+    public void ALSetData(string key, string value)
+    {
+        _data[key] = value;
+    }
+
+    /// <summary>Retrieve data by key. Returns empty string if not found.</summary>
+    public string ALGetData(string key)
+    {
+        return _data.TryGetValue(key, out var value) ? value : string.Empty;
+    }
+
+    /// <summary>Check whether a key has been set.</summary>
+    public bool ALHasData(string key)
+    {
+        return _data.ContainsKey(key);
+    }
+
+    /// <summary>Register an action on the notification. Stored but not invoked in standalone mode.</summary>
+    public void ALAddAction(string actionCaption, int codeunitId, string functionName)
+    {
+        _actions.Add((actionCaption, codeunitId, functionName));
+    }
+
+    /// <summary>AddAction with description parameter.</summary>
+    public void ALAddAction(string actionCaption, int codeunitId, string functionName, string description)
+    {
+        _actions.Add((actionCaption, codeunitId, functionName));
+    }
+}

--- a/AlRunner/Runtime/MockTaskScheduler.cs
+++ b/AlRunner/Runtime/MockTaskScheduler.cs
@@ -1,0 +1,87 @@
+namespace AlRunner.Runtime;
+
+using Microsoft.Dynamics.Nav.Runtime;
+using Microsoft.Dynamics.Nav.Types;
+
+/// <summary>
+/// Standalone replacement for ALTaskScheduler static methods.
+/// ALTaskScheduler.ALCreateTask/ALTaskExists/ALCancelTask/ALSetTaskReady require
+/// the BC service tier. CreateTask dispatches the codeunit synchronously via
+/// MockCodeunitHandle (same pattern as MockSession.ALStartSession).
+/// </summary>
+public static class MockTaskScheduler
+{
+    /// <summary>
+    /// CreateTask — dispatches the target codeunit synchronously and returns a new Guid.
+    /// Matches ALTaskScheduler.ALCreateTask(int codeunitId, int failureCodeunitId, bool isReady).
+    /// </summary>
+    public static Guid ALCreateTask(int codeunitId, int failureCodeunitId, bool isReady)
+    {
+        var taskId = Guid.NewGuid();
+        try
+        {
+            MockCodeunitHandle.RunCodeunit(codeunitId);
+        }
+        catch
+        {
+            // Swallow: in BC, task failures are logged, not thrown
+        }
+        return taskId;
+    }
+
+    /// <summary>
+    /// CreateTask with company name parameter.
+    /// </summary>
+    public static Guid ALCreateTask(int codeunitId, int failureCodeunitId, bool isReady, string companyName)
+    {
+        return ALCreateTask(codeunitId, failureCodeunitId, isReady);
+    }
+
+    /// <summary>
+    /// CreateTask with company name and NotBefore datetime.
+    /// </summary>
+    public static Guid ALCreateTask(int codeunitId, int failureCodeunitId, bool isReady, string companyName, NavDateTime notBefore)
+    {
+        return ALCreateTask(codeunitId, failureCodeunitId, isReady);
+    }
+
+    /// <summary>
+    /// CreateTask with company name, NotBefore, and RecordId.
+    /// </summary>
+    public static Guid ALCreateTask(int codeunitId, int failureCodeunitId, bool isReady, string companyName, NavDateTime notBefore, NavRecordId recordId)
+    {
+        return ALCreateTask(codeunitId, failureCodeunitId, isReady);
+    }
+
+    /// <summary>
+    /// TaskExists — always returns false (task completed synchronously).
+    /// </summary>
+    public static bool ALTaskExists(Guid taskId)
+    {
+        return false;
+    }
+
+    /// <summary>
+    /// CancelTask — no-op (task already completed synchronously).
+    /// </summary>
+    public static bool ALCancelTask(Guid taskId)
+    {
+        return true;
+    }
+
+    /// <summary>
+    /// SetTaskReady — no-op (task already ran synchronously).
+    /// </summary>
+    public static bool ALSetTaskReady(Guid taskId)
+    {
+        return true;
+    }
+
+    /// <summary>
+    /// SetTaskReady with NotBefore parameter.
+    /// </summary>
+    public static bool ALSetTaskReady(Guid taskId, NavDateTime notBefore)
+    {
+        return true;
+    }
+}

--- a/AlRunner/Runtime/MockTaskScheduler.cs
+++ b/AlRunner/Runtime/MockTaskScheduler.cs
@@ -24,7 +24,17 @@ public static class MockTaskScheduler
         }
         catch
         {
-            // Swallow: in BC, task failures are logged, not thrown
+            if (failureCodeunitId != 0)
+            {
+                try
+                {
+                    MockCodeunitHandle.RunCodeunit(failureCodeunitId);
+                }
+                catch
+                {
+                    // Preserve original task failure if failure handler also fails
+                }
+            }
         }
         return taskId;
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ All notable changes to this project are documented here. Format based on
 
 ## [Unreleased]
 
+### Added
+- **MockNotification** — In-memory replacement for `NavNotification`. Message,
+  Send, Recall, SetData/GetData/HasData, AddAction, Id, Scope. Send and Recall
+  are no-ops; data store is in-memory; Id auto-generates a Guid. (#121)
+- **BigText support** — `NavBigText` works as-is (real BC type, no session
+  dependency). AddText, GetSubText, TextPos, Length all function correctly. (#121)
+- **MockTaskScheduler** — CreateTask dispatches codeunit synchronously via
+  MockCodeunitHandle (same pattern as MockSession.StartSession), returns a Guid.
+  TaskExists returns false, CancelTask/SetTaskReady are no-ops. (#121)
+- **MockDataTransfer** — Minimal stub so code using DataTransfer compiles and
+  runs without error. SetTables, AddFieldValue, AddConstantValue, AddJoin,
+  AddSourceFilter, CopyFields, CopyRows are all no-ops. (#121)
+- Test suite `tests/bucket-2/122-unstubbed-types/` with 21 test cases covering
+  all four types.
+
 ## [1.0.14] - 2026-04-14
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,6 +146,9 @@ dotnet run --project AlRunner -- ./src ./test
 | `AlRunner/Runtime/MockTestPageHandle.cs` | TestPage mock with full lifecycle, field access, navigation |
 | `AlRunner/Runtime/MockRecordRef.cs` | RecordRef backed by MockRecordHandle; Mark/ClearMarks (stubs), Rename, FieldExists, HasFilter, GetPosition, Ascending, ModifyAll |
 | `AlRunner/Runtime/MockFieldRef.cs` | FieldRef with value get/set, range/filter, ALSetTable (no-op stub for BC compiler page API extensions) |
+| `AlRunner/Runtime/MockNotification.cs` | In-memory Notification mock: Message, Send, Recall, SetData/GetData/HasData, AddAction, Id, Scope |
+| `AlRunner/Runtime/MockTaskScheduler.cs` | TaskScheduler stubs: CreateTask (sync dispatch), TaskExists, CancelTask, SetTaskReady |
+| `AlRunner/Runtime/MockDataTransfer.cs` | DataTransfer stubs: SetTables, AddFieldValue, AddConstantValue, CopyFields, CopyRows (no-ops) |
 | `AlRunner/stubs/LibraryAssert.al` | AL stub for codeunit 130 (auto-loaded) |
 | `AlRunner/stubs/LibraryVariableStorage.al` | AL stub for codeunit 131004 (auto-loaded) |
 | `docs/limitations.md` | Full breakdown of architectural limits and behavioral differences |

--- a/tests/bucket-2/122-unstubbed-types/src/BigTextHelper.al
+++ b/tests/bucket-2/122-unstubbed-types/src/BigTextHelper.al
@@ -1,0 +1,58 @@
+codeunit 59821 "BigText Helper"
+{
+    procedure AddAndGetLength(): Integer
+    var
+        BT: BigText;
+    begin
+        BT.AddText('Hello ');
+        BT.AddText('World');
+        exit(BT.Length());
+    end;
+
+    procedure AddAndGetSubText(): Text
+    var
+        BT: BigText;
+        T: Text;
+    begin
+        BT.AddText('Hello World');
+        BT.GetSubText(T, 1, 5);
+        exit(T);
+    end;
+
+    procedure TextPosFound(): Integer
+    var
+        BT: BigText;
+    begin
+        BT.AddText('Hello World');
+        exit(BT.TextPos('World'));
+    end;
+
+    procedure TextPosMissing(): Integer
+    var
+        BT: BigText;
+    begin
+        BT.AddText('Hello World');
+        exit(BT.TextPos('Xyz'));
+    end;
+
+    procedure GetSubTextAcrossBoundary(): Text
+    var
+        BT: BigText;
+        T: Text;
+    begin
+        BT.AddText('Hello');
+        BT.AddText(' World');
+        BT.GetSubText(T, 4, 5);
+        exit(T);
+    end;
+
+    procedure GetSubTextNoLength(): Text
+    var
+        BT: BigText;
+        T: Text;
+    begin
+        BT.AddText('Hello World');
+        BT.GetSubText(T, 7);
+        exit(T);
+    end;
+}

--- a/tests/bucket-2/122-unstubbed-types/src/DataTransferHelper.al
+++ b/tests/bucket-2/122-unstubbed-types/src/DataTransferHelper.al
@@ -32,30 +32,48 @@ table 59811 "DT Target"
 
 codeunit 59823 "DataTransfer Helper"
 {
-    procedure CopyRowsNoError()
+    procedure CopyRowsLeavesTargetEmpty(): Boolean
     var
         DT: DataTransfer;
+        Src: Record "DT Source";
+        Tgt: Record "DT Target";
     begin
+        Src."Entry No." := 1;
+        Src."Name" := 'Test';
+        Src.Insert();
+
         DT.SetTables(Database::"DT Source", Database::"DT Target");
         DT.AddFieldValue(2, 2);
         DT.CopyRows();
+
+        exit(Tgt.IsEmpty());
     end;
 
-    procedure CopyFieldsNoError()
+    procedure CopyFieldsLeavesTargetEmpty(): Boolean
     var
         DT: DataTransfer;
+        Src: Record "DT Source";
+        Tgt: Record "DT Target";
     begin
+        Src."Entry No." := 1;
+        Src."Name" := 'Test';
+        Src.Insert();
+
         DT.SetTables(Database::"DT Source", Database::"DT Target");
         DT.AddFieldValue(2, 2);
         DT.CopyFields();
+
+        exit(Tgt.IsEmpty());
     end;
 
-    procedure AddConstantValueNoError()
+    procedure AddConstantValueNoError(): Boolean
     var
         DT: DataTransfer;
+        Tgt: Record "DT Target";
     begin
         DT.SetTables(Database::"DT Source", Database::"DT Target");
         DT.AddConstantValue('test', 2);
         DT.CopyRows();
+        exit(Tgt.IsEmpty());
     end;
 }

--- a/tests/bucket-2/122-unstubbed-types/src/DataTransferHelper.al
+++ b/tests/bucket-2/122-unstubbed-types/src/DataTransferHelper.al
@@ -1,0 +1,61 @@
+table 59810 "DT Source"
+{
+    DataClassification = ToBeClassified;
+
+    fields
+    {
+        field(1; "Entry No."; Integer) { }
+        field(2; "Name"; Text[100]) { }
+    }
+
+    keys
+    {
+        key(PK; "Entry No.") { Clustered = true; }
+    }
+}
+
+table 59811 "DT Target"
+{
+    DataClassification = ToBeClassified;
+
+    fields
+    {
+        field(1; "Entry No."; Integer) { }
+        field(2; "Name"; Text[100]) { }
+    }
+
+    keys
+    {
+        key(PK; "Entry No.") { Clustered = true; }
+    }
+}
+
+codeunit 59823 "DataTransfer Helper"
+{
+    procedure CopyRowsNoError()
+    var
+        DT: DataTransfer;
+    begin
+        DT.SetTables(Database::"DT Source", Database::"DT Target");
+        DT.AddFieldValue(2, 2);
+        DT.CopyRows();
+    end;
+
+    procedure CopyFieldsNoError()
+    var
+        DT: DataTransfer;
+    begin
+        DT.SetTables(Database::"DT Source", Database::"DT Target");
+        DT.AddFieldValue(2, 2);
+        DT.CopyFields();
+    end;
+
+    procedure AddConstantValueNoError()
+    var
+        DT: DataTransfer;
+    begin
+        DT.SetTables(Database::"DT Source", Database::"DT Target");
+        DT.AddConstantValue('test', 2);
+        DT.CopyRows();
+    end;
+}

--- a/tests/bucket-2/122-unstubbed-types/src/NotificationHelper.al
+++ b/tests/bucket-2/122-unstubbed-types/src/NotificationHelper.al
@@ -32,13 +32,14 @@ codeunit 59820 "Notification Helper"
         exit(N.HasData('nonexistent'));
     end;
 
-    procedure RecallNotification()
+    procedure RecallNotification(): Guid
     var
         N: Notification;
     begin
         N.Message := 'To recall';
         N.Send();
         N.Recall();
+        exit(N.Id);
     end;
 
     procedure GetMessage(): Text
@@ -49,21 +50,24 @@ codeunit 59820 "Notification Helper"
         exit(N.Message);
     end;
 
-    procedure SetScope()
+    procedure SetScopeAndGetId(): Guid
     var
         N: Notification;
     begin
         N.Scope := NotificationScope::LocalScope;
+        N.Message := 'Scoped notification';
         N.Send();
+        exit(N.Id);
     end;
 
-    procedure AddActionNoError()
+    procedure AddActionAndGetMessage(): Text
     var
         N: Notification;
     begin
         N.Message := 'With action';
         N.AddAction('Click', Codeunit::"Notification Helper", 'HandleAction');
         N.Send();
+        exit(N.Message);
     end;
 
     procedure HandleAction(N: Notification)

--- a/tests/bucket-2/122-unstubbed-types/src/NotificationHelper.al
+++ b/tests/bucket-2/122-unstubbed-types/src/NotificationHelper.al
@@ -1,0 +1,73 @@
+codeunit 59820 "Notification Helper"
+{
+    procedure CreateAndSend(): Guid
+    var
+        N: Notification;
+    begin
+        N.Message := 'Test notification';
+        N.Send();
+        exit(N.Id);
+    end;
+
+    procedure SetAndGetData(DataKey: Text; DataValue: Text): Text
+    var
+        N: Notification;
+    begin
+        N.SetData(DataKey, DataValue);
+        exit(N.GetData(DataKey));
+    end;
+
+    procedure HasDataForKey(DataKey: Text): Boolean
+    var
+        N: Notification;
+    begin
+        N.SetData(DataKey, 'val');
+        exit(N.HasData(DataKey));
+    end;
+
+    procedure HasDataForMissingKey(): Boolean
+    var
+        N: Notification;
+    begin
+        exit(N.HasData('nonexistent'));
+    end;
+
+    procedure RecallNotification()
+    var
+        N: Notification;
+    begin
+        N.Message := 'To recall';
+        N.Send();
+        N.Recall();
+    end;
+
+    procedure GetMessage(): Text
+    var
+        N: Notification;
+    begin
+        N.Message := 'My message';
+        exit(N.Message);
+    end;
+
+    procedure SetScope()
+    var
+        N: Notification;
+    begin
+        N.Scope := NotificationScope::LocalScope;
+        N.Send();
+    end;
+
+    procedure AddActionNoError()
+    var
+        N: Notification;
+    begin
+        N.Message := 'With action';
+        N.AddAction('Click', Codeunit::"Notification Helper", 'HandleAction');
+        N.Send();
+    end;
+
+    procedure HandleAction(N: Notification)
+    begin
+        // Handler stub
+    end;
+}

--- a/tests/bucket-2/122-unstubbed-types/src/TaskSchedulerHelper.al
+++ b/tests/bucket-2/122-unstubbed-types/src/TaskSchedulerHelper.al
@@ -1,0 +1,31 @@
+codeunit 59822 "TaskScheduler Helper"
+{
+    procedure CreateTaskReturnsGuid(): Guid
+    begin
+        exit(TaskScheduler.CreateTask(Codeunit::"TaskScheduler Helper", 0, true));
+    end;
+
+    procedure TaskExistsReturnsBool(): Boolean
+    var
+        TaskId: Guid;
+    begin
+        TaskId := TaskScheduler.CreateTask(Codeunit::"TaskScheduler Helper", 0, true);
+        exit(TaskScheduler.TaskExists(TaskId));
+    end;
+
+    procedure CancelTaskNoError()
+    var
+        TaskId: Guid;
+    begin
+        TaskId := TaskScheduler.CreateTask(Codeunit::"TaskScheduler Helper", 0, true);
+        TaskScheduler.CancelTask(TaskId);
+    end;
+
+    procedure SetTaskReadyNoError()
+    var
+        TaskId: Guid;
+    begin
+        TaskId := TaskScheduler.CreateTask(Codeunit::"TaskScheduler Helper", 0, true);
+        TaskScheduler.SetTaskReady(TaskId);
+    end;
+}

--- a/tests/bucket-2/122-unstubbed-types/src/TaskSchedulerHelper.al
+++ b/tests/bucket-2/122-unstubbed-types/src/TaskSchedulerHelper.al
@@ -13,19 +13,19 @@ codeunit 59822 "TaskScheduler Helper"
         exit(TaskScheduler.TaskExists(TaskId));
     end;
 
-    procedure CancelTaskNoError()
+    procedure CancelTaskReturnsTrue(): Boolean
     var
         TaskId: Guid;
     begin
         TaskId := TaskScheduler.CreateTask(Codeunit::"TaskScheduler Helper", 0, true);
-        TaskScheduler.CancelTask(TaskId);
+        exit(TaskScheduler.CancelTask(TaskId));
     end;
 
-    procedure SetTaskReadyNoError()
+    procedure SetTaskReadyReturnsTrue(): Boolean
     var
         TaskId: Guid;
     begin
         TaskId := TaskScheduler.CreateTask(Codeunit::"TaskScheduler Helper", 0, true);
-        TaskScheduler.SetTaskReady(TaskId);
+        exit(TaskScheduler.SetTaskReady(TaskId));
     end;
 }

--- a/tests/bucket-2/122-unstubbed-types/test/UnstubbedTypesTests.al
+++ b/tests/bucket-2/122-unstubbed-types/test/UnstubbedTypesTests.al
@@ -47,12 +47,15 @@ codeunit 59830 "Unstubbed Types Tests"
     end;
 
     [Test]
-    procedure NotificationRecallNoError()
+    procedure NotificationRecallPreservesId()
     var
         Helper: Codeunit "Notification Helper";
+        Id: Guid;
+        EmptyGuid: Guid;
     begin
-        // Positive: Recall completes without error
-        Helper.RecallNotification();
+        // Positive: Recall completes and Id is still accessible
+        Id := Helper.RecallNotification();
+        Assert.AreNotEqual(EmptyGuid, Id, 'Notification.Id should be non-empty after Recall');
     end;
 
     [Test]
@@ -65,21 +68,24 @@ codeunit 59830 "Unstubbed Types Tests"
     end;
 
     [Test]
-    procedure NotificationScopeNoError()
+    procedure NotificationScopePreservesId()
     var
         Helper: Codeunit "Notification Helper";
+        Id: Guid;
+        EmptyGuid: Guid;
     begin
-        // Positive: Setting Scope and sending does not error
-        Helper.SetScope();
+        // Positive: Setting Scope and sending preserves Id
+        Id := Helper.SetScopeAndGetId();
+        Assert.AreNotEqual(EmptyGuid, Id, 'Notification with Scope should have non-empty Id after Send');
     end;
 
     [Test]
-    procedure NotificationAddActionNoError()
+    procedure NotificationAddActionPreservesMessage()
     var
         Helper: Codeunit "Notification Helper";
     begin
-        // Positive: AddAction + Send does not error
-        Helper.AddActionNoError();
+        // Positive: AddAction + Send preserves the message
+        Assert.AreEqual('With action', Helper.AddActionAndGetMessage(), 'Notification.Message should be preserved after AddAction + Send');
     end;
 
     // === BigText Tests ===
@@ -153,58 +159,58 @@ codeunit 59830 "Unstubbed Types Tests"
     end;
 
     [Test]
-    procedure TaskSchedulerTaskExistsReturnsBool()
+    procedure TaskSchedulerTaskExistsReturnsFalse()
     var
         Helper: Codeunit "TaskScheduler Helper";
     begin
-        // Positive: TaskExists returns a boolean (no crash)
-        Helper.TaskExistsReturnsBool();
+        // Positive: TaskExists returns false (task ran synchronously, no longer active)
+        Assert.IsFalse(Helper.TaskExistsReturnsBool(), 'TaskExists should return false for a completed synchronous task');
     end;
 
     [Test]
-    procedure TaskSchedulerCancelTaskNoError()
+    procedure TaskSchedulerCancelTaskReturnsTrue()
     var
         Helper: Codeunit "TaskScheduler Helper";
     begin
-        // Positive: CancelTask completes without error
-        Helper.CancelTaskNoError();
+        // Positive: CancelTask returns true (no-op success)
+        Assert.IsTrue(Helper.CancelTaskReturnsTrue(), 'CancelTask should return true');
     end;
 
     [Test]
-    procedure TaskSchedulerSetTaskReadyNoError()
+    procedure TaskSchedulerSetTaskReadyReturnsTrue()
     var
         Helper: Codeunit "TaskScheduler Helper";
     begin
-        // Positive: SetTaskReady completes without error
-        Helper.SetTaskReadyNoError();
+        // Positive: SetTaskReady returns true (no-op success)
+        Assert.IsTrue(Helper.SetTaskReadyReturnsTrue(), 'SetTaskReady should return true');
     end;
 
     // === DataTransfer Tests ===
 
     [Test]
-    procedure DataTransferCopyRowsNoError()
+    procedure DataTransferCopyRowsIsNoOp()
     var
         Helper: Codeunit "DataTransfer Helper";
     begin
-        // Positive: SetTables + AddFieldValue + CopyRows completes
-        Helper.CopyRowsNoError();
+        // Positive: CopyRows is a no-op — target table remains empty
+        Assert.IsTrue(Helper.CopyRowsLeavesTargetEmpty(), 'CopyRows should be a no-op: target must remain empty');
     end;
 
     [Test]
-    procedure DataTransferCopyFieldsNoError()
+    procedure DataTransferCopyFieldsIsNoOp()
     var
         Helper: Codeunit "DataTransfer Helper";
     begin
-        // Positive: CopyFields completes without error
-        Helper.CopyFieldsNoError();
+        // Positive: CopyFields is a no-op — target table remains empty
+        Assert.IsTrue(Helper.CopyFieldsLeavesTargetEmpty(), 'CopyFields should be a no-op: target must remain empty');
     end;
 
     [Test]
-    procedure DataTransferAddConstantValueNoError()
+    procedure DataTransferAddConstantValueIsNoOp()
     var
         Helper: Codeunit "DataTransfer Helper";
     begin
-        // Positive: AddConstantValue + CopyRows completes
-        Helper.AddConstantValueNoError();
+        // Positive: AddConstantValue + CopyRows is a no-op
+        Assert.IsTrue(Helper.AddConstantValueNoError(), 'AddConstantValue + CopyRows should be a no-op: target must remain empty');
     end;
 }

--- a/tests/bucket-2/122-unstubbed-types/test/UnstubbedTypesTests.al
+++ b/tests/bucket-2/122-unstubbed-types/test/UnstubbedTypesTests.al
@@ -1,0 +1,210 @@
+codeunit 59830 "Unstubbed Types Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    // === Notification Tests ===
+
+    [Test]
+    procedure NotificationSendNoError()
+    var
+        Helper: Codeunit "Notification Helper";
+        Id: Guid;
+        EmptyGuid: Guid;
+    begin
+        // Positive: Send completes without error and Id is a non-empty Guid
+        Id := Helper.CreateAndSend();
+        Assert.AreNotEqual(EmptyGuid, Id, 'Notification.Id should be non-empty after creation');
+    end;
+
+    [Test]
+    procedure NotificationSetGetDataRoundTrip()
+    var
+        Helper: Codeunit "Notification Helper";
+    begin
+        // Positive: SetData/GetData preserves the value
+        Assert.AreEqual('myvalue', Helper.SetAndGetData('mykey', 'myvalue'), 'GetData should return the value set by SetData');
+    end;
+
+    [Test]
+    procedure NotificationHasDataTrue()
+    var
+        Helper: Codeunit "Notification Helper";
+    begin
+        // Positive: HasData returns true for a key that was set
+        Assert.IsTrue(Helper.HasDataForKey('testkey'), 'HasData should return true for a set key');
+    end;
+
+    [Test]
+    procedure NotificationHasDataFalse()
+    var
+        Helper: Codeunit "Notification Helper";
+    begin
+        // Negative: HasData returns false for a key that was not set
+        Assert.IsFalse(Helper.HasDataForMissingKey(), 'HasData should return false for a missing key');
+    end;
+
+    [Test]
+    procedure NotificationRecallNoError()
+    var
+        Helper: Codeunit "Notification Helper";
+    begin
+        // Positive: Recall completes without error
+        Helper.RecallNotification();
+    end;
+
+    [Test]
+    procedure NotificationMessageProperty()
+    var
+        Helper: Codeunit "Notification Helper";
+    begin
+        // Positive: Message property round-trips
+        Assert.AreEqual('My message', Helper.GetMessage(), 'Message property should return what was set');
+    end;
+
+    [Test]
+    procedure NotificationScopeNoError()
+    var
+        Helper: Codeunit "Notification Helper";
+    begin
+        // Positive: Setting Scope and sending does not error
+        Helper.SetScope();
+    end;
+
+    [Test]
+    procedure NotificationAddActionNoError()
+    var
+        Helper: Codeunit "Notification Helper";
+    begin
+        // Positive: AddAction + Send does not error
+        Helper.AddActionNoError();
+    end;
+
+    // === BigText Tests ===
+
+    [Test]
+    procedure BigTextAddTextAndLength()
+    var
+        Helper: Codeunit "BigText Helper";
+    begin
+        // Positive: Two AddText calls, length = sum of both
+        Assert.AreEqual(11, Helper.AddAndGetLength(), 'BigText.Length should be 11 for "Hello World"');
+    end;
+
+    [Test]
+    procedure BigTextGetSubText()
+    var
+        Helper: Codeunit "BigText Helper";
+    begin
+        // Positive: GetSubText(1, 5) returns first 5 chars
+        Assert.AreEqual('Hello', Helper.AddAndGetSubText(), 'GetSubText(1, 5) should return "Hello"');
+    end;
+
+    [Test]
+    procedure BigTextTextPosFound()
+    var
+        Helper: Codeunit "BigText Helper";
+    begin
+        // Positive: TextPos finds "World" at position 7 (1-based)
+        Assert.AreEqual(7, Helper.TextPosFound(), 'TextPos("World") should return 7');
+    end;
+
+    [Test]
+    procedure BigTextTextPosMissing()
+    var
+        Helper: Codeunit "BigText Helper";
+    begin
+        // Negative: TextPos returns 0 for missing text
+        Assert.AreEqual(0, Helper.TextPosMissing(), 'TextPos should return 0 for missing text');
+    end;
+
+    [Test]
+    procedure BigTextGetSubTextAcrossBoundary()
+    var
+        Helper: Codeunit "BigText Helper";
+    begin
+        // Positive: GetSubText across AddText boundary
+        Assert.AreEqual('lo Wo', Helper.GetSubTextAcrossBoundary(), 'GetSubText should work across AddText boundaries');
+    end;
+
+    [Test]
+    procedure BigTextGetSubTextToEnd()
+    var
+        Helper: Codeunit "BigText Helper";
+    begin
+        // Positive: GetSubText without length returns from position to end
+        Assert.AreEqual('World', Helper.GetSubTextNoLength(), 'GetSubText without length should return to end');
+    end;
+
+    // === TaskScheduler Tests ===
+
+    [Test]
+    procedure TaskSchedulerCreateTaskReturnsGuid()
+    var
+        Helper: Codeunit "TaskScheduler Helper";
+        Id: Guid;
+        EmptyGuid: Guid;
+    begin
+        // Positive: CreateTask returns a non-empty Guid
+        Id := Helper.CreateTaskReturnsGuid();
+        Assert.AreNotEqual(EmptyGuid, Id, 'CreateTask should return a non-empty Guid');
+    end;
+
+    [Test]
+    procedure TaskSchedulerTaskExistsReturnsBool()
+    var
+        Helper: Codeunit "TaskScheduler Helper";
+    begin
+        // Positive: TaskExists returns a boolean (no crash)
+        Helper.TaskExistsReturnsBool();
+    end;
+
+    [Test]
+    procedure TaskSchedulerCancelTaskNoError()
+    var
+        Helper: Codeunit "TaskScheduler Helper";
+    begin
+        // Positive: CancelTask completes without error
+        Helper.CancelTaskNoError();
+    end;
+
+    [Test]
+    procedure TaskSchedulerSetTaskReadyNoError()
+    var
+        Helper: Codeunit "TaskScheduler Helper";
+    begin
+        // Positive: SetTaskReady completes without error
+        Helper.SetTaskReadyNoError();
+    end;
+
+    // === DataTransfer Tests ===
+
+    [Test]
+    procedure DataTransferCopyRowsNoError()
+    var
+        Helper: Codeunit "DataTransfer Helper";
+    begin
+        // Positive: SetTables + AddFieldValue + CopyRows completes
+        Helper.CopyRowsNoError();
+    end;
+
+    [Test]
+    procedure DataTransferCopyFieldsNoError()
+    var
+        Helper: Codeunit "DataTransfer Helper";
+    begin
+        // Positive: CopyFields completes without error
+        Helper.CopyFieldsNoError();
+    end;
+
+    [Test]
+    procedure DataTransferAddConstantValueNoError()
+    var
+        Helper: Codeunit "DataTransfer Helper";
+    begin
+        // Positive: AddConstantValue + CopyRows completes
+        Helper.AddConstantValueNoError();
+    end;
+}


### PR DESCRIPTION
## Summary

Implements runtime support for 4 unstubbed types identified in #121:

| Type | Approach | Mock class |
|------|----------|------------|
| **Notification** | Full mock | `MockNotification` — Message, Send, Recall, SetData/GetData/HasData, AddAction, Id, Scope |
| **BigText** | No mock needed | Real `NavBigText` works standalone (no session dependency) |
| **TaskScheduler** | Static stubs | `MockTaskScheduler` — CreateTask dispatches synchronously, TaskExists/CancelTask/SetTaskReady are stubs |
| **DataTransfer** | Minimal stub | `MockDataTransfer` — SetTables, AddFieldValue, AddConstantValue, CopyRows/CopyFields are no-ops |

### Changes
- **3 new mock classes**: `MockNotification.cs`, `MockTaskScheduler.cs`, `MockDataTransfer.cs`
- **3 rewriter rules**: `NavNotification→MockNotification`, `NavDataTransfer→MockDataTransfer`, `ALTaskScheduler→MockTaskScheduler`
- **21 new tests** in `tests/bucket-2/122-unstubbed-types/` — all pass
- **Full suite**: all tests pass with zero regressions
- Updated `PrintGuide()`, `CHANGELOG.md`, `CLAUDE.md`

### Design Decisions
- **BigText**: `NavBigText` works without mocking — it has no session/DB dependencies. Tests exercise it directly.
- **TaskScheduler.CreateTask**: Dispatches the target codeunit synchronously (same as `MockSession.ALStartSession`). Returns a new GUID.
- **DataTransfer**: CopyRows/CopyFields are no-ops since cross-table data transfer requires DB infrastructure. Tests verify methods compile and don't crash.
- **Notification**: Full in-memory implementation with data bag, scope, and action tracking. Send/Recall are no-ops (no UI).

Closes #121