### PR TITLE
fix: MockHttpContent.ALGetHeaders as method not property (#968)

### DIFF
--- a/AlRunner/Runtime/MockHttpContent.cs
+++ b/AlRunner/Runtime/MockHttpContent.cs
@@ -43,8 +43,15 @@ public class MockHttpContent
         text.Value = new NavText(_textContent);
     }
 
-    /// <summary>Content headers. BC emits <c>content.ALGetHeaders</c>.</summary>
-    public MockHttpHeaders ALGetHeaders => _headers;
+    /// <summary>
+    /// Content headers. BC emits <c>content.ALGetHeaders(errorLevel, byref headers)</c>
+    /// as a method call with a ByRef out parameter. The headers collection is shared
+    /// with the content so later mutations round-trip.
+    /// </summary>
+    public void ALGetHeaders(DataError errorLevel, ByRef<MockHttpHeaders> headers)
+    {
+        headers.Value = _headers;
+    }
 
     /// <summary>
     /// ALAssign for the ByRef pattern and <c>content := response.Content</c>.

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -2878,7 +2878,8 @@ HttpContent.GetHeaders:
   layer: runtime-api
   category: HttpContent
   status: covered
-  notes: overloads=1
+  tests: tests/bucket-2/216-httpcontent-getheaders
+  notes: overloads=1. MockHttpContent.ALGetHeaders is now a method (was a property; BC emits it as a method call with a ByRef out parameter).
 
 HttpContent.IsSecretContent:
   layer: runtime-api

--- a/tests/bucket-2/216-httpcontent-getheaders/al-runner.json
+++ b/tests/bucket-2/216-httpcontent-getheaders/al-runner.json
@@ -1,0 +1,4 @@
+{
+  "sourcePath": "./src",
+  "testPath": "./test"
+}

--- a/tests/bucket-2/216-httpcontent-getheaders/src/HttpContentGetHeadersSrc.al
+++ b/tests/bucket-2/216-httpcontent-getheaders/src/HttpContentGetHeadersSrc.al
@@ -1,0 +1,24 @@
+/// Exercises HttpContent.GetHeaders() — must be invocable as a method.
+codeunit 60440 "HCGH Src"
+{
+    procedure GetContentHeaders_DoesNotThrow(): Boolean
+    var
+        content: HttpContent;
+        headers: HttpHeaders;
+    begin
+        content.WriteFrom('test body');
+        content.GetHeaders(headers);
+        exit(true);
+    end;
+
+    procedure GetContentHeaders_ThenAdd(): Boolean
+    var
+        content: HttpContent;
+        headers: HttpHeaders;
+    begin
+        content.WriteFrom('hello');
+        content.GetHeaders(headers);
+        headers.Add('Content-Type', 'text/plain');
+        exit(headers.Contains('Content-Type'));
+    end;
+}

--- a/tests/bucket-2/216-httpcontent-getheaders/test/HttpContentGetHeadersTest.al
+++ b/tests/bucket-2/216-httpcontent-getheaders/test/HttpContentGetHeadersTest.al
@@ -1,0 +1,22 @@
+codeunit 60441 "HCGH Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "HCGH Src";
+
+    [Test]
+    procedure GetHeaders_DoesNotThrow()
+    begin
+        Assert.IsTrue(Src.GetContentHeaders_DoesNotThrow(),
+            'HttpContent.GetHeaders must be callable as a method');
+    end;
+
+    [Test]
+    procedure GetHeaders_Then_Add_Contains()
+    begin
+        Assert.IsTrue(Src.GetContentHeaders_ThenAdd(),
+            'Headers obtained via GetHeaders must be mutable — Add + Contains must work');
+    end;
+}


### PR DESCRIPTION
## Summary
- Closes #968
- BC emits `HttpContent.GetHeaders(var headers)` as a method call with ByRef out. MockHttpContent had ALGetHeaders as a property → CS1955.
- Changed to a void method taking `DataError` + `ByRef<MockHttpHeaders>`. Headers collection is shared so later mutations round-trip.
- New suite `tests/bucket-2/216-httpcontent-getheaders` — 2 tests.
- bucket-2 regression: 1540 pass (up from previous sessions), 3 pre-existing timezone failures.

## Test plan
- [x] New suite — 2/2 pass
- [x] bucket-2 regression — no new failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)