### PR TITLE
fix: coerce NavBoolean→NavText in CoerceToExpectedType (#bool-cast-fix)

### DIFF
--- a/AlRunner/Runtime/MockRecordHandle.cs
+++ b/AlRunner/Runtime/MockRecordHandle.cs
@@ -238,6 +238,13 @@ public class MockRecordHandle
             int length = TableFieldRegistry.GetFieldLength(_tableId, fieldNo) ?? 250;
             return new NavCode(length, ((string)nt).ToUpperInvariant());
         }
+        // When a Boolean value (NavBoolean) ends up in a Text/Code field slot — e.g. via
+        // FieldRef.Value := BooleanFieldRef.Value — the BC runtime casts the stored value
+        // to NavText with (NavText)GetFieldValueSafe(fieldNo, NavType.Text), which throws
+        // "Unable to cast NavBoolean to NavText". Convert using AL's standard Boolean→Text
+        // representation: true → "Yes", false → "No".
+        if (expectedType == NavType.Text && value is NavBoolean nb)
+            return new NavText((bool)nb ? "Yes" : "No");
         return value;
     }
 

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -2624,8 +2624,13 @@ FieldRef.Value:
     the stored value was NavText. GetFieldValueSafe now coerces NavText → NavCode (uppercased,
     length from TableFieldRegistry or 250 fallback) when expectedType is Code.
     SetFieldValueSafe applies the same coercion so the field bag stays consistent.
+    Fix (bool-cast-fix): Copying a Boolean FieldRef.Value into a Text FieldRef.Value stores
+    NavBoolean in the Text field slot. A subsequent (NavText)GetFieldValueSafe(fieldNo,
+    NavType.Text) cast then threw "Unable to cast NavBoolean to NavText". CoerceToExpectedType
+    now converts NavBoolean → NavText ("Yes"/"No") when expectedType is Text.
   tests:
     - tests/bucket-2/101-navtext-to-navcode
+    - tests/bucket-1/100-bool-to-text
 
 # ── File ────────────────────────────────────────────────────────
 

--- a/tests/bucket-1/100-bool-to-text/src/Source.al
+++ b/tests/bucket-1/100-bool-to-text/src/Source.al
@@ -1,0 +1,37 @@
+table 170001 "BTT Bool Table"
+{
+    fields
+    {
+        field(1; Id; Integer) { }
+        field(2; Flag; Boolean) { }
+        field(3; Name; Text[100]) { }
+    }
+    keys { key(PK; Id) { Clustered = true; } }
+}
+
+codeunit 170002 "BTT Bool Helper"
+{
+    /// Copy a Boolean FieldRef.Value into a Text FieldRef.Value, then read the text field.
+    /// The BC transpiler stores the Boolean field via MockRecordRef with NavType.Text, and
+    /// later reads the Text field with (NavText)GetFieldValueSafe(3, NavType.Text).
+    /// If CoerceToExpectedType doesn't convert NavBoolean→NavText the cast throws:
+    ///   "Unable to cast NavBoolean to NavText"
+    procedure CopyBoolFieldRefToTextField(var Rec: Record "BTT Bool Table"): Text[100]
+    var
+        RecRef: RecordRef;
+        FldRefBool: FieldRef;
+        FldRefText: FieldRef;
+    begin
+        RecRef.GetTable(Rec);
+        FldRefBool := RecRef.Field(2);     // Boolean field
+        FldRefText := RecRef.Field(3);     // Text[100] field
+        FldRefText.Value := FldRefBool.Value;   // store bool value in text slot
+        RecRef.SetTable(Rec);
+        exit(Rec.Name);                    // reads text field back as (NavText)GetFieldValueSafe
+    end;
+
+    procedure GetFlagAsText(var Rec: Record "BTT Bool Table"): Text
+    begin
+        exit(Format(Rec.Flag));
+    end;
+}

--- a/tests/bucket-1/100-bool-to-text/test/TestBoolToText.al
+++ b/tests/bucket-1/100-bool-to-text/test/TestBoolToText.al
@@ -1,0 +1,100 @@
+codeunit 170003 "BTT Bool To Text Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    // ---------------------------------------------------------------
+    // Positive: Boolean FieldRef value copied to Text FieldRef, then
+    // the text field is read back with (NavText)GetFieldValueSafe.
+    // Before the fix this threw:
+    //   "Unable to cast NavBoolean to NavText"
+    // ---------------------------------------------------------------
+
+    [Test]
+    procedure CopyBoolFieldRefToTextField_True_ReturnsYes()
+    var
+        Helper: Codeunit "BTT Bool Helper";
+        Rec: Record "BTT Bool Table";
+        Result: Text[100];
+    begin
+        // [GIVEN] A record with Flag = true
+        Rec.Id := 1;
+        Rec.Flag := true;
+
+        // [WHEN] Boolean FieldRef.Value is assigned to a Text FieldRef.Value
+        //        and the text field is read back
+        // Previously crashed: Unable to cast NavBoolean to NavText
+        Result := Helper.CopyBoolFieldRefToTextField(Rec);
+
+        // [THEN] A true Boolean coerced to Text yields "Yes"
+        Assert.AreEqual('Yes', Result, 'CopyBoolToText for true Boolean should yield Yes');
+    end;
+
+    [Test]
+    procedure CopyBoolFieldRefToTextField_False_ReturnsNo()
+    var
+        Helper: Codeunit "BTT Bool Helper";
+        Rec: Record "BTT Bool Table";
+        Result: Text[100];
+    begin
+        // [GIVEN] A record with Flag = false
+        Rec.Id := 2;
+        Rec.Flag := false;
+
+        // [WHEN] Boolean FieldRef.Value is assigned to a Text FieldRef.Value
+        Result := Helper.CopyBoolFieldRefToTextField(Rec);
+
+        // [THEN] A false Boolean coerced to Text yields "No"
+        Assert.AreEqual('No', Result, 'CopyBoolToText for false Boolean should yield No');
+    end;
+
+    // ---------------------------------------------------------------
+    // Negative: must not return empty (proves coercion is real)
+    // ---------------------------------------------------------------
+
+    [Test]
+    procedure CopyBoolFieldRefToTextField_True_IsNotEmpty()
+    var
+        Helper: Codeunit "BTT Bool Helper";
+        Rec: Record "BTT Bool Table";
+        Result: Text[100];
+    begin
+        // [GIVEN] A record with Flag = true
+        Rec.Id := 3;
+        Rec.Flag := true;
+
+        // [WHEN] Boolean → Text FieldRef copy
+        Result := Helper.CopyBoolFieldRefToTextField(Rec);
+
+        // [THEN] Must not be empty — a no-op stub returning '' would fail this
+        Assert.AreNotEqual('', Result, 'Coerced Boolean text field must not be empty');
+    end;
+
+    // ---------------------------------------------------------------
+    // Regression guard: direct field Format still works
+    // ---------------------------------------------------------------
+
+    [Test]
+    procedure BoolFieldDirect_True_FormatsAsYes()
+    var
+        Helper: Codeunit "BTT Bool Helper";
+        Rec: Record "BTT Bool Table";
+    begin
+        Rec.Id := 4;
+        Rec.Flag := true;
+        Assert.AreEqual('Yes', Helper.GetFlagAsText(Rec), 'Format(Rec.Flag) for true should yield Yes');
+    end;
+
+    [Test]
+    procedure BoolFieldDirect_False_FormatsAsNo()
+    var
+        Helper: Codeunit "BTT Bool Helper";
+        Rec: Record "BTT Bool Table";
+    begin
+        Rec.Id := 5;
+        Rec.Flag := false;
+        Assert.AreEqual('No', Helper.GetFlagAsText(Rec), 'Format(Rec.Flag) for false should yield No');
+    end;
+}


### PR DESCRIPTION
## Summary

- **Root cause**: When a Boolean `FieldRef.Value` is assigned to a Text `FieldRef.Value`, `MockRecordRef.SetFieldValue` stores a `NavBoolean` in the text field slot using `NavType.Text`. A subsequent `(NavText)GetFieldValueSafe(fieldNo, NavType.Text)` cast then throws `"Unable to cast NavBoolean to NavText"` at runtime, affecting 37+ tests in real-world projects.
- **Fix**: Extended `CoerceToExpectedType` in `MockRecordHandle` to handle `NavBoolean → NavText` coercion: `true` → `"Yes"`, `false` → `"No"` (AL standard Boolean text representation).
- **Tests**: New suite `tests/bucket-1/100-bool-to-text/` with 5 tests — 3 directly reproduce the crash via `FieldRef` cross-copy (RED before fix, GREEN after), plus 2 regression guards for direct `Format(Rec.Flag)` access.
- **Coverage**: Updated `docs/coverage.yaml` `FieldRef.Value` entry.

## Test plan

- [ ] `tests/bucket-1/100-bool-to-text/` — 5 tests all pass (3 proved the crash, 2 are regression guards)
- [ ] Bucket-1: 1596 pass, 2 pre-existing failures (`DT2Time_*`) — no new regressions
- [ ] Bucket-2 (excluding pre-existing `130-cross-ext-al0275` structural issue): 1604 pass, 3 pre-existing failures — no new regressions