### PR TITLE
test: Record.Get proving tests — retrieve by primary key (#275)

### DIFF
--- a/AlRunner.Tests/PipelineTests.cs
+++ b/AlRunner.Tests/PipelineTests.cs
@@ -524,4 +524,17 @@ namespace AlRunnerGenerated {
         Assert.True(result.Passed > 0);
         Assert.Equal(0, result.Failed);
     }
+
+    [Fact]
+    public void RecordGet_RetrievesByPrimaryKey()
+    {
+        var pipeline = new AlRunnerPipeline();
+        var result = pipeline.Run(new PipelineOptions
+        {
+            InputPaths = { TestPath("48-record-get", "src"), TestPath("48-record-get", "test") }
+        });
+        Assert.Equal(0, result.ExitCode);
+        Assert.True(result.Passed > 0);
+        Assert.Equal(0, result.Failed);
+    }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@ All notable changes to this project are documented here. Format based on
   all 4 ordinals by index, `Contains` positive, instance-variable syntax, and 2 negative
   tests (ordinal 9 not contained, count ≠ 3). Coverage map: `EnumType.Names` and
   `EnumType.Ordinals` moved from `gap` to `covered`.
+- **Test coverage: `Record.Get` by primary key (#275)** — `MockRecordHandle.ALGet` was
+  already implemented; new suite `tests/bucket-1/48-record-get` adds 6 proving tests:
+  single-key Get retrieves correct record, Get returns true on match, Get on missing key
+  throws "not found" error, Get distinguishes between different keys, composite PK Get
+  loads the correct row, and composite-key not-found also errors correctly.
 - **Record.Count with SetFilter expressions coverage (#260)** — `Count` with
   SetFilter comparators / OR-lists / range expressions was already honoured
   in `MockRecordHandle.ALCount` but had no dedicated proving test. New suite

--- a/tests/bucket-1/48-record-get/src/RecordGetTable.al
+++ b/tests/bucket-1/48-record-get/src/RecordGetTable.al
@@ -1,0 +1,33 @@
+table 55200 "Record Get Table"
+{
+    DataClassification = CustomerContent;
+
+    fields
+    {
+        field(1; Code; Code[20]) { }
+        field(2; Description; Text[50]) { }
+        field(3; Quantity; Integer) { }
+    }
+
+    keys
+    {
+        key(PK; Code) { Clustered = true; }
+    }
+}
+
+table 55210 "Record Get Composite"
+{
+    DataClassification = CustomerContent;
+
+    fields
+    {
+        field(1; CompanyNo; Code[10]) { }
+        field(2; EntryNo; Integer) { }
+        field(3; Amount; Decimal) { }
+    }
+
+    keys
+    {
+        key(PK; CompanyNo, EntryNo) { Clustered = true; }
+    }
+}

--- a/tests/bucket-1/48-record-get/test/TestRecordGet.al
+++ b/tests/bucket-1/48-record-get/test/TestRecordGet.al
@@ -1,0 +1,108 @@
+codeunit 55201 "Test Record Get"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    [Test]
+    procedure GetRetrievesRecordByPrimaryKey()
+    var
+        Rec: Record "Record Get Table";
+    begin
+        // Insert a record, then Get it by PK — must load the correct row
+        Rec.Init();
+        Rec.Code := 'ABC';
+        Rec.Description := 'Test Record';
+        Rec.Quantity := 42;
+        Rec.Insert();
+
+        Clear(Rec);
+        Rec.Get('ABC');
+        Assert.AreEqual('ABC', Rec.Code, 'Code must match inserted value');
+        Assert.AreEqual('Test Record', Rec.Description, 'Description must match');
+        Assert.AreEqual(42, Rec.Quantity, 'Quantity must match');
+    end;
+
+    [Test]
+    procedure GetReturnsTrueWhenRecordExists()
+    var
+        Rec: Record "Record Get Table";
+        Found: Boolean;
+    begin
+        Rec.Init();
+        Rec.Code := 'EXIST';
+        Rec.Insert();
+
+        Found := Rec.Get('EXIST');
+        Assert.AreEqual(true, Found, 'Get must return true when record exists');
+    end;
+
+    [Test]
+    procedure GetWithNonExistentKeyErrors()
+    var
+        Rec: Record "Record Get Table";
+    begin
+        // Get on a key that was never inserted must throw
+        asserterror Rec.Get('NONEXIST');
+        Assert.ExpectedError('not found');
+    end;
+
+    [Test]
+    procedure GetDistinguishesBetweenDifferentKeys()
+    var
+        Rec: Record "Record Get Table";
+    begin
+        // Insert two records, Get should load the one matching the key
+        Rec.Init();
+        Rec.Code := 'A';
+        Rec.Description := 'Alpha';
+        Rec.Insert();
+
+        Rec.Init();
+        Rec.Code := 'B';
+        Rec.Description := 'Beta';
+        Rec.Insert();
+
+        Rec.Get('A');
+        Assert.AreEqual('Alpha', Rec.Description, 'Get(A) must return Alpha record');
+
+        Rec.Get('B');
+        Assert.AreEqual('Beta', Rec.Description, 'Get(B) must return Beta record');
+    end;
+
+    [Test]
+    procedure GetWithCompositePrimaryKey()
+    var
+        Rec: Record "Record Get Composite";
+    begin
+        // Composite PK: (CompanyNo, EntryNo)
+        Rec.Init();
+        Rec."CompanyNo" := 'COMP1';
+        Rec."EntryNo" := 10;
+        Rec.Amount := 100.0;
+        Rec.Insert();
+
+        Rec.Init();
+        Rec."CompanyNo" := 'COMP1';
+        Rec."EntryNo" := 20;
+        Rec.Amount := 200.0;
+        Rec.Insert();
+
+        Clear(Rec);
+        Rec.Get('COMP1', 10);
+        Assert.AreEqual(100.0, Rec.Amount, 'Get(COMP1,10) must return Amount=100');
+
+        Rec.Get('COMP1', 20);
+        Assert.AreEqual(200.0, Rec.Amount, 'Get(COMP1,20) must return Amount=200');
+    end;
+
+    [Test]
+    procedure GetWithCompositeKeyNotFoundErrors()
+    var
+        Rec: Record "Record Get Composite";
+    begin
+        asserterror Rec.Get('NOCOMP', 999);
+        Assert.ExpectedError('not found');
+    end;
+}


### PR DESCRIPTION
Closes #275

## Summary

- Add AL test suite `tests/bucket-1/48-record-get` with 6 proving tests for `Record.Get`
- Add C# `PipelineTests.RecordGet_RetrievesByPrimaryKey()` for end-to-end validation
- Update `CHANGELOG.md` under `[Unreleased]`

`MockRecordHandle.ALGet` was already fully implemented. This PR adds the proving test coverage.

## Test cases

| Test | What it proves |
|---|---|
| `GetRetrievesRecordByPrimaryKey` | Single-key Get loads exact row with all fields |
| `GetReturnsTrueWhenRecordExists` | Return value is `true` on match |
| `GetWithNonExistentKeyErrors` | Throws "not found" error for missing key |
| `GetDistinguishesBetweenDifferentKeys` | Get('A') vs Get('B') load the right rows |
| `GetWithCompositePrimaryKey` | Composite (CompanyNo, EntryNo) PK: correct row loaded |
| `GetWithCompositeKeyNotFoundErrors` | Composite not-found also errors |