### PR TITLE
test: Record.HasFilter coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ All notable changes to this project are documented here. Format based on
   adds 5 proving tests: normal Record → false, `temporary` Record → true,
   stays temporary after Insert, temp store is isolated from the persisted
   table, and normal Record stays non-temporary after Insert.
+- **Record.HasFilter coverage (#253)** — `MockRecordHandle.ALHasFilter`
+  (`_filters.Count > 0`) now has dedicated proving tests. New suite
+  `tests/bucket-1/43-hasfilter` covers fresh record (false), `SetRange`
+  (true), `SetFilter` (true), `Reset()` (false), and clearing filters
+  one-by-one (remains true until last cleared). RED confirmed by
+  temporarily stubbing `ALHasFilter` to always return false. Coverage map:
+  `Table.HasFilter` moved from `gap` to `covered`.
 - **Record.LockTable coverage (#250)** — `ALLockTable` in `MockRecordHandle`
   is a correct no-op (the runner has no SQL transaction isolation) but
   previously had no proving test. New suite `tests/bucket-1/42-locktable`

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -5822,7 +5822,9 @@ Table.GetView:
 Table.HasFilter:
   layer: runtime-api
   category: Table
-  status: gap
+  status: covered
+  tests:
+    - tests/bucket-1/43-hasfilter
   notes: overloads=1
 
 Table.HasLinks:

--- a/tests/bucket-1/43-hasfilter/src/HasFilterTable.al
+++ b/tests/bucket-1/43-hasfilter/src/HasFilterTable.al
@@ -1,0 +1,16 @@
+table 54600 "HF Probe"
+{
+    DataClassification = CustomerContent;
+
+    fields
+    {
+        field(1; "No."; Code[20]) { }
+        field(2; "Status"; Integer) { }
+        field(3; "Category"; Integer) { }
+    }
+
+    keys
+    {
+        key(PK; "No.") { Clustered = true; }
+    }
+}

--- a/tests/bucket-1/43-hasfilter/test/TestHasFilter.al
+++ b/tests/bucket-1/43-hasfilter/test/TestHasFilter.al
@@ -1,0 +1,72 @@
+codeunit 54600 "Test HasFilter"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    [Test]
+    procedure HasFilterFalseOnFreshRecord()
+    var
+        Rec: Record "HF Probe";
+    begin
+        // Negative: fresh record variable has no filters.
+        Assert.IsFalse(Rec.HasFilter,
+            'HasFilter must be false on a fresh record variable');
+    end;
+
+    [Test]
+    procedure HasFilterTrueAfterSetRange()
+    var
+        Rec: Record "HF Probe";
+    begin
+        // Positive: SetRange activates a filter.
+        Rec.SetRange(Status, 1);
+        Assert.IsTrue(Rec.HasFilter,
+            'HasFilter must be true after SetRange');
+    end;
+
+    [Test]
+    procedure HasFilterTrueAfterSetFilter()
+    var
+        Rec: Record "HF Probe";
+    begin
+        // Positive: SetFilter also activates a filter.
+        Rec.SetFilter(Status, '>5');
+        Assert.IsTrue(Rec.HasFilter,
+            'HasFilter must be true after SetFilter');
+    end;
+
+    [Test]
+    procedure HasFilterFalseAfterReset()
+    var
+        Rec: Record "HF Probe";
+    begin
+        // Negative/reset: Reset clears all filters.
+        Rec.SetRange(Status, 1);
+        Rec.SetRange(Category, 2);
+        Assert.IsTrue(Rec.HasFilter, 'Precondition: filters active');
+
+        Rec.Reset();
+        Assert.IsFalse(Rec.HasFilter,
+            'HasFilter must be false after Reset');
+    end;
+
+    [Test]
+    procedure HasFilterRemainsTrueAfterOneOfManyCleared()
+    var
+        Rec: Record "HF Probe";
+    begin
+        // Positive/partial: clearing one filter leaves others; HasFilter still true.
+        Rec.SetRange(Status, 1);
+        Rec.SetRange(Category, 2);
+
+        Rec.SetRange(Status);  // clear the Status filter only
+        Assert.IsTrue(Rec.HasFilter,
+            'HasFilter must still be true while Category filter is active');
+
+        Rec.SetRange(Category);  // clear the last filter
+        Assert.IsFalse(Rec.HasFilter,
+            'HasFilter must be false after the last filter is cleared');
+    end;
+}


### PR DESCRIPTION
Closes #253

## Summary
- `MockRecordHandle.ALHasFilter` already returned true when any filter was active, but the coverage map listed `Table.HasFilter` as `gap` and no dedicated proving test existed.
- Adds `tests/bucket-1/43-hasfilter` with five proving tests:
  - Fresh record (false)
  - After `SetRange` (true)
  - After `SetFilter` (true)
  - After `Reset()` (false)
  - Partial-clear: two filters, clearing one leaves HasFilter true, clearing the second yields false
- RED confirmed by stubbing `ALHasFilter` to always return false — 4 of 5 tests failed (the fresh-record test trivially passes), restored after.
- Coverage map: `Table.HasFilter` moved from `gap` to `covered`.

## Test plan
- [x] New suite passes (5/5)
- [x] RED proven before restoring

🤖 Generated with [Claude Code](https://claude.com/claude-code)