### PR TITLE
test: Database.SelectLatestVersion proving tests (#313)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to this project are documented here. Format based on
 ## [Unreleased]
 
 ### Added
+- **`Database.SelectLatestVersion` coverage (#313)** — `SelectLatestVersion()` was already
+  a no-op (stripped by `StripEntireCallMethods` in `RoslynRewriter`) but had no proving
+  tests. New suite `tests/bucket-1/58-database-select-latest-version` adds 3 tests:
+  call without error, call after insert still shows record with correct field value,
+  multiple calls are all no-ops. Coverage map: `Database.SelectLatestVersion` moved
+  from `gap` to `covered`.
 - **`Record.IsEmpty` coverage (#299)** — `ALIsEmpty` was already implemented in
   `MockRecordHandle` (`GetFilteredAndMarkedRecords().Count == 0`) but had no proving
   tests. New suite `tests/bucket-1/56-isempty` adds 5 proving tests: empty table →

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -1487,8 +1487,9 @@ Database.RegisterTableConnection:
 Database.SelectLatestVersion:
   layer: runtime-api
   category: Database
-  status: gap
-  notes: overloads=2
+  status: covered
+  tests: tests/bucket-1/58-database-select-latest-version
+  notes: overloads=2 (no-arg and optional Boolean); both stripped to no-op by RoslynRewriter
 
 Database.SerialNumber:
   layer: runtime-api

--- a/tests/bucket-1/58-database-select-latest-version/src/SelectLatestVersionTable.al
+++ b/tests/bucket-1/58-database-select-latest-version/src/SelectLatestVersionTable.al
@@ -1,0 +1,12 @@
+table 58400 "SelectLatestVersion Test Table"
+{
+    fields
+    {
+        field(1; Id; Integer) { }
+        field(2; Value; Text[50]) { }
+    }
+    keys
+    {
+        key(PK; Id) { Clustered = true; }
+    }
+}

--- a/tests/bucket-1/58-database-select-latest-version/test/SelectLatestVersionTest.al
+++ b/tests/bucket-1/58-database-select-latest-version/test/SelectLatestVersionTest.al
@@ -1,0 +1,43 @@
+codeunit 58401 "Test Database SelectLatestVersion"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    [Test]
+    procedure SelectLatestVersion_DoesNotError()
+    begin
+        // SelectLatestVersion() is a no-op in the runner — must not raise any error
+        SelectLatestVersion();
+        Assert.IsTrue(true, 'SelectLatestVersion() must complete without error');
+    end;
+
+    [Test]
+    procedure SelectLatestVersion_AfterInsert_RecordStillVisible()
+    var
+        Rec: Record "SelectLatestVersion Test Table";
+    begin
+        // Insert a record, call SelectLatestVersion(), then verify the record is still visible
+        Rec.Id := 1;
+        Rec.Value := 'Hello';
+        Rec.Insert();
+
+        SelectLatestVersion();
+
+        Rec.Reset();
+        Assert.AreEqual(1, Rec.Count(), 'SelectLatestVersion() must not clear in-memory record state');
+        Rec.Get(1);
+        Assert.AreEqual('Hello', Rec.Value, 'Record field must retain its value after SelectLatestVersion()');
+    end;
+
+    [Test]
+    procedure SelectLatestVersion_MultipleTimes_NoError()
+    begin
+        // Multiple calls must all be no-ops
+        SelectLatestVersion();
+        SelectLatestVersion();
+        SelectLatestVersion();
+        Assert.IsTrue(true, 'Multiple SelectLatestVersion() calls must all complete without error');
+    end;
+}


### PR DESCRIPTION
Closes #313

## Summary

- `SelectLatestVersion()` was already stripped to a no-op by `RoslynRewriter.StripEntireCallMethods` (`ALSelectLatestVersion` entry) but had no proving tests.
- New suite `tests/bucket-1/58-database-select-latest-version` adds 3 proving tests:
  - `SelectLatestVersion_DoesNotError` — bare call must not raise
  - `SelectLatestVersion_AfterInsert_RecordStillVisible` — asserts the record is still there with the correct field value after the call
  - `SelectLatestVersion_MultipleTimes_NoError` — three consecutive calls are all no-ops
- `docs/coverage.yaml`: `Database.SelectLatestVersion` moved from `gap` to `covered`
- `CHANGELOG.md`: entry added under `[Unreleased]`

## Test plan

- [ ] CI bucket-1 run includes new suite and all 3 tests pass
- [ ] No regressions in other bucket-1 suites