### PR TITLE
test: XmlDeclaration — Create/Version/Encoding/Standalone coverage (#705)

### DIFF
--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -8825,14 +8825,16 @@ XmlDeclaration.AsXmlNode:
 XmlDeclaration.Create:
   layer: runtime-api
   category: XmlDeclaration
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-2/198-xmldeclaration
+  notes: overloads=1. Covered via NavXmlDeclaration native — Create(version, encoding, standalone).
 
 XmlDeclaration.Encoding:
   layer: runtime-api
   category: XmlDeclaration
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-2/198-xmldeclaration
+  notes: overloads=1. Covered via NavXmlDeclaration native — getter and setter round-trip.
 
 XmlDeclaration.GetDocument:
   layer: runtime-api
@@ -8873,14 +8875,16 @@ XmlDeclaration.SelectSingleNode:
 XmlDeclaration.Standalone:
   layer: runtime-api
   category: XmlDeclaration
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-2/198-xmldeclaration
+  notes: overloads=1. Covered via NavXmlDeclaration native — getter and setter round-trip.
 
 XmlDeclaration.Version:
   layer: runtime-api
   category: XmlDeclaration
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-2/198-xmldeclaration
+  notes: overloads=1. Covered via NavXmlDeclaration native — getter and setter round-trip.
 
 XmlDeclaration.WriteTo:
   layer: runtime-api

--- a/tests/bucket-2/198-xmldeclaration/al-runner.json
+++ b/tests/bucket-2/198-xmldeclaration/al-runner.json
@@ -1,0 +1,4 @@
+{
+  "sourcePath": "./src",
+  "testPath": "./test"
+}

--- a/tests/bucket-2/198-xmldeclaration/src/XmlDeclarationSrc.al
+++ b/tests/bucket-2/198-xmldeclaration/src/XmlDeclarationSrc.al
@@ -1,0 +1,54 @@
+/// Exercises XmlDeclaration — Create, Version, Encoding, Standalone.
+codeunit 60250 "XDL Src"
+{
+    procedure CreateAndGetVersion(): Text
+    var
+        decl: XmlDeclaration;
+    begin
+        decl := XmlDeclaration.Create('1.0', 'utf-8', 'yes');
+        exit(decl.Version);
+    end;
+
+    procedure CreateAndGetEncoding(): Text
+    var
+        decl: XmlDeclaration;
+    begin
+        decl := XmlDeclaration.Create('1.0', 'utf-8', 'yes');
+        exit(decl.Encoding);
+    end;
+
+    procedure CreateAndGetStandalone(): Text
+    var
+        decl: XmlDeclaration;
+    begin
+        decl := XmlDeclaration.Create('1.0', 'utf-8', 'yes');
+        exit(decl.Standalone);
+    end;
+
+    procedure SetVersion(v: Text): Text
+    var
+        decl: XmlDeclaration;
+    begin
+        decl := XmlDeclaration.Create('1.0', 'utf-8', '');
+        decl.Version := v;
+        exit(decl.Version);
+    end;
+
+    procedure SetEncoding(enc: Text): Text
+    var
+        decl: XmlDeclaration;
+    begin
+        decl := XmlDeclaration.Create('1.0', 'utf-8', '');
+        decl.Encoding := enc;
+        exit(decl.Encoding);
+    end;
+
+    procedure SetStandalone(sa: Text): Text
+    var
+        decl: XmlDeclaration;
+    begin
+        decl := XmlDeclaration.Create('1.0', '', '');
+        decl.Standalone := sa;
+        exit(decl.Standalone);
+    end;
+}

--- a/tests/bucket-2/198-xmldeclaration/test/XmlDeclarationTest.al
+++ b/tests/bucket-2/198-xmldeclaration/test/XmlDeclarationTest.al
@@ -1,0 +1,57 @@
+codeunit 60251 "XDL Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "XDL Src";
+
+    [Test]
+    procedure Create_Version()
+    begin
+        Assert.AreEqual('1.0', Src.CreateAndGetVersion(),
+            'XmlDeclaration.Version must return the supplied version');
+    end;
+
+    [Test]
+    procedure Create_Encoding()
+    begin
+        Assert.AreEqual('utf-8', Src.CreateAndGetEncoding(),
+            'XmlDeclaration.Encoding must return the supplied encoding');
+    end;
+
+    [Test]
+    procedure Create_Standalone()
+    begin
+        Assert.AreEqual('yes', Src.CreateAndGetStandalone(),
+            'XmlDeclaration.Standalone must return the supplied standalone flag');
+    end;
+
+    [Test]
+    procedure SetVersion_RoundTrip()
+    begin
+        Assert.AreEqual('1.1', Src.SetVersion('1.1'),
+            'Version setter must round-trip');
+    end;
+
+    [Test]
+    procedure SetEncoding_RoundTrip()
+    begin
+        Assert.AreEqual('utf-16', Src.SetEncoding('utf-16'),
+            'Encoding setter must round-trip');
+    end;
+
+    [Test]
+    procedure SetStandalone_RoundTrip()
+    begin
+        Assert.AreEqual('no', Src.SetStandalone('no'),
+            'Standalone setter must round-trip');
+    end;
+
+    [Test]
+    procedure Version_NotEncoding_NegativeTrap()
+    begin
+        Assert.AreNotEqual(Src.CreateAndGetEncoding(), Src.CreateAndGetVersion(),
+            'Version and Encoding must not alias');
+    end;
+}


### PR DESCRIPTION
## Summary
- Closes #705 (partial — covers 4 of 14 listed methods; remainder follow-up)
- All four `XmlDeclaration` core members (`Create`, `Version`, `Encoding`, `Standalone`) already work via BC's native `NavXmlDeclaration`. This PR adds the first proving tests and flips coverage.yaml.
- New suite `tests/bucket-2/198-xmldeclaration` — 7 tests.

## Test plan
- [x] New suite — 7/7 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)