### PR TITLE
feat: Text built-ins — PadStr negative length + proving tests

### DIFF
--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -2439,6 +2439,19 @@ public void ClearApplicationMemberVariables() { }
                 }
             }
 
+            // ALSystemString.ALPadStr(source, length, filler) -> AlCompat.PadStr(source, length, filler)
+            // Real BC impl validates length >= 0 and throws NavNCLOutsidePermittedRangeException on
+            // negative length — but AL documents negative length as "left-pad". AlCompat.PadStr
+            // implements the AL-level contract (negative = left-pad, truncates when source is longer).
+            if (exprText == "ALSystemString" && methodName == "ALPadStr")
+            {
+                return visited.WithExpression(
+                    SyntaxFactory.MemberAccessExpression(
+                        SyntaxKind.SimpleMemberAccessExpression,
+                        SyntaxFactory.IdentifierName("AlCompat"),
+                        SyntaxFactory.IdentifierName("PadStr")));
+            }
+
             // ALDatabase.ALIsInWriteTransaction() -> false
             // The real ALIsInWriteTransaction calls NavSession.HasWriteTransaction() which crashes
             // with NullReferenceException when NavSession is null (runner context, no DB).

--- a/AlRunner/Runtime/AlScope.cs
+++ b/AlRunner/Runtime/AlScope.cs
@@ -824,6 +824,26 @@ public static class AlCompat
     }
 
     /// <summary>
+    /// AL PadStr(String, Length, Filler): pad or truncate to fixed width.
+    /// Positive Length = right-pad (append filler). Negative Length = left-pad (prepend filler).
+    /// If |Length| &lt;= source length, result is source truncated to |Length| (no padding added).
+    /// The real BC ALSystemString.ALPadStr rejects negative Length with NavNCLOutsidePermittedRangeException,
+    /// so we route through AlCompat to implement AL's documented behavior.
+    /// </summary>
+    public static string PadStr(string? source, int length, string? filler)
+    {
+        var src = source ?? "";
+        var fillCh = string.IsNullOrEmpty(filler) ? ' ' : filler![0];
+        int absLen = length < 0 ? -length : length;
+        if (src.Length >= absLen) return src.Substring(0, absLen);
+        int padCount = absLen - src.Length;
+        var pad = new string(fillCh, padCount);
+        return length < 0 ? pad + src : src + pad;
+    }
+
+    public static string PadStr(string? source, int length) => PadStr(source, length, " ");
+
+    /// <summary>
     /// Format with AL format string (e.g. '&lt;Year4&gt;-&lt;Month,2&gt;-&lt;Day,2&gt;').
     /// The BC transpiler emits NavFormatEvaluateHelper.Format(session, value, length, formatString)
     /// which the rewriter strips the session arg from, producing AlCompat.Format(value, length, formatString).

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -6976,8 +6976,8 @@ Text.IndexOf:
 Text.IndexOfAny:
   layer: runtime-api
   category: Text
-  status: gap
-  notes: overloads=2
+  status: covered
+  notes: overloads=2; BC native NavTextExtensions.ALIndexOfAny works standalone. Tested in bucket-1/67-text-builtins.
 
 Text.InsStr:
   layer: runtime-api
@@ -7018,8 +7018,8 @@ Text.PadRight:
 Text.PadStr:
   layer: runtime-api
   category: Text
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; negative length = left-pad (rewriter routes ALPadStr -> AlCompat.PadStr; BC native rejects negative length). Tested in bucket-1/67-text-builtins.
 
 Text.Remove:
   layer: runtime-api
@@ -7055,8 +7055,8 @@ Text.StartsWith:
 Text.StrCheckSum:
   layer: runtime-api
   category: Text
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; BC native ALSystemString.ALStrCheckSum works standalone (default modulus 10). Tested in bucket-1/67-text-builtins.
 
 Text.StrLen:
   layer: runtime-api
@@ -7067,8 +7067,8 @@ Text.StrLen:
 Text.StrPos:
   layer: runtime-api
   category: Text
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; BC native works standalone. Tested in bucket-1/67-text-builtins.
 
 Text.StrSubstNo:
   layer: runtime-api
@@ -7079,20 +7079,20 @@ Text.StrSubstNo:
 Text.Substring:
   layer: runtime-api
   category: Text
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; BC native NavTextExtensions.ALSubstring works standalone (1-based). Tested in bucket-1/67-text-builtins.
 
 Text.ToLower:
   layer: runtime-api
   category: Text
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; BC native works standalone. Tested in bucket-1/67-text-builtins.
 
 Text.ToUpper:
   layer: runtime-api
   category: Text
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; BC native works standalone. Tested in bucket-1/67-text-builtins.
 
 Text.Trim:
   layer: runtime-api

--- a/tests/bucket-1/67-text-builtins/al-runner.json
+++ b/tests/bucket-1/67-text-builtins/al-runner.json
@@ -1,0 +1,4 @@
+{
+  "sourcePath": "./src",
+  "testPath": "./test"
+}

--- a/tests/bucket-1/67-text-builtins/src/TextBuiltins.al
+++ b/tests/bucket-1/67-text-builtins/src/TextBuiltins.al
@@ -1,0 +1,67 @@
+codeunit 50167 "Text Builtins Helper"
+{
+    procedure CallToLower(Input: Text): Text
+    begin
+        exit(Input.ToLower());
+    end;
+
+    procedure CallToUpper(Input: Text): Text
+    begin
+        exit(Input.ToUpper());
+    end;
+
+    procedure CallSubstring(Input: Text; StartPos: Integer; Length: Integer): Text
+    begin
+        exit(Input.Substring(StartPos, Length));
+    end;
+
+    procedure CallSubstringFromStart(Input: Text; StartPos: Integer): Text
+    begin
+        exit(Input.Substring(StartPos));
+    end;
+
+    procedure CallPadStr(Input: Text; Length: Integer): Text
+    begin
+        exit(PadStr(Input, Length));
+    end;
+
+    procedure CallPadStrRight(Input: Text; Length: Integer): Text
+    begin
+        exit(PadStr(Input, Length, ' '));
+    end;
+
+    procedure CallPadStrLeft(Input: Text; Length: Integer): Text
+    begin
+        exit(PadStr(Input, -Length, ' '));
+    end;
+
+    procedure CallPadStrChar(Input: Text; Length: Integer; Pad: Char): Text
+    begin
+        exit(PadStr(Input, Length, Pad));
+    end;
+
+    procedure CallStrPos(Haystack: Text; Needle: Text): Integer
+    begin
+        exit(StrPos(Haystack, Needle));
+    end;
+
+    procedure CallIndexOfAny(Input: Text; Chars: Text): Integer
+    begin
+        exit(Input.IndexOfAny(Chars));
+    end;
+
+    procedure CallIndexOfAnyStart(Input: Text; Chars: Text; StartIndex: Integer): Integer
+    begin
+        exit(Input.IndexOfAny(Chars, StartIndex));
+    end;
+
+    procedure CallStrCheckSum(Digits: Text; Weights: Text): Integer
+    begin
+        exit(StrCheckSum(Digits, Weights));
+    end;
+
+    procedure CallStrCheckSumSimple(Digits: Text): Integer
+    begin
+        exit(StrCheckSum(Digits));
+    end;
+}

--- a/tests/bucket-1/67-text-builtins/test/TextBuiltinsTest.al
+++ b/tests/bucket-1/67-text-builtins/test/TextBuiltinsTest.al
@@ -1,0 +1,143 @@
+codeunit 50967 "Text Builtins Test"
+{
+    Subtype = Test;
+
+    var
+        Helper: Codeunit "Text Builtins Helper";
+        Assert: Codeunit Assert;
+
+    [Test]
+    procedure TestToLower()
+    begin
+        Assert.AreEqual('hello world', Helper.CallToLower('Hello World'), 'ToLower mixed case');
+        Assert.AreEqual('abcdef', Helper.CallToLower('ABCDEF'), 'ToLower all upper');
+        Assert.AreEqual('already lower', Helper.CallToLower('already lower'), 'ToLower already lower');
+        Assert.AreEqual('', Helper.CallToLower(''), 'ToLower empty string');
+        Assert.AreEqual('123!@#', Helper.CallToLower('123!@#'), 'ToLower non-letters unchanged');
+    end;
+
+    [Test]
+    procedure TestToUpper()
+    begin
+        Assert.AreEqual('HELLO WORLD', Helper.CallToUpper('Hello World'), 'ToUpper mixed case');
+        Assert.AreEqual('ABCDEF', Helper.CallToUpper('abcdef'), 'ToUpper all lower');
+        Assert.AreEqual('ALREADY UPPER', Helper.CallToUpper('ALREADY UPPER'), 'ToUpper already upper');
+        Assert.AreEqual('', Helper.CallToUpper(''), 'ToUpper empty string');
+        Assert.AreEqual('123!@#', Helper.CallToUpper('123!@#'), 'ToUpper non-letters unchanged');
+    end;
+
+    [Test]
+    procedure TestSubstring()
+    begin
+        // AL Substring is 1-based
+        Assert.AreEqual('Hello', Helper.CallSubstring('Hello World', 1, 5), 'Substring from start');
+        Assert.AreEqual('World', Helper.CallSubstring('Hello World', 7, 5), 'Substring at offset');
+        Assert.AreEqual('o', Helper.CallSubstring('Hello World', 5, 1), 'Single char substring');
+        Assert.AreEqual('Hello World', Helper.CallSubstring('Hello World', 1, 11), 'Full string substring');
+    end;
+
+    [Test]
+    procedure TestSubstringFromStart()
+    begin
+        // Substring(start) returns from start to end
+        Assert.AreEqual('World', Helper.CallSubstringFromStart('Hello World', 7), 'Substring to end');
+        Assert.AreEqual('Hello World', Helper.CallSubstringFromStart('Hello World', 1), 'Substring from 1');
+        Assert.AreEqual('d', Helper.CallSubstringFromStart('Hello World', 11), 'Last char');
+    end;
+
+    [Test]
+    procedure TestSubstringInvalidRange()
+    begin
+        // AL Substring errors on out-of-range arguments
+        asserterror Helper.CallSubstring('Hello', 10, 3);
+    end;
+
+    [Test]
+    procedure TestPadStrRightFills()
+    begin
+        // Positive length = right-pad with space (default)
+        Assert.AreEqual('Hello     ', Helper.CallPadStr('Hello', 10), 'PadStr right-pad default');
+        Assert.AreEqual('Hello     ', Helper.CallPadStrRight('Hello', 10), 'PadStr right-pad explicit');
+    end;
+
+    [Test]
+    procedure TestPadStrTruncates()
+    begin
+        // When input is longer than length, truncate (no padding)
+        Assert.AreEqual('Hello', Helper.CallPadStr('Hello World', 5), 'PadStr truncates long input');
+    end;
+
+    [Test]
+    procedure TestPadStrLeftFills()
+    begin
+        // Negative length = left-pad with space (default)
+        Assert.AreEqual('     Hello', Helper.CallPadStrLeft('Hello', 10), 'PadStr left-pad');
+    end;
+
+    [Test]
+    procedure TestPadStrWithChar()
+    var
+        Star: Char;
+    begin
+        Star := 42; // '*'
+        Assert.AreEqual('Hello*****', Helper.CallPadStrChar('Hello', 10, Star), 'PadStr right-pad with char');
+        Assert.AreEqual('*****Hello', Helper.CallPadStrChar('Hello', -10, Star), 'PadStr left-pad with char');
+    end;
+
+    [Test]
+    procedure TestPadStrLeftTruncates()
+    begin
+        // Negative length with over-length input should still truncate
+        Assert.AreEqual('Hello', Helper.CallPadStrLeft('Hello World', 5), 'PadStr negative length truncates');
+    end;
+
+    [Test]
+    procedure TestStrPos()
+    begin
+        // StrPos is 1-based, 0 = not found
+        Assert.AreEqual(1, Helper.CallStrPos('Hello World', 'Hello'), 'StrPos match at start');
+        Assert.AreEqual(7, Helper.CallStrPos('Hello World', 'World'), 'StrPos match middle');
+        Assert.AreEqual(2, Helper.CallStrPos('Hello', 'ell'), 'StrPos match middle 2');
+        Assert.AreEqual(0, Helper.CallStrPos('Hello', 'xyz'), 'StrPos no match returns 0');
+        Assert.AreEqual(0, Helper.CallStrPos('', 'a'), 'StrPos empty haystack');
+    end;
+
+    [Test]
+    procedure TestIndexOfAny()
+    begin
+        // 1-based, 0 if not found
+        Assert.AreEqual(3, Helper.CallIndexOfAny('Hello World', 'lo'), 'IndexOfAny first l');
+        Assert.AreEqual(6, Helper.CallIndexOfAny('Hello World', ' '), 'IndexOfAny space');
+        Assert.AreEqual(0, Helper.CallIndexOfAny('Hello', 'xyz'), 'IndexOfAny no match');
+    end;
+
+    [Test]
+    procedure TestIndexOfAnyWithStart()
+    begin
+        // Search from given 1-based start index
+        Assert.AreEqual(4, Helper.CallIndexOfAnyStart('Hello World', 'lo', 4), 'IndexOfAny from 4');
+        Assert.AreEqual(5, Helper.CallIndexOfAnyStart('Hello World', 'lo', 5), 'IndexOfAny from 5');
+        Assert.AreEqual(8, Helper.CallIndexOfAnyStart('Hello World', 'lo', 6), 'IndexOfAny from 6');
+    end;
+
+    [Test]
+    procedure TestStrCheckSum()
+    begin
+        // BC StrCheckSum default modulus is 10 (not 11).
+        // Formula: (10 - (sum(digit[i]*weight[i]) mod 10)) mod 10
+        // '12' weights '34': 1*3 + 2*4 = 11; 11 mod 10 = 1; (10 - 1) mod 10 = 9
+        Assert.AreEqual(9, Helper.CallStrCheckSum('12', '34'), 'StrCheckSum 12,34');
+        // '123' weights '111': 1+2+3 = 6; (10 - 6) mod 10 = 4
+        Assert.AreEqual(4, Helper.CallStrCheckSum('123', '111'), 'StrCheckSum 123,111 weights-all-1');
+        // '0' weights '1': 0; (10 - 0) mod 10 = 0
+        Assert.AreEqual(0, Helper.CallStrCheckSum('0', '1'), 'StrCheckSum zero input');
+    end;
+
+    [Test]
+    procedure TestStrCheckSumBarcode()
+    begin
+        // EAN-13 style: digits '590123412345' with alternating weights '131313131313'.
+        // sum = 5+27+0+3+2+9+4+3+2+9+4+15 = 83; 83 mod 10 = 3; (10 - 3) mod 10 = 7
+        Assert.AreEqual(7, Helper.CallStrCheckSum('590123412345', '131313131313'), 'StrCheckSum EAN-13 style');
+    end;
+}


### PR DESCRIPTION
Closes #367

## Summary

Issue #367 flagged seven AL Text built-ins as gaps: `Substring`, `ToUpper`, `ToLower`, `PadStr`, `StrPos`, `IndexOfAny`, `StrCheckSum`. Investigation with proving tests showed BC's native `NavTextExtensions` / `ALSystemString` implementations already work standalone for six of them. The only real gap is `PadStr` with negative length — AL documents negative length as left-pad, but BC's native `ALSystemString.ALPadStr` rejects it with `NavNCLOutsidePermittedRangeException`.

## Changes

- `AlCompat.PadStr(source, length, filler)` — implements AL's documented behavior: positive length = right-pad, negative length = left-pad, `|length|` ≤ source length = truncate. Default filler is space. (`AlRunner/Runtime/AlScope.cs`)
- Rewriter rule `ALSystemString.ALPadStr(...)` → `AlCompat.PadStr(...)` in `AlRunner/RoslynRewriter.cs`
- `tests/bucket-1/67-text-builtins/` — proving-test suite covering all seven functions (positive + negative + truncation cases, including EAN-13 style checksum for `StrCheckSum`)
- `docs/coverage.yaml` — all seven entries marked `covered` with notes on where they're tested

## Verification

- 15/15 new tests pass in the new suite
- Full bucket-1 regression: 495 tests pass (4 pre-existing failures unrelated to these changes — confirmed by stashing my diff)
- Full bucket-2 regression (excluding `130-cross-ext-al0275` which needs non-standard dirs): 624 tests pass

## Notes for reviewer

- BC's `StrCheckSum` default modulus is 10 (not 11 as I initially assumed); tests document the actual formula: `(10 - (Σ digit[i]·weight[i] mod 10)) mod 10`
- Added a 2-arg `PadStr(source, length)` overload so the BC compiler's 2-arg emit matches