### PR TITLE
feat: Database.UserSecurityId — fixed non-null Guid stub

### DIFF
--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -2644,6 +2644,19 @@ public void ClearApplicationMemberVariables() { }
                     .WithTriviaFrom(visited);
             }
 
+            // ALDatabase.ALUserSecurityId() -> AlCompat.UserSecurityId()
+            // Real impl requires NavSession (crashes with NullReferenceException standalone).
+            // AlCompat.UserSecurityId returns a fixed non-null Guid so stability is preserved
+            // across reads within a test run.
+            if (exprText == "ALDatabase" && methodName == "ALUserSecurityId")
+            {
+                return visited.WithExpression(
+                    SyntaxFactory.MemberAccessExpression(
+                        SyntaxKind.SimpleMemberAccessExpression,
+                        SyntaxFactory.IdentifierName("AlCompat"),
+                        SyntaxFactory.IdentifierName("UserSecurityId")));
+            }
+
             // ALDatabase.ALLastUsedRowVersion() -> 0L
             // ALDatabase.ALMinimumActiveRowVersion() -> 0L
             // BC lowers Database.LastUsedRowVersion / MinimumActiveRowVersion to method

--- a/AlRunner/Runtime/AlScope.cs
+++ b/AlRunner/Runtime/AlScope.cs
@@ -1446,6 +1446,17 @@ public static class AlCompat
     public static NavGuid ALCreateSequentialGuid() => new NavGuid(Guid.NewGuid());
 
     /// <summary>
+    /// Replacement for ALDatabase.ALUserSecurityId() which requires NavSession.
+    /// Returns a fixed non-null Guid stable across reads within a process so tests
+    /// that compare two reads observe equality. The exact value is arbitrary; what
+    /// matters is that it is non-null and stable.
+    /// </summary>
+    private static readonly Guid _userSecurityId =
+        new Guid("22222222-2222-2222-2222-222222222222");
+
+    public static Guid UserSecurityId() => _userSecurityId;
+
+    /// <summary>
     /// Replacement for ALDatabase.ALCurrentTransactionType() which requires NavSession.
     /// The runner has no real transaction tracking; returns TransactionType.Update,
     /// the most common real-world value and a predictable stable stub.

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -1681,8 +1681,10 @@ Database.UserId:
 Database.UserSecurityId:
   layer: runtime-api
   category: Database
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; rewriter routes to AlCompat.UserSecurityId which returns a fixed non-null Guid stable across reads.
+  tests:
+    - tests/bucket-2/147-usersecurityid
 
 # ── Date ────────────────────────────────────────────────────────
 

--- a/tests/bucket-2/147-usersecurityid/al-runner.json
+++ b/tests/bucket-2/147-usersecurityid/al-runner.json
@@ -1,0 +1,4 @@
+{
+  "sourcePath": "./src",
+  "testPath": "./test"
+}

--- a/tests/bucket-2/147-usersecurityid/src/UserSecurityIdSrc.al
+++ b/tests/bucket-2/147-usersecurityid/src/UserSecurityIdSrc.al
@@ -1,0 +1,26 @@
+/// Helper codeunit exercising Database.UserSecurityId.
+codeunit 59540 "USI Src"
+{
+    procedure GetUserSecurityId(): Guid
+    begin
+        exit(Database.UserSecurityId);
+    end;
+
+    procedure IsUserSecurityIdNonNull(): Boolean
+    var
+        g: Guid;
+    begin
+        g := Database.UserSecurityId;
+        exit(not IsNullGuid(g));
+    end;
+
+    procedure BothReadsEqual(): Boolean
+    var
+        a: Guid;
+        b: Guid;
+    begin
+        a := Database.UserSecurityId;
+        b := Database.UserSecurityId;
+        exit(a = b);
+    end;
+}

--- a/tests/bucket-2/147-usersecurityid/test/UserSecurityIdTest.al
+++ b/tests/bucket-2/147-usersecurityid/test/UserSecurityIdTest.al
@@ -1,0 +1,50 @@
+codeunit 59541 "USI Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "USI Src";
+
+    [Test]
+    procedure UserSecurityId_ReadCompletes()
+    var
+        g: Guid;
+    begin
+        // Positive: the read must complete and return a Guid.
+        g := Src.GetUserSecurityId();
+        Assert.IsTrue(true, 'Reading Database.UserSecurityId must not throw');
+    end;
+
+    [Test]
+    procedure UserSecurityId_IsNonNullGuid()
+    begin
+        // Positive: the returned Guid must be non-null — a null-guid stub would
+        // match AL's default-initialised `Guid` value and be useless for downstream
+        // auditing/filter logic.
+        Assert.IsTrue(Src.IsUserSecurityIdNonNull(),
+            'Database.UserSecurityId must be a non-null Guid');
+    end;
+
+    [Test]
+    procedure UserSecurityId_IsStable()
+    begin
+        // Two consecutive reads must return the same Guid — the stub must be
+        // a fixed value, not freshly generated per call.
+        Assert.IsTrue(Src.BothReadsEqual(),
+            'Two consecutive reads of UserSecurityId must return the same Guid');
+    end;
+
+    [Test]
+    procedure UserSecurityId_NotNullGuidLiteral_NegativeTrap()
+    var
+        g: Guid;
+        nullGuid: Guid;
+    begin
+        // Negative: guard against a stub that returns the null Guid {00000000-...}.
+        g := Src.GetUserSecurityId();
+        Clear(nullGuid);
+        Assert.AreNotEqual(nullGuid, g,
+            'Database.UserSecurityId must differ from the zero/null Guid');
+    end;
+}


### PR DESCRIPTION
Closes #479

## Summary

`Database.UserSecurityId` crashed with NullReferenceException standalone (real impl requires NavSession). Added a rewriter rule routing to a new `AlCompat.UserSecurityId()` that returns a fixed non-null Guid so reads are stable across the process.

## Changes

- `AlRunner/RoslynRewriter.cs` — `ALDatabase.ALUserSecurityId()` → `AlCompat.UserSecurityId()`
- `AlRunner/Runtime/AlScope.cs` — new `AlCompat.UserSecurityId()` method returning the fixed Guid `22222222-2222-2222-2222-222222222222`
- `tests/bucket-2/147-usersecurityid/` — helper + 4 proving tests (read-completes, non-null, stability across reads, negative trap against zero Guid)
- `docs/coverage.yaml` — `Database.UserSecurityId` marked `covered`

## Verification

- 4/4 new tests pass
- Full bucket-2: 773 pass (3 pre-existing DateTime/timezone failures)