### PR TITLE
fix: implement XmlAttributeCollection namespace-qualified overloads — closes #1376

### DIFF
--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -2498,6 +2498,97 @@ public void Unbind() { AlRunner.Runtime.EventSubscriberRegistry.Unbind(this); }
             }
         }
 
+        // XmlAttributeCollection namespace-qualified overloads.
+        // BC's NavXmlAttributeCollection uses LINQ-to-XML internally.  When the
+        // namespace URI contains ':' (e.g. "http://…") the NCL XML layer rejects
+        // it as a literal XML name fragment and throws NavNCLXmlException.
+        // Redirect the three failing overloads to AlCompat helpers that bypass NCL
+        // and operate directly on the underlying XElement.
+        //
+        // Discriminators (before visiting — receiver still un-visited):
+        //   ALGet   4 args: (DataError, string, string, ByRef<NavXmlAttribute>)
+        //   ALRemove 2 args: (string, string)   — no DataError first arg
+        //   ALSet   3 args: (string, string, string)
+        //
+        // ALGet 4-arg is unique to NavXmlAttributeCollection (record ALGet uses
+        // fewer args and ByRef<record> types).  ALRemove 2-string and ALSet 3-string
+        // are similarly distinct from other AL ALRemove/ALSet overloads.
+        if (node.Expression is MemberAccessExpressionSyntax xmlAttrMa)
+        {
+            var xmlAttrMethodName = xmlAttrMa.Name.Identifier.Text;
+            var args = node.ArgumentList.Arguments;
+
+            // ALGet(DataError, string, string, ByRef<NavXmlAttribute>) — 4-arg namespace Get
+            if (xmlAttrMethodName == "ALGet" &&
+                args.Count == 4 &&
+                args[0].Expression.ToString().StartsWith("DataError") &&
+                args[3].ToString().Contains("NavXmlAttribute"))
+            {
+                var receiverExpr = (ExpressionSyntax)Visit(xmlAttrMa.Expression)!;
+                var deExpr       = (ExpressionSyntax)Visit(args[0].Expression)!;
+                var nsExpr       = (ExpressionSyntax)Visit(args[1].Expression)!;
+                var nameExpr     = (ExpressionSyntax)Visit(args[2].Expression)!;
+                var refExpr      = (ExpressionSyntax)Visit(args[3].Expression)!;
+                return SyntaxFactory.InvocationExpression(
+                    SyntaxFactory.MemberAccessExpression(
+                        SyntaxKind.SimpleMemberAccessExpression,
+                        SyntaxFactory.IdentifierName("AlCompat"),
+                        SyntaxFactory.IdentifierName("XmlAttrCollGetByNs")),
+                    SyntaxFactory.ArgumentList(SyntaxFactory.SeparatedList(new[]
+                    {
+                        SyntaxFactory.Argument(receiverExpr),
+                        SyntaxFactory.Argument(deExpr),
+                        SyntaxFactory.Argument(nsExpr),
+                        SyntaxFactory.Argument(nameExpr),
+                        SyntaxFactory.Argument(refExpr)
+                    }))).WithTriviaFrom(node);
+            }
+
+            // ALRemove(string, string) — 2-arg namespace Remove (no DataError)
+            if (xmlAttrMethodName == "ALRemove" &&
+                args.Count == 2 &&
+                !args[0].Expression.ToString().StartsWith("DataError"))
+            {
+                var receiverExpr = (ExpressionSyntax)Visit(xmlAttrMa.Expression)!;
+                var nsExpr       = (ExpressionSyntax)Visit(args[0].Expression)!;
+                var nameExpr     = (ExpressionSyntax)Visit(args[1].Expression)!;
+                return SyntaxFactory.InvocationExpression(
+                    SyntaxFactory.MemberAccessExpression(
+                        SyntaxKind.SimpleMemberAccessExpression,
+                        SyntaxFactory.IdentifierName("AlCompat"),
+                        SyntaxFactory.IdentifierName("XmlAttrCollRemoveByNs")),
+                    SyntaxFactory.ArgumentList(SyntaxFactory.SeparatedList(new[]
+                    {
+                        SyntaxFactory.Argument(receiverExpr),
+                        SyntaxFactory.Argument(nsExpr),
+                        SyntaxFactory.Argument(nameExpr)
+                    }))).WithTriviaFrom(node);
+            }
+
+            // ALSet(string, string, string) — 3-arg namespace Set
+            if (xmlAttrMethodName == "ALSet" &&
+                args.Count == 3 &&
+                !args[0].Expression.ToString().StartsWith("DataError"))
+            {
+                var receiverExpr = (ExpressionSyntax)Visit(xmlAttrMa.Expression)!;
+                var nsExpr       = (ExpressionSyntax)Visit(args[0].Expression)!;
+                var nameExpr     = (ExpressionSyntax)Visit(args[1].Expression)!;
+                var valExpr      = (ExpressionSyntax)Visit(args[2].Expression)!;
+                return SyntaxFactory.InvocationExpression(
+                    SyntaxFactory.MemberAccessExpression(
+                        SyntaxKind.SimpleMemberAccessExpression,
+                        SyntaxFactory.IdentifierName("AlCompat"),
+                        SyntaxFactory.IdentifierName("XmlAttrCollSetByNs")),
+                    SyntaxFactory.ArgumentList(SyntaxFactory.SeparatedList(new[]
+                    {
+                        SyntaxFactory.Argument(receiverExpr),
+                        SyntaxFactory.Argument(nsExpr),
+                        SyntaxFactory.Argument(nameExpr),
+                        SyntaxFactory.Argument(valExpr)
+                    }))).WithTriviaFrom(node);
+            }
+        }
+
         // Now recurse into children first
         var visited = (InvocationExpressionSyntax)base.VisitInvocationExpression(node)!;
 

--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -2507,18 +2507,23 @@ public void Unbind() { AlRunner.Runtime.EventSubscriberRegistry.Unbind(this); }
         //
         // Discriminators (before visiting — receiver still un-visited):
         //   ALGet   4 args: (DataError, string, string, ByRef<NavXmlAttribute>)
-        //   ALRemove 2 args: (string, string)   — no DataError first arg
-        //   ALSet   3 args: (string, string, string)
+        //   ALRemove 2 args: (string, string) where receiver is an InvocationExpression
+        //   ALSet   3 args: (string, string, string) where receiver is an InvocationExpression
         //
         // ALGet 4-arg is unique to NavXmlAttributeCollection (record ALGet uses
-        // fewer args and ByRef<record> types).  ALRemove 2-string and ALSet 3-string
-        // are similarly distinct from other AL ALRemove/ALSet overloads.
+        // fewer args and ByRef<record> types).
+        //
+        // ALRemove 2-arg and ALSet 3-arg: restrict to receivers that are invocations
+        // (i.e. result of a method call like ALAttributes()) rather than static type
+        // references (e.g. NavTextExtensions.ALRemove(lbl, idx) from Label.Remove in AL,
+        // which is also a 2-arg non-DataError call on a plain type identifier).
         if (node.Expression is MemberAccessExpressionSyntax xmlAttrMa)
         {
             var xmlAttrMethodName = xmlAttrMa.Name.Identifier.Text;
             var args = node.ArgumentList.Arguments;
 
-            // ALGet(DataError, string, string, ByRef<NavXmlAttribute>) — 4-arg namespace Get
+            // ALGet(DataError, string, string, ByRef<NavXmlAttribute>) — 4-arg namespace Get.
+            // The ByRef<NavXmlAttribute> arg makes this unique to NavXmlAttributeCollection.
             if (xmlAttrMethodName == "ALGet" &&
                 args.Count == 4 &&
                 args[0].Expression.ToString().StartsWith("DataError") &&
@@ -2544,10 +2549,14 @@ public void Unbind() { AlRunner.Runtime.EventSubscriberRegistry.Unbind(this); }
                     }))).WithTriviaFrom(node);
             }
 
-            // ALRemove(string, string) — 2-arg namespace Remove (no DataError)
+            // ALRemove(string, string) — 2-arg namespace Remove.
+            // Guard: receiver must be an invocation (e.g. el.ALAttributes()), not a
+            // static type reference like NavTextExtensions (which also has a 2-arg
+            // ALRemove(NavText, int) that BC emits for Label.Remove(index)).
             if (xmlAttrMethodName == "ALRemove" &&
                 args.Count == 2 &&
-                !args[0].Expression.ToString().StartsWith("DataError"))
+                !args[0].Expression.ToString().StartsWith("DataError") &&
+                xmlAttrMa.Expression is InvocationExpressionSyntax)
             {
                 var receiverExpr = (ExpressionSyntax)Visit(xmlAttrMa.Expression)!;
                 var nsExpr       = (ExpressionSyntax)Visit(args[0].Expression)!;
@@ -2565,10 +2574,12 @@ public void Unbind() { AlRunner.Runtime.EventSubscriberRegistry.Unbind(this); }
                     }))).WithTriviaFrom(node);
             }
 
-            // ALSet(string, string, string) — 3-arg namespace Set
+            // ALSet(string, string, string) — 3-arg namespace Set.
+            // Guard: receiver must be an invocation (same reason as ALRemove above).
             if (xmlAttrMethodName == "ALSet" &&
                 args.Count == 3 &&
-                !args[0].Expression.ToString().StartsWith("DataError"))
+                !args[0].Expression.ToString().StartsWith("DataError") &&
+                xmlAttrMa.Expression is InvocationExpressionSyntax)
             {
                 var receiverExpr = (ExpressionSyntax)Visit(xmlAttrMa.Expression)!;
                 var nsExpr       = (ExpressionSyntax)Visit(args[0].Expression)!;

--- a/AlRunner/Runtime/AlScope.cs
+++ b/AlRunner/Runtime/AlScope.cs
@@ -3304,6 +3304,92 @@ public static class AlCompat
         }
     }
 
+    // -----------------------------------------------------------------------
+    // XmlAttributeCollection namespace-qualified overloads.
+    //
+    // BC's NavXmlAttributeCollection uses LINQ-to-XML (XElement) internally.
+    // When the namespace URI contains ':' (e.g. 'http://...'), BC's NCL XML
+    // layer interprets it as an XML name fragment and throws
+    // NavNCLXmlException("':' character cannot be included in a name").
+    //
+    // These helpers bypass the NCL layer and operate directly on the XElement
+    // via reflection, using System.Xml.Linq.XName for correct namespace lookup.
+    //
+    // BC compiler mapping (AL → emitted C#):
+    //   Get(ns, name, var attr)       → ALGet(errorLevel, ns, name, ByRef)   [4 args]
+    //   Remove(ns, name)              → ALRemove(ns, name)                   [2 strings]
+    //   Set(ns, name, value)          → ALSet(ns, name, value)               [3 strings]
+    //
+    // Note: Get(Text, XmlAttribute) and Remove(XmlAttribute) work correctly
+    // via BC native and need no override.
+    // -----------------------------------------------------------------------
+
+    // Reflection accessors — initialised once per AppDomain.
+    private static readonly System.Reflection.FieldInfo? s_xmlAttrCollElementField =
+        typeof(NavXmlAttributeCollection).GetField("element",
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+
+    private static readonly System.Reflection.ConstructorInfo? s_navXmlAttributeCtor =
+        typeof(NavXmlAttribute).GetConstructor(
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic,
+            null,
+            new[] { typeof(System.Xml.Linq.XAttribute) },
+            null);
+
+    /// <summary>
+    /// Get(namespaceURI, localName, var attr) — namespace-qualified lookup.
+    /// BC emits: <c>ALGet(errorLevel, namespaceURI, localName, ByRef)</c>.
+    /// Uses LINQ-to-XML to look up <c>{namespaceURI}localName</c> on the element.
+    /// </summary>
+    public static bool XmlAttrCollGetByNs(
+        NavXmlAttributeCollection coll,
+        DataError errorLevel,
+        string namespaceURI,
+        string localName,
+        ByRef<NavXmlAttribute> result)
+    {
+        var el = s_xmlAttrCollElementField?.GetValue(coll) as System.Xml.Linq.XElement;
+        if (el == null) return false;
+
+        var xattr = el.Attribute(System.Xml.Linq.XName.Get(localName, namespaceURI));
+        if (xattr == null) return false;
+
+        var navAttr = s_navXmlAttributeCtor?.Invoke(new object[] { xattr }) as NavXmlAttribute;
+        if (navAttr == null) return false;
+
+        result.Value = navAttr;
+        return true;
+    }
+
+    /// <summary>
+    /// Remove(namespaceURI, localName) — namespace-qualified remove.
+    /// BC emits: <c>ALRemove(namespaceURI, localName)</c>.
+    /// Uses LINQ-to-XML to locate and remove <c>{namespaceURI}localName</c>.
+    /// </summary>
+    public static void XmlAttrCollRemoveByNs(
+        NavXmlAttributeCollection coll,
+        string namespaceURI,
+        string localName)
+    {
+        var el = s_xmlAttrCollElementField?.GetValue(coll) as System.Xml.Linq.XElement;
+        el?.Attribute(System.Xml.Linq.XName.Get(localName, namespaceURI))?.Remove();
+    }
+
+    /// <summary>
+    /// Set(namespaceURI, localName, value) — namespace-qualified set/overwrite.
+    /// BC emits: <c>ALSet(namespaceURI, localName, value)</c>.
+    /// Uses LINQ-to-XML <c>SetAttributeValue</c> to create or replace the attribute.
+    /// </summary>
+    public static void XmlAttrCollSetByNs(
+        NavXmlAttributeCollection coll,
+        string namespaceURI,
+        string localName,
+        string value)
+    {
+        var el = s_xmlAttrCollElementField?.GetValue(coll) as System.Xml.Linq.XElement;
+        el?.SetAttributeValue(System.Xml.Linq.XName.Get(localName, namespaceURI), value);
+    }
+
 }
 
 /// <summary>

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -10459,17 +10459,26 @@ XmlAttributeCollection.Get (Integer, XmlAttribute):
 XmlAttributeCollection.Get (Text, Text, XmlAttribute):
   layer: runtime-api
   category: XmlAttributeCollection
-  status: gap
+  status: covered
+  tests:
+    - tests/bucket-1/310-xmlattrcollection-ns
+  notes: AlCompat.XmlAttrCollGetByNs — intercepts ALGet(DataError,ns,name,ByRef) to bypass NCL ':' validation; uses LINQ-to-XML XName.Get for lookup. Closes #1376.
 
 XmlAttributeCollection.Get (Text, XmlAttribute):
   layer: runtime-api
   category: XmlAttributeCollection
-  status: gap
+  status: covered
+  tests:
+    - tests/bucket-1/310-xmlattrcollection-ns
+  notes: BC native NavXmlAttributeCollection.ALGet(DataError, string, ByRef) — works without NCL issue. Proven in tests/bucket-1/310-xmlattrcollection-ns.
 
 XmlAttributeCollection.Remove (Text, Text):
   layer: runtime-api
   category: XmlAttributeCollection
-  status: gap
+  status: covered
+  tests:
+    - tests/bucket-1/310-xmlattrcollection-ns
+  notes: AlCompat.XmlAttrCollRemoveByNs — intercepts ALRemove(ns, name) to bypass NCL ':' validation; uses LINQ-to-XML XAttribute.Remove(). Closes #1376.
 
 XmlAttributeCollection.Remove (Text):
   layer: runtime-api
@@ -10480,7 +10489,10 @@ XmlAttributeCollection.Remove (Text):
 XmlAttributeCollection.Remove (XmlAttribute):
   layer: runtime-api
   category: XmlAttributeCollection
-  status: gap
+  status: covered
+  tests:
+    - tests/bucket-1/310-xmlattrcollection-ns
+  notes: BC native NavXmlAttributeCollection.ALRemove(NavXmlAttribute) — works correctly. Proven in tests/bucket-1/310-xmlattrcollection-ns.
 
 XmlAttributeCollection.RemoveAll ():
   layer: runtime-api
@@ -10491,7 +10503,10 @@ XmlAttributeCollection.RemoveAll ():
 XmlAttributeCollection.Set (Text, Text, Text):
   layer: runtime-api
   category: XmlAttributeCollection
-  status: gap
+  status: covered
+  tests:
+    - tests/bucket-1/310-xmlattrcollection-ns
+  notes: AlCompat.XmlAttrCollSetByNs — intercepts ALSet(ns, name, value) to bypass NCL ':' validation; uses LINQ-to-XML SetAttributeValue(XName.Get). Closes #1376.
 
 XmlAttributeCollection.Set (Text, Text):
   layer: runtime-api

--- a/tests/bucket-1/310-xmlattrcollection-ns/al-runner.json
+++ b/tests/bucket-1/310-xmlattrcollection-ns/al-runner.json
@@ -1,0 +1,4 @@
+{
+  "description": "XmlAttributeCollection namespace-qualified overloads — Get(Text,XmlAttribute), Get(Text,Text,XmlAttribute), Remove(XmlAttribute), Remove(Text,Text), Set(Text,Text,Text)",
+  "issue": "https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/1376"
+}

--- a/tests/bucket-1/310-xmlattrcollection-ns/src/XmlAttrCollNsSrc.al
+++ b/tests/bucket-1/310-xmlattrcollection-ns/src/XmlAttrCollNsSrc.al
@@ -1,0 +1,177 @@
+/// Helper codeunit exercising namespace-qualified XmlAttributeCollection overloads:
+///   Get(Text, XmlAttribute)              — Get by local name (text overload)
+///   Get(Text, Text, XmlAttribute)        — Get by namespaceURI + localName
+///   Remove(XmlAttribute)                 — Remove by attribute reference
+///   Remove(Text, Text)                   — Remove by namespaceURI + localName
+///   Set(Text, Text, Text)                — Set namespaceURI + localName + value
+/// All are BC-native methods on NavXmlAttributeCollection. Issue #1376.
+codeunit 310000 "XACNS Src"
+{
+    // ── Get(localName: Text, var attr: XmlAttribute) ──────────────────────────
+    // Text overload — retrieve by attribute name string.
+
+    /// Build element with attribute named localName; retrieve by text name.
+    procedure Get_ByLocalName_Value(localName: Text): Text
+    var
+        el: XmlElement;
+        attr: XmlAttribute;
+    begin
+        el := XmlElement.Create('root');
+        el.SetAttribute(localName, 'hello');
+        if el.Attributes().Get(localName, attr) then
+            exit(attr.Value);
+        exit('');
+    end;
+
+    /// Returns false when the named attribute does not exist (text overload).
+    procedure Get_ByLocalName_Missing(): Boolean
+    var
+        el: XmlElement;
+        attr: XmlAttribute;
+    begin
+        el := XmlElement.Create('root');
+        el.SetAttribute('other', '1');
+        exit(el.Attributes().Get('missing', attr));
+    end;
+
+    /// Distinct values for distinct attribute names — proves Get is name-sensitive.
+    procedure Get_ByLocalName_TwoAttrs_First(): Text
+    var
+        el: XmlElement;
+        attr: XmlAttribute;
+    begin
+        el := XmlElement.Create('root');
+        el.SetAttribute('a', 'one');
+        el.SetAttribute('b', 'two');
+        if el.Attributes().Get('a', attr) then
+            exit(attr.Value);
+        exit('');
+    end;
+
+    procedure Get_ByLocalName_TwoAttrs_Second(): Text
+    var
+        el: XmlElement;
+        attr: XmlAttribute;
+    begin
+        el := XmlElement.Create('root');
+        el.SetAttribute('a', 'one');
+        el.SetAttribute('b', 'two');
+        if el.Attributes().Get('b', attr) then
+            exit(attr.Value);
+        exit('');
+    end;
+
+    // ── Get(namespaceURI: Text, localName: Text, var attr: XmlAttribute) ──────
+    // BC maps this to NavXmlAttributeCollection.ALGet(errorLevel, localName, namespaceUri, result).
+
+    /// Add a namespace-qualified attribute via SetAttribute(name, ns, value),
+    /// then retrieve it using Get(namespaceURI, localName).
+    procedure Get_ByNamespace_Value(namespaceURI: Text; localName: Text): Text
+    var
+        el: XmlElement;
+        attr: XmlAttribute;
+    begin
+        el := XmlElement.Create('root');
+        // XmlElement.SetAttribute(Text, Text, Text) = ALSetAttribute(localName, ns, value)
+        el.SetAttribute(localName, namespaceURI, 'nsval');
+        if el.Attributes().Get(namespaceURI, localName, attr) then
+            exit(attr.Value);
+        exit('');
+    end;
+
+    /// Returns false when no attribute with that namespace exists.
+    procedure Get_ByNamespace_Missing(): Boolean
+    var
+        el: XmlElement;
+        attr: XmlAttribute;
+    begin
+        el := XmlElement.Create('root');
+        exit(el.Attributes().Get('http://missing', 'x', attr));
+    end;
+
+    // ── Remove(attr: XmlAttribute) ────────────────────────────────────────────
+
+    /// Add two attributes; remove first by reference; remaining count must be 1.
+    procedure Remove_ByRef_CountAfter(): Integer
+    var
+        el: XmlElement;
+        a1: XmlAttribute;
+        a2: XmlAttribute;
+    begin
+        el := XmlElement.Create('root');
+        a1 := XmlAttribute.Create('color', 'blue');
+        a2 := XmlAttribute.Create('size', '42');
+        el.Add(a1);
+        el.Add(a2);
+        el.Attributes().Remove(a1);
+        exit(el.Attributes().Count());
+    end;
+
+    /// After Remove(attr), Get(name) returns false.
+    procedure Remove_ByRef_GetAfterRemove(): Boolean
+    var
+        el: XmlElement;
+        attr: XmlAttribute;
+        dummy: XmlAttribute;
+    begin
+        el := XmlElement.Create('root');
+        attr := XmlAttribute.Create('id', '7');
+        el.Add(attr);
+        el.Attributes().Remove(attr);
+        exit(el.Attributes().Get('id', dummy));
+    end;
+
+    // ── Remove(namespaceURI: Text, localName: Text) ───────────────────────────
+
+    /// Add namespace-qualified attribute; remove by NS + local name; count = 0.
+    procedure Remove_ByNs_Count(): Integer
+    var
+        el: XmlElement;
+    begin
+        el := XmlElement.Create('root');
+        el.SetAttribute('kind', 'http://ns', 'v');
+        el.Attributes().Remove('http://ns', 'kind');
+        exit(el.Attributes().Count());
+    end;
+
+    /// After Remove(ns, name), Get(ns, name) returns false.
+    procedure Remove_ByNs_GetAfterRemove(): Boolean
+    var
+        el: XmlElement;
+        attr: XmlAttribute;
+    begin
+        el := XmlElement.Create('root');
+        el.SetAttribute('kind', 'http://ns', 'v');
+        el.Attributes().Remove('http://ns', 'kind');
+        exit(el.Attributes().Get('http://ns', 'kind', attr));
+    end;
+
+    // ── Set(namespaceURI: Text, localName: Text, value: Text) ─────────────────
+
+    /// Set a namespace-qualified attribute; retrieve it via Get(ns, name).
+    procedure Set_ByNs_GetValue(namespaceURI: Text; localName: Text; value: Text): Text
+    var
+        el: XmlElement;
+        attr: XmlAttribute;
+    begin
+        el := XmlElement.Create('root');
+        el.Attributes().Set(namespaceURI, localName, value);
+        if el.Attributes().Get(namespaceURI, localName, attr) then
+            exit(attr.Value);
+        exit('');
+    end;
+
+    /// Set overwrites an existing namespace-qualified attribute.
+    procedure Set_ByNs_Overwrite(): Text
+    var
+        el: XmlElement;
+        attr: XmlAttribute;
+    begin
+        el := XmlElement.Create('root');
+        el.SetAttribute('color', 'http://ns', 'old');
+        el.Attributes().Set('http://ns', 'color', 'new');
+        if el.Attributes().Get('http://ns', 'color', attr) then
+            exit(attr.Value);
+        exit('');
+    end;
+}

--- a/tests/bucket-1/310-xmlattrcollection-ns/test/XmlAttrCollNsTest.al
+++ b/tests/bucket-1/310-xmlattrcollection-ns/test/XmlAttrCollNsTest.al
@@ -1,0 +1,129 @@
+/// Tests for namespace-qualified XmlAttributeCollection overloads (issue #1376):
+///   Get(Text, XmlAttribute), Get(Text, Text, XmlAttribute),
+///   Remove(XmlAttribute), Remove(Text, Text), Set(Text, Text, Text).
+codeunit 310001 "XACNS Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "XACNS Src";
+
+    // ── Get(Text, XmlAttribute) ───────────────────────────────────────────────
+
+    [Test]
+    procedure Get_ByLocalName_ReturnsValue()
+    begin
+        Assert.AreEqual('hello', Src.Get_ByLocalName_Value('id'),
+            'Get(localName, attr) must return the attribute value');
+    end;
+
+    [Test]
+    procedure Get_ByLocalName_Missing_ReturnsFalse()
+    begin
+        Assert.IsFalse(Src.Get_ByLocalName_Missing(),
+            'Get(localName, attr) on a missing attribute must return false');
+    end;
+
+    [Test]
+    procedure Get_ByLocalName_IsNameSensitive()
+    begin
+        // Negative trap: attributes a='one' and b='two' must return different values,
+        // proving that Get dispatches on the actual name, not a constant.
+        Assert.AreNotEqual(
+            Src.Get_ByLocalName_TwoAttrs_First(),
+            Src.Get_ByLocalName_TwoAttrs_Second(),
+            'Get must return different values for different attribute names');
+    end;
+
+    [Test]
+    procedure Get_ByLocalName_TwoAttrs_FirstValue()
+    begin
+        Assert.AreEqual('one', Src.Get_ByLocalName_TwoAttrs_First(),
+            'Get(a) must return the value for attribute a');
+    end;
+
+    [Test]
+    procedure Get_ByLocalName_TwoAttrs_SecondValue()
+    begin
+        Assert.AreEqual('two', Src.Get_ByLocalName_TwoAttrs_Second(),
+            'Get(b) must return the value for attribute b');
+    end;
+
+    // ── Get(Text, Text, XmlAttribute) ─────────────────────────────────────────
+
+    [Test]
+    procedure Get_ByNamespace_ReturnsValue()
+    begin
+        Assert.AreEqual('nsval',
+            Src.Get_ByNamespace_Value('http://example.com', 'color'),
+            'Get(namespaceURI, localName, attr) must return the stored attribute value');
+    end;
+
+    [Test]
+    procedure Get_ByNamespace_Missing_ReturnsFalse()
+    begin
+        Assert.IsFalse(Src.Get_ByNamespace_Missing(),
+            'Get(ns, name) with no matching attribute must return false');
+    end;
+
+    // ── Remove(XmlAttribute) ─────────────────────────────────────────────────
+
+    [Test]
+    procedure Remove_ByRef_LeavesOtherAttributes()
+    begin
+        // Two attributes added; one removed by reference; one must remain.
+        Assert.AreEqual(1, Src.Remove_ByRef_CountAfter(),
+            'Remove(attr) must remove exactly the referenced attribute');
+    end;
+
+    [Test]
+    procedure Remove_ByRef_GetReturnsFalse()
+    begin
+        Assert.IsFalse(Src.Remove_ByRef_GetAfterRemove(),
+            'After Remove(attr), Get(name) must return false');
+    end;
+
+    // ── Remove(Text, Text) ────────────────────────────────────────────────────
+
+    [Test]
+    procedure Remove_ByNs_ClearsAttribute()
+    begin
+        Assert.AreEqual(0, Src.Remove_ByNs_Count(),
+            'Remove(ns, name) must delete the namespace-qualified attribute');
+    end;
+
+    [Test]
+    procedure Remove_ByNs_GetReturnsFalse()
+    begin
+        Assert.IsFalse(Src.Remove_ByNs_GetAfterRemove(),
+            'After Remove(ns, name), Get(ns, name) must return false');
+    end;
+
+    // ── Set(Text, Text, Text) ─────────────────────────────────────────────────
+
+    [Test]
+    procedure Set_ByNs_StoresValue()
+    begin
+        Assert.AreEqual('green',
+            Src.Set_ByNs_GetValue('http://example.com', 'color', 'green'),
+            'Set(ns, name, value) must make the value retrievable via Get(ns, name)');
+    end;
+
+    [Test]
+    procedure Set_ByNs_DifferentValues_DifferentResults()
+    begin
+        // Negative trap: Set stores the actual value, not a constant.
+        Assert.AreNotEqual(
+            Src.Set_ByNs_GetValue('http://example.com', 'color', 'green'),
+            Src.Set_ByNs_GetValue('http://example.com', 'color', 'red'),
+            'Set must store the supplied value, not a constant');
+    end;
+
+    [Test]
+    procedure Set_ByNs_Overwrites_ExistingValue()
+    begin
+        Assert.AreEqual('new', Src.Set_ByNs_Overwrite(),
+            'Set(ns, name, value) must overwrite an existing namespace-qualified attribute');
+    end;
+}


### PR DESCRIPTION
Closes #1376

## Problem

BC's `NavXmlAttributeCollection` uses LINQ-to-XML (`XElement`) internally. When the namespace URI contains `':'` (e.g. `'http://...'`), the NCL XML layer interprets it as an XML name fragment and throws `NavNCLXmlException("':' character cannot be included in a name")`. The three affected overloads are:

- `Get(namespaceURI, localName, var attr)` — 4-arg namespace Get
- `Remove(namespaceURI, localName)` — 2-arg namespace Remove
- `Set(namespaceURI, localName, value)` — 3-arg namespace Set

`Get(Text, XmlAttribute)` and `Remove(XmlAttribute)` work correctly via BC native.

## Solution

Add three static helpers in `AlCompat` that bypass the NCL layer and use `System.Xml.Linq.XName.Get(localName, namespaceURI)` to correctly address namespace-qualified attributes on the underlying `XElement`:

- `XmlAttrCollGetByNs` — retrieves `{ns}name` via reflection on the private `element` field
- `XmlAttrCollRemoveByNs` — calls `XAttribute.Remove()` on the found attribute
- `XmlAttrCollSetByNs` — calls `XElement.SetAttributeValue(XName.Get(...))`

Add RoslynRewriter intercept rules to redirect the three failing BC-emitted calls to these helpers. The discriminators are specific enough to avoid false matches with other AL types.

## Tests

New suite `tests/bucket-1/310-xmlattrcollection-ns` (IDs 310000–310001) — 14 tests, all pass:

- `Get_ByLocalName_*` (5 tests) — text-overload Get, including positive + negative + name-sensitivity trap
- `Get_ByNamespace_*` (2 tests) — namespace-qualified Get, positive + negative
- `Remove_ByRef_*` (2 tests) — Remove(XmlAttribute) already works, now proven
- `Remove_ByNs_*` (2 tests) — namespace Remove, positive + Get-after-remove
- `Set_ByNs_*` (3 tests) — namespace Set, positive + value-sensitivity trap + overwrite