### PR TITLE
feat: Database.DataFileInformation stub (#504)

### DIFF
--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -2740,6 +2740,18 @@ public void ClearApplicationMemberVariables() { }
                         SyntaxFactory.IdentifierName("ALIsNullGuid")));
             }
 
+            // ALDatabase.ALDataFileInformation() -> "STANDALONE"
+            // The real implementation queries the BC data file path from NavSession, which
+            // is unavailable in the runner. Return a fixed non-empty string so AL code that
+            // tests for non-empty (the normal guard) behaves correctly standalone.
+            if (exprText == "ALDatabase" && methodName == "ALDataFileInformation")
+            {
+                return SyntaxFactory.LiteralExpression(
+                    SyntaxKind.StringLiteralExpression,
+                    SyntaxFactory.Literal("STANDALONE"))
+                    .WithTriviaFrom(visited);
+            }
+
             // ALSystemDate.ALWorkDate(null!) -> ALSystemDate.ALWorkDate(NavDate.Default)
             // The rewriter turns this.Session -> null!, which makes ALWorkDate ambiguous between
             // the NavSession and NavDate overloads. We disambiguate to the NavDate overload.

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -1558,8 +1558,8 @@ Database.CurrentTransactionType:
 Database.DataFileInformation:
   layer: runtime-api
   category: Database
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: returns fixed "STANDALONE" stub; RoslynRewriter rewrites ALDatabase.ALDataFileInformation() to string literal; tests/bucket-2/154-datafileinformation
 
 Database.ExportData:
   layer: runtime-api

--- a/tests/bucket-2/153-sleep/src/SleepSrc.al
+++ b/tests/bucket-2/153-sleep/src/SleepSrc.al
@@ -1,6 +1,6 @@
 /// Helper codeunit that calls Sleep() — the AL built-in that pauses execution.
 /// In the runner, Sleep must be a no-op so tests run without actually blocking.
-codeunit 61200 "SLP Helper"
+codeunit 61300 "SLP Helper"
 {
     procedure DoSleep(ms: Integer)
     begin

--- a/tests/bucket-2/153-sleep/test/SleepTest.al
+++ b/tests/bucket-2/153-sleep/test/SleepTest.al
@@ -1,4 +1,4 @@
-codeunit 61201 "SLP Tests"
+codeunit 61301 "SLP Tests"
 {
     Subtype = Test;
 

--- a/tests/bucket-2/154-datafileinformation/src/DataFileInformationSrc.al
+++ b/tests/bucket-2/154-datafileinformation/src/DataFileInformationSrc.al
@@ -1,0 +1,10 @@
+/// Helper codeunit that wraps Database.DataFileInformation() so the test
+/// codeunit can call it without a direct Database reference that might
+/// confuse the compiler in isolated contexts.
+codeunit 61400 "DFI Helper"
+{
+    procedure GetDataFileInformation(): Text
+    begin
+        exit(Database.DataFileInformation());
+    end;
+}

--- a/tests/bucket-2/154-datafileinformation/test/DataFileInformationTest.al
+++ b/tests/bucket-2/154-datafileinformation/test/DataFileInformationTest.al
@@ -1,0 +1,45 @@
+codeunit 61401 "DFI Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    // ------------------------------------------------------------------
+    // Positive: DataFileInformation returns the expected stub value.
+    // ------------------------------------------------------------------
+
+    [Test]
+    procedure DataFileInformation_ReturnsNonEmpty()
+    var
+        H: Codeunit "DFI Helper";
+        Result: Text;
+    begin
+        Result := H.GetDataFileInformation();
+        Assert.AreNotEqual('', Result, 'DataFileInformation must return a non-empty string');
+    end;
+
+    [Test]
+    procedure DataFileInformation_ReturnsStandaloneStub()
+    var
+        H: Codeunit "DFI Helper";
+    begin
+        Assert.AreEqual('STANDALONE', H.GetDataFileInformation(), 'DataFileInformation must return the STANDALONE stub value');
+    end;
+
+    // ------------------------------------------------------------------
+    // Negative: return value must not be an empty string (proves stub is not a no-op).
+    // ------------------------------------------------------------------
+
+    [Test]
+    procedure DataFileInformation_IsIdempotent()
+    var
+        H: Codeunit "DFI Helper";
+        First: Text;
+        Second: Text;
+    begin
+        First := H.GetDataFileInformation();
+        Second := H.GetDataFileInformation();
+        Assert.AreEqual(First, Second, 'DataFileInformation must return the same value on repeated calls');
+    end;
+}


### PR DESCRIPTION
Closes #504

## Changes

- **RoslynRewriter**: rewrites `ALDatabase.ALDataFileInformation()` → `"STANDALONE"` string literal. The real BC implementation queries the data file path via `NavSession`, which is unavailable in the runner. A fixed non-empty stub satisfies any AL guard that tests for non-empty.
- **ID collision fix**: `153-sleep` codeunit IDs changed from 61200/61201 → 61300/61301 to resolve collision with `153-database-checklicensefile` (both were merged with the same IDs).
- **Test suite**: `tests/bucket-2/154-datafileinformation` (codeunit IDs 61400/61401)
  - `DataFileInformation_ReturnsNonEmpty` — proves stub is not an empty string
  - `DataFileInformation_ReturnsStandaloneStub` — asserts exact value `"STANDALONE"`
  - `DataFileInformation_IsIdempotent` — proves repeated calls return the same value
- **Coverage**: `Database.DataFileInformation` status: `gap` → `covered`