### PR TITLE
fix: mark Table.Validate as covered in coverage.yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ All notable changes to this project are documented here. Format based on
 ## [Unreleased]
 
 ### Added
+- **`Table.Validate` coverage.yaml fix (#270)** — `Table.Validate` was
+  listed as `status: gap` in `docs/coverage.yaml` despite 5 proving tests
+  already existing in `tests/bucket-1/18-validate-trigger` (OnValidate fires
+  on name-uppercase, computed amount, direct-Validate, direct-assign-skips,
+  zero-quantity). Corrected status to `covered`.
 - **`Table.CopyFilters` coverage (#274)** — `ALCopyFilters` was already
   implemented in `MockRecordHandle` but had no proving tests. New suite
   `tests/bucket-1/48-copyfilters` adds 7 tests: SetRange transfer, SetFilter

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -6075,7 +6075,8 @@ Table.Truncate:
 Table.Validate:
   layer: runtime-api
   category: Table
-  status: gap
+  status: covered
+  tests: tests/bucket-1/18-validate-trigger
   notes: overloads=1
 
 Table.WritePermission:


### PR DESCRIPTION
Closes #270

## Summary

`Table.Validate` was listed as `status: gap` in `docs/coverage.yaml` despite 5 proving tests already existing in `tests/bucket-1/18-validate-trigger`:

| Test | What it proves |
|------|---------------|
| `TestNameUppercased` | OnValidate fires and transforms field value (Name → uppercase) |
| `TestQuantityCalculatesAmount` | OnValidate fires and computes derived field (Amount = Qty × Price) |
| `TestDirectValidateOnRecord` | `Rec.Validate(Field, Value)` fires OnValidate on an existing record |
| `TestDirectAssignSkipsValidateTrigger` | Direct field assignment does NOT fire OnValidate (negative case) |
| `TestZeroQuantityValidate` | Edge case: zero-value Validate still fires trigger |

This is the same pattern as #223 (SetCurrentKey) and #272 — implementation and tests existed but coverage.yaml was not updated.

Change: `Table.Validate` → `status: covered`, `tests: tests/bucket-1/18-validate-trigger`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)