### PR TITLE
fix: implement Report.Run 2-arg (StaticRun 2-arg) — closes #1427

### DIFF
--- a/AlRunner/Runtime/MockReportHandle.cs
+++ b/AlRunner/Runtime/MockReportHandle.cs
@@ -333,8 +333,21 @@ public class MockReportHandle
     }
 
     /// <summary>
+    /// Static Report.Run(reportId, requestPage) — 2-argument overload.
+    /// BC emits this form for <c>Report.Run(id, true)</c> when only the request-page flag
+    /// is supplied and <c>systemPrinter</c> is omitted.
+    /// <paramref name="requestPage"/> is ignored in standalone mode.
+    /// Fixes CS1501 'StaticRun' (2 args) — issue #1427.
+    /// </summary>
+    public static void StaticRun(int reportId, bool requestPage)
+    {
+        var handle = new MockReportHandle(reportId) { UseRequestForm = requestPage };
+        handle.Run();
+    }
+
+    /// <summary>
     /// Static Report.Run(reportId, requestPage, systemPrinter) — 3-argument overload.
-    /// BC emits this form when no record argument is supplied (e.g. <c>Report.Run(id, true)</c>).
+    /// BC emits this form when no record argument is supplied (e.g. <c>Report.Run(id, true, false)</c>).
     /// <paramref name="requestPage"/> and <paramref name="systemPrinter"/> are ignored in standalone mode.
     /// </summary>
     public static void StaticRun(int reportId, bool requestPage, bool systemPrinter)

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -6530,6 +6530,14 @@ Report.RdlcLayout (Integer, InStream):
     - tests/bucket-2/page-report/90-report-static
   notes: NavReport.RdlcLayout → MockReportHandle.StaticRdlcLayout (returns 0).
 
+Report.Run (Integer, Boolean):
+  layer: runtime-api
+  category: Report
+  status: covered
+  tests:
+    - tests/bucket-2/page-report/310200-report-run-2arg
+  notes: "Report.Run(ReportId, RequestPage) — 2-arg overload. BC emits this when systemPrinter is omitted. Fixes CS1501 'StaticRun' (2 args) — issue #1427."
+
 Report.Run (Integer, Boolean, Boolean, Table):
   layer: runtime-api
   category: Report

--- a/tests/bucket-2/page-report/310200-report-run-2arg/src/src.al
+++ b/tests/bucket-2/page-report/310200-report-run-2arg/src/src.al
@@ -1,0 +1,35 @@
+/// Source objects for Report.Run 2-arg overload test (issue #1427).
+/// BC emits Report.Run(ReportId, RequestPage) — two arguments, no SystemPrinter.
+report 310200 "RR2 Report"
+{
+    dataset
+    {
+        dataitem(DataLine; "RR2 Table")
+        {
+        }
+    }
+}
+
+table 310200 "RR2 Table"
+{
+    fields
+    {
+        field(1; "No."; Code[20]) { }
+        field(2; Value; Integer) { }
+    }
+    keys { key(PK; "No.") { Clustered = true; } }
+}
+
+/// Exercises Report.Run with 2 arguments: (ReportId, RequestPage)
+codeunit 310201 "RR2 Source"
+{
+    procedure CallRunTwoArgs(ReportId: Integer)
+    begin
+        Report.Run(ReportId, false);
+    end;
+
+    procedure CallRunTwoArgsRequestPageTrue(ReportId: Integer)
+    begin
+        Report.Run(ReportId, true);
+    end;
+}

--- a/tests/bucket-2/page-report/310200-report-run-2arg/test/test.al
+++ b/tests/bucket-2/page-report/310200-report-run-2arg/test/test.al
@@ -1,0 +1,31 @@
+codeunit 310202 "RR2 Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "RR2 Source";
+
+    // ------------------------------------------------------------------
+    // Report.Run(ReportId, RequestPage) — 2-arg overload
+    // Issue #1427: CS1501 'StaticRun' (2 args) no overload
+    // ------------------------------------------------------------------
+
+    [Test]
+    procedure ReportRun_TwoArgs_RequestPageFalse_NoError()
+    begin
+        // [GIVEN] A report ID
+        // [WHEN]  Report.Run(id, false) is called — 2-arg overload
+        // [THEN]  No error — must compile and execute without crashing
+        Src.CallRunTwoArgs(310200);
+    end;
+
+    [Test]
+    procedure ReportRun_TwoArgs_RequestPageTrue_NoError()
+    begin
+        // [GIVEN] A report ID
+        // [WHEN]  Report.Run(id, true) — requestPage=true, still no-op in standalone mode
+        // [THEN]  No error
+        Src.CallRunTwoArgsRequestPageTrue(310200);
+    end;
+}


### PR DESCRIPTION
Closes #1427

Add `MockReportHandle.StaticRun(int reportId, bool requestPage)` 2-arg overload.

BC emits `Report.Run(ObjectId, true)` as `NavReport.Run(id, bool)` with 2 arguments. The rewriter maps this to `MockReportHandle.StaticRun(...)`, but only 1-arg and 3-arg overloads existed — causing `CS1501: No overload for method 'StaticRun' takes 2 arguments`.

The new overload delegates to the existing `Run()` path with `UseRequestForm = requestPage`, matching the 3-arg behaviour without the unused `systemPrinter` parameter.