### PR TITLE
feat: TestAction — Enabled, Visible, Invoke; ProductName — Full, Marketing, Short

### DIFF
--- a/AlRunner/Runtime/MockTestPageHandle.cs
+++ b/AlRunner/Runtime/MockTestPageHandle.cs
@@ -523,6 +523,18 @@ public class MockTestPageAction
         _result = result;
     }
 
+    /// <summary>
+    /// BC emits: <c>action.ALEnabled()</c> for <c>TestAction.Enabled()</c>.
+    /// Stub: always returns true in standalone mode.
+    /// </summary>
+    public bool ALEnabled() => true;
+
+    /// <summary>
+    /// BC emits: <c>action.ALVisible()</c> for <c>TestAction.Visible()</c>.
+    /// Stub: always returns true in standalone mode.
+    /// </summary>
+    public bool ALVisible() => true;
+
     public void ALInvoke()
     {
         if (_parent != null)

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -4400,19 +4400,19 @@ Page.Update:
 ProductName.Full:
   layer: runtime-api
   category: ProductName
-  status: gap
+  status: covered
   notes: overloads=1
 
 ProductName.Marketing:
   layer: runtime-api
   category: ProductName
-  status: gap
+  status: covered
   notes: overloads=1
 
 ProductName.Short:
   layer: runtime-api
   category: ProductName
-  status: gap
+  status: covered
   notes: overloads=1
 
 # ── Query ───────────────────────────────────────────────────────
@@ -6721,19 +6721,19 @@ TaskScheduler.TaskExists:
 TestAction.Enabled:
   layer: runtime-api
   category: TestAction
-  status: gap
+  status: covered
   notes: overloads=1
 
 TestAction.Invoke:
   layer: runtime-api
   category: TestAction
-  status: gap
+  status: covered
   notes: overloads=1
 
 TestAction.Visible:
   layer: runtime-api
   category: TestAction
-  status: gap
+  status: covered
   notes: overloads=1
 
 # ── TestField ───────────────────────────────────────────────────

--- a/tests/bucket-1/171-testaction-productname/al-runner.json
+++ b/tests/bucket-1/171-testaction-productname/al-runner.json
@@ -1,0 +1,4 @@
+{
+  "sourcePath": "./src",
+  "testPath": "./test"
+}

--- a/tests/bucket-1/171-testaction-productname/src/TestActionProductNameSrc.al
+++ b/tests/bucket-1/171-testaction-productname/src/TestActionProductNameSrc.al
@@ -1,0 +1,60 @@
+/// Helper codeunit exercising ProductName — issue #755.
+codeunit 98000 "TAPN Src"
+{
+    // ProductName.Full() — must not throw
+    procedure ProductNameFull(): Text
+    begin
+        exit(ProductName.Full());
+    end;
+
+    // ProductName.Marketing() — must not throw
+    procedure ProductNameMarketing(): Text
+    begin
+        exit(ProductName.Marketing());
+    end;
+
+    // ProductName.Short() — must not throw
+    procedure ProductNameShort(): Text
+    begin
+        exit(ProductName.Short());
+    end;
+}
+
+// Minimal table and page for TestAction testing
+table 98000 "TAPN Record"
+{
+    fields
+    {
+        field(1; Id; Integer) { }
+        field(2; Name; Text[50]) { }
+    }
+    keys { key(PK; Id) { Clustered = true; } }
+}
+
+page 98000 "TAPN Card"
+{
+    PageType = Card;
+    SourceTable = "TAPN Record";
+
+    layout
+    {
+        area(Content)
+        {
+            field(NameField; Rec.Name) { }
+        }
+    }
+
+    actions
+    {
+        area(Processing)
+        {
+            action(DoSomething)
+            {
+                Caption = 'Do Something';
+                trigger OnAction()
+                begin
+                end;
+            }
+        }
+    }
+}

--- a/tests/bucket-1/171-testaction-productname/test/TestActionProductNameTest.al
+++ b/tests/bucket-1/171-testaction-productname/test/TestActionProductNameTest.al
@@ -1,0 +1,70 @@
+codeunit 98001 "TAPN Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "TAPN Src";
+
+    // ── ProductName ──────────────────────────────────────────────
+
+    [Test]
+    procedure ProductName_Full_ReturnsNonEmpty()
+    begin
+        Assert.AreNotEqual('', Src.ProductNameFull(),
+            'ProductName.Full() must return a non-empty string');
+    end;
+
+    [Test]
+    procedure ProductName_Marketing_DoesNotThrow()
+    var
+        result: Text;
+    begin
+        result := Src.ProductNameMarketing();
+        Assert.IsTrue(true, 'ProductName.Marketing() must not throw');
+    end;
+
+    [Test]
+    procedure ProductName_Short_DoesNotThrow()
+    var
+        result: Text;
+    begin
+        result := Src.ProductNameShort();
+        Assert.IsTrue(true, 'ProductName.Short() must not throw');
+    end;
+
+    // ── TestAction — Enabled / Visible / Invoke ──────────────────
+
+    [Test]
+    procedure TestAction_Enabled_ReturnsTrue()
+    var
+        Page: TestPage "TAPN Card";
+    begin
+        Page.OpenView();
+        Assert.IsTrue(Page.DoSomething.Enabled(),
+            'TestAction.Enabled() must return true');
+        Page.Close();
+    end;
+
+    [Test]
+    procedure TestAction_Visible_ReturnsTrue()
+    var
+        Page: TestPage "TAPN Card";
+    begin
+        Page.OpenView();
+        Assert.IsTrue(Page.DoSomething.Visible(),
+            'TestAction.Visible() must return true');
+        Page.Close();
+    end;
+
+    [Test]
+    procedure TestAction_Invoke_DoesNotThrow()
+    var
+        Page: TestPage "TAPN Card";
+    begin
+        Page.OpenView();
+        Page.DoSomething.Invoke();
+        Assert.IsTrue(true, 'TestAction.Invoke() must not throw');
+        Page.Close();
+    end;
+}


### PR DESCRIPTION
Closes #755

## Summary

- **TestAction.Enabled / Visible**: Added `ALEnabled()` and `ALVisible()` to `MockTestPageAction` — both return `true` as stubs (matching BC standalone mode behavior)
- **TestAction.Invoke**: Was already implemented (`ALInvoke()` on `MockTestPageAction`); now covered by test
- **ProductName.Full / Marketing / Short**: Work natively via `ALProductName` static class from the BC runtime DLLs — no mock needed
- New test suite `tests/bucket-1/171-testaction-productname/` (codeunits/table/page 98000, codeunit 98001) with 6 tests covering all 6 gap methods
- Updated `docs/coverage.yaml`: all 6 entries marked `covered`

## Test plan

- [x] RED: Roslyn compilation failed (2 errors for ALEnabled/ALVisible on MockTestPageAction)
- [x] GREEN: all 6 tests pass after adding ALEnabled/ALVisible
- [x] Bucket-1 regression: 1015 passed, 2 pre-existing failures (DT2Time, unrelated)