### PR TITLE
feat: InStream.EOS — end-of-stream detection

### DIFF
--- a/AlRunner/Runtime/MockInStream.cs
+++ b/AlRunner/Runtime/MockInStream.cs
@@ -56,6 +56,9 @@ public class MockInStream
     /// <summary>ALIsEOS — BC's InStream.EOS() mapped to this property.</summary>
     public bool ALIsEOS => EOS;
 
+    /// <summary>ALEOS() — BC emits inStream.ALEOS() for InStr.EOS() calls.</summary>
+    public bool ALEOS() => EOS;
+
     /// <summary>Read all remaining bytes as a UTF-8 string (used by MockJsonHelper.ReadFrom).</summary>
     public string ReadAll()
     {

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -2961,8 +2961,9 @@ HttpResponseMessage.ReasonPhrase:
 InStream.EOS:
   layer: runtime-api
   category: InStream
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-1/266-instream-eos
+  notes: overloads=1; BC emits ALEOS() method on NavInStream; MockInStream.ALEOS() added returning pos >= length
 
 InStream.Length:
   layer: runtime-api

--- a/tests/bucket-1/266-instream-eos/src/InStreamEosSrc.al
+++ b/tests/bucket-1/266-instream-eos/src/InStreamEosSrc.al
@@ -39,25 +39,25 @@ codeunit 84000 "InStream EOS Src"
         exit(InStr.EOS());
     end;
 
-    procedure CountLinesUsingEOS(): Integer
+    /// Read a 4-byte stream in 2-byte chunks — loop must iterate exactly twice.
+    procedure CountChunksUsingEOS(): Integer
     var
         Rec: Record "IEos Data";
         InStr: InStream;
         OutStr: OutStream;
-        Line: Text;
+        Chunk: Text;
         Count: Integer;
     begin
         Rec."Entry No." := 1;
         Rec.Content.CreateOutStream(OutStr);
-        OutStr.WriteText('Line1');
-        OutStr.WriteText('Line2');
+        OutStr.WriteText('AABB');   // 4 bytes
         Rec.Content.CreateInStream(InStr);
         Count := 0;
         while not InStr.EOS() do begin
-            InStr.ReadText(Line);
+            InStr.ReadText(Chunk, 2);   // read 2 bytes at a time
             Count += 1;
         end;
-        exit(Count);
+        exit(Count);  // expects 2: 'AA' then 'BB'
     end;
 }
 

--- a/tests/bucket-1/266-instream-eos/src/InStreamEosSrc.al
+++ b/tests/bucket-1/266-instream-eos/src/InStreamEosSrc.al
@@ -1,0 +1,75 @@
+/// Helper codeunit that exercises InStream.EOS() detection.
+codeunit 84000 "InStream EOS Src"
+{
+    procedure EmptyStreamIsEOS(): Boolean
+    var
+        Rec: Record "IEos Data";
+        InStr: InStream;
+    begin
+        Rec."Entry No." := 1;
+        Rec.Content.CreateInStream(InStr);
+        exit(InStr.EOS());
+    end;
+
+    procedure NonEmptyStreamIsNotEOSAtStart(): Boolean
+    var
+        Rec: Record "IEos Data";
+        InStr: InStream;
+        OutStr: OutStream;
+    begin
+        Rec."Entry No." := 1;
+        Rec.Content.CreateOutStream(OutStr);
+        OutStr.WriteText('Hello');
+        Rec.Content.CreateInStream(InStr);
+        exit(not InStr.EOS());
+    end;
+
+    procedure StreamIsEOSAfterReadingAll(): Boolean
+    var
+        Rec: Record "IEos Data";
+        InStr: InStream;
+        OutStr: OutStream;
+        Line: Text;
+    begin
+        Rec."Entry No." := 1;
+        Rec.Content.CreateOutStream(OutStr);
+        OutStr.WriteText('Hello');
+        Rec.Content.CreateInStream(InStr);
+        InStr.ReadText(Line);
+        exit(InStr.EOS());
+    end;
+
+    procedure CountLinesUsingEOS(): Integer
+    var
+        Rec: Record "IEos Data";
+        InStr: InStream;
+        OutStr: OutStream;
+        Line: Text;
+        Count: Integer;
+    begin
+        Rec."Entry No." := 1;
+        Rec.Content.CreateOutStream(OutStr);
+        OutStr.WriteText('Line1');
+        OutStr.WriteText('Line2');
+        Rec.Content.CreateInStream(InStr);
+        Count := 0;
+        while not InStr.EOS() do begin
+            InStr.ReadText(Line);
+            Count += 1;
+        end;
+        exit(Count);
+    end;
+}
+
+table 84000 "IEos Data"
+{
+    fields
+    {
+        field(1; "Entry No."; Integer) { }
+        field(2; Content; Blob) { }
+    }
+    keys
+    {
+        key(PK; "Entry No.") { }
+    }
+}

--- a/tests/bucket-1/266-instream-eos/test/InStreamEosTest.al
+++ b/tests/bucket-1/266-instream-eos/test/InStreamEosTest.al
@@ -1,0 +1,63 @@
+codeunit 84001 "InStream EOS Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    // ------------------------------------------------------------------
+    // Positive: EOS() returns true when stream is empty or exhausted.
+    // ------------------------------------------------------------------
+
+    [Test]
+    procedure EOS_EmptyStream_ReturnsTrue()
+    var
+        Src: Codeunit "InStream EOS Src";
+    begin
+        // [GIVEN] A blob with no content and an InStream created from it
+        // [WHEN] EOS() is called immediately
+        // [THEN] Returns true — stream has no data
+        Assert.IsTrue(Src.EmptyStreamIsEOS(), 'EOS() must return true for an empty stream');
+    end;
+
+    [Test]
+    procedure EOS_AfterReadingAll_ReturnsTrue()
+    var
+        Src: Codeunit "InStream EOS Src";
+    begin
+        // [GIVEN] A blob with content, fully read
+        // [WHEN] EOS() is called after reading all data
+        // [THEN] Returns true
+        Assert.IsTrue(Src.StreamIsEOSAfterReadingAll(), 'EOS() must return true after reading all content');
+    end;
+
+    // ------------------------------------------------------------------
+    // Negative: EOS() returns false when data remains.
+    // ------------------------------------------------------------------
+
+    [Test]
+    procedure EOS_NonEmptyStreamAtStart_ReturnsFalse()
+    var
+        Src: Codeunit "InStream EOS Src";
+    begin
+        // [GIVEN] A blob with content, stream not yet read
+        // [WHEN] EOS() is called at position 0
+        // [THEN] Returns false — data remains
+        Assert.IsTrue(Src.NonEmptyStreamIsNotEOSAtStart(), 'EOS() must return false at start of non-empty stream');
+    end;
+
+    // ------------------------------------------------------------------
+    // Integration: EOS() drives a read loop correctly.
+    // ------------------------------------------------------------------
+
+    [Test]
+    procedure EOS_DriveReadLoop_CountsLines()
+    var
+        Src: Codeunit "InStream EOS Src";
+    begin
+        // [GIVEN] A stream with 2 WriteText calls
+        // [WHEN] Loop reads lines until EOS()
+        // [THEN] Exactly 2 iterations
+        Assert.AreEqual(2, Src.CountLinesUsingEOS(), 'EOS() loop must read exactly 2 lines from 2-line stream');
+    end;
+}

--- a/tests/bucket-1/266-instream-eos/test/InStreamEosTest.al
+++ b/tests/bucket-1/266-instream-eos/test/InStreamEosTest.al
@@ -51,13 +51,13 @@ codeunit 84001 "InStream EOS Test"
     // ------------------------------------------------------------------
 
     [Test]
-    procedure EOS_DriveReadLoop_CountsLines()
+    procedure EOS_DriveReadLoop_CountsChunks()
     var
         Src: Codeunit "InStream EOS Src";
     begin
-        // [GIVEN] A stream with 2 WriteText calls
-        // [WHEN] Loop reads lines until EOS()
-        // [THEN] Exactly 2 iterations
-        Assert.AreEqual(2, Src.CountLinesUsingEOS(), 'EOS() loop must read exactly 2 lines from 2-line stream');
+        // [GIVEN] A 4-byte stream, reading 2 bytes at a time
+        // [WHEN] Loop reads chunks until EOS()
+        // [THEN] Exactly 2 iterations (AA then BB)
+        Assert.AreEqual(2, Src.CountChunksUsingEOS(), 'EOS() loop must iterate exactly twice for 4-byte stream read in 2-byte chunks');
     end;
 }


### PR DESCRIPTION
Closes #617

## Summary
- BC emits `inStream.ALEOS()` for `InStr.EOS()` calls; `MockInStream` had `ALIsEOS` property but was missing the `ALEOS()` method
- Adds `ALEOS()` method to `MockInStream` returning `_pos >= _data.Length`
- Adds test suite `tests/bucket-1/266-instream-eos/` with 4 tests
- Updates `docs/coverage.yaml`: `InStream.EOS` gap → covered

## Test plan
- [ ] `EOS_EmptyStream_ReturnsTrue` — EOS on empty stream returns true
- [ ] `EOS_NonEmptyStreamAtStart_ReturnsFalse` — EOS at start of non-empty stream returns false
- [ ] `EOS_AfterReadingAll_ReturnsTrue` — EOS after reading all content returns true
- [ ] `EOS_DriveReadLoop_CountsLines` — EOS-driven loop reads exactly 2 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)