### PR TITLE
feat: Database.SessionId and HasTableConnection proving tests (issue #843)

### DIFF
--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -1657,8 +1657,9 @@ Database.GetDefaultTableConnection:
 Database.HasTableConnection:
   layer: runtime-api
   category: Database
-  status: stub
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-1/101-database-stubs
+  notes: overloads=1; returns false for unregistered connections.
 
 Database.ImportData:
   layer: runtime-api
@@ -1738,8 +1739,9 @@ Database.ServiceInstanceId:
 Database.SessionId:
   layer: runtime-api
   category: Database
-  status: stub
-  notes: overloads=1; returns 1 (stable non-zero stub)
+  status: covered
+  tests: tests/bucket-1/101-database-stubs
+  notes: overloads=1; returns 1 (stable non-zero stub); proved non-zero and stable.
 
 Database.SetDefaultTableConnection:
   layer: runtime-api

--- a/tests/bucket-1/101-database-stubs/src/DatabaseStubsSrc.al
+++ b/tests/bucket-1/101-database-stubs/src/DatabaseStubsSrc.al
@@ -1,0 +1,12 @@
+codeunit 116000 "DB Stubs Src"
+{
+    procedure GetSessionId(): Integer
+    begin
+        exit(Database.SessionId());
+    end;
+
+    procedure HasTableConnectionCRM(connName: Text): Boolean
+    begin
+        exit(Database.HasTableConnection(TableConnectionType::CRM, connName));
+    end;
+}

--- a/tests/bucket-1/101-database-stubs/test/DatabaseStubsTest.al
+++ b/tests/bucket-1/101-database-stubs/test/DatabaseStubsTest.al
@@ -1,0 +1,46 @@
+codeunit 116001 "DB Stubs Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "DB Stubs Src";
+
+    [Test]
+    procedure SessionId_IsNonZero()
+    begin
+        Assert.IsTrue(Src.GetSessionId() > 0,
+            'Database.SessionId must return a positive non-zero stub value');
+    end;
+
+    [Test]
+    procedure SessionId_IsStable()
+    begin
+        Assert.AreEqual(Src.GetSessionId(), Src.GetSessionId(),
+            'Database.SessionId must return the same value on repeated calls');
+    end;
+
+    [Test]
+    procedure SessionId_IsNotNoop()
+    begin
+        // Negative trap: a no-op returning 0 would fail the > 0 check;
+        // additionally confirm the return value is a specific stable positive int.
+        Assert.AreNotEqual(0, Src.GetSessionId(),
+            'Database.SessionId must not return 0 — stub must return at least 1');
+    end;
+
+    [Test]
+    procedure HasTableConnection_UnregisteredReturnsFalse()
+    begin
+        Assert.IsFalse(Src.HasTableConnectionCRM('NonExistent'),
+            'HasTableConnection must return false for an unregistered connection name');
+    end;
+
+    [Test]
+    procedure HasTableConnection_NotANoop()
+    begin
+        // Negative trap: a stub always returning true would fail this assertion.
+        Assert.AreNotEqual(true, Src.HasTableConnectionCRM('AlsoNotRegistered'),
+            'HasTableConnection must not be a no-op always returning true');
+    end;
+}


### PR DESCRIPTION
Closes #843

Add 5-test suite `tests/bucket-1/101-database-stubs` (codeunits 116000/116001) proving:
- `Database.SessionId()` returns a stable positive integer (non-zero, same on repeated calls)
- `Database.HasTableConnection(type, name)` returns false for unregistered connections

Both stubs already existed; this PR adds the RED/GREEN proving tests that were missing. Update `docs/coverage.yaml`: both entries `stub` → `covered`.

IDs 116000/116001 were chosen to avoid collision with `210-testpage-action-invoke` (114001) on main.