### PR TITLE
feat: TestPage.OpenEdit/OpenView/OpenNew — set editable state (issue #866)

### DIFF
--- a/AlRunner/Runtime/MockTestPageHandle.cs
+++ b/AlRunner/Runtime/MockTestPageHandle.cs
@@ -46,10 +46,11 @@ public class MockTestPageHandle
         PageId = pageId;
     }
 
-    // Lifecycle methods — no-ops in standalone mode
-    public void ALOpenEdit() { }
-    public void ALOpenView() { }
-    public void ALOpenNew() { }
+    private bool _editable = true;
+
+    public void ALOpenEdit() { _editable = true; }
+    public void ALOpenView() { _editable = false; }
+    public void ALOpenNew() { _editable = true; }
     public void ALClose() { }
     public void ALTrap() { }
     public void ALNew() { }
@@ -62,10 +63,10 @@ public class MockTestPageHandle
     public string ALCaption => "TestPage";
 
     /// <summary>
-    /// Whether the page is editable. Stub returns true.
+    /// Whether the page is editable. Set by ALOpenEdit/ALOpenView/ALOpenNew.
     /// BC emits <c>tP.Target.ALEditable</c> as a property access.
     /// </summary>
-    public bool ALEditable => true;
+    public bool ALEditable => _editable;
 
     /// <summary>
     /// Returns the number of validation errors on the page. Stub returns 0.

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -7332,20 +7332,23 @@ TestPage.OK:
 TestPage.OpenEdit:
   layer: runtime-api
   category: TestPage
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-1/102-testpage-openmode
+  notes: overloads=1; sets ALEditable=true on MockTestPageHandle.
 
 TestPage.OpenNew:
   layer: runtime-api
   category: TestPage
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-1/102-testpage-openmode
+  notes: overloads=1; sets ALEditable=true on MockTestPageHandle.
 
 TestPage.OpenView:
   layer: runtime-api
   category: TestPage
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-1/102-testpage-openmode
+  notes: overloads=1; sets ALEditable=false on MockTestPageHandle.
 
 TestPage.Prev:
   layer: runtime-api

--- a/tests/bucket-1/102-testpage-openmode/src/OpenModeSrc.al
+++ b/tests/bucket-1/102-testpage-openmode/src/OpenModeSrc.al
@@ -1,0 +1,7 @@
+page 117000 "OPM Card Page"
+{
+    PageType = Card;
+    ApplicationArea = All;
+    UsageCategory = None;
+    Caption = 'OPM Card';
+}

--- a/tests/bucket-1/102-testpage-openmode/test/OpenModeTest.al
+++ b/tests/bucket-1/102-testpage-openmode/test/OpenModeTest.al
@@ -1,0 +1,56 @@
+codeunit 117001 "OPM Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    [Test]
+    procedure OpenEdit_IsEditable()
+    var
+        P: TestPage "OPM Card Page";
+    begin
+        P.OpenEdit();
+        Assert.IsTrue(P.Editable(), 'OpenEdit must set page editable = true');
+        P.Close();
+    end;
+
+    [Test]
+    procedure OpenView_IsNotEditable()
+    var
+        P: TestPage "OPM Card Page";
+    begin
+        P.OpenView();
+        Assert.IsFalse(P.Editable(), 'OpenView must set page editable = false');
+        P.Close();
+    end;
+
+    [Test]
+    procedure OpenNew_IsEditable()
+    var
+        P: TestPage "OPM Card Page";
+    begin
+        P.OpenNew();
+        Assert.IsTrue(P.Editable(), 'OpenNew must set page editable = true');
+        P.Close();
+    end;
+
+    [Test]
+    procedure OpenView_NotANoop_EditDiffers()
+    begin
+        // Negative trap: OpenView and OpenEdit must produce different Editable states.
+        // If Editable() always returned true (no-op) this would fail.
+        Assert.AreNotEqual(
+            IsViewEditable(),
+            true,
+            'OpenView must produce editable=false, not the same as OpenEdit');
+    end;
+
+    local procedure IsViewEditable(): Boolean
+    var
+        P: TestPage "OPM Card Page";
+    begin
+        P.OpenView();
+        exit(P.Editable());
+    end;
+}


### PR DESCRIPTION
Closes #866

Add `_editable` field to `MockTestPageHandle`; `ALOpenEdit`/`ALOpenNew` set it `true`, `ALOpenView` sets it `false`. `ALEditable` now returns `_editable` instead of hardcoded `true`.

4-test suite in `tests/bucket-1/102-testpage-openmode` with positive and negative proving tests (including that OpenView ≠ editable, which would fail against the old always-true stub). Update `docs/coverage.yaml`: all three entries `gap` → `covered`.