### PR TITLE
feat: add CopyArray 3-arg overload

### DIFF
--- a/AlRunner/Runtime/AlScope.cs
+++ b/AlRunner/Runtime/AlScope.cs
@@ -2015,6 +2015,18 @@ public static class AlCompat
             dest[i] = src[srcStart + i];
     }
 
+    /// <summary>
+    /// 3-arg overload of <see cref="ALCopyArray{T}"/>: copies all remaining elements
+    /// from <paramref name="src"/> starting at 1-based <paramref name="fromIndex"/>
+    /// into the beginning of <paramref name="dest"/>.
+    /// Equivalent to <c>CopyArray(Dest, Src, FromIndex)</c> in AL (no Count argument).
+    /// </summary>
+    public static void ALCopyArray<T>(MockArray<T> dest, MockArray<T> src, int fromIndex)
+    {
+        int count = src.Length - fromIndex + 1;  // all elements from fromIndex to end
+        ALCopyArray(dest, src, fromIndex, count);
+    }
+
     // -----------------------------------------------------------------------
     // GUID creation helpers
     // -----------------------------------------------------------------------

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -6341,8 +6341,10 @@ System.CopyArray:
   layer: runtime-api
   category: System
   status: covered
-  tests: tests/bucket-2/199-system-array-random
-  notes: overloads=1. ALSystemArray.ALCopyArray redirected to AlCompat.ALCopyArray; copies count elements from 1-based fromIndex in src to dest[0..].
+  tests:
+    - tests/bucket-2/199-system-array-random
+    - tests/bucket-1/99-copyarray-3arg
+  notes: overloads=2. ALSystemArray.ALCopyArray redirected to AlCompat.ALCopyArray; 4-arg overload copies count elements from 1-based fromIndex; 3-arg overload (no count) copies all remaining elements from fromIndex to end.
 
 System.CopyStream:
   layer: runtime-api

--- a/tests/bucket-1/99-copyarray-3arg/src/CopyArray3ArgSrc.al
+++ b/tests/bucket-1/99-copyarray-3arg/src/CopyArray3ArgSrc.al
@@ -1,0 +1,17 @@
+/// Helper codeunit for CopyArray 3-arg overload (no count parameter).
+codeunit 99600 "CA3 Src"
+{
+    // ── CopyArray 3-arg (no count) ────────────────────────────────────────────
+
+    /// CopyArray(Dest, Src, FromIndex) — copies all elements from FromIndex to end.
+    procedure CopyFromIndex(var Src: array[5] of Integer; FromIndex: Integer; var Dest: array[5] of Integer)
+    begin
+        CopyArray(Dest, Src, FromIndex);
+    end;
+
+    /// CopyArray(Dest, Src, 1) — from index 1 means copy everything.
+    procedure CopyAll(var Src: array[5] of Integer; var Dest: array[5] of Integer)
+    begin
+        CopyArray(Dest, Src, 1);
+    end;
+}

--- a/tests/bucket-1/99-copyarray-3arg/test/CopyArray3ArgTest.al
+++ b/tests/bucket-1/99-copyarray-3arg/test/CopyArray3ArgTest.al
@@ -1,0 +1,94 @@
+/// Tests for CopyArray with 3 arguments (no count parameter).
+/// Regression for issue #1155: CS7036 — required parameter 'count' missing.
+codeunit 99601 "CA3 Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        H: Codeunit "CA3 Src";
+
+    // ── Positive: copy from mid-array ─────────────────────────────────────────
+
+    [Test]
+    procedure CopyArray3Arg_FromIndex3_CopiesRemainingElements()
+    var
+        Src: array[5] of Integer;
+        Dest: array[5] of Integer;
+    begin
+        // Src = [10, 20, 30, 40, 50]; FromIndex = 3 → copies elements 30, 40, 50
+        Src[1] := 10;
+        Src[2] := 20;
+        Src[3] := 30;
+        Src[4] := 40;
+        Src[5] := 50;
+        H.CopyFromIndex(Src, 3, Dest);
+        Assert.AreEqual(30, Dest[1], 'Dest[1] must be Src[3]=30');
+        Assert.AreEqual(40, Dest[2], 'Dest[2] must be Src[4]=40');
+        Assert.AreEqual(50, Dest[3], 'Dest[3] must be Src[5]=50');
+    end;
+
+    // ── Positive: copy from index 1 copies everything ─────────────────────────
+
+    [Test]
+    procedure CopyArray3Arg_FromIndex1_CopiesAllElements()
+    var
+        Src: array[5] of Integer;
+        Dest: array[5] of Integer;
+    begin
+        Src[1] := 1;
+        Src[2] := 2;
+        Src[3] := 3;
+        Src[4] := 4;
+        Src[5] := 5;
+        H.CopyAll(Src, Dest);
+        Assert.AreEqual(1, Dest[1], 'Dest[1] must be 1');
+        Assert.AreEqual(2, Dest[2], 'Dest[2] must be 2');
+        Assert.AreEqual(3, Dest[3], 'Dest[3] must be 3');
+        Assert.AreEqual(4, Dest[4], 'Dest[4] must be 4');
+        Assert.AreEqual(5, Dest[5], 'Dest[5] must be 5');
+    end;
+
+    // ── Negative: elements before FromIndex are not copied ────────────────────
+
+    [Test]
+    procedure CopyArray3Arg_FromIndex3_EarlyElementsNotInDest()
+    var
+        Src: array[5] of Integer;
+        Dest: array[5] of Integer;
+    begin
+        Src[1] := 10;
+        Src[2] := 20;
+        Src[3] := 30;
+        Src[4] := 40;
+        Src[5] := 50;
+        H.CopyFromIndex(Src, 3, Dest);
+        // Dest[4] and Dest[5] should be default (0) — only 3 elements copied
+        Assert.AreEqual(0, Dest[4], 'Dest[4] must be default 0 — only 3 elements were copied');
+        Assert.AreEqual(0, Dest[5], 'Dest[5] must be default 0 — only 3 elements were copied');
+    end;
+
+    // ── Negative: 3-arg result differs from 4-arg with partial count ──────────
+
+    [Test]
+    procedure CopyArray3Arg_VsPartial4Arg_DifferentResults()
+    var
+        Src: array[5] of Integer;
+        Dest3: array[5] of Integer;
+        Dest4: array[5] of Integer;
+    begin
+        // CopyArray(Dest, Src, 2) copies 4 elements: Src[2..5]
+        // CopyArray(Dest, Src, 2, 2) copies only 2 elements: Src[2..3]
+        Src[1] := 100;
+        Src[2] := 200;
+        Src[3] := 300;
+        Src[4] := 400;
+        Src[5] := 500;
+        CopyArray(Dest3, Src, 2);
+        CopyArray(Dest4, Src, 2, 2);
+        Assert.AreEqual(200, Dest3[1], '3-arg Dest3[1] = Src[2]');
+        Assert.AreEqual(500, Dest3[4], '3-arg Dest3[4] = Src[5]');
+        Assert.AreEqual(200, Dest4[1], '4-arg Dest4[1] = Src[2]');
+        Assert.AreEqual(0, Dest4[4], '4-arg with count=2: Dest4[4] must be default 0');
+    end;
+}


### PR DESCRIPTION
Closes #1155

## Summary
- Adds a 3-arg overload of `AlCompat.ALCopyArray<T>` that copies all remaining elements from `fromIndex` to the end of the source array
- Fixes the `CS7036` error: `CopyArray(Dest, Source, FromIndex)` with no count argument now compiles and executes correctly
- New AL test suite `99-copyarray-3arg` in bucket-1 with 4 proving tests (positive + negative cases)
- Updates `docs/coverage.yaml` to reflect 2 overloads now covered

## Test plan
- [ ] `CopyArray3Arg_FromIndex3_CopiesRemainingElements` — 3-arg call copies exactly 3 elements from index 3
- [ ] `CopyArray3Arg_FromIndex1_CopiesAllElements` — 3-arg call from index 1 copies all 5 elements
- [ ] `CopyArray3Arg_FromIndex3_EarlyElementsNotInDest` — elements beyond the copied range stay at default (0)
- [ ] `CopyArray3Arg_VsPartial4Arg_DifferentResults` — proves 3-arg and 4-arg with count=2 produce different results (breaking mock detection)
- [ ] All existing bucket-1 and bucket-2 tests unaffected