### PR TITLE
test: addafter_action_modification coverage

### DIFF
--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -1025,7 +1025,9 @@ add_dataset_modification:
 addafter_action_modification:
   layer: syntax
   category: modification
-  status: gap
+  status: covered
+  tests:
+    - tests/bucket-1/68-addafter-action
 
 addafter_dataset_modification:
   layer: syntax

--- a/tests/bucket-1/68-addafter-action/al-runner.json
+++ b/tests/bucket-1/68-addafter-action/al-runner.json
@@ -1,0 +1,4 @@
+{
+  "sourcePath": "./src",
+  "testPath": "./test"
+}

--- a/tests/bucket-1/68-addafter-action/src/AddafterActionSrc.al
+++ b/tests/bucket-1/68-addafter-action/src/AddafterActionSrc.al
@@ -1,0 +1,107 @@
+/// Table backing the base page used by the page extension in this suite.
+table 50406 "AAA Product"
+{
+    DataClassification = CustomerContent;
+    fields
+    {
+        field(1; Code; Code[20]) { }
+        field(2; Description; Text[100]) { }
+    }
+    keys
+    {
+        key(PK; Code) { Clustered = true; }
+    }
+}
+
+/// Base page with a "New" action so the pageextension has something to addafter.
+page 50406 "AAA Product Card"
+{
+    PageType = Card;
+    SourceTable = "AAA Product";
+
+    actions
+    {
+        area(Processing)
+        {
+            action("New")
+            {
+                ApplicationArea = All;
+                trigger OnAction()
+                begin
+                end;
+            }
+        }
+    }
+}
+
+/// pageextension using addafter in the actions area (single action inserted).
+/// This is the exact construct issue #406 says fails to compile.
+pageextension 50406 "AAA Product Card After" extends "AAA Product Card"
+{
+    actions
+    {
+        addafter("New")
+        {
+            action(MyAction)
+            {
+                ApplicationArea = All;
+                Caption = 'My Action';
+                trigger OnAction()
+                var
+                    Helper: Codeunit "AAA Product Helper";
+                begin
+                    Message(Helper.GetMessage());
+                end;
+            }
+        }
+    }
+}
+
+/// pageextension using addafter in the actions area with multiple actions inserted.
+/// Proves addafter with an action group (multiple action bodies) compiles.
+pageextension 50407 "AAA Product Card AfterMulti" extends "AAA Product Card"
+{
+    actions
+    {
+        addafter("New")
+        {
+            action(ActionAlpha)
+            {
+                ApplicationArea = All;
+                Caption = 'Alpha';
+                trigger OnAction()
+                begin
+                end;
+            }
+            action(ActionBeta)
+            {
+                ApplicationArea = All;
+                Caption = 'Beta';
+                trigger OnAction()
+                begin
+                end;
+            }
+        }
+    }
+}
+
+/// Helper codeunit with business logic exercised by the tests.
+/// Proves that the compilation unit containing pageextensions with addafter
+/// in the actions area compiles and codeunits alongside remain callable.
+codeunit 50406 "AAA Product Helper"
+{
+    procedure GetMessage(): Text
+    begin
+        exit('hello');
+    end;
+
+    procedure AddWithBonus(a: Integer; b: Integer): Integer
+    begin
+        exit(a + b + 1);
+    end;
+
+    procedure Concat(a: Text; b: Text): Text
+    begin
+        exit(a + '|' + b);
+    end;
+}

--- a/tests/bucket-1/68-addafter-action/test/AddafterActionTest.al
+++ b/tests/bucket-1/68-addafter-action/test/AddafterActionTest.al
@@ -1,0 +1,74 @@
+codeunit 50968 "AAA Addafter Action Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    [Test]
+    procedure PageExtAddafterAction_CompilesAndHelperRuns()
+    var
+        Helper: Codeunit "AAA Product Helper";
+    begin
+        // Positive: the compilation unit containing pageextensions with `addafter` in
+        // the `actions` area must compile, and codeunits defined alongside them must
+        // be callable. This is what issue #406 says currently fails.
+        Assert.AreEqual('hello', Helper.GetMessage(), 'Helper.GetMessage must return hello');
+    end;
+
+    [Test]
+    procedure PageExtAddafterAction_AddWithBonus()
+    var
+        Helper: Codeunit "AAA Product Helper";
+    begin
+        // Proving: helper performs real work, not a no-op stub (issue #203 standard).
+        Assert.AreEqual(8, Helper.AddWithBonus(3, 4), 'AddWithBonus(3,4) must return 3+4+1=8');
+        Assert.AreEqual(1, Helper.AddWithBonus(0, 0), 'AddWithBonus(0,0) must return 0+0+1=1');
+        Assert.AreEqual(-4, Helper.AddWithBonus(-2, -3), 'AddWithBonus(-2,-3) must return -5+1=-4');
+    end;
+
+    [Test]
+    procedure PageExtAddafterAction_AddWithBonus_NotPlainSum()
+    var
+        Helper: Codeunit "AAA Product Helper";
+    begin
+        // Negative: guard against the no-op trap — AddWithBonus must NOT return a plain sum.
+        Assert.AreNotEqual(7, Helper.AddWithBonus(3, 4), 'AddWithBonus must not just return a+b');
+    end;
+
+    [Test]
+    procedure PageExtAddafterAction_Concat()
+    var
+        Helper: Codeunit "AAA Product Helper";
+    begin
+        // Proving concat logic runs in same compilation unit as pageextensions.
+        Assert.AreEqual('a|b', Helper.Concat('a', 'b'), 'Concat must join with | separator');
+        Assert.AreEqual('|', Helper.Concat('', ''), 'Concat of empties must still include separator');
+    end;
+
+    [Test]
+    procedure PageExtAddafterAction_Concat_SeparatorPresent()
+    var
+        Helper: Codeunit "AAA Product Helper";
+    begin
+        // Negative: Concat must NOT simply return a+b (which would miss the '|' separator).
+        Assert.AreNotEqual('ab', Helper.Concat('a', 'b'), 'Concat must not just return a+b without separator');
+    end;
+
+    [Test]
+    procedure PageExtAddafterAction_TableInCompilationUnit_Usable()
+    var
+        Product: Record "AAA Product";
+    begin
+        // Positive: the source table in the same compilation unit as the pageextensions
+        // must be usable — inserts/finds work, proving the compilation unit is live.
+        Product.Init();
+        Product.Code := 'SKU1';
+        Product.Description := 'Widget';
+        Product.Insert();
+
+        Product.Reset();
+        Assert.IsTrue(Product.Get('SKU1'), 'Product SKU1 must be retrievable after Insert');
+        Assert.AreEqual('Widget', Product.Description, 'Description must roundtrip through the table');
+    end;
+}


### PR DESCRIPTION
Closes #406

## Summary

Issue #406 flagged `addafter` inside a pageextension's `actions` area as an unhandled construct. A reproduction shows the runner **already** compiles and runs this pattern correctly — what was missing was a dedicated proving test. This mirrors how PRs #388/#398 (actionref_declaration) and #395/#400 (systemaction_declaration) were handled: the construct worked, but had no coverage.

## Changes

- `tests/bucket-1/68-addafter-action/` — new suite with two pageextensions that use `addafter` in the actions area (single action and multi-action insertion), a helper codeunit, and a backing table. Six proving tests exercise helper business logic (with no-op traps) and a table round-trip, so the whole compilation unit has to compile and stay live.
- `docs/coverage.yaml` — `addafter_action_modification` marked `covered`

## Verification

- 6/6 tests pass in the new suite
- Full bucket-1 regression: 583 pass (4 pre-existing environmental failures unrelated to this change — same ones as PR #377)

## Notes

The related action-area modifications (`addbefore_action_modification`, `addfirst_action_modification`, `addlast_action_modification`, `modify_action_modification`) are still `gap` in coverage.yaml — out of scope for this issue but candidates for follow-up PRs since they likely work for the same reason.