### PR TITLE
test: XmlComment.Create / Value / AsXmlNode coverage

### DIFF
--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -8218,14 +8218,18 @@ XmlComment.AddBeforeSelf:
 XmlComment.AsXmlNode:
   layer: runtime-api
   category: XmlComment
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; BC native works standalone. Resulting XmlNode.IsXmlComment is true.
+  tests:
+    - tests/bucket-2/165-xmlcomment
 
 XmlComment.Create:
   layer: runtime-api
   category: XmlComment
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; BC native works standalone. Comment text round-trips via .Value, comment can be attached to an XmlElement via .Add.
+  tests:
+    - tests/bucket-2/165-xmlcomment
 
 XmlComment.GetDocument:
   layer: runtime-api
@@ -8266,8 +8270,10 @@ XmlComment.SelectSingleNode:
 XmlComment.Value:
   layer: runtime-api
   category: XmlComment
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; BC native works standalone. Round-trips comment text from Create.
+  tests:
+    - tests/bucket-2/165-xmlcomment
 
 XmlComment.WriteTo:
   layer: runtime-api

--- a/tests/bucket-2/165-xmlcomment/al-runner.json
+++ b/tests/bucket-2/165-xmlcomment/al-runner.json
@@ -1,0 +1,4 @@
+{
+  "sourcePath": "./src",
+  "testPath": "./test"
+}

--- a/tests/bucket-2/165-xmlcomment/src/XmlCommentSrc.al
+++ b/tests/bucket-2/165-xmlcomment/src/XmlCommentSrc.al
@@ -1,0 +1,33 @@
+/// Helper codeunit exercising XmlComment.
+codeunit 59780 "XCM Src"
+{
+    procedure CreateAndGetValue(text: Text): Text
+    var
+        c: XmlComment;
+    begin
+        c := XmlComment.Create(text);
+        exit(c.Value);
+    end;
+
+    procedure CreateAsXmlNode(text: Text): XmlNode
+    var
+        c: XmlComment;
+    begin
+        c := XmlComment.Create(text);
+        exit(c.AsXmlNode());
+    end;
+
+    procedure AttachToElement(text: Text): Integer
+    var
+        root: XmlElement;
+        c: XmlComment;
+        nodes: XmlNodeList;
+    begin
+        root := XmlElement.Create('root');
+        c := XmlComment.Create(text);
+        root.Add(c);
+
+        nodes := root.GetChildNodes();
+        exit(nodes.Count);
+    end;
+}

--- a/tests/bucket-2/165-xmlcomment/test/XmlCommentTest.al
+++ b/tests/bucket-2/165-xmlcomment/test/XmlCommentTest.al
@@ -1,0 +1,60 @@
+codeunit 59781 "XCM Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "XCM Src";
+
+    [Test]
+    procedure XmlComment_Create_RoundTripsValue()
+    begin
+        // Positive: XmlComment.Create(text).Value returns the same text.
+        Assert.AreEqual('my comment', Src.CreateAndGetValue('my comment'),
+            'XmlComment.Value must round-trip the text');
+    end;
+
+    [Test]
+    procedure XmlComment_Create_EmptyText()
+    begin
+        // Edge: empty comment body is allowed.
+        Assert.AreEqual('', Src.CreateAndGetValue(''),
+            'XmlComment with empty body must round-trip as empty');
+    end;
+
+    [Test]
+    procedure XmlComment_Create_SpecialChars()
+    begin
+        // Special chars (UTF-8 / punctuation) must round-trip.
+        Assert.AreEqual('caf\u00e9 & snowman \u2603', Src.CreateAndGetValue('caf\u00e9 & snowman \u2603'),
+            'XmlComment must preserve special characters');
+    end;
+
+    [Test]
+    procedure XmlComment_AsXmlNode_IsXmlComment()
+    var
+        node: XmlNode;
+    begin
+        // Positive: AsXmlNode returns a valid XmlNode whose underlying type is XmlComment.
+        node := Src.CreateAsXmlNode('n');
+        Assert.IsTrue(node.IsXmlComment, 'AsXmlNode().IsXmlComment must be true for a comment');
+    end;
+
+    [Test]
+    procedure XmlComment_AttachToElement_IncrementsChildCount()
+    begin
+        // Proving: adding a comment to an element brings child-node count to 1.
+        Assert.AreEqual(1, Src.AttachToElement('comment'),
+            'Attaching a comment must increase child count to 1');
+    end;
+
+    [Test]
+    procedure XmlComment_DifferentTexts_DifferentValues_NegativeTrap()
+    begin
+        // Negative trap: guard against a stub that returns a fixed string.
+        Assert.AreNotEqual(
+            Src.CreateAndGetValue('alpha'),
+            Src.CreateAndGetValue('beta'),
+            'Different comment texts must produce different Values');
+    end;
+}


### PR DESCRIPTION
Closes #524

## Summary

BC native XmlComment works standalone — what was missing was a proving suite.

## Changes

- `tests/bucket-2/165-xmlcomment/` — helper + 6 tests (Create round-trip, empty, special chars, AsXmlNode.IsXmlComment, attach-to-element, negative trap)
- `docs/coverage.yaml` — `XmlComment.Create`, `XmlComment.Value`, `XmlComment.AsXmlNode` marked `covered`

Other XmlComment members (AddAfterSelf/Remove/GetParent/etc.) remain `gap` for follow-up PRs.

## Verification

- 6/6 new tests pass
- Full bucket-2: 953 pass (3 pre-existing DateTime/timezone failures)