### PR TITLE
fix: add MockVersion.ALCreate 2-arg and 3-arg overloads — closes #1323

### DIFF
--- a/AlRunner/Runtime/MockVersion.cs
+++ b/AlRunner/Runtime/MockVersion.cs
@@ -40,6 +40,33 @@ public struct MockVersion
         => ALCreate(null, major, minor, build, revision);
 
     /// <summary>
+    /// BC lowers <c>Version.Create(major, minor, build)</c>
+    /// to <c>NavVersion.ALCreate(major, minor, build)</c>.
+    /// Build is set; revision defaults to 0.
+    /// </summary>
+    public static MockVersion ALCreate(object? major, object? minor, object? build)
+    {
+        var result = new MockVersion();
+        result._major = AlCompat.NavIndirectValueToInt32(major);
+        result._minor = AlCompat.NavIndirectValueToInt32(minor);
+        result._build = AlCompat.NavIndirectValueToInt32(build);
+        return result;
+    }
+
+    /// <summary>
+    /// BC lowers <c>Version.Create(major, minor)</c>
+    /// to <c>NavVersion.ALCreate(major, minor)</c>.
+    /// Build and revision default to 0.
+    /// </summary>
+    public static MockVersion ALCreate(object? major, object? minor)
+    {
+        var result = new MockVersion();
+        result._major = AlCompat.NavIndirectValueToInt32(major);
+        result._minor = AlCompat.NavIndirectValueToInt32(minor);
+        return result;
+    }
+
+    /// <summary>
     /// BC lowers <c>Version.Create(Text)</c> to <c>NavVersion.ALCreate(text)</c>.
     /// Parses a dotted version string (e.g. <c>"25.1.30000.12345"</c>) into its
     /// major/minor/build/revision components.

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -9748,6 +9748,20 @@ Version.Create (1-arg string literal):
   tests: tests/bucket-2/306-version-create-string
   notes: overloads=1; ALCreate(string) overload added in #1322 to fix CS1503 when BC emits a C# string (not NavText) for string-literal arguments like Version.Create('25.0.0.0') in inline expressions
 
+Version.Create (2-arg major/minor):
+  layer: runtime-api
+  category: Version
+  status: covered
+  tests: tests/bucket-2/307-version-create-2arg
+  notes: overloads=1; ALCreate(major,minor) overload added in #1323 to fix CS1501 when BC emits NavVersion.ALCreate(major,minor) for Version.Create(major,minor) — build and revision default to 0
+
+Version.Create (3-arg major/minor/build):
+  layer: runtime-api
+  category: Version
+  status: covered
+  tests: tests/bucket-2/307-version-create-2arg
+  notes: overloads=1; ALCreate(major,minor,build) overload added in #1323 to fix CS1501 when BC emits NavVersion.ALCreate(major,minor,build) for Version.Create(major,minor,build) — revision defaults to 0
+
 Version.Major:
   layer: runtime-api
   category: Version

--- a/tests/bucket-2/307-version-create-2arg/src/VersionCreate2ArgHelper.al
+++ b/tests/bucket-2/307-version-create-2arg/src/VersionCreate2ArgHelper.al
@@ -1,0 +1,17 @@
+codeunit 307000 "Version Create 2Arg Helper"
+{
+    procedure CreateMajorMinor(Major: Integer; Minor: Integer): Version
+    begin
+        exit(Version.Create(Major, Minor));
+    end;
+
+    procedure CreateMajorMinorBuild(Major: Integer; Minor: Integer; Build: Integer): Version
+    begin
+        exit(Version.Create(Major, Minor, Build));
+    end;
+
+    procedure CreateMajorMinorBuildRevision(Major: Integer; Minor: Integer; Build: Integer; Revision: Integer): Version
+    begin
+        exit(Version.Create(Major, Minor, Build, Revision));
+    end;
+}

--- a/tests/bucket-2/307-version-create-2arg/test/VersionCreate2ArgTest.al
+++ b/tests/bucket-2/307-version-create-2arg/test/VersionCreate2ArgTest.al
@@ -1,0 +1,61 @@
+codeunit 307001 "Version Create 2Arg Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit "Library Assert";
+
+    [Test]
+    procedure Create2Arg_MajorMinor_PopulatesCorrectly()
+    var
+        Helper: Codeunit "Version Create 2Arg Helper";
+        Ver: Version;
+    begin
+        // Positive: Version.Create(major, minor) sets major/minor and zeroes build/revision
+        Ver := Helper.CreateMajorMinor(5, 3);
+        Assert.AreEqual(5, Ver.Major(), 'Major must be 5');
+        Assert.AreEqual(3, Ver.Minor(), 'Minor must be 3');
+        Assert.AreEqual(0, Ver.Build(), 'Build must default to 0');
+        Assert.AreEqual(0, Ver.Revision(), 'Revision must default to 0');
+    end;
+
+    [Test]
+    procedure Create2Arg_NonDefaultValues_NotZero()
+    var
+        Helper: Codeunit "Version Create 2Arg Helper";
+        Ver: Version;
+    begin
+        // Positive: non-zero values are stored — proves the mock is not a no-op
+        Ver := Helper.CreateMajorMinor(17, 42);
+        Assert.AreEqual(17, Ver.Major(), 'Major must be 17, not zero-default');
+        Assert.AreEqual(42, Ver.Minor(), 'Minor must be 42, not zero-default');
+    end;
+
+    [Test]
+    procedure Create3Arg_MajorMinorBuild_PopulatesCorrectly()
+    var
+        Helper: Codeunit "Version Create 2Arg Helper";
+        Ver: Version;
+    begin
+        // Positive: Version.Create(major, minor, build) sets all three; revision defaults to 0
+        Ver := Helper.CreateMajorMinorBuild(2, 1, 500);
+        Assert.AreEqual(2, Ver.Major(), 'Major must be 2');
+        Assert.AreEqual(1, Ver.Minor(), 'Minor must be 1');
+        Assert.AreEqual(500, Ver.Build(), 'Build must be 500');
+        Assert.AreEqual(0, Ver.Revision(), 'Revision must default to 0');
+    end;
+
+    [Test]
+    procedure Create4Arg_AllComponents_PopulatesCorrectly()
+    var
+        Helper: Codeunit "Version Create 2Arg Helper";
+        Ver: Version;
+    begin
+        // Positive: Version.Create(major, minor, build, revision) sets all four components
+        Ver := Helper.CreateMajorMinorBuildRevision(7, 3, 100, 42);
+        Assert.AreEqual(7, Ver.Major(), 'Major must be 7');
+        Assert.AreEqual(3, Ver.Minor(), 'Minor must be 3');
+        Assert.AreEqual(100, Ver.Build(), 'Build must be 100');
+        Assert.AreEqual(42, Ver.Revision(), 'Revision must be 42');
+    end;
+}


### PR DESCRIPTION
Closes #1323

## Root cause

BC lowers `Version.Create(major, minor)` to `NavVersion.ALCreate(major, minor)` (2 args) and `Version.Create(major, minor, build)` to `NavVersion.ALCreate(major, minor, build)` (3 args). Neither overload existed in `MockVersion`, causing CS1501 compilation gaps reported 18× in telemetry.

## Fix

Added two new overloads to `MockVersion`:
- `ALCreate(object? major, object? minor)` — sets major/minor; build and revision default to 0
- `ALCreate(object? major, object? minor, object? build)` — sets major/minor/build; revision defaults to 0

## Tests

New suite `tests/bucket-2/307-version-create-2arg` (IDs 307000–307001) covers:
- `Create2Arg_MajorMinor_PopulatesCorrectly` — positive: major/minor set correctly, build/revision = 0
- `Create2Arg_NonDefaultValues_NotZero` — proves mock is not a no-op (non-default values stored)
- `Create3Arg_MajorMinorBuild_PopulatesCorrectly` — positive: major/minor/build set; revision = 0
- `Create4Arg_AllComponents_PopulatesCorrectly` — existing 4-arg form still works