### PR TITLE
fix: system codeunit Invoke/RunCodeunit is a no-op instead of throwing

### DIFF
--- a/AlRunner.Tests/RunnerErrorClassificationTests.cs
+++ b/AlRunner.Tests/RunnerErrorClassificationTests.cs
@@ -40,6 +40,64 @@ public class RunnerErrorClassificationTests
     }
 
     /// <summary>
+    /// System codeunits (IDs 1–9999) are BC platform codeunits that cannot be
+    /// provided as user stubs. Invoke on a missing system codeunit must return null
+    /// (no-op) rather than throwing, so event-subscriber code that happens to call
+    /// methods on the publisher codeunit handle does not crash the runner.
+    /// </summary>
+    [Fact]
+    public void MockCodeunitHandle_SystemCodeunitInvoke_ReturnsNullNoOp()
+    {
+        // Codeunit 27 = "Company-Initialize" (system codeunit, never compiled into the test assembly)
+        var handle = new AlRunner.Runtime.MockCodeunitHandle(27);
+        // Must NOT throw — system codeunits are no-ops
+        var result = handle.Invoke(0, Array.Empty<object>());
+        // Return value should be null (no-op default)
+        Assert.Null(result);
+    }
+
+    /// <summary>
+    /// System codeunit IDs at boundary (1 and 9999) are also treated as no-ops.
+    /// User codeunit IDs (50000+) still throw for missing codeunits.
+    /// Proves the range check is correct.
+    /// </summary>
+    [Theory]
+    [InlineData(1)]
+    [InlineData(9999)]
+    public void MockCodeunitHandle_SystemCodeunitBoundary_InvokeIsNoOp(int codeunitId)
+    {
+        var handle = new AlRunner.Runtime.MockCodeunitHandle(codeunitId);
+        // Must not throw — boundary system codeunits are still no-ops
+        var result = handle.Invoke(0, Array.Empty<object>());
+        Assert.Null(result);
+    }
+
+    /// <summary>
+    /// ID 10000 is NOT a system codeunit — it falls outside the 1-9999 range.
+    /// Missing non-system codeunits must still throw.
+    /// </summary>
+    [Fact]
+    public void MockCodeunitHandle_NonSystemMissingCodeunit_StillThrows()
+    {
+        var handle = new AlRunner.Runtime.MockCodeunitHandle(10000);
+        Assert.Throws<InvalidOperationException>(() =>
+            handle.Invoke(0, Array.Empty<object>()));
+    }
+
+    /// <summary>
+    /// Static RunCodeunit(int) overload for a missing system codeunit must not throw.
+    /// </summary>
+    [Fact]
+    public void MockCodeunitHandle_RunCodeunit_SystemId_DoesNotThrow()
+    {
+        // RunCodeunit(27) — system codeunit "Company-Initialize", not compiled into test assembly
+        // Must not throw — system codeunits are treated as no-ops
+        var ex = Record.Exception(() =>
+            AlRunner.Runtime.MockCodeunitHandle.RunCodeunit(27));
+        Assert.Null(ex);
+    }
+
+    /// <summary>
     /// Regular assertion failures (user logic wrong) must NOT be classified as
     /// runner bugs. IsRunnerBug must stay false for plain Fail outcomes.
     /// </summary>

--- a/AlRunner/Runtime/MockCodeunitHandle.cs
+++ b/AlRunner/Runtime/MockCodeunitHandle.cs
@@ -163,6 +163,12 @@ public class MockCodeunitHandle
         var codeunitType = FindCodeunitType(assembly);
         if (codeunitType == null)
         {
+            // System codeunits (IDs 1-9999) are part of the BC platform and cannot be provided
+            // as user stubs. Treat calls to missing system codeunits as no-ops instead of
+            // throwing: the subscriber dispatch path works independently of the publisher class.
+            if (IsSystemCodeunitId(_codeunitId))
+                return null;
+
             throw new InvalidOperationException(BuildCodeunitNotFoundMessage(_codeunitId, assembly));
         }
 
@@ -284,7 +290,16 @@ public class MockCodeunitHandle
             var assembly = CurrentAssembly ?? Assembly.GetExecutingAssembly();
             var codeunitType = FindCodeunitType(assembly);
             if (codeunitType == null)
+            {
+                // System codeunits are treated as no-ops — fire OnRun event for subscribers
+                // but don't throw (the publisher body is a platform implementation).
+                if (IsSystemCodeunitId(_codeunitId))
+                {
+                    AlCompat.FireEvent(EventSubscriberRegistry.ObjectTypeCodeunit, _codeunitId, "OnRun");
+                    return true;
+                }
                 throw new InvalidOperationException(BuildCodeunitNotFoundMessage(_codeunitId, assembly));
+            }
 
             EnsureInstance(codeunitType);
             InvokeOnRun(codeunitType, _codeunitInstance!, record as MockRecordHandle);
@@ -359,6 +374,14 @@ public class MockCodeunitHandle
         var codeunitType = handle.FindCodeunitType(assembly);
         if (codeunitType == null)
         {
+            // System codeunits (IDs 1-9999) are platform implementations that cannot be
+            // provided as user stubs. Treat them as no-ops: fire the OnRun event so any
+            // compiled event subscribers still execute, but don't throw.
+            if (IsSystemCodeunitId(codeunitId))
+            {
+                AlCompat.FireEvent(EventSubscriberRegistry.ObjectTypeCodeunit, codeunitId, "OnRun");
+                return;
+            }
             throw new InvalidOperationException(BuildCodeunitNotFoundMessage(codeunitId, assembly));
         }
 
@@ -728,6 +751,14 @@ public class MockCodeunitHandle
         var expectedName = $"Codeunit{_codeunitId}";
         return assembly.GetTypes().FirstOrDefault(t => t.Name == expectedName);
     }
+
+    /// <summary>
+    /// Returns true when <paramref name="codeunitId"/> falls in the BC system/platform
+    /// range (1–9999). System codeunits are part of the BC service tier and cannot be
+    /// provided as user stubs; calls to missing system codeunits are treated as no-ops.
+    /// </summary>
+    private static bool IsSystemCodeunitId(int codeunitId)
+        => codeunitId is >= 1 and <= 9999;
 
     /// <summary>
     /// Build a descriptive error message when a codeunit is not found in the assembly.

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -1567,7 +1567,11 @@ Codeunit.Run:
   tests:
     - tests/bucket-1/64-codeunit-run-record
     - tests/bucket-1/112-codeunit-onrun-record
-  notes: overloads=2 (no-record and with-record variants); returns true on success, false on trapped error
+    - tests/bucket-1/128-codeunit-not-found
+  notes: >
+    overloads=2 (no-record and with-record variants); returns true on success, false on trapped error.
+    Missing system codeunits (IDs 1-9999) are treated as no-ops (fire OnRun event for subscribers, no throw);
+    missing user/test-toolkit codeunits still throw with a descriptive error.
 
 # ── CodeunitInstance ────────────────────────────────────────────
 

--- a/tests/bucket-1/128-codeunit-not-found/src/Probe.al
+++ b/tests/bucket-1/128-codeunit-not-found/src/Probe.al
@@ -14,7 +14,7 @@ codeunit 56280 "Missing CU Probe"
 
     procedure CallMissingSystemCodeunit()
     begin
-        // Call a system-range codeunit (1-9999) that doesn't exist
+        // Call a system-range codeunit (1-9999) that doesn't exist — should be a no-op
         Codeunit.Run(9999);
     end;
 
@@ -22,5 +22,10 @@ codeunit 56280 "Missing CU Probe"
     begin
         // Call a codeunit that does exist in the assembly (positive path)
         Codeunit.Run(56282);
+    end;
+
+    procedure SetFiredFlag(var Fired: Boolean)
+    begin
+        Fired := true;
     end;
 }

--- a/tests/bucket-1/128-codeunit-not-found/test/Tests.al
+++ b/tests/bucket-1/128-codeunit-not-found/test/Tests.al
@@ -50,12 +50,11 @@ codeunit 56281 "Missing CU Tests"
     end;
 
     [Test]
-    procedure MissingSystemCodeunitIdentifiesRange()
+    procedure MissingSystemCodeunit_IsNoOp()
     begin
-        // [WHEN]  A system-range codeunit (1-9999) that does not exist is called
-        asserterror Probe.CallMissingSystemCodeunit();
-        // [THEN]  Error message identifies it as a system codeunit
-        Assert.ExpectedMessage('system', GetLastErrorText());
+        // [WHEN]  A system-range codeunit (1-9999) that does not exist is called via Codeunit.Run
+        // [THEN]  No error is raised — system codeunits are treated as no-ops
+        Probe.CallMissingSystemCodeunit();
     end;
 
     [Test]


### PR DESCRIPTION
## Summary

- `MockCodeunitHandle.Invoke` and `RunCodeunitCore` now return `null`/no-op for missing system codeunit IDs (1-9999) instead of throwing `InvalidOperationException`
- `MockCodeunitHandle.Run` (instance method) also fires `AlCompat.FireEvent` for the `OnRun` event on missing system codeunits so compiled event subscribers still execute
- User-range (50xxx+) and test-toolkit-range (130xxx) missing codeunits continue to throw with descriptive `--stubs`/`--generate-stubs` hints
- AL test `MissingSystemCodeunitIdentifiesRange` updated to `MissingSystemCodeunit_IsNoOp` reflecting new no-op behavior
- 5 new C# unit tests added to `RunnerErrorClassificationTests` covering boundary conditions (IDs 1, 9999, 10000, and static `RunCodeunit`)
- `docs/coverage.yaml` updated for `Codeunit.Run` to document the system codeunit no-op semantics

## Test plan

- [ ] `dotnet run --project AlRunner -f net8.0 -- tests/bucket-1/128-codeunit-not-found/src tests/bucket-1/128-codeunit-not-found/test` — all 7 tests pass including new `MissingSystemCodeunit_IsNoOp`
- [ ] `dotnet test AlRunner.Tests/ -f net8.0 --filter "MockCodeunitHandle"` — all 6 unit tests pass
- [ ] `dotnet test AlRunner.Tests/ -f net8.0` — all 301 C# unit tests pass
- [ ] Bucket-1 and bucket-2 AL test suites show no new failures (pre-existing `DT2Time` failures unrelated)