### PR TITLE
test: Today / Time built-in coverage (#454)

### DIFF
--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -5693,13 +5693,13 @@ System.TemporaryPath:
 System.Time:
   layer: runtime-api
   category: System
-  status: gap
+  status: covered
   notes: overloads=1
 
 System.Today:
   layer: runtime-api
   category: System
-  status: gap
+  status: covered
   notes: overloads=1
 
 System.Variant2Date:

--- a/tests/bucket-2/141-today-time/src/TodayTimeSrc.al
+++ b/tests/bucket-2/141-today-time/src/TodayTimeSrc.al
@@ -1,0 +1,25 @@
+/// Helper codeunit exercising the Today and Time built-ins.
+codeunit 60600 "TT Helper"
+{
+    procedure GetToday(): Date
+    begin
+        exit(Today);
+    end;
+
+    procedure GetCurrentTime(): Time
+    begin
+        exit(Time);
+    end;
+
+    /// Returns true if Today is strictly after 2000-01-01.
+    procedure IsAfter2000(): Boolean
+    begin
+        exit(Today > DMY2Date(1, 1, 2000));
+    end;
+
+    /// Returns true if Today is strictly before 2100-01-01.
+    procedure IsBefore2100(): Boolean
+    begin
+        exit(Today < DMY2Date(1, 1, 2100));
+    end;
+}

--- a/tests/bucket-2/141-today-time/test/TodayTimeTests.al
+++ b/tests/bucket-2/141-today-time/test/TodayTimeTests.al
@@ -1,0 +1,68 @@
+codeunit 60601 "TT Today Time Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Helper: Codeunit "TT Helper";
+
+    // -----------------------------------------------------------------------
+    // Today — returns current date (non-zero, plausible range)
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure Today_IsNotZeroDate()
+    begin
+        // Positive: Today returns a non-zero date
+        Assert.AreNotEqual(0D, Helper.GetToday(), 'Today must not return the zero date');
+    end;
+
+    [Test]
+    procedure Today_IsAfter2000()
+    begin
+        // Positive: Today is after Jan 1 2000 (proves it returns a real current date)
+        Assert.IsTrue(Helper.IsAfter2000(), 'Today must be after year 2000');
+    end;
+
+    [Test]
+    procedure Today_IsBefore2100()
+    begin
+        // Positive: Today is before Jan 1 2100 (upper-bound sanity check)
+        Assert.IsTrue(Helper.IsBefore2100(), 'Today must be before year 2100');
+    end;
+
+    [Test]
+    procedure Today_Consistent()
+    var
+        d1: Date;
+        d2: Date;
+    begin
+        // Positive: two consecutive calls to Today return the same date
+        d1 := Helper.GetToday();
+        d2 := Helper.GetToday();
+        Assert.AreEqual(d1, d2, 'Two consecutive Today calls must return the same date');
+    end;
+
+    // -----------------------------------------------------------------------
+    // Time — returns current time (non-zero)
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure Time_IsNotZero()
+    begin
+        // Positive: Time returns a non-zero time (runner has been running for at least a moment)
+        Assert.AreNotEqual(0T, Helper.GetCurrentTime(), 'Time must not return the zero time');
+    end;
+
+    // -----------------------------------------------------------------------
+    // Negative
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure TodayTime_Negative_Error()
+    begin
+        // Negative: error mechanism works correctly
+        asserterror Error('expected error');
+        Assert.ExpectedError('expected error');
+    end;
+}


### PR DESCRIPTION
Closes #454

Adds test suite `tests/bucket-2/141-today-time/` proving that `Today` and `Time` built-ins work correctly.

Both built-ins already work via BC's NavSession-free path — the BC runtime handles these through `ALSystemDate` without requiring an active session. Tests confirmed **GREEN across all 7 BC versions** (BC 26.0 through 28.0) with no runner changes needed.

## Tests

- `Today_IsNotZeroDate` — Today returns a non-zero date
- `Today_IsAfter2000` — Today > 2000-01-01 (proves real current date, not default)
- `Today_IsBefore2100` — sanity upper bound
- `Today_Consistent` — two consecutive calls return the same date
- `Time_IsNotZero` — Time returns a non-zero time (runner has been running)
- `TodayTime_Negative_Error` — error mechanism works

## Coverage updates

- `System.Today` → `covered`
- `System.Time` → `covered`