### PR TITLE
test: ErrorInfo.DetailedMessage coverage

### DIFF
--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -2108,8 +2108,10 @@ ErrorInfo.DataClassification:
 ErrorInfo.DetailedMessage:
   layer: runtime-api
   category: ErrorInfo
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; BC native property works standalone on default-initialised ErrorInfo values. AL emits as property get/set.
+  tests:
+    - tests/bucket-2/170-errorinfo-detailedmsg
 
 ErrorInfo.ErrorType:
   layer: runtime-api

--- a/tests/bucket-2/170-errorinfo-detailedmsg/al-runner.json
+++ b/tests/bucket-2/170-errorinfo-detailedmsg/al-runner.json
@@ -1,0 +1,4 @@
+{
+  "sourcePath": "./src",
+  "testPath": "./test"
+}

--- a/tests/bucket-2/170-errorinfo-detailedmsg/src/ErrorInfoDetailedMsgSrc.al
+++ b/tests/bucket-2/170-errorinfo-detailedmsg/src/ErrorInfoDetailedMsgSrc.al
@@ -1,0 +1,28 @@
+/// Helper codeunit exercising ErrorInfo.DetailedMessage() getter and setter.
+codeunit 59910 "EID Src"
+{
+    procedure SetAndGet(detail: Text): Text
+    var
+        ei: ErrorInfo;
+    begin
+        ei.DetailedMessage := detail;
+        exit(ei.DetailedMessage);
+    end;
+
+    procedure FreshDetailedMessage(): Text
+    var
+        ei: ErrorInfo;
+    begin
+        // A default-initialised ErrorInfo should have an empty DetailedMessage.
+        exit(ei.DetailedMessage);
+    end;
+
+    procedure SetDifferentValues(a: Text; b: Text): Text
+    var
+        ei: ErrorInfo;
+    begin
+        ei.DetailedMessage := a;
+        ei.DetailedMessage := b;
+        exit(ei.DetailedMessage);
+    end;
+}

--- a/tests/bucket-2/170-errorinfo-detailedmsg/test/ErrorInfoDetailedMsgTest.al
+++ b/tests/bucket-2/170-errorinfo-detailedmsg/test/ErrorInfoDetailedMsgTest.al
@@ -1,0 +1,64 @@
+codeunit 59911 "EID Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "EID Src";
+
+    [Test]
+    procedure DetailedMessage_SetAndGet_RoundsTrip()
+    begin
+        // Positive: DetailedMessage getter returns what the setter set.
+        Assert.AreEqual(
+            'See the audit log for details.',
+            Src.SetAndGet('See the audit log for details.'),
+            'DetailedMessage must round-trip the set value');
+    end;
+
+    [Test]
+    procedure DetailedMessage_EmptyString()
+    begin
+        // Edge: empty string round-trips cleanly.
+        Assert.AreEqual('', Src.SetAndGet(''),
+            'DetailedMessage must round-trip an empty string');
+    end;
+
+    [Test]
+    procedure DetailedMessage_Fresh_IsEmpty()
+    begin
+        // Positive: a default-initialised ErrorInfo has empty DetailedMessage.
+        Assert.AreEqual('', Src.FreshDetailedMessage(),
+            'Fresh ErrorInfo must have empty DetailedMessage');
+    end;
+
+    [Test]
+    procedure DetailedMessage_LastWriteWins()
+    begin
+        // Proving: repeated setter calls overwrite — the last value wins.
+        Assert.AreEqual(
+            'second',
+            Src.SetDifferentValues('first', 'second'),
+            'DetailedMessage must reflect the last setter call');
+    end;
+
+    [Test]
+    procedure DetailedMessage_Unicode()
+    begin
+        // Special characters round-trip through the storage.
+        Assert.AreEqual(
+            'caf\u00e9 & snowman \u2603',
+            Src.SetAndGet('caf\u00e9 & snowman \u2603'),
+            'DetailedMessage must preserve unicode characters');
+    end;
+
+    [Test]
+    procedure DetailedMessage_DifferentInputs_DifferentOutputs_NegativeTrap()
+    begin
+        // Negative: guard against a stub that returns a fixed value.
+        Assert.AreNotEqual(
+            Src.SetAndGet('alpha'),
+            Src.SetAndGet('beta'),
+            'Different inputs must produce different DetailedMessage values');
+    end;
+}


### PR DESCRIPTION
Closes #588

## Summary

BC native `ErrorInfo.DetailedMessage` property works standalone (thin backing-field access). Adds a dedicated proving suite.

## Changes

- `tests/bucket-2/170-errorinfo-detailedmsg/` — helper + 6 proving tests (set-get round-trip, empty string, fresh = empty, last-write-wins, unicode, different-inputs-different-outputs trap)
- `docs/coverage.yaml` — `ErrorInfo.DetailedMessage` marked `covered`

## Verification

- 6/6 new tests pass
- Full bucket-2: 1006 pass (3 pre-existing DateTime/timezone failures)