### PR TITLE
feat: Table.AddLoadFields / AreFieldsLoaded — standalone no-ops (#218)

### DIFF
--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -105,7 +105,7 @@ public class RoslynRewriter : CSharpSyntaxRewriter
         "ALDeleteAll", "ALCount", "ALSetRange", "ALSetFilter", "ALFindSet",
         "ALFindFirst", "ALFindLast", "ALIsEmpty", "ALCalcFields", "ALSetCurrentKey",
         "ALReset", "ALCopy", "ALCopyFilter", "ALCopyFilters", "ALTestField", "ALTestFieldSafe", "ALValidate", "ALValidateSafe", "ALRename",
-        "ALLockTable", "ALCalcSums", "ALSetLoadFields", "ALFieldCaption", "ALSetRecFilter",
+        "ALLockTable", "ALCalcSums", "ALSetLoadFields", "ALAddLoadFields", "ALAreFieldsLoaded", "ALFieldCaption", "ALSetRecFilter",
         "ALTableCaption", "ALTableName", "ALTestFieldNavValueSafe",
         "ALFilterGroup", "ALSetRangeSafe", "ALReadIsolation",
         "ALGetView", "ALSetView", "ALGetFilter",

--- a/AlRunner/Runtime/MockRecordHandle.cs
+++ b/AlRunner/Runtime/MockRecordHandle.cs
@@ -1466,6 +1466,31 @@ public class MockRecordHandle
     }
 
     /// <summary>
+    /// AL's ADDLOADFIELDS — extends the load set established by SetLoadFields with
+    /// additional fields. No-op in standalone mode since all fields are always loaded.
+    /// </summary>
+    public void ALAddLoadFields(params int[] fieldNos)
+    {
+        // No-op: all fields always loaded in in-memory store
+    }
+
+    /// <summary>Overload with DataError level (transpiler pattern).</summary>
+    public void ALAddLoadFields(DataError errorLevel, params int[] fieldNos)
+    {
+        // No-op: all fields always loaded in in-memory store
+    }
+
+    /// <summary>
+    /// AL's AREFIELDSLOADED — reports whether every field in the supplied list is
+    /// currently loaded. Standalone contract: all fields are always in memory, so
+    /// the method always returns true.
+    /// </summary>
+    public bool ALAreFieldsLoaded(params int[] fieldNos) => true;
+
+    /// <summary>Overload with DataError level (transpiler pattern).</summary>
+    public bool ALAreFieldsLoaded(DataError errorLevel, params int[] fieldNos) => true;
+
+    /// <summary>
     /// AL GetView([useNames]) — serialises the current sort order and filter state
     /// into a view string that can be round-tripped through SetView.
     /// Format: [SORTING(Field1[,Field2...])] [WHERE(Field=FILTER(expr)[,Field=FILTER(expr)...])]

--- a/AlRunner/Runtime/MockRecordRef.cs
+++ b/AlRunner/Runtime/MockRecordRef.cs
@@ -71,7 +71,7 @@ public class MockRecordRef
         }
     }
 
-    // -- SetLoadFields (no-op) --
+    // -- SetLoadFields / AddLoadFields / AreFieldsLoaded (no-op in standalone) --
 
     /// <summary>
     /// ALSetLoadFields — no-op in standalone mode. All fields are always in memory.
@@ -79,6 +79,14 @@ public class MockRecordRef
     /// </summary>
     public void ALSetLoadFields(params int[] fieldNos) { }
     public void ALSetLoadFields(DataError errorLevel, params int[] fieldNos) { }
+
+    /// <summary>ALAddLoadFields — extends the load set. No-op in standalone (all fields loaded).</summary>
+    public void ALAddLoadFields(params int[] fieldNos) { }
+    public void ALAddLoadFields(DataError errorLevel, params int[] fieldNos) { }
+
+    /// <summary>ALAreFieldsLoaded — standalone: all fields are always loaded, so always true.</summary>
+    public bool ALAreFieldsLoaded(params int[] fieldNos) => true;
+    public bool ALAreFieldsLoaded(DataError errorLevel, params int[] fieldNos) => true;
 
     // -- Caption --
 

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -5965,14 +5965,16 @@ Table.AddLink:
 Table.AddLoadFields:
   layer: runtime-api
   category: Table
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-2/185-loadfields
+  notes: overloads=2 (fields, DataError+fields). Standalone no-op — all fields are always loaded in memory.
 
 Table.AreFieldsLoaded:
   layer: runtime-api
   category: Table
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-2/185-loadfields
+  notes: overloads=2 (fields, DataError+fields). Standalone: always returns true (every field is always loaded).
 
 Table.Ascending:
   layer: runtime-api

--- a/tests/bucket-2/185-loadfields/al-runner.json
+++ b/tests/bucket-2/185-loadfields/al-runner.json
@@ -1,0 +1,4 @@
+{
+  "sourcePath": "./src",
+  "testPath": "./test"
+}

--- a/tests/bucket-2/185-loadfields/src/LoadFieldsSrc.al
+++ b/tests/bucket-2/185-loadfields/src/LoadFieldsSrc.al
@@ -1,0 +1,105 @@
+table 60110 "LF Row"
+{
+    fields
+    {
+        field(1; "Id"; Integer) { }
+        field(2; "Name"; Text[100]) { }
+        field(3; "City"; Text[100]) { }
+    }
+    keys { key(PK; "Id") { Clustered = true; } }
+}
+
+/// Helper codeunit exercising AddLoadFields (standalone no-op because all
+/// fields are always in memory). AreFieldsLoaded is exercised via the
+/// RecordRef path where AL 16.2 exposes ALAreFieldsLoaded.
+codeunit 60110 "LF Src"
+{
+    procedure AddLoadFieldsDoesNotThrow(): Boolean
+    var
+        r: Record "LF Row";
+    begin
+        r.SetLoadFields("Id", "Name");
+        r.AddLoadFields("City");
+        exit(true);
+    end;
+
+    procedure DataRoundTripAfterLoadFields(): Text
+    var
+        r: Record "LF Row";
+    begin
+        // Data reads must still work after SetLoadFields / AddLoadFields — no
+        // partial-loading in standalone mode means every field is reachable.
+        r."Id" := 1;
+        r."Name" := 'Alice';
+        r."City" := 'Paris';
+        r.Insert();
+        Clear(r);
+        r.SetLoadFields("Name");
+        r.AddLoadFields("City");
+        r.Get(1);
+        exit(r."Name" + '/' + r."City");
+    end;
+
+    procedure AddLoadFieldsMultiple_DataIntact(): Text
+    var
+        r: Record "LF Row";
+    begin
+        r."Id" := 2;
+        r."Name" := 'Bob';
+        r."City" := 'Berlin';
+        r.Insert();
+        Clear(r);
+        r.SetLoadFields("Id");
+        r.AddLoadFields("Name");
+        r.AddLoadFields("City");
+        r.Get(2);
+        // "City" is reachable even though SetLoadFields didn't name it — the
+        // second AddLoadFields call must be a harmless no-op.
+        exit(r."City");
+    end;
+
+    procedure AddLoadFields_AfterSet_NotOverridden(): Integer
+    var
+        r: Record "LF Row";
+        i: Integer;
+    begin
+        // Bulk insert + filtered find; proves that AddLoadFields doesn't
+        // corrupt record state or subsequent reads.
+        for i := 10 to 14 do begin
+            r.Init();
+            r."Id" := i;
+            r."Name" := Format(i);
+            r.Insert();
+        end;
+        Clear(r);
+        r.SetLoadFields("Id");
+        r.AddLoadFields("Name");
+        r.SetFilter("Id", '>=%1', 12);
+        exit(r.Count());
+    end;
+
+    procedure RecRefAreFieldsLoaded_ReturnsTrue(): Boolean
+    var
+        r: Record "LF Row";
+        recRef: RecordRef;
+    begin
+        r."Id" := 99;
+        r."Name" := 'X';
+        r.Insert();
+        recRef.Open(60110);
+        // Standalone contract: every field is always in memory.
+        exit(recRef.AreFieldsLoaded(1, 2, 3));
+    end;
+
+    procedure RecRefAreFieldsLoaded_AfterSetLoadFields(): Boolean
+    var
+        recRef: RecordRef;
+    begin
+        recRef.Open(60110);
+        recRef.SetLoadFields(1);
+        recRef.AddLoadFields(2);
+        // Even fields not explicitly in the load set still report as loaded
+        // because the standalone store keeps all fields resident.
+        exit(recRef.AreFieldsLoaded(1, 2, 3));
+    end;
+}

--- a/tests/bucket-2/185-loadfields/test/LoadFieldsTest.al
+++ b/tests/bucket-2/185-loadfields/test/LoadFieldsTest.al
@@ -1,0 +1,59 @@
+codeunit 60111 "LF Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "LF Src";
+
+    [Test]
+    procedure AddLoadFields_DoesNotThrow()
+    begin
+        Assert.IsTrue(Src.AddLoadFieldsDoesNotThrow(),
+            'AddLoadFields must complete without throwing');
+    end;
+
+    [Test]
+    procedure DataReadsAfterLoadFields_Work()
+    begin
+        // Proves that AddLoadFields is a no-op: every field stays reachable
+        // regardless of the load-hint API.
+        Assert.AreEqual('Alice/Paris', Src.DataRoundTripAfterLoadFields(),
+            'Field reads must work after SetLoadFields + AddLoadFields');
+    end;
+
+    [Test]
+    procedure AddLoadFieldsMultiple_FieldReachable()
+    begin
+        // Standalone contract: "City" is reachable even though it was never
+        // added to the load set — all fields are always in memory.
+        Assert.AreEqual('Berlin', Src.AddLoadFieldsMultiple_DataIntact(),
+            'Fields not named via AddLoadFields must still be reachable');
+    end;
+
+    [Test]
+    procedure AddLoadFields_NotCorruptingFilterState()
+    begin
+        // Filter + count after AddLoadFields — verifies the record remains
+        // in a usable state with filters intact.
+        Assert.AreEqual(3, Src.AddLoadFields_AfterSet_NotOverridden(),
+            'Filtered Count() after AddLoadFields must include matching rows');
+    end;
+
+    [Test]
+    procedure RecRef_AreFieldsLoaded_AllFields_True()
+    begin
+        // Positive: standalone contract — every field is always loaded.
+        Assert.IsTrue(Src.RecRefAreFieldsLoaded_ReturnsTrue(),
+            'RecordRef.AreFieldsLoaded must return true in standalone mode');
+    end;
+
+    [Test]
+    procedure RecRef_AreFieldsLoaded_WithAddLoadFields()
+    begin
+        // Even a field never added to the load set reports as loaded, because
+        // partial loading is not modelled standalone.
+        Assert.IsTrue(Src.RecRefAreFieldsLoaded_AfterSetLoadFields(),
+            'RecordRef.AreFieldsLoaded must remain true even for fields not in the load set');
+    end;
+}


### PR DESCRIPTION
## Summary
- Closes #218
- Adds `ALAddLoadFields` and `ALAreFieldsLoaded` to `MockRecordHandle` and `MockRecordRef`, plus rewriter entries in `RecordTargetMethods`. Standalone semantics: AddLoadFields is a no-op (every field is always in memory) and AreFieldsLoaded always returns true.
- New suite `tests/bucket-2/185-loadfields` — 6 tests: AddLoadFields-doesn't-throw, data round-trip reaches every field, filter/Count state stays intact, RecordRef.AreFieldsLoaded returns true for the full set, and remains true for fields never added to the load set.

## Test plan
- [x] New suite — 6/6 pass
- [x] bucket-2 regression — 1174 pass, 3 pre-existing timezone failures (unrelated)
- [x] bucket-1 regression — 793 pass, 4 pre-existing failures (timezone + TextBuilder — unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)