### PR TITLE
test: Record.SetAscending sort direction coverage (#305)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ All notable changes to this project are documented here. Format based on
 ## [Unreleased]
 
 ### Added
+- **`Table.SetAscending` coverage (#305)** — New suite `tests/bucket-1/55-setascending`
+  adds 6 proving tests: default PK ascending, `SetAscending(Name, false)` → descending,
+  explicit `SetAscending(Name, true)`, composite key with mixed directions (Priority asc +
+  Code desc), `Reset()` restores default ascending, and `FindLast` with descending key.
+  Coverage map: `Table.SetAscending` moved from `gap` to `covered`.
 - **`Table.TestField` enum coverage (#302)** — New suite `tests/bucket-1/54-testfield-enum`
   adds 6 proving tests for `TestField` with enum fields: matching enum value passes,
   wrong value errors, default-vs-non-zero, non-default passes the no-value check, and

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -5994,8 +5994,10 @@ Table.SecurityFiltering:
 Table.SetAscending:
   layer: runtime-api
   category: Table
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests:
+    - tests/bucket-1/55-setascending
+  notes: overloads=1; ascending/descending per key field, composite key, Reset clears direction
 
 Table.SetAutoCalcFields:
   layer: runtime-api

--- a/tests/bucket-1/55-setascending/src/SetAscendingTable.al
+++ b/tests/bucket-1/55-setascending/src/SetAscendingTable.al
@@ -1,4 +1,4 @@
-table 56200 "SA Item"
+table 56300 "SA Item"
 {
     DataClassification = ToBeClassified;
 

--- a/tests/bucket-1/55-setascending/src/SetAscendingTable.al
+++ b/tests/bucket-1/55-setascending/src/SetAscendingTable.al
@@ -1,0 +1,34 @@
+table 56200 "SA Item"
+{
+    DataClassification = ToBeClassified;
+
+    fields
+    {
+        field(1; "Code"; Code[20])
+        {
+            DataClassification = ToBeClassified;
+        }
+        field(2; "Name"; Text[100])
+        {
+            DataClassification = ToBeClassified;
+        }
+        field(3; "Priority"; Integer)
+        {
+            DataClassification = ToBeClassified;
+        }
+    }
+
+    keys
+    {
+        key(PK; "Code")
+        {
+            Clustered = true;
+        }
+        key(SK_Name; "Name")
+        {
+        }
+        key(SK_Priority; "Priority", "Code")
+        {
+        }
+    }
+}

--- a/tests/bucket-1/55-setascending/test/SetAscendingTests.al
+++ b/tests/bucket-1/55-setascending/test/SetAscendingTests.al
@@ -1,0 +1,171 @@
+codeunit 56201 "SetAscending Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    local procedure Seed()
+    var
+        Item: Record "SA Item";
+    begin
+        Item.DeleteAll();
+        // Inserted out-of-order to prove sorting is by key, not insertion order
+        // Code: C/B/A, Name: Charlie/Bravo/Alpha, Priority: 2/1/3
+        Item.Init(); Item.Code := 'C'; Item.Name := 'Charlie'; Item.Priority := 2; Item.Insert();
+        Item.Init(); Item.Code := 'B'; Item.Name := 'Bravo';   Item.Priority := 1; Item.Insert();
+        Item.Init(); Item.Code := 'A'; Item.Name := 'Alpha';   Item.Priority := 3; Item.Insert();
+    end;
+
+    // -----------------------------------------------------------------------
+    // Default ascending (no SetAscending call)
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure SetAscending_DefaultPKAscending()
+    var
+        Item: Record "SA Item";
+        Codes: Text;
+    begin
+        // [GIVEN] Three records inserted in non-PK order
+        Seed();
+
+        // [WHEN] FindSet with no SetAscending — default is ascending
+        Item.FindSet();
+        repeat
+            Codes += Item.Code;
+        until Item.Next() = 0;
+
+        // [THEN] Codes come out A B C (PK ascending)
+        Assert.AreEqual('ABC', Codes, 'Default sort must be PK ascending');
+    end;
+
+    // -----------------------------------------------------------------------
+    // SetAscending(field, false) — descending order
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure SetAscending_NameDescending_IteratesZtoA()
+    var
+        Item: Record "SA Item";
+        Names: Text;
+    begin
+        // [GIVEN] Three records with distinct Names
+        Seed();
+
+        // [WHEN] SetCurrentKey(Name), SetAscending(Name, false), FindSet
+        Item.SetCurrentKey(Name);
+        Item.SetAscending(Name, false);
+        Item.FindSet();
+        repeat
+            Names += Item.Name + '|';
+        until Item.Next() = 0;
+
+        // [THEN] Names come out Charlie|Bravo|Alpha| (Name descending)
+        Assert.AreEqual('Charlie|Bravo|Alpha|', Names, 'SetAscending(Name, false) must iterate Name descending');
+    end;
+
+    [Test]
+    procedure SetAscending_NameAscending_IteratesAtoZ()
+    var
+        Item: Record "SA Item";
+        Names: Text;
+    begin
+        // [GIVEN] Three records
+        Seed();
+
+        // [WHEN] SetCurrentKey(Name), SetAscending(Name, true) — explicit ascending
+        Item.SetCurrentKey(Name);
+        Item.SetAscending(Name, true);
+        Item.FindSet();
+        repeat
+            Names += Item.Name + '|';
+        until Item.Next() = 0;
+
+        // [THEN] Names come out Alpha|Bravo|Charlie| (Name ascending)
+        Assert.AreEqual('Alpha|Bravo|Charlie|', Names, 'SetAscending(Name, true) must iterate Name ascending');
+    end;
+
+    // -----------------------------------------------------------------------
+    // SetAscending affects only the specified field — composite key
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure SetAscending_CompositeKey_PriorityAscCodeDesc()
+    var
+        Item: Record "SA Item";
+        Items: Text;
+    begin
+        // [GIVEN] Four records: A(P=1), B(P=1), C(P=2), D(P=2)
+        Seed();
+        Item.Init(); Item.Code := 'D'; Item.Name := 'Delta'; Item.Priority := 2; Item.Insert();
+
+        // [WHEN] SetCurrentKey(Priority, Code), Priority ascending (default), Code descending
+        Item.SetCurrentKey(Priority, Code);
+        Item.SetAscending(Priority, true);
+        Item.SetAscending(Code, false);
+        Item.FindSet();
+        repeat
+            Items += Item.Code;
+        until Item.Next() = 0;
+
+        // [THEN] Priority 1 first (B, A — Code desc), then Priority 2 (D, C — Code desc)
+        Assert.AreEqual('BADC', Items, 'Composite key: Priority asc, Code desc must give BADC');
+    end;
+
+    // -----------------------------------------------------------------------
+    // Reset clears ascending setting
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure SetAscending_ResetClearsDirection()
+    var
+        Item: Record "SA Item";
+        Codes: Text;
+    begin
+        // [GIVEN] Records, SetAscending(Code, false) set to descending
+        Seed();
+        Item.SetCurrentKey(Code);
+        Item.SetAscending(Code, false);
+
+        // Confirm descending first
+        Item.FindSet();
+        repeat
+            Codes += Item.Code;
+        until Item.Next() = 0;
+        Assert.AreEqual('CBA', Codes, 'Before Reset: descending must give CBA');
+
+        // [WHEN] Reset is called
+        Item.Reset();
+
+        // [THEN] Default ascending is restored after Reset
+        Codes := '';
+        Item.FindSet();
+        repeat
+            Codes += Item.Code;
+        until Item.Next() = 0;
+        Assert.AreEqual('ABC', Codes, 'After Reset: ascending must be restored, giving ABC');
+    end;
+
+    // -----------------------------------------------------------------------
+    // FindLast respects SetAscending
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure SetAscending_FindLast_WithDescendingKey()
+    var
+        Item: Record "SA Item";
+    begin
+        // [GIVEN] A=Alpha, B=Bravo, C=Charlie
+        Seed();
+
+        // [WHEN] SetCurrentKey(Name), SetAscending(Name, false) — Name desc
+        // FindLast in Name-desc order: the "last" is the smallest name = Alpha
+        Item.SetCurrentKey(Name);
+        Item.SetAscending(Name, false);
+        Item.FindLast();
+
+        // [THEN] FindLast in descending-name order yields Alpha (lowest name = last position)
+        Assert.AreEqual('A', Item.Code, 'FindLast with Name descending must return Alpha (Code=A)');
+    end;
+}

--- a/tests/bucket-1/55-setascending/test/SetAscendingTests.al
+++ b/tests/bucket-1/55-setascending/test/SetAscendingTests.al
@@ -1,4 +1,4 @@
-codeunit 56201 "SetAscending Tests"
+codeunit 56301 "SetAscending Tests"
 {
     Subtype = Test;
 

--- a/tests/bucket-1/55-setascending/test/SetAscendingTests.al
+++ b/tests/bucket-1/55-setascending/test/SetAscendingTests.al
@@ -96,7 +96,7 @@ codeunit 56201 "SetAscending Tests"
         Item: Record "SA Item";
         Items: Text;
     begin
-        // [GIVEN] Four records: A(P=1), B(P=1), C(P=2), D(P=2)
+        // [GIVEN] Four records: B(P=1), C(P=2), D(P=2), A(P=3) — from Seed + extra D
         Seed();
         Item.Init(); Item.Code := 'D'; Item.Name := 'Delta'; Item.Priority := 2; Item.Insert();
 
@@ -109,8 +109,8 @@ codeunit 56201 "SetAscending Tests"
             Items += Item.Code;
         until Item.Next() = 0;
 
-        // [THEN] Priority 1 first (B, A — Code desc), then Priority 2 (D, C — Code desc)
-        Assert.AreEqual('BADC', Items, 'Composite key: Priority asc, Code desc must give BADC');
+        // [THEN] B(P=1), then D and C (P=2, Code desc: D>C), then A(P=3)
+        Assert.AreEqual('BDCA', Items, 'Composite key: Priority asc, Code desc must give BDCA');
     end;
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
Closes #305

Add 6 proving tests for `Record.SetAscending` in new suite `tests/bucket-1/55-setascending`.

## What is tested

| Test | Scenario |
|---|---|
| `SetAscending_DefaultPKAscending` | No `SetAscending` call → FindSet gives A B C |
| `SetAscending_NameDescending_IteratesZtoA` | `SetAscending(Name, false)` → Charlie\|Bravo\|Alpha\| |
| `SetAscending_NameAscending_IteratesAtoZ` | `SetAscending(Name, true)` explicit → Alpha\|Bravo\|Charlie\| |
| `SetAscending_CompositeKey_PriorityAscCodeDesc` | Composite key: Priority asc + Code desc → BADC |
| `SetAscending_ResetClearsDirection` | `Reset()` restores default ascending after descending was set |
| `SetAscending_FindLast_WithDescendingKey` | `FindLast` with Name-desc key returns Alpha (smallest name = last position) |

## Coverage

- `Table.SetAscending`: `gap` → `covered`

## Notes

No runtime changes required — `ALSetAscending` and the `GetFilteredRecords` sort logic were already implemented correctly. This PR proves the feature works end-to-end and closes the coverage gap.