### PR TITLE
feat: JsonArray.Clone() and AsToken() — proving tests

### DIFF
--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -3106,14 +3106,16 @@ JsonArray.Add:
 JsonArray.AsToken:
   layer: runtime-api
   category: JsonArray
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-2/193-jsonarray-clone-astoken
+  notes: overloads=1. Works natively via NavJsonToken.ALAsToken() — no rewriter redirect needed. Covered with IsArray() and Count() round-trip checks.
 
 JsonArray.Clone:
   layer: runtime-api
   category: JsonArray
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-2/193-jsonarray-clone-astoken
+  notes: overloads=1. ALClone → MockJsonHelper.Clone (deep-clones via Newtonsoft DeepClone). Covered with empty-array, element-copy, and independence (mutation-after-clone) tests.
 
 JsonArray.Count:
   layer: runtime-api

--- a/tests/bucket-2/193-jsonarray-clone-astoken/src/JsonArrayCloneSrc.al
+++ b/tests/bucket-2/193-jsonarray-clone-astoken/src/JsonArrayCloneSrc.al
@@ -1,5 +1,5 @@
 /// Source codeunit exercising JsonArray.Clone() and JsonArray.AsToken().
-codeunit 60250 "JAC Src"
+codeunit 62010 "JAC Src"
 {
     /// Clone an array and return the clone as a JsonToken.
     procedure CloneArray(Arr: JsonArray): JsonToken

--- a/tests/bucket-2/193-jsonarray-clone-astoken/src/JsonArrayCloneSrc.al
+++ b/tests/bucket-2/193-jsonarray-clone-astoken/src/JsonArrayCloneSrc.al
@@ -1,0 +1,49 @@
+/// Source codeunit exercising JsonArray.Clone() and JsonArray.AsToken().
+codeunit 60250 "JAC Src"
+{
+    /// Clone an array and return the clone as a JsonToken.
+    procedure CloneArray(Arr: JsonArray): JsonToken
+    begin
+        exit(Arr.Clone());
+    end;
+
+    /// Verify Clone produces an independent deep copy:
+    /// mutate the original and confirm the clone is unchanged.
+    procedure CloneIsIndependent(Arr: JsonArray): Integer
+    var
+        Clone: JsonToken;
+        CloneArr: JsonArray;
+    begin
+        Clone := Arr.Clone();
+        CloneArr := Clone.AsArray();
+        // Mutate original — clone must not see the new element
+        Arr.Add(999);
+        exit(CloneArr.Count());
+    end;
+
+    /// Convert a JsonArray to a JsonToken via AsToken().
+    procedure ArrayAsToken(Arr: JsonArray): JsonToken
+    begin
+        exit(Arr.AsToken());
+    end;
+
+    /// Confirm that AsToken() returns a token that IsArray() = true.
+    procedure AsTokenIsArray(Arr: JsonArray): Boolean
+    var
+        Token: JsonToken;
+    begin
+        Token := Arr.AsToken();
+        exit(Token.IsArray());
+    end;
+
+    /// Confirm that after AsToken the array content is accessible.
+    procedure AsTokenCount(Arr: JsonArray): Integer
+    var
+        Token: JsonToken;
+        A: JsonArray;
+    begin
+        Token := Arr.AsToken();
+        A := Token.AsArray();
+        exit(A.Count());
+    end;
+}

--- a/tests/bucket-2/193-jsonarray-clone-astoken/test/JsonArrayCloneTest.al
+++ b/tests/bucket-2/193-jsonarray-clone-astoken/test/JsonArrayCloneTest.al
@@ -1,5 +1,5 @@
 /// Tests for JsonArray.Clone() and JsonArray.AsToken().
-codeunit 60251 "JAC Test"
+codeunit 62011 "JAC Test"
 {
     Subtype = Test;
 

--- a/tests/bucket-2/193-jsonarray-clone-astoken/test/JsonArrayCloneTest.al
+++ b/tests/bucket-2/193-jsonarray-clone-astoken/test/JsonArrayCloneTest.al
@@ -1,0 +1,96 @@
+/// Tests for JsonArray.Clone() and JsonArray.AsToken().
+codeunit 60251 "JAC Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "JAC Src";
+
+    // ── Clone ──────────────────────────────────────────────────────────────
+
+    [Test]
+    procedure Clone_EmptyArray_ReturnsEmptyToken()
+    var
+        Arr: JsonArray;
+        Token: JsonToken;
+        CloneArr: JsonArray;
+    begin
+        // [GIVEN] an empty array
+        // [WHEN] Clone is called
+        Token := Src.CloneArray(Arr);
+        CloneArr := Token.AsArray();
+        // [THEN] clone is an array with 0 elements
+        Assert.AreEqual(0, CloneArr.Count(), 'Clone of empty array must have count 0');
+    end;
+
+    [Test]
+    procedure Clone_ArrayWithElements_CopiesCount()
+    var
+        Arr: JsonArray;
+        Token: JsonToken;
+        CloneArr: JsonArray;
+    begin
+        // [GIVEN] array with 3 elements
+        Arr.Add('a');
+        Arr.Add('b');
+        Arr.Add('c');
+        // [WHEN] Clone is called
+        Token := Src.CloneArray(Arr);
+        CloneArr := Token.AsArray();
+        // [THEN] clone has the same count
+        Assert.AreEqual(3, CloneArr.Count(), 'Clone must have same element count');
+    end;
+
+    [Test]
+    procedure Clone_IsDeepCopy_OriginalMutationNotReflected()
+    var
+        Arr: JsonArray;
+    begin
+        // [GIVEN] array with 2 elements
+        Arr.Add(10);
+        Arr.Add(20);
+        // [WHEN] Clone is taken and original is mutated
+        // [THEN] clone count is still 2 (not 3)
+        Assert.AreEqual(2, Src.CloneIsIndependent(Arr),
+            'Clone must not reflect mutation of original after cloning');
+    end;
+
+    // ── AsToken ───────────────────────────────────────────────────────────
+
+    [Test]
+    procedure AsToken_EmptyArray_IsArray()
+    var
+        Arr: JsonArray;
+    begin
+        // [GIVEN] an empty array
+        // [WHEN] AsToken is called
+        // [THEN] the resulting token reports IsArray = true
+        Assert.IsTrue(Src.AsTokenIsArray(Arr), 'AsToken() on JsonArray must yield IsArray=true');
+    end;
+
+    [Test]
+    procedure AsToken_PreservesCount()
+    var
+        Arr: JsonArray;
+    begin
+        // [GIVEN] array with 2 elements
+        Arr.Add(1);
+        Arr.Add(2);
+        // [WHEN] AsToken is called and array is recovered
+        // [THEN] count is still 2
+        Assert.AreEqual(2, Src.AsTokenCount(Arr), 'AsToken().AsArray() must preserve element count');
+    end;
+
+    [Test]
+    procedure AsToken_IsNotValue()
+    var
+        Arr: JsonArray;
+        Token: JsonToken;
+    begin
+        // [GIVEN/WHEN] empty array converted to token
+        Token := Src.ArrayAsToken(Arr);
+        // [THEN] IsValue = false
+        Assert.IsFalse(Token.IsValue(), 'AsToken on JsonArray must not be a value');
+    end;
+}


### PR DESCRIPTION
Closes #762

## What

Adds a proving test suite for `JsonArray.Clone()` and `JsonArray.AsToken()` — the two remaining runtime-api gaps for JsonArray highlighted in the issue.

Both methods were already functional but untested:
- **Clone** routes through `ALClone` → `MockJsonHelper.Clone` (Newtonsoft `DeepClone`) — already wired in the rewriter and helper
- **AsToken** works natively via `NavJsonToken.ALAsToken()`, same as `ALAsArray`/`ALAsObject`/`ALAsValue` (no `TrappableOperationExecutor` path)

## Tests (`tests/bucket-2/193-jsonarray-clone-astoken/`)

| Test | Proves |
|------|--------|
| `Clone_EmptyArray_ReturnsEmptyToken` | Clone of empty array → 0-count token |
| `Clone_ArrayWithElements_CopiesCount` | Clone copies all elements |
| `Clone_IsDeepCopy_OriginalMutationNotReflected` | Mutating original after clone doesn't affect clone |
| `AsToken_EmptyArray_IsArray` | `AsToken()` returns a token that `IsArray()` = true |
| `AsToken_PreservesCount` | Round-trip through AsToken → AsArray preserves count |
| `AsToken_IsNotValue` | AsToken is not a value token |

Also updates `docs/coverage.yaml` to mark both as `covered`.