### PR TITLE
feat: NavApp.GetResourceAsText/GetResourceAsJson/ListResources — no-op stubs

### DIFF
--- a/AlRunner/Runtime/MockNavApp.cs
+++ b/AlRunner/Runtime/MockNavApp.cs
@@ -43,4 +43,31 @@ public static class MockNavApp
     {
         return NavList<NavModuleInfo>.Default;
     }
+
+    /// <summary>
+    /// NavApp.GetResourceAsText(ResourceName, var Text) — no .app in standalone mode,
+    /// leaves the out parameter empty.
+    /// </summary>
+    public static void ALGetResourceAsText(DataError errorLevel, NavText resourceName, ByRef<NavText> text)
+    {
+        text.Value = NavText.Empty;
+    }
+
+    /// <summary>
+    /// NavApp.GetResourceAsJson(ResourceName, var Token) — no .app in standalone mode,
+    /// leaves the out token at its default state.
+    /// </summary>
+    public static void ALGetResourceAsJson(DataError errorLevel, NavText resourceName, ByRef<NavJsonToken> token)
+    {
+        // NavJsonToken default is already an empty/null-backed token — leave it.
+    }
+
+    /// <summary>
+    /// NavApp.ListResources(var ResourceNames) — no .app in standalone mode,
+    /// returns an empty list.
+    /// </summary>
+    public static void ALListResources(DataError errorLevel, ByRef<NavList<NavText>> list)
+    {
+        list.Value = NavList<NavText>.Default;
+    }
 }

--- a/AlRunner/Runtime/MockNavApp.cs
+++ b/AlRunner/Runtime/MockNavApp.cs
@@ -56,14 +56,14 @@ public static class MockNavApp
         => NavText.Empty;
 
     /// <summary>
-    /// NavApp.GetResourceAsJson(ResourceName [, TextEncoding]) : JsonToken — function
-    /// returning the resource as a JSON token. No .app in standalone mode; returns default.
-    /// BC emits: ALNavApp.ALGetResourceAsJson(DataError, NavText [, object?]) → NavJsonToken
+    /// NavApp.GetResourceAsJson(ResourceName [, TextEncoding]) : JsonObject — function
+    /// returning the resource as a JSON object. No .app in standalone mode; returns default.
+    /// BC emits: ALNavApp.ALGetResourceAsJson(DataError, NavText [, object?]) → NavJsonObject
     /// </summary>
-    public static NavJsonToken ALGetResourceAsJson(DataError errorLevel, NavText resourceName)
+    public static NavJsonObject ALGetResourceAsJson(DataError errorLevel, NavText resourceName)
         => default;
 
-    public static NavJsonToken ALGetResourceAsJson(DataError errorLevel, NavText resourceName, object? encoding)
+    public static NavJsonObject ALGetResourceAsJson(DataError errorLevel, NavText resourceName, object? encoding)
         => default;
 
     /// <summary>

--- a/AlRunner/Runtime/MockNavApp.cs
+++ b/AlRunner/Runtime/MockNavApp.cs
@@ -45,28 +45,31 @@ public static class MockNavApp
     }
 
     /// <summary>
-    /// NavApp.GetResourceAsText(ResourceName, var Text) — no .app in standalone mode,
-    /// leaves the out parameter empty.
+    /// NavApp.GetResourceAsText(ResourceName, TextEncoding, var Text) — no .app in
+    /// standalone mode, leaves the out parameter empty.
+    /// BC emits: ALNavApp.ALGetResourceAsText(DataError, NavText, TextEncoding, ByRef&lt;NavText&gt;)
     /// </summary>
-    public static void ALGetResourceAsText(DataError errorLevel, NavText resourceName, ByRef<NavText> text)
+    public static void ALGetResourceAsText(DataError errorLevel, NavText resourceName, object? encoding, ByRef<NavText> text)
     {
         text.Value = NavText.Empty;
     }
 
     /// <summary>
-    /// NavApp.GetResourceAsJson(ResourceName, var Token) — no .app in standalone mode,
-    /// leaves the out token at its default state.
+    /// NavApp.GetResourceAsJson(ResourceName, TextEncoding, var Token) — no .app in
+    /// standalone mode, leaves the out token at its default state.
+    /// BC emits: ALNavApp.ALGetResourceAsJson(DataError, NavText, TextEncoding, ByRef&lt;NavJsonToken&gt;)
     /// </summary>
-    public static void ALGetResourceAsJson(DataError errorLevel, NavText resourceName, ByRef<NavJsonToken> token)
+    public static void ALGetResourceAsJson(DataError errorLevel, NavText resourceName, object? encoding, ByRef<NavJsonToken> token)
     {
         // NavJsonToken default is already an empty/null-backed token — leave it.
     }
 
     /// <summary>
-    /// NavApp.ListResources(var ResourceNames) — no .app in standalone mode,
+    /// NavApp.ListResources(ResourceType, var ResourceNames) — no .app in standalone mode,
     /// returns an empty list.
+    /// BC emits: ALNavApp.ALListResources(DataError, NavText, ByRef&lt;NavList&lt;NavText&gt;&gt;)
     /// </summary>
-    public static void ALListResources(DataError errorLevel, ByRef<NavList<NavText>> list)
+    public static void ALListResources(DataError errorLevel, NavText resourceType, ByRef<NavList<NavText>> list)
     {
         list.Value = NavList<NavText>.Default;
     }

--- a/AlRunner/Runtime/MockNavApp.cs
+++ b/AlRunner/Runtime/MockNavApp.cs
@@ -45,32 +45,35 @@ public static class MockNavApp
     }
 
     /// <summary>
-    /// NavApp.GetResourceAsText(ResourceName, TextEncoding, var Text) — no .app in
-    /// standalone mode, leaves the out parameter empty.
-    /// BC emits: ALNavApp.ALGetResourceAsText(DataError, NavText, TextEncoding, ByRef&lt;NavText&gt;)
+    /// NavApp.GetResourceAsText(ResourceName [, TextEncoding]) : Text — function returning
+    /// the resource as a string. No .app in standalone mode; returns empty string.
+    /// BC emits: ALNavApp.ALGetResourceAsText(DataError, NavText [, object?]) → NavText
     /// </summary>
-    public static void ALGetResourceAsText(DataError errorLevel, NavText resourceName, object? encoding, ByRef<NavText> text)
-    {
-        text.Value = NavText.Empty;
-    }
+    public static NavText ALGetResourceAsText(DataError errorLevel, NavText resourceName)
+        => NavText.Empty;
+
+    public static NavText ALGetResourceAsText(DataError errorLevel, NavText resourceName, object? encoding)
+        => NavText.Empty;
 
     /// <summary>
-    /// NavApp.GetResourceAsJson(ResourceName, TextEncoding, var Token) — no .app in
-    /// standalone mode, leaves the out token at its default state.
-    /// BC emits: ALNavApp.ALGetResourceAsJson(DataError, NavText, TextEncoding, ByRef&lt;NavJsonToken&gt;)
+    /// NavApp.GetResourceAsJson(ResourceName [, TextEncoding]) : JsonToken — function
+    /// returning the resource as a JSON token. No .app in standalone mode; returns default.
+    /// BC emits: ALNavApp.ALGetResourceAsJson(DataError, NavText [, object?]) → NavJsonToken
     /// </summary>
-    public static void ALGetResourceAsJson(DataError errorLevel, NavText resourceName, object? encoding, ByRef<NavJsonToken> token)
-    {
-        // NavJsonToken default is already an empty/null-backed token — leave it.
-    }
+    public static NavJsonToken ALGetResourceAsJson(DataError errorLevel, NavText resourceName)
+        => default;
+
+    public static NavJsonToken ALGetResourceAsJson(DataError errorLevel, NavText resourceName, object? encoding)
+        => default;
 
     /// <summary>
-    /// NavApp.ListResources(ResourceType, var ResourceNames) — no .app in standalone mode,
-    /// returns an empty list.
-    /// BC emits: ALNavApp.ALListResources(DataError, NavText, ByRef&lt;NavList&lt;NavText&gt;&gt;)
+    /// NavApp.ListResources([ResourceType]) : List of [Text] — function returning
+    /// resource names. No .app in standalone mode; returns empty list.
+    /// BC emits: ALNavApp.ALListResources(DataError [, NavText]) → NavList&lt;NavText&gt;
     /// </summary>
-    public static void ALListResources(DataError errorLevel, NavText resourceType, ByRef<NavList<NavText>> list)
-    {
-        list.Value = NavList<NavText>.Default;
-    }
+    public static NavList<NavText> ALListResources(DataError errorLevel)
+        => NavList<NavText>.Default;
+
+    public static NavList<NavText> ALListResources(DataError errorLevel, NavText resourceType)
+        => NavList<NavText>.Default;
 }

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -3952,14 +3952,16 @@ NavApp.GetResource:
 NavApp.GetResourceAsJson:
   layer: runtime-api
   category: NavApp
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-1/267-navapp-resources
+  notes: overloads=1; no-op stub in MockNavApp.ALGetResourceAsJson — leaves token at default in standalone mode
 
 NavApp.GetResourceAsText:
   layer: runtime-api
   category: NavApp
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-1/267-navapp-resources
+  notes: overloads=1; no-op stub in MockNavApp.ALGetResourceAsText — sets text to empty in standalone mode
 
 NavApp.IsEntitled:
   layer: runtime-api
@@ -3982,8 +3984,9 @@ NavApp.IsUnlicensed:
 NavApp.ListResources:
   layer: runtime-api
   category: NavApp
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-1/267-navapp-resources
+  notes: overloads=1; no-op stub in MockNavApp.ALListResources — returns empty list in standalone mode
 
 NavApp.LoadPackageData:
   layer: runtime-api

--- a/tests/bucket-1/267-navapp-resources/src/NavAppResourceSrc.al
+++ b/tests/bucket-1/267-navapp-resources/src/NavAppResourceSrc.al
@@ -1,0 +1,27 @@
+/// Helper codeunit that exercises NavApp resource methods in standalone mode.
+codeunit 85000 "NavApp Resource Src"
+{
+    procedure GetTextResource(ResourceName: Text): Text
+    var
+        ResourceText: Text;
+    begin
+        NavApp.GetResourceAsText(ResourceName, ResourceText);
+        exit(ResourceText);
+    end;
+
+    procedure GetJsonResource(ResourceName: Text): JsonToken
+    var
+        Token: JsonToken;
+    begin
+        NavApp.GetResourceAsJson(ResourceName, Token);
+        exit(Token);
+    end;
+
+    procedure ListAllResources(): Integer
+    var
+        ResourceList: List of [Text];
+    begin
+        NavApp.ListResources(ResourceList);
+        exit(ResourceList.Count());
+    end;
+}

--- a/tests/bucket-1/267-navapp-resources/src/NavAppResourceSrc.al
+++ b/tests/bucket-1/267-navapp-resources/src/NavAppResourceSrc.al
@@ -6,7 +6,7 @@ codeunit 85000 "NavApp Resource Src"
         exit(NavApp.GetResourceAsText(ResourceName));
     end;
 
-    procedure GetJsonResource(ResourceName: Text): JsonToken
+    procedure GetJsonResource(ResourceName: Text): JsonObject
     begin
         exit(NavApp.GetResourceAsJson(ResourceName));
     end;

--- a/tests/bucket-1/267-navapp-resources/src/NavAppResourceSrc.al
+++ b/tests/bucket-1/267-navapp-resources/src/NavAppResourceSrc.al
@@ -2,26 +2,20 @@
 codeunit 85000 "NavApp Resource Src"
 {
     procedure GetTextResource(ResourceName: Text): Text
-    var
-        ResourceText: Text;
     begin
-        NavApp.GetResourceAsText(ResourceName, TextEncoding::UTF8, ResourceText);
-        exit(ResourceText);
+        exit(NavApp.GetResourceAsText(ResourceName));
     end;
 
     procedure GetJsonResource(ResourceName: Text): JsonToken
-    var
-        Token: JsonToken;
     begin
-        NavApp.GetResourceAsJson(ResourceName, TextEncoding::UTF8, Token);
-        exit(Token);
+        exit(NavApp.GetResourceAsJson(ResourceName));
     end;
 
     procedure ListAllResources(): Integer
     var
         ResourceList: List of [Text];
     begin
-        NavApp.ListResources('', ResourceList);
+        ResourceList := NavApp.ListResources();
         exit(ResourceList.Count());
     end;
 }

--- a/tests/bucket-1/267-navapp-resources/src/NavAppResourceSrc.al
+++ b/tests/bucket-1/267-navapp-resources/src/NavAppResourceSrc.al
@@ -5,7 +5,7 @@ codeunit 85000 "NavApp Resource Src"
     var
         ResourceText: Text;
     begin
-        NavApp.GetResourceAsText(ResourceName, ResourceText);
+        NavApp.GetResourceAsText(ResourceName, TextEncoding::UTF8, ResourceText);
         exit(ResourceText);
     end;
 
@@ -13,7 +13,7 @@ codeunit 85000 "NavApp Resource Src"
     var
         Token: JsonToken;
     begin
-        NavApp.GetResourceAsJson(ResourceName, Token);
+        NavApp.GetResourceAsJson(ResourceName, TextEncoding::UTF8, Token);
         exit(Token);
     end;
 
@@ -21,7 +21,7 @@ codeunit 85000 "NavApp Resource Src"
     var
         ResourceList: List of [Text];
     begin
-        NavApp.ListResources(ResourceList);
+        NavApp.ListResources('', ResourceList);
         exit(ResourceList.Count());
     end;
 }

--- a/tests/bucket-1/267-navapp-resources/test/NavAppResourceTest.al
+++ b/tests/bucket-1/267-navapp-resources/test/NavAppResourceTest.al
@@ -1,3 +1,4 @@
+/// Tests for NavApp resource method stubs (GetResourceAsText, GetResourceAsJson, ListResources).
 codeunit 85001 "NavApp Resource Test"
 {
     Subtype = Test;

--- a/tests/bucket-1/267-navapp-resources/test/NavAppResourceTest.al
+++ b/tests/bucket-1/267-navapp-resources/test/NavAppResourceTest.al
@@ -26,13 +26,12 @@ codeunit 85001 "NavApp Resource Test"
     procedure GetResourceAsJson_MissingResource_ReturnsEmpty()
     var
         Src: Codeunit "NavApp Resource Src";
-        Token: JsonToken;
+        Obj: JsonObject;
     begin
         // [GIVEN] No .app is loaded
         // [WHEN] GetResourceAsJson is called for a non-existent resource
-        Token := Src.GetJsonResource('nonexistent.json');
-        // [THEN] Returns a default/empty token — no exception
-        // Token should be a value type that can be assigned without error
+        Obj := Src.GetJsonResource('nonexistent.json');
+        // [THEN] Returns a default/empty JsonObject — no exception
         Assert.IsTrue(true, 'GetResourceAsJson must not throw for missing resource in standalone mode');
     end;
 

--- a/tests/bucket-1/267-navapp-resources/test/NavAppResourceTest.al
+++ b/tests/bucket-1/267-navapp-resources/test/NavAppResourceTest.al
@@ -1,0 +1,66 @@
+codeunit 85001 "NavApp Resource Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    // ------------------------------------------------------------------
+    // Positive: methods return safe defaults in standalone mode.
+    // ------------------------------------------------------------------
+
+    [Test]
+    procedure GetResourceAsText_MissingResource_ReturnsEmpty()
+    var
+        Src: Codeunit "NavApp Resource Src";
+        Result: Text;
+    begin
+        // [GIVEN] No .app is loaded (standalone mode)
+        // [WHEN] GetResourceAsText is called for a non-existent resource
+        Result := Src.GetTextResource('nonexistent.txt');
+        // [THEN] Returns empty string — no exception
+        Assert.AreEqual('', Result, 'GetResourceAsText must return empty string for missing resource in standalone mode');
+    end;
+
+    [Test]
+    procedure GetResourceAsJson_MissingResource_ReturnsEmpty()
+    var
+        Src: Codeunit "NavApp Resource Src";
+        Token: JsonToken;
+    begin
+        // [GIVEN] No .app is loaded
+        // [WHEN] GetResourceAsJson is called for a non-existent resource
+        Token := Src.GetJsonResource('nonexistent.json');
+        // [THEN] Returns a default/empty token — no exception
+        // Token should be a value type that can be assigned without error
+        Assert.IsTrue(true, 'GetResourceAsJson must not throw for missing resource in standalone mode');
+    end;
+
+    [Test]
+    procedure ListResources_ReturnsEmpty()
+    var
+        Src: Codeunit "NavApp Resource Src";
+    begin
+        // [GIVEN] No .app is loaded
+        // [WHEN] ListResources is called
+        // [THEN] Returns 0 resources — no exception
+        Assert.AreEqual(0, Src.ListAllResources(), 'ListResources must return empty list in standalone mode');
+    end;
+
+    // ------------------------------------------------------------------
+    // Negative: calling twice still returns empty (no state leak).
+    // ------------------------------------------------------------------
+
+    [Test]
+    procedure GetResourceAsText_CalledTwice_BothReturnEmpty()
+    var
+        Src: Codeunit "NavApp Resource Src";
+        R1: Text;
+        R2: Text;
+    begin
+        R1 := Src.GetTextResource('a.txt');
+        R2 := Src.GetTextResource('b.txt');
+        Assert.AreEqual('', R1, 'First call must return empty');
+        Assert.AreEqual('', R2, 'Second call must return empty');
+    end;
+}


### PR DESCRIPTION
Closes #636

Implements no-op stubs for the three NavApp resource methods:
- `NavApp.GetResourceAsText(ResourceName [, TextEncoding]) : Text` → returns empty string
- `NavApp.GetResourceAsJson(ResourceName [, TextEncoding]) : JsonObject` → returns default JsonObject
- `NavApp.ListResources([ResourceType]) : List of [Text]` → returns empty list

Standalone mode has no `.app` bundle, so all three return safe defaults matching BC's contract (false/empty = "not found").

Also adds `InStream.EOS()` support — BC emits `inStream.ALEOS()` and the mock now exposes `ALEOS()`.

Tests in bucket-1/266-instream-eos and bucket-1/267-navapp-resources.