### PR TITLE
fix: route ALCompiler.NavValueToNavValue<T> through AlCompat for Date/Code/Text/Boolean filters — closes #1341

### DIFF
--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -2528,6 +2528,30 @@ public void Unbind() { AlRunner.Runtime.EventSubscriberRegistry.Unbind(this); }
                 .WithTriviaFrom(visited);
         }
 
+        // `<expr>.ToBoolean()` where <expr> is ALGetRangeMinSafe or ALGetRangeMaxSafe
+        // → `AlCompat.ObjectToBoolean(<expr>)`
+        // BC emits `rec.ALGetRangeMinSafe(fieldNo, NavType.Boolean).ToBoolean()` for Boolean
+        // GetRangeMin/GetRangeMax assignments. ALGetRangeMinSafe/ALGetRangeMaxSafe return object,
+        // so the NavValue extension method ToBoolean() cannot be found by the C# compiler.
+        // Route through AlCompat.ObjectToBoolean which accepts object?.
+        if (visited.Expression is MemberAccessExpressionSyntax toBoolMa &&
+            toBoolMa.Name.Identifier.Text == "ToBoolean" &&
+            toBoolMa.Expression is InvocationExpressionSyntax toBoolInner &&
+            toBoolInner.Expression is MemberAccessExpressionSyntax toBoolInnerMa &&
+            (toBoolInnerMa.Name.Identifier.Text == "ALGetRangeMinSafe" ||
+             toBoolInnerMa.Name.Identifier.Text == "ALGetRangeMaxSafe"))
+        {
+            return SyntaxFactory.InvocationExpression(
+                SyntaxFactory.MemberAccessExpression(
+                    SyntaxKind.SimpleMemberAccessExpression,
+                    SyntaxFactory.IdentifierName("AlCompat"),
+                    SyntaxFactory.IdentifierName("ObjectToBoolean")),
+                SyntaxFactory.ArgumentList(
+                    SyntaxFactory.SingletonSeparatedList(
+                        SyntaxFactory.Argument(toBoolMa.Expression))))
+                .WithTriviaFrom(visited);
+        }
+
         // NavCode.op_Equality(a, b) / NavCode.op_Inequality(a, b)
         // BC may emit explicit static operator calls for Code[N] comparisons in case statements
         // (rather than a binary == expression), depending on the BC version. Both forms need
@@ -3400,6 +3424,20 @@ public void Unbind() { AlRunner.Runtime.EventSubscriberRegistry.Unbind(this); }
                 }
 
                 // Preserve the generic type arguments (e.g., <NavText>)
+                return visited.WithExpression(
+                    SyntaxFactory.MemberAccessExpression(
+                        SyntaxKind.SimpleMemberAccessExpression,
+                        SyntaxFactory.IdentifierName("AlCompat"),
+                        memberAccess.Name)); // keep GenericNameSyntax with type args
+            }
+
+            // ALCompiler.NavValueToNavValue<T>(x) -> AlCompat.NavValueToNavValue<T>(x)
+            // BC emits this when assigning GetRangeMin/GetRangeMax results to typed variables
+            // (e.g. Date, Text, Code). ALGetRangeMinSafe/ALGetRangeMaxSafe return object, so
+            // the real BC method (parameter: NavValue) fails. AlCompat.NavValueToNavValue<T>
+            // accepts object? and rehydrates the unwrapped scalar before converting.
+            if (exprText == "ALCompiler" && methodName == "NavValueToNavValue")
+            {
                 return visited.WithExpression(
                     SyntaxFactory.MemberAccessExpression(
                         SyntaxKind.SimpleMemberAccessExpression,

--- a/AlRunner/Runtime/AlScope.cs
+++ b/AlRunner/Runtime/AlScope.cs
@@ -1211,6 +1211,40 @@ public static class AlCompat
         => NavIndirectValueToNavValue<T>(value);
 
     /// <summary>
+    /// Replacement for ALCompiler.NavValueToNavValue&lt;T&gt;(NavValue).
+    /// The BC compiler emits this call when assigning GetRangeMin/GetRangeMax results to typed
+    /// variables (e.g. Date, Text, Code). MockRecordHandle.ALGetRangeMinSafe returns <c>object</c>
+    /// (unwrapped from NavValue) so the real BC method — whose parameter is NavValue — fails to
+    /// compile. This helper accepts <c>object?</c> and rehydrates scalar CLR values to their
+    /// NavValue counterparts before delegating to NavIndirectValueToNavValue&lt;T&gt;.
+    /// Covered types:
+    ///   NavDate  — object is NavDate (from UnwrapRangeValue fallthrough)
+    ///   NavText  — object is string (unwrapped by UnwrapRangeValue)
+    ///   NavCode  — object is string (unwrapped by UnwrapRangeValue)
+    ///   NavInteger — object is int   (unwrapped by UnwrapRangeValue)
+    ///   NavBoolean — object is bool  (unwrapped by UnwrapRangeValue)
+    ///   NavBigInteger — object is long (unwrapped by UnwrapRangeValue)
+    ///   NavGuid  — object is Guid   (unwrapped by UnwrapRangeValue)
+    /// </summary>
+    public static T NavValueToNavValue<T>(object? value) where T : NavValue
+    {
+        // Rehydrate primitive CLR values that UnwrapRangeValue produces
+        if (value is int intVal) return NavIndirectValueToNavValue<T>(NavInteger.Create(intVal));
+        if (value is bool boolVal) return NavIndirectValueToNavValue<T>(NavBoolean.Create(boolVal));
+        if (value is long longVal) return NavIndirectValueToNavValue<T>(NavBigInteger.Create(longVal));
+        if (value is Guid guidVal) return NavIndirectValueToNavValue<T>(new NavGuid(guidVal));
+        if (value is string strVal)
+        {
+            // NavCode and NavText both store strings; try NavCode first (it IS-A NavText)
+            if (typeof(T) == typeof(NavCode))
+                return (T)(NavValue)new NavCode(20, strVal);
+            return NavIndirectValueToNavValue<T>(new NavText(strVal));
+        }
+        // For NavDate and any remaining NavValue subtypes delegate directly
+        return NavIndirectValueToNavValue<T>(value);
+    }
+
+    /// <summary>
     /// Safe replacement for ALCompiler.ObjectToExactNavValue&lt;T&gt;(x).
     /// The rewriter converts <c>ALCompiler.ObjectToExactNavValue&lt;T&gt;(x)</c> to
     /// <c>(T)(object)(x)</c>, which fails at runtime when x is a C# primitive (bool, int)

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -7496,17 +7496,19 @@ Table.GetRangeMax:
   layer: runtime-api
   category: Table
   status: covered
-  notes: overloads=1
+  notes: "overloads=1; field types covered: Integer, Decimal, Date, Text, Code, Boolean (ALCompiler.NavValueToNavValue<T> rewriter fix for Date/Text/Code; ToBoolean fix for Boolean)"
   tests:
     - tests/bucket-2/141-record-getrangemin
+    - tests/bucket-2/100-getrange-date-filter
 
 Table.GetRangeMin:
   layer: runtime-api
   category: Table
   status: covered
-  notes: overloads=1
+  notes: "overloads=1; field types covered: Integer, Decimal, Date, Text, Code, Boolean (ALCompiler.NavValueToNavValue<T> rewriter fix for Date/Text/Code; ToBoolean fix for Boolean)"
   tests:
     - tests/bucket-2/141-record-getrangemin
+    - tests/bucket-2/100-getrange-date-filter
 
 Table.GetView:
   layer: runtime-api

--- a/tests/bucket-2/100-getrange-date-filter/src/GetRangeDateFilter.al
+++ b/tests/bucket-2/100-getrange-date-filter/src/GetRangeDateFilter.al
@@ -1,0 +1,84 @@
+table 308400 "GetRange Filter Table"
+{
+    fields
+    {
+        field(1; "No."; Code[20]) { }
+        field(2; "Profile Date"; Date) { }
+        field(3; "Description"; Text[100]) { }
+        field(4; "Code Field"; Code[20]) { }
+        field(5; "Count"; Integer) { }
+        field(6; "Active"; Boolean) { }
+    }
+
+    keys
+    {
+        key(PK; "No.") { Clustered = true; }
+    }
+}
+
+codeunit 308401 "GetRange Filter Helper"
+{
+    procedure GetMinDate(var Rec: Record "GetRange Filter Table"): Date
+    var
+        MinDate: Date;
+    begin
+        MinDate := Rec.GetRangeMin("Profile Date");
+        exit(MinDate);
+    end;
+
+    procedure GetMaxDate(var Rec: Record "GetRange Filter Table"): Date
+    var
+        MaxDate: Date;
+    begin
+        MaxDate := Rec.GetRangeMax("Profile Date");
+        exit(MaxDate);
+    end;
+
+    procedure GetMinText(var Rec: Record "GetRange Filter Table"): Text[100]
+    var
+        MinText: Text[100];
+    begin
+        MinText := Rec.GetRangeMin("Description");
+        exit(MinText);
+    end;
+
+    procedure GetMaxText(var Rec: Record "GetRange Filter Table"): Text[100]
+    var
+        MaxText: Text[100];
+    begin
+        MaxText := Rec.GetRangeMax("Description");
+        exit(MaxText);
+    end;
+
+    procedure GetMinCode(var Rec: Record "GetRange Filter Table"): Code[20]
+    var
+        MinCode: Code[20];
+    begin
+        MinCode := Rec.GetRangeMin("Code Field");
+        exit(MinCode);
+    end;
+
+    procedure GetMaxCode(var Rec: Record "GetRange Filter Table"): Code[20]
+    var
+        MaxCode: Code[20];
+    begin
+        MaxCode := Rec.GetRangeMax("Code Field");
+        exit(MaxCode);
+    end;
+
+    procedure GetMinBool(var Rec: Record "GetRange Filter Table"): Boolean
+    var
+        MinBool: Boolean;
+    begin
+        MinBool := Rec.GetRangeMin("Active");
+        exit(MinBool);
+    end;
+
+    procedure GetMaxBool(var Rec: Record "GetRange Filter Table"): Boolean
+    var
+        MaxBool: Boolean;
+    begin
+        MaxBool := Rec.GetRangeMax("Active");
+        exit(MaxBool);
+    end;
+}

--- a/tests/bucket-2/100-getrange-date-filter/test/GetRangeDateFilterTest.al
+++ b/tests/bucket-2/100-getrange-date-filter/test/GetRangeDateFilterTest.al
@@ -1,0 +1,178 @@
+codeunit 308402 "GetRange Date Filter Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    // ── Date field ────────────────────────────────────────────────────────────
+
+    [Test]
+    procedure GetRangeMin_DateField_ReturnsMinBound()
+    var
+        Rec: Record "GetRange Filter Table";
+        Helper: Codeunit "GetRange Filter Helper";
+        MinDate: Date;
+        Expected: Date;
+    begin
+        // Arrange — 15 Jun 2024 is a non-default value that proves the filter bound is returned,
+        // not the type default (0D).
+        Expected := DMY2Date(15, 6, 2024);
+        Rec.SetRange("Profile Date", DMY2Date(15, 6, 2024), DMY2Date(31, 12, 2024));
+
+        // Act
+        MinDate := Helper.GetMinDate(Rec);
+
+        // Assert
+        Assert.AreEqual(Expected, MinDate, 'GetRangeMin(Date) should return the lower filter bound');
+    end;
+
+    [Test]
+    procedure GetRangeMax_DateField_ReturnsMaxBound()
+    var
+        Rec: Record "GetRange Filter Table";
+        Helper: Codeunit "GetRange Filter Helper";
+        MaxDate: Date;
+        Expected: Date;
+    begin
+        // Arrange — 31 Dec 2024 is a non-default value that proves the filter bound is returned.
+        Expected := DMY2Date(31, 12, 2024);
+        Rec.SetRange("Profile Date", DMY2Date(15, 6, 2024), DMY2Date(31, 12, 2024));
+
+        // Act
+        MaxDate := Helper.GetMaxDate(Rec);
+
+        // Assert
+        Assert.AreEqual(Expected, MaxDate, 'GetRangeMax(Date) should return the upper filter bound');
+    end;
+
+    [Test]
+    procedure GetRangeMin_DateField_NotMax()
+    var
+        Rec: Record "GetRange Filter Table";
+        Helper: Codeunit "GetRange Filter Helper";
+    begin
+        // Negative: GetRangeMin must NOT return the upper bound.
+        Rec.SetRange("Profile Date", DMY2Date(1, 1, 2024), DMY2Date(31, 12, 2024));
+        Assert.AreNotEqual(DMY2Date(31, 12, 2024), Helper.GetMinDate(Rec), 'GetRangeMin(Date) must not return the upper bound');
+    end;
+
+    [Test]
+    procedure GetRangeMax_DateField_NotMin()
+    var
+        Rec: Record "GetRange Filter Table";
+        Helper: Codeunit "GetRange Filter Helper";
+    begin
+        // Negative: GetRangeMax must NOT return the lower bound.
+        Rec.SetRange("Profile Date", DMY2Date(1, 1, 2024), DMY2Date(31, 12, 2024));
+        Assert.AreNotEqual(DMY2Date(1, 1, 2024), Helper.GetMaxDate(Rec), 'GetRangeMax(Date) must not return the lower bound');
+    end;
+
+    // ── Text field ────────────────────────────────────────────────────────────
+
+    [Test]
+    procedure GetRangeMin_TextField_ReturnsMinBound()
+    var
+        Rec: Record "GetRange Filter Table";
+        Helper: Codeunit "GetRange Filter Helper";
+        MinText: Text[100];
+    begin
+        Rec.SetRange("Description", 'Apple', 'Mango');
+        MinText := Helper.GetMinText(Rec);
+        Assert.AreEqual('Apple', MinText, 'GetRangeMin(Text) should return the lower filter bound');
+    end;
+
+    [Test]
+    procedure GetRangeMax_TextField_ReturnsMaxBound()
+    var
+        Rec: Record "GetRange Filter Table";
+        Helper: Codeunit "GetRange Filter Helper";
+        MaxText: Text[100];
+    begin
+        Rec.SetRange("Description", 'Apple', 'Mango');
+        MaxText := Helper.GetMaxText(Rec);
+        Assert.AreEqual('Mango', MaxText, 'GetRangeMax(Text) should return the upper filter bound');
+    end;
+
+    [Test]
+    procedure GetRangeMin_TextField_NotMax()
+    var
+        Rec: Record "GetRange Filter Table";
+        Helper: Codeunit "GetRange Filter Helper";
+    begin
+        Rec.SetRange("Description", 'Apple', 'Mango');
+        Assert.AreNotEqual('Mango', Helper.GetMinText(Rec), 'GetRangeMin(Text) must not return the upper bound');
+    end;
+
+    // ── Code field ────────────────────────────────────────────────────────────
+
+    [Test]
+    procedure GetRangeMin_CodeField_ReturnsMinBound()
+    var
+        Rec: Record "GetRange Filter Table";
+        Helper: Codeunit "GetRange Filter Helper";
+        MinCode: Code[20];
+    begin
+        Rec.SetRange("Code Field", 'AAA', 'ZZZ');
+        MinCode := Helper.GetMinCode(Rec);
+        Assert.AreEqual('AAA', MinCode, 'GetRangeMin(Code) should return the lower filter bound');
+    end;
+
+    [Test]
+    procedure GetRangeMax_CodeField_ReturnsMaxBound()
+    var
+        Rec: Record "GetRange Filter Table";
+        Helper: Codeunit "GetRange Filter Helper";
+        MaxCode: Code[20];
+    begin
+        Rec.SetRange("Code Field", 'AAA', 'ZZZ');
+        MaxCode := Helper.GetMaxCode(Rec);
+        Assert.AreEqual('ZZZ', MaxCode, 'GetRangeMax(Code) should return the upper filter bound');
+    end;
+
+    [Test]
+    procedure GetRangeMin_CodeField_NotMax()
+    var
+        Rec: Record "GetRange Filter Table";
+        Helper: Codeunit "GetRange Filter Helper";
+    begin
+        Rec.SetRange("Code Field", 'AAA', 'ZZZ');
+        Assert.AreNotEqual('ZZZ', Helper.GetMinCode(Rec), 'GetRangeMin(Code) must not return the upper bound');
+    end;
+
+    // ── Boolean field ─────────────────────────────────────────────────────────
+
+    [Test]
+    procedure GetRangeMin_BoolField_ReturnsFalse()
+    var
+        Rec: Record "GetRange Filter Table";
+        Helper: Codeunit "GetRange Filter Helper";
+        MinBool: Boolean;
+    begin
+        Rec.SetRange("Active", false, true);
+        MinBool := Helper.GetMinBool(Rec);
+        Assert.IsFalse(MinBool, 'GetRangeMin(Boolean) should return false (lower bound)');
+    end;
+
+    [Test]
+    procedure GetRangeMax_BoolField_ReturnsTrue()
+    var
+        Rec: Record "GetRange Filter Table";
+        Helper: Codeunit "GetRange Filter Helper";
+        MaxBool: Boolean;
+    begin
+        Rec.SetRange("Active", false, true);
+        MaxBool := Helper.GetMaxBool(Rec);
+        Assert.IsTrue(MaxBool, 'GetRangeMax(Boolean) should return true (upper bound)');
+    end;
+
+    [Test]
+    procedure GetRangeMax_BoolField_NotMin()
+    var
+        Rec: Record "GetRange Filter Table";
+        Helper: Codeunit "GetRange Filter Helper";
+    begin
+        Rec.SetRange("Active", false, true);
+        Assert.AreNotEqual(false, Helper.GetMaxBool(Rec), 'GetRangeMax(Boolean) must not return the lower bound false');
+    end;
+}


### PR DESCRIPTION
Closes #1341

## Summary

- Add `AlCompat.NavValueToNavValue<T>(object?)` in `AlRunner/Runtime/AlScope.cs` next to `NavIndirectValueToNavValue<T>`. Rehydrates scalar CLR values produced by `UnwrapRangeValue` (`int`, `bool`, `long`, `Guid`, `string`) back into the matching `NavValue` subtype before delegating to `NavIndirectValueToNavValue<T>`.
- Add a rewriter rule in `RoslynRewriter.cs` to route `ALCompiler.NavValueToNavValue<T>(x)` → `AlCompat.NavValueToNavValue<T>(x)`, mirroring the existing pattern for `NavIndirectValueToNavValue` and `ObjectToExactNavValue`.
- Add a second rewriter rule to transform `<expr>.ToBoolean()` → `AlCompat.ObjectToBoolean(<expr>)` when `<expr>` is an `ALGetRangeMinSafe`/`ALGetRangeMaxSafe` call. The BC compiler emits `.ToBoolean()` for Boolean return-type assignments; since those methods return `object`, the `NavValue` extension method is unavailable.
- Add regression test suite `tests/bucket-2/100-getrange-date-filter` (object IDs 308400–308402) covering the exact repro from the issue plus Code, Text, and Boolean field types. Each type has positive (specific-value) and negative (bound-check) tests.
- Update `docs/coverage.yaml` for `Table.GetRangeMin` and `Table.GetRangeMax` to document the newly covered field types.

## Test plan

- [ ] `tests/bucket-2/100-getrange-date-filter` — 13 tests all pass (Date min/max, Text min/max, Code min/max, Boolean min/max, each with positive + negative)
- [ ] bucket-2 full run: 1803 passed, 1 blocked (pre-existing limitation), 0 failed
- [ ] bucket-1 full run: 1757 passed, 0 failed