### PR TITLE
docs: agents must not edit CHANGELOG.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,10 +32,11 @@ Every feature, fix, or mock addition requires a test. No exceptions.
 ## Documentation must stay current
 
 Any change affecting behavior, CLI flags, or mock capabilities must update:
-- `CHANGELOG.md` — entry under `[Unreleased]` (always required)
 - `README.md` — supported/unsupported feature list, CLI flags
 - `PrintGuide()` in `AlRunner/Program.cs` — `--guide` output
 - `docs/limitations.md` — if the change affects known gaps
+
+**Do NOT touch `CHANGELOG.md`.** It is generated from commit messages on `main` after merge. Editing it in PRs causes conflicts that block the queue.
 
 ---
 
@@ -91,7 +92,7 @@ Workers self-select from the `status: ready` queue. The orchestrator does not as
 | `AlRunner/Runtime/` | All mock implementations (MockRecordHandle, AlScope, etc.) |
 | `tests/bucket-1/`, `tests/bucket-2/` | AL test suites |
 | `docs/limitations.md` | Known gaps and architectural limits |
-| `CHANGELOG.md` | Always update under `[Unreleased]` |
+| `CHANGELOG.md` | **Do not edit** — generated from commits post-merge |
 
 ## Exit codes
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,7 +120,6 @@ dotnet run --project AlRunner -- ./src ./test
 2. **Documentation must stay current** — any change affecting behavior, CLI flags, or mock capabilities must be reflected in:
    - `README.md` (supported/unsupported feature list, CLI flags)
    - `--guide` output (`PrintGuide()` in `Program.cs`) — the primary way external agents discover runner capabilities
-   - `CHANGELOG.md` (entry under `[Unreleased]` — always required)
    - `docs/limitations.md` (if the change affects known gaps)
 
 3. **File issues for gaps** — never silently work around a gap; always report it.


### PR DESCRIPTION
## Summary

- Removes the CHANGELOG editing requirement from `AGENTS.md` and `CLAUDE.md`
- Adds explicit **do not touch** notice in both files
- CHANGELOG will be generated from commit messages on `main` post-merge

## Why

Impl agents editing `CHANGELOG.md` in every PR causes merge conflicts that block the queue and require manual rebases. The changelog can be reconstructed from squash-commit messages instead.