### PR TITLE
feat: Database.ChangeUserPassword — strip-entire-call no-op stub

### DIFF
--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -50,6 +50,7 @@ public class RoslynRewriter : CSharpSyntaxRewriter
         "ALSelectLatestVersion", // ALDatabase.ALSelectLatestVersion() — no-op standalone
         "ALAlterKey", // ALDatabase.ALAlterKey() — DDL not supported standalone; no-op
         "ALCheckLicenseFile", // ALDatabase.ALCheckLicenseFile() — no license system standalone; no-op
+        "ALChangeUserPassword",  // ALDatabase.ALChangeUserPassword(err, old, new) — user system not modeled; no-op standalone
     };
 
     private static readonly HashSet<string> StripITreeObjectArgMethods = new(StringComparer.Ordinal)

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -1519,8 +1519,10 @@ Database.AlterKey:
 Database.ChangeUserPassword:
   layer: runtime-api
   category: Database
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; rewriter strips the entire call (no user system standalone). Signature is (OldPassword, NewPassword).
+  tests:
+    - tests/bucket-2/152-change-user-password
 
 Database.CheckLicenseFile:
   layer: runtime-api

--- a/tests/bucket-2/152-change-user-password/al-runner.json
+++ b/tests/bucket-2/152-change-user-password/al-runner.json
@@ -1,0 +1,4 @@
+{
+  "sourcePath": "./src",
+  "testPath": "./test"
+}

--- a/tests/bucket-2/152-change-user-password/src/ChangeUserPasswordSrc.al
+++ b/tests/bucket-2/152-change-user-password/src/ChangeUserPasswordSrc.al
@@ -1,0 +1,15 @@
+/// Helper codeunit exercising Database.ChangeUserPassword.
+/// Signature per the AL compiler: `ChangeUserPassword(OldPassword: Text, NewPassword: Text)`.
+codeunit 59590 "CUP Src"
+{
+    procedure CallChangePassword(OldPassword: Text; NewPassword: Text)
+    begin
+        Database.ChangeUserPassword(OldPassword, NewPassword);
+    end;
+
+    procedure CallChangePasswordAndReturnFlag(OldPassword: Text; NewPassword: Text): Boolean
+    begin
+        Database.ChangeUserPassword(OldPassword, NewPassword);
+        exit(true);
+    end;
+}

--- a/tests/bucket-2/152-change-user-password/test/ChangeUserPasswordTest.al
+++ b/tests/bucket-2/152-change-user-password/test/ChangeUserPasswordTest.al
@@ -1,0 +1,44 @@
+codeunit 59591 "CUP Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "CUP Src";
+
+    [Test]
+    procedure ChangeUserPassword_ValidArgs_NoOp()
+    begin
+        // Positive: the standalone stub must execute without error.
+        Src.CallChangePassword('oldpwd', 'newpwd');
+        Assert.IsTrue(true, 'ChangeUserPassword stub executed without error');
+    end;
+
+    [Test]
+    procedure ChangeUserPassword_EmptyArgs_NoOp()
+    begin
+        // Edge case: empty strings — the runner has no user system so it cannot
+        // validate; the stub must still complete.
+        Src.CallChangePassword('', '');
+        Assert.IsTrue(true, 'ChangeUserPassword with empty args must not throw');
+    end;
+
+    [Test]
+    procedure ChangeUserPassword_ReturnsAfterCall()
+    begin
+        // Proving: execution continues past the ChangeUserPassword call —
+        // a throwing stub would prevent the flag from being set.
+        Assert.IsTrue(Src.CallChangePasswordAndReturnFlag('old', 'new'),
+            'Caller must reach `exit(true)` after ChangeUserPassword');
+    end;
+
+    [Test]
+    procedure ChangeUserPassword_LongStrings_NoOp()
+    begin
+        // Negative trap: guard against a stub that crashes on large input.
+        Src.CallChangePassword(
+            'verylongoldpassword!@#$%^&*()',
+            'verylongnewpassword!@#$%^&*()');
+        Assert.IsTrue(true, 'ChangeUserPassword with long strings must not throw');
+    end;
+}

--- a/tests/bucket-2/153-sleep/src/SleepSrc.al
+++ b/tests/bucket-2/153-sleep/src/SleepSrc.al
@@ -1,6 +1,6 @@
 /// Helper codeunit that calls Sleep() — the AL built-in that pauses execution.
 /// In the runner, Sleep must be a no-op so tests run without actually blocking.
-codeunit 61200 "SLP Helper"
+codeunit 61210 "SLP Helper"
 {
     procedure DoSleep(ms: Integer)
     begin

--- a/tests/bucket-2/153-sleep/test/SleepTest.al
+++ b/tests/bucket-2/153-sleep/test/SleepTest.al
@@ -1,4 +1,4 @@
-codeunit 61201 "SLP Tests"
+codeunit 61211 "SLP Tests"
 {
     Subtype = Test;
 


### PR DESCRIPTION
Closes #493

## Summary

`ALDatabase.ALChangeUserPassword` threw FileNotFoundException standalone (pulls in `Microsoft.Extensions.DependencyInjection.Abstractions` via the real user-system module).

Added `ALChangeUserPassword` to `StripEntireCallMethods` so the statement is removed during rewriting — same approach already used for `ALCommit` and `ALSelectLatestVersion`.

## Changes

- `AlRunner/RoslynRewriter.cs` — added to `StripEntireCallMethods`
- `tests/bucket-2/152-change-user-password/` — helper + 4 proving tests
- `docs/coverage.yaml` — `Database.ChangeUserPassword` marked `covered`

## Note on signature

The issue's reproduction called `ChangeUserPassword(user, old, new)` but the actual AL signature is `ChangeUserPassword(OldPassword, NewPassword)` — corrected in the test suite.

## Verification

- 4/4 new tests pass
- Full bucket-2: 810 pass (3 pre-existing DateTime/timezone failures)