### PR TITLE
fix: MockFilterPageBuilder.ALRunModal returns bool to fix CS0019

### DIFF
--- a/AlRunner/Runtime/MockFilterPageBuilder.cs
+++ b/AlRunner/Runtime/MockFilterPageBuilder.cs
@@ -126,12 +126,18 @@ public class MockFilterPageBuilder
     // ── RunModal ──────────────────────────────────────────────────────────────
 
     /// <summary>
-    /// Simulate running the filter dialog. In standalone mode no UI is shown;
-    /// returns FormResult.OK (equivalent to Action::OK).
+    /// Simulate running the filter dialog. In standalone mode no UI is shown.
+    /// <para>
+    /// <c>FilterPageBuilder.RunModal()</c> in AL returns <c>Boolean</c> (true = user accepted).
+    /// BC emits <c>fPB.ALRunModal(DataError)</c>; the return type must be <c>bool</c> so that
+    /// compound boolean expressions like <c>cond &amp; fPB.ALRunModal()</c> compile without
+    /// CS0019 ("Operator '&amp;' cannot be applied to operands of type 'bool' and 'FormResult'").
+    /// </para>
+    /// Always returns <c>true</c> in standalone mode (equivalent to Action::OK accepted).
     /// </summary>
-    public FormResult ALRunModal()
-        => FormResult.OK;
+    public bool ALRunModal()
+        => true;
 
-    public FormResult ALRunModal(DataError errorLevel)
-        => FormResult.OK;
+    public bool ALRunModal(DataError errorLevel)
+        => true;
 }

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -2735,8 +2735,8 @@ FilterPageBuilder.RunModal:
   layer: runtime-api
   category: FilterPageBuilder
   status: covered
-  notes: overloads=1; MockFilterPageBuilder; returns FormResult.OK (Action::OK) — no UI
-  tests: tests/bucket-2/179-filter-page-builder
+  notes: "overloads=2; MockFilterPageBuilder; returns bool (true=OK) — fixed CS0019 (was returning FormResult causing 'bool & FormResult' error in compound boolean expressions); BC emits ALRunModal(DataError) expecting bool return"
+  tests: tests/bucket-2/179-filter-page-builder, tests/bucket-1/284-formresult-operator
 
 FilterPageBuilder.SetView:
   layer: runtime-api

--- a/tests/bucket-1/284-formresult-operator/src/FormResultSrc.al
+++ b/tests/bucket-1/284-formresult-operator/src/FormResultSrc.al
@@ -1,0 +1,88 @@
+/// Source codeunit exercising bool & FormResult operator — issue #985.
+/// Root cause: MockFilterPageBuilder.ALRunModal() returned FormResult (wrong type),
+/// causing CS0019 when used in compound boolean expressions.
+/// FilterPageBuilder.RunModal() returns Boolean in AL; BC emits ALRunModal → bool.
+table 132000 "FRO FPB Table"
+{
+    fields { field(1; Id; Integer) { } }
+    keys { key(PK; Id) { Clustered = true; } }
+}
+
+codeunit 132001 "FRO Source"
+{
+    // AL compound condition: SomeBoolean and (Action = Action::OK)
+    // BC emits: boolVar & (formResult == FormResult.OK)
+    // The & operator between bool and FormResult must be defined.
+
+    procedure BoolAndFormResult_True(): Boolean
+    var
+        Cond: Boolean;
+        Act: Action;
+    begin
+        Cond := true;
+        Act := Action::OK;
+        // In AL: (Cond) and (Act = Action::OK)
+        // BC emits: Cond & (Act == FormResult.OK) — must not CS0019
+        exit(Cond and (Act = Action::OK));
+    end;
+
+    procedure BoolAndFormResult_False(): Boolean
+    var
+        Cond: Boolean;
+        Act: Action;
+    begin
+        Cond := true;
+        Act := Action::Cancel;
+        exit(Cond and (Act = Action::OK));
+    end;
+
+    procedure BoolOrFormResult_True(): Boolean
+    var
+        Cond: Boolean;
+        Act: Action;
+    begin
+        Cond := false;
+        Act := Action::OK;
+        exit(Cond or (Act = Action::OK));
+    end;
+
+    procedure FormResultAsAction_Compiles(): Action
+    var
+        Act: Action;
+    begin
+        Act := Action::LookupOK;
+        exit(Act);
+    end;
+
+    // FilterPageBuilder.RunModal() returns Boolean in AL.
+    // BC emits: cond & fPB.ALRunModal(DataError.TrapError)
+    // MockFilterPageBuilder.ALRunModal must return bool (not FormResult)
+    // to avoid CS0019 when used in compound boolean expressions.
+
+    procedure FilterBuilderAndBool_True(Cond: Boolean): Boolean
+    var
+        FPB: FilterPageBuilder;
+    begin
+        FPB.AddTable('FRO FPB Table', DATABASE::"FRO FPB Table");
+        // FilterPageBuilder.RunModal() returns Boolean — in standalone mode always true
+        exit(Cond and FPB.RunModal());
+    end;
+
+    procedure FilterBuilderAndBool_CondFalse(): Boolean
+    var
+        FPB: FilterPageBuilder;
+    begin
+        FPB.AddTable('FRO FPB Table', DATABASE::"FRO FPB Table");
+        // false and anything = false
+        exit(false and FPB.RunModal());
+    end;
+
+    procedure FilterBuilderOrBool_True(): Boolean
+    var
+        FPB: FilterPageBuilder;
+    begin
+        FPB.AddTable('FRO FPB Table', DATABASE::"FRO FPB Table");
+        // false or RunModal() = RunModal() = true in standalone
+        exit(false or FPB.RunModal());
+    end;
+}

--- a/tests/bucket-1/284-formresult-operator/test/FormResultTest.al
+++ b/tests/bucket-1/284-formresult-operator/test/FormResultTest.al
@@ -1,0 +1,77 @@
+codeunit 132002 "FRO Test"
+{
+    Subtype = Test;
+    var
+        Assert: Codeunit Assert;
+
+    [Test]
+    procedure BoolAndFormResult_BothTrue_ReturnsTrue()
+    var
+        Src: Codeunit "FRO Source";
+    begin
+        // [GIVEN] bool=true AND (Action=Action::OK) → true AND true
+        Assert.IsTrue(Src.BoolAndFormResult_True(), 'true and (Action=Action::OK) must be true');
+    end;
+
+    [Test]
+    procedure BoolAndFormResult_ActionMismatch_ReturnsFalse()
+    var
+        Src: Codeunit "FRO Source";
+    begin
+        // [GIVEN] bool=true AND (Action::Cancel=Action::OK) → true AND false
+        Assert.IsFalse(Src.BoolAndFormResult_False(), 'true and (Cancel=OK) must be false');
+    end;
+
+    [Test]
+    procedure BoolOrFormResult_ActionTrue_ReturnsTrue()
+    var
+        Src: Codeunit "FRO Source";
+    begin
+        // [GIVEN] bool=false OR (Action=Action::OK) → false OR true
+        Assert.IsTrue(Src.BoolOrFormResult_True(), 'false or (Action=Action::OK) must be true');
+    end;
+
+    [Test]
+    procedure FormResultAsAction_ReturnsLookupOK()
+    var
+        Src: Codeunit "FRO Source";
+    begin
+        // [GIVEN] Action::LookupOK assigned and returned
+        Assert.AreEqual(Action::LookupOK, Src.FormResultAsAction_Compiles(), 'Action::LookupOK must round-trip');
+    end;
+
+    // ── FilterPageBuilder.RunModal() in compound boolean ────────────────────────
+    // FilterPageBuilder.RunModal() returns Boolean in AL.
+    // BC emits: cond & fPB.ALRunModal(DataError.TrapError)
+    // MockFilterPageBuilder.ALRunModal() must return bool to avoid CS0019.
+
+    [Test]
+    procedure FilterBuilderAndBool_CondTrue_ReturnsTrue()
+    var
+        Src: Codeunit "FRO Source";
+    begin
+        // [GIVEN] true and FilterPageBuilder.RunModal() — RunModal always true in standalone
+        // [THEN] true and true = true
+        Assert.IsTrue(Src.FilterBuilderAndBool_True(true), 'true and FPB.RunModal() must be true');
+    end;
+
+    [Test]
+    procedure FilterBuilderAndBool_CondFalse_ReturnsFalse()
+    var
+        Src: Codeunit "FRO Source";
+    begin
+        // [GIVEN] false and FilterPageBuilder.RunModal() — short-circuits to false
+        // [THEN] false and anything = false
+        Assert.IsFalse(Src.FilterBuilderAndBool_CondFalse(), 'false and FPB.RunModal() must be false');
+    end;
+
+    [Test]
+    procedure FilterBuilderOrBool_RunModalTrue_ReturnsTrue()
+    var
+        Src: Codeunit "FRO Source";
+    begin
+        // [GIVEN] false or FilterPageBuilder.RunModal() — RunModal returns true in standalone
+        // [THEN] false or true = true
+        Assert.IsTrue(Src.FilterBuilderOrBool_True(), 'false or FPB.RunModal() must be true');
+    end;
+}


### PR DESCRIPTION
Closes #985

## Root cause

`FilterPageBuilder.RunModal()` in AL returns **`Boolean`** — not `Action`. BC emits `fPB.ALRunModal(DataError.TrapError)` in C# expecting a `bool` return type, so compound boolean expressions like:

```al
exit(Cond and FPB.RunModal());
```

were compiled to:

```csharp
this.γretVal = this.cond & this.fPB.ALRunModal(DataError.TrapError);
```

The mock returned `FormResult`, making this `bool & FormResult` → **CS0019**.

## Fix

Changed `MockFilterPageBuilder.ALRunModal()` return type from `FormResult` to `bool` (returns `true` — always accepted in standalone mode, equivalent to Action::OK).

## Tests (RED → GREEN)

Added `tests/bucket-1/284-formresult-operator/` with 7 tests:

| Test | Proves |
|------|--------|
| `BoolAndFormResult_BothTrue_ReturnsTrue` | `true and (Action=Action::OK)` = `true` |
| `BoolAndFormResult_ActionMismatch_ReturnsFalse` | `true and (Action::Cancel=Action::OK)` = `false` |
| `BoolOrFormResult_ActionTrue_ReturnsTrue` | `false or (Action=Action::OK)` = `true` |
| `FormResultAsAction_ReturnsLookupOK` | `Action::LookupOK` round-trips |
| `FilterBuilderAndBool_CondTrue_ReturnsTrue` | `true and FPB.RunModal()` = `true` (**was CS0019**) |
| `FilterBuilderAndBool_CondFalse_ReturnsFalse` | `false and FPB.RunModal()` = `false` (**was CS0019**) |
| `FilterBuilderOrBool_RunModalTrue_ReturnsTrue` | `false or FPB.RunModal()` = `true` (**was CS0019**) |

Full regression: 1508 passed, 2 pre-existing failures (timezone-related, unrelated).