### PR TITLE
feat: add missing ALFieldError, AutoFormat, EnsureGlobalVars on Record types

### DIFF
--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -757,9 +757,13 @@ public bool ALHasLinks => Rec.ALHasLinks;
 public void ALCopyLinks(MockRecordHandle source) => Rec.ALCopyLinks(source);
 public bool ALWritePermission => Rec.ALWritePermission;
 public void ALSetPermissionFilter() => Rec.ALSetPermissionFilter();
+public void ALFieldError(int fieldNo) => Rec.ALFieldError(fieldNo);
+public void ALFieldError(int fieldNo, string message) => Rec.ALFieldError(fieldNo, message);
 protected bool CallGetDecimalPlacesExtensionMethod(int fieldNo, ref string result) { return false; }
 protected bool CallGetTableRelationExtensionMethod(int fieldNo, MockRecordHandle rec, ref bool result) { return false; }
 protected bool CallGetFormatExtensionMethod(int fieldNo, ref string result) { return false; }
+protected bool CallGetAutoFormatStringExtensionMethod(int fieldNo, ref string result) { return false; }
+protected void EnsureGlobalVariablesInitialized() { }
 ";
             var delegatingMembers = CSharpSyntaxTree.ParseText(
                 $"class _Temp_ {{ {delegatingCode} }}").GetRoot()

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -7058,8 +7058,22 @@ Table.FieldError:
   layer: runtime-api
   category: Table
   status: covered
-  tests: tests/bucket-1/180-table-metadata-stubs
-  notes: overloads=2; MockRecordHandle.ALFieldError(fieldNo) / ALFieldError(fieldNo, msg) — throws validation error
+  tests: tests/bucket-1/96-fielderror-autoformat
+  notes: overloads=2; MockRecordHandle.ALFieldError(fieldNo) / ALFieldError(fieldNo, msg) — throws validation error; delegated on Record classes
+
+Table.CallGetAutoFormatStringExtensionMethod:
+  layer: compiler-infra
+  category: Table
+  status: stub
+  tests: tests/bucket-1/96-fielderror-autoformat
+  notes: BC internal formatting hook; no-op stub returning false on Record classes
+
+Table.EnsureGlobalVariablesInitialized:
+  layer: compiler-infra
+  category: Table
+  status: stub
+  tests: tests/bucket-1/96-fielderror-autoformat
+  notes: BC internal init hook; no-op stub on Record classes
 
 Table.FieldName:
   layer: runtime-api

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -7062,14 +7062,14 @@ Table.FieldError:
   notes: overloads=2; MockRecordHandle.ALFieldError(fieldNo) / ALFieldError(fieldNo, msg) — throws validation error; delegated on Record classes
 
 Table.CallGetAutoFormatStringExtensionMethod:
-  layer: compiler-infra
+  layer: runtime-api
   category: Table
   status: stub
   tests: tests/bucket-1/96-fielderror-autoformat
   notes: BC internal formatting hook; no-op stub returning false on Record classes
 
 Table.EnsureGlobalVariablesInitialized:
-  layer: compiler-infra
+  layer: runtime-api
   category: Table
   status: stub
   tests: tests/bucket-1/96-fielderror-autoformat

--- a/tests/bucket-1/96-fielderror-autoformat/src/FieldErrorAutoFormat.al
+++ b/tests/bucket-1/96-fielderror-autoformat/src/FieldErrorAutoFormat.al
@@ -1,0 +1,40 @@
+table 1264001 "Field Error AutoFormat"
+{
+    DataClassification = CustomerContent;
+
+    fields
+    {
+        field(1; "Code"; Code[20])
+        {
+            Caption = 'Code';
+        }
+        field(2; "Description"; Text[100])
+        {
+            Caption = 'Description';
+        }
+        field(3; "Amount"; Decimal)
+        {
+            Caption = 'Amount';
+        }
+    }
+
+    keys
+    {
+        key(PK; "Code")
+        {
+            Clustered = true;
+        }
+    }
+
+    trigger OnInsert()
+    begin
+        if Description = '' then
+            FieldError(Description);
+    end;
+
+    procedure ValidateCode()
+    begin
+        if Code = '' then
+            FieldError(Code, 'must not be blank');
+    end;
+}

--- a/tests/bucket-1/96-fielderror-autoformat/test/TestFieldErrorAutoFormat.al
+++ b/tests/bucket-1/96-fielderror-autoformat/test/TestFieldErrorAutoFormat.al
@@ -1,0 +1,79 @@
+codeunit 1264002 "Test FieldError AutoFormat"
+{
+    Subtype = Test;
+
+    [Test]
+    procedure FieldError_InTrigger_RaisesError()
+    var
+        Rec: Record "Field Error AutoFormat";
+    begin
+        // [GIVEN] A record with Code but no Description
+        Rec.Code := 'TEST';
+        // Description is blank
+
+        // [WHEN] Insert fires the OnInsert trigger
+        // [THEN] FieldError raises an error containing the field caption
+        asserterror Rec.Insert(true);
+        Assert.ExpectedError('Description');
+    end;
+
+    [Test]
+    procedure FieldError_InTrigger_DefaultMessage()
+    var
+        Rec: Record "Field Error AutoFormat";
+    begin
+        // [GIVEN] A record with Code but no Description
+        Rec.Code := 'TEST2';
+
+        // [WHEN] Insert fires the OnInsert trigger
+        // [THEN] FieldError raises an error with default "must have a value"
+        asserterror Rec.Insert(true);
+        Assert.ExpectedError('must have a value');
+    end;
+
+    [Test]
+    procedure FieldError_InTableProc_CustomMessage()
+    var
+        Rec: Record "Field Error AutoFormat";
+    begin
+        // [GIVEN] A record with blank Code
+        // Code is blank by default
+
+        // [WHEN] ValidateCode is called
+        // [THEN] FieldError raises an error with custom message
+        asserterror Rec.ValidateCode();
+        Assert.ExpectedError('must not be blank');
+    end;
+
+    [Test]
+    procedure FieldError_InTableProc_ContainsFieldCaption()
+    var
+        Rec: Record "Field Error AutoFormat";
+    begin
+        // [GIVEN] A record with blank Code
+
+        // [WHEN] ValidateCode is called
+        // [THEN] Error contains the field caption "Code"
+        asserterror Rec.ValidateCode();
+        Assert.ExpectedError('Code');
+    end;
+
+    [Test]
+    procedure FieldError_SuccessPath_NoError()
+    var
+        Rec: Record "Field Error AutoFormat";
+    begin
+        // [GIVEN] A record with all required fields filled
+        Rec.Code := 'VALID';
+        Rec.Description := 'Valid description';
+
+        // [WHEN] Insert is called with valid data
+        Rec.Insert(true);
+
+        // [THEN] No error is raised, record is inserted
+        Assert.IsTrue(Rec.Get('VALID'), 'Record should exist after insert');
+    end;
+
+    var
+        Assert: Codeunit "Library Assert";
+}


### PR DESCRIPTION
Closes #1264

## Summary
- Added `ALFieldError(int)` and `ALFieldError(int, string)` delegating methods on Record classes (forwarding to `Rec.ALFieldError`). The methods existed on `MockRecordHandle` but were not delegated, causing CS1061 when `FieldError` is called inside table triggers/methods.
- Added `CallGetAutoFormatStringExtensionMethod` as a no-op stub (returns false) on Record classes — BC internal formatting hook.
- Added `EnsureGlobalVariablesInitialized` as a no-op stub on Record classes — BC internal init hook.

## Test plan
- [x] RED: Tests fail on main with CS1061 for ALFieldError on Record class
- [x] GREEN: All 5 tests pass after adding delegates
- [x] No regressions in bucket-1 (1635 passed, 66 failed — same 66 as main)
- [x] coverage.yaml updated