### PR TITLE
test: CreateDateTime / DT2Date / DT2Time built-in coverage

### DIFF
--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -5404,7 +5404,7 @@ System.CopyStream:
 System.CreateDateTime:
   layer: runtime-api
   category: System
-  status: gap
+  status: covered
   notes: overloads=1
 
 System.CreateEncryptionKey:
@@ -5464,7 +5464,7 @@ System.DMY2Date:
 System.DT2Date:
   layer: runtime-api
   category: System
-  status: gap
+  status: covered
   notes: overloads=1
 
 System.DT2Time:

--- a/tests/bucket-2/140-create-datetime/src/CreateDateTimeSrc.al
+++ b/tests/bucket-2/140-create-datetime/src/CreateDateTimeSrc.al
@@ -1,0 +1,35 @@
+/// Helper codeunit exercising CreateDateTime / DT2Date / DT2Time built-ins.
+codeunit 60500 "CDT Helper"
+{
+    procedure MakeDateTime(d: Date; t: Time): DateTime
+    begin
+        exit(CreateDateTime(d, t));
+    end;
+
+    procedure ExtractDate(dt: DateTime): Date
+    begin
+        exit(DT2Date(dt));
+    end;
+
+    procedure ExtractTime(dt: DateTime): Time
+    begin
+        exit(DT2Time(dt));
+    end;
+
+    /// Returns true when CreateDateTime round-trips through DT2Date and DT2Time.
+    procedure RoundTrip(d: Date; t: Time): Boolean
+    var
+        dt: DateTime;
+    begin
+        dt := CreateDateTime(d, t);
+        exit((DT2Date(dt) = d) and (DT2Time(dt) = t));
+    end;
+
+    /// Returns true when DT2Date of a 0DT is 0D (the zero DateTime).
+    procedure ZeroDateTimeIsZeroDate(): Boolean
+    var
+        dt: DateTime;
+    begin
+        exit(DT2Date(dt) = 0D);
+    end;
+}

--- a/tests/bucket-2/140-create-datetime/test/CreateDateTimeTests.al
+++ b/tests/bucket-2/140-create-datetime/test/CreateDateTimeTests.al
@@ -1,0 +1,103 @@
+codeunit 60501 "CDT Create DateTime Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Helper: Codeunit "CDT Helper";
+
+    // -----------------------------------------------------------------------
+    // CreateDateTime — construct a DateTime from Date + Time
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure CreateDateTime_RoundTrip_Positive()
+    var
+        d: Date;
+        t: Time;
+    begin
+        // [GIVEN] A specific date and time
+        // [WHEN]  CreateDateTime combines them, DT2Date/DT2Time decompose
+        // [THEN]  The round-trip preserves both components
+        d := DMY2Date(15, 6, 2024);
+        t := 120000T;
+        Assert.IsTrue(Helper.RoundTrip(d, t), 'CreateDateTime round-trip must preserve date and time');
+    end;
+
+    [Test]
+    procedure CreateDateTime_RoundTrip_MidnightTime()
+    var
+        d: Date;
+        t: Time;
+    begin
+        // Edge case: midnight (0T) round-trips correctly
+        d := DMY2Date(1, 1, 2023);
+        t := 000000T;
+        Assert.IsTrue(Helper.RoundTrip(d, t), 'CreateDateTime round-trip must work at midnight');
+    end;
+
+    // -----------------------------------------------------------------------
+    // DT2Date — extract the date component
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure DT2Date_ExtractsCorrectDate()
+    var
+        d: Date;
+    begin
+        // Positive: DT2Date returns exactly the date passed to CreateDateTime
+        d := DMY2Date(1, 1, 2023);
+        Assert.AreEqual(d, Helper.ExtractDate(Helper.MakeDateTime(d, 080000T)), 'DT2Date must return the date component');
+    end;
+
+    [Test]
+    procedure DT2Date_DifferentDates_Distinct()
+    var
+        d1: Date;
+        d2: Date;
+    begin
+        // Negative: two different dates produce different DT2Date results
+        d1 := DMY2Date(1, 1, 2023);
+        d2 := DMY2Date(2, 1, 2023);
+        Assert.AreNotEqual(
+            Helper.ExtractDate(Helper.MakeDateTime(d1, 120000T)),
+            Helper.ExtractDate(Helper.MakeDateTime(d2, 120000T)),
+            'DT2Date must distinguish different dates');
+    end;
+
+    [Test]
+    procedure DT2Date_ZeroDateTime_IsZeroDate()
+    begin
+        // Edge case: zero DateTime (0DT) decomposes to zero date (0D)
+        Assert.IsTrue(Helper.ZeroDateTimeIsZeroDate(), 'DT2Date of zero DateTime must be 0D');
+    end;
+
+    // -----------------------------------------------------------------------
+    // DT2Time — extract the time component
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure DT2Time_ExtractsCorrectTime()
+    var
+        d: Date;
+        t: Time;
+    begin
+        // Positive: DT2Time returns exactly the time passed to CreateDateTime
+        d := DMY2Date(15, 6, 2024);
+        t := 153000T;
+        Assert.AreEqual(t, Helper.ExtractTime(Helper.MakeDateTime(d, t)), 'DT2Time must return the time component');
+    end;
+
+    [Test]
+    procedure DT2Time_DifferentTimes_Distinct()
+    var
+        d: Date;
+    begin
+        // Negative: two different times produce different DT2Time results
+        d := DMY2Date(1, 1, 2023);
+        Assert.AreNotEqual(
+            Helper.ExtractTime(Helper.MakeDateTime(d, 080000T)),
+            Helper.ExtractTime(Helper.MakeDateTime(d, 090000T)),
+            'DT2Time must distinguish different times');
+    end;
+}


### PR DESCRIPTION
Closes #455

Adds test suite `tests/bucket-2/140-create-datetime/` proving that `CreateDateTime`, `DT2Date`, and `DT2Time` built-ins work correctly. These use BC's native `NavDateTime`/`NavDate`/`NavTime` types via the Microsoft DLLs, so no runner changes are needed — the suite proves the round-trip holds.

## Tests

- `CreateDateTime_RoundTrip_Positive` — verifies `DT2Date(CreateDateTime(d,t)) = d` and `DT2Time(...) = t`
- `CreateDateTime_RoundTrip_MidnightTime` — edge case: midnight (0T)
- `DT2Date_ExtractsCorrectDate` — positive assertion with specific date
- `DT2Date_DifferentDates_Distinct` — negative: two different dates produce distinct DT2Date results
- `DT2Date_ZeroDateTime_IsZeroDate` — edge case: 0DT → 0D
- `DT2Time_ExtractsCorrectTime` — positive assertion with specific time
- `DT2Time_DifferentTimes_Distinct` — negative: two different times produce distinct DT2Time results

## Coverage updates

- `System.CreateDateTime` → `covered`
- `System.DT2Date` → `covered`
- `System.DT2Time` was already `covered`