### PR TITLE
feat: Database.UnregisterTableConnection — strip-entire-call no-op

### DIFF
--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -58,6 +58,7 @@ public class RoslynRewriter : CSharpSyntaxRewriter
         "ALDataFileInformation", // ALDatabase.ALDataFileInformation(showDialog, ref name, ...) — queries BC data file; no real DB standalone; no-op
         "ALRegisterTableConnection",  // ALDatabase.ALRegisterTableConnection(target, ct, name, conn) — no external connections standalone; no-op
         "ALSetDefaultTableConnection",  // ALDatabase.ALSetDefaultTableConnection(ct, name) — no external connections standalone; no-op
+        "ALUnregisterTableConnection",  // ALDatabase.ALUnregisterTableConnection(ct, name) — no external connections standalone; no-op
     };
 
     private static readonly HashSet<string> StripITreeObjectArgMethods = new(StringComparer.Ordinal)

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -1697,8 +1697,10 @@ Database.TenantId:
 Database.UnregisterTableConnection:
   layer: runtime-api
   category: Database
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; rewriter strips the entire call (no external connections standalone). Pairs with RegisterTableConnection / SetDefaultTableConnection.
+  tests:
+    - tests/bucket-2/164-unregister-table-connection
 
 Database.UserId:
   layer: runtime-api

--- a/tests/bucket-2/164-unregister-table-connection/al-runner.json
+++ b/tests/bucket-2/164-unregister-table-connection/al-runner.json
@@ -1,0 +1,4 @@
+{
+  "sourcePath": "./src",
+  "testPath": "./test"
+}

--- a/tests/bucket-2/164-unregister-table-connection/src/UnregisterTableConnectionSrc.al
+++ b/tests/bucket-2/164-unregister-table-connection/src/UnregisterTableConnectionSrc.al
@@ -1,0 +1,14 @@
+/// Helper codeunit exercising Database.UnregisterTableConnection.
+codeunit 59770 "UTC Src"
+{
+    procedure CallUnregister(ct: TableConnectionType; name: Text)
+    begin
+        Database.UnregisterTableConnection(ct, name);
+    end;
+
+    procedure CallUnregisterAndReturnFlag(ct: TableConnectionType; name: Text): Boolean
+    begin
+        Database.UnregisterTableConnection(ct, name);
+    exit(true);
+    end;
+}

--- a/tests/bucket-2/164-unregister-table-connection/test/UnregisterTableConnectionTest.al
+++ b/tests/bucket-2/164-unregister-table-connection/test/UnregisterTableConnectionTest.al
@@ -1,0 +1,50 @@
+codeunit 59771 "UTC Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "UTC Src";
+
+    [Test]
+    procedure UnregisterTableConnection_NoOp()
+    begin
+        // Positive: standalone stub must complete without error.
+        Src.CallUnregister(TableConnectionType::ExternalSQL, 'MyConn');
+        Assert.IsTrue(true, 'UnregisterTableConnection must not throw');
+    end;
+
+    [Test]
+    procedure UnregisterTableConnection_EmptyName()
+    begin
+        // Edge: empty name must not crash the stub.
+        Src.CallUnregister(TableConnectionType::ExternalSQL, '');
+        Assert.IsTrue(true, 'UnregisterTableConnection with empty name must not throw');
+    end;
+
+    [Test]
+    procedure UnregisterTableConnection_ExecutionContinues()
+    begin
+        // Proving: execution continues past the call.
+        Assert.IsTrue(Src.CallUnregisterAndReturnFlag(TableConnectionType::CRM, 'CRMConn'),
+            'Caller must reach `exit(true)` after UnregisterTableConnection');
+    end;
+
+    [Test]
+    procedure UnregisterTableConnection_DifferentTypes()
+    begin
+        // Both available TableConnectionType enum values must complete.
+        Src.CallUnregister(TableConnectionType::ExternalSQL, 'SqlConn');
+        Src.CallUnregister(TableConnectionType::CRM, 'CrmConn');
+        Assert.IsTrue(true, 'Calls with both connection types must not throw');
+    end;
+
+    [Test]
+    procedure UnregisterTableConnection_NonExistent_NoOp()
+    begin
+        // Edge: unregistering a connection that was never registered is a no-op
+        // (the runner has no connection registry, but the call must still complete).
+        Src.CallUnregister(TableConnectionType::ExternalSQL, 'NeverRegistered');
+        Assert.IsTrue(true, 'Unregister of non-existent connection must not throw');
+    end;
+}


### PR DESCRIPTION
Closes #547

## Summary

Completes the Register/SetDefault/Unregister trio (PRs #521 and #545 covered the first two). Add `ALUnregisterTableConnection` to `StripEntireCallMethods`.

## Changes

- `AlRunner/RoslynRewriter.cs` — added to `StripEntireCallMethods`
- `tests/bucket-2/164-unregister-table-connection/` — helper + 5 proving tests
- `docs/coverage.yaml` — `Database.UnregisterTableConnection` marked `covered`

## Verification

- 5/5 new tests pass
- Full bucket-2: 947 pass (3 pre-existing DateTime/timezone failures)