### PR TITLE
feat: JsonValue typed conversions — AsBoolean/AsInteger/AsText/AsDecimal/IsNull/SetValue

### DIFF
--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -3469,8 +3469,9 @@ JsonValue.AsBigInteger:
 JsonValue.AsBoolean:
   layer: runtime-api
   category: JsonValue
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; BC native NavJsonValue.ALAsBoolean works standalone
+  test: tests/bucket-1/85-jsonvalue-conversions
 
 JsonValue.AsByte:
   layer: runtime-api
@@ -3505,8 +3506,9 @@ JsonValue.AsDateTime:
 JsonValue.AsDecimal:
   layer: runtime-api
   category: JsonValue
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; BC native NavJsonValue.ALAsDecimal works standalone
+  test: tests/bucket-1/85-jsonvalue-conversions
 
 JsonValue.AsDuration:
   layer: runtime-api
@@ -3517,8 +3519,9 @@ JsonValue.AsDuration:
 JsonValue.AsInteger:
   layer: runtime-api
   category: JsonValue
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; BC native NavJsonValue.ALAsInteger works standalone
+  test: tests/bucket-1/85-jsonvalue-conversions
 
 JsonValue.AsOption:
   layer: runtime-api
@@ -3529,8 +3532,9 @@ JsonValue.AsOption:
 JsonValue.AsText:
   layer: runtime-api
   category: JsonValue
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; BC native NavJsonValue.ALAsText works standalone
+  test: tests/bucket-1/85-jsonvalue-conversions
 
 JsonValue.AsTime:
   layer: runtime-api
@@ -3553,8 +3557,9 @@ JsonValue.Clone:
 JsonValue.IsNull:
   layer: runtime-api
   category: JsonValue
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; BC native NavJsonValue.ALIsNull works standalone
+  test: tests/bucket-1/85-jsonvalue-conversions
 
 JsonValue.IsUndefined:
   layer: runtime-api
@@ -3583,14 +3588,16 @@ JsonValue.SelectToken:
 JsonValue.SetValue:
   layer: runtime-api
   category: JsonValue
-  status: gap
-  notes: overloads=12
+  status: covered
+  notes: overloads=12; text/integer/boolean/decimal overloads proven; BC native works standalone
+  test: tests/bucket-1/85-jsonvalue-conversions
 
 JsonValue.SetValueToNull:
   layer: runtime-api
   category: JsonValue
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; BC native works standalone; verified with IsNull
+  test: tests/bucket-1/85-jsonvalue-conversions
 
 JsonValue.SetValueToUndefined:
   layer: runtime-api

--- a/tests/bucket-1/84-errorinfo-verbosity/src/EIVerbositySrc.al
+++ b/tests/bucket-1/84-errorinfo-verbosity/src/EIVerbositySrc.al
@@ -1,4 +1,4 @@
-codeunit 83600 "EI Verbosity Src"
+codeunit 83700 "EI Verbosity Src"
 {
     procedure SetError_GetIsError(): Boolean
     var

--- a/tests/bucket-1/84-errorinfo-verbosity/test/EIVerbosityTest.al
+++ b/tests/bucket-1/84-errorinfo-verbosity/test/EIVerbosityTest.al
@@ -1,4 +1,4 @@
-codeunit 83601 "EI Verbosity Tests"
+codeunit 83701 "EI Verbosity Tests"
 {
     Subtype = Test;
 

--- a/tests/bucket-1/85-jsonvalue-conversions/src/JVConvSrc.al
+++ b/tests/bucket-1/85-jsonvalue-conversions/src/JVConvSrc.al
@@ -1,0 +1,108 @@
+codeunit 83800 "JV Conv Src"
+{
+    procedure TextRoundTrip(): Text
+    var
+        JV: JsonValue;
+    begin
+        JV.SetValue('hello');
+        exit(JV.AsText());
+    end;
+
+    procedure IntegerRoundTrip(): Integer
+    var
+        JV: JsonValue;
+    begin
+        JV.SetValue(42);
+        exit(JV.AsInteger());
+    end;
+
+    procedure BooleanTrueRoundTrip(): Boolean
+    var
+        JV: JsonValue;
+    begin
+        JV.SetValue(true);
+        exit(JV.AsBoolean());
+    end;
+
+    procedure BooleanFalseRoundTrip(): Boolean
+    var
+        JV: JsonValue;
+    begin
+        JV.SetValue(false);
+        exit(JV.AsBoolean());
+    end;
+
+    procedure DecimalRoundTrip(): Decimal
+    var
+        JV: JsonValue;
+    begin
+        JV.SetValue(3.14);
+        exit(JV.AsDecimal());
+    end;
+
+    procedure NullIsNull(): Boolean
+    var
+        JV: JsonValue;
+    begin
+        JV.SetValueToNull();
+        exit(JV.IsNull());
+    end;
+
+    procedure NonNullIsNotNull(): Boolean
+    var
+        JV: JsonValue;
+    begin
+        JV.SetValue('data');
+        exit(JV.IsNull());
+    end;
+
+    procedure TextFromToken(): Text
+    var
+        JA: JsonArray;
+        JT: JsonToken;
+    begin
+        JA.Add('world');
+        JA.Get(0, JT);
+        exit(JT.AsValue().AsText());
+    end;
+
+    procedure IntegerFromToken(): Integer
+    var
+        JA: JsonArray;
+        JT: JsonToken;
+    begin
+        JA.Add(99);
+        JA.Get(0, JT);
+        exit(JT.AsValue().AsInteger());
+    end;
+
+    procedure BooleanFromToken(): Boolean
+    var
+        JA: JsonArray;
+        JT: JsonToken;
+    begin
+        JA.Add(true);
+        JA.Get(0, JT);
+        exit(JT.AsValue().AsBoolean());
+    end;
+
+    procedure TextFromObjectGet(): Text
+    var
+        JO: JsonObject;
+        JT: JsonToken;
+    begin
+        JO.Add('name', 'Alice');
+        JO.Get('name', JT);
+        exit(JT.AsValue().AsText());
+    end;
+
+    procedure IntegerFromObjectGet(): Integer
+    var
+        JO: JsonObject;
+        JT: JsonToken;
+    begin
+        JO.Add('count', 7);
+        JO.Get('count', JT);
+        exit(JT.AsValue().AsInteger());
+    end;
+}

--- a/tests/bucket-1/85-jsonvalue-conversions/test/JVConvTest.al
+++ b/tests/bucket-1/85-jsonvalue-conversions/test/JVConvTest.al
@@ -1,0 +1,92 @@
+codeunit 83801 "JV Conv Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "JV Conv Src";
+
+    [Test]
+    procedure SetValue_AsText_RoundTrip()
+    begin
+        Assert.AreEqual('hello', Src.TextRoundTrip(), 'SetValue text then AsText must return same value');
+    end;
+
+    [Test]
+    procedure SetValue_AsInteger_RoundTrip()
+    begin
+        Assert.AreEqual(42, Src.IntegerRoundTrip(), 'SetValue integer then AsInteger must return 42');
+    end;
+
+    [Test]
+    procedure SetValue_AsBoolean_True()
+    begin
+        Assert.IsTrue(Src.BooleanTrueRoundTrip(), 'SetValue true then AsBoolean must return true');
+    end;
+
+    [Test]
+    procedure SetValue_AsBoolean_False()
+    begin
+        Assert.IsFalse(Src.BooleanFalseRoundTrip(), 'SetValue false then AsBoolean must return false');
+    end;
+
+    [Test]
+    procedure SetValue_AsDecimal_RoundTrip()
+    var
+        Expected: Decimal;
+    begin
+        Expected := 3.14;
+        Assert.AreEqual(Expected, Src.DecimalRoundTrip(), 'SetValue decimal then AsDecimal must return 3.14');
+    end;
+
+    [Test]
+    procedure SetValueToNull_IsNull_True()
+    begin
+        Assert.IsTrue(Src.NullIsNull(), 'SetValueToNull then IsNull must return true');
+    end;
+
+    [Test]
+    procedure SetValue_IsNull_False()
+    begin
+        Assert.IsFalse(Src.NonNullIsNotNull(), 'SetValue text then IsNull must return false');
+    end;
+
+    [Test]
+    procedure AsText_ViaJsonToken()
+    begin
+        Assert.AreEqual('world', Src.TextFromToken(), 'AsText via JsonArray/JsonToken must return ''world''');
+    end;
+
+    [Test]
+    procedure AsInteger_ViaJsonToken()
+    begin
+        Assert.AreEqual(99, Src.IntegerFromToken(), 'AsInteger via JsonArray/JsonToken must return 99');
+    end;
+
+    [Test]
+    procedure AsBoolean_ViaJsonToken()
+    begin
+        Assert.IsTrue(Src.BooleanFromToken(), 'AsBoolean via JsonArray/JsonToken must return true');
+    end;
+
+    [Test]
+    procedure AsText_ViaJsonObjectGet()
+    begin
+        Assert.AreEqual('Alice', Src.TextFromObjectGet(), 'AsText via JsonObject.Get must return ''Alice''');
+    end;
+
+    [Test]
+    procedure AsInteger_ViaJsonObjectGet()
+    begin
+        Assert.AreEqual(7, Src.IntegerFromObjectGet(), 'AsInteger via JsonObject.Get must return 7');
+    end;
+
+    [Test]
+    procedure AsText_NotEmpty()
+    var
+        JV: JsonValue;
+    begin
+        JV.SetValue('test');
+        Assert.AreNotEqual('', JV.AsText(), 'AsText on set value must not be empty');
+    end;
+}


### PR DESCRIPTION
Closes #629

BC native `NavJsonValue` methods (`ALAsBoolean`, `ALAsInteger`, `ALAsText`, `ALAsDecimal`, `ALIsNull`, `ALSetValue`, `ALSetValueToNull`) all work standalone via the BC runtime DLL — no rewriter rules or mock implementations required.

Adds a comprehensive test suite proving:
- `SetValue`/`AsText` round-trip
- `SetValue`/`AsInteger` round-trip
- `SetValue`/`AsBoolean` round-trip (both true and false)
- `SetValue`/`AsDecimal` round-trip (3.14)
- `SetValueToNull`/`IsNull` → true
- `SetValue`/`IsNull` → false (negative case)
- All three typed accessors via `JsonArray.Get` + `JsonToken.AsValue()`
- AsText and AsInteger via `JsonObject.Get` + `JsonToken.AsValue()`

Updates `docs/coverage.yaml`: `JsonValue.AsBoolean`, `AsDecimal`, `AsInteger`, `AsText`, `IsNull`, `SetValue`, `SetValueToNull` → `status: covered`.