### PR TITLE
fix: add CheckType no-op stub on Record classes

### DIFF
--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -760,6 +760,7 @@ public bool ALWritePermission => Rec.ALWritePermission;
 public void ALSetPermissionFilter() => Rec.ALSetPermissionFilter();
 public void ALFieldError(int fieldNo) => Rec.ALFieldError(fieldNo);
 public void ALFieldError(int fieldNo, string message) => Rec.ALFieldError(fieldNo, message);
+public void CheckType(NavType expected, NavType actual) { /* no-op: type validation is a BC runtime concern */ }
 protected bool CallGetDecimalPlacesExtensionMethod(int fieldNo, ref string result) { return false; }
 protected bool CallGetTableRelationExtensionMethod(int fieldNo, MockRecordHandle rec, ref bool result) { return false; }
 protected bool CallGetFormatExtensionMethod(int fieldNo, ref string result) { return false; }

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -7081,6 +7081,13 @@ Table.FieldError:
   tests: tests/bucket-1/96-fielderror-autoformat
   notes: overloads=2; MockRecordHandle.ALFieldError(fieldNo) / ALFieldError(fieldNo, msg) — throws validation error; delegated on Record classes
 
+Table.CheckType:
+  layer: runtime-api
+  category: Table
+  status: stub
+  tests: tests/bucket-1/1280-checktype-tableext
+  notes: overloads=1; CheckType(NavType expected, NavType actual) — BC compiler-emitted type validation; no-op stub on Record classes
+
 Table.CallGetAutoFormatStringExtensionMethod:
   layer: runtime-api
   category: Table

--- a/tests/bucket-1/1280-checktype-tableext/src/CheckTypeLogic.al
+++ b/tests/bucket-1/1280-checktype-tableext/src/CheckTypeLogic.al
@@ -1,0 +1,27 @@
+codeunit 1280001 "CheckType Logic"
+{
+    /// <summary>
+    /// Returns the discount amount when Line Discount % is non-zero.
+    /// This triggers CheckType calls in the BC-generated C# code because
+    /// comparing a field value (if "Line Discount %" <> 0) emits CheckType.
+    /// </summary>
+    procedure CalcDiscountAmount(var Rec: Record "CheckType Base Table"): Decimal
+    var
+        DiscountPct: Decimal;
+    begin
+        DiscountPct := Rec."Line Discount %";
+        if DiscountPct <> 0 then
+            exit(Rec."Amount" * DiscountPct / 100);
+        exit(0);
+    end;
+
+    /// <summary>
+    /// Tests that Extra Code comparison (Code field) also works through CheckType.
+    /// </summary>
+    procedure HasExtraCode(var Rec: Record "CheckType Base Table"): Boolean
+    begin
+        if Rec."Extra Code" <> '' then
+            exit(true);
+        exit(false);
+    end;
+}

--- a/tests/bucket-1/1280-checktype-tableext/src/CheckTypeTable.al
+++ b/tests/bucket-1/1280-checktype-tableext/src/CheckTypeTable.al
@@ -1,0 +1,22 @@
+table 1280001 "CheckType Base Table"
+{
+    DataClassification = CustomerContent;
+
+    fields
+    {
+        field(1; "No."; Code[20])
+        {
+        }
+        field(2; "Amount"; Decimal)
+        {
+        }
+    }
+
+    keys
+    {
+        key(PK; "No.")
+        {
+            Clustered = true;
+        }
+    }
+}

--- a/tests/bucket-1/1280-checktype-tableext/src/CheckTypeTableExt.al
+++ b/tests/bucket-1/1280-checktype-tableext/src/CheckTypeTableExt.al
@@ -1,0 +1,12 @@
+tableextension 1280001 "CheckType Table Ext" extends "CheckType Base Table"
+{
+    fields
+    {
+        field(50100; "Line Discount %"; Decimal)
+        {
+        }
+        field(50101; "Extra Code"; Code[10])
+        {
+        }
+    }
+}

--- a/tests/bucket-1/1280-checktype-tableext/test/TestCheckType.al
+++ b/tests/bucket-1/1280-checktype-tableext/test/TestCheckType.al
@@ -1,0 +1,76 @@
+codeunit 1280002 "Test CheckType"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    [Test]
+    procedure CheckType_DiscountNonZero_ReturnsAmount()
+    var
+        Rec: Record "CheckType Base Table";
+        Logic: Codeunit "CheckType Logic";
+        Result: Decimal;
+    begin
+        // Positive: non-zero discount % returns computed discount amount
+        Rec.Init();
+        Rec."No." := 'CT01';
+        Rec."Amount" := 200;
+        Rec."Line Discount %" := 10;
+        Rec.Insert(true);
+
+        Rec.Get('CT01');
+        Result := Logic.CalcDiscountAmount(Rec);
+        Assert.AreEqual(20, Result, 'Discount on 200 at 10% should be 20');
+    end;
+
+    [Test]
+    procedure CheckType_DiscountZero_ReturnsZero()
+    var
+        Rec: Record "CheckType Base Table";
+        Logic: Codeunit "CheckType Logic";
+        Result: Decimal;
+    begin
+        // Positive: zero discount % returns 0
+        Rec.Init();
+        Rec."No." := 'CT02';
+        Rec."Amount" := 500;
+        Rec."Line Discount %" := 0;
+        Rec.Insert(true);
+
+        Rec.Get('CT02');
+        Result := Logic.CalcDiscountAmount(Rec);
+        Assert.AreEqual(0, Result, 'Zero discount should return 0');
+    end;
+
+    [Test]
+    procedure CheckType_ExtraCodeNonEmpty_ReturnsTrue()
+    var
+        Rec: Record "CheckType Base Table";
+        Logic: Codeunit "CheckType Logic";
+    begin
+        // Positive: non-empty Extra Code returns true
+        Rec.Init();
+        Rec."No." := 'CT03';
+        Rec."Extra Code" := 'ABC';
+        Rec.Insert(true);
+
+        Rec.Get('CT03');
+        Assert.IsTrue(Logic.HasExtraCode(Rec), 'Should return true for non-empty Extra Code');
+    end;
+
+    [Test]
+    procedure CheckType_ExtraCodeEmpty_ReturnsFalse()
+    var
+        Rec: Record "CheckType Base Table";
+        Logic: Codeunit "CheckType Logic";
+    begin
+        // Negative: empty Extra Code returns false
+        Rec.Init();
+        Rec."No." := 'CT04';
+        Rec.Insert(true);
+
+        Rec.Get('CT04');
+        Assert.IsFalse(Logic.HasExtraCode(Rec), 'Should return false for empty Extra Code');
+    end;
+}


### PR DESCRIPTION
Closes #1280

## Summary
- The BC compiler emits `CheckType(NavType expected, NavType actual)` calls on Table and TableExtension classes for runtime type validation (e.g., when comparing field values like `if "Line Discount %" <> 0 then`)
- After the RoslynRewriter strips the BC base class (`NavApplicationObjectBase`), these calls fail with CS1061
- Added `CheckType` as a no-op method in the injected delegate block for Record classes
- Added test suite exercising table extension field comparisons (the pattern that triggers CheckType)
- Updated `docs/coverage.yaml`

## Test plan
- [x] New test suite `tests/bucket-1/1280-checktype-tableext` with 4 tests (positive + negative for Decimal and Code field comparisons on table extensions)
- [x] Full bucket-1 and bucket-3 pass (same 66 pre-existing failures as main)
- [x] `--dump-rewritten` confirms `CheckType` method is injected on both Table and TableExtension classes