### PR TITLE
fix: change MockMedia.ALMediaId from method to property

### DIFF
--- a/AlRunner/Runtime/MockMedia.cs
+++ b/AlRunner/Runtime/MockMedia.cs
@@ -39,9 +39,12 @@ public class MockMedia : NavValue
 
     // ── MediaId ──────────────────────────────────────────────────────────────────
 
-    /// <summary>BC emits <c>m.ALMediaId(errorLevel)</c> for <c>Media.MediaId()</c>.</summary>
-    public NavGuid ALMediaId(DataError errorLevel) => new NavGuid(_id);
-    public NavGuid ALMediaId() => new NavGuid(_id);
+    /// <summary>
+    /// BC emits <c>m.ALMediaId</c> (property access, no parentheses) for
+    /// <c>Media.MediaId()</c>. Must be a property — a method overload would
+    /// produce CS1503 / CS0428 "method group" errors when used as an argument.
+    /// </summary>
+    public Guid ALMediaId => _id;
 
     // ── ALImport (BC-emitted name for Media.ImportFile) ───────────────────────────
 

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -4408,9 +4408,10 @@ Media.MediaId:
   layer: runtime-api
   category: Media
   status: covered
-  notes: overloads=1
+  notes: "MockMedia.ALMediaId property (not method); fixes CS1503 method-group-to-object when used as argument"
   tests:
     - tests/bucket-1/272-media
+    - tests/bucket-1/1259-media-mediaid-as-arg
 
 # ── MediaSet ────────────────────────────────────────────────────
 

--- a/tests/bucket-1/1259-media-mediaid-as-arg/src/MediaIdArgSrc.al
+++ b/tests/bucket-1/1259-media-mediaid-as-arg/src/MediaIdArgSrc.al
@@ -1,0 +1,19 @@
+table 1259001 "Media Id Arg Table"
+{
+    fields
+    {
+        field(1; "No."; Code[20]) { }
+        field(2; Image; Media) { }
+    }
+    keys { key(PK; "No.") { Clustered = true; } }
+}
+
+codeunit 1259001 "Media Id Arg Src"
+{
+    /// Accepts a Guid argument and returns it — used to prove
+    /// that MediaId() can be passed as an argument.
+    procedure GetGuidBack(Id: Guid): Guid
+    begin
+        exit(Id);
+    end;
+}

--- a/tests/bucket-1/1259-media-mediaid-as-arg/test/MediaIdArgTest.al
+++ b/tests/bucket-1/1259-media-mediaid-as-arg/test/MediaIdArgTest.al
@@ -1,0 +1,36 @@
+codeunit 1259002 "Media Id Arg Test"
+{
+    Subtype = Test;
+    var
+        Assert: Codeunit Assert;
+
+    [Test]
+    procedure MediaId_AsArgument_Compiles()
+    var
+        Rec: Record "Media Id Arg Table";
+        Helper: Codeunit "Media Id Arg Src";
+        Id: Guid;
+    begin
+        // Positive: MediaId() result can be passed as a Guid argument.
+        // This reproduces the CS1503 "method group to object" error from issue #1259.
+        Rec.Init();
+        Rec."No." := 'A1';
+        Rec.Insert();
+        Id := Helper.GetGuidBack(Rec.Image.MediaId());
+        Assert.IsFalse(IsNullGuid(Id), 'MediaId passed as arg must return non-empty GUID');
+    end;
+
+    [Test]
+    procedure MediaId_Standalone_ReturnsNonEmpty()
+    var
+        Rec: Record "Media Id Arg Table";
+        Id: Guid;
+    begin
+        // Positive: MediaId() standalone returns a non-empty GUID.
+        Rec.Init();
+        Rec."No." := 'A2';
+        Rec.Insert();
+        Id := Rec.Image.MediaId();
+        Assert.IsFalse(IsNullGuid(Id), 'MediaId must return a non-empty GUID');
+    end;
+}


### PR DESCRIPTION
Closes #1259

## Summary
- BC emits `Media.MediaId()` as a property access (`m.ALMediaId`, no parentheses), but `MockMedia` defined `ALMediaId` as method overloads. When the result was used as an argument (e.g. `record.Get(rec.Image.ALMediaId)`), Roslyn raised CS1503 ("method group to object") / CS0428 errors.
- Changed `ALMediaId` from two method overloads to a `Guid` property, matching `MockMediaSet.ALMediaId`'s existing pattern.
- Added test suite `1259-media-mediaid-as-arg` with positive tests for both standalone usage and as-argument usage.

## Test plan
- [x] RED: new tests fail with CS8917/CS0428 before the fix
- [x] GREEN: both tests pass after changing to property
- [x] Existing `272-media` and `278-mediaset-methods` tests still pass
- [x] Full bucket-1 and bucket-3 pass