### PR TITLE
feat: ErrorInfo.SystemId — get/set system ID on error info

### DIFF
--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -1121,6 +1121,10 @@ addfirst_fieldgroup_modification:
   layer: syntax
   category: modification
   status: gap
+  notes: >
+    Language gap: AL compiler (BC 26–28) rejects addfirst inside tableextension
+    fieldgroups with AL0104 — addfirst is not a valid keyword in this position.
+    addlast works; addfirst does not exist at these BC versions.
 
 addfirst_modification:
   layer: syntax
@@ -2110,8 +2114,10 @@ ErrorInfo.RecordId:
 ErrorInfo.SystemId:
   layer: runtime-api
   category: ErrorInfo
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; getter ALSystemId() + setter ALSystemId(Guid) on NavALErrorInfo
+  tests:
+    - tests/bucket-1/263-errorinfo-systemid
 
 ErrorInfo.TableId:
   layer: runtime-api

--- a/tests/bucket-1/263-errorinfo-systemid/src/EISystemIdSrc.al
+++ b/tests/bucket-1/263-errorinfo-systemid/src/EISystemIdSrc.al
@@ -1,0 +1,28 @@
+/// Helper codeunit that exercises ErrorInfo.SystemId get and set.
+codeunit 61930 "EI SystemId Src"
+{
+    procedure SetAndGet(): Guid
+    var
+        ei: ErrorInfo;
+        g: Guid;
+    begin
+        g := CreateGuid();
+        ei.SystemId(g);
+        exit(ei.SystemId());
+    end;
+
+    procedure GetDefault(): Guid
+    var
+        ei: ErrorInfo;
+    begin
+        exit(ei.SystemId());
+    end;
+
+    procedure SetAndGetSpecific(g: Guid): Guid
+    var
+        ei: ErrorInfo;
+    begin
+        ei.SystemId(g);
+        exit(ei.SystemId());
+    end;
+}

--- a/tests/bucket-1/263-errorinfo-systemid/test/EISystemIdTest.al
+++ b/tests/bucket-1/263-errorinfo-systemid/test/EISystemIdTest.al
@@ -1,0 +1,66 @@
+codeunit 61931 "EI SystemId Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    // ------------------------------------------------------------------
+    // Positive: SystemId round-trips correctly.
+    // ------------------------------------------------------------------
+
+    [Test]
+    procedure SystemId_RoundTrip()
+    var
+        Src: Codeunit "EI SystemId Src";
+    begin
+        // [GIVEN/WHEN] A new GUID is set on ErrorInfo.SystemId
+        // [THEN]  The same non-null GUID is returned from SystemId()
+        Assert.IsTrue(not IsNullGuid(Src.SetAndGet()), 'SystemId round-trip must not be null GUID');
+    end;
+
+    [Test]
+    procedure SystemId_SpecificValue_RoundTrips()
+    var
+        Src: Codeunit "EI SystemId Src";
+        g: Guid;
+        result: Guid;
+    begin
+        // [GIVEN] A specific GUID
+        g := '{12345678-1234-1234-1234-123456789ABC}';
+        // [WHEN]  It is set as SystemId
+        result := Src.SetAndGetSpecific(g);
+        // [THEN]  The exact same GUID is returned — proving value is stored and retrieved
+        Assert.AreEqual(Format(g), Format(result), 'SystemId must return the exact GUID that was set');
+    end;
+
+    // ------------------------------------------------------------------
+    // Negative: default SystemId is null GUID.
+    // ------------------------------------------------------------------
+
+    [Test]
+    procedure SystemId_DefaultIsNullGuid()
+    var
+        Src: Codeunit "EI SystemId Src";
+    begin
+        // [GIVEN] An ErrorInfo with no SystemId set
+        // [THEN]  SystemId() returns a null GUID
+        Assert.IsTrue(IsNullGuid(Src.GetDefault()), 'Default SystemId must be null GUID');
+    end;
+
+    [Test]
+    procedure SystemId_NotSameAsOtherRoundTrip()
+    var
+        Src: Codeunit "EI SystemId Src";
+        g1: Guid;
+        g2: Guid;
+    begin
+        // [GIVEN] Two different GUIDs set on separate ErrorInfo variables
+        g1 := '{11111111-1111-1111-1111-111111111111}';
+        g2 := '{22222222-2222-2222-2222-222222222222}';
+        // [THEN]  Each returns its own value — they are independent
+        Assert.AreEqual(Format(g1), Format(Src.SetAndGetSpecific(g1)), 'First GUID must match');
+        Assert.AreEqual(Format(g2), Format(Src.SetAndGetSpecific(g2)), 'Second GUID must match');
+        Assert.AreNotEqual(Format(g1), Format(g2), 'GUIDs must be distinct');
+    end;
+}


### PR DESCRIPTION
Closes #600

## Summary

- Added test suite `tests/bucket-1/263-errorinfo-systemid` with four proving tests for `ErrorInfo.SystemId` getter and setter
- Tests cover: round-trip (non-null GUID), specific value round-trip, null default, and independence of two separate instances
- Updated `docs/coverage.yaml`: `ErrorInfo.SystemId` → covered

## Test plan

- [ ] All four tests in `263-errorinfo-systemid` pass in CI
- [ ] Bucket-1 full regression passes
- [ ] `docs/coverage.yaml` updated with test reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)