### PR TITLE
test: Record.Count with filters coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ All notable changes to this project are documented here. Format based on
   filtered set returns filtered last, filter with no matches returns false,
   `SetFilter('<>Z')` proves filters are honoured (returns M, not Z), and
   `FindFirst`/`FindLast` return different records.
+- **Record.Count with filters coverage (#257)** — `MockRecordHandle.ALCount`
+  already honoured active filters via `GetFilteredAndMarkedRecords`, but had
+  no dedicated proving test. New suite `tests/bucket-1/44-count-filtered`
+  covers empty table (0), total count (5), filtered subset (3 for Status=1,
+  2 for Status=2), zero-match filter, restoration after `Reset`, and range
+  filter (`Amount` in 20..40). RED confirmed by temporarily pointing
+  `ALCount` at the unfiltered row count. Coverage map: `Table.Count` moved
+  from `gap` to `covered`.
 - **Test coverage: `Record.IsTemporary()` (#254)** — `MockRecordHandle.ALIsTemporary`
   was already implemented; new suite `tests/bucket-1/254-record-istemporary`
   adds 5 proving tests: normal Record → false, `temporary` Record → true,

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -5658,7 +5658,9 @@ Table.CopyLinks:
 Table.Count:
   layer: runtime-api
   category: Table
-  status: gap
+  status: covered
+  tests:
+    - tests/bucket-1/44-count-filtered
   notes: overloads=1
 
 Table.CountApprox:

--- a/tests/bucket-1/44-count-filtered/src/CountProbe.al
+++ b/tests/bucket-1/44-count-filtered/src/CountProbe.al
@@ -1,0 +1,16 @@
+table 54700 "Count Probe"
+{
+    DataClassification = CustomerContent;
+
+    fields
+    {
+        field(1; "No."; Code[20]) { }
+        field(2; "Status"; Integer) { }
+        field(3; "Amount"; Decimal) { }
+    }
+
+    keys
+    {
+        key(PK; "No.") { Clustered = true; }
+    }
+}

--- a/tests/bucket-1/44-count-filtered/test/TestCountFiltered.al
+++ b/tests/bucket-1/44-count-filtered/test/TestCountFiltered.al
@@ -1,0 +1,103 @@
+codeunit 54700 "Test Count Filtered"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    [Test]
+    procedure CountReturnsTotalOnEmptyTable()
+    var
+        Rec: Record "Count Probe";
+    begin
+        // Negative: empty table has 0 count.
+        Assert.AreEqual(0, Rec.Count, 'Empty table must have Count 0');
+    end;
+
+    [Test]
+    procedure CountReturnsTotalWhenNoFilter()
+    var
+        Rec: Record "Count Probe";
+    begin
+        Seed();
+        Assert.AreEqual(5, Rec.Count,
+            'Count must be 5 across the whole table (no filter)');
+    end;
+
+    [Test]
+    procedure CountReturnsFilteredSubset()
+    var
+        Rec: Record "Count Probe";
+    begin
+        // Positive: SetRange filters Count to matching subset.
+        Seed();
+        Rec.SetRange(Status, 1);
+        Assert.AreEqual(3, Rec.Count,
+            'Count must reflect Status=1 rows only (A, C, E)');
+
+        Rec.SetRange(Status, 2);
+        Assert.AreEqual(2, Rec.Count,
+            'Count must reflect Status=2 rows only (B, D)');
+    end;
+
+    [Test]
+    procedure CountFilteredToZeroWhenNoMatch()
+    var
+        Rec: Record "Count Probe";
+    begin
+        // Negative: filter with no matches yields Count 0.
+        Seed();
+        Rec.SetRange(Status, 999);
+        Assert.AreEqual(0, Rec.Count,
+            'Count must be 0 for a filter that matches nothing');
+    end;
+
+    [Test]
+    procedure CountReturnsFullAfterReset()
+    var
+        Rec: Record "Count Probe";
+    begin
+        // Positive/reset: clearing filters restores the full count.
+        Seed();
+        Rec.SetRange(Status, 1);
+        Assert.AreEqual(3, Rec.Count, 'Precondition: filtered to 3');
+
+        Rec.Reset();
+        Assert.AreEqual(5, Rec.Count,
+            'Count must return to full 5 after Reset');
+    end;
+
+    [Test]
+    procedure CountRespectsRangeFilter()
+    var
+        Rec: Record "Count Probe";
+    begin
+        // Positive: range-style SetRange is honoured.
+        Seed();
+        Rec.SetRange(Amount, 20, 40);
+        Assert.AreEqual(3, Rec.Count,
+            'Amount 20..40 covers rows B(20), C(30), D(40) — expect 3');
+    end;
+
+    local procedure Seed()
+    var
+        Rec: Record "Count Probe";
+    begin
+        Insert2('A', 1, 10);
+        Insert2('B', 2, 20);
+        Insert2('C', 1, 30);
+        Insert2('D', 2, 40);
+        Insert2('E', 1, 50);
+    end;
+
+    local procedure Insert2("No.": Code[20]; Status: Integer; Amount: Decimal)
+    var
+        Rec: Record "Count Probe";
+    begin
+        Rec.Init();
+        Rec."No." := "No.";
+        Rec.Status := Status;
+        Rec.Amount := Amount;
+        Rec.Insert(true);
+    end;
+}


### PR DESCRIPTION
Closes #257

## Summary
- `MockRecordHandle.ALCount` already honoured active filters via `GetFilteredAndMarkedRecords`, but the coverage map listed `Table.Count` as `gap` with no dedicated proving test.
- Adds `tests/bucket-1/44-count-filtered` with six proving tests:
  - Empty table → 0
  - Unfiltered total → 5
  - `SetRange(Status, 1)` → 3; `SetRange(Status, 2)` → 2
  - Filter with no matches → 0
  - `Reset()` restores full count (5)
  - Range filter `SetRange(Amount, 20, 40)` → 3
- RED confirmed by temporarily pointing `ALCount` at the unfiltered row list — 4 filter-specific tests failed, restored after.
- Coverage map: `Table.Count` moved from `gap` to `covered`.

## Test plan
- [x] New suite passes (6/6)
- [x] RED proven before restoring

🤖 Generated with [Claude Code](https://claude.com/claude-code)