### PR TITLE
test: Record.FindSet / SetCurrentKey iteration coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ All notable changes to this project are documented here. Format based on
 ## [Unreleased]
 
 ### Added
+- **`Table.FindSet` / `SetCurrentKey` iteration coverage (#301)** — New suite
+  `tests/bucket-1/53-findset` adds 8 proving tests: PK-order iteration (no
+  `SetCurrentKey`), Name-key iteration, Priority-key iteration, filter+key
+  combined, `FindSet` returns true/false, empty table → false, no-match filter
+  → false, and `FindLast` with `SetCurrentKey`. `SetCurrentKey` sort was already
+  wired via the PK-sort fix in #297. Coverage map: `Table.FindSet` moved from
+  `gap` to `covered`.
 - **`Table.FindFirst` coverage + PK sort fix (#297)** — New suite
   `tests/bucket-1/52-findfirst` adds 7 proving tests for `FindFirst`. The tests
   revealed a bug: `GetFilteredRecords` only sorted when `SetCurrentKey` had been

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -5784,8 +5784,10 @@ Table.FindLast:
 Table.FindSet:
   layer: runtime-api
   category: Table
-  status: gap
-  notes: overloads=2
+  status: covered
+  tests:
+    - tests/bucket-1/53-findset
+  notes: overloads=2; SetCurrentKey sort order respected via GetFilteredRecords PK-fallback fix
 
 Table.Get:
   layer: runtime-api

--- a/tests/bucket-1/53-findset/src/FindSetTable.al
+++ b/tests/bucket-1/53-findset/src/FindSetTable.al
@@ -1,0 +1,34 @@
+table 56000 "FS Item"
+{
+    DataClassification = ToBeClassified;
+
+    fields
+    {
+        field(1; "No."; Code[20])
+        {
+            DataClassification = ToBeClassified;
+        }
+        field(2; "Name"; Text[100])
+        {
+            DataClassification = ToBeClassified;
+        }
+        field(3; "Priority"; Integer)
+        {
+            DataClassification = ToBeClassified;
+        }
+    }
+
+    keys
+    {
+        key(PK; "No.")
+        {
+            Clustered = true;
+        }
+        key(SK_Name; "Name")
+        {
+        }
+        key(SK_Priority; "Priority", "No.")
+        {
+        }
+    }
+}

--- a/tests/bucket-1/53-findset/test/FindSetTests.al
+++ b/tests/bucket-1/53-findset/test/FindSetTests.al
@@ -1,0 +1,170 @@
+codeunit 56001 "FindSet Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    local procedure Seed()
+    var
+        Item: Record "FS Item";
+    begin
+        Item.DeleteAll();
+        // Insert in non-alphabetical, non-priority order to prove sorting
+        Item.Init(); Item."No." := 'C'; Item.Name := 'Charlie'; Item.Priority := 2; Item.Insert();
+        Item.Init(); Item."No." := 'A'; Item.Name := 'Alpha';   Item.Priority := 3; Item.Insert();
+        Item.Init(); Item."No." := 'B'; Item.Name := 'Bravo';   Item.Priority := 1; Item.Insert();
+    end;
+
+    // -----------------------------------------------------------------------
+    // FindSet — PK order (default, no SetCurrentKey)
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure FindSet_NoPKOrder_IteratesInPKOrder()
+    var
+        Item: Record "FS Item";
+        Codes: Text;
+    begin
+        // [GIVEN] Three records inserted out-of-PK order
+        Seed();
+
+        // [WHEN] FindSet with no SetCurrentKey, iterate with Next
+        Item.FindSet();
+        repeat
+            Codes += Item."No.";
+        until Item.Next() = 0;
+
+        // [THEN] Codes come out A B C (PK ascending)
+        Assert.AreEqual('ABC', Codes, 'FindSet without SetCurrentKey must iterate in PK order');
+    end;
+
+    [Test]
+    procedure FindSet_WithSetCurrentKey_IteratesInAlternateKeyOrder()
+    var
+        Item: Record "FS Item";
+        Names: Text;
+    begin
+        // [GIVEN] Three records: C=Charlie, A=Alpha, B=Bravo
+        Seed();
+
+        // [WHEN] SetCurrentKey to Name, then FindSet
+        Item.SetCurrentKey(Name);
+        Item.FindSet();
+        repeat
+            Names += Item.Name + '|';
+        until Item.Next() = 0;
+
+        // [THEN] Names come out Alpha|Bravo|Charlie| (Name ascending)
+        Assert.AreEqual('Alpha|Bravo|Charlie|', Names, 'FindSet with SetCurrentKey(Name) must iterate in Name order');
+    end;
+
+    [Test]
+    procedure FindSet_WithSetCurrentKeyPriority_IteratesInPriorityOrder()
+    var
+        Item: Record "FS Item";
+        Codes: Text;
+    begin
+        // [GIVEN] A=Priority 3, B=Priority 1, C=Priority 2
+        Seed();
+
+        // [WHEN] SetCurrentKey to Priority
+        Item.SetCurrentKey(Priority);
+        Item.FindSet();
+        repeat
+            Codes += Item."No.";
+        until Item.Next() = 0;
+
+        // [THEN] B(1) C(2) A(3) — sorted by Priority ascending
+        Assert.AreEqual('BCA', Codes, 'FindSet with SetCurrentKey(Priority) must iterate in Priority order');
+    end;
+
+    // -----------------------------------------------------------------------
+    // FindSet — with filters
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure FindSet_WithFilterAndSetCurrentKey_RespectsFilterAndOrder()
+    var
+        Item: Record "FS Item";
+        Codes: Text;
+    begin
+        // [GIVEN] Four records: A(P=3), B(P=1), C(P=2), D(P=2)
+        Seed();
+        Item.Init(); Item."No." := 'D'; Item.Name := 'Delta'; Item.Priority := 2; Item.Insert();
+
+        // [WHEN] Filter to Priority >= 2, SetCurrentKey(Priority), FindSet
+        Item.SetCurrentKey(Priority);
+        Item.SetFilter(Priority, '>=2');
+        Item.FindSet();
+        repeat
+            Codes += Item."No.";
+        until Item.Next() = 0;
+
+        // [THEN] C and D (P=2) then A (P=3), ordered by Priority then PK
+        Assert.AreEqual('CDA', Codes, 'FindSet with filter and SetCurrentKey must respect both filter and sort order');
+    end;
+
+    [Test]
+    procedure FindSet_ReturnsTrueWhenRecordsExist()
+    var
+        Item: Record "FS Item";
+    begin
+        // [GIVEN] At least one record
+        Seed();
+
+        // [WHEN/THEN] FindSet returns true
+        Assert.IsTrue(Item.FindSet(), 'FindSet must return true when records exist');
+    end;
+
+    // -----------------------------------------------------------------------
+    // FindSet — negative tests
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure FindSet_EmptyTable_ReturnsFalse()
+    var
+        Item: Record "FS Item";
+    begin
+        // [GIVEN] Empty table
+        Item.DeleteAll();
+
+        // [WHEN/THEN] FindSet returns false
+        Assert.IsFalse(Item.FindSet(), 'FindSet on empty table must return false');
+    end;
+
+    [Test]
+    procedure FindSet_FilterMatchesNothing_ReturnsFalse()
+    var
+        Item: Record "FS Item";
+    begin
+        // [GIVEN] Records exist but none match Priority=999
+        Seed();
+
+        // [WHEN] SetRange to non-existent priority
+        Item.SetRange(Priority, 999);
+
+        // [THEN] FindSet returns false
+        Assert.IsFalse(Item.FindSet(), 'FindSet with no matching records must return false');
+    end;
+
+    // -----------------------------------------------------------------------
+    // FindLast — respects SetCurrentKey
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure FindLast_WithSetCurrentKey_ReturnsLastInAlternateKeyOrder()
+    var
+        Item: Record "FS Item";
+    begin
+        // [GIVEN] A=Alpha, B=Bravo, C=Charlie sorted by Name: Alpha < Bravo < Charlie
+        Seed();
+
+        // [WHEN] SetCurrentKey(Name), FindLast
+        Item.SetCurrentKey(Name);
+        Assert.IsTrue(Item.FindLast(), 'FindLast with SetCurrentKey must return true');
+
+        // [THEN] Last by Name order is Charlie
+        Assert.AreEqual('C', Item."No.", 'FindLast with SetCurrentKey(Name) must return C (Charlie = last by Name)');
+    end;
+}


### PR DESCRIPTION
Closes #301

## What

`Table.FindSet` was listed as `gap` in `docs/coverage.yaml`. The `SetCurrentKey` sort order was already wired after the PK-sort fix in #297 (`GetFilteredRecords` now always sorts — by `_currentKeyFields` when set, falling back to PK otherwise).

## Tests

New suite `tests/bucket-1/53-findset` — 8 proving tests:

| Test | Proves |
|---|---|
| `FindSet_NoPKOrder_IteratesInPKOrder` | Inserted C-A-B, iterates A-B-C (PK) |
| `FindSet_WithSetCurrentKey_IteratesInAlternateKeyOrder` | Name key: Alpha→Bravo→Charlie |
| `FindSet_WithSetCurrentKeyPriority_IteratesInPriorityOrder` | Priority key: B(1)→C(2)→A(3) |
| `FindSet_WithFilterAndSetCurrentKey_RespectsFilterAndOrder` | Filter + alternate key combined |
| `FindSet_ReturnsTrueWhenRecordsExist` | True when records present |
| `FindSet_EmptyTable_ReturnsFalse` | Empty → false (negative) |
| `FindSet_FilterMatchesNothing_ReturnsFalse` | No-match → false (negative) |
| `FindLast_WithSetCurrentKey_ReturnsLastInAlternateKeyOrder` | FindLast also respects alternate key |

## Coverage

`docs/coverage.yaml`: `Table.FindSet` `gap` → `covered`