### PR TITLE
test: Dictionary type coverage — Add/Get/Set/Remove/ContainsKey/Count/Keys/Values

### DIFF
--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -464,7 +464,9 @@ code_type:
 dictionary_type:
   layer: syntax
   category: type
-  status: gap
+  status: covered
+  tests:
+    - tests/bucket-2/138-dictionary
 
 list_type:
   layer: syntax

--- a/tests/bucket-2/138-dictionary/al-runner.json
+++ b/tests/bucket-2/138-dictionary/al-runner.json
@@ -1,0 +1,4 @@
+{
+  "sourcePath": "./src",
+  "testPath": "./test"
+}

--- a/tests/bucket-2/138-dictionary/src/DictionarySrc.al
+++ b/tests/bucket-2/138-dictionary/src/DictionarySrc.al
@@ -1,0 +1,72 @@
+/// Helper codeunit exercising AL Dictionary operations: Add, Get, Set, Remove,
+/// ContainsKey, Count, Keys, Values — the surface named in issue #220.
+codeunit 59530 "Dict Helper"
+{
+    procedure Build(): Dictionary of [Text, Integer]
+    var
+        d: Dictionary of [Text, Integer];
+    begin
+        d.Add('one', 1);
+        d.Add('two', 2);
+        d.Add('three', 3);
+        exit(d);
+    end;
+
+    procedure CountOf(d: Dictionary of [Text, Integer]): Integer
+    begin
+        exit(d.Count());
+    end;
+
+    procedure GetByKey(d: Dictionary of [Text, Integer]; keyName: Text): Integer
+    begin
+        exit(d.Get(keyName));
+    end;
+
+    procedure ContainsKey(d: Dictionary of [Text, Integer]; keyName: Text): Boolean
+    begin
+        exit(d.ContainsKey(keyName));
+    end;
+
+    /// AL Dictionary.Set returns void — overwrites or adds as needed.
+    procedure SetValue(var d: Dictionary of [Text, Integer]; keyName: Text; value: Integer)
+    begin
+        d.Set(keyName, value);
+    end;
+
+    /// AL Dictionary.Remove returns Boolean — true if the key was present.
+    procedure RemoveKey(var d: Dictionary of [Text, Integer]; keyName: Text): Boolean
+    begin
+        exit(d.Remove(keyName));
+    end;
+
+    procedure SumValues(d: Dictionary of [Text, Integer]): Integer
+    var
+        vals: List of [Integer];
+        v: Integer;
+        total: Integer;
+    begin
+        vals := d.Values();
+        total := 0;
+        foreach v in vals do
+            total += v;
+        exit(total);
+    end;
+
+    /// Return whether each of the three build keys is present in d.Keys().
+    /// Using a set-membership check (Contains) rather than iteration order.
+    procedure AllBuildKeysPresent(d: Dictionary of [Text, Integer]): Boolean
+    var
+        keys: List of [Text];
+    begin
+        keys := d.Keys();
+        exit(keys.Contains('one') and keys.Contains('two') and keys.Contains('three'));
+    end;
+
+    procedure KeysCount(d: Dictionary of [Text, Integer]): Integer
+    var
+        keys: List of [Text];
+    begin
+        keys := d.Keys();
+        exit(keys.Count());
+    end;
+}

--- a/tests/bucket-2/138-dictionary/test/DictionaryTest.al
+++ b/tests/bucket-2/138-dictionary/test/DictionaryTest.al
@@ -1,0 +1,144 @@
+codeunit 59531 "Dict Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Helper: Codeunit "Dict Helper";
+
+    [Test]
+    procedure Count_ReturnsEntryCount()
+    var
+        d: Dictionary of [Text, Integer];
+    begin
+        d := Helper.Build();
+        Assert.AreEqual(3, Helper.CountOf(d), 'Count must be 3 after Add("one"),("two"),("three")');
+    end;
+
+    [Test]
+    procedure Get_ReturnsValueByKey()
+    var
+        d: Dictionary of [Text, Integer];
+    begin
+        d := Helper.Build();
+        Assert.AreEqual(1, Helper.GetByKey(d, 'one'), 'Get("one") must return 1');
+        Assert.AreEqual(2, Helper.GetByKey(d, 'two'), 'Get("two") must return 2');
+        Assert.AreEqual(3, Helper.GetByKey(d, 'three'), 'Get("three") must return 3');
+    end;
+
+    [Test]
+    procedure Get_MissingKey_Errors()
+    var
+        d: Dictionary of [Text, Integer];
+    begin
+        d := Helper.Build();
+        asserterror Helper.GetByKey(d, 'missing');
+    end;
+
+    [Test]
+    procedure ContainsKey_TrueForPresent_FalseForAbsent()
+    var
+        d: Dictionary of [Text, Integer];
+    begin
+        d := Helper.Build();
+        Assert.IsTrue(Helper.ContainsKey(d, 'one'), 'ContainsKey("one") must be true');
+        Assert.IsTrue(Helper.ContainsKey(d, 'two'), 'ContainsKey("two") must be true');
+        Assert.IsFalse(Helper.ContainsKey(d, 'missing'), 'ContainsKey("missing") must be false');
+    end;
+
+    [Test]
+    procedure AddDuplicate_Errors()
+    var
+        d: Dictionary of [Text, Integer];
+    begin
+        d := Helper.Build();
+        asserterror d.Add('one', 99);
+    end;
+
+    [Test]
+    procedure Set_OverwritesExistingValue()
+    var
+        d: Dictionary of [Text, Integer];
+    begin
+        d := Helper.Build();
+        Helper.SetValue(d, 'two', 20);
+        Assert.AreEqual(20, Helper.GetByKey(d, 'two'), 'Set must overwrite existing value');
+        Assert.AreEqual(3, Helper.CountOf(d), 'Set on existing key must not change count');
+    end;
+
+    [Test]
+    procedure Set_AddsWhenKeyAbsent()
+    var
+        d: Dictionary of [Text, Integer];
+    begin
+        d := Helper.Build();
+        Helper.SetValue(d, 'four', 4);
+        Assert.AreEqual(4, Helper.GetByKey(d, 'four'), 'Set must add when key absent');
+        Assert.AreEqual(4, Helper.CountOf(d), 'Set must increase count when adding');
+    end;
+
+    [Test]
+    procedure Remove_PresentKey_ReturnsTrueAndDrops()
+    var
+        d: Dictionary of [Text, Integer];
+    begin
+        d := Helper.Build();
+        Assert.IsTrue(Helper.RemoveKey(d, 'one'), 'Remove of present key must return true');
+        Assert.AreEqual(2, Helper.CountOf(d), 'Count must drop to 2');
+        Assert.IsFalse(Helper.ContainsKey(d, 'one'), 'Key one must be gone');
+    end;
+
+    [Test]
+    procedure Remove_MissingKey_ReturnsFalse()
+    var
+        d: Dictionary of [Text, Integer];
+    begin
+        d := Helper.Build();
+        Assert.IsFalse(Helper.RemoveKey(d, 'missing'), 'Remove of missing key must return false');
+        Assert.AreEqual(3, Helper.CountOf(d), 'Count must be unchanged');
+    end;
+
+    [Test]
+    procedure Values_ReturnsAllValues()
+    var
+        d: Dictionary of [Text, Integer];
+    begin
+        // Sum of 1+2+3 = 6 regardless of iteration order, so this is order-insensitive.
+        d := Helper.Build();
+        Assert.AreEqual(6, Helper.SumValues(d), 'SumValues must be 1+2+3=6');
+    end;
+
+    [Test]
+    procedure Keys_ReturnsAllKeys()
+    var
+        d: Dictionary of [Text, Integer];
+    begin
+        // Set-membership check — Keys() iteration order is not guaranteed, but
+        // the set of keys must be exactly the three build keys.
+        d := Helper.Build();
+        Assert.IsTrue(Helper.AllBuildKeysPresent(d),
+            'Keys must contain one, two, and three');
+        Assert.AreEqual(3, Helper.KeysCount(d), 'Keys count must equal dictionary count');
+    end;
+
+    [Test]
+    procedure EmptyDictionary_CountZero_NoKeys()
+    var
+        d: Dictionary of [Text, Integer];
+    begin
+        // Guard against a no-op Build() — a constructor returning an empty
+        // dict would still pass CountOf<=3 but must fail CountOf=0.
+        Assert.AreEqual(0, Helper.CountOf(d), 'Fresh dictionary Count must be 0');
+        Assert.IsFalse(Helper.ContainsKey(d, 'anything'), 'Fresh dictionary ContainsKey must be false');
+    end;
+
+    [Test]
+    procedure Build_NotEmpty_NegativeTrap()
+    var
+        d: Dictionary of [Text, Integer];
+    begin
+        // Negative: guard against Build() silently returning an empty dict.
+        d := Helper.Build();
+        Assert.AreNotEqual(0, Helper.CountOf(d), 'Build must not return an empty dictionary');
+    end;
+}


### PR DESCRIPTION
Closes #220

## Summary

BC's `NavDictionary<K,V>` works standalone; this PR adds proving-test coverage for the full surface named in the issue.

## Changes

- `tests/bucket-2/138-dictionary/` — helper codeunit + 13 tests covering `Add`, `Get`, `Set`, `Remove`, `ContainsKey`, `Count`, `Keys`, `Values`, plus duplicate-key error, missing-key error, empty-dict invariants, and a no-op trap on `Build()`
- `docs/coverage.yaml` — `dictionary_type` marked `covered`

## AL quirks discovered while writing the suite

- `key` is a reserved AL keyword → parameters renamed to `keyName`
- `Dictionary.Set(k, v)` returns void (not Boolean)
- `List of [T]` has no `Sort` method → key-order tests use set-membership instead of a sorted join

## Verification

- 13/13 new tests pass
- Full bucket-2 regression: 678 pass (no failures)