### PR TITLE
feat: DateTime.ToText / Decimal.ToText — session-free via AlCompat.Format

### DIFF
--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -1820,6 +1820,33 @@ public void ClearApplicationMemberVariables() { }
         // Now recurse into children first
         var visited = (InvocationExpressionSyntax)base.VisitInvocationExpression(node)!;
 
+        // `<expr>.ToText(null!)` -> `AlCompat.Format(<expr>)`
+        // BC lowers AL's `dateTimeVar.ToText()` / `dateVar.ToText()` to `navDt.ToText(session)`
+        // where `session` is emitted as `null!`. The real implementation dereferences session
+        // for CultureInfo and crashes with NullReferenceException standalone.
+        // AlCompat.Format handles every BC value type (including NavDate/NavDateTime/NavTime)
+        // without session access. We key on the single-argument `null!` pattern to avoid
+        // catching legitimate ToText(length) overloads — the compiler only emits
+        // `null!` for the session parameter placeholder.
+        if (visited.ArgumentList.Arguments.Count == 1 &&
+            visited.Expression is MemberAccessExpressionSyntax toTextMa &&
+            toTextMa.Name.Identifier.Text == "ToText" &&
+            visited.ArgumentList.Arguments[0].Expression is PostfixUnaryExpressionSyntax pu &&
+            pu.IsKind(SyntaxKind.SuppressNullableWarningExpression) &&
+            pu.Operand is LiteralExpressionSyntax lit &&
+            lit.IsKind(SyntaxKind.NullLiteralExpression))
+        {
+            return SyntaxFactory.InvocationExpression(
+                SyntaxFactory.MemberAccessExpression(
+                    SyntaxKind.SimpleMemberAccessExpression,
+                    SyntaxFactory.IdentifierName("AlCompat"),
+                    SyntaxFactory.IdentifierName("Format")),
+                SyntaxFactory.ArgumentList(
+                    SyntaxFactory.SingletonSeparatedList(
+                        SyntaxFactory.Argument(toTextMa.Expression))))
+                .WithTriviaFrom(visited);
+        }
+
         // NavCode.op_Equality(a, b) / NavCode.op_Inequality(a, b)
         // BC may emit explicit static operator calls for Code[N] comparisons in case statements
         // (rather than a binary == expression), depending on the BC version. Both forms need

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -1743,8 +1743,10 @@ DateTime.Time:
 DateTime.ToText:
   layer: runtime-api
   category: DateTime
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; rewriter redirects `<navDateTime>.ToText(null!)` to `AlCompat.Format` (session-free).
+  tests:
+    - tests/bucket-2/146-totext
 
 # ── Debugger ────────────────────────────────────────────────────
 
@@ -1867,8 +1869,10 @@ Debugger.Stop:
 Decimal.ToText:
   layer: runtime-api
   category: Decimal
-  status: gap
-  notes: overloads=2
+  status: covered
+  notes: overloads=2; BC native `ALCompiler.ToText(null, decimal)` works standalone.
+  tests:
+    - tests/bucket-2/146-totext
 
 # ── Dialog ──────────────────────────────────────────────────────
 

--- a/tests/bucket-2/146-totext/al-runner.json
+++ b/tests/bucket-2/146-totext/al-runner.json
@@ -1,0 +1,4 @@
+{
+  "sourcePath": "./src",
+  "testPath": "./test"
+}

--- a/tests/bucket-2/146-totext/src/ToTextSrc.al
+++ b/tests/bucket-2/146-totext/src/ToTextSrc.al
@@ -1,0 +1,45 @@
+/// Helper codeunit exercising DateTime.ToText() and Decimal.ToText() — the
+/// methods issue #480 says are not implemented.
+codeunit 59390 "TT Src"
+{
+    procedure FormatDateTime(dt: DateTime): Text
+    begin
+        exit(dt.ToText());
+    end;
+
+    procedure FormatDecimal(d: Decimal): Text
+    begin
+        exit(d.ToText());
+    end;
+
+    procedure MakeKnownDateTime(): DateTime
+    begin
+        // Anchor a fixed DateTime so string length / content assertions are
+        // timezone-independent (the wall-clock date is preserved end-to-end).
+        exit(CreateDateTime(DMY2Date(15, 6, 2025), 120000T));
+    end;
+
+    procedure FormatKnownDateTime(): Text
+    var
+        dt: DateTime;
+    begin
+        dt := MakeKnownDateTime();
+        exit(dt.ToText());
+    end;
+
+    procedure FormatDecimalZero(): Text
+    var
+        d: Decimal;
+    begin
+        d := 0;
+        exit(d.ToText());
+    end;
+
+    procedure FormatDecimalSpecific(): Text
+    var
+        d: Decimal;
+    begin
+        d := 123.45;
+        exit(d.ToText());
+    end;
+}

--- a/tests/bucket-2/146-totext/test/ToTextTest.al
+++ b/tests/bucket-2/146-totext/test/ToTextTest.al
@@ -1,0 +1,96 @@
+codeunit 59391 "TT Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "TT Src";
+
+    [Test]
+    procedure DateTimeToText_ReturnsNonEmpty()
+    var
+        dt: DateTime;
+    begin
+        dt := CreateDateTime(DMY2Date(1, 1, 2025), 000000T);
+        Assert.AreNotEqual('', Src.FormatDateTime(dt),
+            'DateTime.ToText must return a non-empty string');
+    end;
+
+    [Test]
+    procedure DateTimeToText_ContainsYear()
+    begin
+        // Format is locale-dependent, but the 4-digit year 2025 must appear
+        // in any sensible DateTime string representation.
+        Assert.IsTrue(
+            StrPos(Src.FormatKnownDateTime(), '2025') > 0,
+            'DateTime.ToText for 2025-06-15 12:00 must contain "2025"');
+    end;
+
+    [Test]
+    procedure DateTimeToText_DifferentValues_DifferentStrings()
+    var
+        a: DateTime;
+        b: DateTime;
+    begin
+        // Negative: guard against a stub that returns the same string for
+        // all inputs — two different DateTimes must produce distinct text.
+        a := CreateDateTime(DMY2Date(1, 1, 2020), 120000T);
+        b := CreateDateTime(DMY2Date(1, 1, 2025), 120000T);
+        Assert.AreNotEqual(Src.FormatDateTime(a), Src.FormatDateTime(b),
+            'Different DateTime values must produce different text');
+    end;
+
+    [Test]
+    procedure DecimalToText_ReturnsNonEmpty()
+    var
+        d: Decimal;
+    begin
+        d := 42.5;
+        Assert.AreNotEqual('', Src.FormatDecimal(d),
+            'Decimal.ToText must return a non-empty string');
+    end;
+
+    [Test]
+    procedure DecimalToText_Zero_ContainsZero()
+    begin
+        // Decimal 0 must produce a string containing '0'.
+        Assert.IsTrue(
+            StrPos(Src.FormatDecimalZero(), '0') > 0,
+            'Decimal 0.ToText must contain the digit 0');
+    end;
+
+    [Test]
+    procedure DecimalToText_SpecificValue_ContainsDigits()
+    var
+        s: Text;
+    begin
+        // Decimal 123.45 must contain at least the integer-part digits.
+        s := Src.FormatDecimalSpecific();
+        Assert.IsTrue(StrPos(s, '123') > 0, 'Decimal 123.45.ToText must contain "123"');
+        Assert.IsTrue(StrPos(s, '45') > 0, 'Decimal 123.45.ToText must contain "45"');
+    end;
+
+    [Test]
+    procedure DecimalToText_DifferentValues_DifferentStrings()
+    var
+        a: Decimal;
+        b: Decimal;
+    begin
+        // Negative: guard against a stub that returns the same string for all inputs.
+        a := 1;
+        b := 9999;
+        Assert.AreNotEqual(Src.FormatDecimal(a), Src.FormatDecimal(b),
+            'Different Decimal values must produce different text');
+    end;
+
+    [Test]
+    procedure DateTimeToText_NotRawZero_NegativeTrap()
+    var
+        dt: DateTime;
+    begin
+        // Negative: guard against returning just "0" (would suggest a default integer).
+        dt := CreateDateTime(DMY2Date(15, 6, 2025), 120000T);
+        Assert.AreNotEqual('0', Src.FormatDateTime(dt),
+            'DateTime.ToText must not return just "0"');
+    end;
+}


### PR DESCRIPTION
Closes #480

## Summary

`Decimal.ToText()` already worked (static `ALCompiler.ToText` handles it). `DateTime.ToText()` threw because BC lowers it to `navDt.ToText(session)` where the real impl dereferences session for CultureInfo.

Added a narrow rewriter rule: `<expr>.ToText(null!)` → `AlCompat.Format(<expr>)`. The `null!` (suppress-nullable + null literal) match is the exact placeholder BC emits for session parameters, so legitimate `ToText(length)` overloads are untouched.

## Changes

- `AlRunner/RoslynRewriter.cs` — new rule in `VisitInvocationExpression` after recursion
- `tests/bucket-2/146-totext/` — helper + 8 proving tests (non-empty, contains-year, different-values-different-strings for both; negative traps)
- `docs/coverage.yaml` — `DateTime.ToText` and `Decimal.ToText` marked `covered`

## Verification

- 8/8 new tests pass
- Full bucket-2: 769 pass (3 pre-existing DateTime/timezone failures)
- Full bucket-1: 661 pass (4 pre-existing failures)