### PR TITLE
feat: Xmlport.Run — static no-op stub

### DIFF
--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -2110,6 +2110,20 @@ public void ClearApplicationMemberVariables() { }
                     visited.ArgumentList);
             }
 
+            // NavXmlPort.Run(portId [, showPage, showXml]) -> MockXmlPortHandle.StaticRun(...)
+            // BC emits `NavXmlPort.Run(<id>)` for Xmlport.Run(Xmlport::"X"). No file I/O or
+            // interactive target standalone — the stub completes as a no-op so caller
+            // execution continues unaffected.
+            if (exprText == "NavXmlPort" && methodName == "Run")
+            {
+                return SyntaxFactory.InvocationExpression(
+                    SyntaxFactory.MemberAccessExpression(
+                        SyntaxKind.SimpleMemberAccessExpression,
+                        SyntaxFactory.IdentifierName("MockXmlPortHandle"),
+                        SyntaxFactory.IdentifierName("StaticRun")),
+                    visited.ArgumentList);
+            }
+
             // NavQuery.ALSaveAsCsv/ALSaveAsXml/ALSaveAsJson/ALSaveAsExcel -> MockQueryHandle statics
             // BC emits these static calls for Query.SaveAsCsv(queryId, ...) etc.
             // NavQuery requires the service tier; forward to MockQueryHandle stubs.

--- a/AlRunner/Runtime/MockXmlPortHandle.cs
+++ b/AlRunner/Runtime/MockXmlPortHandle.cs
@@ -80,4 +80,15 @@ public class MockXmlPortHandle
         => throw new NotSupportedException(
             $"XmlPort {xmlPortId} Export requires the BC service tier and is not supported by al-runner. " +
             "Use AL interface injection to abstract XmlPort dependencies for testing.");
+
+    /// <summary>
+    /// Static <c>Xmlport.Run(portId [, showPage [, showXml]])</c> — no-op standalone.
+    /// The real implementation opens a request page or imports/exports via file
+    /// dialogs, neither of which apply to al-runner. Unlike StaticImport/Export
+    /// (which take explicit stream arguments and thus indicate intentional I/O),
+    /// Run is a "fire and forget" entry-point — tests that call it generally
+    /// just want the compilation unit to build and control to flow past the call.
+    /// `params object?[]` accepts any trailing arg shape BC emits.
+    /// </summary>
+    public static void StaticRun(int xmlPortId, params object?[] args) { }
 }

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -9278,8 +9278,10 @@ Xmlport.Import:
 Xmlport.Run:
   layer: runtime-api
   category: Xmlport
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; rewriter routes NavXmlPort.Run -> MockXmlPortHandle.StaticRun which is a no-op (no file I/O or interactive UI standalone). Accepts all arg shapes via params object?[].
+  tests:
+    - tests/bucket-2/163-xmlport-run
 
 # ── XmlportInstance ─────────────────────────────────────────────
 

--- a/tests/bucket-2/163-xmlport-run/al-runner.json
+++ b/tests/bucket-2/163-xmlport-run/al-runner.json
@@ -1,0 +1,4 @@
+{
+  "sourcePath": "./src",
+  "testPath": "./test"
+}

--- a/tests/bucket-2/163-xmlport-run/src/XmlportRunSrc.al
+++ b/tests/bucket-2/163-xmlport-run/src/XmlportRunSrc.al
@@ -1,0 +1,35 @@
+/// Minimal xmlport object — exercised for Xmlport.Run dispatch.
+xmlport 59760 "XPR Minimal"
+{
+    Direction = Export;
+    Format = Xml;
+
+    schema
+    {
+        textelement(root)
+        {
+            textattribute(version) { }
+        }
+    }
+}
+
+/// Helper codeunit exercising Xmlport.Run.
+codeunit 59760 "XPR Src"
+{
+    procedure CallRun()
+    begin
+        Xmlport.Run(Xmlport::"XPR Minimal");
+    end;
+
+    procedure CallRunAndReturnFlag(): Boolean
+    begin
+        Xmlport.Run(Xmlport::"XPR Minimal");
+        exit(true);
+    end;
+
+    procedure CallRunWithShowPage(showPage: Boolean; showXml: Boolean): Boolean
+    begin
+        Xmlport.Run(Xmlport::"XPR Minimal", showPage, showXml);
+        exit(true);
+    end;
+}

--- a/tests/bucket-2/163-xmlport-run/test/XmlportRunTest.al
+++ b/tests/bucket-2/163-xmlport-run/test/XmlportRunTest.al
@@ -1,0 +1,54 @@
+codeunit 59761 "XPR Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "XPR Src";
+
+    [Test]
+    procedure XmlportRun_SingleArg_NoOp()
+    begin
+        // Positive: the standalone stub must execute without error. There is no
+        // file I/O or interactive import/export target, so Xmlport.Run is a
+        // no-op that completes and lets execution continue.
+        Src.CallRun();
+        Assert.IsTrue(true, 'Xmlport.Run must not throw');
+    end;
+
+    [Test]
+    procedure XmlportRun_ExecutionContinues()
+    begin
+        // Proving: execution continues past Xmlport.Run (flag gets set).
+        Assert.IsTrue(Src.CallRunAndReturnFlag(),
+            'Caller must reach `exit(true)` after Xmlport.Run');
+    end;
+
+    [Test]
+    procedure XmlportRun_WithShowPageFalse()
+    begin
+        // 3-arg overload with showPage=false / showXml=false must complete.
+        Assert.IsTrue(Src.CallRunWithShowPage(false, false),
+            'Xmlport.Run 3-arg (false, false) must complete');
+    end;
+
+    [Test]
+    procedure XmlportRun_WithShowPageTrue()
+    begin
+        // 3-arg overload with both showPage=true / showXml=true must also complete
+        // (no UI standalone; the flags are ignored).
+        Assert.IsTrue(Src.CallRunWithShowPage(true, true),
+            'Xmlport.Run 3-arg (true, true) must complete');
+    end;
+
+    [Test]
+    procedure XmlportRun_MixedFlags_NegativeTrap()
+    begin
+        // Negative trap: flag interaction must not throw. Tests both mixed
+        // combinations that a naive stub might accidentally branch on.
+        Assert.IsTrue(Src.CallRunWithShowPage(true, false),
+            'Xmlport.Run (true, false) must complete');
+        Assert.IsTrue(Src.CallRunWithShowPage(false, true),
+            'Xmlport.Run (false, true) must complete');
+    end;
+}


### PR DESCRIPTION
Closes #551
Closes #550 (duplicate)

## Summary

`NavXmlPort.Run(id [, showPage, showXml])` wasn't routed; AL code calling `Xmlport.Run` failed. Added rewriter rule and `MockXmlPortHandle.StaticRun` stub.

Unlike StaticImport/Export (which take explicit streams — still throw), Run is a fire-and-forget entry point. Tests calling it generally want the compilation unit to build and control to flow past; a no-op serves that.

## Changes

- `AlRunner/RoslynRewriter.cs` — route `NavXmlPort.Run(...)` → `MockXmlPortHandle.StaticRun(...)`
- `AlRunner/Runtime/MockXmlPortHandle.cs` — new static `StaticRun(portId, params object?[] args)` (no-op)
- `tests/bucket-2/163-xmlport-run/` — minimal xmlport + helper + 5 proving tests
- `docs/coverage.yaml` — `Xmlport.Run` marked `covered`

## Verification

- 5/5 new tests pass
- Full bucket-2: 937 pass (3 pre-existing DateTime/timezone failures)