### PR TITLE
fix: implicit int→MockFieldRef conversion for BC-emitted field numbers

### DIFF
--- a/AlRunner/Runtime/MockFieldRef.cs
+++ b/AlRunner/Runtime/MockFieldRef.cs
@@ -399,6 +399,20 @@ public class MockFieldRef
     /// <summary>Static Default factory — mirrors NavFieldRef.Default(ITreeObject).</summary>
     public static MockFieldRef Default() => new MockFieldRef();
 
+    /// <summary>
+    /// Implicit conversion from int (field number) to MockFieldRef.
+    /// The BC compiler sometimes emits an int (from ALFieldNo) where a MockFieldRef
+    /// parameter is expected — e.g. FilterPageBuilder.AddFieldNo in AL compiles to
+    /// ALAddField(DataError, NavText, int) but MockFilterPageBuilder.ALAddField
+    /// expects MockFieldRef. This operator lets the C# compiler auto-convert.
+    /// </summary>
+    public static implicit operator MockFieldRef(int fieldNo)
+    {
+        var fr = new MockFieldRef();
+        fr._fieldNo = fieldNo;
+        return fr;
+    }
+
     // -- Internal helpers --
 
     // Cached PropertyInfo for NavDecimal.Value — resolved once at type-init,

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -2538,6 +2538,15 @@ ErrorInfo.Verbosity:
 
 # ── FieldRef ────────────────────────────────────────────────────
 
+FieldRef (implicit int conversion):
+  layer: runtime-api
+  category: FieldRef
+  status: covered
+  notes: >
+    implicit operator MockFieldRef(int) — BC compiler sometimes emits int (field number)
+    where MockFieldRef is expected (e.g. FilterPageBuilder.AddFieldNo). Issue #1277.
+  tests: tests/bucket-2/96-fpb-addfieldno
+
 FieldRef.Active:
   layer: runtime-api
   category: FieldRef
@@ -2979,8 +2988,13 @@ FilterPageBuilder.AddFieldNo:
   layer: runtime-api
   category: FilterPageBuilder
   status: covered
-  notes: overloads=1; MockFilterPageBuilder
-  tests: tests/bucket-2/179-filter-page-builder
+  notes: >
+    overloads=1; MockFilterPageBuilder. BC compiler emits ALAddField(DataError, NavText, int)
+    for the AL AddFieldNo call — the int (field number) is passed where MockFieldRef is expected.
+    Fixed via implicit operator MockFieldRef(int) on MockFieldRef (issue #1277).
+  tests:
+    - tests/bucket-2/179-filter-page-builder
+    - tests/bucket-2/96-fpb-addfieldno
 
 FilterPageBuilder.AddRecord:
   layer: runtime-api

--- a/tests/bucket-2/96-fpb-addfieldno/src/FPBFieldNoSrc.al
+++ b/tests/bucket-2/96-fpb-addfieldno/src/FPBFieldNoSrc.al
@@ -1,0 +1,13 @@
+codeunit 305000 "FPB FieldNo Src"
+{
+    /// AddFieldNo with name, table name, and field number.
+    /// This matches the telemetry pattern: AddFieldNo(TableName(), FieldNo("..."))
+    procedure AddFieldNoAndGetCount(): Integer
+    var
+        Rec: Record "FPB FieldNo Table";
+        FPB: FilterPageBuilder;
+    begin
+        FPB.AddFieldNo(Rec.TableName(), Rec.FieldNo("Task No."));
+        exit(FPB.Count);
+    end;
+}

--- a/tests/bucket-2/96-fpb-addfieldno/src/FPBFieldNoTable.al
+++ b/tests/bucket-2/96-fpb-addfieldno/src/FPBFieldNoTable.al
@@ -1,0 +1,16 @@
+table 305000 "FPB FieldNo Table"
+{
+    DataClassification = ToBeClassified;
+
+    fields
+    {
+        field(1; "Entry No."; Integer) { }
+        field(2; "Task No."; Code[20]) { }
+        field(3; "Description"; Text[100]) { }
+    }
+
+    keys
+    {
+        key(PK; "Entry No.") { Clustered = true; }
+    }
+}

--- a/tests/bucket-2/96-fpb-addfieldno/test/FPBFieldNoTest.al
+++ b/tests/bucket-2/96-fpb-addfieldno/test/FPBFieldNoTest.al
@@ -1,0 +1,20 @@
+codeunit 305001 "FPB FieldNo Test"
+{
+    Subtype = Test;
+
+    [Test]
+    procedure AddFieldNo_Compiles_CountIsOne()
+    var
+        Src: Codeunit "FPB FieldNo Src";
+        Result: Integer;
+    begin
+        // [SCENARIO] FilterPageBuilder.AddFieldNo compiles and runs when FieldNo (int) is passed
+        // [WHEN] We call AddFieldNo with table ID and field number
+        Result := Src.AddFieldNoAndGetCount();
+        // [THEN] One entry is registered
+        Assert.AreEqual(1, Result, 'Count should be 1 after AddFieldNo');
+    end;
+
+    var
+        Assert: Codeunit "Library Assert";
+}


### PR DESCRIPTION
Closes #1277

## Summary
- Add `implicit operator MockFieldRef(int)` to `MockFieldRef` so that when the BC compiler emits an `int` (field number from `ALFieldNo`) where `MockFieldRef` is expected, C# auto-converts it
- The BC compiler translates `FilterPageBuilder.AddFieldNo(TableName, FieldNo)` to `ALAddField(DataError, NavText, int)`, but `MockFilterPageBuilder.ALAddField` expects `MockFieldRef` — this caused CS1503
- Added test suite `96-fpb-addfieldno` proving the fix with a positive assertion (count = 1 after AddFieldNo)

## Test plan
- [x] RED: confirmed CS1503 compilation error before fix
- [x] GREEN: test passes after adding implicit operator
- [x] bucket-1 and bucket-2 full regression — no new failures