### PR TITLE
fix: skip TableNo codeunits in OnRun; add --run-codeunit; remove implicit RunOnRun

### DIFF
--- a/AlRunner.Tests/PipelineTests.cs
+++ b/AlRunner.Tests/PipelineTests.cs
@@ -753,4 +753,20 @@ namespace AlRunnerGenerated {
         // because Calculator methods don't exist in the fallback class).
         Assert.NotEqual(0, result.ExitCode);
     }
+
+    [Fact]
+    public void NoTestCodeunits_Exit1_WithHelpfulMessage()
+    {
+        // Source dirs with no Subtype = Test codeunits should NOT implicitly run OnRun.
+        // Instead, exit 1 with a message pointing to --run-codeunit.
+        var pipeline = new AlRunnerPipeline();
+        var result = pipeline.Run(new PipelineOptions
+        {
+            InputPaths = { TestPath("1247-tableno-codeunit", "src") }
+        });
+
+        Assert.Equal(1, result.ExitCode);
+        Assert.Contains("No test codeunits found", result.StdErr);
+        Assert.Contains("--run-codeunit", result.StdErr);
+    }
 }

--- a/AlRunner/Pipeline.cs
+++ b/AlRunner/Pipeline.cs
@@ -23,6 +23,12 @@ public class PipelineOptions
     public bool IterationTracking { get; set; }
     /// <summary>Run only this specific procedure by name (e.g. "TestCalculateVAT").</summary>
     public string? RunProcedure { get; set; }
+    /// <summary>
+    /// When set, run the OnRun trigger of the named codeunit explicitly instead of
+    /// executing test codeunits. Codeunits with TableNo set are skipped (they require
+    /// a record to be passed in and cannot run standalone).
+    /// </summary>
+    public string? RunCodeunit { get; set; }
     /// <summary>If set, write a JUnit XML test report to this path after test execution.</summary>
     public string? OutputJunitPath { get; set; }
     /// <summary>When true, promote exit code 2 (runner limitations) to exit code 1 (failure).</summary>
@@ -773,9 +779,10 @@ public class AlRunnerPipeline
         Executor.RegisterStatements(GetRewrittenStrings());
 
         bool hasTests = alSources.Any(s => s.Contains("Subtype = Test"));
+        bool explicitRunCodeunit = options.RunCodeunit != null;
 
         int exitCode;
-        if (hasTests)
+        if (hasTests || explicitRunCodeunit)
         {
             Runtime.MessageCapture.Reset();
             Runtime.MessageCapture.Enable();
@@ -793,65 +800,54 @@ public class AlRunnerPipeline
             }
 
             var runSw = System.Diagnostics.Stopwatch.StartNew();
-            var results = Executor.RunTests(assembly, captureValues: options.CaptureValues, runProcedure: options.RunProcedure, initEvents: options.InitEvents, testIsolation: options.TestIsolation, testTimeoutSeconds: options.TestTimeoutSeconds);
-            runSw.Stop();
-            testResults.AddRange(results);
-            if (results.Count == 0 && options.RunProcedure != null)
-                stderr.WriteLine($"Error: Procedure '{options.RunProcedure}' not found in the generated code.");
-            if (!options.OutputJson)
-                Executor.PrintResults(results, runSw.ElapsedMilliseconds, options.Verbose, options.Strict);
-            exitCode = Executor.ExitCode(results, options.Strict);
-
-            if (options.CaptureValues)
-                Runtime.ValueCapture.Disable();
-            if (options.IterationTracking)
-                Runtime.IterationTracker.Disable();
-            Runtime.MessageCapture.Disable();
-
-            Dictionary<string, string>? scopeToObject = null;
-            if (options.IterationTracking || options.ShowCoverage)
+            if (explicitRunCodeunit)
             {
-                scopeToObject = CoverageReport.BuildScopeToObjectMap(generatedCSharpList!);
+                exitCode = Executor.RunOnRun(assembly, options.RunCodeunit!, captureValues: options.CaptureValues);
+                runSw.Stop();
+                if (options.CaptureValues) Runtime.ValueCapture.Disable();
+                if (options.IterationTracking) Runtime.IterationTracker.Disable();
+                Runtime.MessageCapture.Disable();
+                if (options.IterationTracking || options.ShowCoverage)
+                    _scopeToObject = CoverageReport.BuildScopeToObjectMap(generatedCSharpList!);
             }
-
-            _scopeToObject = scopeToObject;
-
-            if (options.ShowCoverage)
+            else
             {
-                Executor.PrintCoverageReport();
+                var results = Executor.RunTests(assembly, captureValues: options.CaptureValues, runProcedure: options.RunProcedure, initEvents: options.InitEvents, testIsolation: options.TestIsolation, testTimeoutSeconds: options.TestTimeoutSeconds);
+                runSw.Stop();
+                testResults.AddRange(results);
+                if (results.Count == 0 && options.RunProcedure != null)
+                    stderr.WriteLine($"Error: Procedure '{options.RunProcedure}' not found in the generated code.");
+                if (!options.OutputJson)
+                    Executor.PrintResults(results, runSw.ElapsedMilliseconds, options.Verbose, options.Strict);
+                exitCode = Executor.ExitCode(results, options.Strict);
 
-                var sourceSpans = CoverageReport.ParseSourceSpans(generatedCSharpList!);
-                var (hitStmts, totalStmts) = Runtime.AlScope.GetCoverageSets();
+                if (options.CaptureValues)
+                    Runtime.ValueCapture.Disable();
+                if (options.IterationTracking)
+                    Runtime.IterationTracker.Disable();
+                Runtime.MessageCapture.Disable();
 
-                CoverageReport.WriteCobertura("cobertura.xml", sourceSpans, hitStmts, totalStmts, scopeToObject!);
-                Log.Info("Coverage report: cobertura.xml");
+                Dictionary<string, string>? scopeToObject = null;
+                if (options.IterationTracking || options.ShowCoverage)
+                    scopeToObject = CoverageReport.BuildScopeToObjectMap(generatedCSharpList!);
+
+                _scopeToObject = scopeToObject;
+
+                if (options.ShowCoverage)
+                {
+                    Executor.PrintCoverageReport();
+                    var sourceSpans = CoverageReport.ParseSourceSpans(generatedCSharpList!);
+                    var (hitStmts, totalStmts) = Runtime.AlScope.GetCoverageSets();
+                    CoverageReport.WriteCobertura("cobertura.xml", sourceSpans, hitStmts, totalStmts, scopeToObject!);
+                    Log.Info("Coverage report: cobertura.xml");
+                }
             }
         }
         else
         {
-            Runtime.MessageCapture.Reset();
-            Runtime.MessageCapture.Enable();
-            if (options.CaptureValues)
-            {
-                Runtime.ValueCapture.Reset();
-                Runtime.ValueCapture.Enable();
-            }
-            if (options.IterationTracking)
-            {
-                Runtime.IterationTracker.Reset();
-                Runtime.IterationTracker.Enable();
-            }
-            exitCode = Executor.RunOnRun(assembly, captureValues: options.CaptureValues);
-            if (options.CaptureValues)
-                Runtime.ValueCapture.Disable();
-            if (options.IterationTracking)
-                Runtime.IterationTracker.Disable();
-            Runtime.MessageCapture.Disable();
-
-            if (options.IterationTracking || options.ShowCoverage)
-            {
-                _scopeToObject = CoverageReport.BuildScopeToObjectMap(generatedCSharpList!);
-            }
+            stderr.WriteLine("No test codeunits found (Subtype = Test). Source compiled successfully.");
+            stderr.WriteLine("To run a specific codeunit\u0027s OnRun trigger, use: --run-codeunit <CodunitName>");
+            exitCode = 1;
         }
         Timer.EndStage("Test execution");
         Timer.Print();

--- a/AlRunner/Pipeline.cs
+++ b/AlRunner/Pipeline.cs
@@ -780,9 +780,10 @@ public class AlRunnerPipeline
 
         bool hasTests = alSources.Any(s => s.Contains("Subtype = Test"));
         bool explicitRunCodeunit = options.RunCodeunit != null;
+        bool isInlineMode = options.InlineCode != null;
 
         int exitCode;
-        if (hasTests || explicitRunCodeunit)
+        if (hasTests || explicitRunCodeunit || isInlineMode)
         {
             Runtime.MessageCapture.Reset();
             Runtime.MessageCapture.Enable();
@@ -800,9 +801,12 @@ public class AlRunnerPipeline
             }
 
             var runSw = System.Diagnostics.Stopwatch.StartNew();
-            if (explicitRunCodeunit)
+            if (explicitRunCodeunit || isInlineMode)
             {
-                exitCode = Executor.RunOnRun(assembly, options.RunCodeunit!, captureValues: options.CaptureValues);
+                if (explicitRunCodeunit)
+                    exitCode = Executor.RunOnRun(assembly, options.RunCodeunit!, captureValues: options.CaptureValues);
+                else
+                    exitCode = Executor.RunOnRun(assembly, captureValues: options.CaptureValues);
                 runSw.Stop();
                 if (options.CaptureValues) Runtime.ValueCapture.Disable();
                 if (options.IterationTracking) Runtime.IterationTracker.Disable();

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -3499,6 +3499,31 @@ public static class Executor
         return clean;
     }
 
+    /// <summary>Run the first OnRun trigger found in the assembly (inline-code mode).</summary>
+    public static int RunOnRun(Assembly assembly, bool captureValues = false)
+    {
+        Type? scopeType = null;
+        foreach (var type in assembly.GetTypes())
+        {
+            foreach (var nested in type.GetNestedTypes(BindingFlags.NonPublic | BindingFlags.Public))
+            {
+                if (nested.Name.Contains("OnRun_Scope"))
+                {
+                    scopeType = nested;
+                    break;
+                }
+            }
+            if (scopeType != null) break;
+        }
+        if (scopeType == null)
+        {
+            Console.Error.WriteLine("Error: No OnRun trigger found in the generated code.");
+            return 1;
+        }
+        return RunOnRunScope(scopeType, captureValues);
+    }
+
+    /// <summary>Run a named codeunit's OnRun trigger explicitly (--run-codeunit mode).</summary>
     public static int RunOnRun(Assembly assembly, string codeunitName, bool captureValues = false)
     {
         // Find the codeunit class whose name matches (case-insensitive)
@@ -3550,6 +3575,12 @@ public static class Executor
             Console.Error.WriteLine($"Error: Codeunit '{codeunitName}' has no OnRun trigger.");
             return 1;
         }
+        return RunOnRunScope(scopeType, captureValues);
+    }
+
+    private static int RunOnRunScope(Type scopeType, bool captureValues)
+    {
+        var parentType = scopeType.DeclaringType!;
         var parent = RuntimeHelpers.GetUninitializedObject(parentType);
 
         // Call InitializeComponent() if it exists

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -53,6 +53,8 @@ if (args.Length == 0 || args.Any(a => a is "-h" or "--help"))
     Console.Error.WriteLine("  --capture-values      Capture variable values after each test for inline display");
     Console.Error.WriteLine("  --iteration-tracking  Track per-iteration data for loops (requires --output-json)");
     Console.Error.WriteLine("  --run <procedure>     Run only the specified procedure by name");
+    Console.Error.WriteLine("  --run-codeunit <name> Run the OnRun trigger of a named codeunit explicitly");
+    Console.Error.WriteLine("                        (codeunits with TableNo set are skipped)");
     Console.Error.WriteLine("  --server              Start in server mode (JSON-RPC over stdin/stdout)");
     Console.Error.WriteLine("  --dap [port]          Start DAP debugger server (default port 4711)");
     Console.Error.WriteLine("                        Connect VS Code or any DAP client to set breakpoints");
@@ -234,6 +236,12 @@ while (argIdx < args.Length)
             argIdx++;
             if (argIdx >= args.Length) { Console.Error.WriteLine("Error: --run requires a procedure name"); return 1; }
             options.RunProcedure = args[argIdx];
+            argIdx++;
+            break;
+        case "--run-codeunit":
+            argIdx++;
+            if (argIdx >= args.Length) { Console.Error.WriteLine("Error: --run-codeunit requires a codeunit name"); return 1; }
+            options.RunCodeunit = args[argIdx];
             argIdx++;
             break;
         case "--verbose":
@@ -3491,39 +3499,57 @@ public static class Executor
         return clean;
     }
 
-    public static int RunOnRun(Assembly assembly, bool captureValues = false)
+    public static int RunOnRun(Assembly assembly, string codeunitName, bool captureValues = false)
     {
-        Type? scopeType = null;
-
+        // Find the codeunit class whose name matches (case-insensitive)
+        Type? parentType = null;
         foreach (var type in assembly.GetTypes())
         {
-            foreach (var nested in type.GetNestedTypes(BindingFlags.NonPublic | BindingFlags.Public))
+            var displayName = type.Name;
+            var nameAttr = type.GetCustomAttributes()
+                .FirstOrDefault(a => a.GetType().Name is "NavObjectNameAttribute" or "NavDisplayNameAttribute");
+            if (nameAttr != null)
             {
-                if (nested.Name.Contains("OnRun_Scope"))
-                {
-                    scopeType = nested;
-                    break;
-                }
+                var nameProp = nameAttr.GetType().GetProperty("Name") ?? nameAttr.GetType().GetProperty("DisplayName");
+                displayName = nameProp?.GetValue(nameAttr) as string ?? displayName;
             }
-            if (scopeType != null) break;
+            if (string.Equals(displayName, codeunitName, StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(type.Name, codeunitName, StringComparison.OrdinalIgnoreCase))
+            {
+                parentType = type;
+                break;
+            }
         }
 
-        if (scopeType == null)
+        if (parentType == null)
         {
-            Console.Error.WriteLine("Error: No OnRun trigger found in the generated code.");
-            Log.Info("Available types:");
-            foreach (var t in assembly.GetTypes())
-            {
-                Log.Info($"  {t.FullName}");
-                foreach (var n in t.GetNestedTypes(BindingFlags.NonPublic | BindingFlags.Public))
-                    Log.Info($"    {n.Name}");
-            }
+            Console.Error.WriteLine($"Error: Codeunit '{codeunitName}' not found in the generated code.");
+            Console.Error.WriteLine("Available codeunits:");
+            foreach (var t in assembly.GetTypes().Where(t => t.Name.StartsWith("Codeunit", StringComparison.OrdinalIgnoreCase)))
+                Console.Error.WriteLine($"  {t.Name}");
             return 1;
         }
 
-        // Create the parent codeunit and scope using the constructor
-        // (the scope constructor initializes local record variables etc.)
-        var parentType = scopeType.DeclaringType!;
+        // Codeunits with TableNo set require a record to be passed in — skip them.
+        var tableNoAttr = parentType.GetCustomAttributes()
+            .FirstOrDefault(a => a.GetType().Name == "NavObjectTableNoAttribute");
+        if (tableNoAttr != null)
+        {
+            var tableNoProp = tableNoAttr.GetType().GetProperty("TableNo") ?? tableNoAttr.GetType().GetProperty("Value");
+            var tableNo = tableNoProp?.GetValue(tableNoAttr);
+            Console.Error.WriteLine($"Skipping '{codeunitName}': TableNo = {tableNo} — this codeunit requires a record to be passed in and cannot run standalone.");
+            Console.Error.WriteLine("Call it from a test codeunit via Codeunit.Run() with a populated record instead.");
+            return 2;
+        }
+
+        var scopeType = parentType.GetNestedTypes(BindingFlags.NonPublic | BindingFlags.Public)
+            .FirstOrDefault(n => n.Name.Contains("OnRun_Scope"));
+
+        if (scopeType == null)
+        {
+            Console.Error.WriteLine($"Error: Codeunit '{codeunitName}' has no OnRun trigger.");
+            return 1;
+        }
         var parent = RuntimeHelpers.GetUninitializedObject(parentType);
 
         // Call InitializeComponent() if it exists

--- a/tests/excluded/1247-tableno-codeunit/src/Cod91247.al
+++ b/tests/excluded/1247-tableno-codeunit/src/Cod91247.al
@@ -1,0 +1,7 @@
+codeunit 91247 "No Test Probe"
+{
+    trigger OnRun()
+    begin
+        Message('I run via OnRun, not as a test');
+    end;
+}


### PR DESCRIPTION
Closes #1247

## Problem

Codeunits with `TableNo` set (e.g. `TableNo = AllObjWithCaption`) are designed to be called via `Codeunit.Run()` or `TaskScheduler.CreateTask()` with a populated record. They cannot run standalone. AL Runner was implicitly finding any codeunit with an `OnRun` trigger and running it when no `Subtype = Test` codeunits were present — causing a `NullReferenceException` when the code accessed `Rec` fields.

## Changes

- **Remove implicit RunOnRun fallback**: when no test codeunits are found, print a clear message instead of silently trying to run an OnRun trigger
- **Add `--run-codeunit <name>`**: explicit opt-in for running a named codeunit's OnRun trigger directly
- **Skip TableNo codeunits**: `RunOnRun` detects `NavObjectTableNoAttribute` on the codeunit class and returns exit 2 with a clear explanation instead of crashing

## Behaviour

Before:
```
Runtime error: NullReferenceException: Object reference not set...
```

After (no tests found):
```
No test codeunits found (Subtype = Test). Source compiled successfully.
To run a specific codeunit's OnRun trigger, use: --run-codeunit <CodunitName>
```

After (explicit `--run-codeunit` on a TableNo codeunit):
```
Skipping 'CleanupErrorHandlerMFCBAP': TableNo = 2000000058 — this codeunit requires a record to be passed in and cannot run standalone.
Call it from a test codeunit via Codeunit.Run() with a populated record instead.
```