### PR TITLE
feat: mark Session.BindSubscription / Session.UnbindSubscription as covered

### DIFF
--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -5108,7 +5108,7 @@ Session.ApplicationIdentifier:
 Session.BindSubscription:
   layer: runtime-api
   category: Session
-  status: gap
+  status: covered
   notes: overloads=1
 
 Session.CurrentClientType:
@@ -5204,7 +5204,7 @@ Session.StopSession:
 Session.UnbindSubscription:
   layer: runtime-api
   category: Session
-  status: gap
+  status: covered
   notes: overloads=1
 
 # ── SessionInformation ──────────────────────────────────────────


### PR DESCRIPTION
Closes #222

`BindSubscription` and `UnbindSubscription` are already fully implemented in the runner:

- **RoslynRewriter** (`Program.cs:3309`) rewrites `ALSession.ALBindSubscription(DataError, target)` → `target.Bind()` and `ALUnbindSubscription` → `target.Unbind()`
- **MockCodeunitHandle** has `Bind()` / `Unbind()` instance methods that register/deregister the codeunit instance in `EventSubscriberRegistry`
- **EventSubscriberRegistry** dispatches events only to bound instances for `EventSubscriberInstance = Manual` subscribers

The existing test suite `tests/bucket-2/100-bind-subscription` already proves all three scenarios with positive + negative assertions:
1. Manual subscriber does NOT fire before `BindSubscription` (negative)
2. Manual subscriber fires after `BindSubscription` (positive, asserts count = 1)
3. Manual subscriber stops firing after `UnbindSubscription` (negative, asserts count unchanged)

This PR simply updates `docs/coverage.yaml` to reflect the working implementation.