### PR TITLE
feat: TestFilter stubs — Ascending, CurrentKey, SetCurrentKey, GetFilter, SetFilter

### DIFF
--- a/AlRunner/Runtime/MockTestPageHandle.cs
+++ b/AlRunner/Runtime/MockTestPageHandle.cs
@@ -540,15 +540,23 @@ public class MockTestPageAction
 }
 
 /// <summary>
-/// Mock for TestPage.Filter property. BC emits:
+/// Mock for TestPage.Filter property. BC emits method calls for all TestFilter
+/// operations:
 ///   tP.ALFilter.ALSetFilter(fieldNo, filterValue)
+///   tP.ALFilter.ALGetFilter(fieldNo) → string
+///   tP.ALFilter.ALAscending(value)   (setter)
+///   tP.ALFilter.ALAscending()        (getter) → bool
+///   tP.ALFilter.ALSetCurrentKey(fieldNo, ...)
+///   tP.ALFilter.ALCurrentKey()       → string
 ///
-/// Tracks per-field filter expressions in memory so that <see cref="ALGetFilter"/>
-/// can return the last value set for a given field.
+/// Tracks per-field filter expressions, sort direction, and current key in
+/// memory so that GetFilter / Ascending / CurrentKey return what was last set.
 /// </summary>
 public class MockTestPageFilter
 {
     private readonly Dictionary<int, string> _filters = new();
+    private bool _ascending = true;
+    private int[] _currentKeyFields = Array.Empty<int>();
 
     /// <summary>
     /// Sets a filter on the given field.
@@ -561,9 +569,49 @@ public class MockTestPageFilter
 
     /// <summary>
     /// Returns the last filter set for a field.
+    /// BC emits: ALGetFilter(fieldNo) → string
     /// </summary>
     public string ALGetFilter(int fieldNo)
     {
         return _filters.TryGetValue(fieldNo, out var filter) ? filter : "";
+    }
+
+    /// <summary>
+    /// Sets the sort direction.
+    /// BC emits: ALAscending(value) when AL code calls Filter.Ascending(false/true).
+    /// </summary>
+    public void ALAscending(bool value)
+    {
+        _ascending = value;
+    }
+
+    /// <summary>
+    /// Gets the sort direction. Defaults to true (ascending).
+    /// BC emits: ALAscending() when AL code reads Filter.Ascending().
+    /// </summary>
+    public bool ALAscending()
+    {
+        return _ascending;
+    }
+
+    /// <summary>
+    /// Sets the current sort key by field numbers.
+    /// BC emits: ALSetCurrentKey(fieldNo, ...) for Filter.SetCurrentKey(Field1, ...).
+    /// </summary>
+    public void ALSetCurrentKey(params int[] fieldNos)
+    {
+        _currentKeyFields = fieldNos ?? Array.Empty<int>();
+    }
+
+    /// <summary>
+    /// Returns the current sort key as a comma-separated list of field numbers.
+    /// Returns empty string when no key has been set.
+    /// BC emits: ALCurrentKey() for Filter.CurrentKey().
+    /// </summary>
+    public string ALCurrentKey()
+    {
+        if (_currentKeyFields.Length == 0)
+            return string.Empty;
+        return string.Join(",", _currentKeyFields);
     }
 }

--- a/AlRunner/Runtime/MockTestPageHandle.cs
+++ b/AlRunner/Runtime/MockTestPageHandle.cs
@@ -540,22 +540,20 @@ public class MockTestPageAction
 }
 
 /// <summary>
-/// Mock for TestPage.Filter property. BC emits method calls for all TestFilter
-/// operations:
-///   tP.ALFilter.ALSetFilter(fieldNo, filterValue)
-///   tP.ALFilter.ALGetFilter(fieldNo) → string
-///   tP.ALFilter.ALAscending(value)   (setter)
-///   tP.ALFilter.ALAscending()        (getter) → bool
-///   tP.ALFilter.ALSetCurrentKey(fieldNo, ...)
-///   tP.ALFilter.ALCurrentKey()       → string
+/// Mock for TestPage.Filter property. BC emits the following patterns:
+///   tP.ALFilter.ALSetFilter(fieldNo, filterValue)       — method
+///   tP.ALFilter.ALGetFilter(fieldNo) → string           — method
+///   tP.ALFilter.ALAscending = false                     — property setter
+///   tP.ALFilter.ALAscending                             — property getter
+///   tP.ALFilter.ALSetCurrentKey(DataError, fieldNo, ...) — method (DataError-prefixed)
+///   tP.ALFilter.ALCurrentKey                            — property getter
 ///
 /// Tracks per-field filter expressions, sort direction, and current key in
-/// memory so that GetFilter / Ascending / CurrentKey return what was last set.
+/// memory so assertions can verify what was last set.
 /// </summary>
 public class MockTestPageFilter
 {
     private readonly Dictionary<int, string> _filters = new();
-    private bool _ascending = true;
     private int[] _currentKeyFields = Array.Empty<int>();
 
     /// <summary>
@@ -577,41 +575,40 @@ public class MockTestPageFilter
     }
 
     /// <summary>
-    /// Sets the sort direction.
-    /// BC emits: ALAscending(value) when AL code calls Filter.Ascending(false/true).
+    /// Sort direction. Defaults to true (ascending).
+    /// BC compiles Filter.Ascending(false) → ALAscending = false (property assignment)
+    /// and Filter.Ascending() → ALAscending (property read).
     /// </summary>
-    public void ALAscending(bool value)
-    {
-        _ascending = value;
-    }
-
-    /// <summary>
-    /// Gets the sort direction. Defaults to true (ascending).
-    /// BC emits: ALAscending() when AL code reads Filter.Ascending().
-    /// </summary>
-    public bool ALAscending()
-    {
-        return _ascending;
-    }
+    public bool ALAscending { get; set; } = true;
 
     /// <summary>
     /// Sets the current sort key by field numbers.
-    /// BC emits: ALSetCurrentKey(fieldNo, ...) for Filter.SetCurrentKey(Field1, ...).
+    /// BC emits: ALSetCurrentKey(DataError, fieldNo, ...) — DataError is prepended
+    /// for error-handling on the sort operation.
     /// </summary>
+    public void ALSetCurrentKey(DataError errorLevel, params int[] fieldNos)
+    {
+        _currentKeyFields = fieldNos ?? Array.Empty<int>();
+    }
+
+    /// <summary>Legacy overload without DataError (defensive — kept for compat).</summary>
     public void ALSetCurrentKey(params int[] fieldNos)
     {
         _currentKeyFields = fieldNos ?? Array.Empty<int>();
     }
 
     /// <summary>
-    /// Returns the current sort key as a comma-separated list of field numbers.
-    /// Returns empty string when no key has been set.
-    /// BC emits: ALCurrentKey() for Filter.CurrentKey().
+    /// Returns the current sort key as a comma-separated string of field numbers.
+    /// Empty when no SetCurrentKey has been called.
+    /// BC compiles Filter.CurrentKey() → ALCurrentKey (property read).
     /// </summary>
-    public string ALCurrentKey()
+    public string ALCurrentKey
     {
-        if (_currentKeyFields.Length == 0)
-            return string.Empty;
-        return string.Join(",", _currentKeyFields);
+        get
+        {
+            if (_currentKeyFields.Length == 0)
+                return string.Empty;
+            return string.Join(",", _currentKeyFields);
+        }
     }
 }

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -6937,14 +6937,14 @@ TestFilter.Ascending:
   category: TestFilter
   status: covered
   tests: tests/bucket-1/93-testfilter
-  notes: overloads=2 (getter ALAscending() + setter ALAscending(bool)); defaults to true
+  notes: property ALAscending (bool); BC lowers Ascending() → property read, Ascending(false) → property assignment; defaults true
 
 TestFilter.CurrentKey:
   layer: runtime-api
   category: TestFilter
   status: covered
   tests: tests/bucket-1/93-testfilter
-  notes: overloads=1; ALCurrentKey() returns comma-separated field numbers set via SetCurrentKey
+  notes: property ALCurrentKey (string); BC lowers CurrentKey() → property read; returns comma-separated field numbers
 
 TestFilter.GetFilter:
   layer: runtime-api
@@ -6958,7 +6958,7 @@ TestFilter.SetCurrentKey:
   category: TestFilter
   status: covered
   tests: tests/bucket-1/93-testfilter
-  notes: overloads=1; ALSetCurrentKey(params int[] fieldNos) stores field numbers for CurrentKey
+  notes: overloads=2 (DataError + fields; fields only); BC prepends DataError to the call
 
 TestFilter.SetFilter:
   layer: runtime-api

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -6935,32 +6935,37 @@ TestField.Visible:
 TestFilter.Ascending:
   layer: runtime-api
   category: TestFilter
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-1/93-testfilter
+  notes: overloads=2 (getter ALAscending() + setter ALAscending(bool)); defaults to true
 
 TestFilter.CurrentKey:
   layer: runtime-api
   category: TestFilter
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-1/93-testfilter
+  notes: overloads=1; ALCurrentKey() returns comma-separated field numbers set via SetCurrentKey
 
 TestFilter.GetFilter:
   layer: runtime-api
   category: TestFilter
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-1/93-testfilter
+  notes: overloads=1; ALGetFilter(int fieldNo) returns last filter set for that field
 
 TestFilter.SetCurrentKey:
   layer: runtime-api
   category: TestFilter
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-1/93-testfilter
+  notes: overloads=1; ALSetCurrentKey(params int[] fieldNos) stores field numbers for CurrentKey
 
 TestFilter.SetFilter:
   layer: runtime-api
   category: TestFilter
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-1/93-testfilter
+  notes: overloads=1; ALSetFilter(int fieldNo, string filterExpression) stores per-field filters
 
 # ── TestHttpRequestMessage ──────────────────────────────────────
 

--- a/tests/bucket-1/93-testfilter/src/TestFilterSrc.al
+++ b/tests/bucket-1/93-testfilter/src/TestFilterSrc.al
@@ -1,0 +1,39 @@
+/// Source objects for TestFilter method coverage.
+/// Tests: Ascending (get/set), CurrentKey (get), SetCurrentKey (set),
+/// SetFilter (store), GetFilter (retrieve).
+
+table 96000 "TPF Test Record"
+{
+    fields
+    {
+        field(1; Id; Integer) { }
+        field(2; Name; Text[100]) { }
+        field(3; Amount; Decimal) { }
+    }
+    keys
+    {
+        key(PK; Id) { Clustered = true; }
+        key(ByName; Name) { }
+    }
+}
+
+page 96000 "TPF Test Page"
+{
+    PageType = List;
+    SourceTable = "TPF Test Record";
+    ApplicationArea = All;
+    UsageCategory = None;
+
+    layout
+    {
+        area(Content)
+        {
+            repeater(Lines)
+            {
+                field(IdField; Rec.Id) { ApplicationArea = All; }
+                field(NameField; Rec.Name) { ApplicationArea = All; }
+                field(AmountField; Rec.Amount) { ApplicationArea = All; }
+            }
+        }
+    }
+}

--- a/tests/bucket-1/93-testfilter/test/TestFilterTest.al
+++ b/tests/bucket-1/93-testfilter/test/TestFilterTest.al
@@ -4,7 +4,7 @@
 ///
 /// Proof strategy: if MockTestPageFilter is missing any of these methods,
 /// Roslyn compilation fails with CS1061 and ALL tests in this bucket go RED.
-codeunit 96001 "TPF TestFilter Tests"
+codeunit 96100 "TPF TestFilter Tests"
 {
     Subtype = Test;
 

--- a/tests/bucket-1/93-testfilter/test/TestFilterTest.al
+++ b/tests/bucket-1/93-testfilter/test/TestFilterTest.al
@@ -1,0 +1,131 @@
+/// Tests for TestFilter methods on TestPage.Filter:
+/// Ascending (get/set), CurrentKey (get), SetCurrentKey,
+/// SetFilter (store by field), GetFilter (retrieve).
+///
+/// Proof strategy: if MockTestPageFilter is missing any of these methods,
+/// Roslyn compilation fails with CS1061 and ALL tests in this bucket go RED.
+codeunit 96001 "TPF TestFilter Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    // ── SetFilter / GetFilter ──────────────────────────────────────────────────
+
+    [Test]
+    procedure SetFilter_GetFilter_RoundTrip()
+    var
+        TP: TestPage "TPF Test Page";
+    begin
+        // Positive: a filter set via SetFilter is returned by GetFilter.
+        TP.OpenView();
+        TP.Filter.SetFilter(Name, 'Alice*');
+        Assert.AreEqual('Alice*', TP.Filter.GetFilter(Name),
+            'GetFilter must return the value set by SetFilter');
+        TP.Close();
+    end;
+
+    [Test]
+    procedure GetFilter_ReturnsEmpty_WhenNotSet()
+    var
+        TP: TestPage "TPF Test Page";
+    begin
+        // Negative: GetFilter returns empty string when no filter was set.
+        TP.OpenView();
+        Assert.AreEqual('', TP.Filter.GetFilter(Name),
+            'GetFilter must return empty string when no filter is set');
+        TP.Close();
+    end;
+
+    [Test]
+    procedure SetFilter_NotDefaultEmpty()
+    var
+        TP: TestPage "TPF Test Page";
+    begin
+        // Negative: a no-op SetFilter that always stores '' would fail this.
+        TP.OpenView();
+        TP.Filter.SetFilter(Name, 'Bob');
+        Assert.AreNotEqual('', TP.Filter.GetFilter(Name),
+            'SetFilter must persist a non-empty expression');
+        TP.Close();
+    end;
+
+    // ── Ascending ─────────────────────────────────────────────────────────────
+
+    [Test]
+    procedure Ascending_DefaultIsTrue()
+    var
+        TP: TestPage "TPF Test Page";
+    begin
+        // Positive: default sort direction is ascending.
+        TP.OpenView();
+        Assert.IsTrue(TP.Filter.Ascending(),
+            'Ascending() must default to true');
+        TP.Close();
+    end;
+
+    [Test]
+    procedure Ascending_Set_GetRoundTrip()
+    var
+        TP: TestPage "TPF Test Page";
+    begin
+        // Positive: Ascending(false) followed by Ascending() returns false.
+        TP.OpenView();
+        TP.Filter.Ascending(false);
+        Assert.IsFalse(TP.Filter.Ascending(),
+            'Ascending() must reflect the value set via Ascending(false)');
+        TP.Close();
+    end;
+
+    [Test]
+    procedure Ascending_NotStuckAtDefault()
+    var
+        TP: TestPage "TPF Test Page";
+    begin
+        // Negative: a no-op Ascending setter that always returns true would fail.
+        TP.OpenView();
+        TP.Filter.Ascending(false);
+        Assert.AreNotEqual(true, TP.Filter.Ascending(),
+            'Ascending setter must actually change the value');
+        TP.Close();
+    end;
+
+    // ── CurrentKey / SetCurrentKey ─────────────────────────────────────────────
+
+    [Test]
+    procedure SetCurrentKey_CurrentKey_RoundTrip()
+    var
+        TP: TestPage "TPF Test Page";
+    begin
+        // Positive: SetCurrentKey followed by CurrentKey returns non-empty text.
+        TP.OpenView();
+        TP.Filter.SetCurrentKey(Name);
+        Assert.AreNotEqual('', TP.Filter.CurrentKey(),
+            'CurrentKey must be non-empty after SetCurrentKey');
+        TP.Close();
+    end;
+
+    [Test]
+    procedure CurrentKey_AfterSetCurrentKey_NotDefault()
+    var
+        TP: TestPage "TPF Test Page";
+        k: Text;
+    begin
+        // Negative: a no-op SetCurrentKey that always returns '' would fail this.
+        TP.OpenView();
+        TP.Filter.SetCurrentKey(Name);
+        k := TP.Filter.CurrentKey();
+        Assert.AreNotEqual('', k,
+            'CurrentKey must return a non-empty value after SetCurrentKey');
+        TP.Close();
+    end;
+
+    [Test]
+    procedure AllFilterMethods_Compile()
+    begin
+        // Proof: reaching this line means all TestFilter stubs compiled.
+        Assert.IsTrue(true,
+            'All TestFilter stub methods must compile without CS1061');
+    end;
+}


### PR DESCRIPTION
Closes #747

Adds 3 missing `MockTestPageFilter` methods and marks all 5 TestFilter entries as covered in `docs/coverage.yaml`.

## What was missing

`MockTestPageFilter` only had `ALSetFilter(int, string)` and `ALGetFilter(int)`. AL test code calling `Filter.Ascending()`, `Filter.SetCurrentKey(Field)`, or `Filter.CurrentKey()` failed with CS1061 at Roslyn compilation time.

## Changes

- **`AlRunner/Runtime/MockTestPageFilter`**: added
  - `ALAscending()` → bool getter (defaults `true`)
  - `ALAscending(bool)` → setter
  - `ALSetCurrentKey(params int[])` → stores field numbers
  - `ALCurrentKey()` → returns comma-separated field numbers (non-empty after `SetCurrentKey`)

- **`tests/bucket-1/93-testfilter/`**: new test suite (codeunit 96001)
  - SetFilter/GetFilter round-trip + empty-default negative
  - Ascending default + set/get round-trip + stuck-at-default negative
  - SetCurrentKey/CurrentKey round-trip + no-op negative
  - Compilation proof test

- **`docs/coverage.yaml`**: all 5 `TestFilter.*` entries changed `gap → covered`