### PR TITLE
fix: add --test-isolation method to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -73,7 +73,7 @@ jobs:
               [ -d "${suite}test" ] && args="$args ${suite}test"
             done
             echo "=== $bucket ==="
-            dotnet run --no-build --project AlRunner --framework net10.0 -- --strict $args
+            dotnet run --no-build --project AlRunner --framework net10.0 -- --strict --test-isolation method $args
           done
 
       - name: Run stubs test


### PR DESCRIPTION
The publish workflow was missing --test-isolation method, causing 66 test failures on release. The test-matrix.yml CI workflow has it; this makes publish.yml match.