### PR TITLE
fix: add ALViewFromStream 4-arg overload — closes #1331

### DIFF
--- a/AlRunner/Runtime/MockFile.cs
+++ b/AlRunner/Runtime/MockFile.cs
@@ -210,6 +210,20 @@ public class MockFile
     public void ALViewFromStream(object? parent, MockInStream inStream) { }
 
     /// <summary>
+    /// ALViewFromStream static 3-arg overload — BC emits this for the 2-arg AL form:
+    ///   File.ViewFromStream(InStream, FileName).
+    /// BC passes DataError as the first arg. No-op; no UI in standalone mode.
+    /// </summary>
+    public static void ALViewFromStream(object? scope, MockInStream inStream, string fileName) { }
+
+    /// <summary>
+    /// ALViewFromStream static 4-arg overload — BC emits this for the 3-arg AL form:
+    ///   File.ViewFromStream(InStream, FileName, IsEditable).
+    /// BC passes DataError as the first arg. No-op; no UI in standalone mode.
+    /// </summary>
+    public static void ALViewFromStream(object? scope, MockInStream inStream, string fileName, bool isEditable) { }
+
+    /// <summary>
     /// ALUploadIntoStream — BC standalone UploadIntoStream maps here as a static.
     /// BC emits (scope, title, folder, filter, ByRef&lt;NavText&gt; fileName, MockInStream inStream, Guid extra).
     /// Always returns false (no UI in standalone mode).

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -2996,6 +2996,20 @@ File.ViewFromStream:
   notes: overloads=1; MockFile.ALViewFromStream() no-op (no UI in standalone)
   test: tests/bucket-1/87-file-io/test/FileTest.al
 
+File.ViewFromStream (3-arg):
+  layer: runtime-api
+  category: File
+  status: covered
+  notes: static overload (scope, InStream, FileName); 2-arg AL form File.ViewFromStream(InStream, FileName)
+  test: tests/bucket-2/307-viewfromstream-4arg/test/ViewFromStreamTests.al
+
+File.ViewFromStream (4-arg):
+  layer: runtime-api
+  category: File
+  status: covered
+  notes: static overload (scope, InStream, FileName, IsEditable); 3-arg AL form File.ViewFromStream(InStream, FileName, IsEditable); fixes CS1501 telemetry gap
+  test: tests/bucket-2/307-viewfromstream-4arg/test/ViewFromStreamTests.al
+
 File.Write:
   layer: runtime-api
   category: File

--- a/tests/bucket-2/307-viewfromstream-4arg/src/ViewFromStreamHelper.al
+++ b/tests/bucket-2/307-viewfromstream-4arg/src/ViewFromStreamHelper.al
@@ -1,0 +1,30 @@
+codeunit 307500 "ViewFromStream Helper"
+{
+    /// <summary>
+    /// Calls ViewFromStream with 3 AL args: InStream, FileName, IsEditable.
+    /// BC emits this as the 4-arg C# form:
+    ///   ALViewFromStream(parent, inStream, fileName, isEditable)
+    /// </summary>
+    procedure CallViewFromStream4Arg()
+    var
+        InStr: InStream;
+    begin
+        // 3-arg AL form: InStream, FileName, IsEditable
+        // BC transpiles to ALViewFromStream(parent, InStr, 'test.txt', true) — 4 C# args
+        File.ViewFromStream(InStr, 'test.txt', true);
+    end;
+
+    /// <summary>
+    /// Calls ViewFromStream with 2 AL args: InStream, FileName.
+    /// BC emits this as the 3-arg C# form:
+    ///   ALViewFromStream(parent, inStream, fileName)
+    /// </summary>
+    procedure CallViewFromStream3Arg()
+    var
+        InStr: InStream;
+    begin
+        // 2-arg AL form: InStream, FileName
+        // BC transpiles to ALViewFromStream(parent, InStr, 'test.txt') — 3 C# args
+        File.ViewFromStream(InStr, 'test.txt');
+    end;
+}

--- a/tests/bucket-2/307-viewfromstream-4arg/test/ViewFromStreamTests.al
+++ b/tests/bucket-2/307-viewfromstream-4arg/test/ViewFromStreamTests.al
@@ -1,0 +1,36 @@
+codeunit 307501 "ViewFromStream Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    /// <summary>
+    /// Positive: ViewFromStream(InStream, FileName, IsEditable) is a no-op in standalone mode
+    /// — it must not throw. This is the 3-arg AL form which BC transpiles to the 4-arg C# call
+    /// ALViewFromStream(parent, inStream, fileName, isEditable).
+    /// </summary>
+    [Test]
+    procedure ViewFromStream_4Arg_NoThrow()
+    var
+        Helper: Codeunit "ViewFromStream Helper";
+    begin
+        // Verifies that ALViewFromStream with 4 C# args compiles and runs without error.
+        // The entire claim is "this does not crash" — the overload is a no-op in standalone mode.
+        Helper.CallViewFromStream4Arg();
+    end;
+
+    /// <summary>
+    /// Positive: ViewFromStream(InStream, FileName) is a no-op in standalone mode
+    /// — it must not throw. This is the 2-arg AL form which BC transpiles to the 3-arg C# call
+    /// ALViewFromStream(parent, inStream, fileName).
+    /// </summary>
+    [Test]
+    procedure ViewFromStream_3Arg_NoThrow()
+    var
+        Helper: Codeunit "ViewFromStream Helper";
+    begin
+        // Verifies that ALViewFromStream with 3 C# args compiles and runs without error.
+        Helper.CallViewFromStream3Arg();
+    end;
+}


### PR DESCRIPTION
Closes #1331

## Problem

BC transpiles the 2-arg AL form `File.ViewFromStream(InStream, FileName)` and the 3-arg AL form `File.ViewFromStream(InStream, FileName, IsEditable)` as **static** calls to `MockFile`:

- 2-arg AL → `MockFile.ALViewFromStream(DataError.ThrowError, inStream, fileName)` (3 C# args)
- 3-arg AL → `MockFile.ALViewFromStream(DataError.ThrowError, inStream, fileName, isEditable)` (4 C# args)

`MockFile` only had an **instance** 2-arg overload `(object? parent, MockInStream inStream)`, so both static forms produced `CS1501: No overload for method 'ALViewFromStream' takes N arguments`.

## Fix

Added two static no-op overloads to `MockFile`:
- `public static void ALViewFromStream(object? scope, MockInStream inStream, string fileName)` (3 C# args)
- `public static void ALViewFromStream(object? scope, MockInStream inStream, string fileName, bool isEditable)` (4 C# args)

## Tests (TDD)

New suite `tests/bucket-2/307-viewfromstream-4arg/` with AL IDs 307500–307501:
- `ViewFromStream_4Arg_NoThrow` — verifies `ALViewFromStream` with 4 C# args compiles and runs without error
- `ViewFromStream_3Arg_NoThrow` — verifies `ALViewFromStream` with 3 C# args compiles and runs without error

Both tests confirmed RED before the fix and GREEN after.

## Coverage

Updated `docs/coverage.yaml` with separate entries for `File.ViewFromStream (3-arg)` and `File.ViewFromStream (4-arg)`.