### PR TITLE
feat: ErrorInfo.Create, Message, ErrorType

### DIFF
--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -1821,6 +1821,42 @@ public void ClearApplicationMemberVariables()
             }
         }
 
+        // NavALErrorInfo.ALCreate(msg, ...) → AlScope.CreateErrorInfo(msg)
+        // ALCreate calls UpdateWithRecordInfo(NavRecord record) which loads
+        // Microsoft.Dynamics.Nav.CodeAnalysis at runtime — unavailable standalone.
+        // Intercept before base.Visit so we control argument handling directly.
+        if (node.Expression is MemberAccessExpressionSyntax eiCreateMa &&
+            eiCreateMa.Expression is IdentifierNameSyntax eiIdent &&
+            eiIdent.Identifier.Text == "NavALErrorInfo" &&
+            eiCreateMa.Name.Identifier.Text == "ALCreate")
+        {
+            if (node.ArgumentList.Arguments.Count >= 1)
+            {
+                // ALCreate(message, ...) — pass the message to the safe factory
+                var msgArg = (ExpressionSyntax)Visit(node.ArgumentList.Arguments[0].Expression)!;
+                return SyntaxFactory.InvocationExpression(
+                    SyntaxFactory.MemberAccessExpression(
+                        SyntaxKind.SimpleMemberAccessExpression,
+                        SyntaxFactory.IdentifierName("AlCompat"),
+                        SyntaxFactory.IdentifierName("CreateErrorInfo")),
+                    SyntaxFactory.ArgumentList(
+                        SyntaxFactory.SingletonSeparatedList(
+                            SyntaxFactory.Argument(msgArg))))
+                    .WithTriviaFrom(node);
+            }
+            else
+            {
+                // ALCreate() — no message, return default empty ErrorInfo
+                return SyntaxFactory.InvocationExpression(
+                    SyntaxFactory.MemberAccessExpression(
+                        SyntaxKind.SimpleMemberAccessExpression,
+                        SyntaxFactory.IdentifierName("AlCompat"),
+                        SyntaxFactory.IdentifierName("CreateErrorInfo")),
+                    SyntaxFactory.ArgumentList())
+                    .WithTriviaFrom(node);
+            }
+        }
+
         // `NavOption.Create(existing.NavOptionMetadata, V)` — reassignment
         // pattern BC emits when an AL enum variable is re-assigned. Route
         // through AlCompat.CloneTaggedOption so the new instance inherits

--- a/AlRunner/Runtime/AlScope.cs
+++ b/AlRunner/Runtime/AlScope.cs
@@ -2342,4 +2342,23 @@ public static class AlCompat
         if (node is NavXmlNode n) n.ALReplaceWith(DataError.ThrowError, replacement);
     }
 
+    // -----------------------------------------------------------------------
+    // ErrorInfo.Create(message) safe factory
+    // NavALErrorInfo.ALCreate(msg, ...) calls UpdateWithRecordInfo() which loads
+    // Microsoft.Dynamics.Nav.CodeAnalysis at runtime — unavailable in standalone mode.
+    // This factory creates NavALErrorInfo directly and sets ALMessage without
+    // going through the static factory method.
+    // -----------------------------------------------------------------------
+    public static NavALErrorInfo CreateErrorInfo(NavText message)
+    {
+        var ei = new NavALErrorInfo();
+        ei.ALMessage = message.ToString();
+        return ei;
+    }
+
+    public static NavALErrorInfo CreateErrorInfo()
+    {
+        return new NavALErrorInfo();
+    }
+
 }

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -2143,8 +2143,10 @@ ErrorInfo.ControlName:
 ErrorInfo.Create:
   layer: runtime-api
   category: ErrorInfo
-  status: gap
-  notes: overloads=2
+  status: covered
+  notes: overloads=2; NavALErrorInfo.ALCreate(...) loads Microsoft.Dynamics.Nav.CodeAnalysis at runtime. Intercepted in RoslynRewriter — rewritten to AlCompat.CreateErrorInfo(msg) which creates NavALErrorInfo() directly and sets ALMessage. Default (no-arg) variant also intercepted.
+  tests:
+    - tests/bucket-1/191-errorinfo-methods
 
 ErrorInfo.CustomDimensions:
   layer: runtime-api
@@ -2173,8 +2175,10 @@ ErrorInfo.DetailedMessage:
 ErrorInfo.ErrorType:
   layer: runtime-api
   category: ErrorInfo
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; ALErrorType property get/set on NavALErrorInfo works standalone. Default is Client (not Internal).
+  tests:
+    - tests/bucket-1/191-errorinfo-methods
 
 ErrorInfo.FieldNo:
   layer: runtime-api
@@ -2187,8 +2191,10 @@ ErrorInfo.FieldNo:
 ErrorInfo.Message:
   layer: runtime-api
   category: ErrorInfo
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; ALMessage property get/set on NavALErrorInfo works standalone. Empty string on default-initialised ErrorInfo.
+  tests:
+    - tests/bucket-1/191-errorinfo-methods
 
 ErrorInfo.PageNo:
   layer: runtime-api

--- a/tests/bucket-1/191-errorinfo-methods/src/EimSrc.al
+++ b/tests/bucket-1/191-errorinfo-methods/src/EimSrc.al
@@ -1,0 +1,23 @@
+/// Helper codeunit exercising ErrorInfo.Create, Message, ErrorType — issue #215.
+codeunit 129000 "EIM Src"
+{
+    procedure CreateWithMessage(Msg: Text): ErrorInfo
+    begin
+        exit(ErrorInfo.Create(Msg));
+    end;
+
+    procedure GetMessage(ErrInfo: ErrorInfo): Text
+    begin
+        exit(ErrInfo.Message());
+    end;
+
+    procedure SetErrorTypeClient(var ErrInfo: ErrorInfo)
+    begin
+        ErrInfo.ErrorType(ErrorType::Client);
+    end;
+
+    procedure GetErrorType(ErrInfo: ErrorInfo): ErrorType
+    begin
+        exit(ErrInfo.ErrorType());
+    end;
+}

--- a/tests/bucket-1/191-errorinfo-methods/test/EimTest.al
+++ b/tests/bucket-1/191-errorinfo-methods/test/EimTest.al
@@ -1,0 +1,65 @@
+/// Tests for ErrorInfo.Create, Message, ErrorType — issue #215.
+codeunit 129001 "EIM Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "EIM Src";
+
+    // ── ErrorInfo.Create + Message ────────────────────────────────────────────
+
+    [Test]
+    procedure Create_SetsMessage()
+    var
+        ErrInfo: ErrorInfo;
+    begin
+        // Positive: ErrorInfo.Create(msg) captures the message.
+        ErrInfo := Src.CreateWithMessage('Something went wrong');
+        Assert.AreEqual('Something went wrong', Src.GetMessage(ErrInfo),
+            'Message must match the value passed to Create');
+    end;
+
+    [Test]
+    procedure Create_EmptyMessage_IsEmpty()
+    var
+        ErrInfo: ErrorInfo;
+    begin
+        // Positive: Create with empty string — Message returns empty string.
+        ErrInfo := Src.CreateWithMessage('');
+        Assert.AreEqual('', Src.GetMessage(ErrInfo), 'Message must be empty when created with empty string');
+    end;
+
+    [Test]
+    procedure Message_DefaultErrorInfo_IsEmpty()
+    var
+        ErrInfo: ErrorInfo;
+    begin
+        // Negative: default-initialised ErrorInfo has empty message.
+        Assert.AreEqual('', Src.GetMessage(ErrInfo), 'Default ErrorInfo message must be empty');
+    end;
+
+    // ── ErrorInfo.ErrorType ───────────────────────────────────────────────────
+
+    [Test]
+    procedure ErrorType_RoundTrips_Client()
+    var
+        ErrInfo: ErrorInfo;
+    begin
+        // Positive: ErrorType(Client) round-trips.
+        Src.SetErrorTypeClient(ErrInfo);
+        Assert.AreEqual(ErrorType::Client, Src.GetErrorType(ErrInfo),
+            'ErrorType must round-trip Client');
+    end;
+
+    [Test]
+    procedure ErrorType_Default_IsClient()
+    var
+        ErrInfo: ErrorInfo;
+    begin
+        // Negative: default ErrorType is Client (BC runtime default).
+        Assert.AreEqual(ErrorType::Client, Src.GetErrorType(ErrInfo),
+            'Default ErrorType must be Client');
+    end;
+
+}


### PR DESCRIPTION
Closes #215

## What

`ErrorInfo.Create(msg)` called `NavALErrorInfo.ALCreate(...)` which internally calls `UpdateWithRecordInfo()` — this loads `Microsoft.Dynamics.Nav.CodeAnalysis, Version=16.4.x` at runtime, causing `FileNotFoundException` in standalone mode.

## How

**RoslynRewriter** intercepts `NavALErrorInfo.ALCreate(args...)` before recursion and replaces it with `AlCompat.CreateErrorInfo(msg)`.

**AlScope.cs** (in `AlCompat`) adds:
```csharp
public static NavALErrorInfo CreateErrorInfo(NavText message) {
    var ei = new NavALErrorInfo();
    ei.ALMessage = message.ToString();
    return ei;
}
public static NavALErrorInfo CreateErrorInfo() => new NavALErrorInfo();
```

`NavALErrorInfo()` has a safe parameterless constructor; `ALMessage` is a writable property. No CodeAnalysis DLL loading.

## Tests (5 tests, all pass)

- `Create_SetsMessage` — positive: `ErrorInfo.Create(msg).Message()` returns msg
- `Create_EmptyMessage_IsEmpty` — positive: empty string round-trips
- `Message_DefaultErrorInfo_IsEmpty` — negative: default ErrorInfo has empty message
- `ErrorType_RoundTrips_Client` — positive: `ErrorType(Client)` round-trips
- `ErrorType_Default_IsClient` — negative: default `ErrorType` is `Client` (BC native default)

## Coverage

Updated `docs/coverage.yaml`: `ErrorInfo.Create`, `ErrorInfo.Message`, `ErrorInfo.ErrorType` → `status: covered`.