### PR TITLE
fix: initialize null backing fields after GetUninitializedObject in event/trigger dispatch

### DIFF
--- a/AlRunner/Runtime/AlScope.cs
+++ b/AlRunner/Runtime/AlScope.cs
@@ -719,9 +719,7 @@ public static class AlCompat
             try
             {
                 instance = System.Runtime.CompilerServices.RuntimeHelpers.GetUninitializedObject(ownerType);
-                var initMethod = ownerType.GetMethod("InitializeComponent",
-                    System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance);
-                initMethod?.Invoke(instance, null);
+                AlCompat.InitializeUninitializedObject(instance);
             }
             catch { continue; }
 
@@ -2722,6 +2720,67 @@ public static class AlCompat
     public static NavALErrorInfo CreateErrorInfo()
     {
         return new NavALErrorInfo();
+    }
+
+    /// <summary>
+    /// After <c>RuntimeHelpers.GetUninitializedObject</c>, call
+    /// <c>InitializeComponent</c> (and <c>InitializeGlobalVariables</c> if present)
+    /// on the instance to run field initializers that the constructor would have run.
+    /// Then, for any remaining reference-type backing fields that are still null,
+    /// initialize them to safe defaults:
+    /// <list type="bullet">
+    ///   <item><description><see cref="MockRecordHandle"/> — <c>new MockRecordHandle(0)</c></description></item>
+    ///   <item><description>Any other type with a public parameterless constructor — <c>Activator.CreateInstance</c></description></item>
+    /// </list>
+    /// This prevents <see cref="NullReferenceException"/> in event subscriber and
+    /// record trigger bodies when the generated class has global variable backing
+    /// fields that are not covered by the explicit Rec/xRec wiring in
+    /// <see cref="MockRecordHandle.TryFireRecordTrigger"/> or the
+    /// <c>InitializeComponent</c> call in <see cref="FireEvent"/>.
+    /// </summary>
+    /// <param name="instance">Object created via <c>GetUninitializedObject</c>.</param>
+    public static void InitializeUninitializedObject(object instance)
+    {
+        var type = instance.GetType();
+
+        // 1. Run InitializeComponent (sets fields with initializer expressions).
+        var initMethod = type.GetMethod("InitializeComponent",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Public |
+            System.Reflection.BindingFlags.Instance);
+        try { initMethod?.Invoke(instance, null); } catch { /* swallow — better a default than a crash */ }
+
+        // 2. Run InitializeGlobalVariables if present (some generated classes use this wrapper).
+        var initGlobals = type.GetMethod("InitializeGlobalVariables",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Public |
+            System.Reflection.BindingFlags.Instance);
+        if (initGlobals != null && initGlobals != initMethod)
+            try { initGlobals.Invoke(instance, null); } catch { /* swallow */ }
+
+        // 3. Walk all instance fields; default-initialize any reference-type field still null.
+        foreach (var field in type.GetFields(
+            System.Reflection.BindingFlags.Instance |
+            System.Reflection.BindingFlags.Public |
+            System.Reflection.BindingFlags.NonPublic))
+        {
+            if (field.FieldType.IsValueType) continue;
+            if (field.GetValue(instance) != null) continue;
+
+            // MockRecordHandle — safe default with table 0.
+            if (field.FieldType == typeof(MockRecordHandle))
+            {
+                field.SetValue(instance, new MockRecordHandle(0));
+                continue;
+            }
+
+            // Other reference types — try a parameterless constructor.
+            try
+            {
+                var ctor = field.FieldType.GetConstructor(System.Type.EmptyTypes);
+                if (ctor != null)
+                    field.SetValue(instance, ctor.Invoke(null));
+            }
+            catch { /* swallow — better null than crash-on-construction */ }
+        }
     }
 
 }

--- a/AlRunner/Runtime/MockRecordHandle.cs
+++ b/AlRunner/Runtime/MockRecordHandle.cs
@@ -491,6 +491,11 @@ public class MockRecordHandle
         try { instance = System.Runtime.CompilerServices.RuntimeHelpers.GetUninitializedObject(recordType); }
         catch { return; }
 
+        // Initialize null fields (global table variables, etc.) before wiring Rec/xRec,
+        // so that any MockRecordHandle fields created by InitializeComponent are in place
+        // and the explicit Rec/xRec assignments below can override them with this handle.
+        AlCompat.InitializeUninitializedObject(instance);
+
         var recBackingField = recordType.GetField("<Rec>k__BackingField",
             System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
         if (recBackingField != null && recBackingField.FieldType.IsInstanceOfType(this))

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -11088,3 +11088,22 @@ Executor.InitEventsIdempotent:
     propagate normally.
   tests:
     - tests/init-events/41-init-events-idempotent
+
+AlCompat.InitializeUninitializedObject:
+  layer: runtime-api
+  category: event-subscriber
+  status: covered
+  notes: >
+    GetUninitializedObject skips constructors, leaving backing fields for AL global
+    variables null. Both FireEvent (event subscriber dispatch) and TryFireRecordTrigger
+    (record trigger firing) call GetUninitializedObject to create fresh instances.
+    The shared helper InitializeUninitializedObject: (1) calls InitializeComponent and
+    InitializeGlobalVariables via reflection so field initializers run, then (2) walks
+    all instance fields and default-initializes any remaining null reference-type field
+    (MockRecordHandle -> new MockRecordHandle(0); other types via parameterless ctor).
+    This prevents NullReferenceException when trigger/subscriber bodies access table
+    global variables (var section on a table object) or codeunit global variables that
+    are not covered by InitializeComponent. FireEvent already called InitializeComponent;
+    TryFireRecordTrigger previously did not — the fix adds the call there too.
+  tests:
+    - tests/bucket-2/100-uninit-field-fix

--- a/tests/bucket-2/100-uninit-field-fix/src/UninitFieldSrc.al
+++ b/tests/bucket-2/100-uninit-field-fix/src/UninitFieldSrc.al
@@ -1,0 +1,61 @@
+/// Table with global var section and OnInsert trigger that uses the global.
+/// Variables declared in the table's global var section become backing fields
+/// on the generated Record class alongside Rec and xRec. When TryFireRecordTrigger
+/// calls GetUninitializedObject, only Rec/xRec are explicitly set — the global
+/// Helper field is null. The trigger body accesses Helper.PK which causes NullRef.
+table 100001 "UIF Source"
+{
+    fields
+    {
+        field(1; PK; Integer) { }
+        field(2; TriggerRan; Boolean) { }
+        field(3; SubscriberRan; Boolean) { }
+        field(4; EventFieldValue; Integer) { }
+    }
+    keys { key(PK; PK) { Clustered = true; } }
+
+    var
+        // This global variable compiles to a backing field on Record100001.
+        // TryFireRecordTrigger sets <Rec>k__BackingField and <xRec>k__BackingField
+        // but NOT <Helper>k__BackingField. Without the fix, Helper is null and
+        // accessing Helper.PK inside the trigger throws NullReferenceException.
+        Helper: Record "UIF Source";
+
+    trigger OnInsert()
+    begin
+        // Access the table-global variable — null without the fix.
+        Rec.TriggerRan := (Helper.PK = 0);
+    end;
+}
+
+/// Counter table used by the event subscriber.
+table 100002 "UIF Counter"
+{
+    fields
+    {
+        field(1; PK; Integer) { }
+        field(2; Hits; Integer) { }
+    }
+    keys { key(PK; PK) { Clustered = true; } }
+}
+
+/// Codeunit with a codeunit-level global Record variable AND an event subscriber.
+/// InitializeComponent initializes GlobalCounter, so this case already works.
+/// This test proves it continues to work after the fix is applied.
+codeunit 100001 "UIF Subscriber"
+{
+    var
+        GlobalCounter: Record "UIF Counter";
+
+    [EventSubscriber(ObjectType::Table, Database::"UIF Source", OnBeforeInsertEvent, '', true, true)]
+    local procedure OnBeforeInsert(var Rec: Record "UIF Source"; RunTrigger: Boolean)
+    begin
+        // GlobalCounter is initialized by InitializeComponent — must not be null.
+        if GlobalCounter.Get(999) then
+            Rec.EventFieldValue := GlobalCounter.Hits
+        else begin
+            Rec.SubscriberRan := true;
+            Rec.EventFieldValue := 42;
+        end;
+    end;
+}

--- a/tests/bucket-2/100-uninit-field-fix/test/UninitFieldTest.al
+++ b/tests/bucket-2/100-uninit-field-fix/test/UninitFieldTest.al
@@ -1,0 +1,57 @@
+/// Tests that GetUninitializedObject instances used for event subscriber dispatch
+/// and record trigger firing have their null reference-type fields initialized,
+/// preventing NullReferenceException in subscriber/trigger bodies.
+codeunit 100002 "UIF Tests"
+{
+    Subtype = Test;
+    var
+        Assert: Codeunit Assert;
+
+    [Test]
+    procedure OnInsertTrigger_SetsFlag_AfterInsert()
+    var
+        Src: Record "UIF Source";
+    begin
+        // Positive: the OnInsert trigger sets TriggerRan = true and calls Modify.
+        // If GetUninitializedObject fields are not initialized this crashes with NullRef.
+        Src.PK := 1;
+        Src.Insert(true);  // runTrigger=true
+
+        // TriggerRan is set on Rec inside the trigger body (before Insert completes),
+        // but Rec in the trigger IS this record — the in-memory store keeps the mutated state.
+        // After Insert, re-fetch to verify the trigger executed without crashing.
+        Src.Get(1);
+        Assert.IsTrue(Src.TriggerRan, 'OnInsert trigger must have set TriggerRan to true on Rec');
+    end;
+
+    [Test]
+    procedure OnBeforeInsertEvent_SubscriberSetsFields()
+    var
+        Src: Record "UIF Source";
+    begin
+        // Positive: the automatic event subscriber on OnBeforeInsertEvent sets
+        // SubscriberRan = true and EventFieldValue = 42 on the Rec parameter.
+        // If FireEvent creates the subscriber instance via GetUninitializedObject without
+        // initializing null fields, accessing a Record local variable inside the
+        // subscriber crashes with NullRef.
+        Src.PK := 2;
+        Src.Insert();
+
+        Src.Get(2);
+        Assert.IsTrue(Src.SubscriberRan, 'OnBeforeInsertEvent subscriber must have set SubscriberRan');
+        Assert.AreEqual(42, Src.EventFieldValue, 'OnBeforeInsertEvent subscriber must have set EventFieldValue to 42');
+    end;
+
+    [Test]
+    procedure OnInsertTrigger_WithoutRunTrigger_DoesNotSetFlag()
+    var
+        Src: Record "UIF Source";
+    begin
+        // Negative: Insert without runTrigger=true must NOT fire the AL trigger.
+        Src.PK := 3;
+        Src.Insert(false);  // runTrigger=false
+
+        Src.Get(3);
+        Assert.IsFalse(Src.TriggerRan, 'OnInsert trigger must NOT fire when runTrigger=false');
+    end;
+}


### PR DESCRIPTION
## Summary

- `GetUninitializedObject` skips constructors, leaving AL global variable backing fields null in event subscriber and record trigger dispatch instances
- Table `var` section globals (compile to backing fields on the generated `RecordN` class) were not initialized by `TryFireRecordTrigger`, causing `NullReferenceException` at line 521 when trigger bodies accessed them
- Adds `AlCompat.InitializeUninitializedObject(instance)` — a shared helper that runs `InitializeComponent`/`InitializeGlobalVariables` via reflection, then default-initializes any remaining null reference-type fields (`MockRecordHandle` → `new MockRecordHandle(0)`; others via parameterless ctor)
- `FireEvent` (AlScope.cs) updated to use the new shared helper (replaces the previous manual `InitializeComponent` call)
- `TryFireRecordTrigger` (MockRecordHandle.cs) now calls the helper before wiring `Rec`/`xRec` backing fields

## Test plan

- [x] RED: `OnInsertTrigger_SetsFlag_AfterInsert` fails with `NullReferenceException` at `MockRecordHandle.cs:521` — table global `var Helper: Record ...` is null without the fix
- [x] GREEN: All 3 tests in `tests/bucket-2/100-uninit-field-fix` pass after the fix
- [x] Full bucket-2: 1616 passed, 3 failed (pre-existing timezone failures in `140-create-datetime`), 1 blocked — no regressions
- [x] `docs/coverage.yaml` updated with `AlCompat.InitializeUninitializedObject` entry