### PR TITLE
test: Record.SetCurrentKey traversal-order coverage (#264)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,13 @@ All notable changes to this project are documented here. Format based on
   filter (`Amount` in 20..40). RED confirmed by temporarily pointing
   `ALCount` at the unfiltered row count. Coverage map: `Table.Count` moved
   from `gap` to `covered`.
+- **`Record.SetCurrentKey` traversal-order coverage (#264)** — sort-order
+  behavior was implemented in `MockRecordHandle` but had no proving tests for
+  FindSet/Next traversal. Extended `tests/bucket-2/109-currentkey` with 5 new
+  tests: SetCurrentKey by Name changes traversal order, SetCurrentKey by
+  Sequence changes traversal order, resetting to primary key restores PK order,
+  Name sort does not traverse in PK order (negative), and descending sort
+  reverses traversal order.
 - **Test coverage: `Record.IsTemporary()` (#254)** — `MockRecordHandle.ALIsTemporary`
   was already implemented; new suite `tests/bucket-1/254-record-istemporary`
   adds 5 proving tests: normal Record → false, `temporary` Record → true,

--- a/tests/bucket-2/109-currentkey/test/CurrentKeyTests.al
+++ b/tests/bucket-2/109-currentkey/test/CurrentKeyTests.al
@@ -67,4 +67,134 @@ codeunit 50809 "CurrentKey Tests"
         // [WHEN/THEN] Ascending should return false
         Assert.IsFalse(Rec.Ascending(), 'Ascending should return false after SetAscending(false)');
     end;
+
+    // -----------------------------------------------------------------------
+    // SetCurrentKey traversal — positive tests
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure SetCurrentKeyByNameChangesTraversalOrder()
+    var
+        Rec: Record "Key Probe";
+    begin
+        // [GIVEN] Records inserted in PK (Code) order: AAA/Zoe, BBB/Anna, CCC/Mike
+        InsertKeyProbe('AAA', 'Zoe', 3);
+        InsertKeyProbe('BBB', 'Anna', 1);
+        InsertKeyProbe('CCC', 'Mike', 2);
+
+        // [WHEN] SetCurrentKey by Name and FindSet
+        Rec.SetCurrentKey("Name");
+        Rec.FindSet();
+
+        // [THEN] First record is Anna (alphabetically first), not Zoe (PK-first)
+        Assert.AreEqual('Anna', Rec."Name", 'First record by Name should be Anna');
+        Rec.Next();
+        Assert.AreEqual('Mike', Rec."Name", 'Second record by Name should be Mike');
+        Rec.Next();
+        Assert.AreEqual('Zoe', Rec."Name", 'Third record by Name should be Zoe');
+    end;
+
+    [Test]
+    procedure SetCurrentKeyBySequenceChangesTraversalOrder()
+    var
+        Rec: Record "Key Probe";
+    begin
+        // [GIVEN] Records inserted in PK order: P1/Seq=30, P2/Seq=10, P3/Seq=20
+        InsertKeyProbe('P1', 'Beta', 30);
+        InsertKeyProbe('P2', 'Alpha', 10);
+        InsertKeyProbe('P3', 'Gamma', 20);
+
+        // [WHEN] SetCurrentKey by Sequence ascending and FindSet
+        Rec.SetCurrentKey("Sequence");
+        Rec.SetAscending("Sequence", true);
+        Rec.FindSet();
+
+        // [THEN] Records traverse in Sequence order: 10, 20, 30
+        Assert.AreEqual(10, Rec."Sequence", 'First by Sequence should be 10');
+        Rec.Next();
+        Assert.AreEqual(20, Rec."Sequence", 'Second by Sequence should be 20');
+        Rec.Next();
+        Assert.AreEqual(30, Rec."Sequence", 'Third by Sequence should be 30');
+    end;
+
+    [Test]
+    procedure ResettingToPrimaryKeyRestoresPKOrder()
+    var
+        Rec: Record "Key Probe";
+    begin
+        // [GIVEN] Records inserted out of PK order intent: CCC, AAA, BBB
+        InsertKeyProbe('CCC', 'Zara', 3);
+        InsertKeyProbe('AAA', 'Anna', 1);
+        InsertKeyProbe('BBB', 'Mike', 2);
+
+        // [WHEN] First sort by Name (changes order), then reset to PK (Code)
+        Rec.SetCurrentKey("Name");
+        Rec.SetCurrentKey("Code");
+        Rec.FindSet();
+
+        // [THEN] Traversal is in PK (Code) order: AAA, BBB, CCC
+        Assert.AreEqual('AAA', Rec."Code", 'First by Code PK should be AAA');
+        Rec.Next();
+        Assert.AreEqual('BBB', Rec."Code", 'Second by Code PK should be BBB');
+        Rec.Next();
+        Assert.AreEqual('CCC', Rec."Code", 'Third by Code PK should be CCC');
+    end;
+
+    // -----------------------------------------------------------------------
+    // SetCurrentKey traversal — negative tests
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure SetCurrentKeyByNameDoesNotTraverseInPKOrder()
+    var
+        Rec: Record "Key Probe";
+        FirstCode: Code[20];
+    begin
+        // [GIVEN] Records where Name-order differs from PK order: X1/Bob, X2/Alice
+        InsertKeyProbe('X1', 'Bob', 2);
+        InsertKeyProbe('X2', 'Alice', 1);
+
+        // [WHEN] SetCurrentKey by Name and read the first record
+        Rec.SetCurrentKey("Name");
+        Rec.FindFirst();
+        FirstCode := Rec."Code";
+
+        // [THEN] First record by Name is X2 (Alice), NOT X1 (PK-first order)
+        Assert.AreEqual('X2', FirstCode, 'Name sort should return X2 (Alice) first, not X1 (Bob)');
+        Assert.AreNotEqual('X1', FirstCode, 'PK-order record X1 should NOT be first when sorted by Name');
+    end;
+
+    [Test]
+    procedure SetCurrentKeyDescendingReversesOrder()
+    var
+        Rec: Record "Key Probe";
+    begin
+        // [GIVEN] Records: D1/Seq=5, D2/Seq=15, D3/Seq=10
+        InsertKeyProbe('D1', 'Alpha', 5);
+        InsertKeyProbe('D2', 'Beta', 15);
+        InsertKeyProbe('D3', 'Gamma', 10);
+
+        // [WHEN] SetCurrentKey by Sequence descending
+        Rec.SetCurrentKey("Sequence");
+        Rec.SetAscending("Sequence", false);
+        Rec.FindSet();
+
+        // [THEN] First record has the HIGHEST Sequence (15), not the lowest
+        Assert.AreEqual(15, Rec."Sequence", 'Descending: first should be Sequence=15');
+        Rec.Next();
+        Assert.AreEqual(10, Rec."Sequence", 'Descending: second should be Sequence=10');
+        Rec.Next();
+        Assert.AreEqual(5, Rec."Sequence", 'Descending: third should be Sequence=5');
+    end;
+
+    local procedure InsertKeyProbe(Code: Code[20]; Name: Text[100]; Sequence: Integer)
+    var
+        Rec: Record "Key Probe";
+    begin
+        Rec.Init();
+        Rec."Code" := Code;
+        Rec."Name" := Name;
+        Rec."Sequence" := Sequence;
+        Rec.Insert();
+    end;
 }


### PR DESCRIPTION
Closes #264

## Summary

Extends the existing `109-currentkey` test suite with 5 proving tests that verify `Record.SetCurrentKey` actually changes FindSet/Next traversal order — not just that the API compiles.

### Tests added

| Test | What it proves |
|------|---------------|
| `SetCurrentKeyByNameChangesTraversalOrder` | FindSet/Next traverses in Name (alphabetical) order, not insertion/PK order |
| `SetCurrentKeyBySequenceChangesTraversalOrder` | FindSet/Next traverses in Sequence (numeric) order ascending |
| `ResettingToPrimaryKeyRestoresPKOrder` | After switching to Name key then back to Code, traversal reverts to PK order |
| `SetCurrentKeyByNameDoesNotTraverseInPKOrder` | Negative: first record by Name is NOT the PK-first record |
| `SetCurrentKeyDescendingReversesOrder` | Descending sort produces reversed traversal order |

Each test inserts records in an order that would differ from the sorted order, then asserts specific expected field values at each `Next()` step — proving the mock, not just that it compiles.