### PR TITLE
feat: JsonObject — GetChar, GetDate, GetDateTime, WriteWithSecretsTo

### DIFF
--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -2302,7 +2302,7 @@ public void ClearApplicationMemberVariables()
             // TrappableOperationExecutor and crash in standalone mode — redirect those.
             // NOTE: do NOT add ALGet/ALContains/ALRemove/ALReplace here — those method names
             // also appear on record proxy classes and would cause a C# type mismatch if intercepted.
-            if (methodName is "ALWriteTo" or "ALReadFrom" or "ALSelectToken" or "ALSelectTokens"
+            if (methodName is "ALWriteTo" or "ALWriteWithSecretsTo" or "ALReadFrom" or "ALSelectToken" or "ALSelectTokens"
                 or "ALGetBoolean" or "ALIsArray" or "ALIsObject" or "ALIsValue" or "ALClone"
                 or "ALKeys"
                 or "ALGetText" or "ALGetInteger" or "ALGetDecimal"
@@ -2311,6 +2311,7 @@ public void ClearApplicationMemberVariables()
                 var helperMethod = methodName switch
                 {
                     "ALWriteTo" => "WriteTo",
+                    "ALWriteWithSecretsTo" => "WriteWithSecretsTo",
                     "ALReadFrom" => "ReadFrom",
                     "ALSelectToken" => "SelectToken",
                     "ALSelectTokens" => "SelectTokens",

--- a/AlRunner/Runtime/MockJsonHelper.cs
+++ b/AlRunner/Runtime/MockJsonHelper.cs
@@ -100,6 +100,31 @@ public static class MockJsonHelper
     }
 
     /// <summary>
+    /// Replacement for NavJsonObject.ALWriteWithSecretsTo(DataError, NavDictionary, ByRef&lt;NavSecretText&gt;).
+    /// In the runner, secrets are treated as plain text — serializes the JSON to a string
+    /// and wraps it in a NavSecretText. The secrets dictionary is intentionally ignored.
+    /// AL: JsonObject.WriteWithSecretsTo(Secrets, var Result) → MockJsonHelper.WriteWithSecretsTo(token, error, secrets, result)
+    /// </summary>
+    public static bool WriteWithSecretsTo(NavJsonToken token, DataError errorLevel, object secrets, ByRef<NavSecretText> result)
+    {
+        try
+        {
+            var backingToken = GetBackingToken(token);
+            using var stringWriter = new StringWriter(CultureInfo.InvariantCulture);
+            using var jsonWriter = new JsonTextWriter(stringWriter) { Formatting = Formatting.None };
+            backingToken.WriteTo(jsonWriter);
+            result.Value = NavSecretText.Create(stringWriter.ToString());
+            return true;
+        }
+        catch (Exception)
+        {
+            if (errorLevel == DataError.ThrowError)
+                throw;
+            return false;
+        }
+    }
+
+    /// <summary>
     /// Fallback WriteTo for non-JSON types (e.g. NavXmlCData, NavXmlElement).
     /// The rewriter intercepts all ALWriteTo calls regardless of receiver type, so XML nodes
     /// also land here. We call ALWriteTo natively via reflection — XML Write methods do not

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -3350,20 +3350,26 @@ JsonObject.GetByte:
 JsonObject.GetChar:
   layer: runtime-api
   category: JsonObject
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; works natively via NavJsonObject (no TrappableOperationExecutor path); BC stores Char as integer code point in JSON
+  tests:
+    - tests/bucket-1/173-jsonobject-extra-methods
 
 JsonObject.GetDate:
   layer: runtime-api
   category: JsonObject
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; works natively via NavJsonObject (no TrappableOperationExecutor path); BC stores Date as ISO 8601 string in JSON
+  tests:
+    - tests/bucket-1/173-jsonobject-extra-methods
 
 JsonObject.GetDateTime:
   layer: runtime-api
   category: JsonObject
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; works natively via NavJsonObject (no TrappableOperationExecutor path); BC stores DateTime as ISO 8601 string in JSON
+  tests:
+    - tests/bucket-1/173-jsonobject-extra-methods
 
 JsonObject.GetDecimal:
   layer: runtime-api
@@ -3485,8 +3491,10 @@ JsonObject.WriteToYaml:
 JsonObject.WriteWithSecretsTo:
   layer: runtime-api
   category: JsonObject
-  status: gap
-  notes: overloads=2
+  status: covered
+  notes: overloads=2; rewriter redirects ALWriteWithSecretsTo to MockJsonHelper.WriteWithSecretsTo; in runner secrets are treated as plain text — serializes JSON to NavSecretText; secrets dict ignored
+  tests:
+    - tests/bucket-1/173-jsonobject-extra-methods
 
 # ── JsonToken ───────────────────────────────────────────────────
 

--- a/tests/bucket-1/173-jsonobject-extra-methods/al-runner.json
+++ b/tests/bucket-1/173-jsonobject-extra-methods/al-runner.json
@@ -1,0 +1,4 @@
+{
+  "description": "JsonObject — GetChar, GetDate, GetDateTime, WriteWithSecretsTo",
+  "issue": 763
+}

--- a/tests/bucket-1/173-jsonobject-extra-methods/src/JsonObjExtraSrc.al
+++ b/tests/bucket-1/173-jsonobject-extra-methods/src/JsonObjExtraSrc.al
@@ -1,0 +1,27 @@
+/// Helper codeunit exercising JsonObject — GetChar, GetDate, GetDateTime, WriteWithSecretsTo.
+codeunit 100000 "JOE Src"
+{
+    procedure GetCharValue(Obj: JsonObject; KeyName: Text): Char
+    begin
+        exit(Obj.GetChar(KeyName));
+    end;
+
+    procedure GetDateValue(Obj: JsonObject; KeyName: Text): Date
+    begin
+        exit(Obj.GetDate(KeyName));
+    end;
+
+    procedure GetDateTimeValue(Obj: JsonObject; KeyName: Text): DateTime
+    begin
+        exit(Obj.GetDateTime(KeyName));
+    end;
+
+    procedure WriteWithSecretsToText(Obj: JsonObject): Text
+    var
+        Secrets: Dictionary of [Text, SecretText];
+        Result: SecretText;
+    begin
+        Obj.WriteWithSecretsTo(Secrets, Result);
+        exit(Result.Unwrap());
+    end;
+}

--- a/tests/bucket-1/173-jsonobject-extra-methods/test/JsonObjExtraTest.al
+++ b/tests/bucket-1/173-jsonobject-extra-methods/test/JsonObjExtraTest.al
@@ -1,0 +1,80 @@
+codeunit 100001 "JOE Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "JOE Src";
+
+    [Test]
+    procedure GetChar_ReturnsCharacterValue()
+    var
+        Obj: JsonObject;
+    begin
+        // Char 65 = 'A'
+        Obj.Add('ch', 65);
+        Assert.AreEqual('A', Src.GetCharValue(Obj, 'ch'), 'GetChar must return the character for code point 65');
+    end;
+
+    [Test]
+    procedure GetChar_MissingKey_Throws()
+    var
+        Obj: JsonObject;
+    begin
+        asserterror Src.GetCharValue(Obj, 'nope');
+        Assert.ExpectedError('');
+    end;
+
+    [Test]
+    procedure GetDate_ReturnsDateValue()
+    var
+        Obj: JsonObject;
+        Expected: Date;
+    begin
+        Expected := DMY2Date(15, 6, 2024);
+        Obj.Add('dt', Expected);
+        Assert.AreEqual(Expected, Src.GetDateValue(Obj, 'dt'), 'GetDate must return the stored date');
+    end;
+
+    [Test]
+    procedure GetDate_MissingKey_Throws()
+    var
+        Obj: JsonObject;
+    begin
+        asserterror Src.GetDateValue(Obj, 'nope');
+        Assert.ExpectedError('');
+    end;
+
+    [Test]
+    procedure GetDateTime_ReturnsDateTimeValue()
+    var
+        Obj: JsonObject;
+        Expected: DateTime;
+    begin
+        Expected := CreateDateTime(DMY2Date(15, 6, 2024), 120000T);
+        Obj.Add('ts', Expected);
+        Assert.AreEqual(Expected, Src.GetDateTimeValue(Obj, 'ts'), 'GetDateTime must return the stored datetime');
+    end;
+
+    [Test]
+    procedure GetDateTime_MissingKey_Throws()
+    var
+        Obj: JsonObject;
+    begin
+        asserterror Src.GetDateTimeValue(Obj, 'nope');
+        Assert.ExpectedError('');
+    end;
+
+    [Test]
+    procedure WriteWithSecretsTo_ProducesValidJson()
+    var
+        Obj: JsonObject;
+        Json: Text;
+    begin
+        Obj.Add('key', 'val');
+        Json := Src.WriteWithSecretsToText(Obj);
+        Assert.IsTrue(Json.StartsWith('{'), 'WriteWithSecretsTo must produce a JSON object string');
+        Assert.IsTrue(Json.Contains('"key"'), 'JSON must contain the key');
+        Assert.IsTrue(Json.Contains('"val"'), 'JSON must contain the value');
+    end;
+}


### PR DESCRIPTION
Closes #763

## What

Implements the 4 remaining `JsonObject` gaps from issue #763:

| Method | Approach |
|--------|----------|
| `GetChar` | Works natively via `NavJsonObject` — no rewriter change needed |
| `GetDate` | Works natively via `NavJsonObject` — no rewriter change needed |
| `GetDateTime` | Works natively via `NavJsonObject` — no rewriter change needed |
| `WriteWithSecretsTo` | New rewriter interception (`ALWriteWithSecretsTo` → `MockJsonHelper.WriteWithSecretsTo`); serializes JSON to `NavSecretText`; secrets dict ignored (runner treats secrets as plain text) |

Note: `GetBoolean`, `GetDecimal`, `GetInteger`, `GetText`, `Keys`, `ReadFrom`, `Remove`, `WriteTo` were already covered before this issue.

## Tests

Added suite `173-jsonobject-extra-methods` (bucket-1, codeunits 100000/100001) — 7 proving tests:

- `GetChar_ReturnsCharacterValue` — code point 65 → `'A'`
- `GetChar_MissingKey_Throws` — missing key throws
- `GetDate_ReturnsDateValue` — round-trip `DMY2Date(15,6,2024)`
- `GetDate_MissingKey_Throws` — missing key throws
- `GetDateTime_ReturnsDateTimeValue` — round-trip `CreateDateTime(...)`
- `GetDateTime_MissingKey_Throws` — missing key throws
- `WriteWithSecretsTo_ProducesValidJson` — asserts output starts with `{`, contains key/value

All 7 pass. Bucket-1 regression: 1034 passed (2 pre-existing DT2Time failures).

## Coverage

Updated `docs/coverage.yaml`: 4 entries gap → covered.