### PR TITLE
fix: NavApp.IsEntitled accepts string literal (CS1503)

### DIFF
--- a/AlRunner/Runtime/MockNavApp.cs
+++ b/AlRunner/Runtime/MockNavApp.cs
@@ -70,6 +70,15 @@ public static class MockNavApp
     public static bool ALIsEntitled(DataError errorLevel, NavText id, Guid appId) => true;
 
     /// <summary>
+    /// String overloads of ALIsEntitled — BC may emit the entitlement-ID argument as a C#
+    /// string literal (CS1503: string → NavText) when the AL Text value is a constant
+    /// expression.  These overloads accept <c>string</c> directly to avoid the implicit-
+    /// conversion error — issue #1231.
+    /// </summary>
+    public static bool ALIsEntitled(DataError errorLevel, string id) => true;
+    public static bool ALIsEntitled(DataError errorLevel, string id, Guid appId) => true;
+
+    /// <summary>
     /// NavApp.GetResourceAsText(ResourceName [, TextEncoding]) : Text — returns the named
     /// embedded resource as a string. No .app bundle in standalone mode; returns empty string.
     /// BC emits: ALNavApp.ALGetResourceAsText(null, NavText [, object?]) → NavText

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -4612,7 +4612,7 @@ NavApp.IsEntitled:
   layer: runtime-api
   category: NavApp
   status: covered
-  notes: overloads=1; MockNavApp.ALIsEntitled() returns true (always entitled in standalone)
+  notes: overloads=4 (NavText 2-arg, NavText 3-arg with AppId, string 2-arg, string 3-arg); string overloads added in #1231 to fix CS1503 when BC emits string literal for Text argument; MockNavApp.ALIsEntitled() returns true (always entitled in standalone)
   test: tests/bucket-1/85-navapp-isinstalling/test/NavAppStatusTest.al
 
 NavApp.IsInstalling:

--- a/tests/bucket-1/85-navapp-isinstalling/src/NavAppStatusSrc.al
+++ b/tests/bucket-1/85-navapp-isinstalling/src/NavAppStatusSrc.al
@@ -16,4 +16,13 @@ codeunit 85000 "NAS Src"
     begin
         exit(NavApp.IsEntitled(EntitlementId));
     end;
+
+    /// <summary>
+    /// Calls NavApp.IsEntitled with a hardcoded string literal — this triggered CS1503
+    /// (cannot convert from 'string' to 'NavText') before issue #1231 was fixed.
+    /// </summary>
+    procedure GetIsEntitledLiteral(): Boolean
+    begin
+        exit(NavApp.IsEntitled('standard_1'));
+    end;
 }

--- a/tests/bucket-1/85-navapp-isinstalling/test/NavAppStatusTest.al
+++ b/tests/bucket-1/85-navapp-isinstalling/test/NavAppStatusTest.al
@@ -58,6 +58,20 @@ codeunit 85001 "NAS Test"
     // contradicts unlicensed=true and installing=true simultaneously.
     // -----------------------------------------------------------------------
 
+    // -----------------------------------------------------------------------
+    // Positive: NavApp.IsEntitled() with a string literal argument — this
+    // previously failed with CS1503: cannot convert from 'string' to 'NavText'
+    // (issue #1231).  The fix adds string overloads so the literal compiles.
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure IsEntitled_StringLiteral_ReturnsTrue()
+    begin
+        // Positive: direct string literal passed to IsEntitled must compile and return true.
+        Assert.IsTrue(Src.GetIsEntitledLiteral(),
+            'NavApp.IsEntitled with a string literal must return true in standalone mode');
+    end;
+
     [Test]
     procedure StatusFlags_AreConsistent()
     var


### PR DESCRIPTION
Closes #1231

## Problem

`NavApp.IsEntitled('standard_1')` failed Roslyn compilation with `CS1503: Argument 2: cannot convert from 'string' to 'Microsoft.Dynamics.Nav.Runtime.NavText'`. The BC transpiler emits the entitlement-ID argument as a raw C# `string` literal when the AL `Text` value is a constant expression, but `MockNavApp.ALIsEntitled` only accepted `NavText`.

## Fix

Added `string` overloads to `MockNavApp.ALIsEntitled` (2-arg and 3-arg with `AppId`), following the same pattern used in #1107 for `ALGetResource`. The mock returns `true` for all overloads (the runner always grants full entitlement in standalone mode).

## Test

Extended the existing `85-navapp-isinstalling` suite:
- Added `GetIsEntitledLiteral()` to `NAS Src` codeunit — calls `NavApp.IsEntitled('standard_1')` with a hardcoded string literal
- Added `IsEntitled_StringLiteral_ReturnsTrue` test — confirms the literal compiles and returns `true`

RED: before fix, suite failed with `CS1503` at Roslyn compilation.
GREEN: after fix, all 6 tests in the suite pass.

## Coverage

Updated `docs/coverage.yaml`: `NavApp.IsEntitled` now shows `overloads=4` (NavText 2-arg, NavText 3-arg, string 2-arg, string 3-arg).