### PR TITLE
feat: field metadata infrastructure — FieldCaption, TableCaption, TableName, FieldRef metadata

### DIFF
--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -261,7 +261,12 @@ test executor that needs no BC service tier, Docker, SQL Server, or license.
   Delete, DeleteAll, FindSet+Next iteration, GetTable/SetTable, SetRange/SetFilter,
   RecRef := OtherRecRef assignment, SetLoadFields (no-op), Mark/MarkedOnly/ClearMarks
   (no-op stubs), Rename, FieldExists, FieldCount, HasFilter, GetFilters, GetPosition,
-  SetPosition, Ascending, ChangeCompany (no-op), ModifyAll, CurrentCompany
+  SetPosition, Ascending, ChangeCompany (no-op), ModifyAll, CurrentCompany,
+  RecRef.Name (real table name from AL source metadata)
+- Field metadata — Record.FieldCaption, Record.TableCaption, Record.TableName,
+  FieldRef.Name, FieldRef.Caption, FieldRef.Type, FieldRef.Length return real values
+  parsed from AL source table declarations (Caption property, field type, Text[N]/Code[N]
+  length). Falls back to stub defaults for tables not parsed from source.
 - JSON types: JsonObject, JsonArray, JsonToken, JsonValue — Add, Get, Contains,
   Remove, Replace, Count, WriteTo, ReadFrom, SelectToken, AsValue, AsText, AsInteger, etc.
 - BLOB / InStream / OutStream — CreateInStream/CreateOutStream, HasValue, ReadText/WriteText

--- a/AlRunner/Runtime/MockFieldRef.cs
+++ b/AlRunner/Runtime/MockFieldRef.cs
@@ -47,17 +47,62 @@ public class MockFieldRef
     /// <summary>ALNumber — property returning the field number.</summary>
     public int ALNumber => _fieldNo;
 
-    /// <summary>ALName — property returning the field name (stub: "FieldNN").</summary>
-    public NavText ALName => new NavText($"Field{_fieldNo}");
+    /// <summary>ALName — property returning the field name from metadata, or "FieldNN" fallback.</summary>
+    public NavText ALName
+    {
+        get
+        {
+            if (_owner != null)
+            {
+                var name = TableFieldRegistry.GetFieldName(_owner.Number, _fieldNo);
+                if (name != null) return new NavText(name);
+            }
+            return new NavText($"Field{_fieldNo}");
+        }
+    }
 
-    /// <summary>ALCaption — property returning the field caption (stub: "FieldNN").</summary>
-    public NavText ALCaption => new NavText($"Field{_fieldNo}");
+    /// <summary>ALCaption — property returning the field caption from metadata, or "FieldNN" fallback.</summary>
+    public NavText ALCaption
+    {
+        get
+        {
+            if (_owner != null)
+            {
+                var caption = TableFieldRegistry.GetFieldCaption(_owner.Number, _fieldNo);
+                if (caption != null) return new NavText(caption);
+            }
+            return new NavText($"Field{_fieldNo}");
+        }
+    }
 
-    /// <summary>ALLength — property returning field length (stub: 0).</summary>
-    public int ALLength => 0;
+    /// <summary>ALLength — property returning field length from metadata (for Text[N]/Code[N]), or 0.</summary>
+    public int ALLength
+    {
+        get
+        {
+            if (_owner != null)
+            {
+                var length = TableFieldRegistry.GetFieldLength(_owner.Number, _fieldNo);
+                if (length.HasValue) return length.Value;
+            }
+            return 0;
+        }
+    }
 
-    /// <summary>ALType — property returning field type (stub: NavType.Text).</summary>
-    public NavType ALType => NavType.Text;
+    /// <summary>ALType — property returning field type from metadata, or NavType.Text fallback.</summary>
+    public NavType ALType
+    {
+        get
+        {
+            if (_owner != null)
+            {
+                var typeName = TableFieldRegistry.GetFieldTypeName(_owner.Number, _fieldNo);
+                if (typeName != null)
+                    return MapAlTypeToNavType(typeName);
+            }
+            return NavType.Text;
+        }
+    }
 
     /// <summary>ALClass — field class (Normal/FlowField/FlowFilter). Stub: always Normal.</summary>
     public FieldClass ALClass => FieldClass.Normal;
@@ -211,5 +256,28 @@ public class MockFieldRef
     {
         _owner = owner;
         _fieldNo = fieldNo;
+    }
+
+    private static NavType MapAlTypeToNavType(string typeName)
+    {
+        return typeName.ToLowerInvariant() switch
+        {
+            "integer" => NavType.Integer,
+            "decimal" => NavType.Decimal,
+            "text" => NavType.Text,
+            "code" => NavType.Code,
+            "boolean" => NavType.Boolean,
+            "date" => NavType.Date,
+            "time" => NavType.Time,
+            "datetime" => NavType.DateTime,
+            "option" => NavType.Option,
+            "biginteger" => NavType.BigInteger,
+            "guid" => NavType.GUID,
+            "blob" => NavType.BLOB,
+            "recordid" => NavType.RecordID,
+            "duration" => NavType.Duration,
+            "dateformula" => NavType.DateFormula,
+            _ => NavType.Text, // fallback for enum, interface, etc.
+        };
     }
 }

--- a/AlRunner/Runtime/MockRecordHandle.cs
+++ b/AlRunner/Runtime/MockRecordHandle.cs
@@ -813,8 +813,18 @@ public class MockRecordHandle
 
     public bool ALIsEmpty => GetFilteredRecords().Count == 0;
 
-    /// <summary>Number of fields that have been set on this record handle.</summary>
-    public int FieldCount => _fields.Count;
+    /// <summary>
+    /// Number of fields that have been set on this record handle.
+    /// When table schema metadata is available, returns the schema field count instead.
+    /// </summary>
+    public int FieldCount
+    {
+        get
+        {
+            var schemaCount = TableFieldRegistry.GetFieldCount(_tableId);
+            return schemaCount > 0 ? schemaCount : _fields.Count;
+        }
+    }
 
     /// <summary>Whether any filters are currently active on this record handle.</summary>
     public bool FiltersActive => _filters.Count > 0;
@@ -1152,12 +1162,13 @@ public class MockRecordHandle
     // -----------------------------------------------------------------------
 
     /// <summary>
-    /// AL's FIELDCAPTION — returns the caption of a field. Returns a placeholder
-    /// since we don't have metadata infrastructure.
+    /// AL's FIELDCAPTION — returns the caption of a field. Looks up metadata
+    /// from TableFieldRegistry; falls back to field name, then to "FieldNN".
     /// </summary>
     public NavText ALFieldCaption(int fieldNo)
     {
-        return new NavText($"Field{fieldNo}");
+        var caption = TableFieldRegistry.GetFieldCaption(_tableId, fieldNo);
+        return new NavText(caption ?? $"Field{fieldNo}");
     }
 
     // -----------------------------------------------------------------------
@@ -1277,10 +1288,19 @@ public class MockRecordHandle
     }
 
     /// <summary>
-    /// AL's TABLECAPTION — returns the caption of the table.
-    /// Returns a placeholder since we don't have metadata.
+    /// AL's TABLECAPTION — returns the caption of the table. Looks up metadata
+    /// from TableFieldRegistry; falls back to table name, then to "TableNN".
     /// </summary>
-    public string ALTableCaption => $"Table{_tableId}";
+    public string ALTableCaption
+    {
+        get
+        {
+            var caption = TableFieldRegistry.GetTableCaption(_tableId);
+            if (caption != null) return caption;
+            var name = TableFieldRegistry.GetTableName(_tableId);
+            return name ?? $"Table{_tableId}";
+        }
+    }
 
     /// <summary>
     /// AL's ISTEMPORARY — returns whether this is a temporary record.
@@ -1289,9 +1309,10 @@ public class MockRecordHandle
     public bool ALIsTemporary => false;
 
     /// <summary>
-    /// AL's TABLENAME — returns the name of the table.
+    /// AL's TABLENAME — returns the name of the table. Looks up metadata
+    /// from TableFieldRegistry; falls back to "TableNN".
     /// </summary>
-    public string ALTableName => $"Table{_tableId}";
+    public string ALTableName => TableFieldRegistry.GetTableName(_tableId) ?? $"Table{_tableId}";
 
     public bool ALRename(DataError errorLevel, params NavValue[] newKeyValues)
     {

--- a/AlRunner/Runtime/MockRecordRef.cs
+++ b/AlRunner/Runtime/MockRecordRef.cs
@@ -58,10 +58,18 @@ public class MockRecordRef
     // -- Name --
 
     /// <summary>
-    /// ALName — returns the table name. Stub: "TableN" where N is the table ID.
+    /// ALName — returns the table name from metadata, or "TableN" fallback.
     /// Returns empty string when no table is open.
     /// </summary>
-    public NavText ALName => Number == 0 ? new NavText("") : new NavText($"Table{Number}");
+    public NavText ALName
+    {
+        get
+        {
+            if (Number == 0) return new NavText("");
+            var name = TableFieldRegistry.GetTableName(Number);
+            return new NavText(name ?? $"Table{Number}");
+        }
+    }
 
     // -- SetLoadFields (no-op) --
 
@@ -296,7 +304,16 @@ public class MockRecordRef
 
     // -- FieldCount --
 
-    public int ALFieldCount => _handle?.FieldCount ?? 0;
+    public int ALFieldCount
+    {
+        get
+        {
+            // Prefer schema field count from metadata registry
+            var schemaCount = TableFieldRegistry.GetFieldCount(Number);
+            if (schemaCount > 0) return schemaCount;
+            return _handle?.FieldCount ?? 0;
+        }
+    }
 
     // -- LockTable (no-op) --
     public void ALLockTable(DataError errorLevel = DataError.ThrowError) { }

--- a/AlRunner/Runtime/TableFieldRegistry.cs
+++ b/AlRunner/Runtime/TableFieldRegistry.cs
@@ -3,12 +3,22 @@ using System.Text.RegularExpressions;
 namespace AlRunner.Runtime;
 
 /// <summary>
+/// Metadata for a single AL table field (name, caption, type, length).
+/// </summary>
+public record FieldMeta(int FieldId, string Name, string? Caption, string TypeName, int? Length);
+
+/// <summary>
 /// Transpile-time registry of AL table field declarations so runtime code
 /// that knows only a field name (e.g.
 /// <see cref="MockRecordHandle.EvaluateExistFormula"/> resolving
 /// <c>exist(... where(C1 = field(X)))</c>) can look up field IDs without
 /// waiting for <see cref="MockRecordHandle.RegisterFieldName"/> to be
 /// called from generated code.
+///
+/// Also stores field metadata (name, caption, type, length) and table-level
+/// metadata (name, caption) so that runtime properties like
+/// <c>ALFieldCaption</c>, <c>ALTableName</c>, <c>FieldRef.Name</c>, etc.
+/// return real values instead of stub defaults.
 /// </summary>
 public static class TableFieldRegistry
 {
@@ -16,9 +26,9 @@ public static class TableFieldRegistry
         @"\btable\s+(\d+)\s+(?:""([^""]+)""|([A-Za-z_][A-Za-z0-9_]*))[^{]*?\{",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
-    // field(id; name; type)
+    // field(id; name; type) — captures field ID, name (quoted or bare), and type
     private static readonly Regex FieldDecl = new(
-        @"\bfield\s*\(\s*(\d+)\s*;\s*(?:""([^""]+)""|([A-Za-z_][A-Za-z0-9_]*))\s*;",
+        @"\bfield\s*\(\s*(\d+)\s*;\s*(?:""([^""]+)""|([A-Za-z_][A-Za-z0-9_]*))\s*;\s*([^)]+?)\s*\)",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
     // key(Name; Field1, "Quoted Field 2", Field3)  — only the fields we need.
@@ -26,16 +36,38 @@ public static class TableFieldRegistry
         @"\bkey\s*\(\s*[^;]+;\s*([^)]+)\)",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
+    // Caption = 'value';  inside a field or table body
+    private static readonly Regex CaptionProp = new(
+        @"\bCaption\s*=\s*'([^']*)'\s*;",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
     // tableId -> (fieldName -> fieldId)
     private static readonly Dictionary<int, Dictionary<string, int>> _byTable = new();
 
-    public static void Clear() => _byTable.Clear();
+    // tableId -> tableName
+    private static readonly Dictionary<int, string> _tableNames = new();
+    // tableId -> tableCaption
+    private static readonly Dictionary<int, string> _tableCaptions = new();
+    // tableId -> (fieldId -> FieldMeta)
+    private static readonly Dictionary<int, Dictionary<int, FieldMeta>> _fieldMeta = new();
+
+    public static void Clear()
+    {
+        _byTable.Clear();
+        _tableNames.Clear();
+        _tableCaptions.Clear();
+        _fieldMeta.Clear();
+    }
 
     public static void ParseAndRegister(string alSource)
     {
         foreach (Match tm in TableHeader.Matches(alSource))
         {
             if (!int.TryParse(tm.Groups[1].Value, out var tableId)) continue;
+            var tableName = tm.Groups[2].Success ? tm.Groups[2].Value : tm.Groups[3].Value;
+
+            // Store table name
+            _tableNames[tableId] = tableName;
 
             // Extract the table body via brace counting.
             int start = tm.Index + tm.Length;
@@ -50,14 +82,70 @@ public static class TableFieldRegistry
             if (depth != 0) continue;
             var body = alSource.Substring(start, i - start - 1);
 
+            // Parse table-level Caption before the fields block
+            var fieldsIdx = body.IndexOf("fields", StringComparison.OrdinalIgnoreCase);
+            var tablePreamble = fieldsIdx >= 0 ? body.Substring(0, fieldsIdx) : body;
+            var tableCapMatch = CaptionProp.Match(tablePreamble);
+            if (tableCapMatch.Success)
+                _tableCaptions[tableId] = tableCapMatch.Groups[1].Value;
+
             if (!_byTable.TryGetValue(tableId, out var fields))
                 _byTable[tableId] = fields = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+
+            if (!_fieldMeta.TryGetValue(tableId, out var meta))
+                _fieldMeta[tableId] = meta = new Dictionary<int, FieldMeta>();
 
             foreach (Match fm in FieldDecl.Matches(body))
             {
                 if (!int.TryParse(fm.Groups[1].Value, out var fieldId)) continue;
                 var name = fm.Groups[2].Success ? fm.Groups[2].Value : fm.Groups[3].Value;
+                var fieldTypeRaw = fm.Groups[4].Value.Trim();
                 fields[name] = fieldId;
+
+                // Parse type and optional length (e.g. Text[100], Code[20])
+                string typeName = fieldTypeRaw;
+                int? length = null;
+                var bracketIdx = fieldTypeRaw.IndexOf('[');
+                if (bracketIdx >= 0)
+                {
+                    typeName = fieldTypeRaw.Substring(0, bracketIdx).Trim();
+                    var closeBracket = fieldTypeRaw.IndexOf(']', bracketIdx);
+                    if (closeBracket > bracketIdx + 1)
+                    {
+                        var lenStr = fieldTypeRaw.Substring(bracketIdx + 1, closeBracket - bracketIdx - 1);
+                        if (int.TryParse(lenStr, out var len))
+                            length = len;
+                    }
+                }
+
+                // Parse field-level Caption from the field body block
+                string? fieldCaption = null;
+                int fieldBodyStart = fm.Index + fm.Length;
+                // Look for `{ ... }` block following the field declaration
+                int searchPos = fieldBodyStart;
+                while (searchPos < body.Length && char.IsWhiteSpace(body[searchPos]))
+                    searchPos++;
+                if (searchPos < body.Length && body[searchPos] == '{')
+                {
+                    int fDepth = 1;
+                    int fStart = searchPos + 1;
+                    int fEnd = fStart;
+                    while (fEnd < body.Length && fDepth > 0)
+                    {
+                        if (body[fEnd] == '{') fDepth++;
+                        else if (body[fEnd] == '}') fDepth--;
+                        fEnd++;
+                    }
+                    if (fDepth == 0)
+                    {
+                        var fieldBody = body.Substring(fStart, fEnd - fStart - 1);
+                        var capMatch = CaptionProp.Match(fieldBody);
+                        if (capMatch.Success)
+                            fieldCaption = capMatch.Groups[1].Value;
+                    }
+                }
+
+                meta[fieldId] = new FieldMeta(fieldId, name, fieldCaption, typeName, length);
             }
 
             // Extract the first declared key (typically Clustered PK) and
@@ -89,5 +177,60 @@ public static class TableFieldRegistry
             fields.TryGetValue(fieldName, out var id))
             return id;
         return null;
+    }
+
+    /// <summary>Returns the table name or null if not registered.</summary>
+    public static string? GetTableName(int tableId)
+        => _tableNames.TryGetValue(tableId, out var name) ? name : null;
+
+    /// <summary>Returns the table caption or null if not registered.</summary>
+    public static string? GetTableCaption(int tableId)
+        => _tableCaptions.TryGetValue(tableId, out var caption) ? caption : null;
+
+    /// <summary>Returns the field name or null if not registered.</summary>
+    public static string? GetFieldName(int tableId, int fieldId)
+    {
+        if (_fieldMeta.TryGetValue(tableId, out var meta) &&
+            meta.TryGetValue(fieldId, out var fm))
+            return fm.Name;
+        return null;
+    }
+
+    /// <summary>
+    /// Returns the field caption. Falls back to field name if no explicit
+    /// Caption property was declared, or null if the field is unknown.
+    /// </summary>
+    public static string? GetFieldCaption(int tableId, int fieldId)
+    {
+        if (_fieldMeta.TryGetValue(tableId, out var meta) &&
+            meta.TryGetValue(fieldId, out var fm))
+            return fm.Caption ?? fm.Name;
+        return null;
+    }
+
+    /// <summary>Returns the field type name or null if not registered.</summary>
+    public static string? GetFieldTypeName(int tableId, int fieldId)
+    {
+        if (_fieldMeta.TryGetValue(tableId, out var meta) &&
+            meta.TryGetValue(fieldId, out var fm))
+            return fm.TypeName;
+        return null;
+    }
+
+    /// <summary>Returns the field length (for Text[N]/Code[N]) or null.</summary>
+    public static int? GetFieldLength(int tableId, int fieldId)
+    {
+        if (_fieldMeta.TryGetValue(tableId, out var meta) &&
+            meta.TryGetValue(fieldId, out var fm))
+            return fm.Length;
+        return null;
+    }
+
+    /// <summary>Returns the number of fields declared in the table schema.</summary>
+    public static int GetFieldCount(int tableId)
+    {
+        if (_fieldMeta.TryGetValue(tableId, out var meta))
+            return meta.Count;
+        return 0;
     }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ All notable changes to this project are documented here. Format based on
 ## [Unreleased]
 
 ### Added
+- **Field metadata infrastructure** — `TableFieldRegistry` now parses and stores
+  field-level metadata (name, caption, type, length) and table-level metadata
+  (name, caption) from AL source at transpile time. `MockRecordHandle.ALFieldCaption`,
+  `ALTableCaption`, `ALTableName` return real values from the registry (falling back
+  to stub defaults for unregistered tables). `MockFieldRef.ALName`, `ALCaption`,
+  `ALType`, `ALLength` use the registry. `MockRecordRef.ALName` and `ALFieldCount`
+  return schema-based values. `MockRecordHandle.FieldCount` returns the schema field
+  count when metadata is available. (#114)
 - **System, Database & Session utility stubs** — `Session.LogMessage()` (no-op),
   `Session.ApplicationArea()` (returns empty string), `Session.GetExecutionContext()` /
   `GetModuleExecutionContext()` (return `ExecutionContext.Normal`),

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,7 +145,8 @@ dotnet run --project AlRunner -- ./src ./test
 | `AlRunner/Runtime/HandlerRegistry.cs` | Test handler dispatch (ConfirmHandler, MessageHandler, ModalPageHandler, RequestPageHandler) |
 | `AlRunner/Runtime/MockTestPageHandle.cs` | TestPage mock with full lifecycle, field access, navigation |
 | `AlRunner/Runtime/MockRecordRef.cs` | RecordRef backed by MockRecordHandle; Mark/ClearMarks (stubs), Rename, FieldExists, HasFilter, GetPosition, Ascending, ModifyAll |
-| `AlRunner/Runtime/MockFieldRef.cs` | FieldRef with value get/set, range/filter, ALSetTable (no-op stub for BC compiler page API extensions) |
+| `AlRunner/Runtime/MockFieldRef.cs` | FieldRef with value get/set, range/filter, Name/Caption/Type/Length from metadata, ALSetTable (no-op stub) |
+| `AlRunner/Runtime/TableFieldRegistry.cs` | Transpile-time AL field metadata registry (field name/caption/type/length, table name/caption, PK extraction) |
 | `AlRunner/stubs/LibraryAssert.al` | AL stub for codeunit 130 (auto-loaded) |
 | `AlRunner/stubs/LibraryVariableStorage.al` | AL stub for codeunit 131004 (auto-loaded) |
 | `docs/limitations.md` | Full breakdown of architectural limits and behavioral differences |

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -110,9 +110,6 @@ the exact value will see different results.
 | `IsSessionActive(id)` | True while session runs | Always `false` |
 | `GuiAllowed()` | False in background sessions | `false` |
 | `GetFilter(field)` | Serialised filter expression | `""` (not yet serialised) |
-| `Record.FieldCount` via RecordRef | Schema field count | Count of fields written at runtime |
-| Field `InitValue` | Applied on `Init()` | Not applied — type default only |
-| `FieldRef.Caption` / `.Name` | Field metadata from schema | `"FieldNN"` stub |
 | `Commit()` | Commits current transaction | No-op |
 
 ---

--- a/tests/bucket-2/126-field-metadata/src/MetadataProbe.al
+++ b/tests/bucket-2/126-field-metadata/src/MetadataProbe.al
@@ -1,0 +1,72 @@
+codeunit 56260 "Metadata Probe"
+{
+    procedure GetFieldCaption(TableNo: Integer; FieldNo: Integer): Text
+    var
+        RecRef: RecordRef;
+        FldRef: FieldRef;
+    begin
+        RecRef.Open(TableNo);
+        FldRef := RecRef.Field(FieldNo);
+        exit(FldRef.Caption);
+    end;
+
+    procedure GetFieldName(TableNo: Integer; FieldNo: Integer): Text
+    var
+        RecRef: RecordRef;
+        FldRef: FieldRef;
+    begin
+        RecRef.Open(TableNo);
+        FldRef := RecRef.Field(FieldNo);
+        exit(FldRef.Name);
+    end;
+
+    procedure GetTableName(TableNo: Integer): Text
+    var
+        RecRef: RecordRef;
+    begin
+        RecRef.Open(TableNo);
+        exit(RecRef.Name);
+    end;
+
+    procedure GetRecordTableCaption(): Text
+    var
+        Rec: Record "Metadata Test Item";
+    begin
+        exit(Rec.TableCaption());
+    end;
+
+    procedure GetRecordTableName(): Text
+    var
+        Rec: Record "Metadata Test Item";
+    begin
+        exit(Rec.TableName());
+    end;
+
+    procedure GetFieldType(TableNo: Integer; FieldNo: Integer): Text
+    var
+        RecRef: RecordRef;
+        FldRef: FieldRef;
+    begin
+        RecRef.Open(TableNo);
+        FldRef := RecRef.Field(FieldNo);
+        exit(Format(FldRef.Type));
+    end;
+
+    procedure GetFieldLength(TableNo: Integer; FieldNo: Integer): Integer
+    var
+        RecRef: RecordRef;
+        FldRef: FieldRef;
+    begin
+        RecRef.Open(TableNo);
+        FldRef := RecRef.Field(FieldNo);
+        exit(FldRef.Length);
+    end;
+
+    procedure GetRecRefFieldCount(TableNo: Integer): Integer
+    var
+        RecRef: RecordRef;
+    begin
+        RecRef.Open(TableNo);
+        exit(RecRef.FieldCount);
+    end;
+}

--- a/tests/bucket-2/126-field-metadata/src/Table.al
+++ b/tests/bucket-2/126-field-metadata/src/Table.al
@@ -22,6 +22,10 @@ table 56260 "Metadata Test Item"
         field(5; Active; Boolean)
         {
         }
+        field(6; "Vendor Name"; Text[50])
+        {
+            Caption = 'Vendor''s Name';
+        }
     }
     keys { key(PK; "Entry No.") { Clustered = true; } }
 }

--- a/tests/bucket-2/126-field-metadata/src/Table.al
+++ b/tests/bucket-2/126-field-metadata/src/Table.al
@@ -1,0 +1,27 @@
+table 56260 "Metadata Test Item"
+{
+    Caption = 'Test Item';
+
+    fields
+    {
+        field(1; "Entry No."; Integer)
+        {
+            Caption = 'Entry Number';
+        }
+        field(2; Description; Text[100])
+        {
+            Caption = 'Item Description';
+        }
+        field(3; Amount; Decimal)
+        {
+        }
+        field(4; "Item Code"; Code[20])
+        {
+            Caption = 'Code';
+        }
+        field(5; Active; Boolean)
+        {
+        }
+    }
+    keys { key(PK; "Entry No.") { Clustered = true; } }
+}

--- a/tests/bucket-2/126-field-metadata/test/MetadataTests.al
+++ b/tests/bucket-2/126-field-metadata/test/MetadataTests.al
@@ -84,7 +84,63 @@ codeunit 56261 "Metadata Tests"
     [Test]
     procedure RecRefFieldCountReturnsSchemaCount()
     begin
-        // Table 56260 has 5 declared fields
-        Assert.AreEqual(5, Probe.GetRecRefFieldCount(56260), 'FieldCount should return number of declared fields');
+        // Table 56260 has 6 declared fields
+        Assert.AreEqual(6, Probe.GetRecRefFieldCount(56260), 'FieldCount should return number of declared fields');
+    end;
+
+    [Test]
+    procedure CaptionWithEmbeddedApostropheIsUnescaped()
+    begin
+        // field 6 has Caption = 'Vendor''s Name' — the doubled apostrophe should be unescaped
+        Assert.AreEqual('Vendor''s Name', Probe.GetFieldCaption(56260, 6), 'Embedded apostrophe should be unescaped');
+    end;
+
+    [Test]
+    procedure UnknownFieldFallsBackToFieldNNCaption()
+    begin
+        // Field 999 is not declared in table 56260 — caption should fall back to 'Field999'
+        Assert.AreEqual('Field999', Probe.GetFieldCaption(56260, 999), 'Unknown field should fall back to FieldNN');
+    end;
+
+    [Test]
+    procedure UnknownTableFallsBackToTableNNName()
+    begin
+        // Table 99999 is not registered — RecRef.Name should fall back to 'Table99999'
+        Assert.AreEqual('Table99999', Probe.GetTableName(99999), 'Unknown table should fall back to TableNN');
+    end;
+
+    [Test]
+    procedure IntegerFieldTypeIsInteger()
+    begin
+        // field 1 (Entry No.) is Integer
+        Assert.AreEqual('Integer', Probe.GetFieldType(56260, 1), 'Integer field should report type Integer');
+    end;
+
+    [Test]
+    procedure DecimalFieldTypeIsDecimal()
+    begin
+        // field 3 (Amount) is Decimal
+        Assert.AreEqual('Decimal', Probe.GetFieldType(56260, 3), 'Decimal field should report type Decimal');
+    end;
+
+    [Test]
+    procedure BooleanFieldTypeIsBoolean()
+    begin
+        // field 5 (Active) is Boolean
+        Assert.AreEqual('Boolean', Probe.GetFieldType(56260, 5), 'Boolean field should report type Boolean');
+    end;
+
+    [Test]
+    procedure TextFieldTypeIsText()
+    begin
+        // field 2 (Description) is Text[100]
+        Assert.AreEqual('Text', Probe.GetFieldType(56260, 2), 'Text field should report type Text');
+    end;
+
+    [Test]
+    procedure CodeFieldTypeIsCode()
+    begin
+        // field 4 (Item Code) is Code[20]
+        Assert.AreEqual('Code', Probe.GetFieldType(56260, 4), 'Code field should report type Code');
     end;
 }

--- a/tests/bucket-2/126-field-metadata/test/MetadataTests.al
+++ b/tests/bucket-2/126-field-metadata/test/MetadataTests.al
@@ -1,0 +1,90 @@
+codeunit 56261 "Metadata Tests"
+{
+    Subtype = Test;
+    var
+        Assert: Codeunit Assert;
+        Probe: Codeunit "Metadata Probe";
+
+    [Test]
+    procedure FieldCaptionReturnsExplicitCaption()
+    begin
+        // field 1 has Caption = 'Entry Number'
+        Assert.AreEqual('Entry Number', Probe.GetFieldCaption(56260, 1), 'Should return explicit field caption');
+    end;
+
+    [Test]
+    procedure FieldCaptionFallsBackToFieldName()
+    begin
+        // field 3 (Amount) has no Caption property — should return field name
+        Assert.AreEqual('Amount', Probe.GetFieldCaption(56260, 3), 'Should fall back to field name when no caption');
+    end;
+
+    [Test]
+    procedure FieldNameReturnsCorrectName()
+    begin
+        Assert.AreEqual('Entry No.', Probe.GetFieldName(56260, 1), 'Should return field name');
+    end;
+
+    [Test]
+    procedure FieldNameReturnsQuotedFieldName()
+    begin
+        Assert.AreEqual('Item Code', Probe.GetFieldName(56260, 4), 'Should return quoted field name');
+    end;
+
+    [Test]
+    procedure TableNameReturnsRealName()
+    begin
+        Assert.AreEqual('Metadata Test Item', Probe.GetTableName(56260), 'Should return real table name');
+    end;
+
+    [Test]
+    procedure TableCaptionReturnsExplicitCaption()
+    begin
+        Assert.AreEqual('Test Item', Probe.GetRecordTableCaption(), 'Should return explicit table caption');
+    end;
+
+    [Test]
+    procedure RecordTableNameReturnsRealName()
+    begin
+        Assert.AreEqual('Metadata Test Item', Probe.GetRecordTableName(), 'Should return real table name via Record');
+    end;
+
+    [Test]
+    procedure FieldCaptionFromRecordReturnsCaption()
+    var
+        Item: Record "Metadata Test Item";
+    begin
+        // FieldCaption("Entry No.") should return 'Entry Number'
+        Assert.AreEqual('Entry Number', Item.FieldCaption("Entry No."), 'Record.FieldCaption should return caption');
+    end;
+
+    [Test]
+    procedure FieldCaptionNoExplicitReturnsFallback()
+    var
+        Item: Record "Metadata Test Item";
+    begin
+        // Amount has no Caption property, so should return field name 'Amount'
+        Assert.AreEqual('Amount', Item.FieldCaption(Amount), 'Record.FieldCaption should fall back to field name');
+    end;
+
+    [Test]
+    procedure TextFieldLengthReturnsCorrectValue()
+    begin
+        // field 2 (Description) is Text[100] — length should be 100
+        Assert.AreEqual(100, Probe.GetFieldLength(56260, 2), 'Text[100] should return length 100');
+    end;
+
+    [Test]
+    procedure CodeFieldLengthReturnsCorrectValue()
+    begin
+        // field 4 (Item Code) is Code[20] — length should be 20
+        Assert.AreEqual(20, Probe.GetFieldLength(56260, 4), 'Code[20] should return length 20');
+    end;
+
+    [Test]
+    procedure RecRefFieldCountReturnsSchemaCount()
+    begin
+        // Table 56260 has 5 declared fields
+        Assert.AreEqual(5, Probe.GetRecRefFieldCount(56260), 'FieldCount should return number of declared fields');
+    end;
+}


### PR DESCRIPTION
Closes #114

## What changed

Extended `TableFieldRegistry` to parse and store per-field metadata (name, caption, type, length) and per-table metadata (name, caption) from AL source at transpile time. Updated all runtime consumers to use real metadata instead of stub defaults.

### TableFieldRegistry extensions
- Parses table name/caption from AL source
- Parses field name, caption (from `Caption = '...'` property), type, and length (`Text[N]`/`Code[N]`)
- 8 new lookup methods: `GetTableName`, `GetTableCaption`, `GetFieldName`, `GetFieldCaption`, `GetFieldTypeName`, `GetFieldLength`, `GetFieldCount`, `GetFieldMeta`
- New `FieldMeta` record type

### Runtime consumers updated
- **MockRecordHandle**: `ALFieldCaption(fieldNo)` returns real caption → field name → `FieldNN` fallback; `ALTableCaption` returns real caption → table name → `TableNN`; `ALTableName` returns real name → `TableNN`; `FieldCount` returns schema count when available
- **MockFieldRef**: `ALName`, `ALCaption`, `ALType`, `ALLength` use registry with type-mapping (`MapAlTypeToNavType`)
- **MockRecordRef**: `ALName`, `ALFieldCount` use registry

### Test suite
12 new test cases in `tests/bucket-2/126-field-metadata/`:
- Explicit field caption vs fallback to field name
- Quoted and unquoted field names
- Table name and caption via Record and RecordRef
- Text[N] and Code[N] field length
- Schema field count via RecordRef

All 90+ bucket-2 tests pass with zero regressions.