### PR TITLE
feat: Database.ExportData no-op stub (#505)

### DIFF
--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -49,6 +49,7 @@ public class RoslynRewriter : CSharpSyntaxRewriter
         "ALCommit",   // ALDatabase.ALCommit() — SQL transaction commit, no-op standalone
         "ALSelectLatestVersion", // ALDatabase.ALSelectLatestVersion() — no-op standalone
         "ALAlterKey", // ALDatabase.ALAlterKey() — DDL not supported standalone; no-op
+        "ALExportData", // ALDatabase.ALExportData() — file I/O not available standalone; no-op
     };
 
     private static readonly HashSet<string> StripITreeObjectArgMethods = new(StringComparer.Ordinal)

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -1564,8 +1564,10 @@ Database.DataFileInformation:
 Database.ExportData:
   layer: runtime-api
   category: Database
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; no-op stub (file I/O out of scope)
+  tests:
+    - tests/bucket-2/153-database-export-data
 
 Database.GetDefaultTableConnection:
   layer: runtime-api

--- a/tests/bucket-2/153-database-export-data/src/DatabaseExportDataSrc.al
+++ b/tests/bucket-2/153-database-export-data/src/DatabaseExportDataSrc.al
@@ -1,0 +1,16 @@
+/// Helper that calls Database.ExportData — must be a no-op stub in the runner
+/// since file I/O is not available without a BC service tier.
+codeunit 50153 "DED Helper"
+{
+    /// Call Database.ExportData with a filename — runner must not throw.
+    procedure CallExportData(FileName: Text)
+    begin
+        Database.ExportData(FileName);
+    end;
+
+    /// Prove helper itself is callable (ensures compilation unit is live).
+    procedure Add(a: Integer; b: Integer): Integer
+    begin
+        exit(a + b);
+    end;
+}

--- a/tests/bucket-2/153-database-export-data/src/DatabaseExportDataSrc.al
+++ b/tests/bucket-2/153-database-export-data/src/DatabaseExportDataSrc.al
@@ -14,3 +14,4 @@ codeunit 50153 "DED Helper"
         exit(a + b);
     end;
 }
+

--- a/tests/bucket-2/153-database-export-data/test/DatabaseExportDataTest.al
+++ b/tests/bucket-2/153-database-export-data/test/DatabaseExportDataTest.al
@@ -33,7 +33,7 @@ codeunit 50154 "DED Database ExportData Test"
     end;
 
     [Test]
-    procedure HelperCodeunit_Add_ProvesBusiness Logic()
+    procedure HelperCodeunit_Add_ProvidesBusinessLogic()
     begin
         // Positive: helper codeunit alongside ExportData call is fully functional.
         Assert.AreEqual(7, Helper.Add(3, 4), 'Add(3,4) must return 7');

--- a/tests/bucket-2/153-database-export-data/test/DatabaseExportDataTest.al
+++ b/tests/bucket-2/153-database-export-data/test/DatabaseExportDataTest.al
@@ -1,0 +1,49 @@
+codeunit 50154 "DED Database ExportData Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Helper: Codeunit "DED Helper";
+
+    [Test]
+    procedure ExportData_WithFilename_DoesNotThrow()
+    begin
+        // Positive: Database.ExportData(FileName) must compile and execute without
+        // throwing an error. The runner stubs it as a no-op (file I/O out of scope).
+        Helper.CallExportData('test.dat');
+        Assert.IsTrue(true, 'ExportData must not throw');
+    end;
+
+    [Test]
+    procedure ExportData_WithEmptyFilename_DoesNotThrow()
+    begin
+        // Positive: empty filename must also be accepted without error.
+        Helper.CallExportData('');
+        Assert.IsTrue(true, 'ExportData with empty filename must not throw');
+    end;
+
+    [Test]
+    procedure ExportData_CalledMultipleTimes_DoesNotThrow()
+    begin
+        // Positive: multiple calls must not accumulate errors.
+        Helper.CallExportData('first.dat');
+        Helper.CallExportData('second.dat');
+        Assert.IsTrue(true, 'Repeated ExportData calls must not throw');
+    end;
+
+    [Test]
+    procedure HelperCodeunit_Add_ProvesBusiness Logic()
+    begin
+        // Positive: helper codeunit alongside ExportData call is fully functional.
+        Assert.AreEqual(7, Helper.Add(3, 4), 'Add(3,4) must return 7');
+        Assert.AreEqual(0, Helper.Add(-1, 1), 'Add(-1,1) must return 0');
+    end;
+
+    [Test]
+    procedure HelperCodeunit_Add_NotWrongResult()
+    begin
+        // Negative: guard against no-op mock returning default value.
+        Assert.AreNotEqual(0, Helper.Add(3, 4), 'Add(3,4) must not return 0');
+    end;
+}


### PR DESCRIPTION
Closes #505

Adds `ALExportData` to `StripEntireCallMethods` in `RoslynRewriter.cs` — the same no-op pattern used by `ALCommit`, `ALSelectLatestVersion`, and `ALAlterKey`. `Database.ExportData` is a file I/O operation that has no meaning without a BC service tier; stripping the call entirely is the correct approach.

## Change
- `AlRunner/RoslynRewriter.cs`: add `"ALExportData"` to `StripEntireCallMethods`
- `tests/bucket-2/153-database-export-data/`: 5 tests — ExportData with filename, empty filename, repeated calls, plus helper proving tests
- `docs/coverage.yaml`: `Database.ExportData` → `covered`