### PR TITLE
fix: add Report instance RunRequestPage 1-arg overload — closes #1333

### DIFF
--- a/AlRunner/Runtime/MockReportHandle.cs
+++ b/AlRunner/Runtime/MockReportHandle.cs
@@ -214,6 +214,13 @@ public class MockReportHandle
     }
 
     /// <summary>
+    /// Instance <c>Rep.RunRequestPage(requestParameters)</c> — 1-argument overload.
+    /// BC emits this when AL code calls <c>SomeReport.RunRequestPage(OldParameters)</c>
+    /// on a report variable. Returns empty string in standalone mode (no request-page UI).
+    /// </summary>
+    public string RunRequestPage(string requestParameters) => string.Empty;
+
+    /// <summary>
     /// Extension-scoped Invoke — called when invoking a method defined in a report
     /// extension. The BC compiler emits (extensionId, memberId, args).
     /// We ignore the extensionId and delegate to the standard Invoke.

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -6009,6 +6009,14 @@ Report.RunRequestPage (2-arg):
   tests:
     - tests/bucket-2/301-report-static-runrequestpage
 
+Report.RunRequestPage (instance 1-arg):
+  layer: runtime-api
+  category: Report
+  status: covered
+  notes: overloads=1; Rep.RunRequestPage(requestParameters) instance form — BC emits this when a Report variable calls RunRequestPage with one Text argument (e.g. SuggestVendorPayments.RunRequestPage(OldParameters)). Returns empty string in standalone mode. Fixes #1333.
+  tests:
+    - tests/bucket-2/308-report-instance-runrequestpage
+
 Report.SaveAs:
   layer: runtime-api
   category: Report

--- a/tests/bucket-2/308-report-instance-runrequestpage/src/ReportInstanceRRP.al
+++ b/tests/bucket-2/308-report-instance-runrequestpage/src/ReportInstanceRRP.al
@@ -1,0 +1,26 @@
+/// Exercises Report instance variable RunRequestPage overloads — issue #1333.
+codeunit 308000 "ReportInstanceRRP Src"
+{
+    /// Call Rep.RunRequestPage(requestParameters) — 1-arg instance overload.
+    procedure RunRequestPage1Arg(requestParameters: Text): Text
+    var
+        Rep: Report "ReportInstanceRRP Report";
+    begin
+        exit(Rep.RunRequestPage(requestParameters));
+    end;
+
+    /// Call Rep.RunRequestPage() — 0-arg instance overload (regression guard).
+    procedure RunRequestPage0Arg(): Text
+    var
+        Rep: Report "ReportInstanceRRP Report";
+    begin
+        exit(Rep.RunRequestPage());
+    end;
+}
+
+report 308000 "ReportInstanceRRP Report"
+{
+    dataset
+    {
+    }
+}

--- a/tests/bucket-2/308-report-instance-runrequestpage/test/ReportInstanceRRPTest.al
+++ b/tests/bucket-2/308-report-instance-runrequestpage/test/ReportInstanceRRPTest.al
@@ -1,0 +1,49 @@
+/// Tests for Report instance variable RunRequestPage(requestParameters) 1-arg overload — issue #1333.
+codeunit 308001 "ReportInstanceRRP Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    [Test]
+    procedure Report_Instance_RunRequestPage_1Arg_ReturnsText()
+    var
+        Src: Codeunit "ReportInstanceRRP Src";
+        Result: Text;
+    begin
+        // [GIVEN] A report instance variable and non-empty request parameters
+        // [WHEN]  Rep.RunRequestPage(requestParameters) 1-arg instance overload is called
+        Result := Src.RunRequestPage1Arg('<RequestPage />');
+
+        // [THEN]  Returns a string in standalone mode (no UI rendered)
+        Assert.AreEqual('', Result, 'RunRequestPage 1-arg instance must return empty string in standalone mode');
+    end;
+
+    [Test]
+    procedure Report_Instance_RunRequestPage_1Arg_EmptyParams()
+    var
+        Src: Codeunit "ReportInstanceRRP Src";
+        Result: Text;
+    begin
+        // [GIVEN] A report instance variable and empty request parameters
+        // [WHEN]  Rep.RunRequestPage('') 1-arg instance overload is called
+        Result := Src.RunRequestPage1Arg('');
+
+        // [THEN]  Returns empty string in standalone mode
+        Assert.AreEqual('', Result, 'RunRequestPage 1-arg instance with empty params must return empty string');
+    end;
+
+    [Test]
+    procedure Report_Instance_RunRequestPage_0Arg_RegressionGuard()
+    var
+        Src: Codeunit "ReportInstanceRRP Src";
+        Result: Text;
+    begin
+        // [GIVEN] A report instance variable with no registered handler
+        // [WHEN]  Rep.RunRequestPage() 0-arg overload is called (no handler registered)
+        // [THEN]  It throws the expected error (pre-existing behavior must not regress)
+        asserterror Result := Src.RunRequestPage0Arg();
+        Assert.ExpectedError('No RequestPageHandler registered');
+    end;
+}


### PR DESCRIPTION
Closes #1333

## Problem

AL patterns like `NewParameters := SuggestVendorPayments.RunRequestPage(OldParameters)` fail to compile with:

```
CS1501: No overload for method 'RunRequestPage' takes 1 arguments
```

`MockReportHandle` had a 0-arg `RunRequestPage()` instance method and a static 1-arg `StaticRunRequestPage(int, string)`, but no 1-arg instance overload.

## Fix

Added `public string RunRequestPage(string requestParameters) => string.Empty;` to `MockReportHandle`, matching the BC instance-method form where a Report variable calls `RunRequestPage` with existing request-page parameters.

## Tests

New suite `tests/bucket-2/308-report-instance-runrequestpage`:
- **Positive**: `Rep.RunRequestPage('<RequestPage />')` returns empty string in standalone mode
- **Positive**: `Rep.RunRequestPage('')` returns empty string for empty params
- **Negative (regression)**: `Rep.RunRequestPage()` (0-arg) still throws `No RequestPageHandler registered` when no handler is registered