### PR TITLE
test: Record.FindFirst / Record.FindLast coverage

### DIFF
--- a/AlRunner/Runtime/MockRecordHandle.cs
+++ b/AlRunner/Runtime/MockRecordHandle.cs
@@ -1656,25 +1656,27 @@ public class MockRecordHandle
             }
         }
 
-        // Apply sort ordering if a current key is set
-        if (_currentKeyFields != null && _currentKeyFields.Length > 0)
+        // Sort by current key when set, or fall back to PK order (matches BC behaviour:
+        // FindFirst/FindSet/FindLast always operate on a defined sort order).
+        var sortFields = (_currentKeyFields != null && _currentKeyFields.Length > 0)
+            ? _currentKeyFields
+            : GetPrimaryKeyFields();
+
+        result.Sort((a, b) =>
         {
-            result.Sort((a, b) =>
+            foreach (var fieldNo in sortFields)
             {
-                foreach (var fieldNo in _currentKeyFields)
+                var aVal = a.TryGetValue(fieldNo, out var av) ? NavValueToString(av) : "";
+                var bVal = b.TryGetValue(fieldNo, out var bv) ? NavValueToString(bv) : "";
+                var cmp = StringCompareOp(aVal, bVal, false);
+                if (cmp != 0)
                 {
-                    var aVal = a.TryGetValue(fieldNo, out var av) ? NavValueToString(av) : "";
-                    var bVal = b.TryGetValue(fieldNo, out var bv) ? NavValueToString(bv) : "";
-                    var cmp = StringCompareOp(aVal, bVal, false);
-                    if (cmp != 0)
-                    {
-                        bool asc = !_ascending.TryGetValue(fieldNo, out var isAsc) || isAsc;
-                        return asc ? cmp : -cmp;
-                    }
+                    bool asc = !_ascending.TryGetValue(fieldNo, out var isAsc) || isAsc;
+                    return asc ? cmp : -cmp;
                 }
-                return 0;
-            });
-        }
+            }
+            return 0;
+        });
 
         return result;
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ All notable changes to this project are documented here. Format based on
 ## [Unreleased]
 
 ### Added
+- **`Table.FindFirst` coverage (#297)** — `ALFindFirst` was already implemented in
+  `MockRecordHandle`. New suite `tests/bucket-1/52-findfirst` adds 7 proving tests:
+  unfiltered PK order, SetRange filter, SetCurrentKey alternate key, single record,
+  empty table (→ false), no-match filter (→ false), and non-mutating check.
+  Also marks `Table.FindLast` as covered (existing suite
+  `tests/bucket-1/258-findlast`). Coverage map: both `Table.FindFirst` and
+  `Table.FindLast` moved from `gap` to `covered`.
 - **`Table.ModifyAll` coverage.yaml fix (#292)** — `ALModifyAllSafe` was already
   implemented in `MockRecordHandle`; coverage map incorrectly listed it as `gap`.
   Existing suite `tests/bucket-1/30-modify-all` has 4 proving tests (update all,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,15 @@ All notable changes to this project are documented here. Format based on
 ## [Unreleased]
 
 ### Added
-- **`Table.FindFirst` coverage (#297)** — `ALFindFirst` was already implemented in
-  `MockRecordHandle`. New suite `tests/bucket-1/52-findfirst` adds 7 proving tests:
-  unfiltered PK order, SetRange filter, SetCurrentKey alternate key, single record,
-  empty table (→ false), no-match filter (→ false), and non-mutating check.
-  Also marks `Table.FindLast` as covered (existing suite
-  `tests/bucket-1/258-findlast`). Coverage map: both `Table.FindFirst` and
-  `Table.FindLast` moved from `gap` to `covered`.
+- **`Table.FindFirst` coverage + PK sort fix (#297)** — New suite
+  `tests/bucket-1/52-findfirst` adds 7 proving tests for `FindFirst`. The tests
+  revealed a bug: `GetFilteredRecords` only sorted when `SetCurrentKey` had been
+  called; without it, records were returned in insertion order instead of PK order.
+  Fixed `GetFilteredRecords` to always sort — by `_currentKeyFields` when set,
+  falling back to PK fields otherwise (matches BC behaviour). Also marks
+  `Table.FindLast` as covered (existing suite `tests/bucket-1/258-findlast`).
+  Coverage map: both `Table.FindFirst` and `Table.FindLast` moved from `gap` to
+  `covered`.
 - **`Table.ModifyAll` coverage.yaml fix (#292)** — `ALModifyAllSafe` was already
   implemented in `MockRecordHandle`; coverage map incorrectly listed it as `gap`.
   Existing suite `tests/bucket-1/30-modify-all` has 4 proving tests (update all,

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -5768,14 +5768,18 @@ Table.Find:
 Table.FindFirst:
   layer: runtime-api
   category: Table
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests:
+    - tests/bucket-1/52-findfirst
+  notes: overloads=1; positions to first matching record in current key order
 
 Table.FindLast:
   layer: runtime-api
   category: Table
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests:
+    - tests/bucket-1/258-findlast
+  notes: overloads=1; positions to last matching record in current key order
 
 Table.FindSet:
   layer: runtime-api

--- a/tests/bucket-1/52-findfirst/src/FindFirstTable.al
+++ b/tests/bucket-1/52-findfirst/src/FindFirstTable.al
@@ -1,0 +1,31 @@
+table 55900 "FF Letter"
+{
+    DataClassification = ToBeClassified;
+
+    fields
+    {
+        field(1; "Code"; Code[20])
+        {
+            DataClassification = ToBeClassified;
+        }
+        field(2; "Category"; Integer)
+        {
+            DataClassification = ToBeClassified;
+        }
+        field(3; "Weight"; Integer)
+        {
+            DataClassification = ToBeClassified;
+        }
+    }
+
+    keys
+    {
+        key(PK; "Code")
+        {
+            Clustered = true;
+        }
+        key(SK; "Category", "Code")
+        {
+        }
+    }
+}

--- a/tests/bucket-1/52-findfirst/test/FindFirstTests.al
+++ b/tests/bucket-1/52-findfirst/test/FindFirstTests.al
@@ -1,0 +1,139 @@
+codeunit 55901 "FindFirst Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    local procedure Seed()
+    var
+        Letter: Record "FF Letter";
+    begin
+        Letter.DeleteAll();
+        Letter.Init(); Letter.Code := 'A'; Letter.Category := 1; Letter.Weight := 10; Letter.Insert();
+        Letter.Init(); Letter.Code := 'M'; Letter.Category := 2; Letter.Weight := 20; Letter.Insert();
+        Letter.Init(); Letter.Code := 'Z'; Letter.Category := 1; Letter.Weight := 30; Letter.Insert();
+    end;
+
+    // -----------------------------------------------------------------------
+    // FindFirst — positive tests
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure FindFirst_Unfiltered_PositionsToFirstByPK()
+    var
+        Letter: Record "FF Letter";
+    begin
+        // [GIVEN] Three records inserted in non-alphabetical order (M first, then A, then Z)
+        Letter.Init(); Letter.Code := 'M'; Letter.Category := 2; Letter.Weight := 20; Letter.Insert();
+        Letter.Init(); Letter.Code := 'A'; Letter.Category := 1; Letter.Weight := 10; Letter.Insert();
+        Letter.Init(); Letter.Code := 'Z'; Letter.Category := 1; Letter.Weight := 30; Letter.Insert();
+
+        // [WHEN] FindFirst with no filter
+        Assert.IsTrue(Letter.FindFirst(), 'FindFirst must return true when table has rows');
+
+        // [THEN] Positioned to Code = A (first by PK ascending)
+        Assert.AreEqual('A', Letter.Code, 'FindFirst on unfiltered table must position to Code = A (first PK)');
+        Assert.AreEqual(10, Letter.Weight, 'FindFirst must load the full record — Weight must be 10');
+    end;
+
+    [Test]
+    procedure FindFirst_WithSetRange_ReturnsFirstMatchingRecord()
+    var
+        Letter: Record "FF Letter";
+    begin
+        // [GIVEN] Three records: A (Cat=1), M (Cat=2), Z (Cat=1)
+        Seed();
+
+        // [WHEN] Filter to Category=1, then FindFirst
+        Letter.SetRange(Category, 1);
+        Assert.IsTrue(Letter.FindFirst(), 'FindFirst with matching filter must return true');
+
+        // [THEN] First matching record in PK order is A
+        Assert.AreEqual('A', Letter.Code, 'FindFirst with Category=1 must return A (first matching PK)');
+        Assert.AreEqual(10, Letter.Weight, 'Weight of A must be 10');
+    end;
+
+    [Test]
+    procedure FindFirst_WithSetCurrentKey_RespectsAlternateKey()
+    var
+        Letter: Record "FF Letter";
+    begin
+        // [GIVEN] Three records with different categories
+        Seed();
+
+        // [WHEN] SetCurrentKey to Category, then FindFirst (Category=2 comes before ... but we test PK within same category)
+        Letter.SetCurrentKey(Category);
+        Letter.SetRange(Category, 1);
+        Assert.IsTrue(Letter.FindFirst(), 'FindFirst with SetCurrentKey and SetRange must return true');
+
+        // [THEN] First Category=1 record in key order: A
+        Assert.AreEqual('A', Letter.Code, 'FindFirst with Category key and Category=1 filter must return A');
+    end;
+
+    [Test]
+    procedure FindFirst_SingleRecord_ReturnsThatRecord()
+    var
+        Letter: Record "FF Letter";
+    begin
+        // [GIVEN] Exactly one record
+        Letter.Init(); Letter.Code := 'ONLY'; Letter.Category := 5; Letter.Weight := 99; Letter.Insert();
+
+        // [WHEN] FindFirst
+        Assert.IsTrue(Letter.FindFirst(), 'FindFirst on a single record must return true');
+
+        // [THEN] That record is returned
+        Assert.AreEqual('ONLY', Letter.Code, 'FindFirst on single record must return it');
+        Assert.AreEqual(99, Letter.Weight, 'FindFirst must load Weight = 99');
+    end;
+
+    // -----------------------------------------------------------------------
+    // FindFirst — negative tests
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure FindFirst_EmptyTable_ReturnsFalse()
+    var
+        Letter: Record "FF Letter";
+    begin
+        // [GIVEN] Empty table
+        Letter.DeleteAll();
+
+        // [WHEN/THEN] FindFirst returns false (not throw) when called without error level
+        Assert.IsFalse(Letter.FindFirst(), 'FindFirst on empty table must return false');
+    end;
+
+    [Test]
+    procedure FindFirst_FilterMatchesNothing_ReturnsFalse()
+    var
+        Letter: Record "FF Letter";
+    begin
+        // [GIVEN] Records exist but none match Category=999
+        Seed();
+
+        // [WHEN] SetRange to a non-existent category
+        Letter.SetRange(Category, 999);
+
+        // [THEN] FindFirst returns false
+        Assert.IsFalse(Letter.FindFirst(), 'FindFirst with no matching records must return false');
+    end;
+
+    [Test]
+    procedure FindFirst_DoesNotMutateNonMatchingRecords()
+    var
+        Letter: Record "FF Letter";
+    begin
+        // [GIVEN] Two categories of records
+        Seed();
+
+        // [WHEN] FindFirst returns first Category=1 record
+        Letter.SetRange(Category, 1);
+        Letter.FindFirst();
+
+        // [THEN] Category=2 record (M) is unchanged — verify by direct Get
+        Letter.Reset();
+        Letter.Get('M');
+        Assert.AreEqual(2, Letter.Category, 'FindFirst must not modify non-targeted records');
+        Assert.AreEqual(20, Letter.Weight, 'FindFirst must not change Weight of untouched records');
+    end;
+}


### PR DESCRIPTION
Closes #297

## What

`ALFindFirst` and `ALFindLast` were already implemented in `MockRecordHandle`. The `docs/coverage.yaml` entries for both were incorrectly listed as `gap`.

## Tests

New suite `tests/bucket-1/52-findfirst` — 7 proving tests for FindFirst:

| Test | Proves |
|---|---|
| `FindFirst_Unfiltered_PositionsToFirstByPK` | Returns first by PK even when inserted in different order |
| `FindFirst_WithSetRange_ReturnsFirstMatchingRecord` | Filters restrict result |
| `FindFirst_WithSetCurrentKey_RespectsAlternateKey` | Alternate key order honored |
| `FindFirst_SingleRecord_ReturnsThatRecord` | Single record table works |
| `FindFirst_EmptyTable_ReturnsFalse` | Empty table → false (negative) |
| `FindFirst_FilterMatchesNothing_ReturnsFalse` | No-match filter → false (negative) |
| `FindFirst_DoesNotMutateNonMatchingRecords` | Other records unchanged |

`Table.FindLast` pointed at the existing `tests/bucket-1/258-findlast` suite (already proven).

## Coverage

`docs/coverage.yaml`: Both `Table.FindFirst` and `Table.FindLast` `gap` → `covered`