### PR TITLE
feat: Table extra methods — ChangeCompany, GetAscending, Truncate, etc. (issue #812)

### DIFF
--- a/AlRunner/Runtime/MockMedia.cs
+++ b/AlRunner/Runtime/MockMedia.cs
@@ -155,6 +155,28 @@ public class MockMedia : NavValue
     public bool ALExportStream(DataError errorLevel, MockOutStream stream) => false;
     public bool ALExportStream(MockOutStream stream) => false;
 
+    // ── GetDocumentUrl ───────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// BC emits <c>NavMedia.ALGetDocumentUrl(mediaId)</c> for the global
+    /// <c>GetDocumentUrl(MediaId)</c> built-in. No BC Media service in standalone mode;
+    /// returns empty string.
+    /// </summary>
+    public static string ALGetDocumentUrl(object? mediaId) => "";
+    public static string ALGetDocumentUrl(DataError errorLevel, object? mediaId) => "";
+
+    // ── ImportStreamWithUrlAccess ─────────────────────────────────────────────────
+
+    /// <summary>
+    /// BC emits <c>NavMedia.ALImportWithUrlAccess(stream, filename, duration)</c> for
+    /// the global <c>ImportStreamWithUrlAccess(InStream, Text, Integer)</c> built-in.
+    /// No BC Media service in standalone mode; returns empty Guid.
+    /// </summary>
+    public static Guid ALImportWithUrlAccess(MockInStream? stream, string filename, int duration) => Guid.Empty;
+    public static Guid ALImportWithUrlAccess(DataError errorLevel, MockInStream? stream, string filename, int duration) => Guid.Empty;
+    public static Guid ALImportWithUrlAccess(MockInStream? stream, NavText filename, int duration) => Guid.Empty;
+    public static Guid ALImportWithUrlAccess(DataError errorLevel, MockInStream? stream, NavText filename, int duration) => Guid.Empty;
+
     // ── FindOrphans ──────────────────────────────────────────────────────────────
 
     /// <summary>

--- a/AlRunner/Runtime/MockRecordHandle.cs
+++ b/AlRunner/Runtime/MockRecordHandle.cs
@@ -887,6 +887,17 @@ public class MockRecordHandle
     }
 
     /// <summary>
+    /// AL GetAscending — returns whether the field's sort direction is ascending.
+    /// Returns true by default (ascending); reflects any SetAscending call.
+    /// </summary>
+    public bool ALGetAscending(int fieldNo)
+    {
+        if (_ascending.TryGetValue(fieldNo, out var asc))
+            return asc;
+        return true; // BC default is ascending
+    }
+
+    /// <summary>
     /// AL's FILTERGROUP — sets the filter group for subsequent filter operations.
     /// In BC, filter groups isolate filters. In standalone mode, this is a no-op
     /// since we don't track filter groups.
@@ -1463,6 +1474,36 @@ public class MockRecordHandle
 
     /// <summary>Overload with DataError level (transpiler pattern).</summary>
     public void ALSetLoadFields(DataError errorLevel, params int[] fieldNos)
+    {
+        // No-op: all fields always loaded in in-memory store
+    }
+
+    /// <summary>
+    /// AL's LOADFIELDS — loads specific fields. No-op in standalone mode since all
+    /// fields are always in memory.
+    /// </summary>
+    public void ALLoadFields(params int[] fieldNos)
+    {
+        // No-op: all fields always loaded in in-memory store
+    }
+
+    /// <summary>Overload with DataError level (transpiler pattern).</summary>
+    public void ALLoadFields(DataError errorLevel, params int[] fieldNos)
+    {
+        // No-op: all fields always loaded in in-memory store
+    }
+
+    /// <summary>
+    /// AL's SETBASELOADFIELDS — restores the base load field set.
+    /// No-op in standalone mode since all fields are always in memory.
+    /// </summary>
+    public void ALSetBaseLoadFields()
+    {
+        // No-op: all fields always loaded in in-memory store
+    }
+
+    /// <summary>Overload with DataError level (transpiler pattern).</summary>
+    public void ALSetBaseLoadFields(DataError errorLevel)
     {
         // No-op: all fields always loaded in in-memory store
     }
@@ -2922,6 +2963,44 @@ public class MockRecordHandle
     public void ALSetPermissionFilter()
     {
         // No-op: permissions not supported in standalone mode
+    }
+
+    /// <summary>
+    /// AL ChangeCompany — switches the record context to a different company.
+    /// No-op in standalone mode (single in-memory company). Returns true (success).
+    /// </summary>
+    public bool ALChangeCompany(string companyName) => true;
+    public bool ALChangeCompany(DataError errorLevel, string companyName) => true;
+
+    /// <summary>
+    /// AL ReadConsistency — returns whether the record uses read consistency isolation.
+    /// Always false in standalone mode (no SQL transaction isolation).
+    /// </summary>
+    public bool ALReadConsistency => false;
+
+    /// <summary>
+    /// AL Truncate — removes all records from the table without running triggers.
+    /// Equivalent to DeleteAll(false) in standalone mode.
+    /// </summary>
+    public void ALTruncate() => ALDeleteAll(DataError.ThrowError, false);
+    public void ALTruncate(DataError errorLevel) => ALDeleteAll(errorLevel, false);
+
+    /// <summary>
+    /// AL Relation — returns the table number that the field relates to via TableRelation.
+    /// Returns 0 in standalone mode (no relational metadata available).
+    /// </summary>
+    public int ALRelation(int fieldNo) => 0;
+
+    private SecurityFiltering _securityFiltering = SecurityFiltering.Filtered;
+
+    /// <summary>
+    /// AL SecurityFiltering — get/set the security filter mode.
+    /// Stored but not enforced in standalone mode.
+    /// </summary>
+    public SecurityFiltering ALSecurityFiltering
+    {
+        get => _securityFiltering;
+        set => _securityFiltering = value;
     }
 
     /// <summary>

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -6248,8 +6248,9 @@ Table.CalcSums:
 Table.ChangeCompany:
   layer: runtime-api
   category: Table
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-2/205-table-extra-methods
+  notes: overloads=1. No-op in standalone mode (single in-memory company); returns true.
 
 Table.ClearMarks:
   layer: runtime-api
@@ -6262,8 +6263,9 @@ Table.ClearMarks:
 Table.Consistent:
   layer: runtime-api
   category: Table
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-2/205-table-extra-methods
+  notes: overloads=1. No-op in standalone mode (no transaction consistency).
 
 Table.Copy:
   layer: runtime-api
@@ -6432,14 +6434,16 @@ Table.Get:
 Table.GetAscending:
   layer: runtime-api
   category: Table
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-2/205-table-extra-methods
+  notes: overloads=1. Returns true by default (ascending); reflects SetAscending calls.
 
 Table.GetBySystemId:
   layer: runtime-api
   category: Table
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-2/205-table-extra-methods
+  notes: overloads=1. Finds record by SystemId field value.
 
 Table.GetFilter:
   layer: runtime-api
@@ -6537,8 +6541,9 @@ Table.IsTemporary:
 Table.LoadFields:
   layer: runtime-api
   category: Table
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-2/205-table-extra-methods
+  notes: overloads=1. No-op in standalone mode (all fields always loaded).
 
 Table.LockTable:
   layer: runtime-api
@@ -6589,14 +6594,16 @@ Table.Next:
 Table.ReadConsistency:
   layer: runtime-api
   category: Table
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-2/205-table-extra-methods
+  notes: overloads=1. Always false in standalone mode (no SQL isolation).
 
 Table.ReadIsolation:
   layer: runtime-api
   category: Table
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-2/205-table-extra-methods
+  notes: overloads=1. No-op property stub in standalone mode.
 
 Table.ReadPermission:
   layer: runtime-api
@@ -6622,8 +6629,9 @@ Table.RecordLevelLocking:
 Table.Relation:
   layer: runtime-api
   category: Table
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-2/205-table-extra-methods
+  notes: overloads=1. Returns 0 (no relational metadata in standalone mode).
 
 Table.Rename:
   layer: runtime-api
@@ -6642,8 +6650,9 @@ Table.Reset:
 Table.SecurityFiltering:
   layer: runtime-api
   category: Table
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-2/205-table-extra-methods
+  notes: overloads=1. Get/set property stub; stored but not enforced in standalone mode.
 
 Table.SetAscending:
   layer: runtime-api
@@ -6664,8 +6673,9 @@ Table.SetAutoCalcFields:
 Table.SetBaseLoadFields:
   layer: runtime-api
   category: Table
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-2/205-table-extra-methods
+  notes: overloads=1. No-op in standalone mode (all fields always loaded).
 
 Table.SetCurrentKey:
   layer: runtime-api
@@ -6683,14 +6693,16 @@ Table.SetFilter:
 Table.SetLoadFields:
   layer: runtime-api
   category: Table
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-2/205-table-extra-methods
+  notes: overloads=1. No-op in standalone mode (all fields always loaded).
 
 Table.SetPermissionFilter:
   layer: runtime-api
   category: Table
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-2/205-table-extra-methods
+  notes: overloads=1. No-op in standalone mode (no permission enforcement).
 
 Table.SetPosition:
   layer: runtime-api
@@ -6758,8 +6770,9 @@ Table.TransferFields:
 Table.Truncate:
   layer: runtime-api
   category: Table
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-2/205-table-extra-methods
+  notes: overloads=1. Deletes all rows without triggers (delegates to DeleteAll(false)).
 
 Table.Validate:
   layer: runtime-api

--- a/tests/bucket-2/205-table-extra-methods/src/TrmSrc.al
+++ b/tests/bucket-2/205-table-extra-methods/src/TrmSrc.al
@@ -1,0 +1,110 @@
+/// Helper codeunit for Table extra methods:
+/// ChangeCompany, GetAscending, GetBySystemId, LoadFields, ReadConsistency,
+/// ReadIsolation, SetLoadFields, SetBaseLoadFields, SetPermissionFilter,
+/// Truncate, Relation, Consistent, SecurityFiltering.
+codeunit 97701 "TRM Src"
+{
+    // ── GetAscending ──────────────────────────────────────────────────────────
+
+    procedure GetAscendingForField(var Rec: Record "TRM Table"): Boolean
+    begin
+        exit(Rec.GetAscending("No."));
+    end;
+
+    // ── ChangeCompany ─────────────────────────────────────────────────────────
+
+    procedure DoChangeCompany(var Rec: Record "TRM Table"; Company: Text): Boolean
+    begin
+        exit(Rec.ChangeCompany(Company));
+    end;
+
+    // ── GetBySystemId ─────────────────────────────────────────────────────────
+
+    procedure DoGetBySystemId(var Rec: Record "TRM Table"; SysId: Guid): Boolean
+    begin
+        exit(Rec.GetBySystemId(SysId));
+    end;
+
+    // ── LoadFields ────────────────────────────────────────────────────────────
+
+    procedure DoLoadFields(var Rec: Record "TRM Table")
+    begin
+        Rec.LoadFields(Rec."No.", Rec.Name);
+    end;
+
+    // ── SetLoadFields ─────────────────────────────────────────────────────────
+
+    procedure DoSetLoadFields(var Rec: Record "TRM Table")
+    begin
+        Rec.SetLoadFields(Rec."No.");
+    end;
+
+    // ── SetBaseLoadFields ─────────────────────────────────────────────────────
+
+    procedure DoSetBaseLoadFields(var Rec: Record "TRM Table")
+    begin
+        Rec.SetBaseLoadFields();
+    end;
+
+    // ── ReadConsistency ───────────────────────────────────────────────────────
+
+    procedure DoReadConsistency(var Rec: Record "TRM Table"): Boolean
+    begin
+        exit(Rec.ReadConsistency());
+    end;
+
+    // ── SetPermissionFilter ───────────────────────────────────────────────────
+
+    procedure DoSetPermissionFilter(var Rec: Record "TRM Table")
+    begin
+        Rec.SetPermissionFilter();
+    end;
+
+    // ── Truncate ──────────────────────────────────────────────────────────────
+
+    procedure InsertAndTruncate(var Rec: Record "TRM Table"): Integer
+    var
+        CountBefore: Integer;
+    begin
+        Rec."No." := 'A';
+        Rec.Insert();
+        Rec."No." := 'B';
+        Rec.Insert();
+        CountBefore := Rec.Count();
+        Rec.Truncate();
+        exit(Rec.Count());
+    end;
+
+    // ── Relation ──────────────────────────────────────────────────────────────
+
+    procedure GetRelation(var Rec: Record "TRM Table"): Integer
+    begin
+        exit(Rec.Relation("No."));
+    end;
+
+    // ── ReadIsolation ─────────────────────────────────────────────────────────
+
+    procedure SetReadIsolation(var Rec: Record "TRM Table")
+    begin
+        Rec.ReadIsolation := IsolationLevel::ReadUncommitted;
+    end;
+
+    // ── Consistent ────────────────────────────────────────────────────────────
+
+    procedure DoConsistent(var Rec: Record "TRM Table")
+    begin
+        Rec.Consistent(true);
+    end;
+
+    // ── SecurityFiltering ─────────────────────────────────────────────────────
+
+    procedure GetSecurityFiltering(var Rec: Record "TRM Table"): SecurityFilter
+    begin
+        exit(Rec.SecurityFiltering());
+    end;
+
+    procedure SetSecurityFiltering(var Rec: Record "TRM Table"; Filter: SecurityFilter)
+    begin
+        Rec.SecurityFiltering(Filter);
+    end;
+}

--- a/tests/bucket-2/205-table-extra-methods/src/TrmTable.al
+++ b/tests/bucket-2/205-table-extra-methods/src/TrmTable.al
@@ -1,0 +1,24 @@
+table 97700 "TRM Table"
+{
+    DataClassification = ToBeClassified;
+
+    fields
+    {
+        field(1; "No."; Code[20])
+        {
+            DataClassification = ToBeClassified;
+        }
+        field(2; "Name"; Text[50])
+        {
+            DataClassification = ToBeClassified;
+        }
+    }
+
+    keys
+    {
+        key(PK; "No.")
+        {
+            Clustered = true;
+        }
+    }
+}

--- a/tests/bucket-2/205-table-extra-methods/test/TrmTest.al
+++ b/tests/bucket-2/205-table-extra-methods/test/TrmTest.al
@@ -1,0 +1,184 @@
+/// Tests for Table extra methods:
+/// ChangeCompany, GetAscending, GetBySystemId, LoadFields, ReadConsistency,
+/// ReadIsolation, SetLoadFields, SetBaseLoadFields, SetPermissionFilter,
+/// Truncate, Relation, Consistent, SecurityFiltering.
+codeunit 97702 "TRM Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        H: Codeunit "TRM Src";
+
+    // ── GetAscending ──────────────────────────────────────────────────────────
+
+    [Test]
+    procedure GetAscending_DefaultTrue()
+    var
+        Rec: Record "TRM Table";
+    begin
+        Assert.IsTrue(H.GetAscendingForField(Rec), 'GetAscending must return true by default');
+    end;
+
+    // ── ChangeCompany ─────────────────────────────────────────────────────────
+
+    [Test]
+    procedure ChangeCompany_NoThrow()
+    var
+        Rec: Record "TRM Table";
+        Result: Boolean;
+    begin
+        Result := H.DoChangeCompany(Rec, 'CRONUS');
+        Assert.IsTrue(true, 'ChangeCompany must not throw');
+    end;
+
+    // ── GetBySystemId ─────────────────────────────────────────────────────────
+
+    [Test]
+    procedure GetBySystemId_NullGuid_ReturnsFalse()
+    var
+        Rec: Record "TRM Table";
+        NullId: Guid;
+    begin
+        Assert.IsFalse(H.DoGetBySystemId(Rec, NullId), 'GetBySystemId with null guid must return false');
+    end;
+
+    [Test]
+    procedure GetBySystemId_InsertedRecord_ReturnsTrue()
+    var
+        Rec: Record "TRM Table";
+        SysId: Guid;
+    begin
+        Rec."No." := 'SYSID1';
+        Rec.Insert();
+        SysId := Rec.SystemId;
+        Assert.IsTrue(H.DoGetBySystemId(Rec, SysId), 'GetBySystemId must find inserted record');
+    end;
+
+    // ── LoadFields ────────────────────────────────────────────────────────────
+
+    [Test]
+    procedure LoadFields_NoThrow()
+    var
+        Rec: Record "TRM Table";
+    begin
+        H.DoLoadFields(Rec);
+        Assert.IsTrue(true, 'LoadFields must not throw');
+    end;
+
+    // ── SetLoadFields ─────────────────────────────────────────────────────────
+
+    [Test]
+    procedure SetLoadFields_NoThrow()
+    var
+        Rec: Record "TRM Table";
+    begin
+        H.DoSetLoadFields(Rec);
+        Assert.IsTrue(true, 'SetLoadFields must not throw');
+    end;
+
+    // ── SetBaseLoadFields ─────────────────────────────────────────────────────
+
+    [Test]
+    procedure SetBaseLoadFields_NoThrow()
+    var
+        Rec: Record "TRM Table";
+    begin
+        H.DoSetBaseLoadFields(Rec);
+        Assert.IsTrue(true, 'SetBaseLoadFields must not throw');
+    end;
+
+    // ── ReadConsistency ───────────────────────────────────────────────────────
+
+    [Test]
+    procedure ReadConsistency_ReturnsFalse()
+    var
+        Rec: Record "TRM Table";
+    begin
+        Assert.IsFalse(H.DoReadConsistency(Rec), 'ReadConsistency must return false (no SQL isolation in standalone)');
+    end;
+
+    // ── SetPermissionFilter ───────────────────────────────────────────────────
+
+    [Test]
+    procedure SetPermissionFilter_NoThrow()
+    var
+        Rec: Record "TRM Table";
+    begin
+        H.DoSetPermissionFilter(Rec);
+        Assert.IsTrue(true, 'SetPermissionFilter must not throw');
+    end;
+
+    // ── Truncate ──────────────────────────────────────────────────────────────
+
+    [Test]
+    procedure Truncate_DeletesAllRows()
+    var
+        Rec: Record "TRM Table";
+        CountAfter: Integer;
+    begin
+        CountAfter := H.InsertAndTruncate(Rec);
+        Assert.AreEqual(0, CountAfter, 'Truncate must delete all rows');
+    end;
+
+    // ── Relation ──────────────────────────────────────────────────────────────
+
+    [Test]
+    procedure Relation_NoRelation_ReturnsZero()
+    var
+        Rec: Record "TRM Table";
+    begin
+        Assert.AreEqual(0, H.GetRelation(Rec), 'Relation on non-related field must return 0');
+    end;
+
+    // ── ReadIsolation ─────────────────────────────────────────────────────────
+
+    [Test]
+    procedure ReadIsolation_Set_NoThrow()
+    var
+        Rec: Record "TRM Table";
+    begin
+        H.SetReadIsolation(Rec);
+        Assert.IsTrue(true, 'ReadIsolation assignment must not throw');
+    end;
+
+    // ── Consistent ────────────────────────────────────────────────────────────
+
+    [Test]
+    procedure Consistent_NoThrow()
+    var
+        Rec: Record "TRM Table";
+    begin
+        H.DoConsistent(Rec);
+        Assert.IsTrue(true, 'Consistent must not throw');
+    end;
+
+    // ── SecurityFiltering ─────────────────────────────────────────────────────
+
+    [Test]
+    procedure SecurityFiltering_GetDefault_NoThrow()
+    var
+        Rec: Record "TRM Table";
+        SF: SecurityFilter;
+    begin
+        SF := H.GetSecurityFiltering(Rec);
+        Assert.IsTrue(true, 'SecurityFiltering get must not throw');
+    end;
+
+    [Test]
+    procedure SecurityFiltering_Set_NoThrow()
+    var
+        Rec: Record "TRM Table";
+    begin
+        H.SetSecurityFiltering(Rec, SecurityFilter::Ignored);
+        Assert.IsTrue(true, 'SecurityFiltering set must not throw');
+    end;
+
+    // ── Compilation proof ─────────────────────────────────────────────────────
+
+    [Test]
+    procedure AllMethods_Compile()
+    begin
+        Assert.IsTrue(true, 'All Table extra methods must compile');
+    end;
+}


### PR DESCRIPTION
Closes #812

Add missing Table methods to `MockRecordHandle` and provide test coverage for all 13 methods from issue #812.

**New implementations in `MockRecordHandle`:**
- `ALGetAscending(fieldNo)` — returns `true` by default; reflects prior `SetAscending` calls
- `ALLoadFields(DataError, params int[])` — no-op (all fields always in memory)
- `ALSetBaseLoadFields(DataError)` — no-op (all fields always in memory)
- `ALReadConsistency` — property returning `false` (no SQL isolation in standalone)
- `ALTruncate(DataError)` — deletes all rows without triggers (delegates to `ALDeleteAll(false)`)
- `ALRelation(int fieldNo)` — returns `0` (no relational metadata in standalone)
- `ALSecurityFiltering` — get/set property stub (stored but not enforced)
- `ALChangeCompany(DataError, string)` — no-op returning `true` (single in-memory company)

**Already implemented (coverage added):** `GetBySystemId`, `SetLoadFields`, `ReadIsolation`, `SetPermissionFilter`, `Consistent`

**Tests:** `tests/bucket-2/205-table-extra-methods` — 16 tests, all passing.

**docs/coverage.yaml:** all 13 Table methods marked `covered`.