### PR TITLE
test: JsonObject mutations — extended coverage (#626)

### DIFF
--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -3281,6 +3281,7 @@ JsonObject.Add:
   notes: overloads=16; works natively via NavJsonObject (no TrappableOperationExecutor path); used in GetBoolean tests
   tests:
     - tests/bucket-1/268-jsonobject-methods
+    - tests/bucket-2/189-jsonobject-mutations
 
 JsonObject.AsToken:
   layer: runtime-api
@@ -3289,6 +3290,7 @@ JsonObject.AsToken:
   notes: overloads=1; works natively via NavJsonObject; tested
   tests:
     - tests/bucket-1/268-jsonobject-methods
+    - tests/bucket-2/189-jsonobject-mutations
 
 JsonObject.Clone:
   layer: runtime-api
@@ -3297,6 +3299,7 @@ JsonObject.Clone:
   notes: overloads=1; rewriter redirects ALClone to MockJsonHelper.Clone (deep-clone via Newtonsoft.Json)
   tests:
     - tests/bucket-1/268-jsonobject-methods
+    - tests/bucket-2/189-jsonobject-mutations
 
 JsonObject.Contains:
   layer: runtime-api
@@ -3305,6 +3308,7 @@ JsonObject.Contains:
   notes: overloads=1; rewriter redirects ALContains to MockJsonHelper.Contains
   tests:
     - tests/bucket-1/268-jsonobject-methods
+    - tests/bucket-2/189-jsonobject-mutations
 
 JsonObject.Get:
   layer: runtime-api
@@ -3313,6 +3317,7 @@ JsonObject.Get:
   notes: overloads=1; rewriter redirects ALGet to MockJsonHelper.Get (JObject key lookup, returns ByRef NavJsonToken)
   tests:
     - tests/bucket-1/268-jsonobject-methods
+    - tests/bucket-2/189-jsonobject-mutations
 
 JsonObject.GetArray:
   layer: runtime-api
@@ -3417,6 +3422,7 @@ JsonObject.Keys:
   notes: overloads=1; rewriter redirects ALKeys to MockJsonHelper.Keys (returns NavList<NavText>)
   tests:
     - tests/bucket-1/268-jsonobject-methods
+    - tests/bucket-2/189-jsonobject-mutations
 
 JsonObject.Path:
   layer: runtime-api

--- a/tests/bucket-2/189-jsonobject-mutations/al-runner.json
+++ b/tests/bucket-2/189-jsonobject-mutations/al-runner.json
@@ -1,0 +1,4 @@
+{
+  "sourcePath": "./src",
+  "testPath": "./test"
+}

--- a/tests/bucket-2/189-jsonobject-mutations/src/JsonObjectMutationsSrc.al
+++ b/tests/bucket-2/189-jsonobject-mutations/src/JsonObjectMutationsSrc.al
@@ -1,0 +1,105 @@
+/// Helper codeunit exercising JsonObject mutation and read operations:
+/// Add, Contains, Get, Clone, Keys, AsToken.
+codeunit 60150 "JOM Src"
+{
+    procedure BuildMixedObject(): JsonObject
+    var
+        o: JsonObject;
+    begin
+        o.Add('name', 'Alice');
+        o.Add('age', 30);
+        o.Add('active', true);
+        o.Add('rate', 3.14);
+        exit(o);
+    end;
+
+    procedure HasKey(o: JsonObject; keyName: Text): Boolean
+    begin
+        exit(o.Contains(keyName));
+    end;
+
+    procedure GetText(o: JsonObject; keyName: Text): Text
+    var
+        t: JsonToken;
+    begin
+        o.Get(keyName, t);
+        exit(t.AsValue().AsText());
+    end;
+
+    procedure GetInteger(o: JsonObject; keyName: Text): Integer
+    var
+        t: JsonToken;
+    begin
+        o.Get(keyName, t);
+        exit(t.AsValue().AsInteger());
+    end;
+
+    procedure GetBoolean(o: JsonObject; keyName: Text): Boolean
+    var
+        t: JsonToken;
+    begin
+        o.Get(keyName, t);
+        exit(t.AsValue().AsBoolean());
+    end;
+
+    procedure GetDecimal(o: JsonObject; keyName: Text): Decimal
+    var
+        t: JsonToken;
+    begin
+        o.Get(keyName, t);
+        exit(t.AsValue().AsDecimal());
+    end;
+
+    procedure GetReturnsFalseForMissing(o: JsonObject; keyName: Text): Boolean
+    var
+        t: JsonToken;
+    begin
+        // AL Get returns Boolean — false when key absent.
+        exit(o.Get(keyName, t));
+    end;
+
+    procedure CloneObject(o: JsonObject): JsonObject
+    var
+        clone: JsonToken;
+    begin
+        // JsonObject.Clone returns a JsonToken; unwrap back to JsonObject.
+        clone := o.Clone();
+        exit(clone.AsObject());
+    end;
+
+    procedure KeyCount(o: JsonObject): Integer
+    var
+        keys: List of [Text];
+    begin
+        keys := o.Keys();
+        exit(keys.Count());
+    end;
+
+    procedure HasSpecificKey(o: JsonObject; keyName: Text): Boolean
+    var
+        keys: List of [Text];
+    begin
+        keys := o.Keys();
+        exit(keys.Contains(keyName));
+    end;
+
+    procedure AsTokenRoundTrip_ReturnsObject(o: JsonObject; keyName: Text): Text
+    var
+        t: JsonToken;
+        back: JsonObject;
+        inner: JsonToken;
+    begin
+        t := o.AsToken();
+        back := t.AsObject();
+        back.Get(keyName, inner);
+        exit(inner.AsValue().AsText());
+    end;
+
+    procedure ReplaceValue(var o: JsonObject; keyName: Text; v: Text)
+    begin
+        // AL allows Replace via Remove + Add.
+        if o.Contains(keyName) then
+            o.Remove(keyName);
+        o.Add(keyName, v);
+    end;
+}

--- a/tests/bucket-2/189-jsonobject-mutations/test/JsonObjectMutationsTest.al
+++ b/tests/bucket-2/189-jsonobject-mutations/test/JsonObjectMutationsTest.al
@@ -1,0 +1,141 @@
+codeunit 60151 "JOM Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "JOM Src";
+
+    // --- Contains ---
+
+    [Test]
+    procedure Contains_ExistingKey_True()
+    begin
+        Assert.IsTrue(Src.HasKey(Src.BuildMixedObject(), 'name'),
+            'Contains must return true for an added key');
+    end;
+
+    [Test]
+    procedure Contains_MissingKey_False()
+    begin
+        Assert.IsFalse(Src.HasKey(Src.BuildMixedObject(), 'missing'),
+            'Contains must return false for an absent key');
+    end;
+
+    // --- Add / Get ---
+
+    [Test]
+    procedure Add_Get_Text()
+    begin
+        Assert.AreEqual('Alice', Src.GetText(Src.BuildMixedObject(), 'name'),
+            'Add("name", "Alice") + Get must return "Alice"');
+    end;
+
+    [Test]
+    procedure Add_Get_Integer()
+    begin
+        Assert.AreEqual(30, Src.GetInteger(Src.BuildMixedObject(), 'age'),
+            'Add("age", 30) + Get must return 30');
+    end;
+
+    [Test]
+    procedure Add_Get_Boolean()
+    begin
+        Assert.IsTrue(Src.GetBoolean(Src.BuildMixedObject(), 'active'),
+            'Add("active", true) + Get must return true');
+    end;
+
+    [Test]
+    procedure Add_Get_Decimal()
+    begin
+        Assert.AreEqual(3.14, Src.GetDecimal(Src.BuildMixedObject(), 'rate'),
+            'Add("rate", 3.14) + Get must return 3.14');
+    end;
+
+    [Test]
+    procedure Get_Missing_ReturnsFalse()
+    begin
+        // Negative: AL's Get returns Boolean — false when key absent.
+        Assert.IsFalse(Src.GetReturnsFalseForMissing(Src.BuildMixedObject(), 'nope'),
+            'Get must return false for a missing key');
+    end;
+
+    // --- Clone ---
+
+    [Test]
+    procedure Clone_PreservesKeys()
+    begin
+        Assert.AreEqual('Alice', Src.GetText(Src.CloneObject(Src.BuildMixedObject()), 'name'),
+            'Clone must preserve string keys and values');
+    end;
+
+    [Test]
+    procedure Clone_IsIndependent()
+    var
+        orig: JsonObject;
+        cloned: JsonObject;
+    begin
+        orig := Src.BuildMixedObject();
+        cloned := Src.CloneObject(orig);
+        // Mutating the clone must not affect the original.
+        Src.ReplaceValue(cloned, 'name', 'Bob');
+        Assert.AreEqual('Alice', Src.GetText(orig, 'name'),
+            'Mutating the clone must not affect the original');
+    end;
+
+    // --- Keys ---
+
+    [Test]
+    procedure Keys_Count_Is4()
+    begin
+        Assert.AreEqual(4, Src.KeyCount(Src.BuildMixedObject()),
+            'Keys on a 4-entry object must return 4 entries');
+    end;
+
+    [Test]
+    procedure Keys_IncludesName()
+    begin
+        Assert.IsTrue(Src.HasSpecificKey(Src.BuildMixedObject(), 'name'),
+            'Keys() must include "name"');
+    end;
+
+    [Test]
+    procedure Keys_ExcludesAbsent()
+    begin
+        Assert.IsFalse(Src.HasSpecificKey(Src.BuildMixedObject(), 'ghost'),
+            'Keys() must not include a key that was never added');
+    end;
+
+    // --- AsToken round-trip ---
+
+    [Test]
+    procedure AsToken_RoundTrip_PreservesObject()
+    begin
+        Assert.AreEqual('Alice', Src.AsTokenRoundTrip_ReturnsObject(Src.BuildMixedObject(), 'name'),
+            'AsToken().AsObject() must return an object semantically equal to the original');
+    end;
+
+    // --- Mutation via Remove + Add ---
+
+    [Test]
+    procedure Replace_Via_RemoveAndAdd()
+    var
+        o: JsonObject;
+    begin
+        o := Src.BuildMixedObject();
+        Src.ReplaceValue(o, 'name', 'Carol');
+        Assert.AreEqual('Carol', Src.GetText(o, 'name'),
+            'Remove+Add replaces a value while preserving the rest of the object');
+    end;
+
+    [Test]
+    procedure Add_NotANoOp_NegativeTrap()
+    var
+        o: JsonObject;
+    begin
+        // Negative trap: Add must actually store — Contains reports true after Add.
+        o.Add('x', 'y');
+        Assert.AreNotEqual(false, Src.HasKey(o, 'x'),
+            'Add must not be a no-op — Contains must report true for added key');
+    end;
+}


### PR DESCRIPTION
## Summary
- Closes #626
- All six `JsonObject` methods referenced by the issue (`Add`, `Contains`, `Get`, `Clone`, `Keys`, `AsToken`) were already implemented and covered by `tests/bucket-1/268-jsonobject-methods`. Issue #626 was filed against stale coverage info.
- This PR adds a second proving suite at `tests/bucket-2/189-jsonobject-mutations` (15 tests) and appends it to each entry's `tests:` array for two-site coverage.

## Test plan
- [x] New suite — 15/15 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)