### PR TITLE
test: JsonValue — AsToken/Clone/IsUndefined/Path + typed As* (#699)

### DIFF
--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -3765,14 +3765,16 @@ JsonValue.AsTime:
 JsonValue.AsToken:
   layer: runtime-api
   category: JsonValue
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-2/208-jsonvalue-extended
+  notes: overloads=1. Covered via NavJsonValue native — AsToken().AsValue().AsInteger() round-trips.
 
 JsonValue.Clone:
   layer: runtime-api
   category: JsonValue
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-2/208-jsonvalue-extended
+  notes: overloads=1. Covered via NavJsonValue native — Clone produces independent copy.
 
 JsonValue.IsNull:
   layer: runtime-api
@@ -3784,14 +3786,16 @@ JsonValue.IsNull:
 JsonValue.IsUndefined:
   layer: runtime-api
   category: JsonValue
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-2/208-jsonvalue-extended
+  notes: overloads=1. Covered via NavJsonValue native — default-initialised returns false (null != undefined), after SetValue also false.
 
 JsonValue.Path:
   layer: runtime-api
   category: JsonValue
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-2/208-jsonvalue-extended
+  notes: overloads=1. Covered via NavJsonValue native — nested value under "score" returns "$.score" (JSONPath notation).
 
 JsonValue.ReadFrom:
   layer: runtime-api

--- a/tests/bucket-2/208-jsonvalue-extended/al-runner.json
+++ b/tests/bucket-2/208-jsonvalue-extended/al-runner.json
@@ -1,0 +1,4 @@
+{
+  "sourcePath": "./src",
+  "testPath": "./test"
+}

--- a/tests/bucket-2/208-jsonvalue-extended/src/JsonValueExtSrc.al
+++ b/tests/bucket-2/208-jsonvalue-extended/src/JsonValueExtSrc.al
@@ -1,0 +1,84 @@
+/// Exercises JsonValue — SetValue + typed As* extraction,
+/// IsUndefined, Path, AsToken, Clone.
+codeunit 60350 "JVX Src"
+{
+    procedure SetAndGetInteger(): Integer
+    var
+        v: JsonValue;
+    begin
+        v.SetValue(42);
+        exit(v.AsInteger());
+    end;
+
+    procedure SetAndGetText(): Text
+    var
+        v: JsonValue;
+    begin
+        v.SetValue('hello');
+        exit(v.AsText());
+    end;
+
+    procedure SetAndGetBoolean(): Boolean
+    var
+        v: JsonValue;
+    begin
+        v.SetValue(true);
+        exit(v.AsBoolean());
+    end;
+
+    procedure SetAndGetDecimal(): Decimal
+    var
+        v: JsonValue;
+    begin
+        v.SetValue(3.14);
+        exit(v.AsDecimal());
+    end;
+
+    procedure IsUndefined_Default(): Boolean
+    var
+        v: JsonValue;
+    begin
+        exit(v.IsUndefined());
+    end;
+
+    procedure IsUndefined_AfterSet(): Boolean
+    var
+        v: JsonValue;
+    begin
+        v.SetValue(1);
+        exit(v.IsUndefined());
+    end;
+
+    procedure PathOfNestedValue(): Text
+    var
+        obj: JsonObject;
+        t: JsonToken;
+    begin
+        obj.Add('score', 99);
+        obj.Get('score', t);
+        exit(t.Path);
+    end;
+
+    procedure AsTokenRoundTrip(): Integer
+    var
+        v: JsonValue;
+        t: JsonToken;
+    begin
+        v.SetValue(77);
+        t := v.AsToken();
+        exit(t.AsValue().AsInteger());
+    end;
+
+    procedure CloneIsIndependent(): Boolean
+    var
+        orig: JsonValue;
+        cloned: JsonToken;
+        clonedVal: JsonValue;
+    begin
+        orig.SetValue(42);
+        cloned := orig.Clone();
+        clonedVal := cloned.AsValue();
+        clonedVal.SetValue(99);
+        exit((orig.AsInteger() = 42) and (clonedVal.AsInteger() = 99));
+    end;
+}

--- a/tests/bucket-2/208-jsonvalue-extended/test/JsonValueExtTest.al
+++ b/tests/bucket-2/208-jsonvalue-extended/test/JsonValueExtTest.al
@@ -1,0 +1,81 @@
+codeunit 60351 "JVX Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "JVX Src";
+
+    [Test]
+    procedure SetValue_AsInteger_RoundTrip()
+    begin
+        Assert.AreEqual(42, Src.SetAndGetInteger(),
+            'SetValue(42) + AsInteger must return 42');
+    end;
+
+    [Test]
+    procedure SetValue_AsText_RoundTrip()
+    begin
+        Assert.AreEqual('hello', Src.SetAndGetText(),
+            'SetValue(hello) + AsText must return hello');
+    end;
+
+    [Test]
+    procedure SetValue_AsBoolean_RoundTrip()
+    begin
+        Assert.IsTrue(Src.SetAndGetBoolean(),
+            'SetValue(true) + AsBoolean must return true');
+    end;
+
+    [Test]
+    procedure SetValue_AsDecimal_RoundTrip()
+    begin
+        Assert.AreEqual(3.14, Src.SetAndGetDecimal(),
+            'SetValue(3.14) + AsDecimal must return 3.14');
+    end;
+
+    [Test]
+    procedure IsUndefined_False_ForDefault()
+    begin
+        // BC's default-initialised JsonValue is not "undefined" — it holds a null token.
+        Assert.IsFalse(Src.IsUndefined_Default(),
+            'A default JsonValue.IsUndefined returns false (null != undefined)');
+    end;
+
+    [Test]
+    procedure IsUndefined_False_AfterSet()
+    begin
+        Assert.IsFalse(Src.IsUndefined_AfterSet(),
+            'JsonValue.IsUndefined must be false after SetValue');
+    end;
+
+    [Test]
+    procedure Path_NestedValue()
+    begin
+        // JSONPath notation: "$.score" for a value under key "score".
+        Assert.AreEqual('$.score', Src.PathOfNestedValue(),
+            'Path of a value under key "score" must be "$.score"');
+    end;
+
+    [Test]
+    procedure AsToken_RoundTrip()
+    begin
+        Assert.AreEqual(77, Src.AsTokenRoundTrip(),
+            'AsToken().AsValue().AsInteger must round-trip the value');
+    end;
+
+    [Test]
+    procedure Clone_IsIndependent()
+    begin
+        Assert.IsTrue(Src.CloneIsIndependent(),
+            'Clone must produce an independent copy');
+    end;
+
+    [Test]
+    procedure SetValue_Changes_Value_NegativeTrap()
+    begin
+        // Negative trap: SetValue must actually change the stored value.
+        Assert.AreNotEqual(0, Src.SetAndGetInteger(),
+            'SetValue must not leave the value at default 0');
+    end;
+}


### PR DESCRIPTION
## Summary
- Closes #699 (partial — covers AsToken, Clone, IsUndefined, Path + proves typed As* round-trips)
- All tested methods work via BC's native NavJsonValue. Coverage.yaml: 4 entries flipped gap → covered.
- New suite `tests/bucket-2/208-jsonvalue-extended` — 10 tests.

## Test plan
- [x] New suite — 10/10 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)