### PR TITLE
test: local interface variable — dispatch and reassignment coverage (#372)

### DIFF
--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -77,6 +77,7 @@ interface_declaration:
     - tests/bucket-1/03-interface-injection
     - tests/bucket-1/31-interface-return
     - tests/bucket-1/32-interface-param
+    - tests/bucket-1/68-interface-local-var
     - tests/bucket-2/42-list-of-interface
     - tests/bucket-2/53-enum-interface
 

--- a/tests/bucket-1/68-interface-local-var/src/InterfaceLocalVarSrc.al
+++ b/tests/bucket-1/68-interface-local-var/src/InterfaceLocalVarSrc.al
@@ -1,0 +1,31 @@
+interface "ILV Greeter"
+{
+    procedure Greet(): Text;
+    procedure GreetName(Name: Text): Text;
+}
+
+codeunit 58300 "ILV Hello Greeter" implements "ILV Greeter"
+{
+    procedure Greet(): Text
+    begin
+        exit('Hello');
+    end;
+
+    procedure GreetName(Name: Text): Text
+    begin
+        exit('Hello ' + Name);
+    end;
+}
+
+codeunit 58301 "ILV Goodbye Greeter" implements "ILV Greeter"
+{
+    procedure Greet(): Text
+    begin
+        exit('Goodbye');
+    end;
+
+    procedure GreetName(Name: Text): Text
+    begin
+        exit('Goodbye ' + Name);
+    end;
+}

--- a/tests/bucket-1/68-interface-local-var/test/InterfaceLocalVarTests.al
+++ b/tests/bucket-1/68-interface-local-var/test/InterfaceLocalVarTests.al
@@ -1,0 +1,83 @@
+codeunit 58302 "ILV Interface Local Var Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    // -----------------------------------------------------------------------
+    // Local interface variable — declare, assign, dispatch
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure LocalInterfaceVar_AssignCodunit_DispatchesCorrectly()
+    var
+        Greeter: Interface "ILV Greeter";
+        Hello: Codeunit "ILV Hello Greeter";
+    begin
+        // [GIVEN] A local interface variable assigned from a codeunit
+        Greeter := Hello;
+        // [WHEN] Dispatch via the interface variable
+        // [THEN] Returns the expected text from the codeunit implementation
+        Assert.AreEqual('Hello', Greeter.Greet(), 'Dispatch through local interface var must call the assigned codeunit');
+    end;
+
+    [Test]
+    procedure LocalInterfaceVar_AssignDifferentImpl_DispatchesCorrectImpl()
+    var
+        Greeter: Interface "ILV Greeter";
+        Goodbye: Codeunit "ILV Goodbye Greeter";
+    begin
+        // [GIVEN] A local interface variable assigned from a different codeunit
+        Greeter := Goodbye;
+        // [WHEN] Dispatch via the interface variable
+        // [THEN] Returns the value from the second codeunit, not the first
+        Assert.AreEqual('Goodbye', Greeter.Greet(), 'Dispatch must use the assigned implementation, not a fixed one');
+    end;
+
+    [Test]
+    procedure LocalInterfaceVar_MethodWithParam_PassesParamCorrectly()
+    var
+        Greeter: Interface "ILV Greeter";
+        Hello: Codeunit "ILV Hello Greeter";
+    begin
+        // [GIVEN] A local interface variable
+        Greeter := Hello;
+        // [WHEN] Method with a parameter is called through the interface
+        // [THEN] Parameter is forwarded correctly
+        Assert.AreEqual('Hello World', Greeter.GreetName('World'), 'Parameter must be passed through interface dispatch');
+    end;
+
+    [Test]
+    procedure LocalInterfaceVar_Reassigned_DispatchesNewImpl()
+    var
+        Greeter: Interface "ILV Greeter";
+        Hello: Codeunit "ILV Hello Greeter";
+        Goodbye: Codeunit "ILV Goodbye Greeter";
+    begin
+        // [GIVEN] A local interface variable assigned to one implementation
+        Greeter := Hello;
+        Assert.AreEqual('Hello', Greeter.Greet(), 'First assignment must dispatch to Hello');
+        // [WHEN] Reassigned to a different codeunit
+        Greeter := Goodbye;
+        // [THEN] Dispatch uses the new implementation
+        Assert.AreEqual('Goodbye', Greeter.Greet(), 'After reassignment, dispatch must use the new implementation');
+    end;
+
+    [Test]
+    procedure TwoLocalInterfaceVars_IndependentDispatch()
+    var
+        Greeter1: Interface "ILV Greeter";
+        Greeter2: Interface "ILV Greeter";
+        Hello: Codeunit "ILV Hello Greeter";
+        Goodbye: Codeunit "ILV Goodbye Greeter";
+    begin
+        // [GIVEN] Two independent local interface variables
+        Greeter1 := Hello;
+        Greeter2 := Goodbye;
+        // [WHEN] Both are dispatched
+        // [THEN] Each dispatches to its own assigned codeunit
+        Assert.AreEqual('Hello', Greeter1.Greet(), 'Greeter1 must dispatch to Hello');
+        Assert.AreEqual('Goodbye', Greeter2.Greet(), 'Greeter2 must dispatch to Goodbye');
+    end;
+}


### PR DESCRIPTION
Closes #372

## What this adds

A dedicated test suite for the most direct interface usage pattern: declaring a **local interface variable** in a procedure body, assigning a codeunit directly to it, and dispatching methods through it.

```al
[Test]
procedure LocalInterfaceVar_AssignCodunit_DispatchesCorrectly()
var
    Greeter: Interface "ILV Greeter";
    Hello: Codeunit "ILV Hello Greeter";
begin
    Greeter := Hello;
    Assert.AreEqual('Hello', Greeter.Greet(), '...');
end;
```

## Tests added (`68-interface-local-var`, 5 tests)

| Test | Proves |
|---|---|
| `LocalInterfaceVar_AssignCodunit_DispatchesCorrectly` | Basic local-var assign + dispatch |
| `LocalInterfaceVar_AssignDifferentImpl_DispatchesCorrectImpl` | Correct impl is selected (not a fixed default) |
| `LocalInterfaceVar_MethodWithParam_PassesParamCorrectly` | Parameters forwarded through interface |
| `LocalInterfaceVar_Reassigned_DispatchesNewImpl` | Reassignment updates dispatch target |
| `TwoLocalInterfaceVars_IndependentDispatch` | Two vars are independent |

## Why no implementation changes

The existing `MockInterfaceHandle` infrastructure (`ALAssign`, `InvokeInterfaceMethod`, `ALCompiler.ToInterface` rewriter interceptor) already handles this case. The gap was missing explicit test coverage for the local-variable form of the pattern. The existing interface suites (03, 31, 32, 42, 53) cover interface fields, parameters, and return values but not this specific scenario.

`docs/coverage.yaml` updated to include the new suite under `interface_declaration`.