### PR TITLE
feat: JsonObject.GetBoolean — typed boolean accessor for JSON objects

### DIFF
--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -2150,11 +2150,12 @@ public void ClearApplicationMemberVariables() { }
             }
 
             // NavJsonToken/NavJsonObject/NavJsonArray/NavJsonValue: ALWriteTo, ALReadFrom,
-            // ALSelectToken, ALSelectTokens -> MockJsonHelper static methods.
+            // ALSelectToken, ALSelectTokens, ALGetBoolean -> MockJsonHelper static methods.
             // These BC methods go through TrappableOperationExecutor -> NavEnvironment
             // which crashes in standalone mode. MockJsonHelper does the same work
             // using Newtonsoft.Json directly.
-            if (methodName is "ALWriteTo" or "ALReadFrom" or "ALSelectToken" or "ALSelectTokens")
+            if (methodName is "ALWriteTo" or "ALReadFrom" or "ALSelectToken" or "ALSelectTokens"
+                or "ALGetBoolean")
             {
                 var helperMethod = methodName switch
                 {
@@ -2162,11 +2163,12 @@ public void ClearApplicationMemberVariables() { }
                     "ALReadFrom" => "ReadFrom",
                     "ALSelectToken" => "SelectToken",
                     "ALSelectTokens" => "SelectTokens",
+                    "ALGetBoolean" => "GetBoolean",
                     _ => null
                 };
                 if (helperMethod is not null)
                 {
-                    // Rewrite: x.ALWriteTo(args) -> MockJsonHelper.WriteTo(x, args)
+                    // Rewrite: x.ALGetBoolean(args) -> MockJsonHelper.GetBoolean(x, args)
                     var args = visited.ArgumentList.Arguments;
                     var newArgs = new SeparatedSyntaxList<ArgumentSyntax>();
                     newArgs = newArgs.Add(SyntaxFactory.Argument(memberAccess.Expression));

--- a/AlRunner/Runtime/MockJsonHelper.cs
+++ b/AlRunner/Runtime/MockJsonHelper.cs
@@ -182,34 +182,26 @@ public static class MockJsonHelper
     }
 
     /// <summary>
-    /// Replacement for NavJsonToken.ALGetBoolean(DataError, key).
+    /// Replacement for NavJsonToken.ALGetBoolean(key).
     /// Returns the boolean value of the named property without going through
     /// TrappableOperationExecutor or NavCurrentThread.Session.
-    /// AL: JsonObject.GetBoolean('key')  →  MockJsonHelper.GetBoolean(token, error, key)
+    /// AL: JsonObject.GetBoolean('key')  →  MockJsonHelper.GetBoolean(token, key)
+    /// Note: BC does not pass a DataError arg for typed JSON getters.
     /// </summary>
-    public static bool GetBoolean(NavJsonToken token, DataError errorLevel, string key)
+    public static bool GetBoolean(NavJsonToken token, string key)
     {
-        try
-        {
-            var backingToken = GetBackingToken(token);
-            if (backingToken is not JObject obj)
-                throw new Exception("The JSON token is not an object.");
+        var backingToken = GetBackingToken(token);
+        if (backingToken is not JObject obj)
+            throw new Exception("The JSON token is not an object.");
 
-            if (!obj.TryGetValue(key, out var val))
-                throw new Exception($"The JSON object does not contain a property with the name '{key}'.");
+        if (!obj.TryGetValue(key, out var val))
+            throw new Exception($"The JSON object does not contain a property with the name '{key}'.");
 
-            if (val.Type != JTokenType.Boolean)
-                throw new Exception(
-                    $"The value of JSON property '{key}' cannot be converted to a Boolean value.");
+        if (val.Type != JTokenType.Boolean)
+            throw new Exception(
+                $"The value of JSON property '{key}' cannot be converted to a Boolean value.");
 
-            return val.Value<bool>();
-        }
-        catch (Exception)
-        {
-            if (errorLevel == DataError.ThrowError)
-                throw;
-            return false;
-        }
+        return val.Value<bool>();
     }
 
     private static bool IsSupportedTokenType(JToken token)

--- a/AlRunner/Runtime/MockJsonHelper.cs
+++ b/AlRunner/Runtime/MockJsonHelper.cs
@@ -181,6 +181,37 @@ public static class MockJsonHelper
         }
     }
 
+    /// <summary>
+    /// Replacement for NavJsonToken.ALGetBoolean(DataError, key).
+    /// Returns the boolean value of the named property without going through
+    /// TrappableOperationExecutor or NavCurrentThread.Session.
+    /// AL: JsonObject.GetBoolean('key')  →  MockJsonHelper.GetBoolean(token, error, key)
+    /// </summary>
+    public static bool GetBoolean(NavJsonToken token, DataError errorLevel, string key)
+    {
+        try
+        {
+            var backingToken = GetBackingToken(token);
+            if (backingToken is not JObject obj)
+                throw new Exception("The JSON token is not an object.");
+
+            if (!obj.TryGetValue(key, out var val))
+                throw new Exception($"The JSON object does not contain a property with the name '{key}'.");
+
+            if (val.Type != JTokenType.Boolean)
+                throw new Exception(
+                    $"The value of JSON property '{key}' cannot be converted to a Boolean value.");
+
+            return val.Value<bool>();
+        }
+        catch (Exception)
+        {
+            if (errorLevel == DataError.ThrowError)
+                throw;
+            return false;
+        }
+    }
+
     private static bool IsSupportedTokenType(JToken token)
     {
         return token.Type switch

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -3179,8 +3179,10 @@ JsonObject.GetBigInteger:
 JsonObject.GetBoolean:
   layer: runtime-api
   category: JsonObject
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; rewriter redirects ALGetBoolean to MockJsonHelper.GetBoolean (JObject backing token lookup; throws on missing key or wrong type)
+  tests:
+    - tests/bucket-1/62-jsonobject-getboolean
 
 JsonObject.GetByte:
   layer: runtime-api

--- a/tests/bucket-1/62-jsonobject-getboolean/test/JsonGetBooleanTest.al
+++ b/tests/bucket-1/62-jsonobject-getboolean/test/JsonGetBooleanTest.al
@@ -1,0 +1,74 @@
+codeunit 81000 "Json GetBoolean Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    // ------------------------------------------------------------------
+    // Positive: GetBoolean returns the correct boolean value for a key.
+    // ------------------------------------------------------------------
+
+    [Test]
+    procedure GetBooleanReturnsTrueForTrueValue()
+    var
+        JObj: JsonObject;
+        Val: Boolean;
+    begin
+        // [GIVEN] A JsonObject with a boolean true value
+        JObj.Add('active', true);
+        // [WHEN]  We call GetBoolean for that key
+        Val := JObj.GetBoolean('active');
+        // [THEN]  The result is true
+        Assert.IsTrue(Val, 'GetBoolean should return true for a true value');
+    end;
+
+    [Test]
+    procedure GetBooleanReturnsFalseForFalseValue()
+    var
+        JObj: JsonObject;
+        Val: Boolean;
+    begin
+        // [GIVEN] A JsonObject with a boolean false value
+        JObj.Add('enabled', false);
+        // [WHEN]  We call GetBoolean for that key
+        Val := JObj.GetBoolean('enabled');
+        // [THEN]  The result is false
+        Assert.IsFalse(Val, 'GetBoolean should return false for a false value');
+    end;
+
+    // ------------------------------------------------------------------
+    // Negative: GetBoolean throws when the key is missing.
+    // ------------------------------------------------------------------
+
+    [Test]
+    procedure GetBooleanThrowsForMissingKey()
+    var
+        JObj: JsonObject;
+        Val: Boolean;
+    begin
+        // [GIVEN] An empty JsonObject
+        // [WHEN]  We call GetBoolean for a key that does not exist
+        // [THEN]  An error is raised
+        asserterror Val := JObj.GetBoolean('missing');
+        Assert.ExpectedError('missing');
+    end;
+
+    // ------------------------------------------------------------------
+    // Negative: GetBoolean throws when the value is not a boolean.
+    // ------------------------------------------------------------------
+
+    [Test]
+    procedure GetBooleanThrowsForNonBooleanValue()
+    var
+        JObj: JsonObject;
+        Val: Boolean;
+    begin
+        // [GIVEN] A JsonObject with a text value at the key
+        JObj.Add('score', 42);
+        // [WHEN]  We call GetBoolean for a non-boolean key
+        // [THEN]  An error is raised indicating a type mismatch
+        asserterror Val := JObj.GetBoolean('score');
+        Assert.ExpectedError('score');
+    end;
+}


### PR DESCRIPTION
Closes #534

## What

Implements `JsonObject.GetBoolean(key)` so AL code that reads boolean values directly from a JSON object compiles and runs correctly in al-runner.

## Root cause

BC generates `navJsonToken.ALGetBoolean(DataError, key)` for `JsonObject.GetBoolean(key)`. Like `ALWriteTo`/`ALReadFrom`/`ALSelectToken`, this goes through `TrappableOperationExecutor → NavEnvironment` which crashes in standalone mode.

## Changes

- **`AlRunner/Runtime/MockJsonHelper.cs`**: Added `GetBoolean(NavJsonToken, DataError, string)` — gets the backing `JToken`, casts to `JObject`, looks up the key, verifies the value is a `JTokenType.Boolean`, and returns the bool. Throws a descriptive error for missing keys or wrong types.
- **`AlRunner/RoslynRewriter.cs`**: Extended the NavJson rewrite block to add `ALGetBoolean → MockJsonHelper.GetBoolean`, following the exact same pattern as the existing `ALWriteTo`, `ALReadFrom`, `ALSelectToken` rewrites.
- **`tests/bucket-1/62-jsonobject-getboolean/`**: New test suite with 4 tests:
  - Positive: returns `true` for a true-valued property
  - Positive: returns `false` for a false-valued property
  - Negative: throws on missing key (error contains key name)
  - Negative: throws on non-boolean value (error contains key name)
- **`docs/coverage.yaml`**: Updated `JsonObject.GetBoolean` from `gap` → `covered`.

## Test coverage

| Test | Direction |
|------|-----------|
| `GetBooleanReturnsTrueForTrueValue` | Positive — returns true |
| `GetBooleanReturnsFalseForFalseValue` | Positive — returns false |
| `GetBooleanThrowsForMissingKey` | Negative — error on missing key |
| `GetBooleanThrowsForNonBooleanValue` | Negative — error on wrong type |