### PR TITLE
feat: Dialog.HideSubsequentDialogs / Dialog.LogInternalError stubs

### DIFF
--- a/AlRunner/Runtime/AlScope.cs
+++ b/AlRunner/Runtime/AlScope.cs
@@ -287,6 +287,21 @@ public class MockDialog
     public void ALClose() { }
     public void ALAssign(MockDialog other) { }
 
+    /// <summary>
+    /// AL's Dialog.HideSubsequentDialogs — emitted as a property setter by the
+    /// BC compiler (`dlg.ALHideSubsequentDialogs = true`). No UI standalone;
+    /// the set is a no-op.
+    /// </summary>
+    public bool ALHideSubsequentDialogs { get; set; }
+
+    /// <summary>
+    /// AL's Dialog.LogInternalError(msg, dataClass, verbosity) — static method in AL.
+    /// BC emits `MockDialog.ALLogInternalError(session, msg, DataClassification, Verbosity)`
+    /// with a leading session (null! standalone). No telemetry pipeline standalone;
+    /// no-op stub. `object?` parameter types accept NavText/string + enum ordinals.
+    /// </summary>
+    public static void ALLogInternalError(object? session, object? msg, object? dataClassification, object? verbosity) { }
+
     // For ByRef<NavDialog> patterns that access .Value
     public MockDialog Value => this;
 

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -1923,26 +1923,30 @@ Dialog.Confirm:
 Dialog.Error:
   layer: runtime-api
   category: Dialog
-  status: gap
-  notes: overloads=2
+  status: covered
+  notes: overloads=2; AlDialog.Error implemented in Runtime/AlScope.cs (throws NavNCLMessageException). Asserterror-catchable per existing suites.
 
 Dialog.HideSubsequentDialogs:
   layer: runtime-api
   category: Dialog
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; emitted as property-set on MockDialog; no-op standalone.
+  tests:
+    - tests/bucket-2/161-dialog-methods
 
 Dialog.LogInternalError:
   layer: runtime-api
   category: Dialog
-  status: gap
-  notes: overloads=2
+  status: covered
+  notes: overloads=2; static MockDialog.ALLogInternalError stub (no telemetry pipeline standalone).
+  tests:
+    - tests/bucket-2/161-dialog-methods
 
 Dialog.Message:
   layer: runtime-api
   category: Dialog
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; AlDialog.Message implemented in Runtime/AlScope.cs, routes to MessageHandler or stdout.
 
 Dialog.Open:
   layer: runtime-api

--- a/tests/bucket-2/161-dialog-methods/al-runner.json
+++ b/tests/bucket-2/161-dialog-methods/al-runner.json
@@ -1,0 +1,4 @@
+{
+  "sourcePath": "./src",
+  "testPath": "./test"
+}

--- a/tests/bucket-2/161-dialog-methods/src/DialogMethodsSrc.al
+++ b/tests/bucket-2/161-dialog-methods/src/DialogMethodsSrc.al
@@ -1,0 +1,38 @@
+/// Helper codeunit exercising the additional Dialog methods per issue #542:
+/// - Dialog.HideSubsequentDialogs (instance method, no-op stub standalone)
+/// - Dialog.LogInternalError (STATIC method, no-op stub standalone)
+///
+/// Dialog.Error and Dialog.Message are already covered by existing tests
+/// (MessageHandler/Assert.ExpectedError suites); this suite is specifically
+/// for the two less-common methods that were flagged as gaps.
+codeunit 59740 "DLGM Src"
+{
+    procedure CallHideSubsequentDialogs(hide: Boolean)
+    var
+        dlg: Dialog;
+    begin
+        dlg.HideSubsequentDialogs(hide);
+    end;
+
+    procedure CallHideAndReturnFlag(hide: Boolean): Boolean
+    var
+        dlg: Dialog;
+    begin
+        dlg.HideSubsequentDialogs(hide);
+        exit(true);
+    end;
+
+    procedure CallLogInternalError(msg: Text)
+    begin
+        Dialog.LogInternalError(msg, DataClassification::SystemMetadata, Verbosity::Normal);
+    end;
+
+    procedure CallBothAndReturnFlag(msg: Text): Boolean
+    var
+        dlg: Dialog;
+    begin
+        dlg.HideSubsequentDialogs(true);
+        Dialog.LogInternalError(msg, DataClassification::SystemMetadata, Verbosity::Normal);
+        exit(true);
+    end;
+}

--- a/tests/bucket-2/161-dialog-methods/test/DialogMethodsTest.al
+++ b/tests/bucket-2/161-dialog-methods/test/DialogMethodsTest.al
@@ -1,0 +1,62 @@
+codeunit 59741 "DLGM Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "DLGM Src";
+
+    [Test]
+    procedure HideSubsequentDialogs_True_NoOp()
+    begin
+        // Positive: standalone stub must complete without error.
+        Src.CallHideSubsequentDialogs(true);
+        Assert.IsTrue(true, 'HideSubsequentDialogs(true) must not throw');
+    end;
+
+    [Test]
+    procedure HideSubsequentDialogs_False_NoOp()
+    begin
+        Src.CallHideSubsequentDialogs(false);
+        Assert.IsTrue(true, 'HideSubsequentDialogs(false) must not throw');
+    end;
+
+    [Test]
+    procedure HideSubsequentDialogs_ExecutionContinues()
+    begin
+        // Proving: execution continues past the call.
+        Assert.IsTrue(Src.CallHideAndReturnFlag(true),
+            'Caller must reach `exit(true)` after HideSubsequentDialogs');
+    end;
+
+    [Test]
+    procedure LogInternalError_NoOp()
+    begin
+        Src.CallLogInternalError('Something went wrong');
+        Assert.IsTrue(true, 'LogInternalError must not throw');
+    end;
+
+    [Test]
+    procedure LogInternalError_EmptyMessage()
+    begin
+        // Edge: empty message must not crash.
+        Src.CallLogInternalError('');
+        Assert.IsTrue(true, 'LogInternalError with empty message must not throw');
+    end;
+
+    [Test]
+    procedure LogInternalError_LongMessage_NegativeTrap()
+    begin
+        // Negative trap: guard against crash on large input.
+        Src.CallLogInternalError('A very long internal-error description that might stress a naive implementation_0123456789_abcdefghij');
+        Assert.IsTrue(true, 'LogInternalError with long message must not throw');
+    end;
+
+    [Test]
+    procedure BothMethodsTogether_NoOp()
+    begin
+        // Proving: both methods can be invoked sequentially without interference.
+        Assert.IsTrue(Src.CallBothAndReturnFlag('nested-call-msg'),
+            'HideSubsequentDialogs + LogInternalError in sequence must complete');
+    end;
+}


### PR DESCRIPTION
Closes #542

## Summary

Both missing from MockDialog. Added:
- `bool ALHideSubsequentDialogs { get; set; }` — BC emits property-set
- `static void ALLogInternalError(session, msg, dataClass, verbosity)` — static method with session placeholder

Dialog.Error / Dialog.Message were already functional (in AlDialog class); this PR also marks their coverage.yaml entries `covered`.

## Changes

- `AlRunner/Runtime/AlScope.cs` — added the two stubs to MockDialog
- `tests/bucket-2/161-dialog-methods/` — helper + 7 proving tests
- `docs/coverage.yaml` — all 4 dialog methods marked `covered`

## Verification

- 7/7 new tests pass
- Full bucket-2: 921 pass (3 pre-existing DateTime/timezone failures)