### PR TITLE
feat: Database.ImportData no-op stub (#517)

### DIFF
--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -52,6 +52,7 @@ public class RoslynRewriter : CSharpSyntaxRewriter
         "ALCheckLicenseFile", // ALDatabase.ALCheckLicenseFile() — no license system standalone; no-op
         "ALChangeUserPassword",  // ALDatabase.ALChangeUserPassword(err, old, new) — user system not modeled; no-op standalone
         "ALCopyCompany",  // ALDatabase.ALCopyCompany(src, dest) — no multi-company store standalone; no-op
+        "ALImportData",   // ALDatabase.ALImportData(tableNo, path, create) — no file I/O standalone; no-op
     };
 
     private static readonly HashSet<string> StripITreeObjectArgMethods = new(StringComparer.Ordinal)

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -1586,8 +1586,8 @@ Database.HasTableConnection:
 Database.ImportData:
   layer: runtime-api
   category: Database
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; no-op stub (no file I/O in standalone mode); ALImportData stripped by RoslynRewriter
 
 Database.IsInWriteTransaction:
   layer: runtime-api

--- a/tests/bucket-2/155-database-importdata/src/ImportDataSrc.al
+++ b/tests/bucket-2/155-database-importdata/src/ImportDataSrc.al
@@ -1,0 +1,20 @@
+/// Helper codeunit that wraps Database.ImportData so the test can
+/// exercise it without calling it inline.
+codeunit 61500 "IDT Helper"
+{
+    /// Call Database.ImportData(tableNumber, path, create) — must be a no-op stub
+    /// in standalone mode (no external file I/O).
+    procedure CallImportData(tableNumber: Integer)
+    var
+        Path: Text;
+        Create: Boolean;
+    begin
+        Database.ImportData(tableNumber, Path, Create);
+    end;
+
+    /// Proving helper — returns a+b+1 to verify the codeunit is live.
+    procedure AddWithBonus(a: Integer; b: Integer): Integer
+    begin
+        exit(a + b + 1);
+    end;
+}

--- a/tests/bucket-2/155-database-importdata/src/ImportDataSrc.al
+++ b/tests/bucket-2/155-database-importdata/src/ImportDataSrc.al
@@ -2,14 +2,14 @@
 /// exercise it without calling it inline.
 codeunit 61500 "IDT Helper"
 {
-    /// Call Database.ImportData(tableNumber, path, create) — must be a no-op stub
+    /// Call Database.ImportData(showDialog, path, create) — must be a no-op stub
     /// in standalone mode (no external file I/O).
-    procedure CallImportData(tableNumber: Integer)
+    procedure CallImportData(showDialog: Boolean)
     var
         Path: Text;
         Create: Boolean;
     begin
-        Database.ImportData(tableNumber, Path, Create);
+        Database.ImportData(showDialog, Path, Create);
     end;
 
     /// Proving helper — returns a+b+1 to verify the codeunit is live.

--- a/tests/bucket-2/155-database-importdata/test/ImportDataTest.al
+++ b/tests/bucket-2/155-database-importdata/test/ImportDataTest.al
@@ -6,23 +6,23 @@ codeunit 61501 "IDT ImportData Test"
         Assert: Codeunit Assert;
 
     [Test]
-    procedure ImportData_NoOp_TableNumber18()
+    procedure ImportData_NoOp_ShowDialogTrue()
     var
         Helper: Codeunit "IDT Helper";
     begin
-        // Positive: Database.ImportData(18, ...) must execute without error (no-op stub).
-        Helper.CallImportData(18);
-        Assert.IsTrue(true, 'ImportData(18) must complete without error');
+        // Positive: Database.ImportData(true, ...) must execute without error (no-op stub).
+        Helper.CallImportData(true);
+        Assert.IsTrue(true, 'ImportData(true) must complete without error');
     end;
 
     [Test]
-    procedure ImportData_NoOp_TableNumber0()
+    procedure ImportData_NoOp_ShowDialogFalse()
     var
         Helper: Codeunit "IDT Helper";
     begin
-        // Positive: Database.ImportData(0, ...) must also be a no-op.
-        Helper.CallImportData(0);
-        Assert.IsTrue(true, 'ImportData(0) must complete without error');
+        // Positive: Database.ImportData(false, ...) must also be a no-op.
+        Helper.CallImportData(false);
+        Assert.IsTrue(true, 'ImportData(false) must complete without error');
     end;
 
     [Test]
@@ -31,8 +31,8 @@ codeunit 61501 "IDT ImportData Test"
         Helper: Codeunit "IDT Helper";
     begin
         // Edge case: calling ImportData multiple times must not error.
-        Helper.CallImportData(18);
-        Helper.CallImportData(27);
+        Helper.CallImportData(false);
+        Helper.CallImportData(true);
         Assert.IsTrue(true, 'ImportData called twice must complete without error');
     end;
 

--- a/tests/bucket-2/155-database-importdata/test/ImportDataTest.al
+++ b/tests/bucket-2/155-database-importdata/test/ImportDataTest.al
@@ -1,0 +1,57 @@
+codeunit 61501 "IDT ImportData Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    [Test]
+    procedure ImportData_NoOp_TableNumber18()
+    var
+        Helper: Codeunit "IDT Helper";
+    begin
+        // Positive: Database.ImportData(18, ...) must execute without error (no-op stub).
+        Helper.CallImportData(18);
+        Assert.IsTrue(true, 'ImportData(18) must complete without error');
+    end;
+
+    [Test]
+    procedure ImportData_NoOp_TableNumber0()
+    var
+        Helper: Codeunit "IDT Helper";
+    begin
+        // Positive: Database.ImportData(0, ...) must also be a no-op.
+        Helper.CallImportData(0);
+        Assert.IsTrue(true, 'ImportData(0) must complete without error');
+    end;
+
+    [Test]
+    procedure ImportData_CalledTwice_NoError()
+    var
+        Helper: Codeunit "IDT Helper";
+    begin
+        // Edge case: calling ImportData multiple times must not error.
+        Helper.CallImportData(18);
+        Helper.CallImportData(27);
+        Assert.IsTrue(true, 'ImportData called twice must complete without error');
+    end;
+
+    [Test]
+    procedure AddWithBonus_ProvingCompilationUnitLive()
+    var
+        Helper: Codeunit "IDT Helper";
+    begin
+        // Proving: the codeunit is live — real computation returns a+b+1.
+        Assert.AreEqual(8, Helper.AddWithBonus(3, 4), 'AddWithBonus(3,4) must return 3+4+1=8');
+        Assert.AreEqual(1, Helper.AddWithBonus(0, 0), 'AddWithBonus(0,0) must return 0+0+1=1');
+    end;
+
+    [Test]
+    procedure AddWithBonus_NotPlainSum()
+    var
+        Helper: Codeunit "IDT Helper";
+    begin
+        // Negative: AddWithBonus must NOT return a plain sum (no-op trap guard).
+        Assert.AreNotEqual(7, Helper.AddWithBonus(3, 4), 'AddWithBonus must not just return a+b');
+    end;
+}


### PR DESCRIPTION
Closes #517

## Summary

`Database.ImportData(tableNumber, var path, var create)` is now a no-op stub in standalone mode. The runner has no external file I/O, so this data-import operation cannot be meaningfully executed.

**Implementation:** Added `ALImportData` to the `StripEntireCallMethods` HashSet in `RoslynRewriter.cs`. The rewriter strips the entire call statement, making it a no-op.

## Test suite: `155-database-importdata`

- **Positive**: calling with table number 18 completes without error
- **Positive**: calling with table number 0 completes without error
- **Edge case**: calling twice in sequence does not error
- **Proving** (`AddWithBonus`): verifies the codeunit is actually executed (a+b+1 ≠ a+b)
- **Negative proving**: `AddWithBonus(3,4)` must not equal 7 (guards against no-op mock)

## Changes

- `AlRunner/RoslynRewriter.cs`: added `ALImportData` to `StripEntireCallMethods`
- `tests/bucket-2/155-database-importdata/`: new test suite
- `docs/coverage.yaml`: `Database.ImportData` → `status: covered`