### PR TITLE
feat: ErrorInfo.Title — get/set title on error info

### DIFF
--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -2181,8 +2181,10 @@ ErrorInfo.TableId:
 ErrorInfo.Title:
   layer: runtime-api
   category: ErrorInfo
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; NavALErrorInfo.ALTitle() works via BC runtime DLL without session.
+  tests:
+    - tests/bucket-1/83-errorinfo-title
 
 ErrorInfo.Verbosity:
   layer: runtime-api

--- a/tests/bucket-1/83-errorinfo-title/src/ErrorInfoTitleSrc.al
+++ b/tests/bucket-1/83-errorinfo-title/src/ErrorInfoTitleSrc.al
@@ -1,0 +1,30 @@
+/// Helper codeunit exercising ErrorInfo.Title() get/set.
+codeunit 83600 "EIT Src"
+{
+    /// Sets Title and returns it (round-trip test).
+    procedure SetAndGet(title: Text): Text
+    var
+        EI: ErrorInfo;
+    begin
+        EI.Title(title);
+        exit(EI.Title());
+    end;
+
+    /// Returns Title on a freshly-initialised ErrorInfo (default empty).
+    procedure DefaultTitle(): Text
+    var
+        EI: ErrorInfo;
+    begin
+        exit(EI.Title());
+    end;
+
+    /// Sets Title twice — last value must win.
+    procedure LastWriteWins(first: Text; second: Text): Text
+    var
+        EI: ErrorInfo;
+    begin
+        EI.Title(first);
+        EI.Title(second);
+        exit(EI.Title());
+    end;
+}

--- a/tests/bucket-1/83-errorinfo-title/test/ErrorInfoTitleTest.al
+++ b/tests/bucket-1/83-errorinfo-title/test/ErrorInfoTitleTest.al
@@ -1,0 +1,54 @@
+codeunit 83601 "EIT Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "EIT Src";
+
+    [Test]
+    procedure Title_SetAndGet_RoundsTrip()
+    begin
+        // Positive: Title getter returns what the setter set.
+        Assert.AreEqual(
+            'Validation Error',
+            Src.SetAndGet('Validation Error'),
+            'Title must round-trip the set value');
+    end;
+
+    [Test]
+    procedure Title_EmptyString_RoundsTrip()
+    begin
+        // Edge: empty string round-trips cleanly.
+        Assert.AreEqual('', Src.SetAndGet(''),
+            'Title must round-trip an empty string');
+    end;
+
+    [Test]
+    procedure Title_Fresh_IsEmpty()
+    begin
+        // Positive: a default-initialised ErrorInfo has an empty Title.
+        Assert.AreEqual('', Src.DefaultTitle(),
+            'Fresh ErrorInfo must have empty Title');
+    end;
+
+    [Test]
+    procedure Title_LastWriteWins()
+    begin
+        // Proving: repeated setter calls overwrite — last value wins.
+        Assert.AreEqual(
+            'Second Title',
+            Src.LastWriteWins('First Title', 'Second Title'),
+            'Title must reflect the last setter call');
+    end;
+
+    [Test]
+    procedure Title_DifferentInputs_DifferentOutputs()
+    begin
+        // Negative: guard against a stub that returns a fixed value.
+        Assert.AreNotEqual(
+            Src.SetAndGet('alpha'),
+            Src.SetAndGet('beta'),
+            'Different inputs must produce different Title values');
+    end;
+}


### PR DESCRIPTION
Closes #594

`ErrorInfo.Title()` getter and `ErrorInfo.Title(value)` setter work via the BC runtime DLL (`NavALErrorInfo.ALTitle`) without requiring a session — same pattern as `ControlName` and `DetailedMessage`.

## Changes

- **Suite 83-errorinfo-title** (bucket-1): 5 proving tests — round-trip, empty string, fresh default empty, last-write-wins, negative guard
- **docs/coverage.yaml**: `ErrorInfo.Title` → `covered`

No runtime code changes needed — `NavALErrorInfo.ALTitle` is provided by the BC DLL and works standalone.

## Test plan
- [ ] `Title_SetAndGet_RoundsTrip` — PASS
- [ ] `Title_EmptyString_RoundsTrip` — PASS
- [ ] `Title_Fresh_IsEmpty` — PASS
- [ ] `Title_LastWriteWins` — PASS
- [ ] `Title_DifferentInputs_DifferentOutputs` — PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)