### PR TITLE
feat: ALFindSet/ALInsert 3-arg overloads (#979)

### DIFF
--- a/AlRunner/Runtime/MockRecordHandle.cs
+++ b/AlRunner/Runtime/MockRecordHandle.cs
@@ -342,6 +342,10 @@ public class MockRecordHandle
 
     public bool ALInsert(DataError errorLevel) => ALInsert(errorLevel, false);
 
+    /// <summary>BC emits ALInsert(DataError, RunTrigger, CheckMandatoryFields) for <c>Insert(RunTrigger, CheckMandatoryFields)</c>.
+    /// CheckMandatoryFields is not enforced in standalone mode — behaves identically to the 2-arg overload.</summary>
+    public bool ALInsert(DataError errorLevel, bool runTrigger, bool checkMandatoryFields) => ALInsert(errorLevel, runTrigger);
+
     public bool ALInsert(DataError errorLevel, bool runTrigger)
     {
         var table = GetRows();
@@ -646,6 +650,11 @@ public class MockRecordHandle
     {
         return ALFind(errorLevel, "-");
     }
+
+    /// <summary>BC 26+ emits ALFindSet(DataError, ForUpdate, ForceNewQuery) for <c>FindSet(ForUpdate, ForceNewQuery)</c>.
+    /// ForceNewQuery is a hint to the BC runtime; in standalone mode both bool args are ignored.</summary>
+    public bool ALFindSet(DataError errorLevel, bool forUpdate, bool forceNewQuery)
+        => ALFindSet(errorLevel, forUpdate);
 
     public bool ALFindFirst(DataError errorLevel = DataError.ThrowError)
     {

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -6613,7 +6613,8 @@ Table.FindSet:
   status: covered
   tests:
     - tests/bucket-1/53-findset
-  notes: overloads=2; SetCurrentKey sort order respected via GetFilteredRecords PK-fallback fix
+    - tests/bucket-1/283-overload-gaps
+  notes: overloads=3; 0-arg, 1-arg (ForUpdate), 2-arg (ForUpdate, ForceNewQuery); BC 26+ emits 3-arg C# form; ForUpdate/ForceNewQuery ignored in standalone mode
 
 Table.Get:
   layer: runtime-api
@@ -6714,10 +6715,11 @@ Table.Insert:
   layer: runtime-api
   category: Table
   status: covered
-  notes: overloads=2; ALInsert(DataError) and ALInsert(DataError, bool runTrigger) add record to in-memory store; triggers OnInsert when runTrigger=true.
+  notes: overloads=3; ALInsert(DataError), ALInsert(DataError, runTrigger), ALInsert(DataError, runTrigger, checkMandatoryFields); CheckMandatoryFields not enforced in standalone mode.
   tests:
     - tests/bucket-1/188-table-crud
     - tests/bucket-1/02-record-operations
+    - tests/bucket-1/283-overload-gaps
 
 Table.IsEmpty:
   layer: runtime-api

--- a/tests/bucket-1/283-overload-gaps/src/OverloadGapSrc.al
+++ b/tests/bucket-1/283-overload-gaps/src/OverloadGapSrc.al
@@ -1,0 +1,46 @@
+/// Source codeunit exercising missing method overloads — issue #979.
+table 131000 "OGap Table"
+{
+    fields
+    {
+        field(1; "No."; Code[20]) { }
+        field(2; Name; Text[50]) { }
+        field(3; Amount; Decimal) { }
+    }
+    keys { key(PK; "No.") { Clustered = true; } }
+}
+
+codeunit 131001 "OGap Source"
+{
+    // ── FindSet 2-arg (ForUpdate, ForceNewQuery) ─────────────────────────────
+    // BC 26+ emits ALFindSet(DataError, bool, bool) for FindSet(ForUpdate, ForceNewQuery).
+    // AL deprecation warning for the ForUpdate param is expected.
+
+    procedure FindSet_TwoArg(var Rec: Record "OGap Table"): Boolean
+    begin
+        exit(Rec.FindSet(true, false));
+    end;
+
+    // ── Insert 2-arg (RunTrigger, CheckMandatoryFields) ──────────────────────
+    // BC emits ALInsert(DataError, bool, bool) for Insert(RunTrigger, CheckMandatoryFields).
+
+    procedure Insert_TwoArg(var Rec: Record "OGap Table")
+    begin
+        Rec.Insert(true, true);
+    end;
+
+    // ── SecretText.Unwrap via parameter passing ───────────────────────────────
+    // AL allows passing Text literals to SecretText parameters (implicit conversion).
+    // BC emits NavSecretText; the runner needs NavSecretText.ALUnwrap() to work.
+
+    procedure SecretText_Unwrap(S: SecretText): Text
+    begin
+        exit(S.Unwrap());
+    end;
+
+    procedure SecretText_GetFromParam(S: SecretText): Text
+    begin
+        // Mirror the unwrap result through the function
+        exit(S.Unwrap());
+    end;
+}

--- a/tests/bucket-1/283-overload-gaps/test/OverloadGapTest.al
+++ b/tests/bucket-1/283-overload-gaps/test/OverloadGapTest.al
@@ -1,0 +1,75 @@
+codeunit 131002 "OGap Test"
+{
+    Subtype = Test;
+    var
+        Assert: Codeunit Assert;
+
+    // ── FindSet(ForUpdate, ForceNewQuery) ────────────────────────────────────
+
+    [Test]
+    procedure FindSet_TwoArg_ReturnsTrueWhenRecordExists()
+    var
+        Src: Codeunit "OGap Source";
+        Rec: Record "OGap Table";
+    begin
+        // [GIVEN] One record in the table
+        Rec.Init();
+        Rec."No." := 'F1';
+        Rec.Insert();
+
+        // [WHEN] FindSet(true, false) — ForUpdate=true, ForceNewQuery=false
+        // [THEN] Returns true (record found)
+        Assert.IsTrue(Src.FindSet_TwoArg(Rec), 'FindSet(true,false) must return true when records exist');
+    end;
+
+    [Test]
+    procedure FindSet_TwoArg_ReturnsFalseWhenEmpty()
+    var
+        Src: Codeunit "OGap Source";
+        Rec: Record "OGap Table";
+    begin
+        // [GIVEN] No records matching the filter
+        Rec.SetFilter("No.", 'NEVEREXISTS');
+
+        // [WHEN/THEN] FindSet(true, false) returns false on empty set
+        Assert.IsFalse(Src.FindSet_TwoArg(Rec), 'FindSet(true,false) must return false when no records match');
+    end;
+
+    // ── Insert(RunTrigger, CheckMandatoryFields) ─────────────────────────────
+
+    [Test]
+    procedure Insert_TwoArg_InsertsRecord()
+    var
+        Src: Codeunit "OGap Source";
+        Rec: Record "OGap Table";
+    begin
+        // [GIVEN] A new record
+        Rec.Init();
+        Rec."No." := 'I1';
+
+        // [WHEN] Insert(true, true)
+        Src.Insert_TwoArg(Rec);
+
+        // [THEN] Record exists in table
+        Rec.Reset();
+        Rec.SetFilter("No.", 'I1');
+        Assert.IsTrue(Rec.FindFirst(), 'Insert(true,true) must persist the record');
+    end;
+
+    [Test]
+    procedure Insert_TwoArg_DuplicateErrors()
+    var
+        Src: Codeunit "OGap Source";
+        Rec: Record "OGap Table";
+    begin
+        // [GIVEN] A record already inserted
+        Rec.Init();
+        Rec."No." := 'DUP';
+        Rec.Insert();
+
+        // [WHEN] Insert the same key again with Insert(true, true)
+        // [THEN] Error — duplicate primary key
+        asserterror Src.Insert_TwoArg(Rec);
+        Assert.ExpectedError('already exists');
+    end;
+}


### PR DESCRIPTION
Closes #979

## Summary

BC 26+ emits 3-argument C# calls for two common AL record operations, causing CS1501 compilation errors:

| AL call | BC emits (C#) | Was missing |
|---|---|---|
| `rec.FindSet(ForUpdate, ForceNewQuery)` | `ALFindSet(DataError, bool, bool)` | 3rd arg `forceNewQuery` |
| `rec.Insert(RunTrigger, CheckMandatoryFields)` | `ALInsert(DataError, bool, bool)` | 3rd arg `checkMandatoryFields` |

Both new overloads delegate to the existing 2-arg versions. The extra arguments (`ForceNewQuery`, `CheckMandatoryFields`) are BC-runtime hints with no standalone equivalent.

## Changes

- **`MockRecordHandle.cs`**: Added `ALFindSet(DataError, bool, bool)` and `ALInsert(DataError, bool, bool)`
- **`tests/bucket-1/283-overload-gaps/`**: 4 tests (FindSet returns true/false, Insert inserts/errors on duplicate)
- **`docs/coverage.yaml`**: Updated `Table.FindSet` and `Table.Insert` overload counts and notes

## Note on other gaps in issue #979

The issue also mentions `ALTestFieldSafe` 4-arg, `Codeunit.Run` on concrete types, and `NavSecretText` conversions. Investigation found:
- `ALTestFieldSafe` already has 2-, 3-, and DataError-prefixed overloads covering all known BC emission patterns
- `SecretText.Unwrap()` is already covered (existing rewriter intercept + `AlCompat.Unwrap`)
- `NavSecretText → string/MockInStream` requires a real-world reproduction case; not reproducible with current AL compiler — filed as a separate observation

The two confirmed CS1501 errors (FindSet and Insert) are fixed in this PR.