### PR TITLE
feat: JsonObject — GetTime/Duration/Option/Byte/BigInteger/Values/Path + ReadFromYaml/WriteToYaml stubs (#791)

### DIFF
--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -2422,7 +2422,8 @@ public void ClearApplicationMemberVariables()
                 or "ALGetBoolean" or "ALIsArray" or "ALIsObject" or "ALIsValue" or "ALClone"
                 or "ALKeys"
                 or "ALGetText" or "ALGetInteger" or "ALGetDecimal"
-                or "ALGetObject" or "ALGetArray")
+                or "ALGetObject" or "ALGetArray"
+                or "ALWriteToYaml" or "ALReadFromYaml")
             {
                 var helperMethod = methodName switch
                 {
@@ -2443,6 +2444,8 @@ public void ClearApplicationMemberVariables()
                     "ALGetDecimal" => "GetDecimal",
                     "ALGetObject" => "GetObject",
                     "ALGetArray" => "GetArray",
+                    "ALWriteToYaml" => "WriteToYaml",
+                    "ALReadFromYaml" => "ReadFromYaml",
                     _ => null
                 };
                 if (helperMethod is not null)

--- a/AlRunner/Runtime/MockJsonHelper.cs
+++ b/AlRunner/Runtime/MockJsonHelper.cs
@@ -474,6 +474,39 @@ public static class MockJsonHelper
         return CreateJsonToken<NavJsonArray>(jArr);
     }
 
+    /// <summary>
+    /// Stub replacement for NavJsonToken.ALWriteToYaml(DataError, ByRef&lt;NavText&gt;).
+    /// BC's WriteToYaml requires YamlDotNet which is not available in the runner.
+    /// Serializes as JSON instead — JSON is valid YAML, so this stub is sufficient for testing.
+    /// AL: JsonObject.WriteToYaml(var Text)  →  MockJsonHelper.WriteToYaml(token, error, data)
+    /// </summary>
+    public static bool WriteToYaml(NavJsonToken token, DataError errorLevel, ByRef<NavText> data)
+        => WriteTo(token, errorLevel, data);
+
+    /// <summary>
+    /// Stub replacement for NavJsonToken.ALWriteToYaml(DataError, OutStream).
+    /// See <see cref="WriteToYaml(NavJsonToken, DataError, ByRef{NavText})"/> for context.
+    /// </summary>
+    public static bool WriteToYaml(NavJsonToken token, DataError errorLevel, MockOutStream stream)
+        => WriteTo(token, errorLevel, stream);
+
+    /// <summary>
+    /// Stub replacement for NavJsonToken.ALReadFromYaml(DataError, string).
+    /// BC's ReadFromYaml requires YamlDotNet which is not available in the runner.
+    /// Parses as JSON instead — simple YAML using JSON notation (the common test case)
+    /// is parsed correctly.
+    /// AL: JsonObject.ReadFromYaml(Text)  →  MockJsonHelper.ReadFromYaml(token, error, text)
+    /// </summary>
+    public static bool ReadFromYaml(NavJsonToken token, DataError errorLevel, string data)
+        => ReadFrom(token, errorLevel, data);
+
+    /// <summary>
+    /// Stub replacement for NavJsonToken.ALReadFromYaml(DataError, InStream).
+    /// See <see cref="ReadFromYaml(NavJsonToken, DataError, string)"/> for context.
+    /// </summary>
+    public static bool ReadFromYaml(NavJsonToken token, DataError errorLevel, MockInStream stream)
+        => ReadFrom(token, errorLevel, stream);
+
     private static bool IsSupportedTokenType(JToken token)
     {
         return token.Type switch

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -3468,8 +3468,10 @@ JsonObject.ReadFrom:
 JsonObject.ReadFromYaml:
   layer: runtime-api
   category: JsonObject
-  status: gap
-  notes: overloads=2
+  status: covered
+  notes: overloads=2; rewriter redirects ALReadFromYaml to MockJsonHelper.ReadFromYaml; stub delegates to ReadFrom (JSON round-trip) — YamlDotNet not available in runner
+  tests:
+    - tests/bucket-1/182-jsonobject-extended
 
 JsonObject.Remove:
   layer: runtime-api
@@ -3510,8 +3512,10 @@ JsonObject.WriteTo:
 JsonObject.WriteToYaml:
   layer: runtime-api
   category: JsonObject
-  status: gap
-  notes: overloads=2
+  status: covered
+  notes: overloads=2; rewriter redirects ALWriteToYaml to MockJsonHelper.WriteToYaml; stub delegates to WriteTo (JSON serialization — valid YAML) — YamlDotNet not available in runner
+  tests:
+    - tests/bucket-1/182-jsonobject-extended
 
 JsonObject.WriteWithSecretsTo:
   layer: runtime-api

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -3341,8 +3341,10 @@ JsonObject.GetArray:
 JsonObject.GetBigInteger:
   layer: runtime-api
   category: JsonObject
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; works natively via NavJsonObject (no TrappableOperationExecutor path); BC stores BigInteger as integer in JSON
+  tests:
+    - tests/bucket-1/182-jsonobject-extended
 
 JsonObject.GetBoolean:
   layer: runtime-api
@@ -3355,8 +3357,10 @@ JsonObject.GetBoolean:
 JsonObject.GetByte:
   layer: runtime-api
   category: JsonObject
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; works natively via NavJsonObject (no TrappableOperationExecutor path); BC stores Byte as integer in JSON
+  tests:
+    - tests/bucket-1/182-jsonobject-extended
 
 JsonObject.GetChar:
   layer: runtime-api
@@ -3393,8 +3397,10 @@ JsonObject.GetDecimal:
 JsonObject.GetDuration:
   layer: runtime-api
   category: JsonObject
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; works natively via NavJsonObject (no TrappableOperationExecutor path); BC stores Duration as integer milliseconds in JSON
+  tests:
+    - tests/bucket-1/182-jsonobject-extended
 
 JsonObject.GetInteger:
   layer: runtime-api
@@ -3415,8 +3421,10 @@ JsonObject.GetObject:
 JsonObject.GetOption:
   layer: runtime-api
   category: JsonObject
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; works natively via NavJsonObject (no TrappableOperationExecutor path); returns integer ordinal
+  tests:
+    - tests/bucket-1/182-jsonobject-extended
 
 JsonObject.GetText:
   layer: runtime-api
@@ -3429,8 +3437,10 @@ JsonObject.GetText:
 JsonObject.GetTime:
   layer: runtime-api
   category: JsonObject
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; works natively via NavJsonObject (no TrappableOperationExecutor path); BC stores Time as integer milliseconds-from-midnight in JSON
+  tests:
+    - tests/bucket-1/182-jsonobject-extended
 
 JsonObject.Keys:
   layer: runtime-api
@@ -3444,8 +3454,10 @@ JsonObject.Keys:
 JsonObject.Path:
   layer: runtime-api
   category: JsonObject
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; rewriter intercepts ALPath property → MockJsonHelper.Path; root object returns "$"
+  tests:
+    - tests/bucket-1/182-jsonobject-extended
 
 JsonObject.ReadFrom:
   layer: runtime-api
@@ -3484,8 +3496,10 @@ JsonObject.SelectToken:
 JsonObject.Values:
   layer: runtime-api
   category: JsonObject
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; works natively via NavJsonObject (no TrappableOperationExecutor path); returns List of [JsonToken] in insertion order
+  tests:
+    - tests/bucket-1/182-jsonobject-extended
 
 JsonObject.WriteTo:
   layer: runtime-api

--- a/tests/bucket-1/182-jsonobject-extended/src/JsonObjExtSrc.al
+++ b/tests/bucket-1/182-jsonobject-extended/src/JsonObjExtSrc.al
@@ -1,5 +1,5 @@
 /// Helper codeunit exercising extended JsonObject methods from issue #791.
-codeunit 109000 "JOEX Src"
+codeunit 112000 "JOEX Src"
 {
     // ── GetTime ────────────────────────────────────────────────────────────────
 

--- a/tests/bucket-1/182-jsonobject-extended/src/JsonObjExtSrc.al
+++ b/tests/bucket-1/182-jsonobject-extended/src/JsonObjExtSrc.al
@@ -53,4 +53,27 @@ codeunit 109000 "JOEX Src"
         exit(Obj.Path());
     end;
 
+    // ── WriteToYaml ───────────────────────────────────────────────────────────
+
+    procedure WriteToYamlText(Obj: JsonObject): Text
+    var
+        Yaml: Text;
+    begin
+        Obj.WriteToYaml(Yaml);
+        exit(Yaml);
+    end;
+
+    // ── ReadFromYaml ──────────────────────────────────────────────────────────
+
+    procedure ReadFromYamlGetText(YamlText: Text; KeyName: Text): Text
+    var
+        Obj: JsonObject;
+        Tok: JsonToken;
+    begin
+        Obj.ReadFromYaml(YamlText);
+        if Obj.Get(KeyName, Tok) then
+            exit(Tok.AsValue().AsText());
+        exit('<not-found>');
+    end;
+
 }

--- a/tests/bucket-1/182-jsonobject-extended/src/JsonObjExtSrc.al
+++ b/tests/bucket-1/182-jsonobject-extended/src/JsonObjExtSrc.al
@@ -1,0 +1,56 @@
+/// Helper codeunit exercising extended JsonObject methods from issue #791.
+codeunit 109000 "JOEX Src"
+{
+    // ── GetTime ────────────────────────────────────────────────────────────────
+
+    procedure GetTime(Obj: JsonObject; KeyName: Text): Time
+    begin
+        exit(Obj.GetTime(KeyName));
+    end;
+
+    // ── GetDuration ────────────────────────────────────────────────────────────
+
+    procedure GetDuration(Obj: JsonObject; KeyName: Text): Duration
+    begin
+        exit(Obj.GetDuration(KeyName));
+    end;
+
+    // ── GetOption ─────────────────────────────────────────────────────────────
+
+    procedure GetOption(Obj: JsonObject; KeyName: Text): Integer
+    begin
+        exit(Obj.GetOption(KeyName));
+    end;
+
+    // ── GetByte ───────────────────────────────────────────────────────────────
+
+    procedure GetByte(Obj: JsonObject; KeyName: Text): Byte
+    begin
+        exit(Obj.GetByte(KeyName));
+    end;
+
+    // ── GetBigInteger ─────────────────────────────────────────────────────────
+
+    procedure GetBigInteger(Obj: JsonObject; KeyName: Text): BigInteger
+    begin
+        exit(Obj.GetBigInteger(KeyName));
+    end;
+
+    // ── Values ────────────────────────────────────────────────────────────────
+
+    procedure ValuesCount(Obj: JsonObject): Integer
+    var
+        Tokens: List of [JsonToken];
+    begin
+        Tokens := Obj.Values();
+        exit(Tokens.Count());
+    end;
+
+    // ── Path ──────────────────────────────────────────────────────────────────
+
+    procedure PathRoot(Obj: JsonObject): Text
+    begin
+        exit(Obj.Path());
+    end;
+
+}

--- a/tests/bucket-1/182-jsonobject-extended/src/JsonObjExtSrc.al
+++ b/tests/bucket-1/182-jsonobject-extended/src/JsonObjExtSrc.al
@@ -1,5 +1,5 @@
 /// Helper codeunit exercising extended JsonObject methods from issue #791.
-codeunit 112000 "JOEX Src"
+codeunit 113000 "JOEX Src"
 {
     // ── GetTime ────────────────────────────────────────────────────────────────
 

--- a/tests/bucket-1/182-jsonobject-extended/test/JsonObjExtTest.al
+++ b/tests/bucket-1/182-jsonobject-extended/test/JsonObjExtTest.al
@@ -1,0 +1,145 @@
+codeunit 109001 "JOEX Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "JOEX Src";
+
+    // ── GetTime ────────────────────────────────────────────────────────────────
+
+    [Test]
+    procedure GetTime_ReturnsStoredTime()
+    var
+        Obj: JsonObject;
+    begin
+        Obj.Add('t', 120000T);
+        Assert.AreEqual(120000T, Src.GetTime(Obj, 't'), 'GetTime must return the stored Time value');
+    end;
+
+    [Test]
+    procedure GetTime_MissingKey_ThrowsError()
+    var
+        Obj: JsonObject;
+    begin
+        asserterror Src.GetTime(Obj, 'missing');
+        Assert.ExpectedError('');
+    end;
+
+    // ── GetDuration ────────────────────────────────────────────────────────────
+
+    [Test]
+    procedure GetDuration_ReturnsStoredDuration()
+    var
+        Obj: JsonObject;
+        D: Duration;
+    begin
+        D := 5000;
+        Obj.Add('d', D);
+        Assert.AreEqual(D, Src.GetDuration(Obj, 'd'), 'GetDuration must return the stored Duration value');
+    end;
+
+    [Test]
+    procedure GetDuration_MissingKey_ThrowsError()
+    var
+        Obj: JsonObject;
+    begin
+        asserterror Src.GetDuration(Obj, 'missing');
+        Assert.ExpectedError('');
+    end;
+
+    // ── GetOption ─────────────────────────────────────────────────────────────
+
+    [Test]
+    procedure GetOption_ReturnsOrdinal()
+    var
+        Obj: JsonObject;
+    begin
+        Obj.Add('opt', 2);
+        Assert.AreEqual(2, Src.GetOption(Obj, 'opt'), 'GetOption must return the integer ordinal');
+    end;
+
+    [Test]
+    procedure GetOption_MissingKey_ThrowsError()
+    var
+        Obj: JsonObject;
+    begin
+        asserterror Src.GetOption(Obj, 'missing');
+        Assert.ExpectedError('');
+    end;
+
+    // ── GetByte ───────────────────────────────────────────────────────────────
+
+    [Test]
+    procedure GetByte_ReturnsStoredValue()
+    var
+        Obj: JsonObject;
+        B: Byte;
+    begin
+        B := 200;
+        Obj.Add('b', B);
+        Assert.AreEqual(B, Src.GetByte(Obj, 'b'), 'GetByte must return the stored Byte value');
+    end;
+
+    [Test]
+    procedure GetByte_MissingKey_ThrowsError()
+    var
+        Obj: JsonObject;
+    begin
+        asserterror Src.GetByte(Obj, 'missing');
+        Assert.ExpectedError('');
+    end;
+
+    // ── GetBigInteger ─────────────────────────────────────────────────────────
+
+    [Test]
+    procedure GetBigInteger_ReturnsStoredValue()
+    var
+        Obj: JsonObject;
+        B: BigInteger;
+    begin
+        Evaluate(B, '9999999999');
+        Obj.Add('b', B);
+        Assert.AreEqual(B, Src.GetBigInteger(Obj, 'b'), 'GetBigInteger must return the stored BigInteger value');
+    end;
+
+    [Test]
+    procedure GetBigInteger_MissingKey_ThrowsError()
+    var
+        Obj: JsonObject;
+    begin
+        asserterror Src.GetBigInteger(Obj, 'missing');
+        Assert.ExpectedError('');
+    end;
+
+    // ── Values ────────────────────────────────────────────────────────────────
+
+    [Test]
+    procedure Values_EmptyObject_ReturnsZero()
+    var
+        Obj: JsonObject;
+    begin
+        Assert.AreEqual(0, Src.ValuesCount(Obj), 'Values on empty object must return 0');
+    end;
+
+    [Test]
+    procedure Values_TwoEntries_ReturnsTwo()
+    var
+        Obj: JsonObject;
+    begin
+        Obj.Add('a', 1);
+        Obj.Add('b', 2);
+        Assert.AreEqual(2, Src.ValuesCount(Obj), 'Values must return 2 tokens for object with 2 entries');
+    end;
+
+    // ── Path ──────────────────────────────────────────────────────────────────
+
+    [Test]
+    procedure Path_RootObject_ReturnsDollar()
+    var
+        Obj: JsonObject;
+    begin
+        Assert.AreEqual('$', Src.PathRoot(Obj), 'Path() on root object must return "$"');
+    end;
+
+}

--- a/tests/bucket-1/182-jsonobject-extended/test/JsonObjExtTest.al
+++ b/tests/bucket-1/182-jsonobject-extended/test/JsonObjExtTest.al
@@ -1,4 +1,4 @@
-codeunit 109001 "JOEX Test"
+codeunit 112001 "JOEX Test"
 {
     Subtype = Test;
 

--- a/tests/bucket-1/182-jsonobject-extended/test/JsonObjExtTest.al
+++ b/tests/bucket-1/182-jsonobject-extended/test/JsonObjExtTest.al
@@ -1,4 +1,4 @@
-codeunit 112001 "JOEX Test"
+codeunit 113001 "JOEX Test"
 {
     Subtype = Test;
 

--- a/tests/bucket-1/182-jsonobject-extended/test/JsonObjExtTest.al
+++ b/tests/bucket-1/182-jsonobject-extended/test/JsonObjExtTest.al
@@ -142,4 +142,28 @@ codeunit 109001 "JOEX Test"
         Assert.AreEqual('$', Src.PathRoot(Obj), 'Path() on root object must return "$"');
     end;
 
+    // ── WriteToYaml ───────────────────────────────────────────────────────────
+
+    [Test]
+    procedure WriteToYaml_ProducesNonEmptyOutput()
+    var
+        Obj: JsonObject;
+        Result: Text;
+    begin
+        Obj.Add('k', 'v');
+        Result := Src.WriteToYamlText(Obj);
+        Assert.IsTrue(Result <> '', 'WriteToYaml must produce non-empty output');
+    end;
+
+    // ── ReadFromYaml ──────────────────────────────────────────────────────────
+
+    [Test]
+    procedure ReadFromYaml_JsonCompatibleInput_ParsesKey()
+    var
+        Result: Text;
+    begin
+        Result := Src.ReadFromYamlGetText('{"key": "value"}', 'key');
+        Assert.AreEqual('value', Result, 'ReadFromYaml must parse JSON-compatible YAML input');
+    end;
+
 }


### PR DESCRIPTION
Closes #791

## What

Adds `tests/bucket-1/182-jsonobject-extended/` — 15 tests covering all 9 `JsonObject` methods from issue #791.

**7 typed getters — work natively via BC runtime** (no rewriter changes needed):

| Method | Tests |
|---|---|
| `GetTime(key)` | round-trip 120000T; missing-key throws |
| `GetDuration(key)` | round-trip 5000ms; missing-key throws |
| `GetOption(key)` | returns ordinal 2; missing-key throws |
| `GetByte(key)` | round-trip 200; missing-key throws |
| `GetBigInteger(key)` | round-trip 9999999999 (via Evaluate); missing-key throws |
| `Values()` | empty → 0, two entries → 2 |
| `Path()` | root object → `"$"` |

**2 YAML methods — stub via JSON round-trip** (rewriter + MockJsonHelper):

| Method | Implementation |
|---|---|
| `ReadFromYaml(Text)` | `ALReadFromYaml` intercepted → `MockJsonHelper.ReadFromYaml` → delegates to `ReadFrom` (JSON parse) |
| `WriteToYaml(var Text)` | `ALWriteToYaml` intercepted → `MockJsonHelper.WriteToYaml` → delegates to `WriteTo` (JSON serialization) |

YamlDotNet is not available in the runner — JSON is valid YAML so the stub is correct for the common test case.

## Coverage update

`docs/coverage.yaml`: all 9 methods marked `covered`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)