### PR TITLE
test: addlast_action_modification coverage

### DIFF
--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -1104,7 +1104,9 @@ addfirst_views_modification:
 addlast_action_modification:
   layer: syntax
   category: modification
-  status: gap
+  status: covered
+  tests:
+    - tests/bucket-1/78-addlast-action
 
 addlast_dataset_modification:
   layer: syntax

--- a/tests/bucket-1/78-addlast-action/al-runner.json
+++ b/tests/bucket-1/78-addlast-action/al-runner.json
@@ -1,0 +1,4 @@
+{
+  "sourcePath": "./src",
+  "testPath": "./test"
+}

--- a/tests/bucket-1/78-addlast-action/src/AddlastActionSrc.al
+++ b/tests/bucket-1/78-addlast-action/src/AddlastActionSrc.al
@@ -1,0 +1,108 @@
+/// Table backing the base page used by the page extension in this suite.
+table 50786 "ALA Product"
+{
+    DataClassification = CustomerContent;
+    fields
+    {
+        field(1; Code; Code[20]) { }
+        field(2; Description; Text[100]) { }
+    }
+    keys
+    {
+        key(PK; Code) { Clustered = true; }
+    }
+}
+
+/// Base page with an existing action so the pageextension has something to addlast inside.
+page 50786 "ALA Product Card"
+{
+    PageType = Card;
+    SourceTable = "ALA Product";
+
+    actions
+    {
+        area(Processing)
+        {
+            action(ExistingAction)
+            {
+                ApplicationArea = All;
+                Caption = 'Existing';
+                trigger OnAction()
+                begin
+                end;
+            }
+        }
+    }
+}
+
+/// pageextension using addlast in the actions area (single action appended).
+/// This is the exact construct issue #415 says fails to compile.
+pageextension 50786 "ALA Product Card Last" extends "ALA Product Card"
+{
+    actions
+    {
+        addlast(Processing)
+        {
+            action(LastAction)
+            {
+                ApplicationArea = All;
+                Caption = 'Last';
+                trigger OnAction()
+                var
+                    Helper: Codeunit "ALA Product Helper";
+                begin
+                    Message(Helper.GetLabel());
+                end;
+            }
+        }
+    }
+}
+
+/// pageextension using addlast in the actions area with multiple actions appended.
+/// Proves addlast with multiple action bodies compiles.
+pageextension 50787 "ALA Product Card LastMulti" extends "ALA Product Card"
+{
+    actions
+    {
+        addlast(Processing)
+        {
+            action(ActionAlpha)
+            {
+                ApplicationArea = All;
+                Caption = 'Alpha';
+                trigger OnAction()
+                begin
+                end;
+            }
+            action(ActionBeta)
+            {
+                ApplicationArea = All;
+                Caption = 'Beta';
+                trigger OnAction()
+                begin
+                end;
+            }
+        }
+    }
+}
+
+/// Helper codeunit with business logic exercised by the tests.
+/// Proves the compilation unit containing pageextensions with addlast in the
+/// actions area compiles and codeunits alongside remain callable.
+codeunit 50786 "ALA Product Helper"
+{
+    procedure GetLabel(): Text
+    begin
+        exit('LastAction');
+    end;
+
+    procedure MultiplyPlusOne(a: Integer; b: Integer): Integer
+    begin
+        exit(a * b + 1);
+    end;
+
+    procedure Wrap(s: Text): Text
+    begin
+        exit('[' + s + ']');
+    end;
+}

--- a/tests/bucket-1/78-addlast-action/test/AddlastActionTest.al
+++ b/tests/bucket-1/78-addlast-action/test/AddlastActionTest.al
@@ -1,0 +1,74 @@
+codeunit 50988 "ALA Addlast Action Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    [Test]
+    procedure PageExtAddlastAction_CompilesAndHelperRuns()
+    var
+        Helper: Codeunit "ALA Product Helper";
+    begin
+        // Positive: the compilation unit containing pageextensions with `addlast` in
+        // the `actions` area must compile, and codeunits defined alongside them must
+        // be callable. This is what issue #415 says currently fails.
+        Assert.AreEqual('LastAction', Helper.GetLabel(), 'Helper.GetLabel must return LastAction');
+    end;
+
+    [Test]
+    procedure PageExtAddlastAction_MultiplyPlusOne()
+    var
+        Helper: Codeunit "ALA Product Helper";
+    begin
+        // Proving: helper performs real work, not a no-op stub (issue #203 standard).
+        Assert.AreEqual(13, Helper.MultiplyPlusOne(3, 4), 'MultiplyPlusOne(3,4) must return 3*4+1=13');
+        Assert.AreEqual(1, Helper.MultiplyPlusOne(0, 0), 'MultiplyPlusOne(0,0) must return 0*0+1=1');
+        Assert.AreEqual(-5, Helper.MultiplyPlusOne(2, -3), 'MultiplyPlusOne(2,-3) must return 2*-3+1=-5');
+    end;
+
+    [Test]
+    procedure PageExtAddlastAction_MultiplyPlusOne_NotPlainSum()
+    var
+        Helper: Codeunit "ALA Product Helper";
+    begin
+        // Negative: guard against the no-op trap — MultiplyPlusOne must NOT just add a+b.
+        Assert.AreNotEqual(7, Helper.MultiplyPlusOne(3, 4), 'MultiplyPlusOne must not just return a+b');
+    end;
+
+    [Test]
+    procedure PageExtAddlastAction_Wrap()
+    var
+        Helper: Codeunit "ALA Product Helper";
+    begin
+        // Proving Wrap runs in same compilation unit as pageextensions.
+        Assert.AreEqual('[hello]', Helper.Wrap('hello'), 'Wrap must add brackets');
+        Assert.AreEqual('[]', Helper.Wrap(''), 'Wrap of empty must be just brackets');
+    end;
+
+    [Test]
+    procedure PageExtAddlastAction_Wrap_BracketsPresent()
+    var
+        Helper: Codeunit "ALA Product Helper";
+    begin
+        // Negative: Wrap must NOT simply return s (no brackets would be the no-op trap).
+        Assert.AreNotEqual('hello', Helper.Wrap('hello'), 'Wrap must not return the raw string');
+    end;
+
+    [Test]
+    procedure PageExtAddlastAction_TableInCompilationUnit_Usable()
+    var
+        Product: Record "ALA Product";
+    begin
+        // Positive: the source table in the same compilation unit as the pageextensions
+        // must be usable — insert and get work, proving the compilation unit is live.
+        Product.Init();
+        Product.Code := 'SKU1';
+        Product.Description := 'Widget';
+        Product.Insert();
+
+        Product.Reset();
+        Assert.IsTrue(Product.Get('SKU1'), 'Product SKU1 must be retrievable after Insert');
+        Assert.AreEqual('Widget', Product.Description, 'Description must roundtrip through the table');
+    end;
+}


### PR DESCRIPTION
Closes #415

## Summary

Mirrors the pattern used in PRs #411 (addafter), #413 (addbefore), and #414 (addfirst) — the feature already works in the runner; this PR adds a proving test suite and marks coverage.

## Changes

- `tests/bucket-1/78-addlast-action/` — new suite with two pageextensions using `addlast` in the actions area (single action and multi-action append), plus a helper codeunit and backing table. Six proving tests with no-op traps and a table round-trip.
- `docs/coverage.yaml` — `addlast_action_modification` marked `covered`

## Verification

- 6/6 new tests pass
- Full bucket-1 regression: 602 pass (same 4 pre-existing environmental failures as prior PRs)