### PR TITLE
test: Record.SetRange(Field) clears field filter (#240)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ All notable changes to this project are documented here. Format based on
   `gap` to `out-of-scope` in `docs/coverage.yaml`.
 
 ### Added
+- **Test coverage: `Record.SetRange(Field)` clears field filter (#240)** — new
+  suite `tests/bucket-1/240-setrange-clear` proves that calling
+  `SetRange(Field)` with no value argument removes only that field's filter
+  while leaving other field filters intact, and that `FindSet()` iterates
+  the full record set afterwards. Behaviour was already implemented in
+  `MockRecordHandle.ALSetRangeSafe`; this adds the proving tests.
 - **Record.TransferFields coverage (#224)** — `ALTransferFields` in
   `MockRecordHandle` now has dedicated proving tests. New suite
   `tests/bucket-1/39-transferfields` verifies matching fields are copied by

--- a/tests/bucket-1/240-setrange-clear/src/ItemTbl.al
+++ b/tests/bucket-1/240-setrange-clear/src/ItemTbl.al
@@ -1,0 +1,13 @@
+table 50240 "SR Item"
+{
+    fields
+    {
+        field(1; "No."; Code[20]) { }
+        field(2; "Status"; Integer) { }
+        field(3; "Category"; Integer) { }
+    }
+    keys
+    {
+        key(PK; "No.") { Clustered = true; }
+    }
+}

--- a/tests/bucket-1/240-setrange-clear/test/SetRangeClearTest.al
+++ b/tests/bucket-1/240-setrange-clear/test/SetRangeClearTest.al
@@ -1,0 +1,94 @@
+codeunit 50240 "SetRange Clear Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    local procedure Seed()
+    var
+        Item: Record "SR Item";
+    begin
+        Item.DeleteAll();
+        Item.Init(); Item."No." := 'A'; Item.Status := 1; Item.Category := 10; Item.Insert();
+        Item.Init(); Item."No." := 'B'; Item.Status := 2; Item.Category := 10; Item.Insert();
+        Item.Init(); Item."No." := 'C'; Item.Status := 1; Item.Category := 20; Item.Insert();
+        Item.Init(); Item."No." := 'D'; Item.Status := 3; Item.Category := 20; Item.Insert();
+    end;
+
+    [Test]
+    procedure SetRange_Clears_Filter_On_Field()
+    var
+        Item: Record "SR Item";
+    begin
+        Seed();
+
+        // [GIVEN] Filter on Status = 1
+        Item.SetRange(Status, 1);
+        Assert.AreEqual(2, Item.Count(), 'Status=1 should match 2 records (A, C)');
+
+        // [WHEN] SetRange(Status) called with no value
+        Item.SetRange(Status);
+
+        // [THEN] Filter cleared — all 4 records returned
+        Assert.AreEqual(4, Item.Count(), 'SetRange(Status) with no value must clear the filter — expected all 4 records');
+    end;
+
+    [Test]
+    procedure SetRange_Clears_Only_Target_Field()
+    var
+        Item: Record "SR Item";
+    begin
+        Seed();
+
+        // [GIVEN] Filters on two fields
+        Item.SetRange(Status, 1);
+        Item.SetRange(Category, 10);
+        Assert.AreEqual(1, Item.Count(), 'Status=1 AND Category=10 should match only A');
+
+        // [WHEN] Clear only the Status filter
+        Item.SetRange(Status);
+
+        // [THEN] Category filter is still active — A and B match (Category=10)
+        Assert.AreEqual(2, Item.Count(), 'After clearing Status filter, Category=10 filter must remain — expected 2 records');
+
+        // [AND] Narrow again with a fresh Status filter to prove filters can be reapplied
+        Item.SetRange(Status, 2);
+        Assert.AreEqual(1, Item.Count(), 'Status=2 AND Category=10 should match only B');
+    end;
+
+    [Test]
+    procedure SetRange_Clear_On_Unfiltered_Field_Is_Noop()
+    var
+        Item: Record "SR Item";
+    begin
+        Seed();
+        // [GIVEN] No filter on Category
+        Item.SetRange(Status, 1);
+
+        // [WHEN] Clear filter on Category (which had no filter)
+        Item.SetRange(Category);
+
+        // [THEN] Status filter unchanged — still 2 records
+        Assert.AreEqual(2, Item.Count(), 'Clearing unfiltered field must not affect other filters');
+    end;
+
+    [Test]
+    procedure SetRange_Clear_Then_FindSet_Iterates_All()
+    var
+        Item: Record "SR Item";
+        Visited: Integer;
+    begin
+        Seed();
+        Item.SetRange(Status, 1);
+        Item.SetRange(Status); // clear
+
+        Visited := 0;
+        if Item.FindSet() then
+            repeat
+                Visited += 1;
+            until Item.Next() = 0;
+
+        Assert.AreEqual(4, Visited, 'FindSet after cleared filter must iterate all 4 records');
+    end;
+}


### PR DESCRIPTION
Closes #240

## Summary
- The runtime behaviour is already implemented in `MockRecordHandle.ALSetRangeSafe(fieldNo, expectedType)` (removes the filter entry). This PR adds the proving tests.
- New suite `tests/bucket-1/240-setrange-clear` with a `"SR Item"` table (50240) and 4 tests covering clearing behaviour.

## Tests (all proving — would fail with a no-op implementation)
- `SetRange_Clears_Filter_On_Field`: Status=1 filter matches 2 rows → after `SetRange(Status)` matches all 4.
- `SetRange_Clears_Only_Target_Field`: Status=1 AND Category=10 matches 1 → after `SetRange(Status)` Category filter still narrows to 2 → reapplying Status=2 narrows to 1.
- `SetRange_Clear_On_Unfiltered_Field_Is_Noop`: clearing Category (unfiltered) does not disturb Status filter.
- `SetRange_Clear_Then_FindSet_Iterates_All`: FindSet iterates all 4 records after the filter is cleared.

## Docs
- CHANGELOG entry under `[Unreleased]` → Added.

## Test plan
- [x] All 4 tests PASS locally.
- [x] Uses strict-value assertions (2, 4, 1, 2, 1, 4 record counts) so a no-op or always-return-default mock would not satisfy them.