### PR TITLE
fix: Database.SID() stub (#573)

### DIFF
--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -1686,6 +1686,38 @@ public void ClearApplicationMemberVariables() { }
                     SyntaxFactory.Literal(1))
                     .WithTriviaFrom(node);
             }
+            // ALDatabase.ALSID() / ALDatabase.ALSid() / ALDatabase.ALGetSID()
+            // Database.SID() requires NavSession (crashes with NullReferenceException standalone).
+            // Return fixed non-real SID string. Intercepted here (before base) to avoid
+            // double-call form and to handle session argument mismatch.
+            // Both ALSID and ALSid checked for BC version compatibility.
+            if (idName == "ALSID" || idName == "ALSid" || idName == "ALGetSID"
+                || idName == "ALGetSid")
+            {
+                return SyntaxFactory.LiteralExpression(
+                    SyntaxKind.StringLiteralExpression,
+                    SyntaxFactory.Literal("S-1-0-0"))
+                    .WithTriviaFrom(node);
+            }
+            // Diagnostic: log any unhandled ALDatabase method that is NOT already
+            // intercepted above — this appears in CI stderr to identify unknown method names.
+            if (!System.Array.Exists(new[] {
+                    "ALSessionID", "ALSessionId", "ALTenantID", "ALSerialNumber",
+                    "ALServiceInstanceID", "ALServiceInstanceId",
+                    "ALUserSecurityId", "ALIsInWriteTransaction",
+                    "ALGetDefaultTableConnection", "ALLastUsedRowVersion",
+                    "ALMinimumActiveRowVersion", "ALHasTableConnection",
+                    "ALCommit", "ALSelectLatestVersion", "ALAlterKey",
+                    "ALCheckLicenseFile", "ALChangeUserPassword", "ALCopyCompany",
+                    "ALImportData", "ALExportData", "ALDataFileInformation",
+                    "ALRegisterTableConnection", "ALSetDefaultTableConnection",
+                    "ALUnregisterTableConnection", "ALRunCodeunit",
+                    "ALGetLastErrorText", "ALGetLastErrorCallStack",
+                    "ALClearLastError" },
+                    n => n == idName))
+            {
+                Console.Error.WriteLine($"[RoslynRewriter] UNHANDLED ALDatabase.{idName} — add intercept");
+            }
         }
 
         // `NavOption.Create(existing.NavOptionMetadata, V)` — reassignment
@@ -2768,18 +2800,6 @@ public void ClearApplicationMemberVariables() { }
                         SyntaxKind.SimpleMemberAccessExpression,
                         SyntaxFactory.IdentifierName("AlCompat"),
                         SyntaxFactory.IdentifierName("UserSecurityId")));
-            }
-
-            // ALDatabase.ALSID() -> AlCompat.DatabaseSID()
-            // Database.SID() requires NavSession (crashes with NullReferenceException standalone).
-            // AlCompat.DatabaseSID returns a fixed non-real SID string stable across calls.
-            if (exprText == "ALDatabase" && methodName == "ALSID")
-            {
-                return visited.WithExpression(
-                    SyntaxFactory.MemberAccessExpression(
-                        SyntaxKind.SimpleMemberAccessExpression,
-                        SyntaxFactory.IdentifierName("AlCompat"),
-                        SyntaxFactory.IdentifierName("DatabaseSID")));
             }
 
             // ALDatabase.ALLastUsedRowVersion() -> 0L

--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -2770,6 +2770,18 @@ public void ClearApplicationMemberVariables() { }
                         SyntaxFactory.IdentifierName("UserSecurityId")));
             }
 
+            // ALDatabase.ALSID() -> AlCompat.DatabaseSID()
+            // Database.SID() requires NavSession (crashes with NullReferenceException standalone).
+            // AlCompat.DatabaseSID returns a fixed non-real SID string stable across calls.
+            if (exprText == "ALDatabase" && methodName == "ALSID")
+            {
+                return visited.WithExpression(
+                    SyntaxFactory.MemberAccessExpression(
+                        SyntaxKind.SimpleMemberAccessExpression,
+                        SyntaxFactory.IdentifierName("AlCompat"),
+                        SyntaxFactory.IdentifierName("DatabaseSID")));
+            }
+
             // ALDatabase.ALLastUsedRowVersion() -> 0L
             // ALDatabase.ALMinimumActiveRowVersion() -> 0L
             // BC lowers Database.LastUsedRowVersion / MinimumActiveRowVersion to method

--- a/AlRunner/Runtime/AlScope.cs
+++ b/AlRunner/Runtime/AlScope.cs
@@ -1500,6 +1500,13 @@ public static class AlCompat
     public static Guid UserSecurityId() => _userSecurityId;
 
     /// <summary>
+    /// Replacement for ALDatabase.ALSID() which requires NavSession.
+    /// Returns a fixed non-real SID string (not a valid Windows domain SID).
+    /// Stable across calls within a process so tests that compare two reads observe equality.
+    /// </summary>
+    public static string DatabaseSID() => "S-1-0-0";
+
+    /// <summary>
     /// Replacement for ALDatabase.ALCurrentTransactionType() which requires NavSession.
     /// The runner has no real transaction tracking; returns TransactionType.Update,
     /// the most common real-world value and a predictable stable stub.

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -1720,7 +1720,7 @@ Database.SetUserPassword:
 Database.SID:
   layer: runtime-api
   category: Database
-  status: gap
+  status: covered
   notes: overloads=1
 
 Database.TenantId:

--- a/tests/bucket-1/83-database-sid/src/DatabaseSidSrc.al
+++ b/tests/bucket-1/83-database-sid/src/DatabaseSidSrc.al
@@ -1,0 +1,21 @@
+/// Helper codeunit exercising Database.SID().
+codeunit 81400 "DS Src"
+{
+    /// Returns the result of Database.SID().
+    procedure GetSid(): Text
+    begin
+        exit(Database.SID());
+    end;
+
+    /// Returns true if SID is non-empty.
+    procedure SidIsNonEmpty(): Boolean
+    begin
+        exit(Database.SID() <> '');
+    end;
+
+    /// Returns the length of the SID string.
+    procedure SidLength(): Integer
+    begin
+        exit(StrLen(Database.SID()));
+    end;
+}

--- a/tests/bucket-1/83-database-sid/test/DatabaseSidTest.al
+++ b/tests/bucket-1/83-database-sid/test/DatabaseSidTest.al
@@ -1,0 +1,72 @@
+codeunit 81401 "DS Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "DS Src";
+
+    // -----------------------------------------------------------------------
+    // Positive: SID is non-empty
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure SID_ReturnsNonEmpty()
+    begin
+        // Positive: Database.SID() must return a non-empty stub value
+        Assert.AreNotEqual('', Src.GetSid(),
+            'Database.SID() must return a non-empty string');
+    end;
+
+    [Test]
+    procedure SID_NonEmpty_ViaHelper()
+    begin
+        // Positive: IsNonEmpty check via helper
+        Assert.IsTrue(Src.SidIsNonEmpty(),
+            'Database.SID() must be non-empty');
+    end;
+
+    [Test]
+    procedure SID_HasPositiveLength()
+    begin
+        // Positive: SID length > 0
+        Assert.IsTrue(Src.SidLength() > 0,
+            'Database.SID() must have positive length');
+    end;
+
+    // -----------------------------------------------------------------------
+    // Negative: SID is not a real Windows SID
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure SID_NotRealWindowsSid()
+    begin
+        // Negative: stub should not return a real domain SID format
+        Assert.AreNotEqual('S-1-5-21', Src.GetSid(),
+            'Database.SID() must not return a real Windows SID prefix');
+    end;
+
+    [Test]
+    procedure SID_ConsistentAcrossCalls()
+    var
+        Sid1: Text;
+        Sid2: Text;
+    begin
+        // Positive: repeated calls return the same stub value
+        Sid1 := Database.SID();
+        Sid2 := Database.SID();
+        Assert.AreEqual(Sid1, Sid2,
+            'Database.SID() must return the same value on repeated calls');
+    end;
+
+    [Test]
+    procedure SID_InlineCall()
+    var
+        Sid: Text;
+    begin
+        // Positive: inline call compiles and returns non-empty
+        Sid := Database.SID();
+        Assert.AreNotEqual('', Sid,
+            'Inline Database.SID() call must return non-empty');
+    end;
+}


### PR DESCRIPTION
Closes #573

## Summary

Add a stub for `Database.SID()` that returns a deterministic string in standalone mode.
