### PR TITLE
feat: stub CurrReport.Preview / PreviewCanPrint as no-op (#1055)

### DIFF
--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -418,6 +418,15 @@ public class RoslynRewriter : CSharpSyntaxRewriter
             preservedMembers.Add(
                 SyntaxFactory.ParseMemberDeclaration(
                     "public int PageNo() => 0;")!);
+            // Preview — CurrReport.Preview() returns false in standalone mode (no print-preview UI).
+            // BC emits: shown = (CurrReport.PreviewCanPrint == false ? true : CurrReport.Preview)
+            // Both are bool properties that default to false in standalone mode.
+            preservedMembers.Add(
+                SyntaxFactory.ParseMemberDeclaration(
+                    "public bool Preview => false;")!);
+            preservedMembers.Add(
+                SyntaxFactory.ParseMemberDeclaration(
+                    "public bool PreviewCanPrint => false;")!);
 
             // For report extensions: inject a CurrReport stub.
             // BC generates a CurrReport property that casts this.ParentObject to the

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -5586,8 +5586,8 @@ ReportInstance.PaperSource:
 ReportInstance.Preview:
   layer: runtime-api
   category: ReportInstance
-  status: gap
-  notes: overloads=1
+  status: covered
+  notes: overloads=1; BC emits CurrReport.Preview (bool property) and CurrReport.PreviewCanPrint (bool property) on the report class — both return false in standalone mode (no print-preview UI); injected as CurrReport stubs in RoslynRewriter.cs
 
 ReportInstance.Print:
   layer: runtime-api

--- a/tests/bucket-2/100-report-preview/src/Source.al
+++ b/tests/bucket-2/100-report-preview/src/Source.al
@@ -1,0 +1,34 @@
+table 98000 "RP Test Data"
+{
+    fields
+    {
+        field(1; Id; Integer) { }
+        field(2; Name; Text[100]) { }
+    }
+    keys { key(PK; Id) { Clustered = true; } }
+}
+
+report 98000 "RP Preview Report"
+{
+    dataset
+    {
+        dataitem(RPTestData; "RP Test Data") { }
+    }
+
+    trigger OnInitReport()
+    var
+        InPreviewMode: Boolean;
+    begin
+        InPreviewMode := CurrReport.Preview();
+    end;
+}
+
+codeunit 98001 "RP Preview Runner"
+{
+    procedure RunPreviewReport()
+    var
+        Rep: Report "RP Preview Report";
+    begin
+        Rep.Run();
+    end;
+}

--- a/tests/bucket-2/100-report-preview/test/TestReportPreview.al
+++ b/tests/bucket-2/100-report-preview/test/TestReportPreview.al
@@ -1,0 +1,19 @@
+codeunit 98002 "RP Report Preview Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    [Test]
+    procedure ReportPreview_NoThrow()
+    var
+        Runner: Codeunit "RP Preview Runner";
+    begin
+        // [GIVEN] A report that calls CurrReport.Preview() in OnInitReport
+        // [WHEN]  The report is run via Rep.Run()
+        // [THEN]  No exception is thrown — Preview() is a no-op stub in standalone mode
+        Runner.RunPreviewReport();
+        Assert.IsTrue(true, 'CurrReport.Preview() must not throw in standalone mode');
+    end;
+}


### PR DESCRIPTION
## Summary

- Closes #1055
- BC emits `CurrReport.Preview` (bool property) and `CurrReport.PreviewCanPrint` (bool property) on the generated report class when AL code calls `CurrReport.Preview()`; both are injected as `false`-returning stubs alongside the existing `Skip`/`Break`/`Quit`/`PrintOnlyIfDetail`/`PageNo` stubs in `RoslynRewriter.cs`
- Adds test suite `tests/bucket-2/100-report-preview` (object IDs 98000–98002)
- Updates `docs/coverage.yaml`: `ReportInstance.Preview` `gap` → `covered`

## Test plan

- [ ] RED: `ReportPreview_NoThrow` fails with CS1061 before the fix (confirmed)
- [ ] GREEN: `ReportPreview_NoThrow` passes after the fix (confirmed — 1 passed)
- [ ] No regressions in bucket-1 (1550 passed, 2 pre-existing DT2Time failures)
- [ ] No regressions in bucket-2 (1567 passed, 3 pre-existing DT2Time/CreateDateTime failures)