### PR TITLE
test: table_relation_expression syntax coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ All notable changes to this project are documented here. Format based on
   delete, empty table (no error), non-matching filter on empty table, and
   count-after-partial-delete. Coverage map: `Table.DeleteAll` moved from `gap`
   to `covered`.
+- **`table_relation_expression` syntax coverage (#285)** — tables with
+  `TableRelation` field properties compile and all record operations work.
+  New suite `tests/bucket-1/49-tablerelation` adds 6 tests: Insert+Get
+  with no parent (FK not enforced), Insert with existing parent, Modify,
+  Delete, Count with filter, and the explicit negative test proving orphan
+  inserts succeed without error. Coverage map:
+  `table_relation_expression` moved from `gap` to `covered`.
 - **`Table.Validate` coverage.yaml fix (#270)** — `Table.Validate` was
   listed as `status: gap` in `docs/coverage.yaml` despite 5 proving tests
   already existing in `tests/bucket-1/18-validate-trigger` (OnValidate fires

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -709,7 +709,8 @@ table_relation_expression:
   layer: syntax
   category: table
   status: covered
-  tests: tests/bucket-1/49-tablerelation
+  tests:
+    - tests/bucket-1/49-tablerelation
   notes: Table relations are parsed but not enforced at runtime
 
 # ── page ────────────────────────────────────────────────────────

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -708,7 +708,8 @@ lookup_formula:
 table_relation_expression:
   layer: syntax
   category: table
-  status: gap
+  status: covered
+  tests: tests/bucket-1/49-tablerelation
   notes: Table relations are parsed but not enforced at runtime
 
 # ── page ────────────────────────────────────────────────────────

--- a/tests/bucket-1/49-tablerelation/src/TableRelationTables.al
+++ b/tests/bucket-1/49-tablerelation/src/TableRelationTables.al
@@ -1,0 +1,56 @@
+/// Parent table — the target of TableRelation references below
+table 55500 "TR Parent"
+{
+    DataClassification = ToBeClassified;
+
+    fields
+    {
+        field(1; "Code"; Code[20])
+        {
+            DataClassification = ToBeClassified;
+        }
+        field(2; "Description"; Text[100])
+        {
+            DataClassification = ToBeClassified;
+        }
+    }
+
+    keys
+    {
+        key(PK; "Code")
+        {
+            Clustered = true;
+        }
+    }
+}
+
+/// Child table — uses TableRelation to reference TR Parent
+table 55501 "TR Child"
+{
+    DataClassification = ToBeClassified;
+
+    fields
+    {
+        field(1; "Entry No."; Integer)
+        {
+            DataClassification = ToBeClassified;
+        }
+        field(2; "Parent Code"; Code[20])
+        {
+            DataClassification = ToBeClassified;
+            TableRelation = "TR Parent".Code;
+        }
+        field(3; "Amount"; Decimal)
+        {
+            DataClassification = ToBeClassified;
+        }
+    }
+
+    keys
+    {
+        key(PK; "Entry No.")
+        {
+            Clustered = true;
+        }
+    }
+}

--- a/tests/bucket-1/49-tablerelation/test/TableRelationTests.al
+++ b/tests/bucket-1/49-tablerelation/test/TableRelationTests.al
@@ -1,0 +1,146 @@
+codeunit 55502 "TableRelation Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    // -----------------------------------------------------------------------
+    // TableRelation syntax — positive tests
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure TableRelation_TableCompilesAndInsertWorks()
+    var
+        Child: Record "TR Child";
+    begin
+        // [GIVEN/WHEN] Insert a child record with a Parent Code value
+        // (no parent record exists — runner does not enforce FK relations)
+        Child.Init();
+        Child."Entry No." := 1;
+        Child."Parent Code" := 'ACME';
+        Child.Amount := 100;
+        Child.Insert();
+
+        // [THEN] Record is inserted without error and can be retrieved
+        Child.Get(1);
+        Assert.AreEqual('ACME', Child."Parent Code", 'Parent Code should be stored as-is');
+        Assert.AreEqual(100, Child.Amount, 'Amount should be stored correctly');
+    end;
+
+    [Test]
+    procedure TableRelation_InsertWithExistingParentWorks()
+    var
+        Parent: Record "TR Parent";
+        Child: Record "TR Child";
+    begin
+        // [GIVEN] A parent record exists
+        Parent.Init();
+        Parent.Code := 'BETA';
+        Parent.Description := 'Beta Corp';
+        Parent.Insert();
+
+        // [WHEN] A child record references the parent
+        Child.Init();
+        Child."Entry No." := 2;
+        Child."Parent Code" := 'BETA';
+        Child.Amount := 200;
+        Child.Insert();
+
+        // [THEN] Both records readable; child holds the parent code
+        Child.Get(2);
+        Assert.AreEqual('BETA', Child."Parent Code", 'Child should reference BETA');
+        Parent.Get('BETA');
+        Assert.AreEqual('Beta Corp', Parent.Description, 'Parent description intact');
+    end;
+
+    [Test]
+    procedure TableRelation_ModifyWorks()
+    var
+        Child: Record "TR Child";
+    begin
+        // [GIVEN] An existing child record
+        Child.Init();
+        Child."Entry No." := 3;
+        Child."Parent Code" := 'OLD';
+        Child.Amount := 50;
+        Child.Insert();
+
+        // [WHEN] Modify updates the Parent Code and Amount
+        Child.Get(3);
+        Child."Parent Code" := 'NEW';
+        Child.Amount := 75;
+        Child.Modify();
+
+        // [THEN] Updated values are persisted
+        Child.Get(3);
+        Assert.AreEqual('NEW', Child."Parent Code", 'Modified Parent Code should be NEW');
+        Assert.AreEqual(75, Child.Amount, 'Modified Amount should be 75');
+    end;
+
+    [Test]
+    procedure TableRelation_DeleteWorks()
+    var
+        Child: Record "TR Child";
+    begin
+        // [GIVEN] An existing child record
+        Child.Init();
+        Child."Entry No." := 4;
+        Child."Parent Code" := 'DEL';
+        Child.Amount := 10;
+        Child.Insert();
+
+        // [WHEN] Delete the record
+        Child.Get(4);
+        Child.Delete();
+
+        // [THEN] Record no longer exists
+        Assert.IsFalse(Child.Get(4), 'Deleted record should not be found');
+    end;
+
+    [Test]
+    procedure TableRelation_CountReflectsInsertedRecords()
+    var
+        Child: Record "TR Child";
+    begin
+        // [GIVEN] Two child records inserted (Entry No. 10 and 11)
+        Child.Init();
+        Child."Entry No." := 10;
+        Child."Parent Code" := 'X';
+        Child.Insert();
+
+        Child.Init();
+        Child."Entry No." := 11;
+        Child."Parent Code" := 'Y';
+        Child.Insert();
+
+        // [WHEN/THEN] Count should reflect inserted records
+        Child.SetFilter("Entry No.", '10|11');
+        Assert.AreEqual(2, Child.Count, 'Count should return 2 for the two inserted records');
+    end;
+
+    // -----------------------------------------------------------------------
+    // TableRelation — negative test: no FK enforcement
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure TableRelation_InsertWithoutParentDoesNotError()
+    var
+        Child: Record "TR Child";
+        Parent: Record "TR Parent";
+        Inserted: Boolean;
+    begin
+        // [GIVEN] No parent record with code 'GHOST' exists
+        Assert.IsFalse(Parent.Get('GHOST'), 'Parent GHOST must not exist before test');
+
+        // [WHEN] Insert a child referencing the non-existent parent
+        Child.Init();
+        Child."Entry No." := 99;
+        Child."Parent Code" := 'GHOST';
+        Child.Insert();  // must NOT raise an error — runner does not enforce FK
+
+        // [THEN] Record was inserted successfully
+        Assert.IsTrue(Child.Get(99), 'Child with orphan Parent Code should be inserted without error');
+        Assert.AreEqual('GHOST', Child."Parent Code", 'Orphan Parent Code stored correctly');
+    end;
+}


### PR DESCRIPTION
Closes #285

## Summary

`table_relation_expression` was `status: gap` in `docs/coverage.yaml`. Tables with `TableRelation` field properties were already parsed by the runner but had no test suite.

New suite `tests/bucket-1/49-tablerelation` (table 55500 TR Parent, table 55501 TR Child, codeunit 55502):

| Test | What it proves |
|------|---------------|
| `TableRelation_TableCompilesAndInsertWorks` | Table with `TableRelation = "TR Parent".Code` compiles; Insert+Get works |
| `TableRelation_InsertWithExistingParentWorks` | Insert child that references an existing parent record |
| `TableRelation_ModifyWorks` | Modify updates Parent Code and Amount correctly |
| `TableRelation_DeleteWorks` | Delete removes the record |
| `TableRelation_CountReflectsInsertedRecords` | Count with filter returns correct count |
| `TableRelation_InsertWithoutParentDoesNotError` | **Negative**: runner does NOT enforce FK — orphan insert succeeds |

Coverage map: `table_relation_expression` → `status: covered`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)