### PR TITLE
feat: Format() multi-token decimal picture strings (#225)

### DIFF
--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -326,6 +326,7 @@ test executor that needs no BC service tier, Docker, SQL Server, or license.
 - Format() / Evaluate() type conversions, including picture strings:
   - Date tokens: `<Year4>`, `<Month,2>`, `<Day,2>`, `<Hours24,2>`, `<Minutes,2>`, `<Seconds,2>`
   - Decimal tokens: `<Precision,min:max>` (round/pad decimals), `<Standard Format,N>` (N=0 default, N=1 integer)
+  - Multi-token decimal picture strings (e.g. `<Precision,2:2><Standard Format,0>`) — Precision wins when both are present
   - Time picture strings applied to Time variables (e.g. `Format(T, 0, '<Hours24,2>:<Minutes,2>')`)
 - Session API: StartSession (dispatches codeunit synchronously, returns true), StopSession (no-op),
   IsSessionActive (returns false), Sleep (no-op)

--- a/AlRunner/Runtime/AlScope.cs
+++ b/AlRunner/Runtime/AlScope.cs
@@ -1015,60 +1015,68 @@ public static class AlCompat
     /// </summary>
     private static string? ApplyDecimalFormatString(decimal value, string formatString)
     {
-        // Strip outer whitespace and angle-brackets to get the token content
         var fs = formatString.Trim();
-        if (!fs.StartsWith('<') || !fs.EndsWith('>'))
+        if (!fs.Contains('<') || !fs.Contains('>'))
             return null;
-        // Only handle single-token picture strings for now
-        // (multi-token strings like '<Precision,1:2><some other>' are not standard for decimals)
-        var token = fs.Substring(1, fs.Length - 2).Trim();
 
-        // <Precision,min:max>
-        if (token.StartsWith("Precision,", StringComparison.OrdinalIgnoreCase))
+        // Extract each <...> token. For decimals, multi-token strings like
+        // '<Precision,2:2><Standard Format,0>' are valid — Precision takes precedence,
+        // otherwise Standard Format applies.
+        string? precisionToken = null;
+        string? standardFormatToken = null;
+        int i = 0;
+        while (i < fs.Length)
         {
-            var rest = token.Substring("Precision,".Length);
+            int start = fs.IndexOf('<', i);
+            if (start < 0) break;
+            int end = fs.IndexOf('>', start);
+            if (end < 0) break;
+            var token = fs.Substring(start + 1, end - start - 1).Trim();
+            if (precisionToken == null && token.StartsWith("Precision,", StringComparison.OrdinalIgnoreCase))
+                precisionToken = token;
+            else if (standardFormatToken == null && token.StartsWith("Standard Format,", StringComparison.OrdinalIgnoreCase))
+                standardFormatToken = token;
+            i = end + 1;
+        }
+
+        if (precisionToken != null)
+        {
+            var rest = precisionToken.Substring("Precision,".Length);
             var colonPos = rest.IndexOf(':');
-            if (colonPos >= 0)
+            if (colonPos >= 0 &&
+                int.TryParse(rest.Substring(0, colonPos).Trim(), out int minDec) &&
+                int.TryParse(rest.Substring(colonPos + 1).Trim(), out int maxDec))
             {
-                if (int.TryParse(rest.Substring(0, colonPos).Trim(), out int minDec) &&
-                    int.TryParse(rest.Substring(colonPos + 1).Trim(), out int maxDec))
+                var rounded = Math.Round(value, maxDec, MidpointRounding.AwayFromZero);
+                if (maxDec <= 0)
+                    return rounded.ToString("0", System.Globalization.CultureInfo.InvariantCulture);
+                var fullFmt = "0." + new string('0', maxDec);
+                var full = rounded.ToString(fullFmt, System.Globalization.CultureInfo.InvariantCulture);
+                if (full.Contains('.'))
                 {
-                    // Round to maxDec decimal places
-                    var rounded = Math.Round(value, maxDec, MidpointRounding.AwayFromZero);
-                    if (maxDec <= 0)
-                        return rounded.ToString("0", System.Globalization.CultureInfo.InvariantCulture);
-                    // Format to maxDec places (fixed), then strip trailing zeros down to minDec
-                    var fullFmt = "0." + new string('0', maxDec);
-                    var full = rounded.ToString(fullFmt, System.Globalization.CultureInfo.InvariantCulture);
-                    // Strip trailing zeros but keep at least minDec decimal digits
-                    if (full.Contains('.'))
-                    {
-                        int dotPos = full.IndexOf('.');
-                        int end = full.Length;
-                        int minEnd = dotPos + 1 + minDec;
-                        while (end > minEnd && full[end - 1] == '0')
-                            end--;
-                        // If minDec == 0 and result ends with '.', remove the dot
-                        if (end == dotPos + 1 && minDec == 0)
-                            end = dotPos;
-                        full = full.Substring(0, end);
-                    }
-                    return full;
+                    int dotPos = full.IndexOf('.');
+                    int endPos = full.Length;
+                    int minEnd = dotPos + 1 + minDec;
+                    while (endPos > minEnd && full[endPos - 1] == '0')
+                        endPos--;
+                    if (endPos == dotPos + 1 && minDec == 0)
+                        endPos = dotPos;
+                    full = full.Substring(0, endPos);
                 }
+                return full;
             }
         }
 
-        // <Standard Format,N>
-        if (token.StartsWith("Standard Format,", StringComparison.OrdinalIgnoreCase))
+        if (standardFormatToken != null)
         {
-            var rest = token.Substring("Standard Format,".Length).Trim();
+            var rest = standardFormatToken.Substring("Standard Format,".Length).Trim();
             if (int.TryParse(rest, out int formatNo))
             {
                 return formatNo switch
                 {
                     1 => Math.Round(value, 0, MidpointRounding.AwayFromZero)
                              .ToString("0", System.Globalization.CultureInfo.InvariantCulture),
-                    _ => FormatDecimal(value), // Format 0 and unknown: default AL decimal formatting
+                    _ => FormatDecimal(value),
                 };
             }
         }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to this project are documented here. Format based on
 ## [Unreleased]
 
 ### Added
+- **Multi-token decimal format strings (#225)** — `Format(decimal, 0, '<Precision,2:2><Standard Format,0>')`
+  now parses every `<...>` token in the picture string instead of only the
+  first. For decimals, `<Precision,min:max>` wins over `<Standard Format,N>`
+  when both are present. Single-token strings are unchanged. New suite
+  `tests/bucket-1/225-format-multi-token` covers integer, fractional, and
+  rounding cases.
 - **`Record.FieldError` (#228)** — raises a field-level validation error
   (`"<FieldCaption> <Message> in <TableCaption>: <PK>"`). Supports both
   `FieldError(Field)` (default `"must have a value"` message) and

--- a/tests/bucket-1/225-format-multi-token/src/MultiFormatHelper.al
+++ b/tests/bucket-1/225-format-multi-token/src/MultiFormatHelper.al
@@ -1,0 +1,23 @@
+codeunit 50225 "Multi Format Helper"
+{
+    procedure FormatPrecisionStd(Value: Decimal): Text
+    begin
+        exit(Format(Value, 0, '<Precision,2:2><Standard Format,0>'));
+    end;
+
+    procedure FormatDatePrecision(MyDate: Date; MyDec: Decimal): Text
+    begin
+        exit(Format(MyDate, 0, '<Year4>-<Month,2>-<Day,2>') + ' ' + Format(MyDec, 0, '<Precision,2:2><Standard Format,0>'));
+    end;
+
+    procedure FormatPrecisionOnly(Value: Decimal): Text
+    begin
+        exit(Format(Value, 0, '<Precision,2:2>'));
+    end;
+
+    procedure FormatUnknownToken(Value: Decimal): Text
+    begin
+        // Unknown/unsupported token — runner must not silently replace with ''
+        exit(Format(Value, 0, '<NotARealToken>'));
+    end;
+}

--- a/tests/bucket-1/225-format-multi-token/test/MultiFormatTest.al
+++ b/tests/bucket-1/225-format-multi-token/test/MultiFormatTest.al
@@ -1,0 +1,52 @@
+codeunit 50226 "Multi Format Tests"
+{
+    Subtype = Test;
+
+    var
+        Helper: Codeunit "Multi Format Helper";
+        Assert: Codeunit Assert;
+
+    [Test]
+    procedure MultiToken_PrecisionStandard_Integer()
+    begin
+        // <Precision,2:2><Standard Format,0> should force 2 decimals (Precision wins for decimals)
+        Assert.AreEqual('1234.00', Helper.FormatPrecisionStd(1234), 'Integer value 1234 with <Precision,2:2><Standard Format,0> must show 2 decimals');
+    end;
+
+    [Test]
+    procedure MultiToken_PrecisionStandard_Fractional()
+    begin
+        Assert.AreEqual('1.50', Helper.FormatPrecisionStd(1.5), 'Value 1.5 with <Precision,2:2><Standard Format,0> must show 1.50');
+    end;
+
+    [Test]
+    procedure MultiToken_PrecisionStandard_TruncatesExtraDecimals()
+    begin
+        // 1.567 rounded to 2 decimals = 1.57
+        Assert.AreEqual('1.57', Helper.FormatPrecisionStd(1.567), 'Value 1.567 with <Precision,2:2><Standard Format,0> must round to 1.57');
+    end;
+
+    [Test]
+    procedure MixedDateAndDecimal_InSeparateCalls()
+    var
+        ResultText: Text;
+    begin
+        ResultText := Helper.FormatDatePrecision(20260101D, 1234.56);
+        Assert.AreEqual('2026-01-01 1234.56', ResultText, 'Date and decimal formatting must compose correctly');
+    end;
+
+    [Test]
+    procedure SingleToken_Precision_StillWorks()
+    begin
+        // Regression: single-token precision still works after multi-token support added
+        Assert.AreEqual('1234.00', Helper.FormatPrecisionOnly(1234), 'Single-token <Precision,2:2> must still produce 2 decimals');
+    end;
+
+    [Test]
+    procedure UnknownToken_PreservedLiterally()
+    begin
+        // Negative: when the format string has no recognised tokens, runner falls back to default formatting
+        // (matches current behavior for unsupported picture strings — value formatted without picture)
+        Assert.AreEqual('5', Helper.FormatUnknownToken(5), 'Unknown token falls back to default numeric formatting');
+    end;
+}


### PR DESCRIPTION
Closes #225

## Summary
- `Format(decimal, 0, '<Precision,2:2><Standard Format,0>')` now honours multi-token picture strings instead of returning the default formatting.
- `ApplyDecimalFormatString` scans every `<...>` token; `<Precision,min:max>` wins over `<Standard Format,N>` when both are present.
- Single-token behaviour unchanged.

## Test plan
- [x] New suite `tests/bucket-1/225-format-multi-token` — 6 tests, RED confirmed before fix, GREEN after.
- [x] Covers integer (`1234` → `1234.00`), fractional (`1.5` → `1.50`), rounding (`1.567` → `1.57`) and single-token regression.
- [x] Existing `tests/bucket-2/85-picture-format` and `tests/bucket-1/12-format-string` still pass.
- [x] Full bucket-1 regression: 200 passed (2 pre-existing failures in 17-text-builder unrelated to this change).

## Docs
- CHANGELOG `[Unreleased]` entry added.
- `--guide` output updated under Format() picture strings.