### PR TITLE
fix: NavValue→NavCode coercion for `in` operator on Code fields — closes #1211

### DIFF
--- a/AlRunner/Runtime/AlScope.cs
+++ b/AlRunner/Runtime/AlScope.cs
@@ -1917,6 +1917,43 @@ public static class AlCompat
     public static int NavCodeCompare(NavCode a, NavCode b)
         => string.Compare((string)a, (string)b, StringComparison.OrdinalIgnoreCase);
 
+    /// <summary>
+    /// NavValue → NavCode coercing overloads for <see cref="NavCodeCompare"/>.
+    /// BC emits <c>new InListNavValue((candidate) =&gt; NavCodeCompare(candidate, new NavCode(...)) == 0)</c>
+    /// for <c>Rec."CodeField" in ['A', 'B']</c>. The lambda parameter is typed
+    /// <c>NavValue</c> (the delegate's signature), but the arguments are NavCode literals,
+    /// so the call without overloads fails with CS1503. These overloads extract the
+    /// underlying string via the same path used elsewhere (NavCode is the expected
+    /// runtime type; any other NavValue is compared by its Format representation).
+    /// Issue #1211.
+    /// </summary>
+    public static int NavCodeCompare(NavValue a, NavCode b)
+        => string.Compare(NavValueToCodeString(a), (string)b, StringComparison.OrdinalIgnoreCase);
+
+    public static int NavCodeCompare(NavCode a, NavValue b)
+        => string.Compare((string)a, NavValueToCodeString(b), StringComparison.OrdinalIgnoreCase);
+
+    public static int NavCodeCompare(NavValue a, NavValue b)
+        => string.Compare(NavValueToCodeString(a), NavValueToCodeString(b), StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>NavValue → NavCode coercing overloads for <see cref="NavCodeEquals"/>. See #1211.</summary>
+    public static bool NavCodeEquals(NavValue a, NavCode b)
+        => string.Equals(NavValueToCodeString(a), (string)b, StringComparison.OrdinalIgnoreCase);
+
+    public static bool NavCodeEquals(NavCode a, NavValue b)
+        => string.Equals((string)a, NavValueToCodeString(b), StringComparison.OrdinalIgnoreCase);
+
+    public static bool NavCodeEquals(NavValue a, NavValue b)
+        => string.Equals(NavValueToCodeString(a), NavValueToCodeString(b), StringComparison.OrdinalIgnoreCase);
+
+    private static string NavValueToCodeString(NavValue v)
+    {
+        if (v is null) return "";
+        if (v is NavCode nc) return (string)nc;
+        if (v is NavText nt) return (string)nt;
+        return Format(v)?.ToString() ?? "";
+    }
+
     // -----------------------------------------------------------------------
     // ALSystemNumeric replacements (ALRandomize/ALRandom require NavSession)
     // -----------------------------------------------------------------------

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -611,6 +611,19 @@ List.CodeField:
     - tests/bucket-2/234-navvalue-to-navcode-list
   notes: NavValue→NavCode conversion for Code field values used in List of [Code[N]] — closes #1185
 
+InOperator.NavCodeList:
+  layer: runtime-api
+  category: Operator
+  status: covered
+  tests:
+    - tests/bucket-1/304-navcode-in-list
+  notes: |
+    AL `in` operator with Code literals on a Code-typed record field
+    (e.g. `if Rec."No." in ['A', 'B']`). BC emits an InListNavValue
+    delegate whose lambda parameter is typed NavValue; the literal side
+    is NavCode, so NavCodeCompare(NavValue, NavCode) overloads in AlCompat
+    resolve CS1503 — closes #1211.
+
 object_reference_type:
   layer: syntax
   category: type

--- a/tests/bucket-1/304-navcode-in-list/src/NcilHelper.al
+++ b/tests/bucket-1/304-navcode-in-list/src/NcilHelper.al
@@ -1,0 +1,40 @@
+table 304000 "NCIL Item"
+{
+    DataClassification = ToBeClassified;
+
+    fields
+    {
+        field(1; "No."; Code[20]) { DataClassification = ToBeClassified; }
+        field(2; Description; Text[100]) { DataClassification = ToBeClassified; }
+    }
+
+    keys
+    {
+        key(PK; "No.") { Clustered = true; }
+    }
+}
+
+codeunit 304000 "NCIL Helper"
+{
+    /// <summary>
+    /// Reproduces issue #1211: AL 'in' operator against a set of Code literals
+    /// on a Code-typed record field. BC compiler emits a call that expects
+    /// NavCode arguments but the field accessor returns NavValue → CS1503.
+    /// </summary>
+    procedure IsWhitelistedNo(var Item: Record "NCIL Item"): Boolean
+    begin
+        if Item."No." in ['ALPHA', 'BETA', 'GAMMA'] then
+            exit(true);
+        exit(false);
+    end;
+
+    /// <summary>
+    /// Negated form — mirrors the exact AL snippet from the telemetry.
+    /// </summary>
+    procedure IsNotWhitelisted(var Item: Record "NCIL Item"): Boolean
+    begin
+        if not (Item."No." in ['ALPHA', 'BETA']) then
+            exit(true);
+        exit(false);
+    end;
+}

--- a/tests/bucket-1/304-navcode-in-list/test/NcilTests.al
+++ b/tests/bucket-1/304-navcode-in-list/test/NcilTests.al
@@ -1,0 +1,99 @@
+// Test suite for issue #1211: CS1503 NavValue → NavCode when a Code field
+// is tested with the AL 'in' operator against a list of Code literals.
+codeunit 304001 "NCIL Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    [Test]
+    procedure InList_MatchingCode_ReturnsTrue()
+    var
+        Helper: Codeunit "NCIL Helper";
+        Item: Record "NCIL Item";
+        UniqueNo: Code[20];
+    begin
+        UniqueNo := 'ALPHA';
+        Item.Init();
+        Item."No." := UniqueNo;
+        Item.Insert();
+        Item.SetRange("No.", UniqueNo);
+        Item.FindFirst();
+
+        Assert.IsTrue(Helper.IsWhitelistedNo(Item),
+            'ALPHA must match [ALPHA, BETA, GAMMA]');
+    end;
+
+    [Test]
+    procedure InList_NonMatchingCode_ReturnsFalse()
+    var
+        Helper: Codeunit "NCIL Helper";
+        Item: Record "NCIL Item";
+        UniqueNo: Code[20];
+    begin
+        UniqueNo := 'OMEGA';
+        Item.Init();
+        Item."No." := UniqueNo;
+        Item.Insert();
+        Item.SetRange("No.", UniqueNo);
+        Item.FindFirst();
+
+        Assert.IsFalse(Helper.IsWhitelistedNo(Item),
+            'OMEGA must not match [ALPHA, BETA, GAMMA]');
+    end;
+
+    [Test]
+    procedure NotInList_NonMatchingCode_ReturnsTrue()
+    var
+        Helper: Codeunit "NCIL Helper";
+        Item: Record "NCIL Item";
+        UniqueNo: Code[20];
+    begin
+        UniqueNo := 'DELTA';
+        Item.Init();
+        Item."No." := UniqueNo;
+        Item.Insert();
+        Item.SetRange("No.", UniqueNo);
+        Item.FindFirst();
+
+        Assert.IsTrue(Helper.IsNotWhitelisted(Item),
+            'DELTA is not in [ALPHA, BETA] → negated test must return true');
+    end;
+
+    [Test]
+    procedure NotInList_MatchingCode_ReturnsFalse()
+    var
+        Helper: Codeunit "NCIL Helper";
+        Item: Record "NCIL Item";
+        UniqueNo: Code[20];
+    begin
+        UniqueNo := 'BETA';
+        Item.Init();
+        Item."No." := UniqueNo;
+        Item.Insert();
+        Item.SetRange("No.", UniqueNo);
+        Item.FindFirst();
+
+        Assert.IsFalse(Helper.IsNotWhitelisted(Item),
+            'BETA is in [ALPHA, BETA] → negated test must return false');
+    end;
+
+    [Test]
+    procedure InList_EmptyRecord_ErrorsOnFieldAccess()
+    var
+        Helper: Codeunit "NCIL Helper";
+        Item: Record "NCIL Item";
+    begin
+        // [GIVEN] Filter matching nothing; FindFirst fails, so any later
+        // evaluation of Item."No." must still not crash the 'in' path.
+        Item.SetRange("No.", 'NONEXISTENT-XYZ-1211');
+        asserterror
+        begin
+            if not Item.FindFirst() then
+                Error('no record');
+            if Helper.IsWhitelistedNo(Item) then;
+        end;
+        Assert.ExpectedError('no record');
+    end;
+}


### PR DESCRIPTION
Closes #1211

## Problem

BC compiler emits, for AL `if Rec."CodeField" in ['A', 'B']`:

```csharp
new InListNavValue((candidate) =>
    AlCompat.NavCodeCompare(candidate, AlCompat.CreateNavCode(20, "A")) == 0
    || AlCompat.NavCodeCompare(candidate, AlCompat.CreateNavCode(20, "B")) == 0)
(((NavCode)rec.GetFieldValueSafe(1, NavType.Code)))
```

`InListNavValue` is a BC delegate whose parameter is typed `NavValue`
(see `Microsoft.Dynamics.Nav.Ncl`). Inside the lambda, `candidate` is
therefore `NavValue`, but the existing `AlCompat.NavCodeCompare`
overload only accepts `NavCode` → 7× CS1503 per Item."No." in [...]
invocation in the telemetry.

## Fix

Add NavValue-accepting overloads of `NavCodeCompare` and `NavCodeEquals`
in `AlRunner/Runtime/AlScope.cs` (`AlCompat`). The coercion extracts
the underlying string via the same safe-cast pattern already used
elsewhere (NavCode / NavText fast paths, `Format` fallback) and then
delegates to the same `string.Compare`/`string.Equals` call with
OrdinalIgnoreCase used by the existing `NavCode,NavCode` overload.

No rewriter change required — overload resolution picks the new
`(NavValue, NavCode)` signature at compile time.

## Tests

New suite: `tests/bucket-1/304-navcode-in-list` (5 tests)

- `InList_MatchingCode_ReturnsTrue` — positive match (ALPHA in list)
- `InList_NonMatchingCode_ReturnsFalse` — negative (OMEGA not in list)
- `NotInList_NonMatchingCode_ReturnsTrue` — negated `not (... in [...])` positive case
- `NotInList_MatchingCode_ReturnsFalse` — negated, matching code
- `InList_EmptyRecord_ErrorsOnFieldAccess` — `asserterror` + `Assert.ExpectedError`

Full suite: 1604 passed / 66 failed (baseline on main: 1599 / 66) — +5 new, zero regressions.

## Files changed

- `AlRunner/Runtime/AlScope.cs` — six new overloads + private `NavValueToCodeString` helper
- `docs/coverage.yaml` — `InOperator.NavCodeList` entry
- `tests/bucket-1/304-navcode-in-list/` — new suite