### PR TITLE
feat: run telemetry triage on hourly schedule

### DIFF
--- a/.github/workflows/telemetry-triage.yml
+++ b/.github/workflows/telemetry-triage.yml
@@ -1,6 +1,8 @@
 name: Telemetry Triage
 
 on:
+  schedule:
+    - cron: '0 * * * *'
   workflow_dispatch:
     inputs:
       from_time:


### PR DESCRIPTION
## Summary
- Adds a `schedule` trigger to `telemetry-triage.yml` so it runs automatically every hour
- No other changes; `FROM_TIME` left blank so the script auto-detects from the last run