### PR TITLE
fix: rewrite MockRecordRef.Factory for RecordRef array declarations

### DIFF
--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -1925,6 +1925,30 @@ public void Unbind() { AlRunner.Runtime.EventSubscriberRegistry.Unbind(this); }
             }
         }
 
+        // new MockArray<MockRecordRef>(new MockRecordRef.Factory(...), N) -> new MockArray<MockRecordRef>(N, () => new MockRecordRef())
+        // NavArray with Factory pattern for RecordRef arrays: replace Factory-based construction with lambda-based MockArray
+        if (typeText.StartsWith("MockArray<MockRecordRef>") && visited.ArgumentList != null &&
+            visited.ArgumentList.Arguments.Count == 2)
+        {
+            var factoryArg = visited.ArgumentList.Arguments[0].Expression;
+            var sizeArg = visited.ArgumentList.Arguments[1].Expression;
+            if (factoryArg is ObjectCreationExpressionSyntax)
+            {
+                // new MockArray<MockRecordRef>(size, () => new MockRecordRef())
+                return SyntaxFactory.ObjectCreationExpression(
+                    SyntaxFactory.ParseTypeName("MockArray<MockRecordRef>"))
+                    .WithArgumentList(SyntaxFactory.ArgumentList(
+                        SyntaxFactory.SeparatedList(new[] {
+                            SyntaxFactory.Argument(sizeArg),
+                            SyntaxFactory.Argument(
+                                SyntaxFactory.ParenthesizedLambdaExpression(
+                                    SyntaxFactory.ObjectCreationExpression(
+                                        SyntaxFactory.ParseTypeName("MockRecordRef"))
+                                        .WithArgumentList(SyntaxFactory.ArgumentList())))
+                        })));
+            }
+        }
+
         // Catch any remaining MockVariant.Factory or NavVariant.Factory construction
         if (typeText.Contains("MockVariant") && typeText.Contains("Factory") && visited.ArgumentList != null)
         {

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -5203,7 +5203,7 @@ record_to_recordref_implicit:
     - tests/bucket-1/1275-record-to-recordref-implicit
 
 recordref_array_factory:
-  layer: rewriter
+  layer: syntax
   category: RecordRef
   status: covered
   notes: >

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -5202,6 +5202,19 @@ record_to_recordref_implicit:
   tests:
     - tests/bucket-1/1275-record-to-recordref-implicit
 
+recordref_array_factory:
+  layer: rewriter
+  category: RecordRef
+  status: covered
+  notes: >
+    BC compiler emits NavRecordRef.Factory for arrays of RecordRef variables
+    (e.g. array[3] of RecordRef). After rewriting NavRecordRef to MockRecordRef,
+    the Factory nested type reference caused CS0426. RoslynRewriter now rewrites
+    new MockArray<MockRecordRef>(new MockRecordRef.Factory(...), N) to
+    new MockArray<MockRecordRef>(N, () => new MockRecordRef()). Fixed in issue #1261.
+  tests:
+    - tests/bucket-2/100-recref-factory
+
 RecordRef.AddLink:
   layer: runtime-api
   category: RecordRef

--- a/tests/bucket-2/100-recref-factory/src/RecRefFactorySrc.al
+++ b/tests/bucket-2/100-recref-factory/src/RecRefFactorySrc.al
@@ -1,0 +1,17 @@
+codeunit 304000 "RecRef Factory Src"
+{
+    /// Uses an array of RecordRef variables, which causes the BC compiler
+    /// to emit NavRecordRef.Factory (rewritten to MockRecordRef.Factory).
+    procedure GetRecRefFromArray(): Integer
+    var
+        RecRefs: array[3] of RecordRef;
+        i: Integer;
+    begin
+        // Open each RecordRef to a different "table"
+        for i := 1 to 3 do
+            RecRefs[i].Open(i);
+
+        // Return the table number of the second element to prove array works
+        exit(RecRefs[2].Number);
+    end;
+}

--- a/tests/bucket-2/100-recref-factory/test/RecRefFactoryTest.al
+++ b/tests/bucket-2/100-recref-factory/test/RecRefFactoryTest.al
@@ -1,0 +1,30 @@
+codeunit 304001 "RecRef Factory Test"
+{
+    Subtype = Test;
+
+    [Test]
+    procedure RecRefArray_FactoryCompiles()
+    var
+        Src: Codeunit "RecRef Factory Src";
+        Result: Integer;
+    begin
+        // Positive: array of RecordRef compiles and works correctly
+        Result := Src.GetRecRefFromArray();
+        Assert.AreEqual(2, Result, 'RecRefs[2].Number should be 2 after Open(2)');
+    end;
+
+    [Test]
+    procedure RecRefArray_ElementsAreIndependent()
+    var
+        RecRefs: array[2] of RecordRef;
+    begin
+        // Positive: each element in a RecordRef array is independent
+        RecRefs[1].Open(10);
+        RecRefs[2].Open(20);
+        Assert.AreEqual(10, RecRefs[1].Number, 'RecRefs[1] should have table 10');
+        Assert.AreEqual(20, RecRefs[2].Number, 'RecRefs[2] should have table 20');
+    end;
+
+    var
+        Assert: Codeunit "Library Assert";
+}


### PR DESCRIPTION
Closes #1261

## Summary
- BC compiler emits `NavRecordRef.Factory` nested type for arrays of RecordRef variables (e.g. `array[3] of RecordRef`). After the rewriter transforms `NavRecordRef` to `MockRecordRef`, the code references `MockRecordRef.Factory` which doesn't exist, causing CS0426.
- Added a RoslynRewriter rule that transforms `new MockArray<MockRecordRef>(new MockRecordRef.Factory(...), N)` into `new MockArray<MockRecordRef>(N, () => new MockRecordRef())`, mirroring the existing pattern used for `MockVariant.Factory`.
- Added test suite `100-recref-factory` in bucket-2 with positive tests proving RecordRef arrays compile and elements are independent.

## Test plan
- [x] RED: confirmed CS0426 failure before implementation
- [x] GREEN: both new tests pass after adding the rewriter rule
- [x] Full bucket-1 and bucket-3 pass; bucket-2 passes (pre-existing failures unrelated)