### PR TITLE
fix: qualify shadowed PromptMode enum reference inside page class — closes #1404

### DIFF
--- a/AlRunner.Tests/PagePromptModeRewriterTests.cs
+++ b/AlRunner.Tests/PagePromptModeRewriterTests.cs
@@ -137,4 +137,42 @@ public class PagePromptModeRewriterTests
 
         Assert.DoesNotContain("this.PromptMode", output);
     }
+
+    [Fact]
+    public void PromptMode_BareEnumRhs_QualifiedInsidePageClass()
+    {
+        var input = WrapInPageClass("var x = PromptMode.Content;");
+        var output = RoslynRewriter.Rewrite(input);
+
+        Assert.Contains("Microsoft.Dynamics.Nav.Types.Metadata.PromptMode.Content", output);
+    }
+
+    [Fact]
+    public void PromptMode_InstanceAccessLhs_NotQualified()
+    {
+        var input = WrapInPageClass("CurrPage.PromptMode = null;");
+        var output = RoslynRewriter.Rewrite(input);
+
+        Assert.Contains("CurrPage.PromptMode", output);
+        Assert.DoesNotContain("Microsoft.Dynamics.Nav.Types.Metadata.PromptMode = null", output);
+    }
+
+    [Fact]
+    public void PromptMode_BareEnumRhs_NotQualifiedInCodeunit()
+    {
+        var input = """
+            namespace Microsoft.Dynamics.Nav.BusinessApplication
+            {
+                using AlRunner.Runtime;
+                using Microsoft.Dynamics.Nav.Runtime;
+                using Microsoft.Dynamics.Nav.Types.Metadata;
+                class Codeunit50000 : NavCodeunit {
+                    void M() { var x = PromptMode.Content; }
+                }
+            }
+            """;
+        var output = RoslynRewriter.Rewrite(input);
+
+        Assert.DoesNotContain("Microsoft.Dynamics.Nav.Types.Metadata.PromptMode.Content", output);
+    }
 }

--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -21,6 +21,9 @@ public class RoslynRewriter : CSharpSyntaxRewriter
     // BC emits CurrPage.PromptMode as a static reference on the page class (issue #1266).
     private string? _currentPageClassName;
 
+    private static readonly NameSyntax PromptModeQualifiedName =
+        SyntaxFactory.ParseName("Microsoft.Dynamics.Nav.Types.Metadata.PromptMode");
+
     private static readonly HashSet<string> BcAttributeNames = new(StringComparer.Ordinal)
     {
         "NavCodeunitOptions",
@@ -926,7 +929,7 @@ public bool LookupMode {{ get; set; }}
 // BC generates as calls on the Page<N> class directly (same pattern as LookupMode/#1079).
 public bool Editable {{ get; set; }} = true;
 public string PageCaption {{ get; set; }} = string.Empty;
-public NavOption? PromptMode {{ get; set; }}
+public Microsoft.Dynamics.Nav.Types.Metadata.PromptMode? PromptMode {{ get; set; }}
 public NavText ObjectID(bool withCaption = false) {{ return NavText.Empty; }}
 // SetRecord — BC lowers CurrPage.SetRecord(rec) to this.SetRecord(rec.Target).
 // NavForm provided this; after stripping it we need a stub (issue #1262).
@@ -4505,6 +4508,15 @@ public void Unbind() { AlRunner.Runtime.EventSubscriberRegistry.Unbind(this); }
             visited.Name.Identifier.Text == "PromptMode")
         {
             return visited.WithExpression(SyntaxFactory.ThisExpression());
+        }
+
+        // Bare PromptMode is shadowed by the wrapper-injected instance property
+        // via nested-class simple-name lookup; qualify so it binds to the enum.
+        if (_currentPageClassName != null &&
+            visited.Expression is IdentifierNameSyntax bareIdName &&
+            bareIdName.Identifier.Text == "PromptMode")
+        {
+            return visited.WithExpression(PromptModeQualifiedName);
         }
 
         // Pattern: xxx.Target -> xxx (strip .Target accessor on handles)

--- a/tests/bucket-1/100-page-promptmode/src/PromptModeSrc.al
+++ b/tests/bucket-1/100-page-promptmode/src/PromptModeSrc.al
@@ -7,6 +7,11 @@ page 113000 "PM Test Page"
     PageType = PromptDialog;
     ApplicationArea = All;
     UsageCategory = None;
+
+    procedure SetPromptModeToContent()
+    begin
+        CurrPage.PromptMode := PromptMode::Content;
+    end;
 }
 
 pageextension 113001 "PM Page Ext" extends "PM Test Page"

--- a/tests/bucket-1/100-page-promptmode/test/PromptModeTest.al
+++ b/tests/bucket-1/100-page-promptmode/test/PromptModeTest.al
@@ -4,8 +4,6 @@
 ///
 /// Issue #1266: BC emits Page<N>.PromptMode as a static self-reference inside
 /// PromptDialog pages. The RoslynRewriter converts this to this.PromptMode.
-/// (Cannot test with AL here — PromptDialog PageType not supported by local compiler.
-/// See AlRunner.Tests/PagePromptModeRewriterTests.cs for the C# rewriter tests.)
 codeunit 113003 "PM Test"
 {
     Subtype = Test;
@@ -39,6 +37,12 @@ codeunit 113003 "PM Test"
         // Positive: if MockCurrPage.PromptMode exists, the PromptDialog pageextension
         // compiled (otherwise CS1061 would have made this test not exist at all).
         Assert.IsTrue(true, 'CurrPage.PromptMode get/set compiled successfully');
+    end;
+
+    [Test]
+    procedure PageProcPromptModeContent_Compiles()
+    begin
+        Assert.IsTrue(true, 'CurrPage.PromptMode := PromptMode::Content compiled successfully');
     end;
 
     [Test]


### PR DESCRIPTION
Closes #1404

## Summary

BC emits AL `CurrPage.PromptMode := PromptMode::Content;` (in a page-internal procedure) as bare `PromptMode.Content` inside a nested `_Scope` class. The wrapper-injected `PromptMode` property on the page wrapper shadows the namespace-level `Microsoft.Dynamics.Nav.Types.Metadata.PromptMode` enum via C# nested-class simple-name lookup → `CS0120`. Sibling to #1266 (which handled the `Page<N>.PromptMode → this.PromptMode` form). Reproduces against `GTM-BC-9AAdvMan-ItemConfigurator`.

## Solution

- New `RoslynRewriter.VisitMemberAccessExpression` rule: inside a page class, qualify bare `PromptMode.<member>` to `Microsoft.Dynamics.Nav.Types.Metadata.PromptMode.<member>`. Gated on bare `IdentifierName("PromptMode")` LHS so instance accesses (`_parent.CurrPage.PromptMode = …`) are untouched.
- Wrapper-injected property type `NavOption?` → the enum, so the assignment type-checks. `MockCurrPage.PromptMode` (pageextension path) unchanged.

## Tests

- AL: `[Test] PageProcPromptModeContent_Compiles` in `tests/bucket-1/100-page-promptmode/` — RED before fix (`CS0120 on Page113000.PromptMode`), GREEN after. Removes stale `(Cannot test with AL here…)` doc line.
- C#: 3 new `[Fact]`s in `AlRunner.Tests/PagePromptModeRewriterTests.cs`:
    - `PromptMode_BareEnumRhs_QualifiedInsidePageClass` — positive
    - `PromptMode_InstanceAccessLhs_NotQualified` — negative pin: instance access untouched
    - `PromptMode_BareEnumRhs_NotQualifiedInCodeunit` — negative pin: rule scoped to page classes

## Test plan

- [x] `dotnet build AlRunner/AlRunner.csproj` → 0 errors
- [x] `dotnet test AlRunner.Tests/` → 385 passed × net8/net9/net10
- [x] AL bucket loop `--strict --test-isolation method` → 3874 passed / 0 failed (bucket-1: 1958, bucket-2: 1904, bucket-3: 6, bucket-4: 4) + stubs: 2
- [x] `node scripts/coverage-gen.js --validate` → `Validation passed (1849 entries)`
- [x] Re-run `AlRunner.exe` against `GTM-BC-9AAdvMan-ItemConfigurator` — `CS0120 on Page71116155.PromptMode` gone (10 → 9 errors; remaining are unrelated gaps)