### PR TITLE
fix: missing method overloads — Report.Execute(Text), File.Create bool, RecordRef.AddLink, RecordRef.GetView(bool)

### DIFF
--- a/AlRunner/Runtime/MockFile.cs
+++ b/AlRunner/Runtime/MockFile.cs
@@ -67,16 +67,17 @@ public class MockFile
 
     // ── Instance methods ──────────────────────────────────────────────────────
 
-    /// <summary>ALCreate — opens an in-memory buffer for writing.</summary>
-    public void ALCreate(object? parent, DataError errorLevel, string name)
+    /// <summary>ALCreate — opens an in-memory buffer for writing. Returns true (success) — AL File.Create() returns Boolean.</summary>
+    public bool ALCreate(object? parent, DataError errorLevel, string name)
     {
         _name = name;
         _data = Array.Empty<byte>();
         _pos = 0;
         _writeMode = true;
+        return true;
     }
 
-    public void ALCreate(object? parent, string name) => ALCreate(parent, DataError.ThrowError, name);
+    public bool ALCreate(object? parent, string name) => ALCreate(parent, DataError.ThrowError, name);
 
     /// <summary>ALOpen — opens an in-memory buffer for reading.</summary>
     public void ALOpen(object? parent, DataError errorLevel, string name)
@@ -265,6 +266,19 @@ public class MockFile
     {
         fileName.Value = NavText.Empty;
         return false;
+    }
+
+    /// <summary>
+    /// AL's Clear(File) — rewriter emits file.Clear().
+    /// Resets the file to its default (closed) state: empty buffer, position 0, default flags.
+    /// </summary>
+    public void Clear()
+    {
+        _data = Array.Empty<byte>();
+        _pos = 0;
+        _name = string.Empty;
+        _textMode = true;
+        _writeMode = false;
     }
 
     /// <summary>ALAssign — copies the backing data and state from another MockFile.</summary>

--- a/AlRunner/Runtime/MockRecordRef.cs
+++ b/AlRunner/Runtime/MockRecordRef.cs
@@ -112,11 +112,17 @@ public class MockRecordRef
     /// <summary>ALIsDirty — standalone has no write-pending tracking; always false.</summary>
     public bool ALIsDirty => false;
 
-    // -- CopyLinks — no-op in standalone (no BC link service) --
+    // -- CopyLinks / AddLink — no-op in standalone (no BC link service) --
 
     /// <summary>ALCopyLinks — copies record links. No-op in standalone mode.</summary>
     public void ALCopyLinks(MockRecordRef fromRef) { }
     public void ALCopyLinks(object fromRecord) { }
+
+    /// <summary>
+    /// ALAddLink — adds a link to the record. No-op in standalone mode (no BC link service).
+    /// Returns 0 as the link ID.
+    /// </summary>
+    public int ALAddLink(string url, string description = "") => 0;
 
     // -- ReadConsistency — no SQL transactions in standalone --
 
@@ -335,6 +341,13 @@ public class MockRecordRef
 
     /// <summary>ALGetView — delegates to the underlying record handle's view text.</summary>
     public string ALGetView() => _handle?.ALGetView() ?? string.Empty;
+
+    /// <summary>
+    /// ALGetView(useNames) — 1-argument overload for RecordRef.GetView(UseNames).
+    /// The <paramref name="useNames"/> flag controls whether field/table names or IDs
+    /// appear in the view string; standalone returns the same view text regardless.
+    /// </summary>
+    public string ALGetView(bool useNames) => ALGetView();
 
     /// <summary>ALSetView — applies a filter-view string (stub: no-op; view strings require full BC parser).</summary>
     public void ALSetView(string view) => _handle?.ALSetView(view);

--- a/AlRunner/Runtime/MockReportHandle.cs
+++ b/AlRunner/Runtime/MockReportHandle.cs
@@ -366,6 +366,11 @@ public class MockReportHandle
     /// <summary>Instance <c>Rep.Print(requestPageXml)</c> — no-op in standalone mode.</summary>
     public void Print(string requestPageXml) { }
 
+    // ── Instance Execute method ──────────────────────────────────────────────
+    // BC emits rep.Execute(xmlText) for Report.Execute(XmlText) on an instance variable.
+    /// <summary>Instance <c>Rep.Execute(xmlText)</c> — no-op in standalone mode (no rendering engine).</summary>
+    public void Execute(string xmlText) { }
+
     // Report.Execute / Report.Print — no-ops in standalone mode
     public static void StaticExecute(int reportId) { }
 

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -2703,8 +2703,10 @@ File.Create:
   layer: runtime-api
   category: File
   status: covered
-  notes: overloads=1; MockFile.ALCreate() opens in-memory buffer
-  test: tests/bucket-1/87-file-io/test/FileTest.al
+  notes: overloads=2; MockFile.ALCreate() opens in-memory buffer, returns true (Boolean result per AL spec)
+  tests:
+    - tests/bucket-1/87-file-io
+    - tests/bucket-1/302-overload-gaps
 
 File.CreateInStream:
   layer: runtime-api
@@ -5070,7 +5072,9 @@ RecordRef.AddLink:
   layer: runtime-api
   category: RecordRef
   status: covered
-  notes: overloads=1
+  notes: overloads=2; MockRecordRef.ALAddLink no-op, returns 0 (no BC link service in standalone)
+  tests:
+    - tests/bucket-1/302-overload-gaps
 
 RecordRef.AddLoadFields:
   layer: runtime-api
@@ -5280,7 +5284,9 @@ RecordRef.GetView:
   layer: runtime-api
   category: RecordRef
   status: covered
-  notes: overloads=1
+  notes: overloads=2; ALGetView() and ALGetView(bool useNames) — useNames flag ignored in standalone
+  tests:
+    - tests/bucket-1/302-overload-gaps
 
 RecordRef.HasFilter:
   layer: runtime-api
@@ -5557,9 +5563,10 @@ Report.Execute:
   layer: runtime-api
   category: Report
   status: covered
-  notes: overloads=1; NavReport.Execute → MockReportHandle.StaticExecute (no-op).
+  notes: overloads=2; StaticExecute (static) + instance Execute(xmlText) — both no-op in standalone.
   tests:
     - tests/bucket-1/90-report-static
+    - tests/bucket-1/302-overload-gaps
 
 Report.GetSubstituteReportId:
   layer: runtime-api

--- a/tests/bucket-1/302-overload-gaps/src/OverloadGapsReport.al
+++ b/tests/bucket-1/302-overload-gaps/src/OverloadGapsReport.al
@@ -1,0 +1,6 @@
+/// Minimal report used by the overload-gaps test suite to exercise
+/// the instance Execute(XmlText) method (issue #1180).
+report 302001 "OG Dummy Report"
+{
+    dataset { }
+}

--- a/tests/bucket-1/302-overload-gaps/src/OverloadGapsSrc.al
+++ b/tests/bucket-1/302-overload-gaps/src/OverloadGapsSrc.al
@@ -1,0 +1,35 @@
+/// Source codeunit exercising the 4 missing method overloads.
+/// Issues: #1180 (Report.Execute), #1183 (File.Create bool return),
+///         #1187 (RecordRef.AddLink), #1192 (RecordRef.GetView(false)).
+codeunit 302100 "OG Src"
+{
+    // Issue #1180 — Report.Execute(XmlText) on an instance variable.
+    procedure CallReportExecute(var Rep: Report "OG Dummy Report"; XmlText: Text)
+    begin
+        Rep.Execute(XmlText);
+    end;
+
+    // Issue #1183 — File.Create() returns Boolean.
+    procedure CreateFileReturnsTrue(var F: File; FileName: Text): Boolean
+    begin
+        exit(F.Create(FileName));
+    end;
+
+    // Negative: result of File.Create can be tested with NOT operator (the bug: CS0023 void).
+    procedure CanNegatCreateResult(var F: File; FileName: Text): Boolean
+    begin
+        exit(not F.Create(FileName));
+    end;
+
+    // Issue #1187 — RecordRef.AddLink(Url, Description) returns Integer (link ID).
+    procedure AddLinkReturnsId(var RecRef: RecordRef; Url: Text; Description: Text): Integer
+    begin
+        exit(RecRef.AddLink(Url, Description));
+    end;
+
+    // Issue #1192 — RecordRef.GetView(UseNames) — 1-argument overload.
+    procedure GetViewWithUseNames(var RecRef: RecordRef; UseNames: Boolean): Text
+    begin
+        exit(RecRef.GetView(UseNames));
+    end;
+}

--- a/tests/bucket-1/302-overload-gaps/src/OverloadGapsTable.al
+++ b/tests/bucket-1/302-overload-gaps/src/OverloadGapsTable.al
@@ -1,0 +1,13 @@
+// Shared table for overload-gaps test suite (issues #1180, #1183, #1187, #1192)
+table 302000 "OG Table"
+{
+    fields
+    {
+        field(1; Id; Integer) { }
+        field(2; Name; Text[50]) { }
+    }
+    keys
+    {
+        key(PK; Id) { Clustered = true; }
+    }
+}

--- a/tests/bucket-1/302-overload-gaps/test/OverloadGapsTest.al
+++ b/tests/bucket-1/302-overload-gaps/test/OverloadGapsTest.al
@@ -1,0 +1,108 @@
+/// Tests for four missing method overloads:
+///   #1180 — Report instance .Execute(XmlText)
+///   #1183 — File.Create() returns Boolean
+///   #1187 — RecordRef.AddLink(Url, Description)
+///   #1192 — RecordRef.GetView(UseNames)
+codeunit 302101 "OG Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "OG Src";
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // #1180 — Report.Execute(XmlText) — instance method, no-op in standalone
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Test]
+    procedure Report_Execute_XmlText_IsNoOp()
+    var
+        Rep: Report "OG Dummy Report";
+    begin
+        // Must compile and not throw.  Entire claim: this does not crash.
+        Src.CallReportExecute(Rep, '<Report />');
+    end;
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // #1183 — File.Create() returns Boolean (positive: returns true)
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Test]
+    procedure File_Create_ReturnsTrue()
+    var
+        F: File;
+    begin
+        Assert.IsTrue(Src.CreateFileReturnsTrue(F, 'test.txt'),
+            'File.Create should return true on success');
+    end;
+
+    [Test]
+    procedure File_Create_ResultCanBeNegated()
+    var
+        F: File;
+    begin
+        // NOT operator on the return value must compile (CS0023 guard).
+        Assert.IsFalse(Src.CanNegatCreateResult(F, 'test.txt'),
+            'NOT File.Create should return false when Create succeeds');
+    end;
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // #1187 — RecordRef.AddLink(Url, Description) — returns link ID (0 in stub)
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Test]
+    procedure RecordRef_AddLink_ReturnsZero()
+    var
+        Rec: Record "OG Table";
+        RecRef: RecordRef;
+        LinkId: Integer;
+    begin
+        RecRef.GetTable(Rec);
+        LinkId := Src.AddLinkReturnsId(RecRef, 'https://example.com', 'Example Link');
+        Assert.AreEqual(0, LinkId, 'AddLink should return 0 (stub no-op)');
+    end;
+
+    [Test]
+    procedure RecordRef_AddLink_UrlOnly_ReturnsZero()
+    var
+        Rec: Record "OG Table";
+        RecRef: RecordRef;
+    begin
+        RecRef.GetTable(Rec);
+        // 1-arg form: description defaults to empty
+        Assert.AreEqual(0, Src.AddLinkReturnsId(RecRef, 'https://example.com', ''),
+            'AddLink with empty description should return 0');
+    end;
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // #1192 — RecordRef.GetView(UseNames) — 1-argument overload
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Test]
+    procedure RecordRef_GetView_UseNames_True_ReturnsText()
+    var
+        Rec: Record "OG Table";
+        RecRef: RecordRef;
+        ViewText: Text;
+    begin
+        RecRef.Open(Database::"OG Table");
+        ViewText := Src.GetViewWithUseNames(RecRef, true);
+        // Must compile and return the same value as the 0-arg overload.
+        Assert.AreEqual(RecRef.GetView(), ViewText,
+            'GetView(true) should return the same view as GetView()');
+    end;
+
+    [Test]
+    procedure RecordRef_GetView_UseNames_False_ReturnsText()
+    var
+        Rec: Record "OG Table";
+        RecRef: RecordRef;
+        ViewText: Text;
+    begin
+        RecRef.Open(Database::"OG Table");
+        ViewText := Src.GetViewWithUseNames(RecRef, false);
+        Assert.AreEqual(RecRef.GetView(), ViewText,
+            'GetView(false) should return the same view as GetView()');
+    end;
+}


### PR DESCRIPTION
## Summary

- **#1180** — Add `Execute(string xmlText)` instance method (no-op) to `MockReportHandle` — resolves CS1061 when AL code calls `Rep.Execute(XmlText)` on an instance variable.
- **#1183** — Change `MockFile.ALCreate` return type from `void` to `bool` (returns `true`) — resolves CS0023 (`!` operator on void) when AL code uses `NOT File.Create(...)`.
- **#1187** — Add `ALAddLink(string url, string description = "")` returning `0` to `MockRecordRef` — resolves CS1061 for `RecordRef.AddLink()` calls.
- **#1192** — Add `ALGetView(bool useNames)` overload to `MockRecordRef` that delegates to `ALGetView()` — resolves CS1501 (no overload takes 1 argument) for `RecordRef.GetView(false)`.

New test suite `tests/bucket-1/302-overload-gaps` with 7 proving tests covers all 4 fixes. `docs/coverage.yaml` updated.

Closes #1180, closes #1183, closes #1187, closes #1192

## Test plan

- [x] `Report_Execute_XmlText_IsNoOp` — compile + no throw
- [x] `File_Create_ReturnsTrue` — `File.Create()` returns `true`
- [x] `File_Create_ResultCanBeNegated` — `NOT File.Create()` compiles and returns `false`
- [x] `RecordRef_AddLink_ReturnsZero` — `AddLink(url, description)` returns `0`
- [x] `RecordRef_AddLink_UrlOnly_ReturnsZero` — `AddLink(url, "")` returns `0`
- [x] `RecordRef_GetView_UseNames_True_ReturnsText` — `GetView(true)` equals `GetView()`
- [x] `RecordRef_GetView_UseNames_False_ReturnsText` — `GetView(false)` equals `GetView()`