### PR TITLE
feat: auto-detect .alpackages folder when --packages not specified — issue #1033

### DIFF
--- a/AlRunner.Tests/PipelineTests.cs
+++ b/AlRunner.Tests/PipelineTests.cs
@@ -572,4 +572,102 @@ namespace AlRunnerGenerated {
         Assert.True(result.Passed > 0);
         Assert.Equal(0, result.Failed);
     }
+
+    // ─── ResolvePackagePaths auto-detection (issue #1033) ──────────────────────
+
+    [Fact]
+    public void ResolvePackagePaths_NullInputs_ReturnsEmpty()
+    {
+        // No explicit paths, no input paths → no packages discovered
+        var result = AlTranspiler.ResolvePackagePaths(null, null);
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void ResolvePackagePaths_AutoDiscovers_AlpackagesInInputDir()
+    {
+        // Positive: .alpackages next to the input dir is auto-discovered
+        var tmp = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        var srcDir = Path.Combine(tmp, "src");
+        var pkgDir = Path.Combine(tmp, "src", ".alpackages");
+        Directory.CreateDirectory(srcDir);
+        Directory.CreateDirectory(pkgDir);
+
+        // Plant a dummy .app file so the directory qualifies
+        File.WriteAllBytes(Path.Combine(pkgDir, "Dummy.app"), new byte[] { 0x50, 0x4B });
+
+        try
+        {
+            var result = AlTranspiler.ResolvePackagePaths(null, new List<string> { srcDir });
+            Assert.Single(result);
+            Assert.Equal(Path.GetFullPath(pkgDir), result[0], StringComparer.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            Directory.Delete(tmp, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ResolvePackagePaths_AutoDiscovers_AlpackagesInParentDir()
+    {
+        // Positive: .alpackages in the parent of the input dir is also found
+        var tmp = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        var srcDir = Path.Combine(tmp, "src");
+        var pkgDir = Path.Combine(tmp, ".alpackages");
+        Directory.CreateDirectory(srcDir);
+        Directory.CreateDirectory(pkgDir);
+        File.WriteAllBytes(Path.Combine(pkgDir, "Dummy.app"), new byte[] { 0x50, 0x4B });
+
+        try
+        {
+            var result = AlTranspiler.ResolvePackagePaths(null, new List<string> { srcDir });
+            Assert.Single(result);
+            Assert.Equal(Path.GetFullPath(pkgDir), result[0], StringComparer.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            Directory.Delete(tmp, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ResolvePackagePaths_NoAlpackagesDir_ReturnsEmpty()
+    {
+        // Negative: when no .alpackages folder exists, nothing is discovered
+        var tmp = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        var srcDir = Path.Combine(tmp, "src");
+        Directory.CreateDirectory(srcDir);
+
+        try
+        {
+            var result = AlTranspiler.ResolvePackagePaths(null, new List<string> { srcDir });
+            Assert.Empty(result);
+        }
+        finally
+        {
+            Directory.Delete(tmp, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ResolvePackagePaths_ExplicitPaths_StillIncluded()
+    {
+        // When --packages is given explicitly, those paths are included in the result
+        var tmp = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        var pkgDir = Path.Combine(tmp, "mypkgs");
+        Directory.CreateDirectory(pkgDir);
+        File.WriteAllBytes(Path.Combine(pkgDir, "Dummy.app"), new byte[] { 0x50, 0x4B });
+
+        try
+        {
+            var result = AlTranspiler.ResolvePackagePaths(new List<string> { pkgDir }, null);
+            Assert.Single(result);
+            Assert.Equal(Path.GetFullPath(pkgDir), result[0], StringComparer.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            Directory.Delete(tmp, recursive: true);
+        }
+    }
 }

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -1353,7 +1353,7 @@ public static class AlTranspiler
         return defaults;
     }
 
-    private static List<string> ResolvePackagePaths(List<string>? explicitPaths, List<string>? inputPaths)
+    public static List<string> ResolvePackagePaths(List<string>? explicitPaths, List<string>? inputPaths)
     {
         var result = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -30,6 +30,7 @@ if (args.Length == 0 || args.Any(a => a is "-h" or "--help"))
     Console.Error.WriteLine("Options:");
     Console.Error.WriteLine("  --coverage            Show statement-level coverage report and write cobertura.xml");
     Console.Error.WriteLine("  --packages <dir>      Add symbol references from .app files in directory");
+    Console.Error.WriteLine("                        (auto-detected: .alpackages in/near source dirs when omitted)");
     Console.Error.WriteLine("  --stubs <dir>         Override dependency objects with stub AL files");
     Console.Error.WriteLine("  --dump-csharp         Print generated C# (before rewriting) and exit");
     Console.Error.WriteLine("  --dump-rewritten      Print rewritten C# (after rewriting) and exit");
@@ -463,8 +464,12 @@ AL interface and provide a mock implementation in the test.
 
 Step 1 — Run normally and note the gaps:
 ```
-al-runner --packages .alpackages ./src ./test
+al-runner ./src ./test
 ```
+If a `.alpackages` directory exists in or near your source paths, al-runner
+auto-detects it — no `--packages` flag required. Pass `--packages <dir>`
+explicitly only when the packages are in a non-standard location.
+
 If you see `Tip: use --stubs to provide stub AL files for unsupported dependencies`,
 one or more objects were excluded from compilation. Stubs can restore them.
 
@@ -867,74 +872,72 @@ public static class AlTranspiler
         );
 
         // --- Symbol reference support ---
-        // Only enable symbol references when --packages is explicitly provided.
-        // This avoids conflicts when compiling self-contained multi-project spikes from source.
+        // Always call ResolvePackagePaths so that .alpackages directories adjacent to
+        // the input paths are auto-discovered even when --packages is not specified.
         bool hasExplicitPackages = packagePaths != null && packagePaths.Count > 0;
-        var allPackagePaths = hasExplicitPackages ? ResolvePackagePaths(packagePaths, inputPaths) : new List<string>();
+        var allPackagePaths = ResolvePackagePaths(packagePaths, inputPaths);
+        bool hasAnyPackages = allPackagePaths.Count > 0;
+
+        if (!hasExplicitPackages && hasAnyPackages)
+            Log.Info($"Auto-detected package directories: {string.Join(", ", allPackagePaths)}");
+
         // Populated during the "load all packages" path for use in the reactive conflict resolver.
         var loadedPackageSpecs = new List<PackageSpec>();
         Microsoft.Dynamics.Nav.CodeAnalysis.ISymbolReferenceLoader? refLoader = null;
 
-        if (hasExplicitPackages)
+        if (hasAnyPackages)
         {
-            var depSpecs = DiscoverDependencies(inputPaths, forceResolve: true);
+            var depSpecs = DiscoverDependencies(inputPaths, forceResolve: hasExplicitPackages);
 
-            if (allPackagePaths.Count > 0)
+            Log.Info($"Symbol references: scanning {allPackagePaths.Count} package directories");
+            foreach (var p in allPackagePaths)
+                Log.Info($"  {p}");
+
+            refLoader = ReferenceLoaderFactory.CreateReferenceLoader(allPackagePaths);
+
+            if (depSpecs.Count > 0)
             {
-                Log.Info($"Symbol references: scanning {allPackagePaths.Count} package directories");
-                foreach (var p in allPackagePaths)
-                    Log.Info($"  {p}");
+                Log.Info($"Adding {depSpecs.Count} symbol reference specifications:");
+                foreach (var spec in depSpecs)
+                    Log.Info($"  {FormatSpec(spec)}");
 
-                refLoader = ReferenceLoaderFactory.CreateReferenceLoader(allPackagePaths);
-
-                if (depSpecs.Count > 0)
-                {
-                    Log.Info($"Adding {depSpecs.Count} symbol reference specifications:");
-                    foreach (var spec in depSpecs)
-                        Log.Info($"  {FormatSpec(spec)}");
-
-                    compilation = compilation
-                        .WithReferenceLoader(refLoader)
-                        .AddReferences(depSpecs.ToArray());
-                }
-                else
-                {
-                    // No explicit dependencies in app.json — load all .app files from
-                    // the packages directory as symbol references. This handles the BC
-                    // convention where Application/System dependencies are implicit.
-                    // PackageScanner deduplicates: first by GUID (keeping highest version),
-                    // then by (publisher+name+version) to eliminate self-duplicates that
-                    // would otherwise produce AL0275 "ambiguous reference" errors.
-                    Log.Info("No explicit dependencies found. Loading all .app packages as symbols...");
-
-                    var scannedSpecs = PackageScanner.ScanForSpecs(
-                        allPackagePaths,
-                        excludeGuid: appIdentity.AppId,
-                        excludeName: appIdentity.Name);
-
-                    loadedPackageSpecs.AddRange(scannedSpecs);
-
-                    if (loadedPackageSpecs.Count > 0)
-                    {
-                        var allAppSpecs = loadedPackageSpecs
-                            .Select(s => new SymbolReferenceSpecification(
-                                s.Publisher, s.Name, s.Version,
-                                false, s.AppId, false, ImmutableArray<Guid>.Empty))
-                            .ToArray();
-                        Log.Info($"  Loaded {allAppSpecs.Length} symbol packages (deduplicated by identity)");
-                        compilation = compilation
-                            .WithReferenceLoader(refLoader)
-                            .AddReferences(allAppSpecs);
-                    }
-                    else
-                    {
-                        compilation = compilation.WithReferenceLoader(refLoader);
-                    }
-                }
+                compilation = compilation
+                    .WithReferenceLoader(refLoader)
+                    .AddReferences(depSpecs.ToArray());
             }
             else
             {
-                Console.Error.WriteLine("Warning: --packages specified but no package directories with .app files found.");
+                // No explicit dependencies in app.json — load all .app files from
+                // the packages directory as symbol references. This handles the BC
+                // convention where Application/System dependencies are implicit.
+                // PackageScanner deduplicates: first by GUID (keeping highest version),
+                // then by (publisher+name+version) to eliminate self-duplicates that
+                // would otherwise produce AL0275 "ambiguous reference" errors.
+                Log.Info("No explicit dependencies found. Loading all .app packages as symbols...");
+
+                var scannedSpecs = PackageScanner.ScanForSpecs(
+                    allPackagePaths,
+                    excludeGuid: appIdentity.AppId,
+                    excludeName: appIdentity.Name);
+
+                loadedPackageSpecs.AddRange(scannedSpecs);
+
+                if (loadedPackageSpecs.Count > 0)
+                {
+                    var allAppSpecs = loadedPackageSpecs
+                        .Select(s => new SymbolReferenceSpecification(
+                            s.Publisher, s.Name, s.Version,
+                            false, s.AppId, false, ImmutableArray<Guid>.Empty))
+                        .ToArray();
+                    Log.Info($"  Loaded {allAppSpecs.Length} symbol packages (deduplicated by identity)");
+                    compilation = compilation
+                        .WithReferenceLoader(refLoader)
+                        .AddReferences(allAppSpecs);
+                }
+                else
+                {
+                    compilation = compilation.WithReferenceLoader(refLoader);
+                }
             }
         }
 


### PR DESCRIPTION
Closes #1033

## Summary
- Always call `ResolvePackagePaths()` regardless of whether `--packages` was explicitly provided
- Auto-discovers `.alpackages` directories in/near source paths (same dir, parent, or grandparent — as the method already supported)
- Logs which directories were auto-detected when no explicit `--packages` was given
- Updated `--help` text and `--guide` output to document the auto-detection behaviour

## Test plan
- [x] All existing test buckets pass (no regressions — pre-existing failures verified as unrelated)
- [x] Build succeeds with no new errors/warnings
- [ ] Manual test: verify `.alpackages` is found when `--packages` is omitted