### PR TITLE
feat: ModuleDependencyInfo — Id, Name, Publisher

### DIFF
--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -3992,19 +3992,19 @@ MediaSet.Remove:
 ModuleDependencyInfo.Id:
   layer: runtime-api
   category: ModuleDependencyInfo
-  status: gap
+  status: covered
   notes: overloads=1
 
 ModuleDependencyInfo.Name:
   layer: runtime-api
   category: ModuleDependencyInfo
-  status: gap
+  status: covered
   notes: overloads=1
 
 ModuleDependencyInfo.Publisher:
   layer: runtime-api
   category: ModuleDependencyInfo
-  status: gap
+  status: covered
   notes: overloads=1
 
 # ── ModuleInfo ──────────────────────────────────────────────────

--- a/tests/bucket-1/172-moduledependencyinfo/al-runner.json
+++ b/tests/bucket-1/172-moduledependencyinfo/al-runner.json
@@ -1,0 +1,4 @@
+{
+  "sourcePath": "./src",
+  "testPath": "./test"
+}

--- a/tests/bucket-1/172-moduledependencyinfo/src/ModuleDepInfoSrc.al
+++ b/tests/bucket-1/172-moduledependencyinfo/src/ModuleDepInfoSrc.al
@@ -1,0 +1,18 @@
+/// Helper codeunit exercising ModuleDependencyInfo — issue #759.
+codeunit 99000 "MDI Src"
+{
+    procedure GetDependencyId(Dep: ModuleDependencyInfo): Text
+    begin
+        exit(Dep.Id());
+    end;
+
+    procedure GetDependencyName(Dep: ModuleDependencyInfo): Text
+    begin
+        exit(Dep.Name());
+    end;
+
+    procedure GetDependencyPublisher(Dep: ModuleDependencyInfo): Text
+    begin
+        exit(Dep.Publisher());
+    end;
+}

--- a/tests/bucket-1/172-moduledependencyinfo/test/ModuleDepInfoTest.al
+++ b/tests/bucket-1/172-moduledependencyinfo/test/ModuleDepInfoTest.al
@@ -1,0 +1,36 @@
+codeunit 99001 "MDI Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "MDI Src";
+
+    [Test]
+    procedure ModuleDependencyInfo_Id_ReturnsZeroGuid()
+    var
+        Dep: ModuleDependencyInfo;
+    begin
+        // Default ModuleDependencyInfo has zero Guid; Id() converts Guid to Text
+        Assert.AreEqual('{00000000-0000-0000-0000-000000000000}', Src.GetDependencyId(Dep),
+            'Id() must return zero Guid text for default ModuleDependencyInfo');
+    end;
+
+    [Test]
+    procedure ModuleDependencyInfo_Name_ReturnsText()
+    var
+        Dep: ModuleDependencyInfo;
+    begin
+        Assert.AreEqual('', Src.GetDependencyName(Dep),
+            'Name() must return empty string for default ModuleDependencyInfo');
+    end;
+
+    [Test]
+    procedure ModuleDependencyInfo_Publisher_ReturnsText()
+    var
+        Dep: ModuleDependencyInfo;
+    begin
+        Assert.AreEqual('', Src.GetDependencyPublisher(Dep),
+            'Publisher() must return empty string for default ModuleDependencyInfo');
+    end;
+}


### PR DESCRIPTION
Closes #759

## What

`ModuleDependencyInfo` is a native BC struct exposed via `NavModuleDependencyInfo` in the BC runtime DLLs. No mock class is needed — the struct works as-is once the ctor arg is stripped.

## Tests

Added suite `172-moduledependencyinfo` (bucket-1, codeunits 99000/99001):

| Test | Assertion |
|------|-----------|
| `ModuleDependencyInfo_Id_ReturnsZeroGuid` | `Id()` → `{00000000-0000-0000-0000-000000000000}` |
| `ModuleDependencyInfo_Name_ReturnsText` | `Name()` → `''` |
| `ModuleDependencyInfo_Publisher_ReturnsText` | `Publisher()` → `''` |

All 3 pass. Bucket-1 regression: 1027 passed (2 pre-existing DT2Time failures unrelated to this PR).

## Coverage

Updated `docs/coverage.yaml`: 3 `ModuleDependencyInfo` entries gap → covered.