### PR TITLE
fix: implement MockFieldRef.ALKeyIndex — closes #1434

### DIFF
--- a/AlRunner/Runtime/MockFieldRef.cs
+++ b/AlRunner/Runtime/MockFieldRef.cs
@@ -173,6 +173,22 @@ public class MockFieldRef
     /// <summary>ALRecord — returns the owning record ref. Stub for compile compat.</summary>
     public MockRecordRef ALRecord() => _owner ?? new MockRecordRef();
 
+    /// <summary>
+    /// ALKeyIndex — called when the BC transpiler lowers
+    /// <c>KeyRef := FldRef.Record().KeyIndex(n)</c> to
+    /// <c>KeyRef.ALAssign(FldRef.ALKeyIndex(compilationTarget, n))</c>.
+    /// Delegates to the owning RecordRef's KeyIndex implementation.
+    /// </summary>
+    public MockKeyRef ALKeyIndex(int index)
+        => (_owner ?? new MockRecordRef()).ALKeyIndex(index);
+
+    /// <summary>
+    /// ALKeyIndex with compilation-target argument — BC emits an extra object
+    /// parameter (the compilation target) before the index for chained calls.
+    /// </summary>
+    public MockKeyRef ALKeyIndex(object compilationTarget, int index)
+        => ALKeyIndex(index);
+
     /// <summary>ALValidate — set value and fire OnValidate trigger.</summary>
     public void ALValidate(NavValue value)
     {

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -2328,6 +2328,17 @@ FieldRef.Record ():
   category: FieldRef
   status: covered
 
+FieldRef.KeyIndex (Integer):
+  layer: runtime-api
+  category: FieldRef
+  status: covered
+  notes: >
+    The BC transpiler lowers `KeyRef := FldRef.Record().KeyIndex(n)` to
+    `KeyRef.ALAssign(FldRef.ALKeyIndex(compilationTarget, n))` — the `.Record()`
+    call is inlined and KeyIndex is called directly on MockFieldRef.
+    MockFieldRef.ALKeyIndex(int) and ALKeyIndex(object, int) delegate to the
+    owning MockRecordRef.ALKeyIndex. Issue #1434.
+
 FieldRef.Relation ():
   layer: runtime-api
   category: FieldRef

--- a/tests/bucket-1/record-table/1310-fieldref-record-keyindex/src/FrkSrc.al
+++ b/tests/bucket-1/record-table/1310-fieldref-record-keyindex/src/FrkSrc.al
@@ -1,0 +1,46 @@
+/// Helper codeunit exercising FldRef.Record().KeyIndex(n).
+/// The BC transpiler lowers this chain to FldRef.ALKeyIndex(compilationTarget, n)
+/// on the MockFieldRef — this codeunit proves that path works end-to-end.
+codeunit 1310002 "FRK Src"
+{
+    /// Returns KeyRef.FieldCount for the PK obtained via FldRef.Record().KeyIndex(1).
+    procedure GetKeyFieldCountViaFieldRef(): Integer
+    var
+        RecRef: RecordRef;
+        FldRef: FieldRef;
+        KRef: KeyRef;
+    begin
+        RecRef.Open(Database::"FRK Test Entry");
+        FldRef := RecRef.Field(1);
+        KRef := FldRef.Record().KeyIndex(1);
+        exit(KRef.FieldCount);
+    end;
+
+    /// Returns the field number of the Nth PK field (1-based) obtained via
+    /// FldRef.Record().KeyIndex(1).FieldIndex(fieldIdx).Number().
+    procedure GetPkFieldNoViaFieldRef(FieldIdx: Integer): Integer
+    var
+        RecRef: RecordRef;
+        FldRef: FieldRef;
+        KRef: KeyRef;
+        KFldRef: FieldRef;
+    begin
+        RecRef.Open(Database::"FRK Test Entry");
+        FldRef := RecRef.Field(1);
+        KRef := FldRef.Record().KeyIndex(1);
+        KFldRef := KRef.FieldIndex(FieldIdx);
+        exit(KFldRef.Number());
+    end;
+
+    /// Verifies that an out-of-range index raises an error.
+    procedure GetKeyIndexOutOfRange()
+    var
+        RecRef: RecordRef;
+        FldRef: FieldRef;
+        KRef: KeyRef;
+    begin
+        RecRef.Open(Database::"FRK Test Entry");
+        FldRef := RecRef.Field(1);
+        KRef := FldRef.Record().KeyIndex(99);
+    end;
+}

--- a/tests/bucket-1/record-table/1310-fieldref-record-keyindex/src/FrkTable.al
+++ b/tests/bucket-1/record-table/1310-fieldref-record-keyindex/src/FrkTable.al
@@ -1,0 +1,15 @@
+/// Table used by FieldRef.Record().KeyIndex tests.
+/// Two-field PK (Id, Code) so KeyRef.FieldCount = 2.
+table 1310001 "FRK Test Entry"
+{
+    fields
+    {
+        field(1; Id; Integer) { }
+        field(2; Code; Code[20]) { }
+        field(3; Description; Text[100]) { }
+    }
+    keys
+    {
+        key(PK; Id, Code) { Clustered = true; }
+    }
+}

--- a/tests/bucket-1/record-table/1310-fieldref-record-keyindex/test/FrkTests.al
+++ b/tests/bucket-1/record-table/1310-fieldref-record-keyindex/test/FrkTests.al
@@ -1,0 +1,59 @@
+/// Tests for FieldRef.Record().KeyIndex(n) — exercises MockFieldRef.ALKeyIndex.
+///
+/// The BC transpiler lowers  KeyRef := FldRef.Record().KeyIndex(1)
+/// to  KeyRef.ALAssign(FldRef.ALKeyIndex(compilationTarget, 1)).
+/// MockFieldRef must therefore expose ALKeyIndex delegating to its owning
+/// MockRecordRef.
+codeunit 1310003 "FRK Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "FRK Src";
+
+    // ── Positive: KeyRef.FieldCount via the FieldRef chain ──────────────
+
+    [Test]
+    procedure FieldRef_Record_KeyIndex_FieldCount()
+    begin
+        // [GIVEN] FRK Test Entry has a 2-field PK (Id, Code)
+        // [WHEN]  KRef := FldRef.Record().KeyIndex(1)
+        // [THEN]  KRef.FieldCount = 2
+        Assert.AreEqual(2, Src.GetKeyFieldCountViaFieldRef(),
+            'KeyRef.FieldCount via FldRef.Record().KeyIndex(1) must equal 2');
+    end;
+
+    // ── Positive: KeyRef.FieldIndex field numbers ────────────────────────
+
+    [Test]
+    procedure FieldRef_Record_KeyIndex_FirstPkField()
+    begin
+        // [GIVEN] PK = (Id field 1, Code field 2)
+        // [WHEN]  KRef.FieldIndex(1)
+        // [THEN]  field number = 1
+        Assert.AreEqual(1, Src.GetPkFieldNoViaFieldRef(1),
+            'First PK field accessed via FldRef chain must be field 1');
+    end;
+
+    [Test]
+    procedure FieldRef_Record_KeyIndex_SecondPkField()
+    begin
+        // [GIVEN] PK = (Id field 1, Code field 2)
+        // [WHEN]  KRef.FieldIndex(2)
+        // [THEN]  field number = 2
+        Assert.AreEqual(2, Src.GetPkFieldNoViaFieldRef(2),
+            'Second PK field accessed via FldRef chain must be field 2');
+    end;
+
+    // ── Negative: out-of-range key index ────────────────────────────────
+
+    [Test]
+    procedure FieldRef_Record_KeyIndex_OutOfRange_Throws()
+    begin
+        // [WHEN]  FldRef.Record().KeyIndex(99)
+        // [THEN]  error contains "out of range"
+        asserterror Src.GetKeyIndexOutOfRange();
+        Assert.ExpectedError('out of range');
+    end;
+}


### PR DESCRIPTION
Closes #1434

## Root cause

The BC transpiler lowers `KeyRef := FldRef.Record().KeyIndex(n)` to
`KeyRef.ALAssign(FldRef.ALKeyIndex(compilationTarget, n))` — it inlines the
`.Record()` chain and calls `ALKeyIndex` directly on the `MockFieldRef`.
This mirrors the existing pattern for `RecRef := FldRef.Record()` which
transpiles to `RecRef.ALAssign(FldRef)` (see `MockRecordRef.ALAssign(MockFieldRef)`).

`MockFieldRef` was missing `ALKeyIndex`, causing a CS1061 compilation gap.

## Fix

Add `ALKeyIndex(int)` and `ALKeyIndex(object, int)` overloads to `MockFieldRef`
that delegate to the owning `MockRecordRef.ALKeyIndex`.

## Tests

New suite `tests/bucket-1/record-table/1310-fieldref-record-keyindex/`:
- **Positive**: `FieldRef_Record_KeyIndex_FieldCount` — asserts `KRef.FieldCount = 2` (two-field PK)
- **Positive**: `FieldRef_Record_KeyIndex_FirstPkField` — asserts first PK field number = 1
- **Positive**: `FieldRef_Record_KeyIndex_SecondPkField` — asserts second PK field number = 2
- **Negative**: `FieldRef_Record_KeyIndex_OutOfRange_Throws` — asserts error "out of range" for index 99

All 4 new tests pass. Full suite: 1775 passed (bucket-1), 2104 passed (bucket-2).