### PR TITLE
fix: add MockHttpClient.Clear() for global Clear(client) syntax — closes #1334

### DIFF
--- a/AlRunner/Runtime/MockHttpClient.cs
+++ b/AlRunner/Runtime/MockHttpClient.cs
@@ -104,8 +104,23 @@ public class MockHttpClient
     /// <summary>SetBaseAddress — stores the base URL.</summary>
     public void ALSetBaseAddress(DataError errorLevel, NavText url) => _baseAddress = (string)url;
 
-    /// <summary>Clear — resets base address and other state.</summary>
-    public void ALClear() => _baseAddress = string.Empty;
+    /// <summary>
+    /// Clear — resets all HttpClient state to defaults.
+    /// Called via AL instance method <c>client.Clear()</c> (BC emits <c>client.ALClear()</c>)
+    /// and via AL global <c>Clear(client)</c> (BC emits <c>ALSystemVariable.Clear(client)</c>
+    /// which the rewriter transforms to <c>client.Clear()</c> — issue #1334).
+    /// </summary>
+    public void Clear()
+    {
+        _baseAddress = string.Empty;
+        _defaultHeaders = new MockHttpHeaders();
+        ALTimeout = 30;
+        ALUseDefaultNetworkWindowsAuthentication = false;
+        ALUseServerCertificateValidation = false;
+    }
+
+    /// <summary>ALClear — BC instance-method variant; delegates to <see cref="Clear"/>.</summary>
+    public void ALClear() => Clear();
 
     /// <summary>UseResponseCookies — stores the flag (emitted as method, no DataError).</summary>
     public void ALUseResponseCookies(bool value) { }

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -3119,7 +3119,7 @@ HttpClient.Clear:
   layer: runtime-api
   category: HttpClient
   status: covered
-  notes: overloads=1
+  notes: overloads=1; instance method client.Clear() via ALClear(); global Clear(client) via MockHttpClient.Clear() — issue #1334
 
 HttpClient.DefaultRequestHeaders:
   layer: runtime-api

--- a/tests/bucket-1/168-httpclient-config/src/HttpClientConfigSrc.al
+++ b/tests/bucket-1/168-httpclient-config/src/HttpClientConfigSrc.al
@@ -10,13 +10,23 @@ codeunit 94000 "HCC Src"
         exit(client.GetBaseAddress());
     end;
 
-    // Clear resets the base address to empty
+    // Clear resets the base address to empty (instance-method syntax)
     procedure ClearResetsBaseAddress(url: Text): Text
     var
         client: HttpClient;
     begin
         client.SetBaseAddress(url);
         client.Clear();
+        exit(client.GetBaseAddress());
+    end;
+
+    // GlobalClear resets the base address to empty (global Clear(x) syntax — issue #1334)
+    procedure GlobalClearResetsBaseAddress(url: Text): Text
+    var
+        client: HttpClient;
+    begin
+        client.SetBaseAddress(url);
+        Clear(client);
         exit(client.GetBaseAddress());
     end;
 

--- a/tests/bucket-1/168-httpclient-config/test/HttpClientConfigTest.al
+++ b/tests/bucket-1/168-httpclient-config/test/HttpClientConfigTest.al
@@ -35,6 +35,16 @@ codeunit 94001 "HCC Test"
             'Clear must reset base address to empty string');
     end;
 
+    [Test]
+    procedure HttpClient_GlobalClear_ResetsBaseAddress()
+    begin
+        // Clear(client) lowers to ALSystemVariable.Clear(client) → client.Clear()
+        // MockHttpClient must expose a public Clear() method — issue #1334
+        Assert.AreEqual('',
+            Src.GlobalClearResetsBaseAddress('https://api.example.com'),
+            'Global Clear(client) must reset base address to empty string');
+    end;
+
     // ── UseResponseCookies ───────────────────────────────────────
 
     [Test]


### PR DESCRIPTION
Closes #1334

## What changed

`MockHttpClient` only exposed `ALClear()` (the instance-method path: `client.Clear()` → BC emits `client.ALClear()`). When AL code uses the global `Clear(client)` syntax, the BC compiler emits `ALSystemVariable.Clear(client)`, which the RoslynRewriter transforms to `client.Clear()`. `MockHttpClient` was missing that public `Clear()` method, causing CS1061.

## Fix

- Added `public void Clear()` to `MockHttpClient` — resets base address, default headers, timeout, and authentication flags to their defaults.
- Changed `ALClear()` to delegate to `Clear()` so both call paths share one implementation.

## Tests

RED → GREEN in `tests/bucket-1/168-httpclient-config`:
- New test `HttpClient_GlobalClear_ResetsBaseAddress` explicitly calls `Clear(client)` (global syntax) and asserts the base address is reset to `''`.
- Existing test `HttpClient_Clear_ResetsBaseAddress` (instance-method syntax) continues to pass.
- Full bucket-1: 1691 passed, 66 failed (same 66 pre-existing failures as on `main`).

## Coverage

Updated `docs/coverage.yaml` — `HttpClient.Clear` entry now documents both overload paths.