### PR TITLE
feat: Database.TenantId — return zero GUID stub

### DIFF
--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -1659,6 +1659,19 @@ public void ClearApplicationMemberVariables() { }
                 .WithTriviaFrom(node);
         }
 
+        // NavDatabase.TenantId() — BC emits this form for Database.TenantId() in some compiler
+        // versions. Returns the zero GUID so tests can assert a deterministic non-empty value.
+        if (node.Expression is MemberAccessExpressionSyntax navDbTenantMa &&
+            navDbTenantMa.Expression is IdentifierNameSyntax navDbTenantIdent &&
+            navDbTenantIdent.Identifier.Text == "NavDatabase" &&
+            navDbTenantMa.Name.Identifier.Text == "TenantId")
+        {
+            return SyntaxFactory.LiteralExpression(
+                SyntaxKind.StringLiteralExpression,
+                SyntaxFactory.Literal("00000000-0000-0000-0000-000000000000"))
+                .WithTriviaFrom(node);
+        }
+
         // ALDatabase.ALTenantID() / ALDatabase.ALSerialNumber() / ALDatabase.ALServiceInstanceID()
         // BC emits these as method calls on ALDatabase; the real implementations require
         // NavSession and crash with NullReferenceException standalone. Catch the invocation
@@ -1672,7 +1685,14 @@ public void ClearApplicationMemberVariables() { }
             dbIdIdent.Identifier.Text == "ALDatabase")
         {
             var idName = dbIdMa.Name.Identifier.Text;
-            if (idName == "ALTenantID" || idName == "ALSerialNumber")
+            if (idName == "ALTenantID")
+            {
+                return SyntaxFactory.LiteralExpression(
+                    SyntaxKind.StringLiteralExpression,
+                    SyntaxFactory.Literal("00000000-0000-0000-0000-000000000000"))
+                    .WithTriviaFrom(node);
+            }
+            if (idName == "ALSerialNumber")
             {
                 return SyntaxFactory.LiteralExpression(
                     SyntaxKind.StringLiteralExpression,
@@ -3346,8 +3366,8 @@ public void ClearApplicationMemberVariables() { }
         // These static property accesses crash because ALDatabase requires a live BC session.
         // ALCompanyName routes to MockSession.GetCompanyName() (configurable via --company-name CLI flag).
         // ALUserID redirects to AlScope.UserId (configurable via --user-id CLI flag).
-        // ALTenantID and ALSerialNumber return a fixed non-empty string ("STANDALONE") so
-        // telemetry / licensing branches that test non-empty behave consistently.
+        // ALTenantID returns the zero GUID ("00000000-0000-0000-0000-000000000000") — deterministic
+        // and detectable by tests. ALSerialNumber returns "STANDALONE" (opaque non-empty value).
         // (Note: BC sometimes emits these as method calls instead — see the invocation
         // handler at the top of VisitInvocationExpression which uses the same placeholder.)
         if (visited.Expression is IdentifierNameSyntax dbId &&
@@ -3369,6 +3389,13 @@ public void ClearApplicationMemberVariables() { }
                     SyntaxKind.SimpleMemberAccessExpression,
                     SyntaxFactory.IdentifierName("AlScope"),
                     SyntaxFactory.IdentifierName("UserId"))
+                    .WithTriviaFrom(visited);
+            }
+            if (visited.Name.Identifier.Text == "ALTenantID")
+            {
+                return SyntaxFactory.LiteralExpression(
+                    SyntaxKind.StringLiteralExpression,
+                    SyntaxFactory.Literal("00000000-0000-0000-0000-000000000000"))
                     .WithTriviaFrom(visited);
             }
             return SyntaxFactory.LiteralExpression(

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -1727,9 +1727,10 @@ Database.TenantId:
   layer: runtime-api
   category: Database
   status: covered
-  notes: overloads=1; rewriter stubs ALTenantID (property and method) to the fixed string "STANDALONE".
+  notes: overloads=1; rewriter stubs ALTenantID (property and method) and NavDatabase.TenantId() to the zero GUID "00000000-0000-0000-0000-000000000000".
   tests:
     - tests/bucket-2/148-db-identity
+    - tests/bucket-2/169-database-tenantid
 
 Database.UnregisterTableConnection:
   layer: runtime-api

--- a/tests/bucket-2/169-database-tenantid/src/DatabaseTenantIdSrc.al
+++ b/tests/bucket-2/169-database-tenantid/src/DatabaseTenantIdSrc.al
@@ -1,0 +1,16 @@
+/// Source codeunit that calls Database.TenantId() — used to prove the
+/// runner handles the call without error and returns a deterministic stub.
+
+codeunit 61830 "DTI Src"
+{
+    procedure GetTenantId(): Text
+    begin
+        exit(Database.TenantId());
+    end;
+
+    /// Proving helper — returns a+b+1 to verify the codeunit is live.
+    procedure AddWithBonus(a: Integer; b: Integer): Integer
+    begin
+        exit(a + b + 1);
+    end;
+}

--- a/tests/bucket-2/169-database-tenantid/test/DatabaseTenantIdTest.al
+++ b/tests/bucket-2/169-database-tenantid/test/DatabaseTenantIdTest.al
@@ -1,0 +1,53 @@
+codeunit 61831 "DTI Database TenantId Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    [Test]
+    procedure TenantId_ReturnsNonEmptyStub()
+    var
+        Src: Codeunit "DTI Src";
+    begin
+        // Positive: Database.TenantId() must return a non-empty stub string.
+        Assert.AreNotEqual('', Src.GetTenantId(), 'TenantId must return a non-empty stub');
+    end;
+
+    [Test]
+    procedure TenantId_IsZeroGuid()
+    var
+        Src: Codeunit "DTI Src";
+    begin
+        // Positive: stub must be the zero GUID — deterministic and detectable.
+        Assert.AreEqual('00000000-0000-0000-0000-000000000000', Src.GetTenantId(), 'TenantId stub must be zero GUID');
+    end;
+
+    [Test]
+    procedure TenantId_NotStandaloneString()
+    var
+        Src: Codeunit "DTI Src";
+    begin
+        // Negative: must NOT return generic "STANDALONE" (guards against wrong stub).
+        Assert.AreNotEqual('STANDALONE', Src.GetTenantId(), 'TenantId stub must not be STANDALONE');
+    end;
+
+    [Test]
+    procedure AddWithBonus_ProvingCompilationUnitLive()
+    var
+        Src: Codeunit "DTI Src";
+    begin
+        // Proving: the codeunit is live — real computation returns a+b+1.
+        Assert.AreEqual(8, Src.AddWithBonus(3, 4), 'AddWithBonus(3,4) must return 8');
+        Assert.AreEqual(1, Src.AddWithBonus(0, 0), 'AddWithBonus(0,0) must return 1');
+    end;
+
+    [Test]
+    procedure AddWithBonus_NotPlainSum()
+    var
+        Src: Codeunit "DTI Src";
+    begin
+        // Negative: AddWithBonus must NOT return a plain sum.
+        Assert.AreNotEqual(7, Src.AddWithBonus(3, 4), 'AddWithBonus must not just return a+b');
+    end;
+}


### PR DESCRIPTION
Closes #576

Returns the zero GUID `00000000-0000-0000-0000-000000000000` from `Database.TenantId()` instead of the generic `"STANDALONE"` string.

## Changes

- **RoslynRewriter**: new rule intercepts `NavDatabase.TenantId()` (the form BC emits in some compiler versions) → zero GUID literal
- **RoslynRewriter**: `ALDatabase.ALTenantID` property and method forms now return zero GUID (split from `ALSerialNumber` which keeps `"STANDALONE"`)
- **Suite 169-database-tenantid**: five tests — non-empty, is zero GUID, not STANDALONE, proving codeunit live, not plain sum
- **docs/coverage.yaml**: notes updated, new suite reference added

## Test plan
- [ ] `TenantId_ReturnsNonEmptyStub` — PASS
- [ ] `TenantId_IsZeroGuid` — PASS (key proving test)
- [ ] `TenantId_NotStandaloneString` — PASS (guards against regression)
- [ ] `AddWithBonus_ProvingCompilationUnitLive` — PASS
- [ ] `AddWithBonus_NotPlainSum` — PASS
- [ ] Existing bucket-2 tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)