### PR TITLE
feat: FieldRef.Active() proving tests (issue #349)

### DIFF
--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -1954,6 +1954,7 @@ FieldRef.Active:
   layer: runtime-api
   category: FieldRef
   status: covered
+  tests: tests/bucket-1/62-fieldref-active
   notes: overloads=1
 
 FieldRef.CalcField:

--- a/tests/bucket-1/62-fieldref-active/src/FieldRefActiveSrc.al
+++ b/tests/bucket-1/62-fieldref-active/src/FieldRefActiveSrc.al
@@ -1,0 +1,43 @@
+table 57800 "FA Test"
+{
+    DataClassification = CustomerContent;
+
+    fields
+    {
+        field(1; "Code"; Code[20]) { }
+        field(2; "Name"; Text[100]) { }
+        field(3; "Amount"; Decimal) { }
+        field(4; "Qty"; Integer) { }
+        field(5; "Active"; Boolean) { }
+    }
+
+    keys
+    {
+        key(PK; "Code") { Clustered = true; }
+    }
+}
+
+codeunit 57801 "FA Helper"
+{
+    procedure IsFieldActiveByNo(RecRef: RecordRef; FieldNo: Integer): Boolean
+    var
+        FRef: FieldRef;
+    begin
+        FRef := RecRef.Field(FieldNo);
+        exit(FRef.Active());
+    end;
+
+    procedure CountActiveFields(RecRef: RecordRef): Integer
+    var
+        FRef: FieldRef;
+        I: Integer;
+        Cnt: Integer;
+    begin
+        for I := 1 to RecRef.FieldCount() do begin
+            FRef := RecRef.FieldIndex(I);
+            if FRef.Active() then
+                Cnt += 1;
+        end;
+        exit(Cnt);
+    end;
+}

--- a/tests/bucket-1/62-fieldref-active/test/FieldRefActiveTests.al
+++ b/tests/bucket-1/62-fieldref-active/test/FieldRefActiveTests.al
@@ -1,0 +1,97 @@
+codeunit 57802 "FA FieldRef Active Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Helper: Codeunit "FA Helper";
+
+    // -----------------------------------------------------------------------
+    // FieldRef.Active() — normal fields always return true
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure Active_PKField_ReturnsTrue()
+    var
+        RecRef: RecordRef;
+    begin
+        // [GIVEN] RecordRef opened on FA Test
+        // [WHEN] Active() called on field(1) — the PK field (Code)
+        // [THEN] returns true (PK fields are always active)
+        RecRef.Open(Database::"FA Test");
+        Assert.IsTrue(Helper.IsFieldActiveByNo(RecRef, 1), 'PK field (Code) must be active');
+        RecRef.Close();
+    end;
+
+    [Test]
+    procedure Active_TextNonPKField_ReturnsTrue()
+    var
+        RecRef: RecordRef;
+    begin
+        // [GIVEN] RecordRef opened on FA Test
+        // [WHEN] Active() called on field(2) — Name (Text)
+        // [THEN] returns true
+        RecRef.Open(Database::"FA Test");
+        Assert.IsTrue(Helper.IsFieldActiveByNo(RecRef, 2), 'Name field (Text) must be active');
+        RecRef.Close();
+    end;
+
+    [Test]
+    procedure Active_DecimalField_ReturnsTrue()
+    var
+        RecRef: RecordRef;
+    begin
+        // [GIVEN] RecordRef opened on FA Test
+        // [WHEN] Active() called on field(3) — Amount (Decimal)
+        // [THEN] returns true
+        RecRef.Open(Database::"FA Test");
+        Assert.IsTrue(Helper.IsFieldActiveByNo(RecRef, 3), 'Amount field (Decimal) must be active');
+        RecRef.Close();
+    end;
+
+    [Test]
+    procedure Active_BooleanField_ReturnsTrue()
+    var
+        RecRef: RecordRef;
+    begin
+        // [GIVEN] RecordRef opened on FA Test
+        // [WHEN] Active() called on field(5) — Active (Boolean)
+        // [THEN] returns true
+        RecRef.Open(Database::"FA Test");
+        Assert.IsTrue(Helper.IsFieldActiveByNo(RecRef, 5), 'Active field (Boolean) must be active');
+        RecRef.Close();
+    end;
+
+    [Test]
+    procedure Active_AllFieldsActiveViaFieldIndex()
+    var
+        RecRef: RecordRef;
+        Count: Integer;
+    begin
+        // [GIVEN] RecordRef opened on FA Test (5 fields)
+        // [WHEN] CountActiveFields iterates all fields via FieldIndex and checks Active()
+        // [THEN] all 5 fields are active
+        RecRef.Open(Database::"FA Test");
+        Count := Helper.CountActiveFields(RecRef);
+        Assert.AreEqual(5, Count, 'All 5 fields must be active (normal fields are always active)');
+        RecRef.Close();
+    end;
+
+    [Test]
+    procedure Active_ActiveCountMatchesFieldCount()
+    var
+        RecRef: RecordRef;
+        ActiveCount: Integer;
+        FieldCount: Integer;
+    begin
+        // [GIVEN] RecordRef opened on FA Test
+        // [WHEN] Active() checked on all fields
+        // [THEN] active count equals FieldCount — no fields are inactive
+        RecRef.Open(Database::"FA Test");
+        FieldCount := RecRef.FieldCount();
+        ActiveCount := Helper.CountActiveFields(RecRef);
+        Assert.AreEqual(FieldCount, ActiveCount,
+            'Active field count must equal total FieldCount for a table with no disabled fields');
+        RecRef.Close();
+    end;
+}


### PR DESCRIPTION
Closes #349

## Summary
- New test suite `tests/bucket-1/62-fieldref-active/` with 6 proving tests for `FieldRef.Active()`
- Tests cover: PK field, Text field, Decimal field, Boolean field, all-fields-via-FieldIndex loop, and count-equals-FieldCount invariant
- Updated `docs/coverage.yaml` with `tests:` pointer for `FieldRef.Active`
- No implementation change needed: `MockFieldRef.ALActive` was already correctly returning `true` for all normal fields