### PR TITLE
docs: register Table.Rename as covered in coverage.yaml (#281)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ All notable changes to this project are documented here. Format based on
   and source is not mutated by the copy. RED confirmed by temporarily no-oping
   `ALCopyFilters`. Coverage map: `Table.CopyFilters` moved from `gap` to
   `covered`.
+- **`Record.Rename` coverage (#281)** — `MockRecordHandle.ALRename` was already
+  fully implemented but `Table.Rename` remained `status: gap` in coverage.yaml
+  because the existing `tests/bucket-2/107-rename` suite was not registered.
+  That suite provides 9 proving tests: single-field PK update + old-key removal,
+  composite PK rename, duplicate-key error, non-existent-record error, return-value
+  (false) variants, and count-preservation. Coverage map: `Table.Rename` moved
+  from `gap` to `covered`.
 - **`fieldgroups` section syntax coverage (#279)** — tables with `fieldgroups`
   declarations (e.g. `DropDown`, `Brick`) compile and all record operations
   work correctly. New suite `tests/bucket-1/48-fieldgroups`: 5 positive tests

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -5957,8 +5957,10 @@ Table.Relation:
 Table.Rename:
   layer: runtime-api
   category: Table
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1 (single-field and composite PK)
+  tests:
+    - tests/bucket-2/107-rename
 
 Table.Reset:
   layer: runtime-api


### PR DESCRIPTION
Closes #281

## Summary

`MockRecordHandle.ALRename` was already fully implemented and `tests/bucket-2/107-rename` already contained 9 proving tests covering all acceptance criteria. `docs/coverage.yaml` just had `Table.Rename` as `status: gap` because the suite was never registered there.

**No new tests needed** — the existing suite proves:
- Single-field PK rename: new key found, old key gone
- Composite PK rename: all three key fields updated
- Duplicate-key error (`asserterror` + `Assert.ExpectedError('already exists')`)
- Non-existent record error (`asserterror` + `Assert.ExpectedError('does not exist')`)
- Return-value (false) variants for both error cases
- Record count unchanged after rename

### Changes
- `docs/coverage.yaml`: `Table.Rename` → `covered`, references `tests/bucket-2/107-rename`
- `CHANGELOG.md`: entry added under `[Unreleased]`