### PR TITLE
fix: detect duplicate object names across apps as AL0197 — closes #1344

### DIFF
--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -1473,6 +1473,23 @@ public static class AlTranspiler
                 Log.Info($"  {FormatAlDiagnostic(d, treeToPath)}");
             if (otherErrors.Count > 10)
                 Log.Info($"  ... and {otherErrors.Count - 10} more");
+
+            // AL0197 for a non-extension type (Codeunit, Table, Page, etc.) is a genuine
+            // duplicate-object error — two different apps define the same object.  This is
+            // never valid and the real BC compiler rejects it.  Return null so the pipeline
+            // exits with code 3 (AL compile error).
+            var genuineDuplicates = declErrors
+                .Where(d => d.Id == "AL0197" && !DiagnosticClassifier.IsCrossExtensionDuplicateDeclaration(d.GetMessage()))
+                .ToList();
+            if (genuineDuplicates.Count > 0)
+            {
+                Console.Error.WriteLine($"AL compilation errors — duplicate object declarations ({genuineDuplicates.Count}):");
+                foreach (var d in genuineDuplicates.Take(10))
+                    Console.Error.WriteLine($"  {FormatAlDiagnostic(d, treeToPath)}");
+                if (genuineDuplicates.Count > 10)
+                    Console.Error.WriteLine($"  ... and {genuineDuplicates.Count - 10} more");
+                return null;
+            }
         }
 
         // Store compilation for symbol table queries by auto-stub generation

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -6009,6 +6009,7 @@ Report.RunRequestPage (2-arg):
   tests:
     - tests/bucket-2/301-report-static-runrequestpage
 
+
 Report.RunRequestPage (instance 1-arg):
   layer: runtime-api
   category: Report
@@ -12013,3 +12014,20 @@ MockRecordHandle.CoerceToExpectedType.NavOptionToNavText:
     is passed to a reflected method expecting NavText.
   tests:
     - tests/bucket-2/235-navoption-to-navtext
+
+AL0197.NonExtensionTypeDuplicate:
+  layer: al-compile
+  category: diagnostic
+  status: covered
+  notes: >
+    When two source directories define a non-extension object (Codeunit, Table,
+    Page, etc.) with the same name, the BC compiler emits AL0197. Previously the
+    runner logged the error but continued and exited 0 — the test would silently
+    pick one definition and run. Fix: after the AL0275/AL0197 suppression passes,
+    any remaining AL0197 errors whose object type is NOT in ExtensionObjectTypes
+    (i.e. genuine non-extension duplicates) are reported to stderr and cause
+    TranspileMulti to return null → pipeline exits with code 3 (AL compile error).
+    Extension-type collisions (PageExtension, TableExtension, etc.) continue to be
+    suppressed as before, because they compile independently in production BC.
+  tests:
+    - tests/excluded/131-genuine-codeunit-collision

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -12016,7 +12016,7 @@ MockRecordHandle.CoerceToExpectedType.NavOptionToNavText:
     - tests/bucket-2/235-navoption-to-navtext
 
 AL0197.NonExtensionTypeDuplicate:
-  layer: al-compile
+  layer: syntax
   category: diagnostic
   status: covered
   notes: >

--- a/tests/excluded/131-genuine-codeunit-collision/al-runner.json
+++ b/tests/excluded/131-genuine-codeunit-collision/al-runner.json
@@ -1,5 +1,4 @@
 {
-  "expectedExitCode": 0,
-  "knownGap": "https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/1344",
-  "comment": "Runner does not detect duplicate codeunit names across apps (AL0197/AL0275 not enforced). Should be exit 3 once #1344 is fixed."
+  "expectedExitCode": 3,
+  "comment": "Duplicate codeunit name across apps emits AL0197 — runner must exit 3. Fixed by #1344."
 }


### PR DESCRIPTION
Closes #1344

## Summary

- When two source directories define the same non-extension object name (Codeunit, Table, Page, etc.), the BC compiler emits AL0197. The runner previously logged these with `Log.Info` (only visible with `--verbose`) but continued and exited 0.
- Fix adds a post-suppression check in `TranspileMulti`: if any AL0197 errors remain for non-extension types after all suppression passes, they are reported to stderr and `TranspileMulti` returns `null` → pipeline exits with code 3 (AL compile error).
- Extension-type collisions (PageExtension, TableExtension, etc.) continue to be suppressed as before — they compile independently in production BC and their names are never referenced by AL code.
- Updated `tests/excluded/131-genuine-codeunit-collision/al-runner.json`: `expectedExitCode` changed from 0 (knownGap) to 3.

## Test proof

**RED** (before fix): `dotnet run --project AlRunner -- appA appB test` → exit 0 (silently picks one definition)
**GREEN** (after fix): same command → exit 3 with "AL compilation errors — duplicate object declarations (2)"

All bucket tests and excluded fixture tests pass.