### PR TITLE
feat: Table metadata stubs — FieldName, CurrentCompany, RecordLevelLocking (#805)

### DIFF
--- a/AlRunner/Runtime/MockRecordHandle.cs
+++ b/AlRunner/Runtime/MockRecordHandle.cs
@@ -2892,6 +2892,30 @@ public class MockRecordHandle
     public bool ALWritePermission => true;
 
     /// <summary>
+    /// AL RecordLevelLocking — returns whether record-level locking is in effect.
+    /// In standalone mode there is no SQL locking, so always returns false.
+    /// </summary>
+    public bool ALRecordLevelLocking => false;
+
+    /// <summary>
+    /// AL FieldName — returns the AL field name (identifier) for a given field number.
+    /// Looks up from TableFieldRegistry; falls back to "FieldNN" if not registered.
+    /// BC lowers <c>Rec.FieldName(SomeField)</c> to <c>rec.ALFieldName(fieldNo)</c>.
+    /// </summary>
+    public NavText ALFieldName(int fieldNo)
+    {
+        var name = TableFieldRegistry.GetFieldName(_tableId, fieldNo);
+        return new NavText(name ?? $"Field{fieldNo}");
+    }
+
+    /// <summary>
+    /// AL CurrentCompany — returns the current company name.
+    /// In standalone mode returns the configured company name (default "CRONUS").
+    /// This mirrors <c>CompanyName()</c> built-in, which BC also routes here on record instances.
+    /// </summary>
+    public string ALCurrentCompany => MockSession.GetCompanyName();
+
+    /// <summary>
     /// AL SetPermissionFilter — applies permission-based filtering.
     /// No-op in standalone mode (no permission enforcement).
     /// </summary>

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -6293,14 +6293,16 @@ Table.CountApprox:
 Table.CurrentCompany:
   layer: runtime-api
   category: Table
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-1/180-table-metadata-stubs
+  notes: overloads=1; MockRecordHandle.ALCurrentCompany → MockSession.GetCompanyName() (default "CRONUS")
 
 Table.CurrentKey:
   layer: runtime-api
   category: Table
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-1/180-table-metadata-stubs
+  notes: overloads=1; MockRecordHandle.ALCurrentKey — returns comma-separated field names from current sort key
 
 Table.Delete:
   layer: runtime-api
@@ -6330,26 +6332,30 @@ Table.DeleteLinks:
 Table.FieldActive:
   layer: runtime-api
   category: Table
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-1/180-table-metadata-stubs
+  notes: overloads=1; MockRecordHandle.ALFieldActive(fieldNo) — always true in standalone (no field disabling)
 
 Table.FieldCaption:
   layer: runtime-api
   category: Table
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-1/180-table-metadata-stubs
+  notes: overloads=1; MockRecordHandle.ALFieldCaption(fieldNo) — from TableFieldRegistry; falls back to "FieldNN"
 
 Table.FieldError:
   layer: runtime-api
   category: Table
-  status: gap
-  notes: overloads=2
+  status: covered
+  tests: tests/bucket-1/180-table-metadata-stubs
+  notes: overloads=2; MockRecordHandle.ALFieldError(fieldNo) / ALFieldError(fieldNo, msg) — throws validation error
 
 Table.FieldName:
   layer: runtime-api
   category: Table
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-1/180-table-metadata-stubs
+  notes: overloads=1; MockRecordHandle.ALFieldName(fieldNo) — from TableFieldRegistry; falls back to "FieldNN"
 
 Table.FieldNo:
   layer: runtime-api
@@ -6502,8 +6508,9 @@ Table.IsEmpty:
 Table.IsTemporary:
   layer: runtime-api
   category: Table
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-1/180-table-metadata-stubs
+  notes: overloads=1; MockRecordHandle.ALIsTemporary — reflects _isTemporary flag set at construction
 
 Table.LoadFields:
   layer: runtime-api
@@ -6572,20 +6579,23 @@ Table.ReadIsolation:
 Table.ReadPermission:
   layer: runtime-api
   category: Table
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-1/180-table-metadata-stubs
+  notes: overloads=1; MockRecordHandle.ALReadPermission — always true (no permission system in standalone)
 
 Table.RecordId:
   layer: runtime-api
   category: Table
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-1/180-table-metadata-stubs
+  notes: overloads=1; MockRecordHandle.ALRecordId — returns NavRecordId.Default (no-crash stub); TableNo returns 0 in standalone
 
 Table.RecordLevelLocking:
   layer: runtime-api
   category: Table
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-1/180-table-metadata-stubs
+  notes: overloads=1; MockRecordHandle.ALRecordLevelLocking — always false (no SQL locking in standalone)
 
 Table.Relation:
   layer: runtime-api
@@ -6693,14 +6703,16 @@ Table.SetView:
 Table.TableCaption:
   layer: runtime-api
   category: Table
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-1/180-table-metadata-stubs
+  notes: overloads=1; MockRecordHandle.ALTableCaption — from TableFieldRegistry; falls back to ALTableName
 
 Table.TableName:
   layer: runtime-api
   category: Table
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-1/180-table-metadata-stubs
+  notes: overloads=1; MockRecordHandle.ALTableName — from TableFieldRegistry; falls back to "TableNN"
 
 Table.TestField:
   layer: runtime-api
@@ -6737,8 +6749,9 @@ Table.Validate:
 Table.WritePermission:
   layer: runtime-api
   category: Table
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-1/180-table-metadata-stubs
+  notes: overloads=1; MockRecordHandle.ALWritePermission — always true (no permission system in standalone)
 
 # ── TaskScheduler ───────────────────────────────────────────────
 

--- a/tests/bucket-1/180-table-metadata-stubs/src/TableMetaSrc.al
+++ b/tests/bucket-1/180-table-metadata-stubs/src/TableMetaSrc.al
@@ -1,0 +1,144 @@
+/// In-suite table used by the table-metadata-stubs test.
+table 107000 "TMI Record"
+{
+    Caption = 'TMI Record';
+
+    fields
+    {
+        field(1; Id; Integer) { Caption = 'Id'; }
+        field(2; Name; Text[50]) { Caption = 'Name'; }
+        field(3; Amount; Decimal) { Caption = 'Amount'; }
+    }
+    keys
+    {
+        key(PK; Id) { Clustered = true; }
+    }
+}
+
+/// Helper codeunit exercising Table record metadata and introspection methods.
+codeunit 107000 "TMI Src"
+{
+    // ── FieldCaption ────────────────────────────────────────────────────────────
+
+    procedure FieldCaptionId(var Rec: Record "TMI Record"): Text
+    begin
+        exit(Rec.FieldCaption(Id));
+    end;
+
+    procedure FieldCaptionName(var Rec: Record "TMI Record"): Text
+    begin
+        exit(Rec.FieldCaption(Name));
+    end;
+
+    procedure FieldCaptionAmount(var Rec: Record "TMI Record"): Text
+    begin
+        exit(Rec.FieldCaption(Amount));
+    end;
+
+    // ── FieldName ───────────────────────────────────────────────────────────────
+
+    procedure FieldNameId(var Rec: Record "TMI Record"): Text
+    begin
+        exit(Rec.FieldName(Id));
+    end;
+
+    procedure FieldNameName(var Rec: Record "TMI Record"): Text
+    begin
+        exit(Rec.FieldName(Name));
+    end;
+
+    // ── FieldActive ─────────────────────────────────────────────────────────────
+
+    procedure IsFieldIdActive(var Rec: Record "TMI Record"): Boolean
+    begin
+        exit(Rec.FieldActive(Id));
+    end;
+
+    procedure IsFieldNameActive(var Rec: Record "TMI Record"): Boolean
+    begin
+        exit(Rec.FieldActive(Name));
+    end;
+
+    // ── FieldError ──────────────────────────────────────────────────────────────
+
+    procedure TriggerFieldError(var Rec: Record "TMI Record")
+    begin
+        Rec.FieldError(Name);
+    end;
+
+    procedure TriggerFieldErrorWithMessage(var Rec: Record "TMI Record"; Msg: Text)
+    begin
+        Rec.FieldError(Name, Msg);
+    end;
+
+    // ── TableCaption ────────────────────────────────────────────────────────────
+
+    procedure GetTableCaption(var Rec: Record "TMI Record"): Text
+    begin
+        exit(Rec.TableCaption());
+    end;
+
+    // ── TableName ───────────────────────────────────────────────────────────────
+
+    procedure GetTableName(var Rec: Record "TMI Record"): Text
+    begin
+        exit(Rec.TableName());
+    end;
+
+    // ── CurrentKey ──────────────────────────────────────────────────────────────
+
+    procedure GetCurrentKey(var Rec: Record "TMI Record"): Text
+    begin
+        exit(Rec.CurrentKey());
+    end;
+
+    // ── CurrentCompany ──────────────────────────────────────────────────────────
+
+    procedure GetCurrentCompany(var Rec: Record "TMI Record"): Text
+    begin
+        exit(Rec.CurrentCompany());
+    end;
+
+    // ── IsTemporary ─────────────────────────────────────────────────────────────
+
+    procedure CheckIsTemporary(var Rec: Record "TMI Record"): Boolean
+    begin
+        exit(Rec.IsTemporary());
+    end;
+
+    procedure CheckTempIsTemporary(var Rec: Record "TMI Record" temporary): Boolean
+    begin
+        exit(Rec.IsTemporary());
+    end;
+
+    // ── ReadPermission ──────────────────────────────────────────────────────────
+
+    procedure HasReadPermission(var Rec: Record "TMI Record"): Boolean
+    begin
+        exit(Rec.ReadPermission());
+    end;
+
+    // ── WritePermission ─────────────────────────────────────────────────────────
+
+    procedure HasWritePermission(var Rec: Record "TMI Record"): Boolean
+    begin
+        exit(Rec.WritePermission());
+    end;
+
+    // ── RecordLevelLocking ──────────────────────────────────────────────────────
+
+    procedure GetRecordLevelLocking(var Rec: Record "TMI Record"): Boolean
+    begin
+        exit(Rec.RecordLevelLocking());
+    end;
+
+    // ── RecordId ────────────────────────────────────────────────────────────────
+
+    procedure GetRecordIdDoesNotCrash(var Rec: Record "TMI Record"): Boolean
+    var
+        RId: RecordId;
+    begin
+        RId := Rec.RecordId();
+        exit(true); // just prove it doesn't crash
+    end;
+}

--- a/tests/bucket-1/180-table-metadata-stubs/test/TableMetaTest.al
+++ b/tests/bucket-1/180-table-metadata-stubs/test/TableMetaTest.al
@@ -1,0 +1,229 @@
+codeunit 107001 "TMI Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "TMI Src";
+
+    // ── FieldCaption ────────────────────────────────────────────────────────────
+
+    [Test]
+    procedure FieldCaption_Id_ReturnsId()
+    var
+        Rec: Record "TMI Record";
+    begin
+        Assert.AreEqual('Id', Src.FieldCaptionId(Rec), 'FieldCaption for "Id" field must return "Id"');
+    end;
+
+    [Test]
+    procedure FieldCaption_Name_ReturnsName()
+    var
+        Rec: Record "TMI Record";
+    begin
+        Assert.AreEqual('Name', Src.FieldCaptionName(Rec), 'FieldCaption for "Name" field must return "Name"');
+    end;
+
+    [Test]
+    procedure FieldCaption_Amount_ReturnsAmount()
+    var
+        Rec: Record "TMI Record";
+    begin
+        Assert.AreEqual('Amount', Src.FieldCaptionAmount(Rec), 'FieldCaption for "Amount" field must return "Amount"');
+    end;
+
+    [Test]
+    procedure FieldCaption_DiffersForDifferentFields()
+    var
+        Rec: Record "TMI Record";
+    begin
+        Assert.AreNotEqual(Src.FieldCaptionId(Rec), Src.FieldCaptionName(Rec),
+            'FieldCaption must differ for different fields');
+    end;
+
+    // ── FieldName ───────────────────────────────────────────────────────────────
+
+    [Test]
+    procedure FieldName_Id_ReturnsId()
+    var
+        Rec: Record "TMI Record";
+    begin
+        Assert.AreEqual('Id', Src.FieldNameId(Rec), 'FieldName for "Id" field must return "Id"');
+    end;
+
+    [Test]
+    procedure FieldName_Name_ReturnsName()
+    var
+        Rec: Record "TMI Record";
+    begin
+        Assert.AreEqual('Name', Src.FieldNameName(Rec), 'FieldName for "Name" field must return "Name"');
+    end;
+
+    // ── FieldActive ─────────────────────────────────────────────────────────────
+
+    [Test]
+    procedure FieldActive_IdField_ReturnsTrue()
+    var
+        Rec: Record "TMI Record";
+    begin
+        Assert.IsTrue(Src.IsFieldIdActive(Rec), 'FieldActive must return true for existing "Id" field');
+    end;
+
+    [Test]
+    procedure FieldActive_NameField_ReturnsTrue()
+    var
+        Rec: Record "TMI Record";
+    begin
+        Assert.IsTrue(Src.IsFieldNameActive(Rec), 'FieldActive must return true for existing "Name" field');
+    end;
+
+    // ── FieldError ──────────────────────────────────────────────────────────────
+
+    [Test]
+    procedure FieldError_ThrowsError()
+    var
+        Rec: Record "TMI Record";
+    begin
+        asserterror Src.TriggerFieldError(Rec);
+        Assert.ExpectedError('');
+    end;
+
+    [Test]
+    procedure FieldError_WithMessage_ContainsMessage()
+    var
+        Rec: Record "TMI Record";
+    begin
+        asserterror Src.TriggerFieldErrorWithMessage(Rec, 'must not be blank');
+        Assert.ExpectedError('must not be blank');
+    end;
+
+    // ── TableCaption ────────────────────────────────────────────────────────────
+
+    [Test]
+    procedure TableCaption_ReturnsNonEmpty()
+    var
+        Rec: Record "TMI Record";
+    begin
+        Assert.AreNotEqual('', Src.GetTableCaption(Rec), 'TableCaption must return non-empty string');
+    end;
+
+    [Test]
+    procedure TableCaption_ContainsTableIdentifier()
+    var
+        Rec: Record "TMI Record";
+        Caption: Text;
+    begin
+        Caption := Src.GetTableCaption(Rec);
+        Assert.IsTrue(Caption.Contains('TMI'), 'TableCaption must contain table identifier "TMI"');
+    end;
+
+    // ── TableName ───────────────────────────────────────────────────────────────
+
+    [Test]
+    procedure TableName_ReturnsTMIRecord()
+    var
+        Rec: Record "TMI Record";
+    begin
+        Assert.AreEqual('TMI Record', Src.GetTableName(Rec), 'TableName must return "TMI Record"');
+    end;
+
+    [Test]
+    procedure TableName_DiffersFromFieldName()
+    var
+        Rec: Record "TMI Record";
+    begin
+        // Table name must not equal a field name
+        Assert.AreNotEqual(Src.GetTableName(Rec), Src.FieldNameId(Rec),
+            'TableName must not equal a field name');
+    end;
+
+    // ── CurrentKey ──────────────────────────────────────────────────────────────
+
+    [Test]
+    procedure CurrentKey_DefaultContainsPkField()
+    var
+        Rec: Record "TMI Record";
+        CurKey: Text;
+    begin
+        CurKey := Src.GetCurrentKey(Rec);
+        // Default sort is by PK (field "Id")
+        Assert.IsTrue(CurKey.Contains('Id'), 'CurrentKey must contain PK field "Id" by default');
+    end;
+
+    [Test]
+    procedure CurrentKey_NotEmpty()
+    var
+        Rec: Record "TMI Record";
+    begin
+        Assert.AreNotEqual('', Src.GetCurrentKey(Rec), 'CurrentKey must return non-empty string');
+    end;
+
+    // ── CurrentCompany ──────────────────────────────────────────────────────────
+
+    [Test]
+    procedure CurrentCompany_ReturnsNonEmpty()
+    var
+        Rec: Record "TMI Record";
+    begin
+        Assert.AreNotEqual('', Src.GetCurrentCompany(Rec), 'CurrentCompany must return non-empty string');
+    end;
+
+    // ── IsTemporary ─────────────────────────────────────────────────────────────
+
+    [Test]
+    procedure IsTemporary_RegularRecord_ReturnsFalse()
+    var
+        Rec: Record "TMI Record";
+    begin
+        Assert.IsFalse(Src.CheckIsTemporary(Rec), 'IsTemporary must return false for a regular record');
+    end;
+
+    [Test]
+    procedure IsTemporary_TempRecord_ReturnsTrue()
+    var
+        Rec: Record "TMI Record" temporary;
+    begin
+        Assert.IsTrue(Src.CheckTempIsTemporary(Rec), 'IsTemporary must return true for a temporary record');
+    end;
+
+    // ── ReadPermission ──────────────────────────────────────────────────────────
+
+    [Test]
+    procedure ReadPermission_ReturnsTrue()
+    var
+        Rec: Record "TMI Record";
+    begin
+        Assert.IsTrue(Src.HasReadPermission(Rec), 'ReadPermission must return true in standalone runner');
+    end;
+
+    // ── WritePermission ─────────────────────────────────────────────────────────
+
+    [Test]
+    procedure WritePermission_ReturnsTrue()
+    var
+        Rec: Record "TMI Record";
+    begin
+        Assert.IsTrue(Src.HasWritePermission(Rec), 'WritePermission must return true in standalone runner');
+    end;
+
+    // ── RecordLevelLocking ──────────────────────────────────────────────────────
+
+    [Test]
+    procedure RecordLevelLocking_ReturnsFalse()
+    var
+        Rec: Record "TMI Record";
+    begin
+        Assert.IsFalse(Src.GetRecordLevelLocking(Rec), 'RecordLevelLocking must return false in standalone runner');
+    end;
+
+    // ── RecordId ────────────────────────────────────────────────────────────────
+
+    [Test]
+    procedure RecordId_DoesNotCrash()
+    var
+        Rec: Record "TMI Record";
+    begin
+        // RecordId() must not throw — standalone returns a default RecordId value
+        Assert.IsTrue(Src.GetRecordIdDoesNotCrash(Rec), 'RecordId() must not crash');
+    end;
+}


### PR DESCRIPTION
Closes #805

## Summary

Adds three missing `MockRecordHandle` methods and confirms 10 already-working ones with 23 proving tests.

**New methods:**
| Method | Implementation |
|---|---|
| `FieldName(field)` → `ALFieldName(fieldNo)` | `TableFieldRegistry.GetFieldName`; falls back to `"FieldNN"` |
| `CurrentCompany()` → `ALCurrentCompany` | `MockSession.GetCompanyName()` (default `"CRONUS"`, CLI-configurable) |
| `RecordLevelLocking()` → `ALRecordLevelLocking` | Always `false` — no SQL locking in standalone mode |

**Methods confirmed already working (no changes):**
`FieldCaption`, `FieldActive`, `FieldError` (both overloads), `TableCaption`, `TableName`, `CurrentKey`, `IsTemporary`, `ReadPermission`, `WritePermission`, `RecordId`

## Tests

`tests/bucket-1/180-table-metadata-stubs/` — 23 tests with an in-suite `TMI Record` table (ID 107000):
- `FieldCaption` returns the registered caption for each field
- `FieldName` returns the AL identifier name
- `FieldActive` returns true for existing fields
- `FieldError` throws; `FieldError(field, msg)` error contains the custom message
- `TableCaption` non-empty, contains table identifier
- `TableName` returns exact `"TMI Record"`
- `CurrentKey` contains `"Id"` (PK field) by default
- `CurrentCompany` non-empty
- `IsTemporary` false for regular record, true for `temporary` record
- `ReadPermission` / `WritePermission` both true
- `RecordLevelLocking` false
- `RecordId()` doesn't crash