### PR TITLE
feat: Variant.IsXml*/IsInStream/IsOutStream/IsDictionary type-check methods

### DIFF
--- a/AlRunner/Runtime/AlScope.cs
+++ b/AlRunner/Runtime/AlScope.cs
@@ -1532,7 +1532,7 @@ public static class AlCompat
     public static bool ALIsNotification(object? v) { v = UnwrapVariant(v); return v is MockNotification; }
     public static bool ALIsTextBuilder(object? v) { v = UnwrapVariant(v); return v is MockTextBuilder; }
     public static bool ALIsList(object? v) { v = UnwrapVariant(v); return v != null && v.GetType().IsGenericType && (v.GetType().GetGenericTypeDefinition().FullName?.StartsWith("Microsoft.Dynamics.Nav.Runtime.NavList", StringComparison.Ordinal) == true); }
-    public static bool ALIsDictionary(object? v) => false;
+    public static bool ALIsDictionary(object? v) { v = UnwrapVariant(v); return v != null && v.GetType().IsGenericType && (v.GetType().GetGenericTypeDefinition().FullName?.StartsWith("Microsoft.Dynamics.Nav.Runtime.NavDictionary", StringComparison.Ordinal) == true); }
 
     // Misc stubs — no mock types in standalone mode
     public static bool ALIsAction(object? v) => false;

--- a/AlRunner/Runtime/MockVariant.cs
+++ b/AlRunner/Runtime/MockVariant.cs
@@ -113,33 +113,36 @@ public class MockVariant
         _value.GetType().IsGenericType &&
         _value.GetType().GetGenericTypeDefinition().FullName?.StartsWith("Microsoft.Dynamics.Nav.Runtime.NavList", StringComparison.Ordinal) == true;
 
-    // IsDictionary — no Dictionary mock in standalone mode; always false
-    public bool ALIsDictionary => false;
+    // IsDictionary — NavDictionary<K,V> is generic; check open generic definition
+    public bool ALIsDictionary => _value != null &&
+        _value.GetType().IsGenericType &&
+        _value.GetType().GetGenericTypeDefinition().FullName?.StartsWith(
+            "Microsoft.Dynamics.Nav.Runtime.NavDictionary", StringComparison.Ordinal) == true;
 
-    // XML Is* — no XML mocks in standalone mode; always false
-    public bool ALIsXmlAttribute => false;
-    public bool ALIsXmlAttributeCollection => false;
-    public bool ALIsXmlCData => false;
-    public bool ALIsXmlComment => false;
-    public bool ALIsXmlDeclaration => false;
-    public bool ALIsXmlDocument => false;
-    public bool ALIsXmlDocumentType => false;
-    public bool ALIsXmlElement => false;
-    public bool ALIsXmlNamespaceManager => false;
-    public bool ALIsXmlNameTable => false;
-    public bool ALIsXmlNode => false;
-    public bool ALIsXmlNodeList => false;
-    public bool ALIsXmlProcessingInstruction => false;
-    public bool ALIsXmlReadOptions => false;
-    public bool ALIsXmlText => false;
-    public bool ALIsXmlWriteOptions => false;
+    // XML Is* — check BC runtime types (NavXml* work standalone; XmlNameTable is mocked)
+    public bool ALIsXmlAttribute => _value is NavXmlAttribute;
+    public bool ALIsXmlAttributeCollection => _value is NavXmlAttributeCollection;
+    public bool ALIsXmlCData => _value is NavXmlCData;
+    public bool ALIsXmlComment => _value is NavXmlComment;
+    public bool ALIsXmlDeclaration => _value is NavXmlDeclaration;
+    public bool ALIsXmlDocument => _value is NavXmlDocument;
+    public bool ALIsXmlDocumentType => _value is NavXmlDocumentType;
+    public bool ALIsXmlElement => _value is NavXmlElement;
+    public bool ALIsXmlNamespaceManager => _value is NavXmlNamespaceManager;
+    public bool ALIsXmlNameTable => _value is MockXmlNameTable;
+    public bool ALIsXmlNode => _value is NavXmlNode;
+    public bool ALIsXmlNodeList => _value is NavXmlNodeList;
+    public bool ALIsXmlProcessingInstruction => _value is NavXmlProcessingInstruction;
+    public bool ALIsXmlReadOptions => _value is NavXmlReadOptions;
+    public bool ALIsXmlText => _value is NavXmlText;
+    public bool ALIsXmlWriteOptions => _value is NavXmlWriteOptions;
 
     // Misc stubs — types not representable in standalone mode
     public bool ALIsAction => false;
     public bool ALIsAutomation => false;
     public bool ALIsBinary => false;
     public bool ALIsClientType => false;
-    public bool ALIsCodeunit => false;
+    public bool ALIsCodeunit => _value is MockCodeunitHandle;
     public bool ALIsDataClassification => false;
     public bool ALIsDataClassificationType => false;
     public bool ALIsDefaultLayout => false;

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -8234,7 +8234,7 @@ Variant.IsCodeunit:
   layer: runtime-api
   category: Variant
   status: stub
-  notes: overloads=1; always returns false (codeunit identity not tracked in Variant)
+  notes: overloads=1; checks MockCodeunitHandle — no direct test yet
 
 Variant.IsDataClassification:
   layer: runtime-api
@@ -8281,8 +8281,9 @@ Variant.IsDefaultLayout:
 Variant.IsDictionary:
   layer: runtime-api
   category: Variant
-  status: stub
-  notes: overloads=1; always returns false (no Dictionary mock in standalone mode)
+  status: covered
+  tests: tests/bucket-1/274-variant-typecheck
+  notes: overloads=1; checks NavDictionary open generic via AlCompat.ALIsDictionary
 
 Variant.IsDotNet:
   layer: runtime-api
@@ -8329,8 +8330,9 @@ Variant.IsGuid:
 Variant.IsInStream:
   layer: runtime-api
   category: Variant
-  status: stub
-  notes: overloads=1; always returns false (stream assignment to Variant not tested in standalone)
+  status: covered
+  tests: tests/bucket-1/274-variant-typecheck
+  notes: overloads=1; checks MockInStream via AlCompat.ALIsInStream
 
 Variant.IsInteger:
   layer: runtime-api
@@ -8401,8 +8403,9 @@ Variant.IsOption:
 Variant.IsOutStream:
   layer: runtime-api
   category: Variant
-  status: stub
-  notes: overloads=1; always returns false (stream assignment to Variant not tested in standalone)
+  status: covered
+  tests: tests/bucket-1/274-variant-typecheck
+  notes: overloads=1; checks MockOutStream via AlCompat.ALIsOutStream
 
 Variant.IsPromptMode:
   layer: runtime-api
@@ -8499,98 +8502,108 @@ Variant.IsWideChar:
 Variant.IsXmlAttribute:
   layer: runtime-api
   category: Variant
-  status: stub
-  notes: overloads=1; always returns false (no XML mock in standalone mode)
+  status: covered
+  tests: tests/bucket-1/274-variant-typecheck
+  notes: overloads=1; checks NavXmlAttribute via MockVariant
 
 Variant.IsXmlAttributeCollection:
   layer: runtime-api
   category: Variant
   status: stub
-  notes: overloads=1; always returns false
+  notes: overloads=1; checks NavXmlAttributeCollection — no direct test yet
 
 Variant.IsXmlCData:
   layer: runtime-api
   category: Variant
-  status: stub
-  notes: overloads=1; always returns false
+  status: covered
+  tests: tests/bucket-1/274-variant-typecheck
+  notes: overloads=1; checks NavXmlCData via MockVariant
 
 Variant.IsXmlComment:
   layer: runtime-api
   category: Variant
-  status: stub
-  notes: overloads=1; always returns false
+  status: covered
+  tests: tests/bucket-1/274-variant-typecheck
+  notes: overloads=1; checks NavXmlComment via MockVariant
 
 Variant.IsXmlDeclaration:
   layer: runtime-api
   category: Variant
-  status: stub
-  notes: overloads=1; always returns false
+  status: covered
+  tests: tests/bucket-1/274-variant-typecheck
+  notes: overloads=1; checks NavXmlDeclaration via MockVariant
 
 Variant.IsXmlDocument:
   layer: runtime-api
   category: Variant
-  status: stub
-  notes: overloads=1; always returns false
+  status: covered
+  tests: tests/bucket-1/274-variant-typecheck
+  notes: overloads=1; checks NavXmlDocument via MockVariant
 
 Variant.IsXmlDocumentType:
   layer: runtime-api
   category: Variant
   status: stub
-  notes: overloads=1; always returns false
+  notes: overloads=1; checks NavXmlDocumentType — no direct test yet
 
 Variant.IsXmlElement:
   layer: runtime-api
   category: Variant
-  status: stub
-  notes: overloads=1; always returns false
+  status: covered
+  tests: tests/bucket-1/274-variant-typecheck
+  notes: overloads=1; checks NavXmlElement via MockVariant
 
 Variant.IsXmlNamespaceManager:
   layer: runtime-api
   category: Variant
   status: stub
-  notes: overloads=1; always returns false
+  notes: overloads=1; checks NavXmlNamespaceManager — no direct test yet
 
 Variant.IsXmlNameTable:
   layer: runtime-api
   category: Variant
   status: stub
-  notes: overloads=1; always returns false
+  notes: overloads=1; checks MockXmlNameTable — no direct test yet
 
 Variant.IsXmlNode:
   layer: runtime-api
   category: Variant
-  status: stub
-  notes: overloads=1; always returns false
+  status: covered
+  tests: tests/bucket-1/274-variant-typecheck
+  notes: overloads=1; checks NavXmlNode via MockVariant
 
 Variant.IsXmlNodeList:
   layer: runtime-api
   category: Variant
-  status: stub
-  notes: overloads=1; always returns false
+  status: covered
+  tests: tests/bucket-1/274-variant-typecheck
+  notes: overloads=1; checks NavXmlNodeList via MockVariant
 
 Variant.IsXmlProcessingInstruction:
   layer: runtime-api
   category: Variant
-  status: stub
-  notes: overloads=1; always returns false
+  status: covered
+  tests: tests/bucket-1/274-variant-typecheck
+  notes: overloads=1; checks NavXmlProcessingInstruction via MockVariant
 
 Variant.IsXmlReadOptions:
   layer: runtime-api
   category: Variant
   status: stub
-  notes: overloads=1; always returns false
+  notes: overloads=1; checks NavXmlReadOptions — no direct test yet
 
 Variant.IsXmlText:
   layer: runtime-api
   category: Variant
-  status: stub
-  notes: overloads=1; always returns false
+  status: covered
+  tests: tests/bucket-1/274-variant-typecheck
+  notes: overloads=1; checks NavXmlText via MockVariant
 
 Variant.IsXmlWriteOptions:
   layer: runtime-api
   category: Variant
   status: stub
-  notes: overloads=1; always returns false
+  notes: overloads=1; checks NavXmlWriteOptions — no direct test yet
 
 # ── Version ─────────────────────────────────────────────────────
 

--- a/tests/bucket-1/274-variant-typecheck/src/VTCSrc.al
+++ b/tests/bucket-1/274-variant-typecheck/src/VTCSrc.al
@@ -3,7 +3,7 @@
 ///   XmlDocument, XmlElement, XmlNode, XmlProcessingInstruction, XmlCData,
 ///   XmlComment, XmlDeclaration, XmlText, XmlNodeList, XmlAttribute,
 ///   InStream, OutStream, Codeunit, Dictionary.
-table 116000 "VTC Data"
+table 118000 "VTC Data"
 {
     fields
     {
@@ -16,7 +16,7 @@ table 116000 "VTC Data"
     }
 }
 
-codeunit 116001 "VTC Src"
+codeunit 118001 "VTC Src"
 {
     // ── XmlDocument ────────────────────────────────────────────────────────────
 

--- a/tests/bucket-1/274-variant-typecheck/src/VTCSrc.al
+++ b/tests/bucket-1/274-variant-typecheck/src/VTCSrc.al
@@ -1,0 +1,290 @@
+/// Helper codeunit + table exercising Variant.IsXxx type-check methods (issue #844).
+/// Tests cover the subset where the runner has mock support:
+///   XmlDocument, XmlElement, XmlNode, XmlProcessingInstruction, XmlCData,
+///   XmlComment, XmlDeclaration, XmlText, XmlNodeList, XmlAttribute,
+///   InStream, OutStream, Codeunit, Dictionary.
+table 116000 "VTC Data"
+{
+    fields
+    {
+        field(1; "Entry No."; Integer) { }
+        field(2; Content; Blob) { }
+    }
+    keys
+    {
+        key(PK; "Entry No.") { Clustered = true; }
+    }
+}
+
+codeunit 116001 "VTC Src"
+{
+    // ── XmlDocument ────────────────────────────────────────────────────────────
+
+    procedure IsXmlDocument_ForDoc(): Boolean
+    var
+        v: Variant;
+        Doc: XmlDocument;
+    begin
+        Doc := XmlDocument.Create();
+        v := Doc;
+        exit(v.IsXmlDocument());
+    end;
+
+    procedure IsXmlDocument_ForInteger(): Boolean
+    var
+        v: Variant;
+    begin
+        v := 42;
+        exit(v.IsXmlDocument());
+    end;
+
+    // ── XmlElement ────────────────────────────────────────────────────────────
+
+    procedure IsXmlElement_ForElement(): Boolean
+    var
+        v: Variant;
+        Elem: XmlElement;
+    begin
+        Elem := XmlElement.Create('root');
+        v := Elem;
+        exit(v.IsXmlElement());
+    end;
+
+    procedure IsXmlElement_ForDoc(): Boolean
+    var
+        v: Variant;
+        Doc: XmlDocument;
+    begin
+        Doc := XmlDocument.Create();
+        v := Doc;
+        exit(v.IsXmlElement());
+    end;
+
+    // ── XmlNode ────────────────────────────────────────────────────────────────
+
+    procedure IsXmlNode_ForElement(): Boolean
+    var
+        v: Variant;
+        Elem: XmlElement;
+        Node: XmlNode;
+    begin
+        Elem := XmlElement.Create('root');
+        Node := Elem.AsXmlNode();
+        v := Node;
+        exit(v.IsXmlNode());
+    end;
+
+    procedure IsXmlNode_ForInteger(): Boolean
+    var
+        v: Variant;
+    begin
+        v := 99;
+        exit(v.IsXmlNode());
+    end;
+
+    // ── XmlProcessingInstruction ──────────────────────────────────────────────
+
+    procedure IsXmlPI_ForPI(): Boolean
+    var
+        v: Variant;
+        PI: XmlProcessingInstruction;
+    begin
+        PI := XmlProcessingInstruction.Create('target', 'data');
+        v := PI;
+        exit(v.IsXmlProcessingInstruction());
+    end;
+
+    procedure IsXmlPI_ForElement(): Boolean
+    var
+        v: Variant;
+        Elem: XmlElement;
+    begin
+        Elem := XmlElement.Create('root');
+        v := Elem;
+        exit(v.IsXmlProcessingInstruction());
+    end;
+
+    // ── XmlCData ──────────────────────────────────────────────────────────────
+
+    procedure IsXmlCData_ForCData(): Boolean
+    var
+        v: Variant;
+        CData: XmlCData;
+    begin
+        CData := XmlCData.Create('some data');
+        v := CData;
+        exit(v.IsXmlCData());
+    end;
+
+    procedure IsXmlCData_ForText(): Boolean
+    var
+        v: Variant;
+    begin
+        v := 'text';
+        exit(v.IsXmlCData());
+    end;
+
+    // ── XmlComment ────────────────────────────────────────────────────────────
+
+    procedure IsXmlComment_ForComment(): Boolean
+    var
+        v: Variant;
+        Comment: XmlComment;
+    begin
+        Comment := XmlComment.Create('a comment');
+        v := Comment;
+        exit(v.IsXmlComment());
+    end;
+
+    procedure IsXmlComment_ForText(): Boolean
+    var
+        v: Variant;
+    begin
+        v := 'text';
+        exit(v.IsXmlComment());
+    end;
+
+    // ── XmlDeclaration ────────────────────────────────────────────────────────
+
+    procedure IsXmlDeclaration_ForDecl(): Boolean
+    var
+        v: Variant;
+        Decl: XmlDeclaration;
+    begin
+        Decl := XmlDeclaration.Create('1.0', 'UTF-8', '');
+        v := Decl;
+        exit(v.IsXmlDeclaration());
+    end;
+
+    procedure IsXmlDeclaration_ForText(): Boolean
+    var
+        v: Variant;
+    begin
+        v := 'text';
+        exit(v.IsXmlDeclaration());
+    end;
+
+    // ── XmlText ───────────────────────────────────────────────────────────────
+
+    procedure IsXmlText_ForXmlText(): Boolean
+    var
+        v: Variant;
+        XT: XmlText;
+    begin
+        XT := XmlText.Create('hello');
+        v := XT;
+        exit(v.IsXmlText());
+    end;
+
+    procedure IsXmlText_ForText(): Boolean
+    var
+        v: Variant;
+    begin
+        v := 'hello';
+        exit(v.IsXmlText());
+    end;
+
+    // ── XmlNodeList ───────────────────────────────────────────────────────────
+
+    procedure IsXmlNodeList_ForNodeList(): Boolean
+    var
+        v: Variant;
+        Elem: XmlElement;
+        NL: XmlNodeList;
+    begin
+        Elem := XmlElement.Create('root');
+        NL := Elem.GetChildNodes();
+        v := NL;
+        exit(v.IsXmlNodeList());
+    end;
+
+    procedure IsXmlNodeList_ForText(): Boolean
+    var
+        v: Variant;
+    begin
+        v := 'text';
+        exit(v.IsXmlNodeList());
+    end;
+
+    // ── XmlAttribute ──────────────────────────────────────────────────────────
+
+    procedure IsXmlAttribute_ForAttr(): Boolean
+    var
+        v: Variant;
+        Attr: XmlAttribute;
+    begin
+        Attr := XmlAttribute.Create('name', 'value');
+        v := Attr;
+        exit(v.IsXmlAttribute());
+    end;
+
+    procedure IsXmlAttribute_ForText(): Boolean
+    var
+        v: Variant;
+    begin
+        v := 'text';
+        exit(v.IsXmlAttribute());
+    end;
+
+    // ── InStream / OutStream ──────────────────────────────────────────────────
+
+    procedure IsInStream_ForInStream(): Boolean
+    var
+        v: Variant;
+        Rec: Record "VTC Data";
+        IS: InStream;
+    begin
+        Rec."Entry No." := 1;
+        Rec.Content.CreateInStream(IS);
+        v := IS;
+        exit(v.IsInStream());
+    end;
+
+    procedure IsInStream_ForText(): Boolean
+    var
+        v: Variant;
+    begin
+        v := 'hello';
+        exit(v.IsInStream());
+    end;
+
+    procedure IsOutStream_ForOutStream(): Boolean
+    var
+        v: Variant;
+        Rec: Record "VTC Data";
+        OS: OutStream;
+    begin
+        Rec."Entry No." := 1;
+        Rec.Content.CreateOutStream(OS);
+        v := OS;
+        exit(v.IsOutStream());
+    end;
+
+    procedure IsOutStream_ForText(): Boolean
+    var
+        v: Variant;
+    begin
+        v := 'hello';
+        exit(v.IsOutStream());
+    end;
+
+    // ── IsDictionary ──────────────────────────────────────────────────────────
+
+    procedure IsDictionary_ForDict(): Boolean
+    var
+        v: Variant;
+        D: Dictionary of [Text, Text];
+    begin
+        D.Add('k', 'v');
+        v := D;
+        exit(v.IsDictionary());
+    end;
+
+    procedure IsDictionary_ForText(): Boolean
+    var
+        v: Variant;
+    begin
+        v := 'text';
+        exit(v.IsDictionary());
+    end;
+}

--- a/tests/bucket-1/274-variant-typecheck/test/VTCTest.al
+++ b/tests/bucket-1/274-variant-typecheck/test/VTCTest.al
@@ -1,0 +1,216 @@
+codeunit 116002 "VTC Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "VTC Src";
+
+    // ── XmlDocument ────────────────────────────────────────────────────────────
+
+    [Test]
+    procedure VTC_IsXmlDocument_TrueForXmlDocument()
+    begin
+        Assert.IsTrue(Src.IsXmlDocument_ForDoc(),
+            'IsXmlDocument must be true when Variant holds XmlDocument');
+    end;
+
+    [Test]
+    procedure VTC_IsXmlDocument_FalseForInteger()
+    begin
+        Assert.IsFalse(Src.IsXmlDocument_ForInteger(),
+            'IsXmlDocument must be false when Variant holds Integer');
+    end;
+
+    // ── XmlElement ────────────────────────────────────────────────────────────
+
+    [Test]
+    procedure VTC_IsXmlElement_TrueForXmlElement()
+    begin
+        Assert.IsTrue(Src.IsXmlElement_ForElement(),
+            'IsXmlElement must be true when Variant holds XmlElement');
+    end;
+
+    [Test]
+    procedure VTC_IsXmlElement_FalseForXmlDocument()
+    begin
+        Assert.IsFalse(Src.IsXmlElement_ForDoc(),
+            'IsXmlElement must be false when Variant holds XmlDocument');
+    end;
+
+    // ── XmlNode ────────────────────────────────────────────────────────────────
+
+    [Test]
+    procedure VTC_IsXmlNode_TrueForXmlNode()
+    begin
+        Assert.IsTrue(Src.IsXmlNode_ForElement(),
+            'IsXmlNode must be true when Variant holds XmlNode');
+    end;
+
+    [Test]
+    procedure VTC_IsXmlNode_FalseForInteger()
+    begin
+        Assert.IsFalse(Src.IsXmlNode_ForInteger(),
+            'IsXmlNode must be false when Variant holds Integer');
+    end;
+
+    // ── XmlProcessingInstruction ──────────────────────────────────────────────
+
+    [Test]
+    procedure VTC_IsXmlPI_TrueForPI()
+    begin
+        Assert.IsTrue(Src.IsXmlPI_ForPI(),
+            'IsXmlProcessingInstruction must be true when Variant holds XmlProcessingInstruction');
+    end;
+
+    [Test]
+    procedure VTC_IsXmlPI_FalseForElement()
+    begin
+        Assert.IsFalse(Src.IsXmlPI_ForElement(),
+            'IsXmlProcessingInstruction must be false when Variant holds XmlElement');
+    end;
+
+    // ── XmlCData ──────────────────────────────────────────────────────────────
+
+    [Test]
+    procedure VTC_IsXmlCData_TrueForCData()
+    begin
+        Assert.IsTrue(Src.IsXmlCData_ForCData(),
+            'IsXmlCData must be true when Variant holds XmlCData');
+    end;
+
+    [Test]
+    procedure VTC_IsXmlCData_FalseForText()
+    begin
+        Assert.IsFalse(Src.IsXmlCData_ForText(),
+            'IsXmlCData must be false when Variant holds Text');
+    end;
+
+    // ── XmlComment ────────────────────────────────────────────────────────────
+
+    [Test]
+    procedure VTC_IsXmlComment_TrueForComment()
+    begin
+        Assert.IsTrue(Src.IsXmlComment_ForComment(),
+            'IsXmlComment must be true when Variant holds XmlComment');
+    end;
+
+    [Test]
+    procedure VTC_IsXmlComment_FalseForText()
+    begin
+        Assert.IsFalse(Src.IsXmlComment_ForText(),
+            'IsXmlComment must be false when Variant holds Text');
+    end;
+
+    // ── XmlDeclaration ────────────────────────────────────────────────────────
+
+    [Test]
+    procedure VTC_IsXmlDeclaration_TrueForDeclaration()
+    begin
+        Assert.IsTrue(Src.IsXmlDeclaration_ForDecl(),
+            'IsXmlDeclaration must be true when Variant holds XmlDeclaration');
+    end;
+
+    [Test]
+    procedure VTC_IsXmlDeclaration_FalseForText()
+    begin
+        Assert.IsFalse(Src.IsXmlDeclaration_ForText(),
+            'IsXmlDeclaration must be false when Variant holds Text');
+    end;
+
+    // ── XmlText ───────────────────────────────────────────────────────────────
+
+    [Test]
+    procedure VTC_IsXmlText_TrueForXmlText()
+    begin
+        Assert.IsTrue(Src.IsXmlText_ForXmlText(),
+            'IsXmlText must be true when Variant holds XmlText');
+    end;
+
+    [Test]
+    procedure VTC_IsXmlText_FalseForText()
+    begin
+        Assert.IsFalse(Src.IsXmlText_ForText(),
+            'IsXmlText must be false when Variant holds AL Text');
+    end;
+
+    // ── XmlNodeList ───────────────────────────────────────────────────────────
+
+    [Test]
+    procedure VTC_IsXmlNodeList_TrueForNodeList()
+    begin
+        Assert.IsTrue(Src.IsXmlNodeList_ForNodeList(),
+            'IsXmlNodeList must be true when Variant holds XmlNodeList');
+    end;
+
+    [Test]
+    procedure VTC_IsXmlNodeList_FalseForText()
+    begin
+        Assert.IsFalse(Src.IsXmlNodeList_ForText(),
+            'IsXmlNodeList must be false when Variant holds Text');
+    end;
+
+    // ── XmlAttribute ──────────────────────────────────────────────────────────
+
+    [Test]
+    procedure VTC_IsXmlAttribute_TrueForAttribute()
+    begin
+        Assert.IsTrue(Src.IsXmlAttribute_ForAttr(),
+            'IsXmlAttribute must be true when Variant holds XmlAttribute');
+    end;
+
+    [Test]
+    procedure VTC_IsXmlAttribute_FalseForText()
+    begin
+        Assert.IsFalse(Src.IsXmlAttribute_ForText(),
+            'IsXmlAttribute must be false when Variant holds Text');
+    end;
+
+    // ── InStream ──────────────────────────────────────────────────────────────
+
+    [Test]
+    procedure VTC_IsInStream_TrueForInStream()
+    begin
+        Assert.IsTrue(Src.IsInStream_ForInStream(),
+            'IsInStream must be true when Variant holds InStream');
+    end;
+
+    [Test]
+    procedure VTC_IsInStream_FalseForText()
+    begin
+        Assert.IsFalse(Src.IsInStream_ForText(),
+            'IsInStream must be false when Variant holds Text');
+    end;
+
+    // ── OutStream ─────────────────────────────────────────────────────────────
+
+    [Test]
+    procedure VTC_IsOutStream_TrueForOutStream()
+    begin
+        Assert.IsTrue(Src.IsOutStream_ForOutStream(),
+            'IsOutStream must be true when Variant holds OutStream');
+    end;
+
+    [Test]
+    procedure VTC_IsOutStream_FalseForText()
+    begin
+        Assert.IsFalse(Src.IsOutStream_ForText(),
+            'IsOutStream must be false when Variant holds Text');
+    end;
+
+    // ── IsDictionary ──────────────────────────────────────────────────────────
+
+    [Test]
+    procedure VTC_IsDictionary_TrueForDictionary()
+    begin
+        Assert.IsTrue(Src.IsDictionary_ForDict(),
+            'IsDictionary must be true when Variant holds Dictionary of [Text, Text]');
+    end;
+
+    [Test]
+    procedure VTC_IsDictionary_FalseForText()
+    begin
+        Assert.IsFalse(Src.IsDictionary_ForText(),
+            'IsDictionary must be false when Variant holds Text');
+    end;
+}

--- a/tests/bucket-1/274-variant-typecheck/test/VTCTest.al
+++ b/tests/bucket-1/274-variant-typecheck/test/VTCTest.al
@@ -1,4 +1,4 @@
-codeunit 116002 "VTC Tests"
+codeunit 118002 "VTC Tests"
 {
     Subtype = Test;
 


### PR DESCRIPTION
Closes #844

Replace all-false stubs in `MockVariant` with real BC `NavXml*` type checks.
Fix `AlCompat.ALIsDictionary` to inspect the `NavDictionary` open generic
(BC compiler routes `IsDictionary()` through `AlCompat` rather than the
`MockVariant` property). Add `MockVariant.ALIsCodeunit` to check
`MockCodeunitHandle`.

## Changes

- **`AlRunner/Runtime/MockVariant.cs`** — 16 XML Is* properties now check real
  `NavXml*` BC types (`NavXmlDocument`, `NavXmlElement`, `NavXmlNode`, etc.);
  `ALIsDictionary` checks open generic; `ALIsCodeunit` checks `MockCodeunitHandle`
- **`AlRunner/Runtime/AlScope.cs`** — `AlCompat.ALIsDictionary` fixed to match
  `NavDictionary<K,V>` by open generic prefix
- **`tests/bucket-1/274-variant-typecheck/`** — new suite, 26 tests covering
  positive + negative cases for all supported Variant.Is* XML/stream/dict checks
- **`tests/bucket-1/273-page-background-task/`** — fix object IDs 113000→116005
  to avoid collision with suite 100 (added after PR #847 was branched)
- **`docs/coverage.yaml`** — 10 entries promoted from `stub` to `covered`;
  6 remaining stubs updated with accurate type-check notes

## Test plan

- [x] 26 new VTC tests pass (positive + negative for each Is* method)
- [x] 5 BGT tests pass (suite 273 ID collision resolved)
- [x] Full bucket-1 run: 1325 passed, 4 failed (pre-existing failures in suites
  17 and 61, unrelated to this PR)