### PR TITLE
fix: route codeunit 130002 (real BC Library Assert ID) to MockAssert

### DIFF
--- a/AlRunner/Runtime/MockCodeunitHandle.cs
+++ b/AlRunner/Runtime/MockCodeunitHandle.cs
@@ -147,8 +147,8 @@ public class MockCodeunitHandle
     /// </summary>
     public object? Invoke(int memberId, object[] args)
     {
-        // Route codeunit 130 ("Library Assert"), 131 ("Assert" alias stub), and 130000 (Assert from BC test toolkit) to MockAssert
-        if (_codeunitId is 130 or 131 or 130000)
+        // Route codeunit 130 ("Library Assert"), 131 ("Assert" alias stub), 130000 (Assert from BC test toolkit), and 130002 (real BC "Library Assert" ID) to MockAssert
+        if (_codeunitId is 130 or 131 or 130000 or 130002)
             return InvokeAssert(memberId, args);
 
         // Route codeunit 131004 (Library - Variable Storage) to MockVariableStorage

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -11125,3 +11125,15 @@ AlCompat.InitializeUninitializedObject:
   tests:
     - tests/bucket-2/100-uninit-field-fix
     - tests/bucket-2/101-validate-uninit
+
+MockCodeunitHandle.InvokeAssert130002:
+  layer: runtime-api
+  category: test-toolkit
+  status: covered
+  notes: >
+    Route codeunit 130002 (the real BC "Library Assert" ID) to MockAssert,
+    matching the existing routing for IDs 130, 131, and 130000. External
+    projects compiled against BC's real test toolkit reference 130002 rather
+    than the runner's built-in stub ID 130.
+  tests:
+    - tests/bucket-2/103-assert-130002

--- a/tests/bucket-2/103-assert-130002/src/Assert130002.al
+++ b/tests/bucket-2/103-assert-130002/src/Assert130002.al
@@ -1,0 +1,18 @@
+// Codeunit 130002 is the real BC "Library Assert" ID.
+// The runner's built-in stub uses 130. This codeunit verifies
+// that calls to 130002 are routed to MockAssert just like 130.
+codeunit 130002 "Library Assert 130002"
+{
+    procedure AreEqual(Expected: Variant; Actual: Variant; Msg: Text)
+    begin
+        // Placeholder — the runner routes this to MockAssert at runtime
+    end;
+
+    procedure IsTrue(Condition: Boolean; Msg: Text)
+    begin
+    end;
+
+    procedure IsFalse(Condition: Boolean; Msg: Text)
+    begin
+    end;
+}

--- a/tests/bucket-2/103-assert-130002/test/Assert130002Test.al
+++ b/tests/bucket-2/103-assert-130002/test/Assert130002Test.al
@@ -1,0 +1,32 @@
+codeunit 100006 "Assert 130002 Test"
+{
+    Subtype = Test;
+
+    [Test]
+    procedure AreEqual_ViaCodeunit130002_RoutesToMockAssert()
+    var
+        Assert130002: Codeunit "Library Assert 130002";
+        Assert: Codeunit "Library Assert";
+    begin
+        // [GIVEN] Codeunit 130002 ("Library Assert" real BC ID)
+        // [WHEN] Call AreEqual via the 130002 codeunit with matching values
+        // [THEN] It routes to MockAssert and passes (proving the routing works)
+        Assert130002.AreEqual(42, 42, 'AreEqual via codeunit 130002 should route to MockAssert');
+
+        // Also verify a non-default value to prove it's not a no-op
+        Assert130002.AreEqual('hello', 'hello', 'String comparison should also work via 130002');
+    end;
+
+    [Test]
+    procedure AreEqual_ViaCodeunit130002_FailsOnMismatch()
+    var
+        Assert130002: Codeunit "Library Assert 130002";
+        Assert: Codeunit "Library Assert";
+    begin
+        // [GIVEN] Codeunit 130002
+        // [WHEN] Call AreEqual with mismatched values
+        // [THEN] It should raise an error (proving it actually calls MockAssert, not a no-op)
+        asserterror Assert130002.AreEqual(1, 2, 'Values should not match');
+        Assert.ExpectedError('Assert.AreEqual failed');
+    end;
+}


### PR DESCRIPTION
## Summary
- BC's real `Library Assert` codeunit is ID **130002**, but the runner's built-in stub uses ID 130
- External projects compiled against BC's test toolkit (ksef, Cash365, etc.) reference 130002
- This fell through to the empty auto-stub, blocking entire test codeunits with `Method with member ID X not found in codeunit 130002`
- Fix: add 130002 to the existing MockAssert routing alongside 130, 131, and 130000

**Impact**: Unblocks 33 ksef tests that were all blocked by this.

## Test plan
- [x] RED: negative test fails without routing (no-op stub doesn't error on mismatched values)
- [x] GREEN: both tests pass with routing
- [x] Bucket-2 regression: no new failures