### PR TITLE
fix: add string overload to MockVersion.ALCreate — closes #1322

### DIFF
--- a/AlRunner/Runtime/MockVersion.cs
+++ b/AlRunner/Runtime/MockVersion.cs
@@ -45,9 +45,17 @@ public struct MockVersion
     /// major/minor/build/revision components.
     /// </summary>
     public static MockVersion ALCreate(NavText versionText)
+        => ALCreate(versionText.ToString());
+
+    /// <summary>
+    /// Overload accepting a plain <c>string</c>. BC string literals (e.g.
+    /// <c>Version.Create('25.0.0.0')</c>) are emitted as C# <c>string</c> by the
+    /// BC compiler when they appear inline rather than via a <c>Text</c> variable.
+    /// Without this overload, Roslyn raises CS1503: 'string' → 'NavText'.
+    /// </summary>
+    public static MockVersion ALCreate(string versionText)
     {
-        var text = versionText.ToString();
-        var parts = text.Split('.');
+        var parts = (versionText ?? string.Empty).Split('.');
         var result = new MockVersion();
         if (parts.Length > 0 && int.TryParse(parts[0], out var maj)) result._major    = maj;
         if (parts.Length > 1 && int.TryParse(parts[1], out var min)) result._minor    = min;

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -9681,6 +9681,13 @@ Version.Create (1-arg text):
   tests: tests/bucket-1/96-version-create-text
   notes: overloads=1; parses dotted version string e.g. '25.1.30000.12345' into major/minor/build/revision
 
+Version.Create (1-arg string literal):
+  layer: runtime-api
+  category: Version
+  status: covered
+  tests: tests/bucket-2/306-version-create-string
+  notes: overloads=1; ALCreate(string) overload added in #1322 to fix CS1503 when BC emits a C# string (not NavText) for string-literal arguments like Version.Create('25.0.0.0') in inline expressions
+
 Version.Major:
   layer: runtime-api
   category: Version

--- a/tests/bucket-2/306-version-create-string/src/VersionCreateStringSrc.al
+++ b/tests/bucket-2/306-version-create-string/src/VersionCreateStringSrc.al
@@ -1,0 +1,42 @@
+/// Exercises Version.Create with string literals — the pattern that triggered
+/// CS1503: 'string' → 'NavText' in telemetry issue #1322.
+/// BC emits string literals as C# string, not NavText, when they appear
+/// directly in Version.Create() calls inline (not via a Text variable).
+codeunit 306000 "Version Create String Src"
+{
+    /// Returns true when ApiVersion (Text) <= the literal threshold.
+    /// This reproduces the exact pattern from the telemetry report:
+    ///   Version.Create(ApiVersion) <= Version.Create('25.0.0.0')
+    procedure IsVersionAtOrBelow(ApiVersion: Text; Threshold: Text): Boolean
+    var
+        Actual: Version;
+        Limit: Version;
+    begin
+        Actual := Version.Create(ApiVersion);
+        Limit := Version.Create(Threshold);
+        exit(Actual <= Limit);
+    end;
+
+    /// Inline comparison with a string literal on the right side:
+    /// Version.Create(v) <= Version.Create('1.0.0.0')
+    procedure IsAtOrBelow1000(v: Text): Boolean
+    begin
+        exit(Version.Create(v) <= Version.Create('1.0.0.0'));
+    end;
+
+    /// Inline comparison with a string literal on the left side:
+    /// Version.Create('1.0.0.0') <= Version.Create(v)
+    procedure IsAbove1000(v: Text): Boolean
+    begin
+        exit(Version.Create('1.0.0.0') < Version.Create(v));
+    end;
+
+    /// Returns the major component after creating from a string literal.
+    procedure MajorFromLiteral(): Integer
+    var
+        V: Version;
+    begin
+        V := Version.Create('25.3.10000.5');
+        exit(V.Major());
+    end;
+}

--- a/tests/bucket-2/306-version-create-string/test/VersionCreateStringTest.al
+++ b/tests/bucket-2/306-version-create-string/test/VersionCreateStringTest.al
@@ -1,0 +1,50 @@
+codeunit 306001 "Version Create String Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit "Library Assert";
+        Src: Codeunit "Version Create String Src";
+
+    /// Positive: variable vs variable comparison works (baseline, existing coverage)
+    [Test]
+    procedure VariableVsVariable_LessOrEqual()
+    begin
+        Assert.IsTrue(Src.IsVersionAtOrBelow('1.0.0.0', '2.0.0.0'),
+            '1.0.0.0 <= 2.0.0.0 must be true');
+        Assert.IsFalse(Src.IsVersionAtOrBelow('3.0.0.0', '2.0.0.0'),
+            '3.0.0.0 <= 2.0.0.0 must be false');
+    end;
+
+    /// Positive: inline Version.Create(var) <= Version.Create('literal') — core issue #1322
+    [Test]
+    procedure InlineLiteralOnRight_AtOrBelow()
+    begin
+        // Proves the string overload works: 0.9.0.0 <= 1.0.0.0
+        Assert.IsTrue(Src.IsAtOrBelow1000('0.9.0.0'),
+            '0.9.0.0 <= 1.0.0.0 must be true');
+        // Negative direction: 1.1.0.0 > 1.0.0.0 so not <=
+        Assert.IsFalse(Src.IsAtOrBelow1000('1.1.0.0'),
+            '1.1.0.0 <= 1.0.0.0 must be false');
+    end;
+
+    /// Positive: inline Version.Create('literal') < Version.Create(var) — literal on left side
+    [Test]
+    procedure InlineLiteralOnLeft_Above()
+    begin
+        // 1.0.0.0 < 2.0.0.0 is true
+        Assert.IsTrue(Src.IsAbove1000('2.0.0.0'),
+            '1.0.0.0 < 2.0.0.0 must be true');
+        // 1.0.0.0 < 1.0.0.0 is false
+        Assert.IsFalse(Src.IsAbove1000('1.0.0.0'),
+            '1.0.0.0 < 1.0.0.0 must be false');
+    end;
+
+    /// Positive: MajorFromLiteral returns non-default value, proving string is correctly parsed
+    [Test]
+    procedure MajorFromLiteral_ReturnsCorrectValue()
+    begin
+        // Must return 25, not 0 — proves the string overload actually parses '25.3.10000.5'
+        Assert.AreEqual(25, Src.MajorFromLiteral(), 'Major from string literal must be 25');
+    end;
+}


### PR DESCRIPTION
Closes #1322

## Problem

When BC emits `Version.Create('literal')` with a string literal in an inline expression (e.g. `Version.Create(ApiVersion) <= Version.Create('25.0.0.0')`), the BC compiler generates a C# `string` argument rather than `NavText`. `MockVersion.ALCreate` only accepted `NavText`, causing CS1503 19× per telemetry.

## Fix

Add `MockVersion.ALCreate(string versionText)` overload. The existing `ALCreate(NavText)` overload now delegates to the `string` overload so parsing logic stays in one place (DRY).

## Tests

New suite `tests/bucket-2/306-version-create-string` with 4 proving tests:

- `VariableVsVariable_LessOrEqual` — baseline, Text variable comparison
- `InlineLiteralOnRight_AtOrBelow` — `Version.Create(var) <= Version.Create('1.0.0.0')` (exact telemetry pattern)
- `InlineLiteralOnLeft_Above` — `Version.Create('1.0.0.0') < Version.Create(var)` (literal on left side)
- `MajorFromLiteral_ReturnsCorrectValue` — asserts 25 (non-default) to prove string is actually parsed

All 4 pass; bucket-2 full run: 1639 passed (no regressions).