### PR TITLE
feat: add Version.Create(Text) 1-arg ALCreate overload

### DIFF
--- a/AlRunner/Runtime/MockVersion.cs
+++ b/AlRunner/Runtime/MockVersion.cs
@@ -40,6 +40,23 @@ public struct MockVersion
         => ALCreate(null, major, minor, build, revision);
 
     /// <summary>
+    /// BC lowers <c>Version.Create(Text)</c> to <c>NavVersion.ALCreate(text)</c>.
+    /// Parses a dotted version string (e.g. <c>"25.1.30000.12345"</c>) into its
+    /// major/minor/build/revision components.
+    /// </summary>
+    public static MockVersion ALCreate(NavText versionText)
+    {
+        var text = versionText.ToString();
+        var parts = text.Split('.');
+        var result = new MockVersion();
+        if (parts.Length > 0 && int.TryParse(parts[0], out var maj)) result._major    = maj;
+        if (parts.Length > 1 && int.TryParse(parts[1], out var min)) result._minor    = min;
+        if (parts.Length > 2 && int.TryParse(parts[2], out var bld)) result._build    = bld;
+        if (parts.Length > 3 && int.TryParse(parts[3], out var rev)) result._revision = rev;
+        return result;
+    }
+
+    /// <summary>
     /// Default (zero) instance — BC emits <c>NavVersion.Default</c> for uninitialized
     /// <c>Version</c> variables (0.0.0.0).
     /// </summary>

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -9529,7 +9529,14 @@ Version.Create:
   category: Version
   status: covered
   tests: tests/bucket-1/96-version
-  notes: overloads=2
+  notes: overloads=2; ALCreate(major,minor,build,revision) and ALCreate(NavText versionText) for Version.Create(Text)
+
+Version.Create (1-arg text):
+  layer: runtime-api
+  category: Version
+  status: covered
+  tests: tests/bucket-1/96-version-create-text
+  notes: overloads=1; parses dotted version string e.g. '25.1.30000.12345' into major/minor/build/revision
 
 Version.Major:
   layer: runtime-api

--- a/tests/bucket-1/96-version-create-text/src/VersionCreateTextHelper.al
+++ b/tests/bucket-1/96-version-create-text/src/VersionCreateTextHelper.al
@@ -1,0 +1,52 @@
+codeunit 1296001 "Version Create Text Helper"
+{
+    procedure CreateFromText(VersionText: Text): Text
+    var
+        Ver: Version;
+    begin
+        Ver := Version.Create(VersionText);
+        exit(Format(Ver));
+    end;
+
+    procedure CreateAndCompareMajor(VersionText: Text): Integer
+    var
+        Ver: Version;
+    begin
+        Ver := Version.Create(VersionText);
+        exit(Ver.Major());
+    end;
+
+    procedure CreateAndCompareMinor(VersionText: Text): Integer
+    var
+        Ver: Version;
+    begin
+        Ver := Version.Create(VersionText);
+        exit(Ver.Minor());
+    end;
+
+    procedure CreateAndCompareBuild(VersionText: Text): Integer
+    var
+        Ver: Version;
+    begin
+        Ver := Version.Create(VersionText);
+        exit(Ver.Build());
+    end;
+
+    procedure CreateAndCompareRevision(VersionText: Text): Integer
+    var
+        Ver: Version;
+    begin
+        Ver := Version.Create(VersionText);
+        exit(Ver.Revision());
+    end;
+
+    procedure CompareVersions(TextA: Text; TextB: Text): Boolean
+    var
+        VerA: Version;
+        VerB: Version;
+    begin
+        VerA := Version.Create(TextA);
+        VerB := Version.Create(TextB);
+        exit(VerA < VerB);
+    end;
+}

--- a/tests/bucket-1/96-version-create-text/test/VersionCreateTextTest.al
+++ b/tests/bucket-1/96-version-create-text/test/VersionCreateTextTest.al
@@ -1,0 +1,41 @@
+codeunit 1296002 "Version Create Text Test"
+{
+    Subtype = Test;
+
+    [Test]
+    procedure CreateFromText_FourPart()
+    var
+        Helper: Codeunit "Version Create Text Helper";
+    begin
+        // Positive: Version.Create('25.1.30000.12345') parses all four components
+        Assert.AreEqual(25, Helper.CreateAndCompareMajor('25.1.30000.12345'), 'Major should be 25');
+        Assert.AreEqual(1, Helper.CreateAndCompareMinor('25.1.30000.12345'), 'Minor should be 1');
+        Assert.AreEqual(30000, Helper.CreateAndCompareBuild('25.1.30000.12345'), 'Build should be 30000');
+        Assert.AreEqual(12345, Helper.CreateAndCompareRevision('25.1.30000.12345'), 'Revision should be 12345');
+    end;
+
+    [Test]
+    procedure CreateFromText_Comparison()
+    var
+        Helper: Codeunit "Version Create Text Helper";
+    begin
+        // Positive: Version created from text supports comparison operators
+        Assert.IsTrue(Helper.CompareVersions('1.0.0.0', '2.0.0.0'), '1.0 < 2.0 should be true');
+        Assert.IsFalse(Helper.CompareVersions('3.0.0.0', '2.0.0.0'), '3.0 < 2.0 should be false');
+    end;
+
+    [Test]
+    procedure CreateFromText_PlatformStyleVersion()
+    var
+        Helper: Codeunit "Version Create Text Helper";
+    begin
+        // Positive: realistic platform version string (the actual pattern from the issue)
+        Assert.AreEqual(25, Helper.CreateAndCompareMajor('25.0.30000.0'), 'Platform major');
+        Assert.AreEqual(0, Helper.CreateAndCompareMinor('25.0.30000.0'), 'Platform minor');
+        Assert.AreEqual(30000, Helper.CreateAndCompareBuild('25.0.30000.0'), 'Platform build');
+        Assert.AreEqual(0, Helper.CreateAndCompareRevision('25.0.30000.0'), 'Platform revision');
+    end;
+
+    var
+        Assert: Codeunit "Library Assert";
+}


### PR DESCRIPTION
Closes #1296

## Summary
- Add `ALCreate(NavText)` overload to `MockVersion` that parses a dotted version string (e.g. `'25.1.30000.12345'`) into major/minor/build/revision components
- AL's `Version.Create(Text)` transpiles to `MockVersion.ALCreate(NavText)` but only the 4-arg overload existed, causing CS1501 compilation errors
- Added test suite `96-version-create-text` with 3 proving tests covering component extraction, comparison operators, and realistic platform version strings
- Updated `docs/coverage.yaml` with the new overload entry

## Test plan
- [x] RED: confirmed CS1501 error before implementation
- [x] GREEN: all 3 new tests pass after adding the overload
- [x] Full bucket-1 and bucket-3 test suites pass (bucket-2 has pre-existing unrelated issue on main)