### PR TITLE
test: ErrorInfo.TableId coverage — get/set round-trip

### DIFF
--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -2152,8 +2152,10 @@ ErrorInfo.SystemId:
 ErrorInfo.TableId:
   layer: runtime-api
   category: ErrorInfo
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; BC native property works standalone. Integer get/set with 0 as fresh default.
+  tests:
+    - tests/bucket-2/171-errorinfo-tableid
 
 ErrorInfo.Title:
   layer: runtime-api

--- a/tests/bucket-2/171-errorinfo-tableid/al-runner.json
+++ b/tests/bucket-2/171-errorinfo-tableid/al-runner.json
@@ -1,0 +1,4 @@
+{
+  "sourcePath": "./src",
+  "testPath": "./test"
+}

--- a/tests/bucket-2/171-errorinfo-tableid/src/ErrorInfoTableIdSrc.al
+++ b/tests/bucket-2/171-errorinfo-tableid/src/ErrorInfoTableIdSrc.al
@@ -1,0 +1,27 @@
+/// Helper codeunit exercising ErrorInfo.TableId getter/setter.
+codeunit 59920 "EIT Src"
+{
+    procedure SetAndGet(tableId: Integer): Integer
+    var
+        ei: ErrorInfo;
+    begin
+        ei.TableId := tableId;
+        exit(ei.TableId);
+    end;
+
+    procedure FreshTableId(): Integer
+    var
+        ei: ErrorInfo;
+    begin
+        exit(ei.TableId);
+    end;
+
+    procedure LastWriteWins(a: Integer; b: Integer): Integer
+    var
+        ei: ErrorInfo;
+    begin
+        ei.TableId := a;
+        ei.TableId := b;
+        exit(ei.TableId);
+    end;
+}

--- a/tests/bucket-2/171-errorinfo-tableid/test/ErrorInfoTableIdTest.al
+++ b/tests/bucket-2/171-errorinfo-tableid/test/ErrorInfoTableIdTest.al
@@ -1,0 +1,52 @@
+codeunit 59921 "EIT Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "EIT Src";
+
+    [Test]
+    procedure TableId_SetAndGet()
+    begin
+        Assert.AreEqual(18, Src.SetAndGet(18), 'TableId must round-trip 18');
+    end;
+
+    [Test]
+    procedure TableId_Zero()
+    begin
+        // 0 is a valid TableId value (fresh default).
+        Assert.AreEqual(0, Src.SetAndGet(0), 'TableId must round-trip 0');
+    end;
+
+    [Test]
+    procedure TableId_Fresh_IsZero()
+    begin
+        // Default-initialised ErrorInfo has TableId = 0.
+        Assert.AreEqual(0, Src.FreshTableId(), 'Fresh ErrorInfo TableId must be 0');
+    end;
+
+    [Test]
+    procedure TableId_LastWriteWins()
+    begin
+        Assert.AreEqual(27, Src.LastWriteWins(18, 27),
+            'TableId setter must overwrite; last write wins');
+    end;
+
+    [Test]
+    procedure TableId_LargeValue()
+    begin
+        // Large valid table IDs must round-trip.
+        Assert.AreEqual(50000, Src.SetAndGet(50000), 'TableId 50000 must round-trip');
+        Assert.AreEqual(2000000000, Src.SetAndGet(2000000000), 'TableId near INT_MAX must round-trip');
+    end;
+
+    [Test]
+    procedure TableId_DifferentInputs_DifferentOutputs_NegativeTrap()
+    begin
+        Assert.AreNotEqual(
+            Src.SetAndGet(18),
+            Src.SetAndGet(27),
+            'Different TableId inputs must produce different outputs');
+    end;
+}


### PR DESCRIPTION
Closes #598

## Summary

BC native `ErrorInfo.TableId` property works standalone — same pattern as `DetailedMessage` covered in PR #590. Adds proving-test suite.

## Changes

- `tests/bucket-2/171-errorinfo-tableid/` — helper + 6 proving tests (set-get, zero, fresh=0, last-write-wins, large values, different-inputs-different-outputs trap)
- `docs/coverage.yaml` — `ErrorInfo.TableId` marked `covered`

## Verification

- 6/6 new tests pass
- Full bucket-2: 1012 pass (3 pre-existing DateTime/timezone failures)