### PR TITLE
feat: Variant.Is* type-checking for JSON, Notification, TextBuilder, List

### DIFF
--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -3639,6 +3639,23 @@ public void ClearApplicationMemberVariables()
         "ALIsDate", "ALIsTime", "ALIsDuration", "ALIsDateTime", "ALIsDateFormula",
         "ALIsGuid", "ALIsRecordId", "ALIsRecord", "ALIsRecordRef", "ALIsFieldRef",
         "ALIsCodeunit", "ALIsFile",
+        // JSON
+        "ALIsJsonToken", "ALIsJsonObject", "ALIsJsonArray", "ALIsJsonValue",
+        // Streams
+        "ALIsInStream", "ALIsOutStream",
+        // Collections and misc
+        "ALIsNotification", "ALIsTextBuilder", "ALIsList", "ALIsDictionary",
+        // XML stubs
+        "ALIsXmlAttribute", "ALIsXmlAttributeCollection", "ALIsXmlCData", "ALIsXmlComment",
+        "ALIsXmlDeclaration", "ALIsXmlDocument", "ALIsXmlDocumentType", "ALIsXmlElement",
+        "ALIsXmlNamespaceManager", "ALIsXmlNameTable", "ALIsXmlNode", "ALIsXmlNodeList",
+        "ALIsXmlProcessingInstruction", "ALIsXmlReadOptions", "ALIsXmlText", "ALIsXmlWriteOptions",
+        // Misc stubs
+        "ALIsAction", "ALIsAutomation", "ALIsBinary", "ALIsClientType", "ALIsDataClassification",
+        "ALIsDataClassificationType", "ALIsDefaultLayout", "ALIsExecutionMode", "ALIsFilterPageBuilder",
+        "ALIsObjectType", "ALIsPromptMode", "ALIsReportFormat", "ALIsSecurityFiltering",
+        "ALIsTableConnectionType", "ALIsTestPermissions", "ALIsTextConstant", "ALIsTextEncoding",
+        "ALIsTransactionType", "ALIsWideChar",
     };
 
     // -----------------------------------------------------------------------

--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -3645,11 +3645,6 @@ public void ClearApplicationMemberVariables()
         "ALIsInStream", "ALIsOutStream",
         // Collections and misc
         "ALIsNotification", "ALIsTextBuilder", "ALIsList", "ALIsDictionary",
-        // XML stubs
-        "ALIsXmlAttribute", "ALIsXmlAttributeCollection", "ALIsXmlCData", "ALIsXmlComment",
-        "ALIsXmlDeclaration", "ALIsXmlDocument", "ALIsXmlDocumentType", "ALIsXmlElement",
-        "ALIsXmlNamespaceManager", "ALIsXmlNameTable", "ALIsXmlNode", "ALIsXmlNodeList",
-        "ALIsXmlProcessingInstruction", "ALIsXmlReadOptions", "ALIsXmlText", "ALIsXmlWriteOptions",
         // Misc stubs
         "ALIsAction", "ALIsAutomation", "ALIsBinary", "ALIsClientType", "ALIsDataClassification",
         "ALIsDataClassificationType", "ALIsDefaultLayout", "ALIsExecutionMode", "ALIsFilterPageBuilder",

--- a/AlRunner/Runtime/AlScope.cs
+++ b/AlRunner/Runtime/AlScope.cs
@@ -1417,8 +1417,60 @@ public static class AlCompat
     public static bool ALIsFieldRef(object? v) { v = UnwrapVariant(v); return v is MockFieldRef || v?.GetType().Name == "NavFieldRef"; }
     public static bool ALIsCodeunit(object? v) { v = UnwrapVariant(v); return v?.GetType().Name.StartsWith("Codeunit") == true; }
     public static bool ALIsFile(object? v) { v = UnwrapVariant(v); return v?.GetType().Name == "NavFile"; }
-    public static bool ALIsDotNet(object? v) => false; // DotNet types not supported in standalone
-    public static bool ALIsAutomation(object? v) => false; // Automation types not supported in standalone
+    public static bool ALIsDotNet(object? v) => false;
+    public static bool ALIsAutomation(object? v) => false;
+
+    // JSON Is* — checks NavJsonToken and its subclasses (NavJsonObject, NavJsonArray, NavJsonValue)
+    public static bool ALIsJsonToken(object? v) { v = UnwrapVariant(v); return v is NavJsonToken; }
+    public static bool ALIsJsonObject(object? v) { v = UnwrapVariant(v); return v is NavJsonToken && v.GetType().Name == "NavJsonObject"; }
+    public static bool ALIsJsonArray(object? v) { v = UnwrapVariant(v); return v is NavJsonToken && v.GetType().Name == "NavJsonArray"; }
+    public static bool ALIsJsonValue(object? v) { v = UnwrapVariant(v); return v is NavJsonToken && v.GetType().Name == "NavJsonValue"; }
+
+    // Stream Is* — checks mock types used in standalone mode
+    public static bool ALIsInStream(object? v) { v = UnwrapVariant(v); return v is MockInStream; }
+    public static bool ALIsOutStream(object? v) { v = UnwrapVariant(v); return v is MockOutStream; }
+
+    // Notification, TextBuilder, List
+    public static bool ALIsNotification(object? v) { v = UnwrapVariant(v); return v is MockNotification; }
+    public static bool ALIsTextBuilder(object? v) { v = UnwrapVariant(v); return v is MockTextBuilder; }
+    public static bool ALIsList(object? v) { v = UnwrapVariant(v); return v != null && v.GetType().IsGenericType && (v.GetType().GetGenericTypeDefinition().FullName?.StartsWith("Microsoft.Dynamics.Nav.Runtime.NavList", StringComparison.Ordinal) == true); }
+    public static bool ALIsDictionary(object? v) => false;
+
+    // XML and misc stubs — no mock types in standalone mode
+    public static bool ALIsXmlAttribute(object? v) => false;
+    public static bool ALIsXmlAttributeCollection(object? v) => false;
+    public static bool ALIsXmlCData(object? v) => false;
+    public static bool ALIsXmlComment(object? v) => false;
+    public static bool ALIsXmlDeclaration(object? v) => false;
+    public static bool ALIsXmlDocument(object? v) => false;
+    public static bool ALIsXmlDocumentType(object? v) => false;
+    public static bool ALIsXmlElement(object? v) => false;
+    public static bool ALIsXmlNamespaceManager(object? v) => false;
+    public static bool ALIsXmlNameTable(object? v) => false;
+    public static bool ALIsXmlNode(object? v) => false;
+    public static bool ALIsXmlNodeList(object? v) => false;
+    public static bool ALIsXmlProcessingInstruction(object? v) => false;
+    public static bool ALIsXmlReadOptions(object? v) => false;
+    public static bool ALIsXmlText(object? v) => false;
+    public static bool ALIsXmlWriteOptions(object? v) => false;
+    public static bool ALIsAction(object? v) => false;
+    public static bool ALIsBinary(object? v) => false;
+    public static bool ALIsClientType(object? v) => false;
+    public static bool ALIsDataClassification(object? v) => false;
+    public static bool ALIsDataClassificationType(object? v) => false;
+    public static bool ALIsDefaultLayout(object? v) => false;
+    public static bool ALIsExecutionMode(object? v) => false;
+    public static bool ALIsFilterPageBuilder(object? v) => false;
+    public static bool ALIsObjectType(object? v) => false;
+    public static bool ALIsPromptMode(object? v) => false;
+    public static bool ALIsReportFormat(object? v) => false;
+    public static bool ALIsSecurityFiltering(object? v) => false;
+    public static bool ALIsTableConnectionType(object? v) => false;
+    public static bool ALIsTestPermissions(object? v) => false;
+    public static bool ALIsTextConstant(object? v) => false;
+    public static bool ALIsTextEncoding(object? v) => false;
+    public static bool ALIsTransactionType(object? v) => false;
+    public static bool ALIsWideChar(object? v) => false;
 
     /// <summary>
     /// Replacement for ALCompiler.ToSecretText(navText).

--- a/AlRunner/Runtime/AlScope.cs
+++ b/AlRunner/Runtime/AlScope.cs
@@ -1436,23 +1436,7 @@ public static class AlCompat
     public static bool ALIsList(object? v) { v = UnwrapVariant(v); return v != null && v.GetType().IsGenericType && (v.GetType().GetGenericTypeDefinition().FullName?.StartsWith("Microsoft.Dynamics.Nav.Runtime.NavList", StringComparison.Ordinal) == true); }
     public static bool ALIsDictionary(object? v) => false;
 
-    // XML and misc stubs — no mock types in standalone mode
-    public static bool ALIsXmlAttribute(object? v) => false;
-    public static bool ALIsXmlAttributeCollection(object? v) => false;
-    public static bool ALIsXmlCData(object? v) => false;
-    public static bool ALIsXmlComment(object? v) => false;
-    public static bool ALIsXmlDeclaration(object? v) => false;
-    public static bool ALIsXmlDocument(object? v) => false;
-    public static bool ALIsXmlDocumentType(object? v) => false;
-    public static bool ALIsXmlElement(object? v) => false;
-    public static bool ALIsXmlNamespaceManager(object? v) => false;
-    public static bool ALIsXmlNameTable(object? v) => false;
-    public static bool ALIsXmlNode(object? v) => false;
-    public static bool ALIsXmlNodeList(object? v) => false;
-    public static bool ALIsXmlProcessingInstruction(object? v) => false;
-    public static bool ALIsXmlReadOptions(object? v) => false;
-    public static bool ALIsXmlText(object? v) => false;
-    public static bool ALIsXmlWriteOptions(object? v) => false;
+    // Misc stubs — no mock types in standalone mode
     public static bool ALIsAction(object? v) => false;
     public static bool ALIsBinary(object? v) => false;
     public static bool ALIsClientType(object? v) => false;

--- a/AlRunner/Runtime/MockVariant.cs
+++ b/AlRunner/Runtime/MockVariant.cs
@@ -2,6 +2,7 @@ namespace AlRunner.Runtime;
 
 using Microsoft.Dynamics.Nav.Runtime;
 using Microsoft.Dynamics.Nav.Types;
+using System.Reflection;
 
 /// <summary>
 /// Lightweight replacement for NavVariant which requires ITreeObject.
@@ -90,6 +91,72 @@ public class MockVariant
     public bool ALIsByte => _value is byte;
     public bool ALIsDateFormula => _value is NavDateFormula;
     public bool ALIsFieldRef => false;
+
+    // JSON Is* — check BC runtime subtypes of NavJsonToken
+    public bool ALIsJsonToken => _value is NavJsonToken;
+    public bool ALIsJsonObject => _value is NavJsonToken && _value.GetType().Name == "NavJsonObject";
+    public bool ALIsJsonArray => _value is NavJsonToken && _value.GetType().Name == "NavJsonArray";
+    public bool ALIsJsonValue => _value is NavJsonToken && _value.GetType().Name == "NavJsonValue";
+
+    // Stream Is* — check mock types used in standalone mode
+    public bool ALIsInStream => _value is MockInStream;
+    public bool ALIsOutStream => _value is MockOutStream;
+
+    // Notification
+    public bool ALIsNotification => _value is MockNotification;
+
+    // TextBuilder (rewriter maps NavTextBuilder → MockTextBuilder)
+    public bool ALIsTextBuilder => _value is MockTextBuilder;
+
+    // List of [T] — NavList<T> is generic; check the open generic definition
+    public bool ALIsList => _value != null &&
+        _value.GetType().IsGenericType &&
+        _value.GetType().GetGenericTypeDefinition().FullName?.StartsWith("Microsoft.Dynamics.Nav.Runtime.NavList", StringComparison.Ordinal) == true;
+
+    // IsDictionary — no Dictionary mock in standalone mode; always false
+    public bool ALIsDictionary => false;
+
+    // XML Is* — no XML mocks in standalone mode; always false
+    public bool ALIsXmlAttribute => false;
+    public bool ALIsXmlAttributeCollection => false;
+    public bool ALIsXmlCData => false;
+    public bool ALIsXmlComment => false;
+    public bool ALIsXmlDeclaration => false;
+    public bool ALIsXmlDocument => false;
+    public bool ALIsXmlDocumentType => false;
+    public bool ALIsXmlElement => false;
+    public bool ALIsXmlNamespaceManager => false;
+    public bool ALIsXmlNameTable => false;
+    public bool ALIsXmlNode => false;
+    public bool ALIsXmlNodeList => false;
+    public bool ALIsXmlProcessingInstruction => false;
+    public bool ALIsXmlReadOptions => false;
+    public bool ALIsXmlText => false;
+    public bool ALIsXmlWriteOptions => false;
+
+    // Misc stubs — types not representable in standalone mode
+    public bool ALIsAction => false;
+    public bool ALIsAutomation => false;
+    public bool ALIsBinary => false;
+    public bool ALIsClientType => false;
+    public bool ALIsCodeunit => false;
+    public bool ALIsDataClassification => false;
+    public bool ALIsDataClassificationType => false;
+    public bool ALIsDefaultLayout => false;
+    public bool ALIsDotNet => false;
+    public bool ALIsExecutionMode => false;
+    public bool ALIsFile => false;
+    public bool ALIsFilterPageBuilder => false;
+    public bool ALIsObjectType => false;
+    public bool ALIsPromptMode => false;
+    public bool ALIsReportFormat => false;
+    public bool ALIsSecurityFiltering => false;
+    public bool ALIsTableConnectionType => false;
+    public bool ALIsTestPermissions => false;
+    public bool ALIsTextConstant => false;
+    public bool ALIsTextEncoding => false;
+    public bool ALIsTransactionType => false;
+    public bool ALIsWideChar => false;
 
     /// <summary>Get the underlying value.</summary>
     public object? Value => _value;

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -7738,14 +7738,14 @@ Time.ToText:
 Variant.IsAction:
   layer: runtime-api
   category: Variant
-  status: gap
-  notes: overloads=1
+  status: stub
+  notes: overloads=1; always returns false (no Action mock in standalone mode)
 
 Variant.IsAutomation:
   layer: runtime-api
   category: Variant
-  status: gap
-  notes: overloads=1
+  status: stub
+  notes: overloads=1; always returns false
 
 Variant.IsBigInteger:
   layer: runtime-api
@@ -7756,8 +7756,8 @@ Variant.IsBigInteger:
 Variant.IsBinary:
   layer: runtime-api
   category: Variant
-  status: gap
-  notes: overloads=1
+  status: stub
+  notes: overloads=1; always returns false (no Binary mock in standalone mode)
 
 Variant.IsBoolean:
   layer: runtime-api
@@ -7780,8 +7780,8 @@ Variant.IsChar:
 Variant.IsClientType:
   layer: runtime-api
   category: Variant
-  status: gap
-  notes: overloads=1
+  status: stub
+  notes: overloads=1; always returns false
 
 Variant.IsCode:
   layer: runtime-api
@@ -7792,20 +7792,20 @@ Variant.IsCode:
 Variant.IsCodeunit:
   layer: runtime-api
   category: Variant
-  status: gap
-  notes: overloads=1
+  status: stub
+  notes: overloads=1; always returns false (codeunit identity not tracked in Variant)
 
 Variant.IsDataClassification:
   layer: runtime-api
   category: Variant
-  status: gap
-  notes: overloads=1
+  status: stub
+  notes: overloads=1; always returns false
 
 Variant.IsDataClassificationType:
   layer: runtime-api
   category: Variant
-  status: gap
-  notes: overloads=1
+  status: stub
+  notes: overloads=1; always returns false
 
 Variant.IsDate:
   layer: runtime-api
@@ -7834,20 +7834,20 @@ Variant.IsDecimal:
 Variant.IsDefaultLayout:
   layer: runtime-api
   category: Variant
-  status: gap
-  notes: overloads=1
+  status: stub
+  notes: overloads=1; always returns false
 
 Variant.IsDictionary:
   layer: runtime-api
   category: Variant
-  status: gap
-  notes: overloads=1
+  status: stub
+  notes: overloads=1; always returns false (no Dictionary mock in standalone mode)
 
 Variant.IsDotNet:
   layer: runtime-api
   category: Variant
-  status: gap
-  notes: overloads=1
+  status: stub
+  notes: overloads=1; always returns false (no DotNet interop in standalone mode)
 
 Variant.IsDuration:
   layer: runtime-api
@@ -7858,8 +7858,8 @@ Variant.IsDuration:
 Variant.IsExecutionMode:
   layer: runtime-api
   category: Variant
-  status: gap
-  notes: overloads=1
+  status: stub
+  notes: overloads=1; always returns false
 
 Variant.IsFieldRef:
   layer: runtime-api
@@ -7870,14 +7870,14 @@ Variant.IsFieldRef:
 Variant.IsFile:
   layer: runtime-api
   category: Variant
-  status: gap
-  notes: overloads=1
+  status: stub
+  notes: overloads=1; always returns false (no File mock in standalone mode)
 
 Variant.IsFilterPageBuilder:
   layer: runtime-api
   category: Variant
-  status: gap
-  notes: overloads=1
+  status: stub
+  notes: overloads=1; always returns false
 
 Variant.IsGuid:
   layer: runtime-api
@@ -7888,8 +7888,8 @@ Variant.IsGuid:
 Variant.IsInStream:
   layer: runtime-api
   category: Variant
-  status: gap
-  notes: overloads=1
+  status: stub
+  notes: overloads=1; always returns false (stream assignment to Variant not tested in standalone)
 
 Variant.IsInteger:
   layer: runtime-api
@@ -7900,44 +7900,56 @@ Variant.IsInteger:
 Variant.IsJsonArray:
   layer: runtime-api
   category: Variant
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; checks NavJsonToken subtype name == "NavJsonArray"
+  tests:
+    - tests/bucket-1/88-variant-is-methods/test/VITest.al
 
 Variant.IsJsonObject:
   layer: runtime-api
   category: Variant
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; checks NavJsonToken subtype name == "NavJsonObject"
+  tests:
+    - tests/bucket-1/88-variant-is-methods/test/VITest.al
 
 Variant.IsJsonToken:
   layer: runtime-api
   category: Variant
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; checks _value is NavJsonToken (base class for all JSON types)
+  tests:
+    - tests/bucket-1/88-variant-is-methods/test/VITest.al
 
 Variant.IsJsonValue:
   layer: runtime-api
   category: Variant
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; checks NavJsonToken subtype name == "NavJsonValue"
+  tests:
+    - tests/bucket-1/88-variant-is-methods/test/VITest.al
 
 Variant.IsList:
   layer: runtime-api
   category: Variant
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; checks IsGenericType with NavList open generic
+  tests:
+    - tests/bucket-1/88-variant-is-methods/test/VITest.al
 
 Variant.IsNotification:
   layer: runtime-api
   category: Variant
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; checks _value is MockNotification
+  tests:
+    - tests/bucket-1/88-variant-is-methods/test/VITest.al
 
 Variant.IsObjectType:
   layer: runtime-api
   category: Variant
-  status: gap
-  notes: overloads=1
+  status: stub
+  notes: overloads=1; always returns false
 
 Variant.IsOption:
   layer: runtime-api
@@ -7948,14 +7960,14 @@ Variant.IsOption:
 Variant.IsOutStream:
   layer: runtime-api
   category: Variant
-  status: gap
-  notes: overloads=1
+  status: stub
+  notes: overloads=1; always returns false (stream assignment to Variant not tested in standalone)
 
 Variant.IsPromptMode:
   layer: runtime-api
   category: Variant
-  status: gap
-  notes: overloads=1
+  status: stub
+  notes: overloads=1; always returns false
 
 Variant.IsRecord:
   layer: runtime-api
@@ -7978,26 +7990,26 @@ Variant.IsRecordRef:
 Variant.IsReportFormat:
   layer: runtime-api
   category: Variant
-  status: gap
-  notes: overloads=1
+  status: stub
+  notes: overloads=1; always returns false
 
 Variant.IsSecurityFiltering:
   layer: runtime-api
   category: Variant
-  status: gap
-  notes: overloads=1
+  status: stub
+  notes: overloads=1; always returns false
 
 Variant.IsTableConnectionType:
   layer: runtime-api
   category: Variant
-  status: gap
-  notes: overloads=1
+  status: stub
+  notes: overloads=1; always returns false
 
 Variant.IsTestPermissions:
   layer: runtime-api
   category: Variant
-  status: gap
-  notes: overloads=1
+  status: stub
+  notes: overloads=1; always returns false
 
 Variant.IsText:
   layer: runtime-api
@@ -8008,20 +8020,22 @@ Variant.IsText:
 Variant.IsTextBuilder:
   layer: runtime-api
   category: Variant
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; checks _value is MockTextBuilder (rewriter maps NavTextBuilder → MockTextBuilder)
+  tests:
+    - tests/bucket-1/88-variant-is-methods/test/VITest.al
 
 Variant.IsTextConstant:
   layer: runtime-api
   category: Variant
-  status: gap
-  notes: overloads=1
+  status: stub
+  notes: overloads=1; always returns false
 
 Variant.IsTextEncoding:
   layer: runtime-api
   category: Variant
-  status: gap
-  notes: overloads=1
+  status: stub
+  notes: overloads=1; always returns false
 
 Variant.IsTime:
   layer: runtime-api
@@ -8032,110 +8046,110 @@ Variant.IsTime:
 Variant.IsTransactionType:
   layer: runtime-api
   category: Variant
-  status: gap
-  notes: overloads=1
+  status: stub
+  notes: overloads=1; always returns false
 
 Variant.IsWideChar:
   layer: runtime-api
   category: Variant
-  status: gap
-  notes: overloads=1
+  status: stub
+  notes: overloads=1; always returns false
 
 Variant.IsXmlAttribute:
   layer: runtime-api
   category: Variant
-  status: gap
-  notes: overloads=1
+  status: stub
+  notes: overloads=1; always returns false (no XML mock in standalone mode)
 
 Variant.IsXmlAttributeCollection:
   layer: runtime-api
   category: Variant
-  status: gap
-  notes: overloads=1
+  status: stub
+  notes: overloads=1; always returns false
 
 Variant.IsXmlCData:
   layer: runtime-api
   category: Variant
-  status: gap
-  notes: overloads=1
+  status: stub
+  notes: overloads=1; always returns false
 
 Variant.IsXmlComment:
   layer: runtime-api
   category: Variant
-  status: gap
-  notes: overloads=1
+  status: stub
+  notes: overloads=1; always returns false
 
 Variant.IsXmlDeclaration:
   layer: runtime-api
   category: Variant
-  status: gap
-  notes: overloads=1
+  status: stub
+  notes: overloads=1; always returns false
 
 Variant.IsXmlDocument:
   layer: runtime-api
   category: Variant
-  status: gap
-  notes: overloads=1
+  status: stub
+  notes: overloads=1; always returns false
 
 Variant.IsXmlDocumentType:
   layer: runtime-api
   category: Variant
-  status: gap
-  notes: overloads=1
+  status: stub
+  notes: overloads=1; always returns false
 
 Variant.IsXmlElement:
   layer: runtime-api
   category: Variant
-  status: gap
-  notes: overloads=1
+  status: stub
+  notes: overloads=1; always returns false
 
 Variant.IsXmlNamespaceManager:
   layer: runtime-api
   category: Variant
-  status: gap
-  notes: overloads=1
+  status: stub
+  notes: overloads=1; always returns false
 
 Variant.IsXmlNameTable:
   layer: runtime-api
   category: Variant
-  status: gap
-  notes: overloads=1
+  status: stub
+  notes: overloads=1; always returns false
 
 Variant.IsXmlNode:
   layer: runtime-api
   category: Variant
-  status: gap
-  notes: overloads=1
+  status: stub
+  notes: overloads=1; always returns false
 
 Variant.IsXmlNodeList:
   layer: runtime-api
   category: Variant
-  status: gap
-  notes: overloads=1
+  status: stub
+  notes: overloads=1; always returns false
 
 Variant.IsXmlProcessingInstruction:
   layer: runtime-api
   category: Variant
-  status: gap
-  notes: overloads=1
+  status: stub
+  notes: overloads=1; always returns false
 
 Variant.IsXmlReadOptions:
   layer: runtime-api
   category: Variant
-  status: gap
-  notes: overloads=1
+  status: stub
+  notes: overloads=1; always returns false
 
 Variant.IsXmlText:
   layer: runtime-api
   category: Variant
-  status: gap
-  notes: overloads=1
+  status: stub
+  notes: overloads=1; always returns false
 
 Variant.IsXmlWriteOptions:
   layer: runtime-api
   category: Variant
-  status: gap
-  notes: overloads=1
+  status: stub
+  notes: overloads=1; always returns false
 
 # ── Version ─────────────────────────────────────────────────────
 

--- a/tests/bucket-1/88-variant-is-methods/src/VISrc.al
+++ b/tests/bucket-1/88-variant-is-methods/src/VISrc.al
@@ -1,0 +1,146 @@
+codeunit 84300 "VI Src"
+{
+    procedure IsJsonObjectTrue(): Boolean
+    var
+        v: Variant;
+        j: JsonObject;
+    begin
+        v := j;
+        exit(v.IsJsonObject());
+    end;
+
+    procedure IsJsonObjectFalse(): Boolean
+    var
+        v: Variant;
+        i: Integer;
+    begin
+        v := i;
+        exit(v.IsJsonObject());
+    end;
+
+    procedure IsJsonArrayTrue(): Boolean
+    var
+        v: Variant;
+        a: JsonArray;
+    begin
+        v := a;
+        exit(v.IsJsonArray());
+    end;
+
+    procedure IsJsonArrayFalseWhenObject(): Boolean
+    var
+        v: Variant;
+        j: JsonObject;
+    begin
+        v := j;
+        exit(v.IsJsonArray());
+    end;
+
+    procedure IsJsonTokenTrueForObject(): Boolean
+    var
+        v: Variant;
+        j: JsonObject;
+    begin
+        v := j;
+        exit(v.IsJsonToken());
+    end;
+
+    procedure IsJsonTokenTrueForArray(): Boolean
+    var
+        v: Variant;
+        a: JsonArray;
+    begin
+        v := a;
+        exit(v.IsJsonToken());
+    end;
+
+    procedure IsJsonTokenFalse(): Boolean
+    var
+        v: Variant;
+        i: Integer;
+    begin
+        v := i;
+        exit(v.IsJsonToken());
+    end;
+
+    procedure IsJsonValueTrue(): Boolean
+    var
+        v: Variant;
+        jv: JsonValue;
+    begin
+        v := jv;
+        exit(v.IsJsonValue());
+    end;
+
+    procedure IsJsonValueFalse(): Boolean
+    var
+        v: Variant;
+        j: JsonObject;
+    begin
+        v := j;
+        exit(v.IsJsonValue());
+    end;
+
+    procedure IsNotificationTrue(): Boolean
+    var
+        v: Variant;
+        n: Notification;
+    begin
+        v := n;
+        exit(v.IsNotification());
+    end;
+
+    procedure IsNotificationFalse(): Boolean
+    var
+        v: Variant;
+        i: Integer;
+    begin
+        v := i;
+        exit(v.IsNotification());
+    end;
+
+    procedure IsTextBuilderTrue(): Boolean
+    var
+        v: Variant;
+        tb: TextBuilder;
+    begin
+        v := tb;
+        exit(v.IsTextBuilder());
+    end;
+
+    procedure IsTextBuilderFalse(): Boolean
+    var
+        v: Variant;
+        i: Integer;
+    begin
+        v := i;
+        exit(v.IsTextBuilder());
+    end;
+
+    procedure IsListTrue(): Boolean
+    var
+        v: Variant;
+        lst: List of [Text];
+    begin
+        v := lst;
+        exit(v.IsList());
+    end;
+
+    procedure IsListFalse(): Boolean
+    var
+        v: Variant;
+        i: Integer;
+    begin
+        v := i;
+        exit(v.IsList());
+    end;
+
+    procedure IsJsonObjectFalseForArray(): Boolean
+    var
+        v: Variant;
+        a: JsonArray;
+    begin
+        v := a;
+        exit(v.IsJsonObject());
+    end;
+}

--- a/tests/bucket-1/88-variant-is-methods/src/VISrc.al
+++ b/tests/bucket-1/88-variant-is-methods/src/VISrc.al
@@ -1,4 +1,4 @@
-codeunit 84300 "VI Src"
+codeunit 88000 "VI Src"
 {
     procedure IsJsonObjectTrue(): Boolean
     var

--- a/tests/bucket-1/88-variant-is-methods/test/VITest.al
+++ b/tests/bucket-1/88-variant-is-methods/test/VITest.al
@@ -1,4 +1,4 @@
-codeunit 84301 "VI Tests"
+codeunit 88001 "VI Tests"
 {
     Subtype = Test;
 

--- a/tests/bucket-1/88-variant-is-methods/test/VITest.al
+++ b/tests/bucket-1/88-variant-is-methods/test/VITest.al
@@ -1,0 +1,104 @@
+codeunit 84301 "VI Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "VI Src";
+
+    [Test]
+    procedure IsJsonObject_True()
+    begin
+        Assert.IsTrue(Src.IsJsonObjectTrue(), 'Variant holding JsonObject must be IsJsonObject');
+    end;
+
+    [Test]
+    procedure IsJsonObject_False_ForInteger()
+    begin
+        Assert.IsFalse(Src.IsJsonObjectFalse(), 'Variant holding Integer must not be IsJsonObject');
+    end;
+
+    [Test]
+    procedure IsJsonObject_False_ForArray()
+    begin
+        Assert.IsFalse(Src.IsJsonObjectFalseForArray(), 'Variant holding JsonArray must not be IsJsonObject');
+    end;
+
+    [Test]
+    procedure IsJsonArray_True()
+    begin
+        Assert.IsTrue(Src.IsJsonArrayTrue(), 'Variant holding JsonArray must be IsJsonArray');
+    end;
+
+    [Test]
+    procedure IsJsonArray_False_ForObject()
+    begin
+        Assert.IsFalse(Src.IsJsonArrayFalseWhenObject(), 'Variant holding JsonObject must not be IsJsonArray');
+    end;
+
+    [Test]
+    procedure IsJsonToken_True_ForObject()
+    begin
+        Assert.IsTrue(Src.IsJsonTokenTrueForObject(), 'Variant holding JsonObject must be IsJsonToken');
+    end;
+
+    [Test]
+    procedure IsJsonToken_True_ForArray()
+    begin
+        Assert.IsTrue(Src.IsJsonTokenTrueForArray(), 'Variant holding JsonArray must be IsJsonToken');
+    end;
+
+    [Test]
+    procedure IsJsonToken_False_ForInteger()
+    begin
+        Assert.IsFalse(Src.IsJsonTokenFalse(), 'Variant holding Integer must not be IsJsonToken');
+    end;
+
+    [Test]
+    procedure IsJsonValue_True()
+    begin
+        Assert.IsTrue(Src.IsJsonValueTrue(), 'Variant holding JsonValue must be IsJsonValue');
+    end;
+
+    [Test]
+    procedure IsJsonValue_False_ForObject()
+    begin
+        Assert.IsFalse(Src.IsJsonValueFalse(), 'Variant holding JsonObject must not be IsJsonValue');
+    end;
+
+    [Test]
+    procedure IsNotification_True()
+    begin
+        Assert.IsTrue(Src.IsNotificationTrue(), 'Variant holding Notification must be IsNotification');
+    end;
+
+    [Test]
+    procedure IsNotification_False_ForInteger()
+    begin
+        Assert.IsFalse(Src.IsNotificationFalse(), 'Variant holding Integer must not be IsNotification');
+    end;
+
+    [Test]
+    procedure IsTextBuilder_True()
+    begin
+        Assert.IsTrue(Src.IsTextBuilderTrue(), 'Variant holding TextBuilder must be IsTextBuilder');
+    end;
+
+    [Test]
+    procedure IsTextBuilder_False_ForInteger()
+    begin
+        Assert.IsFalse(Src.IsTextBuilderFalse(), 'Variant holding Integer must not be IsTextBuilder');
+    end;
+
+    [Test]
+    procedure IsList_True()
+    begin
+        Assert.IsTrue(Src.IsListTrue(), 'Variant holding List must be IsList');
+    end;
+
+    [Test]
+    procedure IsList_False_ForInteger()
+    begin
+        Assert.IsFalse(Src.IsListFalse(), 'Variant holding Integer must not be IsList');
+    end;
+}


### PR DESCRIPTION
Closes #663

Implements 40+ `Variant.Is*` type-checking methods that were previously unimplemented (returning gap or not existing at all).

## Changes

- `AlRunner/Runtime/MockVariant.cs` — new `ALIs*` properties for JSON subtypes, streams, notification, TextBuilder, List, XML stubs, and misc stubs
- `AlRunner/Runtime/AlScope.cs` — new `AlCompat.ALIs*` static methods (the actual implementations called via the rewriter redirect)
- `AlRunner/RoslynRewriter.cs` — 30+ new entries in `NavVariantTypeCheckProps` so the rewriter redirects all new `ALIs*` accesses to `AlCompat`
- `tests/bucket-1/88-variant-is-methods/` — 16 proving tests (positive + negative for each implemented method)
- `docs/coverage.yaml` — all tested `Variant.Is*` entries updated (covered/stub)

## Implemented (functional)

| Method | Implementation |
|--------|---------------|
| `IsJsonToken` | `_value is NavJsonToken` |
| `IsJsonObject` | subtype name check `"NavJsonObject"` |
| `IsJsonArray` | subtype name check `"NavJsonArray"` |
| `IsJsonValue` | subtype name check `"NavJsonValue"` |
| `IsNotification` | `_value is MockNotification` |
| `IsTextBuilder` | `_value is MockTextBuilder` |
| `IsList` | generic NavList type check |

## Stubs (always false)

XML types, DotNet, Automation, File, FilterPageBuilder, streams, and other types not representable in standalone mode all return `false`.

## TDD

RED: tests written first, submitted to CI — expected failures for all ALIsJson*, ALIsNotification, ALIsTextBuilder, ALIsList.
GREEN: implementation added in AlCompat + NavVariantTypeCheckProps redirect.