### PR TITLE
feat: [ErrorBehavior(ErrorBehavior::Collect)] on test procedures

### DIFF
--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -2315,8 +2315,34 @@ public static class Executor
                     continue;
                 }
 
+                // Detect [ErrorBehavior(ErrorBehavior::Collect)] on the test procedure.
+                // BC generates: scope.RunBehavior(false, null, ErrorBehavior.Collect) where
+                // ErrorBehavior.Collect = 1 is boxed before the call.  In IL this produces
+                // ldc.i4.1 (0x17) immediately followed by box (0x8C).  The executor bypasses
+                // RunBehavior() and calls OnRun() directly, so we must activate collecting
+                // mode manually using AlScope.RunWithCollecting().
+                bool collectingTest = false;
+                if (testMethod != null)
+                {
+                    var ilBytes = testMethod.GetMethodBody()?.GetILAsByteArray();
+                    if (ilBytes != null)
+                    {
+                        for (int i = 0; i < ilBytes.Length - 1; i++)
+                        {
+                            if (ilBytes[i] == 0x17 && ilBytes[i + 1] == 0x8C) // ldc.i4.1 + box
+                            {
+                                collectingTest = true;
+                                break;
+                            }
+                        }
+                    }
+                }
+
                 var sw = System.Diagnostics.Stopwatch.StartNew();
-                onRunMethod.Invoke(scope, null);
+                if (collectingTest)
+                    AlRunner.Runtime.AlScope.RunWithCollecting(() => onRunMethod.Invoke(scope, null));
+                else
+                    onRunMethod.Invoke(scope, null);
                 sw.Stop();
 
                 // Capture variable values from scope fields if enabled

--- a/AlRunner/Runtime/AlScope.cs
+++ b/AlRunner/Runtime/AlScope.cs
@@ -221,6 +221,19 @@ public class AlScope : IDisposable, ITreeObject
         _collectedErrors = null;
     }
 
+    /// <summary>
+    /// Runs <paramref name="body"/> with <see cref="IsCollectingErrors"/> set to true,
+    /// then restores the previous state.  Called by the test executor when the test
+    /// procedure itself is annotated with [ErrorBehavior(ErrorBehavior::Collect)].
+    /// </summary>
+    public static void RunWithCollecting(Action body)
+    {
+        bool was = _isCollectingErrors;
+        _isCollectingErrors = true;
+        try { body(); }
+        finally { _isCollectingErrors = was; }
+    }
+
     public static AlScope? FindTryMethodScope(AlScope scope)
     {
         // In the real runtime this walks the scope chain looking for a
@@ -467,7 +480,13 @@ public static class AlDialog
 
         if (errorInfo != null && errorInfo.ALCollectible && AlScope.IsCollectingErrors)
         {
-            AlScope.CollectedErrors.Add(errorInfo);
+            // Store a shallow clone so later mutations to the same ErrorInfo object
+            // (common in BC-generated code that reuses one local variable for multiple errors)
+            // do not overwrite already-collected messages.
+            var cloneMethod = typeof(object).GetMethod("MemberwiseClone",
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+            var snapshot = (NavALErrorInfo)(cloneMethod!.Invoke(errorInfo, null) ?? errorInfo);
+            AlScope.CollectedErrors.Add(snapshot);
             return;
         }
 

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -2120,8 +2120,10 @@ ErrorInfo.Callstack:
 ErrorInfo.Collectible:
   layer: runtime-api
   category: ErrorInfo
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; ErrorInfo.Collectible := true marks errors for collection. [ErrorBehavior(ErrorBehavior::Collect)] on source-side methods works via AlScope.RunBehavior. [ErrorBehavior(ErrorBehavior::Collect)] on test procedures handled by executor detecting ldc.i4.1+box in test method IL and calling AlScope.RunWithCollecting. HasCollectedErrors, ClearCollectedErrors, IsCollectingErrors, GetCollectedErrors all functional.
+  tests:
+    - tests/bucket-1/272-collectible-errors
 
 ErrorInfo.ControlName:
   layer: runtime-api

--- a/tests/bucket-1/272-collectible-errors/src/CeSrc.al
+++ b/tests/bucket-1/272-collectible-errors/src/CeSrc.al
@@ -1,0 +1,54 @@
+codeunit 84700 "CE Src"
+{
+    /// Raises two collectible errors (no [ErrorBehavior] here — caller must be in collect mode).
+    procedure RaiseTwoErrors()
+    var
+        ErrInfo: ErrorInfo;
+    begin
+        ErrInfo.Collectible := true;
+        ErrInfo.Message := 'First error';
+        Error(ErrInfo);
+
+        ErrInfo.Collectible := true;
+        ErrInfo.Message := 'Second error';
+        Error(ErrInfo);
+    end;
+
+    /// Returns the count of currently collected errors.
+    procedure CountCollectedErrors(): Integer
+    begin
+        if HasCollectedErrors() then
+            exit(GetCollectedErrors().Count());
+        exit(0);
+    end;
+
+    /// Returns whether we are currently inside a collecting context.
+    procedure IsCollecting(): Boolean
+    begin
+        exit(IsCollectingErrors());
+    end;
+
+    /// Source-side method with [ErrorBehavior(Collect)] that raises one collectible error.
+    [ErrorBehavior(ErrorBehavior::Collect)]
+    procedure RaiseOneInCollectContext(Msg: Text)
+    var
+        ErrInfo: ErrorInfo;
+    begin
+        ErrInfo.Collectible := true;
+        ErrInfo.Message := Msg;
+        Error(ErrInfo);
+    end;
+
+    /// Returns first message from collected errors (or empty string).
+    procedure GetFirstMessage(): Text
+    var
+        Errors: List of [ErrorInfo];
+        Err: ErrorInfo;
+    begin
+        if not HasCollectedErrors() then
+            exit('');
+        Errors := GetCollectedErrors();
+        Err := Errors.Get(1);
+        exit(Err.Message);
+    end;
+}

--- a/tests/bucket-1/272-collectible-errors/test/CeTest.al
+++ b/tests/bucket-1/272-collectible-errors/test/CeTest.al
@@ -1,0 +1,90 @@
+codeunit 84701 "CE Test"
+{
+    Subtype = Test;
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "CE Src";
+
+    // ── Source-side [ErrorBehavior(Collect)] (baseline — already proven) ────────
+
+    [Test]
+    procedure SourceSideCollect_CollectsError()
+    begin
+        // Positive: [ErrorBehavior(Collect)] on a source method collects the error.
+        Src.RaiseOneInCollectContext('hello');
+        Assert.IsTrue(HasCollectedErrors(), 'Error must be collected after source-side Collect call');
+        ClearCollectedErrors();
+    end;
+
+    [Test]
+    procedure SourceSideCollect_MessagePreserved()
+    begin
+        // Positive: collected error message is preserved.
+        Src.RaiseOneInCollectContext('specific-value');
+        Assert.AreEqual('specific-value', Src.GetFirstMessage(), 'Collected error message must equal set value');
+        ClearCollectedErrors();
+    end;
+
+    // ── Test-side [ErrorBehavior(Collect)] ─────────────────────────────────────
+
+    [Test]
+    [ErrorBehavior(ErrorBehavior::Collect)]
+    procedure TestSideCollect_CollectsTwoErrors()
+    begin
+        // Positive: [ErrorBehavior(Collect)] on the TEST procedure activates collecting mode
+        // so that collectible errors from called code are collected, not thrown.
+        Src.RaiseTwoErrors();
+        Assert.AreEqual(2, Src.CountCollectedErrors(), 'Both collectible errors must be collected');
+    end;
+
+    [Test]
+    [ErrorBehavior(ErrorBehavior::Collect)]
+    procedure TestSideCollect_IsCollectingErrors()
+    begin
+        // Positive: IsCollectingErrors() must return true inside [ErrorBehavior(Collect)] test.
+        Assert.IsTrue(Src.IsCollecting(), 'IsCollectingErrors must be true inside ErrorBehavior::Collect');
+    end;
+
+    [Test]
+    [ErrorBehavior(ErrorBehavior::Collect)]
+    procedure TestSideCollect_MessagePreserved()
+    begin
+        // Positive: first collected error has the correct message.
+        Src.RaiseTwoErrors();
+        Assert.AreEqual('First error', Src.GetFirstMessage(), 'First collected error message must be correct');
+    end;
+
+    // ── HasCollectedErrors / ClearCollectedErrors ──────────────────────────────
+
+    [Test]
+    procedure HasCollectedErrors_FalseByDefault()
+    begin
+        // Positive: no errors collected before any collection call.
+        Assert.IsFalse(HasCollectedErrors(), 'HasCollectedErrors must be false before any collection');
+    end;
+
+    [Test]
+    procedure ClearCollectedErrors_EmptiesCollection()
+    begin
+        // Positive: after ClearCollectedErrors the collection is empty.
+        Src.RaiseOneInCollectContext('to be cleared');
+        ClearCollectedErrors();
+        Assert.IsFalse(HasCollectedErrors(), 'HasCollectedErrors must be false after ClearCollectedErrors');
+    end;
+
+    [Test]
+    procedure IsCollectingErrors_FalseOutside()
+    begin
+        // Negative: IsCollectingErrors must be false outside any [ErrorBehavior(Collect)] scope.
+        Assert.IsFalse(IsCollectingErrors(), 'IsCollectingErrors must be false outside collect scope');
+    end;
+
+    // ── GetCollectedErrors count ───────────────────────────────────────────────
+
+    [Test]
+    procedure GetCollectedErrors_ZeroWithoutCollection()
+    begin
+        // Positive: GetCollectedErrors returns empty list when nothing collected.
+        Assert.AreEqual(0, Src.CountCollectedErrors(), 'CountCollectedErrors must be 0 before collection');
+    end;
+}


### PR DESCRIPTION
Closes #858

## Summary

- **Root cause**: The test executor called `scope.OnRun()` directly, bypassing the BC-generated `scope.RunBehavior(false, null, ErrorBehavior.Collect)` that activates collecting mode.
- **Fix 1 (executor)**: Detect `[ErrorBehavior(ErrorBehavior::Collect)]` on the test procedure by scanning the parent test method's IL for the `ldc.i4.1` + `box` pattern (the encoding of `ErrorBehavior.Collect = 1` being boxed). If found, wrap `OnRun()` in the new `AlScope.RunWithCollecting()` helper.
- **Fix 2 (snapshot)**: `NavALErrorInfo` is a reference type; BC generates code that reuses one local variable for multiple errors. `Error(NavALErrorInfo)` now stores a `MemberwiseClone` snapshot so later property mutations don't corrupt already-collected messages.
- **New helper**: `AlScope.RunWithCollecting(Action)` — sets `_isCollectingErrors = true` for the duration, then restores it.
- **Tests**: 9 tests in `tests/bucket-1/272-collectible-errors` (all 9 pass). Covers source-side `[ErrorBehavior(Collect)]`, test-side, `HasCollectedErrors`, `ClearCollectedErrors`, `IsCollectingErrors`, `GetCollectedErrors`, message preservation, and multi-error collection.
- **coverage.yaml**: `ErrorInfo.Collectible` → `covered`

## Test plan

- [x] All 9 tests in `tests/bucket-1/272-collectible-errors` pass
- [x] No regressions in bucket-1 or bucket-2 (pre-existing failures confirmed unchanged)
- [x] `docs/coverage.yaml` updated: `ErrorInfo.Collectible` gap → covered

🤖 Generated with [Claude Code](https://claude.com/claude-code)