### PR TITLE
feat: table fieldgroup(Fixed) section coverage (#284)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,6 @@ All notable changes to this project are documented here. Format based on
 ## [Unreleased]
 
 ### Added
-- **`table fixed_section` coverage (#284)** — `fieldgroup(Fixed; ...)` in a table declaration
-  compiles and works without any runner changes; the BC compiler treats it identically to
-  `fieldgroup(DropDown; ...)` and `fieldgroup(Brick; ...)` (metadata only, no effect on the
-  emitted C# data class). New suite `tests/bucket-1/59-table-fixed-section` adds 5 proving
-  tests: Insert+Get, Modify, Delete, Get-missing returns false, duplicate key errors.
-  Coverage map: `fixed_section` moved from `gap` to `covered`.
 - **`Database.SelectLatestVersion` coverage (#313)** — `SelectLatestVersion()` was already
   a no-op (stripped by `StripEntireCallMethods` in `RoslynRewriter`) but had no proving
   tests. New suite `tests/bucket-1/58-database-select-latest-version` adds 3 tests:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to this project are documented here. Format based on
 ## [Unreleased]
 
 ### Added
+- **`table fixed_section` coverage (#284)** — `fieldgroup(Fixed; ...)` in a table declaration
+  compiles and works without any runner changes; the BC compiler treats it identically to
+  `fieldgroup(DropDown; ...)` and `fieldgroup(Brick; ...)` (metadata only, no effect on the
+  emitted C# data class). New suite `tests/bucket-1/59-table-fixed-section` adds 5 proving
+  tests: Insert+Get, Modify, Delete, Get-missing returns false, duplicate key errors.
+  Coverage map: `fixed_section` moved from `gap` to `covered`.
 - **`Database.SelectLatestVersion` coverage (#313)** — `SelectLatestVersion()` was already
   a no-op (stripped by `StripEntireCallMethods` in `RoslynRewriter`) but had no proving
   tests. New suite `tests/bucket-1/58-database-select-latest-version` adds 3 tests:

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -679,7 +679,9 @@ fields_section:
 fixed_section:
   layer: syntax
   category: table
-  status: gap
+  status: covered
+  tests: tests/bucket-1/59-table-fixed-section
+  notes: fieldgroup(Fixed; ...) is handled identically to DropDown/Brick by the BC compiler; no runner changes needed
 
 key_declaration:
   layer: syntax

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -680,7 +680,8 @@ fixed_section:
   layer: syntax
   category: table
   status: covered
-  tests: tests/bucket-1/59-table-fixed-section
+  tests:
+    - tests/bucket-1/59-table-fixed-section
   notes: fieldgroup(Fixed; ...) is handled identically to DropDown/Brick by the BC compiler; no runner changes needed
 
 key_declaration:

--- a/tests/bucket-1/59-table-fixed-section/src/FixedSectionTable.al
+++ b/tests/bucket-1/59-table-fixed-section/src/FixedSectionTable.al
@@ -1,0 +1,22 @@
+table 59400 "Fixed Section Test Table"
+{
+    DataClassification = ToBeClassified;
+
+    fields
+    {
+        field(1; Id; Integer) { }
+        field(2; Name; Text[100]) { }
+        field(3; Amount; Decimal) { }
+    }
+
+    keys
+    {
+        key(PK; Id) { Clustered = true; }
+    }
+
+    fieldgroups
+    {
+        fieldgroup(DropDown; Id, Name) { }
+        fieldgroup(Fixed; Id, Name, Amount) { }
+    }
+}

--- a/tests/bucket-1/59-table-fixed-section/test/FixedSectionTest.al
+++ b/tests/bucket-1/59-table-fixed-section/test/FixedSectionTest.al
@@ -1,0 +1,96 @@
+codeunit 59401 "Test Table Fixed Section"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    [Test]
+    procedure FixedSection_InsertAndGet()
+    var
+        Rec: Record "Fixed Section Test Table";
+    begin
+        // [GIVEN] A table with fieldgroup(Fixed; ...) compiles and allows Insert
+        Rec.Id := 1;
+        Rec.Name := 'Widget';
+        Rec.Amount := 99.50;
+        Rec.Insert();
+
+        // [WHEN] Get the record by PK
+        Rec.Get(1);
+
+        // [THEN] All fields retain their values
+        Assert.AreEqual(1, Rec.Id, 'Id must be 1');
+        Assert.AreEqual('Widget', Rec.Name, 'Name must be Widget');
+        Assert.AreEqual(99.50, Rec.Amount, 'Amount must be 99.50');
+    end;
+
+    [Test]
+    procedure FixedSection_Modify()
+    var
+        Rec: Record "Fixed Section Test Table";
+    begin
+        // [GIVEN] An inserted record on a table with fieldgroup(Fixed; ...)
+        Rec.Id := 2;
+        Rec.Name := 'Original';
+        Rec.Amount := 10.00;
+        Rec.Insert();
+
+        // [WHEN] Modify the record
+        Rec.Get(2);
+        Rec.Name := 'Modified';
+        Rec.Modify();
+
+        // [THEN] The modified field is persisted
+        Rec.Get(2);
+        Assert.AreEqual('Modified', Rec.Name, 'Name must reflect modification');
+    end;
+
+    [Test]
+    procedure FixedSection_Delete()
+    var
+        Rec: Record "Fixed Section Test Table";
+    begin
+        // [GIVEN] An inserted record on a table with fieldgroup(Fixed; ...)
+        Rec.Id := 3;
+        Rec.Name := 'ToDelete';
+        Rec.Amount := 5.00;
+        Rec.Insert();
+
+        // [WHEN] Delete the record
+        Rec.Get(3);
+        Rec.Delete();
+
+        // [THEN] Get returns false
+        Assert.IsFalse(Rec.Get(3), 'Get must return false after Delete');
+    end;
+
+    [Test]
+    procedure FixedSection_GetNonExistent_ReturnsFalse()
+    var
+        Rec: Record "Fixed Section Test Table";
+    begin
+        // [GIVEN] No record with Id 999 exists
+        // [WHEN] Get is called for a non-existent key
+        // [THEN] Get returns false — fieldgroup(Fixed) does not affect key lookups
+        Assert.IsFalse(Rec.Get(999), 'Get must return false for missing key');
+    end;
+
+    [Test]
+    procedure FixedSection_DuplicateKey_Errors()
+    var
+        Rec: Record "Fixed Section Test Table";
+    begin
+        // [GIVEN] A record with Id 4 already exists
+        Rec.Id := 4;
+        Rec.Name := 'First';
+        Rec.Amount := 1.00;
+        Rec.Insert();
+
+        // [WHEN/THEN] Inserting a second record with the same key errors
+        Rec.Id := 4;
+        Rec.Name := 'Duplicate';
+        asserterror Rec.Insert();
+        Assert.ExpectedError('already exists');
+    end;
+}


### PR DESCRIPTION
Closes #284

Adds a proving test suite for AL tables with `fieldgroup(Fixed; ...)` declarations.

## What

- New suite `tests/bucket-1/59-table-fixed-section` with 5 tests:
  - Insert + Get with all fields retained
  - Modify persists changes
  - Delete removes the record
  - Get on non-existent key returns false (negative)
  - Duplicate key Insert errors (negative)
- `docs/coverage.yaml`: `fixed_section` → `covered`
- `CHANGELOG.md` entry under `[Unreleased]`

## Why this works

`fieldgroup(Fixed; ...)` is handled identically to `fieldgroup(DropDown; ...)` and `fieldgroup(Brick; ...)` by the BC compiler — the declaration is metadata only and does not affect the C# class generated for the table's data operations. The runner's in-memory table store (`MockRecordHandle`) requires no changes.