### PR TITLE
chore: remove temporary ALDatabase diagnostic from #593

### DIFF
--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -1701,25 +1701,6 @@ public void ClearApplicationMemberVariables() { }
                     SyntaxFactory.Literal("S-1-0-0"))
                     .WithTriviaFrom(node);
             }
-            // Diagnostic: log any unhandled ALDatabase method that is NOT already
-            // intercepted above — this appears in CI stderr to identify unknown method names.
-            if (!System.Array.Exists(new[] {
-                    "ALSessionID", "ALSessionId", "ALTenantID", "ALSerialNumber",
-                    "ALServiceInstanceID", "ALServiceInstanceId",
-                    "ALUserSecurityId", "ALIsInWriteTransaction",
-                    "ALGetDefaultTableConnection", "ALLastUsedRowVersion",
-                    "ALMinimumActiveRowVersion", "ALHasTableConnection",
-                    "ALCommit", "ALSelectLatestVersion", "ALAlterKey",
-                    "ALCheckLicenseFile", "ALChangeUserPassword", "ALCopyCompany",
-                    "ALImportData", "ALExportData", "ALDataFileInformation",
-                    "ALRegisterTableConnection", "ALSetDefaultTableConnection",
-                    "ALUnregisterTableConnection", "ALRunCodeunit",
-                    "ALGetLastErrorText", "ALGetLastErrorCallStack",
-                    "ALClearLastError" },
-                    n => n == idName))
-            {
-                Console.Error.WriteLine($"[RoslynRewriter] UNHANDLED ALDatabase.{idName} — add intercept");
-            }
         }
 
         // `NavOption.Create(existing.NavOptionMetadata, V)` — reassignment


### PR DESCRIPTION
The diagnostic `Console.Error.WriteLine` added to identify the `Database.SID()` method
name was merged as part of #593. This PR removes it.

No functional change — the SID intercept itself is preserved.