### PR TITLE
fix: implement MockPartFormHandle.PageCaption — closes #1440

### DIFF
--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -922,8 +922,12 @@ protected bool CallGetAutoFormatStringExtensionMethod(int fieldNo, ref string re
 protected void EnsureGlobalVariablesInitialized() {{ }}
 // BC emits CurrPage.SubPart.Page.SomeProcedure() as
 // CurrPage.GetPart(partHash).CreateNavFormHandle(scope).Invoke(methodHash, args).
-// Returns a MockPagePartHandle that dispatches the call to the subpage class.
-public MockPagePartHandle GetPart(int partHash) {{ return new MockPagePartHandle(partHash); }}
+// Returns a cached MockPagePartHandle so that state (e.g. PageCaption) set in one
+// BC statement is visible when the same part handle is read in the next statement.
+// _partHandles is initialised lazily to survive GetUninitializedObject construction.
+// Issue #1440.
+private System.Collections.Generic.Dictionary<int, MockPagePartHandle>? _partHandles;
+public MockPagePartHandle GetPart(int partHash) {{ _partHandles ??= new(); if (!_partHandles.TryGetValue(partHash, out var handle)) {{ handle = new MockPagePartHandle(partHash); _partHandles[partHash] = handle; }} return handle; }}
 // RunModal() — dispatches to ModalPageHandler if registered, otherwise no-op.
 // BC generates CurrPage.RunModal() as a call on the Page<N> class directly (issue #1079).
 public FormResult RunModal() {{ return HandlerRegistry.InvokeModalPageHandler({pageIdStr}); }}

--- a/AlRunner/Runtime/MockPagePartHandle.cs
+++ b/AlRunner/Runtime/MockPagePartHandle.cs
@@ -18,6 +18,7 @@ namespace AlRunner.Runtime;
 public class MockPagePartHandle
 {
     private readonly int _partHash;
+    private MockPartFormHandle? _cachedHandle;
 
     public MockPagePartHandle(int partHash)
     {
@@ -26,13 +27,16 @@ public class MockPagePartHandle
 
     /// <summary>
     /// BC calls this to obtain a form handle from the part.
-    /// Returns a <see cref="MockPartFormHandle"/> that can invoke methods
-    /// on the subpage by searching all Page* classes in the assembly.
+    /// Returns a cached <see cref="MockPartFormHandle"/> so that state written
+    /// in one BC statement (e.g. <c>CurrPage.SubPart.Page.Caption := X</c>)
+    /// is visible when the same part handle is read in the next statement
+    /// (e.g. <c>exit(CurrPage.SubPart.Page.Caption)</c>).
     /// The <paramref name="scope"/> argument (the calling scope object) is unused
     /// in standalone mode — no real page lifecycle runs.
+    /// Issue #1440.
     /// </summary>
     public MockPartFormHandle CreateNavFormHandle(object? scope)
-        => new MockPartFormHandle(_partHash);
+        => _cachedHandle ??= new MockPartFormHandle(_partHash);
 }
 
 /// <summary>
@@ -83,6 +87,13 @@ public class MockPartFormHandle
     /// Issue #1186.
     /// </summary>
     public void Update(bool saveRecord = true) { }
+
+    /// <summary>
+    /// Stub property. BC emits <c>CurrPage.SubPart.Page.Caption</c> get/set as
+    /// <c>CurrPage.GetPart(hash).CreateNavFormHandle(scope).PageCaption</c>.
+    /// Issue #1440.
+    /// </summary>
+    public string PageCaption { get; set; } = "";
 
     /// <summary>
     /// Invokes a procedure on the subpage identified by its method hash.

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -5628,6 +5628,16 @@ Page.Caption (Text):
   category: Page
   status: covered
 
+Page.Caption (subpage part handle):
+  layer: runtime-api
+  category: Page
+  status: covered
+  notes: >
+    MockPartFormHandle.PageCaption get/set stub; also fixed MockPagePartHandle.CreateNavFormHandle
+    to return a cached handle instance so that set-then-get round-trips work correctly.
+    GetPart() on the generated Page<N> class now caches MockPagePartHandle by hash.
+    Closes #1440.
+
 Page.Close ():
   layer: runtime-api
   category: Page

--- a/tests/bucket-2/page-report/311700-partformhandle-pagecaption/src/PfhCaptionSrc.al
+++ b/tests/bucket-2/page-report/311700-partformhandle-pagecaption/src/PfhCaptionSrc.al
@@ -1,0 +1,66 @@
+/// Source objects for MockPartFormHandle.PageCaption tests (issue #1440).
+
+table 311700 "PFH Caption Record"
+{
+    DataClassification = ToBeClassified;
+    fields
+    {
+        field(1; Id; Integer) { DataClassification = ToBeClassified; }
+    }
+    keys
+    {
+        key(PK; Id) { Clustered = true; }
+    }
+}
+
+/// ListPart subpage used to test PageCaption on the part form handle.
+page 311700 "PFH Caption Sub Page"
+{
+    PageType = ListPart;
+    Caption = 'My Sub Page Caption';
+    SourceTable = "PFH Caption Record";
+
+    layout
+    {
+        area(Content)
+        {
+            repeater(Lines)
+            {
+                field(Id; Rec.Id) { ApplicationArea = All; }
+            }
+        }
+    }
+}
+
+/// Card page that hosts the subpage and exposes PageCaption get/set on the part.
+page 311701 "PFH Caption Card Page"
+{
+    PageType = Card;
+
+    layout
+    {
+        area(Content)
+        {
+            part(SubPart; "PFH Caption Sub Page") { ApplicationArea = All; }
+        }
+    }
+
+    /// Gets CurrPage.SubPart.Page.Caption — exercises the PageCaption getter.
+    procedure GetPartCaption(): Text
+    begin
+        exit(CurrPage.SubPart.Page.Caption);
+    end;
+
+    /// Sets CurrPage.SubPart.Page.Caption := NewCaption — exercises the PageCaption setter.
+    procedure SetPartCaption(NewCaption: Text)
+    begin
+        CurrPage.SubPart.Page.Caption := NewCaption;
+    end;
+
+    /// Round-trip: sets Caption then reads it back.
+    procedure SetThenGetPartCaption(NewCaption: Text): Text
+    begin
+        CurrPage.SubPart.Page.Caption := NewCaption;
+        exit(CurrPage.SubPart.Page.Caption);
+    end;
+}

--- a/tests/bucket-2/page-report/311700-partformhandle-pagecaption/test/PfhCaptionTest.al
+++ b/tests/bucket-2/page-report/311700-partformhandle-pagecaption/test/PfhCaptionTest.al
@@ -1,0 +1,67 @@
+/// Tests for MockPartFormHandle.PageCaption (issue #1440).
+codeunit 311702 "PFH Caption Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    /// Positive: PageCaption getter must return a non-null string without throwing.
+    /// A missing PageCaption property would cause CS1061 at Roslyn compile time,
+    /// preventing the test codeunit from loading at all.
+    [Test]
+    procedure PartPageCaption_Get_NoThrow()
+    var
+        CardPage: Page "PFH Caption Card Page";
+        Result: Text;
+    begin
+        // WHEN the card page getter that reads CurrPage.SubPart.Page.Caption is called
+        // THEN it must compile and return without throwing
+        Result := CardPage.GetPartCaption();
+        Assert.IsTrue(true, 'CurrPage.SubPart.Page.Caption (get) must not throw');
+    end;
+
+    /// Positive: PageCaption setter must accept a value without throwing.
+    /// A missing PageCaption setter would cause CS1061 at Roslyn compile time.
+    [Test]
+    procedure PartPageCaption_Set_NoThrow()
+    var
+        CardPage: Page "PFH Caption Card Page";
+    begin
+        // WHEN the card page setter that writes CurrPage.SubPart.Page.Caption is called
+        // THEN it must compile and not throw
+        CardPage.SetPartCaption('My Caption');
+        Assert.IsTrue(true, 'CurrPage.SubPart.Page.Caption (set) must not throw');
+    end;
+
+    /// Positive (proving): set then get must return the assigned value.
+    /// A no-op getter that always returns '' would fail this test.
+    [Test]
+    procedure PartPageCaption_SetThenGet_ReturnsAssignedValue()
+    var
+        CardPage: Page "PFH Caption Card Page";
+        Result: Text;
+    begin
+        // WHEN a specific caption is assigned via the part handle
+        // THEN reading it back must return that exact value — not empty or a default
+        Result := CardPage.SetThenGetPartCaption('Expected Caption Value');
+        Assert.AreEqual('Expected Caption Value', Result, 'PageCaption round-trip must return the assigned value');
+    end;
+
+    /// Positive (proving): distinct values must be distinguishable.
+    /// Two successive sets with different captions must both be observable.
+    [Test]
+    procedure PartPageCaption_SetTwice_ReturnsSecondValue()
+    var
+        CardPage: Page "PFH Caption Card Page";
+        First: Text;
+        Second: Text;
+    begin
+        // WHEN caption is set to two different values in sequence
+        // THEN each read must return the value that was last set
+        First := CardPage.SetThenGetPartCaption('Caption One');
+        Second := CardPage.SetThenGetPartCaption('Caption Two');
+        Assert.AreEqual('Caption One', First, 'First SetThenGet must return Caption One');
+        Assert.AreEqual('Caption Two', Second, 'Second SetThenGet must return Caption Two');
+    end;
+}


### PR DESCRIPTION
Closes #1440

## Summary

- Add `PageCaption { get; set; }` stub to `MockPartFormHandle` so that `CurrPage.SubPart.Page.Caption` get/set compiles (fixes `CS1061`).
- Cache the `MockPartFormHandle` instance inside `MockPagePartHandle.CreateNavFormHandle` (via `??=`) so that set-then-get round-trips on the same part handle work correctly within a single AL procedure.
- Cache `MockPagePartHandle` by hash in the generated `GetPart()` method (`RoslynRewriter.cs`) using lazy initialisation (survives `GetUninitializedObject` construction).
- New AL test suite `bucket-2/page-report/311700-partformhandle-pagecaption` with 4 proving tests: get no-throw, set no-throw, set-then-get round-trip (`Assert.AreEqual`), and two-value distinguishability check.