### PR TITLE
test: movefirst_modification coverage — pageextension movefirst() in layout

### DIFF
--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -1188,7 +1188,9 @@ movebefore_modification:
 movefirst_modification:
   layer: syntax
   category: modification
-  status: gap
+  status: covered
+  tests:
+    - tests/bucket-2/137-movefirst
 
 movelast_modification:
   layer: syntax

--- a/tests/bucket-2/137-movefirst/src/MovefirstSrc.al
+++ b/tests/bucket-2/137-movefirst/src/MovefirstSrc.al
@@ -1,0 +1,67 @@
+/// Table backing the base page used by the page extension in this suite.
+table 60200 "MF Item"
+{
+    DataClassification = CustomerContent;
+    fields
+    {
+        field(1; Code; Code[20]) { }
+        field(2; Description; Text[100]) { }
+        field(3; Price; Decimal) { }
+        field(4; Quantity; Integer) { }
+    }
+    keys
+    {
+        key(PK; Code) { Clustered = true; }
+    }
+}
+
+/// Base page with multiple fields in the layout so the pageextension has
+/// something to reposition with movefirst.
+page 60200 "MF Item Card"
+{
+    PageType = Card;
+    SourceTable = "MF Item";
+
+    layout
+    {
+        area(Content)
+        {
+            field(CodeField; Rec.Code) { ApplicationArea = All; }
+            field(DescriptionField; Rec.Description) { ApplicationArea = All; }
+            field(PriceField; Rec.Price) { ApplicationArea = All; }
+            field(QuantityField; Rec.Quantity) { ApplicationArea = All; }
+        }
+    }
+}
+
+/// pageextension using movefirst in the layout area — moves PriceField and
+/// QuantityField to be first in the content area.
+/// movefirst is a layout reorder directive; it has no effect on runtime data
+/// but must not block compilation.
+pageextension 60200 "MF Item Card Ext" extends "MF Item Card"
+{
+    layout
+    {
+        movefirst(content; PriceField, QuantityField)
+    }
+}
+
+/// Business logic helper — proves that the compilation unit containing a
+/// pageextension with movefirst compiles and executes logic correctly.
+codeunit 60200 "MF Helper"
+{
+    procedure GetLabel(): Text
+    begin
+        exit('movefirst ok');
+    end;
+
+    procedure CalcTotal(Price: Decimal; Qty: Integer): Decimal
+    begin
+        exit(Price * Qty);
+    end;
+
+    procedure FormatCode(Code: Code[20]): Text
+    begin
+        exit('[' + Code + ']');
+    end;
+}

--- a/tests/bucket-2/137-movefirst/test/MovefirstTests.al
+++ b/tests/bucket-2/137-movefirst/test/MovefirstTests.al
@@ -1,0 +1,57 @@
+codeunit 60201 "MF Movefirst Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Helper: Codeunit "MF Helper";
+
+    // -----------------------------------------------------------------------
+    // Positive: pageextension with movefirst compiles; logic runs
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure Movefirst_PageExtCompiles_LogicRuns()
+    begin
+        // [GIVEN] A pageextension using movefirst() in the layout area
+        // [WHEN]  Business logic in the same compilation unit is called
+        // [THEN]  It executes — movefirst() declaration does not block compilation
+        Assert.AreEqual('movefirst ok', Helper.GetLabel(), 'Helper must return expected label');
+    end;
+
+    [Test]
+    procedure Movefirst_WrongValue_Fails()
+    begin
+        // Negative: asserterror proves the assertion fires for wrong values
+        asserterror Assert.AreEqual('Wrong', Helper.GetLabel(), '');
+        Assert.ExpectedError('Wrong');
+    end;
+
+    [Test]
+    procedure Movefirst_CalcTotal_Positive()
+    begin
+        // Positive: price * qty computes correctly
+        Assert.AreEqual(250, Helper.CalcTotal(25, 10), 'CalcTotal(25,10) must be 250');
+    end;
+
+    [Test]
+    procedure Movefirst_CalcTotal_Zero()
+    begin
+        // Edge case: zero quantity gives zero total
+        Assert.AreEqual(0, Helper.CalcTotal(25, 0), 'CalcTotal with zero qty must be 0');
+    end;
+
+    [Test]
+    procedure Movefirst_FormatCode_NonEmpty()
+    begin
+        // Positive: code is wrapped in brackets
+        Assert.AreEqual('[ITM001]', Helper.FormatCode('ITM001'), 'FormatCode must wrap in brackets');
+    end;
+
+    [Test]
+    procedure Movefirst_FormatCode_Empty()
+    begin
+        // Edge case: empty code still formats with brackets
+        Assert.AreEqual('[]', Helper.FormatCode(''), 'FormatCode with empty code must produce []');
+    end;
+}


### PR DESCRIPTION
Closes #437

Adds test suite `tests/bucket-2/137-movefirst/` proving that a `pageextension` using `movefirst()` in the `layout` area compiles and runs correctly.

`movefirst` is a pure BC-compiler layout reorder directive (like `movebefore`, which is already covered). The runner does not need to implement field reordering — the directive just must not block compilation or test execution.

## Changes

- `tests/bucket-2/137-movefirst/src/MovefirstSrc.al` — table, base page, pageextension with `movefirst(content; PriceField, QuantityField)`, and helper codeunit
- `tests/bucket-2/137-movefirst/test/MovefirstTests.al` — 6 tests (positive + negative + edge cases)
- `docs/coverage.yaml` — `movefirst_modification` updated from `gap` to `covered`