### PR TITLE
feat: implement Record.CalcSums — sum numeric fields with current filters

### DIFF
--- a/AlRunner/Runtime/MockRecordHandle.cs
+++ b/AlRunner/Runtime/MockRecordHandle.cs
@@ -1311,12 +1311,27 @@ public class MockRecordHandle
     }
 
     /// <summary>
-    /// AL's CALCSUMS — calculates sum of specified fields across filtered records.
-    /// Returns true; the actual sum is not computed (would need field metadata to know types).
+    /// AL's CALCSUMS — calculates sum of specified fields across all records that match
+    /// the current filters and writes each sum back into the corresponding field on this record.
     /// </summary>
     public bool ALCalcSums(DataError errorLevel, params int[] fieldNos)
     {
-        // No-op stub: real implementation would sum over filtered records
+        var rows = GetFilteredRecords();
+        foreach (var fieldNo in fieldNos)
+        {
+            decimal sum = 0m;
+            bool isInteger = true;
+            foreach (var row in rows)
+            {
+                if (!row.TryGetValue(fieldNo, out var val)) continue;
+                if (!(val is NavInteger) && !(val is NavBigInteger))
+                    isInteger = false;
+                sum += NavValueToDecimal(val);
+            }
+            _fields[fieldNo] = isInteger
+                ? (NavValue)NavInteger.Create((int)sum)
+                : NavDecimal.Create(new Decimal18(sum));
+        }
         return true;
     }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ All notable changes to this project are documented here. Format based on
 ## [Unreleased]
 
 ### Added
+- **`Record.CalcSums` implementation (#293)** — `ALCalcSums` was a no-op stub; now
+  sums each requested field across all records matching the current filters and writes
+  the result back into the record's fields. Integer fields stay `NavInteger`; Decimal
+  fields become `NavDecimal`. New suite `tests/bucket-1/51-calcsums` adds 6 proving
+  tests: Decimal sum, Integer sum, filtered sum, multi-field sum, empty result (→ 0),
+  and filter-excludes-all (→ 0). Coverage map: `Table.CalcSums` moved from `gap` to
+  `covered`.
 - **`Record.DeleteAll` coverage (#289)** — `ALDeleteAll` was already fully
   implemented in `MockRecordHandle` (no-filter variant clears all rows; filter
   variant removes only matching rows). New suite `tests/bucket-1/50-deleteall`

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -5622,8 +5622,10 @@ Table.CalcFields:
 Table.CalcSums:
   layer: runtime-api
   category: Table
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests:
+    - tests/bucket-1/51-calcsums
+  notes: overloads=1; sums filtered records and writes result back into the record fields
 
 Table.ChangeCompany:
   layer: runtime-api

--- a/tests/bucket-1/51-calcsums/src/CalcSumsTable.al
+++ b/tests/bucket-1/51-calcsums/src/CalcSumsTable.al
@@ -1,4 +1,4 @@
-table 55700 "CalcSums Entry"
+table 55800 "CalcSums Entry"
 {
     DataClassification = ToBeClassified;
 

--- a/tests/bucket-1/51-calcsums/src/CalcSumsTable.al
+++ b/tests/bucket-1/51-calcsums/src/CalcSumsTable.al
@@ -1,0 +1,32 @@
+table 55700 "CalcSums Entry"
+{
+    DataClassification = ToBeClassified;
+
+    fields
+    {
+        field(1; "Entry No."; Integer)
+        {
+            DataClassification = ToBeClassified;
+        }
+        field(2; "Status"; Integer)
+        {
+            DataClassification = ToBeClassified;
+        }
+        field(3; "Amount"; Decimal)
+        {
+            DataClassification = ToBeClassified;
+        }
+        field(4; "Quantity"; Integer)
+        {
+            DataClassification = ToBeClassified;
+        }
+    }
+
+    keys
+    {
+        key(PK; "Entry No.")
+        {
+            Clustered = true;
+        }
+    }
+}

--- a/tests/bucket-1/51-calcsums/test/CalcSumsTests.al
+++ b/tests/bucket-1/51-calcsums/test/CalcSumsTests.al
@@ -1,4 +1,4 @@
-codeunit 55701 "CalcSums Tests"
+codeunit 55801 "CalcSums Tests"
 {
     Subtype = Test;
 

--- a/tests/bucket-1/51-calcsums/test/CalcSumsTests.al
+++ b/tests/bucket-1/51-calcsums/test/CalcSumsTests.al
@@ -1,0 +1,132 @@
+codeunit 55701 "CalcSums Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    // -----------------------------------------------------------------------
+    // Record.CalcSums — positive tests
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure CalcSums_DecimalField_ReturnsCorrectSum()
+    var
+        Entry: Record "CalcSums Entry";
+    begin
+        // [GIVEN] Three entries with Amount 10.5, 20.0, 30.75
+        InsertEntry(1, 1, 10.5, 0);
+        InsertEntry(2, 1, 20.0, 0);
+        InsertEntry(3, 1, 30.75, 0);
+
+        // [WHEN] CalcSums on Amount (no filter — all records)
+        Entry.CalcSums(Amount);
+
+        // [THEN] Amount = 61.25
+        Assert.AreEqual(61.25, Entry.Amount, 'CalcSums Decimal: sum should be 61.25');
+    end;
+
+    [Test]
+    procedure CalcSums_IntegerField_ReturnsCorrectSum()
+    var
+        Entry: Record "CalcSums Entry";
+    begin
+        // [GIVEN] Three entries with Quantity 5, 10, 15
+        InsertEntry(4, 1, 0, 5);
+        InsertEntry(5, 1, 0, 10);
+        InsertEntry(6, 1, 0, 15);
+
+        // [WHEN] CalcSums on Quantity (no filter — all records)
+        Entry.CalcSums(Quantity);
+
+        // [THEN] Quantity = 30
+        Assert.AreEqual(30, Entry.Quantity, 'CalcSums Integer: sum should be 30');
+    end;
+
+    [Test]
+    procedure CalcSums_WithFilter_SumsOnlyMatchingRecords()
+    var
+        Entry: Record "CalcSums Entry";
+    begin
+        // [GIVEN] Two status=1 entries (Amount 100, 200) and one status=2 (Amount 999)
+        InsertEntry(10, 1, 100, 0);
+        InsertEntry(11, 1, 200, 0);
+        InsertEntry(12, 2, 999, 0);
+
+        // [WHEN] Filter to Status=1 then CalcSums
+        Entry.SetRange(Status, 1);
+        Entry.CalcSums(Amount);
+
+        // [THEN] Amount = 300, not 1299
+        Assert.AreEqual(300, Entry.Amount, 'CalcSums with filter: should sum only Status=1 records');
+    end;
+
+    [Test]
+    procedure CalcSums_MultipleFields_BothUpdated()
+    var
+        Entry: Record "CalcSums Entry";
+    begin
+        // [GIVEN] Two entries
+        InsertEntry(20, 1, 50.5, 3);
+        InsertEntry(21, 1, 49.5, 7);
+
+        // [WHEN] CalcSums on both Amount and Quantity
+        Entry.CalcSums(Amount, Quantity);
+
+        // [THEN] Amount = 100, Quantity = 10
+        Assert.AreEqual(100, Entry.Amount, 'CalcSums multi: Amount should be 100');
+        Assert.AreEqual(10, Entry.Quantity, 'CalcSums multi: Quantity should be 10');
+    end;
+
+    // -----------------------------------------------------------------------
+    // Record.CalcSums — negative / edge-case tests
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure CalcSums_EmptyResult_ReturnsZero()
+    var
+        Entry: Record "CalcSums Entry";
+    begin
+        // [GIVEN] No records exist matching Status = 999
+        // (table is empty for this value — no inserts)
+
+        // [WHEN] SetRange to a non-existent status, then CalcSums
+        Entry.SetRange(Status, 999);
+        Entry.CalcSums(Amount);
+
+        // [THEN] Amount is 0 (no records to sum)
+        Assert.AreEqual(0, Entry.Amount, 'CalcSums empty: should return 0 when no records match');
+    end;
+
+    [Test]
+    procedure CalcSums_FilterExcludesAll_QuantityZero()
+    var
+        Entry: Record "CalcSums Entry";
+    begin
+        // [GIVEN] One entry with Status=1
+        InsertEntry(30, 1, 42, 7);
+
+        // [WHEN] Filter to Status=2 (no match)
+        Entry.SetRange(Status, 2);
+        Entry.CalcSums(Quantity);
+
+        // [THEN] Quantity = 0
+        Assert.AreEqual(0, Entry.Quantity, 'CalcSums filter excludes all: Quantity should be 0');
+    end;
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    local procedure InsertEntry(EntryNo: Integer; Status: Integer; Amount: Decimal; Quantity: Integer)
+    var
+        Entry: Record "CalcSums Entry";
+    begin
+        Entry.Init();
+        Entry."Entry No." := EntryNo;
+        Entry.Status := Status;
+        Entry.Amount := Amount;
+        Entry.Quantity := Quantity;
+        Entry.Insert();
+    end;
+}


### PR DESCRIPTION
Closes #293

## What

`ALCalcSums` in `MockRecordHandle` was a no-op stub that returned `true` without computing anything. This PR implements the real behaviour: for each requested field number, sum the field values across all records matching the current filters, then write the result back into `_fields` on the record.

Integer/BigInteger fields accumulate into `NavInteger`; all other numeric types into `NavDecimal`.

## Tests

New suite `tests/bucket-1/51-calcsums` — 6 proving tests:

| Test | Proves |
|---|---|
| `CalcSums_DecimalField_ReturnsCorrectSum` | Decimal fields summed correctly (10.5+20+30.75=61.25) |
| `CalcSums_IntegerField_ReturnsCorrectSum` | Integer fields summed correctly (5+10+15=30) |
| `CalcSums_WithFilter_SumsOnlyMatchingRecords` | Filter restricts records summed (Status=1 only) |
| `CalcSums_MultipleFields_BothUpdated` | Two fields updated in one call |
| `CalcSums_EmptyResult_ReturnsZero` | No matching records → 0 |
| `CalcSums_FilterExcludesAll_QuantityZero` | Filter matches nothing → 0 |

## Coverage

`docs/coverage.yaml`: `Table.CalcSums` `gap` → `covered`