### PR TITLE
fix: MockNotification — ALRecall returns bool, add ALAssign and Clear

### DIFF
--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -489,8 +489,10 @@ test executor that needs no BC service tier, Docker, SQL Server, or license.
   properties and Invoke() work without error. Import/Export (instance and static)
   throw NotSupportedException with actionable guidance.
   Use AL interface injection to abstract XmlPort I/O for testing.
-- Notification — Message, Send, Recall, SetData/GetData/HasData, AddAction, Id, Scope.
+- Notification — Message, Send, Recall (returns bool), SetData/GetData/HasData, AddAction, Id, Scope, Clear.
   Send dispatches to [SendNotificationHandler] if registered; otherwise no-op.
+  Recall() returns true (standalone mode; no real recall possible).
+  Clear(N) resets Message, Id, Scope, data, and actions to defaults.
   Data store is in-memory; Id auto-generates a Guid.
 - BigText — MockBigText replaces NavBigText. AddText, GetSubText, TextPos, Length
   all work via in-memory StringBuilder. Note: TextPos is 1-based in AL.

--- a/AlRunner/Runtime/MockNotification.cs
+++ b/AlRunner/Runtime/MockNotification.cs
@@ -35,16 +35,16 @@ public class MockNotification
         HandlerRegistry.InvokeSendNotificationHandler(this);
     }
 
-    /// <summary>Recall — no-op in standalone mode.</summary>
-    public void ALRecall(DataError errorLevel)
+    /// <summary>Recall — no-op in standalone mode. Returns true (BC semantics: true if recalled).</summary>
+    public bool ALRecall(DataError errorLevel)
     {
-        // No-op
+        return true;
     }
 
-    /// <summary>Recall without DataError parameter.</summary>
-    public void ALRecall()
+    /// <summary>Recall without DataError parameter. Returns true.</summary>
+    public bool ALRecall()
     {
-        // No-op
+        return true;
     }
 
     /// <summary>Store a key-value pair on the notification.</summary>
@@ -75,5 +75,36 @@ public class MockNotification
     public void ALAddAction(string actionCaption, int codeunitId, string functionName, string description)
     {
         _actions.Add((actionCaption, codeunitId, functionName));
+    }
+
+    /// <summary>
+    /// ALAssign — copy all state from <paramref name="other"/> into this instance.
+    /// BC emits <c>n.ALAssign(otherN)</c> for AL assignment <c>n := otherN</c>.
+    /// </summary>
+    public void ALAssign(MockNotification other)
+    {
+        if (other == null) return;
+        ALId = other.ALId;
+        ALMessage = other.ALMessage;
+        ALScope = other.ALScope;
+        _data.Clear();
+        foreach (var kv in other._data)
+            _data[kv.Key] = kv.Value;
+        _actions.Clear();
+        foreach (var a in other._actions)
+            _actions.Add(a);
+    }
+
+    /// <summary>
+    /// Clear — reset all state to defaults.
+    /// BC emits <c>n.Clear()</c> / <c>Clear(n)</c> which the rewriter rewrites to <c>n.Clear()</c>.
+    /// </summary>
+    public void Clear()
+    {
+        ALId = Guid.NewGuid();
+        ALMessage = string.Empty;
+        ALScope = NotificationScope.LocalScope;
+        _data.Clear();
+        _actions.Clear();
     }
 }

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -4609,17 +4609,35 @@ Notification.Message:
   status: covered
   notes: overloads=1
 
+Notification.Clear:
+  layer: runtime-api
+  category: Notification
+  status: covered
+  notes: >
+    MockNotification.Clear() resets Message, Id, Scope, data, and actions to defaults.
+    BC emits n.Clear() for Clear(n) calls. Issue #1153.
+  tests:
+    - tests/bucket-2/228-notification-gaps
+
 Notification.Recall:
   layer: runtime-api
   category: Notification
   status: covered
-  notes: overloads=1
+  notes: >
+    overloads=2 (with/without DataError). Returns bool (true) — BC semantics.
+    Fixed in issue #1153: was void, caused CS0029 when return value captured.
+  tests:
+    - tests/bucket-2/228-notification-gaps
 
 Notification.Scope:
   layer: runtime-api
   category: Notification
   status: covered
-  notes: overloads=1
+  notes: >
+    overloads=1. NotificationScope enum (LocalScope, GlobalScope) — ALScope property.
+    Round-trip verified (set and read back) in issue #1153.
+  tests:
+    - tests/bucket-2/228-notification-gaps
 
 Notification.Send:
   layer: runtime-api

--- a/tests/bucket-2/228-notification-gaps/src/NotificationGapsHelper.al
+++ b/tests/bucket-2/228-notification-gaps/src/NotificationGapsHelper.al
@@ -1,0 +1,30 @@
+codeunit 228001 "Notification Gaps Helper"
+{
+    procedure BuildScopedNotification(Msg: Text; Scp: NotificationScope): Notification
+    var
+        N: Notification;
+    begin
+        N.Message := Msg;
+        N.Scope := Scp;
+        exit(N);
+    end;
+
+    procedure RecallNotification(var N: Notification): Boolean
+    begin
+        exit(N.Recall());
+    end;
+
+    procedure ClearNotification(var N: Notification)
+    begin
+        Clear(N);
+    end;
+
+    procedure GetMessageAfterClear(Msg: Text): Text
+    var
+        N: Notification;
+    begin
+        N.Message := Msg;
+        Clear(N);
+        exit(N.Message);
+    end;
+}

--- a/tests/bucket-2/228-notification-gaps/test/NotificationGapsTests.al
+++ b/tests/bucket-2/228-notification-gaps/test/NotificationGapsTests.al
@@ -1,0 +1,82 @@
+codeunit 228002 "Notification Gaps Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Helper: Codeunit "Notification Gaps Helper";
+
+    // ── Gap 1: NotificationScope assignment ──────────────────────
+
+    [Test]
+    procedure Scope_LocalScope_IsRetained()
+    var
+        N: Notification;
+    begin
+        // Positive: setting Scope to LocalScope should compile and round-trip
+        N := Helper.BuildScopedNotification('msg', NotificationScope::LocalScope);
+        Assert.AreEqual(NotificationScope::LocalScope, N.Scope, 'Scope should be LocalScope');
+    end;
+
+    [Test]
+    procedure Scope_GlobalScope_IsRetained()
+    var
+        N: Notification;
+    begin
+        // Positive: setting Scope to GlobalScope should compile and round-trip
+        N := Helper.BuildScopedNotification('scoped', NotificationScope::GlobalScope);
+        Assert.AreEqual(NotificationScope::GlobalScope, N.Scope, 'Scope should be GlobalScope');
+    end;
+
+    // ── Gap 2: Recall() returns Boolean ──────────────────────────
+
+    [Test]
+    procedure Recall_ReturnsBooleanTrue()
+    var
+        N: Notification;
+        Recalled: Boolean;
+    begin
+        // Positive: Recall() must return a boolean (used in if-statement);
+        // standalone mode always returns true
+        N.Message := 'recall me';
+        Recalled := Helper.RecallNotification(N);
+        Assert.IsTrue(Recalled, 'Recall() should return true');
+    end;
+
+    [Test]
+    procedure Recall_CanBeUsedInIfStatement()
+    var
+        N: Notification;
+        Hit: Boolean;
+    begin
+        // Positive: prove that if Notification.Recall() then ... compiles and executes
+        N.Message := 'if test';
+        Hit := false;
+        if N.Recall() then
+            Hit := true;
+        Assert.IsTrue(Hit, 'Branch inside if Recall() should be taken');
+    end;
+
+    // ── Gap 3: Clear(Notification) resets message ─────────────────
+
+    [Test]
+    procedure Clear_ResetsMessageToEmpty()
+    var
+        Result: Text;
+    begin
+        // Positive: after Clear() the Message should be empty string
+        Result := Helper.GetMessageAfterClear('before clear');
+        Assert.AreEqual('', Result, 'Message should be empty after Clear()');
+    end;
+
+    [Test]
+    procedure Clear_DirectOnVariable()
+    var
+        N: Notification;
+    begin
+        // Positive: Clear(N) directly in test code should compile and reset message
+        N.Message := 'to be cleared';
+        Clear(N);
+        Assert.AreEqual('', N.Message, 'Message should be empty after Clear(N)');
+    end;
+}


### PR DESCRIPTION
## Summary

Fixes three compilation gaps in `MockNotification` (issue #1153):

- **ALRecall returns bool**: `ALRecall(DataError)` and `ALRecall()` changed from `void` to `bool` (returns `true`). This fixes `CS0029` when the return value is captured and `CS0019` when used in `if N.Recall() then ...`.
- **ALAssign added**: `ALAssign(MockNotification other)` copies all state (Id, Message, Scope, data, actions). BC emits this for AL assignment `n := otherN`. Fixes `CS1061` on Notification return-from-procedure patterns.
- **Clear added**: `Clear()` resets Message, Id (new Guid), Scope, data dictionary, and actions. BC emits `n.Clear()` for AL `Clear(n)`. Fixes `CS1061` on Clear calls.

## Test plan

- [x] RED: ran `tests/bucket-2/228-notification-gaps` before fix — 9 Roslyn errors confirmed
- [x] GREEN: ran after fix — 6/6 tests pass
- [x] No regressions: `tests/bucket-2/122-unstubbed-types` and `tests/bucket-2/131-send-notification-handler` all pass
- [x] `docs/coverage.yaml` updated with `Notification.Clear` entry and updated notes/tests for `Notification.Recall` and `Notification.Scope`
- [x] `--guide` output updated in `Program.cs`

Closes #1153