### PR TITLE
fix: add DataError-typed UploadIntoStream 2-arg overload — closes #1213, #1214

### DIFF
--- a/AlRunner/Runtime/MockFile.cs
+++ b/AlRunner/Runtime/MockFile.cs
@@ -257,6 +257,18 @@ public class MockFile
     }
 
     /// <summary>
+    /// 2-arg AL form with explicit DataError typing — preferred by C# overload
+    /// resolution over the <c>object?</c> variant when BC emits
+    /// <c>ALUploadIntoStream(DataError.TrapError, title, ByRef&lt;MockInStream&gt;, Guid)</c>
+    /// (issues #1213/#1214). Functionally identical — always returns false (no UI
+    /// in standalone mode).
+    /// </summary>
+    public static bool ALUploadIntoStream(DataError errorLevel, string dialogTitle, ByRef<MockInStream> inStream, Guid extra)
+    {
+        return false;
+    }
+
+    /// <summary>
     /// 2-arg AL form fallback without trailing Guid (older/newer BC emit variants).
     /// </summary>
     public static bool ALUploadIntoStream(object? scope, string dialogTitle, ByRef<MockInStream> inStream)

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -2890,8 +2890,8 @@ File.UploadIntoStream:
   layer: runtime-api
   category: File
   status: covered
-  notes: overloads=5; 5-arg and 6-arg (with/without Guid) for BC≤25 5-param AL form; 4-arg (no DataError/Folder/Guid) for newer BC 4-param AL form; 2-param AL form (Title, var InStream) emitting (DataError, string, ByRef&lt;MockInStream&gt;, Guid) — all no-op stubs returning false
-  test: tests/bucket-1/1210-upload-into-stream-2arg/test/UisShort.Test.al
+  notes: overloads=6; 5-arg and 6-arg (with/without Guid) for BC≤25 5-param AL form; 4-arg (no DataError/Folder/Guid) for newer BC 4-param AL form; 2-param AL form (Title, var InStream) emitting (DataError, string, ByRef&lt;MockInStream&gt;, Guid) — both (object?, string, ByRef&lt;MockInStream&gt;, Guid) and DataError-typed (DataError, string, ByRef&lt;MockInStream&gt;, Guid) overloads for issues #1213/#1214; all no-op stubs returning false
+  test: tests/bucket-1/1213-upload-into-stream-local-instream/test/UisLocal.Test.al
 
 File.View:
   layer: runtime-api

--- a/tests/bucket-1/1213-upload-into-stream-local-instream/src/UisLocal.Codeunit.al
+++ b/tests/bucket-1/1213-upload-into-stream-local-instream/src/UisLocal.Codeunit.al
@@ -1,0 +1,25 @@
+/// Helper exercising the 2-arg form of UploadIntoStream where the InStream
+/// is a LOCAL variable (not a var parameter). This matches the call shape in
+/// BBW Item List reported by telemetry (issues #1213/#1214):
+///
+///     if not UploadIntoStream('Title', FileInStream) then ...
+///
+/// where `FileInStream` is declared locally inside the procedure. BC's
+/// compiler emits this as `ALUploadIntoStream(DataError.TrapError, title,
+/// ByRef<MockInStream>, Guid)`. A DataError-typed overload (MockFile.cs) is
+/// required so C# overload resolution picks a matching signature instead of
+/// trying to bind to the 4-arg `(string, string, ByRef<NavText>, MockInStream)`
+/// and raising CS1503 at args 1 (DataError→string) and 4 (Guid→MockInStream).
+codeunit 121211 "UIS Local Src"
+{
+    /// <summary>
+    /// Calls UploadIntoStream with a LOCAL InStream variable.
+    /// Returns the Boolean result so the test can assert it directly.
+    /// </summary>
+    procedure CallUploadIntoStreamLocal(): Boolean
+    var
+        FileInStream: InStream;
+    begin
+        exit(UploadIntoStream('Upload', FileInStream));
+    end;
+}

--- a/tests/bucket-1/1213-upload-into-stream-local-instream/test/UisLocal.Test.al
+++ b/tests/bucket-1/1213-upload-into-stream-local-instream/test/UisLocal.Test.al
@@ -1,0 +1,42 @@
+/// Tests for UploadIntoStream with a local InStream (issues #1213/#1214).
+/// BC emits `ALUploadIntoStream(DataError, string, ByRef<MockInStream>, Guid)`
+/// — previously triggered CS1503 at args 1 (DataError→string) and 4
+/// (Guid→MockInStream) because C# overload resolution fell back to the
+/// 4-arg `(string, string, ByRef<NavText>, MockInStream)` signature.
+codeunit 121212 "UIS Local Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    // -----------------------------------------------------------------------
+    // Positive: The local-InStream form compiles and returns false in
+    // standalone mode (no client/UI). Proves our rewriter + MockFile overload
+    // resolve the BC-emitted call shape for issues #1213/#1214.
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure UploadIntoStreamLocal_ReturnsFalse_NoThrow()
+    var
+        Src: Codeunit "UIS Local Src";
+    begin
+        Assert.IsFalse(Src.CallUploadIntoStreamLocal(),
+            'UploadIntoStream with local InStream must return false in standalone mode (no client)');
+    end;
+
+    // -----------------------------------------------------------------------
+    // Negative: A broken stub that returns true would be caught here.
+    // Asserting true must fail and produce the expected error.
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure UploadIntoStreamLocal_AssertingTrueFails()
+    var
+        Src: Codeunit "UIS Local Src";
+    begin
+        asserterror Assert.IsTrue(Src.CallUploadIntoStreamLocal(),
+            'This assertion should fail because the stub returns false.');
+        Assert.ExpectedError('This assertion should fail');
+    end;
+}


### PR DESCRIPTION
Closes #1213
Closes #1214

## Problem

BC emits the 2-arg AL form `UploadIntoStream(Title, FileInStream)` as:

```
ALUploadIntoStream(DataError.TrapError, title, ByRef<MockInStream>, Guid)
```

Before PR #1219 there was no 4-arg overload with this shape. C# overload resolution fell back to the 4-arg `(string, string, ByRef<NavText>, MockInStream)` signature and raised two CS1503 errors telemetered from `BBW Item List`:

- **#1214** — Argument 1: `DataError` → `string`
- **#1213** — Argument 4: `Guid` → `MockInStream`

PR #1219 resolved the call via an `object?`-typed first parameter (DataError boxes to `object?`). This PR adds a DataError-typed overload so overload resolution picks the exact match without relying on boxing.

## Change

- Add `MockFile.ALUploadIntoStream(DataError errorLevel, string dialogTitle, ByRef<MockInStream> inStream, Guid extra)` — no-op returning `false` (no UI in standalone mode), matches the pattern used by sibling methods in `MockFile` / `MockFileUpload` / `MockStream`.
- New AL regression test `tests/bucket-1/1213-upload-into-stream-local-instream/` covering the local-InStream call pattern from `BBW Item List`:
  - **Positive**: `Assert.IsFalse(Src.CallUploadIntoStreamLocal(), ...)` — proves the compiled call returns `false`.
  - **Negative**: `asserterror Assert.IsTrue(...)` + `Assert.ExpectedError` — would catch a broken stub that flips the return value.
- `docs/coverage.yaml` — bump `File.UploadIntoStream` overload count to 6 and document the DataError-typed variant.

No changes to `CHANGELOG.md` (generated post-merge).