### PR TITLE
feat: FlowTemplateGallery customaction support — issue #1044

### DIFF
--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -863,6 +863,18 @@ customaction_declaration:
   tests:
     - tests/bucket-1/75-customaction
 
+customaction_flowtemplategallery:
+  layer: syntax
+  category: page
+  status: covered
+  notes: >
+    customaction with CustomActionType = FlowTemplateGallery — Power Automate
+    template gallery integration is out of scope at runtime (no network I/O),
+    but the page element must not prevent compilation or page instantiation.
+    The BC compiler emits no C# for this element; it is pure metadata.
+  tests:
+    - tests/bucket-1/75-customaction
+
 fileuploadaction_declaration:
   layer: syntax
   category: page

--- a/tests/bucket-1/75-customaction/src/CustomActionSrc.al
+++ b/tests/bucket-1/75-customaction/src/CustomActionSrc.al
@@ -42,7 +42,27 @@ page 59600 "CA Order Card"
                 FlowId = '00000000-0000-0000-0000-000000000001';
             }
         }
+        area(Navigation)
+        {
+            customaction(CreateFlowFromTemplate)
+            {
+                Caption = 'Create approval flow';
+                CustomActionType = FlowTemplateGallery;
+                FlowTemplateCategoryName = 'd365bc_approval_salesOrder';
+            }
+        }
     }
+}
+
+/// Helper procedure for page-instantiation test.
+codeunit 59602 "CA Page Runner"
+{
+    procedure RunOrderCard()
+    var
+        P: Page "CA Order Card";
+    begin
+        P.Run();
+    end;
 }
 
 /// Business logic helper — proves that the compilation unit containing

--- a/tests/bucket-1/75-customaction/test/CustomActionTests.al
+++ b/tests/bucket-1/75-customaction/test/CustomActionTests.al
@@ -5,6 +5,7 @@ codeunit 59601 "CA Custom Action Tests"
     var
         Assert: Codeunit Assert;
         Helper: Codeunit "CA Order Helper";
+        PageRunner: Codeunit "CA Page Runner";
 
     // -----------------------------------------------------------------------
     // Positive: pages with customaction declarations compile; logic runs
@@ -29,9 +30,21 @@ codeunit 59601 "CA Custom Action Tests"
     end;
 
     [Test]
+    procedure CustomAction_FlowTemplateGallery_PageInstantiates()
+    begin
+        // [GIVEN] A page with customaction(FlowTemplateGallery) in the action area
+        // [WHEN]  The page is instantiated and run
+        // [THEN]  Compilation succeeds and Run() is a no-op — FlowTemplateGallery
+        //         is out of scope at runtime (no Power Automate integration) but
+        //         must not prevent the page from compiling or being used.
+        PageRunner.RunOrderCard();
+        Assert.IsTrue(true, 'Page with FlowTemplateGallery customaction must compile and run as no-op');
+    end;
+
+    [Test]
     procedure CustomAction_MultipleCustomActions_Compile()
     begin
-        // [GIVEN] A page with multiple customaction declarations (Flow + FlowTemplate)
+        // [GIVEN] A page with multiple customaction declarations (Flow + FlowTemplateGallery)
         // [WHEN]  Business logic is called
         // [THEN]  Multiple customactions in different areas compile together
         Assert.AreEqual(25, Helper.CalcTax(500, 5), 'customaction: 5% tax on 500 must be 25');


### PR DESCRIPTION
## Summary

- Extends `tests/bucket-1/75-customaction` to cover `CustomActionType = FlowTemplateGallery`
- Adds `FlowTemplateGallery` customaction block to the existing `CA Order Card` page fixture
- Adds a `CA Page Runner` helper codeunit for page instantiation
- Adds proving test `CustomAction_FlowTemplateGallery_PageInstantiates` that both compiles and runs the page as a no-op
- Updates `docs/coverage.yaml` with new `customaction_flowtemplategallery` entry

**No rewriter change needed:** The BC compiler emits no C# for `customaction` elements — they are pure page metadata. The page compiles and instantiates correctly. Power Automate integration is out of scope at runtime.

Closes #1044

## Test plan

- [x] RED: feature was untested (no specific test for FlowTemplateGallery)
- [x] GREEN: `CustomAction_FlowTemplateGallery_PageInstantiates` passes
- [x] All 7 tests in 75-customaction pass
- [x] Bucket-1: 1538 passed (pre-existing DT2Time failures unchanged)
- [x] `docs/coverage.yaml` updated with `customaction_flowtemplategallery` entry