### PR TITLE
feat: Database.LastUsedRowVersion / MinimumActiveRowVersion stubs

### DIFF
--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -2617,6 +2617,22 @@ public void ClearApplicationMemberVariables() { }
                     .WithTriviaFrom(visited);
             }
 
+            // ALDatabase.ALLastUsedRowVersion() -> 0L
+            // ALDatabase.ALMinimumActiveRowVersion() -> 0L
+            // BC lowers Database.LastUsedRowVersion / MinimumActiveRowVersion to method
+            // calls on ALDatabase that require a live NavSession. The runner has no real
+            // database — 0L (no rows ever written / no active transactions) is the
+            // correct standalone value, and preserves the real BC invariant that
+            // MinimumActiveRowVersion <= LastUsedRowVersion.
+            if (exprText == "ALDatabase" &&
+                (methodName == "ALLastUsedRowVersion" || methodName == "ALMinimumActiveRowVersion"))
+            {
+                return SyntaxFactory.LiteralExpression(
+                    SyntaxKind.NumericLiteralExpression,
+                    SyntaxFactory.Literal(0L))
+                    .WithTriviaFrom(visited);
+            }
+
             // ALDatabase.ALHasTableConnection(type, name) -> AlCompat.HasTableConnection(type, name)
             // The runner has no real external table connections; always returns false.
             if (exprText == "ALDatabase" && methodName == "ALHasTableConnection")

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -1580,8 +1580,10 @@ Database.IsInWriteTransaction:
 Database.LastUsedRowVersion:
   layer: runtime-api
   category: Database
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; method stubbed to `0L` via rewriter (no real DB ⇒ no rows written).
+  tests:
+    - tests/bucket-2/145-rowversion
 
 Database.LockTimeout:
   layer: runtime-api
@@ -1602,8 +1604,10 @@ Database.LockTimeoutDuration:
 Database.MinimumActiveRowVersion:
   layer: runtime-api
   category: Database
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; method stubbed to `0L` via rewriter (no real DB ⇒ no active transactions).
+  tests:
+    - tests/bucket-2/145-rowversion
 
 Database.RegisterTableConnection:
   layer: runtime-api

--- a/tests/bucket-2/145-rowversion/al-runner.json
+++ b/tests/bucket-2/145-rowversion/al-runner.json
@@ -1,0 +1,4 @@
+{
+  "sourcePath": "./src",
+  "testPath": "./test"
+}

--- a/tests/bucket-2/145-rowversion/src/RowVersionSrc.al
+++ b/tests/bucket-2/145-rowversion/src/RowVersionSrc.al
@@ -1,0 +1,23 @@
+/// Helper codeunit exercising Database.LastUsedRowVersion / Database.MinimumActiveRowVersion.
+codeunit 59380 "RV Src"
+{
+    procedure GetLastUsedRowVersion(): BigInteger
+    begin
+        exit(Database.LastUsedRowVersion);
+    end;
+
+    procedure GetMinimumActiveRowVersion(): BigInteger
+    begin
+        exit(Database.MinimumActiveRowVersion);
+    end;
+
+    procedure LastUsedNonNegative(): Boolean
+    begin
+        exit(Database.LastUsedRowVersion >= 0);
+    end;
+
+    procedure MinActiveNonNegative(): Boolean
+    begin
+        exit(Database.MinimumActiveRowVersion >= 0);
+    end;
+}

--- a/tests/bucket-2/145-rowversion/test/RowVersionTest.al
+++ b/tests/bucket-2/145-rowversion/test/RowVersionTest.al
@@ -1,0 +1,60 @@
+codeunit 59381 "RV Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "RV Src";
+
+    [Test]
+    procedure LastUsedRowVersion_IsNonNegative()
+    begin
+        // Positive: without a real DB the stub must still produce a non-negative
+        // BigInteger — a negative value would indicate an unwired return.
+        Assert.IsTrue(Src.LastUsedNonNegative(),
+            'Database.LastUsedRowVersion must be non-negative');
+    end;
+
+    [Test]
+    procedure MinimumActiveRowVersion_IsNonNegative()
+    begin
+        Assert.IsTrue(Src.MinActiveNonNegative(),
+            'Database.MinimumActiveRowVersion must be non-negative');
+    end;
+
+    [Test]
+    procedure LastUsedRowVersion_ReadCompletes()
+    var
+        rv: BigInteger;
+    begin
+        // Negative: guard against a throwing stub — just reading into a variable
+        // must complete successfully.
+        rv := Src.GetLastUsedRowVersion();
+        Assert.IsTrue(rv >= 0, 'Read must complete and return a non-negative BigInteger');
+    end;
+
+    [Test]
+    procedure MinimumActiveRowVersion_ReadCompletes()
+    var
+        rv: BigInteger;
+    begin
+        rv := Src.GetMinimumActiveRowVersion();
+        Assert.IsTrue(rv >= 0, 'Read must complete and return a non-negative BigInteger');
+    end;
+
+    [Test]
+    procedure RowVersions_InvariantRelationship()
+    var
+        lastUsed: BigInteger;
+        minActive: BigInteger;
+    begin
+        // In BC, MinimumActiveRowVersion <= LastUsedRowVersion is the real invariant
+        // (min active version can never exceed the highest version ever used).
+        // Under stubs both are zero so the relation holds trivially; this test
+        // locks the invariant in case future stubs return non-zero values.
+        lastUsed := Src.GetLastUsedRowVersion();
+        minActive := Src.GetMinimumActiveRowVersion();
+        Assert.IsTrue(minActive <= lastUsed,
+            'MinimumActiveRowVersion must be <= LastUsedRowVersion');
+    end;
+}


### PR DESCRIPTION
Closes #483

## Summary

Both BC runtime methods crash standalone (need NavSession). Added a rewriter rule stubbing both invocations to `0L`, preserving the `MinActive <= LastUsed` invariant.

## Changes

- `AlRunner/RoslynRewriter.cs` — `ALDatabase.ALLastUsedRowVersion()` and `ALDatabase.ALMinimumActiveRowVersion()` → `0L`
- `tests/bucket-2/145-rowversion/` — helper + 5 proving tests (non-negative for both, read-completes negative traps, invariant check)
- `docs/coverage.yaml` — both entries marked `covered`

## Verification

- 5/5 new tests pass
- Full bucket-2 regression: 761 pass (3 pre-existing DateTime/timezone failures)