### PR TITLE
feat: TestHttpRequestMessage — Path, RequestType, HasSecretUri

### DIFF
--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -1099,6 +1099,8 @@ public void ClearApplicationMemberVariables()
             return node.WithIdentifier(SyntaxFactory.Identifier("MockCookie"));
         if (text == "NavTestHttpResponseMessage")
             return node.WithIdentifier(SyntaxFactory.Identifier("MockTestHttpResponseMessage"));
+        if (text == "NavTestHttpRequestMessage")
+            return node.WithIdentifier(SyntaxFactory.Identifier("MockTestHttpRequestMessage"));
 
         // NavFormHandle -> MockFormHandle
         // BC emits `Page "X"` AL variables as `NavFormHandle p` fields with
@@ -1523,7 +1525,7 @@ public void ClearApplicationMemberVariables()
         // whose .Tree must not be null. Strip it — the mocks are parameterless.
         if (typeText is "MockHttpClient" or "MockHttpResponseMessage"
             or "MockHttpContent" or "MockHttpRequestMessage" or "MockCookie"
-            or "MockTestHttpResponseMessage"
+            or "MockTestHttpResponseMessage" or "MockTestHttpRequestMessage"
             && visited.ArgumentList?.Arguments.Count == 1)
         {
             return visited.WithArgumentList(SyntaxFactory.ArgumentList());

--- a/AlRunner/Runtime/MockJsonHelper.cs
+++ b/AlRunner/Runtime/MockJsonHelper.cs
@@ -338,6 +338,13 @@ public static class MockJsonHelper
     public static NavText Path(MockCookie cookie)
         => new NavText(cookie.ALPath);
 
+    /// <summary>
+    /// Overload for TestHttpRequestMessage.Path — BC emits req.ALPath as a property access,
+    /// which the rewriter converts to MockJsonHelper.Path(req). Returns the HTTP request path.
+    /// </summary>
+    public static NavText Path(MockTestHttpRequestMessage req)
+        => req.ALPath;
+
     /// <summary>Returns true if the token's backing store is a JArray.</summary>
     public static bool IsArray(NavJsonToken token)
         => GetBackingToken(token) is JArray;

--- a/AlRunner/Runtime/MockTestHttpRequestMessage.cs
+++ b/AlRunner/Runtime/MockTestHttpRequestMessage.cs
@@ -1,0 +1,29 @@
+namespace AlRunner.Runtime;
+
+using Microsoft.Dynamics.Nav.Runtime;
+using Microsoft.Dynamics.Nav.Types;
+
+/// <summary>
+/// Stub for BC's <c>TestHttpRequestMessage</c> / <c>NavTestHttpRequestMessage</c> type.
+///
+/// BC emits <c>new NavTestHttpRequestMessage(this)</c> in scope-class field initialisers.
+/// The rewriter renames the type to <c>MockTestHttpRequestMessage</c> and strips the arg.
+///
+/// Provides in-memory defaults for all four gap properties:
+///   Path, RequestType — empty string by default
+///   HasSecretUri — always false in standalone mode
+///   QueryParameters — not accessible from AL directly (infrastructure method)
+/// </summary>
+public class MockTestHttpRequestMessage
+{
+    public MockTestHttpRequestMessage() { }
+
+    /// <summary>HTTP request path (e.g. "/api/items"). Default is empty.</summary>
+    public NavText ALPath { get; set; } = NavText.Empty;
+
+    /// <summary>HTTP method (e.g. "GET", "POST"). Default is empty.</summary>
+    public NavText ALRequestType { get; set; } = NavText.Empty;
+
+    /// <summary>Always false — no secret URI support in standalone mode.</summary>
+    public bool ALHasSecretUri => false;
+}

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -1165,7 +1165,8 @@ addfirst_fieldgroup_modification:
   layer: syntax
   category: modification
   status: covered
-  tests: tests/bucket-1/277-addfirst-fieldgroup
+  tests:
+    - tests/bucket-1/277-addfirst-fieldgroup
   notes: >
     PrepareSourceForStandalone strips addfirst(GroupName; Fields) lines from
     tableextension fieldgroups before AL compilation — the runner's BC compiler
@@ -7172,26 +7173,32 @@ TestFilter.SetFilter:
 TestHttpRequestMessage.HasSecretUri:
   layer: runtime-api
   category: TestHttpRequestMessage
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; MockTestHttpRequestMessage.ALHasSecretUri property always returns false.
+  tests:
+    - tests/bucket-1/185-testhttprequestmessage
 
 TestHttpRequestMessage.Path:
   layer: runtime-api
   category: TestHttpRequestMessage
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; MockTestHttpRequestMessage.ALPath property (NavText); BC emits ALPath which rewriter redirects via MockJsonHelper.Path(MockTestHttpRequestMessage) overload.
+  tests:
+    - tests/bucket-1/185-testhttprequestmessage
 
 TestHttpRequestMessage.QueryParameters:
   layer: runtime-api
   category: TestHttpRequestMessage
   status: gap
-  notes: overloads=1
+  notes: overloads=1; Dictionary of [Text,Text] return — not yet testable without web-service handler context.
 
 TestHttpRequestMessage.RequestType:
   layer: runtime-api
   category: TestHttpRequestMessage
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; MockTestHttpRequestMessage.ALRequestType property (NavText).
+  tests:
+    - tests/bucket-1/185-testhttprequestmessage
 
 # ── TestHttpResponseMessage ─────────────────────────────────────
 

--- a/tests/bucket-1/185-testhttprequestmessage/test/TestHttpRequestMsgTest.al
+++ b/tests/bucket-1/185-testhttprequestmessage/test/TestHttpRequestMsgTest.al
@@ -1,0 +1,62 @@
+/// Tests for TestHttpRequestMessage — issue #752.
+codeunit 121001 "THRQM Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    // ── Path ──────────────────────────────────────────────────────
+
+    [Test]
+    procedure Path_Default_IsEmpty()
+    var
+        Req: TestHttpRequestMessage;
+    begin
+        Assert.AreEqual('', Req.Path,
+            'Path must default to empty string');
+    end;
+
+    [Test]
+    procedure Path_TwoInstances_AreEqual()
+    var
+        Req1: TestHttpRequestMessage;
+        Req2: TestHttpRequestMessage;
+    begin
+        // Both must return the same empty default — not an instance-independent fault
+        Assert.AreEqual(Req1.Path, Req2.Path,
+            'Two fresh TestHttpRequestMessage instances must have the same Path default');
+    end;
+
+    // ── RequestType ───────────────────────────────────────────────
+
+    [Test]
+    procedure RequestType_Default_IsEmpty()
+    var
+        Req: TestHttpRequestMessage;
+    begin
+        Assert.AreEqual('', Req.RequestType,
+            'RequestType must default to empty string');
+    end;
+
+    // ── HasSecretUri ──────────────────────────────────────────────
+
+    [Test]
+    procedure HasSecretUri_ReturnsFalse()
+    var
+        Req: TestHttpRequestMessage;
+    begin
+        Assert.IsFalse(Req.HasSecretUri(),
+            'HasSecretUri must return false in standalone mode');
+    end;
+
+    [Test]
+    procedure HasSecretUri_IsNotNoop()
+    var
+        Req: TestHttpRequestMessage;
+    begin
+        // Negative: must return false — not some other value
+        Assert.AreNotEqual(true, Req.HasSecretUri(),
+            'HasSecretUri must return false (not true)');
+    end;
+}


### PR DESCRIPTION
Closes #752

## Changes

- **`MockTestHttpRequestMessage`** — new class backing `NavTestHttpRequestMessage` (BC's `TestHttpRequestMessage` type)
- **`RoslynRewriter`** — added `NavTestHttpRequestMessage → MockTestHttpRequestMessage` type rename + 1-arg ctor strip (same pattern as `MockTestHttpResponseMessage`)
- **`MockJsonHelper.Path`** — added overload for `MockTestHttpRequestMessage`; BC emits `req.ALPath` for `TestHttpRequestMessage.Path` which the rewriter redirects to `MockJsonHelper.Path(req)` — this overload returns the stored `ALPath` NavText
- **5 tests** in `tests/bucket-1/185-testhttprequestmessage/`:
  - `Path_Default_IsEmpty` — Path defaults to ''
  - `Path_TwoInstances_AreEqual` — two independent instances share same default
  - `RequestType_Default_IsEmpty` — RequestType defaults to ''
  - `HasSecretUri_ReturnsFalse` — IsFalse assertion
  - `HasSecretUri_IsNotNoop` — AreNotEqual(true, ...) cross-check
- **`docs/coverage.yaml`**: HasSecretUri, Path, RequestType → covered; QueryParameters left as gap (requires web-service handler context to construct non-empty query params)

## Not covered

`QueryParameters` returns a `Dictionary of [Text, Text]` populated by the BC web framework — no way to inject values in standalone tests. Remains gap.