### PR TITLE
feat: Database.SetUserPassword — strip call as no-op in standalone mode

### DIFF
--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -51,6 +51,7 @@ public class RoslynRewriter : CSharpSyntaxRewriter
         "ALAlterKey", // ALDatabase.ALAlterKey() — DDL not supported standalone; no-op
         "ALCheckLicenseFile", // ALDatabase.ALCheckLicenseFile() — no license system standalone; no-op
         "ALChangeUserPassword",  // ALDatabase.ALChangeUserPassword(err, old, new) — user system not modeled; no-op standalone
+        "ALSetUserPassword",     // ALDatabase.ALSetUserPassword(userId, newPwd) — service-tier user system; no-op standalone
         "ALCopyCompany",  // ALDatabase.ALCopyCompany(src, dest) — no multi-company store standalone; no-op
         "ALImportData",   // ALDatabase.ALImportData(tableNo, path, create) — no file I/O standalone; no-op
         "ALExportData",   // ALDatabase.ALExportData(fileName, ...) — no file I/O standalone; no-op

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -1719,8 +1719,10 @@ Database.SetDefaultTableConnection:
 Database.SetUserPassword:
   layer: runtime-api
   category: Database
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1 (userId, newPassword); rewriter strips the entire call (no service-tier user system standalone).
+  tests:
+    - tests/bucket-1/264-database-setuserpassword
 
 Database.SID:
   layer: runtime-api

--- a/tests/bucket-1/264-database-setuserpassword/src/SetUserPwdSrc.al
+++ b/tests/bucket-1/264-database-setuserpassword/src/SetUserPwdSrc.al
@@ -1,0 +1,11 @@
+/// Helper codeunit exercising Database.SetUserPassword().
+/// In standalone mode the call must be a silent no-op —
+/// the runner has no service tier and cannot change real passwords.
+codeunit 82050 "SUP Src"
+{
+    procedure ChangePassword(UserId: Guid; NewPwd: Text): Boolean
+    begin
+        Database.SetUserPassword(UserId, NewPwd);
+        exit(true);
+    end;
+}

--- a/tests/bucket-1/264-database-setuserpassword/test/SetUserPwdTest.al
+++ b/tests/bucket-1/264-database-setuserpassword/test/SetUserPwdTest.al
@@ -1,0 +1,53 @@
+codeunit 82051 "SUP Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "SUP Src";
+
+    // -----------------------------------------------------------------------
+    // Positive: Database.SetUserPassword must be a silent no-op in standalone
+    // mode — the runner has no service tier, so password changes are ignored.
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure SetUserPassword_WithValidGuid_IsNoOp()
+    var
+        UserId: Guid;
+    begin
+        // Positive: a valid UserId + non-empty password must complete without error.
+        UserId := CreateGuid();
+        Assert.IsTrue(Src.ChangePassword(UserId, 'NewP@ssw0rd!'),
+            'Database.SetUserPassword must not throw in standalone mode');
+    end;
+
+    [Test]
+    procedure SetUserPassword_WithEmptyPassword_IsNoOp()
+    var
+        UserId: Guid;
+    begin
+        // Positive: empty password must also be silently accepted.
+        UserId := CreateGuid();
+        Assert.IsTrue(Src.ChangePassword(UserId, ''),
+            'Database.SetUserPassword with empty password must not throw');
+    end;
+
+    // -----------------------------------------------------------------------
+    // Negative: control-flow after the call still executes — the no-op does
+    // not prevent subsequent code from running.
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure SetUserPassword_ReturnsTrueAfterCall()
+    var
+        UserId: Guid;
+        Result: Boolean;
+    begin
+        // Negative: proves the function actually ran past the SetUserPassword
+        // call and returned a meaningful value (not just swallowed by a crash).
+        UserId := CreateGuid();
+        Result := Src.ChangePassword(UserId, 'S3cr3t!');
+        Assert.IsTrue(Result, 'Return value after SetUserPassword must be true');
+    end;
+}


### PR DESCRIPTION
Closes #613

## Summary
- Add `ALSetUserPassword` to `StripEntireCallMethods` in `RoslynRewriter.cs` alongside `ALChangeUserPassword` — the service-tier user system is unavailable standalone, so password changes are silently dropped
- Add test suite `264-database-setuserpassword` (bucket-1, IDs 82050–82051) with 3 tests: two no-throw positive cases (valid GUID + empty password) and one control-flow continuation proof
- Mark `Database.SetUserPassword` as `covered` in `docs/coverage.yaml`

## Test plan
- [ ] RED confirmed: tests fail before the rewriter change
- [ ] GREEN confirmed: all 3 tests pass with `ALSetUserPassword` stripped
- [ ] Full bucket-1 regression passes
- [ ] Coverage manifest validates

🤖 Generated with [Claude Code](https://claude.com/claude-code)