### PR TITLE
feat: TestPage.RunPageBackgroundTask and TestHttpRequestMessage.QueryParameters

### DIFF
--- a/AlRunner/Runtime/MockTestHttpRequestMessage.cs
+++ b/AlRunner/Runtime/MockTestHttpRequestMessage.cs
@@ -12,7 +12,7 @@ using Microsoft.Dynamics.Nav.Types;
 /// Provides in-memory defaults for all four gap properties:
 ///   Path, RequestType — empty string by default
 ///   HasSecretUri — always false in standalone mode
-///   QueryParameters — not accessible from AL directly (infrastructure method)
+///   QueryParameters — returns empty Dictionary of [Text,Text] (no URI parsing in standalone)
 /// </summary>
 public class MockTestHttpRequestMessage
 {
@@ -26,4 +26,12 @@ public class MockTestHttpRequestMessage
 
     /// <summary>Always false — no secret URI support in standalone mode.</summary>
     public bool ALHasSecretUri => false;
+
+    /// <summary>
+    /// BC emits <c>req.ALQueryParameters</c> (property) for
+    /// <c>TestHttpRequestMessage.QueryParameters()</c>.
+    /// Returns an empty dictionary — no URI query-string parsing in standalone mode.
+    /// </summary>
+    public NavDictionary<NavText, NavText> ALQueryParameters
+        => NavDictionary<NavText, NavText>.Default;
 }

--- a/AlRunner/Runtime/MockTestPageHandle.cs
+++ b/AlRunner/Runtime/MockTestPageHandle.cs
@@ -370,6 +370,20 @@ public class MockTestPageHandle
         return new MockTestPageAction(() => method.Invoke(page, null));
     }
 
+    // ── RunPageBackgroundTask ──────────────────────────────────────────────────
+
+    /// <summary>
+    /// BC emits <c>tP.Target.ALRunPageBackgroundTask(taskId)</c> for
+    /// <c>TestPage.RunPageBackgroundTask(TaskId: Integer)</c>.
+    /// Returns an empty dictionary — no background task execution in standalone mode.
+    /// </summary>
+    public NavDictionary<NavText, NavText> ALRunPageBackgroundTask(int taskId)
+        => NavDictionary<NavText, NavText>.Default;
+
+    /// <summary>Overload with optional RecordId parameter.</summary>
+    public NavDictionary<NavText, NavText> ALRunPageBackgroundTask(int taskId, object recordId)
+        => NavDictionary<NavText, NavText>.Default;
+
     /// <summary>
     /// Returns a MockTestPageAction for built-in actions (OK, Cancel, Close, etc.).
     /// BC casts FormResult enum values: GetBuiltInAction((FormResult)1) for OK.

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -7273,8 +7273,10 @@ TestHttpRequestMessage.Path:
 TestHttpRequestMessage.QueryParameters:
   layer: runtime-api
   category: TestHttpRequestMessage
-  status: gap
-  notes: overloads=1; Dictionary of [Text,Text] return — not yet testable without web-service handler context.
+  status: covered
+  notes: overloads=1; BC emits ALQueryParameters property returning NavDictionary<NavText,NavText>; empty stub (no URI parsing in standalone)
+  tests:
+    - tests/bucket-1/190-test-infra-stubs
 
 TestHttpRequestMessage.RequestType:
   layer: runtime-api
@@ -7532,8 +7534,10 @@ TestPage.Previous:
 TestPage.RunPageBackgroundTask:
   layer: runtime-api
   category: TestPage
-  status: gap
-  notes: overloads=1; Requires service-tier background task infrastructure — architectural limit.
+  status: covered
+  notes: overloads=2 (taskId; taskId+recordId); returns empty NavDictionary<NavText,NavText> — no background task execution in standalone mode
+  tests:
+    - tests/bucket-1/190-test-infra-stubs
 
 TestPage.Trap:
   layer: runtime-api

--- a/tests/bucket-1/190-test-infra-stubs/src/TisSrc.al
+++ b/tests/bucket-1/190-test-infra-stubs/src/TisSrc.al
@@ -1,5 +1,5 @@
 /// Minimal card page used by test-infra-stubs test suite — issue #950.
-page 127000 "TIS Card Page"
+page 128000 "TIS Card Page"
 {
     PageType = Card;
     ApplicationArea = All;

--- a/tests/bucket-1/190-test-infra-stubs/src/TisSrc.al
+++ b/tests/bucket-1/190-test-infra-stubs/src/TisSrc.al
@@ -1,0 +1,8 @@
+/// Minimal card page used by test-infra-stubs test suite — issue #950.
+page 127000 "TIS Card Page"
+{
+    PageType = Card;
+    ApplicationArea = All;
+    UsageCategory = None;
+    Caption = 'TIS Card';
+}

--- a/tests/bucket-1/190-test-infra-stubs/test/TisTest.al
+++ b/tests/bucket-1/190-test-infra-stubs/test/TisTest.al
@@ -1,0 +1,77 @@
+/// Tests for TestPage.RunPageBackgroundTask and TestHttpRequestMessage.QueryParameters — issue #950.
+codeunit 127001 "TIS Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    // ── TestPage.RunPageBackgroundTask ────────────────────────────────────────
+
+    [Test]
+    procedure RunPageBackgroundTask_ReturnsEmptyDict()
+    var
+        P: TestPage "TIS Card Page";
+        Result: Dictionary of [Text, Text];
+    begin
+        // Positive: RunPageBackgroundTask returns empty dictionary in runner (no-op stub).
+        P.OpenView();
+        Result := P.RunPageBackgroundTask(1);
+        Assert.AreEqual(0, Result.Count(), 'RunPageBackgroundTask must return empty dictionary in runner');
+        P.Close();
+    end;
+
+    [Test]
+    procedure RunPageBackgroundTask_CountIsNotPositive()
+    var
+        P: TestPage "TIS Card Page";
+        Result: Dictionary of [Text, Text];
+    begin
+        // Negative: result dict must be empty (no background task runs in standalone).
+        P.OpenView();
+        Result := P.RunPageBackgroundTask(1);
+        Assert.IsFalse(Result.Count() > 0, 'RunPageBackgroundTask result must have 0 entries in runner');
+        P.Close();
+    end;
+
+    [Test]
+    procedure RunPageBackgroundTask_DifferentTaskIds_BothEmpty()
+    var
+        P: TestPage "TIS Card Page";
+        R1: Dictionary of [Text, Text];
+        R2: Dictionary of [Text, Text];
+    begin
+        // Positive: different task IDs both return empty dicts.
+        P.OpenView();
+        R1 := P.RunPageBackgroundTask(1);
+        R2 := P.RunPageBackgroundTask(99);
+        Assert.AreEqual(0, R1.Count(), 'Task 1 must return empty dict');
+        Assert.AreEqual(0, R2.Count(), 'Task 99 must return empty dict');
+        P.Close();
+    end;
+
+    // ── TestHttpRequestMessage.QueryParameters ────────────────────────────────
+
+    [Test]
+    procedure QueryParameters_FreshRequest_IsEmpty()
+    var
+        Req: TestHttpRequestMessage;
+        Params: Dictionary of [Text, Text];
+    begin
+        // Positive: fresh request has no query parameters.
+        Params := Req.QueryParameters();
+        Assert.AreEqual(0, Params.Count(), 'Fresh TestHttpRequestMessage must have 0 query parameters');
+    end;
+
+    [Test]
+    procedure QueryParameters_CountIsNotPositive()
+    var
+        Req: TestHttpRequestMessage;
+        Params: Dictionary of [Text, Text];
+    begin
+        // Negative: count must not be positive (no params in runner stub).
+        Params := Req.QueryParameters();
+        Assert.IsFalse(Params.Count() > 0, 'QueryParameters count must not be positive on a fresh request');
+    end;
+
+}

--- a/tests/bucket-1/190-test-infra-stubs/test/TisTest.al
+++ b/tests/bucket-1/190-test-infra-stubs/test/TisTest.al
@@ -1,5 +1,5 @@
 /// Tests for TestPage.RunPageBackgroundTask and TestHttpRequestMessage.QueryParameters — issue #950.
-codeunit 127001 "TIS Test"
+codeunit 128001 "TIS Test"
 {
     Subtype = Test;
 


### PR DESCRIPTION
Closes #950

## Summary

- **`TestPage.RunPageBackgroundTask`**: Added `ALRunPageBackgroundTask(taskId: int)` to `MockTestPageHandle`. BC emits this returning `Dictionary of [Text, Text]` (task output params), not `Boolean`. Returns empty `NavDictionary<NavText, NavText>` — no background scheduler in standalone mode.
- **`TestHttpRequestMessage.QueryParameters`**: Added `ALQueryParameters` property to `MockTestHttpRequestMessage`. BC emits this as a property access (not method call). Returns empty `NavDictionary<NavText, NavText>` — no URI query-string parsing needed in standalone tests.
- New test suite `tests/bucket-1/190-test-infra-stubs` with 5 proving tests (objects 127000–127001).

## Test plan

- [x] RED: `ALRunPageBackgroundTask` and `ALQueryParameters` missing → Roslyn CS1061 errors
- [x] GREEN: 5 tests pass, `1474 passed, 2 failed` (same 2 pre-existing DT2Time failures)