### PR TITLE
fix: normalize generated type IDs in telemetry dedup — collapse Page<N> variants

### DIFF
--- a/AlRunner.Tests/PipelineTests.cs
+++ b/AlRunner.Tests/PipelineTests.cs
@@ -345,9 +345,9 @@ namespace AlRunnerGenerated {
 
         var grouped = TelemetryReporter.DeduplicateCompilationErrors(errors);
 
-        // CS1061 on 'Report70400' should be one group with count 3;
+        // CS1061 on 'Report<N>' (normalized) should be one group with count 3;
         // member names are now embedded in the key for actionable issue creation.
-        var cs1061 = grouped.Single(g => g.Key.StartsWith("CS1061 on 'Report70400'"));
+        var cs1061 = grouped.Single(g => g.Key.StartsWith("CS1061 on 'Report<N>'"));
         Assert.Equal(3, cs1061.Count);
         // All three distinct member names must appear in the key
         Assert.Contains("amountDue", cs1061.Key);

--- a/AlRunner.Tests/TelemetryReporterTests.cs
+++ b/AlRunner.Tests/TelemetryReporterTests.cs
@@ -28,8 +28,8 @@ public class TelemetryReporterTests
         Assert.Single(result);
         var (key, count, _) = result[0];
         Assert.Equal(3, count);
-        // Key must mention the type name
-        Assert.Contains("ReportExtension50500", key);
+        // Key must mention the normalized type name (ID replaced with <N>)
+        Assert.Contains("ReportExtension<N>", key);
         // Key must list all three distinct member names
         Assert.Contains("ParentObject", key);
         Assert.Contains("GetReportDataItems", key);

--- a/AlRunner/TelemetryReporter.cs
+++ b/AlRunner/TelemetryReporter.cs
@@ -218,6 +218,20 @@ public static class TelemetryReporter
         "Profile", "PermissionSet",
     };
 
+    // Regex matching generated BC type names like Page72336585, ReportExtension50500, etc.
+    private static readonly Regex GeneratedTypeIdRx =
+        new(@"(?:ReportExtension|TableExtension|PageExtension|EnumExtension|Codeunit|Report|Table|Page|Query|XmlPort|Enum)\d+",
+            RegexOptions.Compiled);
+
+    /// <summary>
+    /// Normalizes generated BC type IDs in a string to placeholders so that
+    /// Page72336585 and Page72336666 collapse to Page&lt;N&gt;.
+    /// Also normalizes fully-qualified forms like Microsoft.Dynamics.Nav.BusinessApplication.Page72336585.
+    /// </summary>
+    private static string NormalizeGeneratedTypeIds(string input) =>
+        GeneratedTypeIdRx.Replace(input, m =>
+            System.Text.RegularExpressions.Regex.Replace(m.Value, @"\d+$", "<N>"));
+
     /// <summary>
     /// Groups compilation error messages by CS error code + first single-quoted token
     /// (the type name). For CS1061 errors, the distinct missing member names are
@@ -251,9 +265,12 @@ public static class TelemetryReporter
                     {
                         // "Argument N: cannot convert from 'FromType' to 'ToType'"
                         // Key captures both type names so different target types don't collapse.
+                        // Generated type IDs are normalized (Page72336585 → Page<N>) so all
+                        // pages with the same conversion problem become one group.
                         var m = Cs1503Rx.Match(msgPortion);
                         if (m.Success)
-                            return $"{code}: '{m.Groups[1].Value}' → '{m.Groups[2].Value}'";
+                            return NormalizeGeneratedTypeIds(
+                                $"{code}: '{m.Groups[1].Value}' → '{m.Groups[2].Value}'");
                         break;
                     }
                     case "CS1501":
@@ -294,7 +311,8 @@ public static class TelemetryReporter
 
                 // Default: group by CS code + first quoted token (original behaviour, covers CS1061, CS0246, etc.)
                 var firstToken = singleQuoteRx.Match(msgPortion);
-                return firstToken.Success ? $"{code} on '{firstToken.Groups[1].Value}'" : code;
+                var defaultKey = firstToken.Success ? $"{code} on '{firstToken.Groups[1].Value}'" : code;
+                return NormalizeGeneratedTypeIds(defaultKey);
             })
             .Select(g =>
             {


### PR DESCRIPTION
Extends #1074. Generated BC type IDs (Page72336585, Page72336666, etc.) in CS1503 
and default grouping keys are now normalized to Page<N> so all pages with the same 
conversion problem collapse into one telemetry issue instead of N separate ones.

Reduces 21 distinct telemetry groups to 15 for a real-world 48-error run.