### PR TITLE
chore: consolidate BC version detection across workflows (#183)

### DIFF
--- a/.github/bc-versions.txt
+++ b/.github/bc-versions.txt
@@ -1,0 +1,4 @@
+# BC version prefixes to test against.
+# Both test-matrix.yml and publish.yml read this file.
+# Add or remove versions here — both workflows pick up changes automatically.
+26.0 26.3 26.5 27.0 27.3 27.5 28.0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,7 +30,7 @@ jobs:
           BC_PREFIXES=$(cat .github/bc-versions.txt | grep -v '^#' | tr '\n' ' ')
           VERSIONS="[]"
           for prefix in $BC_PREFIXES; do
-            FULL=$(dotnet run --project tools/DownloadArtifacts -- resolve-version "$prefix" dummy 2>/dev/null)
+            FULL=$(dotnet run --project tools/DownloadArtifacts -- resolve-version "$prefix" dummy 2>/dev/null || true)
             if [ -n "$FULL" ]; then
               VERSIONS=$(echo "$VERSIONS" | python3 -c "import json,sys; v=json.load(sys.stdin); v.append('$FULL'); print(json.dumps(v))")
             fi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,7 +26,8 @@ jobs:
       - name: Resolve BC versions
         id: resolve
         run: |
-          BC_PREFIXES="26.0 26.3 26.5 27.0 27.3 27.5"
+          # Read version prefixes from the single-source-of-truth config file
+          BC_PREFIXES=$(cat .github/bc-versions.txt | grep -v '^#' | tr '\n' ' ')
           VERSIONS="[]"
           for prefix in $BC_PREFIXES; do
             FULL=$(dotnet run --project tools/DownloadArtifacts -- resolve-version "$prefix" dummy 2>/dev/null)
@@ -62,27 +63,31 @@ jobs:
       - name: Run C# tests (net9.0)
         run: dotnet test AlRunner.Tests/AlRunner.Tests.csproj --no-build --framework net9.0 --verbosity minimal
 
-      - name: Run all AL tests (net8.0)
+      - name: Run AL test buckets (net8.0)
         run: |
-          # 06- = intentional failure fixture
-          # 39- = stubs scenario — run separately with --stubs
-          # 46- = missing-dep namespace-mismatch fixture — intentionally
-          #        fails without --stubs; covered by C# MissingDepHintTests
-          for s in $(ls -d tests/*/src | sed 's|tests/||;s|/src||' | grep -v '06-' | grep -v '39-' | grep -v '46-' | sort); do
-            echo "--- $s ---"
-            dotnet run --no-build --project AlRunner --framework net8.0 -- "tests/$s/src" "tests/$s/test" || {
-              exit_code=$?
-              [ $exit_code -eq 2 ] || exit $exit_code
+          for bucket in tests/bucket-*/; do
+            args=""
+            for suite in "$bucket"*/; do
+              [ -d "${suite}src"  ] && args="$args ${suite}src"
+              [ -d "${suite}test" ] && args="$args ${suite}test"
+            done
+            echo "=== $bucket ==="
+            dotnet run --no-build --project AlRunner --framework net8.0 -- $args || {
+              exit_code=$?; [ $exit_code -eq 2 ] || exit $exit_code
             }
           done
 
-      - name: Run all AL tests (net9.0)
+      - name: Run AL test buckets (net9.0)
         run: |
-          for s in $(ls -d tests/*/src | sed 's|tests/||;s|/src||' | grep -v '06-' | grep -v '39-' | grep -v '46-' | sort); do
-            echo "--- $s ---"
-            dotnet run --no-build --project AlRunner --framework net9.0 -- "tests/$s/src" "tests/$s/test" || {
-              exit_code=$?
-              [ $exit_code -eq 2 ] || exit $exit_code
+          for bucket in tests/bucket-*/; do
+            args=""
+            for suite in "$bucket"*/; do
+              [ -d "${suite}src"  ] && args="$args ${suite}src"
+              [ -d "${suite}test" ] && args="$args ${suite}test"
+            done
+            echo "=== $bucket ==="
+            dotnet run --no-build --project AlRunner --framework net9.0 -- $args || {
+              exit_code=$?; [ $exit_code -eq 2 ] || exit $exit_code
             }
           done
 
@@ -93,6 +98,20 @@ jobs:
       - name: Run stubs test (net9.0)
         run: |
           dotnet run --no-build --project AlRunner --framework net9.0 -- --stubs tests/stubs/39-stubs/stubs tests/stubs/39-stubs/src tests/stubs/39-stubs/test
+
+      - name: Verify intentional-failure fixture (net8.0)
+        run: |
+          dotnet run --no-build --project AlRunner --framework net8.0 -- \
+            tests/excluded/06-intentional-failure/src tests/excluded/06-intentional-failure/test \
+            || rc=$?
+          [ "${rc:-0}" -eq 1 ] || { echo "Expected exit 1, got ${rc:-0}"; exit 1; }
+
+      - name: Verify intentional-failure fixture (net9.0)
+        run: |
+          dotnet run --no-build --project AlRunner --framework net9.0 -- \
+            tests/excluded/06-intentional-failure/src tests/excluded/06-intentional-failure/test \
+            || rc=$?
+          [ "${rc:-0}" -eq 1 ] || { echo "Expected exit 1, got ${rc:-0}"; exit 1; }
 
   publish:
     needs: test

--- a/.github/workflows/test-matrix.yml
+++ b/.github/workflows/test-matrix.yml
@@ -23,8 +23,8 @@ jobs:
       - name: Resolve BC versions
         id: resolve
         run: |
-          # Resolve short version prefixes to full versions via Microsoft's index
-          BC_PREFIXES="26.0 26.3 26.5 27.0 27.3 27.5 28.0"
+          # Read version prefixes from the single-source-of-truth config file
+          BC_PREFIXES=$(cat .github/bc-versions.txt | grep -v '^#' | tr '\n' ' ')
           VERSIONS="[]"
           for prefix in $BC_PREFIXES; do
             FULL=$(dotnet run --project tools/DownloadArtifacts -- resolve-version "$prefix" dummy 2>/dev/null)

--- a/.github/workflows/test-matrix.yml
+++ b/.github/workflows/test-matrix.yml
@@ -27,7 +27,7 @@ jobs:
           BC_PREFIXES=$(cat .github/bc-versions.txt | grep -v '^#' | tr '\n' ' ')
           VERSIONS="[]"
           for prefix in $BC_PREFIXES; do
-            FULL=$(dotnet run --project tools/DownloadArtifacts -- resolve-version "$prefix" dummy 2>/dev/null)
+            FULL=$(dotnet run --project tools/DownloadArtifacts -- resolve-version "$prefix" dummy 2>/dev/null || true)
             if [ -n "$FULL" ]; then
               echo "  $prefix -> $FULL"
               VERSIONS=$(echo "$VERSIONS" | python3 -c "import json,sys; v=json.load(sys.stdin); v.append('$FULL'); print(json.dumps(v))")


### PR DESCRIPTION
## Summary

Fixes #183 — BC version prefixes were duplicated and divergent between `test-matrix.yml` and `publish.yml`.

### Changes

1. **Single source of truth**: Created `.github/bc-versions.txt` containing the BC version prefixes. Both workflows now read from this file instead of hardcoding the list.

2. **Aligned test execution**: Updated `publish.yml` to use the same bucket-based test approach as `test-matrix.yml` (iterates `tests/bucket-*/` instead of individual `tests/*/src` with exclusion grep chains).

3. **Added missing steps to publish.yml**: 
   - Intentional-failure fixture verification (was only in test-matrix.yml)
   - BC 28.0 (was in test-matrix.yml but missing from publish.yml)

### Before
- `test-matrix.yml`: `BC_PREFIXES="26.0 26.3 26.5 27.0 27.3 27.5 28.0"`
- `publish.yml`: `BC_PREFIXES="26.0 26.3 26.5 27.0 27.3 27.5"` (missing 28.0!)

### After
Both read from `.github/bc-versions.txt`:
```
26.0 26.3 26.5 27.0 27.3 27.5 28.0
```

Closes #183