### PR TITLE
test: JsonArray.Path + typed getter coverage notes (#790)

### DIFF
--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -3148,8 +3148,8 @@ JsonArray.GetArray:
 JsonArray.GetBigInteger:
   layer: runtime-api
   category: JsonArray
-  status: gap
-  notes: overloads=1
+  status: stub
+  notes: overloads=1. BC 21+ typed overload not present in AL 16.2. Indirectly reachable via Get + AsValue().AsBigInteger().
 
 JsonArray.GetBoolean:
   layer: runtime-api
@@ -3161,26 +3161,26 @@ JsonArray.GetBoolean:
 JsonArray.GetByte:
   layer: runtime-api
   category: JsonArray
-  status: gap
-  notes: overloads=1
+  status: stub
+  notes: overloads=1. BC 21+ typed overload not present in AL 16.2.
 
 JsonArray.GetChar:
   layer: runtime-api
   category: JsonArray
-  status: gap
-  notes: overloads=1
+  status: stub
+  notes: overloads=1. BC 21+ typed overload not present in AL 16.2.
 
 JsonArray.GetDate:
   layer: runtime-api
   category: JsonArray
-  status: gap
-  notes: overloads=1
+  status: stub
+  notes: overloads=1. BC 21+ typed overload not present in AL 16.2.
 
 JsonArray.GetDateTime:
   layer: runtime-api
   category: JsonArray
-  status: gap
-  notes: overloads=1
+  status: stub
+  notes: overloads=1. BC 21+ typed overload not present in AL 16.2.
 
 JsonArray.GetDecimal:
   layer: runtime-api
@@ -3192,8 +3192,8 @@ JsonArray.GetDecimal:
 JsonArray.GetDuration:
   layer: runtime-api
   category: JsonArray
-  status: gap
-  notes: overloads=1
+  status: stub
+  notes: overloads=1. BC 21+ typed overload not present in AL 16.2.
 
 JsonArray.GetInteger:
   layer: runtime-api
@@ -3212,8 +3212,8 @@ JsonArray.GetObject:
 JsonArray.GetOption:
   layer: runtime-api
   category: JsonArray
-  status: gap
-  notes: overloads=1
+  status: stub
+  notes: overloads=1. BC 21+ typed overload not present in AL 16.2.
 
 JsonArray.GetText:
   layer: runtime-api
@@ -3225,8 +3225,8 @@ JsonArray.GetText:
 JsonArray.GetTime:
   layer: runtime-api
   category: JsonArray
-  status: gap
-  notes: overloads=1
+  status: stub
+  notes: overloads=1. BC 21+ typed overload not present in AL 16.2.
 
 JsonArray.IndexOf:
   layer: runtime-api
@@ -3245,8 +3245,9 @@ JsonArray.Insert:
 JsonArray.Path:
   layer: runtime-api
   category: JsonArray
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-2/204-jsonarray-path
+  notes: overloads=1. Covered via NavJsonArray native — root returns "$", nested returns "$.key" (JSONPath notation).
 
 JsonArray.ReadFrom:
   layer: runtime-api

--- a/tests/bucket-2/204-jsonarray-path/al-runner.json
+++ b/tests/bucket-2/204-jsonarray-path/al-runner.json
@@ -1,0 +1,4 @@
+{
+  "sourcePath": "./src",
+  "testPath": "./test"
+}

--- a/tests/bucket-2/204-jsonarray-path/src/JsonArrayPathSrc.al
+++ b/tests/bucket-2/204-jsonarray-path/src/JsonArrayPathSrc.al
@@ -1,0 +1,63 @@
+/// Exercises JsonArray.Path, AsToken, Clone, WriteTo — methods not yet
+/// covered by earlier suites.
+codeunit 60320 "JAP Src"
+{
+    procedure PathOfRootArray(): Text
+    var
+        a: JsonArray;
+    begin
+        a.Add(1);
+        exit(a.Path);
+    end;
+
+    procedure PathOfNestedArray(): Text
+    var
+        obj: JsonObject;
+        a: JsonArray;
+        t: JsonToken;
+    begin
+        a.Add('x');
+        obj.Add('items', a);
+        obj.Get('items', t);
+        exit(t.Path);
+    end;
+
+    procedure CloneIsIndependent(): Boolean
+    var
+        orig: JsonArray;
+        cloned: JsonToken;
+        clonedArr: JsonArray;
+        t: JsonToken;
+    begin
+        orig.Add(42);
+        cloned := orig.Clone();
+        clonedArr := cloned.AsArray();
+        clonedArr.Add(99);
+        // orig should still have 1 element, cloned has 2.
+        exit((orig.Count() = 1) and (clonedArr.Count() = 2));
+    end;
+
+    procedure AsTokenRoundTrip(): Integer
+    var
+        a: JsonArray;
+        t: JsonToken;
+        back: JsonArray;
+    begin
+        a.Add(1);
+        a.Add(2);
+        t := a.AsToken();
+        back := t.AsArray();
+        exit(back.Count());
+    end;
+
+    procedure WriteToContainsValues(): Boolean
+    var
+        a: JsonArray;
+        outText: Text;
+    begin
+        a.Add(42);
+        a.Add('hello');
+        a.WriteTo(outText);
+        exit(outText.Contains('42') and outText.Contains('hello'));
+    end;
+}

--- a/tests/bucket-2/204-jsonarray-path/test/JsonArrayPathTest.al
+++ b/tests/bucket-2/204-jsonarray-path/test/JsonArrayPathTest.al
@@ -1,0 +1,45 @@
+codeunit 60321 "JAP Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "JAP Src";
+
+    [Test]
+    procedure Path_RootArray_IsDollar()
+    begin
+        // JSONPath notation: root-level container path is "$".
+        Assert.AreEqual('$', Src.PathOfRootArray(),
+            'JsonArray.Path at root must return "$" (JSONPath root)');
+    end;
+
+    [Test]
+    procedure Path_Nested_ContainsKey()
+    begin
+        // JSONPath notation: "$.items" for an array under key "items".
+        Assert.AreEqual('$.items', Src.PathOfNestedArray(),
+            'JsonArray.Path for a nested array must be "$.items"');
+    end;
+
+    [Test]
+    procedure Clone_IsIndependent()
+    begin
+        Assert.IsTrue(Src.CloneIsIndependent(),
+            'Clone must produce an independent copy — mutations must not propagate');
+    end;
+
+    [Test]
+    procedure AsToken_RoundTrip_PreservesCount()
+    begin
+        Assert.AreEqual(2, Src.AsTokenRoundTrip(),
+            'AsToken().AsArray().Count must equal the original count');
+    end;
+
+    [Test]
+    procedure WriteTo_ContainsValues()
+    begin
+        Assert.IsTrue(Src.WriteToContainsValues(),
+            'WriteTo must serialise the array values to text');
+    end;
+}


### PR DESCRIPTION
## Summary
- Closes #790
- `JsonArray.Path` works via NavJsonArray native (JSONPath notation: `$` for root, `$.key` for nested). Adds a 5-test suite also covering Clone independence, AsToken round-trip, and WriteTo serialisation.
- BC 21+ typed getters (`GetBigInteger`, `GetByte`, `GetChar`, `GetDate`, `GetDateTime`, `GetDuration`, `GetOption`, `GetTime`) are not present in AL 16.2. Coverage entries flipped gap → stub with a version-limitation note.

## Test plan
- [x] New suite — 5/5 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)