### PR TITLE
fix: add StaticRunRequestPage 2-arg overload — closes #1329

### DIFF
--- a/AlRunner/Runtime/MockReportHandle.cs
+++ b/AlRunner/Runtime/MockReportHandle.cs
@@ -427,6 +427,13 @@ public class MockReportHandle
     // Report.RunRequestPage — no request page UI in standalone mode
     public static string StaticRunRequestPage(int reportId) => string.Empty;
 
+    /// <summary>
+    /// BC emits <c>MockReportHandle.StaticRunRequestPage(reportId, requestParameters)</c>
+    /// for <c>Report.RunRequestPage(ReportId, RequestPageParameters)</c>.
+    /// Returns empty string in standalone mode (no UI available).
+    /// </summary>
+    public static string StaticRunRequestPage(int reportId, string requestParameters) => string.Empty;
+
     // Report.ValidateAndPrepareLayout / Report.WordXmlPart — no-ops
     public static void StaticValidateAndPrepareLayout(int reportId) { }
 

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -5941,13 +5941,22 @@ Report.RunModal:
     - tests/bucket-1/90-report-static
     - tests/bucket-1/287-report-runmodal-4arg
 
-Report.RunRequestPage:
+Report.RunRequestPage (1-arg):
   layer: runtime-api
   category: Report
   status: covered
-  notes: overloads=1; NavReport.RunRequestPage → MockReportHandle.StaticRunRequestPage (returns empty string).
+  notes: NavReport.RunRequestPage(ReportId) → MockReportHandle.StaticRunRequestPage(int) (returns empty string).
   tests:
     - tests/bucket-1/90-report-static
+    - tests/bucket-2/301-report-static-runrequestpage
+
+Report.RunRequestPage (2-arg):
+  layer: runtime-api
+  category: Report
+  status: covered
+  notes: NavReport.RunRequestPage(ReportId, RequestPageParameters) → MockReportHandle.StaticRunRequestPage(int, string) (returns empty string in standalone mode). Fixes CS1501 compilation gap — issue #1329.
+  tests:
+    - tests/bucket-2/301-report-static-runrequestpage
 
 Report.SaveAs:
   layer: runtime-api

--- a/tests/bucket-2/301-report-static-runrequestpage/src/ReportRunRequestPageSrc.al
+++ b/tests/bucket-2/301-report-static-runrequestpage/src/ReportRunRequestPageSrc.al
@@ -1,0 +1,15 @@
+/// Exercises Report.RunRequestPage with the 2-argument overload (reportId, requestParameters).
+codeunit 307400 "RRP Src"
+{
+    /// Call Report.RunRequestPage(reportId, requestParameters) — 2-arg overload.
+    procedure RunRequestPage2Arg(reportId: Integer; requestParameters: Text): Text
+    begin
+        exit(Report.RunRequestPage(reportId, requestParameters));
+    end;
+
+    /// Call Report.RunRequestPage(reportId) — 1-arg overload (regression guard).
+    procedure RunRequestPage1Arg(reportId: Integer): Text
+    begin
+        exit(Report.RunRequestPage(reportId));
+    end;
+}

--- a/tests/bucket-2/301-report-static-runrequestpage/test/ReportRunRequestPageTest.al
+++ b/tests/bucket-2/301-report-static-runrequestpage/test/ReportRunRequestPageTest.al
@@ -1,0 +1,50 @@
+/// Tests for Report.RunRequestPage 2-arg overload — issue #1329.
+codeunit 307401 "RRP Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    [Test]
+    procedure Report_RunRequestPage_2Arg_ReturnsText()
+    var
+        Src: Codeunit "RRP Src";
+        Result: Text;
+    begin
+        // [GIVEN] A valid (dummy) report id and non-empty request parameters
+        // [WHEN]  Report.RunRequestPage(reportId, requestParameters) is called
+        Result := Src.RunRequestPage2Arg(99999, '<ReqParams />');
+
+        // [THEN]  Returns empty string in standalone mode (no UI, no request page rendered)
+        Assert.AreEqual('', Result, 'RunRequestPage 2-arg must return empty string in standalone mode');
+    end;
+
+    [Test]
+    procedure Report_RunRequestPage_2Arg_EmptyParams_ReturnsText()
+    var
+        Src: Codeunit "RRP Src";
+        Result: Text;
+    begin
+        // [GIVEN] A valid (dummy) report id and an empty request parameters string
+        // [WHEN]  Report.RunRequestPage(reportId, '') is called
+        Result := Src.RunRequestPage2Arg(99999, '');
+
+        // [THEN]  Returns empty string in standalone mode
+        Assert.AreEqual('', Result, 'RunRequestPage 2-arg with empty params must return empty string in standalone mode');
+    end;
+
+    [Test]
+    procedure Report_RunRequestPage_1Arg_StillWorks()
+    var
+        Src: Codeunit "RRP Src";
+        Result: Text;
+    begin
+        // [GIVEN] A valid (dummy) report id
+        // [WHEN]  Report.RunRequestPage(reportId) 1-arg overload is called
+        Result := Src.RunRequestPage1Arg(99999);
+
+        // [THEN]  Returns empty string in standalone mode (regression guard)
+        Assert.AreEqual('', Result, 'RunRequestPage 1-arg must still return empty string in standalone mode');
+    end;
+}


### PR DESCRIPTION
Closes #1329

## Problem

`Report.RunRequestPage(ReportId, RequestPageParameters)` (2-arg overload) was not handled by the runner. The BC compiler emits `MockReportHandle.StaticRunRequestPage(int, string)` for this call, but only the 1-arg form `StaticRunRequestPage(int)` existed, causing:

```
CS1501: No overload for method 'StaticRunRequestPage' takes 2 arguments
```

## Fix

Added `StaticRunRequestPage(int reportId, string requestParameters)` overload to `MockReportHandle`. Returns empty string in standalone mode (no request page UI available), consistent with the existing 1-arg behaviour.

## Tests

New suite `tests/bucket-2/301-report-static-runrequestpage` with 3 proving tests:
- `Report_RunRequestPage_2Arg_ReturnsText` — 2-arg with non-empty params compiles and returns `''`
- `Report_RunRequestPage_2Arg_EmptyParams_ReturnsText` — 2-arg with empty params compiles and returns `''`
- `Report_RunRequestPage_1Arg_StillWorks` — regression guard for existing 1-arg overload

## Coverage

Updated `docs/coverage.yaml` with separate overload-level entries for `Report.RunRequestPage (1-arg)` and `Report.RunRequestPage (2-arg)`.