### PR TITLE
test: Variable attribute syntax coverage — [Protected] and [InternallyVisible] (#278)

### DIFF
--- a/AlRunner.Tests/PipelineTests.cs
+++ b/AlRunner.Tests/PipelineTests.cs
@@ -537,4 +537,17 @@ namespace AlRunnerGenerated {
         Assert.True(result.Passed > 0);
         Assert.Equal(0, result.Failed);
     }
+
+    [Fact]
+    public void VarAttributes_ProtectedAndInternallyVisibleCompileAndRun()
+    {
+        var pipeline = new AlRunnerPipeline();
+        var result = pipeline.Run(new PipelineOptions
+        {
+            InputPaths = { TestPath("49-var-attributes", "src"), TestPath("49-var-attributes", "test") }
+        });
+        Assert.Equal(0, result.ExitCode);
+        Assert.True(result.Passed > 0);
+        Assert.Equal(0, result.Failed);
+    }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,13 @@ All notable changes to this project are documented here. Format based on
   composite PK rename, duplicate-key error, non-existent-record error, return-value
   (false) variants, and count-preservation. Coverage map: `Table.Rename` moved
   from `gap` to `covered`.
+- **Variable attribute syntax coverage (#278)** — AL variables declared with
+  `[Protected]` or `[InternallyVisible]` attributes now compile and run correctly.
+  The BC compiler emits these as standard C# attributes which are stripped by the
+  existing `BcAttributeNames` filter in `RoslynRewriter`. New suite
+  `tests/bucket-1/49-var-attributes` proves `[Protected]` and `[InternallyVisible]`
+  variables assign/read correctly and default to type zeros. Coverage map:
+  `var_attribute_item` and `var_attribute_open` moved from `gap` to `covered`.
 - **`fieldgroups` section syntax coverage (#279)** — tables with `fieldgroups`
   declarations (e.g. `DropDown`, `Brick`) compile and all record operations
   work correctly. New suite `tests/bucket-1/48-fieldgroups`: 5 positive tests

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -593,12 +593,16 @@ parameter_list:
 var_attribute_item:
   layer: syntax
   category: variable
-  status: gap
+  status: covered
+  tests:
+    - tests/bucket-1/49-var-attributes
 
 var_attribute_open:
   layer: syntax
   category: variable
-  status: gap
+  status: covered
+  tests:
+    - tests/bucket-1/49-var-attributes
 
 var_section:
   layer: syntax

--- a/tests/bucket-1/49-var-attributes/src/VarAttributeHelper.al
+++ b/tests/bucket-1/49-var-attributes/src/VarAttributeHelper.al
@@ -1,0 +1,52 @@
+codeunit 55300 "Var Attribute Helper"
+{
+    var
+        [Protected]
+        ProtectedInt: Integer;
+        [Protected]
+        ProtectedText: Text[50];
+        [InternallyVisible]
+        InternalInt: Integer;
+        [InternallyVisible]
+        InternalText: Text[100];
+
+    procedure SetProtectedInt(Value: Integer)
+    begin
+        ProtectedInt := Value;
+    end;
+
+    procedure GetProtectedInt(): Integer
+    begin
+        exit(ProtectedInt);
+    end;
+
+    procedure SetProtectedText(Value: Text[50])
+    begin
+        ProtectedText := Value;
+    end;
+
+    procedure GetProtectedText(): Text[50]
+    begin
+        exit(ProtectedText);
+    end;
+
+    procedure SetInternalInt(Value: Integer)
+    begin
+        InternalInt := Value;
+    end;
+
+    procedure GetInternalInt(): Integer
+    begin
+        exit(InternalInt);
+    end;
+
+    procedure SetInternalText(Value: Text[100])
+    begin
+        InternalText := Value;
+    end;
+
+    procedure GetInternalText(): Text[100]
+    begin
+        exit(InternalText);
+    end;
+}

--- a/tests/bucket-1/49-var-attributes/src/VarAttributeHelper.al
+++ b/tests/bucket-1/49-var-attributes/src/VarAttributeHelper.al
@@ -1,4 +1,4 @@
-codeunit 55300 "Var Attribute Helper"
+codeunit 55500 "Var Attribute Helper"
 {
     var
         [Protected]

--- a/tests/bucket-1/49-var-attributes/test/TestVarAttributes.al
+++ b/tests/bucket-1/49-var-attributes/test/TestVarAttributes.al
@@ -1,4 +1,4 @@
-codeunit 55301 "Test Var Attributes"
+codeunit 55501 "Test Var Attributes"
 {
     Subtype = Test;
 

--- a/tests/bucket-1/49-var-attributes/test/TestVarAttributes.al
+++ b/tests/bucket-1/49-var-attributes/test/TestVarAttributes.al
@@ -1,0 +1,63 @@
+codeunit 55301 "Test Var Attributes"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    [Test]
+    procedure ProtectedIntVariableAssignAndRead()
+    var
+        Helper: Codeunit "Var Attribute Helper";
+    begin
+        // [Protected] attribute is syntactic — assigned value must round-trip
+        Helper.SetProtectedInt(42);
+        Assert.AreEqual(42, Helper.GetProtectedInt(), '[Protected] Integer must store and return assigned value');
+    end;
+
+    [Test]
+    procedure ProtectedTextVariableAssignAndRead()
+    var
+        Helper: Codeunit "Var Attribute Helper";
+    begin
+        Helper.SetProtectedText('Hello');
+        Assert.AreEqual('Hello', Helper.GetProtectedText(), '[Protected] Text must store and return assigned value');
+    end;
+
+    [Test]
+    procedure InternallyVisibleIntVariableAssignAndRead()
+    var
+        Helper: Codeunit "Var Attribute Helper";
+    begin
+        // [InternallyVisible] attribute is syntactic — assigned value must round-trip
+        Helper.SetInternalInt(99);
+        Assert.AreEqual(99, Helper.GetInternalInt(), '[InternallyVisible] Integer must store and return assigned value');
+    end;
+
+    [Test]
+    procedure InternallyVisibleTextVariableAssignAndRead()
+    var
+        Helper: Codeunit "Var Attribute Helper";
+    begin
+        Helper.SetInternalText('World');
+        Assert.AreEqual('World', Helper.GetInternalText(), '[InternallyVisible] Text must store and return assigned value');
+    end;
+
+    [Test]
+    procedure ProtectedIntDefaultsToZero()
+    var
+        Helper: Codeunit "Var Attribute Helper";
+    begin
+        // [Protected] Integer without assignment must return 0 (type default)
+        Assert.AreEqual(0, Helper.GetProtectedInt(), '[Protected] Integer default must be 0');
+    end;
+
+    [Test]
+    procedure InternallyVisibleIntDefaultsToZero()
+    var
+        Helper: Codeunit "Var Attribute Helper";
+    begin
+        // [InternallyVisible] Integer without assignment must return 0 (type default)
+        Assert.AreEqual(0, Helper.GetInternalInt(), '[InternallyVisible] Integer default must be 0');
+    end;
+}


### PR DESCRIPTION
Closes #278

## Summary

- Add AL test suite `tests/bucket-1/49-var-attributes` with 6 proving tests for variable attributes
- Update `docs/coverage.yaml`: `var_attribute_item` and `var_attribute_open` → `covered`
- Add C# `PipelineTests.VarAttributes_ProtectedAndInternallyVisibleCompileAndRun()`
- Update `CHANGELOG.md`

The BC compiler emits `[Protected]` and `[InternallyVisible]` as C# attributes that are already stripped by `BcAttributeNames` in `RoslynRewriter`. This PR adds the proving test coverage.

## Test cases

| Test | What it proves |
|---|---|
| `ProtectedIntVariableAssignAndRead` | `[Protected]` Integer round-trips assigned value |
| `ProtectedTextVariableAssignAndRead` | `[Protected]` Text round-trips assigned value |
| `InternallyVisibleIntVariableAssignAndRead` | `[InternallyVisible]` Integer round-trips value |
| `InternallyVisibleTextVariableAssignAndRead` | `[InternallyVisible]` Text round-trips value |
| `ProtectedIntDefaultsToZero` | `[Protected]` Integer defaults to 0 |
| `InternallyVisibleIntDefaultsToZero` | `[InternallyVisible]` Integer defaults to 0 |