### PR TITLE
test: visible_attribute_condition coverage — conditional Visible on page controls

### DIFF
--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -908,6 +908,14 @@ views_section:
   tests:
     - tests/bucket-1/72-views-section
 
+visible_attribute_condition:
+  layer: syntax
+  category: page
+  status: covered
+  notes: Conditional `Visible = <expression>` on page controls compiles and the referenced page-level variables flow through normally. No UI to render standalone, but compilation path is clean.
+  tests:
+    - tests/bucket-2/167-visible-condition
+
 # ── report ──────────────────────────────────────────────────────
 
 dataset_section:

--- a/tests/bucket-2/167-visible-condition/al-runner.json
+++ b/tests/bucket-2/167-visible-condition/al-runner.json
@@ -1,0 +1,4 @@
+{
+  "sourcePath": "./src",
+  "testPath": "./test"
+}

--- a/tests/bucket-2/167-visible-condition/src/VisibleConditionSrc.al
+++ b/tests/bucket-2/167-visible-condition/src/VisibleConditionSrc.al
@@ -1,0 +1,77 @@
+table 59870 "VCA Item"
+{
+    DataClassification = CustomerContent;
+    fields
+    {
+        field(1; "No."; Code[20]) { }
+        field(2; Name; Text[100]) { }
+        field(3; Price; Decimal) { }
+        field(4; IsActive; Boolean) { }
+    }
+    keys
+    {
+        key(PK; "No.") { Clustered = true; }
+    }
+}
+
+/// Page with controls that use Visible = <expression>. BC AL supports two forms:
+/// 1. A direct reference to a page-level boolean variable (e.g. `Visible = ShowPrice`)
+/// 2. A simple expression — often pre-computed into a boolean via trigger logic
+/// The Visible property value is captured at render time; the runner has no UI
+/// so the Visible expression never affects execution, but the compilation unit
+/// must still compile with these constructs present.
+page 59870 "VCA Item Card"
+{
+    PageType = Card;
+    SourceTable = "VCA Item";
+
+    layout
+    {
+        area(Content)
+        {
+            field(NoField; Rec."No.") { }
+            field(NameField; Rec.Name) { }
+            field(PriceField; Rec.Price)
+            {
+                // Conditional Visible attribute referencing a page-level boolean.
+                Visible = ShowPrice;
+            }
+            field(ActiveField; Rec.IsActive)
+            {
+                // Another conditional Visible — referencing a negated boolean.
+                Visible = not HideActiveFlag;
+            }
+        }
+    }
+
+    var
+        ShowPrice: Boolean;
+        HideActiveFlag: Boolean;
+
+    trigger OnOpenPage()
+    begin
+        ShowPrice := Rec.Price > 0;
+        HideActiveFlag := false;
+    end;
+}
+
+/// Helper codeunit — proves the compilation unit containing a page with
+/// conditional Visible attributes compiles and codeunits remain callable.
+codeunit 59870 "VCA Helper"
+{
+    procedure GetLabel(): Text
+    begin
+        exit('visible-conditional');
+    end;
+
+    procedure ShouldShowPrice(price: Decimal): Boolean
+    begin
+        // Mirror the trigger's logic so tests can exercise it without the page.
+        exit(price > 0);
+    end;
+
+    procedure ShouldShowActive(hideFlag: Boolean): Boolean
+    begin
+        exit(not hideFlag);
+    end;
+}

--- a/tests/bucket-2/167-visible-condition/test/VisibleConditionTest.al
+++ b/tests/bucket-2/167-visible-condition/test/VisibleConditionTest.al
@@ -1,0 +1,72 @@
+codeunit 59871 "VCA Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Helper: Codeunit "VCA Helper";
+
+    [Test]
+    procedure VisibleCondition_CompilesAndHelperRuns()
+    begin
+        // Positive: compilation unit containing a page with conditional
+        // `Visible = <expression>` attributes must compile, and codeunits
+        // defined alongside must remain callable.
+        Assert.AreEqual('visible-conditional', Helper.GetLabel(),
+            'Helper.GetLabel must return visible-conditional');
+    end;
+
+    [Test]
+    procedure VisibleCondition_ShouldShowPrice_True()
+    begin
+        // Proving: the logic the page uses for Visible is reachable from test code.
+        Assert.IsTrue(Helper.ShouldShowPrice(1.0), 'Price 1.0 must show (>0)');
+        Assert.IsTrue(Helper.ShouldShowPrice(0.01), 'Price 0.01 must show (>0)');
+        Assert.IsTrue(Helper.ShouldShowPrice(1000), 'Price 1000 must show');
+    end;
+
+    [Test]
+    procedure VisibleCondition_ShouldShowPrice_False()
+    begin
+        Assert.IsFalse(Helper.ShouldShowPrice(0), 'Price 0 must not show');
+        Assert.IsFalse(Helper.ShouldShowPrice(-1), 'Negative price must not show');
+    end;
+
+    [Test]
+    procedure VisibleCondition_ShouldShowActive()
+    begin
+        // Proving the negated-boolean form works.
+        Assert.IsTrue(Helper.ShouldShowActive(false), 'not false = true');
+        Assert.IsFalse(Helper.ShouldShowActive(true), 'not true = false');
+    end;
+
+    [Test]
+    procedure VisibleCondition_TableInCompilationUnit_Usable()
+    var
+        Item: Record "VCA Item";
+    begin
+        // Positive: the source table is usable — proves the whole compilation
+        // unit (page + table + codeunit) is live end-to-end.
+        Item.Init();
+        Item."No." := 'I1';
+        Item.Name := 'Widget';
+        Item.Price := 9.99;
+        Item.IsActive := true;
+        Item.Insert();
+
+        Item.Reset();
+        Assert.IsTrue(Item.Get('I1'), 'Item I1 must be retrievable');
+        Assert.AreEqual(9.99, Item.Price, 'Price must roundtrip');
+        Assert.AreEqual(true, Item.IsActive, 'IsActive must roundtrip');
+    end;
+
+    [Test]
+    procedure VisibleCondition_ShouldShowPrice_NotAlwaysTrue_NegativeTrap()
+    begin
+        // Negative: guard against ShouldShowPrice always returning true.
+        Assert.AreNotEqual(
+            Helper.ShouldShowPrice(5),
+            Helper.ShouldShowPrice(-5),
+            'ShouldShowPrice must differ for positive vs negative inputs');
+    end;
+}


### PR DESCRIPTION
Closes #568

## Summary

Pages using `Visible = <expression>` already compile and run cleanly. Adds a dedicated proving suite and a new `visible_attribute_condition` entry in coverage.yaml.

## Changes

- `tests/bucket-2/167-visible-condition/` — page with two forms of conditional Visible (direct boolean + negated), helper codeunit mirroring the logic, 6 proving tests
- `docs/coverage.yaml` — new `visible_attribute_condition` entry marked `covered`

## Verification

- 6/6 new tests pass
- Full bucket-2: 984 pass (3 pre-existing DateTime/timezone failures)