### PR TITLE
fix: add MockReportHandle.ALAssign — closes #1328

### DIFF
--- a/AlRunner/Runtime/MockReportHandle.cs
+++ b/AlRunner/Runtime/MockReportHandle.cs
@@ -366,6 +366,22 @@ public class MockReportHandle
     }
 
     /// <summary>
+    /// AL assignment: <c>Rep1 := Rep2</c>.
+    /// The BC compiler emits <c>Rep1.ALAssign(Rep2)</c> for report variable assignment.
+    /// Copies the report ID, table-view filter, and internal report instance reference
+    /// so both variables point at the same execution state — matching AL semantics.
+    /// </summary>
+    public void ALAssign(MockReportHandle other)
+    {
+        // ReportId is init-only; share internal state by copying mutable fields.
+        _reportInstance = other._reportInstance;
+        _tableView = other._tableView;
+        UseRequestForm = other.UseRequestForm;
+        FormatRegion = other.FormatRegion;
+        Language = other.Language;
+    }
+
+    /// <summary>
     /// AL's <c>Clear(rep)</c> — the rewriter emits <c>rep.Clear()</c>. Resets the
     /// report handle to its default (un-run) state. No-op in standalone mode.
     /// </summary>

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -5848,6 +5848,13 @@ RecordRef.WritePermission:
 
 # ── Report ──────────────────────────────────────────────────────
 
+Report.ALAssign:
+  layer: runtime-api
+  category: Report
+  status: covered
+  tests: tests/bucket-2/111-report-alassign
+  notes: "overloads=1; AL Rep1 := Rep2 emits Rep1.ALAssign(Rep2) — added to MockReportHandle; copies _reportInstance, _tableView, UseRequestForm, FormatRegion, Language — closes #1328."
+
 Report.Clear:
   layer: runtime-api
   category: Report

--- a/tests/bucket-2/111-report-alassign/src/RasSrc.al
+++ b/tests/bucket-2/111-report-alassign/src/RasSrc.al
@@ -1,0 +1,33 @@
+/// Minimal report stub for Report.ALAssign coverage (issue #1328).
+report 307200 "RAS Report"
+{
+    dataset { }
+}
+
+/// Source codeunit exercising Report := Report assignment (ALAssign).
+/// BC compiler lowers Rep1 := Rep2 to Rep1.ALAssign(Rep2) on MockReportHandle.
+codeunit 307201 "RAS Src"
+{
+    /// Assign one report variable to another and run the assigned variable.
+    /// This exercises the Rep1 := Rep2 path which emits ALAssign on the handle.
+    procedure AssignAndRun(): Boolean
+    var
+        Rep1: Report "RAS Report";
+        Rep2: Report "RAS Report";
+    begin
+        Rep1 := Rep2;   // BC compiler emits Rep1.ALAssign(Rep2)
+        exit(true);
+    end;
+
+    /// Assign twice to ensure the handle state is properly replaced each time.
+    procedure AssignTwice(): Boolean
+    var
+        Rep1: Report "RAS Report";
+        Rep2: Report "RAS Report";
+        Rep3: Report "RAS Report";
+    begin
+        Rep1 := Rep2;
+        Rep1 := Rep3;
+        exit(true);
+    end;
+}

--- a/tests/bucket-2/111-report-alassign/test/RasTest.al
+++ b/tests/bucket-2/111-report-alassign/test/RasTest.al
@@ -1,0 +1,42 @@
+/// Tests proving that Report := Report assignment compiles and runs correctly.
+/// Covers issue #1328: MockReportHandle was missing ALAssign(),
+/// causing CS1061 at Roslyn compile time.
+codeunit 307202 "RAS Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "RAS Src";
+
+    [Test]
+    procedure ReportAssign_DoesNotThrow()
+    begin
+        // [GIVEN] Two report variables
+        // [WHEN]  Rep1 := Rep2 is executed (compiler emits Rep1.ALAssign(Rep2))
+        // [THEN]  No error is raised and the procedure returns true
+        Assert.IsTrue(Src.AssignAndRun(), 'Report := Report assignment must not throw');
+    end;
+
+    [Test]
+    procedure ReportAssignTwice_DoesNotThrow()
+    begin
+        // [GIVEN] Three report variables
+        // [WHEN]  Rep1 is assigned twice from different sources
+        // [THEN]  No error is raised
+        Assert.IsTrue(Src.AssignTwice(), 'Double Report := Report assignment must not throw');
+    end;
+
+    [Test]
+    procedure ReportAssignInline_DoesNotThrow()
+    var
+        Rep1: Report "RAS Report";
+        Rep2: Report "RAS Report";
+    begin
+        // [GIVEN] Two report variables declared inline in the test
+        // [WHEN]  Assignment is done directly in test body
+        Rep1 := Rep2;
+        // [THEN]  No error
+        Assert.IsTrue(true, 'Inline Report := Report must not throw');
+    end;
+}


### PR DESCRIPTION
Closes #1328

## Problem

BC compiler emits `Rep1.ALAssign(Rep2)` for Report variable assignment (`Rep1 := Rep2` in AL). `MockReportHandle` was missing this method, causing `CS1061` at Roslyn compile time when code like `SuggestVendorPayments.Execute(Parameters)` uses report variable assignment.

## Solution

Added `MockReportHandle.ALAssign(MockReportHandle other)` that copies the mutable handle state:
- `_reportInstance` — the cached runtime report class instance
- `_tableView` — any SetTableView filter
- `UseRequestForm` — request page flag
- `FormatRegion` / `Language` — report settings

`ReportId` is intentionally not copied (it is init-only via constructor) — in AL, both sides of `Rep1 := Rep2` are the same report type, so the ID is already correct.

## Tests

New suite `tests/bucket-2/111-report-alassign` (IDs 307200–307202):
- `ReportAssign_DoesNotThrow` — positive: assignment compiles and returns true
- `ReportAssignTwice_DoesNotThrow` — positive: double-assignment works
- `ReportAssignInline_DoesNotThrow` — positive: inline test-body assignment works

All 3 tests pass (GREEN). Confirmed RED (4× CS1061 errors) before the fix.

## Coverage

Added `Report.ALAssign` entry to `docs/coverage.yaml`.