### PR TITLE
feat: System error-handling utilities (GetLastErrorText, GetLastErrorCode, GetLastErrorCallStack, ClearLastError, GetCollectedErrors, etc.)

### DIFF
--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -2240,6 +2240,8 @@ public static class Executor
             AlRunner.Runtime.MockIsolatedStorage.ResetAll();
             AlRunner.Runtime.MockVariableStorage.Reset();
             AlRunner.Runtime.AlScope.ResetLastStatement();
+            AlRunner.Runtime.AlScope.LastErrorText = "";
+            AlRunner.Runtime.AlScope.LastErrorCode = "";
             AlRunner.Runtime.AlScope.ResetCollectedErrors();
             AlRunner.Runtime.HandlerRegistry.Reset();
             AlRunner.Runtime.MockSession.Reset();

--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -3546,18 +3546,27 @@ public void ClearApplicationMemberVariables()
             }
         }
 
-        // Pattern: ALSystemErrorHandling.ALGetLastErrorText -> AlScope.LastErrorText
+        // Pattern: ALSystemErrorHandling.ALGetLastErrorText     -> AlScope.LastErrorText
+        //          ALSystemErrorHandling.ALGetLastErrorCode     -> AlScope.LastErrorCode
+        //          ALSystemErrorHandling.ALGetLastErrorCallStack -> AlScope.LastErrorCallStack
         // ALSystemErrorHandling accesses NavCurrentThread.Session which is null in standalone mode.
         if (visited.Expression is IdentifierNameSyntax errHandlingId &&
             errHandlingId.Identifier.Text == "ALSystemErrorHandling")
         {
             var errProp = visited.Name.Identifier.Text;
-            if (errProp == "ALGetLastErrorText" || errProp == "ALGetLastErrorCode" || errProp == "ALGetLastErrorCallStack")
+            string? scopeProp = errProp switch
+            {
+                "ALGetLastErrorText" => "LastErrorText",
+                "ALGetLastErrorCode" => "LastErrorCode",
+                "ALGetLastErrorCallStack" => "LastErrorCallStack",
+                _ => null
+            };
+            if (scopeProp != null)
             {
                 return SyntaxFactory.MemberAccessExpression(
                     SyntaxKind.SimpleMemberAccessExpression,
                     SyntaxFactory.IdentifierName("AlScope"),
-                    SyntaxFactory.IdentifierName("LastErrorText"));
+                    SyntaxFactory.IdentifierName(scopeProp));
             }
         }
 

--- a/AlRunner/Runtime/AlScope.cs
+++ b/AlRunner/Runtime/AlScope.cs
@@ -150,6 +150,12 @@ public class AlScope : IDisposable, ITreeObject
     public static string LastErrorText { get; set; } = "";
 
     /// <summary>
+    /// Stores the last error code. Always empty in standalone runner (BC error codes
+    /// require structured ErrorInfo which is beyond runner scope).
+    /// </summary>
+    public static string LastErrorCode { get; set; } = "";
+
+    /// <summary>
     /// Configurable user ID returned by UserId() — defaults to "TESTUSER".
     /// Set via --user-id CLI flag or PipelineOptions.UserId before running.
     /// </summary>
@@ -185,6 +191,13 @@ public class AlScope : IDisposable, ITreeObject
             CollectedErrors.Clear();
         return result;
     }
+
+    /// <summary>
+    /// Zero-arg overload emitted by BC compiler for GetCollectedErrors() in AL.
+    /// Returns the collected errors without clearing (BC default behaviour).
+    /// </summary>
+    public static NavList<NavALErrorInfo> GetCollectedErrors()
+        => GetCollectedErrors(clearErrors: false);
 
     /// <summary>Clears all collected errors.</summary>
     public static void ClearCollectedErrors() => CollectedErrors.Clear();

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -5778,14 +5778,14 @@ System.ClearAll:
 System.ClearCollectedErrors:
   layer: runtime-api
   category: System
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; AlScope.ClearCollectedErrors(); tested in 176-system-error-utils
 
 System.ClearLastError:
   layer: runtime-api
   category: System
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; rewrites to AlScope.LastErrorText = ""; tested in 176-system-error-utils
 
 System.ClosingDate:
   layer: runtime-api
@@ -5962,8 +5962,8 @@ System.Format:
 System.GetCollectedErrors:
   layer: runtime-api
   category: System
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; zero-arg AlScope.GetCollectedErrors(); tested in 176-system-error-utils
 
 System.GetDocumentUrl:
   layer: runtime-api
@@ -5980,14 +5980,14 @@ System.GetDotNetType:
 System.GetLastErrorCallStack:
   layer: runtime-api
   category: System
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; returns AlScope.LastErrorCallStack (always "" in runner); tested in 176-system-error-utils
 
 System.GetLastErrorCode:
   layer: runtime-api
   category: System
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; returns AlScope.LastErrorCode (always "" in runner); tested in 176-system-error-utils
 
 System.GetLastErrorObject:
   layer: runtime-api
@@ -5998,8 +5998,8 @@ System.GetLastErrorObject:
 System.GetLastErrorText:
   layer: runtime-api
   category: System
-  status: gap
-  notes: overloads=2
+  status: covered
+  notes: overloads=2; returns AlScope.LastErrorText set by asserterror; tested in 176-system-error-utils
 
 System.GetUrl:
   layer: runtime-api
@@ -6022,8 +6022,8 @@ System.GuiAllowed:
 System.HasCollectedErrors:
   layer: runtime-api
   category: System
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; AlScope.HasCollectedErrors; tested in 176-system-error-utils
 
 System.Hyperlink:
   layer: runtime-api
@@ -6052,8 +6052,8 @@ System.ImportStreamWithUrlAccess:
 System.IsCollectingErrors:
   layer: runtime-api
   category: System
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; AlScope.IsCollectingErrors; tested in 176-system-error-utils
 
 System.IsNull:
   layer: runtime-api

--- a/tests/bucket-1/176-system-error-utils/src/SystemErrorUtilsSrc.al
+++ b/tests/bucket-1/176-system-error-utils/src/SystemErrorUtilsSrc.al
@@ -1,0 +1,42 @@
+codeunit 103000 "SEU Src"
+{
+    procedure GetLastErrText(): Text
+    begin
+        exit(GetLastErrorText());
+    end;
+
+    procedure GetLastErrCode(): Text
+    begin
+        exit(GetLastErrorCode());
+    end;
+
+    procedure GetLastErrCallStack(): Text
+    begin
+        exit(GetLastErrorCallStack());
+    end;
+
+    procedure IsCollecting(): Boolean
+    begin
+        exit(IsCollectingErrors());
+    end;
+
+    procedure HasCollected(): Boolean
+    begin
+        exit(HasCollectedErrors());
+    end;
+
+    procedure ClearLast()
+    begin
+        ClearLastError();
+    end;
+
+    procedure ClearCollected()
+    begin
+        ClearCollectedErrors();
+    end;
+
+    procedure GetCollected(): List of [ErrorInfo]
+    begin
+        exit(GetCollectedErrors());
+    end;
+}

--- a/tests/bucket-1/176-system-error-utils/test/SystemErrorUtilsTest.al
+++ b/tests/bucket-1/176-system-error-utils/test/SystemErrorUtilsTest.al
@@ -1,0 +1,73 @@
+codeunit 103001 "SEU Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "SEU Src";
+
+    [Test]
+    procedure GetLastErrorText_NoError_ReturnsEmpty()
+    begin
+        Src.ClearLast();
+        Assert.AreEqual('', Src.GetLastErrText(), 'GetLastErrorText must be empty when no error');
+    end;
+
+    [Test]
+    procedure GetLastErrorText_AfterError_ReturnsMessage()
+    begin
+        asserterror Error('Test error message');
+        Assert.IsTrue(Src.GetLastErrText().Contains('Test error message'), 'GetLastErrorText must contain the error message');
+    end;
+
+    [Test]
+    procedure ClearLastError_ResetsText()
+    begin
+        asserterror Error('Some error');
+        Src.ClearLast();
+        Assert.AreEqual('', Src.GetLastErrText(), 'GetLastErrorText must be empty after ClearLastError');
+    end;
+
+    [Test]
+    procedure GetLastErrorCode_ReturnsText()
+    begin
+        // Error codes may be empty in the runner — just verify it does not crash and returns Text
+        Assert.AreEqual('', Src.GetLastErrCode(), 'GetLastErrorCode must return empty string when no error code set');
+    end;
+
+    [Test]
+    procedure GetLastErrorCallStack_ReturnsText()
+    begin
+        // Call stack is empty in standalone runner — verify no crash
+        Assert.AreEqual('', Src.GetLastErrCallStack(), 'GetLastErrorCallStack must return empty string in runner');
+    end;
+
+    [Test]
+    procedure IsCollectingErrors_FalseByDefault()
+    begin
+        Assert.IsFalse(Src.IsCollecting(), 'IsCollectingErrors must be false outside a collect scope');
+    end;
+
+    [Test]
+    procedure HasCollectedErrors_FalseByDefault()
+    begin
+        Assert.IsFalse(Src.HasCollected(), 'HasCollectedErrors must be false when not collecting');
+    end;
+
+    [Test]
+    procedure GetCollectedErrors_EmptyByDefault()
+    var
+        Errors: List of [ErrorInfo];
+    begin
+        Src.ClearCollected();
+        Errors := Src.GetCollected();
+        Assert.AreEqual(0, Errors.Count(), 'GetCollectedErrors must return empty list when no errors collected');
+    end;
+
+    [Test]
+    procedure ClearCollectedErrors_DoesNotCrash()
+    begin
+        Src.ClearCollected();
+        Assert.IsFalse(Src.HasCollected(), 'HasCollectedErrors must be false after ClearCollectedErrors');
+    end;
+}


### PR DESCRIPTION
Closes #783

## Changes

- **`AlScope.LastErrorCode`** — new property (always `""` in standalone runner); gives `GetLastErrorCode()` its own distinct field separate from `LastErrorText`
- **RoslynRewriter fix** — `ALGetLastErrorCode` now maps to `AlScope.LastErrorCode` and `ALGetLastErrorCallStack` maps to `AlScope.LastErrorCallStack`; previously both incorrectly mapped to `LastErrorText`
- **`AlScope.GetCollectedErrors()`** — zero-arg overload matching what BC compiler emits; existing overload required `bool clearErrors` param
- **Per-test reset** — `LastErrorText` and `LastErrorCode` now reset between tests in `Program.cs` to prevent cross-test contamination

## Test suite

`tests/bucket-1/176-system-error-utils` — 9 tests:
- `GetLastErrorText_NoError_ReturnsEmpty` / `_AfterError_ReturnsMessage`
- `ClearLastError_ResetsText`
- `GetLastErrorCode_ReturnsText` (empty string)
- `GetLastErrorCallStack_ReturnsText` (empty string)
- `IsCollectingErrors_FalseByDefault`
- `HasCollectedErrors_FalseByDefault`
- `GetCollectedErrors_EmptyByDefault`
- `ClearCollectedErrors_DoesNotCrash`

Note: `GetLastErrorObject` remains a gap (not in scope for this PR).