### PR TITLE
test: ErrorInfo.CustomDimensions coverage — Dictionary get/set

### DIFF
--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -2103,8 +2103,10 @@ ErrorInfo.Create:
 ErrorInfo.CustomDimensions:
   layer: runtime-api
   category: ErrorInfo
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; BC native property works standalone. Dictionary of [Text, Text] get/set with empty default. Setter replaces (not merges).
+  tests:
+    - tests/bucket-2/173-errorinfo-customdims
 
 ErrorInfo.DataClassification:
   layer: runtime-api

--- a/tests/bucket-2/173-errorinfo-customdims/al-runner.json
+++ b/tests/bucket-2/173-errorinfo-customdims/al-runner.json
@@ -1,0 +1,4 @@
+{
+  "sourcePath": "./src",
+  "testPath": "./test"
+}

--- a/tests/bucket-2/173-errorinfo-customdims/src/ErrorInfoCustomDimsSrc.al
+++ b/tests/bucket-2/173-errorinfo-customdims/src/ErrorInfoCustomDimsSrc.al
@@ -1,0 +1,49 @@
+/// Helper codeunit exercising ErrorInfo.CustomDimensions getter/setter.
+codeunit 59940 "EICD Src"
+{
+    procedure SetAndGetCount(): Integer
+    var
+        ei: ErrorInfo;
+        dims: Dictionary of [Text, Text];
+    begin
+        dims.Add('key1', 'value1');
+        dims.Add('key2', 'value2');
+        ei.CustomDimensions := dims;
+        exit(ei.CustomDimensions.Count());
+    end;
+
+    procedure FreshCount(): Integer
+    var
+        ei: ErrorInfo;
+    begin
+        // A default-initialised ErrorInfo has an empty CustomDimensions dictionary.
+        exit(ei.CustomDimensions.Count());
+    end;
+
+    procedure SetAndGetValue(dimKey: Text; dimValue: Text): Text
+    var
+        ei: ErrorInfo;
+        dims: Dictionary of [Text, Text];
+    begin
+        dims.Add(dimKey, dimValue);
+        ei.CustomDimensions := dims;
+        exit(ei.CustomDimensions.Get(dimKey));
+    end;
+
+    procedure LastWriteWins_NewCount(): Integer
+    var
+        ei: ErrorInfo;
+        first: Dictionary of [Text, Text];
+        second: Dictionary of [Text, Text];
+    begin
+        first.Add('a', '1');
+        first.Add('b', '2');
+        first.Add('c', '3');
+        ei.CustomDimensions := first;
+
+        second.Add('x', '9');
+        ei.CustomDimensions := second;
+
+        exit(ei.CustomDimensions.Count());
+    end;
+}

--- a/tests/bucket-2/173-errorinfo-customdims/test/ErrorInfoCustomDimsTest.al
+++ b/tests/bucket-2/173-errorinfo-customdims/test/ErrorInfoCustomDimsTest.al
@@ -1,0 +1,48 @@
+codeunit 59941 "EICD Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "EICD Src";
+
+    [Test]
+    procedure CustomDimensions_SetAndGet_CountPreserved()
+    begin
+        Assert.AreEqual(2, Src.SetAndGetCount(),
+            'CustomDimensions must preserve 2 added entries');
+    end;
+
+    [Test]
+    procedure CustomDimensions_Fresh_IsEmpty()
+    begin
+        Assert.AreEqual(0, Src.FreshCount(),
+            'Fresh ErrorInfo CustomDimensions must have Count 0');
+    end;
+
+    [Test]
+    procedure CustomDimensions_ValueRetrievable()
+    begin
+        // Proving the value stored under a key is retrievable.
+        Assert.AreEqual('world', Src.SetAndGetValue('hello', 'world'),
+            'CustomDimensions must allow retrieving values by key');
+    end;
+
+    [Test]
+    procedure CustomDimensions_LastWriteWins()
+    begin
+        // Setting CustomDimensions with a new dictionary must replace the prior one,
+        // not merge — the new count (1) wins over the old (3).
+        Assert.AreEqual(1, Src.LastWriteWins_NewCount(),
+            'Subsequent CustomDimensions setter must replace, not merge');
+    end;
+
+    [Test]
+    procedure CustomDimensions_DifferentValues_DifferentResults_NegativeTrap()
+    begin
+        Assert.AreNotEqual(
+            Src.SetAndGetValue('k', 'alpha'),
+            Src.SetAndGetValue('k', 'beta'),
+            'Different stored values must produce different retrievals');
+    end;
+}


### PR DESCRIPTION
Closes #608

Same pattern as prior ErrorInfo property PRs (#590/#601/#605). BC native works standalone.

- `tests/bucket-2/173-errorinfo-customdims/` — helper + 5 proving tests (count preserved, fresh empty, value retrievable, last-write-wins replaces, negative trap)
- `docs/coverage.yaml` — `ErrorInfo.CustomDimensions` marked `covered`

5/5 new tests pass.