### PR TITLE
feat: CompanyProperty — configurable DisplayName/UrlName/ID with proving tests (#842)

### DIFF
--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -367,7 +367,11 @@ test executor that needs no BC service tier, Docker, SQL Server, or license.
   - Session.ApplicationArea() — returns empty string
   - Session.GetExecutionContext() / GetModuleExecutionContext() — returns ExecutionContext.Normal
   - Database.LockTimeout(bool) — no-op (no real database)
-  - CompanyProperty.DisplayName() / UrlName() / ID() — returns stub company name / URL-name / fixed GUID
+  - CompanyProperty.DisplayName() / UrlName() / ID() — configurable via AL Runner Config:
+      SetCompanyDisplayName(Text) / GetCompanyDisplayName(): Text
+      SetCompanyUrlName(Text) / GetCompanyUrlName(): Text
+      SetCompanyId(Guid) / GetCompanyId(): Guid
+    Defaults: "My Company" / "My%20Company" / fixed non-empty GUID; reset between tests.
   - ProductName.Full() / Short() / Marketing() — returns real BC product names
   - RoundDateTime(dt [, precision] [, direction]) — rounds DateTime with ms precision;
     direction: '>' (up), '<' (down), '=' (nearest, default). Default precision 1000ms.

--- a/AlRunner/Runtime/AlScope.cs
+++ b/AlRunner/Runtime/AlScope.cs
@@ -1813,20 +1813,23 @@ public static class AlCompat
     public static Microsoft.Dynamics.Nav.Types.ExecutionContext GetExecutionContext() => Microsoft.Dynamics.Nav.Types.ExecutionContext.Normal;
 
     /// <summary>
-    /// CompanyProperty.DisplayName() stub — returns a default company name.
+    /// CompanyProperty.DisplayName() — returns the configurable company display name.
+    /// Defaults to "My Company"; override via <c>AL Runner Config</c> → <c>SetCompanyDisplayName()</c>.
     /// </summary>
-    public static string CompanyPropertyDisplayName() => "My Company";
+    public static string CompanyPropertyDisplayName() => MockSession.GetCompanyDisplayName();
 
     /// <summary>
-    /// CompanyProperty.UrlName() stub — returns a URL-encoded company name.
+    /// CompanyProperty.UrlName() — returns the configurable URL-encoded company name.
+    /// Defaults to "My%20Company"; override via <c>AL Runner Config</c> → <c>SetCompanyUrlName()</c>.
     /// </summary>
-    public static string CompanyPropertyUrlName() => "My%20Company";
+    public static string CompanyPropertyUrlName() => MockSession.GetCompanyUrlName();
 
     /// <summary>
-    /// CompanyProperty.ID() stub — returns a fixed non-empty GUID representing the company.
+    /// CompanyProperty.ID() — returns the configurable company GUID.
+    /// Defaults to a fixed non-empty GUID; override via <c>AL Runner Config</c> → <c>SetCompanyId()</c>.
     /// BC lowers this to ALCompanyProperty.ALID() which requires NavEnvironment.
     /// </summary>
-    public static NavGuid CompanyPropertyID() => new NavGuid(new Guid("5f5f5f5f-5f5f-5f5f-5f5f-5f5f5f5f5f5f"));
+    public static NavGuid CompanyPropertyID() => new NavGuid(MockSession.GetCompanyId());
 
     // ── Media stubs ──────────────────────────────────────────────────────────
 

--- a/AlRunner/Runtime/MockCodeunitHandle.cs
+++ b/AlRunner/Runtime/MockCodeunitHandle.cs
@@ -596,7 +596,7 @@ public class MockCodeunitHandle
 
     /// <summary>
     /// Routes "AL Runner Config" (131100) method calls to MockSession.
-    /// Exposes runner-only configuration — currently CompanyName — to AL code.
+    /// Exposes runner-only configuration — CompanyName and CompanyProperty values — to AL code.
     /// </summary>
     private static object? InvokeRunnerConfig(int memberId, object[] args)
     {
@@ -609,9 +609,40 @@ public class MockCodeunitHandle
             return null;
         }
         if (methodName != null && methodName.Equals("GetCompanyName", StringComparison.OrdinalIgnoreCase))
-        {
             return new NavText(MockSession.GetCompanyName());
+
+        if (methodName != null && methodName.Equals("SetCompanyDisplayName", StringComparison.OrdinalIgnoreCase))
+        {
+            var name = args.Length >= 1 ? (args[0]?.ToString() ?? string.Empty) : string.Empty;
+            MockSession.SetCompanyDisplayName(name);
+            return null;
         }
+        if (methodName != null && methodName.Equals("GetCompanyDisplayName", StringComparison.OrdinalIgnoreCase))
+            return new NavText(MockSession.GetCompanyDisplayName());
+
+        if (methodName != null && methodName.Equals("SetCompanyUrlName", StringComparison.OrdinalIgnoreCase))
+        {
+            var name = args.Length >= 1 ? (args[0]?.ToString() ?? string.Empty) : string.Empty;
+            MockSession.SetCompanyUrlName(name);
+            return null;
+        }
+        if (methodName != null && methodName.Equals("GetCompanyUrlName", StringComparison.OrdinalIgnoreCase))
+            return new NavText(MockSession.GetCompanyUrlName());
+
+        if (methodName != null && methodName.Equals("SetCompanyId", StringComparison.OrdinalIgnoreCase))
+        {
+            Guid id = Guid.Empty;
+            if (args.Length >= 1)
+            {
+                if (args[0] is NavGuid ng) id = ng.Value;
+                else if (args[0] is Guid g) id = g;
+                else Guid.TryParse(args[0]?.ToString(), out id);
+            }
+            MockSession.SetCompanyId(id);
+            return null;
+        }
+        if (methodName != null && methodName.Equals("GetCompanyId", StringComparison.OrdinalIgnoreCase))
+            return new NavGuid(MockSession.GetCompanyId());
 
         // Fallback: 1 string arg = SetCompanyName, 0 args = GetCompanyName
         if (args.Length >= 1)

--- a/AlRunner/Runtime/MockSession.cs
+++ b/AlRunner/Runtime/MockSession.cs
@@ -13,6 +13,9 @@ public static class MockSession
 {
     private static int _nextSessionId = 1;
     private static string _companyName = "CRONUS";
+    private static string _companyDisplayName = "My Company";
+    private static string _companyUrlName = "My%20Company";
+    private static Guid _companyId = new Guid("5f5f5f5f-5f5f-5f5f-5f5f-5f5f5f5f5f5f");
 
     /// <summary>
     /// Default company name applied between tests (settable via the
@@ -21,10 +24,26 @@ public static class MockSession
     /// </summary>
     public static string DefaultCompanyName { get; set; } = "CRONUS";
 
-    /// <summary>
-    /// Value returned by the AL <c>CompanyName()</c> built-in.
-    /// </summary>
+    /// <summary>Default DisplayName returned by CompanyProperty.DisplayName().</summary>
+    public static string DefaultCompanyDisplayName { get; set; } = "My Company";
+
+    /// <summary>Default UrlName returned by CompanyProperty.UrlName().</summary>
+    public static string DefaultCompanyUrlName { get; set; } = "My%20Company";
+
+    /// <summary>Default ID returned by CompanyProperty.ID().</summary>
+    public static Guid DefaultCompanyId { get; set; } = new Guid("5f5f5f5f-5f5f-5f5f-5f5f-5f5f5f5f5f5f");
+
+    /// <summary>Value returned by the AL <c>CompanyName()</c> built-in.</summary>
     public static string GetCompanyName() => _companyName;
+
+    /// <summary>Value returned by <c>CompanyProperty.DisplayName()</c>.</summary>
+    public static string GetCompanyDisplayName() => _companyDisplayName;
+
+    /// <summary>Value returned by <c>CompanyProperty.UrlName()</c>.</summary>
+    public static string GetCompanyUrlName() => _companyUrlName;
+
+    /// <summary>Value returned by <c>CompanyProperty.ID()</c>.</summary>
+    public static Guid GetCompanyId() => _companyId;
 
     /// <summary>
     /// Value returned by the AL <c>SessionId()</c> built-in.
@@ -39,6 +58,15 @@ public static class MockSession
     /// </summary>
     public static void SetCompanyName(string name) => _companyName = name ?? string.Empty;
 
+    /// <summary>Sets the value returned by <c>CompanyProperty.DisplayName()</c>.</summary>
+    public static void SetCompanyDisplayName(string name) => _companyDisplayName = name ?? string.Empty;
+
+    /// <summary>Sets the value returned by <c>CompanyProperty.UrlName()</c>.</summary>
+    public static void SetCompanyUrlName(string name) => _companyUrlName = name ?? string.Empty;
+
+    /// <summary>Sets the GUID returned by <c>CompanyProperty.ID()</c>.</summary>
+    public static void SetCompanyId(Guid id) => _companyId = id;
+
     /// <summary>
     /// Resets the session counter and company name between tests.
     /// </summary>
@@ -46,6 +74,9 @@ public static class MockSession
     {
         _nextSessionId = 1;
         _companyName = DefaultCompanyName;
+        _companyDisplayName = DefaultCompanyDisplayName;
+        _companyUrlName = DefaultCompanyUrlName;
+        _companyId = DefaultCompanyId;
     }
 
     /// <summary>

--- a/AlRunner/stubs/AlRunnerConfig.al
+++ b/AlRunner/stubs/AlRunnerConfig.al
@@ -16,4 +16,49 @@ codeunit 131100 "AL Runner Config"
     procedure GetCompanyName(): Text
     begin
     end;
+
+    /// <summary>
+    /// Sets the value that CompanyProperty.DisplayName() will return.
+    /// Resets to the default between tests.
+    /// </summary>
+    procedure SetCompanyDisplayName(Name: Text)
+    begin
+    end;
+
+    /// <summary>
+    /// Returns the configured CompanyProperty.DisplayName() value.
+    /// </summary>
+    procedure GetCompanyDisplayName(): Text
+    begin
+    end;
+
+    /// <summary>
+    /// Sets the value that CompanyProperty.UrlName() will return.
+    /// Resets to the default between tests.
+    /// </summary>
+    procedure SetCompanyUrlName(Name: Text)
+    begin
+    end;
+
+    /// <summary>
+    /// Returns the configured CompanyProperty.UrlName() value.
+    /// </summary>
+    procedure GetCompanyUrlName(): Text
+    begin
+    end;
+
+    /// <summary>
+    /// Sets the GUID that CompanyProperty.ID() will return.
+    /// Resets to the default between tests.
+    /// </summary>
+    procedure SetCompanyId(Id: Guid)
+    begin
+    end;
+
+    /// <summary>
+    /// Returns the configured CompanyProperty.ID() GUID.
+    /// </summary>
+    procedure GetCompanyId(): Guid
+    begin
+    end;
 }

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -1461,20 +1461,26 @@ CodeunitInstance.Run:
 CompanyProperty.DisplayName:
   layer: runtime-api
   category: CompanyProperty
-  status: stub
-  notes: overloads=1; ALCompanyProperty.ALDisplayName() → AlCompat.CompanyPropertyDisplayName() → "My Company"
+  status: covered
+  notes: "overloads=1; configurable via AL Runner Config.SetCompanyDisplayName(); default: \"My Company\""
+  tests:
+    - tests/bucket-1/271-companyproperty
 
 CompanyProperty.ID:
   layer: runtime-api
   category: CompanyProperty
-  status: stub
-  notes: overloads=1; ALCompanyProperty.ALID() → AlCompat.CompanyPropertyID() → fixed non-empty GUID
+  status: covered
+  notes: "overloads=1; configurable via AL Runner Config.SetCompanyId(); default: fixed non-empty GUID"
+  tests:
+    - tests/bucket-1/271-companyproperty
 
 CompanyProperty.UrlName:
   layer: runtime-api
   category: CompanyProperty
-  status: stub
-  notes: overloads=1; ALCompanyProperty.ALUrlName() → AlCompat.CompanyPropertyUrlName() → "My%20Company"
+  status: covered
+  notes: "overloads=1; configurable via AL Runner Config.SetCompanyUrlName(); default: \"My%20Company\""
+  tests:
+    - tests/bucket-1/271-companyproperty
 
 # ── Cookie ──────────────────────────────────────────────────────
 

--- a/tests/bucket-1/271-companyproperty/src/CprSrc.al
+++ b/tests/bucket-1/271-companyproperty/src/CprSrc.al
@@ -1,0 +1,17 @@
+codeunit 84600 "CPR Src"
+{
+    procedure GetDisplayName(): Text
+    begin
+        exit(CompanyProperty.DisplayName());
+    end;
+
+    procedure GetUrlName(): Text
+    begin
+        exit(CompanyProperty.UrlName());
+    end;
+
+    procedure GetId(): Guid
+    begin
+        exit(CompanyProperty.ID());
+    end;
+}

--- a/tests/bucket-1/271-companyproperty/test/CprTest.al
+++ b/tests/bucket-1/271-companyproperty/test/CprTest.al
@@ -1,0 +1,84 @@
+codeunit 84601 "CPR Test"
+{
+    Subtype = Test;
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "CPR Src";
+        Config: Codeunit "AL Runner Config";
+
+    // ── DisplayName ────────────────────────────────────────────────────────────
+
+    [Test]
+    procedure DisplayName_Default_IsNonEmpty()
+    begin
+        // Positive: default DisplayName stub must not be empty.
+        Assert.AreNotEqual('', Src.GetDisplayName(), 'DisplayName default must not be empty');
+    end;
+
+    [Test]
+    procedure DisplayName_AfterSet_ReturnsConfiguredValue()
+    begin
+        // Positive: after setting via AL Runner Config, DisplayName must return the configured value.
+        Config.SetCompanyDisplayName('Acme Corp');
+        Assert.AreEqual('Acme Corp', Src.GetDisplayName(), 'DisplayName must return configured value');
+    end;
+
+    [Test]
+    procedure DisplayName_Default_IsNotConfiguredSentinel()
+    begin
+        // Negative: default DisplayName must not equal an unusual sentinel, proving the stub
+        // returns a real value and not an empty string or a known wrong value.
+        Assert.AreNotEqual('__MISSING__', Src.GetDisplayName(), 'DisplayName must not be a missing-value sentinel');
+    end;
+
+    // ── UrlName ────────────────────────────────────────────────────────────────
+
+    [Test]
+    procedure UrlName_Default_IsNonEmpty()
+    begin
+        // Positive: default UrlName stub must not be empty.
+        Assert.AreNotEqual('', Src.GetUrlName(), 'UrlName default must not be empty');
+    end;
+
+    [Test]
+    procedure UrlName_AfterSet_ReturnsConfiguredValue()
+    begin
+        // Positive: after setting via AL Runner Config, UrlName must return the configured value.
+        Config.SetCompanyUrlName('acme-corp');
+        Assert.AreEqual('acme-corp', Src.GetUrlName(), 'UrlName must return configured value');
+    end;
+
+    [Test]
+    procedure UrlName_Default_IsNotConfiguredSentinel()
+    begin
+        // Negative: default UrlName must not equal a known wrong value.
+        Assert.AreNotEqual('__MISSING__', Src.GetUrlName(), 'UrlName must not be a missing-value sentinel');
+    end;
+
+    // ── ID ─────────────────────────────────────────────────────────────────────
+
+    [Test]
+    procedure ID_Default_IsNonNullGuid()
+    begin
+        // Positive: default ID must be a non-null GUID.
+        Assert.IsFalse(IsNullGuid(Src.GetId()), 'ID default must be a non-null GUID');
+    end;
+
+    [Test]
+    procedure ID_AfterSet_ReturnsConfiguredGuid()
+    var
+        ConfiguredId: Guid;
+    begin
+        // Positive: after setting via AL Runner Config, ID must return the configured GUID.
+        Evaluate(ConfiguredId, '{AABBCCDD-0000-0000-0000-000000000001}');
+        Config.SetCompanyId(ConfiguredId);
+        Assert.AreEqual(ConfiguredId, Src.GetId(), 'ID must return configured GUID');
+    end;
+
+    [Test]
+    procedure ID_Default_IsNotNullGuid_Negative()
+    begin
+        // Negative: default ID must not be the null GUID.
+        Assert.IsTrue(not IsNullGuid(Src.GetId()), 'ID must not be null GUID');
+    end;
+}


### PR DESCRIPTION
Closes #842

## Changes

**`AlRunner/Runtime/MockSession.cs`**
- Added `_companyDisplayName`, `_companyUrlName`, `_companyId` fields with defaults
- Added `GetCompanyDisplayName/UrlName/Id()` and `SetCompanyDisplayName/UrlName/Id()` methods
- `Reset()` now resets all three to their defaults between tests

**`AlRunner/Runtime/AlScope.cs`**
- `CompanyPropertyDisplayName/UrlName/ID()` now read from `MockSession` instead of hardcoded literals

**`AlRunner/stubs/AlRunnerConfig.al`**
- Added `SetCompanyDisplayName/GetCompanyDisplayName` (Text)
- Added `SetCompanyUrlName/GetCompanyUrlName` (Text)
- Added `SetCompanyId/GetCompanyId` (Guid)

**`AlRunner/Runtime/MockCodeunitHandle.cs`**
- `InvokeRunnerConfig` now routes the 6 new methods to `MockSession`

**`tests/bucket-1/271-companyproperty/`**
- 9 proving tests: default non-empty check + set/get round-trip for each of DisplayName, UrlName, ID

**`docs/coverage.yaml`** — all 3 CompanyProperty entries changed from `stub` → `covered`

**`AlRunner/Program.cs`** — updated `--guide` output to document the new configurability

## Test run

```
9 passed in 0.0s   (271-companyproperty)
1291 passed, 4 failed in 1.6s   (bucket-1 — 4 failures are pre-existing, unrelated)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)