### PR TITLE
test: XML collection introspection coverage (Count + IsEmpty)

### DIFF
--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -8042,8 +8042,10 @@ XmlAttribute.WriteTo:
 XmlAttributeCollection.Count:
   layer: runtime-api
   category: XmlAttributeCollection
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; BC native works standalone when the XmlElement is built programmatically.
+  tests:
+    - tests/bucket-2/144-xml-collections
 
 XmlAttributeCollection.Get:
   layer: runtime-api
@@ -8690,8 +8692,10 @@ XmlElement.InnerXml:
 XmlElement.IsEmpty:
   layer: runtime-api
   category: XmlElement
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; BC native works standalone when the XmlElement is built programmatically.
+  tests:
+    - tests/bucket-2/144-xml-collections
 
 XmlElement.LocalName:
   layer: runtime-api
@@ -9004,8 +9008,10 @@ XmlNode.WriteTo:
 XmlNodeList.Count:
   layer: runtime-api
   category: XmlNodeList
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; BC native works standalone when the XmlElement is built programmatically.
+  tests:
+    - tests/bucket-2/144-xml-collections
 
 XmlNodeList.Get:
   layer: runtime-api

--- a/tests/bucket-2/144-xml-collections/al-runner.json
+++ b/tests/bucket-2/144-xml-collections/al-runner.json
@@ -1,0 +1,4 @@
+{
+  "sourcePath": "./src",
+  "testPath": "./test"
+}

--- a/tests/bucket-2/144-xml-collections/src/XmlCollectionsSrc.al
+++ b/tests/bucket-2/144-xml-collections/src/XmlCollectionsSrc.al
@@ -1,0 +1,102 @@
+/// Helper codeunit exercising XmlNodeList.Count, XmlAttributeCollection.Count,
+/// and XmlElement.IsEmpty — the surface issue #481 names.
+/// Builds XmlElements programmatically (no XmlDocument.ReadFrom) so the test
+/// does not depend on the XML-text-parser path.
+codeunit 59370 "XC Src"
+{
+    procedure GetChildElementCount_Empty(): Integer
+    var
+        root: XmlElement;
+        nodes: XmlNodeList;
+    begin
+        root := XmlElement.Create('root');
+        nodes := root.GetChildNodes();
+        exit(nodes.Count);
+    end;
+
+    procedure GetChildElementCount_OneChild(): Integer
+    var
+        root: XmlElement;
+        child: XmlElement;
+        nodes: XmlNodeList;
+    begin
+        root := XmlElement.Create('root');
+        child := XmlElement.Create('child');
+        root.Add(child);
+        nodes := root.GetChildNodes();
+        exit(nodes.Count);
+    end;
+
+    procedure GetChildElementCount_Three(): Integer
+    var
+        root: XmlElement;
+        a: XmlElement;
+        b: XmlElement;
+        c: XmlElement;
+        nodes: XmlNodeList;
+    begin
+        root := XmlElement.Create('root');
+        a := XmlElement.Create('a');
+        b := XmlElement.Create('b');
+        c := XmlElement.Create('c');
+        root.Add(a);
+        root.Add(b);
+        root.Add(c);
+        nodes := root.GetChildNodes();
+        exit(nodes.Count);
+    end;
+
+    procedure GetAttributeCount_Zero(): Integer
+    var
+        root: XmlElement;
+        attrs: XmlAttributeCollection;
+    begin
+        root := XmlElement.Create('root');
+        attrs := root.Attributes();
+        exit(attrs.Count);
+    end;
+
+    procedure GetAttributeCount_Two(): Integer
+    var
+        root: XmlElement;
+        attrs: XmlAttributeCollection;
+    begin
+        root := XmlElement.Create('root');
+        root.SetAttribute('a', '1');
+        root.SetAttribute('b', '2');
+        attrs := root.Attributes();
+        exit(attrs.Count);
+    end;
+
+    procedure GetAttributeCount_Three(): Integer
+    var
+        root: XmlElement;
+        attrs: XmlAttributeCollection;
+    begin
+        root := XmlElement.Create('root');
+        root.SetAttribute('id', 'x');
+        root.SetAttribute('name', 'y');
+        root.SetAttribute('kind', 'z');
+        attrs := root.Attributes();
+        exit(attrs.Count);
+    end;
+
+    procedure IsElementEmpty_NoChildren(): Boolean
+    var
+        root: XmlElement;
+    begin
+        root := XmlElement.Create('root');
+        exit(root.IsEmpty);
+    end;
+
+    procedure IsElementEmpty_WithChild(): Boolean
+    var
+        root: XmlElement;
+        child: XmlElement;
+    begin
+        root := XmlElement.Create('root');
+        child := XmlElement.Create('child');
+        root.Add(child);
+        exit(root.IsEmpty);
+    end;
+}

--- a/tests/bucket-2/144-xml-collections/test/XmlCollectionsTest.al
+++ b/tests/bucket-2/144-xml-collections/test/XmlCollectionsTest.al
@@ -1,0 +1,84 @@
+codeunit 59371 "XC Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "XC Src";
+
+    [Test]
+    procedure XmlNodeList_Count_NoChildren()
+    begin
+        Assert.AreEqual(0, Src.GetChildElementCount_Empty(),
+            'XmlElement with 0 children must have GetChildNodes.Count = 0');
+    end;
+
+    [Test]
+    procedure XmlNodeList_Count_OneChild()
+    begin
+        Assert.AreEqual(1, Src.GetChildElementCount_OneChild(),
+            'XmlElement with 1 child must have GetChildNodes.Count = 1');
+    end;
+
+    [Test]
+    procedure XmlNodeList_Count_ThreeChildren()
+    begin
+        Assert.AreEqual(3, Src.GetChildElementCount_Three(),
+            'XmlElement with 3 children must have GetChildNodes.Count = 3');
+    end;
+
+    [Test]
+    procedure XmlNodeList_Count_NotFixed_NegativeTrap()
+    begin
+        // Negative: guard against a stub that always returns the same value.
+        Assert.AreNotEqual(
+            Src.GetChildElementCount_Empty(),
+            Src.GetChildElementCount_Three(),
+            'Count must differ for elements with different child counts');
+    end;
+
+    [Test]
+    procedure XmlAttributeCollection_Count_NoAttributes()
+    begin
+        Assert.AreEqual(0, Src.GetAttributeCount_Zero(),
+            'XmlElement with 0 attributes must have Attributes.Count = 0');
+    end;
+
+    [Test]
+    procedure XmlAttributeCollection_Count_TwoAttributes()
+    begin
+        Assert.AreEqual(2, Src.GetAttributeCount_Two(),
+            'XmlElement with 2 attributes must have Attributes.Count = 2');
+    end;
+
+    [Test]
+    procedure XmlAttributeCollection_Count_ThreeAttributes()
+    begin
+        Assert.AreEqual(3, Src.GetAttributeCount_Three(),
+            'XmlElement with 3 attributes must have Attributes.Count = 3');
+    end;
+
+    [Test]
+    procedure XmlAttributeCollection_Count_NotFixed_NegativeTrap()
+    begin
+        // Negative: guard against a stub that always returns the same value.
+        Assert.AreNotEqual(
+            Src.GetAttributeCount_Zero(),
+            Src.GetAttributeCount_Two(),
+            'Attributes.Count must differ for elements with different attribute counts');
+    end;
+
+    [Test]
+    procedure XmlElement_IsEmpty_TrueForEmpty()
+    begin
+        Assert.IsTrue(Src.IsElementEmpty_NoChildren(),
+            'XmlElement with no children must report IsEmpty = true');
+    end;
+
+    [Test]
+    procedure XmlElement_IsEmpty_FalseForWithChild()
+    begin
+        Assert.IsFalse(Src.IsElementEmpty_WithChild(),
+            'XmlElement with a child must report IsEmpty = false');
+    end;
+}


### PR DESCRIPTION
Closes #481

## Summary

BC's native `NavXmlNodeList`, `NavXmlAttributeCollection`, and `NavXmlElement` work standalone when XmlElements are constructed programmatically (`XmlElement.Create` + `Add` + `SetAttribute`). Adding proving-test coverage; no runner code change needed.

## Notes on scope

`XmlDocument.ReadFrom(Text, var XmlDocument)` currently crashes because the rewriter-emitted `MockJsonHelper.ReadFrom(NavXmlDocument, ...)` references `NavXmlDocument` as a type and `MockJsonHelper.ReadFrom` has no XmlDocument overload — that's a separate, larger gap worth its own issue. This PR's tests sidestep that path entirely.

## Changes

- `tests/bucket-2/144-xml-collections/` — helper codeunit (programmatic XmlElement construction) + 10 tests:
  - `XmlNodeList.Count` for 0, 1, 3 children + negative trap
  - `XmlAttributeCollection.Count` for 0, 2, 3 attributes + negative trap
  - `XmlElement.IsEmpty` for empty / with-child elements
- `docs/coverage.yaml` — all three entries marked `covered`

## Verification

- 10/10 new tests pass
- Full bucket-2 regression: 756 pass (3 pre-existing DateTime/timezone failures)