### PR TITLE
fix: add 2-arg UploadIntoStream overload — closes #1210

### DIFF
--- a/AlRunner/Runtime/MockFile.cs
+++ b/AlRunner/Runtime/MockFile.cs
@@ -245,6 +245,26 @@ public class MockFile
     }
 
     /// <summary>
+    /// 2-arg AL form: UploadIntoStream(DialogTitle, var InStream).
+    /// BC emits this as: ALUploadIntoStream(DataError.TrapError, title, ByRef&lt;NavInStream&gt;, Guid).
+    /// After the NavInStream→MockInStream rewrite the 3rd arg is ByRef&lt;MockInStream&gt;,
+    /// so we need a matching overload (issue #1210).
+    /// Always returns false (no UI in standalone mode).
+    /// </summary>
+    public static bool ALUploadIntoStream(object? scope, string dialogTitle, ByRef<MockInStream> inStream, Guid extra)
+    {
+        return false;
+    }
+
+    /// <summary>
+    /// 2-arg AL form fallback without trailing Guid (older/newer BC emit variants).
+    /// </summary>
+    public static bool ALUploadIntoStream(object? scope, string dialogTitle, ByRef<MockInStream> inStream)
+    {
+        return false;
+    }
+
+    /// <summary>
     /// ALDownloadFromStream — BC standalone DownloadFromStream maps here as a static.
     /// BC emits (scope, MockInStream inStream, title, folder, filter, ByRef&lt;NavText&gt; fileName, NavText extra).
     /// No-op (no UI in standalone mode).

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -2890,8 +2890,8 @@ File.UploadIntoStream:
   layer: runtime-api
   category: File
   status: covered
-  notes: overloads=3; 5-arg and 6-arg (with/without Guid) for BC≤25 5-param AL form; 4-arg (no DataError/Folder/Guid) for newer BC 4-param AL form — all no-op stubs returning false
-  test: AlRunner.Tests/MockFile4ArgTests.cs
+  notes: overloads=5; 5-arg and 6-arg (with/without Guid) for BC≤25 5-param AL form; 4-arg (no DataError/Folder/Guid) for newer BC 4-param AL form; 2-param AL form (Title, var InStream) emitting (DataError, string, ByRef&lt;MockInStream&gt;, Guid) — all no-op stubs returning false
+  test: tests/bucket-1/1210-upload-into-stream-2arg/test/UisShort.Test.al
 
 File.View:
   layer: runtime-api

--- a/tests/bucket-1/1210-upload-into-stream-2arg/src/UisShort.Codeunit.al
+++ b/tests/bucket-1/1210-upload-into-stream-2arg/src/UisShort.Codeunit.al
@@ -1,0 +1,17 @@
+/// Helper exercising the 2-arg AL form of UploadIntoStream.
+///
+/// Some BC projects call the short form `UploadIntoStream(Title, var InStream)`
+/// (telemetry issue #1210). BC's compiler emits that to a C# call whose
+/// shape does not match our existing `NavFile.ALUploadIntoStream` overloads,
+/// producing CS1503 after the NavInStream -> MockInStream rewrite.
+codeunit 121011 "UIS2 Src"
+{
+    /// <summary>
+    /// Calls the 2-arg AL form: UploadIntoStream(Title, var InStream).
+    /// Returns the Boolean result so the test can assert it directly.
+    /// </summary>
+    procedure CallUploadIntoStream2Arg(var InStr: InStream): Boolean
+    begin
+        exit(UploadIntoStream('Upload', InStr));
+    end;
+}

--- a/tests/bucket-1/1210-upload-into-stream-2arg/test/UisShort.Test.al
+++ b/tests/bucket-1/1210-upload-into-stream-2arg/test/UisShort.Test.al
@@ -1,0 +1,42 @@
+/// Tests for the 2-arg AL form UploadIntoStream(Title, var InStream).
+/// Issue #1210 — rewriter/signature gap caused CS1503 at compile time.
+codeunit 121012 "UIS2 Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    // -----------------------------------------------------------------------
+    // Positive: The 2-arg AL form compiles and returns false in standalone
+    // mode (no client/UI is available). This proves the rewriter produces
+    // a call site that matches a MockFile overload.
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure UploadIntoStream2Arg_ReturnsFalse_NoThrow()
+    var
+        Src: Codeunit "UIS2 Src";
+        InStr: InStream;
+    begin
+        Assert.IsFalse(Src.CallUploadIntoStream2Arg(InStr),
+            '2-arg UploadIntoStream must return false in standalone mode (no client)');
+    end;
+
+    // -----------------------------------------------------------------------
+    // Negative: A stub that always "succeeds" would incorrectly return true.
+    // Ensure asserting true fails — this catches a broken mock that flips
+    // the return value.
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure UploadIntoStream2Arg_AssertingTrueFails()
+    var
+        Src: Codeunit "UIS2 Src";
+        InStr: InStream;
+    begin
+        asserterror Assert.IsTrue(Src.CallUploadIntoStream2Arg(InStr),
+            'This assertion should fail because the stub returns false.');
+        Assert.ExpectedError('This assertion should fail');
+    end;
+}


### PR DESCRIPTION
Closes #1210

## Problem

Telemetry reports CS1503 at AL `UploadIntoStream('...', FileInStream)` — argument 3 `ByRef<MockInStream>` cannot convert to `ByRef<NavText>`.

BC emits the 2-parameter AL form `UploadIntoStream(Title, var InStream)` as a C# call with the shape:

```csharp
MockFile.ALUploadIntoStream(DataError.TrapError, "Upload", ByRef<NavInStream>, Guid.Empty);
```

After the NavInStream→MockInStream rewrite, argument 3 becomes `ByRef<MockInStream>`, which matches no existing MockFile overload. The Roslyn compiler then picks the closest existing overload `(string, string, ByRef<NavText>, MockInStream)` and reports a conversion error.

## Fix

Add matching MockFile.ALUploadIntoStream overloads in `AlRunner/Runtime/MockFile.cs`:

- `(object? scope, string dialogTitle, ByRef<MockInStream> inStream, Guid extra)`
- `(object? scope, string dialogTitle, ByRef<MockInStream> inStream)` — fallback without trailing Guid

Both return false (no UI available in standalone mode).

## Tests

`tests/bucket-1/1210-upload-into-stream-2arg/`:

- **Positive** `UploadIntoStream2Arg_ReturnsFalse_NoThrow`: AL code calls the 2-arg form and must return false. This proves the rewriter produces a call site that matches a MockFile overload (compiles) and that the stub behavior is correct.
- **Negative** `UploadIntoStream2Arg_AssertingTrueFails`: asserts that `Assert.IsTrue` fails (via `asserterror` + `Assert.ExpectedError`), catching a broken mock that flips the return to true.

## Coverage

Updated `docs/coverage.yaml` — `File.UploadIntoStream` now lists 5 overloads and cites the new bucket-1 test.