### PR TITLE
fix: coerce plain T to ByRef<T> in InvokeSubscriber for implicit DB event subscribers

### DIFF
--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -759,6 +759,9 @@ is used, the publishing codeunit instance is passed as the first subscriber para
 `OnBeforeModifyEvent`, `OnAfterModifyEvent`, `OnBeforeDeleteEvent`,
 `OnAfterDeleteEvent`, `OnBeforeValidateEvent`, `OnAfterValidateEvent` fire from
 record operations. The `Rec` and `xRec` references are passed to subscribers.
+Subscribers may declare `var RunTrigger: Boolean` (BC compiles this as `ByRef<bool>`);
+al-runner automatically coerces the plain `bool` into `ByRef<bool>` so the
+subscriber is invoked correctly.
 
 **Manual binding** — Codeunits with `EventSubscriberInstance = Manual` only fire
 after `BindSubscription(Sub)`. Call `UnbindSubscription(Sub)` to stop. Bindings

--- a/AlRunner/Runtime/AlScope.cs
+++ b/AlRunner/Runtime/AlScope.cs
@@ -729,18 +729,116 @@ public static class AlCompat
         }
     }
 
+    // Open generic type for ByRef<T> from the BC runtime.
+    // Used in InvokeSubscriber to detect when a subscriber parameter is ByRef<T>
+    // and the event arg is a plain T — e.g. "var RunTrigger: Boolean" compiles
+    // to ByRef<bool> but FireImplicitDbEvent passes a raw bool.
+    private static readonly System.Type? _byRefOpenGeneric = typeof(ByRef<bool>).GetGenericTypeDefinition();
+
+    /// <summary>
+    /// Invoke an event subscriber method, coercing each argument to the
+    /// declared parameter type.  The most common mismatch is a plain value
+    /// being passed for a <c>ByRef&lt;T&gt;</c> parameter (e.g. a subscriber
+    /// that declares <c>var RunTrigger: Boolean</c> where BC emits
+    /// <c>ByRef&lt;bool&gt;</c> but <see cref="MockRecordHandle.FireImplicitDbEvent"/>
+    /// passes a plain <c>bool</c>).
+    ///
+    /// When the arg count is less than the parameter count (subscriber declares
+    /// extra optional-style params) the remaining args stay null; reference-type
+    /// params accept null, and value-type params are left as default(T).
+    /// </summary>
     private static void InvokeSubscriber(object? instance, System.Reflection.MethodInfo method, object?[] eventArgs)
     {
         var parameters = method.GetParameters();
         var args = new object?[parameters.Length];
-        for (int i = 0; i < args.Length && i < eventArgs.Length; i++)
-            args[i] = eventArgs[i];
+        for (int i = 0; i < args.Length; i++)
+        {
+            var raw = i < eventArgs.Length ? eventArgs[i] : null;
+            args[i] = CoerceArgForParameter(parameters[i], raw);
+        }
         try { method.Invoke(instance, args); }
         catch (System.Reflection.TargetInvocationException tie)
         {
             if (tie.InnerException != null) throw tie.InnerException;
             throw;
         }
+    }
+
+    /// <summary>
+    /// Coerce <paramref name="arg"/> so it is assignable to the declared
+    /// <paramref name="param"/> type.
+    ///
+    /// <list type="bullet">
+    ///   <item><c>ByRef&lt;T&gt;</c> param + plain <c>T</c> arg — wraps the value
+    ///   in a <c>ByRef&lt;T&gt;</c> using a getter/setter backed by a local
+    ///   variable so mutation inside the subscriber is captured (though the
+    ///   writeback currently only matters to the subscriber itself, not to the
+    ///   caller, since implicit DB event firers do not use the returned value).</item>
+    ///   <item>Value-type param + null arg — returns <c>Activator.CreateInstance(T)</c>
+    ///   (the default value) so reflection does not throw on the unboxing.</item>
+    ///   <item>All other cases — returns <paramref name="arg"/> unchanged.</item>
+    /// </list>
+    /// </summary>
+    private static object? CoerceArgForParameter(System.Reflection.ParameterInfo param, object? arg)
+    {
+        var paramType = param.ParameterType;
+
+        // ByRef<T> wrapping: subscriber declared "var X: SomeType" for a
+        // value or non-record type, so BC emits ByRef<T>.  The event fires
+        // with a plain T — we wrap it.
+        if (_byRefOpenGeneric != null
+            && paramType.IsGenericType
+            && paramType.GetGenericTypeDefinition() == _byRefOpenGeneric)
+        {
+            // If arg is already ByRef<T>, pass it through.
+            if (arg != null && paramType.IsInstanceOfType(arg))
+                return arg;
+
+            var innerType = paramType.GetGenericArguments()[0];
+            // Build a ByRef<T> using its (Func<T>, Action<T>) constructor.
+            // We use a single-element object array as the backing store so that
+            // mutations inside the subscriber are captured even though we don't
+            // propagate them back to the original eventArgs.
+            var store = new object?[] { arg };
+            try
+            {
+                // Build Func<T>: () => (T)store[0]
+                var funcType = typeof(System.Func<>).MakeGenericType(innerType);
+                var actionType = typeof(System.Action<>).MakeGenericType(innerType);
+
+                // Use a generic helper to avoid per-type Activator overheads.
+                var helperMethod = typeof(AlCompat).GetMethod(
+                    nameof(MakeByRef),
+                    System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)
+                    ?.MakeGenericMethod(innerType);
+
+                if (helperMethod != null)
+                    return helperMethod.Invoke(null, new[] { store });
+            }
+            catch { /* fall through — return arg as-is and let Invoke give a clearer error */ }
+
+            return arg;
+        }
+
+        // Value-type param with null arg: supply the type default so Invoke
+        // does not throw "Object of type 'null' cannot be converted to type T".
+        if (arg == null && paramType.IsValueType)
+            return System.Activator.CreateInstance(paramType);
+
+        return arg;
+    }
+
+    /// <summary>
+    /// Generic helper that creates a <c>ByRef&lt;T&gt;</c> backed by
+    /// <paramref name="store"/>[0] via getter/setter lambdas.
+    /// Called reflectively from <see cref="CoerceArgForParameter"/> to avoid
+    /// generating per-type IL at runtime.
+    /// </summary>
+    private static ByRef<T> MakeByRef<T>(object?[] store)
+    {
+        return new ByRef<T>(
+            () => store[0] is T v ? v : default!,
+            v => store[0] = v);
     }
 
     /// <summary>

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -655,6 +655,7 @@ event_declaration:
   status: covered
   tests:
     - tests/bucket-2/100-bind-subscription
+    - tests/bucket-2/225-db-event-byref-params
     - tests/bucket-2/37-event-scope
     - tests/bucket-2/66-event-subscribers
     - tests/bucket-2/97-event-params
@@ -698,6 +699,7 @@ trigger_declaration:
   status: covered
   tests:
     - tests/bucket-1/18-validate-trigger
+    - tests/bucket-2/225-db-event-byref-params
     - tests/bucket-2/63-oninsert-trigger
     - tests/bucket-2/98-db-trigger-events
     - tests/bucket-2/99-validate-events
@@ -10989,3 +10991,19 @@ init_events_lifecycle:
     --init-events CLI flag fires BC lifecycle integration events (OnCompanyInitialize from Codeunit 27, OnInstallAppPerCompany from Codeunit 2) before each test (after per-test table reset). Allows [EventSubscriber] handlers on system events to perform setup work without the system codeunits being present. Subscriber code is discovered by reflection on compiled classes.
   tests:
     - tests/init-events/40-init-events
+
+implicit_db_event_byref_params:
+  layer: runtime-api
+  category: table
+  status: covered
+  notes: >
+    InvokeSubscriber now coerces plain-T event args to ByRef<T> when the subscriber
+    method parameter is ByRef<T>. This fixes crashes for subscribers that declare
+    "var RunTrigger: Boolean" (BC emits ByRef<bool>) for implicit DB trigger events
+    (OnBefore/AfterInsertEvent, OnBefore/AfterModifyEvent, OnBefore/AfterDeleteEvent).
+    Without the fix, method.Invoke threw ArgumentException:
+    "Object of type 'System.Boolean' cannot be converted to type
+    'Microsoft.Dynamics.Nav.Runtime.ByRef`1[System.Boolean]'".
+    Also handles value-type parameters with null args (fills in default(T)).
+  tests:
+    - tests/bucket-2/225-db-event-byref-params

--- a/tests/bucket-2/225-db-event-byref-params/src/DbEventByRefParams.al
+++ b/tests/bucket-2/225-db-event-byref-params/src/DbEventByRefParams.al
@@ -1,0 +1,113 @@
+// Tests for implicit DB event subscribers that declare "var" on non-record params
+// (e.g. "var RunTrigger: Boolean"). BC compiles these as ByRef<bool> in the
+// generated C#, while FireImplicitDbEvent passes a plain bool.
+// The runner must wrap the plain value in ByRef<T> before dispatching.
+
+table 59851 "DEBP Source"
+{
+    fields
+    {
+        field(1; PK; Integer) { }
+        field(2; Name; Text[100]) { }
+        field(3; Amount; Decimal) { }
+    }
+    keys { key(PK; PK) { Clustered = true; } }
+}
+
+table 59852 "DEBP Log"
+{
+    fields
+    {
+        field(1; PK; Integer) { }
+        field(2; EventType; Text[50]) { }
+        field(3; RunTriggerWasTrue; Boolean) { }
+        field(4; RecName; Text[100]) { }
+    }
+    keys { key(PK; PK) { Clustered = true; } }
+}
+
+codeunit 59851 "DEBP Subscriber"
+{
+    // var RunTrigger: Boolean — BC emits ByRef<bool> for this parameter.
+    // Without the fix, InvokeSubscriber crashes with:
+    //   ArgumentException: Object of type 'System.Boolean' cannot be converted
+    //   to type 'Microsoft.Dynamics.Nav.Runtime.ByRef`1[System.Boolean]'
+
+    [EventSubscriber(ObjectType::Table, Database::"DEBP Source", OnBeforeInsertEvent, '', true, true)]
+    local procedure OnBeforeInsert(var Rec: Record "DEBP Source"; var RunTrigger: Boolean)
+    var
+        Log: Record "DEBP Log";
+    begin
+        Log.PK := 1;
+        Log.EventType := 'BeforeInsert';
+        Log.RunTriggerWasTrue := RunTrigger;
+        Log.RecName := Rec.Name;
+        if not Log.Insert() then
+            Log.Modify();
+    end;
+
+    [EventSubscriber(ObjectType::Table, Database::"DEBP Source", OnAfterInsertEvent, '', true, true)]
+    local procedure OnAfterInsert(var Rec: Record "DEBP Source"; var RunTrigger: Boolean)
+    var
+        Log: Record "DEBP Log";
+    begin
+        Log.PK := 2;
+        Log.EventType := 'AfterInsert';
+        Log.RunTriggerWasTrue := RunTrigger;
+        Log.RecName := Rec.Name;
+        if not Log.Insert() then
+            Log.Modify();
+    end;
+
+    [EventSubscriber(ObjectType::Table, Database::"DEBP Source", OnBeforeModifyEvent, '', true, true)]
+    local procedure OnBeforeModify(var Rec: Record "DEBP Source"; var xRec: Record "DEBP Source"; var RunTrigger: Boolean)
+    var
+        Log: Record "DEBP Log";
+    begin
+        Log.PK := 3;
+        Log.EventType := 'BeforeModify';
+        Log.RunTriggerWasTrue := RunTrigger;
+        Log.RecName := Rec.Name;
+        if not Log.Insert() then
+            Log.Modify();
+    end;
+
+    [EventSubscriber(ObjectType::Table, Database::"DEBP Source", OnAfterModifyEvent, '', true, true)]
+    local procedure OnAfterModify(var Rec: Record "DEBP Source"; var xRec: Record "DEBP Source"; var RunTrigger: Boolean)
+    var
+        Log: Record "DEBP Log";
+    begin
+        Log.PK := 4;
+        Log.EventType := 'AfterModify';
+        Log.RunTriggerWasTrue := RunTrigger;
+        Log.RecName := Rec.Name;
+        if not Log.Insert() then
+            Log.Modify();
+    end;
+
+    [EventSubscriber(ObjectType::Table, Database::"DEBP Source", OnBeforeDeleteEvent, '', true, true)]
+    local procedure OnBeforeDelete(var Rec: Record "DEBP Source"; var RunTrigger: Boolean)
+    var
+        Log: Record "DEBP Log";
+    begin
+        Log.PK := 5;
+        Log.EventType := 'BeforeDelete';
+        Log.RunTriggerWasTrue := RunTrigger;
+        Log.RecName := Rec.Name;
+        if not Log.Insert() then
+            Log.Modify();
+    end;
+
+    [EventSubscriber(ObjectType::Table, Database::"DEBP Source", OnAfterDeleteEvent, '', true, true)]
+    local procedure OnAfterDelete(var Rec: Record "DEBP Source"; var RunTrigger: Boolean)
+    var
+        Log: Record "DEBP Log";
+    begin
+        Log.PK := 6;
+        Log.EventType := 'AfterDelete';
+        Log.RunTriggerWasTrue := RunTrigger;
+        Log.RecName := Rec.Name;
+        if not Log.Insert() then
+            Log.Modify();
+    end;
+}

--- a/tests/bucket-2/225-db-event-byref-params/test/DbEventByRefParamsTest.al
+++ b/tests/bucket-2/225-db-event-byref-params/test/DbEventByRefParamsTest.al
@@ -1,0 +1,129 @@
+codeunit 59853 "DEBP Tests"
+{
+    Subtype = Test;
+    var
+        Assert: Codeunit Assert;
+
+    // -----------------------------------------------------------------------
+    // Positive tests: subscriber with "var RunTrigger: Boolean" fires and
+    // receives the correct values. This was crashing before the fix:
+    //   ArgumentException: Object of type 'System.Boolean' cannot be converted
+    //   to type 'Microsoft.Dynamics.Nav.Runtime.ByRef`1[System.Boolean]'
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure BeforeInsertEvent_VarRunTriggerSubscriberFires()
+    var
+        Src: Record "DEBP Source";
+        Log: Record "DEBP Log";
+    begin
+        // Positive: subscriber with var RunTrigger fires on Insert
+        Src.PK := 1;
+        Src.Name := 'Alpha';
+        Src.Insert();
+
+        Assert.IsTrue(Log.Get(1), 'BeforeInsert log should exist');
+        Assert.AreEqual('BeforeInsert', Log.EventType, 'EventType should be BeforeInsert');
+        Assert.AreEqual('Alpha', Log.RecName, 'RecName should match Rec.Name');
+    end;
+
+    [Test]
+    procedure AfterInsertEvent_VarRunTriggerSubscriberFires()
+    var
+        Src: Record "DEBP Source";
+        Log: Record "DEBP Log";
+    begin
+        // Positive: subscriber with var RunTrigger fires on Insert (after)
+        Src.PK := 1;
+        Src.Name := 'Beta';
+        Src.Insert();
+
+        Assert.IsTrue(Log.Get(2), 'AfterInsert log should exist');
+        Assert.AreEqual('AfterInsert', Log.EventType, 'EventType should be AfterInsert');
+        Assert.AreEqual('Beta', Log.RecName, 'RecName should match');
+    end;
+
+    [Test]
+    procedure BeforeModifyEvent_VarRunTriggerSubscriberFires()
+    var
+        Src: Record "DEBP Source";
+        Log: Record "DEBP Log";
+    begin
+        // Positive: subscriber with var RunTrigger fires on Modify (before)
+        Src.PK := 1;
+        Src.Name := 'Gamma';
+        Src.Insert();
+        Src.Name := 'Delta';
+        Src.Modify();
+
+        Assert.IsTrue(Log.Get(3), 'BeforeModify log should exist');
+        Assert.AreEqual('BeforeModify', Log.EventType, 'EventType should be BeforeModify');
+    end;
+
+    [Test]
+    procedure AfterModifyEvent_VarRunTriggerSubscriberFires()
+    var
+        Src: Record "DEBP Source";
+        Log: Record "DEBP Log";
+    begin
+        // Positive: subscriber with var RunTrigger fires on Modify (after)
+        Src.PK := 1;
+        Src.Name := 'Epsilon';
+        Src.Insert();
+        Src.Name := 'Zeta';
+        Src.Modify();
+
+        Assert.IsTrue(Log.Get(4), 'AfterModify log should exist');
+        Assert.AreEqual('AfterModify', Log.EventType, 'EventType should be AfterModify');
+        Assert.AreEqual('Zeta', Log.RecName, 'RecName should be modified value');
+    end;
+
+    [Test]
+    procedure BeforeDeleteEvent_VarRunTriggerSubscriberFires()
+    var
+        Src: Record "DEBP Source";
+        Log: Record "DEBP Log";
+    begin
+        // Positive: subscriber with var RunTrigger fires on Delete (before)
+        Src.PK := 1;
+        Src.Name := 'Eta';
+        Src.Insert();
+        Src.Delete();
+
+        Assert.IsTrue(Log.Get(5), 'BeforeDelete log should exist');
+        Assert.AreEqual('BeforeDelete', Log.EventType, 'EventType should be BeforeDelete');
+        Assert.AreEqual('Eta', Log.RecName, 'RecName should match');
+    end;
+
+    [Test]
+    procedure AfterDeleteEvent_VarRunTriggerSubscriberFires()
+    var
+        Src: Record "DEBP Source";
+        Log: Record "DEBP Log";
+    begin
+        // Positive: subscriber with var RunTrigger fires on Delete (after)
+        Src.PK := 1;
+        Src.Name := 'Theta';
+        Src.Insert();
+        Src.Delete();
+
+        Assert.IsTrue(Log.Get(6), 'AfterDelete log should exist');
+        Assert.AreEqual('AfterDelete', Log.EventType, 'EventType should be AfterDelete');
+        Assert.AreEqual('Theta', Log.RecName, 'RecName should match');
+    end;
+
+    // -----------------------------------------------------------------------
+    // Negative: confirm the subscriber does NOT fire when the source table
+    // is never touched (proves each test is isolated).
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure NoEventWithoutDatabaseOperation()
+    var
+        Log: Record "DEBP Log";
+    begin
+        // Negative: no DB operations on DEBP Source → no log entries
+        Assert.IsFalse(Log.Get(1), 'Log PK=1 should not exist without insert');
+        Assert.IsFalse(Log.Get(2), 'Log PK=2 should not exist without insert');
+    end;
+}


### PR DESCRIPTION
## Summary

- Fixes crash in `InvokeSubscriber` (AlScope.cs) when implicit DB event subscribers declare `var RunTrigger: Boolean` — BC compiles this as `ByRef<bool>` but `FireImplicitDbEvent` passes a plain `bool`, causing `ArgumentException: Object of type 'System.Boolean' cannot be converted to type 'Microsoft.Dynamics.Nav.Runtime.ByRef\`1[System.Boolean]'`
- Adds `CoerceArgForParameter` helper that wraps plain `T` args in `ByRef<T>` (using getter/setter lambdas) when the subscriber method parameter is declared as `ByRef<T>`
- Also fills in `default(T)` for value-type parameters when `eventArgs` has fewer entries than the subscriber's parameter count
- Adds test suite `225-db-event-byref-params` with 7 tests covering all 6 implicit DB events + a negative isolation test

## Test plan

- [ ] New test suite `225-db-event-byref-params`: 6 positive tests (one per DB event) confirm subscribers with `var RunTrigger: Boolean` fire correctly; 1 negative test confirms no spurious firing
- [ ] All existing bucket-1 and bucket-2 tests continue to pass (only pre-existing DT2Time/CreateDateTime timezone failures unrelated to this change)
- [ ] All 305 C# unit tests pass
- [ ] Stubs tests pass