### PR TITLE
feat: MockRecordRef.ALFilterGroup delegation (#969)

### DIFF
--- a/AlRunner/Runtime/MockRecordRef.cs
+++ b/AlRunner/Runtime/MockRecordRef.cs
@@ -92,6 +92,21 @@ public class MockRecordRef
     public void ALLoadFields(params int[] fieldNos) { }
     public void ALLoadFields(DataError errorLevel, params int[] fieldNos) { }
 
+    /// <summary>
+    /// ALFilterGroup — set/get the active filter group. Standalone no-op (groups not tracked);
+    /// reads always return 0. Exposed as a property so BC can emit both the assignment form
+    /// (<c>recRef.ALFilterGroup = 2</c>) and the invocation form (<c>recRef.ALFilterGroup(2)</c>
+    /// via the method overload below).
+    /// </summary>
+    public int ALFilterGroup
+    {
+        get => _handle?.ALFilterGroup ?? 0;
+        set { if (_handle != null) _handle.ALFilterGroup = value; }
+    }
+
+    /// <summary>Method overload for recRef.ALFilterGroup(n) call syntax.</summary>
+    public void SetALFilterGroup(int groupId) => _handle?.SetALFilterGroup(groupId);
+
     // -- IsDirty — no dirty tracking in standalone --
 
     /// <summary>ALIsDirty — standalone has no write-pending tracking; always false.</summary>

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -4912,7 +4912,8 @@ RecordRef.FilterGroup:
   layer: runtime-api
   category: RecordRef
   status: covered
-  notes: overloads=1
+  tests: tests/bucket-2/217-recref-filtergroup
+  notes: overloads=1. ALFilterGroup property/method on MockRecordRef delegates to MockRecordHandle — no-op standalone, reads return 0.
 
 RecordRef.Find:
   layer: runtime-api

--- a/tests/bucket-2/217-recref-filtergroup/al-runner.json
+++ b/tests/bucket-2/217-recref-filtergroup/al-runner.json
@@ -1,0 +1,4 @@
+{
+  "sourcePath": "./src",
+  "testPath": "./test"
+}

--- a/tests/bucket-2/217-recref-filtergroup/src/RecRefFilterGroupSrc.al
+++ b/tests/bucket-2/217-recref-filtergroup/src/RecRefFilterGroupSrc.al
@@ -1,0 +1,29 @@
+table 60460 "RFG Row"
+{
+    fields
+    {
+        field(1; "Id"; Integer) { }
+    }
+    keys { key(PK; "Id") { Clustered = true; } }
+}
+
+/// Exercises RecordRef.FilterGroup.
+codeunit 60460 "RFG Src"
+{
+    procedure FilterGroup_SetThenGet(group: Integer): Integer
+    var
+        rr: RecordRef;
+    begin
+        rr.Open(60460);
+        rr.FilterGroup(group);
+        exit(rr.FilterGroup());
+    end;
+
+    procedure FilterGroup_DefaultIsZero(): Integer
+    var
+        rr: RecordRef;
+    begin
+        rr.Open(60460);
+        exit(rr.FilterGroup());
+    end;
+}

--- a/tests/bucket-2/217-recref-filtergroup/test/RecRefFilterGroupTest.al
+++ b/tests/bucket-2/217-recref-filtergroup/test/RecRefFilterGroupTest.al
@@ -1,0 +1,24 @@
+codeunit 60461 "RFG Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "RFG Src";
+
+    [Test]
+    procedure FilterGroup_Default_IsZero()
+    begin
+        Assert.AreEqual(0, Src.FilterGroup_DefaultIsZero(),
+            'Default FilterGroup must be 0');
+    end;
+
+    [Test]
+    procedure FilterGroup_Setter_DoesNotThrow()
+    begin
+        // Standalone: filter groups are not tracked, setter is a no-op.
+        // Reading after set returns 0 (the default). The point is that the call compiles + runs.
+        Src.FilterGroup_SetThenGet(2);
+        Assert.IsTrue(true, 'FilterGroup setter must not throw');
+    end;
+}


### PR DESCRIPTION
## Summary
- Closes #969 (partial — ALFilterGroup fixed; Factory nested type is a separate concern)
- MockRecordRef had no ALFilterGroup; CS1061 when BC emitted `recRef.FilterGroup()` or `recRef.FilterGroup := n`.
- Added property + setter method that delegate to MockRecordHandle (which already has them).
- New suite `tests/bucket-2/217-recref-filtergroup` — 2 tests.

## Test plan
- [x] New suite — 2/2 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)