### PR TITLE
docs: mark System.CanLoadType and System.GetDotNetType as not-possible (#992)

### DIFF
--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -5951,8 +5951,8 @@ System.CalcDate:
 System.CanLoadType:
   layer: runtime-api
   category: System
-  status: gap
-  notes: overloads=1; requires DotNet type variable — not testable without DotNet package references; stub not implemented (DotNet type resolution unavailable in standalone mode)
+  status: not-possible
+  notes: requires DotNet type parameter — unavailable in standalone mode; no DotNet type resolution without BC service tier
 
 System.CaptionClassTranslate:
   layer: runtime-api
@@ -6186,8 +6186,8 @@ System.GetDocumentUrl:
 System.GetDotNetType:
   layer: runtime-api
   category: System
-  status: gap
-  notes: overloads=1; requires DotNet variable — not testable without DotNet package references; stub not implemented
+  status: not-possible
+  notes: requires DotNet type parameter — unavailable in standalone mode; no DotNet type resolution without BC service tier
 
 System.GetLastErrorCallStack:
   layer: runtime-api


### PR DESCRIPTION
Closes #992

Both `System.CanLoadType` and `System.GetDotNetType` require a `DotNet` type parameter that is unavailable in standalone mode (no BC service tier = no DotNet type resolution). Issue #956 determined this, but no PR was ever opened to update the coverage map.

Changes: `docs/coverage.yaml` — changed `status: gap` → `status: not-possible` and updated notes for both entries. No test needed (documentation correction only).