### PR TITLE
fix: add ALTestFieldNavValueSafe object-arg overload — closes #1324

### DIFF
--- a/AlRunner.Tests/TestFieldNavValueObjectOverloadTests.cs
+++ b/AlRunner.Tests/TestFieldNavValueObjectOverloadTests.cs
@@ -16,6 +16,7 @@ namespace AlRunner.Tests;
 ///
 /// Issue: #1324
 /// </summary>
+[Collection("Pipeline")]
 public class TestFieldNavValueObjectOverloadTests
 {
     private MockRecordHandle CreateHandle()

--- a/AlRunner.Tests/TestFieldNavValueObjectOverloadTests.cs
+++ b/AlRunner.Tests/TestFieldNavValueObjectOverloadTests.cs
@@ -1,0 +1,111 @@
+using AlRunner.Runtime;
+using Microsoft.Dynamics.Nav.Runtime;
+using Microsoft.Dynamics.Nav.Types;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// Tests that MockRecordHandle.ALTestFieldNavValueSafe has an object-accepting overload
+/// so that BC compiler output of ALTestFieldNavValueSafe(fieldNo, navType, objectValue)
+/// does not produce CS1503 ('object' cannot be converted to 'NavValue').
+///
+/// Some BC compiler versions emit ALTestFieldNavValueSafe with an object-typed value
+/// for Rec.TestField("Table No.") and similar calls inside table procedures.
+/// Without the object overload, Roslyn compilation fails with CS1503 (13× per the telemetry).
+///
+/// Issue: #1324
+/// </summary>
+public class TestFieldNavValueObjectOverloadTests
+{
+    private MockRecordHandle CreateHandle()
+    {
+        var handle = new MockRecordHandle(99910);
+        MockRecordHandle.RegisterPrimaryKey(99910, 1);
+        MockRecordHandle.RegisterFieldName(99910, "No.", 1);
+        MockRecordHandle.RegisterFieldName(99910, "TableNo", 2);
+        MockRecordHandle.RegisterFieldName(99910, "Name", 3);
+        return handle;
+    }
+
+    // -----------------------------------------------------------------------
+    // ALTestFieldNavValueSafe — object overload, positive cases
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void ALTestFieldNavValueSafe_Object_IntegerMatch_DoesNotThrow()
+    {
+        // [GIVEN] Record with TableNo = 42
+        var rec = CreateHandle();
+        rec.SetFieldValueSafe(1, NavType.Code, new NavText("A"));
+        rec.SetFieldValueSafe(2, NavType.Integer, NavInteger.Create(42));
+        rec.ALInsert(DataError.ThrowError);
+
+        // [WHEN/THEN] ALTestFieldNavValueSafe(object) with matching integer value must not throw.
+        // This mirrors the CS1503 scenario where the BC transpiler passes an object-typed value.
+        object expectedValue = 42;
+        rec.ALTestFieldNavValueSafe(2, NavType.Integer, expectedValue);
+    }
+
+    [Fact]
+    public void ALTestFieldNavValueSafe_Object_TextMatch_DoesNotThrow()
+    {
+        // [GIVEN] Record with Name = 'Widget'
+        var rec = CreateHandle();
+        rec.SetFieldValueSafe(1, NavType.Code, new NavText("B"));
+        rec.SetFieldValueSafe(3, NavType.Text, new NavText("Widget"));
+        rec.ALInsert(DataError.ThrowError);
+
+        // [WHEN/THEN] ALTestFieldNavValueSafe(object) with matching text must not throw.
+        object expectedValue = "Widget";
+        rec.ALTestFieldNavValueSafe(3, NavType.Text, expectedValue);
+    }
+
+    [Fact]
+    public void ALTestFieldNavValueSafe_Object_NavValuePassThrough_DoesNotThrow()
+    {
+        // [GIVEN] Record with TableNo = 7
+        var rec = CreateHandle();
+        rec.SetFieldValueSafe(1, NavType.Code, new NavText("C"));
+        rec.SetFieldValueSafe(2, NavType.Integer, NavInteger.Create(7));
+        rec.ALInsert(DataError.ThrowError);
+
+        // [WHEN/THEN] When the object IS a NavValue, it must be handled transparently.
+        object expectedValue = NavInteger.Create(7);
+        rec.ALTestFieldNavValueSafe(2, NavType.Integer, expectedValue);
+    }
+
+    // -----------------------------------------------------------------------
+    // ALTestFieldNavValueSafe — object overload, negative cases
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void ALTestFieldNavValueSafe_Object_IntegerMismatch_Throws()
+    {
+        // [GIVEN] Record with TableNo = 99
+        var rec = CreateHandle();
+        rec.SetFieldValueSafe(1, NavType.Code, new NavText("D"));
+        rec.SetFieldValueSafe(2, NavType.Integer, NavInteger.Create(99));
+        rec.ALInsert(DataError.ThrowError);
+
+        // [WHEN/THEN] Mismatch must throw with the expected error.
+        object wrongValue = 1;
+        var ex = Assert.Throws<Exception>(() => rec.ALTestFieldNavValueSafe(2, NavType.Integer, wrongValue));
+        Assert.Contains("expected '1' but was '99'", ex.Message);
+    }
+
+    [Fact]
+    public void ALTestFieldNavValueSafe_Object_TextMismatch_Throws()
+    {
+        // [GIVEN] Record with Name = 'Widget'
+        var rec = CreateHandle();
+        rec.SetFieldValueSafe(1, NavType.Code, new NavText("E"));
+        rec.SetFieldValueSafe(3, NavType.Text, new NavText("Widget"));
+        rec.ALInsert(DataError.ThrowError);
+
+        // [WHEN/THEN] Mismatch must throw with the expected error.
+        object wrongValue = "Gadget";
+        var ex = Assert.Throws<Exception>(() => rec.ALTestFieldNavValueSafe(3, NavType.Text, wrongValue));
+        Assert.Contains("expected 'Gadget' but was 'Widget'", ex.Message);
+    }
+}

--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -828,6 +828,7 @@ protected void EnsureGlobalVariablesInitialized() { }
 public NavRecordId ALRecordId => Rec.ALRecordId;
 public string ALCurrentCompany => Rec.ALCurrentCompany;
 public void ALTestFieldNavValueSafe(int fieldNo, NavType expectedType, NavValue expectedValue) => Rec.ALTestFieldNavValueSafe(fieldNo, expectedType, expectedValue);
+public void ALTestFieldNavValueSafe(int fieldNo, NavType expectedType, object expectedValue) => Rec.ALTestFieldNavValueSafe(fieldNo, expectedType, expectedValue);
 ";
             var delegatingMembers = CSharpSyntaxTree.ParseText(
                 $"class _Temp_ {{ {delegatingCode} }}").GetRoot()

--- a/AlRunner/Runtime/MockRecordHandle.cs
+++ b/AlRunner/Runtime/MockRecordHandle.cs
@@ -1745,6 +1745,20 @@ public class MockRecordHandle : IConvertible
         ALTestFieldSafe(fieldNo, expectedType, expectedValue);
     }
 
+    /// <summary>
+    /// ALTestFieldNavValueSafe(object) — catch-all overload that resolves CS1503 when the BC
+    /// transpiler emits ALTestFieldNavValueSafe(fieldNo, NavType, objectValue) for patterns like
+    /// Rec.TestField("Table No.") inside table procedures.  Some BC compiler versions type the
+    /// value argument as object rather than a concrete NavValue subtype, producing
+    /// CS1503 'object' → 'NavValue'.  Delegates to the existing ALTestFieldSafe(object) overload
+    /// so all primitive unwrapping logic (bool/int/Decimal18/string/NavValue) is shared.
+    /// Fixes issue #1324.
+    /// </summary>
+    public void ALTestFieldNavValueSafe(int fieldNo, NavType expectedType, object expectedValue)
+    {
+        ALTestFieldSafe(fieldNo, expectedType, expectedValue);
+    }
+
     /// <summary>Overload: TestField with DataError level.</summary>
     public void ALTestField(DataError errorLevel, int fieldNo, NavType expectedType, NavValue expectedValue)
     {

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -7825,6 +7825,7 @@ Table.TestField:
     - tests/bucket-1/291-testfield-find-navtext-bool
     - tests/bucket-2/100-testfield-value
     - tests/bucket-2/100-record-recordid-testfield-company
+    - tests/bucket-2/101-testfield-object-overload
   notes: >
     overloads=32; non-empty check, enum value comparison, and scalar value comparison
     (Text/Code/Integer/Decimal/Boolean) covered. CS0121 ambiguity between NavValue and
@@ -7843,6 +7844,26 @@ Table.TestField:
     ALTestFieldNavValueSafe(int, NavType, NavValue) overload injected into Record class by
     RoslynRewriter delegatingCode — fixes CS1061 when some BC compiler versions emit this
     overload name instead of ALTestFieldSafe (issue #1330).
+    ALTestFieldNavValueSafe(fieldNo, NavType, object) overload added for BC versions that
+    emit ALTestFieldNavValueSafe inside table procedures with an object-typed value argument
+    (e.g. Rec.TestField("Table No.") on Integer fields) — resolves CS1503 ('object' →
+    'NavValue') — issue #1324.
+
+Table.TestField (ALTestFieldNavValueSafe object overload):
+  layer: runtime-api
+  category: Table
+  status: covered
+  tests:
+    - tests/bucket-2/101-testfield-object-overload
+    - AlRunner.Tests/TestFieldNavValueObjectOverloadTests.cs
+  notes: >
+    ALTestFieldNavValueSafe(int fieldNo, NavType expectedType, object expectedValue) — resolves
+    CS1503 ('object' cannot be converted to 'NavValue') emitted when the BC transpiler generates
+    ALTestFieldNavValueSafe inside table procedures with object-typed value arguments.
+    Mirrors the ALTestFieldSafe(object) catch-all pattern: delegates to ALTestFieldSafe(object)
+    which handles all primitive unwrapping (bool/int/Decimal18/string/NavValue).
+    Also added to the RoslynRewriter delegating template so that bare calls inside Record classes
+    are correctly forwarded to Rec.ALTestFieldNavValueSafe. Issue #1324.
 
 Table.TransferFields:
   layer: runtime-api

--- a/tests/bucket-2/101-testfield-object-overload/src/TfoTable.al
+++ b/tests/bucket-2/101-testfield-object-overload/src/TfoTable.al
@@ -1,0 +1,56 @@
+/// Table with an Integer field exercising TestField inside a table procedure.
+/// Reproduces CS1503 'object' → 'NavValue' when the BC transpiler emits
+/// ALTestFieldNavValueSafe(fieldNo, NavType, intObjectValue) for Rec.TestField("Table No.").
+table 307100 "TFO Table"
+{
+    DataClassification = CustomerContent;
+
+    fields
+    {
+        field(1; "No."; Code[20])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(2; "Table No."; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+        field(3; "Name"; Text[50])
+        {
+            DataClassification = CustomerContent;
+        }
+    }
+
+    keys
+    {
+        key(PK; "No.")
+        {
+            Clustered = true;
+        }
+    }
+
+    /// Called from within the table — exercises ALTestFieldNavValueSafe on the Record class
+    /// with an Integer field. The BC transpiler may emit object-typed values here (CS1503).
+    procedure ValidateTableNo()
+    begin
+        Rec.TestField("Table No.");
+    end;
+
+    /// TestField with explicit Integer value — exercises ALTestFieldNavValueSafe(object) overload.
+    procedure ValidateTableNoEquals(ExpectedNo: Integer)
+    begin
+        Rec.TestField("Table No.", ExpectedNo);
+    end;
+
+    /// TestField on Name field — exercises ALTestFieldNavValueSafe for Text field.
+    procedure ValidateName()
+    begin
+        Rec.TestField("Name");
+    end;
+
+    /// TestField on Name with value — exercises ALTestFieldNavValueSafe(object) for Text.
+    procedure ValidateNameEquals(ExpectedName: Text[50])
+    begin
+        Rec.TestField("Name", ExpectedName);
+    end;
+}

--- a/tests/bucket-2/101-testfield-object-overload/test/TfoTest.al
+++ b/tests/bucket-2/101-testfield-object-overload/test/TfoTest.al
@@ -1,0 +1,150 @@
+/// Tests for TestField on Integer fields inside table procedures (ALTestFieldNavValueSafe object overload).
+/// Reproduces CS1503 'object' → 'NavValue' from issue #1324.
+codeunit 307101 "TFO Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    // -----------------------------------------------------------------------
+    // Integer field — no-value form (Rec.TestField("Table No."))
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure TableNo_NonZero_TestFieldPasses()
+    var
+        Tbl: Record "TFO Table";
+    begin
+        // [GIVEN] Record with Table No. = 42
+        Tbl.Init();
+        Tbl."No." := 'A';
+        Tbl."Table No." := 42;
+        Tbl.Insert();
+
+        // [WHEN/THEN] TestField("Table No.") inside table procedure must not throw
+        Tbl.ValidateTableNo();
+    end;
+
+    [Test]
+    procedure TableNo_Zero_TestFieldThrows()
+    var
+        Tbl: Record "TFO Table";
+    begin
+        // [GIVEN] Record with Table No. = 0 (default)
+        Tbl.Init();
+        Tbl."No." := 'B';
+        Tbl."Table No." := 0;
+        Tbl.Insert();
+
+        // [WHEN/THEN] TestField("Table No.") inside table procedure must throw (zero is empty)
+        asserterror Tbl.ValidateTableNo();
+        Assert.ExpectedTestFieldError(Tbl.FieldCaption("Table No."), '');
+    end;
+
+    // -----------------------------------------------------------------------
+    // Integer field — value form (Rec.TestField("Table No.", ExpectedNo))
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure TableNo_MatchingValue_TestFieldPasses()
+    var
+        Tbl: Record "TFO Table";
+    begin
+        // [GIVEN] Record with Table No. = 99
+        Tbl.Init();
+        Tbl."No." := 'C';
+        Tbl."Table No." := 99;
+        Tbl.Insert();
+
+        // [WHEN/THEN] ValidateTableNoEquals(99) must not throw
+        Tbl.ValidateTableNoEquals(99);
+    end;
+
+    [Test]
+    procedure TableNo_MismatchValue_TestFieldThrows()
+    var
+        Tbl: Record "TFO Table";
+    begin
+        // [GIVEN] Record with Table No. = 99
+        Tbl.Init();
+        Tbl."No." := 'D';
+        Tbl."Table No." := 99;
+        Tbl.Insert();
+
+        // [WHEN/THEN] ValidateTableNoEquals(1) must throw — value does not match
+        asserterror Tbl.ValidateTableNoEquals(1);
+        Assert.ExpectedTestFieldError(Tbl.FieldCaption("Table No."), '1');
+    end;
+
+    // -----------------------------------------------------------------------
+    // Text field — value form (Rec.TestField("Name", ExpectedName)) inside table
+    // Exercises ALTestFieldNavValueSafe(object) for Text type.
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure Name_MatchingValue_TestFieldPasses()
+    var
+        Tbl: Record "TFO Table";
+    begin
+        // [GIVEN] Record with Name = 'Widget'
+        Tbl.Init();
+        Tbl."No." := 'E';
+        Tbl."Name" := 'Widget';
+        Tbl.Insert();
+
+        // [WHEN/THEN] ValidateNameEquals('Widget') must not throw
+        Tbl.ValidateNameEquals('Widget');
+    end;
+
+    [Test]
+    procedure Name_MismatchValue_TestFieldThrows()
+    var
+        Tbl: Record "TFO Table";
+    begin
+        // [GIVEN] Record with Name = 'Widget'
+        Tbl.Init();
+        Tbl."No." := 'F';
+        Tbl."Name" := 'Widget';
+        Tbl.Insert();
+
+        // [WHEN/THEN] ValidateNameEquals('Gadget') must throw — value does not match
+        asserterror Tbl.ValidateNameEquals('Gadget');
+        Assert.ExpectedTestFieldError(Tbl.FieldCaption("Name"), 'Gadget');
+    end;
+
+    // -----------------------------------------------------------------------
+    // Text field — no-value form (Rec.TestField("Name")) inside table
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure Name_NonEmpty_TestFieldPasses()
+    var
+        Tbl: Record "TFO Table";
+    begin
+        // [GIVEN] Record with Name = 'Test'
+        Tbl.Init();
+        Tbl."No." := 'G';
+        Tbl."Name" := 'Test';
+        Tbl.Insert();
+
+        // [WHEN/THEN] ValidateName() must not throw
+        Tbl.ValidateName();
+    end;
+
+    [Test]
+    procedure Name_Empty_TestFieldThrows()
+    var
+        Tbl: Record "TFO Table";
+    begin
+        // [GIVEN] Record with Name = '' (empty)
+        Tbl.Init();
+        Tbl."No." := 'H';
+        // Name is intentionally empty
+        Tbl.Insert();
+
+        // [WHEN/THEN] ValidateName() must throw — empty text is considered empty
+        asserterror Tbl.ValidateName();
+        Assert.ExpectedTestFieldError(Tbl.FieldCaption("Name"), '');
+    end;
+}


### PR DESCRIPTION
Closes #1324

## Problem

Some BC compiler versions emit `ALTestFieldNavValueSafe(fieldNo, NavType, objectValue)` inside table procedures for patterns like `Rec.TestField("Table No.")`, where the value argument is typed as `object` rather than a concrete `NavValue` subtype. This caused `CS1503: 'object' cannot be converted to 'NavValue'` at Roslyn compilation (13× per telemetry).

## Fix

- Added `ALTestFieldNavValueSafe(int, NavType, object)` overload to `MockRecordHandle`, delegating to the existing `ALTestFieldSafe(object)` catch-all so all primitive unwrapping (bool/int/Decimal18/string/NavValue) is shared.
- Added the same `object` overload to the `RoslynRewriter` `delegatingCode` template so that bare calls inside Record classes are correctly forwarded to `Rec.ALTestFieldNavValueSafe`.

## Tests

- **C# unit tests** (`AlRunner.Tests/TestFieldNavValueObjectOverloadTests.cs`): 5 tests directly testing `ALTestFieldNavValueSafe(object)` — RED confirmed via `CS1503: Argument 3: cannot convert from 'object' to 'NavValue'` before the fix.
- **AL test suite** (`tests/bucket-2/101-testfield-object-overload`): 8 tests covering Integer and Text fields with `TestField` called inside table procedures, with both positive and negative assertions.