### PR TITLE
fix: implement MockHttpClient.ALAssign — closes #1447

### DIFF
--- a/AlRunner/Runtime/MockHttpClient.cs
+++ b/AlRunner/Runtime/MockHttpClient.cs
@@ -139,4 +139,23 @@ public class MockHttpClient
 
     /// <summary>AddCertificate(thumbprint, password) — no-op stub.</summary>
     public void ALAddCertificate(DataError errorLevel, NavText thumbprint, NavText password) { }
+
+    // ── ALAssign (issue #1447) ─────────────────────────────────────────────
+
+    /// <summary>
+    /// ALAssign — copy all observable state from <paramref name="other"/> into this instance.
+    /// BC emits <c>target.ALAssign(source)</c> for the AL assignment <c>target := source</c>
+    /// and for the ByRef pattern <c>ByRef&lt;MockHttpClient&gt;(() =&gt; c, v =&gt; c.ALAssign(v))</c>
+    /// used when an HttpClient is passed by var (e.g. <c>var Client: HttpClient</c>).
+    /// Covers the 4 occurrences surfaced by issue #1447.
+    /// </summary>
+    public void ALAssign(MockHttpClient other)
+    {
+        if (other == null) return;
+        _baseAddress = other._baseAddress;
+        _defaultHeaders = other._defaultHeaders;
+        ALTimeout = other.ALTimeout;
+        ALUseDefaultNetworkWindowsAuthentication = other.ALUseDefaultNetworkWindowsAuthentication;
+        ALUseServerCertificateValidation = other.ALUseServerCertificateValidation;
+    }
 }

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -3034,6 +3034,12 @@ HttpClient.UseWindowsAuthentication (Text, Text, Text):
   category: HttpClient
   status: not-tested
 
+HttpClient.:= (ALAssign):
+  layer: runtime-api
+  category: HttpClient
+  status: covered
+  notes: ALAssign copies baseAddress, defaultHeaders, timeout, useDefaultNetworkWindowsAuthentication, useServerCertificateValidation — issue #1447
+
 # ── HttpContent ─────────────────────────────────────────────────
 
 HttpContent.Clear ():

--- a/tests/bucket-2/data-formats/311-httpclient-assign/src/HCA_Src.al
+++ b/tests/bucket-2/data-formats/311-httpclient-assign/src/HCA_Src.al
@@ -1,0 +1,66 @@
+/// Helper codeunit exercising HttpClient ALAssign (`:=` operator) — issue #1447.
+codeunit 311000 "HCA Src"
+{
+    // ConfigureAndAssign — sets base address on source, assigns to target via `:=`, returns target base address.
+    procedure ConfigureAndAssign(url: Text): Text
+    var
+        source: HttpClient;
+        target: HttpClient;
+    begin
+        source.SetBaseAddress(url);
+        target := source;
+        exit(target.GetBaseAddress());
+    end;
+
+    // AssignCopiesHeaders — adds a header to source, assigns, checks target has it.
+    procedure AssignCopiesHeaders(headerName: Text; headerValue: Text): Boolean
+    var
+        source: HttpClient;
+        target: HttpClient;
+        headers: HttpHeaders;
+    begin
+        source.DefaultRequestHeaders().Add(headerName, headerValue);
+        target := source;
+        headers := target.DefaultRequestHeaders();
+        exit(headers.Contains(headerName));
+    end;
+
+    // AssignedClientIsUsable — assign an empty client, verify GetBaseAddress still works.
+    procedure AssignedEmptyClientBaseAddress(): Text
+    var
+        source: HttpClient;
+        target: HttpClient;
+    begin
+        target := source;
+        exit(target.GetBaseAddress());
+    end;
+
+    // SelfAssign — assigning a var to itself must not throw and state is preserved.
+    procedure SelfAssign(url: Text): Text
+    var
+        client: HttpClient;
+    begin
+        client.SetBaseAddress(url);
+        client := client;
+        exit(client.GetBaseAddress());
+    end;
+
+    // ConfigureServerCertificateValidation — exact trigger pattern from issue #1447:
+    //   procedure ConfigureServerCertificateValidation(var Client: HttpClient)
+    procedure ConfigureServerCertificateValidation(var Client: HttpClient)
+    begin
+        Client.UseServerCertificateValidation(true);
+    end;
+
+    // AssignAndCallByVar — calls ConfigureServerCertificateValidation with an assigned client.
+    procedure AssignAndCallByVar(url: Text): Boolean
+    var
+        source: HttpClient;
+        target: HttpClient;
+    begin
+        source.SetBaseAddress(url);
+        target := source;
+        ConfigureServerCertificateValidation(target);
+        exit(true);
+    end;
+}

--- a/tests/bucket-2/data-formats/311-httpclient-assign/test/HCA_Test.al
+++ b/tests/bucket-2/data-formats/311-httpclient-assign/test/HCA_Test.al
@@ -1,0 +1,69 @@
+codeunit 311001 "HCA Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "HCA Src";
+
+    // ── Positive: assignment copies state ──────────────────────────────
+
+    [Test]
+    procedure HttpClient_Assign_CopiesBaseAddress()
+    begin
+        // Positive: source base address must appear on target after assignment
+        Assert.AreEqual('https://api.example.com',
+            Src.ConfigureAndAssign('https://api.example.com'),
+            'Target GetBaseAddress must equal source after := assignment');
+    end;
+
+    [Test]
+    procedure HttpClient_Assign_BaseAddress_IsDistinctForDifferentSources()
+    begin
+        // Strengthen: two different source URLs produce different results
+        Assert.AreNotEqual(
+            Src.ConfigureAndAssign('https://a.example.com'),
+            Src.ConfigureAndAssign('https://b.example.com'),
+            'Different source base URLs must not collide after assignment');
+    end;
+
+    [Test]
+    procedure HttpClient_Assign_CopiesDefaultRequestHeaders()
+    begin
+        // Positive: header added to source must be present on target after assignment
+        Assert.IsTrue(
+            Src.AssignCopiesHeaders('X-Test-Header', 'hello'),
+            'DefaultRequestHeaders from source must be accessible on target after assignment');
+    end;
+
+    [Test]
+    procedure HttpClient_Assign_EmptyClientBaseAddressIsEmpty()
+    begin
+        // Positive: assigning empty client gives empty base address on target
+        Assert.AreEqual('',
+            Src.AssignedEmptyClientBaseAddress(),
+            'Target GetBaseAddress must be empty when source was never configured');
+    end;
+
+    // ── Self-assign / stability ────────────────────────────────────────
+
+    [Test]
+    procedure HttpClient_SelfAssign_PreservesBaseAddress()
+    begin
+        // Negative-flavoured: self-assign must not corrupt state
+        Assert.AreEqual('https://self.example.com',
+            Src.SelfAssign('https://self.example.com'),
+            'Self-assignment must preserve the stored base address');
+    end;
+
+    // ── var-parameter (ConfigureServerCertificateValidation pattern) ───
+
+    [Test]
+    procedure HttpClient_AssignAndCallByVar_DoesNotThrow()
+    begin
+        // Exact trigger from issue #1447: assign then pass by var — must not throw
+        Assert.IsTrue(
+            Src.AssignAndCallByVar('https://api.example.com'),
+            'Assigning an HttpClient and passing the result by var must not throw');
+    end;
+}


### PR DESCRIPTION
Closes #1447

## Summary

- Adds `ALAssign(MockHttpClient other)` to `MockHttpClient` — the method BC emits for the AL `:=` operator on `HttpClient` variables and for the ByRef pattern used when passing `var Client: HttpClient` to a procedure.
- Copies all observable state: `_baseAddress`, `_defaultHeaders`, `ALTimeout`, `ALUseDefaultNetworkWindowsAuthentication`, `ALUseServerCertificateValidation`.
- Follows the same pattern as `MockHttpContent.ALAssign`, `MockNotification.ALAssign`, and other sibling mocks.

## Test suite added

`tests/bucket-2/data-formats/311-httpclient-assign/` — 6 proving tests:
- **Positive**: assign copies base address (specific non-default value), copies default-request headers, empty source gives empty base address.
- **Distinct values**: two different source URLs produce different results on target (prevents no-op mock passing).
- **Self-assign stability**: self-assignment preserves state.
- **var-parameter**: exact trigger from the issue (`ConfigureServerCertificateValidation(var Client: HttpClient)`) works after assignment.

## Coverage

`docs/coverage.yaml` updated with `HttpClient.:= (ALAssign): covered`.