### PR TITLE
test: Record.IsEmpty coverage (#299)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to this project are documented here. Format based on
 ## [Unreleased]
 
 ### Added
+- **`Record.IsEmpty` coverage (#299)** — `ALIsEmpty` was already implemented in
+  `MockRecordHandle` (`GetFilteredAndMarkedRecords().Count == 0`) but had no proving
+  tests. New suite `tests/bucket-1/56-isempty` adds 5 proving tests: empty table →
+  true, records exist → false, filter excludes all → true, filter matches some →
+  false, Reset clears filter → false. Coverage map: `Table.IsEmpty` moved from `gap`
+  to `covered`.
 - **`Database.Commit` coverage (#311)** — `Commit()` was already a no-op (stripped by
   `StripEntireCallMethods` in `RoslynRewriter`) but had no proving tests. New suite
   `tests/bucket-1/56-database-commit` adds 4 tests: commit without error, commit after

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -5877,8 +5877,10 @@ Table.Insert:
 Table.IsEmpty:
   layer: runtime-api
   category: Table
-  status: gap
+  status: covered
   notes: overloads=1
+  tests:
+    - tests/bucket-1/56-isempty
 
 Table.IsTemporary:
   layer: runtime-api

--- a/tests/bucket-1/56-isempty/src/IsEmptyTable.al
+++ b/tests/bucket-1/56-isempty/src/IsEmptyTable.al
@@ -1,0 +1,24 @@
+table 56500 "IE Test Table"
+{
+    DataClassification = ToBeClassified;
+
+    fields
+    {
+        field(1; "No."; Code[20])
+        {
+            DataClassification = ToBeClassified;
+        }
+        field(2; Status; Integer)
+        {
+            DataClassification = ToBeClassified;
+        }
+    }
+
+    keys
+    {
+        key(PK; "No.")
+        {
+            Clustered = true;
+        }
+    }
+}

--- a/tests/bucket-1/56-isempty/src/IsEmptyTable.al
+++ b/tests/bucket-1/56-isempty/src/IsEmptyTable.al
@@ -1,4 +1,4 @@
-table 56500 "IE Test Table"
+table 56600 "IE Test Table"
 {
     DataClassification = ToBeClassified;
 

--- a/tests/bucket-1/56-isempty/test/IsEmptyTests.al
+++ b/tests/bucket-1/56-isempty/test/IsEmptyTests.al
@@ -1,4 +1,4 @@
-codeunit 56501 "IsEmpty Tests"
+codeunit 56601 "IsEmpty Tests"
 {
     Subtype = Test;
 

--- a/tests/bucket-1/56-isempty/test/IsEmptyTests.al
+++ b/tests/bucket-1/56-isempty/test/IsEmptyTests.al
@@ -1,0 +1,109 @@
+codeunit 56501 "IsEmpty Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    // -----------------------------------------------------------------------
+    // IsEmpty on a table with no records
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure IsEmptyReturnsTrueOnEmptyTable()
+    var
+        Rec: Record "IE Test Table";
+    begin
+        // [GIVEN] Table has no records (clean test isolation)
+        // [WHEN] IsEmpty called with no filters
+        // [THEN] Returns true
+        Assert.IsTrue(Rec.IsEmpty(), 'IsEmpty must return true on a table with no rows');
+    end;
+
+    // -----------------------------------------------------------------------
+    // IsEmpty on a table that has records
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure IsEmptyReturnsFalseWhenRecordsExist()
+    var
+        Rec: Record "IE Test Table";
+    begin
+        // [GIVEN] Table has one record
+        InsertRow('A001', 1);
+
+        // [WHEN] IsEmpty called with no filters
+        // [THEN] Returns false
+        Assert.IsFalse(Rec.IsEmpty(), 'IsEmpty must return false when rows exist');
+    end;
+
+    // -----------------------------------------------------------------------
+    // IsEmpty respects filters that exclude all records
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure IsEmptyReturnsTrueWhenFilterExcludesAll()
+    var
+        Rec: Record "IE Test Table";
+    begin
+        // [GIVEN] Table has records but filter matches none
+        InsertRow('B001', 1);
+        InsertRow('B002', 2);
+        Rec.SetRange(Status, 99);
+
+        // [WHEN] IsEmpty called with excluding filter
+        // [THEN] Returns true
+        Assert.IsTrue(Rec.IsEmpty(), 'IsEmpty must return true when filter matches no rows');
+    end;
+
+    // -----------------------------------------------------------------------
+    // IsEmpty respects filters that match some records
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure IsEmptyReturnsFalseWhenFilterMatchesSome()
+    var
+        Rec: Record "IE Test Table";
+    begin
+        // [GIVEN] Table has records, filter matches at least one
+        InsertRow('C001', 1);
+        InsertRow('C002', 2);
+        InsertRow('C003', 1);
+        Rec.SetRange(Status, 1);
+
+        // [WHEN] IsEmpty called with partial filter
+        // [THEN] Returns false (2 rows match)
+        Assert.IsFalse(Rec.IsEmpty(), 'IsEmpty must return false when filter matches some rows');
+    end;
+
+    // -----------------------------------------------------------------------
+    // IsEmpty after Reset clears filter — table again visible
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure IsEmptyAfterResetReflectsAllRows()
+    var
+        Rec: Record "IE Test Table";
+    begin
+        // [GIVEN] Table has records; filter set to exclude all; then Reset
+        InsertRow('D001', 1);
+        Rec.SetRange(Status, 99);
+        Assert.IsTrue(Rec.IsEmpty(), 'Pre-condition: filter must exclude all rows');
+
+        // [WHEN] Reset removes the filter
+        Rec.Reset();
+
+        // [THEN] IsEmpty returns false (rows are now visible)
+        Assert.IsFalse(Rec.IsEmpty(), 'IsEmpty must return false after Reset when rows exist');
+    end;
+
+    local procedure InsertRow(No: Code[20]; Status: Integer)
+    var
+        Rec: Record "IE Test Table";
+    begin
+        Rec.Init();
+        Rec."No." := No;
+        Rec.Status := Status;
+        Rec.Insert();
+    end;
+}


### PR DESCRIPTION
Closes #299

`ALIsEmpty` was already implemented in `MockRecordHandle` (`GetFilteredAndMarkedRecords().Count == 0`) but had no proving tests.

## Changes

- New suite `tests/bucket-1/56-isempty` (table 56400, codeunit 56401) with 5 proving tests:
  1. `IsEmptyReturnsTrueOnEmptyTable` — empty table → true
  2. `IsEmptyReturnsFalseWhenRecordsExist` — records exist, no filter → false
  3. `IsEmptyReturnsTrueWhenFilterExcludesAll` — filter matches 0 rows → true
  4. `IsEmptyReturnsFalseWhenFilterMatchesSome` — filter matches some rows → false
  5. `IsEmptyAfterResetReflectsAllRows` — excluding filter → Reset → false

- `docs/coverage.yaml`: `Table.IsEmpty` moved from `gap` to `covered`
- `CHANGELOG.md` entry added