### PR TITLE
test: Database.Commit proving tests (#311)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ All notable changes to this project are documented here. Format based on
 ## [Unreleased]
 
 ### Added
+- **`Database.Commit` coverage (#311)** — `Commit()` was already a no-op (stripped by
+  `StripEntireCallMethods` in `RoslynRewriter`) but had no proving tests. New suite
+  `tests/bucket-1/56-database-commit` adds 4 tests: commit without error, commit after
+  insert preserves records, multiple commits are all no-ops, commit after modify preserves
+  modified values. Coverage map: `Database.Commit` moved from `gap` to `covered`.
 - **`Table.SetAscending` coverage (#305)** — New suite `tests/bucket-1/55-setascending`
   adds 6 proving tests: default PK ascending, `SetAscending(Name, false)` → descending,
   explicit `SetAscending(Name, true)`, composite key with mixed directions (Priority asc +

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -1396,7 +1396,8 @@ Database.CheckLicenseFile:
 Database.Commit:
   layer: runtime-api
   category: Database
-  status: gap
+  status: covered
+  tests: tests/bucket-1/56-database-commit
   notes: overloads=1
 
 Database.CompanyName:

--- a/tests/bucket-1/56-database-commit/src/CommitHelper.al
+++ b/tests/bucket-1/56-database-commit/src/CommitHelper.al
@@ -1,0 +1,12 @@
+table 56400 "Commit Test Table"
+{
+    fields
+    {
+        field(1; Id; Integer) { }
+        field(2; Value; Text[50]) { }
+    }
+    keys
+    {
+        key(PK; Id) { Clustered = true; }
+    }
+}

--- a/tests/bucket-1/56-database-commit/test/TestDatabaseCommit.al
+++ b/tests/bucket-1/56-database-commit/test/TestDatabaseCommit.al
@@ -1,0 +1,63 @@
+codeunit 56401 "Test Database Commit"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    [Test]
+    procedure Commit_DoesNotError()
+    begin
+        // Commit() is a no-op in the runner — must not raise any error
+        Commit();
+        Assert.IsTrue(true, 'Commit() must complete without error');
+    end;
+
+    [Test]
+    procedure Commit_AfterInsert_RecordStillExists()
+    var
+        Rec: Record "Commit Test Table";
+    begin
+        // Insert, commit, then verify the record still exists
+        Rec.Id := 1;
+        Rec.Value := 'Before Commit';
+        Rec.Insert();
+
+        Commit();
+
+        Rec.Reset();
+        Assert.AreEqual(1, Rec.Count(), 'Commit() must not clear in-memory record state');
+        Rec.Get(1);
+        Assert.AreEqual('Before Commit', Rec.Value, 'Committed record must retain its field values');
+    end;
+
+    [Test]
+    procedure Commit_MultipleTimes_NoError()
+    begin
+        // Multiple commits in a row must all be no-ops
+        Commit();
+        Commit();
+        Commit();
+        Assert.IsTrue(true, 'Multiple Commit() calls must all complete without error');
+    end;
+
+    [Test]
+    procedure Commit_AfterModify_RecordHasNewValue()
+    var
+        Rec: Record "Commit Test Table";
+    begin
+        // Insert + modify + commit — record must retain the modified value
+        Rec.Id := 2;
+        Rec.Value := 'Original';
+        Rec.Insert();
+
+        Rec.Value := 'Modified';
+        Rec.Modify();
+
+        Commit();
+
+        Rec.Reset();
+        Rec.Get(2);
+        Assert.AreEqual('Modified', Rec.Value, 'Commit() after Modify must leave modified value intact');
+    end;
+}


### PR DESCRIPTION
Closes #311

## Summary

- `Commit()` / `ALCommit` was already a no-op (stripped by `StripEntireCallMethods` in `RoslynRewriter`) but had no proving tests
- Adds `tests/bucket-1/56-database-commit` with 4 tests proving the no-op works correctly
- Updates `docs/coverage.yaml`: `Database.Commit` → `covered`
- Adds `CHANGELOG.md` entry under `[Unreleased]`

## Test plan

- [ ] `Commit()` called alone completes without error
- [ ] `Commit()` after `Insert()` — record still exists with correct value
- [ ] Multiple `Commit()` calls in sequence — all no-ops, no error
- [ ] `Commit()` after `Modify()` — record retains modified value

🤖 Generated with [Claude Code](https://claude.com/claude-code)