### PR TITLE
fix: implement MockRecordRef.ALWritePermission — closes #1441

### DIFF
--- a/AlRunner/Runtime/MockRecordRef.cs
+++ b/AlRunner/Runtime/MockRecordRef.cs
@@ -701,6 +701,15 @@ public class MockRecordRef
     /// </summary>
     public bool ALReadPermission => true;
 
+    // -- WritePermission — always true in standalone (no permission enforcement) --
+
+    /// <summary>
+    /// ALWritePermission — returns whether the current user has write permission on the table.
+    /// Standalone mode has no permission enforcement; always returns <c>true</c>.
+    /// BC compiler emits <c>recRef.ALWritePermission</c>.
+    /// </summary>
+    public bool ALWritePermission => true;
+
     // -- SetAutoCalcFields — no-op in standalone (CalcFields computed on demand) --
 
     /// <summary>

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -6442,6 +6442,9 @@ RecordRef.WritePermission ():
   layer: runtime-api
   category: RecordRef
   status: covered
+  tests:
+    - tests/bucket-1/record-table/311-recref-writepermission
+  notes: MockRecordRef.ALWritePermission always returns true in standalone (no permission system)
 
 # ── Report ──────────────────────────────────────────────────────
 

--- a/tests/bucket-1/record-table/311-recref-writepermission/src/RecRefWritePermHelper.al
+++ b/tests/bucket-1/record-table/311-recref-writepermission/src/RecRefWritePermHelper.al
@@ -1,0 +1,43 @@
+table 311001 "RecRef WritePerm Table"
+{
+    fields
+    {
+        field(1; "Entry No."; Integer) { }
+        field(2; "Description"; Text[100]) { }
+    }
+
+    keys
+    {
+        key(PK; "Entry No.") { }
+    }
+}
+
+codeunit 311002 "RecRef WritePerm Helper"
+{
+    procedure TestWritePermission(): Boolean
+    var
+        RecRef: RecordRef;
+    begin
+        RecRef.Open(Database::"RecRef WritePerm Table");
+        // WritePermission returns true in standalone mode (no permission enforcement)
+        exit(RecRef.WritePermission);
+    end;
+
+    procedure TestWritePermissionOnClosedRef(): Boolean
+    var
+        RecRef: RecordRef;
+    begin
+        // WritePermission on an unopen RecordRef; always true in standalone
+        exit(RecRef.WritePermission);
+    end;
+
+    procedure TestWritePermissionAfterClose(): Boolean
+    var
+        RecRef: RecordRef;
+    begin
+        RecRef.Open(Database::"RecRef WritePerm Table");
+        RecRef.Close();
+        // WritePermission after close; always true in standalone
+        exit(RecRef.WritePermission);
+    end;
+}

--- a/tests/bucket-1/record-table/311-recref-writepermission/test/RecRefWritePermTest.al
+++ b/tests/bucket-1/record-table/311-recref-writepermission/test/RecRefWritePermTest.al
@@ -1,0 +1,34 @@
+codeunit 311003 "RecRef WritePerm Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    [Test]
+    procedure WritePermission_OpenRef_ReturnsTrue()
+    // Proves WritePermission returns true (not a default false stub) when RecordRef is open
+    var
+        Helper: Codeunit "RecRef WritePerm Helper";
+    begin
+        Assert.IsTrue(Helper.TestWritePermission(), 'WritePermission should return true in standalone mode');
+    end;
+
+    [Test]
+    procedure WritePermission_ClosedRef_ReturnsTrue()
+    // Proves WritePermission returns true on a closed (uninitialized) RecordRef
+    var
+        Helper: Codeunit "RecRef WritePerm Helper";
+    begin
+        Assert.IsTrue(Helper.TestWritePermissionOnClosedRef(), 'WritePermission on closed RecordRef should return true');
+    end;
+
+    [Test]
+    procedure WritePermission_AfterClose_ReturnsTrue()
+    // Proves WritePermission returns true after the RecordRef is explicitly closed
+    var
+        Helper: Codeunit "RecRef WritePerm Helper";
+    begin
+        Assert.IsTrue(Helper.TestWritePermissionAfterClose(), 'WritePermission after Close() should return true');
+    end;
+}


### PR DESCRIPTION
Closes #1441

## Summary

- Add `ALWritePermission` property to `MockRecordRef` returning `true` (standalone mode has no permission enforcement, matching the existing `ALReadPermission` and `MockRecordHandle.ALWritePermission` patterns)
- New test suite `311-recref-writepermission` with 3 tests covering open RecordRef, closed (uninitialized) RecordRef, and post-`Close()` RecordRef
- Update `docs/coverage.yaml` with test reference and notes for `RecordRef.WritePermission ()`

## Test plan
- [x] RED: confirm CS1061 error before implementation
- [x] GREEN: all 3 new tests pass after implementation
- [x] Full bucket-1 (1777 passed, 1 pre-existing blocked) — no regressions
- [x] Full bucket-2 (2104 passed) — no regressions