### PR TITLE
fix: implement miscellaneous single-method gaps — closes #1382

### DIFF
--- a/AlRunner/Runtime/MockCodeunitHandle.cs
+++ b/AlRunner/Runtime/MockCodeunitHandle.cs
@@ -454,6 +454,28 @@ public class MockCodeunitHandle
         RunCodeunitCore(codeunitId, null);
     }
 
+    /// <summary>
+    /// Codeunit.Run(Text, Table) — run a codeunit by name with an optional record parameter.
+    /// BC lowers <c>Codeunit.Run(Text, Rec)</c> to
+    /// <c>NavCodeunit.RunCodeunit(DataError, NavText codeunitName, MockRecordHandle)</c>.
+    /// The rewriter already maps <c>NavCodeunit.RunCodeunit</c> to <c>MockCodeunitHandle.RunCodeunit</c>,
+    /// so this overload is reached when the second argument is a NavText name rather than an integer ID.
+    /// Resolves the name to an ID via <see cref="CodeunitNameRegistry"/>.
+    /// </summary>
+    public static bool RunCodeunit(DataError errorLevel, NavText codeunitName, MockRecordHandle? record = null)
+        => RunCodeunitByName(errorLevel, codeunitName.ToString(), record);
+
+    public static bool RunCodeunit(DataError errorLevel, string codeunitName, MockRecordHandle? record = null)
+        => RunCodeunitByName(errorLevel, codeunitName, record);
+
+    private static bool RunCodeunitByName(DataError errorLevel, string name, MockRecordHandle? record)
+    {
+        var id = CodeunitNameRegistry.GetIdByName(name);
+        if (id == null)
+            throw new InvalidOperationException($"Codeunit.Run: codeunit '{name}' not found in registry.");
+        return RunCodeunit(errorLevel, id.Value, record);
+    }
+
     private static void RunCodeunitCore(int codeunitId, MockRecordHandle? record = null)
     {
         var handle = new MockCodeunitHandle(codeunitId);

--- a/AlRunner/Runtime/MockDataTransfer.cs
+++ b/AlRunner/Runtime/MockDataTransfer.cs
@@ -55,6 +55,21 @@ public class MockDataTransfer
         // No-op
     }
 
+    /// <summary>
+    /// AddDestinationFilter(Integer, Text, Joker) — 3-argument destination filter.
+    /// BC lowers the 3rd argument (the filter value, which is a "Joker"/any-type in AL)
+    /// to <c>object</c> in C#. No-op in standalone mode.
+    /// </summary>
+    public void ALAddDestinationFilter(int fieldNo, string filterExpression, object? value)
+    {
+        // No-op: destination filtering is a DataTransfer bulk-data feature not supported standalone.
+    }
+
+    public void ALAddDestinationFilter(int fieldNo, NavText filterExpression, object? value)
+    {
+        // No-op
+    }
+
     /// <summary>Copy field values from source to target. No-op in standalone mode.</summary>
     public void ALCopyFields()
     {

--- a/AlRunner/Runtime/MockMedia.cs
+++ b/AlRunner/Runtime/MockMedia.cs
@@ -102,6 +102,35 @@ public class MockMedia : NavValue
         return _id;
     }
 
+    /// <summary>
+    /// BC emits <c>ALImport(errorLevel, stream, fileName, mimeType, description)</c> for
+    /// <c>Media.ImportStream(InStream, Text, Text, Text)</c> — the 4-arg AL form.
+    /// Sets HasValue to true and returns the stable media GUID.
+    /// </summary>
+    public Guid ALImport(DataError errorLevel, MockInStream stream, NavText fileName, NavText mimeType, NavText description)
+    {
+        _hasValue = true;
+        return _id;
+    }
+
+    public Guid ALImport(DataError errorLevel, MockInStream stream, string fileName, string mimeType, string description)
+    {
+        _hasValue = true;
+        return _id;
+    }
+
+    public Guid ALImport(DataError errorLevel, MockInStream stream, NavText fileName, NavText mimeType, string description)
+    {
+        _hasValue = true;
+        return _id;
+    }
+
+    public Guid ALImport(DataError errorLevel, MockInStream stream, string fileName, string mimeType, NavText description)
+    {
+        _hasValue = true;
+        return _id;
+    }
+
     // ── ALExport (BC-emitted for Media.ExportFile and Media.ExportStream) ────────
 
     /// <summary>

--- a/AlRunner/Runtime/MockRecordRef.cs
+++ b/AlRunner/Runtime/MockRecordRef.cs
@@ -608,7 +608,32 @@ public class MockRecordRef
 
     // -- FieldExists --
     public bool ALFieldExists(int fieldNo) => _handle?.HasField(fieldNo) ?? false;
-    public bool ALFieldExists(string fieldName) => false;
+
+    /// <summary>
+    /// ALFieldExists(string) — checks whether a field with the given name exists on the table.
+    /// Looks up the field ID in the <see cref="TableFieldRegistry"/> by name; returns true
+    /// when the field is registered for this table, false otherwise.
+    /// </summary>
+    public bool ALFieldExists(string fieldName)
+    {
+        if (Number == 0 || string.IsNullOrEmpty(fieldName)) return false;
+        return TableFieldRegistry.GetFieldId(Number, fieldName).HasValue;
+    }
+
+    /// <summary>
+    /// ALFullyQualifiedName — returns the fully qualified name of the table in the format
+    /// "&lt;CompanyName&gt;$&lt;TableName&gt;" (e.g. "CRONUS$Customer").
+    /// Delegates to the underlying handle when open, otherwise builds from registry data.
+    /// </summary>
+    public string ALFullyQualifiedName
+    {
+        get
+        {
+            if (_handle != null) return _handle.ALFullyQualifiedName;
+            var tableName = TableFieldRegistry.GetTableName(Number) ?? $"Table{Number}";
+            return $"{MockSession.GetCompanyName()}${tableName}";
+        }
+    }
 
     // -- RecordLevelLocking --
     /// <summary>Standalone: always true — no SQL table-level locking to worry about.</summary>

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -1372,7 +1372,10 @@ Codeunit.Run (Integer, Table):
 Codeunit.Run (Text, Table):
   layer: runtime-api
   category: Codeunit
-  status: gap
+  status: covered
+  tests:
+    - tests/bucket-2/310400-misc-single-method-gaps
+  notes: MockCodeunitHandle.RunCodeunit(DataError, NavText/string, MockRecordHandle) overload resolves codeunit name via CodeunitNameRegistry; closes #1382
 
 # ── CodeunitInstance ────────────────────────────────────────────
 
@@ -1457,7 +1460,10 @@ DataTransfer.AddConstantValue (Joker, Integer):
 DataTransfer.AddDestinationFilter (Integer, Text, Joker):
   layer: runtime-api
   category: DataTransfer
-  status: gap
+  status: covered
+  tests:
+    - tests/bucket-2/310400-misc-single-method-gaps
+  notes: MockDataTransfer.ALAddDestinationFilter(int, string/NavText, object?) no-op overload; closes #1382
 
 DataTransfer.AddFieldValue (Integer, Integer):
   layer: runtime-api
@@ -1633,7 +1639,10 @@ Database.SelectLatestVersion ():
 Database.SelectLatestVersion (Integer):
   layer: runtime-api
   category: Database
-  status: gap
+  status: covered
+  tests:
+    - tests/bucket-2/310400-misc-single-method-gaps
+  notes: ALSelectLatestVersion is already in StripEntireCallMethods in RoslynRewriter — the call is stripped as a no-op regardless of argument count; closes #1382
 
 Database.SerialNumber ():
   layer: runtime-api
@@ -5058,7 +5067,10 @@ Media.ImportFile (Text, Text, Text):
 Media.ImportStream (InStream, Text, Text, Text):
   layer: runtime-api
   category: Media
-  status: gap
+  status: covered
+  tests:
+    - tests/bucket-2/310400-misc-single-method-gaps
+  notes: BC emits ALImport(DataError, stream, fileName, mimeType, description) for the 4-arg AL form; 5-arg overloads added to MockMedia; closes #1382
 
 Media.ImportStream (InStream, Text, Text):
   layer: runtime-api
@@ -6079,7 +6091,10 @@ RecordRef.FieldExist (Integer):
 RecordRef.FieldExist (Text):
   layer: runtime-api
   category: RecordRef
-  status: gap
+  status: covered
+  tests:
+    - tests/bucket-2/310400-misc-single-method-gaps
+  notes: MockRecordRef.ALFieldExists(string) now looks up via TableFieldRegistry.GetFieldId(tableId, name); closes #1382
 
 RecordRef.FieldIndex (Integer):
   layer: runtime-api
@@ -6121,7 +6136,10 @@ RecordRef.FindSet (Boolean):
 RecordRef.FullyQualifiedName ():
   layer: runtime-api
   category: RecordRef
-  status: gap
+  status: covered
+  tests:
+    - tests/bucket-2/310400-misc-single-method-gaps
+  notes: MockRecordRef.ALFullyQualifiedName property added; delegates to handle.ALFullyQualifiedName (CompanyName$TableName); closes #1382
 
 RecordRef.Get (RecordId):
   layer: runtime-api
@@ -6953,7 +6971,10 @@ Session.LogMessage (Text, Text, Verbosity, DataClassification, TelemetryScope, D
 Session.LogMessage (Text, Text, Verbosity, DataClassification, TelemetryScope, Text, Text, Text, Text):
   layer: runtime-api
   category: Session
-  status: gap
+  status: covered
+  tests:
+    - tests/bucket-2/310400-misc-single-method-gaps
+  notes: ALSession.ALLogMessage is stripped as a no-op by RoslynRewriter for all arities (statement-level strip); closes #1382
 
 Session.LogSecurityAudit (Text, SecurityOperationResult, Text, AuditCategory, Array, Array):
   layer: runtime-api
@@ -10131,7 +10152,11 @@ Version.Build ():
 Version.Create (Integer, Integer, Integer, Integer):
   layer: runtime-api
   category: Version
-  status: gap
+  status: covered
+  tests:
+    - tests/bucket-1/96-version
+    - tests/bucket-2/310400-misc-single-method-gaps
+  notes: MockVersion.ALCreate(session, major, minor, build, revision) and ALCreate(major, minor, build, revision) already implemented; closes #1382
 
 Version.Create (Text):
   layer: runtime-api

--- a/tests/bucket-2/310400-misc-single-method-gaps/src/MiscGapsSrc.al
+++ b/tests/bucket-2/310400-misc-single-method-gaps/src/MiscGapsSrc.al
@@ -1,0 +1,146 @@
+/// Table used by RecordRef gap tests (FieldExist by name, FullyQualifiedName) and Media tests.
+table 310400 "Misc Gaps Table"
+{
+    DataClassification = CustomerContent;
+    fields
+    {
+        field(1; "No."; Code[20]) { }
+        field(2; Name; Text[100]) { }
+        field(3; Amount; Decimal) { }
+        field(4; MediaField; Media) { }
+    }
+    keys
+    {
+        key(PK; "No.") { Clustered = true; }
+    }
+}
+
+/// Blob table used to create InStream/OutStream values in tests.
+table 310401 "Misc Gaps Blob Table"
+{
+    fields
+    {
+        field(1; PK; Integer) { }
+        field(2; BlobData; Blob) { }
+    }
+    keys { key(PK; PK) { } }
+}
+
+/// Helper codeunit for RecordRef gap tests.
+codeunit 310402 "Misc Gaps RecordRef Helper"
+{
+    /// RecordRef.FieldExist(Text) — look up a field by name.
+    procedure FieldExistByName(TableNo: Integer; FieldName: Text): Boolean
+    var
+        RecRef: RecordRef;
+    begin
+        RecRef.Open(TableNo);
+        exit(RecRef.FieldExist(FieldName));
+    end;
+
+    /// RecordRef.FullyQualifiedName() — returns CompanyName$TableName.
+    procedure GetFullyQualifiedName(TableNo: Integer): Text
+    var
+        RecRef: RecordRef;
+    begin
+        RecRef.Open(TableNo);
+        exit(RecRef.FullyQualifiedName());
+    end;
+}
+
+/// Helper codeunit for Version.Create(4-arg) test.
+codeunit 310403 "Misc Gaps Version Helper"
+{
+    /// Version.Create(major, minor, build, revision) via local Integer variables.
+    procedure CreateVersion(Major: Integer; Minor: Integer; Build: Integer; Revision: Integer): Version
+    begin
+        exit(Version.Create(Major, Minor, Build, Revision));
+    end;
+}
+
+/// Target codeunit for Codeunit.Run(Text, Table) test.
+codeunit 310404 "Misc Gaps Run Target"
+{
+    TableNo = "Misc Gaps Table";
+
+    trigger OnRun()
+    begin
+        // Increment Amount on the record passed to OnRun.
+        Rec.Amount += 1;
+        Rec.Modify();
+    end;
+}
+
+/// Helper codeunit that calls Codeunit.Run(Text, var Record) using a Text name.
+codeunit 310405 "Misc Gaps Codeunit Run Helper"
+{
+    procedure RunByTextName(var Rec: Record "Misc Gaps Table")
+    var
+        CUName: Text;
+    begin
+        CUName := 'Misc Gaps Run Target';
+        Codeunit.Run(CUName, Rec);
+    end;
+}
+
+/// Helper codeunit for Media.ImportStream(InStream, Text, Text, Text) — 4-arg form.
+codeunit 310406 "Misc Gaps Media Helper"
+{
+    procedure ImportStream4Arg(var Rec: Record "Misc Gaps Table"; var InStr: InStream; FileName: Text; MimeType: Text; Description: Text)
+    begin
+        Rec.MediaField.ImportStream(InStr, FileName, MimeType, Description);
+    end;
+
+    procedure HasValue(var Rec: Record "Misc Gaps Table"): Boolean
+    begin
+        exit(Rec.MediaField.HasValue());
+    end;
+
+    procedure MakeBlobInStream(var BlobRec: Record "Misc Gaps Blob Table" temporary; var InStr: InStream)
+    var
+        OutStr: OutStream;
+    begin
+        BlobRec.BlobData.CreateOutStream(OutStr);
+        OutStr.WriteText('test-content');
+        BlobRec.BlobData.CreateInStream(InStr);
+    end;
+}
+
+/// Helper codeunit for DataTransfer.AddDestinationFilter(Integer, Text, Joker).
+codeunit 310407 "Misc Gaps DataTransfer Helper"
+{
+    procedure AddDestinationFilterVariant(TableNoFrom: Integer; TableNoTo: Integer)
+    var
+        DT: DataTransfer;
+    begin
+        DT.SetTables(TableNoFrom, TableNoTo);
+        DT.AddDestinationFilter(1, '310400', 310400);
+    end;
+}
+
+/// Helper codeunit for Database.SelectLatestVersion(Integer).
+codeunit 310408 "Misc Gaps Database Helper"
+{
+    procedure CallSelectLatestVersionWithCompany(CompanyId: Integer)
+    begin
+        Database.SelectLatestVersion(CompanyId);
+    end;
+}
+
+/// Helper codeunit for Session.LogMessage 9-arg form.
+codeunit 310409 "Misc Gaps Session Helper"
+{
+    procedure LogMessage9Arg(
+        EventId: Text;
+        Msg: Text;
+        Verb: Verbosity;
+        DC: DataClassification;
+        Scope: TelemetryScope;
+        Dim1Key: Text;
+        Dim1Value: Text;
+        Dim2Key: Text;
+        Dim2Value: Text)
+    begin
+        Session.LogMessage(EventId, Msg, Verb, DC, Scope, Dim1Key, Dim1Value, Dim2Key, Dim2Value);
+    end;
+}

--- a/tests/bucket-2/310400-misc-single-method-gaps/test/MiscGapsTest.al
+++ b/tests/bucket-2/310400-misc-single-method-gaps/test/MiscGapsTest.al
@@ -1,0 +1,168 @@
+/// Tests for miscellaneous single-method gaps (issue #1382):
+///   RecordRef.FieldExist(Text), RecordRef.FullyQualifiedName,
+///   Codeunit.Run(Text,Table), DataTransfer.AddDestinationFilter,
+///   Database.SelectLatestVersion(Integer), Session.LogMessage(9-arg),
+///   Media.ImportStream(InStream,Text,Text,Text), Version.Create(4-arg).
+codeunit 310490 "Misc Gaps Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        RecRefHelper: Codeunit "Misc Gaps RecordRef Helper";
+        VersionHelper: Codeunit "Misc Gaps Version Helper";
+
+    // ── RecordRef.FieldExist(Text) ─────────────────────────────────────────────
+
+    [Test]
+    procedure RecordRef_FieldExistByName_ExistingField_ReturnsTrue()
+    begin
+        // [GIVEN] Table 310400 has field named "No."
+        // [WHEN] FieldExist is called with "No."
+        // [THEN] Returns true
+        Assert.IsTrue(RecRefHelper.FieldExistByName(310400, 'No.'), 'FieldExist(''No.'') must return true');
+    end;
+
+    [Test]
+    procedure RecordRef_FieldExistByName_AnotherExistingField_ReturnsTrue()
+    begin
+        // [GIVEN] Table 310400 has field named "Name"
+        // [WHEN] FieldExist is called with "Name"
+        // [THEN] Returns true
+        Assert.IsTrue(RecRefHelper.FieldExistByName(310400, 'Name'), 'FieldExist(''Name'') must return true');
+    end;
+
+    [Test]
+    procedure RecordRef_FieldExistByName_NonExistingField_ReturnsFalse()
+    begin
+        // [GIVEN] Table 310400 does not have field named "DoesNotExist"
+        // [WHEN] FieldExist is called with "DoesNotExist"
+        // [THEN] Returns false
+        Assert.IsFalse(RecRefHelper.FieldExistByName(310400, 'DoesNotExist'), 'FieldExist(''DoesNotExist'') must return false');
+    end;
+
+    // ── RecordRef.FullyQualifiedName ───────────────────────────────────────────
+
+    [Test]
+    procedure RecordRef_FullyQualifiedName_ReturnsCompanyDollarTable()
+    var
+        FQN: Text;
+    begin
+        // [GIVEN] RecordRef opened on table 310400 (name "Misc Gaps Table")
+        // [WHEN] FullyQualifiedName is called
+        FQN := RecRefHelper.GetFullyQualifiedName(310400);
+        // [THEN] Returns "CRONUS$Misc Gaps Table"
+        Assert.AreEqual('CRONUS$Misc Gaps Table', FQN, 'FullyQualifiedName must return CompanyName$TableName');
+    end;
+
+    // ── Version.Create(Integer, Integer, Integer, Integer) ────────────────────
+
+    [Test]
+    procedure Version_Create4Arg_StoresAllComponents()
+    var
+        Ver: Version;
+    begin
+        // [GIVEN] Version.Create called with (1, 2, 3, 4)
+        Ver := VersionHelper.CreateVersion(1, 2, 3, 4);
+        // [THEN] Each component is correct
+        Assert.AreEqual(1, Ver.Major(), 'Major must be 1');
+        Assert.AreEqual(2, Ver.Minor(), 'Minor must be 2');
+        Assert.AreEqual(3, Ver.Build(), 'Build must be 3');
+        Assert.AreEqual(4, Ver.Revision(), 'Revision must be 4');
+    end;
+
+    [Test]
+    procedure Version_Create4Arg_ZeroComponents()
+    var
+        Ver: Version;
+    begin
+        // [GIVEN] Version.Create called with all zeros
+        Ver := VersionHelper.CreateVersion(0, 0, 0, 0);
+        // [THEN] All components are 0
+        Assert.AreEqual(0, Ver.Major(), 'Major must be 0');
+        Assert.AreEqual(0, Ver.Minor(), 'Minor must be 0');
+        Assert.AreEqual(0, Ver.Build(), 'Build must be 0');
+        Assert.AreEqual(0, Ver.Revision(), 'Revision must be 0');
+    end;
+
+    // ── Codeunit.Run(Text, Table) ──────────────────────────────────────────────
+
+    [Test]
+    procedure Codeunit_Run_ByTextName_WithRecord_Succeeds()
+    var
+        Rec: Record "Misc Gaps Table";
+        RunHelper: Codeunit "Misc Gaps Codeunit Run Helper";
+    begin
+        // [GIVEN] A record in the table
+        Rec."No." := 'RUN001';
+        Rec.Amount := 5;
+        Rec.Insert();
+        // [WHEN] RunByTextName is called (uses Codeunit.Run(Text, Rec))
+        RunHelper.RunByTextName(Rec);
+        // [THEN] OnRun incremented Amount to 6
+        Rec.Get('RUN001');
+        Assert.AreEqual(6, Rec.Amount, 'Codeunit.Run(Text,Rec) must have incremented Amount');
+    end;
+
+    // ── Media.ImportStream(InStream, Text, Text, Text) ────────────────────────
+
+    [Test]
+    procedure Media_ImportStream_4Arg_SetsHasValue()
+    var
+        Rec: Record "Misc Gaps Table";
+        MediaHelper: Codeunit "Misc Gaps Media Helper";
+        BlobRec: Record "Misc Gaps Blob Table" temporary;
+        InStr: InStream;
+    begin
+        // [GIVEN] A record and an InStream from a temporary blob
+        Rec."No." := 'MEDIA001';
+        Rec.Insert();
+        MediaHelper.MakeBlobInStream(BlobRec, InStr);
+        // [WHEN] ImportStream with 4 args is called on the Media field
+        MediaHelper.ImportStream4Arg(Rec, InStr, 'file.png', 'image/png', 'Test Image');
+        // [THEN] HasValue is true after the import
+        Assert.IsTrue(MediaHelper.HasValue(Rec), 'Media.HasValue must be true after ImportStream(4-arg)');
+    end;
+
+    // ── DataTransfer.AddDestinationFilter(Integer, Text, Joker) ──────────────
+
+    [Test]
+    procedure DataTransfer_AddDestinationFilter_3Arg_NoThrow()
+    var
+        DTHelper: Codeunit "Misc Gaps DataTransfer Helper";
+    begin
+        // [GIVEN/WHEN] AddDestinationFilter with 3 args is called
+        // [THEN] Does not throw
+        DTHelper.AddDestinationFilterVariant(310400, 310400);
+    end;
+
+    // ── Database.SelectLatestVersion(Integer) ────────────────────────────────
+
+    [Test]
+    procedure Database_SelectLatestVersion_WithCompanyId_NoThrow()
+    var
+        DBHelper: Codeunit "Misc Gaps Database Helper";
+    begin
+        // [GIVEN/WHEN] SelectLatestVersion(42) is called
+        // [THEN] Does not throw (no-op stub)
+        DBHelper.CallSelectLatestVersionWithCompany(42);
+    end;
+
+    // ── Session.LogMessage(9-arg) ─────────────────────────────────────────────
+
+    [Test]
+    procedure Session_LogMessage_9Arg_NoThrow()
+    var
+        SessionHelper: Codeunit "Misc Gaps Session Helper";
+    begin
+        // [GIVEN/WHEN] LogMessage with 9 args is called
+        // [THEN] Does not throw (telemetry is a no-op in standalone mode)
+        SessionHelper.LogMessage9Arg(
+            'TEST0001',
+            'Test telemetry message',
+            Verbosity::Normal,
+            DataClassification::SystemMetadata,
+            TelemetryScope::ExtensionPublisher,
+            'Dim1', 'Val1', 'Dim2', 'Val2');
+    end;
+}


### PR DESCRIPTION
Closes #1382

## Summary

Implements 8 missing AL method overloads surfaced in issue #1382:

- **RecordRef.FieldExist(Text)**: `ALFieldExists(string)` now uses `TableFieldRegistry.GetFieldId` to look up by name (previously always returned false).
- **RecordRef.FullyQualifiedName()**: added `ALFullyQualifiedName` property to `MockRecordRef` (was missing; `MockRecordHandle` had it but the RecordRef wrapper didn't expose it).
- **Codeunit.Run(Text, Table)**: added `RunCodeunit(DataError, NavText/string, MockRecordHandle)` overloads to `MockCodeunitHandle` that resolve the codeunit name via `CodeunitNameRegistry`.
- **DataTransfer.AddDestinationFilter(Integer, Text, Joker)**: added no-op `ALAddDestinationFilter(int, string/NavText, object?)` overloads to `MockDataTransfer`.
- **Database.SelectLatestVersion(Integer)**: already handled — `ALSelectLatestVersion` is in `StripEntireCallMethods` and is stripped for all arities; test added to confirm no-throw.
- **Session.LogMessage(9-arg)**: already handled — `ALLogMessage` is stripped as a no-op by `RoslynRewriter` for all arities; test added to confirm no-throw.
- **Media.ImportStream(InStream, Text, Text, Text)**: added 5-arg `ALImport` overloads to `MockMedia` (BC emits `ALImport` returning Guid for the 4-arg AL form, not `ALImportStream`).
- **Version.Create(Integer, Integer, Integer, Integer)**: already implemented via existing `ALCreate` overloads (also tested in `96-version`); `coverage.yaml` updated to reflect covered status.

## Test plan

- [ ] New suite `tests/bucket-2/310400-misc-single-method-gaps` — 11 tests, all PASS
- [ ] Verified bucket-1 and bucket-2 have no new failures introduced
- [ ] `docs/coverage.yaml` updated — all 8 entries flipped from `gap` → `covered`