### PR TITLE
fix: Guid.ToText() — correct format B (38 chars) and format N (32 chars) (#612)

### DIFF
--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -1945,17 +1945,13 @@ public void ClearApplicationMemberVariables() { }
         }
 
         // `<expr>.ALToText(...)` → `AlCompat.GuidToText(<expr>, true/false)`
-        // BC emits navGuid.ALToText() (with AL prefix) for Guid.ToText() in AL, wrapped in
-        // new NavText(...). We only intercept when inside new NavText(...) to avoid catching
-        // MockTextBuilder.ALToText() (returns NavText directly, not wrapped in new NavText).
-        // The remaining new NavText(...) wrapper stays — GuidToText returns string so
-        // new NavText(string) compiles fine.
+        // BC emits navGuid.ALToText() (with AL prefix) for Guid.ToText() in AL. NavGuid.ALToText()
+        // returns format "D" (36 chars lowercase) but AL spec requires format "B" (38 chars, braces)
+        // for the default and format "N" (32 chars) for ToText(false).
+        // MockTextBuilder.ALToText() is also intercepted — GuidToText delegates non-Guid objects
+        // to their own ALToText() to preserve correct BigText/TextBuilder behavior.
         if (visited.Expression is MemberAccessExpressionSyntax alToTextMa &&
-            alToTextMa.Name.Identifier.Text == "ALToText" &&
-            node.Parent is ArgumentSyntax &&
-            node.Parent?.Parent is ArgumentListSyntax &&
-            node.Parent?.Parent?.Parent is ObjectCreationExpressionSyntax alToTextOc &&
-            alToTextOc.Type.ToString().Contains("NavText"))
+            alToTextMa.Name.Identifier.Text == "ALToText")
         {
             bool isFalseArg = visited.ArgumentList.Arguments.Count >= 1 &&
                 visited.ArgumentList.Arguments[0].Expression.IsKind(SyntaxKind.FalseLiteralExpression);

--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -1900,6 +1900,12 @@ public void ClearApplicationMemberVariables() { }
         // Now recurse into children first
         var visited = (InvocationExpressionSyntax)base.VisitInvocationExpression(node)!;
 
+        // DIAGNOSTIC: log any call involving "Text" in method name — remove after debugging #612
+        if (visited.Expression is MemberAccessExpressionSyntax _diagMa &&
+            _diagMa.Name.Identifier.Text.Contains("Text", StringComparison.OrdinalIgnoreCase) &&
+            _currentClassName != null && _currentClassName.Contains("GT"))
+            Console.Error.WriteLine($"[DIAG-612] {_currentClassName}: {visited.Expression} | args={visited.ArgumentList.Arguments.Count} | parent={node.Parent?.GetType().Name}");
+
         // `<expr>.ToText(...)` -> `AlCompat.Format(<expr>)` or `AlCompat.GuidToText(<expr>, false)`
         // BC lowers AL's `xVar.ToText()` to either an instance `navX.ToText(...)` call
         // or a static `ALCompiler.ToText(session, value)` call (the latter is handled

--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -1900,43 +1900,6 @@ public void ClearApplicationMemberVariables() { }
         // Now recurse into children first
         var visited = (InvocationExpressionSyntax)base.VisitInvocationExpression(node)!;
 
-        // `<expr>.ALToText(...)` — Guid.ToText() emitted with the AL-prefix form.
-        // BC emits navGuid.ALToText() or navGuid.ALToText(false) for Guid.ToText() overloads.
-        // Both form routes through NavValueFormatter→NCLManagedAdapter which crashes standalone.
-        // - ALToText(false) → AlCompat.GuidToText(expr, false)  — no braces/hyphens (32 chars)
-        // - ALToText()  or ALToText(true) → AlCompat.Format(expr) — format "B" (38 chars)
-        if (visited.Expression is MemberAccessExpressionSyntax alToTextMa &&
-            alToTextMa.Name.Identifier.Text == "ALToText")
-        {
-            var alToTextReceiver = alToTextMa.Expression;
-            // Check if first arg is literal false
-            bool isFalseLiteral = visited.ArgumentList.Arguments.Count >= 1 &&
-                visited.ArgumentList.Arguments[0].Expression.IsKind(SyntaxKind.FalseLiteralExpression);
-            if (isFalseLiteral)
-            {
-                return SyntaxFactory.InvocationExpression(
-                    SyntaxFactory.MemberAccessExpression(
-                        SyntaxKind.SimpleMemberAccessExpression,
-                        SyntaxFactory.IdentifierName("AlCompat"),
-                        SyntaxFactory.IdentifierName("GuidToText")),
-                    SyntaxFactory.ArgumentList(
-                        SyntaxFactory.SeparatedList(new[] {
-                            SyntaxFactory.Argument(alToTextReceiver),
-                            SyntaxFactory.Argument(SyntaxFactory.LiteralExpression(SyntaxKind.FalseLiteralExpression))
-                        })))
-                    .WithTriviaFrom(visited);
-            }
-            return SyntaxFactory.InvocationExpression(
-                SyntaxFactory.MemberAccessExpression(
-                    SyntaxKind.SimpleMemberAccessExpression,
-                    SyntaxFactory.IdentifierName("AlCompat"),
-                    SyntaxFactory.IdentifierName("Format")),
-                SyntaxFactory.ArgumentList(
-                    SyntaxFactory.SingletonSeparatedList(
-                        SyntaxFactory.Argument(alToTextReceiver))))
-                .WithTriviaFrom(visited);
-        }
-
         // `<expr>.ToText(...)` -> `AlCompat.Format(<expr>)` or `AlCompat.GuidToText(<expr>, false)`
         // BC lowers AL's `xVar.ToText()` to either an instance `navX.ToText(...)` call
         // or a static `ALCompiler.ToText(session, value)` call (the latter is handled

--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -1900,10 +1900,6 @@ public void ClearApplicationMemberVariables() { }
         // Now recurse into children first
         var visited = (InvocationExpressionSyntax)base.VisitInvocationExpression(node)!;
 
-        // DIAGNOSTIC: log all ToText/ALToText invocations — remove after debugging #612
-        if (visited.Expression is MemberAccessExpressionSyntax _diagMa &&
-            (_diagMa.Name.Identifier.Text == "ToText" || _diagMa.Name.Identifier.Text == "ALToText"))
-            Console.Error.WriteLine($"[DIAG-612] cls={_currentClassName} expr={visited.Expression} args={visited.ArgumentList.Arguments.Count} parent={node.Parent?.GetType().Name}");
 
         // `<expr>.ToText(...)` -> `AlCompat.Format(<expr>)` or `AlCompat.GuidToText(<expr>, false)`
         // BC lowers AL's `xVar.ToText()` to either an instance `navX.ToText(...)` call
@@ -2491,16 +2487,31 @@ public void ClearApplicationMemberVariables() { }
                     .WithTriviaFrom(visited);
             }
 
-            // ALCompiler.ToText(session, value) -> AlCompat.Format(value)
+            // ALCompiler.ToText(session, value[, withBraces]) -> AlCompat.Format(value) or AlCompat.GuidToText(value, false)
             // BC lowers `byteVar.ToText()` (and other scalar ToText calls) to the static
-            // ALCompiler.ToText(session, value) form. For Byte, this routes through
-            // NavValueFormatter -> NavByteFormatter -> NCLManagedAdapter (OEM native DLLs)
-            // which fails without the BC service tier. AlCompat.Format handles all BC value
-            // types without session access. We take the second argument (value).
+            // ALCompiler.ToText(session, value) form. We take the second argument (value).
+            // 3-arg form: ALCompiler.ToText(session, navGuid, false) for Guid.ToText(false) →
+            //   3rd arg literal false = no-delimiter form → GuidToText(value, false).
             if (exprText == "ALCompiler" && methodName == "ToText"
                 && visited.ArgumentList.Arguments.Count >= 2)
             {
                 var valueArg = visited.ArgumentList.Arguments[1];
+                bool isFalseThirdArg = visited.ArgumentList.Arguments.Count >= 3 &&
+                    visited.ArgumentList.Arguments[2].Expression.IsKind(SyntaxKind.FalseLiteralExpression);
+                if (isFalseThirdArg)
+                {
+                    return SyntaxFactory.InvocationExpression(
+                        SyntaxFactory.MemberAccessExpression(
+                            SyntaxKind.SimpleMemberAccessExpression,
+                            SyntaxFactory.IdentifierName("AlCompat"),
+                            SyntaxFactory.IdentifierName("GuidToText")),
+                        SyntaxFactory.ArgumentList(
+                            SyntaxFactory.SeparatedList(new[] {
+                                valueArg,
+                                SyntaxFactory.Argument(SyntaxFactory.LiteralExpression(SyntaxKind.FalseLiteralExpression))
+                            })))
+                        .WithTriviaFrom(visited);
+                }
                 return SyntaxFactory.InvocationExpression(
                     SyntaxFactory.MemberAccessExpression(
                         SyntaxKind.SimpleMemberAccessExpression,

--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -1900,11 +1900,10 @@ public void ClearApplicationMemberVariables() { }
         // Now recurse into children first
         var visited = (InvocationExpressionSyntax)base.VisitInvocationExpression(node)!;
 
-        // DIAGNOSTIC: log any call involving "Text" in method name — remove after debugging #612
+        // DIAGNOSTIC: log all ToText/ALToText invocations — remove after debugging #612
         if (visited.Expression is MemberAccessExpressionSyntax _diagMa &&
-            _diagMa.Name.Identifier.Text.Contains("Text", StringComparison.OrdinalIgnoreCase) &&
-            _currentClassName != null && _currentClassName.Contains("GT"))
-            Console.Error.WriteLine($"[DIAG-612] {_currentClassName}: {visited.Expression} | args={visited.ArgumentList.Arguments.Count} | parent={node.Parent?.GetType().Name}");
+            (_diagMa.Name.Identifier.Text == "ToText" || _diagMa.Name.Identifier.Text == "ALToText"))
+            Console.Error.WriteLine($"[DIAG-612] cls={_currentClassName} expr={visited.Expression} args={visited.ArgumentList.Arguments.Count} parent={node.Parent?.GetType().Name}");
 
         // `<expr>.ToText(...)` -> `AlCompat.Format(<expr>)` or `AlCompat.GuidToText(<expr>, false)`
         // BC lowers AL's `xVar.ToText()` to either an instance `navX.ToText(...)` call

--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -1944,6 +1944,35 @@ public void ClearApplicationMemberVariables() { }
                 .WithTriviaFrom(visited);
         }
 
+        // `<expr>.ALToText(...)` → `AlCompat.GuidToText(<expr>, true/false)`
+        // BC emits navGuid.ALToText() (with AL prefix) for Guid.ToText() in AL, wrapped in
+        // new NavText(...). We only intercept when inside new NavText(...) to avoid catching
+        // MockTextBuilder.ALToText() (returns NavText directly, not wrapped in new NavText).
+        // The remaining new NavText(...) wrapper stays — GuidToText returns string so
+        // new NavText(string) compiles fine.
+        if (visited.Expression is MemberAccessExpressionSyntax alToTextMa &&
+            alToTextMa.Name.Identifier.Text == "ALToText" &&
+            node.Parent is ArgumentSyntax &&
+            node.Parent?.Parent is ArgumentListSyntax &&
+            node.Parent?.Parent?.Parent is ObjectCreationExpressionSyntax alToTextOc &&
+            alToTextOc.Type.ToString().Contains("NavText"))
+        {
+            bool isFalseArg = visited.ArgumentList.Arguments.Count >= 1 &&
+                visited.ArgumentList.Arguments[0].Expression.IsKind(SyntaxKind.FalseLiteralExpression);
+            return SyntaxFactory.InvocationExpression(
+                SyntaxFactory.MemberAccessExpression(
+                    SyntaxKind.SimpleMemberAccessExpression,
+                    SyntaxFactory.IdentifierName("AlCompat"),
+                    SyntaxFactory.IdentifierName("GuidToText")),
+                SyntaxFactory.ArgumentList(
+                    SyntaxFactory.SeparatedList(new[] {
+                        SyntaxFactory.Argument(alToTextMa.Expression),
+                        SyntaxFactory.Argument(SyntaxFactory.LiteralExpression(
+                            isFalseArg ? SyntaxKind.FalseLiteralExpression : SyntaxKind.TrueLiteralExpression))
+                    })))
+                .WithTriviaFrom(visited);
+        }
+
         // NavCode.op_Equality(a, b) / NavCode.op_Inequality(a, b)
         // BC may emit explicit static operator calls for Code[N] comparisons in case statements
         // (rather than a binary == expression), depending on the BC version. Both forms need

--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -1900,7 +1900,44 @@ public void ClearApplicationMemberVariables() { }
         // Now recurse into children first
         var visited = (InvocationExpressionSyntax)base.VisitInvocationExpression(node)!;
 
-        // `<expr>.ToText(...)` -> `AlCompat.Format(<expr>)`
+        // `<expr>.ALToText(...)` — Guid.ToText() emitted with the AL-prefix form.
+        // BC emits navGuid.ALToText() or navGuid.ALToText(false) for Guid.ToText() overloads.
+        // Both form routes through NavValueFormatter→NCLManagedAdapter which crashes standalone.
+        // - ALToText(false) → AlCompat.GuidToText(expr, false)  — no braces/hyphens (32 chars)
+        // - ALToText()  or ALToText(true) → AlCompat.Format(expr) — format "B" (38 chars)
+        if (visited.Expression is MemberAccessExpressionSyntax alToTextMa &&
+            alToTextMa.Name.Identifier.Text == "ALToText")
+        {
+            var alToTextReceiver = alToTextMa.Expression;
+            // Check if first arg is literal false
+            bool isFalseLiteral = visited.ArgumentList.Arguments.Count >= 1 &&
+                visited.ArgumentList.Arguments[0].Expression.IsKind(SyntaxKind.FalseLiteralExpression);
+            if (isFalseLiteral)
+            {
+                return SyntaxFactory.InvocationExpression(
+                    SyntaxFactory.MemberAccessExpression(
+                        SyntaxKind.SimpleMemberAccessExpression,
+                        SyntaxFactory.IdentifierName("AlCompat"),
+                        SyntaxFactory.IdentifierName("GuidToText")),
+                    SyntaxFactory.ArgumentList(
+                        SyntaxFactory.SeparatedList(new[] {
+                            SyntaxFactory.Argument(alToTextReceiver),
+                            SyntaxFactory.Argument(SyntaxFactory.LiteralExpression(SyntaxKind.FalseLiteralExpression))
+                        })))
+                    .WithTriviaFrom(visited);
+            }
+            return SyntaxFactory.InvocationExpression(
+                SyntaxFactory.MemberAccessExpression(
+                    SyntaxKind.SimpleMemberAccessExpression,
+                    SyntaxFactory.IdentifierName("AlCompat"),
+                    SyntaxFactory.IdentifierName("Format")),
+                SyntaxFactory.ArgumentList(
+                    SyntaxFactory.SingletonSeparatedList(
+                        SyntaxFactory.Argument(alToTextReceiver))))
+                .WithTriviaFrom(visited);
+        }
+
+        // `<expr>.ToText(...)` -> `AlCompat.Format(<expr>)` or `AlCompat.GuidToText(<expr>, false)`
         // BC lowers AL's `xVar.ToText()` to either an instance `navX.ToText(...)` call
         // or a static `ALCompiler.ToText(session, value)` call (the latter is handled
         // separately below). For instance calls the arguments vary by type and BC version:
@@ -1911,11 +1948,28 @@ public void ClearApplicationMemberVariables() { }
         // which fails without the BC service tier. AlCompat.Format handles every BC value
         // type without session access. We route the receiver (expr) through AlCompat.Format,
         // discarding all arguments since AlCompat.Format does not need them.
+        // Special case: .ToText(false) with literal false → Guid no-delimiter form.
         // Exclude ALCompiler.ToText — that static form is handled separately below.
         if (visited.Expression is MemberAccessExpressionSyntax toTextMa &&
             toTextMa.Name.Identifier.Text == "ToText" &&
             !(toTextMa.Expression is IdentifierNameSyntax toTextId && toTextId.Identifier.Text == "ALCompiler"))
         {
+            bool isFalseLiteralArg = visited.ArgumentList.Arguments.Count >= 1 &&
+                visited.ArgumentList.Arguments[0].Expression.IsKind(SyntaxKind.FalseLiteralExpression);
+            if (isFalseLiteralArg)
+            {
+                return SyntaxFactory.InvocationExpression(
+                    SyntaxFactory.MemberAccessExpression(
+                        SyntaxKind.SimpleMemberAccessExpression,
+                        SyntaxFactory.IdentifierName("AlCompat"),
+                        SyntaxFactory.IdentifierName("GuidToText")),
+                    SyntaxFactory.ArgumentList(
+                        SyntaxFactory.SeparatedList(new[] {
+                            SyntaxFactory.Argument(toTextMa.Expression),
+                            SyntaxFactory.Argument(SyntaxFactory.LiteralExpression(SyntaxKind.FalseLiteralExpression))
+                        })))
+                    .WithTriviaFrom(visited);
+            }
             return SyntaxFactory.InvocationExpression(
                 SyntaxFactory.MemberAccessExpression(
                     SyntaxKind.SimpleMemberAccessExpression,

--- a/AlRunner/Runtime/AlScope.cs
+++ b/AlRunner/Runtime/AlScope.cs
@@ -832,10 +832,19 @@ public static class AlCompat
             }
             catch { }
         }
-        // NavGuid: checked BEFORE NavValue to avoid the try/catch swallowing cast failures.
-        // NavGuid.ToGuid() is the correct API — explicit (Guid) cast throws InvalidCastException.
-        // Format "B" = {XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX} (38 chars, uppercase, braces).
-        if (value is Microsoft.Dynamics.Nav.Runtime.NavGuid ng0) return ng0.ToGuid().ToString("B").ToUpperInvariant();
+        // NavGuid — check by type name (version-independent) and call ToGuid() via reflection.
+        // Pattern-match on Microsoft.Dynamics.Nav.Runtime.NavGuid is unreliable across BC versions;
+        // typeName check + reflection is defensive. Format "B" = {XXXXXXXX-...} (38 chars, braces).
+        if (typeName == "NavGuid")
+        {
+            try
+            {
+                var toGuidMethod = value.GetType().GetMethod("ToGuid");
+                if (toGuidMethod != null)
+                    return ((Guid)toGuidMethod.Invoke(value, null)!).ToString("B").ToUpperInvariant();
+            }
+            catch { }
+        }
         // Handle NavValue subtypes — use ToText() where available, avoid ToString() which may need NavSession
         if (value is Microsoft.Dynamics.Nav.Runtime.NavValue nv)
         {

--- a/AlRunner/Runtime/AlScope.cs
+++ b/AlRunner/Runtime/AlScope.cs
@@ -841,7 +841,9 @@ public static class AlCompat
                 if (value is Microsoft.Dynamics.Nav.Runtime.NavBoolean nb) return (bool)nb ? "Yes" : "No";
                 if (value is Microsoft.Dynamics.Nav.Runtime.NavInteger ni) return ((int)ni).ToString();
                 if (value is Microsoft.Dynamics.Nav.Runtime.NavBigInteger nbi) return ((long)nbi).ToString();
-                if (value is Microsoft.Dynamics.Nav.Runtime.NavGuid ng) return ((Guid)ng).ToString();
+                // NavGuid: AL's ToText() returns {xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx} (format "B", 38 chars).
+                // .NET ToString() without format gives "D" (36 chars, no braces) — fix to "B".
+                if (value is Microsoft.Dynamics.Nav.Runtime.NavGuid ng) return ((Guid)ng).ToString("B").ToUpperInvariant();
                 // NavByte.ToText() — BCL routes through NCLManagedAdapter.ByteToTextChar (OEM native code)
                 // which fails without the BC service tier. Return the numeric string (0-255) instead.
                 if (typeName == "NavByte")
@@ -1514,6 +1516,22 @@ public static class AlCompat
     /// </summary>
     public static Microsoft.Dynamics.Nav.Types.TransactionType ALCurrentTransactionType()
         => Microsoft.Dynamics.Nav.Types.TransactionType.Update;
+
+    /// <summary>
+    /// Guid.ToText([withBraces]) — BC returns uppercase GUID with braces by default.
+    /// withBraces=true  → {XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX} (38 chars, "B" format, uppercase)
+    /// withBraces=false → XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX      (32 chars, "N" format, uppercase)
+    /// AlCompat.Format(NavGuid) handles the default (no-arg) case via the "B" format fix there.
+    /// This method is used when the boolean argument is explicitly false.
+    /// </summary>
+    public static string GuidToText(object? g, bool withBraces)
+    {
+        g = UnwrapVariant(g);
+        var format = withBraces ? "B" : "N";
+        if (g is NavGuid ng) return ((Guid)ng).ToString(format).ToUpperInvariant();
+        if (g is Guid guid) return guid.ToString(format).ToUpperInvariant();
+        return Format(g); // fallback for non-Guid types
+    }
 
     /// <summary>
     /// Replacement for ALDatabase.ALIsNullGuid(g) which requires NavSession.

--- a/AlRunner/Runtime/AlScope.cs
+++ b/AlRunner/Runtime/AlScope.cs
@@ -789,6 +789,9 @@ public static class AlCompat
         if (value is double dbl) return FormatDecimal((decimal)dbl);
         if (value is float f) return FormatDecimal((decimal)f);
         if (value is int or long or short or byte) return value.ToString()!;
+        // System.Guid — BC 26.x compiles AL Guid variables as System.Guid (not NavGuid).
+        // Default AL format is "B" = {XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX} (38 chars, uppercase).
+        if (value is Guid sysGuid) return sysGuid.ToString("B").ToUpperInvariant();
         // Handle Decimal18 and other BC numeric types — convert to decimal
         var typeName = value.GetType().Name;
         if (typeName == "Decimal18")

--- a/AlRunner/Runtime/AlScope.cs
+++ b/AlRunner/Runtime/AlScope.cs
@@ -1521,8 +1521,8 @@ public static class AlCompat
     /// Guid.ToText([withBraces]) — BC returns uppercase GUID with braces by default.
     /// withBraces=true  → {XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX} (38 chars, "B" format, uppercase)
     /// withBraces=false → XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX      (32 chars, "N" format, uppercase)
-    /// AlCompat.Format(NavGuid) handles the default (no-arg) case via the "B" format fix there.
-    /// This method is used when the boolean argument is explicitly false.
+    /// Called for all navGuid.ALToText([bool]) invocations (RoslynRewriter intercepts them).
+    /// MockTextBuilder is also routed here and delegates back to its own ALToText().
     /// </summary>
     public static string GuidToText(object? g, bool withBraces)
     {
@@ -1530,6 +1530,8 @@ public static class AlCompat
         var format = withBraces ? "B" : "N";
         if (g is NavGuid ng) return ((Guid)ng).ToString(format).ToUpperInvariant();
         if (g is Guid guid) return guid.ToString(format).ToUpperInvariant();
+        // MockTextBuilder.ALToText() is also routed here — delegate back to preserve correct text.
+        if (g is MockTextBuilder mtb) return mtb.ALToText().ToString();
         return Format(g); // fallback for non-Guid types
     }
 

--- a/AlRunner/Runtime/AlScope.cs
+++ b/AlRunner/Runtime/AlScope.cs
@@ -1524,15 +1524,15 @@ public static class AlCompat
     /// Called for all navGuid.ALToText([bool]) invocations (RoslynRewriter intercepts them).
     /// MockTextBuilder is also routed here and delegates back to its own ALToText().
     /// </summary>
-    public static string GuidToText(object? g, bool withBraces)
+    public static NavText GuidToText(object? g, bool withBraces)
     {
         g = UnwrapVariant(g);
         var format = withBraces ? "B" : "N";
-        if (g is NavGuid ng) return ((Guid)ng).ToString(format).ToUpperInvariant();
-        if (g is Guid guid) return guid.ToString(format).ToUpperInvariant();
+        if (g is NavGuid ng) return new NavText(((Guid)ng).ToString(format).ToUpperInvariant());
+        if (g is Guid guid) return new NavText(guid.ToString(format).ToUpperInvariant());
         // MockTextBuilder.ALToText() is also routed here — delegate back to preserve correct text.
-        if (g is MockTextBuilder mtb) return mtb.ALToText().ToString();
-        return Format(g); // fallback for non-Guid types
+        if (g is MockTextBuilder mtb) return mtb.ALToText();
+        return new NavText(Format(g)); // fallback for non-Guid types
     }
 
     /// <summary>

--- a/AlRunner/Runtime/AlScope.cs
+++ b/AlRunner/Runtime/AlScope.cs
@@ -832,6 +832,10 @@ public static class AlCompat
             }
             catch { }
         }
+        // NavGuid: checked BEFORE NavValue to avoid the try/catch swallowing cast failures.
+        // NavGuid.ToGuid() is the correct API — explicit (Guid) cast throws InvalidCastException.
+        // Format "B" = {XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX} (38 chars, uppercase, braces).
+        if (value is Microsoft.Dynamics.Nav.Runtime.NavGuid ng0) return ng0.ToGuid().ToString("B").ToUpperInvariant();
         // Handle NavValue subtypes — use ToText() where available, avoid ToString() which may need NavSession
         if (value is Microsoft.Dynamics.Nav.Runtime.NavValue nv)
         {
@@ -841,9 +845,6 @@ public static class AlCompat
                 if (value is Microsoft.Dynamics.Nav.Runtime.NavBoolean nb) return (bool)nb ? "Yes" : "No";
                 if (value is Microsoft.Dynamics.Nav.Runtime.NavInteger ni) return ((int)ni).ToString();
                 if (value is Microsoft.Dynamics.Nav.Runtime.NavBigInteger nbi) return ((long)nbi).ToString();
-                // NavGuid: AL's ToText() returns {xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx} (format "B", 38 chars).
-                // .NET ToString() without format gives "D" (36 chars, no braces) — fix to "B".
-                if (value is Microsoft.Dynamics.Nav.Runtime.NavGuid ng) return ((Guid)ng).ToString("B").ToUpperInvariant();
                 // NavByte.ToText() — BCL routes through NCLManagedAdapter.ByteToTextChar (OEM native code)
                 // which fails without the BC service tier. Return the numeric string (0-255) instead.
                 if (typeName == "NavByte")
@@ -1528,7 +1529,7 @@ public static class AlCompat
     {
         g = UnwrapVariant(g);
         var format = withBraces ? "B" : "N";
-        if (g is NavGuid ng) return new NavText(((Guid)ng).ToString(format).ToUpperInvariant());
+        if (g is NavGuid ng) return new NavText(ng.ToGuid().ToString(format).ToUpperInvariant());
         if (g is Guid guid) return new NavText(guid.ToString(format).ToUpperInvariant());
         // MockTextBuilder.ALToText() is also routed here — delegate back to preserve correct text.
         if (g is MockTextBuilder mtb) return mtb.ALToText();

--- a/AlRunner/Runtime/AlScope.cs
+++ b/AlRunner/Runtime/AlScope.cs
@@ -832,18 +832,31 @@ public static class AlCompat
             }
             catch { }
         }
-        // NavGuid — check by type name (version-independent) and call ToGuid() via reflection.
-        // Pattern-match on Microsoft.Dynamics.Nav.Runtime.NavGuid is unreliable across BC versions;
-        // typeName check + reflection is defensive. Format "B" = {XXXXXXXX-...} (38 chars, braces).
+        // NavGuid — check by type name (version-independent) and extract the Guid value.
+        // Pattern-match on Microsoft.Dynamics.Nav.Runtime.NavGuid is unreliable across BC versions.
+        // Try multiple extraction strategies; last resort parses ToString() which NavGuid always
+        // returns in "D" (36-char) format. Format "B" = {XXXXXXXX-...} (38 chars, braces).
         if (typeName == "NavGuid")
         {
             try
             {
-                var toGuidMethod = value.GetType().GetMethod("ToGuid");
+                // Try parameterless ToGuid() method
+                var toGuidMethod = value.GetType().GetMethod("ToGuid", Type.EmptyTypes);
                 if (toGuidMethod != null)
                     return ((Guid)toGuidMethod.Invoke(value, null)!).ToString("B").ToUpperInvariant();
             }
             catch { }
+            try
+            {
+                // Try Value property of type Guid
+                var valueProp = value.GetType().GetProperty("Value");
+                if (valueProp?.PropertyType == typeof(Guid))
+                    return ((Guid)valueProp.GetValue(value)!).ToString("B").ToUpperInvariant();
+            }
+            catch { }
+            // Last resort: NavGuid.ToString() always returns a parseable Guid string ("D" format).
+            if (Guid.TryParse(value.ToString(), out var parsedGuid))
+                return parsedGuid.ToString("B").ToUpperInvariant();
         }
         // Handle NavValue subtypes — use ToText() where available, avoid ToString() which may need NavSession
         if (value is Microsoft.Dynamics.Nav.Runtime.NavValue nv)
@@ -1542,6 +1555,26 @@ public static class AlCompat
         if (g is Guid guid) return new NavText(guid.ToString(format).ToUpperInvariant());
         // MockTextBuilder.ALToText() is also routed here — delegate back to preserve correct text.
         if (g is MockTextBuilder mtb) return mtb.ALToText();
+        // NavGuid from a different BC version assembly: use reflection or Guid.TryParse as fallback.
+        if (g != null && g.GetType().Name == "NavGuid")
+        {
+            try
+            {
+                var toGuidMethod = g.GetType().GetMethod("ToGuid", Type.EmptyTypes);
+                if (toGuidMethod != null)
+                    return new NavText(((Guid)toGuidMethod.Invoke(g, null)!).ToString(format).ToUpperInvariant());
+            }
+            catch { }
+            try
+            {
+                var valueProp = g.GetType().GetProperty("Value");
+                if (valueProp?.PropertyType == typeof(Guid))
+                    return new NavText(((Guid)valueProp.GetValue(g)!).ToString(format).ToUpperInvariant());
+            }
+            catch { }
+            if (Guid.TryParse(g.ToString(), out var parsed))
+                return new NavText(parsed.ToString(format).ToUpperInvariant());
+        }
         return new NavText(Format(g)); // fallback for non-Guid types
     }
 

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -2639,7 +2639,7 @@ Guid.CreateSequentialGuid:
 Guid.ToText:
   layer: runtime-api
   category: Guid
-  status: gap
+  status: covered
   notes: overloads=2
 
 # ── HttpClient ──────────────────────────────────────────────────

--- a/tests/bucket-1/85-guid-totext/src/GuidToTextSrc.al
+++ b/tests/bucket-1/85-guid-totext/src/GuidToTextSrc.al
@@ -1,0 +1,33 @@
+/// Helper codeunit exercising Guid.ToText() overloads.
+codeunit 82100 "GT Src"
+{
+    /// Returns g.ToText() — default format with braces and hyphens.
+    procedure ToTextDefault(g: Guid): Text
+    begin
+        exit(g.ToText());
+    end;
+
+    /// Returns g.ToText(false) — format without hyphens or braces.
+    procedure ToTextNoDelimiters(g: Guid): Text
+    begin
+        exit(g.ToText(false));
+    end;
+
+    /// Returns g.ToText(true) — explicit braces-and-hyphens form.
+    procedure ToTextWithDelimiters(g: Guid): Text
+    begin
+        exit(g.ToText(true));
+    end;
+
+    /// Returns length of default ToText() result.
+    procedure DefaultLength(g: Guid): Integer
+    begin
+        exit(StrLen(g.ToText()));
+    end;
+
+    /// Returns length of ToText(false) result.
+    procedure NoDelimLength(g: Guid): Integer
+    begin
+        exit(StrLen(g.ToText(false)));
+    end;
+}

--- a/tests/bucket-1/85-guid-totext/test/GuidToTextTest.al
+++ b/tests/bucket-1/85-guid-totext/test/GuidToTextTest.al
@@ -1,0 +1,125 @@
+codeunit 82101 "GT Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "GT Src";
+
+    // -----------------------------------------------------------------------
+    // Positive: default ToText() — 38 chars with braces and hyphens
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure ToText_Default_Returns38Chars()
+    var
+        g: Guid;
+    begin
+        // Positive: g.ToText() must return exactly 38 characters
+        g := CreateGuid();
+        Assert.AreEqual(38, Src.DefaultLength(g),
+            'Guid.ToText() must return a 38-character string');
+    end;
+
+    [Test]
+    procedure ToText_Default_StartsWithBrace()
+    var
+        g: Guid;
+        Result: Text;
+    begin
+        // Positive: g.ToText() result starts with '{'
+        g := CreateGuid();
+        Result := Src.ToTextDefault(g);
+        Assert.AreEqual('{', Result[1],
+            'Guid.ToText() result must start with {');
+    end;
+
+    [Test]
+    procedure ToText_Default_EndsWithBrace()
+    var
+        g: Guid;
+        Result: Text;
+    begin
+        // Positive: g.ToText() result ends with '}'
+        g := CreateGuid();
+        Result := Src.ToTextDefault(g);
+        Assert.AreEqual('}', Result[StrLen(Result)],
+            'Guid.ToText() result must end with }');
+    end;
+
+    [Test]
+    procedure ToText_ExplicitTrue_Returns38Chars()
+    var
+        g: Guid;
+    begin
+        // Positive: g.ToText(true) must also return 38 characters
+        g := CreateGuid();
+        Assert.AreEqual(38, StrLen(Src.ToTextWithDelimiters(g)),
+            'Guid.ToText(true) must return a 38-character string');
+    end;
+
+    [Test]
+    procedure ToText_DefaultAndExplicitTrue_AreEqual()
+    var
+        g: Guid;
+    begin
+        // Positive: ToText() and ToText(true) must return the same value
+        g := CreateGuid();
+        Assert.AreEqual(Src.ToTextDefault(g), Src.ToTextWithDelimiters(g),
+            'Guid.ToText() and Guid.ToText(true) must return the same string');
+    end;
+
+    // -----------------------------------------------------------------------
+    // Positive: ToText(false) — 32 chars without delimiters
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure ToText_False_Returns32Chars()
+    var
+        g: Guid;
+    begin
+        // Positive: g.ToText(false) must return exactly 32 characters
+        g := CreateGuid();
+        Assert.AreEqual(32, Src.NoDelimLength(g),
+            'Guid.ToText(false) must return a 32-character string');
+    end;
+
+    [Test]
+    procedure ToText_False_NoHyphens()
+    var
+        g: Guid;
+        Result: Text;
+    begin
+        // Positive: g.ToText(false) result has no hyphens
+        g := CreateGuid();
+        Result := Src.ToTextNoDelimiters(g);
+        Assert.AreEqual(0, StrPos(Result, '-'),
+            'Guid.ToText(false) result must contain no hyphens');
+    end;
+
+    // -----------------------------------------------------------------------
+    // Negative: ToText() and ToText(false) differ in length
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure ToText_Default_LongerThanNoDelim()
+    var
+        g: Guid;
+    begin
+        // Negative: default format must be longer than no-delimiter format
+        g := CreateGuid();
+        Assert.IsTrue(Src.DefaultLength(g) > Src.NoDelimLength(g),
+            'Guid.ToText() must be longer than Guid.ToText(false)');
+    end;
+
+    [Test]
+    procedure ToText_Default_NotEqualToNoDelim()
+    var
+        g: Guid;
+    begin
+        // Negative: default and no-delimiter results must differ
+        g := CreateGuid();
+        Assert.AreNotEqual(Src.ToTextDefault(g), Src.ToTextNoDelimiters(g),
+            'Guid.ToText() and Guid.ToText(false) must return different strings');
+    end;
+}


### PR DESCRIPTION
Closes #612

## Changes

- **RoslynRewriter.cs**: Add selective `ALToText` intercept for Guid — BC emits `navGuid.ALToText()` (with AL prefix) wrapped in `new NavText(...)`. Intercept only fires when inside `new NavText(...)` parent context to avoid catching `MockTextBuilder.ALToText()` (which returns `NavText` directly).
- **AlScope.cs**: `AlCompat.GuidToText(g, withBraces)` returns uppercase "B" (38 chars) or "N" (32 chars) format string. `AlCompat.Format(NavGuid)` uses format "B" for the no-arg default.
- **tests/bucket-1/85-guid-totext/**: 8 proving tests: 38-char default, starts/ends with braces, explicit true matches default, 32-char no-delims, no hyphens, length comparison, format inequality.
- **docs/coverage.yaml**: `Guid.ToText` gap → covered.