### PR TITLE
feat: Database.CompanyName — promote stub → covered (#851)

### DIFF
--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -1617,8 +1617,10 @@ Database.Commit:
 Database.CompanyName:
   layer: runtime-api
   category: Database
-  status: stub
-  notes: overloads=1; returns "CRONUS" by default; configurable via --company-name CLI flag
+  status: covered
+  notes: overloads=1; returns "CRONUS" by default; configurable via --company-name CLI flag or "AL Runner Config".SetCompanyName(). Per-test reset restores the default.
+  tests:
+    - tests/bucket-1/242-company-name
 
 Database.CopyCompany:
   layer: runtime-api


### PR DESCRIPTION
Closes #851

## What

`Database.CompanyName` was listed as `status: stub` in `docs/coverage.yaml` but the proving tests have existed since commits #334 and #249 in `tests/bucket-1/242-company-name/`:

| Test | Proves |
|------|--------|
| `CompanyName_Default_IsCRONUS` | Default stub returns `'CRONUS'` |
| `CompanyName_Configurable_ReturnsSetValue` | `SetCompanyName()` round-trip |
| `CompanyName_SetToEmpty_ReturnsEmpty` | Cleared to `''` works |
| `CompanyName_ResetBetweenTests_RestoresDefault` | Per-test reset restores default |
| `CompanyName_UsedInStrSubstNo` | Composes correctly in `StrSubstNo` |

## Change

Single line change: `docs/coverage.yaml` entry for `Database.CompanyName` updated from `status: stub` → `status: covered` with test path added.

No runtime change needed — the stub already works correctly.