### PR TITLE
fix: add Clear method to MockDataTransfer

### DIFF
--- a/AlRunner/Runtime/MockDataTransfer.cs
+++ b/AlRunner/Runtime/MockDataTransfer.cs
@@ -66,4 +66,14 @@ public class MockDataTransfer
     {
         // No-op: requires real database
     }
+
+    /// <summary>Reset the DataTransfer to its initial state.</summary>
+    public void Clear()
+    {
+        _sourceTableId = 0;
+        _targetTableId = 0;
+        _fieldMappings.Clear();
+        _constantValues.Clear();
+        ALUpdateAuditFields = false;
+    }
 }

--- a/tests/bucket-1/269-datatransfer-clear/src/DataTransferClearSrc.al
+++ b/tests/bucket-1/269-datatransfer-clear/src/DataTransferClearSrc.al
@@ -1,0 +1,56 @@
+table 1269001 "DTC Item"
+{
+    DataClassification = CustomerContent;
+    fields
+    {
+        field(1; "No."; Code[20]) { }
+        field(2; Description; Text[100]) { }
+    }
+    keys
+    {
+        key(PK; "No.") { Clustered = true; }
+    }
+}
+
+codeunit 1269001 "DTC Src"
+{
+    procedure ClearAfterSetup_DoesNotThrow()
+    var
+        DT: DataTransfer;
+    begin
+        DT.SetTables(Database::"DTC Item", Database::"DTC Item");
+        DT.AddFieldValue(1, 1);
+        DT.AddConstantValue('X', 2);
+        Clear(DT);
+    end;
+
+    procedure ClearThenCopyFields_DoesNotThrow()
+    var
+        DT: DataTransfer;
+    begin
+        DT.SetTables(Database::"DTC Item", Database::"DTC Item");
+        DT.AddFieldValue(1, 1);
+        Clear(DT);
+        DT.CopyFields();
+    end;
+
+    procedure ClearThenCopyRows_DoesNotThrow()
+    var
+        DT: DataTransfer;
+    begin
+        DT.SetTables(Database::"DTC Item", Database::"DTC Item");
+        DT.AddFieldValue(1, 1);
+        Clear(DT);
+        DT.CopyRows();
+    end;
+
+    procedure UpdateAuditFieldsSurvivesClear(): Boolean
+    var
+        DT: DataTransfer;
+    begin
+        // In BC, Clear resets the DataTransfer including UpdateAuditFields.
+        DT.UpdateAuditFields := true;
+        Clear(DT);
+        exit(DT.UpdateAuditFields);
+    end;
+}

--- a/tests/bucket-1/269-datatransfer-clear/test/DataTransferClearTest.al
+++ b/tests/bucket-1/269-datatransfer-clear/test/DataTransferClearTest.al
@@ -1,0 +1,41 @@
+codeunit 1269002 "DTC Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "DTC Src";
+
+    [Test]
+    procedure Clear_AfterSetup_DoesNotThrow()
+    begin
+        // Positive: calling Clear after SetTables + AddFieldValue + AddConstantValue
+        // must not throw -- the method must exist and be callable.
+        Src.ClearAfterSetup_DoesNotThrow();
+        Assert.IsTrue(true, 'DataTransfer.Clear must not throw');
+    end;
+
+    [Test]
+    procedure Clear_ThenCopyFields_DoesNotThrow()
+    begin
+        // Positive: Clear followed by CopyFields must not throw.
+        Src.ClearThenCopyFields_DoesNotThrow();
+        Assert.IsTrue(true, 'CopyFields after Clear must not throw');
+    end;
+
+    [Test]
+    procedure Clear_ThenCopyRows_DoesNotThrow()
+    begin
+        // Positive: Clear followed by CopyRows must not throw.
+        Src.ClearThenCopyRows_DoesNotThrow();
+        Assert.IsTrue(true, 'CopyRows after Clear must not throw');
+    end;
+
+    [Test]
+    procedure Clear_ResetsUpdateAuditFields()
+    begin
+        // Positive: after Clear, UpdateAuditFields must be back to default (false).
+        Assert.IsFalse(Src.UpdateAuditFieldsSurvivesClear(),
+            'UpdateAuditFields must be false after Clear');
+    end;
+}


### PR DESCRIPTION
Closes #1269

## Summary
- Added `Clear()` method to `MockDataTransfer` that resets all internal state (source/target table IDs, field mappings, constant values, and `UpdateAuditFields`)
- The BC compiler transpiles `Clear(DataTransfer)` to a `.Clear()` call on the mock object, which was missing and caused CS1061 errors
- Added test suite `269-datatransfer-clear` with 4 tests covering clear-after-setup, clear-then-copy, and UpdateAuditFields reset
- Updated `docs/coverage.yaml`

## Test plan
- [x] RED: confirmed CS1061 before adding `Clear()`
- [x] GREEN: all 4 tests pass after implementation
- [x] Tests verify Clear does not throw, and that UpdateAuditFields resets to false