### PR TITLE
feat: Record.Init() InitValue test suite + remove stale limitation

### DIFF
--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -3103,9 +3103,10 @@ public void ClearApplicationMemberVariables()
                     .WithTriviaFrom(visited);
             }
 
-            // NavMedia.ALGetDocumentUrl(mediaId) -> AlCompat.GetDocumentUrl(mediaId)
-            // No BC Media service in standalone mode — return empty string stub.
-            if (exprText == "NavMedia" && methodName == "ALGetDocumentUrl")
+            // MockMedia.ALGetDocumentUrl(mediaId) -> AlCompat.GetDocumentUrl(mediaId)
+            // NavMedia is renamed to MockMedia by VisitIdentifierName before this rule runs.
+            // No BC Media service in standalone mode — return empty Guid stub.
+            if (exprText == "MockMedia" && methodName == "ALGetDocumentUrl")
             {
                 return visited.WithExpression(
                     SyntaxFactory.MemberAccessExpression(
@@ -3114,9 +3115,10 @@ public void ClearApplicationMemberVariables()
                         SyntaxFactory.IdentifierName("GetDocumentUrl")));
             }
 
-            // NavMedia.ALImportWithUrlAccess(stream, filename, duration) -> AlCompat.ImportStreamWithUrlAccess(stream, filename, duration)
-            // No BC Media service in standalone mode — return empty string stub.
-            if (exprText == "NavMedia" && methodName == "ALImportWithUrlAccess")
+            // MockMedia.ALImportWithUrlAccess(stream, filename, duration) -> AlCompat.ImportStreamWithUrlAccess(stream, filename, duration)
+            // NavMedia is renamed to MockMedia by VisitIdentifierName before this rule runs.
+            // No BC Media service in standalone mode — return Guid.Empty stub.
+            if (exprText == "MockMedia" && methodName == "ALImportWithUrlAccess")
             {
                 return visited.WithExpression(
                     SyntaxFactory.MemberAccessExpression(

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -6510,6 +6510,7 @@ Table.Init:
   tests:
     - tests/bucket-1/47-initvalue
     - tests/bucket-1/56-init-reset
+    - tests/bucket-1/197-record-init-value
   notes: overloads=1; clears non-PK fields to defaults, preserves PK, applies InitValue
 
 Table.Insert:

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -122,7 +122,6 @@ the exact value will see different results.
 | `IsSessionActive(id)` | True while session runs | Always `false` |
 | `GuiAllowed()` | False in background sessions | `false` |
 | `GetFilter(field)` | Serialised filter expression | Returns serialised filter expression (functional) |
-| Field `InitValue` | Applied on `Init()` | Not applied — type default only |
 | `FieldRef.Caption` / `.Name` | Field metadata from schema | Real values when parsed from AL source; `"FieldNN"` stub otherwise |
 | `Commit()` | Commits current transaction | No-op |
 

--- a/tests/bucket-1/197-record-init-value/src/InitValueSrc.al
+++ b/tests/bucket-1/197-record-init-value/src/InitValueSrc.al
@@ -1,0 +1,68 @@
+/// Source codeunit exercising Record.Init() with field InitValue declarations.
+codeunit 100400 "InitValue Src"
+{
+    /// Call Rec.Init() and return the Priority field (InitValue = 5).
+    procedure GetPriorityAfterInit(): Integer
+    var
+        Rec: Record "IV Test Table";
+    begin
+        Rec.Init();
+        exit(Rec.Priority);
+    end;
+
+    /// Call Rec.Init() and return the IsActive field (InitValue = true).
+    procedure GetIsActiveAfterInit(): Boolean
+    var
+        Rec: Record "IV Test Table";
+    begin
+        Rec.Init();
+        exit(Rec.IsActive);
+    end;
+
+    /// Call Rec.Init() and return the Score field (InitValue = 9.99).
+    procedure GetScoreAfterInit(): Decimal
+    var
+        Rec: Record "IV Test Table";
+    begin
+        Rec.Init();
+        exit(Rec.Score);
+    end;
+
+    /// Call Rec.Init() on a field with no InitValue; must return type default.
+    procedure GetNoAfterInit(): Code[20]
+    var
+        Rec: Record "IV Test Table";
+    begin
+        Rec.Init();
+        exit(Rec."No.");
+    end;
+
+    /// Call Rec.Init() on a Text field with no InitValue; must return empty.
+    procedure GetDescAfterInit(): Text[100]
+    var
+        Rec: Record "IV Test Table";
+    begin
+        Rec.Init();
+        exit(Rec.Description);
+    end;
+
+    /// Set Priority to a non-default value, call Init(), verify InitValue is restored.
+    procedure GetPriorityAfterReinit(): Integer
+    var
+        Rec: Record "IV Test Table";
+    begin
+        Rec.Priority := 99;
+        Rec.Init();
+        exit(Rec.Priority);
+    end;
+
+    /// PK field must be preserved across Init().
+    procedure GetNoPkPreserved(PkVal: Code[20]): Code[20]
+    var
+        Rec: Record "IV Test Table";
+    begin
+        Rec."No." := PkVal;
+        Rec.Init();
+        exit(Rec."No.");
+    end;
+}

--- a/tests/bucket-1/197-record-init-value/src/InitValueTable.al
+++ b/tests/bucket-1/197-record-init-value/src/InitValueTable.al
@@ -1,0 +1,25 @@
+/// Table with several field types and InitValue declarations for Init() tests.
+table 100400 "IV Test Table"
+{
+    fields
+    {
+        field(1; "No."; Code[20]) { }
+        field(2; Priority; Integer)
+        {
+            InitValue = 5;
+        }
+        field(3; IsActive; Boolean)
+        {
+            InitValue = true;
+        }
+        field(4; Score; Decimal)
+        {
+            InitValue = 9.99;
+        }
+        field(5; Description; Text[100]) { }
+    }
+    keys
+    {
+        key(PK; "No.") { Clustered = true; }
+    }
+}

--- a/tests/bucket-1/197-record-init-value/test/InitValueTest.al
+++ b/tests/bucket-1/197-record-init-value/test/InitValueTest.al
@@ -1,0 +1,89 @@
+/// Tests for Record.Init() applying field InitValue declarations.
+/// Covers: Integer InitValue, Boolean InitValue, Decimal InitValue,
+/// fields without InitValue (type default), PK preservation, and reinit.
+codeunit 100401 "InitValue Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "InitValue Src";
+
+    // ── InitValue applied ─────────────────────────────────────────────────────
+
+    [Test]
+    procedure Init_IntegerInitValue_AppliedCorrectly()
+    begin
+        // [GIVEN] Priority has InitValue = 5
+        // [WHEN] Rec.Init() is called
+        // [THEN] Priority = 5 (not 0)
+        Assert.AreEqual(5, Src.GetPriorityAfterInit(),
+            'Priority must equal InitValue = 5 after Init()');
+    end;
+
+    [Test]
+    procedure Init_BooleanInitValue_AppliedCorrectly()
+    begin
+        // [GIVEN] IsActive has InitValue = true
+        // [WHEN] Rec.Init() is called
+        // [THEN] IsActive = true (not false)
+        Assert.IsTrue(Src.GetIsActiveAfterInit(),
+            'IsActive must equal InitValue = true after Init()');
+    end;
+
+    [Test]
+    procedure Init_DecimalInitValue_AppliedCorrectly()
+    begin
+        // [GIVEN] Score has InitValue = 9.99
+        // [WHEN] Rec.Init() is called
+        // [THEN] Score = 9.99 (not 0)
+        Assert.AreEqual(9.99, Src.GetScoreAfterInit(),
+            'Score must equal InitValue = 9.99 after Init()');
+    end;
+
+    // ── No InitValue → type defaults ──────────────────────────────────────────
+
+    [Test]
+    procedure Init_CodeFieldNoInitValue_EmptyString()
+    begin
+        // [GIVEN] "No." has no InitValue (Code[20])
+        // [WHEN] Rec.Init() is called on a fresh record
+        // [THEN] "No." = '' (type default for Code)
+        Assert.AreEqual('', Src.GetNoAfterInit(),
+            'Code field with no InitValue must be empty after Init()');
+    end;
+
+    [Test]
+    procedure Init_TextFieldNoInitValue_EmptyString()
+    begin
+        // [GIVEN] Description has no InitValue (Text[100])
+        // [WHEN] Rec.Init() is called
+        // [THEN] Description = '' (type default for Text)
+        Assert.AreEqual('', Src.GetDescAfterInit(),
+            'Text field with no InitValue must be empty after Init()');
+    end;
+
+    // ── Reinit overwrites previous value ─────────────────────────────────────
+
+    [Test]
+    procedure Init_OverwritesPreviousValue_WithInitValue()
+    begin
+        // [GIVEN] Priority was set to 99
+        // [WHEN] Rec.Init() is called
+        // [THEN] Priority is reset to InitValue = 5 (not 99)
+        Assert.AreEqual(5, Src.GetPriorityAfterReinit(),
+            'Priority must be reset to InitValue = 5 when Init() is called after assigning 99');
+    end;
+
+    // ── PK field preserved ────────────────────────────────────────────────────
+
+    [Test]
+    procedure Init_PreservesPKField()
+    begin
+        // [GIVEN] "No." (PK) was set to 'TEST001'
+        // [WHEN] Rec.Init() is called
+        // [THEN] "No." is still 'TEST001' — PK fields survive Init()
+        Assert.AreEqual('TEST001', Src.GetNoPkPreserved('TEST001'),
+            'PK field "No." must be preserved across Init()');
+    end;
+}


### PR DESCRIPTION
Closes #819

## Summary

- `TableInitValueRegistry` + `MockRecordHandle.ALInit()` already apply `InitValue` on `Init()` — no runtime changes were needed
- Added `tests/bucket-1/197-record-init-value` with 7 dedicated tests:
  - Integer/Boolean/Decimal `InitValue` applied after `Init()`
  - Code/Text fields without `InitValue` stay at type default (`''`)
  - `Init()` overwrites previous field value with `InitValue`
  - PK fields preserved across `Init()`
- Removed stale _"Field `InitValue` not applied — type default only"_ row from `docs/limitations.md`
- **Bonus fix**: corrected `RoslynRewriter` rules for `MockMedia.ALGetDocumentUrl` and `MockMedia.ALImportWithUrlAccess` — `VisitIdentifierName` renames `NavMedia→MockMedia` before `VisitInvocationExpression` runs, so the receiver check must match `"MockMedia"` not `"NavMedia"` (was causing `CS0117` in bucket-1 regression)

## Test plan

- [x] `tests/bucket-1/197-record-init-value` — 7 tests, all passing
- [x] Bucket-1 regression: 1222 passed, 2 pre-existing DT2Time timezone failures (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)