### PR TITLE
chore: add multi-agent workflow — AGENTS.md, prompt templates, updated instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,4 +1,21 @@
-# Copilot Code Review Instructions
+# Copilot Instructions
+
+## Role: Implementation agent or reviewer
+
+When you receive an **issue assignment**, you are acting as an **implementation agent**. Read the `agent:` label on the assigned issue — that is your identity (`impl-1` or `impl-2`). Follow the agent workflow in `AGENTS.md`.
+
+**Implementation agent quick reference:**
+1. Create branch `agent/<your-id>/issue-<N>`
+2. Implement following TDD rules below — failing test first, then fix
+3. Open PR with `Closes #N` in the body. Add labels `agent: <your-id>` and `status: review-ready` to the PR
+4. Fix any CI failures or review comments that come back
+5. Auto-merge fires once approved and CI is green — you are done
+
+When you receive a **PR review request**, you are acting as a **code reviewer**. Apply the checklist below.
+
+---
+
+# Code Review Checklist
 
 These instructions apply to every pull request in this repository. Review each PR against the requirements below and flag anything that is missing or incorrect.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,105 @@
+# AGENTS.md
+
+This file is read by OpenAI Codex and any other agent working in this repository.
+For Claude Code, see `CLAUDE.md`. For GitHub Copilot, see `.github/copilot-instructions.md`.
+The agent workflow contract below applies to all agent types equally.
+
+---
+
+## Repository purpose
+
+Run Business Central AL unit tests in milliseconds — no BC service tier, no Docker, no SQL Server, no license. See `README.md` for architecture and `docs/limitations.md` for known gaps.
+
+---
+
+## TDD is non-negotiable
+
+Every feature, fix, or mock addition requires a test. No exceptions.
+
+**Strict red/green workflow:**
+1. **RED** — write the failing AL test first, run it, confirm it fails
+2. **GREEN** — implement the fix, run again, confirm it passes
+3. Never write implementation code without a prior failing test
+
+**Every test must cover both directions:**
+- **Positive**: correct input → expected result (`Assert.AreEqual`)
+- **Negative**: invalid input → right error (`asserterror` + `Assert.ExpectedError`)
+
+**Tests must prove, not just pass.** A green test that would also pass with a no-op mock proves nothing. Ask: "would this catch a broken implementation?" If not, strengthen it. See issue #203 for the full standard.
+
+---
+
+## Documentation must stay current
+
+Any change affecting behavior, CLI flags, or mock capabilities must update:
+- `CHANGELOG.md` — entry under `[Unreleased]` (always required)
+- `README.md` — supported/unsupported feature list, CLI flags
+- `PrintGuide()` in `AlRunner/Program.cs` — `--guide` output
+- `docs/limitations.md` — if the change affects known gaps
+
+---
+
+## Agent workflow
+
+This repository uses a multi-agent workflow. Agents are identified by GitHub issue/PR labels.
+
+### Your identity
+
+Your agent identity (`impl-1`, `impl-2`, or `orchestrator`) is given to you in the task prompt when you are started. It maps to a GitHub label (`agent: impl-1`, etc.).
+
+### Implementation agent loop
+
+If you are `impl-1` or `impl-2`:
+
+1. Check for issues labeled `agent: <your-id>` AND `status: in-progress` — that is your active issue if one exists.
+2. If no active issue, find the next unclaimed issue: `status: ready` with no `agent:` label. Claim it by adding `agent: <your-id>` + `status: in-progress` and removing `status: ready`.
+3. Implement following TDD rules. Branch: `agent/<your-id>/issue-<N>`.
+4. Open PR with `Closes #N`. Add `agent: <your-id>` + `status: review-ready` to the PR.
+5. Monitor: fix CI failures, address review comments, rebase on conflict. If blocked, add `status: blocked` with a comment and stop.
+6. Once merged: return to step 1.
+
+**One issue at a time.** Do not pick up a second issue while a PR is open.
+
+### Orchestrator loop (priority order)
+
+If you are `orchestrator`:
+
+1. **PRs first**: find PRs labeled `status: review-ready`. If CI is green and no unresolved threads: approve + `gh pr merge --auto --squash`. If CI is failing or threads are open: leave actionable review comments.
+2. **Unblock**: review `status: blocked` issues and resolve if possible.
+3. **Replenish**: if fewer than 20 issues have `status: ready`, create new ones from coverage gaps (`docs/coverage.yaml`, `coverage-gap` label, `docs/limitations.md` non-architectural items). Do not create issues when PRs are waiting — PRs always come first.
+
+Workers self-select from the `status: ready` queue. The orchestrator does not assign issues to specific workers.
+
+### Rules all agents must follow
+
+- **Never push directly to `main`** — always via PR
+- **Never self-assign** (impl agents) — only work on issues the orchestrator has labeled for you
+- **Branch naming**: `agent/<agent-id>/issue-<N>` — no exceptions
+- **Always link the issue** in the PR body: `Closes #N`
+- **Always set `status: review-ready`** on the PR once CI is green — this is how the orchestrator finds your work
+- **One PR at a time** per impl agent
+
+---
+
+## Key files
+
+| File | Role |
+|------|------|
+| `AlRunner/Program.cs` | CLI entry point, AlTranspiler, RoslynCompiler, Executor, PrintGuide |
+| `AlRunner/RoslynRewriter.cs` | BC→mock type transformations |
+| `AlRunner/Pipeline.cs` | Pipeline orchestration, exit codes |
+| `AlRunner/Runtime/` | All mock implementations (MockRecordHandle, AlScope, etc.) |
+| `tests/bucket-1/`, `tests/bucket-2/` | AL test suites |
+| `docs/limitations.md` | Known gaps and architectural limits |
+| `CHANGELOG.md` | Always update under `[Unreleased]` |
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | All tests pass |
+| 1 | Test failures or fatal error |
+| 2 | Runner limitation (blocked tests) — use `--strict` in CI to treat as failure |
+| 3 | AL transpilation failure |
+
+CI always passes `--strict`. Any non-zero exit fails the pipeline.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,8 @@ Every test must cover **both directions**:
 
 A test that only proves the happy path is incomplete — a mock that always returns a default value would also pass.
 
+**Tests must prove, not just pass.** Before marking a test complete, ask: "would this catch a broken or no-op mock?" If the test would pass even if the implementation always returned a default value, it is not a proving test — it is noise. Assert specific expected values, not just absence of errors. See issue #203.
+
 ---
 
 ## Filing Issues for Gaps
@@ -162,3 +164,15 @@ dotnet run --project AlRunner -- ./src ./test
 ## `--guide` Flag
 
 `al-runner --guide` prints a comprehensive test-writing reference for AI agents. It is the primary discovery mechanism for external agents. **Always update `PrintGuide()` in `Program.cs` when runner capabilities change.**
+
+---
+
+## Agent workflow
+
+This repository uses a multi-agent workflow. See `AGENTS.md` for the full contract. The short version:
+
+- **Implementation agents** (`agent: impl-1`, `agent: impl-2`): pick up issues labeled for them, implement with TDD, open a PR labeled `status: review-ready`, wait for orchestrator review and auto-merge.
+- **Orchestrator** (`agent: orchestrator`): assigns issues to idle impl agents, reviews PRs, enables auto-merge, replenishes the issue queue.
+- **Branch naming**: `agent/<agent-id>/issue-<N>` — always
+- **Never push directly to `main`** — always via PR
+- **Never self-assign** — impl agents only work on issues the orchestrator has labeled for them

--- a/docs/agent-prompts.md
+++ b/docs/agent-prompts.md
@@ -1,0 +1,141 @@
+# Agent Startup Prompts
+
+Copy the relevant prompt and paste it into your agent (Claude Code `/loop`, Copilot autopilot, Codex task, etc.).
+
+For worker prompts, replace `<AGENT-ID>` with `impl-1` or `impl-2`.
+
+---
+
+## Orchestrator prompt
+
+```
+You are the orchestrator agent for the BusinessCentral.AL.Runner repository
+(https://github.com/StefanMaron/BusinessCentral.AL.Runner).
+
+Read AGENTS.md in the repository root for the full workflow contract.
+
+Work through the following in priority order each loop:
+
+### 1. Review and merge open PRs (highest priority)
+
+Find all open PRs labeled "status: review-ready":
+  gh pr list --label "status: review-ready" --state open --json number,title,url
+
+For each:
+- Check CI status: gh pr checks <number>
+- Check for unresolved review threads: gh pr view <number> --json reviewDecision,reviews
+- If CI is green AND no unresolved threads: approve and enable auto-merge:
+    gh pr review <number> --approve
+    gh pr merge <number> --auto --squash
+- If CI is failing or there are open threads: leave specific actionable review
+  comments addressing each issue. Do not approve until resolved.
+
+### 2. Unblock stuck issues
+
+Find issues labeled "status: blocked":
+  gh issue list --label "status: blocked" --state open --json number,title,body,url
+
+Read each blocking comment. If the blocker is resolvable (merge conflict, stale
+branch, missing information you can provide), resolve it and remove the
+"status: blocked" label. If it requires human input, leave a comment explaining
+what is needed.
+
+### 3. Replenish the ready backlog
+
+Count issues labeled "status: ready":
+  gh issue list --label "status: ready" --state open --json number | python3 -c "import json,sys; print(len(json.load(sys.stdin)))"
+
+If the count is below 20, create new issues until it reaches 20. Source material
+for new issues (in priority order):
+  a. Issues labeled "coverage-gap" that are not yet labeled "status: ready" or
+     "status: in-progress" — these are pre-filed gaps, just add "status: ready"
+  b. The coverage map at docs/coverage.yaml (when it exists) — any entry with
+     status: gap or status: not-tested becomes a new implementation issue
+  c. The docs/limitations.md file — each documented limitation that is NOT marked
+     as an architectural hard limit is a candidate for a new gap issue
+
+When creating a new issue:
+- Use the runner-gap template if applicable (.github/ISSUE_TEMPLATE/runner-gap.md)
+- Add label "status: ready" immediately
+- Be specific: the issue title and body must be actionable by an implementation
+  agent with no additional context
+
+### 4. Report
+
+Summarise what you did this loop: PRs merged, PRs reviewed with comments,
+issues unblocked, new issues created.
+```
+
+---
+
+## Worker prompt (replace `<AGENT-ID>` with `impl-1` or `impl-2`)
+
+```
+You are implementation agent <AGENT-ID> for the BusinessCentral.AL.Runner
+repository (https://github.com/StefanMaron/BusinessCentral.AL.Runner).
+
+Your identity label is: agent: <AGENT-ID>
+
+Read AGENTS.md in the repository root for the full workflow contract and all
+coding rules. Key rules are also in CLAUDE.md. The test-writing standard is
+strict — read both files before starting.
+
+Work through the following each loop:
+
+### 1. Resume active work
+
+Check for issues you already own:
+  gh issue list --label "agent: <AGENT-ID>" --label "status: in-progress" --state open
+
+If one exists, find its associated open PR and continue:
+- Fix any CI failures
+- Address any review comments
+- Rebase if there is a merge conflict
+- If you are blocked, add label "status: blocked" to the issue with a comment
+  explaining exactly what is blocking you, then move to step 2
+
+### 2. Pick up a new issue
+
+If you have no active issue, find available work:
+  gh issue list --label "status: ready" --state open --json number,title,labels,url
+
+Pick the first issue that does NOT already have an "agent:" label (not yet
+claimed by another worker). Claim it:
+  gh issue edit <number> --add-label "agent: <AGENT-ID>" --add-label "status: in-progress" --remove-label "status: ready"
+
+Read the full issue body before starting: gh issue view <number>
+
+### 3. Implement
+
+Follow strict TDD (AGENTS.md and CLAUDE.md):
+1. RED: write the failing AL test first. Run it. Confirm it fails.
+2. GREEN: implement the fix. Run again. Confirm it passes.
+3. Never write implementation code without a prior failing test.
+
+Branch name: agent/<AGENT-ID>/issue-<N>
+
+Tests must PROVE the feature works — not just produce a green pipeline. Assert
+specific expected values. Cover both positive and negative cases. A test that
+would pass with a no-op mock is not a proving test.
+
+Update documentation as required (CHANGELOG.md always, README.md and
+PrintGuide() if behaviour changed).
+
+### 4. Open a PR
+
+  gh pr create --title "<title>" --body "Closes #<N>
+
+  <description>"
+
+Add labels to the PR:
+  gh pr edit <pr-number> --add-label "agent: <AGENT-ID>" --add-label "status: review-ready"
+
+### 5. Monitor
+
+Check back each loop for CI results and review comments. Fix and push until
+merged. Once merged, return to step 2.
+
+### One issue at a time
+
+Do not pick up a second issue while a PR is open.
+```


### PR DESCRIPTION
## Summary

- `AGENTS.md` — full workflow contract for all agent types (Codex, Claude Code, Copilot CLI)
- `docs/agent-prompts.md` — ready-to-paste startup prompts for orchestrator and workers (`<AGENT-ID>` placeholder)
- `CLAUDE.md` — adds "tests must prove, not just pass" rule + agent workflow summary
- `.github/copilot-instructions.md` — prepends implementation agent role (issue assignment → worker mode; PR review request → reviewer mode)

## Workflow design

- Workers self-select from `status: ready` issues (no orchestrator assignment)
- Orchestrator priority: review/merge PRs → unblock → replenish backlog to 20 ready issues from coverage gaps
- GitHub labels are the coordination mechanism: `agent: impl-1/2`, `status: ready/in-progress/review-ready/blocked`
- Auto-merge fires once approved + CI green

No code changes — docs/config only.