### PR TITLE
feat: NavApp archive stubs — GetArchiveVersion/LoadPackageData/RestoreArchiveData/DeleteArchiveData (#740)

### DIFF
--- a/AlRunner/Runtime/MockNavApp.cs
+++ b/AlRunner/Runtime/MockNavApp.cs
@@ -102,4 +102,23 @@ public static class MockNavApp
 
     public static NavList<NavText> ALListResources(object? errorLevel, NavText resourceType)
         => NavList<NavText>.Default;
+
+    /// <summary>
+    /// NavApp.GetArchiveVersion() : Text — returns the archive version of the calling
+    /// extension's data. No archive in standalone mode; returns empty.
+    /// BC emits: ALNavApp.ALNavAppGetArchiveVersion(null)
+    /// </summary>
+    public static NavText ALNavAppGetArchiveVersion(object? errorLevel)
+        => NavText.Empty;
+    public static NavText ALNavAppGetArchiveVersion()
+        => NavText.Empty;
+
+    public static void ALNavAppLoadPackageData(object? errorLevel, int tableNo) { }
+    public static void ALNavAppLoadPackageData(int tableNo) { }
+
+    public static void ALNavAppRestoreArchiveData(object? errorLevel, int tableNo) { }
+    public static void ALNavAppRestoreArchiveData(int tableNo) { }
+
+    public static void ALNavAppDeleteArchiveData(object? errorLevel, int tableNo) { }
+    public static void ALNavAppDeleteArchiveData(int tableNo) { }
 }

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -4072,8 +4072,9 @@ ModuleInfo.Publisher:
 NavApp.DeleteArchiveData:
   layer: runtime-api
   category: NavApp
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-2/201-navapp-archive
+  notes: overloads=1. No-op standalone — no archive store. Stub on MockNavApp.
 
 NavApp.GetArchiveRecordRef:
   layer: runtime-api
@@ -4084,8 +4085,9 @@ NavApp.GetArchiveRecordRef:
 NavApp.GetArchiveVersion:
   layer: runtime-api
   category: NavApp
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-2/201-navapp-archive
+  notes: overloads=1. Returns empty — no archive in standalone mode. Stub on MockNavApp.
 
 NavApp.GetCallerCallstackModuleInfos:
   layer: runtime-api
@@ -4162,14 +4164,16 @@ NavApp.ListResources:
 NavApp.LoadPackageData:
   layer: runtime-api
   category: NavApp
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-2/201-navapp-archive
+  notes: overloads=1. No-op standalone — no .app package data to import. Stub on MockNavApp.
 
 NavApp.RestoreArchiveData:
   layer: runtime-api
   category: NavApp
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-2/201-navapp-archive
+  notes: overloads=1. No-op standalone — no archive store. Stub on MockNavApp.
 
 # ── Notification ────────────────────────────────────────────────
 

--- a/tests/bucket-2/201-navapp-archive/al-runner.json
+++ b/tests/bucket-2/201-navapp-archive/al-runner.json
@@ -1,0 +1,4 @@
+{
+  "sourcePath": "./src",
+  "testPath": "./test"
+}

--- a/tests/bucket-2/201-navapp-archive/src/NavAppArchiveSrc.al
+++ b/tests/bucket-2/201-navapp-archive/src/NavAppArchiveSrc.al
@@ -1,0 +1,29 @@
+/// Exercises NavApp archive/resource stubs:
+/// GetArchiveVersion, LoadPackageData, RestoreArchiveData, DeleteArchiveData.
+/// GetArchiveRecordRef and GetResource require types (RecordRef/InStream)
+/// that are complex to test here; separate follow-up.
+codeunit 60280 "NAR Src"
+{
+    procedure GetArchiveVersion(): Text
+    begin
+        exit(NavApp.GetArchiveVersion());
+    end;
+
+    procedure LoadPackageData_DoesNotThrow(): Boolean
+    begin
+        NavApp.LoadPackageData(0);
+        exit(true);
+    end;
+
+    procedure RestoreArchiveData_DoesNotThrow(): Boolean
+    begin
+        NavApp.RestoreArchiveData(0);
+        exit(true);
+    end;
+
+    procedure DeleteArchiveData_DoesNotThrow(): Boolean
+    begin
+        NavApp.DeleteArchiveData(0);
+        exit(true);
+    end;
+}

--- a/tests/bucket-2/201-navapp-archive/test/NavAppArchiveTest.al
+++ b/tests/bucket-2/201-navapp-archive/test/NavAppArchiveTest.al
@@ -1,0 +1,36 @@
+codeunit 60281 "NAR Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "NAR Src";
+
+    [Test]
+    procedure GetArchiveVersion_ReturnsEmpty()
+    begin
+        Assert.AreEqual('', Src.GetArchiveVersion(),
+            'NavApp.GetArchiveVersion must return empty in standalone mode');
+    end;
+
+    [Test]
+    procedure LoadPackageData_DoesNotThrow()
+    begin
+        Assert.IsTrue(Src.LoadPackageData_DoesNotThrow(),
+            'NavApp.LoadPackageData must complete without throwing');
+    end;
+
+    [Test]
+    procedure RestoreArchiveData_DoesNotThrow()
+    begin
+        Assert.IsTrue(Src.RestoreArchiveData_DoesNotThrow(),
+            'NavApp.RestoreArchiveData must complete without throwing');
+    end;
+
+    [Test]
+    procedure DeleteArchiveData_DoesNotThrow()
+    begin
+        Assert.IsTrue(Src.DeleteArchiveData_DoesNotThrow(),
+            'NavApp.DeleteArchiveData must complete without throwing');
+    end;
+}


### PR DESCRIPTION
## Summary
- Closes #740 (partial — 4 of 6 methods; GetArchiveRecordRef and GetResource need follow-up)
- Adds `MockNavApp` stubs for `ALNavAppGetArchiveVersion` (empty string), `ALNavAppLoadPackageData` / `ALNavAppRestoreArchiveData` / `ALNavAppDeleteArchiveData` (no-ops). Each has both with/without errorLevel overloads.
- New suite `tests/bucket-2/201-navapp-archive` — 4 tests.

## Test plan
- [x] New suite — 4/4 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)