### PR TITLE
docs: coverage gap audit — add 11 missing runtime-api entries

### DIFF
--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -1863,6 +1863,30 @@ Database.UserSecurityId:
   tests:
     - tests/bucket-2/147-usersecurityid
 
+Database.UserName:
+  layer: runtime-api
+  category: Database
+  status: gap
+  notes: overloads=1; ALDatabase.UserName(userId: String) returns the display name for the given security-id string; requires a live BC session/directory; runner has no user directory. Requires a MockSession.GetUserName() stub.
+
+Database.KeyGroupDisable:
+  layer: runtime-api
+  category: Database
+  status: gap
+  notes: overloads=1; ALDatabase.ALKeyGroupDisable(keyGroupName: String) disables a key group; requires a live BC database context. No equivalent in runner mocks.
+
+Database.KeyGroupEnable:
+  layer: runtime-api
+  category: Database
+  status: gap
+  notes: overloads=1; ALDatabase.ALKeyGroupEnable(keyGroupName: String) enables a key group; requires a live BC database context. No equivalent in runner mocks.
+
+Database.KeyGroupEnabled:
+  layer: runtime-api
+  category: Database
+  status: gap
+  notes: overloads=1; ALDatabase.ALKeyGroupEnabled(keyGroupName: String) returns whether a key group is enabled; requires a live BC database context. Could stub to always return true.
+
 # ── Date ────────────────────────────────────────────────────────
 
 Date.Day:
@@ -7746,6 +7770,48 @@ TestPage.GetRecord:
     TestPage.GetRecord(var Rec) was removed in BC 26+. MockTestPageHandle.ALGetRecord()
     exists internally (returns _currentRecord after GoToKey/GoToRecord) but the AL method
     can no longer be called from test code compiled against BC 26+ DLLs.
+
+TestPage.Preview:
+  layer: runtime-api
+  category: TestPage
+  status: covered
+  notes: overloads=1; BC emits tP.Target.ALPreview().ALInvoke() — MockTestPageHandle.ALPreview() returns MockTestPageAction which no-ops on ALInvoke().
+
+TestPage.Print:
+  layer: runtime-api
+  category: TestPage
+  status: covered
+  notes: overloads=1; BC emits tP.Target.ALPrint().ALInvoke() — MockTestPageHandle.ALPrint() returns MockTestPageAction which no-ops on ALInvoke().
+
+TestPage.SaveAsPdf:
+  layer: runtime-api
+  category: TestPage
+  status: covered
+  notes: overloads=1; no-op stub — MockTestPageHandle.ALSaveAsPdf(fileName) accepts the file name and does nothing (no real report engine).
+
+TestPage.SaveAsExcel:
+  layer: runtime-api
+  category: TestPage
+  status: covered
+  notes: overloads=1; no-op stub — MockTestPageHandle.ALSaveAsExcel(fileName) accepts the file name and does nothing.
+
+TestPage.SaveAsWord:
+  layer: runtime-api
+  category: TestPage
+  status: covered
+  notes: overloads=1; no-op stub — MockTestPageHandle.ALSaveAsWord(fileName) accepts the file name and does nothing.
+
+TestPage.SaveAsXml:
+  layer: runtime-api
+  category: TestPage
+  status: covered
+  notes: overloads=1; no-op stub — MockTestPageHandle.ALSaveAsXml(reportFileName, dataFileName) accepts two file names and does nothing.
+
+TestPage.Schedule:
+  layer: runtime-api
+  category: TestPage
+  status: covered
+  notes: overloads=1; BC emits tP.Target.ALSchedule().ALInvoke() — MockTestPageHandle.ALSchedule() returns MockTestPageAction which no-ops on ALInvoke().
 
 # ── TestPart ────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Systematic audit of BC Service Tier DLLs against the RoslynRewriter dispatch table and Runtime mocks. Reflected `ALDatabase`, `ALSession`, `ALNumberSequence`, `ALTaskScheduler`, `ALNavApp` from `Microsoft.Dynamics.Nav.Ncl.dll` and cross-checked every public AL-callable method against `docs/coverage.yaml`.

- 4 genuine **gaps** discovered (BC methods with no rewriter rule or mock, not previously tracked)
- 7 **covered** methods discovered (implemented in `MockTestPageHandle` but never documented in `coverage.yaml`)

No C# code was changed — this is a documentation-only audit PR.

## Changes

### New gap entries (`status: gap`)

| Entry | BC method | Notes |
|---|---|---|
| `Database.UserName` | `ALDatabase.UserName(userId: String)` | Returns display name for a user security-id; requires live BC directory |
| `Database.KeyGroupDisable` | `ALDatabase.ALKeyGroupDisable(name)` | Disables a BC key group; requires live DB context |
| `Database.KeyGroupEnable` | `ALDatabase.ALKeyGroupEnable(name)` | Enables a BC key group |
| `Database.KeyGroupEnabled` | `ALDatabase.ALKeyGroupEnabled(name)` | Queries key group state; could stub to `true` |

### New covered entries (`status: covered`)

| Entry | Implementation |
|---|---|
| `TestPage.Preview` | `MockTestPageHandle.ALPreview()` → `MockTestPageAction` (no-op invoke) |
| `TestPage.Print` | `MockTestPageHandle.ALPrint()` → `MockTestPageAction` |
| `TestPage.Schedule` | `MockTestPageHandle.ALSchedule()` → `MockTestPageAction` |
| `TestPage.SaveAsPdf` | `MockTestPageHandle.ALSaveAsPdf(fileName)` — no-op stub |
| `TestPage.SaveAsExcel` | `MockTestPageHandle.ALSaveAsExcel(fileName)` — no-op stub |
| `TestPage.SaveAsWord` | `MockTestPageHandle.ALSaveAsWord(fileName)` — no-op stub |
| `TestPage.SaveAsXml` | `MockTestPageHandle.ALSaveAsXml(reportFile, dataFile)` — no-op stub |

## Test plan

- [ ] No test changes required — this is a `docs/coverage.yaml`-only update
- [ ] Verify all existing tests still pass: `for bucket in tests/bucket-*/; do ...`
- [ ] Review that the 4 gap entries are accurate BC method names vs the DLL
- [ ] Review that the 7 covered entries match `MockTestPageHandle.cs` method signatures