### PR TITLE
test: XmlElement — 14 core methods proven via BC native (#664)

### DIFF
--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -9046,8 +9046,9 @@ XmlDocumentType.WriteTo:
 XmlElement.Add:
   layer: runtime-api
   category: XmlElement
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-2/191-xmlelement
+  notes: overloads=1. Covered via NavXmlElement native — child XmlElement add and text add.
 
 XmlElement.AddAfterSelf:
   layer: runtime-api
@@ -9070,26 +9071,30 @@ XmlElement.AddFirst:
 XmlElement.AsXmlNode:
   layer: runtime-api
   category: XmlElement
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-2/191-xmlelement
+  notes: overloads=1. Covered via NavXmlElement native — AsXmlNode().AsXmlElement().Name round-trips.
 
 XmlElement.Attributes:
   layer: runtime-api
   category: XmlElement
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-2/191-xmlelement
+  notes: overloads=1. Covered via NavXmlElement native — Attributes().Get(name, var XmlAttribute) returns true + populates the attribute.
 
 XmlElement.Create:
   layer: runtime-api
   category: XmlElement
-  status: gap
-  notes: overloads=4
+  status: covered
+  tests: tests/bucket-2/191-xmlelement
+  notes: overloads=4. Covered via NavXmlElement native — 1-arg Create(name) tested for Name, children, attributes, SelectNodes.
 
 XmlElement.GetChildElements:
   layer: runtime-api
   category: XmlElement
-  status: gap
-  notes: overloads=3
+  status: covered
+  tests: tests/bucket-2/191-xmlelement
+  notes: overloads=3. Covered via NavXmlElement native — reflects the number of added child elements.
 
 XmlElement.GetChildNodes:
   layer: runtime-api
@@ -9136,26 +9141,30 @@ XmlElement.GetPrefixOfNamespace:
 XmlElement.HasAttributes:
   layer: runtime-api
   category: XmlElement
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-2/191-xmlelement
+  notes: overloads=1. Covered via NavXmlElement native — true after SetAttribute, false initially, false after RemoveAttribute.
 
 XmlElement.HasElements:
   layer: runtime-api
   category: XmlElement
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-2/191-xmlelement
+  notes: overloads=1. Covered via NavXmlElement native — true after Add, false initially.
 
 XmlElement.InnerText:
   layer: runtime-api
   category: XmlElement
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-2/191-xmlelement
+  notes: overloads=1. Covered via NavXmlElement native — reflects text added via Add.
 
 XmlElement.InnerXml:
   layer: runtime-api
   category: XmlElement
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-2/191-xmlelement
+  notes: overloads=1. Covered via NavXmlElement native — serialises child elements + attributes.
 
 XmlElement.IsEmpty:
   layer: runtime-api
@@ -9168,14 +9177,16 @@ XmlElement.IsEmpty:
 XmlElement.LocalName:
   layer: runtime-api
   category: XmlElement
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-2/191-xmlelement
+  notes: overloads=1. Covered via NavXmlElement native.
 
 XmlElement.Name:
   layer: runtime-api
   category: XmlElement
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-2/191-xmlelement
+  notes: overloads=1. Covered via NavXmlElement native — returns the Create() name.
 
 XmlElement.NamespaceUri:
   layer: runtime-api
@@ -9200,8 +9211,9 @@ XmlElement.RemoveAllAttributes:
 XmlElement.RemoveAttribute:
   layer: runtime-api
   category: XmlElement
-  status: gap
-  notes: overloads=3
+  status: covered
+  tests: tests/bucket-2/191-xmlelement
+  notes: overloads=3. Covered via NavXmlElement native — clears the named attribute; HasAttributes becomes false if it was the only one.
 
 XmlElement.RemoveNodes:
   layer: runtime-api
@@ -9224,8 +9236,9 @@ XmlElement.ReplaceWith:
 XmlElement.SelectNodes:
   layer: runtime-api
   category: XmlElement
-  status: gap
-  notes: overloads=2
+  status: covered
+  tests: tests/bucket-2/191-xmlelement
+  notes: overloads=2. Covered via NavXmlElement native — XPath matches descendants on a programmatically-built element.
 
 XmlElement.SelectSingleNode:
   layer: runtime-api
@@ -9238,8 +9251,9 @@ XmlElement.SelectSingleNode:
 XmlElement.SetAttribute:
   layer: runtime-api
   category: XmlElement
-  status: gap
-  notes: overloads=2
+  status: covered
+  tests: tests/bucket-2/191-xmlelement
+  notes: overloads=2. Covered via NavXmlElement native — value readable via Attributes().Get; HasAttributes becomes true.
 
 XmlElement.WriteTo:
   layer: runtime-api

--- a/tests/bucket-2/191-xmlelement/al-runner.json
+++ b/tests/bucket-2/191-xmlelement/al-runner.json
@@ -1,0 +1,4 @@
+{
+  "sourcePath": "./src",
+  "testPath": "./test"
+}

--- a/tests/bucket-2/191-xmlelement/src/XmlElementSrc.al
+++ b/tests/bucket-2/191-xmlelement/src/XmlElementSrc.al
@@ -1,0 +1,141 @@
+/// Helper codeunit exercising XmlElement — creation, attributes, children,
+/// query, and properties.
+codeunit 60170 "XEL Src"
+{
+    procedure Create_Name(): Text
+    var
+        el: XmlElement;
+    begin
+        el := XmlElement.Create('root');
+        exit(el.Name);
+    end;
+
+    procedure Create_And_InnerXml(): Text
+    var
+        root: XmlElement;
+        child: XmlElement;
+    begin
+        root := XmlElement.Create('root');
+        child := XmlElement.Create('item');
+        child.SetAttribute('id', '1');
+        root.Add(child);
+        exit(root.InnerXml);
+    end;
+
+    procedure Create_SetAttribute_Read(): Text
+    var
+        el: XmlElement;
+        attr: XmlAttribute;
+        found: Boolean;
+    begin
+        el := XmlElement.Create('root');
+        el.SetAttribute('color', 'blue');
+        // Read back via Attributes().
+        if el.Attributes().Get('color', attr) then
+            exit(attr.Value);
+        exit('');
+    end;
+
+    procedure HasAttributes_After_Set(): Boolean
+    var
+        el: XmlElement;
+    begin
+        el := XmlElement.Create('root');
+        el.SetAttribute('id', '1');
+        exit(el.HasAttributes());
+    end;
+
+    procedure HasAttributes_NoAttributes_False(): Boolean
+    var
+        el: XmlElement;
+    begin
+        el := XmlElement.Create('root');
+        exit(el.HasAttributes());
+    end;
+
+    procedure HasElements_AfterAdd(): Boolean
+    var
+        root: XmlElement;
+        child: XmlElement;
+    begin
+        root := XmlElement.Create('root');
+        child := XmlElement.Create('item');
+        root.Add(child);
+        exit(root.HasElements());
+    end;
+
+    procedure HasElements_Empty_False(): Boolean
+    var
+        el: XmlElement;
+    begin
+        el := XmlElement.Create('root');
+        exit(el.HasElements());
+    end;
+
+    procedure LocalName(): Text
+    var
+        el: XmlElement;
+    begin
+        el := XmlElement.Create('book');
+        exit(el.LocalName);
+    end;
+
+    procedure GetChildElementCount(): Integer
+    var
+        root: XmlElement;
+        a: XmlElement;
+        b: XmlElement;
+    begin
+        root := XmlElement.Create('root');
+        a := XmlElement.Create('child1');
+        b := XmlElement.Create('child2');
+        root.Add(a);
+        root.Add(b);
+        exit(root.GetChildElements().Count());
+    end;
+
+    procedure InnerText_FromAddText(): Text
+    var
+        el: XmlElement;
+    begin
+        el := XmlElement.Create('greeting');
+        el.Add('hello world');
+        exit(el.InnerText);
+    end;
+
+    procedure SelectNodesCount(): Integer
+    var
+        root: XmlElement;
+        a: XmlElement;
+        b: XmlElement;
+        nodes: XmlNodeList;
+    begin
+        root := XmlElement.Create('root');
+        a := XmlElement.Create('item');
+        b := XmlElement.Create('item');
+        root.Add(a);
+        root.Add(b);
+        root.SelectNodes('//item', nodes);
+        exit(nodes.Count());
+    end;
+
+    procedure RemoveAttribute_Gone(): Boolean
+    var
+        el: XmlElement;
+    begin
+        el := XmlElement.Create('root');
+        el.SetAttribute('id', '1');
+        el.RemoveAttribute('id');
+        exit(el.HasAttributes());
+    end;
+
+    procedure AsXmlNode_NameMatches(): Text
+    var
+        el: XmlElement;
+        n: XmlNode;
+    begin
+        el := XmlElement.Create('widget');
+        n := el.AsXmlNode();
+        exit(n.AsXmlElement().Name);
+    end;
+}

--- a/tests/bucket-2/191-xmlelement/test/XmlElementTest.al
+++ b/tests/bucket-2/191-xmlelement/test/XmlElementTest.al
@@ -1,0 +1,147 @@
+codeunit 60171 "XEL Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "XEL Src";
+
+    // --- Create + Name ---
+
+    [Test]
+    procedure Create_Name_Matches()
+    begin
+        Assert.AreEqual('root', Src.Create_Name(),
+            'XmlElement.Create(name).Name must return the given name');
+    end;
+
+    [Test]
+    procedure LocalName_Matches()
+    begin
+        Assert.AreEqual('book', Src.LocalName(),
+            'XmlElement.LocalName must return the element name');
+    end;
+
+    // --- InnerXml ---
+
+    [Test]
+    procedure Create_InnerXml_ContainsChild()
+    var
+        inner: Text;
+    begin
+        inner := Src.Create_And_InnerXml();
+        Assert.IsTrue(inner.Contains('<item'),
+            'InnerXml after Add must contain the child element');
+    end;
+
+    [Test]
+    procedure Create_InnerXml_ContainsAttribute()
+    var
+        inner: Text;
+    begin
+        inner := Src.Create_And_InnerXml();
+        Assert.IsTrue(inner.Contains('id="1"'),
+            'InnerXml must contain attribute id="1"');
+    end;
+
+    // --- SetAttribute + Attributes ---
+
+    [Test]
+    procedure SetAttribute_Read()
+    begin
+        Assert.AreEqual('blue', Src.Create_SetAttribute_Read(),
+            'SetAttribute value must be readable via Attributes().Get');
+    end;
+
+    [Test]
+    procedure HasAttributes_True_After_SetAttribute()
+    begin
+        Assert.IsTrue(Src.HasAttributes_After_Set(),
+            'HasAttributes must be true after SetAttribute');
+    end;
+
+    [Test]
+    procedure HasAttributes_False_Initially()
+    begin
+        Assert.IsFalse(Src.HasAttributes_NoAttributes_False(),
+            'HasAttributes must be false on a fresh element');
+    end;
+
+    [Test]
+    procedure RemoveAttribute_ClearsHasAttributes()
+    begin
+        Assert.IsFalse(Src.RemoveAttribute_Gone(),
+            'HasAttributes must be false after the only attribute is removed');
+    end;
+
+    // --- HasElements ---
+
+    [Test]
+    procedure HasElements_True_AfterAdd()
+    begin
+        Assert.IsTrue(Src.HasElements_AfterAdd(),
+            'HasElements must be true after Add');
+    end;
+
+    [Test]
+    procedure HasElements_False_Empty()
+    begin
+        Assert.IsFalse(Src.HasElements_Empty_False(),
+            'HasElements must be false on a fresh element');
+    end;
+
+    // --- GetChildElements ---
+
+    [Test]
+    procedure GetChildElements_Count2()
+    begin
+        Assert.AreEqual(2, Src.GetChildElementCount(),
+            'GetChildElements.Count must reflect the number of added children');
+    end;
+
+    // --- InnerText ---
+
+    [Test]
+    procedure InnerText_AfterAddText()
+    begin
+        Assert.AreEqual('hello world', Src.InnerText_FromAddText(),
+            'InnerText must return the text added to the element');
+    end;
+
+    // --- SelectNodes ---
+
+    [Test]
+    procedure SelectNodes_CountsDescendants()
+    begin
+        Assert.AreEqual(2, Src.SelectNodesCount(),
+            'SelectNodes(//item) must return both item children');
+    end;
+
+    // --- AsXmlNode ---
+
+    [Test]
+    procedure AsXmlNode_RoundTrip_PreservesName()
+    begin
+        Assert.AreEqual('widget', Src.AsXmlNode_NameMatches(),
+            'AsXmlNode().AsXmlElement().Name must equal the original name');
+    end;
+
+    // --- Negative traps ---
+
+    [Test]
+    procedure HasAttributes_DifferentBefore_After()
+    begin
+        // Negative trap: HasAttributes must actually reflect state.
+        Assert.AreNotEqual(Src.HasAttributes_NoAttributes_False(),
+            Src.HasAttributes_After_Set(),
+            'HasAttributes must differ before and after SetAttribute');
+    end;
+
+    [Test]
+    procedure HasElements_DifferentBefore_After()
+    begin
+        Assert.AreNotEqual(Src.HasElements_Empty_False(),
+            Src.HasElements_AfterAdd(),
+            'HasElements must differ before and after Add');
+    end;
+}


### PR DESCRIPTION
## Summary
- Closes #664 (partial — covers 14 of 30 listed methods; remainder can follow in a later pass)
- All 14 `XmlElement` methods exercised by the new suite already work end-to-end via BC's native `NavXmlElement` implementation. This PR adds proving tests and flips coverage.yaml from `gap` → `covered` for each.
- New suite `tests/bucket-2/191-xmlelement` — 16 tests covering Create + Name + LocalName, Add (element/text), SetAttribute / Attributes / RemoveAttribute, HasAttributes (before/after/removed + negative differs trap), HasElements (before/after + differs trap), GetChildElements.Count, InnerText, InnerXml, SelectNodes(XPath, var XmlNodeList), AsXmlNode round-trip.
- coverage.yaml entries updated: `Add`, `AsXmlNode`, `Attributes`, `Create`, `GetChildElements`, `HasAttributes`, `HasElements`, `InnerText`, `InnerXml`, `LocalName`, `Name`, `RemoveAttribute`, `SelectNodes`, `SetAttribute`.

## Test plan
- [x] New suite — 16/16 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)