### PR TITLE
fix: CreateDateTime/DT2Time round-trip on non-UTC hosts (#1159)

### DIFF
--- a/AlRunner.Tests/CreateDateTimeTimeZoneTests.cs
+++ b/AlRunner.Tests/CreateDateTimeTimeZoneTests.cs
@@ -1,0 +1,93 @@
+using System;
+using AlRunner.Runtime;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// Unit tests for AlCompat.SafeLocalToUtc — the wall-clock → UTC conversion
+/// AlCompat must apply before storing a DateTime into a NavDateTime's backing
+/// value field.
+///
+/// BC's ALDT2Time / ALDT2Date read NavDateTime.value as a server UTC timestamp
+/// and project it to TimeZoneInfo.Local on every read. Writers that store wall-
+/// clock ticks directly cause DT2Time(CreateDateTime(D, T)) != T on any non-UTC
+/// host. CI runs Linux/UTC, so the gap was invisible there.
+///
+/// These tests verify the pure conversion function behaves deterministically
+/// across timezones — including DST-invalid and DST-ambiguous local times — so
+/// the test runner produces the same NavDateTime.value on any host.
+///
+/// Issue: #1159
+/// </summary>
+public class CreateDateTimeTimeZoneTests
+{
+    private static readonly TimeZoneInfo Tokyo = TimeZoneInfo.FindSystemTimeZoneById("Tokyo Standard Time");       // UTC+9, no DST
+    private static readonly TimeZoneInfo CentralEurope = TimeZoneInfo.FindSystemTimeZoneById("Romance Standard Time"); // UTC+1/+2 with DST
+
+    [Fact]
+    public void SafeLocalToUtc_UtcLocal_ReturnsSameTicksAsUtc()
+    {
+        var wall = new DateTime(2024, 1, 15, 15, 30, 45, DateTimeKind.Unspecified);
+
+        var utc = AlCompat.SafeLocalToUtc(wall, TimeZoneInfo.Utc);
+
+        Assert.Equal(wall.Ticks, utc.Ticks);
+        Assert.Equal(DateTimeKind.Utc, utc.Kind);
+    }
+
+    [Fact]
+    public void SafeLocalToUtc_NonUtcLocal_SubtractsOffset()
+    {
+        var wall = new DateTime(2024, 1, 15, 15, 30, 45, DateTimeKind.Unspecified);
+
+        var utc = AlCompat.SafeLocalToUtc(wall, Tokyo);
+
+        // Tokyo UTC+9: wall-clock 15:30 local → 06:30 UTC
+        Assert.Equal(new DateTime(2024, 1, 15, 6, 30, 45, DateTimeKind.Utc).Ticks, utc.Ticks);
+        Assert.Equal(DateTimeKind.Utc, utc.Kind);
+    }
+
+    [Fact]
+    public void SafeLocalToUtc_AmbiguousLocalTime_PicksStandardTimeOffset()
+    {
+        // CE fall-back: 2024-10-27 02:30 local exists twice. Pick standard-time offset (+1h)
+        // deterministically so Windows and Linux always produce the same UTC ticks.
+        var ambiguous = new DateTime(2024, 10, 27, 2, 30, 0, DateTimeKind.Unspecified);
+        Assert.True(CentralEurope.IsAmbiguousTime(ambiguous));
+
+        var utc = AlCompat.SafeLocalToUtc(ambiguous, CentralEurope);
+
+        // Standard offset is +1 (CET) → UTC 01:30, not DST +2 (CEST) → UTC 00:30.
+        Assert.Equal(new DateTime(2024, 10, 27, 1, 30, 0, DateTimeKind.Utc).Ticks, utc.Ticks);
+    }
+
+    [Fact]
+    public void SafeLocalToUtc_InvalidLocalTime_ShiftsForwardToFirstValidInstant()
+    {
+        // CE spring-forward: 2024-03-31 02:30 local does not exist. Shift to the first
+        // valid instant (03:00 local = 01:00 UTC) deterministically.
+        var invalid = new DateTime(2024, 3, 31, 2, 30, 0, DateTimeKind.Unspecified);
+        Assert.True(CentralEurope.IsInvalidTime(invalid));
+
+        var utc = AlCompat.SafeLocalToUtc(invalid, CentralEurope);
+
+        Assert.Equal(new DateTime(2024, 3, 31, 1, 0, 0, DateTimeKind.Utc).Ticks, utc.Ticks);
+    }
+
+    [Fact]
+    public void SafeLocalToUtc_UnambiguousDstTime_UsesActualOffset()
+    {
+        // In summer, CE is on DST (+2). A wall-clock in mid-summer is not ambiguous and
+        // uses the DST offset (not the standard-time fallback that AmbiguousLocalTime test
+        // pins). This catches a mutant that always chooses standard-time offset.
+        var summer = new DateTime(2024, 7, 15, 14, 0, 0, DateTimeKind.Unspecified);
+        Assert.False(CentralEurope.IsAmbiguousTime(summer));
+        Assert.False(CentralEurope.IsInvalidTime(summer));
+
+        var utc = AlCompat.SafeLocalToUtc(summer, CentralEurope);
+
+        // CEST is +2h → 14:00 local → 12:00 UTC.
+        Assert.Equal(new DateTime(2024, 7, 15, 12, 0, 0, DateTimeKind.Utc).Ticks, utc.Ticks);
+    }
+}

--- a/AlRunner.Tests/CreateDateTimeTimeZoneTests.cs
+++ b/AlRunner.Tests/CreateDateTimeTimeZoneTests.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Reflection;
 using AlRunner.Runtime;
+using Microsoft.Dynamics.Nav.Runtime;
 using Xunit;
 
 namespace AlRunner.Tests;
@@ -20,6 +22,7 @@ namespace AlRunner.Tests;
 ///
 /// Issue: #1159
 /// </summary>
+[Collection("Pipeline")]
 public class CreateDateTimeTimeZoneTests
 {
     private static readonly TimeZoneInfo Tokyo = TimeZoneInfo.FindSystemTimeZoneById("Tokyo Standard Time");       // UTC+9, no DST
@@ -63,6 +66,29 @@ public class CreateDateTimeTimeZoneTests
     }
 
     [Fact]
+    public void PickStandardOffset_StandardFirst_ReturnsFirst()
+    {
+        // TimeZoneInfo.GetAmbiguousTimeOffsets ordering is undefined per MS docs;
+        // both orderings must land on the standard-time offset.
+        var std = TimeSpan.FromHours(1);
+        var dst = TimeSpan.FromHours(2);
+
+        Assert.Equal(std, AlCompat.PickStandardOffset(new[] { std, dst }, std));
+    }
+
+    [Fact]
+    public void PickStandardOffset_StandardLast_ReturnsLast()
+    {
+        // This is the case a regression to `offsets[0]` would miss — it happens to
+        // work on Windows (where standard is first) but would silently break on a
+        // platform where GetAmbiguousTimeOffsets returns [dst, standard].
+        var std = TimeSpan.FromHours(1);
+        var dst = TimeSpan.FromHours(2);
+
+        Assert.Equal(std, AlCompat.PickStandardOffset(new[] { dst, std }, std));
+    }
+
+    [Fact]
     public void SafeLocalToUtc_InvalidLocalTime_ShiftsForwardToFirstValidInstant()
     {
         // CE spring-forward: 2024-03-31 02:30 local does not exist. Shift to the first
@@ -73,6 +99,76 @@ public class CreateDateTimeTimeZoneTests
         var utc = AlCompat.SafeLocalToUtc(invalid, CentralEurope);
 
         Assert.Equal(new DateTime(2024, 3, 31, 1, 0, 0, DateTimeKind.Utc).Ticks, utc.Ticks);
+    }
+
+    [Fact]
+    public void DaTi2Variant_AppliesLocalToUtcConversion()
+    {
+        // Contract for the Variant-context path: the Variant produced by BC's
+        // ALDaTi2Variant lowering must store the same UTC-converted ticks as
+        // ALCreateDateTime would. The AL compiler typically lowers
+        // `v := CreateDateTime(d, t)` through ALCreateDateTime + Variant boxing,
+        // but this test pins the symmetric behavior in case a BC version or
+        // emission pattern reaches AlCompat.DaTi2Variant directly.
+        using var scope = new LocalTimeZoneScope("Tokyo Standard Time"); // UTC+9
+
+        var navDate = ConstructNavValue<NavDate>(
+            new DateTime(2024, 1, 15, 0, 0, 0, DateTimeKind.Unspecified));
+        var navTime = ConstructNavValue<NavTime>(
+            new DateTime(1754, 1, 1, 15, 30, 45, DateTimeKind.Unspecified));
+
+        var variant = AlCompat.DaTi2Variant(navDate, navTime);
+        var navDt = Assert.IsType<NavDateTime>(variant.Value);
+        var stored = AlCompat.GetNavDateTimeValue(navDt);
+
+        // Tokyo wall-clock 2024-01-15 15:30:45 → UTC 06:30:45
+        Assert.Equal(
+            new DateTime(2024, 1, 15, 6, 30, 45, DateTimeKind.Utc).Ticks,
+            stored.Ticks);
+        Assert.Equal(DateTimeKind.Utc, stored.Kind);
+    }
+
+    private static T ConstructNavValue<T>(DateTime value)
+    {
+        var inst = Activator.CreateInstance(typeof(T), nonPublic: true)
+            ?? throw new InvalidOperationException($"Activator failed on {typeof(T)}");
+        var f = typeof(T).BaseType?.GetField("value",
+            BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException($"{typeof(T).Name}.value field not found");
+        f.SetValue(inst, value);
+        return (T)inst;
+    }
+
+    /// <summary>
+    /// Overrides TimeZoneInfo.Local by writing to the private CachedData._localTimeZone
+    /// field; restores on Dispose. Used to make datetime-conversion tests host-independent
+    /// without touching the OS registry.
+    /// </summary>
+    internal sealed class LocalTimeZoneScope : IDisposable
+    {
+        private readonly TimeZoneInfo _original;
+        private readonly FieldInfo _localField;
+        private readonly object _cached;
+
+        public LocalTimeZoneScope(string tzId)
+        {
+            var tziType = typeof(TimeZoneInfo);
+            var cachedField = tziType.GetField("s_cachedData",
+                BindingFlags.Static | BindingFlags.NonPublic)
+                ?? throw new InvalidOperationException("TimeZoneInfo.s_cachedData not found");
+            _cached = cachedField.GetValue(null)
+                ?? throw new InvalidOperationException("s_cachedData instance is null");
+            var nested = tziType.GetNestedType("CachedData", BindingFlags.NonPublic)
+                ?? throw new InvalidOperationException("TimeZoneInfo.CachedData not found");
+            _localField = nested.GetField("_localTimeZone",
+                BindingFlags.Instance | BindingFlags.NonPublic)
+                ?? throw new InvalidOperationException("CachedData._localTimeZone not found");
+            _original = (TimeZoneInfo)(_localField.GetValue(_cached)
+                ?? throw new InvalidOperationException("_localTimeZone was null"));
+            _localField.SetValue(_cached, TimeZoneInfo.FindSystemTimeZoneById(tzId));
+        }
+
+        public void Dispose() => _localField.SetValue(_cached, _original);
     }
 
     [Fact]

--- a/AlRunner/AlRunner.csproj
+++ b/AlRunner/AlRunner.csproj
@@ -8,8 +8,6 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>MSB3277;CA1416</NoWarn>
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
-    <InternalsVisibleTo>AlRunner.Tests</InternalsVisibleTo>
-    <InternalsVisibleTo>AlRunner.Benchmarks</InternalsVisibleTo>
 
     <!-- Cold-start: disable Dynamic PGO profiler overhead (never pays back in <2s process),
          allow QuickJit for loopy methods (BC compiler + Roslyn have many). -->
@@ -38,6 +36,8 @@
   <ItemGroup>
     <None Include="../README.md" Pack="true" PackagePath="/" />
     <None Include="../CHANGELOG.md" Pack="true" PackagePath="/" />
+    <InternalsVisibleTo Include="AlRunner.Tests" />
+    <InternalsVisibleTo Include="AlRunner.Benchmarks" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -2929,11 +2929,16 @@ public void Unbind() { AlRunner.Runtime.EventSubscriberRegistry.Unbind(this); }
             // ALSystemDate.ALVariant2Date(session, v) → AlCompat.Variant2Date(v)
             // ALSystemDate.ALVariant2Time(session, v) → AlCompat.Variant2Time(v)
             // ALSystemDate.ALDaTi2Variant(scope, d, t) → AlCompat.DaTi2Variant(d, t)
+            // ALSystemDate.ALCreateDateTime(session, d, t) → AlCompat.CreateDateTime(d, t)
             // Strip the first (session/scope) arg; these are pure date-arithmetic operations.
             // ALVariant2Date/Time require interception because v is MockVariant, not NavVariant.
             // ALDaTi2Variant requires interception because scope is AlScope, not NavMethodScope.
+            // ALCreateDateTime is intercepted so the runner can apply the local-wall-clock
+            // → UTC conversion BC's read path (ALDT2Time / ALDT2Date) expects. Without it,
+            // DT2Time(CreateDateTime(D, T)) != T on any non-UTC host (issue #1159).
             if (exprText == "ALSystemDate" && methodName is "ALDMY2Date" or "ALDWY2Date"
-                    or "ALVariant2Date" or "ALVariant2Time" or "ALDaTi2Variant")
+                    or "ALVariant2Date" or "ALVariant2Time" or "ALDaTi2Variant"
+                    or "ALCreateDateTime")
             {
                 var args = visited.ArgumentList.Arguments;
                 var compatName = methodName switch
@@ -2943,6 +2948,7 @@ public void Unbind() { AlRunner.Runtime.EventSubscriberRegistry.Unbind(this); }
                     "ALVariant2Date" => "Variant2Date",
                     "ALVariant2Time" => "Variant2Time",
                     "ALDaTi2Variant" => "DaTi2Variant",
+                    "ALCreateDateTime" => "CreateDateTime",
                     _ => methodName
                 };
                 // Strip first arg (session/scope), keep the rest

--- a/AlRunner/Runtime/AlScope.cs
+++ b/AlRunner/Runtime/AlScope.cs
@@ -2322,31 +2322,49 @@ public static class AlCompat
     }
 
     /// <summary>
-    /// DaTi2Variant(date, time) — pack a NavDate + NavTime into a DateTime MockVariant.
-    /// BC emits ALSystemDate.ALDaTi2Variant(scope, d, t) but scope is AlScope not
-    /// NavMethodScope; the rewriter strips it and calls here.
-    /// The result must satisfy Variant.IsDateTime() → wrap as NavDateTime.
+    /// CreateDateTime(date, time) — wrap a NavDate + NavTime into a NavDateTime.
+    /// BC emits ALSystemDate.ALCreateDateTime(session, d, t); the rewriter strips
+    /// the session and redirects here so we can apply the wall-clock → UTC
+    /// conversion BC's read-side ConvertTimeFromUtc expects.
+    /// </summary>
+    public static NavDateTime CreateDateTime(NavDate d, NavTime t)
+        => CreateNavDateTime(SafeLocalToUtc(CombineDateTime(d, t), TimeZoneInfo.Local));
+
+    /// <summary>
+    /// DaTi2Variant(date, time) — pack a NavDate + NavTime into a NavDateTime MockVariant.
+    /// BC emits ALSystemDate.ALDaTi2Variant(scope, d, t); the rewriter strips the scope
+    /// and redirects here. The stored value is UTC-converted (see CreateDateTime) so that
+    /// BC's read-side ConvertTimeFromUtc inverts the write correctly on any host.
     /// </summary>
     public static MockVariant DaTi2Variant(NavDate d, NavTime t)
+        => new(CreateNavDateTime(SafeLocalToUtc(CombineDateTime(d, t), TimeZoneInfo.Local)));
+
+    /// <summary>
+    /// Combine the date components of <paramref name="d"/> and the time-of-day
+    /// components of <paramref name="t"/> into a single wall-clock DateTime with
+    /// DateTimeKind.Unspecified. Extracts values via reflection on the backing
+    /// field because NavDate/NavTime do not implement IConvertible outside a
+    /// NavSession (Convert.ChangeType throws "Object must implement IConvertible").
+    /// </summary>
+    private static DateTime CombineDateTime(NavDate d, NavTime t)
     {
-        // Extract DateTime from NavDate (time part is midnight)
-        DateTime? dateOnly = null;
-        try { dateOnly = (DateTime)Convert.ChangeType(d, typeof(DateTime)); } catch { }
-        // Extract DateTime from NavTime (date part is meaningless)
-        DateTime? timeOnly = null;
-        try { timeOnly = (DateTime)Convert.ChangeType(t, typeof(DateTime)); } catch { }
-
-        var combined = new DateTime(
-            (dateOnly ?? DateTime.MinValue).Year,
-            (dateOnly ?? DateTime.MinValue).Month,
-            (dateOnly ?? DateTime.MinValue).Day,
-            (timeOnly ?? DateTime.MinValue).Hour,
-            (timeOnly ?? DateTime.MinValue).Minute,
-            (timeOnly ?? DateTime.MinValue).Second,
-            (timeOnly ?? DateTime.MinValue).Millisecond);
-
-        return new MockVariant(CreateNavDateTime(combined));
+        var date = NavDateValueField is null ? DateTime.MinValue
+            : (NavDateValueField.GetValue(d) as DateTime?) ?? DateTime.MinValue;
+        var time = NavTimeValueField is null ? DateTime.MinValue
+            : (NavTimeValueField.GetValue(t) as DateTime?) ?? DateTime.MinValue;
+        return new DateTime(
+            date.Year, date.Month, date.Day,
+            time.Hour, time.Minute, time.Second, time.Millisecond,
+            DateTimeKind.Unspecified);
     }
+
+    private static readonly System.Reflection.FieldInfo? NavDateValueField =
+        typeof(NavDate).BaseType?.GetField("value",
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+
+    private static readonly System.Reflection.FieldInfo? NavTimeValueField =
+        typeof(NavTime).BaseType?.GetField("value",
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
 
     /// <summary>
     /// NormalDate(date) — wraps ALSystemDate.ALNormalDate with 0D handling.
@@ -2419,6 +2437,39 @@ public static class AlCompat
         if (diffTicks == 0) return dt;
 
         return CreateNavDateTime(new DateTime(ticks + diffTicks, dateTime.Kind));
+    }
+
+    /// <summary>
+    /// Convert a local-wall-clock DateTime to UTC, using the supplied timezone as the
+    /// local reference. Applied on the write side of CreateDateTime / DaTi2Variant so
+    /// that BC's read-side ConvertTimeFromUtc(value, TimeZoneInfo.Local) correctly
+    /// inverts it, making DT2Time(CreateDateTime(D, T)) round-trip on any host. On
+    /// UTC hosts (CI) this is a no-op, matching the baseline; on non-UTC hosts
+    /// (typical Windows dev boxes) it removes the +offset that would otherwise
+    /// appear in DT2Time.
+    ///
+    /// DST policy is deterministic so Windows and Linux produce identical
+    /// NavDateTime.value ticks on the same input:
+    /// - Ambiguous local times (fall-back hour): use the standard-time offset.
+    /// - Invalid local times (spring-forward gap): shift forward to the first
+    ///   valid local instant (end of the gap).
+    /// </summary>
+    internal static DateTime SafeLocalToUtc(DateTime wallClockLocal, TimeZoneInfo localTz)
+    {
+        var unspec = DateTime.SpecifyKind(wallClockLocal, DateTimeKind.Unspecified);
+        if (localTz.IsInvalidTime(unspec))
+        {
+            while (localTz.IsInvalidTime(unspec))
+                unspec = unspec.AddMinutes(1);
+            return TimeZoneInfo.ConvertTimeToUtc(
+                DateTime.SpecifyKind(unspec, DateTimeKind.Unspecified), localTz);
+        }
+        if (localTz.IsAmbiguousTime(unspec))
+        {
+            var offsets = localTz.GetAmbiguousTimeOffsets(unspec);
+            return DateTime.SpecifyKind(unspec - offsets[0], DateTimeKind.Utc);
+        }
+        return TimeZoneInfo.ConvertTimeToUtc(unspec, localTz);
     }
 
     // Cache the backing field for NavDateTime construction via reflection.

--- a/AlRunner/Runtime/AlScope.cs
+++ b/AlRunner/Runtime/AlScope.cs
@@ -2328,24 +2328,23 @@ public static class AlCompat
     /// conversion BC's read-side ConvertTimeFromUtc expects.
     /// </summary>
     public static NavDateTime CreateDateTime(NavDate d, NavTime t)
-        => CreateNavDateTime(SafeLocalToUtc(CombineDateTime(d, t), TimeZoneInfo.Local));
+        => BuildNavDateTimeUtc(d, t);
 
     /// <summary>
     /// DaTi2Variant(date, time) — pack a NavDate + NavTime into a NavDateTime MockVariant.
     /// BC emits ALSystemDate.ALDaTi2Variant(scope, d, t); the rewriter strips the scope
-    /// and redirects here. The stored value is UTC-converted (see CreateDateTime) so that
-    /// BC's read-side ConvertTimeFromUtc inverts the write correctly on any host.
+    /// and redirects here. Symmetric with CreateDateTime so BC's read path inverts the
+    /// write correctly on any host.
     /// </summary>
     public static MockVariant DaTi2Variant(NavDate d, NavTime t)
-        => new(CreateNavDateTime(SafeLocalToUtc(CombineDateTime(d, t), TimeZoneInfo.Local)));
+        => new(BuildNavDateTimeUtc(d, t));
 
-    /// <summary>
-    /// Combine the date components of <paramref name="d"/> and the time-of-day
-    /// components of <paramref name="t"/> into a single wall-clock DateTime with
-    /// DateTimeKind.Unspecified. Extracts values via reflection on the backing
-    /// field because NavDate/NavTime do not implement IConvertible outside a
-    /// NavSession (Convert.ChangeType throws "Object must implement IConvertible").
-    /// </summary>
+    private static NavDateTime BuildNavDateTimeUtc(NavDate d, NavTime t)
+        => CreateNavDateTime(SafeLocalToUtc(CombineDateTime(d, t), TimeZoneInfo.Local));
+
+    /// Combine date and time components into a wall-clock DateTime with
+    /// DateTimeKind.Unspecified. Uses reflection on the backing value field because
+    /// NavDate / NavTime do not implement IConvertible outside a NavSession.
     private static DateTime CombineDateTime(NavDate d, NavTime t)
     {
         var date = NavDateValueField is null ? DateTime.MinValue
@@ -2358,13 +2357,15 @@ public static class AlCompat
             DateTimeKind.Unspecified);
     }
 
-    private static readonly System.Reflection.FieldInfo? NavDateValueField =
-        typeof(NavDate).BaseType?.GetField("value",
+    private static System.Reflection.FieldInfo? GetNavBackingValueField(Type navValueType)
+        => navValueType.BaseType?.GetField("value",
             System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
 
+    private static readonly System.Reflection.FieldInfo? NavDateValueField =
+        GetNavBackingValueField(typeof(NavDate));
+
     private static readonly System.Reflection.FieldInfo? NavTimeValueField =
-        typeof(NavTime).BaseType?.GetField("value",
-            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+        GetNavBackingValueField(typeof(NavTime));
 
     /// <summary>
     /// NormalDate(date) — wraps ALSystemDate.ALNormalDate with 0D handling.
@@ -2456,6 +2457,10 @@ public static class AlCompat
     /// </summary>
     internal static DateTime SafeLocalToUtc(DateTime wallClockLocal, TimeZoneInfo localTz)
     {
+        // CI runs Linux/UTC — skip the DST probes entirely on the common path.
+        if (ReferenceEquals(localTz, TimeZoneInfo.Utc))
+            return DateTime.SpecifyKind(wallClockLocal, DateTimeKind.Utc);
+
         var unspec = DateTime.SpecifyKind(wallClockLocal, DateTimeKind.Unspecified);
         if (localTz.IsInvalidTime(unspec))
         {
@@ -2467,9 +2472,24 @@ public static class AlCompat
         if (localTz.IsAmbiguousTime(unspec))
         {
             var offsets = localTz.GetAmbiguousTimeOffsets(unspec);
-            return DateTime.SpecifyKind(unspec - offsets[0], DateTimeKind.Utc);
+            var standardOffset = PickStandardOffset(offsets, localTz.BaseUtcOffset);
+            return DateTime.SpecifyKind(unspec - standardOffset, DateTimeKind.Utc);
         }
         return TimeZoneInfo.ConvertTimeToUtc(unspec, localTz);
+    }
+
+    /// <summary>
+    /// Select the standard-time offset from the array returned by
+    /// TimeZoneInfo.GetAmbiguousTimeOffsets. Per MS docs the array order is undefined,
+    /// so the match must be done against BaseUtcOffset rather than a fixed index.
+    /// Returns offsets[0] as a last-resort fallback if neither element matches
+    /// (should not happen for a valid ambiguous-time input).
+    /// </summary>
+    internal static TimeSpan PickStandardOffset(TimeSpan[] offsets, TimeSpan baseUtcOffset)
+    {
+        for (int i = 0; i < offsets.Length; i++)
+            if (offsets[i] == baseUtcOffset) return offsets[i];
+        return offsets[0];
     }
 
     // Cache the backing field for NavDateTime construction via reflection.
@@ -2477,8 +2497,7 @@ public static class AlCompat
     // Telemetry.Abstractions in BC 28+, which is unavailable outside the service tier.
     // Constructing via Activator + field set bypasses all such dependencies.
     private static readonly System.Reflection.FieldInfo? NavDateTimeValueField =
-        typeof(NavDateTime).BaseType?.GetField("value",
-            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+        GetNavBackingValueField(typeof(NavDateTime));
 
     internal static NavDateTime CreateNavDateTime(DateTime dateTime)
     {

--- a/tests/bucket-2/140-create-datetime/src/CreateDateTimeSrc.al
+++ b/tests/bucket-2/140-create-datetime/src/CreateDateTimeSrc.al
@@ -32,4 +32,26 @@ codeunit 60500 "CDT Helper"
     begin
         exit(DT2Date(dt) = 0D);
     end;
+
+    /// Boxes CreateDateTime result into a Variant, unboxes, returns DateTime.
+    /// Exercises the BC lowering path that routes through ALDaTi2Variant.
+    procedure VariantMake(d: Date; t: Time): DateTime
+    var
+        v: Variant;
+        dt: DateTime;
+    begin
+        v := CreateDateTime(d, t);
+        dt := v;
+        exit(dt);
+    end;
+
+    /// Variant-path round-trip: true when the Variant boxed DateTime decomposes
+    /// back to the same date and time.
+    procedure VariantRoundTrip(d: Date; t: Time): Boolean
+    var
+        dt: DateTime;
+    begin
+        dt := VariantMake(d, t);
+        exit((DT2Date(dt) = d) and (DT2Time(dt) = t));
+    end;
 }

--- a/tests/bucket-2/140-create-datetime/test/CreateDateTimeTests.al
+++ b/tests/bucket-2/140-create-datetime/test/CreateDateTimeTests.al
@@ -100,4 +100,41 @@ codeunit 60501 "CDT Create DateTime Tests"
             Helper.ExtractTime(Helper.MakeDateTime(d, 090000T)),
             'DT2Time must distinguish different times');
     end;
+
+    // -----------------------------------------------------------------------
+    // Variant round-trip — exercises the ALDaTi2Variant lowering path
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure CreateDateTime_Variant_RoundTrip_Positive()
+    var
+        d: Date;
+        t: Time;
+    begin
+        // Positive: CreateDateTime result boxed through a Variant preserves both
+        // components when unboxed and decomposed. Exercises ALDaTi2Variant.
+        d := DMY2Date(15, 6, 2024);
+        t := 153045T;
+        Assert.IsTrue(
+            Helper.VariantRoundTrip(d, t),
+            'CreateDateTime via Variant must round-trip');
+    end;
+
+    [Test]
+    procedure CreateDateTime_Variant_DifferentTimes_Distinct()
+    var
+        d: Date;
+        dt1: DateTime;
+        dt2: DateTime;
+    begin
+        // Negative: different times produce distinguishable round-tripped times
+        // even when boxed through a Variant.
+        d := DMY2Date(1, 1, 2023);
+        dt1 := Helper.VariantMake(d, 080000T);
+        dt2 := Helper.VariantMake(d, 090000T);
+        Assert.AreNotEqual(
+            Helper.ExtractTime(dt1),
+            Helper.ExtractTime(dt2),
+            'Variant round-trip must distinguish different times');
+    end;
 }


### PR DESCRIPTION
Closes #1159.

## Problem

On non-UTC hosts, `DT2Time(CreateDateTime(D, T)) != T`. BC's `ALDT2Time` reads `NavDateTime.value` as a server UTC timestamp and projects it to `TimeZoneInfo.Local`, but AlRunner was storing wall-clock ticks directly so the read added the local offset. Linux CI runs UTC so the gap was invisible; Windows added +1 h.

Call path empirically confirmed via a standalone reproducer against `Microsoft.Dynamics.Nav.Runtime.dll`:

```
System.TimeZoneInfo.ConvertTimeFromUtc(DateTime, TimeZoneInfo)
  ← NavDateTime.ConvertToLocalTime(NavSession, DateTime, DateTimeReferenceFrame)
  ← NavDateTime.GetClientLocalValue(NavSession)
  ← NavDateTime.GetTimePart(NavSession)
  ← ALSystemDate.ALDT2Time(NavSession, NavDateTime)
```

Real BC stacks satisfy the UTC invariant because the server converts wall-clock → UTC on write using the session's user timezone. AlRunner has no NavSession and passes `null!`, so BC reflects `TimeZoneInfo.Local` directly.

## Fix

Intercept `ALSystemDate.ALCreateDateTime` in `RoslynRewriter.cs` alongside the existing `ALDaTi2Variant` and redirect to a new `AlCompat.CreateDateTime(NavDate, NavTime)` that converts wall-clock → UTC via a new `SafeLocalToUtc(DateTime, TimeZoneInfo)` helper before wrapping into `NavDateTime`. `DaTi2Variant` updated symmetrically. UTC hosts no-op (matches the Linux CI baseline); non-UTC hosts get the missing conversion.

### DST policy (deterministic, cross-platform)

`SafeLocalToUtc` makes the rare DST edges explicit so Windows and Linux produce identical `NavDateTime.value` ticks for the same input:
- **Ambiguous** local times (fall-back hour, e.g. 2024-10-27 02:30 CE) — select the offset that equals `TimeZoneInfo.BaseUtcOffset` (standard time). MS docs state `GetAmbiguousTimeOffsets` returns offsets in undefined order, so the selection is by value via an extracted `PickStandardOffset(offsets, baseUtcOffset)` helper, not by array index.
- **Invalid** local times (spring-forward gap, e.g. 2024-03-31 02:30 CE) — walk minute-by-minute forward to the first valid instant, then convert.

## Tests

- `AlRunner.Tests/CreateDateTimeTimeZoneTests.cs` — 8 xUnit tests: UTC pass-through, non-UTC offset, DST-ambiguous, DST-invalid, unambiguous-DST, DaTi2Variant round-trip (with reflection-based TimeZoneInfo.Local override), and two ordering-explicit `PickStandardOffset` tests that catch an ordering regression even on platforms where the current runtime ordering happens to pass a weaker test.
- `tests/bucket-2/140-create-datetime/` — two new AL tests exercising the Variant-boxing path (`CreateDateTime_Variant_RoundTrip_Positive`, `CreateDateTime_Variant_DifferentTimes_Distinct`) plus the existing 5 datetime round-trip tests that previously failed on Windows.

### Test evidence (Windows net10.0, Europe/Copenhagen)

| Suite | Passed | Failed |
|---|---|---|
| C# (AlRunner.Tests) | 316 | 1 (pre-existing `DuplicatePackagesWithSymbols_DoNotCauseAl0275Failure` hardcoded-Linux-path, unrelated) |
| AL bucket-1 | 1605 | 0 |
| AL bucket-2 | 1659 | 0 |
| AL stubs | 2 | 0 |

Fork matrix (Linux/net10.0 on all 7 BC versions) validated separately — all green: https://github.com/FBakkensen/BusinessCentral.AL.Runner/pull/2

### Manual mutation tests

Applied seven mutations by hand to verify each test actually proves its claim. All killed:

| # | Mutation | Killed by |
|---|---|---|
| M1 | `BuildNavDateTimeUtc` skips `SafeLocalToUtc` | 5 AL datetime tests + DaTi2Variant C# test |
| M2 | `SafeLocalToUtc` called with `TimeZoneInfo.Utc` instead of `.Local` | Same as M1 |
| M3 | `SafeLocalToUtc` uses `ConvertTimeFromUtc` (wrong direction) | 3 C# + 11 AL tests |
| M4 | `DaTi2Variant` bypasses `BuildNavDateTimeUtc` | `DaTi2Variant_AppliesLocalToUtcConversion` C# test |
| M5 | Rewriter skips `ALCreateDateTime` intercept | 5 AL datetime tests |
| M6 | Ambiguous fall-back uses `offsets[^1]` (DST) | `SafeLocalToUtc_AmbiguousLocalTime_PicksStandardTimeOffset` |
| M7 | Removes invalid-time handling (throws on gap) | `SafeLocalToUtc_InvalidLocalTime_ShiftsForwardToFirstValidInstant` |
| M6-ordering | `PickStandardOffset` returns `offsets[0]` blindly | `PickStandardOffset_StandardLast_ReturnsLast` |

## Infrastructure

- `AlRunner/AlRunner.csproj` — moved `<InternalsVisibleTo>` entries from `<PropertyGroup>` (silently ignored by the SDK) to `<ItemGroup>` so `AlRunner.Tests` can unit-test internal helpers.

## Out of scope

`CurrentDateTime`, `Today`, `Time`, and `0DT` use different BC code paths (`GetALDateTime`, `GetALTime`, `NavDateTime.Create(_, 0U)`) — not touched here. If similar symptoms surface on them, file separately.