### PR TITLE
test: unary_expression comprehensive proving tests

### DIFF
--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -434,6 +434,7 @@ unary_expression:
   status: covered
   tests:
     - tests/bucket-1/01-pure-function
+    - tests/bucket-2/166-unary-expression
 
 # ── type ────────────────────────────────────────────────────────
 

--- a/tests/bucket-2/166-unary-expression/al-runner.json
+++ b/tests/bucket-2/166-unary-expression/al-runner.json
@@ -1,0 +1,4 @@
+{
+  "sourcePath": "./src",
+  "testPath": "./test"
+}

--- a/tests/bucket-2/166-unary-expression/src/UnaryExpressionSrc.al
+++ b/tests/bucket-2/166-unary-expression/src/UnaryExpressionSrc.al
@@ -1,0 +1,41 @@
+/// Helper codeunit exercising AL unary operators: `-x`, `+x`, `not b`.
+codeunit 59860 "UNE Src"
+{
+    procedure Negate(n: Integer): Integer
+    begin
+        exit(-n);
+    end;
+
+    procedure NegateDecimal(d: Decimal): Decimal
+    begin
+        exit(-d);
+    end;
+
+    procedure Identity(n: Integer): Integer
+    begin
+        exit(+n);
+    end;
+
+    procedure LogicalNot(b: Boolean): Boolean
+    begin
+        exit(not b);
+    end;
+
+    procedure NotInBranch(b: Boolean): Text
+    begin
+        if not b then
+            exit('was-false')
+        else
+            exit('was-true');
+    end;
+
+    procedure NegateInExpression(a: Integer; b: Integer): Integer
+    begin
+        exit(a + -b);
+    end;
+
+    procedure NegateNegative(n: Integer): Integer
+    begin
+        exit(-(-n));
+    end;
+}

--- a/tests/bucket-2/166-unary-expression/test/UnaryExpressionTest.al
+++ b/tests/bucket-2/166-unary-expression/test/UnaryExpressionTest.al
@@ -1,0 +1,87 @@
+codeunit 59861 "UNE Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "UNE Src";
+
+    [Test]
+    procedure UnaryMinus_Positive_Negates()
+    begin
+        Assert.AreEqual(-5, Src.Negate(5), 'Unary minus on 5 must be -5');
+    end;
+
+    [Test]
+    procedure UnaryMinus_Negative_ReturnsPositive()
+    begin
+        Assert.AreEqual(5, Src.Negate(-5), 'Unary minus on -5 must be 5');
+    end;
+
+    [Test]
+    procedure UnaryMinus_Zero_ReturnsZero()
+    begin
+        Assert.AreEqual(0, Src.Negate(0), 'Unary minus on 0 must be 0');
+    end;
+
+    [Test]
+    procedure UnaryMinus_Decimal()
+    begin
+        Assert.AreEqual(-3.14, Src.NegateDecimal(3.14), 'Unary minus on decimal 3.14 must be -3.14');
+        Assert.AreEqual(2.5, Src.NegateDecimal(-2.5), 'Unary minus on -2.5 must be 2.5');
+    end;
+
+    [Test]
+    procedure UnaryPlus_NoOp()
+    begin
+        // Unary plus must be a no-op (returns the value unchanged).
+        Assert.AreEqual(7, Src.Identity(7), 'Unary plus on 7 must be 7');
+        Assert.AreEqual(-3, Src.Identity(-3), 'Unary plus on -3 must be -3');
+        Assert.AreEqual(0, Src.Identity(0), 'Unary plus on 0 must be 0');
+    end;
+
+    [Test]
+    procedure LogicalNot_TrueBecomesFalse()
+    begin
+        Assert.IsFalse(Src.LogicalNot(true), 'not true must be false');
+    end;
+
+    [Test]
+    procedure LogicalNot_FalseBecomesTrue()
+    begin
+        Assert.IsTrue(Src.LogicalNot(false), 'not false must be true');
+    end;
+
+    [Test]
+    procedure LogicalNot_InIfBranch()
+    begin
+        // Proving: `not` works inside an if-condition branch.
+        Assert.AreEqual('was-false', Src.NotInBranch(false),
+            'if not false → was-false');
+        Assert.AreEqual('was-true', Src.NotInBranch(true),
+            'if not true → was-true');
+    end;
+
+    [Test]
+    procedure UnaryMinus_InCompoundExpression()
+    begin
+        // `a + -b` must compute a - b.
+        Assert.AreEqual(7, Src.NegateInExpression(10, 3), '10 + -3 must be 7');
+        Assert.AreEqual(5, Src.NegateInExpression(2, -3), '2 + -(-3) must be 5');
+    end;
+
+    [Test]
+    procedure UnaryMinus_Double()
+    begin
+        // -(-n) must be n.
+        Assert.AreEqual(9, Src.NegateNegative(9), '-(-9) must be 9');
+        Assert.AreEqual(-4, Src.NegateNegative(-4), '-(-(-4)) must be -4');
+    end;
+
+    [Test]
+    procedure UnaryMinus_NotIdentity_NegativeTrap()
+    begin
+        // Negative: guard against a Negate that's actually identity.
+        Assert.AreNotEqual(5, Src.Negate(5), 'Unary minus must flip sign, not identity');
+    end;
+}


### PR DESCRIPTION
Closes #558

## Summary

`unary_expression` was already `covered` via `tests/bucket-1/01-pure-function` but lacked an exhaustive dedicated suite for unary operators.

## Changes

- `tests/bucket-2/166-unary-expression/` — helper + 11 proving tests (unary minus on int/decimal/zero, unary plus no-op, logical `not` in expression and if-branch, compound expressions, double negation, negative identity trap)
- `docs/coverage.yaml` — appended this suite to `unary_expression` entry

## Verification

- 11/11 new tests pass
- Full bucket-2: 978 pass (3 pre-existing DateTime/timezone failures)