### PR TITLE
test: XmlNode — IsXml*, AsXml*, WriteTo, SelectNodes, SelectSingleNode, Remove, ReplaceWith, GetParent, GetDocument, AddAfterSelf, AddBeforeSelf

### DIFF
--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -9570,164 +9570,189 @@ XmlNamespaceManager.RemoveNamespace:
 XmlNode.AddAfterSelf:
   layer: runtime-api
   category: XmlNode
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-1/179-xmlnode-methods
+  notes: overloads=1; BC native NavXmlNode.ALAddAfterSelf works standalone
 
 XmlNode.AddBeforeSelf:
   layer: runtime-api
   category: XmlNode
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-1/179-xmlnode-methods
+  notes: overloads=1; BC native NavXmlNode.ALAddBeforeSelf works standalone
 
 XmlNode.AsXmlAttribute:
   layer: runtime-api
   category: XmlNode
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-1/179-xmlnode-methods
+  notes: overloads=1; BC native NavXmlNode.ALAsXmlAttribute works standalone; errors on type mismatch
 
 XmlNode.AsXmlCData:
   layer: runtime-api
   category: XmlNode
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-1/179-xmlnode-methods
+  notes: overloads=1; BC native NavXmlNode.ALAsXmlCData works standalone
 
 XmlNode.AsXmlComment:
   layer: runtime-api
   category: XmlNode
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-1/179-xmlnode-methods
+  notes: overloads=1; BC native NavXmlNode.ALAsXmlComment works standalone
 
 XmlNode.AsXmlDeclaration:
   layer: runtime-api
   category: XmlNode
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-1/179-xmlnode-methods
+  notes: overloads=1; BC native NavXmlNode.ALAsXmlDeclaration works standalone
 
 XmlNode.AsXmlDocument:
   layer: runtime-api
   category: XmlNode
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-1/179-xmlnode-methods
+  notes: overloads=1; BC native NavXmlNode.ALAsXmlDocument works standalone; IsXmlDocument verified
 
 XmlNode.AsXmlDocumentType:
   layer: runtime-api
   category: XmlNode
   status: gap
-  notes: overloads=1
+  notes: overloads=1; not tested (XmlDocumentType.AsXmlNode not yet exercised in suite)
 
 XmlNode.AsXmlElement:
   layer: runtime-api
   category: XmlNode
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-1/179-xmlnode-methods
+  notes: overloads=1; BC native NavXmlNode.ALAsXmlElement works standalone; errors on type mismatch
 
 XmlNode.AsXmlProcessingInstruction:
   layer: runtime-api
   category: XmlNode
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-1/179-xmlnode-methods
+  notes: overloads=1; BC native NavXmlNode.ALAsXmlProcessingInstruction works standalone
 
 XmlNode.AsXmlText:
   layer: runtime-api
   category: XmlNode
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-1/179-xmlnode-methods
+  notes: overloads=1; BC native NavXmlNode.ALAsXmlText works standalone
 
 XmlNode.GetDocument:
   layer: runtime-api
   category: XmlNode
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-1/179-xmlnode-methods
+  notes: overloads=1; BC native NavXmlNode.ALGetDocument works standalone; true when in doc, false for orphan
 
 XmlNode.GetParent:
   layer: runtime-api
   category: XmlNode
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-1/179-xmlnode-methods
+  notes: overloads=1; BC native NavXmlNode.ALGetParent works standalone; true when parented, false for orphan
 
 XmlNode.IsXmlAttribute:
   layer: runtime-api
   category: XmlNode
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-1/179-xmlnode-methods
+  notes: overloads=1; BC native NavXmlNode.ALIsXmlAttribute works standalone
 
 XmlNode.IsXmlCData:
   layer: runtime-api
   category: XmlNode
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-1/179-xmlnode-methods
+  notes: overloads=1; BC native NavXmlNode.ALIsXmlCData works standalone
 
 XmlNode.IsXmlComment:
   layer: runtime-api
   category: XmlNode
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-1/179-xmlnode-methods
+  notes: overloads=1; BC native NavXmlNode.ALIsXmlComment works standalone
 
 XmlNode.IsXmlDeclaration:
   layer: runtime-api
   category: XmlNode
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-1/179-xmlnode-methods
+  notes: overloads=1; BC native NavXmlNode.ALIsXmlDeclaration works standalone
 
 XmlNode.IsXmlDocument:
   layer: runtime-api
   category: XmlNode
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-1/179-xmlnode-methods
+  notes: overloads=1; BC native NavXmlNode.ALIsXmlDocument works standalone
 
 XmlNode.IsXmlDocumentType:
   layer: runtime-api
   category: XmlNode
   status: gap
-  notes: overloads=1
+  notes: overloads=1; not tested (XmlDocumentType.AsXmlNode not yet exercised in suite)
 
 XmlNode.IsXmlElement:
   layer: runtime-api
   category: XmlNode
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-1/179-xmlnode-methods
+  notes: overloads=1; BC native NavXmlNode.ALIsXmlElement works standalone
 
 XmlNode.IsXmlProcessingInstruction:
   layer: runtime-api
   category: XmlNode
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-1/179-xmlnode-methods
+  notes: overloads=1; BC native NavXmlNode.ALIsXmlProcessingInstruction works standalone
 
 XmlNode.IsXmlText:
   layer: runtime-api
   category: XmlNode
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-1/179-xmlnode-methods
+  notes: overloads=1; BC native NavXmlNode.ALIsXmlText works standalone
 
 XmlNode.Remove:
   layer: runtime-api
   category: XmlNode
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-1/179-xmlnode-methods
+  notes: overloads=1; BC native NavXmlNode.ALRemove works standalone; detaches from parent
 
 XmlNode.ReplaceWith:
   layer: runtime-api
   category: XmlNode
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-1/179-xmlnode-methods
+  notes: overloads=1; BC native NavXmlNode.ALReplaceWith works standalone; substitutes node in parent
 
 XmlNode.SelectNodes:
   layer: runtime-api
   category: XmlNode
-  status: gap
-  notes: overloads=2
+  status: covered
+  tests: tests/bucket-1/179-xmlnode-methods
+  notes: overloads=2; BC native NavXmlNode.ALSelectNodes works standalone via XPath on programmatic trees
 
 XmlNode.SelectSingleNode:
   layer: runtime-api
   category: XmlNode
-  status: gap
-  notes: overloads=2
+  status: covered
+  tests: tests/bucket-1/179-xmlnode-methods
+  notes: overloads=2; BC native NavXmlNode.ALSelectSingleNode works standalone via XPath on programmatic trees
 
 XmlNode.WriteTo:
   layer: runtime-api
   category: XmlNode
-  status: gap
-  notes: overloads=4
+  status: covered
+  tests: tests/bucket-1/179-xmlnode-methods
+  notes: overloads=4; BC native NavXmlNode.ALWriteTo works standalone; elements and attributes serialized correctly
 
 # ── XmlNodeList ─────────────────────────────────────────────────
 

--- a/tests/bucket-1/179-xmlnode-methods/src/XmlNodeSrc.al
+++ b/tests/bucket-1/179-xmlnode-methods/src/XmlNodeSrc.al
@@ -1,0 +1,215 @@
+/// Helper codeunit exercising XmlNode type-checking, casting, and navigation methods.
+codeunit 106000 "XNN Src"
+{
+    // ── Type checks ─────────────────────────────────────────────────────────────
+
+    procedure IsElement(Node: XmlNode): Boolean
+    begin
+        exit(Node.IsXmlElement());
+    end;
+
+    procedure IsAttribute(Node: XmlNode): Boolean
+    begin
+        exit(Node.IsXmlAttribute());
+    end;
+
+    procedure IsText(Node: XmlNode): Boolean
+    begin
+        exit(Node.IsXmlText());
+    end;
+
+    procedure IsCData(Node: XmlNode): Boolean
+    begin
+        exit(Node.IsXmlCData());
+    end;
+
+    procedure IsComment(Node: XmlNode): Boolean
+    begin
+        exit(Node.IsXmlComment());
+    end;
+
+    procedure IsDeclaration(Node: XmlNode): Boolean
+    begin
+        exit(Node.IsXmlDeclaration());
+    end;
+
+    procedure IsDocument(Node: XmlNode): Boolean
+    begin
+        exit(Node.IsXmlDocument());
+    end;
+
+    procedure IsProcessingInstruction(Node: XmlNode): Boolean
+    begin
+        exit(Node.IsXmlProcessingInstruction());
+    end;
+
+    // ── Type casts ──────────────────────────────────────────────────────────────
+
+    procedure AsElementName(Node: XmlNode): Text
+    var
+        Elem: XmlElement;
+    begin
+        Elem := Node.AsXmlElement();
+        exit(Elem.Name);
+    end;
+
+    procedure AsAttributeName(Node: XmlNode): Text
+    var
+        Attr: XmlAttribute;
+    begin
+        Attr := Node.AsXmlAttribute();
+        exit(Attr.Name);
+    end;
+
+    procedure AsTextValue(Node: XmlNode): Text
+    var
+        Txt: XmlText;
+    begin
+        Txt := Node.AsXmlText();
+        exit(Txt.Value);
+    end;
+
+    procedure AsCDataValue(Node: XmlNode): Text
+    var
+        CData: XmlCData;
+    begin
+        CData := Node.AsXmlCData();
+        exit(CData.Value);
+    end;
+
+    procedure AsCommentValue(Node: XmlNode): Text
+    var
+        Comment: XmlComment;
+    begin
+        Comment := Node.AsXmlComment();
+        exit(Comment.Value);
+    end;
+
+    procedure AsDeclarationVersion(Node: XmlNode): Text
+    var
+        Decl: XmlDeclaration;
+    begin
+        Decl := Node.AsXmlDeclaration();
+        exit(Decl.Version);
+    end;
+
+    procedure AsProcessingInstructionTarget(Node: XmlNode): Text
+    var
+        PI: XmlProcessingInstruction;
+        Result: Text;
+    begin
+        PI := Node.AsXmlProcessingInstruction();
+        PI.GetTarget(Result);
+        exit(Result);
+    end;
+
+    procedure AsElementWrongType(Node: XmlNode): XmlElement
+    var
+        Elem: XmlElement;
+    begin
+        // Must throw an error when the node is not an element
+        Elem := Node.AsXmlElement();
+        exit(Elem);
+    end;
+
+    // ── WriteTo ─────────────────────────────────────────────────────────────────
+
+    procedure WriteNodeToText(Node: XmlNode): Text
+    var
+        Result: Text;
+    begin
+        Node.WriteTo(Result);
+        exit(Result);
+    end;
+
+    // ── GetParent ───────────────────────────────────────────────────────────────
+
+    procedure NodeGetParent(Node: XmlNode; var Parent: XmlElement): Boolean
+    begin
+        exit(Node.GetParent(Parent));
+    end;
+
+    // ── GetDocument ─────────────────────────────────────────────────────────────
+
+    procedure NodeGetDocument(Node: XmlNode; var Doc: XmlDocument): Boolean
+    begin
+        exit(Node.GetDocument(Doc));
+    end;
+
+    // ── SelectNodes ─────────────────────────────────────────────────────────────
+
+    procedure NodeSelectNodesCount(Root: XmlElement; XPath: Text): Integer
+    var
+        Node: XmlNode;
+        NodeList: XmlNodeList;
+    begin
+        Node := Root.AsXmlNode();
+        Node.SelectNodes(XPath, NodeList);
+        exit(NodeList.Count());
+    end;
+
+    // ── SelectSingleNode ────────────────────────────────────────────────────────
+
+    procedure NodeSelectSingleNodeFound(Root: XmlElement; XPath: Text): Boolean
+    var
+        Node: XmlNode;
+        Found: XmlNode;
+    begin
+        Node := Root.AsXmlNode();
+        exit(Node.SelectSingleNode(XPath, Found));
+    end;
+
+    procedure NodeSelectSingleNodeName(Root: XmlElement; XPath: Text): Text
+    var
+        Node: XmlNode;
+        Found: XmlNode;
+    begin
+        Node := Root.AsXmlNode();
+        if Node.SelectSingleNode(XPath, Found) then
+            exit(Found.AsXmlElement().Name);
+        exit('');
+    end;
+
+    // ── Remove ──────────────────────────────────────────────────────────────────
+
+    procedure RemoveNodeFromParent(Node: XmlNode)
+    begin
+        Node.Remove();
+    end;
+
+    // ── ReplaceWith ─────────────────────────────────────────────────────────────
+
+    procedure ReplaceNodeWith(OldNode: XmlNode; NewNode: XmlNode)
+    begin
+        OldNode.ReplaceWith(NewNode);
+    end;
+
+    // ── AddAfterSelf ────────────────────────────────────────────────────────────
+
+    procedure AddAfterSelfNode(Ref: XmlNode; NewNode: XmlNode)
+    begin
+        Ref.AddAfterSelf(NewNode);
+    end;
+
+    // ── AddBeforeSelf ───────────────────────────────────────────────────────────
+
+    procedure AddBeforeSelfNode(Ref: XmlNode; NewNode: XmlNode)
+    begin
+        Ref.AddBeforeSelf(NewNode);
+    end;
+
+    // ── Helper: Build 2-child element tree ────────────────────────────────────
+    procedure BuildTwoChildTree(): XmlElement
+    var
+        Root: XmlElement;
+        Item1: XmlElement;
+        Item2: XmlElement;
+    begin
+        Root := XmlElement.Create('root');
+        Item1 := XmlElement.Create('item');
+        Item2 := XmlElement.Create('item');
+        Root.Add(Item1);
+        Root.Add(Item2);
+        exit(Root);
+    end;
+}

--- a/tests/bucket-1/179-xmlnode-methods/test/XmlNodeTest.al
+++ b/tests/bucket-1/179-xmlnode-methods/test/XmlNodeTest.al
@@ -1,0 +1,531 @@
+codeunit 106001 "XNN Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "XNN Src";
+
+    // ── IsXmlElement ────────────────────────────────────────────────────────────
+
+    [Test]
+    procedure IsElement_True_ForElement()
+    var
+        Elem: XmlElement;
+        Node: XmlNode;
+    begin
+        Elem := XmlElement.Create('root');
+        Node := Elem.AsXmlNode();
+        Assert.IsTrue(Src.IsElement(Node), 'IsXmlElement must be true for an element node');
+    end;
+
+    [Test]
+    procedure IsElement_False_ForAttribute()
+    var
+        Attr: XmlAttribute;
+        Node: XmlNode;
+    begin
+        Attr := XmlAttribute.Create('id', 'val');
+        Node := Attr.AsXmlNode();
+        Assert.IsFalse(Src.IsElement(Node), 'IsXmlElement must be false for an attribute node');
+    end;
+
+    // ── IsXmlAttribute ──────────────────────────────────────────────────────────
+
+    [Test]
+    procedure IsAttribute_True_ForAttribute()
+    var
+        Attr: XmlAttribute;
+        Node: XmlNode;
+    begin
+        Attr := XmlAttribute.Create('myattr', 'myval');
+        Node := Attr.AsXmlNode();
+        Assert.IsTrue(Src.IsAttribute(Node), 'IsXmlAttribute must be true for an attribute node');
+    end;
+
+    [Test]
+    procedure IsAttribute_False_ForElement()
+    var
+        Elem: XmlElement;
+        Node: XmlNode;
+    begin
+        Elem := XmlElement.Create('root');
+        Node := Elem.AsXmlNode();
+        Assert.IsFalse(Src.IsAttribute(Node), 'IsXmlAttribute must be false for an element node');
+    end;
+
+    // ── IsXmlText ───────────────────────────────────────────────────────────────
+
+    [Test]
+    procedure IsText_True_ForText()
+    var
+        Txt: XmlText;
+        Node: XmlNode;
+    begin
+        Txt := XmlText.Create('hello');
+        Node := Txt.AsXmlNode();
+        Assert.IsTrue(Src.IsText(Node), 'IsXmlText must be true for a text node');
+    end;
+
+    [Test]
+    procedure IsText_False_ForElement()
+    var
+        Elem: XmlElement;
+        Node: XmlNode;
+    begin
+        Elem := XmlElement.Create('root');
+        Node := Elem.AsXmlNode();
+        Assert.IsFalse(Src.IsText(Node), 'IsXmlText must be false for an element node');
+    end;
+
+    // ── IsXmlCData ──────────────────────────────────────────────────────────────
+
+    [Test]
+    procedure IsCData_True_ForCData()
+    var
+        CData: XmlCData;
+        Node: XmlNode;
+    begin
+        CData := XmlCData.Create('rawdata');
+        Node := CData.AsXmlNode();
+        Assert.IsTrue(Src.IsCData(Node), 'IsXmlCData must be true for a CDATA node');
+    end;
+
+    [Test]
+    procedure IsCData_False_ForText()
+    var
+        Txt: XmlText;
+        Node: XmlNode;
+    begin
+        Txt := XmlText.Create('hello');
+        Node := Txt.AsXmlNode();
+        Assert.IsFalse(Src.IsCData(Node), 'IsXmlCData must be false for a text node');
+    end;
+
+    // ── IsXmlComment ────────────────────────────────────────────────────────────
+
+    [Test]
+    procedure IsComment_True_ForComment()
+    var
+        Comment: XmlComment;
+        Node: XmlNode;
+    begin
+        Comment := XmlComment.Create('a comment');
+        Node := Comment.AsXmlNode();
+        Assert.IsTrue(Src.IsComment(Node), 'IsXmlComment must be true for a comment node');
+    end;
+
+    [Test]
+    procedure IsComment_False_ForElement()
+    var
+        Elem: XmlElement;
+        Node: XmlNode;
+    begin
+        Elem := XmlElement.Create('root');
+        Node := Elem.AsXmlNode();
+        Assert.IsFalse(Src.IsComment(Node), 'IsXmlComment must be false for an element node');
+    end;
+
+    // ── IsXmlDeclaration ────────────────────────────────────────────────────────
+
+    [Test]
+    procedure IsDeclaration_True_ForDeclaration()
+    var
+        Decl: XmlDeclaration;
+        Node: XmlNode;
+    begin
+        Decl := XmlDeclaration.Create('1.0', 'utf-8', '');
+        Node := Decl.AsXmlNode();
+        Assert.IsTrue(Src.IsDeclaration(Node), 'IsXmlDeclaration must be true for a declaration node');
+    end;
+
+    [Test]
+    procedure IsDeclaration_False_ForElement()
+    var
+        Elem: XmlElement;
+        Node: XmlNode;
+    begin
+        Elem := XmlElement.Create('root');
+        Node := Elem.AsXmlNode();
+        Assert.IsFalse(Src.IsDeclaration(Node), 'IsXmlDeclaration must be false for an element node');
+    end;
+
+    // ── IsXmlProcessingInstruction ──────────────────────────────────────────────
+
+    [Test]
+    procedure IsProcessingInstruction_True_ForPI()
+    var
+        PI: XmlProcessingInstruction;
+        Node: XmlNode;
+    begin
+        PI := XmlProcessingInstruction.Create('xml-stylesheet', 'type="text/xsl"');
+        Node := PI.AsXmlNode();
+        Assert.IsTrue(Src.IsProcessingInstruction(Node), 'IsXmlProcessingInstruction must be true for a PI node');
+    end;
+
+    [Test]
+    procedure IsProcessingInstruction_False_ForElement()
+    var
+        Elem: XmlElement;
+        Node: XmlNode;
+    begin
+        Elem := XmlElement.Create('root');
+        Node := Elem.AsXmlNode();
+        Assert.IsFalse(Src.IsProcessingInstruction(Node), 'IsXmlProcessingInstruction must be false for an element');
+    end;
+
+    // ── IsXmlDocument — XmlDocument.AsXmlNode() ─────────────────────────────────
+
+    [Test]
+    procedure IsDocument_True_ForDocument()
+    var
+        Doc: XmlDocument;
+        Root: XmlElement;
+        Node: XmlNode;
+    begin
+        // Build a document programmatically to avoid XmlDocument.ReadFrom gap
+        Doc := XmlDocument.Create();
+        Root := XmlElement.Create('root');
+        Doc.Add(Root);
+        Node := Doc.AsXmlNode();
+        Assert.IsTrue(Src.IsDocument(Node), 'IsXmlDocument must be true for an XmlDocument node');
+    end;
+
+    [Test]
+    procedure IsDocument_False_ForElement()
+    var
+        Elem: XmlElement;
+        Node: XmlNode;
+    begin
+        Elem := XmlElement.Create('root');
+        Node := Elem.AsXmlNode();
+        Assert.IsFalse(Src.IsDocument(Node), 'IsXmlDocument must be false for an element node');
+    end;
+
+    // ── AsXmlElement ────────────────────────────────────────────────────────────
+
+    [Test]
+    procedure AsElement_ReturnsCorrectName()
+    var
+        Elem: XmlElement;
+        Node: XmlNode;
+    begin
+        Elem := XmlElement.Create('myelem');
+        Node := Elem.AsXmlNode();
+        Assert.AreEqual('myelem', Src.AsElementName(Node), 'AsXmlElement.Name must match the element name');
+    end;
+
+    [Test]
+    procedure AsElement_ThrowsForAttribute()
+    var
+        Attr: XmlAttribute;
+        Node: XmlNode;
+    begin
+        Attr := XmlAttribute.Create('id', 'val');
+        Node := Attr.AsXmlNode();
+        asserterror Src.AsElementWrongType(Node);
+        Assert.ExpectedError('');
+    end;
+
+    // ── AsXmlAttribute ──────────────────────────────────────────────────────────
+
+    [Test]
+    procedure AsAttribute_ReturnsCorrectName()
+    var
+        Attr: XmlAttribute;
+        Node: XmlNode;
+    begin
+        Attr := XmlAttribute.Create('myattr', 'myval');
+        Node := Attr.AsXmlNode();
+        Assert.AreEqual('myattr', Src.AsAttributeName(Node), 'AsXmlAttribute.Name must match the attribute name');
+    end;
+
+    // ── AsXmlText ───────────────────────────────────────────────────────────────
+
+    [Test]
+    procedure AsText_ReturnsCorrectValue()
+    var
+        Txt: XmlText;
+        Node: XmlNode;
+    begin
+        Txt := XmlText.Create('textval');
+        Node := Txt.AsXmlNode();
+        Assert.AreEqual('textval', Src.AsTextValue(Node), 'AsXmlText.Value must match the text value');
+    end;
+
+    // ── AsXmlCData ──────────────────────────────────────────────────────────────
+
+    [Test]
+    procedure AsCData_ReturnsCorrectValue()
+    var
+        CData: XmlCData;
+        Node: XmlNode;
+    begin
+        CData := XmlCData.Create('rawdata');
+        Node := CData.AsXmlNode();
+        Assert.AreEqual('rawdata', Src.AsCDataValue(Node), 'AsXmlCData.Value must match the CDATA value');
+    end;
+
+    // ── AsXmlComment ────────────────────────────────────────────────────────────
+
+    [Test]
+    procedure AsComment_ReturnsCorrectValue()
+    var
+        Comment: XmlComment;
+        Node: XmlNode;
+    begin
+        Comment := XmlComment.Create('my comment');
+        Node := Comment.AsXmlNode();
+        Assert.AreEqual('my comment', Src.AsCommentValue(Node), 'AsXmlComment.Value must match the comment');
+    end;
+
+    // ── AsXmlDeclaration ────────────────────────────────────────────────────────
+
+    [Test]
+    procedure AsDeclaration_ReturnsVersion()
+    var
+        Decl: XmlDeclaration;
+        Node: XmlNode;
+    begin
+        Decl := XmlDeclaration.Create('1.0', 'utf-8', '');
+        Node := Decl.AsXmlNode();
+        Assert.AreEqual('1.0', Src.AsDeclarationVersion(Node), 'AsXmlDeclaration.Version must return 1.0');
+    end;
+
+    // ── AsXmlProcessingInstruction ──────────────────────────────────────────────
+
+    [Test]
+    procedure AsProcessingInstruction_ReturnsTarget()
+    var
+        PI: XmlProcessingInstruction;
+        Node: XmlNode;
+    begin
+        PI := XmlProcessingInstruction.Create('xml-stylesheet', 'type="text/xsl"');
+        Node := PI.AsXmlNode();
+        Assert.AreEqual('xml-stylesheet', Src.AsProcessingInstructionTarget(Node), 'AsXmlProcessingInstruction.Target must match');
+    end;
+
+    // ── WriteTo ─────────────────────────────────────────────────────────────────
+
+    [Test]
+    procedure WriteTo_ContainsElementName()
+    var
+        Elem: XmlElement;
+        Node: XmlNode;
+        Result: Text;
+    begin
+        Elem := XmlElement.Create('widget');
+        Node := Elem.AsXmlNode();
+        Result := Src.WriteNodeToText(Node);
+        Assert.IsTrue(Result.Contains('widget'), 'WriteTo must serialize the element name');
+    end;
+
+    [Test]
+    procedure WriteTo_AttributeNode_ContainsValue()
+    var
+        Attr: XmlAttribute;
+        Node: XmlNode;
+        Result: Text;
+    begin
+        Attr := XmlAttribute.Create('color', 'blue');
+        Node := Attr.AsXmlNode();
+        Result := Src.WriteNodeToText(Node);
+        Assert.IsTrue(Result.Contains('blue'), 'WriteTo of an attribute node must contain its value');
+    end;
+
+    // ── GetParent ───────────────────────────────────────────────────────────────
+
+    [Test]
+    procedure GetParent_True_ForChildNode()
+    var
+        Root: XmlElement;
+        Child: XmlElement;
+        Node: XmlNode;
+        Parent: XmlElement;
+    begin
+        Root := XmlElement.Create('root');
+        Child := XmlElement.Create('child');
+        Root.Add(Child);
+        Node := Child.AsXmlNode();
+        Assert.IsTrue(Src.NodeGetParent(Node, Parent), 'GetParent must return true for a parented child node');
+    end;
+
+    [Test]
+    procedure GetParent_False_ForOrphanNode()
+    var
+        Elem: XmlElement;
+        Node: XmlNode;
+        Parent: XmlElement;
+    begin
+        Elem := XmlElement.Create('orphan');
+        Node := Elem.AsXmlNode();
+        Assert.IsFalse(Src.NodeGetParent(Node, Parent), 'GetParent must return false for a node with no parent');
+    end;
+
+    // ── GetDocument ─────────────────────────────────────────────────────────────
+
+    [Test]
+    procedure GetDocument_True_ForDocumentChild()
+    var
+        Doc: XmlDocument;
+        Root: XmlElement;
+        Node: XmlNode;
+        FoundDoc: XmlDocument;
+    begin
+        Doc := XmlDocument.Create();
+        Root := XmlElement.Create('root');
+        Doc.Add(Root);
+        Node := Root.AsXmlNode();
+        Assert.IsTrue(Src.NodeGetDocument(Node, FoundDoc), 'GetDocument must return true for a node in a document');
+    end;
+
+    [Test]
+    procedure GetDocument_False_ForOrphanNode()
+    var
+        Elem: XmlElement;
+        Node: XmlNode;
+        Doc: XmlDocument;
+    begin
+        Elem := XmlElement.Create('orphan');
+        Node := Elem.AsXmlNode();
+        Assert.IsFalse(Src.NodeGetDocument(Node, Doc), 'GetDocument must return false for an orphan node');
+    end;
+
+    // ── SelectNodes ─────────────────────────────────────────────────────────────
+
+    [Test]
+    procedure SelectNodes_FindsTwoChildren()
+    var
+        Root: XmlElement;
+    begin
+        Root := Src.BuildTwoChildTree();
+        Assert.AreEqual(2, Src.NodeSelectNodesCount(Root, 'item'), 'SelectNodes must find 2 item children');
+    end;
+
+    [Test]
+    procedure SelectNodes_NoMatch_ReturnsZeroCount()
+    var
+        Root: XmlElement;
+    begin
+        Root := Src.BuildTwoChildTree();
+        Assert.AreEqual(0, Src.NodeSelectNodesCount(Root, 'zzz'), 'SelectNodes with no match must return 0');
+    end;
+
+    // ── SelectSingleNode ────────────────────────────────────────────────────────
+
+    [Test]
+    procedure SelectSingleNode_ReturnsTrue_ForMatch()
+    var
+        Root: XmlElement;
+    begin
+        Root := Src.BuildTwoChildTree();
+        Assert.IsTrue(Src.NodeSelectSingleNodeFound(Root, 'item'), 'SelectSingleNode must return true for matching xpath');
+    end;
+
+    [Test]
+    procedure SelectSingleNode_ReturnsFalse_ForNoMatch()
+    var
+        Root: XmlElement;
+    begin
+        Root := Src.BuildTwoChildTree();
+        Assert.IsFalse(Src.NodeSelectSingleNodeFound(Root, 'zzz'), 'SelectSingleNode must return false for no-match');
+    end;
+
+    // ── Remove ──────────────────────────────────────────────────────────────────
+
+    [Test]
+    procedure Remove_DecrementsParentChildCount()
+    var
+        Root: XmlElement;
+        Child: XmlElement;
+        Node: XmlNode;
+    begin
+        Root := XmlElement.Create('root');
+        Child := XmlElement.Create('child');
+        Root.Add(Child);
+        Node := Child.AsXmlNode();
+        Src.RemoveNodeFromParent(Node);
+        Assert.AreEqual(0, Root.GetChildNodes().Count(), 'Remove must detach the node from its parent');
+    end;
+
+    // ── ReplaceWith ─────────────────────────────────────────────────────────────
+
+    [Test]
+    procedure ReplaceWith_SubstitutesNode()
+    var
+        Root: XmlElement;
+        OldChild: XmlElement;
+        NewChild: XmlElement;
+        OldNode: XmlNode;
+        NewNode: XmlNode;
+        Nodes: XmlNodeList;
+        Result: XmlNode;
+        ResultElem: XmlElement;
+    begin
+        Root := XmlElement.Create('root');
+        OldChild := XmlElement.Create('old');
+        Root.Add(OldChild);
+        NewChild := XmlElement.Create('new');
+        OldNode := OldChild.AsXmlNode();
+        NewNode := NewChild.AsXmlNode();
+        Src.ReplaceNodeWith(OldNode, NewNode);
+        Nodes := Root.GetChildNodes();
+        Nodes.Get(1, Result);
+        ResultElem := Result.AsXmlElement();
+        Assert.AreEqual('new', ResultElem.Name, 'ReplaceWith must substitute the old node with the new one');
+    end;
+
+    // ── AddAfterSelf ────────────────────────────────────────────────────────────
+
+    [Test]
+    procedure AddAfterSelf_PlacesNodeAfter()
+    var
+        Root: XmlElement;
+        First: XmlElement;
+        Second: XmlElement;
+        FirstNode: XmlNode;
+        SecondNode: XmlNode;
+        Nodes: XmlNodeList;
+        N: XmlNode;
+        NE: XmlElement;
+    begin
+        Root := XmlElement.Create('root');
+        First := XmlElement.Create('first');
+        Root.Add(First);
+        Second := XmlElement.Create('second');
+        FirstNode := First.AsXmlNode();
+        SecondNode := Second.AsXmlNode();
+        Src.AddAfterSelfNode(FirstNode, SecondNode);
+        Nodes := Root.GetChildNodes();
+        Nodes.Get(2, N);
+        NE := N.AsXmlElement();
+        Assert.AreEqual('second', NE.Name, 'AddAfterSelf must insert the node immediately after the reference node');
+    end;
+
+    // ── AddBeforeSelf ───────────────────────────────────────────────────────────
+
+    [Test]
+    procedure AddBeforeSelf_PlacesNodeBefore()
+    var
+        Root: XmlElement;
+        First: XmlElement;
+        Second: XmlElement;
+        FirstNode: XmlNode;
+        SecondNode: XmlNode;
+        Nodes: XmlNodeList;
+        N: XmlNode;
+        NE: XmlElement;
+    begin
+        Root := XmlElement.Create('root');
+        First := XmlElement.Create('first');
+        Root.Add(First);
+        Second := XmlElement.Create('second');
+        FirstNode := First.AsXmlNode();
+        SecondNode := Second.AsXmlNode();
+        Src.AddBeforeSelfNode(FirstNode, SecondNode);
+        Nodes := Root.GetChildNodes();
+        Nodes.Get(1, N);
+        NE := N.AsXmlElement();
+        Assert.AreEqual('second', NE.Name, 'AddBeforeSelf must insert the node immediately before the reference node');
+    end;
+}


### PR DESCRIPTION
Closes #799

## Summary

All 19 XmlNode methods listed in the issue are confirmed working natively via the BC runtime (`NavXmlNode`) — no rewriter changes needed. The BC runtime XML types implement these methods without going through `TrappableOperationExecutor`, so they work in standalone mode already.

**Methods confirmed covered:**
- **Type checks (9):** `IsXmlAttribute`, `IsXmlCData`, `IsXmlComment`, `IsXmlDeclaration`, `IsXmlDocument`, `IsXmlElement`, `IsXmlProcessingInstruction`, `IsXmlText` — all return correct true/false based on underlying type
- **Type casts (8):** `AsXmlAttribute`, `AsXmlCData`, `AsXmlComment`, `AsXmlDeclaration`, `AsXmlElement`, `AsXmlProcessingInstruction`, `AsXmlText`, `AsXmlDocument` — return typed node; error on wrong-type cast
- **Navigation/mutation (8):** `AddAfterSelf`, `AddBeforeSelf`, `GetDocument`, `GetParent`, `Remove`, `ReplaceWith`, `SelectNodes`, `SelectSingleNode`, `WriteTo`

**Note:** `IsXmlDocumentType` / `AsXmlDocumentType` left as gap — `XmlDocumentType.AsXmlNode()` path not yet tested; low priority.

**Tests avoid `XmlDocument.ReadFrom`** (known gap #481) — all trees built programmatically via `XmlElement.Create` / `XmlDocument.Create`.

## Test results

38 passing tests in `tests/bucket-1/179-xmlnode-methods/` covering positive + negative cases for every method.