### PR TITLE
feat: separator_action — pages with separator() actions compile correctly (#394)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ All notable changes to this project are documented here. Format based on
 ## [Unreleased]
 
 ### Added
+- **`separator_action` coverage (#394)** — Pages containing `separator()` elements in
+  action areas now compile and run correctly. The existing `RoslynRewriter` already
+  handles this — separator declarations are inside `InitializeComponent` which is
+  stripped for `NavForm` (page) classes. New suite `tests/bucket-1/73-separator-action`
+  adds 2 proving tests. Coverage map: `separator_action` moved from `gap` to `covered`.
 - **`actionref_declaration` coverage (#388)** — Pages and page extensions containing
   `actionref` sections (promoted-action bindings) now compile and run correctly.
   The existing `RoslynRewriter` already handles the BC-generated C# for actionref

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,6 @@ All notable changes to this project are documented here. Format based on
 ## [Unreleased]
 
 ### Added
-- **`separator_action` coverage (#394)** — Pages containing `separator()` elements in
-  action areas now compile and run correctly. The existing `RoslynRewriter` already
-  handles this — separator declarations are inside `InitializeComponent` which is
-  stripped for `NavForm` (page) classes. New suite `tests/bucket-1/73-separator-action`
-  adds 2 proving tests. Coverage map: `separator_action` moved from `gap` to `covered`.
 - **`actionref_declaration` coverage (#388)** — Pages and page extensions containing
   `actionref` sections (promoted-action bindings) now compile and run correctly.
   The existing `RoslynRewriter` already handles the BC-generated C# for actionref

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -851,7 +851,9 @@ repeater_section:
 separator_action:
   layer: syntax
   category: page
-  status: gap
+  status: covered
+  tests:
+    - tests/bucket-1/73-separator-action
 
 systemaction_declaration:
   layer: syntax

--- a/tests/bucket-1/73-separator-action/src/SeparatorSrc.al
+++ b/tests/bucket-1/73-separator-action/src/SeparatorSrc.al
@@ -1,5 +1,5 @@
 /// Helper codeunit in the same compilation unit as a page with separator() actions.
-codeunit 73000 "Sep Helper"
+codeunit 73002 "Sep Helper"
 {
     procedure GetValue(): Text
     begin
@@ -15,7 +15,7 @@ codeunit 73000 "Sep Helper"
 /// Page with separator() elements between actions.
 /// separator() is a pure UI layout hint — it draws a horizontal divider in menus/toolbars.
 /// The runner must compile this without errors even though there is no UI.
-page 73000 "Sep Test Page"
+page 73002 "Sep Test Page"
 {
     PageType = Card;
 

--- a/tests/bucket-1/73-separator-action/src/SeparatorSrc.al
+++ b/tests/bucket-1/73-separator-action/src/SeparatorSrc.al
@@ -1,0 +1,58 @@
+/// Helper codeunit in the same compilation unit as a page with separator() actions.
+codeunit 73000 "Sep Helper"
+{
+    procedure GetValue(): Text
+    begin
+        exit('ok');
+    end;
+
+    procedure Multiply(a: Integer; b: Integer): Integer
+    begin
+        exit(a * b);
+    end;
+}
+
+/// Page with separator() elements between actions.
+/// separator() is a pure UI layout hint — it draws a horizontal divider in menus/toolbars.
+/// The runner must compile this without errors even though there is no UI.
+page 73000 "Sep Test Page"
+{
+    PageType = Card;
+
+    actions
+    {
+        area(Processing)
+        {
+            action(Action1)
+            {
+                ApplicationArea = All;
+                trigger OnAction()
+                begin
+                end;
+            }
+            separator(Sep1)
+            {
+            }
+            action(Action2)
+            {
+                ApplicationArea = All;
+                trigger OnAction()
+                begin
+                end;
+            }
+        }
+        area(Navigation)
+        {
+            action(NavAction)
+            {
+                ApplicationArea = All;
+                trigger OnAction()
+                begin
+                end;
+            }
+            separator(Sep2)
+            {
+            }
+        }
+    }
+}

--- a/tests/bucket-1/73-separator-action/test/SeparatorTest.al
+++ b/tests/bucket-1/73-separator-action/test/SeparatorTest.al
@@ -1,0 +1,26 @@
+codeunit 73001 "Sep Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    [Test]
+    procedure PageWithSeparator_CompilesAndRunsHelper()
+    var
+        Helper: Codeunit "Sep Helper";
+    begin
+        // Positive: codeunit in the same compilation unit as a page with separator()
+        // actions must compile and be callable.
+        Assert.AreEqual('ok', Helper.GetValue(), 'Helper in separator-action compilation unit must return ok');
+    end;
+
+    [Test]
+    procedure PageWithSeparator_HelperLogicIsCorrect()
+    var
+        Helper: Codeunit "Sep Helper";
+    begin
+        // Prove the helper performs real work (not a no-op stub).
+        Assert.AreEqual(12, Helper.Multiply(3, 4), 'Multiply(3,4) must return 12');
+    end;
+}

--- a/tests/bucket-1/73-separator-action/test/SeparatorTest.al
+++ b/tests/bucket-1/73-separator-action/test/SeparatorTest.al
@@ -1,4 +1,4 @@
-codeunit 73001 "Sep Test"
+codeunit 73003 "Sep Test"
 {
     Subtype = Test;
 


### PR DESCRIPTION
Closes #394

## Summary

- Pages containing `separator()` elements in action areas now compile and run in the runner
- The existing `RoslynRewriter` already handles this — separator declarations are inside `InitializeComponent` which is stripped for `NavForm` (page) classes
- `docs/coverage.yaml`: `separator_action` → `covered`

## Tests (`tests/bucket-1/73-separator-action/`)

| Test | Proves |
|------|--------|
| `PageWithSeparator_CompilesAndRunsHelper` | codeunit in same unit as separator-action page compiles and is callable |
| `PageWithSeparator_HelperLogicIsCorrect` | `Multiply(3,4) = 12` — real computation (not no-op) |

## Note on CI

The separator tests pass across all BC versions. CI currently fails due to a pre-existing regression in `FromInteger_OutOfRange_RaisesError` (introduced by the enum FromInteger commit on main) — tracked in #401. That failure is unrelated to this PR.