### PR TITLE
fix: implement Page.Run/RunModal 3-arg overloads — closes #1374

### DIFF
--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -5430,22 +5430,34 @@ Page.Run ():
 Page.Run (Integer, Table, Integer):
   layer: runtime-api
   category: Page
-  status: gap
+  status: covered
+  tests:
+    - tests/bucket-2/100-page-run-3arg
+  notes: 3rd argument (position/focus field) accepted and ignored — no real UI in standalone mode.
 
 Page.Run (Integer, Table, Joker):
   layer: runtime-api
   category: Page
-  status: gap
+  status: covered
+  tests:
+    - tests/bucket-2/100-page-run-3arg
+  notes: 3rd argument (position/focus field as Joker) accepted and ignored — no real UI in standalone mode.
 
 Page.Run (Text, Table, Integer):
   layer: runtime-api
   category: Page
-  status: gap
+  status: covered
+  tests:
+    - tests/bucket-2/100-page-run-3arg
+  notes: Text page-ID form. 3rd argument (position/focus field) accepted and ignored — no real UI in standalone mode.
 
 Page.Run (Text, Table, Joker):
   layer: runtime-api
   category: Page
-  status: gap
+  status: covered
+  tests:
+    - tests/bucket-2/100-page-run-3arg
+  notes: Text page-ID form. 3rd argument (position/focus field as Joker) accepted and ignored — no real UI in standalone mode.
 
 Page.RunModal ():
   layer: runtime-api
@@ -5460,32 +5472,50 @@ Page.RunModal ():
 Page.RunModal (Integer, Table, FieldRef):
   layer: runtime-api
   category: Page
-  status: gap
+  status: covered
+  tests:
+    - tests/bucket-2/100-page-run-3arg
+  notes: 3rd argument (position as FieldRef) accepted and ignored — no real UI in standalone mode. Returns default(FormResult) = Action::None.
 
 Page.RunModal (Integer, Table, Integer):
   layer: runtime-api
   category: Page
-  status: gap
+  status: covered
+  tests:
+    - tests/bucket-2/100-page-run-3arg
+  notes: 3rd argument (position as integer field number) accepted and ignored — no real UI in standalone mode. Returns default(FormResult) = Action::None.
 
 Page.RunModal (Integer, Table, Joker):
   layer: runtime-api
   category: Page
-  status: gap
+  status: covered
+  tests:
+    - tests/bucket-2/100-page-run-3arg
+  notes: 3rd argument (position as Joker) accepted and ignored — no real UI in standalone mode. Returns default(FormResult) = Action::None.
 
 Page.RunModal (Text, Table, FieldRef):
   layer: runtime-api
   category: Page
-  status: gap
+  status: covered
+  tests:
+    - tests/bucket-2/100-page-run-3arg
+  notes: Text page-ID form. 3rd argument (position as FieldRef) accepted and ignored — no real UI in standalone mode. Returns default(FormResult) = Action::None.
 
 Page.RunModal (Text, Table, Integer):
   layer: runtime-api
   category: Page
-  status: gap
+  status: covered
+  tests:
+    - tests/bucket-2/100-page-run-3arg
+  notes: Text page-ID form. 3rd argument (position as integer field number) accepted and ignored — no real UI in standalone mode. Returns default(FormResult) = Action::None.
 
 Page.RunModal (Text, Table, Joker):
   layer: runtime-api
   category: Page
-  status: gap
+  status: covered
+  tests:
+    - tests/bucket-2/100-page-run-3arg
+  notes: Text page-ID form. 3rd argument (position as Joker) accepted and ignored — no real UI in standalone mode. Returns default(FormResult) = Action::None.
 
 Page.SaveRecord ():
   layer: runtime-api

--- a/tests/bucket-2/100-page-run-3arg/src/Source.al
+++ b/tests/bucket-2/100-page-run-3arg/src/Source.al
@@ -1,0 +1,108 @@
+/// Source codeunit exercising Page.Run / Page.RunModal 3-argument overloads.
+/// All 10 overloads from issue #1374 are exercised here.
+/// The position/focus argument is accepted and ignored by the runner — no real UI.
+codeunit 309600 "P3A Source"
+{
+    // -----------------------------------------------------------------------
+    // Page.Run 3-arg overloads
+    // -----------------------------------------------------------------------
+
+    /// Page.Run(Integer, Table, Integer) — position as integer field number
+    procedure RunIntTableInt(var Rec: Record "P3A Row")
+    begin
+        Page.Run(Page::"P3A Card", Rec, 1);
+    end;
+
+    /// Page.Run(Integer, Table, Joker) — position as Joker (field variable)
+    procedure RunIntTableJoker(var Rec: Record "P3A Row")
+    begin
+        Page.Run(Page::"P3A Card", Rec, Rec.Id);
+    end;
+
+    /// Page.Run(Text, Table, Integer) — page name as Text, position as integer
+    procedure RunTextTableInt(var Rec: Record "P3A Row"; PageName: Text)
+    begin
+        Page.Run(PageName, Rec, 1);
+    end;
+
+    /// Page.Run(Text, Table, Joker) — page name as Text, position as Joker
+    procedure RunTextTableJoker(var Rec: Record "P3A Row"; PageName: Text)
+    begin
+        Page.Run(PageName, Rec, Rec.Id);
+    end;
+
+    // -----------------------------------------------------------------------
+    // Page.RunModal 3-arg overloads
+    // -----------------------------------------------------------------------
+
+    /// Page.RunModal(Integer, Table, FieldRef) — position as FieldRef
+    procedure RunModalIntTableFieldRef(var Rec: Record "P3A Row"): Action
+    var
+        RRef: RecordRef;
+        FRef: FieldRef;
+    begin
+        RRef.GetTable(Rec);
+        FRef := RRef.Field(1);
+        exit(Page.RunModal(Page::"P3A Card", Rec, FRef));
+    end;
+
+    /// Page.RunModal(Integer, Table, Integer) — position as integer field number
+    procedure RunModalIntTableInt(var Rec: Record "P3A Row"): Action
+    begin
+        exit(Page.RunModal(Page::"P3A Card", Rec, 1));
+    end;
+
+    /// Page.RunModal(Integer, Table, Joker) — position as Joker (field variable)
+    procedure RunModalIntTableJoker(var Rec: Record "P3A Row"): Action
+    begin
+        exit(Page.RunModal(Page::"P3A Card", Rec, Rec.Id));
+    end;
+
+    /// Page.RunModal(Text, Table, FieldRef) — page name as Text, position as FieldRef
+    procedure RunModalTextTableFieldRef(var Rec: Record "P3A Row"; PageName: Text): Action
+    var
+        RRef: RecordRef;
+        FRef: FieldRef;
+    begin
+        RRef.GetTable(Rec);
+        FRef := RRef.Field(1);
+        exit(Page.RunModal(PageName, Rec, FRef));
+    end;
+
+    /// Page.RunModal(Text, Table, Integer) — page name as Text, position as integer
+    procedure RunModalTextTableInt(var Rec: Record "P3A Row"; PageName: Text): Action
+    begin
+        exit(Page.RunModal(PageName, Rec, 1));
+    end;
+
+    /// Page.RunModal(Text, Table, Joker) — page name as Text, position as Joker
+    procedure RunModalTextTableJoker(var Rec: Record "P3A Row"; PageName: Text): Action
+    begin
+        exit(Page.RunModal(PageName, Rec, Rec.Id));
+    end;
+}
+
+table 309600 "P3A Row"
+{
+    fields
+    {
+        field(1; Id; Integer) { }
+        field(2; Name; Text[100]) { }
+    }
+    keys { key(PK; Id) { Clustered = true; } }
+}
+
+page 309600 "P3A Card"
+{
+    PageType = Card;
+    SourceTable = "P3A Row";
+
+    layout
+    {
+        area(Content)
+        {
+            field(IdField; Rec.Id) { }
+            field(NameField; Rec.Name) { }
+        }
+    }
+}

--- a/tests/bucket-2/100-page-run-3arg/test/Test.al
+++ b/tests/bucket-2/100-page-run-3arg/test/Test.al
@@ -1,0 +1,136 @@
+/// Tests for Page.Run / Page.RunModal 3-argument overloads — issue #1374.
+/// All 10 overloads are exercised. The position/focus argument is accepted and
+/// ignored by the runner (no real UI). Tests are "no-throw" stubs per CLAUDE.md
+/// exception: when the *entire* claim is "this does not crash", names make that explicit.
+codeunit 309601 "P3A Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "P3A Source";
+
+    // -----------------------------------------------------------------------
+    // Page.Run 3-arg — no-throw stubs
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure PageRun_IntTableInt_NoThrow()
+    var
+        Rec: Record "P3A Row";
+    begin
+        // [WHEN] Page.Run(Integer, Table, Integer) is called
+        // [THEN] No error is raised — position arg is accepted and ignored
+        Src.RunIntTableInt(Rec);
+        Assert.IsTrue(true, 'Page.Run(Integer, Table, Integer) must be a no-op');
+    end;
+
+    [Test]
+    procedure PageRun_IntTableJoker_NoThrow()
+    var
+        Rec: Record "P3A Row";
+    begin
+        // [WHEN] Page.Run(Integer, Table, Joker) is called
+        // [THEN] No error is raised
+        Src.RunIntTableJoker(Rec);
+        Assert.IsTrue(true, 'Page.Run(Integer, Table, Joker) must be a no-op');
+    end;
+
+    [Test]
+    procedure PageRun_TextTableInt_NoThrow()
+    var
+        Rec: Record "P3A Row";
+    begin
+        // [WHEN] Page.Run(Text, Table, Integer) is called
+        // [THEN] No error is raised
+        Src.RunTextTableInt(Rec, 'P3A Card');
+        Assert.IsTrue(true, 'Page.Run(Text, Table, Integer) must be a no-op');
+    end;
+
+    [Test]
+    procedure PageRun_TextTableJoker_NoThrow()
+    var
+        Rec: Record "P3A Row";
+    begin
+        // [WHEN] Page.Run(Text, Table, Joker) is called
+        // [THEN] No error is raised
+        Src.RunTextTableJoker(Rec, 'P3A Card');
+        Assert.IsTrue(true, 'Page.Run(Text, Table, Joker) must be a no-op');
+    end;
+
+    // -----------------------------------------------------------------------
+    // Page.RunModal 3-arg — return Action::None (stub default)
+    // -----------------------------------------------------------------------
+
+    [Test]
+    procedure PageRunModal_IntTableFieldRef_ReturnsNone()
+    var
+        Rec: Record "P3A Row";
+        Result: Action;
+    begin
+        // [WHEN] Page.RunModal(Integer, Table, FieldRef) is called
+        Result := Src.RunModalIntTableFieldRef(Rec);
+        // [THEN] Returns Action::None (stub default = 0) — proves a value was returned
+        Assert.AreEqual(Action::None, Result, 'Page.RunModal(Integer, Table, FieldRef) must return Action::None');
+    end;
+
+    [Test]
+    procedure PageRunModal_IntTableInt_ReturnsNone()
+    var
+        Rec: Record "P3A Row";
+        Result: Action;
+    begin
+        // [WHEN] Page.RunModal(Integer, Table, Integer) is called
+        Result := Src.RunModalIntTableInt(Rec);
+        // [THEN] Returns Action::None (stub default)
+        Assert.AreEqual(Action::None, Result, 'Page.RunModal(Integer, Table, Integer) must return Action::None');
+    end;
+
+    [Test]
+    procedure PageRunModal_IntTableJoker_ReturnsNone()
+    var
+        Rec: Record "P3A Row";
+        Result: Action;
+    begin
+        // [WHEN] Page.RunModal(Integer, Table, Joker) is called
+        Result := Src.RunModalIntTableJoker(Rec);
+        // [THEN] Returns Action::None (stub default)
+        Assert.AreEqual(Action::None, Result, 'Page.RunModal(Integer, Table, Joker) must return Action::None');
+    end;
+
+    [Test]
+    procedure PageRunModal_TextTableFieldRef_ReturnsNone()
+    var
+        Rec: Record "P3A Row";
+        Result: Action;
+    begin
+        // [WHEN] Page.RunModal(Text, Table, FieldRef) is called
+        Result := Src.RunModalTextTableFieldRef(Rec, 'P3A Card');
+        // [THEN] Returns Action::None (stub default)
+        Assert.AreEqual(Action::None, Result, 'Page.RunModal(Text, Table, FieldRef) must return Action::None');
+    end;
+
+    [Test]
+    procedure PageRunModal_TextTableInt_ReturnsNone()
+    var
+        Rec: Record "P3A Row";
+        Result: Action;
+    begin
+        // [WHEN] Page.RunModal(Text, Table, Integer) is called
+        Result := Src.RunModalTextTableInt(Rec, 'P3A Card');
+        // [THEN] Returns Action::None (stub default)
+        Assert.AreEqual(Action::None, Result, 'Page.RunModal(Text, Table, Integer) must return Action::None');
+    end;
+
+    [Test]
+    procedure PageRunModal_TextTableJoker_ReturnsNone()
+    var
+        Rec: Record "P3A Row";
+        Result: Action;
+    begin
+        // [WHEN] Page.RunModal(Text, Table, Joker) is called
+        Result := Src.RunModalTextTableJoker(Rec, 'P3A Card');
+        // [THEN] Returns Action::None (stub default)
+        Assert.AreEqual(Action::None, Result, 'Page.RunModal(Text, Table, Joker) must return Action::None');
+    end;
+}


### PR DESCRIPTION
Closes #1374

## Summary

All 10 three-argument overloads of `Page.Run` and `Page.RunModal` (Integer/Text page-ID × Table × Integer/Joker/FieldRef position) were listed as `status: gap` in `docs/coverage.yaml`, but investigation shows they already compile and execute correctly through the existing `NavForm.Run`/`NavForm.RunModal` rewriter paths:

- **`Page.Run` 3-arg** → statement-level rewriter strips to `EmptyStatement` (no-op) — the third position argument is included in the discarded call
- **`Page.RunModal` 3-arg** → expression-level rewriter returns `default(FormResult)` = `Action::None` — the third position argument is part of the matched `NavForm.RunModal` invocation

The position/focus field argument has no meaning in standalone mode (no real UI), so accepting and ignoring it is the correct behavior.

## Changes

- Added test suite `tests/bucket-2/100-page-run-3arg/` (IDs 309600–309601) with 10 tests covering all overload variants
- Updated `docs/coverage.yaml`: all 10 entries flipped from `gap` → `covered`