### PR TITLE
docs: mark FieldRef enum introspection as covered (#643)

### DIFF
--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -2232,8 +2232,9 @@ FieldRef.Class:
 FieldRef.EnumValueCount:
   layer: runtime-api
   category: FieldRef
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-2/123-fieldref-enum
+  notes: overloads=1. Covered: returns member count for enum fields; returns 0 for non-enum fields.
 
 FieldRef.FieldError:
   layer: runtime-api
@@ -2244,8 +2245,9 @@ FieldRef.FieldError:
 FieldRef.GetEnumValueCaption:
   layer: runtime-api
   category: FieldRef
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-2/123-fieldref-enum
+  notes: overloads=1. Covered: 1-based index → caption. Standalone note — EnumRegistry only captures names, so Caption returns the AL identifier (same as Name).
 
 FieldRef.GetEnumValueCaptionFromOrdinalValue:
   layer: runtime-api
@@ -2256,8 +2258,9 @@ FieldRef.GetEnumValueCaptionFromOrdinalValue:
 FieldRef.GetEnumValueName:
   layer: runtime-api
   category: FieldRef
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-2/123-fieldref-enum
+  notes: overloads=1. Covered: 1-based index → member name; out-of-range throws.
 
 FieldRef.GetEnumValueNameFromOrdinalValue:
   layer: runtime-api
@@ -2268,8 +2271,9 @@ FieldRef.GetEnumValueNameFromOrdinalValue:
 FieldRef.GetEnumValueOrdinal:
   layer: runtime-api
   category: FieldRef
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-2/123-fieldref-enum
+  notes: overloads=1. Covered: 1-based index → ordinal; out-of-range throws.
 
 FieldRef.GetFilter:
   layer: runtime-api


### PR DESCRIPTION
## Summary
- Closes #643
- Suite `tests/bucket-2/123-fieldref-enum` already covers all four `MockFieldRef` enum introspection methods (`EnumValueCount`, `GetEnumValueName`, `GetEnumValueCaption`, `GetEnumValueOrdinal`) with both positive and out-of-range negative cases
- Updates `docs/coverage.yaml` to flip each entry from `gap` → `covered` with a `tests:` pointer. Notes the standalone caveat that EnumRegistry doesn't capture captions separately from names (so `GetEnumValueCaption` returns the AL identifier)

## Test plan
- [x] Suite 123 — 15/15 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)