### PR TITLE
test: Record.TestField with enum field coverage (#302)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ All notable changes to this project are documented here. Format based on
 ## [Unreleased]
 
 ### Added
+- **`Table.TestField` enum coverage (#302)** — New suite `tests/bucket-1/54-testfield-enum`
+  adds 6 proving tests for `TestField` with enum fields: matching enum value passes,
+  wrong value errors, default-vs-non-zero, non-default passes the no-value check, and
+  default value fails the no-value check. Coverage map: `Table.TestField` moved from
+  `gap` to `covered` (also surfaces the existing `27-testfield-error` suite).
 - **`Table.FindSet` / `SetCurrentKey` iteration coverage (#301)** — New suite
   `tests/bucket-1/53-findset` adds 8 proving tests: PK-order iteration (no
   `SetCurrentKey`), Name-key iteration, Priority-key iteration, filter+key

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -6075,8 +6075,11 @@ Table.TableName:
 Table.TestField:
   layer: runtime-api
   category: Table
-  status: gap
-  notes: overloads=26
+  status: covered
+  tests:
+    - tests/bucket-1/27-testfield-error
+    - tests/bucket-1/54-testfield-enum
+  notes: overloads=26; basic non-empty check and enum value comparison covered
 
 Table.TransferFields:
   layer: runtime-api

--- a/tests/bucket-1/54-testfield-enum/src/TestFieldEnumObjects.al
+++ b/tests/bucket-1/54-testfield-enum/src/TestFieldEnumObjects.al
@@ -1,0 +1,39 @@
+enum 56100 "TFE Status"
+{
+    Extensible = false;
+
+    value(0; "Draft")
+    {
+    }
+    value(1; "Active")
+    {
+    }
+    value(2; "Closed")
+    {
+    }
+}
+
+table 56100 "TFE Order"
+{
+    DataClassification = ToBeClassified;
+
+    fields
+    {
+        field(1; "No."; Code[20])
+        {
+            DataClassification = ToBeClassified;
+        }
+        field(2; "Status"; Enum "TFE Status")
+        {
+            DataClassification = ToBeClassified;
+        }
+    }
+
+    keys
+    {
+        key(PK; "No.")
+        {
+            Clustered = true;
+        }
+    }
+}

--- a/tests/bucket-1/54-testfield-enum/test/TestFieldEnumTests.al
+++ b/tests/bucket-1/54-testfield-enum/test/TestFieldEnumTests.al
@@ -1,0 +1,117 @@
+codeunit 56101 "TestField Enum Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    local procedure MakeOrder(No: Code[20]; Status: Enum "TFE Status")
+    var
+        Ord: Record "TFE Order";
+    begin
+        Ord.DeleteAll();
+        Ord.Init();
+        Ord."No." := No;
+        Ord.Status := Status;
+        Ord.Insert();
+    end;
+
+    // -----------------------------------------------------------------------
+    // TestField(Field, EnumValue) — positive: matching value passes
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure TestField_EnumMatchingValue_NoError()
+    var
+        Ord: Record "TFE Order";
+    begin
+        // [GIVEN] An order with Status = Active
+        MakeOrder('ORD-1', "TFE Status"::Active);
+        Ord.Get('ORD-1');
+
+        // [WHEN/THEN] TestField with exact matching enum value — no error raised
+        Ord.TestField(Status, "TFE Status"::Active);
+    end;
+
+    [Test]
+    procedure TestField_EnumMatchingClosedValue_NoError()
+    var
+        Ord: Record "TFE Order";
+    begin
+        // [GIVEN] An order with Status = Closed
+        MakeOrder('ORD-2', "TFE Status"::Closed);
+        Ord.Get('ORD-2');
+
+        // [WHEN/THEN] TestField with matching Closed enum value — no error
+        Ord.TestField(Status, "TFE Status"::Closed);
+    end;
+
+    // -----------------------------------------------------------------------
+    // TestField(Field, EnumValue) — negative: wrong value errors
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure TestField_EnumWrongValue_Errors()
+    var
+        Ord: Record "TFE Order";
+    begin
+        // [GIVEN] An order with Status = Active
+        MakeOrder('ORD-3', "TFE Status"::Active);
+        Ord.Get('ORD-3');
+
+        // [WHEN] TestField expects Closed but Status is Active
+        asserterror Ord.TestField(Status, "TFE Status"::Closed);
+
+        // [THEN] Error is raised (TestField failure message)
+        Assert.ExpectedError('TestField');
+    end;
+
+    [Test]
+    procedure TestField_EnumDefaultExpectedButNonZero_Errors()
+    var
+        Ord: Record "TFE Order";
+    begin
+        // [GIVEN] An order with Status = Active (ordinal 1)
+        MakeOrder('ORD-4', "TFE Status"::Active);
+        Ord.Get('ORD-4');
+
+        // [WHEN] TestField expects Draft (ordinal 0) but field is Active
+        asserterror Ord.TestField(Status, "TFE Status"::Draft);
+
+        // [THEN] Error is raised
+        Assert.ExpectedError('TestField');
+    end;
+
+    // -----------------------------------------------------------------------
+    // TestField(Field) without expected value — non-zero check
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure TestField_EnumNonDefault_NoError()
+    var
+        Ord: Record "TFE Order";
+    begin
+        // [GIVEN] An order with Status = Active (non-zero)
+        MakeOrder('ORD-5', "TFE Status"::Active);
+        Ord.Get('ORD-5');
+
+        // [WHEN/THEN] TestField(Status) passes since value is non-default
+        Ord.TestField(Status);
+    end;
+
+    [Test]
+    procedure TestField_EnumAtDefault_Errors()
+    var
+        Ord: Record "TFE Order";
+    begin
+        // [GIVEN] An order with Status = Draft (ordinal 0 — default)
+        MakeOrder('ORD-6', "TFE Status"::Draft);
+        Ord.Get('ORD-6');
+
+        // [WHEN] TestField(Status) — must have a non-default value
+        asserterror Ord.TestField(Status);
+
+        // [THEN] Error is raised since Status is at default value
+        Assert.ExpectedError('TestField');
+    end;
+}


### PR DESCRIPTION
Closes #302

Add 6 proving tests for `TestField` with AL enum fields in new suite `tests/bucket-1/54-testfield-enum`.

## What is tested

| Test | Scenario |
|---|---|
| `TestField_EnumMatchingValue_NoError` | `TestField(Status, Active)` when field = Active → passes |
| `TestField_EnumMatchingClosedValue_NoError` | `TestField(Status, Closed)` when field = Closed → passes |
| `TestField_EnumWrongValue_Errors` | `TestField(Status, Closed)` when field = Active → errors |
| `TestField_EnumDefaultExpectedButNonZero_Errors` | `TestField(Status, Draft)` when field = Active → errors |
| `TestField_EnumNonDefault_NoError` | `TestField(Status)` when field = Active (non-default) → passes |
| `TestField_EnumAtDefault_Errors` | `TestField(Status)` when field = Draft (ordinal 0) → errors |

## Coverage

- `Table.TestField`: `gap` → `covered` (also surfaces existing `27-testfield-error` suite in the manifest)

## Notes

No runtime changes were required — `ALTestFieldSafe` already compares values via `NavValueToString`, which returns the numeric ordinal for `NavOption`/enum fields. This PR proves the feature works and closes the coverage gap.