### PR TITLE
fix: TestRequestPage field value proving tests + NavInteger cast in ExtractDecimal (issue #848)

### DIFF
--- a/AlRunner/Runtime/AlScope.cs
+++ b/AlRunner/Runtime/AlScope.cs
@@ -1219,6 +1219,11 @@ public static class AlCompat
         if (value is decimal d) return d;
         if (value is double dbl) return (decimal)dbl;
         if (value is float f) return (decimal)f;
+        if (value is int i) return i;
+        if (value is long l) return l;
+        // BC numeric types via explicit cast operators
+        if (value is Microsoft.Dynamics.Nav.Runtime.NavInteger ni) return (decimal)(int)ni;
+        if (value is Microsoft.Dynamics.Nav.Runtime.NavBigInteger nbi) return (decimal)(long)nbi;
         var typeName = value.GetType().Name;
         if (typeName == "Decimal18" || typeName == "NavDecimal")
         {

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -6944,9 +6944,10 @@ TestField.AsDecimal:
   layer: runtime-api
   category: TestField
   status: covered
-  notes: overloads=1; AlCompat.ObjectToDecimal(_value)
+  notes: overloads=1; AlCompat.ObjectToDecimal(_value); fixed NavInteger/NavBigInteger cast in ExtractDecimal (issue #848)
   tests:
     - tests/bucket-1/71-testpage
+    - tests/bucket-1/269-testrequestpage-methods
 
 TestField.AsInteger:
   layer: runtime-api
@@ -7064,9 +7065,10 @@ TestField.SetValue:
   layer: runtime-api
   category: TestField
   status: covered
-  notes: overloads=2; stores value in-memory
+  notes: overloads=2; stores value in-memory; integer SetValue then AsDecimal proved in TestRequestPage handler
   tests:
     - tests/bucket-1/71-testpage
+    - tests/bucket-1/269-testrequestpage-methods
 
 TestField.ShowMandatory:
   layer: runtime-api

--- a/tests/bucket-1/269-testrequestpage-methods/test/TrmTest.al
+++ b/tests/bucket-1/269-testrequestpage-methods/test/TrmTest.al
@@ -8,6 +8,7 @@ codeunit 84401 "TRM Test"
         NavResult: Boolean;
         ValidationCount: Integer;
         ValidationMsg: Text;
+        FieldDecimal: Decimal;
 
     // ── OK action ──────────────────────────────────────────────────────────────
     [Test]
@@ -433,4 +434,40 @@ codeunit 84401 "TRM Test"
     begin
         NavResult := RequestPage.IsExpanded();
     end;
+
+    // ── Field value set/get round-trip ─────────────────────────────────────────
+    [Test]
+    [HandlerFunctions('FieldValue_SetAndGet_Handler')]
+    procedure FieldValue_SetAndGet_RoundTrips_Decimal()
+    begin
+        // Positive: SetValue(42.5) then AsDecimal() must return 42.5.
+        // Proves field value write + read round-trips correctly.
+        Src.RunReport();
+        Assert.AreEqual(42.5, FieldDecimal, 'SetValue(42.5) then AsDecimal() must return 42.5');
+    end;
+
+    [RequestPageHandler]
+    procedure FieldValue_SetAndGet_Handler(var RequestPage: TestRequestPage "TRM Report")
+    begin
+        RequestPage."AmountFld".SetValue(42.5);
+        FieldDecimal := RequestPage."AmountFld".AsDecimal();
+    end;
+
+    [Test]
+    [HandlerFunctions('FieldValue_NotDefaultWhenSet_Handler')]
+    procedure FieldValue_NotDefaultWhenSet()
+    begin
+        // Negative: a no-op SetValue that discards the write would return 0.
+        // This test fails if the field value is not stored.
+        Src.RunReport();
+        Assert.AreNotEqual(0, FieldDecimal, 'Field value after SetValue must not be the zero default');
+    end;
+
+    [RequestPageHandler]
+    procedure FieldValue_NotDefaultWhenSet_Handler(var RequestPage: TestRequestPage "TRM Report")
+    begin
+        RequestPage."AmountFld".SetValue(99);
+        FieldDecimal := RequestPage."AmountFld".AsDecimal();
+    end;
+
 }

--- a/tests/bucket-1/273-page-background-task/src/BGTaskSrc.al
+++ b/tests/bucket-1/273-page-background-task/src/BGTaskSrc.al
@@ -3,7 +3,7 @@
 /// GetBackgroundParameters, SetBackgroundTaskResult are static Page.* methods.
 
 // ── Minimal page ──────────────────────────────────────────────────────────────
-page 113000 "BGT Page"
+page 115000 "BGT Page"
 {
     PageType = Card;
     ApplicationArea = All;
@@ -12,7 +12,7 @@ page 113000 "BGT Page"
 }
 
 // ── Page extension that calls all four background task methods ────────────────
-pageextension 113001 "BGT Page Ext" extends "BGT Page"
+pageextension 115001 "BGT Page Ext" extends "BGT Page"
 {
     trigger OnOpenPage()
     var
@@ -36,12 +36,12 @@ pageextension 113001 "BGT Page Ext" extends "BGT Page"
 }
 
 // ── Stub codeunit for the background task (just needs to exist) ───────────────
-codeunit 113002 "BGT Codeunit"
+codeunit 115002 "BGT Codeunit"
 {
 }
 
 // ── Helper codeunit with assertions accessible from test ─────────────────────
-codeunit 113003 "BGT Helper"
+codeunit 115003 "BGT Helper"
 {
     procedure AllMethodsCompile(): Boolean
     begin

--- a/tests/bucket-1/273-page-background-task/test/BGTaskTest.al
+++ b/tests/bucket-1/273-page-background-task/test/BGTaskTest.al
@@ -1,4 +1,4 @@
-codeunit 113004 "BGT Tests"
+codeunit 115004 "BGT Tests"
 {
     Subtype = Test;
 


### PR DESCRIPTION
Closes #848

## Summary

- Added proving tests to `269-testrequestpage-methods`: `FieldValue_SetAndGet_RoundTrips_Decimal` and `FieldValue_NotDefaultWhenSet` confirm that `SetValue(integer)` → `AsDecimal()` round-trips correctly through a `[RequestPageHandler]`
- Fixed `ExtractDecimal` in `AlScope.cs` to handle `NavInteger` and `NavBigInteger` BC types, which previously threw `"Unable to cast NavInteger to IConvertible"` when `SetValue(99)` was called in a request page handler
- Updated `docs/coverage.yaml` for `TestField.AsDecimal` and `TestField.SetValue`

## Root cause

`AlCompat.ObjectToDecimal` calls `ExtractDecimal`, which handled `decimal`, `double`, `float`, and `Decimal18`/`NavDecimal` but not `NavInteger` or `NavBigInteger`. Passing an integer literal to `SetValue()` in a `TestRequestPage` handler stored the value as `NavInteger`, and the subsequent `AsDecimal()` call hit `Convert.ToDecimal(NavInteger)` which throws because `NavInteger` doesn't implement `IConvertible`.

## Test plan

- RED: `FieldValue_NotDefaultWhenSet` failed with `Unable to cast NavInteger to IConvertible`
- GREEN: both new tests pass after adding `NavInteger`/`NavBigInteger` branches to `ExtractDecimal`
- Full bucket-1 regression: 1286 passed, 2 failed (pre-existing DT2Time timezone failures unrelated to this change)