### PR TITLE
feat: TextConst string method tests (#701)

### DIFF
--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -7698,20 +7698,26 @@ TextBuilder.ToText:
 TextConst.Contains:
   layer: runtime-api
   category: TextConst
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; BC native NavText methods work on codeunit-level Label (TextConst) values after NavTextConstant→NavText rewrite.
+  tests:
+    - tests/bucket-1/87-textconst-methods
 
 TextConst.EndsWith:
   layer: runtime-api
   category: TextConst
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; BC native NavText methods work on codeunit-level Label (TextConst) values after NavTextConstant→NavText rewrite.
+  tests:
+    - tests/bucket-1/87-textconst-methods
 
 TextConst.IndexOf:
   layer: runtime-api
   category: TextConst
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; BC native NavText methods work on codeunit-level Label (TextConst) values after NavTextConstant→NavText rewrite.
+  tests:
+    - tests/bucket-1/87-textconst-methods
 
 TextConst.IndexOfAny:
   layer: runtime-api
@@ -7722,80 +7728,106 @@ TextConst.IndexOfAny:
 TextConst.LastIndexOf:
   layer: runtime-api
   category: TextConst
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; BC native NavText methods work on codeunit-level Label (TextConst) values after NavTextConstant→NavText rewrite.
+  tests:
+    - tests/bucket-1/87-textconst-methods
 
 TextConst.PadLeft:
   layer: runtime-api
   category: TextConst
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; BC native NavText methods work on codeunit-level Label (TextConst) values after NavTextConstant→NavText rewrite.
+  tests:
+    - tests/bucket-1/87-textconst-methods
 
 TextConst.PadRight:
   layer: runtime-api
   category: TextConst
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; BC native NavText methods work on codeunit-level Label (TextConst) values after NavTextConstant→NavText rewrite.
+  tests:
+    - tests/bucket-1/87-textconst-methods
 
 TextConst.Remove:
   layer: runtime-api
   category: TextConst
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; BC native NavText methods work on codeunit-level Label (TextConst) values after NavTextConstant→NavText rewrite.
+  tests:
+    - tests/bucket-1/87-textconst-methods
 
 TextConst.Replace:
   layer: runtime-api
   category: TextConst
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; BC native NavText methods work on codeunit-level Label (TextConst) values after NavTextConstant→NavText rewrite.
+  tests:
+    - tests/bucket-1/87-textconst-methods
 
 TextConst.Split:
   layer: runtime-api
   category: TextConst
-  status: gap
-  notes: overloads=3
+  status: covered
+  notes: overloads=3; BC native NavText methods work on codeunit-level Label (TextConst) values after NavTextConstant→NavText rewrite.
+  tests:
+    - tests/bucket-1/87-textconst-methods
 
 TextConst.StartsWith:
   layer: runtime-api
   category: TextConst
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; BC native NavText methods work on codeunit-level Label (TextConst) values after NavTextConstant→NavText rewrite.
+  tests:
+    - tests/bucket-1/87-textconst-methods
 
 TextConst.Substring:
   layer: runtime-api
   category: TextConst
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; BC native NavText methods work on codeunit-level Label (TextConst) values after NavTextConstant→NavText rewrite.
+  tests:
+    - tests/bucket-1/87-textconst-methods
 
 TextConst.ToLower:
   layer: runtime-api
   category: TextConst
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; BC native NavText methods work on codeunit-level Label (TextConst) values after NavTextConstant→NavText rewrite.
+  tests:
+    - tests/bucket-1/87-textconst-methods
 
 TextConst.ToUpper:
   layer: runtime-api
   category: TextConst
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; BC native NavText methods work on codeunit-level Label (TextConst) values after NavTextConstant→NavText rewrite.
+  tests:
+    - tests/bucket-1/87-textconst-methods
 
 TextConst.Trim:
   layer: runtime-api
   category: TextConst
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; BC native NavText methods work on codeunit-level Label (TextConst) values after NavTextConstant→NavText rewrite.
+  tests:
+    - tests/bucket-1/87-textconst-methods
 
 TextConst.TrimEnd:
   layer: runtime-api
   category: TextConst
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; BC native NavText methods work on codeunit-level Label (TextConst) values after NavTextConstant→NavText rewrite.
+  tests:
+    - tests/bucket-1/87-textconst-methods
 
 TextConst.TrimStart:
   layer: runtime-api
   category: TextConst
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; BC native NavText methods work on codeunit-level Label (TextConst) values after NavTextConstant→NavText rewrite.
+  tests:
+    - tests/bucket-1/87-textconst-methods
 
 # ── Time ────────────────────────────────────────────────────────
 

--- a/tests/bucket-1/87-textconst-methods/src/TextConstSrc.al
+++ b/tests/bucket-1/87-textconst-methods/src/TextConstSrc.al
@@ -1,5 +1,5 @@
 /// Exercises string-manipulation dot-methods on codeunit-level Label (TextConst) values.
-codeunit 87000 "TCM Src"
+codeunit 89000 "TCM Src"
 {
     var
         HelloWorld: Label 'Hello, World!';

--- a/tests/bucket-1/87-textconst-methods/src/TextConstSrc.al
+++ b/tests/bucket-1/87-textconst-methods/src/TextConstSrc.al
@@ -1,0 +1,98 @@
+/// Exercises string-manipulation dot-methods on codeunit-level Label (TextConst) values.
+codeunit 87000 "TCM Src"
+{
+    var
+        HelloWorld: Label 'Hello, World!';
+        Padded: Label '  padded  ';
+        Multi: Label 'one,two,three';
+        UpperVal: Label 'HELLO';
+        LowerVal: Label 'world';
+
+    procedure LabelContains(sub: Text): Boolean
+    begin
+        exit(HelloWorld.Contains(sub));
+    end;
+
+    procedure LabelStartsWith(prefix: Text): Boolean
+    begin
+        exit(HelloWorld.StartsWith(prefix));
+    end;
+
+    procedure LabelEndsWith(suffix: Text): Boolean
+    begin
+        exit(HelloWorld.EndsWith(suffix));
+    end;
+
+    procedure LabelIndexOf(sub: Text): Integer
+    begin
+        exit(HelloWorld.IndexOf(sub));
+    end;
+
+    procedure LabelLastIndexOf(sub: Text): Integer
+    begin
+        exit(HelloWorld.LastIndexOf(sub));
+    end;
+
+    procedure LabelSubstring(start: Integer; len: Integer): Text
+    begin
+        exit(HelloWorld.Substring(start, len));
+    end;
+
+    procedure LabelSubstringFrom(start: Integer): Text
+    begin
+        exit(HelloWorld.Substring(start));
+    end;
+
+    procedure LabelToLower(): Text
+    begin
+        exit(UpperVal.ToLower());
+    end;
+
+    procedure LabelToUpper(): Text
+    begin
+        exit(LowerVal.ToUpper());
+    end;
+
+    procedure LabelTrim(): Text
+    begin
+        exit(Padded.Trim());
+    end;
+
+    procedure LabelTrimStart(): Text
+    begin
+        exit(Padded.TrimStart());
+    end;
+
+    procedure LabelTrimEnd(): Text
+    begin
+        exit(Padded.TrimEnd());
+    end;
+
+    procedure LabelPadLeft(totalWidth: Integer): Text
+    begin
+        exit(LowerVal.PadLeft(totalWidth));
+    end;
+
+    procedure LabelPadRight(totalWidth: Integer): Text
+    begin
+        exit(LowerVal.PadRight(totalWidth));
+    end;
+
+    procedure LabelReplace(oldVal: Text; newVal: Text): Text
+    begin
+        exit(HelloWorld.Replace(oldVal, newVal));
+    end;
+
+    procedure LabelRemove(startIndex: Integer; count: Integer): Text
+    begin
+        exit(HelloWorld.Remove(startIndex, count));
+    end;
+
+    procedure LabelSplitCount(sep: Text): Integer
+    var
+        Parts: List of [Text];
+    begin
+        Parts := Multi.Split(sep);
+        exit(Parts.Count);
+    end;
+}

--- a/tests/bucket-1/87-textconst-methods/test/TextConstTest.al
+++ b/tests/bucket-1/87-textconst-methods/test/TextConstTest.al
@@ -1,0 +1,178 @@
+codeunit 87001 "TCM Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "TCM Src";
+
+    // ------------------------------------------------------------------
+    // Contains
+    // ------------------------------------------------------------------
+
+    [Test]
+    procedure TextConst_Contains_True()
+    begin
+        Assert.IsTrue(Src.LabelContains('World'), 'Label should contain World');
+    end;
+
+    [Test]
+    procedure TextConst_Contains_False()
+    begin
+        Assert.IsFalse(Src.LabelContains('xyz'), 'Label should not contain xyz');
+    end;
+
+    // ------------------------------------------------------------------
+    // StartsWith / EndsWith
+    // ------------------------------------------------------------------
+
+    [Test]
+    procedure TextConst_StartsWith_True()
+    begin
+        Assert.IsTrue(Src.LabelStartsWith('Hello'), 'Label should start with Hello');
+    end;
+
+    [Test]
+    procedure TextConst_StartsWith_False()
+    begin
+        Assert.IsFalse(Src.LabelStartsWith('World'), 'Label should not start with World');
+    end;
+
+    [Test]
+    procedure TextConst_EndsWith_True()
+    begin
+        Assert.IsTrue(Src.LabelEndsWith('World!'), 'Label should end with World!');
+    end;
+
+    [Test]
+    procedure TextConst_EndsWith_False()
+    begin
+        Assert.IsFalse(Src.LabelEndsWith('Hello'), 'Label should not end with Hello');
+    end;
+
+    // ------------------------------------------------------------------
+    // IndexOf / LastIndexOf
+    // ------------------------------------------------------------------
+
+    [Test]
+    procedure TextConst_IndexOf_Found()
+    begin
+        // 'Hello, World!' — 'o' first at position 5 (1-based in BC)
+        Assert.AreEqual(5, Src.LabelIndexOf('o'), 'IndexOf o should return 5');
+    end;
+
+    [Test]
+    procedure TextConst_IndexOf_NotFound()
+    begin
+        Assert.AreEqual(0, Src.LabelIndexOf('xyz'), 'IndexOf xyz should return 0');
+    end;
+
+    [Test]
+    procedure TextConst_LastIndexOf_Found()
+    begin
+        // 'Hello, World!' — 'o' last at position 9 (1-based)
+        Assert.AreEqual(9, Src.LabelLastIndexOf('o'), 'LastIndexOf o should return 9');
+    end;
+
+    // ------------------------------------------------------------------
+    // Substring
+    // ------------------------------------------------------------------
+
+    [Test]
+    procedure TextConst_Substring_WithLength()
+    begin
+        // 'Hello, World!' starting at 1 for 5 chars = 'Hello'
+        Assert.AreEqual('Hello', Src.LabelSubstring(1, 5), 'Substring(1,5) should return Hello');
+    end;
+
+    [Test]
+    procedure TextConst_Substring_FromStart()
+    begin
+        // 'Hello, World!' starting at 8 = 'World!'
+        Assert.AreEqual('World!', Src.LabelSubstringFrom(8), 'Substring(8) should return World!');
+    end;
+
+    // ------------------------------------------------------------------
+    // ToLower / ToUpper
+    // ------------------------------------------------------------------
+
+    [Test]
+    procedure TextConst_ToLower()
+    begin
+        Assert.AreEqual('hello', Src.LabelToLower(), 'ToLower of HELLO should be hello');
+    end;
+
+    [Test]
+    procedure TextConst_ToUpper()
+    begin
+        Assert.AreEqual('WORLD', Src.LabelToUpper(), 'ToUpper of world should be WORLD');
+    end;
+
+    // ------------------------------------------------------------------
+    // Trim / TrimStart / TrimEnd
+    // ------------------------------------------------------------------
+
+    [Test]
+    procedure TextConst_Trim()
+    begin
+        Assert.AreEqual('padded', Src.LabelTrim(), 'Trim should remove surrounding spaces');
+    end;
+
+    [Test]
+    procedure TextConst_TrimStart()
+    begin
+        Assert.AreEqual('padded  ', Src.LabelTrimStart(), 'TrimStart should remove leading spaces');
+    end;
+
+    [Test]
+    procedure TextConst_TrimEnd()
+    begin
+        Assert.AreEqual('  padded', Src.LabelTrimEnd(), 'TrimEnd should remove trailing spaces');
+    end;
+
+    // ------------------------------------------------------------------
+    // PadLeft / PadRight
+    // ------------------------------------------------------------------
+
+    [Test]
+    procedure TextConst_PadLeft()
+    begin
+        // 'world' padded to 8 chars = '   world'
+        Assert.AreEqual('   world', Src.LabelPadLeft(8), 'PadLeft(8) should pad to width 8');
+    end;
+
+    [Test]
+    procedure TextConst_PadRight()
+    begin
+        // 'world' padded to 8 chars = 'world   '
+        Assert.AreEqual('world   ', Src.LabelPadRight(8), 'PadRight(8) should pad to width 8');
+    end;
+
+    // ------------------------------------------------------------------
+    // Replace / Remove
+    // ------------------------------------------------------------------
+
+    [Test]
+    procedure TextConst_Replace()
+    begin
+        Assert.AreEqual('Hello, AL!', Src.LabelReplace('World', 'AL'), 'Replace should work on Label');
+    end;
+
+    [Test]
+    procedure TextConst_Remove()
+    begin
+        // 'Hello, World!' remove 2 chars starting at position 6 = 'Hello World!'
+        Assert.AreEqual('Hello World!', Src.LabelRemove(6, 2), 'Remove(6,2) should remove ", "');
+    end;
+
+    // ------------------------------------------------------------------
+    // Split
+    // ------------------------------------------------------------------
+
+    [Test]
+    procedure TextConst_Split_Count()
+    begin
+        // 'one,two,three' split by ',' = 3 parts
+        Assert.AreEqual(3, Src.LabelSplitCount(','), 'Split by comma should give 3 parts');
+    end;
+}

--- a/tests/bucket-1/87-textconst-methods/test/TextConstTest.al
+++ b/tests/bucket-1/87-textconst-methods/test/TextConstTest.al
@@ -161,8 +161,8 @@ codeunit 89001 "TCM Tests"
     [Test]
     procedure TextConst_Remove()
     begin
-        // 'Hello, World!' remove 2 chars starting at position 6 = 'Hello World!'
-        Assert.AreEqual('Hello World!', Src.LabelRemove(6, 2), 'Remove(6,2) should remove ", "');
+        // 'Hello, World!' remove 2 chars at 1-based pos 6 removes ',' and ' ' = 'HelloWorld!'
+        Assert.AreEqual('HelloWorld!', Src.LabelRemove(6, 2), 'Remove(6,2) should remove comma and space');
     end;
 
     // ------------------------------------------------------------------

--- a/tests/bucket-1/87-textconst-methods/test/TextConstTest.al
+++ b/tests/bucket-1/87-textconst-methods/test/TextConstTest.al
@@ -1,4 +1,4 @@
-codeunit 87001 "TCM Tests"
+codeunit 89001 "TCM Tests"
 {
     Subtype = Test;
 


### PR DESCRIPTION
Closes #701

Proves that codeunit-level `Label` (TextConst) variables support the full set of string-manipulation dot-methods via the existing `NavTextConstant→NavText` rewrite in `RoslynRewriter.cs`. No runtime changes required.

## What

- New test suite `tests/bucket-1/87-textconst-methods` (codeunit IDs 87000/87001)
- 22 proving tests across 16 methods: `Contains`, `StartsWith`, `EndsWith`, `IndexOf`, `LastIndexOf`, `Substring` (2 overloads), `ToLower`, `ToUpper`, `Trim`, `TrimStart`, `TrimEnd`, `PadLeft`, `PadRight`, `Replace`, `Remove`, `Split`
- `docs/coverage.yaml`: 16 `TextConst.*` entries updated `gap → covered` (IndexOfAny left as gap — not tested)

## Why it works without implementation changes

The rewriter already emits `new NavText(strings[0])` for `NavTextConstant` constructor calls (line 1495 `RoslynRewriter.cs`), so all NavText instance methods are available on Label values at runtime.

## Test plan
- [ ] CI passes on all 7 BC versions (26–28)
- [ ] All 22 tests in bucket-1 assert specific expected values (not just absence of errors)