### PR TITLE
fix: add object overloads for string-expecting methods — closes #1297

### DIFF
--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -731,6 +731,18 @@ public void ALSetFilter(DataError errorLevel, int fieldNo, string filterExpressi
 public void ALSetFilter(DataError errorLevel, int fieldNo, NavType expectedType, string filterExpression, params NavValue[] args) => Rec.ALSetFilter(fieldNo, expectedType, filterExpression, args);
 public void ALSetFilter(DataError errorLevel, int fieldNo, NavType expectedType, string filterExpression, object arg1) => Rec.ALSetFilter(errorLevel, fieldNo, expectedType, filterExpression, arg1);
 public void ALSetFilter(DataError errorLevel, int fieldNo, NavType expectedType, string filterExpression, object arg1, object arg2) => Rec.ALSetFilter(errorLevel, fieldNo, expectedType, filterExpression, arg1, arg2);
+public void ALSetFilter(int fieldNo, object filterExpression) => Rec.ALSetFilter(fieldNo, filterExpression);
+public void ALSetFilter(int fieldNo, object filterExpression, object arg1) => Rec.ALSetFilter(fieldNo, filterExpression, arg1);
+public void ALSetFilter(int fieldNo, object filterExpression, object arg1, object arg2) => Rec.ALSetFilter(fieldNo, filterExpression, arg1, arg2);
+public void ALSetFilter(int fieldNo, NavType expectedType, object filterExpression) => Rec.ALSetFilter(fieldNo, expectedType, filterExpression);
+public void ALSetFilter(int fieldNo, NavType expectedType, object filterExpression, object arg1) => Rec.ALSetFilter(fieldNo, expectedType, filterExpression, arg1);
+public void ALSetFilter(int fieldNo, NavType expectedType, object filterExpression, object arg1, object arg2) => Rec.ALSetFilter(fieldNo, expectedType, filterExpression, arg1, arg2);
+public void ALSetFilter(DataError errorLevel, int fieldNo, object filterExpression) => Rec.ALSetFilter(errorLevel, fieldNo, filterExpression);
+public void ALSetFilter(DataError errorLevel, int fieldNo, object filterExpression, object arg1) => Rec.ALSetFilter(errorLevel, fieldNo, filterExpression, arg1);
+public void ALSetFilter(DataError errorLevel, int fieldNo, object filterExpression, object arg1, object arg2) => Rec.ALSetFilter(errorLevel, fieldNo, filterExpression, arg1, arg2);
+public void ALSetFilter(DataError errorLevel, int fieldNo, NavType expectedType, object filterExpression) => Rec.ALSetFilter(errorLevel, fieldNo, expectedType, filterExpression);
+public void ALSetFilter(DataError errorLevel, int fieldNo, NavType expectedType, object filterExpression, object arg1) => Rec.ALSetFilter(errorLevel, fieldNo, expectedType, filterExpression, arg1);
+public void ALSetFilter(DataError errorLevel, int fieldNo, NavType expectedType, object filterExpression, object arg1, object arg2) => Rec.ALSetFilter(errorLevel, fieldNo, expectedType, filterExpression, arg1, arg2);
 public void ALCopy(MockRecordHandle source, bool shareFilters = false) => Rec.ALCopy(source, shareFilters);
 public void ALCopyFilter(int fromFieldNo, MockRecordHandle target) => Rec.ALCopyFilter(fromFieldNo, target);
 public void ALCopyFilter(int fromFieldNo, MockRecordHandle target, int toFieldNo) => Rec.ALCopyFilter(fromFieldNo, target, toFieldNo);

--- a/AlRunner/Runtime/AlScope.cs
+++ b/AlRunner/Runtime/AlScope.cs
@@ -601,6 +601,14 @@ public static class AlDialog
         MessageCapture.Capture(formatted);
     }
 
+    /// <summary>
+    /// Object overload for Message — handles NavComplexValue→object rewrite.
+    /// When the rewriter replaces NavComplexValue with object, the format string
+    /// becomes typed as object. This overload converts it to string via Format().
+    /// </summary>
+    public static void Message(object format, params object?[] args)
+        => Message(AlCompat.Format(format), args);
+
     public static void Error(string format, params object?[] args)
     {
         // In BC, Error('') performs a silent transaction rollback without
@@ -616,6 +624,14 @@ public static class AlDialog
         else
             throw new Exception(format);
     }
+
+    /// <summary>
+    /// Object overload for Error — handles NavComplexValue→object rewrite.
+    /// When the rewriter replaces NavComplexValue with object, the format string
+    /// becomes typed as object. This overload converts it to string via Format().
+    /// </summary>
+    public static void Error(object format, params object?[] args)
+        => Error(AlCompat.Format(format), args);
 
     /// <summary>
     /// Overload for AL's Error(ErrorInfo) pattern where NavALErrorInfo is passed directly.
@@ -1402,6 +1418,14 @@ public static class AlCompat
     }
 
     /// <summary>
+    /// Object overload for StrSubstNo — handles NavComplexValue→object rewrite.
+    /// When the rewriter replaces NavComplexValue with object, the format string
+    /// becomes typed as object. This overload converts it to string via Format().
+    /// </summary>
+    public static string StrSubstNo(object fmt, params Microsoft.Dynamics.Nav.Runtime.NavValue[] args)
+        => StrSubstNo(Format(fmt), args);
+
+    /// <summary>
     /// AL PadStr(String, Length, Filler): pad or truncate to fixed width.
     /// Positive Length = right-pad (append filler). Negative Length = left-pad (prepend filler).
     /// If |Length| &lt;= source length, result is source truncated to |Length| (no padding added).
@@ -1420,6 +1444,12 @@ public static class AlCompat
     }
 
     public static string PadStr(string? source, int length) => PadStr(source, length, " ");
+
+    /// <summary>
+    /// Object overloads for PadStr — handles NavComplexValue→object rewrite.
+    /// </summary>
+    public static string PadStr(object source, int length, string? filler) => PadStr(Format(source), length, filler);
+    public static string PadStr(object source, int length) => PadStr(Format(source), length, " ");
 
     /// <summary>
     /// Format with AL format string (e.g. '&lt;Year4&gt;-&lt;Month,2&gt;-&lt;Day,2&gt;').
@@ -2640,6 +2670,11 @@ public static class AlCompat
         return parts[n - 1];
     }
 
+    /// <summary>
+    /// Object overload for SelectStr — handles NavComplexValue→object rewrite.
+    /// </summary>
+    public static string SelectStr(int n, object s) => SelectStr(n, Format(s));
+
     // -----------------------------------------------------------------------
     // Replacement for ALSystemString.ALIncStr
     // AL IncStr(s) increments the last numeric sequence found in s.
@@ -2666,6 +2701,11 @@ public static class AlCompat
         return s.Substring(0, start) + incremented + s.Substring(end + 1);
     }
 
+    /// <summary>
+    /// Object overload for IncStr — handles NavComplexValue→object rewrite.
+    /// </summary>
+    public static string IncStr(object s) => IncStr(Format(s));
+
     // -----------------------------------------------------------------------
     // Replacement for ALSystemString.ALConvertStr
     // AL ConvertStr(String, FromChars, ToChars) replaces each character in
@@ -2690,6 +2730,12 @@ public static class AlCompat
         return sb.ToString();
     }
 
+    /// <summary>
+    /// Object overload for ConvertStr — handles NavComplexValue→object rewrite.
+    /// </summary>
+    public static string ConvertStr(object s, string fromChars, string toChars)
+        => ConvertStr(Format(s), fromChars, toChars);
+
     // -----------------------------------------------------------------------
     // Replacement for ALSystemString.ALCopyStr (2-param variant)
     // AL CopyStr(String, Position) returns the substring from Position to end.
@@ -2706,6 +2752,11 @@ public static class AlCompat
         if (position > s.Length) return "";
         return s.Substring(position - 1);
     }
+
+    /// <summary>
+    /// Object overload for CopyStr — handles NavComplexValue→object rewrite.
+    /// </summary>
+    public static string CopyStr(object s, int position) => CopyStr(Format(s), position);
 
     // -----------------------------------------------------------------------
     // SecretStrSubstNo() replacement

--- a/AlRunner/Runtime/MockRecordHandle.cs
+++ b/AlRunner/Runtime/MockRecordHandle.cs
@@ -1345,41 +1345,55 @@ public class MockRecordHandle : IConvertible
     public void ALSetFilter(DataError errorLevel, int fieldNo, NavType expectedType, string filterExpression, params NavValue[] args)
         => ALSetFilter(fieldNo, expectedType, filterExpression, args);
 
-    // ---- object catch-all overloads for ALSetFilter ----
-    // Non-params overloads for 1–3 filter substitution args.
+    // ---- object catch-all overloads for ALSetFilter (string filter expression) ----
+    // Non-params overloads for 1–2 filter substitution args.
     // Resolves CS1503: 'object' → 'NavValue' — issue #1260.
 
-    /// <summary>ALSetFilter with 1 object arg.</summary>
     public void ALSetFilter(int fieldNo, string filterExpression, object arg1)
         => ALSetFilter(fieldNo, filterExpression, AlCompat.ToNavValue(arg1));
-
-    /// <summary>ALSetFilter with 2 object args.</summary>
     public void ALSetFilter(int fieldNo, string filterExpression, object arg1, object arg2)
         => ALSetFilter(fieldNo, filterExpression, AlCompat.ToNavValue(arg1), AlCompat.ToNavValue(arg2));
-
-    /// <summary>ALSetFilter(NavType) with 1 object arg.</summary>
     public void ALSetFilter(int fieldNo, NavType expectedType, string filterExpression, object arg1)
         => ALSetFilter(fieldNo, expectedType, filterExpression, AlCompat.ToNavValue(arg1));
-
-    /// <summary>ALSetFilter(NavType) with 2 object args.</summary>
     public void ALSetFilter(int fieldNo, NavType expectedType, string filterExpression, object arg1, object arg2)
         => ALSetFilter(fieldNo, expectedType, filterExpression, AlCompat.ToNavValue(arg1), AlCompat.ToNavValue(arg2));
-
-    /// <summary>ALSetFilter(DataError) with 1 object arg.</summary>
     public void ALSetFilter(DataError errorLevel, int fieldNo, string filterExpression, object arg1)
         => ALSetFilter(fieldNo, filterExpression, AlCompat.ToNavValue(arg1));
-
-    /// <summary>ALSetFilter(DataError) with 2 object args.</summary>
     public void ALSetFilter(DataError errorLevel, int fieldNo, string filterExpression, object arg1, object arg2)
         => ALSetFilter(fieldNo, filterExpression, AlCompat.ToNavValue(arg1), AlCompat.ToNavValue(arg2));
-
-    /// <summary>ALSetFilter(DataError, NavType) with 1 object arg.</summary>
     public void ALSetFilter(DataError errorLevel, int fieldNo, NavType expectedType, string filterExpression, object arg1)
         => ALSetFilter(fieldNo, expectedType, filterExpression, AlCompat.ToNavValue(arg1));
-
-    /// <summary>ALSetFilter(DataError, NavType) with 2 object args.</summary>
     public void ALSetFilter(DataError errorLevel, int fieldNo, NavType expectedType, string filterExpression, object arg1, object arg2)
         => ALSetFilter(fieldNo, expectedType, filterExpression, AlCompat.ToNavValue(arg1), AlCompat.ToNavValue(arg2));
+
+    // ---- object catch-all overloads for ALSetFilter (object filter expression) ----
+    // Resolves CS1503: 'object' → 'string' — issue #1297.
+    // When NavComplexValue→object rewrite makes the filter expression typed as object.
+
+    public void ALSetFilter(int fieldNo, object filterExpression)
+        => ALSetFilter(fieldNo, AlCompat.Format(filterExpression));
+    public void ALSetFilter(int fieldNo, object filterExpression, object arg1)
+        => ALSetFilter(fieldNo, AlCompat.Format(filterExpression), AlCompat.ToNavValue(arg1));
+    public void ALSetFilter(int fieldNo, object filterExpression, object arg1, object arg2)
+        => ALSetFilter(fieldNo, AlCompat.Format(filterExpression), AlCompat.ToNavValue(arg1), AlCompat.ToNavValue(arg2));
+    public void ALSetFilter(int fieldNo, NavType expectedType, object filterExpression)
+        => ALSetFilter(fieldNo, expectedType, AlCompat.Format(filterExpression));
+    public void ALSetFilter(int fieldNo, NavType expectedType, object filterExpression, object arg1)
+        => ALSetFilter(fieldNo, expectedType, AlCompat.Format(filterExpression), AlCompat.ToNavValue(arg1));
+    public void ALSetFilter(int fieldNo, NavType expectedType, object filterExpression, object arg1, object arg2)
+        => ALSetFilter(fieldNo, expectedType, AlCompat.Format(filterExpression), AlCompat.ToNavValue(arg1), AlCompat.ToNavValue(arg2));
+    public void ALSetFilter(DataError errorLevel, int fieldNo, object filterExpression)
+        => ALSetFilter(fieldNo, AlCompat.Format(filterExpression));
+    public void ALSetFilter(DataError errorLevel, int fieldNo, object filterExpression, object arg1)
+        => ALSetFilter(fieldNo, AlCompat.Format(filterExpression), AlCompat.ToNavValue(arg1));
+    public void ALSetFilter(DataError errorLevel, int fieldNo, object filterExpression, object arg1, object arg2)
+        => ALSetFilter(fieldNo, AlCompat.Format(filterExpression), AlCompat.ToNavValue(arg1), AlCompat.ToNavValue(arg2));
+    public void ALSetFilter(DataError errorLevel, int fieldNo, NavType expectedType, object filterExpression)
+        => ALSetFilter(fieldNo, expectedType, AlCompat.Format(filterExpression));
+    public void ALSetFilter(DataError errorLevel, int fieldNo, NavType expectedType, object filterExpression, object arg1)
+        => ALSetFilter(fieldNo, expectedType, AlCompat.Format(filterExpression), AlCompat.ToNavValue(arg1));
+    public void ALSetFilter(DataError errorLevel, int fieldNo, NavType expectedType, object filterExpression, object arg1, object arg2)
+        => ALSetFilter(fieldNo, expectedType, AlCompat.Format(filterExpression), AlCompat.ToNavValue(arg1), AlCompat.ToNavValue(arg2));
 
     // -----------------------------------------------------------------------
     // SetCurrentKey — set sort key (with DataError first param)

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -2325,7 +2325,7 @@ Dialog.Message:
   status: covered
   notes: overloads=1; AlDialog.Message implemented in Runtime/AlScope.cs, routes to MessageHandler or stdout.
 
-Dialog.Error (object overload):
+NavComplexValue object-to-string overloads:
   layer: compilation
   category: Dialog
   status: covered

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -2325,6 +2325,19 @@ Dialog.Message:
   status: covered
   notes: overloads=1; AlDialog.Message implemented in Runtime/AlScope.cs, routes to MessageHandler or stdout.
 
+Dialog.Error (object overload):
+  layer: compilation
+  category: Dialog
+  status: covered
+  notes: >
+    When the rewriter replaces NavComplexValue with object, the format string
+    argument to Error/Message becomes typed as object instead of string, causing
+    CS1503. Object overloads on AlDialog.Error and AlDialog.Message convert via
+    AlCompat.Format(). Same pattern applied to AlCompat.StrSubstNo, CopyStr,
+    SelectStr, PadStr, IncStr, ConvertStr, and ALSetFilter (filter expression).
+  tests:
+    - tests/bucket-2/96-object-to-string-conv
+
 Dialog.Open:
   layer: runtime-api
   category: Dialog

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -2326,7 +2326,7 @@ Dialog.Message:
   notes: overloads=1; AlDialog.Message implemented in Runtime/AlScope.cs, routes to MessageHandler or stdout.
 
 NavComplexValue object-to-string overloads:
-  layer: compilation
+  layer: runtime-api
   category: Dialog
   status: covered
   notes: >

--- a/tests/bucket-2/96-object-to-string-conv/src/ObjectToStringSrc.al
+++ b/tests/bucket-2/96-object-to-string-conv/src/ObjectToStringSrc.al
@@ -1,4 +1,4 @@
-table 304010 "Obj To Str Table"
+table 305010 "Obj To Str Table"
 {
     DataClassification = CustomerContent;
 
@@ -23,7 +23,7 @@ table 304010 "Obj To Str Table"
     }
 }
 
-codeunit 304010 "Obj To Str Helper"
+codeunit 305010 "Obj To Str Helper"
 {
     procedure ErrorFromVariant(Msg: Variant)
     begin

--- a/tests/bucket-2/96-object-to-string-conv/src/ObjectToStringSrc.al
+++ b/tests/bucket-2/96-object-to-string-conv/src/ObjectToStringSrc.al
@@ -1,0 +1,87 @@
+table 304010 "Obj To Str Table"
+{
+    DataClassification = CustomerContent;
+
+    fields
+    {
+        field(1; "Code"; Code[20])
+        {
+            Caption = 'Code';
+        }
+        field(2; "Description"; Text[100])
+        {
+            Caption = 'Description';
+        }
+    }
+
+    keys
+    {
+        key(PK; "Code")
+        {
+            Clustered = true;
+        }
+    }
+}
+
+codeunit 304010 "Obj To Str Helper"
+{
+    procedure ErrorFromVariant(Msg: Variant)
+    begin
+        Error(Msg);
+    end;
+
+    procedure ErrorFromVariantFmt(Fmt: Variant; Val: Variant)
+    begin
+        Error(Fmt, Val);
+    end;
+
+    procedure StrSubstNoFromVariant(Fmt: Variant; Val: Variant): Text
+    begin
+        exit(StrSubstNo(Fmt, Val));
+    end;
+
+    procedure CopyStrFromVariant(S: Variant): Text
+    begin
+        exit(CopyStr(S, 2, 3));
+    end;
+
+    procedure LowerFromVariant(S: Variant): Text
+    begin
+        exit(LowerCase(S));
+    end;
+
+    procedure UpperFromVariant(S: Variant): Text
+    begin
+        exit(UpperCase(S));
+    end;
+
+    procedure PadStrFromVariant(S: Variant): Text
+    begin
+        exit(PadStr(S, 8));
+    end;
+
+    procedure IncStrFromVariant(S: Variant): Text
+    begin
+        exit(IncStr(S));
+    end;
+
+    procedure DelChrFromVariant(S: Variant): Text
+    begin
+        exit(DelChr(S, '=', ' '));
+    end;
+
+    procedure SetFilterFromVariantExpr(var Rec: Record "Obj To Str Table"; FilterExpr: Variant)
+    begin
+        Rec.SetFilter("Code", FilterExpr);
+    end;
+
+    procedure SetFilterFromVariantExprAndArg(var Rec: Record "Obj To Str Table"; FilterExpr: Variant; Val: Variant)
+    begin
+        Rec.SetFilter("Code", FilterExpr, Val);
+    end;
+
+    procedure MessageFromVariant(Msg: Variant)
+    begin
+        Message(Msg);
+    end;
+}

--- a/tests/bucket-2/96-object-to-string-conv/test/ObjectToStringTest.al
+++ b/tests/bucket-2/96-object-to-string-conv/test/ObjectToStringTest.al
@@ -1,4 +1,4 @@
-codeunit 304011 "Obj To Str Test"
+codeunit 305011 "Obj To Str Test"
 {
     Subtype = Test;
 

--- a/tests/bucket-2/96-object-to-string-conv/test/ObjectToStringTest.al
+++ b/tests/bucket-2/96-object-to-string-conv/test/ObjectToStringTest.al
@@ -1,0 +1,125 @@
+codeunit 304011 "Obj To Str Test"
+{
+    Subtype = Test;
+
+    [Test]
+    procedure StrSubstNoFromVariant_ReturnsFormatted()
+    var
+        Helper: Codeunit "Obj To Str Helper";
+        Result: Text;
+    begin
+        // Variant holding format string + variant arg passed to StrSubstNo
+        Result := Helper.StrSubstNoFromVariant('Hello %1', 'World');
+        Assert.AreEqual('Hello World', Result, 'StrSubstNo via Variant should format correctly');
+    end;
+
+    [Test]
+    procedure ErrorFromVariant_RaisesExpectedError()
+    var
+        Helper: Codeunit "Obj To Str Helper";
+    begin
+        asserterror Helper.ErrorFromVariant('Variant error message');
+        Assert.ExpectedError('Variant error message');
+    end;
+
+    [Test]
+    procedure ErrorFromVariantFmt_RaisesFormattedError()
+    var
+        Helper: Codeunit "Obj To Str Helper";
+    begin
+        asserterror Helper.ErrorFromVariantFmt('Error: %1', 'detail');
+        Assert.ExpectedError('Error: detail');
+    end;
+
+    [Test]
+    procedure CopyStrFromVariant_ReturnsCopied()
+    var
+        Helper: Codeunit "Obj To Str Helper";
+        Result: Text;
+    begin
+        // CopyStr(S, 2, 3) on 'ABCDEF' → 'BCD'
+        Result := Helper.CopyStrFromVariant('ABCDEF');
+        Assert.AreEqual('BCD', Result, 'CopyStr via Variant should return substring');
+    end;
+
+    [Test]
+    procedure LowerFromVariant_ReturnsLowerCase()
+    var
+        Helper: Codeunit "Obj To Str Helper";
+        Result: Text;
+    begin
+        Result := Helper.LowerFromVariant('HELLO');
+        Assert.AreEqual('hello', Result, 'LowerCase via Variant should return lowercase');
+    end;
+
+    [Test]
+    procedure UpperFromVariant_ReturnsUpperCase()
+    var
+        Helper: Codeunit "Obj To Str Helper";
+        Result: Text;
+    begin
+        Result := Helper.UpperFromVariant('hello');
+        Assert.AreEqual('HELLO', Result, 'UpperCase via Variant should return uppercase');
+    end;
+
+    [Test]
+    procedure PadStrFromVariant_ReturnsPadded()
+    var
+        Helper: Codeunit "Obj To Str Helper";
+        Result: Text;
+    begin
+        // PadStr('AB', 8) → 'AB      ' (padded to 8)
+        Result := Helper.PadStrFromVariant('AB');
+        Assert.AreEqual(8, StrLen(Result), 'PadStr via Variant should pad to length');
+    end;
+
+    [Test]
+    procedure IncStrFromVariant_ReturnsIncremented()
+    var
+        Helper: Codeunit "Obj To Str Helper";
+        Result: Text;
+    begin
+        Result := Helper.IncStrFromVariant('ABC1');
+        Assert.AreEqual('ABC2', Result, 'IncStr via Variant should increment number');
+    end;
+
+    [Test]
+    procedure DelChrFromVariant_ReturnsFiltered()
+    var
+        Helper: Codeunit "Obj To Str Helper";
+        Result: Text;
+    begin
+        // DelChr('A B C', '=', ' ') → 'ABC'
+        Result := Helper.DelChrFromVariant('A B C');
+        Assert.AreEqual('ABC', Result, 'DelChr via Variant should remove characters');
+    end;
+
+    [Test]
+    procedure SetFilterFromVariantExpr_Compiles()
+    var
+        Helper: Codeunit "Obj To Str Helper";
+        Rec: Record "Obj To Str Table";
+    begin
+        // Just verify it compiles and does not crash
+        Helper.SetFilterFromVariantExpr(Rec, 'ABC');
+    end;
+
+    [Test]
+    procedure SetFilterFromVariantExprAndArg_FindsRecord()
+    var
+        Helper: Codeunit "Obj To Str Helper";
+        Rec: Record "Obj To Str Table";
+    begin
+        Rec.Init();
+        Rec."Code" := 'TEST';
+        Rec.Description := 'Test Record';
+        Rec.Insert();
+
+        Helper.SetFilterFromVariantExprAndArg(Rec, '%1', 'TEST');
+        Assert.IsTrue(Rec.FindFirst(), 'Should find record via Variant filter');
+        Assert.AreEqual('TEST', Rec."Code", 'Found wrong record');
+    end;
+
+    var
+        Assert: Codeunit Assert;
+}


### PR DESCRIPTION
Closes #1297

## Summary
- When the rewriter replaces `NavComplexValue` with `object`, arguments to methods expecting `string` become typed as `object`, causing CS1503: `'object' → 'string'` (9 occurrences in telemetry)
- Added `object` catch-all overloads to `AlDialog.Error/Message`, `AlCompat.StrSubstNo`, `AlCompat.CopyStr/SelectStr/PadStr/IncStr/ConvertStr`, and `MockRecordHandle.ALSetFilter` (filter expression parameter)
- Each overload converts the object to string via `AlCompat.Format()`

## Test plan
- [x] 11 new AL tests covering Variant→string conversions through Error, StrSubstNo, CopyStr, LowerCase, UpperCase, PadStr, IncStr, DelChr, and SetFilter
- [x] All existing tests pass (1677 passed in bucket-1, 6 passed in bucket-3, same as main)
- [x] Stubs test passes (2 passed)