### PR TITLE
test: Text.PadLeft/PadRight/Remove/Replace/Trim* — coverage (#209)

### DIFF
--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -7325,14 +7325,16 @@ Text.MaxStrLen:
 Text.PadLeft:
   layer: runtime-api
   category: Text
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-2/183-text-padtrim
+  notes: overloads=2 (with padChar / default space). Covered via NavText native — pad char, default space, no-op when source already longer.
 
 Text.PadRight:
   layer: runtime-api
   category: Text
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-2/183-text-padtrim
+  notes: overloads=2 (with padChar / default space). Covered via NavText native — includes differs-from-PadLeft trap.
 
 Text.PadStr:
   layer: runtime-api
@@ -7343,14 +7345,16 @@ Text.PadStr:
 Text.Remove:
   layer: runtime-api
   category: Text
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-2/183-text-padtrim
+  notes: overloads=2 (1-arg from-index / 2-arg with count). Covered via NavText native — 1-based AL convention.
 
 Text.Replace:
   layer: runtime-api
   category: Text
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-2/183-text-padtrim
+  notes: overloads=2 (char/char, text/text). Covered via NavText native — single-char, string replace, no-match-unchanged.
 
 Text.SelectStr:
   layer: runtime-api
@@ -7417,20 +7421,23 @@ Text.ToUpper:
 Text.Trim:
   layer: runtime-api
   category: Text
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-2/183-text-padtrim
+  notes: overloads=1. Covered via NavText native — both-sides strip, no-whitespace-unchanged.
 
 Text.TrimEnd:
   layer: runtime-api
   category: Text
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-2/183-text-padtrim
+  notes: overloads=1. Covered via NavText native — trailing strip only, differs-from-TrimStart trap.
 
 Text.TrimStart:
   layer: runtime-api
   category: Text
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-2/183-text-padtrim
+  notes: overloads=1. Covered via NavText native — leading strip only.
 
 Text.UpperCase:
   layer: runtime-api

--- a/tests/bucket-2/183-text-padtrim/al-runner.json
+++ b/tests/bucket-2/183-text-padtrim/al-runner.json
@@ -1,0 +1,4 @@
+{
+  "sourcePath": "./src",
+  "testPath": "./test"
+}

--- a/tests/bucket-2/183-text-padtrim/src/TextPadTrimSrc.al
+++ b/tests/bucket-2/183-text-padtrim/src/TextPadTrimSrc.al
@@ -1,0 +1,58 @@
+/// Helper codeunit exercising Text padding/trim/remove/replace methods.
+codeunit 60080 "TPT Src"
+{
+    procedure PadLeftIt(v: Text; totalLength: Integer; padChar: Char): Text
+    begin
+        exit(v.PadLeft(totalLength, padChar));
+    end;
+
+    procedure PadLeft_SpaceDefault(v: Text; totalLength: Integer): Text
+    begin
+        exit(v.PadLeft(totalLength));
+    end;
+
+    procedure PadRightIt(v: Text; totalLength: Integer; padChar: Char): Text
+    begin
+        exit(v.PadRight(totalLength, padChar));
+    end;
+
+    procedure PadRight_SpaceDefault(v: Text; totalLength: Integer): Text
+    begin
+        exit(v.PadRight(totalLength));
+    end;
+
+    procedure RemoveFromStart(v: Text; startIndex: Integer): Text
+    begin
+        exit(v.Remove(startIndex));
+    end;
+
+    procedure RemoveCount(v: Text; startIndex: Integer; count: Integer): Text
+    begin
+        exit(v.Remove(startIndex, count));
+    end;
+
+    procedure ReplaceChars(v: Text; oldChar: Char; newChar: Char): Text
+    begin
+        exit(v.Replace(oldChar, newChar));
+    end;
+
+    procedure ReplaceStrings(v: Text; oldStr: Text; newStr: Text): Text
+    begin
+        exit(v.Replace(oldStr, newStr));
+    end;
+
+    procedure TrimIt(v: Text): Text
+    begin
+        exit(v.Trim());
+    end;
+
+    procedure TrimStartIt(v: Text): Text
+    begin
+        exit(v.TrimStart());
+    end;
+
+    procedure TrimEndIt(v: Text): Text
+    begin
+        exit(v.TrimEnd());
+    end;
+}

--- a/tests/bucket-2/183-text-padtrim/test/TextPadTrimTest.al
+++ b/tests/bucket-2/183-text-padtrim/test/TextPadTrimTest.al
@@ -1,0 +1,137 @@
+codeunit 60081 "TPT Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "TPT Src";
+
+    // --- PadLeft ---
+
+    [Test]
+    procedure PadLeft_AddsPadChar()
+    begin
+        Assert.AreEqual('0000042', Src.PadLeftIt('42', 7, '0'),
+            'PadLeft must pad the left side with the given char to the total length');
+    end;
+
+    [Test]
+    procedure PadLeft_Default_PadsWithSpace()
+    begin
+        Assert.AreEqual('     42', Src.PadLeft_SpaceDefault('42', 7),
+            'PadLeft with no char argument must pad with spaces');
+    end;
+
+    [Test]
+    procedure PadLeft_AlreadyLongerThanLength_Unchanged()
+    begin
+        // .NET semantics: if the source is already longer, PadLeft returns it unchanged.
+        Assert.AreEqual('hello', Src.PadLeftIt('hello', 3, '*'),
+            'PadLeft must not truncate when source >= target length');
+    end;
+
+    // --- PadRight ---
+
+    [Test]
+    procedure PadRight_AddsPadChar()
+    begin
+        Assert.AreEqual('42*****', Src.PadRightIt('42', 7, '*'),
+            'PadRight must pad the right side with the given char');
+    end;
+
+    [Test]
+    procedure PadRight_Default_PadsWithSpace()
+    begin
+        Assert.AreEqual('42     ', Src.PadRight_SpaceDefault('42', 7),
+            'PadRight with no char argument must pad with spaces');
+    end;
+
+    [Test]
+    procedure PadRight_DifferentFromPadLeft_NegativeTrap()
+    begin
+        // Negative trap: PadLeft and PadRight must produce different results
+        // when padding a short string.
+        Assert.AreNotEqual(Src.PadLeftIt('x', 3, '_'), Src.PadRightIt('x', 3, '_'),
+            'PadLeft and PadRight must produce different strings');
+    end;
+
+    // --- Remove ---
+
+    [Test]
+    procedure Remove_FromIndex_ToEnd()
+    begin
+        // AL 1-based: Remove(3) deletes from position 3 to the end.
+        Assert.AreEqual('Hi', Src.RemoveFromStart('Hi World', 3),
+            'Remove(index) deletes from the 1-based index to the end');
+    end;
+
+    [Test]
+    procedure Remove_Count()
+    begin
+        // AL 1-based: Remove(3, 4) deletes 4 chars starting at index 3.
+        // "Hello World" -> remove positions 3..6 ("llo ") -> "HeWorld"
+        Assert.AreEqual('HeWorld', Src.RemoveCount('Hello World', 3, 4),
+            'Remove(index, count) removes count chars starting at the index');
+    end;
+
+    // --- Replace ---
+
+    [Test]
+    procedure Replace_SingleChar()
+    begin
+        Assert.AreEqual('H.llo', Src.ReplaceChars('Hello', 'e', '.'),
+            'Replace(char, char) must substitute every occurrence');
+    end;
+
+    [Test]
+    procedure Replace_String()
+    begin
+        Assert.AreEqual('Hello there', Src.ReplaceStrings('Hello world', 'world', 'there'),
+            'Replace(text, text) must substitute the needle');
+    end;
+
+    [Test]
+    procedure Replace_NoMatch_Unchanged()
+    begin
+        // When the needle is absent the string must be returned unchanged.
+        Assert.AreEqual('Hello', Src.ReplaceStrings('Hello', 'xyz', 'abc'),
+            'Replace returns the source unchanged when the needle is absent');
+    end;
+
+    // --- Trim ---
+
+    [Test]
+    procedure Trim_StripsBothSides()
+    begin
+        Assert.AreEqual('hello', Src.TrimIt('   hello   '),
+            'Trim must strip whitespace on both sides');
+    end;
+
+    [Test]
+    procedure Trim_NoWhitespace_Unchanged()
+    begin
+        Assert.AreEqual('hello', Src.TrimIt('hello'),
+            'Trim on a non-whitespace string must return the string unchanged');
+    end;
+
+    [Test]
+    procedure TrimStart_StripsLeading()
+    begin
+        Assert.AreEqual('hello   ', Src.TrimStartIt('   hello   '),
+            'TrimStart must strip leading whitespace only');
+    end;
+
+    [Test]
+    procedure TrimEnd_StripsTrailing()
+    begin
+        Assert.AreEqual('   hello', Src.TrimEndIt('   hello   '),
+            'TrimEnd must strip trailing whitespace only');
+    end;
+
+    [Test]
+    procedure TrimStart_DiffersFromTrimEnd_NegativeTrap()
+    begin
+        Assert.AreNotEqual(Src.TrimStartIt('   x   '), Src.TrimEndIt('   x   '),
+            'TrimStart and TrimEnd must produce different results on a two-sided string');
+    end;
+}


### PR DESCRIPTION
## Summary
- Closes #209
- All seven `Text` padding/trim/remove/replace methods already work via NavText's native C# implementation. This PR adds the first proving tests and flips coverage.yaml from `gap` → `covered` for each.
- New suite `tests/bucket-2/183-text-padtrim` — 16 tests covering positive/default/no-op/no-match/differs-from-sibling traps for each method.

## Test plan
- [x] New suite — 16/16 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)