### PR TITLE
fix: pre-seed User table + tolerate duplicate-PK errors in init events

### DIFF
--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -2317,6 +2317,31 @@ public static class Executor
         }
     }
 
+    /// <summary>
+    /// Fire an init-lifecycle event, silently swallowing "record already exists"
+    /// errors from subscribers.
+    ///
+    /// Why: the runner fires both codeunit-2 and codeunit-27 OnCompanyInitialize
+    /// events in a single init cycle. Real-world extension subscribers sometimes
+    /// unconditionally call Record.Insert() without a prior Get/FindFirst guard.
+    /// When the same subscriber (or two subscribers inserting the same PK) fires
+    /// more than once per init cycle, the second Insert() raises "already exists".
+    /// Aborting the entire test run for that would be too harsh — BC itself ignores
+    /// double-init scenarios. We swallow duplicate-PK errors during init firing only.
+    /// </summary>
+    private static void FireInitEvent(int publisherId, string eventName)
+    {
+        try
+        {
+            AlRunner.Runtime.AlCompat.FireEvent(publisherId, eventName);
+        }
+        catch (Exception ex) when (ex.Message.Contains("already exists"))
+        {
+            // Duplicate-PK from an always-insert subscriber — harmless during init.
+            // The first insert succeeded; swallow the rest.
+        }
+    }
+
     public static List<AlRunner.TestResult> RunTests(Assembly assembly, bool captureValues = false, string? runProcedure = null, bool initEvents = false, AlRunner.TestIsolation testIsolation = AlRunner.TestIsolation.Codeunit)
     {
         // Find test methods using [NavTest] attribute on the parent method,
@@ -2405,6 +2430,10 @@ public static class Executor
                 AlRunner.Runtime.MockIsolatedStorage.ResetAll();
                 AlRunner.Runtime.MockVariableStorage.Reset();
 
+                // Pre-seed system tables (e.g. User table 2000000120) so that common
+                // AL patterns like User.Get(UserSecurityId()) work out of the box.
+                AlRunner.Runtime.MockRecordHandle.SeedSystemTables();
+
                 // Fire lifecycle integration events ONCE per codeunit reset when --init-events is set.
                 // This seeds company-initialization data so subscribers' setup data is present
                 // for all tests in the codeunit, matching BC's behaviour where company data
@@ -2416,10 +2445,10 @@ public static class Executor
                 //   OnCompanyInitialize     → publisher 2 or 27 (differs across BC versions)
                 if (initEvents)
                 {
-                    AlRunner.Runtime.AlCompat.FireEvent(2000000010, "OnInstallAppPerDatabase");
-                    AlRunner.Runtime.AlCompat.FireEvent(2000000010, "OnInstallAppPerCompany");
-                    AlRunner.Runtime.AlCompat.FireEvent(2, "OnCompanyInitialize");
-                    AlRunner.Runtime.AlCompat.FireEvent(27, "OnCompanyInitialize");
+                    FireInitEvent(2000000010, "OnInstallAppPerDatabase");
+                    FireInitEvent(2000000010, "OnInstallAppPerCompany");
+                    FireInitEvent(2, "OnCompanyInitialize");
+                    FireInitEvent(27, "OnCompanyInitialize");
                 }
 
                 currentCodeunitType = parentType;

--- a/AlRunner/Runtime/MockRecordHandle.cs
+++ b/AlRunner/Runtime/MockRecordHandle.cs
@@ -78,6 +78,53 @@ public class MockRecordHandle
         // Keep PK and field name registrations — they are structural, not data
     }
 
+    // ── System table IDs ────────────────────────────────────────────────────
+    private const int UserTableId = 2000000120;
+
+    // User table field numbers (BC standard)
+    private const int UserSecurityIdFieldNo = 1;
+    private const int UserNameFieldNo       = 2;
+
+    /// <summary>
+    /// Pre-seed system tables required by common AL patterns.
+    /// Called after every table reset so the standard runner user is always present.
+    ///
+    /// Currently seeded:
+    ///   Table 2000000120 "User" — one row for the configured user so that
+    ///   <c>User.Get(UserSecurityId())</c> succeeds without a "record not found" error.
+    /// </summary>
+    public static void SeedSystemTables()
+    {
+        // Ensure the User table PK is registered on field 1 (User Security ID).
+        if (!_primaryKeys.ContainsKey(UserTableId))
+            _primaryKeys[UserTableId] = new[] { UserSecurityIdFieldNo };
+
+        // Ensure the table bucket exists.
+        if (!_tables.ContainsKey(UserTableId))
+            _tables[UserTableId] = new List<Dictionary<int, NavValue>>();
+
+        var userTable = _tables[UserTableId];
+
+        // Seed exactly one row — idempotent so multiple calls are harmless.
+        var secId = AlCompat.UserSecurityId();            // stable GUID 22222222-…
+        var userName = AlScope.UserId;                    // default "TESTUSER"
+
+        // Skip if already seeded (e.g. when called more than once without ResetAll).
+        foreach (var row in userTable)
+        {
+            if (row.TryGetValue(UserSecurityIdFieldNo, out var existing) &&
+                existing is NavGuid existingGuid &&
+                existingGuid.ToGuid() == secId)
+                return;
+        }
+
+        userTable.Add(new Dictionary<int, NavValue>
+        {
+            [UserSecurityIdFieldNo] = new NavGuid(secId),
+            [UserNameFieldNo]       = new NavCode(50, userName.ToUpperInvariant()),
+        });
+    }
+
     /// <summary>
     /// Register the primary key field numbers for a table.
     /// Call this before inserting/getting records for tables with composite PKs.

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -11055,3 +11055,36 @@ Codeunit.InitEventsPublisherIDs:
     in codeunit mode, per method in method mode).
   tests:
     - tests/init-events/40-init-events
+
+Executor.UserTableSeed:
+  layer: runtime-api
+  category: executor
+  status: covered
+  notes: >
+    The runner pre-seeds the User system table (2000000120) after every table reset.
+    One row is inserted with "User Security ID" = the stable AlCompat.UserSecurityId()
+    GUID (22222222-2222-2222-2222-222222222222) and "User Name" = AlScope.UserId
+    (default "TESTUSER", configurable via --user-id). This allows AL code that calls
+    User.Get(UserSecurityId()) to succeed without a "record not found" error.
+    The seeding is idempotent — multiple calls without an intervening ResetAll() are
+    safe. Tests that need a custom User record can Insert() additional rows or modify
+    the seeded row.
+  tests:
+    - tests/bucket-2/227-user-table-seed
+
+Executor.InitEventsIdempotent:
+  layer: runtime-api
+  category: executor
+  status: covered
+  notes: >
+    The runner's init-event firing (--init-events) now silently swallows
+    "record already exists" errors thrown by subscribers. Real-world extension
+    subscribers sometimes unconditionally call Record.Insert() without a prior
+    Get/FindFirst guard. Because the runner fires both codeunit-2 and codeunit-27
+    OnCompanyInitialize events in a single init cycle, a subscriber registered for
+    both (or two subscribers inserting the same primary key) would throw on the
+    second Insert(). The fix wraps each FireEvent call during init-event firing in
+    a try/catch that discards duplicate-PK errors; all other exceptions still
+    propagate normally.
+  tests:
+    - tests/init-events/41-init-events-idempotent

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -10999,7 +10999,7 @@ Codeunit.InitEvents:
   tests:
     - tests/init-events/40-init-events
 
-implicit_db_event_byref_params:
+Table.ImplicitDbEventByRefParams:
   layer: runtime-api
   category: table
   status: covered

--- a/tests/bucket-2/227-user-table-seed/src/UserTableStub.al
+++ b/tests/bucket-2/227-user-table-seed/src/UserTableStub.al
@@ -1,0 +1,18 @@
+/// Minimal stub for the BC system User table (ID 2000000120).
+/// The runner pre-seeds this table with the configured user so that
+/// AL code calling User.Get(UserSecurityId()) succeeds without errors.
+table 2000000120 "User"
+{
+    DataClassification = EndUserIdentifiableInformation;
+    fields
+    {
+        field(1; "User Security ID"; Guid) { }
+        field(2; "User Name"; Code[50]) { }
+        field(3; "Full Name"; Text[80]) { }
+    }
+    keys
+    {
+        key(PK; "User Security ID") { Clustered = true; }
+        key(UserName; "User Name") { }
+    }
+}

--- a/tests/bucket-2/227-user-table-seed/test/UserTableSeedTest.al
+++ b/tests/bucket-2/227-user-table-seed/test/UserTableSeedTest.al
@@ -1,0 +1,59 @@
+/// Tests that the runner pre-seeds the User system table (2000000120)
+/// with a record matching the configured user, so AL code that calls
+/// User.Get(UserSecurityId()) succeeds without "record not found" errors.
+codeunit 227001 "User Table Seed Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    /// Positive: User.Get(UserSecurityId()) must succeed — the runner must
+    /// have pre-seeded the User table so the current user's record exists.
+    [Test]
+    procedure UserGet_BySecurityId_Succeeds()
+    var
+        User: Record User;
+    begin
+        // [GIVEN] The runner pre-seeds the User table before each test
+        // [WHEN]  User.Get is called with the current UserSecurityId
+        // [THEN]  The record is found — no "record not found" error
+        Assert.IsTrue(User.Get(UserSecurityId()), 'User.Get(UserSecurityId()) must succeed in al-runner');
+    end;
+
+    /// Positive: the seeded User record must carry the correct "User Name"
+    /// matching UserId() — proves the seeded row is not an empty stub.
+    [Test]
+    procedure UserGet_BySecurityId_HasCorrectUserName()
+    var
+        User: Record User;
+    begin
+        // [GIVEN] Runner has pre-seeded the User table
+        // [WHEN]  The record is retrieved by UserSecurityId
+        User.Get(UserSecurityId());
+        // [THEN]  "User Name" matches the configured UserId() value
+        Assert.AreEqual(UserId(), User."User Name", 'Seeded User record must have User Name = UserId()');
+    end;
+
+    /// Positive: User table contains exactly one row — not empty, not duplicated.
+    [Test]
+    procedure UserTable_ContainsExactlyOneRow()
+    var
+        User: Record User;
+    begin
+        Assert.AreEqual(1, User.Count(), 'User table must contain exactly one pre-seeded row');
+    end;
+
+    /// Negative: looking up a non-existent security ID must return false (not crash).
+    [Test]
+    procedure UserGet_UnknownGuid_ReturnsFalse()
+    var
+        User: Record User;
+        UnknownGuid: Guid;
+    begin
+        // [GIVEN] A GUID that was never inserted
+        Evaluate(UnknownGuid, '{FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF}');
+        // [WHEN/THEN] Get returns false — no exception, no "record not found" crash
+        Assert.IsFalse(User.Get(UnknownGuid), 'Get on unknown GUID must return false, not throw');
+    end;
+}

--- a/tests/init-events/41-init-events-idempotent/src/IdempotentSubscriberSrc.al
+++ b/tests/init-events/41-init-events-idempotent/src/IdempotentSubscriberSrc.al
@@ -1,0 +1,45 @@
+/// Table written to by the always-insert subscriber.
+/// Has a single integer PK so a second Insert() on the same ID
+/// would throw "record already exists" without a guard.
+table 57200 "Idempotent Sentinel"
+{
+    DataClassification = CustomerContent;
+    fields
+    {
+        field(1; Id; Integer) { }
+    }
+    keys { key(PK; Id) { Clustered = true; } }
+}
+
+/// Subscriber that ALWAYS calls Insert() without a Get-check guard.
+/// This mimics real-world extensions where the developer forgot to check
+/// for an existing record before inserting.
+///
+/// The runner fires both codeunit-2 and codeunit-27 OnCompanyInitialize
+/// events in the same init cycle. If the subscriber fires on BOTH, the
+/// second Insert() throws "The Idempotent Sentinel already exists."
+/// The runner must catch and swallow that error so tests still run.
+codeunit 57200 "Always-Insert Subscriber"
+{
+    [EventSubscriber(ObjectType::Codeunit, 2, 'OnCompanyInitialize', '', false, false)]
+    local procedure OnCompanyInit_CU2()
+    var
+        Sentinel: Record "Idempotent Sentinel";
+    begin
+        // Unconditional Insert — no exists-check.
+        // The runner must not let a duplicate-PK error abort init-event firing.
+        Sentinel.Id := 1;
+        Sentinel.Insert();
+    end;
+
+    [EventSubscriber(ObjectType::Codeunit, 27, 'OnCompanyInitialize', '', false, false)]
+    local procedure OnCompanyInit_CU27()
+    var
+        Sentinel: Record "Idempotent Sentinel";
+    begin
+        // Second unconditional Insert on the same PK — triggers "already exists"
+        // if the runner does not catch subscriber errors during init firing.
+        Sentinel.Id := 1;
+        Sentinel.Insert();
+    end;
+}

--- a/tests/init-events/41-init-events-idempotent/test/IdempotentInitTest.al
+++ b/tests/init-events/41-init-events-idempotent/test/IdempotentInitTest.al
@@ -1,0 +1,46 @@
+/// Tests that --init-events tolerates subscribers that unconditionally insert
+/// records without an existence-check guard.
+///
+/// Real extensions often have subscribers like:
+///   Rec.Id := 1;
+///   Rec.Insert();   // no Get/FindFirst guard
+///
+/// The runner fires both codeunit-2 and codeunit-27 OnCompanyInitialize events
+/// in a single init cycle. If the same subscriber registers for both, the second
+/// Insert() throws "record already exists". The runner must swallow that error
+/// and let all tests execute normally.
+codeunit 57201 "Init Events Idempotent Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    /// Positive: tests run at all — the "always Insert" subscriber must not abort
+    /// the init-event firing and leave tests unable to execute.
+    [Test]
+    procedure AlwaysInsertSubscriber_DoesNotAbortTestRun()
+    var
+        Sentinel: Record "Idempotent Sentinel";
+    begin
+        // [GIVEN]  --init-events is active; the "Always-Insert Subscriber" fires
+        //          once for CU-2 and once for CU-27 OnCompanyInitialize.
+        // [WHEN]   This test method executes (proves init-events did not crash)
+        // [THEN]   At least one insert succeeded — Sentinel row 1 exists
+        Assert.IsTrue(Sentinel.Get(1), '--init-events: sentinel row must exist after init-event firing');
+    end;
+
+    /// Positive: even when a duplicate-PK error is swallowed, the test table
+    /// is usable — subsequent Get/Insert/Modify in the test work normally.
+    [Test]
+    procedure TableIsUsableAfterInitEvents_SubscriberError()
+    var
+        Sentinel: Record "Idempotent Sentinel";
+    begin
+        // [GIVEN]  Init event fired (possibly with a swallowed insert error)
+        // [WHEN]   This test reads and then modifies the seeded record
+        // [THEN]   The table and its data are intact
+        Assert.IsTrue(Sentinel.Get(1), 'Sentinel row must be readable after init-events');
+        Assert.AreEqual(1, Sentinel.Count(), 'Table must have exactly one row after init-events');
+    end;
+}


### PR DESCRIPTION
## Summary

- **Fix 1 — User table seeding**: Pre-seeds the User system table (2000000120) after every table reset with a row for the configured runner user. This lets AL code calling `User.Get(UserSecurityId())` succeed without a "record not found" error. The row carries `AlCompat.UserSecurityId()` (stable GUID `22222222-…`) as the PK and `AlScope.UserId` (`"TESTUSER"` by default) as `"User Name"`. Seeding is idempotent.

- **Fix 2 — Init-events duplicate-PK tolerance**: Wraps each `--init-events` `FireEvent` call in a `try/catch` that silently discards `"record already exists"` errors. The runner fires both codeunit-2 and codeunit-27 `OnCompanyInitialize` in a single init cycle; real-world extension subscribers that unconditionally call `Insert()` (no `Get` guard) throw on the second fire. Only init-event subscriber errors are swallowed — test-body errors still propagate normally.

## Test plan

- [ ] `tests/bucket-2/227-user-table-seed` — 4 AL tests: `UserGet_BySecurityId_Succeeds`, `UserGet_BySecurityId_HasCorrectUserName`, `UserTable_ContainsExactlyOneRow`, `UserGet_UnknownGuid_ReturnsFalse`
- [ ] `tests/init-events/41-init-events-idempotent` — 2 AL tests: `AlwaysInsertSubscriber_DoesNotAbortTestRun`, `TableIsUsableAfterInitEvents_SubscriberError`
- [ ] Bucket-1 and bucket-2 pass with `--test-isolation method --strict` (only pre-existing DT2Time/CreateDateTime timezone failures remain)
- [ ] Init-events suite (40 + 41) passes with `--init-events`
- [ ] Stubs test passes
- [ ] `docs/coverage.yaml` updated with `Executor.UserTableSeed` and `Executor.InitEventsIdempotent`