### PR TITLE
test: addfirst_action_modification coverage — pageextension addfirst in actions area (#413)

### DIFF
--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -1075,7 +1075,9 @@ addbefore_views_modification:
 addfirst_action_modification:
   layer: syntax
   category: modification
-  status: gap
+  status: covered
+  tests:
+    - tests/bucket-1/76-addfirst-action
 
 addfirst_dataset_modification:
   layer: syntax

--- a/tests/bucket-1/76-addfirst-action/src/AddfirstActionSrc.al
+++ b/tests/bucket-1/76-addfirst-action/src/AddfirstActionSrc.al
@@ -1,0 +1,107 @@
+/// Table backing the base page used by the page extension in this suite.
+table 50796 "AFA Product"
+{
+    DataClassification = CustomerContent;
+    fields
+    {
+        field(1; Code; Code[20]) { }
+        field(2; Description; Text[100]) { }
+    }
+    keys
+    {
+        key(PK; Code) { Clustered = true; }
+    }
+}
+
+/// Base page with an existing action so the pageextension has something to addfirst against.
+page 50796 "AFA Product Card"
+{
+    PageType = Card;
+    SourceTable = "AFA Product";
+
+    actions
+    {
+        area(Processing)
+        {
+            action("Existing")
+            {
+                ApplicationArea = All;
+                trigger OnAction()
+                begin
+                end;
+            }
+        }
+    }
+}
+
+/// pageextension using addfirst in the actions area (single action inserted).
+/// This is the exact construct issue #413 says fails to compile.
+pageextension 50796 "AFA Product Card First" extends "AFA Product Card"
+{
+    actions
+    {
+        addfirst(Processing)
+        {
+            action(MyFirstAction)
+            {
+                ApplicationArea = All;
+                Caption = 'My First Action';
+                trigger OnAction()
+                var
+                    Helper: Codeunit "AFA Product Helper";
+                begin
+                    Message(Helper.GetMessage());
+                end;
+            }
+        }
+    }
+}
+
+/// pageextension using addfirst in the actions area with multiple actions inserted.
+/// Proves addfirst with multiple action bodies compiles.
+pageextension 50797 "AFA Product Card FirstMulti" extends "AFA Product Card"
+{
+    actions
+    {
+        addfirst(Processing)
+        {
+            action(ActionAlpha)
+            {
+                ApplicationArea = All;
+                Caption = 'Alpha';
+                trigger OnAction()
+                begin
+                end;
+            }
+            action(ActionBeta)
+            {
+                ApplicationArea = All;
+                Caption = 'Beta';
+                trigger OnAction()
+                begin
+                end;
+            }
+        }
+    }
+}
+
+/// Helper codeunit with business logic exercised by the tests.
+/// Proves that the compilation unit containing pageextensions with addfirst
+/// in the actions area compiles and codeunits alongside remain callable.
+codeunit 50796 "AFA Product Helper"
+{
+    procedure GetMessage(): Text
+    begin
+        exit('first');
+    end;
+
+    procedure AddWithBonus(a: Integer; b: Integer): Integer
+    begin
+        exit(a + b + 1);
+    end;
+
+    procedure Concat(a: Text; b: Text): Text
+    begin
+        exit(a + '|' + b);
+    end;
+}

--- a/tests/bucket-1/76-addfirst-action/test/AddfirstActionTest.al
+++ b/tests/bucket-1/76-addfirst-action/test/AddfirstActionTest.al
@@ -1,0 +1,74 @@
+codeunit 50798 "AFA Addfirst Action Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    [Test]
+    procedure PageExtAddfirstAction_CompilesAndHelperRuns()
+    var
+        Helper: Codeunit "AFA Product Helper";
+    begin
+        // Positive: the compilation unit containing pageextensions with `addfirst` in
+        // the `actions` area must compile, and codeunits defined alongside them must
+        // be callable. This is what issue #413 says currently fails.
+        Assert.AreEqual('first', Helper.GetMessage(), 'Helper.GetMessage must return first');
+    end;
+
+    [Test]
+    procedure PageExtAddfirstAction_AddWithBonus()
+    var
+        Helper: Codeunit "AFA Product Helper";
+    begin
+        // Proving: helper performs real work, not a no-op stub (issue #203 standard).
+        Assert.AreEqual(8, Helper.AddWithBonus(3, 4), 'AddWithBonus(3,4) must return 3+4+1=8');
+        Assert.AreEqual(1, Helper.AddWithBonus(0, 0), 'AddWithBonus(0,0) must return 0+0+1=1');
+        Assert.AreEqual(-4, Helper.AddWithBonus(-2, -3), 'AddWithBonus(-2,-3) must return -5+1=-4');
+    end;
+
+    [Test]
+    procedure PageExtAddfirstAction_AddWithBonus_NotPlainSum()
+    var
+        Helper: Codeunit "AFA Product Helper";
+    begin
+        // Negative: guard against the no-op trap — AddWithBonus must NOT return a plain sum.
+        Assert.AreNotEqual(7, Helper.AddWithBonus(3, 4), 'AddWithBonus must not just return a+b');
+    end;
+
+    [Test]
+    procedure PageExtAddfirstAction_Concat()
+    var
+        Helper: Codeunit "AFA Product Helper";
+    begin
+        // Proving concat logic runs in same compilation unit as pageextensions.
+        Assert.AreEqual('a|b', Helper.Concat('a', 'b'), 'Concat must join with | separator');
+        Assert.AreEqual('|', Helper.Concat('', ''), 'Concat of empties must still include separator');
+    end;
+
+    [Test]
+    procedure PageExtAddfirstAction_Concat_SeparatorPresent()
+    var
+        Helper: Codeunit "AFA Product Helper";
+    begin
+        // Negative: Concat must NOT simply return a+b (which would miss the '|' separator).
+        Assert.AreNotEqual('ab', Helper.Concat('a', 'b'), 'Concat must not just return a+b without separator');
+    end;
+
+    [Test]
+    procedure PageExtAddfirstAction_TableInCompilationUnit_Usable()
+    var
+        Product: Record "AFA Product";
+    begin
+        // Positive: the source table in the same compilation unit as the pageextensions
+        // must be usable — inserts/finds work, proving the compilation unit is live.
+        Product.Init();
+        Product.Code := 'SKU1';
+        Product.Description := 'Widget';
+        Product.Insert();
+
+        Product.Reset();
+        Assert.IsTrue(Product.Get('SKU1'), 'Product SKU1 must be retrievable after Insert');
+        Assert.AreEqual('Widget', Product.Description, 'Description must roundtrip through the table');
+    end;
+}


### PR DESCRIPTION
Closes #413

Issue #413 flagged `addfirst` inside a pageextension's `actions` area as an unhandled construct. A reproduction shows the runner already compiles and runs this pattern correctly (same as `addafter`/`addbefore` in actions, covered by #411/#412); what was missing was a dedicated proving test.

## Changes

- Adds `tests/bucket-1/76-addfirst-action/` with:
  - `src/AddfirstActionSrc.al`: table, base page with an existing action, two pageextensions using `addfirst` in the `actions` area (single and multi-action), and a helper codeunit
  - `test/AddfirstActionTest.al`: six proving tests (positive and negative) covering helper business logic and table round-trip
- Marks `addfirst_action_modification` as `covered` in `docs/coverage.yaml`

## Test plan

- [ ] GREEN: all six tests pass — `addfirst` in actions compiles correctly without any rewriter changes
- [ ] Full regression unaffected