### PR TITLE
feat: Record.FieldNo field metadata introspection (#355)

### DIFF
--- a/AlRunner/Runtime/MockRecordHandle.cs
+++ b/AlRunner/Runtime/MockRecordHandle.cs
@@ -956,7 +956,8 @@ public class MockRecordHandle
         if (_fieldNames.TryGetValue(_tableId, out var dict) &&
             dict.TryGetValue(fieldName, out var fieldNo))
             return fieldNo;
-        return 0;
+        // Fall back to TableFieldRegistry (populated at transpile-time from AL source declarations)
+        return TableFieldRegistry.GetFieldId(_tableId, fieldName) ?? 0;
     }
 
     /// <summary>

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -5768,8 +5768,8 @@ Table.FieldName:
 Table.FieldNo:
   layer: runtime-api
   category: Table
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; ALFieldNo(string) falls back to TableFieldRegistry; suite 63-record-fieldno
 
 Table.FilterGroup:
   layer: runtime-api

--- a/tests/bucket-1/63-record-fieldno/src/FieldNoTable.al
+++ b/tests/bucket-1/63-record-fieldno/src/FieldNoTable.al
@@ -1,0 +1,12 @@
+table 63000 "FN Test Table"
+{
+    fields
+    {
+        field(1; Code; Code[10]) { }
+        field(2; Description; Text[100]) { }
+    }
+    keys
+    {
+        key(PK; Code) { Clustered = true; }
+    }
+}

--- a/tests/bucket-1/63-record-fieldno/test/FieldNoTest.al
+++ b/tests/bucket-1/63-record-fieldno/test/FieldNoTest.al
@@ -1,0 +1,65 @@
+codeunit 63001 "FieldNo Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    // --- Record.FieldNo(fieldName) ---
+
+    [Test]
+    procedure FieldNo_KnownField_ReturnsNonZero()
+    var
+        Rec: Record "FN Test Table";
+    begin
+        // Code is field 1 — FieldNo must return a positive number
+        Assert.AreNotEqual(0, Rec.FieldNo(Code), 'FieldNo(Code) must be non-zero');
+    end;
+
+    [Test]
+    procedure FieldNo_SecondField_ReturnsNonZero()
+    var
+        Rec: Record "FN Test Table";
+    begin
+        // Description is field 2 — FieldNo must return a positive number
+        Assert.AreNotEqual(0, Rec.FieldNo(Description), 'FieldNo(Description) must be non-zero');
+    end;
+
+    [Test]
+    procedure FieldNo_DifferentFields_ReturnDifferentNumbers()
+    var
+        Rec: Record "FN Test Table";
+    begin
+        // Code(1) and Description(2) must have distinct field numbers
+        Assert.AreNotEqual(Rec.FieldNo(Code), Rec.FieldNo(Description),
+            'Code and Description must have different field numbers');
+    end;
+
+    [Test]
+    procedure FieldNo_SameField_IsIdempotent()
+    var
+        Rec: Record "FN Test Table";
+    begin
+        // Calling FieldNo twice on the same field yields the same result
+        Assert.AreEqual(Rec.FieldNo(Code), Rec.FieldNo(Code),
+            'FieldNo(Code) must return the same number each time');
+    end;
+
+    [Test]
+    procedure FieldNo_Code_Returns1()
+    var
+        Rec: Record "FN Test Table";
+    begin
+        // Code is declared as field 1 — prove exact value
+        Assert.AreEqual(1, Rec.FieldNo(Code), 'FieldNo(Code) must equal 1');
+    end;
+
+    [Test]
+    procedure FieldNo_Description_Returns2()
+    var
+        Rec: Record "FN Test Table";
+    begin
+        // Description is declared as field 2 — prove exact value
+        Assert.AreEqual(2, Rec.FieldNo(Description), 'FieldNo(Description) must equal 2');
+    end;
+}


### PR DESCRIPTION
Closes #355

## Summary

`Record.FieldNo(FieldName)` was silently returning 0 for any field name because
`MockRecordHandle.ALFieldNo(string)` only checked the runtime `_fieldNames` map,
which is never populated. The fix adds a fallback to `TableFieldRegistry.GetFieldId`,
which is populated at transpile-time from the AL source field declarations.

**Change:** `AlRunner/Runtime/MockRecordHandle.cs` — `ALFieldNo(string)` now falls
back to `TableFieldRegistry.GetFieldId(_tableId, fieldName)` before returning 0.

## Tests

New suite `tests/bucket-1/63-record-fieldno/` (table 63000, codeunit 63001) with 6
proving tests:
- `FieldNo(Code)` → non-zero, exact value 1
- `FieldNo(Description)` → non-zero, exact value 2
- Different fields → different numbers
- Same field → idempotent