### PR TITLE
docs: align CONTRIBUTING/CLAUDE bucket-loop with CI — closes #1409

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,18 +122,21 @@ tests/bucket-N/NN-descriptive-name/
 ### Running tests
 
 ```bash
-# Run all buckets
+# Run all buckets (mirrors .github/workflows/test-matrix.yml)
 for bucket in tests/bucket-*/; do
   args=""
   for suite in "$bucket"*/; do
     [ -d "${suite}src"  ] && args="$args ${suite}src"
+    for appdir in "${suite}"app*/; do
+      [ -d "$appdir" ] && args="$args $appdir"
+    done
     [ -d "${suite}test" ] && args="$args ${suite}test"
   done
-  dotnet run --project AlRunner -- $args
+  dotnet run --project AlRunner --framework net10.0 -- --strict --test-isolation method $args
 done
 
 # Stubs test (separate invocation)
-dotnet run --project AlRunner -- --stubs tests/stubs/39-stubs/stubs tests/stubs/39-stubs/src tests/stubs/39-stubs/test
+dotnet run --project AlRunner --framework net10.0 -- --stubs tests/stubs/39-stubs/stubs tests/stubs/39-stubs/src tests/stubs/39-stubs/test
 ```
 
 ### Build

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,7 +65,7 @@ Write the failing test first, verify it fails for the right reason, then impleme
 
 ## The full CI pipeline must pass
 
-All pull requests run against a matrix of BC versions (currently 26.0–27.5) on both net8.0 and net9.0. A PR cannot merge unless every job in the matrix is green.
+All pull requests run against a matrix of BC versions (currently 26.0–27.5) on net10.0. A PR cannot merge unless every job in the matrix is green.
 
 To run the same checks locally before pushing:
 
@@ -76,20 +76,23 @@ dotnet build AlRunner.slnx
 # C# unit tests
 dotnet test AlRunner.Tests/
 
-# AL end-to-end tests (net8.0)
+# AL end-to-end tests (mirrors .github/workflows/test-matrix.yml)
 for bucket in tests/bucket-*/; do
   args=""
   for suite in "$bucket"*/; do
     [ -d "${suite}src"  ] && args="$args ${suite}src"
+    for appdir in "${suite}"app*/; do
+      [ -d "$appdir" ] && args="$args $appdir"
+    done
     [ -d "${suite}test" ] && args="$args ${suite}test"
   done
-  dotnet run --project AlRunner --framework net8.0 -- $args || {
+  dotnet run --project AlRunner --framework net10.0 -- --strict --test-isolation method $args || {
     rc=$?; [ $rc -eq 2 ] || exit $rc
   }
 done
 
 # Stubs suite (needs --stubs flag)
-dotnet run --project AlRunner --framework net8.0 -- \
+dotnet run --project AlRunner --framework net10.0 -- \
   --stubs tests/stubs/39-stubs/stubs tests/stubs/39-stubs/src tests/stubs/39-stubs/test
 ```
 


### PR DESCRIPTION
Closes #1409

## Summary

Aligns the local-run bash blocks in `CONTRIBUTING.md` and `CLAUDE.md` with `.github/workflows/test-matrix.yml`.

- Inner `app*/` loop — without it, bucket-2 hard-errors on missing `AppA Helper` / `AppB Helper`
- `--strict --test-isolation method` — without these, ~180 false failures from cross-test record state leakage
- `--framework net10.0` — matches CI; mandatory because the project's three TFMs (`net8.0;net9.0;net10.0`) make `dotnet run` ambiguous without a flag
- Prose claim "on both net8.0 and net9.0" → "on net10.0" — corrects what `test-matrix.yml` actually invokes
- `--no-build` deliberately omitted — CI-only optimization; foot-gun in iterative local dev (stale binaries, fails outright if `dotnet build` is skipped)

## Test plan

- [x] Patched bash block run verbatim against `upstream/main` → 3873 passed, 0 failed (bucket-1: 1957, bucket-2: 1904, bucket-3: 6, bucket-4: 4, stubs: 2)