### PR TITLE
test: JsonArray typed getters — GetBigInteger/Byte/Char/Date/DateTime/Duration/Option/Time (#841)

### DIFF
--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -3184,8 +3184,10 @@ JsonArray.GetArray:
 JsonArray.GetBigInteger:
   layer: runtime-api
   category: JsonArray
-  status: stub
-  notes: overloads=1. BC 21+ typed overload not present in AL 16.2. Indirectly reachable via Get + AsValue().AsBigInteger().
+  status: covered
+  notes: overloads=1. Works natively via NavJsonArray; single-arg form GetBigInteger(idx) returns BigInteger directly.
+  tests:
+    - tests/bucket-1/183-jsonarray-extended-getters
 
 JsonArray.GetBoolean:
   layer: runtime-api
@@ -3197,26 +3199,34 @@ JsonArray.GetBoolean:
 JsonArray.GetByte:
   layer: runtime-api
   category: JsonArray
-  status: stub
-  notes: overloads=1. BC 21+ typed overload not present in AL 16.2.
+  status: covered
+  notes: overloads=1. Works natively via NavJsonArray; single-arg form GetByte(idx) returns Byte directly.
+  tests:
+    - tests/bucket-1/183-jsonarray-extended-getters
 
 JsonArray.GetChar:
   layer: runtime-api
   category: JsonArray
-  status: stub
-  notes: overloads=1. BC 21+ typed overload not present in AL 16.2.
+  status: covered
+  notes: overloads=1. Works natively via NavJsonArray; single-arg form GetChar(idx) returns Char directly.
+  tests:
+    - tests/bucket-1/183-jsonarray-extended-getters
 
 JsonArray.GetDate:
   layer: runtime-api
   category: JsonArray
-  status: stub
-  notes: overloads=1. BC 21+ typed overload not present in AL 16.2.
+  status: covered
+  notes: overloads=1. Works natively via NavJsonArray; single-arg form GetDate(idx) returns Date directly.
+  tests:
+    - tests/bucket-1/183-jsonarray-extended-getters
 
 JsonArray.GetDateTime:
   layer: runtime-api
   category: JsonArray
-  status: stub
-  notes: overloads=1. BC 21+ typed overload not present in AL 16.2.
+  status: covered
+  notes: overloads=1. Works natively via NavJsonArray; single-arg form GetDateTime(idx) returns DateTime directly.
+  tests:
+    - tests/bucket-1/183-jsonarray-extended-getters
 
 JsonArray.GetDecimal:
   layer: runtime-api
@@ -3228,8 +3238,10 @@ JsonArray.GetDecimal:
 JsonArray.GetDuration:
   layer: runtime-api
   category: JsonArray
-  status: stub
-  notes: overloads=1. BC 21+ typed overload not present in AL 16.2.
+  status: covered
+  notes: overloads=1. Works natively via NavJsonArray; single-arg form GetDuration(idx) returns Duration directly.
+  tests:
+    - tests/bucket-1/183-jsonarray-extended-getters
 
 JsonArray.GetInteger:
   layer: runtime-api
@@ -3248,8 +3260,10 @@ JsonArray.GetObject:
 JsonArray.GetOption:
   layer: runtime-api
   category: JsonArray
-  status: stub
-  notes: overloads=1. BC 21+ typed overload not present in AL 16.2.
+  status: covered
+  notes: overloads=1. Works natively via NavJsonArray; single-arg form GetOption(idx) returns Integer ordinal directly.
+  tests:
+    - tests/bucket-1/183-jsonarray-extended-getters
 
 JsonArray.GetText:
   layer: runtime-api
@@ -3261,8 +3275,10 @@ JsonArray.GetText:
 JsonArray.GetTime:
   layer: runtime-api
   category: JsonArray
-  status: stub
-  notes: overloads=1. BC 21+ typed overload not present in AL 16.2.
+  status: covered
+  notes: overloads=1. Works natively via NavJsonArray; single-arg form GetTime(idx) returns Time directly.
+  tests:
+    - tests/bucket-1/183-jsonarray-extended-getters
 
 JsonArray.IndexOf:
   layer: runtime-api

--- a/tests/bucket-1/183-jsonarray-extended-getters/src/JArrayExtSrc.al
+++ b/tests/bucket-1/183-jsonarray-extended-getters/src/JArrayExtSrc.al
@@ -1,7 +1,7 @@
 /// Helper codeunit for JsonArray typed getters: GetBigInteger, GetByte,
 /// GetChar, GetDate, GetDateTime, GetDuration, GetOption, GetTime.
 /// These BC 21+ single-arg overloads return the typed value directly.
-codeunit 114000 "JAEX Src"
+codeunit 115000 "JAEX Src"
 {
     // ── GetBigInteger ─────────────────────────────────────────────────────────
 

--- a/tests/bucket-1/183-jsonarray-extended-getters/src/JArrayExtSrc.al
+++ b/tests/bucket-1/183-jsonarray-extended-getters/src/JArrayExtSrc.al
@@ -1,0 +1,61 @@
+/// Helper codeunit for JsonArray typed getters: GetBigInteger, GetByte,
+/// GetChar, GetDate, GetDateTime, GetDuration, GetOption, GetTime.
+/// These BC 21+ single-arg overloads return the typed value directly.
+codeunit 114000 "JAEX Src"
+{
+    // ── GetBigInteger ─────────────────────────────────────────────────────────
+
+    procedure GetBigInteger(Arr: JsonArray; Idx: Integer): BigInteger
+    begin
+        exit(Arr.GetBigInteger(Idx));
+    end;
+
+    // ── GetByte ───────────────────────────────────────────────────────────────
+
+    procedure GetByte(Arr: JsonArray; Idx: Integer): Byte
+    begin
+        exit(Arr.GetByte(Idx));
+    end;
+
+    // ── GetChar ───────────────────────────────────────────────────────────────
+
+    procedure GetChar(Arr: JsonArray; Idx: Integer): Char
+    begin
+        exit(Arr.GetChar(Idx));
+    end;
+
+    // ── GetDate ───────────────────────────────────────────────────────────────
+
+    procedure GetDate(Arr: JsonArray; Idx: Integer): Date
+    begin
+        exit(Arr.GetDate(Idx));
+    end;
+
+    // ── GetDateTime ───────────────────────────────────────────────────────────
+
+    procedure GetDateTime(Arr: JsonArray; Idx: Integer): DateTime
+    begin
+        exit(Arr.GetDateTime(Idx));
+    end;
+
+    // ── GetDuration ───────────────────────────────────────────────────────────
+
+    procedure GetDuration(Arr: JsonArray; Idx: Integer): Duration
+    begin
+        exit(Arr.GetDuration(Idx));
+    end;
+
+    // ── GetOption ─────────────────────────────────────────────────────────────
+
+    procedure GetOption(Arr: JsonArray; Idx: Integer): Integer
+    begin
+        exit(Arr.GetOption(Idx));
+    end;
+
+    // ── GetTime ───────────────────────────────────────────────────────────────
+
+    procedure GetTime(Arr: JsonArray; Idx: Integer): Time
+    begin
+        exit(Arr.GetTime(Idx));
+    end;
+}

--- a/tests/bucket-1/183-jsonarray-extended-getters/test/JArrayExtTest.al
+++ b/tests/bucket-1/183-jsonarray-extended-getters/test/JArrayExtTest.al
@@ -1,0 +1,180 @@
+codeunit 114001 "JAEX Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "JAEX Src";
+
+    // ── GetBigInteger ─────────────────────────────────────────────────────────
+
+    [Test]
+    procedure GetBigInteger_ReturnsStoredValue()
+    var
+        Arr: JsonArray;
+        B: BigInteger;
+    begin
+        Evaluate(B, '9999999999');
+        Arr.Add(B);
+        Assert.AreEqual(B, Src.GetBigInteger(Arr, 0), 'GetBigInteger must return the stored BigInteger');
+    end;
+
+    [Test]
+    procedure GetBigInteger_OutOfBounds_ThrowsError()
+    var
+        Arr: JsonArray;
+    begin
+        asserterror Src.GetBigInteger(Arr, 0);
+        Assert.ExpectedError('');
+    end;
+
+    // ── GetByte ───────────────────────────────────────────────────────────────
+
+    [Test]
+    procedure GetByte_ReturnsStoredValue()
+    var
+        Arr: JsonArray;
+        Val: Byte;
+    begin
+        Val := 200;
+        Arr.Add(Val);
+        Assert.AreEqual(Val, Src.GetByte(Arr, 0), 'GetByte must return the stored Byte');
+    end;
+
+    [Test]
+    procedure GetByte_OutOfBounds_ThrowsError()
+    var
+        Arr: JsonArray;
+    begin
+        asserterror Src.GetByte(Arr, 0);
+        Assert.ExpectedError('');
+    end;
+
+    // ── GetChar ───────────────────────────────────────────────────────────────
+
+    [Test]
+    procedure GetChar_ReturnsStoredValue()
+    var
+        Arr: JsonArray;
+        Val: Char;
+    begin
+        Val := 65; // 'A'
+        Arr.Add(Val);
+        Assert.AreEqual(Val, Src.GetChar(Arr, 0), 'GetChar must return the stored Char');
+    end;
+
+    [Test]
+    procedure GetChar_OutOfBounds_ThrowsError()
+    var
+        Arr: JsonArray;
+    begin
+        asserterror Src.GetChar(Arr, 0);
+        Assert.ExpectedError('');
+    end;
+
+    // ── GetDate ───────────────────────────────────────────────────────────────
+
+    [Test]
+    procedure GetDate_ReturnsStoredValue()
+    var
+        Arr: JsonArray;
+        D: Date;
+    begin
+        D := DMY2Date(15, 6, 2024);
+        Arr.Add(D);
+        Assert.AreEqual(D, Src.GetDate(Arr, 0), 'GetDate must return the stored Date');
+    end;
+
+    [Test]
+    procedure GetDate_OutOfBounds_ThrowsError()
+    var
+        Arr: JsonArray;
+    begin
+        asserterror Src.GetDate(Arr, 0);
+        Assert.ExpectedError('');
+    end;
+
+    // ── GetDateTime ───────────────────────────────────────────────────────────
+
+    [Test]
+    procedure GetDateTime_ReturnsStoredValue()
+    var
+        Arr: JsonArray;
+        DT: DateTime;
+    begin
+        DT := CreateDateTime(DMY2Date(1, 3, 2025), 120000T);
+        Arr.Add(DT);
+        Assert.AreEqual(DT, Src.GetDateTime(Arr, 0), 'GetDateTime must return the stored DateTime');
+    end;
+
+    [Test]
+    procedure GetDateTime_OutOfBounds_ThrowsError()
+    var
+        Arr: JsonArray;
+    begin
+        asserterror Src.GetDateTime(Arr, 0);
+        Assert.ExpectedError('');
+    end;
+
+    // ── GetDuration ───────────────────────────────────────────────────────────
+
+    [Test]
+    procedure GetDuration_ReturnsStoredValue()
+    var
+        Arr: JsonArray;
+        D: Duration;
+    begin
+        D := 5000;
+        Arr.Add(D);
+        Assert.AreEqual(D, Src.GetDuration(Arr, 0), 'GetDuration must return the stored Duration');
+    end;
+
+    [Test]
+    procedure GetDuration_OutOfBounds_ThrowsError()
+    var
+        Arr: JsonArray;
+    begin
+        asserterror Src.GetDuration(Arr, 0);
+        Assert.ExpectedError('');
+    end;
+
+    // ── GetOption ─────────────────────────────────────────────────────────────
+
+    [Test]
+    procedure GetOption_ReturnsStoredOrdinal()
+    var
+        Arr: JsonArray;
+    begin
+        Arr.Add(3);
+        Assert.AreEqual(3, Src.GetOption(Arr, 0), 'GetOption must return the stored integer ordinal');
+    end;
+
+    [Test]
+    procedure GetOption_OutOfBounds_ThrowsError()
+    var
+        Arr: JsonArray;
+    begin
+        asserterror Src.GetOption(Arr, 0);
+        Assert.ExpectedError('');
+    end;
+
+    // ── GetTime ───────────────────────────────────────────────────────────────
+
+    [Test]
+    procedure GetTime_ReturnsStoredValue()
+    var
+        Arr: JsonArray;
+    begin
+        Arr.Add(153000T);
+        Assert.AreEqual(153000T, Src.GetTime(Arr, 0), 'GetTime must return the stored Time');
+    end;
+
+    [Test]
+    procedure GetTime_OutOfBounds_ThrowsError()
+    var
+        Arr: JsonArray;
+    begin
+        asserterror Src.GetTime(Arr, 0);
+        Assert.ExpectedError('');
+    end;
+}

--- a/tests/bucket-1/183-jsonarray-extended-getters/test/JArrayExtTest.al
+++ b/tests/bucket-1/183-jsonarray-extended-getters/test/JArrayExtTest.al
@@ -1,4 +1,4 @@
-codeunit 114001 "JAEX Test"
+codeunit 115001 "JAEX Test"
 {
     Subtype = Test;
 


### PR DESCRIPTION
Closes #841

## Summary

Adds 16 proving tests for the 8 `JsonArray` typed getters that were previously `status: stub` in `docs/coverage.yaml`:
`GetBigInteger`, `GetByte`, `GetChar`, `GetDate`, `GetDateTime`, `GetDuration`, `GetOption`, `GetTime`

## Approach

All 8 typed getters work natively via the BC runtime (`NavJsonArray`) using the single-arg form `GetXxx(idx)` that returns the typed value directly — no rewriter or runtime changes needed.

For each method:
- **Positive**: store value in `JsonArray` → call typed getter → assert round-trip matches
- **Negative**: call getter on empty array → `asserterror` confirms error thrown

Suite: `tests/bucket-1/183-jsonarray-extended-getters/` (codeunits 114000/114001)

## Test results

16/16 pass. Full bucket-1 regression: 1300 pass, 2 fail (pre-existing DT2Time failures unrelated to this PR).

## Coverage

`docs/coverage.yaml`: 8 entries promoted from `stub` → `covered`.