### PR TITLE
fix: mark actionref_declaration as covered in coverage.yaml (#388)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ All notable changes to this project are documented here. Format based on
 ## [Unreleased]
 
 ### Added
+- **`actionref_declaration` coverage (#388)** — Pages and page extensions containing
+  `actionref` sections (promoted-action bindings) now compile and run correctly.
+  The existing `RoslynRewriter` already handles the BC-generated C# for actionref
+  (the actionref declarations are inside `InitializeComponent` which is stripped).
+  New suite `tests/bucket-1/72-actionref` adds 2 proving tests confirming that a
+  codeunit in the same compilation unit as a page with actionref compiles and executes.
+  Coverage map: `actionref_declaration` moved from `gap` to `covered`.
 - **`Database.SelectLatestVersion` coverage (#313)** — `SelectLatestVersion()` was already
   a no-op (stripped by `StripEntireCallMethods` in `RoslynRewriter`) but had no proving
   tests. New suite `tests/bucket-1/58-database-select-latest-version` adds 3 tests:

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -766,7 +766,9 @@ action_group_section:
 actionref_declaration:
   layer: syntax
   category: page
-  status: gap
+  status: covered
+  tests:
+    - tests/bucket-1/72-actionref
 
 actions_section:
   layer: syntax


### PR DESCRIPTION
Follow-up to #391: the coverage.yaml and CHANGELOG.md updates were not included in the merged PR.

- `docs/coverage.yaml`: `actionref_declaration` status → `covered`, test pointer added
- `CHANGELOG.md`: entry added explaining the behavior