### PR TITLE
test: ErrorInfo.FieldNo coverage — get/set round-trip

### DIFF
--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -2125,8 +2125,10 @@ ErrorInfo.ErrorType:
 ErrorInfo.FieldNo:
   layer: runtime-api
   category: ErrorInfo
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; BC native property works standalone. Integer get/set with 0 as fresh default.
+  tests:
+    - tests/bucket-2/172-errorinfo-fieldno
 
 ErrorInfo.Message:
   layer: runtime-api

--- a/tests/bucket-2/172-errorinfo-fieldno/al-runner.json
+++ b/tests/bucket-2/172-errorinfo-fieldno/al-runner.json
@@ -1,0 +1,4 @@
+{
+  "sourcePath": "./src",
+  "testPath": "./test"
+}

--- a/tests/bucket-2/172-errorinfo-fieldno/src/ErrorInfoFieldNoSrc.al
+++ b/tests/bucket-2/172-errorinfo-fieldno/src/ErrorInfoFieldNoSrc.al
@@ -1,0 +1,27 @@
+/// Helper codeunit exercising ErrorInfo.FieldNo getter/setter.
+codeunit 59930 "EIF Src"
+{
+    procedure SetAndGet(fieldNo: Integer): Integer
+    var
+        ei: ErrorInfo;
+    begin
+        ei.FieldNo := fieldNo;
+        exit(ei.FieldNo);
+    end;
+
+    procedure FreshFieldNo(): Integer
+    var
+        ei: ErrorInfo;
+    begin
+        exit(ei.FieldNo);
+    end;
+
+    procedure LastWriteWins(a: Integer; b: Integer): Integer
+    var
+        ei: ErrorInfo;
+    begin
+        ei.FieldNo := a;
+        ei.FieldNo := b;
+        exit(ei.FieldNo);
+    end;
+}

--- a/tests/bucket-2/172-errorinfo-fieldno/test/ErrorInfoFieldNoTest.al
+++ b/tests/bucket-2/172-errorinfo-fieldno/test/ErrorInfoFieldNoTest.al
@@ -1,0 +1,49 @@
+codeunit 59931 "EIF Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "EIF Src";
+
+    [Test]
+    procedure FieldNo_SetAndGet()
+    begin
+        Assert.AreEqual(3, Src.SetAndGet(3), 'FieldNo must round-trip 3');
+    end;
+
+    [Test]
+    procedure FieldNo_Zero()
+    begin
+        Assert.AreEqual(0, Src.SetAndGet(0), 'FieldNo must round-trip 0');
+    end;
+
+    [Test]
+    procedure FieldNo_Fresh_IsZero()
+    begin
+        Assert.AreEqual(0, Src.FreshFieldNo(), 'Fresh ErrorInfo FieldNo must be 0');
+    end;
+
+    [Test]
+    procedure FieldNo_LastWriteWins()
+    begin
+        Assert.AreEqual(7, Src.LastWriteWins(3, 7),
+            'FieldNo setter must overwrite; last write wins');
+    end;
+
+    [Test]
+    procedure FieldNo_LargeValues()
+    begin
+        Assert.AreEqual(10000, Src.SetAndGet(10000), 'FieldNo 10000 must round-trip');
+        Assert.AreEqual(2000000000, Src.SetAndGet(2000000000), 'FieldNo near INT_MAX must round-trip');
+    end;
+
+    [Test]
+    procedure FieldNo_DifferentInputs_DifferentOutputs_NegativeTrap()
+    begin
+        Assert.AreNotEqual(
+            Src.SetAndGet(3),
+            Src.SetAndGet(7),
+            'Different FieldNo inputs must produce different outputs');
+    end;
+}


### PR DESCRIPTION
Closes #596

Same pattern as PR #601 (TableId) and PR #590 (DetailedMessage). BC native property works standalone.

- `tests/bucket-2/172-errorinfo-fieldno/` — helper + 6 proving tests
- `docs/coverage.yaml` — `ErrorInfo.FieldNo` marked `covered`

6/6 new tests pass.