### PR TITLE
feat: MockDialog.Clear() — fix CS1061 for AL Clear(dlg)

### DIFF
--- a/AlRunner/Runtime/AlScope.cs
+++ b/AlRunner/Runtime/AlScope.cs
@@ -402,6 +402,12 @@ public class MockDialog
     public void ALAssign(MockDialog other) { }
 
     /// <summary>
+    /// AL's Clear(dlg) — rewriter emits dlg.Clear(). Resets the dialog to its
+    /// default (unopen) state. No-op standalone: there is no real UI to dismiss.
+    /// </summary>
+    public void Clear() { }
+
+    /// <summary>
     /// AL's Dialog.HideSubsequentDialogs — emitted as a property setter by the
     /// BC compiler (`dlg.ALHideSubsequentDialogs = true`). No UI standalone;
     /// the set is a no-op.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,6 @@ All notable changes to this project are documented here. Format based on
 ## [Unreleased]
 
 ### Added
-- **`Dialog.Clear` (#964)** — `Clear(dlg)` on a `Dialog` variable now compiles and
-  runs. The BC compiler lowers AL `Clear(T)` to `T.Clear()` on the mock type;
-  `MockDialog` was missing this method, causing a Roslyn CS1061 error. Added a no-op
-  `Clear()` to `MockDialog` in `AlScope.cs`. New suite `tests/bucket-1/192-dialog-clear`
-  proves the fix with 4 tests (open-close-clear, clear without open, clear twice, inline).
-  Coverage map: `Dialog.Clear` added as `covered`.
 - **`actionref_declaration` coverage (#388)** — Pages and page extensions containing
   `actionref` sections (promoted-action bindings) now compile and run correctly.
   The existing `RoslynRewriter` already handles the BC-generated C# for actionref

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to this project are documented here. Format based on
 ## [Unreleased]
 
 ### Added
+- **`Dialog.Clear` (#964)** — `Clear(dlg)` on a `Dialog` variable now compiles and
+  runs. The BC compiler lowers AL `Clear(T)` to `T.Clear()` on the mock type;
+  `MockDialog` was missing this method, causing a Roslyn CS1061 error. Added a no-op
+  `Clear()` to `MockDialog` in `AlScope.cs`. New suite `tests/bucket-1/192-dialog-clear`
+  proves the fix with 4 tests (open-close-clear, clear without open, clear twice, inline).
+  Coverage map: `Dialog.Clear` added as `covered`.
 - **`actionref_declaration` coverage (#388)** — Pages and page extensions containing
   `actionref` sections (promoted-action bindings) now compile and run correctly.
   The existing `RoslynRewriter` already handles the BC-generated C# for actionref

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -1996,6 +1996,13 @@ Decimal.ToText:
 
 # ── Dialog ──────────────────────────────────────────────────────
 
+Dialog.Clear:
+  layer: runtime-api
+  category: Dialog
+  status: covered
+  tests: tests/bucket-1/192-dialog-clear
+  notes: overloads=1; AL Clear(dlg) rewriter emits dlg.Clear() — no-op stub added to MockDialog.
+
 Dialog.Close:
   layer: runtime-api
   category: Dialog

--- a/tests/bucket-1/192-dialog-clear/src/DialogClearSrc.al
+++ b/tests/bucket-1/192-dialog-clear/src/DialogClearSrc.al
@@ -1,0 +1,32 @@
+/// Source helpers for Dialog Clear() coverage (issue #964).
+/// Exercises Clear(dlg) — which the BC compiler lowers to MockDialog.Clear().
+codeunit 97706 "Dialog Clear Src"
+{
+    procedure OpenAndClear()
+    var
+        dlg: Dialog;
+    begin
+        dlg.Open('Processing...');
+        dlg.Close();
+        Clear(dlg);
+    end;
+
+    procedure ClearWithoutOpen()
+    var
+        dlg: Dialog;
+    begin
+        Clear(dlg);
+    end;
+
+    procedure ClearTwice()
+    var
+        dlg: Dialog;
+    begin
+        dlg.Open('Step 1');
+        dlg.Close();
+        Clear(dlg);
+        dlg.Open('Step 2');
+        dlg.Close();
+        Clear(dlg);
+    end;
+}

--- a/tests/bucket-1/192-dialog-clear/test/DialogClearTest.al
+++ b/tests/bucket-1/192-dialog-clear/test/DialogClearTest.al
@@ -1,0 +1,56 @@
+/// Tests proving that Clear(dlg) on a Dialog variable compiles and runs without error.
+/// Covers issue #964: MockDialog was missing Clear(), causing CS1061 at Roslyn compile time.
+codeunit 97707 "Dialog Clear Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "Dialog Clear Src";
+
+    [Test]
+    procedure ClearAfterOpenClose_DoesNotThrow()
+    begin
+        // [GIVEN] A dialog that has been opened and closed
+        // [WHEN]  Clear(dlg) is called
+        // [THEN]  No error is raised
+        Src.OpenAndClear();
+        Assert.IsTrue(true, 'Clear(dlg) after Open/Close must not throw');
+    end;
+
+    [Test]
+    procedure ClearWithoutOpen_DoesNotThrow()
+    begin
+        // [GIVEN] A fresh dialog variable that was never opened
+        // [WHEN]  Clear(dlg) is called
+        // [THEN]  No error is raised
+        Src.ClearWithoutOpen();
+        Assert.IsTrue(true, 'Clear(dlg) on an unopened Dialog must not throw');
+    end;
+
+    [Test]
+    procedure ClearTwice_DoesNotThrow()
+    begin
+        // [GIVEN] A dialog that is opened, closed, cleared, opened again, closed and cleared
+        // [WHEN]  Both Clear() calls complete
+        // [THEN]  No error is raised
+        Src.ClearTwice();
+        Assert.IsTrue(true, 'Calling Clear(dlg) twice must not throw');
+    end;
+
+    [Test]
+    procedure ClearInline_DoesNotThrow()
+    var
+        dlg: Dialog;
+    begin
+        // [GIVEN] A dialog opened and closed inline
+        dlg.Open('Hello');
+        dlg.Close();
+
+        // [WHEN]  Clear called directly in the test body
+        Clear(dlg);
+
+        // [THEN]  No error
+        Assert.IsTrue(true, 'Inline Clear(dlg) must not throw');
+    end;
+}


### PR DESCRIPTION
Closes #964

## Summary

`Clear(dlg)` on a `Dialog` variable compiled and ran in AL but caused a Roslyn `CS1061` error at runner compile time: `'MockDialog' does not contain a definition for 'Clear'`.

**Root cause:** The BC compiler lowers AL `Clear(T)` to an instance `T.Clear()` call on the mock type. `MockDialog` was missing this method.

**Fix:** Added a no-op `public void Clear() { }` to `MockDialog` in `AlScope.cs`. This matches the pattern used by all other `Close()`-style lifecycle methods — no real UI state to reset standalone.

**Tests:** New suite `tests/bucket-1/192-dialog-clear` (codeunits 97706–97707) with 4 proving tests:
- Clear after Open/Close
- Clear without prior Open
- Clear twice (open-close-clear twice)
- Inline Clear in test body

**Coverage:** `Dialog.Clear` added to `docs/coverage.yaml` as `covered`.