### PR TITLE
test: JsonArray.Count coverage

### DIFF
--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -2937,8 +2937,10 @@ JsonArray.Clone:
 JsonArray.Count:
   layer: runtime-api
   category: JsonArray
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; BC native NavJsonArray.ALCount works standalone.
+  tests:
+    - tests/bucket-2/142-jsonarray-count
 
 JsonArray.Get:
   layer: runtime-api

--- a/tests/bucket-2/142-jsonarray-count/al-runner.json
+++ b/tests/bucket-2/142-jsonarray-count/al-runner.json
@@ -1,0 +1,4 @@
+{
+  "sourcePath": "./src",
+  "testPath": "./test"
+}

--- a/tests/bucket-2/142-jsonarray-count/src/JsonArrayCountSrc.al
+++ b/tests/bucket-2/142-jsonarray-count/src/JsonArrayCountSrc.al
@@ -1,0 +1,50 @@
+/// Helper codeunit exercising JsonArray.Count() — the method issue #468 says
+/// is not supported at runtime.
+codeunit 59350 "JAC Count Src"
+{
+    procedure GetCount(arr: JsonArray): Integer
+    begin
+        exit(arr.Count());
+    end;
+
+    /// Build an array with `n` text entries and return it.
+    procedure BuildWith(n: Integer): JsonArray
+    var
+        arr: JsonArray;
+        i: Integer;
+    begin
+        for i := 1 to n do
+            arr.Add('item-' + Format(i));
+        exit(arr);
+    end;
+
+    /// Mixed-type array — proves Count counts all tokens regardless of value type.
+    procedure BuildMixed(): JsonArray
+    var
+        arr: JsonArray;
+    begin
+        arr.Add('text');
+        arr.Add(42);
+        arr.Add(true);
+        arr.Add(3.14);
+        exit(arr);
+    end;
+
+    /// Array containing a nested object and nested array — Count must still
+    /// report the top-level length, not recurse into children.
+    procedure BuildNested(): JsonArray
+    var
+        outer: JsonArray;
+        inner: JsonArray;
+        obj: JsonObject;
+    begin
+        inner.Add('a');
+        inner.Add('b');
+        obj.Add('key', 'value');
+
+        outer.Add('first');
+        outer.Add(inner);
+        outer.Add(obj);
+        exit(outer);
+    end;
+}

--- a/tests/bucket-2/142-jsonarray-count/test/JsonArrayCountTest.al
+++ b/tests/bucket-2/142-jsonarray-count/test/JsonArrayCountTest.al
@@ -1,0 +1,83 @@
+codeunit 59351 "JAC Count Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "JAC Count Src";
+
+    [Test]
+    procedure Count_EmptyArray_IsZero()
+    var
+        arr: JsonArray;
+    begin
+        // Positive: Count() on an uninitialised JsonArray must return 0.
+        Assert.AreEqual(0, Src.GetCount(arr), 'empty array count must be 0');
+    end;
+
+    [Test]
+    procedure Count_AfterThreeAdds_IsThree()
+    var
+        arr: JsonArray;
+    begin
+        arr.Add('first');
+        arr.Add('second');
+        arr.Add('third');
+        Assert.AreEqual(3, Src.GetCount(arr), 'count after 3 Adds must be 3');
+    end;
+
+    [Test]
+    procedure Count_AfterOneAdd_IsOne()
+    var
+        arr: JsonArray;
+    begin
+        arr.Add('only');
+        Assert.AreEqual(1, Src.GetCount(arr), 'count after single Add must be 1');
+    end;
+
+    [Test]
+    procedure Count_MatchesBuilderArg()
+    begin
+        // Proving: BuildWith(n) produces an array of exactly n elements.
+        Assert.AreEqual(0, Src.GetCount(Src.BuildWith(0)), 'BuildWith(0) count');
+        Assert.AreEqual(5, Src.GetCount(Src.BuildWith(5)), 'BuildWith(5) count');
+        Assert.AreEqual(10, Src.GetCount(Src.BuildWith(10)), 'BuildWith(10) count');
+    end;
+
+    [Test]
+    procedure Count_MixedTypes_CountsAllTokens()
+    begin
+        // Count must count all entries regardless of token type (text, integer,
+        // boolean, decimal) — four Adds = 4.
+        Assert.AreEqual(4, Src.GetCount(Src.BuildMixed()),
+            'mixed-type array with 4 Adds must have Count=4');
+    end;
+
+    [Test]
+    procedure Count_NestedStructures_CountsTopLevelOnly()
+    var
+        arr: JsonArray;
+    begin
+        // Nested JsonArray + JsonObject count as 1 token each at the top level,
+        // so the outer array has 3 entries (not the 7 you'd get if Count recursed).
+        arr := Src.BuildNested();
+        Assert.AreEqual(3, Src.GetCount(arr),
+            'top-level count must be 3; Count must not recurse into children');
+    end;
+
+    [Test]
+    procedure Count_NotBuilderArgTimesTwo_NegativeTrap()
+    begin
+        // Negative: guard against a Count() that accidentally returns n*2 or similar.
+        Assert.AreNotEqual(10, Src.GetCount(Src.BuildWith(5)),
+            'Count of 5-element array must not be 10');
+    end;
+
+    [Test]
+    procedure Count_NotFixedConstant_NegativeTrap()
+    begin
+        // Negative: guard against a Count() stub that always returns the same value.
+        Assert.AreNotEqual(Src.GetCount(Src.BuildWith(3)), Src.GetCount(Src.BuildWith(7)),
+            'Count must differ for arrays of different sizes');
+    end;
+}


### PR DESCRIPTION
Closes #468

## Summary

BC native `NavJsonArray.ALCount` works standalone; adding dedicated proving-test coverage for the specific variants the issue names.

## Changes

- `tests/bucket-2/142-jsonarray-count/` — helper codeunit + 8 tests (empty, 1 Add, 3 Adds, builder-arg match across sizes, mixed types, nested top-level counting, plus two negative traps)
- `docs/coverage.yaml` — `JsonArray.Count` marked `covered`

## Verification

- 8/8 new tests pass
- Full bucket-2 regression: 720 pass, 3 pre-existing DateTime/timezone failures (unrelated)