### PR TITLE
fix: Table.ModifyAll coverage.yaml gap → covered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ All notable changes to this project are documented here. Format based on
 ## [Unreleased]
 
 ### Added
+- **`Table.ModifyAll` coverage.yaml fix (#292)** — `ALModifyAllSafe` was already
+  implemented in `MockRecordHandle`; coverage map incorrectly listed it as `gap`.
+  Existing suite `tests/bucket-1/30-modify-all` has 4 proving tests (update all,
+  filter-scoped update, empty table no-op, runTrigger overload). Coverage map:
+  `Table.ModifyAll` moved from `gap` to `covered`.
 - **`Record.CalcSums` implementation (#293)** — `ALCalcSums` was a no-op stub; now
   sums each requested field across all records matching the current filters and writes
   the result back into the record's fields. Integer fields stay `NavInteger`; Decimal

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -5916,8 +5916,10 @@ Table.Modify:
 Table.ModifyAll:
   layer: runtime-api
   category: Table
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests:
+    - tests/bucket-1/30-modify-all
+  notes: overloads=1; bulk-sets a field value on all filtered records
 
 Table.Next:
   layer: runtime-api


### PR DESCRIPTION
Closes #292

## What

`ALModifyAllSafe` in `MockRecordHandle` was already fully implemented — it bulk-updates a single field on all records matching the current filters, with an optional `runTrigger` overload. The `docs/coverage.yaml` entry for `Table.ModifyAll` incorrectly listed it as `gap`.

## Evidence

Existing suite `tests/bucket-1/30-modify-all` has 4 proving tests:

| Test | Proves |
|---|---|
| `ModifyAllUpdatesAllRecords` | All records updated when no filter |
| `ModifyAllWithFilterUpdatesMatchingOnly` | Only filter-matching records changed; non-matching unchanged |
| `ModifyAllOnEmptyTableDoesNotCrash` | Empty table is a no-op (count still 0) |
| `ModifyAllWithRunTrigger` | Two-arg overload with `runTrigger = true` |

## Coverage change

`docs/coverage.yaml`: `Table.ModifyAll` `gap` → `covered`