### PR TITLE
test: grid section coverage — grid layout sections in pages (#403)

### DIFF
--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -805,7 +805,9 @@ fileuploadaction_declaration:
 grid_section:
   layer: syntax
   category: page
-  status: gap
+  status: covered
+  tests:
+    - tests/bucket-1/74-grid-section
 
 group_section:
   layer: syntax

--- a/tests/bucket-1/74-grid-section/src/GridSectionSrc.al
+++ b/tests/bucket-1/74-grid-section/src/GridSectionSrc.al
@@ -1,0 +1,66 @@
+table 59500 "GS Product"
+{
+    DataClassification = CustomerContent;
+    fields
+    {
+        field(1; Code; Code[20]) { }
+        field(2; Name; Text[100]) { }
+        field(3; Price; Decimal) { }
+        field(4; Quantity; Integer) { }
+    }
+    keys
+    {
+        key(PK; Code) { Clustered = true; }
+    }
+}
+
+/// Card page containing a grid section — a multi-column layout directive.
+/// Grid sections group fields into columns for display; they have no runtime
+/// effect in a unit-test context. This proves grid sections do not block compilation.
+page 59500 "GS Product Card"
+{
+    PageType = Card;
+    SourceTable = "GS Product";
+
+    layout
+    {
+        area(Content)
+        {
+            group(General)
+            {
+                grid(TopGrid)
+                {
+                    field(Code; Rec.Code) { ApplicationArea = All; }
+                    field(Name; Rec.Name) { ApplicationArea = All; }
+                }
+                grid(PricingGrid)
+                {
+                    field(Price; Rec.Price) { ApplicationArea = All; }
+                    field(Quantity; Rec.Quantity) { ApplicationArea = All; }
+                }
+            }
+        }
+    }
+}
+
+/// Business logic helper — proves the compilation unit containing
+/// the page with grid sections compiles and executes logic correctly.
+codeunit 59500 "GS Product Helper"
+{
+    procedure CalcTotal(Price: Decimal; Quantity: Integer): Decimal
+    begin
+        exit(Price * Quantity);
+    end;
+
+    procedure IsExpensive(Price: Decimal): Boolean
+    begin
+        exit(Price > 100);
+    end;
+
+    procedure FormatLabel(Name: Text; Quantity: Integer): Text
+    begin
+        if Quantity = 0 then
+            exit(Name + ' (out of stock)');
+        exit(Name + ' (' + Format(Quantity) + ')');
+    end;
+}

--- a/tests/bucket-1/74-grid-section/test/GridSectionTests.al
+++ b/tests/bucket-1/74-grid-section/test/GridSectionTests.al
@@ -1,0 +1,58 @@
+codeunit 59501 "GS Grid Section Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Helper: Codeunit "GS Product Helper";
+
+    // -----------------------------------------------------------------------
+    // Positive: pages with grid sections compile; business logic runs
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure GridSection_CardPageCompiles_LogicRuns()
+    begin
+        // [GIVEN] A compilation unit containing a Card page with a grid section
+        // [WHEN]  Business logic in the same unit is called
+        // [THEN]  It executes — grid section does not block compilation
+        Assert.AreEqual(250, Helper.CalcTotal(50, 5), 'grid section: 50 * 5 must be 250');
+    end;
+
+    [Test]
+    procedure GridSection_MultipleGrids_Compile()
+    begin
+        // [GIVEN] A Card page with two grid sections (TopGrid and PricingGrid)
+        // [WHEN]  Business logic is called
+        // [THEN]  Multiple grid declarations in the same page compile
+        Assert.AreEqual(0, Helper.CalcTotal(100, 0), 'grid section: 100 * 0 must be 0');
+    end;
+
+    [Test]
+    procedure GridSection_IsExpensive_True()
+    begin
+        // Positive: price above threshold is expensive
+        Assert.IsTrue(Helper.IsExpensive(150), 'Price 150 must be expensive');
+    end;
+
+    [Test]
+    procedure GridSection_IsExpensive_False()
+    begin
+        // Negative: price at/below threshold is not expensive
+        Assert.IsFalse(Helper.IsExpensive(100), 'Price exactly 100 must not be expensive');
+    end;
+
+    [Test]
+    procedure GridSection_FormatLabel_InStock()
+    begin
+        // Positive: in-stock item includes quantity in label
+        Assert.AreEqual('Widget (10)', Helper.FormatLabel('Widget', 10), 'In-stock label must include quantity');
+    end;
+
+    [Test]
+    procedure GridSection_FormatLabel_OutOfStock()
+    begin
+        // Negative: out-of-stock item shows out-of-stock label
+        Assert.AreEqual('Widget (out of stock)', Helper.FormatLabel('Widget', 0), 'Zero quantity must show out-of-stock');
+    end;
+}


### PR DESCRIPTION
Closes #403

## Summary

Adds test suite `tests/bucket-1/74-grid-section/` proving that AL pages with `grid` layout sections compile and execute business logic correctly.

### Tests

- `GridSection_CardPageCompiles_LogicRuns` — Card page with a grid section does not block compilation
- `GridSection_MultipleGrids_Compile` — multiple grid sections in the same page compile
- `GridSection_IsExpensive_True/False` — positive/negative cases for helper logic
- `GridSection_FormatLabel_InStock/OutOfStock` — positive/negative cases proving the compilation unit runs

### Coverage

`docs/coverage.yaml`: `grid_section` → `covered`