### PR TITLE
feat: Media.FindOrphans and MediaSet.FindOrphans — return empty List of [Guid] (#949)

### DIFF
--- a/AlRunner/Runtime/MockMedia.cs
+++ b/AlRunner/Runtime/MockMedia.cs
@@ -225,12 +225,13 @@ public class MockMedia : NavValue
     /// <summary>
     /// BC emits <c>NavMedia.ALFindOrphans(errorLevel)</c> for the static <c>Media.FindOrphans()</c>.
     /// Returns an empty list — no orphaned media in a standalone test environment.
+    /// AL <c>List of [Guid]</c> compiles to <c>NavList&lt;System.Guid&gt;</c>.
     /// </summary>
-    public static NavList<NavGuid> ALFindOrphans(DataError errorLevel)
-        => NavList<NavGuid>.Default;
+    public static NavList<Guid> ALFindOrphans(DataError errorLevel)
+        => NavList<Guid>.Default;
 
-    public static NavList<NavGuid> ALFindOrphans()
-        => NavList<NavGuid>.Default;
+    public static NavList<Guid> ALFindOrphans()
+        => NavList<Guid>.Default;
 
     // ── GetDocumentUrl ────────────────────────────────────────────────────────────
 

--- a/AlRunner/Runtime/MockMediaSet.cs
+++ b/AlRunner/Runtime/MockMediaSet.cs
@@ -110,4 +110,18 @@ public class MockMediaSet : NavValue
     /// <c>MediaSet.ExportFile(FileName)</c>. Returns 0 — no blob data in standalone mode.
     /// </summary>
     public int ALExport(DataError errorLevel, string fileName) => 0;
+
+    // ── FindOrphans ───────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// BC emits <c>MockMediaSet.ALFindOrphans(errorLevel)</c> for the static
+    /// <c>MediaSet.FindOrphans()</c>. Returns an empty list — no orphaned media
+    /// in a standalone test environment.
+    /// AL <c>List of [Guid]</c> compiles to <c>NavList&lt;System.Guid&gt;</c>.
+    /// </summary>
+    public static NavList<Guid> ALFindOrphans(DataError errorLevel)
+        => NavList<Guid>.Default;
+
+    public static NavList<Guid> ALFindOrphans()
+        => NavList<Guid>.Default;
 }

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -4016,8 +4016,10 @@ Media.ExportStream:
 Media.FindOrphans:
   layer: runtime-api
   category: Media
-  status: gap
-  notes: "BC 17+ method — not recognised by the BC 16.2 AL compiler used for transpilation; MockMedia.ALFindOrphans() is implemented but untestable from AL until the compiler is upgraded"
+  status: covered
+  tests:
+    - tests/bucket-1/280-media-findorphans
+  notes: "Static method returning List of [Guid]; MockMedia.ALFindOrphans() returns NavList<Guid>.Default (empty list) — no orphaned media in standalone mode."
 
 Media.HasValue:
   layer: runtime-api
@@ -4072,8 +4074,10 @@ MediaSet.ExportFile:
 MediaSet.FindOrphans:
   layer: runtime-api
   category: MediaSet
-  status: gap
-  notes: "BC 17+ method — not recognised by the BC 16.2 AL compiler used for transpilation; same compiler limitation as Media.FindOrphans"
+  status: covered
+  tests:
+    - tests/bucket-1/280-media-findorphans
+  notes: "Static method returning List of [Guid]; MockMediaSet.ALFindOrphans() returns NavList<Guid>.Default (empty list) — no orphaned media in standalone mode."
 
 MediaSet.ImportFile:
   layer: runtime-api

--- a/tests/bucket-1/280-media-findorphans/src/MfoSrc.al
+++ b/tests/bucket-1/280-media-findorphans/src/MfoSrc.al
@@ -1,0 +1,13 @@
+/// Source codeunit for Media/MediaSet.FindOrphans tests (issue #949).
+codeunit 127001 "MFO Source"
+{
+    procedure GetOrphanedMedia(): List of [Guid]
+    begin
+        exit(Media.FindOrphans());
+    end;
+
+    procedure GetOrphanedMediaSet(): List of [Guid]
+    begin
+        exit(MediaSet.FindOrphans());
+    end;
+}

--- a/tests/bucket-1/280-media-findorphans/test/MfoTest.al
+++ b/tests/bucket-1/280-media-findorphans/test/MfoTest.al
@@ -1,0 +1,32 @@
+codeunit 127002 "MFO Test"
+{
+    Subtype = Test;
+    var
+        Assert: Codeunit Assert;
+
+    // ── Media.FindOrphans ─────────────────────────────────────────────────────
+
+    [Test]
+    procedure Media_FindOrphans_ReturnsEmptyList()
+    var
+        Src: Codeunit "MFO Source";
+        Orphans: List of [Guid];
+    begin
+        // Positive: FindOrphans returns an empty list in standalone mode (no real blob store).
+        Orphans := Src.GetOrphanedMedia();
+        Assert.AreEqual(0, Orphans.Count(), 'Media.FindOrphans must return empty list in runner');
+    end;
+
+    // ── MediaSet.FindOrphans ──────────────────────────────────────────────────
+
+    [Test]
+    procedure MediaSet_FindOrphans_ReturnsEmptyList()
+    var
+        Src: Codeunit "MFO Source";
+        Orphans: List of [Guid];
+    begin
+        // Positive: MediaSet.FindOrphans returns an empty list in standalone mode.
+        Orphans := Src.GetOrphanedMediaSet();
+        Assert.AreEqual(0, Orphans.Count(), 'MediaSet.FindOrphans must return empty list in runner');
+    end;
+}


### PR DESCRIPTION
Closes #949

## Summary

- **MockMedia.ALFindOrphans**: fixed return type from `NavList<NavGuid>` to `NavList<Guid>` — AL `List of [Guid]` compiles to `NavList<System.Guid>`, not `NavList<NavGuid>`
- **MockMediaSet**: added static `ALFindOrphans()` / `ALFindOrphans(DataError)` returning `NavList<Guid>.Default` (empty list — no orphaned media in standalone mode)
- **Test suite 280-media-findorphans**: 2 tests covering `Media.FindOrphans()` and `MediaSet.FindOrphans()`
- **docs/coverage.yaml**: both `Media.FindOrphans` and `MediaSet.FindOrphans` updated from `gap` → `covered`

## Test plan

- [x] 280-media-findorphans suite: 2/2 pass
- [x] Full bucket-1 (1469 tests): no regressions (4 pre-existing failures unrelated)