### PR TITLE
fix: type MockTestPageField.ALValue as string to match BC's TestPageField.Value — closes #1407

### DIFF
--- a/AlRunner/Runtime/MockTestPageHandle.cs
+++ b/AlRunner/Runtime/MockTestPageHandle.cs
@@ -344,7 +344,7 @@ public class MockTestPageHandle
         for (var i = 0; i < keyValues.Length; i++)
         {
             var v = keyValues[i];
-            if (v is MockTestPageField f) v = f.ALValue;
+            if (v is MockTestPageField f) v = f.RawValue;
             navValues[i] = AlCompat.ToNavValue(v);
         }
         return ALGoToKey(errorLevel, navValues);
@@ -496,7 +496,7 @@ public class MockTestPageHandle
         foreach (var (hash, fieldId) in _hashToFieldId)
         {
             var value = rec.GetFieldValueSafe(fieldId, default);
-            GetField(hash).ALValue = value;
+            GetField(hash).ALSetValue(null!, value);
         }
     }
 
@@ -612,7 +612,9 @@ public class MockTestPageHandle
 ///
 /// Stores the last set value and returns it via the settable ALValue property.
 /// The backing store is <c>object?</c> so both <see cref="NavValue"/> instances
-/// and raw CLR values (assigned through the setter) are supported.
+/// and raw CLR values (assigned through <see cref="ALSetValue"/>) are supported.
+/// The <see cref="ALValue"/> property is typed <see cref="NavValue"/> to match BC's
+/// emit pattern <c>new NavText(field.ALValue)</c>.
 /// </summary>
 public class MockTestPageField
 {
@@ -639,15 +641,30 @@ public class MockTestPageField
     }
 
     /// <summary>
-    /// Get or set the current field value.
-    /// The getter returns the last value written via <see cref="ALSetValue"/> or the setter.
-    /// The value may be a <see cref="NavValue"/>, a raw CLR type, or <c>null</c>.
+    /// Get or set the current field value. Typed as <c>string</c> to match BC's
+    /// real <c>NavTestPageField.ALValue</c> (BC's <c>TestPage.&lt;Field&gt;.Value</c>
+    /// is typed <c>Text</c>). This lets BC's emit pattern
+    /// <c>new NavText(field.ALValue)</c> resolve the <c>string</c> constructor
+    /// overload, which is the case BC reaches when assigning <c>.Value</c> to a
+    /// typed Text/Code local variable. Storage stays <c>object?</c> so values
+    /// flowing through <see cref="ALSetValue"/> keep their original type for other
+    /// callers; the getter renders via <see cref="AlCompat.Format"/>.
     /// </summary>
-    public object? ALValue
+    public string ALValue
     {
-        get => _value;
+        get => AlCompat.Format(AlCompat.ToNavValue(_value));
         set => _value = value;
     }
+
+    /// <summary>
+    /// Internal access to the raw stored value (pre-formatting). Used by C#
+    /// callers that need to preserve the original CLR type of the value (e.g.
+    /// key-value lookups in <see cref="MockTestPageHandle.ALGoToKey"/>) — going
+    /// through <see cref="ALValue"/> would coerce the value to a <c>string</c>
+    /// and a subsequent <see cref="AlCompat.ToNavValue"/> would re-wrap it as
+    /// <c>NavText</c>, losing the typed comparison against the table key.
+    /// </summary>
+    internal object? RawValue => _value;
 
     /// <summary>
     /// ALCaption — returns the field caption. Stub: empty string.

--- a/tests/bucket-1/310000-testpage-value-to-typed/src/TestPageValueSrc.al
+++ b/tests/bucket-1/310000-testpage-value-to-typed/src/TestPageValueSrc.al
@@ -1,0 +1,24 @@
+table 70140700 "TPV Read Record"
+{
+    fields
+    {
+        field(1; "No."; Code[20]) { }
+        field(2; Description; Text[100]) { }
+    }
+    keys { key(PK; "No.") { Clustered = true; } }
+}
+
+page 70140700 "TPV Read Card"
+{
+    PageType = Card;
+    SourceTable = "TPV Read Record";
+
+    layout
+    {
+        area(Content)
+        {
+            field(NoField; Rec."No.") { }
+            field(DescriptionField; Rec.Description) { }
+        }
+    }
+}

--- a/tests/bucket-1/310000-testpage-value-to-typed/test/TestPageValueTest.al
+++ b/tests/bucket-1/310000-testpage-value-to-typed/test/TestPageValueTest.al
@@ -1,0 +1,82 @@
+codeunit 70140700 "TPV Read Tests"
+{
+    Subtype = Test;
+
+    trigger OnRun()
+    begin
+        // [FEATURE] TestPage field .Value assignment to typed local variable
+    end;
+
+    [Test]
+    procedure TextFieldValueAssignsToTextVar()
+    var
+        Card: TestPage "TPV Read Card";
+        Captured: Text;
+    begin
+        Initialize();
+        // [SCENARIO] Reading TestPage.<TextField>.Value into a Text variable
+        // [GIVEN] A card with a Text field set to a known value
+        Card.OpenNew();
+        Card.DescriptionField.SetValue('Contoso Ltd');
+
+        // [WHEN] The field's .Value is assigned to a Text variable
+        // BC emits: captured = new NavText(card.GetField(h).ALValue)
+        Captured := Card.DescriptionField.Value;
+
+        // [THEN] The variable holds the value that was set (proves not a stub default)
+        Assert.AreEqual('Contoso Ltd', Captured, 'Text var should hold the value set on the field');
+        Card.Close();
+    end;
+
+    [Test]
+    procedure CodeFieldValueAssignsToCodeVar()
+    var
+        Card: TestPage "TPV Read Card";
+        Captured: Code[20];
+    begin
+        Initialize();
+        // [SCENARIO] Reading TestPage.<CodeField>.Value into a Code variable
+        // [GIVEN] A card with a Code field set to a known value
+        Card.OpenNew();
+        Card.NoField.SetValue('CUST-1407');
+
+        // [WHEN] The field's .Value is assigned to a Code variable
+        // BC emits: captured = new NavCode(card.GetField(h).ALValue)
+        Captured := Card.NoField.Value;
+
+        // [THEN] The variable holds the value that was set
+        Assert.AreEqual('CUST-1407', Captured, 'Code var should hold the value set on the field');
+        Card.Close();
+    end;
+
+    [Test]
+    procedure TextValueDoesNotMatchUnsetValue()
+    var
+        Card: TestPage "TPV Read Card";
+        Captured: Text;
+    begin
+        Initialize();
+        // [SCENARIO] Negative — assigning .Value to a Text var and asserting
+        // a different literal must not match (catches a stub returning '').
+        // [GIVEN] A card with a Text field set to a specific value
+        Card.OpenNew();
+        Card.DescriptionField.SetValue('Fabrikam Inc');
+
+        // [WHEN] Captured holds the field value
+        Captured := Card.DescriptionField.Value;
+
+        // [THEN] An unrelated literal must not equal the captured value
+        Assert.AreNotEqual('Contoso Ltd', Captured, 'Captured value should not match an unrelated literal');
+        Card.Close();
+    end;
+
+    local procedure Initialize()
+    var
+        Rec: Record "TPV Read Record";
+    begin
+        Rec.DeleteAll();
+    end;
+
+    var
+        Assert: Codeunit "Library Assert";
+}


### PR DESCRIPTION
## Summary
- Fixes #1407: BC emits `new NavText(<expr>.GetField(h).ALValue)` when assigning `TestPage.<Field>.Value` to a typed Text/Code local. The mock returned `object?`, so Roslyn rejected the constructor call (`NavText(string)`) with `CS1503: object → string`.
- `MockTestPageField.ALValue`: `object?` → `string` (matches BC's `NavTestPageField.ALValue`). Storage stays `object?`; getter renders via `AlCompat.Format(AlCompat.ToNavValue(_value))`.
- New `internal RawValue` accessor + two internal call-site updates so type-sensitive paths (`ALGoToKey` unwrap, `PopulateFieldsFromRecord`) keep the original CLR type instead of round-tripping through string.

## Test plan
- [x] New `tests/bucket-1/310000-testpage-value-to-typed/` (3 tests): Text & Code field `.Value` → typed local + a negative `AreNotEqual` (catches a stub returning `''`).
- [x] Full bucket-1 loop: 1961/1961 PASS.
- [x] Full bucket-2 loop: 1905/1905 PASS.
- [x] Re-run against `GTM-BC-9AAdvMan-ItemConfigurator` (the original telemetry source for #1405/#1406/#1407): the `CS1503` in `NALICF RuleSet Entry Val Test` is gone. The remaining errors are the unrelated `CS0426 'Factory'` already in flight under #1406 / PR #1416.

🤖 Generated with [Claude Code](https://claude.com/claude-code)