### PR TITLE
feat: TestPage.Trap — register trap so next RunModal on same page returns OK (issue #869)

### DIFF
--- a/AlRunner/Runtime/HandlerRegistry.cs
+++ b/AlRunner/Runtime/HandlerRegistry.cs
@@ -39,6 +39,9 @@ public static class HandlerRegistry
     // Registered send notification handler: method that takes (ByRef<MockNotification> notification) and returns bool
     private static MethodInfo? _sendNotificationHandler;
 
+    // Trap registry: TestPage.Trap() registers a handle here; consumed by the next RunModal on the same pageId.
+    private static readonly Dictionary<int, MockTestPageHandle> _trapHandles = new();
+
     /// <summary>
     /// Register handlers for the current test. Called by the Executor before each test.
     /// </summary>
@@ -173,13 +176,20 @@ public static class HandlerRegistry
     }
 
     /// <summary>
+    /// Register a TestPage trap for the given page ID. Consumed by the next RunModal on that page.
+    /// </summary>
+    public static void RegisterTrap(int pageId, MockTestPageHandle handle) => _trapHandles[pageId] = handle;
+
+    /// <summary>
     /// Invoke the registered modal page handler for the given page ID.
-    /// Creates a MockTestPageHandle, passes it to the handler, and returns
-    /// the FormResult set by the handler (via OK/Cancel action invocation).
-    /// Throws if no handler is registered.
+    /// If a Trap is registered for this page, consumes it and returns OK.
+    /// Throws if neither a trap nor a ModalPageHandler is registered.
     /// </summary>
     public static FormResult InvokeModalPageHandler(int pageId)
     {
+        if (_trapHandles.Remove(pageId))
+            return FormResult.OK;
+
         if (_modalPageHandler == null || _parentInstance == null)
             throw new Exception($"No ModalPageHandler registered for page {pageId}. " +
                 "Add [HandlerFunctions('YourHandler')] to the test and a " +
@@ -368,5 +378,6 @@ public static class HandlerRegistry
         _requestPageHandler = null;
         _reportHandler = null;
         _sendNotificationHandler = null;
+        _trapHandles.Clear();
     }
 }

--- a/AlRunner/Runtime/MockTestPageHandle.cs
+++ b/AlRunner/Runtime/MockTestPageHandle.cs
@@ -52,7 +52,7 @@ public class MockTestPageHandle
     public void ALOpenView() { _editable = false; }
     public void ALOpenNew() { _editable = true; }
     public void ALClose() { }
-    public void ALTrap() { }
+    public void ALTrap() { HandlerRegistry.RegisterTrap(PageId, this); }
     public void ALNew() { }
     public void ClearReference() { }
 

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -7391,8 +7391,9 @@ TestPage.RunPageBackgroundTask:
 TestPage.Trap:
   layer: runtime-api
   category: TestPage
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-1/103-testpage-trap
+  notes: overloads=1; registers trap in HandlerRegistry; consumed by next MockFormHandle.RunModal on same pageId.
 
 TestPage.ValidationErrorCount:
   layer: runtime-api

--- a/tests/bucket-1/103-testpage-trap/src/TrapSrc.al
+++ b/tests/bucket-1/103-testpage-trap/src/TrapSrc.al
@@ -1,0 +1,7 @@
+page 118000 "TRAP Card Page"
+{
+    PageType = Card;
+    ApplicationArea = All;
+    UsageCategory = None;
+    Caption = 'TRAP Card';
+}

--- a/tests/bucket-1/103-testpage-trap/test/TrapTest.al
+++ b/tests/bucket-1/103-testpage-trap/test/TrapTest.al
@@ -1,0 +1,38 @@
+codeunit 118001 "TRAP Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    [Test]
+    procedure Trap_DoesNotCrash()
+    var
+        TP: TestPage "TRAP Card Page";
+    begin
+        // Positive: Trap() must not throw.
+        TP.Trap();
+    end;
+
+    [Test]
+    procedure Trap_PreventsModalHandlerException()
+    var
+        TP: TestPage "TRAP Card Page";
+        P: Page "TRAP Card Page";
+    begin
+        // Positive: after Trap(), RunModal() on the matching Page var must
+        // succeed (return OK) instead of throwing "No ModalPageHandler registered".
+        TP.Trap();
+        P.RunModal();
+    end;
+
+    [Test]
+    procedure WithoutTrap_RunModal_Throws()
+    var
+        P: Page "TRAP Card Page";
+    begin
+        // Negative trap: without a prior Trap() call, RunModal() must throw.
+        asserterror P.RunModal();
+        Assert.ExpectedError('ModalPageHandler');
+    end;
+}


### PR DESCRIPTION
Closes #869

`ALTrap()` now calls `HandlerRegistry.RegisterTrap(PageId, this)`. `InvokeModalPageHandler` checks the trap registry first; if a trap is registered for the pageId, it consumes it and returns `FormResult.OK` instead of throwing "No ModalPageHandler registered." `Reset()` clears traps between tests.

3-test suite with proving positive + negative tests:
- `Trap_DoesNotCrash` — Trap() itself doesn't throw
- `Trap_PreventsModalHandlerException` — after Trap(), `p.RunModal()` succeeds (would fail without fix)
- `WithoutTrap_RunModal_Throws` — negative: without Trap, RunModal throws as expected