### PR TITLE
fix: ALReadAs returns bool so 'if Content.ReadAs(T) then' compiles

### DIFF
--- a/AlRunner/Runtime/AlScope.cs
+++ b/AlRunner/Runtime/AlScope.cs
@@ -2253,8 +2253,11 @@ public static class AlCompat
     /// is the stored text content (round-trip from WriteFrom).
     /// Note: This is a text-only round-trip. Binary data written via InStream will be
     /// UTF-8 decoded on load and re-encoded on read, which may not preserve raw bytes.
+    ///
+    /// Returns <c>true</c> (matching the real BC API) so that BC-generated code that
+    /// uses <c>if Content.ReadAs(Stream) then</c> compiles without CS0019 (#1250).
     /// </summary>
-    public static void HttpContentReadAs(MockHttpContent content, object? scope, DataError errorLevel, ByRef<MockInStream> stream)
+    public static bool HttpContentReadAs(MockHttpContent content, object? scope, DataError errorLevel, ByRef<MockInStream> stream)
     {
         var text = content.GetText();
         if (string.IsNullOrEmpty(text))
@@ -2267,6 +2270,7 @@ public static class AlCompat
             ms.Init(System.Text.Encoding.UTF8.GetBytes(text));
             stream.Value = ms;
         }
+        return true;
     }
 
     // -----------------------------------------------------------------------

--- a/AlRunner/Runtime/MockHttpContent.cs
+++ b/AlRunner/Runtime/MockHttpContent.cs
@@ -37,10 +37,16 @@ public class MockHttpContent
     /// BC emits the 2-arg text variant:
     /// <c>content.ALReadAs(DataError, ByRef&lt;NavText&gt;)</c>
     /// for <c>HttpContent.ReadAs(var Text)</c>. Called directly on the mock.
+    ///
+    /// Returns <c>true</c> (matching the real BC API) so that BC-generated code that
+    /// uses <c>if Content.ReadAs(ResponseBodyText) then</c> compiles without CS0019.
+    /// BC emits <c>CStmtHit(N) &amp; (content.ALReadAs(...))</c>, which requires the
+    /// method to return <c>bool</c>; a <c>void</c> return caused CS0019 (#1250).
     /// </summary>
-    public void ALReadAs(DataError errorLevel, ByRef<NavText> text)
+    public bool ALReadAs(DataError errorLevel, ByRef<NavText> text)
     {
         text.Value = new NavText(_textContent);
+        return true;
     }
 
     /// <summary>

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -3196,7 +3196,8 @@ HttpContent.ReadAs:
   layer: runtime-api
   category: HttpContent
   status: covered
-  notes: overloads=3
+  tests: tests/bucket-1/1250-httpcontent-readas-bool
+  notes: overloads=3; ALReadAs returns bool (not void) so 'if Content.ReadAs(T) then' compiles without CS0019 (#1250)
 
 HttpContent.WriteFrom:
   layer: runtime-api

--- a/tests/bucket-1/1250-httpcontent-readas-bool/src/HttpContentReadAsBoolSrc.al
+++ b/tests/bucket-1/1250-httpcontent-readas-bool/src/HttpContentReadAsBoolSrc.al
@@ -1,0 +1,36 @@
+/// <summary>
+/// Probe for issue #1250: HttpContent.ReadAs(var Text) in an 'if' condition.
+///
+/// BC emits: if CStmtHit(N) &amp; (content.ALReadAs(DataError.TrapError, ByRef&lt;NavText&gt;))
+/// MockHttpContent.ALReadAs was void — so '&amp;' between bool and void caused CS0019.
+/// The fix: ALReadAs returns bool (true = success, matching the real BC API).
+///
+/// ReadAsConditional() exercises the exact pattern that triggered CS0019.
+/// GetProbeVersion() is a pure-logic sentinel called by tests to confirm compilation.
+/// </summary>
+codeunit 1250 "HTTP ReadAs Bool Probe"
+{
+    /// <summary>
+    /// Uses HttpContent.ReadAs(var Text) as the condition of an 'if' statement.
+    /// BC emits this as: CStmtHit(N) &amp; (content.ALReadAs(DataError.TrapError, ByRef&lt;NavText&gt;))
+    /// which fails with CS0019 when ALReadAs returns void.
+    /// Never called by tests — HTTP is not available in standalone mode.
+    /// </summary>
+    procedure ReadAsConditional(var Content: HttpContent): Text
+    var
+        ResponseBodyText: Text;
+    begin
+        if Content.ReadAs(ResponseBodyText) then
+            exit(ResponseBodyText);
+        exit('');
+    end;
+
+    /// <summary>
+    /// Pure-logic sentinel with no HTTP variables.
+    /// Tests call this to confirm the codeunit compiled without CS0019.
+    /// </summary>
+    procedure GetProbeVersion(): Integer
+    begin
+        exit(1250);
+    end;
+}

--- a/tests/bucket-1/1250-httpcontent-readas-bool/test/HttpContentReadAsBoolTest.al
+++ b/tests/bucket-1/1250-httpcontent-readas-bool/test/HttpContentReadAsBoolTest.al
@@ -1,0 +1,41 @@
+/// <summary>
+/// Tests for issue #1250: HttpContent.ReadAs(var Text) in an 'if' condition
+/// caused CS0019 because MockHttpContent.ALReadAs returned void.
+///
+/// Positive test: GetProbeVersion() returns the expected value — proves the codeunit
+///   compiled (CS0019 is gone) and the pure-logic path works.
+/// Negative test: GetProbeVersion() with wrong expected value fires Assert.AreEqual error —
+///   proves the assertion framework is live and would catch a broken stub.
+/// </summary>
+codeunit 1251 "HTTP ReadAs Bool Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit "Assert";
+
+    /// <summary>
+    /// Positive: probe version returns 1250, proving the codeunit compiled
+    /// without CS0019 and the conditional ReadAs pattern is accepted by the runner.
+    /// </summary>
+    [Test]
+    procedure ProbeVersionReturnsExpectedValue()
+    var
+        Probe: Codeunit "HTTP ReadAs Bool Probe";
+    begin
+        Assert.AreEqual(1250, Probe.GetProbeVersion(), 'GetProbeVersion should return 1250');
+    end;
+
+    /// <summary>
+    /// Negative: wrong expected value triggers a failure, proving the assertion
+    /// is live and a broken no-op stub returning 0 would be caught.
+    /// </summary>
+    [Test]
+    procedure ProbeVersionWrongExpectationFails()
+    var
+        Probe: Codeunit "HTTP ReadAs Bool Probe";
+    begin
+        asserterror Assert.AreEqual(9999, Probe.GetProbeVersion(), 'should not be 9999');
+        Assert.ExpectedError('AreEqual');
+    end;
+}


### PR DESCRIPTION
Closes #1250

## Root cause

BC emits `if Content.ReadAs(ResponseBodyText) then` as:

```csharp
if (CStmtHit(N) & this.content.Value.ALReadAs(DataError.TrapError, new ByRef<NavText>(...)))
```

The `&` operator requires both sides to be `bool`. `CStmtHit()` returns `bool`, but `MockHttpContent.ALReadAs` and `AlCompat.HttpContentReadAs` both returned `void` — producing CS0019 "Operator '&' cannot be applied to operands of type 'bool' and 'void'".

## Fix

- `MockHttpContent.ALReadAs(DataError, ByRef<NavText>)` → returns `bool` (always `true`)
- `AlCompat.HttpContentReadAs(...)` → returns `bool` (always `true`)

Returning `bool` is backwards-compatible: discarding a return value is valid C#, so existing call sites that used these as statements are unaffected.

## Test

New suite `tests/bucket-1/1250-httpcontent-readas-bool/` with the exact `if Content.ReadAs(T) then` pattern that triggered CS0019, plus positive/negative assertions.