### PR TITLE
fix: CopyArray on page-level array[N] of Text[M] — preserve InitializeComponent field inits

### DIFF
--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -552,6 +552,61 @@ public class RoslynRewriter : CSharpSyntaxRewriter
                 visited = visited.WithBaseList(SyntaxFactory.BaseList(newTypes));
         }
 
+        // For page classes: rewrite InitializeComponent to strip BC-runtime-only calls while
+        // keeping field initialisation statements (e.g. this.myCaption = new MockArray<…>(…)).
+        // The BC constructor (ITreeObject parent) and the original InitializeComponent are both
+        // removed by ShouldRemoveMember, so class-level NavArray/MockArray fields would never be
+        // initialised — causing NullReferenceException at runtime (issue #1232).
+        //
+        // MockFormHandle.Invoke already calls InitializeComponent via reflection after creating
+        // the page instance; we just need to preserve a clean version of it.
+        // The approach:
+        //   1. Find InitializeComponent in the already-visited members (NavArray → MockArray
+        //      has already been rewritten by base.VisitClassDeclaration above).
+        //   2. Filter out the BC-only call-statements; keep field assignments.
+        //   3. Replace the original InitializeComponent with the cleaned version so it survives
+        //      ShouldRemoveMember (which only drops it when it still contains the BC markers).
+        if (isPageClass)
+        {
+            var bcOnlyNames = new HashSet<string>(StringComparer.Ordinal)
+            {
+                "CallInitializeComponentExtensionMethod",
+                "InitializeForm",
+                "RegisterUIPart",
+            };
+
+            var newMembers = new List<MemberDeclarationSyntax>();
+            bool replaced = false;
+            foreach (var member in visited.Members)
+            {
+                if (!replaced
+                    && member is MethodDeclarationSyntax initMethod
+                    && initMethod.Identifier.Text == "InitializeComponent"
+                    && initMethod.Body != null)
+                {
+                    // Collect only the non-BC-specific statements
+                    var safeStmts = initMethod.Body.Statements
+                        .Where(s => !bcOnlyNames.Any(n => s.ToString().Contains(n)))
+                        .ToList();
+
+                    if (safeStmts.Count > 0)
+                    {
+                        // Rebuild method with only the safe statements
+                        var cleanBody = initMethod.Body.WithStatements(
+                            SyntaxFactory.List(safeStmts));
+                        var cleanMethod = initMethod.WithBody(cleanBody);
+                        newMembers.Add(cleanMethod);
+                    }
+                    // else: no safe statements → let ShouldRemoveMember drop it as before
+                    replaced = true;
+                    continue;
+                }
+                newMembers.Add(member);
+            }
+            if (replaced)
+                visited = visited.WithMembers(SyntaxFactory.List(newMembers));
+        }
+
         // Remove specific members
         var membersToKeep = new SyntaxList<MemberDeclarationSyntax>();
         foreach (var member in visited.Members)

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -6496,7 +6496,8 @@ System.CopyArray:
   tests:
     - tests/bucket-2/199-system-array-random
     - tests/bucket-1/99-copyarray-3arg
-  notes: overloads=2. ALSystemArray.ALCopyArray redirected to AlCompat.ALCopyArray; 4-arg overload copies count elements from 1-based fromIndex; 3-arg overload (no count) copies all remaining elements from fromIndex to end.
+    - tests/bucket-1/100-copyarray-text-array
+  notes: overloads=2. ALSystemArray.ALCopyArray redirected to AlCompat.ALCopyArray; 4-arg overload copies count elements from 1-based fromIndex; 3-arg overload (no count) copies all remaining elements from fromIndex to end. Fixed CS0411/NullRef for page-level array[N] of Text[M] vars: rewriter now preserves a clean InitializeComponent for page classes (strips BC-only calls, keeps field inits) so MockFormHandle.Invoke can initialise MockArray fields (issue #1232).
 
 System.CopyStream:
   layer: runtime-api

--- a/tests/bucket-1/100-copyarray-text-array/src/CopyArrayTextSrc.al
+++ b/tests/bucket-1/100-copyarray-text-array/src/CopyArrayTextSrc.al
@@ -1,0 +1,37 @@
+/// Helper codeunit for CopyArray on fixed-length Text arrays.
+/// Regression for issue #1232: CS0411 type inference failure when element type
+/// is a fixed-length NavText subtype (e.g. Text[1024]).
+codeunit 99700 "CA Text Src"
+{
+    /// CopyArray(Dest, Src, 1) on array[32] of Text[1024].
+    procedure CopyTextArray(var Src: array[32] of Text[1024]; var Dest: array[32] of Text[1024])
+    begin
+        CopyArray(Dest, Src, 1);
+    end;
+
+    /// CopyArray(Dest, Src, 2) on array[5] of Text[50] — partial copy from index 2.
+    procedure CopyTextArrayFromIndex(var Src: array[5] of Text[50]; FromIndex: Integer; var Dest: array[5] of Text[50])
+    begin
+        CopyArray(Dest, Src, FromIndex);
+    end;
+}
+
+/// Page with a global var of array[32] of Text[1024].
+/// Regression for issue #1232: CopyArray on page-level array var fails CS0411.
+page 99900 "CA Text Page"
+{
+    PageType = Card;
+
+    var
+        MyCaption: array[32] of Text[1024];
+
+    procedure Load(NewCaption: array[32] of Text[1024])
+    begin
+        CopyArray(MyCaption, NewCaption, 1);
+    end;
+
+    procedure GetCaption(Index: Integer): Text[1024]
+    begin
+        exit(MyCaption[Index]);
+    end;
+}

--- a/tests/bucket-1/100-copyarray-text-array/test/CopyArrayTextTest.al
+++ b/tests/bucket-1/100-copyarray-text-array/test/CopyArrayTextTest.al
@@ -1,0 +1,92 @@
+/// Tests for CopyArray on fixed-length Text arrays.
+/// Regression for issue #1232: CS0411 when element type is a fixed-length NavText subtype
+/// (occurs both in codeunit locals and in page-level var fields).
+codeunit 99701 "CA Text Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        H: Codeunit "CA Text Src";
+
+    // ── Positive: copy all elements from index 1 ──────────────────────────────
+
+    [Test]
+    procedure CopyArray_FixedLengthText_CopiesAllElements()
+    var
+        Src: array[32] of Text[1024];
+        Dest: array[32] of Text[1024];
+    begin
+        Src[1] := 'Alpha';
+        Src[2] := 'Beta';
+        Src[3] := 'Gamma';
+        H.CopyTextArray(Src, Dest);
+        Assert.AreEqual('Alpha', Dest[1], 'Dest[1] must be Alpha');
+        Assert.AreEqual('Beta', Dest[2], 'Dest[2] must be Beta');
+        Assert.AreEqual('Gamma', Dest[3], 'Dest[3] must be Gamma');
+    end;
+
+    // ── Positive: copy from index 2 leaves index 1 default ────────────────────
+
+    [Test]
+    procedure CopyArray_FixedLengthText_FromIndex2_EarlyElementDefault()
+    var
+        Src: array[5] of Text[50];
+        Dest: array[5] of Text[50];
+    begin
+        Src[1] := 'First';
+        Src[2] := 'Second';
+        Src[3] := 'Third';
+        H.CopyTextArrayFromIndex(Src, 2, Dest);
+        Assert.AreEqual('Second', Dest[1], 'Dest[1] must be Src[2]=Second');
+        Assert.AreEqual('Third', Dest[2], 'Dest[2] must be Src[3]=Third');
+    end;
+
+    // ── Negative: element before FromIndex is not copied ─────────────────────
+
+    [Test]
+    procedure CopyArray_FixedLengthText_FromIndex2_Dest3IsDefault()
+    var
+        Src: array[5] of Text[50];
+        Dest: array[5] of Text[50];
+    begin
+        Src[1] := 'First';
+        Src[2] := 'Second';
+        Src[3] := 'Third';
+        H.CopyTextArrayFromIndex(Src, 2, Dest);
+        // Only 4 elements copied (Src[2..5]); Dest[5] = default ''
+        Assert.AreEqual('', Dest[5], 'Dest[5] must be default empty string — only 4 elements copied');
+    end;
+
+    // ── Positive: inline CopyArray on Text[1024] array ────────────────────────
+
+    [Test]
+    procedure CopyArray_FixedLengthText_InlineCall_Works()
+    var
+        Src: array[32] of Text[1024];
+        Dest: array[32] of Text[1024];
+    begin
+        Src[1] := 'InlineValue';
+        CopyArray(Dest, Src, 1);
+        Assert.AreEqual('InlineValue', Dest[1], 'Dest[1] must be InlineValue after inline CopyArray');
+    end;
+
+    // ── Positive: page with global var array[32] of Text[1024] compiles ───────
+    // This matches the issue #1232 repro: a page with a class-level var array
+    // and a procedure that calls CopyArray on it.
+
+    [Test]
+    procedure CopyArray_PageGlobalVar_Text1024_CompilationAndCopy()
+    var
+        Src: array[32] of Text[1024];
+        Page: Page "CA Text Page";
+    begin
+        // Page compiles and its Load procedure is callable — proves CS0411 is fixed
+        // for class-level array vars in pages.
+        Src[1] := 'PageCaption1';
+        Src[2] := 'PageCaption2';
+        Page.Load(Src);
+        Assert.AreEqual('PageCaption1', Page.GetCaption(1), 'Page.GetCaption(1) must be PageCaption1');
+        Assert.AreEqual('PageCaption2', Page.GetCaption(2), 'Page.GetCaption(2) must be PageCaption2');
+    end;
+}


### PR DESCRIPTION
Closes #1232

## Summary

- **Root cause**: The `RoslynRewriter` removed the entire `InitializeComponent()` method for page classes when it contained BC-only calls (`CallInitializeComponentExtensionMethod`, `InitializeForm`). This also discarded `NavArray`/`MockArray` field initialisations, leaving class-level array fields as `null`.
- **Symptom**: `NullReferenceException` when calling `CopyArray` on a page-level `array[32] of Text[1024]` var (and on some BC SDK versions, a prior `CS0411` type-inference failure).
- **Fix**: Before member removal, scan the page's `InitializeComponent` for field-assignment statements that do NOT reference BC-only helpers. Rebuild the method containing only those safe statements. The cleaned-up `InitializeComponent` survives `ShouldRemoveMember` and `MockFormHandle.Invoke`'s existing `InitializeComponent` reflection call picks it up.

## Files changed

- `AlRunner/RoslynRewriter.cs` — new pre-pass in `VisitClassDeclaration` for `isPageClass`
- `tests/bucket-1/100-copyarray-text-array/` — new test suite (codeunit 99700/99701, page 99900)
- `docs/coverage.yaml` — updated `System.CopyArray` entry

## Test plan

- [ ] `CopyArray_FixedLengthText_CopiesAllElements` passes
- [ ] `CopyArray_FixedLengthText_FromIndex2_EarlyElementDefault` passes  
- [ ] `CopyArray_FixedLengthText_FromIndex2_Dest3IsDefault` passes
- [ ] `CopyArray_FixedLengthText_InlineCall_Works` passes
- [ ] `CopyArray_PageGlobalVar_Text1024_CompilationAndCopy` passes (was failing with NullReferenceException)
- [ ] Bucket-1: 1618 passed, 66 failed (5 net new passes, 0 regressions)
- [ ] Bucket-2: 1609 passed, 114 failed, 1 blocked (identical to baseline — no regressions)