### PR TITLE
feat: System.Abs / Power / Round — proving tests + 1-arg Round fix (#211)

### DIFF
--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -2915,6 +2915,21 @@ public void ClearApplicationMemberVariables() { }
                         SyntaxFactory.IdentifierName(methodName)));
             }
 
+            // ALSystemNumeric.ALRound(v) single-arg -> AlCompat.ALRound(v)
+            // The BC SDK's 1-arg overload defaults precision to 0 (no rounding).
+            // AL semantics are that Round(v) rounds to the nearest integer, so we
+            // redirect to our own helper. The 2-arg and 3-arg overloads already
+            // behave correctly and stay on ALSystemNumeric.
+            if (exprText == "ALSystemNumeric" && methodName == "ALRound"
+                && visited.ArgumentList.Arguments.Count == 1)
+            {
+                return visited.WithExpression(
+                    SyntaxFactory.MemberAccessExpression(
+                        SyntaxKind.SimpleMemberAccessExpression,
+                        SyntaxFactory.IdentifierName("AlCompat"),
+                        SyntaxFactory.IdentifierName("ALRound")));
+            }
+
             // value.ALByValue(this) -> value  (strip ITreeObject calls)
             // value.ModifyLength(N) -> value  (strip length modification)
             if (StripITreeObjectArgMethods.Contains(methodName))

--- a/AlRunner/Runtime/AlScope.cs
+++ b/AlRunner/Runtime/AlScope.cs
@@ -1471,6 +1471,18 @@ public static class AlCompat
         return _random.Next(1, maxNumber + 1);
     }
 
+    /// <summary>
+    /// Replacement for ALSystemNumeric.ALRound(v) single-arg — the BC SDK's 1-arg
+    /// overload defaults precision to 0 (no rounding), which diverges from AL's
+    /// documented behaviour where Round(v) rounds to the nearest integer.
+    /// Uses AwayFromZero so 3.5 -> 4 and -3.5 -> -4, matching AL semantics.
+    /// </summary>
+    public static Decimal18 ALRound(Decimal18 v)
+    {
+        decimal rounded = Math.Round((decimal)v, 0, MidpointRounding.AwayFromZero);
+        return new Decimal18(rounded);
+    }
+
     // -----------------------------------------------------------------------
     // GUID creation helpers
     // -----------------------------------------------------------------------

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -5472,8 +5472,9 @@ SessionSettings.TimeZone:
 System.Abs:
   layer: runtime-api
   category: System
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-2/178-math-abs-power-round
+  notes: overloads=1. Covered via ALSystemNumeric.ALAbs (integer + decimal, positive/negative/zero).
 
 System.ApplicationPath:
   layer: runtime-api
@@ -5825,8 +5826,9 @@ System.NormalDate:
 System.Power:
   layer: runtime-api
   category: System
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-2/178-math-abs-power-round
+  notes: overloads=1. Covered via ALSystemNumeric.ALPower (integer exponent, fractional/sqrt, negative base, zero exponent).
 
 System.Random:
   layer: runtime-api
@@ -5843,8 +5845,9 @@ System.Randomize:
 System.Round:
   layer: runtime-api
   category: System
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-2/178-math-abs-power-round
+  notes: overloads=3 (1-arg/2-arg/3-arg). 1-arg form is redirected to AlCompat.ALRound because the BC SDK's 1-arg overload defaults precision to 0 (no rounding), while AL semantics round to nearest integer.
 
 System.RoundDateTime:
   layer: runtime-api

--- a/tests/bucket-2/178-math-abs-power-round/al-runner.json
+++ b/tests/bucket-2/178-math-abs-power-round/al-runner.json
@@ -1,0 +1,4 @@
+{
+  "sourcePath": "./src",
+  "testPath": "./test"
+}

--- a/tests/bucket-2/178-math-abs-power-round/src/MathAbsPowerRoundSrc.al
+++ b/tests/bucket-2/178-math-abs-power-round/src/MathAbsPowerRoundSrc.al
@@ -1,0 +1,34 @@
+/// Helper codeunit exercising the global AL math functions Abs, Power, Round.
+codeunit 60030 "MATH Src"
+{
+    procedure AbsDecimal(v: Decimal): Decimal
+    begin
+        exit(Abs(v));
+    end;
+
+    procedure AbsInteger(v: Integer): Integer
+    begin
+        exit(Abs(v));
+    end;
+
+    procedure PowerIt(base: Decimal; exponent: Decimal): Decimal
+    begin
+        exit(Power(base, exponent));
+    end;
+
+    procedure RoundTwoArg(v: Decimal; precision: Decimal): Decimal
+    begin
+        exit(Round(v, precision));
+    end;
+
+    procedure RoundThreeArg(v: Decimal; precision: Decimal; direction: Text[1]): Decimal
+    begin
+        exit(Round(v, precision, direction));
+    end;
+
+    procedure RoundOneArg(v: Decimal): Decimal
+    begin
+        // Default precision is 1 (rounds to nearest integer as Decimal).
+        exit(Round(v));
+    end;
+}

--- a/tests/bucket-2/178-math-abs-power-round/test/MathAbsPowerRoundTest.al
+++ b/tests/bucket-2/178-math-abs-power-round/test/MathAbsPowerRoundTest.al
@@ -1,0 +1,153 @@
+codeunit 60031 "MATH Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "MATH Src";
+
+    // --- Abs ---
+
+    [Test]
+    procedure Abs_Negative_Decimal()
+    begin
+        Assert.AreEqual(42.5, Src.AbsDecimal(-42.5), 'Abs(-42.5) must be 42.5');
+    end;
+
+    [Test]
+    procedure Abs_Positive_Decimal()
+    begin
+        Assert.AreEqual(7.25, Src.AbsDecimal(7.25), 'Abs(7.25) must be 7.25');
+    end;
+
+    [Test]
+    procedure Abs_Zero_Decimal()
+    begin
+        Assert.AreEqual(0, Src.AbsDecimal(0), 'Abs(0) must be 0');
+    end;
+
+    [Test]
+    procedure Abs_Negative_Integer()
+    begin
+        Assert.AreEqual(5, Src.AbsInteger(-5), 'Abs(-5) must be 5');
+    end;
+
+    [Test]
+    procedure Abs_MaxInt()
+    begin
+        // Negative trap: if Abs were a no-op the call would return -5.
+        Assert.AreNotEqual(-5, Src.AbsInteger(-5),
+            'Abs must not leave a negative value negative');
+    end;
+
+    // --- Power ---
+
+    [Test]
+    procedure Power_Squared()
+    begin
+        Assert.AreEqual(16, Src.PowerIt(4, 2), '4^2 = 16');
+    end;
+
+    [Test]
+    procedure Power_TwoToTheTen()
+    begin
+        Assert.AreEqual(1024, Src.PowerIt(2, 10), '2^10 = 1024');
+    end;
+
+    [Test]
+    procedure Power_ZeroExponent()
+    begin
+        // Any non-zero base to the 0 power is 1.
+        Assert.AreEqual(1, Src.PowerIt(7.5, 0), 'x^0 = 1');
+    end;
+
+    [Test]
+    procedure Power_FractionalExponent()
+    begin
+        // 9^0.5 = 3 (square root).
+        Assert.AreEqual(3, Src.PowerIt(9, 0.5), 'sqrt(9) via Power(9, 0.5) = 3');
+    end;
+
+    [Test]
+    procedure Power_NegativeBase()
+    begin
+        // (-2)^3 = -8 — preserves sign for integer exponents.
+        Assert.AreEqual(-8, Src.PowerIt(-2, 3), '(-2)^3 = -8');
+    end;
+
+    [Test]
+    procedure Power_NotJustMultiplication()
+    begin
+        // Negative trap: make sure the impl doesn't just return base*exponent.
+        Assert.AreNotEqual(20, Src.PowerIt(4, 5),
+            'Power must not return base*exponent (would be 20)');
+    end;
+
+    // --- Round ---
+
+    [Test]
+    procedure Round_TwoArg_RoundsUp()
+    begin
+        // 3.456 rounded to 0.01 precision → 3.46 (half-even / standard rounding).
+        Assert.AreEqual(3.46, Src.RoundTwoArg(3.456, 0.01), 'Round(3.456, 0.01) = 3.46');
+    end;
+
+    [Test]
+    procedure Round_TwoArg_RoundsDown()
+    begin
+        Assert.AreEqual(3.45, Src.RoundTwoArg(3.454, 0.01), 'Round(3.454, 0.01) = 3.45');
+    end;
+
+    [Test]
+    procedure Round_OneArg_ToInteger()
+    begin
+        Assert.AreEqual(4, Src.RoundOneArg(3.7), 'Round(3.7) = 4');
+    end;
+
+    [Test]
+    procedure Round_ThreeArg_Up()
+    begin
+        // Direction '>' forces round-up.
+        Assert.AreEqual(3.46, Src.RoundThreeArg(3.451, 0.01, '>'),
+            'Round(3.451, 0.01, ''>'') forces rounding up to 3.46');
+    end;
+
+    [Test]
+    procedure Round_ThreeArg_Down()
+    begin
+        // Direction '<' forces round-down.
+        Assert.AreEqual(3.45, Src.RoundThreeArg(3.459, 0.01, '<'),
+            'Round(3.459, 0.01, ''<'') forces rounding down to 3.45');
+    end;
+
+    [Test]
+    procedure Round_ThreeArg_Nearest()
+    begin
+        // Direction '=' is standard nearest-rounding.
+        Assert.AreEqual(3.46, Src.RoundThreeArg(3.456, 0.01, '='),
+            'Round(3.456, 0.01, ''='') = 3.46');
+    end;
+
+    [Test]
+    procedure Round_Precision10()
+    begin
+        // Coarser precision: 347 rounds to 350 with precision 10.
+        Assert.AreEqual(350, Src.RoundTwoArg(347, 10), 'Round(347, 10) = 350');
+    end;
+
+    [Test]
+    procedure Round_NegativeValue()
+    begin
+        Assert.AreEqual(-3.46, Src.RoundTwoArg(-3.456, 0.01),
+            'Round(-3.456, 0.01) = -3.46');
+    end;
+
+    [Test]
+    procedure Round_IsNotTruncation()
+    begin
+        // Negative trap: guard against Round being implemented as integer truncation.
+        // 3.7 truncated = 3, but rounded = 4.
+        Assert.AreNotEqual(3, Src.RoundOneArg(3.7),
+            'Round(3.7) must not truncate to 3');
+    end;
+}


### PR DESCRIPTION
## Summary
- Closes #211
- `Abs(v)` and `Power(b, e)` already worked end-to-end via the BC SDK's `ALSystemNumeric` helpers — this PR adds the first proving tests for them
- Fixes `Round(v)` single-arg: the BC SDK's 1-arg `ALSystemNumeric.ALRound` defaults precision to `0` (no rounding), so `Round(3.7)` returned `3.7`. Rewriter now redirects single-arg calls to `AlCompat.ALRound`, which uses `Math.Round` with `AwayFromZero` to match AL semantics. 2-arg and 3-arg forms untouched (they already behave correctly).
- New suite `tests/bucket-2/178-math-abs-power-round` — 20 tests covering positive, negative, zero, fractional exponent, negative base, three direction forms for Round, plus "not-a-no-op" traps on Abs/Power/Round.

## Test plan
- [x] New suite — 20/20 pass
- [x] bucket-2 regression — 1094 pass, 3 pre-existing timezone failures (unrelated)
- [x] bucket-1 regression — 751 pass, 4 pre-existing timezone failures (unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)