### PR TITLE
fix: add session-aware TestField.ALAsDateTime overload — closes #1216

### DIFF
--- a/AlRunner/Runtime/MockTestPageHandle.cs
+++ b/AlRunner/Runtime/MockTestPageHandle.cs
@@ -731,13 +731,19 @@ public class MockTestPageField
 
     /// <summary>
     /// ALAsDateTime — returns the stored field value as a NavDateTime.
-    /// BC emits <c>tP.GetField(hash).ALAsDateTime()</c> for TestField.AsDateTime().
+    /// BC emits <c>tP.GetField(hash).ALAsDateTime()</c> (or the session-aware
+    /// overload) for TestField.AsDateTime(). Throws when the stored value
+    /// cannot be converted to a datetime — matching BC's NavNCLConversionException.
     /// </summary>
     public NavDateTime ALAsDateTime()
     {
         if (_value is NavDateTime dt) return dt;
         if (_value is MockVariant mv && mv.Value is NavDateTime mvdt) return mvdt;
-        return NavDateTime.Default;
+        if (_value is DateTime sysDt) return NavDateTime.CreateFromObject(sysDt);
+        if (_value is MockVariant mv2 && mv2.Value is DateTime mvsDt) return NavDateTime.CreateFromObject(mvsDt);
+        if (_value is null) return NavDateTime.Default;
+        throw new InvalidOperationException(
+            $"Cannot convert field value of type {_value.GetType().Name} to DateTime.");
     }
 
     /// <summary>

--- a/AlRunner/Runtime/MockTestPageHandle.cs
+++ b/AlRunner/Runtime/MockTestPageHandle.cs
@@ -747,6 +747,15 @@ public class MockTestPageField
     }
 
     /// <summary>
+    /// ALAsDateTime(session) — session-aware overload that BC emits for
+    /// <c>TestField.AsDateTime()</c>. BC's NavTestField has both a 0-arg
+    /// (obsolete) overload and a 1-arg overload that takes a NavSession;
+    /// recent BC compilers always emit the session form. The mock ignores
+    /// the session argument since standalone mode has no client timezone.
+    /// </summary>
+    public NavDateTime ALAsDateTime(object? session) => ALAsDateTime();
+
+    /// <summary>
     /// ALAssertEquals — asserts that the stored field value equals the expected value.
     /// Throws if the values differ (string comparison via AlCompat.Format).
     /// BC emits <c>tP.GetField(hash).ALAssertEquals(session, expected)</c>.

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -7596,7 +7596,7 @@ TestField.AsDateTime:
   layer: runtime-api
   category: TestField
   status: covered
-  notes: overloads=1; returns stored NavDateTime or NavDateTime.Default
+  notes: overloads=2 (0-arg, session); BC emits session-aware form (issue #1216); throws on non-convertible values
   tests:
     - tests/bucket-1/86-testfield-methods
 

--- a/tests/bucket-1/86-testfield-methods/src/TestFieldMethodsSrc.al
+++ b/tests/bucket-1/86-testfield-methods/src/TestFieldMethodsSrc.al
@@ -11,6 +11,7 @@ table 86100 "TFM Record"
         field(5; Amt; Decimal) { }
         field(6; PostDate; Date) { }
         field(7; PostTime; Time) { }
+        field(8; PostDateTime; DateTime) { }
     }
     keys { key(PK; Id) { Clustered = true; } }
 }
@@ -30,6 +31,7 @@ page 86100 "TFM Card"
             field(AmtField; Rec.Amt) { }
             field(DateField; Rec.PostDate) { }
             field(TimeField; Rec.PostTime) { }
+            field(DateTimeField; Rec.PostDateTime) { }
         }
     }
 }

--- a/tests/bucket-1/86-testfield-methods/test/TestFieldMethodsTest.al
+++ b/tests/bucket-1/86-testfield-methods/test/TestFieldMethodsTest.al
@@ -258,4 +258,39 @@ codeunit 86101 "TFM Test"
         Assert.AreEqual(T, TP.TimeField.AsTime(), 'AsTime must return the time set via SetValue');
         TP.Close();
     end;
+
+    // ------------------------------------------------------------------
+    // AsDateTime (regression for issue #1216 — CS1501 ALAsDateTime not found)
+    // ------------------------------------------------------------------
+
+    [Test]
+    procedure AsDateTime_ReturnsSetDateTime()
+    var
+        TP: TestPage "TFM Card";
+        DT: DateTime;
+    begin
+        // [GIVEN] DateTimeField set to a specific datetime
+        TP.OpenNew();
+        DT := CreateDateTime(19840101D, 120000T);
+        TP.DateTimeField.SetValue(DT);
+        // [THEN] AsDateTime returns that datetime
+        Assert.AreEqual(DT, TP.DateTimeField.AsDateTime(), 'AsDateTime must return the datetime set via SetValue');
+        TP.Close();
+    end;
+
+    [Test]
+    procedure AsDateTime_NonDateTimeField_RaisesError()
+    var
+        TP: TestPage "TFM Card";
+        DT: DateTime;
+    begin
+        // [GIVEN] A text field holding a non-datetime string
+        TP.OpenNew();
+        TP.NameField.SetValue('not-a-datetime');
+        // [WHEN] AsDateTime is called on the text field
+        // [THEN] A conversion error is raised
+        asserterror DT := TP.NameField.AsDateTime();
+        Assert.ExpectedError('');
+        TP.Close();
+    end;
 }


### PR DESCRIPTION
Closes #1216

## Problem
Telemetry reported `CS1501: ALAsDateTime method not found` — BC's AL compiler emits `TestField.AsDateTime()` as `.ALAsDateTime(session)` (one argument), but `MockTestPageHandle` only exposed a 0-arg overload, so test pages using `AsDateTime()` failed to compile.

BC's real `NavTestField` has two overloads:
- `ALAsDateTime()` (obsolete)
- `ALAsDateTime(NavSession session)` — the form recent BC compilers emit

## Fix
1. Add `ALAsDateTime(object? session)` overload to `MockTestPageHandle` in `AlRunner/Runtime/MockTestPageHandle.cs`. The session argument is ignored — standalone mode has no client timezone.
2. Tighten the conversion: `ALAsDateTime()` now throws `InvalidOperationException` when the stored value cannot be converted, matching BC's `NavNCLConversionException` behaviour, so callers get a real error instead of a silent `NavDateTime.Default`.

## Tests (RED → GREEN)
Extended `tests/bucket-1/86-testfield-methods`:
- **Positive**: `AsDateTime_ReturnsSetDateTime` — sets a DateTime field via `SetValue(CreateDateTime(19840101D, 120000T))` and asserts the exact round-trip.
- **Negative**: `AsDateTime_NonDateTimeField_RaisesError` — calls `AsDateTime()` on a text field and asserts the conversion error.

Both tests fail on `main` (CS1501) and pass after the fix.

## Coverage
Updated `TestField.AsDateTime` entry in `docs/coverage.yaml` to note the 2-overload surface and the issue link.