### PR TITLE
feat: --compile-dep and --dep-dlls for dependency execution (#1124)

### DIFF
--- a/AlRunner/DepCompiler.cs
+++ b/AlRunner/DepCompiler.cs
@@ -1,0 +1,315 @@
+using System.Reflection;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace AlRunner;
+
+/// <summary>
+/// Compiles a dependency .app package through the AL→C#→rewrite→Roslyn pipeline
+/// and produces a .dll on disk. The resulting DLL uses the same mock types
+/// (AlScope, MockRecordHandle, etc.) as the main test assembly, enabling
+/// cross-assembly codeunit dispatch via MockCodeunitHandle.
+/// </summary>
+public static class DepCompiler
+{
+    /// <summary>
+    /// Compile a single .app dependency (or directory of AL source) to a .dll in <paramref name="outputDir"/>.
+    /// Returns 0 on success, 1 on failure.
+    /// </summary>
+    public static int CompileDep(string appPath, string outputDir, List<string> packagePaths)
+    {
+        // If appPath is a directory, compile AL source files directly
+        if (Directory.Exists(appPath))
+            return CompileDepFromDir(appPath, outputDir, packagePaths);
+
+        if (!File.Exists(appPath))
+        {
+            Console.Error.WriteLine($"Error: .app file or directory not found: {appPath}");
+            return 1;
+        }
+
+        Directory.CreateDirectory(outputDir);
+
+        // 1. Read manifest for naming
+        var (publisher, name, version) = ReadAppIdentity(appPath);
+        var dllName = SanitizeName($"{publisher}_{name}_{version}.dll");
+        var dllPath = Path.Combine(outputDir, dllName);
+
+        // 2. Cache check — skip if DLL already exists
+        if (File.Exists(dllPath))
+        {
+            Console.Error.WriteLine($"Cached: {dllName} (already exists in {outputDir})");
+            return 0;
+        }
+
+        Console.Error.WriteLine($"Compiling dependency: {name} by {publisher} v{version}");
+
+        // 3. Extract AL sources from .app
+        List<(string Name, string Source)> alEntries;
+        try
+        {
+            alEntries = AppPackageReader.ExtractAlSources(appPath);
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"Error extracting AL from {appPath}: {ex.Message}");
+            return 1;
+        }
+
+        if (alEntries.Count == 0)
+        {
+            Console.Error.WriteLine($"Warning: no AL source found in {appPath} — skipping");
+            return 0;
+        }
+
+        var alSources = alEntries.Select(e => e.Source).ToList();
+        Console.Error.WriteLine($"  Extracted {alSources.Count} AL files");
+
+        // 4. Register metadata (enums, tables, etc.)
+        foreach (var src in alSources)
+        {
+            Runtime.EnumRegistry.ParseAndRegister(src);
+            Runtime.TableInitValueRegistry.ParseAndRegister(src);
+            Runtime.CodeunitNameRegistry.ParseAndRegister(src);
+            Runtime.CalcFormulaRegistry.ParseAndRegister(src);
+            Runtime.TableFieldRegistry.ParseAndRegister(src);
+        }
+
+        // 5. Resolve package paths — include the .app's own .alpackages and any explicit paths
+        var allPackagePaths = new List<string>(packagePaths);
+        var appDir = Path.GetDirectoryName(Path.GetFullPath(appPath));
+        if (appDir != null)
+        {
+            var alPkg = Path.Combine(appDir, ".alpackages");
+            if (Directory.Exists(alPkg) && !allPackagePaths.Contains(alPkg))
+                allPackagePaths.Add(alPkg);
+        }
+        // Also add output dir as package path so dep-on-dep chains resolve
+        if (Directory.Exists(outputDir))
+        {
+            foreach (var existingDll in Directory.GetFiles(outputDir, "*.app"))
+            {
+                var dir = Path.GetDirectoryName(existingDll);
+                if (dir != null && !allPackagePaths.Contains(dir))
+                    allPackagePaths.Add(dir);
+            }
+        }
+
+        // 6. Transpile AL → C#
+        var csharpList = AlTranspiler.TranspileMulti(alSources, allPackagePaths.Count > 0 ? allPackagePaths : null, null);
+        if (csharpList == null || csharpList.Count == 0)
+        {
+            Console.Error.WriteLine($"  AL transpilation produced no output for {name}");
+            return 1;
+        }
+        Console.Error.WriteLine($"  Transpiled {csharpList.Count} C# objects");
+
+        // 7. Rewrite C# (BC types → mock types — same rewriter as main pipeline)
+        var rewrittenTrees = new List<SyntaxTree>();
+        int rewriteErrors = 0;
+        foreach (var item in csharpList)
+        {
+            try
+            {
+                var tree = RoslynRewriter.RewriteToTree(item.Code);
+                if (tree != null)
+                    rewrittenTrees.Add(tree);
+            }
+            catch
+            {
+                rewriteErrors++;
+                // Generate minimal stub so other types can still reference it
+                var className = ExtractClassName(item.Name);
+                if (className != null)
+                {
+                    var stubCode = $"namespace Microsoft.Dynamics.Nav.BusinessApplication {{ public class {className} {{ }} }}";
+                    rewrittenTrees.Add(CSharpSyntaxTree.ParseText(stubCode, path: $"{className}_stub.cs"));
+                }
+            }
+        }
+        if (rewriteErrors > 0)
+            Console.Error.WriteLine($"  {rewriteErrors} rewrite error(s) — stub classes generated for those");
+
+        if (rewrittenTrees.Count == 0)
+        {
+            Console.Error.WriteLine($"  No rewritten C# trees — cannot compile");
+            return 1;
+        }
+
+        // 8. Compile to DLL on disk
+        var references = RoslynCompiler.LoadReferences();
+        // Add any existing dep DLLs in outputDir as references (for dep-on-dep chains)
+        foreach (var dll in Directory.GetFiles(outputDir, "*.dll"))
+        {
+            try { references.Add(MetadataReference.CreateFromFile(dll)); }
+            catch { /* skip unloadable */ }
+        }
+
+        var errors = new List<string>();
+        bool success = CompileToDisk(rewrittenTrees, references, dllPath, errors);
+
+        if (!success)
+        {
+            Console.Error.WriteLine($"  Roslyn compilation failed ({errors.Count} errors):");
+            foreach (var err in errors.Take(20))
+                Console.Error.WriteLine($"    {err}");
+            return 1;
+        }
+
+        Console.Error.WriteLine($"  Compiled: {dllName}");
+        return 0;
+    }
+
+    /// <summary>
+    /// Compile syntax trees to a DLL file on disk (instead of in-memory like CompileFromTrees).
+    /// </summary>
+    internal static bool CompileToDisk(List<SyntaxTree> syntaxTrees, List<MetadataReference> references,
+        string outputPath, IList<string>? errorSink = null)
+    {
+        var compilation = CSharpCompilation.Create(
+            Path.GetFileNameWithoutExtension(outputPath),
+            syntaxTrees,
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+                .WithAllowUnsafe(true));
+
+        var result = compilation.Emit(outputPath);
+
+        if (!result.Success)
+        {
+            var errors = result.Diagnostics
+                .Where(d => d.Severity == DiagnosticSeverity.Error)
+                .ToList();
+            foreach (var d in errors)
+                errorSink?.Add(d.ToString());
+            // Clean up partial output
+            try { File.Delete(outputPath); } catch { }
+            return false;
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Compile a directory of AL source files to a dependency .dll.
+    /// </summary>
+    private static int CompileDepFromDir(string srcDir, string outputDir, List<string> packagePaths)
+    {
+        Directory.CreateDirectory(outputDir);
+        var dirName = Path.GetFileName(srcDir.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+        var dllName = SanitizeName($"{dirName}.dll");
+        var dllPath = Path.Combine(outputDir, dllName);
+
+        if (File.Exists(dllPath))
+        {
+            Console.Error.WriteLine($"Cached: {dllName}");
+            return 0;
+        }
+
+        var alFiles = Directory.GetFiles(srcDir, "*.al", SearchOption.AllDirectories);
+        if (alFiles.Length == 0)
+        {
+            Console.Error.WriteLine($"No .al files found in {srcDir}");
+            return 1;
+        }
+
+        var alSources = alFiles.Select(File.ReadAllText).ToList();
+        Console.Error.WriteLine($"Compiling dependency from directory: {dirName} ({alSources.Count} AL files)");
+
+        foreach (var src in alSources)
+        {
+            Runtime.EnumRegistry.ParseAndRegister(src);
+            Runtime.TableInitValueRegistry.ParseAndRegister(src);
+            Runtime.CodeunitNameRegistry.ParseAndRegister(src);
+            Runtime.CalcFormulaRegistry.ParseAndRegister(src);
+            Runtime.TableFieldRegistry.ParseAndRegister(src);
+        }
+
+        var allPackagePaths = new List<string>(packagePaths);
+        var alPkg = Path.Combine(srcDir, ".alpackages");
+        if (Directory.Exists(alPkg) && !allPackagePaths.Contains(alPkg))
+            allPackagePaths.Add(alPkg);
+
+        var csharpList = AlTranspiler.TranspileMulti(alSources, allPackagePaths.Count > 0 ? allPackagePaths : null, null);
+        if (csharpList == null || csharpList.Count == 0)
+        {
+            Console.Error.WriteLine($"  AL transpilation produced no output");
+            return 1;
+        }
+
+        var rewrittenTrees = new List<Microsoft.CodeAnalysis.SyntaxTree>();
+        foreach (var item in csharpList)
+        {
+            try
+            {
+                var tree = RoslynRewriter.RewriteToTree(item.Code);
+                if (tree != null) rewrittenTrees.Add(tree);
+            }
+            catch
+            {
+                var className = ExtractClassName(item.Name);
+                if (className != null)
+                {
+                    var stubCode = $"namespace Microsoft.Dynamics.Nav.BusinessApplication {{ public class {className} {{ }} }}";
+                    rewrittenTrees.Add(CSharpSyntaxTree.ParseText(stubCode));
+                }
+            }
+        }
+
+        var references = RoslynCompiler.LoadReferences();
+        foreach (var dll in Directory.GetFiles(outputDir, "*.dll"))
+        {
+            try { references.Add(MetadataReference.CreateFromFile(dll)); }
+            catch { }
+        }
+
+        var errors = new List<string>();
+        if (!CompileToDisk(rewrittenTrees, references, dllPath, errors))
+        {
+            Console.Error.WriteLine($"  Compilation failed ({errors.Count} errors):");
+            foreach (var err in errors.Take(10))
+                Console.Error.WriteLine($"    {err}");
+            return 1;
+        }
+
+        Console.Error.WriteLine($"  Compiled: {dllName}");
+        return 0;
+    }
+
+    private static (string Publisher, string Name, string Version) ReadAppIdentity(string appPath)
+    {
+        try
+        {
+            var manifest = AlTranspiler.LoadNavxManifest(appPath);
+            if (manifest != null)
+            {
+                var ns = System.Xml.Linq.XNamespace.Get("http://schemas.microsoft.com/navx/2015/manifest");
+                // Root is <Package>, <App> is a child element
+                var app = manifest.Root?.Element(ns + "App") ?? manifest.Root;
+                if (app != null)
+                {
+                    var publisher = app.Attribute("Publisher")?.Value ?? "Unknown";
+                    var name = app.Attribute("Name")?.Value ?? "Unknown";
+                    var version = app.Attribute("Version")?.Value ?? "0.0.0.0";
+                    return (publisher, name, version);
+                }
+            }
+        }
+        catch { }
+        return ("Unknown", Path.GetFileNameWithoutExtension(appPath), "0.0.0.0");
+    }
+
+    private static string SanitizeName(string name)
+    {
+        return string.Concat(name.Select(c =>
+            char.IsLetterOrDigit(c) || c == '_' || c == '-' || c == '.' ? c : '_'));
+    }
+
+    private static string? ExtractClassName(string objectName)
+    {
+        // Object names are like "MyCodeunit", "Record12345", etc.
+        // Clean to valid C# identifier
+        var clean = new string(objectName.Where(c => char.IsLetterOrDigit(c) || c == '_').ToArray());
+        return string.IsNullOrEmpty(clean) ? null : clean;
+    }
+}

--- a/AlRunner/Pipeline.cs
+++ b/AlRunner/Pipeline.cs
@@ -45,6 +45,9 @@ public class PipelineOptions
     /// </summary>
     public TestIsolation TestIsolation { get; set; } = TestIsolation.Method;
 
+    /// <summary>Directories containing pre-compiled dependency DLLs (rewritten C# with mock types).</summary>
+    public List<string> DepDllPaths { get; set; } = new();
+
     /// <summary>
     /// Optional override for the C# rewriter step, intended for unit-testing the pipeline's
     /// rewriter-error-handling path. When set, replaces <see cref="RoslynRewriter.RewriteToTree"/>
@@ -701,6 +704,24 @@ public class AlRunnerPipeline
         var mapperTask = Task.Run(() =>
             SourceLineMapper.Build(generatedCSharpList, GetRewrittenStrings()));
         var preloadedRefs = refsTask.Result;
+
+        // Load dependency DLLs as MetadataReferences for Roslyn compilation
+        var depDllAssemblyPaths = new List<string>();
+        foreach (var depDir in options.DepDllPaths)
+        {
+            if (!Directory.Exists(depDir)) continue;
+            foreach (var dll in Directory.GetFiles(depDir, "*.dll"))
+            {
+                try
+                {
+                    preloadedRefs.Add(Microsoft.CodeAnalysis.MetadataReference.CreateFromFile(dll));
+                    depDllAssemblyPaths.Add(Path.GetFullPath(dll));
+                    Log.Info($"Added dep DLL reference: {Path.GetFileName(dll)}");
+                }
+                catch (Exception ex) { Log.Info($"Skipping dep DLL {dll}: {ex.Message}"); }
+            }
+        }
+
         var compilationErrorSink = new List<string>();
         var compileResult = RoslynCompiler.Compile(rewrittenTreeList, preloadedRefs, compilationErrorSink);
         mapperTask.Wait();
@@ -727,6 +748,21 @@ public class AlRunnerPipeline
         Timer.StartStage("Test execution");
         var assembly = compileResult.Assembly;
         Runtime.MockCodeunitHandle.CurrentAssembly = assembly;
+
+        // Load dependency DLLs into the same ALC for runtime type resolution
+        var depAssemblies = new List<Assembly>();
+        foreach (var dllPath in depDllAssemblyPaths)
+        {
+            try
+            {
+                var depAsm = compileResult.LoadContext.LoadFromAssemblyPath(dllPath);
+                depAssemblies.Add(depAsm);
+                Log.Info($"Loaded dep assembly: {depAsm.GetName().Name}");
+            }
+            catch (Exception ex) { Log.Info($"Failed to load dep assembly {dllPath}: {ex.Message}"); }
+        }
+        Runtime.MockCodeunitHandle.DependencyAssemblies = depAssemblies.Count > 0 ? depAssemblies : null;
+
         Executor.RegisterStatements(GetRewrittenStrings());
 
         bool hasTests = alSources.Any(s => s.Contains("Subtype = Test"));

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -31,6 +31,9 @@ if (args.Length == 0 || args.Any(a => a is "-h" or "--help"))
     Console.Error.WriteLine("  --coverage            Show statement-level coverage report and write cobertura.xml");
     Console.Error.WriteLine("  --packages <dir>      Add symbol references from .app files in directory");
     Console.Error.WriteLine("                        (auto-detected: .alpackages in/near source dirs when omitted)");
+    Console.Error.WriteLine("  --dep-dlls <dir>      Load pre-compiled dependency DLLs for runtime execution");
+    Console.Error.WriteLine("  --compile-dep <app> <out-dir> [--packages <dir>]");
+    Console.Error.WriteLine("                        Compile a .app dependency to a rewritten DLL on disk");
     Console.Error.WriteLine("  --stubs <dir>         Override dependency objects with stub AL files");
     Console.Error.WriteLine("  --init-events         Fire BC lifecycle integration events before each codeunit");
     Console.Error.WriteLine("                        (OnCompanyInitialize from CU 2/27, OnInstallAppPerCompany from CU 2)");
@@ -219,6 +222,37 @@ while (argIdx < args.Length)
             };
             argIdx++;
             break;
+        case "--dep-dlls":
+            argIdx++;
+            if (argIdx >= args.Length) { Console.Error.WriteLine("Error: --dep-dlls requires a directory argument"); return 1; }
+            options.DepDllPaths.Add(Path.GetFullPath(args[argIdx]));
+            argIdx++;
+            break;
+        case "--compile-dep":
+        {
+            argIdx++;
+            if (argIdx >= args.Length) { Console.Error.WriteLine("Error: --compile-dep requires <app-path> <output-dir>"); return 1; }
+            var cdAppPath = Path.GetFullPath(args[argIdx]);
+            argIdx++;
+            if (argIdx >= args.Length) { Console.Error.WriteLine("Error: --compile-dep requires <app-path> <output-dir>"); return 1; }
+            var cdOutDir = Path.GetFullPath(args[argIdx]);
+            argIdx++;
+            var cdPkgPaths = new List<string>();
+            while (argIdx < args.Length)
+            {
+                if (args[argIdx] == "--packages" && argIdx + 1 < args.Length)
+                {
+                    argIdx++;
+                    cdPkgPaths.Add(Path.GetFullPath(args[argIdx]));
+                    argIdx++;
+                }
+                else
+                {
+                    argIdx++;
+                }
+            }
+            return AlRunner.DepCompiler.CompileDep(cdAppPath, cdOutDir, cdPkgPaths);
+        }
         case "--stubs":
             argIdx++;
             if (argIdx >= args.Length) { Console.Error.WriteLine("Error: --stubs requires a directory argument"); return 1; }

--- a/AlRunner/Runtime/AlScope.cs
+++ b/AlRunner/Runtime/AlScope.cs
@@ -700,6 +700,19 @@ public static class AlCompat
     {
         var asm = MockCodeunitHandle.CurrentAssembly;
         if (asm == null) return;
+
+        FireEventInAssembly(asm, objectType, publisherId, eventName, eventArgs);
+
+        // Also fire events from dependency assemblies
+        if (MockCodeunitHandle.DependencyAssemblies != null)
+        {
+            foreach (var depAsm in MockCodeunitHandle.DependencyAssemblies)
+                FireEventInAssembly(depAsm, objectType, publisherId, eventName, eventArgs);
+        }
+    }
+
+    private static void FireEventInAssembly(System.Reflection.Assembly asm, int objectType, int publisherId, string eventName, object?[] eventArgs)
+    {
         var subs = EventSubscriberRegistry.GetSubscribers(asm, objectType, publisherId, eventName);
         foreach (var sub in subs)
         {

--- a/AlRunner/Runtime/MockCodeunitHandle.cs
+++ b/AlRunner/Runtime/MockCodeunitHandle.cs
@@ -18,6 +18,13 @@ public class MockCodeunitHandle
     /// </summary>
     public static Assembly? CurrentAssembly { get; set; }
 
+    /// <summary>
+    /// Additional assemblies containing compiled dependency codeunits/tables/pages.
+    /// Loaded from --dep-dlls directories. Searched by FindCodeunitType, event dispatch,
+    /// and record trigger resolution when a type is not found in CurrentAssembly.
+    /// </summary>
+    public static List<Assembly>? DependencyAssemblies { get; set; }
+
     public MockCodeunitHandle(int codeunitId)
     {
         _codeunitId = codeunitId;
@@ -749,7 +756,19 @@ public class MockCodeunitHandle
     private Type? FindCodeunitType(Assembly assembly)
     {
         var expectedName = $"Codeunit{_codeunitId}";
-        return assembly.GetTypes().FirstOrDefault(t => t.Name == expectedName);
+        var type = assembly.GetTypes().FirstOrDefault(t => t.Name == expectedName);
+        if (type != null) return type;
+
+        // Search dependency assemblies
+        if (DependencyAssemblies != null)
+        {
+            foreach (var depAsm in DependencyAssemblies)
+            {
+                type = depAsm.GetTypes().FirstOrDefault(t => t.Name == expectedName);
+                if (type != null) return type;
+            }
+        }
+        return null;
     }
 
     /// <summary>

--- a/AlRunner/Runtime/MockFormHandle.cs
+++ b/AlRunner/Runtime/MockFormHandle.cs
@@ -76,14 +76,7 @@ public class MockFormHandle
     /// <summary>Dispatch a plain helper procedure on the page's generated class.</summary>
     public object? Invoke(int memberId, object[] args)
     {
-        var assembly = MockCodeunitHandle.CurrentAssembly;
-        if (assembly == null) return null;
-
-        Type? pageType = null;
-        foreach (var t in assembly.GetTypes())
-        {
-            if (t.Name == $"Page{PageId}") { pageType = t; break; }
-        }
+        Type? pageType = MockRecordHandle.FindTypeAcrossAssemblies($"Page{PageId}");
         if (pageType == null) return null;
 
         if (_pageInstance == null)

--- a/AlRunner/Runtime/MockPagePartHandle.cs
+++ b/AlRunner/Runtime/MockPagePartHandle.cs
@@ -65,14 +65,11 @@ public class MockPartFormHandle
     /// </summary>
     public object? Invoke(int memberId, object[] args)
     {
-        var assembly = MockCodeunitHandle.CurrentAssembly;
-        if (assembly == null) return null;
-
         var absMemberId = Math.Abs(memberId).ToString();
         var memberIdStr = memberId.ToString();
 
         // Search all Page* classes for the method whose scope class name encodes memberId.
-        foreach (var t in assembly.GetTypes())
+        foreach (var t in MockRecordHandle.GetAllAssemblies().SelectMany(a => a.GetTypes()))
         {
             if (!t.Name.StartsWith("Page", StringComparison.Ordinal)) continue;
 

--- a/AlRunner/Runtime/MockRecordHandle.cs
+++ b/AlRunner/Runtime/MockRecordHandle.cs
@@ -468,17 +468,43 @@ public class MockRecordHandle
     /// the trigger's <c>Rec.SetFieldValueSafe(…)</c> calls mutate this
     /// instance's field bag in place.
     /// </summary>
-    private void TryFireRecordTrigger(string triggerName)
+    /// <summary>
+    /// Enumerate CurrentAssembly and all DependencyAssemblies.
+    /// </summary>
+    internal static IEnumerable<System.Reflection.Assembly> GetAllAssemblies()
+    {
+        var main = MockCodeunitHandle.CurrentAssembly;
+        if (main != null) yield return main;
+        if (MockCodeunitHandle.DependencyAssemblies != null)
+            foreach (var dep in MockCodeunitHandle.DependencyAssemblies)
+                yield return dep;
+    }
+
+    /// <summary>
+    /// Search CurrentAssembly and DependencyAssemblies for a type by name.
+    /// Used by MockRecordHandle, MockFormHandle, MockReportHandle, MockPagePartHandle.
+    /// </summary>
+    internal static Type? FindTypeAcrossAssemblies(string typeName)
     {
         var assembly = MockCodeunitHandle.CurrentAssembly;
-        if (assembly == null) return;
-
-        var recordTypeName = $"Record{_tableId}";
-        Type? recordType = null;
-        foreach (var t in assembly.GetTypes())
+        if (assembly != null)
         {
-            if (t.Name == recordTypeName) { recordType = t; break; }
+            foreach (var t in assembly.GetTypes())
+                if (t.Name == typeName) return t;
         }
+        if (MockCodeunitHandle.DependencyAssemblies != null)
+        {
+            foreach (var depAsm in MockCodeunitHandle.DependencyAssemblies)
+                foreach (var t in depAsm.GetTypes())
+                    if (t.Name == typeName) return t;
+        }
+        return null;
+    }
+
+    private void TryFireRecordTrigger(string triggerName)
+    {
+        var recordTypeName = $"Record{_tableId}";
+        Type? recordType = FindTypeAcrossAssemblies(recordTypeName);
         if (recordType == null) return;
 
         // Generated Record classes are plain classes (post-rewrite) with
@@ -1144,14 +1170,14 @@ public class MockRecordHandle
     /// </summary>
     private void FireOnValidate(int fieldNo)
     {
-        var assembly = MockCodeunitHandle.CurrentAssembly;
-        if (assembly == null) return;
-
-        // Search both the Record class and any TableExtension classes for the trigger
+        // Search both the Record class and any TableExtension classes for the trigger,
+        // across main assembly and dependency assemblies
         var recordTypeName = $"Record{_tableId}";
-        var candidateTypes = assembly.GetTypes()
-            .Where(t => t.Name == recordTypeName || t.Name.StartsWith("TableExtension"))
-            .ToList();
+        var candidateTypes = new List<Type>();
+        foreach (var asm in GetAllAssemblies())
+            candidateTypes.AddRange(asm.GetTypes()
+                .Where(t => t.Name == recordTypeName || t.Name.StartsWith("TableExtension")));
+        if (candidateTypes.Count == 0) return;
 
         foreach (var candidateType in candidateTypes)
         {
@@ -3225,9 +3251,8 @@ public class MockRecordHandle
     public object? Invoke(int memberId, object[] args)
     {
         // Delegate to MockCodeunitHandle-style dispatch on the record type
-        var assembly = MockCodeunitHandle.CurrentAssembly ?? System.Reflection.Assembly.GetExecutingAssembly();
         var recordTypeName = $"Record{_tableId}";
-        var recordType = assembly.GetTypes().FirstOrDefault(t => t.Name == recordTypeName);
+        var recordType = FindTypeAcrossAssemblies(recordTypeName);
         if (recordType == null)
         {
             throw new InvalidOperationException($"Record type {recordTypeName} not found in assembly for Invoke");

--- a/AlRunner/Runtime/MockReportHandle.cs
+++ b/AlRunner/Runtime/MockReportHandle.cs
@@ -266,11 +266,7 @@ public class MockReportHandle
         if (_reportInstance != null)
             return _reportInstance;
 
-        var assembly = MockCodeunitHandle.CurrentAssembly;
-        if (assembly == null)
-            return null;
-
-        var reportType = assembly.GetTypes().FirstOrDefault(t => t.Name == $"Report{ReportId}");
+        var reportType = MockRecordHandle.FindTypeAcrossAssemblies($"Report{ReportId}");
         if (reportType == null)
             return null;
 

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -11167,6 +11167,31 @@ RoslynRewriter.CompareToEquality:
   tests:
     - tests/bucket-2/105-validate-case
 
+DepCompiler.CompileDep:
+  layer: runtime-api
+  category: dependency-execution
+  status: covered
+  notes: >
+    --compile-dep compiles a dependency .app package (or AL source directory)
+    through the full AL→C#→rewrite→Roslyn pipeline and produces a .dll on disk.
+    The DLL uses the same mock types as the main test assembly. Supports caching
+    by app identity (skips if DLL already exists). Output DLLs can be loaded via
+    --dep-dlls for runtime execution of dependency codeunits.
+  tests:
+    - tests/dep-dlls
+
+MockCodeunitHandle.DependencyAssemblies:
+  layer: runtime-api
+  category: dependency-execution
+  status: covered
+  notes: >
+    --dep-dlls loads pre-compiled dependency DLLs into the AssemblyLoadContext.
+    FindCodeunitType, FireEvent, TryFireRecordTrigger, and type lookups in
+    MockFormHandle/MockReportHandle/MockPagePartHandle all search dependency
+    assemblies when a type is not found in the main assembly.
+  tests:
+    - tests/dep-dlls
+
 MockCodeunitHandle.LibraryTestInitialize:
   layer: runtime-api
   category: test-toolkit

--- a/tests/dep-dlls/dep-src/DepHelper.al
+++ b/tests/dep-dlls/dep-src/DepHelper.al
@@ -1,0 +1,14 @@
+// Dependency codeunit — compiled separately via --compile-dep,
+// then loaded via --dep-dlls and called from test code.
+codeunit 60001 "Dep Helper"
+{
+    procedure AddNumbers(A: Integer; B: Integer): Integer
+    begin
+        exit(A + B);
+    end;
+
+    procedure GetGreeting(Name: Text): Text
+    begin
+        exit('Hello, ' + Name + '!');
+    end;
+}

--- a/tests/dep-dlls/test/DepDllTest.al
+++ b/tests/dep-dlls/test/DepDllTest.al
@@ -1,0 +1,31 @@
+codeunit 60002 "Dep DLL Test"
+{
+    Subtype = Test;
+
+    [Test]
+    procedure DepHelper_AddNumbers_ReturnsSum()
+    var
+        Helper: Codeunit "Dep Helper";
+        Assert: Codeunit "Library Assert";
+        Result: Integer;
+    begin
+        // [GIVEN] A dependency codeunit compiled separately and loaded via --dep-dlls
+        // [WHEN] Call AddNumbers
+        Result := Helper.AddNumbers(3, 4);
+        // [THEN] Returns the actual sum (not the auto-stub default of 0)
+        Assert.AreEqual(7, Result, 'Dep codeunit should return actual computed value, not stub default');
+    end;
+
+    [Test]
+    procedure DepHelper_GetGreeting_ReturnsFormattedText()
+    var
+        Helper: Codeunit "Dep Helper";
+        Assert: Codeunit "Library Assert";
+        Result: Text;
+    begin
+        // [WHEN] Call GetGreeting
+        Result := Helper.GetGreeting('World');
+        // [THEN] Returns formatted greeting
+        Assert.AreEqual('Hello, World!', Result, 'Dep codeunit should return formatted text');
+    end;
+}


### PR DESCRIPTION
## Summary

Implements the 3-layer dependency architecture from issue #1124:

- **Layer 2**: `--dep-dlls <dir>` — load pre-compiled dependency DLLs at runtime
- **Layer 3**: `--compile-dep <app|dir> <out-dir>` — compile .app packages or AL directories to rewritten DLLs

### How it works

```bash
# Compile a dependency .app to a DLL (one-time)
al-runner --compile-dep .alpackages/MyDep.app ./deps/ --packages .alpackages

# Run tests with the compiled dependency
al-runner --dep-dlls ./deps/ ./src ./test
```

The compiled DLLs go through the same AL→C#→rewrite→Roslyn pipeline as the main test assembly, so they use the same mock types (AlScope, MockRecordHandle, etc.) and interop seamlessly.

### Runtime changes

- `MockCodeunitHandle.DependencyAssemblies` — static list of dep assemblies
- `FindCodeunitType` — searches dep assemblies when type not found in main
- `AlCompat.FireEvent` — dispatches events to dep assembly subscribers
- `MockRecordHandle.FindTypeAcrossAssemblies` — shared helper for cross-assembly type lookup
- Updated MockFormHandle, MockReportHandle, MockPagePartHandle to search dep assemblies

### Caching

`--compile-dep` skips compilation if the output DLL already exists (by name match). Re-run is safe.

## Test plan
- [x] `--compile-dep` with .app file produces DLL (tested with Microsoft_Any.app)
- [x] `--compile-dep` with AL directory produces DLL
- [x] `--dep-dlls` loads assemblies and adds Roslyn MetadataReferences
- [x] FindCodeunitType searches dep assemblies
- [x] Bucket-1: 1602 passed, 2 failed (pre-existing timezone)
- [x] Bucket-2: 1648 passed, 3 failed (pre-existing), 0 regressions