### PR TITLE
feat: tooltip_control_property — Tooltip on page controls compiles correctly

### DIFF
--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -888,6 +888,14 @@ systempart_section:
   tests:
     - tests/bucket-1/261-page-part-section
 
+tooltip_control_property:
+  layer: syntax
+  category: page
+  status: covered
+  notes: Tooltip is a compile-time annotation; the BC compiler emits it in generated C# and the runner accepts it unchanged
+  tests:
+    - tests/bucket-1/262-tooltip-control-property
+
 usercontrol_section:
   layer: syntax
   category: page

--- a/tests/bucket-1/262-tooltip-control-property/src/TooltipSrc.al
+++ b/tests/bucket-1/262-tooltip-control-property/src/TooltipSrc.al
@@ -1,0 +1,49 @@
+/// Source objects for tooltip_control_property test suite.
+/// Verifies that Tooltip on page controls compiles without error.
+table 80950 "TTP Test Record"
+{
+    fields
+    {
+        field(1; Id; Integer) { }
+        field(2; Name; Text[50]) { }
+        field(3; Amount; Decimal) { }
+        field(4; Active; Boolean) { }
+    }
+    keys { key(PK; Id) { Clustered = true; } }
+}
+
+page 80950 "TTP Test Page"
+{
+    PageType = Card;
+    SourceTable = "TTP Test Record";
+
+    layout
+    {
+        area(Content)
+        {
+            group(General)
+            {
+                field(IdField; Rec.Id)
+                {
+                    ApplicationArea = All;
+                    Tooltip = 'Specifies the unique identifier for the record';
+                }
+                field(NameField; Rec.Name)
+                {
+                    ApplicationArea = All;
+                    Tooltip = 'Specifies the name of the record';
+                }
+                field(AmountField; Rec.Amount)
+                {
+                    ApplicationArea = All;
+                    Tooltip = 'Specifies the monetary amount associated with this record';
+                }
+                field(ActiveField; Rec.Active)
+                {
+                    ApplicationArea = All;
+                    Tooltip = 'Indicates whether this record is currently active';
+                }
+            }
+        }
+    }
+}

--- a/tests/bucket-1/262-tooltip-control-property/test/TooltipTest.al
+++ b/tests/bucket-1/262-tooltip-control-property/test/TooltipTest.al
@@ -1,0 +1,68 @@
+codeunit 80951 "TTP Tooltip Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    // -----------------------------------------------------------------------
+    // Positive: page with Tooltip properties on controls compiles and the
+    // backing table is fully usable.
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure TooltipControl_PageWithTooltips_DoesNotBlockCompilation()
+    var
+        Rec: Record "TTP Test Record";
+    begin
+        // Positive: inserting and reading back a record works when the page
+        // that uses this table has Tooltip on every field control.
+        Rec.Init();
+        Rec.Id := 1;
+        Rec.Name := 'Widget';
+        Rec.Amount := 9.99;
+        Rec.Active := true;
+        Rec.Insert();
+
+        Rec.Get(1);
+        Assert.AreEqual(1, Rec.Id, 'Id must match inserted value');
+        Assert.AreEqual('Widget', Rec.Name, 'Name must match inserted value');
+        Assert.AreEqual(9.99, Rec.Amount, 'Amount must match inserted value');
+        Assert.IsTrue(Rec.Active, 'Active must be true');
+    end;
+
+    [Test]
+    procedure TooltipControl_MultipleControlTypes_AllFieldsAccessible()
+    var
+        Rec: Record "TTP Test Record";
+    begin
+        // Positive: Integer, Text, Decimal and Boolean fields with Tooltip all
+        // remain accessible after compilation.
+        Rec.Init();
+        Rec.Id := 2;
+        Rec.Name := 'Gadget';
+        Rec.Amount := 0;
+        Rec.Active := false;
+        Rec.Insert();
+
+        Rec.Get(2);
+        Assert.AreEqual('Gadget', Rec.Name, 'Text field accessible when page has Tooltip');
+        Assert.AreEqual(0, Rec.Amount, 'Decimal field accessible when page has Tooltip');
+        Assert.IsFalse(Rec.Active, 'Boolean field accessible when page has Tooltip');
+    end;
+
+    // -----------------------------------------------------------------------
+    // Negative: error paths still work when compiled alongside a page with
+    // Tooltip properties.
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure TooltipControl_GetNonExistent_RaisesError()
+    var
+        Rec: Record "TTP Test Record";
+    begin
+        // Negative: record-not-found error still propagates correctly.
+        asserterror Rec.Get(9999);
+        Assert.ExpectedError('');
+    end;
+}


### PR DESCRIPTION
Closes #567

## Summary
- Add test suite `262-tooltip-control-property` proving that the `Tooltip` property on page controls does not block AL compilation or the Roslyn rewrite stage
- Three tests covering Integer, Text, Decimal, and Boolean field controls with `Tooltip`, plus a negative record-not-found path
- Add `tooltip_control_property` entry to `docs/coverage.yaml` (gap → covered)

## Test plan
- [ ] RED confirmed: tests pass on fresh CI run (no implementation change needed — Tooltip is metadata the BC compiler and runner already handle transparently)
- [ ] GREEN confirmed: all 3 tests pass
- [ ] Full bucket-1 regression passes
- [ ] Coverage manifest validates

🤖 Generated with [Claude Code](https://claude.com/claude-code)