### PR TITLE
feat: Database.CurrentTransactionType() stub — returns TransactionType::Update (#323)

### DIFF
--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -2382,19 +2382,6 @@ public void ClearApplicationMemberVariables() { }
                         SyntaxFactory.IdentifierName("HasTableConnection")));
             }
 
-            // ALDatabase.ALCurrentTransactionType([session]) -> AlCompat.ALCurrentTransactionType()
-            // The real implementation requires NavSession; our stub returns TransactionType::Update (ordinal 2).
-            // Replace the entire invocation (including args) to drop any session argument BC may pass.
-            if (exprText == "ALDatabase" && methodName == "ALCurrentTransactionType")
-            {
-                return SyntaxFactory.InvocationExpression(
-                    SyntaxFactory.MemberAccessExpression(
-                        SyntaxKind.SimpleMemberAccessExpression,
-                        SyntaxFactory.IdentifierName("AlCompat"),
-                        SyntaxFactory.IdentifierName("ALCurrentTransactionType")),
-                    SyntaxFactory.ArgumentList())
-                    .WithTriviaFrom(visited);
-            }
 
             // ALDatabase.ALCreateGuid() -> AlCompat.ALCreateGuid()
             // ALDatabase.ALCreateSequentialGuid() -> AlCompat.ALCreateSequentialGuid()
@@ -2819,6 +2806,24 @@ public void ClearApplicationMemberVariables() { }
                     SyntaxFactory.IdentifierName(targetProp))
                     .WithTriviaFrom(visited);
             }
+        }
+
+        // Pattern: ALDatabase.ALCurrentTransactionType (property get — no parentheses)
+        // BC lowers CurrentTransactionType() to a PROPERTY GETTER on ALDatabase, NOT a method call.
+        // The generated C# is `ALDatabase.ALCurrentTransactionType` (a MemberAccessExpressionSyntax),
+        // not `ALDatabase.ALCurrentTransactionType(...)` (an InvocationExpressionSyntax).
+        // Rewrite to AlCompat.ALCurrentTransactionType() which returns TransactionType::Update.
+        if (visited.Expression is IdentifierNameSyntax txDbId &&
+            txDbId.Identifier.Text == "ALDatabase" &&
+            visited.Name.Identifier.Text == "ALCurrentTransactionType")
+        {
+            return SyntaxFactory.InvocationExpression(
+                SyntaxFactory.MemberAccessExpression(
+                    SyntaxKind.SimpleMemberAccessExpression,
+                    SyntaxFactory.IdentifierName("AlCompat"),
+                    SyntaxFactory.IdentifierName("ALCurrentTransactionType")),
+                SyntaxFactory.ArgumentList())
+                .WithTriviaFrom(visited);
         }
 
         // Pattern: ALDatabase.ALCompanyName / ALDatabase.ALUserID / ALDatabase.ALTenantID / ALDatabase.ALSerialNumber

--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -2382,6 +2382,17 @@ public void ClearApplicationMemberVariables() { }
                         SyntaxFactory.IdentifierName("HasTableConnection")));
             }
 
+            // ALDatabase.ALCurrentTransactionType() -> AlCompat.ALCurrentTransactionType()
+            // The real implementation requires NavSession; our stub returns TransactionType::Update (ordinal 2).
+            if (exprText == "ALDatabase" && methodName == "ALCurrentTransactionType")
+            {
+                return visited.WithExpression(
+                    SyntaxFactory.MemberAccessExpression(
+                        SyntaxKind.SimpleMemberAccessExpression,
+                        SyntaxFactory.IdentifierName("AlCompat"),
+                        SyntaxFactory.IdentifierName("ALCurrentTransactionType")));
+            }
+
             // ALDatabase.ALCreateGuid() -> AlCompat.ALCreateGuid()
             // ALDatabase.ALCreateSequentialGuid() -> AlCompat.ALCreateSequentialGuid()
             // The real implementations require NavSession; ours use System.Guid.NewGuid().

--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -2382,15 +2382,18 @@ public void ClearApplicationMemberVariables() { }
                         SyntaxFactory.IdentifierName("HasTableConnection")));
             }
 
-            // ALDatabase.ALCurrentTransactionType() -> AlCompat.ALCurrentTransactionType()
+            // ALDatabase.ALCurrentTransactionType([session]) -> AlCompat.ALCurrentTransactionType()
             // The real implementation requires NavSession; our stub returns TransactionType::Update (ordinal 2).
+            // Replace the entire invocation (including args) to drop any session argument BC may pass.
             if (exprText == "ALDatabase" && methodName == "ALCurrentTransactionType")
             {
-                return visited.WithExpression(
+                return SyntaxFactory.InvocationExpression(
                     SyntaxFactory.MemberAccessExpression(
                         SyntaxKind.SimpleMemberAccessExpression,
                         SyntaxFactory.IdentifierName("AlCompat"),
-                        SyntaxFactory.IdentifierName("ALCurrentTransactionType")));
+                        SyntaxFactory.IdentifierName("ALCurrentTransactionType")),
+                    SyntaxFactory.ArgumentList())
+                    .WithTriviaFrom(visited);
             }
 
             // ALDatabase.ALCreateGuid() -> AlCompat.ALCreateGuid()

--- a/AlRunner/Runtime/AlScope.cs
+++ b/AlRunner/Runtime/AlScope.cs
@@ -1346,12 +1346,12 @@ public static class AlCompat
 
     /// <summary>
     /// Replacement for ALDatabase.ALCurrentTransactionType() which requires NavSession.
-    /// The runner has no real transaction tracking; returns TransactionType::Update (ordinal 2),
+    /// The runner has no real transaction tracking; returns TransactionType.Update,
     /// the most common real-world value and a predictable stable stub.
-    /// TransactionType ordinals: Browse=0, Snapshot=1, Update=2, Report=3.
+    /// TransactionType is a BC enum: Browse=0, Snapshot=1, Update=2, Report=3.
     /// </summary>
-    public static NavOption ALCurrentTransactionType()
-        => AlRunner.Runtime.MockRecordHandle.CreateOptionValue(2); // TransactionType::Update
+    public static Microsoft.Dynamics.Nav.Types.TransactionType ALCurrentTransactionType()
+        => Microsoft.Dynamics.Nav.Types.TransactionType.Update;
 
     /// <summary>
     /// Replacement for ALDatabase.ALIsNullGuid(g) which requires NavSession.

--- a/AlRunner/Runtime/AlScope.cs
+++ b/AlRunner/Runtime/AlScope.cs
@@ -1344,6 +1344,16 @@ public static class AlCompat
     /// </summary>
     public static NavGuid ALCreateSequentialGuid() => new NavGuid(Guid.NewGuid());
 
+    /// <summary>
+    /// Replacement for ALDatabase.ALCurrentTransactionType() which requires NavSession.
+    /// The runner has no real transaction tracking; returns TransactionType::Update (ordinal 2),
+    /// the most common real-world value and a predictable stable stub.
+    /// TransactionType ordinals: Browse=0, Snapshot=1, Update=2, Report=3.
+    /// </summary>
+    public static NavOption ALCurrentTransactionType()
+        => AlRunner.Runtime.MockRecordHandle.CreateOptionValue(2); // TransactionType::Update
+
+    /// <summary>
     /// Replacement for ALDatabase.ALIsNullGuid(g) which requires NavSession.
     /// Returns true when the GUID is the all-zeros default ({00000000-...}).
     /// </summary>

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -1418,8 +1418,10 @@ Database.CopyCompany:
 Database.CurrentTransactionType:
   layer: runtime-api
   category: Database
-  status: gap
-  notes: overloads=1
+  status: stub
+  tests:
+    - tests/bucket-2/62-current-transaction-type
+  notes: stub returning TransactionType::Update (ordinal 2); runner has no real transaction tracking
 
 Database.DataFileInformation:
   layer: runtime-api

--- a/tests/bucket-2/62-current-transaction-type/test/TestCurrentTransactionType.al
+++ b/tests/bucket-2/62-current-transaction-type/test/TestCurrentTransactionType.al
@@ -1,0 +1,46 @@
+codeunit 62000 "Test CurrentTransactionType"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    [Test]
+    procedure CurrentTransactionType_ReturnsUpdate()
+    var
+        TxType: TransactionType;
+    begin
+        // [GIVEN] The runner has no real transaction system
+        // [WHEN] CurrentTransactionType() is called
+        TxType := CurrentTransactionType();
+
+        // [THEN] Returns TransactionType::Update (the stable stub value)
+        Assert.AreEqual(TransactionType::Update, TxType, 'CurrentTransactionType() must return Update in runner');
+    end;
+
+    [Test]
+    procedure CurrentTransactionType_IsStable()
+    var
+        T1: TransactionType;
+        T2: TransactionType;
+    begin
+        // [GIVEN] Multiple calls to CurrentTransactionType()
+        T1 := CurrentTransactionType();
+        T2 := CurrentTransactionType();
+
+        // [THEN] Always returns the same value
+        Assert.AreEqual(T1, T2, 'CurrentTransactionType() must return a stable value');
+    end;
+
+    [Test]
+    procedure CurrentTransactionType_NotBrowse()
+    var
+        TxType: TransactionType;
+    begin
+        // [GIVEN] The stub always returns Update
+        TxType := CurrentTransactionType();
+
+        // [THEN] It does not return Browse (proves it is not defaulting to ordinal 0)
+        Assert.AreNotEqual(TransactionType::Browse, TxType, 'CurrentTransactionType() must not return Browse');
+    end;
+}


### PR DESCRIPTION
Closes #323

Implements a stable stub for `CurrentTransactionType()`. The runner has no real transaction system; the stub always returns `TransactionType::Update` (ordinal 2), the most common real-world value.

## What

- `AlRunner/RoslynRewriter.cs`: new rule redirects `ALDatabase.ALCurrentTransactionType()` → `AlCompat.ALCurrentTransactionType()`
- `AlRunner/Runtime/AlScope.cs` (`AlCompat`): `ALCurrentTransactionType()` returns `MockRecordHandle.CreateOptionValue(2)`
- New suite `tests/bucket-2/62-current-transaction-type/test/TestCurrentTransactionType.al` (codeunit 62000)
- `docs/coverage.yaml`: `Database.CurrentTransactionType` → `status: stub`

## Tests

| Test | What it proves |
|---|---|
| `CurrentTransactionType_ReturnsUpdate` | Returns `TransactionType::Update` (not a crash, not wrong value) |
| `CurrentTransactionType_IsStable` | Two consecutive calls return the same value |
| `CurrentTransactionType_NotBrowse` | Anti-default: not ordinal 0 (Browse), proving the stub is active |