### PR TITLE
fix: add RecordRef.ReadPermission/SetAutoCalcFields — closes #1326

### DIFF
--- a/AlRunner/Runtime/MockRecordRef.cs
+++ b/AlRunner/Runtime/MockRecordRef.cs
@@ -667,6 +667,27 @@ public class MockRecordRef
     public int ALSystemModifiedAtNo => 2000000003;
     public int ALSystemModifiedByNo => 2000000004;
 
+    // -- ReadPermission — always true in standalone (no permission enforcement) --
+
+    /// <summary>
+    /// ALReadPermission — returns whether the current user has read permission on the table.
+    /// Standalone mode has no permission enforcement; always returns <c>true</c>.
+    /// BC compiler emits <c>recRef.ALReadPermission</c>.
+    /// </summary>
+    public bool ALReadPermission => true;
+
+    // -- SetAutoCalcFields — no-op in standalone (CalcFields computed on demand) --
+
+    /// <summary>
+    /// ALSetAutoCalcFields — marks FlowFields / FlowFilters that should be auto-calculated
+    /// when a record is fetched.  In standalone mode all fields are always available in memory
+    /// so this is a no-op.  BC compiler emits
+    /// <c>recRef.ALSetAutoCalcFields(DataError, params int[] fieldNos)</c> and
+    /// <c>recRef.ALSetAutoCalcFields(params int[] fieldNos)</c>.
+    /// </summary>
+    public void ALSetAutoCalcFields(params int[] fieldNos) { }
+    public void ALSetAutoCalcFields(DataError errorLevel, params int[] fieldNos) { }
+
     // -- ReadIsolation (no-op in standalone mode) --
     /// <summary>
     /// AL's RecordRef.ReadIsolation — sets read isolation level.

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -5727,7 +5727,8 @@ RecordRef.ReadPermission:
   layer: runtime-api
   category: RecordRef
   status: covered
-  notes: overloads=1
+  notes: overloads=1; MockRecordRef.ALReadPermission always returns true in standalone (no permission enforcement)
+  tests: tests/bucket-2/306-recref-readpermission-autocalcfields
 
 RecordRef.RecordId:
   layer: runtime-api
@@ -5765,7 +5766,8 @@ RecordRef.SetAutoCalcFields:
   layer: runtime-api
   category: RecordRef
   status: covered
-  notes: overloads=1
+  notes: overloads=2; MockRecordRef.ALSetAutoCalcFields(params int[]) and ALSetAutoCalcFields(DataError, params int[]); no-op in standalone (all fields always available in memory). Fixed CS1061 in issue #1326.
+  tests: tests/bucket-2/306-recref-readpermission-autocalcfields
 
 RecordRef.SetLoadFields:
   layer: runtime-api

--- a/tests/bucket-2/306-recref-readpermission-autocalcfields/src/RecRefPermHelper.al
+++ b/tests/bucket-2/306-recref-readpermission-autocalcfields/src/RecRefPermHelper.al
@@ -1,0 +1,60 @@
+table 306000 "RecRef Perm Table"
+{
+    fields
+    {
+        field(1; "Entry No."; Integer) { }
+        field(2; "Amount"; Decimal) { }
+        field(3; "Description"; Text[100]) { }
+    }
+
+    keys
+    {
+        key(PK; "Entry No.") { }
+    }
+}
+
+codeunit 306001 "RecRef Perm Helper"
+{
+    procedure TestReadPermission(): Boolean
+    var
+        RecRef: RecordRef;
+    begin
+        RecRef.Open(Database::"RecRef Perm Table");
+        // ReadPermission returns true in standalone mode (no permission enforcement)
+        exit(RecRef.ReadPermission);
+    end;
+
+    procedure TestSetAutoCalcFieldsNoThrow(): Boolean
+    var
+        RecRef: RecordRef;
+        FldRef: FieldRef;
+    begin
+        RecRef.Open(Database::"RecRef Perm Table");
+        FldRef := RecRef.Field(2);
+        // SetAutoCalcFields should not throw
+        RecRef.SetAutoCalcFields(FldRef.Number);
+        exit(true);
+    end;
+
+    procedure TestSetAutoCalcFieldsMultiple(): Boolean
+    var
+        RecRef: RecordRef;
+        FldRef2: FieldRef;
+        FldRef3: FieldRef;
+    begin
+        RecRef.Open(Database::"RecRef Perm Table");
+        FldRef2 := RecRef.Field(2);
+        FldRef3 := RecRef.Field(3);
+        // Passing multiple field numbers should not throw
+        RecRef.SetAutoCalcFields(FldRef2.Number, FldRef3.Number);
+        exit(true);
+    end;
+
+    procedure TestReadPermissionOnClosedRef(): Boolean
+    var
+        RecRef: RecordRef;
+    begin
+        // ReadPermission on an unopen RecordRef; always true in standalone
+        exit(RecRef.ReadPermission);
+    end;
+}

--- a/tests/bucket-2/306-recref-readpermission-autocalcfields/src/RecRefPermHelper.al
+++ b/tests/bucket-2/306-recref-readpermission-autocalcfields/src/RecRefPermHelper.al
@@ -1,4 +1,4 @@
-table 306000 "RecRef Perm Table"
+table 306020 "RecRef Perm Table"
 {
     fields
     {
@@ -13,7 +13,7 @@ table 306000 "RecRef Perm Table"
     }
 }
 
-codeunit 306001 "RecRef Perm Helper"
+codeunit 306021 "RecRef Perm Helper"
 {
     procedure TestReadPermission(): Boolean
     var

--- a/tests/bucket-2/306-recref-readpermission-autocalcfields/test/RecRefPermTest.al
+++ b/tests/bucket-2/306-recref-readpermission-autocalcfields/test/RecRefPermTest.al
@@ -1,4 +1,4 @@
-codeunit 306010 "RecRef Perm Test"
+codeunit 306022 "RecRef Perm Test"
 {
     Subtype = Test;
 

--- a/tests/bucket-2/306-recref-readpermission-autocalcfields/test/RecRefPermTest.al
+++ b/tests/bucket-2/306-recref-readpermission-autocalcfields/test/RecRefPermTest.al
@@ -1,0 +1,43 @@
+codeunit 306010 "RecRef Perm Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    [Test]
+    procedure ReadPermission_ReturnsTrue()
+    // Proves ReadPermission returns true (not a default false stub)
+    var
+        Helper: Codeunit "RecRef Perm Helper";
+    begin
+        Assert.IsTrue(Helper.TestReadPermission(), 'ReadPermission should return true in standalone mode');
+    end;
+
+    [Test]
+    procedure ReadPermission_OnClosedRef_ReturnsTrue()
+    // Even on a closed RecordRef, ReadPermission should be true (no permission enforcement)
+    var
+        Helper: Codeunit "RecRef Perm Helper";
+    begin
+        Assert.IsTrue(Helper.TestReadPermissionOnClosedRef(), 'ReadPermission on closed RecordRef should return true');
+    end;
+
+    [Test]
+    procedure SetAutoCalcFields_SingleField_NoThrow()
+    // Proves SetAutoCalcFields(FldRef.Number) compiles and runs without error
+    var
+        Helper: Codeunit "RecRef Perm Helper";
+    begin
+        Assert.IsTrue(Helper.TestSetAutoCalcFieldsNoThrow(), 'SetAutoCalcFields with one field number should not throw');
+    end;
+
+    [Test]
+    procedure SetAutoCalcFields_MultipleFields_NoThrow()
+    // Proves SetAutoCalcFields(n, m) compiles and runs without error
+    var
+        Helper: Codeunit "RecRef Perm Helper";
+    begin
+        Assert.IsTrue(Helper.TestSetAutoCalcFieldsMultiple(), 'SetAutoCalcFields with multiple field numbers should not throw');
+    end;
+}


### PR DESCRIPTION
Closes #1326

## Problem

`MockRecordRef` was missing two members that the BC compiler emits when compiling AL code that uses `RecordRef.ReadPermission` and `RecordRef.SetAutoCalcFields(FldRef.Number())`:

- `ALReadPermission` — property (bool)
- `ALSetAutoCalcFields` — method with two overloads: `(params int[])` and `(DataError, params int[])`

This caused `CS1061` compilation failures at runtime.

## Solution

- `ALReadPermission` — new bool property on `MockRecordRef`, always returns `true` (no permission enforcement in standalone mode).
- `ALSetAutoCalcFields(params int[] fieldNos)` — no-op (all fields always in memory; CalcFields computed on demand).
- `ALSetAutoCalcFields(DataError errorLevel, params int[] fieldNos)` — BC compiler emits the `DataError`-prefixed form; also a no-op.

## Tests

New suite `tests/bucket-2/306-recref-readpermission-autocalcfields`:
- `ReadPermission_ReturnsTrue` — asserts `true`, not just "no crash"
- `ReadPermission_OnClosedRef_ReturnsTrue` — proves result is `true` even on a closed RecordRef
- `SetAutoCalcFields_SingleField_NoThrow` — proves `SetAutoCalcFields(FldRef.Number)` compiles and runs
- `SetAutoCalcFields_MultipleFields_NoThrow` — proves multi-field overload also works

4/4 tests pass (GREEN).