### PR TITLE
fix: add string overload for AlCompat.CreateErrorInfo

### DIFF
--- a/AlRunner/Runtime/AlScope.cs
+++ b/AlRunner/Runtime/AlScope.cs
@@ -2915,6 +2915,17 @@ public static class AlCompat
         return ei;
     }
 
+    /// <summary>
+    /// String overload — BC may emit ErrorInfo.Create('literal') as a raw C# string
+    /// argument.  Without this overload, Roslyn reports CS1503 (string → NavText).
+    /// </summary>
+    public static NavALErrorInfo CreateErrorInfo(string message)
+    {
+        var ei = new NavALErrorInfo();
+        ei.ALMessage = message;
+        return ei;
+    }
+
     public static NavALErrorInfo CreateErrorInfo()
     {
         return new NavALErrorInfo();

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -2436,9 +2436,10 @@ ErrorInfo.Create:
   layer: runtime-api
   category: ErrorInfo
   status: covered
-  notes: overloads=2; NavALErrorInfo.ALCreate(...) loads Microsoft.Dynamics.Nav.CodeAnalysis at runtime. Intercepted in RoslynRewriter — rewritten to AlCompat.CreateErrorInfo(msg) which creates NavALErrorInfo() directly and sets ALMessage. Default (no-arg) variant also intercepted.
+  notes: overloads=2; NavALErrorInfo.ALCreate(...) loads Microsoft.Dynamics.Nav.CodeAnalysis at runtime. Intercepted in RoslynRewriter — rewritten to AlCompat.CreateErrorInfo(msg) which creates NavALErrorInfo() directly and sets ALMessage. Default (no-arg) variant also intercepted. String overload added in #1278 to fix CS1503 when BC emits string literal for the message argument.
   tests:
     - tests/bucket-1/191-errorinfo-methods
+    - tests/bucket-1/1278-string-to-navtext
 
 ErrorInfo.CustomDimensions:
   layer: runtime-api

--- a/tests/bucket-1/1278-string-to-navtext/src/StringNavTextSrc.al
+++ b/tests/bucket-1/1278-string-to-navtext/src/StringNavTextSrc.al
@@ -1,0 +1,37 @@
+/// Exercises string-to-NavText conversion patterns.
+/// BC may emit string literals where NavText parameters are expected.
+codeunit 1278001 "StringNavText Src"
+{
+    /// Creates an ErrorInfo with a string literal message.
+    /// BC emits ErrorInfo.Create('msg') as NavALErrorInfo.ALCreate(string),
+    /// which the rewriter maps to AlCompat.CreateErrorInfo(string).
+    /// Without a string overload, this triggers CS1503 (string → NavText).
+    procedure CreateErrorInfoWithLiteral(): Text
+    var
+        ErrInfo: ErrorInfo;
+    begin
+        ErrInfo := ErrorInfo.Create('Something went wrong');
+        exit(ErrInfo.Message);
+    end;
+
+    /// Creates an ErrorInfo from a Text variable.
+    procedure CreateErrorInfoFromVar(): Text
+    var
+        ErrInfo: ErrorInfo;
+        Msg: Text;
+    begin
+        Msg := 'Variable message';
+        ErrInfo := ErrorInfo.Create(Msg);
+        exit(ErrInfo.Message);
+    end;
+
+    /// Raises an error using ErrorInfo.Create with a literal.
+    /// This exercises the full Error(ErrorInfo) path.
+    procedure RaiseErrorInfoLiteral()
+    var
+        ErrInfo: ErrorInfo;
+    begin
+        ErrInfo := ErrorInfo.Create('Deliberate test error');
+        Error(ErrInfo);
+    end;
+}

--- a/tests/bucket-1/1278-string-to-navtext/test/StringNavTextTest.al
+++ b/tests/bucket-1/1278-string-to-navtext/test/StringNavTextTest.al
@@ -1,0 +1,34 @@
+/// Tests string-to-NavText conversion in ErrorInfo.Create — issue #1278.
+codeunit 1278002 "StringNavText Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit "Library Assert";
+        Src: Codeunit "StringNavText Src";
+
+    [Test]
+    procedure ErrorInfo_Create_WithLiteral()
+    begin
+        // Positive: string literal passes through to ErrorInfo.Message
+        Assert.AreEqual('Something went wrong', Src.CreateErrorInfoWithLiteral(),
+            'ErrorInfo.Create with string literal should set Message');
+    end;
+
+    [Test]
+    procedure ErrorInfo_Create_FromVar()
+    begin
+        // Positive: Text variable passes through to ErrorInfo.Message
+        Assert.AreEqual('Variable message', Src.CreateErrorInfoFromVar(),
+            'ErrorInfo.Create with Text variable should set Message');
+    end;
+
+    [Test]
+    procedure ErrorInfo_Create_Literal_RaisesCorrectError()
+    begin
+        // Negative: ErrorInfo.Create with a literal, then Error(ErrorInfo),
+        // must raise exactly the message that was passed.
+        asserterror Src.RaiseErrorInfoLiteral();
+        Assert.ExpectedError('Deliberate test error');
+    end;
+}


### PR DESCRIPTION
Closes #1278

## Summary
- Added `string` overload for `AlCompat.CreateErrorInfo()` in `AlScope.cs` — BC may emit `ErrorInfo.Create('literal')` with a raw C# string argument instead of `NavText`, causing CS1503 at Roslyn compile time
- Added test suite `tests/bucket-1/1278-string-to-navtext/` with 3 tests: literal message, variable message, and error-raising path
- Updated `docs/coverage.yaml` with the new test reference

## Test plan
- [x] RED: `ErrorInfo.Create('literal')` fails with CS1503 before fix
- [x] GREEN: all 3 tests pass after adding string overload
- [x] Full bucket-1 suite passes (66 pre-existing failures unrelated)