### PR TITLE
test: lookup CalcFormula coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to this project are documented here. Format based on
 ## [Unreleased]
 
 ### Added
+- **CalcField `lookup` formula coverage (#231)** — the `lookup(...)` CalcFormula
+  kind in `MockRecordHandle.ALCalcFields` now has dedicated proving tests. New
+  suite `tests/bucket-1/38-lookup-formula` exercises text lookup, decimal
+  lookup, first-match disambiguation, and the no-match default path (empty
+  text / zero decimal). Coverage map: `lookup_formula` moved from `gap` to
+  `covered`.
 - **Multi-token decimal format strings (#225)** — `Format(decimal, 0, '<Precision,2:2><Standard Format,0>')`
   now parses every `<...>` token in the picture string instead of only the
   first. For decimals, `<Precision,min:max>` wins over `<Standard Format,N>`

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -691,7 +691,10 @@ keys_section:
 lookup_formula:
   layer: syntax
   category: table
-  status: gap
+  status: covered
+  tests:
+    - tests/bucket-1/38-lookup-formula
+    - tests/bucket-2/124-temp-records-flowfields
 
 table_relation_expression:
   layer: syntax

--- a/tests/bucket-1/38-lookup-formula/src/LookupFormulaTables.al
+++ b/tests/bucket-1/38-lookup-formula/src/LookupFormulaTables.al
@@ -1,0 +1,43 @@
+table 54100 "LF Parent"
+{
+    DataClassification = CustomerContent;
+
+    fields
+    {
+        field(1; "No."; Code[20]) { }
+        field(2; "Name"; Text[50]) { }
+        field(10; "Child Name"; Text[50])
+        {
+            FieldClass = FlowField;
+            CalcFormula = lookup("LF Child".Name where("Parent No." = field("No.")));
+        }
+        field(11; "Child Amount"; Decimal)
+        {
+            FieldClass = FlowField;
+            CalcFormula = lookup("LF Child".Amount where("Parent No." = field("No.")));
+        }
+    }
+
+    keys
+    {
+        key(PK; "No.") { Clustered = true; }
+    }
+}
+
+table 54101 "LF Child"
+{
+    DataClassification = CustomerContent;
+
+    fields
+    {
+        field(1; "Entry No."; Integer) { }
+        field(2; "Parent No."; Code[20]) { }
+        field(3; "Name"; Text[50]) { }
+        field(4; "Amount"; Decimal) { }
+    }
+
+    keys
+    {
+        key(PK; "Entry No.") { Clustered = true; }
+    }
+}

--- a/tests/bucket-1/38-lookup-formula/test/TestLookupFormula.al
+++ b/tests/bucket-1/38-lookup-formula/test/TestLookupFormula.al
@@ -1,0 +1,106 @@
+codeunit 54100 "Test Lookup Formula"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    [Test]
+    procedure LookupReturnsTextFromRelatedRow()
+    var
+        Parent: Record "LF Parent";
+        Child: Record "LF Child";
+    begin
+        // Positive: lookup FlowField returns the Name of the matching child row.
+        Parent.Init();
+        Parent."No." := 'P1';
+        Parent.Name := 'Parent One';
+        Parent.Insert(true);
+
+        Child.Init();
+        Child."Entry No." := 1;
+        Child."Parent No." := 'P1';
+        Child.Name := 'ChildAlpha';
+        Child.Amount := 42.5;
+        Child.Insert(true);
+
+        Parent.Get('P1');
+        Parent.CalcFields("Child Name");
+        Assert.AreEqual('ChildAlpha', Parent."Child Name",
+            'Lookup should resolve Child.Name for matching row');
+    end;
+
+    [Test]
+    procedure LookupReturnsDecimalFromRelatedRow()
+    var
+        Parent: Record "LF Parent";
+        Child: Record "LF Child";
+    begin
+        // Positive: lookup FlowField returns the numeric Amount of the matching child row.
+        Parent.Init();
+        Parent."No." := 'P2';
+        Parent.Name := 'Parent Two';
+        Parent.Insert(true);
+
+        Child.Init();
+        Child."Entry No." := 2;
+        Child."Parent No." := 'P2';
+        Child.Name := 'ChildBeta';
+        Child.Amount := 99.99;
+        Child.Insert(true);
+
+        Parent.Get('P2');
+        Parent.CalcFields("Child Amount");
+        Assert.AreEqual(99.99, Parent."Child Amount",
+            'Lookup should resolve Child.Amount for matching row');
+    end;
+
+    [Test]
+    procedure LookupReturnsFirstMatchingRow()
+    var
+        Parent: Record "LF Parent";
+        Child: Record "LF Child";
+    begin
+        // Positive/disambiguation: multiple children — lookup returns the first match.
+        Parent.Init();
+        Parent."No." := 'P3';
+        Parent.Insert(true);
+
+        Child.Init();
+        Child."Entry No." := 10;
+        Child."Parent No." := 'P3';
+        Child.Name := 'FirstChild';
+        Child.Insert(true);
+
+        Child.Init();
+        Child."Entry No." := 11;
+        Child."Parent No." := 'P3';
+        Child.Name := 'SecondChild';
+        Child.Insert(true);
+
+        Parent.Get('P3');
+        Parent.CalcFields("Child Name");
+        Assert.AreEqual('FirstChild', Parent."Child Name",
+            'Lookup should return the first matching child row');
+    end;
+
+    [Test]
+    procedure LookupWithNoMatchClearsField()
+    var
+        Parent: Record "LF Parent";
+    begin
+        // Negative: no matching child — lookup should clear the field to default.
+        Parent.Init();
+        Parent."No." := 'P4';
+        Parent.Insert(true);
+
+        Parent.Get('P4');
+        Parent.CalcFields("Child Name");
+        Assert.AreEqual('', Parent."Child Name",
+            'Lookup with no matching row should produce empty/default text');
+
+        Parent.CalcFields("Child Amount");
+        Assert.AreEqual(0, Parent."Child Amount",
+            'Lookup with no matching row should produce 0 for decimal');
+    end;
+}


### PR DESCRIPTION
Closes #231

## Summary
- `MockRecordHandle.ALCalcFields` already handled the `lookup(...)` CalcFormula kind, but `lookup_formula` was marked `gap` in `docs/coverage.yaml` because no dedicated proving test existed.
- Adds `tests/bucket-1/38-lookup-formula` with four tests:
  - `LookupReturnsTextFromRelatedRow` — Text lookup returns matching child's Name
  - `LookupReturnsDecimalFromRelatedRow` — Decimal lookup returns matching child's Amount
  - `LookupReturnsFirstMatchingRow` — with multiple matches, the first row wins
  - `LookupWithNoMatchClearsField` — no matching child yields empty text / 0 decimal
- RED was confirmed by temporarily stubbing the `Lookup` case (3 positive tests failed, then restored).
- Coverage map: `lookup_formula` moved from `gap` to `covered`.

## Test plan
- [x] New suite passes (4/4)
- [x] RED confirmed before keeping implementation
- [x] Bucket-1 regression clean (208 passed; only pre-existing `TestBuildGreeting` / `TestBuildList` failures on main remain)

🤖 Generated with [Claude Code](https://claude.com/claude-code)