### PR TITLE
fix: NavOption → NavText coercion in field assignment and method dispatch

### DIFF
--- a/AlRunner/Runtime/MockCodeunitHandle.cs
+++ b/AlRunner/Runtime/MockCodeunitHandle.cs
@@ -1030,6 +1030,21 @@ public class MockCodeunitHandle
                 return ctorWithLen.Invoke(new object[] { 250, strVal });
         }
 
+        // NavOption -> NavText conversion (issue #1199).
+        // When an Enum/Option value is passed to a method expecting Text via reflection
+        // dispatch, convert the ordinal integer to a string and wrap in NavText —
+        // consistent with AlCompat.Format() for NavOption values.
+        if (targetType.Name == "NavText" && arg is NavOption navOptForText)
+        {
+            var textStr = navOptForText.Value.ToString(System.Globalization.CultureInfo.InvariantCulture);
+            var ctor = targetType.GetConstructor(new[] { typeof(string) });
+            if (ctor != null)
+                return ctor.Invoke(new object[] { textStr });
+            var ctorWithLen = targetType.GetConstructor(new[] { typeof(int), typeof(string) });
+            if (ctorWithLen != null)
+                return ctorWithLen.Invoke(new object[] { 250, textStr });
+        }
+
         // NavText -> string conversion (when target is string)
         if (targetType == typeof(string) && arg is NavValue navVal)
         {

--- a/AlRunner/Runtime/MockRecordHandle.cs
+++ b/AlRunner/Runtime/MockRecordHandle.cs
@@ -323,6 +323,13 @@ public class MockRecordHandle
         // representation: true → "Yes", false → "No".
         if (expectedType == NavType.Text && value is NavBoolean nb)
             return new NavText((bool)nb ? "Yes" : "No");
+        // When an Option/Enum value (NavOption) ends up in a Text field slot — e.g. via
+        // FieldRef.Value := EnumFieldRef.Value — the BC runtime casts the stored value
+        // to NavText with (NavText)GetFieldValueSafe(fieldNo, NavType.Text), which throws
+        // "Unable to cast NavOption to NavText" (issue #1199).
+        // Convert using the ordinal integer as a string, consistent with AlCompat.Format().
+        if (expectedType == NavType.Text && value is NavOption nopt)
+            return new NavText(nopt.Value.ToString(System.Globalization.CultureInfo.InvariantCulture));
         return value;
     }
 

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -11480,3 +11480,21 @@ RoslynRewriter.NavMediaSystemRecord:
     by ITreeObject parent parameters) handles the ctor. Closes #1188.
   tests:
     - tests/bucket-2/100-tenant-media
+
+MockRecordHandle.CoerceToExpectedType.NavOptionToNavText:
+  layer: runtime-api
+  category: record-field
+  status: covered
+  notes: >
+    When an Enum/Option field value (NavOption) is assigned to a Text field slot
+    via FieldRef.Value := EnumFieldRef.Value, MockRecordRef.SetFieldValue calls
+    SetFieldValueSafe(textFieldNo, NavType.Text, navOptionValue). Previously,
+    CoerceToExpectedType stored NavOption as-is; a subsequent direct field read
+    emitting (NavText)GetFieldValueSafe(textFieldNo, NavType.Text) threw
+    "Unable to cast NavOption to NavText" (issue #1199). Fix converts NavOption
+    to NavText using the ordinal integer as a string, consistent with
+    AlCompat.Format() for NavOption. Also fixed ConvertArgInternal in
+    MockCodeunitHandle for the same NavOption → NavText coercion when NavOption
+    is passed to a reflected method expecting NavText.
+  tests:
+    - tests/bucket-2/235-navoption-to-navtext

--- a/tests/bucket-2/235-navoption-to-navtext/src/NavOptionToNavTextHelper.al
+++ b/tests/bucket-2/235-navoption-to-navtext/src/NavOptionToNavTextHelper.al
@@ -1,0 +1,87 @@
+/// Source for NavOption → NavText runtime conversion tests.
+/// Issue #1199: storing an Option/Enum value into a Text field slot via FieldRef
+/// assignment caused InvalidCastException:
+///   "Object of type NavOption cannot be converted to type NavText"
+///
+/// The crash happened in two places:
+///   1. MockRecordHandle.CoerceToExpectedType — NavOption stored in a Text field slot
+///      was not coerced to NavText; later (NavText) cast on GetFieldValueSafe failed.
+///   2. MockCodeunitHandle.ConvertArgInternal — NavOption passed as a NavText arg
+///      to a reflected method call was not converted, and Convert.ChangeType failed.
+
+enum 235000 "NOT Color"
+{
+    Extensible = false;
+
+    value(0; " ") { }
+    value(1; "Red") { }
+    value(2; "Green") { }
+    value(3; "Blue") { }
+}
+
+table 235000 "NOT Record"
+{
+    DataClassification = ToBeClassified;
+
+    fields
+    {
+        field(1; Id; Integer) { DataClassification = ToBeClassified; }
+        field(2; Color; Enum "NOT Color") { DataClassification = ToBeClassified; }
+        field(3; ColorText; Text[50]) { DataClassification = ToBeClassified; }
+    }
+
+    keys
+    {
+        key(PK; Id) { Clustered = true; }
+    }
+}
+
+codeunit 235000 "NOT Helper"
+{
+    /// <summary>
+    /// Copies the Color enum field value to ColorText via FieldRef.
+    /// BC emits: colorTextFRef.ALValue = colorFRef.ALValue
+    ///   → SetFieldValueSafe(colorTextFieldNo, NavType.Text, navOptionValue)
+    /// CoerceToExpectedType must convert NavOption → NavText so that the later
+    /// (NavText)GetFieldValueSafe(colorTextFieldNo, NavType.Text) cast succeeds.
+    /// </summary>
+    procedure CopyEnumToTextViaFieldRef(var Rec: Record "NOT Record")
+    var
+        RecRef: RecordRef;
+        ColorFRef: FieldRef;
+        ColorTextFRef: FieldRef;
+    begin
+        RecRef.GetTable(Rec);
+        ColorFRef := RecRef.Field(2);     // Color (Enum "NOT Color")
+        ColorTextFRef := RecRef.Field(3); // ColorText (Text[50])
+        ColorTextFRef.Value := ColorFRef.Value;
+        RecRef.SetTable(Rec);
+    end;
+
+    /// <summary>
+    /// Returns the ColorText field value after CopyEnumToTextViaFieldRef.
+    /// </summary>
+    procedure GetColorText(var Rec: Record "NOT Record"): Text
+    begin
+        exit(Rec.ColorText);
+    end;
+
+    /// <summary>
+    /// Sets a record with the given Id and Color, copies Color → ColorText
+    /// via FieldRef, modifies, then returns ColorText.
+    /// Full round-trip exercising NavOption → NavText coercion.
+    /// </summary>
+    procedure RoundTripEnumToText(Id: Integer; C: Enum "NOT Color"): Text
+    var
+        Rec: Record "NOT Record";
+    begin
+        Rec.Init();
+        Rec.Id := Id;
+        Rec.Color := C;
+        Rec.Insert();
+
+        Rec.Get(Id);
+        CopyEnumToTextViaFieldRef(Rec);
+        exit(Rec.ColorText);
+    end;
+}

--- a/tests/bucket-2/235-navoption-to-navtext/test/NavOptionToNavTextTest.al
+++ b/tests/bucket-2/235-navoption-to-navtext/test/NavOptionToNavTextTest.al
@@ -1,0 +1,135 @@
+/// Tests for NavOption → NavText runtime conversion — issue #1199.
+/// Before the fix, storing an Enum/Option field value into a Text field slot via
+/// FieldRef threw: "Object of type NavOption cannot be converted to type NavText".
+///
+/// The fix adds NavOption → NavText coercion in:
+///   1. MockRecordHandle.CoerceToExpectedType (NavType.Text + NavOption stored value)
+///   2. MockCodeunitHandle.ConvertArgInternal (NavOption arg for NavText parameter)
+codeunit 235001 "NOT Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Helper: Codeunit "NOT Helper";
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // CoerceToExpectedType — NavOption stored in Text field slot
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Test]
+    procedure FieldRef_EnumToText_DefaultValue_DoesNotCrash()
+    var
+        Rec: Record "NOT Record";
+        Result: Text;
+    begin
+        // [GIVEN] A record with Color at its default (ordinal 0)
+        Rec.Init();
+        Rec.Id := 1;
+        Rec.Color := Enum::"NOT Color"::" ";
+        Rec.Insert();
+        Rec.Get(1);
+
+        // [WHEN] Copy Color (Enum) → ColorText (Text) via FieldRef
+        // Before fix: InvalidCastException "NavOption cannot be converted to NavText"
+        Helper.CopyEnumToTextViaFieldRef(Rec);
+
+        // [THEN] ColorText was stored and read back without exception
+        Result := Rec.ColorText;
+        Assert.AreNotEqual('CRASH', Result, 'ColorText must be set without exception');
+    end;
+
+    [Test]
+    procedure FieldRef_EnumToText_NonZeroOrdinal_IsNotEmpty()
+    var
+        Rec: Record "NOT Record";
+        Result: Text;
+    begin
+        // [GIVEN] A record with Color = Red (ordinal 1)
+        Rec.Init();
+        Rec.Id := 2;
+        Rec.Color := Enum::"NOT Color"::Red;
+        Rec.Insert();
+        Rec.Get(2);
+
+        // [WHEN] Copy Color (Enum) → ColorText (Text) via FieldRef
+        Helper.CopyEnumToTextViaFieldRef(Rec);
+
+        // [THEN] ColorText is not empty — a non-zero ordinal produces a non-empty string
+        Result := Rec.ColorText;
+        Assert.AreNotEqual('', Result,
+            'ColorText must not be empty for a non-default enum value');
+    end;
+
+    [Test]
+    procedure FieldRef_EnumToText_DifferentColors_ProduceDifferentTexts()
+    var
+        RecRed: Record "NOT Record";
+        RecBlue: Record "NOT Record";
+        RedText: Text;
+        BlueText: Text;
+    begin
+        // [GIVEN] Two records with different Color values
+        RecRed.Init();
+        RecRed.Id := 3;
+        RecRed.Color := Enum::"NOT Color"::Red;   // ordinal 1
+        RecRed.Insert();
+
+        RecBlue.Init();
+        RecBlue.Id := 4;
+        RecBlue.Color := Enum::"NOT Color"::Blue;  // ordinal 3
+        RecBlue.Insert();
+
+        RecRed.Get(3);
+        RecBlue.Get(4);
+
+        // [WHEN] Copy each Color → ColorText via FieldRef
+        Helper.CopyEnumToTextViaFieldRef(RecRed);
+        Helper.CopyEnumToTextViaFieldRef(RecBlue);
+
+        // [THEN] The two text values are different — proves a non-stub conversion
+        RedText := RecRed.ColorText;
+        BlueText := RecBlue.ColorText;
+        Assert.AreNotEqual(RedText, BlueText,
+            'Red and Blue must produce distinct text values');
+    end;
+
+    [Test]
+    procedure RoundTrip_RedEnum_YieldsOrdinalString()
+    var
+        Result: Text;
+    begin
+        // [GIVEN/WHEN] Round-trip: insert with Color=Red (ordinal 1), copy to ColorText, read back
+        Result := Helper.RoundTripEnumToText(5, Enum::"NOT Color"::Red);
+
+        // [THEN] Returns the ordinal as string: '1'
+        Assert.AreEqual('1', Result,
+            'Red (ordinal 1) stored via FieldRef must read back as ''1''');
+    end;
+
+    [Test]
+    procedure RoundTrip_BlueEnum_YieldsOrdinalString()
+    var
+        Result: Text;
+    begin
+        // [GIVEN/WHEN] Round-trip: insert with Color=Blue (ordinal 3), copy to ColorText, read back
+        Result := Helper.RoundTripEnumToText(6, Enum::"NOT Color"::Blue);
+
+        // [THEN] Returns the ordinal as string: '3'
+        Assert.AreEqual('3', Result,
+            'Blue (ordinal 3) stored via FieldRef must read back as ''3''');
+    end;
+
+    [Test]
+    procedure RoundTrip_DefaultEnum_YieldsZeroString()
+    var
+        Result: Text;
+    begin
+        // [GIVEN/WHEN] Round-trip: insert with Color=" " (ordinal 0), copy to ColorText, read back
+        Result := Helper.RoundTripEnumToText(7, Enum::"NOT Color"::" ");
+
+        // [THEN] Returns the ordinal as string: '0'
+        Assert.AreEqual('0', Result,
+            'Default enum (ordinal 0) stored via FieldRef must read back as ''0''');
+    end;
+}


### PR DESCRIPTION
## Summary

- **Root cause**: `MockRecordHandle.CoerceToExpectedType` and `MockCodeunitHandle.ConvertArgInternal` had no handling for NavOption → NavText conversion
- **Fix 1**: `CoerceToExpectedType` — when `expectedType == NavType.Text` and `value is NavOption`, convert ordinal to string and wrap in `NavText` (consistent with `AlCompat.Format()`)
- **Fix 2**: `ConvertArgInternal` — same NavOption → NavText coercion for reflection-based method dispatch

Closes #1199

## What crashed

```
Object of type 'Microsoft.Dynamics.Nav.Runtime.NavOption' cannot be converted to type 'Microsoft.Dynamics.Nav.Runtime.NavText'
```

This happened when:
1. AL code assigned an Enum/Option field value to a Text field via FieldRef: `colorTextFRef.Value := colorFRef.Value` → `SetFieldValueSafe(textFieldNo, NavType.Text, navOption)` stored NavOption as-is; later `(NavText)GetFieldValueSafe(textFieldNo, NavType.Text)` threw.
2. NavOption passed as argument to a reflected method expecting NavText → `ConvertArgInternal` fell through to `Convert.ChangeType` which failed.

## Test plan

- `tests/bucket-2/235-navoption-to-navtext` — 6 proving tests:
  - `FieldRef_EnumToText_DefaultValue_DoesNotCrash` — exercises the crash path with ordinal 0
  - `FieldRef_EnumToText_NonZeroOrdinal_IsNotEmpty` — non-default ordinal produces non-empty text
  - `FieldRef_EnumToText_DifferentColors_ProduceDifferentTexts` — different enum values → different text (proves non-stub conversion)
  - `RoundTrip_RedEnum_YieldsOrdinalString` — asserts '1' for Red (ordinal 1)
  - `RoundTrip_BlueEnum_YieldsOrdinalString` — asserts '3' for Blue (ordinal 3)
  - `RoundTrip_DefaultEnum_YieldsZeroString` — asserts '0' for default (ordinal 0)
- All 6 were RED before the fix (exact error matched issue), all 6 are GREEN after
- No regressions: bucket-1 (1595/66) and bucket-2 (1601/114 with the new suite) unchanged