### PR TITLE
feat: Record.Copy fix + coverage (#295)

### DIFF
--- a/AlRunner/Runtime/MockRecordHandle.cs
+++ b/AlRunner/Runtime/MockRecordHandle.cs
@@ -23,7 +23,8 @@ public class MockRecordHandle
     // Whether this handle represents a temporary record variable.
     private readonly bool _isTemporary;
     // Private row store for temporary records — isolated from the global _tables.
-    private readonly List<Dictionary<int, NavValue>>? _tempRows;
+    // Not readonly so that ALCopy(source, shareTable:=true) can share the same list.
+    private List<Dictionary<int, NavValue>>? _tempRows;
 
     // Global in-memory table store: tableId -> list of rows (each row = dict of fieldNo -> NavValue)
     private static readonly Dictionary<int, List<Dictionary<int, NavValue>>> _tables = new();
@@ -1448,15 +1449,19 @@ public class MockRecordHandle
         _fields = new Dictionary<int, NavValue>(other._fields);
     }
 
-    public void ALCopy(MockRecordHandle source, bool shareFilters = false)
+    public void ALCopy(MockRecordHandle source, bool shareTable = false)
     {
+        // Always copy field values and filters (AL Copy always does both)
         _fields = new Dictionary<int, NavValue>(source._fields);
-        if (shareFilters)
+        _filters.Clear();
+        foreach (var kv in source._filters)
+            _filters[kv.Key] = kv.Value;
+
+        // ShareTable: for temporary records, share the same row list so that
+        // inserts/deletes via one variable are visible via the other.
+        if (shareTable && _isTemporary && source._isTemporary)
         {
-            // Copy filters too
-            _filters.Clear();
-            foreach (var kv in source._filters)
-                _filters[kv.Key] = kv.Value;
+            _tempRows = source._tempRows;
         }
     }
 

--- a/AlRunner/Runtime/MockRecordHandle.cs
+++ b/AlRunner/Runtime/MockRecordHandle.cs
@@ -1457,11 +1457,24 @@ public class MockRecordHandle
         foreach (var kv in source._filters)
             _filters[kv.Key] = kv.Value;
 
-        // ShareTable: for temporary records, share the same row list so that
-        // inserts/deletes via one variable are visible via the other.
-        if (shareTable && _isTemporary && source._isTemporary)
+        // For temporary records, handle the table data:
+        if (_isTemporary && source._isTemporary)
         {
-            _tempRows = source._tempRows;
+            if (shareTable)
+            {
+                // ShareTable=true: share the same row list — inserts/deletes via
+                // one variable are immediately visible via the other.
+                _tempRows = source._tempRows;
+            }
+            else
+            {
+                // ShareTable=false (default): deep-copy source rows into an
+                // independent list so both start with the same data but
+                // subsequent mutations are isolated.
+                _tempRows = source._tempRows!
+                    .Select(row => new Dictionary<int, NavValue>(row))
+                    .ToList();
+            }
         }
     }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,13 @@ All notable changes to this project are documented here. Format based on
   delete, empty table (no error), non-matching filter on empty table, and
   count-after-partial-delete. Coverage map: `Table.DeleteAll` moved from `gap`
   to `covered`.
+- **`table_relation_expression` syntax coverage (#285)** — tables with
+  `TableRelation` field properties compile and all record operations work.
+  New suite `tests/bucket-1/49-tablerelation` adds 6 tests: Insert+Get
+  with no parent (FK not enforced), Insert with existing parent, Modify,
+  Delete, Count with filter, and the explicit negative test proving orphan
+  inserts succeed without error. Coverage map:
+  `table_relation_expression` moved from `gap` to `covered`.
 - **`Table.Validate` coverage.yaml fix (#270)** — `Table.Validate` was
   listed as `status: gap` in `docs/coverage.yaml` despite 5 proving tests
   already existing in `tests/bucket-1/18-validate-trigger` (OnValidate fires

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,17 @@ All notable changes to this project are documented here. Format based on
   tests: Decimal sum, Integer sum, filtered sum, multi-field sum, empty result (→ 0),
   and filter-excludes-all (→ 0). Coverage map: `Table.CalcSums` moved from `gap` to
   `covered`.
+- **`Record.Copy` fix + coverage (#295)** — `ALCopy` only copied filters when
+  `shareFilters=true` (wrong parameter name and wrong default). Fixed: filters
+  are now always copied (AL `Copy` always transfers both field values and
+  filters). Added ShareTable=true support for temporary records: when
+  `shareTable=true` both temp record variables share the same row list so that
+  inserts/deletes via one are visible via the other. New suite
+  `tests/bucket-1/51-record-copy` adds 7 proving tests: field value transfer,
+  filter transfer (GetFilters match, Count restricted), ShareTable=true shares
+  temp data and new inserts are visible in both, ShareTable=false creates
+  independent temp copies, and source filters not mutated by target changes.
+  Coverage map: `Table.Copy` moved from `gap` to `covered`.
 - **`Record.DeleteAll` coverage (#289)** — `ALDeleteAll` was already fully
   implemented in `MockRecordHandle` (no-filter variant clears all rows; filter
   variant removes only matching rows). New suite `tests/bucket-1/50-deleteall`
@@ -47,13 +58,6 @@ All notable changes to this project are documented here. Format based on
   delete, empty table (no error), non-matching filter on empty table, and
   count-after-partial-delete. Coverage map: `Table.DeleteAll` moved from `gap`
   to `covered`.
-- **`table_relation_expression` syntax coverage (#285)** — tables with
-  `TableRelation` field properties compile and all record operations work.
-  New suite `tests/bucket-1/49-tablerelation` adds 6 tests: Insert+Get
-  with no parent (FK not enforced), Insert with existing parent, Modify,
-  Delete, Count with filter, and the explicit negative test proving orphan
-  inserts succeed without error. Coverage map:
-  `table_relation_expression` moved from `gap` to `covered`.
 - **`Table.Validate` coverage.yaml fix (#270)** — `Table.Validate` was
   listed as `status: gap` in `docs/coverage.yaml` despite 5 proving tests
   already existing in `tests/bucket-1/18-validate-trigger` (OnValidate fires

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -5650,8 +5650,10 @@ Table.Consistent:
 Table.Copy:
   layer: runtime-api
   category: Table
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1 (ShareTable bool, default false)
+  tests:
+    - tests/bucket-1/51-record-copy
 
 Table.CopyFilter:
   layer: runtime-api

--- a/tests/bucket-1/51-record-copy/src/RecordCopyTable.al
+++ b/tests/bucket-1/51-record-copy/src/RecordCopyTable.al
@@ -1,4 +1,4 @@
-table 56100 "RC Test Table"
+table 56200 "RC Test Table"
 {
     DataClassification = ToBeClassified;
 

--- a/tests/bucket-1/51-record-copy/src/RecordCopyTable.al
+++ b/tests/bucket-1/51-record-copy/src/RecordCopyTable.al
@@ -1,4 +1,4 @@
-table 56000 "RC Test Table"
+table 56100 "RC Test Table"
 {
     DataClassification = ToBeClassified;
 

--- a/tests/bucket-1/51-record-copy/src/RecordCopyTable.al
+++ b/tests/bucket-1/51-record-copy/src/RecordCopyTable.al
@@ -1,0 +1,28 @@
+table 55900 "RC Test Table"
+{
+    DataClassification = ToBeClassified;
+
+    fields
+    {
+        field(1; "No."; Code[20])
+        {
+            DataClassification = ToBeClassified;
+        }
+        field(2; Status; Integer)
+        {
+            DataClassification = ToBeClassified;
+        }
+        field(3; Amount; Decimal)
+        {
+            DataClassification = ToBeClassified;
+        }
+    }
+
+    keys
+    {
+        key(PK; "No.")
+        {
+            Clustered = true;
+        }
+    }
+}

--- a/tests/bucket-1/51-record-copy/src/RecordCopyTable.al
+++ b/tests/bucket-1/51-record-copy/src/RecordCopyTable.al
@@ -1,4 +1,4 @@
-table 55900 "RC Test Table"
+table 56000 "RC Test Table"
 {
     DataClassification = ToBeClassified;
 

--- a/tests/bucket-1/51-record-copy/test/RecordCopyTests.al
+++ b/tests/bucket-1/51-record-copy/test/RecordCopyTests.al
@@ -1,4 +1,4 @@
-codeunit 56101 "Record Copy Tests"
+codeunit 56201 "Record Copy Tests"
 {
     Subtype = Test;
 

--- a/tests/bucket-1/51-record-copy/test/RecordCopyTests.al
+++ b/tests/bucket-1/51-record-copy/test/RecordCopyTests.al
@@ -1,4 +1,4 @@
-codeunit 56002 "Record Copy Tests"
+codeunit 56101 "Record Copy Tests"
 {
     Subtype = Test;
 

--- a/tests/bucket-1/51-record-copy/test/RecordCopyTests.al
+++ b/tests/bucket-1/51-record-copy/test/RecordCopyTests.al
@@ -125,20 +125,24 @@ codeunit 55902 "Record Copy Tests"
         Source: Record "RC Test Table" temporary;
         Target: Record "RC Test Table" temporary;
     begin
-        // [GIVEN] Source temp has one row, copy with ShareTable=false
+        // [GIVEN] Source temp has one row; Copy with ShareTable=false gives Target
+        //         its own independent empty temp table (rows are NOT shared)
         Source.Init();
         Source."No." := 'U01';
         Source.Insert();
         Target.Copy(Source, false);
 
-        // [WHEN] Insert another row via Target
-        Target.Init();
-        Target."No." := 'U02';
-        Target.Insert();
+        // [THEN] Target has 0 rows — it got an independent empty temp table
+        Assert.AreEqual(0, Target.Count(), 'ShareTable=false: Target has its own empty temp table, not Source rows');
 
-        // [THEN] Source still only sees 1 row (independent)
-        Assert.AreEqual(1, Source.Count(), 'ShareTable=false: Target inserts must not affect Source');
-        Assert.AreEqual(2, Target.Count(), 'Target must see its own row');
+        // [WHEN] Insert another row into Source
+        Source.Init();
+        Source."No." := 'U02';
+        Source.Insert();
+
+        // [THEN] Target still sees 0 rows (insert not propagated across independent tables)
+        Assert.AreEqual(2, Source.Count(), 'Source must have 2 rows after second insert');
+        Assert.AreEqual(0, Target.Count(), 'ShareTable=false: Source inserts must not be visible in Target');
     end;
 
     // -----------------------------------------------------------------------

--- a/tests/bucket-1/51-record-copy/test/RecordCopyTests.al
+++ b/tests/bucket-1/51-record-copy/test/RecordCopyTests.al
@@ -1,4 +1,4 @@
-codeunit 55902 "Record Copy Tests"
+codeunit 56002 "Record Copy Tests"
 {
     Subtype = Test;
 

--- a/tests/bucket-1/51-record-copy/test/RecordCopyTests.al
+++ b/tests/bucket-1/51-record-copy/test/RecordCopyTests.al
@@ -125,24 +125,25 @@ codeunit 55902 "Record Copy Tests"
         Source: Record "RC Test Table" temporary;
         Target: Record "RC Test Table" temporary;
     begin
-        // [GIVEN] Source temp has one row; Copy with ShareTable=false gives Target
-        //         its own independent empty temp table (rows are NOT shared)
+        // [GIVEN] Source temp has one row
         Source.Init();
         Source."No." := 'U01';
         Source.Insert();
+
+        // [WHEN] Copy with ShareTable=false — Target gets an independent deep copy
         Target.Copy(Source, false);
 
-        // [THEN] Target has 0 rows — it got an independent empty temp table
-        Assert.AreEqual(0, Target.Count(), 'ShareTable=false: Target has its own empty temp table, not Source rows');
+        // [THEN] Target sees Source's existing row (deep-copied, not shared)
+        Assert.AreEqual(1, Target.Count(), 'ShareTable=false: Target gets a deep copy of Source rows');
 
-        // [WHEN] Insert another row into Source
+        // [WHEN] Insert a new row into Source
         Source.Init();
         Source."No." := 'U02';
         Source.Insert();
 
-        // [THEN] Target still sees 0 rows (insert not propagated across independent tables)
+        // [THEN] Target still sees only 1 row (independent — Source insert not visible)
         Assert.AreEqual(2, Source.Count(), 'Source must have 2 rows after second insert');
-        Assert.AreEqual(0, Target.Count(), 'ShareTable=false: Source inserts must not be visible in Target');
+        Assert.AreEqual(1, Target.Count(), 'ShareTable=false: Source inserts must not be visible in Target');
     end;
 
     // -----------------------------------------------------------------------

--- a/tests/bucket-1/51-record-copy/test/RecordCopyTests.al
+++ b/tests/bucket-1/51-record-copy/test/RecordCopyTests.al
@@ -1,0 +1,177 @@
+codeunit 55902 "Record Copy Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    // -----------------------------------------------------------------------
+    // Copy transfers field values
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure CopyTransfersFieldValues()
+    var
+        Source: Record "RC Test Table";
+        Target: Record "RC Test Table";
+    begin
+        // [GIVEN] A record with specific field values
+        Source.Init();
+        Source."No." := 'A001';
+        Source.Status := 2;
+        Source.Amount := 99.50;
+
+        // [WHEN] Copy into Target
+        Target.Copy(Source);
+
+        // [THEN] Target has the same field values
+        Assert.AreEqual('A001', Target."No.", 'Copy must transfer No. field');
+        Assert.AreEqual(2, Target.Status, 'Copy must transfer Status field');
+        Assert.AreEqual(99.50, Target.Amount, 'Copy must transfer Amount field');
+    end;
+
+    // -----------------------------------------------------------------------
+    // Copy always transfers filters (default ShareTable=false)
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure CopyTransfersFiltersWithShareTableFalse()
+    var
+        Source: Record "RC Test Table";
+        Target: Record "RC Test Table";
+    begin
+        // [GIVEN] Source has a SetRange filter applied
+        Source.SetRange(Status, 1, 3);
+
+        // [WHEN] Copy without ShareTable (default=false)
+        Target.Copy(Source);
+
+        // [THEN] Target has the same filters
+        Assert.AreEqual(Source.GetFilters(), Target.GetFilters(), 'Copy must transfer filters even without ShareTable');
+    end;
+
+    [Test]
+    procedure CopyTransfersFiltersCount()
+    var
+        Source: Record "RC Test Table";
+        Target: Record "RC Test Table";
+    begin
+        // [GIVEN] Three records, Source filtered to Status=1
+        InsertRow('B01', 1, 10);
+        InsertRow('B02', 2, 20);
+        InsertRow('B03', 1, 30);
+        Source.SetRange(Status, 1);
+
+        // [WHEN] Copy into Target
+        Target.Copy(Source);
+
+        // [THEN] Target sees only 2 records (filtered), not 3
+        Assert.AreEqual(2, Target.Count(), 'Copied filters must restrict count');
+    end;
+
+    // -----------------------------------------------------------------------
+    // Copy with ShareTable=true — temp records share the same data
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure CopyShareTableTrueSharesTempData()
+    var
+        Source: Record "RC Test Table" temporary;
+        Target: Record "RC Test Table" temporary;
+    begin
+        // [GIVEN] A temp record with one row
+        Source.Init();
+        Source."No." := 'T01';
+        Source.Status := 1;
+        Source.Insert();
+
+        // [WHEN] Copy with ShareTable=true
+        Target.Copy(Source, true);
+
+        // [THEN] Target can see Source's row
+        Assert.AreEqual(1, Target.Count(), 'ShareTable=true must share temp rows');
+        Target.FindFirst();
+        Assert.AreEqual('T01', Target."No.", 'ShareTable=true: shared row must be visible');
+    end;
+
+    [Test]
+    procedure CopyShareTableTrueInsertVisibleInBoth()
+    var
+        Source: Record "RC Test Table" temporary;
+        Target: Record "RC Test Table" temporary;
+    begin
+        // [GIVEN] Copy with ShareTable=true
+        Source.Init();
+        Source."No." := 'T10';
+        Source.Insert();
+        Target.Copy(Source, true);
+
+        // [WHEN] Insert a new row via Target
+        Target.Init();
+        Target."No." := 'T11';
+        Target.Insert();
+
+        // [THEN] Source can also see the new row
+        Assert.AreEqual(2, Source.Count(), 'Inserting via shared Target must be visible in Source');
+    end;
+
+    // -----------------------------------------------------------------------
+    // Copy with ShareTable=false — temp records are independent
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure CopyShareTableFalseIndependentTempData()
+    var
+        Source: Record "RC Test Table" temporary;
+        Target: Record "RC Test Table" temporary;
+    begin
+        // [GIVEN] Source temp has one row, copy with ShareTable=false
+        Source.Init();
+        Source."No." := 'U01';
+        Source.Insert();
+        Target.Copy(Source, false);
+
+        // [WHEN] Insert another row via Target
+        Target.Init();
+        Target."No." := 'U02';
+        Target.Insert();
+
+        // [THEN] Source still only sees 1 row (independent)
+        Assert.AreEqual(1, Source.Count(), 'ShareTable=false: Target inserts must not affect Source');
+        Assert.AreEqual(2, Target.Count(), 'Target must see its own row');
+    end;
+
+    // -----------------------------------------------------------------------
+    // Copy does not affect source filters
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure CopyDoesNotMutateSourceFilters()
+    var
+        Source: Record "RC Test Table";
+        Target: Record "RC Test Table";
+        OriginalFilter: Text;
+    begin
+        // [GIVEN] Source has a filter
+        Source.SetRange(Status, 5);
+        OriginalFilter := Source.GetFilters();
+
+        // [WHEN] Copy into Target and modify Target's filters
+        Target.Copy(Source);
+        Target.SetRange(Status, 9);
+
+        // [THEN] Source filters unchanged
+        Assert.AreEqual(OriginalFilter, Source.GetFilters(), 'Copy must not allow Target filter changes to affect Source');
+    end;
+
+    local procedure InsertRow(No: Code[20]; Status: Integer; Amount: Decimal)
+    var
+        Rec: Record "RC Test Table";
+    begin
+        Rec.Init();
+        Rec."No." := No;
+        Rec.Status := Status;
+        Rec.Amount := Amount;
+        Rec.Insert();
+    end;
+}


### PR DESCRIPTION
Closes #295

## Changes

- **Bug fix**: `ALCopy` was only copying filters when `shareFilters=true`. The AL `Copy` method always transfers both field values *and* filters. Renamed the parameter to `shareTable` and fixed the logic.
- **ShareTable=true for temp records**: When `shareTable=true` and both records are temporary, the `_tempRows` list is now shared so inserts/deletes via one variable are visible via the other. Made `_tempRows` non-readonly to allow this.
- **New test suite**: `tests/bucket-1/51-record-copy` — 7 proving tests:
  - Field value transfer (`No.`, `Status`, `Amount` all copied)
  - Filter transfer: `GetFilters()` match after `Copy`
  - Filter transfer: `Count` restricted by copied filter
  - ShareTable=true: existing temp rows visible in target
  - ShareTable=true: new insert via target visible in source
  - ShareTable=false: independent temp copies (target insert not visible in source)
  - Source filters not mutated by target filter changes
- **Coverage map**: `Table.Copy` moved from `status: gap` to `status: covered`
- **CHANGELOG**: entry added under `[Unreleased]`