### PR TITLE
feat: Database.SessionId — stub returning 1 (#316)

### DIFF
--- a/AlRunner.Tests/PipelineTests.cs
+++ b/AlRunner.Tests/PipelineTests.cs
@@ -513,6 +513,28 @@ namespace AlRunnerGenerated {
     }
 
     [Fact]
+    public void SessionId_ReturnsPositiveInteger()
+    {
+        // Validates that SessionId() is correctly rewritten to MockSession.GetSessionId().
+        // If this test fails, DumpCSharp output below shows the actual BC-compiled form
+        // (pre-rewrite) so the exact property/method name can be identified.
+        var dumpPipeline = new AlRunnerPipeline();
+        var dumpResult = dumpPipeline.Run(new PipelineOptions
+        {
+            DumpCSharp = true,
+            InlineCode = "if SessionId() <= 0 then error('fail');"
+        });
+
+        var pipeline = new AlRunnerPipeline();
+        var result = pipeline.Run(new PipelineOptions
+        {
+            InlineCode = "if SessionId() <= 0 then error('SessionId() must return a positive integer');"
+        });
+        Assert.True(result.ExitCode == 0,
+            $"SessionId() returned non-positive or crashed.\nPre-rewrite C#:\n{dumpResult.StdOut}");
+    }
+
+    [Fact]
     public void InitValue_AppliedOnRecordInit()
     {
         var pipeline = new AlRunnerPipeline();

--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -1600,6 +1600,25 @@ public void ClearApplicationMemberVariables() { }
             return base.VisitInvocationExpression(node);
         }
 
+        // ALDatabase.ALSessionID() -> MockSession.GetSessionId()
+        // BC lowers SessionId() to a 0-argument static method call on ALDatabase.
+        // This must be caught before base.VisitInvocationExpression because the MemberAccess
+        // visitor would otherwise replace the callee with MockSession.GetSessionId() and produce
+        // the invalid double-call form MockSession.GetSessionId()().
+        if (node.Expression is MemberAccessExpressionSyntax sessionMa &&
+            sessionMa.Expression is IdentifierNameSyntax sessionDbIdent &&
+            sessionDbIdent.Identifier.Text == "ALDatabase" &&
+            (sessionMa.Name.Identifier.Text == "ALSessionID" || sessionMa.Name.Identifier.Text == "ALSessionId"))
+        {
+            return SyntaxFactory.InvocationExpression(
+                SyntaxFactory.MemberAccessExpression(
+                    SyntaxKind.SimpleMemberAccessExpression,
+                    SyntaxFactory.IdentifierName("MockSession"),
+                    SyntaxFactory.IdentifierName("GetSessionId")),
+                SyntaxFactory.ArgumentList())
+                .WithTriviaFrom(node);
+        }
+
         // `NavOption.Create(existing.NavOptionMetadata, V)` — reassignment
         // pattern BC emits when an AL enum variable is re-assigned. Route
         // through AlCompat.CloneTaggedOption so the new instance inherits
@@ -1956,24 +1975,6 @@ public void ClearApplicationMemberVariables() { }
                     SyntaxKind.SimpleMemberAccessExpression,
                     SyntaxFactory.IdentifierName("NCLOptionMetadata"),
                     SyntaxFactory.IdentifierName("Default"));
-            }
-
-            // ALSession.ALSessionID(session) / ALDatabase.ALSessionID(session)
-            // -> MockSession.GetSessionId()
-            // SessionId() is a global AL function that returns the current session ID.
-            // BC may lower it to ALSession.ALSessionID or ALDatabase.ALSessionID with a NavSession arg
-            // that becomes null! after the Session→null! rewrite, causing NullReferenceException.
-            // Replace the entire invocation with a 0-arg call to MockSession.GetSessionId().
-            if ((methodName == "ALSessionID" || methodName == "ALSessionId") &&
-                (exprText == "ALSession" || exprText == "ALDatabase"))
-            {
-                return SyntaxFactory.InvocationExpression(
-                    SyntaxFactory.MemberAccessExpression(
-                        SyntaxKind.SimpleMemberAccessExpression,
-                        SyntaxFactory.IdentifierName("MockSession"),
-                        SyntaxFactory.IdentifierName("GetSessionId")),
-                    SyntaxFactory.ArgumentList())
-                    .WithTriviaFrom(visited);
             }
 
             // ALSession.ALStartSession(...) -> MockSession.ALStartSession(...)
@@ -2823,20 +2824,6 @@ public void ClearApplicationMemberVariables() { }
         if (memberName == "IsEventSessionRecorderEnabled")
         {
             return SyntaxFactory.LiteralExpression(SyntaxKind.FalseLiteralExpression)
-                .WithTriviaFrom(visited);
-        }
-        // Pattern: <any>.ALSessionID or <any>.ALSessionId — the BC compiler lowers SessionId() to
-        // a property access on ALDatabase or this.Session. The rewriter turns this.Session → null!,
-        // so null!.ALSessionID throws NullReferenceException. BC follows the ALUserID naming convention
-        // (uppercase "ID"), but we also catch lowercase "Id" for robustness across BC versions.
-        // Catch by member name regardless of receiver and redirect to MockSession.GetSessionId().
-        if (memberName == "ALSessionID" || memberName == "ALSessionId")
-        {
-            return SyntaxFactory.InvocationExpression(
-                SyntaxFactory.MemberAccessExpression(
-                    SyntaxKind.SimpleMemberAccessExpression,
-                    SyntaxFactory.IdentifierName("MockSession"),
-                    SyntaxFactory.IdentifierName("GetSessionId")))
                 .WithTriviaFrom(visited);
         }
         if (memberName.StartsWith("ALIs") && NavVariantTypeCheckProps.Contains(memberName))

--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -2756,6 +2756,20 @@ public void ClearApplicationMemberVariables() { }
             }
         }
 
+        // Pattern: ALDatabase.ALSessionId — integer property, crashes without a live BC session.
+        // Rewrite to MockSession.GetSessionId() which returns a stable non-zero stub value (1).
+        if (visited.Expression is IdentifierNameSyntax sessionDbId &&
+            sessionDbId.Identifier.Text == "ALDatabase" &&
+            visited.Name.Identifier.Text == "ALSessionId")
+        {
+            return SyntaxFactory.InvocationExpression(
+                SyntaxFactory.MemberAccessExpression(
+                    SyntaxKind.SimpleMemberAccessExpression,
+                    SyntaxFactory.IdentifierName("MockSession"),
+                    SyntaxFactory.IdentifierName("GetSessionId")))
+                .WithTriviaFrom(visited);
+        }
+
         // Pattern: ALDatabase.ALCompanyName / ALDatabase.ALUserID / ALDatabase.ALTenantID / ALDatabase.ALSerialNumber
         // These static property accesses crash because ALDatabase requires a live BC session.
         // ALCompanyName routes to MockSession.GetCompanyName() (configurable via --company-name CLI flag).

--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -2756,20 +2756,6 @@ public void ClearApplicationMemberVariables() { }
             }
         }
 
-        // Pattern: ALDatabase.ALSessionId — integer property, crashes without a live BC session.
-        // Rewrite to MockSession.GetSessionId() which returns a stable non-zero stub value (1).
-        if (visited.Expression is IdentifierNameSyntax sessionDbId &&
-            sessionDbId.Identifier.Text == "ALDatabase" &&
-            visited.Name.Identifier.Text == "ALSessionId")
-        {
-            return SyntaxFactory.InvocationExpression(
-                SyntaxFactory.MemberAccessExpression(
-                    SyntaxKind.SimpleMemberAccessExpression,
-                    SyntaxFactory.IdentifierName("MockSession"),
-                    SyntaxFactory.IdentifierName("GetSessionId")))
-                .WithTriviaFrom(visited);
-        }
-
         // Pattern: ALDatabase.ALCompanyName / ALDatabase.ALUserID / ALDatabase.ALTenantID / ALDatabase.ALSerialNumber
         // These static property accesses crash because ALDatabase requires a live BC session.
         // ALCompanyName routes to MockSession.GetCompanyName() (configurable via --company-name CLI flag).
@@ -2819,6 +2805,18 @@ public void ClearApplicationMemberVariables() { }
         if (memberName == "IsEventSessionRecorderEnabled")
         {
             return SyntaxFactory.LiteralExpression(SyntaxKind.FalseLiteralExpression)
+                .WithTriviaFrom(visited);
+        }
+        // Pattern: <any>.ALSessionId — the BC compiler lowers SessionId() to this.Session.ALSessionId.
+        // The rewriter turns this.Session → null!, so null!.ALSessionId throws NullReferenceException.
+        // Catch ALSessionId by member name regardless of receiver and redirect to MockSession.GetSessionId().
+        if (memberName == "ALSessionId")
+        {
+            return SyntaxFactory.InvocationExpression(
+                SyntaxFactory.MemberAccessExpression(
+                    SyntaxKind.SimpleMemberAccessExpression,
+                    SyntaxFactory.IdentifierName("MockSession"),
+                    SyntaxFactory.IdentifierName("GetSessionId")))
                 .WithTriviaFrom(visited);
         }
         if (memberName.StartsWith("ALIs") && NavVariantTypeCheckProps.Contains(memberName))

--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -1958,6 +1958,24 @@ public void ClearApplicationMemberVariables() { }
                     SyntaxFactory.IdentifierName("Default"));
             }
 
+            // ALSession.ALSessionID(session) / ALDatabase.ALSessionID(session)
+            // -> MockSession.GetSessionId()
+            // SessionId() is a global AL function that returns the current session ID.
+            // BC may lower it to ALSession.ALSessionID or ALDatabase.ALSessionID with a NavSession arg
+            // that becomes null! after the Session→null! rewrite, causing NullReferenceException.
+            // Replace the entire invocation with a 0-arg call to MockSession.GetSessionId().
+            if ((methodName == "ALSessionID" || methodName == "ALSessionId") &&
+                (exprText == "ALSession" || exprText == "ALDatabase"))
+            {
+                return SyntaxFactory.InvocationExpression(
+                    SyntaxFactory.MemberAccessExpression(
+                        SyntaxKind.SimpleMemberAccessExpression,
+                        SyntaxFactory.IdentifierName("MockSession"),
+                        SyntaxFactory.IdentifierName("GetSessionId")),
+                    SyntaxFactory.ArgumentList())
+                    .WithTriviaFrom(visited);
+            }
+
             // ALSession.ALStartSession(...) -> MockSession.ALStartSession(...)
             // ALSession.ALIsSessionActive(...) -> MockSession.ALIsSessionActive(...)
             // ALSession.ALStopSession(...) -> MockSession.ALStopSession(...)
@@ -2807,10 +2825,12 @@ public void ClearApplicationMemberVariables() { }
             return SyntaxFactory.LiteralExpression(SyntaxKind.FalseLiteralExpression)
                 .WithTriviaFrom(visited);
         }
-        // Pattern: <any>.ALSessionId — the BC compiler lowers SessionId() to this.Session.ALSessionId.
-        // The rewriter turns this.Session → null!, so null!.ALSessionId throws NullReferenceException.
-        // Catch ALSessionId by member name regardless of receiver and redirect to MockSession.GetSessionId().
-        if (memberName == "ALSessionId")
+        // Pattern: <any>.ALSessionID or <any>.ALSessionId — the BC compiler lowers SessionId() to
+        // a property access on ALDatabase or this.Session. The rewriter turns this.Session → null!,
+        // so null!.ALSessionID throws NullReferenceException. BC follows the ALUserID naming convention
+        // (uppercase "ID"), but we also catch lowercase "Id" for robustness across BC versions.
+        // Catch by member name regardless of receiver and redirect to MockSession.GetSessionId().
+        if (memberName == "ALSessionID" || memberName == "ALSessionId")
         {
             return SyntaxFactory.InvocationExpression(
                 SyntaxFactory.MemberAccessExpression(

--- a/AlRunner/Runtime/MockSession.cs
+++ b/AlRunner/Runtime/MockSession.cs
@@ -27,6 +27,13 @@ public static class MockSession
     public static string GetCompanyName() => _companyName;
 
     /// <summary>
+    /// Value returned by the AL <c>SessionId()</c> built-in.
+    /// Returns a stable non-zero integer (1) — the exact value is not meaningful
+    /// in standalone mode; the only contract is that it is positive and consistent.
+    /// </summary>
+    public static int GetSessionId() => 1;
+
+    /// <summary>
     /// Sets the value returned by the AL <c>CompanyName()</c> built-in.
     /// Reset back to <see cref="DefaultCompanyName"/> before each test.
     /// </summary>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ All notable changes to this project are documented here. Format based on
   without requiring the `--user-id` CLI flag. New suite `tests/bucket-1/57-userid`
   adds 2 proving tests: UserId is non-empty, UserId is consistent across calls.
   Coverage map: `Database.UserId` moved from `gap` to `covered`.
+- **`Database.SessionId` (#316)** — `SessionId()` now returns a stable non-zero integer (1).
+  The BC compiler lowers this global function to `ALDatabase.ALSessionId` (a property access).
+  `RoslynRewriter` now redirects that to `MockSession.GetSessionId()`. New suite
+  `tests/bucket-1/58-database-sessionid` proves: positive call returns > 0, and consecutive
+  calls return the same value. Coverage map: `Database.SessionId` moved from `gap` to `stub`.
 - **`Record.IsEmpty` coverage (#299)** — `ALIsEmpty` was already implemented in
   `MockRecordHandle` (`GetFilteredAndMarkedRecords().Count == 0`) but had no proving
   tests. New suite `tests/bucket-1/56-isempty` adds 5 proving tests: empty table →

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -1506,8 +1506,8 @@ Database.ServiceInstanceId:
 Database.SessionId:
   layer: runtime-api
   category: Database
-  status: gap
-  notes: overloads=1
+  status: stub
+  notes: overloads=1; returns 1 (stable non-zero stub)
 
 Database.SetDefaultTableConnection:
   layer: runtime-api

--- a/tests/bucket-1/58-database-sessionid/test/TestDatabaseSessionId.al
+++ b/tests/bucket-1/58-database-sessionid/test/TestDatabaseSessionId.al
@@ -1,0 +1,29 @@
+codeunit 58401 "Test Database SessionId"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    [Test]
+    procedure SessionId_ReturnsPositiveInteger()
+    var
+        Id: Integer;
+    begin
+        // SessionId() must return a non-zero positive integer in the runner
+        Id := SessionId();
+        Assert.IsTrue(Id > 0, 'SessionId() must return a positive integer');
+    end;
+
+    [Test]
+    procedure SessionId_IsStable_WithinSameContext()
+    var
+        Id1: Integer;
+        Id2: Integer;
+    begin
+        // SessionId() must return the same value on consecutive calls
+        Id1 := SessionId();
+        Id2 := SessionId();
+        Assert.AreEqual(Id1, Id2, 'SessionId() must return the same value on consecutive calls');
+    end;
+}

--- a/tests/bucket-1/58-database-sessionid/test/TestDatabaseSessionId.al
+++ b/tests/bucket-1/58-database-sessionid/test/TestDatabaseSessionId.al
@@ -1,4 +1,4 @@
-codeunit 58401 "Test Database SessionId"
+codeunit 58501 "Test Database SessionId"
 {
     Subtype = Test;
 


### PR DESCRIPTION
Closes #316

## What

`SessionId()` previously crashed because `ALDatabase.ALSessionId` requires a live BC session. This PR adds a stub so AL code calling `SessionId()` returns a stable non-zero integer.

## How

- **`RoslynRewriter.cs`**: new `MemberAccessExpression` rewrite redirects `ALDatabase.ALSessionId` → `MockSession.GetSessionId()`.
- **`MockSession.cs`**: adds `GetSessionId()` returning `1` — stable and non-zero, matching the issue spec.
- **New test suite** `tests/bucket-1/58-database-sessionid`: two proving tests — `SessionId() > 0` and `SessionId()` returns the same value on consecutive calls.
- `docs/coverage.yaml`: `Database.SessionId` → `stub`.
- `CHANGELOG.md`: updated under `[Unreleased]`.