### PR TITLE
feat: add Report.RunModal 2/3/4-arg static overloads

### DIFF
--- a/AlRunner/Runtime/MockReportHandle.cs
+++ b/AlRunner/Runtime/MockReportHandle.cs
@@ -314,6 +314,39 @@ public class MockReportHandle
     }
 
     /// <summary>
+    /// Static Report.RunModal(reportId, requestWindow) — 2-argument overload.
+    /// <paramref name="requestWindow"/> is ignored in standalone mode (no UI).
+    /// </summary>
+    public static void StaticRunModal(int reportId, bool requestWindow)
+    {
+        var handle = new MockReportHandle(reportId) { UseRequestForm = requestWindow };
+        handle.RunModal();
+    }
+
+    /// <summary>
+    /// Static Report.RunModal(reportId, requestWindow, systemPrinter) — 3-argument overload.
+    /// <paramref name="requestWindow"/> and <paramref name="systemPrinter"/> are ignored in standalone mode.
+    /// </summary>
+    public static void StaticRunModal(int reportId, bool requestWindow, bool systemPrinter)
+    {
+        var handle = new MockReportHandle(reportId) { UseRequestForm = requestWindow };
+        handle.RunModal();
+    }
+
+    /// <summary>
+    /// Static Report.RunModal(reportId, requestWindow, systemPrinter, record) — 4-argument overload.
+    /// <paramref name="requestWindow"/>, <paramref name="systemPrinter"/>, and <paramref name="record"/>
+    /// are ignored in standalone mode (no rendering, no service-tier table filtering).
+    /// </summary>
+    public static void StaticRunModal(int reportId, bool requestWindow, bool systemPrinter, object record)
+    {
+        var handle = new MockReportHandle(reportId) { UseRequestForm = requestWindow };
+        if (record is MockRecordHandle rec)
+            handle.SetTableView(rec);
+        handle.RunModal();
+    }
+
+    /// <summary>
     /// AL's <c>Clear(rep)</c> — the rewriter emits <c>rep.Clear()</c>. Resets the
     /// report handle to its default (un-run) state. No-op in standalone mode.
     /// </summary>

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -5343,9 +5343,10 @@ Report.RunModal:
   layer: runtime-api
   category: Report
   status: covered
-  notes: overloads=1; NavReport.RunModal → MockReportHandle.StaticRunModal (no-op/handler dispatch).
+  notes: "overloads=4 (1-arg, 2-arg, 3-arg, 4-arg); NavReport.RunModal → MockReportHandle.StaticRunModal. 2-arg adds requestWindow; 3-arg adds systemPrinter; 4-arg adds record Variant (stored via SetTableView if MockRecordHandle). All are no-op/handler dispatch in standalone mode."
   tests:
     - tests/bucket-1/90-report-static
+    - tests/bucket-1/287-report-runmodal-4arg
 
 Report.RunRequestPage:
   layer: runtime-api

--- a/tests/bucket-1/287-report-runmodal-4arg/src/Src.al
+++ b/tests/bucket-1/287-report-runmodal-4arg/src/Src.al
@@ -1,0 +1,36 @@
+/// Minimal table needed so tests can pass a record Variant to Report.RunModal.
+table 163000 "RRM4 Dummy"
+{
+    fields
+    {
+        field(1; Id; Integer) { }
+    }
+    keys
+    {
+        key(PK; Id) { Clustered = true; }
+    }
+}
+
+/// Source codeunit that exercises Report.RunModal with 2-, 3-, and 4-argument forms.
+codeunit 163001 "RRM4 Src"
+{
+    procedure CallRunModal1Arg(reportId: Integer)
+    begin
+        Report.RunModal(reportId);
+    end;
+
+    procedure CallRunModal2Arg(reportId: Integer; requestWindow: Boolean)
+    begin
+        Report.RunModal(reportId, requestWindow);
+    end;
+
+    procedure CallRunModal3Arg(reportId: Integer; requestWindow: Boolean; systemPrinter: Boolean)
+    begin
+        Report.RunModal(reportId, requestWindow, systemPrinter);
+    end;
+
+    procedure CallRunModal4Arg(reportId: Integer; requestWindow: Boolean; systemPrinter: Boolean; var rec: Record "RRM4 Dummy")
+    begin
+        Report.RunModal(reportId, requestWindow, systemPrinter, rec);
+    end;
+}

--- a/tests/bucket-1/287-report-runmodal-4arg/test/Test.al
+++ b/tests/bucket-1/287-report-runmodal-4arg/test/Test.al
@@ -1,0 +1,50 @@
+codeunit 163002 "RRM4 Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "RRM4 Src";
+
+    // ------------------------------------------------------------------
+    // Report.RunModal — all static overloads are no-ops in standalone mode
+    // ------------------------------------------------------------------
+
+    [Test]
+    procedure Report_RunModal_1Arg_IsNoOp()
+    begin
+        // [GIVEN] A non-existent report id
+        // [WHEN]  Report.RunModal(id) 1-arg is called
+        // [THEN]  No error — stub is a no-op in standalone mode
+        Src.CallRunModal1Arg(99999);
+    end;
+
+    [Test]
+    procedure Report_RunModal_2Arg_IsNoOp()
+    begin
+        // [GIVEN] A non-existent report id
+        // [WHEN]  Report.RunModal(id, false) 2-arg is called
+        // [THEN]  No error — stub is a no-op in standalone mode
+        Src.CallRunModal2Arg(99999, false);
+    end;
+
+    [Test]
+    procedure Report_RunModal_3Arg_IsNoOp()
+    begin
+        // [GIVEN] A non-existent report id
+        // [WHEN]  Report.RunModal(id, false, false) 3-arg is called
+        // [THEN]  No error — stub is a no-op in standalone mode
+        Src.CallRunModal3Arg(99999, false, false);
+    end;
+
+    [Test]
+    procedure Report_RunModal_4Arg_IsNoOp()
+    var
+        DummyRec: Record "RRM4 Dummy";
+    begin
+        // [GIVEN] A non-existent report id and a record variable
+        // [WHEN]  Report.RunModal(id, false, false, Rec) 4-arg is called
+        // [THEN]  No error — stub is a no-op in standalone mode
+        Src.CallRunModal4Arg(99999, false, false, DummyRec);
+    end;
+}


### PR DESCRIPTION
Fixes #1043.

## Summary

- Added `StaticRunModal(int, bool)` (2-arg), `StaticRunModal(int, bool, bool)` (3-arg), and `StaticRunModal(int, bool, bool, object)` (4-arg) overloads to `MockReportHandle`.
- The 2-arg overload respects `requestWindow` via `UseRequestForm`.
- The 3-arg overload accepts `systemPrinter` (ignored in standalone mode).
- The 4-arg overload accepts a `record` Variant; if it is a `MockRecordHandle`, it is stored via `SetTableView` for handler dispatch.
- The RoslynRewriter already routes `NavReport.RunModal(...)` → `MockReportHandle.StaticRunModal(...)` with the full argument list, so no rewriter changes were needed.
- Updated `docs/coverage.yaml`: `Report.RunModal` now reflects `overloads=4`.

## Test plan

- [x] RED: confirmed 3 compilation errors before fix (`CS1501: No overload for method 'StaticRunModal' takes 2/3/4 arguments`).
- [x] GREEN: new suite `tests/bucket-1/287-report-runmodal-4arg` — 4 tests pass (1-arg, 2-arg, 3-arg, 4-arg no-op assertions).
- [x] Full bucket-1: 1541 passed (2 pre-existing `DT2Time` failures, unrelated).
- [x] Full bucket-2: 1564 passed (3 pre-existing datetime failures, unrelated).