### PR TITLE
feat: HttpHeaders — Clear, Keys, TryAddWithoutValidation, ContainsSecret, GetSecretValues

### DIFF
--- a/AlRunner/Runtime/MockHttpHeaders.cs
+++ b/AlRunner/Runtime/MockHttpHeaders.cs
@@ -84,9 +84,41 @@ public class MockHttpHeaders
     /// <summary>Number of distinct header names.</summary>
     public int ALCount => _headers.Count;
 
+    /// <summary>Exposes stored header names for MockJsonHelper.Keys() interception.</summary>
+    public IEnumerable<string> HeaderNames => _headers.Keys;
+
     /// <summary>Removes all headers.</summary>
-    public void Clear()
+    public void Clear() => _headers.Clear();
+
+    /// <summary>
+    /// BC emits: <c>headers.ALClear()</c>
+    /// for <c>HttpHeaders.Clear()</c>.
+    /// </summary>
+    public void ALClear() => _headers.Clear();
+
+    /// <summary>
+    /// BC emits: <c>headers.ALTryAddWithoutValidation(DataError, name, value)</c>
+    /// for <c>HttpHeaders.TryAddWithoutValidation(name, value)</c>.
+    /// Adds the header without format validation; always succeeds.
+    /// </summary>
+    public bool ALTryAddWithoutValidation(DataError errorLevel, NavText name, NavText value)
     {
-        _headers.Clear();
+        ALAdd(errorLevel, (string)name, (string)value);
+        return true;
     }
+
+    /// <summary>
+    /// BC emits: <c>headers.ALIsHeaderValueSecret(name)</c>
+    /// for <c>HttpHeaders.ContainsSecret(name)</c>.
+    /// Plain in-memory headers are never secret — always returns false.
+    /// </summary>
+    public bool ALIsHeaderValueSecret(NavText name) => false;
+
+    /// <summary>
+    /// Overload for <c>HttpHeaders.GetSecretValues(name, secrets)</c>:
+    /// BC emits <c>ALGetValues(DataError, NavText, NavList&lt;NavSecretText&gt;)</c>.
+    /// Plain headers have no secret values; the list is left empty.
+    /// </summary>
+    public bool ALGetValues(DataError errorLevel, NavText key, NavList<NavSecretText> values)
+        => false;
 }

--- a/AlRunner/Runtime/MockHttpRequestMessage.cs
+++ b/AlRunner/Runtime/MockHttpRequestMessage.cs
@@ -42,8 +42,15 @@ public class MockHttpRequestMessage
         set => _content = value ?? new();
     }
 
-    /// <summary>Request headers. BC emits <c>request.ALGetHeaders</c>.</summary>
-    public MockHttpHeaders ALGetHeaders => _headers;
+    /// <summary>
+    /// BC emits: <c>request.ALGetHeaders(DataError, ByRef&lt;MockHttpHeaders&gt;)</c>
+    /// for <c>HttpRequestMessage.GetHeaders(headers)</c>.
+    /// Sets the out-parameter to the stored headers instance.
+    /// </summary>
+    public void ALGetHeaders(DataError errorLevel, ByRef<MockHttpHeaders> headers)
+    {
+        headers.Value = _headers;
+    }
 
     /// <summary>
     /// ALAssign for the ByRef pattern.

--- a/AlRunner/Runtime/MockJsonHelper.cs
+++ b/AlRunner/Runtime/MockJsonHelper.cs
@@ -305,6 +305,20 @@ public static class MockJsonHelper
     }
 
     /// <summary>
+    /// Overload for <c>HttpHeaders.Keys()</c>.
+    /// BC routes ALL <c>.Keys()</c> calls through MockJsonHelper; this overload
+    /// handles the case where the receiver is a <c>MockHttpHeaders</c>.
+    /// Returns a list of all distinct header names.
+    /// </summary>
+    public static NavList<NavText> Keys(MockHttpHeaders headers)
+    {
+        var list = NavList<NavText>.Default;
+        foreach (var key in headers.HeaderNames)
+            list.ALAdd(new NavText(key));
+        return list;
+    }
+
+    /// <summary>
     /// Replacement for NavJsonObject.ALKeys(DataError).
     /// Returns a list of all property names in the object.
     /// AL: JsonObject.Keys()  →  MockJsonHelper.Keys(token, error)

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -2849,7 +2849,7 @@ HttpHeaders.Add:
 HttpHeaders.Clear:
   layer: runtime-api
   category: HttpHeaders
-  status: gap
+  status: covered
   notes: overloads=1
 
 HttpHeaders.Contains:
@@ -2861,13 +2861,13 @@ HttpHeaders.Contains:
 HttpHeaders.ContainsSecret:
   layer: runtime-api
   category: HttpHeaders
-  status: gap
+  status: covered
   notes: overloads=1
 
 HttpHeaders.GetSecretValues:
   layer: runtime-api
   category: HttpHeaders
-  status: gap
+  status: covered
   notes: overloads=2
 
 HttpHeaders.GetValues:
@@ -2879,7 +2879,7 @@ HttpHeaders.GetValues:
 HttpHeaders.Keys:
   layer: runtime-api
   category: HttpHeaders
-  status: gap
+  status: covered
   notes: overloads=1
 
 HttpHeaders.Remove:
@@ -2891,7 +2891,7 @@ HttpHeaders.Remove:
 HttpHeaders.TryAddWithoutValidation:
   layer: runtime-api
   category: HttpHeaders
-  status: gap
+  status: covered
   notes: overloads=2
 
 # ── HttpRequestMessage ──────────────────────────────────────────

--- a/tests/bucket-1/170-httpheaders-methods/al-runner.json
+++ b/tests/bucket-1/170-httpheaders-methods/al-runner.json
@@ -1,0 +1,4 @@
+{
+  "sourcePath": "./src",
+  "testPath": "./test"
+}

--- a/tests/bucket-1/170-httpheaders-methods/src/HttpHeadersMethodsSrc.al
+++ b/tests/bucket-1/170-httpheaders-methods/src/HttpHeadersMethodsSrc.al
@@ -1,0 +1,73 @@
+/// Helper codeunit exercising HttpHeaders gap methods — issue #746.
+codeunit 97000 "HHM Src"
+{
+    // TryAddWithoutValidation — adds header, returns true
+    procedure TryAddWithoutValidation(name: Text; value: Text): Boolean
+    var
+        req: HttpRequestMessage;
+        headers: HttpHeaders;
+    begin
+        req.GetHeaders(headers);
+        exit(headers.TryAddWithoutValidation(name, value));
+    end;
+
+    // TryAddWithoutValidation then Contains — header is present
+    procedure TryAddThenContains(name: Text; value: Text): Boolean
+    var
+        req: HttpRequestMessage;
+        headers: HttpHeaders;
+    begin
+        req.GetHeaders(headers);
+        headers.TryAddWithoutValidation(name, value);
+        exit(headers.Contains(name));
+    end;
+
+    // Clear — removes all headers
+    procedure ClearRemovesHeaders(name: Text; value: Text): Boolean
+    var
+        req: HttpRequestMessage;
+        headers: HttpHeaders;
+    begin
+        req.GetHeaders(headers);
+        headers.Add(name, value);
+        headers.Clear();
+        exit(headers.Contains(name));
+    end;
+
+    // Keys — returns names of added headers
+    procedure KeysContainsAdded(name: Text; value: Text): Boolean
+    var
+        req: HttpRequestMessage;
+        headers: HttpHeaders;
+        keys: List of [Text];
+    begin
+        req.GetHeaders(headers);
+        headers.Add(name, value);
+        keys := headers.Keys();
+        exit(keys.Contains(name));
+    end;
+
+    // ContainsSecret — returns false for plain headers
+    procedure ContainsSecretFalseForPlain(name: Text; value: Text): Boolean
+    var
+        req: HttpRequestMessage;
+        headers: HttpHeaders;
+    begin
+        req.GetHeaders(headers);
+        headers.Add(name, value);
+        exit(headers.ContainsSecret(name));
+    end;
+
+    // GetSecretValues — returns empty list for plain headers
+    procedure GetSecretValuesEmptyForPlain(name: Text; value: Text): Integer
+    var
+        req: HttpRequestMessage;
+        headers: HttpHeaders;
+        secrets: List of [SecretText];
+    begin
+        req.GetHeaders(headers);
+        headers.Add(name, value);
+        headers.GetSecretValues(name, secrets);
+        exit(secrets.Count());
+    end;
+}

--- a/tests/bucket-1/170-httpheaders-methods/test/HttpHeadersMethodsTest.al
+++ b/tests/bucket-1/170-httpheaders-methods/test/HttpHeadersMethodsTest.al
@@ -1,0 +1,60 @@
+codeunit 97001 "HHM Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "HHM Src";
+
+    // ── TryAddWithoutValidation ──────────────────────────────────
+
+    [Test]
+    procedure HttpHeaders_TryAddWithoutValidation_ReturnsTrue()
+    begin
+        Assert.IsTrue(Src.TryAddWithoutValidation('X-Custom', 'value'),
+            'TryAddWithoutValidation must return true on success');
+    end;
+
+    [Test]
+    procedure HttpHeaders_TryAddWithoutValidation_HeaderIsPresent()
+    begin
+        Assert.IsTrue(Src.TryAddThenContains('X-Custom', 'value'),
+            'Header added via TryAddWithoutValidation must be retrievable via Contains');
+    end;
+
+    // ── Clear ────────────────────────────────────────────────────
+
+    [Test]
+    procedure HttpHeaders_Clear_RemovesAllHeaders()
+    begin
+        Assert.IsFalse(Src.ClearRemovesHeaders('X-Test', 'val'),
+            'Contains must return false after Clear');
+    end;
+
+    // ── Keys ─────────────────────────────────────────────────────
+
+    [Test]
+    procedure HttpHeaders_Keys_ContainsAddedHeader()
+    begin
+        Assert.IsTrue(Src.KeysContainsAdded('X-Keys', 'v'),
+            'Keys() must include names of headers that have been added');
+    end;
+
+    // ── ContainsSecret ───────────────────────────────────────────
+
+    [Test]
+    procedure HttpHeaders_ContainsSecret_FalseForPlainHeader()
+    begin
+        Assert.IsFalse(Src.ContainsSecretFalseForPlain('X-Plain', 'value'),
+            'ContainsSecret must return false for plain (non-secret) headers');
+    end;
+
+    // ── GetSecretValues ──────────────────────────────────────────
+
+    [Test]
+    procedure HttpHeaders_GetSecretValues_EmptyForPlainHeader()
+    begin
+        Assert.AreEqual(0, Src.GetSecretValuesEmptyForPlain('X-Plain', 'value'),
+            'GetSecretValues must return empty list for plain (non-secret) headers');
+    end;
+}


### PR DESCRIPTION
Closes #746

## Summary

- `MockHttpHeaders`: added `ALClear()`, `ALTryAddWithoutValidation(DataError, NavText, NavText)` (returns bool), `ALIsHeaderValueSecret(NavText)` (always false — maps to `ContainsSecret`), `ALGetValues(DataError, NavText, NavList<NavSecretText>)` overload (always returns false for non-secret headers), `HeaderNames` property for Keys interception
- `MockHttpRequestMessage`: converted `ALGetHeaders` from property to method `ALGetHeaders(DataError, ByRef<MockHttpHeaders>)` — matches BC-generated call signature for `HttpRequestMessage.GetHeaders(headers)`
- `MockJsonHelper`: added `Keys(MockHttpHeaders)` overload — BC routes all `.Keys()` calls through `MockJsonHelper`, this overload handles the `HttpHeaders.Keys()` case and returns a `NavList<NavText>` of header names
- New test suite `tests/bucket-1/170-httpheaders-methods/` (codeunits 97000/97001) with 6 tests covering all 5 gap methods, with positive and negative cases
- Updated `docs/coverage.yaml`: all 5 `HttpHeaders.*` gap entries marked `covered`

## Test plan

- [x] RED: Roslyn compilation failed with 12 errors before implementation
- [x] GREEN: all 6 tests pass after implementation
- [x] Bucket-1 regression: 1009 passed, 2 pre-existing failures (DT2Time, unrelated)