### PR TITLE
feat: add missing JsonObject/JsonArray overloads — issue #1025

### DIFF
--- a/AlRunner/Runtime/MockJsonHelper.cs
+++ b/AlRunner/Runtime/MockJsonHelper.cs
@@ -418,6 +418,25 @@ public static class MockJsonHelper
     }
 
     /// <summary>
+    /// Replacement for NavJsonObject.ALGetText(key, requireValueExists).
+    /// Returns the string value of the named property, with optional existence check.
+    /// AL: JsonObject.GetText('key', true)  →  MockJsonHelper.GetText(token, key, requireValueExists)
+    /// </summary>
+    public static NavText GetText(NavJsonToken token, string key, bool requireValueExists)
+    {
+        var backingToken = GetBackingToken(token);
+        if (backingToken is not JObject obj)
+            throw new Exception("The JSON token is not an object.");
+        if (!obj.TryGetValue(key, out var val))
+        {
+            if (requireValueExists)
+                throw new Exception($"The JSON object does not contain a property with the name '{key}'.");
+            return new NavText(string.Empty);
+        }
+        return new NavText(val.Value<string>() ?? string.Empty);
+    }
+
+    /// <summary>
     /// Replacement for NavJsonObject.ALGetInteger(key).
     /// Returns the integer value of the named property.
     /// AL: JsonObject.GetInteger('key')  →  MockJsonHelper.GetInteger(token, key)
@@ -461,6 +480,24 @@ public static class MockJsonHelper
             throw new Exception($"The JSON object does not contain a property with the name '{key}'.");
         if (val is not JObject jObj)
             throw new Exception($"The value of JSON property '{key}' is not an object.");
+        return CreateJsonToken<NavJsonObject>(jObj);
+    }
+
+    /// <summary>
+    /// Replacement for NavJsonArray.ALGetObject(index).
+    /// Returns the JsonObject element at the given integer index.
+    /// AL: JsonArray.GetObject(0)  →  MockJsonHelper.GetObject(token, 0)
+    /// </summary>
+    public static NavJsonObject GetObject(NavJsonToken token, int index)
+    {
+        var backingToken = GetBackingToken(token);
+        if (backingToken is not JArray arr)
+            throw new Exception("The JSON token is not an array.");
+        if (index < 0 || index >= arr.Count)
+            throw new Exception($"The index {index} is outside the bounds of the JSON array.");
+        var elem = arr[index];
+        if (elem is not JObject jObj)
+            throw new Exception($"The element at index {index} is not a JSON object.");
         return CreateJsonToken<NavJsonObject>(jObj);
     }
 

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -3335,8 +3335,10 @@ JsonArray.GetObject:
   layer: runtime-api
   category: JsonArray
   status: covered
-  tests: tests/bucket-2/187-jsonarray-typed-getters
-  notes: overloads=1. Indirectly covered via JsonArray.Get + JsonToken.AsObject(). The BC 21+ typed GetObject(idx) overload is not present in the AL 16.2 compiler bundled with the runner.
+  tests:
+    - tests/bucket-2/187-jsonarray-typed-getters
+    - tests/bucket-1/100-json-overloads
+  notes: overloads=2. Integer-indexed overload GetObject(idx) now covered via MockJsonHelper.GetObject(token, int) — issue #1025.
 
 JsonArray.GetOption:
   layer: runtime-api
@@ -3561,9 +3563,10 @@ JsonObject.GetText:
   layer: runtime-api
   category: JsonObject
   status: covered
-  notes: overloads=1; rewriter redirects ALGetText to MockJsonHelper.GetText
+  notes: overloads=2; rewriter redirects ALGetText to MockJsonHelper.GetText; 2-arg bool overload GetText(key, requireValueExists) now covered — issue #1025
   tests:
     - tests/bucket-1/268-jsonobject-methods
+    - tests/bucket-1/100-json-overloads
 
 JsonObject.GetTime:
   layer: runtime-api

--- a/tests/bucket-1/100-json-overloads/src/JsonOverloadsSrc.al
+++ b/tests/bucket-1/100-json-overloads/src/JsonOverloadsSrc.al
@@ -1,5 +1,5 @@
 /// Source helpers for JsonObject.GetText(key, bool) and JsonArray.GetObject(int) overloads.
-codeunit 161000 "JSON Overloads Src"
+codeunit 162000 "JSON Overloads Src"
 {
     // ── JsonObject.GetText(key, requireValueExists) ────────────────────────────
 

--- a/tests/bucket-1/100-json-overloads/src/JsonOverloadsSrc.al
+++ b/tests/bucket-1/100-json-overloads/src/JsonOverloadsSrc.al
@@ -1,0 +1,17 @@
+/// Source helpers for JsonObject.GetText(key, bool) and JsonArray.GetObject(int) overloads.
+codeunit 161000 "JSON Overloads Src"
+{
+    // ── JsonObject.GetText(key, requireValueExists) ────────────────────────────
+
+    procedure GetTextWithBool(Obj: JsonObject; PropName: Text; RequireValueExists: Boolean): Text
+    begin
+        exit(Obj.GetText(PropName, RequireValueExists));
+    end;
+
+    // ── JsonArray.GetObject(index) ─────────────────────────────────────────────
+
+    procedure GetObjectByIndex(Arr: JsonArray; Idx: Integer): JsonObject
+    begin
+        exit(Arr.GetObject(Idx));
+    end;
+}

--- a/tests/bucket-1/100-json-overloads/test/JsonOverloadsTest.al
+++ b/tests/bucket-1/100-json-overloads/test/JsonOverloadsTest.al
@@ -1,4 +1,4 @@
-codeunit 161001 "JSON Overloads Test"
+codeunit 162001 "JSON Overloads Test"
 {
     Subtype = Test;
 

--- a/tests/bucket-1/100-json-overloads/test/JsonOverloadsTest.al
+++ b/tests/bucket-1/100-json-overloads/test/JsonOverloadsTest.al
@@ -1,0 +1,84 @@
+codeunit 161001 "JSON Overloads Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "JSON Overloads Src";
+
+    // ── JsonObject.GetText(key, true) — key exists ────────────────────────────
+
+    [Test]
+    procedure GetText_WithRequireTrue_KeyExists_ReturnsValue()
+    var
+        Obj: JsonObject;
+    begin
+        Obj.Add('name', 'Alice');
+        Assert.AreEqual('Alice', Src.GetTextWithBool(Obj, 'name', true),
+            'GetText(key, true) must return the property value when key exists');
+    end;
+
+    // ── JsonObject.GetText(key, true) — key missing ───────────────────────────
+
+    [Test]
+    procedure GetText_WithRequireTrue_KeyMissing_ThrowsError()
+    var
+        Obj: JsonObject;
+    begin
+        asserterror Src.GetTextWithBool(Obj, 'missing', true);
+        Assert.ExpectedError('');
+    end;
+
+    // ── JsonObject.GetText(key, false) — key missing returns empty ────────────
+
+    [Test]
+    procedure GetText_WithRequireFalse_KeyMissing_ReturnsEmpty()
+    var
+        Obj: JsonObject;
+        Result: Text;
+    begin
+        Result := Src.GetTextWithBool(Obj, 'missing', false);
+        Assert.AreEqual('', Result, 'GetText(key, false) must return empty text when key is missing');
+    end;
+
+    // ── JsonObject.GetText(key, false) — key exists returns value ─────────────
+
+    [Test]
+    procedure GetText_WithRequireFalse_KeyExists_ReturnsValue()
+    var
+        Obj: JsonObject;
+    begin
+        Obj.Add('city', 'Berlin');
+        Assert.AreEqual('Berlin', Src.GetTextWithBool(Obj, 'city', false),
+            'GetText(key, false) must return value when key exists');
+    end;
+
+    // ── JsonArray.GetObject(index) — returns object at index ─────────────────
+
+    [Test]
+    procedure GetObject_ByIndex_ReturnsCorrectObject()
+    var
+        Arr: JsonArray;
+        Inner: JsonObject;
+        Got: JsonObject;
+        Token: JsonToken;
+    begin
+        Inner.Add('id', 42);
+        Arr.Add(Inner);
+        Got := Src.GetObjectByIndex(Arr, 0);
+        Got.Get('id', Token);
+        Assert.AreEqual(42, Token.AsValue().AsInteger(),
+            'GetObject(0) must return the object stored at index 0');
+    end;
+
+    // ── JsonArray.GetObject(index) — out of bounds throws ────────────────────
+
+    [Test]
+    procedure GetObject_ByIndex_OutOfBounds_ThrowsError()
+    var
+        Arr: JsonArray;
+    begin
+        asserterror Src.GetObjectByIndex(Arr, 0);
+        Assert.ExpectedError('');
+    end;
+}


### PR DESCRIPTION
Closes #1025

## Summary
- Add `MockJsonHelper.GetText(token, key, bool)` overload for `JsonObject.GetText(Text, Boolean)` — when key missing and `requireValueExists=true` it throws; when `false` it returns empty text
- Add `MockJsonHelper.GetObject(token, int)` overload for `JsonArray.GetObject(Integer)` — extracts element at integer index from backing JArray and wraps in NavJsonObject
- Both overloads were missing, causing CS1501/CS1503 from the rewriter's correct prepend-receiver dispatch; no rewriter changes needed

## Test plan
- [x] New tests for JsonObject.GetText with bool parameter (positive: returns value when key exists; negative: errors when key missing and requireValueExists=true; plus false-variant returning empty)
- [x] New tests for JsonArray.GetObject with integer index (positive: returns correct nested object value; negative: out-of-bounds throws)
- [x] All 6 new tests pass (1527 passed vs 1521 baseline in bucket-1)
- [x] Bucket-1 pre-existing failures (DT2Time x2) are confirmed pre-existing and unchanged
- [x] docs/coverage.yaml updated for both JsonArray.GetObject and JsonObject.GetText