### PR TITLE
test: Page<N>.RunModal + LookupMode instance-form coverage (#971)

### DIFF
--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -4505,8 +4505,10 @@ Page.LookupMode:
   layer: runtime-api
   category: Page
   status: covered
-  tests: tests/bucket-1/89-page-static
-  notes: overloads=1
+  tests:
+    - tests/bucket-1/89-page-static
+    - tests/bucket-2/218-page-runmodal-lookup
+  notes: overloads=1. Also proven on instance Page<N> — setter + getter round-trip.
 
 Page.ObjectId:
   layer: runtime-api
@@ -4533,8 +4535,10 @@ Page.RunModal:
   layer: runtime-api
   category: Page
   status: covered
-  tests: tests/bucket-1/89-page-static
-  notes: overloads=4
+  tests:
+    - tests/bucket-1/89-page-static
+    - tests/bucket-2/218-page-runmodal-lookup
+  notes: overloads=4. Instance form Page<N>.RunModal() dispatches to ModalPageHandler.
 
 Page.SaveRecord:
   layer: runtime-api

--- a/tests/bucket-2/218-page-runmodal-lookup/al-runner.json
+++ b/tests/bucket-2/218-page-runmodal-lookup/al-runner.json
@@ -1,0 +1,4 @@
+{
+  "sourcePath": "./src",
+  "testPath": "./test"
+}

--- a/tests/bucket-2/218-page-runmodal-lookup/src/PageRunModalSrc.al
+++ b/tests/bucket-2/218-page-runmodal-lookup/src/PageRunModalSrc.al
@@ -1,0 +1,41 @@
+page 60470 "PRM Card"
+{
+    PageType = Card;
+    SourceTable = "PRM Source";
+
+    layout
+    {
+        area(Content)
+        {
+            field(Id; Rec."Id") { ApplicationArea = All; }
+        }
+    }
+}
+
+table 60470 "PRM Source"
+{
+    fields
+    {
+        field(1; "Id"; Integer) { }
+    }
+    keys { key(PK; "Id") { Clustered = true; } }
+}
+
+/// Exercises Page<N>.RunModal and LookupMode on a generated page class.
+codeunit 60470 "PRM Src"
+{
+    procedure PageRunModal_ReturnsAction(): Action
+    var
+        pg: Page "PRM Card";
+    begin
+        exit(pg.RunModal());
+    end;
+
+    procedure PageLookupMode_SetAndGet(): Boolean
+    var
+        pg: Page "PRM Card";
+    begin
+        pg.LookupMode := true;
+        exit(pg.LookupMode);
+    end;
+}

--- a/tests/bucket-2/218-page-runmodal-lookup/test/PageRunModalTest.al
+++ b/tests/bucket-2/218-page-runmodal-lookup/test/PageRunModalTest.al
@@ -1,0 +1,30 @@
+codeunit 60471 "PRM Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "PRM Src";
+
+    [Test]
+    [HandlerFunctions('PRMModalHandler')]
+    procedure RunModal_ReturnsAction()
+    begin
+        // Standalone: RunModal dispatches to the ModalPageHandler, returns Action.
+        Src.PageRunModal_ReturnsAction();
+        Assert.IsTrue(true, 'Page.RunModal must not throw when a handler is registered');
+    end;
+
+    [ModalPageHandler]
+    procedure PRMModalHandler(var pg: TestPage "PRM Card")
+    begin
+        pg.OK().Invoke();
+    end;
+
+    [Test]
+    procedure LookupMode_SetAndGet_RoundTrips()
+    begin
+        Assert.IsTrue(Src.PageLookupMode_SetAndGet(),
+            'Page.LookupMode setter + getter must round-trip');
+    end;
+}


### PR DESCRIPTION
## Summary
- Closes #971 (partial — RunModal and LookupMode instance forms covered; GetPart/CheckType etc. are out of scope for this PR)
- Instance `Page<N>.RunModal()` and `LookupMode` already work via the page mock infrastructure. Adds proving tests exercising the instance form specifically.
- New suite `tests/bucket-2/218-page-runmodal-lookup` — 2 tests.

## Test plan
- [x] New suite — 2/2 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)