### PR TITLE
test: attribute_item — DataClassification and ObsoleteState on table fields

### DIFF
--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -1274,6 +1274,7 @@ attribute_item:
     - tests/bucket-2/100-bind-subscription
     - tests/bucket-2/41-try-function
     - tests/bucket-2/66-event-subscribers
+    - tests/bucket-1/83-attribute-item
 
 visible_attribute_condition:
   layer: syntax

--- a/tests/bucket-1/83-attribute-item/src/AttributeItemSrc.al
+++ b/tests/bucket-1/83-attribute-item/src/AttributeItemSrc.al
@@ -1,0 +1,78 @@
+/// Table with DataClassification on the table and each field.
+table 82000 "AI Test Record"
+{
+    DataClassification = CustomerContent;
+
+    fields
+    {
+        field(1; Id; Integer)
+        {
+            DataClassification = SystemMetadata;
+        }
+        field(2; Name; Text[100])
+        {
+            DataClassification = EndUserIdentifiableInformation;
+        }
+        field(3; Notes; Text[250])
+        {
+            DataClassification = CustomerContent;
+            ObsoleteState = Pending;
+            ObsoleteReason = 'Use Description instead';
+        }
+        field(4; Amount; Decimal)
+        {
+            DataClassification = OrganizationIdentifiableInformation;
+        }
+        field(5; Active; Boolean)
+        {
+            DataClassification = ToBeClassified;
+        }
+    }
+    keys
+    {
+        key(PK; Id) { Clustered = true; }
+    }
+}
+
+/// Table extension that adds a field with DataClassification.
+tableextension 82000 "AI Test Record Ext" extends "AI Test Record"
+{
+    fields
+    {
+        field(10; Code; Code[20])
+        {
+            DataClassification = ToBeClassified;
+        }
+    }
+}
+
+/// Codeunit that exercises the table with attribute-annotated fields.
+codeunit 82000 "AI Attribute Item Lib"
+{
+    procedure InsertRecord(Id: Integer; Name: Text[100]): Boolean
+    var
+        Rec: Record "AI Test Record";
+    begin
+        Rec.Init();
+        Rec.Id := Id;
+        Rec.Name := Name;
+        Rec.Amount := 100;
+        Rec.Active := true;
+        exit(Rec.Insert());
+    end;
+
+    procedure GetName(Id: Integer): Text[100]
+    var
+        Rec: Record "AI Test Record";
+    begin
+        Rec.Get(Id);
+        exit(Rec.Name);
+    end;
+
+    procedure CountRecords(): Integer
+    var
+        Rec: Record "AI Test Record";
+    begin
+        exit(Rec.Count());
+    end;
+}

--- a/tests/bucket-1/83-attribute-item/test/AttributeItemTest.al
+++ b/tests/bucket-1/83-attribute-item/test/AttributeItemTest.al
@@ -1,0 +1,92 @@
+codeunit 82001 "AI Attribute Item Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Lib: Codeunit "AI Attribute Item Lib";
+
+    [Test]
+    procedure TableWithDataClassificationCompiles()
+    var
+        Rec: Record "AI Test Record";
+    begin
+        // [GIVEN] A table with DataClassification on the table and fields
+        // [WHEN] The table is initialized and inserted
+        Rec.Init();
+        Rec.Id := 1;
+        Rec.Name := 'TestName';
+        Rec.Insert();
+        // [THEN] Record count is 1 — DataClassification did not block compilation/execution
+        Assert.AreEqual(1, Rec.Count(), 'Table with DataClassification must compile and insert');
+    end;
+
+    [Test]
+    procedure FieldsWithVariousDataClassificationsWork()
+    var
+        Rec: Record "AI Test Record";
+    begin
+        // [GIVEN] A table with fields having different DataClassification values
+        Rec.Init();
+        Rec.Id := 2;
+        Rec.Name := 'Alice';
+        Rec.Amount := 42.5;
+        Rec.Active := true;
+        Rec.Insert();
+        // [WHEN] The record is retrieved
+        Rec.Get(2);
+        // [THEN] All field values are correct — DataClassification is metadata only
+        Assert.AreEqual('Alice', Rec.Name, 'Name field with EUII classification must round-trip');
+        Assert.AreEqual(42.5, Rec.Amount, 'Amount field with OII classification must round-trip');
+        Assert.IsTrue(Rec.Active, 'Active field with ToBeClassified must round-trip');
+    end;
+
+    [Test]
+    procedure FieldWithObsoleteStatePendingCompiles()
+    var
+        Rec: Record "AI Test Record";
+    begin
+        // [GIVEN] A table field with ObsoleteState = Pending and ObsoleteReason
+        // [WHEN] The record is inserted with Notes set
+        Rec.Init();
+        Rec.Id := 3;
+        Rec.Name := 'ObsoleteTest';
+        Rec.Notes := 'some notes';
+        Rec.Insert();
+        // [THEN] The obsolete field still works — ObsoleteState is metadata only
+        Rec.Get(3);
+        Assert.AreEqual('some notes', Rec.Notes, 'Obsolete-pending field must still be readable');
+    end;
+
+    [Test]
+    procedure TableExtensionWithDataClassificationCompiles()
+    var
+        Rec: Record "AI Test Record";
+    begin
+        // [GIVEN] A tableextension that adds a field with DataClassification = ToBeClassified
+        // [WHEN] The extended field is set and inserted
+        Rec.Init();
+        Rec.Id := 4;
+        Rec.Name := 'ExtTest';
+        Rec.Code := 'ABC123';
+        Rec.Insert();
+        // [THEN] The extension field persists correctly
+        Rec.Get(4);
+        Assert.AreEqual('ABC123', Rec.Code, 'Table extension field with DataClassification must round-trip');
+    end;
+
+    [Test]
+    procedure CannnotInsertDuplicatePK()
+    var
+        Rec: Record "AI Test Record";
+    begin
+        // [GIVEN] A record already exists with Id = 5
+        Rec.Init();
+        Rec.Id := 5;
+        Rec.Insert();
+        // [WHEN] A second insert with the same PK is attempted
+        // [THEN] An error is raised
+        asserterror Rec.Insert();
+        Assert.ExpectedError('already exists');
+    end;
+}


### PR DESCRIPTION
Closes #566

Adds suite `83-attribute-item` to verify that tables and tableextensions with AL item attribute properties (`DataClassification`, `ObsoleteState`, `ObsoleteReason`) compile and execute correctly in the runner.

## What this covers

- Table-level `DataClassification = CustomerContent`
- Field-level `DataClassification` with all standard values: `SystemMetadata`, `EndUserIdentifiableInformation`, `CustomerContent`, `OrganizationIdentifiableInformation`, `ToBeClassified`
- Field with `ObsoleteState = Pending` + `ObsoleteReason` — still readable/writable at runtime
- `tableextension` adding a field with `DataClassification = ToBeClassified`

## Tests

Five proving tests:
1. `TableWithDataClassificationCompiles` — table inserts successfully with DataClassification on all levels
2. `FieldsWithVariousDataClassificationsWork` — fields with different DataClassification values all round-trip correctly (asserts specific values)
3. `FieldWithObsoleteStatePendingCompiles` — obsolete-pending field still stores and retrieves data
4. `TableExtensionWithDataClassificationCompiles` — extension field with DataClassification round-trips
5. `CannnotInsertDuplicatePK` — negative case: duplicate PK raises the expected error

## docs/coverage.yaml

Added `tests/bucket-1/83-attribute-item` to the existing `attribute_item` entry.