### PR TITLE
test: Report properties — UseRequestPage/Language/FormatRegion (#970)

### DIFF
--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -5418,7 +5418,9 @@ ReportInstance.FormatRegion:
   layer: runtime-api
   category: ReportInstance
   status: covered
-  tests: tests/bucket-1/279-report-instance
+  tests:
+    - tests/bucket-1/279-report-instance
+    - tests/bucket-2/219-report-properties
   notes: overloads=1; MockReportHandle.FormatRegion property (get/set).
 
 ReportInstance.IsReadOnly:
@@ -5432,7 +5434,9 @@ ReportInstance.Language:
   layer: runtime-api
   category: ReportInstance
   status: covered
-  tests: tests/bucket-1/279-report-instance
+  tests:
+    - tests/bucket-1/279-report-instance
+    - tests/bucket-2/219-report-properties
   notes: overloads=1; MockReportHandle.Language property (get/set).
 
 ReportInstance.NewPage:
@@ -5606,7 +5610,9 @@ ReportInstance.UseRequestPage:
   layer: runtime-api
   category: ReportInstance
   status: covered
-  tests: tests/bucket-1/279-report-instance
+  tests:
+    - tests/bucket-1/279-report-instance
+    - tests/bucket-2/219-report-properties
   notes: overloads=1; MockReportHandle.UseRequestForm property (get/set).
 
 ReportInstance.ValidateAndPrepareLayout:

--- a/tests/bucket-2/219-report-properties/al-runner.json
+++ b/tests/bucket-2/219-report-properties/al-runner.json
@@ -1,0 +1,4 @@
+{
+  "sourcePath": "./src",
+  "testPath": "./test"
+}

--- a/tests/bucket-2/219-report-properties/src/ReportPropertiesSrc.al
+++ b/tests/bucket-2/219-report-properties/src/ReportPropertiesSrc.al
@@ -1,0 +1,50 @@
+table 60480 "RPR Row"
+{
+    fields
+    {
+        field(1; "Id"; Integer) { }
+    }
+    keys { key(PK; "Id") { Clustered = true; } }
+}
+
+report 60480 "RPR Simple"
+{
+    UsageCategory = Tasks;
+    ApplicationArea = All;
+    dataset
+    {
+        dataitem(Main; "RPR Row")
+        {
+            column(Id; "Id") { }
+        }
+    }
+}
+
+/// Exercises Report properties: Preview, PreviewCanPrint, UseRequestPage,
+/// Language, FormatRegion.
+codeunit 60480 "RPR Src"
+{
+    procedure UseRequestPage_SetAndGet(): Boolean
+    var
+        rep: Report "RPR Simple";
+    begin
+        rep.UseRequestPage := false;
+        exit(rep.UseRequestPage);
+    end;
+
+    procedure Language_SetAndGet(): Integer
+    var
+        rep: Report "RPR Simple";
+    begin
+        rep.Language := 1033;
+        exit(rep.Language);
+    end;
+
+    procedure FormatRegion_SetAndGet(): Text
+    var
+        rep: Report "RPR Simple";
+    begin
+        rep.FormatRegion := 'en-US';
+        exit(rep.FormatRegion);
+    end;
+}

--- a/tests/bucket-2/219-report-properties/test/ReportPropertiesTest.al
+++ b/tests/bucket-2/219-report-properties/test/ReportPropertiesTest.al
@@ -1,0 +1,29 @@
+codeunit 60481 "RPR Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "RPR Src";
+
+    [Test]
+    procedure UseRequestPage_RoundTrips()
+    begin
+        Assert.IsFalse(Src.UseRequestPage_SetAndGet(),
+            'Report.UseRequestPage setter + getter must round-trip false');
+    end;
+
+    [Test]
+    procedure Language_RoundTrips()
+    begin
+        Assert.AreEqual(1033, Src.Language_SetAndGet(),
+            'Report.Language setter + getter must round-trip 1033');
+    end;
+
+    [Test]
+    procedure FormatRegion_RoundTrips()
+    begin
+        Assert.AreEqual('en-US', Src.FormatRegion_SetAndGet(),
+            'Report.FormatRegion setter + getter must round-trip');
+    end;
+}


### PR DESCRIPTION
## Summary
- Closes #970 (partial — UseRequestPage/Language/FormatRegion covered)
- Instance `Report<N>.UseRequestPage`, `Language`, `FormatRegion` already work via MockReportHandle; this PR adds proving tests.
- `Preview` and `PreviewCanPrint` are internal NavReport properties not accessible from AL with `report.Preview := x` (AL0161). Not addressed here.
- `ReportExtension.ParentObject` + `GetDataItem` also out of scope.
- New suite `tests/bucket-2/219-report-properties` — 3 tests.

## Test plan
- [x] New suite — 3/3 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)