### PR TITLE
fix: renumber MSM Test codeunit 123001 → 124001 (bucket-1 ID collision)

### DIFF
--- a/tests/bucket-1/278-mediaset-methods/test/MsmTest.al
+++ b/tests/bucket-1/278-mediaset-methods/test/MsmTest.al
@@ -1,4 +1,4 @@
-codeunit 123001 "MSM Test"
+codeunit 124001 "MSM Test"
 {
     Subtype = Test;
     var


### PR DESCRIPTION
## Summary

PR #914 introduced codeunit 123001 (`MSM Test`) in `tests/bucket-1/278-mediaset-methods/`, but PR #916 (merged in the same window) also introduced codeunit 123001 (`TpmTest`) in `tests/bucket-1/187-testpage-methods/`. This causes CS0229 ambiguity errors when the full bucket-1 is compiled.

Renumbers MSM Test from 123001 → 124001 (the 124xxx range is unused in bucket-1).

## Test plan
- [ ] Full bucket-1 run shows 1433 passed (no CS0229 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)