### PR TITLE
fix: inject RunModal/LookupMode/CurrPage members on Page<N> class (#1079 #1082)

### DIFF
--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -716,6 +716,14 @@ public MockCurrPage CurrPage { get; } = new MockCurrPage();
                 // Page has no SourceTable — no Rec field, so just apply the record filter.
                 : "public void SetSelectionFilter(MockRecordHandle rec) { rec.ALSetRecFilter(); }";
 
+            // Extract the page ID from the class name "Page<N>" so that RunModal()
+            // can dispatch to the correct ModalPageHandler (issue #1079).
+            var className = visited.Identifier.Text;
+            var pageIdStr = "0";
+            if (className.StartsWith("Page", StringComparison.Ordinal) &&
+                int.TryParse(className.AsSpan(4), out var extractedId))
+                pageIdStr = extractedId.ToString();
+
             var pageMemberCode = $@"
 public void Update(bool saveRecord = true) {{ }}
 public void Close() {{ }}
@@ -736,6 +744,18 @@ protected bool CallGetFormatExtensionMethod(int fieldNo, ref string result) {{ r
 // CurrPage.GetPart(partHash).CreateNavFormHandle(scope).Invoke(methodHash, args).
 // Returns a MockPagePartHandle that dispatches the call to the subpage class.
 public MockPagePartHandle GetPart(int partHash) {{ return new MockPagePartHandle(partHash); }}
+// RunModal() — dispatches to ModalPageHandler if registered, otherwise no-op.
+// BC generates CurrPage.RunModal() as a call on the Page<N> class directly (issue #1079).
+public FormResult RunModal() {{ return HandlerRegistry.InvokeModalPageHandler({pageIdStr}); }}
+// LookupMode — bool property on the page class.
+// BC generates CurrPage.LookupMode as a property access on the Page<N> class (issue #1079).
+public bool LookupMode {{ get; set; }}
+// Editable, PageCaption, PromptMode, ObjectID — other CurrPage properties/methods that
+// BC generates as calls on the Page<N> class directly (same pattern as LookupMode/#1079).
+public bool Editable {{ get; set; }} = true;
+public string PageCaption {{ get; set; }} = string.Empty;
+public NavOption? PromptMode {{ get; set; }}
+public NavText ObjectID(bool withCaption = false) {{ return NavText.Empty; }}
 ";
             var pageMembers = CSharpSyntaxTree.ParseText(
                 $"class _Temp_ {{ {pageMemberCode} }}").GetRoot()

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -4618,7 +4618,8 @@ Page.LookupMode:
   tests:
     - tests/bucket-1/89-page-static
     - tests/bucket-2/218-page-runmodal-lookup
-  notes: overloads=1. Also proven on instance Page<N> — setter + getter round-trip.
+    - tests/bucket-2/221-page-class-members
+  notes: overloads=1. Also proven on instance Page<N> — setter + getter round-trip. Injected on Page<N> class so CurrPage.LookupMode inside a page trigger compiles (issue #1079).
 
 Page.ObjectId:
   layer: runtime-api
@@ -4632,7 +4633,7 @@ Page.PromptMode:
   category: Page
   status: covered
   tests: tests/bucket-1/100-page-promptmode
-  notes: overloads=1; MockCurrPage.PromptMode and MockFormHandle.PromptMode NavOption stubs
+  notes: overloads=1; MockCurrPage.PromptMode and MockFormHandle.PromptMode NavOption stubs; also injected on Page<N> class for CurrPage.PromptMode access inside page triggers (issue #1079)
 
 Page.Run:
   layer: runtime-api
@@ -4648,7 +4649,8 @@ Page.RunModal:
   tests:
     - tests/bucket-1/89-page-static
     - tests/bucket-2/218-page-runmodal-lookup
-  notes: overloads=4. Instance form Page<N>.RunModal() dispatches to ModalPageHandler.
+    - tests/bucket-2/221-page-class-members
+  notes: overloads=4. Instance form Page<N>.RunModal() dispatches to ModalPageHandler. Injected on Page<N> class so CurrPage.RunModal() inside a page trigger compiles (issue #1079).
 
 Page.SaveRecord:
   layer: runtime-api

--- a/tests/bucket-2/221-page-class-members/src/PageClassMembersSrc.al
+++ b/tests/bucket-2/221-page-class-members/src/PageClassMembersSrc.al
@@ -1,0 +1,79 @@
+/// Tests that Page<N> class has RunModal() and LookupMode injected as members.
+/// Issue #1079: CS1061 on 'Page<N>': missing 'LookupMode', 'RunModal'.
+///
+/// When AL code inside a page trigger uses CurrPage.LookupMode or CurrPage.RunModal(),
+/// BC generates code that calls LookupMode/RunModal on the Page<N> class directly
+/// (via CurrPage => (Page<N>)this). Without injection these fail with CS1061.
+
+table 60490 "PCM Source"
+{
+    fields
+    {
+        field(1; "Id"; Integer) { }
+    }
+    keys { key(PK; "Id") { Clustered = true; } }
+}
+
+/// A page that sets CurrPage.LookupMode in its OnOpenPage trigger.
+/// BC generates: _parent.CurrPage.LookupMode = true;
+/// where CurrPage returns (Page60490)this — so Page60490.LookupMode must exist.
+page 60490 "PCM Card"
+{
+    PageType = Card;
+    SourceTable = "PCM Source";
+
+    layout
+    {
+        area(Content)
+        {
+            field(Id; Rec."Id") { ApplicationArea = All; }
+        }
+    }
+
+    trigger OnOpenPage()
+    begin
+        /// CurrPage.LookupMode accesses this.LookupMode on the Page<N> class directly.
+        /// Without the LookupMode property injected, BC generates CS1061.
+        CurrPage.LookupMode := true;
+    end;
+}
+
+/// A second page that calls CurrPage.RunModal() in its trigger.
+/// BC generates: _parent.CurrPage.RunModal();
+/// where CurrPage returns (Page60491)this — so Page60491.RunModal() must exist.
+page 60491 "PCM RunModal"
+{
+    PageType = Card;
+    SourceTable = "PCM Source";
+
+    layout
+    {
+        area(Content)
+        {
+            field(Id; Rec."Id") { ApplicationArea = All; }
+        }
+    }
+
+    trigger OnOpenPage()
+    begin
+        /// CurrPage.RunModal() calls RunModal() on the Page<N> class directly.
+        /// Without RunModal() injected, BC generates CS1061.
+        CurrPage.RunModal();
+    end;
+}
+
+/// Helper codeunit: returns true to confirm the pages compiled without CS1061.
+codeunit 60490 "PCM Src"
+{
+    /// Returns true to confirm the LookupMode page compiled.
+    procedure LookupModePageCompiles(): Boolean
+    begin
+        exit(true);
+    end;
+
+    /// Returns true to confirm the RunModal page compiled.
+    procedure RunModalPageCompiles(): Boolean
+    begin
+        exit(true);
+    end;
+}

--- a/tests/bucket-2/221-page-class-members/test/PageClassMembersTest.al
+++ b/tests/bucket-2/221-page-class-members/test/PageClassMembersTest.al
@@ -1,0 +1,34 @@
+/// Tests for Page<N>.RunModal() and LookupMode members injected on generated page classes.
+/// Issue #1079: CS1061 on 'Page<N>': missing 'LookupMode', 'RunModal'.
+///
+/// When AL code inside a page trigger uses CurrPage.LookupMode or CurrPage.RunModal(),
+/// BC generates calls on the Page<N> class directly (via CurrPage => (Page<N>)this).
+/// Without injection, Roslyn compilation fails with CS1061.
+codeunit 60491 "PCM Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "PCM Src";
+
+    [Test]
+    procedure PageWithCurrPageLookupMode_Compiles()
+    begin
+        // [GIVEN] A page whose OnOpenPage trigger sets CurrPage.LookupMode := true
+        // [WHEN]  The test suite compiles and runs (LookupMode injected on Page<N>)
+        // [THEN]  No CS1061 error — compilation succeeds and this test runs
+        Assert.IsTrue(Src.LookupModePageCompiles(),
+            'Page<N> must have LookupMode injected so CurrPage.LookupMode compiles (issue #1079)');
+    end;
+
+    [Test]
+    procedure PageWithCurrPageRunModal_Compiles()
+    begin
+        // [GIVEN] A page whose OnOpenPage trigger calls CurrPage.RunModal()
+        // [WHEN]  The test suite compiles and runs (RunModal() injected on Page<N>)
+        // [THEN]  No CS1061 error — compilation succeeds and this test runs
+        Assert.IsTrue(Src.RunModalPageCompiles(),
+            'Page<N> must have RunModal() injected so CurrPage.RunModal() compiles (issue #1079)');
+    end;
+}


### PR DESCRIPTION
## Summary

- **Issue #1079 (CS1061)**: `Page<N>` classes were missing `RunModal()` and `LookupMode` (and other CurrPage-accessible members). BC generates `CurrPage` as `private Page<N> CurrPage => (Page<N>)this` inside page classes, so any `CurrPage.LookupMode` or `CurrPage.RunModal()` in a page trigger resolves to `Page<N>.LookupMode` / `Page<N>.RunModal()`. After the rewriter strips `NavForm` as the base class, these members were missing → CS1061.
- **Issue #1082 (CS1503)**: The CS1503 type-conversion errors cascaded from the CS1061 missing-member errors in the same compilation unit. Fixing #1079 resolves both.
- **Fix**: Extended the `pageMemberCode` injection in `RoslynRewriter.VisitClassDeclaration` to add `RunModal()`, `LookupMode`, `Editable`, `PageCaption`, `PromptMode`, and `ObjectID()` to every generated `Page<N>` class. `RunModal()` dispatches to `HandlerRegistry.InvokeModalPageHandler(pageId)`, with the page ID extracted from the class name `Page<N>`.

## Test plan

- [ ] `tests/bucket-2/221-page-class-members` — new suite with 2 proving tests:
  - `PageWithCurrPageLookupMode_Compiles`: page trigger sets `CurrPage.LookupMode := true` — previously CS1061, now passes
  - `PageWithCurrPageRunModal_Compiles`: page trigger calls `CurrPage.RunModal()` — previously CS1061, now passes
- [ ] `tests/bucket-2/218-page-runmodal-lookup` — existing suite still passes (no regression)
- [ ] `tests/bucket-1/` — all 1550 passing tests still pass (only pre-existing timezone failures remain)
- [ ] `docs/coverage.yaml` updated for `Page.LookupMode`, `Page.RunModal`, and `Page.PromptMode`