### PR TITLE
test: add_dataset_modification coverage

### DIFF
--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -1043,7 +1043,9 @@ implements_clause:
 add_dataset_modification:
   layer: syntax
   category: modification
-  status: gap
+  status: covered
+  tests:
+    - tests/bucket-2/141-add-dataset
 
 addafter_action_modification:
   layer: syntax

--- a/tests/bucket-2/141-add-dataset/al-runner.json
+++ b/tests/bucket-2/141-add-dataset/al-runner.json
@@ -1,0 +1,4 @@
+{
+  "sourcePath": "./src",
+  "testPath": "./test"
+}

--- a/tests/bucket-2/141-add-dataset/src/AddDatasetSrc.al
+++ b/tests/bucket-2/141-add-dataset/src/AddDatasetSrc.al
@@ -1,0 +1,75 @@
+/// Source table used as the dataitem for the base report.
+table 59340 "ADM Item"
+{
+    DataClassification = CustomerContent;
+    fields
+    {
+        field(1; "No."; Code[20]) { }
+        field(2; Name; Text[100]) { }
+        field(3; Qty; Integer) { }
+        field(4; Price; Decimal) { }
+    }
+    keys
+    {
+        key(PK; "No.") { Clustered = true; }
+    }
+}
+
+/// Base report — the reportextension adds columns to its single dataitem.
+report 59340 "ADM Base Report"
+{
+    dataset
+    {
+        dataitem(ItemRec; "ADM Item")
+        {
+            column(ItemNo; "No.") { }
+            column(ItemName; Name) { }
+        }
+    }
+}
+
+/// reportextension using add(DataItem) to append columns to an existing
+/// dataitem. This is the exact construct issue #449 says fails to compile.
+reportextension 59341 "ADM Report Ext" extends "ADM Base Report"
+{
+    dataset
+    {
+        add(ItemRec)
+        {
+            column(ItemQty; Qty) { }
+        }
+    }
+}
+
+/// reportextension using add(DataItem) with multiple columns added in one block.
+reportextension 59342 "ADM Report Ext Multi" extends "ADM Base Report"
+{
+    dataset
+    {
+        add(ItemRec)
+        {
+            column(ItemPrice; Price) { }
+            column(ItemLineTotal; Qty * Price) { }
+        }
+    }
+}
+
+/// Helper codeunit — proves the compilation unit containing reportextensions
+/// with add() in the dataset area compiles and codeunits alongside remain callable.
+codeunit 59340 "ADM Helper"
+{
+    procedure GetLabel(): Text
+    begin
+        exit('dataset-add');
+    end;
+
+    procedure LineTotal(qty: Integer; price: Decimal): Decimal
+    begin
+        exit(qty * price);
+    end;
+
+    procedure Brackets(s: Text): Text
+    begin
+        exit('{' + s + '}');
+    end;
+}

--- a/tests/bucket-2/141-add-dataset/test/AddDatasetTest.al
+++ b/tests/bucket-2/141-add-dataset/test/AddDatasetTest.al
@@ -1,0 +1,70 @@
+codeunit 59343 "ADM Add Dataset Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Helper: Codeunit "ADM Helper";
+
+    [Test]
+    procedure ReportExtAddDataset_CompilesAndHelperRuns()
+    begin
+        // Positive: the compilation unit containing reportextensions with `add()`
+        // in the dataset section must compile, and codeunits defined alongside
+        // them must be callable. This is what issue #449 says currently fails.
+        Assert.AreEqual('dataset-add', Helper.GetLabel(),
+            'Helper.GetLabel must return dataset-add');
+    end;
+
+    [Test]
+    procedure ReportExtAddDataset_LineTotal()
+    begin
+        // Proving: helper performs real work, not a no-op stub (issue #203 standard).
+        Assert.AreEqual(50, Helper.LineTotal(5, 10), 'LineTotal(5,10) must be 50');
+        Assert.AreEqual(0, Helper.LineTotal(0, 99), 'LineTotal(0,99) must be 0');
+        Assert.AreEqual(-20, Helper.LineTotal(-2, 10), 'LineTotal(-2,10) must be -20');
+    end;
+
+    [Test]
+    procedure ReportExtAddDataset_LineTotal_NotJustSum()
+    begin
+        // Negative: guard against a no-op returning qty+price.
+        Assert.AreNotEqual(15, Helper.LineTotal(5, 10), 'LineTotal must not just return qty+price');
+    end;
+
+    [Test]
+    procedure ReportExtAddDataset_Brackets()
+    begin
+        // Proving Brackets runs in same compilation unit as reportextensions.
+        Assert.AreEqual('{hi}', Helper.Brackets('hi'), 'Brackets must wrap with {}');
+        Assert.AreEqual('{}', Helper.Brackets(''), 'Brackets of empty must be just {}');
+    end;
+
+    [Test]
+    procedure ReportExtAddDataset_Brackets_BracesPresent()
+    begin
+        // Negative: Brackets must NOT return the raw string.
+        Assert.AreNotEqual('hi', Helper.Brackets('hi'), 'Brackets must not return the raw string');
+    end;
+
+    [Test]
+    procedure ReportExtAddDataset_TableInCompilationUnit_Usable()
+    var
+        Item: Record "ADM Item";
+    begin
+        // Positive: the source table in the same compilation unit as the
+        // reportextensions must be usable — proves the whole compilation unit is live.
+        Item.Init();
+        Item."No." := 'I1';
+        Item.Name := 'Widget';
+        Item.Qty := 3;
+        Item.Price := 9.99;
+        Item.Insert();
+
+        Item.Reset();
+        Assert.IsTrue(Item.Get('I1'), 'Item I1 must be retrievable after Insert');
+        Assert.AreEqual('Widget', Item.Name, 'Name must roundtrip');
+        Assert.AreEqual(3, Item.Qty, 'Qty must roundtrip');
+        Assert.AreEqual(9.99, Item.Price, 'Price must roundtrip');
+    end;
+}


### PR DESCRIPTION
Closes #449

## Summary

Feature already works; adding proving-test coverage for `add(DataItem)` in reportextension dataset sections. Mirrors the pattern in bucket-2/135-addfirst-dataset.

## Changes

- `tests/bucket-2/141-add-dataset/` — two reportextensions using `add(ItemRec)` (single column + multi-column variants), plus helper codeunit and backing table. Six proving tests with no-op traps and a table round-trip.
- `docs/coverage.yaml` — `add_dataset_modification` marked `covered`

## Verification

- 6/6 new tests pass
- Full bucket-2 regression: 712 pass, 3 pre-existing DateTime/timezone failures in bucket-2/140-create-datetime (unrelated to this change)