### PR TITLE
fix: NavText→NavCode cast + base.Parent.Bind() null-deref

### DIFF
--- a/AlRunner.Tests/AlScopeParentTests.cs
+++ b/AlRunner.Tests/AlScopeParentTests.cs
@@ -58,7 +58,7 @@ public class AlScopeParentTests
     /// shadow it with their own injected `public T Parent => _parent` property.
     /// </summary>
     [Fact]
-    public void AlScope_InstanceParent_ReturnsNull()
+    public void AlScope_InstanceParent_ReturnsSelf()
     {
         var prop = typeof(AlScope).GetProperty(
             "Parent",
@@ -70,7 +70,8 @@ public class AlScopeParentTests
         var instance = new MinimalAlScope();
         var value = prop!.GetValue(instance);
 
-        Assert.Null(value);
+        // Parent returns `this` (not null) so base.Parent.Bind() doesn't NPE
+        Assert.Same(instance, value);
     }
 
     /// <summary>

--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -4426,6 +4426,15 @@ public void Unbind() { AlRunner.Runtime.EventSubscriberRegistry.Unbind(this); }
                 if (targetExpr is MemberAccessExpressionSyntax targetMa &&
                     targetMa.Name.Identifier.Text == "Target")
                     targetExpr = targetMa.Expression;
+                // base.Parent (inside a scope class) → _parent.
+                // The VisitMemberAccessExpression rule (base.Parent.xxx → _parent.xxx) only
+                // fires when base.Parent appears as the inner half of a 3-part chain.  Here
+                // base.Parent is a bare argument, so the rule never fires.  Resolve it now
+                // before creating the new call node (which won't be re-visited).
+                if (targetExpr is MemberAccessExpressionSyntax baseParentMa &&
+                    baseParentMa.Name.Identifier.Text == "Parent" &&
+                    baseParentMa.Expression is BaseExpressionSyntax)
+                    targetExpr = SyntaxFactory.IdentifierName("_parent");
                 var call = SyntaxFactory.InvocationExpression(
                     SyntaxFactory.MemberAccessExpression(
                         SyntaxKind.SimpleMemberAccessExpression,

--- a/AlRunner/Runtime/AlScope.cs
+++ b/AlRunner/Runtime/AlScope.cs
@@ -209,7 +209,7 @@ public class AlScope : IDisposable, ITreeObject
     public static string LastErrorCallStack { get; set; } = "";
 
     /// <summary>
-    /// Instance null-returning stub for <c>Parent</c> — issues #1092 and #1105.
+    /// Instance <c>this</c>-returning stub for <c>Parent</c> — issues #1092, #1105, #1111.
     ///
     /// Some BC compiler versions emit <c>this.Parent</c> (instance access) in
     /// generated scope class code when a scope class body references a parent
@@ -223,16 +223,22 @@ public class AlScope : IDisposable, ITreeObject
     ///
     /// The real parent reference is always accessed through the injected instance
     /// property on the concrete scope subclass (e.g. <c>public Codeunit123 Parent => _parent;</c>)
-    /// which shadows this base stub, so returning null here is safe — this base
-    /// stub is only reached when the rewriter did not inject a typed Parent.
+    /// which shadows this base stub.
     ///
-    /// Returning <c>dynamic?</c> instead of <c>object?</c> allows calls such as
-    /// <c>base.Parent.Bind()</c> to compile via dynamic dispatch when the rewriter
-    /// has not yet converted <c>base.Parent</c> to <c>_parent</c> — issue #1xxx.
-    /// Concrete scope classes shadow this with a strongly-typed property so the
-    /// dynamic dispatch penalty only affects the rare unresolved case.
+    /// Returning <c>this</c> (rather than null) prevents a runtime null-dereference when
+    /// BC emits <c>ALSession.ALBindSubscription(DataError, base.Parent)</c> inside a scope
+    /// class and the rewriter rewrites this to <c>base.Parent.Bind()</c> but does NOT
+    /// further rewrite <c>base.Parent</c> to <c>_parent</c> (because the new node is not
+    /// re-visited — issue #1111).  With <c>Parent => this</c>, <c>base.Parent.Bind()</c>
+    /// calls <c>AlScope.Bind()</c> (the no-op stub) instead of throwing
+    /// "Cannot perform runtime binding on a null reference".
+    ///
+    /// Returning <c>dynamic</c> instead of <c>object</c> allows calls such as
+    /// <c>base.Parent.Bind()</c> to compile via dynamic dispatch.  Concrete scope
+    /// classes shadow this with a strongly-typed property so the dynamic dispatch
+    /// penalty only affects the rare unresolved case.
     /// </summary>
-    public virtual dynamic? Parent => null;
+    public virtual dynamic Parent => this;
 
     // ── Collectible errors ──────────────────────────────────────────────
     // Thread-static to avoid cross-test contamination in parallel scenarios.

--- a/AlRunner/Runtime/MockRecordHandle.cs
+++ b/AlRunner/Runtime/MockRecordHandle.cs
@@ -210,7 +210,7 @@ public class MockRecordHandle
 
     public void SetFieldValueSafe(int fieldNo, NavType expectedType, NavValue value)
     {
-        _fields[fieldNo] = value;
+        _fields[fieldNo] = CoerceToExpectedType(fieldNo, expectedType, value);
     }
 
     /// <summary>
@@ -220,7 +220,25 @@ public class MockRecordHandle
     /// </summary>
     public void SetFieldValueSafe(int fieldNo, NavType expectedType, NavValue value, bool validate)
     {
-        _fields[fieldNo] = value;
+        _fields[fieldNo] = CoerceToExpectedType(fieldNo, expectedType, value);
+    }
+
+    /// <summary>
+    /// Coerce <paramref name="value"/> to match <paramref name="expectedType"/> when the
+    /// incoming type differs.  The primary case is NavText stored in a Code[N] field slot:
+    /// FieldRef.Value setter always calls SetFieldValue with NavType.Text, so a Code field
+    /// receives a NavText.  A subsequent direct field read emits
+    /// <c>(NavCode)GetFieldValueSafe(fieldNo, NavType.Code)</c> which throws
+    /// InvalidCastException unless we store a NavCode here.
+    /// </summary>
+    private NavValue CoerceToExpectedType(int fieldNo, NavType expectedType, NavValue value)
+    {
+        if (expectedType == NavType.Code && value is NavText nt)
+        {
+            int length = TableFieldRegistry.GetFieldLength(_tableId, fieldNo) ?? 250;
+            return new NavCode(length, ((string)nt).ToUpperInvariant());
+        }
+        return value;
     }
 
     /// <summary>
@@ -245,7 +263,7 @@ public class MockRecordHandle
     public NavValue GetFieldValueSafe(int fieldNo, NavType expectedType)
     {
         if (_fields.TryGetValue(fieldNo, out var val))
-            return val;
+            return CoerceToExpectedType(fieldNo, expectedType, val);
         // For Media/MediaSet types, auto-generate and persist a unique value
         // so that repeated reads return the same value, and different records
         // (or re-inserted records) get different MediaIds.

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -42,15 +42,16 @@ alscope_parent_instance:
   category: object
   status: covered
   notes: >
-    AlScope.Parent instance property stub — issues #1092 and #1105.
+    AlScope.Parent instance property stub — issues #1092, #1105, #1111.
     Some BC compiler versions emit this.Parent (instance access) in scope class bodies;
     others emit AlScope.Parent (static class access). A static stub fixed CS0117 (#1092)
     but introduced CS0176 for instance access (#1105). The fix changes Parent to a virtual
     instance property so both this.Parent and base.Parent compile and resolve correctly.
-    Changed return type to dynamic? so that base.Parent.Bind()/Unbind() compiles via
-    dynamic dispatch when the rewriter has not yet converted base.Parent to _parent.
-    Concrete scope subclasses shadow the base stub with their injected typed Parent property.
-    Verified by reflection unit tests and AL integration tests.
+    Changed return type to dynamic so that base.Parent.Bind()/Unbind() compiles via
+    dynamic dispatch. Returns `this` (not null) so that base.Parent.Bind() falls back to
+    AlScope.Bind() (no-op) rather than throwing "Cannot perform runtime binding on a null
+    reference" — issue #1111. Concrete scope subclasses shadow the base stub with their
+    injected typed Parent property.
   tests:
     - tests/bucket-1/290-alscope-parent
     - tests/bucket-2/100-alscope-parent-instance
@@ -80,9 +81,14 @@ alscope_bind_unbind:
     The rewriter injects Bind()/Unbind() into every codeunit class (delegating to
     EventSubscriberRegistry). AlScope also gets virtual no-op stubs as a fallback.
     Issue #1106 / Gap 2.
+    Additional fix (issue #1111): when BC emits ALSession.ALBindSubscription(DataError, base.Parent)
+    with base.Parent as a bare argument (not base.Parent.field), the VisitMemberAccessExpression
+    base.Parent→_parent rule never fired on the newly created node. The rewriter now resolves
+    base.Parent → _parent directly in the ALBindSubscription handler before creating target.Bind().
   tests:
     - tests/bucket-1/168-scope-bind-unbind
     - tests/bucket-2/100-bind-subscription
+    - tests/bucket-2/101-base-parent-bind
 
 codeunit_permissions_property:
   layer: syntax
@@ -2588,7 +2594,16 @@ FieldRef.Value:
   layer: runtime-api
   category: FieldRef
   status: covered
-  notes: overloads=1
+  notes: >
+    overloads=1; get/set via MockFieldRef.ALValue.
+    Fix (issue #1111): FieldRef.Value setter stores NavText via MockRecordRef.SetFieldValue
+    (always NavType.Text). A subsequent direct Code[N] field read emits
+    (NavCode)GetFieldValueSafe(fieldNo, NavType.Code) which threw InvalidCastException when
+    the stored value was NavText. GetFieldValueSafe now coerces NavText → NavCode (uppercased,
+    length from TableFieldRegistry or 250 fallback) when expectedType is Code.
+    SetFieldValueSafe applies the same coercion so the field bag stays consistent.
+  tests:
+    - tests/bucket-2/101-navtext-to-navcode
 
 # ── File ────────────────────────────────────────────────────────
 

--- a/tests/bucket-2/101-base-parent-bind/src/BaseParentBindSrc.al
+++ b/tests/bucket-2/101-base-parent-bind/src/BaseParentBindSrc.al
@@ -1,0 +1,63 @@
+// Reproducer for base.Parent.Bind() null-dereference — issue #1111.
+//
+// When an EventSubscriberInstance=Manual codeunit has a procedure that:
+//   (a) accesses a codeunit-level variable via `this.Var` (forces a scope class), AND
+//   (b) calls BindSubscription(this) in the same procedure body,
+// the BC compiler emits base.Parent.Bind() inside the scope class.
+//
+// The rewriter rewrites ALSession.ALBindSubscription(DataError, target) → target.Bind(),
+// but when target is base.Parent (unresolved by the base.Parent→_parent rewrite because
+// base.Parent appears as a bare argument, not base.Parent.field), the resulting
+// base.Parent.Bind() is never re-visited. AlScope.Parent returns null, so calling
+// Bind() on it throws: "Cannot perform runtime binding on a null reference".
+//
+// Fix: AlScope.Parent must return `this` instead of null, so base.Parent.Bind()
+// calls AlScope.Bind() (the no-op stub) rather than dereferencing null.
+
+codeunit 98500 "BPB Subscriber"
+{
+    EventSubscriberInstance = Manual;
+
+    var
+        BindCount: Integer;
+
+    /// Called by tests to bind this subscriber and fire the event in one shot.
+    /// The `this.BindCount += 1` forces a scope class, and `BindSubscription(this)`
+    /// inside the same procedure emits `base.Parent.Bind()` in that scope class.
+    procedure RegisterAndFire(var Publisher: Codeunit "BPB Publisher")
+    begin
+        this.BindCount += 1;   // forces a scope class → base.Parent.Bind() is emitted here
+        BindSubscription(this);
+        Publisher.Fire();
+        UnbindSubscription(this);
+    end;
+
+    [EventSubscriber(ObjectType::Codeunit, Codeunit::"BPB Publisher", 'OnFire', '', true, true)]
+    local procedure HandleFire()
+    begin
+        BindCount += 1;
+    end;
+
+    procedure GetBindCount(): Integer
+    begin
+        exit(BindCount);
+    end;
+
+    procedure Reset()
+    begin
+        BindCount := 0;
+    end;
+}
+
+codeunit 98501 "BPB Publisher"
+{
+    [IntegrationEvent(false, false)]
+    procedure OnFire()
+    begin
+    end;
+
+    procedure Fire()
+    begin
+        OnFire();
+    end;
+}

--- a/tests/bucket-2/101-base-parent-bind/test/BaseParentBindTest.al
+++ b/tests/bucket-2/101-base-parent-bind/test/BaseParentBindTest.al
@@ -1,0 +1,57 @@
+// Test suite for base.Parent.Bind() null-dereference fix.
+// When an EventSubscriberInstance=Manual codeunit's procedure uses `this.Var` (scope class)
+// AND calls BindSubscription(this), BC emits base.Parent.Bind() in the scope class.
+// Before the fix: AlScope.Parent returns null → runtime binding on null → exception.
+// After the fix: AlScope.Parent returns `this` → base.Parent.Bind() calls AlScope.Bind() (no-op).
+codeunit 98502 "BPB Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    // Positive: RegisterAndFire must not throw even though base.Parent.Bind() is in the scope.
+    // BindCount starts at 0, RegisterAndFire increments it to 1 (this.BindCount += 1),
+    // then BindSubscription fires the event which increments it to 2.
+    [Test]
+    procedure RegisterAndFire_ScopeBindUnbind_NoThrow()
+    var
+        Sub: Codeunit "BPB Subscriber";
+        Pub: Codeunit "BPB Publisher";
+    begin
+        Sub.Reset();
+        Sub.RegisterAndFire(Pub);
+        // After RegisterAndFire:
+        //   this.BindCount += 1 → 1
+        //   BindSubscription(this) → base.Parent.Bind() must NOT throw
+        //   Fire() → subscriber fires → BindCount += 1 → 2
+        Assert.AreEqual(2, Sub.GetBindCount(), 'BindCount must be 2: 1 from this.BindCount += 1, 1 from event handler');
+    end;
+
+    // Positive: calling RegisterAndFire twice accumulates correctly,
+    // proving the scope survives multiple invocations.
+    [Test]
+    procedure RegisterAndFire_TwoCalls_AccumulatesCount()
+    var
+        Sub: Codeunit "BPB Subscriber";
+        Pub: Codeunit "BPB Publisher";
+    begin
+        Sub.Reset();
+        Sub.RegisterAndFire(Pub);
+        Sub.RegisterAndFire(Pub);
+        // Each call: +1 from this.BindCount, +1 from event → +2 per call
+        Assert.AreEqual(4, Sub.GetBindCount(), 'BindCount must be 4 after two RegisterAndFire calls');
+    end;
+
+    // Positive: after Reset(), counter is zero even after prior calls.
+    [Test]
+    procedure Reset_ClearsBindCount()
+    var
+        Sub: Codeunit "BPB Subscriber";
+        Pub: Codeunit "BPB Publisher";
+    begin
+        Sub.RegisterAndFire(Pub);
+        Sub.Reset();
+        Assert.AreEqual(0, Sub.GetBindCount(), 'BindCount must be 0 after Reset()');
+    end;
+}

--- a/tests/bucket-2/101-navtext-to-navcode/src/NavCodeHelper.al
+++ b/tests/bucket-2/101-navtext-to-navcode/src/NavCodeHelper.al
@@ -1,0 +1,51 @@
+/// Helper codeunit that sets a Code[20] field via FieldRef (NavText) and reads it back directly.
+/// This triggers the NavText stored in Code field slot → cast fails on direct access.
+codeunit 98400 "NTC Helper"
+{
+    /// Set a Code field via FieldRef (value arrives as NavText) then read it back directly.
+    /// This is the exact pattern that causes InvalidCastException:
+    ///   FieldRef.Value := textValue  → SetFieldValue(fieldNo, NavType.Text, NavText)
+    ///   record."Category"           → (NavCode)GetFieldValueSafe(fieldNo, NavType.Code) → FAIL
+    procedure InsertAndReadViaFieldRef(Id: Integer; CategoryValue: Text[100]): Code[20]
+    var
+        RecRef: RecordRef;
+        FldId: FieldRef;
+        FldCat: FieldRef;
+        Rec: Record "NTC Table";
+    begin
+        // Set up record via RecordRef/FieldRef — this stores NavText in the Code field slot
+        RecRef.Open(Database::"NTC Table");
+        RecRef.Init();
+        FldId := RecRef.Field(1);
+        FldId.Value := Id;
+        FldCat := RecRef.Field(2);
+        FldCat.Value := CategoryValue;  // NavText stored in Code[20] slot
+        RecRef.Insert();
+        RecRef.Close();
+
+        // Now read the Code field directly — BC codegen emits (NavCode)GetFieldValueSafe(2, NavType.Code)
+        // If the stored value is NavText, this cast fails with InvalidCastException.
+        Rec.Get(Id);
+        exit(Rec."Category");
+    end;
+
+    /// Insert using a Code literal (baseline — should always work).
+    procedure InsertWithCodeCategory(Id: Integer; Category: Code[20])
+    var
+        Rec: Record "NTC Table";
+    begin
+        Rec.Init();
+        Rec."Id" := Id;
+        Rec."Category" := Category;
+        Rec.Insert();
+    end;
+
+    /// Read the Category field back as Code.
+    procedure GetCategory(Id: Integer): Code[20]
+    var
+        Rec: Record "NTC Table";
+    begin
+        Rec.Get(Id);
+        exit(Rec."Category");
+    end;
+}

--- a/tests/bucket-2/101-navtext-to-navcode/src/NavCodeTable.al
+++ b/tests/bucket-2/101-navtext-to-navcode/src/NavCodeTable.al
@@ -1,0 +1,25 @@
+/// Table with a Code[20] field used for NavText→NavCode cast testing.
+table 98400 "NTC Table"
+{
+    DataClassification = ToBeClassified;
+
+    fields
+    {
+        field(1; "Id"; Integer)
+        {
+            DataClassification = ToBeClassified;
+        }
+        field(2; "Category"; Code[20])
+        {
+            DataClassification = ToBeClassified;
+        }
+    }
+
+    keys
+    {
+        key(PK; "Id")
+        {
+            Clustered = true;
+        }
+    }
+}

--- a/tests/bucket-2/101-navtext-to-navcode/test/NavCodeTest.al
+++ b/tests/bucket-2/101-navtext-to-navcode/test/NavCodeTest.al
@@ -1,0 +1,59 @@
+// Test suite for NavText → NavCode cast fix.
+// Bug: FieldRef.Value setter stores NavText in a Code[N] field slot
+// (via MockRecordRef.SetFieldValue → SetFieldValueSafe(fieldNo, NavType.Text, navText)).
+// A subsequent direct record field read emits (NavCode)GetFieldValueSafe(2, NavType.Code),
+// which throws InvalidCastException because the stored value is NavText not NavCode.
+// Fix: SetFieldValueSafe must coerce NavText → NavCode when expectedType == NavType.Code.
+codeunit 98401 "NTC Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    // Positive: set a Code field via FieldRef (NavText), then read it directly.
+    // Before the fix this throws InvalidCastException; after it must round-trip.
+    [Test]
+    procedure FieldRef_TextValue_ThenDirectRead_Succeeds()
+    var
+        Helper: Codeunit "NTC Helper";
+        Result: Code[20];
+    begin
+        Result := Helper.InsertAndReadViaFieldRef(1, 'ALPHA');
+        Assert.AreEqual('ALPHA', Result, 'Code field set via FieldRef (NavText) must round-trip without cast error');
+    end;
+
+    // Positive: code is uppercased — ensures we don't just return NavText.ToString().
+    [Test]
+    procedure FieldRef_LowercaseText_IsUppercased()
+    var
+        Helper: Codeunit "NTC Helper";
+        Result: Code[20];
+    begin
+        Result := Helper.InsertAndReadViaFieldRef(2, 'lower');
+        Assert.AreEqual('LOWER', Result, 'Code field must uppercase the NavText value on coercion');
+    end;
+
+    // Positive: empty text in Code field slot returns empty Code.
+    [Test]
+    procedure FieldRef_EmptyText_ReturnsEmptyCode()
+    var
+        Helper: Codeunit "NTC Helper";
+        Result: Code[20];
+    begin
+        Result := Helper.InsertAndReadViaFieldRef(3, '');
+        Assert.AreEqual('', Result, 'Empty NavText in Code slot must return empty Code');
+    end;
+
+    // Regression: direct Code assignment still works after the fix.
+    [Test]
+    procedure DirectCode_Assignment_StillWorks()
+    var
+        Helper: Codeunit "NTC Helper";
+        Result: Code[20];
+    begin
+        Helper.InsertWithCodeCategory(4, 'BETA');
+        Result := Helper.GetCategory(4);
+        Assert.AreEqual('BETA', Result, 'Direct Code assignment must still round-trip correctly');
+    end;
+}


### PR DESCRIPTION
## Summary

- **Bug 1 (NavText→NavCode cast):** `FieldRef.Value` setter stores NavText in Code[N] field slots (via `MockRecordRef.SetFieldValue` which always passes `NavType.Text`). A subsequent direct Code field read emits `(NavCode)GetFieldValueSafe(fieldNo, NavType.Code)`, throwing `InvalidCastException`. Fixed by coercing `NavText → NavCode` (uppercased, length from `TableFieldRegistry` or 250 fallback) in both `GetFieldValueSafe` and `SetFieldValueSafe` when `expectedType == NavType.Code`.

- **Bug 2 (base.Parent.Bind() null-deref):** When an `EventSubscriberInstance=Manual` codeunit has a procedure using `this.Var` (forces a scope class) AND calls `BindSubscription(this)`, BC emits `ALSession.ALBindSubscription(DataError, base.Parent)` in the scope class. The rewriter creates `base.Parent.Bind()` but the new node is not re-visited, so `base.Parent → _parent` never fires. `AlScope.Parent` returned null → "Cannot perform runtime binding on a null reference". Fixed by: (1) returning `this` from `AlScope.Parent` so `base.Parent.Bind()` hits `AlScope.Bind()` (no-op) as fallback, AND (2) fixing the `ALBindSubscription` rewriter to resolve `base.Parent → _parent` before creating the `target.Bind()` node.

## Test plan

- [ ] `tests/bucket-2/101-navtext-to-navcode` — 4 tests covering FieldRef NavText→NavCode round-trip (was RED before fix, GREEN after)
- [ ] `tests/bucket-2/101-base-parent-bind` — 3 tests covering `base.Parent.Bind()` in scope class (was RED before fix, GREEN after)  
- [ ] Full bucket-1 and bucket-2 runs pass (only pre-existing timezone failures remain)