### PR TITLE
fix: NavMediaSystemRecord base class + Media stream overloads

### DIFF
--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -463,7 +463,8 @@ public class RoslynRewriter : CSharpSyntaxRewriter
                 if (typeText == "NavCodeunit" || typeText == "NavTestCodeunit"
                     || typeText == "NavUpgradeCodeunit" || typeText == "NavTestRunnerCodeUnit")
                     isCodeunitClass = true;
-                if (typeText == "NavRecord" || typeText == "NavRecordExtension")
+                if (typeText == "NavRecord" || typeText == "NavRecordExtension"
+                    || typeText == "NavMediaSystemRecord")
                     isRecordClass = true;
                 if (typeText == "NavFormExtension")
                     isPageExtensionClass = true;
@@ -504,7 +505,8 @@ public class RoslynRewriter : CSharpSyntaxRewriter
                 if (typeText == "NavCodeunit" || typeText == "NavTestCodeunit" || typeText == "NavTestRunnerCodeUnit" || typeText == "NavRecord"
                     || typeText == "NavFormExtension" || typeText == "NavRecordExtension"
                     || typeText == "NavEventScope" || typeText == "NavUpgradeCodeunit"
-                    || typeText == "NavForm")
+                    || typeText == "NavForm"
+                    || typeText == "NavMediaSystemRecord")
                 {
                     // Remove these base classes entirely
                     continue;

--- a/AlRunner/Runtime/MockMedia.cs
+++ b/AlRunner/Runtime/MockMedia.cs
@@ -74,15 +74,43 @@ public class MockMedia : NavValue
         return _id;
     }
 
-    // ── ALExport (BC-emitted name for Media.ExportFile) ───────────────────────
+    // BC emits ALImport(errorLevel, inStream, description) for Media.ImportStream(InStream, Text)
+    public Guid ALImport(DataError errorLevel, MockInStream stream, NavText description)
+    {
+        _hasValue = true;
+        return _id;
+    }
+
+    public Guid ALImport(DataError errorLevel, MockInStream stream, string description)
+    {
+        _hasValue = true;
+        return _id;
+    }
+
+    public Guid ALImport(DataError errorLevel, MockInStream stream, NavText description, NavText mimeType)
+    {
+        _hasValue = true;
+        return _id;
+    }
+
+    public Guid ALImport(DataError errorLevel, MockInStream stream, string description, string mimeType)
+    {
+        _hasValue = true;
+        return _id;
+    }
+
+    // ── ALExport (BC-emitted for Media.ExportFile and Media.ExportStream) ────────
 
     /// <summary>
-    /// BC emits <c>m.ALExport(errorLevel, fileName)</c>
-    /// for <c>Media.ExportFile(FileName)</c>.
+    /// BC emits <c>m.ALExport(errorLevel, fileName)</c> for <c>Media.ExportFile(FileName)</c>.
     /// Returns false — no blob data in standalone mode.
     /// </summary>
     public bool ALExport(DataError errorLevel, NavText fileName) => false;
     public bool ALExport(DataError errorLevel, string fileName) => false;
+
+    // BC emits ALExport(errorLevel, outStream) for Media.ExportStream(OutStream)
+    public bool ALExport(DataError errorLevel, MockOutStream stream) => false;
+    public bool ALExport(MockOutStream stream) => false;
 
     // ── ImportFile ───────────────────────────────────────────────────────────────
 

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -4331,9 +4331,10 @@ Media.ExportStream:
   layer: runtime-api
   category: Media
   status: covered
-  notes: overloads=2
+  notes: "overloads=2; BC emits ALExport(DataError, OutStream) for ExportStream — stream overload added to MockMedia; no-op in standalone mode"
   tests:
     - tests/bucket-1/272-media
+    - tests/bucket-2/101-media-streams
 
 Media.FindOrphans:
   layer: runtime-api
@@ -4363,9 +4364,10 @@ Media.ImportStream:
   layer: runtime-api
   category: Media
   status: covered
-  notes: overloads=2
+  notes: "overloads=2; BC emits ALImport(DataError, InStream, description) for ImportStream — stream overload added to MockMedia; sets HasValue=true"
   tests:
     - tests/bucket-1/272-media
+    - tests/bucket-2/101-media-streams
 
 Media.MediaId:
   layer: runtime-api
@@ -11462,3 +11464,19 @@ StubGenerator.SymbolTablePass:
     to disk and counted in the new GeneratedFromSymbolTable field of GenerateResult.
     Falls back gracefully to zero extra stubs when compilation is unavailable.
   tests: []
+
+RoslynRewriter.NavMediaSystemRecord:
+  layer: runtime-api
+  category: rewriter
+  status: covered
+  notes: >
+    BC emits NavMediaSystemRecord as the base class for system media tables
+    (e.g. "Tenant Media", table 2000000184). NavMediaSystemRecord has a
+    7-arg constructor requiring ITreeObject, NCLMetaTable, NavRecord, string,
+    SecurityFiltering — all unavailable in standalone mode. The rewriter now
+    treats NavMediaSystemRecord identically to NavRecord: marks the containing
+    class as a record class (for Rec/xRec table-ID tracking) and strips it
+    from the base class list. The existing constructor-removal rule (triggered
+    by ITreeObject parent parameters) handles the ctor. Closes #1188.
+  tests:
+    - tests/bucket-2/100-tenant-media

--- a/tests/bucket-2/100-tenant-media/src/TenantMediaSrc.al
+++ b/tests/bucket-2/100-tenant-media/src/TenantMediaSrc.al
@@ -1,0 +1,35 @@
+/// Minimal stub for the Tenant Media system table (ID 2000000184).
+/// BC's compiler generates NavMediaSystemRecord as the base class for
+/// system tables in this ID range — the runner's rewriter must handle that.
+table 2000000184 "Tenant Media"
+{
+    fields
+    {
+        field(1; ID; Guid) { }
+        field(2; "Mime Type"; Text[100]) { }
+        field(3; Content; Media) { }
+    }
+    keys
+    {
+        key(PK; ID) { Clustered = true; }
+    }
+}
+
+/// Helper codeunit that references the Tenant Media system table.
+/// Exercises basic record operations against the in-memory mock.
+codeunit 303000 "TMD Helper"
+{
+    procedure IsEmpty(): Boolean
+    var
+        TenantMedia: Record "Tenant Media";
+    begin
+        exit(TenantMedia.IsEmpty());
+    end;
+
+    procedure CountRecords(): Integer
+    var
+        TenantMedia: Record "Tenant Media";
+    begin
+        exit(TenantMedia.Count());
+    end;
+}

--- a/tests/bucket-2/100-tenant-media/test/TenantMediaTest.al
+++ b/tests/bucket-2/100-tenant-media/test/TenantMediaTest.al
@@ -1,0 +1,28 @@
+/// Tests that the Tenant Media system table (ID 2000000184) can be referenced
+/// via the auto-stub mechanism without a NavMediaSystemRecord constructor error.
+codeunit 303001 "TMD Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "TMD Helper";
+
+    // ── Positive: IsEmpty returns true on a fresh store ───────────────────────
+
+    [Test]
+    procedure TenantMedia_IsEmpty_ReturnsTrueWhenNoRecords()
+    begin
+        // Positive: fresh runner store has no Tenant Media rows.
+        Assert.IsTrue(Src.IsEmpty(), 'Tenant Media must be empty in a fresh runner store');
+    end;
+
+    // ── Positive: Count returns 0 on a fresh store ────────────────────────────
+
+    [Test]
+    procedure TenantMedia_Count_ReturnsZeroWhenEmpty()
+    begin
+        // Positive: count on an empty table must be zero, not a negative or crash.
+        Assert.AreEqual(0, Src.CountRecords(), 'Tenant Media count must be 0 in a fresh runner store');
+    end;
+}

--- a/tests/bucket-2/101-media-streams/src/MediaStreamsSrc.al
+++ b/tests/bucket-2/101-media-streams/src/MediaStreamsSrc.al
@@ -1,0 +1,59 @@
+/// Table with a Media field used by the media-stream tests.
+table 303010 "MST Media Table"
+{
+    fields
+    {
+        field(1; "No."; Code[20]) { }
+        field(2; Content; Media) { }
+    }
+    keys
+    {
+        key(PK; "No.") { Clustered = true; }
+    }
+}
+
+/// Helper blob table used to create real InStream / OutStream values.
+table 303011 "MST Blob Table"
+{
+    fields
+    {
+        field(1; PK; Integer) { }
+        field(2; Blob; Blob) { }
+    }
+    keys { key(PK; PK) { } }
+}
+
+/// Helper codeunit that exercises Media.ImportStream and Media.ExportStream.
+codeunit 303012 "MST Helper"
+{
+    procedure ImportFromStream(var Rec: Record "MST Media Table"; var Source: InStream): Boolean
+    begin
+        Rec.Content.ImportStream(Source, '');
+        exit(Rec.Content.HasValue());
+    end;
+
+    procedure ExportToStream(var Rec: Record "MST Media Table"; var Target: OutStream): Boolean
+    begin
+        Rec.Content.ExportStream(Target);
+        exit(true);
+    end;
+
+    procedure HasValue(var Rec: Record "MST Media Table"): Boolean
+    begin
+        exit(Rec.Content.HasValue());
+    end;
+
+    procedure MakeBlobInStream(var BlobRec: Record "MST Blob Table" temporary; var InStr: InStream)
+    var
+        OutStr: OutStream;
+    begin
+        BlobRec.Blob.CreateOutStream(OutStr);
+        OutStr.WriteText('test-content');
+        BlobRec.Blob.CreateInStream(InStr);
+    end;
+
+    procedure MakeBlobOutStream(var BlobRec: Record "MST Blob Table" temporary; var OutStr: OutStream)
+    begin
+        BlobRec.Blob.CreateOutStream(OutStr);
+    end;
+}

--- a/tests/bucket-2/101-media-streams/test/MediaStreamsTest.al
+++ b/tests/bucket-2/101-media-streams/test/MediaStreamsTest.al
@@ -1,0 +1,73 @@
+/// Tests for Media.ImportStream (accepts InStream) and Media.ExportStream (accepts OutStream).
+/// Verifies that stream-based overloads compile and execute without CS1503.
+codeunit 303013 "MST Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Helper: Codeunit "MST Helper";
+
+    // ── ImportStream ──────────────────────────────────────────────────────────
+
+    [Test]
+    procedure ImportStream_SetsHasValueTrue()
+    var
+        Rec: Record "MST Media Table";
+        BlobRec: Record "MST Blob Table" temporary;
+        InStr: InStream;
+    begin
+        // Positive: after ImportStream, HasValue must be true.
+        Rec.Init();
+        Rec."No." := 'IMPORT-1';
+        Rec.Insert();
+        Helper.MakeBlobInStream(BlobRec, InStr);
+        Assert.IsTrue(Helper.ImportFromStream(Rec, InStr), 'ImportStream must return true');
+        Assert.IsTrue(Helper.HasValue(Rec), 'HasValue must be true after ImportStream');
+    end;
+
+    [Test]
+    procedure ImportStream_ReturnsFalseWhenHasValueNotYetSet()
+    var
+        Rec: Record "MST Media Table";
+    begin
+        // Negative: a fresh record has no media — HasValue must be false.
+        Rec.Init();
+        Rec."No." := 'IMPORT-2';
+        Rec.Insert();
+        Assert.IsFalse(Helper.HasValue(Rec), 'HasValue must be false before any import');
+    end;
+
+    // ── ExportStream ──────────────────────────────────────────────────────────
+
+    [Test]
+    procedure ExportStream_ReturnsTrue()
+    var
+        Rec: Record "MST Media Table";
+        BlobRec: Record "MST Blob Table" temporary;
+        OutStr: OutStream;
+    begin
+        // Positive: ExportStream must return true (no crash) even with no stored data.
+        Rec.Init();
+        Rec."No." := 'EXPORT-1';
+        Rec.Insert();
+        Helper.MakeBlobOutStream(BlobRec, OutStr);
+        Assert.IsTrue(Helper.ExportToStream(Rec, OutStr), 'ExportStream must return true');
+    end;
+
+    [Test]
+    procedure ExportStream_DoesNotRaiseOnEmptyMedia()
+    var
+        Rec: Record "MST Media Table";
+        BlobRec: Record "MST Blob Table" temporary;
+        OutStr: OutStream;
+    begin
+        // Negative: ExportStream on a Media field with no content must not raise an error.
+        Rec.Init();
+        Rec."No." := 'EXPORT-2';
+        Rec.Insert();
+        Helper.MakeBlobOutStream(BlobRec, OutStr);
+        // If this doesn't throw, the test passes.
+        Helper.ExportToStream(Rec, OutStr);
+    end;
+}


### PR DESCRIPTION
## Summary

- **#1188 — Tenant Media auto-stub NavMediaSystemRecord constructor**: BC emits `NavMediaSystemRecord` as the base class for system media tables (e.g. "Tenant Media", table 2000000184). The rewriter now treats `NavMediaSystemRecord` identically to `NavRecord`: marks the class as a record class in the pre-visit detection pass and strips it from the base class list in the post-visit pass. The existing constructor-removal rule (ITreeObject parent) handles the 7-arg ctor automatically.

- **#1190 — Media ImportStream/ExportStream stream overloads**: BC emits `ALImport(DataError, InStream, description)` for `Media.ImportStream(InStream, Text)` and `ALExport(DataError, OutStream)` for `Media.ExportStream(OutStream)`. `MockMedia` previously had only file-based overloads for these method names. Added stream-accepting overloads for both with and without MIME type variants.

## Test plan

- [ ] `tests/bucket-2/100-tenant-media` — 2 tests: `TenantMedia_IsEmpty_ReturnsTrueWhenNoRecords`, `TenantMedia_Count_ReturnsZeroWhenEmpty`
- [ ] `tests/bucket-2/101-media-streams` — 4 tests: `ImportStream_SetsHasValueTrue`, `ImportStream_ReturnsFalseWhenHasValueNotYetSet`, `ExportStream_ReturnsTrue`, `ExportStream_DoesNotRaiseOnEmptyMedia`
- [ ] RED confirmed before each fix, GREEN after
- [ ] `docs/coverage.yaml` updated with new test suites and `RoslynRewriter.NavMediaSystemRecord` entry

Closes #1188, closes #1190