### PR TITLE
test: JsonArray mutations — Add/Set/Insert/RemoveAt/IndexOf coverage (#624)

### DIFF
--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -3099,8 +3099,9 @@ IsolatedStorage.SetEncrypted:
 JsonArray.Add:
   layer: runtime-api
   category: JsonArray
-  status: gap
-  notes: overloads=16
+  status: covered
+  tests: tests/bucket-2/188-jsonarray-mutations
+  notes: overloads=16. Covered via NavJsonArray native — Integer, Text, Boolean, and JsonObject Add forms all append and retain typed values.
 
 JsonArray.AsToken:
   layer: runtime-api
@@ -3222,14 +3223,16 @@ JsonArray.GetTime:
 JsonArray.IndexOf:
   layer: runtime-api
   category: JsonArray
-  status: gap
-  notes: overloads=16
+  status: covered
+  tests: tests/bucket-2/188-jsonarray-mutations
+  notes: overloads=16. Covered via NavJsonArray native — returns 0-based index when found, -1 when absent.
 
 JsonArray.Insert:
   layer: runtime-api
   category: JsonArray
-  status: gap
-  notes: overloads=16
+  status: covered
+  tests: tests/bucket-2/188-jsonarray-mutations
+  notes: overloads=16. Covered via NavJsonArray native — increases Count, shifts existing elements, middle-position insertion correct.
 
 JsonArray.Path:
   layer: runtime-api
@@ -3246,8 +3249,9 @@ JsonArray.ReadFrom:
 JsonArray.RemoveAt:
   layer: runtime-api
   category: JsonArray
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-2/188-jsonarray-mutations
+  notes: overloads=1. Covered via NavJsonArray native — decreases Count, shifts remaining elements left, not-a-no-op trap.
 
 JsonArray.SelectToken:
   layer: runtime-api
@@ -3258,8 +3262,9 @@ JsonArray.SelectToken:
 JsonArray.Set:
   layer: runtime-api
   category: JsonArray
-  status: gap
-  notes: overloads=16
+  status: covered
+  tests: tests/bucket-2/188-jsonarray-mutations
+  notes: overloads=16. Covered via NavJsonArray native — replaces element at index, Count unchanged.
 
 JsonArray.WriteTo:
   layer: runtime-api

--- a/tests/bucket-2/188-jsonarray-mutations/al-runner.json
+++ b/tests/bucket-2/188-jsonarray-mutations/al-runner.json
@@ -1,0 +1,4 @@
+{
+  "sourcePath": "./src",
+  "testPath": "./test"
+}

--- a/tests/bucket-2/188-jsonarray-mutations/src/JsonArrayMutationsSrc.al
+++ b/tests/bucket-2/188-jsonarray-mutations/src/JsonArrayMutationsSrc.al
@@ -1,0 +1,93 @@
+/// Helper codeunit exercising JsonArray mutation methods:
+/// Add, Set, Insert, RemoveAt, IndexOf.
+codeunit 60140 "JAM Src"
+{
+    procedure BuildThreeElementArray(): JsonArray
+    var
+        a: JsonArray;
+    begin
+        a.Add(42);
+        a.Add('hello');
+        a.Add(true);
+        exit(a);
+    end;
+
+    procedure Count(a: JsonArray): Integer
+    begin
+        exit(a.Count());
+    end;
+
+    procedure FirstInt(a: JsonArray): Integer
+    var
+        t: JsonToken;
+    begin
+        a.Get(0, t);
+        exit(t.AsValue().AsInteger());
+    end;
+
+    procedure SecondText(a: JsonArray): Text
+    var
+        t: JsonToken;
+    begin
+        a.Get(1, t);
+        exit(t.AsValue().AsText());
+    end;
+
+    procedure ThirdBool(a: JsonArray): Boolean
+    var
+        t: JsonToken;
+    begin
+        a.Get(2, t);
+        exit(t.AsValue().AsBoolean());
+    end;
+
+    procedure SetItem_Int(var a: JsonArray; idx: Integer; v: Integer)
+    begin
+        a.Set(idx, v);
+    end;
+
+    procedure InsertInt(var a: JsonArray; idx: Integer; v: Integer)
+    begin
+        a.Insert(idx, v);
+    end;
+
+    procedure RemoveAt(var a: JsonArray; idx: Integer)
+    begin
+        a.RemoveAt(idx);
+    end;
+
+    procedure IntAt(a: JsonArray; idx: Integer): Integer
+    var
+        t: JsonToken;
+    begin
+        a.Get(idx, t);
+        exit(t.AsValue().AsInteger());
+    end;
+
+    procedure AddJsonObject(): JsonArray
+    var
+        a: JsonArray;
+        obj: JsonObject;
+    begin
+        obj.Add('k', 'v');
+        a.Add(obj);
+        exit(a);
+    end;
+
+    procedure NestedObjectKey(a: JsonArray; idx: Integer; keyName: Text): Text
+    var
+        t: JsonToken;
+        obj: JsonObject;
+        inner: JsonToken;
+    begin
+        a.Get(idx, t);
+        obj := t.AsObject();
+        obj.Get(keyName, inner);
+        exit(inner.AsValue().AsText());
+    end;
+
+    procedure IndexOfInt(a: JsonArray; v: Integer): Integer
+    begin
+        exit(a.IndexOf(v));
+    end;
+}

--- a/tests/bucket-2/188-jsonarray-mutations/test/JsonArrayMutationsTest.al
+++ b/tests/bucket-2/188-jsonarray-mutations/test/JsonArrayMutationsTest.al
@@ -1,0 +1,190 @@
+codeunit 60141 "JAM Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "JAM Src";
+
+    // --- Add ---
+
+    [Test]
+    procedure Add_ThreeMixed_CountIs3()
+    begin
+        Assert.AreEqual(3, Src.Count(Src.BuildThreeElementArray()),
+            'Three Add calls must produce a 3-element array');
+    end;
+
+    [Test]
+    procedure Add_IntegerStored()
+    begin
+        Assert.AreEqual(42, Src.FirstInt(Src.BuildThreeElementArray()),
+            'Integer Add must be retrievable as Integer');
+    end;
+
+    [Test]
+    procedure Add_TextStored()
+    begin
+        Assert.AreEqual('hello', Src.SecondText(Src.BuildThreeElementArray()),
+            'Text Add must be retrievable as Text');
+    end;
+
+    [Test]
+    procedure Add_BooleanStored()
+    begin
+        Assert.IsTrue(Src.ThirdBool(Src.BuildThreeElementArray()),
+            'Boolean Add(true) must be retrievable as true');
+    end;
+
+    [Test]
+    procedure Add_JsonObject()
+    begin
+        Assert.AreEqual('v', Src.NestedObjectKey(Src.AddJsonObject(), 0, 'k'),
+            'Adding a JsonObject must preserve its key/value pairs');
+    end;
+
+    // --- Set ---
+
+    [Test]
+    procedure Set_ReplacesElement()
+    var
+        a: JsonArray;
+    begin
+        a := Src.BuildThreeElementArray();
+        Src.SetItem_Int(a, 0, 99);
+        Assert.AreEqual(99, Src.FirstInt(a),
+            'Set(0, 99) must replace the first element');
+    end;
+
+    [Test]
+    procedure Set_DoesNotChangeCount()
+    var
+        a: JsonArray;
+    begin
+        a := Src.BuildThreeElementArray();
+        Src.SetItem_Int(a, 0, 99);
+        Assert.AreEqual(3, Src.Count(a),
+            'Set must not change the array length');
+    end;
+
+    // --- Insert ---
+
+    [Test]
+    procedure Insert_AtStart_IncreasesCount()
+    var
+        a: JsonArray;
+    begin
+        a := Src.BuildThreeElementArray();
+        Src.InsertInt(a, 0, 7);
+        Assert.AreEqual(4, Src.Count(a),
+            'Insert must increase count by 1');
+    end;
+
+    [Test]
+    procedure Insert_AtStart_ShiftsOriginal()
+    var
+        a: JsonArray;
+    begin
+        a := Src.BuildThreeElementArray();
+        Src.InsertInt(a, 0, 7);
+        // 42 (was at index 0) should now be at index 1.
+        Assert.AreEqual(42, Src.IntAt(a, 1),
+            'Insert at front must shift original elements right');
+    end;
+
+    [Test]
+    procedure Insert_Middle_CorrectPosition()
+    var
+        a: JsonArray;
+    begin
+        a.Add(1);
+        a.Add(3);
+        Src.InsertInt(a, 1, 2);
+        Assert.AreEqual(2, Src.IntAt(a, 1),
+            'Insert(1, 2) must place 2 at index 1');
+    end;
+
+    // --- RemoveAt ---
+
+    [Test]
+    procedure RemoveAt_DecreasesCount()
+    var
+        a: JsonArray;
+    begin
+        a := Src.BuildThreeElementArray();
+        Src.RemoveAt(a, 1);
+        Assert.AreEqual(2, Src.Count(a),
+            'RemoveAt must decrease count by 1');
+    end;
+
+    [Test]
+    procedure RemoveAt_ShiftsRemaining()
+    var
+        a: JsonArray;
+        t: JsonToken;
+    begin
+        a := Src.BuildThreeElementArray();
+        Src.RemoveAt(a, 0);
+        // After removing index 0, what was at 1 ("hello") is now at 0.
+        a.Get(0, t);
+        Assert.AreEqual('hello', t.AsValue().AsText(),
+            'RemoveAt(0) must shift remaining elements left');
+    end;
+
+    [Test]
+    procedure RemoveAt_NegativeTrap_NotANoop()
+    var
+        a: JsonArray;
+    begin
+        // Negative trap: RemoveAt must actually remove — count must change.
+        a := Src.BuildThreeElementArray();
+        Src.RemoveAt(a, 0);
+        Assert.AreNotEqual(3, Src.Count(a),
+            'RemoveAt must not be a no-op — count must decrease');
+    end;
+
+    // --- IndexOf ---
+
+    [Test]
+    procedure IndexOf_Int_Found()
+    var
+        a: JsonArray;
+    begin
+        a.Add(10);
+        a.Add(20);
+        a.Add(30);
+        Assert.AreEqual(1, Src.IndexOfInt(a, 20),
+            'IndexOf(20) must return index 1 (0-based)');
+    end;
+
+    [Test]
+    procedure IndexOf_Int_NotFound_ReturnsNegative()
+    var
+        a: JsonArray;
+    begin
+        a.Add(10);
+        a.Add(20);
+        // AL convention for JsonArray.IndexOf: returns -1 when not found.
+        Assert.AreEqual(-1, Src.IndexOfInt(a, 99),
+            'IndexOf must return -1 when the value is absent');
+    end;
+
+    // --- Combined ---
+
+    [Test]
+    procedure Build_Insert_Remove_EndToEnd()
+    var
+        a: JsonArray;
+    begin
+        a.Add(1);
+        a.Add(2);
+        a.Add(3);
+        Src.InsertInt(a, 0, 0);     // [0, 1, 2, 3]
+        Src.RemoveAt(a, 3);          // [0, 1, 2]
+        Src.SetItem_Int(a, 1, 99);   // [0, 99, 2]
+        Assert.AreEqual(3, Src.Count(a), 'Final count must be 3');
+        Assert.AreEqual(0, Src.IntAt(a, 0), 'Index 0 must be 0');
+        Assert.AreEqual(99, Src.IntAt(a, 1), 'Index 1 must be 99');
+        Assert.AreEqual(2, Src.IntAt(a, 2), 'Index 2 must be 2');
+    end;
+}


### PR DESCRIPTION
## Summary
- Closes #624
- All five `JsonArray` mutation methods (`Add`, `Set`, `Insert`, `RemoveAt`, `IndexOf`) already work via BC's native NavJsonArray. This PR adds the first proving tests and flips coverage.yaml.
- New suite `tests/bucket-2/188-jsonarray-mutations` — 16 tests covering Add (Integer/Text/Boolean/JsonObject), Set (replaces + count unchanged), Insert (start/middle, shifts + count), RemoveAt (count down + shift + not-a-no-op trap), IndexOf (found/absent), and a combined end-to-end scenario.

## Test plan
- [x] New suite — 16/16 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)