### PR TITLE
feat: auto-stub test-toolkit codeunits (130000-139999) so Codeunit.Run no-ops

### DIFF
--- a/AlRunner/Pipeline.cs
+++ b/AlRunner/Pipeline.cs
@@ -657,6 +657,18 @@ public class AlRunnerPipeline
         }
         Timer.EndStage("Roslyn rewriting");
 
+        // Inject minimal C# stub classes for test-toolkit codeunits (130000–139999) that
+        // are referenced in the generated C# but were NOT compiled from source.
+        // This allows MockCodeunitHandle.FindCodeunitType to find them at runtime and
+        // execute as no-ops (no OnRun method → InvokeOnRun silently returns) instead of
+        // throwing InvalidOperationException.
+        var testToolkitStubs = GenerateTestToolkitStubs(generatedCSharpList);
+        if (testToolkitStubs.Count > 0)
+        {
+            rewrittenTreeList.AddRange(testToolkitStubs);
+            Log.Info($"Injected {testToolkitStubs.Count} test-toolkit codeunit stub(s)");
+        }
+
         // Step 3: Compile
         Timer.StartStage("Roslyn compilation");
         var mapperTask = Task.Run(() =>
@@ -1239,6 +1251,66 @@ public class AlRunnerPipeline
         }
 
         return generatedCSharpList;
+    }
+
+    /// <summary>
+    /// Scans the generated C# for test-toolkit codeunit IDs (130000–139999) referenced
+    /// via <c>NavCodeunit.RunCodeunit</c> or <c>new NavCodeunitHandle(..., id)</c> patterns,
+    /// then returns a minimal rewritten C# syntax tree for each ID that does NOT already
+    /// have a compiled class in <paramref name="generatedCSharpList"/>. The generated stub
+    /// classes are empty (no methods) so that <see cref="AlRunner.Runtime.MockCodeunitHandle.FindCodeunitType"/>
+    /// finds them at runtime and treats any call as a silent no-op instead of throwing.
+    /// Codeunits with runner-native mock implementations (130/131/130000, 131004, 131100) are
+    /// excluded — they are never looked up by <c>FindCodeunitType</c>.
+    /// </summary>
+    internal static List<(string Name, Microsoft.CodeAnalysis.SyntaxTree Tree)> GenerateTestToolkitStubs(
+        List<(string Name, string Code)> generatedCSharpList)
+    {
+        // IDs already compiled from source — no stub needed.
+        var alreadyPresent = new HashSet<int>();
+        var classPattern = new Regex(@"class\s+Codeunit(\d+)", RegexOptions.Compiled);
+        foreach (var (_, code) in generatedCSharpList)
+        {
+            foreach (Match m in classPattern.Matches(code))
+            {
+                if (int.TryParse(m.Groups[1].Value, out int id))
+                    alreadyPresent.Add(id);
+            }
+        }
+
+        // Codeunits that have dedicated runner-native mock implementations and are
+        // dispatched via InvokeAssert / InvokeVariableStorage / InvokeRunnerConfig
+        // before FindCodeunitType is ever consulted — never need a stub class.
+        var nativeMockIds = new HashSet<int> { 130, 131, 130000, 131004, 131100 };
+
+        // Scan all generated C# for test-toolkit ID literals that appear as the
+        // codeunit ID argument in a RunCodeunit / NavCodeunitHandle call.
+        // Pattern: a comma or opening-paren followed by a 6-digit ID in 130000-139999.
+        var idPattern = new Regex(@"(?:,\s*|[\(\s])1(3[0-9]{4})\b", RegexOptions.Compiled);
+        var referencedIds = new HashSet<int>();
+        foreach (var (_, code) in generatedCSharpList)
+        {
+            foreach (Match m in idPattern.Matches(code))
+            {
+                if (int.TryParse("1" + m.Groups[1].Value, out int id)
+                    && id is >= 130000 and <= 139999
+                    && !nativeMockIds.Contains(id))
+                {
+                    referencedIds.Add(id);
+                }
+            }
+        }
+
+        var stubs = new List<(string Name, Microsoft.CodeAnalysis.SyntaxTree Tree)>();
+        foreach (var id in referencedIds.Where(id => !alreadyPresent.Contains(id)).OrderBy(id => id))
+        {
+            // Minimal class — no OnRun method so MockCodeunitHandle.InvokeOnRun silently returns.
+            var stubCode = $"namespace Microsoft.Dynamics.Nav.BusinessApplication {{ public class Codeunit{id} {{ }} }}";
+            var tree = Microsoft.CodeAnalysis.CSharp.CSharpSyntaxTree.ParseText(
+                stubCode, path: $"TestToolkitStub{id}.cs");
+            stubs.Add(($"TestToolkitStub{id}", tree));
+        }
+        return stubs;
     }
 
     private static List<string> GetSeparateStubSources(List<string> stubSources, List<string> alSources)

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -1585,7 +1585,9 @@ Codeunit.Run:
   notes: >
     overloads=2 (no-record and with-record variants); returns true on success, false on trapped error.
     Missing system codeunits (IDs 1-9999) are treated as no-ops (fire OnRun event for subscribers, no throw);
-    missing user/test-toolkit codeunits still throw with a descriptive error.
+    missing test-toolkit codeunits (130000-139999) are auto-stubbed at compile time — FindCodeunitType finds an
+    empty class, InvokeOnRun silently returns (no OnRun method), so calls are no-ops without throwing;
+    missing user-range codeunits (e.g. 50xxx) still throw with a descriptive error.
 
 # ── CodeunitInstance ────────────────────────────────────────────
 

--- a/tests/bucket-1/128-codeunit-not-found/src/Probe.al
+++ b/tests/bucket-1/128-codeunit-not-found/src/Probe.al
@@ -12,6 +12,13 @@ codeunit 56280 "Missing CU Probe"
         Codeunit.Run(130512);
     end;
 
+    procedure CallLibraryERM()
+    begin
+        // Call Library - ERM (132217) — a test toolkit codeunit not in the assembly
+        // After the fix, this should be a no-op
+        Codeunit.Run(132217);
+    end;
+
     procedure CallMissingSystemCodeunit()
     begin
         // Call a system-range codeunit (1-9999) that doesn't exist — should be a no-op

--- a/tests/bucket-1/128-codeunit-not-found/test/Tests.al
+++ b/tests/bucket-1/128-codeunit-not-found/test/Tests.al
@@ -41,12 +41,19 @@ codeunit 56281 "Missing CU Tests"
     end;
 
     [Test]
-    procedure MissingTestToolkitCodeunitIdentifiesRange()
+    procedure MissingTestToolkitCodeunit_IsNoOp()
     begin
-        // [WHEN]  A test-toolkit-range codeunit (130xxx) that does not exist is called
-        asserterror Probe.CallMissingTestToolkitCodeunit();
-        // [THEN]  Error message identifies the test toolkit range
-        Assert.ExpectedMessage('test toolkit', GetLastErrorText());
+        // [WHEN]  A test-toolkit-range codeunit (130xxx-139999) not in the assembly is called
+        // [THEN]  No error is raised — test toolkit codeunits are treated as no-ops
+        Probe.CallMissingTestToolkitCodeunit();
+    end;
+
+    [Test]
+    procedure LibraryERM_IsNoOp()
+    begin
+        // [WHEN]  Library - ERM (132217) not in the assembly is called via Codeunit.Run
+        // [THEN]  No error is raised — test toolkit codeunits are treated as no-ops
+        Probe.CallLibraryERM();
     end;
 
     [Test]


### PR DESCRIPTION
## Summary

- Calling `Codeunit.Run(id)` on any test-toolkit codeunit (IDs 130000–139999) not compiled from source previously threw `InvalidOperationException`, blocking tests that reference Library - ERM (132217), Library - Lower Permissions (130440), and similar helpers.
- Fix: after AL transpilation, scan the generated C# for test-toolkit IDs referenced via `NavCodeunit.RunCodeunit`. For each referenced ID not already compiled from source, inject a minimal C# stub class (`public class CodeunitNNNNN {}`) into the Roslyn compilation. At runtime, `MockCodeunitHandle.FindCodeunitType` finds the stub; since it has no `OnRun` method, `InvokeOnRun` silently returns — the same no-op semantics as system codeunits (1-9999).
- Native-mock IDs (130/131/130000=Assert, 131004=Variable Storage, 131100=AL Runner Config) are excluded — they dispatch before `FindCodeunitType` is consulted.

## Test plan

- [ ] `MissingTestToolkitCodeunit_IsNoOp` — `Codeunit.Run(130512)` completes without error
- [ ] `LibraryERM_IsNoOp` — `Codeunit.Run(132217)` completes without error
- [ ] All original 6 tests in 128-codeunit-not-found still pass (user-range IDs still throw, system IDs still no-op, error message hints still present)
- [ ] All bucket-1 and bucket-2 tests pass (no regressions)