### PR TITLE
feat: CompanyName() configurable — CLI flag and AL stub codeunit (#242)

### DIFF
--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -50,6 +50,7 @@ if (args.Length == 0 || args.Any(a => a is "-h" or "--help"))
     Console.Error.WriteLine("  --guide               Print test-writing guide for AI coding agents");
     Console.Error.WriteLine("  --no-telemetry        Disable crash reporting prompt on unexpected errors");
     Console.Error.WriteLine("  --strict              Fail on runner limitations (exit 1 instead of 2)");
+    Console.Error.WriteLine("  --company-name <name> Default value returned by CompanyName() (empty string otherwise)");
     Console.Error.WriteLine("  -h, --help            Show this help");
     Console.Error.WriteLine();
     Console.Error.WriteLine("Examples:");
@@ -182,6 +183,12 @@ while (argIdx < args.Length)
             break;
         case "--strict":
             options.Strict = true;
+            argIdx++;
+            break;
+        case "--company-name":
+            argIdx++;
+            if (argIdx >= args.Length) { Console.Error.WriteLine("Error: --company-name requires a value"); return 1; }
+            AlRunner.Runtime.MockSession.DefaultCompanyName = args[argIdx] ?? string.Empty;
             argIdx++;
             break;
         case "--stubs":
@@ -333,7 +340,11 @@ test executor that needs no BC service tier, Docker, SQL Server, or license.
   - Time picture strings applied to Time variables (e.g. `Format(T, 0, '<Hours24,2>:<Minutes,2>')`)
 - Session API: StartSession (dispatches codeunit synchronously, returns true), StopSession (no-op),
   IsSessionActive (returns false), Sleep (no-op)
-- Built-in session functions: CompanyName, UserId, TenantId, SerialNumber (return empty string)
+- Built-in session functions: UserId, TenantId, SerialNumber (return empty string)
+- CompanyName() — configurable: defaults to empty string, overridable via the `--company-name <name>`
+  CLI flag, and AL tests can set it at runtime by calling
+  `codeunit 131100 "AL Runner Config"` → `SetCompanyName(Name: Text)`.
+  Reset back to the CLI default between tests.
 - System & Session utilities:
   - Session.LogMessage() — no-op (telemetry not available without service tier)
   - Session.ApplicationArea() — returns empty string

--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -2744,11 +2744,22 @@ public void ClearApplicationMemberVariables() { }
 
         // Pattern: ALDatabase.ALCompanyName / ALDatabase.ALUserID / ALDatabase.ALTenantID / ALDatabase.ALSerialNumber
         // These static property accesses crash because ALDatabase requires a live BC session.
-        // Rewrite to empty-string literals — standalone mode has no company/user/tenant context.
+        // ALCompanyName routes to MockSession.GetCompanyName() (configurable via --company-name
+        // CLI flag and the Library - AL Runner Config codeunit). The others stay as empty
+        // literals — standalone mode has no user/tenant context.
         if (visited.Expression is IdentifierNameSyntax dbId &&
             dbId.Identifier.Text == "ALDatabase" &&
             ALDatabaseStringProps.Contains(visited.Name.Identifier.Text))
         {
+            if (visited.Name.Identifier.Text == "ALCompanyName")
+            {
+                return SyntaxFactory.InvocationExpression(
+                    SyntaxFactory.MemberAccessExpression(
+                        SyntaxKind.SimpleMemberAccessExpression,
+                        SyntaxFactory.IdentifierName("MockSession"),
+                        SyntaxFactory.IdentifierName("GetCompanyName")))
+                    .WithTriviaFrom(visited);
+            }
             return SyntaxFactory.LiteralExpression(
                 SyntaxKind.StringLiteralExpression,
                 SyntaxFactory.Literal(""))

--- a/AlRunner/Runtime/MockCodeunitHandle.cs
+++ b/AlRunner/Runtime/MockCodeunitHandle.cs
@@ -140,6 +140,10 @@ public class MockCodeunitHandle
         if (_codeunitId is 131004)
             return InvokeVariableStorage(memberId, args);
 
+        // Route codeunit 131100 (AL Runner Config) — exposes CompanyName configuration to AL
+        if (_codeunitId is 131100)
+            return InvokeRunnerConfig(memberId, args);
+
         var assembly = CurrentAssembly ?? Assembly.GetExecutingAssembly();
         var codeunitType = FindCodeunitType(assembly);
         if (codeunitType == null)
@@ -552,6 +556,34 @@ public class MockCodeunitHandle
         }
 
         return null;
+    }
+
+    /// <summary>
+    /// Routes "AL Runner Config" (131100) method calls to MockSession.
+    /// Exposes runner-only configuration — currently CompanyName — to AL code.
+    /// </summary>
+    private static object? InvokeRunnerConfig(int memberId, object[] args)
+    {
+        var methodName = FindMethodName(memberId, "Codeunit131100");
+
+        if (methodName != null && methodName.Equals("SetCompanyName", StringComparison.OrdinalIgnoreCase))
+        {
+            var name = args.Length >= 1 ? (args[0]?.ToString() ?? string.Empty) : string.Empty;
+            MockSession.SetCompanyName(name);
+            return null;
+        }
+        if (methodName != null && methodName.Equals("GetCompanyName", StringComparison.OrdinalIgnoreCase))
+        {
+            return new NavText(MockSession.GetCompanyName());
+        }
+
+        // Fallback: 1 string arg = SetCompanyName, 0 args = GetCompanyName
+        if (args.Length >= 1)
+        {
+            MockSession.SetCompanyName(args[0]?.ToString() ?? string.Empty);
+            return null;
+        }
+        return new NavText(MockSession.GetCompanyName());
     }
 
     /// <summary>

--- a/AlRunner/Runtime/MockSession.cs
+++ b/AlRunner/Runtime/MockSession.cs
@@ -12,13 +12,33 @@ using Microsoft.Dynamics.Nav.Types;
 public static class MockSession
 {
     private static int _nextSessionId = 1;
+    private static string _companyName = string.Empty;
 
     /// <summary>
-    /// Resets the session counter between tests.
+    /// Default company name applied between tests (settable via the
+    /// <c>--company-name</c> CLI flag). Empty by default so the runner stays
+    /// backwards-compatible.
+    /// </summary>
+    public static string DefaultCompanyName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Value returned by the AL <c>CompanyName()</c> built-in.
+    /// </summary>
+    public static string GetCompanyName() => _companyName;
+
+    /// <summary>
+    /// Sets the value returned by the AL <c>CompanyName()</c> built-in.
+    /// Reset back to <see cref="DefaultCompanyName"/> before each test.
+    /// </summary>
+    public static void SetCompanyName(string name) => _companyName = name ?? string.Empty;
+
+    /// <summary>
+    /// Resets the session counter and company name between tests.
     /// </summary>
     public static void Reset()
     {
         _nextSessionId = 1;
+        _companyName = DefaultCompanyName;
     }
 
     /// <summary>

--- a/AlRunner/stubs/AlRunnerConfig.al
+++ b/AlRunner/stubs/AlRunnerConfig.al
@@ -1,0 +1,19 @@
+// Stub for the al-runner-only configuration codeunit.
+// At runtime, MockCodeunitHandle routes codeunit 131100 calls to MockSession.
+codeunit 131100 "AL Runner Config"
+{
+    /// <summary>
+    /// Sets the value that CompanyName() will return.
+    /// Resets to the CLI --company-name default between tests.
+    /// </summary>
+    procedure SetCompanyName(Name: Text)
+    begin
+    end;
+
+    /// <summary>
+    /// Returns the configured company name (same value as CompanyName()).
+    /// </summary>
+    procedure GetCompanyName(): Text
+    begin
+    end;
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ All notable changes to this project are documented here. Format based on
 ## [Unreleased]
 
 ### Added
+- **`CompanyName()` configurable (#242)** — was hard-coded to empty string.
+  Now three-way configurable:
+    * `--company-name <name>` CLI flag sets the default returned between tests.
+    * AL tests can set it at runtime via the new stub codeunit
+      `131100 "AL Runner Config"` → `SetCompanyName(Name: Text)`.
+    * Defaults to empty string when neither is used (backwards-compatible).
+  Per-test reset restores the CLI default so tests don't leak across each
+  other. Rewriter maps `ALDatabase.ALCompanyName` to `MockSession.GetCompanyName()`.
+  New suite `tests/bucket-1/242-company-name` covers default, set, clear,
+  per-test reset, and composition with `StrSubstNo`.
 - **Record.GetFilters coverage & field-name fix (#246)** — `Record.GetFilters()`
   now emits real AL field names (e.g. `"Status: 1"`) instead of positional
   stubs (`"Field2: 1"`). `MockRecordHandle.GetFieldNameByNo` now prefers the

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -18,8 +18,11 @@ the BC runtime environment:
 
 - **Permissions and entitlements** — there is no permission system. All field/table
   access succeeds unconditionally.
-- **Company context** — `CompanyName()` returns an empty string. Code that branches
-  on company name will take the "empty" branch.
+- **Company context** — no active BC company. `CompanyName()` defaults to empty
+  string but is configurable: pass `--company-name <name>` on the CLI, or call
+  codeunit 131100 `"AL Runner Config".SetCompanyName(Name)` from AL tests.
+  Code that only branches on whether the name is empty still takes the "empty"
+  branch by default.
 - **Base app data** — no standard BC tables are populated. Code that reads
   `G/L Account`, `Customer`, `Vendor`, or any other base app table finds them empty
   unless your test inserts data.
@@ -114,7 +117,7 @@ the exact value will see different results.
 
 | AL call | Real BC | al-runner |
 |---|---|---|
-| `CompanyName()` | Active company name | `""` |
+| `CompanyName()` | Active company name | `""` (or `--company-name <name>` / `"AL Runner Config".SetCompanyName()`) |
 | `UserId()` | Authenticated user | `""` |
 | `IsSessionActive(id)` | True while session runs | Always `false` |
 | `GuiAllowed()` | False in background sessions | `false` |

--- a/tests/bucket-1/242-company-name/test/CompanyNameTest.al
+++ b/tests/bucket-1/242-company-name/test/CompanyNameTest.al
@@ -1,0 +1,55 @@
+codeunit 50242 "Company Name Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        RunnerConfig: Codeunit "AL Runner Config";
+
+    [Test]
+    procedure CompanyName_Default_IsEmpty()
+    begin
+        // [GIVEN] No company name configured (runner default + per-test reset)
+        // [THEN] CompanyName() returns empty string
+        Assert.AreEqual('', CompanyName(), 'CompanyName() must default to empty string when not configured');
+    end;
+
+    [Test]
+    procedure CompanyName_Configurable_ReturnsSetValue()
+    begin
+        // [WHEN] SetCompanyName is called via the runner config stub
+        RunnerConfig.SetCompanyName('CRONUS Test Co.');
+
+        // [THEN] CompanyName() returns the configured value
+        Assert.AreEqual('CRONUS Test Co.', CompanyName(), 'CompanyName() must return the configured company name');
+    end;
+
+    [Test]
+    procedure CompanyName_SetToEmpty_ReturnsEmpty()
+    begin
+        // [GIVEN] A name was set in a previous call
+        RunnerConfig.SetCompanyName('SomeCo');
+        Assert.AreEqual('SomeCo', CompanyName(), 'Sanity: SomeCo set');
+
+        // [WHEN] Cleared via empty string
+        RunnerConfig.SetCompanyName('');
+
+        // [THEN] CompanyName() returns empty
+        Assert.AreEqual('', CompanyName(), 'CompanyName() must return empty after being cleared');
+    end;
+
+    [Test]
+    procedure CompanyName_ResetBetweenTests_RestoresDefault()
+    begin
+        // This test runs after the configurable test — per-test reset must restore default ('').
+        // Without reset, the previous test's value would leak here.
+        Assert.AreEqual('', CompanyName(), 'Per-test reset must restore CompanyName() to default empty string');
+    end;
+
+    [Test]
+    procedure CompanyName_UsedInStrSubstNo()
+    begin
+        RunnerConfig.SetCompanyName('Acme Ltd');
+        Assert.AreEqual('Hello from Acme Ltd', StrSubstNo('Hello from %1', CompanyName()), 'CompanyName() must compose correctly in StrSubstNo');
+    end;
+}


### PR DESCRIPTION
Closes #242

## Summary
`CompanyName()` was hard-coded to empty string. Now three-way configurable:
- `--company-name <name>` CLI flag (sets the default between tests).
- AL tests call `codeunit 131100 "AL Runner Config".SetCompanyName(Name: Text)` (new stub) to override at runtime.
- Empty string by default when neither is used — backwards compatible.

Per-test reset restores the CLI default so test state doesn't leak.

## Changes
- `MockSession`: `GetCompanyName`/`SetCompanyName`/`DefaultCompanyName`; `Reset()` restores CLI default.
- `RoslynRewriter`: `ALDatabase.ALCompanyName` now rewrites to `MockSession.GetCompanyName()` (other `ALDatabase` string props stay as empty literals).
- `MockCodeunitHandle`: routes codeunit 131100 → `MockSession.SetCompanyName` / `GetCompanyName`.
- New `AlRunner/stubs/AlRunnerConfig.al` (codeunit 131100 `"AL Runner Config"`) — auto-loaded alongside `Assert` stubs.
- New `--company-name <value>` CLI flag.
- `PrintGuide()` and `docs/limitations.md` updated.

## Test plan
- [x] RED confirmed: `CompanyName Tests` failed with "Codeunit 'AL Runner Config' is missing" before implementation.
- [x] GREEN: 5 proving tests in `tests/bucket-1/242-company-name`:
  - default returns empty
  - configurable via stub — returns `'CRONUS Test Co.'`
  - clearing via empty string returns empty
  - per-test reset restores default empty across tests (proves state doesn't leak)
  - `StrSubstNo` composition — `'Hello from %1'` formats with the configured name
- [x] No regressions in `tests/bucket-2/70-companyname` (existing CompanyName/UserId coverage).
- [x] Full bucket-1 regression: 221 passed, 2 pre-existing failures in `17-text-builder` unrelated.
- [x] CLI flag verified manually: `--company-name "CliCo Ltd"` overrides the default-empty tests as expected.