### PR TITLE
fix: add DataError-prefixed overloads for field-level record methods

### DIFF
--- a/AlRunner.Tests/DataErrorToIntOverloadTests.cs
+++ b/AlRunner.Tests/DataErrorToIntOverloadTests.cs
@@ -1,0 +1,187 @@
+using AlRunner.Runtime;
+using Microsoft.Dynamics.Nav.Runtime;
+using Microsoft.Dynamics.Nav.Types;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// Tests that MockRecordHandle methods which take int fieldNo as their first
+/// parameter also accept a DataError-prefixed overload.
+///
+/// BC compiler versions may emit DataError as the first argument to field-level
+/// operations (SetFieldValueSafe, GetFieldValueSafe, GetFieldRefSafe,
+/// ALSetRangeSafe, ALSetFilter, ALModifyAllSafe) that previously only accepted
+/// int. Without DataError overloads these cause CS1503 at Roslyn compilation.
+///
+/// Issue: #1267
+/// </summary>
+public class DataErrorToIntOverloadTests
+{
+    private MockRecordHandle CreateHandle()
+    {
+        var handle = new MockRecordHandle(99900);
+        MockRecordHandle.RegisterPrimaryKey(99900, 1);
+        MockRecordHandle.RegisterFieldName(99900, "EntryNo", 1);
+        MockRecordHandle.RegisterFieldName(99900, "Name", 2);
+        MockRecordHandle.RegisterFieldName(99900, "Amount", 3);
+        return handle;
+    }
+
+    // -----------------------------------------------------------------------
+    // SetFieldValueSafe DataError overloads
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void SetFieldValueSafe_DataError_3arg_SetsValue()
+    {
+        var rec = CreateHandle();
+        // Use the existing non-DataError overload to set PK
+        rec.SetFieldValueSafe(1, NavType.Integer, NavInteger.Default);
+
+        // Call the DataError overload — must compile and set the value
+        rec.SetFieldValueSafe(DataError.ThrowError, 2, NavType.Text, new NavText("hello"));
+
+        var result = rec.GetFieldValueSafe(2, NavType.Text);
+        Assert.Equal("hello", ((NavText)result).Value);
+    }
+
+    [Fact]
+    public void SetFieldValueSafe_DataError_4arg_SetsValueWithValidate()
+    {
+        var rec = CreateHandle();
+        rec.SetFieldValueSafe(1, NavType.Integer, NavInteger.Default);
+
+        rec.SetFieldValueSafe(DataError.ThrowError, 2, NavType.Text, new NavText("world"), false);
+
+        var result = rec.GetFieldValueSafe(2, NavType.Text);
+        Assert.Equal("world", ((NavText)result).Value);
+    }
+
+    // -----------------------------------------------------------------------
+    // GetFieldValueSafe DataError overloads
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void GetFieldValueSafe_DataError_2arg_ReturnsValue()
+    {
+        var rec = CreateHandle();
+        rec.SetFieldValueSafe(2, NavType.Text, new NavText("test"));
+
+        var result = rec.GetFieldValueSafe(DataError.ThrowError, 2, NavType.Text);
+        Assert.Equal("test", ((NavText)result).Value);
+    }
+
+    [Fact]
+    public void GetFieldValueSafe_DataError_3arg_WithLocale_ReturnsValue()
+    {
+        var rec = CreateHandle();
+        rec.SetFieldValueSafe(2, NavType.Text, new NavText("locale"));
+
+        var result = rec.GetFieldValueSafe(DataError.ThrowError, 2, NavType.Text, false);
+        Assert.Equal("locale", ((NavText)result).Value);
+    }
+
+    // -----------------------------------------------------------------------
+    // GetFieldRefSafe DataError overload
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void GetFieldRefSafe_DataError_ReturnsValue()
+    {
+        var rec = CreateHandle();
+        rec.SetFieldValueSafe(2, NavType.Text, new NavText("ref"));
+
+        var result = rec.GetFieldRefSafe(DataError.ThrowError, 2, NavType.Text);
+        Assert.Equal("ref", ((NavText)result).Value);
+    }
+
+    // -----------------------------------------------------------------------
+    // ALSetRangeSafe DataError overloads
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void ALSetRangeSafe_DataError_ClearRange_NoThrow()
+    {
+        var rec = CreateHandle();
+        rec.ALSetRangeSafe(2, NavType.Text, new NavText("x"));
+        // Clear range via DataError overload — must not throw
+        rec.ALSetRangeSafe(DataError.ThrowError, 2, NavType.Text);
+    }
+
+    [Fact]
+    public void ALSetRangeSafe_DataError_SingleValue_NoThrow()
+    {
+        var rec = CreateHandle();
+        rec.ALSetRangeSafe(DataError.ThrowError, 2, NavType.Text, new NavText("filtered"));
+    }
+
+    [Fact]
+    public void ALSetRangeSafe_DataError_FromToRange_NoThrow()
+    {
+        var rec = CreateHandle();
+        rec.ALSetRangeSafe(DataError.ThrowError, 2, NavType.Text,
+            new NavText("A"), new NavText("Z"));
+    }
+
+    // -----------------------------------------------------------------------
+    // ALSetFilter DataError overloads
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void ALSetFilter_DataError_StringExpr_NoThrow()
+    {
+        var rec = CreateHandle();
+        rec.ALSetFilter(DataError.ThrowError, 2, "<>''");
+    }
+
+    [Fact]
+    public void ALSetFilter_DataError_WithNavType_NoThrow()
+    {
+        var rec = CreateHandle();
+        rec.ALSetFilter(DataError.ThrowError, 2, NavType.Text, "<>''");
+    }
+
+    // -----------------------------------------------------------------------
+    // ALModifyAllSafe DataError overloads
+    // -----------------------------------------------------------------------
+
+    private MockRecordHandle CreateHandleForModifyAll(int tableId)
+    {
+        var handle = new MockRecordHandle(tableId);
+        MockRecordHandle.RegisterPrimaryKey(tableId, 1);
+        MockRecordHandle.RegisterFieldName(tableId, "EntryNo", 1);
+        MockRecordHandle.RegisterFieldName(tableId, "Name", 2);
+        return handle;
+    }
+
+    [Fact]
+    public void ALModifyAllSafe_DataError_3arg_UpdatesValue()
+    {
+        var rec = CreateHandleForModifyAll(99901);
+        rec.SetFieldValueSafe(1, NavType.Integer, NavInteger.Default);
+        rec.SetFieldValueSafe(2, NavType.Text, new NavText("original"));
+        rec.ALInsert(DataError.ThrowError);
+
+        rec.ALModifyAllSafe(DataError.ThrowError, 2, NavType.Text, new NavText("updated"));
+
+        rec.ALFindFirst();
+        var result = rec.GetFieldValueSafe(2, NavType.Text);
+        Assert.Equal("updated", ((NavText)result).Value);
+    }
+
+    [Fact]
+    public void ALModifyAllSafe_DataError_4arg_UpdatesValue()
+    {
+        var rec = CreateHandleForModifyAll(99902);
+        rec.SetFieldValueSafe(1, NavType.Integer, NavInteger.Default);
+        rec.SetFieldValueSafe(2, NavType.Text, new NavText("original"));
+        rec.ALInsert(DataError.ThrowError);
+
+        rec.ALModifyAllSafe(DataError.ThrowError, 2, NavType.Text, new NavText("triggered"), false);
+
+        rec.ALFindFirst();
+        var result = rec.GetFieldValueSafe(2, NavType.Text);
+        Assert.Equal("triggered", ((NavText)result).Value);
+    }
+}

--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -662,9 +662,14 @@ public class RoslynRewriter : CSharpSyntaxRewriter
             var delegatingCode = @"
 public NavValue GetFieldValueSafe(int fieldNo, NavType expectedType) => Rec.GetFieldValueSafe(fieldNo, expectedType);
 public NavValue GetFieldValueSafe(int fieldNo, NavType expectedType, bool useLocale) => Rec.GetFieldValueSafe(fieldNo, expectedType, useLocale);
+public NavValue GetFieldValueSafe(DataError errorLevel, int fieldNo, NavType expectedType) => Rec.GetFieldValueSafe(fieldNo, expectedType);
+public NavValue GetFieldValueSafe(DataError errorLevel, int fieldNo, NavType expectedType, bool useLocale) => Rec.GetFieldValueSafe(fieldNo, expectedType, useLocale);
 public void SetFieldValueSafe(int fieldNo, NavType expectedType, NavValue value) => Rec.SetFieldValueSafe(fieldNo, expectedType, value);
 public void SetFieldValueSafe(int fieldNo, NavType expectedType, NavValue value, bool validate) => Rec.SetFieldValueSafe(fieldNo, expectedType, value, validate);
+public void SetFieldValueSafe(DataError errorLevel, int fieldNo, NavType expectedType, NavValue value) => Rec.SetFieldValueSafe(fieldNo, expectedType, value);
+public void SetFieldValueSafe(DataError errorLevel, int fieldNo, NavType expectedType, NavValue value, bool validate) => Rec.SetFieldValueSafe(fieldNo, expectedType, value, validate);
 public NavValue GetFieldRefSafe(int fieldNo, NavType expectedType) => Rec.GetFieldRefSafe(fieldNo, expectedType);
+public NavValue GetFieldRefSafe(DataError errorLevel, int fieldNo, NavType expectedType) => Rec.GetFieldRefSafe(fieldNo, expectedType);
 public bool ALInsert(DataError errorLevel) => Rec.ALInsert(errorLevel);
 public bool ALInsert(DataError errorLevel, bool runTrigger) => Rec.ALInsert(errorLevel, runTrigger);
 public bool ALModify(DataError errorLevel) => Rec.ALModify(errorLevel);
@@ -688,8 +693,13 @@ public void ALSetRange(int fieldNo, NavType expectedType, NavValue fromValue, Na
 public void ALSetRangeSafe(int fieldNo, NavType expectedType) => Rec.ALSetRangeSafe(fieldNo, expectedType);
 public void ALSetRangeSafe(int fieldNo, NavType expectedType, NavValue value) => Rec.ALSetRangeSafe(fieldNo, expectedType, value);
 public void ALSetRangeSafe(int fieldNo, NavType expectedType, NavValue fromValue, NavValue toValue) => Rec.ALSetRangeSafe(fieldNo, expectedType, fromValue, toValue);
+public void ALSetRangeSafe(DataError errorLevel, int fieldNo, NavType expectedType) => Rec.ALSetRangeSafe(fieldNo, expectedType);
+public void ALSetRangeSafe(DataError errorLevel, int fieldNo, NavType expectedType, NavValue value) => Rec.ALSetRangeSafe(fieldNo, expectedType, value);
+public void ALSetRangeSafe(DataError errorLevel, int fieldNo, NavType expectedType, NavValue fromValue, NavValue toValue) => Rec.ALSetRangeSafe(fieldNo, expectedType, fromValue, toValue);
 public void ALSetFilter(int fieldNo, string filterExpression, params NavValue[] args) => Rec.ALSetFilter(fieldNo, filterExpression, args);
 public void ALSetFilter(int fieldNo, NavType expectedType, string filterExpression, params NavValue[] args) => Rec.ALSetFilter(fieldNo, expectedType, filterExpression, args);
+public void ALSetFilter(DataError errorLevel, int fieldNo, string filterExpression, params NavValue[] args) => Rec.ALSetFilter(fieldNo, filterExpression, args);
+public void ALSetFilter(DataError errorLevel, int fieldNo, NavType expectedType, string filterExpression, params NavValue[] args) => Rec.ALSetFilter(fieldNo, expectedType, filterExpression, args);
 public void ALCopy(MockRecordHandle source, bool shareFilters = false) => Rec.ALCopy(source, shareFilters);
 public void ALCopyFilter(int fromFieldNo, MockRecordHandle target) => Rec.ALCopyFilter(fromFieldNo, target);
 public void ALCopyFilter(int fromFieldNo, MockRecordHandle target, int toFieldNo) => Rec.ALCopyFilter(fromFieldNo, target, toFieldNo);

--- a/AlRunner/Runtime/MockRecordHandle.cs
+++ b/AlRunner/Runtime/MockRecordHandle.cs
@@ -430,6 +430,14 @@ public class MockRecordHandle : IConvertible
         SetFieldValueSafe(fieldNo, expectedType, value, validate);
     }
 
+    /// <summary>DataError-prefixed overload — BC compiler may prepend DataError to field assignment calls.</summary>
+    public void SetFieldValueSafe(DataError errorLevel, int fieldNo, NavType expectedType, NavValue value)
+        => SetFieldValueSafe(fieldNo, expectedType, value);
+
+    /// <summary>DataError-prefixed overload with validate flag.</summary>
+    public void SetFieldValueSafe(DataError errorLevel, int fieldNo, NavType expectedType, NavValue value, bool validate)
+        => SetFieldValueSafe(fieldNo, expectedType, value, validate);
+
     public NavValue GetFieldValueSafe(int fieldNo, NavType expectedType)
     {
         if (_fields.TryGetValue(fieldNo, out var val))
@@ -513,6 +521,18 @@ public class MockRecordHandle : IConvertible
     {
         return GetFieldValueSafe(fieldNo, expectedType);
     }
+
+    /// <summary>DataError-prefixed overload — BC compiler may prepend DataError to field read calls.</summary>
+    public NavValue GetFieldValueSafe(DataError errorLevel, int fieldNo, NavType expectedType)
+        => GetFieldValueSafe(fieldNo, expectedType);
+
+    /// <summary>DataError-prefixed overload with locale flag.</summary>
+    public NavValue GetFieldValueSafe(DataError errorLevel, int fieldNo, NavType expectedType, bool useLocale)
+        => GetFieldValueSafe(fieldNo, expectedType, useLocale);
+
+    /// <summary>DataError-prefixed GetFieldRefSafe overload.</summary>
+    public NavValue GetFieldRefSafe(DataError errorLevel, int fieldNo, NavType expectedType)
+        => GetFieldRefSafe(fieldNo, expectedType);
 
     public void Clear()
     {
@@ -852,6 +872,14 @@ public class MockRecordHandle : IConvertible
         }
     }
 
+    /// <summary>DataError-prefixed overload — BC compiler may prepend DataError to ModifyAll calls.</summary>
+    public void ALModifyAllSafe(DataError errorLevel, int fieldNo, NavType expectedType, NavValue value)
+        => ALModifyAllSafe(fieldNo, expectedType, value);
+
+    /// <summary>DataError-prefixed overload with runTrigger flag.</summary>
+    public void ALModifyAllSafe(DataError errorLevel, int fieldNo, NavType expectedType, NavValue value, bool runTrigger)
+        => ALModifyAllSafe(fieldNo, expectedType, value, runTrigger);
+
     public bool ALGet(DataError errorLevel, params NavValue[] keyValues)
     {
         var table = GetRows();
@@ -1168,6 +1196,18 @@ public class MockRecordHandle : IConvertible
         ALSetRange(fieldNo, expectedType, fromValue, toValue);
     }
 
+    /// <summary>DataError-prefixed overload — clear range.</summary>
+    public void ALSetRangeSafe(DataError errorLevel, int fieldNo, NavType expectedType)
+        => ALSetRangeSafe(fieldNo, expectedType);
+
+    /// <summary>DataError-prefixed overload — single value range.</summary>
+    public void ALSetRangeSafe(DataError errorLevel, int fieldNo, NavType expectedType, NavValue value)
+        => ALSetRangeSafe(fieldNo, expectedType, value);
+
+    /// <summary>DataError-prefixed overload — from/to range.</summary>
+    public void ALSetRangeSafe(DataError errorLevel, int fieldNo, NavType expectedType, NavValue fromValue, NavValue toValue)
+        => ALSetRangeSafe(fieldNo, expectedType, fromValue, toValue);
+
     // -----------------------------------------------------------------------
     // SetFilter — expression-based filtering
     // -----------------------------------------------------------------------
@@ -1204,6 +1244,14 @@ public class MockRecordHandle : IConvertible
             IsRangeFilter = false,
         };
     }
+
+    /// <summary>DataError-prefixed overload — BC compiler may prepend DataError to SetFilter calls.</summary>
+    public void ALSetFilter(DataError errorLevel, int fieldNo, string filterExpression, params NavValue[] args)
+        => ALSetFilter(fieldNo, filterExpression, args);
+
+    /// <summary>DataError-prefixed overload with NavType.</summary>
+    public void ALSetFilter(DataError errorLevel, int fieldNo, NavType expectedType, string filterExpression, params NavValue[] args)
+        => ALSetFilter(fieldNo, expectedType, filterExpression, args);
 
     // -----------------------------------------------------------------------
     // SetCurrentKey — set sort key (with DataError first param)

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -7385,7 +7385,7 @@ Table.ModifyAll:
   status: covered
   tests:
     - tests/bucket-1/30-modify-all
-  notes: overloads=1; bulk-sets a field value on all filtered records
+  notes: overloads=4; ALModifyAllSafe(fieldNo, NavType, value[, runTrigger]) plus DataError-prefixed overloads for each (issue #1267).
 
 Table.Next:
   layer: runtime-api
@@ -7495,7 +7495,7 @@ Table.SetFilter:
   layer: runtime-api
   category: Table
   status: covered
-  notes: overloads=2; ALSetFilter(fieldNo, filterExpression, params NavValue[] args) stores filter expression for use in Find/Count.
+  notes: overloads=4; ALSetFilter(fieldNo, expr, args), ALSetFilter(fieldNo, NavType, expr, args), plus DataError-prefixed overloads for each (issue #1267).
   tests:
     - tests/bucket-1/188-table-crud
     - tests/bucket-1/09-setfilter-expressions
@@ -7526,7 +7526,7 @@ Table.SetRange:
   layer: runtime-api
   category: Table
   status: covered
-  notes: overloads=3; ALSetRange(fieldNo, type) clears range, ALSetRange(fieldNo, type, value) sets equality, ALSetRange(fieldNo, type, from, to) sets range filter.
+  notes: overloads=6; ALSetRange/ALSetRangeSafe (clear/single/range) plus DataError-prefixed overloads for each (issue #1267).
   tests:
     - tests/bucket-1/188-table-crud
     - tests/bucket-1/240-setrange-clear


### PR DESCRIPTION
Closes #1267

## Summary
- Added DataError-prefixed overloads for `SetFieldValueSafe`, `GetFieldValueSafe`, `GetFieldRefSafe`, `ALSetRangeSafe`, `ALSetFilter`, and `ALModifyAllSafe` on `MockRecordHandle`
- Added corresponding proxy overloads in `RoslynRewriter` delegating code for record classes
- All overloads ignore the DataError parameter and delegate to the existing implementation

## Test plan
- [x] 12 C# unit tests in `DataErrorToIntOverloadTests.cs` covering all new overloads
- [x] Tests verify both compilation (method exists) and behavior (values are correctly set/read through DataError overloads)
- [x] All 366 existing tests pass across net8.0/net9.0/net10.0
- [x] All AL test buckets pass