### PR TITLE
fix: InitializeUninitializedObject in OnValidate and record method dispatch

### DIFF
--- a/AlRunner/Runtime/MockRecordHandle.cs
+++ b/AlRunner/Runtime/MockRecordHandle.cs
@@ -1183,8 +1183,9 @@ public class MockRecordHandle
             // FieldTriggerType.OnValidate == 0
             if (triggerType?.ToString() == "OnValidate" && triggerFieldNo is int fno && fno == fieldNo)
             {
-                // Create instance and wire Rec to this MockRecordHandle
+                // Create instance, initialize null fields, and wire Rec to this MockRecordHandle
                 var instance = System.Runtime.CompilerServices.RuntimeHelpers.GetUninitializedObject(type);
+                AlCompat.InitializeUninitializedObject(instance);
                 var backingField = type.GetField("<Rec>k__BackingField",
                     System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
                 backingField?.SetValue(instance, this);
@@ -3248,6 +3249,7 @@ public class MockRecordHandle
                 if (method == null) continue;
 
                 var instance = System.Runtime.CompilerServices.RuntimeHelpers.GetUninitializedObject(recordType);
+                AlCompat.InitializeUninitializedObject(instance);
                 // Wire the Rec property to point to this MockRecordHandle instance.
                 // The generated Record class has: public MockRecordHandle Rec { get; } = new MockRecordHandle(tableId);
                 // Since GetUninitializedObject doesn't run initializers, Rec is null.

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -11107,3 +11107,4 @@ AlCompat.InitializeUninitializedObject:
     TryFireRecordTrigger previously did not — the fix adds the call there too.
   tests:
     - tests/bucket-2/100-uninit-field-fix
+    - tests/bucket-2/101-validate-uninit

--- a/tests/bucket-2/101-validate-uninit/src/ValidateUninitSrc.al
+++ b/tests/bucket-2/101-validate-uninit/src/ValidateUninitSrc.al
@@ -1,0 +1,54 @@
+/// Table with a global var section and an OnValidate trigger on a field.
+/// The OnValidate trigger reads a global Record variable. When
+/// TryFireOnValidateInType calls GetUninitializedObject, the global
+/// var's backing field is null unless InitializeUninitializedObject is called.
+table 100003 "Validate Uninit Table"
+{
+    DataClassification = CustomerContent;
+
+    fields
+    {
+        field(1; PK; Code[20]) { }
+        field(2; "Rate Code"; Code[10])
+        {
+            trigger OnValidate()
+            var
+                Position: Integer;
+            begin
+                // Access a global Record variable — this forces the runtime
+                // to resolve the backing field created by the var section.
+                // Without proper initialization after GetUninitializedObject,
+                // accessing Helper.PK would throw NullReferenceException.
+                Position := Helper.PK;
+                if "Rate Code" = 'SPECIAL' then
+                    Position := 99;
+                Rec."Mapped Position" := Position;
+            end;
+        }
+        field(3; "Mapped Position"; Integer) { }
+    }
+
+    keys
+    {
+        key(PK; PK) { Clustered = true; }
+    }
+
+    var
+        Helper: Record "Validate Helper Table";
+}
+
+table 100004 "Validate Helper Table"
+{
+    DataClassification = CustomerContent;
+
+    fields
+    {
+        field(1; PK; Integer) { }
+        field(2; "Helper Value"; Text[50]) { }
+    }
+
+    keys
+    {
+        key(PK; PK) { Clustered = true; }
+    }
+}

--- a/tests/bucket-2/101-validate-uninit/test/ValidateUninitTest.al
+++ b/tests/bucket-2/101-validate-uninit/test/ValidateUninitTest.al
@@ -1,0 +1,41 @@
+codeunit 100005 "Validate Uninit Test"
+{
+    Subtype = Test;
+
+    [Test]
+    procedure OnValidate_WithGlobalVar_DoesNotCrash()
+    var
+        Rec: Record "Validate Uninit Table";
+        Assert: Codeunit "Library Assert";
+    begin
+        // [GIVEN] A record in the table
+        Rec.PK := 'TEST';
+        Rec.Insert(false);
+
+        // [WHEN] Validate a field on a table that has a global var section
+        // This triggers TryFireOnValidateInType which uses GetUninitializedObject.
+        // Without InitializeUninitializedObject, the global Helper field is null
+        // and accessing Helper.PK throws NullReferenceException.
+        Rec.Validate("Rate Code", 'ABC');
+
+        // [THEN] No crash, and the trigger body ran (Position defaulted to 0)
+        Assert.AreEqual(0, Rec."Mapped Position", 'Default position should be 0 from uninitialized Helper.PK');
+    end;
+
+    [Test]
+    procedure OnValidate_SpecialCode_SetsPosition99()
+    var
+        Rec: Record "Validate Uninit Table";
+        Assert: Codeunit "Library Assert";
+    begin
+        // [GIVEN] A record
+        Rec.PK := 'TEST2';
+        Rec.Insert(false);
+
+        // [WHEN] Validate with special code
+        Rec.Validate("Rate Code", 'SPECIAL');
+
+        // [THEN] Trigger sets position to 99
+        Assert.AreEqual(99, Rec."Mapped Position", 'SPECIAL code should set position to 99');
+    end;
+}


### PR DESCRIPTION
## Summary
- Add `AlCompat.InitializeUninitializedObject()` calls to two more `GetUninitializedObject` sites in MockRecordHandle that were missed in #1131
- `TryFireOnValidateInType` — OnValidate triggers on tables with global var sections would NullRef
- Record method dispatch (end of `Invoke`) — same issue for record methods

Found via ksef project (5 of 6 failures were this exact NullRef pattern).

## Test plan
- [x] RED: test fails without fix (NullRef in `TryFireOnValidateInType`)
- [x] GREEN: test passes with fix
- [x] Bucket-2 regression: 1616 passed, 3 failed (pre-existing timezone), 0 new failures