### PR TITLE
test: XmlElement.RemoveAllAttributes proving tests

### DIFF
--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -8772,8 +8772,10 @@ XmlElement.Remove:
 XmlElement.RemoveAllAttributes:
   layer: runtime-api
   category: XmlElement
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; BC native works standalone. Preserves element name + children; only attributes are cleared.
+  tests:
+    - tests/bucket-2/159-xml-removeallattrs
 
 XmlElement.RemoveAttribute:
   layer: runtime-api

--- a/tests/bucket-2/159-xml-removeallattrs/al-runner.json
+++ b/tests/bucket-2/159-xml-removeallattrs/al-runner.json
@@ -1,0 +1,4 @@
+{
+  "sourcePath": "./src",
+  "testPath": "./test"
+}

--- a/tests/bucket-2/159-xml-removeallattrs/src/RemoveAllAttrsSrc.al
+++ b/tests/bucket-2/159-xml-removeallattrs/src/RemoveAllAttrsSrc.al
@@ -1,0 +1,66 @@
+/// Helper codeunit exercising XmlElement.RemoveAllAttributes().
+/// Builds XmlElement programmatically (avoiding XmlDocument.ReadFrom which
+/// hits a separate rewriter gap — see #481).
+codeunit 59720 "RAA Src"
+{
+    procedure BuildWithThreeAttrs(): XmlElement
+    var
+        root: XmlElement;
+    begin
+        root := XmlElement.Create('root');
+        root.SetAttribute('a', '1');
+        root.SetAttribute('b', '2');
+        root.SetAttribute('c', '3');
+        exit(root);
+    end;
+
+    procedure AttrCount(elt: XmlElement): Integer
+    var
+        attrs: XmlAttributeCollection;
+    begin
+        attrs := elt.Attributes();
+        exit(attrs.Count);
+    end;
+
+    procedure RemoveAll(elt: XmlElement)
+    begin
+        elt.RemoveAllAttributes();
+    end;
+
+    /// Build element, remove all attributes, return attribute count (expected 0).
+    procedure RoundTripCount(): Integer
+    var
+        elt: XmlElement;
+    begin
+        elt := BuildWithThreeAttrs();
+        elt.RemoveAllAttributes();
+        exit(AttrCount(elt));
+    end;
+
+    /// Build with attrs + one child element, remove attributes, return child count.
+    procedure PreservesChildren(): Integer
+    var
+        elt: XmlElement;
+        child: XmlElement;
+        kids: XmlNodeList;
+    begin
+        elt := XmlElement.Create('root');
+        elt.SetAttribute('x', '9');
+        child := XmlElement.Create('child');
+        elt.Add(child);
+        elt.RemoveAllAttributes();
+
+        kids := elt.GetChildNodes();
+        exit(kids.Count);
+    end;
+
+    /// Build, remove, return the element's LocalName (must not be affected).
+    procedure PreservesName(): Text
+    var
+        elt: XmlElement;
+    begin
+        elt := BuildWithThreeAttrs();
+        elt.RemoveAllAttributes();
+        exit(elt.LocalName);
+    end;
+}

--- a/tests/bucket-2/159-xml-removeallattrs/test/RemoveAllAttrsTest.al
+++ b/tests/bucket-2/159-xml-removeallattrs/test/RemoveAllAttrsTest.al
@@ -1,0 +1,87 @@
+codeunit 59721 "RAA Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "RAA Src";
+
+    [Test]
+    procedure RemoveAllAttrs_Baseline_ThreeAttrs()
+    var
+        elt: XmlElement;
+    begin
+        // Baseline: BuildWithThreeAttrs produces an element with 3 attributes.
+        // This catches a no-op Build that would otherwise make the RemoveAll
+        // test trivially pass with zero inputs.
+        elt := Src.BuildWithThreeAttrs();
+        Assert.AreEqual(3, Src.AttrCount(elt),
+            'BuildWithThreeAttrs must produce 3 attributes');
+    end;
+
+    [Test]
+    procedure RemoveAllAttrs_ClearsAll()
+    begin
+        // Positive: after RemoveAttributes, attribute count is 0.
+        Assert.AreEqual(0, Src.RoundTripCount(),
+            'After RemoveAttributes, attribute count must be 0');
+    end;
+
+    [Test]
+    procedure RemoveAllAttrs_PreservesChildren()
+    begin
+        // Positive: children survive attribute removal — child count must be 1
+        // (element had one <child/> before RemoveAttributes).
+        Assert.AreEqual(1, Src.PreservesChildren(),
+            'RemoveAttributes must not remove child elements');
+    end;
+
+    [Test]
+    procedure RemoveAllAttrs_PreservesName()
+    begin
+        // Positive: the element's LocalName is unaffected by attribute removal.
+        Assert.AreEqual('root', Src.PreservesName(),
+            'RemoveAttributes must not change the element name');
+    end;
+
+    [Test]
+    procedure RemoveAllAttrs_Idempotent()
+    var
+        elt: XmlElement;
+    begin
+        // Calling RemoveAttributes twice in a row must not throw and must still
+        // leave the element with zero attributes.
+        elt := Src.BuildWithThreeAttrs();
+        Src.RemoveAll(elt);
+        Src.RemoveAll(elt);
+        Assert.AreEqual(0, Src.AttrCount(elt),
+            'Double-RemoveAttributes must still yield 0 attributes');
+    end;
+
+    [Test]
+    procedure RemoveAllAttrs_OnEmptyAttrElement()
+    var
+        elt: XmlElement;
+    begin
+        // Edge: calling RemoveAttributes on an element with no attributes is a no-op.
+        elt := XmlElement.Create('bare');
+        Src.RemoveAll(elt);
+        Assert.AreEqual(0, Src.AttrCount(elt),
+            'RemoveAttributes on an element with no attributes must not throw');
+    end;
+
+    [Test]
+    procedure RemoveAllAttrs_DoesNotAffectOtherElement_NegativeTrap()
+    var
+        a: XmlElement;
+        b: XmlElement;
+    begin
+        // Negative: RemoveAttributes must only affect the receiver. Removing
+        // from element a must leave element b's attributes intact.
+        a := Src.BuildWithThreeAttrs();
+        b := Src.BuildWithThreeAttrs();
+        Src.RemoveAll(a);
+        Assert.AreEqual(3, Src.AttrCount(b),
+            'RemoveAttributes on element a must not touch element b');
+    end;
+}


### PR DESCRIPTION
Closes #536

## Summary

BC native `XmlElement.RemoveAllAttributes` works standalone; adds a dedicated proving suite.

## Changes

- `tests/bucket-2/159-xml-removeallattrs/` — helper + 7 tests (baseline build count, clears all, preserves children, preserves LocalName, idempotent, on-empty no-op, no cross-element interference)
- `docs/coverage.yaml` — `XmlElement.RemoveAllAttributes` marked `covered`

## Verification

- 7/7 new tests pass
- Full bucket-2: 909 pass (3 pre-existing DateTime/timezone failures)