### PR TITLE
test: addfirst_dataset_modification coverage — reportextension addfirst in dataset area (#416)

### DIFF
--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -1086,7 +1086,9 @@ addfirst_action_modification:
 addfirst_dataset_modification:
   layer: syntax
   category: modification
-  status: gap
+  status: covered
+  tests:
+    - tests/bucket-2/135-addfirst-dataset
 
 addfirst_fieldgroup_modification:
   layer: syntax

--- a/tests/bucket-2/135-addfirst-dataset/src/AddfirstDatasetSrc.al
+++ b/tests/bucket-2/135-addfirst-dataset/src/AddfirstDatasetSrc.al
@@ -1,0 +1,62 @@
+/// Table used as the dataitem source for the base report.
+table 59300 "AFDS Item"
+{
+    DataClassification = CustomerContent;
+    fields
+    {
+        field(1; "No."; Code[20]) { }
+        field(2; Description; Text[100]) { }
+        field(3; Quantity; Integer) { }
+    }
+    keys
+    {
+        key(PK; "No.") { Clustered = true; }
+    }
+}
+
+/// Base report with a dataset — reportextension will prepend columns using addfirst.
+report 59300 "AFDS Base Report"
+{
+    dataset
+    {
+        dataitem(AFDSItem; "AFDS Item")
+        {
+            column(Description; Description) { }
+            column(Quantity; Quantity) { }
+        }
+    }
+}
+
+/// reportextension using addfirst in the dataset area (prepend a column).
+/// This is the exact construct issue #416 says fails to compile.
+reportextension 59301 "AFDS Report Ext" extends "AFDS Base Report"
+{
+    dataset
+    {
+        addfirst(AFDSItem)
+        {
+            column(ItemNo; "No.") { }
+        }
+    }
+}
+
+/// Helper codeunit with business logic exercised by the tests.
+/// Proves that the compilation unit containing reportextensions with addfirst
+/// in the dataset area compiles and codeunits alongside remain callable.
+codeunit 59300 "AFDS Helper"
+{
+    procedure GetLabel(): Text
+    begin
+        exit('dataset first');
+    end;
+
+    procedure AddWithBonus(a: Integer; b: Integer): Integer
+    begin
+        exit(a + b + 1);
+    end;
+
+    procedure Concat(a: Text; b: Text): Text
+    begin
+        exit(a + '|' + b);
+    end;
+}

--- a/tests/bucket-2/135-addfirst-dataset/src/AddfirstDatasetSrc.al
+++ b/tests/bucket-2/135-addfirst-dataset/src/AddfirstDatasetSrc.al
@@ -4,38 +4,60 @@ table 59300 "AFDS Item"
     DataClassification = CustomerContent;
     fields
     {
-        field(1; "No."; Code[20]) { }
+        field(1; Code; Code[20]) { }
         field(2; Description; Text[100]) { }
         field(3; Quantity; Integer) { }
     }
     keys
     {
-        key(PK; "No.") { Clustered = true; }
+        key(PK; Code) { Clustered = true; }
     }
 }
 
-/// Base report with a dataset — reportextension will prepend columns using addfirst.
+/// Extra table used as a nested child dataitem in the report extension.
+table 59301 "AFDS Sub"
+{
+    DataClassification = CustomerContent;
+    fields
+    {
+        field(1; ParentCode; Code[20]) { }
+        field(2; Note; Text[100]) { }
+    }
+    keys
+    {
+        key(PK; ParentCode) { Clustered = true; }
+    }
+}
+
+/// Base report with a single dataitem — the reportextension will add a child
+/// dataitem at the beginning using addfirst.
 report 59300 "AFDS Base Report"
 {
     dataset
     {
         dataitem(AFDSItem; "AFDS Item")
         {
-            column(Description; Description) { }
-            column(Quantity; Quantity) { }
+            column(ItemCode; Code) { }
+            column(ItemDescription; Description) { }
+            column(ItemQuantity; Quantity) { }
         }
     }
 }
 
-/// reportextension using addfirst in the dataset area (prepend a column).
+/// reportextension using addfirst in the dataset area — adds a new child dataitem
+/// as the first nested dataitem inside AFDSItem.
 /// This is the exact construct issue #416 says fails to compile.
-reportextension 59301 "AFDS Report Ext" extends "AFDS Base Report"
+reportextension 59302 "AFDS Report Ext" extends "AFDS Base Report"
 {
     dataset
     {
         addfirst(AFDSItem)
         {
-            column(ItemNo; "No.") { }
+            dataitem(AFDSSub; "AFDS Sub")
+            {
+                column(SubParentCode; ParentCode) { }
+                column(SubNote; Note) { }
+            }
         }
     }
 }

--- a/tests/bucket-2/135-addfirst-dataset/test/AddfirstDatasetTest.al
+++ b/tests/bucket-2/135-addfirst-dataset/test/AddfirstDatasetTest.al
@@ -63,7 +63,7 @@ codeunit 59302 "AFDS Addfirst Dataset Test"
         // Positive: the source table in the same compilation unit as the reportextensions
         // must be usable — inserts/finds work, proving the compilation unit is live.
         Item.Init();
-        Item."No." := 'ITEM1';
+        Item.Code := 'ITEM1';
         Item.Description := 'Test Item';
         Item.Quantity := 5;
         Item.Insert();

--- a/tests/bucket-2/135-addfirst-dataset/test/AddfirstDatasetTest.al
+++ b/tests/bucket-2/135-addfirst-dataset/test/AddfirstDatasetTest.al
@@ -1,0 +1,76 @@
+codeunit 59302 "AFDS Addfirst Dataset Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    [Test]
+    procedure ReportExtAddfirstDataset_CompilesAndHelperRuns()
+    var
+        Helper: Codeunit "AFDS Helper";
+    begin
+        // Positive: the compilation unit containing reportextensions with `addfirst` in
+        // the `dataset` area must compile, and codeunits defined alongside them must
+        // be callable. This is what issue #416 says currently fails.
+        Assert.AreEqual('dataset first', Helper.GetLabel(), 'Helper.GetLabel must return dataset first');
+    end;
+
+    [Test]
+    procedure ReportExtAddfirstDataset_AddWithBonus()
+    var
+        Helper: Codeunit "AFDS Helper";
+    begin
+        // Proving: helper performs real work, not a no-op stub (issue #203 standard).
+        Assert.AreEqual(8, Helper.AddWithBonus(3, 4), 'AddWithBonus(3,4) must return 3+4+1=8');
+        Assert.AreEqual(1, Helper.AddWithBonus(0, 0), 'AddWithBonus(0,0) must return 0+0+1=1');
+        Assert.AreEqual(-4, Helper.AddWithBonus(-2, -3), 'AddWithBonus(-2,-3) must return -5+1=-4');
+    end;
+
+    [Test]
+    procedure ReportExtAddfirstDataset_AddWithBonus_NotPlainSum()
+    var
+        Helper: Codeunit "AFDS Helper";
+    begin
+        // Negative: guard against the no-op trap — AddWithBonus must NOT return a plain sum.
+        Assert.AreNotEqual(7, Helper.AddWithBonus(3, 4), 'AddWithBonus must not just return a+b');
+    end;
+
+    [Test]
+    procedure ReportExtAddfirstDataset_Concat()
+    var
+        Helper: Codeunit "AFDS Helper";
+    begin
+        // Proving concat logic runs in same compilation unit as reportextensions.
+        Assert.AreEqual('a|b', Helper.Concat('a', 'b'), 'Concat must join with | separator');
+        Assert.AreEqual('|', Helper.Concat('', ''), 'Concat of empties must still include separator');
+    end;
+
+    [Test]
+    procedure ReportExtAddfirstDataset_Concat_SeparatorPresent()
+    var
+        Helper: Codeunit "AFDS Helper";
+    begin
+        // Negative: Concat must NOT simply return a+b (which would miss the '|' separator).
+        Assert.AreNotEqual('ab', Helper.Concat('a', 'b'), 'Concat must not just return a+b without separator');
+    end;
+
+    [Test]
+    procedure ReportExtAddfirstDataset_TableInCompilationUnit_Usable()
+    var
+        Item: Record "AFDS Item";
+    begin
+        // Positive: the source table in the same compilation unit as the reportextensions
+        // must be usable — inserts/finds work, proving the compilation unit is live.
+        Item.Init();
+        Item."No." := 'ITEM1';
+        Item.Description := 'Test Item';
+        Item.Quantity := 5;
+        Item.Insert();
+
+        Item.Reset();
+        Assert.IsTrue(Item.Get('ITEM1'), 'ITEM1 must be retrievable after Insert');
+        Assert.AreEqual('Test Item', Item.Description, 'Description must roundtrip through the table');
+        Assert.AreEqual(5, Item.Quantity, 'Quantity must roundtrip through the table');
+    end;
+}


### PR DESCRIPTION
Closes #416

Issue #416 flagged `addfirst` inside a reportextension's `dataset` area as an unhandled construct. A reproduction shows the runner already compiles and runs this pattern correctly; what was missing was a dedicated proving test.

## Changes

- Adds `tests/bucket-2/135-addfirst-dataset/` with:
  - `src/AddfirstDatasetSrc.al`: backing table, base report with dataset, reportextension using `addfirst` in dataset area, and a helper codeunit
  - `test/AddfirstDatasetTest.al`: six proving tests (positive and negative) covering helper business logic and table round-trip
- Marks `addfirst_dataset_modification` as `covered` in `docs/coverage.yaml`

## Test plan

- [ ] GREEN: all six tests pass — `addfirst` in reportextension dataset compiles correctly without any rewriter changes
- [ ] Full regression unaffected