### PR TITLE
feat: Guid.IsNullGuid — check if GUID is all-zeros (#318)

### DIFF
--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -2374,6 +2374,17 @@ public void ClearApplicationMemberVariables() { }
                         SyntaxFactory.IdentifierName(methodName)));
             }
 
+            // ALDatabase.ALIsNullGuid(g) -> AlCompat.ALIsNullGuid(g)
+            // The real implementation goes through NavSession; ours checks Guid.Empty.
+            if (exprText == "ALDatabase" && methodName == "ALIsNullGuid")
+            {
+                return visited.WithExpression(
+                    SyntaxFactory.MemberAccessExpression(
+                        SyntaxKind.SimpleMemberAccessExpression,
+                        SyntaxFactory.IdentifierName("AlCompat"),
+                        SyntaxFactory.IdentifierName("ALIsNullGuid")));
+            }
+
             // ALSystemDate.ALWorkDate(null!) -> ALSystemDate.ALWorkDate(NavDate.Default)
             // The rewriter turns this.Session -> null!, which makes ALWorkDate ambiguous between
             // the NavSession and NavDate overloads. We disambiguate to the NavDate overload.

--- a/AlRunner/Runtime/AlScope.cs
+++ b/AlRunner/Runtime/AlScope.cs
@@ -1332,6 +1332,18 @@ public static class AlCompat
     /// </summary>
     public static NavGuid ALCreateSequentialGuid() => new NavGuid(Guid.NewGuid());
 
+    /// <summary>
+    /// Replacement for ALDatabase.ALIsNullGuid(g) which requires NavSession.
+    /// Returns true when the GUID is the all-zeros default ({00000000-...}).
+    /// </summary>
+    public static NavBoolean ALIsNullGuid(object? g)
+    {
+        g = UnwrapVariant(g);
+        if (g is NavGuid ng) return NavBoolean.Create(ng.ToGuid() == Guid.Empty);
+        if (g is Guid guid) return NavBoolean.Create(guid == Guid.Empty);
+        return NavBoolean.Create(true); // null/unset treated as empty
+    }
+
     // -----------------------------------------------------------------------
     // HttpContent stream helpers
     // -----------------------------------------------------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,12 @@ All notable changes to this project are documented here. Format based on
   `RoslynRewriter` now redirects that to `MockSession.GetSessionId()`. New suite
   `tests/bucket-1/58-database-sessionid` proves: positive call returns > 0, and consecutive
   calls return the same value. Coverage map: `Database.SessionId` moved from `gap` to `stub`.
+- **`Guid.IsNullGuid` (#318)** — `IsNullGuid(G)` now correctly returns `true` for the
+  all-zeros GUID and `false` for any non-zero GUID. The BC compiler lowers this global
+  function to `ALDatabase.ALIsNullGuid(G)`; `RoslynRewriter` now redirects that to
+  `AlCompat.ALIsNullGuid(G)`, which checks `NavGuid.ToGuid() == Guid.Empty`. New suite
+  `tests/bucket-1/58-is-null-guid` proves both directions. Coverage map: `Guid.IsNullGuid`
+  moved from `gap` to `covered`.
 - **`Record.IsEmpty` coverage (#299)** — `ALIsEmpty` was already implemented in
   `MockRecordHandle` (`GetFilteredAndMarkedRecords().Count == 0`) but had no proving
   tests. New suite `tests/bucket-1/56-isempty` adds 5 proving tests: empty table →

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -5499,7 +5499,8 @@ System.IsNull:
 System.IsNullGuid:
   layer: runtime-api
   category: System
-  status: gap
+  status: covered
+  tests: tests/bucket-1/58-is-null-guid
   notes: overloads=1
 
 System.IsServiceTier:

--- a/tests/bucket-1/58-is-null-guid/test/TestIsNullGuid.al
+++ b/tests/bucket-1/58-is-null-guid/test/TestIsNullGuid.al
@@ -1,0 +1,26 @@
+codeunit 58500 "Test IsNullGuid"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    [Test]
+    procedure IsNullGuid_UninitializedGuid_ReturnsTrue()
+    var
+        G: Guid;
+    begin
+        // An uninitialized Guid is all zeros — IsNullGuid must return true
+        Assert.IsTrue(IsNullGuid(G), 'IsNullGuid must return true for uninitialized (all-zeros) GUID');
+    end;
+
+    [Test]
+    procedure IsNullGuid_AfterCreateGuid_ReturnsFalse()
+    var
+        G: Guid;
+    begin
+        // A GUID created by CreateGuid() is non-zero — IsNullGuid must return false
+        G := CreateGuid();
+        Assert.IsFalse(IsNullGuid(G), 'IsNullGuid must return false for a freshly created GUID');
+    end;
+}


### PR DESCRIPTION
Closes #318

## What changed

`IsNullGuid(G)` was a runner gap — calling it caused a Roslyn compilation failure. The BC compiler lowers `IsNullGuid(G)` to `ALDatabase.ALIsNullGuid(G)`. This PR:

1. **`RoslynRewriter.cs`** — redirects `ALDatabase.ALIsNullGuid(g)` → `AlCompat.ALIsNullGuid(g)`
2. **`AlScope.cs`** — implements `AlCompat.ALIsNullGuid(object? g)` by checking `NavGuid.ToGuid() == Guid.Empty`

## Tests

New suite `tests/bucket-1/58-is-null-guid` (codeunit 56700):
- `IsNullGuid_UninitializedGuid_ReturnsTrue` — uninitialized Guid (all-zeros) → true ✓
- `IsNullGuid_AfterCreateGuid_ReturnsFalse` — result of `CreateGuid()` → false ✓

Both directions proven; a no-op mock would fail at least one test.