### PR TITLE
fix: settable RecordRef.CurrentKeyIndex with re-sort — closes #1218

### DIFF
--- a/AlRunner/Runtime/MockRecordHandle.cs
+++ b/AlRunner/Runtime/MockRecordHandle.cs
@@ -45,6 +45,14 @@ public class MockRecordHandle : IConvertible
     // Primary key field numbers per table (registered via RegisterPrimaryKey)
     private static readonly Dictionary<int, int[]> _primaryKeys = new();
 
+    // All declared keys per table, in declaration order. Index 0 = primary key.
+    // Used by ALCurrentKeyIndex get/set to switch iteration sort order.
+    private static readonly Dictionary<int, List<int[]>> _tableKeys = new();
+
+    // 1-based index into _tableKeys[_tableId] for the currently active key.
+    // 1 means "primary key" (the default). The setter updates _currentKeyFields.
+    private int _currentKeyIndex = 1;
+
     // Cache: (recordType, triggerName) → (recBackingField, xRecBackingField, triggerMethod)
     // Avoids repeated GetField/GetMethod calls in TryFireRecordTriggerCore (1,093 calls/run).
     private record TriggerReflectionInfo(
@@ -163,6 +171,34 @@ public class MockRecordHandle : IConvertible
     public static void RegisterPrimaryKey(int tableId, params int[] fieldNos)
     {
         _primaryKeys[tableId] = fieldNos;
+        // Keep _tableKeys[0] in sync with primary key for ALCurrentKeyIndex resolution.
+        if (!_tableKeys.TryGetValue(tableId, out var list))
+            _tableKeys[tableId] = list = new List<int[]>();
+        if (list.Count == 0)
+            list.Add(fieldNos);
+        else
+            list[0] = fieldNos;
+    }
+
+    /// <summary>
+    /// Register all declared keys for a table, in declaration order.
+    /// The first entry is the clustered primary key. Subsequent entries are
+    /// secondary keys referenced by <c>RecRef.CurrentKeyIndex := N</c>.
+    /// </summary>
+    public static void RegisterKeys(int tableId, List<int[]> keys)
+    {
+        if (keys == null || keys.Count == 0) return;
+        _tableKeys[tableId] = new List<int[]>(keys);
+        _primaryKeys[tableId] = keys[0];
+    }
+
+    internal static List<int[]> GetKeysForTable(int tableId)
+    {
+        if (_tableKeys.TryGetValue(tableId, out var list) && list.Count > 0)
+            return list;
+        if (_primaryKeys.TryGetValue(tableId, out var pk))
+            return new List<int[]> { pk };
+        return new List<int[]> { new[] { 1 } };
     }
 
     /// <summary>
@@ -3203,6 +3239,35 @@ public class MockRecordHandle : IConvertible
             foreach (var fieldNo in keyFields)
                 names.Add(GetFieldNameByNo(fieldNo));
             return string.Join(",", names);
+        }
+    }
+
+    /// <summary>
+    /// AL RecordRef.KeyCount — number of declared keys for this table.
+    /// The primary key is always key 1. Secondary keys follow in declaration order.
+    /// </summary>
+    public int ALKeyCount => GetKeysForTable(_tableId).Count;
+
+    /// <summary>
+    /// AL RecordRef.CurrentKeyIndex — 1-based index of the active sort key.
+    /// Setting this re-sorts subsequent FindSet/Next iteration by the selected
+    /// key's fields. Throws when the index is out of range.
+    /// </summary>
+    public int ALCurrentKeyIndex
+    {
+        get => _currentKeyIndex;
+        set
+        {
+            var keys = GetKeysForTable(_tableId);
+            if (value < 1 || value > keys.Count)
+                throw new Exception(
+                    $"RecordRef.CurrentKeyIndex: index {value} out of range for table {ALTableName} " +
+                    $"(valid: 1..{keys.Count}).");
+            _currentKeyIndex = value;
+            _currentKeyFields = (int[])keys[value - 1].Clone();
+            // Invalidate any cached result set so the next FindSet re-sorts by the new key.
+            _currentResultSet = null;
+            _cursorPosition = -1;
         }
     }
 

--- a/AlRunner/Runtime/MockRecordRef.cs
+++ b/AlRunner/Runtime/MockRecordRef.cs
@@ -598,18 +598,33 @@ public class MockRecordRef
 
     // -- CurrentKey / CurrentKeyIndex --
     public string ALCurrentKey => _handle?.ALCurrentKey ?? "";
-    public int ALCurrentKeyIndex => 1;
+
+    /// <summary>
+    /// AL RecRef.CurrentKeyIndex — 1-based index of the active sort key.
+    /// Setter switches subsequent iteration to the selected key's fields.
+    /// </summary>
+    public int ALCurrentKeyIndex
+    {
+        get => _handle?.ALCurrentKeyIndex ?? 1;
+        set
+        {
+            if (_handle == null)
+                throw new Exception("RecordRef.CurrentKeyIndex: RecordRef is not open.");
+            _handle.ALCurrentKeyIndex = value;
+        }
+    }
 
     // -- KeyCount / KeyIndex --
-    public int ALKeyCount => 1;
+    public int ALKeyCount => _handle?.ALKeyCount ?? 1;
     public MockKeyRef ALKeyIndex(int index)
     {
-        if (index == 1 && _handle != null)
-        {
-            var pkFields = _handle.GetPrimaryKeyFieldNos();
-            return new MockKeyRef(Number, pkFields, this);
-        }
-        throw new Exception($"RecordRef.KeyIndex: index {index} out of range (only 1 key available)");
+        if (_handle == null)
+            throw new Exception("RecordRef.KeyIndex: RecordRef is not open.");
+        var keys = MockRecordHandle.GetKeysForTable(Number);
+        if (index < 1 || index > keys.Count)
+            throw new Exception(
+                $"RecordRef.KeyIndex: index {index} out of range (valid: 1..{keys.Count}).");
+        return new MockKeyRef(Number, keys[index - 1], this);
     }
 
     // -- CurrentCompany --

--- a/AlRunner/Runtime/TableFieldRegistry.cs
+++ b/AlRunner/Runtime/TableFieldRegistry.cs
@@ -213,26 +213,26 @@ public static class TableFieldRegistry
                 _optionMembersFields[(tableId, fieldId)] = om.Groups[2].Value.Trim();
             }
 
-            // Extract the first declared key (typically Clustered PK) and
-            // register its field numbers so MockRecordHandle.ALInsert can
-            // enforce uniqueness. BC's registration path only fires for
-            // tables whose generated code references ALFieldNo / a runtime
-            // PK helper; synthetic test fixtures often skip that path.
-            var firstKey = KeyDecl.Match(body);
-            if (firstKey.Success)
+            // Extract all declared keys (primary + secondary) and register them
+            // so RecRef.CurrentKeyIndex := N can switch the active sort key.
+            // The first matched key is the clustered primary key.
+            var keys = new List<int[]>();
+            foreach (Match km in KeyDecl.Matches(body))
             {
-                var keyList = firstKey.Groups[1].Value;
-                var pkFieldIds = new List<int>();
+                var keyList = km.Groups[1].Value;
+                var keyFieldIds = new List<int>();
                 foreach (var rawPart in keyList.Split(','))
                 {
                     var part = rawPart.Trim().Trim('"').Trim();
                     if (part.Length == 0) continue;
                     if (fields.TryGetValue(part, out var fid))
-                        pkFieldIds.Add(fid);
+                        keyFieldIds.Add(fid);
                 }
-                if (pkFieldIds.Count > 0)
-                    MockRecordHandle.RegisterPrimaryKey(tableId, pkFieldIds.ToArray());
+                if (keyFieldIds.Count > 0)
+                    keys.Add(keyFieldIds.ToArray());
             }
+            if (keys.Count > 0)
+                MockRecordHandle.RegisterKeys(tableId, keys);
         }
 
         // Parse tableextension and page declarations: both need a name→ID reverse map.

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -5235,7 +5235,7 @@ RecordRef.CurrentKeyIndex:
   layer: runtime-api
   category: RecordRef
   status: covered
-  notes: overloads=1
+  notes: overloads=1; getter + setter — setting re-sorts iteration by the Nth declared key (1-based). Invalid index throws. All keys parsed and registered via TableFieldRegistry. Issue #1218.
 
 RecordRef.Delete:
   layer: runtime-api
@@ -5409,13 +5409,13 @@ RecordRef.KeyCount:
   layer: runtime-api
   category: RecordRef
   status: covered
-  notes: overloads=1
+  notes: overloads=1; returns number of declared keys (PK + secondaries) from TableFieldRegistry. Issue #1218.
 
 RecordRef.KeyIndex:
   layer: runtime-api
   category: RecordRef
   status: covered
-  notes: overloads=1
+  notes: overloads=1; returns MockKeyRef for the Nth declared key (1-based). Out-of-range index throws. Issue #1218.
 
 RecordRef.LoadFields:
   layer: runtime-api

--- a/tests/bucket-1/1218-recordref-currentkeyindex-setter/src/CkiSrc.Codeunit.al
+++ b/tests/bucket-1/1218-recordref-currentkeyindex-setter/src/CkiSrc.Codeunit.al
@@ -1,0 +1,20 @@
+/// Helper procedures that exercise RecordRef.CurrentKeyIndex get/set
+/// — the BC-emitted C# uses the `:=` form which compiles to a property
+/// setter on MockRecordRef.ALCurrentKeyIndex.
+codeunit 1218001 "CKI Src"
+{
+    procedure SetCurrentKeyIndex(var RecRef: RecordRef; Index: Integer)
+    begin
+        RecRef.CurrentKeyIndex := Index;
+    end;
+
+    procedure GetCurrentKeyIndex(var RecRef: RecordRef): Integer
+    begin
+        exit(RecRef.CurrentKeyIndex);
+    end;
+
+    procedure GetKeyCount(var RecRef: RecordRef): Integer
+    begin
+        exit(RecRef.KeyCount());
+    end;
+}

--- a/tests/bucket-1/1218-recordref-currentkeyindex-setter/src/CkiTable.Table.al
+++ b/tests/bucket-1/1218-recordref-currentkeyindex-setter/src/CkiTable.Table.al
@@ -1,0 +1,14 @@
+table 1218000 "CKI Table"
+{
+    fields
+    {
+        field(1; Id; Integer) { }
+        field(2; Name; Text[50]) { }
+        field(3; SortVal; Integer) { }
+    }
+    keys
+    {
+        key(PK; Id) { Clustered = true; }
+        key(BySortVal; SortVal) { }
+    }
+}

--- a/tests/bucket-1/1218-recordref-currentkeyindex-setter/test/CkiTests.al
+++ b/tests/bucket-1/1218-recordref-currentkeyindex-setter/test/CkiTests.al
@@ -1,0 +1,130 @@
+codeunit 1218002 "CKI Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "CKI Src";
+
+    local procedure SeedRecords()
+    var
+        Rec: Record "CKI Table";
+    begin
+        Rec.DeleteAll();
+
+        Rec.Init();
+        Rec.Id := 1; Rec.Name := 'Alpha'; Rec.SortVal := 30;
+        Rec.Insert();
+
+        Rec.Init();
+        Rec.Id := 2; Rec.Name := 'Bravo'; Rec.SortVal := 10;
+        Rec.Insert();
+
+        Rec.Init();
+        Rec.Id := 3; Rec.Name := 'Charlie'; Rec.SortVal := 20;
+        Rec.Insert();
+    end;
+
+    // ------------------------------------------------------------------
+    // Positive: setting CurrentKeyIndex re-sorts the record set by the
+    // secondary key. Iteration order must match the SortVal order, not
+    // the insertion (PK) order.
+    // ------------------------------------------------------------------
+    [Test]
+    procedure RecordRef_CurrentKeyIndex_SwitchesSortToSecondaryKey()
+    var
+        RecRef: RecordRef;
+        FldRef: FieldRef;
+        IdsInOrder: Text;
+    begin
+        SeedRecords();
+
+        RecRef.Open(Database::"CKI Table");
+        Src.SetCurrentKeyIndex(RecRef, 2);
+
+        Assert.AreEqual(2, Src.GetCurrentKeyIndex(RecRef),
+            'CurrentKeyIndex getter should return the value that was set');
+
+        if RecRef.FindSet() then
+            repeat
+                FldRef := RecRef.Field(1);
+                IdsInOrder += Format(FldRef.Value) + ',';
+            until RecRef.Next() = 0;
+
+        // Secondary key is SortVal: 10 (id=2), 20 (id=3), 30 (id=1)
+        Assert.AreEqual('2,3,1,', IdsInOrder,
+            'Iteration order after CurrentKeyIndex := 2 must follow SortVal ascending');
+    end;
+
+    // ------------------------------------------------------------------
+    // Positive: KeyCount reflects both declared keys.
+    // ------------------------------------------------------------------
+    [Test]
+    procedure RecordRef_KeyCount_ReturnsDeclaredKeyCount()
+    var
+        RecRef: RecordRef;
+    begin
+        SeedRecords();
+        RecRef.Open(Database::"CKI Table");
+        Assert.AreEqual(2, Src.GetKeyCount(RecRef),
+            'KeyCount should match the number of declared keys (PK + BySortVal)');
+    end;
+
+    // ------------------------------------------------------------------
+    // Positive: default CurrentKeyIndex is 1 (primary key) and iteration
+    // follows PK order.
+    // ------------------------------------------------------------------
+    [Test]
+    procedure RecordRef_CurrentKeyIndex_DefaultsToPrimaryKey()
+    var
+        RecRef: RecordRef;
+        FldRef: FieldRef;
+        IdsInOrder: Text;
+    begin
+        SeedRecords();
+
+        RecRef.Open(Database::"CKI Table");
+        Assert.AreEqual(1, Src.GetCurrentKeyIndex(RecRef),
+            'Default CurrentKeyIndex should be 1 (primary key)');
+
+        if RecRef.FindSet() then
+            repeat
+                FldRef := RecRef.Field(1);
+                IdsInOrder += Format(FldRef.Value) + ',';
+            until RecRef.Next() = 0;
+
+        Assert.AreEqual('1,2,3,', IdsInOrder,
+            'Default iteration must follow PK (Id) ascending order');
+    end;
+
+    // ------------------------------------------------------------------
+    // Negative: setting CurrentKeyIndex to an out-of-range value must
+    // throw with a recognizable error message.
+    // ------------------------------------------------------------------
+    [Test]
+    procedure RecordRef_CurrentKeyIndex_OutOfRange_Throws()
+    var
+        RecRef: RecordRef;
+    begin
+        SeedRecords();
+        RecRef.Open(Database::"CKI Table");
+
+        asserterror Src.SetCurrentKeyIndex(RecRef, 99);
+        Assert.ExpectedError('out of range');
+    end;
+
+    // ------------------------------------------------------------------
+    // Negative: zero is not a valid key index (keys are 1-based).
+    // ------------------------------------------------------------------
+    [Test]
+    procedure RecordRef_CurrentKeyIndex_Zero_Throws()
+    var
+        RecRef: RecordRef;
+    begin
+        SeedRecords();
+        RecRef.Open(Database::"CKI Table");
+
+        asserterror Src.SetCurrentKeyIndex(RecRef, 0);
+        Assert.ExpectedError('out of range');
+    end;
+}


### PR DESCRIPTION
Closes #1218

## Problem
BC AL syntax `RecRef.CurrentKeyIndex := N` lowers to a C# property assignment on `MockRecordRef.ALCurrentKeyIndex`, but the property was declared get-only (`=> 1`). Roslyn raised `CS0200: Property or indexer 'MockRecordRef.ALCurrentKeyIndex' cannot be assigned to -- it is read only`, breaking any AL code that switches keys at runtime.

## Fix
1. **`MockRecordRef.ALCurrentKeyIndex`** now has a setter that delegates to the underlying `MockRecordHandle`.
2. **`MockRecordHandle.ALCurrentKeyIndex`** setter validates the 1-based index against the registered key list, swaps `_currentKeyFields` to the selected key's fields, and invalidates the cached result set + cursor so the next `FindSet`/`Next` iterates in the new sort order.
3. **`TableFieldRegistry`** now parses **every** `key(...)` declaration (not just the first). `MockRecordHandle.RegisterKeys` stores them in declaration order; `ALKeyCount` and `ALKeyIndex(N)` use that list.
4. Out-of-range index throws a descriptive `RecordRef.CurrentKeyIndex: index N out of range …` error.

## Test suite
`tests/bucket-1/1218-recordref-currentkeyindex-setter/` — table with PK + secondary key `BySortVal`, seeded so PK and secondary order differ:

- `RecordRef_CurrentKeyIndex_SwitchesSortToSecondaryKey` — asserts iteration order becomes `2,3,1` (SortVal ascending) after `CurrentKeyIndex := 2`.
- `RecordRef_KeyCount_ReturnsDeclaredKeyCount` — asserts `KeyCount = 2`.
- `RecordRef_CurrentKeyIndex_DefaultsToPrimaryKey` — asserts default is `1` and PK iteration order is `1,2,3`.
- `RecordRef_CurrentKeyIndex_OutOfRange_Throws` — negative, `asserterror` + `Assert.ExpectedError('out of range')`.
- `RecordRef_CurrentKeyIndex_Zero_Throws` — negative, 1-based boundary.

RED confirmed on baseline (CS0200). GREEN: all 5 pass after the fix. Full bucket-1 run: `1604 passed` (5 more than baseline's 1599); the 66 pre-existing failures are unrelated and unchanged.

## Docs
`docs/coverage.yaml` — `RecordRef.CurrentKeyIndex`, `RecordRef.KeyCount`, `RecordRef.KeyIndex` notes updated.