### PR TITLE
fix: bump AL compiler to v17.0 for BC 28 runtime 17 support

### DIFF
--- a/AlRunner/AlRunner.csproj
+++ b/AlRunner/AlRunner.csproj
@@ -41,7 +41,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <_ALToolVersion>16.2.28.57946</_ALToolVersion>
+    <_ALToolVersion>17.0.34.45391</_ALToolVersion>
     <_BCVersion>27.5.46862.48827</_BCVersion>
     <!-- Cross-platform cache directory for auto-downloaded dependencies -->
     <_CacheBase Condition="$([MSBuild]::IsOSPlatform('Windows'))">$(LOCALAPPDATA)/al-runner</_CacheBase>

--- a/tools/DownloadArtifacts/Program.cs
+++ b/tools/DownloadArtifacts/Program.cs
@@ -72,7 +72,9 @@ static int DownloadAlCompiler(string version, string outputDir)
     foreach (var entry in zip.Entries)
     {
         var name = entry.FullName.Replace('\\', '/');
-        if (!name.StartsWith("tools/net8.0/any/", StringComparison.OrdinalIgnoreCase))
+        // v16 uses tools/net8.0/any/, v17+ uses lib/net8.0/
+        if (!name.StartsWith("tools/net8.0/any/", StringComparison.OrdinalIgnoreCase)
+            && !name.StartsWith("lib/net8.0/", StringComparison.OrdinalIgnoreCase))
             continue;
         if (!name.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
             continue;


### PR DESCRIPTION
Closes #1255

## Problem

`--compile-dep` fails with AL1153 when loading BC 28 `.app` packages that declare `runtime: "17.0"`. The AL compiler v16 cannot load runtime 17 modules.

## Fix

- Bump `_ALToolVersion` from `16.2.28.57946` to `17.0.34.45391`
- Update `DownloadArtifacts` to extract DLLs from `lib/net8.0/` (v17 package layout) in addition to `tools/net8.0/any/` (v16 layout)

## Validation

Build + smoke test pass locally with v17. The test matrix runs against BC 26.0–28.0, so CI will confirm full compatibility.