### PR TITLE
feat: ReportInstance remaining — Execute, Print, PageNo, ValidateAndPrepareLayout (#948)

### DIFF
--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -410,6 +410,10 @@ public class RoslynRewriter : CSharpSyntaxRewriter
             preservedMembers.Add(
                 SyntaxFactory.ParseMemberDeclaration(
                     "public bool PrintOnlyIfDetail { get; set; }")!);
+            // PageNo — CurrReport.PageNo() returns current page number; always 0 in standalone mode.
+            preservedMembers.Add(
+                SyntaxFactory.ParseMemberDeclaration(
+                    "public int PageNo() => 0;")!);
 
             // For report extensions: inject a CurrReport stub.
             // BC generates a CurrReport property that casts this.ParentObject to the

--- a/AlRunner/Runtime/MockReportHandle.cs
+++ b/AlRunner/Runtime/MockReportHandle.cs
@@ -298,8 +298,17 @@ public class MockReportHandle
         handle.RunModal();
     }
 
+    // ── Instance Print method ────────────────────────────────────────────────
+    // BC emits rep.Print(requestPageXml) for Report.Print() on an instance variable.
+    /// <summary>Instance <c>Rep.Print(requestPageXml)</c> — no-op in standalone mode.</summary>
+    public void Print(string requestPageXml) { }
+
     // Report.Execute / Report.Print — no-ops in standalone mode
     public static void StaticExecute(int reportId) { }
+
+    /// <summary>BC emits <c>MockReportHandle.StaticExecute(reportId, requestPage)</c> for <c>Report.Execute(N, requestPage)</c>.</summary>
+    public static void StaticExecute(int reportId, string requestPage) { }
+
     public static void StaticPrint(int reportId) { }
 
     // Report.SaveAs* — no-ops (no real file I/O in standalone mode)
@@ -330,5 +339,17 @@ public class MockReportHandle
 
     // Report.ValidateAndPrepareLayout / Report.WordXmlPart — no-ops
     public static void StaticValidateAndPrepareLayout(int reportId) { }
+
+    /// <summary>
+    /// BC emits <c>MockReportHandle.StaticValidateAndPrepareLayout(errorLevel, reportId, inStreamIn, ByRef&lt;inStreamOut&gt;, layoutType)</c>
+    /// for <c>Report.ValidateAndPrepareLayout(N, InStrIn, InStrOut, LayoutType)</c>. No-op in standalone mode.
+    /// </summary>
+    public static void StaticValidateAndPrepareLayout(
+        DataError errorLevel,
+        int reportId,
+        MockInStream inStreamIn,
+        ByRef<MockInStream> inStreamOut,
+        object layoutType) { }
+
     public static string StaticWordXmlPart(int reportId) => string.Empty;
 }

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -5368,8 +5368,9 @@ ReportInstance.ExcelLayout:
 ReportInstance.Execute:
   layer: runtime-api
   category: ReportInstance
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-1/281-report-instance-ext
+  notes: overloads=1; MockReportHandle.StaticExecute(id, requestPage) — no-op in standalone mode.
 
 ReportInstance.FormatRegion:
   layer: runtime-api
@@ -5395,14 +5396,16 @@ ReportInstance.Language:
 ReportInstance.NewPage:
   layer: runtime-api
   category: ReportInstance
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-1/281-report-instance-ext
+  notes: overloads=1; Deprecated in BC; BC compiler compiles CurrReport.NewPage() to a blank statement — no injection needed.
 
 ReportInstance.NewPagePerRecord:
   layer: runtime-api
   category: ReportInstance
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-1/281-report-instance-ext
+  notes: overloads=1; Both CurrReport.NewPagePerRecord (in trigger) and Rep.NewPagePerRecord (instance setter) compile to blank statements — no injection needed.
 
 ReportInstance.ObjectId:
   layer: runtime-api
@@ -5414,14 +5417,16 @@ ReportInstance.ObjectId:
 ReportInstance.PageNo:
   layer: runtime-api
   category: ReportInstance
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-1/281-report-instance-ext
+  notes: overloads=1; Injected as public int PageNo() => 0 into stripped report class by RoslynRewriter.
 
 ReportInstance.PaperSource:
   layer: runtime-api
   category: ReportInstance
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-1/281-report-instance-ext
+  notes: overloads=1; Deprecated in BC; BC compiler compiles CurrReport.PaperSource() to a blank statement — no injection needed.
 
 ReportInstance.Preview:
   layer: runtime-api
@@ -5432,8 +5437,9 @@ ReportInstance.Preview:
 ReportInstance.Print:
   layer: runtime-api
   category: ReportInstance
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-1/281-report-instance-ext
+  notes: overloads=1; MockReportHandle.Print(requestPageXml) instance method — no-op in standalone mode.
 
 ReportInstance.PrintOnlyIfDetail:
   layer: runtime-api
@@ -5480,8 +5486,9 @@ ReportInstance.RunRequestPage:
 ReportInstance.SaveAs:
   layer: runtime-api
   category: ReportInstance
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-1/281-report-instance-ext
+  notes: overloads=1; MockReportHandle.SaveAs(errorLevel, requestParams, format, outStream) — no-op in standalone mode.
 
 ReportInstance.SaveAsExcel:
   layer: runtime-api
@@ -5528,8 +5535,9 @@ ReportInstance.SetTableView:
 ReportInstance.ShowOutput:
   layer: runtime-api
   category: ReportInstance
-  status: gap
-  notes: overloads=2
+  status: covered
+  tests: tests/bucket-1/281-report-instance-ext
+  notes: overloads=2; Deprecated in BC; BC compiler compiles CurrReport.ShowOutput to default(bool) = false — no injection needed.
 
 ReportInstance.Skip:
   layer: runtime-api
@@ -5548,8 +5556,9 @@ ReportInstance.TargetFormat:
 ReportInstance.TotalsCausedBy:
   layer: runtime-api
   category: ReportInstance
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-1/281-report-instance-ext
+  notes: overloads=1; Deprecated in BC; BC compiler compiles CurrReport.TotalsCausedBy to default(int) = 0 — no injection needed.
 
 ReportInstance.UseRequestPage:
   layer: runtime-api
@@ -5561,8 +5570,9 @@ ReportInstance.UseRequestPage:
 ReportInstance.ValidateAndPrepareLayout:
   layer: runtime-api
   category: ReportInstance
-  status: gap
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-1/281-report-instance-ext
+  notes: overloads=1; MockReportHandle.StaticValidateAndPrepareLayout(errorLevel, id, inStreamIn, ByRef<inStreamOut>, layoutType) — no-op in standalone mode.
 
 ReportInstance.WordLayout:
   layer: runtime-api

--- a/tests/bucket-1/281-report-instance-ext/src/RieSrc.al
+++ b/tests/bucket-1/281-report-instance-ext/src/RieSrc.al
@@ -1,0 +1,87 @@
+/// Source objects for ReportInstance extended method tests (issue #948).
+table 128000 "RIE Table"
+{
+    fields
+    {
+        field(1; "No."; Code[20]) { }
+    }
+    keys { key(PK; "No.") { Clustered = true; } }
+}
+
+/// Report that exercises CurrReport.* methods requiring injection or compilation.
+/// All the if-false blocks prove these compile; the trigger runs normally.
+report 128000 "RIE Report"
+{
+    dataset
+    {
+        dataitem(RieData; "RIE Table")
+        {
+            trigger OnPreDataItem()
+            var
+                PageNum: Integer;
+                Caused: Integer;
+                Show: Boolean;
+            begin
+                if false then begin
+                    CurrReport.NewPage();
+                    CurrReport.NewPagePerRecord := true;
+                    PageNum := CurrReport.PageNo;
+                    CurrReport.PaperSource(1, 1);
+                    Show := CurrReport.ShowOutput;
+                    Caused := CurrReport.TotalsCausedBy;
+                end;
+            end;
+        }
+    }
+}
+
+/// Exercises ReportInstance methods accessible from external code.
+codeunit 128001 "RIE Source"
+{
+    procedure Execute_NoOp()
+    begin
+        Report.Execute(128000, '');
+    end;
+
+    procedure Print_NoOp()
+    var
+        Rep: Report "RIE Report";
+    begin
+        Rep.UseRequestPage(false);
+        Rep.Print('');
+    end;
+
+    procedure SaveAs_NoOp()
+    var
+        Rep: Report "RIE Report";
+        OutStr: OutStream;
+    begin
+        Rep.UseRequestPage(false);
+        Rep.SaveAs('', ReportFormat::Pdf, OutStr);
+    end;
+
+    procedure NewPagePerRecord_Set()
+    var
+        Rep: Report "RIE Report";
+    begin
+        Rep.UseRequestPage(false);
+        Rep.NewPagePerRecord := true;
+    end;
+
+    procedure ValidateAndPrepareLayout_NoOp()
+    var
+        InStrIn: InStream;
+        InStrOut: InStream;
+    begin
+        Report.ValidateAndPrepareLayout(128000, InStrIn, InStrOut, ReportLayoutType::RDLC);
+    end;
+
+    procedure RunWithCurrReportMethods_NoThrow()
+    var
+        Rep: Report "RIE Report";
+    begin
+        // Runs the report to exercise CurrReport.* methods in the trigger
+        Rep.UseRequestPage(false);
+        Rep.Run();
+    end;
+}

--- a/tests/bucket-1/281-report-instance-ext/test/RieTest.al
+++ b/tests/bucket-1/281-report-instance-ext/test/RieTest.al
@@ -1,0 +1,79 @@
+codeunit 128002 "RIE Test"
+{
+    Subtype = Test;
+    var
+        Assert: Codeunit Assert;
+
+    // ── Static Execute ────────────────────────────────────────────────────────
+
+    [Test]
+    procedure Execute_NoThrow()
+    var
+        Src: Codeunit "RIE Source";
+    begin
+        // Positive: Report.Execute(id, requestPage) must not throw in standalone mode.
+        Src.Execute_NoOp();
+        Assert.IsTrue(true, 'Report.Execute must not throw');
+    end;
+
+    // ── Instance Print ────────────────────────────────────────────────────────
+
+    [Test]
+    procedure Print_NoThrow()
+    var
+        Src: Codeunit "RIE Source";
+    begin
+        // Positive: Rep.Print(requestPage) must not throw in standalone mode.
+        Src.Print_NoOp();
+        Assert.IsTrue(true, 'Rep.Print must not throw');
+    end;
+
+    // ── Instance SaveAs ───────────────────────────────────────────────────────
+
+    [Test]
+    procedure SaveAs_NoThrow()
+    var
+        Src: Codeunit "RIE Source";
+    begin
+        // Positive: Rep.SaveAs(requestPage, format, outStream) must not throw.
+        Src.SaveAs_NoOp();
+        Assert.IsTrue(true, 'Rep.SaveAs must not throw');
+    end;
+
+    // ── NewPagePerRecord (instance property setter) ───────────────────────────
+
+    [Test]
+    procedure NewPagePerRecord_NoThrow()
+    var
+        Src: Codeunit "RIE Source";
+    begin
+        // Positive: Rep.NewPagePerRecord := true must compile and run without error.
+        Src.NewPagePerRecord_Set();
+        Assert.IsTrue(true, 'Rep.NewPagePerRecord setter must not throw');
+    end;
+
+    // ── ValidateAndPrepareLayout (static) ─────────────────────────────────────
+
+    [Test]
+    procedure ValidateAndPrepareLayout_NoThrow()
+    var
+        Src: Codeunit "RIE Source";
+    begin
+        // Positive: Report.ValidateAndPrepareLayout must not throw in standalone mode.
+        Src.ValidateAndPrepareLayout_NoOp();
+        Assert.IsTrue(true, 'Report.ValidateAndPrepareLayout must not throw');
+    end;
+
+    // ── CurrReport.* via report run (NewPage, PageNo, PaperSource, etc.) ──────
+
+    [Test]
+    procedure CurrReportMethods_NoThrow()
+    var
+        Src: Codeunit "RIE Source";
+    begin
+        // Positive: Running a report that uses CurrReport.NewPage/PageNo/PaperSource/
+        // ShowOutput/TotalsCausedBy/NewPagePerRecord inside if-false must not throw.
+        Src.RunWithCurrReportMethods_NoThrow();
+        Assert.IsTrue(true, 'Report with CurrReport.* in if-false block must not throw');
+    end;
+}


### PR DESCRIPTION
Closes #948

## Summary

Implements 10 of the 12 remaining ReportInstance gaps (CreateTotals and Preview remain — CreateTotals requires field-var parameters not testable from external code; Preview is protected/inaccessible from external AL code):

- **MockReportHandle.StaticExecute**: adds `(int, string)` 2-arg overload for `Report.Execute(id, requestPage)`
- **MockReportHandle.Print**: adds instance `Print(string requestPageXml)` — no-op in standalone mode
- **MockReportHandle.StaticValidateAndPrepareLayout**: adds 5-arg overload matching BC emit signature `(DataError, int, MockInStream, ByRef<MockInStream>, object layoutType)`
- **RoslynRewriter**: injects `public int PageNo() => 0` into stripped report classes (BC emits `CurrReport.PageNo()`)
- **NewPage, PaperSource, ShowOutput, TotalsCausedBy, NewPagePerRecord**: verified by `--dump-rewritten` that BC compiler compiles these deprecated methods to blank statements or `default(T)` — no injection needed
- **SaveAs instance**: already existed from #945
- **Test suite 281-report-instance-ext**: 6 tests covering all accessible methods
- **docs/coverage.yaml**: 10 ReportInstance entries updated `gap` → `covered`

## Test plan

- [x] 281-report-instance-ext suite: 6/6 pass
- [x] Full bucket-1 (1475 tests): no regressions (4 pre-existing failures unrelated)