### PR TITLE
fix: implement RecordRef.Insert(Boolean) and Insert(Boolean,Boolean) overloads — closes #1430

### DIFF
--- a/AlRunner/Runtime/MockRecordRef.cs
+++ b/AlRunner/Runtime/MockRecordRef.cs
@@ -383,6 +383,9 @@ public class MockRecordRef
     public bool Insert(bool runTrigger) => _handle != null && _handle.ALInsert(DataError.ThrowError, runTrigger);
     public bool ALInsert(DataError errorLevel) => _handle != null && _handle.ALInsert(errorLevel);
     public bool ALInsert(DataError errorLevel, bool runTrigger) => _handle != null && _handle.ALInsert(errorLevel, runTrigger);
+    /// <summary>BC emits ALInsert(DataError, RunTrigger, BelowXRec) for <c>RecordRef.Insert(RunTrigger, BelowXRec)</c>.
+    /// BelowXRec is no-op in standalone mode; RunTrigger is forwarded as usual.</summary>
+    public bool ALInsert(DataError errorLevel, bool runTrigger, bool belowXRec) => _handle != null && _handle.ALInsert(errorLevel, runTrigger);
 
     public bool Modify() => Modify(false);
     public bool Modify(bool runTrigger) => _handle != null && _handle.ALModify(DataError.ThrowError, runTrigger);

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -6253,12 +6253,14 @@ RecordRef.Insert ():
 RecordRef.Insert (Boolean, Boolean):
   layer: runtime-api
   category: RecordRef
-  status: not-tested
+  status: covered
+  notes: MockRecordRef.ALInsert(DataError, runTrigger, belowXRec) — BelowXRec is no-op in standalone; RunTrigger forwarded to MockRecordHandle. Tested in 312-recref-insert-overloads.
 
 RecordRef.Insert (Boolean):
   layer: runtime-api
   category: RecordRef
-  status: not-tested
+  status: covered
+  notes: MockRecordRef.ALInsert(DataError, runTrigger) — trigger-aware insert via RecordRef. Tested in 312-recref-insert-overloads.
 
 RecordRef.IsDirty ():
   layer: runtime-api

--- a/tests/bucket-1/record-table/312-recref-insert-overloads/src/RecRefInsertHelper.al
+++ b/tests/bucket-1/record-table/312-recref-insert-overloads/src/RecRefInsertHelper.al
@@ -1,0 +1,65 @@
+/// Table and helper for RecordRef.Insert(Boolean) and Insert(Boolean, Boolean) overload tests.
+table 312001 "RecRef Insert Row"
+{
+    DataClassification = CustomerContent;
+    fields
+    {
+        field(1; Id; Integer) { }
+        field(2; Marker; Text[50]) { }
+    }
+    keys
+    {
+        key(PK; Id) { Clustered = true; }
+    }
+
+    trigger OnInsert()
+    begin
+        Rec.Marker := 'triggered';
+    end;
+}
+
+/// Helper codeunit wrapping RecordRef.Insert overloads so AL compiles each form explicitly.
+codeunit 312002 "RecRef Insert Helper"
+{
+    /// RecordRef.Insert(Boolean) — 1-arg form; runTrigger controls whether OnInsert fires.
+    procedure InsertViaRecRefBool(Id: Integer; RunTrigger: Boolean)
+    var
+        Rec: Record "RecRef Insert Row";
+        RecRef: RecordRef;
+    begin
+        Rec.Init();
+        Rec.Id := Id;
+        RecRef.GetTable(Rec);
+        RecRef.Insert(RunTrigger);
+    end;
+
+    /// RecordRef.Insert(Boolean, Boolean) — 2-arg form; BelowXRec is accepted but no-op in standalone.
+    procedure InsertViaRecRefBoolBool(Id: Integer; RunTrigger: Boolean; BelowXRec: Boolean)
+    var
+        Rec: Record "RecRef Insert Row";
+        RecRef: RecordRef;
+    begin
+        Rec.Init();
+        Rec.Id := Id;
+        RecRef.GetTable(Rec);
+        RecRef.Insert(RunTrigger, BelowXRec);
+    end;
+
+    /// Read back the Marker field for a given Id.
+    procedure GetMarker(Id: Integer): Text[50]
+    var
+        Rec: Record "RecRef Insert Row";
+    begin
+        if Rec.Get(Id) then
+            exit(Rec.Marker);
+        exit('');
+    end;
+
+    /// Return whether a record with the given Id exists.
+    procedure RecordExists(Id: Integer): Boolean
+    var
+        Rec: Record "RecRef Insert Row";
+    begin
+        exit(Rec.Get(Id));
+    end;
+}

--- a/tests/bucket-1/record-table/312-recref-insert-overloads/test/RecRefInsertTest.al
+++ b/tests/bucket-1/record-table/312-recref-insert-overloads/test/RecRefInsertTest.al
@@ -1,0 +1,63 @@
+codeunit 312003 "RecRef Insert Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    // -------------------------------------------------------------------------
+    // RecordRef.Insert(Boolean) — 1-arg overload
+    // -------------------------------------------------------------------------
+
+    [Test]
+    procedure RecRefInsert_Bool_TriggerTrue_RecordExistsAndMarkerSet()
+    // Proves Insert(true) persists the record and fires OnInsert (which sets Marker).
+    var
+        Helper: Codeunit "RecRef Insert Helper";
+    begin
+        Helper.InsertViaRecRefBool(1, true);
+
+        Assert.IsTrue(Helper.RecordExists(1), 'Record should exist after RecordRef.Insert(true)');
+        Assert.AreEqual('triggered', Helper.GetMarker(1), 'OnInsert should have set Marker to ''triggered''');
+    end;
+
+    [Test]
+    procedure RecRefInsert_Bool_TriggerFalse_RecordExistsMarkerBlank()
+    // Proves Insert(false) persists the record but skips OnInsert (Marker stays blank).
+    var
+        Helper: Codeunit "RecRef Insert Helper";
+    begin
+        Helper.InsertViaRecRefBool(2, false);
+
+        Assert.IsTrue(Helper.RecordExists(2), 'Record should exist after RecordRef.Insert(false)');
+        Assert.AreEqual('', Helper.GetMarker(2), 'OnInsert must NOT fire when RunTrigger=false');
+    end;
+
+    // -------------------------------------------------------------------------
+    // RecordRef.Insert(Boolean, Boolean) — 2-arg overload
+    // -------------------------------------------------------------------------
+
+    [Test]
+    procedure RecRefInsert_BoolBool_TriggerTrue_RecordExistsAndMarkerSet()
+    // Proves Insert(true, false) compiles and persists the record, firing OnInsert.
+    var
+        Helper: Codeunit "RecRef Insert Helper";
+    begin
+        Helper.InsertViaRecRefBoolBool(3, true, false);
+
+        Assert.IsTrue(Helper.RecordExists(3), 'Record should exist after RecordRef.Insert(true, false)');
+        Assert.AreEqual('triggered', Helper.GetMarker(3), 'OnInsert should have set Marker to ''triggered'' with Insert(true,false)');
+    end;
+
+    [Test]
+    procedure RecRefInsert_BoolBool_TriggerFalse_RecordExistsMarkerBlank()
+    // Proves Insert(false, true) compiles and skips OnInsert.
+    var
+        Helper: Codeunit "RecRef Insert Helper";
+    begin
+        Helper.InsertViaRecRefBoolBool(4, false, true);
+
+        Assert.IsTrue(Helper.RecordExists(4), 'Record should exist after RecordRef.Insert(false, true)');
+        Assert.AreEqual('', Helper.GetMarker(4), 'OnInsert must NOT fire when RunTrigger=false in Insert(false,true)');
+    end;
+}


### PR DESCRIPTION
Closes #1430

## Summary

- Added `ALInsert(DataError, bool runTrigger, bool belowXRec)` to `MockRecordRef`, delegating to `MockRecordHandle.ALInsert(errorLevel, runTrigger)` — `BelowXRec` is no-op in standalone mode (no physical record ordering).
- Added tests for both the 1-arg `Insert(Boolean)` and 2-arg `Insert(Boolean, Boolean)` `RecordRef` overloads in new suite `312-recref-insert-overloads`.
- Updated `docs/coverage.yaml`: both `RecordRef.Insert (Boolean)` and `RecordRef.Insert (Boolean, Boolean)` are now `covered`.

## Test plan

- [x] RED: `dotnet run -- tests/.../312-recref-insert-overloads/src .../test` → `CS1501: No overload for method 'ALInsert' takes 3 arguments`
- [x] GREEN: same run after fix → `4 passed`
- [x] Full bucket-1: `1785 passed, 1 blocked` (no regressions)
- [x] Full bucket-2: `2110 passed` (no regressions)
- [x] bucket-feature-niw: `4 passed` (no regressions)