### PR TITLE
fix: rewrite ALCompiler.ObjectToNavOutStream/InStream on chained-call path (#1026)

### DIFF
--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -3675,6 +3675,31 @@ public void ClearApplicationMemberVariables()
                         newName));
             }
 
+            // ALCompiler.ObjectToNavOutStream(parent, expr) -> AlCompat.ObjectToMockOutStream(parent, expr)
+            // BC emits this wrapper when an expression returning OutStream is used directly (chained),
+            // e.g. TempBlob.CreateOutStream().WriteText(...). After the NavOutStream→MockOutStream rename
+            // the inner expression already returns MockOutStream but the wrapper still returns NavOutStream,
+            // causing CS1503. AlCompat.ObjectToMockOutStream performs the same extraction with MockOutStream.
+            if (exprText == "ALCompiler" && methodName == "ObjectToNavOutStream")
+            {
+                return visited.WithExpression(
+                    SyntaxFactory.MemberAccessExpression(
+                        SyntaxKind.SimpleMemberAccessExpression,
+                        SyntaxFactory.IdentifierName("AlCompat"),
+                        SyntaxFactory.IdentifierName("ObjectToMockOutStream")));
+            }
+
+            // ALCompiler.ObjectToNavInStream(parent, expr) -> AlCompat.ObjectToMockInStream(parent, expr)
+            // Symmetric to ObjectToNavOutStream — see comment above.
+            if (exprText == "ALCompiler" && methodName == "ObjectToNavInStream")
+            {
+                return visited.WithExpression(
+                    SyntaxFactory.MemberAccessExpression(
+                        SyntaxKind.SimpleMemberAccessExpression,
+                        SyntaxFactory.IdentifierName("AlCompat"),
+                        SyntaxFactory.IdentifierName("ObjectToMockInStream")));
+            }
+
             // ALSystemErrorHandling.ALClearLastError() -> AlScope.LastErrorText = ""
             // ALSystemErrorHandling.ALGetLastErrorTextFunc(...) -> AlScope.LastErrorText
             // ALSystemErrorHandling.ALGetLastErrorObject(...) -> AlScope.GetLastErrorObject()

--- a/AlRunner/Runtime/AlScope.cs
+++ b/AlRunner/Runtime/AlScope.cs
@@ -863,6 +863,37 @@ public static class AlCompat
     }
 
     /// <summary>
+    /// Replacement for ALCompiler.ObjectToNavOutStream on the chained-call path.
+    /// BC emits ALCompiler.ObjectToNavOutStream(parent, expr) when an expression
+    /// that returns OutStream is used directly (chained), e.g.:
+    ///   TempBlob.CreateOutStream().WriteText(...)
+    /// After the rewriter renames NavOutStream → MockOutStream in type identifiers,
+    /// the method invocation is still wired to ALCompiler.ObjectToNavOutStream which
+    /// returns NavOutStream. This replacement returns MockOutStream instead.
+    /// </summary>
+    public static MockOutStream ObjectToMockOutStream(object? parent, object? value)
+    {
+        if (value is MockOutStream mockOutStream)
+            return mockOutStream;
+
+        // Fallback: return an empty stream rather than throw, so callers that
+        // just chain a write-and-discard don't crash.
+        return MockOutStream.Default();
+    }
+
+    /// <summary>
+    /// Replacement for ALCompiler.ObjectToNavInStream on the chained-call path.
+    /// See ObjectToMockOutStream for the symmetric explanation.
+    /// </summary>
+    public static MockInStream ObjectToMockInStream(object? parent, object? value)
+    {
+        if (value is MockInStream mockInStream)
+            return mockInStream;
+
+        return MockInStream.Default();
+    }
+
+    /// <summary>
     /// Replacement for ALCompiler.NavIndirectValueToBoolean.
     /// Extracts a boolean from a variant/indirect value holder.
     /// </summary>

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -1425,17 +1425,19 @@ Blob.CreateInStream:
   layer: runtime-api
   category: Blob
   status: covered
-  notes: overloads=1
+  notes: overloads=1; chained-call pattern (CreateInStream().ReadText()) supported via ALCompiler.ObjectToNavInStream→AlCompat.ObjectToMockInStream rewrite (issue #1026)
   tests:
     - tests/bucket-2/151-blob-stream
+    - tests/bucket-1/96-blob-stream-chained
 
 Blob.CreateOutStream:
   layer: runtime-api
   category: Blob
   status: covered
-  notes: overloads=1
+  notes: overloads=1; chained-call pattern (CreateOutStream().WriteText()) supported via ALCompiler.ObjectToNavOutStream→AlCompat.ObjectToMockOutStream rewrite (issue #1026)
   tests:
     - tests/bucket-2/151-blob-stream
+    - tests/bucket-1/96-blob-stream-chained
 
 Blob.Export:
   layer: runtime-api
@@ -3167,7 +3169,9 @@ InStream.ReadText:
   layer: runtime-api
   category: InStream
   status: covered
-  notes: overloads=1
+  notes: overloads=1; chained-call pattern supported (e.g. blob.CreateInStream().ReadText(...)) — see issue #1026
+  tests:
+    - tests/bucket-1/96-blob-stream-chained
 
 InStream.ResetPosition:
   layer: runtime-api
@@ -4488,13 +4492,17 @@ OutStream.Write:
   layer: runtime-api
   category: OutStream
   status: covered
-  notes: overloads=23
+  notes: overloads=23; chained-call pattern supported (e.g. blob.CreateOutStream().Write(...)) — see issue #1026
+  tests:
+    - tests/bucket-1/96-blob-stream-chained
 
 OutStream.WriteText:
   layer: runtime-api
   category: OutStream
   status: covered
-  notes: overloads=1
+  notes: overloads=1; chained-call pattern supported (e.g. blob.CreateOutStream().WriteText(...)) — see issue #1026
+  tests:
+    - tests/bucket-1/96-blob-stream-chained
 
 # ── Page ────────────────────────────────────────────────────────
 

--- a/tests/bucket-1/96-blob-stream-chained/src/TempBlobLike.al
+++ b/tests/bucket-1/96-blob-stream-chained/src/TempBlobLike.al
@@ -1,5 +1,5 @@
 /// A table holding a Blob, used internally by BSC TempBlobLike codeunit.
-table 160002 "BSC TempBlobData"
+table 163100 "BSC TempBlobData"
 {
     fields
     {
@@ -11,7 +11,7 @@ table 160002 "BSC TempBlobData"
 /// A codeunit that exposes CreateOutStream() returning OutStream and
 /// CreateInStream() returning InStream — mimicking the pattern of
 /// Codeunit "Temp Blob" from BC standard library (issue #1026).
-codeunit 160003 "BSC TempBlobLike"
+codeunit 163101 "BSC TempBlobLike"
 {
     var
         Rec: Record "BSC TempBlobData";
@@ -41,7 +41,7 @@ codeunit 160003 "BSC TempBlobLike"
 }
 
 /// Exercises the chained-call pattern: TempBlobLike.CreateOutStream().WriteText(...)
-codeunit 160004 "BSC ChainedStreamSrc"
+codeunit 163102 "BSC ChainedStreamSrc"
 {
     procedure WriteTextChained(var TempBlob: Codeunit "BSC TempBlobLike"; InputText: Text)
     begin

--- a/tests/bucket-1/96-blob-stream-chained/src/TempBlobLike.al
+++ b/tests/bucket-1/96-blob-stream-chained/src/TempBlobLike.al
@@ -1,0 +1,58 @@
+/// A table holding a Blob, used internally by BSC TempBlobLike codeunit.
+table 160002 "BSC TempBlobData"
+{
+    fields
+    {
+        field(1; PK; Integer) { }
+        field(2; Content; Blob) { }
+    }
+}
+
+/// A codeunit that exposes CreateOutStream() returning OutStream and
+/// CreateInStream() returning InStream — mimicking the pattern of
+/// Codeunit "Temp Blob" from BC standard library (issue #1026).
+codeunit 160003 "BSC TempBlobLike"
+{
+    var
+        Rec: Record "BSC TempBlobData";
+
+    /// Returns an OutStream backed by the internal Blob. Caller can chain .Write*() on it.
+    procedure CreateOutStream(): OutStream
+    var
+        OStr: OutStream;
+    begin
+        Rec.Content.CreateOutStream(OStr);
+        exit(OStr);
+    end;
+
+    /// Returns an InStream backed by the internal Blob.
+    procedure CreateInStream(): InStream
+    var
+        IStr: InStream;
+    begin
+        Rec.Content.CreateInStream(IStr);
+        exit(IStr);
+    end;
+
+    procedure HasValue(): Boolean
+    begin
+        exit(Rec.Content.HasValue());
+    end;
+}
+
+/// Exercises the chained-call pattern: TempBlobLike.CreateOutStream().WriteText(...)
+codeunit 160004 "BSC ChainedStreamSrc"
+{
+    procedure WriteTextChained(var TempBlob: Codeunit "BSC TempBlobLike"; InputText: Text)
+    begin
+        TempBlob.CreateOutStream().WriteText(InputText);
+    end;
+
+    procedure ReadTextChained(var TempBlob: Codeunit "BSC TempBlobLike"): Text
+    var
+        Result: Text;
+    begin
+        TempBlob.CreateInStream().ReadText(Result);
+        exit(Result);
+    end;
+}

--- a/tests/bucket-1/96-blob-stream-chained/test/TestBlobStreamChained.al
+++ b/tests/bucket-1/96-blob-stream-chained/test/TestBlobStreamChained.al
@@ -1,0 +1,49 @@
+codeunit 160005 "BSC TestBlobStreamChained"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        ChainedSrc: Codeunit "BSC ChainedStreamSrc";
+
+    [Test]
+    procedure ChainedOutStream_WriteText_And_ReadBack()
+    var
+        TempBlob: Codeunit "BSC TempBlobLike";
+    begin
+        // Positive: write text via chained CreateOutStream().WriteText(), read back via chained CreateInStream()
+        ChainedSrc.WriteTextChained(TempBlob, 'Hello Chained');
+        Assert.AreEqual('Hello Chained', ChainedSrc.ReadTextChained(TempBlob), 'Chained write/read should round-trip');
+    end;
+
+    [Test]
+    procedure ChainedOutStream_HasValue_AfterWrite()
+    var
+        TempBlob: Codeunit "BSC TempBlobLike";
+    begin
+        // Positive: HasValue is true after chained write
+        ChainedSrc.WriteTextChained(TempBlob, 'data');
+        Assert.IsTrue(TempBlob.HasValue(), 'TempBlob must have value after chained write');
+    end;
+
+    [Test]
+    procedure ChainedOutStream_OverwriteReplaces()
+    var
+        TempBlob: Codeunit "BSC TempBlobLike";
+    begin
+        // Positive: second chained write replaces first
+        ChainedSrc.WriteTextChained(TempBlob, 'First');
+        ChainedSrc.WriteTextChained(TempBlob, 'Second');
+        Assert.AreEqual('Second', ChainedSrc.ReadTextChained(TempBlob), 'Second write should replace first');
+    end;
+
+    [Test]
+    procedure ChainedOutStream_WrongValueFails()
+    var
+        TempBlob: Codeunit "BSC TempBlobLike";
+    begin
+        // Negative: chained write does not produce wrong value
+        ChainedSrc.WriteTextChained(TempBlob, 'Expected');
+        Assert.AreNotEqual('NotExpected', ChainedSrc.ReadTextChained(TempBlob), 'Chained write should not produce wrong value');
+    end;
+}

--- a/tests/bucket-1/96-blob-stream-chained/test/TestBlobStreamChained.al
+++ b/tests/bucket-1/96-blob-stream-chained/test/TestBlobStreamChained.al
@@ -1,4 +1,4 @@
-codeunit 160005 "BSC TestBlobStreamChained"
+codeunit 163103 "BSC TestBlobStreamChained"
 {
     Subtype = Test;
 


### PR DESCRIPTION
## Summary

- **Root cause**: BC emits `ALCompiler.ObjectToNavOutStream(parent, expr)` / `ALCompiler.ObjectToNavInStream(parent, expr)` when a method returning `OutStream`/`InStream` is used directly in a chained expression (e.g. `TempBlob.CreateOutStream().WriteText(...)`). The existing `NavOutStream → MockOutStream` identifier rewrite in `VisitIdentifierName` handles type declarations and variable annotations but not this wrapper call, which still returned `NavOutStream`, causing `CS1503`.
- **Fix**: Added `AlCompat.ObjectToMockOutStream` and `AlCompat.ObjectToMockInStream` helper methods, and two new `RoslynRewriter` rules that redirect `ALCompiler.ObjectToNavOutStream → AlCompat.ObjectToMockOutStream` and `ALCompiler.ObjectToNavInStream → AlCompat.ObjectToMockInStream` (symmetric to the existing `ObjectToNavArray → ObjectToMockArray` redirect at RoslynRewriter.cs:3660).
- **Coverage**: New test suite `tests/bucket-1/96-blob-stream-chained` proves the chained pattern compiles, round-trips data, and that the mock isn't a no-op. `docs/coverage.yaml` updated for Blob.CreateInStream, Blob.CreateOutStream, OutStream.Write, OutStream.WriteText, InStream.ReadText.

## Test plan

- [x] RED confirmed: `CS1503: cannot convert from NavOutStream to MockOutStream` before fix
- [x] GREEN confirmed: 4/4 new tests pass after fix
- [x] bucket-1 full run: 1525 passed, 2 pre-existing failures (DT2Time — unrelated)
- [x] bucket-2 full run: 1564 passed, 3 pre-existing failures (DT2Time/CreateDateTime — unrelated)
- [x] `docs/coverage.yaml` updated
- [x] CHANGELOG not touched