### PR TITLE
fix: route CalcDate through AlCompat to avoid NavNCLDateInvalidException

### DIFF
--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -3120,15 +3120,18 @@ public void Unbind() { AlRunner.Runtime.EventSubscriberRegistry.Unbind(this); }
             // ALSystemDate.ALVariant2Time(session, v) → AlCompat.Variant2Time(v)
             // ALSystemDate.ALDaTi2Variant(scope, d, t) → AlCompat.DaTi2Variant(d, t)
             // ALSystemDate.ALCreateDateTime(session, d, t) → AlCompat.CreateDateTime(d, t)
+            // ALSystemDate.ALCalcDate(session, formula, date) → AlCompat.CalcDate(formula, date)
             // Strip the first (session/scope) arg; these are pure date-arithmetic operations.
             // ALVariant2Date/Time require interception because v is MockVariant, not NavVariant.
             // ALDaTi2Variant requires interception because scope is AlScope, not NavMethodScope.
             // ALCreateDateTime is intercepted so the runner can apply the local-wall-clock
             // → UTC conversion BC's read path (ALDT2Time / ALDT2Date) expects. Without it,
             // DT2Time(CreateDateTime(D, T)) != T on any non-UTC host (issue #1159).
+            // ALCalcDate is intercepted because the BC runtime throws
+            // NavNCLDateInvalidException when the session is null on some platforms (issue #1258).
             if (exprText == "ALSystemDate" && methodName is "ALDMY2Date" or "ALDWY2Date"
                     or "ALVariant2Date" or "ALVariant2Time" or "ALDaTi2Variant"
-                    or "ALCreateDateTime")
+                    or "ALCreateDateTime" or "ALCalcDate")
             {
                 var args = visited.ArgumentList.Arguments;
                 var compatName = methodName switch
@@ -3139,6 +3142,7 @@ public void Unbind() { AlRunner.Runtime.EventSubscriberRegistry.Unbind(this); }
                     "ALVariant2Time" => "Variant2Time",
                     "ALDaTi2Variant" => "DaTi2Variant",
                     "ALCreateDateTime" => "CreateDateTime",
+                    "ALCalcDate" => "CalcDate",
                     _ => methodName
                 };
                 // Strip first arg (session/scope), keep the rest

--- a/AlRunner/Runtime/AlScope.cs
+++ b/AlRunner/Runtime/AlScope.cs
@@ -2491,6 +2491,181 @@ public static class AlCompat
     }
 
     /// <summary>
+    /// CalcDate(formula, date) — wraps ALSystemDate.ALCalcDate with null-session handling.
+    /// BC runtime throws NavNCLDateInvalidException when the session is null on some
+    /// platforms (Windows). We try the real BC call first, then fall back to .NET date
+    /// arithmetic if it throws. String-formula overload.
+    /// </summary>
+    public static NavDate CalcDate(string formula, NavDate date)
+    {
+        if (date == NavDate.Default)
+            throw new Exception("You cannot base a date calculation on an undefined date.\n\nDate: 0D\nFormula: " + (formula ?? "") + ".");
+        try
+        {
+            return ALSystemDate.ALCalcDate(null!, formula, date);
+        }
+        catch (Exception ex) when (ex.GetType().Name.Contains("NavNCL") || ex is NullReferenceException)
+        {
+            return CalcDateFallback(formula, date);
+        }
+    }
+
+    /// <summary>
+    /// CalcDate(formula, date) — DateFormula overload.
+    /// Extracts the formula string from NavDateFormula and delegates to the string overload.
+    /// </summary>
+    public static NavDate CalcDate(NavDateFormula formula, NavDate date)
+    {
+        if (date == NavDate.Default)
+            throw new Exception("You cannot base a date calculation on an undefined date.\n\nDate: 0D\nFormula: " + (formula?.ToString() ?? "") + ".");
+        try
+        {
+            return ALSystemDate.ALCalcDate(null!, formula, date);
+        }
+        catch (Exception ex) when (ex.GetType().Name.Contains("NavNCL") || ex is NullReferenceException)
+        {
+            // Extract the formula string from NavDateFormula via its ToString()
+            var formulaStr = formula.ToString() ?? "";
+            // NavDateFormula.ToString() may not include angle brackets; ensure they are present
+            if (!string.IsNullOrEmpty(formulaStr) && !formulaStr.StartsWith("<"))
+                formulaStr = "<" + formulaStr + ">";
+            return CalcDateFallback(formulaStr, date);
+        }
+    }
+
+    /// <summary>
+    /// Fallback CalcDate implementation using .NET date arithmetic.
+    /// Parses common BC date formula patterns: +/-NnD, +/-NnW, +/-NnM, +/-NnQ, +/-NnY,
+    /// CD, CW, CM, CQ, CY, and combinations thereof.
+    /// </summary>
+    private static NavDate CalcDateFallback(string formula, NavDate date)
+    {
+        if (date == NavDate.Default)
+            throw new Exception("You cannot base a date calculation on an undefined date.");
+
+        var dateVal = NavDateValueField is null ? DateTime.MinValue
+            : (NavDateValueField.GetValue(date) as DateTime?) ?? DateTime.MinValue;
+
+        if (dateVal == DateTime.MinValue)
+            throw new Exception("You cannot base a date calculation on an undefined date.");
+
+        // Strip angle brackets if present
+        var f = formula.Trim();
+        if (f.StartsWith("<") && f.EndsWith(">"))
+            f = f.Substring(1, f.Length - 2);
+
+        var result = ApplyDateFormula(f, dateVal);
+        return NavDate.Create((uint)((result.Year * 10000) + (result.Month * 100) + result.Day));
+    }
+
+    /// <summary>
+    /// Parse and apply a date formula string (without angle brackets) to a DateTime.
+    /// Supports: [+/-]N{D|W|M|Q|Y}, C{D|W|M|Q|Y}, and combinations.
+    /// </summary>
+    private static DateTime ApplyDateFormula(string formula, DateTime baseDate)
+    {
+        var result = baseDate;
+        int i = 0;
+        while (i < formula.Length)
+        {
+            if (formula[i] == ' ') { i++; continue; }
+
+            // Parse sign
+            int sign = 1;
+            if (i < formula.Length && (formula[i] == '+' || formula[i] == '-'))
+            {
+                if (formula[i] == '-') sign = -1;
+                i++;
+            }
+
+            // Check for 'C' prefix (Current period)
+            // In BC: CM/CW/CQ/CY = end of current period, -CM/-CW/-CQ/-CY = start of current period.
+            if (i < formula.Length && (formula[i] == 'C' || formula[i] == 'c'))
+            {
+                i++;
+                if (i < formula.Length)
+                {
+                    char unit = char.ToUpper(formula[i]);
+                    i++;
+                    // ISO day: Mon=0 … Sun=6
+                    int isoDay = ((int)result.DayOfWeek + 6) % 7;
+                    if (sign < 0)
+                    {
+                        // Beginning of period (ISO week starts on Monday)
+                        result = unit switch
+                        {
+                            'D' => result,
+                            'W' => result.AddDays(-isoDay),
+                            'M' => new DateTime(result.Year, result.Month, 1),
+                            'Q' => GetQuarterStart(result),
+                            'Y' => new DateTime(result.Year, 1, 1),
+                            _ => result
+                        };
+                    }
+                    else
+                    {
+                        // End of period (ISO week ends on Sunday)
+                        result = unit switch
+                        {
+                            'D' => result,
+                            'W' => result.AddDays(6 - isoDay),
+                            'M' => new DateTime(result.Year, result.Month,
+                                        DateTime.DaysInMonth(result.Year, result.Month)),
+                            'Q' => GetQuarterEnd(result),
+                            'Y' => new DateTime(result.Year, 12, 31),
+                            _ => result
+                        };
+                    }
+                }
+                continue;
+            }
+
+            // Parse number
+            int number = 0;
+            bool hasNumber = false;
+            while (i < formula.Length && char.IsDigit(formula[i]))
+            {
+                number = number * 10 + (formula[i] - '0');
+                hasNumber = true;
+                i++;
+            }
+
+            if (!hasNumber) number = 1;
+
+            // Parse unit
+            if (i < formula.Length)
+            {
+                char unit = char.ToUpper(formula[i]);
+                i++;
+                int n = sign * number;
+                result = unit switch
+                {
+                    'D' => result.AddDays(n),
+                    'W' => result.AddDays(n * 7),
+                    'M' => result.AddMonths(n),
+                    'Q' => result.AddMonths(n * 3),
+                    'Y' => result.AddYears(n),
+                    _ => result
+                };
+            }
+        }
+        return result;
+    }
+
+    private static DateTime GetQuarterEnd(DateTime date)
+    {
+        int quarterMonth = ((date.Month - 1) / 3 + 1) * 3;
+        return new DateTime(date.Year, quarterMonth,
+            DateTime.DaysInMonth(date.Year, quarterMonth));
+    }
+
+    private static DateTime GetQuarterStart(DateTime date)
+    {
+        int quarterMonth = ((date.Month - 1) / 3) * 3 + 1;
+        return new DateTime(date.Year, quarterMonth, 1);
+    }
+
+    /// <summary>
     /// RoundDateTime(dt) — rounds to nearest 1000ms (default precision).
     /// </summary>
     public static NavDateTime RoundDateTime(NavDateTime dt)

--- a/AlRunner/Runtime/AlScope.cs
+++ b/AlRunner/Runtime/AlScope.cs
@@ -2496,6 +2496,10 @@ public static class AlCompat
     /// platforms (Windows). We try the real BC call first, then fall back to .NET date
     /// arithmetic if it throws. String-formula overload.
     /// </summary>
+    public static NavDate CalcDate(string formula) => CalcDate(formula, ALSystemDate.ALToday(null!));
+
+    public static NavDate CalcDate(NavDateFormula formula) => CalcDate(formula, ALSystemDate.ALToday(null!));
+
     public static NavDate CalcDate(string formula, NavDate date)
     {
         if (date == NavDate.Default)

--- a/AlRunner/Runtime/AlScope.cs
+++ b/AlRunner/Runtime/AlScope.cs
@@ -2496,9 +2496,9 @@ public static class AlCompat
     /// platforms (Windows). We try the real BC call first, then fall back to .NET date
     /// arithmetic if it throws. String-formula overload.
     /// </summary>
-    public static NavDate CalcDate(string formula) => CalcDate(formula, ALSystemDate.ALToday(null!));
+    public static NavDate CalcDate(string formula) => CalcDate(formula, NavDate.Create(DateTime.Today));
 
-    public static NavDate CalcDate(NavDateFormula formula) => CalcDate(formula, ALSystemDate.ALToday(null!));
+    public static NavDate CalcDate(NavDateFormula formula) => CalcDate(formula, NavDate.Create(DateTime.Today));
 
     public static NavDate CalcDate(string formula, NavDate date)
     {

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -6555,8 +6555,8 @@ System.CalcDate:
   layer: runtime-api
   category: System
   status: covered
-  tests: tests/bucket-2/181-calcdate
-  notes: overloads=2. Covered via BC's ALCalcDate — formula parsing (D/W/M/Y, compound, empty) and DateFormula-typed overload all pass through the SDK.
+  tests: tests/bucket-2/181-calcdate, tests/bucket-2/96-calcdate-navdateinvalid
+  notes: overloads=2. Routed through AlCompat.CalcDate which tries BC's ALCalcDate first and falls back to .NET date arithmetic when NavNCLDateInvalidException is thrown (issue #1258, Windows with null session).
 
 System.CanLoadType:
   layer: runtime-api

--- a/tests/bucket-2/96-calcdate-navdateinvalid/src/CalcDateHelper.al
+++ b/tests/bucket-2/96-calcdate-navdateinvalid/src/CalcDateHelper.al
@@ -1,0 +1,29 @@
+codeunit 304002 "CalcDate Helper"
+{
+    /// Reproduce the scenario from telemetry: take CurrentDateTime,
+    /// extract the date, CalcDate +7D on it, then CreateDateTime back.
+    procedure CalcNextReportDate(CurrentDT: DateTime; DaysToAdd: Integer): DateTime
+    var
+        d: Date;
+        t: Time;
+        df: DateFormula;
+    begin
+        d := DT2Date(CurrentDT);
+        t := DT2Time(CurrentDT);
+        Evaluate(df, StrSubstNo('<+%1D>', DaysToAdd));
+        d := CalcDate(df, d);
+        exit(CreateDateTime(d, t));
+    end;
+
+    /// CalcDate with a string formula (second overload).
+    procedure CalcNextReportDateStr(CurrentDT: DateTime; DaysToAdd: Integer): DateTime
+    var
+        d: Date;
+        t: Time;
+    begin
+        d := DT2Date(CurrentDT);
+        t := DT2Time(CurrentDT);
+        d := CalcDate(StrSubstNo('<+%1D>', DaysToAdd), d);
+        exit(CreateDateTime(d, t));
+    end;
+}

--- a/tests/bucket-2/96-calcdate-navdateinvalid/test/CalcDateHelperTest.al
+++ b/tests/bucket-2/96-calcdate-navdateinvalid/test/CalcDateHelperTest.al
@@ -1,0 +1,78 @@
+codeunit 304003 "CalcDate Helper Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit "Library Assert";
+        Helper: Codeunit "CalcDate Helper";
+
+    [Test]
+    procedure CalcDateFormulaAdd7Days()
+    var
+        BaseDT: DateTime;
+        ResultDT: DateTime;
+        ExpectedDate: Date;
+    begin
+        // Positive: CalcDate with DateFormula overload adds 7 days correctly
+        BaseDT := CreateDateTime(DMY2Date(15, 3, 2025), 120000T);
+        ResultDT := Helper.CalcNextReportDate(BaseDT, 7);
+        ExpectedDate := DMY2Date(22, 3, 2025);
+        Assert.AreEqual(ExpectedDate, DT2Date(ResultDT), 'Date should be 7 days later');
+        Assert.AreEqual(120000T, DT2Time(ResultDT), 'Time component should be preserved');
+    end;
+
+    [Test]
+    procedure CalcDateStringAdd7Days()
+    var
+        BaseDT: DateTime;
+        ResultDT: DateTime;
+        ExpectedDate: Date;
+    begin
+        // Positive: CalcDate with string overload adds 7 days correctly
+        BaseDT := CreateDateTime(DMY2Date(15, 3, 2025), 120000T);
+        ResultDT := Helper.CalcNextReportDateStr(BaseDT, 7);
+        ExpectedDate := DMY2Date(22, 3, 2025);
+        Assert.AreEqual(ExpectedDate, DT2Date(ResultDT), 'Date should be 7 days later');
+        Assert.AreEqual(120000T, DT2Time(ResultDT), 'Time component should be preserved');
+    end;
+
+    [Test]
+    procedure CalcDateFormulaAdd30Days()
+    var
+        BaseDT: DateTime;
+        ResultDT: DateTime;
+        ExpectedDate: Date;
+    begin
+        // Positive: CalcDate with DateFormula adds 30 days, crossing month boundary
+        BaseDT := CreateDateTime(DMY2Date(15, 3, 2025), 080000T);
+        ResultDT := Helper.CalcNextReportDate(BaseDT, 30);
+        ExpectedDate := DMY2Date(14, 4, 2025);
+        Assert.AreEqual(ExpectedDate, DT2Date(ResultDT), 'Date should be 30 days later');
+    end;
+
+    [Test]
+    procedure CalcDateFormulaFromCurrentDateTime()
+    var
+        BaseDT: DateTime;
+        ResultDT: DateTime;
+        BaseDate: Date;
+        ResultDate: Date;
+    begin
+        // Positive: CalcDate from CurrentDateTime (the telemetry scenario)
+        BaseDT := CurrentDateTime;
+        ResultDT := Helper.CalcNextReportDate(BaseDT, 7);
+        BaseDate := DT2Date(BaseDT);
+        ResultDate := DT2Date(ResultDT);
+        Assert.IsTrue(ResultDate > BaseDate, 'Result date must be after base date');
+    end;
+
+    [Test]
+    procedure CalcDateWithZeroDateThrows()
+    var
+        d: Date;
+    begin
+        // Negative: CalcDate on 0D should throw
+        asserterror d := CalcDate('<+7D>', 0D);
+        Assert.ExpectedError('undefined date');
+    end;
+}


### PR DESCRIPTION
Closes #1258

## Summary
- Intercept `ALSystemDate.ALCalcDate` in `RoslynRewriter` (both string and `NavDateFormula` overloads) and route through `AlCompat.CalcDate`
- `AlCompat.CalcDate` tries BC's `ALCalcDate` first, falls back to .NET date arithmetic when `NavNCLDateInvalidException` or `NullReferenceException` is thrown (Windows with null session)
- Fallback parser handles common date formula patterns: `+/-N{D|W|M|Q|Y}`, `C{D|W|M|Q|Y}`, and combinations
- Explicit `0D` guard throws the same BC error message

## Test plan
- [x] `CalcDateFormulaAdd7Days` — DateFormula overload adds 7 days, asserts specific date and preserved time
- [x] `CalcDateStringAdd7Days` — string overload adds 7 days, asserts specific date and preserved time
- [x] `CalcDateFormulaAdd30Days` — crosses month boundary (March 15 + 30 = April 14)
- [x] `CalcDateFormulaFromCurrentDateTime` — reproduces the telemetry scenario (CurrentDateTime + 7 days)
- [x] `CalcDateWithZeroDateThrows` — negative test: CalcDate on 0D throws "undefined date"
- [x] All existing tests pass (1677 passed in bucket-1, 6 passed in bucket-3, stubs pass)