### PR TITLE
feat: implement SelectStr, IncStr, ConvertStr, CopyStr text builtins

### DIFF
--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -2362,6 +2362,51 @@ public void ClearApplicationMemberVariables() { }
                         SyntaxFactory.IdentifierName("StrSubstNo")));
             }
 
+            // ALSystemString.ALSelectStr(n, s) -> AlCompat.SelectStr(n, s)
+            // The real ALSelectStr calls NavSession for locale, crashing without NavSession.
+            if (exprText == "ALSystemString" && methodName == "ALSelectStr")
+            {
+                return visited.WithExpression(
+                    SyntaxFactory.MemberAccessExpression(
+                        SyntaxKind.SimpleMemberAccessExpression,
+                        SyntaxFactory.IdentifierName("AlCompat"),
+                        SyntaxFactory.IdentifierName("SelectStr")));
+            }
+
+            // ALSystemString.ALIncStr(s) -> AlCompat.IncStr(s)
+            // The real ALIncStr calls NavValueFormatter, crashing without NavSession.
+            if (exprText == "ALSystemString" && methodName == "ALIncStr")
+            {
+                return visited.WithExpression(
+                    SyntaxFactory.MemberAccessExpression(
+                        SyntaxKind.SimpleMemberAccessExpression,
+                        SyntaxFactory.IdentifierName("AlCompat"),
+                        SyntaxFactory.IdentifierName("IncStr")));
+            }
+
+            // ALSystemString.ALConvertStr(s, from, to) -> AlCompat.ConvertStr(s, from, to)
+            // The real ALConvertStr accesses NavSession for locale, crashing without NavSession.
+            if (exprText == "ALSystemString" && methodName == "ALConvertStr")
+            {
+                return visited.WithExpression(
+                    SyntaxFactory.MemberAccessExpression(
+                        SyntaxKind.SimpleMemberAccessExpression,
+                        SyntaxFactory.IdentifierName("AlCompat"),
+                        SyntaxFactory.IdentifierName("ConvertStr")));
+            }
+
+            // ALSystemString.ALCopyStr(s, position) -> AlCompat.CopyStr(s, position)  [2-arg variant]
+            // The 3-arg variant (s, position, length) is handled by the BC runtime natively.
+            if (exprText == "ALSystemString" && methodName == "ALCopyStr"
+                && visited.ArgumentList.Arguments.Count == 2)
+            {
+                return visited.WithExpression(
+                    SyntaxFactory.MemberAccessExpression(
+                        SyntaxKind.SimpleMemberAccessExpression,
+                        SyntaxFactory.IdentifierName("AlCompat"),
+                        SyntaxFactory.IdentifierName("CopyStr")));
+            }
+
             // ALDatabase.ALIsInWriteTransaction() -> false
             // The real ALIsInWriteTransaction calls NavSession.HasWriteTransaction() which crashes
             // with NullReferenceException when NavSession is null (runner context, no DB).

--- a/AlRunner/Runtime/AlScope.cs
+++ b/AlRunner/Runtime/AlScope.cs
@@ -1537,4 +1537,89 @@ public static class AlCompat
         var val = NavDateTimeValueField.GetValue(dt);
         return val is DateTime d ? d : default;
     }
+
+    // -----------------------------------------------------------------------
+    // Replacement for ALSystemString.ALSelectStr
+    // AL SelectStr(Number, String) returns the Nth comma-delimited token
+    // (1-based). Throws if Number is out of range.
+    // -----------------------------------------------------------------------
+
+    /// <summary>
+    /// AL <c>SelectStr(n, s)</c> — returns the Nth comma-separated token from s (1-based).
+    /// Throws when n is less than 1 or greater than the number of tokens.
+    /// </summary>
+    public static string SelectStr(int n, string s)
+    {
+        var parts = (s ?? "").Split(',');
+        if (n < 1 || n > parts.Length)
+            throw new Exception($"The index ({n}) in SelectStr is out of range (1..{parts.Length}).");
+        return parts[n - 1];
+    }
+
+    // -----------------------------------------------------------------------
+    // Replacement for ALSystemString.ALIncStr
+    // AL IncStr(s) increments the last numeric sequence found in s.
+    // e.g. 'DOC001' -> 'DOC002', 'A099' -> 'A100'.
+    // -----------------------------------------------------------------------
+
+    /// <summary>
+    /// AL <c>IncStr(s)</c> — increments the trailing numeric sequence in s,
+    /// preserving leading zeros and width. Returns s unchanged if no digits found.
+    /// </summary>
+    public static string IncStr(string s)
+    {
+        if (string.IsNullOrEmpty(s)) return s;
+        // Find the last run of digit characters
+        int end = s.Length - 1;
+        while (end >= 0 && !char.IsDigit(s[end]))
+            end--;
+        if (end < 0) return s; // no digits
+        int start = end;
+        while (start > 0 && char.IsDigit(s[start - 1]))
+            start--;
+        var digits = s.Substring(start, end - start + 1);
+        var incremented = (long.Parse(digits) + 1).ToString().PadLeft(digits.Length, '0');
+        return s.Substring(0, start) + incremented + s.Substring(end + 1);
+    }
+
+    // -----------------------------------------------------------------------
+    // Replacement for ALSystemString.ALConvertStr
+    // AL ConvertStr(String, FromChars, ToChars) replaces each character in
+    // FromChars with the corresponding character in ToChars.
+    // -----------------------------------------------------------------------
+
+    /// <summary>
+    /// AL <c>ConvertStr(s, fromChars, toChars)</c> — character-for-character
+    /// replacement. Each character in fromChars is replaced with the corresponding
+    /// character in toChars. FromChars and ToChars must have the same length.
+    /// </summary>
+    public static string ConvertStr(string s, string fromChars, string toChars)
+    {
+        if (string.IsNullOrEmpty(s)) return s;
+        if (string.IsNullOrEmpty(fromChars)) return s;
+        var sb = new System.Text.StringBuilder(s.Length);
+        foreach (char c in s)
+        {
+            int idx = fromChars.IndexOf(c);
+            sb.Append(idx >= 0 && idx < toChars.Length ? toChars[idx] : c);
+        }
+        return sb.ToString();
+    }
+
+    // -----------------------------------------------------------------------
+    // Replacement for ALSystemString.ALCopyStr (2-param variant)
+    // AL CopyStr(String, Position) returns the substring from Position to end.
+    // -----------------------------------------------------------------------
+
+    /// <summary>
+    /// AL <c>CopyStr(s, position)</c> — returns the substring starting at
+    /// position (1-based) through the end of the string.
+    /// </summary>
+    public static string CopyStr(string s, int position)
+    {
+        if (string.IsNullOrEmpty(s)) return "";
+        if (position < 1) position = 1;
+        if (position > s.Length) return "";
+        return s.Substring(position - 1);
+    }
 }

--- a/AlRunner/Runtime/AlScope.cs
+++ b/AlRunner/Runtime/AlScope.cs
@@ -1552,7 +1552,7 @@ public static class AlCompat
     {
         var parts = (s ?? "").Split(',');
         if (n < 1 || n > parts.Length)
-            throw new Exception($"The index ({n}) in SelectStr is out of range (1..{parts.Length}).");
+            throw new Exception($"The SELECTSTR comma-string {s} does not contain a value for index {n}.");
         return parts[n - 1];
     }
 

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -6917,14 +6917,16 @@ Text.Contains:
 Text.ConvertStr:
   layer: runtime-api
   category: Text
-  status: gap
+  status: covered
+  tests: tests/bucket-1/66-text-selectstr-incstr
   notes: overloads=1
 
 Text.CopyStr:
   layer: runtime-api
   category: Text
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-1/66-text-selectstr-incstr
+  notes: overloads=2 (2-param via AlCompat; 3-param via BC runtime)
 
 Text.DelChr:
   layer: runtime-api
@@ -6947,7 +6949,8 @@ Text.EndsWith:
 Text.IncStr:
   layer: runtime-api
   category: Text
-  status: gap
+  status: covered
+  tests: tests/bucket-1/66-text-selectstr-incstr
   notes: overloads=2
 
 Text.IndexOf:
@@ -7019,7 +7022,8 @@ Text.Replace:
 Text.SelectStr:
   layer: runtime-api
   category: Text
-  status: gap
+  status: covered
+  tests: tests/bucket-1/66-text-selectstr-incstr
   notes: overloads=1
 
 Text.Split:

--- a/tests/bucket-1/66-text-selectstr-incstr/src/TextBuiltinsSrc.al
+++ b/tests/bucket-1/66-text-selectstr-incstr/src/TextBuiltinsSrc.al
@@ -1,0 +1,27 @@
+codeunit 58100 "TBI Text Builtins Helper"
+{
+    procedure SelectStrToken(n: Integer; s: Text): Text
+    begin
+        exit(SelectStr(n, s));
+    end;
+
+    procedure IncStrValue(s: Text): Text
+    begin
+        exit(IncStr(s));
+    end;
+
+    procedure ConvertStrValue(s: Text; fromChars: Text; toChars: Text): Text
+    begin
+        exit(ConvertStr(s, fromChars, toChars));
+    end;
+
+    procedure CopyStrFromPos(s: Text; position: Integer): Text
+    begin
+        exit(CopyStr(s, position));
+    end;
+
+    procedure CopyStrSubstring(s: Text; position: Integer; length: Integer): Text
+    begin
+        exit(CopyStr(s, position, length));
+    end;
+}

--- a/tests/bucket-1/66-text-selectstr-incstr/test/TextBuiltinsTests.al
+++ b/tests/bucket-1/66-text-selectstr-incstr/test/TextBuiltinsTests.al
@@ -36,9 +36,9 @@ codeunit 58101 "TBI Text Builtins Tests"
     begin
         // [GIVEN] 2-token string
         // [WHEN] index 3 requested
-        // [THEN] error is raised
+        // [THEN] BC error: "The SELECTSTR comma-string ... does not contain a value for index N."
         asserterror Helper.SelectStrToken(3, 'A,B');
-        Assert.ExpectedError('out of range');
+        Assert.ExpectedError('does not contain a value for index');
     end;
 
     // -----------------------------------------------------------------------

--- a/tests/bucket-1/66-text-selectstr-incstr/test/TextBuiltinsTests.al
+++ b/tests/bucket-1/66-text-selectstr-incstr/test/TextBuiltinsTests.al
@@ -1,0 +1,146 @@
+codeunit 58101 "TBI Text Builtins Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Helper: Codeunit "TBI Text Builtins Helper";
+
+    // -----------------------------------------------------------------------
+    // SelectStr
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure SelectStr_FirstToken_ReturnsFirst()
+    begin
+        // [GIVEN] Comma-separated string 'Alpha,Beta,Gamma'
+        // [WHEN] SelectStr(1, ...) called
+        // [THEN] Returns 'Alpha'
+        Assert.AreEqual('Alpha', Helper.SelectStrToken(1, 'Alpha,Beta,Gamma'), 'SelectStr(1) must return Alpha');
+    end;
+
+    [Test]
+    procedure SelectStr_SecondToken_ReturnsSecond()
+    begin
+        Assert.AreEqual('Beta', Helper.SelectStrToken(2, 'Alpha,Beta,Gamma'), 'SelectStr(2) must return Beta');
+    end;
+
+    [Test]
+    procedure SelectStr_LastToken_ReturnsLast()
+    begin
+        Assert.AreEqual('Gamma', Helper.SelectStrToken(3, 'Alpha,Beta,Gamma'), 'SelectStr(3) must return Gamma');
+    end;
+
+    [Test]
+    procedure SelectStr_OutOfRange_ThrowsError()
+    begin
+        // [GIVEN] 2-token string
+        // [WHEN] index 3 requested
+        // [THEN] error is raised
+        asserterror Helper.SelectStrToken(3, 'A,B');
+        Assert.ExpectedError('out of range');
+    end;
+
+    // -----------------------------------------------------------------------
+    // IncStr
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure IncStr_TrailingDigits_Incremented()
+    begin
+        // [GIVEN] 'DOC001'
+        // [WHEN] IncStr called
+        // [THEN] Returns 'DOC002'
+        Assert.AreEqual('DOC002', Helper.IncStrValue('DOC001'), 'IncStr must increment trailing digits');
+    end;
+
+    [Test]
+    procedure IncStr_PreservesLeadingZeros()
+    begin
+        // [GIVEN] 'A099' → 'A100' (width preserved)
+        Assert.AreEqual('A100', Helper.IncStrValue('A099'), 'IncStr must handle carry with leading zeros');
+    end;
+
+    [Test]
+    procedure IncStr_NoDigits_ReturnsUnchanged()
+    begin
+        // [GIVEN] 'ABC' (no digits)
+        // [WHEN] IncStr called
+        // [THEN] Returns 'ABC' unchanged
+        Assert.AreEqual('ABC', Helper.IncStrValue('ABC'), 'IncStr with no digits must return unchanged string');
+    end;
+
+    // -----------------------------------------------------------------------
+    // ConvertStr
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure ConvertStr_SingleChar_Replaced()
+    begin
+        // [GIVEN] 'Hello', from='H', to='J'
+        // [WHEN] ConvertStr called
+        // [THEN] Returns 'Jello'
+        Assert.AreEqual('Jello', Helper.ConvertStrValue('Hello', 'H', 'J'), 'ConvertStr must replace H with J');
+    end;
+
+    [Test]
+    procedure ConvertStr_MultipleChars_AllReplaced()
+    begin
+        // [GIVEN] 'abc', from='ac', to='AC'
+        // [WHEN] ConvertStr called
+        // [THEN] Returns 'AbC'
+        Assert.AreEqual('AbC', Helper.ConvertStrValue('abc', 'ac', 'AC'), 'ConvertStr must replace all matching chars');
+    end;
+
+    [Test]
+    procedure ConvertStr_NoMatch_Unchanged()
+    begin
+        // [GIVEN] 'Hello', from='xyz', to='XYZ'
+        // [WHEN] ConvertStr called
+        // [THEN] Returns 'Hello' unchanged
+        Assert.AreEqual('Hello', Helper.ConvertStrValue('Hello', 'xyz', 'XYZ'), 'ConvertStr with no match must return unchanged');
+    end;
+
+    // -----------------------------------------------------------------------
+    // CopyStr — 2-param (position to end)
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure CopyStr_FromPosition_ReturnsRemainder()
+    begin
+        // [GIVEN] 'ABCDEF', position=3
+        // [WHEN] CopyStr(s, 3) called
+        // [THEN] Returns 'CDEF'
+        Assert.AreEqual('CDEF', Helper.CopyStrFromPos('ABCDEF', 3), 'CopyStr(s,3) must return from position 3 to end');
+    end;
+
+    [Test]
+    procedure CopyStr_FromPosition1_ReturnsWhole()
+    begin
+        // [GIVEN] 'Hello', position=1
+        // [THEN] Returns 'Hello'
+        Assert.AreEqual('Hello', Helper.CopyStrFromPos('Hello', 1), 'CopyStr(s,1) must return full string');
+    end;
+
+    // -----------------------------------------------------------------------
+    // CopyStr — 3-param (position + length)
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure CopyStr_ThreeParam_ReturnsSubstring()
+    begin
+        // [GIVEN] 'ABCDEF', position=2, length=3
+        // [WHEN] CopyStr(s, 2, 3) called
+        // [THEN] Returns 'BCD'
+        Assert.AreEqual('BCD', Helper.CopyStrSubstring('ABCDEF', 2, 3), 'CopyStr(s,2,3) must return 3 chars from position 2');
+    end;
+
+    [Test]
+    procedure CopyStr_ThreeParam_LengthBeyondEnd_ReturnsToEnd()
+    begin
+        // [GIVEN] 'Hello', position=3, length=100
+        // [WHEN] CopyStr called
+        // [THEN] Returns 'llo' (truncated at end)
+        Assert.AreEqual('llo', Helper.CopyStrSubstring('Hello', 3, 100), 'CopyStr with oversized length must return to end');
+    end;
+}


### PR DESCRIPTION
Closes #359

## Summary

- Adds `AlCompat.SelectStr`, `AlCompat.IncStr`, `AlCompat.ConvertStr`, `AlCompat.CopyStr` (2-param) to `AlScope.cs`
- `RoslynRewriter` intercepts `ALSystemString.ALSelectStr/ALIncStr/ALConvertStr/ALCopyStr` (2-arg) and routes to `AlCompat` methods — these previously crashed without `NavSession`
- 3-arg `CopyStr(s, pos, len)` continues to use the BC runtime natively
- Test suite `tests/bucket-1/66-text-selectstr-incstr` (codeunits 58100/58101, 14 tests) covers positive paths and the `SelectStr` out-of-range error path
- `docs/coverage.yaml` updated: `Text.SelectStr`, `Text.IncStr`, `Text.ConvertStr`, `Text.CopyStr` marked `covered`

## Test plan

- [ ] All bucket-1 tests pass in CI
- [ ] `SelectStr` returns correct token for positions 1, 2, last
- [ ] `SelectStr` throws on out-of-range index
- [ ] `IncStr` increments trailing digits and handles carry (`A099` → `A100`)
- [ ] `IncStr` returns unchanged string when no digits present
- [ ] `ConvertStr` replaces single and multiple characters; returns unchanged when no match
- [ ] `CopyStr(s, pos)` returns substring from position to end
- [ ] `CopyStr(s, pos, len)` returns correct length substring, clamped at end