### PR TITLE
feat: graceful codeunit-not-found fallback + --init-events lifecycle flag

### DIFF
--- a/AlRunner/Pipeline.cs
+++ b/AlRunner/Pipeline.cs
@@ -26,6 +26,14 @@ public class PipelineOptions
     /// <summary>When true, promote exit code 2 (runner limitations) to exit code 1 (failure).</summary>
     public bool Strict { get; set; }
 
+    /// <summary>
+    /// When true, fire standard BC lifecycle integration events (OnCompanyInitialize from
+    /// Codeunit 27, OnInstallAppPerCompany from Codeunit 2) before test execution.
+    /// This allows extensions with [EventSubscriber] on system events to perform
+    /// setup work without the actual system codeunits being present.
+    /// </summary>
+    public bool InitEvents { get; set; }
+
     /// <summary>Configures the value returned by UserId() — defaults to "TESTUSER".</summary>
     public string? UserId { get; set; }
 
@@ -703,7 +711,7 @@ public class AlRunnerPipeline
             }
 
             var runSw = System.Diagnostics.Stopwatch.StartNew();
-            var results = Executor.RunTests(assembly, captureValues: options.CaptureValues, runProcedure: options.RunProcedure);
+            var results = Executor.RunTests(assembly, captureValues: options.CaptureValues, runProcedure: options.RunProcedure, initEvents: options.InitEvents);
             runSw.Stop();
             testResults.AddRange(results);
             if (results.Count == 0 && options.RunProcedure != null)

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -32,6 +32,8 @@ if (args.Length == 0 || args.Any(a => a is "-h" or "--help"))
     Console.Error.WriteLine("  --packages <dir>      Add symbol references from .app files in directory");
     Console.Error.WriteLine("                        (auto-detected: .alpackages in/near source dirs when omitted)");
     Console.Error.WriteLine("  --stubs <dir>         Override dependency objects with stub AL files");
+    Console.Error.WriteLine("  --init-events         Fire BC lifecycle integration events before test execution");
+    Console.Error.WriteLine("                        (OnCompanyInitialize from CU 27, OnInstallAppPerCompany from CU 2)");
     Console.Error.WriteLine("  --dump-csharp         Print generated C# (before rewriting) and exit");
     Console.Error.WriteLine("  --dump-rewritten      Print rewritten C# (after rewriting) and exit");
     Console.Error.WriteLine("  -e '<al code>'        Run inline AL code");
@@ -197,6 +199,10 @@ while (argIdx < args.Length)
             argIdx++;
             if (argIdx >= args.Length) { Console.Error.WriteLine("Error: --user-id requires a value argument"); return 1; }
             options.UserId = args[argIdx];
+            argIdx++;
+            break;
+        case "--init-events":
+            options.InitEvents = true;
             argIdx++;
             break;
         case "--stubs":
@@ -612,6 +618,35 @@ al-runner --iteration-tracking ./src ./test                   # track loop itera
 al-runner --server                                         # long-running JSON-RPC daemon (stdin/stdout)
 al-runner --generate-stubs .alpackages ./stubs             # scaffold stubs from .app packages (all codeunits)
 al-runner --generate-stubs .alpackages ./stubs ./src ./test  # only stubs referenced in source
+al-runner --init-events ./src ./test                          # fire OnCompanyInitialize before each test
+```
+
+### --init-events: lifecycle event pre-seeding
+
+Pass `--init-events` when your extension has `[EventSubscriber]` methods that listen
+to BC system lifecycle events and need to run their setup logic before each test.
+
+Events fired before every test (after the per-test table reset):
+- `OnCompanyInitialize` from Codeunit 27 "Company-Initialize"
+- `OnInstallAppPerCompany` from Codeunit 2 "Install"
+
+The publisher codeunits (27, 2) do not need to be present in the assembly — al-runner
+will look up subscribers by reflection and dispatch to them directly. Missing publisher
+codeunits are silently skipped (graceful fallback, not a crash).
+
+Use case: extensions like Cash365 that use `[EventSubscriber(ObjectType::Codeunit, 27, 'OnCompanyInitialize', '', false, false)]`
+to create required setup records (number series, posting groups, etc.) before any
+business logic runs. With `--init-events`, those subscribers fire automatically before
+each test, eliminating the need to manually call setup procedures in every test.
+
+```al
+// This subscriber fires automatically with --init-events:
+[EventSubscriber(ObjectType::Codeunit, 27, 'OnCompanyInitialize', '', false, false)]
+local procedure OnCompanyInitialize()
+begin
+    // Create required setup records for your extension
+    InsertDefaultSetup();
+end;
 ```
 
 ### Machine-readable output (--output-json)
@@ -2265,7 +2300,7 @@ public static class Executor
         }
     }
 
-    public static List<AlRunner.TestResult> RunTests(Assembly assembly, bool captureValues = false, string? runProcedure = null)
+    public static List<AlRunner.TestResult> RunTests(Assembly assembly, bool captureValues = false, string? runProcedure = null, bool initEvents = false)
     {
         // Find test methods using [NavTest] attribute on the parent method,
         // then find the corresponding _Scope_ nested class.
@@ -2344,6 +2379,16 @@ public static class Executor
             AlRunner.Runtime.MockSession.Reset();
             AlRunner.Runtime.MockLanguage.Reset();
             AlRunner.Runtime.EventSubscriberRegistry.ResetBindings();
+
+            // Re-fire lifecycle integration events after each table reset when --init-events is set.
+            // This ensures that company-initialization setup data (created by [EventSubscriber]
+            // handlers on e.g. Codeunit 27 OnCompanyInitialize) is present before every test,
+            // matching BC's behaviour where company data persists across tests.
+            if (initEvents)
+            {
+                AlRunner.Runtime.AlCompat.FireEvent(27, "OnCompanyInitialize");
+                AlRunner.Runtime.AlCompat.FireEvent(2, "OnInstallAppPerCompany");
+            }
 
             try
             {

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -10958,3 +10958,20 @@ XmlportInstance.TextEncoding:
   notes: overloads=1; property on MockXmlPortHandle
   tests:
     - tests/bucket-1/90-xmlport-instance
+
+codeunit_not_found_graceful_fallback:
+  layer: runtime-api
+  category: codeunit
+  status: covered
+  notes: Missing codeunits (not in the compiled assembly) are now a soft warning instead of a fatal throw. RunCodeunit, Run(), and Invoke() log a warning to stderr and return a default value (null/true), allowing the calling test to continue. Tests prove execution continues after Codeunit.Run(99999) and Codeunit.Run(27).
+  tests:
+    - tests/bucket-1/128-codeunit-not-found
+
+init_events_lifecycle:
+  layer: runtime-api
+  category: codeunit
+  status: covered
+  notes: >
+    --init-events CLI flag fires BC lifecycle integration events (OnCompanyInitialize from Codeunit 27, OnInstallAppPerCompany from Codeunit 2) before each test (after per-test table reset). Allows [EventSubscriber] handlers on system events to perform setup work without the system codeunits being present. Subscriber code is discovered by reflection on compiled classes.
+  tests:
+    - tests/init-events/40-init-events

--- a/tests/init-events/40-init-events/src/InitEventsSrc.al
+++ b/tests/init-events/40-init-events/src/InitEventsSrc.al
@@ -1,0 +1,32 @@
+/// Table used to record that the init-event subscriber fired.
+table 57100 "Init Events Sentinel"
+{
+    DataClassification = CustomerContent;
+    fields
+    {
+        field(1; Id; Integer) { }
+        field(2; Fired; Boolean) { }
+    }
+    keys { key(PK; Id) { Clustered = true; } }
+}
+
+/// Subscriber that listens to OnCompanyInitialize (Codeunit 27).
+/// When --init-events fires OnCompanyInitialize before tests run,
+/// this subscriber sets the sentinel record so the test can detect it.
+codeunit 57100 "Init Events Subscriber"
+{
+    [EventSubscriber(ObjectType::Codeunit, 27, 'OnCompanyInitialize', '', false, false)]
+    local procedure HandleOnCompanyInitialize()
+    var
+        Sentinel: Record "Init Events Sentinel";
+    begin
+        if not Sentinel.Get(1) then begin
+            Sentinel.Id := 1;
+            Sentinel.Fired := true;
+            Sentinel.Insert();
+        end else begin
+            Sentinel.Fired := true;
+            Sentinel.Modify();
+        end;
+    end;
+}

--- a/tests/init-events/40-init-events/test/InitEventsTest.al
+++ b/tests/init-events/40-init-events/test/InitEventsTest.al
@@ -1,0 +1,20 @@
+/// Tests that --init-events fires OnCompanyInitialize before test execution,
+/// allowing subscribers on system codeunits to perform setup work.
+codeunit 57101 "Init Events Tests"
+{
+    Subtype = Test;
+    var
+        Assert: Codeunit Assert;
+
+    [Test]
+    procedure OnCompanyInitialize_FiredBeforeTests_SentinelPresent()
+    var
+        Sentinel: Record "Init Events Sentinel";
+    begin
+        // [GIVEN]  The runner is started with --init-events
+        // [WHEN]   Test execution begins (OnCompanyInitialize was fired before this test)
+        // [THEN]   The sentinel record written by the subscriber exists
+        Assert.IsTrue(Sentinel.Get(1), '--init-events must fire OnCompanyInitialize before test execution');
+        Assert.IsTrue(Sentinel.Fired, 'Subscriber must have set Fired = true on the sentinel record');
+    end;
+}


### PR DESCRIPTION
## Summary

- **Graceful missing-codeunit fallback**: `RunCodeunit()`, `Run()`, and `Invoke()` in `MockCodeunitHandle` no longer throw `InvalidOperationException` when a codeunit isn't in the compiled assembly. They now log a stderr warning (`⚠ Codeunit N not found — returning default value`) and return a default (null/true), so the calling test continues instead of dying with ERROR status.
- **`--init-events` CLI flag**: fires `OnCompanyInitialize` (Codeunit 27) and `OnInstallAppPerCompany` (Codeunit 2) before every test (after the per-test table reset). Extensions with `[EventSubscriber]` on system lifecycle events can seed required setup data without those system codeunits being present. Publisher codeunits need not exist — the graceful fallback prevents crashes, while subscriber code is dispatched via reflection.

## Changes

- `AlRunner/Runtime/MockCodeunitHandle.cs` — three throw-sites changed to log+return
- `AlRunner/Pipeline.cs` — added `InitEvents` to `PipelineOptions`; pass to `RunTests`
- `AlRunner/Program.cs` — `--init-events` CLI flag; events fired per-test inside `RunTests`; `PrintGuide()` updated
- `tests/bucket-1/128-codeunit-not-found/` — old "throw-expecting" tests replaced with proving graceful-continuation tests
- `tests/init-events/40-init-events/` — new separate test suite (requires `--init-events`, like stubs tests)
- `docs/coverage.yaml` — two new entries

## Test plan

- [ ] `dotnet run --project AlRunner --framework net9.0 -- tests/bucket-1/128-codeunit-not-found/src tests/bucket-1/128-codeunit-not-found/test` → 3 PASS
- [ ] `dotnet run --project AlRunner --framework net9.0 -- --init-events tests/init-events/40-init-events/src tests/init-events/40-init-events/test` → 1 PASS
- [ ] `dotnet run --project AlRunner --framework net9.0 -- tests/init-events/40-init-events/src tests/init-events/40-init-events/test` → 1 FAIL (proves test is not vacuous)
- [ ] All bucket-1 and bucket-2 tests: only pre-existing DT2Time failures remain
- [ ] Stubs test: unaffected