### PR TITLE
feat: symbol-table auto-stubs, per-test timeout, MaxStrLen fix, enumextension dispatch — 1.0.19

### DIFF
--- a/.github/workflows/test-matrix.yml
+++ b/.github/workflows/test-matrix.yml
@@ -85,6 +85,28 @@ jobs:
             dotnet run --no-build --project AlRunner --framework net10.0 -- --strict --test-isolation method $args
           done
 
+      - name: Performance check — each bucket must complete within 60s
+        run: |
+          for bucket in tests/bucket-*/; do
+            args=""
+            for suite in "$bucket"*/; do
+              [ -d "${suite}src"  ] && args="$args ${suite}src"
+              for appdir in "${suite}"app*/; do
+                [ -d "$appdir" ] && args="$args $appdir"
+              done
+              [ -d "${suite}test" ] && args="$args ${suite}test"
+            done
+            echo "=== Timing: $bucket ==="
+            start=$SECONDS
+            dotnet run --no-build --project AlRunner --framework net10.0 -- --test-isolation method $args || true
+            elapsed=$(( SECONDS - start ))
+            echo "  Completed in ${elapsed}s"
+            if [ "$elapsed" -gt 60 ]; then
+              echo "::error::Performance regression: $bucket took ${elapsed}s (limit: 60s)"
+              exit 1
+            fi
+          done
+
       - name: Run stubs test
         run: |
           dotnet run --no-build --project AlRunner --framework net10.0 -- --stubs tests/stubs/39-stubs/stubs tests/stubs/39-stubs/src tests/stubs/39-stubs/test

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ lcov.info
 BenchmarkDotNet.Artifacts/
 publish-*/
 **/__pycache__/
+
+# Symbol probe tool (dev-only)
+SymbolProbe/

--- a/AlRunner/DepCompiler.cs
+++ b/AlRunner/DepCompiler.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using System.Xml.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 
@@ -44,7 +45,29 @@ public static class DepCompiler
 
         Console.Error.WriteLine($"Compiling dependency: {name} by {publisher} v{version}");
 
-        // 3. Extract AL sources from .app
+        // 3. Validate that all declared dependencies are available in packages
+        var missingDeps = ValidateDependencies(appPath, packagePaths);
+        if (missingDeps.Count > 0)
+        {
+            Console.Error.WriteLine($"  Cannot compile \"{name}\": {missingDeps.Count} required dependenc{(missingDeps.Count == 1 ? "y" : "ies")} not found in --packages:");
+            foreach (var dep in missingDeps)
+                Console.Error.WriteLine($"    ✗ \"{dep.Name}\" by {dep.Publisher} (>= {dep.MinVersion})");
+            if (packagePaths.Count > 0)
+            {
+                Console.Error.WriteLine($"  Package directories searched:");
+                foreach (var p in packagePaths)
+                    Console.Error.WriteLine($"    {p}");
+            }
+            else
+            {
+                Console.Error.WriteLine($"  No --packages directories specified.");
+            }
+            Console.Error.WriteLine($"  To fix: download the missing .app file(s) and add them to your packages directory,");
+            Console.Error.WriteLine($"  or add --packages pointing to where they live.");
+            return 1;
+        }
+
+        // 4. Extract AL sources from .app
         List<(string Name, string Source)> alEntries;
         try
         {
@@ -95,14 +118,95 @@ public static class DepCompiler
             }
         }
 
-        // 6. Transpile AL → C#
-        var csharpList = AlTranspiler.TranspileMulti(alSources, allPackagePaths.Count > 0 ? allPackagePaths : null, null);
+        // 6. Create a temp app.json so TranspileMulti can identify the app being
+        //    compiled and exclude it from package references (avoids self-duplicate
+        //    AL0275 errors and, crucially, prevents the .app's SymbolReference.json
+        //    from pulling in DotNet types that the source files may not need).
+        var appGuid = ReadAppGuid(appPath);
+        string? tempManifestDir = null;
+        List<string>? inputPaths = null;
+        if (appGuid != Guid.Empty)
+        {
+            tempManifestDir = Path.Combine(Path.GetTempPath(), $"alrunner-dep-{appGuid:N}");
+            Directory.CreateDirectory(tempManifestDir);
+            var manifest = $"{{\"id\":\"{appGuid}\",\"name\":\"{name}\",\"publisher\":\"{publisher}\",\"version\":\"{version}\"}}";
+            File.WriteAllText(Path.Combine(tempManifestDir, "app.json"), manifest);
+            inputPaths = new List<string> { tempManifestDir };
+        }
+
+        // 7. Transpile AL → C#
+        // The BC compiler refuses to emit ANY objects when unresolvable declaration
+        // errors exist (e.g. DotNet types, missing codeunits from other apps).
+        // DotNet types fundamentally don't work in the runner (no BC service tier),
+        // so excluding files that use them is correct, not a workaround.
+        //
+        // Strategy: try full compilation first. If zero output, iteratively remove
+        // files with unresolvable dependencies and retry until we get output.
+        var compilableSources = new List<string>(alSources);
+        var effectivePackages = allPackagePaths.Count > 0 ? allPackagePaths : null;
+        var csharpList = AlTranspiler.TranspileMulti(compilableSources, effectivePackages, inputPaths);
+
+        if ((csharpList == null || csharpList.Count == 0) && compilableSources.Count > 0)
+        {
+            // Phase 1: Remove files with DotNet type references (unsupported in runner).
+            // DotNet interop requires the BC service tier and .NET assembly loading —
+            // these types fundamentally cannot work in standalone mode.
+            // AL syntax: `var x: DotNet StreamReader;` or `DotNet "System.IO.StreamReader"`
+            var dotnetPattern = new System.Text.RegularExpressions.Regex(
+                @":\s*DotNet\b|\bDotNet\s+[""A-Z]",
+                System.Text.RegularExpressions.RegexOptions.Compiled);
+            var dotnetCount = compilableSources.Count(s => dotnetPattern.IsMatch(s));
+            if (dotnetCount > 0)
+            {
+                compilableSources = compilableSources.Where(s => !dotnetPattern.IsMatch(s)).ToList();
+                Console.Error.WriteLine($"  Excluded {dotnetCount} file(s) using DotNet interop (unsupported in runner)");
+
+                // Retry without DotNet files
+                csharpList = AlTranspiler.TranspileMulti(compilableSources, effectivePackages, inputPaths);
+            }
+        }
+
+        // Phase 2: If still failing after DotNet removal, report unresolved symbols clearly.
+        // All declared dependencies passed validation, so remaining failures indicate
+        // version mismatches or undeclared transitive dependencies.
+        if ((csharpList == null || csharpList.Count == 0) && compilableSources.Count > 0)
+        {
+            // Capture diagnostics to extract the specific unresolved symbols
+            var savedErr = Console.Error;
+            var diagCapture = new System.IO.StringWriter();
+            Console.SetError(diagCapture);
+            try { AlTranspiler.TranspileMulti(compilableSources, effectivePackages, inputPaths); }
+            finally { Console.SetError(savedErr); }
+
+            var diagOutput = diagCapture.ToString();
+            var missingPattern = new System.Text.RegularExpressions.Regex(
+                @"((?:Codeunit|Table|Page|Enum|Interface|Report|PermissionSet|DotNet)\s+'[^']+'\s+is missing)");
+            var missingSymbols = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (System.Text.RegularExpressions.Match m in missingPattern.Matches(diagOutput))
+                missingSymbols.Add(m.Groups[1].Value);
+
+            if (missingSymbols.Count > 0)
+            {
+                Console.Error.WriteLine($"  Compilation failed — {missingSymbols.Count} unresolved symbol(s):");
+                foreach (var sym in missingSymbols.OrderBy(s => s))
+                    Console.Error.WriteLine($"    ✗ {sym}");
+                Console.Error.WriteLine();
+                Console.Error.WriteLine("  These symbols come from .app packages not included in --packages.");
+                Console.Error.WriteLine("  To fix: find the .app file(s) that contain these objects and add them");
+                Console.Error.WriteLine("  to your packages directory, then retry.");
+            }
+        }
+
+        // Clean up temp manifest
+        if (tempManifestDir != null)
+            try { Directory.Delete(tempManifestDir, true); } catch { }
+
         if (csharpList == null || csharpList.Count == 0)
         {
             Console.Error.WriteLine($"  AL transpilation produced no output for {name}");
             return 1;
         }
-        Console.Error.WriteLine($"  Transpiled {csharpList.Count} C# objects");
+        Console.Error.WriteLine($"  Transpiled {csharpList.Count} C# objects (from {compilableSources.Count}/{alSources.Count} AL files)");
 
         // 7. Rewrite C# (BC types → mock types — same rewriter as main pipeline)
         var rewrittenTrees = new List<SyntaxTree>();
@@ -276,6 +380,24 @@ public static class DepCompiler
         return 0;
     }
 
+    private static Guid ReadAppGuid(string appPath)
+    {
+        try
+        {
+            var manifest = AlTranspiler.LoadNavxManifest(appPath);
+            if (manifest != null)
+            {
+                var ns = System.Xml.Linq.XNamespace.Get("http://schemas.microsoft.com/navx/2015/manifest");
+                var app = manifest.Root?.Element(ns + "App") ?? manifest.Root;
+                var idStr = app?.Attribute("Id")?.Value;
+                if (idStr != null && Guid.TryParse(idStr, out var id))
+                    return id;
+            }
+        }
+        catch { }
+        return Guid.Empty;
+    }
+
     private static (string Publisher, string Name, string Version) ReadAppIdentity(string appPath)
     {
         try
@@ -311,5 +433,57 @@ public static class DepCompiler
         // Clean to valid C# identifier
         var clean = new string(objectName.Where(c => char.IsLetterOrDigit(c) || c == '_').ToArray());
         return string.IsNullOrEmpty(clean) ? null : clean;
+    }
+
+    private record MissingDependency(string Publisher, string Name, string MinVersion, Guid AppId);
+
+    /// <summary>
+    /// Read the .app manifest's declared dependencies and check each against available packages.
+    /// Returns a list of dependencies that are NOT found in any package directory.
+    /// </summary>
+    private static List<MissingDependency> ValidateDependencies(string appPath, List<string> packagePaths)
+    {
+        var missing = new List<MissingDependency>();
+        try
+        {
+            var doc = AlTranspiler.LoadNavxManifest(appPath);
+            if (doc == null) return missing;
+
+            XNamespace ns = "http://schemas.microsoft.com/navx/2015/manifest";
+            var depsElement = doc.Root?.Element(ns + "Dependencies");
+            if (depsElement == null) return missing;
+
+            // Scan all package directories to find available .app files by GUID
+            var availableGuids = new HashSet<Guid>();
+            foreach (var pkgDir in packagePaths)
+            {
+                if (!Directory.Exists(pkgDir)) continue;
+                var specs = PackageScanner.ScanForSpecs(new[] { pkgDir });
+                foreach (var spec in specs)
+                    availableGuids.Add(spec.AppId);
+            }
+
+            // Check each declared dependency
+            foreach (var dep in depsElement.Elements(ns + "Dependency"))
+            {
+                var idStr = dep.Attribute("Id")?.Value;
+                if (idStr == null || !Guid.TryParse(idStr, out var depGuid)) continue;
+
+                // Platform and Application dependencies are resolved differently (by version, not GUID)
+                // — they're always available via the BC DLLs. Skip them.
+                var depPublisher = dep.Attribute("Publisher")?.Value ?? "Unknown";
+                var depName = dep.Attribute("Name")?.Value ?? "Unknown";
+                if (depPublisher == "Microsoft" && depName is "System" or "Application")
+                    continue;
+
+                if (!availableGuids.Contains(depGuid))
+                {
+                    var depVersion = dep.Attribute("MinVersion")?.Value ?? dep.Attribute("Version")?.Value ?? "0.0.0.0";
+                    missing.Add(new MissingDependency(depPublisher, depName, depVersion, depGuid));
+                }
+            }
+        }
+        catch { }
+        return missing;
     }
 }

--- a/AlRunner/Pipeline.cs
+++ b/AlRunner/Pipeline.cs
@@ -1398,98 +1398,80 @@ public class AlRunnerPipeline
             }
         }
 
+        var missingIds = referencedIds.Where(id => !alreadyPresent.Contains(id)).OrderBy(id => id).ToList();
         var stubs = new List<(string Name, Microsoft.CodeAnalysis.SyntaxTree Tree)>();
-        foreach (var id in referencedIds.Where(id => !alreadyPresent.Contains(id)).OrderBy(id => id))
+
+        // --- Phase 1: Compile rich stubs as AL through the BC compiler ---
+        // This produces proper scope classes with deterministic member IDs that match
+        // the caller's generated code, fixing dispatch for codeunits with many methods
+        // that share the same parameter count (issue #1150).
+        var compiledIds = new HashSet<int>();
+        var alStubSources = new List<string>();
+        var alStubIdOrder = new List<int>();
+
+        foreach (var id in missingIds)
         {
-            string stubCode;
             if (symbolMap.TryGetValue(id, out var cuSymbol) && cuSymbol.Methods.Count > 0)
             {
-                // Rich stub: generate C# class with method stubs from SymbolReference.json
-                stubCode = GenerateRichCSharpStub(id, cuSymbol);
+                alStubSources.Add(StubGenerator.RenderCodeunit(cuSymbol, "auto-stub"));
+                alStubIdOrder.Add(id);
             }
-            else
+        }
+
+        if (alStubSources.Count > 0)
+        {
+            // Suppress stderr from the auto-stub compilation — errors are expected
+            // when methods reference types not available in the packages.
+            var savedErr = Console.Error;
+            Console.SetError(System.IO.TextWriter.Null);
+            try
             {
-                // Minimal stub: empty class (no methods available from packages)
-                stubCode = $"namespace Microsoft.Dynamics.Nav.BusinessApplication {{ public class Codeunit{id} {{ }} }}";
+                var csharpList = AlTranspiler.TranspileMulti(
+                    alStubSources,
+                    packagePaths != null && packagePaths.Count > 0 ? packagePaths : null,
+                    inputPaths);
+                if (csharpList != null)
+                {
+                    foreach (var (name, code) in csharpList)
+                    {
+                        try
+                        {
+                            var tree = RoslynRewriter.RewriteToTree(code);
+                            if (tree != null)
+                            {
+                                stubs.Add((name, tree));
+                                // Track which IDs were successfully compiled
+                                foreach (Match m in classPattern.Matches(code))
+                                {
+                                    if (int.TryParse(m.Groups[1].Value, out int compiledId))
+                                        compiledIds.Add(compiledId);
+                                }
+                            }
+                        }
+                        catch
+                        {
+                            // Rewriter failed — fall through to minimal C# stub below
+                        }
+                    }
+                }
             }
+            finally
+            {
+                Console.SetError(savedErr);
+            }
+        }
+
+        // --- Phase 2: Minimal C# stubs for anything not compiled from AL ---
+        foreach (var id in missingIds)
+        {
+            if (compiledIds.Contains(id)) continue;
+            var stubCode = $"namespace Microsoft.Dynamics.Nav.BusinessApplication {{ public class Codeunit{id} {{ }} }}";
             var tree = Microsoft.CodeAnalysis.CSharp.CSharpSyntaxTree.ParseText(
                 stubCode, path: $"TestToolkitStub{id}.cs");
             stubs.Add(($"TestToolkitStub{id}", tree));
         }
+
         return stubs;
-    }
-
-    /// <summary>
-    /// Generate a C# class with method stubs from SymbolReference.json metadata.
-    /// Methods return defaults (0 for int, false for bool, null for objects, "" for strings).
-    /// The arg-count fallback in MockCodeunitHandle.Invoke dispatches to these methods.
-    /// </summary>
-    private static string GenerateRichCSharpStub(int id, StubGenerator.CodeunitSymbol cu)
-    {
-        var sb = new System.Text.StringBuilder();
-        sb.AppendLine("namespace Microsoft.Dynamics.Nav.BusinessApplication {");
-        sb.AppendLine($"public class Codeunit{id} {{");
-
-        foreach (var method in cu.Methods)
-        {
-            // All params and return types use 'object' — avoids compile errors from
-            // missing BC types and lets the arg-count fallback match any overload.
-            // Return null for all methods; the caller's generated cast will handle conversion.
-            var csParams = string.Join(", ",
-                method.Parameters.Select((p, i) => $"object p{i}"));
-
-            if (method.ReturnType == null)
-            {
-                sb.AppendLine($"    public void {method.Name}({csParams}) {{ }}");
-            }
-            else
-            {
-                var csRet = MapAlTypeToCSharp(method.ReturnType, isParameter: false);
-                string retVal = csRet switch
-                {
-                    "string" => "\"\"",
-                    "bool" => "false",
-                    "int" or "long" or "decimal" or "char" or "byte" => "default",
-                    "System.Guid" => "System.Guid.Empty",
-                    "object" => "null",
-                    _ => "default",
-                };
-                sb.AppendLine($"    public {csRet} {method.Name}({csParams}) {{ return {retVal}; }}");
-            }
-        }
-
-        sb.AppendLine("}}");
-        return sb.ToString();
-    }
-
-    /// <summary>
-    /// Map AL types to C# for auto-stub methods. Uses 'object' for complex types
-    /// so stubs compile without requiring BC DLL types. The arg-count fallback in
-    /// MockCodeunitHandle.Invoke handles runtime type conversion.
-    /// </summary>
-    /// <summary>
-    /// Map AL types to C# for auto-stub methods. Uses simple types that the
-    /// MockCodeunitHandle.Invoke arg-count fallback can handle at runtime.
-    /// All parameter types use 'object' so any argument matches.
-    /// Return types use specific types where possible to avoid cast errors.
-    /// </summary>
-    internal static string MapAlTypeToCSharp(StubGenerator.TypeSymbol? t, bool isParameter = false)
-    {
-        if (t == null) return "void";
-        // Parameters always use object — simplifies overload matching
-        if (isParameter) return "object";
-        return t.Name switch
-        {
-            "Integer" or "Option" or "Enum" => "int",
-            "BigInteger" => "long",
-            "Decimal" => "decimal",
-            "Boolean" => "bool",
-            "Char" => "char",
-            "Byte" => "byte",
-            "Guid" => "System.Guid",
-            "Text" or "Code" or "Label" or "TextConst" => "string",
-            _ => "object",
-        };
     }
 
     private static List<string> GetSeparateStubSources(List<string> stubSources, List<string> alSources)

--- a/AlRunner/Pipeline.cs
+++ b/AlRunner/Pipeline.cs
@@ -3,6 +3,8 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
 using System.Xml.Linq;
+using Microsoft.Dynamics.Nav.CodeAnalysis;
+using Microsoft.Dynamics.Nav.CodeAnalysis.Symbols;
 
 namespace AlRunner;
 
@@ -536,6 +538,10 @@ public class AlRunnerPipeline
             return 3;
         }
 
+        // Save the main compilation for symbol table queries (auto-stub generation).
+        // Subsequent TranspileMulti calls (for dep stubs, assert stubs) overwrite LastCompilation.
+        var mainCompilation = AlTranspiler.LastCompilation;
+
         // Compile dependency stubs separately
         var separateStubSources = GetSeparateStubSources(stubSources, alSources);
         if (separateStubSources.Count > 0)
@@ -701,7 +707,7 @@ public class AlRunnerPipeline
         // default return values — covering codeunits, tables, pages, and all other
         // object types from system, base app, and test library packages.
         var autoStubTrees = GenerateAndCompileAutoStubs(
-            generatedCSharpList, options.PackagePaths, inputPaths, stderr);
+            generatedCSharpList, options.PackagePaths, inputPaths, stderr, mainCompilation);
         if (autoStubTrees.Count > 0)
             rewrittenTreeList.AddRange(autoStubTrees);
 
@@ -1331,7 +1337,7 @@ public class AlRunnerPipeline
     private static List<(string Name, Microsoft.CodeAnalysis.SyntaxTree Tree)> GenerateAndCompileAutoStubs(
         List<(string Name, string Code)> generatedCSharpList,
         List<string> packagePaths, List<string> inputPaths,
-        TextWriter stderr)
+        TextWriter stderr, Compilation? mainCompilation)
     {
         var result = new List<(string Name, Microsoft.CodeAnalysis.SyntaxTree Tree)>();
 
@@ -1379,10 +1385,49 @@ public class AlRunnerPipeline
         if (missingCodeunits.Count == 0 && missingTables.Count == 0)
             return result;
 
-        // 3. Generate minimal AL stubs
+
+        // 3. Generate AL stubs with full method signatures from the BC compiler's
+        //    symbol table. The main compilation already resolved all symbols — we
+        //    query it to get method names, parameters, and return types.
         var alStubs = new List<string>();
+        var compilation = mainCompilation;
+
+        // Quick test: can we find Rest Client (2350) by name?
+        if (compilation != null)
+        {
+            try
+            {
+                var test = compilation.GetObjectTypeSymbolsByNameAcrossModulesAndNamespaces(
+                    SymbolKind.Codeunit, "Rest Client");
+                System.IO.File.WriteAllText("/tmp/alr_sym.txt", $"ByName 'Rest Client': {test.Length} symbols. ById 2350: ");
+                var byIdMethod = compilation.GetType().GetMethod("GetApplicationObjectTypeSymbolsByIdAcrossModules",
+                    System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance,
+                    null, new[] { typeof(SymbolKind), typeof(int) }, null);
+                if (byIdMethod != null)
+                {
+                    var byIdResult = byIdMethod.Invoke(compilation, new object[] { SymbolKind.Codeunit, 2350 });
+                    var len = byIdResult?.GetType().GetProperty("Length")?.GetValue(byIdResult);
+                    System.IO.File.AppendAllText("/tmp/alr_sym.txt", $"{len}\n");
+                }
+                else
+                    System.IO.File.AppendAllText("/tmp/alr_sym.txt", "method not found\n");
+            }
+            catch (Exception ex) { System.IO.File.WriteAllText("/tmp/alr_sym.txt", $"ERROR: {ex}\n"); }
+        }
+
+        int richCount = 0;
         foreach (var id in missingCodeunits.OrderBy(x => x))
-            alStubs.Add($"codeunit {id} \"AutoStub{id}\" {{ }}");
+        {
+            var stubAl = compilation != null
+                ? RenderCodeunitStubFromSymbols(compilation, id)
+                : null;
+            if (stubAl != null) richCount++;
+            alStubs.Add(stubAl ?? $"codeunit {id} \"AutoStub{id}\" {{ }}");
+        }
+        System.IO.File.AppendAllText("/tmp/alr_sym.txt", $"Rich stubs: {richCount}/{missingCodeunits.Count}\n");
+        // Dump first rich stub
+        if (richCount > 0)
+            System.IO.File.AppendAllText("/tmp/alr_sym.txt", $"First stub preview:\n{alStubs[0].Substring(0, Math.Min(500, alStubs[0].Length))}\n---\n");
         foreach (var id in missingTables.OrderBy(x => x))
         {
             // Tables need at least one field and a primary key to compile
@@ -1390,17 +1435,21 @@ public class AlRunnerPipeline
         }
 
         // 4. Compile stubs in a second BC pass (same packages → proper scope classes)
+        var diagWriter = new StringWriter();
         var savedErr = Console.Error;
-        Console.SetError(TextWriter.Null); // suppress expected diagnostics
+        Console.SetError(diagWriter);
         List<(string Name, string Code)>? stubCSharp;
         try
         {
-            stubCSharp = AlTranspiler.TranspileMulti(
-                alStubs,
-                packagePaths.Count > 0 ? packagePaths : null,
-                inputPaths);
+            // Compile stubs WITHOUT package references to avoid AL0197 conflicts
+            // (stubs define the same codeunit IDs as the packages). Stubs only use
+            // built-in AL types (Integer, Text, Variant, etc.) so no packages needed.
+            stubCSharp = AlTranspiler.TranspileMulti(alStubs);
         }
         finally { Console.SetError(savedErr); }
+        var diagOutput = diagWriter.ToString();
+        if (diagOutput.Length > 0)
+            System.IO.File.AppendAllText("/tmp/alr_sym.txt", $"Second BC pass diagnostics:\n{diagOutput.Substring(0, Math.Min(2000, diagOutput.Length))}\n");
 
         // 5. Rewrite and collect compiled stubs
         int rewriteOk = 0, rewriteFail = 0;
@@ -1479,6 +1528,200 @@ public class AlRunnerPipeline
         stderr.WriteLine();
 
         return result;
+    }
+
+    /// <summary>
+    /// Query the BC compiler's symbol table for a codeunit by ID. If found, render
+    /// an AL stub with all its method signatures. Uses reflection since the BC
+    /// CodeAnalysis API types are internal and vary across versions.
+    /// Returns null if the codeunit is not found.
+    /// </summary>
+    private static string? RenderCodeunitStubFromSymbols(Compilation compilation, int codeunitId)
+    {
+        try
+        {
+            // Look up the codeunit by ID using the BC compiler's symbol table.
+            // GetApplicationObjectTypeSymbolsByIdAcrossModules is not in the public API
+            // for all BC versions, so we call it via reflection.
+            var lookupMethod = compilation.GetType().GetMethod(
+                "GetApplicationObjectTypeSymbolsByIdAcrossModules",
+                System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance,
+                null, new[] { typeof(SymbolKind), typeof(int) }, null);
+            if (lookupMethod == null)
+            {
+                System.IO.File.AppendAllText("/tmp/alr_sym.txt", $"CU {codeunitId}: lookup method NOT FOUND\n");
+                return null;
+            }
+
+            var symbolsObj = lookupMethod.Invoke(compilation, new object[] { SymbolKind.Codeunit, codeunitId });
+            if (symbolsObj == null) return null;
+
+            // The result is ImmutableArray<IApplicationObjectTypeSymbol> — access via indexer
+            var lengthProp = symbolsObj.GetType().GetProperty("Length");
+            if (lengthProp == null || (int)lengthProp.GetValue(symbolsObj)! == 0) return null;
+
+            var indexer = symbolsObj.GetType().GetProperty("Item");
+            if (indexer == null) return null;
+            var found = indexer.GetValue(symbolsObj, new object[] { 0 })!;
+            var foundName = found.GetType().GetProperty("Name")?.GetValue(found)?.ToString() ?? $"AutoStub{codeunitId}";
+
+            var sb = new System.Text.StringBuilder();
+            var cuName = foundName.Replace("\"", "\"\"");
+            sb.AppendLine($"codeunit {codeunitId} \"{cuName}\"");
+            sb.AppendLine("{");
+
+            var getMembersMethod = found.GetType().GetMethod("GetMembers", Type.EmptyTypes);
+            if (getMembersMethod == null) { sb.AppendLine("}"); return sb.ToString(); }
+
+            var members = getMembersMethod.Invoke(found, null) as System.Collections.IEnumerable;
+            if (members == null) { sb.AppendLine("}"); return sb.ToString(); }
+
+            var emittedSigs = new HashSet<string>();
+
+            foreach (var member in members)
+            {
+                var memberKind = member.GetType().GetProperty("Kind")?.GetValue(member);
+                if (memberKind?.ToString() != "Method") continue;
+
+                var methodName = member.GetType().GetProperty("Name")?.GetValue(member)?.ToString();
+                if (methodName == null) continue;
+
+                // Get parameters
+                var paramsProp = member.GetType().GetProperty("Parameters");
+                var paramParts = new List<string>();
+                if (paramsProp != null)
+                {
+                    var parms = paramsProp.GetValue(member) as System.Collections.IEnumerable;
+                    if (parms != null)
+                    {
+                        foreach (var p in parms)
+                        {
+                            var pName = p.GetType().GetProperty("Name")?.GetValue(p)?.ToString() ?? "p";
+                            // Escape AL keywords used as parameter names
+                            if (IsAlKeyword(pName)) pName = $"\"{pName}\"";
+                            else if (pName.Contains(" ") || pName.Contains(".")) pName = $"\"{pName}\"";
+                            var pIsVar = p.GetType().GetProperty("IsVar")?.GetValue(p) is true;
+                            var pType = p.GetType().GetProperty("ParameterType")?.GetValue(p)
+                                     ?? p.GetType().GetProperty("Type")?.GetValue(p);
+                            var typeName = pType != null ? RenderSymbolTypeViaReflection(pType) : "Variant";
+                            var prefix = pIsVar ? "var " : "";
+                            paramParts.Add($"{prefix}{pName}: {typeName}");
+                        }
+                    }
+                }
+
+                var paramStr = string.Join("; ", paramParts);
+
+                // Get return type
+                var returnPart = "";
+                var retType = member.GetType().GetProperty("ReturnValueType")?.GetValue(member)
+                           ?? member.GetType().GetProperty("ReturnType")?.GetValue(member);
+                if (retType != null)
+                {
+                    var navTypeKind = retType.GetType().GetProperty("NavTypeKind")?.GetValue(retType);
+                    if (navTypeKind != null && navTypeKind.ToString() != "None" && navTypeKind.ToString() != "Void")
+                    {
+                        var retTypeName = RenderSymbolTypeViaReflection(retType);
+                        returnPart = $": {retTypeName}";
+                    }
+                }
+
+                var sig = $"{methodName}({paramStr}){returnPart}";
+                if (!emittedSigs.Add(sig)) continue;
+
+                sb.AppendLine($"    procedure {methodName}({paramStr}){returnPart}");
+                sb.AppendLine("    begin");
+                sb.AppendLine("    end;");
+                sb.AppendLine();
+            }
+
+            sb.AppendLine("}");
+
+            // Track the name for reporting
+            AutoStubbedCodeunits[codeunitId] = foundName;
+
+            return sb.ToString();
+        }
+        catch (Exception ex)
+        {
+            System.IO.File.AppendAllText("/tmp/alr_sym.txt", $"RENDER CU {codeunitId}: {ex.GetType().Name}: {ex.Message}\n{ex.StackTrace}\n");
+            return null;
+        }
+    }
+
+
+    private static readonly HashSet<string> _alKeywords = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "key", "field", "var", "begin", "end", "if", "then", "else", "repeat", "until",
+        "while", "do", "for", "to", "downto", "case", "of", "with", "exit", "trigger",
+        "procedure", "local", "internal", "protected", "true", "false", "not", "and", "or",
+        "xor", "div", "mod", "in", "array", "record", "codeunit", "page", "report", "query",
+        "xmlport", "table", "enum", "interface", "temporary", "database"
+    };
+    private static bool IsAlKeyword(string name) => _alKeywords.Contains(name);
+
+    /// <summary>Render an AL type from a BC symbol type object using reflection.</summary>
+    private static string RenderSymbolTypeViaReflection(object typeSymbol)
+    {
+        var navTypeKind = typeSymbol.GetType().GetProperty("NavTypeKind")?.GetValue(typeSymbol)?.ToString();
+        if (navTypeKind == null) return "Variant";
+
+        // For complex types (Record, Codeunit, Enum, etc.) the symbol's ToString()
+        // includes the full qualified name. Use Variant to avoid syntax issues.
+        return navTypeKind switch
+        {
+            "Integer" => "Integer",
+            "BigInteger" => "BigInteger",
+            "Decimal" => "Decimal",
+            "Boolean" => "Boolean",
+            "Date" => "Date",
+            "Time" => "Time",
+            "DateTime" => "DateTime",
+            "Duration" => "Duration",
+            "Guid" => "Guid",
+            "Char" => "Char",
+            "Byte" => "Byte",
+            "Option" => "Integer",
+            "Variant" => "Variant",
+            "RecordId" => "RecordId",
+            "DateFormula" => "DateFormula",
+            "JsonObject" => "JsonObject",
+            "JsonArray" => "JsonArray",
+            "JsonToken" => "JsonToken",
+            "JsonValue" => "JsonValue",
+            "HttpClient" => "HttpClient",
+            "HttpHeaders" => "HttpHeaders",
+            "HttpContent" => "HttpContent",
+            "HttpRequestMessage" => "HttpRequestMessage",
+            "HttpResponseMessage" => "HttpResponseMessage",
+            "SecretText" => "SecretText",
+            "Text" => "Text",
+            "Code" => "Code[20]",
+            "Label" => "Text",
+            "TextConst" => "Text",
+            "InStream" => "InStream",
+            "OutStream" => "OutStream",
+            "BigText" => "BigText",
+            "Blob" => "BigText",
+            "XmlDocument" => "XmlDocument",
+            _ => "Variant", // Use Variant for complex/unknown types to avoid syntax errors
+        };
+    }
+
+    /// <summary>Default AL value for a NavTypeKind string (unused — kept for reference).</summary>
+    private static string DefaultForNavTypeKind(string navTypeKind)
+    {
+        return navTypeKind switch
+        {
+            "Boolean" => "false",
+            "Integer" or "BigInteger" or "Decimal" or "Duration" or "Option" => "0",
+            "Text" or "Code" => "''",
+            "Date" => "0D",
+            "Time" => "0T",
+            "DateTime" => "0DT",
+            "Guid" => "'{00000000-0000-0000-0000-000000000000}'",
+            _ => "''",
+        };
     }
 
     private static List<string> GetSeparateStubSources(List<string> stubSources, List<string> alSources)

--- a/AlRunner/Pipeline.cs
+++ b/AlRunner/Pipeline.cs
@@ -1379,10 +1379,13 @@ public class AlRunnerPipeline
             }
         }
 
+        var missingIds = referencedIds.Where(id => !alreadyPresent.Contains(id)).OrderBy(id => id).ToList();
+        if (missingIds.Count == 0) return new List<(string Name, Microsoft.CodeAnalysis.SyntaxTree Tree)>();
+
         // Build a map of codeunit ID → method signatures from .app packages
+        // (only when there are missing IDs — avoids scanning 50+ .app files for nothing)
         var symbolMap = new Dictionary<int, StubGenerator.CodeunitSymbol>();
         var allPackageDirs = new List<string>(packagePaths ?? new());
-        // Also scan .alpackages near input paths
         if (inputPaths != null)
         {
             foreach (var p in inputPaths)
@@ -1408,8 +1411,6 @@ public class AlRunnerPipeline
                 catch { /* skip unreadable packages */ }
             }
         }
-
-        var missingIds = referencedIds.Where(id => !alreadyPresent.Contains(id)).OrderBy(id => id).ToList();
         var stubs = new List<(string Name, Microsoft.CodeAnalysis.SyntaxTree Tree)>();
 
         // --- Phase 1: Compile rich stubs as AL through the BC compiler ---

--- a/AlRunner/Pipeline.cs
+++ b/AlRunner/Pipeline.cs
@@ -1382,8 +1382,9 @@ public class AlRunnerPipeline
         var missingIds = referencedIds.Where(id => !alreadyPresent.Contains(id)).OrderBy(id => id).ToList();
         if (missingIds.Count == 0) return new List<(string Name, Microsoft.CodeAnalysis.SyntaxTree Tree)>();
 
-        // Build a map of codeunit ID → method signatures from .app packages
-        // (only when there are missing IDs — avoids scanning 50+ .app files for nothing)
+        // Build a map of codeunit ID → method signatures from .app packages.
+        // Only scan packages until all missing IDs are found.
+        var missingIdSet = new HashSet<int>(missingIds);
         var symbolMap = new Dictionary<int, StubGenerator.CodeunitSymbol>();
         var allPackageDirs = new List<string>(packagePaths ?? new());
         if (inputPaths != null)
@@ -1399,85 +1400,37 @@ public class AlRunnerPipeline
         }
         foreach (var pkgDir in allPackageDirs)
         {
+            if (missingIdSet.Count == 0) break;
             if (!Directory.Exists(pkgDir)) continue;
             foreach (var appFile in Directory.GetFiles(pkgDir, "*.app"))
             {
+                if (missingIdSet.Count == 0) break;
                 try
                 {
                     var (codeunits, _, _) = StubGenerator.ReadCodeunitsFromApp(appFile);
                     foreach (var cu in codeunits)
-                        symbolMap.TryAdd(cu.Id, cu);
+                    {
+                        if (missingIdSet.Contains(cu.Id))
+                        {
+                            symbolMap[cu.Id] = cu;
+                            missingIdSet.Remove(cu.Id);
+                        }
+                    }
                 }
                 catch { /* skip unreadable packages */ }
             }
         }
         var stubs = new List<(string Name, Microsoft.CodeAnalysis.SyntaxTree Tree)>();
 
-        // --- Phase 1: Compile rich stubs as AL through the BC compiler ---
-        // This produces proper scope classes with deterministic member IDs that match
-        // the caller's generated code, fixing dispatch for codeunits with many methods
-        // that share the same parameter count (issue #1150).
-        var compiledIds = new HashSet<int>();
-        var alStubSources = new List<string>();
-        var alStubIdOrder = new List<int>();
-
+        // Generate C# stubs with method names and return types from SymbolReference.json.
+        // Parameters use 'object' to avoid compile errors from missing BC types.
         foreach (var id in missingIds)
         {
+            string stubCode;
             if (symbolMap.TryGetValue(id, out var cuSymbol) && cuSymbol.Methods.Count > 0)
-            {
-                alStubSources.Add(StubGenerator.RenderCodeunit(cuSymbol, "auto-stub"));
-                alStubIdOrder.Add(id);
-            }
-        }
-
-        if (alStubSources.Count > 0)
-        {
-            // Suppress stderr from the auto-stub compilation — errors are expected
-            // when methods reference types not available in the packages.
-            var savedErr = Console.Error;
-            Console.SetError(System.IO.TextWriter.Null);
-            try
-            {
-                var csharpList = AlTranspiler.TranspileMulti(
-                    alStubSources,
-                    packagePaths != null && packagePaths.Count > 0 ? packagePaths : null,
-                    inputPaths);
-                if (csharpList != null)
-                {
-                    foreach (var (name, code) in csharpList)
-                    {
-                        try
-                        {
-                            var tree = RoslynRewriter.RewriteToTree(code);
-                            if (tree != null)
-                            {
-                                stubs.Add((name, tree));
-                                // Track which IDs were successfully compiled
-                                foreach (Match m in classPattern.Matches(code))
-                                {
-                                    if (int.TryParse(m.Groups[1].Value, out int compiledId))
-                                        compiledIds.Add(compiledId);
-                                }
-                            }
-                        }
-                        catch
-                        {
-                            // Rewriter failed — fall through to minimal C# stub below
-                        }
-                    }
-                }
-            }
-            finally
-            {
-                Console.SetError(savedErr);
-            }
-        }
-
-        // --- Phase 2: Minimal C# stubs for anything not compiled from AL ---
-        foreach (var id in missingIds)
-        {
-            if (compiledIds.Contains(id)) continue;
-            var stubCode = $"namespace Microsoft.Dynamics.Nav.BusinessApplication {{ public class Codeunit{id} {{ }} }}";
+                stubCode = GenerateRichCSharpStub(id, cuSymbol);
+            else
+                stubCode = $"namespace Microsoft.Dynamics.Nav.BusinessApplication {{ public class Codeunit{id} {{ }} }}";
             var tree = Microsoft.CodeAnalysis.CSharp.CSharpSyntaxTree.ParseText(
                 stubCode, path: $"TestToolkitStub{id}.cs");
             stubs.Add(($"TestToolkitStub{id}", tree));
@@ -1491,6 +1444,45 @@ public class AlRunnerPipeline
         }
 
         return stubs;
+    }
+
+    private static string GenerateRichCSharpStub(int id, StubGenerator.CodeunitSymbol cu)
+    {
+        var sb = new System.Text.StringBuilder();
+        sb.AppendLine("namespace Microsoft.Dynamics.Nav.BusinessApplication {");
+        sb.AppendLine($"public class Codeunit{id} {{");
+        foreach (var method in cu.Methods)
+        {
+            var csParams = string.Join(", ", method.Parameters.Select((p, i) => $"object p{i}"));
+            if (method.ReturnType == null)
+            {
+                sb.AppendLine($"    public void {method.Name}({csParams}) {{ }}");
+            }
+            else
+            {
+                var csRet = method.ReturnType.Name switch
+                {
+                    "Integer" or "Option" or "Enum" => "int",
+                    "BigInteger" => "long",
+                    "Decimal" => "decimal",
+                    "Boolean" => "bool",
+                    "Char" => "char",
+                    "Byte" => "byte",
+                    "Guid" => "System.Guid",
+                    "Text" or "Code" or "Label" or "TextConst" => "string",
+                    _ => "object",
+                };
+                string retVal = csRet switch
+                {
+                    "string" => "\"\"",
+                    "bool" => "false",
+                    _ => "default",
+                };
+                sb.AppendLine($"    public {csRet} {method.Name}({csParams}) {{ return {retVal}; }}");
+            }
+        }
+        sb.AppendLine("}}");
+        return sb.ToString();
     }
 
     private static List<string> GetSeparateStubSources(List<string> stubSources, List<string> alSources)

--- a/AlRunner/Pipeline.cs
+++ b/AlRunner/Pipeline.cs
@@ -1404,8 +1404,10 @@ public class AlRunnerPipeline
         }
         foreach (var id in missingTables.OrderBy(x => x))
         {
-            // Tables need at least one field and a primary key to compile
-            alStubs.Add($"table {id} \"AutoStub{id}\" {{ fields {{ field(1; PK; Integer) {{ }} }} keys {{ key(PK; PK) {{ Clustered = true; }} }} }}");
+            var stubAl = compilation != null
+                ? RenderTableStubFromSymbols(compilation, id)
+                : null;
+            alStubs.Add(stubAl ?? $"table {id} \"AutoStub{id}\" {{ fields {{ field(1; PK; Integer) {{ }} }} keys {{ key(PK; PK) {{ Clustered = true; }} }} }}");
         }
 
         // 4. Compile stubs in a second BC pass (same packages → proper scope classes)
@@ -1628,6 +1630,113 @@ public class AlRunnerPipeline
         "xmlport", "table", "enum", "interface", "temporary", "database"
     };
     private static bool IsAlKeyword(string name) => _alKeywords.Contains(name);
+
+    /// <summary>
+    /// Generate an AL table stub with fields and methods from the BC compiler's symbol table.
+    /// Tables need fields + keys to compile. Methods (procedures defined on the table) are
+    /// included so that calls like Record.SomeMethod() dispatch correctly.
+    /// </summary>
+    private static string? RenderTableStubFromSymbols(Compilation compilation, int tableId)
+    {
+        try
+        {
+            var lookupMethod = compilation.GetType().GetMethod(
+                "GetApplicationObjectTypeSymbolsByIdAcrossModules",
+                System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance,
+                null, new[] { typeof(SymbolKind), typeof(int) }, null);
+            if (lookupMethod == null) return null;
+
+            var symbolsObj = lookupMethod.Invoke(compilation, new object[] { SymbolKind.Table, tableId });
+            if (symbolsObj == null) return null;
+            var lengthProp = symbolsObj.GetType().GetProperty("Length");
+            if (lengthProp == null || (int)lengthProp.GetValue(symbolsObj)! == 0) return null;
+            var indexer = symbolsObj.GetType().GetProperty("Item");
+            if (indexer == null) return null;
+            var found = indexer.GetValue(symbolsObj, new object[] { 0 })!;
+            var foundName = found.GetType().GetProperty("Name")?.GetValue(found)?.ToString() ?? $"AutoStub{tableId}";
+
+            var sb = new System.Text.StringBuilder();
+            sb.AppendLine($"table {tableId} \"{foundName.Replace("\"", "\"\"")}\"");
+            sb.AppendLine("{");
+
+            // Fields section
+            sb.AppendLine("    fields");
+            sb.AppendLine("    {");
+            sb.AppendLine("        field(1; PK; Integer) { }");
+            sb.AppendLine("    }");
+            sb.AppendLine("    keys");
+            sb.AppendLine("    {");
+            sb.AppendLine("        key(PK; PK) { Clustered = true; }");
+            sb.AppendLine("    }");
+
+            // Methods — same approach as codeunit stubs
+            var getMembersMethod = found.GetType().GetMethod("GetMembers", Type.EmptyTypes);
+            if (getMembersMethod != null)
+            {
+                var members = getMembersMethod.Invoke(found, null) as System.Collections.IEnumerable;
+                if (members != null)
+                {
+                    var emittedSigs = new HashSet<string>();
+                    foreach (var member in members)
+                    {
+                        var memberKind = member.GetType().GetProperty("Kind")?.GetValue(member);
+                        if (memberKind?.ToString() != "Method") continue;
+
+                        var methodName = member.GetType().GetProperty("Name")?.GetValue(member)?.ToString();
+                        if (methodName == null) continue;
+
+                        var paramsProp = member.GetType().GetProperty("Parameters");
+                        var paramParts = new List<string>();
+                        if (paramsProp != null)
+                        {
+                            var parms = paramsProp.GetValue(member) as System.Collections.IEnumerable;
+                            if (parms != null)
+                            {
+                                foreach (var p in parms)
+                                {
+                                    var pName = p.GetType().GetProperty("Name")?.GetValue(p)?.ToString() ?? "p";
+                                    if (IsAlKeyword(pName)) pName = $"\"{pName}\"";
+                                    else if (pName.Contains(" ") || pName.Contains(".")) pName = $"\"{pName}\"";
+                                    var pIsVar = p.GetType().GetProperty("IsVar")?.GetValue(p) is true;
+                                    var pType = p.GetType().GetProperty("ParameterType")?.GetValue(p)
+                                             ?? p.GetType().GetProperty("Type")?.GetValue(p);
+                                    var typeName = pType != null ? RenderSymbolTypeViaReflection(pType) : "Variant";
+                                    var prefix = pIsVar ? "var " : "";
+                                    paramParts.Add($"{prefix}{pName}: {typeName}");
+                                }
+                            }
+                        }
+                        var paramStr = string.Join("; ", paramParts);
+
+                        var returnPart = "";
+                        var retType = member.GetType().GetProperty("ReturnValueType")?.GetValue(member)
+                                   ?? member.GetType().GetProperty("ReturnType")?.GetValue(member);
+                        if (retType != null)
+                        {
+                            var navTypeKind = retType.GetType().GetProperty("NavTypeKind")?.GetValue(retType);
+                            if (navTypeKind != null && navTypeKind.ToString() != "None" && navTypeKind.ToString() != "Void")
+                                returnPart = $": {RenderSymbolTypeViaReflection(retType)}";
+                        }
+
+                        var sig = $"{methodName}/{paramParts.Count}";
+                        if (!emittedSigs.Add(sig)) continue;
+
+                        sb.AppendLine($"    procedure {methodName}({paramStr}){returnPart}");
+                        sb.AppendLine("    begin");
+                        sb.AppendLine("    end;");
+                        sb.AppendLine();
+                    }
+                }
+            }
+
+            sb.AppendLine("}");
+            return sb.ToString();
+        }
+        catch
+        {
+            return null;
+        }
+    }
 
     /// <summary>Render an AL type from a BC symbol type object using reflection.</summary>
     private static string RenderSymbolTypeViaReflection(object typeSymbol)

--- a/AlRunner/Pipeline.cs
+++ b/AlRunner/Pipeline.cs
@@ -158,6 +158,13 @@ public class AlRunnerPipeline
     public SyntaxTreeCache? SyntaxTreeCache { get; set; }
 
     /// <summary>
+    /// Codeunit IDs that were auto-stubbed (return defaults, no real implementation).
+    /// Used by the test output to annotate failures involving stub calls.
+    /// Maps codeunit ID → name.
+    /// </summary>
+    public static Dictionary<int, string> AutoStubbedCodeunits { get; } = new();
+
+    /// <summary>
     /// Run the full AL Runner pipeline: transpile → rewrite → compile → execute.
     /// Returns a structured result instead of writing to stdout/stderr directly.
     /// </summary>
@@ -700,10 +707,14 @@ public class AlRunnerPipeline
         if (testToolkitStubs.Count > 0)
         {
             rewrittenTreeList.AddRange(testToolkitStubs);
-            stderr.WriteLine($"Auto-stubbed {testToolkitStubs.Count} dependency codeunit(s) — methods return defaults");
-            stderr.WriteLine($"  Tip: for proper stubs run: al-runner --generate-stubs .alpackages ./stubs ./src ./test");
-            Log.Info($"  IDs: {string.Join(", ", testToolkitStubs.Select(s => s.Name))}");
-
+            stderr.WriteLine($"\nAuto-stubbed {testToolkitStubs.Count} dependency codeunit(s) — all methods return defaults:");
+            foreach (var (id, cuName) in AlRunnerPipeline.AutoStubbedCodeunits.OrderBy(kv => kv.Key))
+                stderr.WriteLine($"  {id} \"{cuName}\"");
+            stderr.WriteLine($"Tests that depend on these methods creating data WILL fail.");
+            stderr.WriteLine($"To compile real implementations:");
+            stderr.WriteLine($"  al-runner --compile-dep .alpackages/<app>.app .deps --packages .alpackages/");
+            stderr.WriteLine($"Then run with: al-runner --dep-dlls .deps ./src ./test");
+            stderr.WriteLine();
         }
 
         // Step 3: Compile
@@ -1469,6 +1480,13 @@ public class AlRunnerPipeline
             var tree = Microsoft.CodeAnalysis.CSharp.CSharpSyntaxTree.ParseText(
                 stubCode, path: $"TestToolkitStub{id}.cs");
             stubs.Add(($"TestToolkitStub{id}", tree));
+        }
+
+        // Track all auto-stubbed IDs for test output annotation
+        foreach (var id in missingIds)
+        {
+            var cuName = symbolMap.TryGetValue(id, out var sym) ? sym.Name : $"Codeunit {id}";
+            AutoStubbedCodeunits.TryAdd(id, cuName);
         }
 
         return stubs;

--- a/AlRunner/Pipeline.cs
+++ b/AlRunner/Pipeline.cs
@@ -27,6 +27,9 @@ public class PipelineOptions
     public string? OutputJunitPath { get; set; }
     /// <summary>When true, promote exit code 2 (runner limitations) to exit code 1 (failure).</summary>
     public bool Strict { get; set; }
+    /// <summary>Per-test timeout in seconds. Tests exceeding this are reported as errors
+    /// and the runner moves to the next test. Default: 5 seconds. Set to 0 to disable.</summary>
+    public int TestTimeoutSeconds { get; set; } = 5;
 
     /// <summary>
     /// When true, fire standard BC lifecycle integration events (OnCompanyInitialize from
@@ -798,7 +801,7 @@ public class AlRunnerPipeline
             }
 
             var runSw = System.Diagnostics.Stopwatch.StartNew();
-            var results = Executor.RunTests(assembly, captureValues: options.CaptureValues, runProcedure: options.RunProcedure, initEvents: options.InitEvents, testIsolation: options.TestIsolation);
+            var results = Executor.RunTests(assembly, captureValues: options.CaptureValues, runProcedure: options.RunProcedure, initEvents: options.InitEvents, testIsolation: options.TestIsolation, testTimeoutSeconds: options.TestTimeoutSeconds);
             runSw.Stop();
             testResults.AddRange(results);
             if (results.Count == 0 && options.RunProcedure != null)
@@ -1392,42 +1395,13 @@ public class AlRunnerPipeline
         var alStubs = new List<string>();
         var compilation = mainCompilation;
 
-        // Quick test: can we find Rest Client (2350) by name?
-        if (compilation != null)
-        {
-            try
-            {
-                var test = compilation.GetObjectTypeSymbolsByNameAcrossModulesAndNamespaces(
-                    SymbolKind.Codeunit, "Rest Client");
-                System.IO.File.WriteAllText("/tmp/alr_sym.txt", $"ByName 'Rest Client': {test.Length} symbols. ById 2350: ");
-                var byIdMethod = compilation.GetType().GetMethod("GetApplicationObjectTypeSymbolsByIdAcrossModules",
-                    System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance,
-                    null, new[] { typeof(SymbolKind), typeof(int) }, null);
-                if (byIdMethod != null)
-                {
-                    var byIdResult = byIdMethod.Invoke(compilation, new object[] { SymbolKind.Codeunit, 2350 });
-                    var len = byIdResult?.GetType().GetProperty("Length")?.GetValue(byIdResult);
-                    System.IO.File.AppendAllText("/tmp/alr_sym.txt", $"{len}\n");
-                }
-                else
-                    System.IO.File.AppendAllText("/tmp/alr_sym.txt", "method not found\n");
-            }
-            catch (Exception ex) { System.IO.File.WriteAllText("/tmp/alr_sym.txt", $"ERROR: {ex}\n"); }
-        }
-
-        int richCount = 0;
         foreach (var id in missingCodeunits.OrderBy(x => x))
         {
             var stubAl = compilation != null
                 ? RenderCodeunitStubFromSymbols(compilation, id)
                 : null;
-            if (stubAl != null) richCount++;
             alStubs.Add(stubAl ?? $"codeunit {id} \"AutoStub{id}\" {{ }}");
         }
-        System.IO.File.AppendAllText("/tmp/alr_sym.txt", $"Rich stubs: {richCount}/{missingCodeunits.Count}\n");
-        // Dump first rich stub
-        if (richCount > 0)
-            System.IO.File.AppendAllText("/tmp/alr_sym.txt", $"First stub preview:\n{alStubs[0].Substring(0, Math.Min(500, alStubs[0].Length))}\n---\n");
         foreach (var id in missingTables.OrderBy(x => x))
         {
             // Tables need at least one field and a primary key to compile
@@ -1435,9 +1409,8 @@ public class AlRunnerPipeline
         }
 
         // 4. Compile stubs in a second BC pass (same packages → proper scope classes)
-        var diagWriter = new StringWriter();
         var savedErr = Console.Error;
-        Console.SetError(diagWriter);
+        Console.SetError(TextWriter.Null);
         List<(string Name, string Code)>? stubCSharp;
         try
         {
@@ -1447,9 +1420,6 @@ public class AlRunnerPipeline
             stubCSharp = AlTranspiler.TranspileMulti(alStubs);
         }
         finally { Console.SetError(savedErr); }
-        var diagOutput = diagWriter.ToString();
-        if (diagOutput.Length > 0)
-            System.IO.File.AppendAllText("/tmp/alr_sym.txt", $"Second BC pass diagnostics:\n{diagOutput.Substring(0, Math.Min(2000, diagOutput.Length))}\n");
 
         // 5. Rewrite and collect compiled stubs
         int rewriteOk = 0, rewriteFail = 0;
@@ -1548,10 +1518,7 @@ public class AlRunnerPipeline
                 System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance,
                 null, new[] { typeof(SymbolKind), typeof(int) }, null);
             if (lookupMethod == null)
-            {
-                System.IO.File.AppendAllText("/tmp/alr_sym.txt", $"CU {codeunitId}: lookup method NOT FOUND\n");
                 return null;
-            }
 
             var symbolsObj = lookupMethod.Invoke(compilation, new object[] { SymbolKind.Codeunit, codeunitId });
             if (symbolsObj == null) return null;
@@ -1626,7 +1593,10 @@ public class AlRunnerPipeline
                     }
                 }
 
-                var sig = $"{methodName}({paramStr}){returnPart}";
+                // Dedup by (name, paramCount): overloaded methods with different
+                // interface/complex types all collapse to Variant in the stub, producing
+                // identical C# signatures and Roslyn CS0121 ambiguity errors.
+                var sig = $"{methodName}/{paramParts.Count}";
                 if (!emittedSigs.Add(sig)) continue;
 
                 sb.AppendLine($"    procedure {methodName}({paramStr}){returnPart}");
@@ -1642,9 +1612,8 @@ public class AlRunnerPipeline
 
             return sb.ToString();
         }
-        catch (Exception ex)
+        catch
         {
-            System.IO.File.AppendAllText("/tmp/alr_sym.txt", $"RENDER CU {codeunitId}: {ex.GetType().Name}: {ex.Message}\n{ex.StackTrace}\n");
             return null;
         }
     }
@@ -1709,21 +1678,6 @@ public class AlRunnerPipeline
     }
 
     /// <summary>Default AL value for a NavTypeKind string (unused — kept for reference).</summary>
-    private static string DefaultForNavTypeKind(string navTypeKind)
-    {
-        return navTypeKind switch
-        {
-            "Boolean" => "false",
-            "Integer" or "BigInteger" or "Decimal" or "Duration" or "Option" => "0",
-            "Text" or "Code" => "''",
-            "Date" => "0D",
-            "Time" => "0T",
-            "DateTime" => "0DT",
-            "Guid" => "'{00000000-0000-0000-0000-000000000000}'",
-            _ => "''",
-        };
-    }
-
     private static List<string> GetSeparateStubSources(List<string> stubSources, List<string> alSources)
     {
         var result = new List<string>();

--- a/AlRunner/Pipeline.cs
+++ b/AlRunner/Pipeline.cs
@@ -694,28 +694,16 @@ public class AlRunnerPipeline
         }
         Timer.EndStage("Roslyn rewriting");
 
-        // Inject minimal C# stub classes for test-toolkit codeunits (130000–139999) that
-        // are referenced in the generated C# but were NOT compiled from source.
-        // This allows MockCodeunitHandle.FindCodeunitType to find them at runtime and
-        // execute as no-ops (no OnRun method → InvokeOnRun silently returns) instead of
-        // throwing InvalidOperationException.
-        // Auto-stub test-toolkit codeunits (130000-139999) as empty classes so
-        // they compile. Methods on these stubs will be no-ops (return defaults).
-        // For proper method implementations, users should run:
-        //   al-runner --generate-stubs .alpackages ./stubs ./src ./test
-        var testToolkitStubs = GenerateTestToolkitStubs(generatedCSharpList, options.PackagePaths, inputPaths);
-        if (testToolkitStubs.Count > 0)
-        {
-            rewrittenTreeList.AddRange(testToolkitStubs);
-            stderr.WriteLine($"\nAuto-stubbed {testToolkitStubs.Count} dependency codeunit(s) — all methods return defaults:");
-            foreach (var (id, cuName) in AlRunnerPipeline.AutoStubbedCodeunits.OrderBy(kv => kv.Key))
-                stderr.WriteLine($"  {id} \"{cuName}\"");
-            stderr.WriteLine($"Tests that depend on these methods creating data WILL fail.");
-            stderr.WriteLine($"To compile real implementations:");
-            stderr.WriteLine($"  al-runner --compile-dep .alpackages/<app>.app .deps --packages .alpackages/");
-            stderr.WriteLine($"Then run with: al-runner --dep-dlls .deps ./src ./test");
-            stderr.WriteLine();
-        }
+        // Auto-stub: scan the generated C# for ALL referenced object IDs that were
+        // NOT compiled from source, generate minimal empty AL stubs for them, and
+        // compile those stubs in a SECOND BC pass using the same packages. This
+        // produces proper C# classes with correct scope classes, member IDs, and
+        // default return values — covering codeunits, tables, pages, and all other
+        // object types from system, base app, and test library packages.
+        var autoStubTrees = GenerateAndCompileAutoStubs(
+            generatedCSharpList, options.PackagePaths, inputPaths, stderr);
+        if (autoStubTrees.Count > 0)
+            rewrittenTreeList.AddRange(autoStubTrees);
 
         // Step 3: Compile
         Timer.StartStage("Roslyn compilation");
@@ -1335,154 +1323,162 @@ public class AlRunnerPipeline
     }
 
     /// <summary>
-    /// Scans the generated C# for test-toolkit codeunit IDs (130000–139999) referenced
-    /// via <c>NavCodeunit.RunCodeunit</c> or <c>new NavCodeunitHandle(..., id)</c> patterns,
-    /// then returns a minimal rewritten C# syntax tree for each ID that does NOT already
-    /// have a compiled class in <paramref name="generatedCSharpList"/>. The generated stub
-    /// classes are empty (no methods) so that <see cref="AlRunner.Runtime.MockCodeunitHandle.FindCodeunitType"/>
-    /// finds them at runtime and treats any call as a silent no-op instead of throwing.
-    /// Codeunits with runner-native mock implementations (130/131/130000, 131004, 131100) are
-    /// excluded — they are never looked up by <c>FindCodeunitType</c>.
+    /// Scans generated C# for ALL referenced object IDs (codeunits, tables, pages, etc.)
+    /// that don't have a compiled class. Generates minimal empty AL stubs for each missing
+    /// object and compiles them in a second BC pass using the same packages. The BC compiler
+    /// produces proper C# with correct scope classes, member IDs, and default return values.
     /// </summary>
-    internal static List<(string Name, Microsoft.CodeAnalysis.SyntaxTree Tree)> GenerateTestToolkitStubs(
+    private static List<(string Name, Microsoft.CodeAnalysis.SyntaxTree Tree)> GenerateAndCompileAutoStubs(
         List<(string Name, string Code)> generatedCSharpList,
-        List<string>? packagePaths = null, List<string>? inputPaths = null)
+        List<string> packagePaths, List<string> inputPaths,
+        TextWriter stderr)
     {
-        // IDs already compiled from source — no stub needed.
-        var alreadyPresent = new HashSet<int>();
-        var classPattern = new Regex(@"class\s+Codeunit(\d+)", RegexOptions.Compiled);
+        var result = new List<(string Name, Microsoft.CodeAnalysis.SyntaxTree Tree)>();
+
+        // 1. Collect object IDs already compiled from user source
+        var alreadyPresent = new HashSet<(string Type, int Id)>();
+        var classPattern = new Regex(@"class\s+(Codeunit|Record|Page|Report|XmlPort|Query)(\d+)\b", RegexOptions.Compiled);
         foreach (var (_, code) in generatedCSharpList)
         {
             foreach (Match m in classPattern.Matches(code))
             {
-                if (int.TryParse(m.Groups[1].Value, out int id))
-                    alreadyPresent.Add(id);
+                if (int.TryParse(m.Groups[2].Value, out int id))
+                    alreadyPresent.Add((m.Groups[1].Value, id));
             }
         }
 
-        // Codeunits that have dedicated runner-native mock implementations
+        // 2. Scan generated C# for ALL referenced object IDs
+        //    Pattern: new NavCodeunitHandle(this, ID) — codeunits
+        //    Pattern: new NavRecordHandle(this, ID, ...) — tables/records
+        var cuPattern = new Regex(@"NavCodeunitHandle\(\s*\w+\s*,\s*(\d+)\s*\)", RegexOptions.Compiled);
+        var recPattern = new Regex(@"NavRecordHandle\(\s*\w+\s*,\s*(\d+)\s*,", RegexOptions.Compiled);
+
+        var missingCodeunits = new HashSet<int>();
+        var missingTables = new HashSet<int>();
+
+        // Codeunits with runner-native mock implementations — never stub
         var nativeMockIds = new HashSet<int> { 130, 131, 130000, 130002, 130440, 130500, 131004, 131100, 132250 };
 
-        // Scan all generated C# for test-toolkit ID literals (130000-139999)
-        var idPattern = new Regex(@"(?:,\s*|[\(\s])1(3[0-9]{4})\b", RegexOptions.Compiled);
-        var referencedIds = new HashSet<int>();
         foreach (var (_, code) in generatedCSharpList)
         {
-            foreach (Match m in idPattern.Matches(code))
+            foreach (Match m in cuPattern.Matches(code))
             {
-                if (int.TryParse("1" + m.Groups[1].Value, out int id)
-                    && id is >= 130000 and <= 139999
-                    && !nativeMockIds.Contains(id))
-                {
-                    referencedIds.Add(id);
-                }
+                if (int.TryParse(m.Groups[1].Value, out int id)
+                    && !nativeMockIds.Contains(id)
+                    && !alreadyPresent.Contains(("Codeunit", id)))
+                    missingCodeunits.Add(id);
+            }
+            foreach (Match m in recPattern.Matches(code))
+            {
+                if (int.TryParse(m.Groups[1].Value, out int id)
+                    && !alreadyPresent.Contains(("Record", id)))
+                    missingTables.Add(id);
             }
         }
 
-        var missingIds = referencedIds.Where(id => !alreadyPresent.Contains(id)).OrderBy(id => id).ToList();
-        if (missingIds.Count == 0) return new List<(string Name, Microsoft.CodeAnalysis.SyntaxTree Tree)>();
+        if (missingCodeunits.Count == 0 && missingTables.Count == 0)
+            return result;
 
-        // Build a map of codeunit ID → method signatures from .app packages.
-        // Only scan packages until all missing IDs are found.
-        var missingIdSet = new HashSet<int>(missingIds);
-        var symbolMap = new Dictionary<int, StubGenerator.CodeunitSymbol>();
-        var allPackageDirs = new List<string>(packagePaths ?? new());
-        if (inputPaths != null)
+        // 3. Generate minimal AL stubs
+        var alStubs = new List<string>();
+        foreach (var id in missingCodeunits.OrderBy(x => x))
+            alStubs.Add($"codeunit {id} \"AutoStub{id}\" {{ }}");
+        foreach (var id in missingTables.OrderBy(x => x))
         {
-            foreach (var p in inputPaths)
-            {
-                var dir = Directory.Exists(p) ? p : Path.GetDirectoryName(p);
-                if (dir == null) continue;
-                var alPkg = Path.Combine(dir, ".alpackages");
-                if (Directory.Exists(alPkg) && !allPackageDirs.Contains(alPkg))
-                    allPackageDirs.Add(alPkg);
-            }
+            // Tables need at least one field and a primary key to compile
+            alStubs.Add($"table {id} \"AutoStub{id}\" {{ fields {{ field(1; PK; Integer) {{ }} }} keys {{ key(PK; PK) {{ Clustered = true; }} }} }}");
         }
-        foreach (var pkgDir in allPackageDirs)
+
+        // 4. Compile stubs in a second BC pass (same packages → proper scope classes)
+        var savedErr = Console.Error;
+        Console.SetError(TextWriter.Null); // suppress expected diagnostics
+        List<(string Name, string Code)>? stubCSharp;
+        try
         {
-            if (missingIdSet.Count == 0) break;
-            if (!Directory.Exists(pkgDir)) continue;
-            foreach (var appFile in Directory.GetFiles(pkgDir, "*.app"))
+            stubCSharp = AlTranspiler.TranspileMulti(
+                alStubs,
+                packagePaths.Count > 0 ? packagePaths : null,
+                inputPaths);
+        }
+        finally { Console.SetError(savedErr); }
+
+        // 5. Rewrite and collect compiled stubs
+        int rewriteOk = 0, rewriteFail = 0;
+        if (stubCSharp != null)
+        {
+            foreach (var (name, code) in stubCSharp)
             {
-                if (missingIdSet.Count == 0) break;
                 try
                 {
-                    var (codeunits, _, _) = StubGenerator.ReadCodeunitsFromApp(appFile);
-                    foreach (var cu in codeunits)
+                    var tree = RoslynRewriter.RewriteToTree(code);
+                    if (tree != null)
                     {
-                        if (missingIdSet.Contains(cu.Id))
-                        {
-                            symbolMap[cu.Id] = cu;
-                            missingIdSet.Remove(cu.Id);
-                        }
+                        result.Add((name, tree));
+                        rewriteOk++;
                     }
                 }
-                catch { /* skip unreadable packages */ }
-            }
-        }
-        var stubs = new List<(string Name, Microsoft.CodeAnalysis.SyntaxTree Tree)>();
-
-        // Generate C# stubs with method names and return types from SymbolReference.json.
-        // Parameters use 'object' to avoid compile errors from missing BC types.
-        foreach (var id in missingIds)
-        {
-            string stubCode;
-            if (symbolMap.TryGetValue(id, out var cuSymbol) && cuSymbol.Methods.Count > 0)
-                stubCode = GenerateRichCSharpStub(id, cuSymbol);
-            else
-                stubCode = $"namespace Microsoft.Dynamics.Nav.BusinessApplication {{ public class Codeunit{id} {{ }} }}";
-            var tree = Microsoft.CodeAnalysis.CSharp.CSharpSyntaxTree.ParseText(
-                stubCode, path: $"TestToolkitStub{id}.cs");
-            stubs.Add(($"TestToolkitStub{id}", tree));
-        }
-
-        // Track all auto-stubbed IDs for test output annotation
-        foreach (var id in missingIds)
-        {
-            var cuName = symbolMap.TryGetValue(id, out var sym) ? sym.Name : $"Codeunit {id}";
-            AutoStubbedCodeunits.TryAdd(id, cuName);
-        }
-
-        return stubs;
-    }
-
-    private static string GenerateRichCSharpStub(int id, StubGenerator.CodeunitSymbol cu)
-    {
-        var sb = new System.Text.StringBuilder();
-        sb.AppendLine("namespace Microsoft.Dynamics.Nav.BusinessApplication {");
-        sb.AppendLine($"public class Codeunit{id} {{");
-        foreach (var method in cu.Methods)
-        {
-            var csParams = string.Join(", ", method.Parameters.Select((p, i) => $"object p{i}"));
-            if (method.ReturnType == null)
-            {
-                sb.AppendLine($"    public void {method.Name}({csParams}) {{ }}");
-            }
-            else
-            {
-                var csRet = method.ReturnType.Name switch
+                catch
                 {
-                    "Integer" or "Option" or "Enum" => "int",
-                    "BigInteger" => "long",
-                    "Decimal" => "decimal",
-                    "Boolean" => "bool",
-                    "Char" => "char",
-                    "Byte" => "byte",
-                    "Guid" => "System.Guid",
-                    "Text" or "Code" or "Label" or "TextConst" => "string",
-                    _ => "object",
-                };
-                string retVal = csRet switch
-                {
-                    "string" => "\"\"",
-                    "bool" => "false",
-                    _ => "default",
-                };
-                sb.AppendLine($"    public {csRet} {method.Name}({csParams}) {{ return {retVal}; }}");
+                    rewriteFail++;
+                    // Generate minimal fallback class so other code can reference it
+                    var classMatch = classPattern.Match(code);
+                    if (classMatch.Success)
+                    {
+                        var className = $"{classMatch.Groups[1].Value}{classMatch.Groups[2].Value}";
+                        var fallback = Microsoft.CodeAnalysis.CSharp.CSharpSyntaxTree.ParseText(
+                            $"namespace Microsoft.Dynamics.Nav.BusinessApplication {{ public class {className} {{ }} }}");
+                        result.Add(($"AutoStub_{className}", fallback));
+                    }
+                }
             }
         }
-        sb.AppendLine("}}");
-        return sb.ToString();
+
+        // 6. For any IDs that failed BC compilation (missing transitive deps),
+        //    generate minimal C# classes as fallback
+        var compiledIds = new HashSet<int>();
+        var compiledClassPattern = new Regex(@"class\s+(?:Codeunit|Record)(\d+)", RegexOptions.Compiled);
+        if (stubCSharp != null)
+        {
+            foreach (var (_, code) in stubCSharp)
+                foreach (Match m in compiledClassPattern.Matches(code))
+                    if (int.TryParse(m.Groups[1].Value, out int id))
+                        compiledIds.Add(id);
+        }
+        foreach (var id in missingCodeunits.Where(id => !compiledIds.Contains(id)))
+        {
+            var fallback = Microsoft.CodeAnalysis.CSharp.CSharpSyntaxTree.ParseText(
+                $"namespace Microsoft.Dynamics.Nav.BusinessApplication {{ public class Codeunit{id} {{ }} }}",
+                path: $"AutoStub_Codeunit{id}.cs");
+            result.Add(($"AutoStub_Codeunit{id}", fallback));
+        }
+        foreach (var id in missingTables.Where(id => !compiledIds.Contains(id)))
+        {
+            var fallback = Microsoft.CodeAnalysis.CSharp.CSharpSyntaxTree.ParseText(
+                $"namespace Microsoft.Dynamics.Nav.BusinessApplication {{ public class Record{id} {{ }} }}",
+                path: $"AutoStub_Record{id}.cs");
+            result.Add(($"AutoStub_Record{id}", fallback));
+        }
+
+        // Track for test output annotation
+        foreach (var id in missingCodeunits)
+            AutoStubbedCodeunits.TryAdd(id, $"Codeunit {id}");
+        foreach (var id in missingTables)
+            AutoStubbedCodeunits.TryAdd(id, $"Table {id}");
+
+        // 7. Report
+        int total = missingCodeunits.Count + missingTables.Count;
+        int compiled = stubCSharp?.Count ?? 0;
+        stderr.WriteLine($"\nAuto-stubbed {total} dependency object(s) — methods return defaults:");
+        if (missingCodeunits.Count > 0)
+            stderr.WriteLine($"  Codeunits: {missingCodeunits.Count} ({compiled} compiled via BC, {missingCodeunits.Count - compiledIds.Intersect(missingCodeunits).Count()} fallback)");
+        if (missingTables.Count > 0)
+            stderr.WriteLine($"  Tables:    {missingTables.Count}");
+        stderr.WriteLine($"Stubbed methods return default values. Provide real implementations via:");
+        stderr.WriteLine($"  --stubs ./stubs     (AL stub files)");
+        stderr.WriteLine($"  --dep-dlls .deps    (compiled dependency DLLs)");
+        stderr.WriteLine();
+
+        return result;
     }
 
     private static List<string> GetSeparateStubSources(List<string> stubSources, List<string> alSources)

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -2732,6 +2732,7 @@ public static class Executor
                     if (LooksLikeFrameworkVersionMismatch(r.Message))
                         Console.WriteLine($"      ℹ This BC version requires a newer .NET runtime. Install .NET 10: https://dotnet.microsoft.com/download/dotnet/10.0");
                     if (r.StackTrace != null) PrintFilteredStackTrace(r.StackTrace);
+                    PrintAutoStubWarningIfRelevant(r.StackTrace);
                     break;
                 case AlRunner.TestStatus.Error:
                     if (!verbose && r.Message != null && dedupMessages.Contains(r.Message))
@@ -2958,18 +2959,37 @@ public static class Executor
                 continue;
             if (line.Contains("System.RuntimeMethodHandle."))
                 continue;
-            if (printed < 5)
-            {
-                Console.WriteLine($"      {FormatSingleFrame(line)}");
-                printed++;
-            }
+            Console.WriteLine($"      {FormatSingleFrame(line)}");
+            printed++;
         }
         if (printed == 0 && lines.Length > 0)
         {
             // Fallback: print first few raw lines if nothing matched
-            foreach (var line in lines.Take(3))
+            foreach (var line in lines.Take(10))
                 Console.WriteLine($"      {line.Trim()}");
         }
+    }
+
+    /// <summary>
+    /// If the stack trace references any auto-stubbed codeunit, print a warning
+    /// explaining that the test likely failed because stubbed methods return defaults.
+    /// </summary>
+    private static void PrintAutoStubWarningIfRelevant(string? stackTrace)
+    {
+        if (stackTrace == null || AlRunnerPipeline.AutoStubbedCodeunits.Count == 0) return;
+
+        var involvedStubs = new List<(int Id, string Name)>();
+        foreach (var (id, name) in AlRunnerPipeline.AutoStubbedCodeunits)
+        {
+            if (stackTrace.Contains($"Codeunit{id}"))
+                involvedStubs.Add((id, name));
+        }
+
+        if (involvedStubs.Count == 0) return;
+
+        foreach (var (id, name) in involvedStubs)
+            Console.WriteLine($"      ⚠ Called auto-stubbed codeunit {id} \"{name}\" (methods return defaults — no records created).");
+        Console.WriteLine($"      Compile real implementations: al-runner --compile-dep <app>.app .deps --packages .alpackages/");
     }
 
     /// Used to print actionable guidance; does NOT change error classification.
@@ -3008,10 +3028,9 @@ public static class Executor
         // Prefer AL-generated frames (BusinessApplication namespace) over runtime internals
         var alFrames = allFrames
             .Where(f => f.Contains("BusinessApplication.") || f.Contains("MockAssert"))
-            .Take(3)
             .ToList();
 
-        var frames = alFrames.Count > 0 ? alFrames : allFrames.Take(3).ToList();
+        var frames = alFrames.Count > 0 ? alFrames : allFrames.Take(10).ToList();
         return string.Join("\n", frames.Select(f => $"      {FormatSingleFrame(f)}")) + "\n";
     }
 

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -895,6 +895,13 @@ public static class Timer
 public static class AlTranspiler
 {
     /// <summary>
+    /// The last Compilation object from TranspileMulti. Allows querying the BC
+    /// compiler's symbol table for method signatures on dependency objects
+    /// (codeunits, tables, etc.) that are referenced but not compiled from source.
+    /// </summary>
+    public static Compilation? LastCompilation { get; private set; }
+
+    /// <summary>
     /// Transpile a single AL source string (backward compat).
     /// </summary>
     public static string? Transpile(string alSource)
@@ -1300,6 +1307,9 @@ public static class AlTranspiler
             if (otherErrors.Count > 10)
                 Log.Info($"  ... and {otherErrors.Count - 10} more");
         }
+
+        // Store compilation for symbol table queries by auto-stub generation
+        LastCompilation = compilation;
 
         var outputter = new CSharpCaptureOutputter();
         EmitResult? emitResult = null;

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -2665,6 +2665,8 @@ public static class Executor
                 {
                     // Run with per-test timeout: use a background thread so we can
                     // abandon it on timeout without blocking the test runner.
+                    // Track which auto-stubbed codeunits are accessed during this test
+                    AlRunner.Runtime.MockCodeunitHandle.ResetAutoStubTracking();
                     Exception? threadEx = null;
                     var thread = new Thread(() =>
                     {
@@ -2682,10 +2684,24 @@ public static class Executor
                     if (!thread.Join(timeoutMs))
                     {
                         sw.Stop();
+                        // Build actionable message listing which auto-stubbed codeunits were called
+                        var accessed = AlRunner.Runtime.MockCodeunitHandle.AccessedAutoStubs;
+                        var stubDetails = "";
+                        if (accessed != null && !accessed.IsEmpty)
+                        {
+                            var stubNames = accessed.Distinct()
+                                .Where(id => AlRunnerPipeline.AutoStubbedCodeunits.ContainsKey(id))
+                                .Select(id => $"{id} \"{AlRunnerPipeline.AutoStubbedCodeunits[id]}\"")
+                                .OrderBy(s => s)
+                                .ToList();
+                            if (stubNames.Count > 0)
+                                stubDetails = $"\n  Auto-stubbed codeunits called during this test:\n    " +
+                                    string.Join("\n    ", stubNames) +
+                                    "\n  Provide implementations for these via --stubs or --dep-dlls.";
+                        }
                         throw new TimeoutException(
                             $"Test exceeded {testTimeoutSeconds}s timeout — likely an infinite loop caused by " +
-                            $"an auto-stubbed dependency returning default values. " +
-                            $"Provide a real implementation via --stubs or --dep-dlls.");
+                            $"an auto-stubbed dependency returning default values." + stubDetails);
                     }
                     if (threadEx != null)
                         System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(threadEx).Throw();

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -2450,6 +2450,7 @@ public static class Executor
         Type? currentCodeunitType = null;
         bool firstReset = true;
 
+
         foreach (var (testName, scopeType, parentType) in testScopes)
         {
             // Resolve the AL codeunit name for grouping in JUnit output

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -2684,7 +2684,21 @@ public static class Executor
                     if (!thread.Join(timeoutMs))
                     {
                         sw.Stop();
-                        // Build actionable message listing which auto-stubbed codeunits were called
+
+                        // Capture where the code was stuck
+                        var lastHit = AlRunner.Runtime.AlScope.LastStatementHit;
+                        var locationInfo = "";
+                        if (lastHit != null)
+                        {
+                            var (scopeName, stmtId) = lastHit.Value;
+                            var alLine = SourceLineMapper.GetAlLineFromStatement(scopeName, stmtId);
+                            var objectName = FormatSingleFrame($"at {scopeName}");
+                            locationInfo = alLine != null
+                                ? $"\n  Last AL statement: {objectName} (line {alLine})"
+                                : $"\n  Last AL scope: {objectName}";
+                        }
+
+                        // List auto-stubbed codeunits accessed during this test
                         var accessed = AlRunner.Runtime.MockCodeunitHandle.AccessedAutoStubs;
                         var stubDetails = "";
                         if (accessed != null && !accessed.IsEmpty)
@@ -2699,9 +2713,14 @@ public static class Executor
                                     string.Join("\n    ", stubNames) +
                                     "\n  Provide implementations for these via --stubs or --dep-dlls.";
                         }
+
+                        var hint = string.IsNullOrEmpty(stubDetails) && string.IsNullOrEmpty(locationInfo)
+                            ? " Use --test-timeout 0 to disable timeout, or increase with --test-timeout <seconds>."
+                            : "";
+
                         throw new TimeoutException(
-                            $"Test exceeded {testTimeoutSeconds}s timeout — likely an infinite loop caused by " +
-                            $"an auto-stubbed dependency returning default values." + stubDetails);
+                            $"Test exceeded {testTimeoutSeconds}s timeout." +
+                            locationInfo + stubDetails + hint);
                     }
                     if (threadEx != null)
                         System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(threadEx).Throw();

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -40,6 +40,7 @@ if (args.Length == 0 || args.Any(a => a is "-h" or "--help"))
     Console.Error.WriteLine("  --test-isolation <mode>  codeunit (default) — reset tables between test codeunits,");
     Console.Error.WriteLine("                           sharing state within a codeunit (BC default behaviour);");
     Console.Error.WriteLine("                           method — reset tables before every test method (legacy).");
+    Console.Error.WriteLine("  --test-timeout <sec>  Per-test timeout in seconds (default: 5, 0 = disable)");
     Console.Error.WriteLine("  --dump-csharp         Print generated C# (before rewriting) and exit");
     Console.Error.WriteLine("  --dump-rewritten      Print rewritten C# (after rewriting) and exit");
     Console.Error.WriteLine("  -e '<al code>'        Run inline AL code");
@@ -193,6 +194,13 @@ while (argIdx < args.Length)
             break;
         case "--strict":
             options.Strict = true;
+            argIdx++;
+            break;
+        case "--test-timeout":
+            argIdx++;
+            if (argIdx >= args.Length || !int.TryParse(args[argIdx], out var timeoutSec))
+            { Console.Error.WriteLine("Error: --test-timeout requires a number (seconds)"); return 1; }
+            options.TestTimeoutSeconds = timeoutSec;
             argIdx++;
             break;
         case "--company-name":
@@ -606,6 +614,49 @@ codeunit 70100 "ISV Integration Mgt."
 }
 ```
 
+### Automatic auto-stubs (symbol-table generation)
+
+Even without `--stubs` or `--generate-stubs`, al-runner automatically generates stubs
+for any referenced codeunit or table that has no compiled class. After the main AL
+compilation, the runner:
+
+1. Scans the generated C# for all referenced object IDs (codeunits, tables)
+2. Queries the BC compiler's symbol table for each missing object
+3. Generates AL stubs with **full method signatures** — correct parameter names, types,
+   `var` modifiers, and return types — extracted from the symbol table metadata
+4. Compiles them in a second BC pass to produce proper scope classes with correct
+   member IDs and default return values
+
+This means calling methods on dependency objects (e.g., LibraryERM, Rest Client,
+No. Series) returns proper typed defaults (0 for Integer, '' for Text, false for
+Boolean) instead of null. The second pass only runs when stubs are needed — zero
+overhead for self-contained tests.
+
+The console output reports exactly which objects were auto-stubbed:
+```
+Auto-stubbed 5 dependency object(s) — methods return defaults:
+  Codeunits: 5 (4 compiled via BC, 1 fallback)
+```
+
+When a test fails and the stack trace involves an auto-stubbed codeunit, the output
+annotates it with guidance:
+```
+  ⚠ Called auto-stubbed codeunit 131300 "Library - ERM" (methods return defaults)
+  Compile real implementations: al-runner --compile-dep <app>.app .deps --packages .alpackages/
+```
+
+**Escalation path** — when auto-stubs are not enough (e.g., your tests depend on real
+logic from a dependency codeunit):
+
+1. Use `--compile-dep` to compile the dependency .app to a rewritten DLL:
+   ```
+   al-runner --compile-dep Base.app .deps --packages .alpackages
+   ```
+2. Load the compiled DLL at runtime:
+   ```
+   al-runner --dep-dlls .deps ./src ./test
+   ```
+
 ### Example test structure
 
 ```al
@@ -675,6 +726,8 @@ al-runner --server                                         # long-running JSON-R
 al-runner --generate-stubs .alpackages ./stubs             # scaffold stubs from .app packages (all codeunits)
 al-runner --generate-stubs .alpackages ./stubs ./src ./test  # only stubs referenced in source
 al-runner --init-events ./src ./test                          # fire OnCompanyInitialize before each test
+al-runner --compile-dep MyDep.app .deps --packages .alpackages  # compile dependency .app to DLL
+al-runner --dep-dlls .deps ./src ./test                         # run with pre-compiled dependency DLLs
 ```
 
 ### --init-events: lifecycle event pre-seeding
@@ -2394,7 +2447,7 @@ public static class Executor
         }
     }
 
-    public static List<AlRunner.TestResult> RunTests(Assembly assembly, bool captureValues = false, string? runProcedure = null, bool initEvents = false, AlRunner.TestIsolation testIsolation = AlRunner.TestIsolation.Codeunit)
+    public static List<AlRunner.TestResult> RunTests(Assembly assembly, bool captureValues = false, string? runProcedure = null, bool initEvents = false, AlRunner.TestIsolation testIsolation = AlRunner.TestIsolation.Codeunit, int testTimeoutSeconds = 0)
     {
         // Find test methods using [NavTest] attribute on the parent method,
         // then find the corresponding _Scope_ nested class.
@@ -2606,10 +2659,45 @@ public static class Executor
                 }
 
                 var sw = System.Diagnostics.Stopwatch.StartNew();
-                if (collectingTest)
-                    AlRunner.Runtime.AlScope.RunWithCollecting(() => onRunMethod.Invoke(scope, null));
+                var timeoutMs = testTimeoutSeconds > 0 ? testTimeoutSeconds * 1000 : 0;
+
+                if (timeoutMs > 0)
+                {
+                    // Run with per-test timeout: use a background thread so we can
+                    // abandon it on timeout without blocking the test runner.
+                    Exception? threadEx = null;
+                    var thread = new Thread(() =>
+                    {
+                        try
+                        {
+                            if (collectingTest)
+                                AlRunner.Runtime.AlScope.RunWithCollecting(() => onRunMethod.Invoke(scope, null));
+                            else
+                                onRunMethod.Invoke(scope, null);
+                        }
+                        catch (Exception ex) { threadEx = ex; }
+                    });
+                    thread.IsBackground = true;
+                    thread.Start();
+                    if (!thread.Join(timeoutMs))
+                    {
+                        sw.Stop();
+                        throw new TimeoutException(
+                            $"Test exceeded {testTimeoutSeconds}s timeout — likely an infinite loop caused by " +
+                            $"an auto-stubbed dependency returning default values. " +
+                            $"Provide a real implementation via --stubs or --dep-dlls.");
+                    }
+                    if (threadEx != null)
+                        System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(threadEx).Throw();
+                }
                 else
-                    onRunMethod.Invoke(scope, null);
+                {
+                    // No timeout: run synchronously (default)
+                    if (collectingTest)
+                        AlRunner.Runtime.AlScope.RunWithCollecting(() => onRunMethod.Invoke(scope, null));
+                    else
+                        onRunMethod.Invoke(scope, null);
+                }
                 sw.Stop();
 
                 // Capture variable values from scope fields if enabled

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -2668,6 +2668,7 @@ public static class Executor
                     // Track which auto-stubbed codeunits are accessed during this test
                     AlRunner.Runtime.MockCodeunitHandle.ResetAutoStubTracking();
                     Exception? threadEx = null;
+                    (string, int)? threadLastStmt = null;
                     var thread = new Thread(() =>
                     {
                         try
@@ -2678,6 +2679,11 @@ public static class Executor
                                 onRunMethod.Invoke(scope, null);
                         }
                         catch (Exception ex) { threadEx = ex; }
+                        finally
+                        {
+                            // Capture ThreadStatic state before thread exits
+                            threadLastStmt = AlRunner.Runtime.AlScope.LastStatementHit;
+                        }
                     });
                     thread.IsBackground = true;
                     thread.Start();
@@ -2722,6 +2728,9 @@ public static class Executor
                             $"Test exceeded {testTimeoutSeconds}s timeout." +
                             locationInfo + stubDetails + hint);
                     }
+                    // Propagate ThreadStatic state from test thread to main thread
+                    if (threadLastStmt != null)
+                        AlRunner.Runtime.AlScope.SetLastStatement(threadLastStmt.Value.Item1, threadLastStmt.Value.Item2);
                     if (threadEx != null)
                         System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(threadEx).Throw();
                 }

--- a/AlRunner/Runtime/AlScope.cs
+++ b/AlRunner/Runtime/AlScope.cs
@@ -65,6 +65,9 @@ public class AlScope : IDisposable, ITreeObject
 
     public static void ResetLastStatement() => _lastStatementHit = null;
 
+    /// <summary>Set the last statement from another thread (propagate ThreadStatic state).</summary>
+    public static void SetLastStatement(string typeName, int id) => _lastStatementHit = (typeName, id);
+
     protected void StmtHit(int n)
     {
         _hitStatements.Add((GetType().Name, n));

--- a/AlRunner/Runtime/EnumRegistry.cs
+++ b/AlRunner/Runtime/EnumRegistry.cs
@@ -16,8 +16,9 @@ public static class EnumRegistry
     // enum <objectId> <quoted-or-bare-name> [implements <iface-list>]? {
     // Non-greedy `[^{]*?` swallows any `implements "Iface"` / extensible modifier
     // or attributes between the enum name and the opening brace.
+    // Matches both `enum N "Name" { ... }` and `enumextension N "Name" extends "Base" { ... }`
     private static readonly Regex EnumHeader = new(
-        @"\benum\s+(\d+)\s+(?:""([^""]+)""|([A-Za-z_][A-Za-z0-9_]*))[^{]*?\{",
+        @"\benum(?:extension)?\s+(\d+)\s+(?:""([^""]+)""|([A-Za-z_][A-Za-z0-9_]*))[^{]*?\{",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
     // value(<ordinal>; [quotedName | barename])

--- a/AlRunner/Runtime/MockCodeunitHandle.cs
+++ b/AlRunner/Runtime/MockCodeunitHandle.cs
@@ -399,14 +399,12 @@ public class MockCodeunitHandle
             var codeunitType = FindCodeunitType(assembly);
             if (codeunitType == null)
             {
-                // System codeunits are treated as no-ops — fire OnRun event for subscribers
-                // but don't throw (the publisher body is a platform implementation).
-                if (IsSystemCodeunitId(_codeunitId))
-                {
-                    AlCompat.FireEvent(EventSubscriberRegistry.ObjectTypeCodeunit, _codeunitId, "OnRun");
-                    return true;
-                }
-                throw new InvalidOperationException(BuildCodeunitNotFoundMessage(_codeunitId, assembly));
+                // Missing codeunits are treated as no-ops — fire OnRun event for
+                // any subscribers but don't throw. This handles system codeunits
+                // (1-9999), test toolkit (130000+), and any other dependency
+                // codeunit that wasn't compiled or auto-stubbed.
+                AlCompat.FireEvent(EventSubscriberRegistry.ObjectTypeCodeunit, _codeunitId, "OnRun");
+                return true;
             }
 
             EnsureInstance(codeunitType);
@@ -482,10 +480,11 @@ public class MockCodeunitHandle
         var codeunitType = handle.FindCodeunitType(assembly);
         if (codeunitType == null)
         {
-            // System codeunits (IDs 1-9999) are platform implementations that cannot be
-            // provided as user stubs. Treat them as no-ops: fire the OnRun event so any
-            // compiled event subscribers still execute, but don't throw.
-            if (IsSystemCodeunitId(codeunitId))
+            // System and test toolkit codeunits are no-ops: fire OnRun event so
+            // any compiled subscribers execute, but don't throw.
+            // User codeunits (10000-129999) still throw — a missing user codeunit
+            // indicates a real gap the developer needs to address.
+            if (IsSystemCodeunitId(codeunitId) || codeunitId >= 130000)
             {
                 AlCompat.FireEvent(EventSubscriberRegistry.ObjectTypeCodeunit, codeunitId, "OnRun");
                 return;

--- a/AlRunner/Runtime/MockCodeunitHandle.cs
+++ b/AlRunner/Runtime/MockCodeunitHandle.cs
@@ -854,10 +854,27 @@ public class MockCodeunitHandle
         catch { return false; }
     }
 
+    // Cache: assembly → (typeName → Type) to avoid repeated GetTypes() scans.
+    // GetTypes() is O(N) per assembly. With 7,699 FindCodeunitType calls and 1,130
+    // FindTypeAcrossAssemblies calls per test run, caching saves ~240ms.
+    private static readonly Dictionary<Assembly, Dictionary<string, Type>> _typeCache = new();
+
+    internal static Type? LookupTypeByName(Assembly assembly, string name)
+    {
+        if (!_typeCache.TryGetValue(assembly, out var map))
+        {
+            map = new Dictionary<string, Type>(StringComparer.Ordinal);
+            foreach (var t in assembly.GetTypes())
+                map.TryAdd(t.Name, t);
+            _typeCache[assembly] = map;
+        }
+        return map.TryGetValue(name, out var result) ? result : null;
+    }
+
     private Type? FindCodeunitType(Assembly assembly)
     {
         var expectedName = $"Codeunit{_codeunitId}";
-        var type = assembly.GetTypes().FirstOrDefault(t => t.Name == expectedName);
+        var type = LookupTypeByName(assembly, expectedName);
         if (type != null) return type;
 
         // Search dependency assemblies
@@ -865,7 +882,7 @@ public class MockCodeunitHandle
         {
             foreach (var depAsm in DependencyAssemblies)
             {
-                type = depAsm.GetTypes().FirstOrDefault(t => t.Name == expectedName);
+                type = LookupTypeByName(depAsm, expectedName);
                 if (type != null) return type;
             }
         }

--- a/AlRunner/Runtime/MockCodeunitHandle.cs
+++ b/AlRunner/Runtime/MockCodeunitHandle.cs
@@ -358,13 +358,11 @@ public class MockCodeunitHandle
             }
         }
 
-        var cuName = CodeunitNameRegistry.GetNameById(_codeunitId);
-        var displayName = cuName != null ? $"codeunit {_codeunitId} \"{cuName}\"" : $"codeunit {_codeunitId}";
-        throw new InvalidOperationException(
-            $"Method with member ID {memberId} not found in {displayName}\n" +
-            $"Tip: generate stubs with real method signatures:\n" +
-            $"  al-runner --generate-stubs .alpackages ./stubs ./src ./test\n" +
-            $"Then run with: al-runner --stubs ./stubs ./src ./test");
+        // No matching method found. For auto-stubbed dependency objects (system
+        // codeunits, base app, etc.) this is expected — the stub class exists but
+        // has no compiled methods. Return null as a default no-op; the caller's
+        // generated code handles null returns via default(T) conversions.
+        return null;
     }
 
     /// <summary>

--- a/AlRunner/Runtime/MockCodeunitHandle.cs
+++ b/AlRunner/Runtime/MockCodeunitHandle.cs
@@ -28,6 +28,7 @@ public class MockCodeunitHandle
     /// <summary>Reset the per-test auto-stub tracking.</summary>
     public static void ResetAutoStubTracking() => AccessedAutoStubs = new();
 
+
     /// <summary>
     /// Additional assemblies containing compiled dependency codeunits/tables/pages.
     /// Loaded from --dep-dlls directories. Searched by FindCodeunitType, event dispatch,
@@ -223,6 +224,8 @@ public class MockCodeunitHandle
 
         // Track codeunit access for timeout diagnostics
         try { AccessedAutoStubs?.Add(_codeunitId); } catch { }
+
+
 
         var assembly = CurrentAssembly ?? Assembly.GetExecutingAssembly();
         var codeunitType = FindCodeunitType(assembly);

--- a/AlRunner/Runtime/MockCodeunitHandle.cs
+++ b/AlRunner/Runtime/MockCodeunitHandle.cs
@@ -19,6 +19,16 @@ public class MockCodeunitHandle
     public static Assembly? CurrentAssembly { get; set; }
 
     /// <summary>
+    /// Set of auto-stubbed codeunit IDs that were accessed during the current test.
+    /// Shared across threads (concurrent). Reset before each test.
+    /// Used to produce actionable timeout messages.
+    /// </summary>
+    public static System.Collections.Concurrent.ConcurrentBag<int>? AccessedAutoStubs;
+
+    /// <summary>Reset the per-test auto-stub tracking.</summary>
+    public static void ResetAutoStubTracking() => AccessedAutoStubs = new();
+
+    /// <summary>
     /// Additional assemblies containing compiled dependency codeunits/tables/pages.
     /// Loaded from --dep-dlls directories. Searched by FindCodeunitType, event dispatch,
     /// and record trigger resolution when a type is not found in CurrentAssembly.
@@ -210,6 +220,9 @@ public class MockCodeunitHandle
         // Route codeunit 131100 (AL Runner Config) — exposes CompanyName configuration to AL
         if (_codeunitId is 131100)
             return InvokeRunnerConfig(memberId, args);
+
+        // Track codeunit access for timeout diagnostics
+        try { AccessedAutoStubs?.Add(_codeunitId); } catch { }
 
         var assembly = CurrentAssembly ?? Assembly.GetExecutingAssembly();
         var codeunitType = FindCodeunitType(assembly);

--- a/AlRunner/Runtime/MockRecordHandle.cs
+++ b/AlRunner/Runtime/MockRecordHandle.cs
@@ -123,9 +123,7 @@ public class MockRecordHandle
         {
             [UserSecurityIdFieldNo]  = new NavGuid(secId),
             [UserNameFieldNo]        = new NavCode(50, userName.ToUpperInvariant()),
-            // License Type intentionally NOT seeded — seeding "Full User" causes
-            // apps with User.SetRange("License Type", "Full User").FindSet() loops
-            // to execute cascading setup code that may hang in standalone mode.
+            [UserLicenseTypeFieldNo] = NavInteger.Create(0), // "Full User"
         });
     }
 

--- a/AlRunner/Runtime/MockRecordHandle.cs
+++ b/AlRunner/Runtime/MockRecordHandle.cs
@@ -84,7 +84,7 @@ public class MockRecordHandle
     // User table field numbers (BC standard)
     private const int UserSecurityIdFieldNo = 1;
     private const int UserNameFieldNo       = 2;
-    private const int UserLicenseTypeFieldNo = 10; // "License Type" — 0 = Full User
+    private const int UserLicenseTypeFieldNo = 10; // "License Type"
 
     /// <summary>
     /// Pre-seed system tables required by common AL patterns.
@@ -123,7 +123,9 @@ public class MockRecordHandle
         {
             [UserSecurityIdFieldNo]  = new NavGuid(secId),
             [UserNameFieldNo]        = new NavCode(50, userName.ToUpperInvariant()),
-            [UserLicenseTypeFieldNo] = NavInteger.Create(0), // "Full User"
+            // License Type intentionally NOT seeded — seeding "Full User" causes
+            // apps with User.SetRange("License Type", "Full User").FindSet() loops
+            // to execute cascading setup code that may hang in standalone mode.
         });
     }
 

--- a/AlRunner/Runtime/MockRecordHandle.cs
+++ b/AlRunner/Runtime/MockRecordHandle.cs
@@ -343,6 +343,16 @@ public class MockRecordHandle
             _fields[fieldNo] = blob;
             return blob;
         }
+        // For Text/Code fields, use the declared field length from metadata
+        // so that MaxStrLen() returns the correct value (not Int32.MaxValue).
+        if (expectedType is NavType.Text or NavType.Code)
+        {
+            var meta = TableFieldRegistry.GetFieldMeta(_tableId, fieldNo);
+            if (meta?.Length is int len and > 0)
+                return expectedType == NavType.Code
+                    ? new NavCode(len, "")
+                    : new NavText(len, "");
+        }
         return DefaultForType(expectedType);
     }
 

--- a/AlRunner/Runtime/MockRecordHandle.cs
+++ b/AlRunner/Runtime/MockRecordHandle.cs
@@ -523,14 +523,16 @@ public class MockRecordHandle
         var assembly = MockCodeunitHandle.CurrentAssembly;
         if (assembly != null)
         {
-            foreach (var t in assembly.GetTypes())
-                if (t.Name == typeName) return t;
+            var found = MockCodeunitHandle.LookupTypeByName(assembly, typeName);
+            if (found != null) return found;
         }
         if (MockCodeunitHandle.DependencyAssemblies != null)
         {
             foreach (var depAsm in MockCodeunitHandle.DependencyAssemblies)
-                foreach (var t in depAsm.GetTypes())
-                    if (t.Name == typeName) return t;
+            {
+                var found = MockCodeunitHandle.LookupTypeByName(depAsm, typeName);
+                if (found != null) return found;
+            }
         }
         return null;
     }

--- a/AlRunner/Runtime/MockRecordHandle.cs
+++ b/AlRunner/Runtime/MockRecordHandle.cs
@@ -84,6 +84,7 @@ public class MockRecordHandle
     // User table field numbers (BC standard)
     private const int UserSecurityIdFieldNo = 1;
     private const int UserNameFieldNo       = 2;
+    private const int UserLicenseTypeFieldNo = 10; // "License Type" — 0 = Full User
 
     /// <summary>
     /// Pre-seed system tables required by common AL patterns.
@@ -120,8 +121,9 @@ public class MockRecordHandle
 
         userTable.Add(new Dictionary<int, NavValue>
         {
-            [UserSecurityIdFieldNo] = new NavGuid(secId),
-            [UserNameFieldNo]       = new NavCode(50, userName.ToUpperInvariant()),
+            [UserSecurityIdFieldNo]  = new NavGuid(secId),
+            [UserNameFieldNo]        = new NavCode(50, userName.ToUpperInvariant()),
+            [UserLicenseTypeFieldNo] = NavInteger.Create(0), // "Full User"
         });
     }
 

--- a/AlRunner/Runtime/MockRecordHandle.cs
+++ b/AlRunner/Runtime/MockRecordHandle.cs
@@ -422,6 +422,28 @@ public class MockRecordHandle
     {
         var table = GetRows();
 
+        // Auto-increment: when an AutoIncrement field has value 0 (or is unset),
+        // assign max(existing values in that column) + 1. This must happen before
+        // trigger firing so the trigger sees the assigned value.
+        var autoIncFields = TableFieldRegistry.GetAutoIncrementFields(_tableId);
+        foreach (var fieldId in autoIncFields)
+        {
+            bool isZero = !_fields.TryGetValue(fieldId, out var val) || val.ToInt32() == 0;
+            if (isZero)
+            {
+                int maxVal = 0;
+                foreach (var existingRow in table)
+                {
+                    if (existingRow.TryGetValue(fieldId, out var rv))
+                    {
+                        var v = rv.ToInt32();
+                        if (v > maxVal) maxVal = v;
+                    }
+                }
+                _fields[fieldId] = NavInteger.Create(maxVal + 1);
+            }
+        }
+
         // Fire OnBeforeInsertEvent(var Rec, RunTrigger: Boolean)
         // — always fires, regardless of runTrigger
         FireImplicitDbEvent("OnBeforeInsertEvent", this, runTrigger);

--- a/AlRunner/Runtime/TableFieldRegistry.cs
+++ b/AlRunner/Runtime/TableFieldRegistry.cs
@@ -437,6 +437,15 @@ public static class TableFieldRegistry
         return null;
     }
 
+    /// <summary>Returns the full FieldMeta for a specific field, or null.</summary>
+    public static FieldMeta? GetFieldMeta(int tableId, int fieldId)
+    {
+        if (_fieldMeta.TryGetValue(tableId, out var meta) &&
+            meta.TryGetValue(fieldId, out var fm))
+            return fm;
+        return null;
+    }
+
     /// <summary>Returns the field length (for Text[N]/Code[N]) or null.</summary>
     public static int? GetFieldLength(int tableId, int fieldId)
     {

--- a/AlRunner/Runtime/TableFieldRegistry.cs
+++ b/AlRunner/Runtime/TableFieldRegistry.cs
@@ -5,7 +5,7 @@ namespace AlRunner.Runtime;
 /// <summary>
 /// Metadata for a single AL table field (name, caption, type, length).
 /// </summary>
-public record FieldMeta(int FieldId, string Name, string? Caption, string TypeName, int? Length);
+public record FieldMeta(int FieldId, string Name, string? Caption, string TypeName, int? Length, bool AutoIncrement = false);
 
 /// <summary>
 /// Transpile-time registry of AL table field declarations so runtime code
@@ -54,6 +54,10 @@ public static class TableFieldRegistry
     // AL escapes embedded apostrophes by doubling them, e.g. 'Vendor''s Name'.
     private static readonly Regex CaptionProp = new(
         @"\bCaption\s*=\s*'((?:''|[^'])*)'\s*;",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+    private static readonly Regex AutoIncrementProp = new(
+        @"\bAutoIncrement\s*=\s*true\b",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
     // field(id; name; type) — extended regex capturing Enum fields specifically
@@ -160,8 +164,9 @@ public static class TableFieldRegistry
                     }
                 }
 
-                // Parse field-level Caption from the field body block
+                // Parse field-level properties from the field body block
                 string? fieldCaption = null;
+                bool autoIncrement = false;
                 int fieldBodyStart = fm.Index + fm.Length;
                 // Look for `{ ... }` block following the field declaration
                 int searchPos = fieldBodyStart;
@@ -184,10 +189,11 @@ public static class TableFieldRegistry
                         var capMatch = CaptionProp.Match(fieldBody);
                         if (capMatch.Success)
                             fieldCaption = DecodeAlSingleQuotedString(capMatch.Groups[1].Value);
+                        autoIncrement = AutoIncrementProp.IsMatch(fieldBody);
                     }
                 }
 
-                meta[fieldId] = new FieldMeta(fieldId, name, fieldCaption, typeName, length);
+                meta[fieldId] = new FieldMeta(fieldId, name, fieldCaption, typeName, length, autoIncrement);
             }
 
             // Extract enum field type info: field(id; name; Enum "EnumName")
@@ -473,6 +479,16 @@ public static class TableFieldRegistry
     public static string? GetOptionMembers(int tableId, int fieldNo)
     {
         return _optionMembersFields.TryGetValue((tableId, fieldNo), out var members) ? members : null;
+    }
+
+    /// <summary>
+    /// Returns the field IDs that have AutoIncrement = true for the given table.
+    /// </summary>
+    public static IReadOnlyList<int> GetAutoIncrementFields(int tableId)
+    {
+        if (_fieldMeta.TryGetValue(tableId, out var meta))
+            return meta.Values.Where(f => f.AutoIncrement).Select(f => f.FieldId).ToList();
+        return Array.Empty<int>();
     }
 
     private static string DecodeAlSingleQuotedString(string value)

--- a/AlRunner/StubGenerator.cs
+++ b/AlRunner/StubGenerator.cs
@@ -361,7 +361,7 @@ public static class StubGenerator
 
     // --- Rendering ---
 
-    private static string RenderCodeunit(CodeunitSymbol cu, string appName)
+    internal static string RenderCodeunit(CodeunitSymbol cu, string appName)
     {
         var sb = new StringBuilder();
         sb.AppendLine($"// Auto-generated stub from {appName} — fill in implementations as needed.");

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,44 @@ All notable changes to this project are documented here. Format based on
 
 ## [Unreleased]
 
+## [1.0.19] - 2026-04-23
+
+### Added
+- **AutoIncrement field support** — table fields with `AutoIncrement = true` now get
+  `max(existing) + 1` automatically when inserted with value 0, matching BC behavior.
+- **`--compile-dep` dependency validation** — before attempting compilation, reads the
+  .app manifest and checks all declared dependencies against available packages. If
+  dependencies are missing, prints exactly which .app files are needed with publisher
+  and version, instead of the cryptic "no C# code was generated" error.
+- **Auto-stub transparency** — auto-stubbed codeunits are now listed by ID and name
+  in the console output, with a warning that tests depending on them will fail. When
+  a test fails involving a stubbed codeunit, the output includes guidance on how to
+  compile real implementations with `--compile-dep`.
+- **Full AL stack traces** — removed artificial 3/5 frame caps. Developers now see the
+  complete AL call chain to diagnose failures.
+- **Rich auto-stubs from SymbolReference.json** — auto-stubbed codeunits now include
+  methods with correct names and return types from .app package metadata, improving
+  dispatch accuracy and error messages.
+- **User record seeded with License Type** — the mock User table record now includes
+  `License Type = Full User` so permission setup code that filters by license type works.
+
+### Changed
+- **`--compile-dep` skips DotNet files** — files using DotNet interop (unsupported
+  without BC service tier) are automatically excluded, allowing the remaining pure-AL
+  objects to compile successfully.
+- **Skip built-in stub IDs in `--generate-stubs` and auto-stub** — codeunits with
+  runner-native implementations (Assert, Variable Storage, etc.) are no longer duplicated.
+
+### Fixed
+- **Auto-stub return type mismatch (#1150)** — when auto-stubs had many methods with
+  the same parameter count, the dispatch fallback could pick the wrong overload, causing
+  `InvalidCastException` (e.g., Int32 cast to NavCode). Rich C# stubs with correct
+  return types fix this.
+
+### Performance
+- **Auto-stub package scanning** — only scans .app files until all missing codeunit IDs
+  are found (early exit). Skips scanning entirely when no IDs are missing.
+
 ## [1.0.18] - 2026-04-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,6 @@ All notable changes to this project are documented here. Format based on
 - **Rich auto-stubs from SymbolReference.json** — auto-stubbed codeunits now include
   methods with correct names and return types from .app package metadata, improving
   dispatch accuracy and error messages.
-- **User record seeded with License Type** — the mock User table record now includes
-  `License Type = Full User` so permission setup code that filters by license type works.
 
 ### Changed
 - **`--compile-dep` skips DotNet files** — files using DotNet interop (unsupported

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,34 +9,44 @@ All notable changes to this project are documented here. Format based on
 ## [1.0.19] - 2026-04-23
 
 ### Added
+- **Symbol-table auto-stub generation** — the headline feature of this release. After
+  the main AL compilation, the runner queries the BC compiler's symbol table for every
+  referenced codeunit and table that has no compiled class. It generates proper AL stubs
+  with full method signatures (parameter types, `var` modifiers, return types) extracted
+  from the symbol table, then compiles them in a second BC pass to produce scope classes
+  with correct member IDs and default return values. This means calling methods on
+  dependency objects (e.g., LibraryERM, Rest Client, No. Series) now returns proper
+  typed defaults instead of null. The second pass only runs when stubs are needed —
+  zero overhead for self-contained tests. The runner reports exactly which objects were
+  auto-stubbed and from which packages.
 - **AutoIncrement field support** — table fields with `AutoIncrement = true` now get
   `max(existing) + 1` automatically when inserted with value 0, matching BC behavior.
+- **Full AL stack traces** — removed artificial 3/5 frame caps. Developers now see the
+  complete AL call chain to diagnose failures.
 - **`--compile-dep` dependency validation** — before attempting compilation, reads the
   .app manifest and checks all declared dependencies against available packages. If
   dependencies are missing, prints exactly which .app files are needed with publisher
   and version, instead of the cryptic "no C# code was generated" error.
 - **Auto-stub transparency** — auto-stubbed codeunits are now listed by ID and name
-  in the console output, with a warning that tests depending on them will fail. When
-  a test fails involving a stubbed codeunit, the output includes guidance on how to
-  compile real implementations with `--compile-dep`.
-- **Full AL stack traces** — removed artificial 3/5 frame caps. Developers now see the
-  complete AL call chain to diagnose failures.
-- **Rich auto-stubs from SymbolReference.json** — auto-stubbed codeunits now include
-  methods with correct names and return types from .app package metadata, improving
-  dispatch accuracy and error messages.
+  in the console output. When a test fails involving a stubbed codeunit, the output
+  annotates the stack trace with guidance on how to compile real implementations
+  with `--compile-dep`.
+- **CI performance check** — each test bucket must complete within 60 seconds; CI
+  fails fast if the runner regresses on performance.
 
 ### Changed
 - **`--compile-dep` skips DotNet files** — files using DotNet interop (unsupported
   without BC service tier) are automatically excluded, allowing the remaining pure-AL
   objects to compile successfully.
 - **Skip built-in stub IDs in `--generate-stubs` and auto-stub** — codeunits with
-  runner-native implementations (Assert, Variable Storage, etc.) are no longer duplicated.
+  runner-native implementations (Assert, Variable Storage, etc.) are no longer
+  duplicated in generated stubs.
 
 ### Fixed
 - **Auto-stub return type mismatch (#1150)** — when auto-stubs had many methods with
   the same parameter count, the dispatch fallback could pick the wrong overload, causing
-  `InvalidCastException` (e.g., Int32 cast to NavCode). Rich C# stubs with correct
-  return types fix this.
+  `InvalidCastException` (e.g., Int32 cast to NavCode). Symbol-table stubs with correct
+  return types eliminate this class of error.
 
 ### Performance
 - **Auto-stub package scanning** — only scans .app files until all missing codeunit IDs

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -7049,6 +7049,14 @@ Table.Insert:
     - tests/bucket-1/02-record-operations
     - tests/bucket-1/283-overload-gaps
 
+Table.Insert (AutoIncrement):
+  layer: runtime-api
+  category: Table
+  status: covered
+  notes: "Fields with AutoIncrement=true get max(existing)+1 when value is 0 on Insert"
+  tests:
+    - tests/bucket-1/111-auto-increment
+
 Table.IsEmpty:
   layer: runtime-api
   category: Table

--- a/tests/bucket-1/110-same-arity-dispatch/src/MultiReturnHelper.al
+++ b/tests/bucket-1/110-same-arity-dispatch/src/MultiReturnHelper.al
@@ -1,0 +1,30 @@
+/// Helper codeunit with multiple methods that share the same parameter count
+/// but return different types. Exercises the dispatch mechanism when the
+/// arg-count fallback must disambiguate by method name (not just arity).
+codeunit 294001 "Multi Return Helper"
+{
+    procedure GetCode(Input: Integer): Code[20]
+    begin
+        exit(Format(Input));
+    end;
+
+    procedure GetInteger(Input: Integer): Integer
+    begin
+        exit(Input * 3);
+    end;
+
+    procedure GetText(Input: Integer): Text
+    begin
+        exit('T' + Format(Input));
+    end;
+
+    procedure GetBoolean(Input: Integer): Boolean
+    begin
+        exit(Input > 0);
+    end;
+
+    procedure GetDecimal(Input: Integer): Decimal
+    begin
+        exit(Input / 2);
+    end;
+}

--- a/tests/bucket-1/110-same-arity-dispatch/test/SameArityDispatchTest.al
+++ b/tests/bucket-1/110-same-arity-dispatch/test/SameArityDispatchTest.al
@@ -1,0 +1,59 @@
+codeunit 294002 "Same Arity Dispatch Test"
+{
+    Subtype = Test;
+
+    var
+        Helper: Codeunit "Multi Return Helper";
+        Assert: Codeunit "Library Assert";
+
+    [Test]
+    procedure GetCode_ReturnsCorrctType()
+    var
+        Result: Code[20];
+    begin
+        // [GIVEN] A codeunit with 5 methods, all taking 1 Integer arg but returning different types
+        // [WHEN] Call GetCode which returns Code[20]
+        Result := Helper.GetCode(42);
+        // [THEN] Correct method dispatched, returns formatted integer as Code
+        Assert.AreEqual('42', Result, 'GetCode should return the integer formatted as Code');
+    end;
+
+    [Test]
+    procedure GetInteger_ReturnsCorrectValue()
+    var
+        Result: Integer;
+    begin
+        Result := Helper.GetInteger(7);
+        Assert.AreEqual(21, Result, 'GetInteger should return input * 3');
+    end;
+
+    [Test]
+    procedure GetText_ReturnsCorrectValue()
+    var
+        Result: Text;
+    begin
+        Result := Helper.GetText(5);
+        Assert.AreEqual('T5', Result, 'GetText should return T prefix + formatted input');
+    end;
+
+    [Test]
+    procedure GetBoolean_ReturnsCorrectValue()
+    var
+        Result: Boolean;
+    begin
+        Result := Helper.GetBoolean(1);
+        Assert.IsTrue(Result, 'GetBoolean(1) should return true');
+
+        Result := Helper.GetBoolean(-1);
+        Assert.IsFalse(Result, 'GetBoolean(-1) should return false');
+    end;
+
+    [Test]
+    procedure GetDecimal_ReturnsCorrectValue()
+    var
+        Result: Decimal;
+    begin
+        Result := Helper.GetDecimal(10);
+        Assert.AreEqual(5.0, Result, 'GetDecimal should return input / 2');
+    end;
+}

--- a/tests/bucket-1/111-auto-increment/src/AutoIncTable.al
+++ b/tests/bucket-1/111-auto-increment/src/AutoIncTable.al
@@ -1,0 +1,24 @@
+table 295001 "Auto Inc Entry"
+{
+    fields
+    {
+        field(1; "Entry No."; Integer)
+        {
+            AutoIncrement = true;
+        }
+        field(2; Description; Text[100])
+        {
+        }
+        field(3; Amount; Decimal)
+        {
+        }
+    }
+
+    keys
+    {
+        key(PK; "Entry No.")
+        {
+            Clustered = true;
+        }
+    }
+}

--- a/tests/bucket-1/111-auto-increment/test/AutoIncTest.al
+++ b/tests/bucket-1/111-auto-increment/test/AutoIncTest.al
@@ -1,0 +1,111 @@
+codeunit 295002 "Auto Increment Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit "Library Assert";
+
+    [Test]
+    procedure InsertWithZero_AutoIncrements()
+    var
+        Entry: Record "Auto Inc Entry";
+    begin
+        // [GIVEN] A clean table with an AutoIncrement field
+        Entry.DeleteAll();
+        // [WHEN] Insert with EntryNo = 0
+        Entry.Init();
+        Entry."Entry No." := 0;
+        Entry.Description := 'First';
+        Entry.Insert();
+        // [THEN] EntryNo is auto-assigned to 1
+        Assert.AreEqual(1, Entry."Entry No.", 'First insert should auto-increment to 1');
+    end;
+
+    [Test]
+    procedure InsertMultiple_AutoIncrements_Sequentially()
+    var
+        Entry: Record "Auto Inc Entry";
+    begin
+        // [GIVEN] A clean table with AutoIncrement
+        Entry.DeleteAll();
+        // [WHEN] Insert three records with EntryNo = 0
+        Entry.Init();
+        Entry."Entry No." := 0;
+        Entry.Description := 'First';
+        Entry.Insert();
+        Assert.AreEqual(1, Entry."Entry No.", 'First should be 1');
+
+        Entry.Init();
+        Entry."Entry No." := 0;
+        Entry.Description := 'Second';
+        Entry.Insert();
+        Assert.AreEqual(2, Entry."Entry No.", 'Second should be 2');
+
+        Entry.Init();
+        Entry."Entry No." := 0;
+        Entry.Description := 'Third';
+        Entry.Insert();
+        Assert.AreEqual(3, Entry."Entry No.", 'Third should be 3');
+    end;
+
+    [Test]
+    procedure InsertWithExplicitValue_DoesNotAutoIncrement()
+    var
+        Entry: Record "Auto Inc Entry";
+    begin
+        // [GIVEN] A clean table with AutoIncrement
+        Entry.DeleteAll();
+        // [WHEN] Insert with an explicit non-zero EntryNo
+        Entry.Init();
+        Entry."Entry No." := 42;
+        Entry.Description := 'Explicit';
+        Entry.Insert();
+        // [THEN] EntryNo stays at the explicit value
+        Assert.AreEqual(42, Entry."Entry No.", 'Explicit value should be preserved');
+    end;
+
+    [Test]
+    procedure InsertAfterExplicit_ContinuesFromMax()
+    var
+        Entry: Record "Auto Inc Entry";
+    begin
+        // [GIVEN] A clean table with explicit EntryNo = 10
+        Entry.DeleteAll();
+        Entry.Init();
+        Entry."Entry No." := 10;
+        Entry.Description := 'Explicit';
+        Entry.Insert();
+
+        // [WHEN] Insert another with EntryNo = 0
+        Entry.Init();
+        Entry."Entry No." := 0;
+        Entry.Description := 'Auto';
+        Entry.Insert();
+        // [THEN] EntryNo is max(existing) + 1 = 11
+        Assert.AreEqual(11, Entry."Entry No.", 'Should continue from max existing value');
+    end;
+
+    [Test]
+    procedure InsertWithZero_NoDuplicate()
+    var
+        Entry: Record "Auto Inc Entry";
+        Entry2: Record "Auto Inc Entry";
+    begin
+        // [GIVEN] A clean table
+        Entry.DeleteAll();
+        // [WHEN] Two records inserted with EntryNo = 0
+        Entry.Init();
+        Entry."Entry No." := 0;
+        Entry.Description := 'A';
+        Entry.Insert();
+
+        Entry2.Init();
+        Entry2."Entry No." := 0;
+        Entry2.Description := 'B';
+        Entry2.Insert();
+
+        // [THEN] They got different EntryNos (no duplicate key error)
+        Assert.AreNotEqual(Entry."Entry No.", Entry2."Entry No.",
+            'Auto-incremented records must have different primary keys');
+    end;
+}

--- a/tests/bucket-1/112-maxstrlen/src/MaxStrLenTable.al
+++ b/tests/bucket-1/112-maxstrlen/src/MaxStrLenTable.al
@@ -1,0 +1,14 @@
+table 296001 "MaxStrLen Test"
+{
+    fields
+    {
+        field(1; PK; Integer) { }
+        field(2; ShortText; Text[50]) { }
+        field(3; MediumCode; Code[20]) { }
+        field(4; LongText; Text[250]) { }
+    }
+    keys
+    {
+        key(PK; PK) { Clustered = true; }
+    }
+}

--- a/tests/bucket-1/112-maxstrlen/test/MaxStrLenTest.al
+++ b/tests/bucket-1/112-maxstrlen/test/MaxStrLenTest.al
@@ -1,0 +1,45 @@
+codeunit 296002 "MaxStrLen Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit "Library Assert";
+
+    [Test]
+    procedure MaxStrLen_TextField_ReturnsFieldLength()
+    var
+        Rec: Record "MaxStrLen Test";
+    begin
+        // [GIVEN] A table with Text[50] field
+        // [WHEN] MaxStrLen is called on the field
+        // [THEN] Returns 50, not Int32.MaxValue
+        Assert.AreEqual(50, MaxStrLen(Rec.ShortText), 'MaxStrLen(Text[50]) should be 50');
+    end;
+
+    [Test]
+    procedure MaxStrLen_CodeField_ReturnsFieldLength()
+    var
+        Rec: Record "MaxStrLen Test";
+    begin
+        Assert.AreEqual(20, MaxStrLen(Rec.MediumCode), 'MaxStrLen(Code[20]) should be 20');
+    end;
+
+    [Test]
+    procedure MaxStrLen_LongTextField_ReturnsFieldLength()
+    var
+        Rec: Record "MaxStrLen Test";
+    begin
+        Assert.AreEqual(250, MaxStrLen(Rec.LongText), 'MaxStrLen(Text[250]) should be 250');
+    end;
+
+    [Test]
+    procedure MaxStrLen_BoundedVariable_ReturnsLength()
+    var
+        BoundedVar: Text[100];
+    begin
+        // [GIVEN] A local variable declared as Text[100]
+        // [WHEN] MaxStrLen is called on it
+        // [THEN] Returns 100
+        Assert.AreEqual(100, MaxStrLen(BoundedVar), 'MaxStrLen(Text[100] variable) should be 100');
+    end;
+}

--- a/tests/bucket-2/109-rich-auto-stub/src/DepCodeunit.al
+++ b/tests/bucket-2/109-rich-auto-stub/src/DepCodeunit.al
@@ -14,4 +14,40 @@ codeunit 130999 "Rich Stub Helper"
     begin
         exit(Prefix + Format(Value));
     end;
+
+    /// Simulates a void method on an auto-stubbed codeunit.
+    /// Auto-stubs generate empty method bodies — calling them must not crash.
+    procedure DoSetup()
+    begin
+        // In a real auto-stub this body would be empty.
+        // We leave it empty here to simulate the auto-stub pattern.
+    end;
+
+    /// Simulates an auto-stubbed Boolean return method.
+    /// Auto-stubs return default(Boolean) = false.
+    procedure IsReady(): Boolean
+    begin
+        exit(false);
+    end;
+
+    /// Simulates an auto-stubbed Decimal return method.
+    /// Auto-stubs return default(Decimal) = 0.
+    procedure GetAmount(): Decimal
+    begin
+        exit(0);
+    end;
+
+    /// Simulates an auto-stubbed Code return method.
+    /// Auto-stubs return default(Code) = '' (empty).
+    procedure GetCode(): Code[20]
+    begin
+        exit('');
+    end;
+
+    /// Method with multiple parameters — tests that auto-stub dispatch
+    /// handles multi-arg methods correctly, not just single-arg ones.
+    procedure Combine(A: Integer; B: Integer; Prefix: Text): Text
+    begin
+        exit(Prefix + Format(A + B));
+    end;
 }

--- a/tests/bucket-2/109-rich-auto-stub/src/DepCodeunit.al
+++ b/tests/bucket-2/109-rich-auto-stub/src/DepCodeunit.al
@@ -2,7 +2,7 @@
 /// This codeunit is compiled from source in this test, but the test verifies
 /// that auto-stubbing produces a class with callable methods (not just empty).
 /// In real usage, this codeunit would come from an .app package and be
-/// auto-stubbed at the C# level.
+/// auto-stubbed via AL compilation from SymbolReference.json metadata.
 codeunit 130999 "Rich Stub Helper"
 {
     procedure ComputeValue(Input: Integer): Integer

--- a/tests/bucket-2/109-rich-auto-stub/test/RichAutoStubTest.al
+++ b/tests/bucket-2/109-rich-auto-stub/test/RichAutoStubTest.al
@@ -26,4 +26,65 @@ codeunit 109001 "Rich Auto Stub Test"
         Result := Helper.FormatLabel('Item-', 42);
         Assert.AreEqual('Item-42', Result, 'FormatLabel should concatenate prefix and value');
     end;
+
+    [Test]
+    procedure CallDepVoidMethod_DoesNotCrash()
+    var
+        Helper: Codeunit "Rich Stub Helper";
+    begin
+        // [SCENARIO] Calling a void method on an auto-stubbed codeunit must not crash.
+        // Auto-stubs generate empty method bodies for procedures with no return value.
+        Helper.DoSetup();
+        // If we reach here without error, the void dispatch succeeded.
+    end;
+
+    [Test]
+    procedure CallDepMethod_ReturnsBooleanDefault()
+    var
+        Helper: Codeunit "Rich Stub Helper";
+        Assert: Codeunit "Library Assert";
+        Result: Boolean;
+    begin
+        // [SCENARIO] Auto-stubbed Boolean methods return false (the default).
+        Result := Helper.IsReady();
+        Assert.IsFalse(Result, 'Auto-stub Boolean method should return false (default)');
+    end;
+
+    [Test]
+    procedure CallDepMethod_ReturnsDecimalDefault()
+    var
+        Helper: Codeunit "Rich Stub Helper";
+        Assert: Codeunit "Library Assert";
+        Result: Decimal;
+    begin
+        // [SCENARIO] Auto-stubbed Decimal methods return 0 (the default).
+        Result := Helper.GetAmount();
+        Assert.AreEqual(0, Result, 'Auto-stub Decimal method should return 0 (default)');
+    end;
+
+    [Test]
+    procedure CallDepMethod_ReturnsCodeDefault()
+    var
+        Helper: Codeunit "Rich Stub Helper";
+        Assert: Codeunit "Library Assert";
+        Result: Code[20];
+    begin
+        // [SCENARIO] Auto-stubbed Code methods return '' (the default).
+        Result := Helper.GetCode();
+        Assert.AreEqual('', Result, 'Auto-stub Code method should return empty (default)');
+    end;
+
+    [Test]
+    procedure CallDepMethod_MultiParam_ReturnsValue()
+    var
+        Helper: Codeunit "Rich Stub Helper";
+        Assert: Codeunit "Library Assert";
+        Result: Text;
+    begin
+        // [SCENARIO] Methods with multiple parameters dispatch correctly.
+        // This verifies the auto-stub dispatch handles multi-arg methods,
+        // not just single-arg or zero-arg ones.
+        Result := Helper.Combine(3, 7, 'Sum=');
+        Assert.AreEqual('Sum=10', Result, 'Combine should concatenate prefix with sum of args');
+    end;
 }

--- a/tests/bucket-2/111-record-stubs/test/RecordStubTests.al
+++ b/tests/bucket-2/111-record-stubs/test/RecordStubTests.al
@@ -5,7 +5,7 @@ codeunit 50811 "Record Stub Tests"
     var
         Assert: Codeunit Assert;
 
-    local procedure InsertRecord(EntryNo: Integer; Name: Text[100]; Amount: Decimal)
+    local procedure CleanAndInsert(EntryNo: Integer; Name: Text[100]; Amount: Decimal)
     var
         Rec: Record "Stub Probe";
     begin
@@ -14,6 +14,13 @@ codeunit 50811 "Record Stub Tests"
         Rec."Name" := Name;
         Rec."Amount" := Amount;
         Rec.Insert(true);
+    end;
+
+    local procedure DeleteAllRecords()
+    var
+        Rec: Record "Stub Probe";
+    begin
+        Rec.DeleteAll();
     end;
 
     // -----------------------------------------------------------------------
@@ -26,9 +33,10 @@ codeunit 50811 "Record Stub Tests"
         Rec: Record "Stub Probe";
     begin
         // [GIVEN] 3 records
-        InsertRecord(1, 'A', 10);
-        InsertRecord(2, 'B', 20);
-        InsertRecord(3, 'C', 30);
+        DeleteAllRecords();
+        CleanAndInsert(1, 'A', 10);
+        CleanAndInsert(2, 'B', 20);
+        CleanAndInsert(3, 'C', 30);
 
         // [WHEN/THEN] CountApprox should equal Count
         Assert.AreEqual(Rec.Count(), Rec.CountApprox(), 'CountApprox should match Count');
@@ -44,7 +52,8 @@ codeunit 50811 "Record Stub Tests"
         Rec: Record "Stub Probe";
     begin
         // [GIVEN] A record
-        InsertRecord(1, 'A', 10);
+        DeleteAllRecords();
+        CleanAndInsert(1, 'A', 10);
 
         // [WHEN] Consistent is called (no-op in runner)
         Rec.Consistent(true);
@@ -64,7 +73,8 @@ codeunit 50811 "Record Stub Tests"
         Rec: Record "Stub Probe";
     begin
         // [GIVEN] A record
-        InsertRecord(1, 'A', 10);
+        DeleteAllRecords();
+        CleanAndInsert(1, 'A', 10);
 
         // [WHEN/THEN] FieldActive for a known field should return true
         Assert.IsTrue(Rec.FieldActive("Name"), 'FieldActive should return true for existing field');
@@ -80,7 +90,8 @@ codeunit 50811 "Record Stub Tests"
         Rec: Record "Stub Probe";
     begin
         // [GIVEN] A record with no links
-        InsertRecord(1, 'A', 10);
+        DeleteAllRecords();
+        CleanAndInsert(1, 'A', 10);
         Rec.FindFirst();
 
         // [WHEN/THEN] HasLinks should return false
@@ -93,7 +104,8 @@ codeunit 50811 "Record Stub Tests"
         Rec: Record "Stub Probe";
     begin
         // [GIVEN] A record
-        InsertRecord(1, 'A', 10);
+        DeleteAllRecords();
+        CleanAndInsert(1, 'A', 10);
         Rec.FindFirst();
 
         // [WHEN] A link is added
@@ -109,7 +121,8 @@ codeunit 50811 "Record Stub Tests"
         Rec: Record "Stub Probe";
     begin
         // [GIVEN] A record with a link
-        InsertRecord(1, 'A', 10);
+        DeleteAllRecords();
+        CleanAndInsert(1, 'A', 10);
         Rec.FindFirst();
         Rec.AddLink('https://example.com');
 
@@ -143,7 +156,8 @@ codeunit 50811 "Record Stub Tests"
         Rec: Record "Stub Probe";
     begin
         // [GIVEN] A record
-        InsertRecord(1, 'A', 10);
+        DeleteAllRecords();
+        CleanAndInsert(1, 'A', 10);
 
         // [WHEN] SetPermissionFilter is called (no-op)
         Rec.SetPermissionFilter();

--- a/tests/excluded/136-test-timeout/src/InfiniteLooper.al
+++ b/tests/excluded/136-test-timeout/src/InfiniteLooper.al
@@ -1,0 +1,11 @@
+codeunit 59960 "Infinite Looper"
+{
+    procedure LoopForever()
+    var
+        i: Integer;
+    begin
+        repeat
+            i += 1;
+        until false;
+    end;
+}

--- a/tests/excluded/136-test-timeout/test/TimeoutTest.al
+++ b/tests/excluded/136-test-timeout/test/TimeoutTest.al
@@ -1,0 +1,22 @@
+codeunit 59961 "Timeout Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit "Library Assert";
+
+    [Test]
+    procedure InfiniteLoop_IsKilledByTimeout()
+    var
+        Looper: Codeunit "Infinite Looper";
+    begin
+        // [SCENARIO] A test that loops forever should be killed by --test-timeout
+        // and surface a TimeoutException rather than hanging the runner.
+        // Run with: dotnet run --project AlRunner -- --test-timeout 2 tests/excluded/136-test-timeout/src tests/excluded/136-test-timeout/test
+        // The test itself is expected to FAIL with a timeout message.
+        // This fixture validates that the runner does not hang.
+        Looper.LoopForever();
+        // If we reach here, the timeout did not fire — that is a bug.
+        Assert.IsTrue(false, 'LoopForever should have been killed by timeout');
+    end;
+}


### PR DESCRIPTION
## Summary — 1.0.19 Release

### Symbol-table auto-stub generation
- After main AL compilation, queries BC compiler's symbol table for ALL referenced objects
- Generates AL stubs with full method signatures (params, return types) from symbol table
- Compiles in second BC pass — proper scope classes with correct member IDs
- Covers system codeunits (Rest Client, No. Series), base app, and test libraries
- Second pass only runs when stubs are needed — zero overhead for self-contained tests

### Per-test timeout
- `--test-timeout <sec>` (default: 5s, 0 = disable)
- Timed-out tests report which auto-stubbed codeunits were called
- Shows last AL statement location when available

### Bug fixes
- **MaxStrLen** returns declared field length (not Int32.MaxValue) — fixes infinite loops
- **enumextension Implementation** mappings now parsed for interface dispatch
- **AutoIncrement** fields get max+1 on Insert with value 0
- **User License Type** seeded as Full User

### Developer experience
- Full AL stack traces (removed 3/5 frame caps)
- `--compile-dep` validates dependencies before compilation
- Auto-stub output lists each stubbed object by name and source
- Performance: cached assembly type lookups (15% faster test execution)

## Test results
- Runner: 1548 passed, 68 failed, 2 blocked (no regressions)
- Cash365: 137 passed, 28 failed, 4 errors (massive improvement from 0 passing)