### PR TITLE
fix: resolve CS0121 MockDialog.ALUpdate NavValue/int ambiguity

### DIFF
--- a/AlRunner/Runtime/AlScope.cs
+++ b/AlRunner/Runtime/AlScope.cs
@@ -497,7 +497,6 @@ public class MockDialog
     public void ALOpen(Guid id, NavText text, string text2) { }
     public void ALUpdate(int fieldNo, NavValue value) { }
     public void ALUpdate(int fieldNo, string value) { }
-    public void ALUpdate(int fieldNo, int value) { }
     public void ALUpdate(int fieldNo, NavText value) { }
     /// <summary>
     /// Explicit NavCode overload to resolve CS0121 ambiguity when a Code field value

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -2345,7 +2345,8 @@ Dialog.Update:
   status: covered
   tests:
     - tests/bucket-2/232-dialog-code-update
-  notes: overloads=1 (+ NavCode overload added to resolve CS0121 ambiguity when Code field values are passed — closes #1179)
+    - tests/bucket-1/1279-dialog-navvalue-int-ambiguity
+  notes: overloads=1 (NavCode overload for CS0121 #1179; removed int overload to fix NavValue/int CS0121 ambiguity #1279)
 
 # ── Duration ────────────────────────────────────────────────────
 

--- a/tests/bucket-1/1279-dialog-navvalue-int-ambiguity/src/DialogIntHelper.al
+++ b/tests/bucket-1/1279-dialog-navvalue-int-ambiguity/src/DialogIntHelper.al
@@ -1,0 +1,50 @@
+table 1279001 "DNIA Job"
+{
+    DataClassification = ToBeClassified;
+
+    fields
+    {
+        field(1; "No."; Code[20]) { DataClassification = ToBeClassified; }
+        field(2; Description; Text[100]) { DataClassification = ToBeClassified; }
+        field(3; "Line Count"; Integer) { DataClassification = ToBeClassified; }
+    }
+
+    keys
+    {
+        key(PK; "No.") { Clustered = true; }
+    }
+}
+
+codeunit 1279001 "DNIA Helper"
+{
+    /// <summary>
+    /// Mimics the telemetry scenario: Dialog.Update(3, "No.") where "No." is a Code field.
+    /// BC compiler emits ALUpdate(int, NavValue) but the int overload ALUpdate(int, int)
+    /// also matches because NavValue has implicit conversion to int, causing CS0121.
+    /// </summary>
+    procedure ShowJobProgress(JobNo: Code[20]): Text
+    var
+        Window: Dialog;
+    begin
+        Window.Open('Processing Job #1######## Lines #2######');
+        Window.Update(1, JobNo);
+        // This is the problematic call: field number 3, Code field value
+        // NavValue wrapping a Code should not be ambiguous with the int overload
+        Window.Update(3, JobNo);
+        Window.Close();
+        exit('Processed:' + JobNo);
+    end;
+
+    /// <summary>
+    /// Dialog.Update with an Integer field value — must still work.
+    /// </summary>
+    procedure ShowCountInDialog(Count: Integer): Text
+    var
+        Window: Dialog;
+    begin
+        Window.Open('Count #1######');
+        Window.Update(1, Count);
+        Window.Close();
+        exit('Count:' + Format(Count));
+    end;
+}

--- a/tests/bucket-1/1279-dialog-navvalue-int-ambiguity/test/DialogIntHelperTest.al
+++ b/tests/bucket-1/1279-dialog-navvalue-int-ambiguity/test/DialogIntHelperTest.al
@@ -1,0 +1,54 @@
+// Test suite for issue #1279: Dialog.Update with Code field value causes CS0121
+// ambiguity between MockDialog.ALUpdate(int, NavValue) and ALUpdate(int, int).
+// NavValue has implicit conversion to int, so the compiler cannot choose.
+// Fix: remove the int overload since NavValue already covers it.
+codeunit 1279002 "DNIA Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    [Test]
+    procedure ShowJobProgress_CodeField_NoAmbiguity()
+    var
+        Helper: Codeunit "DNIA Helper";
+        Result: Text;
+    begin
+        // [GIVEN] A Code[20] value passed to Dialog.Update with an int field number
+        // [WHEN] ShowJobProgress is called — internally calls Window.Update(3, JobNo)
+        // where JobNo is Code[20] (emitted as NavValue by BC compiler)
+        Result := Helper.ShowJobProgress('JOB-100');
+
+        // [THEN] Should compile and return the expected string
+        Assert.AreEqual('Processed:JOB-100', Result, 'Dialog.Update(int, NavValue) must not be ambiguous with ALUpdate(int, int)');
+    end;
+
+    [Test]
+    procedure ShowCountInDialog_IntegerField_StillWorks()
+    var
+        Helper: Codeunit "DNIA Helper";
+        Result: Text;
+    begin
+        // [GIVEN] An Integer value passed to Dialog.Update
+        // [WHEN] ShowCountInDialog is called — internally calls Window.Update(1, Count)
+        Result := Helper.ShowCountInDialog(42);
+
+        // [THEN] Should compile and return the expected string
+        Assert.AreEqual('Count:42', Result, 'Dialog.Update with Integer must still work after removing int overload');
+    end;
+
+    [Test]
+    procedure ShowJobProgress_EmptyCode_NoAmbiguity()
+    var
+        Helper: Codeunit "DNIA Helper";
+        Result: Text;
+    begin
+        // [GIVEN] An empty Code value
+        // [WHEN] ShowJobProgress is called
+        Result := Helper.ShowJobProgress('');
+
+        // [THEN] Should compile and return expected result
+        Assert.AreEqual('Processed:', Result, 'Dialog.Update with empty Code must not be ambiguous');
+    end;
+}


### PR DESCRIPTION
Closes #1279

## Summary
- Removed `MockDialog.ALUpdate(int, int)` overload that caused CS0121 ambiguity with `ALUpdate(int, NavValue)` when BC compiler emits `AlCompat.ToNavValue()` wrappers around integer arguments
- The `int` overload was redundant since BC always wraps values via `ToNavValue()`, so `ALUpdate(int, NavValue)` handles all cases
- Added test suite `1279-dialog-navvalue-int-ambiguity` covering Code field and Integer field passed to `Dialog.Update`

## Test plan
- [x] New tests pass: Code field value passed to Dialog.Update compiles without CS0121
- [x] Integer values passed to Dialog.Update still work (resolves to NavValue overload)
- [x] Existing dialog test suites (85, 232) still pass
- [x] Full bucket-1 regression: no new failures