### PR TITLE
feat: TextBuilder — Insert, Remove, Replace, Length, Clear, Capacity, MaxCapacity, EnsureCapacity (#725)

### DIFF
--- a/AlRunner/Runtime/MockTextBuilder.cs
+++ b/AlRunner/Runtime/MockTextBuilder.cs
@@ -46,6 +46,83 @@ public class MockTextBuilder
         return new NavText(_sb.ToString());
     }
 
+    // ── New methods (#725) ──────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Returns the number of characters in the builder.
+    /// BC emits <c>tb.ALLength</c> for <c>TextBuilder.Length</c>.
+    /// </summary>
+    public int ALLength => _sb.Length;
+
+    /// <summary>
+    /// Returns the current capacity of the underlying StringBuilder.
+    /// BC emits <c>tb.ALCapacity</c> for <c>TextBuilder.Capacity</c>.
+    /// </summary>
+    public int ALCapacity => _sb.Capacity;
+
+    /// <summary>
+    /// Returns the maximum capacity of the underlying StringBuilder.
+    /// BC emits <c>tb.ALMaxCapacity</c> for <c>TextBuilder.MaxCapacity</c>.
+    /// </summary>
+    public int ALMaxCapacity => _sb.MaxCapacity;
+
+    /// <summary>
+    /// Clears the builder.
+    /// BC emits <c>tb.ALClear(DataError)</c> or <c>tb.ALClear()</c>.
+    /// </summary>
+    public void ALClear(DataError errorLevel) => _sb.Clear();
+    public void ALClear() => _sb.Clear();
+
+    /// <summary>
+    /// Ensures the builder has at least the specified capacity.
+    /// BC emits <c>tb.ALEnsureCapacity(DataError, capacity)</c>.
+    /// </summary>
+    public void ALEnsureCapacity(DataError errorLevel, int capacity)
+    {
+        if (_sb.Capacity < capacity)
+            _sb.Capacity = capacity;
+    }
+    public void ALEnsureCapacity(int capacity)
+    {
+        if (_sb.Capacity < capacity)
+            _sb.Capacity = capacity;
+    }
+
+    /// <summary>
+    /// Inserts text at the specified zero-based position.
+    /// BC emits <c>tb.ALInsert(DataError, index, text)</c>.
+    /// </summary>
+    public void ALInsert(DataError errorLevel, int index, NavText text)
+        => _sb.Insert(index, (string)text);
+    public void ALInsert(DataError errorLevel, int index, string text)
+        => _sb.Insert(index, text);
+    public void ALInsert(int index, NavText text)
+        => _sb.Insert(index, (string)text);
+    public void ALInsert(int index, string text)
+        => _sb.Insert(index, text);
+
+    /// <summary>
+    /// Removes <paramref name="count"/> characters starting at zero-based <paramref name="startIndex"/>.
+    /// BC emits <c>tb.ALRemove(DataError, startIndex, count)</c>.
+    /// </summary>
+    public void ALRemove(DataError errorLevel, int startIndex, int count)
+        => _sb.Remove(startIndex, count);
+    public void ALRemove(int startIndex, int count)
+        => _sb.Remove(startIndex, count);
+
+    /// <summary>
+    /// Replaces all occurrences of <paramref name="oldValue"/> with <paramref name="newValue"/>.
+    /// BC emits <c>tb.ALReplace(DataError, oldValue, newValue)</c>.
+    /// </summary>
+    public void ALReplace(DataError errorLevel, NavText oldValue, NavText newValue)
+        => _sb.Replace((string)oldValue, (string)newValue);
+    public void ALReplace(DataError errorLevel, string oldValue, string newValue)
+        => _sb.Replace(oldValue, newValue);
+    public void ALReplace(NavText oldValue, NavText newValue)
+        => _sb.Replace((string)oldValue, (string)newValue);
+    public void ALReplace(string oldValue, string newValue)
+        => _sb.Replace(oldValue, newValue);
+
     /// <summary>
     /// Implicit conversion to string for formatting contexts.
     /// </summary>

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -7668,50 +7668,58 @@ TextBuilder.AppendLine:
 TextBuilder.Capacity:
   layer: runtime-api
   category: TextBuilder
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; MockTextBuilder.ALCapacity => _sb.Capacity
+  tests: tests/bucket-1/271-textbuilder-methods
 
 TextBuilder.Clear:
   layer: runtime-api
   category: TextBuilder
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; MockTextBuilder.ALClear() clears StringBuilder
+  tests: tests/bucket-1/271-textbuilder-methods
 
 TextBuilder.EnsureCapacity:
   layer: runtime-api
   category: TextBuilder
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; MockTextBuilder.ALEnsureCapacity(capacity) sets _sb.Capacity
+  tests: tests/bucket-1/271-textbuilder-methods
 
 TextBuilder.Insert:
   layer: runtime-api
   category: TextBuilder
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; MockTextBuilder.ALInsert(DataError, index, text) delegates to _sb.Insert
+  tests: tests/bucket-1/271-textbuilder-methods
 
 TextBuilder.Length:
   layer: runtime-api
   category: TextBuilder
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; MockTextBuilder.ALLength => _sb.Length
+  tests: tests/bucket-1/271-textbuilder-methods
 
 TextBuilder.MaxCapacity:
   layer: runtime-api
   category: TextBuilder
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; MockTextBuilder.ALMaxCapacity => _sb.MaxCapacity
+  tests: tests/bucket-1/271-textbuilder-methods
 
 TextBuilder.Remove:
   layer: runtime-api
   category: TextBuilder
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; MockTextBuilder.ALRemove(DataError, startIndex, count)
+  tests: tests/bucket-1/271-textbuilder-methods
 
 TextBuilder.Replace:
   layer: runtime-api
   category: TextBuilder
-  status: gap
-  notes: overloads=2
+  status: covered
+  notes: overloads=2; MockTextBuilder.ALReplace(DataError, oldValue, newValue)
+  tests: tests/bucket-1/271-textbuilder-methods
 
 TextBuilder.ToText:
   layer: runtime-api

--- a/tests/bucket-1/271-textbuilder-methods/src/TbmSrc.al
+++ b/tests/bucket-1/271-textbuilder-methods/src/TbmSrc.al
@@ -1,0 +1,78 @@
+/// Helper codeunit exercising the 8 missing TextBuilder methods.
+codeunit 84405 "TBM Src"
+{
+    // ── Insert ──────────────────────────────────────────────────────────────────
+    procedure InsertAtPosition(base: Text; pos: Integer; toInsert: Text): Text
+    var
+        TB: TextBuilder;
+    begin
+        TB.Append(base);
+        TB.Insert(pos, toInsert);
+        exit(TB.ToText());
+    end;
+
+    // ── Remove ──────────────────────────────────────────────────────────────────
+    procedure RemoveRange(base: Text; startPos: Integer; count: Integer): Text
+    var
+        TB: TextBuilder;
+    begin
+        TB.Append(base);
+        TB.Remove(startPos, count);
+        exit(TB.ToText());
+    end;
+
+    // ── Replace ─────────────────────────────────────────────────────────────────
+    procedure ReplaceText(base: Text; oldVal: Text; newVal: Text): Text
+    var
+        TB: TextBuilder;
+    begin
+        TB.Append(base);
+        TB.Replace(oldVal, newVal);
+        exit(TB.ToText());
+    end;
+
+    // ── Length ──────────────────────────────────────────────────────────────────
+    procedure GetLength(text: Text): Integer
+    var
+        TB: TextBuilder;
+    begin
+        TB.Append(text);
+        exit(TB.Length);
+    end;
+
+    // ── Clear ───────────────────────────────────────────────────────────────────
+    procedure AppendThenClear(text: Text): Text
+    var
+        TB: TextBuilder;
+    begin
+        TB.Append(text);
+        TB.Clear();
+        exit(TB.ToText());
+    end;
+
+    // ── Capacity ────────────────────────────────────────────────────────────────
+    procedure GetCapacity(): Integer
+    var
+        TB: TextBuilder;
+    begin
+        TB.Append('hello');
+        exit(TB.Capacity);
+    end;
+
+    // ── MaxCapacity ─────────────────────────────────────────────────────────────
+    procedure GetMaxCapacity(): Integer
+    var
+        TB: TextBuilder;
+    begin
+        exit(TB.MaxCapacity);
+    end;
+
+    // ── EnsureCapacity ──────────────────────────────────────────────────────────
+    procedure EnsureAndGetCapacity(minCapacity: Integer): Integer
+    var
+        TB: TextBuilder;
+    begin
+        TB.EnsureCapacity(minCapacity);
+        exit(TB.Capacity);
+    end;
+}

--- a/tests/bucket-1/271-textbuilder-methods/test/TbmTest.al
+++ b/tests/bucket-1/271-textbuilder-methods/test/TbmTest.al
@@ -1,0 +1,136 @@
+codeunit 84406 "TBM Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "TBM Src";
+
+    // ── Insert ──────────────────────────────────────────────────────────────────
+    [Test]
+    procedure Insert_AtMiddle_ProducesExpectedString()
+    begin
+        // Positive: Insert(5, ', World') after 'Hello' gives 'Hello, World'.
+        Assert.AreEqual('Hello, World', Src.InsertAtPosition('Hello', 5, ', World'),
+            'Insert at position 5 must splice text correctly');
+    end;
+
+    [Test]
+    procedure Insert_AtZero_PrependsText()
+    begin
+        // Positive: Insert(0, 'Hi ') before 'there' gives 'Hi there'.
+        Assert.AreEqual('Hi there', Src.InsertAtPosition('there', 0, 'Hi '),
+            'Insert at position 0 must prepend');
+    end;
+
+    [Test]
+    procedure Insert_AtEnd_AppendsText()
+    begin
+        // Positive: Insert(5, '!') at end of 'Hello' gives 'Hello!'.
+        Assert.AreEqual('Hello!', Src.InsertAtPosition('Hello', 5, '!'),
+            'Insert at length position must append');
+    end;
+
+    // ── Remove ──────────────────────────────────────────────────────────────────
+    [Test]
+    procedure Remove_MiddleRange_ProducesExpectedString()
+    begin
+        // Positive: Remove(5, 7) from 'Hello, World' gives 'Hello'.
+        Assert.AreEqual('Hello', Src.RemoveRange('Hello, World', 5, 7),
+            'Remove(5,7) must delete ", World"');
+    end;
+
+    [Test]
+    procedure Remove_FromStart_ProducesExpectedString()
+    begin
+        // Positive: Remove(0, 6) from 'Hello World' gives 'World'.
+        Assert.AreEqual('World', Src.RemoveRange('Hello World', 0, 6),
+            'Remove(0,6) must delete "Hello "');
+    end;
+
+    // ── Replace ─────────────────────────────────────────────────────────────────
+    [Test]
+    procedure Replace_Occurrence_ProducesExpectedString()
+    begin
+        // Positive: Replace('World', 'BC') in 'Hello World' gives 'Hello BC'.
+        Assert.AreEqual('Hello BC', Src.ReplaceText('Hello World', 'World', 'BC'),
+            'Replace must substitute matching text');
+    end;
+
+    [Test]
+    procedure Replace_NoMatch_LeavesStringUnchanged()
+    begin
+        // Negative: Replace('xyz', 'abc') in 'Hello' leaves 'Hello' unchanged.
+        Assert.AreEqual('Hello', Src.ReplaceText('Hello', 'xyz', 'abc'),
+            'Replace with no match must leave string unchanged');
+    end;
+
+    // ── Length ──────────────────────────────────────────────────────────────────
+    [Test]
+    procedure Length_ReturnsCharacterCount()
+    begin
+        // Positive: Length of 'Hello' is 5.
+        Assert.AreEqual(5, Src.GetLength('Hello'),
+            'Length must return the number of characters');
+    end;
+
+    [Test]
+    procedure Length_EmptyBuilder_ReturnsZero()
+    begin
+        // Positive: Length of '' is 0.
+        Assert.AreEqual(0, Src.GetLength(''),
+            'Length of empty builder must be 0');
+    end;
+
+    // ── Clear ───────────────────────────────────────────────────────────────────
+    [Test]
+    procedure Clear_AfterAppend_ReturnsEmptyString()
+    begin
+        // Positive: Clear() resets ToText() to ''.
+        Assert.AreEqual('', Src.AppendThenClear('Hello'),
+            'Clear must reset builder to empty string');
+    end;
+
+    [Test]
+    procedure Clear_NotEqualToOriginal()
+    begin
+        // Negative: cleared builder does not return original content.
+        Assert.AreNotEqual('Hello', Src.AppendThenClear('Hello'),
+            'After Clear, ToText must not return the original text');
+    end;
+
+    // ── Capacity ────────────────────────────────────────────────────────────────
+    [Test]
+    procedure Capacity_AfterAppend_IsPositive()
+    begin
+        // Positive: Capacity is greater than 0 after appending text.
+        Assert.IsTrue(Src.GetCapacity() > 0,
+            'Capacity must be positive after appending text');
+    end;
+
+    // ── MaxCapacity ─────────────────────────────────────────────────────────────
+    [Test]
+    procedure MaxCapacity_IsPositive()
+    begin
+        // Positive: MaxCapacity is a large positive number.
+        Assert.IsTrue(Src.GetMaxCapacity() > 0,
+            'MaxCapacity must be a positive number');
+    end;
+
+    // ── EnsureCapacity ──────────────────────────────────────────────────────────
+    [Test]
+    procedure EnsureCapacity_AtLeastRequestedSize()
+    begin
+        // Positive: after EnsureCapacity(100), Capacity >= 100.
+        Assert.IsTrue(Src.EnsureAndGetCapacity(100) >= 100,
+            'After EnsureCapacity(100), Capacity must be at least 100');
+    end;
+
+    [Test]
+    procedure EnsureCapacity_WithSmallValue_DoesNotCrash()
+    begin
+        // Positive: EnsureCapacity(1) does not crash.
+        Src.EnsureAndGetCapacity(1);
+        Assert.IsTrue(true, 'EnsureCapacity(1) must not crash');
+    end;
+}


### PR DESCRIPTION
Closes #725

Adds 8 missing methods to `MockTextBuilder`:

| Method | Implementation |
|--------|----------------|
| `Length` | `ALLength => _sb.Length` |
| `Capacity` | `ALCapacity => _sb.Capacity` |
| `MaxCapacity` | `ALMaxCapacity => _sb.MaxCapacity` |
| `Clear` | `ALClear()` clears StringBuilder |
| `EnsureCapacity` | sets `_sb.Capacity` when below threshold |
| `Insert` | `_sb.Insert(index, text)` |
| `Remove` | `_sb.Remove(startIndex, count)` |
| `Replace` | `_sb.Replace(oldValue, newValue)` |

Each method has `DataError` and bare overloads to match BC codegen patterns.

New suite `tests/bucket-1/271-textbuilder-methods` — 14 proving tests with RED confirmed, GREEN after implementation.