### PR TITLE
feat: TestHttpResponseMessage — Content, Headers, HttpStatusCode, IsSuccessfulRequest, ReasonPhrase, IsBlockedByEnvironment

### DIFF
--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -1080,6 +1080,8 @@ public void ClearApplicationMemberVariables()
             return node.WithIdentifier(SyntaxFactory.Identifier("MockHttpRequestMessage"));
         if (text == "NavCookie")
             return node.WithIdentifier(SyntaxFactory.Identifier("MockCookie"));
+        if (text == "NavTestHttpResponseMessage")
+            return node.WithIdentifier(SyntaxFactory.Identifier("MockTestHttpResponseMessage"));
 
         // NavFormHandle -> MockFormHandle
         // BC emits `Page "X"` AL variables as `NavFormHandle p` fields with
@@ -1476,6 +1478,7 @@ public void ClearApplicationMemberVariables()
         // whose .Tree must not be null. Strip it — the mocks are parameterless.
         if (typeText is "MockHttpClient" or "MockHttpResponseMessage"
             or "MockHttpContent" or "MockHttpRequestMessage" or "MockCookie"
+            or "MockTestHttpResponseMessage"
             && visited.ArgumentList?.Arguments.Count == 1)
         {
             return visited.WithArgumentList(SyntaxFactory.ArgumentList());

--- a/AlRunner/Runtime/MockHttpHeaders.cs
+++ b/AlRunner/Runtime/MockHttpHeaders.cs
@@ -67,6 +67,20 @@ public class MockHttpHeaders
         return _headers.ContainsKey(key);
     }
 
+    /// <summary>
+    /// Overload emitted when the caller declares <c>array[N] of Text</c>.
+    /// BC emits <c>ALGetValues(DataError, key, MockArray&lt;NavText&gt;)</c>.
+    /// Populates the array with stored header values.
+    /// </summary>
+    public bool ALGetValues(DataError errorLevel, string key, MockArray<NavText> values)
+    {
+        if (!_headers.TryGetValue(key, out var list) || list.Count == 0) return false;
+        int count = Math.Min(values.Length, list.Count);
+        for (int i = 0; i < count; i++)
+            values[i] = new NavText(0, list[i]);
+        return true;
+    }
+
     /// <summary>Number of distinct header names.</summary>
     public int ALCount => _headers.Count;
 

--- a/AlRunner/Runtime/MockTestHttpResponseMessage.cs
+++ b/AlRunner/Runtime/MockTestHttpResponseMessage.cs
@@ -1,0 +1,35 @@
+namespace AlRunner.Runtime;
+
+using Microsoft.Dynamics.Nav.Runtime;
+using Microsoft.Dynamics.Nav.Types;
+
+/// <summary>
+/// Stub for <c>NavTestHttpResponseMessage</c> / AL's <c>TestHttpResponseMessage</c> variable.
+///
+/// BC emits <c>new NavTestHttpResponseMessage(this)</c> in scope-class field initialisers.
+/// The rewriter renames the type to <c>MockTestHttpResponseMessage</c> and strips the arg.
+///
+/// Default state mirrors a successful HTTP 200 OK response.
+/// </summary>
+public class MockTestHttpResponseMessage
+{
+    public MockTestHttpResponseMessage() { }
+
+    /// <summary>HTTP status code. Default is 200 (OK).</summary>
+    public int ALHttpStatusCode { get; set; } = 200;
+
+    /// <summary>True when status code is in the 200–299 range.</summary>
+    public bool ALIsSuccessfulRequest => ALHttpStatusCode >= 200 && ALHttpStatusCode < 300;
+
+    /// <summary>HTTP reason phrase (e.g. "OK", "Not Found").</summary>
+    public string ALReasonPhrase { get; set; } = "OK";
+
+    /// <summary>Response body content.</summary>
+    public MockHttpContent ALContent { get; set; } = new();
+
+    /// <summary>Response headers.</summary>
+    public MockHttpHeaders ALHeaders { get; set; } = new();
+
+    /// <summary>Always false — environment blocking is not applicable in test mode.</summary>
+    public bool ALIsBlockedByEnvironment => false;
+}

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -6993,37 +6993,37 @@ TestHttpRequestMessage.RequestType:
 TestHttpResponseMessage.Content:
   layer: runtime-api
   category: TestHttpResponseMessage
-  status: gap
+  status: covered
   notes: overloads=1
 
 TestHttpResponseMessage.Headers:
   layer: runtime-api
   category: TestHttpResponseMessage
-  status: gap
+  status: covered
   notes: overloads=1
 
 TestHttpResponseMessage.HttpStatusCode:
   layer: runtime-api
   category: TestHttpResponseMessage
-  status: gap
+  status: covered
   notes: overloads=1
 
 TestHttpResponseMessage.IsBlockedByEnvironment:
   layer: runtime-api
   category: TestHttpResponseMessage
-  status: gap
+  status: covered
   notes: overloads=1
 
 TestHttpResponseMessage.IsSuccessfulRequest:
   layer: runtime-api
   category: TestHttpResponseMessage
-  status: gap
+  status: covered
   notes: overloads=1
 
 TestHttpResponseMessage.ReasonPhrase:
   layer: runtime-api
   category: TestHttpResponseMessage
-  status: gap
+  status: covered
   notes: overloads=1
 
 # ── TestPage ────────────────────────────────────────────────────

--- a/tests/bucket-1/168-httpclient-config/src/HttpClientConfigSrc.al
+++ b/tests/bucket-1/168-httpclient-config/src/HttpClientConfigSrc.al
@@ -1,5 +1,5 @@
 /// Helper codeunit exercising HttpClient configuration methods — issue #732.
-codeunit 93000 "HCC Src"
+codeunit 94000 "HCC Src"
 {
     // SetBaseAddress + GetBaseAddress — round-trip
     procedure SetAndGetBaseAddress(url: Text): Text

--- a/tests/bucket-1/168-httpclient-config/test/HttpClientConfigTest.al
+++ b/tests/bucket-1/168-httpclient-config/test/HttpClientConfigTest.al
@@ -1,4 +1,4 @@
-codeunit 93001 "HCC Test"
+codeunit 94001 "HCC Test"
 {
     Subtype = Test;
 

--- a/tests/bucket-1/169-testhttpresponsemessage/al-runner.json
+++ b/tests/bucket-1/169-testhttpresponsemessage/al-runner.json
@@ -1,0 +1,3 @@
+{
+  "testPath": "./test"
+}

--- a/tests/bucket-1/169-testhttpresponsemessage/test/TestHttpResponseMsgTest.al
+++ b/tests/bucket-1/169-testhttpresponsemessage/test/TestHttpResponseMsgTest.al
@@ -1,0 +1,122 @@
+/// Tests for TestHttpResponseMessage — issue #739.
+codeunit 96001 "THRM Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    // ── HttpStatusCode ───────────────────────────────────────────
+
+    [Test]
+    procedure TestHttpResponseMsg_HttpStatusCode_GetSet()
+    var
+        Resp: TestHttpResponseMessage;
+    begin
+        Resp.HttpStatusCode := 404;
+        Assert.AreEqual(404, Resp.HttpStatusCode,
+            'HttpStatusCode must round-trip via get/set');
+    end;
+
+    [Test]
+    procedure TestHttpResponseMsg_HttpStatusCode_DefaultIs200()
+    var
+        Resp: TestHttpResponseMessage;
+    begin
+        Assert.AreEqual(200, Resp.HttpStatusCode,
+            'HttpStatusCode default must be 200');
+    end;
+
+    // ── IsSuccessfulRequest ──────────────────────────────────────
+
+    [Test]
+    procedure TestHttpResponseMsg_IsSuccessfulRequest_TrueFor200()
+    var
+        Resp: TestHttpResponseMessage;
+    begin
+        Resp.HttpStatusCode := 200;
+        Assert.IsTrue(Resp.IsSuccessfulRequest(),
+            'Status 200 must be a successful request');
+    end;
+
+    [Test]
+    procedure TestHttpResponseMsg_IsSuccessfulRequest_TrueFor201()
+    var
+        Resp: TestHttpResponseMessage;
+    begin
+        Resp.HttpStatusCode := 201;
+        Assert.IsTrue(Resp.IsSuccessfulRequest(),
+            'Status 201 must be a successful request');
+    end;
+
+    [Test]
+    procedure TestHttpResponseMsg_IsSuccessfulRequest_FalseFor400()
+    var
+        Resp: TestHttpResponseMessage;
+    begin
+        Resp.HttpStatusCode := 400;
+        Assert.IsFalse(Resp.IsSuccessfulRequest(),
+            'Status 400 must not be a successful request');
+    end;
+
+    [Test]
+    procedure TestHttpResponseMsg_IsSuccessfulRequest_FalseFor500()
+    var
+        Resp: TestHttpResponseMessage;
+    begin
+        Resp.HttpStatusCode := 500;
+        Assert.IsFalse(Resp.IsSuccessfulRequest(),
+            'Status 500 must not be a successful request');
+    end;
+
+    // ── ReasonPhrase ─────────────────────────────────────────────
+
+    [Test]
+    procedure TestHttpResponseMsg_ReasonPhrase_GetSet()
+    var
+        Resp: TestHttpResponseMessage;
+    begin
+        Resp.ReasonPhrase := 'Not Found';
+        Assert.AreEqual('Not Found', Resp.ReasonPhrase,
+            'ReasonPhrase must round-trip via get/set');
+    end;
+
+    // ── Content ──────────────────────────────────────────────────
+
+    [Test]
+    procedure TestHttpResponseMsg_Content_IsNonNull()
+    var
+        Resp: TestHttpResponseMessage;
+        Body: Text;
+    begin
+        Resp.Content.WriteFrom('hello');
+        Resp.Content.ReadAs(Body);
+        Assert.AreEqual('hello', Body,
+            'Content must allow writing and reading back');
+    end;
+
+    // ── Headers ──────────────────────────────────────────────────
+
+    [Test]
+    procedure TestHttpResponseMsg_Headers_CanAdd()
+    var
+        Resp: TestHttpResponseMessage;
+        vals: array[1] of Text;
+    begin
+        Resp.Headers.Add('X-Test', 'abc');
+        Resp.Headers.GetValues('X-Test', vals);
+        Assert.AreEqual('abc', vals[1],
+            'Headers must store and retrieve added header values');
+    end;
+
+    // ── IsBlockedByEnvironment ───────────────────────────────────
+
+    [Test]
+    procedure TestHttpResponseMsg_IsBlockedByEnvironment_ReturnsFalse()
+    var
+        Resp: TestHttpResponseMessage;
+    begin
+        Assert.IsFalse(Resp.IsBlockedByEnvironment(),
+            'IsBlockedByEnvironment must return false in test mode');
+    end;
+}


### PR DESCRIPTION
Closes #739

## Summary

- New `MockTestHttpResponseMessage` class in `AlRunner/Runtime/` — in-memory stub for BC's `NavTestHttpResponseMessage` / AL `TestHttpResponseMessage` type
- Added rewriter rules: `NavTestHttpResponseMessage` → `MockTestHttpResponseMessage` (type rename + ctor arg stripping)
- Added `MockHttpHeaders.ALGetValues(DataError, string, MockArray<NavText>)` overload to populate header arrays
- New test suite `tests/bucket-1/169-testhttpresponsemessage/` (codeunit 96001) with 10 tests covering all 6 properties: `HttpStatusCode` (default 200, get/set), `IsSuccessfulRequest` (true for 200/201, false for 400/500), `ReasonPhrase` (get/set), `Content` (write/read), `Headers` (add/retrieve), `IsBlockedByEnvironment` (returns false)
- Also fixes codeunit ID collision in main: 168-httpclient-config renumbered from 93000/93001 → 94000/94001 (collided with newly-merged 92-recordref-stub-methods)
- Updated `docs/coverage.yaml`: all 6 `TestHttpResponseMessage.*` entries marked `covered`

## Test plan

- [x] GREEN: all 10 tests pass
- [x] Bucket-1 regression: 1003 passed, 2 pre-existing failures (DT2Time, unrelated)
- [x] ID collision in bucket-1 resolved (was causing 50 Roslyn CS0101/CS0111 errors)