### PR TITLE
feat: Database.DataFileInformation no-op stub (#504)

### DIFF
--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -54,6 +54,7 @@ public class RoslynRewriter : CSharpSyntaxRewriter
         "ALCopyCompany",  // ALDatabase.ALCopyCompany(src, dest) — no multi-company store standalone; no-op
         "ALImportData",   // ALDatabase.ALImportData(tableNo, path, create) — no file I/O standalone; no-op
         "ALExportData",   // ALDatabase.ALExportData(fileName, ...) — no file I/O standalone; no-op
+        "ALDataFileInformation", // ALDatabase.ALDataFileInformation(showDialog, ref name, ...) — queries BC data file; no real DB standalone; no-op
     };
 
     private static readonly HashSet<string> StripITreeObjectArgMethods = new(StringComparer.Ordinal)

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -1562,8 +1562,8 @@ Database.CurrentTransactionType:
 Database.DataFileInformation:
   layer: runtime-api
   category: Database
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: no-op stub; ALDataFileInformation added to StripEntireCallMethods in RoslynRewriter; var params remain at defaults; tests/bucket-2/154-datafileinformation
 
 Database.ExportData:
   layer: runtime-api

--- a/tests/bucket-2/154-datafileinformation/src/DataFileInformationSrc.al
+++ b/tests/bucket-2/154-datafileinformation/src/DataFileInformationSrc.al
@@ -1,9 +1,18 @@
+/// Minimal table needed as the SourceTable var parameter in DataFileInformation.
+table 61320 "DFI Source"
+{
+    fields
+    {
+        field(1; ID; Integer) { }
+    }
+}
+
 /// Helper codeunit exercising Database.DataFileInformation.
 /// Signature per the AL compiler (9 parameters):
 ///   DataFileInformation(ShowDialog: Boolean; var Name: Text; var Description: Text;
 ///     var HasApplication: Boolean; var HasApplicationData: Boolean;
 ///     var HasGlobalData: Boolean; var TenantInformation: Text;
-///     var CreationDateTime: DateTime; var DatabaseVersion: Text)
+///     var CreationDateTime: DateTime; var SourceTable: Table)
 codeunit 61300 "DFI Helper"
 {
     procedure CallDataFileInformation(ShowDialog: Boolean)
@@ -15,10 +24,10 @@ codeunit 61300 "DFI Helper"
         HasGlobalData: Boolean;
         TenantInformation: Text;
         CreationDateTime: DateTime;
-        DatabaseVersion: Text;
+        SourceRec: Record "DFI Source";
     begin
         Database.DataFileInformation(ShowDialog, Name, Description, HasApplication,
-            HasApplicationData, HasGlobalData, TenantInformation, CreationDateTime, DatabaseVersion);
+            HasApplicationData, HasGlobalData, TenantInformation, CreationDateTime, SourceRec);
     end;
 
     procedure CallAndReturnFlag(ShowDialog: Boolean): Boolean
@@ -30,10 +39,10 @@ codeunit 61300 "DFI Helper"
         HasGlobalData: Boolean;
         TenantInformation: Text;
         CreationDateTime: DateTime;
-        DatabaseVersion: Text;
+        SourceRec: Record "DFI Source";
     begin
         Database.DataFileInformation(ShowDialog, Name, Description, HasApplication,
-            HasApplicationData, HasGlobalData, TenantInformation, CreationDateTime, DatabaseVersion);
+            HasApplicationData, HasGlobalData, TenantInformation, CreationDateTime, SourceRec);
         exit(true);
     end;
 }

--- a/tests/bucket-2/154-datafileinformation/src/DataFileInformationSrc.al
+++ b/tests/bucket-2/154-datafileinformation/src/DataFileInformationSrc.al
@@ -1,0 +1,39 @@
+/// Helper codeunit exercising Database.DataFileInformation.
+/// Signature per the AL compiler (9 parameters):
+///   DataFileInformation(ShowDialog: Boolean; var Name: Text; var Description: Text;
+///     var HasApplication: Boolean; var HasApplicationData: Boolean;
+///     var HasGlobalData: Boolean; var TenantInformation: Text;
+///     var CreationDateTime: DateTime; var DatabaseVersion: Text)
+codeunit 61300 "DFI Helper"
+{
+    procedure CallDataFileInformation(ShowDialog: Boolean)
+    var
+        Name: Text;
+        Description: Text;
+        HasApplication: Boolean;
+        HasApplicationData: Boolean;
+        HasGlobalData: Boolean;
+        TenantInformation: Text;
+        CreationDateTime: DateTime;
+        DatabaseVersion: Text;
+    begin
+        Database.DataFileInformation(ShowDialog, Name, Description, HasApplication,
+            HasApplicationData, HasGlobalData, TenantInformation, CreationDateTime, DatabaseVersion);
+    end;
+
+    procedure CallAndReturnFlag(ShowDialog: Boolean): Boolean
+    var
+        Name: Text;
+        Description: Text;
+        HasApplication: Boolean;
+        HasApplicationData: Boolean;
+        HasGlobalData: Boolean;
+        TenantInformation: Text;
+        CreationDateTime: DateTime;
+        DatabaseVersion: Text;
+    begin
+        Database.DataFileInformation(ShowDialog, Name, Description, HasApplication,
+            HasApplicationData, HasGlobalData, TenantInformation, CreationDateTime, DatabaseVersion);
+        exit(true);
+    end;
+}

--- a/tests/bucket-2/154-datafileinformation/test/DataFileInformationTest.al
+++ b/tests/bucket-2/154-datafileinformation/test/DataFileInformationTest.al
@@ -1,0 +1,52 @@
+codeunit 61301 "DFI Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    // ------------------------------------------------------------------
+    // Positive: DataFileInformation completes without error.
+    // The stub is a no-op — var parameters keep their default values.
+    // ------------------------------------------------------------------
+
+    [Test]
+    procedure DataFileInformation_ShowDialogFalse_NoError()
+    var
+        H: Codeunit "DFI Helper";
+    begin
+        H.CallDataFileInformation(false);
+        Assert.IsTrue(true, 'DataFileInformation(false) must complete without error');
+    end;
+
+    [Test]
+    procedure DataFileInformation_ShowDialogTrue_NoError()
+    var
+        H: Codeunit "DFI Helper";
+    begin
+        H.CallDataFileInformation(true);
+        Assert.IsTrue(true, 'DataFileInformation(true) must complete without error');
+    end;
+
+    [Test]
+    procedure DataFileInformation_ReturnFlagAfterCall_IsTrue()
+    var
+        H: Codeunit "DFI Helper";
+    begin
+        Assert.IsTrue(H.CallAndReturnFlag(false), 'Execution must continue after DataFileInformation no-op');
+    end;
+
+    // ------------------------------------------------------------------
+    // Negative: error handling still works after DataFileInformation.
+    // ------------------------------------------------------------------
+
+    [Test]
+    procedure DataFileInformation_ErrorAfterCall_CaughtCorrectly()
+    var
+        H: Codeunit "DFI Helper";
+    begin
+        H.CallDataFileInformation(false);
+        asserterror Error('post-call error');
+        Assert.ExpectedError('post-call error');
+    end;
+}


### PR DESCRIPTION
Closes #504

## What

`Database.DataFileInformation(ShowDialog: Boolean; var Name: Text; var Description: Text; var HasApplication: Boolean; var HasApplicationData: Boolean; var HasGlobalData: Boolean; var TenantInformation: Text; var CreationDateTime: DateTime; var DatabaseVersion: Text)` populates file information from a live BC database. The runner has no real database, so the call is a no-op stub.

## How

Added `ALDataFileInformation` to `StripEntireCallMethods` in `RoslynRewriter.cs` — the same pattern used by `ALCommit`, `ALAlterKey`, `ALCheckLicenseFile`, and `ALChangeUserPassword`. The entire statement is replaced with an empty statement (`;`), leaving `var` parameters at their default values.

## Tests

New suite `tests/bucket-2/154-datafileinformation/` (codeunit IDs 61300/61301):
- `DataFileInformation_ShowDialogFalse_NoError` — call with ShowDialog=false completes without error
- `DataFileInformation_ShowDialogTrue_NoError` — call with ShowDialog=true completes without error
- `DataFileInformation_ReturnFlagAfterCall_IsTrue` — execution continues normally after the no-op call
- `DataFileInformation_ErrorAfterCall_CaughtCorrectly` — error handling works after the call

## Coverage

`Database.DataFileInformation`: `gap` → `covered`