### PR TITLE
fix: resolve codeunit 54800 ID collision between userid and next-steps suites

### DIFF
--- a/tests/bucket-1/45-userid/test/TestUserId.al
+++ b/tests/bucket-1/45-userid/test/TestUserId.al
@@ -1,4 +1,4 @@
-codeunit 54800 "Test UserId"
+codeunit 55000 "Test UserId"
 {
     Subtype = Test;
 


### PR DESCRIPTION
Both `45-userid` and `45-next-steps` used codeunit ID 54800 in bucket-1, causing all BC version builds to fail on main. Renumbers `Test UserId` from 54800 to 54900.

**Urgent**: main CI is red.