### PR TITLE
feat: Record.FieldError — raise field-level validation error

### DIFF
--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -252,6 +252,8 @@ test executor that needs no BC service tier, Docker, SQL Server, or license.
   separate from non-temporary records. `IsTemporary()` returns the correct value.
   `RecordRef.Open(tableId, true)` opens a temporary RecordRef.
 - TransferFields, CountApprox, Consistent (no-op), FieldActive (true), AddLink/HasLinks/DeleteLinks
+- FieldError(Field) / FieldError(Field, Text) — raise a field-level error message
+  formatted as "<FieldCaption> <Message> in <TableCaption>: <PK>", catchable via asserterror
 - WritePermission/ReadPermission (true), SetPermissionFilter (no-op), LockTable (no-op)
 - Composite primary keys, sort ordering (SetCurrentKey / SetAscending), CurrentKey, Ascending
 - SETRANGE / SETFILTER filtering (=, <>, <, <=, >, >=, wildcards, OR via |)

--- a/AlRunner/Runtime/MockRecordHandle.cs
+++ b/AlRunner/Runtime/MockRecordHandle.cs
@@ -1093,6 +1093,37 @@ public class MockRecordHandle
     }
 
     // -----------------------------------------------------------------------
+    // FieldError — raise a field-level validation error
+    // -----------------------------------------------------------------------
+
+    /// <summary>AL's FIELDERROR(FieldNo) — raises the default "must have a value" error.</summary>
+    public void ALFieldError(int fieldNo)
+    {
+        throw new Exception(FormatFieldError(fieldNo, "must have a value"));
+    }
+
+    /// <summary>AL's FIELDERROR(FieldNo, Text) — raises "&lt;field&gt; &lt;text&gt; in &lt;table&gt;: &lt;pk&gt;".</summary>
+    public void ALFieldError(int fieldNo, string message)
+    {
+        throw new Exception(FormatFieldError(fieldNo, message));
+    }
+
+    private string FormatFieldError(int fieldNo, string message)
+    {
+        string fieldName = TableFieldRegistry.GetFieldCaption(_tableId, fieldNo)
+                           ?? TableFieldRegistry.GetFieldName(_tableId, fieldNo)
+                           ?? $"Field {fieldNo}";
+        string tableName = TableFieldRegistry.GetTableCaption(_tableId)
+                           ?? TableFieldRegistry.GetTableName(_tableId)
+                           ?? $"Table {_tableId}";
+        var pkFields = GetPrimaryKeyFields();
+        var pk = string.Join(",", pkFields.Select(f =>
+            $"{TableFieldRegistry.GetFieldName(_tableId, f) ?? ("Field " + f)}='" +
+            (_fields.TryGetValue(f, out var v) ? NavValueToString(v) : "") + "'"));
+        return $"{fieldName} {message} in {tableName}: {pk}";
+    }
+
+    // -----------------------------------------------------------------------
     // CalcFields / CalcSums — stubs (no SQL aggregation available)
     // -----------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes to this project are documented here. Format based on
 ## [Unreleased]
 
 ### Added
+- **`Record.FieldError` (#228)** — raises a field-level validation error
+  (`"<FieldCaption> <Message> in <TableCaption>: <PK>"`). Supports both
+  `FieldError(Field)` (default `"must have a value"` message) and
+  `FieldError(Field, Text)`. Errors are catchable via `asserterror`.
 - **Enum extension test coverage (#227)** — new suite
   `tests/bucket-1/36-enum-extension` confirms that `enumextension` objects
   transpile and run correctly: base enum values retain their ordinals,

--- a/tests/bucket-1/228-field-error/src/FieldErrorTable.al
+++ b/tests/bucket-1/228-field-error/src/FieldErrorTable.al
@@ -1,0 +1,36 @@
+table 60100 FieldErrorTable
+{
+    DataClassification = SystemMetadata;
+
+    fields
+    {
+        field(1; "Code"; Code[10])
+        {
+        }
+        field(2; "Name"; Text[100])
+        {
+            Caption = 'Name';
+        }
+    }
+
+    keys
+    {
+        key(PK; "Code")
+        {
+            Clustered = true;
+        }
+    }
+}
+
+codeunit 60100 FieldErrorHelper
+{
+    procedure RaiseFieldErrorNoMessage(var Rec: Record FieldErrorTable)
+    begin
+        Rec.FieldError("Name");
+    end;
+
+    procedure RaiseFieldErrorWithMessage(var Rec: Record FieldErrorTable)
+    begin
+        Rec.FieldError("Name", 'must not be empty');
+    end;
+}

--- a/tests/bucket-1/228-field-error/test/FieldErrorTest.al
+++ b/tests/bucket-1/228-field-error/test/FieldErrorTest.al
@@ -1,0 +1,59 @@
+codeunit 60101 FieldErrorTest
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    [Test]
+    procedure FieldError_WithMessage_RaisesError()
+    var
+        Rec: Record FieldErrorTable;
+        Helper: Codeunit FieldErrorHelper;
+    begin
+        // [GIVEN] A record with a populated key
+        Rec.Init();
+        Rec.Code := 'TEST';
+        Rec.Insert(false);
+
+        // [WHEN] FieldError is called with a custom message
+        asserterror Helper.RaiseFieldErrorWithMessage(Rec);
+
+        // [THEN] The error text contains the field caption and the custom message
+        Assert.ExpectedError('must not be empty');
+    end;
+
+    [Test]
+    procedure FieldError_NoMessage_RaisesError()
+    var
+        Rec: Record FieldErrorTable;
+        Helper: Codeunit FieldErrorHelper;
+    begin
+        // [GIVEN] A record with a populated key
+        Rec.Init();
+        Rec.Code := 'TEST2';
+        Rec.Insert(false);
+
+        // [WHEN] FieldError is called without a message
+        asserterror Helper.RaiseFieldErrorNoMessage(Rec);
+
+        // [THEN] The error text references the field name
+        Assert.ExpectedError('Name');
+    end;
+
+    [Test]
+    procedure FieldError_NoErrorRaised_AssertFails()
+    var
+        Rec: Record FieldErrorTable;
+    begin
+        // [GIVEN] A record with a populated key
+        Rec.Init();
+        Rec.Code := 'OK';
+        Rec."Name" := 'Something';
+        Rec.Insert(false);
+
+        // [WHEN] No FieldError call is made
+        // [THEN] ExpectedError should fail since no error occurred
+        asserterror Assert.ExpectedError('must not be empty');
+    end;
+}


### PR DESCRIPTION
Closes #228

## Summary
- Implements `Record.FieldError(Field)` and `Record.FieldError(Field, Text)` via two new `ALFieldError` overloads on `MockRecordHandle`.
- Error text format: `"<FieldCaption> <Message> in <TableCaption>: <PK>"`. The no-message overload uses BC's default `"must have a value"`.
- Errors are catchable with `asserterror` / verifiable with `Assert.ExpectedError`.

## Test plan
- [x] New suite `tests/bucket-1/228-field-error` with:
  - `FieldError_WithMessage_RaisesError` — positive, asserts custom message substring
  - `FieldError_NoMessage_RaisesError` — positive, asserts field name substring
  - `FieldError_NoErrorRaised_AssertFails` — negative, `ExpectedError` fails when no error occurred
- [x] RED confirmed before implementation (`MockRecordHandle does not contain a definition for 'ALFieldError'`); GREEN after
- [x] Full bucket-1 regression: 187 passed, 2 pre-existing unrelated failures (TextBuilder: `TestBuildGreeting`, `TestBuildList` — same on `main`)
- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] `PrintGuide()` updated with the new capability

🤖 Generated with [Claude Code](https://claude.com/claude-code)