### PR TITLE
feat: LockTable(Wait: Boolean) overload — no-op stub (#358)

### DIFF
--- a/AlRunner/Runtime/MockRecordHandle.cs
+++ b/AlRunner/Runtime/MockRecordHandle.cs
@@ -1441,6 +1441,12 @@ public class MockRecordHandle
         // No-op: no SQL transaction isolation needed
     }
 
+    // LockTable(Wait: Boolean) overload — BC compiles this to ALLockTable(bool)
+    public void ALLockTable(bool wait)
+    {
+        // No-op: no SQL transaction isolation needed
+    }
+
     /// <summary>
     /// AL's READISOLATION — sets read isolation level for the record.
     /// No-op in standalone mode since there's no SQL transaction.

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -5942,7 +5942,7 @@ Table.LockTable:
   status: covered
   tests:
     - tests/bucket-1/42-locktable
-  notes: overloads=1
+  notes: overloads=2 (no-arg; Wait:Boolean)
 
 Table.Mark:
   layer: runtime-api

--- a/tests/bucket-1/42-locktable/test/TestLockTable.al
+++ b/tests/bucket-1/42-locktable/test/TestLockTable.al
@@ -94,4 +94,44 @@ codeunit 54500 "Test LockTable"
         Assert.AreEqual(0, Rec.Count,
             'Record should be deleted after LockTable + Delete');
     end;
+
+    [Test]
+    procedure LockTableWaitFalseIsNoOp()
+    var
+        Rec: Record "Lock Probe";
+    begin
+        // Positive: LockTable(Wait: Boolean) overload is a no-op — must not raise an error.
+        Rec.LockTable(false);
+        Assert.AreEqual(0, Rec.Count, 'LockTable(false) must not alter the table or throw');
+    end;
+
+    [Test]
+    procedure LockTableWaitTrueIsNoOp()
+    var
+        Rec: Record "Lock Probe";
+    begin
+        // Positive: LockTable(true) is also a no-op.
+        Rec.LockTable(true);
+        Assert.AreEqual(0, Rec.Count, 'LockTable(true) must not alter the table or throw');
+    end;
+
+    [Test]
+    procedure LockTableWaitFalseDoesNotBlockInsert()
+    var
+        Rec: Record "Lock Probe";
+    begin
+        // Positive: Insert still works after LockTable(false).
+        Rec.LockTable(false);
+        Rec.Init();
+        Rec."No." := 'E';
+        Rec.Name := 'WithWait';
+        Rec.Amount := 99;
+        Rec.Insert(true);
+
+        Rec.Get('E');
+        Assert.AreEqual('WithWait', Rec.Name,
+            'Record inserted after LockTable(false) must be retrievable');
+        Assert.AreEqual(99, Rec.Amount,
+            'Amount must match after LockTable(false) + Insert');
+    end;
 }


### PR DESCRIPTION
Closes #358

## Summary

`MockRecordHandle` had `ALLockTable(DataError)` for the no-arg form but lacked the `ALLockTable(bool wait)` overload that BC generates for `LockTable(Wait: Boolean)`. AL code calling `Rec.LockTable(false)` or `Rec.LockTable(true)` would throw a method-not-found error at runtime.

## Changes

- `AlRunner/Runtime/MockRecordHandle.cs`: add `ALLockTable(bool wait)` no-op overload alongside the existing `ALLockTable(DataError)` overload
- `tests/bucket-1/42-locktable/test/TestLockTable.al`: three new proving tests — `LockTableWaitFalseIsNoOp`, `LockTableWaitTrueIsNoOp`, `LockTableWaitFalseDoesNotBlockInsert`
- `docs/coverage.yaml`: update `Table.LockTable` notes from `overloads=1` to `overloads=2`

## Test plan

- [ ] Existing 5 `LockTable()` tests still pass (regression)
- [ ] New `LockTableWaitFalseIsNoOp` passes (no error on `LockTable(false)`)
- [ ] New `LockTableWaitTrueIsNoOp` passes (no error on `LockTable(true)`)
- [ ] New `LockTableWaitFalseDoesNotBlockInsert` passes (Insert works after `LockTable(false)`)
- [ ] Full bucket-1 regression clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)