### PR TITLE
feat: fix 3 CS1503 gaps — HttpHeaders.ContainsSecret string, FilterPageBuilder.GetView(bool), AlScope.Parent dynamic?

### DIFF
--- a/AlRunner/Runtime/AlScope.cs
+++ b/AlRunner/Runtime/AlScope.cs
@@ -225,8 +225,14 @@ public class AlScope : IDisposable, ITreeObject
     /// property on the concrete scope subclass (e.g. <c>public Codeunit123 Parent => _parent;</c>)
     /// which shadows this base stub, so returning null here is safe — this base
     /// stub is only reached when the rewriter did not inject a typed Parent.
+    ///
+    /// Returning <c>dynamic?</c> instead of <c>object?</c> allows calls such as
+    /// <c>base.Parent.Bind()</c> to compile via dynamic dispatch when the rewriter
+    /// has not yet converted <c>base.Parent</c> to <c>_parent</c> — issue #1xxx.
+    /// Concrete scope classes shadow this with a strongly-typed property so the
+    /// dynamic dispatch penalty only affects the rare unresolved case.
     /// </summary>
-    public virtual object? Parent => null;
+    public virtual dynamic? Parent => null;
 
     // ── Collectible errors ──────────────────────────────────────────────
     // Thread-static to avoid cross-test contamination in parallel scenarios.

--- a/AlRunner/Runtime/MockFilterPageBuilder.cs
+++ b/AlRunner/Runtime/MockFilterPageBuilder.cs
@@ -92,6 +92,22 @@ public class MockFilterPageBuilder
         => ALGetView(caption);
 
     /// <summary>
+    /// Two-argument overload for <c>FilterPageBuilder.GetView(caption, useNames)</c>.
+    /// BC emits <c>ALGetView(NavText, bool)</c> for this form — issue #1xxx.
+    /// The <c>useNames</c> flag controls whether field names or captions are used in the
+    /// filter string; the mock stores and returns the filter as-is regardless.
+    /// </summary>
+    public string ALGetView(NavText caption, bool useNames)
+        => ALGetView((string)caption);
+
+    /// <summary>
+    /// String-key overload of the two-argument <c>GetView(caption, useNames)</c> form.
+    /// Handles the case where the caption is a raw C# string (text constant in AL).
+    /// </summary>
+    public string ALGetView(string caption, bool useNames)
+        => ALGetView(caption);
+
+    /// <summary>
     /// Store a filter string for the named table caption.
     /// Has no effect if the caption is not registered.
     /// </summary>

--- a/AlRunner/Runtime/MockHttpHeaders.cs
+++ b/AlRunner/Runtime/MockHttpHeaders.cs
@@ -137,6 +137,14 @@ public class MockHttpHeaders
     public bool ALIsHeaderValueSecret(NavText name) => false;
 
     /// <summary>
+    /// String-key overload for <c>HttpHeaders.ContainsSecret(name)</c>.
+    /// BC emits <c>headers.ALIsHeaderValueSecret("Content-Type")</c> (raw string literal)
+    /// when the header name is a text constant — issue #1xxx.
+    /// Plain in-memory headers are never secret — always returns false.
+    /// </summary>
+    public bool ALIsHeaderValueSecret(string name) => false;
+
+    /// <summary>
     /// Overload for <c>HttpHeaders.GetValues(name, values)</c> when the caller declares
     /// <c>values: List of [Text]</c>.
     /// BC emits <c>ALGetValues(DataError, key, NavList&lt;NavText&gt;)</c> for this form —

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -47,6 +47,8 @@ alscope_parent_instance:
     others emit AlScope.Parent (static class access). A static stub fixed CS0117 (#1092)
     but introduced CS0176 for instance access (#1105). The fix changes Parent to a virtual
     instance property so both this.Parent and base.Parent compile and resolve correctly.
+    Changed return type to dynamic? so that base.Parent.Bind()/Unbind() compiles via
+    dynamic dispatch when the rewriter has not yet converted base.Parent to _parent.
     Concrete scope subclasses shadow the base stub with their injected typed Parent property.
     Verified by reflection unit tests and AL integration tests.
   tests:
@@ -2849,8 +2851,14 @@ FilterPageBuilder.GetView:
   layer: runtime-api
   category: FilterPageBuilder
   status: covered
-  notes: overloads=1; MockFilterPageBuilder; round-trips with SetView
-  tests: tests/bucket-2/179-filter-page-builder
+  notes: >
+    overloads=3; MockFilterPageBuilder; round-trips with SetView.
+    Added two-argument overloads (NavText/string caption, bool useNames) — BC emits
+    ALGetView(NavText, bool) for the FilterPageBuilder.GetView(caption, useNames) form,
+    causing CS1503 without the overloads.
+  tests:
+    - tests/bucket-2/179-filter-page-builder
+    - tests/bucket-2/224-filterpagebuilder-getview-bool
 
 FilterPageBuilder.Name:
   layer: runtime-api
@@ -3061,7 +3069,12 @@ HttpHeaders.ContainsSecret:
   layer: runtime-api
   category: HttpHeaders
   status: covered
-  notes: overloads=1
+  notes: >
+    overloads=2; MockHttpHeaders.ALIsHeaderValueSecret — NavText and string overloads.
+    BC emits ALIsHeaderValueSecret with a raw string literal when the header name is a
+    text constant (e.g. 'Content-Type'). The string overload was added to fix CS1503.
+  tests:
+    - tests/bucket-2/223-httpheaders-isheadervaluesecret-string
 
 HttpHeaders.GetSecretValues:
   layer: runtime-api

--- a/tests/bucket-2/223-httpheaders-isheadervaluesecret-string/src/Source.al
+++ b/tests/bucket-2/223-httpheaders-isheadervaluesecret-string/src/Source.al
@@ -1,0 +1,33 @@
+// Source helpers for issue #xxx — HttpHeaders.ContainsSecret called with a literal key.
+//
+// BC emits headers.ALIsHeaderValueSecret("Content-Type") where the header name is a
+// raw C# string literal (not NavText). The existing mock only has ALIsHeaderValueSecret(NavText),
+// causing CS1503 on compile. The fix adds a string overload.
+//
+// AL: Headers.ContainsSecret('Content-Type') → C#: headers.ALIsHeaderValueSecret("Content-Type")
+codeunit 62230 "HHSecSrc"
+{
+    /// Returns whether the header key is a secret header.
+    /// Always false in standalone mode.
+    procedure IsSecretHeader(HeaderKey: Text): Boolean
+    var
+        Headers: HttpHeaders;
+    begin
+        exit(Headers.ContainsSecret(HeaderKey));
+    end;
+
+    /// Mimics the exact pattern from FinApiConnector/BizBankApi:
+    ///   if Headers.ContainsSecret('Content-Type') then Headers.Remove('Content-Type');
+    ///   Headers.Add('Content-Type', 'application/x-www-form-urlencoded');
+    /// BC emits ALIsHeaderValueSecret with the string literal "Content-Type".
+    procedure SetContentTypeHeader(ContentType: Text): Boolean
+    var
+        Headers: HttpHeaders;
+    begin
+        if not Headers.ContainsSecret('Content-Type') then begin
+            Headers.Add('Content-Type', ContentType);
+            exit(Headers.Contains('Content-Type'));
+        end;
+        exit(false);
+    end;
+}

--- a/tests/bucket-2/223-httpheaders-isheadervaluesecret-string/test/Test.al
+++ b/tests/bucket-2/223-httpheaders-isheadervaluesecret-string/test/Test.al
@@ -1,0 +1,42 @@
+// Tests for issue #xxx — HttpHeaders.IsHeaderValueSecret with string literal argument.
+//
+// BC emits ALIsHeaderValueSecret("Content-Type") with a raw string literal.
+// The mock must accept a string key, not just NavText.
+codeunit 62231 "HHSecTest"
+{
+    Subtype = Test;
+
+    var Assert: Codeunit Assert;
+
+    // Positive: IsHeaderValueSecret always returns false in standalone mode.
+    // Proves the string-key overload resolves and returns the expected non-default value (false).
+    [Test]
+    procedure IsHeaderValueSecret_StringKey_ReturnsFalse()
+    var
+        Src: Codeunit HHSecSrc;
+    begin
+        Assert.IsFalse(Src.IsSecretHeader('Authorization'), 'Non-secret header must return false');
+
+    end;
+
+    // Positive: the literal-argument pattern from FinApiConnector compiles and returns true
+    // (header was added successfully).
+    [Test]
+    procedure SetContentTypeHeader_LiteralArg_HeaderAdded()
+    var
+        Src: Codeunit HHSecSrc;
+    begin
+        Assert.IsTrue(
+            Src.SetContentTypeHeader('application/json'),
+            'Content-Type header should be present after add');
+    end;
+
+    // Negative: a different header key also returns false for IsHeaderValueSecret.
+    [Test]
+    procedure IsHeaderValueSecret_AnotherKey_ReturnsFalse()
+    var
+        Src: Codeunit HHSecSrc;
+    begin
+        Assert.IsFalse(Src.IsSecretHeader('X-Custom-Header'), 'Custom header must not be secret');
+    end;
+}

--- a/tests/bucket-2/224-filterpagebuilder-getview-bool/src/Source.al
+++ b/tests/bucket-2/224-filterpagebuilder-getview-bool/src/Source.al
@@ -1,0 +1,43 @@
+// Source helpers for issue #xxx — FilterPageBuilder.GetView(caption, useNames: Boolean).
+//
+// BC emits filterPageBuilder.ALGetView(NavText, bool) for the two-argument overload
+// FilterPageBuilder.GetView(caption, useNames). The existing mock only accepts
+// ALGetView(string) and ALGetView(DataError, string), causing CS1503 on compile.
+// The fix adds the (NavText/string, bool) overloads.
+codeunit 62232 "FPBGetViewSrc"
+{
+    /// Registers a table, sets a view, and retrieves it using the two-arg GetView form.
+    /// Mimics the PermissionHelper.GetCustomFilter pattern.
+    procedure RoundTripView(TableId: Integer; FilterIn: Text[2048]) Filter: Text[2048]
+    var
+        FilterPageBuilder: FilterPageBuilder;
+        CaptionTok: Label 'Items', Locked = true;
+        TempText: Text;
+    begin
+        FilterPageBuilder.AddTable(CaptionTok, TableId);
+
+        if FilterIn <> '' then
+            FilterPageBuilder.SetView(CaptionTok, FilterIn);
+
+        // The two-arg GetView(caption, useNames) form — BC emits ALGetView(NavText, bool).
+        // This is the exact pattern from PermissionHelper.GetCustomFilter line ~82.
+        if FilterPageBuilder.RunModal() then begin
+            TempText := FilterPageBuilder.GetView(CaptionTok, false);
+            if StrLen(TempText) <= 2048 then
+                Filter := CopyStr(TempText, 1, 2048);
+        end;
+    end;
+
+    /// Returns the view via one-arg GetView to confirm the two-arg variant doesn't break
+    /// the existing zero-or-one-arg behaviour.
+    procedure GetViewOneArg(TableId: Integer; ViewIn: Text): Text
+    var
+        FilterPageBuilder: FilterPageBuilder;
+        CaptionTok: Label 'Payments', Locked = true;
+    begin
+        FilterPageBuilder.AddTable(CaptionTok, TableId);
+        if ViewIn <> '' then
+            FilterPageBuilder.SetView(CaptionTok, ViewIn);
+        exit(FilterPageBuilder.GetView(CaptionTok));
+    end;
+}

--- a/tests/bucket-2/224-filterpagebuilder-getview-bool/test/Test.al
+++ b/tests/bucket-2/224-filterpagebuilder-getview-bool/test/Test.al
@@ -1,0 +1,58 @@
+// Tests for issue #xxx — FilterPageBuilder.GetView(caption, useNames: Boolean).
+//
+// BC emits ALGetView(NavText, bool) for the two-arg GetView form. Exercises the fix
+// that adds the missing overloads to MockFilterPageBuilder.
+codeunit 62233 "FPBGetViewTest"
+{
+    Subtype = Test;
+
+    var Assert: Codeunit Assert;
+
+    // Positive: GetView with two args round-trips the stored view.
+    // A no-op stub would return empty string, so checking the exact non-empty result
+    // proves the round-trip works.
+    [Test]
+    procedure GetView_TwoArgs_RoundTripsView()
+    var
+        Src: Codeunit FPBGetViewSrc;
+        FilterIn: Text[2048];
+        FilterOut: Text[2048];
+    begin
+        FilterIn := 'WHERE(No.=FILTER(A..Z))';
+        FilterOut := Src.RoundTripView(50000, FilterIn);
+        Assert.AreEqual(FilterIn, FilterOut, 'GetView(caption, false) should return the stored view');
+    end;
+
+    // Positive: GetView with two args on an empty filter returns empty string.
+    [Test]
+    procedure GetView_TwoArgs_EmptyFilter_ReturnsEmpty()
+    var
+        Src: Codeunit FPBGetViewSrc;
+        FilterOut: Text[2048];
+    begin
+        FilterOut := Src.RoundTripView(50000, '');
+        Assert.AreEqual('', FilterOut, 'GetView with empty filter should return empty string');
+    end;
+
+    // Positive: one-arg GetView still works after adding the two-arg overload.
+    [Test]
+    procedure GetView_OneArg_StillWorks()
+    var
+        Src: Codeunit FPBGetViewSrc;
+        Result: Text;
+    begin
+        Result := Src.GetViewOneArg(50000, 'WHERE(No.=FILTER(1..9))');
+        Assert.AreEqual('WHERE(No.=FILTER(1..9))', Result, 'One-arg GetView should still return stored view');
+    end;
+
+    // Negative: GetView with two args when no view was set returns empty string.
+    [Test]
+    procedure GetView_TwoArgs_NoView_ReturnsEmpty()
+    var
+        Src: Codeunit FPBGetViewSrc;
+        FilterOut: Text[2048];
+    begin
+        FilterOut := Src.RoundTripView(50001, '');
+        Assert.AreEqual('', FilterOut, 'No view set should return empty string');
+    end;
+}


### PR DESCRIPTION
## Summary

- **Root cause 1** (`AlScope.Parent`): Changed return type from `object?` to `dynamic?` so `base.Parent.Bind()/Unbind()` compiles via dynamic dispatch in BC compiler variants that emit `base.Parent` without the `.Target` suffix before the rewriter converts it to `_parent`.
- **Root cause 2** (`HttpHeaders.ContainsSecret` with string literal): Added `string` overload to `MockHttpHeaders.ALIsHeaderValueSecret`. BC emits `ALIsHeaderValueSecret("Content-Type")` (raw C# string) for `HttpHeaders.ContainsSecret('Content-Type')`, causing CS1503 in `FinApiConnector` and `BizBankApi`.
- **Root cause 3** (`FilterPageBuilder.GetView(caption, useNames)`): Added `(NavText, bool)` and `(string, bool)` overloads to `MockFilterPageBuilder.ALGetView`. BC emits `ALGetView(NavText, bool)` for the two-argument form, causing CS1503 in `PermissionHelper.GetCustomFilter`.

## Test plan

- [ ] `tests/bucket-2/223-httpheaders-isheadervaluesecret-string` — 3 tests covering positive (false result), literal-arg compile, and negative cases for `ALIsHeaderValueSecret` with string key
- [ ] `tests/bucket-2/224-filterpagebuilder-getview-bool` — 4 tests covering round-trip view, empty filter, one-arg backward compat, and no-view case for `ALGetView(caption, bool)`
- [ ] All bucket-1 and bucket-2 tests still pass (pre-existing 5 DT2Time failures unchanged)
- [ ] External Cash365 codebase: 5 CS1503 compilation errors gone (verified with `--packages` flag against Banqr/Cash365)