### PR TITLE
fix: AlScope.Parent virtual instance — CS0176 (#1105)

### DIFF
--- a/AlRunner.Tests/AlScopeParentTests.cs
+++ b/AlRunner.Tests/AlScopeParentTests.cs
@@ -5,52 +5,82 @@ using Xunit;
 namespace AlRunner.Tests;
 
 /// <summary>
-/// Unit tests for AlScope.Parent static property — issue #1092.
+/// Unit tests for AlScope.Parent instance property — issues #1092 and #1105.
 ///
-/// The BC compiler emits `AlScope.Parent` as a static member access in some
-/// scope class contexts (e.g. when a test codeunit trigger references a parent
-/// scope through the class name rather than the base instance). Without a static
-/// `Parent` property on AlScope, the generated C# fails with:
-///   CS0117: 'AlScope' does not contain a definition for 'Parent'
+/// The BC compiler emits `Parent` access in scope class bodies in two patterns:
+///   • Some versions use `base.Parent.xxx` (handled by the RoslynRewriter rewrite)
+///   • Other versions use `this.Parent` (instance access on the scope class)
 ///
-/// The fix adds a static null-returning stub so the generated code compiles.
-/// Because the real parent reference is always accessed through the injected
-/// instance property on the concrete scope subclass, returning null here is safe.
+/// Issue #1092 (CS0117) was fixed by adding a static `Parent` stub.
+/// Issue #1105 (CS0176) shows that `this.Parent` in a scope class where the
+/// enclosing-type injection was skipped causes CS0176 ("static member accessed
+/// with an instance reference") because the static `AlScope.Parent` is resolved.
+///
+/// The correct fix: `Parent` must be an **instance** property on `AlScope`.
+/// This allows `this.Parent` to resolve correctly at both compile-time and runtime.
+/// The injected `public TParent Parent => _parent` on concrete scope subclasses
+/// hides (not overrides) the base instance property, so both levels work.
 /// </summary>
 public class AlScopeParentTests
 {
     /// <summary>
-    /// Positive: AlScope.Parent is a static property accessible as a class-level member.
-    /// This is a no-op stub test — the entire claim is "AlScope.Parent exists and does not crash."
-    /// Without this property, CS0117 fires when BC-generated C# accesses AlScope.Parent statically.
+    /// Positive: AlScope.Parent is an *instance* property (not static).
+    /// An instance property prevents CS0176 when BC-generated C# accesses Parent
+    /// via `this.Parent` on a scope class that inherits from AlScope.
     /// </summary>
     [Fact]
-    public void AlScope_StaticParent_Exists()
+    public void AlScope_InstanceParent_Exists()
     {
         var prop = typeof(AlScope).GetProperty(
             "Parent",
-            BindingFlags.Public | BindingFlags.Static);
+            BindingFlags.Public | BindingFlags.Instance);
 
         Assert.NotNull(prop);
     }
 
     /// <summary>
-    /// Positive: AlScope.Parent returns null (the safe no-op stub value).
-    /// Verifies the stub is not a throwing accessor — static access must succeed.
+    /// Negative: AlScope.Parent must NOT be static, so that `this.Parent` in scope
+    /// subclasses does not trigger CS0176.
     /// </summary>
     [Fact]
-    public void AlScope_StaticParent_ReturnsNull()
+    public void AlScope_Parent_IsNotStatic()
     {
-        // Access AlScope.Parent directly at the type level (not through an instance).
-        // This is exactly what the BC-generated code does when it emits AlScope.Parent.
-        var prop = typeof(AlScope).GetProperty(
+        var staticProp = typeof(AlScope).GetProperty(
             "Parent",
             BindingFlags.Public | BindingFlags.Static);
 
+        Assert.Null(staticProp);
+    }
+
+    /// <summary>
+    /// Positive: AlScope.Parent returns null on a base instance.
+    /// The instance property is a safe no-op stub — concrete scope subclasses
+    /// shadow it with their own injected `public T Parent => _parent` property.
+    /// </summary>
+    [Fact]
+    public void AlScope_InstanceParent_ReturnsNull()
+    {
+        var prop = typeof(AlScope).GetProperty(
+            "Parent",
+            BindingFlags.Public | BindingFlags.Instance);
+
         Assert.NotNull(prop);
 
-        var value = prop!.GetValue(null);
+        // AlScope is abstract — use a minimal concrete subclass to access via instance.
+        var instance = new MinimalAlScope();
+        var value = prop!.GetValue(instance);
 
         Assert.Null(value);
+    }
+
+    /// <summary>
+    /// Minimal concrete AlScope subclass for reflection-based instance tests.
+    /// Mimics the structure of a BC-generated scope class (after rewriting) that
+    /// does NOT shadow Parent with its own injected property — i.e., the worst case
+    /// where the fallback to AlScope.Parent must succeed as an instance access.
+    /// </summary>
+    private sealed class MinimalAlScope : AlScope
+    {
+        protected override void OnRun() { }
     }
 }

--- a/AlRunner/Runtime/AlScope.cs
+++ b/AlRunner/Runtime/AlScope.cs
@@ -209,19 +209,24 @@ public class AlScope : IDisposable, ITreeObject
     public static string LastErrorCallStack { get; set; } = "";
 
     /// <summary>
-    /// Static null-returning stub for <c>AlScope.Parent</c> — issue #1092.
+    /// Instance null-returning stub for <c>Parent</c> — issues #1092 and #1105.
     ///
-    /// Some BC compiler versions emit <c>AlScope.Parent</c> as a static member
-    /// access in generated scope class code (e.g. when a test codeunit trigger
-    /// references a parent scope). Without this static property, the generated
-    /// C# fails with CS0117: 'AlScope' does not contain a definition for 'Parent'.
+    /// Some BC compiler versions emit <c>this.Parent</c> (instance access) in
+    /// generated scope class code when a scope class body references a parent
+    /// codeunit field. Without this instance property, the generated C# fails with:
+    ///   CS0176: 'AlScope.Parent' cannot be accessed with an instance reference.
     ///
-    /// The real parent reference is always accessed through the instance <c>Parent</c>
-    /// property injected by <see cref="RoslynRewriter"/> into the concrete scope
-    /// subclass, so returning null here is safe — this static stub is never reached
-    /// at runtime when the rewriter has correctly wired the <c>_parent</c> field.
+    /// Earlier versions (issue #1092) emitted a static class-qualified access that
+    /// was fixed with a static property, but that caused CS0176 for the instance
+    /// pattern. The correct fix is an instance (virtual) property so that both
+    /// <c>this.Parent</c> and <c>base.Parent</c> compile and resolve correctly.
+    ///
+    /// The real parent reference is always accessed through the injected instance
+    /// property on the concrete scope subclass (e.g. <c>public Codeunit123 Parent => _parent;</c>)
+    /// which shadows this base stub, so returning null here is safe — this base
+    /// stub is only reached when the rewriter did not inject a typed Parent.
     /// </summary>
-    public static object? Parent => null;
+    public virtual object? Parent => null;
 
     // ── Collectible errors ──────────────────────────────────────────────
     // Thread-static to avoid cross-test contamination in parallel scenarios.

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -37,19 +37,21 @@ codeunit_declaration:
     - tests/bucket-1/112-codeunit-onrun-record
     - tests/bucket-2/216-inherent-permissions
 
-alscope_parent_static:
+alscope_parent_instance:
   layer: syntax
   category: object
   status: covered
   notes: >
-    AlScope.Parent static property stub — issue #1092.
-    Some BC compiler versions emit AlScope.Parent as a static member access in
-    generated scope class code, causing CS0117. The fix adds a static null-returning
-    stub on AlScope so the generated C# compiles. The real parent reference is always
-    accessed through the instance Parent property injected by RoslynRewriter into the
-    concrete scope subclass. Verified by reflection unit tests and AL integration tests.
+    AlScope.Parent instance property stub — issues #1092 and #1105.
+    Some BC compiler versions emit this.Parent (instance access) in scope class bodies;
+    others emit AlScope.Parent (static class access). A static stub fixed CS0117 (#1092)
+    but introduced CS0176 for instance access (#1105). The fix changes Parent to a virtual
+    instance property so both this.Parent and base.Parent compile and resolve correctly.
+    Concrete scope subclasses shadow the base stub with their injected typed Parent property.
+    Verified by reflection unit tests and AL integration tests.
   tests:
     - tests/bucket-1/290-alscope-parent
+    - tests/bucket-2/100-alscope-parent-instance
 
 codeunit_permissions_property:
   layer: syntax

--- a/tests/bucket-2/100-alscope-parent-instance/src/Source.al
+++ b/tests/bucket-2/100-alscope-parent-instance/src/Source.al
@@ -1,0 +1,46 @@
+// Source codeunit for issue #1105 — AlScope.Parent instance access.
+//
+// When a codeunit procedure assigns to a codeunit-level variable using
+// `this.SomeVar := value;`, the BC compiler generates a scope class that
+// accesses the parent codeunit via `this.Parent` (instance access on AlScope).
+// With AlScope.Parent defined as static, CS0176 fires: "Member cannot be
+// accessed with an instance reference."
+//
+// The fix: change AlScope.Parent from static to instance property.
+codeunit 98301 "Scope Parent Instance Src"
+{
+    var
+        IsActivated: Boolean;
+        Counter: Integer;
+
+    procedure Activate()
+    begin
+        this.IsActivated := true;
+    end;
+
+    procedure Deactivate()
+    begin
+        this.IsActivated := false;
+    end;
+
+    procedure Increment(Amount: Integer)
+    begin
+        this.Counter += Amount;
+    end;
+
+    procedure Reset()
+    begin
+        this.IsActivated := false;
+        this.Counter := 0;
+    end;
+
+    procedure GetActivated(): Boolean
+    begin
+        exit(IsActivated);
+    end;
+
+    procedure GetCounter(): Integer
+    begin
+        exit(Counter);
+    end;
+}

--- a/tests/bucket-2/100-alscope-parent-instance/test/Tests.al
+++ b/tests/bucket-2/100-alscope-parent-instance/test/Tests.al
@@ -1,0 +1,64 @@
+// Test suite for issue #1105 — AlScope.Parent instance access (CS0176).
+//
+// When AL procedures use `this.SomeVar := value;`, the BC compiler generates
+// scope classes that access the parent codeunit via `this.Parent` (an instance
+// reference on the AlScope base class). With AlScope.Parent as static, the
+// generated C# fails with CS0176. The fix changes Parent to an instance property.
+codeunit 98302 "Scope Parent Instance Tests"
+{
+    Subtype = Test;
+
+    var Assert: Codeunit Assert;
+
+    // Positive: Activate() uses `this.IsActivated := true` which generates a scope
+    // class accessing Parent via instance. After the fix this should compile and run.
+    [Test]
+    procedure ScopeParentInstance_Activate_SetsTrue()
+    var
+        Src: Codeunit "Scope Parent Instance Src";
+    begin
+        Src.Reset();
+        Src.Activate();
+        Assert.IsTrue(Src.GetActivated(), 'IsActivated should be true after Activate()');
+    end;
+
+    // Positive: Deactivate() uses `this.IsActivated := false` — the exact pattern from
+    // the telemetry that triggered CS0176 on AlScope.Parent.
+    [Test]
+    procedure ScopeParentInstance_Deactivate_SetsFalse()
+    var
+        Src: Codeunit "Scope Parent Instance Src";
+    begin
+        Src.Reset();
+        Src.Activate();
+        Src.Deactivate();
+        Assert.IsFalse(Src.GetActivated(), 'IsActivated should be false after Deactivate()');
+    end;
+
+    // Positive: Increment() uses `this.Counter += Amount` — proves non-default value
+    // so a no-op stub would not pass.
+    [Test]
+    procedure ScopeParentInstance_Increment_AccumulatesValue()
+    var
+        Src: Codeunit "Scope Parent Instance Src";
+    begin
+        Src.Reset();
+        Src.Increment(5);
+        Src.Increment(3);
+        Assert.AreEqual(8, Src.GetCounter(), 'Counter should be 8 after two increments');
+    end;
+
+    // Negative: after Reset(), both IsActivated and Counter are cleared via this.X access.
+    // Proves that the instance assignment through scope parent works correctly.
+    [Test]
+    procedure ScopeParentInstance_Reset_ClearsAll()
+    var
+        Src: Codeunit "Scope Parent Instance Src";
+    begin
+        Src.Activate();
+        Src.Increment(42);
+        Src.Reset();
+        Assert.IsFalse(Src.GetActivated(), 'IsActivated should be false after Reset()');
+        Assert.AreEqual(0, Src.GetCounter(), 'Counter should be 0 after Reset()');
+    end;
+}


### PR DESCRIPTION
## Summary

- Changes `AlScope.Parent` from `public static object? Parent => null` to `public virtual object? Parent => null`
- CS0176 fired when BC-generated scope class code used `this.Parent` (instance access) on the static base property
- Virtual instance property allows `this.Parent` and `base.Parent` to compile correctly; concrete subclasses shadow it with their injected typed `Parent => _parent` property

## Test plan

- [ ] C# unit tests in `AlScopeParentTests` updated: verify `Parent` is instance (not static), returns null from base instance
- [ ] New AL test suite `tests/bucket-2/100-alscope-parent-instance` exercises `this.Var` assignment patterns (the exact AL pattern from the telemetry: `this.TestIsActivated := false;`)
- [ ] Existing `tests/bucket-1/290-alscope-parent` tests still pass (no regression to #1092 fix)
- [ ] All 289 C# unit tests pass
- [ ] All bucket tests pass (pre-existing DT2Time and CreateDateTime failures are unrelated)
- [ ] `docs/coverage.yaml` updated with new entry `alscope_parent_instance` covering both #1092 and #1105

Closes #1105