### PR TITLE
feat: add 4-arg ALUploadIntoStream overload — issue #1021

### DIFF
--- a/AlRunner.Tests/AlRunner.Tests.csproj
+++ b/AlRunner.Tests/AlRunner.Tests.csproj
@@ -32,6 +32,13 @@
     <Reference Include="Microsoft.Dynamics.Nav.CodeAnalysis">
       <HintPath>../AlRunner/bin/$(Configuration)/$(TargetFramework)/Microsoft.Dynamics.Nav.CodeAnalysis.dll</HintPath>
     </Reference>
+    <!-- BC runtime types needed for MockFile/MockInStream unit tests (issue #1021) -->
+    <Reference Include="Microsoft.Dynamics.Nav.Types">
+      <HintPath>../AlRunner/bin/$(Configuration)/$(TargetFramework)/Microsoft.Dynamics.Nav.Types.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Dynamics.Nav.Ncl">
+      <HintPath>../AlRunner/bin/$(Configuration)/$(TargetFramework)/Microsoft.Dynamics.Nav.Ncl.dll</HintPath>
+    </Reference>
   </ItemGroup>
 
   <!-- Copy BC compiler and service tier DLLs from AlRunner output so in-process tests can find them -->

--- a/AlRunner.Tests/MockFile4ArgTests.cs
+++ b/AlRunner.Tests/MockFile4ArgTests.cs
@@ -1,0 +1,60 @@
+using AlRunner.Runtime;
+using Microsoft.Dynamics.Nav.Runtime;
+using Microsoft.Dynamics.Nav.Types;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// Unit tests for the 4-argument C# overload of MockFile.ALUploadIntoStream.
+///
+/// The 4-arg AL form UploadIntoStream(DialogTitle, Filter, FileName, InStream)
+/// (without the optional 'fromFolder' parameter) is emitted by newer BC versions
+/// as a 4-arg C# call: ALUploadIntoStream(title, filter, ref fileName, ref inStream).
+/// Without the matching 4-param C# overload, the runner fails with CS1501.
+///
+/// Issue: #1021
+/// </summary>
+public class MockFile4ArgTests
+{
+    /// <summary>
+    /// Positive: 4-arg ALUploadIntoStream compiles and returns false in standalone mode.
+    /// This is a no-op stub test — the entire claim is "this overload exists and does not crash."
+    /// </summary>
+    [Fact]
+    public void ALUploadIntoStream_4Arg_ReturnsFalse()
+    {
+        var fileName = NavText.Empty;
+        var byRefFileName = new ByRef<NavText>(() => fileName, v => fileName = v);
+        var inStream = new MockInStream();
+
+        bool result = MockFile.ALUploadIntoStream(
+            "Upload",
+            "*.txt",
+            byRefFileName,
+            inStream);
+
+        Assert.False(result, "4-arg ALUploadIntoStream must return false in standalone mode");
+    }
+
+    /// <summary>
+    /// Positive: 4-arg ALUploadIntoStream clears FileName to empty (stub behaviour).
+    /// This proves the stub is not a no-op that ignores its arguments — it actively
+    /// clears FileName, which is the correct behaviour for a cancelled/stubbed upload.
+    /// </summary>
+    [Fact]
+    public void ALUploadIntoStream_4Arg_ClearsFileName()
+    {
+        var fileName = new NavText("preset-value");
+        var byRefFileName = new ByRef<NavText>(() => fileName, v => fileName = v);
+        var inStream = new MockInStream();
+
+        MockFile.ALUploadIntoStream(
+            "Upload",
+            "*.txt",
+            byRefFileName,
+            inStream);
+
+        Assert.Equal(NavText.Empty, fileName);
+    }
+}

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -325,7 +325,7 @@ test executor that needs no BC service tier, Docker, SQL Server, or license.
   round-trips text. HttpResponseMessage default status is 200. HttpHeaders supports
   Add/Contains/Remove. HttpClient.Send/Get/Post/Put/Delete/Patch throw
   NotSupportedException (use AL interface injection for HTTP-dependent code).
-- File dialog stubs: UploadIntoStream (5-arg and 6-arg), DownloadFromStream (4 overloads) —
+- File dialog stubs: UploadIntoStream (4-arg, 5-arg, 6-arg), DownloadFromStream (4 overloads) —
   all return false in standalone mode (no client UI). Compile and run without error.
 - Library - Variable Storage (codeunit 131004) — Enqueue, DequeueText, DequeueInteger,
   DequeueDecimal, DequeueBoolean, DequeueDate, DequeueVariant, AssertEmpty, Clear, IsEmpty

--- a/AlRunner/Runtime/MockFile.cs
+++ b/AlRunner/Runtime/MockFile.cs
@@ -233,6 +233,17 @@ public class MockFile
     }
 
     /// <summary>
+    /// 4-arg AL form: UploadIntoStream(DialogTitle, Filter, FileName, InStream).
+    /// Newer BC versions emit this without DataError, fromFolder, or Guid args.
+    /// Always returns false (no UI in standalone mode).
+    /// </summary>
+    public static bool ALUploadIntoStream(string dialogTitle, string fromFilter, ByRef<NavText> fileName, MockInStream inStream)
+    {
+        fileName.Value = NavText.Empty;
+        return false;
+    }
+
+    /// <summary>
     /// ALDownloadFromStream — BC standalone DownloadFromStream maps here as a static.
     /// BC emits (scope, MockInStream inStream, title, folder, filter, ByRef&lt;NavText&gt; fileName, NavText extra).
     /// No-op (no UI in standalone mode).

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -2665,7 +2665,8 @@ File.UploadIntoStream:
   layer: runtime-api
   category: File
   status: covered
-  notes: overloads=2
+  notes: overloads=3; 5-arg and 6-arg (with/without Guid) for BC≤25 5-param AL form; 4-arg (no DataError/Folder/Guid) for newer BC 4-param AL form — all no-op stubs returning false
+  test: AlRunner.Tests/MockFile4ArgTests.cs
 
 File.View:
   layer: runtime-api

--- a/tests/bucket-1/160-upload-into-stream-stubs/src/UploadIntoStreamSrc.al
+++ b/tests/bucket-1/160-upload-into-stream-stubs/src/UploadIntoStreamSrc.al
@@ -1,0 +1,16 @@
+/// Helper exercising UploadIntoStream stub behaviour.
+/// BC 26+ compiles UploadIntoStream(Title, Folder, Filter, FileName, InStream) to a
+/// 6-arg C# call.  Newer BC also emits a 4-arg form (no Folder/DataError/Guid) —
+/// that path is covered at the C# level in AlRunner.Tests/MockFile4ArgTests.cs
+/// (issue #1021).
+codeunit 160002 "UIS Src"
+{
+    /// <summary>
+    /// Calls the 5-arg AL form and returns both the Boolean result and the
+    /// post-call value of FileName so the test can assert them separately.
+    /// </summary>
+    procedure CallUploadIntoStream(var FileName: Text; var InStr: InStream): Boolean
+    begin
+        exit(UploadIntoStream('Upload', '', '*.txt', FileName, InStr));
+    end;
+}

--- a/tests/bucket-1/160-upload-into-stream-stubs/test/UploadIntoStreamTest.al
+++ b/tests/bucket-1/160-upload-into-stream-stubs/test/UploadIntoStreamTest.al
@@ -1,0 +1,46 @@
+/// Tests for UploadIntoStream stub behaviour (issue #1021).
+/// The 5-arg AL form (Title, Folder, Filter, FileName, InStream) is tested here.
+/// The 4-arg AL form (Title, Filter, FileName, InStream) — available in newer BC
+/// versions — is covered at the C# level in AlRunner.Tests/MockFile4ArgTests.cs.
+codeunit 160003 "UIS Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    // -----------------------------------------------------------------------
+    // Positive: UploadIntoStream returns false in standalone mode.
+    // No client/UI is available, so the stub must always return false.
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure UploadIntoStream_ReturnsFalse_NoThrow()
+    var
+        Src: Codeunit "UIS Src";
+        InStr: InStream;
+        FileName: Text;
+    begin
+        // The entire claim: compiles and returns false (no crash).
+        Assert.IsFalse(Src.CallUploadIntoStream(FileName, InStr),
+            'UploadIntoStream must return false in standalone mode (no client)');
+    end;
+
+    // -----------------------------------------------------------------------
+    // Positive: FileName is empty after the call (stub clears it).
+    // This proves the stub actively touches FileName, not just that it runs.
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure UploadIntoStream_ClearsFileName()
+    var
+        Src: Codeunit "UIS Src";
+        InStr: InStream;
+        FileName: Text;
+    begin
+        FileName := 'preset-value';
+        Src.CallUploadIntoStream(FileName, InStr);
+        Assert.AreEqual('', FileName,
+            'UploadIntoStream stub must clear FileName (no upload in standalone mode)');
+    end;
+}


### PR DESCRIPTION
Closes #1021

## Summary
- Add missing 4-param C# overload `MockFile.ALUploadIntoStream(title, filter, ByRef<NavText> fileName, MockInStream inStream)` for the 4-arg AL `UploadIntoStream(DialogTitle, Filter, FileName, InStream)` form emitted by newer BC versions (no DataError/Folder/Guid args)
- No-op stub (file I/O out of scope) — returns false, clears filename
- Add `Microsoft.Dynamics.Nav.Types` and `Microsoft.Dynamics.Nav.Ncl` compile-time references to `AlRunner.Tests` to enable direct BC runtime type usage in unit tests

## Test plan
- [x] RED: `MockFile4ArgTests` failed to compile before the fix (CS1501: No overload for method 'ALUploadIntoStream' takes 4 arguments)
- [x] GREEN: Both `ALUploadIntoStream_4Arg_ReturnsFalse` and `ALUploadIntoStream_4Arg_ClearsFileName` pass after the fix
- [x] All 237 existing `AlRunner.Tests` tests continue to pass
- [x] `docs/coverage.yaml` updated — `File.UploadIntoStream` now documents 3 overloads
- [x] `--guide` output updated to list 4-arg form