### PR TITLE
feat: MockVersion equality + comparison operators (#976)

### DIFF
--- a/AlRunner/Runtime/MockVersion.cs
+++ b/AlRunner/Runtime/MockVersion.cs
@@ -84,4 +84,25 @@ public struct MockVersion
     /// </summary>
     public NavText ALToText(object? session = null)
         => new NavText($"{_major}.{_minor}.{_build}.{_revision}");
+
+    // ── Comparison / equality operators ───────────────────────────────────────
+    // BC lowers AL's v1 = v2, v1 > v2 etc. to C# operator expressions on the
+    // emitted type. Provide MockVersion vs MockVersion overloads that compare
+    // lexicographically on (major, minor, build, revision).
+
+    private long ToSortKey()
+        => ((long)_major << 48) | ((long)(_minor & 0xFFFF) << 32) | ((long)(_build & 0xFFFF) << 16) | (long)(_revision & 0xFFFF);
+
+    public static bool operator ==(MockVersion a, MockVersion b)
+        => a._major == b._major && a._minor == b._minor && a._build == b._build && a._revision == b._revision;
+
+    public static bool operator !=(MockVersion a, MockVersion b) => !(a == b);
+
+    public static bool operator <(MockVersion a, MockVersion b) => a.ToSortKey() < b.ToSortKey();
+    public static bool operator >(MockVersion a, MockVersion b) => a.ToSortKey() > b.ToSortKey();
+    public static bool operator <=(MockVersion a, MockVersion b) => a.ToSortKey() <= b.ToSortKey();
+    public static bool operator >=(MockVersion a, MockVersion b) => a.ToSortKey() >= b.ToSortKey();
+
+    public override bool Equals(object? obj) => obj is MockVersion other && this == other;
+    public override int GetHashCode() => ToSortKey().GetHashCode();
 }

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -8838,6 +8838,13 @@ Version.Build:
   tests: tests/bucket-1/96-version
   notes: overloads=1
 
+Version.Compare:
+  layer: runtime-api
+  category: Version
+  status: covered
+  tests: tests/bucket-2/215-version-compare
+  notes: MockVersion overloads == / != / < / > / <= / >= operators; comparison is lexicographic on (major, minor, build, revision).
+
 Version.Create:
   layer: runtime-api
   category: Version

--- a/tests/bucket-2/215-version-compare/al-runner.json
+++ b/tests/bucket-2/215-version-compare/al-runner.json
@@ -1,0 +1,4 @@
+{
+  "sourcePath": "./src",
+  "testPath": "./test"
+}

--- a/tests/bucket-2/215-version-compare/src/VersionCompareSrc.al
+++ b/tests/bucket-2/215-version-compare/src/VersionCompareSrc.al
@@ -1,0 +1,33 @@
+/// Exercises Version comparison operators (==, <, >, <=, >=).
+codeunit 60430 "VC Src"
+{
+    procedure IsGreater(v1: Version; v2: Version): Boolean
+    begin
+        exit(v1 > v2);
+    end;
+
+    procedure IsLess(v1: Version; v2: Version): Boolean
+    begin
+        exit(v1 < v2);
+    end;
+
+    procedure IsEqual(v1: Version; v2: Version): Boolean
+    begin
+        exit(v1 = v2);
+    end;
+
+    procedure IsGreaterOrEqual(v1: Version; v2: Version): Boolean
+    begin
+        exit(v1 >= v2);
+    end;
+
+    procedure IsLessOrEqual(v1: Version; v2: Version): Boolean
+    begin
+        exit(v1 <= v2);
+    end;
+
+    procedure IsNotEqual(v1: Version; v2: Version): Boolean
+    begin
+        exit(v1 <> v2);
+    end;
+}

--- a/tests/bucket-2/215-version-compare/test/VersionCompareTest.al
+++ b/tests/bucket-2/215-version-compare/test/VersionCompareTest.al
@@ -1,0 +1,96 @@
+codeunit 60431 "VC Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "VC Src";
+
+    [Test]
+    procedure Greater_TrueForNewer()
+    var
+        v1, v2 : Version;
+    begin
+        v1 := Version.Create(2, 0, 0, 0);
+        v2 := Version.Create(1, 0, 0, 0);
+        Assert.IsTrue(Src.IsGreater(v1, v2),
+            'Version 2.0.0.0 > 1.0.0.0 must be true');
+    end;
+
+    [Test]
+    procedure Less_TrueForOlder()
+    var
+        v1, v2 : Version;
+    begin
+        v1 := Version.Create(1, 0, 0, 0);
+        v2 := Version.Create(2, 0, 0, 0);
+        Assert.IsTrue(Src.IsLess(v1, v2),
+            'Version 1.0.0.0 < 2.0.0.0 must be true');
+    end;
+
+    [Test]
+    procedure Equal_TrueForSame()
+    var
+        v1, v2 : Version;
+    begin
+        v1 := Version.Create(1, 2, 3, 4);
+        v2 := Version.Create(1, 2, 3, 4);
+        Assert.IsTrue(Src.IsEqual(v1, v2),
+            'Version 1.2.3.4 = 1.2.3.4 must be true');
+    end;
+
+    [Test]
+    procedure Equal_FalseForDifferent()
+    var
+        v1, v2 : Version;
+    begin
+        v1 := Version.Create(1, 0, 0, 0);
+        v2 := Version.Create(2, 0, 0, 0);
+        Assert.IsFalse(Src.IsEqual(v1, v2),
+            'Version 1.0.0.0 = 2.0.0.0 must be false');
+    end;
+
+    [Test]
+    procedure GreaterOrEqual_TrueForEqual()
+    var
+        v1, v2 : Version;
+    begin
+        v1 := Version.Create(1, 0, 0, 0);
+        v2 := Version.Create(1, 0, 0, 0);
+        Assert.IsTrue(Src.IsGreaterOrEqual(v1, v2),
+            'Version 1.0.0.0 >= 1.0.0.0 must be true');
+    end;
+
+    [Test]
+    procedure LessOrEqual_TrueForEqual()
+    var
+        v1, v2 : Version;
+    begin
+        v1 := Version.Create(1, 0, 0, 0);
+        v2 := Version.Create(1, 0, 0, 0);
+        Assert.IsTrue(Src.IsLessOrEqual(v1, v2),
+            'Version 1.0.0.0 <= 1.0.0.0 must be true');
+    end;
+
+    [Test]
+    procedure NotEqual_TrueForDifferent()
+    var
+        v1, v2 : Version;
+    begin
+        v1 := Version.Create(1, 0, 0, 0);
+        v2 := Version.Create(2, 0, 0, 0);
+        Assert.IsTrue(Src.IsNotEqual(v1, v2),
+            'Version 1.0.0.0 <> 2.0.0.0 must be true');
+    end;
+
+    [Test]
+    procedure MinorVersionMatters()
+    var
+        v1, v2 : Version;
+    begin
+        v1 := Version.Create(1, 1, 0, 0);
+        v2 := Version.Create(1, 0, 0, 0);
+        Assert.IsTrue(Src.IsGreater(v1, v2),
+            'Version 1.1.0.0 must be greater than 1.0.0.0');
+    end;
+}


### PR DESCRIPTION
## Summary
- Closes #976
- AL `Version` comparison (`v1 > v2`, `v1 = v2`, etc.) failed with CS0019 because MockVersion had no comparison operators.
- Adds `==`, `!=`, `<`, `>`, `<=`, `>=` operators that compare lexicographically on (major, minor, build, revision). Also overrides `Equals`/`GetHashCode`.
- New suite `tests/bucket-2/215-version-compare` — 8 tests.

## Test plan
- [x] New suite — 8/8 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)