### PR TITLE
fix: detect duplicate pageextension names within same extension as AL0197 — closes #1345

### DIFF
--- a/AlRunner/Pipeline.cs
+++ b/AlRunner/Pipeline.cs
@@ -542,6 +542,21 @@ public class AlRunnerPipeline
         while (sourceFilePaths.Count < alSources.Count)
             sourceFilePaths.Add(null);
 
+        // Pre-compile check: detect duplicate extension object names within the same
+        // app.json scope. These are genuine AL0197 errors that the runner must enforce
+        // because when all source files are compiled together in a single BC compilation
+        // pass, the BC compiler assigns ONE extension identity to all objects and cannot
+        // distinguish same-extension from cross-extension duplicates. We detect them here
+        // using the actual app.json file structure instead.
+        var sameExtDups = DetectSameExtensionDuplicates(sourceFilePaths, alSources);
+        if (sameExtDups.Count > 0)
+        {
+            stderr.WriteLine($"AL compile error (AL0197): duplicate extension object name within the same extension ({sameExtDups.Count} error(s)):");
+            foreach (var msg in sameExtDups)
+                stderr.WriteLine($"  {msg}");
+            return 3;
+        }
+
         // Step 1: Transpile
         Timer.StartStage("AL transpilation");
         var generatedCSharpList = Transpile(options, alSources, inputGroups, inputPaths, stubSources, stderr,
@@ -1193,6 +1208,92 @@ public class AlRunnerPipeline
         }
 
         return source;
+    }
+
+    // Regex to detect extension object declarations: captures type and name.
+    // Matches: pageextension, tableextension, reportextension, enumextension,
+    //          permissionsetextension, pageCustomization (all extension-type objects).
+    private static readonly Regex ExtensionObjectDeclPattern = new(
+        @"^\s*(?<type>pageextension|tableextension|reportextension|enumextension|permissionsetextension|pagecustomization)\s+\d+\s+""(?<name>[^""]+)""",
+        RegexOptions.IgnoreCase | RegexOptions.Multiline | RegexOptions.Compiled);
+
+    /// <summary>
+    /// Walks up from <paramref name="filePath"/> to find the nearest app.json.
+    /// Returns the app.json path, or null if none found.
+    /// </summary>
+    private static string? FindOwningAppJson(string filePath)
+    {
+        var dir = Path.GetDirectoryName(Path.GetFullPath(filePath));
+        while (dir != null)
+        {
+            var candidate = Path.Combine(dir, "app.json");
+            if (File.Exists(candidate))
+                return candidate;
+            dir = Path.GetDirectoryName(dir);
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Scans source files for same-extension duplicate extension object names.
+    /// Groups files by owning app.json; within each group, if two files declare an
+    /// extension object (pageextension, tableextension, etc.) with the same name,
+    /// that is a genuine AL0197 error — not a cross-extension collision.
+    /// Returns a list of error messages, or an empty list if no duplicates detected.
+    /// </summary>
+    private static List<string> DetectSameExtensionDuplicates(
+        List<string?> sourceFilePaths,
+        List<string> alSources)
+    {
+        var errors = new List<string>();
+
+        // Group file paths by their owning app.json.
+        // Files with no owning app.json are grouped under a null key (skip them).
+        var appJsonToFiles = new Dictionary<string, List<(string FilePath, string Source)>>(StringComparer.OrdinalIgnoreCase);
+        for (int i = 0; i < sourceFilePaths.Count && i < alSources.Count; i++)
+        {
+            var fp = sourceFilePaths[i];
+            if (fp == null) continue;
+            var appJson = FindOwningAppJson(fp);
+            if (appJson == null) continue;
+            if (!appJsonToFiles.TryGetValue(appJson, out var list))
+            {
+                list = new List<(string, string)>();
+                appJsonToFiles[appJson] = list;
+            }
+            list.Add((fp, alSources[i]));
+        }
+
+        // For each app.json group, detect duplicate extension object names.
+        foreach (var (appJson, files) in appJsonToFiles)
+        {
+            // Map of "type:name" (case-insensitive) → first declaring file path
+            var seen = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var (filePath, source) in files)
+            {
+                foreach (Match m in ExtensionObjectDeclPattern.Matches(source))
+                {
+                    var objectType = m.Groups["type"].Value;
+                    var objectName = m.Groups["name"].Value;
+                    var key = $"{objectType}:{objectName}";
+                    if (seen.TryGetValue(key, out var firstFile))
+                    {
+                        errors.Add(
+                            $"error AL0197: An application object of type '{objectType}' " +
+                            $"with name '{objectName}' is already declared in " +
+                            $"'{Path.GetFileName(firstFile)}' " +
+                            $"(same extension: {Path.GetFileName(appJson)})");
+                    }
+                    else
+                    {
+                        seen[key] = filePath;
+                    }
+                }
+            }
+        }
+
+        return errors;
     }
 
     private static List<(string Name, string Code)>? Transpile(

--- a/AlRunner/Pipeline.cs
+++ b/AlRunner/Pipeline.cs
@@ -1217,6 +1217,18 @@ public class AlRunnerPipeline
         @"^\s*(?<type>pageextension|tableextension|reportextension|enumextension|permissionsetextension|pagecustomization)\s+\d+\s+""(?<name>[^""]+)""",
         RegexOptions.IgnoreCase | RegexOptions.Multiline | RegexOptions.Compiled);
 
+    // Canonical type names matching the BC compiler's AL0197 message format.
+    private static readonly Dictionary<string, string> ExtensionTypeDisplayNames =
+        new(StringComparer.OrdinalIgnoreCase)
+        {
+            { "pageextension",          "PageExtension" },
+            { "tableextension",         "TableExtension" },
+            { "reportextension",        "ReportExtension" },
+            { "enumextension",          "EnumExtension" },
+            { "permissionsetextension", "PermissionSetExtension" },
+            { "pagecustomization",      "PageCustomization" },
+        };
+
     /// <summary>
     /// Walks up from <paramref name="filePath"/> to find the nearest app.json.
     /// Returns the app.json path, or null if none found.
@@ -1274,13 +1286,14 @@ public class AlRunnerPipeline
             {
                 foreach (Match m in ExtensionObjectDeclPattern.Matches(source))
                 {
-                    var objectType = m.Groups["type"].Value;
+                    var rawType  = m.Groups["type"].Value;
+                    var displayType = ExtensionTypeDisplayNames.TryGetValue(rawType, out var dt) ? dt : rawType;
                     var objectName = m.Groups["name"].Value;
-                    var key = $"{objectType}:{objectName}";
+                    var key = $"{rawType}:{objectName}";
                     if (seen.TryGetValue(key, out var firstFile))
                     {
                         errors.Add(
-                            $"error AL0197: An application object of type '{objectType}' " +
+                            $"error AL0197: An application object of type '{displayType}' " +
                             $"with name '{objectName}' is already declared in " +
                             $"'{Path.GetFileName(firstFile)}' " +
                             $"(same extension: {Path.GetFileName(appJson)})");

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -301,6 +301,21 @@ tableextension_declaration:
     - tests/bucket-2/33-extension-validate
     - tests/bucket-2/34-extension-parent-object
 
+al0197_duplicate_extension_name_same_extension:
+  layer: syntax
+  category: extension
+  status: covered
+  notes: >
+    AL diagnostic AL0197: runner detects duplicate extension object names (pageextension,
+    tableextension, etc.) within the same app.json scope as a compile error (exit 3).
+    Cross-extension duplicates from different app.json directories are correctly
+    suppressed (they are valid in BC where each extension compiles independently).
+    Implemented as a pre-compile scan in Pipeline.DetectSameExtensionDuplicates.
+    Issue #1345.
+  tests:
+    - tests/excluded/135-same-ext-pageext-duplicate
+    - tests/bucket-2/130-cross-ext-al0275
+
 # ── statement ───────────────────────────────────────────────────
 
 asserterror_statement:

--- a/tests/excluded/135-same-ext-pageext-duplicate/al-runner.json
+++ b/tests/excluded/135-same-ext-pageext-duplicate/al-runner.json
@@ -1,5 +1,4 @@
 {
-  "expectedExitCode": 0,
-  "knownGap": "https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/1345",
-  "comment": "Runner does not detect duplicate pageextension names in same extension (AL0197 not enforced). Should be exit 3 once #1345 is fixed."
+  "expectedExitCode": 3,
+  "comment": "Duplicate pageextension names in the same extension must fail with AL0197 (exit 3). Fixed by #1345."
 }


### PR DESCRIPTION
Closes #1345

## Summary

- Adds `DetectSameExtensionDuplicates` pre-compile check in `Pipeline.cs` that groups AL source files by their owning `app.json` and detects duplicate extension object names (pageextension, tableextension, reportextension, enumextension, permissionsetextension, pageCustomization) within the same app.json scope.
- When duplicates are found, the runner exits with code 3 (AL compile error), matching BC compiler AL0197 behaviour.
- Cross-extension duplicates (different app.json directories) are correctly NOT flagged — those are valid in production BC.
- Updates `tests/excluded/135-same-ext-pageext-duplicate/al-runner.json` from `expectedExitCode: 0` to `expectedExitCode: 3`.
- Adds `al0197_duplicate_extension_name_same_extension` entry to `docs/coverage.yaml`.

## Why pre-compile scan (not post-compile AL0197 parsing)

When all source files are compiled together in a single BC compilation pass, the BC compiler assigns **one** extension identity to all objects. This means it cannot distinguish same-extension from cross-extension duplicates in AL0197 messages. The pre-compile scan uses the actual `app.json` file structure to make the correct determination.

## Test plan

- [x] RED confirmed: fixture exits 0 before fix
- [x] GREEN confirmed: fixture exits 3 after fix  
- [x] Cross-extension test (`tests/bucket-2/130-cross-ext-al0275`) still exits 0 (no false positive)
- [x] All 4 buckets pass (exit 0) with no regressions
- [x] Stubs test passes
- [x] `docs/coverage.yaml` updated