### PR TITLE
feat: Date2DMY / Date2DWY coverage — Day, Month, Year, DayOfWeek, WeekNo (#336)

### DIFF
--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -1561,38 +1561,38 @@ Database.UserSecurityId:
 Date.Day:
   layer: runtime-api
   category: Date
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; via Date2DMY(D,1)
 
 Date.DayOfWeek:
   layer: runtime-api
   category: Date
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; via Date2DWY(D,1)
 
 Date.Month:
   layer: runtime-api
   category: Date
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; via Date2DMY(D,2)
 
 Date.ToText:
   layer: runtime-api
   category: Date
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; via Format(D) handled by AlCompat.Format
 
 Date.WeekNo:
   layer: runtime-api
   category: Date
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; via Date2DWY(D,2)
 
 Date.Year:
   layer: runtime-api
   category: Date
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; via Date2DMY(D,3)
 
 # ── DateTime ────────────────────────────────────────────────────
 
@@ -5304,14 +5304,14 @@ System.CurrentDateTime:
 System.Date2DMY:
   layer: runtime-api
   category: System
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; day=index 1, month=index 2, year=index 3
 
 System.Date2DWY:
   layer: runtime-api
   category: System
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; day-of-week=index 1, week-no=index 2
 
 System.DaTi2Variant:
   layer: runtime-api

--- a/tests/bucket-1/61-date-decomposition/src/DateHelper.al
+++ b/tests/bucket-1/61-date-decomposition/src/DateHelper.al
@@ -1,0 +1,27 @@
+codeunit 60500 "Date Decomposition Helper"
+{
+    procedure GetDay(D: Date): Integer
+    begin
+        exit(Date2DMY(D, 1));
+    end;
+
+    procedure GetMonth(D: Date): Integer
+    begin
+        exit(Date2DMY(D, 2));
+    end;
+
+    procedure GetYear(D: Date): Integer
+    begin
+        exit(Date2DMY(D, 3));
+    end;
+
+    procedure GetDayOfWeek(D: Date): Integer
+    begin
+        exit(Date2DWY(D, 1));
+    end;
+
+    procedure GetWeekNo(D: Date): Integer
+    begin
+        exit(Date2DWY(D, 2));
+    end;
+}

--- a/tests/bucket-1/61-date-decomposition/test/TestDateDecomposition.al
+++ b/tests/bucket-1/61-date-decomposition/test/TestDateDecomposition.al
@@ -1,0 +1,76 @@
+codeunit 60501 "Test Date Decomposition"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    // --- Date2DMY ---
+
+    [Test]
+    procedure Date2DMY_ExtractsDay()
+    var
+        Helper: Codeunit "Date Decomposition Helper";
+    begin
+        // 20240115D = January 15, 2024 → day = 15
+        Assert.AreEqual(15, Helper.GetDay(20240115D), 'Date2DMY(D,1) must return day 15');
+    end;
+
+    [Test]
+    procedure Date2DMY_ExtractsMonth()
+    var
+        Helper: Codeunit "Date Decomposition Helper";
+    begin
+        // 20240115D = January 15, 2024 → month = 1
+        Assert.AreEqual(1, Helper.GetMonth(20240115D), 'Date2DMY(D,2) must return month 1');
+    end;
+
+    [Test]
+    procedure Date2DMY_ExtractsYear()
+    var
+        Helper: Codeunit "Date Decomposition Helper";
+    begin
+        // 20240115D = January 15, 2024 → year = 2024
+        Assert.AreEqual(2024, Helper.GetYear(20240115D), 'Date2DMY(D,3) must return year 2024');
+    end;
+
+    [Test]
+    procedure Date2DMY_DifferentDate_ExtractsCorrectly()
+    var
+        Helper: Codeunit "Date Decomposition Helper";
+    begin
+        // 20231231D = December 31, 2023
+        Assert.AreEqual(31, Helper.GetDay(20231231D), 'Day of Dec 31 must be 31');
+        Assert.AreEqual(12, Helper.GetMonth(20231231D), 'Month of Dec 31 must be 12');
+        Assert.AreEqual(2023, Helper.GetYear(20231231D), 'Year of Dec 31 must be 2023');
+    end;
+
+    // --- Date2DWY ---
+
+    [Test]
+    procedure Date2DWY_ExtractsDayOfWeek()
+    var
+        Helper: Codeunit "Date Decomposition Helper";
+    begin
+        // 20240115D = Monday → day-of-week = 1 (BC: 1=Monday)
+        Assert.AreEqual(1, Helper.GetDayOfWeek(20240115D), 'Date2DWY(D,1) must return 1 for Monday');
+    end;
+
+    [Test]
+    procedure Date2DWY_ExtractsWeekNo()
+    var
+        Helper: Codeunit "Date Decomposition Helper";
+    begin
+        // 20240115D = January 15, 2024 = week 3
+        Assert.AreEqual(3, Helper.GetWeekNo(20240115D), 'Date2DWY(D,2) must return week 3 for Jan 15 2024');
+    end;
+
+    [Test]
+    procedure Date2DWY_Sunday_ReturnsSeven()
+    var
+        Helper: Codeunit "Date Decomposition Helper";
+    begin
+        // 20240114D = January 14, 2024 = Sunday → 7
+        Assert.AreEqual(7, Helper.GetDayOfWeek(20240114D), 'Date2DWY(D,1) must return 7 for Sunday');
+    end;
+}


### PR DESCRIPTION
Closes #336

## What changed

New test suite `tests/bucket-1/61-date-decomposition` (codeunits 60500/60501) proving `Date2DMY` and `Date2DWY` work correctly via the BC runtime types — no runner changes needed.

**7 test methods:**
- `Date2DMY_ExtractsDay` — `Date2DMY(20240115D,1)` → 15 ✓
- `Date2DMY_ExtractsMonth` — `Date2DMY(20240115D,2)` → 1 ✓
- `Date2DMY_ExtractsYear` — `Date2DMY(20240115D,3)` → 2024 ✓
- `Date2DMY_DifferentDate_ExtractsCorrectly` — day/month/year of `20231231D` all correct ✓
- `Date2DWY_ExtractsDayOfWeek` — `Date2DWY(20240115D,1)` → 1 (Monday) ✓
- `Date2DWY_ExtractsWeekNo` — `Date2DWY(20240115D,2)` → 3 (week 3) ✓
- `Date2DWY_Sunday_ReturnsSeven` — `Date2DWY(20240114D,1)` → 7 (Sunday) ✓

**Coverage map updated:** `Date.Day`, `Date.Month`, `Date.Year`, `Date.DayOfWeek`, `Date.WeekNo`, `Date.ToText`, `System.Date2DMY`, `System.Date2DWY` → `covered`