### PR TITLE
fix: implement Report.Execute/Run/RunModal Text-name overloads and RunRequestPage(Integer,Text) — closes #1377

### DIFF
--- a/AlRunner/Runtime/MockReportHandle.cs
+++ b/AlRunner/Runtime/MockReportHandle.cs
@@ -341,6 +341,21 @@ public class MockReportHandle
     }
 
     /// <summary>
+    /// Static Report.Run(reportName, requestPage, systemPrinter) — Text-name 3-argument overload.
+    /// BC emits this form when AL passes a report name string and no record argument.
+    /// Report-name lookup is not supported in standalone mode; call is a no-op.
+    /// </summary>
+    public static void StaticRun(string reportName, bool requestPage, bool systemPrinter) { }
+
+    /// <summary>
+    /// Static Report.Run(reportName, requestPage, systemPrinter, record) — Text-name 4-argument overload.
+    /// BC emits this form for <c>Report.Run(Report::"X", requestPage, systemPrinter, Rec)</c> when the
+    /// first argument is resolved to a string name at compile time.
+    /// Report-name lookup is not supported in standalone mode; call is a no-op.
+    /// </summary>
+    public static void StaticRun(string reportName, bool requestPage, bool systemPrinter, object record) { }
+
+    /// <summary>
     /// Static Report.RunModal(reportId) — redirected from NavReport.RunModal() by the rewriter.
     /// If a ReportHandler is registered, invoke it; otherwise create an instance and RunModal().
     /// </summary>
@@ -384,6 +399,21 @@ public class MockReportHandle
     }
 
     /// <summary>
+    /// Static Report.RunModal(reportName, requestWindow, systemPrinter) — Text-name 3-argument overload.
+    /// BC emits this form when AL passes a report name string and no record argument.
+    /// Report-name lookup is not supported in standalone mode; call is a no-op.
+    /// </summary>
+    public static void StaticRunModal(string reportName, bool requestWindow, bool systemPrinter) { }
+
+    /// <summary>
+    /// Static Report.RunModal(reportName, requestWindow, systemPrinter, record) — Text-name 4-argument overload.
+    /// BC emits this form for <c>Report.RunModal(Report::"X", requestWindow, systemPrinter, Rec)</c> when the
+    /// first argument is resolved to a string name at compile time.
+    /// Report-name lookup is not supported in standalone mode; call is a no-op.
+    /// </summary>
+    public static void StaticRunModal(string reportName, bool requestWindow, bool systemPrinter, object record) { }
+
+    /// <summary>
     /// AL assignment: <c>Rep1 := Rep2</c>.
     /// The BC compiler emits <c>Rep1.ALAssign(Rep2)</c> for report variable assignment.
     /// Copies the report ID, table-view filter, and internal report instance reference
@@ -420,6 +450,20 @@ public class MockReportHandle
 
     /// <summary>BC emits <c>MockReportHandle.StaticExecute(reportId, requestPage)</c> for <c>Report.Execute(N, requestPage)</c>.</summary>
     public static void StaticExecute(int reportId, string requestPage) { }
+
+    /// <summary>
+    /// BC emits <c>MockReportHandle.StaticExecute(reportId, requestPage, recordRef)</c> for
+    /// <c>Report.Execute(N, RequestPageXml, RecordRef)</c> — Integer-id 3-argument overload.
+    /// No-op in standalone mode (no rendering engine).
+    /// </summary>
+    public static void StaticExecute(int reportId, string requestPage, MockRecordRef recordRef) { }
+
+    /// <summary>
+    /// BC emits <c>MockReportHandle.StaticExecute(reportName, requestPage, recordRef)</c> for
+    /// <c>Report.Execute(ReportName, RequestPageXml, RecordRef)</c> — Text-name 3-argument overload.
+    /// Report-name lookup is not supported in standalone mode; call is a no-op.
+    /// </summary>
+    public static void StaticExecute(string reportName, string requestPage, MockRecordRef recordRef) { }
 
     public static void StaticPrint(int reportId) { }
 

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -6197,7 +6197,10 @@ Report.Execute (Integer, Text, RecordRef):
 Report.Execute (Text, Text, RecordRef):
   layer: runtime-api
   category: Report
-  status: gap
+  status: covered
+  tests:
+    - tests/bucket-1/309700-report-text-name-overloads
+  notes: MockReportHandle.StaticExecute(string, string, MockRecordRef) — no-op in standalone mode. Fixes #1377.
 
 Report.GetSubstituteReportId (Integer):
   layer: runtime-api
@@ -6237,7 +6240,10 @@ Report.Run (Integer, Boolean, Boolean, Table):
 Report.Run (Text, Boolean, Boolean, Table):
   layer: runtime-api
   category: Report
-  status: gap
+  status: covered
+  tests:
+    - tests/bucket-1/309700-report-text-name-overloads
+  notes: MockReportHandle.StaticRun(string, bool, bool) and StaticRun(string, bool, bool, object) — no-op in standalone mode. Fixes #1377.
 
 Report.RunModal (Integer, Boolean, Boolean, Table):
   layer: runtime-api
@@ -6255,12 +6261,19 @@ Report.RunModal (Integer, Boolean, Boolean, Table):
 Report.RunModal (Text, Boolean, Boolean, Table):
   layer: runtime-api
   category: Report
-  status: gap
+  status: covered
+  tests:
+    - tests/bucket-1/309700-report-text-name-overloads
+  notes: MockReportHandle.StaticRunModal(string, bool, bool) and StaticRunModal(string, bool, bool, object) — no-op in standalone mode. Fixes #1377.
 
 Report.RunRequestPage (Integer, Text):
   layer: runtime-api
   category: Report
-  status: gap
+  status: covered
+  tests:
+    - tests/bucket-1/309700-report-text-name-overloads
+    - tests/bucket-2/301-report-static-runrequestpage
+  notes: MockReportHandle.StaticRunRequestPage(int, string) — returns empty string in standalone mode. Fixes #1377.
 
 Report.SaveAs (Integer, Text, ReportFormat, OutStream, RecordRef):
   layer: runtime-api

--- a/tests/bucket-1/309700-report-text-name-overloads/src/ReportTextNameSrc.al
+++ b/tests/bucket-1/309700-report-text-name-overloads/src/ReportTextNameSrc.al
@@ -1,0 +1,24 @@
+/// Exercises the Text-name overloads of Report.Execute, Report.Run, Report.RunModal
+/// and the 2-argument Report.RunRequestPage(Integer, Text) — issue #1377.
+codeunit 309700 "RptTextName Src"
+{
+    procedure CallExecuteTextName(reportName: Text; requestPageXml: Text; var recRef: RecordRef)
+    begin
+        Report.Execute(reportName, requestPageXml, recRef);
+    end;
+
+    procedure CallRunTextName(reportName: Text; printDialog: Boolean; useRequestPage: Boolean; var rec: Record "RptTextName Table")
+    begin
+        Report.Run(reportName, printDialog, useRequestPage, rec);
+    end;
+
+    procedure CallRunModalTextName(reportName: Text; printDialog: Boolean; useRequestPage: Boolean; var rec: Record "RptTextName Table")
+    begin
+        Report.RunModal(reportName, printDialog, useRequestPage, rec);
+    end;
+
+    procedure CallRunRequestPage2Arg(reportId: Integer; requestParameters: Text): Text
+    begin
+        exit(Report.RunRequestPage(reportId, requestParameters));
+    end;
+}

--- a/tests/bucket-1/309700-report-text-name-overloads/src/ReportTextNameTable.al
+++ b/tests/bucket-1/309700-report-text-name-overloads/src/ReportTextNameTable.al
@@ -1,0 +1,21 @@
+/// Minimal table used as a record filter for Text-name Report overload tests.
+table 309700 "RptTextName Table"
+{
+    fields
+    {
+        field(1; "No."; Code[20]) { }
+        field(2; Amount; Decimal) { }
+    }
+    keys { key(PK; "No.") { Clustered = true; } }
+}
+
+/// Report that accepts RptTextName Table as a data item.
+report 309700 "RptTextName Report"
+{
+    dataset
+    {
+        dataitem(DataLine; "RptTextName Table")
+        {
+        }
+    }
+}

--- a/tests/bucket-1/309700-report-text-name-overloads/test/ReportTextNameTest.al
+++ b/tests/bucket-1/309700-report-text-name-overloads/test/ReportTextNameTest.al
@@ -1,0 +1,95 @@
+/// Tests for Text-name Report overloads and RunRequestPage 2-arg variant — issue #1377.
+codeunit 309701 "RptTextName Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    // ── Report.Execute(Text, Text, RecordRef) ─────────────────────────────
+
+    [Test]
+    procedure Report_Execute_TextName_IsNoOp()
+    var
+        Src: Codeunit "RptTextName Src";
+        RecRef: RecordRef;
+    begin
+        // [GIVEN] A report name (non-existent), request XML, and an unbound RecordRef
+        // [WHEN]  Report.Execute(reportName, requestPageXml, RecordRef) is called
+        // [THEN]  No error — overload is a no-op in standalone mode
+        Src.CallExecuteTextName('RptTextName Report', '<ReqPage />', RecRef);
+    end;
+
+    // ── Report.Run(Text, Boolean, Boolean, Table) ─────────────────────────
+
+    [Test]
+    procedure Report_Run_TextName_IsNoOp()
+    var
+        Src: Codeunit "RptTextName Src";
+        Rec: Record "RptTextName Table";
+    begin
+        // [GIVEN] A report name, request-page/printer flags, and an empty record
+        // [WHEN]  Report.Run(reportName, false, false, Rec) is called
+        // [THEN]  No error — overload is a no-op when report type is unknown
+        Src.CallRunTextName('RptTextName Report', false, false, Rec);
+    end;
+
+    [Test]
+    procedure Report_Run_TextName_WithData_IsNoOp()
+    var
+        Src: Codeunit "RptTextName Src";
+        Rec: Record "RptTextName Table";
+    begin
+        // [GIVEN] A record with data inserted
+        Rec.Init();
+        Rec."No." := 'TN-001';
+        Rec.Amount := 100;
+        Rec.Insert();
+
+        // [WHEN]  Report.Run(reportName, false, false, Rec) is called
+        // [THEN]  No error — overload completes without exception
+        Src.CallRunTextName('RptTextName Report', false, false, Rec);
+    end;
+
+    // ── Report.RunModal(Text, Boolean, Boolean, Table) ────────────────────
+
+    [Test]
+    procedure Report_RunModal_TextName_IsNoOp()
+    var
+        Src: Codeunit "RptTextName Src";
+        Rec: Record "RptTextName Table";
+    begin
+        // [GIVEN] A report name, request-page/printer flags, and an empty record
+        // [WHEN]  Report.RunModal(reportName, false, false, Rec) is called
+        // [THEN]  No error — overload is a no-op when report type is unknown
+        Src.CallRunModalTextName('RptTextName Report', false, false, Rec);
+    end;
+
+    // ── Report.RunRequestPage(Integer, Text) ─────────────────────────────
+
+    [Test]
+    procedure Report_RunRequestPage_IntText_ReturnsEmpty()
+    var
+        Src: Codeunit "RptTextName Src";
+        Result: Text;
+    begin
+        // [GIVEN] A report id and non-empty request parameters
+        // [WHEN]  Report.RunRequestPage(reportId, requestParameters) is called
+        // [THEN]  Returns empty string in standalone mode (no request-page UI)
+        Result := Src.CallRunRequestPage2Arg(99999, '<ReqParams />');
+        Assert.AreEqual('', Result, 'RunRequestPage(Integer,Text) must return empty string in standalone mode');
+    end;
+
+    [Test]
+    procedure Report_RunRequestPage_IntText_EmptyParams_ReturnsEmpty()
+    var
+        Src: Codeunit "RptTextName Src";
+        Result: Text;
+    begin
+        // [GIVEN] A report id and an empty request-parameters string
+        // [WHEN]  Report.RunRequestPage(reportId, '') is called
+        // [THEN]  Returns empty string in standalone mode
+        Result := Src.CallRunRequestPage2Arg(99999, '');
+        Assert.AreEqual('', Result, 'RunRequestPage(Integer,Text) with empty params must return empty string in standalone mode');
+    end;
+}


### PR DESCRIPTION
Closes #1377

## Summary

- Added `StaticExecute(string reportName, string requestPage, MockRecordRef recordRef)` — Text-name `Report.Execute(Text,Text,RecordRef)` overload (no-op in standalone mode)
- Added `StaticExecute(int reportId, string requestPage, MockRecordRef recordRef)` — Integer `Report.Execute(Integer,Text,RecordRef)` overload (no-op; previously only 1- and 2-arg forms existed)
- Added `StaticRun(string, bool, bool)` and `StaticRun(string, bool, bool, object)` — Text-name `Report.Run(Text,Boolean,Boolean,Table)` overloads
- Added `StaticRunModal(string, bool, bool)` and `StaticRunModal(string, bool, bool, object)` — Text-name `Report.RunModal(Text,Boolean,Boolean,Table)` overloads
- `StaticRunRequestPage(int, string)` already existed; coverage.yaml entry was not updated — corrected

## Test suite
New suite `tests/bucket-1/309700-report-text-name-overloads/` with 6 tests covering all 4 overloads (positive: no-error call + return-value assertion for `RunRequestPage`).

## docs/coverage.yaml
All 4 gap entries flipped from `status: gap` to `status: covered`.