### PR TITLE
fix: rewrite ALCompiler.ToRecordRef to MockRecordRef.FromHandle

### DIFF
--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -3201,6 +3201,26 @@ public void Unbind() { AlRunner.Runtime.EventSubscriberRegistry.Unbind(this); }
                     SyntaxFactory.ParenthesizedExpression(arg));
             }
 
+            // ALCompiler.ToRecordRef(scope, record) -> MockRecordRef.FromHandle(record)
+            // BC emits this when a Record variable is passed by value to a RecordRef parameter
+            // in the same codeunit (direct call, not Invoke). The second argument is a NavRecord
+            // (the underlying record handle). After .Target stripping it becomes MockRecordHandle.
+            // MockRecordRef.FromHandle wraps the handle so it can be used as a RecordRef.
+            // Issue: https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/1242
+            if (exprText == "ALCompiler" && methodName == "ToRecordRef" &&
+                visited.ArgumentList.Arguments.Count >= 2)
+            {
+                var recordArg = visited.ArgumentList.Arguments[1].Expression;
+                return SyntaxFactory.InvocationExpression(
+                    SyntaxFactory.MemberAccessExpression(
+                        SyntaxKind.SimpleMemberAccessExpression,
+                        SyntaxFactory.IdentifierName("MockRecordRef"),
+                        SyntaxFactory.IdentifierName("FromHandle")),
+                    SyntaxFactory.ArgumentList(
+                        SyntaxFactory.SingletonSeparatedList(
+                            SyntaxFactory.Argument(recordArg))));
+            }
+
             // ALCompiler.NavIndirectValueToDecimal(x) -> AlCompat.ObjectToDecimal(x)
             if (exprText == "ALCompiler" && methodName == "NavIndirectValueToDecimal")
             {

--- a/AlRunner/Runtime/MockRecordRef.cs
+++ b/AlRunner/Runtime/MockRecordRef.cs
@@ -17,6 +17,20 @@ public class MockRecordRef
 
     public MockRecordRef() { }
 
+    /// <summary>
+    /// Creates a <see cref="MockRecordRef"/> that wraps an existing
+    /// <see cref="MockRecordHandle"/> — used by the rewriter when BC emits
+    /// <c>ALCompiler.ToRecordRef(scope, record)</c> to pass a Record variable
+    /// as a RecordRef by-value parameter in the same codeunit.
+    /// </summary>
+    public static MockRecordRef FromHandle(MockRecordHandle handle)
+    {
+        var rr = new MockRecordRef();
+        rr._handle = handle;
+        rr.Number = handle.TableId;
+        return rr;
+    }
+
     public void Clear()
     {
         Number = 0;

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -5155,6 +5155,18 @@ RecordId.TableNo:
 
 # ── RecordRef ───────────────────────────────────────────────────
 
+record_as_recordref_param:
+  layer: syntax
+  category: RecordRef
+  status: covered
+  notes: >
+    Passing a Record variable by value to a RecordRef parameter in the same codeunit.
+    BC emits ALCompiler.ToRecordRef(scope, record.Target) for this pattern; the rewriter
+    now converts it to MockRecordRef.FromHandle(handle) so MockRecordHandle is not
+    passed where NavRecord was expected. Fixed in issue #1242.
+  tests:
+    - tests/bucket-2/236-recordref-param
+
 RecordRef.AddLink:
   layer: runtime-api
   category: RecordRef

--- a/tests/bucket-2/236-recordref-param/src/RecRefParamSrc.al
+++ b/tests/bucket-2/236-recordref-param/src/RecRefParamSrc.al
@@ -8,7 +8,7 @@
 // compilation where MockRecordHandle (from rec.Target rewrite) is incompatible
 // with the NavRecord parameter of the real ALCompiler.ToRecordRef.
 
-table 56580 "RecRef Param Table"
+table 237000 "RecRef Param Table"
 {
     fields
     {

--- a/tests/bucket-2/236-recordref-param/src/RecRefParamSrc.al
+++ b/tests/bucket-2/236-recordref-param/src/RecRefParamSrc.al
@@ -1,0 +1,18 @@
+// Suite 236: RecordRef as a non-var procedure parameter, with a Record variable
+// passed to it in the same codeunit.
+// Reproduces CS1503: cannot convert from 'AlRunner.Runtime.MockRecordHandle'
+// to 'Microsoft.Dynamics.Nav.Runtime.NavRecord'.
+// Root cause: BC emits ALCompiler.ToRecordRef(scope, rec.Target) when a Record
+// variable is passed by value to a RecordRef parameter; the rewriter did not
+// handle ALCompiler.ToRecordRef, so the raw BC method call survived into Roslyn
+// compilation where MockRecordHandle (from rec.Target rewrite) is incompatible
+// with the NavRecord parameter of the real ALCompiler.ToRecordRef.
+
+table 56580 "RecRef Param Table"
+{
+    fields
+    {
+        field(1; Id; Integer) { }
+        field(2; Name; Text[50]) { }
+    }
+}

--- a/tests/bucket-2/236-recordref-param/test/RecRefParamTest.al
+++ b/tests/bucket-2/236-recordref-param/test/RecRefParamTest.al
@@ -1,0 +1,80 @@
+// Issue 1242: CS1503 when Record variable is passed to a RecordRef by-value
+// parameter inside the same codeunit.
+// BC emits ALCompiler.ToRecordRef(scope, rec.Target) for this pattern; the
+// rewriter must convert it to new MockRecordRef(handle) so MockRecordHandle is
+// not passed where NavRecord was expected.
+
+codeunit 56581 "RecRef Param Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    // ---------------------------------------------------------------
+    // Helper procedure: takes RecordRef by value (in same codeunit).
+    // ---------------------------------------------------------------
+
+    procedure FieldCountFromRecordRef(RecRef: RecordRef): Integer
+    begin
+        exit(RecRef.FieldCount);
+    end;
+
+    procedure IsOpenFromRecordRef(RecRef: RecordRef): Boolean
+    begin
+        exit(RecRef.Number <> 0);
+    end;
+
+    // ---------------------------------------------------------------
+    // Positive: passing a Record variable to a RecordRef by-value param
+    // in the same codeunit — previously caused CS1503.
+    // ---------------------------------------------------------------
+
+    [Test]
+    procedure RecordPassedToRecordRefParam_FieldCount()
+    var
+        Rec: Record "RecRef Param Table";
+    begin
+        // [GIVEN] A Record variable for table 56580 (2 fields)
+        // [WHEN]  Passed by value to FieldCountFromRecordRef in this codeunit
+        // [THEN]  Returns 2 — proves the mock RecordRef wraps the Record correctly
+        Assert.AreEqual(2, FieldCountFromRecordRef(Rec), 'FieldCount from Record→RecordRef must be 2');
+    end;
+
+    [Test]
+    procedure RecordPassedToRecordRefParam_IsOpen_ReturnsTrue()
+    var
+        Rec: Record "RecRef Param Table";
+    begin
+        // [GIVEN] A Record variable (always has a table number bound)
+        // [WHEN]  Passed by value to IsOpenFromRecordRef
+        // [THEN]  Number != 0 → true
+        Assert.IsTrue(IsOpenFromRecordRef(Rec), 'Record converted to RecordRef must report as open');
+    end;
+
+    // ---------------------------------------------------------------
+    // Negative: unbound RecordRef (default) has Number == 0.
+    // ---------------------------------------------------------------
+
+    [Test]
+    procedure UnboundRecordRefParam_IsOpen_ReturnsFalse()
+    var
+        RecRef: RecordRef;
+    begin
+        // [GIVEN] A plain unbound RecordRef variable
+        // [WHEN]  Passed by value to IsOpenFromRecordRef
+        // [THEN]  Number == 0 → false
+        Assert.IsFalse(IsOpenFromRecordRef(RecRef), 'Unbound RecordRef must not report as open');
+    end;
+
+    [Test]
+    procedure RecordPassedToRecordRefParam_FieldCountNotZero()
+    var
+        Rec: Record "RecRef Param Table";
+    begin
+        // [GIVEN] A Record variable (2 fields)
+        // [WHEN]  FieldCountFromRecordRef is called
+        // [THEN]  Result is not 0 — a no-op mock would return 0 and fail this
+        Assert.AreNotEqual(0, FieldCountFromRecordRef(Rec), 'FieldCount must not be 0 for a bound Record');
+    end;
+}

--- a/tests/bucket-2/236-recordref-param/test/RecRefParamTest.al
+++ b/tests/bucket-2/236-recordref-param/test/RecRefParamTest.al
@@ -1,10 +1,10 @@
 // Issue 1242: CS1503 when Record variable is passed to a RecordRef by-value
 // parameter inside the same codeunit.
 // BC emits ALCompiler.ToRecordRef(scope, rec.Target) for this pattern; the
-// rewriter must convert it to new MockRecordRef(handle) so MockRecordHandle is
-// not passed where NavRecord was expected.
+// rewriter must convert it to MockRecordRef.FromHandle(handle) so MockRecordHandle
+// is not passed where NavRecord was expected.
 
-codeunit 56581 "RecRef Param Tests"
+codeunit 237001 "RecRef Param Tests"
 {
     Subtype = Test;
 
@@ -12,7 +12,7 @@ codeunit 56581 "RecRef Param Tests"
         Assert: Codeunit Assert;
 
     // ---------------------------------------------------------------
-    // Helper procedure: takes RecordRef by value (in same codeunit).
+    // Helper procedures: take RecordRef by value (same codeunit).
     // ---------------------------------------------------------------
 
     procedure FieldCountFromRecordRef(RecRef: RecordRef): Integer
@@ -35,7 +35,7 @@ codeunit 56581 "RecRef Param Tests"
     var
         Rec: Record "RecRef Param Table";
     begin
-        // [GIVEN] A Record variable for table 56580 (2 fields)
+        // [GIVEN] A Record variable for table 237000 (2 fields)
         // [WHEN]  Passed by value to FieldCountFromRecordRef in this codeunit
         // [THEN]  Returns 2 — proves the mock RecordRef wraps the Record correctly
         Assert.AreEqual(2, FieldCountFromRecordRef(Rec), 'FieldCount from Record→RecordRef must be 2');


### PR DESCRIPTION
## Summary

- BC emits `ALCompiler.ToRecordRef(scope, record.Target)` when a `Record` variable is passed by value to a `RecordRef` parameter in the same codeunit (direct call path, not through `Invoke`).
- After `.Target` stripping in the rewriter, the second argument became `MockRecordHandle`, which is incompatible with the real `ALCompiler.ToRecordRef`'s `NavRecord` parameter — causing CS1503.
- Fix: new rewrite rule converts `ALCompiler.ToRecordRef(scope, handle)` → `MockRecordRef.FromHandle(handle)`, and `MockRecordRef.FromHandle` is a new static factory that wraps a `MockRecordHandle`.

Closes #1242

## Test plan

- [ ] New suite `tests/bucket-2/236-recordref-param` fails with CS1503 on unpatched code (RED confirmed)
- [ ] All 4 tests pass after fix (GREEN confirmed)
- [ ] bucket-1 passes with same 1619/66 ratio as main (no regression)
- [ ] CI green