### PR TITLE
fix: NavObjectDictionary → MockObjectDictionary to lift ITreeObject constraint on codeunit-value dictionaries

### DIFF
--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -1552,6 +1552,21 @@ public void Unbind() { AlRunner.Runtime.EventSubscriberRegistry.Unbind(this); }
                 visited.TypeArgumentList);
         }
 
+        // NavObjectDictionary<TKey, TValue> -> MockObjectDictionary<TKey, TValue>
+        // BC emits `Dictionary of [K, Codeunit X]` (and similar) as
+        // NavObjectDictionary<TKey, TValue>, which constrains
+        //   TValue : ITreeObject, IALAssignable<TValue>
+        // MockCodeunitHandle and MockInterfaceHandle don't implement ITreeObject,
+        // so using the real type causes CS0311 (issues #1239, #1240, #1241).
+        // MockObjectDictionary<TKey, TValue> exposes the same API without constraints.
+        if (visited.Identifier.Text == "NavObjectDictionary" &&
+            visited.TypeArgumentList.Arguments.Count == 2)
+        {
+            return SyntaxFactory.GenericName(
+                SyntaxFactory.Identifier("MockObjectDictionary"),
+                visited.TypeArgumentList);
+        }
+
         return visited;
     }
 
@@ -1738,6 +1753,15 @@ public void Unbind() { AlRunner.Runtime.EventSubscriberRegistry.Unbind(this); }
         // After VisitGenericName, NavObjectList has already been renamed.
         // MockObjectList doesn't need the ITreeObject parent.
         if (typeText.StartsWith("MockObjectList<") && visited.ArgumentList != null &&
+            visited.ArgumentList.Arguments.Count == 1)
+        {
+            return visited.WithArgumentList(SyntaxFactory.ArgumentList());
+        }
+
+        // new MockObjectDictionary<TKey, TValue>(this) -> new MockObjectDictionary<TKey, TValue>()
+        // After VisitGenericName, NavObjectDictionary has been renamed to MockObjectDictionary.
+        // The real ctor takes ITreeObject parent — strip it as the mock is parameterless.
+        if (typeText.StartsWith("MockObjectDictionary<") && visited.ArgumentList != null &&
             visited.ArgumentList.Arguments.Count == 1)
         {
             return visited.WithArgumentList(SyntaxFactory.ArgumentList());

--- a/AlRunner/Runtime/MockObjectDictionary.cs
+++ b/AlRunner/Runtime/MockObjectDictionary.cs
@@ -1,0 +1,162 @@
+namespace AlRunner.Runtime;
+
+using System.Collections;
+using System.Collections.Generic;
+using System.Reflection;
+using Microsoft.Dynamics.Nav.Runtime;
+using Microsoft.Dynamics.Nav.Types;
+
+/// <summary>
+/// Standalone replacement for <c>NavObjectDictionary&lt;TKey, TValue&gt;</c>.
+/// BC's real type constrains <c>TValue : ITreeObject, IALAssignable&lt;TValue&gt;</c>
+/// and requires a valid parent with a non-null Tree handler; neither is available
+/// in standalone mode.
+///
+/// MockObjectDictionary exposes the same API surface the transpiled code calls
+/// (ALAdd, ALContainsKey, ALGet, ALRemove, ALSet, ALCount, ALKeys, ALValues, Clear)
+/// on a plain <c>Dictionary&lt;TKey, TValue&gt;</c> without any ITreeObject constraint.
+///
+/// This resolves issues #1239, #1240, #1241 where
+/// <c>Dictionary of [Guid, Codeunit X]</c> (and similar) caused CS0311/CS1503
+/// errors because <c>MockCodeunitHandle</c> does not implement <c>ITreeObject</c>.
+/// </summary>
+public class MockObjectDictionary<TKey, TValue> : IEnumerable<KeyValuePair<TKey, TValue>>
+    where TKey : notnull
+{
+    private readonly Dictionary<TKey, TValue> _dict = new();
+
+    /// <summary>
+    /// Default constructor — no ITreeObject parent needed.
+    /// </summary>
+    public MockObjectDictionary() { }
+
+    /// <summary>
+    /// BC-style constructor stand-in — rewriter strips the ITreeObject parent argument.
+    /// </summary>
+    public MockObjectDictionary(object? _) { }
+
+    // -----------------------------------------------------------------------
+    // AL API
+    // -----------------------------------------------------------------------
+
+    /// <summary>Number of entries.</summary>
+    public int ALCount => _dict.Count;
+
+    /// <summary>
+    /// ALAdd — adds a key/value pair. Throws if the key already exists
+    /// (mirrors NavObjectDictionary behaviour when DataError = ThrowError).
+    /// </summary>
+    public bool ALAdd(DataError errorLevel, TKey key, TValue value)
+    {
+        if (_dict.ContainsKey(key))
+        {
+            if (errorLevel == DataError.ThrowError)
+                throw new InvalidOperationException(
+                    $"An entry with key '{key}' is already present in the dictionary.");
+            return false;
+        }
+        _dict[key] = value;
+        return true;
+    }
+
+    /// <summary>ALContainsKey — returns true if the key is present.</summary>
+    public bool ALContainsKey(TKey key) => _dict.ContainsKey(key);
+
+    /// <summary>
+    /// ALGet — retrieves the value by key; returns true if found.
+    /// The stored value is assigned into <paramref name="handle"/> via <c>ALAssign</c>
+    /// (reflection-based) so the caller's variable is updated, matching the
+    /// NavObjectDictionary ITreeObject/IALAssignable out-parameter contract.
+    ///
+    /// The generated code passes the AL variable directly (not wrapped in ByRef&lt;T&gt;)
+    /// because MockCodeunitHandle is already a reference type and the BC compiler
+    /// uses ALAssign semantics for ITreeObject-typed out-parameters.
+    /// </summary>
+    public bool ALGet(DataError errorLevel, TKey key, TValue handle)
+    {
+        if (!_dict.TryGetValue(key, out var stored))
+            return false;
+
+        // Assign the retrieved value into the caller's handle via ALAssign
+        // (mirrors NavObjectDictionary's IALAssignable<T>.ALAssign pattern).
+        if (handle != null && stored != null)
+        {
+            var method = handle.GetType().GetMethod(
+                "ALAssign",
+                BindingFlags.Public | BindingFlags.Instance,
+                null,
+                new[] { stored.GetType() },
+                null);
+            method?.Invoke(handle, new object[] { stored });
+        }
+
+        return true;
+    }
+
+    /// <summary>ALGet — retrieves the value by key; throws if not found.</summary>
+    public TValue ALGet(TKey key)
+    {
+        if (!_dict.TryGetValue(key, out var value))
+            throw new InvalidOperationException(
+                $"The key '{key}' is not present in the dictionary.");
+        return value;
+    }
+
+    /// <summary>ALRemove — removes the key; returns true if it was present.</summary>
+    public bool ALRemove(TKey key) => _dict.Remove(key);
+
+    /// <summary>ALSet — adds or overwrites the value for a key.</summary>
+    public void ALSet(TKey key, TValue value) => _dict[key] = value;
+
+    /// <summary>
+    /// ALSet with old-value out-param — sets key/value and returns the previous
+    /// value via <paramref name="oldValue"/> wrapper. Returns true if the key existed.
+    /// </summary>
+    public bool ALSet(TKey key, TValue value, ByRef<TValue> oldValue)
+    {
+        bool existed = _dict.TryGetValue(key, out var prev);
+        if (existed && oldValue != null)
+            oldValue.Value = prev!;
+        _dict[key] = value;
+        return existed;
+    }
+
+    /// <summary>
+    /// ALKeys — returns a NavList of all keys (matches <c>Dictionary.Keys()</c> in AL).
+    /// </summary>
+    public NavList<TKey> ALKeys
+    {
+        get
+        {
+            var list = NavList<TKey>.Default;
+            foreach (var k in _dict.Keys)
+                list.ALAdd(k);
+            return list;
+        }
+    }
+
+    /// <summary>
+    /// ALValues — returns a MockObjectList of all values.
+    /// Mirrors NavObjectDictionary.ALValues which returns NavObjectList&lt;TValue&gt;.
+    /// </summary>
+    public MockObjectList<TValue> ALValues
+    {
+        get
+        {
+            var list = new MockObjectList<TValue>();
+            foreach (var v in _dict.Values)
+                list.ALAdd(v);
+            return list;
+        }
+    }
+
+    /// <summary>Clear all entries.</summary>
+    public void Clear() => _dict.Clear();
+
+    /// <summary>Default factory — matches NavObjectDictionary.Default pattern.</summary>
+    public static MockObjectDictionary<TKey, TValue> Default => new();
+
+    // IEnumerable
+    public IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator() => _dict.GetEnumerator();
+    IEnumerator IEnumerable.GetEnumerator() => _dict.GetEnumerator();
+}

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -576,6 +576,20 @@ dictionary_type:
   tests:
     - tests/bucket-2/138-dictionary
 
+dictionary_codeunit_value_type:
+  layer: rewriter
+  category: type
+  status: covered
+  tests:
+    - tests/bucket-1/1239-dict-codeunit-value
+  notes: >
+    Dictionary of [K, Codeunit X] compiles to NavObjectDictionary<TKey,TValue>
+    which constrains TValue : ITreeObject, IALAssignable<TValue>.
+    MockCodeunitHandle/MockInterfaceHandle don't implement ITreeObject so the
+    rewriter replaces NavObjectDictionary with MockObjectDictionary (no
+    constraint). Fixes issues #1239 (CS0311 ITreeObject constraint),
+    #1240 (CS1503 ByRef out-param), #1241 (CS1503 Keys() call site).
+
 list_type:
   layer: syntax
   category: type

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -577,7 +577,7 @@ dictionary_type:
     - tests/bucket-2/138-dictionary
 
 dictionary_codeunit_value_type:
-  layer: rewriter
+  layer: syntax
   category: type
   status: covered
   tests:

--- a/tests/bucket-1/1239-dict-codeunit-value/src/DictCuSrc.al
+++ b/tests/bucket-1/1239-dict-codeunit-value/src/DictCuSrc.al
@@ -1,0 +1,60 @@
+/// Source codeunit for Dictionary of [Guid, Codeunit] tests (issues #1239, #1240, #1241).
+/// Exercises NavObjectDictionary<TKey, TValue> where TValue is a codeunit type:
+///   - Add / ContainsKey / Get (out-param and return) / Remove / Keys()
+codeunit 1239001 "Dict Cu Manager"
+{
+    var
+        ActiveTasks: Dictionary of [Guid, Codeunit "Dict Cu Task Handle"];
+
+    /// Register a task handle under the given ID.
+    procedure Register(TaskID: Guid; TaskHandle: Codeunit "Dict Cu Task Handle")
+    begin
+        ActiveTasks.Add(TaskID, TaskHandle);
+    end;
+
+    /// Return true if the task ID is registered.
+    procedure HasTask(TaskID: Guid): Boolean
+    begin
+        exit(ActiveTasks.ContainsKey(TaskID));
+    end;
+
+    /// Get the handle by ID using the out-parameter overload (issue #1240).
+    procedure TryGet(TaskID: Guid; var TaskHandle: Codeunit "Dict Cu Task Handle"): Boolean
+    begin
+        exit(ActiveTasks.Get(TaskID, TaskHandle));
+    end;
+
+    /// Get the number of registered tasks.
+    procedure Count(): Integer
+    begin
+        exit(ActiveTasks.Count());
+    end;
+
+    /// Return all registered task IDs (issue #1239 / #1241 — Keys() call).
+    procedure GetKeys(): List of [Guid]
+    begin
+        exit(ActiveTasks.Keys());
+    end;
+
+    /// Remove a task and return whether it was present.
+    procedure Deregister(TaskID: Guid): Boolean
+    begin
+        exit(ActiveTasks.Remove(TaskID));
+    end;
+}
+
+codeunit 1239002 "Dict Cu Task Handle"
+{
+    var
+        Name: Text;
+
+    procedure SetName(n: Text)
+    begin
+        Name := n;
+    end;
+
+    procedure GetName(): Text
+    begin
+        exit(Name);
+    end;
+}

--- a/tests/bucket-1/1239-dict-codeunit-value/test/DictCuTest.al
+++ b/tests/bucket-1/1239-dict-codeunit-value/test/DictCuTest.al
@@ -1,0 +1,143 @@
+/// Tests for Dictionary of [Guid, Codeunit X] — issues #1239, #1240, #1241.
+/// Verifies that NavObjectDictionary with a codeunit value type compiles and runs
+/// in al-runner without ITreeObject constraint errors.
+codeunit 1239003 "Dict Cu Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Manager: Codeunit "Dict Cu Manager";
+
+    // ------------------------------------------------------------------
+    // Positive tests
+    // ------------------------------------------------------------------
+
+    [Test]
+    procedure Register_ThenCount_ReturnsOne()
+    var
+        ID: Guid;
+        Handle: Codeunit "Dict Cu Task Handle";
+    begin
+        // Prove Add + Count work for a codeunit-value dictionary.
+        ID := CreateGuid();
+        Handle.SetName('alpha');
+        Manager.Register(ID, Handle);
+        Assert.AreEqual(1, Manager.Count(), 'Count must be 1 after one Register');
+    end;
+
+    [Test]
+    procedure HasTask_PresentKey_ReturnsTrue()
+    var
+        ID: Guid;
+        Handle: Codeunit "Dict Cu Task Handle";
+    begin
+        // Prove ContainsKey works.
+        ID := CreateGuid();
+        Handle.SetName('beta');
+        Manager.Register(ID, Handle);
+        Assert.IsTrue(Manager.HasTask(ID), 'HasTask must return true for a registered ID');
+    end;
+
+    [Test]
+    procedure HasTask_AbsentKey_ReturnsFalse()
+    var
+        AbsentID: Guid;
+    begin
+        // Prove ContainsKey returns false for an unregistered key — issue #1239.
+        AbsentID := CreateGuid();
+        Assert.IsFalse(Manager.HasTask(AbsentID), 'HasTask must return false for an unknown ID');
+    end;
+
+    [Test]
+    procedure TryGet_PresentKey_ReturnsTrueAndHandle()
+    var
+        ID: Guid;
+        Handle: Codeunit "Dict Cu Task Handle";
+        Retrieved: Codeunit "Dict Cu Task Handle";
+    begin
+        // Prove ALGet(key, ByRef<TValue>) overload works — issue #1240.
+        ID := CreateGuid();
+        Handle.SetName('gamma');
+        Manager.Register(ID, Handle);
+        Assert.IsTrue(Manager.TryGet(ID, Retrieved), 'TryGet must return true for a registered ID');
+        Assert.AreEqual('gamma', Retrieved.GetName(), 'Retrieved handle must carry the same name');
+    end;
+
+    [Test]
+    procedure TryGet_AbsentKey_ReturnsFalse()
+    var
+        AbsentID: Guid;
+        Retrieved: Codeunit "Dict Cu Task Handle";
+    begin
+        // Prove the out-param overload returns false when key is missing.
+        AbsentID := CreateGuid();
+        Assert.IsFalse(Manager.TryGet(AbsentID, Retrieved), 'TryGet must return false for an unknown ID');
+    end;
+
+    [Test]
+    procedure GetKeys_ReturnsRegisteredIDs()
+    var
+        ID1: Guid;
+        ID2: Guid;
+        Handle: Codeunit "Dict Cu Task Handle";
+        Keys: List of [Guid];
+    begin
+        // Prove Keys() compiles and returns all registered IDs — issues #1239 / #1241.
+        ID1 := CreateGuid();
+        ID2 := CreateGuid();
+        Handle.SetName('delta');
+        Manager.Register(ID1, Handle);
+        Handle.SetName('epsilon');
+        Manager.Register(ID2, Handle);
+        Keys := Manager.GetKeys();
+        Assert.AreEqual(2, Keys.Count(), 'Keys must contain both registered IDs');
+        Assert.IsTrue(Keys.Contains(ID1), 'Keys must contain ID1');
+        Assert.IsTrue(Keys.Contains(ID2), 'Keys must contain ID2');
+    end;
+
+    [Test]
+    procedure Deregister_PresentKey_ReturnsTrueAndReducesCount()
+    var
+        ID: Guid;
+        Handle: Codeunit "Dict Cu Task Handle";
+    begin
+        // Prove Remove works.
+        ID := CreateGuid();
+        Handle.SetName('zeta');
+        Manager.Register(ID, Handle);
+        Assert.IsTrue(Manager.Deregister(ID), 'Deregister must return true for a present key');
+        Assert.AreEqual(0, Manager.Count(), 'Count must drop to 0 after removal');
+        Assert.IsFalse(Manager.HasTask(ID), 'HasTask must return false after removal');
+    end;
+
+    [Test]
+    procedure Deregister_AbsentKey_ReturnsFalse()
+    var
+        AbsentID: Guid;
+    begin
+        // Prove Remove returns false for a missing key (not present in dictionary).
+        AbsentID := CreateGuid();
+        Assert.IsFalse(Manager.Deregister(AbsentID), 'Deregister must return false for an absent key');
+    end;
+
+    // ------------------------------------------------------------------
+    // Negative test
+    // ------------------------------------------------------------------
+
+    [Test]
+    procedure TryGet_AfterDeregister_ReturnsFalse()
+    var
+        ID: Guid;
+        Handle: Codeunit "Dict Cu Task Handle";
+        Retrieved: Codeunit "Dict Cu Task Handle";
+    begin
+        // Prove that once deregistered a key is truly gone.
+        ID := CreateGuid();
+        Handle.SetName('eta');
+        Manager.Register(ID, Handle);
+        Manager.Deregister(ID);
+        Assert.IsFalse(Manager.TryGet(ID, Retrieved),
+            'TryGet after Deregister must return false');
+    end;
+}


### PR DESCRIPTION
## Summary

- BC emits `NavObjectDictionary<TKey, TValue>` for AL `Dictionary of [K, Codeunit X]`, which constrains `TValue : ITreeObject, IALAssignable<TValue>`. `MockCodeunitHandle` (and `MockInterfaceHandle`) don't implement `ITreeObject`, causing three compile errors at the Roslyn stage.
- Added `MockObjectDictionary<TKey, TValue>` — a plain `Dictionary<K,V>`-backed replacement with no BC runtime constraints, exposing the full AL Dictionary API: `ALAdd`, `ALGet` (both overloads), `ALContainsKey`, `ALRemove`, `ALSet`, `ALCount`, `ALKeys`, `ALValues`, `Clear`.
- The rewriter now maps `NavObjectDictionary<K,V>` → `MockObjectDictionary<K,V>` and strips the ITreeObject parent from the constructor (same pattern as `NavObjectList` → `MockObjectList`).

Closes #1239, Closes #1240, Closes #1241

## Test plan

- [x] RED: confirmed all three CS error types before the fix (6 Roslyn errors on the new test suite)
- [x] GREEN: 9 new AL tests in `tests/bucket-1/1239-dict-codeunit-value/` all pass
- [x] Positive tests: `Register/Count`, `HasTask` (true/false), `TryGet` (present/absent), `GetKeys` (verifies `Keys()` call — issue #1241), `Deregister` (present/absent)
- [x] Negative test: `TryGet_AfterDeregister_ReturnsFalse`
- [x] No regressions in bucket-1 (1628 pass, 66 fail — same 66 pre-existing failures) or bucket-2
- [x] `docs/coverage.yaml` updated with `dictionary_codeunit_value_type` entry