### PR TITLE
test: List.RemoveRange proving tests (#497)

### DIFF
--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -492,8 +492,8 @@ List.Reverse:
 List.RemoveRange:
   layer: runtime-api
   category: List
-  status: gap
-  notes: List.RemoveRange(index, count) does not compile with AL compiler 16.2; not a valid AL syntax at this toolchain version
+  status: covered
+  notes: available from BC 26+; NavList<T> (real BC type) provides ALRemoveRange; tests/bucket-2/152-list-removerange
 
 object_reference_type:
   layer: syntax

--- a/tests/bucket-2/152-list-removerange/src/ListRemoveRangeSrc.al
+++ b/tests/bucket-2/152-list-removerange/src/ListRemoveRangeSrc.al
@@ -1,0 +1,35 @@
+/// Helper codeunit that exercises List.RemoveRange so tests can call it
+/// without managing list state inline.
+codeunit 61100 "LRR Helper"
+{
+    /// Build [1,2,3,4,5] and call RemoveRange(startIndex, count).
+    /// Returns the resulting list so the test can assert its contents.
+    procedure BuildAndRemoveRange(startIndex: Integer; count: Integer): List of [Integer]
+    var
+        Items: List of [Integer];
+    begin
+        Items.Add(1);
+        Items.Add(2);
+        Items.Add(3);
+        Items.Add(4);
+        Items.Add(5);
+        Items.RemoveRange(startIndex, count);
+        exit(Items);
+    end;
+
+    /// Return count of elements after a RemoveRange on a single-element list.
+    procedure RemoveOnlyElement(): List of [Integer]
+    var
+        Items: List of [Integer];
+    begin
+        Items.Add(42);
+        Items.RemoveRange(1, 1);
+        exit(Items);
+    end;
+
+    /// Proving helper — not related to RemoveRange; proves the codeunit is live.
+    procedure AddWithBonus(a: Integer; b: Integer): Integer
+    begin
+        exit(a + b + 1);
+    end;
+}

--- a/tests/bucket-2/152-list-removerange/test/ListRemoveRangeTest.al
+++ b/tests/bucket-2/152-list-removerange/test/ListRemoveRangeTest.al
@@ -1,0 +1,89 @@
+codeunit 61101 "LRR RemoveRange Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    [Test]
+    procedure RemoveRange_Middle_LeavesFirstAndLast()
+    var
+        Helper: Codeunit "LRR Helper";
+        Result: List of [Integer];
+    begin
+        // Positive: RemoveRange(2, 3) on [1,2,3,4,5] leaves [1,5].
+        Result := Helper.BuildAndRemoveRange(2, 3);
+        Assert.AreEqual(2, Result.Count(), 'Count must be 2 after removing 3 middle elements');
+        Assert.AreEqual(1, Result.Get(1), 'First element must be 1');
+        Assert.AreEqual(5, Result.Get(2), 'Second element must be 5');
+    end;
+
+    [Test]
+    procedure RemoveRange_FromStart_LeavesRemainder()
+    var
+        Helper: Codeunit "LRR Helper";
+        Result: List of [Integer];
+    begin
+        // Positive: RemoveRange(1, 2) on [1,2,3,4,5] leaves [3,4,5].
+        Result := Helper.BuildAndRemoveRange(1, 2);
+        Assert.AreEqual(3, Result.Count(), 'Count must be 3 after removing 2 from start');
+        Assert.AreEqual(3, Result.Get(1), 'First element must be 3');
+        Assert.AreEqual(4, Result.Get(2), 'Second element must be 4');
+        Assert.AreEqual(5, Result.Get(3), 'Third element must be 5');
+    end;
+
+    [Test]
+    procedure RemoveRange_FromEnd_LeavesHead()
+    var
+        Helper: Codeunit "LRR Helper";
+        Result: List of [Integer];
+    begin
+        // Positive: RemoveRange(4, 2) on [1,2,3,4,5] leaves [1,2,3].
+        Result := Helper.BuildAndRemoveRange(4, 2);
+        Assert.AreEqual(3, Result.Count(), 'Count must be 3 after removing 2 from end');
+        Assert.AreEqual(1, Result.Get(1), 'First element must be 1');
+        Assert.AreEqual(2, Result.Get(2), 'Second element must be 2');
+        Assert.AreEqual(3, Result.Get(3), 'Third element must be 3');
+    end;
+
+    [Test]
+    procedure RemoveRange_SingleElement_EmptiesList()
+    var
+        Helper: Codeunit "LRR Helper";
+        Result: List of [Integer];
+    begin
+        // Edge case: removing the only element leaves an empty list.
+        Result := Helper.RemoveOnlyElement();
+        Assert.AreEqual(0, Result.Count(), 'List must be empty after removing only element');
+    end;
+
+    [Test]
+    procedure RemoveRange_ResultNotOriginalSize()
+    var
+        Helper: Codeunit "LRR Helper";
+        Result: List of [Integer];
+    begin
+        // Negative: after RemoveRange(2, 3) the count must NOT be 5.
+        Result := Helper.BuildAndRemoveRange(2, 3);
+        Assert.AreNotEqual(5, Result.Count(), 'Count must not be 5 after removal');
+    end;
+
+    [Test]
+    procedure AddWithBonus_ProvingCompilationUnitLive()
+    var
+        Helper: Codeunit "LRR Helper";
+    begin
+        // Proving: the codeunit is live — real computation returns a+b+1.
+        Assert.AreEqual(8, Helper.AddWithBonus(3, 4), 'AddWithBonus(3,4) must return 3+4+1=8');
+        Assert.AreEqual(1, Helper.AddWithBonus(0, 0), 'AddWithBonus(0,0) must return 0+0+1=1');
+    end;
+
+    [Test]
+    procedure AddWithBonus_NotPlainSum()
+    var
+        Helper: Codeunit "LRR Helper";
+    begin
+        // Negative: AddWithBonus must NOT return a plain sum (no-op trap guard).
+        Assert.AreNotEqual(7, Helper.AddWithBonus(3, 4), 'AddWithBonus must not just return a+b');
+    end;
+}


### PR DESCRIPTION
Closes #497

## What

`List.RemoveRange(Index, Count)` removes `Count` elements starting at `Index` (1-based) from a `List of [T]`. This feature is available in BC 26+ via `NavList<T>.ALRemoveRange`.

## How

`NavList<T>` is a real BC type (from the Microsoft DLL, not a mock). The BC compiler lowers `list.RemoveRange(i, n)` to `list.ALRemoveRange(i, n)` on the native `NavList<T>` — no runner mock changes are needed. The gap was simply missing test coverage.

## Tests

New suite `tests/bucket-2/152-list-removerange/`:
- `RemoveRange_Middle_LeavesFirstAndLast` — removes 3 elements from middle of [1,2,3,4,5], leaves [1,5]
- `RemoveRange_FromStart_LeavesRemainder` — removes 2 from start, leaves [3,4,5]
- `RemoveRange_FromEnd_LeavesHead` — removes 2 from end, leaves [1,2,3]
- `RemoveRange_SingleElement_EmptiesList` — removes the only element, count becomes 0
- `RemoveRange_ResultNotOriginalSize` — negative trap: count ≠ original size
- `AddWithBonus_ProvingCompilationUnitLive` / `AddWithBonus_NotPlainSum` — codeunit-live guard

## Coverage

`docs/coverage.yaml`: `List.RemoveRange` gap → covered