### PR TITLE
docs: add overload-level coverage tracking to agent prompts

### DIFF
--- a/docs/agent-prompts/impl.md
+++ b/docs/agent-prompts/impl.md
@@ -48,6 +48,12 @@ Collisions → CS0101 build errors on all BC versions. IDs may repeat across buc
 
 Required doc updates:
 - docs/coverage.yaml — REQUIRED for every feature implemented (orchestrator blocks merge without it)
+  - Track at **overload level**: if a method has multiple overloads, each must have its own entry
+    (e.g. `File.UploadIntoStream (5-arg)` and `File.UploadIntoStream (6-arg)` are separate entries).
+    The auto-generated coverage scan only sees method names, not overloads — telemetry issues
+    often surface missing overloads that the scan missed. Always add the specific overload you implemented.
+  - When implementing a fix surfaced by telemetry (compilation gaps, runtime gaps), add a coverage
+    entry even if the parent method already appears as "covered" — the overload was the gap.
 - README.md, PrintGuide() in AlRunner/Program.cs, docs/limitations.md — only if behavior changes
 - Do NOT edit CHANGELOG.md
 

--- a/docs/agent-prompts/orchestrator.md
+++ b/docs/agent-prompts/orchestrator.md
@@ -30,6 +30,8 @@ For each PR:
 4. coverage.yaml NOT in diff (PR adds tests/coverage) → check existing comments; if not yet posted:
      "Please update docs/coverage.yaml to mark the implemented gap as covered. Required before merging."
    Do NOT merge until coverage.yaml is updated.
+   Coverage must be tracked at **overload level** — if the PR adds a new method overload,
+   it needs its own entry (e.g. `JsonObject.GetText (2-arg with bool)` separate from the base `GetText`).
 5. CI green + no CHANGELOG + coverage.yaml updated:
    - CI in progress:  gh pr merge <N> --auto --squash --repo StefanMaron/BusinessCentral.AL.Runner
    - CI complete:     gh pr merge <N> --squash --repo StefanMaron/BusinessCentral.AL.Runner


### PR DESCRIPTION
## Summary
- Agent prompts (impl + orchestrator) now require overload-level entries in `coverage.yaml`
- Telemetry-surfaced gaps often involve missing method overloads that the auto-generated scan misses
- Implementation agents must add specific overload entries even when the parent method shows as "covered"

## Test plan
- [x] No code changes — documentation only