### PR TITLE
feat: Database.CheckLicenseFile no-op stub (#501)

### DIFF
--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -49,6 +49,7 @@ public class RoslynRewriter : CSharpSyntaxRewriter
         "ALCommit",   // ALDatabase.ALCommit() — SQL transaction commit, no-op standalone
         "ALSelectLatestVersion", // ALDatabase.ALSelectLatestVersion() — no-op standalone
         "ALAlterKey", // ALDatabase.ALAlterKey() — DDL not supported standalone; no-op
+        "ALCheckLicenseFile", // ALDatabase.ALCheckLicenseFile() — no license system standalone; no-op
     };
 
     private static readonly HashSet<string> StripITreeObjectArgMethods = new(StringComparer.Ordinal)

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -1525,8 +1525,8 @@ Database.ChangeUserPassword:
 Database.CheckLicenseFile:
   layer: runtime-api
   category: Database
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; no-op stub (no license system standalone); tests/bucket-2/153-database-checklicensefile
 
 Database.Commit:
   layer: runtime-api

--- a/tests/bucket-2/153-database-checklicensefile/src/CheckLicenseFileSrc.al
+++ b/tests/bucket-2/153-database-checklicensefile/src/CheckLicenseFileSrc.al
@@ -1,0 +1,16 @@
+/// Helper codeunit that wraps Database.CheckLicenseFile so the test can
+/// exercise it without calling it inline.
+codeunit 61200 "CLF Helper"
+{
+    /// Call Database.CheckLicenseFile() — must be a no-op stub in standalone mode.
+    procedure CallCheckLicenseFile()
+    begin
+        Database.CheckLicenseFile();
+    end;
+
+    /// Proving helper — returns a+b+1 to verify the codeunit is live.
+    procedure AddWithBonus(a: Integer; b: Integer): Integer
+    begin
+        exit(a + b + 1);
+    end;
+}

--- a/tests/bucket-2/153-database-checklicensefile/src/CheckLicenseFileSrc.al
+++ b/tests/bucket-2/153-database-checklicensefile/src/CheckLicenseFileSrc.al
@@ -1,11 +1,11 @@
-/// Helper codeunit that wraps Database.CheckLicenseFile so the test can
-/// exercise it without calling it inline.
+/// Helper codeunit that wraps Database.CheckLicenseFile(KeyNumber) so the
+/// test can exercise it without calling it inline.
 codeunit 61200 "CLF Helper"
 {
-    /// Call Database.CheckLicenseFile() — must be a no-op stub in standalone mode.
-    procedure CallCheckLicenseFile()
+    /// Call Database.CheckLicenseFile(keyNumber) — must be a no-op stub in standalone mode.
+    procedure CallCheckLicenseFile(keyNumber: Integer)
     begin
-        Database.CheckLicenseFile();
+        Database.CheckLicenseFile(keyNumber);
     end;
 
     /// Proving helper — returns a+b+1 to verify the codeunit is live.

--- a/tests/bucket-2/153-database-checklicensefile/test/CheckLicenseFileTest.al
+++ b/tests/bucket-2/153-database-checklicensefile/test/CheckLicenseFileTest.al
@@ -6,13 +6,23 @@ codeunit 61201 "CLF CheckLicenseFile Test"
         Assert: Codeunit Assert;
 
     [Test]
-    procedure CheckLicenseFile_NoOp_ExecutesWithoutError()
+    procedure CheckLicenseFile_NoOp_KeyNumber1()
     var
         Helper: Codeunit "CLF Helper";
     begin
-        // Positive: Database.CheckLicenseFile() must execute without error (no-op stub).
-        Helper.CallCheckLicenseFile();
-        Assert.IsTrue(true, 'CheckLicenseFile() must complete without error');
+        // Positive: Database.CheckLicenseFile(1) must execute without error (no-op stub).
+        Helper.CallCheckLicenseFile(1);
+        Assert.IsTrue(true, 'CheckLicenseFile(1) must complete without error');
+    end;
+
+    [Test]
+    procedure CheckLicenseFile_NoOp_KeyNumber0()
+    var
+        Helper: Codeunit "CLF Helper";
+    begin
+        // Positive: Database.CheckLicenseFile(0) must also be a no-op.
+        Helper.CallCheckLicenseFile(0);
+        Assert.IsTrue(true, 'CheckLicenseFile(0) must complete without error');
     end;
 
     [Test]
@@ -21,8 +31,8 @@ codeunit 61201 "CLF CheckLicenseFile Test"
         Helper: Codeunit "CLF Helper";
     begin
         // Edge case: calling CheckLicenseFile multiple times must not error.
-        Helper.CallCheckLicenseFile();
-        Helper.CallCheckLicenseFile();
+        Helper.CallCheckLicenseFile(1);
+        Helper.CallCheckLicenseFile(2);
         Assert.IsTrue(true, 'CheckLicenseFile() called twice must complete without error');
     end;
 

--- a/tests/bucket-2/153-database-checklicensefile/test/CheckLicenseFileTest.al
+++ b/tests/bucket-2/153-database-checklicensefile/test/CheckLicenseFileTest.al
@@ -1,0 +1,47 @@
+codeunit 61201 "CLF CheckLicenseFile Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    [Test]
+    procedure CheckLicenseFile_NoOp_ExecutesWithoutError()
+    var
+        Helper: Codeunit "CLF Helper";
+    begin
+        // Positive: Database.CheckLicenseFile() must execute without error (no-op stub).
+        Helper.CallCheckLicenseFile();
+        Assert.IsTrue(true, 'CheckLicenseFile() must complete without error');
+    end;
+
+    [Test]
+    procedure CheckLicenseFile_CalledTwice_NoError()
+    var
+        Helper: Codeunit "CLF Helper";
+    begin
+        // Edge case: calling CheckLicenseFile multiple times must not error.
+        Helper.CallCheckLicenseFile();
+        Helper.CallCheckLicenseFile();
+        Assert.IsTrue(true, 'CheckLicenseFile() called twice must complete without error');
+    end;
+
+    [Test]
+    procedure AddWithBonus_ProvingCompilationUnitLive()
+    var
+        Helper: Codeunit "CLF Helper";
+    begin
+        // Proving: the codeunit is live — real computation returns a+b+1.
+        Assert.AreEqual(8, Helper.AddWithBonus(3, 4), 'AddWithBonus(3,4) must return 3+4+1=8');
+        Assert.AreEqual(1, Helper.AddWithBonus(0, 0), 'AddWithBonus(0,0) must return 0+0+1=1');
+    end;
+
+    [Test]
+    procedure AddWithBonus_NotPlainSum()
+    var
+        Helper: Codeunit "CLF Helper";
+    begin
+        // Negative: AddWithBonus must NOT return a plain sum (no-op trap guard).
+        Assert.AreNotEqual(7, Helper.AddWithBonus(3, 4), 'AddWithBonus must not just return a+b');
+    end;
+}


### PR DESCRIPTION
Closes #501

## What

`Database.CheckLicenseFile()` is a licensing operation. The runner has no license system, so it's a no-op stub.

## How

Added `ALCheckLicenseFile` to `StripEntireCallMethods` in `RoslynRewriter.cs`. The BC compiler lowers `Database.CheckLicenseFile()` to `ALDatabase.ALCheckLicenseFile()`. The rewriter strips the entire expression statement to an empty statement — same pattern as `ALCommit`, `ALSelectLatestVersion`, and `ALAlterKey`.

## Tests

New suite `tests/bucket-2/153-database-checklicensefile/`:
- `CheckLicenseFile_NoOp_ExecutesWithoutError` — single call completes without error
- `CheckLicenseFile_CalledTwice_NoError` — repeated calls are safe
- `AddWithBonus_ProvingCompilationUnitLive` — proves codeunit is live
- `AddWithBonus_NotPlainSum` — trap guard against no-op mock

## Coverage

`docs/coverage.yaml`: `Database.CheckLicenseFile` gap → covered