### PR TITLE
feat: DataTransfer.UpdateAuditFields round-trip property

### DIFF
--- a/AlRunner/Runtime/MockDataTransfer.cs
+++ b/AlRunner/Runtime/MockDataTransfer.cs
@@ -16,6 +16,14 @@ public class MockDataTransfer
     private readonly List<(int SourceFieldId, int TargetFieldId)> _fieldMappings = new();
     private readonly List<(object Value, int TargetFieldId)> _constantValues = new();
 
+    /// <summary>
+    /// DataTransfer.UpdateAuditFields — when true, BC auto-populates SystemModifiedAt/By
+    /// on the target records during CopyRows/CopyFields. Default is false.
+    /// In standalone mode there is no real database so audit-field propagation is a no-op,
+    /// but the property must still round-trip for test code that reads it back.
+    /// </summary>
+    public bool ALUpdateAuditFields { get; set; }
+
     /// <summary>Set source and target table IDs.</summary>
     public void ALSetTables(int sourceTableId, int targetTableId)
     {

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -1491,8 +1491,10 @@ DataTransfer.SetTables:
 DataTransfer.UpdateAuditFields:
   layer: runtime-api
   category: DataTransfer
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; auto-property added to MockDataTransfer (default false; round-trips on set). CopyRows/CopyFields remain no-ops as there is no real DB.
+  tests:
+    - tests/bucket-2/149-datatransfer-audit
 
 # ── Database ────────────────────────────────────────────────────
 

--- a/tests/bucket-2/149-datatransfer-audit/al-runner.json
+++ b/tests/bucket-2/149-datatransfer-audit/al-runner.json
@@ -1,0 +1,4 @@
+{
+  "sourcePath": "./src",
+  "testPath": "./test"
+}

--- a/tests/bucket-2/149-datatransfer-audit/src/DataTransferAuditSrc.al
+++ b/tests/bucket-2/149-datatransfer-audit/src/DataTransferAuditSrc.al
@@ -1,0 +1,45 @@
+table 59560 "DTA Item"
+{
+    DataClassification = CustomerContent;
+    fields
+    {
+        field(1; "No."; Code[20]) { }
+        field(2; Description; Text[100]) { }
+        field(3; "Created At"; DateTime) { }
+        field(4; "Created By"; Text[50]) { }
+    }
+    keys
+    {
+        key(PK; "No.") { Clustered = true; }
+    }
+}
+
+/// Helper codeunit exercising DataTransfer.UpdateAuditFields — the property
+/// issue #475 says is not stubbed.
+codeunit 59560 "DTA Src"
+{
+    procedure GetUpdateAuditFieldsDefault(): Boolean
+    var
+        DT: DataTransfer;
+    begin
+        exit(DT.UpdateAuditFields);
+    end;
+
+    procedure SetAndGetUpdateAuditFields(Val: Boolean): Boolean
+    var
+        DT: DataTransfer;
+    begin
+        DT.UpdateAuditFields := Val;
+        exit(DT.UpdateAuditFields);
+    end;
+
+    procedure CopyFieldsWithAudit()
+    var
+        DT: DataTransfer;
+    begin
+        DT.SetTables(Database::"DTA Item", Database::"DTA Item");
+        DT.AddFieldValue(1, 1);
+        DT.UpdateAuditFields := true;
+        DT.CopyFields();
+    end;
+}

--- a/tests/bucket-2/149-datatransfer-audit/test/DataTransferAuditTest.al
+++ b/tests/bucket-2/149-datatransfer-audit/test/DataTransferAuditTest.al
@@ -1,0 +1,40 @@
+codeunit 59561 "DTA Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "DTA Src";
+
+    [Test]
+    procedure UpdateAuditFields_DefaultFalse()
+    begin
+        // Positive: BC's DataTransfer.UpdateAuditFields default is false.
+        Assert.IsFalse(Src.GetUpdateAuditFieldsDefault(),
+            'DataTransfer.UpdateAuditFields must default to false');
+    end;
+
+    [Test]
+    procedure UpdateAuditFields_SetTrueReadBack()
+    begin
+        // Positive: setter must take effect; reader must round-trip.
+        Assert.IsTrue(Src.SetAndGetUpdateAuditFields(true),
+            'UpdateAuditFields := true must read back as true');
+    end;
+
+    [Test]
+    procedure UpdateAuditFields_SetFalseReadBack()
+    begin
+        Assert.IsFalse(Src.SetAndGetUpdateAuditFields(false),
+            'UpdateAuditFields := false must read back as false');
+    end;
+
+    [Test]
+    procedure CopyFieldsWithAudit_DoesNotThrow()
+    begin
+        // Negative trap: the entire flow (SetTables + AddFieldValue +
+        // UpdateAuditFields := true + CopyFields) must complete without throwing.
+        Src.CopyFieldsWithAudit();
+        Assert.IsTrue(true, 'CopyFields with UpdateAuditFields must not throw');
+    end;
+}


### PR DESCRIPTION
Closes #475

## Summary

`ALUpdateAuditFields` was missing from `MockDataTransfer`, causing CS1061 compile errors when AL code read or set `DataTransfer.UpdateAuditFields`.

## Changes

- `AlRunner/Runtime/MockDataTransfer.cs` — add `public bool ALUpdateAuditFields { get; set; }` (default `false`, round-trips on set; CopyRows/CopyFields stay no-ops standalone)
- `tests/bucket-2/149-datatransfer-audit/` — helper + 4 proving tests (default-false, set-true/set-false round-trip, CopyFields+audit flow completes without throwing)
- `docs/coverage.yaml` — `DataTransfer.UpdateAuditFields` marked `covered`

## Verification

- 4/4 new tests pass
- Full bucket-2: 784 pass (3 pre-existing DateTime/timezone failures)