### PR TITLE
feat: Session.CurrentClientType / CurrentExecutionMode / DefaultClientType stubs (#698)

### DIFF
--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -2415,6 +2415,17 @@ public void ClearApplicationMemberVariables()
                     .WithTriviaFrom(visited);
             }
 
+            // ALSession.ALGetCurrentExecutionMode(session) -> ExecutionMode.Standard
+            // Real implementation requires a NavSession (null in standalone).
+            if (exprText == "ALSession" && methodName == "ALGetCurrentExecutionMode")
+            {
+                return SyntaxFactory.MemberAccessExpression(
+                    SyntaxKind.SimpleMemberAccessExpression,
+                    SyntaxFactory.IdentifierName("ExecutionMode"),
+                    SyntaxFactory.IdentifierName("Standard"))
+                    .WithTriviaFrom(visited);
+            }
+
             // ALSession.ALGetExecutionContext(session) / ALGetModuleExecutionContext(session)
             // -> AlCompat.GetExecutionContext()
             if (exprText == "ALSession" &&
@@ -3426,6 +3437,22 @@ public void ClearApplicationMemberVariables()
             // Also handle ToDecimal, and other methods that may chain after Target
             // e.g. this.spikeItem.Target.GetFieldValueSafe(3, NavType.Decimal).ToDecimal()
             // The GetFieldValueSafe is caught above; ToDecimal chains on its result, not on Target.
+        }
+
+        // Pattern: ALSession.ALCurrentClientType -> NavClientType.Background
+        //          ALSession.ALDefaultClientType -> NavClientType.Background
+        // Both access NavSession which is null in standalone mode.
+        if (visited.Expression is IdentifierNameSyntax sessionId &&
+            sessionId.Identifier.Text == "ALSession")
+        {
+            var propName = visited.Name.Identifier.Text;
+            if (propName == "ALCurrentClientType" || propName == "ALDefaultClientType")
+            {
+                return SyntaxFactory.MemberAccessExpression(
+                    SyntaxKind.SimpleMemberAccessExpression,
+                    SyntaxFactory.IdentifierName("NavClientType"),
+                    SyntaxFactory.IdentifierName("Background"));
+            }
         }
 
         // Pattern: ALSystemErrorHandling.ALGetLastErrorText -> AlScope.LastErrorText

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -5443,20 +5443,23 @@ Session.BindSubscription:
 Session.CurrentClientType:
   layer: runtime-api
   category: Session
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-2/190-session-methods
+  notes: overloads=1. Rewriter replaces ALSession.ALCurrentClientType with NavClientType.Background (no NavSession standalone).
 
 Session.CurrentExecutionMode:
   layer: runtime-api
   category: Session
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-2/190-session-methods
+  notes: overloads=1. Rewriter replaces ALSession.ALGetCurrentExecutionMode with ExecutionMode.Standard.
 
 Session.DefaultClientType:
   layer: runtime-api
   category: Session
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-2/190-session-methods
+  notes: overloads=1. Rewriter replaces ALSession.ALDefaultClientType with NavClientType.Background.
 
 Session.EnableVerboseTelemetry:
   layer: runtime-api
@@ -5491,14 +5494,16 @@ Session.IsSessionActive:
 Session.LogAuditMessage:
   layer: runtime-api
   category: Session
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-2/190-session-methods
+  notes: overloads=1. Covered via BC native — telemetry is silently dropped in standalone mode.
 
 Session.LogMessage:
   layer: runtime-api
   category: Session
-  status: gap
-  notes: overloads=2
+  status: covered
+  tests: tests/bucket-2/190-session-methods
+  notes: overloads=2. Covered via BC native — telemetry is silently dropped in standalone mode.
 
 Session.LogSecurityAudit:
   layer: runtime-api

--- a/tests/bucket-2/190-session-methods/al-runner.json
+++ b/tests/bucket-2/190-session-methods/al-runner.json
@@ -1,0 +1,4 @@
+{
+  "sourcePath": "./src",
+  "testPath": "./test"
+}

--- a/tests/bucket-2/190-session-methods/src/SessionMethodsSrc.al
+++ b/tests/bucket-2/190-session-methods/src/SessionMethodsSrc.al
@@ -1,0 +1,35 @@
+/// Helper codeunit exercising the Session built-in's static methods.
+codeunit 60160 "SES Src"
+{
+    procedure GetClientType(): ClientType
+    begin
+        exit(Session.CurrentClientType());
+    end;
+
+    procedure GetExecutionMode(): ExecutionMode
+    begin
+        exit(Session.CurrentExecutionMode());
+    end;
+
+    procedure GetDefaultClientType(): ClientType
+    begin
+        exit(Session.DefaultClientType());
+    end;
+
+    procedure LogMessageDoesNotThrow(): Boolean
+    var
+        dims: Dictionary of [Text, Text];
+    begin
+        dims.Add('source', 'test');
+        Session.LogMessage('TAG001', 'test message', Verbosity::Normal,
+            DataClassification::SystemMetadata, TelemetryScope::All, dims);
+        exit(true);
+    end;
+
+    procedure LogAuditMessageDoesNotThrow(): Boolean
+    begin
+        Session.LogAuditMessage('audit', SecurityOperationResult::Success,
+            AuditCategory::UserManagement, 1, 1);
+        exit(true);
+    end;
+}

--- a/tests/bucket-2/190-session-methods/test/SessionMethodsTest.al
+++ b/tests/bucket-2/190-session-methods/test/SessionMethodsTest.al
@@ -1,0 +1,55 @@
+codeunit 60161 "SES Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "SES Src";
+
+    [Test]
+    procedure CurrentClientType_IsBackground()
+    begin
+        // Standalone contract — no interactive session, so client type is Background.
+        Assert.AreEqual(ClientType::Background, Src.GetClientType(),
+            'Session.CurrentClientType must report Background in standalone mode');
+    end;
+
+    [Test]
+    procedure CurrentExecutionMode_IsStandard()
+    begin
+        // Standalone contract — ExecutionMode::Standard (no debugger attached).
+        Assert.AreEqual(ExecutionMode::Standard, Src.GetExecutionMode(),
+            'Session.CurrentExecutionMode must report Standard in standalone mode');
+    end;
+
+    [Test]
+    procedure DefaultClientType_IsBackground()
+    begin
+        Assert.AreEqual(ClientType::Background, Src.GetDefaultClientType(),
+            'Session.DefaultClientType must report Background in standalone mode');
+    end;
+
+    [Test]
+    procedure LogMessage_DoesNotThrow()
+    begin
+        // Positive: LogMessage with a dictionary is a no-op standalone but must
+        // not throw — the runner silently drops telemetry.
+        Assert.IsTrue(Src.LogMessageDoesNotThrow(),
+            'Session.LogMessage must complete without throwing');
+    end;
+
+    [Test]
+    procedure LogAuditMessage_DoesNotThrow()
+    begin
+        Assert.IsTrue(Src.LogAuditMessageDoesNotThrow(),
+            'Session.LogAuditMessage must complete without throwing');
+    end;
+
+    [Test]
+    procedure ClientType_NotWebClient_NegativeTrap()
+    begin
+        // Negative trap: standalone must not report an interactive client type.
+        Assert.AreNotEqual(ClientType::Web, Src.GetClientType(),
+            'Session.CurrentClientType must not report Web in standalone mode');
+    end;
+}


### PR DESCRIPTION
## Summary
- Closes #698 (partial — covers 5 of the 14 listed methods; the rest are either already-covered or trivial follow-ups)
- `Session.CurrentClientType` / `DefaultClientType` are lowered by BC to `ALSession.ALCurrentClientType` / `ALDefaultClientType` — both properties dereference NavSession (null standalone) and NRE. Rewriter now replaces them with `NavClientType.Background`.
- `Session.CurrentExecutionMode` lowers to `ALSession.ALGetCurrentExecutionMode(session)` with the same crash. Rewriter redirects to `ExecutionMode.Standard`.
- `Session.LogMessage` / `LogAuditMessage` already work (telemetry silently dropped); this PR adds the first proving tests for them.
- New suite `tests/bucket-2/190-session-methods` — 6 tests.

## Test plan
- [x] New suite — 6/6 pass
- [x] bucket-2 regression — 1272 pass, 3 pre-existing timezone failures (unrelated)
- [x] bucket-1 regression — 832 pass, 4 pre-existing failures (unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)