### PR TITLE
fix: renumber EI Verbosity suite to 83700/83701 (CS0101 collision)

### DIFF
--- a/tests/bucket-1/84-errorinfo-verbosity/src/EIVerbositySrc.al
+++ b/tests/bucket-1/84-errorinfo-verbosity/src/EIVerbositySrc.al
@@ -1,4 +1,4 @@
-codeunit 83600 "EI Verbosity Src"
+codeunit 83700 "EI Verbosity Src"
 {
     procedure SetError_GetIsError(): Boolean
     var

--- a/tests/bucket-1/84-errorinfo-verbosity/test/EIVerbosityTest.al
+++ b/tests/bucket-1/84-errorinfo-verbosity/test/EIVerbosityTest.al
@@ -1,4 +1,4 @@
-codeunit 83601 "EI Verbosity Tests"
+codeunit 83701 "EI Verbosity Tests"
 {
     Subtype = Test;
 


### PR DESCRIPTION
Fixes CS0101 object ID collision in bucket-1.

`83-errorinfo-title` and `84-errorinfo-verbosity` were independently merged with the same codeunit IDs (83600/83601). This causes `error CS0101: The namespace 'NavObjectNamespace' already contains a definition for 'Codeunit_83600'` on all BC versions.

Renumbers the verbosity suite to 83700/83701 to resolve the collision.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>