### PR TITLE
feat: Database.DataFileInformation no-op stub (#504)

### DIFF
--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -50,6 +50,7 @@ public class RoslynRewriter : CSharpSyntaxRewriter
         "ALSelectLatestVersion", // ALDatabase.ALSelectLatestVersion() — no-op standalone
         "ALAlterKey", // ALDatabase.ALAlterKey() — DDL not supported standalone; no-op
         "ALCheckLicenseFile", // ALDatabase.ALCheckLicenseFile() — no license system standalone; no-op
+        "ALDataFileInformation", // ALDatabase.ALDataFileInformation() — no real DB standalone; no-op
     };
 
     private static readonly HashSet<string> StripITreeObjectArgMethods = new(StringComparer.Ordinal)

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -1558,8 +1558,8 @@ Database.CurrentTransactionType:
 Database.DataFileInformation:
   layer: runtime-api
   category: Database
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; no-op stub (no real DB standalone); tests/bucket-2/154-database-datafileinformation
 
 Database.ExportData:
   layer: runtime-api

--- a/tests/bucket-2/153-database-checklicensefile/src/CheckLicenseFileSrc.al
+++ b/tests/bucket-2/153-database-checklicensefile/src/CheckLicenseFileSrc.al
@@ -1,6 +1,6 @@
 /// Helper codeunit that wraps Database.CheckLicenseFile(KeyNumber) so the
 /// test can exercise it without calling it inline.
-codeunit 61200 "CLF Helper"
+codeunit 61220 "CLF Helper"
 {
     /// Call Database.CheckLicenseFile(keyNumber) — must be a no-op stub in standalone mode.
     procedure CallCheckLicenseFile(keyNumber: Integer)

--- a/tests/bucket-2/153-database-checklicensefile/test/CheckLicenseFileTest.al
+++ b/tests/bucket-2/153-database-checklicensefile/test/CheckLicenseFileTest.al
@@ -1,4 +1,4 @@
-codeunit 61201 "CLF CheckLicenseFile Test"
+codeunit 61221 "CLF CheckLicenseFile Test"
 {
     Subtype = Test;
 

--- a/tests/bucket-2/154-database-datafileinformation/src/DataFileInformationSrc.al
+++ b/tests/bucket-2/154-database-datafileinformation/src/DataFileInformationSrc.al
@@ -1,0 +1,16 @@
+/// Helper codeunit that wraps Database.DataFileInformation so the test can
+/// exercise it without calling it inline.
+codeunit 61300 "DFI Helper"
+{
+    /// Call Database.DataFileInformation(showDialog) — must be a no-op stub in standalone mode.
+    procedure CallDataFileInformation(showDialog: Boolean)
+    begin
+        Database.DataFileInformation(showDialog);
+    end;
+
+    /// Proving helper — returns a+b+1 to verify the codeunit is live.
+    procedure AddWithBonus(a: Integer; b: Integer): Integer
+    begin
+        exit(a + b + 1);
+    end;
+}

--- a/tests/bucket-2/154-database-datafileinformation/src/DataFileInformationSrc.al
+++ b/tests/bucket-2/154-database-datafileinformation/src/DataFileInformationSrc.al
@@ -1,11 +1,45 @@
+/// Minimal table needed to supply the 'var Table: Record' parameter of
+/// Database.DataFileInformation.
+table 61300 "DFI Rec"
+{
+    DataClassification = CustomerContent;
+    fields
+    {
+        field(1; Id; Integer) { }
+    }
+    keys
+    {
+        key(PK; Id) { Clustered = true; }
+    }
+}
+
 /// Helper codeunit that wraps Database.DataFileInformation so the test can
-/// exercise it without calling it inline.
+/// exercise the correct 9-argument signature.
 codeunit 61300 "DFI Helper"
 {
-    /// Call Database.DataFileInformation(showDialog) — must be a no-op stub in standalone mode.
+    /// Call Database.DataFileInformation with all required parameters.
+    /// In standalone mode this must be a no-op stub.
     procedure CallDataFileInformation(showDialog: Boolean)
+    var
+        FileName: Text;
+        CompanyName: Text;
+        FileExists: Boolean;
+        FileIsCompressed: Boolean;
+        AllowsDirectAccess: Boolean;
+        DatabaseVersion: Text;
+        FileCreated: DateTime;
+        Rec: Record "DFI Rec";
     begin
-        Database.DataFileInformation(showDialog);
+        Database.DataFileInformation(
+            showDialog,
+            FileName,
+            CompanyName,
+            FileExists,
+            FileIsCompressed,
+            AllowsDirectAccess,
+            DatabaseVersion,
+            FileCreated,
+            Rec);
     end;
 
     /// Proving helper — returns a+b+1 to verify the codeunit is live.

--- a/tests/bucket-2/154-database-datafileinformation/test/DataFileInformationTest.al
+++ b/tests/bucket-2/154-database-datafileinformation/test/DataFileInformationTest.al
@@ -1,0 +1,57 @@
+codeunit 61301 "DFI DataFileInformation Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    [Test]
+    procedure DataFileInformation_NoOp_ShowDialogTrue()
+    var
+        Helper: Codeunit "DFI Helper";
+    begin
+        // Positive: Database.DataFileInformation(true) must execute without error (no-op stub).
+        Helper.CallDataFileInformation(true);
+        Assert.IsTrue(true, 'DataFileInformation(true) must complete without error');
+    end;
+
+    [Test]
+    procedure DataFileInformation_NoOp_ShowDialogFalse()
+    var
+        Helper: Codeunit "DFI Helper";
+    begin
+        // Positive: Database.DataFileInformation(false) must also be a no-op.
+        Helper.CallDataFileInformation(false);
+        Assert.IsTrue(true, 'DataFileInformation(false) must complete without error');
+    end;
+
+    [Test]
+    procedure DataFileInformation_CalledTwice_NoError()
+    var
+        Helper: Codeunit "DFI Helper";
+    begin
+        // Edge case: calling DataFileInformation multiple times must not error.
+        Helper.CallDataFileInformation(false);
+        Helper.CallDataFileInformation(true);
+        Assert.IsTrue(true, 'DataFileInformation called twice must complete without error');
+    end;
+
+    [Test]
+    procedure AddWithBonus_ProvingCompilationUnitLive()
+    var
+        Helper: Codeunit "DFI Helper";
+    begin
+        // Proving: the codeunit is live — real computation returns a+b+1.
+        Assert.AreEqual(8, Helper.AddWithBonus(3, 4), 'AddWithBonus(3,4) must return 3+4+1=8');
+        Assert.AreEqual(1, Helper.AddWithBonus(0, 0), 'AddWithBonus(0,0) must return 0+0+1=1');
+    end;
+
+    [Test]
+    procedure AddWithBonus_NotPlainSum()
+    var
+        Helper: Codeunit "DFI Helper";
+    begin
+        // Negative: AddWithBonus must NOT return a plain sum (no-op trap guard).
+        Assert.AreNotEqual(7, Helper.AddWithBonus(3, 4), 'AddWithBonus must not just return a+b');
+    end;
+}


### PR DESCRIPTION
Closes #504

## What

`Database.DataFileInformation(ShowDialog: Boolean)` displays database file information — a UI/DB operation that has no equivalent in standalone mode. It's a no-op stub.

## How

Added `ALDataFileInformation` to `StripEntireCallMethods` in `RoslynRewriter.cs`. Same pattern as `ALCommit`, `ALSelectLatestVersion`, `ALAlterKey`, and `ALCheckLicenseFile`.

## Tests

New suite `tests/bucket-2/154-database-datafileinformation/`:
- `DataFileInformation_NoOp_ShowDialogTrue` — showDialog=true executes without error
- `DataFileInformation_NoOp_ShowDialogFalse` — showDialog=false executes without error
- `DataFileInformation_CalledTwice_NoError` — repeated calls are safe
- `AddWithBonus_ProvingCompilationUnitLive` / `AddWithBonus_NotPlainSum` — codeunit-live guard

## Coverage

`docs/coverage.yaml`: `Database.DataFileInformation` gap → covered