### PR TITLE
feat: Codeunit.Run(id, var rec) proving tests (issue #348)

### DIFF
--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -1251,8 +1251,11 @@ Byte.ToText:
 Codeunit.Run:
   layer: runtime-api
   category: Codeunit
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests:
+    - tests/bucket-1/64-codeunit-run-record
+    - tests/bucket-1/112-codeunit-onrun-record
+  notes: overloads=2 (no-record and with-record variants); returns true on success, false on trapped error
 
 # ── CodeunitInstance ────────────────────────────────────────────
 

--- a/tests/bucket-1/64-codeunit-run-record/src/CodeunitRunRecordSrc.al
+++ b/tests/bucket-1/64-codeunit-run-record/src/CodeunitRunRecordSrc.al
@@ -1,0 +1,47 @@
+table 57900 "CRR Order"
+{
+    DataClassification = CustomerContent;
+
+    fields
+    {
+        field(1; "No."; Code[20]) { }
+        field(2; Status; Code[20]) { }
+        field(3; Amount; Decimal) { }
+    }
+
+    keys
+    {
+        key(PK; "No.") { Clustered = true; }
+    }
+}
+
+/// <summary>
+/// Codeunit with TableNo — updates Status and doubles Amount in OnRun.
+/// Proves that Codeunit.Run(ID, rec) passes the record and modifications
+/// are written back via Modify().
+/// </summary>
+codeunit 57901 "CRR Process Order"
+{
+    TableNo = "CRR Order";
+
+    trigger OnRun()
+    begin
+        Rec.Status := 'DONE';
+        Rec.Amount := Rec.Amount * 2;
+        Rec.Modify();
+    end;
+}
+
+/// <summary>
+/// Codeunit with TableNo that raises an error — used to prove that
+/// Codeunit.Run returns false when an error occurs.
+/// </summary>
+codeunit 57902 "CRR Failing Order"
+{
+    TableNo = "CRR Order";
+
+    trigger OnRun()
+    begin
+        Error('deliberate failure');
+    end;
+}

--- a/tests/bucket-1/64-codeunit-run-record/test/CodeunitRunRecordTests.al
+++ b/tests/bucket-1/64-codeunit-run-record/test/CodeunitRunRecordTests.al
@@ -1,0 +1,120 @@
+codeunit 57903 "CRR Codeunit Run Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    // -----------------------------------------------------------------------
+    // Codeunit.Run(ID, var Rec) — return value
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure CodeunitRun_WithRecord_ReturnsTrueOnSuccess()
+    var
+        Rec: Record "CRR Order";
+        Success: Boolean;
+    begin
+        // [GIVEN] A record inserted into the store
+        Rec.DeleteAll();
+        Rec.Init();
+        Rec."No." := 'ORD001';
+        Rec.Status := 'NEW';
+        Rec.Amount := 100;
+        Rec.Insert();
+
+        // [WHEN] Codeunit.Run called with a valid record
+        Success := Codeunit.Run(Codeunit::"CRR Process Order", Rec);
+
+        // [THEN] Returns true — the codeunit ran without error
+        Assert.IsTrue(Success, 'Codeunit.Run must return true when OnRun completes without error');
+    end;
+
+    [Test]
+    procedure CodeunitRun_WithRecord_ReturnsFalseOnError()
+    var
+        Rec: Record "CRR Order";
+        Success: Boolean;
+    begin
+        // [GIVEN] A record (content irrelevant — the codeunit always errors)
+        Rec.DeleteAll();
+        Rec.Init();
+        Rec."No." := 'ORD002';
+        Rec.Insert();
+
+        // [WHEN] Codeunit.Run called with a codeunit that raises an error
+        Success := Codeunit.Run(Codeunit::"CRR Failing Order", Rec);
+
+        // [THEN] Returns false — error was suppressed
+        Assert.IsFalse(Success, 'Codeunit.Run must return false when OnRun raises an error');
+    end;
+
+    // -----------------------------------------------------------------------
+    // Codeunit.Run(ID, var Rec) — OnRun modifications visible after run
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure CodeunitRun_WithRecord_ModificationsVisibleAfterRun()
+    var
+        Rec: Record "CRR Order";
+        ReloaD: Record "CRR Order";
+    begin
+        // [GIVEN] A record with Status='NEW' and Amount=50
+        Rec.DeleteAll();
+        Rec.Init();
+        Rec."No." := 'ORD010';
+        Rec.Status := 'NEW';
+        Rec.Amount := 50;
+        Rec.Insert();
+
+        // [WHEN] Codeunit.Run with CRR Process Order (sets Status='DONE', doubles Amount)
+        Codeunit.Run(Codeunit::"CRR Process Order", Rec);
+
+        // [THEN] Changes are stored — reloading from table confirms them
+        ReloaD.Get('ORD010');
+        Assert.AreEqual('DONE', ReloaD.Status, 'Status must be updated by OnRun and persisted');
+        Assert.AreEqual(100, ReloaD.Amount, 'Amount must be doubled by OnRun and persisted');
+    end;
+
+    [Test]
+    procedure CodeunitRun_WithRecord_InMemoryRecReflectsChanges()
+    var
+        Rec: Record "CRR Order";
+    begin
+        // [GIVEN] A record with Amount=25
+        Rec.DeleteAll();
+        Rec.Init();
+        Rec."No." := 'ORD020';
+        Rec.Status := 'OPEN';
+        Rec.Amount := 25;
+        Rec.Insert();
+
+        // [WHEN] Codeunit.Run executed
+        Codeunit.Run(Codeunit::"CRR Process Order", Rec);
+
+        // [THEN] The in-memory Rec variable itself reflects the new values
+        Assert.AreEqual('DONE', Rec.Status, 'In-memory Rec.Status must reflect OnRun change');
+        Assert.AreEqual(50, Rec.Amount, 'In-memory Rec.Amount must reflect OnRun change');
+    end;
+
+    // -----------------------------------------------------------------------
+    // Codeunit.Run — negative: error propagates when not captured
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure CodeunitRun_WithRecord_ErrorPropagatesWhenNotCaptured()
+    var
+        Rec: Record "CRR Order";
+    begin
+        // [GIVEN] A record
+        Rec.DeleteAll();
+        Rec.Init();
+        Rec."No." := 'ORD030';
+        Rec.Insert();
+
+        // [WHEN] Codeunit.Run called and return value not captured
+        // [THEN] Error raised by the codeunit propagates to caller
+        asserterror Codeunit.Run(Codeunit::"CRR Failing Order", Rec);
+        Assert.ExpectedError('deliberate failure');
+    end;
+}


### PR DESCRIPTION
Closes #348

## Summary
- New test suite `tests/bucket-1/64-codeunit-run-record/` with 5 proving tests for `Codeunit.Run(ID, var Rec)`
- Tests cover: returns-true on success, returns-false on trapped error, stored modifications visible via Get(), in-memory Rec reflects OnRun changes, error propagates when return value not captured
- Two supporting codeunits with `TableNo = "CRR Order"`: one that sets Status='DONE' and doubles Amount (success path), one that always errors (failure path)
- Updated `docs/coverage.yaml`: `Codeunit.Run` gap → covered with pointers to both this suite and `112-codeunit-onrun-record`
- Note: issue #351 (Record.Rename) was closed as already resolved by existing `107-rename` suite