### PR TITLE
fix: add MockObjectList.ALAssign for List of [RecordRef] var params — closes #1335

### DIFF
--- a/AlRunner/Runtime/MockObjectList.cs
+++ b/AlRunner/Runtime/MockObjectList.cs
@@ -34,6 +34,17 @@ public class MockObjectList<T> : IEnumerable<T>
 
     public bool ALRemove(T item) => _items.Remove(item);
 
+    /// <summary>
+    /// ALAssign — BC emits <c>list.ALAssign(other)</c> for the AL <c>:=</c>
+    /// assignment operator on <c>List of [T]</c> variables.  Clears the current
+    /// list and copies all items from <paramref name="other"/>.
+    /// </summary>
+    public void ALAssign(MockObjectList<T> other)
+    {
+        _items.Clear();
+        _items.AddRange(other._items);
+    }
+
     public void Clear() => _items.Clear();
 
     public IEnumerator<T> GetEnumerator() => _items.GetEnumerator();

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -4808,6 +4808,20 @@ Label.TrimStart (Text):
     - tests/bucket-2/186-label-string-methods
   notes: . Covered via NavText native — leading strip only.
 
+# ── List ────────────────────────────────────────────────────────
+
+List.Assign (:=):
+  layer: runtime-api
+  category: List
+  status: covered
+  tests:
+    - tests/bucket-2/308700-list-of-recordref
+  notes: |
+    BC emits `list.ALAssign(other)` for the `:=` assignment operator on
+    `List of [T]` (NavObjectList<T>) variables passed by `var`. MockObjectList<T>
+    was missing ALAssign — caused CS1061 (surfaced as CS1503 in some BC versions)
+    on codeunits with a `var List of [RecordRef]` parameter — closes #1335.
+
 # ── Media ───────────────────────────────────────────────────────
 
 Media.ExportFile (Text):

--- a/tests/bucket-2/308700-list-of-recordref/src/ListOfRecordRef.al
+++ b/tests/bucket-2/308700-list-of-recordref/src/ListOfRecordRef.al
@@ -1,0 +1,43 @@
+table 308700 "List RecordRef Table"
+{
+    fields
+    {
+        field(1; "Entry No."; Integer) { }
+        field(2; "Function Id"; Integer) { }
+    }
+    keys
+    {
+        key(PK; "Entry No.") { Clustered = true; }
+    }
+}
+
+codeunit 308700 "List Of RecordRef Helper"
+{
+    /// Reproduces CS1503 from issue #1335:
+    /// A procedure with List of [RecordRef] var param and Integer param.
+    /// The BC compiler emits C# where the list parameter uses a type that
+    /// the runner must handle correctly.
+    procedure GetRecRef(var Rec: RecordRef; var RelatedRefs: List of [RecordRef]; FunctionId: Integer; var CurrentRef: RecordRef): Boolean
+    begin
+        exit(FunctionId > 0);
+    end;
+
+    /// Caller passes Integer field (matching telemetry: TempFunctionField2."Function Id")
+    /// and a List of [RecordRef] var parameter — exact pattern from issue #1335.
+    procedure CallGetRecRef(var TempTable: Record "List RecordRef Table" temporary): Boolean
+    var
+        Rec: RecordRef;
+        RelatedRefs: List of [RecordRef];
+        CurrentRef: RecordRef;
+    begin
+        exit(GetRecRef(Rec, RelatedRefs, TempTable."Function Id", CurrentRef));
+    end;
+
+    /// Assign a new list to a var List of [RecordRef] parameter.
+    procedure UpdateList(var Refs: List of [RecordRef])
+    var
+        NewList: List of [RecordRef];
+    begin
+        Refs := NewList;
+    end;
+}

--- a/tests/bucket-2/308700-list-of-recordref/test/ListOfRecordRefTest.al
+++ b/tests/bucket-2/308700-list-of-recordref/test/ListOfRecordRefTest.al
@@ -1,0 +1,64 @@
+codeunit 308701 "List Of RecordRef Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Helper: Codeunit "List Of RecordRef Helper";
+
+    [Test]
+    procedure GetRecRef_WithIntegerField_Positive()
+    var
+        TempTable: Record "List RecordRef Table" temporary;
+        Result: Boolean;
+    begin
+        // [GIVEN] A temp record with Function Id = 99
+        TempTable.Init();
+        TempTable."Entry No." := 1;
+        TempTable."Function Id" := 99;
+        TempTable.Insert();
+
+        // [WHEN] Calling GetRecRef with an Integer field as FunctionId (reproduces CS1503 telemetry)
+        Result := Helper.CallGetRecRef(TempTable);
+
+        // [THEN] Returns true because 99 > 0
+        Assert.IsTrue(Result, 'GetRecRef should return true for FunctionId = 99');
+    end;
+
+    [Test]
+    procedure GetRecRef_WithZeroIntegerField_Negative()
+    var
+        TempTable: Record "List RecordRef Table" temporary;
+        Result: Boolean;
+    begin
+        // [GIVEN] A temp record with Function Id = 0
+        TempTable.Init();
+        TempTable."Entry No." := 2;
+        TempTable."Function Id" := 0;
+        TempTable.Insert();
+
+        // [WHEN] Calling GetRecRef with zero Integer field
+        Result := Helper.CallGetRecRef(TempTable);
+
+        // [THEN] Returns false because 0 is not > 0
+        Assert.IsFalse(Result, 'GetRecRef should return false for FunctionId = 0');
+    end;
+
+    [Test]
+    procedure ListOfRecordRef_Assign_ClearsExisting()
+    var
+        Refs: List of [RecordRef];
+        RecRef: RecordRef;
+    begin
+        // [GIVEN] A list with one entry
+        RecRef.Open(308700);
+        Refs.Add(RecRef);
+        Assert.AreEqual(1, Refs.Count(), 'List should have 1 element before UpdateList');
+
+        // [WHEN] Assigning a new (empty) list via var parameter
+        Helper.UpdateList(Refs);
+
+        // [THEN] The list is now empty — ALAssign replaced the list
+        Assert.AreEqual(0, Refs.Count(), 'List should be empty after UpdateList assigns a new list');
+    end;
+}


### PR DESCRIPTION
Closes #1335

## Root cause

BC emits `list.ALAssign(other)` for the AL `:=` assignment operator on `List of [T]` variables, including `List of [RecordRef]`. The transpiler wraps any `var` list parameter in a `ByRef<MockObjectList<T>>` setter lambda that calls `.ALAssign(setValue)`. `MockObjectList<T>` was missing this method, causing:

```
CS1061: 'MockObjectList<MockRecordRef>' does not contain a definition for 'ALAssign'
```

(Surfaced in telemetry as CS1503 depending on BC version.)

The pattern from the telemetry:
```al
GetRecRef(RecRef, RelatedRecRefs, TempFunctionField2."Function Id", CurrentRecRef)
```
where `RelatedRecRefs` is `List of [RecordRef]` passed as a `var` parameter.

## Fix

Added `ALAssign(MockObjectList<T> other)` to `MockObjectList<T>` that clears the current list and copies all items from the source — matching AL's copy-by-value `:=` semantics for list types.

## Tests

New suite `tests/bucket-2/308700-list-of-recordref`:
- `GetRecRef_WithIntegerField_Positive` — reproduces the exact telemetry call pattern with FunctionId=99, asserts `true` (99>0)
- `GetRecRef_WithZeroIntegerField_Negative` — FunctionId=0, asserts `false`
- `ListOfRecordRef_Assign_ClearsExisting` — exercises `MockObjectList.ALAssign` directly via `UpdateList(var Refs: List of [RecordRef])`