### PR TITLE
fix: NavIndirectValueToNavValue<MockRecordRef> — rewrite to direct cast

### DIFF
--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -3013,8 +3013,21 @@ public void ClearApplicationMemberVariables()
             }
 
             // ALCompiler.NavIndirectValueToNavValue<T>(x) -> AlCompat.NavIndirectValueToNavValue<T>(x)
+            // Special case: T=MockRecordRef (NavRecordRef after rewriting) — MockRecordRef does not
+            // implement NavValue and cannot satisfy the generic constraint. Emit a direct cast
+            // (MockRecordRef)(x) instead, mirroring how NavIndirectValueToINavRecordHandle is handled.
             if (exprText == "ALCompiler" && methodName == "NavIndirectValueToNavValue")
             {
+                if (memberAccess.Name is GenericNameSyntax recRefGeneric &&
+                    recRefGeneric.TypeArgumentList.Arguments.Count == 1 &&
+                    recRefGeneric.TypeArgumentList.Arguments[0].ToString() == "MockRecordRef")
+                {
+                    var arg = visited.ArgumentList.Arguments[0].Expression;
+                    return SyntaxFactory.CastExpression(
+                        SyntaxFactory.ParseTypeName("MockRecordRef"),
+                        SyntaxFactory.ParenthesizedExpression(arg));
+                }
+
                 // Preserve the generic type arguments (e.g., <NavText>)
                 return visited.WithExpression(
                     SyntaxFactory.MemberAccessExpression(

--- a/AlRunner/Runtime/MockVariant.cs
+++ b/AlRunner/Runtime/MockVariant.cs
@@ -83,7 +83,7 @@ public class MockVariant
     public bool ALIsGuid => _value is NavGuid or Guid;
     public bool ALIsOption => _value is NavOption;
     public bool ALIsRecord => _value is MockRecordHandle;
-    public bool ALIsRecordRef => false;
+    public bool ALIsRecordRef => _value is MockRecordRef;
     public bool ALIsRecordId => false;
     public bool ALIsBigInteger => _value is NavBigInteger or long;
     public bool ALIsDuration => false;
@@ -176,6 +176,20 @@ public class MockVariant
         throw new InvalidCastException(
             $"Cannot cast Variant (holding {v._value?.GetType().Name ?? "null"}) to Record. " +
             "The Variant must contain a Record value.");
+    }
+
+    /// <summary>
+    /// Explicit cast to MockRecordRef.
+    /// Supports the AL pattern: MyRecRef := MyVariant;
+    /// The BC compiler emits ALCompiler.NavIndirectValueToNavValue&lt;NavRecordRef&gt;(variant),
+    /// which the rewriter transforms to (MockRecordRef)(variant).
+    /// </summary>
+    public static explicit operator MockRecordRef(MockVariant v)
+    {
+        if (v._value is MockRecordRef rr) return rr;
+        throw new InvalidCastException(
+            $"Cannot cast Variant (holding {v._value?.GetType().Name ?? "null"}) to RecordRef. " +
+            "The Variant must contain a RecordRef value.");
     }
 
     /// <summary>

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -8655,7 +8655,8 @@ Variant.IsRecordRef:
   layer: runtime-api
   category: Variant
   status: covered
-  notes: overloads=1
+  tests: tests/bucket-2/215-recordref-navvalue
+  notes: overloads=1; ALIsRecordRef checks _value is MockRecordRef; round-trip via Variant also proven (NavIndirectValueToNavValue<MockRecordRef> rewritten to direct cast)
 
 Variant.IsReportFormat:
   layer: runtime-api

--- a/tests/bucket-2/215-recordref-navvalue/src/NviSrc.al
+++ b/tests/bucket-2/215-recordref-navvalue/src/NviSrc.al
@@ -1,0 +1,44 @@
+/// Minimal table for RecordRef / NavIndirectValueToNavValue coverage.
+table 97900 "NVI Table"
+{
+    fields
+    {
+        field(1; Id; Integer) { }
+        field(2; Name; Text[50]) { }
+    }
+    keys
+    {
+        key(PK; Id) { Clustered = true; }
+    }
+}
+
+/// Source helpers for RecordRef-in-Variant coverage (issue #983).
+/// Exercises patterns that the BC compiler lowers to
+/// NavIndirectValueToNavValue<NavRecordRef>(…), which the runner must
+/// translate without requiring MockRecordRef : NavValue.
+codeunit 97901 "NVI Src"
+{
+    /// Assign a RecordRef to a Variant, then recover it from the Variant.
+    /// The BC compiler emits NavIndirectValueToNavValue<NavRecordRef> for the
+    /// Variant → RecordRef assignment.
+    procedure RoundtripRecordRefViaVariant(rr: RecordRef): Integer
+    var
+        v: Variant;
+        rr2: RecordRef;
+    begin
+        v := rr;
+        rr2 := v;
+        exit(rr2.Number);
+    end;
+
+    /// Read the first text field of a record through a RecordRef / FieldRef,
+    /// then format its Variant value.  This pattern is the canonical
+    /// real-world trigger (see issue #983 reproduction).
+    procedure GetNameViaRecordRef(rr: RecordRef): Text
+    var
+        fref: FieldRef;
+    begin
+        fref := rr.Field(2);
+        exit(Format(fref.Value));
+    end;
+}

--- a/tests/bucket-2/215-recordref-navvalue/test/NviTest.al
+++ b/tests/bucket-2/215-recordref-navvalue/test/NviTest.al
@@ -1,0 +1,71 @@
+/// Tests proving RecordRef survives a Variant round-trip and FieldRef.Value
+/// works correctly when the underlying record was opened via RecordRef.
+/// Covers issue #983.
+///
+/// Test strategy:
+///   RoundtripRecordRefViaVariant — assigns RecordRef → Variant → RecordRef;
+///     proves the BC-emitted NavIndirectValueToNavValue<NavRecordRef> path works.
+///   GetNameViaRecordRef — reads a text field via FieldRef.Value and Format();
+///     proves the canonical real-world trigger from the issue report.
+codeunit 97902 "NVI Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "NVI Src";
+
+    // ── RoundtripRecordRefViaVariant ──────────────────────────────────────────
+
+    [Test]
+    procedure RoundtripRecordRef_ReturnsCorrectTableNo()
+    var
+        rec: Record "NVI Table";
+        rr: RecordRef;
+    begin
+        // [GIVEN] A RecordRef opened on NVI Table
+        rr.Open(Database::"NVI Table");
+        // [WHEN]  The RecordRef is round-tripped through a Variant
+        // [THEN]  The recovered RecordRef has the same table number
+        Assert.AreEqual(Database::"NVI Table", Src.RoundtripRecordRefViaVariant(rr),
+            'Table number must survive Variant round-trip');
+    end;
+
+    // ── GetNameViaRecordRef ───────────────────────────────────────────────────
+
+    [Test]
+    procedure GetNameViaRecordRef_ReturnsFieldValue()
+    var
+        rec: Record "NVI Table";
+        rr: RecordRef;
+    begin
+        // [GIVEN] A record with a known Name value
+        rec.Init();
+        rec.Id := 1;
+        rec.Name := 'Hello';
+        rec.Insert();
+        rr.GetTable(rec);
+        // [WHEN]  GetNameViaRecordRef is called
+        // [THEN]  The formatted field value is returned
+        Assert.AreEqual('Hello', Src.GetNameViaRecordRef(rr),
+            'Name field value must be returned via FieldRef.Value / Format');
+    end;
+
+    [Test]
+    procedure GetNameViaRecordRef_EmptyString_WhenNameBlank()
+    var
+        rec: Record "NVI Table";
+        rr: RecordRef;
+    begin
+        // [GIVEN] A record with a blank Name
+        rec.Init();
+        rec.Id := 2;
+        rec.Name := '';
+        rec.Insert();
+        rr.GetTable(rec);
+        // [WHEN]  GetNameViaRecordRef is called
+        // [THEN]  Empty string is returned
+        Assert.AreEqual('', Src.GetNameViaRecordRef(rr),
+            'Blank Name must return empty string');
+    end;
+}


### PR DESCRIPTION
Closes #983

## What

When a Variant is assigned to a RecordRef variable, the BC compiler emits
`ALCompiler.NavIndirectValueToNavValue<NavRecordRef>(…)`. After the
RoslynRewriter turns `NavRecordRef` → `MockRecordRef`, the call became
`AlCompat.NavIndirectValueToNavValue<MockRecordRef>(…)`, which failed at
Roslyn compilation with CS0311 because `MockRecordRef` does not implement
`NavValue`.

## Fix

Three changes, all tightly coupled:

1. **RoslynRewriter** — when the generic type argument of
   `NavIndirectValueToNavValue` is `MockRecordRef` (post-child-rewrite), emit
   a direct cast `(MockRecordRef)(…)` instead of the uncallable generic form.
   This mirrors the existing `NavIndirectValueToINavRecordHandle` →
   `(MockRecordHandle)(…)` pattern.

2. **MockVariant.explicit operator MockRecordRef** — allows the emitted
   `(MockRecordRef)(variant)` to compile and run, extracting the held
   `MockRecordRef` from the variant box (throws `InvalidCastException` if the
   variant does not hold a RecordRef, matching BC behaviour).

3. **MockVariant.ALIsRecordRef** — was hard-coded `false`; now correctly
   returns `_value is MockRecordRef`.

## Tests (`tests/bucket-2/215-recordref-navvalue/`)

- `RoundtripRecordRef_ReturnsCorrectTableNo` — assigns a RecordRef into a
  Variant and recovers it; proves the `NavIndirectValueToNavValue<MockRecordRef>`
  rewrite path end-to-end.
- `GetNameViaRecordRef_ReturnsFieldValue` — reads a text field via
  `FieldRef.Value` and `Format()`; proves the canonical real-world trigger from
  the issue report.
- `GetNameViaRecordRef_EmptyString_WhenNameBlank` — negative case: blank field
  returns empty string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)