### PR TITLE
test: addlast_views_modification coverage — pageextension addlast() in views

### DIFF
--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -1158,7 +1158,9 @@ addlast_modification:
 addlast_views_modification:
   layer: syntax
   category: modification
-  status: gap
+  status: covered
+  tests:
+    - tests/bucket-2/139-addlast-views
 
 modify_action_modification:
   layer: syntax

--- a/tests/bucket-2/139-addlast-views/src/AddlastViewsSrc.al
+++ b/tests/bucket-2/139-addlast-views/src/AddlastViewsSrc.al
@@ -1,0 +1,88 @@
+/// Table backing the base page used by the page extension in this suite.
+table 60400 "ALV Product"
+{
+    DataClassification = CustomerContent;
+    fields
+    {
+        field(1; Code; Code[20]) { }
+        field(2; Name; Text[100]) { }
+        field(3; Active; Boolean) { }
+    }
+    keys
+    {
+        key(PK; Code) { Clustered = true; }
+    }
+}
+
+/// Base page with an existing view so the pageextension has something to append after.
+page 60400 "ALV Product List"
+{
+    PageType = List;
+    SourceTable = "ALV Product";
+
+    layout
+    {
+        area(Content)
+        {
+            repeater(Lines)
+            {
+                field(CodeField; Rec.Code) { ApplicationArea = All; }
+                field(NameField; Rec.Name) { ApplicationArea = All; }
+                field(ActiveField; Rec.Active) { ApplicationArea = All; }
+            }
+        }
+    }
+
+    views
+    {
+        view(AllRecords)
+        {
+            Caption = 'All Records';
+        }
+    }
+}
+
+/// Page extension using addlast() in the views area — appends a view at the end
+/// of the views section. addlast in views is a compile-time directive; it has
+/// no runtime effect in unit-test context, so proving compilation is sufficient.
+pageextension 60400 "ALV Product List Ext" extends "ALV Product List"
+{
+    views
+    {
+        addlast
+        {
+            view(ActiveOnly)
+            {
+                Caption = 'Active Only';
+                Filters = where(Active = const(true));
+            }
+            view(InactiveOnly)
+            {
+                Caption = 'Inactive Only';
+                Filters = where(Active = const(false));
+            }
+        }
+    }
+}
+
+/// Business logic helper — proves that the compilation unit containing a
+/// pageextension with addlast(views) compiles and executes logic correctly.
+codeunit 60400 "ALV Helper"
+{
+    procedure GetLabel(): Text
+    begin
+        exit('addlast views ok');
+    end;
+
+    procedure IsActive(Active: Boolean): Text
+    begin
+        if Active then
+            exit('Active');
+        exit('Inactive');
+    end;
+
+    procedure FormatCode(Code: Code[20]; Name: Text): Text
+    begin
+        exit(Code + ': ' + Name);
+    end;
+}

--- a/tests/bucket-2/139-addlast-views/test/AddlastViewsTests.al
+++ b/tests/bucket-2/139-addlast-views/test/AddlastViewsTests.al
@@ -1,0 +1,57 @@
+codeunit 60401 "ALV Addlast Views Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Helper: Codeunit "ALV Helper";
+
+    // -----------------------------------------------------------------------
+    // Positive: pageextension with addlast(views) compiles; logic runs
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure AddlastViews_PageExtCompiles_LogicRuns()
+    begin
+        // [GIVEN] A pageextension using addlast() in the views area
+        // [WHEN]  Business logic in the same compilation unit is called
+        // [THEN]  It executes — addlast(views) declaration does not block compilation
+        Assert.AreEqual('addlast views ok', Helper.GetLabel(), 'Helper must return expected label');
+    end;
+
+    [Test]
+    procedure AddlastViews_WrongValue_Fails()
+    begin
+        // Negative: asserterror proves the assertion fires for wrong values
+        asserterror Assert.AreEqual('Wrong', Helper.GetLabel(), '');
+        Assert.ExpectedError('Wrong');
+    end;
+
+    [Test]
+    procedure AddlastViews_IsActive_True()
+    begin
+        // Positive: active record formats as Active
+        Assert.AreEqual('Active', Helper.IsActive(true), 'Active must format as Active');
+    end;
+
+    [Test]
+    procedure AddlastViews_IsActive_False()
+    begin
+        // Negative: inactive record formats as Inactive
+        Assert.AreEqual('Inactive', Helper.IsActive(false), 'Inactive must format as Inactive');
+    end;
+
+    [Test]
+    procedure AddlastViews_FormatCode_NonEmpty()
+    begin
+        // Positive: code and name combined correctly
+        Assert.AreEqual('PRD001: Widget', Helper.FormatCode('PRD001', 'Widget'), 'FormatCode must combine Code and Name');
+    end;
+
+    [Test]
+    procedure AddlastViews_FormatCode_EmptyName()
+    begin
+        // Edge case: empty name produces trailing colon-space
+        Assert.AreEqual('PRD002: ', Helper.FormatCode('PRD002', ''), 'FormatCode with empty name must have trailing colon-space');
+    end;
+}


### PR DESCRIPTION
Closes #430

Adds test suite `tests/bucket-2/139-addlast-views/` proving that a `pageextension` using `addlast` in the `views` area compiles and runs correctly.

`addlast` in views is a pure BC-compiler directive that appends views to the end of the views section at compile time (no target parameter, unlike `addafter`). No runner changes are needed — the directive just must not block compilation or test execution. This matches `addafter_views` and `addbefore_views` which are already covered.

## Changes

- `tests/bucket-2/139-addlast-views/src/AddlastViewsSrc.al` — base table/page with existing view, pageextension with `addlast { view(...) { ... } }` (two views), and helper codeunit
- `tests/bucket-2/139-addlast-views/test/AddlastViewsTests.al` — 6 tests (positive + negative + edge cases)
- `docs/coverage.yaml` — `addlast_views_modification` updated from `gap` to `covered`