### PR TITLE
test: CaptionClassTranslate proof tests (#980)

### DIFF
--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -5966,7 +5966,9 @@ System.CaptionClassTranslate:
   layer: runtime-api
   category: System
   status: covered
-  tests: tests/bucket-1/196-system-misc-stubs
+  tests:
+    - tests/bucket-1/196-system-misc-stubs
+    - tests/bucket-2/214-captionclass
   notes: overloads=1; ALSystemObject.ALCaptionClassTranslate → AlCompat.CaptionClassTranslate; returns input expression unchanged in standalone mode
   notes: overloads=1
 

--- a/tests/bucket-2/214-captionclass/al-runner.json
+++ b/tests/bucket-2/214-captionclass/al-runner.json
@@ -1,0 +1,4 @@
+{
+  "sourcePath": "./src",
+  "testPath": "./test"
+}

--- a/tests/bucket-2/214-captionclass/src/CaptionClassSrc.al
+++ b/tests/bucket-2/214-captionclass/src/CaptionClassSrc.al
@@ -1,0 +1,8 @@
+/// Exercises CaptionClassTranslate — BC's resource translation system.
+codeunit 60420 "CCT Src"
+{
+    procedure TranslateCaption(expr: Text): Text
+    begin
+        exit(CaptionClassTranslate(expr));
+    end;
+}

--- a/tests/bucket-2/214-captionclass/test/CaptionClassTest.al
+++ b/tests/bucket-2/214-captionclass/test/CaptionClassTest.al
@@ -1,0 +1,30 @@
+codeunit 60421 "CCT Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "CCT Src";
+
+    [Test]
+    procedure CaptionClassTranslate_ReturnsInput()
+    begin
+        // Standalone contract: no caption-class resolver available; return input unchanged.
+        Assert.AreEqual('1,1,Sales', Src.TranslateCaption('1,1,Sales'),
+            'CaptionClassTranslate must return the input unchanged in standalone mode');
+    end;
+
+    [Test]
+    procedure CaptionClassTranslate_Empty_ReturnsEmpty()
+    begin
+        Assert.AreEqual('', Src.TranslateCaption(''),
+            'CaptionClassTranslate on empty input must return empty');
+    end;
+
+    [Test]
+    procedure CaptionClassTranslate_DoesNotThrow()
+    begin
+        Src.TranslateCaption('anything');
+        Assert.IsTrue(true, 'CaptionClassTranslate must not throw');
+    end;
+}


### PR DESCRIPTION
## Summary
- Closes #980
- `CaptionClassTranslate` already works via AlCompat; this PR adds a second proving-test site.
- New suite `tests/bucket-2/214-captionclass` — 3 tests.

## Test plan
- [x] New suite — 3/3 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)