### PR TITLE
feat: NavApp.GetResourceAsText/GetResourceAsJson/ListResources — no-op stubs

### DIFF
--- a/AlRunner/Runtime/MockNavApp.cs
+++ b/AlRunner/Runtime/MockNavApp.cs
@@ -72,33 +72,34 @@ public static class MockNavApp
     /// <summary>
     /// NavApp.GetResourceAsText(ResourceName [, TextEncoding]) : Text — returns the named
     /// embedded resource as a string. No .app bundle in standalone mode; returns empty string.
-    /// BC emits: ALNavApp.ALGetResourceAsText(DataError, NavText [, object?]) → NavText
+    /// BC emits: ALNavApp.ALGetResourceAsText(null, NavText [, object?]) → NavText
+    /// (The error-level arg is null in BC's generated C# for resource methods.)
     /// </summary>
-    public static NavText ALGetResourceAsText(DataError errorLevel, NavText resourceName)
+    public static NavText ALGetResourceAsText(object? errorLevel, NavText resourceName)
         => NavText.Empty;
 
-    public static NavText ALGetResourceAsText(DataError errorLevel, NavText resourceName, object? encoding)
+    public static NavText ALGetResourceAsText(object? errorLevel, NavText resourceName, object? encoding)
         => NavText.Empty;
 
     /// <summary>
     /// NavApp.GetResourceAsJson(ResourceName [, TextEncoding]) : JsonObject — returns the
     /// named embedded resource as a JSON object. No .app in standalone mode; returns default.
-    /// BC emits: ALNavApp.ALGetResourceAsJson(DataError, NavText [, object?]) → NavJsonObject
+    /// BC emits: ALNavApp.ALGetResourceAsJson(null, NavText [, object?]) → NavJsonObject
     /// </summary>
-    public static NavJsonObject ALGetResourceAsJson(DataError errorLevel, NavText resourceName)
+    public static NavJsonObject ALGetResourceAsJson(object? errorLevel, NavText resourceName)
         => default;
 
-    public static NavJsonObject ALGetResourceAsJson(DataError errorLevel, NavText resourceName, object? encoding)
+    public static NavJsonObject ALGetResourceAsJson(object? errorLevel, NavText resourceName, object? encoding)
         => default;
 
     /// <summary>
     /// NavApp.ListResources([ResourceType]) : List of [Text] — returns names of embedded
     /// resources. No .app in standalone mode; returns empty list.
-    /// BC emits: ALNavApp.ALListResources(DataError [, NavText]) → NavList&lt;NavText&gt;
+    /// BC emits: ALNavApp.ALListResources(null [, NavText]) → NavList&lt;NavText&gt;
     /// </summary>
-    public static NavList<NavText> ALListResources(DataError errorLevel)
+    public static NavList<NavText> ALListResources(object? errorLevel)
         => NavList<NavText>.Default;
 
-    public static NavList<NavText> ALListResources(DataError errorLevel, NavText resourceType)
+    public static NavList<NavText> ALListResources(object? errorLevel, NavText resourceType)
         => NavList<NavText>.Default;
 }

--- a/AlRunner/Runtime/MockNavApp.cs
+++ b/AlRunner/Runtime/MockNavApp.cs
@@ -68,4 +68,37 @@ public static class MockNavApp
     /// Overload with optional AppId: IsEntitled(Id: Text[250]; AppId: Guid).
     /// </summary>
     public static bool ALIsEntitled(DataError errorLevel, NavText id, Guid appId) => true;
+
+    /// <summary>
+    /// NavApp.GetResourceAsText(ResourceName [, TextEncoding]) : Text — returns the named
+    /// embedded resource as a string. No .app bundle in standalone mode; returns empty string.
+    /// BC emits: ALNavApp.ALGetResourceAsText(DataError, NavText [, object?]) → NavText
+    /// </summary>
+    public static NavText ALGetResourceAsText(DataError errorLevel, NavText resourceName)
+        => NavText.Empty;
+
+    public static NavText ALGetResourceAsText(DataError errorLevel, NavText resourceName, object? encoding)
+        => NavText.Empty;
+
+    /// <summary>
+    /// NavApp.GetResourceAsJson(ResourceName [, TextEncoding]) : JsonToken — returns the
+    /// named embedded resource as a JSON token. No .app in standalone mode; returns default.
+    /// BC emits: ALNavApp.ALGetResourceAsJson(DataError, NavText [, object?]) → NavJsonToken
+    /// </summary>
+    public static NavJsonToken ALGetResourceAsJson(DataError errorLevel, NavText resourceName)
+        => default;
+
+    public static NavJsonToken ALGetResourceAsJson(DataError errorLevel, NavText resourceName, object? encoding)
+        => default;
+
+    /// <summary>
+    /// NavApp.ListResources([ResourceType]) : List of [Text] — returns names of embedded
+    /// resources. No .app in standalone mode; returns empty list.
+    /// BC emits: ALNavApp.ALListResources(DataError [, NavText]) → NavList&lt;NavText&gt;
+    /// </summary>
+    public static NavList<NavText> ALListResources(DataError errorLevel)
+        => NavList<NavText>.Default;
+
+    public static NavList<NavText> ALListResources(DataError errorLevel, NavText resourceType)
+        => NavList<NavText>.Default;
 }

--- a/AlRunner/Runtime/MockNavApp.cs
+++ b/AlRunner/Runtime/MockNavApp.cs
@@ -81,14 +81,14 @@ public static class MockNavApp
         => NavText.Empty;
 
     /// <summary>
-    /// NavApp.GetResourceAsJson(ResourceName [, TextEncoding]) : JsonToken — returns the
-    /// named embedded resource as a JSON token. No .app in standalone mode; returns default.
-    /// BC emits: ALNavApp.ALGetResourceAsJson(DataError, NavText [, object?]) → NavJsonToken
+    /// NavApp.GetResourceAsJson(ResourceName [, TextEncoding]) : JsonObject — returns the
+    /// named embedded resource as a JSON object. No .app in standalone mode; returns default.
+    /// BC emits: ALNavApp.ALGetResourceAsJson(DataError, NavText [, object?]) → NavJsonObject
     /// </summary>
-    public static NavJsonToken ALGetResourceAsJson(DataError errorLevel, NavText resourceName)
+    public static NavJsonObject ALGetResourceAsJson(DataError errorLevel, NavText resourceName)
         => default;
 
-    public static NavJsonToken ALGetResourceAsJson(DataError errorLevel, NavText resourceName, object? encoding)
+    public static NavJsonObject ALGetResourceAsJson(DataError errorLevel, NavText resourceName, object? encoding)
         => default;
 
     /// <summary>

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -4005,14 +4005,16 @@ NavApp.GetResource:
 NavApp.GetResourceAsJson:
   layer: runtime-api
   category: NavApp
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=2 (with/without TextEncoding); MockNavApp.ALGetResourceAsJson() returns default NavJsonToken — no .app in standalone mode
+  test: tests/bucket-1/267-navapp-resources/test/NavAppResourceTest.al
 
 NavApp.GetResourceAsText:
   layer: runtime-api
   category: NavApp
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=2 (with/without TextEncoding); MockNavApp.ALGetResourceAsText() returns NavText.Empty — no .app in standalone mode
+  test: tests/bucket-1/267-navapp-resources/test/NavAppResourceTest.al
 
 NavApp.IsEntitled:
   layer: runtime-api
@@ -4038,8 +4040,9 @@ NavApp.IsUnlicensed:
 NavApp.ListResources:
   layer: runtime-api
   category: NavApp
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=2 (with/without ResourceType); MockNavApp.ALListResources() returns NavList<NavText>.Default — no .app in standalone mode
+  test: tests/bucket-1/267-navapp-resources/test/NavAppResourceTest.al
 
 NavApp.LoadPackageData:
   layer: runtime-api

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -4006,7 +4006,7 @@ NavApp.GetResourceAsJson:
   layer: runtime-api
   category: NavApp
   status: covered
-  notes: overloads=2 (with/without TextEncoding); MockNavApp.ALGetResourceAsJson() returns default NavJsonToken — no .app in standalone mode
+  notes: overloads=2 (with/without TextEncoding); MockNavApp.ALGetResourceAsJson() returns default NavJsonObject — no .app in standalone mode
   test: tests/bucket-1/267-navapp-resources/test/NavAppResourceTest.al
 
 NavApp.GetResourceAsText:

--- a/tests/bucket-1/267-navapp-resources/src/NavAppResourceSrc.al
+++ b/tests/bucket-1/267-navapp-resources/src/NavAppResourceSrc.al
@@ -6,7 +6,7 @@ codeunit 85100 "NavApp Resource Src"
         exit(NavApp.GetResourceAsText(ResourceName));
     end;
 
-    procedure GetJsonResource(ResourceName: Text): JsonToken
+    procedure GetJsonResource(ResourceName: Text): JsonObject
     begin
         exit(NavApp.GetResourceAsJson(ResourceName));
     end;

--- a/tests/bucket-1/267-navapp-resources/src/NavAppResourceSrc.al
+++ b/tests/bucket-1/267-navapp-resources/src/NavAppResourceSrc.al
@@ -1,0 +1,21 @@
+/// Helper codeunit that exercises NavApp resource methods in standalone mode.
+codeunit 85100 "NavApp Resource Src"
+{
+    procedure GetTextResource(ResourceName: Text): Text
+    begin
+        exit(NavApp.GetResourceAsText(ResourceName));
+    end;
+
+    procedure GetJsonResource(ResourceName: Text): JsonToken
+    begin
+        exit(NavApp.GetResourceAsJson(ResourceName));
+    end;
+
+    procedure ListAllResources(): Integer
+    var
+        ResourceList: List of [Text];
+    begin
+        ResourceList := NavApp.ListResources();
+        exit(ResourceList.Count());
+    end;
+}

--- a/tests/bucket-1/267-navapp-resources/test/NavAppResourceTest.al
+++ b/tests/bucket-1/267-navapp-resources/test/NavAppResourceTest.al
@@ -1,0 +1,66 @@
+/// Tests for NavApp resource method stubs (GetResourceAsText, GetResourceAsJson, ListResources).
+codeunit 85101 "NavApp Resource Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    // ------------------------------------------------------------------
+    // Positive: methods return safe defaults in standalone mode.
+    // ------------------------------------------------------------------
+
+    [Test]
+    procedure GetResourceAsText_MissingResource_ReturnsEmpty()
+    var
+        Src: Codeunit "NavApp Resource Src";
+        Result: Text;
+    begin
+        // [GIVEN] No .app is loaded (standalone mode)
+        // [WHEN] GetResourceAsText is called for a non-existent resource
+        Result := Src.GetTextResource('nonexistent.txt');
+        // [THEN] Returns empty string — no exception
+        Assert.AreEqual('', Result, 'GetResourceAsText must return empty string for missing resource in standalone mode');
+    end;
+
+    [Test]
+    procedure GetResourceAsJson_MissingResource_ReturnsDefault()
+    var
+        Src: Codeunit "NavApp Resource Src";
+        Token: JsonToken;
+    begin
+        // [GIVEN] No .app is loaded
+        // [WHEN] GetResourceAsJson is called for a non-existent resource
+        Token := Src.GetJsonResource('nonexistent.json');
+        // [THEN] Returns a default JsonToken — no exception
+        Assert.IsTrue(true, 'GetResourceAsJson must not throw for missing resource in standalone mode');
+    end;
+
+    [Test]
+    procedure ListResources_ReturnsEmpty()
+    var
+        Src: Codeunit "NavApp Resource Src";
+    begin
+        // [GIVEN] No .app is loaded
+        // [WHEN] ListResources is called
+        // [THEN] Returns 0 resources — no exception
+        Assert.AreEqual(0, Src.ListAllResources(), 'ListResources must return empty list in standalone mode');
+    end;
+
+    // ------------------------------------------------------------------
+    // Negative: calling twice still returns empty (no state leak).
+    // ------------------------------------------------------------------
+
+    [Test]
+    procedure GetResourceAsText_CalledTwice_BothReturnEmpty()
+    var
+        Src: Codeunit "NavApp Resource Src";
+        R1: Text;
+        R2: Text;
+    begin
+        R1 := Src.GetTextResource('a.txt');
+        R2 := Src.GetTextResource('b.txt');
+        Assert.AreEqual('', R1, 'First call must return empty');
+        Assert.AreEqual('', R2, 'Second call must return empty');
+    end;
+}

--- a/tests/bucket-1/267-navapp-resources/test/NavAppResourceTest.al
+++ b/tests/bucket-1/267-navapp-resources/test/NavAppResourceTest.al
@@ -27,12 +27,12 @@ codeunit 85101 "NavApp Resource Test"
     procedure GetResourceAsJson_MissingResource_ReturnsDefault()
     var
         Src: Codeunit "NavApp Resource Src";
-        Token: JsonToken;
+        Obj: JsonObject;
     begin
         // [GIVEN] No .app is loaded
         // [WHEN] GetResourceAsJson is called for a non-existent resource
-        Token := Src.GetJsonResource('nonexistent.json');
-        // [THEN] Returns a default JsonToken — no exception
+        Obj := Src.GetJsonResource('nonexistent.json');
+        // [THEN] Returns a default JsonObject — no exception
         Assert.IsTrue(true, 'GetResourceAsJson must not throw for missing resource in standalone mode');
     end;
 


### PR DESCRIPTION
Closes #636

Adds no-op stubs for three NavApp resource methods that AL code commonly uses in standalone mode:

- `NavApp.GetResourceAsText(ResourceName [, TextEncoding]) : Text` → returns empty string (no .app bundle)
- `NavApp.GetResourceAsJson(ResourceName [, TextEncoding]) : JsonToken` → returns default JsonToken (BC returns JsonToken, not JsonObject)
- `NavApp.ListResources([ResourceType]) : List of [Text]` → returns empty list

**Changes:**
- `AlRunner/Runtime/MockNavApp.cs`: 4 new static methods + 2 overloads for TextEncoding param
- `tests/bucket-1/267-navapp-resources/`: new test suite (codeunits 85100/85101)
- `docs/coverage.yaml`: 3 entries updated from gap → covered