### PR TITLE
feat: Record Mark / MarkedOnly / ClearMarks

### DIFF
--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -258,6 +258,9 @@ test executor that needs no BC service tier, Docker, SQL Server, or license.
 - Composite primary keys, sort ordering (SetCurrentKey / SetAscending), CurrentKey, Ascending
 - SETRANGE / SETFILTER filtering (=, <>, <, <=, >, >=, wildcards, OR via |)
 - GetFilter(field), GetFilters, HasFilter — return active filter expressions
+- Record marking: `Rec.Mark(true/false)`, `Rec.Mark()` getter, `Rec.MarkedOnly(true)`,
+  `Rec.ClearMarks()`. Marks are per record-variable; MarkedOnly gates FindSet/FindFirst/
+  FindLast/Next/Count/IsEmpty to the marked subset.
 - FlowField CalcFormula — CalcFields evaluates exist(), count(), sum(), and lookup() formulas
   against the in-memory table store. Where-clause conditions support field() and const() references.
 - Cross-codeunit dispatch (Codeunit.Run, Codeunit.Run(id, Rec) with record parameter, direct codeunit variable calls)

--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -89,7 +89,7 @@ public class RoslynRewriter : CSharpSyntaxRewriter
         "ALLockTable", "ALCalcSums", "ALSetLoadFields", "ALFieldCaption", "ALSetRecFilter",
         "ALTableCaption", "ALTableName", "ALTestFieldNavValueSafe",
         "ALFilterGroup", "ALSetRangeSafe", "ALReadIsolation",
-        "ALTransferFields", "ALMark", "ALMarkedOnly",
+        "ALTransferFields", "ALMark", "ALMarkedOnly", "ALClearMarks",
         "ALGetFilters", "ALGetRangeMinSafe", "ALGetRangeMaxSafe",
         "ALHasFilter", "ALCurrentKey", "ALAscending", "ALCountApprox",
         "ALConsistent", "ALFieldActive", "ALAddLink", "ALDeleteLink", "ALDeleteLinks",
@@ -561,7 +561,9 @@ public int ALFilterGroup { get => Rec.ALFilterGroup; set => Rec.ALFilterGroup = 
 public object ALReadIsolation { get => Rec.ALReadIsolation; set => Rec.ALReadIsolation = value; }
 public void Clear() => Rec.Clear();
 public void ALTransferFields(MockRecordHandle source, bool initPrimaryKey = true) => Rec.ALTransferFields(source, initPrimaryKey);
-public void ALMark(bool mark = true) => Rec.ALMark(mark);
+public void ALMark(bool mark) => Rec.ALMark(mark);
+public bool ALMark() => Rec.ALMark();
+public void ALClearMarks() => Rec.ALClearMarks();
 public bool ALMarkedOnly { get => Rec.ALMarkedOnly; set => Rec.ALMarkedOnly = value; }
 public int CurrFieldNo { get; set; }
 public string ALGetFilters => Rec.ALGetFilters;

--- a/AlRunner/Runtime/MockRecordHandle.cs
+++ b/AlRunner/Runtime/MockRecordHandle.cs
@@ -599,7 +599,7 @@ public class MockRecordHandle
 
     public bool ALFind(DataError errorLevel, string searchMethod = "-")
     {
-        var filtered = GetFilteredRecords();
+        var filtered = GetFilteredAndMarkedRecords();
         if (filtered.Count == 0)
         {
             _currentResultSet = filtered;
@@ -636,7 +636,7 @@ public class MockRecordHandle
 
     public bool ALFindLast(DataError errorLevel = DataError.ThrowError)
     {
-        var filtered = GetFilteredRecords();
+        var filtered = GetFilteredAndMarkedRecords();
         if (filtered.Count == 0)
         {
             _currentResultSet = filtered;
@@ -869,9 +869,9 @@ public class MockRecordHandle
     // Count / IsEmpty — respect active filters
     // -----------------------------------------------------------------------
 
-    public int ALCount => GetFilteredRecords().Count;
+    public int ALCount => GetFilteredAndMarkedRecords().Count;
 
-    public bool ALIsEmpty => GetFilteredRecords().Count == 0;
+    public bool ALIsEmpty => GetFilteredAndMarkedRecords().Count == 0;
 
     /// <summary>
     /// Number of fields that have been set on this record handle.
@@ -2099,24 +2099,59 @@ public class MockRecordHandle
         }
     }
 
-    /// <summary>
-    /// AL's MARK — marks or unmarks the current record.
-    /// In standalone mode, no-op (marking is used for filtered iteration).
-    /// </summary>
-    public void ALMark(bool mark = true)
+    // -- Mark / MarkedOnly / ClearMarks --
+    // Marks are per record-variable (per handle instance). Keyed by PK string.
+    private readonly HashSet<string> _markedRecords = new();
+    private bool _markedOnly;
+
+    /// <summary>AL Mark() — returns whether the current record is marked.</summary>
+    public bool ALMark() => _markedRecords.Contains(GetCurrentPkKey());
+
+    /// <summary>AL Mark(bool) — marks or unmarks the current record.</summary>
+    public void ALMark(bool mark)
     {
-        // No-op: record marking not implemented in standalone mode
+        var key = GetCurrentPkKey();
+        if (mark) _markedRecords.Add(key);
+        else _markedRecords.Remove(key);
     }
 
     /// <summary>
-    /// AL's MARKEDONLY — sets/gets whether to only iterate over marked records.
-    /// Exposed as both a property (for assignment: rec.ALMarkedOnly = true) and a method.
-    /// In standalone mode, no-op.
+    /// AL MarkedOnly — when true, iteration (FindSet/Next/Count) returns only marked records.
+    /// Exposed as a property; AL's MarkedOnly(true) setter syntax and MarkedOnly() getter syntax
+    /// are both routed through the BC compiler to the same underlying property.
     /// </summary>
     public bool ALMarkedOnly
     {
-        get => false;
-        set { /* No-op: record marking not implemented in standalone mode */ }
+        get => _markedOnly;
+        set => _markedOnly = value;
+    }
+
+    /// <summary>AL ClearMarks — removes all marks on this record variable.</summary>
+    public void ALClearMarks() => _markedRecords.Clear();
+
+    private string GetCurrentPkKey()
+    {
+        var pk = GetPrimaryKeyFields();
+        var parts = new List<string>(pk.Length);
+        foreach (var f in pk)
+            parts.Add(_fields.TryGetValue(f, out var v) ? NavValueToString(v) : "");
+        return string.Join("|", parts);
+    }
+
+    private string GetRowPkKey(Dictionary<int, NavValue> row)
+    {
+        var pk = GetPrimaryKeyFields();
+        var parts = new List<string>(pk.Length);
+        foreach (var f in pk)
+            parts.Add(row.TryGetValue(f, out var v) ? NavValueToString(v) : "");
+        return string.Join("|", parts);
+    }
+
+    private List<Dictionary<int, NavValue>> GetFilteredAndMarkedRecords()
+    {
+        var rows = GetFilteredRecords();
+        if (!_markedOnly) return rows;
+        return rows.Where(r => _markedRecords.Contains(GetRowPkKey(r))).ToList();
     }
 
     /// <summary>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ All notable changes to this project are documented here. Format based on
   (`"<FieldCaption> <Message> in <TableCaption>: <PK>"`). Supports both
   `FieldError(Field)` (default `"must have a value"` message) and
   `FieldError(Field, Text)`. Errors are catchable via `asserterror`.
+- **Record.Mark / Record.MarkedOnly / Record.ClearMarks (#226)** — the
+  record-variable marking surface is now functional (previously no-ops).
+  `Mark(true/false)` flips the mark for the current record, `Mark()` returns
+  the current state, `MarkedOnly(true)` filters subsequent `FindSet` /
+  `FindFirst` / `FindLast` / `Next` / `Count` / `IsEmpty` iteration to the
+  marked subset, and `ClearMarks()` wipes all marks. Marks are per
+  record-variable instance, keyed on primary key values. New suite
+  `tests/bucket-1/37-record-mark` exercises positive (marked subset),
+  negative (MarkedOnly off), and reset (ClearMarks) paths.
 - **Enum extension test coverage (#227)** — new suite
   `tests/bucket-1/36-enum-extension` confirms that `enumextension` objects
   transpile and run correctly: base enum values retain their ordinals,

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -5616,7 +5616,9 @@ Table.ChangeCompany:
 Table.ClearMarks:
   layer: runtime-api
   category: Table
-  status: gap
+  status: covered
+  tests:
+    - tests/bucket-1/37-record-mark
   notes: overloads=1
 
 Table.Consistent:
@@ -5862,13 +5864,17 @@ Table.LockTable:
 Table.Mark:
   layer: runtime-api
   category: Table
-  status: gap
+  status: covered
+  tests:
+    - tests/bucket-1/37-record-mark
   notes: overloads=1
 
 Table.MarkedOnly:
   layer: runtime-api
   category: Table
-  status: gap
+  status: covered
+  tests:
+    - tests/bucket-1/37-record-mark
   notes: overloads=1
 
 Table.Modify:

--- a/tests/bucket-1/37-record-mark/src/RecordMarkTable.al
+++ b/tests/bucket-1/37-record-mark/src/RecordMarkTable.al
@@ -1,0 +1,25 @@
+table 54000 "Record Mark Table"
+{
+    DataClassification = CustomerContent;
+
+    fields
+    {
+        field(1; "No."; Code[20])
+        {
+        }
+        field(2; "Name"; Text[50])
+        {
+        }
+        field(3; "Amount"; Decimal)
+        {
+        }
+    }
+
+    keys
+    {
+        key(PK; "No.")
+        {
+            Clustered = true;
+        }
+    }
+}

--- a/tests/bucket-1/37-record-mark/test/TestRecordMark.al
+++ b/tests/bucket-1/37-record-mark/test/TestRecordMark.al
@@ -1,0 +1,113 @@
+codeunit 54000 "Test Record Mark"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    [Test]
+    procedure MarkedOnlyReturnsOnlyMarkedRecords()
+    var
+        Rec: Record "Record Mark Table";
+        Count: Integer;
+    begin
+        // Positive: marking a subset and enabling MarkedOnly returns only marked rows.
+        InsertRow('A', 'Alpha', 10);
+        InsertRow('B', 'Beta', 20);
+        InsertRow('C', 'Gamma', 30);
+        InsertRow('D', 'Delta', 40);
+
+        Rec.FindSet();
+        repeat
+            if (Rec."No." = 'A') or (Rec."No." = 'C') then
+                Rec.Mark(true);
+        until Rec.Next() = 0;
+
+        Rec.MarkedOnly(true);
+        Count := 0;
+        if Rec.FindSet() then
+            repeat
+                Count += 1;
+                Assert.IsTrue((Rec."No." = 'A') or (Rec."No." = 'C'),
+                    'Only marked records A and C should be returned, got ' + Rec."No.");
+            until Rec.Next() = 0;
+        Assert.AreEqual(2, Count, 'MarkedOnly iteration should yield exactly 2 records');
+    end;
+
+    [Test]
+    procedure MarkGetterReturnsCurrentState()
+    var
+        Rec: Record "Record Mark Table";
+    begin
+        // Positive: Mark() returns true after Mark(true), false after Mark(false).
+        InsertRow('X', 'xray', 1);
+        Rec.Get('X');
+
+        Assert.IsFalse(Rec.Mark(), 'Mark() should be false before marking');
+        Rec.Mark(true);
+        Assert.IsTrue(Rec.Mark(), 'Mark() should be true after Mark(true)');
+        Rec.Mark(false);
+        Assert.IsFalse(Rec.Mark(), 'Mark() should be false after Mark(false)');
+    end;
+
+    [Test]
+    procedure ClearMarksRemovesAllMarks()
+    var
+        Rec: Record "Record Mark Table";
+        Count: Integer;
+    begin
+        // Positive: ClearMarks wipes all marks; MarkedOnly iteration then finds nothing.
+        InsertRow('P', 'P', 1);
+        InsertRow('Q', 'Q', 2);
+        InsertRow('R', 'R', 3);
+
+        Rec.FindSet();
+        repeat
+            Rec.Mark(true);
+        until Rec.Next() = 0;
+
+        Rec.ClearMarks();
+        Rec.MarkedOnly(true);
+
+        Count := 0;
+        if Rec.FindSet() then
+            repeat
+                Count += 1;
+            until Rec.Next() = 0;
+        Assert.AreEqual(0, Count, 'No records should be returned after ClearMarks');
+    end;
+
+    [Test]
+    procedure MarkedOnlyOffReturnsAllRecords()
+    var
+        Rec: Record "Record Mark Table";
+        Count: Integer;
+    begin
+        // Negative/off-switch: MarkedOnly(false) after marking still returns every record.
+        InsertRow('1', 'One', 1);
+        InsertRow('2', 'Two', 2);
+        InsertRow('3', 'Three', 3);
+
+        Rec.Get('1');
+        Rec.Mark(true);
+
+        Rec.MarkedOnly(false);
+        Count := 0;
+        if Rec.FindSet() then
+            repeat
+                Count += 1;
+            until Rec.Next() = 0;
+        Assert.AreEqual(3, Count, 'MarkedOnly(false) should return all records');
+    end;
+
+    local procedure InsertRow("No.": Code[20]; Name: Text[50]; Amount: Decimal)
+    var
+        Rec: Record "Record Mark Table";
+    begin
+        Rec.Init();
+        Rec."No." := "No.";
+        Rec.Name := Name;
+        Rec.Amount := Amount;
+        Rec.Insert(true);
+    end;
+}


### PR DESCRIPTION
Closes #226

## Summary
- Promotes `Record.Mark(true/false)`, `Record.Mark()`, `Record.MarkedOnly(true/false)`, and `Record.ClearMarks()` on `MockRecordHandle` from no-ops to functional implementations.
- Marks are stored per record-variable instance, keyed on primary key values.
- `MarkedOnly = true` now filters `FindSet` / `FindFirst` / `FindLast` / `Next` / `Count` / `IsEmpty` to the marked subset.
- `RoslynRewriter` gains the parameterless `ALMark()` getter and `ALClearMarks()` delegation on `RecordBase`, and whitelists `ALClearMarks` in the record-target method set.

## Test plan
- New suite `tests/bucket-1/37-record-mark` with four proving tests:
  - `MarkedOnlyReturnsOnlyMarkedRecords` — marks A + C, MarkedOnly iterator returns exactly those
  - `MarkGetterReturnsCurrentState` — `Mark()` returns true after `Mark(true)`, false after `Mark(false)`
  - `ClearMarksRemovesAllMarks` — after `ClearMarks()`, MarkedOnly iterator yields zero rows
  - `MarkedOnlyOffReturnsAllRecords` — `MarkedOnly(false)` after marking still returns every record
- RED confirmed before implementation; GREEN after.
- Bucket-1 + bucket-2 (excl. pre-existing cross-ext suite) full regression passes. Two prior failures (`TestBuildGreeting`, `TestBuildList`) exist on `main` and are unrelated.

## Docs
- `CHANGELOG.md` under `[Unreleased]`
- `docs/coverage.yaml`: `Table.Mark`, `Table.MarkedOnly`, `Table.ClearMarks` moved from `gap` to `covered`
- `PrintGuide()` updated with record-marking surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)