### PR TITLE
feat: SessionInformation — SqlRowsRead/SqlStatementsExecuted/Callstack stubs (#750)

### DIFF
--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -2424,6 +2424,16 @@ public void ClearApplicationMemberVariables()
                         SyntaxFactory.IdentifierName(targetMethod)));
             }
 
+            // ALSessionInformation.GetALCallstack(session) -> ""
+            // The real implementation dereferences NavSession (null standalone).
+            if (exprText == "ALSessionInformation" && methodName == "GetALCallstack")
+            {
+                return SyntaxFactory.LiteralExpression(
+                    SyntaxKind.StringLiteralExpression,
+                    SyntaxFactory.Literal(""))
+                    .WithTriviaFrom(visited);
+            }
+
             // ALTaskScheduler.ALCreateTask/ALTaskExists/ALCancelTask/ALSetTaskReady -> MockTaskScheduler
             // TaskScheduler APIs require the BC service tier. MockTaskScheduler dispatches
             // CreateTask synchronously via MockCodeunitHandle (same pattern as MockSession).
@@ -3488,6 +3498,29 @@ public void ClearApplicationMemberVariables()
                     SyntaxKind.SimpleMemberAccessExpression,
                     SyntaxFactory.IdentifierName("NavClientType"),
                     SyntaxFactory.IdentifierName("Background"));
+            }
+        }
+
+        // Pattern: ALSessionInformation.ALSqlRowsRead -> 0L
+        //          ALSessionInformation.ALSqlStatementsExecuted -> 0L
+        //          ALSessionInformation.ALCallstack -> ""
+        //          ALSessionInformation.ALAITokensUsed -> 0L
+        // All dereference NavSession (null standalone). Return safe defaults.
+        if (visited.Expression is IdentifierNameSyntax sessInfoId &&
+            sessInfoId.Identifier.Text == "ALSessionInformation")
+        {
+            var prop = visited.Name.Identifier.Text;
+            if (prop == "ALSqlRowsRead" || prop == "ALSqlStatementsExecuted" || prop == "ALAITokensUsed")
+            {
+                return SyntaxFactory.LiteralExpression(
+                    SyntaxKind.NumericLiteralExpression,
+                    SyntaxFactory.Literal(0L));
+            }
+            if (prop == "ALCallstack")
+            {
+                return SyntaxFactory.LiteralExpression(
+                    SyntaxKind.StringLiteralExpression,
+                    SyntaxFactory.Literal(""));
             }
         }
 

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -5600,26 +5600,29 @@ Session.UnbindSubscription:
 SessionInformation.AITokensUsed:
   layer: runtime-api
   category: SessionInformation
-  status: gap
-  notes: overloads=1
+  status: stub
+  notes: overloads=1. Rewriter replaces ALSessionInformation.ALAITokensUsed with 0L. No explicit test (no AL 16.2 syntax for this yet).
 
 SessionInformation.Callstack:
   layer: runtime-api
   category: SessionInformation
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-2/196-sessioninfo
+  notes: overloads=1. Rewriter replaces ALSessionInformation.GetALCallstack(session) with "". Standalone: no call stack to report.
 
 SessionInformation.SqlRowsRead:
   layer: runtime-api
   category: SessionInformation
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-2/196-sessioninfo
+  notes: overloads=1. Rewriter replaces ALSessionInformation.ALSqlRowsRead with 0L. Standalone: no SQL.
 
 SessionInformation.SqlStatementsExecuted:
   layer: runtime-api
   category: SessionInformation
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-2/196-sessioninfo
+  notes: overloads=1. Rewriter replaces ALSessionInformation.ALSqlStatementsExecuted with 0L. Standalone: no SQL.
 
 # ── SessionSettings ─────────────────────────────────────────────
 

--- a/tests/bucket-2/196-sessioninfo/al-runner.json
+++ b/tests/bucket-2/196-sessioninfo/al-runner.json
@@ -1,0 +1,4 @@
+{
+  "sourcePath": "./src",
+  "testPath": "./test"
+}

--- a/tests/bucket-2/196-sessioninfo/src/SessionInfoSrc.al
+++ b/tests/bucket-2/196-sessioninfo/src/SessionInfoSrc.al
@@ -1,0 +1,20 @@
+/// Exercises SessionInformation static methods — SqlRowsRead, SqlStatementsExecuted,
+/// AITokensUsed, Callstack. All are telemetry counters that return safe defaults
+/// in standalone mode (no real DB or AI backend).
+codeunit 60230 "SI Src"
+{
+    procedure GetSqlRowsRead(): BigInteger
+    begin
+        exit(SessionInformation.SqlRowsRead());
+    end;
+
+    procedure GetSqlStatementsExecuted(): BigInteger
+    begin
+        exit(SessionInformation.SqlStatementsExecuted());
+    end;
+
+    procedure GetCallstack(): Text
+    begin
+        exit(SessionInformation.Callstack());
+    end;
+}

--- a/tests/bucket-2/196-sessioninfo/test/SessionInfoTest.al
+++ b/tests/bucket-2/196-sessioninfo/test/SessionInfoTest.al
@@ -1,0 +1,33 @@
+codeunit 60231 "SI Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "SI Src";
+
+    [Test]
+    procedure SqlRowsRead_ReturnsZero()
+    begin
+        // Standalone contract — no real SQL, so the counter is always 0.
+        Assert.AreEqual(0, Src.GetSqlRowsRead(),
+            'SessionInformation.SqlRowsRead must return 0 in standalone mode');
+    end;
+
+    [Test]
+    procedure SqlStatementsExecuted_ReturnsZero()
+    begin
+        Assert.AreEqual(0, Src.GetSqlStatementsExecuted(),
+            'SessionInformation.SqlStatementsExecuted must return 0 in standalone mode');
+    end;
+
+    [Test]
+    procedure Callstack_DoesNotThrow()
+    var
+        cs: Text;
+    begin
+        // Callstack may return empty or a stack trace; just verify it doesn't crash.
+        cs := Src.GetCallstack();
+        Assert.IsTrue(true, 'SessionInformation.Callstack must not throw');
+    end;
+}


### PR DESCRIPTION
## Summary
- Closes #750
- `SessionInformation.SqlRowsRead`, `SqlStatementsExecuted`, and `Callstack` all dereference NavSession (null standalone). Rewriter now replaces the property accesses with `0L` and the `GetALCallstack(session)` method call with `""`.
- Also stubs `AITokensUsed` (0L) in the rewriter for future-proofing, though no test is added (AL 16.2 may not expose it).
- New suite `tests/bucket-2/196-sessioninfo` — 3 tests.

## Test plan
- [x] New suite — 3/3 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)