### PR TITLE
feat: add missing ALGetResource(4-arg) and StaticSaveAs(5/6-arg) overloads

### DIFF
--- a/AlRunner/Runtime/MockNavApp.cs
+++ b/AlRunner/Runtime/MockNavApp.cs
@@ -118,8 +118,12 @@ public static class MockNavApp
     public static void ALNavAppGetArchiveRecordRef(int tableId, MockRecordRef recordRef) { }
 
     /// NavApp.GetResource(ResourceName; var InStream) — no-op in standalone mode.
-    /// BC emits: ALNavApp.ALGetResource(null!, NavText, MockInStream)
+    /// BC emits: ALNavApp.ALGetResource(null!, NavText, ByRef&lt;MockInStream&gt;)
     public static void ALGetResource(object? errorLevel, NavText resourceName, MockInStream inStream) { }
+
+    /// NavApp.GetResource(ResourceName; var InStream; TextEncoding) — no-op in standalone mode.
+    /// BC emits: ALNavApp.ALGetResource(null!, NavText, ByRef&lt;MockInStream&gt;, TextEncoding)
+    public static void ALGetResource(object? errorLevel, NavText resourceName, MockInStream inStream, object? encoding) { }
 
     public static void ALNavAppLoadPackageData(object? errorLevel, int tableNo) { }
     public static void ALNavAppLoadPackageData(int tableNo) { }

--- a/AlRunner/Runtime/MockReportHandle.cs
+++ b/AlRunner/Runtime/MockReportHandle.cs
@@ -368,6 +368,18 @@ public class MockReportHandle
     // Report.SaveAs* — no-ops (no real file I/O in standalone mode)
     // BC emits NavReport.SaveAs*(DataError, int, string) — first arg is a DataError status object
     public static void StaticSaveAs(int reportId, string format, string path) { }
+
+    /// <summary>
+    /// BC emits <c>MockReportHandle.StaticSaveAs(DataError, reportId, requestData, format, ByRef&lt;OutStream&gt;)</c>
+    /// for <c>Report.SaveAs(ReportId, RequestData, Format, OutStream)</c>. No-op in standalone mode.
+    /// </summary>
+    public static void StaticSaveAs(object err, int reportId, string requestData, object format, MockOutStream outStream) { }
+
+    /// <summary>
+    /// BC emits <c>MockReportHandle.StaticSaveAs(DataError, reportId, requestData, format, ByRef&lt;OutStream&gt;, RecordRef)</c>
+    /// for <c>Report.SaveAs(ReportId, RequestData, Format, OutStream, RecordRef)</c>. No-op in standalone mode.
+    /// </summary>
+    public static void StaticSaveAs(object err, int reportId, string requestData, object format, MockOutStream outStream, MockRecordRef recordRef) { }
     public static void StaticSaveAsPdf(int reportId, string path) { }
     public static void StaticSaveAsPdf(object err, int reportId, string path) { }
     public static void StaticSaveAsWord(int reportId, string path) { }

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -4367,8 +4367,10 @@ NavApp.GetResource:
   layer: runtime-api
   category: NavApp
   status: covered
-  tests: tests/bucket-1/99-misc-stubs
-  notes: overloads=1; no-op standalone — no .app bundle to read resource from. Stub on MockNavApp.
+  tests:
+    - tests/bucket-1/99-misc-stubs
+    - tests/bucket-2/221-navapp-getresource-encoding
+  notes: overloads=2 (with/without TextEncoding); no-op standalone — no .app bundle to read resource from. Stub on MockNavApp. Fixes #1087.
 
 NavApp.GetResourceAsJson:
   layer: runtime-api
@@ -5417,9 +5419,10 @@ Report.SaveAs:
   layer: runtime-api
   category: Report
   status: covered
-  notes: overloads=1; NavReport.SaveAs → MockReportHandle.StaticSaveAs (no-op).
+  notes: overloads=3 (path-only, OutStream, OutStream+RecordRef); NavReport.SaveAs → MockReportHandle.StaticSaveAs (no-op). Fixes #1088.
   tests:
     - tests/bucket-1/90-report-static
+    - tests/bucket-2/222-report-saveas-recordref
 
 Report.SaveAsExcel:
   layer: runtime-api

--- a/tests/bucket-2/221-navapp-getresource-encoding/src/NavAppGetResourceEncodingSrc.al
+++ b/tests/bucket-2/221-navapp-getresource-encoding/src/NavAppGetResourceEncodingSrc.al
@@ -1,0 +1,36 @@
+/// Helper table providing a Blob field for InStream creation in tests.
+table 98100 "NGRE Blob"
+{
+    fields
+    {
+        field(1; "Entry No."; Integer) { }
+        field(2; Content; Blob) { }
+    }
+    keys
+    {
+        key(PK; "Entry No.") { Clustered = true; }
+    }
+}
+
+/// Exercises NavApp.GetResource(ResourceName; var InStream; TextEncoding) — the
+/// 3-AL-arg / 4-C#-arg overload (ResourceName + InStream + TextEncoding).
+codeunit 98101 "NavApp GetResource Encoding Src"
+{
+    procedure GetResourceWithEncoding(ResourceName: Text)
+    var
+        Rec: Record "NGRE Blob";
+        IS: InStream;
+    begin
+        Rec.Content.CreateInStream(IS);
+        NavApp.GetResource(ResourceName, IS, TextEncoding::UTF8);
+    end;
+
+    procedure GetResourceNoEncoding(ResourceName: Text)
+    var
+        Rec: Record "NGRE Blob";
+        IS: InStream;
+    begin
+        Rec.Content.CreateInStream(IS);
+        NavApp.GetResource(ResourceName, IS);
+    end;
+}

--- a/tests/bucket-2/221-navapp-getresource-encoding/test/NavAppGetResourceEncodingTest.al
+++ b/tests/bucket-2/221-navapp-getresource-encoding/test/NavAppGetResourceEncodingTest.al
@@ -1,0 +1,31 @@
+/// Tests that NavApp.GetResource with a TextEncoding parameter compiles and
+/// runs without throwing in standalone mode (no-op stub contract).
+codeunit 98102 "NavApp GetResource Encoding Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    [Test]
+    procedure GetResource_WithEncoding_IsNoOp()
+    var
+        Src: Codeunit "NavApp GetResource Encoding Src";
+    begin
+        // [GIVEN] A resource name and TextEncoding::UTF8
+        // [WHEN]  NavApp.GetResource(ResourceName, InStream, TextEncoding::UTF8) is called
+        // [THEN]  No exception — the 4-arg C# overload (with encoding) is a no-op
+        Src.GetResourceWithEncoding('test.txt');
+    end;
+
+    [Test]
+    procedure GetResource_WithoutEncoding_IsNoOp()
+    var
+        Src: Codeunit "NavApp GetResource Encoding Src";
+    begin
+        // [GIVEN] A resource name
+        // [WHEN]  NavApp.GetResource(ResourceName, InStream) is called (existing 3-arg form)
+        // [THEN]  No exception — regression guard for existing overload
+        Src.GetResourceNoEncoding('test.txt');
+    end;
+}

--- a/tests/bucket-2/222-report-saveas-recordref/src/ReportSaveAsRecordRefSrc.al
+++ b/tests/bucket-2/222-report-saveas-recordref/src/ReportSaveAsRecordRefSrc.al
@@ -1,0 +1,41 @@
+/// Helper table providing a Blob field for OutStream creation in tests.
+table 98200 "RSRR Blob"
+{
+    fields
+    {
+        field(1; "Entry No."; Integer) { }
+        field(2; Content; Blob) { }
+    }
+    keys
+    {
+        key(PK; "Entry No.") { Clustered = true; }
+    }
+}
+
+/// Exercises Report.SaveAs(ReportId; RequestData; Format; var OutStream; RecordRef) —
+/// the 5-arg static overload with a RecordRef filter parameter.
+codeunit 98201 "Report SaveAs RecordRef Src"
+{
+    procedure SaveAsWithRecordRef(ReportId: Integer; RequestData: Text)
+    var
+        Rec: Record "RSRR Blob";
+        RecRef: RecordRef;
+        OS: OutStream;
+        Format: ReportFormat;
+    begin
+        Rec.Content.CreateOutStream(OS);
+        Format := ReportFormat::Pdf;
+        Report.SaveAs(ReportId, RequestData, Format, OS, RecRef);
+    end;
+
+    procedure SaveAsWithoutRecordRef(ReportId: Integer; RequestData: Text)
+    var
+        Rec: Record "RSRR Blob";
+        OS: OutStream;
+        Format: ReportFormat;
+    begin
+        Rec.Content.CreateOutStream(OS);
+        Format := ReportFormat::Pdf;
+        Report.SaveAs(ReportId, RequestData, Format, OS);
+    end;
+}

--- a/tests/bucket-2/222-report-saveas-recordref/test/ReportSaveAsRecordRefTest.al
+++ b/tests/bucket-2/222-report-saveas-recordref/test/ReportSaveAsRecordRefTest.al
@@ -1,0 +1,31 @@
+/// Tests that Report.SaveAs with a RecordRef parameter compiles and runs
+/// without throwing in standalone mode (no-op stub contract).
+codeunit 98202 "Report SaveAs RecordRef Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    [Test]
+    procedure Report_SaveAs_WithRecordRef_IsNoOp()
+    var
+        Src: Codeunit "Report SaveAs RecordRef Src";
+    begin
+        // [GIVEN] A report id, request data, and a RecordRef
+        // [WHEN]  Report.SaveAs(Id, RequestData, Format, OutStream, RecordRef) is called
+        // [THEN]  No exception — the 5-arg static overload is a no-op in standalone mode
+        Src.SaveAsWithRecordRef(99999, '');
+    end;
+
+    [Test]
+    procedure Report_SaveAs_WithoutRecordRef_IsNoOp()
+    var
+        Src: Codeunit "Report SaveAs RecordRef Src";
+    begin
+        // [GIVEN] A report id and request data
+        // [WHEN]  Report.SaveAs(Id, RequestData, Format, OutStream) is called (existing form)
+        // [THEN]  No exception — regression guard for existing 4-arg overload
+        Src.SaveAsWithoutRecordRef(99999, '');
+    end;
+}


### PR DESCRIPTION
## Summary

- **#1087** — `NavApp.GetResource(ResourceName; var InStream; TextEncoding)`: adds 4-arg C# overload `MockNavApp.ALGetResource(object?, NavText, MockInStream, object?)` as a no-op stub. New test suite `221-navapp-getresource-encoding`.
- **#1088** — `Report.SaveAs(ReportId, RequestData, Format, OutStream[, RecordRef])`: adds 5-arg and 6-arg `MockReportHandle.StaticSaveAs` overloads (with `DataError + NavReportFormat + ByRef<MockOutStream>` and optional `MockRecordRef`) as no-op stubs. New test suite `222-report-saveas-recordref`.
- `docs/coverage.yaml` updated for both methods.

## Test plan

- [x] Suite 221: RED confirmed (`CS1501: ALGetResource takes 4 arguments`), GREEN after fix (2/2 pass)
- [x] Suite 222: RED confirmed (`CS1501: StaticSaveAs takes 5/6 arguments`), GREEN after fix (2/2 pass)
- [x] Bucket-1: 1550 passed, 2 failed (pre-existing timezone failures, unrelated)
- [x] Bucket-2: 1573 passed, 3 failed, 1 blocked (pre-existing, unrelated)

Closes #1087
Closes #1088