### PR TITLE
fix: read application_Version for runner version in triage KQL

### DIFF
--- a/tools/telemetry-triage/triage.py
+++ b/tools/telemetry-triage/triage.py
@@ -129,7 +129,7 @@ KQL = """
 exceptions
 | where timestamp > datetime({from_time})
 | where cloud_RoleName == "al-runner"
-| extend ver = tostring(customDimensions["ai.application.ver"])
+| extend ver = application_Version
 | extend os  = tostring(customDimensions["os"])
 | summarize
     occurrences  = count(),


### PR DESCRIPTION
## Problem

All telemetry issues show `Versions: unknown`. The KQL query read `customDimensions["ai.application.ver"]` but `ai.application.ver` is sent as an App Insights **tag**, which maps to the `application_Version` column — not `customDimensions`.

## Fix

Change `extend ver = tostring(customDimensions["ai.application.ver"])` → `extend ver = application_Version`.

This will show actual version numbers (e.g. `1.0.23`) in future triage issues, enabling version-aware filtering.