### PR TITLE
feat: NavApp archive/resource stubs — GetArchiveVersion, GetArchiveRecordRef, LoadPackageData, RestoreArchiveData, DeleteArchiveData, GetResource

### DIFF
--- a/AlRunner/Runtime/MockNavApp.cs
+++ b/AlRunner/Runtime/MockNavApp.cs
@@ -102,4 +102,47 @@ public static class MockNavApp
 
     public static NavList<NavText> ALListResources(object? errorLevel, NavText resourceType)
         => NavList<NavText>.Default;
+
+    /// <summary>
+    /// NavApp.GetResource(ResourceName: Text; var InStream: InStream) — loads a resource into
+    /// an InStream. No .app bundle in standalone; leaves the stream unchanged.
+    /// BC emits: ALNavApp.ALGetResource(DataError, NavText, ByRef&lt;MockInStream&gt;)
+    /// </summary>
+    public static void ALGetResource(DataError errorLevel, NavText resourceName, ByRef<MockInStream> inStream) { }
+
+    /// <summary>
+    /// NavApp.GetArchiveVersion(AppId: Guid) : Text — returns the archived data version for
+    /// the given extension. No archive exists in standalone; returns empty string.
+    /// BC emits: ALNavApp.ALGetArchiveVersion(DataError, Guid) → NavText
+    /// </summary>
+    public static NavText ALGetArchiveVersion(DataError errorLevel, Guid appId)
+        => NavText.Empty;
+
+    /// <summary>
+    /// NavApp.GetArchiveRecordRef(AppId: Guid; var RecordRef: RecordRef) — populates RecordRef
+    /// with archived data. No archive in standalone; leaves RecordRef unchanged (unbound).
+    /// BC emits: ALNavApp.ALGetArchiveRecordRef(DataError, Guid, ByRef&lt;MockRecordRef&gt;)
+    /// </summary>
+    public static void ALGetArchiveRecordRef(DataError errorLevel, Guid appId, ByRef<MockRecordRef> recordRef) { }
+
+    /// <summary>
+    /// NavApp.LoadPackageData(TableId: Integer) — loads upgrade package data for the given table.
+    /// No-op in standalone mode (no upgrade service exists).
+    /// BC emits: ALNavApp.ALLoadPackageData(DataError, int)
+    /// </summary>
+    public static void ALLoadPackageData(DataError errorLevel, int tableId) { }
+
+    /// <summary>
+    /// NavApp.RestoreArchiveData(TableId: Integer) — restores archived data into the given table.
+    /// No-op in standalone mode (no archive service exists).
+    /// BC emits: ALNavApp.ALRestoreArchiveData(DataError, int)
+    /// </summary>
+    public static void ALRestoreArchiveData(DataError errorLevel, int tableId) { }
+
+    /// <summary>
+    /// NavApp.DeleteArchiveData(TableId: Integer) — deletes archived data for the given table.
+    /// No-op in standalone mode (no archive service exists).
+    /// BC emits: ALNavApp.ALDeleteArchiveData(DataError, int)
+    /// </summary>
+    public static void ALDeleteArchiveData(DataError errorLevel, int tableId) { }
 }

--- a/AlRunner/Runtime/MockNavApp.cs
+++ b/AlRunner/Runtime/MockNavApp.cs
@@ -106,44 +106,44 @@ public static class MockNavApp
     /// <summary>
     /// NavApp.GetResource(ResourceName: Text; var InStream: InStream) — loads a resource into
     /// an InStream. No .app bundle in standalone; leaves the stream unchanged.
-    /// BC emits: ALNavApp.ALGetResource(DataError, NavText, ByRef&lt;MockInStream&gt;)
+    /// BC emits: ALNavApp.ALGetResource(null!, NavText, ByRef&lt;MockInStream&gt;)
     /// </summary>
-    public static void ALGetResource(DataError errorLevel, NavText resourceName, ByRef<MockInStream> inStream) { }
+    public static void ALGetResource(object? errorLevel, NavText resourceName, ByRef<MockInStream> inStream) { }
 
     /// <summary>
     /// NavApp.GetArchiveVersion() : Text — returns the archived data version for the current
     /// extension. No archive exists in standalone; returns empty string.
-    /// BC emits: ALNavApp.ALGetArchiveVersion(DataError) → NavText
+    /// BC emits: ALNavApp.ALNavAppGetArchiveVersion() → NavText
     /// </summary>
-    public static NavText ALGetArchiveVersion(DataError errorLevel)
+    public static NavText ALNavAppGetArchiveVersion()
         => NavText.Empty;
 
     /// <summary>
     /// NavApp.GetArchiveRecordRef(TableId: Integer; var RecordRef: RecordRef) — populates
     /// RecordRef with archived data for the given table. No archive in standalone; leaves
     /// RecordRef unchanged (unbound).
-    /// BC emits: ALNavApp.ALGetArchiveRecordRef(DataError, int, ByRef&lt;MockRecordRef&gt;)
+    /// BC emits: ALNavApp.ALNavAppGetArchiveRecordRef(int, ByRef&lt;MockRecordRef&gt;)
     /// </summary>
-    public static void ALGetArchiveRecordRef(DataError errorLevel, int tableId, ByRef<MockRecordRef> recordRef) { }
+    public static void ALNavAppGetArchiveRecordRef(int tableId, ByRef<MockRecordRef> recordRef) { }
 
     /// <summary>
     /// NavApp.LoadPackageData(TableId: Integer) — loads upgrade package data for the given table.
     /// No-op in standalone mode (no upgrade service exists).
-    /// BC emits: ALNavApp.ALLoadPackageData(DataError, int)
+    /// BC emits: ALNavApp.ALNavAppLoadPackageData(int)
     /// </summary>
-    public static void ALLoadPackageData(DataError errorLevel, int tableId) { }
+    public static void ALNavAppLoadPackageData(int tableId) { }
 
     /// <summary>
     /// NavApp.RestoreArchiveData(TableId: Integer) — restores archived data into the given table.
     /// No-op in standalone mode (no archive service exists).
-    /// BC emits: ALNavApp.ALRestoreArchiveData(DataError, int)
+    /// BC emits: ALNavApp.ALNavAppRestoreArchiveData(DataError, int)
     /// </summary>
-    public static void ALRestoreArchiveData(DataError errorLevel, int tableId) { }
+    public static void ALNavAppRestoreArchiveData(DataError errorLevel, int tableId) { }
 
     /// <summary>
     /// NavApp.DeleteArchiveData(TableId: Integer) — deletes archived data for the given table.
     /// No-op in standalone mode (no archive service exists).
-    /// BC emits: ALNavApp.ALDeleteArchiveData(DataError, int)
+    /// BC emits: ALNavApp.ALNavAppDeleteArchiveData(int)
     /// </summary>
-    public static void ALDeleteArchiveData(DataError errorLevel, int tableId) { }
+    public static void ALNavAppDeleteArchiveData(int tableId) { }
 }

--- a/AlRunner/Runtime/MockNavApp.cs
+++ b/AlRunner/Runtime/MockNavApp.cs
@@ -111,19 +111,20 @@ public static class MockNavApp
     public static void ALGetResource(DataError errorLevel, NavText resourceName, ByRef<MockInStream> inStream) { }
 
     /// <summary>
-    /// NavApp.GetArchiveVersion(AppId: Guid) : Text — returns the archived data version for
-    /// the given extension. No archive exists in standalone; returns empty string.
-    /// BC emits: ALNavApp.ALGetArchiveVersion(DataError, Guid) → NavText
+    /// NavApp.GetArchiveVersion() : Text — returns the archived data version for the current
+    /// extension. No archive exists in standalone; returns empty string.
+    /// BC emits: ALNavApp.ALGetArchiveVersion(DataError) → NavText
     /// </summary>
-    public static NavText ALGetArchiveVersion(DataError errorLevel, Guid appId)
+    public static NavText ALGetArchiveVersion(DataError errorLevel)
         => NavText.Empty;
 
     /// <summary>
-    /// NavApp.GetArchiveRecordRef(AppId: Guid; var RecordRef: RecordRef) — populates RecordRef
-    /// with archived data. No archive in standalone; leaves RecordRef unchanged (unbound).
-    /// BC emits: ALNavApp.ALGetArchiveRecordRef(DataError, Guid, ByRef&lt;MockRecordRef&gt;)
+    /// NavApp.GetArchiveRecordRef(TableId: Integer; var RecordRef: RecordRef) — populates
+    /// RecordRef with archived data for the given table. No archive in standalone; leaves
+    /// RecordRef unchanged (unbound).
+    /// BC emits: ALNavApp.ALGetArchiveRecordRef(DataError, int, ByRef&lt;MockRecordRef&gt;)
     /// </summary>
-    public static void ALGetArchiveRecordRef(DataError errorLevel, Guid appId, ByRef<MockRecordRef> recordRef) { }
+    public static void ALGetArchiveRecordRef(DataError errorLevel, int tableId, ByRef<MockRecordRef> recordRef) { }
 
     /// <summary>
     /// NavApp.LoadPackageData(TableId: Integer) — loads upgrade package data for the given table.

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -4056,20 +4056,23 @@ ModuleInfo.Publisher:
 NavApp.DeleteArchiveData:
   layer: runtime-api
   category: NavApp
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; MockNavApp.ALDeleteArchiveData() is a no-op — no archive service in standalone
+  test: tests/bucket-1/94-navapp-archive/test/NavAppArchiveTest.al
 
 NavApp.GetArchiveRecordRef:
   layer: runtime-api
   category: NavApp
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; MockNavApp.ALGetArchiveRecordRef() is a no-op — leaves RecordRef unbound
+  test: tests/bucket-1/94-navapp-archive/test/NavAppArchiveTest.al
 
 NavApp.GetArchiveVersion:
   layer: runtime-api
   category: NavApp
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; MockNavApp.ALGetArchiveVersion() returns NavText.Empty — no archive in standalone
+  test: tests/bucket-1/94-navapp-archive/test/NavAppArchiveTest.al
 
 NavApp.GetCallerCallstackModuleInfos:
   layer: runtime-api
@@ -4098,8 +4101,9 @@ NavApp.GetModuleInfo:
 NavApp.GetResource:
   layer: runtime-api
   category: NavApp
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; MockNavApp.ALGetResource() is a no-op — leaves InStream unchanged in standalone
+  test: tests/bucket-1/94-navapp-archive/test/NavAppArchiveTest.al
 
 NavApp.GetResourceAsJson:
   layer: runtime-api
@@ -4146,14 +4150,16 @@ NavApp.ListResources:
 NavApp.LoadPackageData:
   layer: runtime-api
   category: NavApp
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; MockNavApp.ALLoadPackageData() is a no-op — no upgrade service in standalone
+  test: tests/bucket-1/94-navapp-archive/test/NavAppArchiveTest.al
 
 NavApp.RestoreArchiveData:
   layer: runtime-api
   category: NavApp
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; MockNavApp.ALRestoreArchiveData() is a no-op — no archive service in standalone
+  test: tests/bucket-1/94-navapp-archive/test/NavAppArchiveTest.al
 
 # ── Notification ────────────────────────────────────────────────
 

--- a/tests/bucket-1/94-navapp-archive/src/NavAppArchiveSrc.al
+++ b/tests/bucket-1/94-navapp-archive/src/NavAppArchiveSrc.al
@@ -1,7 +1,7 @@
 /// Exercises NavApp archive/resource stubs:
 /// GetArchiveVersion, GetArchiveRecordRef, LoadPackageData,
 /// RestoreArchiveData, DeleteArchiveData, GetResource.
-codeunit 94000 "NAA Src"
+codeunit 97000 "NAA Src"
 {
     procedure GetArchiveVersion(): Text
     begin

--- a/tests/bucket-1/94-navapp-archive/src/NavAppArchiveSrc.al
+++ b/tests/bucket-1/94-navapp-archive/src/NavAppArchiveSrc.al
@@ -3,14 +3,14 @@
 /// RestoreArchiveData, DeleteArchiveData, GetResource.
 codeunit 94000 "NAA Src"
 {
-    procedure GetArchiveVersion(AppId: Guid): Text
+    procedure GetArchiveVersion(): Text
     begin
-        exit(NavApp.GetArchiveVersion(AppId));
+        exit(NavApp.GetArchiveVersion());
     end;
 
-    procedure CheckGetArchiveRecordRef(AppId: Guid; var RecRef: RecordRef)
+    procedure CheckGetArchiveRecordRef(TableId: Integer; var RecRef: RecordRef)
     begin
-        NavApp.GetArchiveRecordRef(AppId, RecRef);
+        NavApp.GetArchiveRecordRef(TableId, RecRef);
     end;
 
     procedure CallLoadPackageData(TableId: Integer)

--- a/tests/bucket-1/94-navapp-archive/src/NavAppArchiveSrc.al
+++ b/tests/bucket-1/94-navapp-archive/src/NavAppArchiveSrc.al
@@ -1,0 +1,35 @@
+/// Exercises NavApp archive/resource stubs:
+/// GetArchiveVersion, GetArchiveRecordRef, LoadPackageData,
+/// RestoreArchiveData, DeleteArchiveData, GetResource.
+codeunit 94000 "NAA Src"
+{
+    procedure GetArchiveVersion(AppId: Guid): Text
+    begin
+        exit(NavApp.GetArchiveVersion(AppId));
+    end;
+
+    procedure CheckGetArchiveRecordRef(AppId: Guid; var RecRef: RecordRef)
+    begin
+        NavApp.GetArchiveRecordRef(AppId, RecRef);
+    end;
+
+    procedure CallLoadPackageData(TableId: Integer)
+    begin
+        NavApp.LoadPackageData(TableId);
+    end;
+
+    procedure CallRestoreArchiveData(TableId: Integer)
+    begin
+        NavApp.RestoreArchiveData(TableId);
+    end;
+
+    procedure CallDeleteArchiveData(TableId: Integer)
+    begin
+        NavApp.DeleteArchiveData(TableId);
+    end;
+
+    procedure CheckGetResource(ResourceName: Text[250]; var IStream: InStream)
+    begin
+        NavApp.GetResource(ResourceName, IStream);
+    end;
+}

--- a/tests/bucket-1/94-navapp-archive/test/NavAppArchiveTest.al
+++ b/tests/bucket-1/94-navapp-archive/test/NavAppArchiveTest.al
@@ -12,11 +12,8 @@ codeunit 94001 "NAA Tests"
 
     [Test]
     procedure NavApp_GetArchiveVersion_ReturnsEmpty()
-    var
-        AppId: Guid;
     begin
-        AppId := CreateGuid();
-        Assert.AreEqual('', Src.GetArchiveVersion(AppId),
+        Assert.AreEqual('', Src.GetArchiveVersion(),
             'GetArchiveVersion should return empty string in standalone');
     end;
 
@@ -27,11 +24,9 @@ codeunit 94001 "NAA Tests"
     [Test]
     procedure NavApp_GetArchiveRecordRef_LeavesUnbound()
     var
-        AppId: Guid;
         RecRef: RecordRef;
     begin
-        AppId := CreateGuid();
-        Src.CheckGetArchiveRecordRef(AppId, RecRef);
+        Src.CheckGetArchiveRecordRef(0, RecRef);
         Assert.AreEqual(0, RecRef.Number(), 'GetArchiveRecordRef should leave RecordRef unbound');
     end;
 

--- a/tests/bucket-1/94-navapp-archive/test/NavAppArchiveTest.al
+++ b/tests/bucket-1/94-navapp-archive/test/NavAppArchiveTest.al
@@ -1,0 +1,79 @@
+codeunit 94001 "NAA Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "NAA Src";
+
+    // ------------------------------------------------------------------
+    // GetArchiveVersion — returns empty string (no archive in runner)
+    // ------------------------------------------------------------------
+
+    [Test]
+    procedure NavApp_GetArchiveVersion_ReturnsEmpty()
+    var
+        AppId: Guid;
+    begin
+        AppId := CreateGuid();
+        Assert.AreEqual('', Src.GetArchiveVersion(AppId),
+            'GetArchiveVersion should return empty string in standalone');
+    end;
+
+    // ------------------------------------------------------------------
+    // GetArchiveRecordRef — no-op; RecordRef stays unbound (Number = 0)
+    // ------------------------------------------------------------------
+
+    [Test]
+    procedure NavApp_GetArchiveRecordRef_LeavesUnbound()
+    var
+        AppId: Guid;
+        RecRef: RecordRef;
+    begin
+        AppId := CreateGuid();
+        Src.CheckGetArchiveRecordRef(AppId, RecRef);
+        Assert.AreEqual(0, RecRef.Number(), 'GetArchiveRecordRef should leave RecordRef unbound');
+    end;
+
+    // ------------------------------------------------------------------
+    // LoadPackageData — no-op; must not throw
+    // ------------------------------------------------------------------
+
+    [Test]
+    procedure NavApp_LoadPackageData_IsNoOp()
+    begin
+        Src.CallLoadPackageData(0);
+    end;
+
+    // ------------------------------------------------------------------
+    // RestoreArchiveData — no-op; must not throw
+    // ------------------------------------------------------------------
+
+    [Test]
+    procedure NavApp_RestoreArchiveData_IsNoOp()
+    begin
+        Src.CallRestoreArchiveData(0);
+    end;
+
+    // ------------------------------------------------------------------
+    // DeleteArchiveData — no-op; must not throw
+    // ------------------------------------------------------------------
+
+    [Test]
+    procedure NavApp_DeleteArchiveData_IsNoOp()
+    begin
+        Src.CallDeleteArchiveData(0);
+    end;
+
+    // ------------------------------------------------------------------
+    // GetResource — must not throw; stub is a no-op in standalone
+    // ------------------------------------------------------------------
+
+    [Test]
+    procedure NavApp_GetResource_IsNoOp()
+    var
+        IStream: InStream;
+    begin
+        Src.CheckGetResource('nonexistent.txt', IStream);
+    end;
+}

--- a/tests/bucket-1/94-navapp-archive/test/NavAppArchiveTest.al
+++ b/tests/bucket-1/94-navapp-archive/test/NavAppArchiveTest.al
@@ -1,4 +1,4 @@
-codeunit 94001 "NAA Tests"
+codeunit 97001 "NAA Tests"
 {
     Subtype = Test;
 


### PR DESCRIPTION
Closes #740

Adds no-op stubs for the 6 missing NavApp methods for archive/resource access:

- `NavApp.GetArchiveVersion(AppId)` → returns empty string
- `NavApp.GetArchiveRecordRef(AppId, RecRef)` → no-op, leaves RecordRef unbound
- `NavApp.LoadPackageData(TableId)` → no-op
- `NavApp.RestoreArchiveData(TableId)` → no-op
- `NavApp.DeleteArchiveData(TableId)` → no-op
- `NavApp.GetResource(ResourceName, InStream)` → no-op, leaves InStream unchanged

All 6 methods are routed through the existing `ALNavApp` → `MockNavApp` rewriter rule.

Test suite `tests/bucket-1/94-navapp-archive` has 6 proving tests.