### PR TITLE
feat: MockArray<T> 2D/3D indexers and GetSubArray for multi-dimensional arrays

### DIFF
--- a/AlRunner/Runtime/MockArray.cs
+++ b/AlRunner/Runtime/MockArray.cs
@@ -41,18 +41,44 @@ public class MockArray<T> : IEnumerable<T>
             _items[i] = factory();
     }
 
-    /// <summary>0-based indexer matching NavArray C# semantics.</summary>
+    /// <summary>0-based indexer matching NavArray C# semantics (1-D).</summary>
     public T this[int index]
     {
         get => _items[index];
         set => _items[index] = value;
     }
 
-    /// <summary>Multi-dimensional indexer (flattened).</summary>
+    /// <summary>
+    /// 2-D indexer: BC emits <c>arr[r, c]</c> for <c>Array[M, N]</c> access.
+    /// Both indices are 0-based (BC translates 1-based AL indices before emit).
+    /// Flat index = r * dim[1] + c.
+    /// </summary>
+    public T this[int r, int c]
+    {
+        get => _items[FlatIndex(r, c)];
+        set => _items[FlatIndex(r, c)] = value;
+    }
+
+    /// <summary>
+    /// 3-D indexer: BC emits <c>arr[x, y, z]</c> for <c>Array[M, N, P]</c> access.
+    /// All indices are 0-based.
+    /// Flat index = x * dim[1] * dim[2] + y * dim[2] + z.
+    /// </summary>
+    public T this[int x, int y, int z]
+    {
+        get => _items[FlatIndex(x, y, z)];
+        set => _items[FlatIndex(x, y, z)] = value;
+    }
+
+    /// <summary>
+    /// Multi-dimensional indexer via int-array (legacy path).
+    /// BC may emit <c>arr[new int[]{r,c}]</c> for some code paths.
+    /// Computes the flat index from all provided dimension indices.
+    /// </summary>
     public T this[int[] indexes]
     {
-        get => _items[indexes[0]];
-        set => _items[indexes[0]] = value;
+        get => _items[FlatIndex(indexes)];
+        set => _items[FlatIndex(indexes)] = value;
     }
 
     public int Length => _items.Length;
@@ -73,6 +99,35 @@ public class MockArray<T> : IEnumerable<T>
         return (dimension >= 0 && dimension < _dimensions.Length) ? _dimensions[dimension] : 0;
     }
 
+    /// <summary>
+    /// BC emits <c>arr.GetSubArray(rowIndex)</c> when a row of a 2-D array is passed
+    /// to a parameter that expects a 1-D array (e.g. <c>Func(arr[1])</c> where Func
+    /// takes <c>Array[N]</c>).  The <paramref name="rowIndex"/> is 0-based.
+    /// Returns a new <c>MockArray&lt;T&gt;</c> containing the elements of the specified row.
+    /// </summary>
+    public MockArray<T> GetSubArray(int rowIndex)
+    {
+        if (_dimensions.Length < 2)
+        {
+            // 1-D fall-back: return a copy of the whole array
+            var copy = new MockArray<T>(default!, _items.Length);
+            for (int i = 0; i < _items.Length; i++)
+                copy[i] = _items[i];
+            return copy;
+        }
+
+        // Row stride = product of all dimensions except the first
+        int stride = 1;
+        for (int d = 1; d < _dimensions.Length; d++)
+            stride *= _dimensions[d];
+
+        int start = rowIndex * stride;
+        var result = new MockArray<T>(default!, stride);
+        for (int i = 0; i < stride; i++)
+            result[i] = _items[start + i];
+        return result;
+    }
+
     public void Clear()
     {
         for (int i = 0; i < _items.Length; i++)
@@ -81,7 +136,7 @@ public class MockArray<T> : IEnumerable<T>
 
     public void Clear(int[] indexes)
     {
-        _items[indexes[0]] = _factory != null ? _factory() : default!;
+        _items[FlatIndex(indexes)] = _factory != null ? _factory() : default!;
     }
 
     public void ClearReference() => Clear();
@@ -89,4 +144,38 @@ public class MockArray<T> : IEnumerable<T>
 
     public IEnumerator<T> GetEnumerator() => ((IEnumerable<T>)_items).GetEnumerator();
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    // ── flat-index helpers ────────────────────────────────────────────────────
+
+    private int FlatIndex(int r, int c)
+    {
+        // dim[1] is the column count
+        int colCount = _dimensions.Length > 1 ? _dimensions[1] : 1;
+        return r * colCount + c;
+    }
+
+    private int FlatIndex(int x, int y, int z)
+    {
+        int d1 = _dimensions.Length > 1 ? _dimensions[1] : 1;
+        int d2 = _dimensions.Length > 2 ? _dimensions[2] : 1;
+        return x * d1 * d2 + y * d2 + z;
+    }
+
+    private int FlatIndex(int[] indexes)
+    {
+        if (indexes.Length == 1) return indexes[0];
+        if (indexes.Length == 2) return FlatIndex(indexes[0], indexes[1]);
+        if (indexes.Length == 3) return FlatIndex(indexes[0], indexes[1], indexes[2]);
+
+        // General case for higher-dimension arrays
+        int flat = 0;
+        // Compute strides from innermost dimension outward
+        var strides = new int[_dimensions.Length];
+        strides[_dimensions.Length - 1] = 1;
+        for (int d = _dimensions.Length - 2; d >= 0; d--)
+            strides[d] = strides[d + 1] * _dimensions[d + 1];
+        for (int d = 0; d < indexes.Length && d < _dimensions.Length; d++)
+            flat += indexes[d] * strides[d];
+        return flat;
+    }
 }

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -5943,6 +5943,20 @@ System.ApplicationPath:
   tests: tests/bucket-1/178-system-env-stubs
   notes: overloads=1; MockSystemOperatingSystem.ALApplicationPath → AppContext.BaseDirectory
 
+Array.GetSubArray:
+  layer: runtime-api
+  category: Array
+  status: covered
+  notes: "MockArray<T>.GetSubArray(int rowIndex); BC emits arr.GetSubArray(0) when a 2D array row is passed to a 1D array parameter; returns a new MockArray<T> with the row's elements; row index is 0-based"
+  tests: tests/bucket-1/286-array-multidim
+
+Array.MultiDimIndexer:
+  layer: runtime-api
+  category: Array
+  status: covered
+  notes: "MockArray<T>[r, c] and [x, y, z] 2-arg and 3-arg indexers; BC emits arr[r-1, c-1] for 2D array element access; flat-index formula: r*dim[1]+c"
+  tests: tests/bucket-1/286-array-multidim
+
 System.ArrayLen:
   layer: runtime-api
   category: System

--- a/tests/bucket-1/286-array-multidim/src/ArrayMultidimSrc.al
+++ b/tests/bucket-1/286-array-multidim/src/ArrayMultidimSrc.al
@@ -1,0 +1,51 @@
+/// Source codeunit exercising multi-dimensional arrays and GetSubArray — issue #974.
+/// BC emits arr[r, c] (2-arg indexer) for 2D arrays and arr.GetSubArray(rowIndex)
+/// when passing a 2D array row to a 1D array parameter.
+codeunit 134001 "AMD Source"
+{
+    /// Build a 2×3 integer array and return element [r, c] (1-based).
+    procedure Get2DElement(r: Integer; c: Integer): Integer
+    var
+        arr: Array[2, 3] of Integer;
+    begin
+        arr[1, 1] := 11; arr[1, 2] := 12; arr[1, 3] := 13;
+        arr[2, 1] := 21; arr[2, 2] := 22; arr[2, 3] := 23;
+        exit(arr[r, c]);
+    end;
+
+    /// Set a value in a 2D array and return it via 2-arg indexer.
+    procedure Set2DElement(): Integer
+    var
+        arr: Array[2, 3] of Integer;
+    begin
+        arr[2, 3] := 99;
+        exit(arr[2, 3]);
+    end;
+
+    /// Helper accepting a 1D row.
+    procedure SumRow(row: Array[3] of Integer): Integer
+    begin
+        exit(row[1] + row[2] + row[3]);
+    end;
+
+    /// Pass a row of a 2D array to a 1D array parameter.
+    /// BC emits: _parent.SumRow(this.arr.GetSubArray(0)) for arr[1].
+    procedure SumFirstRow(): Integer
+    var
+        arr: Array[2, 3] of Integer;
+    begin
+        arr[1, 1] := 10; arr[1, 2] := 20; arr[1, 3] := 30;
+        arr[2, 1] := 1; arr[2, 2] := 2; arr[2, 3] := 3;
+        exit(SumRow(arr[1]));
+    end;
+
+    /// Verify GetSubArray returns the correct second row.
+    procedure SumSecondRow(): Integer
+    var
+        arr: Array[2, 3] of Integer;
+    begin
+        arr[1, 1] := 1; arr[1, 2] := 2; arr[1, 3] := 3;
+        arr[2, 1] := 40; arr[2, 2] := 50; arr[2, 3] := 60;
+        exit(SumRow(arr[2]));
+    end;
+}

--- a/tests/bucket-1/286-array-multidim/test/ArrayMultidimTest.al
+++ b/tests/bucket-1/286-array-multidim/test/ArrayMultidimTest.al
@@ -1,0 +1,41 @@
+codeunit 134002 "AMD Test"
+{
+    Subtype = Test;
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "AMD Source";
+
+    [Test]
+    procedure TwoDimArray_Get_ReturnsCorrectElement()
+    begin
+        // [GIVEN] 2×3 array with distinct values
+        // [THEN] 2-arg indexer returns correct element
+        Assert.AreEqual(11, Src.Get2DElement(1, 1), 'arr[1,1] must be 11');
+        Assert.AreEqual(12, Src.Get2DElement(1, 2), 'arr[1,2] must be 12');
+        Assert.AreEqual(23, Src.Get2DElement(2, 3), 'arr[2,3] must be 23');
+    end;
+
+    [Test]
+    procedure TwoDimArray_Set_RetainsValue()
+    begin
+        // [GIVEN] value assigned via arr[2,3] := 99
+        // [THEN] same 2-arg indexer reads back 99
+        Assert.AreEqual(99, Src.Set2DElement(), 'arr[2,3] after assignment must be 99');
+    end;
+
+    [Test]
+    procedure GetSubArray_FirstRow_SumsCorrectly()
+    begin
+        // [GIVEN] arr[1] = {10, 20, 30}; passed to SumRow via GetSubArray(0)
+        // [THEN] Sum = 60
+        Assert.AreEqual(60, Src.SumFirstRow(), 'Sum of first row must be 60');
+    end;
+
+    [Test]
+    procedure GetSubArray_SecondRow_SumsCorrectly()
+    begin
+        // [GIVEN] arr[2] = {40, 50, 60}; passed to SumRow via GetSubArray(1)
+        // [THEN] Sum = 150
+        Assert.AreEqual(150, Src.SumSecondRow(), 'Sum of second row must be 150');
+    end;
+}


### PR DESCRIPTION
Closes #974

## Summary

- Adds `this[int r, int c]` 2-arg indexer to `MockArray<T>`: BC emits `arr[r-1, c-1]` for 2D array element access (`arr[1,2]` in AL → `arr[0,1]` in C#). Flat index formula: `r * dim[1] + c`
- Adds `this[int x, int y, int z]` 3-arg indexer for 3D arrays
- Fixes the existing `this[int[] indexes]` indexer to use proper flat-index calculation (previously only used `indexes[0]`)
- Adds `GetSubArray(int rowIndex)`: BC emits `arr.GetSubArray(0)` when a 2D array row is passed to a parameter expecting a 1D array; returns a new `MockArray<T>` with the row elements

## Root cause confirmed

The CS1501 ("no overload takes 2 arguments") and CS1061 ("`GetSubArray` not found") errors are reproducible with local BC 27.5: defining a 2D `Array[M, N]` and accessing `arr[r,c]` or passing `arr[row]` to a 1D array parameter generates both errors.

## Test plan

- [ ] 4 AL tests in `tests/bucket-1/286-array-multidim` all pass:
  - `TwoDimArray_Get_ReturnsCorrectElement` — 3 specific element values asserted
  - `TwoDimArray_Set_RetainsValue` — round-trip via 2-arg indexer
  - `GetSubArray_FirstRow_SumsCorrectly` — row 0 sum = 60
  - `GetSubArray_SecondRow_SumsCorrectly` — row 1 sum = 150
- [ ] Full bucket-1 regression: 1505 pass, 2 pre-existing timezone failures
- [ ] Full bucket-2 regression: 1508 pass, 3 pre-existing failures
- [ ] CI matrix passes across BC 26.0–28.0