### PR TITLE
fix: add 2-arg ALValidateSafe overload to injected Record class

### DIFF
--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -695,6 +695,7 @@ public void ALCopyFilter(int fromFieldNo, MockRecordHandle target) => Rec.ALCopy
 public void ALCopyFilter(int fromFieldNo, MockRecordHandle target, int toFieldNo) => Rec.ALCopyFilter(fromFieldNo, target, toFieldNo);
 public void ALCopyFilters(MockRecordHandle source) => Rec.ALCopyFilters(source);
 public void ALValidateSafe(int fieldNo, NavType expectedType, NavValue value) => Rec.ALValidateSafe(fieldNo, expectedType, value);
+public void ALValidateSafe(int fieldNo, NavType expectedType) => Rec.ALValidateSafe(fieldNo, expectedType);
 public void ALValidate(DataError errorLevel, int fieldNo, NavType expectedType, NavValue value) => Rec.ALValidate(errorLevel, fieldNo, expectedType, value);
 public void ALTestFieldSafe(int fieldNo, NavType expectedType) => Rec.ALTestFieldSafe(fieldNo, expectedType);
 public void ALTestFieldSafe(int fieldNo, NavType expectedType, NavValue expectedValue) => Rec.ALTestFieldSafe(fieldNo, expectedType, expectedValue);

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -7561,7 +7561,14 @@ Table.Validate:
   category: Table
   status: covered
   tests: tests/bucket-1/18-validate-trigger
-  notes: overloads=1
+  notes: overloads=2; Validate(Field, Value) and Validate(Field) (no value, re-validates current value)
+
+Table.Validate (2-arg, no value):
+  layer: runtime-api
+  category: Table
+  status: covered
+  tests: tests/bucket-1/96-validate-no-value
+  notes: overloads=1; ALValidateSafe(fieldNo, expectedType) — re-validates current field value without setting a new one. The 2-arg overload was missing from the injected Record class delegate methods.
 
 Table.WritePermission:
   layer: runtime-api

--- a/tests/bucket-1/96-validate-no-value/src/ValidateNoValueTable.al
+++ b/tests/bucket-1/96-validate-no-value/src/ValidateNoValueTable.al
@@ -1,0 +1,29 @@
+table 305001 "Validate No Value Table"
+{
+    DataClassification = CustomerContent;
+
+    fields
+    {
+        field(1; "Entry No."; Integer) { }
+        field(2; Quantity; Decimal)
+        {
+            trigger OnValidate()
+            begin
+                "Validated Qty" := Quantity * 2;
+            end;
+        }
+        field(3; "Validated Qty"; Decimal) { }
+    }
+
+    keys
+    {
+        key(PK; "Entry No.") { Clustered = true; }
+    }
+
+    trigger OnInsert()
+    begin
+        // This is the pattern from the issue: Validate(field) inside a trigger
+        // BC compiler emits ALValidateSafe(fieldNo, NavType, NavValue) for this
+        Validate(Quantity);
+    end;
+}

--- a/tests/bucket-1/96-validate-no-value/test/ValidateNoValueTest.al
+++ b/tests/bucket-1/96-validate-no-value/test/ValidateNoValueTest.al
@@ -1,0 +1,41 @@
+codeunit 305002 "Validate No Value Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit "Library Assert";
+
+    [Test]
+    procedure ValidateNoValue_InOnInsert_FiresTrigger()
+    var
+        Rec: Record "Validate No Value Table";
+    begin
+        // [GIVEN] A record with Quantity set directly (bypassing trigger)
+        Rec.Init();
+        Rec."Entry No." := 1;
+        Rec.Quantity := 5;
+
+        // [WHEN] Insert fires OnInsert which calls Validate(Quantity) without a value
+        Rec.Insert(true);
+
+        // [THEN] The OnValidate trigger fires and sets Validated Qty = Quantity * 2
+        Assert.AreEqual(10, Rec."Validated Qty", 'OnValidate should fire via Validate(Quantity) in OnInsert and set Validated Qty to Quantity * 2');
+    end;
+
+    [Test]
+    procedure ValidateWithValue_SetsAndFiresTrigger()
+    var
+        Rec: Record "Validate No Value Table";
+    begin
+        // [GIVEN] A record with no Quantity
+        Rec.Init();
+        Rec."Entry No." := 2;
+
+        // [WHEN] Validate(Quantity, 7) is called with a value
+        Rec.Validate(Quantity, 7);
+
+        // [THEN] Quantity is set to 7 and OnValidate fires
+        Assert.AreEqual(7, Rec.Quantity, 'Quantity should be set to 7');
+        Assert.AreEqual(14, Rec."Validated Qty", 'OnValidate should fire and set Validated Qty to 14');
+    end;
+}


### PR DESCRIPTION
Closes #1265

## Summary
- The BC compiler emits `ALValidateSafe(fieldNo, expectedType)` for `Validate(Field)` calls without a value (re-validate current field value), but the RoslynRewriter only injected the 3-arg overload on the Record class, causing CS7036 at Roslyn compilation time.
- Added the missing 2-arg delegate method in `RoslynRewriter.cs` that forwards to `MockRecordHandle.ALValidateSafe(int, NavType)`.
- Added test suite `96-validate-no-value` with a table that calls `Validate(Quantity)` inside `OnInsert()` trigger, proving the 2-arg overload compiles and fires the OnValidate trigger correctly.

## Test plan
- [x] RED: confirmed CS7036 compilation error before fix
- [x] GREEN: both tests pass after adding the overload
- [x] Full bucket-1 and bucket-3 suites pass (bucket-2 has pre-existing missing dependency issue)
- [x] Stubs test passes