### PR TITLE
test: Label.Split/Substring/PadLeft/PadRight/Remove/Trim*/IndexOfAny/LastIndexOf — coverage (#662)

### DIFF
--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -3760,32 +3760,42 @@ Label.IndexOf:
 Label.IndexOfAny:
   layer: runtime-api
   category: Label
-  status: gap
-  notes: overloads=2
+  status: covered
+  notes: overloads=2. Covered via NavText native — returns 1-based position of the earliest matching char; 0 when none match.
+  tests:
+    - tests/bucket-2/186-label-string-methods
 
 Label.LastIndexOf:
   layer: runtime-api
   category: Label
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1. Covered via NavText native — 1-based last occurrence, 0 when not found.
+  tests:
+    - tests/bucket-2/186-label-string-methods
 
 Label.PadLeft:
   layer: runtime-api
   category: Label
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1 (with padChar). Covered via NavText native.
+  tests:
+    - tests/bucket-2/186-label-string-methods
 
 Label.PadRight:
   layer: runtime-api
   category: Label
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1 (with padChar). Covered via NavText native.
+  tests:
+    - tests/bucket-2/186-label-string-methods
 
 Label.Remove:
   layer: runtime-api
   category: Label
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1 (from-index). Covered via NavText native — 1-based AL convention.
+  tests:
+    - tests/bucket-2/186-label-string-methods
 
 Label.Replace:
   layer: runtime-api
@@ -3798,8 +3808,10 @@ Label.Replace:
 Label.Split:
   layer: runtime-api
   category: Label
-  status: gap
-  notes: overloads=3
+  status: covered
+  notes: overloads=3 (Char, Text, List of [Char]). Covered via NavText native.
+  tests:
+    - tests/bucket-2/186-label-string-methods
 
 Label.StartsWith:
   layer: runtime-api
@@ -3812,8 +3824,10 @@ Label.StartsWith:
 Label.Substring:
   layer: runtime-api
   category: Label
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=2 (from-index, from-index+length). Covered via NavText native.
+  tests:
+    - tests/bucket-2/186-label-string-methods
 
 Label.ToLower:
   layer: runtime-api
@@ -3842,14 +3856,18 @@ Label.Trim:
 Label.TrimEnd:
   layer: runtime-api
   category: Label
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1. Covered via NavText native — trailing strip only, differs-from-TrimStart trap.
+  tests:
+    - tests/bucket-2/186-label-string-methods
 
 Label.TrimStart:
   layer: runtime-api
   category: Label
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1. Covered via NavText native — leading strip only.
+  tests:
+    - tests/bucket-2/186-label-string-methods
 
 # ── Media ───────────────────────────────────────────────────────
 

--- a/tests/bucket-2/186-label-string-methods/al-runner.json
+++ b/tests/bucket-2/186-label-string-methods/al-runner.json
@@ -1,0 +1,4 @@
+{
+  "sourcePath": "./src",
+  "testPath": "./test"
+}

--- a/tests/bucket-2/186-label-string-methods/src/LabelStringMethodsSrc.al
+++ b/tests/bucket-2/186-label-string-methods/src/LabelStringMethodsSrc.al
@@ -1,0 +1,79 @@
+/// Helper codeunit exercising Label string-method coverage.
+/// Each procedure uses a Label with a canonical literal and invokes the
+/// target method directly on the Label value — Labels in BC are string-like
+/// values so these routing tests exercise the same NavText code paths as
+/// plain Text but via the Label syntax.
+codeunit 60120 "LBS Src"
+{
+    procedure Split_ByComma_Count(): Integer
+    var
+        lbl: Label 'a,b,c';
+        parts: List of [Text];
+    begin
+        parts := lbl.Split(',');
+        exit(parts.Count());
+    end;
+
+    procedure Substring_From(index: Integer): Text
+    var
+        lbl: Label 'Hello World';
+    begin
+        exit(lbl.Substring(index));
+    end;
+
+    procedure Substring_FromLength(index: Integer; length: Integer): Text
+    var
+        lbl: Label 'Hello World';
+    begin
+        exit(lbl.Substring(index, length));
+    end;
+
+    procedure PadLeftIt(total: Integer; padChar: Char): Text
+    var
+        lbl: Label '42';
+    begin
+        exit(lbl.PadLeft(total, padChar));
+    end;
+
+    procedure PadRightIt(total: Integer; padChar: Char): Text
+    var
+        lbl: Label '42';
+    begin
+        exit(lbl.PadRight(total, padChar));
+    end;
+
+    procedure RemoveFromStart(index: Integer): Text
+    var
+        lbl: Label 'Hello World';
+    begin
+        exit(lbl.Remove(index));
+    end;
+
+    procedure TrimStartIt(): Text
+    var
+        lbl: Label '   padded   ';
+    begin
+        exit(lbl.TrimStart());
+    end;
+
+    procedure TrimEndIt(): Text
+    var
+        lbl: Label '   padded   ';
+    begin
+        exit(lbl.TrimEnd());
+    end;
+
+    procedure LastIndexOfIt(needle: Text): Integer
+    var
+        lbl: Label 'Hello World';
+    begin
+        exit(lbl.LastIndexOf(needle));
+    end;
+
+    procedure IndexOfAnyIt(chars: Text): Integer
+    var
+        lbl: Label 'Hello World';
+    begin
+        exit(lbl.IndexOfAny(chars));
+    end;
+}

--- a/tests/bucket-2/186-label-string-methods/test/LabelStringMethodsTest.al
+++ b/tests/bucket-2/186-label-string-methods/test/LabelStringMethodsTest.al
@@ -1,0 +1,106 @@
+codeunit 60121 "LBS Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "LBS Src";
+
+    [Test]
+    procedure Label_Split_ByComma()
+    begin
+        Assert.AreEqual(3, Src.Split_ByComma_Count(),
+            'Label.Split('','') on "a,b,c" must return 3 parts');
+    end;
+
+    [Test]
+    procedure Label_Substring_FromIndex()
+    begin
+        // 1-based: position 7 in "Hello World" starts at "World".
+        Assert.AreEqual('World', Src.Substring_From(7),
+            'Label.Substring(7) on "Hello World" must return "World"');
+    end;
+
+    [Test]
+    procedure Label_Substring_FromIndexLength()
+    begin
+        // Substring(1, 5) takes the first 5 chars.
+        Assert.AreEqual('Hello', Src.Substring_FromLength(1, 5),
+            'Label.Substring(1,5) on "Hello World" must return "Hello"');
+    end;
+
+    [Test]
+    procedure Label_PadLeft_WithChar()
+    begin
+        Assert.AreEqual('0000042', Src.PadLeftIt(7, '0'),
+            'Label.PadLeft(7, ''0'') on "42" must return "0000042"');
+    end;
+
+    [Test]
+    procedure Label_PadRight_WithChar()
+    begin
+        Assert.AreEqual('42*****', Src.PadRightIt(7, '*'),
+            'Label.PadRight(7, ''*'') on "42" must return "42*****"');
+    end;
+
+    [Test]
+    procedure Label_Remove_FromIndex()
+    begin
+        // 1-based: Remove(3) on "Hello World" drops from position 3 to end.
+        Assert.AreEqual('He', Src.RemoveFromStart(3),
+            'Label.Remove(3) on "Hello World" must return "He"');
+    end;
+
+    [Test]
+    procedure Label_TrimStart_StripsLeadingOnly()
+    begin
+        Assert.AreEqual('padded   ', Src.TrimStartIt(),
+            'Label.TrimStart on "   padded   " must strip only the leading spaces');
+    end;
+
+    [Test]
+    procedure Label_TrimEnd_StripsTrailingOnly()
+    begin
+        Assert.AreEqual('   padded', Src.TrimEndIt(),
+            'Label.TrimEnd on "   padded   " must strip only the trailing spaces');
+    end;
+
+    [Test]
+    procedure Label_LastIndexOf_Found()
+    begin
+        // 'o' appears at positions 5 and 8 in "Hello World"; LastIndexOf returns 8.
+        Assert.AreEqual(8, Src.LastIndexOfIt('o'),
+            'Label.LastIndexOf(''o'') on "Hello World" must return 8');
+    end;
+
+    [Test]
+    procedure Label_LastIndexOf_NotFound()
+    begin
+        Assert.AreEqual(0, Src.LastIndexOfIt('xyz'),
+            'Label.LastIndexOf must return 0 when the needle is absent');
+    end;
+
+    [Test]
+    procedure Label_IndexOfAny_FindsFirstMatchingChar()
+    begin
+        // "Hello World" IndexOfAny "xyzW" — 'W' at position 7, earliest match.
+        Assert.AreEqual(7, Src.IndexOfAnyIt('xyzW'),
+            'Label.IndexOfAny must return the 1-based position of the earliest matching char');
+    end;
+
+    [Test]
+    procedure Label_IndexOfAny_NotFound()
+    begin
+        Assert.AreEqual(0, Src.IndexOfAnyIt('xyz'),
+            'Label.IndexOfAny must return 0 when no supplied char is in the Label');
+    end;
+
+    [Test]
+    procedure Label_TrimStart_DiffersFromTrimEnd_NegativeTrap()
+    begin
+        // Negative trap: TrimStart and TrimEnd on a two-sided padded string
+        // must not be implemented as the same method.
+        Assert.AreNotEqual(Src.TrimStartIt(), Src.TrimEndIt(),
+            'Label.TrimStart and Label.TrimEnd must produce different results');
+    end;
+}


### PR DESCRIPTION
## Summary
- Closes #662
- All nine `Label` string-manipulation methods already work via NavText's native C# implementation — Labels are string-valued so they share the same code paths as Text. This PR adds the first proving tests and flips coverage.yaml.
- New suite `tests/bucket-2/186-label-string-methods` — 13 tests covering Split, Substring (both overloads), PadLeft, PadRight, Remove, TrimStart, TrimEnd (+ differs trap), LastIndexOf (found + not found), IndexOfAny (found + not found).

## Test plan
- [x] New suite — 13/13 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)