### PR TITLE
feat: add Report.Run 4-arg overload (StaticRun)

### DIFF
--- a/AlRunner/Runtime/MockReportHandle.cs
+++ b/AlRunner/Runtime/MockReportHandle.cs
@@ -300,6 +300,19 @@ public class MockReportHandle
     }
 
     /// <summary>
+    /// Static Report.Run(reportId, requestPage, systemPrinter, record) — 4-argument overload.
+    /// <paramref name="requestPage"/> and <paramref name="systemPrinter"/> are ignored in standalone mode.
+    /// <paramref name="record"/> is applied as a table-view filter when it is a <see cref="MockRecordHandle"/>.
+    /// </summary>
+    public static void StaticRun(int reportId, bool requestPage, bool systemPrinter, object record)
+    {
+        var handle = new MockReportHandle(reportId) { UseRequestForm = requestPage };
+        if (record is MockRecordHandle rec)
+            handle.SetTableView(rec);
+        handle.Run();
+    }
+
+    /// <summary>
     /// Static Report.RunModal(reportId) — redirected from NavReport.RunModal() by the rewriter.
     /// If a ReportHandler is registered, invoke it; otherwise create an instance and RunModal().
     /// </summary>

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -5554,9 +5554,10 @@ Report.Run:
   layer: runtime-api
   category: Report
   status: covered
-  notes: overloads=1; NavReport.Run → MockReportHandle.StaticRun (no-op/handler dispatch).
+  notes: "overloads=2 (1-arg, 4-arg); NavReport.Run → MockReportHandle.StaticRun (no-op/handler dispatch). 4-arg adds requestPage, systemPrinter, record Variant (stored via SetTableView if MockRecordHandle)."
   tests:
     - tests/bucket-1/90-report-static
+    - tests/bucket-1/298-report-run-4arg
 
 Report.RunModal:
   layer: runtime-api

--- a/tests/bucket-1/297-record-getposition-bool/test/TestGetPositionBool.al
+++ b/tests/bucket-1/297-record-getposition-bool/test/TestGetPositionBool.al
@@ -1,4 +1,4 @@
-codeunit 297001 "Test GetPosition Boolean"
+codeunit 297003 "Test GetPosition Boolean"
 {
     Subtype = Test;
 

--- a/tests/bucket-1/298-report-run-4arg/src/Rr4Src.al
+++ b/tests/bucket-1/298-report-run-4arg/src/Rr4Src.al
@@ -1,0 +1,50 @@
+/// Source objects for Report.Run 4-arg overload test (issue #1156).
+table 29800 "RR4 Table"
+{
+    fields
+    {
+        field(1; "No."; Code[20]) { }
+        field(2; Amount; Decimal) { }
+    }
+    keys { key(PK; "No.") { Clustered = true; } }
+}
+
+/// Report that accepts RR4 Table as a data item.
+report 29800 "RR4 Report"
+{
+    dataset
+    {
+        dataitem(DataLine; "RR4 Table")
+        {
+        }
+    }
+}
+
+/// Exercises Report.Run with 4 arguments: (ReportId, RequestPage, SystemPrinter, Record)
+codeunit 29801 "RR4 Source"
+{
+    procedure CallRunFourArgs(ReportId: Integer; Rec: Record "RR4 Table")
+    begin
+        Report.Run(ReportId, false, false, Rec);
+    end;
+
+    procedure SetupTableAndRun(ReportId: Integer): Text
+    var
+        Rec: Record "RR4 Table";
+    begin
+        // Insert a record so SetFilter has something to work with
+        Rec.Init();
+        Rec."No." := 'R4-001';
+        Rec.Amount := 42;
+        Rec.Insert();
+
+        // Apply a filter to the record variable before passing to Report.Run
+        Rec.SetFilter("No.", 'R4-001');
+
+        // Call Report.Run with 4 args — must not throw
+        Report.Run(ReportId, false, false, Rec);
+
+        // Return the filter still applied after the call (filter must survive)
+        exit(Rec.GetFilter("No."));
+    end;
+}

--- a/tests/bucket-1/298-report-run-4arg/test/Rr4Test.al
+++ b/tests/bucket-1/298-report-run-4arg/test/Rr4Test.al
@@ -1,0 +1,35 @@
+codeunit 29802 "RR4 Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "RR4 Source";
+
+    // ------------------------------------------------------------------
+    // Report.Run(ReportId, RequestPage, SystemPrinter, Record) — 4-arg
+    // ------------------------------------------------------------------
+
+    [Test]
+    procedure ReportRun_FourArgs_NoError()
+    var
+        Rec: Record "RR4 Table";
+    begin
+        // [GIVEN] A record variable (empty, no filter)
+        // [WHEN]  Report.Run(id, false, false, Rec) is called
+        // [THEN]  No error — 4-arg overload must compile and execute without crashing
+        Src.CallRunFourArgs(29800, Rec);
+    end;
+
+    [Test]
+    procedure ReportRun_FourArgs_FilterSurvivesCall()
+    var
+        FilterAfter: Text;
+    begin
+        // [GIVEN] A record with a filter applied
+        // [WHEN]  Report.Run(id, false, false, Rec) is called
+        // [THEN]  The filter on the record variable is still present after the call
+        FilterAfter := Src.SetupTableAndRun(29800);
+        Assert.AreEqual('R4-001', FilterAfter, 'Filter on record variable must survive Report.Run call');
+    end;
+}


### PR DESCRIPTION
## Summary

- Adds `MockReportHandle.StaticRun(int reportId, bool requestPage, bool systemPrinter, object record)` to fix `CS1501: No overload for method 'StaticRun' takes 4 arguments` when AL code calls `Report.Run(ReportId, RequestPage, SystemPrinter, Record)`
- The `record` arg is applied as a table-view filter when it is a `MockRecordHandle`; all args are no-ops in standalone mode (no UI/printer/I/O)
- Mirrors the existing pattern from the 4-arg `StaticRunModal` overload

Closes #1156

## Test plan

- [ ] `ReportRun_FourArgs_NoError` — confirms the 4-arg overload compiles and executes without error
- [ ] `ReportRun_FourArgs_FilterSurvivesCall` — asserts that a filter applied before `Report.Run` is still present on the record variable after the call (proves the record variable is not mutated by the call)
- [ ] Full bucket-1 regression: 1560 passed, 68 failed (same 68 pre-existing failures, 2 new passes from this PR)