### PR TITLE
fix: rewrite MockArray<MockInterfaceHandle> Factory ctor to lambda — closes #1406

### DIFF
--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -2040,6 +2040,30 @@ public void Unbind() { AlRunner.Runtime.EventSubscriberRegistry.Unbind(this); }
             }
         }
 
+        // new MockArray<MockInterfaceHandle>(new MockInterfaceHandle.Factory(...), N) -> new MockArray<MockInterfaceHandle>(N, () => new MockInterfaceHandle())
+        // BC emits MockInterfaceHandle.Factory for `array[N] of Interface I` local-var declarations;
+        // MockInterfaceHandle has no nested Factory, so without this rewrite Roslyn fails with CS0426.
+        if (typeText.StartsWith("MockArray<MockInterfaceHandle>") && visited.ArgumentList != null &&
+            visited.ArgumentList.Arguments.Count == 2)
+        {
+            var factoryArg = visited.ArgumentList.Arguments[0].Expression;
+            var sizeArg = visited.ArgumentList.Arguments[1].Expression;
+            if (factoryArg is ObjectCreationExpressionSyntax)
+            {
+                return SyntaxFactory.ObjectCreationExpression(
+                    SyntaxFactory.ParseTypeName("MockArray<MockInterfaceHandle>"))
+                    .WithArgumentList(SyntaxFactory.ArgumentList(
+                        SyntaxFactory.SeparatedList(new[] {
+                            SyntaxFactory.Argument(sizeArg),
+                            SyntaxFactory.Argument(
+                                SyntaxFactory.ParenthesizedLambdaExpression(
+                                    SyntaxFactory.ObjectCreationExpression(
+                                        SyntaxFactory.ParseTypeName("MockInterfaceHandle"))
+                                        .WithArgumentList(SyntaxFactory.ArgumentList())))
+                        })));
+            }
+        }
+
         // Catch any remaining MockVariant.Factory or NavVariant.Factory construction
         if (typeText.Contains("MockVariant") && typeText.Contains("Factory") && visited.ArgumentList != null)
         {

--- a/tests/bucket-1/306-interface-array-factory/src/IfcArrayFactoryImplA.al
+++ b/tests/bucket-1/306-interface-array-factory/src/IfcArrayFactoryImplA.al
@@ -1,0 +1,7 @@
+codeunit 305005 "IfcArr Factory Impl A" implements "IfcArr Factory Item"
+{
+    procedure GetValue(): Integer
+    begin
+        exit(17);
+    end;
+}

--- a/tests/bucket-1/306-interface-array-factory/src/IfcArrayFactoryImplB.al
+++ b/tests/bucket-1/306-interface-array-factory/src/IfcArrayFactoryImplB.al
@@ -1,0 +1,7 @@
+codeunit 305006 "IfcArr Factory Impl B" implements "IfcArr Factory Item"
+{
+    procedure GetValue(): Integer
+    begin
+        exit(23);
+    end;
+}

--- a/tests/bucket-1/306-interface-array-factory/src/IfcArrayFactoryItem.al
+++ b/tests/bucket-1/306-interface-array-factory/src/IfcArrayFactoryItem.al
@@ -1,0 +1,4 @@
+interface "IfcArr Factory Item"
+{
+    procedure GetValue(): Integer;
+}

--- a/tests/bucket-1/306-interface-array-factory/src/IfcArrayFactorySrc.al
+++ b/tests/bucket-1/306-interface-array-factory/src/IfcArrayFactorySrc.al
@@ -1,0 +1,23 @@
+codeunit 305007 "IfcArr Factory Src"
+{
+    procedure GetValueFromLocalArray(): Integer
+    var
+        Items: array[3] of Interface "IfcArr Factory Item";
+        ImplA: Codeunit "IfcArr Factory Impl A";
+        ImplB: Codeunit "IfcArr Factory Impl B";
+    begin
+        Items[1] := ImplA;
+        Items[2] := ImplB;
+        Items[3] := ImplA;
+        exit(Items[2].GetValue());
+    end;
+
+    procedure FillItems(var Items: array[2] of Interface "IfcArr Factory Item")
+    var
+        ImplA: Codeunit "IfcArr Factory Impl A";
+        ImplB: Codeunit "IfcArr Factory Impl B";
+    begin
+        Items[1] := ImplA;
+        Items[2] := ImplB;
+    end;
+}

--- a/tests/bucket-1/306-interface-array-factory/test/IfcArrayFactoryTest.al
+++ b/tests/bucket-1/306-interface-array-factory/test/IfcArrayFactoryTest.al
@@ -1,0 +1,36 @@
+codeunit 305008 "IfcArr Factory Test"
+{
+    Subtype = Test;
+
+    [Test]
+    procedure IfcArray_LocalVar_DispatchesCorrectly()
+    var
+        Src: Codeunit "IfcArr Factory Src";
+        Result: Integer;
+    begin
+        // [SCENARIO] Local `array[N] of Interface I` (BC emits MockArray<MockInterfaceHandle>(new MockInterfaceHandle.Factory(this), N))
+        // [GIVEN] Items[2] := ImplB (returns 23)
+        // [WHEN] reading Items[2].GetValue() through the local array
+        // [THEN] dispatches to ImplB, returns 23 — proves array compiles AND carries the assigned impl (a stub returning default(int) would fail)
+        Result := Src.GetValueFromLocalArray();
+        Assert.AreEqual(23, Result, 'Items[2].GetValue() should dispatch to ImplB and return 23');
+    end;
+
+    [Test]
+    procedure IfcArray_VarParam_DispatchesCorrectly()
+    var
+        Src: Codeunit "IfcArr Factory Src";
+        Items: array[2] of Interface "IfcArr Factory Item";
+    begin
+        // [SCENARIO] var-param `array[N] of Interface I` round-trip — caller declares the array, callee fills it.
+        // [GIVEN] empty local array of Interface
+        // [WHEN] passing it as `var` to FillItems which assigns ImplA / ImplB
+        // [THEN] both slots dispatch to the right impl with the right specific return value
+        Src.FillItems(Items);
+        Assert.AreEqual(17, Items[1].GetValue(), 'Items[1] should dispatch to ImplA and return 17');
+        Assert.AreEqual(23, Items[2].GetValue(), 'Items[2] should dispatch to ImplB and return 23');
+    end;
+
+    var
+        Assert: Codeunit "Library Assert";
+}


### PR DESCRIPTION
Closes #1406

## Summary
- BC emits `new MockArray<MockInterfaceHandle>(new MockInterfaceHandle.Factory(this), N)` for `array[N] of Interface I`.
- `MockInterfaceHandle` has no nested `Factory` → `CS0426`.
- Fix: rewriter rule mirroring `MockRecordRef` at `RoslynRewriter.cs:2019` → `(N, () => new MockInterfaceHandle())`.

## Tests
New suite `tests/bucket-1/306-interface-array-factory/` — 2 `[Test]` cases (local-var, var-param round-trip), each asserts dispatch returns the impl-specific value (17 / 23). RED step is the negative case (CS0426 on unfixed runner).

## Test plan
- [x] RED confirmed — same CS0426 as the telemetry
- [x] Bucket loop → 1960 / 1905 / 6 / 4 passed, 0 failed
- [x] Stubs suite → 2 passed
- [x] `coverage-gen.js --validate` → 1849 entries
- [x] `GTM-BC-9AAdvMan-ItemConfigurator` re-run → both `Factory` CS0426 errors gone