### PR TITLE
test: XmlProcessingInstruction — Create/GetTarget/GetData/SetTarget/SetData (#704)

### DIFF
--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -9671,14 +9671,16 @@ XmlProcessingInstruction.AsXmlNode:
 XmlProcessingInstruction.Create:
   layer: runtime-api
   category: XmlProcessingInstruction
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-2/199-xmlpi
+  notes: overloads=1. Covered via NavXmlProcessingInstruction native — Create(target, data).
 
 XmlProcessingInstruction.GetData:
   layer: runtime-api
   category: XmlProcessingInstruction
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-2/199-xmlpi
+  notes: overloads=1. Covered via NavXmlProcessingInstruction native — returns the data set at create time or via SetData.
 
 XmlProcessingInstruction.GetDocument:
   layer: runtime-api
@@ -9695,8 +9697,9 @@ XmlProcessingInstruction.GetParent:
 XmlProcessingInstruction.GetTarget:
   layer: runtime-api
   category: XmlProcessingInstruction
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-2/199-xmlpi
+  notes: overloads=1. Covered via NavXmlProcessingInstruction native — returns the target set at create time or via SetTarget.
 
 XmlProcessingInstruction.Remove:
   layer: runtime-api
@@ -9725,14 +9728,16 @@ XmlProcessingInstruction.SelectSingleNode:
 XmlProcessingInstruction.SetData:
   layer: runtime-api
   category: XmlProcessingInstruction
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-2/199-xmlpi
+  notes: overloads=1. Covered via NavXmlProcessingInstruction native — setter round-trips through GetData.
 
 XmlProcessingInstruction.SetTarget:
   layer: runtime-api
   category: XmlProcessingInstruction
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-2/199-xmlpi
+  notes: overloads=1. Covered via NavXmlProcessingInstruction native — setter round-trips through GetTarget.
 
 XmlProcessingInstruction.WriteTo:
   layer: runtime-api

--- a/tests/bucket-2/199-xmlpi/al-runner.json
+++ b/tests/bucket-2/199-xmlpi/al-runner.json
@@ -1,0 +1,4 @@
+{
+  "sourcePath": "./src",
+  "testPath": "./test"
+}

--- a/tests/bucket-2/199-xmlpi/src/XmlPISrc.al
+++ b/tests/bucket-2/199-xmlpi/src/XmlPISrc.al
@@ -1,0 +1,46 @@
+/// Exercises XmlProcessingInstruction — Create, GetTarget, GetData,
+/// SetTarget, SetData.
+codeunit 60260 "XPI Src"
+{
+    procedure CreateAndGetTarget(): Text
+    var
+        pi: XmlProcessingInstruction;
+        result: Text;
+    begin
+        pi := XmlProcessingInstruction.Create('xml-stylesheet', 'type="text/css"');
+        pi.GetTarget(result);
+        exit(result);
+    end;
+
+    procedure CreateAndGetData(): Text
+    var
+        pi: XmlProcessingInstruction;
+        result: Text;
+    begin
+        pi := XmlProcessingInstruction.Create('xml-stylesheet', 'type="text/css"');
+        pi.GetData(result);
+        exit(result);
+    end;
+
+    procedure SetTargetAndRead(newTarget: Text): Text
+    var
+        pi: XmlProcessingInstruction;
+        result: Text;
+    begin
+        pi := XmlProcessingInstruction.Create('original', 'data');
+        pi.SetTarget(newTarget);
+        pi.GetTarget(result);
+        exit(result);
+    end;
+
+    procedure SetDataAndRead(newData: Text): Text
+    var
+        pi: XmlProcessingInstruction;
+        result: Text;
+    begin
+        pi := XmlProcessingInstruction.Create('target', 'original');
+        pi.SetData(newData);
+        pi.GetData(result);
+        exit(result);
+    end;
+}

--- a/tests/bucket-2/199-xmlpi/test/XmlPITest.al
+++ b/tests/bucket-2/199-xmlpi/test/XmlPITest.al
@@ -1,0 +1,43 @@
+codeunit 60261 "XPI Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "XPI Src";
+
+    [Test]
+    procedure Create_GetTarget()
+    begin
+        Assert.AreEqual('xml-stylesheet', Src.CreateAndGetTarget(),
+            'XmlProcessingInstruction.GetTarget must return the created target');
+    end;
+
+    [Test]
+    procedure Create_GetData()
+    begin
+        Assert.AreEqual('type="text/css"', Src.CreateAndGetData(),
+            'XmlProcessingInstruction.GetData must return the created data');
+    end;
+
+    [Test]
+    procedure SetTarget_RoundTrip()
+    begin
+        Assert.AreEqual('newTarget', Src.SetTargetAndRead('newTarget'),
+            'SetTarget must update and round-trip through GetTarget');
+    end;
+
+    [Test]
+    procedure SetData_RoundTrip()
+    begin
+        Assert.AreEqual('href="style.css"', Src.SetDataAndRead('href="style.css"'),
+            'SetData must update and round-trip through GetData');
+    end;
+
+    [Test]
+    procedure Target_NotData_NegativeTrap()
+    begin
+        Assert.AreNotEqual(Src.CreateAndGetTarget(), Src.CreateAndGetData(),
+            'GetTarget and GetData must not alias');
+    end;
+}


### PR DESCRIPTION
## Summary
- Closes #704 (partial — 5 of 14 listed methods)
- Five core `XmlProcessingInstruction` members already work via BC's native `NavXmlProcessingInstruction`. This PR adds the first proving tests and flips coverage.yaml.
- New suite `tests/bucket-2/199-xmlpi` — 5 tests.

## Test plan
- [x] New suite — 5/5 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)