### PR TITLE
feat: Boolean.ToText — Format(B) returns Yes/No (#330)

### DIFF
--- a/AlRunner/Runtime/AlScope.cs
+++ b/AlRunner/Runtime/AlScope.cs
@@ -748,7 +748,7 @@ public static class AlCompat
             try
             {
                 if (value is Microsoft.Dynamics.Nav.Runtime.NavText nt) return (string)nt;
-                if (value is Microsoft.Dynamics.Nav.Runtime.NavBoolean nb) return ((bool)nb).ToString();
+                if (value is Microsoft.Dynamics.Nav.Runtime.NavBoolean nb) return (bool)nb ? "Yes" : "No";
                 if (value is Microsoft.Dynamics.Nav.Runtime.NavInteger ni) return ((int)ni).ToString();
                 if (value is Microsoft.Dynamics.Nav.Runtime.NavBigInteger nbi) return ((long)nbi).ToString();
                 if (value is Microsoft.Dynamics.Nav.Runtime.NavGuid ng) return ((Guid)ng).ToString();
@@ -832,6 +832,18 @@ public static class AlCompat
     {
         if (!string.IsNullOrEmpty(formatString) && formatString.Contains('<'))
         {
+            // Handle NavBoolean with <Standard Format,N>: format 2 → "1"/"0", others → "Yes"/"No"
+            var unwrapped = value is MockVariant mv2 ? mv2.Value : value;
+            if (unwrapped is Microsoft.Dynamics.Nav.Runtime.NavBoolean nb2)
+            {
+                bool boolVal = (bool)nb2;
+                var stdMatch = System.Text.RegularExpressions.Regex.Match(
+                    formatString, @"<Standard Format,(\d+)>", System.Text.RegularExpressions.RegexOptions.IgnoreCase);
+                if (stdMatch.Success && int.TryParse(stdMatch.Groups[1].Value, out int fmt))
+                    return fmt == 2 ? (boolVal ? "1" : "0") : (boolVal ? "Yes" : "No");
+                return boolVal ? "Yes" : "No";
+            }
+
             // Unwrap NavDate / DateTime for date format strings
             DateTime? dt = ExtractDateTime(value);
             if (dt.HasValue)

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -1232,8 +1232,8 @@ Blob.Length:
 Boolean.ToText:
   layer: runtime-api
   category: Boolean
-  status: gap
-  notes: overloads=2
+  status: covered
+  notes: overloads=2; Format(B) returns Yes/No; Format(B,0,'<Standard Format,2>') returns 1/0
 
 # ── Byte ────────────────────────────────────────────────────────
 

--- a/tests/bucket-1/59-boolean-totext/test/TestBooleanToText.al
+++ b/tests/bucket-1/59-boolean-totext/test/TestBooleanToText.al
@@ -1,0 +1,51 @@
+codeunit 58600 "Test Boolean ToText"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    [Test]
+    procedure FormatTrue_DefaultFormat_ReturnsYes()
+    var
+        B: Boolean;
+        Result: Text;
+    begin
+        B := true;
+        Result := Format(B);
+        Assert.AreEqual('Yes', Result, 'Format(true) must return Yes');
+    end;
+
+    [Test]
+    procedure FormatFalse_DefaultFormat_ReturnsNo()
+    var
+        B: Boolean;
+        Result: Text;
+    begin
+        B := false;
+        Result := Format(B);
+        Assert.AreEqual('No', Result, 'Format(false) must return No');
+    end;
+
+    [Test]
+    procedure FormatTrue_StandardFormat2_Returns1()
+    var
+        B: Boolean;
+        Result: Text;
+    begin
+        B := true;
+        Result := Format(B, 0, '<Standard Format,2>');
+        Assert.AreEqual('1', Result, 'Format(true, 0, Standard Format 2) must return 1');
+    end;
+
+    [Test]
+    procedure FormatFalse_StandardFormat2_Returns0()
+    var
+        B: Boolean;
+        Result: Text;
+    begin
+        B := false;
+        Result := Format(B, 0, '<Standard Format,2>');
+        Assert.AreEqual('0', Result, 'Format(false, 0, Standard Format 2) must return 0');
+    end;
+}


### PR DESCRIPTION
Closes #330

## What changed

`Format(NavBoolean)` in `AlCompat.Format()` was calling `((bool)nb).ToString()` which returns C#'s `"True"`/`"False"` — not BC's `"Yes"`/`"No"`.

**`AlRunner/Runtime/AlScope.cs`** — two fixes:
1. `Format(object? value)`: changed `NavBoolean` branch from `((bool)nb).ToString()` → `(bool)nb ? "Yes" : "No"`
2. `Format(object? value, int length, string formatString)`: added `NavBoolean` handler before date/decimal handling — `<Standard Format,2>` returns `"1"`/`"0"`, all other format strings return `"Yes"`/`"No"`

## Tests

New suite `tests/bucket-1/59-boolean-totext` (codeunit 58600), 4 test methods:
- `FormatTrue_DefaultFormat_ReturnsYes` — `Format(true)` → `'Yes'` ✓
- `FormatFalse_DefaultFormat_ReturnsNo` — `Format(false)` → `'No'` ✓
- `FormatTrue_StandardFormat2_Returns1` — `Format(true, 0, '<Standard Format,2>')` → `'1'` ✓
- `FormatFalse_StandardFormat2_Returns0` — `Format(false, 0, '<Standard Format,2>')` → `'0'` ✓

A no-op mock would fail the first two tests (would get `'True'`/`'False'` instead of `'Yes'`/`'No'`).