### PR TITLE
fix: default test-isolation to codeunit (BC default) + better error output

### DIFF
--- a/AlRunner.Tests/CacheTests.cs
+++ b/AlRunner.Tests/CacheTests.cs
@@ -187,6 +187,7 @@ public class PipelineRewriteCacheTests
 
         var options = new PipelineOptions
         {
+            TestIsolation = AlRunner.TestIsolation.Method,
             InputPaths = { TestPath("01-pure-function", "src"), TestPath("01-pure-function", "test") },
             Verbose = true
         };

--- a/AlRunner.Tests/CaptureValuesTests.cs
+++ b/AlRunner.Tests/CaptureValuesTests.cs
@@ -19,6 +19,7 @@ public class CaptureValuesTests
         var pipeline = new AlRunnerPipeline();
         var result = pipeline.Run(new PipelineOptions
         {
+            TestIsolation = AlRunner.TestIsolation.Method,
             InputPaths = { TestPath("01-pure-function", "src"), TestPath("01-pure-function", "test") },
             CaptureValues = true
         });
@@ -34,6 +35,7 @@ public class CaptureValuesTests
         var pipeline = new AlRunnerPipeline();
         var result = pipeline.Run(new PipelineOptions
         {
+            TestIsolation = AlRunner.TestIsolation.Method,
             InputPaths = { TestPath("01-pure-function", "src"), TestPath("01-pure-function", "test") },
             CaptureValues = true
         });
@@ -51,6 +53,7 @@ public class CaptureValuesTests
         var pipeline = new AlRunnerPipeline();
         var result = pipeline.Run(new PipelineOptions
         {
+            TestIsolation = AlRunner.TestIsolation.Method,
             InputPaths = { TestPath("01-pure-function", "src"), TestPath("01-pure-function", "test") },
             CaptureValues = false
         });
@@ -65,6 +68,7 @@ public class CaptureValuesTests
         var pipeline = new AlRunnerPipeline();
         var result = pipeline.Run(new PipelineOptions
         {
+            TestIsolation = AlRunner.TestIsolation.Method,
             InputPaths = { TestPath("01-pure-function", "src"), TestPath("01-pure-function", "test") },
             CaptureValues = true,
             OutputJson = true

--- a/AlRunner.Tests/DuplicatePackageTests.cs
+++ b/AlRunner.Tests/DuplicatePackageTests.cs
@@ -255,6 +255,7 @@ codeunit 73002 ""Overlap Tests""
             var pipeline = new AlRunnerPipeline();
             var result = pipeline.Run(new PipelineOptions
             {
+            TestIsolation = AlRunner.TestIsolation.Method,
                 InputPaths = { mainSrcDir, testSrcDir },
                 PackagePaths = { pkgDir },
                 Verbose = true

--- a/AlRunner.Tests/ErrorLineMappingTests.cs
+++ b/AlRunner.Tests/ErrorLineMappingTests.cs
@@ -19,6 +19,7 @@ public class ErrorLineMappingTests
         var pipeline = new AlRunnerPipeline();
         var result = pipeline.Run(new PipelineOptions
         {
+            TestIsolation = AlRunner.TestIsolation.Method,
             InputPaths = { TestPath("06-intentional-failure", "src"), TestPath("06-intentional-failure", "test") }
         });
 
@@ -35,6 +36,7 @@ public class ErrorLineMappingTests
         var pipeline = new AlRunnerPipeline();
         var result = pipeline.Run(new PipelineOptions
         {
+            TestIsolation = AlRunner.TestIsolation.Method,
             InputPaths = { TestPath("01-pure-function", "src"), TestPath("01-pure-function", "test") }
         });
 
@@ -49,6 +51,7 @@ public class ErrorLineMappingTests
         var pipeline = new AlRunnerPipeline();
         var result = pipeline.Run(new PipelineOptions
         {
+            TestIsolation = AlRunner.TestIsolation.Method,
             InputPaths = { TestPath("06-intentional-failure", "src"), TestPath("06-intentional-failure", "test") },
             OutputJson = true
         });
@@ -66,6 +69,7 @@ public class ErrorLineMappingTests
         var pipeline = new AlRunnerPipeline();
         var result = pipeline.Run(new PipelineOptions
         {
+            TestIsolation = AlRunner.TestIsolation.Method,
             InputPaths = { TestPath("06-intentional-failure", "src"), TestPath("06-intentional-failure", "test") }
         });
 
@@ -83,6 +87,7 @@ public class ErrorLineMappingTests
         var pipeline = new AlRunnerPipeline();
         var result = pipeline.Run(new PipelineOptions
         {
+            TestIsolation = AlRunner.TestIsolation.Method,
             InputPaths = { TestPath("06-intentional-failure", "src"), TestPath("06-intentional-failure", "test") },
             OutputJson = true
         });

--- a/AlRunner.Tests/InlineCaptureTests.cs
+++ b/AlRunner.Tests/InlineCaptureTests.cs
@@ -22,6 +22,7 @@ public class InlineCaptureTests
         var pipeline = new AlRunnerPipeline();
         var result = pipeline.Run(new PipelineOptions
         {
+            TestIsolation = AlRunner.TestIsolation.Method,
             InputPaths = { TestPath("47-capture-inline", "src"), TestPath("47-capture-inline", "test") },
             CaptureValues = true
         });
@@ -55,6 +56,7 @@ public class InlineCaptureTests
         var pipeline = new AlRunnerPipeline();
         var result = pipeline.Run(new PipelineOptions
         {
+            TestIsolation = AlRunner.TestIsolation.Method,
             InputPaths = { TestPath("47-capture-inline", "src"), TestPath("47-capture-inline", "test") },
             CaptureValues = true,
             OutputJson = true
@@ -77,6 +79,7 @@ public class InlineCaptureTests
         var pipeline = new AlRunnerPipeline();
         var result = pipeline.Run(new PipelineOptions
         {
+            TestIsolation = AlRunner.TestIsolation.Method,
             InputPaths = { TestPath("47-capture-inline", "src"), TestPath("47-capture-inline", "test") },
             CaptureValues = true,
             OutputJson = true

--- a/AlRunner.Tests/JUnitOutputTests.cs
+++ b/AlRunner.Tests/JUnitOutputTests.cs
@@ -222,6 +222,7 @@ public class JUnitOutputTests
             var pipeline = new AlRunnerPipeline();
             var result = pipeline.Run(new PipelineOptions
             {
+            TestIsolation = AlRunner.TestIsolation.Method,
                 InputPaths = { TestPath("01-pure-function", "src"), TestPath("01-pure-function", "test") },
                 OutputJunitPath = junitPath
             });
@@ -259,6 +260,7 @@ public class JUnitOutputTests
             var pipeline = new AlRunnerPipeline();
             pipeline.Run(new PipelineOptions
             {
+            TestIsolation = AlRunner.TestIsolation.Method,
                 OutputJunitPath = junitPath
                 // no InputPaths — triggers "no AL source" early exit
             });

--- a/AlRunner.Tests/JsonOutputTests.cs
+++ b/AlRunner.Tests/JsonOutputTests.cs
@@ -116,6 +116,7 @@ public class JsonOutputTests
         var pipeline = new AlRunnerPipeline();
         var result = pipeline.Run(new PipelineOptions
         {
+            TestIsolation = AlRunner.TestIsolation.Method,
             InputPaths = { TestPath("84-json-compilation-error", "src"), TestPath("84-json-compilation-error", "test") },
             OutputJson = true
         });
@@ -138,6 +139,7 @@ public class JsonOutputTests
         var pipeline = new AlRunnerPipeline();
         var result = pipeline.Run(new PipelineOptions
         {
+            TestIsolation = AlRunner.TestIsolation.Method,
             InputPaths = { TestPath("84-json-compilation-error", "src"), TestPath("84-json-compilation-error", "test") },
             OutputJson = true
         });

--- a/AlRunner.Tests/MissingDepHintTests.cs
+++ b/AlRunner.Tests/MissingDepHintTests.cs
@@ -22,6 +22,7 @@ public class MissingDepHintTests
         var pipeline = new AlRunnerPipeline();
         var result = pipeline.Run(new PipelineOptions
         {
+            TestIsolation = AlRunner.TestIsolation.Method,
             StubPaths = { TestPath("46-missing-dep-hint", "stubs") },
             InputPaths = { TestPath("46-missing-dep-hint", "src") }
         });
@@ -42,6 +43,7 @@ public class MissingDepHintTests
         var pipeline = new AlRunnerPipeline();
         var result = pipeline.Run(new PipelineOptions
         {
+            TestIsolation = AlRunner.TestIsolation.Method,
             InputPaths = { TestPath("46-missing-dep-hint", "src") }
         });
 

--- a/AlRunner.Tests/NavValueToStringPerfTests.cs
+++ b/AlRunner.Tests/NavValueToStringPerfTests.cs
@@ -28,6 +28,7 @@ public class NavValueToStringPerfTests
         var warm = new AlRunnerPipeline();
         warm.Run(new PipelineOptions
         {
+            TestIsolation = AlRunner.TestIsolation.Method,
             InputPaths =
             {
                 TestPath("52-setfilter-and", "src"),
@@ -44,6 +45,7 @@ public class NavValueToStringPerfTests
         var sw = Stopwatch.StartNew();
         var result = pipeline.Run(new PipelineOptions
         {
+            TestIsolation = AlRunner.TestIsolation.Method,
             InputPaths =
             {
                 TestPath("52-setfilter-and", "src"),
@@ -84,6 +86,7 @@ public class NavValueToStringPerfTests
         var pipeline = new AlRunnerPipeline();
         var result = pipeline.Run(new PipelineOptions
         {
+            TestIsolation = AlRunner.TestIsolation.Method,
             InputPaths =
             {
                 TestPath("52-setfilter-and", "src"),

--- a/AlRunner.Tests/PipelineTests.cs
+++ b/AlRunner.Tests/PipelineTests.cs
@@ -19,6 +19,7 @@ public class PipelineTests
         var pipeline = new AlRunnerPipeline();
         var result = pipeline.Run(new PipelineOptions
         {
+            TestIsolation = AlRunner.TestIsolation.Method,
             InputPaths = { TestPath("01-pure-function", "src"), TestPath("01-pure-function", "test") }
         });
 
@@ -31,6 +32,7 @@ public class PipelineTests
         var pipeline = new AlRunnerPipeline();
         var result = pipeline.Run(new PipelineOptions
         {
+            TestIsolation = AlRunner.TestIsolation.Method,
             InputPaths = { TestPath("06-intentional-failure", "src"), TestPath("06-intentional-failure", "test") }
         });
 
@@ -53,6 +55,7 @@ public class PipelineTests
         var pipeline = new AlRunnerPipeline();
         var result = pipeline.Run(new PipelineOptions
         {
+            TestIsolation = AlRunner.TestIsolation.Method,
             InputPaths = { "/nonexistent/path" }
         });
 
@@ -66,6 +69,7 @@ public class PipelineTests
         var pipeline = new AlRunnerPipeline();
         var result = pipeline.Run(new PipelineOptions
         {
+            TestIsolation = AlRunner.TestIsolation.Method,
             InlineCode = "Message('hello');"
         });
 
@@ -78,6 +82,7 @@ public class PipelineTests
         var pipeline = new AlRunnerPipeline();
         var result = pipeline.Run(new PipelineOptions
         {
+            TestIsolation = AlRunner.TestIsolation.Method,
             InputPaths = { TestPath("02-record-operations", "src"), TestPath("02-record-operations", "test") }
         });
 
@@ -90,6 +95,7 @@ public class PipelineTests
         var pipeline = new AlRunnerPipeline();
         var result = pipeline.Run(new PipelineOptions
         {
+            TestIsolation = AlRunner.TestIsolation.Method,
             InputPaths = { TestPath("03-interface-injection", "src"), TestPath("03-interface-injection", "test") }
         });
 
@@ -102,6 +108,7 @@ public class PipelineTests
         var pipeline = new AlRunnerPipeline();
         var result = pipeline.Run(new PipelineOptions
         {
+            TestIsolation = AlRunner.TestIsolation.Method,
             InputPaths = { TestPath("01-pure-function", "src") },
             DumpCSharp = true
         });
@@ -115,6 +122,7 @@ public class PipelineTests
         var pipeline = new AlRunnerPipeline();
         var result = pipeline.Run(new PipelineOptions
         {
+            TestIsolation = AlRunner.TestIsolation.Method,
             InputPaths = { TestPath("01-pure-function", "src") },
             DumpRewritten = true
         });
@@ -130,6 +138,7 @@ public class PipelineTests
         var pipeline = new AlRunnerPipeline();
         var result = pipeline.Run(new PipelineOptions
         {
+            TestIsolation = AlRunner.TestIsolation.Method,
             InputPaths = { TestPath("01-pure-function", "src"), TestPath("01-pure-function", "test") }
         });
 
@@ -151,6 +160,7 @@ public class PipelineTests
         var pipeline = new AlRunnerPipeline();
         var result = pipeline.Run(new PipelineOptions
         {
+            TestIsolation = AlRunner.TestIsolation.Method,
             InputPaths = { TestPath("06-intentional-failure", "src"), TestPath("06-intentional-failure", "test") }
         });
 
@@ -168,6 +178,7 @@ public class PipelineTests
         var pipeline = new AlRunnerPipeline();
         var result = pipeline.Run(new PipelineOptions
         {
+            TestIsolation = AlRunner.TestIsolation.Method,
             InputPaths = { TestPath("01-pure-function", "src"), TestPath("01-pure-function", "test") },
             OutputJson = true
         });
@@ -206,6 +217,7 @@ public class PipelineTests
         var pipeline = new AlRunnerPipeline();
         var result = pipeline.Run(new PipelineOptions
         {
+            TestIsolation = AlRunner.TestIsolation.Method,
             InputPaths = { TestPath("06-intentional-failure", "src"), TestPath("06-intentional-failure", "test") },
             OutputJson = true
         });
@@ -278,6 +290,7 @@ namespace AlRunnerGenerated {
         var pipeline = new AlRunnerPipeline();
         var result = pipeline.Run(new PipelineOptions
         {
+            TestIsolation = AlRunner.TestIsolation.Method,
             InputPaths = { TestPath("67-iteration-tracking", "src"), TestPath("67-iteration-tracking", "test") },
             OutputJson = true,
             IterationTracking = true,
@@ -306,6 +319,7 @@ namespace AlRunnerGenerated {
         var pipeline = new AlRunnerPipeline();
         var result = pipeline.Run(new PipelineOptions
         {
+            TestIsolation = AlRunner.TestIsolation.Method,
             InputPaths = { TestPath("01-pure-function", "src"), TestPath("01-pure-function", "test") }
         });
 
@@ -322,6 +336,7 @@ namespace AlRunnerGenerated {
         var pipeline = new AlRunnerPipeline();
         var result = pipeline.Run(new PipelineOptions
         {
+            TestIsolation = AlRunner.TestIsolation.Method,
             InputPaths = { TestPath("06-intentional-failure", "src"), TestPath("06-intentional-failure", "test") }
         });
 
@@ -396,6 +411,7 @@ namespace AlRunnerGenerated {
         var pipeline = new AlRunnerPipeline();
         var result = pipeline.Run(new PipelineOptions
         {
+            TestIsolation = AlRunner.TestIsolation.Method,
             InputPaths = { TestPath("112-report-dataset-columns", "src"),
                            TestPath("112-report-dataset-columns", "test") }
         });
@@ -412,6 +428,7 @@ namespace AlRunnerGenerated {
         var pipeline = new AlRunnerPipeline();
         var result = pipeline.Run(new PipelineOptions
         {
+            TestIsolation = AlRunner.TestIsolation.Method,
             InputPaths = { TestPath("112-report-dataset-columns", "src"),
                            TestPath("112-report-dataset-columns", "test") }
         });
@@ -431,6 +448,7 @@ namespace AlRunnerGenerated {
         var pipeline = new AlRunnerPipeline();
         var result = pipeline.Run(new PipelineOptions
         {
+            TestIsolation = AlRunner.TestIsolation.Method,
             InputPaths =
             {
                 Path.Combine(testCase, "appA"),
@@ -454,6 +472,7 @@ namespace AlRunnerGenerated {
         var pipeline = new AlRunnerPipeline();
         var result = pipeline.Run(new PipelineOptions
         {
+            TestIsolation = AlRunner.TestIsolation.Method,
             InputPaths =
             {
                 Path.Combine(testCase, "appA"),
@@ -479,6 +498,7 @@ namespace AlRunnerGenerated {
         var pipeline = new AlRunnerPipeline();
         var result = pipeline.Run(new PipelineOptions
         {
+            TestIsolation = AlRunner.TestIsolation.Method,
             InputPaths =
             {
                 Path.Combine(testCase, "src"),
@@ -499,6 +519,7 @@ namespace AlRunnerGenerated {
         var pipeline = new AlRunnerPipeline();
         var result = pipeline.Run(new PipelineOptions
         {
+            TestIsolation = AlRunner.TestIsolation.Method,
             InputPaths = { TestPath("45-userid", "test") }
         });
         Assert.Equal(0, result.ExitCode);
@@ -512,6 +533,7 @@ namespace AlRunnerGenerated {
         var pipeline = new AlRunnerPipeline();
         var result = pipeline.Run(new PipelineOptions
         {
+            TestIsolation = AlRunner.TestIsolation.Method,
             UserId = "TESTUSER123",
             InlineCode = "if UserId() <> 'TESTUSER123' then error('UserId() returned wrong value: ' + UserId());"
         });
@@ -527,6 +549,7 @@ namespace AlRunnerGenerated {
         var dumpPipeline = new AlRunnerPipeline();
         var dumpResult = dumpPipeline.Run(new PipelineOptions
         {
+            TestIsolation = AlRunner.TestIsolation.Method,
             DumpCSharp = true,
             InlineCode = "if SessionId() <= 0 then error('fail');"
         });
@@ -534,6 +557,7 @@ namespace AlRunnerGenerated {
         var pipeline = new AlRunnerPipeline();
         var result = pipeline.Run(new PipelineOptions
         {
+            TestIsolation = AlRunner.TestIsolation.Method,
             InlineCode = "if SessionId() <= 0 then error('SessionId() must return a positive integer');"
         });
         Assert.True(result.ExitCode == 0,
@@ -546,6 +570,7 @@ namespace AlRunnerGenerated {
         var pipeline = new AlRunnerPipeline();
         var result = pipeline.Run(new PipelineOptions
         {
+            TestIsolation = AlRunner.TestIsolation.Method,
             InputPaths = { TestPath("47-initvalue", "src"), TestPath("47-initvalue", "test") }
         });
         Assert.Equal(0, result.ExitCode);
@@ -559,6 +584,7 @@ namespace AlRunnerGenerated {
         var pipeline = new AlRunnerPipeline();
         var result = pipeline.Run(new PipelineOptions
         {
+            TestIsolation = AlRunner.TestIsolation.Method,
             InputPaths = { TestPath("48-record-get", "src"), TestPath("48-record-get", "test") }
         });
         Assert.Equal(0, result.ExitCode);
@@ -572,6 +598,7 @@ namespace AlRunnerGenerated {
         var pipeline = new AlRunnerPipeline();
         var result = pipeline.Run(new PipelineOptions
         {
+            TestIsolation = AlRunner.TestIsolation.Method,
             InputPaths = { TestPath("49-var-attributes", "src"), TestPath("49-var-attributes", "test") }
         });
         Assert.Equal(0, result.ExitCode);
@@ -703,6 +730,7 @@ namespace AlRunnerGenerated {
         var pipeline = new AlRunnerPipeline();
         var result = pipeline.Run(new PipelineOptions
         {
+            TestIsolation = AlRunner.TestIsolation.Method,
             // Supply two objects: a source codeunit (first) + a test codeunit (second).
             InputPaths = { TestPath("01-pure-function", "src"), TestPath("01-pure-function", "test") },
             // Throw only for the src codeunit (Calculator). The test codeunit must

--- a/AlRunner.Tests/RunnerErrorClassificationTests.cs
+++ b/AlRunner.Tests/RunnerErrorClassificationTests.cs
@@ -107,6 +107,7 @@ public class RunnerErrorClassificationTests
         var pipeline = new AlRunnerPipeline();
         var result = pipeline.Run(new PipelineOptions
         {
+            TestIsolation = AlRunner.TestIsolation.Method,
             InputPaths = { TestPath("06-intentional-failure", "src"), TestPath("06-intentional-failure", "test") }
         });
 
@@ -126,6 +127,7 @@ public class RunnerErrorClassificationTests
         var pipeline = new AlRunnerPipeline();
         var result = pipeline.Run(new PipelineOptions
         {
+            TestIsolation = AlRunner.TestIsolation.Method,
             InputPaths = { TestPath("01-pure-function", "src"), TestPath("01-pure-function", "test") }
         });
 
@@ -342,6 +344,7 @@ public class RunnerErrorClassificationTests
         var pipeline = new AlRunnerPipeline();
         var result = pipeline.Run(new PipelineOptions
         {
+            TestIsolation = AlRunner.TestIsolation.Method,
             InputPaths = { TestPath("06-intentional-failure", "src"), TestPath("06-intentional-failure", "test") }
         });
 
@@ -758,6 +761,7 @@ public class RunnerErrorClassificationTests
         // Inject a rewriter that throws unconditionally — simulates a rewriter gap
         var result = pipeline.Run(new PipelineOptions
         {
+            TestIsolation = AlRunner.TestIsolation.Method,
             InlineCode = "Message('hello');",
             RewriterFactory = _ => throw new InvalidOperationException("simulated rewriter gap")
         });
@@ -788,6 +792,7 @@ public class RunnerErrorClassificationTests
         // broken C# — simulates a rewriter gap that slips through to the Roslyn step.
         var result = pipeline.Run(new PipelineOptions
         {
+            TestIsolation = AlRunner.TestIsolation.Method,
             InlineCode = "Message('hello');",
             RewriterFactory = _ =>
                 Microsoft.CodeAnalysis.CSharp.CSharpSyntaxTree.ParseText(
@@ -817,6 +822,7 @@ public class RunnerErrorClassificationTests
         var pipeline = new AlRunnerPipeline();
         var result = pipeline.Run(new PipelineOptions
         {
+            TestIsolation = AlRunner.TestIsolation.Method,
             InputPaths =
             {
                 TestPath("06-intentional-failure", "src"),
@@ -906,6 +912,7 @@ public class RunnerErrorClassificationTests
         var pipeline = new AlRunnerPipeline();
         var result = pipeline.Run(new PipelineOptions
         {
+            TestIsolation = AlRunner.TestIsolation.Method,
             InlineCode = "Message('hello');",
             Strict = true,
             RewriterFactory = _ => throw new InvalidOperationException("simulated rewriter gap")
@@ -921,6 +928,7 @@ public class RunnerErrorClassificationTests
         var pipeline = new AlRunnerPipeline();
         var result = pipeline.Run(new PipelineOptions
         {
+            TestIsolation = AlRunner.TestIsolation.Method,
             InlineCode = "Message('hello');",
             Strict = true,
             RewriterFactory = _ =>
@@ -938,6 +946,7 @@ public class RunnerErrorClassificationTests
         var pipeline = new AlRunnerPipeline();
         var result = pipeline.Run(new PipelineOptions
         {
+            TestIsolation = AlRunner.TestIsolation.Method,
             InlineCode = "Message('hello');",
             Strict = false,
             RewriterFactory = _ => throw new InvalidOperationException("simulated rewriter gap")

--- a/AlRunner.Tests/SingleProcedureTests.cs
+++ b/AlRunner.Tests/SingleProcedureTests.cs
@@ -19,6 +19,7 @@ public class SingleProcedureTests
         var pipeline = new AlRunnerPipeline();
         var result = pipeline.Run(new PipelineOptions
         {
+            TestIsolation = AlRunner.TestIsolation.Method,
             InputPaths = { TestPath("01-pure-function", "src"), TestPath("01-pure-function", "test") },
             RunProcedure = "TestCalculateVAT"
         });
@@ -35,6 +36,7 @@ public class SingleProcedureTests
         var pipeline = new AlRunnerPipeline();
         var result = pipeline.Run(new PipelineOptions
         {
+            TestIsolation = AlRunner.TestIsolation.Method,
             InputPaths = { TestPath("01-pure-function", "src"), TestPath("01-pure-function", "test") },
             RunProcedure = "NonexistentProcedure"
         });
@@ -49,6 +51,7 @@ public class SingleProcedureTests
         var pipeline = new AlRunnerPipeline();
         var result = pipeline.Run(new PipelineOptions
         {
+            TestIsolation = AlRunner.TestIsolation.Method,
             InputPaths = { TestPath("06-intentional-failure", "src"), TestPath("06-intentional-failure", "test") },
             RunProcedure = "TestGreet_WrongExpectedValue"
         });

--- a/AlRunner/Pipeline.cs
+++ b/AlRunner/Pipeline.cs
@@ -43,7 +43,7 @@ public class PipelineOptions
     /// methods share table state (BC's default TestIsolation::Codeunit behaviour).
     /// Method — reset before every individual test method (the previous runner default).
     /// </summary>
-    public TestIsolation TestIsolation { get; set; } = TestIsolation.Method;
+    public TestIsolation TestIsolation { get; set; } = TestIsolation.Codeunit;
 
     /// <summary>Directories containing pre-compiled dependency DLLs (rewritten C# with mock types).</summary>
     public List<string> DepDllPaths { get; set; } = new();

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -2730,7 +2730,7 @@ public static class Executor
                     if (r.Message != null) Console.WriteLine($"      {r.Message}");
                     if (LooksLikeFrameworkVersionMismatch(r.Message))
                         Console.WriteLine($"      ℹ This BC version requires a newer .NET runtime. Install .NET 10: https://dotnet.microsoft.com/download/dotnet/10.0");
-                    if (r.StackTrace != null) Console.Write(r.StackTrace);
+                    if (r.StackTrace != null) PrintFilteredStackTrace(r.StackTrace);
                     break;
                 case AlRunner.TestStatus.Error:
                     if (!verbose && r.Message != null && dedupMessages.Contains(r.Message))
@@ -2747,7 +2747,7 @@ public static class Executor
                             Console.WriteLine($"      ⚑ Runner limitation — update al-runner or file an issue at https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues");
                         else
                             Console.WriteLine($"      Inject this dependency via an AL interface.");
-                        if (r.StackTrace != null) Console.Write(r.StackTrace);
+                        if (r.StackTrace != null) PrintFilteredStackTrace(r.StackTrace);
                     }
                     break;
             }
@@ -2937,6 +2937,40 @@ public static class Executor
     /// <summary>
     /// Returns true when a test result message looks like a .NET framework assembly
     /// version mismatch — e.g. BC 28 DLLs requesting System.Text.Json 10.0 on .NET 8.
+    /// <summary>
+    /// Print a filtered stack trace that shows AL-relevant frames instead of
+    /// the full C# stack. Strips internal AlRunner frames and highlights the
+    /// AL object (Codeunit/Record/Page) that caused the error.
+    /// </summary>
+    private static void PrintFilteredStackTrace(string stackTrace)
+    {
+        var lines = stackTrace.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+        var printed = 0;
+        foreach (var raw in lines)
+        {
+            var line = raw.Trim();
+            if (string.IsNullOrEmpty(line)) continue;
+            // Skip internal runtime frames — keep only AL-generated code and Assert frames
+            if (line.Contains("AlRunner.Runtime.") && !line.Contains("MockAssert"))
+                continue;
+            if (line.Contains("System.Reflection."))
+                continue;
+            if (line.Contains("System.RuntimeMethodHandle."))
+                continue;
+            if (printed < 5)
+            {
+                Console.WriteLine($"      {FormatSingleFrame(line)}");
+                printed++;
+            }
+        }
+        if (printed == 0 && lines.Length > 0)
+        {
+            // Fallback: print first few raw lines if nothing matched
+            foreach (var line in lines.Take(3))
+                Console.WriteLine($"      {line.Trim()}");
+        }
+    }
+
     /// Used to print actionable guidance; does NOT change error classification.
     /// </summary>
     public static bool LooksLikeFrameworkVersionMismatch(string? message)
@@ -2964,13 +2998,65 @@ public static class Executor
 
     private static string? FormatStackFrames(Exception ex)
     {
-        var frames = ex.StackTrace?.Split('\n')
+        var allFrames = ex.StackTrace?.Split('\n')
             .Select(f => f.Trim())
             .Where(f => !string.IsNullOrEmpty(f))
+            .ToList();
+        if (allFrames == null || allFrames.Count == 0) return null;
+
+        // Prefer AL-generated frames (BusinessApplication namespace) over runtime internals
+        var alFrames = allFrames
+            .Where(f => f.Contains("BusinessApplication.") || f.Contains("MockAssert"))
             .Take(3)
             .ToList();
-        if (frames == null || frames.Count == 0) return null;
-        return string.Join("\n", frames.Select(f => $"      {f}")) + "\n";
+
+        var frames = alFrames.Count > 0 ? alFrames : allFrames.Take(3).ToList();
+        return string.Join("\n", frames.Select(f => $"      {FormatSingleFrame(f)}")) + "\n";
+    }
+
+    /// <summary>
+    /// Format a single stack frame for AL-level readability:
+    /// - Strip C# namespace prefix
+    /// - Replace CodeunitNNNNN with Codeunit "Name" (via CodeunitNameRegistry)
+    /// - Replace RecordNNNNN with Record "Name" (via TableFieldRegistry)
+    /// - Strip _Scope_ suffixes
+    /// </summary>
+    private static string FormatSingleFrame(string frame)
+    {
+        var clean = frame.Replace("at Microsoft.Dynamics.Nav.BusinessApplication.", "at ");
+
+        // Resolve Codeunit IDs to names: Codeunit72336722 → Codeunit "EventSubsCABQR"
+        clean = System.Text.RegularExpressions.Regex.Replace(clean, @"Codeunit(\d+)", m =>
+        {
+            if (int.TryParse(m.Groups[1].Value, out var id))
+            {
+                var name = AlRunner.Runtime.CodeunitNameRegistry.GetNameById(id);
+                if (name != null) return $"Codeunit \"{name}\"";
+            }
+            return m.Value;
+        });
+
+        // Resolve Record IDs to names: Record72336618 → Record "Payment Request"
+        clean = System.Text.RegularExpressions.Regex.Replace(clean, @"Record(\d+)", m =>
+        {
+            if (int.TryParse(m.Groups[1].Value, out var id))
+            {
+                var name = AlRunner.Runtime.TableFieldRegistry.GetTableName(id);
+                if (name != null) return $"Record \"{name}\"";
+            }
+            return m.Value;
+        });
+
+        // Strip _Scope_ suffixes for readability
+        var scopeIdx = clean.IndexOf("_Scope_");
+        if (scopeIdx > 0 && clean.StartsWith("at "))
+        {
+            var dotIdx = clean.LastIndexOf('.', scopeIdx);
+            if (dotIdx > 3)
+                clean = "at " + clean.Substring(3, dotIdx - 3);
+        }
+
+        return clean;
     }
 
     public static int RunOnRun(Assembly assembly, bool captureValues = false)

--- a/AlRunner/Runtime/AlScope.cs
+++ b/AlRunner/Runtime/AlScope.cs
@@ -552,6 +552,12 @@ public static class AlDialog
 
     public static void Error(string format, params object?[] args)
     {
+        // In BC, Error('') performs a silent transaction rollback without
+        // showing an error message. It's used as a cancel pattern (e.g. when
+        // a Confirm dialog returns false). In standalone mode we can't roll
+        // back, but we should not propagate it as a test failure.
+        if (string.IsNullOrEmpty(format)) return;
+
         var netFormat = ConvertAlFormat(format);
         var stringArgs = args.Select(a => AlCompat.Format(a)).ToArray();
         if (stringArgs.Length > 0)

--- a/AlRunner/Runtime/CodeunitNameRegistry.cs
+++ b/AlRunner/Runtime/CodeunitNameRegistry.cs
@@ -15,8 +15,9 @@ public static class CodeunitNameRegistry
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
     private static readonly Dictionary<string, int> _nameToId = new(StringComparer.OrdinalIgnoreCase);
+    private static readonly Dictionary<int, string> _idToName = new();
 
-    public static void Clear() => _nameToId.Clear();
+    public static void Clear() { _nameToId.Clear(); _idToName.Clear(); }
 
     public static void ParseAndRegister(string alSource)
     {
@@ -25,11 +26,17 @@ public static class CodeunitNameRegistry
             if (!int.TryParse(m.Groups[1].Value, out var id)) continue;
             var name = m.Groups[2].Success ? m.Groups[2].Value : m.Groups[3].Value;
             _nameToId[name] = id;
+            _idToName[id] = name;
         }
     }
 
     public static int? GetIdByName(string codeunitName)
     {
         return _nameToId.TryGetValue(codeunitName, out var id) ? id : null;
+    }
+
+    public static string? GetNameById(int codeunitId)
+    {
+        return _idToName.TryGetValue(codeunitId, out var name) ? name : null;
     }
 }


### PR DESCRIPTION
## Summary

Three improvements:

### 1. Default test isolation → codeunit
Changes default from `method` to `codeunit` to match BC's default behavior. CI already passes `--test-isolation method` explicitly so the test suite is unaffected.

### 2. Enriched empty subscriber errors
Before:
```
FAIL  TestUpdateNoOfLicensedUsersWithTenUsersWithLicense
      
      at AlRunner.Runtime.AlCompat.InvokeSubscriber(...)
```

After:
```
FAIL  TestUpdateNoOfLicensedUsersWithTenUsersWithLicense
      Event subscriber 'Codeunit72336722.OnAfterInsert_UserLicenseAssignment' raised an error (empty message). 
      This typically means an Error('') call in the subscriber — check if a ConfirmHandler is needed.
```

### 3. Filtered stack traces
Before: walls of `AlRunner.Runtime.*` C# frames
After: AL-level frames like `at Codeunit50014.CreateTestUsers(Int32 numberOfUsers)`

## Test plan
- [x] Cash365: 81/68/11/4 (unchanged, much more readable output)
- [x] CI uses `--test-isolation method` explicitly — not affected by default change