### PR TITLE
feat: UserId() default stub value + coverage (#314)

### DIFF
--- a/AlRunner.Tests/PipelineTests.cs
+++ b/AlRunner.Tests/PipelineTests.cs
@@ -488,7 +488,7 @@ namespace AlRunnerGenerated {
     }
 
     [Fact]
-    public void UserId_DefaultIsEmptyString()
+    public void UserId_DefaultIsTestUser()
     {
         var pipeline = new AlRunnerPipeline();
         var result = pipeline.Run(new PipelineOptions

--- a/AlRunner/Pipeline.cs
+++ b/AlRunner/Pipeline.cs
@@ -26,7 +26,7 @@ public class PipelineOptions
     /// <summary>When true, promote exit code 2 (runner limitations) to exit code 1 (failure).</summary>
     public bool Strict { get; set; }
 
-    /// <summary>Configures the value returned by UserId() — defaults to empty string.</summary>
+    /// <summary>Configures the value returned by UserId() — defaults to "TESTUSER".</summary>
     public string? UserId { get; set; }
 
     /// <summary>
@@ -306,7 +306,7 @@ public class AlRunnerPipeline
             Log.Verbose = true;
 
         // Apply configurable session properties
-        Runtime.AlScope.UserId = options.UserId ?? "";
+        Runtime.AlScope.UserId = options.UserId ?? "TESTUSER";
 
         var alSources = new List<string>();
         var sourceFilePaths = new List<string?>(); // parallel to alSources: file path or null

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -51,7 +51,7 @@ if (args.Length == 0 || args.Any(a => a is "-h" or "--help"))
     Console.Error.WriteLine("  --no-telemetry        Disable crash reporting prompt on unexpected errors");
     Console.Error.WriteLine("  --strict              Fail on runner limitations (exit 1 instead of 2)");
     Console.Error.WriteLine("  --company-name <name> Default value returned by CompanyName() (empty string otherwise)");
-    Console.Error.WriteLine("  --user-id <value>     Set the value returned by UserId() (default: empty string)");
+    Console.Error.WriteLine("  --user-id <value>     Set the value returned by UserId() (default: TESTUSER)");
     Console.Error.WriteLine("  -h, --help            Show this help");
     Console.Error.WriteLine();
     Console.Error.WriteLine("Examples:");
@@ -352,7 +352,7 @@ test executor that needs no BC service tier, Docker, SQL Server, or license.
   CLI flag, and AL tests can set it at runtime by calling
   `codeunit 131100 "AL Runner Config"` → `SetCompanyName(Name: Text)`.
   Reset back to the CLI default between tests.
-- UserId() — configurable via `--user-id <value>` CLI flag (default: empty string)
+- UserId() — configurable via `--user-id <value>` CLI flag (default: "TESTUSER")
 - System & Session utilities:
   - Session.LogMessage() — no-op (telemetry not available without service tier)
   - Session.ApplicationArea() — returns empty string

--- a/AlRunner/Runtime/AlScope.cs
+++ b/AlRunner/Runtime/AlScope.cs
@@ -150,10 +150,10 @@ public class AlScope : IDisposable, ITreeObject
     public static string LastErrorText { get; set; } = "";
 
     /// <summary>
-    /// Configurable user ID returned by UserId() — defaults to empty string.
+    /// Configurable user ID returned by UserId() — defaults to "TESTUSER".
     /// Set via --user-id CLI flag or PipelineOptions.UserId before running.
     /// </summary>
-    public static string UserId { get; set; } = "";
+    public static string UserId { get; set; } = "TESTUSER";
 
     // NavMethodScope static fields/methods — the BC compiler can emit static
     // references to these on scope classes that inherit from AlScope.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ All notable changes to this project are documented here. Format based on
   call without error, call after insert still shows record with correct field value,
   multiple calls are all no-ops. Coverage map: `Database.SelectLatestVersion` moved
   from `gap` to `covered`.
+- **`UserId()` default stub value fix (#314)** — `AlScope.UserId` previously defaulted
+  to `""` (empty string), causing `Assert.AreNotEqual('', UserId())` to fail. Changed
+  default to `"TESTUSER"` so AL code calling `UserId()` gets a stable non-empty value
+  without requiring the `--user-id` CLI flag. New suite `tests/bucket-1/57-userid`
+  adds 2 proving tests: UserId is non-empty, UserId is consistent across calls.
+  Coverage map: `Database.UserId` moved from `gap` to `covered`.
 - **`Record.IsEmpty` coverage (#299)** — `ALIsEmpty` was already implemented in
   `MockRecordHandle` (`GetFilteredAndMarkedRecords().Count == 0`) but had no proving
   tests. New suite `tests/bucket-1/56-isempty` adds 5 proving tests: empty table →

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -1542,8 +1542,10 @@ Database.UnregisterTableConnection:
 Database.UserId:
   layer: runtime-api
   category: Database
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; default stub value "TESTUSER" (configurable via --user-id flag)
+  tests:
+    - tests/bucket-1/57-userid
 
 Database.UserSecurityId:
   layer: runtime-api

--- a/tests/bucket-1/45-userid/test/TestUserId.al
+++ b/tests/bucket-1/45-userid/test/TestUserId.al
@@ -6,12 +6,12 @@ codeunit 55000 "Test UserId"
         Assert: Codeunit Assert;
 
     [Test]
-    procedure UserIdReturnsEmptyStringByDefault()
+    procedure UserIdReturnsTestUserByDefault()
     var
         Id: Text;
     begin
-        // By default, UserId() returns empty string when not configured.
+        // By default, UserId() returns "TESTUSER" when not configured via --user-id.
         Id := UserId();
-        Assert.AreEqual('', Id, 'UserId() must return empty string when not configured');
+        Assert.AreEqual('TESTUSER', Id, 'UserId() must return TESTUSER when not configured');
     end;
 }

--- a/tests/bucket-1/57-userid/test/UserIdTests.al
+++ b/tests/bucket-1/57-userid/test/UserIdTests.al
@@ -1,4 +1,4 @@
-codeunit 56701 "UserId Tests"
+codeunit 56800 "UserId Tests"
 {
     Subtype = Test;
 

--- a/tests/bucket-1/57-userid/test/UserIdTests.al
+++ b/tests/bucket-1/57-userid/test/UserIdTests.al
@@ -1,0 +1,37 @@
+codeunit 56701 "UserId Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    // -----------------------------------------------------------------------
+    // UserId() returns a non-empty string
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure UserIdIsNotEmpty()
+    begin
+        // [WHEN] UserId() is called
+        // [THEN] The result is not empty — runner returns a stable stub value
+        Assert.AreNotEqual('', UserId(), 'UserId() must return a non-empty value in the runner');
+    end;
+
+    // -----------------------------------------------------------------------
+    // UserId() is consistent across calls
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure UserIdIsConsistent()
+    var
+        First: Text;
+        Second: Text;
+    begin
+        // [WHEN] UserId() is called twice
+        First := UserId();
+        Second := UserId();
+
+        // [THEN] Both calls return the same value
+        Assert.AreEqual(First, Second, 'UserId() must return the same value across calls');
+    end;
+}

--- a/tests/bucket-2/70-companyname/test/CompanyNameTest.al
+++ b/tests/bucket-2/70-companyname/test/CompanyNameTest.al
@@ -23,9 +23,10 @@ codeunit 56691 "Company Name Test"
     var
         Result: Text;
     begin
-        // Positive: UserId should return a text value without crashing
+        // Positive: UserId should return a text value without crashing.
+        // Default is "TESTUSER" when not configured via --user-id.
         Result := Helper.GetUserId();
-        Assert.AreEqual('', Result, 'UserId should return empty string in standalone mode');
+        Assert.AreEqual('TESTUSER', Result, 'UserId should return TESTUSER by default');
     end;
 
     [Test]


### PR DESCRIPTION
Closes #314

## Problem
`AlScope.UserId` defaulted to `""`, so AL code calling `UserId()` returned an empty string. The test `Assert.AreNotEqual('', UserId(), ...)` would fail.

## Fix
Changed `AlScope.UserId` default from `""` to `"TESTUSER"`. The `--user-id` CLI flag still overrides this for custom values.

## Tests
New suite `tests/bucket-1/57-userid` (codeunit 56701) with 2 proving tests:
1. `UserIdIsNotEmpty` — `UserId()` returns a non-empty string
2. `UserIdIsConsistent` — two calls return the same value

## Docs
- `docs/coverage.yaml`: `Database.UserId` → `covered`
- `CHANGELOG.md` entry added