### PR TITLE
fix: skip all built-in stub IDs in --generate-stubs and auto-stub

### DIFF
--- a/AlRunner/Pipeline.cs
+++ b/AlRunner/Pipeline.cs
@@ -1351,7 +1351,7 @@ public class AlRunnerPipeline
         // Codeunits that have dedicated runner-native mock implementations and are
         // dispatched via InvokeAssert / InvokeVariableStorage / InvokeRunnerConfig
         // before FindCodeunitType is ever consulted — never need a stub class.
-        var nativeMockIds = new HashSet<int> { 130, 131, 130000, 131004, 131100 };
+        var nativeMockIds = new HashSet<int> { 130, 131, 130000, 130002, 130440, 130500, 131004, 131100, 132250 };
 
         // Scan all generated C# for test-toolkit ID literals that appear as the
         // codeunit ID argument in a RunCodeunit / NavCodeunitHandle call.

--- a/AlRunner/StubGenerator.cs
+++ b/AlRunner/StubGenerator.cs
@@ -12,7 +12,18 @@ namespace AlRunner;
 public static class StubGenerator
 {
     /// <summary>Codeunit IDs that al-runner already mocks natively — skip these.</summary>
-    private static readonly HashSet<int> SkipIds = new() { 130, 131004 };
+    private static readonly HashSet<int> SkipIds = new()
+    {
+        130,     // Assert (LibraryAssert.al)
+        131,     // Library Assert alias (Assert.al)
+        130000,  // Assert BaseApp (routed to MockAssert)
+        130002,  // Library Assert real BC ID (routed to MockAssert)
+        130440,  // Library - Random (LibraryRandom.al)
+        130500,  // Any (LibraryAny.al)
+        131004,  // Library - Variable Storage (LibraryVariableStorage.al)
+        131100,  // AL Runner Config
+        132250,  // Library - Test Initialize (LibraryTestInitialize.al)
+    };
 
     public record GenerateResult(
         int Generated,


### PR DESCRIPTION
## Summary

`--generate-stubs` was creating stubs for codeunits that already have built-in AL stubs (Library - Random, Any, etc.), causing CS0229 ambiguity errors when both the built-in and generated stubs compiled to the same C# class name.

Updated SkipIds to include all 9 built-in stub IDs: 130, 131, 130000, 130002, 130440, 130500, 131004, 131100, 132250.

## Test plan
- [x] Cash365 without stubs: 105 passed (unchanged)
- [x] Cash365 with `--stubs`: 105 passed, 0 blocked (was 11 blocked) — stubs unblock previously-blocked tests
- [x] No CS0229 ambiguity errors