### PR TITLE
feat: page fixed() layout group coverage — TestPage field access (#335)

### DIFF
--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -678,11 +678,11 @@ fields_section:
 
 fixed_section:
   layer: syntax
-  category: table
+  category: page
   status: covered
   tests:
     - tests/bucket-1/59-table-fixed-section
-  notes: fieldgroup(Fixed; ...) is handled identically to DropDown/Brick by the BC compiler; no runner changes needed
+  notes: fixed() layout group on pages — BC compiler treats it identically to group(); TestPage field access works unchanged
 
 key_declaration:
   layer: syntax

--- a/tests/bucket-1/59-table-fixed-section/src/FixedSectionTable.al
+++ b/tests/bucket-1/59-table-fixed-section/src/FixedSectionTable.al
@@ -20,3 +20,28 @@ table 59400 "Fixed Section Test Table"
         fieldgroup(Fixed; Id, Name, Amount) { }
     }
 }
+
+page 59402 "Fixed Section Page"
+{
+    PageType = Card;
+    SourceTable = "Fixed Section Test Table";
+
+    layout
+    {
+        area(Content)
+        {
+            fixed(grpFixed)
+            {
+                group(grpLeft)
+                {
+                    field(IdField; Rec.Id) { }
+                    field(NameField; Rec.Name) { }
+                }
+                group(grpRight)
+                {
+                    field(AmountField; Rec.Amount) { }
+                }
+            }
+        }
+    }
+}

--- a/tests/bucket-1/59-table-fixed-section/test/FixedSectionTest.al
+++ b/tests/bucket-1/59-table-fixed-section/test/FixedSectionTest.al
@@ -93,4 +93,55 @@ codeunit 59401 "Test Table Fixed Section"
         asserterror Rec.Insert();
         Assert.ExpectedError('already exists');
     end;
+
+    // --- Page layout fixed() group tests ---
+
+    [Test]
+    procedure FixedLayoutGroup_SetAndReadLeft()
+    var
+        TP: TestPage "Fixed Section Page";
+    begin
+        // [GIVEN] A page with a fixed() layout group containing grpLeft and grpRight
+        TP.OpenNew();
+
+        // [WHEN] Fields in the left group are set
+        TP.IdField.SetValue(10);
+        TP.NameField.SetValue('Alpha');
+
+        // [THEN] Values are readable — fixed() groups do not break field access
+        Assert.AreEqual('10', TP.IdField.Value, 'IdField in fixed() group must be 10');
+        Assert.AreEqual('Alpha', TP.NameField.Value, 'NameField in fixed() group must be Alpha');
+        TP.Close();
+    end;
+
+    [Test]
+    procedure FixedLayoutGroup_SetAndReadRight()
+    var
+        TP: TestPage "Fixed Section Page";
+    begin
+        // [GIVEN] A page with a fixed() layout group
+        TP.OpenNew();
+
+        // [WHEN] A field in the right group is set
+        TP.AmountField.SetValue(999.99);
+
+        // [THEN] The value is readable from the right-side fixed() group
+        Assert.AreEqual('999.99', TP.AmountField.Value, 'AmountField in fixed() right group must be 999.99');
+        TP.Close();
+    end;
+
+    [Test]
+    procedure FixedLayoutGroup_FieldValue_NotDefaultAfterSet()
+    var
+        TP: TestPage "Fixed Section Page";
+    begin
+        // [GIVEN] A page with a fixed() layout group, name field set to a specific value
+        TP.OpenNew();
+        TP.NameField.SetValue('Beta');
+
+        // [THEN] The value is not the default empty string
+        Assert.AreNotEqual('', TP.NameField.Value, 'NameField must not be empty after SetValue');
+        Assert.AreEqual('Beta', TP.NameField.Value, 'NameField must be Beta');
+        TP.Close();
+    end;
 }


### PR DESCRIPTION
Closes #335

Corrects and completes the `fixed_section` coverage gap. PR #327 incorrectly covered `fieldgroup(Fixed)` on tables — the actual gap is `fixed()` **layout groups on pages**.

## What

- `tests/bucket-1/59-table-fixed-section/src/FixedSectionTable.al`: adds page 59402 `Fixed Section Page` with a `fixed(grpFixed)` layout containing two groups (`grpLeft`: IdField + NameField, `grpRight`: AmountField)
- `tests/bucket-1/59-table-fixed-section/test/FixedSectionTest.al`: adds 3 proving tests for field access through fixed() groups via TestPage
- `docs/coverage.yaml`: corrects `fixed_section` category from `table` → `page` and updates notes

## Tests

| Test | What it proves |
|---|---|
| `FixedLayoutGroup_SetAndReadLeft` | Fields in the left group of fixed() are accessible via TestPage |
| `FixedLayoutGroup_SetAndReadRight` | Fields in the right group of fixed() are accessible via TestPage |
| `FixedLayoutGroup_FieldValue_NotDefaultAfterSet` | Value round-trips correctly; not the default empty string |

All three tests assert specific expected values (not just absence of errors).