### PR TITLE
test: RecordRef.FieldCount coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ All notable changes to this project are documented here. Format based on
 
 ## [Unreleased]
 
+### Added
+- **RecordRef.FieldCount coverage (#238)** — `MockRecordRef.ALFieldCount` and
+  `MockRecordHandle.FieldCount` already preferred the schema field count
+  (from `TableFieldRegistry`) over the runtime written-field count, but this
+  behaviour was listed as a limitation and had no proving test. New suite
+  `tests/bucket-1/40-recordref-fieldcount` covers fresh RecordRef (3 schema
+  fields), invariance after writing, a different 5-field table, and the
+  negative case that FieldCount is not the write count. Removed the
+  `Record.FieldCount via RecordRef` row from `docs/limitations.md`.
+
 ### Changed
 - **Coverage: `type_declaration` reclassified as out-of-scope (#232)** — this
   tree-sitter-al node is the `.NET` type alias declared inside

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -119,7 +119,6 @@ the exact value will see different results.
 | `IsSessionActive(id)` | True while session runs | Always `false` |
 | `GuiAllowed()` | False in background sessions | `false` |
 | `GetFilter(field)` | Serialised filter expression | Returns serialised filter expression (functional) |
-| `Record.FieldCount` via RecordRef | Schema field count | Count of fields written at runtime |
 | Field `InitValue` | Applied on `Init()` | Not applied — type default only |
 | `FieldRef.Caption` / `.Name` | Field metadata from schema | Real values when parsed from AL source; `"FieldNN"` stub otherwise |
 | `Commit()` | Commits current transaction | No-op |

--- a/tests/bucket-1/40-recordref-fieldcount/src/FieldCountTables.al
+++ b/tests/bucket-1/40-recordref-fieldcount/src/FieldCountTables.al
@@ -1,0 +1,35 @@
+table 54300 "FC Three"
+{
+    DataClassification = CustomerContent;
+
+    fields
+    {
+        field(1; "Id"; Integer) { }
+        field(2; "Name"; Text[50]) { }
+        field(3; "Amount"; Decimal) { }
+    }
+
+    keys
+    {
+        key(PK; "Id") { Clustered = true; }
+    }
+}
+
+table 54301 "FC Five"
+{
+    DataClassification = CustomerContent;
+
+    fields
+    {
+        field(1; "Code"; Code[20]) { }
+        field(2; "Description"; Text[100]) { }
+        field(3; "Quantity"; Integer) { }
+        field(4; "Active"; Boolean) { }
+        field(5; "Notes"; Text[250]) { }
+    }
+
+    keys
+    {
+        key(PK; "Code") { Clustered = true; }
+    }
+}

--- a/tests/bucket-1/40-recordref-fieldcount/test/TestFieldCount.al
+++ b/tests/bucket-1/40-recordref-fieldcount/test/TestFieldCount.al
@@ -1,0 +1,75 @@
+codeunit 54300 "Test RecordRef FieldCount"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    [Test]
+    procedure FieldCountReturnsSchemaCountForEmptyRecord()
+    var
+        Rec: Record "FC Three";
+        RecRef: RecordRef;
+    begin
+        // Positive: RecordRef on a freshly-opened table reports schema field count,
+        // even though no fields have been assigned values.
+        RecRef.Open(Database::"FC Three");
+        Assert.AreEqual(3, RecRef.FieldCount,
+            'Empty RecordRef should report 3 schema fields for FC Three');
+        RecRef.Close();
+    end;
+
+    [Test]
+    procedure FieldCountUnchangedAfterSettingFields()
+    var
+        Rec: Record "FC Three";
+        RecRef: RecordRef;
+        Count: Integer;
+    begin
+        // Negative/invariance: setting field values must NOT change FieldCount.
+        // (In BC, FieldCount is a schema property, not a runtime write count.)
+        Rec.Init();
+        Rec."Id" := 1;
+        Rec.Name := 'Alpha';
+        Rec.Amount := 99.5;
+        Rec.Insert(true);
+
+        RecRef.GetTable(Rec);
+        Count := RecRef.FieldCount;
+        Assert.AreEqual(3, Count,
+            'FieldCount should still be 3 after populating all fields');
+        RecRef.Close();
+    end;
+
+    [Test]
+    procedure FieldCountReflectsDifferentTableSchema()
+    var
+        RecRef: RecordRef;
+    begin
+        // Positive: a 5-field table reports 5, proving the count is per-table schema.
+        RecRef.Open(Database::"FC Five");
+        Assert.AreEqual(5, RecRef.FieldCount,
+            'FC Five has 5 schema fields');
+        RecRef.Close();
+    end;
+
+    [Test]
+    procedure FieldCountIsNotWriteCount()
+    var
+        Rec: Record "FC Five";
+        RecRef: RecordRef;
+    begin
+        // Negative: assigning only a subset must not lower FieldCount to that subset.
+        Rec.Init();
+        Rec.Code := 'X';
+        Rec.Description := 'only two fields set';
+        Rec.Insert(true);
+
+        RecRef.GetTable(Rec);
+        Assert.AreNotEqual(2, RecRef.FieldCount,
+            'FieldCount must not reflect the number of fields written (only 2 were set)');
+        Assert.AreEqual(5, RecRef.FieldCount,
+            'FieldCount must be the schema count (5) regardless of writes');
+        RecRef.Close();
+    end;
+}


### PR DESCRIPTION
Closes #238

## Summary
- `MockRecordRef.ALFieldCount` and `MockRecordHandle.FieldCount` already return the schema field count from `TableFieldRegistry` (falling back to the runtime written-field count only when no schema metadata is available), but the behaviour was listed as a limitation and had no proving test.
- Adds `tests/bucket-1/40-recordref-fieldcount` with four proving tests:
  - Fresh RecordRef on a 3-field table reports 3
  - FieldCount unchanged after populating all fields
  - A different 5-field table reports 5 (proves it is per-schema)
  - Negative: writing only 2 fields does not drop FieldCount to 2
- RED confirmed by temporarily pointing `FieldCount` at `_fields.Count` — all 4 tests failed, then restored.
- Removed the `Record.FieldCount via RecordRef` row from `docs/limitations.md`.

## Test plan
- [x] New suite passes (4/4)
- [x] RED proven before restoring implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)