### PR TITLE
fix: enrich telemetry dedup keys for CS1503/CS1501/CS0117/CS1729/CS1674 (#1074)

### DIFF
--- a/AlRunner.Tests/TelemetryReporterTests.cs
+++ b/AlRunner.Tests/TelemetryReporterTests.cs
@@ -84,6 +84,205 @@ public class TelemetryReporterTests
         Assert.Equal(2, result[0].Count);
     }
 
+    // ─── CS1503: cannot convert from 'X' to 'Y' ──────────────────────────────
+
+    [Fact]
+    public void Dedup_CS1503_IncludesBothTypes()
+    {
+        // CS1503: "Argument N: cannot convert from 'FromType' to 'ToType'"
+        // The key must capture BOTH the source and destination types.
+        var errors = new List<string>
+        {
+            "Codeunit50100.cs(10,5): error CS1503: Argument 1: cannot convert from 'NavText' to 'System.String'",
+            "Codeunit50100.cs(20,5): error CS1503: Argument 2: cannot convert from 'NavText' to 'System.String'",
+        };
+
+        var result = TelemetryReporter.DeduplicateCompilationErrors(errors);
+
+        // Both map to the same key because FromType and ToType are the same
+        Assert.Single(result);
+        var (key, count, _) = result[0];
+        Assert.Equal(2, count);
+        Assert.Contains("NavText", key);
+        Assert.Contains("System.String", key);
+    }
+
+    [Fact]
+    public void Dedup_CS1503_DifferentToType_DoesNotMerge()
+    {
+        // Different target types must produce distinct keys.
+        var errors = new List<string>
+        {
+            "Codeunit50100.cs(10,5): error CS1503: Argument 1: cannot convert from 'NavText' to 'System.String'",
+            "Codeunit50100.cs(20,5): error CS1503: Argument 1: cannot convert from 'NavText' to 'System.Int32'",
+        };
+
+        var result = TelemetryReporter.DeduplicateCompilationErrors(errors);
+
+        Assert.Equal(2, result.Count);
+        var keys = result.Select(r => r.Key).ToList();
+        Assert.True(keys.Any(k => k.Contains("System.String")), "Key for String conversion missing");
+        Assert.True(keys.Any(k => k.Contains("System.Int32")), "Key for Int32 conversion missing");
+    }
+
+    // ─── CS1501: no overload for method 'X' takes N arguments ────────────────
+
+    [Fact]
+    public void Dedup_CS1501_IncludesMethodNameAndArgCount()
+    {
+        // CS1501: "No overload for method 'Method' takes N arguments"
+        // Key must include method name and argument count.
+        var errors = new List<string>
+        {
+            "Codeunit50100.cs(5,1): error CS1501: No overload for method 'ALSetRange' takes 3 arguments",
+            "Codeunit50100.cs(9,1): error CS1501: No overload for method 'ALSetRange' takes 3 arguments",
+        };
+
+        var result = TelemetryReporter.DeduplicateCompilationErrors(errors);
+
+        Assert.Single(result);
+        var (key, count, _) = result[0];
+        Assert.Equal(2, count);
+        Assert.Contains("ALSetRange", key);
+        Assert.Contains("3", key);
+    }
+
+    [Fact]
+    public void Dedup_CS1501_DifferentArgCount_DoesNotMerge()
+    {
+        // Same method, different arg count = different key.
+        var errors = new List<string>
+        {
+            "Codeunit50100.cs(5,1): error CS1501: No overload for method 'ALSetRange' takes 2 arguments",
+            "Codeunit50100.cs(9,1): error CS1501: No overload for method 'ALSetRange' takes 3 arguments",
+        };
+
+        var result = TelemetryReporter.DeduplicateCompilationErrors(errors);
+
+        Assert.Equal(2, result.Count);
+        var keys = result.Select(r => r.Key).ToList();
+        Assert.True(keys.Any(k => k.Contains("2")), "Key for 2-arg variant missing");
+        Assert.True(keys.Any(k => k.Contains("3")), "Key for 3-arg variant missing");
+    }
+
+    // ─── CS0117: 'Type' does not contain a definition for 'Member' ───────────
+
+    [Fact]
+    public void Dedup_CS0117_IncludesTypeAndMember()
+    {
+        // CS0117: "'Type' does not contain a definition for 'Member'"
+        // Key must capture both type and member.
+        var errors = new List<string>
+        {
+            "Codeunit50100.cs(5,1): error CS0117: 'AlRunner.Runtime.AlScope' does not contain a definition for 'FooBar'",
+            "Codeunit50100.cs(9,1): error CS0117: 'AlRunner.Runtime.AlScope' does not contain a definition for 'FooBar'",
+        };
+
+        var result = TelemetryReporter.DeduplicateCompilationErrors(errors);
+
+        Assert.Single(result);
+        var (key, count, _) = result[0];
+        Assert.Equal(2, count);
+        Assert.Contains("AlRunner.Runtime.AlScope", key);
+        Assert.Contains("FooBar", key);
+    }
+
+    [Fact]
+    public void Dedup_CS0117_DifferentMember_DoesNotMerge()
+    {
+        // Same type, different missing member = different key.
+        var errors = new List<string>
+        {
+            "Codeunit50100.cs(5,1): error CS0117: 'AlRunner.Runtime.AlScope' does not contain a definition for 'FooBar'",
+            "Codeunit50100.cs(9,1): error CS0117: 'AlRunner.Runtime.AlScope' does not contain a definition for 'BazQux'",
+        };
+
+        var result = TelemetryReporter.DeduplicateCompilationErrors(errors);
+
+        Assert.Equal(2, result.Count);
+        var keys = result.Select(r => r.Key).ToList();
+        Assert.True(keys.Any(k => k.Contains("FooBar")), "Key for FooBar missing");
+        Assert.True(keys.Any(k => k.Contains("BazQux")), "Key for BazQux missing");
+    }
+
+    // ─── CS1729: type has no constructor taking N arguments ──────────────────
+
+    [Fact]
+    public void Dedup_CS1729_IncludesTypeAndArgCount()
+    {
+        // CS1729: "'Type' does not contain a constructor that takes N arguments"
+        // Key must capture type name and arg count.
+        var errors = new List<string>
+        {
+            "Codeunit50100.cs(5,1): error CS1729: 'MockRecordHandle' does not contain a constructor that takes 3 arguments",
+            "Codeunit50200.cs(5,1): error CS1729: 'MockRecordHandle' does not contain a constructor that takes 3 arguments",
+        };
+
+        var result = TelemetryReporter.DeduplicateCompilationErrors(errors);
+
+        Assert.Single(result);
+        var (key, count, _) = result[0];
+        Assert.Equal(2, count);
+        Assert.Contains("MockRecordHandle", key);
+        Assert.Contains("3", key);
+    }
+
+    [Fact]
+    public void Dedup_CS1729_DifferentArgCount_DoesNotMerge()
+    {
+        var errors = new List<string>
+        {
+            "Codeunit50100.cs(5,1): error CS1729: 'MockRecordHandle' does not contain a constructor that takes 2 arguments",
+            "Codeunit50100.cs(9,1): error CS1729: 'MockRecordHandle' does not contain a constructor that takes 4 arguments",
+        };
+
+        var result = TelemetryReporter.DeduplicateCompilationErrors(errors);
+
+        Assert.Equal(2, result.Count);
+        var keys = result.Select(r => r.Key).ToList();
+        Assert.True(keys.Any(k => k.Contains("2")), "Key for 2-arg ctor missing");
+        Assert.True(keys.Any(k => k.Contains("4")), "Key for 4-arg ctor missing");
+    }
+
+    // ─── CS1674: type not disposable ─────────────────────────────────────────
+
+    [Fact]
+    public void Dedup_CS1674_IncludesTypeName()
+    {
+        // CS1674: "'Type': type used in a using statement must be implicitly convertible to 'System.IDisposable'"
+        // Key must capture the type name.
+        var errors = new List<string>
+        {
+            "Codeunit50100.cs(5,1): error CS1674: 'NavText': type used in a using statement must be implicitly convertible to 'System.IDisposable'",
+            "Codeunit50200.cs(7,1): error CS1674: 'NavText': type used in a using statement must be implicitly convertible to 'System.IDisposable'",
+        };
+
+        var result = TelemetryReporter.DeduplicateCompilationErrors(errors);
+
+        Assert.Single(result);
+        var (key, count, _) = result[0];
+        Assert.Equal(2, count);
+        Assert.Contains("NavText", key);
+        Assert.Contains("not IDisposable", key);
+    }
+
+    [Fact]
+    public void Dedup_CS1674_DifferentTypes_DoesNotMerge()
+    {
+        var errors = new List<string>
+        {
+            "Codeunit50100.cs(5,1): error CS1674: 'NavText': type used in a using statement must be implicitly convertible to 'System.IDisposable'",
+            "Codeunit50100.cs(9,1): error CS1674: 'Decimal18': type used in a using statement must be implicitly convertible to 'System.IDisposable'",
+        };
+
+        var result = TelemetryReporter.DeduplicateCompilationErrors(errors);
+
+        Assert.Equal(2, result.Count);
+        var keys = result.Select(r => r.Key).ToList();
+        Assert.True(keys.Any(k => k.Contains("NavText")), "Key for NavText missing");
+        Assert.True(keys.Any(k => k.Contains("Decimal18")), "Key for Decimal18 missing");
+    }
+
     // ─── ScrubMessage ─────────────────────────────────────────────────────────
 
     [Fact]

--- a/AlRunner/TelemetryReporter.cs
+++ b/AlRunner/TelemetryReporter.cs
@@ -189,10 +189,26 @@ public static class TelemetryReporter
 
     // ─── Internals ────────────────────────────────────────────────────────────
 
-    // Regex to parse the missing member name from a CS1061 diagnostic message:
+    // Regex to parse the missing member name from a CS1061/CS0117 diagnostic message:
     // "'TypeName' does not contain a definition for 'MemberName' and …"
     private static readonly Regex MemberNameRx =
         new(@"does not contain a definition for '([^']+)'", RegexOptions.Compiled);
+
+    // Regex for CS1503: "Argument N: cannot convert from 'FromType' to 'ToType'"
+    private static readonly Regex Cs1503Rx =
+        new(@"cannot convert from '([^']+)' to '([^']+)'", RegexOptions.Compiled);
+
+    // Regex for CS1501: "No overload for method 'Method' takes N arguments"
+    private static readonly Regex Cs1501Rx =
+        new(@"No overload for method '([^']+)' takes (\d+) arguments", RegexOptions.Compiled);
+
+    // Regex for CS1729: "'Type' does not contain a constructor that takes N arguments"
+    private static readonly Regex Cs1729Rx =
+        new(@"'([^']+)' does not contain a constructor that takes (\d+) arguments", RegexOptions.Compiled);
+
+    // Regex for CS1674: "'Type': type used in a using statement must be implicitly convertible to …"
+    private static readonly Regex Cs1674Rx =
+        new(@"'([^']+)':\s*type used in a using statement", RegexOptions.Compiled);
 
     // Known BC platform AL object type prefixes used in generated C# class names.
     private static readonly string[] KnownObjectTypePrefixes = new[]
@@ -218,18 +234,67 @@ public static class TelemetryReporter
         // Extract CS code from formatted error: "ObjectName.cs(line,col): error CS1061: ..."
         var csCodeRx = new Regex(@"\berror (CS\d+):");
 
-        // First pass — build a grouping key from CS code + first quoted type name token.
+        // First pass — build a grouping key from CS code + enriched detail per error code.
         // For CS1061 we also accumulate the member names per group.
         return errors
             .GroupBy(err =>
             {
                 var codeMatch = csCodeRx.Match(err);
                 var code = codeMatch.Success ? codeMatch.Groups[1].Value : "CS????";
-                // Extract first single-quoted token from the message portion (after "error CSxxxx: ")
+                // Extract message portion (after "error CSxxxx: ")
                 var msgStart = codeMatch.Success ? codeMatch.Index + codeMatch.Length : 0;
                 var msgPortion = err[msgStart..];
-                var tokenMatch = singleQuoteRx.Match(msgPortion);
-                return tokenMatch.Success ? $"{code} on '{tokenMatch.Groups[1].Value}'" : code;
+
+                switch (code)
+                {
+                    case "CS1503":
+                    {
+                        // "Argument N: cannot convert from 'FromType' to 'ToType'"
+                        // Key captures both type names so different target types don't collapse.
+                        var m = Cs1503Rx.Match(msgPortion);
+                        if (m.Success)
+                            return $"{code}: '{m.Groups[1].Value}' → '{m.Groups[2].Value}'";
+                        break;
+                    }
+                    case "CS1501":
+                    {
+                        // "No overload for method 'Method' takes N arguments"
+                        var m = Cs1501Rx.Match(msgPortion);
+                        if (m.Success)
+                            return $"{code}: '{m.Groups[1].Value}' ({m.Groups[2].Value} args)";
+                        break;
+                    }
+                    case "CS0117":
+                    {
+                        // "'Type' does not contain a definition for 'Member'"
+                        // Key combines type (first token) AND missing member.
+                        var tokenMatch = singleQuoteRx.Match(msgPortion);
+                        var memberMatch = MemberNameRx.Match(msgPortion);
+                        if (tokenMatch.Success && memberMatch.Success)
+                            return $"{code}: '{tokenMatch.Groups[1].Value}.{memberMatch.Groups[1].Value}'";
+                        break;
+                    }
+                    case "CS1729":
+                    {
+                        // "'Type' does not contain a constructor that takes N arguments"
+                        var m = Cs1729Rx.Match(msgPortion);
+                        if (m.Success)
+                            return $"{code}: '{m.Groups[1].Value}' ctor({m.Groups[2].Value} args)";
+                        break;
+                    }
+                    case "CS1674":
+                    {
+                        // "'Type': type used in a using statement must be implicitly convertible to …"
+                        var m = Cs1674Rx.Match(msgPortion);
+                        if (m.Success)
+                            return $"{code}: '{m.Groups[1].Value}' not IDisposable";
+                        break;
+                    }
+                }
+
+                // Default: group by CS code + first quoted token (original behaviour, covers CS1061, CS0246, etc.)
+                var firstToken = singleQuoteRx.Match(msgPortion);
+                return firstToken.Success ? $"{code} on '{firstToken.Groups[1].Value}'" : code;
             })
             .Select(g =>
             {


### PR DESCRIPTION
## Summary

Fixes #1074.

`TelemetryReporter.DeduplicateCompilationErrors()` was grouping CS1503, CS1501, CS0117, CS1729, and CS1674 errors by only the first quoted token, losing critical diagnostic detail needed for actionable triage.

**Changes in `AlRunner/TelemetryReporter.cs`:**
- Added 4 compiled `Regex` instances (CS1503, CS1501, CS1729, CS1674) alongside the existing `MemberNameRx`
- Replaced the single fallback grouping expression with a `switch` on the CS error code; each case extracts the full distinguishing fields from the diagnostic message
- Grouping keys are now:
  - CS1503: `CS1503: 'NavText' → 'System.String'`
  - CS1501: `CS1501: 'ALSetRange' (3 args)`
  - CS0117: `CS0117: 'AlRunner.Runtime.AlScope.FooBar'`
  - CS1729: `CS1729: 'MockRecordHandle' ctor(3 args)`
  - CS1674: `CS1674: 'NavText' not IDisposable`
- CS1061 enrichment from #1039 is preserved unchanged
- Default fallback (first quoted token) still applies to all other error codes

**Changes in `AlRunner.Tests/TelemetryReporterTests.cs`:**
- 9 new `[Fact]` tests added following strict red→green TDD:
  - Positive case (both types/members captured, identical errors collapse)
  - Negative case (different distinguishing field → separate groups)
  - Covers all 5 error codes

## Test plan

- [x] 9 new C# unit tests written RED first, then GREEN after implementation
- [x] All 277 C# tests pass across net8.0 / net9.0 / net10.0
- [x] AL bucket-1 regressions: 1550 passed, 2 failed — same 2 pre-existing timezone failures as on `main`