### PR TITLE
feat: TestPage.GoToKey and GoToRecord — real record lookup

### DIFF
--- a/AlRunner/Runtime/MockTestPageHandle.cs
+++ b/AlRunner/Runtime/MockTestPageHandle.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Reflection;
 using Microsoft.Dynamics.Nav.Runtime;
 using Microsoft.Dynamics.Nav.Types;
@@ -31,6 +32,13 @@ public class MockTestPageHandle
     private MockRecordHandle? _currentRecord;
     private readonly Dictionary<int, MethodInfo> _actionMethodCache = new();
     private bool _actionCacheBuilt;
+
+    // ── Source table and field-hash mapping ───────────────────────────────────
+    // Resolved lazily from the compiled page class's Rec property.
+    // Maps page field hash → source table field ID so that GoToKey/GoToRecord
+    // can populate MockTestPageField values from the positioned record.
+    private int? _sourceTableId;
+    private Dictionary<int, int>? _hashToFieldId; // fieldHash → tableFieldId
 
     /// <summary>
     /// The modal result set by invoking a built-in action (OK, Cancel, etc.).
@@ -149,14 +157,43 @@ public class MockTestPageHandle
     public bool ALFirst() => true;
 
     /// <summary>
-    /// Navigates to a specific record on the page. Stores the record so that when
-    /// a custom action's OnAction trigger fires, the page instance operates on
-    /// this record instead of its default empty one.
+    /// Navigates to a specific record on the page.  Verifies the record exists
+    /// in the in-memory store (via the primary key), sets <c>_currentRecord</c>,
+    /// and populates <see cref="MockTestPageField"/> values so that field reads
+    /// after the call reflect the positioned record.  Returns <c>true</c> when
+    /// the record is found, <c>false</c> otherwise (same semantics as BC).
     /// </summary>
     public bool ALGoToRecord(MockRecordHandle rec)
     {
-        _currentRecord = rec;
-        LinkRecToPageInstance(rec);
+        EnsureFieldMapping();
+
+        // If this page has no registered source table (e.g. TestRequestPage stubs) fall back
+        // to the original "always accept" behaviour: position on the passed record and
+        // return true, which is what the historical no-op stub did.
+        if (!_sourceTableId.HasValue || _sourceTableId.Value == 0)
+        {
+            _currentRecord = rec;
+            EnsurePageInstance();
+            if (_pageInstance != null) LinkRecToPageInstance(rec);
+            PopulateFieldsFromRecord(rec);
+            return true;
+        }
+
+        // Source table is known — do a real lookup so GoToRecord returns true only when
+        // the record actually exists in the in-memory store.
+        var pks = rec.GetPrimaryKeyFieldNos();
+        var keyValues = pks
+            .Select(pk => rec.GetFieldValueSafe(pk, default))
+            .ToArray();
+
+        var fetched = new MockRecordHandle(rec.TableId);
+        if (!fetched.ALGet(DataError.TrapError, keyValues))
+            return false;
+
+        _currentRecord = fetched;
+        EnsurePageInstance();
+        if (_pageInstance != null) LinkRecToPageInstance(fetched);
+        PopulateFieldsFromRecord(fetched);
         return true;
     }
 
@@ -248,10 +285,29 @@ public class MockTestPageHandle
     public MockRecordHandle ALGetRecord() => new MockRecordHandle(0);
 
     /// <summary>
-    /// Navigates to the record matching the given key values. Stub returns true.
-    /// BC emits: ALGoToKey(DataError.TrapError, ALCompiler.ToNavValue(...))
+    /// Navigates to the record with the given primary key value(s).
+    /// Looks up the record in the in-memory store, positions the page cursor on
+    /// it, and populates <see cref="MockTestPageField"/> values so that field
+    /// reads after the call reflect the positioned record.
+    /// Returns <c>true</c> if found, <c>false</c> if not found.
+    /// BC emits: <c>tP.ALGoToKey(DataError, ALCompiler.ToNavValue(key1), ...)</c>
     /// </summary>
-    public bool ALGoToKey(DataError errorLevel, params NavValue[] keyValues) => true;
+    public bool ALGoToKey(DataError errorLevel, params NavValue[] keyValues)
+    {
+        EnsureFieldMapping();
+        // No source-table metadata (stub page such as TestRequestPage) or table ID unresolved —
+        // fall back to the historical stub behaviour and return true.
+        if (!_sourceTableId.HasValue || _sourceTableId.Value == 0) return true;
+
+        var rec = new MockRecordHandle(_sourceTableId.Value);
+        if (!rec.ALGet(DataError.TrapError, keyValues)) return false;
+
+        _currentRecord = rec;
+        EnsurePageInstance();
+        if (_pageInstance != null) LinkRecToPageInstance(rec);
+        PopulateFieldsFromRecord(rec);
+        return true;
+    }
 
     /// <summary>
     /// Returns a filter object for the TestPage. BC emits:
@@ -317,6 +373,76 @@ public class MockTestPageHandle
     {
         var fr = (FormResult)formResult;
         return new MockTestPageAction(this, fr);
+    }
+
+    // ── Source-table / field-hash mapping ────────────────────────────────────
+
+    /// <summary>
+    /// Discovers the page's source table ID and builds the <c>_hashToFieldId</c> map
+    /// (page field hash → table field ID).
+    ///
+    /// Resolution order:
+    /// 1. <see cref="TableFieldRegistry.GetSourceTableId"/> — populated by parsing the
+    ///    <c>SourceTable = "…"</c> property from the AL page declaration at transpile time.
+    ///    This is the reliable path and works even though the RoslynRewriter rewrites the
+    ///    <c>Rec</c> property initialiser to <c>new MockRecordHandle(0)</c>.
+    /// 2. Fallback: read <c>Rec.TableId</c> from the compiled page class.  In practice this
+    ///    always yields 0 for normal pages (see rewriter limitation), but it is kept as a
+    ///    safety net for hand-crafted test scenarios.
+    ///
+    /// Call this before any code that needs to look up record fields by hash.
+    /// </summary>
+    private void EnsureFieldMapping()
+    {
+        if (_hashToFieldId != null) return;
+        _hashToFieldId = new Dictionary<int, int>();
+
+        if (PageId == 0) return;
+
+        // 1. Try the AL-source registry (reliable path).
+        var registryTableId = TableFieldRegistry.GetSourceTableId(PageId);
+        if (registryTableId.HasValue)
+        {
+            _sourceTableId = registryTableId.Value;
+        }
+        else
+        {
+            // 2. Fall back to the compiled page class's Rec property.
+            //    This yields tableId=0 for most rewritten pages, but covers edge cases.
+            EnsurePageInstance();
+            if (_pageInstance == null) return;
+            var recProp = _pageInstance.GetType()
+                .GetProperty("Rec", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+            if (recProp?.GetValue(_pageInstance) is not MockRecordHandle recHandle) return;
+            _sourceTableId = recHandle.TableId;
+        }
+
+        if (_sourceTableId == 0) return;
+
+        // For every field registered in the source table, compute its page-field
+        // hash and record the hash → tableFieldId mapping.
+        foreach (var (fieldId, fieldName) in TableFieldRegistry.GetAllFields(_sourceTableId.Value))
+        {
+            int hash = IdSpaceHelper.GetMemberId(PageId, fieldName);
+            if (hash != 0)
+                _hashToFieldId[hash] = fieldId;
+        }
+    }
+
+    /// <summary>
+    /// Copies field values from <paramref name="rec"/> into the corresponding
+    /// <see cref="MockTestPageField"/> instances using the <c>_hashToFieldId</c>
+    /// map.  Only fields whose page-hash is already known (computed by
+    /// <see cref="EnsureFieldMapping"/>) are populated.
+    /// </summary>
+    private void PopulateFieldsFromRecord(MockRecordHandle rec)
+    {
+        if (_hashToFieldId == null) return;
+        foreach (var (hash, fieldId) in _hashToFieldId)
+        {
+            var value = rec.GetFieldValueSafe(fieldId, default);
+            GetField(hash).ALValue = value;
+        }
     }
 
     // ── Page instance lifecycle ───────────────────────────────────────────────

--- a/AlRunner/Runtime/TableFieldRegistry.cs
+++ b/AlRunner/Runtime/TableFieldRegistry.cs
@@ -26,6 +26,16 @@ public static class TableFieldRegistry
         @"\btable\s+(\d+)\s+(?:""([^""]+)""|([A-Za-z_][A-Za-z0-9_]*))[^{]*?\{",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
+    // page Id "Name" { ... SourceTable = "TableName"; ... }
+    private static readonly Regex PageHeader = new(
+        @"\bpage\s+(\d+)\s+(?:""([^""]+)""|([A-Za-z_][A-Za-z0-9_]*))[^{]*?\{",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+    // SourceTable = "TableName"  or  SourceTable = TableName
+    private static readonly Regex SourceTableProp = new(
+        @"\bSourceTable\s*=\s*(?:""([^""]+)""|([A-Za-z_][A-Za-z0-9_]*))\s*;",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
     // tableextension Id "Name" extends "BaseTableName" { fields { ... } }
     private static readonly Regex TableExtHeader = new(
         @"\btableextension\s+\d+\s+(?:""[^""]*""|[A-Za-z_][A-Za-z0-9_]*)\s+extends\s+(?:""([^""]+)""|([A-Za-z_][A-Za-z0-9_]*))[^{]*?\{",
@@ -67,6 +77,9 @@ public static class TableFieldRegistry
     // (tableId, fieldNo) -> comma-separated option members (for inline Option fields with OptionMembers = A,B,C)
     private static readonly Dictionary<(int TableId, int FieldNo), string> _optionMembersFields = new();
 
+    // pageId -> source tableId (parsed from page SourceTable declarations)
+    private static readonly Dictionary<int, int> _pageSourceTable = new();
+
     private static readonly Regex OptionMembersProp = new(
         @"\bOptionMembers\s*=\s*([^;]+);",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
@@ -85,6 +98,7 @@ public static class TableFieldRegistry
         _fieldMeta.Clear();
         _enumFields.Clear();
         _optionMembersFields.Clear();
+        _pageSourceTable.Clear();
     }
 
     public static void ParseAndRegister(string alSource)
@@ -215,13 +229,40 @@ public static class TableFieldRegistry
             }
         }
 
-        // Parse tableextension declarations: register extension fields under the base table ID.
-        // tableextension N "Name" extends "BaseTableName" { fields { field(...) ... } }
+        // Parse tableextension and page declarations: both need a name→ID reverse map.
+        // Build it once here so both sections can share it.
         // The base table must have been registered (from a prior table declaration in this or a
         // previously-processed source file) so we can resolve the name → ID mapping.
-        // Build a reverse map from table name → table ID for the lookup.
         var nameToId = new Dictionary<string, int>(_tableNames.Count, StringComparer.OrdinalIgnoreCase);
         foreach (var kv in _tableNames) nameToId[kv.Value] = kv.Key;
+
+        // Parse page declarations to record page → source table mappings.
+        // This lets MockTestPageHandle.EnsureFieldMapping() discover which table a page
+        // is backed by without relying on the rewritten Rec property (which loses the table ID).
+        foreach (Match pm in PageHeader.Matches(alSource))
+        {
+            if (!int.TryParse(pm.Groups[1].Value, out var pageId)) continue;
+
+            int pStart = pm.Index + pm.Length;
+            int pDepth = 1, pI = pStart;
+            while (pI < alSource.Length && pDepth > 0)
+            {
+                if (alSource[pI] == '{') pDepth++;
+                else if (alSource[pI] == '}') pDepth--;
+                pI++;
+            }
+            if (pDepth != 0) continue;
+            var pageBody = alSource.Substring(pStart, pI - pStart - 1);
+
+            var stMatch = SourceTableProp.Match(pageBody);
+            if (!stMatch.Success) continue;
+
+            var tableName = stMatch.Groups[1].Success ? stMatch.Groups[1].Value : stMatch.Groups[2].Value;
+            if (nameToId.TryGetValue(tableName, out var sourceTableId))
+                _pageSourceTable[pageId] = sourceTableId;
+        }
+
+        // Parse tableextension declarations: register extension fields under the base table ID.
 
         foreach (Match em in TableExtHeader.Matches(alSource))
         {
@@ -311,6 +352,28 @@ public static class TableFieldRegistry
             return id;
         return null;
     }
+
+    /// <summary>
+    /// Returns all (fieldId, fieldName) pairs registered for the given table.
+    /// Used by <see cref="AlRunner.Runtime.MockTestPageHandle"/> to build
+    /// hash→fieldId mappings for GoToKey/GoToRecord field population.
+    /// </summary>
+    public static IEnumerable<(int FieldId, string FieldName)> GetAllFields(int tableId)
+    {
+        if (_fieldMeta.TryGetValue(tableId, out var meta))
+            foreach (var kv in meta)
+                if (kv.Value.Name != null)
+                    yield return (kv.Key, kv.Value.Name);
+    }
+
+    /// <summary>
+    /// Returns the source table ID for the given page, as declared by
+    /// <c>SourceTable = "TableName"</c> in the page definition, or <c>null</c> if
+    /// not registered.  Populated by <see cref="ParseAndRegister"/> when it
+    /// processes page declarations.
+    /// </summary>
+    public static int? GetSourceTableId(int pageId)
+        => _pageSourceTable.TryGetValue(pageId, out var id) ? id : null;
 
     /// <summary>Returns the table name or null if not registered.</summary>
     public static string? GetTableName(int tableId)

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -7310,14 +7310,29 @@ TestPage.GetValidationError:
 TestPage.GoToKey:
   layer: runtime-api
   category: TestPage
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: >
+    overloads=1; ALGoToKey(DataError, params NavValue[]) performs a real record lookup when the
+    page's SourceTable is registered in TableFieldRegistry (parsed from AL source). Returns true
+    when the record is found and positions the page cursor; returns false when the key does not
+    exist. Falls back to returning true for stub pages (e.g. TestRequestPage) that have no
+    registered source table. Field values are populated from the located record so that field
+    reads after GoToKey reflect the correct row.
+  tests:
+    - tests/bucket-1/274-testpage-gotokey
 
 TestPage.GoToRecord:
   layer: runtime-api
   category: TestPage
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: >
+    overloads=2; ALGoToRecord(MockRecordHandle) and ALGoToRecord(DataError, MockRecordHandle).
+    When the page's SourceTable is registered, re-fetches the record from the in-memory store
+    using its PK values; returns true if found, false if the record does not exist. Falls back
+    to accepting the passed record and returning true for pages without a registered source table.
+    Field values are populated from the located record.
+  tests:
+    - tests/bucket-1/274-testpage-gotokey
 
 TestPage.IsExpanded:
   layer: runtime-api

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -1165,7 +1165,8 @@ addfirst_fieldgroup_modification:
   layer: syntax
   category: modification
   status: covered
-  tests: tests/bucket-1/277-addfirst-fieldgroup
+  tests:
+    - tests/bucket-1/277-addfirst-fieldgroup
   notes: >
     PrepareSourceForStandalone strips addfirst(GroupName; Fields) lines from
     tableextension fieldgroups before AL compilation — the runner's BC compiler

--- a/tests/bucket-1/274-testpage-gotokey/src/GtkSrc.al
+++ b/tests/bucket-1/274-testpage-gotokey/src/GtkSrc.al
@@ -1,0 +1,27 @@
+/// Source objects for TestPage.GoToKey / GoToRecord tests (issue #868).
+table 118000 "GTK Table"
+{
+    fields
+    {
+        field(1; "No."; Code[20]) { }
+        field(2; Name; Text[50]) { }
+    }
+    keys { key(PK; "No.") { Clustered = true; } }
+}
+
+page 118001 "GTK List"
+{
+    PageType = List;
+    SourceTable = "GTK Table";
+    layout
+    {
+        area(Content)
+        {
+            repeater(R)
+            {
+                field("No."; Rec."No.") { }
+                field(Name; Rec.Name) { }
+            }
+        }
+    }
+}

--- a/tests/bucket-1/274-testpage-gotokey/test/GtkTest.al
+++ b/tests/bucket-1/274-testpage-gotokey/test/GtkTest.al
@@ -1,0 +1,93 @@
+codeunit 118002 "GTK Test"
+{
+    Subtype = Test;
+    var
+        Assert: Codeunit Assert;
+
+    // ── GoToKey ───────────────────────────────────────────────────────────────
+
+    [Test]
+    procedure GoToKey_ReturnsTrue_WhenRecordExists()
+    var
+        Rec: Record "GTK Table";
+        TP: TestPage "GTK List";
+    begin
+        // Positive: GoToKey returns true when the record is in the table.
+        Rec.Init();
+        Rec."No." := 'K1';
+        Rec.Name := 'Key One';
+        Rec.Insert();
+
+        TP.OpenView();
+        Assert.IsTrue(TP.GoToKey('K1'), 'GoToKey must return true for an existing record');
+        TP.Close();
+    end;
+
+    [Test]
+    procedure GoToKey_ReturnsFalse_WhenRecordMissing()
+    var
+        TP: TestPage "GTK List";
+    begin
+        // Negative: GoToKey returns false when the key does not exist.
+        TP.OpenView();
+        Assert.IsFalse(TP.GoToKey('NOSUCHKEY'), 'GoToKey must return false for a missing record');
+        TP.Close();
+    end;
+
+    [Test]
+    procedure GoToKey_PositionsOnCorrectRecord()
+    var
+        Rec: Record "GTK Table";
+        TP: TestPage "GTK List";
+    begin
+        // Positive: after GoToKey the page shows the correct record's field values.
+        Rec.Init();
+        Rec."No." := 'K2';
+        Rec.Name := 'Positioned Name';
+        Rec.Insert();
+
+        TP.OpenView();
+        TP.GoToKey('K2');
+        Assert.AreEqual('Positioned Name', TP.Name.Value, 'GoToKey must position page on the correct record');
+        TP.Close();
+    end;
+
+    // ── GoToRecord ────────────────────────────────────────────────────────────
+
+    [Test]
+    procedure GoToRecord_ReturnsTrue_WhenRecordExists()
+    var
+        Rec: Record "GTK Table";
+        TP: TestPage "GTK List";
+    begin
+        // Positive: GoToRecord returns true for an inserted record.
+        Rec.Init();
+        Rec."No." := 'R1';
+        Rec.Name := 'Rec One';
+        Rec.Insert();
+        Rec.Get('R1');
+
+        TP.OpenView();
+        Assert.IsTrue(TP.GoToRecord(Rec), 'GoToRecord must return true for an existing record');
+        TP.Close();
+    end;
+
+    [Test]
+    procedure GoToRecord_PositionsOnCorrectRecord()
+    var
+        Rec: Record "GTK Table";
+        TP: TestPage "GTK List";
+    begin
+        // Positive: after GoToRecord the page shows the correct record's field values.
+        Rec.Init();
+        Rec."No." := 'R2';
+        Rec.Name := 'Rec Two Name';
+        Rec.Insert();
+        Rec.Get('R2');
+
+        TP.OpenView();
+        TP.GoToRecord(Rec);
+        Assert.AreEqual('Rec Two Name', TP.Name.Value, 'GoToRecord must position page on the correct record');
+        TP.Close();
+    end;
+}

--- a/tests/bucket-2/74-testpage-navigation/test/TestPageNavTests.al
+++ b/tests/bucket-2/74-testpage-navigation/test/TestPageNavTests.al
@@ -32,9 +32,16 @@ codeunit 56741 "TPN TestPage Nav Tests"
     [Test]
     procedure TestPageGoToKeyReturnsTrue()
     var
+        Rec: Record "TPN Test Record";
         TP: TestPage "TPN Test Card";
         Result: Boolean;
     begin
+        // GoToKey returns true when the record exists in the table.
+        Rec.Init();
+        Rec.Id := 1;
+        Rec.Name := 'Test';
+        Rec.Insert();
+
         TP.OpenView();
         Result := TP.GoToKey(1);
         Assert.IsTrue(Result, 'GoToKey should return true');
@@ -67,8 +74,9 @@ codeunit 56741 "TPN TestPage Nav Tests"
     var
         TP: TestPage "TPN Test Card";
     begin
+        // GoToKey returns false when the record does not exist in the table.
         TP.OpenView();
-        Assert.IsFalse(not TP.GoToKey(1), 'GoToKey should not return false');
+        Assert.IsFalse(TP.GoToKey(99999), 'GoToKey should return false for a missing record');
         TP.Close();
     end;
 }


### PR DESCRIPTION
Closes #868

## Summary

- **`TableFieldRegistry.ParseAndRegister`** now parses `page N "Name" { SourceTable = "TableName"; }` declarations and registers `pageId → tableId` mappings in a new `_pageSourceTable` dictionary.
- **`TableFieldRegistry.GetSourceTableId(pageId)`** exposes the mapping.
- **`MockTestPageHandle.EnsureFieldMapping()`** uses the registry as primary source for `_sourceTableId` instead of reading the rewritten `Rec.TableId` (which is always 0 after RoslynRewriter transforms the page class).
- **`ALGoToKey`** performs a real in-memory record lookup when `_sourceTableId` is known; returns `true` if found (and populates field values), `false` if not. Falls back to `true` for stub pages (e.g. TestRequestPage) with no registered source table.
- **`ALGoToRecord`** same logic — real lookup when source table is known, stub-true fallback otherwise.
- Updated `74-testpage-navigation` TPN tests to insert records before calling `GoToKey` — those tests were written for the old no-op stub and now prove the correct real-lookup behavior.
- `docs/coverage.yaml`: `TestPage.GoToKey` and `TestPage.GoToRecord` changed from `gap` to `covered`.

## Test plan

- [ ] `tests/bucket-1/274-testpage-gotokey` — 5 new tests, all pass (GoToKey_ReturnsTrue_WhenRecordExists, GoToKey_ReturnsFalse_WhenRecordMissing, GoToKey_PositionsOnCorrectRecord, GoToRecord_ReturnsTrue_WhenRecordExists, GoToRecord_PositionsOnCorrectRecord)
- [ ] Bucket-1 full run: 1358 passed, 4 failed (pre-existing timezone and BigText failures, unrelated)
- [ ] Bucket-2 full run (excl. 130-cross-ext pre-existing): 1468 passed, 3 failed (pre-existing timezone failures, unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)