### PR TITLE
feat: System.ArrayLen — get array length

### DIFF
--- a/AlRunner/Runtime/MockArray.cs
+++ b/AlRunner/Runtime/MockArray.cs
@@ -11,6 +11,7 @@ public class MockArray<T> : IEnumerable<T>
 {
     private readonly T[] _items;
     private readonly Func<T>? _factory;
+    private readonly int[] _dimensions;
 
     /// <summary>
     /// Constructor matching NavArray(T initValue, params int[] dimensions).
@@ -18,8 +19,9 @@ public class MockArray<T> : IEnumerable<T>
     /// </summary>
     public MockArray(T defaultValue, params int[] dimensions)
     {
+        _dimensions = dimensions.Length > 0 ? (int[])dimensions.Clone() : new[] { 0 };
         int totalLength = 1;
-        foreach (var d in dimensions) totalLength *= d;
+        foreach (var d in _dimensions) totalLength *= d;
         _factory = null;
         _items = new T[totalLength];
         for (int i = 0; i < totalLength; i++)
@@ -32,6 +34,7 @@ public class MockArray<T> : IEnumerable<T>
     /// </summary>
     public MockArray(int length, Func<T> factory)
     {
+        _dimensions = new[] { length };
         _factory = factory;
         _items = new T[length];
         for (int i = 0; i < length; i++)
@@ -53,8 +56,22 @@ public class MockArray<T> : IEnumerable<T>
     }
 
     public int Length => _items.Length;
-    public int ArrayLen() => _items.Length;
-    public int ArrayLen(int dimension) => _items.Length;
+
+    /// <summary>
+    /// AL ArrayLen(arr) — returns the length of the first dimension.
+    /// For a 1-D array[N], returns N. For multi-D array[X,Y,...] returns X.
+    /// </summary>
+    public int ArrayLen() => _dimensions.Length > 0 ? _dimensions[0] : 0;
+
+    /// <summary>
+    /// AL ArrayLen(arr, dimension) — returns the length of the specified 1-based dimension.
+    /// For array[3,4], dimension=1 returns 3, dimension=2 returns 4.
+    /// </summary>
+    public int ArrayLen(int dimension)
+    {
+        int idx = dimension - 1; // AL is 1-based
+        return (idx >= 0 && idx < _dimensions.Length) ? _dimensions[idx] : 0;
+    }
 
     public void Clear()
     {

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -5362,8 +5362,8 @@ System.ApplicationPath:
 System.ArrayLen:
   layer: runtime-api
   category: System
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; MockArray stores dimensions; 1-arg and 2-arg forms tested
 
 System.CalcDate:
   layer: runtime-api

--- a/tests/bucket-2/157-xml-documenttype/src/XmlDocumentTypeSrc.al
+++ b/tests/bucket-2/157-xml-documenttype/src/XmlDocumentTypeSrc.al
@@ -1,6 +1,6 @@
 /// Helper codeunit exercising XmlDocumentType.Create and property getters.
 /// Actual signatures: GetName(var Result: Text): Boolean, etc.
-codeunit 61700 "XDT Helper"
+codeunit 61710 "XDT Helper"
 {
     /// Create an XmlDocumentType with the given name and return its name via GetName.
     procedure CreateAndGetName(name: Text): Text

--- a/tests/bucket-2/157-xml-documenttype/test/XmlDocumentTypeTest.al
+++ b/tests/bucket-2/157-xml-documenttype/test/XmlDocumentTypeTest.al
@@ -1,4 +1,4 @@
-codeunit 61701 "XDT XmlDocumentType Test"
+codeunit 61711 "XDT XmlDocumentType Test"
 {
     Subtype = Test;
 

--- a/tests/bucket-2/158-arraylen/src/ArrayLenSrc.al
+++ b/tests/bucket-2/158-arraylen/src/ArrayLenSrc.al
@@ -1,0 +1,31 @@
+/// Helper codeunit exercising ArrayLen() for 1-D and 2-D arrays.
+codeunit 61800 "AL Helper"
+{
+    procedure GetLen1D(): Integer
+    var
+        Arr: array[10] of Integer;
+    begin
+        exit(ArrayLen(Arr));
+    end;
+
+    procedure GetLen1D_Dim1(): Integer
+    var
+        Arr: array[10] of Integer;
+    begin
+        exit(ArrayLen(Arr, 1));
+    end;
+
+    procedure GetLen2D_Dim1(): Integer
+    var
+        Arr: array[3, 4] of Integer;
+    begin
+        exit(ArrayLen(Arr, 1));
+    end;
+
+    procedure GetLen2D_Dim2(): Integer
+    var
+        Arr: array[3, 4] of Integer;
+    begin
+        exit(ArrayLen(Arr, 2));
+    end;
+}

--- a/tests/bucket-2/158-arraylen/test/ArrayLenTest.al
+++ b/tests/bucket-2/158-arraylen/test/ArrayLenTest.al
@@ -1,0 +1,47 @@
+codeunit 61801 "AL Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    [Test]
+    procedure ArrayLen_1D_NoArg_Returns10()
+    var
+        H: Codeunit "AL Helper";
+    begin
+        Assert.AreEqual(10, H.GetLen1D(), 'ArrayLen on array[10] must return 10');
+    end;
+
+    [Test]
+    procedure ArrayLen_1D_Dim1_Returns10()
+    var
+        H: Codeunit "AL Helper";
+    begin
+        Assert.AreEqual(10, H.GetLen1D_Dim1(), 'ArrayLen(arr, 1) on array[10] must return 10');
+    end;
+
+    [Test]
+    procedure ArrayLen_2D_Dim1_Returns3()
+    var
+        H: Codeunit "AL Helper";
+    begin
+        Assert.AreEqual(3, H.GetLen2D_Dim1(), 'ArrayLen(arr, 1) on array[3,4] must return 3');
+    end;
+
+    [Test]
+    procedure ArrayLen_2D_Dim2_Returns4()
+    var
+        H: Codeunit "AL Helper";
+    begin
+        Assert.AreEqual(4, H.GetLen2D_Dim2(), 'ArrayLen(arr, 2) on array[3,4] must return 4');
+    end;
+
+    [Test]
+    procedure ArrayLen_IsNotZero()
+    var
+        H: Codeunit "AL Helper";
+    begin
+        Assert.AreNotEqual(0, H.GetLen1D(), 'ArrayLen must not return zero for non-empty array');
+    end;
+}


### PR DESCRIPTION
Closes #214

## What changed
- `AlRunner/Runtime/MockArray.cs`: Store individual dimensions (params int[]) in `_dimensions` field so that `ArrayLen(arr, N)` returns the length of the Nth dimension rather than the total element count.
- `ArrayLen()` (no dimension arg) returns first dimension — correct per AL spec.
- Test suite `tests/bucket-2/158-arraylen/` with 5 proving tests covering 1-D and 2-D arrays.
- `docs/coverage.yaml`: System.ArrayLen → covered.
- Fixed pre-existing codeunit ID collision: renamed XDT suite from 61700/61701 → 61710/61711 (clashed with IWT suite merged in #531).

## Verified
- 1-D tests pass (no rewriter rule needed — BC compiler calls `arr.ArrayLen()` directly)
- 2-D tests fail on pre-fix code (Expected: 3, Actual: 12) — confirms the test is proving
- MockArray now returns per-dimension size for `ArrayLen(int)`