### PR TITLE
docs: reclassify type_declaration as out-of-scope (#232)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project are documented here. Format based on
 
 ## [Unreleased]
 
+### Changed
+- **Coverage: `type_declaration` reclassified as out-of-scope (#232)** — this
+  tree-sitter-al node is the `.NET` type alias declared inside
+  `dotnet { assembly { type(...) {} } }` blocks (required field `dotnet_type`),
+  not a general user-defined type alias. It requires BC runtime .NET interop,
+  which is an architectural limit like `assembly_declaration`. Moved from
+  `gap` to `out-of-scope` in `docs/coverage.yaml`.
+
 ### Added
 - **CalcField `lookup` formula coverage (#231)** — the `lookup(...)` CalcFormula
   kind in `MockRecordHandle.ALCalcFields` now has dedicated proving tests. New

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -7,9 +7,9 @@ Auto-generated from `docs/coverage.yaml`. Do not edit directly.
 | Status | Count |
 |--------|-------|
 | ✅ Covered | 98 |
-| 🔲 Gap | 47 |
+| 🔲 Gap | 46 |
 | ❌ Not possible | 3 |
-| ⬜ Out of scope | 6 |
+| ⬜ Out of scope | 7 |
 | **Total** | **154** |
 
 ## Summary — runtime-api
@@ -108,7 +108,7 @@ Auto-generated from `docs/coverage.yaml`. Do not edit directly.
 | `option_type` | ✅ covered | `20-option-fields` |  |
 | `record_type` | ✅ covered | `02-record-operations`, `112-codeunit-onrun-record` |  |
 | `text_type` | ✅ covered | `01-pure-function`, `17-text-builder` |  |
-| `type_declaration` | 🔲 gap | — |  |
+| `type_declaration` | ⬜ out-of-scope | — | .NET type alias (nested in dotnet/assembly blocks) — requires BC runtime .NET interop |
 | `type_specification` | ✅ covered | `01-pure-function` |  |
 
 ## Procedure

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -492,7 +492,8 @@ text_type:
 type_declaration:
   layer: syntax
   category: type
-  status: gap
+  status: out-of-scope
+  notes: .NET type alias (nested in dotnet/assembly blocks) — requires BC runtime .NET interop
 
 type_specification:
   layer: syntax


### PR DESCRIPTION
Closes #232

## Summary
- Moves `type_declaration` from `gap` to `out-of-scope` in `docs/coverage.yaml` (and regenerated row in `docs/coverage.md`).
- Rationale: inspecting `scripts/node-types.json` shows the tree-sitter-al `type_declaration` node has a required `dotnet_type` field and appears only inside `dotnet { assembly { ... } }` blocks. It is the AL .NET type alias (e.g. `type(System.IO.File; DotNetFile) { }`), not a general user-defined type alias.
- Like `assembly_declaration` / `dotnet_declaration`, it requires BC runtime .NET interop, which is architecturally out of scope for this runner.

## Note on the issue's reproduction
The issue's AL snippet (`var MyNames: List of [Text];`) is actually `variable_declaration` + generic `list_type`, both already covered (e.g. `tests/bucket-2/83-list-byref`, `tests/bucket-2/42-list-of-interface`). It is not an instance of the `type_declaration` syntax node.

## Test plan
- [x] `docs/coverage.yaml` edit is minimal (3 lines — status + notes).
- [x] `docs/coverage.md` summary counts updated (Gap 47→46, Out of scope 6→7) and the `type_declaration` row reflects the new status.
- [x] `node scripts/coverage-gen.js --validate` passes locally.
- [x] CHANGELOG entry added under `[Unreleased]` → `Changed`.