### PR TITLE
test: QueryInstance — GetFilter/Filters, ColumnCaption/Name/No, SaveAsJson + coverage.yaml (#691)

### DIFF
--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -4327,92 +4327,122 @@ Query.SaveAsXml:
 QueryInstance.Close:
   layer: runtime-api
   category: QueryInstance
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; MockQueryHandle.ALClose is a no-op stub.
+  tests:
+    - tests/bucket-2/90-query-object
 
 QueryInstance.ColumnCaption:
   layer: runtime-api
   category: QueryInstance
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; MockQueryHandle.ALColumnCaption returns stub "Column{n}".
+  tests:
+    - tests/bucket-2/90-query-object
 
 QueryInstance.ColumnName:
   layer: runtime-api
   category: QueryInstance
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; MockQueryHandle.ALColumnName returns stub "Column{n}".
+  tests:
+    - tests/bucket-2/90-query-object
 
 QueryInstance.ColumnNo:
   layer: runtime-api
   category: QueryInstance
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; MockQueryHandle.ALColumnNo returns the column number as-is.
+  tests:
+    - tests/bucket-2/90-query-object
 
 QueryInstance.GetFilter:
   layer: runtime-api
   category: QueryInstance
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; MockQueryHandle.ALGetFilter returns empty string (filters not tracked).
+  tests:
+    - tests/bucket-2/90-query-object
 
 QueryInstance.GetFilters:
   layer: runtime-api
   category: QueryInstance
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; MockQueryHandle.ALGetFilters property returns empty string.
+  tests:
+    - tests/bucket-2/90-query-object
 
 QueryInstance.Open:
   layer: runtime-api
   category: QueryInstance
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; MockQueryHandle.ALOpen throws NotSupportedException (requires BC service tier).
+  tests:
+    - tests/bucket-2/90-query-object
 
 QueryInstance.Read:
   layer: runtime-api
   category: QueryInstance
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; MockQueryHandle.ALRead throws NotSupportedException (requires BC service tier).
+  tests:
+    - tests/bucket-2/90-query-object
 
 QueryInstance.SaveAsCsv:
   layer: runtime-api
   category: QueryInstance
-  status: gap
-  notes: overloads=2
+  status: covered
+  notes: overloads=2; MockQueryHandle.ALSaveAsCsv throws NotSupportedException.
+  tests:
+    - tests/bucket-2/90-query-object
 
 QueryInstance.SaveAsJson:
   layer: runtime-api
   category: QueryInstance
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; MockQueryHandle.ALSaveAsJson throws NotSupportedException.
+  tests:
+    - tests/bucket-2/90-query-object
 
 QueryInstance.SaveAsXml:
   layer: runtime-api
   category: QueryInstance
-  status: gap
-  notes: overloads=2
+  status: covered
+  notes: overloads=2; MockQueryHandle.ALSaveAsXml throws NotSupportedException.
+  tests:
+    - tests/bucket-2/90-query-object
 
 QueryInstance.SecurityFiltering:
   layer: runtime-api
   category: QueryInstance
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; MockQueryHandle.ALSecurityFiltering property get/set.
+  tests:
+    - tests/bucket-2/90-query-object
 
 QueryInstance.SetFilter:
   layer: runtime-api
   category: QueryInstance
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; MockQueryHandle.ALSetFilter is a no-op stub.
+  tests:
+    - tests/bucket-2/90-query-object
 
 QueryInstance.SetRange:
   layer: runtime-api
   category: QueryInstance
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; MockQueryHandle.ALSetRangeSafe is a no-op stub (3 overloads: clear/single/range).
+  tests:
+    - tests/bucket-2/90-query-object
 
 QueryInstance.TopNumberOfRows:
   layer: runtime-api
   category: QueryInstance
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; MockQueryHandle.ALTopNumberOfRowsToReturn property get/set.
+  tests:
+    - tests/bucket-2/90-query-object
 
 # ── RecordId ────────────────────────────────────────────────────
 

--- a/tests/bucket-2/90-query-object/src/QuerySrc.al
+++ b/tests/bucket-2/90-query-object/src/QuerySrc.al
@@ -132,4 +132,53 @@ codeunit 59000 "Query Logic"
     begin
         Q.SaveAsXml('output.xml');
     end;
+
+    /// Returns Q.GetFilter(ColumnRef) — stub returns '' (no filter stored).
+    procedure TryGetFilter(): Text
+    var
+        Q: Query "Item Ledger Query";
+    begin
+        exit(Q.GetFilter(EntryNo));
+    end;
+
+    /// Returns Q.GetFilters — stub returns '' (no filters stored).
+    procedure TryGetFilters(): Text
+    var
+        Q: Query "Item Ledger Query";
+    begin
+        exit(Q.GetFilters);
+    end;
+
+    /// Returns Q.ColumnCaption(ColumnRef) — stub returns a non-empty caption.
+    procedure TryColumnCaption(): Text
+    var
+        Q: Query "Item Ledger Query";
+    begin
+        exit(Q.ColumnCaption(EntryNo));
+    end;
+
+    /// Returns Q.ColumnName(ColumnRef) — stub returns a non-empty name.
+    procedure TryColumnName(): Text
+    var
+        Q: Query "Item Ledger Query";
+    begin
+        exit(Q.ColumnName(EntryNo));
+    end;
+
+    /// Returns Q.ColumnNo(ColumnRef) — stub returns the column number.
+    procedure TryColumnNo(): Integer
+    var
+        Q: Query "Item Ledger Query";
+    begin
+        exit(Q.ColumnNo(EntryNo));
+    end;
+
+    /// Tries Q.SaveAsJson — must throw NotSupportedException.
+    procedure TrySaveAsJson()
+    var
+        Q: Query "Item Ledger Query";
+        OutStr: OutStream;
+    begin
+        Q.SaveAsJson(OutStr);
+    end;
 }

--- a/tests/bucket-2/90-query-object/test/QueryTest.al
+++ b/tests/bucket-2/90-query-object/test/QueryTest.al
@@ -129,4 +129,64 @@ codeunit 59001 "Query Tests"
         asserterror Logic.TrySaveAsXml();
         Assert.ExpectedError('Query');
     end;
+
+    [Test]
+    procedure QuerySaveAsJsonThrowsNotSupported()
+    begin
+        // [GIVEN] A declared Query variable
+        // [WHEN]  We call Q.SaveAsJson(OutStream)
+        // [THEN]  A clear 'Query' error is raised
+        asserterror Logic.TrySaveAsJson();
+        Assert.ExpectedError('Query');
+    end;
+
+    // ------------------------------------------------------------------
+    // Metadata stubs: GetFilter, GetFilters, ColumnCaption, ColumnName, ColumnNo
+    // These return stub values — prove the methods compile and run.
+    // ------------------------------------------------------------------
+
+    [Test]
+    procedure QueryGetFilterReturnsEmpty()
+    begin
+        // [GIVEN] A Query variable with no filter set
+        // [WHEN]  We call Q.GetFilter(ColumnRef)
+        // [THEN]  Empty string is returned (stub — filter state is not tracked)
+        Assert.AreEqual('', Logic.TryGetFilter(), 'GetFilter should return empty string when no filter set');
+    end;
+
+    [Test]
+    procedure QueryGetFiltersReturnsEmpty()
+    begin
+        // [GIVEN] A Query variable with no filters set
+        // [WHEN]  We access Q.GetFilters
+        // [THEN]  Empty string is returned (stub — filter state is not tracked)
+        Assert.AreEqual('', Logic.TryGetFilters(), 'GetFilters should return empty string when no filters set');
+    end;
+
+    [Test]
+    procedure QueryColumnCaptionReturnsNonEmpty()
+    begin
+        // [GIVEN] A declared Query variable
+        // [WHEN]  We call Q.ColumnCaption(ColumnRef)
+        // [THEN]  A non-empty stub caption is returned
+        Assert.AreNotEqual('', Logic.TryColumnCaption(), 'ColumnCaption should return a non-empty stub value');
+    end;
+
+    [Test]
+    procedure QueryColumnNameReturnsNonEmpty()
+    begin
+        // [GIVEN] A declared Query variable
+        // [WHEN]  We call Q.ColumnName(ColumnRef)
+        // [THEN]  A non-empty stub name is returned
+        Assert.AreNotEqual('', Logic.TryColumnName(), 'ColumnName should return a non-empty stub value');
+    end;
+
+    [Test]
+    procedure QueryColumnNoReturnsPositive()
+    begin
+        // [GIVEN] A declared Query variable
+        // [WHEN]  We call Q.ColumnNo(ColumnRef)
+        // [THEN]  A positive integer column number is returned
+        Assert.IsTrue(Logic.TryColumnNo() > 0, 'ColumnNo should return a positive integer');
+    end;
 }


### PR DESCRIPTION
Closes #691

## Summary

`MockQueryHandle` already implements all 15 QueryInstance stub methods. This PR adds the missing tests for 6 methods that had no test coverage, and marks all 15 methods as covered in `docs/coverage.yaml`.

## Changes

- **`tests/bucket-2/90-query-object/src/QuerySrc.al`** — 6 new helper procedures:
  - `TryGetFilter` — calls `Q.GetFilter(ColumnRef)`, returns the result
  - `TryGetFilters` — accesses `Q.GetFilters` property, returns the result
  - `TryColumnCaption` — calls `Q.ColumnCaption(ColumnRef)`, returns the result
  - `TryColumnName` — calls `Q.ColumnName(ColumnRef)`, returns the result
  - `TryColumnNo` — calls `Q.ColumnNo(ColumnRef)`, returns the result
  - `TrySaveAsJson` — calls `Q.SaveAsJson(OutStream)`, expected to throw

- **`tests/bucket-2/90-query-object/test/QueryTest.al`** — 6 new proving tests:
  - `QueryGetFilterReturnsEmpty` — asserts `GetFilter` returns `''` (stub, no filter tracking)
  - `QueryGetFiltersReturnsEmpty` — asserts `GetFilters` returns `''` (stub)
  - `QueryColumnCaptionReturnsNonEmpty` — asserts non-empty stub caption
  - `QueryColumnNameReturnsNonEmpty` — asserts non-empty stub name
  - `QueryColumnNoReturnsPositive` — asserts positive column number
  - `QuerySaveAsJsonThrowsNotSupported` — asserts `NotSupportedException` with `'Query'`

- **`docs/coverage.yaml`** — all 15 `QueryInstance.*` methods flipped from `gap` to `covered`

🤖 Generated with [Claude Code](https://claude.com/claude-code)