### PR TITLE
feat: Database.RegisterTableConnection — strip-entire-call no-op

### DIFF
--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -55,6 +55,7 @@ public class RoslynRewriter : CSharpSyntaxRewriter
         "ALImportData",   // ALDatabase.ALImportData(tableNo, path, create) — no file I/O standalone; no-op
         "ALExportData",   // ALDatabase.ALExportData(fileName, ...) — no file I/O standalone; no-op
         "ALDataFileInformation", // ALDatabase.ALDataFileInformation(showDialog, ref name, ...) — queries BC data file; no real DB standalone; no-op
+        "ALRegisterTableConnection",  // ALDatabase.ALRegisterTableConnection(target, ct, name, conn) — no external connections standalone; no-op
     };
 
     private static readonly HashSet<string> StripITreeObjectArgMethods = new(StringComparer.Ordinal)

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -1632,8 +1632,10 @@ Database.MinimumActiveRowVersion:
 Database.RegisterTableConnection:
   layer: runtime-api
   category: Database
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; rewriter strips the entire call (no external connections standalone). Signature is (ConnectionType, Name, Connection).
+  tests:
+    - tests/bucket-2/156-register-table-connection
 
 Database.SelectLatestVersion:
   layer: runtime-api

--- a/tests/bucket-2/156-register-table-connection/al-runner.json
+++ b/tests/bucket-2/156-register-table-connection/al-runner.json
@@ -1,0 +1,4 @@
+{
+  "sourcePath": "./src",
+  "testPath": "./test"
+}

--- a/tests/bucket-2/156-register-table-connection/src/RegisterTableConnectionSrc.al
+++ b/tests/bucket-2/156-register-table-connection/src/RegisterTableConnectionSrc.al
@@ -1,0 +1,15 @@
+/// Helper codeunit exercising Database.RegisterTableConnection.
+/// Signature per the AL compiler: `RegisterTableConnection(TableConnectionType, Name: Text, Connection: Text)`.
+codeunit 59680 "RTC Src"
+{
+    procedure CallRegister(ct: TableConnectionType; name: Text; conn: Text)
+    begin
+        Database.RegisterTableConnection(ct, name, conn);
+    end;
+
+    procedure CallRegisterAndReturnFlag(ct: TableConnectionType; name: Text; conn: Text): Boolean
+    begin
+        Database.RegisterTableConnection(ct, name, conn);
+        exit(true);
+    end;
+}

--- a/tests/bucket-2/156-register-table-connection/test/RegisterTableConnectionTest.al
+++ b/tests/bucket-2/156-register-table-connection/test/RegisterTableConnectionTest.al
@@ -1,0 +1,53 @@
+codeunit 59681 "RTC Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "RTC Src";
+
+    [Test]
+    procedure RegisterTableConnection_NoOp()
+    begin
+        // Positive: standalone stub must complete without error.
+        Src.CallRegister(TableConnectionType::ExternalSQL, 'MyConn', 'Server=localhost');
+        Assert.IsTrue(true, 'RegisterTableConnection must not throw');
+    end;
+
+    [Test]
+    procedure RegisterTableConnection_EmptyArgs()
+    begin
+        // Edge: empty strings must not crash the stub.
+        Src.CallRegister(TableConnectionType::ExternalSQL, '', '');
+        Assert.IsTrue(true, 'RegisterTableConnection with empty args must not throw');
+    end;
+
+    [Test]
+    procedure RegisterTableConnection_ExecutionContinues()
+    begin
+        // Proving: execution continues past the call (flag gets set).
+        Assert.IsTrue(
+            Src.CallRegisterAndReturnFlag(TableConnectionType::CRM, 'CRMConn', 'Endpoint=crm.example'),
+            'Caller must reach `exit(true)` after RegisterTableConnection');
+    end;
+
+    [Test]
+    procedure RegisterTableConnection_DifferentTypes()
+    begin
+        // Both available TableConnectionType enum values must complete.
+        Src.CallRegister(TableConnectionType::ExternalSQL, 'SqlConn', 'sql-cs');
+        Src.CallRegister(TableConnectionType::CRM, 'CrmConn', 'crm-cs');
+        Assert.IsTrue(true, 'Calls with both connection types must not throw');
+    end;
+
+    [Test]
+    procedure RegisterTableConnection_LongConnectionString_NegativeTrap()
+    begin
+        // Negative trap: guard against crashing on large input.
+        Src.CallRegister(
+            TableConnectionType::ExternalSQL,
+            'VeryLongConnectionName_123456789',
+            'Server=verylonghostname.example.com;Database=db;User=dbuser;Password=pwd;MultipleActiveResultSets=true');
+        Assert.IsTrue(true, 'RegisterTableConnection with long strings must not throw');
+    end;
+}


### PR DESCRIPTION
Closes #520

## Summary

Add `ALRegisterTableConnection` to `StripEntireCallMethods` — same approach as other DB stubs (`ALCommit`, `ALCheckLicenseFile`, `ALChangeUserPassword`). No external connections standalone, so the call has no runtime meaning.

## Changes

- `AlRunner/RoslynRewriter.cs` — added to `StripEntireCallMethods`
- `tests/bucket-2/156-register-table-connection/` — helper + 5 proving tests
- `docs/coverage.yaml` — `Database.RegisterTableConnection` marked `covered`

## Note on signature

The issue's reproduction called `RegisterTableConnection(18, name, conn)` with a TableNo. The actual AL signature takes `(ConnectionType: TableConnectionType, Name: Text, Connection: Text)` — corrected in the suite.

## Verification

- 5/5 new tests pass
- Full bucket-2: 865 pass (3 pre-existing DateTime/timezone failures)