### PR TITLE
fix: emit LF (not OS newline) from TextBuilder.AppendLine

### DIFF
--- a/AlRunner.Tests/MockTextBuilderTests.cs
+++ b/AlRunner.Tests/MockTextBuilderTests.cs
@@ -1,0 +1,70 @@
+using AlRunner.Runtime;
+using Microsoft.Dynamics.Nav.Runtime;
+using Microsoft.Dynamics.Nav.Types;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// Unit tests for MockTextBuilder line-terminator behavior.
+///
+/// BC's TextBuilder.AppendLine appends a bare LF ('\n', Char(10)) on every OS.
+/// MockTextBuilder previously delegated to StringBuilder.AppendLine(), which uses
+/// Environment.NewLine — "\r\n" on Windows, "\n" on Linux/macOS — so AL code that
+/// round-trips through AppendLine produced different bytes depending on the host.
+///
+/// The CI matrix (ubuntu-latest only) never exercised the Windows path, so the
+/// existing AL e2e test tests/bucket-1/17-text-builder passed on CI for the
+/// wrong reason and failed on Windows developer machines.
+///
+/// Note: pre-fix, these assertions fail on Windows (where StringBuilder.AppendLine
+/// emits CRLF) but accidentally pass on Linux (where it already emits LF). Post-fix
+/// they are byte-exact on every OS and serve as regression guards against any future
+/// reintroduction of StringBuilder.AppendLine.
+///
+/// Issue: #1157
+/// </summary>
+public class MockTextBuilderTests
+{
+    [Fact]
+    public void ALAppendLine_NoArgs_EmitsLf_NotCrlf()
+    {
+        var tb = new MockTextBuilder();
+        tb.ALAppendLine();
+
+        Assert.Equal("\n", tb.ToString());
+        Assert.DoesNotContain("\r", tb.ToString());
+    }
+
+    [Fact]
+    public void ALAppendLine_WithDataError_EmitsLf_NotCrlf()
+    {
+        var tb = new MockTextBuilder();
+        tb.ALAppendLine(DataError.ThrowError);
+
+        Assert.Equal("\n", tb.ToString());
+        Assert.DoesNotContain("\r", tb.ToString());
+    }
+
+    [Fact]
+    public void ALAppendLine_WithDataErrorAndText_AppendsTextThenLf_NotCrlf()
+    {
+        var tb = new MockTextBuilder();
+        tb.ALAppendLine(DataError.ThrowError, new NavText("hello"));
+
+        Assert.Equal("hello\n", tb.ToString());
+        Assert.DoesNotContain("\r", tb.ToString());
+    }
+
+    [Fact]
+    public void ALAppendLine_MultipleCalls_ProducesLfJoinedLines_NotCrlf()
+    {
+        var tb = new MockTextBuilder();
+        tb.ALAppendLine(DataError.ThrowError, new NavText("one"));
+        tb.ALAppendLine(DataError.ThrowError, new NavText("two"));
+        tb.ALAppend(DataError.ThrowError, new NavText("three"));
+
+        Assert.Equal("one\ntwo\nthree", tb.ToString());
+        Assert.DoesNotContain("\r", tb.ToString());
+    }
+}

--- a/AlRunner/Runtime/MockTextBuilder.cs
+++ b/AlRunner/Runtime/MockTextBuilder.cs
@@ -23,19 +23,21 @@ public class MockTextBuilder
         _sb.Append((string)text);
     }
 
+    // BC's TextBuilder.AppendLine always appends a bare LF (Char(10)) on every OS —
+    // do NOT use StringBuilder.AppendLine, which emits Environment.NewLine (CRLF on Windows).
     public void ALAppendLine(DataError errorLevel, NavText text)
     {
-        _sb.AppendLine((string)text);
+        _sb.Append((string)text).Append('\n');
     }
 
     public void ALAppendLine(DataError errorLevel)
     {
-        _sb.AppendLine();
+        _sb.Append('\n');
     }
 
     public void ALAppendLine()
     {
-        _sb.AppendLine();
+        _sb.Append('\n');
     }
 
     /// <summary>

--- a/tests/bucket-1/17-text-builder/test/TextBuilderTest.al
+++ b/tests/bucket-1/17-text-builder/test/TextBuilderTest.al
@@ -39,4 +39,29 @@ codeunit 50917 "Text Builder Tests"
             Result,
             'List text should match expected output');
     end;
+
+    [Test]
+    procedure TestAppendLineEmitsLfOnly_NotCrlf()
+    var
+        TB: TextBuilder;
+        Result: Text;
+        LF: Char;
+        CR: Char;
+    begin
+        // [SCENARIO] BC's TextBuilder.AppendLine must emit bare LF on every OS,
+        //            regardless of host line-ending conventions.
+        LF := 10;
+        CR := 13;
+
+        // [WHEN] AppendLine is called
+        TB.AppendLine('line1');
+        TB.Append('line2');
+        Result := TB.ToText();
+
+        // [THEN] Output contains LF (positive)
+        Assert.IsTrue(StrPos(Result, Format(LF)) > 0, 'Output must contain LF (Char(10))');
+
+        // [THEN] Output contains NO CR (negative — guards against CRLF leaking from host OS)
+        Assert.AreEqual(0, StrPos(Result, Format(CR)), 'Output must not contain CR (Char(13))');
+    end;
 }


### PR DESCRIPTION
## Summary

`MockTextBuilder.ALAppendLine` (all 3 overloads) delegated to `StringBuilder.AppendLine()`, which uses `Environment.NewLine` — CRLF on Windows, LF on Linux/macOS. BC's real `TextBuilder.AppendLine` is OS-stable and always emits bare LF (`Char(10)`).

The gap was invisible to CI (`ubuntu-latest` only, where `Environment.NewLine == "\n"` already) but failed `tests/bucket-1/17-text-builder` byte-for-byte on Windows:

```
Expected: Dear Mr. Smith,\nWelcome to our service.\nBest regards
Actual:   Dear Mr. Smith,\r\nWelcome to our service.\r\nBest regards
```

Fix: append `'\n'` explicitly in all three overloads. Much of the AL community develops on Windows, so closing this matters even though CI never reported it.

Closes #1157

## Test plan

- [x] 4 new byte-exact unit tests in `AlRunner.Tests/MockTextBuilderTests.cs` covering all three `ALAppendLine` overloads plus the `ALAppend`/`ALAppendLine` boundary
- [x] Manual mutation test: 7 mutations, 6 killed on every OS, 1 (swap `'\n'` → `Environment.NewLine`) escapes on Linux only — same inherent single-OS limit as the underlying bug
- [x] C# suite net10.0: 308 passed / 1 pre-existing unrelated failure (`DuplicatePackageTests.FindAlcPath` Windows bug)
- [x] AL bucket-1: 1602 passed (was 1600 on main — two `17-text-builder` cases now green on Windows)
- [x] AL bucket-2 and stubs suite: unchanged