### PR TITLE
feat: RecordRef.FieldExist + RecordLevelLocking (#778)

### DIFF
--- a/AlRunner/Runtime/MockRecordHandle.cs
+++ b/AlRunner/Runtime/MockRecordHandle.cs
@@ -949,7 +949,9 @@ public class MockRecordHandle
     public bool HasField(int fieldNo)
     {
         if (_fields.ContainsKey(fieldNo)) return true;
-        return GetRows().Any(r => r.ContainsKey(fieldNo));
+        if (GetRows().Any(r => r.ContainsKey(fieldNo))) return true;
+        var name = TableFieldRegistry.GetFieldName(_tableId, fieldNo);
+        return name != null;
     }
 
     /// <summary>

--- a/AlRunner/Runtime/MockRecordRef.cs
+++ b/AlRunner/Runtime/MockRecordRef.cs
@@ -536,6 +536,10 @@ public class MockRecordRef
     public bool ALFieldExists(int fieldNo) => _handle?.HasField(fieldNo) ?? false;
     public bool ALFieldExists(string fieldName) => false;
 
+    // -- RecordLevelLocking --
+    /// <summary>Standalone: always true — no SQL table-level locking to worry about.</summary>
+    public bool ALRecordLevelLocking => true;
+
     // -- ModifyAll --
     public void ALModifyAll(int fieldNo, NavValue newValue) => _handle?.ALModifyAllSafe(fieldNo, NavType.Text, newValue);
     public void ALModifyAll(int fieldNo, NavValue newValue, bool runTrigger) => _handle?.ALModifyAllSafe(fieldNo, NavType.Text, newValue, runTrigger);

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -4731,8 +4731,9 @@ RecordRef.FieldCount:
 RecordRef.FieldExist:
   layer: runtime-api
   category: RecordRef
-  status: gap
-  notes: overloads=2
+  status: covered
+  tests: tests/bucket-2/202-recref-fieldexist
+  notes: overloads=2. ALFieldExists now checks TableFieldRegistry so it reports true for metadata-registered fields even with no data rows. Known/unknown/second-field tested.
 
 RecordRef.FieldIndex:
   layer: runtime-api
@@ -4944,8 +4945,9 @@ RecordRef.RecordId:
 RecordRef.RecordLevelLocking:
   layer: runtime-api
   category: RecordRef
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-2/202-recref-fieldexist
+  notes: overloads=1. Standalone: always true (row-level locking, no SQL table hints). Property on MockRecordRef.
 
 RecordRef.Rename:
   layer: runtime-api

--- a/tests/bucket-2/202-recref-fieldexist/al-runner.json
+++ b/tests/bucket-2/202-recref-fieldexist/al-runner.json
@@ -1,0 +1,4 @@
+{
+  "sourcePath": "./src",
+  "testPath": "./test"
+}

--- a/tests/bucket-2/202-recref-fieldexist/src/RecRefFieldExistSrc.al
+++ b/tests/bucket-2/202-recref-fieldexist/src/RecRefFieldExistSrc.al
@@ -1,0 +1,29 @@
+table 60300 "RFE Row"
+{
+    fields
+    {
+        field(1; "Id"; Integer) { }
+        field(2; "Name"; Text[100]) { }
+    }
+    keys { key(PK; "Id") { Clustered = true; } }
+}
+
+/// Exercises RecordRef.FieldExist and RecordRef.RecordLevelLocking.
+codeunit 60300 "RFE Src"
+{
+    procedure FieldExist_ByNo(tableNo: Integer; fieldNo: Integer): Boolean
+    var
+        rr: RecordRef;
+    begin
+        rr.Open(tableNo);
+        exit(rr.FieldExist(fieldNo));
+    end;
+
+    procedure RecordLevelLocking_Get(): Boolean
+    var
+        rr: RecordRef;
+    begin
+        rr.Open(60300);
+        exit(rr.RecordLevelLocking());
+    end;
+}

--- a/tests/bucket-2/202-recref-fieldexist/test/RecRefFieldExistTest.al
+++ b/tests/bucket-2/202-recref-fieldexist/test/RecRefFieldExistTest.al
@@ -1,0 +1,50 @@
+codeunit 60301 "RFE Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "RFE Src";
+
+    [Test]
+    procedure FieldExist_KnownField_True()
+    begin
+        // Field 1 ("Id") exists on table 60300.
+        Assert.IsTrue(Src.FieldExist_ByNo(60300, 1),
+            'FieldExist must return true for a known field number');
+    end;
+
+    [Test]
+    procedure FieldExist_Unknown_False()
+    begin
+        // Field 999 does not exist on table 60300.
+        Assert.IsFalse(Src.FieldExist_ByNo(60300, 999),
+            'FieldExist must return false for an unknown field number');
+    end;
+
+    [Test]
+    procedure FieldExist_SecondField_True()
+    begin
+        // Field 2 ("Name") exists.
+        Assert.IsTrue(Src.FieldExist_ByNo(60300, 2),
+            'FieldExist must return true for a second known field');
+    end;
+
+    [Test]
+    procedure RecordLevelLocking_ReturnsTrue()
+    begin
+        // Standalone contract: always use row-level locking (no SQL table hints).
+        Assert.IsTrue(Src.RecordLevelLocking_Get(),
+            'RecordRef.RecordLevelLocking must return true in standalone mode');
+    end;
+
+    [Test]
+    procedure FieldExist_Known_DiffersFromUnknown_NegativeTrap()
+    begin
+        // Negative trap: FieldExist must actually introspect.
+        Assert.AreNotEqual(
+            Src.FieldExist_ByNo(60300, 1),
+            Src.FieldExist_ByNo(60300, 999),
+            'FieldExist on known and unknown field must produce different results');
+    end;
+}


### PR DESCRIPTION
## Summary
- Closes #778 (partial — RecordRef methods covered; page background-task methods are a separate concern)
- `RecordRef.FieldExist`: `MockRecordHandle.HasField` now also checks `TableFieldRegistry` so it reports true for metadata-registered fields even with no data rows.
- `RecordRef.RecordLevelLocking`: new `ALRecordLevelLocking` property on `MockRecordRef` returning `true` (standalone always row-level).
- New suite `tests/bucket-2/202-recref-fieldexist` — 5 tests.
- bucket-2 regression: 1390 pass, 3 pre-existing timezone failures.

## Test plan
- [x] New suite — 5/5 pass
- [x] bucket-2 regression — 1390 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)