### PR TITLE
feat: Database.SerialNumber / TenantId / ServiceInstanceId — fixed stubs

### DIFF
--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -1642,6 +1642,35 @@ public void ClearApplicationMemberVariables() { }
                 .WithTriviaFrom(node);
         }
 
+        // ALDatabase.ALTenantID() / ALDatabase.ALSerialNumber() / ALDatabase.ALServiceInstanceID()
+        // BC emits these as method calls on ALDatabase; the real implementations require
+        // NavSession and crash with NullReferenceException standalone. Catch the invocation
+        // before recursion so the member-access rewrite in VisitMemberAccessExpression doesn't
+        // produce an invalid double-call (e.g. ""()).
+        // Stubs return fixed non-empty/non-zero values so consumers that branch on "has tenant
+        // context" see a consistent affirmative — SerialNumber and TenantId are opaque opaque
+        // identifiers (callers just need stability); ServiceInstanceId is traditionally 1.
+        if (node.Expression is MemberAccessExpressionSyntax dbIdMa &&
+            dbIdMa.Expression is IdentifierNameSyntax dbIdIdent &&
+            dbIdIdent.Identifier.Text == "ALDatabase")
+        {
+            var idName = dbIdMa.Name.Identifier.Text;
+            if (idName == "ALTenantID" || idName == "ALSerialNumber")
+            {
+                return SyntaxFactory.LiteralExpression(
+                    SyntaxKind.StringLiteralExpression,
+                    SyntaxFactory.Literal("STANDALONE"))
+                    .WithTriviaFrom(node);
+            }
+            if (idName == "ALServiceInstanceID" || idName == "ALServiceInstanceId")
+            {
+                return SyntaxFactory.LiteralExpression(
+                    SyntaxKind.NumericLiteralExpression,
+                    SyntaxFactory.Literal(1))
+                    .WithTriviaFrom(node);
+            }
+        }
+
         // `NavOption.Create(existing.NavOptionMetadata, V)` — reassignment
         // pattern BC emits when an AL enum variable is re-assigned. Route
         // through AlCompat.CloneTaggedOption so the new instance inherits
@@ -3212,7 +3241,10 @@ public void ClearApplicationMemberVariables() { }
         // These static property accesses crash because ALDatabase requires a live BC session.
         // ALCompanyName routes to MockSession.GetCompanyName() (configurable via --company-name CLI flag).
         // ALUserID redirects to AlScope.UserId (configurable via --user-id CLI flag).
-        // The rest rewrite to empty-string literals — standalone mode has no tenant context.
+        // ALTenantID and ALSerialNumber return a fixed non-empty string ("STANDALONE") so
+        // telemetry / licensing branches that test non-empty behave consistently.
+        // (Note: BC sometimes emits these as method calls instead — see the invocation
+        // handler at the top of VisitInvocationExpression which uses the same placeholder.)
         if (visited.Expression is IdentifierNameSyntax dbId &&
             dbId.Identifier.Text == "ALDatabase" &&
             ALDatabaseStringProps.Contains(visited.Name.Identifier.Text))
@@ -3236,7 +3268,7 @@ public void ClearApplicationMemberVariables() { }
             }
             return SyntaxFactory.LiteralExpression(
                 SyntaxKind.StringLiteralExpression,
-                SyntaxFactory.Literal(""))
+                SyntaxFactory.Literal("STANDALONE"))
                 .WithTriviaFrom(visited);
         }
 

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -1625,14 +1625,18 @@ Database.SelectLatestVersion:
 Database.SerialNumber:
   layer: runtime-api
   category: Database
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; rewriter stubs ALSerialNumber (property and method) to the fixed string "STANDALONE".
+  tests:
+    - tests/bucket-2/148-db-identity
 
 Database.ServiceInstanceId:
   layer: runtime-api
   category: Database
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; rewriter stubs ALServiceInstanceID() to 1 (non-zero instance id).
+  tests:
+    - tests/bucket-2/148-db-identity
 
 Database.SessionId:
   layer: runtime-api
@@ -1661,8 +1665,10 @@ Database.SID:
 Database.TenantId:
   layer: runtime-api
   category: Database
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; rewriter stubs ALTenantID (property and method) to the fixed string "STANDALONE".
+  tests:
+    - tests/bucket-2/148-db-identity
 
 Database.UnregisterTableConnection:
   layer: runtime-api

--- a/tests/bucket-2/148-db-identity/al-runner.json
+++ b/tests/bucket-2/148-db-identity/al-runner.json
@@ -1,0 +1,4 @@
+{
+  "sourcePath": "./src",
+  "testPath": "./test"
+}

--- a/tests/bucket-2/148-db-identity/src/DbIdentitySrc.al
+++ b/tests/bucket-2/148-db-identity/src/DbIdentitySrc.al
@@ -1,0 +1,19 @@
+/// Helper codeunit exercising Database.SerialNumber / Database.TenantId /
+/// Database.ServiceInstanceId — the identity built-ins listed in issue #478.
+codeunit 59550 "DBI Src"
+{
+    procedure GetSerialNumber(): Text
+    begin
+        exit(Database.SerialNumber);
+    end;
+
+    procedure GetTenantId(): Text
+    begin
+        exit(Database.TenantId);
+    end;
+
+    procedure GetServiceInstanceId(): Integer
+    begin
+        exit(Database.ServiceInstanceId);
+    end;
+}

--- a/tests/bucket-2/148-db-identity/test/DbIdentityTest.al
+++ b/tests/bucket-2/148-db-identity/test/DbIdentityTest.al
@@ -1,0 +1,73 @@
+codeunit 59551 "DBI Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "DBI Src";
+
+    [Test]
+    procedure SerialNumber_NonEmpty()
+    begin
+        // Positive: standalone SerialNumber stub must return a non-empty string —
+        // consumers (telemetry, licensing) branch on empty vs non-empty and an
+        // empty stub makes that branch indistinguishable from a genuine missing
+        // tenant context.
+        Assert.AreNotEqual('', Src.GetSerialNumber(),
+            'Database.SerialNumber must return a non-empty string');
+    end;
+
+    [Test]
+    procedure TenantId_NonEmpty()
+    begin
+        Assert.AreNotEqual('', Src.GetTenantId(),
+            'Database.TenantId must return a non-empty string');
+    end;
+
+    [Test]
+    procedure ServiceInstanceId_NonZero()
+    begin
+        // ServiceInstanceId is an Integer; stub must return a positive ID since
+        // a valid BC service instance always has a non-zero ID.
+        Assert.AreNotEqual(0, Src.GetServiceInstanceId(),
+            'Database.ServiceInstanceId must return a non-zero integer');
+    end;
+
+    [Test]
+    procedure SerialNumber_Stable()
+    begin
+        // Two consecutive reads must yield the same value — the stub must be a
+        // fixed string, not a fresh random value per call.
+        Assert.AreEqual(Src.GetSerialNumber(), Src.GetSerialNumber(),
+            'Database.SerialNumber must be stable across reads');
+    end;
+
+    [Test]
+    procedure TenantId_Stable()
+    begin
+        Assert.AreEqual(Src.GetTenantId(), Src.GetTenantId(),
+            'Database.TenantId must be stable across reads');
+    end;
+
+    [Test]
+    procedure ServiceInstanceId_Stable()
+    begin
+        Assert.AreEqual(Src.GetServiceInstanceId(), Src.GetServiceInstanceId(),
+            'Database.ServiceInstanceId must be stable across reads');
+    end;
+
+    [Test]
+    procedure ReadsComplete_NegativeTrap()
+    var
+        a: Text;
+        b: Text;
+        c: Integer;
+    begin
+        // Negative: guard against a throwing stub — reading all three must complete.
+        a := Src.GetSerialNumber();
+        b := Src.GetTenantId();
+        c := Src.GetServiceInstanceId();
+        Assert.IsTrue((a <> '') and (b <> '') and (c <> 0),
+            'All three identity reads must complete and return non-trivial values');
+    end;
+}


### PR DESCRIPTION
Closes #478

## Summary

All three crashed standalone. The prior code stubbed `ALSerialNumber` / `ALTenantID` as property accesses in `VisitMemberAccessExpression`, but BC sometimes emits them as method calls (`ALDatabase.ALTenantID()`), producing the invalid `""()` form after the property rewrite. `ALServiceInstanceID()` wasn't stubbed at all.

## Changes

- `AlRunner/RoslynRewriter.cs` — new early `VisitInvocationExpression` handler for `ALDatabase.ALTenantID()`, `ALDatabase.ALSerialNumber()`, `ALDatabase.ALServiceInstanceID()`. The property-access fallback is changed from `""` to `"STANDALONE"` so non-empty branches behave consistently.
- `tests/bucket-2/148-db-identity/` — helper + 7 proving tests (non-empty/non-zero for all, stability across reads, negative trap)
- `docs/coverage.yaml` — all three marked `covered`

## Verification

- 7/7 new tests pass
- Full bucket-2: 780 pass (3 pre-existing DateTime/timezone failures)
- Full bucket-1: 661 pass (4 pre-existing failures)