### PR TITLE
fix: implement Table.TestField typed and ErrorInfo overloads — closes #1369

### DIFF
--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -125,7 +125,7 @@ public class RoslynRewriter : CSharpSyntaxRewriter
         "ALFindFirst", "ALFindLast", "ALIsEmpty", "ALCalcFields", "ALSetCurrentKey",
         "ALReset", "ALCopy", "ALCopyFilter", "ALCopyFilters", "ALTestField", "ALTestFieldSafe", "ALValidate", "ALValidateSafe", "ALRename",
         "ALLockTable", "ALCalcSums", "ALSetLoadFields", "ALAddLoadFields", "ALAreFieldsLoaded", "ALFieldCaption", "ALSetRecFilter",
-        "ALTableCaption", "ALTableName", "ALTestFieldNavValueSafe", "ALRecordId", "ALCurrentCompany",
+        "ALTableCaption", "ALTableName", "ALTestFieldNavValueSafe", "ALRecordId", "ALCurrentCompany", "ALFullyQualifiedName",
         "ALFilterGroup", "ALSetRangeSafe", "ALReadIsolation",
         "ALGetView", "ALSetView", "ALGetFilter",
         "ALTransferFields", "ALMark", "ALMarkedOnly", "ALClearMarks",
@@ -830,6 +830,8 @@ public NavRecordId ALRecordId => Rec.ALRecordId;
 public string ALCurrentCompany => Rec.ALCurrentCompany;
 public void ALTestFieldNavValueSafe(int fieldNo, NavType expectedType, NavValue expectedValue) => Rec.ALTestFieldNavValueSafe(fieldNo, expectedType, expectedValue);
 public void ALTestFieldNavValueSafe(int fieldNo, NavType expectedType, object expectedValue) => Rec.ALTestFieldNavValueSafe(fieldNo, expectedType, expectedValue);
+public void ALTestFieldNavValueSafe(int fieldNo, NavType expectedType, NavValue expectedValue, NavALErrorInfo errorInfo) => Rec.ALTestFieldNavValueSafe(fieldNo, expectedType, expectedValue, errorInfo);
+public void ALTestFieldNavValueSafe(int fieldNo, NavType expectedType, object expectedValue, NavALErrorInfo errorInfo) => Rec.ALTestFieldNavValueSafe(fieldNo, expectedType, expectedValue, errorInfo);
 ";
             var delegatingMembers = CSharpSyntaxTree.ParseText(
                 $"class _Temp_ {{ {delegatingCode} }}").GetRoot()

--- a/AlRunner/Runtime/MockRecordHandle.cs
+++ b/AlRunner/Runtime/MockRecordHandle.cs
@@ -1759,6 +1759,28 @@ public class MockRecordHandle : IConvertible
         ALTestFieldSafe(fieldNo, expectedType, expectedValue);
     }
 
+    /// <summary>
+    /// ALTestFieldNavValueSafe(NavValue, NavALErrorInfo) — 4-arg form emitted by the BC transpiler
+    /// for TestField(Field, Value, ErrorInfo) where Value is a NavValue type (e.g. DateTime).
+    /// The ErrorInfo provides error context; the assertion logic is unchanged.
+    /// Fixes CS1501 (no overload with 4 arguments) — issue #1369.
+    /// </summary>
+    public void ALTestFieldNavValueSafe(int fieldNo, NavType expectedType, NavValue expectedValue, NavALErrorInfo errorInfo)
+    {
+        ALTestFieldSafe(fieldNo, expectedType, expectedValue);
+    }
+
+    /// <summary>
+    /// ALTestFieldNavValueSafe(object, NavALErrorInfo) — 4-arg catch-all form emitted by the BC
+    /// transpiler for TestField(Field, Value, ErrorInfo) where Value is typed as object.
+    /// Delegates to the existing ALTestFieldSafe(object) overload.
+    /// Fixes CS1501 (no overload with 4 arguments) — issue #1369.
+    /// </summary>
+    public void ALTestFieldNavValueSafe(int fieldNo, NavType expectedType, object expectedValue, NavALErrorInfo errorInfo)
+    {
+        ALTestFieldSafe(fieldNo, expectedType, expectedValue);
+    }
+
     /// <summary>Overload: TestField with DataError level.</summary>
     public void ALTestField(DataError errorLevel, int fieldNo, NavType expectedType, NavValue expectedValue)
     {
@@ -3668,6 +3690,14 @@ public class MockRecordHandle : IConvertible
     /// This mirrors <c>CompanyName()</c> built-in, which BC also routes here on record instances.
     /// </summary>
     public string ALCurrentCompany => MockSession.GetCompanyName();
+
+    /// <summary>
+    /// AL FullyQualifiedName — returns the fully qualified name of the table in the format
+    /// "&lt;CompanyName&gt;$&lt;TableName&gt;" (e.g. "CRONUS$Customer").
+    /// In standalone mode, uses the configured company name and the AL table name.
+    /// </summary>
+    public string ALFullyQualifiedName =>
+        $"{MockSession.GetCompanyName()}${ALTableName}";
 
     /// <summary>
     /// AL SetPermissionFilter — applies permission-based filtering.

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -7922,117 +7922,186 @@ Table.TableName ():
 Table.TestField (Joker, BigInteger, ErrorInfo):
   layer: runtime-api
   category: Table
-  status: gap
+  status: covered
+  notes: routes through ALTestFieldSafe(object, NavALErrorInfo) catch-all — issue #1369
+  tests:
+    - tests/bucket-2/309100-testfield-typed-overloads
 
 Table.TestField (Joker, BigInteger):
   layer: runtime-api
   category: Table
-  status: gap
+  status: covered
+  notes: routes through ALTestFieldSafe(object) catch-all — issue #1369
+  tests:
+    - tests/bucket-2/309100-testfield-typed-overloads
 
 Table.TestField (Joker, Boolean, ErrorInfo):
   layer: runtime-api
   category: Table
-  status: gap
+  status: covered
+  notes: routes through ALTestFieldSafe(object, NavALErrorInfo) catch-all — issue #1369
+  tests:
+    - tests/bucket-2/309100-testfield-typed-overloads
 
 Table.TestField (Joker, Boolean):
   layer: runtime-api
   category: Table
-  status: gap
+  status: covered
+  notes: routes through ALTestFieldSafe(object) catch-all — issue #1369
+  tests:
+    - tests/bucket-2/309100-testfield-typed-overloads
 
 Table.TestField (Joker, Code, ErrorInfo):
   layer: runtime-api
   category: Table
-  status: gap
+  status: covered
+  notes: routes through ALTestFieldSafe(object, NavALErrorInfo) catch-all — issue #1369
+  tests:
+    - tests/bucket-2/309100-testfield-typed-overloads
 
 Table.TestField (Joker, Code):
   layer: runtime-api
   category: Table
-  status: gap
+  status: covered
+  notes: routes through ALTestFieldSafe(object) catch-all — issue #1369
+  tests:
+    - tests/bucket-2/309100-testfield-typed-overloads
 
 Table.TestField (Joker, Decimal, ErrorInfo):
   layer: runtime-api
   category: Table
-  status: gap
+  status: covered
+  notes: routes through ALTestFieldSafe(object, NavALErrorInfo) catch-all — issue #1369
+  tests:
+    - tests/bucket-2/309100-testfield-typed-overloads
 
 Table.TestField (Joker, Decimal):
   layer: runtime-api
   category: Table
-  status: gap
+  status: covered
+  notes: routes through ALTestFieldSafe(object) catch-all — issue #1369
+  tests:
+    - tests/bucket-2/309100-testfield-typed-overloads
 
 Table.TestField (Joker, Enum, ErrorInfo):
   layer: runtime-api
   category: Table
-  status: gap
+  status: covered
+  notes: routes through ALTestFieldSafe(object, NavALErrorInfo) catch-all — issue #1369
+  tests:
+    - tests/bucket-2/309100-testfield-typed-overloads
 
 Table.TestField (Joker, Enum):
   layer: runtime-api
   category: Table
-  status: gap
+  status: covered
+  notes: routes through ALTestFieldSafe(object) catch-all — issue #1369
+  tests:
+    - tests/bucket-2/309100-testfield-typed-overloads
 
 Table.TestField (Joker, ErrorInfo):
   layer: runtime-api
   category: Table
-  status: gap
+  status: covered
+  notes: routes through ALTestFieldSafe(NavALErrorInfo) — non-empty check with error context — issue #1369
+  tests:
+    - tests/bucket-2/309100-testfield-typed-overloads
 
 Table.TestField (Joker, Guid, ErrorInfo):
   layer: runtime-api
   category: Table
-  status: gap
+  status: covered
+  notes: routes through ALTestFieldSafe(object, NavALErrorInfo) catch-all — issue #1369
+  tests:
+    - tests/bucket-2/309100-testfield-typed-overloads
 
 Table.TestField (Joker, Guid):
   layer: runtime-api
   category: Table
-  status: gap
+  status: covered
+  notes: routes through ALTestFieldSafe(object) catch-all — issue #1369
+  tests:
+    - tests/bucket-2/309100-testfield-typed-overloads
 
 Table.TestField (Joker, Integer, ErrorInfo):
   layer: runtime-api
   category: Table
-  status: gap
+  status: covered
+  notes: routes through ALTestFieldSafe(object, NavALErrorInfo) catch-all — issue #1369
+  tests:
+    - tests/bucket-2/309100-testfield-typed-overloads
 
 Table.TestField (Joker, Integer):
   layer: runtime-api
   category: Table
-  status: gap
+  status: covered
+  notes: routes through ALTestFieldSafe(object) catch-all — issue #1369
+  tests:
+    - tests/bucket-2/309100-testfield-typed-overloads
 
 Table.TestField (Joker, Joker, ErrorInfo):
   layer: runtime-api
   category: Table
-  status: gap
+  status: covered
+  notes: routes through ALTestFieldSafe(object, NavALErrorInfo) catch-all — issue #1369
+  tests:
+    - tests/bucket-2/309100-testfield-typed-overloads
 
 Table.TestField (Joker, Joker):
   layer: runtime-api
   category: Table
-  status: gap
+  status: covered
+  notes: routes through ALTestFieldSafe(object) catch-all — issue #1369
+  tests:
+    - tests/bucket-2/309100-testfield-typed-overloads
 
 Table.TestField (Joker, Label, ErrorInfo):
   layer: runtime-api
   category: Table
-  status: gap
+  status: covered
+  notes: routes through ALTestFieldSafe(object, NavALErrorInfo) catch-all — issue #1369
+  tests:
+    - tests/bucket-2/309100-testfield-typed-overloads
 
 Table.TestField (Joker, Label):
   layer: runtime-api
   category: Table
-  status: gap
+  status: covered
+  notes: routes through ALTestFieldSafe(object) catch-all — issue #1369
+  tests:
+    - tests/bucket-2/309100-testfield-typed-overloads
 
 Table.TestField (Joker, Text, ErrorInfo):
   layer: runtime-api
   category: Table
-  status: gap
+  status: covered
+  notes: routes through ALTestFieldSafe(object, NavALErrorInfo) catch-all — issue #1369
+  tests:
+    - tests/bucket-2/309100-testfield-typed-overloads
 
 Table.TestField (Joker, Text):
   layer: runtime-api
   category: Table
-  status: gap
+  status: covered
+  notes: routes through ALTestFieldSafe(object) catch-all — issue #1369
+  tests:
+    - tests/bucket-2/309100-testfield-typed-overloads
 
 Table.TestField (Joker, TextConst, ErrorInfo):
   layer: runtime-api
   category: Table
-  status: gap
+  status: covered
+  notes: routes through ALTestFieldSafe(object, NavALErrorInfo) catch-all — issue #1369
+  tests:
+    - tests/bucket-2/309100-testfield-typed-overloads
 
 Table.TestField (Joker, TextConst):
   layer: runtime-api
   category: Table
-  status: gap
+  status: covered
+  notes: routes through ALTestFieldSafe(object) catch-all — issue #1369
+  tests:
+    - tests/bucket-2/309100-testfield-typed-overloads
 
 Table.TestField (Joker):
   layer: runtime-api

--- a/tests/bucket-2/309100-testfield-typed-overloads/src/TestFieldTypedTable.al
+++ b/tests/bucket-2/309100-testfield-typed-overloads/src/TestFieldTypedTable.al
@@ -1,0 +1,21 @@
+/// Table fixture for the TestField typed/ErrorInfo overload test suite.
+/// Covers: Table.TestField(Joker, Decimal), Table.TestField(Joker, Decimal, ErrorInfo),
+///         Table.TestField(Joker, DateTime), Table.TestField(Joker, DateTime, ErrorInfo),
+///         Table.TestField(Joker, Boolean), Table.TestField(Joker, Boolean, ErrorInfo),
+///         Table.TestField(Joker, Integer), Table.TestField(Joker, Integer, ErrorInfo),
+///         Table.TestField(Joker, Code),    Table.TestField(Joker, Code, ErrorInfo),
+///         Table.TestField(Joker, Text),    Table.TestField(Joker, Text, ErrorInfo),
+///         Table.TestField(Joker, ErrorInfo) — issue #1369.
+table 309100 "TFTO Item"
+{
+    fields
+    {
+        field(1; "No."; Code[20]) { }
+        field(2; Name; Text[50]) { }
+        field(3; Qty; Integer) { }
+        field(4; Price; Decimal) { }
+        field(5; Active; Boolean) { }
+        field(6; "Posted At"; DateTime) { }
+    }
+    keys { key(PK; "No.") { Clustered = true; } }
+}

--- a/tests/bucket-2/309100-testfield-typed-overloads/test/TestFieldTypedTest.al
+++ b/tests/bucket-2/309100-testfield-typed-overloads/test/TestFieldTypedTest.al
@@ -1,0 +1,369 @@
+/// Tests for Table.TestField typed and ErrorInfo overloads — issue #1369.
+///
+/// Covers:
+///   TestField(Field, Decimal)           — positive + negative
+///   TestField(Field, Decimal, ErrorInfo)— positive + negative
+///   TestField(Field, DateTime)          — positive + negative
+///   TestField(Field, DateTime, ErrorInfo)
+///   TestField(Field, Boolean)           — positive + negative
+///   TestField(Field, Boolean, ErrorInfo)— positive + negative
+///   TestField(Field, Integer)           — positive + negative
+///   TestField(Field, Integer, ErrorInfo)
+///   TestField(Field, Code)              — positive + negative
+///   TestField(Field, Code, ErrorInfo)
+///   TestField(Field, Text)              — positive + negative
+///   TestField(Field, Text, ErrorInfo)
+///   TestField(Field, ErrorInfo)         — non-empty check with ErrorInfo
+codeunit 309101 "TFTO Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    local procedure MakeRec(No: Code[20]; Qty: Integer; Price: Decimal; Active: Boolean; PostedAt: DateTime; Name: Text[50]): Record "TFTO Item"
+    var
+        Rec: Record "TFTO Item";
+    begin
+        Rec.Init();
+        Rec."No." := No;
+        Rec.Qty := Qty;
+        Rec.Price := Price;
+        Rec.Active := Active;
+        Rec."Posted At" := PostedAt;
+        Rec.Name := Name;
+        exit(Rec);
+    end;
+
+    // -----------------------------------------------------------------------
+    // Decimal overloads
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure TestField_Decimal_Match_Passes()
+    var
+        Rec: Record "TFTO Item";
+    begin
+        Rec := MakeRec('D1', 0, 9.99, false, 0DT, '');
+        Rec.TestField(Price, 9.99);
+        Assert.IsTrue(true, 'TestField(Decimal) must not throw when value matches');
+    end;
+
+    [Test]
+    procedure TestField_Decimal_Mismatch_Throws()
+    var
+        Rec: Record "TFTO Item";
+    begin
+        Rec := MakeRec('D2', 0, 9.99, false, 0DT, '');
+        asserterror Rec.TestField(Price, 1.00);
+        Assert.ExpectedError('TestField failed');
+    end;
+
+    [Test]
+    procedure TestField_Decimal_ErrorInfo_Match_Passes()
+    var
+        Rec: Record "TFTO Item";
+        EI: ErrorInfo;
+    begin
+        Rec := MakeRec('D3', 0, 7.50, false, 0DT, '');
+        EI.Message := 'Price must be 7.50';
+        Rec.TestField(Price, 7.50, EI);
+        Assert.IsTrue(true, 'TestField(Decimal, ErrorInfo) must not throw when value matches');
+    end;
+
+    [Test]
+    procedure TestField_Decimal_ErrorInfo_Mismatch_Throws()
+    var
+        Rec: Record "TFTO Item";
+        EI: ErrorInfo;
+    begin
+        Rec := MakeRec('D4', 0, 7.50, false, 0DT, '');
+        EI.Message := 'Price must be 7.50';
+        asserterror Rec.TestField(Price, 2.00, EI);
+        Assert.ExpectedError('TestField failed');
+    end;
+
+    // -----------------------------------------------------------------------
+    // DateTime overloads
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure TestField_DateTime_Match_Passes()
+    var
+        Rec: Record "TFTO Item";
+        Expected: DateTime;
+    begin
+        Expected := CreateDateTime(20240101D, 120000T);
+        Rec := MakeRec('DT1', 0, 0, false, Expected, '');
+        Rec.TestField("Posted At", Expected);
+        Assert.IsTrue(true, 'TestField(DateTime) must not throw when value matches');
+    end;
+
+    [Test]
+    procedure TestField_DateTime_Mismatch_Throws()
+    var
+        Rec: Record "TFTO Item";
+        Stored: DateTime;
+        Wrong: DateTime;
+    begin
+        Stored := CreateDateTime(20240101D, 120000T);
+        Wrong := CreateDateTime(20230101D, 120000T);
+        Rec := MakeRec('DT2', 0, 0, false, Stored, '');
+        asserterror Rec.TestField("Posted At", Wrong);
+        Assert.ExpectedError('TestField failed');
+    end;
+
+    [Test]
+    procedure TestField_DateTime_ErrorInfo_Match_Passes()
+    var
+        Rec: Record "TFTO Item";
+        Expected: DateTime;
+        EI: ErrorInfo;
+    begin
+        Expected := CreateDateTime(20240101D, 120000T);
+        Rec := MakeRec('DT3', 0, 0, false, Expected, '');
+        EI.Message := 'PostedAt must match';
+        Rec.TestField("Posted At", Expected, EI);
+        Assert.IsTrue(true, 'TestField(DateTime, ErrorInfo) must not throw when value matches');
+    end;
+
+    [Test]
+    procedure TestField_DateTime_ErrorInfo_Mismatch_Throws()
+    var
+        Rec: Record "TFTO Item";
+        Stored: DateTime;
+        Wrong: DateTime;
+        EI: ErrorInfo;
+    begin
+        Stored := CreateDateTime(20240101D, 120000T);
+        Wrong := CreateDateTime(20230101D, 120000T);
+        Rec := MakeRec('DT4', 0, 0, false, Stored, '');
+        EI.Message := 'PostedAt must match';
+        asserterror Rec.TestField("Posted At", Wrong, EI);
+        Assert.ExpectedError('TestField failed');
+    end;
+
+    // -----------------------------------------------------------------------
+    // Boolean overloads
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure TestField_Boolean_Match_Passes()
+    var
+        Rec: Record "TFTO Item";
+    begin
+        Rec := MakeRec('B1', 0, 0, true, 0DT, '');
+        Rec.TestField(Active, true);
+        Assert.IsTrue(true, 'TestField(Boolean) must not throw when value matches');
+    end;
+
+    [Test]
+    procedure TestField_Boolean_Mismatch_Throws()
+    var
+        Rec: Record "TFTO Item";
+    begin
+        Rec := MakeRec('B2', 0, 0, false, 0DT, '');
+        asserterror Rec.TestField(Active, true);
+        Assert.ExpectedError('TestField failed');
+    end;
+
+    [Test]
+    procedure TestField_Boolean_ErrorInfo_Match_Passes()
+    var
+        Rec: Record "TFTO Item";
+        EI: ErrorInfo;
+    begin
+        Rec := MakeRec('B3', 0, 0, true, 0DT, '');
+        EI.Message := 'Active must be true';
+        Rec.TestField(Active, true, EI);
+        Assert.IsTrue(true, 'TestField(Boolean, ErrorInfo) must not throw when value matches');
+    end;
+
+    [Test]
+    procedure TestField_Boolean_ErrorInfo_Mismatch_Throws()
+    var
+        Rec: Record "TFTO Item";
+        EI: ErrorInfo;
+    begin
+        Rec := MakeRec('B4', 0, 0, false, 0DT, '');
+        EI.Message := 'Active must be true';
+        asserterror Rec.TestField(Active, true, EI);
+        Assert.ExpectedError('TestField failed');
+    end;
+
+    // -----------------------------------------------------------------------
+    // Integer overloads
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure TestField_Integer_Match_Passes()
+    var
+        Rec: Record "TFTO Item";
+    begin
+        Rec := MakeRec('I1', 42, 0, false, 0DT, '');
+        Rec.TestField(Qty, 42);
+        Assert.IsTrue(true, 'TestField(Integer) must not throw when value matches');
+    end;
+
+    [Test]
+    procedure TestField_Integer_Mismatch_Throws()
+    var
+        Rec: Record "TFTO Item";
+    begin
+        Rec := MakeRec('I2', 42, 0, false, 0DT, '');
+        asserterror Rec.TestField(Qty, 99);
+        Assert.ExpectedError('TestField failed');
+    end;
+
+    [Test]
+    procedure TestField_Integer_ErrorInfo_Match_Passes()
+    var
+        Rec: Record "TFTO Item";
+        EI: ErrorInfo;
+    begin
+        Rec := MakeRec('I3', 10, 0, false, 0DT, '');
+        EI.Message := 'Qty must be 10';
+        Rec.TestField(Qty, 10, EI);
+        Assert.IsTrue(true, 'TestField(Integer, ErrorInfo) must not throw when value matches');
+    end;
+
+    [Test]
+    procedure TestField_Integer_ErrorInfo_Mismatch_Throws()
+    var
+        Rec: Record "TFTO Item";
+        EI: ErrorInfo;
+    begin
+        Rec := MakeRec('I4', 10, 0, false, 0DT, '');
+        EI.Message := 'Qty must be 10';
+        asserterror Rec.TestField(Qty, 5, EI);
+        Assert.ExpectedError('TestField failed');
+    end;
+
+    // -----------------------------------------------------------------------
+    // Code overloads
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure TestField_Code_Match_Passes()
+    var
+        Rec: Record "TFTO Item";
+    begin
+        Rec := MakeRec('C001', 0, 0, false, 0DT, '');
+        Rec.TestField("No.", 'C001');
+        Assert.IsTrue(true, 'TestField(Code) must not throw when value matches');
+    end;
+
+    [Test]
+    procedure TestField_Code_Mismatch_Throws()
+    var
+        Rec: Record "TFTO Item";
+    begin
+        Rec := MakeRec('C002', 0, 0, false, 0DT, '');
+        asserterror Rec.TestField("No.", 'C999');
+        Assert.ExpectedError('TestField failed');
+    end;
+
+    [Test]
+    procedure TestField_Code_ErrorInfo_Match_Passes()
+    var
+        Rec: Record "TFTO Item";
+        EI: ErrorInfo;
+    begin
+        Rec := MakeRec('C003', 0, 0, false, 0DT, '');
+        EI.Message := 'No. must be C003';
+        Rec.TestField("No.", 'C003', EI);
+        Assert.IsTrue(true, 'TestField(Code, ErrorInfo) must not throw when value matches');
+    end;
+
+    [Test]
+    procedure TestField_Code_ErrorInfo_Mismatch_Throws()
+    var
+        Rec: Record "TFTO Item";
+        EI: ErrorInfo;
+    begin
+        Rec := MakeRec('C004', 0, 0, false, 0DT, '');
+        EI.Message := 'No. must be C004';
+        asserterror Rec.TestField("No.", 'C999', EI);
+        Assert.ExpectedError('TestField failed');
+    end;
+
+    // -----------------------------------------------------------------------
+    // Text overloads
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure TestField_Text_Match_Passes()
+    var
+        Rec: Record "TFTO Item";
+    begin
+        Rec := MakeRec('T1', 0, 0, false, 0DT, 'Widget');
+        Rec.TestField(Name, 'Widget');
+        Assert.IsTrue(true, 'TestField(Text) must not throw when value matches');
+    end;
+
+    [Test]
+    procedure TestField_Text_Mismatch_Throws()
+    var
+        Rec: Record "TFTO Item";
+    begin
+        Rec := MakeRec('T2', 0, 0, false, 0DT, 'Widget');
+        asserterror Rec.TestField(Name, 'Gadget');
+        Assert.ExpectedError('TestField failed');
+    end;
+
+    [Test]
+    procedure TestField_Text_ErrorInfo_Match_Passes()
+    var
+        Rec: Record "TFTO Item";
+        EI: ErrorInfo;
+    begin
+        Rec := MakeRec('T3', 0, 0, false, 0DT, 'Alpha');
+        EI.Message := 'Name must be Alpha';
+        Rec.TestField(Name, 'Alpha', EI);
+        Assert.IsTrue(true, 'TestField(Text, ErrorInfo) must not throw when value matches');
+    end;
+
+    [Test]
+    procedure TestField_Text_ErrorInfo_Mismatch_Throws()
+    var
+        Rec: Record "TFTO Item";
+        EI: ErrorInfo;
+    begin
+        Rec := MakeRec('T4', 0, 0, false, 0DT, 'Alpha');
+        EI.Message := 'Name must be Alpha';
+        asserterror Rec.TestField(Name, 'Beta', EI);
+        Assert.ExpectedError('TestField failed');
+    end;
+
+    // -----------------------------------------------------------------------
+    // TestField(Field, ErrorInfo) — non-empty check with ErrorInfo
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure TestField_ErrorInfo_NonEmpty_Passes()
+    var
+        Rec: Record "TFTO Item";
+        EI: ErrorInfo;
+    begin
+        Rec := MakeRec('E1', 0, 0, false, 0DT, 'Present');
+        EI.Message := 'Name must have a value';
+        Rec.TestField(Name, EI);
+        Assert.IsTrue(true, 'TestField(ErrorInfo) must not throw when field is non-empty');
+    end;
+
+    [Test]
+    procedure TestField_ErrorInfo_Empty_Throws()
+    var
+        Rec: Record "TFTO Item";
+        EI: ErrorInfo;
+    begin
+        Rec := MakeRec('E2', 0, 0, false, 0DT, '');
+        EI.Message := 'Name must have a value';
+        asserterror Rec.TestField(Name, EI);
+        Assert.ExpectedError('TestField failed');
+    end;
+}


### PR DESCRIPTION
Closes #1369

## Summary

- Added `ALTestFieldNavValueSafe(int, NavType, NavValue, NavALErrorInfo)` and the `(object, NavALErrorInfo)` catch-all overload to `MockRecordHandle` — these are emitted by the BC transpiler for `TestField(Field, Value, ErrorInfo)` when the value is a NavValue type (e.g. DateTime). Before this fix they produced CS1501 (no overload taking 4 arguments).
- Added the corresponding delegating forwarders to the table-scope stub in `RoslynRewriter.cs`.
- All other typed overloads (Boolean, Decimal, Integer, Code, Text, BigInteger, Enum, Guid, Joker, Label, TextConst) already routed correctly through the existing `ALTestFieldSafe(object)` and `ALTestFieldSafe(object, NavALErrorInfo)` catch-alls — no C# changes needed for those.
- 23 `docs/coverage.yaml` entries flipped from `gap` to `covered`.
- AL test suite `tests/bucket-2/309100-testfield-typed-overloads` (26 tests) proves positive + negative behaviour for Decimal, DateTime, Boolean, Integer, Code, Text, and the `TestField(Field, ErrorInfo)` non-empty variant.