### PR TITLE
feat: SessionSettings.ProfileAppId/ProfileSystemScope tests + fix bucket-1 ID collision (issue #846)

### DIFF
--- a/AlRunner/Runtime/MockSessionSettings.cs
+++ b/AlRunner/Runtime/MockSessionSettings.cs
@@ -26,7 +26,7 @@ public class MockSessionSettings
         ALLocaleId = 0;
         ALProfileId = "";
         ALProfileAppId = new NavGuid(System.Guid.Empty);
-        ALProfileSystemScope = 0;
+        ALProfileSystemScope = false;
         ALTimeZone = "";
     }
 
@@ -45,8 +45,8 @@ public class MockSessionSettings
     /// <summary>ProfileAppId — GUID.</summary>
     public NavGuid ALProfileAppId { get; set; } = new NavGuid(System.Guid.Empty);
 
-    /// <summary>ProfileSystemScope — option (System / Tenant / Extension).</summary>
-    public int ALProfileSystemScope { get; set; }
+    /// <summary>ProfileSystemScope — Boolean (true = System scope, false = Tenant scope).</summary>
+    public bool ALProfileSystemScope { get; set; }
 
     /// <summary>TimeZone — IANA/Windows time-zone name.</summary>
     public string ALTimeZone { get; set; } = "";

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -5763,9 +5763,9 @@ SessionSettings.LocaleId:
 SessionSettings.ProfileAppId:
   layer: runtime-api
   category: SessionSettings
-  status: stub
+  status: covered
   tests: tests/bucket-2/192-session-settings
-  notes: overloads=1. Property present on MockSessionSettings (NavGuid, defaults to Guid.Empty); explicit setter/getter tests TBD.
+  notes: overloads=1. NavGuid setter + getter round-trip; defaults to empty GUID.
 
 SessionSettings.ProfileId:
   layer: runtime-api
@@ -5777,9 +5777,9 @@ SessionSettings.ProfileId:
 SessionSettings.ProfileSystemScope:
   layer: runtime-api
   category: SessionSettings
-  status: stub
+  status: covered
   tests: tests/bucket-2/192-session-settings
-  notes: overloads=1. Option-typed property present on MockSessionSettings; explicit setter/getter tests TBD.
+  notes: overloads=1. Boolean setter + getter round-trip; defaults to false on MockSessionSettings.
 
 SessionSettings.RequestSessionUpdate:
   layer: runtime-api

--- a/tests/bucket-1/273-page-background-task/src/BGTaskSrc.al
+++ b/tests/bucket-1/273-page-background-task/src/BGTaskSrc.al
@@ -3,7 +3,7 @@
 /// GetBackgroundParameters, SetBackgroundTaskResult are static Page.* methods.
 
 // ── Minimal page ──────────────────────────────────────────────────────────────
-page 113000 "BGT Page"
+page 115000 "BGT Page"
 {
     PageType = Card;
     ApplicationArea = All;
@@ -12,7 +12,7 @@ page 113000 "BGT Page"
 }
 
 // ── Page extension that calls all four background task methods ────────────────
-pageextension 113001 "BGT Page Ext" extends "BGT Page"
+pageextension 115001 "BGT Page Ext" extends "BGT Page"
 {
     trigger OnOpenPage()
     var
@@ -36,12 +36,12 @@ pageextension 113001 "BGT Page Ext" extends "BGT Page"
 }
 
 // ── Stub codeunit for the background task (just needs to exist) ───────────────
-codeunit 113002 "BGT Codeunit"
+codeunit 115002 "BGT Codeunit"
 {
 }
 
 // ── Helper codeunit with assertions accessible from test ─────────────────────
-codeunit 113003 "BGT Helper"
+codeunit 115003 "BGT Helper"
 {
     procedure AllMethodsCompile(): Boolean
     begin

--- a/tests/bucket-1/273-page-background-task/test/BGTaskTest.al
+++ b/tests/bucket-1/273-page-background-task/test/BGTaskTest.al
@@ -1,4 +1,4 @@
-codeunit 113004 "BGT Tests"
+codeunit 115004 "BGT Tests"
 {
     Subtype = Test;
 

--- a/tests/bucket-2/192-session-settings/src/SessionSettingsSrc.al
+++ b/tests/bucket-2/192-session-settings/src/SessionSettingsSrc.al
@@ -65,6 +65,40 @@ codeunit 60180 "SST Src"
         exit(s.ProfileId);
     end;
 
+    procedure GetProfileAppId(): Guid
+    var
+        s: SessionSettings;
+    begin
+        s.Init();
+        exit(s.ProfileAppId);
+    end;
+
+    procedure SetAndGetProfileAppId(value: Guid): Guid
+    var
+        s: SessionSettings;
+    begin
+        s.Init();
+        s.ProfileAppId := value;
+        exit(s.ProfileAppId);
+    end;
+
+    procedure GetProfileSystemScope(): Boolean
+    var
+        s: SessionSettings;
+    begin
+        s.Init();
+        exit(s.ProfileSystemScope);
+    end;
+
+    procedure SetAndGetProfileSystemScope(value: Boolean): Boolean
+    var
+        s: SessionSettings;
+    begin
+        s.Init();
+        s.ProfileSystemScope := value;
+        exit(s.ProfileSystemScope);
+    end;
+
     procedure RequestSessionUpdate_NoOp(): Boolean
     var
         s: SessionSettings;

--- a/tests/bucket-2/192-session-settings/test/SessionSettingsTest.al
+++ b/tests/bucket-2/192-session-settings/test/SessionSettingsTest.al
@@ -70,4 +70,52 @@ codeunit 60181 "SST Test"
         Assert.AreNotEqual('', Src.SetAndGetCompany('Contoso'),
             'Company setter must not be a no-op — value must persist');
     end;
+
+    [Test]
+    procedure ProfileAppId_DefaultsToEmptyGuid()
+    begin
+        Assert.IsTrue(IsNullGuid(Src.GetProfileAppId()),
+            'Default SessionSettings.ProfileAppId must be the empty GUID');
+    end;
+
+    [Test]
+    procedure SetAndGet_ProfileAppId()
+    var
+        g: Guid;
+    begin
+        g := '{12345678-1234-1234-1234-1234567890AB}';
+        Assert.AreEqual(g, Src.SetAndGetProfileAppId(g),
+            'SessionSettings.ProfileAppId setter + getter must round-trip');
+    end;
+
+    [Test]
+    procedure ProfileAppId_Setter_NotANoop()
+    var
+        g: Guid;
+    begin
+        g := '{12345678-1234-1234-1234-1234567890AB}';
+        Assert.IsFalse(IsNullGuid(Src.SetAndGetProfileAppId(g)),
+            'ProfileAppId setter must not be a no-op — value must differ from empty GUID');
+    end;
+
+    [Test]
+    procedure ProfileSystemScope_DefaultsToFalse()
+    begin
+        Assert.IsFalse(Src.GetProfileSystemScope(),
+            'Default SessionSettings.ProfileSystemScope must be false');
+    end;
+
+    [Test]
+    procedure SetAndGet_ProfileSystemScope()
+    begin
+        Assert.IsTrue(Src.SetAndGetProfileSystemScope(true),
+            'SessionSettings.ProfileSystemScope setter + getter must round-trip');
+    end;
+
+    [Test]
+    procedure ProfileSystemScope_Setter_NotANoop()
+    begin
+        Assert.AreNotEqual(false, Src.SetAndGetProfileSystemScope(true),
+            'ProfileSystemScope setter must not be a no-op — true must not equal default false');
+    end;
 }


### PR DESCRIPTION
Closes #846

## Changes

**Primary (issue #846):** Fix `MockSessionSettings.ALProfileSystemScope` type (`int` → `bool`); add proving setter/getter round-trip and negative-trap tests for `ProfileAppId` and `ProfileSystemScope` in the `192-session-settings` suite (15 tests, all green).

**Collateral fix:** Renumber `273-page-background-task` IDs 113000–113004 → 115000–115004. The BGT suite (merged in #847) used IDs 113000-113003 that collide with `100-page-promptmode` (merged in #840), breaking bucket-1 compilation on all BC versions. This renumbering restores unique IDs.

## Files changed
- `AlRunner/Runtime/MockSessionSettings.cs`: `ALProfileSystemScope` `int` → `bool`, `ALInit()` uses `false`
- `tests/bucket-2/192-session-settings/src/SessionSettingsSrc.al`: 4 new helper procedures
- `tests/bucket-2/192-session-settings/test/SessionSettingsTest.al`: 6 new proving tests
- `tests/bucket-1/273-page-background-task/`: renumbered 113000-113004 → 115000-115004
- `docs/coverage.yaml`: ProfileAppId and ProfileSystemScope marked `covered`