### PR TITLE
fix: actionable error messages for access-denied + Windows install docs

### DIFF
--- a/AlRunner/ArtifactDownloader.cs
+++ b/AlRunner/ArtifactDownloader.cs
@@ -18,7 +18,14 @@ public static class ArtifactDownloader
     /// </summary>
     public static string? DownloadServiceTierDlls(string artifactUrl, string outputDir)
     {
-        Directory.CreateDirectory(outputDir);
+        try { Directory.CreateDirectory(outputDir); }
+        catch (UnauthorizedAccessException)
+        {
+            Console.Error.WriteLine($"Error: Access denied creating cache directory: {outputDir}");
+            Console.Error.WriteLine("  This is usually caused by antivirus or corporate security policies blocking writes to user profile directories.");
+            Console.Error.WriteLine("  Try adding an exclusion for the al-runner cache path in your security software.");
+            return null;
+        }
 
         using var http = new HttpClient();
         http.Timeout = TimeSpan.FromMinutes(5);
@@ -171,7 +178,13 @@ public static class ArtifactDownloader
             else
                 continue;
 
-            File.WriteAllBytes(Path.Combine(outputDir, basename), fileData);
+            try { File.WriteAllBytes(Path.Combine(outputDir, basename), fileData); }
+            catch (UnauthorizedAccessException)
+            {
+                Console.Error.WriteLine($"Error: Access denied writing {basename} to {outputDir}");
+                Console.Error.WriteLine("  This is usually caused by antivirus or corporate security policies blocking DLL writes to user profile directories.");
+                return null;
+            }
             extracted++;
             totalBytes += fileData.Length;
         }

--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ Full BC pipeline (BcContainerHelper / MsDyn365Bc.On.Linux, 45+ min) -- full fide
 
 ## Quick Start
 
+### Prerequisites
+
+.NET SDK 8, 9, or 10 — download from [https://aka.ms/dotnet/download](https://aka.ms/dotnet/download).
+
 ### Install
 
 ```bash
@@ -32,6 +36,12 @@ dotnet tool install --global MSDyn365BC.AL.Runner
 ```
 
 On first run, the AL compiler (~57 MB from NuGet) and BC Service Tier DLLs (~11 MB via HTTP range requests) are downloaded automatically and cached. No manual setup required. Works on Windows, Linux, and macOS.
+
+> **Windows / corporate environments:** If the install fails with "package not found in NuGet feeds", your machine may be missing the public NuGet.org feed. Add it once:
+> ```powershell
+> dotnet nuget add source https://api.nuget.org/v3/index.json --name nuget.org
+> ```
+> Then re-run the install command.
 
 ### Run
 
@@ -49,6 +59,16 @@ al-runner --run TestMyProcedure ./src ./test
 al-runner --output-json ./src ./test
 al-runner --output-junit results.xml ./src ./test
 ```
+
+### Multi-root workspaces
+
+Pass all source and test directories as separate arguments — AL Runner compiles them together as one project:
+
+```bash
+al-runner ./app1/src ./app1.test/src ./app2/src ./app2.test/src
+```
+
+AL object IDs must be unique across all directories passed in a single invocation.
 
 ### Build from source
 


### PR DESCRIPTION
## Summary

- **ArtifactDownloader**: catch `UnauthorizedAccessException` on directory creation and DLL writes, emit a specific message pointing to antivirus / corporate security policies rather than a bare "Access is denied" that gives no hint of the cause
- **README**: add Prerequisites (.NET SDK 8/9/10), Windows NuGet feed note for corporate environments, and multi-root workspace usage

Closes #1234, closes #1233

## Test plan
- [ ] Verify `al-runner -v` still shows download progress on a clean cache
- [ ] Verify a normal run is unaffected