### PR TITLE
feat: Record.GetPosition / SetPosition — save and restore cursor position

### DIFF
--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -272,6 +272,8 @@ test executor that needs no BC service tier, Docker, SQL Server, or license.
 - Composite primary keys, sort ordering (SetCurrentKey / SetAscending), CurrentKey, Ascending
 - SETRANGE / SETFILTER filtering (=, <>, <, <=, >, >=, wildcards, OR via |)
 - GetFilter(field), GetFilters, HasFilter — return active filter expressions
+- GetPosition() / SetPosition(text) — serialise/restore primary-key cursor position;
+  round-trip guaranteed; SetPosition with unparseable or non-existent position throws
 - Record marking: `Rec.Mark(true/false)`, `Rec.Mark()` getter, `Rec.MarkedOnly(true)`,
   `Rec.ClearMarks()`. Marks are per record-variable; MarkedOnly gates FindSet/FindFirst/
   FindLast/Next/Count/IsEmpty to the marked subset.

--- a/AlRunner/Runtime/MockRecordHandle.cs
+++ b/AlRunner/Runtime/MockRecordHandle.cs
@@ -2436,14 +2436,14 @@ public class MockRecordHandle
     {
         return template switch
         {
-            NavCode _ => new NavCode(raw),
+            NavCode _ => new NavCode(250, raw),
             NavText _ => new NavText(raw),
             NavInteger _ when int.TryParse(raw, System.Globalization.NumberStyles.Integer,
-                System.Globalization.CultureInfo.InvariantCulture, out var iv) => new NavInteger(iv),
+                System.Globalization.CultureInfo.InvariantCulture, out var iv) => NavInteger.Create(iv),
             NavBigInteger _ when long.TryParse(raw, System.Globalization.NumberStyles.Integer,
-                System.Globalization.CultureInfo.InvariantCulture, out var lv) => new NavBigInteger(lv),
+                System.Globalization.CultureInfo.InvariantCulture, out var lv) => NavBigInteger.Create(lv),
             NavGuid _ when Guid.TryParse(raw, out var gv) => new NavGuid(gv),
-            NavBoolean _ when bool.TryParse(raw, out var bv) => new NavBoolean(bv),
+            NavBoolean _ when bool.TryParse(raw, out var bv) => NavBoolean.Create(bv),
             _ => new NavText(raw),
         };
     }

--- a/AlRunner/Runtime/MockRecordHandle.cs
+++ b/AlRunner/Runtime/MockRecordHandle.cs
@@ -2341,6 +2341,114 @@ public class MockRecordHandle
     }
 
     /// <summary>
+    /// AL's GETPOSITION — serialises the current primary-key field values into a text
+    /// string that <see cref="ALSetPosition"/> can use to restore the cursor later.
+    /// Format: <c>FieldName=CONST(Value)</c> for each PK field, comma-separated.
+    /// Example: <c>"No.=CONST(A001)"</c> for a Customer record positioned on No.=A001.
+    /// </summary>
+    public string ALGetPosition()
+    {
+        var pkFields = GetPrimaryKeyFields();
+        var parts = new List<string>(pkFields.Length);
+        foreach (var fieldNo in pkFields)
+        {
+            var name = GetFieldNameByNo(fieldNo);
+            var value = _fields.TryGetValue(fieldNo, out var v) ? NavValueToString(v) : "";
+            parts.Add($"{name}=CONST({value})");
+        }
+        return string.Join(",", parts);
+    }
+
+    /// <summary>
+    /// AL's SETPOSITION — parses a position string produced by <see cref="ALGetPosition"/>
+    /// and repositions the record cursor to the matching row.
+    /// Format expected: <c>FieldName=CONST(Value)</c> for each PK field, comma-separated.
+    /// Throws if the string is unparseable or the row is not found.
+    /// </summary>
+    public void ALSetPosition(string positionText)
+    {
+        if (string.IsNullOrEmpty(positionText))
+            throw new Exception($"SetPosition: position string is empty.");
+
+        // Parse each "FieldName=CONST(Value)" segment
+        var segments = positionText.Split(',');
+        var parsedValues = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var seg in segments)
+        {
+            var trimmed = seg.Trim();
+            var eqIdx = trimmed.IndexOf('=');
+            if (eqIdx < 0)
+                throw new Exception($"SetPosition: invalid position string '{positionText}'.");
+            var fieldName = trimmed[..eqIdx].Trim();
+            var rest = trimmed[(eqIdx + 1)..].Trim();
+            // Expect CONST(value) wrapper
+            if (!rest.StartsWith("CONST(", StringComparison.OrdinalIgnoreCase) || !rest.EndsWith(")"))
+                throw new Exception($"SetPosition: invalid segment '{trimmed}' in position string '{positionText}'.");
+            var rawValue = rest[6..^1]; // strip "CONST(" and ")"
+            parsedValues[fieldName] = rawValue;
+        }
+
+        if (parsedValues.Count == 0)
+            throw new Exception($"SetPosition: position string '{positionText}' has no field values.");
+
+        // Look up field numbers and set them in _fields
+        var pkFields = GetPrimaryKeyFields();
+        foreach (var fieldNo in pkFields)
+        {
+            var name = GetFieldNameByNo(fieldNo);
+            if (!parsedValues.TryGetValue(name, out var rawVal))
+                throw new Exception($"SetPosition: PK field '{name}' not found in position string '{positionText}'.");
+
+            // Preserve the field's existing type — copy the value as NavText/NavCode if present,
+            // or set as a NavText for unknown types. The Find below does a string compare anyway.
+            if (_fields.TryGetValue(fieldNo, out var existing))
+            {
+                // Re-apply the value preserving the existing NavValue type
+                _fields[fieldNo] = ParseNavValue(existing, rawVal);
+            }
+            else
+            {
+                _fields[fieldNo] = new NavText(rawVal);
+            }
+        }
+
+        // Find the row that matches the newly-set PK values
+        var table = GetRows();
+        var matchedPkFields = GetPrimaryKeyFields();
+        for (int i = 0; i < table.Count; i++)
+        {
+            if (RowMatchesPrimaryKey(table[i], _fields, matchedPkFields))
+            {
+                _fields = new Dictionary<int, NavValue>(table[i]);
+                _currentResultSet = table;
+                _cursorPosition = i;
+                return;
+            }
+        }
+        throw new Exception($"SetPosition: no record found for position '{positionText}' in table {_tableId}.");
+    }
+
+    /// <summary>
+    /// Parses a raw string into the same NavValue subtype as <paramref name="template"/>.
+    /// Used by <see cref="ALSetPosition"/> to restore PK field values with correct types.
+    /// </summary>
+    private static NavValue ParseNavValue(NavValue template, string raw)
+    {
+        return template switch
+        {
+            NavCode _ => new NavCode(raw),
+            NavText _ => new NavText(raw),
+            NavInteger _ when int.TryParse(raw, System.Globalization.NumberStyles.Integer,
+                System.Globalization.CultureInfo.InvariantCulture, out var iv) => new NavInteger(iv),
+            NavBigInteger _ when long.TryParse(raw, System.Globalization.NumberStyles.Integer,
+                System.Globalization.CultureInfo.InvariantCulture, out var lv) => new NavBigInteger(lv),
+            NavGuid _ when Guid.TryParse(raw, out var gv) => new NavGuid(gv),
+            NavBoolean _ when bool.TryParse(raw, out var bv) => new NavBoolean(bv),
+            _ => new NavText(raw),
+        };
+    }
+
+    /// <summary>
     /// AL's GETRANGEMIN — returns the minimum value of the filter range for a field.
     /// </summary>
     public NavValue ALGetRangeMinSafe(int fieldNo, NavType expectedType)

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -5869,7 +5869,9 @@ Table.GetFilters:
 Table.GetPosition:
   layer: runtime-api
   category: Table
-  status: gap
+  status: covered
+  tests:
+    - tests/bucket-1/63-record-getposition-setposition
   notes: overloads=1
 
 Table.GetRangeMax:
@@ -6089,7 +6091,9 @@ Table.SetPermissionFilter:
 Table.SetPosition:
   layer: runtime-api
   category: Table
-  status: gap
+  status: covered
+  tests:
+    - tests/bucket-1/63-record-getposition-setposition
   notes: overloads=1
 
 Table.SetRange:

--- a/tests/bucket-1/63-record-getposition-setposition/src/PosTestTable.al
+++ b/tests/bucket-1/63-record-getposition-setposition/src/PosTestTable.al
@@ -1,0 +1,24 @@
+table 63001 "Pos Test Table"
+{
+    DataClassification = ToBeClassified;
+
+    fields
+    {
+        field(1; "No."; Code[20])
+        {
+            DataClassification = ToBeClassified;
+        }
+        field(2; Description; Text[100])
+        {
+            DataClassification = ToBeClassified;
+        }
+    }
+
+    keys
+    {
+        key(PK; "No.")
+        {
+            Clustered = true;
+        }
+    }
+}

--- a/tests/bucket-1/63-record-getposition-setposition/test/TestRecordGetSetPosition.al
+++ b/tests/bucket-1/63-record-getposition-setposition/test/TestRecordGetSetPosition.al
@@ -1,0 +1,95 @@
+codeunit 63401 "Test Record GetPosition"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    [Test]
+    procedure GetPosition_ReturnsNonEmptyString()
+    var
+        Customer: Record Customer;
+        Pos: Text;
+    begin
+        Customer.Init();
+        Customer."No." := 'GP001';
+        Customer.Insert();
+
+        Customer.FindFirst();
+        Pos := Customer.GetPosition();
+        Assert.AreNotEqual('', Pos, 'GetPosition must return a non-empty string after FindFirst');
+    end;
+
+    [Test]
+    procedure SetPosition_RestoresPrimaryKeyRow()
+    var
+        Customer: Record Customer;
+        Pos: Text;
+        FirstNo: Code[20];
+    begin
+        // Insert two rows
+        Customer.Init();
+        Customer."No." := 'SP001';
+        Customer.Insert();
+        Customer.Init();
+        Customer."No." := 'SP002';
+        Customer.Insert();
+
+        // Position at first row, save position
+        Customer.FindFirst();
+        FirstNo := Customer."No.";
+        Pos := Customer.GetPosition();
+
+        // Move to next row
+        Customer.Next();
+        Assert.AreNotEqual(FirstNo, Customer."No.", 'Next must advance to a different row');
+
+        // Restore position — must be back on first row
+        Customer.SetPosition(Pos);
+        Assert.AreEqual(FirstNo, Customer."No.", 'SetPosition must restore the cursor to the saved row');
+    end;
+
+    [Test]
+    procedure GetSetPosition_Roundtrip()
+    var
+        Customer: Record Customer;
+        Pos: Text;
+        SavedNo: Code[20];
+    begin
+        Customer.Init();
+        Customer."No." := 'RT001';
+        Customer.Insert();
+        Customer.Init();
+        Customer."No." := 'RT002';
+        Customer.Insert();
+        Customer.Init();
+        Customer."No." := 'RT003';
+        Customer.Insert();
+
+        // Move to last row, save position
+        Customer.FindLast();
+        SavedNo := Customer."No.";
+        Pos := Customer.GetPosition();
+
+        // Move to first row
+        Customer.FindFirst();
+        Assert.AreNotEqual(SavedNo, Customer."No.", 'FindFirst must give a different row than saved');
+
+        // Restore
+        Customer.SetPosition(Pos);
+        Assert.AreEqual(SavedNo, Customer."No.", 'SetPosition roundtrip must return to the saved row');
+    end;
+
+    [Test]
+    procedure SetPosition_InvalidString_RaisesError()
+    var
+        Customer: Record Customer;
+    begin
+        Customer.Init();
+        Customer."No." := 'INV001';
+        Customer.Insert();
+
+        asserterror Customer.SetPosition('totally-invalid-position-string');
+        Assert.ExpectedError('');
+    end;
+}

--- a/tests/bucket-1/63-record-getposition-setposition/test/TestRecordGetSetPosition.al
+++ b/tests/bucket-1/63-record-getposition-setposition/test/TestRecordGetSetPosition.al
@@ -8,88 +8,88 @@ codeunit 63401 "Test Record GetPosition"
     [Test]
     procedure GetPosition_ReturnsNonEmptyString()
     var
-        Customer: Record Customer;
+        Rec: Record "Pos Test Table";
         Pos: Text;
     begin
-        Customer.Init();
-        Customer."No." := 'GP001';
-        Customer.Insert();
+        Rec.Init();
+        Rec."No." := 'GP001';
+        Rec.Insert();
 
-        Customer.FindFirst();
-        Pos := Customer.GetPosition();
+        Rec.FindFirst();
+        Pos := Rec.GetPosition();
         Assert.AreNotEqual('', Pos, 'GetPosition must return a non-empty string after FindFirst');
     end;
 
     [Test]
     procedure SetPosition_RestoresPrimaryKeyRow()
     var
-        Customer: Record Customer;
+        Rec: Record "Pos Test Table";
         Pos: Text;
         FirstNo: Code[20];
     begin
         // Insert two rows
-        Customer.Init();
-        Customer."No." := 'SP001';
-        Customer.Insert();
-        Customer.Init();
-        Customer."No." := 'SP002';
-        Customer.Insert();
+        Rec.Init();
+        Rec."No." := 'SP001';
+        Rec.Insert();
+        Rec.Init();
+        Rec."No." := 'SP002';
+        Rec.Insert();
 
         // Position at first row, save position
-        Customer.FindFirst();
-        FirstNo := Customer."No.";
-        Pos := Customer.GetPosition();
+        Rec.FindFirst();
+        FirstNo := Rec."No.";
+        Pos := Rec.GetPosition();
 
         // Move to next row
-        Customer.Next();
-        Assert.AreNotEqual(FirstNo, Customer."No.", 'Next must advance to a different row');
+        Rec.Next();
+        Assert.AreNotEqual(FirstNo, Rec."No.", 'Next must advance to a different row');
 
         // Restore position — must be back on first row
-        Customer.SetPosition(Pos);
-        Assert.AreEqual(FirstNo, Customer."No.", 'SetPosition must restore the cursor to the saved row');
+        Rec.SetPosition(Pos);
+        Assert.AreEqual(FirstNo, Rec."No.", 'SetPosition must restore the cursor to the saved row');
     end;
 
     [Test]
     procedure GetSetPosition_Roundtrip()
     var
-        Customer: Record Customer;
+        Rec: Record "Pos Test Table";
         Pos: Text;
         SavedNo: Code[20];
     begin
-        Customer.Init();
-        Customer."No." := 'RT001';
-        Customer.Insert();
-        Customer.Init();
-        Customer."No." := 'RT002';
-        Customer.Insert();
-        Customer.Init();
-        Customer."No." := 'RT003';
-        Customer.Insert();
+        Rec.Init();
+        Rec."No." := 'RT001';
+        Rec.Insert();
+        Rec.Init();
+        Rec."No." := 'RT002';
+        Rec.Insert();
+        Rec.Init();
+        Rec."No." := 'RT003';
+        Rec.Insert();
 
         // Move to last row, save position
-        Customer.FindLast();
-        SavedNo := Customer."No.";
-        Pos := Customer.GetPosition();
+        Rec.FindLast();
+        SavedNo := Rec."No.";
+        Pos := Rec.GetPosition();
 
         // Move to first row
-        Customer.FindFirst();
-        Assert.AreNotEqual(SavedNo, Customer."No.", 'FindFirst must give a different row than saved');
+        Rec.FindFirst();
+        Assert.AreNotEqual(SavedNo, Rec."No.", 'FindFirst must give a different row than saved');
 
         // Restore
-        Customer.SetPosition(Pos);
-        Assert.AreEqual(SavedNo, Customer."No.", 'SetPosition roundtrip must return to the saved row');
+        Rec.SetPosition(Pos);
+        Assert.AreEqual(SavedNo, Rec."No.", 'SetPosition roundtrip must return to the saved row');
     end;
 
     [Test]
     procedure SetPosition_InvalidString_RaisesError()
     var
-        Customer: Record Customer;
+        Rec: Record "Pos Test Table";
     begin
-        Customer.Init();
-        Customer."No." := 'INV001';
-        Customer.Insert();
+        Rec.Init();
+        Rec."No." := 'INV001';
+        Rec.Insert();
 
-        asserterror Customer.SetPosition('totally-invalid-position-string');
+        asserterror Rec.SetPosition('totally-invalid-position-string');
         Assert.ExpectedError('');
     end;
 }


### PR DESCRIPTION
Closes #357

Implements `ALGetPosition` and `ALSetPosition` on `MockRecordHandle` so that AL code using `Rec.GetPosition()` / `Rec.SetPosition(pos)` works in the runner.

## Implementation

**`ALGetPosition()`**
Returns a comma-separated `FieldName=CONST(Value)` string for each primary-key field in declaration order, e.g. `"No.=CONST(A001)"`. Mirrors BC's wire format so position strings are recognisable.

**`ALSetPosition(positionText)`**
1. Parses the position string (each `FieldName=CONST(Value)` segment)
2. Restores PK field values, preserving each field's `NavValue` subtype via a new private `ParseNavValue` helper
3. Scans the in-memory table for the matching row and repositions the cursor
4. Throws a descriptive error if the string is unparseable or no matching row exists

## Tests (`tests/bucket-1/63-record-getposition-setposition/`)
- `GetPosition_ReturnsNonEmptyString` — positive: non-empty string after FindFirst
- `SetPosition_RestoresPrimaryKeyRow` — positive: two-row table, save+restore round-trip
- `GetSetPosition_Roundtrip` — positive: save last, move to first, restore last
- `SetPosition_InvalidString_RaisesError` — negative: bad string → asserterror

## Docs
- `docs/coverage.yaml`: `Table.GetPosition` / `Table.SetPosition` → `covered`
- `PrintGuide()`: documents GetPosition/SetPosition behaviour