### PR TITLE
feat: Table — Delete, Find, Get, Insert, Modify, Reset, SetFilter, SetRange coverage

### DIFF
--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -6451,8 +6451,11 @@ Table.CurrentKey:
 Table.Delete:
   layer: runtime-api
   category: Table
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=2; ALDelete(DataError, bool runTrigger) removes record from in-memory store; triggers OnDelete when runTrigger=true.
+  tests:
+    - tests/bucket-1/188-table-crud
+    - tests/bucket-1/42-locktable
 
 Table.DeleteAll:
   layer: runtime-api
@@ -6520,8 +6523,11 @@ Table.FilterGroup:
 Table.Find:
   layer: runtime-api
   category: Table
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; ALFind(DataError, string searchMethod="-") positions cursor on first/last/next matching record.
+  tests:
+    - tests/bucket-1/188-table-crud
+    - tests/bucket-1/08-sort-ordering
 
 Table.FindFirst:
   layer: runtime-api
@@ -6550,8 +6556,11 @@ Table.FindSet:
 Table.Get:
   layer: runtime-api
   category: Table
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; ALGet(DataError, params NavValue[] keyValues) returns true and positions on record when found.
+  tests:
+    - tests/bucket-1/188-table-crud
+    - tests/bucket-1/02-record-operations
 
 Table.GetAscending:
   layer: runtime-api
@@ -6642,8 +6651,11 @@ Table.Init:
 Table.Insert:
   layer: runtime-api
   category: Table
-  status: gap
-  notes: overloads=3
+  status: covered
+  notes: overloads=2; ALInsert(DataError) and ALInsert(DataError, bool runTrigger) add record to in-memory store; triggers OnInsert when runTrigger=true.
+  tests:
+    - tests/bucket-1/188-table-crud
+    - tests/bucket-1/02-record-operations
 
 Table.IsEmpty:
   layer: runtime-api
@@ -6695,8 +6707,11 @@ Table.MarkedOnly:
 Table.Modify:
   layer: runtime-api
   category: Table
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=2; ALModify(DataError) and ALModify(DataError, bool runTrigger) update record in in-memory store; triggers OnModify when runTrigger=true.
+  tests:
+    - tests/bucket-1/188-table-crud
+    - tests/bucket-1/02-record-operations
 
 Table.ModifyAll:
   layer: runtime-api
@@ -6767,8 +6782,11 @@ Table.Rename:
 Table.Reset:
   layer: runtime-api
   category: Table
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; ALReset() clears all filters, ranges, and current-key overrides.
+  tests:
+    - tests/bucket-1/188-table-crud
+    - tests/bucket-1/30-modify-all
 
 Table.SecurityFiltering:
   layer: runtime-api
@@ -6810,8 +6828,11 @@ Table.SetCurrentKey:
 Table.SetFilter:
   layer: runtime-api
   category: Table
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=2; ALSetFilter(fieldNo, filterExpression, params NavValue[] args) stores filter expression for use in Find/Count.
+  tests:
+    - tests/bucket-1/188-table-crud
+    - tests/bucket-1/09-setfilter-expressions
 
 Table.SetLoadFields:
   layer: runtime-api
@@ -6838,8 +6859,11 @@ Table.SetPosition:
 Table.SetRange:
   layer: runtime-api
   category: Table
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=3; ALSetRange(fieldNo, type) clears range, ALSetRange(fieldNo, type, value) sets equality, ALSetRange(fieldNo, type, from, to) sets range filter.
+  tests:
+    - tests/bucket-1/188-table-crud
+    - tests/bucket-1/240-setrange-clear
 
 Table.SetRecFilter:
   layer: runtime-api

--- a/tests/bucket-1/188-table-crud/src/TcrSrc.al
+++ b/tests/bucket-1/188-table-crud/src/TcrSrc.al
@@ -1,0 +1,16 @@
+/// Minimal table used by table-CRUD test suite — issue #685.
+table 124000 "TCR Item"
+{
+    DataClassification = SystemMetadata;
+    fields
+    {
+        field(1; "No."; Code[20]) { DataClassification = SystemMetadata; }
+        field(2; Name; Text[50]) { DataClassification = SystemMetadata; }
+        field(3; Quantity; Integer) { DataClassification = SystemMetadata; }
+        field(4; Category; Code[10]) { DataClassification = SystemMetadata; }
+    }
+    keys
+    {
+        key(PK; "No.") { Clustered = true; }
+    }
+}

--- a/tests/bucket-1/188-table-crud/test/TcrTest.al
+++ b/tests/bucket-1/188-table-crud/test/TcrTest.al
@@ -1,0 +1,168 @@
+/// Tests for Table CRUD operations — issue #685.
+/// Covers: Insert, Get, Modify, Delete, Find, Reset, SetFilter, SetRange.
+codeunit 124001 "TCR Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    local procedure InsertItem(No: Code[20]; ItemName: Text[50]; Qty: Integer; Cat: Code[10])
+    var
+        Item: Record "TCR Item";
+    begin
+        Item.Init();
+        Item."No." := No;
+        Item.Name := ItemName;
+        Item.Quantity := Qty;
+        Item.Category := Cat;
+        Item.Insert();
+    end;
+
+    // ── Insert / Get ──────────────────────────────────────────────────────────
+
+    [Test]
+    procedure Insert_Get_RoundTrips()
+    var
+        Item: Record "TCR Item";
+    begin
+        InsertItem('A001', 'Apple', 10, 'FRUIT');
+        Assert.IsTrue(Item.Get('A001'), 'Get must return true for inserted record');
+        Assert.AreEqual('Apple', Item.Name, 'Name must match inserted value');
+        Assert.AreEqual(10, Item.Quantity, 'Quantity must match inserted value');
+    end;
+
+    [Test]
+    procedure Get_Missing_ReturnsFalse()
+    var
+        Item: Record "TCR Item";
+    begin
+        Assert.IsFalse(Item.Get('MISSING'), 'Get must return false for non-existent record');
+    end;
+
+    // ── Modify ────────────────────────────────────────────────────────────────
+
+    [Test]
+    procedure Modify_ChangesValue()
+    var
+        Item: Record "TCR Item";
+    begin
+        InsertItem('B001', 'Banana', 5, 'FRUIT');
+        Item.Get('B001');
+        Item.Quantity := 99;
+        Item.Modify();
+        Item.Get('B001');
+        Assert.AreEqual(99, Item.Quantity, 'Quantity must reflect Modify value');
+    end;
+
+    [Test]
+    procedure Modify_DoesNotAffectOtherRecords()
+    var
+        Item: Record "TCR Item";
+    begin
+        InsertItem('C001', 'Cherry', 20, 'FRUIT');
+        InsertItem('C002', 'Cranberry', 30, 'FRUIT');
+        Item.Get('C001');
+        Item.Quantity := 99;
+        Item.Modify();
+        Item.Get('C002');
+        Assert.AreEqual(30, Item.Quantity, 'Other record must not be affected by Modify');
+    end;
+
+    // ── Delete ────────────────────────────────────────────────────────────────
+
+    [Test]
+    procedure Delete_RemovesRecord()
+    var
+        Item: Record "TCR Item";
+    begin
+        InsertItem('D001', 'Date', 15, 'FRUIT');
+        Assert.IsTrue(Item.Get('D001'), 'Record must exist before Delete');
+        Item.Delete();
+        Assert.IsFalse(Item.Get('D001'), 'Get must return false after Delete');
+    end;
+
+    [Test]
+    procedure Delete_DoesNotAffectOtherRecords()
+    var
+        Item: Record "TCR Item";
+    begin
+        InsertItem('E001', 'Elderberry', 7, 'BERRY');
+        InsertItem('E002', 'Eggplant', 3, 'VEG');
+        Item.Get('E001');
+        Item.Delete();
+        Assert.IsTrue(Item.Get('E002'), 'Other record must still exist after Delete');
+    end;
+
+    // ── Find ──────────────────────────────────────────────────────────────────
+
+    [Test]
+    procedure Find_First_PositionsOnFirstRecord()
+    var
+        Item: Record "TCR Item";
+    begin
+        InsertItem('F001', 'Fig', 8, 'FRUIT');
+        InsertItem('F002', 'Feijoa', 4, 'FRUIT');
+        Assert.IsTrue(Item.Find('-'), 'Find(-) must return true when records exist');
+        Assert.AreEqual('F001', Item."No.", 'Find(-) must position on first record');
+    end;
+
+    [Test]
+    procedure Find_EmptyTable_ReturnsFalse()
+    var
+        Item: Record "TCR Item";
+    begin
+        Assert.IsFalse(Item.Find('-'), 'Find(-) must return false on empty table');
+    end;
+
+    // ── SetRange / Reset ──────────────────────────────────────────────────────
+
+    [Test]
+    procedure SetRange_FiltersRecords()
+    var
+        Item: Record "TCR Item";
+    begin
+        InsertItem('G001', 'Grape', 10, 'FRUIT');
+        InsertItem('G002', 'Garlic', 5, 'VEG');
+        InsertItem('G003', 'Ginger', 3, 'VEG');
+        Item.SetRange(Category, 'VEG');
+        Assert.AreEqual(2, Item.Count(), 'SetRange must filter to 2 VEG records');
+    end;
+
+    [Test]
+    procedure Reset_ClearsFilter()
+    var
+        Item: Record "TCR Item";
+    begin
+        InsertItem('H001', 'Hazelnut', 12, 'NUT');
+        InsertItem('H002', 'Honey', 6, 'OTHER');
+        Item.SetRange(Category, 'NUT');
+        Assert.AreEqual(1, Item.Count(), 'Before Reset must be 1');
+        Item.Reset();
+        Assert.AreEqual(2, Item.Count(), 'After Reset must be 2 (filter cleared)');
+    end;
+
+    // ── SetFilter ─────────────────────────────────────────────────────────────
+
+    [Test]
+    procedure SetFilter_WildcardFiltersRecords()
+    var
+        Item: Record "TCR Item";
+    begin
+        InsertItem('I001', 'Ice Apple', 9, 'FRUIT');
+        InsertItem('I002', 'Iceberry', 4, 'BERRY');
+        InsertItem('I003', 'Mango', 20, 'FRUIT');
+        Item.SetFilter(Name, 'Ice*');
+        Assert.AreEqual(2, Item.Count(), 'SetFilter Ice* must match 2 records');
+    end;
+
+    [Test]
+    procedure SetFilter_NoMatch_CountIsZero()
+    var
+        Item: Record "TCR Item";
+    begin
+        InsertItem('J001', 'Jackfruit', 11, 'FRUIT');
+        Item.SetFilter(Name, 'ZZZNOTFOUND*');
+        Assert.AreEqual(0, Item.Count(), 'SetFilter with no match must return Count = 0');
+    end;
+}

--- a/tests/bucket-1/278-mediaset-methods/test/MsmTest.al
+++ b/tests/bucket-1/278-mediaset-methods/test/MsmTest.al
@@ -1,4 +1,4 @@
-codeunit 123001 "MSM Test"
+codeunit 125001 "MSM Test"
 {
     Subtype = Test;
     var


### PR DESCRIPTION
Closes #685

## Summary

All 8 table operations listed in issue #685 are already implemented in `MockRecordHandle` — the issue was filed before these were added. This PR adds a dedicated test suite proving them directly and fixes the stale `docs/coverage.yaml` entries.

- New test suite `tests/bucket-1/188-table-crud` (table 124000, codeunit 124001): 12 tests with direct assertions
  - Insert/Get round-trip: name and quantity preserved
  - Get missing record: returns false
  - Modify: updates value without affecting other records
  - Delete: removes record without affecting other records
  - Find('-'): positions on first record, returns false on empty table
  - SetRange: filters by category
  - Reset: clears filter (Count goes from 1 → 2)
  - SetFilter: wildcard filter matches correct records
- `docs/coverage.yaml`: `Table.Delete`, `Find`, `Get`, `Insert`, `Modify`, `Reset`, `SetFilter`, `SetRange` updated from `gap` → `covered`

## Test plan

- [x] Insert_Get_RoundTrips
- [x] Get_Missing_ReturnsFalse
- [x] Modify_ChangesValue
- [x] Modify_DoesNotAffectOtherRecords
- [x] Delete_RemovesRecord
- [x] Delete_DoesNotAffectOtherRecords
- [x] Find_First_PositionsOnFirstRecord
- [x] Find_EmptyTable_ReturnsFalse
- [x] SetRange_FiltersRecords
- [x] Reset_ClearsFilter
- [x] SetFilter_WildcardFiltersRecords
- [x] SetFilter_NoMatch_CountIsZero
- [x] Full bucket-1 regression: 1437 passed, 2 pre-existing DT2Time failures (unrelated)