### PR TITLE
fix: implicit MockRecordHandle to MockRecordRef conversion

### DIFF
--- a/AlRunner/Runtime/MockRecordRef.cs
+++ b/AlRunner/Runtime/MockRecordRef.cs
@@ -31,6 +31,17 @@ public class MockRecordRef
         return rr;
     }
 
+    /// <summary>
+    /// Implicit conversion from <see cref="MockRecordHandle"/> to <see cref="MockRecordRef"/>.
+    /// In AL, a Record can always be used where a RecordRef is expected. BC sometimes
+    /// emits code paths (beyond <c>ALCompiler.ToRecordRef</c>) where the generated C#
+    /// passes a MockRecordHandle directly to a MockRecordRef parameter, causing CS1503.
+    /// This operator ensures all such code paths compile and behave correctly.
+    /// Issue: https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/1275
+    /// </summary>
+    public static implicit operator MockRecordRef(MockRecordHandle handle)
+        => FromHandle(handle);
+
     public void Clear()
     {
         Number = 0;

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -5189,6 +5189,19 @@ record_as_recordref_param:
   tests:
     - tests/bucket-2/236-recordref-param
 
+record_to_recordref_implicit:
+  layer: runtime-api
+  category: RecordRef
+  status: covered
+  notes: >
+    Implicit conversion from MockRecordHandle to MockRecordRef. BC can emit code paths
+    beyond ALCompiler.ToRecordRef where a Record variable (MockRecordHandle) is passed
+    directly to a MockRecordRef parameter, causing CS1503. An implicit conversion operator
+    on MockRecordRef delegates to FromHandle, ensuring all such code paths compile and
+    produce a correctly-bound RecordRef. Fixed in issue #1275.
+  tests:
+    - tests/bucket-1/1275-record-to-recordref-implicit
+
 RecordRef.AddLink:
   layer: runtime-api
   category: RecordRef

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -5190,7 +5190,7 @@ record_as_recordref_param:
     - tests/bucket-2/236-recordref-param
 
 record_to_recordref_implicit:
-  layer: runtime-api
+  layer: syntax
   category: RecordRef
   status: covered
   notes: >

--- a/tests/bucket-1/1275-record-to-recordref-implicit/src/ImplicitConvTable.al
+++ b/tests/bucket-1/1275-record-to-recordref-implicit/src/ImplicitConvTable.al
@@ -1,0 +1,8 @@
+table 1275001 "Implicit Conv Table"
+{
+    fields
+    {
+        field(1; Id; Integer) { }
+        field(2; Description; Text[100]) { }
+    }
+}

--- a/tests/bucket-1/1275-record-to-recordref-implicit/src/RecRefHelper.al
+++ b/tests/bucket-1/1275-record-to-recordref-implicit/src/RecRefHelper.al
@@ -1,0 +1,12 @@
+codeunit 1275001 "RecRef Implicit Helper"
+{
+    procedure GetFieldCountFromRef(RecRef: RecordRef): Integer
+    begin
+        exit(RecRef.FieldCount);
+    end;
+
+    procedure GetTableNoFromRef(RecRef: RecordRef): Integer
+    begin
+        exit(RecRef.Number);
+    end;
+}

--- a/tests/bucket-1/1275-record-to-recordref-implicit/test/RecRefImplicitTest.al
+++ b/tests/bucket-1/1275-record-to-recordref-implicit/test/RecRefImplicitTest.al
@@ -1,0 +1,83 @@
+// Issue 1275: CS1503 when MockRecordHandle is passed where MockRecordRef is expected.
+// BC can emit code paths where a Record variable (MockRecordHandle) is used where
+// a RecordRef (MockRecordRef) parameter is expected without an explicit
+// ALCompiler.ToRecordRef wrapper. Adding an implicit conversion operator on
+// MockRecordRef ensures all such code paths are handled.
+
+codeunit 1275002 "RecRef Implicit Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    // Helper: same-codeunit procedure taking RecordRef by value
+    procedure GetTableNoFromRef(RecRef: RecordRef): Integer
+    begin
+        exit(RecRef.Number);
+    end;
+
+    // ---------------------------------------------------------------
+    // Positive: pass Record to cross-codeunit RecordRef by-value param
+    // ---------------------------------------------------------------
+
+    [Test]
+    procedure CrossCU_RecordToRecordRef_FieldCount()
+    var
+        Rec: Record "Implicit Conv Table";
+        Helper: Codeunit "RecRef Implicit Helper";
+    begin
+        // [GIVEN] A Record variable for table 1275001 (2 fields)
+        // [WHEN]  Passed to a RecordRef parameter in a different codeunit
+        // [THEN]  Returns 2
+        Assert.AreEqual(2, Helper.GetFieldCountFromRef(Rec),
+            'Cross-CU: FieldCount from Record passed as RecordRef must be 2');
+    end;
+
+    [Test]
+    procedure CrossCU_RecordToRecordRef_TableNo()
+    var
+        Rec: Record "Implicit Conv Table";
+        Helper: Codeunit "RecRef Implicit Helper";
+    begin
+        // [GIVEN] A Record variable bound to table 1275001
+        // [WHEN]  Passed to a RecordRef parameter in a different codeunit
+        // [THEN]  Number returns the table ID
+        Assert.AreEqual(1275001, Helper.GetTableNoFromRef(Rec),
+            'Cross-CU: Table number from Record passed as RecordRef must be 1275001');
+    end;
+
+    // ---------------------------------------------------------------
+    // Same-codeunit: Record passed to local RecordRef by-value param
+    // This exercises the ALCompiler.ToRecordRef path already fixed.
+    // ---------------------------------------------------------------
+
+    [Test]
+    procedure SameCU_RecordToRecordRef_TableNo()
+    var
+        Rec: Record "Implicit Conv Table";
+    begin
+        // [GIVEN] A Record variable bound to table 1275001
+        // [WHEN]  Passed to a RecordRef parameter in the same codeunit
+        // [THEN]  Number returns the table ID
+        Assert.AreEqual(1275001, GetTableNoFromRef(Rec),
+            'Same-CU: Table number from Record passed as RecordRef must be 1275001');
+    end;
+
+    // ---------------------------------------------------------------
+    // Negative: unbound RecordRef has Number == 0
+    // ---------------------------------------------------------------
+
+    [Test]
+    procedure CrossCU_UnboundRecordRef_TableNoIsZero()
+    var
+        RecRef: RecordRef;
+        Helper: Codeunit "RecRef Implicit Helper";
+    begin
+        // [GIVEN] An unbound RecordRef
+        // [WHEN]  Passed to the helper
+        // [THEN]  Number is 0
+        Assert.AreEqual(0, Helper.GetTableNoFromRef(RecRef),
+            'Unbound RecordRef must have Number 0');
+    end;
+}


### PR DESCRIPTION
Closes #1275

## Summary
- Added an implicit conversion operator from `MockRecordHandle` to `MockRecordRef` on the `MockRecordRef` class, delegating to the existing `FromHandle` method
- This resolves CS1503 errors where BC emits code paths that pass a Record variable (`MockRecordHandle`) directly to a `MockRecordRef` parameter without going through `ALCompiler.ToRecordRef`
- Added test suite 1275 in bucket-1 with 4 tests covering cross-codeunit and same-codeunit Record-to-RecordRef conversion
- Updated `docs/coverage.yaml` with the new coverage entry

## Test plan
- [x] New tests pass (4/4): cross-CU field count, cross-CU table number, same-CU table number, unbound RecordRef negative case
- [x] Full bucket-1 regression: 1634 passed, 66 failed (all pre-existing)
- [x] No new failures introduced