### PR TITLE
docs: List.Sort() coverage status corrected to not-possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,6 @@ All notable changes to this project are documented here. Format based on
 ## [Unreleased]
 
 ### Added
-- **`List.Sort` coverage status corrected (#959)** — `List.Sort()` (no-argument overload)
-  does not exist in the AL language at any tested BC version (26.0–28.0); calling it produces
-  AL0132 compiler error. Coverage map: `List.Sort` status changed from `gap` to `not-possible`.
-
-
 - **`actionref_declaration` coverage (#388)** — Pages and page extensions containing
   `actionref` sections (promoted-action bindings) now compile and run correctly.
   The existing `RoslynRewriter` already handles the BC-generated C# for actionref

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ All notable changes to this project are documented here. Format based on
 ## [Unreleased]
 
 ### Added
+- **`List.Sort` coverage status corrected (#959)** — `List.Sort()` (no-argument overload)
+  does not exist in the AL language at any tested BC version (26.0–28.0); calling it produces
+  AL0132 compiler error. Coverage map: `List.Sort` status changed from `gap` to `not-possible`.
+
+
 - **`actionref_declaration` coverage (#388)** — Pages and page extensions containing
   `actionref` sections (promoted-action bindings) now compile and run correctly.
   The existing `RoslynRewriter` already handles the BC-generated C# for actionref

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -483,7 +483,7 @@ list_type:
 List.Sort:
   layer: runtime-api
   category: List
-  status: gap
+  status: not-possible
   notes: 'List of [T]' does not have a Sort() method in AL at any tested BC version (26.0–28.0). AL0132 error: 'List of [Integer]' does not contain a definition for 'Sort'. Not a runner gap — this method does not exist in the AL language for this type.
 
 List.Reverse:


### PR DESCRIPTION
Closes #959

`List.Sort()` (no-argument overload) does not exist in the AL language at any tested BC version (26.0–28.0). Calling it produces an AL0132 compiler error: `'List of [Integer]' does not contain a definition for 'Sort'`. This is not a runner gap — the method simply does not exist in the AL type system.

The `docs/coverage.yaml` entry already had accurate notes documenting this fact, but the `status` field was incorrectly set to `gap` instead of `not-possible`. This PR corrects the status field.

No implementation changes are needed; no test suite is added (the method cannot be called from AL code).