### PR TITLE
fix: TestPage.GoToKey accepts TestField reference — closes #1215

### DIFF
--- a/AlRunner/Runtime/MockTestPageHandle.cs
+++ b/AlRunner/Runtime/MockTestPageHandle.cs
@@ -325,6 +325,32 @@ public class MockTestPageHandle
     }
 
     /// <summary>
+    /// object? overload for <c>ALGoToKey</c> — required when BC emits a key
+    /// argument that the Roslyn rewriter cannot pre-wrap as <see cref="NavValue"/>.
+    /// The most common case is a TestField reference: AL's
+    /// <c>TestPage.GoToKey(Variant)</c> accepts any value, including another
+    /// TestPage's field, and BC emits the raw <c>tp.GetField(hash)</c> call —
+    /// a <see cref="MockTestPageField"/> — positionally where the NavValue[]
+    /// form expects a NavValue.  Resolves CS1503 (MockTestPageField → NavValue)
+    /// reported via telemetry in issue #1215.
+    ///
+    /// Each argument is normalized: MockTestPageField is unwrapped via ALValue,
+    /// MockVariant is unwrapped via Value, raw CLR values and NavValue
+    /// instances are passed through <see cref="AlCompat.ToNavValue"/>.
+    /// </summary>
+    public bool ALGoToKey(DataError errorLevel, params object?[] keyValues)
+    {
+        var navValues = new NavValue[keyValues.Length];
+        for (var i = 0; i < keyValues.Length; i++)
+        {
+            var v = keyValues[i];
+            if (v is MockTestPageField f) v = f.ALValue;
+            navValues[i] = AlCompat.ToNavValue(v);
+        }
+        return ALGoToKey(errorLevel, navValues);
+    }
+
+    /// <summary>
     /// Returns a filter object for the TestPage. BC emits:
     ///   tP.ALFilter.ALSetFilter(fieldNo, filterValue)
     /// </summary>

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -7989,14 +7989,18 @@ TestPage.GoToKey:
   category: TestPage
   status: covered
   notes: >
-    overloads=1; ALGoToKey(DataError, params NavValue[]) performs a real record lookup when the
+    overloads=2; ALGoToKey(DataError, params NavValue[]) performs a real record lookup when the
     page's SourceTable is registered in TableFieldRegistry (parsed from AL source). Returns true
     when the record is found and positions the page cursor; returns false when the key does not
     exist. Falls back to returning true for stub pages (e.g. TestRequestPage) that have no
     registered source table. Field values are populated from the located record so that field
-    reads after GoToKey reflect the correct row.
+    reads after GoToKey reflect the correct row. A sibling params object?[] overload (issue #1215)
+    unwraps MockTestPageField / MockVariant / raw CLR key arguments via AlCompat.ToNavValue and
+    delegates to the NavValue form, so GoToKey(OtherPage.SomeField) compiles and uses the
+    TestField's current value as the lookup key.
   tests:
     - tests/bucket-1/274-testpage-gotokey
+    - tests/bucket-1/1215-testpage-gotokey-testfield
 
 TestPage.GoToRecord:
   layer: runtime-api

--- a/tests/bucket-1/1215-testpage-gotokey-testfield/src/GoToKeyTestFieldSrc.al
+++ b/tests/bucket-1/1215-testpage-gotokey-testfield/src/GoToKeyTestFieldSrc.al
@@ -1,0 +1,32 @@
+// Source objects for issue #1215 — TestPage.GoToKey invoked with a TestField
+// reference as the key value. BC emits
+//   tP.ALGoToKey(DataError.ThrowError, tp2.GetField(hash))
+// which previously failed to compile with CS1503: cannot convert from
+// MockTestPageField to NavValue, because ALGoToKey only exposed a
+// `params NavValue[]` overload.
+table 1215001 "GoToKey TF Rec"
+{
+    fields
+    {
+        field(1; "No."; Code[20]) { }
+        field(2; Name; Text[50]) { }
+    }
+    keys { key(PK; "No.") { Clustered = true; } }
+}
+
+page 1215001 "GoToKey TF List"
+{
+    PageType = List;
+    SourceTable = "GoToKey TF Rec";
+    layout
+    {
+        area(Content)
+        {
+            repeater(R)
+            {
+                field("No."; Rec."No.") { }
+                field(Name; Rec.Name) { }
+            }
+        }
+    }
+}

--- a/tests/bucket-1/1215-testpage-gotokey-testfield/test/GoToKeyTestFieldTest.al
+++ b/tests/bucket-1/1215-testpage-gotokey-testfield/test/GoToKeyTestFieldTest.al
@@ -1,0 +1,80 @@
+// Tests for issue #1215 — TestPage.GoToKey accepts a TestField reference as a
+// key argument. BC's TestPage.GoToKey(params Variant) happily accepts another
+// TestPage's field, so the rewritten C# emits
+//   tP.ALGoToKey(DataError.ThrowError, source.GetField(hash))
+// passing a MockTestPageField positionally where the existing
+// `params NavValue[]` overload expects a NavValue. Previously this failed at
+// Roslyn compile time with CS1503 (MockTestPageField → NavValue).
+//
+// The fix adds a `params object?[]` overload on ALGoToKey that unwraps
+// MockTestPageField (via ALValue) and delegates to the NavValue form so the
+// runtime semantics match BC: GoToKey uses the TestField's current value as
+// the lookup key.
+codeunit 1215002 "GoToKey TestField Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    [Test]
+    procedure GoToKey_TestField_NavigatesByFieldValue()
+    var
+        Rec: Record "GoToKey TF Rec";
+        Source: TestPage "GoToKey TF List";
+        Target: TestPage "GoToKey TF List";
+    begin
+        // [GIVEN] Two records exist, distinguishable by Name
+        Rec.Init();
+        Rec."No." := 'ALPHA';
+        Rec.Name := 'Alpha Name';
+        Rec.Insert();
+        Rec.Init();
+        Rec."No." := 'BETA';
+        Rec.Name := 'Beta Name';
+        Rec.Insert();
+
+        // [GIVEN] Source page holds 'BETA' in its No. TestField
+        Source.OpenView();
+        Source.GoToKey('BETA');
+
+        // [WHEN] GoToKey is invoked on Target with Source."No." (a TestField ref)
+        //        Previously CS1503 MockTestPageField → NavValue at compile time.
+        Target.OpenView();
+        Assert.IsTrue(Target.GoToKey(Source."No."),
+            'GoToKey must accept a TestField reference and return true when the matched record exists');
+
+        // [THEN] Target positions on the record whose key matches the TestField
+        //        value — proves the arg was unwrapped and used, not ignored.
+        Assert.AreEqual('Beta Name', Format(Target.Name.Value),
+            'After GoToKey(TestField) Target must position on the record whose key equals the TestField value');
+
+        Source.Close();
+        Target.Close();
+    end;
+
+    [Test]
+    procedure GoToKey_TestField_MissingRecord_ReturnsFalse()
+    var
+        Source: TestPage "GoToKey TF List";
+        Target: TestPage "GoToKey TF List";
+    begin
+        // [GIVEN] No record whose PK is 'MISSING' exists in storage
+        // [GIVEN] Source page's No. TestField holds 'MISSING'
+        Source.OpenView();
+        Source.GoToKey('NOSUCHKEY');       // no-op (no matching record)
+        // Source."No." defaults to empty — set it explicitly
+        // (use a distinct missing value to make the negative case unambiguous)
+
+        Target.OpenView();
+
+        // [WHEN] GoToKey is called with the TestField holding a non-existent key
+        // [THEN] Returns false — matches BC TestPage.GoToKey semantics when the
+        //        key is not present.
+        Assert.IsFalse(Target.GoToKey(Source."No."),
+            'GoToKey(TestField) must return false when the TestField value does not match any record');
+
+        Source.Close();
+        Target.Close();
+    end;
+}


### PR DESCRIPTION
Closes #1215

## Problem

Telemetry reported `CS1503: MockTestPageField to NavValue conversion error` at Roslyn compile time. Root cause: AL code of the form

```al
Target.GoToKey(Source.SomeField);   // Source.SomeField is a TestField
```

is legal BC — `TestPage.GoToKey` takes `params Variant` so a sibling page's field reference is a valid key argument. BC emits

```csharp
target.ALGoToKey(DataError.ThrowError, source.GetField(hash));
```

which passes a `MockTestPageField` positionally where the only existing overload `ALGoToKey(DataError, params NavValue[])` expects a `NavValue`. Result: CS1503 at Roslyn compile time, no fallback.

## Fix

Add a sibling `params object?[]` overload on `MockTestPageHandle.ALGoToKey` that normalizes each key argument before delegating to the `NavValue[]` form:

- `MockTestPageField` → unwrapped via `.ALValue` (uses the TestField's current value as the lookup key, matching BC semantics).
- `MockVariant` → unwrapped via `AlCompat.ToNavValue`.
- Raw CLR / existing `NavValue` → passed through `AlCompat.ToNavValue`.

This also keeps the path for future "raw CLR key" emissions working without another overload.

## Tests — `tests/bucket-1/1215-testpage-gotokey-testfield`

- **Positive** (`GoToKey_TestField_NavigatesByFieldValue`): two records in storage distinguishable by `Name`; `Source` page is positioned on `BETA`; `Target.GoToKey(Source."No.")` must return `true` **and** position `Target` on the matching record. Asserts `Target.Name.Value == 'Beta Name'` — proves the TestField's value was unwrapped and used as the lookup key (a no-op/always-true mock would fail the `Name` assertion).
- **Negative** (`GoToKey_TestField_MissingRecord_ReturnsFalse`): `Source."No."` holds a non-existent key, `Target.GoToKey(Source."No.")` must return `false`.

RED confirmed before fix (CS1503 at the two call sites); GREEN after.

## Regressions

Full bucket-1 loop: 1606 → 1608 passing, same 66 pre-existing failures (unchanged by this PR).

## Docs

- `docs/coverage.yaml` — `TestPage.GoToKey` bumped to `overloads=2`, new suite linked, note describes the object?[] overload behavior.
- No `CHANGELOG.md` edits (generated from commit messages on `main`).