### PR TITLE
feat: System session/env stubs — GuiAllowed, IsServiceTier, WorkDate, GlobalLanguage, WindowsLanguage, ApplicationPath, TemporaryPath, RoundDateTime, IsNull, Hyperlink

### DIFF
--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -2242,6 +2242,7 @@ public static class Executor
             AlRunner.Runtime.AlScope.ResetLastStatement();
             AlRunner.Runtime.AlScope.LastErrorText = "";
             AlRunner.Runtime.AlScope.LastErrorCode = "";
+            AlRunner.Runtime.AlScope.SetWorkDate(Microsoft.Dynamics.Nav.Runtime.NavDate.Default);
             AlRunner.Runtime.AlScope.ResetCollectedErrors();
             AlRunner.Runtime.HandlerRegistry.Reset();
             AlRunner.Runtime.MockSession.Reset();

--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -3120,26 +3120,35 @@ public void ClearApplicationMemberVariables()
                         SyntaxFactory.IdentifierName("ALIsNullGuid")));
             }
 
-            // ALSystemDate.ALWorkDate(null!) -> ALSystemDate.ALWorkDate(NavDate.Default)
-            // The rewriter turns this.Session -> null!, which makes ALWorkDate ambiguous between
-            // the NavSession and NavDate overloads. We disambiguate to the NavDate overload.
+            // ALSystemDate.ALWorkDate(session)        → AlScope.GetWorkDate()
+            // ALSystemDate.ALWorkDate(session, date)   → AlScope.SetWorkDate(date)
+            // ALWorkDate requires NavSession which is null in standalone mode.
+            // Route both forms through AlScope which holds an in-memory work date.
             if (exprText == "ALSystemDate" && methodName == "ALWorkDate")
             {
                 var args = visited.ArgumentList.Arguments;
                 if (args.Count == 1)
                 {
-                    var argText = args[0].Expression.ToString();
-                    // Match null!, default! or similar null patterns from Session rewriting
-                    if (argText.Contains("null"))
-                    {
-                        return SyntaxFactory.InvocationExpression(
-                            visited.Expression,
-                            SyntaxFactory.ArgumentList(
-                                SyntaxFactory.SingletonSeparatedList(
-                                    SyntaxFactory.Argument(
-                                        SyntaxFactory.DefaultExpression(
-                                            SyntaxFactory.ParseTypeName("NavDate"))))));
-                    }
+                    // Getter form: ALWorkDate(session) → AlScope.GetWorkDate()
+                    return SyntaxFactory.InvocationExpression(
+                        SyntaxFactory.MemberAccessExpression(
+                            SyntaxKind.SimpleMemberAccessExpression,
+                            SyntaxFactory.IdentifierName("AlScope"),
+                            SyntaxFactory.IdentifierName("GetWorkDate")),
+                        SyntaxFactory.ArgumentList())
+                        .WithTriviaFrom(visited);
+                }
+                if (args.Count == 2)
+                {
+                    // Setter form: ALWorkDate(session, date) → AlScope.SetWorkDate(date)
+                    return SyntaxFactory.InvocationExpression(
+                        SyntaxFactory.MemberAccessExpression(
+                            SyntaxKind.SimpleMemberAccessExpression,
+                            SyntaxFactory.IdentifierName("AlScope"),
+                            SyntaxFactory.IdentifierName("SetWorkDate")),
+                        SyntaxFactory.ArgumentList(
+                            SyntaxFactory.SingletonSeparatedList(args[1])))
+                        .WithTriviaFrom(visited);
                 }
             }
 
@@ -3796,17 +3805,18 @@ public void ClearApplicationMemberVariables()
         }
 
         // Pattern: ALSystemLanguage.ALGlobalLanguage -> MockLanguage.ALGlobalLanguage
-        // ALSystemLanguage.get_ALGlobalLanguage / set_ALGlobalLanguage crash because there
-        // is no live BC session context in standalone mode. Redirect both get and set to
-        // MockLanguage.ALGlobalLanguage which is a plain static property backed by an int field.
+        // ALSystemLanguage.ALGlobalLanguage / ALWindowsLanguage crash because there
+        // is no live BC session context in standalone mode.
+        // ALGlobalLanguage: redirect to MockLanguage.ALGlobalLanguage (get/set in-memory).
+        // ALWindowsLanguage: redirect to MockLanguage.ALWindowsLanguage (current-culture LCID).
         if (visited.Expression is IdentifierNameSyntax langId &&
             langId.Identifier.Text == "ALSystemLanguage" &&
-            memberName == "ALGlobalLanguage")
+            (memberName == "ALGlobalLanguage" || memberName == "ALWindowsLanguage"))
         {
             return SyntaxFactory.MemberAccessExpression(
                 SyntaxKind.SimpleMemberAccessExpression,
                 SyntaxFactory.IdentifierName("MockLanguage"),
-                SyntaxFactory.IdentifierName("ALGlobalLanguage"))
+                SyntaxFactory.IdentifierName(memberName))
                 .WithTriviaFrom(visited);
         }
 
@@ -3823,6 +3833,31 @@ public void ClearApplicationMemberVariables()
                 SyntaxFactory.ArgumentList(
                     SyntaxFactory.SingletonSeparatedList(
                         SyntaxFactory.Argument(visited.Expression))));
+        }
+
+        // Pattern: NavEnvironment.IsServiceTier → false
+        // NavEnvironment.IsServiceTier returns true when a BC service tier is present.
+        // In standalone runner there is no service tier, so we always return false.
+        if (visited.Expression is IdentifierNameSyntax envId &&
+            envId.Identifier.Text == "NavEnvironment" &&
+            memberName == "IsServiceTier")
+        {
+            return SyntaxFactory.LiteralExpression(SyntaxKind.FalseLiteralExpression)
+                .WithTriviaFrom(visited);
+        }
+
+        // Pattern: AlCompat.NavIndirectValueToNavValue<NavDotNet>(x).IsNull → false
+        // BC emits this for Variant.IsNull checks. NavDotNet cast fails when the variant holds
+        // a non-DotNet value (Text, Integer, etc.). In standalone mode we never have real
+        // .NET Automation objects, so IsNull is always false for any non-null variant.
+        if (memberName == "IsNull" &&
+            visited.Expression is InvocationExpressionSyntax isNullInvocation &&
+            isNullInvocation.Expression is MemberAccessExpressionSyntax isNullMa &&
+            isNullMa.Name is GenericNameSyntax isNullGeneric &&
+            isNullGeneric.Identifier.Text == "NavIndirectValueToNavValue")
+        {
+            return SyntaxFactory.LiteralExpression(SyntaxKind.FalseLiteralExpression)
+                .WithTriviaFrom(visited);
         }
 
         return visited;

--- a/AlRunner/Runtime/AlScope.cs
+++ b/AlRunner/Runtime/AlScope.cs
@@ -149,6 +149,18 @@ public class AlScope : IDisposable, ITreeObject
     /// </summary>
     public static string LastErrorText { get; set; } = "";
 
+    // ── WorkDate ─────────────────────────────────────────────────────────────
+    // AL WorkDate() returns the session's "working date". In standalone mode,
+    // defaults to NavDate.Default (0D) which tests can override per-test via WorkDate(D).
+
+    private static NavDate _workDate = NavDate.Default;
+
+    /// <summary>WorkDate getter — returns the configured work date.</summary>
+    public static NavDate GetWorkDate() => _workDate;
+
+    /// <summary>WorkDate setter — stores the date for use within this test.</summary>
+    public static void SetWorkDate(NavDate date) => _workDate = date;
+
     /// <summary>
     /// Stores the last error code. Always empty in standalone runner (BC error codes
     /// require structured ErrorInfo which is beyond runner scope).

--- a/AlRunner/Runtime/MockLanguage.cs
+++ b/AlRunner/Runtime/MockLanguage.cs
@@ -21,6 +21,14 @@ public static class MockLanguage
     }
 
     /// <summary>
+    /// Replaces ALSystemLanguage.ALWindowsLanguage.
+    /// Returns the current process culture LCID, matching the host OS setting.
+    /// ALSystemLanguage.get_ALWindowsLanguage requires NavSession and crashes in standalone mode.
+    /// </summary>
+    public static int ALWindowsLanguage
+        => System.Globalization.CultureInfo.CurrentCulture.LCID;
+
+    /// <summary>
     /// Resets the language back to the ENU default between tests.
     /// Called by Executor.ResetAll() between test runs.
     /// </summary>

--- a/AlRunner/Runtime/MockSystemOperatingSystem.cs
+++ b/AlRunner/Runtime/MockSystemOperatingSystem.cs
@@ -24,6 +24,19 @@ public static class MockSystemOperatingSystem
     }
 
     /// <summary>
+    /// ALApplicationPath — AL: ApplicationPath() — returns the application's base directory.
+    /// In standalone mode, returns the runner's own base directory.
+    /// </summary>
+    public static string ALApplicationPath
+        => System.AppContext.BaseDirectory;
+
+    /// <summary>
+    /// ALTemporaryPath — AL: TemporaryPath() — returns the OS temp directory.
+    /// </summary>
+    public static string ALTemporaryPath
+        => System.IO.Path.GetTempPath();
+
+    /// <summary>
     /// ALGuiAllowed — AL: GuiAllowed() — returns whether a GUI client is available.
     /// In standalone mode there is no client surface, so this always returns false.
     /// </summary>

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -5738,8 +5738,9 @@ System.Abs:
 System.ApplicationPath:
   layer: runtime-api
   category: System
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-1/178-system-env-stubs
+  notes: overloads=1; MockSystemOperatingSystem.ALApplicationPath → AppContext.BaseDirectory
 
 System.ArrayLen:
   layer: runtime-api
@@ -6015,14 +6016,16 @@ System.GetUrl:
 System.GlobalLanguage:
   layer: runtime-api
   category: System
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-1/178-system-env-stubs
+  notes: overloads=2 (get/set); MockLanguage.ALGlobalLanguage in-memory store; default 1033 (ENU); reset between tests
 
 System.GuiAllowed:
   layer: runtime-api
   category: System
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-1/178-system-env-stubs
+  notes: overloads=1; MockSystemOperatingSystem.ALGuiAllowed always returns false standalone
 
 System.HasCollectedErrors:
   layer: runtime-api
@@ -6033,8 +6036,9 @@ System.HasCollectedErrors:
 System.Hyperlink:
   layer: runtime-api
   category: System
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-1/178-system-env-stubs
+  notes: overloads=1; MockSystemOperatingSystem.ALHyperlink is a no-op in standalone mode
 
 System.ImportEncryptionKey:
   layer: runtime-api
@@ -6063,8 +6067,9 @@ System.IsCollectingErrors:
 System.IsNull:
   layer: runtime-api
   category: System
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-1/178-system-env-stubs
+  notes: overloads=1; RoslynRewriter intercepts NavIndirectValueToNavValue<NavDotNet>(...).IsNull → false; no real DotNet objects in standalone mode
 
 System.IsNullGuid:
   layer: runtime-api
@@ -6076,8 +6081,9 @@ System.IsNullGuid:
 System.IsServiceTier:
   layer: runtime-api
   category: System
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-1/178-system-env-stubs
+  notes: overloads=1; RoslynRewriter intercepts NavEnvironment.IsServiceTier → false; no service tier in standalone mode
 
 System.NormalDate:
   layer: runtime-api
@@ -6114,8 +6120,9 @@ System.Round:
 System.RoundDateTime:
   layer: runtime-api
   category: System
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-1/178-system-env-stubs
+  notes: overloads=1; AlCompat.RoundDateTime via BC native ALSystemDate.ALRoundDateTime; rounds to nearest interval boundary
 
 System.Sleep:
   layer: runtime-api
@@ -6126,8 +6133,9 @@ System.Sleep:
 System.TemporaryPath:
   layer: runtime-api
   category: System
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-1/178-system-env-stubs
+  notes: overloads=1; MockSystemOperatingSystem.ALTemporaryPath → Path.GetTempPath()
 
 System.Time:
   layer: runtime-api
@@ -6156,14 +6164,16 @@ System.Variant2Time:
 System.WindowsLanguage:
   layer: runtime-api
   category: System
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-1/178-system-env-stubs
+  notes: overloads=1; MockLanguage.ALWindowsLanguage → CultureInfo.CurrentCulture.LCID
 
 System.WorkDate:
   layer: runtime-api
   category: System
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-1/178-system-env-stubs
+  notes: overloads=2 (get/set); AlScope.GetWorkDate/SetWorkDate in-memory store; reset to NavDate.Default between tests
 
 # ── Table ───────────────────────────────────────────────────────
 

--- a/tests/bucket-1/178-system-env-stubs/src/SystemEnvSrc.al
+++ b/tests/bucket-1/178-system-env-stubs/src/SystemEnvSrc.al
@@ -1,0 +1,62 @@
+codeunit 105000 "SEVS Src"
+{
+    procedure GetApplicationPath(): Text
+    begin
+        exit(ApplicationPath());
+    end;
+
+    procedure GetTemporaryPath(): Text
+    begin
+        exit(TemporaryPath());
+    end;
+
+    procedure IsGui(): Boolean
+    begin
+        exit(GuiAllowed());
+    end;
+
+    procedure IsSvcTier(): Boolean
+    begin
+        exit(IsServiceTier());
+    end;
+
+    procedure GetWorkDate(): Date
+    begin
+        exit(WorkDate());
+    end;
+
+    procedure SetWorkDate(D: Date)
+    begin
+        WorkDate(D);
+    end;
+
+    procedure GetGlobalLang(): Integer
+    begin
+        exit(GlobalLanguage());
+    end;
+
+    procedure SetGlobalLang(LCID: Integer)
+    begin
+        GlobalLanguage(LCID);
+    end;
+
+    procedure GetWindowsLang(): Integer
+    begin
+        exit(WindowsLanguage());
+    end;
+
+    procedure RoundDT(DT: DateTime; Precision: Duration): DateTime
+    begin
+        exit(RoundDateTime(DT, Precision));
+    end;
+
+    procedure NullCheck(V: Variant): Boolean
+    begin
+        exit(IsNull(V));
+    end;
+
+    procedure OpenHyperlink(Url: Text)
+    begin
+        Hyperlink(Url);
+    end;
+}

--- a/tests/bucket-1/178-system-env-stubs/test/SystemEnvTest.al
+++ b/tests/bucket-1/178-system-env-stubs/test/SystemEnvTest.al
@@ -1,0 +1,86 @@
+codeunit 105001 "SEVS Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "SEVS Src";
+
+    [Test]
+    procedure GuiAllowed_FalseInRunner()
+    begin
+        Assert.IsFalse(Src.IsGui(), 'GuiAllowed must be false in standalone runner');
+    end;
+
+    [Test]
+    procedure IsServiceTier_FalseInRunner()
+    begin
+        Assert.IsFalse(Src.IsSvcTier(), 'IsServiceTier must be false in standalone runner');
+    end;
+
+    [Test]
+    procedure ApplicationPath_NotEmpty()
+    begin
+        Assert.AreNotEqual('', Src.GetApplicationPath(), 'ApplicationPath must return a non-empty path');
+    end;
+
+    [Test]
+    procedure TemporaryPath_NotEmpty()
+    begin
+        Assert.AreNotEqual('', Src.GetTemporaryPath(), 'TemporaryPath must return a non-empty path');
+    end;
+
+    [Test]
+    procedure WorkDate_GetSet_RoundTrips()
+    begin
+        Src.SetWorkDate(20260417D);
+        Assert.AreEqual(20260417D, Src.GetWorkDate(), 'WorkDate get/set must round-trip');
+    end;
+
+    [Test]
+    procedure GlobalLanguage_DefaultNonZero()
+    begin
+        Assert.AreNotEqual(0, Src.GetGlobalLang(), 'GlobalLanguage must return non-zero LCID');
+    end;
+
+    [Test]
+    procedure GlobalLanguage_SetAndGet()
+    begin
+        Src.SetGlobalLang(2052); // Chinese Simplified
+        Assert.AreEqual(2052, Src.GetGlobalLang(), 'GlobalLanguage must return the value that was set');
+    end;
+
+    [Test]
+    procedure WindowsLanguage_NonZero()
+    begin
+        Assert.AreNotEqual(0, Src.GetWindowsLang(), 'WindowsLanguage must return non-zero LCID');
+    end;
+
+    [Test]
+    procedure RoundDateTime_ToHour_RoundsToNearestHour()
+    var
+        DT: DateTime;
+        Rounded: DateTime;
+    begin
+        // 08:10 is 10 minutes into hour — nearest hour boundary is 08:00 (10 min away vs 50 min to 09:00)
+        DT := CreateDateTime(20260417D, 081000T);
+        Rounded := Src.RoundDT(DT, 3600000); // 1h in ms
+        Assert.AreEqual(CreateDateTime(20260417D, 080000T), Rounded, 'RoundDateTime(08:10, 1h) must round to 08:00');
+    end;
+
+    [Test]
+    procedure IsNull_FalseForText()
+    var
+        V: Variant;
+    begin
+        V := 'hello';
+        Assert.IsFalse(Src.NullCheck(V), 'IsNull must return false for a non-null text variant');
+    end;
+
+    [Test]
+    procedure Hyperlink_NoThrow()
+    begin
+        // no-op in runner — must not throw
+        Src.OpenHyperlink('https://example.com');
+    end;
+}


### PR DESCRIPTION
Closes #796

## Summary

- **MockSystemOperatingSystem**: `ALApplicationPath` → `AppContext.BaseDirectory`, `ALTemporaryPath` → `Path.GetTempPath()`
- **MockLanguage**: `ALWindowsLanguage` → `CultureInfo.CurrentCulture.LCID`
- **AlScope**: `GetWorkDate`/`SetWorkDate` in-memory store; `NavDate.Default` reset between tests
- **RoslynRewriter**: `NavEnvironment.IsServiceTier` → `false`; `NavIndirectValueToNavValue<NavDotNet>(...).IsNull` → `false`; `ALSystemLanguage.ALWindowsLanguage` → `MockLanguage.ALWindowsLanguage`
- **Test suite** `178-system-env-stubs`: 11 proving tests covering all 10 functions
- **docs/coverage.yaml**: all 10 functions marked `covered`

## Functions covered

| AL built-in | Status |
|---|---|
| `GuiAllowed` | always `false` standalone |
| `IsServiceTier` | always `false` standalone |
| `ApplicationPath` | `AppContext.BaseDirectory` |
| `TemporaryPath` | `Path.GetTempPath()` |
| `WorkDate` (get/set) | in-memory `AlScope` store |
| `GlobalLanguage` (get/set) | `MockLanguage` in-memory store |
| `WindowsLanguage` | `CultureInfo.CurrentCulture.LCID` |
| `RoundDateTime` | BC native `ALSystemDate.ALRoundDateTime` |
| `IsNull` | always `false` (no real .NET objects in standalone) |
| `Hyperlink` | no-op (no UI in standalone) |