### PR TITLE
fix: implement ALFieldError 0-arg overload — closes #1428

### DIFF
--- a/AlRunner/Runtime/MockFieldRef.cs
+++ b/AlRunner/Runtime/MockFieldRef.cs
@@ -383,6 +383,27 @@ public class MockFieldRef
         _calcSumResult = NavDecimal.Create(new Decimal18(sum));
     }
 
+    /// <summary>
+    /// ALFieldError() — 0-arg overload: BC FieldRef.FieldError() with no arguments.
+    /// Produces the same error format as the Record.FieldError() default:
+    /// "&lt;FieldCaption&gt; must have a value in &lt;TableCaption&gt;: &lt;PK&gt;."
+    /// Delegates to MockRecordHandle.ALFieldError when an owner record is available.
+    /// </summary>
+    public void ALFieldError()
+    {
+        if (_owner?.Handle != null)
+        {
+            _owner.Handle.ALFieldError(_fieldNo);
+            return;
+        }
+        // Fallback when not bound to a record (e.g. standalone FieldRef).
+        var caption = (_owner != null
+            ? TableFieldRegistry.GetFieldCaption(_owner.Number, _fieldNo)
+              ?? TableFieldRegistry.GetFieldName(_owner.Number, _fieldNo)
+            : null) ?? $"Field{_fieldNo}";
+        throw new Exception($"{caption} must have a value");
+    }
+
     /// <summary>ALFieldError — throws a field-level error.</summary>
     public void ALFieldError(string message)
     {

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -2223,6 +2223,12 @@ FieldRef.EnumValueCount ():
   status: covered
   notes: . Covered: returns member count for enum fields; returns 0 for non-enum fields.
 
+FieldRef.FieldError ():
+  layer: runtime-api
+  category: FieldRef
+  status: covered
+  notes: 0-arg overload — delegates to MockRecordHandle.ALFieldError(fieldNo) producing "<FieldCaption> must have a value in <TableCaption>: <PK>" format. Closes #1428.
+
 FieldRef.FieldError (ErrorInfo):
   layer: runtime-api
   category: FieldRef

--- a/tests/bucket-1/record-table/1311-fieldref-fielderror-0arg/src/FieldRefFe0Table.al
+++ b/tests/bucket-1/record-table/1311-fieldref-fielderror-0arg/src/FieldRefFe0Table.al
@@ -1,0 +1,55 @@
+/// Table for testing FieldRef.FieldError() with 0 args (issue #1428).
+table 1311001 "FieldRef FE0 Table"
+{
+    DataClassification = SystemMetadata;
+
+    fields
+    {
+        field(1; "Code"; Code[10])
+        {
+            Caption = 'Code';
+        }
+        field(2; "Description"; Text[100])
+        {
+            Caption = 'Description';
+        }
+    }
+
+    keys
+    {
+        key(PK; "Code")
+        {
+            Clustered = true;
+        }
+    }
+}
+
+codeunit 1311002 "FieldRef FE0 Helper"
+{
+    /// <summary>
+    /// Calls FieldRef.FieldError() with NO arguments via RecordRef/FieldRef
+    /// on field 2 (Description) of the given record's key value.
+    /// </summary>
+    procedure CallFieldErrorNoArgs(KeyCode: Code[10])
+    var
+        RecRef: RecordRef;
+        FldRef: FieldRef;
+    begin
+        RecRef.Open(Database::"FieldRef FE0 Table");
+        FldRef := RecRef.Field(2);
+        FldRef.FieldError();
+    end;
+
+    /// <summary>
+    /// Calls FieldRef.FieldError(Text) with ONE argument for comparison.
+    /// </summary>
+    procedure CallFieldErrorOneArg(KeyCode: Code[10]; Msg: Text)
+    var
+        RecRef: RecordRef;
+        FldRef: FieldRef;
+    begin
+        RecRef.Open(Database::"FieldRef FE0 Table");
+        FldRef := RecRef.Field(2);
+        FldRef.FieldError(Msg);
+    end;
+}

--- a/tests/bucket-1/record-table/1311-fieldref-fielderror-0arg/test/FieldRefFe0Test.al
+++ b/tests/bucket-1/record-table/1311-fieldref-fielderror-0arg/test/FieldRefFe0Test.al
@@ -1,0 +1,42 @@
+/// Tests for FieldRef.FieldError() 0-arg overload — issue #1428.
+codeunit 1311001 "FieldRef FE0 Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit "Library Assert";
+        Helper: Codeunit "FieldRef FE0 Helper";
+
+    // ── FieldRef.FieldError() — 0 args ───────────────────────────────────────
+
+    [Test]
+    procedure FieldError_0Arg_RaisesError()
+    begin
+        // [GIVEN] A RecordRef/FieldRef for field 2 (Description)
+        // [WHEN] FieldRef.FieldError() is called with NO arguments
+        asserterror Helper.CallFieldErrorNoArgs('X');
+        // [THEN] An error is raised (no crash / CS1501 compile error)
+        // The error text must contain the field caption 'Description'
+        Assert.ExpectedError('Description');
+    end;
+
+    [Test]
+    procedure FieldError_0Arg_ContainsDefaultMessage()
+    begin
+        // [GIVEN] A RecordRef/FieldRef for field 2 (Description)
+        // [WHEN] FieldRef.FieldError() is called with NO arguments
+        asserterror Helper.CallFieldErrorNoArgs('X');
+        // [THEN] The error contains the default "must have a value" fragment
+        Assert.ExpectedError('must have a value');
+    end;
+
+    [Test]
+    procedure FieldError_1Arg_CustomMessage_StillWorks()
+    begin
+        // [GIVEN] A RecordRef/FieldRef for field 2 (Description)
+        // [WHEN] FieldRef.FieldError('custom error') is called
+        asserterror Helper.CallFieldErrorOneArg('X', 'custom error text');
+        // [THEN] The error contains the custom message — existing overload unbroken
+        Assert.ExpectedError('custom error text');
+    end;
+}


### PR DESCRIPTION
Closes #1428

Adds a 0-arg overload for `MockFieldRef.ALFieldError()` so that AL code calling `FieldRef.FieldError()` with no arguments compiles and runs correctly in al-runner.

## Changes
- `AlRunner/Runtime/MockFieldRef.cs`: add `ALFieldError()` (0-arg) that delegates to `MockRecordHandle.ALFieldError(fieldNo)` when bound to a record, producing the standard BC error format `"<FieldCaption> must have a value in <TableCaption>: <PK>"`.
- `tests/bucket-1/record-table/1311-fieldref-fielderror-0arg/`: new test suite with 3 tests proving: error is raised, error contains "must have a value", and the existing 1-arg overload still works.
- `docs/coverage.yaml`: adds `FieldRef.FieldError ()` entry with status `covered`.