### PR TITLE
fix: shim ALSetLoadFields(DataError, params int[]) on record wrapper — closes #1405

### DIFF
--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -784,6 +784,7 @@ public bool ALRename(DataError errorLevel, object key1, object key2) => Rec.ALRe
 public bool ALRename(DataError errorLevel, object key1, object key2, object key3) => Rec.ALRename(errorLevel, key1, key2, key3);
 public bool ALRename(DataError errorLevel, object key1, object key2, object key3, object key4) => Rec.ALRename(errorLevel, key1, key2, key3, key4);
 public void ALSetLoadFields(params int[] fieldNos) => Rec.ALSetLoadFields(fieldNos);
+public void ALSetLoadFields(DataError errorLevel, params int[] fieldNos) => Rec.ALSetLoadFields(errorLevel, fieldNos);
 public void ALSetAutoCalcFields(params object[] fields) => Rec.ALSetAutoCalcFields(fields);
 public string ALGetFilter() => Rec.ALGetFilter();
 public string ALGetFilter(int fieldNo) => Rec.ALGetFilter(fieldNo);

--- a/tests/bucket-2/185-loadfields/src/LoadFieldsSrc.al
+++ b/tests/bucket-2/185-loadfields/src/LoadFieldsSrc.al
@@ -7,6 +7,11 @@ table 60110 "LF Row"
         field(3; "City"; Text[100]) { }
     }
     keys { key(PK; "Id") { Clustered = true; } }
+
+    internal procedure SetLoadFieldsOnSelf()
+    begin
+        SetLoadFields("Id", "Name");
+    end;
 }
 
 /// Helper codeunit exercising AddLoadFields (standalone no-op because all
@@ -101,5 +106,12 @@ codeunit 60110 "LF Src"
         // Even fields not explicitly in the load set still report as loaded
         // because the standalone store keeps all fields resident.
         exit(recRef.AreFieldsLoaded(1, 2, 3));
+    end;
+
+    procedure DriveSetLoadFieldsOnSelf()
+    var
+        r: Record "LF Row";
+    begin
+        r.SetLoadFieldsOnSelf();
     end;
 }

--- a/tests/bucket-2/185-loadfields/test/LoadFieldsTest.al
+++ b/tests/bucket-2/185-loadfields/test/LoadFieldsTest.al
@@ -56,4 +56,10 @@ codeunit 60111 "LF Test"
         Assert.IsTrue(Src.RecRefAreFieldsLoaded_AfterSetLoadFields(),
             'RecordRef.AreFieldsLoaded must remain true even for fields not in the load set');
     end;
+
+    [Test]
+    procedure SetLoadFieldsOnSelf_NoThrow()
+    begin
+        Src.DriveSetLoadFieldsOnSelf();
+    end;
 }


### PR DESCRIPTION
Closes #1405

## Summary

The per-record wrapper class injected by `RoslynRewriter` (around line 786) only shipped the legacy `ALSetLoadFields(params int[] fieldNos)` shim. With AL `runtime: 16.0+`, the BC compiler emits `_parent.ALSetLoadFields(DataError.X, fieldNos)` whenever AL code calls `SetLoadFields` on `Self` from a table procedure (`Lock()`-style helpers, etc.) — producing `CS1503: 'Microsoft.Dynamics.Nav.Types.DataError' to 'int'`. Adds the DataError-prefixed overload, mirroring the pattern already used by `ALCalcFields`/`ALCalcSums`/`ALSetCurrentKey` two lines above (RoslynRewriter.cs:766–768). The underlying `MockRecordHandle.ALSetLoadFields(DataError, params int[])` already existed.

Reproduced against the original telemetry source (`GTM-BC-9AAdvMan-ItemConfigurator`, runtime 16.0): all 6× `DataError → int` errors disappear after the patch (the unrelated #1404 / #1406 / #1407 telemetry errors remain — separate gaps).

## Tests

1 new `[Test]` in `tests/bucket-2/185-loadfields` (extends the existing suite, no new bucket directory):

- `SetLoadFieldsOnSelf_NoThrow` — drives a table internal procedure that calls `SetLoadFields("Id", "Name")` on `Self`. The minimal repro: nothing else (no `ReadIsolation`, no `FindLast`) is required to trigger CS1503 against the unfixed runner. No-throw shape per the CLAUDE.md exception (the runtime contract for `SetLoadFields` is "no-op — every field is always loaded standalone").

## Test plan

- [x] Confirmed RED first — new test fails to compile against unfixed runner with the same `CS1503: 'DataError' → 'int'` as the original telemetry
- [x] `dotnet build AlRunner/AlRunner.csproj` → 0 errors
- [x] AL bucket loop with `--strict --test-isolation method` → bucket-1: 1957 passed, bucket-2: 1905 passed (was 1904 + 1 new), 0 failed
- [x] Stubs suite → 2 passed
- [x] `node scripts/coverage-gen.js --validate` → `Validation passed (1849 entries)`
- [x] Re-run `AlRunner.exe --packages ./test/.alpackages/ ./app ./test/` against `GTM-BC-9AAdvMan-ItemConfigurator` (runtime 16.0) → all 6× `DataError → int` errors gone

## Sibling gaps (filing as separate issues)

While probing minimum repros I confirmed the same wrapper-shim oversight affects three sibling methods and will file follow-ups after this lands:

- `ALAddLoadFields` and `ALAreFieldsLoaded` — missing from the wrapper entirely (CS1061 when called on Self with runtime 16.0+)
- `ALSetAutoCalcFields` — wrapper uses `params object[]`, so `_parent.ALSetAutoCalcFields(DataError.X, fieldNo)` *silently* binds `DataError.X` as a phantom "field" entry (`MockRecordHandle.ALSetAutoCalcFields` then drops it because `field is int` fails) — a silent no-op rather than a loud failure.

Kept this PR scoped to the telemetry-reported gap.