### PR TITLE
fix: add ALAssign to MockFilterPageBuilder

### DIFF
--- a/AlRunner/Runtime/MockFilterPageBuilder.cs
+++ b/AlRunner/Runtime/MockFilterPageBuilder.cs
@@ -156,4 +156,17 @@ public class MockFilterPageBuilder
 
     public bool ALRunModal(DataError errorLevel)
         => true;
+
+    // ── ALAssign ─────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// BC emits <c>fpb2.ALAssign(fpb1)</c> for <c>FPB2 := FPB1</c> in AL.
+    /// Deep-copies all registered tables, views, and the page caption.
+    /// </summary>
+    public void ALAssign(MockFilterPageBuilder other)
+    {
+        _tables.Clear();
+        _tables.AddRange(other._tables);
+        ALPageCaption = other.ALPageCaption;
+    }
 }

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -3049,6 +3049,13 @@ FilterPageBuilder.SetView:
   notes: overloads=1; MockFilterPageBuilder; stores view string per caption
   tests: tests/bucket-2/179-filter-page-builder
 
+FilterPageBuilder.ALAssign:
+  layer: runtime-api
+  category: FilterPageBuilder
+  status: covered
+  notes: overloads=1; deep-copies tables, views, and PageCaption from source MockFilterPageBuilder
+  tests: tests/bucket-1/305-filterpagebuilder-assign
+
 # ── Guid ────────────────────────────────────────────────────────
 
 Guid.CreateGuid:

--- a/tests/bucket-1/305-filterpagebuilder-assign/src/Source.al
+++ b/tests/bucket-1/305-filterpagebuilder-assign/src/Source.al
@@ -1,0 +1,51 @@
+codeunit 305001 "FPB Assign Src"
+{
+    /// <summary>
+    /// Creates a FilterPageBuilder, adds a table, sets a view,
+    /// assigns it to a second variable, then returns the count from the copy.
+    /// Proves ALAssign copies state correctly.
+    /// </summary>
+    procedure AssignAndGetCount(): Integer
+    var
+        FPB1: FilterPageBuilder;
+        FPB2: FilterPageBuilder;
+    begin
+        FPB1.AddTable('Items', 27);
+        FPB1.AddTable('Customers', 18);
+        FPB2 := FPB1;
+        exit(FPB2.Count);
+    end;
+
+    /// <summary>
+    /// Creates a FilterPageBuilder, adds a table with a view,
+    /// assigns it to another variable, and returns the view from the copy.
+    /// Proves the view data survives assignment.
+    /// </summary>
+    procedure AssignAndGetView(): Text
+    var
+        FPB1: FilterPageBuilder;
+        FPB2: FilterPageBuilder;
+    begin
+        FPB1.AddTable('Items', 27);
+        FPB1.SetView('Items', 'WHERE(No.=FILTER(1000..2000))');
+        FPB2 := FPB1;
+        exit(FPB2.GetView('Items'));
+    end;
+
+    /// <summary>
+    /// Assigns a FilterPageBuilder, then modifies the original.
+    /// The copy must retain its original state (deep copy semantics).
+    /// </summary>
+    procedure AssignIsDeepCopy(): Integer
+    var
+        FPB1: FilterPageBuilder;
+        FPB2: FilterPageBuilder;
+    begin
+        FPB1.AddTable('Items', 27);
+        FPB2 := FPB1;
+        FPB1.AddTable('Customers', 18);
+        // FPB2 should still have count 1 if deep copy
+        // FPB2 would have count 2 if shallow copy
+        exit(FPB2.Count);
+    end;
+}

--- a/tests/bucket-1/305-filterpagebuilder-assign/test/Test.al
+++ b/tests/bucket-1/305-filterpagebuilder-assign/test/Test.al
@@ -1,0 +1,36 @@
+codeunit 305002 "FPB Assign Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    [Test]
+    procedure Assign_CopiesCount()
+    var
+        Src: Codeunit "FPB Assign Src";
+    begin
+        Assert.AreEqual(2, Src.AssignAndGetCount(), 'Assigned FPB must preserve count');
+    end;
+
+    [Test]
+    procedure Assign_CopiesView()
+    var
+        Src: Codeunit "FPB Assign Src";
+    begin
+        Assert.AreEqual(
+            'WHERE(No.=FILTER(1000..2000))',
+            Src.AssignAndGetView(),
+            'Assigned FPB must preserve view data');
+    end;
+
+    [Test]
+    procedure Assign_IsDeepCopy()
+    var
+        Src: Codeunit "FPB Assign Src";
+    begin
+        // Deep copy: modifying original after assignment should not affect the copy
+        // If ALAssign does a deep copy, count = 1; if shallow, count = 2
+        Assert.AreEqual(1, Src.AssignIsDeepCopy(), 'Assignment must be a deep copy — original changes must not affect copy');
+    end;
+}


### PR DESCRIPTION
Closes #1276

## Summary
- Add `ALAssign(MockFilterPageBuilder)` method to `MockFilterPageBuilder` with deep-copy semantics (tables list, views, and PageCaption)
- BC emits `ALAssign` for `:=` assignment on FilterPageBuilder variables; without this method, Roslyn compilation fails with CS1061

## Test plan
- [x] RED: confirmed CS1061 compilation failure before implementation
- [x] GREEN: 3 proving tests pass after implementation
  - `Assign_CopiesCount` — verifies count is preserved through assignment (asserts 2, not default 0)
  - `Assign_CopiesView` — verifies view filter string round-trips through assignment
  - `Assign_IsDeepCopy` — verifies modifying original after assignment does not affect the copy
- [x] Full bucket-1 regression: no new failures
- [x] `docs/coverage.yaml` updated with `FilterPageBuilder.ALAssign` entry