### PR TITLE
fix: SecretText in HTTP headers/content — resolve CS1503 NavSecretText/string type mismatches

### DIFF
--- a/AlRunner/Runtime/AlScope.cs
+++ b/AlRunner/Runtime/AlScope.cs
@@ -1906,6 +1906,16 @@ public static class AlCompat
         => content.ALLoadFrom(text);
 
     /// <summary>
+    /// Overload for <c>HttpContent.WriteFrom(SecretText)</c>.
+    /// BC emits <c>AlCompat.HttpContentLoadFrom(content, NavSecretText)</c> after
+    /// the ALLoadFrom redirect — resolving the <c>NavSecretText → MockInStream</c>
+    /// type mismatch (#1086). In standalone mode secrets are treated as plain text:
+    /// the value is unwrapped and stored as UTF-8 text content.
+    /// </summary>
+    public static void HttpContentLoadFrom(MockHttpContent content, NavSecretText secret)
+        => content.ALLoadFrom(Unwrap(secret));
+
+    /// <summary>
     /// Replacement for MockHttpContent.ALReadAs(ITreeObject, DataError, ByRef&lt;MockInStream&gt;).
     /// BC emits content.ALReadAs(this, DataError.ThrowError, stream) for
     /// HttpContent.ReadAs(var Stream: InStream). Returns a MockInStream whose data

--- a/AlRunner/Runtime/MockHttpHeaders.cs
+++ b/AlRunner/Runtime/MockHttpHeaders.cs
@@ -27,7 +27,7 @@ public class MockHttpHeaders
 
     /// <summary>
     /// BC emits: <c>headers.ALAdd(DataError, key, value)</c>
-    /// for <c>HttpHeaders.Add(key, value)</c>.
+    /// for <c>HttpHeaders.Add(key, value)</c> (Text overload).
     /// </summary>
     public void ALAdd(DataError errorLevel, string key, string value)
     {
@@ -38,6 +38,15 @@ public class MockHttpHeaders
         }
         list.Add(value);
     }
+
+    /// <summary>
+    /// BC emits: <c>headers.ALAdd(DataError, key, secretValue)</c>
+    /// for <c>HttpHeaders.Add(key, SecretText)</c>.
+    /// In standalone mode secrets are treated as plain text — the value
+    /// is extracted via <see cref="AlCompat.Unwrap"/> and stored normally.
+    /// </summary>
+    public void ALAdd(DataError errorLevel, string key, NavSecretText secretValue)
+        => ALAdd(errorLevel, key, (string)AlCompat.Unwrap(secretValue));
 
     /// <summary>
     /// BC emits: <c>headers.ALContains(key)</c>
@@ -98,12 +107,25 @@ public class MockHttpHeaders
 
     /// <summary>
     /// BC emits: <c>headers.ALTryAddWithoutValidation(DataError, name, value)</c>
-    /// for <c>HttpHeaders.TryAddWithoutValidation(name, value)</c>.
+    /// for <c>HttpHeaders.TryAddWithoutValidation(name, value)</c> (Text overload).
     /// Adds the header without format validation; always succeeds.
     /// </summary>
     public bool ALTryAddWithoutValidation(DataError errorLevel, NavText name, NavText value)
     {
         ALAdd(errorLevel, (string)name, (string)value);
+        return true;
+    }
+
+    /// <summary>
+    /// Overload for <c>HttpHeaders.TryAddWithoutValidation(name, SecretText)</c>.
+    /// BC emits <c>ALTryAddWithoutValidation(DataError, string-literal, NavSecretText)</c>
+    /// when the header name is a text literal and the value is a SecretText — resolving
+    /// both the <c>string → NavText</c> (#1091) and <c>NavSecretText → NavText</c> (#1086)
+    /// type mismatches. In standalone mode secrets are treated as plain text.
+    /// </summary>
+    public bool ALTryAddWithoutValidation(DataError errorLevel, string name, NavSecretText secretValue)
+    {
+        ALAdd(errorLevel, name, (string)AlCompat.Unwrap(secretValue));
         return true;
     }
 

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -2988,8 +2988,8 @@ HttpContent.WriteFrom:
   layer: runtime-api
   category: HttpContent
   status: covered
-  tests: tests/bucket-1/173-httpcontent-response-methods
-  notes: overloads=3; text overload via ALLoadFrom(NavText); stream/secret overloads via AlCompat redirect
+  tests: tests/bucket-1/173-httpcontent-response-methods, tests/bucket-1/290-secrettext-http
+  notes: overloads=3; text overload via ALLoadFrom(NavText); stream overload via AlCompat.HttpContentLoadFrom(MockInStream); SecretText overload via AlCompat.HttpContentLoadFrom(NavSecretText) — unwraps secret and stores as plain text (#1086)
 
 # ── HttpHeaders ─────────────────────────────────────────────────
 
@@ -2997,7 +2997,8 @@ HttpHeaders.Add:
   layer: runtime-api
   category: HttpHeaders
   status: covered
-  notes: overloads=2
+  tests: tests/bucket-1/290-secrettext-http
+  notes: overloads=3; Text overload (string key, string value); SecretText overload (string key, NavSecretText) — unwraps secret (#1086)
 
 HttpHeaders.Clear:
   layer: runtime-api
@@ -3045,7 +3046,8 @@ HttpHeaders.TryAddWithoutValidation:
   layer: runtime-api
   category: HttpHeaders
   status: covered
-  notes: overloads=2
+  tests: tests/bucket-1/290-secrettext-http
+  notes: overloads=3; NavText/NavText overload; string/NavSecretText overload for literal-name + SecretText-value pattern — resolves string→NavText (#1091) and NavSecretText→NavText gaps
 
 # ── HttpRequestMessage ──────────────────────────────────────────
 

--- a/tests/bucket-1/290-secrettext-http/src/SecretTextHttpSrc.al
+++ b/tests/bucket-1/290-secrettext-http/src/SecretTextHttpSrc.al
@@ -1,0 +1,47 @@
+/// Helper codeunit exercising SecretText in HTTP patterns — issues #1086, #1091.
+///
+/// Exercises:
+///   HttpHeaders.Add(name, SecretText)           — generates ALAdd(DataError, string, NavSecretText)
+///   HttpHeaders.TryAddWithoutValidation(lit, st) — generates ALTryAddWithoutValidation(DataError, string, NavSecretText)
+///   HttpContent.WriteFrom(SecretText)            — generates AlCompat.HttpContentLoadFrom(content, NavSecretText)
+codeunit 165001 "STH Src"
+{
+    /// Add a SecretText header using HttpHeaders.Add.
+    /// BC emits: headers.ALAdd(DataError, string, NavSecretText)
+    procedure AddSecretHeader(name: Text; plainValue: Text)
+    var
+        headers: HttpHeaders;
+        req: HttpRequestMessage;
+        secretVal: SecretText;
+    begin
+        secretVal := plainValue;
+        req.GetHeaders(headers);
+        headers.Add(name, secretVal);
+    end;
+
+    /// TryAddWithoutValidation with a literal name and SecretText value.
+    /// BC emits: ALTryAddWithoutValidation(DataError, "Authorization", NavSecretText)
+    /// — string → NavText (#1091) and NavSecretText → NavText gaps.
+    procedure TryAddSecretHeader(plainValue: Text): Boolean
+    var
+        headers: HttpHeaders;
+        req: HttpRequestMessage;
+        secretVal: SecretText;
+    begin
+        secretVal := plainValue;
+        req.GetHeaders(headers);
+        exit(headers.TryAddWithoutValidation('Authorization', secretVal));
+    end;
+
+    /// WriteFrom with a SecretText value.
+    /// BC emits: AlCompat.HttpContentLoadFrom(content, NavSecretText)
+    /// — NavSecretText → MockInStream gap (#1086).
+    procedure WriteSecretContent(plainValue: Text)
+    var
+        content: HttpContent;
+        secretVal: SecretText;
+    begin
+        secretVal := plainValue;
+        content.WriteFrom(secretVal);
+    end;
+}

--- a/tests/bucket-1/290-secrettext-http/test/SecretTextHttpTest.al
+++ b/tests/bucket-1/290-secrettext-http/test/SecretTextHttpTest.al
@@ -1,0 +1,43 @@
+/// Tests for SecretText in HTTP patterns — issues #1086, #1091.
+codeunit 165002 "STH Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit "Library Assert";
+        Helper: Codeunit "STH Src";
+
+    /// HttpHeaders.Add(name, SecretText) must not throw.
+    [Test]
+    procedure AddSecretHeader_NoThrow()
+    begin
+        // [GIVEN] A non-empty secret value
+        // [WHEN] Adding a secret header using HttpHeaders.Add(name, SecretText)
+        Helper.AddSecretHeader('Authorization', 'bearer-token-abc');
+        // [THEN] No error thrown — compilation and execution succeed
+    end;
+
+    /// HttpHeaders.TryAddWithoutValidation(literal, SecretText) must return true.
+    /// Covers: string → NavText (#1091) and NavSecretText → NavText gaps.
+    [Test]
+    procedure TryAddSecretHeader_ReturnsTrue()
+    var
+        Result: Boolean;
+    begin
+        // [GIVEN] A non-empty secret value
+        // [WHEN] TryAddWithoutValidation with literal name and SecretText value
+        Result := Helper.TryAddSecretHeader('my-api-key-xyz');
+        // [THEN] Returns true (always-succeed stub; non-default value proves mock works)
+        Assert.IsTrue(Result, 'TryAddWithoutValidation with SecretText must return true');
+    end;
+
+    /// HttpContent.WriteFrom(SecretText) must not throw — covers #1086.
+    [Test]
+    procedure WriteSecretContent_NoThrow()
+    begin
+        // [GIVEN] A non-empty secret value
+        // [WHEN] Writing SecretText to HttpContent
+        Helper.WriteSecretContent('secret-body-content');
+        // [THEN] No error thrown — NavSecretText → MockInStream gap resolved
+    end;
+}


### PR DESCRIPTION
## Summary

Fixes #1086 and #1091 — three CS1503 type-mismatch gaps when AL code uses `SecretText` in HTTP patterns:

- **`NavSecretText → MockInStream`** (#1086): `HttpContent.WriteFrom(SecretText)` generates `AlCompat.HttpContentLoadFrom(content, NavSecretText)` but `HttpContentLoadFrom` had no `NavSecretText` overload. Added `HttpContentLoadFrom(MockHttpContent, NavSecretText)` to `AlCompat` — unwraps the secret and stores as plain text.
- **`string → NavText`** (#1091): `HttpHeaders.TryAddWithoutValidation('Authorization', secretVal)` generates `ALTryAddWithoutValidation(DataError, "Authorization", NavSecretText)` where `"Authorization"` is a raw C# string literal. The existing overload takes `NavText` for the name. Added `ALTryAddWithoutValidation(DataError, string, NavSecretText)` overload.
- **`NavSecretText → string`**: `HttpHeaders.Add(name, SecretText)` generates `ALAdd(DataError, string, NavSecretText)` — the existing `ALAdd(DataError, string, string)` can't accept `NavSecretText`. Added `ALAdd(DataError, string, NavSecretText)` overload.

In standalone mode there is no security boundary, so secrets are treated as plain text (same policy as `IsolatedStorage` and `JsonObject` secret methods).

## Changes

- `AlRunner/Runtime/AlScope.cs`: add `AlCompat.HttpContentLoadFrom(MockHttpContent, NavSecretText)` overload
- `AlRunner/Runtime/MockHttpHeaders.cs`: add `ALAdd(DataError, string, NavSecretText)` and `ALTryAddWithoutValidation(DataError, string, NavSecretText)` overloads
- `tests/bucket-1/290-secrettext-http/`: new test suite (3 tests, all RED→GREEN verified)
- `docs/coverage.yaml`: updated `HttpContent.WriteFrom`, `HttpHeaders.Add`, `HttpHeaders.TryAddWithoutValidation` entries

## Test plan

- [ ] `290-secrettext-http/AddSecretHeader_NoThrow` — `HttpHeaders.Add(name, SecretText)` compiles and runs
- [ ] `290-secrettext-http/TryAddSecretHeader_ReturnsTrue` — `TryAddWithoutValidation(literal, SecretText)` returns true
- [ ] `290-secrettext-http/WriteSecretContent_NoThrow` — `HttpContent.WriteFrom(SecretText)` compiles and runs
- [ ] Bucket-1: 1553 passed, 2 pre-existing failures (DT2Time timezone, unrelated)
- [ ] Bucket-2: pre-existing missing-dependency failure, unrelated to this PR