### PR TITLE
test: enum extension coverage (#227)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project are documented here. Format based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), versioning follows
 [SemVer](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **Enum extension test coverage (#227)** — new suite
+  `tests/bucket-1/36-enum-extension` confirms that `enumextension` objects
+  transpile and run correctly: base enum values retain their ordinals,
+  extension values resolve to their declared ordinals (100, 101), and
+  `Format()` / `AsInteger()` work against extension members. Coverage map
+  updated: `enumextension_declaration` moved from `gap` to `covered`.
+
 ## [1.0.15] - 2026-04-15
 
 ### Added

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -147,7 +147,9 @@ xmlport_declaration:
 enumextension_declaration:
   layer: syntax
   category: extension
-  status: gap
+  status: covered
+  tests:
+    - tests/bucket-1/36-enum-extension
 
 pagecustomization_declaration:
   layer: syntax

--- a/tests/bucket-1/36-enum-extension/al-runner.json
+++ b/tests/bucket-1/36-enum-extension/al-runner.json
@@ -1,0 +1,4 @@
+{
+  "sourcePath": "./src",
+  "testPath": "./test"
+}

--- a/tests/bucket-1/36-enum-extension/src/TicketHelper.al
+++ b/tests/bucket-1/36-enum-extension/src/TicketHelper.al
@@ -1,0 +1,30 @@
+codeunit 52820 "Ticket Helper"
+{
+    procedure GetPendingApproval(): Enum "Ticket Status"
+    begin
+        exit(Enum::"Ticket Status"::"Pending Approval");
+    end;
+
+    procedure GetRejected(): Enum "Ticket Status"
+    begin
+        exit(Enum::"Ticket Status"::Rejected);
+    end;
+
+    procedure GetOpen(): Enum "Ticket Status"
+    begin
+        exit(Enum::"Ticket Status"::Open);
+    end;
+
+    procedure FormatStatus(Status: Enum "Ticket Status"): Text
+    begin
+        exit(Format(Status));
+    end;
+
+    procedure PendingOrdinal(): Integer
+    var
+        Status: Enum "Ticket Status";
+    begin
+        Status := Status::"Pending Approval";
+        exit(Status.AsInteger());
+    end;
+}

--- a/tests/bucket-1/36-enum-extension/src/TicketStatusEnum.al
+++ b/tests/bucket-1/36-enum-extension/src/TicketStatusEnum.al
@@ -1,0 +1,13 @@
+enum 52820 "Ticket Status"
+{
+    Extensible = true;
+
+    value(0; "Open")
+    {
+        Caption = 'Open';
+    }
+    value(1; "Closed")
+    {
+        Caption = 'Closed';
+    }
+}

--- a/tests/bucket-1/36-enum-extension/src/TicketStatusExt.al
+++ b/tests/bucket-1/36-enum-extension/src/TicketStatusExt.al
@@ -1,0 +1,11 @@
+enumextension 52821 "Ticket Status Ext" extends "Ticket Status"
+{
+    value(100; "Pending Approval")
+    {
+        Caption = 'Pending Approval';
+    }
+    value(101; "Rejected")
+    {
+        Caption = 'Rejected';
+    }
+}

--- a/tests/bucket-1/36-enum-extension/test/EnumExtensionTest.al
+++ b/tests/bucket-1/36-enum-extension/test/EnumExtensionTest.al
@@ -1,0 +1,100 @@
+codeunit 52920 "Enum Extension Tests"
+{
+    Subtype = Test;
+
+    var
+        Helper: Codeunit "Ticket Helper";
+        Assert: Codeunit Assert;
+
+    [Test]
+    procedure TestBaseEnumValueStillAccessible()
+    var
+        Status: Enum "Ticket Status";
+    begin
+        // [GIVEN] The base enum defines Open = 0
+        // [WHEN] Reading the base value through the helper
+        Status := Helper.GetOpen();
+
+        // [THEN] The ordinal is 0 (base enum value preserved after extension)
+        Assert.AreEqual(0, Status.AsInteger(), 'Base enum value Open should have ordinal 0');
+    end;
+
+    [Test]
+    procedure TestExtensionValuePendingApprovalOrdinal()
+    var
+        Status: Enum "Ticket Status";
+    begin
+        // [GIVEN] The extension adds Pending Approval with ordinal 100
+        // [WHEN] Resolving the extension value
+        Status := Helper.GetPendingApproval();
+
+        // [THEN] Its ordinal is exactly 100 (proves extension ordinals, not base)
+        Assert.AreEqual(100, Status.AsInteger(), 'Pending Approval extension value should have ordinal 100');
+    end;
+
+    [Test]
+    procedure TestExtensionValueRejectedOrdinal()
+    var
+        Status: Enum "Ticket Status";
+    begin
+        Status := Helper.GetRejected();
+
+        Assert.AreEqual(101, Status.AsInteger(), 'Rejected extension value should have ordinal 101');
+    end;
+
+    [Test]
+    procedure TestExtensionValueNotEqualBaseValue()
+    var
+        Pending: Enum "Ticket Status";
+        Open: Enum "Ticket Status";
+    begin
+        // [GIVEN] A base value and an extension value
+        Open := Helper.GetOpen();
+        Pending := Helper.GetPendingApproval();
+
+        // [THEN] They are distinct (negative-style assertion — catches a mock that collapses everything to 0)
+        Assert.AreNotEqual(Open.AsInteger(), Pending.AsInteger(), 'Extension value must not equal base value');
+    end;
+
+    [Test]
+    procedure TestPendingOrdinalHelper()
+    begin
+        // [WHEN] The helper assigns Status::"Pending Approval" locally
+        // [THEN] The ordinal is 100 — proves the extension member is resolvable at the call site too
+        Assert.AreEqual(100, Helper.PendingOrdinal(), 'Local assignment to extension value should yield ordinal 100');
+    end;
+
+    [Test]
+    procedure TestFormatExtensionValue()
+    var
+        Formatted: Text;
+    begin
+        // [WHEN] Formatting the Pending Approval extension value
+        Formatted := Helper.FormatStatus(Helper.GetPendingApproval());
+
+        // [THEN] The formatted text includes the extension value name (not just base names)
+        Assert.IsTrue(
+            (Formatted = 'Pending Approval') or (Formatted = '100'),
+            'Format of extension value should be the name or ordinal, got: ' + Formatted);
+    end;
+
+    [Test]
+    procedure TestExtensionAndBaseDistinctOrdinals()
+    var
+        OpenStatus: Enum "Ticket Status";
+        ClosedStatus: Enum "Ticket Status";
+        Pending: Enum "Ticket Status";
+        Rejected: Enum "Ticket Status";
+    begin
+        OpenStatus := OpenStatus::Open;
+        ClosedStatus := ClosedStatus::Closed;
+        Pending := Pending::"Pending Approval";
+        Rejected := Rejected::Rejected;
+
+        // [THEN] All four ordinals are distinct and match their declared values
+        Assert.AreEqual(0, OpenStatus.AsInteger(), 'Open should be 0');
+        Assert.AreEqual(1, ClosedStatus.AsInteger(), 'Closed should be 1');
+        Assert.AreEqual(100, Pending.AsInteger(), 'Pending Approval should be 100');
+        Assert.AreEqual(101, Rejected.AsInteger(), 'Rejected should be 101');
+    end;
+}


### PR DESCRIPTION
Closes #227

## Summary
- Adds `tests/bucket-1/36-enum-extension` — 7 test cases proving `enumextension` works end-to-end through BC transpile + Roslyn rewrite + in-memory compile.
- Moves `enumextension_declaration` from `gap` to `covered` in `docs/coverage.yaml`.
- No runner code changes: the BC transpiler already handles enum extensions. The issue's acceptance path explicitly allowed this ("If it does, this just needs test coverage to confirm.").

## Proving tests (not just green)
Each test asserts a specific ordinal, not merely the absence of errors:
- base value `Open` → ordinal **0** (base retained after extension)
- `Pending Approval` → ordinal **100** (not a default 0)
- `Rejected` → ordinal **101**
- extension value ≠ base value (would fail against a no-op mock collapsing enums)
- `Format()` returns the extension value name or its ordinal
- local variable assignment to extension member resolves correctly

## TDD note
Strict RED/GREEN did not apply here: the BC compiler already supports `enumextension`, so the first run of the new suite was green. The tests still fail convincingly against a broken implementation — see the distinct-ordinal and `AreNotEqual` assertions.

## Test plan
- [x] `dotnet run --no-build --project AlRunner --framework net10.0 -- tests/bucket-1/36-enum-extension/src tests/bucket-1/36-enum-extension/test` → 7/7 PASS
- [x] Full bucket-1 regression: no new failures (2 pre-existing failures in `17-text-builder` unrelated to this change — confirmed on `main`)