### PR TITLE
fix: implement ALTruncate 2-arg overload — closes #1431

### DIFF
--- a/AlRunner/Runtime/MockRecordHandle.cs
+++ b/AlRunner/Runtime/MockRecordHandle.cs
@@ -3727,6 +3727,9 @@ public class MockRecordHandle : IConvertible
     /// </summary>
     public void ALTruncate() => ALDeleteAll(DataError.ThrowError, false);
     public void ALTruncate(DataError errorLevel) => ALDeleteAll(errorLevel, false);
+    /// <summary>ALTruncate(DataError, bool raiseTrigger) — 2-arg overload emitted by the BC compiler
+    /// when AL calls Truncate(RaiseTrigger: Boolean). Delegates to DeleteAll with the given trigger flag.</summary>
+    public void ALTruncate(DataError errorLevel, bool raiseTrigger) => ALDeleteAll(errorLevel, raiseTrigger);
 
     /// <summary>
     /// AL Relation — returns the table number that the field relates to via TableRelation.

--- a/AlRunner/Runtime/MockRecordRef.cs
+++ b/AlRunner/Runtime/MockRecordRef.cs
@@ -169,6 +169,8 @@ public class MockRecordRef
     /// <summary>ALTruncate — removes all records from the table without running triggers.</summary>
     public void ALTruncate() => _handle?.ALDeleteAll(DataError.ThrowError, false);
     public void ALTruncate(DataError errorLevel) => _handle?.ALDeleteAll(errorLevel, false);
+    /// <summary>ALTruncate(DataError, bool raiseTrigger) — 2-arg overload for RecordRef.Truncate(RaiseTrigger).</summary>
+    public void ALTruncate(DataError errorLevel, bool raiseTrigger) => _handle?.ALDeleteAll(errorLevel, raiseTrigger);
 
     // -- Caption --
 

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -6461,7 +6461,9 @@ RecordRef.Truncate (Boolean):
   layer: runtime-api
   category: RecordRef
   status: covered
-  notes: MockRecordRef.ALTruncate delegates to ALDeleteAll without triggers
+  tests:
+    - tests/bucket-1/record-table/92-recordref-stub-methods
+  notes: MockRecordRef.ALTruncate (0/1/2-arg) delegates to ALDeleteAll; 2-arg overload (DataError, bool raiseTrigger) added in #1431
 
 RecordRef.WritePermission ():
   layer: runtime-api
@@ -8511,7 +8513,9 @@ Table.Truncate (Boolean):
   layer: runtime-api
   category: Table
   status: covered
-  notes: . Deletes all rows without triggers (delegates to DeleteAll(false)).
+  tests:
+    - tests/bucket-1/record-table/205-table-extra-methods
+  notes: MockRecordHandle.ALTruncate (0/1/2-arg). 2-arg overload (DataError, bool raiseTrigger) added in #1431; delegates to DeleteAll(errorLevel, raiseTrigger).
 
 Table.Validate (Joker, Joker):
   layer: runtime-api

--- a/tests/bucket-1/record-table/205-table-extra-methods/src/TrmSrc.al
+++ b/tests/bucket-1/record-table/205-table-extra-methods/src/TrmSrc.al
@@ -75,6 +75,16 @@ codeunit 97701 "TRM Src"
         exit(Rec.Count());
     end;
 
+    procedure InsertAndTruncateWithTrigger(var Rec: Record "TRM Table"; RaiseTrigger: Boolean): Integer
+    begin
+        Rec."No." := 'C';
+        Rec.Insert();
+        Rec."No." := 'D';
+        Rec.Insert();
+        Rec.Truncate(RaiseTrigger);
+        exit(Rec.Count());
+    end;
+
     // ── Relation ──────────────────────────────────────────────────────────────
 
     procedure GetRelation(var Rec: Record "TRM Table"): Integer

--- a/tests/bucket-1/record-table/205-table-extra-methods/test/TrmTest.al
+++ b/tests/bucket-1/record-table/205-table-extra-methods/test/TrmTest.al
@@ -121,6 +121,28 @@ codeunit 97702 "TRM Test"
         Assert.AreEqual(0, CountAfter, 'Truncate must delete all rows');
     end;
 
+    [Test]
+    procedure Truncate_WithTriggerFalse_DeletesAllRows()
+    var
+        Rec: Record "TRM Table";
+        CountAfter: Integer;
+    begin
+        // Truncate(false) — 2-arg overload must compile and delete all rows
+        CountAfter := H.InsertAndTruncateWithTrigger(Rec, false);
+        Assert.AreEqual(0, CountAfter, 'Truncate(false) must delete all rows');
+    end;
+
+    [Test]
+    procedure Truncate_WithTriggerTrue_DeletesAllRows()
+    var
+        Rec: Record "TRM Table";
+        CountAfter: Integer;
+    begin
+        // Truncate(true) — 2-arg overload must compile and delete all rows
+        CountAfter := H.InsertAndTruncateWithTrigger(Rec, true);
+        Assert.AreEqual(0, CountAfter, 'Truncate(true) must delete all rows');
+    end;
+
     // ── Relation ──────────────────────────────────────────────────────────────
 
     [Test]


### PR DESCRIPTION
## Summary

- Added `ALTruncate(DataError errorLevel, bool raiseTrigger)` 2-arg overload to `MockRecordHandle` and `MockRecordRef`
- Matches the BC compiler output for `Record.Truncate(RaiseTrigger: Boolean)` and `RecordRef.Truncate(RaiseTrigger: Boolean)`
- Delegates to `ALDeleteAll(errorLevel, raiseTrigger)` for correct behavior

## Test plan

- [x] RED: confirmed `CS1501: No overload for method 'ALTruncate' takes 2 arguments` before fix
- [x] GREEN: `Truncate_WithTriggerFalse_DeletesAllRows` and `Truncate_WithTriggerTrue_DeletesAllRows` both pass
- [x] Full bucket-1 (1790 passed, 1 pre-existing blocked) and bucket-2 (2110 passed) pass clean

Closes #1431