### PR TITLE
feat: add AL stub for codeunit 130440 (Library - Random)

### DIFF
--- a/AlRunner/stubs/LibraryRandom.al
+++ b/AlRunner/stubs/LibraryRandom.al
@@ -1,0 +1,106 @@
+// Stub for BC's "Library - Random" codeunit (ID 130440) from Test-TestLibraries.
+// Provides pseudo-random value generation for AL tests.
+// All methods use BC built-ins so they run natively inside al-runner.
+// Note: The OnBeforeTestRun/OnAfterTestRun event subscriber is omitted because
+// "CAL Test Runner Publisher" (codeunit 130451) is not available in al-runner.
+codeunit 130440 "Library - Random"
+{
+    SingleInstance = true;
+
+    trigger OnRun()
+    begin
+    end;
+
+    var
+        Seed: Integer;
+        SeedSet: Boolean;
+
+    procedure RandDec(Range: Integer; Decimals: Integer): Decimal
+    begin
+        exit(RandInt(Range * Power(10, Decimals)) / Power(10, Decimals));
+    end;
+
+    procedure RandDecInRange("Min": Integer; "Max": Integer; Decimals: Integer): Decimal
+    begin
+        exit(Min + RandDec(Max - Min, Decimals));
+    end;
+
+    procedure RandDecInDecimalRange("Min": Decimal; "Max": Decimal; Precision: Integer): Decimal
+    var
+        Min2: Integer;
+        Max2: Integer;
+        Pow: Integer;
+    begin
+        Pow := Power(10, Precision);
+        Min2 := Round(Min * Pow, 1, '>');
+        Max2 := Round(Max * Pow, 1, '<');
+        exit(RandIntInRange(Min2, Max2) / Pow);
+    end;
+
+    procedure RandInt(Range: Integer): Integer
+    begin
+        if Range < 1 then
+            exit(1);
+        exit(GetNextValue(Range));
+    end;
+
+    procedure RandIntInRange("Min": Integer; "Max": Integer): Integer
+    begin
+        exit(Min - 1 + RandInt(Max - Min + 1));
+    end;
+
+    procedure RandDate(Delta: Integer): Date
+    begin
+        if Delta = 0 then
+            exit(WorkDate());
+        exit(CalcDate(StrSubstNo('<%1D>', Delta / Abs(Delta) * RandInt(Abs(Delta))), WorkDate()));
+    end;
+
+    procedure RandDateFrom(FromDate: Date; Range: Integer): Date
+    begin
+        if Range = 0 then
+            exit(FromDate);
+        exit(CalcDate(StrSubstNo('<%1D>', Range / Abs(Range) * RandInt(Range)), FromDate));
+    end;
+
+    procedure RandDateFromInRange(FromDate: Date; FromRange: Integer; ToRange: Integer): Date
+    begin
+        if FromRange >= ToRange then
+            exit(FromDate);
+        exit(CalcDate(StrSubstNo('<+%1D>', RandIntInRange(FromRange, ToRange)), FromDate));
+    end;
+
+    procedure RandPrecision(): Decimal
+    begin
+        exit(1 / Power(10, RandInt(5)));
+    end;
+
+    procedure RandText(Length: Integer): Text
+    var
+        GuidTxt: Text;
+    begin
+        while StrLen(GuidTxt) < Length do
+            GuidTxt += LowerCase(DelChr(Format(CreateGuid()), '=', '{}-'));
+        exit(CopyStr(GuidTxt, 1, Length));
+    end;
+
+    procedure Init(): Integer
+    begin
+        exit(SetSeed(Time - 000000T));
+    end;
+
+    procedure SetSeed(Val: Integer): Integer
+    begin
+        Seed := Val;
+        SeedSet := true;
+        Randomize(Seed);
+        exit(Seed);
+    end;
+
+    local procedure GetNextValue(MaxValue: Integer): Integer
+    begin
+        if not SeedSet then
+            SetSeed(1);
+        exit(Random(MaxValue));
+    end;
+}

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -1627,6 +1627,23 @@ CompanyProperty.UrlName:
   tests:
     - tests/bucket-1/271-companyproperty
 
+# ── Library - Random (codeunit 130440) ───────────────────────────
+
+MockCodeunitHandle.LibraryRandom:
+  layer: runtime-api
+  category: LibraryRandom
+  status: covered
+  tests:
+    - tests/bucket-2/106-library-random
+  notes: >
+    AL stub for codeunit 130440 "Library - Random" (Test-TestLibraries).
+    Provides pseudo-random value generation for AL tests via BC built-ins (Random,
+    Randomize, Power, CreateGuid, CalcDate, WorkDate). SingleInstance = true.
+    Auto-loaded from AlRunner/stubs/LibraryRandom.al alongside other built-in stubs.
+    Methods covered: RandInt, RandIntInRange, RandDec, RandDecInRange,
+    RandDecInDecimalRange, RandDate, RandDateFrom, RandDateFromInRange,
+    RandPrecision, RandText, Init, SetSeed.
+
 # ── Any (codeunit 130500) ────────────────────────────────────────
 
 MockCodeunitHandle.LibraryAny:

--- a/tests/bucket-2/106-library-random/test/LibraryRandomTest.al
+++ b/tests/bucket-2/106-library-random/test/LibraryRandomTest.al
@@ -1,0 +1,123 @@
+codeunit 106001 "Library Random Test"
+{
+    Subtype = Test;
+
+    var
+        LibRandom: Codeunit "Library - Random";
+        Assert: Codeunit "Library Assert";
+
+    [Test]
+    procedure RandInt_ReturnsValueInRange()
+    var
+        Result: Integer;
+    begin
+        // Verify RandInt returns a value between 1 and Range (inclusive)
+        Result := LibRandom.RandInt(100);
+        Assert.IsTrue(Result >= 1, 'RandInt result must be >= 1');
+        Assert.IsTrue(Result <= 100, 'RandInt result must be <= 100');
+    end;
+
+    [Test]
+    procedure RandInt_SmallRange_ReturnsOne()
+    var
+        Result: Integer;
+    begin
+        // When Range < 1, RandInt should return 1
+        Result := LibRandom.RandInt(0);
+        Assert.AreEqual(1, Result, 'RandInt(0) must return 1');
+    end;
+
+    [Test]
+    procedure RandIntInRange_ReturnsValueInRange()
+    var
+        Result: Integer;
+        i: Integer;
+    begin
+        // Call multiple times to make sure it doesn't always hit a boundary
+        for i := 1 to 5 do begin
+            Result := LibRandom.RandIntInRange(10, 20);
+            Assert.IsTrue(Result >= 10, 'RandIntInRange result must be >= Min');
+            Assert.IsTrue(Result <= 20, 'RandIntInRange result must be <= Max');
+        end;
+    end;
+
+    [Test]
+    procedure RandDec_ReturnsPositiveDecimal()
+    var
+        Result: Decimal;
+    begin
+        // RandDec(100, 2) returns a decimal > 0 with 2 decimal places
+        Result := LibRandom.RandDec(100, 2);
+        Assert.IsTrue(Result > 0, 'RandDec result must be > 0');
+        Assert.IsTrue(Result <= 100, 'RandDec result must be <= Range');
+    end;
+
+    [Test]
+    procedure RandDecInRange_ReturnsValueInRange()
+    var
+        Result: Decimal;
+    begin
+        Result := LibRandom.RandDecInRange(10, 20, 2);
+        Assert.IsTrue(Result >= 10, 'RandDecInRange result must be >= Min');
+        Assert.IsTrue(Result <= 20, 'RandDecInRange result must be <= Max');
+    end;
+
+    [Test]
+    procedure RandText_ReturnsCorrectLength()
+    var
+        Result: Text;
+    begin
+        Result := LibRandom.RandText(10);
+        Assert.AreEqual(10, StrLen(Result), 'RandText must return exactly 10 characters');
+    end;
+
+    [Test]
+    procedure RandText_LargeLength_ReturnsCorrectLength()
+    var
+        Result: Text;
+    begin
+        Result := LibRandom.RandText(50);
+        Assert.AreEqual(50, StrLen(Result), 'RandText must return exactly 50 characters');
+    end;
+
+    [Test]
+    procedure SetSeed_DeterminesSequence()
+    var
+        Val1a: Integer;
+        Val2a: Integer;
+        Val1b: Integer;
+        Val2b: Integer;
+    begin
+        // Same seed must produce the same sequence
+        LibRandom.SetSeed(42);
+        Val1a := LibRandom.RandInt(1000);
+        Val2a := LibRandom.RandInt(1000);
+
+        LibRandom.SetSeed(42);
+        Val1b := LibRandom.RandInt(1000);
+        Val2b := LibRandom.RandInt(1000);
+
+        Assert.AreEqual(Val1a, Val1b, 'Same seed must produce same first value');
+        Assert.AreEqual(Val2a, Val2b, 'Same seed must produce same second value');
+    end;
+
+    [Test]
+    procedure Init_ReturnsNonZeroSeed()
+    var
+        Seed: Integer;
+    begin
+        // Init() returns Time - 000000T which is almost always non-zero during the day
+        // We just verify the return value is what SetSeed received (i.e., it's >= 0)
+        Seed := LibRandom.Init();
+        Assert.IsTrue(Seed >= 0, 'Init must return a non-negative seed');
+    end;
+
+    [Test]
+    procedure RandDate_ZeroDelta_ReturnsWorkDate()
+    var
+        Result: Date;
+    begin
+        Result := LibRandom.RandDate(0);
+        Assert.AreEqual(WorkDate(), Result, 'RandDate(0) must return WorkDate');
+    end;
+}


### PR DESCRIPTION
## Summary

- Adds `AlRunner/stubs/LibraryRandom.al` — a faithful AL port of BC's codeunit 130440 `"Library - Random"` (SingleInstance=true)
- All 12 public methods implemented using BC built-ins (Random, Randomize, Power, CreateGuid, CalcDate, WorkDate) so they execute natively in al-runner without special routing
- The `OnBeforeTestRun`/`OnAfterTestRun` event subscriber is intentionally omitted (CAL Test Runner Publisher, codeunit 130451, is not available in al-runner)
- 10 proving tests in `tests/bucket-2/106-library-random/` covering RandInt, RandIntInRange, RandDec, RandDecInRange, RandText, SetSeed (deterministic sequence), Init, and RandDate(0)
- `docs/coverage.yaml` updated with `MockCodeunitHandle.LibraryRandom` entry

## Test plan

- [x] RED: test suite failed with "Missing dependencies: Codeunit 'Library - Random' is missing" before stub
- [x] GREEN: all 10 tests pass after adding stub
- [x] Full bucket-2 regression: 1645 passed, 3 failed (pre-existing failures: CreateDateTime_RoundTrip, LogAuditMessage — unrelated to this change)