### PR TITLE
feat: add AL stub for codeunit 132250 (Library - Test Initialize)

### DIFF
--- a/AlRunner/stubs/LibraryTestInitialize.al
+++ b/AlRunner/stubs/LibraryTestInitialize.al
@@ -1,0 +1,25 @@
+// Stub for BC's Library - Test Initialize codeunit (ID 132250).
+// Provides integration event publishers for test initialization hooks.
+// In real BC, test codeunits subscribe to these events to set up test data.
+// In al-runner, the events fire normally through EventSubscriberRegistry.
+codeunit 132250 "Library - Test Initialize"
+{
+    trigger OnRun()
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    procedure OnTestInitialize(CallerCodeunitID: Integer)
+    begin
+    end;
+
+    [IntegrationEvent(false, false)]
+    procedure OnBeforeTestSuiteInitialize(CallerCodeunitID: Integer)
+    begin
+    end;
+
+    [IntegrationEvent(true, false)]
+    procedure OnAfterTestSuiteInitialize(CallerCodeunitID: Integer)
+    begin
+    end;
+}

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -11149,3 +11149,14 @@ RoslynRewriter.CompareToEquality:
     to x == y (and != 0 to x != y). The == operator works correctly standalone.
   tests:
     - tests/bucket-2/105-validate-case
+
+MockCodeunitHandle.LibraryTestInitialize:
+  layer: runtime-api
+  category: test-toolkit
+  status: covered
+  notes: >
+    AL stub for codeunit 132250 (Library - Test Initialize). Provides three
+    integration event publishers (OnTestInitialize, OnBeforeTestSuiteInitialize,
+    OnAfterTestSuiteInitialize) used by BC test codeunits for setup hooks.
+  tests:
+    - tests/bucket-2/107-library-test-init

--- a/tests/bucket-2/107-library-test-init/test/LibTestInitTest.al
+++ b/tests/bucket-2/107-library-test-init/test/LibTestInitTest.al
@@ -1,0 +1,30 @@
+codeunit 107001 "Lib Test Init Test"
+{
+    Subtype = Test;
+
+    [Test]
+    procedure OnTestInitialize_FiresWithoutError()
+    var
+        LibTestInit: Codeunit "Library - Test Initialize";
+    begin
+        // [WHEN] Calling OnTestInitialize (an integration event publisher)
+        // [THEN] No error — the event fires and any subscribers run
+        LibTestInit.OnTestInitialize(Codeunit::"Lib Test Init Test");
+    end;
+
+    [Test]
+    procedure OnBeforeTestSuiteInitialize_FiresWithoutError()
+    var
+        LibTestInit: Codeunit "Library - Test Initialize";
+    begin
+        LibTestInit.OnBeforeTestSuiteInitialize(Codeunit::"Lib Test Init Test");
+    end;
+
+    [Test]
+    procedure OnAfterTestSuiteInitialize_FiresWithoutError()
+    var
+        LibTestInit: Codeunit "Library - Test Initialize";
+    begin
+        LibTestInit.OnAfterTestSuiteInitialize(Codeunit::"Lib Test Init Test");
+    end;
+}


### PR DESCRIPTION
## Summary
- Add `AlRunner/stubs/LibraryTestInitialize.al` — stub for codeunit 132250
- 3 integration event publishers: OnTestInitialize, OnBeforeTestSuiteInitialize, OnAfterTestSuiteInitialize
- Used by BC test codeunits for setup hooks — many external projects reference this

## Test plan
- [x] RED: "Missing dependencies: Codeunit 'Library - Test Initialize' is missing"
- [x] GREEN: 3 tests pass — events fire without error