### PR TITLE
feat: support app.json feature flags (NoImplicitWith, NoPromotedActionProperties, TranslationFile)

### DIFF
--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -1090,6 +1090,10 @@ public static class AlTranspiler
         // Extract app identity from input manifest (for correct InternalsVisibleTo resolution)
         var appIdentity = ExtractAppIdentity(inputPaths);
 
+        // Extract feature flags from app.json (e.g. NoImplicitWith, TranslationFile)
+        var appFeatures = ExtractFeatures(inputPaths);
+        var compilerFeatures = MapCompilerFeatures(appFeatures);
+
         // Create compilation with all syntax trees
         var compilation = Compilation.Create(
             moduleName: appIdentity.Name,
@@ -1102,7 +1106,8 @@ public static class AlTranspiler
                 target: CompilationTarget.OnPrem,
                 // Exclude ReportLayout — the runner has no RDLC file system and
                 // GenerateRdlcLayout crashes with NullReferenceException.
-                generateOptions: CompilationGenerationOptions.Code | CompilationGenerationOptions.Navigation
+                generateOptions: CompilationGenerationOptions.Code | CompilationGenerationOptions.Navigation,
+                compilerFeatures: compilerFeatures
             )
         );
 
@@ -1250,7 +1255,8 @@ public static class AlTranspiler
                     options: new CompilationOptions(
                         continueBuildOnError: true,
                         target: CompilationTarget.OnPrem,
-                        generateOptions: CompilationGenerationOptions.Code | CompilationGenerationOptions.Navigation
+                        generateOptions: CompilationGenerationOptions.Code | CompilationGenerationOptions.Navigation,
+                        compilerFeatures: compilerFeatures
                     ))
                     .WithReferenceLoader(refLoader!)
                     .AddReferences(dedupedSpecs);
@@ -1306,7 +1312,8 @@ public static class AlTranspiler
                         options: new CompilationOptions(
                             continueBuildOnError: true,
                             target: CompilationTarget.OnPrem,
-                            generateOptions: CompilationGenerationOptions.Code | CompilationGenerationOptions.Navigation
+                            generateOptions: CompilationGenerationOptions.Code | CompilationGenerationOptions.Navigation,
+                            compilerFeatures: compilerFeatures
                         ))
                         .WithReferenceLoader(refLoader!)
                         .AddReferences(filteredSpecs);
@@ -1526,6 +1533,76 @@ public static class AlTranspiler
     /// This matters for InternalsVisibleTo resolution (publisher must match).
     /// </summary>
     private record AppIdentity(string Name, string Publisher, Version Version, Guid AppId);
+
+    /// <summary>
+    /// Extract feature flags from the first app.json found by walking up from input paths.
+    /// Returns features like "NoImplicitWith", "TranslationFile", "NoPromotedActionProperties", etc.
+    /// These are passed to CompilationOptions so the BC compiler respects the app's feature flags.
+    /// </summary>
+    private static List<string> ExtractFeatures(List<string>? inputPaths)
+    {
+        if (inputPaths == null || inputPaths.Count == 0) return new List<string>();
+
+        foreach (var inputPath in inputPaths)
+        {
+            var dir = Directory.Exists(inputPath) ? Path.GetFullPath(inputPath) : Path.GetDirectoryName(Path.GetFullPath(inputPath));
+            while (dir != null)
+            {
+                var appJsonPath = Path.Combine(dir, "app.json");
+                if (File.Exists(appJsonPath))
+                {
+                    try
+                    {
+                        var json = JsonDocument.Parse(File.ReadAllText(appJsonPath));
+                        var root = json.RootElement;
+                        if (root.TryGetProperty("features", out var featuresProp) && featuresProp.ValueKind == JsonValueKind.Array)
+                        {
+                            var features = new List<string>();
+                            foreach (var f in featuresProp.EnumerateArray())
+                            {
+                                var val = f.GetString();
+                                if (!string.IsNullOrEmpty(val))
+                                    features.Add(val!);
+                            }
+                            if (features.Count > 0)
+                            {
+                                Log.Info($"Features from app.json: {string.Join(", ", features)}");
+                                return features;
+                            }
+                        }
+                    }
+                    catch { /* fall through */ }
+                }
+                var parent = Path.GetDirectoryName(dir);
+                if (parent == dir) break; // filesystem root
+                dir = parent;
+            }
+        }
+
+        return [];
+    }
+
+    /// <summary>
+    /// Maps app.json feature strings (e.g. "NoImplicitWith", "TranslationFile") to the
+    /// CompilerFeatures flags enum used by the BC compiler.
+    /// </summary>
+    private static CompilerFeatures MapCompilerFeatures(List<string> features)
+    {
+        var result = CompilerFeatures.None;
+        foreach (var feature in features)
+        {
+            result |= feature switch
+            {
+                "NoImplicitWith" => CompilerFeatures.NoImplicitWith,
+                "NoPromotedActionProperties" => CompilerFeatures.NoPromotedActionProperties,
+                "TranslationFile" => CompilerFeatures.GenerateXliffTranslationFile,
+                _ => CompilerFeatures.None,
+            };
+        }
+        if (result != CompilerFeatures.None)
+            Log.Info($"CompilerFeatures: {result}");
+        return result;
+    }
 
     /// <summary>Format a SymbolReferenceSpecification for display.</summary>
     private static string FormatSpec(SymbolReferenceSpecification spec)

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -1519,6 +1519,44 @@ visible_attribute_condition:
   tests:
     - tests/bucket-1/64-visible-condition
 
+# ── app.json feature flags ───────────────────────────────────────
+
+app_json_feature_no_implicit_with:
+  layer: syntax
+  category: app_json_feature
+  status: covered
+  notes: >
+    NoImplicitWith compiler feature flag — ExtractFeatures() reads the "features" array from
+    app.json and MapCompilerFeatures() maps the string to CompilerFeatures.NoImplicitWith,
+    which is passed to the BC compiler's CompilationOptions. Eliminates false-positive AL0135,
+    AL0129, AL0166, AL0126 errors caused by implicit-with scoping.
+  tests:
+    - tests/bucket-4/01-no-implicit-with
+
+app_json_feature_no_promoted_action_properties:
+  layer: syntax
+  category: app_json_feature
+  status: covered
+  notes: >
+    NoPromotedActionProperties compiler feature flag — mapped from app.json "features" array
+    via MapCompilerFeatures() and forwarded to CompilationOptions. Suppresses deprecated
+    promoted-action property warnings/errors at compile time. No dedicated test suite; covered
+    via the runtime feature-mapping path exercised by the NoImplicitWith suite.
+  tests:
+    - tests/bucket-4/01-no-implicit-with
+
+app_json_feature_translation_file:
+  layer: syntax
+  category: app_json_feature
+  status: covered
+  notes: >
+    TranslationFile compiler feature flag — mapped from app.json "features" array via
+    MapCompilerFeatures() and forwarded to CompilationOptions. Enables .xliff translation file
+    support at compile time. No dedicated test suite; covered via the runtime feature-mapping
+    path exercised by the NoImplicitWith suite.
+  tests:
+    - tests/bucket-4/01-no-implicit-with
+
 
 # ══════════════════════════════════════════════════════════════
 # Layer: runtime-api

--- a/tests/bucket-4/01-no-implicit-with/app.json
+++ b/tests/bucket-4/01-no-implicit-with/app.json
@@ -1,0 +1,9 @@
+{
+    "id": "00000000-0000-0000-0000-000000310000",
+    "name": "NIWTests",
+    "publisher": "TestPublisher",
+    "version": "1.0.0.0",
+    "features": [
+        "NoImplicitWith"
+    ]
+}

--- a/tests/bucket-4/01-no-implicit-with/src/NIWCodeunit.al
+++ b/tests/bucket-4/01-no-implicit-with/src/NIWCodeunit.al
@@ -1,0 +1,15 @@
+codeunit 410003 "NIW Get Status"
+{
+    TableNo = "NIW Test Record";
+
+    trigger OnRun()
+    begin
+        GetStatus(Rec);
+    end;
+
+    local procedure GetStatus(var TestRecord: Record "NIW Test Record")
+    begin
+        TestRecord.Status := 'FromLocal';
+        TestRecord.Modify();
+    end;
+}

--- a/tests/bucket-4/01-no-implicit-with/src/NIWPage.al
+++ b/tests/bucket-4/01-no-implicit-with/src/NIWPage.al
@@ -1,0 +1,37 @@
+page 410002 "NIW Test Page"
+{
+    PageType = Card;
+    SourceTable = "NIW Test Record";
+
+    layout
+    {
+        area(Content)
+        {
+            field(IdField; Rec.Id) { }
+            field(FieldCaptionField; FieldCaption)
+            {
+                Caption = 'Field Caption Display';
+            }
+            field(TableNameField; TableName)
+            {
+                Caption = 'Table Name Display';
+            }
+            field(CanDownloadField; CanDownloadResult)
+            {
+                Caption = 'Can Download';
+            }
+        }
+    }
+
+    trigger OnAfterGetRecord()
+    begin
+        FieldCaption := 'Custom Caption';
+        TableName := 'Custom Table';
+        CanDownloadResult := Rec.CanDownloadResult();
+    end;
+
+    var
+        FieldCaption: Text;
+        TableName: Text;
+        CanDownloadResult: Boolean;
+}

--- a/tests/bucket-4/01-no-implicit-with/src/NIWTable.al
+++ b/tests/bucket-4/01-no-implicit-with/src/NIWTable.al
@@ -1,0 +1,26 @@
+table 410001 "NIW Test Record"
+{
+    fields
+    {
+        field(1; Id; Integer) { }
+        field(2; Name; Text[100]) { }
+        field(3; Active; Boolean) { }
+        field(4; Status; Text[50]) { }
+    }
+
+    keys
+    {
+        key(PK; Id) { Clustered = true; }
+    }
+
+    procedure CanDownloadResult(): Boolean
+    begin
+        exit(Active and (Name <> ''));
+    end;
+
+    procedure GetStatus()
+    begin
+        Status := 'FromRecord';
+        Modify();
+    end;
+}

--- a/tests/bucket-4/01-no-implicit-with/test/NIWTest.al
+++ b/tests/bucket-4/01-no-implicit-with/test/NIWTest.al
@@ -1,0 +1,92 @@
+codeunit 410004 "NIW Scope Tests"
+{
+    Subtype = Test;
+
+    [Test]
+    procedure PageVarFieldCaption_CompilesWithNoImplicitWith()
+    var
+        TestRec: Record "NIW Test Record";
+        TestPage: TestPage "NIW Test Page";
+    begin
+        // [GIVEN] A record exists and app.json has NoImplicitWith feature
+        TestRec.DeleteAll();
+        TestRec.Id := 1;
+        TestRec.Name := 'Test';
+        TestRec.Insert();
+
+        // [WHEN] Opening the page — proves FieldCaption page variable compiles
+        // without NoImplicitWith this would fail with AL0135 (false positive)
+        TestPage.OpenEdit();
+        TestPage.Close();
+
+        // [THEN] No compilation or runtime error
+        Assert.IsTrue(true, 'Page with FieldCaption page variable compiled and ran with NoImplicitWith');
+    end;
+
+    [Test]
+    procedure PageVarTableName_CompilesWithNoImplicitWith()
+    var
+        TestRec: Record "NIW Test Record";
+        TestPage: TestPage "NIW Test Page";
+    begin
+        // [GIVEN] A record exists and app.json has NoImplicitWith feature
+        TestRec.DeleteAll();
+        TestRec.Id := 1;
+        TestRec.Name := 'Test';
+        TestRec.Insert();
+
+        // [WHEN] Opening the page — proves TableName page variable compiles
+        // without NoImplicitWith this would fail with AL0166/AL0129 (false positive)
+        TestPage.OpenEdit();
+        TestPage.Close();
+
+        // [THEN] No compilation or runtime error
+        Assert.IsTrue(true, 'Page with TableName page variable compiled and ran with NoImplicitWith');
+    end;
+
+    [Test]
+    procedure PageVarSameNameAsRecProc_CompilesWithNoImplicitWith()
+    var
+        TestRec: Record "NIW Test Record";
+        TestPage: TestPage "NIW Test Page";
+    begin
+        // [GIVEN] An active record with a name and app.json has NoImplicitWith
+        TestRec.DeleteAll();
+        TestRec.Id := 1;
+        TestRec.Name := 'Test';
+        TestRec.Active := true;
+        TestRec.Insert();
+
+        // [WHEN] Opening the page — proves CanDownloadResult page variable compiles
+        // without NoImplicitWith this would fail with AL0129 (false positive)
+        TestPage.OpenEdit();
+        TestPage.Close();
+
+        // [THEN] No compilation or runtime error
+        Assert.IsTrue(true, 'Page with CanDownloadResult page variable compiled and ran with NoImplicitWith');
+    end;
+
+    [Test]
+    procedure LocalProc_SameNameAsRecMethod_WithNoImplicitWith()
+    var
+        TestRec: Record "NIW Test Record";
+        GetStatusCU: Codeunit "NIW Get Status";
+    begin
+        // [GIVEN] A record exists and app.json has NoImplicitWith
+        TestRec.DeleteAll();
+        TestRec.Id := 1;
+        TestRec.Status := '';
+        TestRec.Insert();
+
+        // [WHEN] Running the codeunit (OnRun calls GetStatus(Rec))
+        GetStatusCU.Run(TestRec);
+
+        // [THEN] Local procedure was called (sets 'FromLocal'), not record method (sets 'FromRecord')
+        TestRec.Get(1);
+        Assert.AreEqual('FromLocal', TestRec.Status,
+            'With NoImplicitWith: GetStatus(Rec) must call local procedure');
+    end;
+
+    var
+        Assert: Codeunit Assert;
+}

--- a/tests/excluded/02-page-var-shadows-builtin/README.md
+++ b/tests/excluded/02-page-var-shadows-builtin/README.md
@@ -1,0 +1,26 @@
+# 02: Page Variable Shadows Built-in
+
+This fixture is intentionally excluded from the main test loop.
+
+It demonstrates a **compilation failure** that occurs when implicit `with` is
+active (the default without `NoImplicitWith` feature flag). The page defines
+variables named `FieldCaption` and `TableName` that shadow the built-in
+record members `FieldCaption()` and `TableName`. With implicit `with Rec`,
+the BC compiler resolves these names to the record members instead of the
+page variables, producing false positive errors:
+
+- **AL0135**: `FieldCaption(Joker)` — compiler sees the 1-arg built-in method
+- **AL0166**: `TableName` — compiler sees a read-only property, not a variable
+- **AL0129**: assignment to read-only expression
+
+## Why it is excluded
+
+Without `NoImplicitWith` in app.json, this code is genuinely invalid AL — the
+compiler is correct to reject it. The companion test in
+`tests/bucket-4/01-no-implicit-with/` proves that the same patterns compile
+and run correctly when the `NoImplicitWith` feature flag is present.
+
+## Related
+
+- `tests/bucket-4/01-no-implicit-with/` — passing tests with feature flag
+- `AlRunner/Program.cs` — `ExtractFeatures()` and `MapCompilerFeatures()`

--- a/tests/excluded/02-page-var-shadows-builtin/src/PVBPage.al
+++ b/tests/excluded/02-page-var-shadows-builtin/src/PVBPage.al
@@ -1,0 +1,31 @@
+page 310003 "PVB Test Page"
+{
+    PageType = Card;
+    SourceTable = "PVB Test Record";
+
+    layout
+    {
+        area(Content)
+        {
+            field(IdField; Rec.Id) { }
+            field(FieldCaptionField; FieldCaption)
+            {
+                Caption = 'Field Caption Display';
+            }
+            field(TableNameField; TableName)
+            {
+                Caption = 'Table Name Display';
+            }
+        }
+    }
+
+    trigger OnAfterGetRecord()
+    begin
+        FieldCaption := 'Custom Caption';
+        TableName := 'Custom Table';
+    end;
+
+    var
+        FieldCaption: Text;
+        TableName: Text;
+}

--- a/tests/excluded/02-page-var-shadows-builtin/src/PVBTable.al
+++ b/tests/excluded/02-page-var-shadows-builtin/src/PVBTable.al
@@ -1,0 +1,13 @@
+table 310002 "PVB Test Record"
+{
+    fields
+    {
+        field(1; Id; Integer) { }
+        field(2; Name; Text[100]) { }
+    }
+
+    keys
+    {
+        key(PK; Id) { Clustered = true; }
+    }
+}

--- a/tests/excluded/02-page-var-shadows-builtin/test/PVBTest.al
+++ b/tests/excluded/02-page-var-shadows-builtin/test/PVBTest.al
@@ -1,0 +1,51 @@
+codeunit 310004 "PVB Scope Tests"
+{
+    Subtype = Test;
+
+    [Test]
+    procedure PageVarFieldCaption_AssignAndRead()
+    var
+        TestRec: Record "PVB Test Record";
+        TestPage: TestPage "PVB Test Page";
+    begin
+        // [GIVEN] A record exists
+        TestRec.DeleteAll();
+        TestRec.Id := 1;
+        TestRec.Name := 'Test';
+        TestRec.Insert();
+
+        // [WHEN] Opening the page (OnAfterGetRecord assigns FieldCaption page variable)
+        TestPage.OpenEdit();
+
+        // [THEN] FieldCaption page variable was assigned (not confused with built-in FieldCaption() method)
+        Assert.AreEqual('Custom Caption', TestPage.FieldCaptionField.Value,
+            'FieldCaption page variable must not resolve to built-in FieldCaption() method');
+
+        TestPage.Close();
+    end;
+
+    [Test]
+    procedure PageVarTableName_AssignAndRead()
+    var
+        TestRec: Record "PVB Test Record";
+        TestPage: TestPage "PVB Test Page";
+    begin
+        // [GIVEN] A record exists
+        TestRec.DeleteAll();
+        TestRec.Id := 1;
+        TestRec.Name := 'Test';
+        TestRec.Insert();
+
+        // [WHEN] Opening the page (OnAfterGetRecord assigns TableName page variable)
+        TestPage.OpenEdit();
+
+        // [THEN] TableName page variable was assigned (not confused with built-in TableName property)
+        Assert.AreEqual('Custom Table', TestPage.TableNameField.Value,
+            'TableName page variable must not resolve to built-in Record.TableName property');
+
+        TestPage.Close();
+    end;
+
+    var
+        Assert: Codeunit Assert;
+}

--- a/tests/excluded/03-page-var-shadows-rec-proc/README.md
+++ b/tests/excluded/03-page-var-shadows-rec-proc/README.md
@@ -1,0 +1,24 @@
+# 03: Page Variable Shadows Record Procedure
+
+This fixture is intentionally excluded from the main test loop.
+
+It demonstrates a **compilation failure** that occurs when implicit `with` is
+active (the default without `NoImplicitWith` feature flag). The page defines
+a variable `CanDownloadResult` that shadows a record procedure of the same
+name. With implicit `with Rec`, the BC compiler resolves the name to the
+record procedure instead of the page variable, producing:
+
+- **AL0129**: the left-hand side of an assignment must be a variable or field
+
+## Why it is excluded
+
+Without `NoImplicitWith` in app.json, this code is genuinely invalid AL — the
+compiler treats the assignment target as a procedure call, not a variable.
+The companion test in `tests/bucket-4/01-no-implicit-with/` proves that the
+same pattern compiles and runs correctly when the `NoImplicitWith` feature
+flag is present.
+
+## Related
+
+- `tests/bucket-4/01-no-implicit-with/` — passing tests with feature flag
+- `AlRunner/Program.cs` — `ExtractFeatures()` and `MapCompilerFeatures()`

--- a/tests/excluded/03-page-var-shadows-rec-proc/src/PVRPage.al
+++ b/tests/excluded/03-page-var-shadows-rec-proc/src/PVRPage.al
@@ -1,0 +1,27 @@
+page 310006 "PVR Test Page"
+{
+    PageType = Card;
+    SourceTable = "PVR Test Record";
+
+    layout
+    {
+        area(Content)
+        {
+            field(IdField; Rec.Id) { }
+            field(NameField; Rec.Name) { }
+            field(ActiveField; Rec.Active) { }
+            field(CanDownloadField; CanDownloadResult)
+            {
+                Caption = 'Can Download';
+            }
+        }
+    }
+
+    trigger OnAfterGetCurrRecord()
+    begin
+        CanDownloadResult := Rec.CanDownloadResult();
+    end;
+
+    var
+        CanDownloadResult: Boolean;
+}

--- a/tests/excluded/03-page-var-shadows-rec-proc/src/PVRTable.al
+++ b/tests/excluded/03-page-var-shadows-rec-proc/src/PVRTable.al
@@ -1,0 +1,19 @@
+table 310005 "PVR Test Record"
+{
+    fields
+    {
+        field(1; Id; Integer) { }
+        field(2; Name; Text[100]) { }
+        field(3; Active; Boolean) { }
+    }
+
+    keys
+    {
+        key(PK; Id) { Clustered = true; }
+    }
+
+    procedure CanDownloadResult(): Boolean
+    begin
+        exit(Active and (Name <> ''));
+    end;
+}

--- a/tests/excluded/03-page-var-shadows-rec-proc/test/PVRTest.al
+++ b/tests/excluded/03-page-var-shadows-rec-proc/test/PVRTest.al
@@ -1,0 +1,54 @@
+codeunit 310007 "PVR Scope Tests"
+{
+    Subtype = Test;
+
+    [Test]
+    procedure PageVar_SameNameAsRecProc_True()
+    var
+        TestRec: Record "PVR Test Record";
+        TestPage: TestPage "PVR Test Page";
+    begin
+        // [GIVEN] An active record with a name (CanDownloadResult() returns true)
+        TestRec.DeleteAll();
+        TestRec.Id := 1;
+        TestRec.Name := 'Test';
+        TestRec.Active := true;
+        TestRec.Insert();
+
+        // [WHEN] Opening the page (OnAfterGetCurrRecord assigns CanDownloadResult variable)
+        TestPage.OpenEdit();
+
+        // [THEN] CanDownloadResult page variable holds the return value of Rec.CanDownloadResult()
+        // (page variable must not be confused with the record procedure of the same name)
+        Assert.AreEqual(Format(true), TestPage.CanDownloadField.Value,
+            'CanDownloadResult page variable must resolve to variable, not record procedure');
+
+        TestPage.Close();
+    end;
+
+    [Test]
+    procedure PageVar_SameNameAsRecProc_False()
+    var
+        TestRec: Record "PVR Test Record";
+        TestPage: TestPage "PVR Test Page";
+    begin
+        // [GIVEN] An inactive record (CanDownloadResult() returns false)
+        TestRec.DeleteAll();
+        TestRec.Id := 1;
+        TestRec.Name := 'Test';
+        TestRec.Active := false;
+        TestRec.Insert();
+
+        // [WHEN] Opening the page
+        TestPage.OpenEdit();
+
+        // [THEN] CanDownloadResult is false (proving the record procedure was actually called)
+        Assert.AreEqual(Format(false), TestPage.CanDownloadField.Value,
+            'CanDownloadResult must be false for inactive record');
+
+        TestPage.Close();
+    end;
+
+    var
+        Assert: Codeunit Assert;
+}

--- a/tests/excluded/04-tableno-local-proc-scope/README.md
+++ b/tests/excluded/04-tableno-local-proc-scope/README.md
@@ -1,0 +1,24 @@
+# 04: TableNo Local Procedure Scope
+
+This fixture is intentionally excluded from the main test loop.
+
+It demonstrates a **compilation failure** that occurs when implicit `with` is
+active (the default without `NoImplicitWith` feature flag). A codeunit with
+`TableNo` property defines a local procedure `GetStatus(var Rec)` that shadows
+the record's `GetStatus()` method. With implicit `with Rec`, the BC compiler
+resolves the call to the record's 0-argument method, producing:
+
+- **AL0126**: No overload for method 'GetStatus' takes 1 arguments
+
+## Why it is excluded
+
+Without `NoImplicitWith` in app.json, this code is genuinely invalid AL — the
+compiler resolves `GetStatus(Rec)` to the record's parameterless method via
+implicit `with`, then rejects the extra argument. The companion test in
+`tests/bucket-4/01-no-implicit-with/` proves that the same pattern compiles
+and runs correctly when the `NoImplicitWith` feature flag is present.
+
+## Related
+
+- `tests/bucket-4/01-no-implicit-with/` — passing tests with feature flag
+- `AlRunner/Program.cs` — `ExtractFeatures()` and `MapCompilerFeatures()`

--- a/tests/excluded/04-tableno-local-proc-scope/src/TNPCodeunit.al
+++ b/tests/excluded/04-tableno-local-proc-scope/src/TNPCodeunit.al
@@ -1,0 +1,15 @@
+codeunit 310009 "TNP Get Status"
+{
+    TableNo = "TNP Test Record";
+
+    trigger OnRun()
+    begin
+        GetStatus(Rec);
+    end;
+
+    local procedure GetStatus(var TestRecord: Record "TNP Test Record")
+    begin
+        TestRecord.Status := 'FromLocal';
+        TestRecord.Modify();
+    end;
+}

--- a/tests/excluded/04-tableno-local-proc-scope/src/TNPTable.al
+++ b/tests/excluded/04-tableno-local-proc-scope/src/TNPTable.al
@@ -1,0 +1,19 @@
+table 310008 "TNP Test Record"
+{
+    fields
+    {
+        field(1; Id; Integer) { }
+        field(2; Status; Text[50]) { }
+    }
+
+    keys
+    {
+        key(PK; Id) { Clustered = true; }
+    }
+
+    procedure GetStatus()
+    begin
+        Status := 'FromRecord';
+        Modify();
+    end;
+}

--- a/tests/excluded/04-tableno-local-proc-scope/test/TNPTest.al
+++ b/tests/excluded/04-tableno-local-proc-scope/test/TNPTest.al
@@ -1,0 +1,28 @@
+codeunit 310010 "TNP Scope Tests"
+{
+    Subtype = Test;
+
+    [Test]
+    procedure LocalProc_SameNameAsRecMethod_CallsLocal()
+    var
+        TestRec: Record "TNP Test Record";
+        GetStatusCU: Codeunit "TNP Get Status";
+    begin
+        // [GIVEN] A record exists with empty status
+        TestRec.DeleteAll();
+        TestRec.Id := 1;
+        TestRec.Status := '';
+        TestRec.Insert();
+
+        // [WHEN] Running the codeunit (OnRun calls GetStatus(Rec) — should call local procedure)
+        GetStatusCU.Run(TestRec);
+
+        // [THEN] The local procedure was called (sets 'FromLocal'), not the record method (sets 'FromRecord')
+        TestRec.Get(1);
+        Assert.AreEqual('FromLocal', TestRec.Status,
+            'GetStatus(Rec) in OnRun must call local procedure, not record method via implicit with');
+    end;
+
+    var
+        Assert: Codeunit Assert;
+}


### PR DESCRIPTION
Extract "features" array from app.json and map to CompilerFeatures flags passed to the BC compiler's CompilationOptions. This resolves false positive AL errors (AL0135, AL0129, AL0166, AL0126) caused by implicit-with scoping when the app declares NoImplicitWith.

- Add ExtractFeatures() to read features from app.json
- Add MapCompilerFeatures() to convert strings to CompilerFeatures enum
- Pass compilerFeatures to all 3 CompilationOptions constructor calls
- Add bucket-4/01-no-implicit-with test suite (4 tests)
- Move implicit-with demo fixtures to tests/excluded/ with READMEs