### PR TITLE
fix: prove XmlAttribute.Create(Text, Text, Text) — closes #1399

### DIFF
--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -2054,14 +2054,14 @@ Source: `Microsoft.Dynamics.Nav.CodeAnalysis` method symbol tables. Coverage = A
 | `SetObjectType` | `(ObjectType)` | ✅ covered | (base + DataError); MockWebServiceActionContext; stores int; round-trip tested |
 | `SetResultCode` | `(WebServiceActionResultCode)` | ✅ covered | (base + DataError); MockWebServiceActionContext; stores WebServiceActionResultCode enum; round-trip tested for Created and OkResponse |
 
-## XmlAttribute  (21/24)
+## XmlAttribute  (22/24)
 
 | Method | Signature | Status | Notes |
 |--------|-----------|--------|-------|
 | `AddAfterSelf` | `(Joker)` | ✅ covered | . Covered via NavXmlAttribute native — AddAfterSelf inserts sibling attr into parent element, attr count increases to 2. |
 | `AddBeforeSelf` | `(Joker)` | ✅ covered | . Covered via NavXmlAttribute native — AddBeforeSelf inserts sibling attr into parent element, attr count increases to 2. |
 | `AsXmlNode` | `()` | ✅ covered | . Covered via NavXmlAttribute native — AsXmlNode().AsXmlAttribute().LocalName round-trips. |
-| `Create` | `(Text, Text, Text)` | 🔲 gap |  |
+| `Create` | `(Text, Text, Text)` | ✅ covered | . Covered via NavXmlAttribute native — 3-arg Create(localName, namespaceUri, value) round-trips all three parameters; namespace URI with ':' works without the NCL validation issue that bit XmlAttributeCollection in #1376. Closes #1399. |
 | `Create` | `(Text, Text)` | ✅ covered | . Covered via NavXmlAttribute native — 2-arg Create(name, value) exercised. |
 | `CreateNamespaceDeclaration` | `(Text, Text)` | ✅ covered | . Covered via NavXmlAttribute native — CreateNamespaceDeclaration(prefix, uri) returns attr with IsNamespaceDeclaration=true and LocalName=prefix. |
 | `GetDocument` | `(XmlDocument)` | ✅ covered | . Covered via NavXmlAttribute native — GetDocument returns false for detached attribute. |

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -10340,7 +10340,10 @@ XmlAttribute.AsXmlNode ():
 XmlAttribute.Create (Text, Text, Text):
   layer: runtime-api
   category: XmlAttribute
-  status: gap
+  status: covered
+  tests:
+    - tests/bucket-2/193-xmlattribute
+  notes: . Covered via NavXmlAttribute native — 3-arg Create(localName, namespaceUri, value) round-trips all three parameters; namespace URI with ':' works without the NCL validation issue that bit XmlAttributeCollection in #1376. Closes #1399.
 
 XmlAttribute.Create (Text, Text):
   layer: runtime-api

--- a/tests/bucket-2/193-xmlattribute/src/XmlAttributeSrc.al
+++ b/tests/bucket-2/193-xmlattribute/src/XmlAttributeSrc.al
@@ -80,4 +80,47 @@ codeunit 60190 "XAT Src"
         attr := XmlAttribute.Create('id', '42');
         exit(attr.Name = attr.Value);
     end;
+
+    // ── XmlAttribute.Create(LocalName, NamespaceUri, Value) ──────────────────
+
+    procedure Create3Arg_Value(): Text
+    var
+        attr: XmlAttribute;
+    begin
+        attr := XmlAttribute.Create('isbn', 'urn:books:1', '978-0-13');
+        exit(attr.Value);
+    end;
+
+    procedure Create3Arg_LocalName(): Text
+    var
+        attr: XmlAttribute;
+    begin
+        attr := XmlAttribute.Create('isbn', 'urn:books:1', '978-0-13');
+        exit(attr.LocalName);
+    end;
+
+    procedure Create3Arg_NamespaceUri(): Text
+    var
+        attr: XmlAttribute;
+    begin
+        attr := XmlAttribute.Create('isbn', 'urn:books:1', '978-0-13');
+        exit(attr.NamespaceUri);
+    end;
+
+    procedure Create3Arg_EmptyNamespace_NamespaceUri(): Text
+    var
+        attr: XmlAttribute;
+    begin
+        attr := XmlAttribute.Create('isbn', '', '978-0-13');
+        exit(attr.NamespaceUri);
+    end;
+
+    procedure Create3Arg_NamespaceUri_Aliases_Value_NegativeTrap(): Boolean
+    var
+        attr: XmlAttribute;
+    begin
+        // Negative trap: NamespaceUri and Value must be different slots.
+        attr := XmlAttribute.Create('isbn', 'urn:books:1', '978-0-13');
+        exit(attr.NamespaceUri = attr.Value);
+    end;
 }

--- a/tests/bucket-2/193-xmlattribute/test/XmlAttributeTest.al
+++ b/tests/bucket-2/193-xmlattribute/test/XmlAttributeTest.al
@@ -65,4 +65,41 @@ codeunit 60191 "XAT Test"
         Assert.IsFalse(Src.AttributeValue_Not_AttributeName_NegativeTrap(),
             'XmlAttribute.Name and XmlAttribute.Value must not alias');
     end;
+
+    // ── XmlAttribute.Create(LocalName, NamespaceUri, Value) ──────────────────
+
+    [Test]
+    procedure Create_3Arg_Value()
+    begin
+        Assert.AreEqual('978-0-13', Src.Create3Arg_Value(),
+            'Create(localName, ns, value).Value must return the third argument');
+    end;
+
+    [Test]
+    procedure Create_3Arg_LocalName()
+    begin
+        Assert.AreEqual('isbn', Src.Create3Arg_LocalName(),
+            'Create(localName, ns, value).LocalName must return the first argument');
+    end;
+
+    [Test]
+    procedure Create_3Arg_NamespaceUri()
+    begin
+        Assert.AreEqual('urn:books:1', Src.Create3Arg_NamespaceUri(),
+            'Create(localName, ns, value).NamespaceUri must return the second argument (with '':'')');
+    end;
+
+    [Test]
+    procedure Create_3Arg_EmptyNamespace_BehavesAsNoNamespace()
+    begin
+        Assert.AreEqual('', Src.Create3Arg_EmptyNamespace_NamespaceUri(),
+            'Create(localName, '''', value) must round-trip an empty NamespaceUri');
+    end;
+
+    [Test]
+    procedure Create_3Arg_NamespaceUri_NotAliasingValue_NegativeTrap()
+    begin
+        Assert.IsFalse(Src.Create3Arg_NamespaceUri_Aliases_Value_NegativeTrap(),
+            'XmlAttribute.NamespaceUri and XmlAttribute.Value must not alias');
+    end;
 }


### PR DESCRIPTION
Closes #1399

## Summary

BC native `NavXmlAttribute` already supports the 3-arg `Create(localName, namespaceUri, value)` overload — the gap was illusory. Test-only proof per the issue's "try test-first" hint (mirrors the #1372/#1389 outcome for XmlDocument/Element gaps).

## Tests

5 new `[Test]` cases in `tests/bucket-2/193-xmlattribute` (extends the existing suite, no new bucket directory):

- `Create_3Arg_Value` — third arg → `attr.Value`
- `Create_3Arg_LocalName` — first arg → `attr.LocalName`
- `Create_3Arg_NamespaceUri` — second arg → `attr.NamespaceUri`, URI contains `:` (the same NCL validation path that bit `XmlAttributeCollection` in #1376 — does **not** fire here)
- `Create_3Arg_EmptyNamespace_BehavesAsNoNamespace` — empty URI round-trips as empty
- `Create_3Arg_NamespaceUri_NotAliasingValue_NegativeTrap` — `NamespaceUri ≠ Value`, catches a stub aliasing positional args

The three values used (`'isbn'` / `'urn:books:1'` / `'978-0-13'`) are mutually distinguishable so a no-op stub returning defaults or aliasing slots cannot pass.

## Test plan

- [x] `docs/coverage.yaml` + `docs/coverage.md` flipped `gap` → `covered` for `XmlAttribute.Create (Text, Text, Text)` — per-overload gap list now at **0**
- [x] `dotnet build AlRunner.slnx` → green
- [x] `dotnet test AlRunner.Tests/` → 382 passed × net8/net9/net10
- [x] AL bucket loop with `--strict --test-isolation method` → 3871 passed, 0 failed (bucket-1: 1957, bucket-2: 1904, bucket-3: 6, bucket-4: 4)
- [x] Stubs suite → 2 passed
- [x] `node scripts/coverage-gen.js --validate` → `Validation passed (1849 entries)`