### PR TITLE
feat: addlast_fieldgroup_modification coverage — tableextension addlast() in fieldgroups (#443)

### DIFF
--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -1143,7 +1143,9 @@ addlast_dataset_modification:
 addlast_fieldgroup_modification:
   layer: syntax
   category: modification
-  status: gap
+  status: covered
+  tests:
+    - tests/bucket-2/138-addlast-fieldgroup
 
 addlast_modification:
   layer: syntax

--- a/tests/bucket-2/138-addlast-fieldgroup/src/AddlastFieldgroupSrc.al
+++ b/tests/bucket-2/138-addlast-fieldgroup/src/AddlastFieldgroupSrc.al
@@ -1,0 +1,50 @@
+/// Base table with a fieldgroup — the tableextension will append to it using addlast.
+table 50138 "ALFG Item"
+{
+    DataClassification = CustomerContent;
+    fields
+    {
+        field(1; "No."; Code[20]) { }
+        field(2; Name; Text[100]) { }
+        field(3; Description; Text[200]) { }
+        field(4; Quantity; Integer) { }
+    }
+    keys
+    {
+        key(PK; "No.") { Clustered = true; }
+    }
+    fieldgroups
+    {
+        fieldgroup(DropDown; "No.", Name) { }
+    }
+}
+
+/// tableextension using addlast inside fieldgroups — appends Description to
+/// the DropDown fieldgroup. This is the construct issue #443 says fails.
+tableextension 50139 "ALFG Item Ext" extends "ALFG Item"
+{
+    fieldgroups
+    {
+        addlast(DropDown; Description)
+    }
+}
+
+/// Helper codeunit with business logic in the same compilation unit as the
+/// tableextension. Proves the unit compiles and codeunit logic is callable.
+codeunit 50138 "ALFG Helper"
+{
+    procedure GetLabel(): Text
+    begin
+        exit('fieldgroup last');
+    end;
+
+    procedure AddWithBonus(a: Integer; b: Integer): Integer
+    begin
+        exit(a + b + 1);
+    end;
+
+    procedure Concat(a: Text; b: Text): Text
+    begin
+        exit(a + '|' + b);
+    end;
+}

--- a/tests/bucket-2/138-addlast-fieldgroup/src/AddlastFieldgroupSrc.al
+++ b/tests/bucket-2/138-addlast-fieldgroup/src/AddlastFieldgroupSrc.al
@@ -25,7 +25,7 @@ tableextension 50139 "ALFG Item Ext" extends "ALFG Item"
 {
     fieldgroups
     {
-        addlast(DropDown; Description)
+        addlast(DropDown; Description) { }
     }
 }
 

--- a/tests/bucket-2/138-addlast-fieldgroup/test/AddlastFieldgroupTest.al
+++ b/tests/bucket-2/138-addlast-fieldgroup/test/AddlastFieldgroupTest.al
@@ -1,0 +1,76 @@
+codeunit 50139 "ALFG Addlast Fieldgroup Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    [Test]
+    procedure TableExtAddlastFieldgroup_CompilesAndHelperRuns()
+    var
+        Helper: Codeunit "ALFG Helper";
+    begin
+        // Positive: the compilation unit containing a tableextension with `addlast`
+        // in the `fieldgroups` section must compile, and codeunits defined alongside
+        // must be callable. This is what issue #443 says currently fails.
+        Assert.AreEqual('fieldgroup last', Helper.GetLabel(), 'Helper.GetLabel must return fieldgroup last');
+    end;
+
+    [Test]
+    procedure TableExtAddlastFieldgroup_AddWithBonus()
+    var
+        Helper: Codeunit "ALFG Helper";
+    begin
+        // Proving: helper performs real work — a+b+1, not a no-op (issue #203 standard).
+        Assert.AreEqual(8, Helper.AddWithBonus(3, 4), 'AddWithBonus(3,4) must return 3+4+1=8');
+        Assert.AreEqual(1, Helper.AddWithBonus(0, 0), 'AddWithBonus(0,0) must return 0+0+1=1');
+        Assert.AreEqual(-4, Helper.AddWithBonus(-2, -3), 'AddWithBonus(-2,-3) must return -5+1=-4');
+    end;
+
+    [Test]
+    procedure TableExtAddlastFieldgroup_AddWithBonus_NotPlainSum()
+    var
+        Helper: Codeunit "ALFG Helper";
+    begin
+        // Negative: guard against no-op trap — AddWithBonus must include the +1 bonus.
+        Assert.AreNotEqual(7, Helper.AddWithBonus(3, 4), 'AddWithBonus must not just return a+b');
+    end;
+
+    [Test]
+    procedure TableExtAddlastFieldgroup_Concat()
+    var
+        Helper: Codeunit "ALFG Helper";
+    begin
+        // Proving concat logic runs in same compilation unit as the tableextension.
+        Assert.AreEqual('x|y', Helper.Concat('x', 'y'), 'Concat must join with | separator');
+        Assert.AreEqual('|', Helper.Concat('', ''), 'Concat of empties must still include separator');
+    end;
+
+    [Test]
+    procedure TableExtAddlastFieldgroup_Concat_SeparatorPresent()
+    var
+        Helper: Codeunit "ALFG Helper";
+    begin
+        // Negative: Concat must NOT simply return a+b without the separator.
+        Assert.AreNotEqual('xy', Helper.Concat('x', 'y'), 'Concat must not return a+b without separator');
+    end;
+
+    [Test]
+    procedure TableExtAddlastFieldgroup_TableUsable()
+    var
+        Item: Record "ALFG Item";
+    begin
+        // Positive: the extended table must be fully usable alongside the tableextension.
+        Item.Init();
+        Item."No." := 'ITEM1';
+        Item.Name := 'Widget';
+        Item.Description := 'A small widget';
+        Item.Quantity := 10;
+        Item.Insert();
+
+        Item.Reset();
+        Assert.IsTrue(Item.Get('ITEM1'), 'ITEM1 must be retrievable after Insert');
+        Assert.AreEqual('Widget', Item.Name, 'Name must roundtrip through the table');
+        Assert.AreEqual(10, Item.Quantity, 'Quantity must roundtrip through the table');
+    end;
+}


### PR DESCRIPTION
Closes #443

Adds proving tests for `tableextension` objects using `addlast` in the `fieldgroups` section alongside a helper codeunit and extended table. Verifies the compilation unit compiles and all codeunit/table logic remains callable.

## Test approach

Suite `tests/bucket-2/138-addlast-fieldgroup/` with 6 tests:

- **CompilesAndHelperRuns** — proves the compilation unit containing a tableextension with `addlast` in `fieldgroups` compiles and `GetLabel()` returns the correct value
- **AddWithBonus** — proves helper performs real arithmetic (`a + b + 1`), not a no-op
- **AddWithBonus_NotPlainSum** — negative: ensures the `+1` bonus is present
- **Concat** — proves `|` separator is included in joined strings
- **Concat_SeparatorPresent** — negative: ensures `Concat` is not just `a + b`
- **TableUsable** — proves the extended table is usable alongside the tableextension (Insert/Get roundtrip)

`docs/coverage.yaml`: `addlast_fieldgroup_modification` → `covered`