### PR TITLE
fix: resolve CS0121 ambiguous ALTestFieldSafe overload — issue #1018

### DIFF
--- a/AlRunner/Runtime/MockRecordHandle.cs
+++ b/AlRunner/Runtime/MockRecordHandle.cs
@@ -1137,41 +1137,37 @@ public class MockRecordHandle
             throw new Exception($"TestField failed: field {fieldNo} in table {_tableId} expected '{expectedStr}' but was '{actualStr}'");
     }
 
-    /// <summary>Overload: TestField with bool value (transpiler pattern for Boolean fields).</summary>
-    public void ALTestFieldSafe(int fieldNo, NavType expectedType, bool expectedValue)
+    /// <summary>
+    /// ALTestFieldSafe(object) — catch-all overload that resolves the CS0121 ambiguity.
+    /// When the transpiler emits ALTestFieldSafe(fieldNo, NavType, NavValue-subtype), C#
+    /// cannot choose between the NavValue overload and the primitive overloads (bool/string/
+    /// int/Decimal18) because NavValue subtypes have implicit conversions. This single
+    /// object overload captures all remaining cases and unwraps to NavValue before
+    /// delegating — the same pattern used for MockFieldRef.ALSetRange(object).
+    /// CLR primitives (bool, int, Decimal18, string) are wrapped into the corresponding
+    /// NavValue so that NavValueToString produces locale-consistent output on both sides.
+    /// </summary>
+    public void ALTestFieldSafe(int fieldNo, NavType expectedType, object expectedValue)
     {
+        NavValue? wrapped = expectedValue switch
+        {
+            NavValue nv      => nv,
+            MockVariant mv   => (NavValue?)mv,   // uses MockVariant's improved implicit operator
+            bool   b         => NavBoolean.Create(b),
+            int    i         => NavInteger.Create(i),
+            Decimal18 d18    => NavDecimal.Create(d18),
+            string s         => new NavText(s),
+            _                => null
+        };
+        if (wrapped != null)
+        {
+            ALTestFieldSafe(fieldNo, expectedType, wrapped);
+            return;
+        }
+        // Ultimate fallback: compare via raw ToString() (covers any edge types)
         var actual = GetFieldValueSafe(fieldNo, expectedType);
         var actualStr = NavValueToString(actual);
-        var expectedStr = expectedValue.ToString();
-        if (actualStr != expectedStr)
-            throw new Exception($"TestField failed: field {fieldNo} in table {_tableId} expected '{expectedStr}' but was '{actualStr}'");
-    }
-
-    /// <summary>Overload: TestField with string value (Text/Code fields).</summary>
-    public void ALTestFieldSafe(int fieldNo, NavType expectedType, string expectedValue)
-    {
-        var actual = GetFieldValueSafe(fieldNo, expectedType);
-        var actualStr = NavValueToString(actual);
-        if (actualStr != expectedValue)
-            throw new Exception($"TestField failed: field {fieldNo} in table {_tableId} expected '{expectedValue}' but was '{actualStr}'");
-    }
-
-    /// <summary>Overload: TestField with int value (Integer fields).</summary>
-    public void ALTestFieldSafe(int fieldNo, NavType expectedType, int expectedValue)
-    {
-        var actual = GetFieldValueSafe(fieldNo, expectedType);
-        var actualStr = NavValueToString(actual);
-        var expectedStr = expectedValue.ToString();
-        if (actualStr != expectedStr)
-            throw new Exception($"TestField failed: field {fieldNo} in table {_tableId} expected '{expectedStr}' but was '{actualStr}'");
-    }
-
-    /// <summary>Overload: TestField with Decimal18 value (Decimal fields).</summary>
-    public void ALTestFieldSafe(int fieldNo, NavType expectedType, Decimal18 expectedValue)
-    {
-        var actual = GetFieldValueSafe(fieldNo, expectedType);
-        var actualStr = NavValueToString(actual);
-        var expectedStr = NavValueToString(NavDecimal.Create(expectedValue));
+        var expectedStr = expectedValue?.ToString() ?? "";
         if (actualStr != expectedStr)
             throw new Exception($"TestField failed: field {fieldNo} in table {_tableId} expected '{expectedStr}' but was '{actualStr}'");
     }
@@ -1188,22 +1184,13 @@ public class MockRecordHandle
         ALTestFieldSafe(fieldNo, expectedType, expectedValue);
     }
 
-    /// <summary>Overload: TestField with DataError level and string value.</summary>
-    public void ALTestField(DataError errorLevel, int fieldNo, NavType expectedType, string expectedValue)
+    /// <summary>
+    /// ALTestField(DataError, int, NavType, object) — catch-all DataError overload, same ambiguity
+    /// fix as ALTestFieldSafe(object). Delegates via the object overload.
+    /// </summary>
+    public void ALTestField(DataError errorLevel, int fieldNo, NavType expectedType, object expectedValue)
     {
         ALTestFieldSafe(fieldNo, expectedType, expectedValue);
-    }
-
-    /// <summary>Overload: TestField with DataError level and int value.</summary>
-    public void ALTestField(DataError errorLevel, int fieldNo, NavType expectedType, int expectedValue)
-    {
-        ALTestFieldSafe(fieldNo, expectedType, expectedValue);
-    }
-
-    /// <summary>Overload: TestField with DataError level and Decimal18 value.</summary>
-    public void ALTestField(DataError errorLevel, int fieldNo, NavType expectedType, Decimal18 expectedValue)
-    {
-        ALTestFieldSafe(fieldNo, expectedType, expectedValue);  // delegates to Decimal18 overload
     }
 
     /// <summary>

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -7067,8 +7067,15 @@ Table.TestField:
   tests:
     - tests/bucket-1/27-testfield-error
     - tests/bucket-1/54-testfield-enum
+    - tests/bucket-1/288-testfield-navvalue-overload
     - tests/bucket-2/100-testfield-value
-  notes: overloads=26; non-empty check, enum value comparison, and scalar value comparison (Text/Code/Integer/Decimal) covered
+  notes: >
+    overloads=26; non-empty check, enum value comparison, and scalar value comparison
+    (Text/Code/Integer/Decimal/Boolean) covered. CS0121 ambiguity between NavValue and
+    primitive overloads (bool/string/int/Decimal18) resolved via a single object catch-all
+    in ALTestFieldSafe — same pattern as MockFieldRef.ALSetRange(object) (issue #1018).
+    CLR primitives are wrapped to the matching NavValue type before comparison so that
+    NavValueToString produces locale-consistent output on both sides.
 
 Table.TransferFields:
   layer: runtime-api

--- a/tests/bucket-1/288-testfield-navvalue-overload/src/TestFieldNavValueSrc.al
+++ b/tests/bucket-1/288-testfield-navvalue-overload/src/TestFieldNavValueSrc.al
@@ -1,0 +1,15 @@
+/// Table used by the TestField NavValue-subtype overload test suite.
+/// Exercises Record.TestField(FieldNo, Value) where Value is a NavValue subtype
+/// (e.g. NavInteger) — the pattern that triggered CS0121 ambiguity.
+table 161000 "TFNav Record"
+{
+    fields
+    {
+        field(1; Id; Integer) { }
+        field(2; Qty; Integer) { }
+        field(3; Name; Text[100]) { }
+        field(4; Amt; Decimal) { }
+        field(5; Flag; Boolean) { }
+    }
+    keys { key(PK; Id) { Clustered = true; } }
+}

--- a/tests/bucket-1/288-testfield-navvalue-overload/test/TestFieldNavValueTest.al
+++ b/tests/bucket-1/288-testfield-navvalue-overload/test/TestFieldNavValueTest.al
@@ -1,0 +1,205 @@
+/// Tests for Record.TestField(Field, Value) where Value is stored in a typed
+/// variable (Integer, Decimal, Text, Boolean) — the transpiler emits a NavValue
+/// subtype (NavInteger, NavDecimal, etc.) which previously caused CS0121 ambiguous
+/// overload errors on ALTestFieldSafe. Regression test for issue #1018.
+codeunit 161001 "TFNav Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    // ------------------------------------------------------------------
+    // Integer field — positive case: value matches, no error
+    // ------------------------------------------------------------------
+
+    [Test]
+    procedure TestField_Integer_MatchingValue_NoError()
+    var
+        Rec: Record "TFNav Record";
+        Expected: Integer;
+    begin
+        // [GIVEN] A record with Qty = 42
+        Rec.Init();
+        Rec.Id := 1;
+        Rec.Qty := 42;
+        Rec.Insert(false);
+
+        // [WHEN] TestField is called with the same integer value in a typed variable
+        // The transpiler emits ALTestFieldSafe(fieldNo, NavType.Integer, navIntegerVar)
+        // which triggered CS0121 ambiguity between NavValue and int overloads.
+        Expected := 42;
+        Rec.TestField(Qty, Expected);
+
+        // [THEN] No error is raised — value matches
+        Assert.IsTrue(true, 'TestField must not raise an error when Integer field matches the expected value');
+    end;
+
+    // ------------------------------------------------------------------
+    // Integer field — negative case: value mismatch, error expected
+    // ------------------------------------------------------------------
+
+    [Test]
+    procedure TestField_Integer_MismatchValue_RaisesError()
+    var
+        Rec: Record "TFNav Record";
+        Expected: Integer;
+    begin
+        // [GIVEN] A record with Qty = 99
+        Rec.Init();
+        Rec.Id := 2;
+        Rec.Qty := 99;
+        Rec.Insert(false);
+
+        // [WHEN] TestField is called with a different integer value in a typed variable
+        Expected := 7;
+
+        // [THEN] An error is raised for the value mismatch
+        asserterror Rec.TestField(Qty, Expected);
+        Assert.ExpectedError('TestField failed');
+    end;
+
+    // ------------------------------------------------------------------
+    // Text field — positive case: value matches, no error
+    // ------------------------------------------------------------------
+
+    [Test]
+    procedure TestField_Text_MatchingValue_NoError()
+    var
+        Rec: Record "TFNav Record";
+        Expected: Text[100];
+    begin
+        // [GIVEN] A record with Name = 'Acme'
+        Rec.Init();
+        Rec.Id := 3;
+        Rec.Name := 'Acme';
+        Rec.Insert(false);
+
+        // [WHEN] TestField is called with the same text value in a typed variable
+        Expected := 'Acme';
+        Rec.TestField(Name, Expected);
+
+        // [THEN] No error is raised
+        Assert.IsTrue(true, 'TestField must not raise an error when Text field matches the expected value');
+    end;
+
+    // ------------------------------------------------------------------
+    // Text field — negative case: value mismatch, error expected
+    // ------------------------------------------------------------------
+
+    [Test]
+    procedure TestField_Text_MismatchValue_RaisesError()
+    var
+        Rec: Record "TFNav Record";
+        Expected: Text[100];
+    begin
+        // [GIVEN] A record with Name = 'Acme'
+        Rec.Init();
+        Rec.Id := 4;
+        Rec.Name := 'Acme';
+        Rec.Insert(false);
+
+        // [WHEN] TestField is called with a different text value in a typed variable
+        Expected := 'Beta';
+
+        // [THEN] An error is raised
+        asserterror Rec.TestField(Name, Expected);
+        Assert.ExpectedError('TestField failed');
+    end;
+
+    // ------------------------------------------------------------------
+    // Decimal field — positive case: value matches, no error
+    // ------------------------------------------------------------------
+
+    [Test]
+    procedure TestField_Decimal_MatchingValue_NoError()
+    var
+        Rec: Record "TFNav Record";
+        Expected: Decimal;
+    begin
+        // [GIVEN] A record with Amt = 3.14
+        Rec.Init();
+        Rec.Id := 5;
+        Rec.Amt := 3.14;
+        Rec.Insert(false);
+
+        // [WHEN] TestField is called with the same decimal value in a typed variable
+        Expected := 3.14;
+        Rec.TestField(Amt, Expected);
+
+        // [THEN] No error is raised
+        Assert.IsTrue(true, 'TestField must not raise an error when Decimal field matches the expected value');
+    end;
+
+    // ------------------------------------------------------------------
+    // Decimal field — negative case: value mismatch, error expected
+    // ------------------------------------------------------------------
+
+    [Test]
+    procedure TestField_Decimal_MismatchValue_RaisesError()
+    var
+        Rec: Record "TFNav Record";
+        Expected: Decimal;
+    begin
+        // [GIVEN] A record with Amt = 3.14
+        Rec.Init();
+        Rec.Id := 6;
+        Rec.Amt := 3.14;
+        Rec.Insert(false);
+
+        // [WHEN] TestField is called with a different decimal value in a typed variable
+        Expected := 9.99;
+
+        // [THEN] An error is raised
+        asserterror Rec.TestField(Amt, Expected);
+        Assert.ExpectedError('TestField failed');
+    end;
+
+    // ------------------------------------------------------------------
+    // Boolean field — positive case: value matches, no error
+    // ------------------------------------------------------------------
+
+    [Test]
+    procedure TestField_Boolean_MatchingValue_NoError()
+    var
+        Rec: Record "TFNav Record";
+        Expected: Boolean;
+    begin
+        // [GIVEN] A record with Flag = true
+        Rec.Init();
+        Rec.Id := 7;
+        Rec.Flag := true;
+        Rec.Insert(false);
+
+        // [WHEN] TestField is called with the same boolean value in a typed variable
+        Expected := true;
+        Rec.TestField(Flag, Expected);
+
+        // [THEN] No error is raised
+        Assert.IsTrue(true, 'TestField must not raise an error when Boolean field matches the expected value');
+    end;
+
+    // ------------------------------------------------------------------
+    // Boolean field — negative case: value mismatch, error expected
+    // ------------------------------------------------------------------
+
+    [Test]
+    procedure TestField_Boolean_MismatchValue_RaisesError()
+    var
+        Rec: Record "TFNav Record";
+        Expected: Boolean;
+    begin
+        // [GIVEN] A record with Flag = true
+        Rec.Init();
+        Rec.Id := 8;
+        Rec.Flag := true;
+        Rec.Insert(false);
+
+        // [WHEN] TestField is called with false (mismatch) in a typed variable
+        Expected := false;
+
+        // [THEN] An error is raised
+        asserterror Rec.TestField(Flag, Expected);
+        Assert.ExpectedError('TestField failed');
+    end;
+}


### PR DESCRIPTION
Closes #1018

## Summary
- Replace the four type-specific `ALTestFieldSafe` overloads (`bool`/`string`/`int`/`Decimal18`) and three type-specific `ALTestField(DataError,...)` overloads with single `object` catch-alls that unwrap CLR primitives to the correct `NavValue` type before delegating to the canonical `NavValue` implementation
- Same proven pattern as the `MockFieldRef.ALSetRange(object)` fix: wrap `bool`→`NavBoolean`, `int`→`NavInteger`, `Decimal18`→`NavDecimal`, `string`→`NavText` so `NavValueToString` produces locale-consistent output on both sides of the comparison
- Add test suite `288-testfield-navvalue-overload` with 8 proving tests (positive + negative cases for Integer, Text, Decimal, Boolean fields passed via typed variables — the exact pattern that triggered CS0121)
- Update `docs/coverage.yaml` for `Table.TestField`

## Test plan
- [x] New test suite `288-testfield-navvalue-overload` — 8/8 tests pass (positive + negative for all 4 field types)
- [x] Bucket-1: 1529 passed (pre-existing 2 failures are DT2Time timezone tests unrelated to this change)
- [x] Bucket-2 pre-existing failure confirmed to pre-date this branch (missing AppA/AppB helpers)