### PR TITLE
feat: add MockVariant.Clear() method

### DIFF
--- a/AlRunner/Runtime/MockVariant.cs
+++ b/AlRunner/Runtime/MockVariant.cs
@@ -161,6 +161,15 @@ public class MockVariant
     public bool ALIsTransactionType => false;
     public bool ALIsWideChar => false;
 
+    /// <summary>
+    /// Clear(VariantVar) — resets the variant to its default (empty) state.
+    /// AL's Clear() built-in on a Variant sets it back to no value.
+    /// </summary>
+    public void Clear()
+    {
+        _value = null;
+    }
+
     /// <summary>Get the underlying value.</summary>
     public object? Value => _value;
 

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -8783,6 +8783,13 @@ Time.ToText:
 
 # ── Variant ─────────────────────────────────────────────────────
 
+Variant.Clear:
+  layer: runtime-api
+  category: Variant
+  status: complete
+  tests: tests/bucket-1/97-variant-clear
+  notes: overloads=1; MockVariant.Clear() resets _value to null; proven by Clear_ResetsVariantToDefault, Clear_ViaHelper_ResetsVariantToDefault, Clear_AllowsReassignmentAfterClear
+
 Variant.IsAction:
   layer: runtime-api
   category: Variant

--- a/tests/bucket-1/97-variant-clear/src/VariantClearHelper.al
+++ b/tests/bucket-1/97-variant-clear/src/VariantClearHelper.al
@@ -1,0 +1,17 @@
+codeunit 297001 "Variant Clear Helper"
+{
+    procedure SetIntegerValue(var V: Variant; Value: Integer)
+    begin
+        V := Value;
+    end;
+
+    procedure ClearVariant(var V: Variant)
+    begin
+        Clear(V);
+    end;
+
+    procedure IsVariantInteger(V: Variant): Boolean
+    begin
+        exit(V.IsInteger());
+    end;
+}

--- a/tests/bucket-1/97-variant-clear/test/VariantClearTest.al
+++ b/tests/bucket-1/97-variant-clear/test/VariantClearTest.al
@@ -1,0 +1,60 @@
+codeunit 297002 "Variant Clear Tests"
+{
+    Subtype = Test;
+
+    var
+        Helper: Codeunit "Variant Clear Helper";
+        Assert: Codeunit Assert;
+
+    [Test]
+    procedure Clear_ResetsVariantToDefault()
+    var
+        V: Variant;
+    begin
+        // [GIVEN] A variant holding a specific integer value
+        Helper.SetIntegerValue(V, 42);
+        Assert.IsTrue(V.IsInteger(), 'Variant should hold integer before Clear');
+
+        // [WHEN] Clear is called on the variant
+        Clear(V);
+
+        // [THEN] The variant is no longer an integer (it has been reset)
+        Assert.IsFalse(V.IsInteger(), 'Variant should not be integer after Clear');
+    end;
+
+    [Test]
+    procedure Clear_ViaHelper_ResetsVariantToDefault()
+    var
+        V: Variant;
+    begin
+        // [GIVEN] A variant holding integer 99
+        Helper.SetIntegerValue(V, 99);
+        Assert.IsTrue(V.IsInteger(), 'Variant should hold integer before Clear');
+
+        // [WHEN] Clear is called through a helper procedure (var parameter)
+        Helper.ClearVariant(V);
+
+        // [THEN] The variant is reset and no longer holds an integer
+        Assert.IsFalse(V.IsInteger(), 'Variant should not hold integer after ClearVariant');
+    end;
+
+    [Test]
+    procedure Clear_AllowsReassignmentAfterClear()
+    var
+        V: Variant;
+        Txt: Text;
+    begin
+        // [GIVEN] A variant holding integer 7
+        Helper.SetIntegerValue(V, 7);
+        Assert.IsTrue(V.IsInteger(), 'Variant should hold integer initially');
+
+        // [WHEN] Cleared and then reassigned a text value
+        Clear(V);
+        Txt := 'hello';
+        V := Txt;
+
+        // [THEN] The variant now holds text
+        Assert.IsTrue(V.IsText(), 'Variant should hold text after reassignment');
+        Assert.IsFalse(V.IsInteger(), 'Variant should not hold integer after reassignment');
+    end;
+}


### PR DESCRIPTION
Closes #1152

## Summary
- Adds `Clear()` method to `MockVariant` that resets `_value` to null, fixing the `CS1061` error when AL code calls `Clear(VariantVar)`
- New AL test suite `97-variant-clear` with 3 proving tests (positive + via-helper + reassignment-after-clear)
- Updates `docs/coverage.yaml` with `Variant.Clear` entry (status: complete)

## Test plan
- [x] `Clear_ResetsVariantToDefault` — variant holding integer is no longer IsInteger after Clear
- [x] `Clear_ViaHelper_ResetsVariantToDefault` — Clear through a var-parameter procedure resets the variant
- [x] `Clear_AllowsReassignmentAfterClear` — variant can hold a new type after being cleared
- [x] All 3 new tests pass
- [x] Existing variant tests (suite 11-variant-type) unaffected