### PR TITLE
test: Count with SetFilter expressions coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to this project are documented here. Format based on
 ## [Unreleased]
 
 ### Added
+- **Record.Count with SetFilter expressions coverage (#260)** — `Count` with
+  SetFilter comparators / OR-lists / range expressions was already honoured
+  in `MockRecordHandle.ALCount` but had no dedicated proving test. New suite
+  `tests/bucket-1/46-count-setfilter` covers `'>1'`, `'<2'`, `'<>2'`,
+  `'1|3'`, `'2..3'`, no-match (0), and restoration after `Reset`. RED
+  confirmed by pointing `ALCount` at the unfiltered row list.
 - **`Record.Next(Steps)` overload (#262)** — `MockRecordHandle.ALNext(int)` is
   new (previously only the parameterless `ALNext()` existed). Positive steps
   move forward, negative steps move backward, and the return value is the

--- a/tests/bucket-1/45-next-steps/src/NextStepsTable.al
+++ b/tests/bucket-1/45-next-steps/src/NextStepsTable.al
@@ -1,4 +1,4 @@
-table 54800 "Next Probe"
+table 54802 "Next Probe"
 {
     DataClassification = CustomerContent;
 

--- a/tests/bucket-1/45-next-steps/test/TestNextSteps.al
+++ b/tests/bucket-1/45-next-steps/test/TestNextSteps.al
@@ -1,4 +1,4 @@
-codeunit 54800 "Test Next Steps"
+codeunit 54802 "Test Next Steps"
 {
     Subtype = Test;
 

--- a/tests/bucket-1/46-count-setfilter/src/CountSFProbe.al
+++ b/tests/bucket-1/46-count-setfilter/src/CountSFProbe.al
@@ -1,0 +1,15 @@
+table 54900 "CountSF Probe"
+{
+    DataClassification = CustomerContent;
+
+    fields
+    {
+        field(1; "No."; Code[20]) { }
+        field(2; "Status"; Integer) { }
+    }
+
+    keys
+    {
+        key(PK; "No.") { Clustered = true; }
+    }
+}

--- a/tests/bucket-1/46-count-setfilter/test/TestCountSetFilter.al
+++ b/tests/bucket-1/46-count-setfilter/test/TestCountSetFilter.al
@@ -1,0 +1,115 @@
+codeunit 54900 "Test Count SetFilter"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    [Test]
+    procedure CountWithGreaterThanFilter()
+    var
+        Rec: Record "CountSF Probe";
+    begin
+        // Positive: '>' comparator filter.
+        Seed();
+        Rec.SetFilter(Status, '>1');
+        Assert.AreEqual(3, Rec.Count,
+            'Status>1 matches 2,2,3 — expect 3');
+    end;
+
+    [Test]
+    procedure CountWithLessThanFilter()
+    var
+        Rec: Record "CountSF Probe";
+    begin
+        // Positive: '<' comparator filter.
+        Seed();
+        Rec.SetFilter(Status, '<2');
+        Assert.AreEqual(2, Rec.Count,
+            'Status<2 matches two 1s — expect 2');
+    end;
+
+    [Test]
+    procedure CountWithNotEqualFilter()
+    var
+        Rec: Record "CountSF Probe";
+    begin
+        // Positive: '<>' filter.
+        Seed();
+        Rec.SetFilter(Status, '<>2');
+        Assert.AreEqual(3, Rec.Count,
+            'Status<>2 matches 1,1,3 — expect 3');
+    end;
+
+    [Test]
+    procedure CountWithOrFilter()
+    var
+        Rec: Record "CountSF Probe";
+    begin
+        // Positive: 'a|b' OR-list filter.
+        Seed();
+        Rec.SetFilter(Status, '1|3');
+        Assert.AreEqual(3, Rec.Count,
+            'Status in {1,3} matches 1,1,3 — expect 3');
+    end;
+
+    [Test]
+    procedure CountWithRangeExpressionFilter()
+    var
+        Rec: Record "CountSF Probe";
+    begin
+        // Positive: 'a..b' range expression.
+        Seed();
+        Rec.SetFilter(Status, '2..3');
+        Assert.AreEqual(3, Rec.Count,
+            'Status in 2..3 matches 2,2,3 — expect 3');
+    end;
+
+    [Test]
+    procedure CountWithNoMatchingFilter()
+    var
+        Rec: Record "CountSF Probe";
+    begin
+        // Negative: filter that matches nothing.
+        Seed();
+        Rec.SetFilter(Status, '>99');
+        Assert.AreEqual(0, Rec.Count,
+            'Filter matching nothing must produce Count 0');
+    end;
+
+    [Test]
+    procedure CountRestoredAfterReset()
+    var
+        Rec: Record "CountSF Probe";
+    begin
+        // Positive/reset: Reset returns to the full table count.
+        Seed();
+        Rec.SetFilter(Status, '>1');
+        Assert.AreEqual(3, Rec.Count, 'Precondition: filtered count is 3');
+
+        Rec.Reset();
+        Assert.AreEqual(5, Rec.Count,
+            'After Reset, Count must be the full 5');
+    end;
+
+    local procedure Seed()
+    var
+        Rec: Record "CountSF Probe";
+    begin
+        Insert2('A', 1);
+        Insert2('B', 2);
+        Insert2('C', 1);
+        Insert2('D', 2);
+        Insert2('E', 3);
+    end;
+
+    local procedure Insert2("No.": Code[20]; Status: Integer)
+    var
+        Rec: Record "CountSF Probe";
+    begin
+        Rec.Init();
+        Rec."No." := "No.";
+        Rec.Status := Status;
+        Rec.Insert(true);
+    end;
+}


### PR DESCRIPTION
Closes #260

## Summary
- `MockRecordHandle.ALCount` already honoured `SetFilter` comparators (`>`, `<`, `<>`), OR-lists (`a|b`), and range expressions (`a..b`), but had no dedicated proving test.
- Adds `tests/bucket-1/46-count-setfilter` with seven proving tests:
  - `>1` → 3
  - `<2` → 2
  - `<>2` → 3
  - `1|3` → 3
  - `2..3` → 3
  - no-match (`>99`) → 0
  - `Reset()` restores full count (5)
- RED confirmed by stubbing `ALCount` to return the unfiltered row list — all 7 failed, then restored.

## Test plan
- [x] New suite passes (7/7)
- [x] RED proven before restoring

🤖 Generated with [Claude Code](https://claude.com/claude-code)