### PR TITLE
feat: CurrentTransactionType() stub returning TransactionType::Update

### DIFF
--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -1601,10 +1601,23 @@ public void ClearApplicationMemberVariables() { }
         }
 
         // ALDatabase.ALSessionID() -> MockSession.GetSessionId()
-        // BC lowers SessionId() to a 0-argument static method call on ALDatabase.
-        // This must be caught before base.VisitInvocationExpression because the MemberAccess
-        // visitor would otherwise replace the callee with MockSession.GetSessionId() and produce
-        // the invalid double-call form MockSession.GetSessionId()().
+        // ALDatabase.ALCurrentTransactionType() -> AlCompat.CurrentTransactionType()
+        // These must be caught before base.VisitInvocationExpression because the MemberAccess
+        // visitor would otherwise replace the callee and produce an invalid double-call form.
+        if (node.Expression is MemberAccessExpressionSyntax txMa &&
+            txMa.Expression is IdentifierNameSyntax txDbIdent &&
+            txDbIdent.Identifier.Text == "ALDatabase" &&
+            txMa.Name.Identifier.Text == "ALCurrentTransactionType")
+        {
+            return SyntaxFactory.InvocationExpression(
+                SyntaxFactory.MemberAccessExpression(
+                    SyntaxKind.SimpleMemberAccessExpression,
+                    SyntaxFactory.IdentifierName("AlCompat"),
+                    SyntaxFactory.IdentifierName("CurrentTransactionType")),
+                SyntaxFactory.ArgumentList())
+                .WithTriviaFrom(node);
+        }
+
         if (node.Expression is MemberAccessExpressionSyntax sessionMa &&
             sessionMa.Expression is IdentifierNameSyntax sessionDbIdent &&
             sessionDbIdent.Identifier.Text == "ALDatabase" &&
@@ -2360,19 +2373,6 @@ public void ClearApplicationMemberVariables() { }
                         SyntaxKind.SimpleMemberAccessExpression,
                         SyntaxFactory.IdentifierName("AlCompat"),
                         SyntaxFactory.IdentifierName("StrSubstNo")));
-            }
-
-            // ALDatabase.ALCurrentTransactionType() -> AlCompat.CurrentTransactionType()
-            // Returns NavOption for TransactionType::Update (ordinal 2). Real impl requires NavSession.
-            if (exprText == "ALDatabase" && methodName == "ALCurrentTransactionType")
-            {
-                return SyntaxFactory.InvocationExpression(
-                    SyntaxFactory.MemberAccessExpression(
-                        SyntaxKind.SimpleMemberAccessExpression,
-                        SyntaxFactory.IdentifierName("AlCompat"),
-                        SyntaxFactory.IdentifierName("CurrentTransactionType")),
-                    SyntaxFactory.ArgumentList())
-                    .WithTriviaFrom(visited);
             }
 
             // ALDatabase.ALIsInWriteTransaction() -> false

--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -2362,6 +2362,19 @@ public void ClearApplicationMemberVariables() { }
                         SyntaxFactory.IdentifierName("StrSubstNo")));
             }
 
+            // ALDatabase.ALCurrentTransactionType() -> AlCompat.CurrentTransactionType()
+            // Returns NavOption for TransactionType::Update (ordinal 2). Real impl requires NavSession.
+            if (exprText == "ALDatabase" && methodName == "ALCurrentTransactionType")
+            {
+                return SyntaxFactory.InvocationExpression(
+                    SyntaxFactory.MemberAccessExpression(
+                        SyntaxKind.SimpleMemberAccessExpression,
+                        SyntaxFactory.IdentifierName("AlCompat"),
+                        SyntaxFactory.IdentifierName("CurrentTransactionType")),
+                    SyntaxFactory.ArgumentList())
+                    .WithTriviaFrom(visited);
+            }
+
             // ALDatabase.ALIsInWriteTransaction() -> false
             // The real ALIsInWriteTransaction calls NavSession.HasWriteTransaction() which crashes
             // with NullReferenceException when NavSession is null (runner context, no DB).

--- a/AlRunner/Runtime/AlScope.cs
+++ b/AlRunner/Runtime/AlScope.cs
@@ -1434,6 +1434,13 @@ public static class AlCompat
     public static NavGuid CompanyPropertyID() => new NavGuid(new Guid("5f5f5f5f-5f5f-5f5f-5f5f-5f5f5f5f5f5f"));
 
     /// <summary>
+    /// CurrentTransactionType() stub — returns TransactionType::Update (ordinal 2).
+    /// BC lowers this to ALDatabase.ALCurrentTransactionType() which requires a live session.
+    /// Update is the most common real-world value and is the safest stable stub.
+    /// </summary>
+    public static NavOption CurrentTransactionType() => MockRecordHandle.CreateOptionValue(2);
+
+    /// <summary>
     /// NormalDate(date) — wraps ALSystemDate.ALNormalDate with 0D handling.
     /// BC runtime throws NavNCLDateInvalidException on 0D; we return 0D.
     /// </summary>

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -1418,8 +1418,8 @@ Database.CopyCompany:
 Database.CurrentTransactionType:
   layer: runtime-api
   category: Database
-  status: gap
-  notes: overloads=1
+  status: stub
+  notes: overloads=1; ALDatabase.ALCurrentTransactionType() → AlCompat.CurrentTransactionType() → TransactionType::Update (ordinal 2)
 
 Database.DataFileInformation:
   layer: runtime-api

--- a/tests/bucket-1/62-current-transaction-type/test/TestCurrentTransactionType.al
+++ b/tests/bucket-1/62-current-transaction-type/test/TestCurrentTransactionType.al
@@ -1,0 +1,29 @@
+codeunit 62401 "Test CurrentTransactionType"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    [Test]
+    procedure CurrentTransactionType_ReturnsUpdate()
+    var
+        TxType: TransactionType;
+    begin
+        // Runner stub must return TransactionType::Update (the most common real-world value)
+        TxType := CurrentTransactionType();
+        Assert.AreEqual(TransactionType::Update, TxType, 'CurrentTransactionType() must return Update in runner');
+    end;
+
+    [Test]
+    procedure CurrentTransactionType_IsStable()
+    var
+        T1: TransactionType;
+        T2: TransactionType;
+    begin
+        // Must return the same value on consecutive calls
+        T1 := CurrentTransactionType();
+        T2 := CurrentTransactionType();
+        Assert.AreEqual(T1, T2, 'CurrentTransactionType() must return a stable value');
+    end;
+}


### PR DESCRIPTION
Closes #323

## Summary

`CurrentTransactionType()` in AL is lowered by the BC compiler to `ALDatabase.ALCurrentTransactionType()`, which requires a live `NavSession` and crashes in standalone mode.

Added a rewriter rule that redirects `ALDatabase.ALCurrentTransactionType()` → `AlCompat.CurrentTransactionType()`, returning `NavOption` ordinal 2 (`TransactionType::Update`) — the most common real-world transaction type and safest stable stub value.

## Changes

| File | Change |
|---|---|
| `AlRunner/RoslynRewriter.cs` | New rule: `ALDatabase.ALCurrentTransactionType()` → `AlCompat.CurrentTransactionType()` |
| `AlRunner/Runtime/AlScope.cs` | New stub: `CurrentTransactionType()` returns `MockRecordHandle.CreateOptionValue(2)` |
| `tests/bucket-1/62-current-transaction-type/` | 2 proving tests: returns `TransactionType::Update` (exact value), stable across calls |
| `docs/coverage.yaml` | `Database.CurrentTransactionType`: `gap` → `stub` |