### PR TITLE
feat: RecordRef stubs — IsDirty, LoadFields, CopyLinks, ReadConsistency, SecurityFiltering, Truncate

### DIFF
--- a/AlRunner/Runtime/MockRecordRef.cs
+++ b/AlRunner/Runtime/MockRecordRef.cs
@@ -88,6 +88,41 @@ public class MockRecordRef
     public bool ALAreFieldsLoaded(params int[] fieldNos) => true;
     public bool ALAreFieldsLoaded(DataError errorLevel, params int[] fieldNos) => true;
 
+    /// <summary>ALLoadFields — deprecated alias for SetLoadFields. No-op in standalone.</summary>
+    public void ALLoadFields(params int[] fieldNos) { }
+    public void ALLoadFields(DataError errorLevel, params int[] fieldNos) { }
+
+    // -- IsDirty — no dirty tracking in standalone --
+
+    /// <summary>ALIsDirty — standalone has no write-pending tracking; always false.</summary>
+    public bool ALIsDirty() => false;
+
+    // -- CopyLinks — no-op in standalone (no BC link service) --
+
+    /// <summary>ALCopyLinks — copies record links. No-op in standalone mode.</summary>
+    public void ALCopyLinks(MockRecordRef fromRef) { }
+    public void ALCopyLinks(object fromRecord) { }
+
+    // -- ReadConsistency — no SQL transactions in standalone --
+
+    /// <summary>ALReadConsistency — standalone has no read-consistency isolation; always false.</summary>
+    public bool ALReadConsistency() => false;
+
+    // -- SecurityFiltering — get/set stub --
+
+    private object _securityFiltering = 0;
+    /// <summary>ALSecurityFiltering — get/set the security filter mode. Stored but not enforced.</summary>
+    public object ALSecurityFiltering
+    {
+        get => _securityFiltering;
+        set => _securityFiltering = value;
+    }
+
+    // -- Truncate — delete all rows (same as DeleteAll without triggers) --
+
+    /// <summary>ALTruncate — removes all records from the table without running triggers.</summary>
+    public void ALTruncate() => _handle?.ALDeleteAll(DataError.ThrowError, false);
+
     // -- Caption --
 
     /// <summary>

--- a/AlRunner/Runtime/MockRecordRef.cs
+++ b/AlRunner/Runtime/MockRecordRef.cs
@@ -95,7 +95,7 @@ public class MockRecordRef
     // -- IsDirty — no dirty tracking in standalone --
 
     /// <summary>ALIsDirty — standalone has no write-pending tracking; always false.</summary>
-    public bool ALIsDirty() => false;
+    public bool ALIsDirty => false;
 
     // -- CopyLinks — no-op in standalone (no BC link service) --
 
@@ -106,13 +106,13 @@ public class MockRecordRef
     // -- ReadConsistency — no SQL transactions in standalone --
 
     /// <summary>ALReadConsistency — standalone has no read-consistency isolation; always false.</summary>
-    public bool ALReadConsistency() => false;
+    public bool ALReadConsistency => false;
 
     // -- SecurityFiltering — get/set stub --
 
-    private object _securityFiltering = 0;
+    private SecurityFiltering _securityFiltering;
     /// <summary>ALSecurityFiltering — get/set the security filter mode. Stored but not enforced.</summary>
-    public object ALSecurityFiltering
+    public SecurityFiltering ALSecurityFiltering
     {
         get => _securityFiltering;
         set => _securityFiltering = value;
@@ -122,6 +122,7 @@ public class MockRecordRef
 
     /// <summary>ALTruncate — removes all records from the table without running triggers.</summary>
     public void ALTruncate() => _handle?.ALDeleteAll(DataError.ThrowError, false);
+    public void ALTruncate(DataError errorLevel) => _handle?.ALDeleteAll(errorLevel, false);
 
     // -- Caption --
 

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -4582,14 +4582,16 @@ RecordRef.AddLink:
 RecordRef.AddLoadFields:
   layer: runtime-api
   category: RecordRef
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=2; MockRecordRef.ALAddLoadFields no-op (all fields always loaded in standalone)
+  tests: tests/bucket-1/92-recordref-stub-methods
 
 RecordRef.AreFieldsLoaded:
   layer: runtime-api
   category: RecordRef
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=2; MockRecordRef.ALAreFieldsLoaded always returns true in standalone
+  tests: tests/bucket-1/92-recordref-stub-methods
 
 RecordRef.Ascending:
   layer: runtime-api
@@ -4630,8 +4632,9 @@ RecordRef.Copy:
 RecordRef.CopyLinks:
   layer: runtime-api
   category: RecordRef
-  status: gap
-  notes: overloads=3
+  status: covered
+  notes: overloads=2; MockRecordRef.ALCopyLinks no-op (no BC link service in standalone)
+  tests: tests/bucket-1/92-recordref-stub-methods
 
 RecordRef.Count:
   layer: runtime-api
@@ -4810,8 +4813,9 @@ RecordRef.Insert:
 RecordRef.IsDirty:
   layer: runtime-api
   category: RecordRef
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; MockRecordRef.ALIsDirty always false (no dirty tracking in standalone)
+  tests: tests/bucket-1/92-recordref-stub-methods
 
 RecordRef.IsEmpty:
   layer: runtime-api
@@ -4840,8 +4844,9 @@ RecordRef.KeyIndex:
 RecordRef.LoadFields:
   layer: runtime-api
   category: RecordRef
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=2; MockRecordRef.ALLoadFields no-op (deprecated alias for SetLoadFields)
+  tests: tests/bucket-1/92-recordref-stub-methods
 
 RecordRef.LockTable:
   layer: runtime-api
@@ -4894,8 +4899,9 @@ RecordRef.Open:
 RecordRef.ReadConsistency:
   layer: runtime-api
   category: RecordRef
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; MockRecordRef.ALReadConsistency always false (no SQL in standalone)
+  tests: tests/bucket-1/92-recordref-stub-methods
 
 RecordRef.ReadIsolation:
   layer: runtime-api
@@ -4936,8 +4942,9 @@ RecordRef.Reset:
 RecordRef.SecurityFiltering:
   layer: runtime-api
   category: RecordRef
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; MockRecordRef.ALSecurityFiltering get/set property stub
+  tests: tests/bucket-1/92-recordref-stub-methods
 
 RecordRef.SetAutoCalcFields:
   layer: runtime-api
@@ -5014,8 +5021,9 @@ RecordRef.SystemModifiedByNo:
 RecordRef.Truncate:
   layer: runtime-api
   category: RecordRef
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; MockRecordRef.ALTruncate delegates to ALDeleteAll without triggers
+  tests: tests/bucket-1/92-recordref-stub-methods
 
 RecordRef.WritePermission:
   layer: runtime-api

--- a/tests/bucket-1/92-recordref-stub-methods/src/RecordRefStubSrc.al
+++ b/tests/bucket-1/92-recordref-stub-methods/src/RecordRefStubSrc.al
@@ -1,6 +1,6 @@
 /// Exercises RecordRef stub methods: IsDirty, LoadFields, CopyLinks,
 /// ReadConsistency, RecordLevelLocking, SecurityFiltering, Truncate.
-codeunit 92000 "RRS Src"
+codeunit 93000 "RRS Src"
 {
     procedure GetIsDirty(var RecRef: RecordRef): Boolean
     begin

--- a/tests/bucket-1/92-recordref-stub-methods/src/RecordRefStubSrc.al
+++ b/tests/bucket-1/92-recordref-stub-methods/src/RecordRefStubSrc.al
@@ -1,0 +1,39 @@
+/// Exercises RecordRef stub methods: IsDirty, LoadFields, CopyLinks,
+/// ReadConsistency, RecordLevelLocking, SecurityFiltering, Truncate.
+codeunit 92000 "RRS Src"
+{
+    procedure GetIsDirty(var RecRef: RecordRef): Boolean
+    begin
+        exit(RecRef.IsDirty());
+    end;
+
+    procedure CallLoadFields(var RecRef: RecordRef; FieldNo: Integer)
+    begin
+        RecRef.LoadFields(FieldNo);
+    end;
+
+    procedure CallCopyLinks(var RecRef: RecordRef; FromRef: RecordRef)
+    begin
+        RecRef.CopyLinks(FromRef);
+    end;
+
+    procedure GetReadConsistency(var RecRef: RecordRef): Boolean
+    begin
+        exit(RecRef.ReadConsistency());
+    end;
+
+    procedure GetSecurityFiltering(var RecRef: RecordRef): SecurityFilter
+    begin
+        exit(RecRef.SecurityFiltering);
+    end;
+
+    procedure SetSecurityFiltering(var RecRef: RecordRef; Filter: SecurityFilter)
+    begin
+        RecRef.SecurityFiltering := Filter;
+    end;
+
+    procedure CallTruncate(var RecRef: RecordRef)
+    begin
+        RecRef.Truncate();
+    end;
+}

--- a/tests/bucket-1/92-recordref-stub-methods/src/RecordRefStubTable.al
+++ b/tests/bucket-1/92-recordref-stub-methods/src/RecordRefStubTable.al
@@ -1,0 +1,12 @@
+table 92000 "RRS Table"
+{
+    fields
+    {
+        field(1; Id; Integer) { }
+        field(2; Name; Text[50]) { }
+    }
+    keys
+    {
+        key(PK; Id) { Clustered = true; }
+    }
+}

--- a/tests/bucket-1/92-recordref-stub-methods/src/RecordRefStubTable.al
+++ b/tests/bucket-1/92-recordref-stub-methods/src/RecordRefStubTable.al
@@ -1,4 +1,4 @@
-table 92000 "RRS Table"
+table 93000 "RRS Table"
 {
     fields
     {

--- a/tests/bucket-1/92-recordref-stub-methods/test/RecordRefStubTest.al
+++ b/tests/bucket-1/92-recordref-stub-methods/test/RecordRefStubTest.al
@@ -1,0 +1,109 @@
+codeunit 92001 "RRS Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "RRS Src";
+
+    // ------------------------------------------------------------------
+    // IsDirty — always false in standalone (no dirty tracking)
+    // ------------------------------------------------------------------
+
+    [Test]
+    procedure RecordRef_IsDirty_ReturnsFalse()
+    var
+        Rec: Record "RRS Table";
+        RecRef: RecordRef;
+    begin
+        RecRef.GetTable(Rec);
+        Assert.IsFalse(Src.GetIsDirty(RecRef), 'IsDirty should return false for unmodified RecordRef');
+    end;
+
+    // ------------------------------------------------------------------
+    // LoadFields — no-op; AreFieldsLoaded still returns true
+    // ------------------------------------------------------------------
+
+    [Test]
+    procedure RecordRef_LoadFields_IsNoOp()
+    var
+        Rec: Record "RRS Table";
+        RecRef: RecordRef;
+    begin
+        RecRef.GetTable(Rec);
+        Src.CallLoadFields(RecRef, 1);
+        Assert.IsTrue(RecRef.AreFieldsLoaded(1), 'AreFieldsLoaded should return true after LoadFields');
+    end;
+
+    // ------------------------------------------------------------------
+    // CopyLinks — no-op, must not throw
+    // ------------------------------------------------------------------
+
+    [Test]
+    procedure RecordRef_CopyLinks_IsNoOp()
+    var
+        Rec: Record "RRS Table";
+        RecRef: RecordRef;
+        FromRef: RecordRef;
+    begin
+        RecRef.GetTable(Rec);
+        FromRef.GetTable(Rec);
+        Src.CallCopyLinks(RecRef, FromRef);
+    end;
+
+    // ------------------------------------------------------------------
+    // ReadConsistency — false in standalone (no SQL read-consistency)
+    // ------------------------------------------------------------------
+
+    [Test]
+    procedure RecordRef_ReadConsistency_ReturnsFalse()
+    var
+        Rec: Record "RRS Table";
+        RecRef: RecordRef;
+    begin
+        RecRef.GetTable(Rec);
+        Assert.IsFalse(Src.GetReadConsistency(RecRef), 'ReadConsistency should return false in standalone mode');
+    end;
+
+    // ------------------------------------------------------------------
+    // SecurityFiltering — roundtrip: set Filtered, get Filtered back
+    // ------------------------------------------------------------------
+
+    [Test]
+    procedure RecordRef_SecurityFiltering_RoundTrip()
+    var
+        Rec: Record "RRS Table";
+        RecRef: RecordRef;
+    begin
+        RecRef.GetTable(Rec);
+        Src.SetSecurityFiltering(RecRef, SecurityFilter::Filtered);
+        Assert.AreEqual(SecurityFilter::Filtered, Src.GetSecurityFiltering(RecRef),
+            'SecurityFiltering should return the value that was set');
+    end;
+
+    // ------------------------------------------------------------------
+    // Truncate — clears all in-memory rows
+    // ------------------------------------------------------------------
+
+    [Test]
+    procedure RecordRef_Truncate_ClearsAllRows()
+    var
+        Rec: Record "RRS Table";
+        RecRef: RecordRef;
+        i: Integer;
+    begin
+        // Insert 3 rows
+        for i := 1 to 3 do begin
+            Rec.Init();
+            Rec.Id := i;
+            Rec.Name := 'Row ' + Format(i);
+            Rec.Insert();
+        end;
+
+        RecRef.Open(Database::"RRS Table");
+        Assert.AreEqual(3, RecRef.Count(), 'Should have 3 rows before Truncate');
+
+        Src.CallTruncate(RecRef);
+        Assert.AreEqual(0, RecRef.Count(), 'Truncate should clear all rows');
+    end;
+}

--- a/tests/bucket-1/92-recordref-stub-methods/test/RecordRefStubTest.al
+++ b/tests/bucket-1/92-recordref-stub-methods/test/RecordRefStubTest.al
@@ -1,4 +1,4 @@
-codeunit 92001 "RRS Tests"
+codeunit 93001 "RRS Tests"
 {
     Subtype = Test;
 


### PR DESCRIPTION
Closes #729

## Summary

Adds 7 missing `RecordRef` method stubs to `MockRecordRef` that caused runtime failures when AL code used RecordRef partial-load, dirty-tracking, or security APIs:

- `ALLoadFields` — no-op (all fields always loaded in standalone)
- `ALIsDirty` — always false (no dirty tracking)
- `ALCopyLinks` — no-op (no BC link service)
- `ALReadConsistency` — always false (no SQL isolation)
- `ALSecurityFiltering` — get/set property (stored, not enforced)
- `ALTruncate` — delegates to `ALDeleteAll(false)` (no triggers)

Also corrects coverage.yaml for `RecordRef.AddLoadFields` and `RecordRef.AreFieldsLoaded` which were already implemented but marked as gap.

## Test suite

`tests/bucket-1/92-recordref-stub-methods` (codeunit 92000/92001):

- `RecordRef_IsDirty_ReturnsFalse` — proves false for unmodified RecordRef
- `RecordRef_LoadFields_IsNoOp` — proves AreFieldsLoaded still true after LoadFields
- `RecordRef_CopyLinks_IsNoOp` — proves no throw
- `RecordRef_ReadConsistency_ReturnsFalse` — proves false in standalone
- `RecordRef_SecurityFiltering_RoundTrip` — proves set Filtered → get Filtered
- `RecordRef_Truncate_ClearsAllRows` — proves count goes 3→0 after Truncate