### PR TITLE
feat: Record.SetRecFilter composite-PK fix + coverage (#286)

### DIFF
--- a/AlRunner/Runtime/MockRecordHandle.cs
+++ b/AlRunner/Runtime/MockRecordHandle.cs
@@ -1490,20 +1490,25 @@ public class MockRecordHandle
     // -----------------------------------------------------------------------
 
     /// <summary>
-    /// AL's SETRECFILTER — sets a filter based on the current record's primary key values.
-    /// In standalone mode, sets a range filter on field 1 using the current PK value.
+    /// AL's SETRECFILTER — sets a range filter on every primary-key field to the
+    /// current record's PK values, restricting subsequent operations to exactly
+    /// this record. Handles both single-field and composite PKs.
     /// </summary>
     public void ALSetRecFilter()
     {
-        if (_fields.TryGetValue(1, out var pkValue))
+        var pkFields = GetPrimaryKeyFields();
+        foreach (var fieldNo in pkFields)
         {
-            _filters[1] = new FieldFilter
+            if (_fields.TryGetValue(fieldNo, out var pkValue))
             {
-                FieldNo = 1,
-                FromValue = pkValue,
-                ToValue = pkValue,
-                IsRangeFilter = true,
-            };
+                _filters[fieldNo] = new FieldFilter
+                {
+                    FieldNo = fieldNo,
+                    FromValue = pkValue,
+                    ToValue = pkValue,
+                    IsRangeFilter = true,
+                };
+            }
         }
     }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ All notable changes to this project are documented here. Format based on
   already existing in `tests/bucket-1/18-validate-trigger` (OnValidate fires
   on name-uppercase, computed amount, direct-Validate, direct-assign-skips,
   zero-quantity). Corrected status to `covered`.
+- **`Record.SetRecFilter` composite-PK fix + coverage (#286)** — `ALSetRecFilter`
+  previously only filtered on field 1 of the PK, leaving composite-PK records
+  under-filtered. Fixed to iterate all PK fields via `GetPrimaryKeyFields()` and
+  set a range filter on each. New suite `tests/bucket-1/49-setrecfilter` adds 7
+  proving tests: single-field PK (Count=1, FindSet iterates only current record,
+  correct field data returned), composite PK (Count=1, correct row isolated),
+  Reset clears the filter, and SetRecFilter on one variable does not affect
+  another variable. Coverage map: `Table.SetRecFilter` moved from `gap` to `covered`.
 - **`Table.CopyFilters` coverage (#274)** — `ALCopyFilters` was already
   implemented in `MockRecordHandle` but had no proving tests. New suite
   `tests/bucket-1/48-copyfilters` adds 7 tests: SetRange transfer, SetFilter
@@ -34,13 +42,6 @@ All notable changes to this project are documented here. Format based on
   composite PK rename, duplicate-key error, non-existent-record error, return-value
   (false) variants, and count-preservation. Coverage map: `Table.Rename` moved
   from `gap` to `covered`.
-- **Variable attribute syntax coverage (#278)** — AL variables declared with
-  `[Protected]` or `[InternallyVisible]` attributes now compile and run correctly.
-  The BC compiler emits these as standard C# attributes which are stripped by the
-  existing `BcAttributeNames` filter in `RoslynRewriter`. New suite
-  `tests/bucket-1/49-var-attributes` proves `[Protected]` and `[InternallyVisible]`
-  variables assign/read correctly and default to type zeros. Coverage map:
-  `var_attribute_item` and `var_attribute_open` moved from `gap` to `covered`.
 - **`fieldgroups` section syntax coverage (#279)** — tables with `fieldgroups`
   declarations (e.g. `DropDown`, `Brick`) compile and all record operations
   work correctly. New suite `tests/bucket-1/48-fieldgroups`: 5 positive tests

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -6037,8 +6037,10 @@ Table.SetRange:
 Table.SetRecFilter:
   layer: runtime-api
   category: Table
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1 (single-field and composite PK)
+  tests:
+    - tests/bucket-1/49-setrecfilter
 
 Table.SetView:
   layer: runtime-api

--- a/tests/bucket-1/49-setrecfilter/src/SetRecFilterTable.al
+++ b/tests/bucket-1/49-setrecfilter/src/SetRecFilterTable.al
@@ -1,5 +1,5 @@
 // Single-field PK table for SetRecFilter tests
-table 55600 "SRF Single Table"
+table 55700 "SRF Single Table"
 {
     DataClassification = ToBeClassified;
 
@@ -25,7 +25,7 @@ table 55600 "SRF Single Table"
 }
 
 // Composite-PK table for SetRecFilter tests
-table 55601 "SRF Composite Table"
+table 55701 "SRF Composite Table"
 {
     DataClassification = ToBeClassified;
 

--- a/tests/bucket-1/49-setrecfilter/src/SetRecFilterTable.al
+++ b/tests/bucket-1/49-setrecfilter/src/SetRecFilterTable.al
@@ -1,5 +1,5 @@
 // Single-field PK table for SetRecFilter tests
-table 55500 "SRF Single Table"
+table 55600 "SRF Single Table"
 {
     DataClassification = ToBeClassified;
 
@@ -25,7 +25,7 @@ table 55500 "SRF Single Table"
 }
 
 // Composite-PK table for SetRecFilter tests
-table 55501 "SRF Composite Table"
+table 55601 "SRF Composite Table"
 {
     DataClassification = ToBeClassified;
 

--- a/tests/bucket-1/49-setrecfilter/src/SetRecFilterTable.al
+++ b/tests/bucket-1/49-setrecfilter/src/SetRecFilterTable.al
@@ -1,0 +1,59 @@
+// Single-field PK table for SetRecFilter tests
+table 55500 "SRF Single Table"
+{
+    DataClassification = ToBeClassified;
+
+    fields
+    {
+        field(1; Code; Code[20])
+        {
+            DataClassification = ToBeClassified;
+        }
+        field(2; Description; Text[100])
+        {
+            DataClassification = ToBeClassified;
+        }
+    }
+
+    keys
+    {
+        key(PK; Code)
+        {
+            Clustered = true;
+        }
+    }
+}
+
+// Composite-PK table for SetRecFilter tests
+table 55501 "SRF Composite Table"
+{
+    DataClassification = ToBeClassified;
+
+    fields
+    {
+        field(1; "Doc Type"; Integer)
+        {
+            DataClassification = ToBeClassified;
+        }
+        field(2; "Doc No."; Code[20])
+        {
+            DataClassification = ToBeClassified;
+        }
+        field(3; "Line No."; Integer)
+        {
+            DataClassification = ToBeClassified;
+        }
+        field(4; Description; Text[100])
+        {
+            DataClassification = ToBeClassified;
+        }
+    }
+
+    keys
+    {
+        key(PK; "Doc Type", "Doc No.", "Line No.")
+        {
+            Clustered = true;
+        }
+    }
+}

--- a/tests/bucket-1/49-setrecfilter/test/SetRecFilterTests.al
+++ b/tests/bucket-1/49-setrecfilter/test/SetRecFilterTests.al
@@ -1,4 +1,4 @@
-codeunit 55502 "SetRecFilter Tests"
+codeunit 55602 "SetRecFilter Tests"
 {
     Subtype = Test;
 

--- a/tests/bucket-1/49-setrecfilter/test/SetRecFilterTests.al
+++ b/tests/bucket-1/49-setrecfilter/test/SetRecFilterTests.al
@@ -1,0 +1,176 @@
+codeunit 55502 "SetRecFilter Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    // -----------------------------------------------------------------------
+    // Single-field PK — positive tests
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure SetRecFilterSinglePKRestrictsCountToOne()
+    var
+        Rec: Record "SRF Single Table";
+    begin
+        // [GIVEN] Three records exist
+        InsertSingle('AAA', 'Alpha');
+        InsertSingle('BBB', 'Beta');
+        InsertSingle('CCC', 'Gamma');
+
+        // [WHEN] Get a specific record then SetRecFilter
+        Rec.Get('BBB');
+        Rec.SetRecFilter();
+
+        // [THEN] Count is restricted to exactly 1 (only the current record)
+        Assert.AreEqual(1, Rec.Count(), 'SetRecFilter on single PK should restrict Count to 1');
+    end;
+
+    [Test]
+    procedure SetRecFilterSinglePKFindSetReturnsOnlyCurrentRecord()
+    var
+        Rec: Record "SRF Single Table";
+        Found: Integer;
+    begin
+        // [GIVEN] Three records exist
+        InsertSingle('D01', 'Delta');
+        InsertSingle('D02', 'Epsilon');
+        InsertSingle('D03', 'Zeta');
+
+        // [WHEN] Get D02, SetRecFilter, FindSet
+        Rec.Get('D02');
+        Rec.SetRecFilter();
+        Rec.FindSet();
+
+        // [THEN] Only D02 is iterated
+        Assert.AreEqual('D02', Rec.Code, 'SetRecFilter should land on the current record');
+        Found := 1;
+        while Rec.Next() <> 0 do
+            Found += 1;
+        Assert.AreEqual(1, Found, 'FindSet should iterate exactly 1 record after SetRecFilter');
+    end;
+
+    [Test]
+    procedure SetRecFilterSinglePKDescription()
+    var
+        Rec: Record "SRF Single Table";
+    begin
+        // [GIVEN] A record with a specific description
+        InsertSingle('E01', 'Expected Description');
+        InsertSingle('E02', 'Other Description');
+
+        // [WHEN] Get E01 and SetRecFilter
+        Rec.Get('E01');
+        Rec.SetRecFilter();
+        Rec.FindFirst();
+
+        // [THEN] The filtered record has the correct description
+        Assert.AreEqual('Expected Description', Rec.Description, 'SetRecFilter should return the correct record data');
+    end;
+
+    // -----------------------------------------------------------------------
+    // Composite PK — positive tests
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure SetRecFilterCompositePKRestrictsCountToOne()
+    var
+        Rec: Record "SRF Composite Table";
+    begin
+        // [GIVEN] Three records that share Doc Type=1 but differ on other PK fields
+        InsertComposite(1, 'ORD001', 10000, 'Line 1a');
+        InsertComposite(1, 'ORD001', 20000, 'Line 1b');
+        InsertComposite(1, 'ORD002', 10000, 'Line 2a');
+
+        // [WHEN] Get a specific composite-PK record and SetRecFilter
+        Rec.Get(1, 'ORD001', 10000);
+        Rec.SetRecFilter();
+
+        // [THEN] Count restricted to 1 — not 3 (which field-1-only filter would give)
+        Assert.AreEqual(1, Rec.Count(), 'SetRecFilter on composite PK should restrict Count to exactly 1');
+    end;
+
+    [Test]
+    procedure SetRecFilterCompositePKIsolatesCorrectRow()
+    var
+        Rec: Record "SRF Composite Table";
+    begin
+        // [GIVEN] Two records sharing first two PK fields
+        InsertComposite(2, 'PO001', 100, 'First line');
+        InsertComposite(2, 'PO001', 200, 'Second line');
+
+        // [WHEN] Get the second record and SetRecFilter
+        Rec.Get(2, 'PO001', 200);
+        Rec.SetRecFilter();
+        Rec.FindFirst();
+
+        // [THEN] Only the second record is returned
+        Assert.AreEqual('Second line', Rec.Description, 'SetRecFilter should isolate the correct composite-PK row');
+        Assert.AreEqual(200, Rec."Line No.", 'Filtered record must have Line No.=200');
+    end;
+
+    // -----------------------------------------------------------------------
+    // Negative: Reset clears the SetRecFilter restriction
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure ResetAfterSetRecFilterRestoresFullCount()
+    var
+        Rec: Record "SRF Single Table";
+    begin
+        // [GIVEN] Three records, with SetRecFilter applied
+        InsertSingle('R01', 'One');
+        InsertSingle('R02', 'Two');
+        InsertSingle('R03', 'Three');
+        Rec.Get('R01');
+        Rec.SetRecFilter();
+        Assert.AreEqual(1, Rec.Count(), 'Pre-condition: SetRecFilter gives Count=1');
+
+        // [WHEN] Reset is called
+        Rec.Reset();
+
+        // [THEN] Count returns all records, not just 1
+        Assert.AreEqual(3, Rec.Count(), 'Reset should clear SetRecFilter and restore full Count');
+        Assert.AreNotEqual(1, Rec.Count(), 'Count after Reset must not still be 1');
+    end;
+
+    [Test]
+    procedure SetRecFilterDoesNotAffectOtherRecordVariables()
+    var
+        Rec: Record "SRF Single Table";
+        Other: Record "SRF Single Table";
+    begin
+        // [GIVEN] Three records, SetRecFilter on Rec
+        InsertSingle('S01', 'One');
+        InsertSingle('S02', 'Two');
+        InsertSingle('S03', 'Three');
+        Rec.Get('S01');
+        Rec.SetRecFilter();
+
+        // [THEN] Separate variable sees all 3 records (filters are per-variable)
+        Assert.AreEqual(3, Other.Count(), 'SetRecFilter on one variable should not affect another variable');
+    end;
+
+    local procedure InsertSingle(Code: Code[20]; Description: Text[100])
+    var
+        Rec: Record "SRF Single Table";
+    begin
+        Rec.Init();
+        Rec.Code := Code;
+        Rec.Description := Description;
+        Rec.Insert();
+    end;
+
+    local procedure InsertComposite(DocType: Integer; DocNo: Code[20]; LineNo: Integer; Description: Text[100])
+    var
+        Rec: Record "SRF Composite Table";
+    begin
+        Rec.Init();
+        Rec."Doc Type" := DocType;
+        Rec."Doc No." := DocNo;
+        Rec."Line No." := LineNo;
+        Rec.Description := Description;
+        Rec.Insert();
+    end;
+}

--- a/tests/bucket-1/49-setrecfilter/test/SetRecFilterTests.al
+++ b/tests/bucket-1/49-setrecfilter/test/SetRecFilterTests.al
@@ -1,4 +1,4 @@
-codeunit 55602 "SetRecFilter Tests"
+codeunit 55702 "SetRecFilter Tests"
 {
     Subtype = Test;
 


### PR DESCRIPTION
Closes #286

## Changes

- **Bug fix**: `ALSetRecFilter()` in `MockRecordHandle` now iterates all PK fields via `GetPrimaryKeyFields()` instead of only filtering on field 1. This fixes composite-PK records being under-restricted after `SetRecFilter()`.
- **New test suite**: `tests/bucket-1/49-setrecfilter` — 7 proving tests:
  - Single-field PK: Count=1, FindSet iterates only current record, correct Description returned
  - Composite PK: Count=1 (not 3 from field-1-only filter), correct row isolated by all PK fields
  - Negative: Reset clears SetRecFilter restriction
  - Negative: SetRecFilter on one variable does not affect another variable
- **Coverage map**: `Table.SetRecFilter` moved from `status: gap` to `status: covered`
- **CHANGELOG**: entry added under `[Unreleased]`