### PR TITLE
fix: null guard in CloneTaggedOption — crash on uninitialized enum fields

### DIFF
--- a/AlRunner.Tests/CloneTaggedOptionTests.cs
+++ b/AlRunner.Tests/CloneTaggedOptionTests.cs
@@ -1,0 +1,94 @@
+using AlRunner.Runtime;
+using Microsoft.Dynamics.Nav.Runtime;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// Unit tests for AlCompat.CloneTaggedOption — issue #null-option.
+///
+/// When an AL enum/option field is read before it has been explicitly
+/// assigned, the underlying NavOption reference at the C# level is null.
+/// The BC compiler emits NavOption.Create(existingVar.NavOptionMetadata, V),
+/// which the RoslynRewriter transforms into
+/// AlCompat.CloneTaggedOption(existingVar, V).  If existingVar is null,
+/// ConditionalWeakTable.TryGetValue throws
+/// "Value cannot be null (Parameter 'key')".
+///
+/// Fix: add a null-guard at the start of CloneTaggedOption that returns
+/// NavOption.Create(ordinal) for a null existing argument, matching BC's
+/// behaviour where uninitialized option fields default to ordinal 0.
+/// </summary>
+public class CloneTaggedOptionTests
+{
+    // -------------------------------------------------------------------------
+    // Positive: CloneTaggedOption(null, 0) must NOT throw and must return
+    // a NavOption whose ToInt32() is 0.
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void CloneTaggedOption_NullExisting_Ordinal0_ReturnsDefault()
+    {
+        // Arrange: simulate an uninitialized NavOption (null reference)
+        NavOption? existing = null;
+
+        // Act: must not throw ArgumentNullException / NullReferenceException
+        var result = AlCompat.CloneTaggedOption(existing!, 0);
+
+        // Assert: returned NavOption has ordinal 0
+        Assert.NotNull(result);
+        Assert.Equal(0, result.ToInt32());
+    }
+
+    // -------------------------------------------------------------------------
+    // Positive: CloneTaggedOption(null, 2) must return ordinal 2 —
+    // proving the guard does not always return 0.
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void CloneTaggedOption_NullExisting_NonZeroOrdinal_ReturnsRequestedOrdinal()
+    {
+        NavOption? existing = null;
+
+        var result = AlCompat.CloneTaggedOption(existing!, 2);
+
+        Assert.NotNull(result);
+        Assert.Equal(2, result.ToInt32());
+    }
+
+    // -------------------------------------------------------------------------
+    // Positive (non-null path): CloneTaggedOption with a valid existing option
+    // still returns the requested ordinal — the fix must not break the normal path.
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void CloneTaggedOption_ValidExisting_ReturnsRequestedOrdinal()
+    {
+        // Arrange: create a real NavOption with ordinal 1
+        var existing = MockRecordHandle.CreateOptionValue(1);
+
+        // Act
+        var result = AlCompat.CloneTaggedOption(existing, 3);
+
+        // Assert: the cloned option reflects ordinal 3, not 1
+        Assert.NotNull(result);
+        Assert.Equal(3, result.ToInt32());
+    }
+
+    // -------------------------------------------------------------------------
+    // Negative: the fix must not silently swallow genuinely invalid states.
+    // A non-null existing with ordinal 0 should produce ordinal 0 — the
+    // non-null path is not affected by the guard.
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void CloneTaggedOption_ValidExisting_OrdinalZero_ReturnsZero()
+    {
+        var existing = MockRecordHandle.CreateOptionValue(0);
+
+        var result = AlCompat.CloneTaggedOption(existing, 0);
+
+        Assert.NotNull(result);
+        Assert.Equal(0, result.ToInt32());
+    }
+}

--- a/AlRunner/Runtime/AlScope.cs
+++ b/AlRunner/Runtime/AlScope.cs
@@ -790,6 +790,17 @@ public static class AlCompat
     /// </summary>
     public static NavOption CloneTaggedOption(NavOption existing, int ordinal)
     {
+        // Guard: when an AL enum/option field or variable has never been assigned,
+        // the underlying NavOption reference at the C# level is null.  The BC
+        // compiler emits NavOption.Create(existing.NavOptionMetadata, V) which
+        // the rewriter transforms to CloneTaggedOption(existing, V).  With a null
+        // existing, ConditionalWeakTable.TryGetValue throws
+        // "Value cannot be null (Parameter 'key')".  Treat null as an
+        // uninitialized option and just create a fresh NavOption — BC behaviour
+        // is that uninitialized option fields default to ordinal 0.
+        if (existing == null)
+            return AlRunner.Runtime.MockRecordHandle.CreateOptionValue(ordinal);
+
         var opt = AlRunner.Runtime.MockRecordHandle.CreateOptionValue(ordinal);
         if (_optionEnumId.TryGetValue(existing, out var id))
             _optionEnumId.AddOrUpdate(opt, id);

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -1184,6 +1184,20 @@ xmlport_element:
 
 # ── enum ────────────────────────────────────────────────────────
 
+enum_uninitialized_null_guard:
+  layer: runtime
+  category: enum
+  status: covered
+  notes: >
+    AlCompat.CloneTaggedOption(null, ordinal) — null guard for uninitialized
+    NavOption fields/variables.  Before the fix, ConditionalWeakTable.TryGetValue
+    threw ArgumentNullException("key") when the enum field had never been assigned.
+    Fix returns NavOption.Create(ordinal) for null existing.
+  tests:
+    - tests/bucket-1/292-null-option-default
+  unit_tests:
+    - AlRunner.Tests/CloneTaggedOptionTests.cs
+
 enum_value_declaration:
   layer: syntax
   category: enum

--- a/tests/bucket-1/292-null-option-default/src/NullOptionDefault.al
+++ b/tests/bucket-1/292-null-option-default/src/NullOptionDefault.al
@@ -1,0 +1,80 @@
+/// Helpers for null-option-default tests.
+/// When an enum/option field on a record is read before it has been
+/// explicitly written the underlying NavOption variable is null.
+/// CloneTaggedOption must not crash in that case.
+table 29201 "NullOpt Record"
+{
+    DataClassification = ToBeClassified;
+
+    fields
+    {
+        field(1; Id; Integer)
+        {
+            DataClassification = ToBeClassified;
+        }
+        field(2; Status; Enum "NullOpt Status")
+        {
+            DataClassification = ToBeClassified;
+        }
+    }
+
+    keys
+    {
+        key(PK; Id) { Clustered = true; }
+    }
+}
+
+enum 29201 "NullOpt Status"
+{
+    Extensible = false;
+
+    value(0; Initial) { }
+    value(1; Active)  { }
+    value(2; Closed)  { }
+}
+
+codeunit 29201 "NullOpt Helper"
+{
+    /// Read the Status field from a record that was inserted with Init()
+    /// only (no explicit Status assignment). The NavOption backing the
+    /// field is null at this point — CloneTaggedOption must return the
+    /// default ordinal (0) rather than crashing.
+    procedure ReadUninitializedStatus(Rec: Record "NullOpt Record"): Integer
+    var
+        LocalStatus: Enum "NullOpt Status";
+    begin
+        // Re-assign from the record field — this triggers CloneTaggedOption
+        // with a null `existing` argument.
+        LocalStatus := Rec.Status;
+        exit(LocalStatus.AsInteger());
+    end;
+
+    /// Assign a non-default value and compare it using the enum literal.
+    /// The comparison `rec.Status = rec.Status::Closed` triggers
+    /// CloneTaggedOption(rec.Status.getFieldValue, 2).
+    /// Before the fix, if rec.Status was null this crashed.
+    procedure IsStatusClosed(Rec: Record "NullOpt Record"): Boolean
+    begin
+        exit(Rec.Status = Rec.Status::Closed);
+    end;
+
+    /// Assign a non-default value then re-assign to a local — CloneTaggedOption
+    /// with a non-null `existing` should still work correctly.
+    procedure ReadInitializedStatus(Rec: Record "NullOpt Record"; NewStatus: Enum "NullOpt Status"): Integer
+    var
+        LocalStatus: Enum "NullOpt Status";
+    begin
+        Rec.Status := NewStatus;
+        LocalStatus := Rec.Status;
+        exit(LocalStatus.AsInteger());
+    end;
+
+    /// Sets and reads a status via the record-field enum path, verifying
+    /// that the CloneTaggedOption round-trip (set → get → clone) gives
+    /// back the correct ordinal.
+    procedure SetThenReadStatus(var Rec: Record "NullOpt Record"; NewStatus: Enum "NullOpt Status"): Integer
+    begin
+        Rec.Status := NewStatus;
+        exit(Rec.Status.AsInteger());
+    end;
+}

--- a/tests/bucket-1/292-null-option-default/test/NullOptionDefaultTest.al
+++ b/tests/bucket-1/292-null-option-default/test/NullOptionDefaultTest.al
@@ -1,0 +1,84 @@
+/// Tests that reading an enum/option field before it has been explicitly set
+/// does not crash with "Value cannot be null (Parameter 'key')" in
+/// AlCompat.CloneTaggedOption.
+///
+/// Background: when a record is created with Init() only, the underlying
+/// NavOption for every enum field is null.  Any subsequent re-assignment of
+/// that field to a local enum variable triggers CloneTaggedOption(null, ordinal)
+/// which previously threw a NullReferenceException / ArgumentNullException.
+codeunit 29901 "NullOpt Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    // -------------------------------------------------------------------------
+    // Positive: reading an uninitialized enum field yields ordinal 0 (default)
+    // -------------------------------------------------------------------------
+
+    [Test]
+    procedure ReadUninitializedEnumField_ReturnsDefaultOrdinal()
+    var
+        Rec:    Record "NullOpt Record";
+        Helper: Codeunit "NullOpt Helper";
+        Result: Integer;
+    begin
+        // [GIVEN] A record created with Init() — Status field never assigned
+        Rec.Init();
+        Rec.Id := 1;
+        Rec.Insert(false);
+
+        // [WHEN] The Status field is copied to a local enum variable
+        //        (triggers CloneTaggedOption with null existing)
+        Result := Helper.ReadUninitializedStatus(Rec);
+
+        // [THEN] Ordinal must be 0 — the BC-default for uninitialized enums
+        Assert.AreEqual(0, Result, 'Uninitialized enum field must yield ordinal 0');
+    end;
+
+    // -------------------------------------------------------------------------
+    // Positive: re-assigning a non-default value still returns the correct ordinal
+    // -------------------------------------------------------------------------
+
+    [Test]
+    procedure ReadInitializedEnumField_ReturnsCorrectOrdinal()
+    var
+        Rec:    Record "NullOpt Record";
+        Helper: Codeunit "NullOpt Helper";
+        Result: Integer;
+    begin
+        // [GIVEN] A freshly Init()ed record (Status null)
+        Rec.Init();
+        Rec.Id := 2;
+        Rec.Insert(false);
+
+        // [WHEN] Status is set to Closed (ordinal 2) and then cloned
+        Result := Helper.ReadInitializedStatus(Rec, Rec.Status::Closed);
+
+        // [THEN] Ordinal must be 2
+        Assert.AreEqual(2, Result, 'Initialized enum field must yield the assigned ordinal');
+    end;
+
+    // -------------------------------------------------------------------------
+    // Negative: a truly invalid ordinal should not be silently returned as 0
+    // — prove the positive tests would catch a no-op stub
+    // -------------------------------------------------------------------------
+
+    [Test]
+    procedure ReadInitializedEnumField_ActiveOrdinalIs1()
+    var
+        Rec:    Record "NullOpt Record";
+        Helper: Codeunit "NullOpt Helper";
+        Result: Integer;
+    begin
+        Rec.Init();
+        Rec.Id := 3;
+        Rec.Insert(false);
+
+        Result := Helper.ReadInitializedStatus(Rec, Rec.Status::Active);
+
+        // Ordinal 1 — a no-op stub returning 0 would fail this assertion
+        Assert.AreEqual(1, Result, 'Active enum must yield ordinal 1');
+    end;
+}


### PR DESCRIPTION
## Summary

- `AlCompat.CloneTaggedOption(null, ordinal)` crashed with `ArgumentNullException("key")` because `ConditionalWeakTable.TryGetValue` rejects null keys
- This was the #1 blocker for the Cash365 project — 27 direct crashes when AL code reads an enum/option field that has never been explicitly assigned
- Fix: add a null guard at the start of `CloneTaggedOption` that returns `NavOption.Create(ordinal)` for a null `existing` argument, matching BC behaviour where uninitialized option fields default to ordinal 0

## Changes

- `AlRunner/Runtime/AlScope.cs` — null guard in `CloneTaggedOption`
- `AlRunner.Tests/CloneTaggedOptionTests.cs` — 4 xunit unit tests (2 RED before fix, all 4 GREEN after)
- `tests/bucket-1/292-null-option-default/` — AL integration suite exercising the enum assignment path through `CloneTaggedOption`
- `docs/coverage.yaml` — `enum_uninitialized_null_guard` entry

## TDD

**RED** — `CloneTaggedOption_NullExisting_Ordinal0_ReturnsDefault` and `CloneTaggedOption_NullExisting_NonZeroOrdinal_ReturnsRequestedOrdinal` both threw `ArgumentNullException("key")` before the fix.

**GREEN** — all 4 `CloneTaggedOptionTests` pass after the fix.

## Test plan

- [x] `dotnet test AlRunner.Tests/ --framework net9.0 --filter CloneTaggedOption` — 4/4 pass
- [x] `dotnet test AlRunner.Tests/ --framework net9.0` — 305/305 pass
- [x] bucket-1 — 1590 passed, 2 failed (pre-existing `DT2Time_*` failures unrelated to this change)
- [x] bucket-2 — pre-existing `Missing dependencies` error for `130-cross-ext-al0275` (unrelated)
- [x] stubs — 2/2 pass