### PR TITLE
feat: SessionSettings — in-memory mock + proving tests (#722)

### DIFF
--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -1247,6 +1247,12 @@ public void ClearApplicationMemberVariables()
         if (text == "NavFilterPageBuilder")
             return node.WithIdentifier(SyntaxFactory.Identifier("MockFilterPageBuilder"));
 
+        // NavSessionSettings -> MockSessionSettings
+        // NavSessionSettings.ALInit() dereferences NavSession (null standalone).
+        // MockSessionSettings stores settings in-memory; RequestSessionUpdate is a no-op.
+        if (text == "NavSessionSettings")
+            return node.WithIdentifier(SyntaxFactory.Identifier("MockSessionSettings"));
+
         // NavEventScope -> object (event scope type used for static fields)
         // Use PredefinedType to emit the C# keyword "object" properly, avoiding
         // namespace resolution issues where "object" as an IdentifierName fails.

--- a/AlRunner/Runtime/MockSessionSettings.cs
+++ b/AlRunner/Runtime/MockSessionSettings.cs
@@ -1,0 +1,64 @@
+namespace AlRunner.Runtime;
+
+using Microsoft.Dynamics.Nav.Runtime;
+using Microsoft.Dynamics.Nav.Types;
+
+/// <summary>
+/// In-memory stand-in for NavSessionSettings. Real NavSessionSettings.ALInit()
+/// dereferences NavSession (null in standalone mode). MockSessionSettings keeps
+/// the settings as local fields; RequestSessionUpdate is a no-op because there
+/// is no service-tier session to refresh.
+///
+/// Note: BC emits string (not NavText) for Text-typed properties on this type,
+/// so all text-valued members are declared as <see cref="string"/>. NavText has
+/// implicit conversions to/from string, so callers that supply NavText values
+/// still compile.
+/// </summary>
+public class MockSessionSettings
+{
+    public MockSessionSettings() { }
+
+    /// <summary>ALInit — populates with standalone defaults. Always safe to call.</summary>
+    public void ALInit()
+    {
+        ALCompany = "";
+        ALLanguageId = 0;
+        ALLocaleId = 0;
+        ALProfileId = "";
+        ALProfileAppId = new NavGuid(System.Guid.Empty);
+        ALProfileSystemScope = 0;
+        ALTimeZone = "";
+    }
+
+    /// <summary>Company — AL Text property.</summary>
+    public string ALCompany { get; set; } = "";
+
+    /// <summary>LanguageId — Windows LCID integer.</summary>
+    public int ALLanguageId { get; set; }
+
+    /// <summary>LocaleId — Windows LCID integer.</summary>
+    public int ALLocaleId { get; set; }
+
+    /// <summary>ProfileId — Text[30] identifier.</summary>
+    public string ALProfileId { get; set; } = "";
+
+    /// <summary>ProfileAppId — GUID.</summary>
+    public NavGuid ALProfileAppId { get; set; } = new NavGuid(System.Guid.Empty);
+
+    /// <summary>ProfileSystemScope — option (System / Tenant / Extension).</summary>
+    public int ALProfileSystemScope { get; set; }
+
+    /// <summary>TimeZone — IANA/Windows time-zone name.</summary>
+    public string ALTimeZone { get; set; } = "";
+
+    /// <summary>
+    /// ALRequestSessionUpdate — service-tier API for pushing the new settings to the
+    /// BC session. In standalone there is no session to refresh; the local state is
+    /// already authoritative so the call is a no-op.
+    /// </summary>
+    public void ALRequestSessionUpdate(bool reloadUserProfile) { }
+    public void ALRequestSessionUpdate() { }
+
+    /// <summary>Default factory — mirrors NavSessionSettings.Default(ITreeObject).</summary>
+    public static MockSessionSettings Default() => new MockSessionSettings();
+}

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -5572,56 +5572,65 @@ SessionInformation.SqlStatementsExecuted:
 SessionSettings.Company:
   layer: runtime-api
   category: SessionSettings
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-2/192-session-settings
+  notes: overloads=1. MockSessionSettings holds setting in-memory; setter + getter round-trip tested.
 
 SessionSettings.Init:
   layer: runtime-api
   category: SessionSettings
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-2/192-session-settings
+  notes: overloads=1. NavSessionSettings is rewritten to MockSessionSettings; ALInit populates defaults and never dereferences NavSession.
 
 SessionSettings.LanguageId:
   layer: runtime-api
   category: SessionSettings
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-2/192-session-settings
+  notes: overloads=1. Integer setter + getter round-trip on MockSessionSettings.
 
 SessionSettings.LocaleId:
   layer: runtime-api
   category: SessionSettings
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-2/192-session-settings
+  notes: overloads=1. Integer setter + getter round-trip on MockSessionSettings.
 
 SessionSettings.ProfileAppId:
   layer: runtime-api
   category: SessionSettings
-  status: gap
-  notes: overloads=1
+  status: stub
+  tests: tests/bucket-2/192-session-settings
+  notes: overloads=1. Property present on MockSessionSettings (NavGuid, defaults to Guid.Empty); explicit setter/getter tests TBD.
 
 SessionSettings.ProfileId:
   layer: runtime-api
   category: SessionSettings
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-2/192-session-settings
+  notes: overloads=1. Text setter + getter round-trip on MockSessionSettings.
 
 SessionSettings.ProfileSystemScope:
   layer: runtime-api
   category: SessionSettings
-  status: gap
-  notes: overloads=1
+  status: stub
+  tests: tests/bucket-2/192-session-settings
+  notes: overloads=1. Option-typed property present on MockSessionSettings; explicit setter/getter tests TBD.
 
 SessionSettings.RequestSessionUpdate:
   layer: runtime-api
   category: SessionSettings
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-2/192-session-settings
+  notes: overloads=2 (with/without reloadUserProfile flag). Standalone no-op — no service-tier session to refresh. Preserves local state.
 
 SessionSettings.TimeZone:
   layer: runtime-api
   category: SessionSettings
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-2/192-session-settings
+  notes: overloads=1. Text setter + getter round-trip on MockSessionSettings.
 
 # ── System ──────────────────────────────────────────────────────
 

--- a/tests/bucket-2/192-session-settings/al-runner.json
+++ b/tests/bucket-2/192-session-settings/al-runner.json
@@ -1,0 +1,4 @@
+{
+  "sourcePath": "./src",
+  "testPath": "./test"
+}

--- a/tests/bucket-2/192-session-settings/src/SessionSettingsSrc.al
+++ b/tests/bucket-2/192-session-settings/src/SessionSettingsSrc.al
@@ -1,0 +1,79 @@
+/// Helper codeunit exercising SessionSettings — Init + property
+/// accessors + RequestSessionUpdate. Standalone semantics: settings
+/// hold in-memory defaults; RequestSessionUpdate is a no-op (no
+/// service-tier session to refresh).
+codeunit 60180 "SST Src"
+{
+    procedure Init_DoesNotThrow(): Boolean
+    var
+        s: SessionSettings;
+    begin
+        s.Init();
+        exit(true);
+    end;
+
+    procedure GetCompany(): Text
+    var
+        s: SessionSettings;
+    begin
+        s.Init();
+        exit(s.Company);
+    end;
+
+    procedure SetAndGetCompany(value: Text): Text
+    var
+        s: SessionSettings;
+    begin
+        s.Init();
+        s.Company := value;
+        exit(s.Company);
+    end;
+
+    procedure SetAndGetLanguageId(value: Integer): Integer
+    var
+        s: SessionSettings;
+    begin
+        s.Init();
+        s.LanguageId := value;
+        exit(s.LanguageId);
+    end;
+
+    procedure SetAndGetLocaleId(value: Integer): Integer
+    var
+        s: SessionSettings;
+    begin
+        s.Init();
+        s.LocaleId := value;
+        exit(s.LocaleId);
+    end;
+
+    procedure SetAndGetTimeZone(value: Text): Text
+    var
+        s: SessionSettings;
+    begin
+        s.Init();
+        s.TimeZone := value;
+        exit(s.TimeZone);
+    end;
+
+    procedure SetAndGetProfileId(value: Text): Text
+    var
+        s: SessionSettings;
+    begin
+        s.Init();
+        s.ProfileId := value;
+        exit(s.ProfileId);
+    end;
+
+    procedure RequestSessionUpdate_NoOp(): Boolean
+    var
+        s: SessionSettings;
+    begin
+        s.Init();
+        s.Company := 'Acme';
+        s.RequestSessionUpdate(false);
+        // After the update request the in-memory value stays intact — nothing
+        // to refresh standalone.
+        exit(s.Company = 'Acme');
+    end;
+}

--- a/tests/bucket-2/192-session-settings/test/SessionSettingsTest.al
+++ b/tests/bucket-2/192-session-settings/test/SessionSettingsTest.al
@@ -1,0 +1,73 @@
+codeunit 60181 "SST Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "SST Src";
+
+    [Test]
+    procedure Init_DoesNotThrow()
+    begin
+        Assert.IsTrue(Src.Init_DoesNotThrow(),
+            'SessionSettings.Init must complete without throwing');
+    end;
+
+    [Test]
+    procedure DefaultCompany_IsEmpty()
+    begin
+        Assert.AreEqual('', Src.GetCompany(),
+            'Default SessionSettings.Company must be empty');
+    end;
+
+    [Test]
+    procedure SetAndGet_Company()
+    begin
+        Assert.AreEqual('Contoso', Src.SetAndGetCompany('Contoso'),
+            'SessionSettings.Company setter + getter must round-trip');
+    end;
+
+    [Test]
+    procedure SetAndGet_LanguageId()
+    begin
+        Assert.AreEqual(1033, Src.SetAndGetLanguageId(1033),
+            'SessionSettings.LanguageId setter + getter must round-trip');
+    end;
+
+    [Test]
+    procedure SetAndGet_LocaleId()
+    begin
+        Assert.AreEqual(2057, Src.SetAndGetLocaleId(2057),
+            'SessionSettings.LocaleId setter + getter must round-trip');
+    end;
+
+    [Test]
+    procedure SetAndGet_TimeZone()
+    begin
+        Assert.AreEqual('UTC', Src.SetAndGetTimeZone('UTC'),
+            'SessionSettings.TimeZone setter + getter must round-trip');
+    end;
+
+    [Test]
+    procedure SetAndGet_ProfileId()
+    begin
+        Assert.AreEqual('ACCOUNTANT', Src.SetAndGetProfileId('ACCOUNTANT'),
+            'SessionSettings.ProfileId setter + getter must round-trip');
+    end;
+
+    [Test]
+    procedure RequestSessionUpdate_Is_NoOp()
+    begin
+        Assert.IsTrue(Src.RequestSessionUpdate_NoOp(),
+            'RequestSessionUpdate must be a standalone no-op that preserves local state');
+    end;
+
+    [Test]
+    procedure Company_Setter_NotANoop_NegativeTrap()
+    begin
+        // Negative trap: make sure the setter actually stores — if it were a
+        // no-op the result would equal the default empty string.
+        Assert.AreNotEqual('', Src.SetAndGetCompany('Contoso'),
+            'Company setter must not be a no-op — value must persist');
+    end;
+}


### PR DESCRIPTION
## Summary
- Closes #722
- `NavSessionSettings.ALInit()` dereferences NavSession (null standalone) so any AL code touching SessionSettings NRE'd immediately.
- Adds `MockSessionSettings` with in-memory setter/getter properties for `Company`, `LanguageId`, `LocaleId`, `ProfileId`, `ProfileAppId`, `ProfileSystemScope`, `TimeZone`, plus `ALInit` (resets to defaults) and `ALRequestSessionUpdate` (standalone no-op). `RoslynRewriter` swaps `NavSessionSettings` → `MockSessionSettings`.
- Text members are `string` because BC emits the setter call with a string literal; NavText has implicit conversions so callers that supply NavText still compile.
- New suite `tests/bucket-2/192-session-settings` — 9 tests: Init doesn't throw; default Company empty; setter+getter round-trips for Company/LanguageId/LocaleId/TimeZone/ProfileId; RequestSessionUpdate preserves local state; not-a-no-op trap.

## Test plan
- [x] New suite — 9/9 pass
- [x] bucket-2 regression — 1310 pass, 3 pre-existing timezone failures (unrelated)
- [x] bucket-1 regression — 890 pass, 4 pre-existing failures (unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)