### PR TITLE
feat: temporary records & FlowField sum/count/lookup (#120)

### DIFF
--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -243,11 +243,16 @@ test executor that needs no BC service tier, Docker, SQL Server, or license.
 
 - Pure-logic codeunits (arithmetic, string ops, record CRUD, enums, options)
 - In-memory table store: Insert, Modify, Get, Delete, FindSet, FindFirst, FindLast, Next
+- Temporary records — `Record "X" temporary` uses an isolated in-memory store per variable,
+  separate from non-temporary records. `IsTemporary()` returns the correct value.
+  `RecordRef.Open(tableId, true)` opens a temporary RecordRef.
 - TransferFields, CountApprox, Consistent (no-op), FieldActive (true), AddLink/HasLinks/DeleteLinks
 - WritePermission/ReadPermission (true), SetPermissionFilter (no-op), LockTable (no-op)
 - Composite primary keys, sort ordering (SetCurrentKey / SetAscending), CurrentKey, Ascending
 - SETRANGE / SETFILTER filtering (=, <>, <, <=, >, >=, wildcards, OR via |)
 - GetFilter(field), GetFilters, HasFilter — return active filter expressions
+- FlowField CalcFormula — CalcFields evaluates exist(), count(), sum(), and lookup() formulas
+  against the in-memory table store. Where-clause conditions support field() and const() references.
 - Cross-codeunit dispatch (Codeunit.Run, Codeunit.Run(id, Rec) with record parameter, direct codeunit variable calls)
 - AL interfaces for dependency injection
 - `asserterror` blocks + `GetLastErrorText()`

--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -1158,16 +1158,19 @@ public void ClearApplicationMemberVariables() { }
         var visited = (ObjectCreationExpressionSyntax)base.VisitObjectCreationExpression(node)!;
         var typeText = visited.Type.ToString();
 
-        // new NavRecordHandle(this, NNN, false, SecurityFiltering.XXX) -> new MockRecordHandle(NNN)
+        // new NavRecordHandle(this, NNN, temp, SecurityFiltering.XXX) -> new MockRecordHandle(NNN, temp)
         // After identifier replacement, this is already MockRecordHandle
         if (typeText == "MockRecordHandle" && visited.ArgumentList != null &&
             visited.ArgumentList.Arguments.Count >= 4)
         {
-            // The second argument is the table ID
             var tableIdArg = visited.ArgumentList.Arguments[1];
+            var tempArg = visited.ArgumentList.Arguments[2];
             var newArgs = SyntaxFactory.ArgumentList(
-                SyntaxFactory.SingletonSeparatedList(
-                    SyntaxFactory.Argument(tableIdArg.Expression)));
+                SyntaxFactory.SeparatedList(new[]
+                {
+                    SyntaxFactory.Argument(tableIdArg.Expression),
+                    SyntaxFactory.Argument(tempArg.Expression)
+                }));
             return visited.WithArgumentList(newArgs);
         }
 

--- a/AlRunner/Runtime/CalcFormulaRegistry.cs
+++ b/AlRunner/Runtime/CalcFormulaRegistry.cs
@@ -25,19 +25,12 @@ public static class CalcFormulaRegistry
         @"\bfield\s*\(\s*(\d+)\s*;\s*(?:""([^""]+)""|([A-Za-z_][A-Za-z0-9_]*))\s*;\s*([^)]+?)\)\s*\{([^}]*)\}",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
-    // `CalcFormula = exist(...)` — the argument list can contain nested
-    // parens (e.g. `where(C1 = field(Code1), C2 = field(Code2))`), so regex
-    // alone can't capture the full body. We locate the `exist(` keyword
-    // and then walk parens manually.
-    private static readonly Regex ExistKeyword = new(
-        @"\bCalcFormula\s*=\s*exist\s*\(",
-        RegexOptions.Compiled | RegexOptions.IgnoreCase);
-
-    // Inner head of the exist body: target table name, optionally followed
-    // by `where(...)`. `([\s\S]*)` is a catch-all — we hand-carve the
-    // where body off the end so this only needs to match the target name.
-    private static readonly Regex ExistBodyHead = new(
-        @"^\s*(?:""([^""]+)""|([A-Za-z_][A-Za-z0-9_]*))\s*(?:where\s*\(([\s\S]*)\))?\s*$",
+    // `CalcFormula = exist|count|sum|lookup(...)` — the argument list can
+    // contain nested parens (e.g. `where(C1 = field(Code1))`), so regex
+    // alone can't capture the full body. We locate the keyword and then
+    // walk parens manually.
+    private static readonly Regex FormulaKeyword = new(
+        @"\bCalcFormula\s*=\s*(exist|count|sum|lookup|min|max|average)\s*\(",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
     // Single condition: ChildField = field(SelfField)  | ChildField = const(Value)
@@ -94,33 +87,55 @@ public static class CalcFormulaRegistry
             {
                 if (!int.TryParse(fm.Groups[1].Value, out var fieldId)) continue;
                 var fieldBody = fm.Groups[5].Value;
-                var ek = ExistKeyword.Match(fieldBody);
-                if (!ek.Success) continue;
+                var fk = FormulaKeyword.Match(fieldBody);
+                if (!fk.Success) continue;
 
-                // Walk parens from the `(` of `exist(` to the matching `)`.
-                int openParen = ek.Index + ek.Length - 1; // points at the `(`
+                var kindText = fk.Groups[1].Value.ToLowerInvariant();
+                var kind = kindText switch
+                {
+                    "exist"   => FormulaKind.Exist,
+                    "count"   => FormulaKind.Count,
+                    "sum"     => FormulaKind.Sum,
+                    "lookup"  => FormulaKind.Lookup,
+                    "min"     => FormulaKind.Min,
+                    "max"     => FormulaKind.Max,
+                    "average" => FormulaKind.Average,
+                    _         => FormulaKind.Exist,
+                };
+
+                // Walk parens from the `(` of `keyword(` to the matching `)`.
+                int openParen = fk.Index + fk.Length - 1;
                 int close = FindMatchingParen(fieldBody, openParen);
                 if (close < 0) continue;
-                var existBody = fieldBody.Substring(openParen + 1, close - openParen - 1);
+                var formulaBody = fieldBody.Substring(openParen + 1, close - openParen - 1);
 
-                // Split off a trailing `where(...)` clause if present.
+                // For sum/lookup/min/max/average the body is:
+                //   "Table"."Field" where(...)
+                // For exist/count it's just:
+                //   "Table" where(...)
                 string targetTable;
+                string? targetField = null;
                 string whereText = "";
-                var whereIdx = FindTopLevelKeyword(existBody, "where");
+
+                // Split off a trailing `where(...)` clause first.
+                string preWhere;
+                var whereIdx = FindTopLevelKeyword(formulaBody, "where");
                 if (whereIdx >= 0)
                 {
-                    targetTable = existBody.Substring(0, whereIdx).Trim().Trim('"');
-                    // `where(` then match parens.
-                    int whereOpen = existBody.IndexOf('(', whereIdx);
+                    preWhere = formulaBody.Substring(0, whereIdx).Trim();
+                    int whereOpen = formulaBody.IndexOf('(', whereIdx);
                     if (whereOpen < 0) continue;
-                    int whereClose = FindMatchingParen(existBody, whereOpen);
+                    int whereClose = FindMatchingParen(formulaBody, whereOpen);
                     if (whereClose < 0) continue;
-                    whereText = existBody.Substring(whereOpen + 1, whereClose - whereOpen - 1);
+                    whereText = formulaBody.Substring(whereOpen + 1, whereClose - whereOpen - 1);
                 }
                 else
                 {
-                    targetTable = existBody.Trim().Trim('"');
+                    preWhere = formulaBody.Trim();
                 }
+
+                // Parse "Table"."Field" or "Table" from preWhere.
+                ParseTableAndField(preWhere, out targetTable, out targetField);
 
                 var clauses = new List<WhereClause>();
                 foreach (var cond in SplitTopLevelCommas(whereText))
@@ -133,11 +148,33 @@ public static class CalcFormulaRegistry
                     clauses.Add(new WhereClause(childField, opKind, val.Trim()));
                 }
 
-                var formula = new Formula(tableId, fieldId, FormulaKind.Exist, targetTable, null, clauses);
+                var formula = new Formula(tableId, fieldId, kind, targetTable, targetField, clauses);
                 if (!_byTable.TryGetValue(tableId, out var list))
                     _byTable[tableId] = list = new List<Formula>();
                 list.Add(formula);
             }
+        }
+    }
+
+    /// <summary>
+    /// Parse "Table"."Field" or "Table" from the pre-where portion of a formula body.
+    /// Handles quoted and unquoted identifiers.
+    /// </summary>
+    private static void ParseTableAndField(string text, out string tableName, out string? fieldName)
+    {
+        fieldName = null;
+        // Pattern: "Table"."Field" or Table."Field" etc.
+        // Split on a dot that separates two quoted or unquoted identifiers.
+        var dotMatch = Regex.Match(text,
+            @"^\s*(?:""([^""]+)""|([A-Za-z_][A-Za-z0-9_ ]*))\s*\.\s*(?:""([^""]+)""|([A-Za-z_][A-Za-z0-9_ ]*))\s*$");
+        if (dotMatch.Success)
+        {
+            tableName = (dotMatch.Groups[1].Success ? dotMatch.Groups[1].Value : dotMatch.Groups[2].Value).Trim();
+            fieldName = (dotMatch.Groups[3].Success ? dotMatch.Groups[3].Value : dotMatch.Groups[4].Value).Trim();
+        }
+        else
+        {
+            tableName = text.Trim().Trim('"');
         }
     }
 

--- a/AlRunner/Runtime/MockRecordHandle.cs
+++ b/AlRunner/Runtime/MockRecordHandle.cs
@@ -20,6 +20,11 @@ public class MockRecordHandle
     public int TableId => _tableId;
     private Dictionary<int, NavValue> _fields = new();
 
+    // Whether this handle represents a temporary record variable.
+    private readonly bool _isTemporary;
+    // Private row store for temporary records — isolated from the global _tables.
+    private readonly List<Dictionary<int, NavValue>>? _tempRows;
+
     // Global in-memory table store: tableId -> list of rows (each row = dict of fieldNo -> NavValue)
     private static readonly Dictionary<int, List<Dictionary<int, NavValue>>> _tables = new();
 
@@ -41,12 +46,29 @@ public class MockRecordHandle
     // Field name -> field number mapping per table (registered via RegisterFieldName)
     private static readonly Dictionary<int, Dictionary<string, int>> _fieldNames = new();
 
-    public MockRecordHandle(int tableId)
+    public MockRecordHandle(int tableId) : this(tableId, false) { }
+
+    public MockRecordHandle(int tableId, bool temporary)
     {
         _tableId = tableId;
-        if (!_tables.ContainsKey(tableId))
-            _tables[tableId] = new List<Dictionary<int, NavValue>>();
+        _isTemporary = temporary;
+        if (temporary)
+        {
+            _tempRows = new List<Dictionary<int, NavValue>>();
+        }
+        else
+        {
+            if (!_tables.ContainsKey(tableId))
+                _tables[tableId] = new List<Dictionary<int, NavValue>>();
+        }
     }
+
+    /// <summary>
+    /// Returns the row list for this handle — the private temp store for
+    /// temporary records, or the shared global table for non-temporary ones.
+    /// </summary>
+    private List<Dictionary<int, NavValue>> GetRows()
+        => _isTemporary ? _tempRows! : _tables[_tableId];
 
     /// <summary>Reset all tables between test runs.</summary>
     public static void ResetAll()
@@ -269,7 +291,7 @@ public class MockRecordHandle
 
     public bool ALInsert(DataError errorLevel, bool runTrigger)
     {
-        var table = _tables[_tableId];
+        var table = GetRows();
 
         // Fire OnBeforeInsertEvent(var Rec, RunTrigger: Boolean)
         // — always fires, regardless of runTrigger
@@ -403,7 +425,7 @@ public class MockRecordHandle
 
     public bool ALModify(DataError errorLevel, bool runTrigger)
     {
-        var table = _tables[_tableId];
+        var table = GetRows();
         var pkFields = GetPrimaryKeyFields();
 
         // Capture xRec (snapshot before mutation) for event subscribers
@@ -442,8 +464,8 @@ public class MockRecordHandle
 
     public void ALModifyAllSafe(int fieldNo, NavType expectedType, NavValue value, bool runTrigger)
     {
-        if (!_tables.TryGetValue(_tableId, out var table))
-            return;
+        var table = GetRows();
+        if (table.Count == 0) return;
         var filtered = GetFilteredRecords();
         var pkFields = GetPrimaryKeyFields();
         foreach (var filteredRow in filtered)
@@ -462,7 +484,7 @@ public class MockRecordHandle
 
     public bool ALGet(DataError errorLevel, params NavValue[] keyValues)
     {
-        var table = _tables[_tableId];
+        var table = GetRows();
         var pkFields = GetPrimaryKeyFields();
         foreach (var row in table)
         {
@@ -490,8 +512,7 @@ public class MockRecordHandle
 
     public bool ALGetBySystemId(DataError errorLevel, Guid systemId)
     {
-        if (!_tables.TryGetValue(_tableId, out var table))
-            return false;
+        var table = GetRows();
 
         foreach (var row in table)
         {
@@ -601,7 +622,7 @@ public class MockRecordHandle
 
     public bool ALDelete(DataError errorLevel, bool runTrigger = false)
     {
-        var table = _tables[_tableId];
+        var table = GetRows();
         var pkFields = GetPrimaryKeyFields();
 
         // Fire OnBeforeDeleteEvent(var Rec, RunTrigger: Boolean)
@@ -644,12 +665,12 @@ public class MockRecordHandle
         if (_filters.Count == 0)
         {
             // No filters: delete all records in the table
-            _tables[_tableId] = new List<Dictionary<int, NavValue>>();
+            GetRows().Clear();
         }
         else
         {
             // Filters active: only delete matching records
-            var table = _tables[_tableId];
+            var table = GetRows();
             var toRemove = GetFilteredRecords();
             var toRemoveKeys = new HashSet<string>(
                 toRemove.Select(r => RowKey(r)));
@@ -823,9 +844,7 @@ public class MockRecordHandle
     public bool HasField(int fieldNo)
     {
         if (_fields.ContainsKey(fieldNo)) return true;
-        if (_tables.TryGetValue(_tableId, out var rows))
-            return rows.Any(r => r.ContainsKey(fieldNo));
-        return false;
+        return GetRows().Any(r => r.ContainsKey(fieldNo));
     }
 
     /// <summary>
@@ -1026,7 +1045,7 @@ public class MockRecordHandle
     /// AL's CALCFIELDS — calculates FlowFields by consulting the
     /// transpile-time <see cref="CalcFormulaRegistry"/> and evaluating
     /// <c>exist(...)</c> formulas against the in-memory tables.
-    /// Other formula kinds (count/sum/lookup/...) remain no-ops.
+    /// Other formula kinds (min/max/average) remain no-ops.
     /// </summary>
     public void ALCalcFields(DataError errorLevel, params int[] fieldNos)
     {
@@ -1035,32 +1054,81 @@ public class MockRecordHandle
             var formula = CalcFormulaRegistry.Find(_tableId, fieldNo);
             if (formula is null) continue;
 
-            if (formula.Kind == CalcFormulaRegistry.FormulaKind.Exist)
+            switch (formula.Kind)
             {
-                bool exists = EvaluateExistFormula(formula);
-                _fields[fieldNo] = NavBoolean.Create(exists);
+                case CalcFormulaRegistry.FormulaKind.Exist:
+                {
+                    var rows = GetMatchingRows(formula);
+                    _fields[fieldNo] = NavBoolean.Create(rows.Any());
+                    break;
+                }
+                case CalcFormulaRegistry.FormulaKind.Count:
+                {
+                    var rows = GetMatchingRows(formula);
+                    _fields[fieldNo] = NavInteger.Create(rows.Count);
+                    break;
+                }
+                case CalcFormulaRegistry.FormulaKind.Sum:
+                {
+                    var rows = GetMatchingRows(formula);
+                    var targetId = CalcFormulaRegistry.GetTableIdByName(formula.TargetTableName);
+                    var aggFieldId = targetId.HasValue && formula.TargetAggregateField != null
+                        ? ResolveField(targetId.Value, formula.TargetAggregateField)
+                        : null;
+                    decimal sum = 0m;
+                    if (aggFieldId.HasValue)
+                    {
+                        foreach (var row in rows)
+                        {
+                            if (row.TryGetValue(aggFieldId.Value, out var val))
+                                sum += NavValueToDecimal(val);
+                        }
+                    }
+                    _fields[fieldNo] = NavDecimal.Create(new Decimal18(sum));
+                    break;
+                }
+                case CalcFormulaRegistry.FormulaKind.Lookup:
+                {
+                    var rows = GetMatchingRows(formula);
+                    var targetId = CalcFormulaRegistry.GetTableIdByName(formula.TargetTableName);
+                    var aggFieldId = targetId.HasValue && formula.TargetAggregateField != null
+                        ? ResolveField(targetId.Value, formula.TargetAggregateField)
+                        : null;
+                    if (aggFieldId.HasValue && rows.Count > 0 &&
+                        rows[0].TryGetValue(aggFieldId.Value, out var lookupVal))
+                    {
+                        _fields[fieldNo] = lookupVal;
+                    }
+                    break;
+                }
             }
         }
     }
 
-    private bool EvaluateExistFormula(CalcFormulaRegistry.Formula formula)
+    /// <summary>
+    /// Resolve a field name to its field ID, preferring the transpile-time
+    /// TableFieldRegistry over runtime RegisterFieldName.
+    /// </summary>
+    private static int? ResolveField(int tableId, string fieldName)
     {
-        var targetId = CalcFormulaRegistry.GetTableIdByName(formula.TargetTableName);
-        if (targetId is null || !_tables.TryGetValue(targetId.Value, out var rows)) return false;
+        var fromRegistry = TableFieldRegistry.GetFieldId(tableId, fieldName);
+        if (fromRegistry.HasValue) return fromRegistry;
+        if (_fieldNames.TryGetValue(tableId, out var dict) &&
+            dict.TryGetValue(fieldName, out var id))
+            return id;
+        return null;
+    }
 
-        // Field name -> field id lookups. Prefer the transpile-time
-        // TableFieldRegistry (populated from AL source at pipeline start)
-        // since runtime RegisterFieldName is only called for tables whose
-        // generated code actually references ALFieldNo(name) somewhere.
-        int? ResolveField(int tableId, string fieldName)
-        {
-            var fromRegistry = TableFieldRegistry.GetFieldId(tableId, fieldName);
-            if (fromRegistry.HasValue) return fromRegistry;
-            if (_fieldNames.TryGetValue(tableId, out var dict) &&
-                dict.TryGetValue(fieldName, out var id))
-                return id;
-            return null;
-        }
+    /// <summary>
+    /// Returns all rows from the target table that match the formula's where-clause
+    /// conditions, evaluated against the current record's field values.
+    /// </summary>
+    private List<Dictionary<int, NavValue>> GetMatchingRows(CalcFormulaRegistry.Formula formula)
+    {
+        var result = new List<Dictionary<int, NavValue>>();
+        var targetId = CalcFormulaRegistry.GetTableIdByName(formula.TargetTableName);
+        if (targetId is null || !_tables.TryGetValue(targetId.Value, out var rows))
+            return result;
 
         foreach (var row in rows)
         {
@@ -1095,7 +1163,6 @@ public class MockRecordHandle
                 }
                 else
                 {
-                    // filter(...) not supported yet — treat as non-matching.
                     allMatch = false;
                     break;
                 }
@@ -1106,9 +1173,23 @@ public class MockRecordHandle
                     break;
                 }
             }
-            if (allMatch) return true;
+            if (allMatch) result.Add(row);
         }
-        return false;
+        return result;
+    }
+
+    /// <summary>
+    /// Extract a decimal value from a NavValue (handles NavDecimal, NavInteger, etc.).
+    /// </summary>
+    private static decimal NavValueToDecimal(NavValue value)
+    {
+        if (value is NavDecimal nd) return (decimal)nd.Value;
+        if (value is NavInteger ni) return ni.Value;
+        if (decimal.TryParse(NavValueToString(value),
+                System.Globalization.NumberStyles.Any,
+                System.Globalization.CultureInfo.InvariantCulture, out var d))
+            return d;
+        return 0m;
     }
 
     /// <summary>
@@ -1284,9 +1365,8 @@ public class MockRecordHandle
 
     /// <summary>
     /// AL's ISTEMPORARY — returns whether this is a temporary record.
-    /// In standalone mode, all records are effectively in-memory, returns false.
     /// </summary>
-    public bool ALIsTemporary => false;
+    public bool ALIsTemporary => _isTemporary;
 
     /// <summary>
     /// AL's TABLENAME — returns the name of the table.
@@ -1295,7 +1375,7 @@ public class MockRecordHandle
 
     public bool ALRename(DataError errorLevel, params NavValue[] newKeyValues)
     {
-        var table = _tables[_tableId];
+        var table = GetRows();
         var pkFields = GetPrimaryKeyFields();
 
         // 1. Find the current record in the table by its current PK values
@@ -1371,7 +1451,7 @@ public class MockRecordHandle
     /// </summary>
     private List<Dictionary<int, NavValue>> GetFilteredRecords()
     {
-        var table = _tables[_tableId];
+        var table = GetRows();
         List<Dictionary<int, NavValue>> result;
 
         if (_filters.Count == 0)

--- a/AlRunner/Runtime/MockRecordRef.cs
+++ b/AlRunner/Runtime/MockRecordRef.cs
@@ -30,7 +30,7 @@ public class MockRecordRef
     public void Open(int tableId, bool temporary, string? companyName)
     {
         Number = tableId;
-        _handle = new MockRecordHandle(tableId);
+        _handle = new MockRecordHandle(tableId, temporary);
     }
 
     public void Close()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ All notable changes to this project are documented here. Format based on
 ## [Unreleased]
 
 ### Added
+- **Temporary records** — `Record "X" temporary` variables now use an isolated in-memory
+  store per handle instance, fully separated from non-temporary records of the same table.
+  `IsTemporary()` returns the correct value. `RecordRef.Open(tableId, true)` creates a
+  temporary RecordRef. (#120)
+- **FlowField CalcFormula: count, sum, lookup** — `CalcFields` now evaluates `count(...)`,
+  `sum(...)`, and `lookup(...)` formulas in addition to the existing `exist(...)` support.
+  Count returns the number of matching rows, Sum aggregates a decimal field, and Lookup
+  returns the target field value from the first matching row. (#120)
+
+### Added
 - **System, Database & Session utility stubs** — `Session.LogMessage()` (no-op),
   `Session.ApplicationArea()` (returns empty string), `Session.GetExecutionContext()` /
   `GetModuleExecutionContext()` (return `ExecutionContext.Normal`),

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,7 +139,7 @@ dotnet run --project AlRunner -- ./src ./test
 | `AlRunner/PackageScanner.cs` | .app file scanning and deduplication |
 | `AlRunner/StubGenerator.cs` | `--generate-stubs` command |
 | `AlRunner/Runtime/AlScope.cs` | Base scope, AlDialog, AlCompat (Format, RoundDateTime, utility stubs), MockDialog |
-| `AlRunner/Runtime/MockRecordHandle.cs` | In-memory record store (filtering, composite PKs, sort, triggers) |
+| `AlRunner/Runtime/MockRecordHandle.cs` | In-memory record store (filtering, composite PKs, sort, triggers, temp records, CalcFields) |
 | `AlRunner/Runtime/MockCodeunitHandle.cs` | Cross-codeunit dispatch via reflection |
 | `AlRunner/Runtime/EventSubscriberRegistry.cs` | Event subscriber discovery + dispatch |
 | `AlRunner/Runtime/HandlerRegistry.cs` | Test handler dispatch (ConfirmHandler, MessageHandler, ModalPageHandler, RequestPageHandler) |

--- a/tests/bucket-2/124-temp-records-flowfields/src/FFOrderHeader.al
+++ b/tests/bucket-2/124-temp-records-flowfields/src/FFOrderHeader.al
@@ -1,0 +1,31 @@
+table 56242 "FF Order Header"
+{
+    fields
+    {
+        field(1; "No."; Code[20]) { }
+        field(2; Description; Text[100]) { }
+        field(10; "Line Count"; Integer)
+        {
+            CalcFormula = count("FF Order Line" where("Order No." = field("No.")));
+            FieldClass = FlowField;
+        }
+        field(11; "Total Amount"; Decimal)
+        {
+            CalcFormula = sum("FF Order Line"."Amount" where("Order No." = field("No.")));
+            FieldClass = FlowField;
+        }
+        field(12; "First Item"; Code[20])
+        {
+            CalcFormula = lookup("FF Order Line"."Item No." where("Order No." = field("No.")));
+            FieldClass = FlowField;
+        }
+    }
+
+    keys
+    {
+        key(PK; "No.")
+        {
+            Clustered = true;
+        }
+    }
+}

--- a/tests/bucket-2/124-temp-records-flowfields/src/FFOrderLine.al
+++ b/tests/bucket-2/124-temp-records-flowfields/src/FFOrderLine.al
@@ -1,0 +1,18 @@
+table 56243 "FF Order Line"
+{
+    fields
+    {
+        field(1; "Order No."; Code[20]) { }
+        field(2; "Line No."; Integer) { }
+        field(3; "Item No."; Code[20]) { }
+        field(4; Amount; Decimal) { }
+    }
+
+    keys
+    {
+        key(PK; "Order No.", "Line No.")
+        {
+            Clustered = true;
+        }
+    }
+}

--- a/tests/bucket-2/124-temp-records-flowfields/src/TempTestItem.al
+++ b/tests/bucket-2/124-temp-records-flowfields/src/TempTestItem.al
@@ -1,0 +1,17 @@
+table 56241 "Temp Test Item"
+{
+    fields
+    {
+        field(1; Id; Integer) { }
+        field(2; Name; Text[50]) { }
+        field(3; Amount; Decimal) { }
+    }
+
+    keys
+    {
+        key(PK; Id)
+        {
+            Clustered = true;
+        }
+    }
+}

--- a/tests/bucket-2/124-temp-records-flowfields/test/FlowFieldFormulaTests.al
+++ b/tests/bucket-2/124-temp-records-flowfields/test/FlowFieldFormulaTests.al
@@ -1,0 +1,145 @@
+codeunit 56242 "FlowField Formula Tests"
+{
+    Subtype = Test;
+
+    var Assert: Codeunit Assert;
+
+    [Test]
+    procedure CountFlowFieldReturnsCorrectCount()
+    var
+        Header: Record "FF Order Header";
+        Line: Record "FF Order Line";
+    begin
+        Header.Init();
+        Header."No." := 'ORD001';
+        Header.Insert();
+
+        Line.Init();
+        Line."Order No." := 'ORD001';
+        Line."Line No." := 10000;
+        Line."Item No." := 'ITEM-A';
+        Line.Amount := 100.0;
+        Line.Insert();
+
+        Line.Init();
+        Line."Order No." := 'ORD001';
+        Line."Line No." := 20000;
+        Line."Item No." := 'ITEM-B';
+        Line.Amount := 250.50;
+        Line.Insert();
+
+        Header.Get('ORD001');
+        Header.CalcFields("Line Count");
+        Assert.AreEqual(2, Header."Line Count", 'Count FlowField should return 2 lines');
+    end;
+
+    [Test]
+    procedure SumFlowFieldReturnsCorrectTotal()
+    var
+        Header: Record "FF Order Header";
+        Line: Record "FF Order Line";
+    begin
+        Header.Init();
+        Header."No." := 'ORD002';
+        Header.Insert();
+
+        Line.Init();
+        Line."Order No." := 'ORD002';
+        Line."Line No." := 10000;
+        Line.Amount := 100.00;
+        Line.Insert();
+
+        Line.Init();
+        Line."Order No." := 'ORD002';
+        Line."Line No." := 20000;
+        Line.Amount := 250.50;
+        Line.Insert();
+
+        Header.Get('ORD002');
+        Header.CalcFields("Total Amount");
+        Assert.AreEqual(350.50, Header."Total Amount", 'Sum FlowField should return 350.50');
+    end;
+
+    [Test]
+    procedure LookupFlowFieldReturnsFirstMatch()
+    var
+        Header: Record "FF Order Header";
+        Line: Record "FF Order Line";
+    begin
+        Header.Init();
+        Header."No." := 'ORD003';
+        Header.Insert();
+
+        Line.Init();
+        Line."Order No." := 'ORD003';
+        Line."Line No." := 10000;
+        Line."Item No." := 'FIRST-ITEM';
+        Line.Insert();
+
+        Line.Init();
+        Line."Order No." := 'ORD003';
+        Line."Line No." := 20000;
+        Line."Item No." := 'SECOND-ITEM';
+        Line.Insert();
+
+        Header.Get('ORD003');
+        Header.CalcFields("First Item");
+        Assert.AreEqual('FIRST-ITEM', Header."First Item", 'Lookup FlowField should return first matching item');
+    end;
+
+    [Test]
+    procedure CountFlowFieldReturnsZeroForNoLines()
+    var
+        Header: Record "FF Order Header";
+    begin
+        Header.Init();
+        Header."No." := 'ORD-EMPTY';
+        Header.Insert();
+
+        Header.CalcFields("Line Count");
+        Assert.AreEqual(0, Header."Line Count", 'Count should be 0 when no lines exist');
+    end;
+
+    [Test]
+    procedure SumFlowFieldReturnsZeroForNoLines()
+    var
+        Header: Record "FF Order Header";
+    begin
+        Header.Init();
+        Header."No." := 'ORD-EMPTY2';
+        Header.Insert();
+
+        Header.CalcFields("Total Amount");
+        Assert.AreEqual(0.0, Header."Total Amount", 'Sum should be 0 when no lines exist');
+    end;
+
+    [Test]
+    procedure FlowFieldsFilterByParentKey()
+    var
+        Header1: Record "FF Order Header";
+        Header2: Record "FF Order Header";
+        Line: Record "FF Order Line";
+    begin
+        Header1.Init();
+        Header1."No." := 'H1';
+        Header1.Insert();
+
+        Header2.Init();
+        Header2."No." := 'H2';
+        Header2.Insert();
+
+        Line.Init();
+        Line."Order No." := 'H1';
+        Line."Line No." := 10000;
+        Line.Amount := 500.00;
+        Line.Insert();
+
+        Header1.CalcFields("Line Count", "Total Amount");
+        Assert.AreEqual(1, Header1."Line Count", 'H1 should have 1 line');
+        Assert.AreEqual(500.00, Header1."Total Amount", 'H1 total should be 500');
+
+        Header2.CalcFields("Line Count", "Total Amount");
+        Assert.AreEqual(0, Header2."Line Count", 'H2 should have 0 lines');
+        Assert.AreEqual(0.0, Header2."Total Amount", 'H2 total should be 0');
+    end;
+}

--- a/tests/bucket-2/124-temp-records-flowfields/test/TempRecordTests.al
+++ b/tests/bucket-2/124-temp-records-flowfields/test/TempRecordTests.al
@@ -1,0 +1,71 @@
+codeunit 56241 "Temp Record Tests"
+{
+    Subtype = Test;
+
+    var Assert: Codeunit Assert;
+
+    [Test]
+    procedure TempRecordIsTemporaryReturnsTrue()
+    var
+        TempItem: Record "Temp Test Item" temporary;
+    begin
+        Assert.IsTrue(TempItem.IsTemporary(), 'Temporary record should return IsTemporary = true');
+    end;
+
+    [Test]
+    procedure TempRecordInsertIsolatedFromNonTemp()
+    var
+        TempItem: Record "Temp Test Item" temporary;
+        Item: Record "Temp Test Item";
+    begin
+        TempItem.Init();
+        TempItem.Id := 1;
+        TempItem.Name := 'Temp Only';
+        TempItem.Insert();
+
+        Assert.IsFalse(Item.FindFirst(), 'Non-temp variable should NOT see temp record');
+    end;
+
+    [Test]
+    procedure NonTempRecordInsertNotVisibleToTemp()
+    var
+        TempItem: Record "Temp Test Item" temporary;
+        Item: Record "Temp Test Item";
+    begin
+        Item.Init();
+        Item.Id := 1;
+        Item.Name := 'Real';
+        Item.Insert();
+
+        Assert.IsFalse(TempItem.FindFirst(), 'Temp variable should NOT see non-temp record');
+    end;
+
+    [Test]
+    procedure TempRecordCountIsIsolated()
+    var
+        TempItem: Record "Temp Test Item" temporary;
+        Item: Record "Temp Test Item";
+    begin
+        Item.Init();
+        Item.Id := 1;
+        Item.Insert();
+
+        TempItem.Init();
+        TempItem.Id := 2;
+        TempItem.Insert();
+        TempItem.Init();
+        TempItem.Id := 3;
+        TempItem.Insert();
+
+        Assert.AreEqual(1, Item.Count(), 'Non-temp should have 1 record');
+        Assert.AreEqual(2, TempItem.Count(), 'Temp should have 2 records');
+    end;
+
+    [Test]
+    procedure NonTempRecordIsTemporaryReturnsFalse()
+    var
+        Item: Record "Temp Test Item";
+    begin
+        Assert.IsFalse(Item.IsTemporary(), 'Non-temp record should return IsTemporary = false');
+    end;
+}


### PR DESCRIPTION
## Summary

Implements two high-impact parts of #120:

### Temporary Records
- `MockRecordHandle` now accepts a `temporary` flag — temp records get their own private row store, isolated from the global `_tables`
- `RoslynRewriter` passes the BC compiler's 3rd constructor arg (the temporary boolean) through to `MockRecordHandle`
- `ALIsTemporary` returns the correct value
- `MockRecordRef.Open(tableId, true)` creates a temporary handle
- All CRUD methods use `GetRows()` which routes to the correct store

### FlowField CalcFormula — Sum, Count, Lookup
- `CalcFormulaRegistry` now parses `count()`, `sum()`, `lookup()` formulas (plus `min`, `max`, `average` keywords)
- Sum/lookup parse `"Table"."Field"` dot notation for the aggregate target field
- `ALCalcFields` evaluates: Count → `NavInteger`, Sum → `NavDecimal`, Lookup → target field value
- Extracted shared `GetMatchingRows()` and `ResolveField()` helpers (refactored from the old `EvaluateExistFormula`)

### Tests
11 new tests in `tests/bucket-2/124-temp-records-flowfields/`:
- 5 temporary record tests (isolation, IsTemporary, count isolation)
- 6 FlowField tests (count, sum, lookup, zero-for-empty, parent-key filtering)

All passing. Zero regressions across 90+ existing bucket-2 tests.

Closes #120 (temporary records + FlowField sum/count/lookup)