### PR TITLE
fix: rewrite Page<N>.PromptMode static self-reference — closes #1266

### DIFF
--- a/AlRunner.Tests/PagePromptModeRewriterTests.cs
+++ b/AlRunner.Tests/PagePromptModeRewriterTests.cs
@@ -1,0 +1,140 @@
+using AlRunner;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// Tests for issue #1266 — CS0120 on Page&lt;N&gt;.PromptMode static self-reference.
+///
+/// BC emits CurrPage.PromptMode inside a PromptDialog page as a static reference:
+///   Page71116155.PromptMode  (the enclosing page class name, not an instance reference).
+///
+/// Because the rewriter strips the NavForm base class and injects PromptMode as an
+/// instance property, the static access causes CS0120. The fix rewrites
+///   Page&lt;N&gt;.PromptMode → this.PromptMode
+/// when the access is inside the matching page class.
+/// </summary>
+public class PagePromptModeRewriterTests
+{
+    // Minimal BC-style C# that simulates a page class extending NavForm.
+    // The rewriter strips NavForm, injects PromptMode as instance, and must
+    // rewrite static self-references to instance references.
+    private static string WrapInPageClass(string body, string className = "Page71116155") => $$"""
+        namespace Microsoft.Dynamics.Nav.BusinessApplication
+        {
+            using AlRunner.Runtime;
+            using Microsoft.Dynamics.Nav.Runtime;
+            class {{className}} : NavForm {
+                void OnInit() {
+                    {{body}}
+                }
+            }
+        }
+        """;
+
+    // ─── Positive: static PromptMode → this.PromptMode ───────────────────
+
+    /// <summary>
+    /// Positive: Page&lt;N&gt;.PromptMode (get) inside the page class is rewritten
+    /// to this.PromptMode so it compiles as an instance access.
+    /// </summary>
+    [Fact]
+    public void PromptMode_StaticGet_RewrittenToThis()
+    {
+        var input = WrapInPageClass("var pm = Page71116155.PromptMode;");
+        var output = RoslynRewriter.Rewrite(input);
+
+        Assert.Contains("this.PromptMode", output);
+        Assert.DoesNotContain("Page71116155.PromptMode", output);
+    }
+
+    /// <summary>
+    /// Positive: Page&lt;N&gt;.PromptMode (set) inside the page class is rewritten
+    /// to this.PromptMode so the assignment compiles.
+    /// </summary>
+    [Fact]
+    public void PromptMode_StaticSet_RewrittenToThis()
+    {
+        var input = WrapInPageClass("Page71116155.PromptMode = null;");
+        var output = RoslynRewriter.Rewrite(input);
+
+        Assert.Contains("this.PromptMode", output);
+        Assert.DoesNotContain("Page71116155.PromptMode", output);
+    }
+
+    /// <summary>
+    /// Positive: works with a different page ID — the rule is not hard-coded
+    /// to a specific page number.
+    /// </summary>
+    [Fact]
+    public void PromptMode_DifferentPageId_RewrittenToThis()
+    {
+        var input = WrapInPageClass(
+            "var pm = Page99999.PromptMode;", "Page99999");
+        var output = RoslynRewriter.Rewrite(input);
+
+        Assert.Contains("this.PromptMode", output);
+        Assert.DoesNotContain("Page99999.PromptMode", output);
+    }
+
+    // ─── Negative: non-matching patterns are NOT affected ─────────────────
+
+    /// <summary>
+    /// Negative: a reference to a DIFFERENT page class (not the enclosing one)
+    /// is not rewritten. Only self-references are converted to this.
+    /// </summary>
+    [Fact]
+    public void PromptMode_DifferentPageClass_NotRewritten()
+    {
+        // Inside Page71116155, referencing Page99999.PromptMode should NOT be rewritten.
+        var input = WrapInPageClass("var pm = Page99999.PromptMode;");
+        var output = RoslynRewriter.Rewrite(input);
+
+        // The reference to Page99999 should remain (though PromptMode is not
+        // defined on it, that's a separate compilation concern — the rewriter
+        // must not touch cross-class references).
+        Assert.DoesNotContain("this.PromptMode", output);
+    }
+
+    /// <summary>
+    /// Negative: accessing a DIFFERENT member via PageNNN.X should not be
+    /// affected by the PromptMode rule.
+    /// </summary>
+    [Fact]
+    public void OtherMember_StaticAccess_NotRewrittenByPromptModeRule()
+    {
+        // Page71116155.SomeOtherProp should not be touched by the PromptMode rule.
+        // (Other rewriter rules may handle it, but the PromptMode-specific rule must not.)
+        var input = WrapInPageClass("var x = Page71116155.SomeOtherProp;");
+        var output = RoslynRewriter.Rewrite(input);
+
+        // The PromptMode rule should NOT have injected "this" for SomeOtherProp.
+        // (The original text may be modified by other rewriter rules, but we check
+        // that "this.SomeOtherProp" specifically does not appear.)
+        Assert.DoesNotContain("this.SomeOtherProp", output);
+    }
+
+    /// <summary>
+    /// Negative: in a non-page class (e.g. a codeunit), Page&lt;N&gt;.PromptMode
+    /// is not rewritten because _currentPageClassName is not set.
+    /// </summary>
+    [Fact]
+    public void PromptMode_InCodeunitClass_NotRewritten()
+    {
+        var input = """
+            namespace Microsoft.Dynamics.Nav.BusinessApplication
+            {
+                using AlRunner.Runtime;
+                using Microsoft.Dynamics.Nav.Runtime;
+                class Codeunit50000 : NavCodeunit {
+                    void M() {
+                        var pm = Page71116155.PromptMode;
+                    }
+                }
+            }
+            """;
+        var output = RoslynRewriter.Rewrite(input);
+
+        Assert.DoesNotContain("this.PromptMode", output);
+    }
+}

--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -16,6 +16,11 @@ public class RoslynRewriter : CSharpSyntaxRewriter
     // VisitPropertyDeclaration can extract the table ID for Rec/xRec properties.
     private string? _currentClassName;
 
+    // Track the current page class name so that VisitMemberAccessExpression can
+    // rewrite Page<N>.PromptMode (static self-reference) → this.PromptMode.
+    // BC emits CurrPage.PromptMode as a static reference on the page class (issue #1266).
+    private string? _currentPageClassName;
+
     private static readonly HashSet<string> BcAttributeNames = new(StringComparer.Ordinal)
     {
         "NavCodeunitOptions",
@@ -512,6 +517,11 @@ public class RoslynRewriter : CSharpSyntaxRewriter
         if (isRecordClass)
             _currentClassName = node.Identifier.Text;
 
+        // Track page class name for static self-reference rewriting (issue #1266).
+        var previousPageClassName = _currentPageClassName;
+        if (isPageClass)
+            _currentPageClassName = node.Identifier.Text;
+
         // First, visit children recursively
         var visited = (ClassDeclarationSyntax)base.VisitClassDeclaration(node)!;
 
@@ -905,6 +915,7 @@ public void Unbind() { AlRunner.Runtime.EventSubscriberRegistry.Unbind(this); }
 
         // Restore previous class name context
         _currentClassName = previousClassName;
+        _currentPageClassName = previousPageClassName;
 
         return visited;
     }
@@ -4241,6 +4252,18 @@ public void Unbind() { AlRunner.Runtime.EventSubscriberRegistry.Unbind(this); }
         // ParentObject is rewritten to return Rec, so we just replace base with this.
         if (visited.Name.Identifier.Text == "ParentObject" &&
             visited.Expression is BaseExpressionSyntax)
+        {
+            return visited.WithExpression(SyntaxFactory.ThisExpression());
+        }
+
+        // Pattern: Page<N>.PromptMode → this.PromptMode (issue #1266)
+        // BC emits CurrPage.PromptMode as a static reference on the enclosing page class:
+        //   Page71116155.PromptMode  (CS0120 because PromptMode is an instance property).
+        // Rewrite to this.PromptMode when inside the matching page class.
+        if (_currentPageClassName != null &&
+            visited.Expression is IdentifierNameSyntax pageId &&
+            pageId.Identifier.Text == _currentPageClassName &&
+            visited.Name.Identifier.Text == "PromptMode")
         {
             return visited.WithExpression(SyntaxFactory.ThisExpression());
         }

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -4931,7 +4931,7 @@ Page.PromptMode:
   category: Page
   status: covered
   tests: tests/bucket-1/100-page-promptmode
-  notes: overloads=1; MockCurrPage.PromptMode and MockFormHandle.PromptMode NavOption stubs; also injected on Page<N> class for CurrPage.PromptMode access inside page triggers (issue #1079)
+  notes: overloads=1; MockCurrPage.PromptMode and MockFormHandle.PromptMode NavOption stubs; injected on Page<N> class for CurrPage.PromptMode access inside page triggers (issue #1079); RoslynRewriter converts static self-reference Page<N>.PromptMode → this.PromptMode to fix CS0120 (issue #1266)
 
 Page.NavFormImplicitConversion:
   layer: runtime-api

--- a/tests/bucket-1/100-page-promptmode/test/PromptModeTest.al
+++ b/tests/bucket-1/100-page-promptmode/test/PromptModeTest.al
@@ -1,6 +1,11 @@
 /// Tests for MockCurrPage.PromptMode and MockFormHandle.PromptMode stubs.
 /// If either mock is missing PromptMode, Roslyn compilation of the rewritten C#
 /// fails with CS1061 and ALL tests in this bucket become RED.
+///
+/// Issue #1266: BC emits Page<N>.PromptMode as a static self-reference inside
+/// PromptDialog pages. The RoslynRewriter converts this to this.PromptMode.
+/// (Cannot test with AL here — PromptDialog PageType not supported by local compiler.
+/// See AlRunner.Tests/PagePromptModeRewriterTests.cs for the C# rewriter tests.)
 codeunit 113003 "PM Test"
 {
     Subtype = Test;


### PR DESCRIPTION
Closes #1266

## Summary
- BC emits `CurrPage.PromptMode` inside PromptDialog pages as a static reference `Page<N>.PromptMode`, causing CS0120 because the injected `PromptMode` is an instance property.
- Added `_currentPageClassName` tracking in the RoslynRewriter to detect when we're inside a page class.
- New rewrite rule converts `Page<N>.PromptMode` → `this.PromptMode` when the reference matches the enclosing page class.
- 6 C# unit tests (3 positive, 3 negative) verify the rewrite fires correctly and does not affect cross-class references, non-PromptMode members, or non-page classes.

## Test plan
- [x] RED: 3 positive tests fail without the fix (static reference not rewritten)
- [x] GREEN: all 6 tests pass with the fix
- [x] Full test suite passes (372 C# tests, bucket-1 and bucket-3 AL tests)
- [x] coverage.yaml updated