### PR TITLE
feat: Record.Next(Steps) overload

### DIFF
--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -515,6 +515,7 @@ public bool ALFindSet(DataError errorLevel = DataError.ThrowError, bool forUpdat
 public bool ALFindFirst(DataError errorLevel = DataError.ThrowError) => Rec.ALFindFirst(errorLevel);
 public bool ALFindLast(DataError errorLevel = DataError.ThrowError) => Rec.ALFindLast(errorLevel);
 public int ALNext() => Rec.ALNext();
+public int ALNext(int steps) => Rec.ALNext(steps);
 public bool ALDelete(DataError errorLevel, bool runTrigger = false) => Rec.ALDelete(errorLevel, runTrigger);
 public void ALDeleteAll(bool runTrigger) => Rec.ALDeleteAll(runTrigger);
 public void ALDeleteAll(DataError errorLevel = DataError.ThrowError, bool runTrigger = false) => Rec.ALDeleteAll(errorLevel, runTrigger);

--- a/AlRunner/Runtime/MockRecordHandle.cs
+++ b/AlRunner/Runtime/MockRecordHandle.cs
@@ -659,6 +659,40 @@ public class MockRecordHandle
         return 1;
     }
 
+    /// <summary>
+    /// AL Next(Steps) — moves the cursor forward (Steps &gt; 0) or backward
+    /// (Steps &lt; 0) within the current result set. Returns the signed number
+    /// of steps actually moved; if the requested count exceeds the remaining
+    /// records, the absolute return value is smaller than the request.
+    /// </summary>
+    public int ALNext(int steps)
+    {
+        if (_currentResultSet == null || steps == 0) return 0;
+
+        if (steps > 0)
+        {
+            int remaining = _currentResultSet.Count - 1 - _cursorPosition;
+            int moved = Math.Min(steps, Math.Max(0, remaining));
+            if (moved > 0)
+            {
+                _cursorPosition += moved;
+                _fields = new Dictionary<int, NavValue>(_currentResultSet[_cursorPosition]);
+            }
+            return moved;
+        }
+        else
+        {
+            int remaining = _cursorPosition;
+            int moved = Math.Min(-steps, Math.Max(0, remaining));
+            if (moved > 0)
+            {
+                _cursorPosition -= moved;
+                _fields = new Dictionary<int, NavValue>(_currentResultSet[_cursorPosition]);
+            }
+            return -moved;
+        }
+    }
+
     public bool ALDelete(DataError errorLevel, bool runTrigger = false)
     {
         var table = GetRows();

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ All notable changes to this project are documented here. Format based on
 ## [Unreleased]
 
 ### Added
+- **`Record.Next(Steps)` overload (#262)** — `MockRecordHandle.ALNext(int)` is
+  new (previously only the parameterless `ALNext()` existed). Positive steps
+  move forward, negative steps move backward, and the return value is the
+  signed number of steps actually moved — clamped to the remaining records
+  at either end so the absolute return may be less than the request. Honors
+  active filters (advances within the filtered result set). New suite
+  `tests/bucket-1/45-next-steps` covers Next(1), Next(N) skip, past-end,
+  at-end (returns 0), negative-step backward, past-start, and filter
+  traversal. RED confirmed by compile error (overload missing). Coverage
+  map: `Table.Next` moved from `gap` to `covered`.
 - **Test coverage: `Record.FindLast()` (#258)** — `MockRecordHandle.ALFindLast`
   was already implemented; new suite `tests/bucket-1/258-findlast` adds 6
   proving tests: unfiltered positions to last PK, empty table returns false,

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -5904,7 +5904,9 @@ Table.ModifyAll:
 Table.Next:
   layer: runtime-api
   category: Table
-  status: gap
+  status: covered
+  tests:
+    - tests/bucket-1/45-next-steps
   notes: overloads=1
 
 Table.ReadConsistency:

--- a/tests/bucket-1/45-next-steps/src/NextStepsTable.al
+++ b/tests/bucket-1/45-next-steps/src/NextStepsTable.al
@@ -1,0 +1,15 @@
+table 54800 "Next Probe"
+{
+    DataClassification = CustomerContent;
+
+    fields
+    {
+        field(1; "No."; Code[20]) { }
+        field(2; "Status"; Integer) { }
+    }
+
+    keys
+    {
+        key(PK; "No.") { Clustered = true; }
+    }
+}

--- a/tests/bucket-1/45-next-steps/test/TestNextSteps.al
+++ b/tests/bucket-1/45-next-steps/test/TestNextSteps.al
@@ -1,0 +1,142 @@
+codeunit 54800 "Test Next Steps"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    [Test]
+    procedure NextOneMovesToNextRecord()
+    var
+        Rec: Record "Next Probe";
+        Steps: Integer;
+    begin
+        Seed();
+        Rec.FindFirst();
+        Assert.AreEqual('A', Rec."No.", 'Precondition: first record is A');
+
+        Steps := Rec.Next(1);
+        Assert.AreEqual(1, Steps, 'Next(1) should return 1');
+        Assert.AreEqual('B', Rec."No.", 'After Next(1) should be at B');
+    end;
+
+    [Test]
+    procedure NextSkipsNRecords()
+    var
+        Rec: Record "Next Probe";
+        Steps: Integer;
+    begin
+        Seed();
+        Rec.FindFirst();
+        Steps := Rec.Next(2);
+        Assert.AreEqual(2, Steps, 'Next(2) should return 2');
+        Assert.AreEqual('C', Rec."No.", 'After Next(2) from A should be at C');
+    end;
+
+    [Test]
+    procedure NextPastEndReturnsFewerSteps()
+    var
+        Rec: Record "Next Probe";
+        Steps: Integer;
+    begin
+        // Negative/boundary: asking for more steps than remain returns actual moves.
+        Seed();
+        Rec.FindFirst();
+        Rec.Next(3);
+        Assert.AreEqual('D', Rec."No.", 'Precondition: at D (4th)');
+
+        Steps := Rec.Next(10);
+        Assert.AreEqual(1, Steps,
+            'From D with 5 rows total, only one step remains (to E)');
+        Assert.AreEqual('E', Rec."No.", 'Cursor lands on E');
+    end;
+
+    [Test]
+    procedure NextAtEndReturnsZero()
+    var
+        Rec: Record "Next Probe";
+    begin
+        // Negative: at last record, Next returns 0.
+        Seed();
+        Rec.FindLast();
+        Assert.AreEqual('E', Rec."No.", 'Precondition: at E');
+        Assert.AreEqual(0, Rec.Next(1),
+            'Next(1) at end must return 0');
+    end;
+
+    [Test]
+    procedure NextBackwardMovesReverse()
+    var
+        Rec: Record "Next Probe";
+        Steps: Integer;
+    begin
+        // Positive: negative step count moves backward.
+        Seed();
+        Rec.FindLast();
+        Assert.AreEqual('E', Rec."No.", 'Precondition: at E');
+
+        Steps := Rec.Next(-2);
+        Assert.AreEqual(-2, Steps, 'Next(-2) should return -2');
+        Assert.AreEqual('C', Rec."No.", 'After Next(-2) from E should be at C');
+    end;
+
+    [Test]
+    procedure NextBackwardPastStartReturnsFewer()
+    var
+        Rec: Record "Next Probe";
+        Steps: Integer;
+    begin
+        // Negative/boundary: asking to go before first returns what's possible.
+        Seed();
+        Rec.FindFirst();
+        Rec.Next(1);
+        Assert.AreEqual('B', Rec."No.", 'Precondition: at B');
+
+        Steps := Rec.Next(-5);
+        Assert.AreEqual(-1, Steps,
+            'From B with only 1 row before, Next(-5) should return -1');
+        Assert.AreEqual('A', Rec."No.", 'Cursor lands on A');
+    end;
+
+    [Test]
+    procedure NextHonoursFilter()
+    var
+        Rec: Record "Next Probe";
+    begin
+        // Positive: Next advances within the filtered result set.
+        Seed();
+        Rec.SetRange(Status, 1);  // A, C, E
+        Rec.FindFirst();
+        Assert.AreEqual('A', Rec."No.", 'First Status=1 row is A');
+
+        Rec.Next(1);
+        Assert.AreEqual('C', Rec."No.",
+            'Within Status=1 filter, Next(1) should skip B and land on C');
+        Rec.Next(1);
+        Assert.AreEqual('E', Rec."No.",
+            'Within Status=1 filter, next should be E');
+        Assert.AreEqual(0, Rec.Next(1),
+            'No more filtered rows after E');
+    end;
+
+    local procedure Seed()
+    var
+        Rec: Record "Next Probe";
+    begin
+        Insert2('A', 1);
+        Insert2('B', 2);
+        Insert2('C', 1);
+        Insert2('D', 2);
+        Insert2('E', 1);
+    end;
+
+    local procedure Insert2("No.": Code[20]; Status: Integer)
+    var
+        Rec: Record "Next Probe";
+    begin
+        Rec.Init();
+        Rec."No." := "No.";
+        Rec.Status := Status;
+        Rec.Insert(true);
+    end;
+}


### PR DESCRIPTION
Closes #262

## Summary
- Adds `MockRecordHandle.ALNext(int steps)` (previously only the parameterless `ALNext()` existed). BC's `Rec.Next(Steps)` moves forward for positive steps, backward for negative, and returns the signed number of steps actually moved — clamped to the remaining records at either end.
- Integrates with existing cursor/filter state (operates on `_currentResultSet`), so it naturally honours active filters.
- `RoslynRewriter` delegates `ALNext(int)` on `RecordBase`.
- Adds `tests/bucket-1/45-next-steps` with seven proving tests:
  - `Next(1)` → 'B' (from 'A')
  - `Next(2)` → 'C'
  - Past end: `Next(10)` from 'D' returns 1, lands on 'E'
  - At end: `Next(1)` at 'E' returns 0
  - `Next(-2)` from 'E' returns -2, lands on 'C'
  - Past start: `Next(-5)` from 'B' returns -1, lands on 'A'
  - Filter honoured: with `SetRange(Status, 1)`, `Next(1)` skips the non-matching row
- RED confirmed by pre-implementation compile error (`CS1501: No overload for method 'ALNext' takes 1 arguments`).
- Coverage map: `Table.Next` moved from `gap` to `covered`.

## Test plan
- [x] New suite passes (7/7)
- [x] Bucket-1 regression clean (270 passed; only pre-existing `TestBuildGreeting` / `TestBuildList` remain)

🤖 Generated with [Claude Code](https://claude.com/claude-code)