### PR TITLE
test: System.CalcDate — proving tests (#212)

### DIFF
--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -5510,8 +5510,9 @@ System.ArrayLen:
 System.CalcDate:
   layer: runtime-api
   category: System
-  status: gap
-  notes: overloads=2
+  status: covered
+  tests: tests/bucket-2/181-calcdate
+  notes: overloads=2. Covered via BC's ALCalcDate — formula parsing (D/W/M/Y, compound, empty) and DateFormula-typed overload all pass through the SDK.
 
 System.CanLoadType:
   layer: runtime-api

--- a/tests/bucket-2/181-calcdate/al-runner.json
+++ b/tests/bucket-2/181-calcdate/al-runner.json
@@ -1,0 +1,4 @@
+{
+  "sourcePath": "./src",
+  "testPath": "./test"
+}

--- a/tests/bucket-2/181-calcdate/src/CalcDateSrc.al
+++ b/tests/bucket-2/181-calcdate/src/CalcDateSrc.al
@@ -1,0 +1,40 @@
+/// Helper codeunit exercising CalcDate() formula arithmetic.
+codeunit 60060 "CDF Src"
+{
+    procedure Calc(formula: Text; baseDate: Date): Date
+    begin
+        exit(CalcDate(formula, baseDate));
+    end;
+
+    procedure CalcOneArg(formula: Text): Date
+    begin
+        // Single-arg overload anchors on Today().
+        exit(CalcDate(formula));
+    end;
+
+    procedure CalcFormulaType(formula: DateFormula; baseDate: Date): Date
+    begin
+        // Overload taking a typed DateFormula value.
+        exit(CalcDate(formula, baseDate));
+    end;
+
+    procedure AddOneDay(d: Date): Date
+    begin
+        exit(CalcDate('<+1D>', d));
+    end;
+
+    procedure AddOneMonth(d: Date): Date
+    begin
+        exit(CalcDate('<+1M>', d));
+    end;
+
+    procedure AddOneYear(d: Date): Date
+    begin
+        exit(CalcDate('<+1Y>', d));
+    end;
+
+    procedure SubtractOneWeek(d: Date): Date
+    begin
+        exit(CalcDate('<-1W>', d));
+    end;
+}

--- a/tests/bucket-2/181-calcdate/test/CalcDateTest.al
+++ b/tests/bucket-2/181-calcdate/test/CalcDateTest.al
@@ -1,0 +1,83 @@
+codeunit 60061 "CDF Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "CDF Src";
+
+    [Test]
+    procedure CalcDate_AddOneDay()
+    begin
+        // DMY(15, 6, 2024) + 1D = DMY(16, 6, 2024)
+        Assert.AreEqual(DMY2Date(16, 6, 2024), Src.AddOneDay(DMY2Date(15, 6, 2024)),
+            'CalcDate(''<+1D>'') must add one day');
+    end;
+
+    [Test]
+    procedure CalcDate_AddOneDay_AcrossMonthBoundary()
+    begin
+        // 30-Jun + 1D = 1-Jul
+        Assert.AreEqual(DMY2Date(1, 7, 2024), Src.AddOneDay(DMY2Date(30, 6, 2024)),
+            'CalcDate(''<+1D>'') must wrap from month end to next month');
+    end;
+
+    [Test]
+    procedure CalcDate_AddOneMonth()
+    begin
+        // 15-Jun-2024 + 1M = 15-Jul-2024
+        Assert.AreEqual(DMY2Date(15, 7, 2024), Src.AddOneMonth(DMY2Date(15, 6, 2024)),
+            'CalcDate(''<+1M>'') must add one month');
+    end;
+
+    [Test]
+    procedure CalcDate_AddOneYear()
+    begin
+        Assert.AreEqual(DMY2Date(15, 6, 2025), Src.AddOneYear(DMY2Date(15, 6, 2024)),
+            'CalcDate(''<+1Y>'') must add one year');
+    end;
+
+    [Test]
+    procedure CalcDate_SubtractOneWeek()
+    begin
+        // 15-Jun-2024 (Saturday) - 1W = 8-Jun-2024
+        Assert.AreEqual(DMY2Date(8, 6, 2024), Src.SubtractOneWeek(DMY2Date(15, 6, 2024)),
+            'CalcDate(''<-1W>'') must subtract seven days');
+    end;
+
+    [Test]
+    procedure CalcDate_Compound_MinusYearPlusDay()
+    begin
+        // 15-Jun-2024 with <-1Y+1D> = 16-Jun-2023
+        Assert.AreEqual(DMY2Date(16, 6, 2023), Src.Calc('<-1Y+1D>', DMY2Date(15, 6, 2024)),
+            'Compound formula must apply all terms');
+    end;
+
+    [Test]
+    procedure CalcDate_NotAnIdentityNoOp_NegativeTrap()
+    begin
+        // Negative trap: if CalcDate were a no-op the add-one-day call would
+        // return the input unchanged.
+        Assert.AreNotEqual(DMY2Date(15, 6, 2024), Src.AddOneDay(DMY2Date(15, 6, 2024)),
+            'CalcDate must not be a pass-through');
+    end;
+
+    [Test]
+    procedure CalcDate_EmptyFormula_ReturnsBaseDate()
+    begin
+        // Empty formula = zero offset.
+        Assert.AreEqual(DMY2Date(15, 6, 2024), Src.Calc('<>', DMY2Date(15, 6, 2024)),
+            'CalcDate with an empty formula must return the base date unchanged');
+    end;
+
+    [Test]
+    procedure CalcDate_WithDateFormulaType()
+    var
+        f: DateFormula;
+    begin
+        // Overload taking DateFormula rather than Text.
+        Evaluate(f, '<+1D>');
+        Assert.AreEqual(DMY2Date(16, 6, 2024), Src.CalcFormulaType(f, DMY2Date(15, 6, 2024)),
+            'CalcDate(DateFormula, Date) must respect the typed formula');
+    end;
+}


### PR DESCRIPTION
## Summary
- Closes #212
- `CalcDate()` already works end-to-end via BC's native `ALCalcDate` lowering — the date-formula DSL is fully handled by the SDK and no runner-side glue was missing. This PR just adds the first proving tests and flips coverage.yaml from `gap` → `covered`.
- New suite `tests/bucket-2/181-calcdate` — 9 tests covering `+1D`/`+1M`/`+1Y`/`-1W` offsets, month-boundary wrap, compound `<-1Y+1D>`, empty formula, `DateFormula`-typed overload, and a no-op trap.

## Test plan
- [x] New suite — 9/9 pass
- [x] bucket-2 regression — 1125 pass, 3 pre-existing timezone failures (unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)