### PR TITLE
feat: TextBuilder.Length setter — truncate via assignment (#975)

### DIFF
--- a/AlRunner/Runtime/MockTextBuilder.cs
+++ b/AlRunner/Runtime/MockTextBuilder.cs
@@ -49,10 +49,17 @@ public class MockTextBuilder
     // ── New methods (#725) ──────────────────────────────────────────────────────
 
     /// <summary>
-    /// Returns the number of characters in the builder.
-    /// BC emits <c>tb.ALLength</c> for <c>TextBuilder.Length</c>.
+    /// Returns / sets the number of characters in the builder.
+    /// BC emits <c>tb.ALLength</c> for both <c>TextBuilder.Length</c> reads and
+    /// <c>TextBuilder.Length := N</c> assignments. Setting a smaller value truncates
+    /// the buffer; StringBuilder.Length already throws ArgumentOutOfRangeException
+    /// for negative or over-capacity values, matching BC's error behaviour.
     /// </summary>
-    public int ALLength => _sb.Length;
+    public int ALLength
+    {
+        get => _sb.Length;
+        set => _sb.Length = value;
+    }
 
     /// <summary>
     /// Returns the current capacity of the underlying StringBuilder.

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -8162,8 +8162,10 @@ TextBuilder.Length:
   layer: runtime-api
   category: TextBuilder
   status: covered
-  notes: overloads=1; MockTextBuilder.ALLength => _sb.Length
-  tests: tests/bucket-1/271-textbuilder-methods
+  notes: overloads=1; MockTextBuilder.ALLength is both getter and setter — assigning a smaller value truncates the buffer (BC semantics).
+  tests:
+    - tests/bucket-1/271-textbuilder-methods
+    - tests/bucket-2/211-textbuilder-length-setter
 
 TextBuilder.MaxCapacity:
   layer: runtime-api

--- a/tests/bucket-2/211-textbuilder-length-setter/al-runner.json
+++ b/tests/bucket-2/211-textbuilder-length-setter/al-runner.json
@@ -1,0 +1,4 @@
+{
+  "sourcePath": "./src",
+  "testPath": "./test"
+}

--- a/tests/bucket-2/211-textbuilder-length-setter/src/TextBuilderLengthSrc.al
+++ b/tests/bucket-2/211-textbuilder-length-setter/src/TextBuilderLengthSrc.al
@@ -1,0 +1,30 @@
+/// Exercises TextBuilder.Length setter (truncates the buffer).
+codeunit 60380 "TBL Src"
+{
+    procedure Truncate(v: Text; newLength: Integer): Text
+    var
+        tb: TextBuilder;
+    begin
+        tb.Append(v);
+        tb.Length := newLength;
+        exit(tb.ToText());
+    end;
+
+    procedure TruncateToZero(v: Text): Text
+    var
+        tb: TextBuilder;
+    begin
+        tb.Append(v);
+        tb.Length := 0;
+        exit(tb.ToText());
+    end;
+
+    procedure LengthAfterSet(v: Text; newLength: Integer): Integer
+    var
+        tb: TextBuilder;
+    begin
+        tb.Append(v);
+        tb.Length := newLength;
+        exit(tb.Length);
+    end;
+}

--- a/tests/bucket-2/211-textbuilder-length-setter/test/TextBuilderLengthTest.al
+++ b/tests/bucket-2/211-textbuilder-length-setter/test/TextBuilderLengthTest.al
@@ -1,0 +1,38 @@
+codeunit 60381 "TBL Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "TBL Src";
+
+    [Test]
+    procedure Truncate_KeepsPrefix()
+    begin
+        Assert.AreEqual('Hello', Src.Truncate('Hello World Extra', 5),
+            'Length := 5 must truncate to "Hello"');
+    end;
+
+    [Test]
+    procedure TruncateToZero_ReturnsEmpty()
+    begin
+        Assert.AreEqual('', Src.TruncateToZero('Hello'),
+            'Length := 0 must clear the buffer');
+    end;
+
+    [Test]
+    procedure LengthAfterSet_IsNewLength()
+    begin
+        Assert.AreEqual(3, Src.LengthAfterSet('Hello', 3),
+            'Length after Length := 3 must be 3');
+    end;
+
+    [Test]
+    procedure Truncate_DoesNotKeepFullLength_NegativeTrap()
+    begin
+        // Negative trap: if the setter is a no-op, the returned text
+        // would still be the full input.
+        Assert.AreNotEqual('Hello World Extra', Src.Truncate('Hello World Extra', 5),
+            'Length setter must not be a no-op — full input must not be returned');
+    end;
+}


### PR DESCRIPTION
## Summary
- Closes #975
- `MockTextBuilder.ALLength` was read-only. `tb.Length := 5` failed with CS0200.
- Changed ALLength to get/set — setter delegates to `StringBuilder.Length` (truncates when smaller, throws on invalid).
- New suite `tests/bucket-2/211-textbuilder-length-setter` — 4 tests.

## Test plan
- [x] New suite — 4/4 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)