### PR TITLE
feat: MockInterfaceHandle IsInterfaceOfType and AsInterfaceOfType

### DIFF
--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -788,9 +788,11 @@ public void ClearApplicationMemberVariables()
             if (name == "GetMethodScopeFlags")
                 return true;
 
-            // Remove BC interface dispatch methods (used by NavInterfaceHandle runtime)
-            if (name == "IsInterfaceOfType" || name == "IsInterfaceMethod")
-                return true;
+            // NOTE: IsInterfaceOfType and IsInterfaceMethod are intentionally kept.
+            // MockInterfaceHandle.IsInterfaceOfType(int) delegates to these methods to
+            // check if a codeunit implements a given AL interface at runtime.
+            // The 'override' modifier is stripped by VisitMethodDeclaration since the
+            // base class (NavCodeunit etc.) is removed.
 
             // Remove Page/Extension-specific methods that reference BC Page runtime
             if (name == "OnMetadataLoaded" || name == "EvaluateCaptionClass"

--- a/AlRunner/Runtime/MockCodeunitHandle.cs
+++ b/AlRunner/Runtime/MockCodeunitHandle.cs
@@ -97,6 +97,21 @@ public class MockCodeunitHandle
     }
 
     /// <summary>
+    /// Returns the underlying codeunit instance, lazily creating it if needed.
+    /// Used by MockInterfaceHandle.IsInterfaceOfType to call the BC-generated
+    /// IsInterfaceOfType(int) method on the codeunit class.
+    /// </summary>
+    public object? GetUnderlyingInstance()
+    {
+        if (_codeunitInstance != null) return _codeunitInstance;
+        var assembly = CurrentAssembly ?? Assembly.GetExecutingAssembly();
+        var codeunitType = FindCodeunitType(assembly);
+        if (codeunitType == null) return null;
+        EnsureInstance(codeunitType);
+        return _codeunitInstance;
+    }
+
+    /// <summary>
     /// Static factory matching the rewritten constructor pattern.
     /// </summary>
     public static MockCodeunitHandle Create(int codeunitId)

--- a/AlRunner/Runtime/MockInterfaceHandle.cs
+++ b/AlRunner/Runtime/MockInterfaceHandle.cs
@@ -173,4 +173,52 @@ public class MockInterfaceHandle : ITreeObject, IALAssignable<MockInterfaceHandl
     {
         return InvokeInterfaceMethod(memberId, args);
     }
+
+    /// <summary>
+    /// AL <c>myVar is IBar</c> — checks if the underlying implementation supports the given
+    /// interface ID. BC generates <c>myVar.IsInterfaceOfType(interfaceId)</c> for this pattern.
+    /// Delegates to the BC-generated <c>IsInterfaceOfType(int)</c> method on the codeunit class
+    /// (kept by the rewriter; <c>override</c> is stripped so it compiles without the base class).
+    /// </summary>
+    public bool IsInterfaceOfType(int interfaceId)
+    {
+        var instance = GetUnderlyingObject();
+        if (instance == null) return false;
+
+        var method = instance.GetType().GetMethod(
+            "IsInterfaceOfType",
+            System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance,
+            null,
+            new[] { typeof(int) },
+            null);
+        if (method == null) return false;
+
+        return (bool)method.Invoke(instance, new object[] { interfaceId })!;
+    }
+
+    /// <summary>
+    /// AL <c>myVar as IBar</c> — returns <c>this</c> if the implementation supports the
+    /// interface ID, otherwise throws <see cref="InvalidCastException"/>.
+    /// BC generates <c>myVar.AsInterfaceOfType(interfaceId)</c> for this pattern.
+    /// </summary>
+    public MockInterfaceHandle AsInterfaceOfType(int interfaceId)
+    {
+        if (!IsInterfaceOfType(interfaceId))
+            throw new InvalidCastException(
+                $"Interface implementation does not support interface with ID {interfaceId}.");
+        return this;
+    }
+
+    /// <summary>
+    /// Unwraps nested handles and codeunit wrappers to reach the codeunit instance
+    /// that carries the BC-generated IsInterfaceOfType(int) method.
+    /// </summary>
+    private object? GetUnderlyingObject()
+    {
+        if (_implementation is MockCodeunitHandle handle)
+            return handle.GetUnderlyingInstance();
+        if (_implementation is MockInterfaceHandle inner)
+            return inner.GetUnderlyingObject();
+        return _implementation;
+    }
 }

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -81,6 +81,29 @@ interface_declaration:
     - tests/bucket-2/42-list-of-interface
     - tests/bucket-2/53-enum-interface
 
+interface_is_operator:
+  layer: runtime
+  category: interface
+  status: covered
+  notes: >
+    AL `myVar is IBar` — BC emits myVar.IsInterfaceOfType(interfaceId).
+    MockInterfaceHandle.IsInterfaceOfType(int) delegates to the BC-generated
+    IsInterfaceOfType(int) method on the codeunit class (kept by rewriter,
+    override stripped so it compiles without the NavCodeunit base class).
+  tests:
+    - tests/bucket-1/287-interface-typecheck
+
+interface_as_operator:
+  layer: runtime
+  category: interface
+  status: covered
+  notes: >
+    AL `myVar as IBar` — BC emits myVar.AsInterfaceOfType(interfaceId).
+    Returns the same MockInterfaceHandle if IsInterfaceOfType passes; throws
+    InvalidCastException otherwise (surfaced as AL runtime error).
+  tests:
+    - tests/bucket-1/287-interface-typecheck
+
 page_declaration:
   layer: syntax
   category: object

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -81,8 +81,8 @@ interface_declaration:
     - tests/bucket-2/42-list-of-interface
     - tests/bucket-2/53-enum-interface
 
-interface_is_operator:
-  layer: runtime
+Interface.IsInterfaceOfType:
+  layer: runtime-api
   category: interface
   status: covered
   notes: >
@@ -93,8 +93,8 @@ interface_is_operator:
   tests:
     - tests/bucket-1/287-interface-typecheck
 
-interface_as_operator:
-  layer: runtime
+Interface.AsInterfaceOfType:
+  layer: runtime-api
   category: interface
   status: covered
   notes: >

--- a/tests/bucket-1/287-interface-typecheck/src/InterfaceTypecheckSrc.al
+++ b/tests/bucket-1/287-interface-typecheck/src/InterfaceTypecheckSrc.al
@@ -1,0 +1,54 @@
+/// Source codeunit exercising AL interface `is` and `as` operators — issue #972.
+/// BC emits myVar.IsInterfaceOfType(id) for `is` and myVar.AsInterfaceOfType(id) for `as`.
+
+interface ITC_Base
+{
+    procedure GetValue(): Integer;
+}
+
+interface ITC_Extended
+{
+    procedure GetValue(): Integer;
+    procedure GetExtra(): Integer;
+}
+
+codeunit 135001 "ITC BaseOnly" implements ITC_Base
+{
+    procedure GetValue(): Integer
+    begin
+        exit(10);
+    end;
+}
+
+codeunit 135002 "ITC Extended" implements ITC_Base, ITC_Extended
+{
+    procedure GetValue(): Integer
+    begin
+        exit(20);
+    end;
+
+    procedure GetExtra(): Integer
+    begin
+        exit(99);
+    end;
+}
+
+codeunit 135003 "ITC Source"
+{
+    /// Returns true if v also implements ITC_Extended (AL `is` operator).
+    procedure IsExtended(v: Interface ITC_Base): Boolean
+    begin
+        if v is ITC_Extended then
+            exit(true);
+        exit(false);
+    end;
+
+    /// Casts v to ITC_Extended and returns GetExtra() result (AL `as` operator).
+    procedure AsExtendedGetExtra(v: Interface ITC_Base): Integer
+    var
+        ext: Interface ITC_Extended;
+    begin
+        ext := v as ITC_Extended;
+        exit(ext.GetExtra());
+    end;
+}

--- a/tests/bucket-1/287-interface-typecheck/test/InterfaceTypecheckTest.al
+++ b/tests/bucket-1/287-interface-typecheck/test/InterfaceTypecheckTest.al
@@ -1,0 +1,57 @@
+codeunit 135004 "ITC Test"
+{
+    Subtype = Test;
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "ITC Source";
+        BaseOnly: Codeunit "ITC BaseOnly";
+        Extended: Codeunit "ITC Extended";
+
+    [Test]
+    procedure Is_BaseOnly_ReturnsFalse()
+    var
+        v: Interface ITC_Base;
+    begin
+        // [GIVEN] ITC_BaseOnly only implements ITC_Base
+        // [WHEN] `v is ITC_Extended` is checked
+        // [THEN] false is returned
+        v := BaseOnly;
+        Assert.IsFalse(Src.IsExtended(v), 'ITC_BaseOnly should not satisfy `is ITC_Extended`');
+    end;
+
+    [Test]
+    procedure Is_Extended_ReturnsTrue()
+    var
+        v: Interface ITC_Base;
+    begin
+        // [GIVEN] ITC_Extended implements both ITC_Base and ITC_Extended
+        // [WHEN] `v is ITC_Extended` is checked
+        // [THEN] true is returned
+        v := Extended;
+        Assert.IsTrue(Src.IsExtended(v), 'ITC_Extended should satisfy `is ITC_Extended`');
+    end;
+
+    [Test]
+    procedure As_Extended_ReturnsExtra()
+    var
+        v: Interface ITC_Base;
+    begin
+        // [GIVEN] ITC_Extended implements ITC_Extended
+        // [WHEN] v is cast with `as ITC_Extended` and GetExtra() is called
+        // [THEN] 99 is returned
+        v := Extended;
+        Assert.AreEqual(99, Src.AsExtendedGetExtra(v), 'GetExtra via `as ITC_Extended` must return 99');
+    end;
+
+    [Test]
+    procedure As_BaseOnly_ThrowsOnBadCast()
+    var
+        v: Interface ITC_Base;
+    begin
+        // [GIVEN] ITC_BaseOnly does not implement ITC_Extended
+        // [WHEN] v is cast with `as ITC_Extended`
+        // [THEN] an error is thrown (InvalidCastException wrapped as AL runtime error)
+        v := BaseOnly;
+        asserterror Src.AsExtendedGetExtra(v);
+    end;
+}


### PR DESCRIPTION
Closes #972

## What

Implements `IsInterfaceOfType(int)` and `AsInterfaceOfType(int)` on `MockInterfaceHandle`, enabling AL interface type-check operators:

- `if myVar is IBar then` → BC emits `myVar.IsInterfaceOfType(interfaceId)` → returns true/false
- `barVar := myVar as IBar` → BC emits `myVar.AsInterfaceOfType(interfaceId)` → returns handle or throws

## How

**Key insight**: BC generates `IsInterfaceOfType(int)` and `IsInterfaceMethod(int, int)` methods on every codeunit class that implements an AL interface. These methods are pure switch-case lookups over interface IDs — no BC runtime types involved.

Previously these methods were **removed** by the rewriter as "used by NavInterfaceHandle runtime". This PR keeps them instead (the existing `override`-stripping pass already handles the `override` modifier left without a base class).

Changes:
1. **`RoslynRewriter.cs`**: Remove `IsInterfaceOfType`/`IsInterfaceMethod` from the `ShouldRemoveMember` removal list.
2. **`MockCodeunitHandle`**: Add `GetUnderlyingInstance()` — lazily exposes the codeunit instance.
3. **`MockInterfaceHandle`**: Add `IsInterfaceOfType(int)` (reflects into the codeunit's BC-generated method), `AsInterfaceOfType(int)` (returns `this` or throws), and `GetUnderlyingObject()` helper.

## Tests

New suite `287-interface-typecheck` with 4 proving tests:
- `Is_BaseOnly_ReturnsFalse` — codeunit implementing only the base interface returns false
- `Is_Extended_ReturnsTrue` — codeunit implementing both interfaces returns true
- `As_Extended_ReturnsExtra` — cast succeeds and delegates to the extended method (returns 99)
- `As_BaseOnly_ThrowsOnBadCast` — cast to unsupported interface throws