### PR TITLE
feat: CompanyProperty.ID stub + proving tests for DisplayName/UrlName/ID

### DIFF
--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -358,7 +358,7 @@ test executor that needs no BC service tier, Docker, SQL Server, or license.
   - Session.ApplicationArea() — returns empty string
   - Session.GetExecutionContext() / GetModuleExecutionContext() — returns ExecutionContext.Normal
   - Database.LockTimeout(bool) — no-op (no real database)
-  - CompanyProperty.DisplayName() / UrlName() — returns stub company name (""My Company"" / ""My%20Company"")
+  - CompanyProperty.DisplayName() / UrlName() / ID() — returns stub company name / URL-name / fixed GUID
   - ProductName.Full() / Short() / Marketing() — returns real BC product names
   - RoundDateTime(dt [, precision] [, direction]) — rounds DateTime with ms precision;
     direction: '>' (up), '<' (down), '=' (nearest, default). Default precision 1000ms.

--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -2083,7 +2083,7 @@ public void ClearApplicationMemberVariables() { }
                     SyntaxFactory.ArgumentList())
                     .WithTriviaFrom(visited);
             }
-            if (exprText == "ALCompanyProperty" && methodName == "ALID")
+            if (exprText == "ALCompanyProperty" && methodName == "ALId")
             {
                 return SyntaxFactory.InvocationExpression(
                     SyntaxFactory.MemberAccessExpression(

--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -2083,6 +2083,16 @@ public void ClearApplicationMemberVariables() { }
                     SyntaxFactory.ArgumentList())
                     .WithTriviaFrom(visited);
             }
+            if (exprText == "ALCompanyProperty" && methodName == "ALID")
+            {
+                return SyntaxFactory.InvocationExpression(
+                    SyntaxFactory.MemberAccessExpression(
+                        SyntaxKind.SimpleMemberAccessExpression,
+                        SyntaxFactory.IdentifierName("AlCompat"),
+                        SyntaxFactory.IdentifierName("CompanyPropertyID")),
+                    SyntaxFactory.ArgumentList())
+                    .WithTriviaFrom(visited);
+            }
 
             // ALSystemDate.ALRoundDateTime(session, dt, [precision], [direction])
             // -> AlCompat.RoundDateTime(dt, [precision], [direction])

--- a/AlRunner/Runtime/AlScope.cs
+++ b/AlRunner/Runtime/AlScope.cs
@@ -1428,6 +1428,12 @@ public static class AlCompat
     public static string CompanyPropertyUrlName() => "My%20Company";
 
     /// <summary>
+    /// CompanyProperty.ID() stub — returns a fixed non-empty GUID representing the company.
+    /// BC lowers this to ALCompanyProperty.ALID() which requires NavEnvironment.
+    /// </summary>
+    public static NavGuid CompanyPropertyID() => new NavGuid(new Guid("5f5f5f5f-5f5f-5f5f-5f5f-5f5f5f5f5f5f"));
+
+    /// <summary>
     /// NormalDate(date) — wraps ALSystemDate.ALNormalDate with 0D handling.
     /// BC runtime throws NavNCLDateInvalidException on 0D; we return 0D.
     /// </summary>

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -1267,20 +1267,20 @@ CodeunitInstance.Run:
 CompanyProperty.DisplayName:
   layer: runtime-api
   category: CompanyProperty
-  status: gap
-  notes: overloads=1
+  status: stub
+  notes: overloads=1; ALCompanyProperty.ALDisplayName() → AlCompat.CompanyPropertyDisplayName() → "My Company"
 
 CompanyProperty.ID:
   layer: runtime-api
   category: CompanyProperty
-  status: gap
-  notes: overloads=1
+  status: stub
+  notes: overloads=1; ALCompanyProperty.ALID() → AlCompat.CompanyPropertyID() → fixed non-empty GUID
 
 CompanyProperty.UrlName:
   layer: runtime-api
   category: CompanyProperty
-  status: gap
-  notes: overloads=1
+  status: stub
+  notes: overloads=1; ALCompanyProperty.ALUrlName() → AlCompat.CompanyPropertyUrlName() → "My%20Company"
 
 # ── Cookie ──────────────────────────────────────────────────────
 

--- a/tests/bucket-1/61-company-property/test/TestCompanyProperty.al
+++ b/tests/bucket-1/61-company-property/test/TestCompanyProperty.al
@@ -1,0 +1,52 @@
+codeunit 61401 "Test CompanyProperty"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    [Test]
+    procedure DisplayName_ReturnsNonEmptyString()
+    var
+        Name: Text;
+    begin
+        Name := CompanyProperty.DisplayName();
+        Assert.AreNotEqual('', Name, 'DisplayName must return a non-empty string');
+    end;
+
+    [Test]
+    procedure DisplayName_ReturnsExpectedStubValue()
+    var
+        Name: Text;
+    begin
+        Name := CompanyProperty.DisplayName();
+        Assert.AreEqual('My Company', Name, 'DisplayName must return the stub company name');
+    end;
+
+    [Test]
+    procedure UrlName_ReturnsNonEmptyString()
+    var
+        Name: Text;
+    begin
+        Name := CompanyProperty.UrlName();
+        Assert.AreNotEqual('', Name, 'UrlName must return a non-empty string');
+    end;
+
+    [Test]
+    procedure UrlName_ReturnsExpectedStubValue()
+    var
+        Name: Text;
+    begin
+        Name := CompanyProperty.UrlName();
+        Assert.AreEqual('My%20Company', Name, 'UrlName must return the URL-encoded stub company name');
+    end;
+
+    [Test]
+    procedure ID_ReturnsNonEmptyGuid()
+    var
+        Id: Guid;
+    begin
+        Id := CompanyProperty.ID();
+        Assert.IsFalse(IsNullGuid(Id), 'ID must return a non-empty GUID');
+    end;
+}


### PR DESCRIPTION
Closes #333

## Summary

- `CompanyProperty.ID()` was unimplemented — BC lowers it to `ALCompanyProperty.ALID()` which requires `NavEnvironment`. Added a rewriter rule redirecting it to `AlCompat.CompanyPropertyID()`, which returns a fixed non-empty GUID (`5f5f5f5f-...`).
- `CompanyProperty.DisplayName()` and `CompanyProperty.UrlName()` were already stubbed but had no dedicated proving suite.

## Changes

| File | Change |
|---|---|
| `AlRunner/RoslynRewriter.cs` | New rule: `ALCompanyProperty.ALID()` → `AlCompat.CompanyPropertyID()` |
| `AlRunner/Runtime/AlScope.cs` | New stub: `CompanyPropertyID()` returns fixed non-empty GUID |
| `AlRunner/Program.cs` | Updated `--guide` output to include `ID()` |
| `tests/bucket-1/61-company-property/` | 5 proving tests: DisplayName (non-empty + value), UrlName (non-empty + value), ID (non-null GUID) |
| `docs/coverage.yaml` | DisplayName/ID/UrlName: `gap` → `stub` |