### PR TITLE
feat: Debugger.IsActive/Activate/Deactivate stubs (#958)

### DIFF
--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -66,6 +66,8 @@ public class RoslynRewriter : CSharpSyntaxRewriter
                         // without a UI. Stripping is safe — MockNotification tests that exist don't assert on stored action state.
         "ALAddNavigationAction",  // NavALErrorInfo.ALAddNavigationAction(caption [, description]) —
                         // navigation drill-downs require a UI client to open; no-op in standalone mode.
+        "ALActivate",  // ALDebugger.ALActivate(DataError) — no debugger standalone; no-op
+        "ALDeactivate",  // ALDebugger.ALDeactivate(DataError) — no debugger standalone; no-op
         "ALSendTraceTag",  // ALSession.ALSendTraceTag(session, tag, category, verbosity, msg, classification) — telemetry; no-op standalone
         "ALLogSecurityAudit",  // ALSession.ALLogSecurityAudit(session, desc, result, resultDesc, category, ...) — needs OpenTelemetry DLL; no-op standalone
         "ALEnableVerboseTelemetry",  // ALSession.ALEnableVerboseTelemetry(session, enabled, duration) — telemetry config; no-op standalone
@@ -2580,6 +2582,14 @@ public void ClearApplicationMemberVariables()
                         SyntaxKind.SimpleMemberAccessExpression,
                         SyntaxFactory.IdentifierName("AlScope"),
                         SyntaxFactory.IdentifierName(targetMethod)));
+            }
+
+            // ALDebugger.ALIsActive() -> false
+            // No debugger attached in standalone mode.
+            if (exprText == "ALDebugger" && methodName == "ALIsActive")
+            {
+                return SyntaxFactory.LiteralExpression(SyntaxKind.FalseLiteralExpression)
+                    .WithTriviaFrom(visited);
             }
 
             // ALSessionInformation.GetALCallstack(session) -> ""

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -1873,8 +1873,9 @@ DateTime.ToText:
 Debugger.Activate:
   layer: runtime-api
   category: Debugger
-  status: not-possible
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-2/210-debugger
+  notes: overloads=1. Stripped via StripEntireCallMethods — no debugger infrastructure standalone.
 
 Debugger.Attach:
   layer: runtime-api
@@ -1909,8 +1910,9 @@ Debugger.Continue:
 Debugger.Deactivate:
   layer: runtime-api
   category: Debugger
-  status: not-possible
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-2/210-debugger
+  notes: overloads=1. Stripped via StripEntireCallMethods — no debugger infrastructure standalone.
 
 Debugger.DebuggedSessionID:
   layer: runtime-api
@@ -1939,8 +1941,9 @@ Debugger.GetLastErrorText:
 Debugger.IsActive:
   layer: runtime-api
   category: Debugger
-  status: not-possible
-  notes: overloads=1
+  status: covered
+  tests: tests/bucket-2/210-debugger
+  notes: overloads=1. Rewriter replaces ALDebugger.ALIsActive() with false — no debugger attached standalone.
 
 Debugger.IsAttached:
   layer: runtime-api

--- a/tests/bucket-2/210-debugger/al-runner.json
+++ b/tests/bucket-2/210-debugger/al-runner.json
@@ -1,0 +1,4 @@
+{
+  "sourcePath": "./src",
+  "testPath": "./test"
+}

--- a/tests/bucket-2/210-debugger/src/DebuggerSrc.al
+++ b/tests/bucket-2/210-debugger/src/DebuggerSrc.al
@@ -1,0 +1,21 @@
+/// Exercises Debugger.IsActive and Debugger.DeactivateDebugger — the two
+/// that are most likely to appear in production AL (test helpers).
+codeunit 60370 "DBG Src"
+{
+    procedure IsDebuggerActive(): Boolean
+    begin
+        exit(Debugger.IsActive());
+    end;
+
+    procedure DeactivateDoesNotThrow(): Boolean
+    begin
+        Debugger.Deactivate();
+        exit(true);
+    end;
+
+    procedure ActivateDoesNotThrow(): Boolean
+    begin
+        Debugger.Activate();
+        exit(true);
+    end;
+}

--- a/tests/bucket-2/210-debugger/test/DebuggerTest.al
+++ b/tests/bucket-2/210-debugger/test/DebuggerTest.al
@@ -1,0 +1,29 @@
+codeunit 60371 "DBG Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "DBG Src";
+
+    [Test]
+    procedure IsActive_ReturnsFalse()
+    begin
+        Assert.IsFalse(Src.IsDebuggerActive(),
+            'Debugger.IsActive must return false in standalone mode');
+    end;
+
+    [Test]
+    procedure Deactivate_DoesNotThrow()
+    begin
+        Assert.IsTrue(Src.DeactivateDoesNotThrow(),
+            'Debugger.DeactivateDebugger must not throw');
+    end;
+
+    [Test]
+    procedure Activate_DoesNotThrow()
+    begin
+        Assert.IsTrue(Src.ActivateDoesNotThrow(),
+            'Debugger.Activate must not throw');
+    end;
+}


### PR DESCRIPTION
## Summary
- Closes #958 (partial — 3 of 19 Debugger methods; the rest are rarely used)
- `ALDebugger.ALIsActive()` crashes standalone. Rewriter now replaces it with `false`. `ALActivate`/`ALDeactivate` added to `StripEntireCallMethods` (void no-ops).
- New suite `tests/bucket-2/210-debugger` — 3 tests.

## Test plan
- [x] New suite — 3/3 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)