### PR TITLE
feat: RecordRef/FieldRef API completeness + KeyRef support

### DIFF
--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -263,9 +263,12 @@ test executor that needs no BC service tier, Docker, SQL Server, or license.
 - Dialog variable (Open, Update, Close — all no-ops in standalone mode)
 - RecordRef / FieldRef — Open, Close, Field(n).Value get/set, Insert, Modify,
   Delete, DeleteAll, FindSet+Next iteration, GetTable/SetTable, SetRange/SetFilter,
-  RecRef := OtherRecRef assignment, SetLoadFields (no-op), Mark/MarkedOnly/ClearMarks
-  (no-op stubs), Rename, FieldExists, FieldCount, HasFilter, GetFilters, GetPosition,
-  SetPosition, Ascending, ChangeCompany (no-op), ModifyAll, CurrentCompany
+  RecRef := OtherRecRef assignment, SetLoadFields (no-op), Mark/MarkedOnly/ClearMarks,
+  Rename, FieldExists, FieldCount, HasFilter, GetFilters, GetPosition,
+  SetPosition, Ascending (get/set), ChangeCompany (no-op), ModifyAll, CurrentCompany,
+  FieldRef.GetFilter, FieldRef.GetRangeMin, FieldRef.GetRangeMax, FieldRef.Record,
+  KeyCount, KeyIndex(n), CurrentKeyIndex
+- KeyRef — FieldCount, FieldIndex(n), Record, Active (basic key metadata via KeyRef variable)
 - JSON types: JsonObject, JsonArray, JsonToken, JsonValue — Add, Get, Contains,
   Remove, Replace, Count, WriteTo, ReadFrom, SelectToken, AsValue, AsText, AsInteger, etc.
 - BLOB / InStream / OutStream — CreateInStream/CreateOutStream, HasValue, ReadText/WriteText

--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -1027,6 +1027,12 @@ public void ClearApplicationMemberVariables() { }
         if (text == "NavFieldRef")
             return node.WithIdentifier(SyntaxFactory.Identifier("MockFieldRef"));
 
+        // NavKeyRef -> MockKeyRef
+        // NavKeyRef is used by RecordRef.KeyIndex(). MockKeyRef provides
+        // ALActive, ALFieldCount, ALFieldIndex, ALRecord for key inspection.
+        if (text == "NavKeyRef")
+            return node.WithIdentifier(SyntaxFactory.Identifier("MockKeyRef"));
+
         // NavBLOB -> MockBlob
         // NavBLOB's ALCreateInStream/ALCreateOutStream pass ITreeObject to
         // NavStream ctor which crashes with null in standalone mode.
@@ -1398,6 +1404,14 @@ public void ClearApplicationMemberVariables() { }
         // Strip the ITreeObject 'this' argument.
         if (typeText == "MockFieldRef" && visited.ArgumentList != null &&
             visited.ArgumentList.Arguments.Count == 1)
+        {
+            return visited.WithArgumentList(SyntaxFactory.ArgumentList());
+        }
+
+        // new MockKeyRef(this, ...) -> new MockKeyRef()
+        // After VisitIdentifierName, NavKeyRef is now MockKeyRef.
+        // Strip all constructor args (ITreeObject dependency).
+        if (typeText == "MockKeyRef" && visited.ArgumentList != null)
         {
             return visited.WithArgumentList(SyntaxFactory.ArgumentList());
         }

--- a/AlRunner/Runtime/MockFieldRef.cs
+++ b/AlRunner/Runtime/MockFieldRef.cs
@@ -209,6 +209,11 @@ public class MockFieldRef
 
     // -- Internal helpers --
 
+    // Cached PropertyInfo for NavDecimal.Value — resolved once at type-init,
+    // matching the same pattern used in MockRecordHandle.NavValueToString.
+    private static readonly System.Reflection.PropertyInfo? _navDecimalValueProp =
+        typeof(NavDecimal).GetProperty("Value");
+
     /// <summary>
     /// Extract the underlying CLR value from a NavValue so that Convert.ToInt32 etc. work.
     /// BC compiler emits <c>Convert.ToInt32(fldRef.ALGetRangeMin)</c> which fails on NavValue
@@ -231,9 +236,7 @@ public class MockFieldRef
         {
             try
             {
-                var prop = typeof(NavDecimal).GetProperty("Value",
-                    System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-                var raw = prop?.GetValue(nd);
+                var raw = _navDecimalValueProp?.GetValue(nd);
                 if (raw != null) return Convert.ToDecimal(raw);
             }
             catch { }

--- a/AlRunner/Runtime/MockFieldRef.cs
+++ b/AlRunner/Runtime/MockFieldRef.cs
@@ -68,14 +68,16 @@ public class MockFieldRef
     /// <summary>ALActive — whether the field is active. Stub: always true.</summary>
     public bool ALActive => true;
 
-    /// <summary>ALGetFilter — returns filter string on this field. Stub: empty string.</summary>
-    public string ALGetFilter => "";
+    /// <summary>ALGetFilter — returns the active filter expression for this field.</summary>
+    public string ALGetFilter => _owner?.GetFieldFilter(_fieldNo) ?? "";
 
-    /// <summary>ALGetRangeMin — returns range min. Stub: NavText.Default(0).</summary>
-    public NavValue ALGetRangeMin => NavText.Default(0);
+    /// <summary>ALGetRangeMin — returns the range minimum value for this field.
+    /// Returns the unwrapped CLR value (int, string, etc.) so Convert.ToInt32 etc. work.</summary>
+    public object ALGetRangeMin => UnwrapNavValue(_owner?.GetFieldRangeMin(_fieldNo));
 
-    /// <summary>ALGetRangeMax — returns range max. Stub: NavText.Default(0).</summary>
-    public NavValue ALGetRangeMax => NavText.Default(0);
+    /// <summary>ALGetRangeMax — returns the range maximum value for this field.
+    /// Returns the unwrapped CLR value (int, string, etc.) so Convert.ToInt32 etc. work.</summary>
+    public object ALGetRangeMax => UnwrapNavValue(_owner?.GetFieldRangeMax(_fieldNo));
 
     /// <summary>ALOptionCaption — option caption string. Stub: empty.</summary>
     public string ALOptionCaption => "";
@@ -205,7 +207,39 @@ public class MockFieldRef
     /// <summary>Static Default factory — mirrors NavFieldRef.Default(ITreeObject).</summary>
     public static MockFieldRef Default() => new MockFieldRef();
 
-    // -- Internal wiring --
+    // -- Internal helpers --
+
+    /// <summary>
+    /// Extract the underlying CLR value from a NavValue so that Convert.ToInt32 etc. work.
+    /// BC compiler emits <c>Convert.ToInt32(fldRef.ALGetRangeMin)</c> which fails on NavValue
+    /// because NavValue doesn't implement IConvertible.
+    /// </summary>
+    private static object UnwrapNavValue(NavValue? value)
+    {
+        if (value == null) return 0;
+        switch (value)
+        {
+            case NavInteger ni: return (int)ni;
+            case NavText nt: return (string)nt;
+            case NavCode nc: return (string)nc;
+            case NavBoolean nb: return (bool)nb;
+            case NavBigInteger nbi: return (long)nbi;
+            case NavGuid ng: return (Guid)ng;
+            case NavOption nopt: return nopt.Value;
+        }
+        if (value is NavDecimal nd)
+        {
+            try
+            {
+                var prop = typeof(NavDecimal).GetProperty("Value",
+                    System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+                var raw = prop?.GetValue(nd);
+                if (raw != null) return Convert.ToDecimal(raw);
+            }
+            catch { }
+        }
+        return 0;
+    }
 
     internal void Bind(MockRecordRef owner, int fieldNo)
     {

--- a/AlRunner/Runtime/MockKeyRef.cs
+++ b/AlRunner/Runtime/MockKeyRef.cs
@@ -1,0 +1,63 @@
+namespace AlRunner.Runtime;
+
+using Microsoft.Dynamics.Nav.Types;
+
+/// <summary>
+/// Mock for NavKeyRef — represents a key definition on a table.
+/// In standalone mode we only know the primary key (registered via
+/// MockRecordHandle.RegisterPrimaryKey). ALKeyCount is always 1 and
+/// ALKeyIndex(1) returns the PK fields.
+/// </summary>
+public class MockKeyRef
+{
+    private int _tableId;
+    private int[] _fieldNos;
+    private MockRecordRef? _recordRef;
+
+    /// <summary>Parameterless constructor for BC-declared KeyRef variables (rewriter strips args).</summary>
+    public MockKeyRef()
+    {
+        _fieldNos = Array.Empty<int>();
+    }
+
+    public MockKeyRef(int tableId, int[] fieldNos, MockRecordRef recordRef)
+    {
+        _tableId = tableId;
+        _fieldNos = fieldNos;
+        _recordRef = recordRef;
+    }
+
+    /// <summary>ALActive — whether this key is active. Always true.</summary>
+    public bool ALActive => true;
+
+    /// <summary>ALFieldCount — number of fields in this key.</summary>
+    public int ALFieldCount => _fieldNos.Length;
+
+    /// <summary>
+    /// ALFieldIndex — returns a MockFieldRef for the Nth field (1-based) in this key.
+    /// </summary>
+    public MockFieldRef ALFieldIndex(int index)
+    {
+        if (index >= 1 && index <= _fieldNos.Length && _recordRef != null)
+        {
+            var fref = new MockFieldRef();
+            fref.Bind(_recordRef, _fieldNos[index - 1]);
+            return fref;
+        }
+        throw new Exception($"KeyRef.FieldIndex: index {index} out of range (1..{_fieldNos.Length})");
+    }
+
+    /// <summary>ALRecord — returns the owning RecordRef.</summary>
+    public MockRecordRef ALRecord() => _recordRef ?? new MockRecordRef();
+
+    /// <summary>
+    /// ALAssign — BC emits <c>kRef.ALAssign(recRef.ALKeyIndex(this, n))</c> for
+    /// <c>KRef := RecRef.KeyIndex(n)</c> in AL. Copy the source key's state.
+    /// </summary>
+    public void ALAssign(MockKeyRef other)
+    {
+        _tableId = other._tableId;
+        _fieldNos = other._fieldNos;
+        _recordRef = other._recordRef;
+    }
+}

--- a/AlRunner/Runtime/MockRecordHandle.cs
+++ b/AlRunner/Runtime/MockRecordHandle.cs
@@ -86,6 +86,44 @@ public class MockRecordHandle
         return new[] { 1 };
     }
 
+    /// <summary>Get the PK field numbers for this table (public accessor for MockRecordRef/KeyRef).</summary>
+    public int[] GetPrimaryKeyFieldNos() => GetPrimaryKeyFields();
+
+    /// <summary>
+    /// Set the ascending direction for all current key fields (or PK fields if none set).
+    /// Used by MockRecordRef.Ascending setter which operates on the overall iteration direction.
+    /// </summary>
+    public void SetOverallAscending(bool ascending)
+    {
+        var fields = _currentKeyFields ?? GetPrimaryKeyFields();
+        // Ensure current key fields are set so GetFilteredRecords applies sorting
+        _currentKeyFields ??= GetPrimaryKeyFields();
+        foreach (var f in fields)
+            _ascending[f] = ascending;
+    }
+
+    /// <summary>
+    /// Get the range minimum value for a field. Returns null if no range filter is active.
+    /// Used by MockFieldRef.ALGetRangeMin via MockRecordRef.
+    /// </summary>
+    public NavValue? GetRangeMin(int fieldNo)
+    {
+        if (_filters.TryGetValue(fieldNo, out var filter) && filter.IsRangeFilter)
+            return filter.FromValue;
+        return null;
+    }
+
+    /// <summary>
+    /// Get the range maximum value for a field. Returns null if no range filter is active.
+    /// Used by MockFieldRef.ALGetRangeMax via MockRecordRef.
+    /// </summary>
+    public NavValue? GetRangeMax(int fieldNo)
+    {
+        if (_filters.TryGetValue(fieldNo, out var filter) && filter.IsRangeFilter)
+            return filter.ToValue;
+        return null;
+    }
+
     public void ALInit()
     {
         _fields = new Dictionary<int, NavValue>();

--- a/AlRunner/Runtime/MockRecordRef.cs
+++ b/AlRunner/Runtime/MockRecordRef.cs
@@ -126,24 +126,24 @@ public class MockRecordRef
     public int Count() => _handle?.ALCount ?? 0;
     public int ALCount => Count();
 
-    public bool FindFirst() => TryFind(() => _handle?.ALFindFirst() ?? false);
+    public bool FindFirst() => TryFind(() => MarkedOnlyFind(() => _handle?.ALFindFirst() ?? false));
     public bool ALFindFirst() => FindFirst();
-    public bool ALFindFirst(DataError errorLevel) => _handle != null && _handle.ALFindFirst(errorLevel);
+    public bool ALFindFirst(DataError errorLevel) => _handle != null && MarkedOnlyFind(() => _handle.ALFindFirst(errorLevel));
 
-    public bool FindLast() => TryFind(() => _handle?.ALFindLast() ?? false);
+    public bool FindLast() => TryFind(() => MarkedOnlyFindReverse(() => _handle?.ALFindLast() ?? false));
     public bool ALFindLast() => FindLast();
-    public bool ALFindLast(DataError errorLevel) => _handle != null && _handle.ALFindLast(errorLevel);
+    public bool ALFindLast(DataError errorLevel) => _handle != null && MarkedOnlyFindReverse(() => _handle.ALFindLast(errorLevel));
 
-    public bool FindSet() => TryFind(() => _handle?.ALFindSet() ?? false);
+    public bool FindSet() => TryFind(() => MarkedOnlyFind(() => _handle?.ALFindSet() ?? false));
     public bool ALFindSet() => FindSet();
-    public bool ALFindSet(DataError errorLevel) => _handle != null && _handle.ALFindSet(errorLevel);
-    public bool ALFindSet(DataError errorLevel, bool forUpdate) => _handle != null && _handle.ALFindSet(errorLevel, forUpdate);
+    public bool ALFindSet(DataError errorLevel) => _handle != null && MarkedOnlyFind(() => _handle.ALFindSet(errorLevel));
+    public bool ALFindSet(DataError errorLevel, bool forUpdate) => _handle != null && MarkedOnlyFind(() => _handle.ALFindSet(errorLevel, forUpdate));
 
-    public bool Find(string which) => TryFind(() => _handle?.ALFind(DataError.ThrowError, which) ?? false);
+    public bool Find(string which) => TryFind(() => MarkedOnlyFind(() => _handle?.ALFind(DataError.ThrowError, which) ?? false));
     public bool Find() => Find("=");
     public bool ALFind(string which) => Find(which);
     public bool ALFind(DataError errorLevel) => Find("=");
-    public bool ALFind(DataError errorLevel, string which) => _handle != null && _handle.ALFind(errorLevel, which);
+    public bool ALFind(DataError errorLevel, string which) => _handle != null && MarkedOnlyFind(() => _handle.ALFind(errorLevel, which));
 
     /// <summary>
     /// Try a find operation, catching exceptions for no-DataError callers.
@@ -156,8 +156,35 @@ public class MockRecordRef
         catch { return false; }
     }
 
-    public bool Next() => _handle != null && _handle.ALNext() != 0;
-    public int ALNext() => _handle?.ALNext() ?? 0;
+    /// <summary>
+    /// When MarkedOnly is true, advance forward from the initial find position
+    /// until we land on a marked record (or run out of records).
+    /// </summary>
+    private bool MarkedOnlyFind(Func<bool> findAction)
+    {
+        if (!findAction()) return false;
+        if (!_markedOnly) return true;
+        // Already on a marked record?
+        if (ALMark()) return true;
+        // Advance until we find a marked one
+        while (_handle != null && _handle.ALNext() != 0)
+        {
+            if (ALMark()) return true;
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// MarkedOnly-aware reverse find (for FindLast which should scan backwards).
+    /// Since MockRecordHandle doesn't have ALPrev, we just use forward scan after find.
+    /// </summary>
+    private bool MarkedOnlyFindReverse(Func<bool> findAction)
+    {
+        return MarkedOnlyFind(findAction);
+    }
+
+    public bool Next() => MarkedOnlyNext(() => _handle != null && _handle.ALNext() != 0);
+    public int ALNext() => MarkedOnlyNext(() => (_handle?.ALNext() ?? 0) != 0) ? 1 : 0;
 
     /// <summary>ALNext(steps) — advance N records forward (RecRef.Next(N) in AL).</summary>
     public int ALNext(int steps)
@@ -166,10 +193,23 @@ public class MockRecordRef
         int moved = 0;
         for (int i = 0; i < steps; i++)
         {
-            if (_handle.ALNext() == 0) break;
+            if (!MarkedOnlyNext(() => _handle.ALNext() != 0)) break;
             moved++;
         }
         return moved;
+    }
+
+    /// <summary>
+    /// When MarkedOnly is true, keep advancing until we land on a marked record.
+    /// </summary>
+    private bool MarkedOnlyNext(Func<bool> nextAction)
+    {
+        if (!_markedOnly) return nextAction();
+        while (nextAction())
+        {
+            if (ALMark()) return true;
+        }
+        return false;
     }
 
     /// <summary>ALGetView — delegates to the underlying record handle's view text.</summary>
@@ -302,15 +342,63 @@ public class MockRecordRef
     public void ALLockTable(DataError errorLevel = DataError.ThrowError) { }
     public void ALSetRecFilter() => _handle?.ALSetRecFilter();
 
-    // -- Mark / MarkedOnly (stubs) --
-    public bool ALMark() => false;
-    public void ALMark(bool mark) { }
+    // -- Mark / MarkedOnly --
+    private readonly HashSet<string> _markedRecords = new();
+    private bool _markedOnly;
+
+    /// <summary>
+    /// ALMark() — returns whether the current record is marked.
+    /// </summary>
+    public bool ALMark()
+    {
+        return _markedRecords.Contains(GetCurrentPkKey());
+    }
+
+    /// <summary>
+    /// ALMark(bool) — marks or unmarks the current record.
+    /// </summary>
+    public void ALMark(bool mark)
+    {
+        var key = GetCurrentPkKey();
+        if (mark)
+            _markedRecords.Add(key);
+        else
+            _markedRecords.Remove(key);
+    }
+
+    /// <summary>
+    /// ALMarkedOnly — when true, iteration (FindSet/Next) returns only marked records.
+    /// </summary>
     public bool ALMarkedOnly
     {
-        get => false;
-        set { /* No-op */ }
+        get => _markedOnly;
+        set => _markedOnly = value;
     }
-    public void ALClearMarks() { }
+
+    /// <summary>ALClearMarks — removes all marks.</summary>
+    public void ALClearMarks()
+    {
+        _markedRecords.Clear();
+    }
+
+    /// <summary>
+    /// Build a string key from the current record's PK field values for marking.
+    /// Uses the handle's registered PK fields, falling back to field 1.
+    /// </summary>
+    private string GetCurrentPkKey()
+    {
+        if (_handle == null) return "";
+        var pkFields = _handle.GetPrimaryKeyFieldNos();
+        var parts = new List<string>();
+        foreach (var fno in pkFields)
+        {
+            // Use NavType.Integer as a dummy — GetFieldValueSafe returns the stored value
+            // regardless of expectedType; it only matters for the default fallback.
+            var val = _handle.GetFieldValueSafe(fno, NavType.Integer);
+            parts.Add(AlCompat.Format(val));
+        }
+        return string.Join("|", parts);
+    }
 
     // -- ChangeCompany (no-op in standalone — single company) --
     public bool ALChangeCompany(string companyName) => true;
@@ -318,16 +406,16 @@ public class MockRecordRef
     public bool ALChangeCompany() => true;
     public bool ALChangeCompany(DataError errorLevel) => true;
 
-    // -- Ascending --
+    // -- Ascending (delegates to handle) --
     public bool ALAscending
     {
-        get => true;
-        set { /* No-op in mock */ }
+        get => _handle?.ALAscending ?? true;
+        set => _handle?.SetOverallAscending(value);
     }
 
     // -- HasFilter / GetFilters --
     public bool ALHasFilter => _handle?.FiltersActive ?? false;
-    public string ALGetFilters => "";
+    public string ALGetFilters => _handle?.ALGetFilters ?? "";
 
     // -- GetPosition / SetPosition --
     public string ALGetPosition()
@@ -358,8 +446,24 @@ public class MockRecordRef
     public void ALModifyAll(int fieldNo, NavValue newValue) => _handle?.ALModifyAllSafe(fieldNo, NavType.Text, newValue);
     public void ALModifyAll(int fieldNo, NavValue newValue, bool runTrigger) => _handle?.ALModifyAllSafe(fieldNo, NavType.Text, newValue, runTrigger);
 
-    // -- GetFilter (per-field) --
-    public string ALGetFilter(int fieldNo) => "";
+    // -- GetFilter (per-field — delegates to handle) --
+    public string ALGetFilter(int fieldNo) => _handle?.ALGetFilter(fieldNo) ?? "";
+
+    // -- CurrentKey / CurrentKeyIndex --
+    public string ALCurrentKey => _handle?.ALCurrentKey ?? "";
+    public int ALCurrentKeyIndex => 1;
+
+    // -- KeyCount / KeyIndex --
+    public int ALKeyCount => 1;
+    public MockKeyRef ALKeyIndex(int index)
+    {
+        if (index == 1 && _handle != null)
+        {
+            var pkFields = _handle.GetPrimaryKeyFieldNos();
+            return new MockKeyRef(Number, pkFields, this);
+        }
+        throw new Exception($"RecordRef.KeyIndex: index {index} out of range (only 1 key available)");
+    }
 
     // -- CurrentCompany --
     public string ALCurrentCompany => "";
@@ -416,6 +520,20 @@ public class MockRecordRef
         }
     }
 
+    /// <summary>
+    /// ALAssign(MockFieldRef) — BC emits <c>recRef.ALAssign(fldRef)</c> when AL
+    /// code does <c>RecRef := FldRef.Record()</c>. The compiler inlines the
+    /// .Record() call, so we extract the owner RecordRef from the FieldRef.
+    /// </summary>
+    public void ALAssign(MockFieldRef fieldRef)
+    {
+        var owner = fieldRef.ALRecord();
+        ALAssign(owner);
+    }
+
+    // -- KeyIndex (with compilation target stripped) --
+    public MockKeyRef ALKeyIndex(object compilationTarget, int index) => ALKeyIndex(index);
+
     // -- Copy --
     public void ALCopy(MockRecordRef source, bool shareFilters = false)
     {
@@ -469,5 +587,22 @@ public class MockRecordRef
     internal void TestField(int fieldNo, NavValue expectedValue)
     {
         _handle?.ALTestFieldSafe(fieldNo, NavType.Text, expectedValue);
+    }
+
+    // -- Internal helpers for MockFieldRef filter/range access --
+
+    internal string GetFieldFilter(int fieldNo)
+    {
+        return _handle?.ALGetFilter(fieldNo) ?? "";
+    }
+
+    internal NavValue? GetFieldRangeMin(int fieldNo)
+    {
+        return _handle?.GetRangeMin(fieldNo);
+    }
+
+    internal NavValue? GetFieldRangeMax(int fieldNo)
+    {
+        return _handle?.GetRangeMax(fieldNo);
     }
 }

--- a/AlRunner/Runtime/MockRecordRef.cs
+++ b/AlRunner/Runtime/MockRecordRef.cs
@@ -176,11 +176,44 @@ public class MockRecordRef
 
     /// <summary>
     /// MarkedOnly-aware reverse find (for FindLast which should scan backwards).
-    /// Since MockRecordHandle doesn't have ALPrev, we just use forward scan after find.
+    /// MockRecordHandle has no ALPrev, so we do a two-pass forward scan:
+    /// Pass 1 — walk the entire filtered set from the first record and record the
+    ///          index of the last marked record.
+    /// Pass 2 — restart from the first record and advance to that saved index.
     /// </summary>
     private bool MarkedOnlyFindReverse(Func<bool> findAction)
     {
-        return MarkedOnlyFind(findAction);
+        if (!findAction()) return false;
+        if (!_markedOnly) return true;
+        if (_handle == null) return false;
+
+        // If the reverse-find already landed on a marked record, we're done.
+        if (ALMark()) return true;
+
+        // Pass 1: scan the filtered set forward and remember the index of the
+        // last marked record.
+        if (!_handle.ALFindFirst()) return false;
+
+        int currentIndex = 0;
+        int lastMarkedIndex = ALMark() ? 0 : -1;
+
+        while (_handle.ALNext() != 0)
+        {
+            currentIndex++;
+            if (ALMark())
+                lastMarkedIndex = currentIndex;
+        }
+
+        if (lastMarkedIndex < 0) return false;
+
+        // Pass 2: reposition on the last marked record.
+        if (!_handle.ALFindFirst()) return false;
+        for (int i = 0; i < lastMarkedIndex; i++)
+        {
+            if (_handle.ALNext() == 0) return false;
+        }
+
+        return true;
     }
 
     public bool Next() => MarkedOnlyNext(() => _handle != null && _handle.ALNext() != 0);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ All notable changes to this project are documented here. Format based on
 ## [Unreleased]
 
 ### Added
+- **RecordRef/FieldRef API completeness** — Mark/MarkedOnly/ClearMarks are now
+  functional (in-memory HashSet tracking). FieldRef.GetFilter returns the active
+  filter expression. FieldRef.GetRangeMin/GetRangeMax return the active range
+  bounds. RecordRef.Ascending setter wires through to the handle's sort direction.
+  FieldRef.Record() returns the owning RecordRef. RecordRef.KeyCount/KeyIndex/
+  CurrentKeyIndex provide basic key metadata. (#115)
+- **KeyRef support** — New `MockKeyRef` class replacing `NavKeyRef`. Provides
+  FieldCount, FieldIndex(n), Record, Active, and ALAssign. The RoslynRewriter
+  maps `NavKeyRef` → `MockKeyRef` with constructor arg stripping. (#115)
 - **ErrorInfo type & collectible errors** — `Error(ErrorInfo)` now uses
   `ErrorInfo.Message` for the error text (previously used `.ToString()` which
   included internal field metadata). Collectible errors are fully supported:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,8 +144,9 @@ dotnet run --project AlRunner -- ./src ./test
 | `AlRunner/Runtime/EventSubscriberRegistry.cs` | Event subscriber discovery + dispatch |
 | `AlRunner/Runtime/HandlerRegistry.cs` | Test handler dispatch (ConfirmHandler, MessageHandler, ModalPageHandler, RequestPageHandler) |
 | `AlRunner/Runtime/MockTestPageHandle.cs` | TestPage mock with full lifecycle, field access, navigation |
-| `AlRunner/Runtime/MockRecordRef.cs` | RecordRef backed by MockRecordHandle; Mark/ClearMarks (stubs), Rename, FieldExists, HasFilter, GetPosition, Ascending, ModifyAll |
-| `AlRunner/Runtime/MockFieldRef.cs` | FieldRef with value get/set, range/filter, ALSetTable (no-op stub for BC compiler page API extensions) |
+| `AlRunner/Runtime/MockRecordRef.cs` | RecordRef backed by MockRecordHandle; Mark/MarkedOnly/ClearMarks (functional), Rename, FieldExists, HasFilter, GetPosition, Ascending (get/set), ModifyAll, KeyCount/KeyIndex/CurrentKeyIndex |
+| `AlRunner/Runtime/MockFieldRef.cs` | FieldRef with value get/set, range/filter, GetFilter, GetRangeMin/Max, Record(), ALSetTable (no-op stub) |
+| `AlRunner/Runtime/MockKeyRef.cs` | KeyRef mock: FieldCount, FieldIndex(n), Record, Active, ALAssign |
 | `AlRunner/Runtime/MockNotification.cs` | In-memory Notification mock: Message, Send, Recall, SetData/GetData/HasData, AddAction, Id, Scope |
 | `AlRunner/Runtime/MockTaskScheduler.cs` | TaskScheduler stubs: CreateTask (sync dispatch), TaskExists, CancelTask, SetTaskReady |
 | `AlRunner/Runtime/MockDataTransfer.cs` | DataTransfer stubs: SetTables, AddFieldValue, AddConstantValue, CopyFields, CopyRows (no-ops) |

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -109,7 +109,7 @@ the exact value will see different results.
 | `UserId()` | Authenticated user | `""` |
 | `IsSessionActive(id)` | True while session runs | Always `false` |
 | `GuiAllowed()` | False in background sessions | `false` |
-| `GetFilter(field)` | Serialised filter expression | `""` (not yet serialised) |
+| `GetFilter(field)` | Serialised filter expression | Returns serialised filter expression (functional) |
 | `Record.FieldCount` via RecordRef | Schema field count | Count of fields written at runtime |
 | Field `InitValue` | Applied on `Init()` | Not applied — type default only |
 | `FieldRef.Caption` / `.Name` | Field metadata from schema | `"FieldNN"` stub |

--- a/tests/bucket-2/116-recref-methods/test/RecRefMethodTests.al
+++ b/tests/bucket-2/116-recref-methods/test/RecRefMethodTests.al
@@ -40,12 +40,12 @@ codeunit 50917 "RecRef Method Tests"
     end;
 
     [Test]
-    procedure TestMarkReturnsFalseAsStub()
+    procedure TestMarkReturnsTrueAfterMarking()
     var
         Helper: Codeunit "RecRef Method Helper";
     begin
-        // Mark is a no-op stub — Mark() always returns false
-        Assert.IsFalse(Helper.TestMark(), 'Mark() stub should return false');
+        // Mark(true) marks the record, then Mark() returns true
+        Assert.IsTrue(Helper.TestMark(), 'Mark() should return true after Mark(true)');
     end;
 
     [Test]

--- a/tests/bucket-2/127-recref-fieldref-api/src/ApiProbe.al
+++ b/tests/bucket-2/127-recref-fieldref-api/src/ApiProbe.al
@@ -249,7 +249,38 @@ codeunit 56270 "API Probe"
         RecRef.Open(Database::"API Test Entry");
         FldRef := RecRef.Field(FieldNo);
         FldRef.SetRange(5, 15);
-        // Use FieldRef.GetFilter to verify the filter expression
+        // Use FieldRef.GetFilter to verify the filter expression (exercises MockRecordRef.GetFieldFilter delegation)
         exit(FldRef.GetFilter());
+    end;
+
+    procedure GetRecRefGetFilterNoFilter(FieldNo: Integer): Text
+    var
+        RecRef: RecordRef;
+        FldRef: FieldRef;
+    begin
+        // No filter set — verify delegation returns empty string
+        RecRef.Open(Database::"API Test Entry");
+        FldRef := RecRef.Field(FieldNo);
+        exit(FldRef.GetFilter());
+    end;
+
+    procedure FindLastEntryNoWithMarkedOnly(): Text
+    var
+        RecRef: RecordRef;
+        FldRef: FieldRef;
+    begin
+        RecRef.Open(Database::"API Test Entry");
+        // Mark only entry 2 (the middle one)
+        FldRef := RecRef.Field(1);
+        FldRef.SetRange(2);
+        if RecRef.FindFirst() then
+            RecRef.Mark(true);
+        RecRef.Reset();
+        RecRef.MarkedOnly(true);
+        if RecRef.FindLast() then begin
+            FldRef := RecRef.Field(1);
+            exit(Format(FldRef.Value));
+        end;
+        exit('');
     end;
 }

--- a/tests/bucket-2/127-recref-fieldref-api/src/ApiProbe.al
+++ b/tests/bucket-2/127-recref-fieldref-api/src/ApiProbe.al
@@ -1,0 +1,255 @@
+codeunit 56270 "API Probe"
+{
+    /// <summary>
+    /// Helper codeunit to exercise RecordRef/FieldRef/KeyRef API methods.
+    /// Each procedure isolates a specific API call for testing.
+    /// </summary>
+
+    procedure InsertEntry(EntryNo: Integer; Cat: Code[20]; Desc: Text[100]; Amt: Decimal; IsActive: Boolean)
+    var
+        R: Record "API Test Entry";
+    begin
+        R."Entry No." := EntryNo;
+        R.Category := Cat;
+        R.Description := Desc;
+        R.Amount := Amt;
+        R.Active := IsActive;
+        R.Insert();
+    end;
+
+    procedure GetAscendingDefault(): Boolean
+    var
+        RecRef: RecordRef;
+    begin
+        RecRef.Open(Database::"API Test Entry");
+        exit(RecRef.Ascending);
+    end;
+
+    procedure IterateFieldValuesDescending(FieldNo: Integer): Text
+    var
+        RecRef: RecordRef;
+        FldRef: FieldRef;
+        Result: Text;
+    begin
+        RecRef.Open(Database::"API Test Entry");
+        RecRef.Ascending(false);
+        if RecRef.FindSet() then
+            repeat
+                FldRef := RecRef.Field(FieldNo);
+                if Result <> '' then
+                    Result += ',';
+                Result += Format(FldRef.Value);
+            until RecRef.Next() = 0;
+        RecRef.Close();
+        exit(Result);
+    end;
+
+    procedure MarkRecordByEntryNo(EntryNo: Integer)
+    var
+        RecRef: RecordRef;
+        FldRef: FieldRef;
+    begin
+        RecRef.Open(Database::"API Test Entry");
+        FldRef := RecRef.Field(1);
+        FldRef.SetRange(EntryNo);
+        if RecRef.FindFirst() then
+            RecRef.Mark(true);
+        RecRef.Close();
+    end;
+
+    procedure IsRecordMarked(EntryNo: Integer): Boolean
+    var
+        RecRef: RecordRef;
+        FldRef: FieldRef;
+    begin
+        RecRef.Open(Database::"API Test Entry");
+        FldRef := RecRef.Field(1);
+        FldRef.SetRange(EntryNo);
+        if RecRef.FindFirst() then
+            exit(RecRef.Mark());
+        exit(false);
+    end;
+
+    procedure IterateMarkedOnly(): Text
+    var
+        RecRef: RecordRef;
+        FldRef: FieldRef;
+        Result: Text;
+    begin
+        RecRef.Open(Database::"API Test Entry");
+        // Mark entries 1 and 3
+        FldRef := RecRef.Field(1);
+        FldRef.SetRange(1);
+        if RecRef.FindFirst() then
+            RecRef.Mark(true);
+        FldRef.SetRange(3);
+        if RecRef.FindFirst() then
+            RecRef.Mark(true);
+        // Reset filters and iterate marked only
+        RecRef.Reset();
+        RecRef.MarkedOnly(true);
+        if RecRef.FindSet() then
+            repeat
+                FldRef := RecRef.Field(1);
+                if Result <> '' then
+                    Result += ',';
+                Result += Format(FldRef.Value);
+            until RecRef.Next() = 0;
+        RecRef.Close();
+        exit(Result);
+    end;
+
+    procedure MarkAndClearMarks(): Boolean
+    var
+        RecRef: RecordRef;
+        FldRef: FieldRef;
+    begin
+        RecRef.Open(Database::"API Test Entry");
+        FldRef := RecRef.Field(1);
+        FldRef.SetRange(1);
+        if RecRef.FindFirst() then
+            RecRef.Mark(true);
+        RecRef.ClearMarks();
+        // After ClearMarks, Mark() should return false
+        FldRef.SetRange(1);
+        if RecRef.FindFirst() then
+            exit(RecRef.Mark());
+        exit(false);
+    end;
+
+    procedure GetFilterAfterSetRange(): Text
+    var
+        RecRef: RecordRef;
+        FldRef: FieldRef;
+    begin
+        RecRef.Open(Database::"API Test Entry");
+        FldRef := RecRef.Field(1);
+        FldRef.SetRange(10, 50);
+        exit(FldRef.GetFilter());
+    end;
+
+    procedure GetFilterAfterSetRangeSingle(): Text
+    var
+        RecRef: RecordRef;
+        FldRef: FieldRef;
+    begin
+        RecRef.Open(Database::"API Test Entry");
+        FldRef := RecRef.Field(1);
+        FldRef.SetRange(42);
+        exit(FldRef.GetFilter());
+    end;
+
+    procedure GetFilterAfterSetFilter(): Text
+    var
+        RecRef: RecordRef;
+        FldRef: FieldRef;
+    begin
+        RecRef.Open(Database::"API Test Entry");
+        FldRef := RecRef.Field(3);
+        FldRef.SetFilter('*test*');
+        exit(FldRef.GetFilter());
+    end;
+
+    procedure GetRangeMinAfterSetRange(): Integer
+    var
+        RecRef: RecordRef;
+        FldRef: FieldRef;
+        Val: Integer;
+    begin
+        RecRef.Open(Database::"API Test Entry");
+        FldRef := RecRef.Field(1);
+        FldRef.SetRange(10, 50);
+        Val := FldRef.GetRangeMin();
+        exit(Val);
+    end;
+
+    procedure GetRangeMaxAfterSetRange(): Integer
+    var
+        RecRef: RecordRef;
+        FldRef: FieldRef;
+        Val: Integer;
+    begin
+        RecRef.Open(Database::"API Test Entry");
+        FldRef := RecRef.Field(1);
+        FldRef.SetRange(10, 50);
+        Val := FldRef.GetRangeMax();
+        exit(Val);
+    end;
+
+    procedure GetRangeMinMaxSingle(): Text
+    var
+        RecRef: RecordRef;
+        FldRef: FieldRef;
+        MinVal: Integer;
+        MaxVal: Integer;
+    begin
+        RecRef.Open(Database::"API Test Entry");
+        FldRef := RecRef.Field(1);
+        FldRef.SetRange(10);
+        MinVal := FldRef.GetRangeMin();
+        MaxVal := FldRef.GetRangeMax();
+        exit(Format(MinVal) + ',' + Format(MaxVal));
+    end;
+
+    procedure FieldRefRecordOwner(): Integer
+    var
+        RecRef: RecordRef;
+        FldRef: FieldRef;
+        OwnerRef: RecordRef;
+    begin
+        RecRef.Open(Database::"API Test Entry");
+        FldRef := RecRef.Field(1);
+        OwnerRef := FldRef.Record();
+        exit(OwnerRef.Number);
+    end;
+
+    procedure GetKeyCount(): Integer
+    var
+        RecRef: RecordRef;
+    begin
+        RecRef.Open(Database::"API Test Entry");
+        exit(RecRef.KeyCount);
+    end;
+
+    procedure GetKeyFieldCount(): Integer
+    var
+        RecRef: RecordRef;
+        KRef: KeyRef;
+    begin
+        RecRef.Open(Database::"API Test Entry");
+        KRef := RecRef.KeyIndex(1);
+        exit(KRef.FieldCount);
+    end;
+
+    procedure GetKeyFieldNo(FieldIdx: Integer): Integer
+    var
+        RecRef: RecordRef;
+        KRef: KeyRef;
+        FldRef: FieldRef;
+    begin
+        RecRef.Open(Database::"API Test Entry");
+        KRef := RecRef.KeyIndex(1);
+        FldRef := KRef.FieldIndex(FieldIdx);
+        exit(FldRef.Number());
+    end;
+
+    procedure GetCurrentKeyIndex(): Integer
+    var
+        RecRef: RecordRef;
+    begin
+        RecRef.Open(Database::"API Test Entry");
+        exit(RecRef.CurrentKeyIndex);
+    end;
+
+    procedure GetRecRefGetFilter(FieldNo: Integer): Text
+    var
+        RecRef: RecordRef;
+        FldRef: FieldRef;
+    begin
+        RecRef.Open(Database::"API Test Entry");
+        FldRef := RecRef.Field(FieldNo);
+        FldRef.SetRange(5, 15);
+        // Use FieldRef.GetFilter to verify the filter expression
+        exit(FldRef.GetFilter());
+    end;
+}

--- a/tests/bucket-2/127-recref-fieldref-api/src/Table.al
+++ b/tests/bucket-2/127-recref-fieldref-api/src/Table.al
@@ -1,0 +1,15 @@
+table 56270 "API Test Entry"
+{
+    fields
+    {
+        field(1; "Entry No."; Integer) { }
+        field(2; "Category"; Code[20]) { }
+        field(3; Description; Text[100]) { }
+        field(4; Amount; Decimal) { }
+        field(5; Active; Boolean) { }
+    }
+    keys
+    {
+        key(PK; "Entry No.", "Category") { Clustered = true; }
+    }
+}

--- a/tests/bucket-2/127-recref-fieldref-api/test/ApiTests.al
+++ b/tests/bucket-2/127-recref-fieldref-api/test/ApiTests.al
@@ -240,12 +240,13 @@ codeunit 56271 "API Tests"
     [Test]
     procedure FindLastWithMarkedOnlyReturnsLastMarkedRecord()
     begin
-        // [GIVEN] 3 entries exist; only entry 2 (in the middle) is marked
+        // [GIVEN] 3 entries (Entry No. 1, 2, 3); the probe marks only entry 2 via RecordRef.Mark
+        // Note: the last parameter to InsertEntry is the 'Active' field, not the mark flag
         Probe.InsertEntry(1, 'A', 'Alpha', 10.0, true);
         Probe.InsertEntry(2, 'B', 'Bravo', 20.0, false);
         Probe.InsertEntry(3, 'C', 'Charlie', 30.0, true);
-        // [WHEN] FindLast with MarkedOnly=true
-        // [THEN] Returns entry 2 (the only marked record), not empty
+        // [WHEN] FindLast with MarkedOnly=true (probe internally marks entry 2)
+        // [THEN] FindLast returns entry 2 — the only (and thus last) marked record
         Assert.AreEqual('2', Probe.FindLastEntryNoWithMarkedOnly(),
             'FindLast with MarkedOnly must return the last marked record');
     end;

--- a/tests/bucket-2/127-recref-fieldref-api/test/ApiTests.al
+++ b/tests/bucket-2/127-recref-fieldref-api/test/ApiTests.al
@@ -1,0 +1,245 @@
+codeunit 56271 "API Tests"
+{
+    Subtype = Test;
+    var
+        Assert: Codeunit Assert;
+        Probe: Codeunit "API Probe";
+
+    // === 1. Ascending ===
+
+    [Test]
+    procedure AscendingDefaultIsTrue()
+    begin
+        // [GIVEN] A freshly opened RecRef
+        // [THEN] Ascending defaults to true
+        Assert.IsTrue(Probe.GetAscendingDefault(), 'Default Ascending must be true');
+    end;
+
+    [Test]
+    procedure SetAscendingFalseReversesSortOrder()
+    begin
+        // [GIVEN] 3 entries with Entry No. 1, 2, 3
+        Probe.InsertEntry(1, 'A', 'First', 10.0, true);
+        Probe.InsertEntry(2, 'B', 'Second', 20.0, false);
+        Probe.InsertEntry(3, 'C', 'Third', 30.0, true);
+
+        // [WHEN] Iterating with Ascending=false
+        // [THEN] Entry numbers come in descending order
+        Assert.AreEqual('3,2,1', Probe.IterateFieldValuesDescending(1),
+            'Descending iteration must reverse the order');
+    end;
+
+    // === 2. Mark / MarkedOnly ===
+
+    [Test]
+    procedure MarkRecordAndRetrieve()
+    var
+        RecRef: RecordRef;
+        FldRef: FieldRef;
+    begin
+        // [GIVEN] 2 entries
+        Probe.InsertEntry(1, 'A', 'Alpha', 10.0, true);
+        Probe.InsertEntry(2, 'B', 'Bravo', 20.0, false);
+
+        // [WHEN] Mark entry 1
+        RecRef.Open(Database::"API Test Entry");
+        FldRef := RecRef.Field(1);
+        FldRef.SetRange(1);
+        RecRef.FindFirst();
+        RecRef.Mark(true);
+
+        // [THEN] Mark() returns true for entry 1
+        Assert.IsTrue(RecRef.Mark(), 'Marked record must return true');
+
+        // [THEN] Mark() returns false for entry 2
+        FldRef.SetRange(2);
+        RecRef.FindFirst();
+        Assert.IsFalse(RecRef.Mark(), 'Unmarked record must return false');
+        RecRef.Close();
+    end;
+
+    [Test]
+    procedure MarkedOnlyFiltersIteration()
+    begin
+        // [GIVEN] 3 entries
+        Probe.InsertEntry(1, 'A', 'Alpha', 10.0, true);
+        Probe.InsertEntry(2, 'B', 'Bravo', 20.0, false);
+        Probe.InsertEntry(3, 'C', 'Charlie', 30.0, true);
+
+        // [WHEN] Mark entries 1 and 3, then iterate with MarkedOnly
+        // [THEN] Only entries 1 and 3 are returned
+        Assert.AreEqual('1,3', Probe.IterateMarkedOnly(),
+            'MarkedOnly must filter to only marked records');
+    end;
+
+    [Test]
+    procedure ClearMarksResetsAll()
+    begin
+        // [GIVEN] An entry exists and is marked
+        Probe.InsertEntry(1, 'A', 'Alpha', 10.0, true);
+
+        // [WHEN] Mark then ClearMarks
+        // [THEN] Mark() returns false
+        Assert.IsFalse(Probe.MarkAndClearMarks(),
+            'After ClearMarks, no records should be marked');
+    end;
+
+    // === 3. FieldRef.GetFilter ===
+
+    [Test]
+    procedure GetFilterReturnsRangeExpression()
+    begin
+        // [WHEN] SetRange(10, 50) on Entry No.
+        // [THEN] GetFilter returns "10..50"
+        Assert.AreEqual('10..50', Probe.GetFilterAfterSetRange(),
+            'GetFilter must return range expression');
+    end;
+
+    [Test]
+    procedure GetFilterReturnsSingleValue()
+    begin
+        // [WHEN] SetRange(42) on Entry No.
+        // [THEN] GetFilter returns "42"
+        Assert.AreEqual('42', Probe.GetFilterAfterSetRangeSingle(),
+            'GetFilter for single value must return just the value');
+    end;
+
+    [Test]
+    procedure GetFilterReturnsFilterExpression()
+    begin
+        // [WHEN] SetFilter('*test*') on Description
+        // [THEN] GetFilter returns "*test*"
+        Assert.AreEqual('*test*', Probe.GetFilterAfterSetFilter(),
+            'GetFilter must return filter expression');
+    end;
+
+    // === 4. FieldRef.GetRangeMin / GetRangeMax ===
+
+    [Test]
+    procedure GetRangeMinMax()
+    begin
+        // [WHEN] SetRange(10, 50) on Entry No.
+        // [THEN] GetRangeMin=10, GetRangeMax=50
+        Assert.AreEqual(10, Probe.GetRangeMinAfterSetRange(),
+            'GetRangeMin must return the from value');
+        Assert.AreEqual(50, Probe.GetRangeMaxAfterSetRange(),
+            'GetRangeMax must return the to value');
+    end;
+
+    [Test]
+    procedure GetRangeMinMaxSingleValue()
+    begin
+        // [WHEN] SetRange(10) on Entry No. (single value => from=to=10)
+        // [THEN] Both min and max return 10
+        Assert.AreEqual('10,10', Probe.GetRangeMinMaxSingle(),
+            'Both GetRangeMin and GetRangeMax must return the same value for single-value range');
+    end;
+
+    // === 5. FieldRef.Record ===
+
+    [Test]
+    procedure FieldRefRecordReturnsOwner()
+    begin
+        // [WHEN] Get FieldRef from RecRef on API Test Entry
+        // [THEN] FieldRef.Record().Number matches the table ID
+        Assert.AreEqual(56270, Probe.FieldRefRecordOwner(),
+            'FieldRef.Record must return the owning RecordRef with correct table number');
+    end;
+
+    // === 6. KeyRef ===
+
+    [Test]
+    procedure KeyCountReturnsOne()
+    begin
+        // [THEN] KeyCount >= 1 (we expose at least the PK)
+        Assert.IsTrue(Probe.GetKeyCount() >= 1,
+            'KeyCount must be at least 1');
+    end;
+
+    [Test]
+    procedure KeyRefFieldCountMatchesPK()
+    begin
+        // [GIVEN] Table has composite PK (Entry No., Category) = 2 fields
+        // [THEN] KeyIndex(1).FieldCount = 2
+        Assert.AreEqual(2, Probe.GetKeyFieldCount(),
+            'KeyRef.FieldCount must match PK field count');
+    end;
+
+    [Test]
+    procedure KeyRefFieldIndexReturnsCorrectField()
+    begin
+        // [GIVEN] PK fields are Entry No. (1) and Category (2)
+        // [THEN] FieldIndex(1).Number = 1, FieldIndex(2).Number = 2
+        Assert.AreEqual(1, Probe.GetKeyFieldNo(1),
+            'First PK field must be field 1');
+        Assert.AreEqual(2, Probe.GetKeyFieldNo(2),
+            'Second PK field must be field 2');
+    end;
+
+    // === 7. CurrentKeyIndex ===
+
+    [Test]
+    procedure CurrentKeyIndexReturnsOne()
+    begin
+        // [THEN] CurrentKeyIndex defaults to 1
+        Assert.AreEqual(1, Probe.GetCurrentKeyIndex(),
+            'CurrentKeyIndex must return 1');
+    end;
+
+    // === Negative Tests ===
+
+    [Test]
+    procedure GetFilterReturnsEmptyWhenNoFilter()
+    var
+        RecRef: RecordRef;
+        FldRef: FieldRef;
+    begin
+        // [GIVEN] No filter set
+        RecRef.Open(Database::"API Test Entry");
+        FldRef := RecRef.Field(1);
+        // [THEN] GetFilter returns empty string
+        Assert.AreEqual('', FldRef.GetFilter(),
+            'GetFilter with no active filter must return empty string');
+        RecRef.Close();
+    end;
+
+    [Test]
+    procedure GetRangeMinReturnsDefaultWhenNoRange()
+    var
+        RecRef: RecordRef;
+        FldRef: FieldRef;
+        Val: Integer;
+    begin
+        // [GIVEN] No range set
+        RecRef.Open(Database::"API Test Entry");
+        FldRef := RecRef.Field(1);
+        // [THEN] GetRangeMin returns 0 (default for integer)
+        Val := FldRef.GetRangeMin();
+        Assert.AreEqual(0, Val, 'GetRangeMin with no range must return default');
+        RecRef.Close();
+    end;
+
+    [Test]
+    procedure RecRefGetFilterDelegatesToHandle()
+    begin
+        // [WHEN] SetRange on a field via FieldRef, then read via FieldRef.GetFilter
+        // [THEN] Returns the same range expression
+        Assert.AreEqual('5..15', Probe.GetRecRefGetFilter(1),
+            'FieldRef.GetFilter must return the range set on the field');
+    end;
+
+    [Test]
+    procedure MarkUnmarkedRecordReturnsFalse()
+    var
+        RecRef: RecordRef;
+        FldRef: FieldRef;
+    begin
+        // [GIVEN] An entry exists but is not marked
+        Probe.InsertEntry(1, 'A', 'Alpha', 10.0, true);
+        RecRef.Open(Database::"API Test Entry");
+        RecRef.FindFirst();
+        // [THEN] Mark() returns false
+        Assert.IsFalse(RecRef.Mark(), 'Unmarked record must return false');
+        RecRef.Close();
+    end;
+}

--- a/tests/bucket-2/127-recref-fieldref-api/test/ApiTests.al
+++ b/tests/bucket-2/127-recref-fieldref-api/test/ApiTests.al
@@ -223,9 +223,31 @@ codeunit 56271 "API Tests"
     procedure RecRefGetFilterDelegatesToHandle()
     begin
         // [WHEN] SetRange on a field via FieldRef, then read via FieldRef.GetFilter
-        // [THEN] Returns the same range expression
+        // [THEN] Returns the same range expression — exercises MockRecordRef's delegation to handle
         Assert.AreEqual('5..15', Probe.GetRecRefGetFilter(1),
             'FieldRef.GetFilter must return the range set on the field');
+    end;
+
+    [Test]
+    procedure RecRefGetFilterReturnsEmptyWhenNoFilter()
+    begin
+        // [GIVEN] No filter set on the field
+        // [THEN] FieldRef.GetFilter returns empty string (via MockRecordRef delegation)
+        Assert.AreEqual('', Probe.GetRecRefGetFilterNoFilter(1),
+            'FieldRef.GetFilter must return empty string when no filter is set');
+    end;
+
+    [Test]
+    procedure FindLastWithMarkedOnlyReturnsLastMarkedRecord()
+    begin
+        // [GIVEN] 3 entries exist; only entry 2 (in the middle) is marked
+        Probe.InsertEntry(1, 'A', 'Alpha', 10.0, true);
+        Probe.InsertEntry(2, 'B', 'Bravo', 20.0, false);
+        Probe.InsertEntry(3, 'C', 'Charlie', 30.0, true);
+        // [WHEN] FindLast with MarkedOnly=true
+        // [THEN] Returns entry 2 (the only marked record), not empty
+        Assert.AreEqual('2', Probe.FindLastEntryNoWithMarkedOnly(),
+            'FindLast with MarkedOnly must return the last marked record');
     end;
 
     [Test]


### PR DESCRIPTION
Closes #115

## What changed

Made many RecordRef/FieldRef stub methods functional and added basic KeyRef support.

### RecordRef improvements
- **Ascending/SetAscending** — now wires through to MockRecordHandle's sort direction (was no-op stub)
- **Mark/MarkedOnly/ClearMarks** — functional in-memory record marking with PK-based tracking (was no-op stubs)
- **KeyCount/KeyIndex/CurrentKeyIndex** — returns key metadata using registered PK fields
- **GetFilter(fieldNo)** — delegates to MockRecordHandle's filter store

### FieldRef improvements
- **GetFilter** — returns actual filter expression from handle (`fromValue..toValue` for ranges, raw expression for SetFilter)
- **GetRangeMin/GetRangeMax** — returns unwrapped CLR values from range bounds (fixes `Convert.ToInt32()` compatibility)
- **Record()** — returns owning RecordRef correctly

### New: MockKeyRef
- Replaces `NavKeyRef` via RoslynRewriter mapping
- Properties: `Active`, `FieldCount`, `FieldIndex(n)`, `Record()`
- Built from registered primary key fields

### Bug fixes during implementation
- `GetCurrentPkKey()` called `NavValue.ToString()` which crashed with null session — fixed with `AlCompat.Format()`
- `SetOverallAscending()` didn't set `_currentKeyFields`, so sorting never applied
- Updated pre-existing test `TestMarkReturnsFalseAsStub` → `TestMarkReturnsTrueAfterMarking` (Mark is now functional)

### Test suite
19 new test cases in `tests/bucket-2/127-recref-fieldref-api/` covering all new functionality.
All 90+ bucket-2 tests pass with zero regressions.