### PR TITLE
feat: Record.Count and IsEmpty proving tests (#457)

### DIFF
--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -5818,6 +5818,7 @@ Table.Count:
   tests:
     - tests/bucket-1/44-count-filtered
     - tests/bucket-1/66-record-count
+    - tests/bucket-2/140-record-count
   notes: overloads=1
 
 Table.CountApprox:
@@ -6031,6 +6032,7 @@ Table.IsEmpty:
   notes: overloads=1
   tests:
     - tests/bucket-1/56-isempty
+    - tests/bucket-2/140-record-count
 
 Table.IsTemporary:
   layer: runtime-api

--- a/tests/bucket-2/140-record-count/src/RecordCountSrc.al
+++ b/tests/bucket-2/140-record-count/src/RecordCountSrc.al
@@ -1,0 +1,66 @@
+table 50140 "CNT Item"
+{
+    DataClassification = CustomerContent;
+    fields
+    {
+        field(1; "No."; Code[20]) { }
+        field(2; Name; Text[100]) { }
+        field(3; Active; Boolean) { }
+        field(4; Category; Code[10]) { }
+    }
+    keys
+    {
+        key(PK; "No.") { Clustered = true; }
+    }
+}
+
+codeunit 50140 "CNT Helper"
+{
+    procedure InsertItems(n: Integer)
+    var
+        Rec: Record "CNT Item";
+        i: Integer;
+    begin
+        for i := 1 to n do begin
+            Rec.Init();
+            Rec."No." := Format(i);
+            Rec.Name := 'Item ' + Format(i);
+            Rec.Active := (i mod 2 = 1);
+            if i mod 3 = 0 then
+                Rec.Category := 'C'
+            else
+                Rec.Category := 'A';
+            Rec.Insert();
+        end;
+    end;
+
+    procedure GetCount(): Integer
+    var
+        Rec: Record "CNT Item";
+    begin
+        exit(Rec.Count());
+    end;
+
+    procedure GetActiveCount(): Integer
+    var
+        Rec: Record "CNT Item";
+    begin
+        Rec.SetRange(Active, true);
+        exit(Rec.Count());
+    end;
+
+    procedure GetCountByCategory(Cat: Code[10]): Integer
+    var
+        Rec: Record "CNT Item";
+    begin
+        Rec.SetRange(Category, Cat);
+        exit(Rec.Count());
+    end;
+
+    procedure IsEmptyTable(): Boolean
+    var
+        Rec: Record "CNT Item";
+    begin
+        exit(Rec.IsEmpty());
+    end;
+}

--- a/tests/bucket-2/140-record-count/test/RecordCountTest.al
+++ b/tests/bucket-2/140-record-count/test/RecordCountTest.al
@@ -1,0 +1,86 @@
+codeunit 50141 "CNT Record Count Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Helper: Codeunit "CNT Helper";
+
+    [Test]
+    procedure Count_EmptyTable_ReturnsZero()
+    begin
+        // Positive: Count on empty table returns 0, not throws.
+        Assert.AreEqual(0, Helper.GetCount(), 'Count on empty table must be 0');
+    end;
+
+    [Test]
+    procedure Count_AfterInsert_ReturnsCorrectTotal()
+    begin
+        // Positive: Count returns the number of inserted records.
+        Helper.InsertItems(5);
+        Assert.AreEqual(5, Helper.GetCount(), 'Count must return 5 after inserting 5 records');
+    end;
+
+    [Test]
+    procedure Count_NotZeroAfterInsert()
+    begin
+        // Negative: Count must NOT return 0 when records exist.
+        Helper.InsertItems(3);
+        Assert.AreNotEqual(0, Helper.GetCount(), 'Count must not be 0 when records exist');
+    end;
+
+    [Test]
+    procedure Count_WithFilter_ReturnsFilteredCount()
+    begin
+        // Positive: Count with SetRange returns only matching records.
+        // InsertItems(6): items 1,3,5 are Active=true → count = 3.
+        Helper.InsertItems(6);
+        Assert.AreEqual(3, Helper.GetActiveCount(), 'Active count must be 3 out of 6');
+    end;
+
+    [Test]
+    procedure Count_WithFilter_NotTotalCount()
+    begin
+        // Negative: filtered Count must NOT equal the total count.
+        Helper.InsertItems(4);
+        // InsertItems(4): items 1,3 are Active=true → active count = 2, total = 4.
+        Assert.AreNotEqual(Helper.GetCount(), Helper.GetActiveCount(),
+            'Filtered count must differ from total count');
+    end;
+
+    [Test]
+    procedure Count_WithCategoryFilter_ReturnsCorrect()
+    begin
+        // Positive: SetRange on Category field returns correct subset count.
+        // InsertItems(6): items 3,6 have Category='C' → count = 2.
+        Helper.InsertItems(6);
+        Assert.AreEqual(2, Helper.GetCountByCategory('C'),
+            'Category C count must be 2 out of 6 items');
+        Assert.AreEqual(4, Helper.GetCountByCategory('A'),
+            'Category A count must be 4 out of 6 items');
+    end;
+
+    [Test]
+    procedure Count_WithNoMatchingFilter_ReturnsZero()
+    begin
+        // Positive: SetRange with no matching records returns 0.
+        Helper.InsertItems(3);
+        Assert.AreEqual(0, Helper.GetCountByCategory('Z'),
+            'Count with no matches must return 0');
+    end;
+
+    [Test]
+    procedure IsEmpty_EmptyTable_ReturnsTrue()
+    begin
+        // Positive: IsEmpty on empty table returns true.
+        Assert.IsTrue(Helper.IsEmptyTable(), 'IsEmpty must be true on empty table');
+    end;
+
+    [Test]
+    procedure IsEmpty_AfterInsert_ReturnsFalse()
+    begin
+        // Positive: IsEmpty returns false after inserting records.
+        Helper.InsertItems(1);
+        Assert.IsFalse(Helper.IsEmptyTable(), 'IsEmpty must be false after insert');
+    end;
+}


### PR DESCRIPTION
Closes #457

`ALCount` was already implemented in `MockRecordHandle.cs:921` and covered by bucket-1 suites (44-count-filtered, 66-record-count). This PR adds an explicit proving suite that exercises:

- **Count on empty table** → returns 0
- **Count after insert** → returns exact total
- **Count with SetRange filter** → returns only matching records  
- **Count with no-match filter** → returns 0
- **Category filter count** → verifies correct subset (2 of 6 with `Category='C'`, 4 with `'A'`)
- **IsEmpty on empty table** → true
- **IsEmpty after insert** → false
- **Negative guards** — count must not equal 0 when records exist; filtered count must differ from total

Suite: `tests/bucket-2/140-record-count/`