### PR TITLE
test: Label string-method coverage — 7 methods marked covered

### DIFF
--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -3636,20 +3636,26 @@ KeyRef.Record:
 Label.Contains:
   layer: runtime-api
   category: Label
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; BC native NavTextExtensions.ALContains works standalone when called on Label-typed values.
+  tests:
+    - tests/bucket-2/176-label-methods
 
 Label.EndsWith:
   layer: runtime-api
   category: Label
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; BC native works standalone.
+  tests:
+    - tests/bucket-2/176-label-methods
 
 Label.IndexOf:
   layer: runtime-api
   category: Label
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; BC native works standalone (1-based, 0 when not found).
+  tests:
+    - tests/bucket-2/176-label-methods
 
 Label.IndexOfAny:
   layer: runtime-api
@@ -3684,8 +3690,10 @@ Label.Remove:
 Label.Replace:
   layer: runtime-api
   category: Label
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; BC native works standalone. No-op when substring not found.
+  tests:
+    - tests/bucket-2/176-label-methods
 
 Label.Split:
   layer: runtime-api
@@ -3696,8 +3704,10 @@ Label.Split:
 Label.StartsWith:
   layer: runtime-api
   category: Label
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; BC native works standalone.
+  tests:
+    - tests/bucket-2/176-label-methods
 
 Label.Substring:
   layer: runtime-api
@@ -3708,20 +3718,26 @@ Label.Substring:
 Label.ToLower:
   layer: runtime-api
   category: Label
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; BC native works standalone.
+  tests:
+    - tests/bucket-2/176-label-methods
 
 Label.ToUpper:
   layer: runtime-api
   category: Label
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; BC native works standalone.
+  tests:
+    - tests/bucket-2/176-label-methods
 
 Label.Trim:
   layer: runtime-api
   category: Label
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; BC native works standalone (removes leading/trailing whitespace).
+  tests:
+    - tests/bucket-2/176-label-methods
 
 Label.TrimEnd:
   layer: runtime-api

--- a/tests/bucket-2/176-label-methods/al-runner.json
+++ b/tests/bucket-2/176-label-methods/al-runner.json
@@ -1,0 +1,4 @@
+{
+  "sourcePath": "./src",
+  "testPath": "./test"
+}

--- a/tests/bucket-2/176-label-methods/src/LabelMethodsSrc.al
+++ b/tests/bucket-2/176-label-methods/src/LabelMethodsSrc.al
@@ -1,0 +1,59 @@
+/// Helper codeunit exercising string-manipulation dot-methods on Label values.
+codeunit 60010 "LBM Src"
+{
+    procedure LabelContains(substr: Text): Boolean
+    var
+        lbl: Label 'Hello World';
+    begin
+        exit(lbl.Contains(substr));
+    end;
+
+    procedure LabelStartsWith(prefix: Text): Boolean
+    var
+        lbl: Label 'Hello World';
+    begin
+        exit(lbl.StartsWith(prefix));
+    end;
+
+    procedure LabelEndsWith(suffix: Text): Boolean
+    var
+        lbl: Label 'Hello World';
+    begin
+        exit(lbl.EndsWith(suffix));
+    end;
+
+    procedure LabelToLower(): Text
+    var
+        lbl: Label 'HELLO World';
+    begin
+        exit(lbl.ToLower());
+    end;
+
+    procedure LabelToUpper(): Text
+    var
+        lbl: Label 'Hello world';
+    begin
+        exit(lbl.ToUpper());
+    end;
+
+    procedure LabelTrim(): Text
+    var
+        lbl: Label '  padded  ';
+    begin
+        exit(lbl.Trim());
+    end;
+
+    procedure LabelReplace(oldVal: Text; newVal: Text): Text
+    var
+        lbl: Label 'Hello World';
+    begin
+        exit(lbl.Replace(oldVal, newVal));
+    end;
+
+    procedure LabelIndexOf(sub: Text): Integer
+    var
+        lbl: Label 'Hello World';
+    begin
+        exit(lbl.IndexOf(sub));
+    end;
+}

--- a/tests/bucket-2/176-label-methods/test/LabelMethodsTest.al
+++ b/tests/bucket-2/176-label-methods/test/LabelMethodsTest.al
@@ -1,0 +1,83 @@
+codeunit 60011 "LBM Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "LBM Src";
+
+    [Test]
+    procedure Label_Contains()
+    begin
+        Assert.IsTrue(Src.LabelContains('World'), 'Label.Contains("World") must be true');
+        Assert.IsTrue(Src.LabelContains('Hello'), 'Label.Contains("Hello") must be true');
+        Assert.IsFalse(Src.LabelContains('xyz'), 'Label.Contains("xyz") must be false');
+    end;
+
+    [Test]
+    procedure Label_StartsWith()
+    begin
+        Assert.IsTrue(Src.LabelStartsWith('Hello'), 'Label.StartsWith("Hello") must be true');
+        Assert.IsFalse(Src.LabelStartsWith('World'), 'Label.StartsWith("World") must be false');
+    end;
+
+    [Test]
+    procedure Label_EndsWith()
+    begin
+        Assert.IsTrue(Src.LabelEndsWith('World'), 'Label.EndsWith("World") must be true');
+        Assert.IsFalse(Src.LabelEndsWith('Hello'), 'Label.EndsWith("Hello") must be false');
+    end;
+
+    [Test]
+    procedure Label_ToLower()
+    begin
+        Assert.AreEqual('hello world', Src.LabelToLower(),
+            'Label.ToLower() on "HELLO World" must be "hello world"');
+    end;
+
+    [Test]
+    procedure Label_ToUpper()
+    begin
+        Assert.AreEqual('HELLO WORLD', Src.LabelToUpper(),
+            'Label.ToUpper() on "Hello world" must be "HELLO WORLD"');
+    end;
+
+    [Test]
+    procedure Label_Trim()
+    begin
+        Assert.AreEqual('padded', Src.LabelTrim(),
+            'Label.Trim() on "  padded  " must be "padded"');
+    end;
+
+    [Test]
+    procedure Label_Replace()
+    begin
+        Assert.AreEqual('Hello Earth', Src.LabelReplace('World', 'Earth'),
+            'Label.Replace("World", "Earth") must produce "Hello Earth"');
+    end;
+
+    [Test]
+    procedure Label_Replace_NotFound_Unchanged()
+    begin
+        // Replacing a non-existent substring must leave the original intact.
+        Assert.AreEqual('Hello World', Src.LabelReplace('xyz', 'Earth'),
+            'Label.Replace of non-existent substring must leave text unchanged');
+    end;
+
+    [Test]
+    procedure Label_IndexOf()
+    begin
+        // 'Hello World': H=1, e=2, l=3, l=4, o=5, (space)=6, W=7, o=8, r=9, l=10, d=11
+        Assert.AreEqual(7, Src.LabelIndexOf('World'), 'IndexOf("World") in "Hello World" must be 7');
+        Assert.AreEqual(1, Src.LabelIndexOf('Hello'), 'IndexOf("Hello") must be 1 (1-based)');
+        Assert.AreEqual(0, Src.LabelIndexOf('xyz'), 'IndexOf of non-existent substring must be 0');
+    end;
+
+    [Test]
+    procedure Label_ToLower_NotIdentity_NegativeTrap()
+    begin
+        // Negative: guard against ToLower() returning the raw text (no casing).
+        Assert.AreNotEqual('HELLO World', Src.LabelToLower(),
+            'Label.ToLower() must lower-case, not return raw');
+    end;
+}


### PR DESCRIPTION
Closes #630

BC native NavTextExtensions string methods work standalone on Label-typed values.

- `tests/bucket-2/176-label-methods/` — helper + 10 proving tests for 7 methods (Contains, StartsWith, EndsWith, ToLower, ToUpper, Trim, Replace, IndexOf)
- `docs/coverage.yaml` — 7 `Label.*` entries marked `covered`. Others (Split, Substring, IndexOfAny, LastIndexOf, PadLeft/Right, Remove, TrimEnd/Start) remain `gap` for follow-ups.

10/10 new tests pass. Full bucket-2: 1053 pass (3 pre-existing timezone failures).