### PR TITLE
feat: Add Clear() to MockReportHandle and MockXmlPortHandle

### DIFF
--- a/AlRunner/Runtime/MockReportHandle.cs
+++ b/AlRunner/Runtime/MockReportHandle.cs
@@ -298,6 +298,12 @@ public class MockReportHandle
         handle.RunModal();
     }
 
+    /// <summary>
+    /// AL's <c>Clear(rep)</c> — the rewriter emits <c>rep.Clear()</c>. Resets the
+    /// report handle to its default (un-run) state. No-op in standalone mode.
+    /// </summary>
+    public void Clear() { }
+
     // ── Instance Print method ────────────────────────────────────────────────
     // BC emits rep.Print(requestPageXml) for Report.Print() on an instance variable.
     /// <summary>Instance <c>Rep.Print(requestPageXml)</c> — no-op in standalone mode.</summary>

--- a/AlRunner/Runtime/MockXmlPortHandle.cs
+++ b/AlRunner/Runtime/MockXmlPortHandle.cs
@@ -60,6 +60,12 @@ public class MockXmlPortHandle
     // Control-flow methods (called from XmlPort triggers in real BC)
     // ------------------------------------------------------------------
 
+    /// <summary>
+    /// AL's <c>Clear(xp)</c> — the rewriter emits <c>xp.Clear()</c>. Resets the
+    /// xmlport handle to its default state. No-op in standalone mode.
+    /// </summary>
+    public void Clear() { }
+
     public void Break() { }
     public void BreakUnbound() { }
     public void Quit() { }

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -5221,6 +5221,13 @@ RecordRef.WritePermission:
 
 # ── Report ──────────────────────────────────────────────────────
 
+Report.Clear:
+  layer: runtime-api
+  category: Report
+  status: covered
+  tests: tests/bucket-1/193-report-xmlport-clear
+  notes: overloads=1; AL Clear(rep) rewriter emits rep.Clear() — no-op stub added to MockReportHandle.
+
 Report.DefaultLayout:
   layer: runtime-api
   category: Report
@@ -10406,6 +10413,13 @@ XmlWriteOptions.PreserveWhitespace:
   notes: overloads=1
 
 # ── Xmlport ─────────────────────────────────────────────────────
+
+Xmlport.Clear:
+  layer: runtime-api
+  category: Xmlport
+  status: covered
+  tests: tests/bucket-1/193-report-xmlport-clear
+  notes: overloads=1; AL Clear(xp) rewriter emits xp.Clear() — no-op stub added to MockXmlPortHandle.
 
 Xmlport.Export:
   layer: runtime-api

--- a/tests/bucket-1/193-report-xmlport-clear/src/ReportXmlPortClearSrc.al
+++ b/tests/bucket-1/193-report-xmlport-clear/src/ReportXmlPortClearSrc.al
@@ -1,0 +1,49 @@
+/// Minimal report stub for Clear() coverage.
+report 97708 "RXC Report"
+{
+    dataset { }
+}
+
+/// Minimal xmlport stub for Clear() coverage.
+xmlport 97709 "RXC XmlPort"
+{
+    Direction = Both;
+    Format = Xml;
+    schema { }
+}
+
+/// Source helpers for Report/XmlPort Clear() coverage (issue #967).
+/// Exercises Clear(rep) and Clear(xp) — which the BC compiler lowers to
+/// rep.Clear() / xp.Clear() on the mock handle types.
+codeunit 97710 "RXC Src"
+{
+    procedure ClearReport()
+    var
+        rep: Report "RXC Report";
+    begin
+        Clear(rep);
+    end;
+
+    procedure ClearXmlPort()
+    var
+        xp: XmlPort "RXC XmlPort";
+    begin
+        Clear(xp);
+    end;
+
+    procedure ClearReportTwice()
+    var
+        rep: Report "RXC Report";
+    begin
+        Clear(rep);
+        Clear(rep);
+    end;
+
+    procedure ClearXmlPortTwice()
+    var
+        xp: XmlPort "RXC XmlPort";
+    begin
+        Clear(xp);
+        Clear(xp);
+    end;
+}

--- a/tests/bucket-1/193-report-xmlport-clear/test/ReportXmlPortClearTest.al
+++ b/tests/bucket-1/193-report-xmlport-clear/test/ReportXmlPortClearTest.al
@@ -1,0 +1,75 @@
+/// Tests proving that Clear(rep) and Clear(xp) compile and run without error.
+/// Covers issue #967: MockReportHandle and MockXmlPortHandle were missing Clear(),
+/// causing CS1061 at Roslyn compile time.
+codeunit 97711 "RXC Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "RXC Src";
+
+    [Test]
+    procedure ClearReport_DoesNotThrow()
+    begin
+        // [GIVEN] A fresh report variable
+        // [WHEN]  Clear(rep) is called
+        // [THEN]  No error is raised
+        Src.ClearReport();
+        Assert.IsTrue(true, 'Clear(rep) must not throw');
+    end;
+
+    [Test]
+    procedure ClearXmlPort_DoesNotThrow()
+    begin
+        // [GIVEN] A fresh xmlport variable
+        // [WHEN]  Clear(xp) is called
+        // [THEN]  No error is raised
+        Src.ClearXmlPort();
+        Assert.IsTrue(true, 'Clear(xp) must not throw');
+    end;
+
+    [Test]
+    procedure ClearReportTwice_DoesNotThrow()
+    begin
+        // [GIVEN] A report variable that is cleared twice
+        // [WHEN]  Both Clear() calls complete
+        // [THEN]  No error is raised
+        Src.ClearReportTwice();
+        Assert.IsTrue(true, 'Calling Clear(rep) twice must not throw');
+    end;
+
+    [Test]
+    procedure ClearXmlPortTwice_DoesNotThrow()
+    begin
+        // [GIVEN] An xmlport variable that is cleared twice
+        // [WHEN]  Both Clear() calls complete
+        // [THEN]  No error is raised
+        Src.ClearXmlPortTwice();
+        Assert.IsTrue(true, 'Calling Clear(xp) twice must not throw');
+    end;
+
+    [Test]
+    procedure ClearReportInline_DoesNotThrow()
+    var
+        rep: Report "RXC Report";
+    begin
+        // [GIVEN] A report variable declared inline
+        // [WHEN]  Clear called directly in the test body
+        Clear(rep);
+        // [THEN]  No error
+        Assert.IsTrue(true, 'Inline Clear(rep) must not throw');
+    end;
+
+    [Test]
+    procedure ClearXmlPortInline_DoesNotThrow()
+    var
+        xp: XmlPort "RXC XmlPort";
+    begin
+        // [GIVEN] An xmlport variable declared inline
+        // [WHEN]  Clear called directly in the test body
+        Clear(xp);
+        // [THEN]  No error
+        Assert.IsTrue(true, 'Inline Clear(xp) must not throw');
+    end;
+}


### PR DESCRIPTION
Closes #967

## Summary

- Added `public void Clear() { }` to `MockReportHandle` — AL `Clear(rep)` is lowered by the BC compiler to `rep.Clear()`, which was causing CS1061 at Roslyn compile time.
- Added `public void Clear() { }` to `MockXmlPortHandle` — same pattern for `Clear(xp)`.
- New test suite `tests/bucket-1/193-report-xmlport-clear/` with 6 tests covering both types via inline and indirect call patterns.
- Updated `docs/coverage.yaml` with `Report.Clear` and `Xmlport.Clear` entries (status: covered).

## Pattern

Same fix as #964 (MockDialog.Clear). The rewriter in `RoslynRewriter.cs` emits `x.Clear()` for every `ALSystemVariable.Clear(x)` call. Any mock type used as a variable target must expose `Clear()`.

## Test plan

- [ ] CI passes for bucket-1 (confirms CS1061 is gone and tests run green)
- [ ] No CHANGELOG.md edits (auto-generated post-merge)