### PR TITLE
fix: add MockPartFormHandle.Close/GetRecord — closes #1325

### DIFF
--- a/AlRunner/Runtime/MockPagePartHandle.cs
+++ b/AlRunner/Runtime/MockPagePartHandle.cs
@@ -53,6 +53,22 @@ public class MockPartFormHandle
     }
 
     /// <summary>
+    /// Close — no-op in standalone mode.
+    /// BC generates <c>CurrPage.SubPart.Page.Close()</c> as
+    /// <c>CurrPage.GetPart(hash).CreateNavFormHandle(scope).Close()</c>.
+    /// Issue #1325.
+    /// </summary>
+    public void Close() { }
+
+    /// <summary>
+    /// GetRecord — no-op in standalone mode.
+    /// BC generates <c>CurrPage.SubPart.Page.GetRecord(rec)</c> as
+    /// <c>CurrPage.GetPart(hash).CreateNavFormHandle(scope).GetRecord(rec.Target)</c>.
+    /// Issue #1325.
+    /// </summary>
+    public void GetRecord(MockRecordHandle rec) { }
+
+    /// <summary>
     /// SetTableView — no-op in standalone mode.
     /// BC generates <c>CurrPage.SubPart.Page.SetTableView(rec)</c> as
     /// <c>CurrPage.GetPart(hash).CreateNavFormHandle(scope).SetTableView(rec.Target)</c>.

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -5079,6 +5079,28 @@ Page.SetRecord (CurrPage):
   tests: tests/bucket-1/1262-page-bookmarktype
   notes: overloads=1; SetRecord(MockRecordHandle) on page class — BC lowers CurrPage.SetRecord(rec) to this.SetRecord(rec.Target); separate from MockFormHandle.SetRecord
 
+PagePart.Close:
+  layer: runtime-api
+  category: PagePart
+  status: covered
+  tests: tests/bucket-2/306-partformhandle-close-getrecord
+  notes: >
+    No-op stub on MockPartFormHandle. BC generates
+    CurrPage.SubPart.Page.Close() as
+    CurrPage.GetPart(hash).CreateNavFormHandle(scope).Close().
+    Issue #1325.
+
+PagePart.GetRecord:
+  layer: runtime-api
+  category: PagePart
+  status: covered
+  tests: tests/bucket-2/306-partformhandle-close-getrecord
+  notes: >
+    No-op stub on MockPartFormHandle. BC generates
+    CurrPage.SubPart.Page.GetRecord(rec) as
+    CurrPage.GetPart(hash).CreateNavFormHandle(scope).GetRecord(rec.Target).
+    Issue #1325.
+
 PagePart.SetTableView:
   layer: runtime-api
   category: PagePart

--- a/tests/bucket-2/306-partformhandle-close-getrecord/src/PfhSrc.al
+++ b/tests/bucket-2/306-partformhandle-close-getrecord/src/PfhSrc.al
@@ -1,0 +1,60 @@
+/// Source objects for MockPartFormHandle.Close / GetRecord tests (issue #1325).
+
+table 306001 "PFH Record"
+{
+    DataClassification = ToBeClassified;
+    fields
+    {
+        field(1; Id; Integer) { DataClassification = ToBeClassified; }
+        field(2; Name; Text[50]) { DataClassification = ToBeClassified; }
+    }
+    keys
+    {
+        key(PK; Id) { Clustered = true; }
+    }
+}
+
+/// ListPart subpage used to test Close and GetRecord on the part form handle.
+page 306001 "PFH Sub Page"
+{
+    PageType = ListPart;
+    SourceTable = "PFH Record";
+
+    layout
+    {
+        area(Content)
+        {
+            repeater(Lines)
+            {
+                field(Id; Rec.Id) { ApplicationArea = All; }
+                field(Name; Rec.Name) { ApplicationArea = All; }
+            }
+        }
+    }
+}
+
+/// Card page that hosts the subpage and exposes Close / GetRecord on the part.
+page 306002 "PFH Card Page"
+{
+    PageType = Card;
+
+    layout
+    {
+        area(Content)
+        {
+            part(SubPart; "PFH Sub Page") { ApplicationArea = All; }
+        }
+    }
+
+    /// Calls CurrPage.SubPart.Page.Close() — must compile and not throw.
+    procedure CallPartClose()
+    begin
+        CurrPage.SubPart.Page.Close();
+    end;
+
+    /// Calls CurrPage.SubPart.Page.GetRecord(rec) — must compile and not throw.
+    procedure CallPartGetRecord(var Rec: Record "PFH Record")
+    begin
+        CurrPage.SubPart.Page.GetRecord(Rec);
+    end;
+}

--- a/tests/bucket-2/306-partformhandle-close-getrecord/test/PfhTest.al
+++ b/tests/bucket-2/306-partformhandle-close-getrecord/test/PfhTest.al
@@ -1,0 +1,52 @@
+/// Tests for MockPartFormHandle.Close and GetRecord (issue #1325).
+codeunit 306003 "PFH Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    /// Positive: CurrPage.SubPart.Page.Close() must compile and execute without error.
+    /// A broken or missing Close stub would cause CS1061 at Roslyn compile time,
+    /// preventing the test codeunit from loading at all.
+    [Test]
+    procedure PartClose_NoThrow()
+    var
+        CardPage: Page "PFH Card Page";
+    begin
+        // WHEN the card page procedure that calls CurrPage.SubPart.Page.Close() is invoked
+        // THEN it must not throw — Close is a no-op in standalone mode.
+        CardPage.CallPartClose();
+        Assert.IsTrue(true, 'CurrPage.SubPart.Page.Close() must not throw');
+    end;
+
+    /// Positive: CurrPage.SubPart.Page.GetRecord(rec) must compile and execute without error.
+    /// A missing GetRecord stub would cause CS1061 at Roslyn compile time.
+    [Test]
+    procedure PartGetRecord_NoThrow()
+    var
+        CardPage: Page "PFH Card Page";
+        Rec: Record "PFH Record";
+    begin
+        // WHEN the card page procedure that calls CurrPage.SubPart.Page.GetRecord(rec) is invoked
+        // THEN it must not throw — GetRecord is a no-op in standalone mode.
+        CardPage.CallPartGetRecord(Rec);
+        Assert.IsTrue(true, 'CurrPage.SubPart.Page.GetRecord(rec) must not throw');
+    end;
+
+    /// Negative / proving: Close and GetRecord are distinct stubs, not aliases.
+    /// Calling them both in sequence must compile (both names must exist on the type)
+    /// and must not interfere with each other.
+    [Test]
+    procedure PartClose_And_GetRecord_AreDistinct()
+    var
+        CardPage: Page "PFH Card Page";
+        Rec: Record "PFH Record";
+    begin
+        // WHEN both part methods are called in sequence
+        // THEN neither throws, proving they are separate, independent stubs.
+        CardPage.CallPartClose();
+        CardPage.CallPartGetRecord(Rec);
+        Assert.IsTrue(true, 'Close and GetRecord must be independent stubs');
+    end;
+}


### PR DESCRIPTION
Closes #1325

## Summary

- Add no-op `Close()` stub to `MockPartFormHandle`: fixes `CS1061` when AL code calls `CurrPage.SubPart.Page.Close()`
- Add no-op `GetRecord(MockRecordHandle rec)` stub to `MockPartFormHandle`: fixes `CS1061` when AL code calls `CurrPage.SubPart.Page.GetRecord(rec)`
- Both methods follow the exact same no-op pattern as the existing `SetTableView`/`Update` stubs on the same type
- New test suite `306-partformhandle-close-getrecord` in `tests/bucket-2/` with 3 proving tests
- `docs/coverage.yaml` updated with `PagePart.Close` and `PagePart.GetRecord` entries

## Root cause

BC generates `CurrPage.SubPart.Page.Close()` as `CurrPage.GetPart(hash).CreateNavFormHandle(scope).Close()` and similarly for `GetRecord`. `MockPartFormHandle` lacked these method stubs, causing Roslyn `CS1061` compilation failures.