### PR TITLE
feat: ErrorInfo.AddAction — strip-entire-call no-op

### DIFF
--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -59,6 +59,10 @@ public class RoslynRewriter : CSharpSyntaxRewriter
         "ALRegisterTableConnection",  // ALDatabase.ALRegisterTableConnection(target, ct, name, conn) — no external connections standalone; no-op
         "ALSetDefaultTableConnection",  // ALDatabase.ALSetDefaultTableConnection(ct, name) — no external connections standalone; no-op
         "ALUnregisterTableConnection",  // ALDatabase.ALUnregisterTableConnection(ct, name) — no external connections standalone; no-op
+        "ALAddAction",  // <navALErrorInfo | mockNotification>.ALAddAction(caption, codeunitId, method [, desc]) —
+                        // NavALErrorInfo.ALAddAction crashes standalone (null parent in NavApplicationObjectBaseHandle ctor),
+                        // and neither interactive ErrorInfo drill-down actions nor Notification action dispatch happen
+                        // without a UI. Stripping is safe — MockNotification tests that exist don't assert on stored action state.
     };
 
     private static readonly HashSet<string> StripITreeObjectArgMethods = new(StringComparer.Ordinal)

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -2056,8 +2056,10 @@ EnumType.Ordinals:
 ErrorInfo.AddAction:
   layer: runtime-api
   category: ErrorInfo
-  status: gap
-  notes: overloads=2
+  status: covered
+  notes: overloads=2 (3-arg + 4-arg with description); rewriter strips the entire call. ALAddAction on NavALErrorInfo crashes standalone (null parent in NavApplicationObjectBaseHandle ctor); stripping is safe because interactive drill-down actions don't fire without a UI.
+  tests:
+    - tests/bucket-2/169-errorinfo-addaction
 
 ErrorInfo.AddNavigationAction:
   layer: runtime-api

--- a/tests/bucket-2/169-errorinfo-addaction/al-runner.json
+++ b/tests/bucket-2/169-errorinfo-addaction/al-runner.json
@@ -1,0 +1,4 @@
+{
+  "sourcePath": "./src",
+  "testPath": "./test"
+}

--- a/tests/bucket-2/169-errorinfo-addaction/src/ErrorInfoActionSrc.al
+++ b/tests/bucket-2/169-errorinfo-addaction/src/ErrorInfoActionSrc.al
@@ -1,0 +1,38 @@
+/// Helper codeunit exercising ErrorInfo.AddAction() with 3-arg and 4-arg forms.
+/// Avoid ErrorInfo.Create(msg) — it hits a separate DLL-loading gap (loads
+/// Microsoft.Dynamics.Nav.CodeAnalysis 16.4.x which is absent standalone).
+/// Default-initialised ErrorInfo values work fine for AddAction tests.
+codeunit 59890 "EIA Src"
+{
+    procedure AddSingleAction(caption: Text): Boolean
+    var
+        ei: ErrorInfo;
+    begin
+        ei.AddAction(caption, Codeunit::"EIA Src", 'DoFix');
+        exit(true);
+    end;
+
+    procedure AddSingleActionWithDescription(caption: Text; desc: Text): Boolean
+    var
+        ei: ErrorInfo;
+    begin
+        ei.AddAction(caption, Codeunit::"EIA Src", 'DoFix', desc);
+        exit(true);
+    end;
+
+    procedure AddMultipleActions(): Boolean
+    var
+        ei: ErrorInfo;
+    begin
+        ei.AddAction('Action 1', Codeunit::"EIA Src", 'DoFix');
+        ei.AddAction('Action 2', Codeunit::"EIA Src", 'DoFix');
+        ei.AddAction('Action 3', Codeunit::"EIA Src", 'DoFix');
+        exit(true);
+    end;
+
+    /// Referenced by AddAction as the target method. Runner doesn't fire
+    /// interactive actions; this is here for AL compilability.
+    procedure DoFix(ei: ErrorInfo)
+    begin
+    end;
+}

--- a/tests/bucket-2/169-errorinfo-addaction/test/ErrorInfoActionTest.al
+++ b/tests/bucket-2/169-errorinfo-addaction/test/ErrorInfoActionTest.al
@@ -1,0 +1,59 @@
+codeunit 59891 "EIA Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "EIA Src";
+
+    [Test]
+    procedure AddAction_3Arg_NoOp()
+    begin
+        // Positive: 3-arg AddAction(caption, codeunitId, method) completes.
+        Assert.IsTrue(Src.AddSingleAction('Fix it'),
+            'AddAction 3-arg must complete without throwing');
+    end;
+
+    [Test]
+    procedure AddAction_4Arg_WithDescription()
+    begin
+        // Positive: 4-arg AddAction(caption, codeunitId, method, description) completes.
+        Assert.IsTrue(Src.AddSingleActionWithDescription('Fix it', 'Resolves the validation error'),
+            'AddAction 4-arg must complete without throwing');
+    end;
+
+    [Test]
+    procedure AddAction_EmptyCaption()
+    begin
+        // Edge: empty caption must not crash.
+        Assert.IsTrue(Src.AddSingleAction(''),
+            'AddAction with empty caption must not throw');
+    end;
+
+    [Test]
+    procedure AddAction_EmptyDescription()
+    begin
+        // Edge: 4-arg with empty description must not crash.
+        Assert.IsTrue(Src.AddSingleActionWithDescription('Fix', ''),
+            'AddAction 4-arg with empty description must not throw');
+    end;
+
+    [Test]
+    procedure AddAction_Multiple()
+    begin
+        // Positive: repeatedly adding actions must not crash the mock.
+        Assert.IsTrue(Src.AddMultipleActions(),
+            'Multiple AddAction calls must complete');
+    end;
+
+    [Test]
+    procedure AddAction_LongStrings_NegativeTrap()
+    begin
+        // Negative trap: guard against a crash on large input.
+        Assert.IsTrue(
+            Src.AddSingleActionWithDescription(
+                'A very long action caption that might stress a naive mock implementation',
+                'A very long action description explaining every detail of how the fix works 0123456789_abcdefghij'),
+            'AddAction with long strings must not throw');
+    end;
+}


### PR DESCRIPTION
Closes #580

## Summary

`ei.ALAddAction(caption, codeunitId, method[, desc])` on NavALErrorInfo crashed standalone (null parent in `NavApplicationObjectBaseHandle` ctor).

Added `ALAddAction` to `StripEntireCallMethods`. Interactive ErrorInfo drill-down actions and Notification action dispatch both need a UI the runner doesn't provide. Verified the existing Notification test (`NotificationAddActionPreservesMessage`) still passes — it asserts on Message preservation, not stored action state.

## Changes

- `AlRunner/RoslynRewriter.cs` — added to `StripEntireCallMethods`
- `tests/bucket-2/169-errorinfo-addaction/` — helper + 6 proving tests (3-arg, 4-arg, empty caption, empty description, multiple calls, long strings)
- `docs/coverage.yaml` — `ErrorInfo.AddAction` marked `covered`

## Verification

- 6/6 new tests pass
- Notification.AddAction test (bucket-2/122-unstubbed-types) still passes
- Full bucket-2: 1000 pass (3 pre-existing DateTime/timezone failures)