### PR TITLE
feat: System env stubs — WorkDate/WindowsLanguage + proving tests (#796)

### DIFF
--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -3120,26 +3120,33 @@ public void ClearApplicationMemberVariables()
                         SyntaxFactory.IdentifierName("ALIsNullGuid")));
             }
 
-            // ALSystemDate.ALWorkDate(null!) -> ALSystemDate.ALWorkDate(NavDate.Default)
-            // The rewriter turns this.Session -> null!, which makes ALWorkDate ambiguous between
-            // the NavSession and NavDate overloads. We disambiguate to the NavDate overload.
+            // ALSystemDate.ALWorkDate(...) -> MockLanguage.ALWorkDate / SetWorkDate
+            // The real BC method requires NavSession (null standalone).
+            // Getter (1-arg with null!) → MockLanguage.ALWorkDate
+            // Setter (2-arg: null!, NavDate) → MockLanguage.SetWorkDate(NavDate)
             if (exprText == "ALSystemDate" && methodName == "ALWorkDate")
             {
                 var args = visited.ArgumentList.Arguments;
                 if (args.Count == 1)
                 {
-                    var argText = args[0].Expression.ToString();
-                    // Match null!, default! or similar null patterns from Session rewriting
-                    if (argText.Contains("null"))
-                    {
-                        return SyntaxFactory.InvocationExpression(
-                            visited.Expression,
-                            SyntaxFactory.ArgumentList(
-                                SyntaxFactory.SingletonSeparatedList(
-                                    SyntaxFactory.Argument(
-                                        SyntaxFactory.DefaultExpression(
-                                            SyntaxFactory.ParseTypeName("NavDate"))))));
-                    }
+                    // Getter: ALWorkDate(null!) → MockLanguage.ALWorkDate
+                    return SyntaxFactory.MemberAccessExpression(
+                        SyntaxKind.SimpleMemberAccessExpression,
+                        SyntaxFactory.IdentifierName("MockLanguage"),
+                        SyntaxFactory.IdentifierName("ALWorkDate"))
+                        .WithTriviaFrom(visited);
+                }
+                if (args.Count == 2)
+                {
+                    // Setter: ALWorkDate(null!, d) → MockLanguage.SetWorkDate(d)
+                    return SyntaxFactory.InvocationExpression(
+                        SyntaxFactory.MemberAccessExpression(
+                            SyntaxKind.SimpleMemberAccessExpression,
+                            SyntaxFactory.IdentifierName("MockLanguage"),
+                            SyntaxFactory.IdentifierName("SetWorkDate")),
+                        SyntaxFactory.ArgumentList(
+                            SyntaxFactory.SingletonSeparatedList(args[1])))
+                        .WithTriviaFrom(visited);
                 }
             }
 
@@ -3801,12 +3808,12 @@ public void ClearApplicationMemberVariables()
         // MockLanguage.ALGlobalLanguage which is a plain static property backed by an int field.
         if (visited.Expression is IdentifierNameSyntax langId &&
             langId.Identifier.Text == "ALSystemLanguage" &&
-            memberName == "ALGlobalLanguage")
+            (memberName == "ALGlobalLanguage" || memberName == "ALWindowsLanguage"))
         {
             return SyntaxFactory.MemberAccessExpression(
                 SyntaxKind.SimpleMemberAccessExpression,
                 SyntaxFactory.IdentifierName("MockLanguage"),
-                SyntaxFactory.IdentifierName("ALGlobalLanguage"))
+                SyntaxFactory.IdentifierName(memberName == "ALGlobalLanguage" ? "ALGlobalLanguage" : "ALWindowsLanguage"))
                 .WithTriviaFrom(visited);
         }
 

--- a/AlRunner/Runtime/MockLanguage.cs
+++ b/AlRunner/Runtime/MockLanguage.cs
@@ -21,11 +21,41 @@ public static class MockLanguage
     }
 
     /// <summary>
+    /// Replaces ALSystemLanguage.ALWindowsLanguage (get).
+    /// Returns the same LCID as GlobalLanguage — standalone has a single language context.
+    /// </summary>
+    public static int ALWindowsLanguage => _globalLanguage;
+
+    private static Microsoft.Dynamics.Nav.Runtime.NavDate? _workDate;
+
+    /// <summary>
+    /// Replaces ALSystemDate.ALWorkDate — get (0 args) and set (1 NavDate arg).
+    /// Default is Today(); setter overrides.
+    /// </summary>
+    public static Microsoft.Dynamics.Nav.Runtime.NavDate ALWorkDate
+    {
+        get
+        {
+            if (_workDate != null) return _workDate;
+            var now = System.DateTime.Today;
+            return AlCompat.DMY2Date(now.Day, now.Month, now.Year);
+        }
+        set => _workDate = value;
+    }
+
+    /// <summary>ALWorkDate setter that takes NavDate parameter (matches the BC 1-arg form).</summary>
+    public static void SetWorkDate(Microsoft.Dynamics.Nav.Runtime.NavDate d)
+    {
+        _workDate = d;
+    }
+
+    /// <summary>
     /// Resets the language back to the ENU default between tests.
     /// Called by Executor.ResetAll() between test runs.
     /// </summary>
     public static void Reset()
     {
         _globalLanguage = 1033;
+        _workDate = default;
     }
 }

--- a/tests/bucket-2/205-system-env/al-runner.json
+++ b/tests/bucket-2/205-system-env/al-runner.json
@@ -1,0 +1,4 @@
+{
+  "sourcePath": "./src",
+  "testPath": "./test"
+}

--- a/tests/bucket-2/205-system-env/src/SystemEnvSrc.al
+++ b/tests/bucket-2/205-system-env/src/SystemEnvSrc.al
@@ -1,0 +1,43 @@
+/// Exercises System environment/session stubs: GuiAllowed, WorkDate,
+/// GlobalLanguage, WindowsLanguage, RoundDateTime, IsNull.
+codeunit 60330 "SEV Src"
+{
+    procedure IsGui(): Boolean
+    begin
+        exit(GuiAllowed());
+    end;
+
+    procedure GetWorkDate(): Date
+    begin
+        exit(WorkDate());
+    end;
+
+    procedure SetAndGetWorkDate(d: Date): Date
+    begin
+        WorkDate(d);
+        exit(WorkDate());
+    end;
+
+    procedure GetGlobalLang(): Integer
+    begin
+        exit(GlobalLanguage());
+    end;
+
+    procedure GetWindowsLang(): Integer
+    begin
+        exit(WindowsLanguage());
+    end;
+
+    procedure RoundDateTimePrecision(dt: DateTime; precision: BigInteger): DateTime
+    begin
+        exit(RoundDateTime(dt, precision));
+    end;
+
+    procedure IsNullCheck(): Boolean
+    var
+        v: Variant;
+    begin
+        // Default Variant is null-ish.
+        exit(IsNull(v));
+    end;
+}

--- a/tests/bucket-2/205-system-env/test/SystemEnvTest.al
+++ b/tests/bucket-2/205-system-env/test/SystemEnvTest.al
@@ -1,0 +1,54 @@
+codeunit 60331 "SEV Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "SEV Src";
+
+    [Test]
+    procedure GuiAllowed_ReturnsFalse()
+    begin
+        // Standalone contract: no GUI, so GuiAllowed is false.
+        Assert.IsFalse(Src.IsGui(),
+            'GuiAllowed must return false in standalone mode');
+    end;
+
+    [Test]
+    procedure WorkDate_ReturnsNonZero()
+    begin
+        // WorkDate defaults to Today() which is non-zero.
+        Assert.AreNotEqual(0D, Src.GetWorkDate(),
+            'WorkDate must return a non-zero date');
+    end;
+
+    [Test]
+    procedure WorkDate_SetAndGet_RoundTrips()
+    begin
+        Assert.AreEqual(DMY2Date(1, 1, 2025), Src.SetAndGetWorkDate(DMY2Date(1, 1, 2025)),
+            'WorkDate setter + getter must round-trip');
+    end;
+
+    [Test]
+    procedure GlobalLanguage_ReturnsPositive()
+    begin
+        // Should return a Windows LCID (e.g. 1033 for en-US).
+        Assert.IsTrue(Src.GetGlobalLang() > 0,
+            'GlobalLanguage must return a positive LCID');
+    end;
+
+    [Test]
+    procedure WindowsLanguage_ReturnsPositive()
+    begin
+        Assert.IsTrue(Src.GetWindowsLang() > 0,
+            'WindowsLanguage must return a positive LCID');
+    end;
+
+    [Test]
+    procedure RoundDateTime_DoesNotThrow()
+    begin
+        // Just verify it completes — the detailed rounding is tested elsewhere.
+        Src.RoundDateTimePrecision(CurrentDateTime(), 1000);
+        Assert.IsTrue(true, 'RoundDateTime must not throw');
+    end;
+}


### PR DESCRIPTION
## Summary
- Closes #796 (partial — WorkDate, WindowsLanguage, GuiAllowed, GlobalLanguage, RoundDateTime covered)
- `WorkDate`: ALSystemDate.ALWorkDate requires NavSession (null standalone). Rewriter now redirects to `MockLanguage.ALWorkDate` (getter: Today(); setter: stores value).
- `WindowsLanguage`: ALSystemLanguage.ALWindowsLanguage crashes standalone. Rewriter redirects to MockLanguage.ALWindowsLanguage (same LCID as GlobalLanguage).
- Also proves GuiAllowed (false), GlobalLanguage (positive), RoundDateTime (doesn't throw) which already worked.
- New suite `tests/bucket-2/205-system-env` — 6 tests.

## Test plan
- [x] New suite — 6/6 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)