### PR TITLE
feat: NavApp.IsInstalling / IsUnlicensed / IsEntitled stubs

### DIFF
--- a/AlRunner/Runtime/MockNavApp.cs
+++ b/AlRunner/Runtime/MockNavApp.cs
@@ -43,4 +43,22 @@ public static class MockNavApp
     {
         return NavList<NavModuleInfo>.Default;
     }
+
+    /// <summary>
+    /// Returns false — no installation lifecycle exists in standalone mode.
+    /// BC's real implementation returns true only during app installation on a service tier.
+    /// </summary>
+    public static bool ALIsInstalling() => false;
+
+    /// <summary>
+    /// Returns false — no license enforcement is applied in standalone mode.
+    /// BC's real implementation returns true when the app has no valid license.
+    /// </summary>
+    public static bool ALIsUnlicensed() => false;
+
+    /// <summary>
+    /// Returns true — the runner grants full entitlement so all code paths are reachable.
+    /// BC's real implementation returns false when the app is not entitled on the tenant.
+    /// </summary>
+    public static bool ALIsEntitled() => true;
 }

--- a/AlRunner/Runtime/MockNavApp.cs
+++ b/AlRunner/Runtime/MockNavApp.cs
@@ -58,7 +58,12 @@ public static class MockNavApp
 
     /// <summary>
     /// Returns true — the runner grants full entitlement so all code paths are reachable.
-    /// BC's real implementation returns false when the app is not entitled on the tenant.
+    /// BC's real signature: IsEntitled(Id: Text[250] [; AppId: Guid]): Boolean
     /// </summary>
-    public static bool ALIsEntitled() => true;
+    public static bool ALIsEntitled(NavText id) => true;
+
+    /// <summary>
+    /// Overload with optional AppId: IsEntitled(Id: Text[250]; AppId: Guid): Boolean
+    /// </summary>
+    public static bool ALIsEntitled(NavText id, Guid appId) => true;
 }

--- a/AlRunner/Runtime/MockNavApp.cs
+++ b/AlRunner/Runtime/MockNavApp.cs
@@ -46,24 +46,26 @@ public static class MockNavApp
 
     /// <summary>
     /// Returns false — no installation lifecycle exists in standalone mode.
+    /// BC emits this as ALNavAppIsInstalling() (type-prefixed method name).
     /// BC's real implementation returns true only during app installation on a service tier.
     /// </summary>
-    public static bool ALIsInstalling() => false;
+    public static bool ALNavAppIsInstalling() => false;
 
     /// <summary>
     /// Returns false — no license enforcement is applied in standalone mode.
+    /// BC emits this as ALIsUnlicensed(DataError).
     /// BC's real implementation returns true when the app has no valid license.
     /// </summary>
-    public static bool ALIsUnlicensed() => false;
+    public static bool ALIsUnlicensed(DataError errorLevel) => false;
 
     /// <summary>
     /// Returns true — the runner grants full entitlement so all code paths are reachable.
-    /// BC's real signature: IsEntitled(Id: Text[250] [; AppId: Guid]): Boolean
+    /// BC emits this as ALIsEntitled(DataError, NavText [, Guid]).
     /// </summary>
-    public static bool ALIsEntitled(NavText id) => true;
+    public static bool ALIsEntitled(DataError errorLevel, NavText id) => true;
 
     /// <summary>
-    /// Overload with optional AppId: IsEntitled(Id: Text[250]; AppId: Guid): Boolean
+    /// Overload with optional AppId: IsEntitled(Id: Text[250]; AppId: Guid).
     /// </summary>
-    public static bool ALIsEntitled(NavText id, Guid appId) => true;
+    public static bool ALIsEntitled(DataError errorLevel, NavText id, Guid appId) => true;
 }

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -3964,20 +3964,23 @@ NavApp.GetResourceAsText:
 NavApp.IsEntitled:
   layer: runtime-api
   category: NavApp
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; MockNavApp.ALIsEntitled() returns true (always entitled in standalone)
+  test: tests/bucket-1/85-navapp-isinstalling/test/NavAppStatusTest.al
 
 NavApp.IsInstalling:
   layer: runtime-api
   category: NavApp
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; MockNavApp.ALIsInstalling() returns false (no install lifecycle)
+  test: tests/bucket-1/85-navapp-isinstalling/test/NavAppStatusTest.al
 
 NavApp.IsUnlicensed:
   layer: runtime-api
   category: NavApp
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; MockNavApp.ALIsUnlicensed() returns false (no license enforcement)
+  test: tests/bucket-1/85-navapp-isinstalling/test/NavAppStatusTest.al
 
 NavApp.ListResources:
   layer: runtime-api

--- a/tests/bucket-1/85-navapp-isinstalling/src/NavAppStatusSrc.al
+++ b/tests/bucket-1/85-navapp-isinstalling/src/NavAppStatusSrc.al
@@ -12,8 +12,8 @@ codeunit 85000 "NAS Src"
         exit(NavApp.IsUnlicensed());
     end;
 
-    procedure GetIsEntitled(): Boolean
+    procedure GetIsEntitled(EntitlementId: Text): Boolean
     begin
-        exit(NavApp.IsEntitled());
+        exit(NavApp.IsEntitled(EntitlementId));
     end;
 }

--- a/tests/bucket-1/85-navapp-isinstalling/src/NavAppStatusSrc.al
+++ b/tests/bucket-1/85-navapp-isinstalling/src/NavAppStatusSrc.al
@@ -1,0 +1,19 @@
+/// Helper codeunit exercising NavApp.IsInstalling(), NavApp.IsUnlicensed(), NavApp.IsEntitled().
+/// In standalone mode: IsInstalling → false, IsUnlicensed → false, IsEntitled → true.
+codeunit 85000 "NAS Src"
+{
+    procedure GetIsInstalling(): Boolean
+    begin
+        exit(NavApp.IsInstalling());
+    end;
+
+    procedure GetIsUnlicensed(): Boolean
+    begin
+        exit(NavApp.IsUnlicensed());
+    end;
+
+    procedure GetIsEntitled(): Boolean
+    begin
+        exit(NavApp.IsEntitled());
+    end;
+}

--- a/tests/bucket-1/85-navapp-isinstalling/test/NavAppStatusTest.al
+++ b/tests/bucket-1/85-navapp-isinstalling/test/NavAppStatusTest.al
@@ -1,0 +1,69 @@
+codeunit 85001 "NAS Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "NAS Src";
+
+    // -----------------------------------------------------------------------
+    // Positive: NavApp.IsInstalling() must return false in standalone mode —
+    // there is no installation lifecycle without a service tier.
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure IsInstalling_ReturnsFalse()
+    begin
+        // Positive: no installation is in progress in standalone mode.
+        Assert.IsFalse(Src.GetIsInstalling(),
+            'NavApp.IsInstalling() must return false in standalone mode');
+    end;
+
+    // -----------------------------------------------------------------------
+    // Positive: NavApp.IsUnlicensed() must return false in standalone mode —
+    // no license enforcement is applied without a service tier.
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure IsUnlicensed_ReturnsFalse()
+    begin
+        // Positive: standalone mode is never considered unlicensed.
+        Assert.IsFalse(Src.GetIsUnlicensed(),
+            'NavApp.IsUnlicensed() must return false in standalone mode');
+    end;
+
+    // -----------------------------------------------------------------------
+    // Positive: NavApp.IsEntitled() must return true in standalone mode —
+    // the runner grants full entitlement so tests can reach all code paths.
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure IsEntitled_ReturnsTrue()
+    begin
+        // Positive: standalone mode is always considered entitled.
+        Assert.IsTrue(Src.GetIsEntitled(),
+            'NavApp.IsEntitled() must return true in standalone mode');
+    end;
+
+    // -----------------------------------------------------------------------
+    // Negative: the three values are mutually consistent — entitled=true
+    // contradicts unlicensed=true and installing=true simultaneously.
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure StatusFlags_AreConsistent()
+    var
+        IsInstalling: Boolean;
+        IsUnlicensed: Boolean;
+        IsEntitled: Boolean;
+    begin
+        // Negative: if entitled, must not also be unlicensed or installing.
+        IsInstalling := Src.GetIsInstalling();
+        IsUnlicensed := Src.GetIsUnlicensed();
+        IsEntitled := Src.GetIsEntitled();
+
+        Assert.IsTrue(IsEntitled, 'Must be entitled');
+        Assert.IsFalse(IsInstalling, 'Must not be installing when entitled');
+        Assert.IsFalse(IsUnlicensed, 'Must not be unlicensed when entitled');
+    end;
+}

--- a/tests/bucket-1/85-navapp-isinstalling/test/NavAppStatusTest.al
+++ b/tests/bucket-1/85-navapp-isinstalling/test/NavAppStatusTest.al
@@ -40,9 +40,17 @@ codeunit 85001 "NAS Test"
     [Test]
     procedure IsEntitled_ReturnsTrue()
     begin
-        // Positive: standalone mode is always considered entitled.
-        Assert.IsTrue(Src.GetIsEntitled(),
-            'NavApp.IsEntitled() must return true in standalone mode');
+        // Positive: standalone mode is always considered entitled for any entitlement ID.
+        Assert.IsTrue(Src.GetIsEntitled('STANDARD'),
+            'NavApp.IsEntitled(id) must return true in standalone mode');
+    end;
+
+    [Test]
+    procedure IsEntitled_EmptyId_ReturnsTrue()
+    begin
+        // Positive: empty entitlement ID is also accepted — standalone grants all.
+        Assert.IsTrue(Src.GetIsEntitled(''),
+            'NavApp.IsEntitled with empty id must return true in standalone mode');
     end;
 
     // -----------------------------------------------------------------------
@@ -60,7 +68,7 @@ codeunit 85001 "NAS Test"
         // Negative: if entitled, must not also be unlicensed or installing.
         IsInstalling := Src.GetIsInstalling();
         IsUnlicensed := Src.GetIsUnlicensed();
-        IsEntitled := Src.GetIsEntitled();
+        IsEntitled := Src.GetIsEntitled('ANY');
 
         Assert.IsTrue(IsEntitled, 'Must be entitled');
         Assert.IsFalse(IsInstalling, 'Must not be installing when entitled');


### PR DESCRIPTION
Closes #637

Adds `MockNavApp.ALIsInstalling()`, `ALIsUnlicensed()`, and `ALIsEntitled()` stubs so AL code calling these methods compiles and runs in standalone mode.

**Standalone semantics:**
- `IsInstalling()` → `false` — no installation lifecycle without a service tier
- `IsUnlicensed()` → `false` — no license enforcement in standalone mode
- `IsEntitled()` → `true` — always entitled so all code paths are reachable

**Test suite:** `tests/bucket-1/85-navapp-isinstalling/` (codeunits 85000/85001) — 4 tests covering all three return values and their mutual consistency.