### PR TITLE
feat: Database.CopyCompany no-op stub (#513)

### DIFF
--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -51,6 +51,7 @@ public class RoslynRewriter : CSharpSyntaxRewriter
         "ALAlterKey", // ALDatabase.ALAlterKey() — DDL not supported standalone; no-op
         "ALCheckLicenseFile", // ALDatabase.ALCheckLicenseFile() — no license system standalone; no-op
         "ALChangeUserPassword",  // ALDatabase.ALChangeUserPassword(err, old, new) — user system not modeled; no-op standalone
+        "ALCopyCompany",  // ALDatabase.ALCopyCompany(src, dest) — no multi-company store standalone; no-op
     };
 
     private static readonly HashSet<string> StripITreeObjectArgMethods = new(StringComparer.Ordinal)

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -1546,8 +1546,8 @@ Database.CompanyName:
 Database.CopyCompany:
   layer: runtime-api
   category: Database
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; no-op stub (no multi-company store in standalone mode); ALCopyCompany stripped by RoslynRewriter
 
 Database.CurrentTransactionType:
   layer: runtime-api

--- a/tests/bucket-2/154-database-copycompany/src/CopyCompanySrc.al
+++ b/tests/bucket-2/154-database-copycompany/src/CopyCompanySrc.al
@@ -1,0 +1,17 @@
+/// Helper codeunit that wraps Database.CopyCompany so the test can
+/// exercise it without calling it inline.
+codeunit 61400 "CCP Helper"
+{
+    /// Call Database.CopyCompany(sourceCompany, destinationCompany) — must be a no-op stub
+    /// in standalone mode (no multi-company data store).
+    procedure CallCopyCompany(sourceCompany: Text; destinationCompany: Text)
+    begin
+        Database.CopyCompany(sourceCompany, destinationCompany);
+    end;
+
+    /// Proving helper — returns a+b+1 to verify the codeunit is live.
+    procedure AddWithBonus(a: Integer; b: Integer): Integer
+    begin
+        exit(a + b + 1);
+    end;
+}

--- a/tests/bucket-2/154-database-copycompany/test/CopyCompanyTest.al
+++ b/tests/bucket-2/154-database-copycompany/test/CopyCompanyTest.al
@@ -1,0 +1,57 @@
+codeunit 61401 "CCP CopyCompany Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    [Test]
+    procedure CopyCompany_NoOp_TypicalCompanyNames()
+    var
+        Helper: Codeunit "CCP Helper";
+    begin
+        // Positive: Database.CopyCompany must execute without error (no-op stub).
+        Helper.CallCopyCompany('Source Company', 'Destination Company');
+        Assert.IsTrue(true, 'CopyCompany must complete without error');
+    end;
+
+    [Test]
+    procedure CopyCompany_NoOp_EmptyNames()
+    var
+        Helper: Codeunit "CCP Helper";
+    begin
+        // Positive: CopyCompany with empty strings must also be a no-op.
+        Helper.CallCopyCompany('', '');
+        Assert.IsTrue(true, 'CopyCompany with empty names must complete without error');
+    end;
+
+    [Test]
+    procedure CopyCompany_CalledTwice_NoError()
+    var
+        Helper: Codeunit "CCP Helper";
+    begin
+        // Edge case: calling CopyCompany multiple times must not error.
+        Helper.CallCopyCompany('A', 'B');
+        Helper.CallCopyCompany('C', 'D');
+        Assert.IsTrue(true, 'CopyCompany called twice must complete without error');
+    end;
+
+    [Test]
+    procedure AddWithBonus_ProvingCompilationUnitLive()
+    var
+        Helper: Codeunit "CCP Helper";
+    begin
+        // Proving: the codeunit is live — real computation returns a+b+1.
+        Assert.AreEqual(8, Helper.AddWithBonus(3, 4), 'AddWithBonus(3,4) must return 3+4+1=8');
+        Assert.AreEqual(1, Helper.AddWithBonus(0, 0), 'AddWithBonus(0,0) must return 0+0+1=1');
+    end;
+
+    [Test]
+    procedure AddWithBonus_NotPlainSum()
+    var
+        Helper: Codeunit "CCP Helper";
+    begin
+        // Negative: AddWithBonus must NOT return a plain sum (no-op trap guard).
+        Assert.AreNotEqual(7, Helper.AddWithBonus(3, 4), 'AddWithBonus must not just return a+b');
+    end;
+}


### PR DESCRIPTION
Closes #513

## Summary

`Database.CopyCompany(sourceCompany, destinationCompany)` is now a no-op stub in standalone mode. The runner has no multi-company data store, so this administrative operation cannot be meaningfully executed.

**Implementation:** Added `ALCopyCompany` to the `StripEntireCallMethods` HashSet in `RoslynRewriter.cs`. The rewriter strips the entire call statement, making it a no-op without any runtime overhead.

## Test suite: `154-database-copycompany`

- **Positive**: calling with typical company names completes without error
- **Positive**: calling with empty string names completes without error
- **Edge case**: calling twice in sequence does not error
- **Proving** (`AddWithBonus`): verifies the codeunit is actually executed (a+b+1 ≠ a+b)
- **Negative proving**: `AddWithBonus(3,4)` must not equal 7 (guards against no-op mock)

## Changes

- `AlRunner/RoslynRewriter.cs`: added `ALCopyCompany` to `StripEntireCallMethods`
- `tests/bucket-2/154-database-copycompany/`: new test suite
- `docs/coverage.yaml`: `Database.CopyCompany` → `status: covered`