### PR TITLE
test: Record.LockTable coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ All notable changes to this project are documented here. Format based on
 ## [Unreleased]
 
 ### Added
+- **Record.LockTable coverage (#250)** — `ALLockTable` in `MockRecordHandle`
+  is a correct no-op (the runner has no SQL transaction isolation) but
+  previously had no proving test. New suite `tests/bucket-1/42-locktable`
+  covers: LockTable does not throw on an empty table, subsequent Modify /
+  Insert / Delete succeed, and repeated LockTable calls are idempotent. RED
+  confirmed by temporarily making ALLockTable throw. Coverage map:
+  `Table.LockTable` moved from `gap` to `covered`.
 - **`CompanyName()` configurable (#242)** — was hard-coded to empty string.
   Now three-way configurable:
     * `--company-name <name>` CLI flag sets the default returned between tests.

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -5864,7 +5864,9 @@ Table.LoadFields:
 Table.LockTable:
   layer: runtime-api
   category: Table
-  status: gap
+  status: covered
+  tests:
+    - tests/bucket-1/42-locktable
   notes: overloads=1
 
 Table.Mark:

--- a/tests/bucket-1/42-locktable/src/LockTableTable.al
+++ b/tests/bucket-1/42-locktable/src/LockTableTable.al
@@ -1,0 +1,16 @@
+table 54500 "Lock Probe"
+{
+    DataClassification = CustomerContent;
+
+    fields
+    {
+        field(1; "No."; Code[20]) { }
+        field(2; "Name"; Text[50]) { }
+        field(3; "Amount"; Decimal) { }
+    }
+
+    keys
+    {
+        key(PK; "No.") { Clustered = true; }
+    }
+}

--- a/tests/bucket-1/42-locktable/test/TestLockTable.al
+++ b/tests/bucket-1/42-locktable/test/TestLockTable.al
@@ -1,0 +1,97 @@
+codeunit 54500 "Test LockTable"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    [Test]
+    procedure LockTableDoesNotThrow()
+    var
+        Rec: Record "Lock Probe";
+    begin
+        // Positive: LockTable on an empty table compiles and runs without error.
+        Rec.LockTable();
+        Assert.AreEqual(0, Rec.Count, 'Table should still be empty after LockTable');
+    end;
+
+    [Test]
+    procedure ModifyWorksAfterLockTable()
+    var
+        Rec: Record "Lock Probe";
+    begin
+        // Positive: subsequent Modify operates normally after LockTable.
+        Rec.Init();
+        Rec."No." := 'A';
+        Rec.Name := 'Original';
+        Rec.Amount := 10;
+        Rec.Insert(true);
+
+        Rec.Get('A');
+        Rec.LockTable();
+        Rec.Name := 'Updated';
+        Rec.Amount := 25;
+        Rec.Modify(true);
+
+        Rec.Get('A');
+        Assert.AreEqual('Updated', Rec.Name,
+            'Name should be updated after LockTable + Modify');
+        Assert.AreEqual(25, Rec.Amount,
+            'Amount should be updated after LockTable + Modify');
+    end;
+
+    [Test]
+    procedure InsertWorksAfterLockTable()
+    var
+        Rec: Record "Lock Probe";
+    begin
+        // Positive: Insert operates normally after LockTable on an empty table.
+        Rec.LockTable();
+
+        Rec.Init();
+        Rec."No." := 'B';
+        Rec.Name := 'Second';
+        Rec.Amount := 7;
+        Rec.Insert(true);
+
+        Rec.Get('B');
+        Assert.AreEqual('Second', Rec.Name,
+            'Record B should be insertable after LockTable');
+    end;
+
+    [Test]
+    procedure LockTableIsIdempotent()
+    var
+        Rec: Record "Lock Probe";
+    begin
+        // Positive: multiple LockTable calls in a row do not break subsequent operations.
+        Rec.Init();
+        Rec."No." := 'C';
+        Rec.Insert(true);
+
+        Rec.LockTable();
+        Rec.LockTable();
+        Rec.LockTable();
+
+        Assert.AreEqual(1, Rec.Count,
+            'Repeated LockTable calls must not alter the table state');
+    end;
+
+    [Test]
+    procedure DeleteWorksAfterLockTable()
+    var
+        Rec: Record "Lock Probe";
+    begin
+        // Positive: Delete works after LockTable.
+        Rec.Init();
+        Rec."No." := 'D';
+        Rec.Insert(true);
+
+        Rec.LockTable();
+        Rec.Get('D');
+        Rec.Delete(true);
+
+        Assert.AreEqual(0, Rec.Count,
+            'Record should be deleted after LockTable + Delete');
+    end;
+}


### PR DESCRIPTION
Closes #250

## Summary
- `ALLockTable` in `MockRecordHandle` is a correct no-op (the runner has no SQL transaction isolation) but was listed as `gap` in `docs/coverage.yaml` because no proving test existed.
- Adds `tests/bucket-1/42-locktable` with five proving tests:
  - `LockTable()` does not throw on an empty table
  - `Modify` succeeds after `LockTable`
  - `Insert` succeeds after `LockTable`
  - Repeated `LockTable` calls are idempotent
  - `Delete` succeeds after `LockTable`
- RED confirmed by temporarily making `ALLockTable` throw — all 5 tests failed, then restored.
- Coverage map: `Table.LockTable` moved from `gap` to `covered`.

## Test plan
- [x] New suite passes (5/5)
- [x] RED proven before restoring the no-op

🤖 Generated with [Claude Code](https://claude.com/claude-code)