### PR TITLE
feat: addlast_dataset_modification coverage — reportextension addlast() in dataset area (#420)

### DIFF
--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -1133,7 +1133,9 @@ addlast_action_modification:
 addlast_dataset_modification:
   layer: syntax
   category: modification
-  status: gap
+  status: covered
+  tests:
+    - tests/bucket-2/136-addlast-dataset
 
 addlast_fieldgroup_modification:
   layer: syntax

--- a/tests/bucket-2/136-addlast-dataset/src/AddlastDatasetSrc.al
+++ b/tests/bucket-2/136-addlast-dataset/src/AddlastDatasetSrc.al
@@ -1,0 +1,84 @@
+/// Table used as the dataitem source for the base report.
+table 59320 "ALDS Item"
+{
+    DataClassification = CustomerContent;
+    fields
+    {
+        field(1; Code; Code[20]) { }
+        field(2; Description; Text[100]) { }
+        field(3; Quantity; Integer) { }
+    }
+    keys
+    {
+        key(PK; Code) { Clustered = true; }
+    }
+}
+
+/// Extra table used as a nested child dataitem in the report extension.
+table 59321 "ALDS Sub"
+{
+    DataClassification = CustomerContent;
+    fields
+    {
+        field(1; ParentCode; Code[20]) { }
+        field(2; Note; Text[100]) { }
+    }
+    keys
+    {
+        key(PK; ParentCode) { Clustered = true; }
+    }
+}
+
+/// Base report with a single dataitem — the reportextension will add a child
+/// dataitem at the end using addlast.
+report 59320 "ALDS Base Report"
+{
+    dataset
+    {
+        dataitem(ALDSItem; "ALDS Item")
+        {
+            column(ItemCode; Code) { }
+            column(ItemDescription; Description) { }
+            column(ItemQuantity; Quantity) { }
+        }
+    }
+}
+
+/// reportextension using addlast in the dataset area — adds a new child dataitem
+/// as the last nested dataitem inside ALDSItem.
+/// This is the exact construct issue #420 says fails to compile.
+reportextension 59322 "ALDS Report Ext" extends "ALDS Base Report"
+{
+    dataset
+    {
+        addlast(ALDSItem)
+        {
+            dataitem(ALDSSub; "ALDS Sub")
+            {
+                column(SubParentCode; ParentCode) { }
+                column(SubNote; Note) { }
+            }
+        }
+    }
+}
+
+/// Helper codeunit with business logic exercised by the tests.
+/// Proves that the compilation unit containing reportextensions with addlast
+/// in the dataset area compiles and codeunits alongside remain callable.
+codeunit 59320 "ALDS Helper"
+{
+    procedure GetLabel(): Text
+    begin
+        exit('dataset last');
+    end;
+
+    procedure AddWithBonus(a: Integer; b: Integer): Integer
+    begin
+        exit(a + b + 1);
+    end;
+
+    procedure Concat(a: Text; b: Text): Text
+    begin
+        exit(a + '|' + b);
+    end;
+}

--- a/tests/bucket-2/136-addlast-dataset/test/AddlastDatasetTest.al
+++ b/tests/bucket-2/136-addlast-dataset/test/AddlastDatasetTest.al
@@ -1,0 +1,76 @@
+codeunit 59322 "ALDS Addlast Dataset Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    [Test]
+    procedure ReportExtAddlastDataset_CompilesAndHelperRuns()
+    var
+        Helper: Codeunit "ALDS Helper";
+    begin
+        // Positive: the compilation unit containing reportextensions with `addlast` in
+        // the `dataset` area must compile, and codeunits defined alongside them must
+        // be callable. This is what issue #420 says currently fails.
+        Assert.AreEqual('dataset last', Helper.GetLabel(), 'Helper.GetLabel must return dataset last');
+    end;
+
+    [Test]
+    procedure ReportExtAddlastDataset_AddWithBonus()
+    var
+        Helper: Codeunit "ALDS Helper";
+    begin
+        // Proving: helper performs real work, not a no-op stub (issue #203 standard).
+        Assert.AreEqual(8, Helper.AddWithBonus(3, 4), 'AddWithBonus(3,4) must return 3+4+1=8');
+        Assert.AreEqual(1, Helper.AddWithBonus(0, 0), 'AddWithBonus(0,0) must return 0+0+1=1');
+        Assert.AreEqual(-4, Helper.AddWithBonus(-2, -3), 'AddWithBonus(-2,-3) must return -5+1=-4');
+    end;
+
+    [Test]
+    procedure ReportExtAddlastDataset_AddWithBonus_NotPlainSum()
+    var
+        Helper: Codeunit "ALDS Helper";
+    begin
+        // Negative: guard against the no-op trap — AddWithBonus must NOT return a plain sum.
+        Assert.AreNotEqual(7, Helper.AddWithBonus(3, 4), 'AddWithBonus must not just return a+b');
+    end;
+
+    [Test]
+    procedure ReportExtAddlastDataset_Concat()
+    var
+        Helper: Codeunit "ALDS Helper";
+    begin
+        // Proving concat logic runs in same compilation unit as reportextensions.
+        Assert.AreEqual('a|b', Helper.Concat('a', 'b'), 'Concat must join with | separator');
+        Assert.AreEqual('|', Helper.Concat('', ''), 'Concat of empties must still include separator');
+    end;
+
+    [Test]
+    procedure ReportExtAddlastDataset_Concat_SeparatorPresent()
+    var
+        Helper: Codeunit "ALDS Helper";
+    begin
+        // Negative: Concat must NOT simply return a+b (which would miss the '|' separator).
+        Assert.AreNotEqual('ab', Helper.Concat('a', 'b'), 'Concat must not just return a+b without separator');
+    end;
+
+    [Test]
+    procedure ReportExtAddlastDataset_TableInCompilationUnit_Usable()
+    var
+        Item: Record "ALDS Item";
+    begin
+        // Positive: the source table in the same compilation unit as the reportextensions
+        // must be usable — inserts/finds work, proving the compilation unit is live.
+        Item.Init();
+        Item.Code := 'ITEM1';
+        Item.Description := 'Test Item';
+        Item.Quantity := 5;
+        Item.Insert();
+
+        Item.Reset();
+        Assert.IsTrue(Item.Get('ITEM1'), 'ITEM1 must be retrievable after Insert');
+        Assert.AreEqual('Test Item', Item.Description, 'Description must roundtrip through the table');
+        Assert.AreEqual(5, Item.Quantity, 'Quantity must roundtrip through the table');
+    end;
+}


### PR DESCRIPTION
Closes #420

Adds proving tests for `reportextension` objects using `addlast` in the `dataset` area alongside helper codeunits and tables. Verifies the compilation unit compiles and all codeunit logic remains callable.

## Test approach

Suite `tests/bucket-2/136-addlast-dataset/` with 6 tests:

- **CompilesAndHelperRuns** — proves the compilation unit compiles and `GetLabel()` returns the correct value
- **AddWithBonus** — proves helper performs real arithmetic (`a + b + 1`), not a no-op
- **AddWithBonus_NotPlainSum** — negative: ensures the `+1` bonus is included (guards against plain-sum mock)
- **Concat** — proves `|` separator is present in joined strings
- **Concat_SeparatorPresent** — negative: ensures `Concat` is not just `a + b`
- **TableInCompilationUnit_Usable** — proves the table defined alongside the reportextension is fully usable (Insert/Get roundtrip)

`docs/coverage.yaml`: `addlast_dataset_modification` → `covered`