### PR TITLE
feat: report dataitem triggers — OnPreDataItem/OnAfterGetRecord/OnPostDataItem execute on Run() (#833)

### DIFF
--- a/AlRunner/Runtime/MockMedia.cs
+++ b/AlRunner/Runtime/MockMedia.cs
@@ -165,18 +165,6 @@ public class MockMedia : NavValue
     public static string ALGetDocumentUrl(object? mediaId) => "";
     public static string ALGetDocumentUrl(DataError errorLevel, object? mediaId) => "";
 
-    // ── ImportStreamWithUrlAccess ─────────────────────────────────────────────────
-
-    /// <summary>
-    /// BC emits <c>NavMedia.ALImportWithUrlAccess(stream, filename, duration)</c> for
-    /// the global <c>ImportStreamWithUrlAccess(InStream, Text, Integer)</c> built-in.
-    /// No BC Media service in standalone mode; returns empty Guid.
-    /// </summary>
-    public static Guid ALImportWithUrlAccess(MockInStream? stream, string filename, int duration) => Guid.Empty;
-    public static Guid ALImportWithUrlAccess(DataError errorLevel, MockInStream? stream, string filename, int duration) => Guid.Empty;
-    public static Guid ALImportWithUrlAccess(MockInStream? stream, NavText filename, int duration) => Guid.Empty;
-    public static Guid ALImportWithUrlAccess(DataError errorLevel, MockInStream? stream, NavText filename, int duration) => Guid.Empty;
-
     // ── FindOrphans ──────────────────────────────────────────────────────────────
 
     /// <summary>

--- a/AlRunner/Runtime/MockReportHandle.cs
+++ b/AlRunner/Runtime/MockReportHandle.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using Microsoft.Dynamics.Nav.Runtime;
+using Microsoft.Dynamics.Nav.Types;
 
 namespace AlRunner.Runtime;
 
@@ -69,7 +70,8 @@ public class MockReportHandle
     }
 
     /// <summary>
-    /// Executes the report lifecycle: OnPreReport → (data iteration) → OnPostReport.
+    /// Executes the report lifecycle:
+    /// OnPreReport → for each data-item: OnPreDataItem → [OnAfterGetRecord per row] → OnPostDataItem → OnPostReport.
     /// The BC service tier normally orchestrates this; we replicate it here since
     /// the base class Run() override is stripped by the rewriter.
     /// </summary>
@@ -78,9 +80,49 @@ public class MockReportHandle
         var reportType = report.GetType();
 
         InvokeTrigger(report, reportType, "OnPreReport");
-        // Data-item iteration is not yet implemented (architectural gap).
-        // OnPreReport and OnPostReport are called unconditionally.
+        ExecuteDataItems(report, reportType);
         InvokeTrigger(report, reportType, "OnPostReport");
+    }
+
+    /// <summary>
+    /// Discovers all MockRecordHandle fields in the report class (each represents
+    /// a data-item), resolves their table IDs via <see cref="TableFieldRegistry"/>,
+    /// and runs the Pre/AfterGetRecord/Post trigger sequence for each one.
+    /// </summary>
+    private static void ExecuteDataItems(object report, Type reportType)
+    {
+        var dataItemFields = reportType
+            .GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
+            .Where(f => f.FieldType == typeof(MockRecordHandle))
+            .ToList();
+
+        foreach (var field in dataItemFields)
+        {
+            var fieldName = field.Name;
+
+            // Resolve the table ID by matching the field name against all registered
+            // table names (stripping spaces/punctuation for the comparison).
+            var tableId = TableFieldRegistry.GetTableIdByNormalizedName(fieldName);
+            if (tableId == null)
+                continue;
+
+            // Initialise the field if BC did not do so (it is null in generated code).
+            var rec = (MockRecordHandle?)field.GetValue(report) ?? new MockRecordHandle(tableId.Value);
+            field.SetValue(report, rec);
+
+            InvokeTrigger(report, reportType, $"{fieldName}_a45_OnPreDataItem");
+
+            if (rec.ALFindSet(DataError.TrapError))
+            {
+                do
+                {
+                    InvokeTrigger(report, reportType, $"{fieldName}_a45_OnAfterGetRecord");
+                }
+                while (rec.ALNext() != 0);
+            }
+
+            InvokeTrigger(report, reportType, $"{fieldName}_a45_OnPostDataItem");
+        }
     }
 
     private static void InvokeTrigger(object report, Type reportType, string name)

--- a/AlRunner/Runtime/TableFieldRegistry.cs
+++ b/AlRunner/Runtime/TableFieldRegistry.cs
@@ -316,6 +316,24 @@ public static class TableFieldRegistry
     public static string? GetTableName(int tableId)
         => _tableNames.TryGetValue(tableId, out var name) ? name : null;
 
+    /// <summary>
+    /// Looks up a table ID by a normalised name (spaces and non-alphanumeric
+    /// characters stripped, comparison is case-insensitive).  Used by
+    /// <see cref="MockReportHandle"/> to map a data-item field name (e.g.
+    /// <c>RDTRecord</c>) back to the original table ID (e.g. <c>84500</c>
+    /// for table "RDT Record").
+    /// </summary>
+    public static int? GetTableIdByNormalizedName(string normalizedName)
+    {
+        foreach (var kv in _tableNames)
+        {
+            var stripped = System.Text.RegularExpressions.Regex.Replace(kv.Value, @"[^A-Za-z0-9]", "");
+            if (string.Equals(stripped, normalizedName, StringComparison.OrdinalIgnoreCase))
+                return kv.Key;
+        }
+        return null;
+    }
+
     /// <summary>Returns the table caption or null if not registered.</summary>
     public static string? GetTableCaption(int tableId)
         => _tableCaptions.TryGetValue(tableId, out var caption) ? caption : null;

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -986,6 +986,30 @@ report_OnPostReport:
   tests:
     - tests/bucket-1/259-report-triggers
 
+report_OnPreDataItem:
+  layer: syntax
+  category: report
+  status: covered
+  notes: "fired once before record iteration for each dataitem; MockReportHandle.ExecuteDataItems"
+  tests:
+    - tests/bucket-1/270-report-dataitem-triggers
+
+report_OnAfterGetRecord:
+  layer: syntax
+  category: report
+  status: covered
+  notes: "fired once per row of the dataitem's in-memory table; MockReportHandle.ExecuteDataItems"
+  tests:
+    - tests/bucket-1/270-report-dataitem-triggers
+
+report_OnPostDataItem:
+  layer: syntax
+  category: report
+  status: covered
+  notes: "fired once after record iteration for each dataitem; MockReportHandle.ExecuteDataItems"
+  tests:
+    - tests/bucket-1/270-report-dataitem-triggers
+
 # ── query ───────────────────────────────────────────────────────
 
 query_column:

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -89,9 +89,10 @@ dispatch, and report/request-page variables support a limited standalone surface
   registered, otherwise throws.
 - Request pages can be handled via `[RequestPageHandler]`, but this is handler dispatch
   only, not real request-page rendering.
-- Report variables can call limited standalone helpers such as `SetTableView()`,
-  helper procedures, `Run()`, and `RunRequestPage()`, but report layout/rendering
-  behavior is still not available.
+- Report variables support `Run()`, `RunRequestPage()`, `SetTableView()`, and
+  helper procedures. Report triggers execute: `OnPreReport`, `OnPreDataItem`,
+  `OnAfterGetRecord` (once per row in the in-memory table), `OnPostDataItem`, and
+  `OnPostReport`. Report layout/rendering is still not available.
 
 ### HTTP — partial support
 

--- a/tests/bucket-1/270-report-dataitem-triggers/src/RdtSrc.al
+++ b/tests/bucket-1/270-report-dataitem-triggers/src/RdtSrc.al
@@ -1,0 +1,82 @@
+table 84500 "RDT Record"
+{
+    fields
+    {
+        field(1; Id; Integer) { }
+        field(2; Amount; Decimal) { }
+    }
+    keys { key(PK; Id) { Clustered = true; } }
+}
+
+report 84501 "RDT Report"
+{
+    dataset
+    {
+        dataitem(RDTRecord; "RDT Record")
+        {
+            trigger OnPreDataItem()
+            begin
+                PreDataItemCount += 1;
+            end;
+
+            trigger OnAfterGetRecord()
+            begin
+                TotalAmount += RDTRecord.Amount;
+                RecordCount += 1;
+            end;
+
+            trigger OnPostDataItem()
+            begin
+                PostDataItemCount += 1;
+            end;
+        }
+    }
+
+    var
+        TotalAmount: Decimal;
+        RecordCount: Integer;
+        PreDataItemCount: Integer;
+        PostDataItemCount: Integer;
+
+    trigger OnPreReport()
+    begin
+        TotalAmount := 0;
+        RecordCount := 0;
+    end;
+
+    trigger OnPostReport()
+    begin
+        // nothing
+    end;
+
+    procedure GetTotalAmount(): Decimal
+    begin
+        exit(TotalAmount);
+    end;
+
+    procedure GetRecordCount(): Integer
+    begin
+        exit(RecordCount);
+    end;
+
+    procedure GetPreDataItemCount(): Integer
+    begin
+        exit(PreDataItemCount);
+    end;
+
+    procedure GetPostDataItemCount(): Integer
+    begin
+        exit(PostDataItemCount);
+    end;
+}
+
+codeunit 84502 "RDT Src"
+{
+    procedure RunReport()
+    var
+        Rep: Report "RDT Report";
+    begin
+        Rep.UseRequestPage(false);
+        Rep.Run();
+    end;
+}

--- a/tests/bucket-1/270-report-dataitem-triggers/test/RdtTest.al
+++ b/tests/bucket-1/270-report-dataitem-triggers/test/RdtTest.al
@@ -1,0 +1,110 @@
+codeunit 84503 "RDT Test"
+{
+    Subtype = Test;
+    var
+        Assert: Codeunit Assert;
+
+    // ── OnAfterGetRecord fires for each record ──────────────────────────────────
+    [Test]
+    procedure OnAfterGetRecord_FiresForEachRecord()
+    var
+        Rec: Record "RDT Record";
+        Rep: Report "RDT Report";
+    begin
+        // Positive: OnAfterGetRecord must fire once per record in the dataitem table.
+        Rec.DeleteAll();
+        Rec.Id := 1; Rec.Amount := 10; Rec.Insert();
+        Rec.Id := 2; Rec.Amount := 20; Rec.Insert();
+
+        Rep.UseRequestPage(false);
+        Rep.Run();
+
+        Assert.AreEqual(2, Rep.GetRecordCount(), 'OnAfterGetRecord must fire for each record');
+    end;
+
+    // ── TotalAmount accumulates across all records ──────────────────────────────
+    [Test]
+    procedure OnAfterGetRecord_AccumulatesValues()
+    var
+        Rec: Record "RDT Record";
+        Rep: Report "RDT Report";
+    begin
+        // Positive: OnAfterGetRecord accumulates Amount across all rows.
+        Rec.DeleteAll();
+        Rec.Id := 1; Rec.Amount := 10; Rec.Insert();
+        Rec.Id := 2; Rec.Amount := 20; Rec.Insert();
+
+        Rep.UseRequestPage(false);
+        Rep.Run();
+
+        Assert.AreEqual(30, Rep.GetTotalAmount(), 'TotalAmount should sum all records');
+    end;
+
+    // ── Empty table: OnAfterGetRecord never fires ───────────────────────────────
+    [Test]
+    procedure OnAfterGetRecord_ZeroRecords_CountIsZero()
+    var
+        Rec: Record "RDT Record";
+        Rep: Report "RDT Report";
+    begin
+        // Negative: when the table is empty, RecordCount stays 0.
+        Rec.DeleteAll();
+
+        Rep.UseRequestPage(false);
+        Rep.Run();
+
+        Assert.AreEqual(0, Rep.GetRecordCount(), 'RecordCount must be 0 when table is empty');
+    end;
+
+    // ── OnPreDataItem fires exactly once ────────────────────────────────────────
+    [Test]
+    procedure OnPreDataItem_FiresOnce()
+    var
+        Rec: Record "RDT Record";
+        Rep: Report "RDT Report";
+    begin
+        // Positive: OnPreDataItem fires exactly once per dataitem.
+        Rec.DeleteAll();
+        Rec.Id := 1; Rec.Amount := 5; Rec.Insert();
+
+        Rep.UseRequestPage(false);
+        Rep.Run();
+
+        Assert.AreEqual(1, Rep.GetPreDataItemCount(), 'OnPreDataItem must fire exactly once');
+    end;
+
+    // ── OnPostDataItem fires exactly once ───────────────────────────────────────
+    [Test]
+    procedure OnPostDataItem_FiresOnce()
+    var
+        Rec: Record "RDT Record";
+        Rep: Report "RDT Report";
+    begin
+        // Positive: OnPostDataItem fires exactly once per dataitem.
+        Rec.DeleteAll();
+        Rec.Id := 1; Rec.Amount := 5; Rec.Insert();
+
+        Rep.UseRequestPage(false);
+        Rep.Run();
+
+        Assert.AreEqual(1, Rep.GetPostDataItemCount(), 'OnPostDataItem must fire exactly once');
+    end;
+
+    // ── Single record: count is exactly 1 ──────────────────────────────────────
+    [Test]
+    procedure OnAfterGetRecord_SingleRecord_CountIsOne()
+    var
+        Rec: Record "RDT Record";
+        Rep: Report "RDT Report";
+    begin
+        // Positive: one record → RecordCount = 1.
+        Rec.DeleteAll();
+        Rec.Id := 1; Rec.Amount := 42; Rec.Insert();
+
+        Rep.UseRequestPage(false);
+        Rep.Run();
+
+        Assert.AreEqual(1, Rep.GetRecordCount(), 'RecordCount must be 1 for single record');
+        Assert.AreEqual(42, Rep.GetTotalAmount(), 'TotalAmount must equal the single record Amount');
+    end;
+}


### PR DESCRIPTION
Closes #833

## Changes

**`AlRunner/Runtime/MockReportHandle.cs`**
- `ExecuteReportLifecycle` now calls a new `ExecuteDataItems` helper that:
  - Discovers all `MockRecordHandle` fields in the generated report class (each represents a data-item)
  - Resolves each field's table ID via `TableFieldRegistry.GetTableIdByNormalizedName`
  - Runs the full trigger sequence: `OnPreDataItem` → `OnAfterGetRecord` (once per row) → `OnPostDataItem`
- Report lifecycle is now: `OnPreReport` → [per data-item: Pre → Records → Post] → `OnPostReport`

**`AlRunner/Runtime/TableFieldRegistry.cs`**
- Added `GetTableIdByNormalizedName(string)`: reverse-lookup table ID by stripping non-alphanumeric characters from registered table names (e.g. `RDTRecord` → "RDT Record" → ID 84500)

**`AlRunner/Runtime/MockMedia.cs`**
- Removed duplicate `ALImportWithUrlAccess` overloads with nullable `MockInStream?` introduced by bae33d1. Commit badb4a2 later added identical overloads with non-nullable `MockInStream`; C# treats the two signatures as identical (CS0111), causing bucket-1 build failures on origin/main.

**`tests/bucket-1/270-report-dataitem-triggers/`**
- New test suite with 6 tests: OnAfterGetRecord fires for each row, accumulates values, zero-records case, OnPreDataItem fires once, OnPostDataItem fires once, single-record case

**`docs/coverage.yaml`** — added `report_OnPreDataItem`, `report_OnAfterGetRecord`, `report_OnPostDataItem` as `covered`

**`docs/limitations.md`** — updated report trigger description to reflect that data-item triggers now execute

## Test run

```
6 passed in 0.0s   (270-report-dataitem-triggers)
1243 passed, 4 failed in 1.5s   (bucket-1 — 4 failures are pre-existing, unrelated to this PR)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)