### PR TITLE
feat: IsolatedStorage.SetEncrypted — transparent-crypto stub

### DIFF
--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -2161,9 +2161,12 @@ public void ClearApplicationMemberVariables() { }
                     visited.ArgumentList);
             }
 
-            // ALIsolatedStorage.ALSet/ALGet/ALContains/ALDelete -> MockIsolatedStorage
+            // ALIsolatedStorage.ALSet/ALSetEncrypted/ALGet/ALContains/ALDelete -> MockIsolatedStorage
+            // SetEncrypted is transparent in the mock — no real crypto needed for tests, and
+            // the value must round-trip through Get/Contains like the plain ALSet path.
             if (exprText == "ALIsolatedStorage" &&
-                (methodName == "ALSet" || methodName == "ALGet" || methodName == "ALContains" || methodName == "ALDelete"))
+                (methodName == "ALSet" || methodName == "ALSetEncrypted"
+                 || methodName == "ALGet" || methodName == "ALContains" || methodName == "ALDelete"))
             {
                 return visited.WithExpression(
                     SyntaxFactory.MemberAccessExpression(

--- a/AlRunner/Runtime/MockIsolatedStorage.cs
+++ b/AlRunner/Runtime/MockIsolatedStorage.cs
@@ -47,6 +47,30 @@ public static class MockIsolatedStorage
         _store[key] = ExtractSecretValue(value);
     }
 
+    // ALSetEncrypted — encrypted variant. In the mock, encryption is transparent
+    // (no crypto); the value round-trips through Get/Contains like a plain ALSet.
+    // Overloads cover the same arg shapes as ALSet: with/without DataScope, and
+    // Text vs NavSecretText value.
+    public static void ALSetEncrypted(DataError errorLevel, string key, string value)
+    {
+        _store[key] = value;
+    }
+
+    public static void ALSetEncrypted(DataError errorLevel, string key, NavSecretText value)
+    {
+        _store[key] = ExtractSecretValue(value);
+    }
+
+    public static void ALSetEncrypted(DataError errorLevel, string key, string value, object dataScope)
+    {
+        _store[key] = value;
+    }
+
+    public static void ALSetEncrypted(DataError errorLevel, string key, NavSecretText value, object dataScope)
+    {
+        _store[key] = ExtractSecretValue(value);
+    }
+
     // ALGet overloads (with DataScope)
     public static bool ALGet(DataError errorLevel, string key, object dataScope, out NavText value)
     {

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -3032,8 +3032,10 @@ IsolatedStorage.Set:
 IsolatedStorage.SetEncrypted:
   layer: runtime-api
   category: IsolatedStorage
-  status: gap
-  notes: overloads=2
+  status: covered
+  notes: overloads=2 (with/without DataScope; Text and NavSecretText value). Rewriter routes to MockIsolatedStorage.ALSetEncrypted which stores plaintext — encryption is transparent standalone, value round-trips through Get/Contains.
+  tests:
+    - tests/bucket-2/175-iso-setencrypted
 
 # ── JsonArray ───────────────────────────────────────────────────
 

--- a/tests/bucket-2/175-iso-setencrypted/al-runner.json
+++ b/tests/bucket-2/175-iso-setencrypted/al-runner.json
@@ -1,0 +1,4 @@
+{
+  "sourcePath": "./src",
+  "testPath": "./test"
+}

--- a/tests/bucket-2/175-iso-setencrypted/src/IsoSetEncryptedSrc.al
+++ b/tests/bucket-2/175-iso-setencrypted/src/IsoSetEncryptedSrc.al
@@ -1,0 +1,28 @@
+/// Helper codeunit exercising IsolatedStorage.SetEncrypted.
+codeunit 59995 "ISE Src"
+{
+    procedure StoreEncrypted2Arg(keyName: Text; value: Text)
+    begin
+        IsolatedStorage.SetEncrypted(keyName, value);
+    end;
+
+    procedure StoreEncrypted3Arg(keyName: Text; value: Text; scope: DataScope)
+    begin
+        IsolatedStorage.SetEncrypted(keyName, value, scope);
+    end;
+
+    procedure StoreAndRetrieve_2Arg(keyName: Text; value: Text): Text
+    var
+        outValue: Text;
+    begin
+        IsolatedStorage.SetEncrypted(keyName, value);
+        IsolatedStorage.Get(keyName, outValue);
+        exit(outValue);
+    end;
+
+    procedure StoreAndContains(keyName: Text; value: Text): Boolean
+    begin
+        IsolatedStorage.SetEncrypted(keyName, value);
+        exit(IsolatedStorage.Contains(keyName));
+    end;
+}

--- a/tests/bucket-2/175-iso-setencrypted/test/IsoSetEncryptedTest.al
+++ b/tests/bucket-2/175-iso-setencrypted/test/IsoSetEncryptedTest.al
@@ -1,0 +1,60 @@
+codeunit 59996 "ISE Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "ISE Src";
+
+    [Test]
+    procedure SetEncrypted_2Arg_NoOp()
+    begin
+        // Positive: 2-arg SetEncrypted(key, value) completes without throwing.
+        Src.StoreEncrypted2Arg('token1', 'secret-value');
+        Assert.IsTrue(true, 'SetEncrypted 2-arg must not throw');
+    end;
+
+    [Test]
+    procedure SetEncrypted_3Arg_NoOp()
+    begin
+        // Positive: 3-arg SetEncrypted(key, value, datascope) completes.
+        Src.StoreEncrypted3Arg('token2', 'secret-value', DataScope::Module);
+        Assert.IsTrue(true, 'SetEncrypted 3-arg must not throw');
+    end;
+
+    [Test]
+    procedure SetEncrypted_RoundTripsWithGet()
+    begin
+        // Store via SetEncrypted, retrieve via Get — value must round-trip.
+        // In runner mode the "encryption" is transparent (no real crypto).
+        Assert.AreEqual('my-secret-payload',
+            Src.StoreAndRetrieve_2Arg('tok-k', 'my-secret-payload'),
+            'SetEncrypted + Get must round-trip the value');
+    end;
+
+    [Test]
+    procedure SetEncrypted_MarksContainsTrue()
+    begin
+        // After SetEncrypted, IsolatedStorage.Contains must return true.
+        Assert.IsTrue(Src.StoreAndContains('tok-c', 'any-value'),
+            'Contains must return true after SetEncrypted');
+    end;
+
+    [Test]
+    procedure SetEncrypted_EmptyValue()
+    begin
+        // Edge: empty value must not crash the stub.
+        Src.StoreEncrypted2Arg('tok-empty', '');
+        Assert.IsTrue(true, 'SetEncrypted with empty value must not throw');
+    end;
+
+    [Test]
+    procedure SetEncrypted_DifferentKeysDifferentValues_NegativeTrap()
+    begin
+        // Negative: guard against a stub that returns the same value for all keys.
+        Assert.AreNotEqual(
+            Src.StoreAndRetrieve_2Arg('tok-a', 'alpha'),
+            Src.StoreAndRetrieve_2Arg('tok-b', 'beta'),
+            'Different keys must store/retrieve different values');
+    end;
+}


### PR DESCRIPTION
Closes #620

## Summary

MockIsolatedStorage had no ALSetEncrypted method. Added 4 overloads (same shapes as ALSet: with/without DataScope × Text/NavSecretText) that store plaintext — encryption is transparent standalone, value round-trips through Get/Contains.

## Changes

- `AlRunner/Runtime/MockIsolatedStorage.cs` — 4 new ALSetEncrypted overloads
- `AlRunner/RoslynRewriter.cs` — extended ALIsolatedStorage routing to include ALSetEncrypted
- `tests/bucket-2/175-iso-setencrypted/` — helper + 6 proving tests
- `docs/coverage.yaml` — `IsolatedStorage.SetEncrypted` marked `covered`

## Verification

- 6/6 new tests pass
- Full bucket-2: 1038 pass (3 pre-existing DateTime/timezone failures)