### PR TITLE
fix: add Report.Run 3-arg overload (no systemPrinter) — closes #1336

### DIFF
--- a/AlRunner/Runtime/MockReportHandle.cs
+++ b/AlRunner/Runtime/MockReportHandle.cs
@@ -310,6 +310,17 @@ public class MockReportHandle
     }
 
     /// <summary>
+    /// Static Report.Run(reportId, requestPage, systemPrinter) — 3-argument overload.
+    /// BC emits this form when no record argument is supplied (e.g. <c>Report.Run(id, true)</c>).
+    /// <paramref name="requestPage"/> and <paramref name="systemPrinter"/> are ignored in standalone mode.
+    /// </summary>
+    public static void StaticRun(int reportId, bool requestPage, bool systemPrinter)
+    {
+        var handle = new MockReportHandle(reportId) { UseRequestForm = requestPage };
+        handle.Run();
+    }
+
+    /// <summary>
     /// Static Report.Run(reportId, requestPage, systemPrinter, record) — 4-argument overload.
     /// <paramref name="requestPage"/> and <paramref name="systemPrinter"/> are ignored in standalone mode.
     /// <paramref name="record"/> is applied as a table-view filter when it is a <see cref="MockRecordHandle"/>.

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -5955,10 +5955,19 @@ Report.Run:
   layer: runtime-api
   category: Report
   status: covered
-  notes: "overloads=2 (1-arg, 4-arg); NavReport.Run → MockReportHandle.StaticRun (no-op/handler dispatch). 4-arg adds requestPage, systemPrinter, record Variant (stored via SetTableView if MockRecordHandle)."
+  notes: "overloads=3 (1-arg, 3-arg, 4-arg); NavReport.Run → MockReportHandle.StaticRun (no-op/handler dispatch). 3-arg adds requestPage+systemPrinter (no record); 4-arg adds record Variant (stored via SetTableView if MockRecordHandle). Fixes CS7036 gap — issue #1336."
   tests:
     - tests/bucket-1/90-report-static
     - tests/bucket-1/298-report-run-4arg
+    - tests/bucket-1/300-report-run-3arg
+
+Report.Run (3-arg):
+  layer: runtime-api
+  category: Report
+  status: covered
+  notes: "Report.Run(ReportId, RequestPage, SystemPrinter) — 3-arg overload. BC emits this when no record is passed. Fixes CS7036 'systemPrinter' missing argument — issue #1336."
+  tests:
+    - tests/bucket-1/300-report-run-3arg
 
 Report.RunModal:
   layer: runtime-api

--- a/tests/bucket-1/300-report-run-3arg/src/src.al
+++ b/tests/bucket-1/300-report-run-3arg/src/src.al
@@ -1,0 +1,35 @@
+/// Source objects for Report.Run 3-arg overload test (issue #1336).
+/// BC emits Report.Run(ReportId, RequestPage, SystemPrinter) — no record argument.
+report 308200 "RR3 Report"
+{
+    dataset
+    {
+        dataitem(DataLine; "RR3 Table")
+        {
+        }
+    }
+}
+
+table 308200 "RR3 Table"
+{
+    fields
+    {
+        field(1; "No."; Code[20]) { }
+    }
+    keys { key(PK; "No.") { Clustered = true; } }
+}
+
+/// Exercises Report.Run with 3 arguments: (ReportId, RequestPage, SystemPrinter)
+codeunit 308201 "RR3 Source"
+{
+    procedure CallRunThreeArgs(ReportId: Integer)
+    begin
+        Report.Run(ReportId, false, false);
+    end;
+
+    procedure CallRunThreeArgsRequestPage(ReportId: Integer)
+    begin
+        // Passing true for requestPage — still must not throw in standalone mode
+        Report.Run(ReportId, true, false);
+    end;
+}

--- a/tests/bucket-1/300-report-run-3arg/test/test.al
+++ b/tests/bucket-1/300-report-run-3arg/test/test.al
@@ -1,0 +1,31 @@
+codeunit 308202 "RR3 Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "RR3 Source";
+
+    // ------------------------------------------------------------------
+    // Report.Run(ReportId, RequestPage, SystemPrinter) — 3-arg overload
+    // Issue #1336: CS7036 'systemPrinter' missing argument
+    // ------------------------------------------------------------------
+
+    [Test]
+    procedure ReportRun_ThreeArgs_NoError()
+    begin
+        // [GIVEN] A report ID
+        // [WHEN]  Report.Run(id, false, false) is called — 3-arg overload
+        // [THEN]  No error — must compile and execute without crashing
+        Src.CallRunThreeArgs(308200);
+    end;
+
+    [Test]
+    procedure ReportRun_ThreeArgs_RequestPageTrue_NoError()
+    begin
+        // [GIVEN] A report ID
+        // [WHEN]  Report.Run(id, true, false) — requestPage=true, still no-op in standalone mode
+        // [THEN]  No error
+        Src.CallRunThreeArgsRequestPage(308200);
+    end;
+}


### PR DESCRIPTION
Closes #1336

## Problem

BC emits `MockReportHandle.StaticRun(int, bool, bool)` when AL code calls `Report.Run(ObjectId, true)` (without a record argument). The existing `StaticRun` overloads only covered 1-arg and 4-arg signatures, causing:

```
CS7036: There is no argument given that corresponds to the required parameter 'systemPrinter' of 'MockReportHandle.StaticRun(int, bool, bool, object)'
```

## Fix

Added a `StaticRun(int requestPage, bool systemPrinter)` 3-argument overload to `MockReportHandle`. Both `requestPage` and `systemPrinter` are respected/ignored the same way as in the 4-arg version (no rendering in standalone mode).

## Tests

New suite `tests/bucket-1/300-report-run-3arg/`:
- `ReportRun_ThreeArgs_NoError` — confirms `Report.Run(id, false, false)` compiles and runs without error
- `ReportRun_ThreeArgs_RequestPageTrue_NoError` — confirms `Report.Run(id, true, false)` also works

Both tests were RED before the fix (CS7036 compilation error) and GREEN after.

## Coverage

Updated `docs/coverage.yaml`:
- Updated `Report.Run` entry to document all 3 overloads (1-arg, 3-arg, 4-arg)
- Added `Report.Run (3-arg)` entry with the new test suite reference