### PR TITLE
feat: Dialog.StrMenu — MockDialog stubs returning defaultNo

### DIFF
--- a/AlRunner/Runtime/AlScope.cs
+++ b/AlRunner/Runtime/AlScope.cs
@@ -302,6 +302,22 @@ public class MockDialog
     /// </summary>
     public static void ALLogInternalError(object? session, object? msg, object? dataClassification, object? verbosity) { }
 
+    /// <summary>
+    /// AL's StrMenu(options [, defaultNo [, caption]]) — displays a menu and
+    /// returns the 1-based index of the selected option (or 0 on cancel).
+    /// BC lowers StrMenu to static calls on MockDialog with a leading session
+    /// (null! standalone) and a trailing Guid (dialog-id token).
+    ///
+    /// No UI standalone — we return the `defaultNo` (0 when omitted), matching
+    /// the "unhandled dialog → use default or cancel" convention already used
+    /// for CONFIRM and MESSAGE without handlers.
+    /// </summary>
+    public static int ALStrMenu(object? session, object? options, Guid dialogId) => 0;
+
+    public static int ALStrMenu(object? session, object? options, int defaultNo, Guid dialogId) => defaultNo;
+
+    public static int ALStrMenu(object? session, object? options, int defaultNo, object? caption, Guid dialogId) => defaultNo;
+
     // For ByRef<NavDialog> patterns that access .Value
     public MockDialog Value => this;
 

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -1957,8 +1957,10 @@ Dialog.Open:
 Dialog.StrMenu:
   layer: runtime-api
   category: Dialog
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1 (3 C# overloads 3/4/5-arg); MockDialog.ALStrMenu returns defaultNo (or 0 when omitted) — "use default or cancel" convention standalone.
+  tests:
+    - tests/bucket-2/162-strmenu
 
 Dialog.Update:
   layer: runtime-api

--- a/tests/bucket-2/162-strmenu/al-runner.json
+++ b/tests/bucket-2/162-strmenu/al-runner.json
@@ -1,0 +1,4 @@
+{
+  "sourcePath": "./src",
+  "testPath": "./test"
+}

--- a/tests/bucket-2/162-strmenu/src/StrMenuSrc.al
+++ b/tests/bucket-2/162-strmenu/src/StrMenuSrc.al
@@ -1,0 +1,19 @@
+/// Helper codeunit exercising StrMenu — the top-level builtin that pops a menu
+/// and returns the 1-based index of the selected option (or 0 on cancel).
+codeunit 59750 "SM Src"
+{
+    procedure Pick(options: Text): Integer
+    begin
+        exit(StrMenu(options));
+    end;
+
+    procedure PickWithDefault(options: Text; defaultNo: Integer): Integer
+    begin
+        exit(StrMenu(options, defaultNo));
+    end;
+
+    procedure PickWithDefaultAndCaption(options: Text; defaultNo: Integer; caption: Text): Integer
+    begin
+        exit(StrMenu(options, defaultNo, caption));
+    end;
+}

--- a/tests/bucket-2/162-strmenu/test/StrMenuTest.al
+++ b/tests/bucket-2/162-strmenu/test/StrMenuTest.al
@@ -1,0 +1,71 @@
+codeunit 59751 "SM Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "SM Src";
+
+    [Test]
+    procedure StrMenu_NoHandler_ReturnsCancel()
+    var
+        choice: Integer;
+    begin
+        // Positive: without a handler registered, StrMenu must return 0 (cancel)
+        // standalone — there is no interactive UI and no default selection.
+        choice := Src.Pick('Alpha,Beta,Gamma');
+        Assert.AreEqual(0, choice, 'Unhandled StrMenu must return 0 (cancel) standalone');
+    end;
+
+    [Test]
+    procedure StrMenu_EmptyOptions_NoOpReturnsZero()
+    begin
+        // Edge: empty options string must not throw; returns 0.
+        Assert.AreEqual(0, Src.Pick(''),
+            'StrMenu with empty options must return 0');
+    end;
+
+    [Test]
+    procedure StrMenu_WithDefault_NoHandler_ReturnsDefault()
+    var
+        choice: Integer;
+    begin
+        // With a default specified (arg 2), an un-handled StrMenu should return
+        // the default selection. Default button 2 means the second menu item.
+        choice := Src.PickWithDefault('Alpha,Beta,Gamma', 2);
+        Assert.AreEqual(2, choice, 'Unhandled StrMenu with defaultNo=2 must return 2');
+    end;
+
+    [Test]
+    procedure StrMenu_DefaultZero_ReturnsCancel()
+    begin
+        // defaultNo=0 means no default → cancel (returns 0).
+        Assert.AreEqual(0, Src.PickWithDefault('A,B,C', 0),
+            'StrMenu with defaultNo=0 must return 0 (cancel)');
+    end;
+
+    [Test]
+    procedure StrMenu_DefaultLast_ReturnsLast()
+    begin
+        // Default pointing at the last option (index 3 of 3) must return 3.
+        Assert.AreEqual(3, Src.PickWithDefault('A,B,C', 3),
+            'StrMenu with defaultNo=last must return the last index');
+    end;
+
+    [Test]
+    procedure StrMenu_WithCaption_NoHandler_ReturnsDefault()
+    begin
+        // Three-arg overload (options, default, caption) must also work.
+        Assert.AreEqual(1, Src.PickWithDefaultAndCaption('Yes,No', 1, 'Proceed?'),
+            'StrMenu 3-arg overload with defaultNo=1 must return 1');
+    end;
+
+    [Test]
+    procedure StrMenu_NotAlwaysFirst_NegativeTrap()
+    begin
+        // Negative: guard against a stub that always returns 1. Setting
+        // defaultNo=3 must yield 3 (not 1).
+        Assert.AreNotEqual(1, Src.PickWithDefault('A,B,C', 3),
+            'StrMenu must honor defaultNo, not always return 1');
+    end;
+}


### PR DESCRIPTION
Closes #548

## Summary

Added three static `ALStrMenu` overloads to MockDialog matching the C# shapes BC emits (3/4/5-arg). Return value is `defaultNo` (or 0 when omitted), matching the "unhandled dialog → use default or cancel" convention already used for CONFIRM/MESSAGE.

## Changes

- `AlRunner/Runtime/AlScope.cs` — three static `ALStrMenu` overloads
- `tests/bucket-2/162-strmenu/` — helper + 7 proving tests
- `docs/coverage.yaml` — `Dialog.StrMenu` marked `covered`

## Verification

- 7/7 new tests pass
- Full bucket-2: 932 pass (3 pre-existing DateTime/timezone failures)