### PR TITLE
fix: implement ALStopSession 3-arg overload — closes #1443

### DIFF
--- a/AlRunner/Runtime/MockSession.cs
+++ b/AlRunner/Runtime/MockSession.cs
@@ -155,6 +155,16 @@ public static class MockSession
     }
 
     /// <summary>
+    /// StopSession with comment — no-op (session already completed synchronously).
+    /// Maps to the AL <c>StopSession(SessionId, Comment)</c> 2-arg overload.
+    /// The comment parameter is accepted but ignored in standalone mode.
+    /// </summary>
+    public static void ALStopSession(DataError errorLevel, int sessionId, string comment)
+    {
+        // No-op: session already completed synchronously; comment is ignored.
+    }
+
+    /// <summary>
     /// Sleep — no-op in standalone mode.
     /// Replaces NavSession.Sleep(int milliseconds).
     /// </summary>

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -7098,6 +7098,9 @@ Session.StopSession (Integer, Text):
   layer: runtime-api
   category: Session
   status: covered
+  tests:
+    - tests/bucket-1/codeunit-runtime/311443-stopsession-comment
+  notes: . closes #1443. comment param ignored — single-process runner.
 
 Session.UnbindSubscription (Codeunit):
   layer: runtime-api

--- a/tests/bucket-1/codeunit-runtime/311443-stopsession-comment/al-runner.json
+++ b/tests/bucket-1/codeunit-runtime/311443-stopsession-comment/al-runner.json
@@ -1,0 +1,4 @@
+{
+  "sourcePath": "./src",
+  "testPath": "./test"
+}

--- a/tests/bucket-1/codeunit-runtime/311443-stopsession-comment/src/StopSessionCommentSrc.al
+++ b/tests/bucket-1/codeunit-runtime/311443-stopsession-comment/src/StopSessionCommentSrc.al
@@ -1,0 +1,14 @@
+/// Exercises the 2-arg AL StopSession(SessionId, Comment) overload — transpiles
+/// to ALStopSession(DataError, int sessionId, string comment) in C#.
+codeunit 311443 "StopSession Comment Src"
+{
+    procedure DoStopSessionWithComment(SessionId: Integer; Comment: Text)
+    begin
+        StopSession(SessionId, Comment);
+    end;
+
+    procedure DoStopSession(SessionId: Integer)
+    begin
+        StopSession(SessionId);
+    end;
+}

--- a/tests/bucket-1/codeunit-runtime/311443-stopsession-comment/test/StopSessionCommentTest.al
+++ b/tests/bucket-1/codeunit-runtime/311443-stopsession-comment/test/StopSessionCommentTest.al
@@ -1,0 +1,51 @@
+codeunit 311444 "StopSession Comment Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    [Test]
+    procedure StopSession_WithComment_DoesNotThrow()
+    var
+        Src: Codeunit "StopSession Comment Src";
+    begin
+        // Positive: StopSession(SessionId, Comment) must not crash.
+        // The comment parameter is accepted and silently ignored (no live session).
+        Src.DoStopSessionWithComment(42, 'Shutting down test session');
+        Assert.IsTrue(true, 'StopSession(Integer, Text) completed without error');
+    end;
+
+    [Test]
+    procedure StopSession_WithComment_DifferentSessionIds_DoesNotThrow()
+    var
+        Src: Codeunit "StopSession Comment Src";
+    begin
+        // Positive: verify multiple session IDs are all accepted — including 0 and
+        // large values — to ensure the overload handles any integer input.
+        Src.DoStopSessionWithComment(0, 'comment for zero');
+        Src.DoStopSessionWithComment(99999, 'comment for large id');
+        Assert.IsTrue(true, 'StopSession(Integer, Text) handled all session IDs');
+    end;
+
+    [Test]
+    procedure StopSession_WithEmptyComment_DoesNotThrow()
+    var
+        Src: Codeunit "StopSession Comment Src";
+    begin
+        // Positive: empty comment string must be accepted (Text default).
+        Src.DoStopSessionWithComment(1, '');
+        Assert.IsTrue(true, 'StopSession(Integer, Text) accepted empty comment');
+    end;
+
+    [Test]
+    procedure StopSession_1Arg_StillWorks()
+    var
+        Src: Codeunit "StopSession Comment Src";
+    begin
+        // Regression: the original 1-arg StopSession(SessionId) must still compile
+        // and run after adding the 2-arg overload.
+        Src.DoStopSession(7);
+        Assert.IsTrue(true, 'StopSession(Integer) still works after adding 2-arg overload');
+    end;
+}


### PR DESCRIPTION
## Summary

- Adds `MockSession.ALStopSession(DataError, int sessionId, string comment)` overload to handle the AL `StopSession(SessionId, Comment)` 2-arg call which transpiles to 3 C# arguments.
- The `comment` parameter is accepted and silently ignored in standalone mode (no live session to stop).
- New test suite `311443-stopsession-comment` with 4 proving tests covering: basic no-throw, multiple session IDs, empty comment, and regression check that 1-arg form still works.

## Test plan

- [x] RED: confirmed `CS1501: No overload for method 'ALStopSession' takes 3 arguments` before fix
- [x] GREEN: all 4 new tests pass after adding the overload
- [x] Full bucket-1 (1792 passed, 1 blocked pre-existing), bucket-2 (2110 passed), bucket-feature-niw all pass

Closes #1443