### PR TITLE
fix: add 3-arg overloads for JsonObject.GetInteger/GetBoolean/GetDecimal

### DIFF
--- a/AlRunner/Runtime/MockJsonHelper.cs
+++ b/AlRunner/Runtime/MockJsonHelper.cs
@@ -307,6 +307,31 @@ public static class MockJsonHelper
     }
 
     /// <summary>
+    /// Replacement for NavJsonToken.ALGetBoolean(key, requireValueExists).
+    /// Returns the boolean value of the named property, with optional existence check.
+    /// AL: JsonObject.GetBoolean('key', true)  →  MockJsonHelper.GetBoolean(token, key, requireValueExists)
+    /// </summary>
+    public static bool GetBoolean(NavJsonToken token, string key, bool requireValueExists)
+    {
+        var backingToken = GetBackingToken(token);
+        if (backingToken is not JObject obj)
+            throw new Exception("The JSON token is not an object.");
+
+        if (!obj.TryGetValue(key, out var val))
+        {
+            if (requireValueExists)
+                throw new Exception($"The JSON object does not contain a property with the name '{key}'.");
+            return false;
+        }
+
+        if (val.Type != JTokenType.Boolean)
+            throw new Exception(
+                $"The value of JSON property '{key}' cannot be converted to a Boolean value.");
+
+        return val.Value<bool>();
+    }
+
+    /// <summary>
     /// Replacement for NavJsonToken.ALPath(DataError).
     /// Returns the BC-style JSON path for the token (e.g. "$" for root, "$.foo" for a field).
     /// Newtonsoft.Json uses "" for root and "foo" for a field — this converts to BC format.
@@ -452,6 +477,25 @@ public static class MockJsonHelper
     }
 
     /// <summary>
+    /// Replacement for NavJsonObject.ALGetInteger(key, requireValueExists).
+    /// Returns the integer value of the named property, with optional existence check.
+    /// AL: JsonObject.GetInteger('key', true)  →  MockJsonHelper.GetInteger(token, key, requireValueExists)
+    /// </summary>
+    public static int GetInteger(NavJsonToken token, string key, bool requireValueExists)
+    {
+        var backingToken = GetBackingToken(token);
+        if (backingToken is not JObject obj)
+            throw new Exception("The JSON token is not an object.");
+        if (!obj.TryGetValue(key, out var val))
+        {
+            if (requireValueExists)
+                throw new Exception($"The JSON object does not contain a property with the name '{key}'.");
+            return 0;
+        }
+        return val.Value<int>();
+    }
+
+    /// <summary>
     /// Replacement for NavJsonObject.ALGetDecimal(key).
     /// Returns the decimal value of the named property.
     /// AL: JsonObject.GetDecimal('key')  →  MockJsonHelper.GetDecimal(token, key)
@@ -463,6 +507,25 @@ public static class MockJsonHelper
             throw new Exception("The JSON token is not an object.");
         if (!obj.TryGetValue(key, out var val))
             throw new Exception($"The JSON object does not contain a property with the name '{key}'.");
+        return NavDecimal.Create(new Decimal18(val.Value<decimal>()));
+    }
+
+    /// <summary>
+    /// Replacement for NavJsonObject.ALGetDecimal(key, requireValueExists).
+    /// Returns the decimal value of the named property, with optional existence check.
+    /// AL: JsonObject.GetDecimal('key', true)  →  MockJsonHelper.GetDecimal(token, key, requireValueExists)
+    /// </summary>
+    public static NavDecimal GetDecimal(NavJsonToken token, string key, bool requireValueExists)
+    {
+        var backingToken = GetBackingToken(token);
+        if (backingToken is not JObject obj)
+            throw new Exception("The JSON token is not an object.");
+        if (!obj.TryGetValue(key, out var val))
+        {
+            if (requireValueExists)
+                throw new Exception($"The JSON object does not contain a property with the name '{key}'.");
+            return NavDecimal.Create(new Decimal18(0m));
+        }
         return NavDecimal.Create(new Decimal18(val.Value<decimal>()));
     }
 

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -3763,9 +3763,17 @@ JsonObject.GetBoolean:
   layer: runtime-api
   category: JsonObject
   status: covered
-  notes: overloads=1; rewriter redirects ALGetBoolean to MockJsonHelper.GetBoolean (JObject backing token lookup; throws on missing key or wrong type)
+  notes: overloads=2; rewriter redirects ALGetBoolean to MockJsonHelper.GetBoolean (JObject backing token lookup; throws on missing key or wrong type)
   tests:
     - tests/bucket-1/62-jsonobject-getboolean
+
+JsonObject.GetBoolean (2-arg):
+  layer: runtime-api
+  category: JsonObject
+  status: covered
+  notes: 2-arg overload (key, requireValueExists); returns false when key is missing and requireValueExists=false
+  tests:
+    - tests/bucket-1/96-json-get-3arg
 
 JsonObject.GetByte:
   layer: runtime-api
@@ -3803,9 +3811,17 @@ JsonObject.GetDecimal:
   layer: runtime-api
   category: JsonObject
   status: covered
-  notes: overloads=1; rewriter redirects ALGetDecimal to MockJsonHelper.GetDecimal
+  notes: overloads=2; rewriter redirects ALGetDecimal to MockJsonHelper.GetDecimal
   tests:
     - tests/bucket-1/268-jsonobject-methods
+
+JsonObject.GetDecimal (2-arg):
+  layer: runtime-api
+  category: JsonObject
+  status: covered
+  notes: 2-arg overload (key, requireValueExists); returns 0 when key is missing and requireValueExists=false
+  tests:
+    - tests/bucket-1/96-json-get-3arg
 
 JsonObject.GetDuration:
   layer: runtime-api
@@ -3819,9 +3835,17 @@ JsonObject.GetInteger:
   layer: runtime-api
   category: JsonObject
   status: covered
-  notes: overloads=1; rewriter redirects ALGetInteger to MockJsonHelper.GetInteger
+  notes: overloads=2; rewriter redirects ALGetInteger to MockJsonHelper.GetInteger
   tests:
     - tests/bucket-1/268-jsonobject-methods
+
+JsonObject.GetInteger (2-arg):
+  layer: runtime-api
+  category: JsonObject
+  status: covered
+  notes: 2-arg overload (key, requireValueExists); returns 0 when key is missing and requireValueExists=false
+  tests:
+    - tests/bucket-1/96-json-get-3arg
 
 JsonObject.GetObject:
   layer: runtime-api

--- a/tests/bucket-1/96-json-get-3arg/src/JsonGet3Arg.Codeunit.al
+++ b/tests/bucket-1/96-json-get-3arg/src/JsonGet3Arg.Codeunit.al
@@ -1,0 +1,31 @@
+codeunit 1281001 "JSON Get 3-Arg Helper"
+{
+    /// <summary>
+    /// Helper that exercises 3-arg GetInteger, GetBoolean, and GetDecimal
+    /// on a JsonObject, mirroring the BC compiler's 3-arg overloads.
+    /// </summary>
+
+    procedure GetIntegerFromJson(JsonText: Text; PropertyName: Text; RequireValue: Boolean): Integer
+    var
+        JsonObj: JsonObject;
+    begin
+        JsonObj.ReadFrom(JsonText);
+        exit(JsonObj.GetInteger(PropertyName, RequireValue));
+    end;
+
+    procedure GetBooleanFromJson(JsonText: Text; PropertyName: Text; RequireValue: Boolean): Boolean
+    var
+        JsonObj: JsonObject;
+    begin
+        JsonObj.ReadFrom(JsonText);
+        exit(JsonObj.GetBoolean(PropertyName, RequireValue));
+    end;
+
+    procedure GetDecimalFromJson(JsonText: Text; PropertyName: Text; RequireValue: Boolean): Decimal
+    var
+        JsonObj: JsonObject;
+    begin
+        JsonObj.ReadFrom(JsonText);
+        exit(JsonObj.GetDecimal(PropertyName, RequireValue));
+    end;
+}

--- a/tests/bucket-1/96-json-get-3arg/test/JsonGet3ArgTest.Codeunit.al
+++ b/tests/bucket-1/96-json-get-3arg/test/JsonGet3ArgTest.Codeunit.al
@@ -1,0 +1,119 @@
+codeunit 1281002 "JSON Get 3-Arg Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit "Library Assert";
+        Helper: Codeunit "JSON Get 3-Arg Helper";
+
+    [Test]
+    procedure GetInteger_3Arg_ReturnsValue()
+    var
+        Result: Integer;
+    begin
+        // [GIVEN] A JSON object with an integer property
+        // [WHEN] GetInteger is called with requireValueExists = true
+        Result := Helper.GetIntegerFromJson('{"qty": 42}', 'qty', true);
+
+        // [THEN] The correct integer value is returned
+        Assert.AreEqual(42, Result, 'GetInteger with 3 args should return the integer value');
+    end;
+
+    [Test]
+    procedure GetInteger_3Arg_MissingKey_NoRequire_ReturnsDefault()
+    var
+        Result: Integer;
+    begin
+        // [GIVEN] A JSON object without the requested key
+        // [WHEN] GetInteger is called with requireValueExists = false
+        Result := Helper.GetIntegerFromJson('{"other": 1}', 'qty', false);
+
+        // [THEN] Default integer (0) is returned
+        Assert.AreEqual(0, Result, 'GetInteger with missing key and requireValueExists=false should return 0');
+    end;
+
+    [Test]
+    procedure GetInteger_3Arg_MissingKey_Require_Throws()
+    begin
+        // [GIVEN] A JSON object without the requested key
+        // [WHEN] GetInteger is called with requireValueExists = true
+        asserterror Helper.GetIntegerFromJson('{"other": 1}', 'qty', true);
+
+        // [THEN] An error is thrown
+        Assert.ExpectedError('does not contain a property');
+    end;
+
+    [Test]
+    procedure GetBoolean_3Arg_ReturnsValue()
+    var
+        Result: Boolean;
+    begin
+        // [GIVEN] A JSON object with a boolean property
+        // [WHEN] GetBoolean is called with requireValueExists = true
+        Result := Helper.GetBooleanFromJson('{"active": true}', 'active', true);
+
+        // [THEN] The correct boolean value is returned
+        Assert.IsTrue(Result, 'GetBoolean with 3 args should return true');
+    end;
+
+    [Test]
+    procedure GetBoolean_3Arg_MissingKey_NoRequire_ReturnsDefault()
+    var
+        Result: Boolean;
+    begin
+        // [GIVEN] A JSON object without the requested key
+        // [WHEN] GetBoolean is called with requireValueExists = false
+        Result := Helper.GetBooleanFromJson('{"other": 1}', 'active', false);
+
+        // [THEN] Default boolean (false) is returned
+        Assert.IsFalse(Result, 'GetBoolean with missing key and requireValueExists=false should return false');
+    end;
+
+    [Test]
+    procedure GetBoolean_3Arg_MissingKey_Require_Throws()
+    begin
+        // [GIVEN] A JSON object without the requested key
+        // [WHEN] GetBoolean is called with requireValueExists = true
+        asserterror Helper.GetBooleanFromJson('{"other": 1}', 'active', true);
+
+        // [THEN] An error is thrown
+        Assert.ExpectedError('does not contain a property');
+    end;
+
+    [Test]
+    procedure GetDecimal_3Arg_ReturnsValue()
+    var
+        Result: Decimal;
+    begin
+        // [GIVEN] A JSON object with a decimal property
+        // [WHEN] GetDecimal is called with requireValueExists = true
+        Result := Helper.GetDecimalFromJson('{"price": 19.99}', 'price', true);
+
+        // [THEN] The correct decimal value is returned
+        Assert.AreEqual(19.99, Result, 'GetDecimal with 3 args should return the decimal value');
+    end;
+
+    [Test]
+    procedure GetDecimal_3Arg_MissingKey_NoRequire_ReturnsDefault()
+    var
+        Result: Decimal;
+    begin
+        // [GIVEN] A JSON object without the requested key
+        // [WHEN] GetDecimal is called with requireValueExists = false
+        Result := Helper.GetDecimalFromJson('{"other": 1}', 'price', false);
+
+        // [THEN] Default decimal (0) is returned
+        Assert.AreEqual(0, Result, 'GetDecimal with missing key and requireValueExists=false should return 0');
+    end;
+
+    [Test]
+    procedure GetDecimal_3Arg_MissingKey_Require_Throws()
+    begin
+        // [GIVEN] A JSON object without the requested key
+        // [WHEN] GetDecimal is called with requireValueExists = true
+        asserterror Helper.GetDecimalFromJson('{"other": 1}', 'price', true);
+
+        // [THEN] An error is thrown
+        Assert.ExpectedError('does not contain a property');
+    end;
+}


### PR DESCRIPTION
Closes #1263, closes #1271, closes #1274

## Summary
- Add `GetInteger(token, key, requireValueExists)` overload to `MockJsonHelper`
- Add `GetBoolean(token, key, requireValueExists)` overload to `MockJsonHelper`
- Add `GetDecimal(token, key, requireValueExists)` overload to `MockJsonHelper`
- All follow the existing `GetText` 2-arg pattern: when `requireValueExists` is `false` and the key is missing, return the type's default value instead of throwing

## Test plan
- [x] 9 AL tests in `tests/bucket-1/96-json-get-3arg/` covering positive, negative (missing key + no require), and error (missing key + require) cases for all three types
- [x] `docs/coverage.yaml` updated with new overload entries