### PR TITLE
test: Database.IsInWriteTransaction proving tests (#322)

### DIFF
--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -1594,8 +1594,8 @@ Database.ImportData:
 Database.IsInWriteTransaction:
   layer: runtime-api
   category: Database
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: RoslynRewriter rewrites ALDatabase.ALIsInWriteTransaction() to false literal; runner has no real transactions; tests/bucket-2/157-isinwritetransaction
 
 Database.LastUsedRowVersion:
   layer: runtime-api

--- a/tests/bucket-2/157-isinwritetransaction/src/IsInWriteTransactionSrc.al
+++ b/tests/bucket-2/157-isinwritetransaction/src/IsInWriteTransactionSrc.al
@@ -1,0 +1,24 @@
+/// Helper codeunit that wraps IsInWriteTransaction() so the test codeunit
+/// can call it and verify the standalone runner always returns false.
+codeunit 61700 "IWT Helper"
+{
+    procedure GetIsInWriteTransaction(): Boolean
+    begin
+        exit(IsInWriteTransaction());
+    end;
+
+    procedure InsertAndCheck(var Rec: Record "IWT Dummy"): Boolean
+    begin
+        Rec.Insert();
+        exit(IsInWriteTransaction());
+    end;
+}
+
+/// Minimal table used to test IsInWriteTransaction after a record insert.
+table 61720 "IWT Dummy"
+{
+    fields
+    {
+        field(1; ID; Integer) { }
+    }
+}

--- a/tests/bucket-2/157-isinwritetransaction/test/IsInWriteTransactionTest.al
+++ b/tests/bucket-2/157-isinwritetransaction/test/IsInWriteTransactionTest.al
@@ -1,0 +1,49 @@
+codeunit 61701 "IWT Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    // ------------------------------------------------------------------
+    // Positive: IsInWriteTransaction() always returns false standalone.
+    // The runner has no real DB transactions; false is the correct stub.
+    // ------------------------------------------------------------------
+
+    [Test]
+    procedure IsInWriteTransaction_ReturnsFalse()
+    var
+        H: Codeunit "IWT Helper";
+    begin
+        Assert.IsFalse(H.GetIsInWriteTransaction(), 'IsInWriteTransaction must return false in standalone runner');
+    end;
+
+    [Test]
+    procedure IsInWriteTransaction_ReturnsFalse_ExactValue()
+    var
+        H: Codeunit "IWT Helper";
+    begin
+        Assert.AreEqual(false, H.GetIsInWriteTransaction(), 'IsInWriteTransaction must return exactly false');
+    end;
+
+    [Test]
+    procedure IsInWriteTransaction_AfterInsert_StillFalse()
+    var
+        H: Codeunit "IWT Helper";
+        Rec: Record "IWT Dummy";
+    begin
+        Assert.IsFalse(H.InsertAndCheck(Rec), 'IsInWriteTransaction must return false even after record insert');
+    end;
+
+    // ------------------------------------------------------------------
+    // Negative: the return value is not true (runner has no write txn).
+    // ------------------------------------------------------------------
+
+    [Test]
+    procedure IsInWriteTransaction_IsNotTrue()
+    var
+        H: Codeunit "IWT Helper";
+    begin
+        Assert.AreNotEqual(true, H.GetIsInWriteTransaction(), 'IsInWriteTransaction must not return true in standalone runner');
+    end;
+}


### PR DESCRIPTION
Closes #322

## What

`Database.IsInWriteTransaction()` was already stubbed in `RoslynRewriter.cs` — `ALDatabase.ALIsInWriteTransaction()` is rewritten to the literal `false` (the runner has no real write transactions). This PR adds proving tests to document and verify that behavior, and marks the coverage entry as covered.

## Tests

Suite `tests/bucket-2/157-isinwritetransaction/` (IDs 61700/61701, table 61720):
- `IsInWriteTransaction_ReturnsFalse` — `Assert.IsFalse(...)` confirms the stub returns false
- `IsInWriteTransaction_ReturnsFalse_ExactValue` — `Assert.AreEqual(false, ...)` asserts exact value
- `IsInWriteTransaction_AfterInsert_StillFalse` — returns false even after a record insert (no implicit transaction promotion)
- `IsInWriteTransaction_IsNotTrue` — `Assert.AreNotEqual(true, ...)` proves it's not a no-op that could return true

## Coverage

`Database.IsInWriteTransaction`: `gap` → `covered`