### PR TITLE
test: Enum.Names / Enum.Ordinals full coverage (#271)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ All notable changes to this project are documented here. Format based on
   and descending Name order via `SetAscending`. RED confirmed by temporarily
   setting `if (false && _currentKeyFields ...)` — all four new tests fail.
   Coverage map: `Table.SetCurrentKey` moved from `gap` to `covered`.
+- **`Enum.Names` / `Enum.Ordinals` coverage (#271)** — both were `status: gap`
+  in coverage.yaml despite having basic suites. Extended `tests/bucket-2/61-enum-names`
+  with 4 new proving tests: second/third name by index, `Contains` positive, type-qualifier
+  syntax (`Enum::"T".Names()`), and 2 negative tests (unknown name not contained,
+  count ≠ 2). Extended `tests/bucket-2/50-enum-ordinals` with 6 new proving tests:
+  all 4 ordinals by index, `Contains` positive, instance-variable syntax, and 2 negative
+  tests (ordinal 9 not contained, count ≠ 3). Coverage map: `EnumType.Names` and
+  `EnumType.Ordinals` moved from `gap` to `covered`.
 - **Record.Count with SetFilter expressions coverage (#260)** — `Count` with
   SetFilter comparators / OR-lists / range expressions was already honoured
   in `MockRecordHandle.ALCount` but had no dedicated proving test. New suite

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -1802,14 +1802,18 @@ EnumType.FromInteger:
 EnumType.Names:
   layer: runtime-api
   category: EnumType
-  status: gap
-  notes: overloads=2
+  status: covered
+  notes: overloads=2 (instance E.Names() and type-qualifier Enum::"T".Names())
+  tests:
+    - tests/bucket-2/61-enum-names
 
 EnumType.Ordinals:
   layer: runtime-api
   category: EnumType
-  status: gap
-  notes: overloads=2
+  status: covered
+  notes: overloads=2 (instance E.Ordinals() and type-qualifier Enum::"T".Ordinals())
+  tests:
+    - tests/bucket-2/50-enum-ordinals
 
 # ── ErrorInfo ───────────────────────────────────────────────────
 

--- a/tests/bucket-2/50-enum-ordinals/src/Status.al
+++ b/tests/bucket-2/50-enum-ordinals/src/Status.al
@@ -24,4 +24,46 @@ codeunit 56500 "EO Inspector"
         Ordinals := Enum::"EO Status".Ordinals();
         exit(Ordinals.Get(1));
     end;
+
+    procedure SecondOrdinal(): Integer
+    var
+        Ordinals: List of [Integer];
+    begin
+        Ordinals := Enum::"EO Status".Ordinals();
+        exit(Ordinals.Get(2));
+    end;
+
+    procedure ThirdOrdinal(): Integer
+    var
+        Ordinals: List of [Integer];
+    begin
+        Ordinals := Enum::"EO Status".Ordinals();
+        exit(Ordinals.Get(3));
+    end;
+
+    procedure FourthOrdinal(): Integer
+    var
+        Ordinals: List of [Integer];
+    begin
+        Ordinals := Enum::"EO Status".Ordinals();
+        exit(Ordinals.Get(4));
+    end;
+
+    procedure OrdinalsContains(Ordinal: Integer): Boolean
+    var
+        Ordinals: List of [Integer];
+    begin
+        Ordinals := Enum::"EO Status".Ordinals();
+        exit(Ordinals.Contains(Ordinal));
+    end;
+
+    procedure OrdinalsInstanceSyntaxCount(): Integer
+    var
+        E: Enum "EO Status";
+        Ordinals: List of [Integer];
+    begin
+        // Verify instance-variable syntax also works
+        Ordinals := E.Ordinals();
+        exit(Ordinals.Count);
+    end;
 }

--- a/tests/bucket-2/50-enum-ordinals/test/StatusTest.al
+++ b/tests/bucket-2/50-enum-ordinals/test/StatusTest.al
@@ -5,6 +5,10 @@ codeunit 56501 "EO Status Tests"
     var
         Assert: Codeunit Assert;
 
+    // -----------------------------------------------------------------------
+    // Enum.Ordinals — positive tests
+    // -----------------------------------------------------------------------
+
     [Test]
     procedure OrdinalsReturnsFourValues()
     var
@@ -22,5 +26,73 @@ codeunit 56501 "EO Status Tests"
     begin
         // First declared ordinal is 0 (the empty member)
         Assert.AreEqual(0, Inspector.FirstOrdinal(), 'First ordinal should be 0');
+    end;
+
+    [Test]
+    procedure SecondOrdinalIsOne()
+    var
+        Inspector: Codeunit "EO Inspector";
+    begin
+        // [GIVEN] EO Status has: " "(0), Open(1), Closed(2), Archived(3)
+        // [THEN] Second ordinal is 1 (Open)
+        Assert.AreEqual(1, Inspector.SecondOrdinal(), 'Second ordinal should be 1 (Open)');
+    end;
+
+    [Test]
+    procedure ThirdOrdinalIsTwo()
+    var
+        Inspector: Codeunit "EO Inspector";
+    begin
+        Assert.AreEqual(2, Inspector.ThirdOrdinal(), 'Third ordinal should be 2 (Closed)');
+    end;
+
+    [Test]
+    procedure FourthOrdinalIsThree()
+    var
+        Inspector: Codeunit "EO Inspector";
+    begin
+        Assert.AreEqual(3, Inspector.FourthOrdinal(), 'Fourth ordinal should be 3 (Archived)');
+    end;
+
+    [Test]
+    procedure OrdinalsContainsTwo()
+    var
+        Inspector: Codeunit "EO Inspector";
+    begin
+        // [GIVEN] Closed has ordinal 2
+        // [THEN] Ordinals().Contains(2) is true
+        Assert.IsTrue(Inspector.OrdinalsContains(2), 'Ordinals should contain 2 (Closed)');
+    end;
+
+    [Test]
+    procedure OrdinalsInstanceSyntaxReturnsSameCount()
+    var
+        Inspector: Codeunit "EO Inspector";
+    begin
+        // Verify that instance-variable syntax E.Ordinals() gives same result
+        Assert.AreEqual(4, Inspector.OrdinalsInstanceSyntaxCount(), 'Instance syntax should also return 4 ordinals');
+    end;
+
+    // -----------------------------------------------------------------------
+    // Enum.Ordinals — negative tests
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure OrdinalsDoesNotContainNine()
+    var
+        Inspector: Codeunit "EO Inspector";
+    begin
+        // [GIVEN] 9 is not a declared ordinal of EO Status
+        // [THEN] Ordinals().Contains(9) returns false
+        Assert.IsFalse(Inspector.OrdinalsContains(9), 'Ordinals should not contain 9');
+    end;
+
+    [Test]
+    procedure OrdinalsCountIsNotThree()
+    var
+        Inspector: Codeunit "EO Inspector";
+    begin
+        // A no-op returning a short list would fail this
+        Assert.AreNotEqual(3, Inspector.CountOrdinals(), 'Count must not be 3 — EO Status has exactly 4 members');
     end;
 }

--- a/tests/bucket-2/61-enum-names/src/Probe.al
+++ b/tests/bucket-2/61-enum-names/src/Probe.al
@@ -27,4 +27,40 @@ codeunit 56610 "EN Probe"
         Names := E.Names();
         exit(Names.Get(1));
     end;
+
+    procedure NamesSecond(): Text
+    var
+        E: Enum "EN Stage";
+        Names: List of [Text];
+    begin
+        Names := Enum::"EN Stage".Names();
+        exit(Names.Get(2));
+    end;
+
+    procedure NamesThird(): Text
+    var
+        E: Enum "EN Stage";
+        Names: List of [Text];
+    begin
+        Names := Enum::"EN Stage".Names();
+        exit(Names.Get(3));
+    end;
+
+    procedure NamesContains(SearchName: Text): Boolean
+    var
+        E: Enum "EN Stage";
+        Names: List of [Text];
+    begin
+        Names := E.Names();
+        exit(Names.Contains(SearchName));
+    end;
+
+    procedure NamesTypeQualifierCount(): Integer
+    var
+        Names: List of [Text];
+    begin
+        // Verify static type-qualifier syntax Enum::"EN Stage".Names() also works
+        Names := Enum::"EN Stage".Names();
+        exit(Names.Count);
+    end;
 }

--- a/tests/bucket-2/61-enum-names/test/ProbeTest.al
+++ b/tests/bucket-2/61-enum-names/test/ProbeTest.al
@@ -4,6 +4,10 @@ codeunit 56611 "EN Tests"
     var
         Assert: Codeunit Assert;
 
+    // -----------------------------------------------------------------------
+    // Enum.Names — positive tests
+    // -----------------------------------------------------------------------
+
     [Test]
     procedure EnumNamesReturnsThree()
     var
@@ -18,5 +22,67 @@ codeunit 56611 "EN Tests"
         Probe: Codeunit "EN Probe";
     begin
         Assert.AreEqual('Draft', Probe.NamesFirst(), 'First declared member is Draft');
+    end;
+
+    [Test]
+    procedure EnumNamesSecondIsReview()
+    var
+        Probe: Codeunit "EN Probe";
+    begin
+        // [GIVEN] EN Stage has Draft(0), Review(1), Published(2)
+        // [WHEN] Names() is called and second element read
+        // [THEN] Second element is 'Review'
+        Assert.AreEqual('Review', Probe.NamesSecond(), 'Second declared member is Review');
+    end;
+
+    [Test]
+    procedure EnumNamesThirdIsPublished()
+    var
+        Probe: Codeunit "EN Probe";
+    begin
+        Assert.AreEqual('Published', Probe.NamesThird(), 'Third declared member is Published');
+    end;
+
+    [Test]
+    procedure EnumNamesContainsDraft()
+    var
+        Probe: Codeunit "EN Probe";
+    begin
+        // [GIVEN] Draft is a declared member of EN Stage
+        // [THEN] Names().Contains('Draft') returns true
+        Assert.IsTrue(Probe.NamesContains('Draft'), 'Names should contain Draft');
+    end;
+
+    [Test]
+    procedure EnumNamesTypeQualifierSyntaxWorks()
+    var
+        Probe: Codeunit "EN Probe";
+    begin
+        // [GIVEN] Enum::"EN Stage".Names() (static type-qualifier form)
+        // [THEN] Returns same count as instance form
+        Assert.AreEqual(3, Probe.NamesTypeQualifierCount(), 'Type-qualifier syntax should return 3 names');
+    end;
+
+    // -----------------------------------------------------------------------
+    // Enum.Names — negative tests
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure EnumNamesDoesNotContainUnknownMember()
+    var
+        Probe: Codeunit "EN Probe";
+    begin
+        // [GIVEN] 'Approved' is not a member of EN Stage
+        // [THEN] Names().Contains('Approved') returns false
+        Assert.IsFalse(Probe.NamesContains('Approved'), 'Names should not contain Approved');
+    end;
+
+    [Test]
+    procedure EnumNamesCountIsNotTwo()
+    var
+        Probe: Codeunit "EN Probe";
+    begin
+        // A no-op implementation returning an empty/short list would fail this
+        Assert.AreNotEqual(2, Probe.NamesCount(), 'Count must not be 2 — EN Stage has exactly 3 members');
     end;
 }


### PR DESCRIPTION
Closes #271

## Summary

Both `EnumType.Names` and `EnumType.Ordinals` were marked `status: gap` in `docs/coverage.yaml` despite having basic suites — those suites only tested count and first element, and had no negative tests.

### Changes

**`tests/bucket-2/61-enum-names`** — 6 new tests added:
- `EnumNamesSecondIsReview` — second element by index
- `EnumNamesThirdIsPublished` — third element by index  
- `EnumNamesContainsDraft` — `Contains` positive
- `EnumNamesTypeQualifierSyntaxWorks` — proves `Enum::"T".Names()` (type-qualifier overload)
- `EnumNamesDoesNotContainUnknownMember` — negative: unknown name not in list
- `EnumNamesCountIsNotTwo` — negative: count ≠ 2 (catches truncated implementations)

**`tests/bucket-2/50-enum-ordinals`** — 7 new tests added:
- `SecondOrdinalIsOne`, `ThirdOrdinalIsTwo`, `FourthOrdinalIsThree` — full list traversal
- `OrdinalsContainsTwo` — `Contains` positive
- `OrdinalsInstanceSyntaxReturnsSameCount` — proves `E.Ordinals()` (instance-variable overload)
- `OrdinalsDoesNotContainNine` — negative: non-existent ordinal not in list
- `OrdinalsCountIsNotThree` — negative: count ≠ 3 (catches truncated implementations)

**`docs/coverage.yaml`** — `EnumType.Names` and `EnumType.Ordinals` moved from `gap` to `covered`, both overloads noted.

**`CHANGELOG.md`** — entry added under `[Unreleased]`.