### PR TITLE
test: Text.Contains/StartsWith/EndsWith/IndexOf/LastIndexOf — coverage (#208)

### DIFF
--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -7237,8 +7237,9 @@ TestRequestPage.ValidationErrorCount:
 Text.Contains:
   layer: runtime-api
   category: Text
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-2/182-text-search
+  notes: overloads=1. Covered via NavText native — positive, negative, case-sensitive, empty-needle.
 
 Text.ConvertStr:
   layer: runtime-api
@@ -7269,8 +7270,9 @@ Text.DelStr:
 Text.EndsWith:
   layer: runtime-api
   category: Text
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-2/182-text-search
+  notes: overloads=1. Covered via NavText native — positive and negative cases.
 
 Text.IncStr:
   layer: runtime-api
@@ -7282,8 +7284,9 @@ Text.IncStr:
 Text.IndexOf:
   layer: runtime-api
   category: Text
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-2/182-text-search
+  notes: overloads=1. Covered via NavText native — returns 1-based index (AL convention), 0 when not found, first-occurrence semantics.
 
 Text.IndexOfAny:
   layer: runtime-api
@@ -7300,8 +7303,9 @@ Text.InsStr:
 Text.LastIndexOf:
   layer: runtime-api
   category: Text
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-2/182-text-search
+  notes: overloads=1. Covered via NavText native — 1-based last occurrence, 0 when not found, differs from IndexOf for multi-match strings.
 
 Text.LowerCase:
   layer: runtime-api
@@ -7361,8 +7365,9 @@ Text.Split:
 Text.StartsWith:
   layer: runtime-api
   category: Text
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-2/182-text-search
+  notes: overloads=1. Covered via NavText native — positive, negative, case-sensitive.
 
 Text.StrCheckSum:
   layer: runtime-api

--- a/tests/bucket-2/182-text-search/al-runner.json
+++ b/tests/bucket-2/182-text-search/al-runner.json
@@ -1,0 +1,4 @@
+{
+  "sourcePath": "./src",
+  "testPath": "./test"
+}

--- a/tests/bucket-2/182-text-search/src/TextSearchSrc.al
+++ b/tests/bucket-2/182-text-search/src/TextSearchSrc.al
@@ -1,0 +1,29 @@
+/// Helper codeunit exercising Text search/navigation methods.
+codeunit 60070 "TXS Src"
+{
+    procedure Contains_Positive(haystack: Text; needle: Text): Boolean
+    begin
+        exit(haystack.Contains(needle));
+    end;
+
+    procedure StartsWith_It(haystack: Text; prefix: Text): Boolean
+    begin
+        exit(haystack.StartsWith(prefix));
+    end;
+
+    procedure EndsWith_It(haystack: Text; suffix: Text): Boolean
+    begin
+        exit(haystack.EndsWith(suffix));
+    end;
+
+    procedure IndexOfIt(haystack: Text; needle: Text): Integer
+    begin
+        // AL convention: 1-based, 0 when not found.
+        exit(haystack.IndexOf(needle));
+    end;
+
+    procedure LastIndexOfIt(haystack: Text; needle: Text): Integer
+    begin
+        exit(haystack.LastIndexOf(needle));
+    end;
+}

--- a/tests/bucket-2/182-text-search/test/TextSearchTest.al
+++ b/tests/bucket-2/182-text-search/test/TextSearchTest.al
@@ -1,0 +1,131 @@
+codeunit 60071 "TXS Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "TXS Src";
+
+    // --- Contains ---
+
+    [Test]
+    procedure Contains_Positive_FindsSubstring()
+    begin
+        Assert.IsTrue(Src.Contains_Positive('Hello World', 'World'),
+            'Contains must find a substring');
+    end;
+
+    [Test]
+    procedure Contains_Negative_NotFound()
+    begin
+        Assert.IsFalse(Src.Contains_Positive('Hello World', 'xyz'),
+            'Contains must return false when the substring is absent');
+    end;
+
+    [Test]
+    procedure Contains_CaseSensitive()
+    begin
+        // AL Text.Contains is case-sensitive.
+        Assert.IsFalse(Src.Contains_Positive('Hello World', 'world'),
+            'Contains is case-sensitive — lowercase "world" must not match');
+    end;
+
+    [Test]
+    procedure Contains_EmptyNeedle_IsTrue()
+    begin
+        // .NET semantics: an empty needle is always contained.
+        Assert.IsTrue(Src.Contains_Positive('Hello', ''),
+            'Contains with empty needle returns true');
+    end;
+
+    // --- StartsWith ---
+
+    [Test]
+    procedure StartsWith_Positive()
+    begin
+        Assert.IsTrue(Src.StartsWith_It('Hello World', 'Hello'),
+            'StartsWith must recognise the prefix');
+    end;
+
+    [Test]
+    procedure StartsWith_Negative()
+    begin
+        Assert.IsFalse(Src.StartsWith_It('Hello World', 'World'),
+            'StartsWith must reject non-prefix');
+    end;
+
+    [Test]
+    procedure StartsWith_CaseSensitive()
+    begin
+        Assert.IsFalse(Src.StartsWith_It('Hello World', 'hello'),
+            'StartsWith is case-sensitive');
+    end;
+
+    // --- EndsWith ---
+
+    [Test]
+    procedure EndsWith_Positive()
+    begin
+        Assert.IsTrue(Src.EndsWith_It('Hello World', 'World'),
+            'EndsWith must recognise the suffix');
+    end;
+
+    [Test]
+    procedure EndsWith_Negative()
+    begin
+        Assert.IsFalse(Src.EndsWith_It('Hello World', 'Hello'),
+            'EndsWith must reject non-suffix');
+    end;
+
+    // --- IndexOf ---
+
+    [Test]
+    procedure IndexOf_Found_Is1Based()
+    begin
+        // AL returns 1-based index; 'World' in 'Hello World' starts at position 7.
+        Assert.AreEqual(7, Src.IndexOfIt('Hello World', 'World'),
+            'IndexOf must return 1-based position of the first match');
+    end;
+
+    [Test]
+    procedure IndexOf_NotFound_Returns0()
+    begin
+        Assert.AreEqual(0, Src.IndexOfIt('Hello World', 'xyz'),
+            'IndexOf must return 0 when the needle is absent (AL convention)');
+    end;
+
+    [Test]
+    procedure IndexOf_FirstOccurrence_NotLast()
+    begin
+        // 'o' appears at positions 5 and 8 in 'Hello World'; IndexOf returns 5.
+        Assert.AreEqual(5, Src.IndexOfIt('Hello World', 'o'),
+            'IndexOf returns the first occurrence, not the last');
+    end;
+
+    // --- LastIndexOf ---
+
+    [Test]
+    procedure LastIndexOf_Found_Is1Based()
+    begin
+        // 'o' appears at positions 5 and 8; LastIndexOf returns 8.
+        Assert.AreEqual(8, Src.LastIndexOfIt('Hello World', 'o'),
+            'LastIndexOf must return the 1-based position of the last occurrence');
+    end;
+
+    [Test]
+    procedure LastIndexOf_NotFound_Returns0()
+    begin
+        Assert.AreEqual(0, Src.LastIndexOfIt('Hello World', 'xyz'),
+            'LastIndexOf must return 0 when the needle is absent');
+    end;
+
+    [Test]
+    procedure LastIndexOf_DiffersFromIndexOf()
+    begin
+        // Negative trap: if LastIndexOf were implemented as IndexOf the two
+        // would return the same thing for strings with multiple matches.
+        Assert.AreNotEqual(Src.IndexOfIt('Hello World', 'o'),
+            Src.LastIndexOfIt('Hello World', 'o'),
+            'LastIndexOf must not be the same as IndexOf for multi-match strings');
+    end;
+}


### PR DESCRIPTION
## Summary
- Closes #208
- All five `Text` search methods (`Contains`, `StartsWith`, `EndsWith`, `IndexOf`, `LastIndexOf`) already work end-to-end via NavText's native C# implementation — this PR just adds the first proving tests and flips coverage.yaml.
- New suite `tests/bucket-2/182-text-search` — 15 tests covering positive/negative/case-sensitive/empty-needle for the boolean methods and 1-based / not-found-returns-0 / multi-match-distinction for the index methods.

## Test plan
- [x] New suite — 15/15 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)