### PR TITLE
feat: Database.SetDefaultTableConnection — strip-entire-call no-op

### DIFF
--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -56,6 +56,7 @@ public class RoslynRewriter : CSharpSyntaxRewriter
         "ALExportData",   // ALDatabase.ALExportData(fileName, ...) — no file I/O standalone; no-op
         "ALDataFileInformation", // ALDatabase.ALDataFileInformation(showDialog, ref name, ...) — queries BC data file; no real DB standalone; no-op
         "ALRegisterTableConnection",  // ALDatabase.ALRegisterTableConnection(target, ct, name, conn) — no external connections standalone; no-op
+        "ALSetDefaultTableConnection",  // ALDatabase.ALSetDefaultTableConnection(ct, name) — no external connections standalone; no-op
     };
 
     private static readonly HashSet<string> StripITreeObjectArgMethods = new(StringComparer.Ordinal)

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -1669,8 +1669,10 @@ Database.SessionId:
 Database.SetDefaultTableConnection:
   layer: runtime-api
   category: Database
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; rewriter strips the entire call (no external connections standalone).
+  tests:
+    - tests/bucket-2/160-set-default-table-connection
 
 Database.SetUserPassword:
   layer: runtime-api

--- a/tests/bucket-2/160-set-default-table-connection/al-runner.json
+++ b/tests/bucket-2/160-set-default-table-connection/al-runner.json
@@ -1,0 +1,4 @@
+{
+  "sourcePath": "./src",
+  "testPath": "./test"
+}

--- a/tests/bucket-2/160-set-default-table-connection/src/SetDefaultTableConnectionSrc.al
+++ b/tests/bucket-2/160-set-default-table-connection/src/SetDefaultTableConnectionSrc.al
@@ -1,0 +1,14 @@
+/// Helper codeunit exercising Database.SetDefaultTableConnection.
+codeunit 59730 "SDTC Src"
+{
+    procedure CallSet(ct: TableConnectionType; name: Text)
+    begin
+        Database.SetDefaultTableConnection(ct, name);
+    end;
+
+    procedure CallSetAndReturnFlag(ct: TableConnectionType; name: Text): Boolean
+    begin
+        Database.SetDefaultTableConnection(ct, name);
+        exit(true);
+    end;
+}

--- a/tests/bucket-2/160-set-default-table-connection/test/SetDefaultTableConnectionTest.al
+++ b/tests/bucket-2/160-set-default-table-connection/test/SetDefaultTableConnectionTest.al
@@ -1,0 +1,52 @@
+codeunit 59731 "SDTC Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "SDTC Src";
+
+    [Test]
+    procedure SetDefaultTableConnection_NoOp()
+    begin
+        // Positive: standalone stub must complete without error.
+        Src.CallSet(TableConnectionType::ExternalSQL, 'MyConn');
+        Assert.IsTrue(true, 'SetDefaultTableConnection must not throw');
+    end;
+
+    [Test]
+    procedure SetDefaultTableConnection_EmptyName()
+    begin
+        // Edge: empty connection name must not crash.
+        Src.CallSet(TableConnectionType::ExternalSQL, '');
+        Assert.IsTrue(true, 'SetDefaultTableConnection with empty name must not throw');
+    end;
+
+    [Test]
+    procedure SetDefaultTableConnection_ExecutionContinues()
+    begin
+        // Proving: execution continues past the call.
+        Assert.IsTrue(Src.CallSetAndReturnFlag(TableConnectionType::CRM, 'CRMConn'),
+            'Caller must reach `exit(true)` after SetDefaultTableConnection');
+    end;
+
+    [Test]
+    procedure SetDefaultTableConnection_DifferentTypes()
+    begin
+        // Both available TableConnectionType enum values must complete.
+        Src.CallSet(TableConnectionType::ExternalSQL, 'SqlConn');
+        Src.CallSet(TableConnectionType::CRM, 'CrmConn');
+        Assert.IsTrue(true, 'Calls with both connection types must not throw');
+    end;
+
+    [Test]
+    procedure SetDefaultTableConnection_RepeatedCalls_NegativeTrap()
+    begin
+        // Negative trap: guard against a stub that accumulates state and crashes
+        // after multiple calls.
+        Src.CallSet(TableConnectionType::ExternalSQL, 'Conn1');
+        Src.CallSet(TableConnectionType::ExternalSQL, 'Conn2');
+        Src.CallSet(TableConnectionType::ExternalSQL, 'Conn3');
+        Assert.IsTrue(true, 'Multiple SetDefaultTableConnection calls must not throw');
+    end;
+}


### PR DESCRIPTION
Closes #543

## Summary

Same pattern as `Database.RegisterTableConnection` (PR #521). Adds `ALSetDefaultTableConnection` to `StripEntireCallMethods`.

## Changes

- `AlRunner/RoslynRewriter.cs` — added to `StripEntireCallMethods`
- `tests/bucket-2/160-set-default-table-connection/` — helper + 5 proving tests
- `docs/coverage.yaml` — `Database.SetDefaultTableConnection` marked `covered`

## Verification

- 5/5 new tests pass
- Full bucket-2: 914 pass (3 pre-existing DateTime/timezone failures)