### PR TITLE
feat: XmlPort.Run — static no-op stub for standalone mode

### DIFF
--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -2079,6 +2079,19 @@ public void ClearApplicationMemberVariables() { }
                 }
             }
 
+            // NavXmlPort.Run(DataError, xmlPortId [, showRequestPage [, isImport]]) -> MockXmlPortHandle.StaticRun(...)
+            // BC emits this static call for XmlPort.Run(XmlPort::"X" [, showRequestPage [, isImport]]).
+            // XmlPort.Run shows a request dialog and performs I/O — no-op in standalone mode.
+            if (exprText == "NavXmlPort" && methodName == "Run")
+            {
+                return SyntaxFactory.InvocationExpression(
+                    SyntaxFactory.MemberAccessExpression(
+                        SyntaxKind.SimpleMemberAccessExpression,
+                        SyntaxFactory.IdentifierName("MockXmlPortHandle"),
+                        SyntaxFactory.IdentifierName("StaticRun")),
+                    visited.ArgumentList);
+            }
+
             // NavXmlPort.Import(DataError, xmlPortId, stream [, rec]) -> MockXmlPortHandle.StaticImport(...)
             // NavXmlPort.Export(DataError, xmlPortId, stream [, rec]) -> MockXmlPortHandle.StaticExport(...)
             // BC emits these static calls for the short form: XmlPort.Import(XmlPort::"X", InStr).

--- a/AlRunner/Runtime/MockXmlPortHandle.cs
+++ b/AlRunner/Runtime/MockXmlPortHandle.cs
@@ -34,6 +34,13 @@ public class MockXmlPortHandle
     public MockOutStream? Destination { get; set; }
 
     /// <summary>
+    /// Instance <c>XP.Run([showRequestPage [, isImport]])</c>. No-op in standalone mode —
+    /// XmlPort.Run opens the request dialog and executes I/O, both of which require the
+    /// BC service tier. In tests, call the code that uses the XmlPort result directly.
+    /// </summary>
+    public void ALRun(object? errorLevel = null, object? showRequestPage = null, object? isImport = null) { }
+
+    /// <summary>
     /// Instance <c>XP.Import()</c>. Always throws — XmlPort I/O requires the service tier.
     /// Use an AL interface to inject a testable implementation.
     /// </summary>
@@ -58,8 +65,10 @@ public class MockXmlPortHandle
     public object? Invoke(int memberId, object[] args) => null;
 
     // ------------------------------------------------------------------
-    // Static form: XmlPort.Import(XmlPort::"X", InStr [, Rec])
+    // Static forms: XmlPort.Import/Export/Run
     // BC emits: NavXmlPort.Import(DataError, xmlPortId, inStr [, rec])
+    //           NavXmlPort.Export(DataError, xmlPortId, outStr [, rec])
+    //           NavXmlPort.Run(DataError) — no portId arg; port resolved via generated class
     // Rewriter redirects these to the statics below.
     // ------------------------------------------------------------------
 
@@ -80,4 +89,13 @@ public class MockXmlPortHandle
         => throw new NotSupportedException(
             $"XmlPort {xmlPortId} Export requires the BC service tier and is not supported by al-runner. " +
             "Use AL interface injection to abstract XmlPort dependencies for testing.");
+
+    /// <summary>
+    /// Static <c>XmlPort.Run([showRequestPage [, isImport]])</c> no-op stub.
+    /// BC emits <c>NavXmlPort.Run(DataError)</c> for the static AL form — no portId is
+    /// passed as an argument; the port identity is resolved through the generated XmlPort
+    /// derived class, not via a parameter. XmlPort.Run shows a request dialog and executes
+    /// I/O, both of which require the BC service tier. In standalone mode this is a no-op.
+    /// </summary>
+    public static void StaticRun(object? errorLevel = null, object? showRequestPage = null, object? isImport = null) { }
 }

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -9278,8 +9278,9 @@ Xmlport.Import:
 Xmlport.Run:
   layer: runtime-api
   category: Xmlport
-  status: gap
+  status: covered
   notes: overloads=1
+  suite: 163-xmlport-run
 
 # ── XmlportInstance ─────────────────────────────────────────────
 

--- a/tests/bucket-2/163-xmlport-run/src/XmlPortRunSrc.al
+++ b/tests/bucket-2/163-xmlport-run/src/XmlPortRunSrc.al
@@ -1,0 +1,27 @@
+/// XmlPort used to prove that XmlPort.Run executes without error.
+/// XmlPort.Run(portId) is a static no-op in standalone mode — no UI, no I/O.
+
+xmlport 61910 "XR XmlPort"
+{
+    Direction = Import;
+    Format = Xml;
+    schema
+    {
+        textelement(Root) { }
+    }
+}
+
+codeunit 61911 "XR Helper"
+{
+    /// Call XmlPort.Run(XmlPort::"XR XmlPort") — must be a no-op stub.
+    procedure RunXmlPort()
+    begin
+        XmlPort.Run(XmlPort::"XR XmlPort");
+    end;
+
+    /// Proving helper — returns a+b+1 to verify the codeunit is live.
+    procedure AddWithBonus(a: Integer; b: Integer): Integer
+    begin
+        exit(a + b + 1);
+    end;
+}

--- a/tests/bucket-2/163-xmlport-run/test/XmlPortRunTest.al
+++ b/tests/bucket-2/163-xmlport-run/test/XmlPortRunTest.al
@@ -1,0 +1,47 @@
+codeunit 61912 "XR XmlPort Run Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    [Test]
+    procedure XmlPortRun_NoError()
+    var
+        Helper: Codeunit "XR Helper";
+    begin
+        // Positive: XmlPort.Run must not throw in standalone mode (no-op stub).
+        Helper.RunXmlPort();
+        Assert.IsTrue(true, 'XmlPort.Run must complete without error');
+    end;
+
+    [Test]
+    procedure XmlPortRun_CalledTwice_NoError()
+    var
+        Helper: Codeunit "XR Helper";
+    begin
+        // Edge case: calling XmlPort.Run twice must not error.
+        Helper.RunXmlPort();
+        Helper.RunXmlPort();
+        Assert.IsTrue(true, 'XmlPort.Run called twice must not error');
+    end;
+
+    [Test]
+    procedure AddWithBonus_ProvingCompilationUnitLive()
+    var
+        Helper: Codeunit "XR Helper";
+    begin
+        // Proving: the codeunit is live — real computation returns a+b+1.
+        Assert.AreEqual(8, Helper.AddWithBonus(3, 4), 'AddWithBonus(3,4) must return 3+4+1=8');
+        Assert.AreEqual(1, Helper.AddWithBonus(0, 0), 'AddWithBonus(0,0) must return 0+0+1=1');
+    end;
+
+    [Test]
+    procedure AddWithBonus_NotPlainSum()
+    var
+        Helper: Codeunit "XR Helper";
+    begin
+        // Negative: AddWithBonus must NOT return a plain sum (no-op trap guard).
+        Assert.AreNotEqual(7, Helper.AddWithBonus(3, 4), 'AddWithBonus must not just return a+b');
+    end;
+}


### PR DESCRIPTION
Closes #550

## What

`XmlPort.Run(XmlPort::"Name")` is the static AL form that opens the XmlPort request dialog and executes import/export. In standalone mode (no BC service tier) it must be a silent no-op.

## How

- **RoslynRewriter**: Added rule to redirect `NavXmlPort.Run(DataError, xmlPortId, ...)` → `MockXmlPortHandle.StaticRun(...)` — parallel to the existing Import/Export static redirects.
- **MockXmlPortHandle**: Added `StaticRun` (static no-op) and `ALRun` (instance no-op, for any instance-method form BC may emit after `.Target` stripping).
- **Suite 163** (`tests/bucket-2/163-xmlport-run/`): Four tests — `XmlPortRun_NoError`, `XmlPortRun_CalledTwice_NoError`, `AddWithBonus_ProvingCompilationUnitLive`, `AddWithBonus_NotPlainSum`.
- **coverage.yaml**: `Xmlport.Run` → `covered`.

## Tests

| Test | What it proves |
|------|---------------|
| `XmlPortRun_NoError` | Static `XmlPort.Run` completes without throwing |
| `XmlPortRun_CalledTwice_NoError` | Idempotent — no side effects accumulate |
| `AddWithBonus_ProvingCompilationUnitLive` | Codeunit is live; returns `a+b+1`, not a stub zero |
| `AddWithBonus_NotPlainSum` | Guards against a no-op stub that returns `a+b` |