### PR TITLE
fix: coverage.yaml invalid layer for Page.NavFormImplicitConversion

### DIFF
--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -4655,7 +4655,7 @@ Page.PromptMode:
   notes: overloads=1; MockCurrPage.PromptMode and MockFormHandle.PromptMode NavOption stubs; also injected on Page<N> class for CurrPage.PromptMode access inside page triggers (issue #1079)
 
 Page.NavFormImplicitConversion:
-  layer: compiler-rewriter
+  layer: runtime-api
   category: Page
   status: covered
   tests: tests/bucket-1/291-page-run-with-var


### PR DESCRIPTION
Layer 'compiler-rewriter' is not valid. Changed to 'runtime-api'.