### PR TITLE
feat: JsonToken.Path, NumberSequence.Range, Time.Millisecond, XmlNodeList.Get, XmlReadOptions/XmlWriteOptions.PreserveWhitespace

### DIFF
--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -2331,6 +2331,7 @@ public void ClearApplicationMemberVariables()
                     "ALIsValue" => "IsValue",
                     "ALClone" => "Clone",
                     "ALKeys" => "Keys",
+
                     "ALGetText" => "GetText",
                     "ALGetInteger" => "GetInteger",
                     "ALGetDecimal" => "GetDecimal",
@@ -3730,6 +3731,21 @@ public void ClearApplicationMemberVariables()
                 SyntaxFactory.IdentifierName("MockLanguage"),
                 SyntaxFactory.IdentifierName("ALGlobalLanguage"))
                 .WithTriviaFrom(visited);
+        }
+
+        // Pattern: token.ALPath → MockJsonHelper.Path(token)
+        // NavJsonToken.ALPath is a property (not method) that returns Newtonsoft path format.
+        // We intercept it to convert to BC $-prefixed format.
+        if (memberName == "ALPath")
+        {
+            return SyntaxFactory.InvocationExpression(
+                SyntaxFactory.MemberAccessExpression(
+                    SyntaxKind.SimpleMemberAccessExpression,
+                    SyntaxFactory.IdentifierName("MockJsonHelper"),
+                    SyntaxFactory.IdentifierName("Path")),
+                SyntaxFactory.ArgumentList(
+                    SyntaxFactory.SingletonSeparatedList(
+                        SyntaxFactory.Argument(visited.Expression))));
         }
 
         return visited;

--- a/AlRunner/Runtime/MockJsonHelper.cs
+++ b/AlRunner/Runtime/MockJsonHelper.cs
@@ -330,6 +330,14 @@ public static class MockJsonHelper
         return new NavText(bcPath);
     }
 
+    /// <summary>
+    /// Overload for Cookie.Path — BC emits cookie.ALPath as a property access,
+    /// which the rewriter converts to MockJsonHelper.Path(cookie). Cookies do not
+    /// need path-format conversion; just wrap the raw string in NavText.
+    /// </summary>
+    public static NavText Path(MockCookie cookie)
+        => new NavText(cookie.ALPath);
+
     /// <summary>Returns true if the token's backing store is a JArray.</summary>
     public static bool IsArray(NavJsonToken token)
         => GetBackingToken(token) is JArray;

--- a/AlRunner/Runtime/MockJsonHelper.cs
+++ b/AlRunner/Runtime/MockJsonHelper.cs
@@ -306,6 +306,30 @@ public static class MockJsonHelper
         return val.Value<bool>();
     }
 
+    /// <summary>
+    /// Replacement for NavJsonToken.ALPath(DataError).
+    /// Returns the BC-style JSON path for the token (e.g. "$" for root, "$.foo" for a field).
+    /// Newtonsoft.Json uses "" for root and "foo" for a field — this converts to BC format.
+    /// AL: JsonToken.Path() → MockJsonHelper.Path(token, error)
+    /// </summary>
+    public static NavText Path(NavJsonToken token)
+    {
+        var backingToken = GetBackingToken(token);
+        var newtonsoftPath = backingToken.Path;
+        // Convert Newtonsoft path to BC $ format:
+        //   ""    → "$"
+        //   "[0]" → "$[0]"
+        //   "foo" → "$.foo"
+        string bcPath;
+        if (string.IsNullOrEmpty(newtonsoftPath))
+            bcPath = "$";
+        else if (newtonsoftPath.StartsWith('['))
+            bcPath = "$" + newtonsoftPath;
+        else
+            bcPath = "$." + newtonsoftPath;
+        return new NavText(bcPath);
+    }
+
     /// <summary>Returns true if the token's backing store is a JArray.</summary>
     public static bool IsArray(NavJsonToken token)
         => GetBackingToken(token) is JArray;

--- a/AlRunner/Runtime/MockNumberSequence.cs
+++ b/AlRunner/Runtime/MockNumberSequence.cs
@@ -37,6 +37,28 @@ public static class MockNumberSequence
         _sequences[name] = startValue;
     }
 
+    public static void ALInsert(string name, long startValue, long increment, bool companySpecific)
+    {
+        _sequences[name] = startValue;
+    }
+
+    /// <summary>
+    /// AL: NumberSequence.Range(Name, Count [, CompanySpecific]) → BigInteger
+    /// Reserves the next Count values and returns the first value of the range.
+    /// Advances the sequence counter by Count.
+    /// </summary>
+    public static long ALRange(string name, long count)
+    {
+        if (!_sequences.ContainsKey(name))
+            _sequences[name] = 0;
+        var first = _sequences[name] + 1;
+        _sequences[name] += count;
+        return first;
+    }
+
+    public static long ALRange(string name, long count, bool companySpecific)
+        => ALRange(name, count);
+
     public static long ALNext(string name)
     {
         if (!_sequences.ContainsKey(name))

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -3565,8 +3565,10 @@ JsonToken.IsValue:
 JsonToken.Path:
   layer: runtime-api
   category: JsonToken
-  status: gap
-  notes: overloads=1; ALPath property is too broadly named — MockCookie also has ALPath; needs type-aware rewriter support
+  status: covered
+  notes: overloads=1; BC emits ALPath as property access; VisitMemberAccessExpression intercepts ALPath→MockJsonHelper.Path(token) which converts Newtonsoft format to BC $-prefixed format
+  tests:
+    - tests/bucket-1/175-misc-gaps
 
 JsonToken.ReadFrom:
   layer: runtime-api
@@ -4262,8 +4264,10 @@ NumberSequence.Next:
 NumberSequence.Range:
   layer: runtime-api
   category: NumberSequence
-  status: gap
-  notes: overloads=2
+  status: covered
+  notes: overloads=2; added ALRange(name, count) and ALRange(name, count, companySpecific) to MockNumberSequence; also added ALInsert 4-arg overload; reserves Count values, returns first
+  tests:
+    - tests/bucket-1/175-misc-gaps
 
 NumberSequence.Restart:
   layer: runtime-api
@@ -7977,8 +7981,10 @@ Time.Hour:
 Time.Millisecond:
   layer: runtime-api
   category: Time
-  status: gap
-  notes: overloads=1; no picture-string token for ms; Time2HMS not available in BC AL
+  status: covered
+  notes: overloads=1; works natively via NavTime; tested with default (0ms) and 000000T+100 (100ms)
+  tests:
+    - tests/bucket-1/175-misc-gaps
 
 Time.Minute:
   layer: runtime-api
@@ -9689,8 +9695,10 @@ XmlNodeList.Count:
 XmlNodeList.Get:
   layer: runtime-api
   category: XmlNodeList
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; works natively via NavXmlNodeList; 1-based index; tested by selecting child element and calling Get(1)
+  tests:
+    - tests/bucket-1/175-misc-gaps
 
 # ── XmlProcessingInstruction ────────────────────────────────────
 
@@ -9794,8 +9802,10 @@ XmlProcessingInstruction.WriteTo:
 XmlReadOptions.PreserveWhitespace:
   layer: runtime-api
   category: XmlReadOptions
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; works natively via NavXmlReadOptions; get and set tested (default false, set to true returns true)
+  tests:
+    - tests/bucket-1/175-misc-gaps
 
 # ── XmlText ─────────────────────────────────────────────────────
 
@@ -9889,7 +9899,10 @@ XmlText.WriteTo:
 XmlWriteOptions.PreserveWhitespace:
   layer: runtime-api
   category: XmlWriteOptions
-  status: gap
+  status: covered
+  notes: overloads=1; works natively via NavXmlWriteOptions; get and set tested (default false, set to true returns true)
+  tests:
+    - tests/bucket-1/175-misc-gaps
   notes: overloads=1
 
 # ── Xmlport ─────────────────────────────────────────────────────

--- a/tests/bucket-1/175-misc-gaps/al-runner.json
+++ b/tests/bucket-1/175-misc-gaps/al-runner.json
@@ -1,0 +1,4 @@
+{
+  "description": "JsonToken.Path, NumberSequence.Range, TextConst.IndexOfAny, Time.Millisecond, XmlNodeList.Get, XmlReadOptions/XmlWriteOptions.PreserveWhitespace",
+  "issue": 776
+}

--- a/tests/bucket-1/175-misc-gaps/src/MiscGapsSrc.al
+++ b/tests/bucket-1/175-misc-gaps/src/MiscGapsSrc.al
@@ -1,0 +1,53 @@
+/// Helper codeunit exercising misc gaps — issue #776.
+codeunit 102000 "MG Src"
+{
+    procedure GetJsonTokenPath(Token: JsonToken): Text
+    begin
+        exit(Token.Path());
+    end;
+
+    procedure GetTimeMillisecond(T: Time): Integer
+    begin
+        exit(T.Millisecond());
+    end;
+
+    procedure GetXmlNodeListItem(NodeList: XmlNodeList; Idx: Integer): Boolean
+    var
+        Node: XmlNode;
+    begin
+        NodeList.Get(Idx, Node);
+        exit(Node.IsXmlElement());
+    end;
+
+    procedure GetPreserveWhitespaceRead(Opts: XmlReadOptions): Boolean
+    begin
+        exit(Opts.PreserveWhitespace());
+    end;
+
+    procedure SetPreserveWhitespaceRead(Opts: XmlReadOptions; Val: Boolean): Boolean
+    begin
+        Opts.PreserveWhitespace(Val);
+        exit(Opts.PreserveWhitespace());
+    end;
+
+    procedure GetPreserveWhitespaceWrite(Opts: XmlWriteOptions): Boolean
+    begin
+        exit(Opts.PreserveWhitespace());
+    end;
+
+    procedure SetPreserveWhitespaceWrite(Opts: XmlWriteOptions; Val: Boolean): Boolean
+    begin
+        Opts.PreserveWhitespace(Val);
+        exit(Opts.PreserveWhitespace());
+    end;
+
+    procedure NumberSequenceRange(SeqName: Text; Count: BigInteger): BigInteger
+    var
+        FirstVal: BigInteger;
+    begin
+        if not NumberSequence.Exists(SeqName) then
+            NumberSequence.Insert(SeqName, 1, 1, false);
+        FirstVal := NumberSequence.Range(SeqName, Count, false);
+        exit(FirstVal);
+    end;
+}

--- a/tests/bucket-1/175-misc-gaps/test/MiscGapsTest.al
+++ b/tests/bucket-1/175-misc-gaps/test/MiscGapsTest.al
@@ -1,0 +1,116 @@
+codeunit 102001 "MG Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "MG Src";
+
+    [Test]
+    procedure JsonToken_Path_RootValue()
+    var
+        Token: JsonToken;
+    begin
+        Token.ReadFrom('"hello"');
+        Assert.AreEqual('$', Src.GetJsonTokenPath(Token), 'root token path must be $');
+    end;
+
+    [Test]
+    procedure JsonToken_Path_ObjectField()
+    var
+        Obj: JsonObject;
+        Token: JsonToken;
+    begin
+        Obj.Add('name', 'test');
+        Obj.Get('name', Token);
+        Assert.AreEqual('$.name', Src.GetJsonTokenPath(Token), 'field token path must be $.name');
+    end;
+
+    [Test]
+    procedure Time_Millisecond_DefaultIsZero()
+    var
+        T: Time;
+    begin
+        Assert.AreEqual(0, Src.GetTimeMillisecond(T), 'default Time has 0 milliseconds');
+    end;
+
+    [Test]
+    procedure Time_Millisecond_NonZero()
+    var
+        T: Time;
+    begin
+        // Add 100ms to midnight via time arithmetic (T + N adds N milliseconds in AL)
+        T := 000000T + 100;
+        Assert.AreEqual(100, Src.GetTimeMillisecond(T), 'T with 100ms component must return 100');
+    end;
+
+    [Test]
+    procedure XmlNodeList_Get_ReturnsElement()
+    var
+        Root: XmlElement;
+        Child: XmlElement;
+        NodeList: XmlNodeList;
+    begin
+        Root := XmlElement.Create('root');
+        Child := XmlElement.Create('child');
+        Root.Add(Child);
+        if Root.SelectNodes('child', NodeList) then
+            Assert.IsTrue(Src.GetXmlNodeListItem(NodeList, 1), 'Get(1) must return the child element');
+    end;
+
+    [Test]
+    procedure XmlReadOptions_PreserveWhitespace_DefaultFalse()
+    var
+        Opts: XmlReadOptions;
+    begin
+        Assert.IsFalse(Src.GetPreserveWhitespaceRead(Opts), 'default XmlReadOptions.PreserveWhitespace must be false');
+    end;
+
+    [Test]
+    procedure XmlReadOptions_PreserveWhitespace_SetTrue()
+    var
+        Opts: XmlReadOptions;
+    begin
+        Assert.IsTrue(Src.SetPreserveWhitespaceRead(Opts, true), 'XmlReadOptions.PreserveWhitespace set to true must return true');
+    end;
+
+    [Test]
+    procedure XmlWriteOptions_PreserveWhitespace_DefaultFalse()
+    var
+        Opts: XmlWriteOptions;
+    begin
+        Assert.IsFalse(Src.GetPreserveWhitespaceWrite(Opts), 'default XmlWriteOptions.PreserveWhitespace must be false');
+    end;
+
+    [Test]
+    procedure XmlWriteOptions_PreserveWhitespace_SetTrue()
+    var
+        Opts: XmlWriteOptions;
+    begin
+        Assert.IsTrue(Src.SetPreserveWhitespaceWrite(Opts, true), 'XmlWriteOptions.PreserveWhitespace set to true must return true');
+    end;
+
+    [Test]
+    procedure NumberSequence_Range_ReturnsFirstValue()
+    var
+        First: BigInteger;
+    begin
+        // Fresh sequence starts at 1; Range(3) reserves 1,2,3 and returns 1
+        First := Src.NumberSequenceRange('MG_RangeTest_' + Format(CurrentDateTime, 0, 9), 3);
+        Assert.IsTrue(First >= 1, 'Range must return a positive first value');
+    end;
+
+    [Test]
+    procedure NumberSequence_Range_AdvancesCounter()
+    var
+        SeqName: Text;
+        First1: BigInteger;
+        First2: BigInteger;
+    begin
+        SeqName := 'MG_RangeAdv_' + Format(CurrentDateTime, 0, 9);
+        First1 := Src.NumberSequenceRange(SeqName, 2);
+        First2 := Src.NumberSequenceRange(SeqName, 2);
+        // Second call should return first1 + 2 (skipped 2 values)
+        Assert.AreEqual(First1 + 2, First2, 'second Range call must start after the first reserved block');
+    end;
+}


### PR DESCRIPTION
Closes #776

## What

Implements 6 small gaps from issue #776:

| Gap | Approach |
|-----|----------|
| `JsonToken.Path` | BC emits `ALPath` as a **property** (not method call). Added `VisitMemberAccessExpression` interception → `MockJsonHelper.Path(token)` which converts Newtonsoft `""` / `"foo"` format to BC `$` / `$.foo` format |
| `NumberSequence.Range` | Added `ALRange(name, count)` and `ALRange(name, count, companySpecific)` to `MockNumberSequence`; also added 4-arg `ALInsert` overload |
| `Time.Millisecond` | Works natively via `NavTime` — no runner changes needed |
| `XmlNodeList.Get` | Works natively via `NavXmlNodeList` |
| `XmlReadOptions.PreserveWhitespace` | Works natively — get and set both work |
| `XmlWriteOptions.PreserveWhitespace` | Works natively — get and set both work |

Note: `TextConst.IndexOfAny` was in the issue title but not in the root-cause or test requirements — no failing AL code was identified for it.

## Tests

Added suite `175-misc-gaps` (bucket-1, codeunits 102000/102001) — 11 proving tests, all green:

- `JsonToken_Path_RootValue` — root token → `$`
- `JsonToken_Path_ObjectField` — field token → `$.name`
- `Time_Millisecond_DefaultIsZero` — default Time → 0
- `Time_Millisecond_NonZero` — `000000T + 100` → 100ms
- `XmlNodeList_Get_ReturnsElement` — Get(1) returns XmlElement
- `XmlReadOptions_PreserveWhitespace_DefaultFalse` / `_SetTrue`
- `XmlWriteOptions_PreserveWhitespace_DefaultFalse` / `_SetTrue`
- `NumberSequence_Range_ReturnsFirstValue` — Range returns ≥1
- `NumberSequence_Range_AdvancesCounter` — second Range starts after first block

Bucket-1 regression: 1075 passed (2 pre-existing DT2Time failures).

## Coverage

Updated `docs/coverage.yaml`: 6 entries gap → covered.