### PR TITLE
feat: strip addfirst in tableextension fieldgroups — issue #816

### DIFF
--- a/AlRunner/Pipeline.cs
+++ b/AlRunner/Pipeline.cs
@@ -946,15 +946,29 @@ public class AlRunnerPipeline
         // contains a report or reportextension declaration — not just when the
         // declaration is at the very start. This handles BOM, header comments,
         // multi-object files, and other common AL file layouts.
-        if (!Regex.IsMatch(source, @"\breport(extension)?\s+\d+", RegexOptions.IgnoreCase))
-            return source;
+        if (Regex.IsMatch(source, @"\breport(extension)?\s+\d+", RegexOptions.IgnoreCase))
+        {
+            source = StripNamedBlock(source, "rendering");
+            // Remove DefaultRenderingLayout property — it references layout names
+            // defined inside the rendering block which we just stripped.
+            source = Regex.Replace(source,
+                @"(?im)^\s*DefaultRenderingLayout\s*=\s*[^;]+;\s*$",
+                "");
+        }
 
-        source = StripNamedBlock(source, "rendering");
-        // Remove DefaultRenderingLayout property — it references layout names
-        // defined inside the rendering block which we just stripped.
-        source = Regex.Replace(source,
-            @"(?im)^\s*DefaultRenderingLayout\s*=\s*[^;]+;\s*$",
-            "");
+        // Strip addfirst(GroupName; Fields...) inside tableextension fieldgroups.
+        // The runner's BC compiler version does not recognise addfirst in fieldgroups
+        // (AL0104). Fieldgroup modifications have no runtime effect in the runner, so
+        // removing them is safe. The distinguishing syntax is a semicolon inside the
+        // parens: addfirst(GroupName; Field1, Field2) vs page-style addfirst(group).
+        if (Regex.IsMatch(source, @"\btableextension\s+\d+", RegexOptions.IgnoreCase) &&
+            Regex.IsMatch(source, @"\baddfirst\s*\(", RegexOptions.IgnoreCase))
+        {
+            source = Regex.Replace(source,
+                @"(?im)^\s*addfirst\s*\([^;)]+;[^)]*\)\s*$",
+                "");
+        }
+
         return source;
     }
 

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -1164,11 +1164,13 @@ addfirst_dataset_modification:
 addfirst_fieldgroup_modification:
   layer: syntax
   category: modification
-  status: gap
+  status: covered
+  tests: tests/bucket-1/277-addfirst-fieldgroup
   notes: >
-    Language gap: AL compiler (BC 26–28) rejects addfirst inside tableextension
-    fieldgroups with AL0104 — addfirst is not a valid keyword in this position.
-    addlast works; addfirst does not exist at these BC versions.
+    PrepareSourceForStandalone strips addfirst(GroupName; Fields) lines from
+    tableextension fieldgroups before AL compilation — the runner's BC compiler
+    version rejects addfirst in this position with AL0104. Fieldgroup
+    modifications have no runtime effect in the runner, so stripping is safe.
 
 addfirst_modification:
   layer: syntax

--- a/tests/bucket-1/274-variant-typecheck/src/VTCSrc.al
+++ b/tests/bucket-1/274-variant-typecheck/src/VTCSrc.al
@@ -3,7 +3,7 @@
 ///   XmlDocument, XmlElement, XmlNode, XmlProcessingInstruction, XmlCData,
 ///   XmlComment, XmlDeclaration, XmlText, XmlNodeList, XmlAttribute,
 ///   InStream, OutStream, Codeunit, Dictionary.
-table 118000 "VTC Data"
+table 120000 "VTC Data"
 {
     fields
     {
@@ -16,7 +16,7 @@ table 118000 "VTC Data"
     }
 }
 
-codeunit 118001 "VTC Src"
+codeunit 120001 "VTC Src"
 {
     // ── XmlDocument ────────────────────────────────────────────────────────────
 

--- a/tests/bucket-1/274-variant-typecheck/test/VTCTest.al
+++ b/tests/bucket-1/274-variant-typecheck/test/VTCTest.al
@@ -1,4 +1,4 @@
-codeunit 118002 "VTC Tests"
+codeunit 120002 "VTC Tests"
 {
     Subtype = Test;
 

--- a/tests/bucket-1/277-addfirst-fieldgroup/src/AFGSrc.al
+++ b/tests/bucket-1/277-addfirst-fieldgroup/src/AFGSrc.al
@@ -1,0 +1,28 @@
+/// Table + tableextension exercising addfirst in fieldgroups (issue #816).
+/// addfirst/addlast in tableextension fieldgroups is valid AL syntax but caused
+/// AL0104 in the runner's BC compiler. The rewriter now strips these as no-ops.
+
+table 119000 "AFG Data"
+{
+    fields
+    {
+        field(1; "Entry No."; Integer) { }
+        field(2; Name; Text[50]) { }
+    }
+    keys
+    {
+        key(PK; "Entry No.") { Clustered = true; }
+    }
+    fieldgroups
+    {
+        fieldgroup(DropDown; "Entry No.", Name) { }
+    }
+}
+
+tableextension 119001 "AFG Data Ext" extends "AFG Data"
+{
+    fieldgroups
+    {
+        addfirst(DropDown; Name)
+    }
+}

--- a/tests/bucket-1/277-addfirst-fieldgroup/test/AFGTest.al
+++ b/tests/bucket-1/277-addfirst-fieldgroup/test/AFGTest.al
@@ -1,0 +1,28 @@
+codeunit 119002 "AFG Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    [Test]
+    procedure AFG_Addfirst_Compiles()
+    begin
+        // Positive: if tableextension with addfirst fieldgroup compiled, we reach here.
+        Assert.IsTrue(true, 'tableextension with addfirst fieldgroup must compile');
+    end;
+
+    [Test]
+    procedure AFG_Record_InsertAndFind()
+    var
+        Rec: Record "AFG Data";
+    begin
+        // Positive: prove the table itself is functional (not just a compilation stub).
+        Rec."Entry No." := 1;
+        Rec.Name := 'Test';
+        Rec.Insert();
+        Rec.Reset();
+        Assert.IsTrue(Rec.FindFirst(), 'Record must be findable after Insert');
+        Assert.AreEqual(1, Rec."Entry No.", 'Entry No. must be 1');
+    end;
+}


### PR DESCRIPTION
Closes #816

The runner's BC compiler version rejects `addfirst` inside `tableextension fieldgroups`
with AL0104. Since fieldgroup modifications have no runtime effect in the runner,
preprocessing them away in `PrepareSourceForStandalone` is safe and preserves AL compatibility.

## Changes

- **`AlRunner/Pipeline.cs`** — `PrepareSourceForStandalone` now strips lines matching
  `addfirst(GroupName; Field1, Field2)` (the fieldgroup-style syntax) when the source
  contains a tableextension. The semicolon-inside-parens pattern reliably distinguishes
  fieldgroup-style from page-style `addfirst(groupName) { ... }` blocks.
- **`tests/bucket-1/277-addfirst-fieldgroup/`** — 2 tests: compilation proof + record roundtrip
- **`docs/coverage.yaml`** — `addfirst_fieldgroup_modification` promoted from `gap` to `covered`
- **`tests/bucket-1/274-variant-typecheck/`** — IDs renumbered 118000→120000 to avoid
  collision with `103-testpage-trap` suite that was merged to main after #863

## Test plan

- [x] RED confirmed: AL0104 before fix
- [x] GREEN: 2 AFG tests pass after fix
- [x] Full bucket-1: 1389 passed, 4 pre-existing failures (suites 17/61, unrelated)