### PR TITLE
feat: SecretText.IsEmpty / Unwrap / SecretStrSubstNo

### DIFF
--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -2425,10 +2425,10 @@ public void ClearApplicationMemberVariables() { }
             // We intercept based on method name only (NavSecretText is the only type with ALUnwrap).
             if (methodName == "ALUnwrap" && visited.ArgumentList.Arguments.Count == 0)
             {
-                var memberAccess = visited.Expression as MemberAccessExpressionSyntax;
-                if (memberAccess != null)
+                var unwrapMemberAccess = visited.Expression as MemberAccessExpressionSyntax;
+                if (unwrapMemberAccess != null)
                 {
-                    var receiver = memberAccess.Expression;
+                    var receiver = unwrapMemberAccess.Expression;
                     return SyntaxFactory.InvocationExpression(
                         SyntaxFactory.MemberAccessExpression(
                             SyntaxKind.SimpleMemberAccessExpression,

--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -2419,28 +2419,6 @@ public void ClearApplicationMemberVariables() { }
                         SyntaxFactory.IdentifierName("SecretStrSubstNo")));
             }
 
-            // <secret>.ALUnwrap() -> AlCompat.Unwrap(<secret>)
-            // NavSecretText.ALUnwrap() may crash without NavSession in some BC versions.
-            // AlCompat.Unwrap() extracts the underlying string via reflection.
-            // We intercept based on method name only (NavSecretText is the only type with ALUnwrap).
-            if (methodName == "ALUnwrap" && visited.ArgumentList.Arguments.Count == 0)
-            {
-                var unwrapMemberAccess = visited.Expression as MemberAccessExpressionSyntax;
-                if (unwrapMemberAccess != null)
-                {
-                    var receiver = unwrapMemberAccess.Expression;
-                    return SyntaxFactory.InvocationExpression(
-                        SyntaxFactory.MemberAccessExpression(
-                            SyntaxKind.SimpleMemberAccessExpression,
-                            SyntaxFactory.IdentifierName("AlCompat"),
-                            SyntaxFactory.IdentifierName("Unwrap")),
-                        SyntaxFactory.ArgumentList(
-                            SyntaxFactory.SingletonSeparatedList(
-                                SyntaxFactory.Argument(receiver))))
-                        .WithTriviaFrom(visited);
-                }
-            }
-
             // ALDatabase.ALIsInWriteTransaction() -> false
             // The real ALIsInWriteTransaction calls NavSession.HasWriteTransaction() which crashes
             // with NullReferenceException when NavSession is null (runner context, no DB).

--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -2407,6 +2407,40 @@ public void ClearApplicationMemberVariables() { }
                         SyntaxFactory.IdentifierName("CopyStr")));
             }
 
+            // ALSystemString.ALSecretStrSubstNo(fmt, arg1, ...) -> AlCompat.SecretStrSubstNo(fmt, arg1, ...)
+            // The BC runtime SecretStrSubstNo creates a NavSecretText that requires NavSession.
+            // AlCompat.SecretStrSubstNo formats the string via StrSubstNo and wraps in NavSecretText.Create().
+            if (exprText == "ALSystemString" && methodName == "ALSecretStrSubstNo")
+            {
+                return visited.WithExpression(
+                    SyntaxFactory.MemberAccessExpression(
+                        SyntaxKind.SimpleMemberAccessExpression,
+                        SyntaxFactory.IdentifierName("AlCompat"),
+                        SyntaxFactory.IdentifierName("SecretStrSubstNo")));
+            }
+
+            // <secret>.ALUnwrap() -> AlCompat.Unwrap(<secret>)
+            // NavSecretText.ALUnwrap() may crash without NavSession in some BC versions.
+            // AlCompat.Unwrap() extracts the underlying string via reflection.
+            // We intercept based on method name only (NavSecretText is the only type with ALUnwrap).
+            if (methodName == "ALUnwrap" && visited.ArgumentList.Arguments.Count == 0)
+            {
+                var memberAccess = visited.Expression as MemberAccessExpressionSyntax;
+                if (memberAccess != null)
+                {
+                    var receiver = memberAccess.Expression;
+                    return SyntaxFactory.InvocationExpression(
+                        SyntaxFactory.MemberAccessExpression(
+                            SyntaxKind.SimpleMemberAccessExpression,
+                            SyntaxFactory.IdentifierName("AlCompat"),
+                            SyntaxFactory.IdentifierName("Unwrap")),
+                        SyntaxFactory.ArgumentList(
+                            SyntaxFactory.SingletonSeparatedList(
+                                SyntaxFactory.Argument(receiver))))
+                        .WithTriviaFrom(visited);
+                }
+            }
+
             // ALDatabase.ALIsInWriteTransaction() -> false
             // The real ALIsInWriteTransaction calls NavSession.HasWriteTransaction() which crashes
             // with NullReferenceException when NavSession is null (runner context, no DB).

--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -2419,6 +2419,26 @@ public void ClearApplicationMemberVariables() { }
                         SyntaxFactory.IdentifierName("SecretStrSubstNo")));
             }
 
+            // x.ALUnwrap() -> AlCompat.Unwrap(x)
+            // BC 27.x+ NavSecretText.ALUnwrap() loads CodeAnalysis 16.4.x at runtime,
+            // which is absent from the runner's DLL path. AlCompat.Unwrap uses reflection
+            // to extract the string and returns NavText — the correct type for the assignment.
+            if (methodName == "ALUnwrap" && visited.ArgumentList.Arguments.Count == 0)
+            {
+                var unwrapMa = visited.Expression as MemberAccessExpressionSyntax;
+                if (unwrapMa != null)
+                {
+                    return SyntaxFactory.InvocationExpression(
+                        SyntaxFactory.MemberAccessExpression(
+                            SyntaxKind.SimpleMemberAccessExpression,
+                            SyntaxFactory.IdentifierName("AlCompat"),
+                            SyntaxFactory.IdentifierName("Unwrap")),
+                        SyntaxFactory.ArgumentList(SyntaxFactory.SingletonSeparatedList(
+                            SyntaxFactory.Argument(unwrapMa.Expression))))
+                        .WithTriviaFrom(visited);
+                }
+            }
+
             // ALDatabase.ALIsInWriteTransaction() -> false
             // The real ALIsInWriteTransaction calls NavSession.HasWriteTransaction() which crashes
             // with NullReferenceException when NavSession is null (runner context, no DB).

--- a/AlRunner/Runtime/AlScope.cs
+++ b/AlRunner/Runtime/AlScope.cs
@@ -1634,49 +1634,6 @@ public static class AlCompat
     }
 
     // -----------------------------------------------------------------------
-    // SecretText.Unwrap() replacement
-    // NavSecretText.ALUnwrap() requires NavSession in some BC versions.
-    // We extract the underlying string via reflection (same approach as
-    // MockIsolatedStorage.ExtractSecretValue).
-    // The rewriter intercepts <secret>.ALUnwrap() → AlCompat.Unwrap(<secret>).
-    // -----------------------------------------------------------------------
-
-    /// <summary>
-    /// AL <c>SecretText.Unwrap()</c> — extracts the underlying plain-text value.
-    /// NavSecretText.ToString() returns "***"; reflection is used to get the real value.
-    /// </summary>
-    public static string Unwrap(NavSecretText st)
-    {
-        if (st.ALIsEmpty()) return "";
-        var flags = System.Reflection.BindingFlags.Instance |
-                    System.Reflection.BindingFlags.NonPublic |
-                    System.Reflection.BindingFlags.Public;
-        foreach (var field in typeof(NavSecretText).GetFields(flags))
-        {
-            if (field.FieldType == typeof(string))
-            {
-                var val = field.GetValue(st);
-                if (val is string s && !string.IsNullOrEmpty(s))
-                    return s;
-            }
-        }
-        foreach (var prop in typeof(NavSecretText).GetProperties(flags))
-        {
-            if (prop.PropertyType == typeof(string) && prop.CanRead)
-            {
-                try
-                {
-                    var val = prop.GetValue(st);
-                    if (val is string s && !string.IsNullOrEmpty(s))
-                        return s;
-                }
-                catch { }
-            }
-        }
-        return st.ToString() ?? "";
-    }
-
-    // -----------------------------------------------------------------------
     // SecretStrSubstNo() replacement
     // Global AL function SecretStrSubstNo(format, args) → SecretText.
     // BC emits ALSystemString.ALSecretStrSubstNo(format, arg1, ...).

--- a/AlRunner/Runtime/AlScope.cs
+++ b/AlRunner/Runtime/AlScope.cs
@@ -1650,4 +1650,51 @@ public static class AlCompat
         var result = StrSubstNo(format, args);
         return NavSecretText.Create(result);
     }
+
+    // -----------------------------------------------------------------------
+    // Unwrap() replacement
+    // AL SecretText.Unwrap() → Text.
+    // BC emits x.ALUnwrap(). In BC 27.x, ALUnwrap() loads CodeAnalysis 16.4.x
+    // at runtime, which is not available in the runner's DLL path.
+    // We extract the string via reflection and wrap in a NavText.
+    // -----------------------------------------------------------------------
+
+    /// <summary>
+    /// AL <c>SecretText.Unwrap()</c> — extracts the underlying string value from a
+    /// <c>NavSecretText</c> struct without calling the native <c>ALUnwrap()</c>
+    /// (which loads an unavailable CodeAnalysis assembly in BC 27.x+).
+    /// </summary>
+    public static NavText Unwrap(NavSecretText st)
+    {
+        if (st.ALIsEmpty()) return new NavText("");
+        // NavSecretText is a struct; box it so reflection can read instance fields.
+        object boxed = st;
+        var flags = System.Reflection.BindingFlags.Instance |
+                    System.Reflection.BindingFlags.NonPublic |
+                    System.Reflection.BindingFlags.Public;
+        foreach (var field in typeof(NavSecretText).GetFields(flags))
+        {
+            if (field.FieldType == typeof(string))
+            {
+                var val = field.GetValue(boxed);
+                if (val is string s)
+                    return new NavText(s);
+            }
+        }
+        foreach (var prop in typeof(NavSecretText).GetProperties(flags))
+        {
+            if (prop.PropertyType == typeof(string) && prop.CanRead)
+            {
+                try
+                {
+                    var val = prop.GetValue(boxed);
+                    if (val is string s)
+                        return new NavText(s);
+                }
+                catch { }
+            }
+        }
+        // Last resort — ToString() returns the value in BC 26.x; may not in 27.x.
+        return new NavText(st.ToString() ?? "");
+    }
 }

--- a/AlRunner/Runtime/AlScope.cs
+++ b/AlRunner/Runtime/AlScope.cs
@@ -1688,7 +1688,7 @@ public static class AlCompat
     /// AL <c>SecretStrSubstNo(format, args)</c> — substitutes %1..%N placeholders
     /// and returns the result as a <c>NavSecretText</c>.
     /// </summary>
-    public static NavSecretText SecretStrSubstNo(string format, params object[] args)
+    public static NavSecretText SecretStrSubstNo(string format, params Microsoft.Dynamics.Nav.Runtime.NavValue[] args)
     {
         var result = StrSubstNo(format, args);
         return NavSecretText.Create(result);

--- a/AlRunner/Runtime/AlScope.cs
+++ b/AlRunner/Runtime/AlScope.cs
@@ -1632,4 +1632,65 @@ public static class AlCompat
         if (position > s.Length) return "";
         return s.Substring(position - 1);
     }
+
+    // -----------------------------------------------------------------------
+    // SecretText.Unwrap() replacement
+    // NavSecretText.ALUnwrap() requires NavSession in some BC versions.
+    // We extract the underlying string via reflection (same approach as
+    // MockIsolatedStorage.ExtractSecretValue).
+    // The rewriter intercepts <secret>.ALUnwrap() → AlCompat.Unwrap(<secret>).
+    // -----------------------------------------------------------------------
+
+    /// <summary>
+    /// AL <c>SecretText.Unwrap()</c> — extracts the underlying plain-text value.
+    /// NavSecretText.ToString() returns "***"; reflection is used to get the real value.
+    /// </summary>
+    public static string Unwrap(NavSecretText st)
+    {
+        if (st.ALIsEmpty()) return "";
+        var flags = System.Reflection.BindingFlags.Instance |
+                    System.Reflection.BindingFlags.NonPublic |
+                    System.Reflection.BindingFlags.Public;
+        foreach (var field in typeof(NavSecretText).GetFields(flags))
+        {
+            if (field.FieldType == typeof(string))
+            {
+                var val = field.GetValue(st);
+                if (val is string s && !string.IsNullOrEmpty(s))
+                    return s;
+            }
+        }
+        foreach (var prop in typeof(NavSecretText).GetProperties(flags))
+        {
+            if (prop.PropertyType == typeof(string) && prop.CanRead)
+            {
+                try
+                {
+                    var val = prop.GetValue(st);
+                    if (val is string s && !string.IsNullOrEmpty(s))
+                        return s;
+                }
+                catch { }
+            }
+        }
+        return st.ToString() ?? "";
+    }
+
+    // -----------------------------------------------------------------------
+    // SecretStrSubstNo() replacement
+    // Global AL function SecretStrSubstNo(format, args) → SecretText.
+    // BC emits ALSystemString.ALSecretStrSubstNo(format, arg1, ...).
+    // We reuse AlCompat.StrSubstNo for the string formatting and wrap in
+    // NavSecretText.Create().
+    // -----------------------------------------------------------------------
+
+    /// <summary>
+    /// AL <c>SecretStrSubstNo(format, args)</c> — substitutes %1..%N placeholders
+    /// and returns the result as a <c>NavSecretText</c>.
+    /// </summary>
+    public static NavSecretText SecretStrSubstNo(string format, params object[] args)
+    {
+        var result = StrSubstNo(format, args);
+        return NavSecretText.Create(result);
+    }
 }

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -5001,7 +5001,7 @@ SecretText.Unwrap:
   category: SecretText
   status: covered
   tests: tests/bucket-1/67-secret-text-methods
-  notes: overloads=1; intercepted via ALUnwrap() → AlCompat.Unwrap() using reflection
+  notes: overloads=1; NavSecretText.ALUnwrap() works without NavSession (proved by test)
 
 # ── Session ─────────────────────────────────────────────────────
 

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -4985,20 +4985,23 @@ RequestPage.Update:
 SecretText.IsEmpty:
   layer: runtime-api
   category: SecretText
-  status: gap
+  status: covered
+  tests: tests/bucket-1/67-secret-text-methods
   notes: overloads=1
 
 SecretText.SecretStrSubstNo:
   layer: runtime-api
   category: SecretText
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-1/67-secret-text-methods
+  notes: overloads=1; intercepted via ALSystemString.ALSecretStrSubstNo → AlCompat.SecretStrSubstNo
 
 SecretText.Unwrap:
   layer: runtime-api
   category: SecretText
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-1/67-secret-text-methods
+  notes: overloads=1; intercepted via ALUnwrap() → AlCompat.Unwrap() using reflection
 
 # ── Session ─────────────────────────────────────────────────────
 

--- a/tests/bucket-1/67-secret-text-methods/src/SecretTextMethodsSrc.al
+++ b/tests/bucket-1/67-secret-text-methods/src/SecretTextMethodsSrc.al
@@ -1,0 +1,48 @@
+codeunit 58200 "STM Secret Text Helper"
+{
+    /// <summary>
+    /// Returns true when the given SecretText holds no value.
+    /// Exercises SecretText.IsEmpty().
+    /// </summary>
+    procedure IsSecretEmpty(secret: SecretText): Boolean
+    begin
+        exit(secret.IsEmpty());
+    end;
+
+    /// <summary>
+    /// Assigns the given plain text to a SecretText and returns IsEmpty.
+    /// Proves that a non-empty assignment is reflected by IsEmpty() = false.
+    /// </summary>
+    procedure IsAssignedSecretEmpty(plainText: Text): Boolean
+    var
+        secret: SecretText;
+    begin
+        secret := plainText;
+        exit(secret.IsEmpty());
+    end;
+
+    /// <summary>
+    /// Assigns the given plain text to a SecretText and returns Unwrap().
+    /// Exercises SecretText.Unwrap() — the only AL-sanctioned way to get the raw value.
+    /// </summary>
+    procedure UnwrapSecret(plainText: Text): Text
+    var
+        secret: SecretText;
+    begin
+        secret := plainText;
+        exit(secret.Unwrap());
+    end;
+
+    /// <summary>
+    /// Builds a formatted SecretText message using SecretStrSubstNo.
+    /// Exercises the global SecretStrSubstNo(format, arg) function.
+    /// The result is a SecretText, unwrapped here for assertion.
+    /// </summary>
+    procedure BuildSecretMessage(fmt: Text; arg: Text): Text
+    var
+        result: SecretText;
+    begin
+        result := SecretStrSubstNo(fmt, arg);
+        exit(result.Unwrap());
+    end;
+}

--- a/tests/bucket-1/67-secret-text-methods/test/SecretTextMethodsTests.al
+++ b/tests/bucket-1/67-secret-text-methods/test/SecretTextMethodsTests.al
@@ -1,0 +1,105 @@
+codeunit 58201 "STM Secret Text Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Helper: Codeunit "STM Secret Text Helper";
+
+    // -----------------------------------------------------------------------
+    // IsEmpty()
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure IsEmpty_UninitialisedSecret_ReturnsTrue()
+    var
+        secret: SecretText;
+    begin
+        // [GIVEN] A default-initialised SecretText (no assignment)
+        // [WHEN] IsEmpty() called
+        // [THEN] Returns true
+        Assert.IsTrue(secret.IsEmpty(), 'Uninitialised SecretText must be empty');
+    end;
+
+    [Test]
+    procedure IsEmpty_AssignedFromText_ReturnsFalse()
+    begin
+        // [GIVEN] A SecretText assigned from a non-empty literal
+        // [WHEN] IsEmpty() called via helper
+        // [THEN] Returns false
+        Assert.IsFalse(Helper.IsAssignedSecretEmpty('my-secret'), 'SecretText assigned from non-empty text must not be empty');
+    end;
+
+    [Test]
+    procedure IsEmpty_AssignedFromEmptyText_ReturnsTrue()
+    begin
+        // [GIVEN] A SecretText assigned from an empty string
+        // [WHEN] IsEmpty() called via helper
+        // [THEN] Returns true
+        Assert.IsTrue(Helper.IsAssignedSecretEmpty(''), 'SecretText assigned from empty text must be empty');
+    end;
+
+    [Test]
+    procedure IsEmpty_PassedAsParam_EmptySecret_ReturnsTrue()
+    var
+        secret: SecretText;
+    begin
+        // [GIVEN] An empty SecretText passed as a parameter
+        Assert.IsTrue(Helper.IsSecretEmpty(secret), 'Empty SecretText parameter: IsEmpty must return true');
+    end;
+
+    // -----------------------------------------------------------------------
+    // Unwrap()
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure Unwrap_ReturnsOriginalText()
+    begin
+        // [GIVEN] A SecretText assigned from 'api-key-123'
+        // [WHEN] Unwrap() called
+        // [THEN] Returns 'api-key-123'
+        Assert.AreEqual('api-key-123', Helper.UnwrapSecret('api-key-123'), 'Unwrap must return the original text value');
+    end;
+
+    [Test]
+    procedure Unwrap_EmptySecret_ReturnsEmpty()
+    begin
+        // [GIVEN] A SecretText assigned from ''
+        // [WHEN] Unwrap() called
+        // [THEN] Returns ''
+        Assert.AreEqual('', Helper.UnwrapSecret(''), 'Unwrap of empty secret must return empty string');
+    end;
+
+    [Test]
+    procedure Unwrap_PreservesCase()
+    begin
+        // [GIVEN] A mixed-case secret
+        // [WHEN] Unwrap() called
+        // [THEN] Original casing preserved
+        Assert.AreEqual('ABC-xyz-123', Helper.UnwrapSecret('ABC-xyz-123'), 'Unwrap must preserve casing');
+    end;
+
+    // -----------------------------------------------------------------------
+    // SecretStrSubstNo()
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure SecretStrSubstNo_SubstitutesArgument()
+    begin
+        // [GIVEN] Format 'Bearer %1' with token 'my-token'
+        // [WHEN] SecretStrSubstNo called
+        // [THEN] Result unwraps to 'Bearer my-token'
+        Assert.AreEqual('Bearer my-token', Helper.BuildSecretMessage('Bearer %1', 'my-token'),
+            'SecretStrSubstNo must substitute %1 with the argument');
+    end;
+
+    [Test]
+    procedure SecretStrSubstNo_ResultIsNotEmpty()
+    begin
+        // [GIVEN] A non-empty format with a non-empty argument
+        // [WHEN] SecretStrSubstNo called and result checked with IsEmpty
+        // [THEN] Result is not empty
+        Assert.IsFalse(Helper.IsAssignedSecretEmpty(Helper.BuildSecretMessage('key=%1', 'value')),
+            'SecretStrSubstNo result assigned back must not be empty');
+    end;
+}


### PR DESCRIPTION
Closes #369

## Summary

- `SecretText.IsEmpty()` already worked via `NavSecretText.ALIsEmpty()` — no change needed, coverage confirmed by new tests
- `SecretText.Unwrap()`: RoslynRewriter intercepts `.ALUnwrap()` → `AlCompat.Unwrap(secret)`, which extracts the underlying string via reflection (same technique as `MockIsolatedStorage.ExtractSecretValue`)  
- `SecretStrSubstNo(fmt, args)`: RoslynRewriter intercepts `ALSystemString.ALSecretStrSubstNo(...)` → `AlCompat.SecretStrSubstNo(...)`, which calls `StrSubstNo` for formatting and wraps in `NavSecretText.Create()`
- Test suite `tests/bucket-1/67-secret-text-methods` (codeunits 58200/58201) — 9 proving tests
- `docs/coverage.yaml`: 3 entries updated from `gap` to `covered`

## Test plan

- [ ] All bucket-1 tests pass in CI
- [ ] `IsEmpty()` returns true for uninitialised SecretText, false for non-empty assignment, true for empty string assignment
- [ ] `Unwrap()` returns original text, preserves casing, returns empty for empty secret
- [ ] `SecretStrSubstNo('Bearer %1', 'token')` unwraps to `'Bearer token'`