### PR TITLE
feat: improve XmlPort & Query runtime error messages (#124)

### DIFF
--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -312,12 +312,19 @@ test executor that needs no BC service tier, Docker, SQL Server, or license.
 - Query variables — declaring Query variables compiles; Close/SetFilter/SetRange/
   TopNumberOfRows are no-ops; Open/Read/SaveAs throw NotSupportedException.
   Inject query dependencies via an AL interface for unit-testable code.
+- XmlPort variables — declaring XmlPort variables compiles; Source/Destination
+  properties and Invoke() work without error. Import/Export (instance and static)
+  throw NotSupportedException with actionable guidance.
+  Use AL interface injection to abstract XmlPort I/O for testing.
 
 ### What al-runner does NOT support
 
 - Pages, Reports — stub them via `--stubs <dir>` or inject via AL interface
+- XmlPort I/O (Import/Export) — XmlPort variables compile and properties work,
+  but Import/Export require the BC service tier. Use AL interface injection to
+  abstract XmlPort dependencies for testing.
 - Query data access (Open/Read) — queries require the BC service tier (SQL views);
-  use AL interfaces to inject query results for testing
+  use Record operations instead, or inject the query behind an AL interface
 - HTTP / REST calls — inject via AL interface
 - Event subscribers — Custom IntegrationEvent/BusinessEvent dispatch works with
   IncludeSender support. Implicit DB trigger events (OnBefore/AfterInsert/Modify/

--- a/AlRunner/Runtime/MockQueryHandle.cs
+++ b/AlRunner/Runtime/MockQueryHandle.cs
@@ -63,7 +63,7 @@ public class MockQueryHandle
     /// </summary>
     public bool ALOpen(DataError errorLevel = default)
         => throw new NotSupportedException(
-            "Query Open/Read requires the BC service tier and is not supported by al-runner. " +
+            $"Query {QueryId} Open requires the BC service tier and is not supported by al-runner. " +
             "Use Record operations instead, or inject the query behind an AL interface.");
 
     /// <summary>
@@ -72,7 +72,7 @@ public class MockQueryHandle
     /// </summary>
     public bool ALRead(DataError errorLevel = default)
         => throw new NotSupportedException(
-            "Query Open/Read requires the BC service tier and is not supported by al-runner. " +
+            $"Query {QueryId} Read requires the BC service tier and is not supported by al-runner. " +
             "Use Record operations instead, or inject the query behind an AL interface.");
 
     /// <summary>

--- a/AlRunner/Runtime/MockQueryHandle.cs
+++ b/AlRunner/Runtime/MockQueryHandle.cs
@@ -63,9 +63,8 @@ public class MockQueryHandle
     /// </summary>
     public bool ALOpen(DataError errorLevel = default)
         => throw new NotSupportedException(
-            $"Query.Open (Query {QueryId}) is not supported in al-runner standalone mode. " +
-            "Query data access requires the BC service tier. " +
-            "Inject the query dependency via an AL interface to make this code unit-testable.");
+            "Query Open/Read requires the BC service tier and is not supported by al-runner. " +
+            "Use Record operations instead, or inject the query behind an AL interface.");
 
     /// <summary>
     /// <c>Q.Read()</c> — reads the next row from the query result set.
@@ -73,9 +72,8 @@ public class MockQueryHandle
     /// </summary>
     public bool ALRead(DataError errorLevel = default)
         => throw new NotSupportedException(
-            $"Query.Read (Query {QueryId}) is not supported in al-runner standalone mode. " +
-            "Query data access requires the BC service tier. " +
-            "Inject the query dependency via an AL interface to make this code unit-testable.");
+            "Query Open/Read requires the BC service tier and is not supported by al-runner. " +
+            "Use Record operations instead, or inject the query behind an AL interface.");
 
     /// <summary>
     /// <c>Q.Close()</c> — closes the query. No-op in standalone mode.

--- a/AlRunner/Runtime/MockXmlPortHandle.cs
+++ b/AlRunner/Runtime/MockXmlPortHandle.cs
@@ -39,7 +39,7 @@ public class MockXmlPortHandle
     /// </summary>
     public void Import(object? errorLevel = null)
         => throw new NotSupportedException(
-            "XmlPort Import/Export requires the BC service tier and is not supported by al-runner. " +
+            $"XmlPort {XmlPortId} Import requires the BC service tier and is not supported by al-runner. " +
             "Use AL interface injection to abstract XmlPort dependencies for testing.");
 
     /// <summary>
@@ -48,7 +48,7 @@ public class MockXmlPortHandle
     /// </summary>
     public void Export(object? errorLevel = null)
         => throw new NotSupportedException(
-            "XmlPort Import/Export requires the BC service tier and is not supported by al-runner. " +
+            $"XmlPort {XmlPortId} Export requires the BC service tier and is not supported by al-runner. " +
             "Use AL interface injection to abstract XmlPort dependencies for testing.");
 
     /// <summary>
@@ -69,7 +69,7 @@ public class MockXmlPortHandle
     /// </summary>
     public static void StaticImport(object? errorLevel, int xmlPortId, object? stream, object? rec = null)
         => throw new NotSupportedException(
-            $"XmlPort Import/Export requires the BC service tier and is not supported by al-runner. " +
+            $"XmlPort {xmlPortId} Import requires the BC service tier and is not supported by al-runner. " +
             "Use AL interface injection to abstract XmlPort dependencies for testing.");
 
     /// <summary>
@@ -78,6 +78,6 @@ public class MockXmlPortHandle
     /// </summary>
     public static void StaticExport(object? errorLevel, int xmlPortId, object? stream, object? rec = null)
         => throw new NotSupportedException(
-            $"XmlPort Import/Export requires the BC service tier and is not supported by al-runner. " +
+            $"XmlPort {xmlPortId} Export requires the BC service tier and is not supported by al-runner. " +
             "Use AL interface injection to abstract XmlPort dependencies for testing.");
 }

--- a/AlRunner/Runtime/MockXmlPortHandle.cs
+++ b/AlRunner/Runtime/MockXmlPortHandle.cs
@@ -39,8 +39,8 @@ public class MockXmlPortHandle
     /// </summary>
     public void Import(object? errorLevel = null)
         => throw new NotSupportedException(
-            $"XmlPort.Import is not supported in al-runner standalone mode. " +
-            "Inject the XmlPort dependency via an AL interface to make this code unit-testable.");
+            "XmlPort Import/Export requires the BC service tier and is not supported by al-runner. " +
+            "Use AL interface injection to abstract XmlPort dependencies for testing.");
 
     /// <summary>
     /// Instance <c>XP.Export()</c>. Always throws — XmlPort I/O requires the service tier.
@@ -48,8 +48,8 @@ public class MockXmlPortHandle
     /// </summary>
     public void Export(object? errorLevel = null)
         => throw new NotSupportedException(
-            $"XmlPort.Export is not supported in al-runner standalone mode. " +
-            "Inject the XmlPort dependency via an AL interface to make this code unit-testable.");
+            "XmlPort Import/Export requires the BC service tier and is not supported by al-runner. " +
+            "Use AL interface injection to abstract XmlPort dependencies for testing.");
 
     /// <summary>
     /// Dispatch a plain helper procedure on the XmlPort (e.g. custom triggers).
@@ -69,8 +69,8 @@ public class MockXmlPortHandle
     /// </summary>
     public static void StaticImport(object? errorLevel, int xmlPortId, object? stream, object? rec = null)
         => throw new NotSupportedException(
-            $"XmlPort.Import (XmlPort {xmlPortId}) is not supported in al-runner standalone mode. " +
-            "Inject the XmlPort dependency via an AL interface to make this code unit-testable.");
+            $"XmlPort Import/Export requires the BC service tier and is not supported by al-runner. " +
+            "Use AL interface injection to abstract XmlPort dependencies for testing.");
 
     /// <summary>
     /// Static <c>XmlPort.Export(portId, OutStr [, Rec])</c> stub.
@@ -78,6 +78,6 @@ public class MockXmlPortHandle
     /// </summary>
     public static void StaticExport(object? errorLevel, int xmlPortId, object? stream, object? rec = null)
         => throw new NotSupportedException(
-            $"XmlPort.Export (XmlPort {xmlPortId}) is not supported in al-runner standalone mode. " +
-            "Inject the XmlPort dependency via an AL interface to make this code unit-testable.");
+            $"XmlPort Import/Export requires the BC service tier and is not supported by al-runner. " +
+            "Use AL interface injection to abstract XmlPort dependencies for testing.");
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project are documented here. Format based on
 
 ## [Unreleased]
 
+### Improved
+- **XmlPort & Query runtime error messages** — `MockXmlPortHandle.Import/Export`
+  and `MockQueryHandle.Open/Read` now throw descriptive `NotSupportedException`
+  messages that mention "BC service tier" and suggest "AL interface injection"
+  (XmlPort) or "Record operations" (Query) as actionable alternatives. (#124)
+
 ### Added
 - **System, Database & Session utility stubs** — `Session.LogMessage()` (no-op),
   `Session.ApplicationArea()` (returns empty string), `Session.GetExecutionContext()` /

--- a/tests/bucket-2/125-xmlport-query-diagnostics/src/DiagSrc.al
+++ b/tests/bucket-2/125-xmlport-query-diagnostics/src/DiagSrc.al
@@ -1,0 +1,137 @@
+table 56250 "Diag Test Item"
+{
+    fields
+    {
+        field(1; "Entry No."; Integer) { }
+        field(2; "Item No."; Code[20]) { }
+        field(3; Quantity; Decimal) { }
+    }
+    keys
+    {
+        key(PK; "Entry No.") { Clustered = true; }
+    }
+}
+
+xmlport 56251 "Diag XmlPort"
+{
+    Direction = Import;
+    Format = Xml;
+
+    schema
+    {
+        textelement(Root)
+        {
+            tableelement(ItemRec; "Diag Test Item")
+            {
+                fieldelement(EntryNo; ItemRec."Entry No.") { }
+                fieldelement(ItemNo; ItemRec."Item No.") { }
+            }
+        }
+    }
+}
+
+query 56252 "Diag Item Query"
+{
+    QueryType = Normal;
+
+    elements
+    {
+        dataitem(Item; "Diag Test Item")
+        {
+            column(EntryNo; "Entry No.") { }
+            column(ItemNo; "Item No.") { }
+            column(Qty; Quantity) { Method = Sum; }
+        }
+    }
+}
+
+/// Logic codeunit that wraps XmlPort and Query calls for test access.
+codeunit 56253 "Diag Logic"
+{
+    // ---- XmlPort lifecycle (should NOT throw) ----
+
+    procedure XmlPortDeclareAndReturn(): Text
+    var
+        XP: XmlPort "Diag XmlPort";
+    begin
+        // Declaring an XmlPort variable and running other logic must work.
+        exit('xmlport-ok');
+    end;
+
+    procedure XmlPortInvoke()
+    var
+        XP: XmlPort "Diag XmlPort";
+    begin
+        // Invoke() returns null — no crash expected.
+    end;
+
+    // ---- XmlPort operations that MUST throw ----
+
+    procedure TryXmlPortImport(var InStr: InStream)
+    var
+        XP: XmlPort "Diag XmlPort";
+    begin
+        XP.SetSource(InStr);
+        XP.Import();
+    end;
+
+    procedure TryXmlPortExport(var OutStr: OutStream)
+    var
+        XP: XmlPort "Diag XmlPort";
+    begin
+        XP.SetDestination(OutStr);
+        XP.Export();
+    end;
+
+    procedure TryStaticXmlPortImport(var InStr: InStream)
+    begin
+        XmlPort.Import(XmlPort::"Diag XmlPort", InStr);
+    end;
+
+    procedure TryStaticXmlPortExport(var OutStr: OutStream)
+    begin
+        XmlPort.Export(XmlPort::"Diag XmlPort", OutStr);
+    end;
+
+    // ---- Query lifecycle (should NOT throw) ----
+
+    procedure QueryDeclareAndReturn(): Text
+    var
+        Q: Query "Diag Item Query";
+    begin
+        exit('query-ok');
+    end;
+
+    procedure QuerySetRangeAndClose()
+    var
+        Q: Query "Diag Item Query";
+    begin
+        Q.SetRange(EntryNo, 1, 100);
+        Q.Close();
+    end;
+
+    procedure QuerySetFilterAndClose()
+    var
+        Q: Query "Diag Item Query";
+    begin
+        Q.SetFilter(ItemNo, 'ITEM*');
+        Q.TopNumberOfRows(5);
+        Q.Close();
+    end;
+
+    // ---- Query operations that MUST throw ----
+
+    procedure TryQueryOpen()
+    var
+        Q: Query "Diag Item Query";
+    begin
+        Q.Open();
+    end;
+
+    procedure TryQueryRead()
+    var
+        Q: Query "Diag Item Query";
+    begin
+        Q.Read();
+    end;
+}

--- a/tests/bucket-2/125-xmlport-query-diagnostics/src/DiagSrc.al
+++ b/tests/bucket-2/125-xmlport-query-diagnostics/src/DiagSrc.al
@@ -28,6 +28,11 @@ xmlport 56251 "Diag XmlPort"
             }
         }
     }
+
+    procedure GetPortName(): Text
+    begin
+        exit('Diag XmlPort');
+    end;
 }
 
 query 56252 "Diag Item Query"
@@ -62,7 +67,10 @@ codeunit 56253 "Diag Logic"
     var
         XP: XmlPort "Diag XmlPort";
     begin
-        // Invoke() returns null — no crash expected.
+        // Call a custom procedure on the XmlPort to exercise Invoke() dispatch.
+        // BC compiles XP.GetPortName() as xP.Invoke(memberId, args);
+        // MockXmlPortHandle.Invoke() returns null — no crash expected.
+        XP.GetPortName();
     end;
 
     // ---- XmlPort operations that MUST throw ----

--- a/tests/bucket-2/125-xmlport-query-diagnostics/test/DiagTests.al
+++ b/tests/bucket-2/125-xmlport-query-diagnostics/test/DiagTests.al
@@ -24,8 +24,8 @@ codeunit 56254 "XmlPort Query Diag Tests"
     procedure XmlPortInvokeDoesNotCrash()
     begin
         // [GIVEN] A codeunit with an XmlPort variable
-        // [WHEN]  Invoke() is called (custom trigger dispatch)
-        // [THEN]  No error — Invoke returns null silently
+        // [WHEN]  A custom procedure on the XmlPort is called (exercises Invoke dispatch)
+        // [THEN]  No error — MockXmlPortHandle.Invoke returns null silently
         Logic.XmlPortInvoke();
     end;
 

--- a/tests/bucket-2/125-xmlport-query-diagnostics/test/DiagTests.al
+++ b/tests/bucket-2/125-xmlport-query-diagnostics/test/DiagTests.al
@@ -1,0 +1,171 @@
+codeunit 56254 "XmlPort Query Diag Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Logic: Codeunit "Diag Logic";
+
+    // ==================================================================
+    // XmlPort lifecycle — must NOT throw
+    // ==================================================================
+
+    [Test]
+    procedure XmlPortDeclarationCompiles()
+    begin
+        // [GIVEN] A codeunit that declares an XmlPort variable
+        // [WHEN]  We call a procedure that doesn't invoke Import/Export
+        // [THEN]  It returns the expected value
+        Assert.AreEqual('xmlport-ok', Logic.XmlPortDeclareAndReturn(),
+            'XmlPort declaration and non-I/O logic should work');
+    end;
+
+    [Test]
+    procedure XmlPortInvokeDoesNotCrash()
+    begin
+        // [GIVEN] A codeunit with an XmlPort variable
+        // [WHEN]  Invoke() is called (custom trigger dispatch)
+        // [THEN]  No error — Invoke returns null silently
+        Logic.XmlPortInvoke();
+    end;
+
+    // ==================================================================
+    // XmlPort error messages — must mention "interface injection"
+    // ==================================================================
+
+    [Test]
+    procedure XmlPortImportErrorMentionsInterfaceInjection()
+    var
+        InStr: InStream;
+    begin
+        // [GIVEN] An XmlPort variable
+        // [WHEN]  Import() is called
+        // [THEN]  Error message contains "interface injection"
+        asserterror Logic.TryXmlPortImport(InStr);
+        Assert.ExpectedMessage('interface injection', GetLastErrorText);
+    end;
+
+    [Test]
+    procedure XmlPortExportErrorMentionsInterfaceInjection()
+    var
+        OutStr: OutStream;
+    begin
+        // [GIVEN] An XmlPort variable
+        // [WHEN]  Export() is called
+        // [THEN]  Error message contains "interface injection"
+        asserterror Logic.TryXmlPortExport(OutStr);
+        Assert.ExpectedMessage('interface injection', GetLastErrorText);
+    end;
+
+    [Test]
+    procedure StaticXmlPortImportErrorMentionsInterfaceInjection()
+    var
+        InStr: InStream;
+    begin
+        // [GIVEN] A static XmlPort.Import call
+        // [WHEN]  XmlPort.Import(portId, InStr) is called
+        // [THEN]  Error message contains "interface injection"
+        asserterror Logic.TryStaticXmlPortImport(InStr);
+        Assert.ExpectedMessage('interface injection', GetLastErrorText);
+    end;
+
+    [Test]
+    procedure StaticXmlPortExportErrorMentionsInterfaceInjection()
+    var
+        OutStr: OutStream;
+    begin
+        // [GIVEN] A static XmlPort.Export call
+        // [WHEN]  XmlPort.Export(portId, OutStr) is called
+        // [THEN]  Error message contains "interface injection"
+        asserterror Logic.TryStaticXmlPortExport(OutStr);
+        Assert.ExpectedMessage('interface injection', GetLastErrorText);
+    end;
+
+    [Test]
+    procedure XmlPortImportErrorMentionsServiceTier()
+    var
+        InStr: InStream;
+    begin
+        // [GIVEN] An XmlPort variable
+        // [WHEN]  Import() is called
+        // [THEN]  Error message mentions "BC service tier"
+        asserterror Logic.TryXmlPortImport(InStr);
+        Assert.ExpectedMessage('BC service tier', GetLastErrorText);
+    end;
+
+    // ==================================================================
+    // Query lifecycle — must NOT throw
+    // ==================================================================
+
+    [Test]
+    procedure QueryDeclarationCompiles()
+    begin
+        // [GIVEN] A codeunit that declares a Query variable
+        // [WHEN]  We call a procedure that doesn't invoke Open/Read
+        // [THEN]  It returns the expected value
+        Assert.AreEqual('query-ok', Logic.QueryDeclareAndReturn(),
+            'Query declaration and non-data logic should work');
+    end;
+
+    [Test]
+    procedure QuerySetRangeAndCloseDoNotThrow()
+    begin
+        // [GIVEN] A Query variable
+        // [WHEN]  SetRange + Close are called
+        // [THEN]  No error — both are no-ops
+        Logic.QuerySetRangeAndClose();
+    end;
+
+    [Test]
+    procedure QuerySetFilterAndCloseDoNotThrow()
+    begin
+        // [GIVEN] A Query variable
+        // [WHEN]  SetFilter + TopNumberOfRows + Close are called
+        // [THEN]  No error — all are no-ops
+        Logic.QuerySetFilterAndClose();
+    end;
+
+    // ==================================================================
+    // Query error messages — must mention "interface"
+    // ==================================================================
+
+    [Test]
+    procedure QueryOpenErrorMentionsInterface()
+    begin
+        // [GIVEN] A Query variable
+        // [WHEN]  Open() is called
+        // [THEN]  Error message contains "interface"
+        asserterror Logic.TryQueryOpen();
+        Assert.ExpectedMessage('interface', GetLastErrorText);
+    end;
+
+    [Test]
+    procedure QueryReadErrorMentionsInterface()
+    begin
+        // [GIVEN] A Query variable
+        // [WHEN]  Read() is called
+        // [THEN]  Error message contains "interface"
+        asserterror Logic.TryQueryRead();
+        Assert.ExpectedMessage('interface', GetLastErrorText);
+    end;
+
+    [Test]
+    procedure QueryOpenErrorMentionsServiceTier()
+    begin
+        // [GIVEN] A Query variable
+        // [WHEN]  Open() is called
+        // [THEN]  Error message mentions "BC service tier"
+        asserterror Logic.TryQueryOpen();
+        Assert.ExpectedMessage('BC service tier', GetLastErrorText);
+    end;
+
+    [Test]
+    procedure QueryOpenErrorMentionsRecord()
+    begin
+        // [GIVEN] A Query variable
+        // [WHEN]  Open() is called
+        // [THEN]  Error message suggests Record operations as alternative
+        asserterror Logic.TryQueryOpen();
+        Assert.ExpectedMessage('Record', GetLastErrorText);
+    end;
+}


### PR DESCRIPTION
## Summary

Improves diagnostic messages for XmlPort and Query runtime limits, addressing #124.

### Changes

**Better error messages:**
- XmlPort Import/Export (instance + static): now says "requires the BC service tier... Use AL interface injection to abstract XmlPort dependencies for testing"
- Query Open/Read: now says "requires the BC service tier... Use Record operations instead, or inject the query behind an AL interface"

**Tests** (`tests/bucket-2/125-xmlport-query-diagnostics/`) — 14 tests:
- 5 XmlPort error message checks (interface injection, BC service tier)
- 4 Query error message checks (interface, BC service tier, Record)
- 3 lifecycle tests (variable creation, invoke, SetRange/Close, SetFilter/Close)
- 2 declaration compilation smoke tests

**No regressions** — existing tests 84-xmlport (6/6) and 90-query-object (12/12) all pass.

Closes #124