### PR TITLE
fix: actionable error messages for missing codeunit methods + auto-stub tip

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,1 @@
-{"sessionId":"4a9dea4e-68bd-4ff6-8eb3-9c8c47457a8b","pid":3678960,"acquiredAt":1776352607730}
+{"sessionId":"7ed5dff8-7519-4890-88c3-aa9f610e5ac8","pid":40172,"acquiredAt":1776874034194}

--- a/AlRunner/Pipeline.cs
+++ b/AlRunner/Pipeline.cs
@@ -692,12 +692,18 @@ public class AlRunnerPipeline
         // This allows MockCodeunitHandle.FindCodeunitType to find them at runtime and
         // execute as no-ops (no OnRun method → InvokeOnRun silently returns) instead of
         // throwing InvalidOperationException.
+        // Auto-stub test-toolkit codeunits (130000-139999) as empty classes so
+        // they compile. Methods on these stubs will be no-ops (return defaults).
+        // For proper method implementations, users should run:
+        //   al-runner --generate-stubs .alpackages ./stubs ./src ./test
         var testToolkitStubs = GenerateTestToolkitStubs(generatedCSharpList);
         if (testToolkitStubs.Count > 0)
         {
             rewrittenTreeList.AddRange(testToolkitStubs);
-            stderr.WriteLine($"Auto-stubbed {testToolkitStubs.Count} dependency codeunit(s) as no-ops");
+            stderr.WriteLine($"Auto-stubbed {testToolkitStubs.Count} dependency codeunit(s) — methods return defaults");
+            stderr.WriteLine($"  Tip: for proper stubs run: al-runner --generate-stubs .alpackages ./stubs ./src ./test");
             Log.Info($"  IDs: {string.Join(", ", testToolkitStubs.Select(s => s.Name))}");
+
         }
 
         // Step 3: Compile

--- a/AlRunner/Runtime/MockCodeunitHandle.cs
+++ b/AlRunner/Runtime/MockCodeunitHandle.cs
@@ -321,8 +321,13 @@ public class MockCodeunitHandle
             return bestMethod.Invoke(_codeunitInstance, convertedArgs);
         }
 
+        var cuName = CodeunitNameRegistry.GetNameById(_codeunitId);
+        var displayName = cuName != null ? $"codeunit {_codeunitId} \"{cuName}\"" : $"codeunit {_codeunitId}";
         throw new InvalidOperationException(
-            $"Method with member ID {memberId} not found in codeunit {_codeunitId}");
+            $"Method with member ID {memberId} not found in {displayName}\n" +
+            $"Tip: generate stubs with real method signatures:\n" +
+            $"  al-runner --generate-stubs .alpackages ./stubs ./src ./test\n" +
+            $"Then run with: al-runner --stubs ./stubs ./src ./test");
     }
 
     /// <summary>
@@ -856,8 +861,9 @@ public class MockCodeunitHandle
         else if (available.Count > 20)
             msg += $" {available.Count} codeunits available in assembly (use --dump-rewritten to inspect).";
 
-        msg += " Hint: include the codeunit's AL source in your source paths,"
-             + " use --stubs to provide a stub, or use --generate-stubs to auto-scaffold stubs from .app packages.";
+        msg += "\nTo fix: generate stubs from your .app packages:\n"
+             + "  al-runner --generate-stubs .alpackages ./stubs ./src ./test\n"
+             + "Then run with: al-runner --stubs ./stubs ./src ./test";
 
         return msg;
     }


### PR DESCRIPTION
## Summary

Better guidance when a method is not found on a dependency codeunit:

**Before:**
```
Method with member ID 1593999805 not found in codeunit 131300
⚑ Runner limitation
```

**After:**
```
Method with member ID 1593999805 not found in codeunit 131300 "Library - ERM"
Tip: generate stubs with real method signatures:
  al-runner --generate-stubs .alpackages ./stubs ./src ./test
Then run with: al-runner --stubs ./stubs ./src ./test
```

Also prints auto-stub summary to stderr:
```
Auto-stubbed 8 dependency codeunit(s) — methods return defaults
  Tip: for proper stubs run: al-runner --generate-stubs .alpackages ./stubs ./src ./test
```

## Test plan
- [x] Cash365: 105 passed (with SingleInstance from #1146)
- [x] Error messages show codeunit name + actionable command