### PR TITLE
fix: resolve codeunit 165001 ID collision

### DIFF
--- a/tests/bucket-1/290-testfield-errorinfo/src/TestFieldEISrc.al
+++ b/tests/bucket-1/290-testfield-errorinfo/src/TestFieldEISrc.al
@@ -2,7 +2,7 @@
 /// Tests that TestField(Field, Value, ErrorInfo) and TestField(Field, ErrorInfo)
 /// compile and behave correctly — resolves CS1501 (4-arg ALTestFieldSafe overload
 /// missing) tracked in issues #1083, #1084, #1089.
-table 165001 "TFEi Record"
+table 166001 "TFEi Record"
 {
     fields
     {

--- a/tests/bucket-1/290-testfield-errorinfo/test/TestFieldEITest.al
+++ b/tests/bucket-1/290-testfield-errorinfo/test/TestFieldEITest.al
@@ -7,7 +7,7 @@
 /// Before fix: both produced CS1501 (no 4-arg overload) or CS1503 (wrong type match).
 /// After fix:  compile and execute correctly — the ErrorInfo is used as error context
 ///             when the check fails, and ignored when it passes (issues #1083, #1084, #1089).
-codeunit 165001 "TFEi Test"
+codeunit 166001 "TFEi Test"
 {
     Subtype = Test;
 


### PR DESCRIPTION
Codeunit 165001 used by both 290-secrettext-http and 290-testfield-errorinfo. Changed testfield-errorinfo to 166001/166002.