### PR TITLE
fix: handle extra scope ctor params in RunTests()

### DIFF
--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -2730,8 +2730,20 @@ public static class Executor
                 object scope;
                 if (ctors.Length > 0 && ctors[0].GetParameters().Length > 0)
                 {
-                    // Constructor takes the parent codeunit
-                    scope = ctors[0].Invoke(new[] { parent });
+                    // Constructor takes the parent codeunit as first parameter, and may have
+                    // additional parameters for AL procedure parameters captured by the scope
+                    // (e.g. a helper procedure named "TestXxx" with parameters).
+                    // Supply the parent for the first param and default values for the rest
+                    // to avoid "Parameter count mismatch" when extra params are present.
+                    var ctorParams = ctors[0].GetParameters();
+                    var args = new object?[ctorParams.Length];
+                    args[0] = parent;
+                    for (int i = 1; i < ctorParams.Length; i++)
+                    {
+                        var pt = ctorParams[i].ParameterType;
+                        args[i] = pt.IsValueType ? Activator.CreateInstance(pt) : null;
+                    }
+                    scope = ctors[0].Invoke(args);
                 }
                 else if (ctors.Length > 0)
                 {

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -11292,6 +11292,25 @@ Executor.InitEventsIdempotent:
   tests:
     - tests/init-events/41-init-events-idempotent
 
+Executor.ScopeCtorExtraParams:
+  layer: runtime-api
+  category: executor
+  status: covered
+  notes: >
+    RunTests() now handles scope constructors with more than one parameter.
+    The BC compiler generates a _Scope_ class for every procedure, including
+    helpers in test codeunits whose names start with "Test" (so the executor
+    picks them up via the "Test*" fallback heuristic). If such a helper has AL
+    parameters, the generated constructor is
+      (ParentType parent, ParamType1 p1, ParamType2 p2, …)
+    rather than the usual single-arg form. Previously, RunTests() always called
+    ctors[0].Invoke(new[] { parent }) which threw "Parameter count mismatch".
+    The fix supplies the parent as the first arg and provides default values
+    (Activator.CreateInstance for value types, null for reference types) for
+    any additional parameters, mirroring the logic already present in RunOnRun().
+  tests:
+    - tests/bucket-3/01-executor-ctor-params
+
 AlCompat.InitializeUninitializedObject:
   layer: runtime-api
   category: event-subscriber

--- a/tests/bucket-3/01-executor-ctor-params/src/CtorParamsHelper.al
+++ b/tests/bucket-3/01-executor-ctor-params/src/CtorParamsHelper.al
@@ -1,0 +1,19 @@
+codeunit 310000 "ECP Helper"
+{
+    /// <summary>
+    /// Simple helper: multiply two integers.
+    /// The test codeunit calls this helper from a Test method that starts with "Test"
+    /// but also defines a TestXxx(param) helper — that helper's scope constructor
+    /// has extra parameters beyond (parent), which previously caused
+    /// "Parameter count mismatch" in the Executor.
+    /// </summary>
+    procedure Multiply(A: Integer; B: Integer): Integer
+    begin
+        exit(A * B);
+    end;
+
+    procedure Add(A: Integer; B: Integer): Integer
+    begin
+        exit(A + B);
+    end;
+}

--- a/tests/bucket-3/01-executor-ctor-params/test/CtorParamsTest.al
+++ b/tests/bucket-3/01-executor-ctor-params/test/CtorParamsTest.al
@@ -1,0 +1,94 @@
+/// <summary>
+/// Suite 01 (bucket-3): Executor parameter-count fix.
+///
+/// When a test codeunit contains a helper procedure whose name starts with "Test"
+/// but is NOT a [Test] method (it has parameters), the BC compiler generates a
+/// _Scope_ class whose constructor has MORE than one parameter (parent + each AL
+/// parameter).  Before the fix, RunTests() called
+///   ctors[0].Invoke(new[] { parent })
+/// which throws "Parameter count mismatch" for such a scope.
+///
+/// After the fix, the executor supplies default values for extra ctor params so
+/// the scope is constructed correctly and execution continues.
+/// </summary>
+codeunit 310001 "ECP Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Helper: Codeunit "ECP Helper";
+
+    // -----------------------------------------------------------------
+    // Positive: basic arithmetic round-trips through the helper codeunit
+    // -----------------------------------------------------------------
+
+    [Test]
+    procedure Multiply_TwoPositives_ReturnsProduct()
+    begin
+        // [GIVEN] Two positive integers
+        // [WHEN] Multiply is called
+        // [THEN] Returns the product
+        Assert.AreEqual(12, Helper.Multiply(3, 4), 'Multiply(3,4) must return 12');
+    end;
+
+    [Test]
+    procedure Multiply_ByZero_ReturnsZero()
+    begin
+        // [GIVEN] One factor is zero
+        // [WHEN] Multiply is called
+        // [THEN] Returns 0 (not a default that would pass a no-op stub)
+        Assert.AreEqual(0, Helper.Multiply(5, 0), 'Multiply(5,0) must return 0');
+        Assert.AreEqual(0, Helper.Multiply(0, 7), 'Multiply(0,7) must return 0');
+    end;
+
+    [Test]
+    procedure Add_TwoIntegers_ReturnsSum()
+    begin
+        Assert.AreEqual(7, Helper.Add(3, 4), 'Add(3,4) must return 7');
+    end;
+
+    // -----------------------------------------------------------------
+    // This is the key trigger for issue-1200:
+    // A helper named TestXxx WITH parameters generates a _Scope_ class
+    // whose constructor has (parent, param1, param2, ...).
+    // The [Test] method below calls it; the executor must not crash when
+    // it encounters the TestVerifyProduct_Scope_xxx type.
+    // -----------------------------------------------------------------
+
+    [Test]
+    procedure TestHelperWithParams_DoesNotCrashExecutor()
+    var
+        Result: Integer;
+    begin
+        // [GIVEN] A helper procedure whose name starts with "Test" and takes params
+        // [WHEN] The executor runs all tests in this codeunit
+        // [THEN] No "Parameter count mismatch" error is thrown; the test runs normally
+        Result := TestComputeProduct(6, 7);
+        Assert.AreEqual(42, Result, 'TestComputeProduct(6,7) must return 42');
+    end;
+
+    [Test]
+    procedure TestHelperWithParams_Negative_WrongResult()
+    var
+        Result: Integer;
+    begin
+        // [GIVEN] A known product
+        // [WHEN] The result is compared to a wrong expected value using asserterror
+        Result := TestComputeProduct(3, 3);
+        asserterror Assert.AreEqual(10, Result, 'Must fail: 3*3 is not 10');
+        Assert.ExpectedError('3*3 is not 10');
+    end;
+
+    /// <summary>
+    /// Helper procedure whose name starts with "Test" AND has parameters.
+    /// BC emits a _Scope_ class with constructor (Codeunit310001 parent, Decimal18 a, Decimal18 b).
+    /// Before fix: RunTests() crashes with "Parameter count mismatch" when it
+    /// tries to instantiate this scope.
+    /// After fix: extra params receive default values; the scope is created correctly.
+    /// </summary>
+    procedure TestComputeProduct(A: Integer; B: Integer): Integer
+    begin
+        exit(A * B);
+    end;
+}


### PR DESCRIPTION
## Summary

- `RunTests()` in `Program.cs` called `ctors[0].Invoke(new[] { parent })` when a scope class had any parameters, but threw `Parameter count mismatch` when the constructor had **more than one** parameter (e.g., a helper named `TestXxx(A, B)` picked up by the `Test*` fallback heuristic)
- Fix: collect all constructor parameters, supply `parent` for the first and `Activator.CreateInstance` / `null` defaults for the rest — the same approach already used in `RunOnRun()`
- New test suite `tests/bucket-3/01-executor-ctor-params` reproduces the crash via `TestComputeProduct(A, B)` and proves the fix

Closes #1200

## Test plan

- [ ] `dotnet run --project AlRunner --framework net9.0 -- tests/bucket-3/01-executor-ctor-params/src tests/bucket-3/01-executor-ctor-params/test` → 6 passed (was 1 failed before fix)
- [ ] Bucket-1 and bucket-2 pass/fail counts unchanged vs baseline
- [ ] `docs/coverage.yaml` updated with `Executor.ScopeCtorExtraParams` entry