### PR TITLE
fix: GetFilters renders real field names

### DIFF
--- a/AlRunner/Runtime/MockRecordHandle.cs
+++ b/AlRunner/Runtime/MockRecordHandle.cs
@@ -2229,6 +2229,11 @@ public class MockRecordHandle
 
     private string GetFieldNameByNo(int fieldNo)
     {
+        // Prefer transpile-time metadata (populated from AL source by PackageScanner)
+        var fromRegistry = TableFieldRegistry.GetFieldName(_tableId, fieldNo);
+        if (!string.IsNullOrEmpty(fromRegistry))
+            return fromRegistry;
+
         if (_fieldNames.TryGetValue(_tableId, out var names))
         {
             foreach (var kv in names)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ All notable changes to this project are documented here. Format based on
 ## [Unreleased]
 
 ### Added
+- **Record.GetFilters coverage & field-name fix (#246)** — `Record.GetFilters()`
+  now emits real AL field names (e.g. `"Status: 1"`) instead of positional
+  stubs (`"Field2: 1"`). `MockRecordHandle.GetFieldNameByNo` now prefers the
+  transpile-time `TableFieldRegistry` metadata before falling back to the
+  runtime-registered name dictionary. New suite
+  `tests/bucket-1/41-getfilters` covers the empty case, single-field filter,
+  combined multi-field filter, post-`Reset` clearing, and range-filter
+  rendering (`1..5`). Coverage map: `Table.GetFilters` moved from `gap` to
+  `covered`.
 - **RecordRef.FieldCount coverage (#238)** — `MockRecordRef.ALFieldCount` and
   `MockRecordHandle.FieldCount` already preferred the schema field count
   (from `TableFieldRegistry`) over the runtime written-field count, but this

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -5790,7 +5790,9 @@ Table.GetFilter:
 Table.GetFilters:
   layer: runtime-api
   category: Table
-  status: gap
+  status: covered
+  tests:
+    - tests/bucket-1/41-getfilters
   notes: overloads=1
 
 Table.GetPosition:

--- a/tests/bucket-1/41-getfilters/src/GetFiltersTable.al
+++ b/tests/bucket-1/41-getfilters/src/GetFiltersTable.al
@@ -1,0 +1,16 @@
+table 54400 "GF Probe"
+{
+    DataClassification = CustomerContent;
+
+    fields
+    {
+        field(1; "No."; Code[20]) { }
+        field(2; "Status"; Integer) { }
+        field(3; "Category"; Integer) { }
+    }
+
+    keys
+    {
+        key(PK; "No.") { Clustered = true; }
+    }
+}

--- a/tests/bucket-1/41-getfilters/test/TestGetFilters.al
+++ b/tests/bucket-1/41-getfilters/test/TestGetFilters.al
@@ -1,0 +1,83 @@
+codeunit 54400 "Test GetFilters"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    [Test]
+    procedure GetFiltersEmptyWhenNoFiltersActive()
+    var
+        Rec: Record "GF Probe";
+    begin
+        // Negative: no filters set — GetFilters should return ''.
+        Assert.AreEqual('', Rec.GetFilters(),
+            'GetFilters must be empty when no filters are active');
+    end;
+
+    [Test]
+    procedure GetFiltersIncludesSingleEqualityFilter()
+    var
+        Rec: Record "GF Probe";
+        Filters: Text;
+    begin
+        // Positive: one SetRange equality filter is rendered as "Field: Value".
+        Rec.SetRange(Status, 1);
+        Filters := Rec.GetFilters();
+
+        Assert.IsTrue(StrPos(Filters, 'Status') > 0,
+            'GetFilters should mention the Status field — got: ' + Filters);
+        Assert.IsTrue(StrPos(Filters, '1') > 0,
+            'GetFilters should include the filter value 1 — got: ' + Filters);
+    end;
+
+    [Test]
+    procedure GetFiltersCombinesMultipleFilters()
+    var
+        Rec: Record "GF Probe";
+        Filters: Text;
+    begin
+        // Positive: multiple SetRange calls must all appear in the combined text.
+        Rec.SetRange(Status, 1);
+        Rec.SetRange(Category, 10);
+        Filters := Rec.GetFilters();
+
+        Assert.IsTrue(StrPos(Filters, 'Status') > 0,
+            'Combined filters should include Status — got: ' + Filters);
+        Assert.IsTrue(StrPos(Filters, 'Category') > 0,
+            'Combined filters should include Category — got: ' + Filters);
+        Assert.IsTrue(StrPos(Filters, '1') > 0,
+            'Combined filters should include value 1 — got: ' + Filters);
+        Assert.IsTrue(StrPos(Filters, '10') > 0,
+            'Combined filters should include value 10 — got: ' + Filters);
+    end;
+
+    [Test]
+    procedure GetFiltersEmptyAfterReset()
+    var
+        Rec: Record "GF Probe";
+    begin
+        // Negative/reset: Reset clears all filters so GetFilters returns ''.
+        Rec.SetRange(Status, 5);
+        Assert.AreNotEqual('', Rec.GetFilters(),
+            'Precondition: filter must be active before Reset');
+
+        Rec.Reset();
+        Assert.AreEqual('', Rec.GetFilters(),
+            'GetFilters must be empty after Reset');
+    end;
+
+    [Test]
+    procedure GetFiltersRendersRangeFilter()
+    var
+        Rec: Record "GF Probe";
+        Filters: Text;
+    begin
+        // Positive: SetRange(field, from, to) renders as "from..to".
+        Rec.SetRange(Status, 1, 5);
+        Filters := Rec.GetFilters();
+
+        Assert.IsTrue(StrPos(Filters, '1..5') > 0,
+            'Range filter should render as "1..5" — got: ' + Filters);
+    end;
+}


### PR DESCRIPTION
Closes #246

## Summary
- `Record.GetFilters()` was rendering filter field identifiers as positional stubs like `"Field2: 1"` instead of the real AL field names (`"Status: 1"`). Root cause: `MockRecordHandle.GetFieldNameByNo` only consulted the runtime-registered `_fieldNames` dictionary, which is populated for `RecordRef.Open` flows but not for direct Record-variable `SetRange` calls. The transpile-time `TableFieldRegistry` already carries the full name metadata.
- `GetFieldNameByNo` now prefers the registry before falling back to the runtime dictionary.
- Adds `tests/bucket-1/41-getfilters` with five proving tests:
  - Empty on fresh record
  - Single equality filter mentions field name AND value
  - Multi-field combined filter mentions every name and value
  - `Reset()` clears filters back to `''`
  - Range filter renders as `"1..5"`
- RED confirmed before fix (`"Field2: 1"` instead of `"Status: 1"`); GREEN after.
- Coverage map: `Table.GetFilters` moved from `gap` to `covered`.

## Test plan
- [x] New suite passes (5/5)
- [x] RED proven before the fix
- [x] Bucket-1 regression clean (225 passed; only pre-existing `TestBuildGreeting` / `TestBuildList` failures on main remain)

🤖 Generated with [Claude Code](https://claude.com/claude-code)