### PR TITLE
feat: Database.LockTimeout / LockTimeoutDuration property-get stubs

### DIFF
--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -3126,6 +3126,32 @@ public void ClearApplicationMemberVariables() { }
                 .WithTriviaFrom(visited);
         }
 
+        // Pattern: ALDatabase.ALLockTimeout (property get) -> true
+        //          ALDatabase.ALLockTimeoutDuration (property get) -> 0L
+        // BC lowers Database.LockTimeout and Database.LockTimeoutDuration to property
+        // getters that require a live NavSession; they crash with NullReferenceException
+        // standalone. Assignment (`ALDatabase.ALLockTimeout = val`) is already stripped
+        // to no-op in VisitExpressionStatement. The runner has no real database, so
+        // true (lock-timeout-enabled by default) and 0L (zero-duration) are sensible
+        // standalone stubs. 0L flows through `ALCompiler.ToDuration(long)` back to
+        // NavDuration without further adaptation.
+        if (visited.Expression is IdentifierNameSyntax lockDbId2 &&
+            lockDbId2.Identifier.Text == "ALDatabase")
+        {
+            if (visited.Name.Identifier.Text == "ALLockTimeout")
+            {
+                return SyntaxFactory.LiteralExpression(SyntaxKind.TrueLiteralExpression)
+                    .WithTriviaFrom(visited);
+            }
+            if (visited.Name.Identifier.Text == "ALLockTimeoutDuration")
+            {
+                return SyntaxFactory.LiteralExpression(
+                    SyntaxKind.NumericLiteralExpression,
+                    SyntaxFactory.Literal(0L))
+                    .WithTriviaFrom(visited);
+            }
+        }
+
         // Pattern: ALDatabase.ALCompanyName / ALDatabase.ALUserID / ALDatabase.ALTenantID / ALDatabase.ALSerialNumber
         // These static property accesses crash because ALDatabase requires a live BC session.
         // ALCompanyName routes to MockSession.GetCompanyName() (configurable via --company-name CLI flag).

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -1586,14 +1586,18 @@ Database.LastUsedRowVersion:
 Database.LockTimeout:
   layer: runtime-api
   category: Database
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; property get stubbed to `true` via rewriter (BC default); setter already a no-op.
+  tests:
+    - tests/bucket-2/143-lock-timeout
 
 Database.LockTimeoutDuration:
   layer: runtime-api
   category: Database
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; property get stubbed to `0L` via rewriter (no timeout), flows through ALCompiler.ToDuration.
+  tests:
+    - tests/bucket-2/143-lock-timeout
 
 Database.MinimumActiveRowVersion:
   layer: runtime-api

--- a/tests/bucket-2/143-lock-timeout/al-runner.json
+++ b/tests/bucket-2/143-lock-timeout/al-runner.json
@@ -1,0 +1,4 @@
+{
+  "sourcePath": "./src",
+  "testPath": "./test"
+}

--- a/tests/bucket-2/143-lock-timeout/src/LockTimeoutSrc.al
+++ b/tests/bucket-2/143-lock-timeout/src/LockTimeoutSrc.al
@@ -1,0 +1,19 @@
+/// Helper codeunit exercising Database.LockTimeout / Database.LockTimeoutDuration.
+codeunit 59360 "LT Src"
+{
+    procedure GetLockTimeout(): Boolean
+    begin
+        exit(Database.LockTimeout);
+    end;
+
+    procedure GetLockTimeoutDuration(): Duration
+    begin
+        exit(Database.LockTimeoutDuration);
+    end;
+
+    procedure SetAndGetLockTimeout(Val: Boolean): Boolean
+    begin
+        Database.LockTimeout(Val);
+        exit(Database.LockTimeout);
+    end;
+}

--- a/tests/bucket-2/143-lock-timeout/test/LockTimeoutTest.al
+++ b/tests/bucket-2/143-lock-timeout/test/LockTimeoutTest.al
@@ -1,0 +1,56 @@
+codeunit 59361 "LT Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "LT Src";
+
+    [Test]
+    procedure LockTimeout_DefaultIsTrue()
+    begin
+        // Positive: BC's Database.LockTimeout default is true.
+        Assert.IsTrue(Src.GetLockTimeout(), 'LockTimeout must default to true');
+    end;
+
+    [Test]
+    procedure LockTimeoutDuration_IsNonNegative()
+    var
+        d: Duration;
+    begin
+        // Positive: LockTimeoutDuration must be >= 0 (a negative duration
+        // would indicate an unwired stub returning garbage).
+        d := Src.GetLockTimeoutDuration();
+        Assert.IsTrue(d >= 0, 'LockTimeoutDuration must be non-negative');
+    end;
+
+    [Test]
+    procedure LockTimeout_SetFalseReadBack()
+    var
+        result: Boolean;
+    begin
+        // In the runner there is no real DB, so setting LockTimeout is a no-op.
+        // The setter call must not throw, and the read afterward must still
+        // be defined. Under the current stub contract the default (true) is
+        // preserved regardless of what's passed to the setter.
+        result := Src.SetAndGetLockTimeout(false);
+        Assert.IsTrue(result, 'After no-op setter, LockTimeout must still read as true (default)');
+    end;
+
+    [Test]
+    procedure LockTimeout_SetTrueReadBack()
+    begin
+        Assert.IsTrue(Src.SetAndGetLockTimeout(true), 'SetAndGetLockTimeout(true) must return true');
+    end;
+
+    [Test]
+    procedure LockTimeout_ReadReturnsBoolean_NegativeTrap()
+    var
+        b: Boolean;
+    begin
+        // Negative: guard against a stub that throws — just reading into a local
+        // variable proves the property getter completes and yields a Boolean.
+        b := Src.GetLockTimeout();
+        Assert.IsTrue(b or (not b), 'LockTimeout read must complete and return a Boolean');
+    end;
+}


### PR DESCRIPTION
Closes #476

## Summary

Setter was already a no-op; getters crashed with NullReferenceException (real BC implementation requires NavSession). Added two rewriter rules to stub the property gets with BC-sensible defaults.

## Changes

- `AlRunner/RoslynRewriter.cs` — in `VisitMemberAccessExpression`:
  - `ALDatabase.ALLockTimeout` → `true`
  - `ALDatabase.ALLockTimeoutDuration` → `0L` (flows through `ALCompiler.ToDuration(long)` to `NavDuration`)
- `tests/bucket-2/143-lock-timeout/` — helper codeunit + 5 proving tests (default reads, non-negative duration, set-then-read, negative-trap for throwing stubs)
- `docs/coverage.yaml` — both entries marked `covered`

## Verification

- 5/5 new tests pass
- Full bucket-2 regression: 746 pass (3 pre-existing DateTime/timezone failures)
- Full bucket-1 regression: 661 pass (4 pre-existing environmental failures)