### PR TITLE
feat: TextConst.IndexOfAny — both overloads proven via Label tests (#835)

### DIFF
--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -7989,8 +7989,10 @@ TextConst.IndexOf:
 TextConst.IndexOfAny:
   layer: runtime-api
   category: TextConst
-  status: gap
-  notes: overloads=2
+  status: covered
+  notes: overloads=2; BC native NavText.ALIndexOfAny works after NavTextConstant→NavText rewrite. Both 1-arg and 2-arg (with startIndex) overloads tested — positive and negative cases.
+  tests:
+    - tests/bucket-1/87-textconst-methods
 
 TextConst.LastIndexOf:
   layer: runtime-api

--- a/tests/bucket-1/87-textconst-methods/src/TextConstSrc.al
+++ b/tests/bucket-1/87-textconst-methods/src/TextConstSrc.al
@@ -33,6 +33,16 @@ codeunit 89000 "TCM Src"
         exit(HelloWorld.LastIndexOf(sub));
     end;
 
+    procedure LabelIndexOfAny(chars: Text): Integer
+    begin
+        exit(HelloWorld.IndexOfAny(chars));
+    end;
+
+    procedure LabelIndexOfAnyFrom(chars: Text; startIndex: Integer): Integer
+    begin
+        exit(HelloWorld.IndexOfAny(chars, startIndex));
+    end;
+
     procedure LabelSubstring(start: Integer; len: Integer): Text
     begin
         exit(HelloWorld.Substring(start, len));

--- a/tests/bucket-1/87-textconst-methods/test/TextConstTest.al
+++ b/tests/bucket-1/87-textconst-methods/test/TextConstTest.al
@@ -75,6 +75,40 @@ codeunit 89001 "TCM Tests"
     end;
 
     // ------------------------------------------------------------------
+    // IndexOfAny
+    // ------------------------------------------------------------------
+
+    [Test]
+    procedure TextConst_IndexOfAny_Found()
+    begin
+        // 'Hello, World!' — first of 'lo' chars: 'l' at position 3
+        Assert.AreEqual(3, Src.LabelIndexOfAny('lo'),
+            'IndexOfAny lo must return 3 — l at position 3 is the earliest match');
+    end;
+
+    [Test]
+    procedure TextConst_IndexOfAny_NotFound()
+    begin
+        Assert.AreEqual(0, Src.LabelIndexOfAny('xyz'),
+            'IndexOfAny xyz must return 0 — no char from xyz is present');
+    end;
+
+    [Test]
+    procedure TextConst_IndexOfAny_WithStartIndex()
+    begin
+        // 'Hello, World!' from position 6: ',', ' ', 'W', 'o'(9) — first of 'lo' is 'o' at 9
+        Assert.AreEqual(9, Src.LabelIndexOfAnyFrom('lo', 6),
+            'IndexOfAny lo from 6 must return 9 — first lo-char after position 6 is o at 9');
+    end;
+
+    [Test]
+    procedure TextConst_IndexOfAny_WithStartIndex_NotFound()
+    begin
+        Assert.AreEqual(0, Src.LabelIndexOfAnyFrom('xyz', 6),
+            'IndexOfAny xyz from 6 must return 0 — xyz not present anywhere');
+    end;
+
+    // ------------------------------------------------------------------
     // Substring
     // ------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #835

## What

`TextConst.IndexOfAny` was listed as `gap` in `docs/coverage.yaml` despite the functionality already working: the BC compiler transpiles `TextConst` labels to `NavTextConstant`, which the runner rewrites to `NavText`; `NavText` exposes `ALIndexOfAny` natively and works standalone.

## Changes

Extends `tests/bucket-1/87-textconst-methods` (the canonical TextConst-method test suite) with four new tests proving both overloads:

| Test | Input | Expected |
|------|-------|---------|
| `IndexOfAny('lo')` | `'Hello, World!'` | `3` — 'l' at pos 3 is earliest match |
| `IndexOfAny('xyz')` | `'Hello, World!'` | `0` — no match |
| `IndexOfAny('lo', 6)` | `'Hello, World!'` | `9` — 'o' at pos 9 is first match ≥ 6 |
| `IndexOfAny('xyz', 6)` | `'Hello, World!'` | `0` — no match from pos 6 |

Updates `docs/coverage.yaml`: `TextConst.IndexOfAny` → `covered`.

## No runtime change needed

`NavText.ALIndexOfAny` is already wired up (proven by `Text.IndexOfAny` in `67-text-builtins` and `Label.IndexOfAny` in `186-label-string-methods`). The only gap was the missing coverage entry and tests.