### PR TITLE
test: Text static — DelChr/DelStr/InsStr/LowerCase/UpperCase/MaxStrLen/StrLen/StrSubstNo (#731)

### DIFF
--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -7521,14 +7521,16 @@ Text.CopyStr:
 Text.DelChr:
   layer: runtime-api
   category: Text
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-2/194-text-static
+  notes: overloads=1. Static Text.DelChr form covered — where='=' strips all, '<' strips leading, '>' strips trailing.
 
 Text.DelStr:
   layer: runtime-api
   category: Text
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-2/194-text-static
+  notes: overloads=2 (pos / pos+count). Both forms covered — 1-based AL convention.
 
 Text.EndsWith:
   layer: runtime-api
@@ -7560,8 +7562,9 @@ Text.IndexOfAny:
 Text.InsStr:
   layer: runtime-api
   category: Text
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-2/194-text-static
+  notes: overloads=1. Static Text.InsStr form covered — insertion at start and middle positions (1-based).
 
 Text.LastIndexOf:
   layer: runtime-api
@@ -7573,14 +7576,16 @@ Text.LastIndexOf:
 Text.LowerCase:
   layer: runtime-api
   category: Text
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-2/194-text-static
+  notes: overloads=1. Static Text.LowerCase form covered — includes differs-from-UpperCase trap.
 
 Text.MaxStrLen:
   layer: runtime-api
   category: Text
-  status: gap
-  notes: overloads=2
+  status: covered
+  tests: tests/bucket-2/194-text-static
+  notes: overloads=2. Static Text.MaxStrLen form covered — returns the declared Text[N] length.
 
 Text.PadLeft:
   layer: runtime-api
@@ -7646,8 +7651,9 @@ Text.StrCheckSum:
 Text.StrLen:
   layer: runtime-api
   category: Text
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-2/194-text-static
+  notes: overloads=1. Static Text.StrLen form covered — length of non-empty and empty strings.
 
 Text.StrPos:
   layer: runtime-api
@@ -7658,8 +7664,9 @@ Text.StrPos:
 Text.StrSubstNo:
   layer: runtime-api
   category: Text
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-2/194-text-static
+  notes: overloads=1 (variadic). Static Text.StrSubstNo form covered — no-placeholder passthrough, single %1, multiple placeholders with mixed Text/Integer args.
 
 Text.Substring:
   layer: runtime-api
@@ -7703,8 +7710,9 @@ Text.TrimStart:
 Text.UpperCase:
   layer: runtime-api
   category: Text
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-2/194-text-static
+  notes: overloads=1. Static Text.UpperCase form covered — includes differs-from-LowerCase trap.
 
 # ── TextBuilder ─────────────────────────────────────────────────
 

--- a/tests/bucket-1/92-recordref-stub-methods/src/RecordRefStubSrc.al
+++ b/tests/bucket-1/92-recordref-stub-methods/src/RecordRefStubSrc.al
@@ -1,6 +1,6 @@
 /// Exercises RecordRef stub methods: IsDirty, LoadFields, CopyLinks,
 /// ReadConsistency, RecordLevelLocking, SecurityFiltering, Truncate.
-codeunit 93000 "RRS Src"
+codeunit 93100 "RRS Src"
 {
     procedure GetIsDirty(var RecRef: RecordRef): Boolean
     begin

--- a/tests/bucket-1/92-recordref-stub-methods/test/RecordRefStubTest.al
+++ b/tests/bucket-1/92-recordref-stub-methods/test/RecordRefStubTest.al
@@ -1,4 +1,4 @@
-codeunit 93001 "RRS Tests"
+codeunit 93101 "RRS Tests"
 {
     Subtype = Test;
 

--- a/tests/bucket-2/194-text-static/al-runner.json
+++ b/tests/bucket-2/194-text-static/al-runner.json
@@ -1,0 +1,4 @@
+{
+  "sourcePath": "./src",
+  "testPath": "./test"
+}

--- a/tests/bucket-2/194-text-static/src/TextStaticSrc.al
+++ b/tests/bucket-2/194-text-static/src/TextStaticSrc.al
@@ -1,5 +1,5 @@
 /// Helper codeunit exercising the static Text.* built-in forms.
-codeunit 60200 "TXST Src"
+codeunit 60210 "TXST Src"
 {
     procedure DelChrIt(v: Text; where: Text; chars: Text): Text
     begin

--- a/tests/bucket-2/194-text-static/src/TextStaticSrc.al
+++ b/tests/bucket-2/194-text-static/src/TextStaticSrc.al
@@ -1,5 +1,5 @@
 /// Helper codeunit exercising the static Text.* built-in forms.
-codeunit 60200 "TXS Src"
+codeunit 60200 "TXST Src"
 {
     procedure DelChrIt(v: Text; where: Text; chars: Text): Text
     begin

--- a/tests/bucket-2/194-text-static/src/TextStaticSrc.al
+++ b/tests/bucket-2/194-text-static/src/TextStaticSrc.al
@@ -1,0 +1,62 @@
+/// Helper codeunit exercising the static Text.* built-in forms.
+codeunit 60200 "TXS Src"
+{
+    procedure DelChrIt(v: Text; where: Text; chars: Text): Text
+    begin
+        exit(Text.DelChr(v, where, chars));
+    end;
+
+    procedure DelStrIt(v: Text; pos: Integer; count: Integer): Text
+    begin
+        exit(Text.DelStr(v, pos, count));
+    end;
+
+    procedure DelStrToEnd(v: Text; pos: Integer): Text
+    begin
+        // 2-arg overload: delete from pos to end.
+        exit(Text.DelStr(v, pos));
+    end;
+
+    procedure InsStrIt(v: Text; ins: Text; pos: Integer): Text
+    begin
+        exit(Text.InsStr(v, ins, pos));
+    end;
+
+    procedure LowerIt(v: Text): Text
+    begin
+        exit(Text.LowerCase(v));
+    end;
+
+    procedure UpperIt(v: Text): Text
+    begin
+        exit(Text.UpperCase(v));
+    end;
+
+    procedure MaxStrLenIt(): Integer
+    var
+        s: Text[50];
+    begin
+        // MaxStrLen reports the declared max length of the argument expression.
+        exit(Text.MaxStrLen(s));
+    end;
+
+    procedure StrLenIt(v: Text): Integer
+    begin
+        exit(Text.StrLen(v));
+    end;
+
+    procedure StrSubstNoOneArg(fmt: Text): Text
+    begin
+        exit(Text.StrSubstNo(fmt));
+    end;
+
+    procedure StrSubstNoTwoArg(fmt: Text; a: Text): Text
+    begin
+        exit(Text.StrSubstNo(fmt, a));
+    end;
+
+    procedure StrSubstNoThreeArg(fmt: Text; a: Text; b: Integer): Text
+    begin
+        exit(Text.StrSubstNo(fmt, a, b));
+    end;
+}

--- a/tests/bucket-2/194-text-static/test/TextStaticTest.al
+++ b/tests/bucket-2/194-text-static/test/TextStaticTest.al
@@ -1,0 +1,139 @@
+codeunit 60201 "TXS Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "TXS Src";
+
+    // --- DelChr ---
+
+    [Test]
+    procedure DelChr_RemovesAll()
+    begin
+        // where='=' means "all occurrences anywhere".
+        Assert.AreEqual('hello', Src.DelChrIt('h e l l o', '=', ' '),
+            'Text.DelChr must remove every space');
+    end;
+
+    [Test]
+    procedure DelChr_Leading()
+    begin
+        Assert.AreEqual('hello', Src.DelChrIt('   hello', '<', ' '),
+            'Text.DelChr(<,'' '') must remove only leading spaces');
+    end;
+
+    [Test]
+    procedure DelChr_Trailing()
+    begin
+        Assert.AreEqual('hello', Src.DelChrIt('hello   ', '>', ' '),
+            'Text.DelChr(>,'' '') must remove only trailing spaces');
+    end;
+
+    // --- DelStr ---
+
+    [Test]
+    procedure DelStr_Range()
+    begin
+        // 1-based: DelStr('hello', 2, 3) removes chars 2..4 ("ell"), leaving "ho".
+        Assert.AreEqual('ho', Src.DelStrIt('hello', 2, 3),
+            'Text.DelStr(v,2,3) must remove three chars starting at position 2');
+    end;
+
+    [Test]
+    procedure DelStr_ToEnd()
+    begin
+        // 2-arg DelStr: delete from pos to end.
+        Assert.AreEqual('hel', Src.DelStrToEnd('hello', 4),
+            'Text.DelStr(v,4) must remove from pos 4 to end');
+    end;
+
+    // --- InsStr ---
+
+    [Test]
+    procedure InsStr_AtStart()
+    begin
+        Assert.AreEqual('!hello', Src.InsStrIt('hello', '!', 1),
+            'Text.InsStr(v,''!'',1) must insert at position 1');
+    end;
+
+    [Test]
+    procedure InsStr_InMiddle()
+    begin
+        Assert.AreEqual('heXXXllo', Src.InsStrIt('hello', 'XXX', 3),
+            'Text.InsStr(v,''XXX'',3) must insert three chars at position 3');
+    end;
+
+    // --- LowerCase / UpperCase ---
+
+    [Test]
+    procedure LowerCase()
+    begin
+        Assert.AreEqual('abc xyz', Src.LowerIt('ABC xyz'),
+            'Text.LowerCase must return all lower-case');
+    end;
+
+    [Test]
+    procedure UpperCase()
+    begin
+        Assert.AreEqual('ABC XYZ', Src.UpperIt('abc XYZ'),
+            'Text.UpperCase must return all upper-case');
+    end;
+
+    [Test]
+    procedure Lower_And_Upper_DifferOnMixed_NegativeTrap()
+    begin
+        Assert.AreNotEqual(Src.LowerIt('AaA'), Src.UpperIt('AaA'),
+            'Text.LowerCase and Text.UpperCase must produce different results on mixed input');
+    end;
+
+    // --- MaxStrLen ---
+
+    [Test]
+    procedure MaxStrLen_ReturnsDeclaredLength()
+    begin
+        // Declared as Text[50].
+        Assert.AreEqual(50, Src.MaxStrLenIt(),
+            'Text.MaxStrLen(s) must return the declared Text[N] length');
+    end;
+
+    // --- StrLen ---
+
+    [Test]
+    procedure StrLen_OfHello_Is5()
+    begin
+        Assert.AreEqual(5, Src.StrLenIt('hello'),
+            'Text.StrLen(''hello'') must return 5');
+    end;
+
+    [Test]
+    procedure StrLen_OfEmpty_Is0()
+    begin
+        Assert.AreEqual(0, Src.StrLenIt(''),
+            'Text.StrLen('''') must return 0');
+    end;
+
+    // --- StrSubstNo ---
+
+    [Test]
+    procedure StrSubstNo_NoPlaceholders()
+    begin
+        // 1-arg form: returns the format string unchanged.
+        Assert.AreEqual('hello', Src.StrSubstNoOneArg('hello'),
+            'Text.StrSubstNo with no placeholders must return the format unchanged');
+    end;
+
+    [Test]
+    procedure StrSubstNo_OneArg()
+    begin
+        Assert.AreEqual('Hello, World', Src.StrSubstNoTwoArg('Hello, %1', 'World'),
+            'Text.StrSubstNo must substitute %1');
+    end;
+
+    [Test]
+    procedure StrSubstNo_TwoArgs_DifferentTypes()
+    begin
+        Assert.AreEqual('Alice is 30', Src.StrSubstNoThreeArg('%1 is %2', 'Alice', 30),
+            'Text.StrSubstNo must substitute %1 (Text) and %2 (Integer)');
+    end;
+}

--- a/tests/bucket-2/194-text-static/test/TextStaticTest.al
+++ b/tests/bucket-2/194-text-static/test/TextStaticTest.al
@@ -1,4 +1,4 @@
-codeunit 60201 "TXST Test"
+codeunit 60211 "TXST Test"
 {
     Subtype = Test;
 

--- a/tests/bucket-2/194-text-static/test/TextStaticTest.al
+++ b/tests/bucket-2/194-text-static/test/TextStaticTest.al
@@ -1,10 +1,10 @@
-codeunit 60201 "TXS Test"
+codeunit 60201 "TXST Test"
 {
     Subtype = Test;
 
     var
         Assert: Codeunit Assert;
-        Src: Codeunit "TXS Src";
+        Src: Codeunit "TXST Src";
 
     // --- DelChr ---
 


### PR DESCRIPTION
## Summary
- Closes #731
- All eight static `Text.*` built-in forms (`DelChr`, `DelStr`, `InsStr`, `LowerCase`, `UpperCase`, `MaxStrLen`, `StrLen`, `StrSubstNo`) already work via BC's native code paths. This PR adds the first proving tests for the static-call form and flips coverage.yaml.
- New suite `tests/bucket-2/194-text-static` — 16 tests covering DelChr modes (=/</>), DelStr (pos and pos+count), InsStr (start/middle), LowerCase/UpperCase + differs trap, MaxStrLen (declared length), StrLen (non-empty/empty), StrSubstNo (no-placeholder / single / multi-arg mixed types).

## Test plan
- [x] New suite — 16/16 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)