### PR TITLE
test: Record.Count / Record.CountApprox coverage (#360)

### DIFF
--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -5718,13 +5718,16 @@ Table.Count:
   status: covered
   tests:
     - tests/bucket-1/44-count-filtered
+    - tests/bucket-1/66-record-count
   notes: overloads=1
 
 Table.CountApprox:
   layer: runtime-api
   category: Table
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests:
+    - tests/bucket-1/66-record-count
+  notes: overloads=1; returns exact count (ALCountApprox = ALCount) in runner context
 
 Table.CurrentCompany:
   layer: runtime-api

--- a/tests/bucket-1/66-record-count/src/CountTable.al
+++ b/tests/bucket-1/66-record-count/src/CountTable.al
@@ -1,4 +1,4 @@
-table 66000 "RC Test Table"
+table 66000 "Count Rows Test Table"
 {
     fields
     {

--- a/tests/bucket-1/66-record-count/src/CountTable.al
+++ b/tests/bucket-1/66-record-count/src/CountTable.al
@@ -1,0 +1,13 @@
+table 66000 "RC Test Table"
+{
+    fields
+    {
+        field(1; Id; Integer) { }
+        field(2; Category; Code[10]) { }
+        field(3; Amount; Decimal) { }
+    }
+    keys
+    {
+        key(PK; Id) { Clustered = true; }
+    }
+}

--- a/tests/bucket-1/66-record-count/test/CountTest.al
+++ b/tests/bucket-1/66-record-count/test/CountTest.al
@@ -7,7 +7,7 @@ codeunit 66001 "Record Count Test"
 
     local procedure InsertRow(Id: Integer; Category: Code[10]; Amount: Decimal)
     var
-        Rec: Record "RC Test Table";
+        Rec: Record "Count Rows Test Table";
     begin
         Rec.Init();
         Rec.Id := Id;
@@ -21,59 +21,59 @@ codeunit 66001 "Record Count Test"
     [Test]
     procedure Count_EmptyTable_ReturnsZero()
     var
-        Rec: Record "RC Test Table";
+        Rec: Record "Count Rows Test Table";
     begin
         // Negative: empty table must return 0
-        Assert.AreEqual(0, Rec.Count(), 'Count() on empty table must be 0');
+        Assert.AreEqual(0, Rec.Count, 'Count() on empty table must be 0');
     end;
 
     [Test]
     procedure Count_AfterInsertOne_ReturnsOne()
     var
-        Rec: Record "RC Test Table";
+        Rec: Record "Count Rows Test Table";
     begin
         InsertRow(1, 'A', 10);
-        Assert.AreEqual(1, Rec.Count(), 'Count() after one insert must be 1');
+        Assert.AreEqual(1, Rec.Count, 'Count() after one insert must be 1');
     end;
 
     [Test]
     procedure Count_AfterInsertThree_ReturnsThree()
     var
-        Rec: Record "RC Test Table";
+        Rec: Record "Count Rows Test Table";
     begin
         InsertRow(1, 'A', 10);
         InsertRow(2, 'B', 20);
         InsertRow(3, 'A', 30);
-        Assert.AreEqual(3, Rec.Count(), 'Count() after three inserts must be 3');
+        Assert.AreEqual(3, Rec.Count, 'Count() after three inserts must be 3');
     end;
 
     [Test]
     procedure Count_WithFilter_ReturnsFilteredCount()
     var
-        Rec: Record "RC Test Table";
+        Rec: Record "Count Rows Test Table";
     begin
         InsertRow(1, 'A', 10);
         InsertRow(2, 'B', 20);
         InsertRow(3, 'A', 30);
         Rec.SetRange(Category, 'A');
-        Assert.AreEqual(2, Rec.Count(), 'Count() with Category=A filter must be 2');
+        Assert.AreEqual(2, Rec.Count, 'Count() with Category=A filter must be 2');
     end;
 
     [Test]
     procedure Count_WithFilter_NoMatch_ReturnsZero()
     var
-        Rec: Record "RC Test Table";
+        Rec: Record "Count Rows Test Table";
     begin
         InsertRow(1, 'A', 10);
         InsertRow(2, 'B', 20);
         Rec.SetRange(Category, 'Z');
-        Assert.AreEqual(0, Rec.Count(), 'Count() with non-matching filter must be 0');
+        Assert.AreEqual(0, Rec.Count, 'Count() with non-matching filter must be 0');
     end;
 
     [Test]
     procedure Count_AfterResetFilter_ReturnsTotalCount()
     var
-        Rec: Record "RC Test Table";
+        Rec: Record "Count Rows Test Table";
     begin
         InsertRow(1, 'A', 10);
         InsertRow(2, 'B', 20);
@@ -81,7 +81,7 @@ codeunit 66001 "Record Count Test"
         Rec.SetRange(Category, 'A');
         // Reset filters — count must go back to full table
         Rec.Reset();
-        Assert.AreEqual(3, Rec.Count(), 'Count() after Reset() must return total row count');
+        Assert.AreEqual(3, Rec.Count, 'Count() after Reset() must return total row count');
     end;
 
     // --- CountApprox ---
@@ -89,33 +89,33 @@ codeunit 66001 "Record Count Test"
     [Test]
     procedure CountApprox_EmptyTable_ReturnsZero()
     var
-        Rec: Record "RC Test Table";
+        Rec: Record "Count Rows Test Table";
     begin
-        Assert.AreEqual(0, Rec.CountApprox(), 'CountApprox() on empty table must be 0');
+        Assert.AreEqual(0, Rec.CountApprox, 'CountApprox() on empty table must be 0');
     end;
 
     [Test]
     procedure CountApprox_MatchesCount_AfterInserts()
     var
-        Rec: Record "RC Test Table";
+        Rec: Record "Count Rows Test Table";
     begin
         InsertRow(1, 'A', 10);
         InsertRow(2, 'B', 20);
         // In runner context CountApprox returns exact count
-        Assert.AreEqual(Rec.Count(), Rec.CountApprox(),
+        Assert.AreEqual(Rec.Count, Rec.CountApprox,
             'CountApprox() must equal Count() in runner context');
     end;
 
     [Test]
     procedure CountApprox_WithFilter_MatchesCount()
     var
-        Rec: Record "RC Test Table";
+        Rec: Record "Count Rows Test Table";
     begin
         InsertRow(1, 'A', 10);
         InsertRow(2, 'B', 20);
         InsertRow(3, 'A', 30);
         Rec.SetRange(Category, 'A');
-        Assert.AreEqual(Rec.Count(), Rec.CountApprox(),
+        Assert.AreEqual(Rec.Count, Rec.CountApprox,
             'CountApprox() must equal Count() when a filter is active');
     end;
 }

--- a/tests/bucket-1/66-record-count/test/CountTest.al
+++ b/tests/bucket-1/66-record-count/test/CountTest.al
@@ -1,0 +1,121 @@
+codeunit 66001 "Record Count Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    local procedure InsertRow(Id: Integer; Category: Code[10]; Amount: Decimal)
+    var
+        Rec: Record "RC Test Table";
+    begin
+        Rec.Init();
+        Rec.Id := Id;
+        Rec.Category := Category;
+        Rec.Amount := Amount;
+        Rec.Insert();
+    end;
+
+    // --- Count ---
+
+    [Test]
+    procedure Count_EmptyTable_ReturnsZero()
+    var
+        Rec: Record "RC Test Table";
+    begin
+        // Negative: empty table must return 0
+        Assert.AreEqual(0, Rec.Count(), 'Count() on empty table must be 0');
+    end;
+
+    [Test]
+    procedure Count_AfterInsertOne_ReturnsOne()
+    var
+        Rec: Record "RC Test Table";
+    begin
+        InsertRow(1, 'A', 10);
+        Assert.AreEqual(1, Rec.Count(), 'Count() after one insert must be 1');
+    end;
+
+    [Test]
+    procedure Count_AfterInsertThree_ReturnsThree()
+    var
+        Rec: Record "RC Test Table";
+    begin
+        InsertRow(1, 'A', 10);
+        InsertRow(2, 'B', 20);
+        InsertRow(3, 'A', 30);
+        Assert.AreEqual(3, Rec.Count(), 'Count() after three inserts must be 3');
+    end;
+
+    [Test]
+    procedure Count_WithFilter_ReturnsFilteredCount()
+    var
+        Rec: Record "RC Test Table";
+    begin
+        InsertRow(1, 'A', 10);
+        InsertRow(2, 'B', 20);
+        InsertRow(3, 'A', 30);
+        Rec.SetRange(Category, 'A');
+        Assert.AreEqual(2, Rec.Count(), 'Count() with Category=A filter must be 2');
+    end;
+
+    [Test]
+    procedure Count_WithFilter_NoMatch_ReturnsZero()
+    var
+        Rec: Record "RC Test Table";
+    begin
+        InsertRow(1, 'A', 10);
+        InsertRow(2, 'B', 20);
+        Rec.SetRange(Category, 'Z');
+        Assert.AreEqual(0, Rec.Count(), 'Count() with non-matching filter must be 0');
+    end;
+
+    [Test]
+    procedure Count_AfterResetFilter_ReturnsTotalCount()
+    var
+        Rec: Record "RC Test Table";
+    begin
+        InsertRow(1, 'A', 10);
+        InsertRow(2, 'B', 20);
+        InsertRow(3, 'A', 30);
+        Rec.SetRange(Category, 'A');
+        // Reset filters — count must go back to full table
+        Rec.Reset();
+        Assert.AreEqual(3, Rec.Count(), 'Count() after Reset() must return total row count');
+    end;
+
+    // --- CountApprox ---
+
+    [Test]
+    procedure CountApprox_EmptyTable_ReturnsZero()
+    var
+        Rec: Record "RC Test Table";
+    begin
+        Assert.AreEqual(0, Rec.CountApprox(), 'CountApprox() on empty table must be 0');
+    end;
+
+    [Test]
+    procedure CountApprox_MatchesCount_AfterInserts()
+    var
+        Rec: Record "RC Test Table";
+    begin
+        InsertRow(1, 'A', 10);
+        InsertRow(2, 'B', 20);
+        // In runner context CountApprox returns exact count
+        Assert.AreEqual(Rec.Count(), Rec.CountApprox(),
+            'CountApprox() must equal Count() in runner context');
+    end;
+
+    [Test]
+    procedure CountApprox_WithFilter_MatchesCount()
+    var
+        Rec: Record "RC Test Table";
+    begin
+        InsertRow(1, 'A', 10);
+        InsertRow(2, 'B', 20);
+        InsertRow(3, 'A', 30);
+        Rec.SetRange(Category, 'A');
+        Assert.AreEqual(Rec.Count(), Rec.CountApprox(),
+            'CountApprox() must equal Count() when a filter is active');
+    end;
+}


### PR DESCRIPTION
Closes #360

## Summary

- Add `tests/bucket-1/66-record-count/` with 9 tests proving `Count()` and `CountApprox()` return correct row counts
- `ALCount` / `ALCountApprox` were already implemented in `MockRecordHandle`; this suite closes the test coverage gap
- Mark `Table.CountApprox` as `covered` in `docs/coverage.yaml`

## Tests

| Test | What it proves |
|------|---------------|
| `Count_EmptyTable_ReturnsZero` | 0 on empty table (negative) |
| `Count_AfterInsertOne_ReturnsOne` | exact count after 1 insert |
| `Count_AfterInsertThree_ReturnsThree` | exact count after 3 inserts |
| `Count_WithFilter_ReturnsFilteredCount` | filter reduces count correctly |
| `Count_WithFilter_NoMatch_ReturnsZero` | non-matching filter → 0 |
| `Count_AfterResetFilter_ReturnsTotalCount` | Reset() restores full count |
| `CountApprox_EmptyTable_ReturnsZero` | 0 on empty table |
| `CountApprox_MatchesCount_AfterInserts` | equals Count() in runner context |
| `CountApprox_WithFilter_MatchesCount` | equals Count() when filter active |