### PR TITLE
test: Record.FindLast() coverage (#258)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to this project are documented here. Format based on
 ## [Unreleased]
 
 ### Added
+- **Test coverage: `Record.FindLast()` (#258)** — `MockRecordHandle.ALFindLast`
+  was already implemented; new suite `tests/bucket-1/258-findlast` adds 6
+  proving tests: unfiltered positions to last PK, empty table returns false,
+  filtered set returns filtered last, filter with no matches returns false,
+  `SetFilter('<>Z')` proves filters are honoured (returns M, not Z), and
+  `FindFirst`/`FindLast` return different records.
 - **Test coverage: `Record.IsTemporary()` (#254)** — `MockRecordHandle.ALIsTemporary`
   was already implemented; new suite `tests/bucket-1/254-record-istemporary`
   adds 5 proving tests: normal Record → false, `temporary` Record → true,

--- a/tests/bucket-1/258-findlast/src/LetterTbl.al
+++ b/tests/bucket-1/258-findlast/src/LetterTbl.al
@@ -1,0 +1,13 @@
+table 50258 "FL Letter"
+{
+    fields
+    {
+        field(1; "Code"; Code[10]) { }
+        field(2; "Category"; Integer) { }
+        field(3; "Weight"; Integer) { }
+    }
+    keys
+    {
+        key(PK; "Code") { Clustered = true; }
+    }
+}

--- a/tests/bucket-1/258-findlast/test/FindLastTest.al
+++ b/tests/bucket-1/258-findlast/test/FindLastTest.al
@@ -1,0 +1,86 @@
+codeunit 50258 "FindLast Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    local procedure Seed()
+    var
+        Letter: Record "FL Letter";
+    begin
+        Letter.DeleteAll();
+        Letter.Init(); Letter.Code := 'A'; Letter.Category := 1; Letter.Weight := 10; Letter.Insert();
+        Letter.Init(); Letter.Code := 'M'; Letter.Category := 2; Letter.Weight := 20; Letter.Insert();
+        Letter.Init(); Letter.Code := 'Z'; Letter.Category := 1; Letter.Weight := 30; Letter.Insert();
+    end;
+
+    [Test]
+    procedure FindLast_Unfiltered_PositionsToLastByPK()
+    var
+        Letter: Record "FL Letter";
+    begin
+        Seed();
+        Assert.IsTrue(Letter.FindLast(), 'FindLast must return true when the table has rows');
+        Assert.AreEqual('Z', Letter.Code, 'FindLast on unfiltered table must position to Code = Z (last by PK)');
+        Assert.AreEqual(30, Letter.Weight, 'FindLast must load the full record — Weight must be 30, not default');
+    end;
+
+    [Test]
+    procedure FindLast_EmptyTable_ReturnsFalse()
+    var
+        Letter: Record "FL Letter";
+    begin
+        Letter.DeleteAll();
+        Assert.IsFalse(Letter.FindLast(), 'FindLast on empty table must return false');
+    end;
+
+    [Test]
+    procedure FindLast_WithFilter_PositionsToFilteredLast()
+    var
+        Letter: Record "FL Letter";
+    begin
+        Seed();
+        Letter.SetRange(Category, 1); // filter: Category = 1 → matches A and Z
+        Assert.IsTrue(Letter.FindLast(), 'FindLast on filtered set with matches must return true');
+        Assert.AreEqual('Z', Letter.Code, 'FindLast within Category=1 must return Z (last matching PK)');
+    end;
+
+    [Test]
+    procedure FindLast_WithFilterNoMatch_ReturnsFalse()
+    var
+        Letter: Record "FL Letter";
+    begin
+        Seed();
+        Letter.SetRange(Category, 99); // no matches
+        Assert.IsFalse(Letter.FindLast(), 'FindLast with filter that matches nothing must return false');
+    end;
+
+    [Test]
+    procedure FindLast_RespectsFilter_NotFullTable()
+    var
+        Letter: Record "FL Letter";
+    begin
+        Seed();
+        // [GIVEN] filter out Z so the filtered last is M (not Z)
+        Letter.SetFilter(Code, '<>Z');
+        Assert.IsTrue(Letter.FindLast(), 'FindLast must return true');
+        // [THEN] proves filtering is applied — if FindLast ignored the filter it would return Z
+        Assert.AreEqual('M', Letter.Code, 'FindLast must honour filter and return M, not Z');
+    end;
+
+    [Test]
+    procedure FindLast_DifferentFromFindFirst()
+    var
+        First: Record "FL Letter";
+        Last: Record "FL Letter";
+    begin
+        Seed();
+        Assert.IsTrue(First.FindFirst(), 'FindFirst must succeed');
+        Assert.IsTrue(Last.FindLast(), 'FindLast must succeed');
+        // Proves FindLast isn't aliased to FindFirst
+        Assert.AreEqual('A', First.Code, 'FindFirst returns A');
+        Assert.AreEqual('Z', Last.Code, 'FindLast returns Z');
+        Assert.AreNotEqual(First.Code, Last.Code, 'FindFirst and FindLast must return different records');
+    end;
+}


### PR DESCRIPTION
Closes #258

## Summary
- `MockRecordHandle.ALFindLast` was already implemented. This PR adds proving tests.
- New suite `tests/bucket-1/258-findlast` — `"FL Letter"` table (50258), 6 tests.

## Tests (strong, would fail with a no-op)
- `FindLast_Unfiltered_PositionsToLastByPK` — returns `Z` and full record (`Weight = 30`).
- `FindLast_EmptyTable_ReturnsFalse` — empty table → `false`.
- `FindLast_WithFilter_PositionsToFilteredLast` — `Category = 1` matches A and Z, returns Z.
- `FindLast_WithFilterNoMatch_ReturnsFalse` — `Category = 99` → `false`.
- `FindLast_RespectsFilter_NotFullTable` — `SetFilter('<>Z')` returns M (not Z), proves filter is applied.
- `FindLast_DifferentFromFindFirst` — FindFirst → A, FindLast → Z (no aliasing).

## Docs
- CHANGELOG entry under `[Unreleased]` → Added.