### PR TITLE
feat: Integer.ToText — test coverage for integer-to-text conversion

### DIFF
--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -2995,8 +2995,9 @@ InStream.ResetPosition:
 Integer.ToText:
   layer: runtime-api
   category: Integer
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; RoslynRewriter redirects `<expr>.ToText()` to `AlCompat.Format(expr)`; NavInteger handled in AlScope.cs
+  test: tests/bucket-1/84-integer-totext
 
 # ── IsolatedStorage ─────────────────────────────────────────────
 

--- a/tests/bucket-1/84-integer-totext/src/IntToTextSrc.al
+++ b/tests/bucket-1/84-integer-totext/src/IntToTextSrc.al
@@ -1,0 +1,34 @@
+codeunit 83500 "Int ToText Src"
+{
+    procedure PositiveToText(): Text
+    var
+        n: Integer;
+    begin
+        n := 42;
+        exit(n.ToText());
+    end;
+
+    procedure NegativeToText(): Text
+    var
+        n: Integer;
+    begin
+        n := -7;
+        exit(n.ToText());
+    end;
+
+    procedure ZeroToText(): Text
+    var
+        n: Integer;
+    begin
+        n := 0;
+        exit(n.ToText());
+    end;
+
+    procedure LargeToText(): Text
+    var
+        n: Integer;
+    begin
+        n := 1000000;
+        exit(n.ToText());
+    end;
+}

--- a/tests/bucket-1/84-integer-totext/test/IntToTextTest.al
+++ b/tests/bucket-1/84-integer-totext/test/IntToTextTest.al
@@ -1,0 +1,50 @@
+codeunit 83501 "Int ToText Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "Int ToText Src";
+
+    [Test]
+    procedure PositiveInteger_ToText_ReturnsString()
+    begin
+        Assert.AreEqual('42', Src.PositiveToText(), 'Integer 42 ToText must return ''42''');
+    end;
+
+    [Test]
+    procedure NegativeInteger_ToText_ReturnsSignedString()
+    begin
+        Assert.AreEqual('-7', Src.NegativeToText(), 'Integer -7 ToText must return ''-7''');
+    end;
+
+    [Test]
+    procedure Zero_ToText_ReturnsZeroString()
+    begin
+        Assert.AreEqual('0', Src.ZeroToText(), 'Integer 0 ToText must return ''0''');
+    end;
+
+    [Test]
+    procedure LargeInteger_ToText_ReturnsString()
+    begin
+        Assert.AreEqual('1000000', Src.LargeToText(), 'Integer 1000000 ToText must return ''1000000''');
+    end;
+
+    [Test]
+    procedure Inline_ToText_RoundTrip()
+    var
+        n: Integer;
+    begin
+        n := 99;
+        Assert.AreEqual('99', n.ToText(), 'Inline integer ToText must return ''99''');
+    end;
+
+    [Test]
+    procedure ToText_NotEmpty()
+    var
+        n: Integer;
+    begin
+        n := 5;
+        Assert.AreNotEqual('', n.ToText(), 'ToText must not return empty string');
+    end;
+}


### PR DESCRIPTION
Closes #618

RoslynRewriter already redirects `.ToText()` calls to `AlCompat.Format(expr)`, and `AlScope.cs` already handles `NavInteger` in the `Format` overload. This PR adds a test suite to prove the feature works correctly:

- `PositiveInteger_ToText_ReturnsString` — `42` → `'42'`
- `NegativeInteger_ToText_ReturnsSignedString` — `-7` → `'-7'`
- `Zero_ToText_ReturnsZeroString` — `0` → `'0'`
- `LargeInteger_ToText_ReturnsString` — `1000000` → `'1000000'`
- `Inline_ToText_RoundTrip` — inline variable usage
- `ToText_NotEmpty` — negative: result is not empty string

Updates `docs/coverage.yaml`: `Integer.ToText` → `status: covered`.