### PR TITLE
fix: implement ALStartSession 3-arg overload — closes #1435

### DIFF
--- a/AlRunner/Runtime/MockSession.cs
+++ b/AlRunner/Runtime/MockSession.cs
@@ -80,6 +80,16 @@ public static class MockSession
     }
 
     /// <summary>
+    /// StartSession without company parameter (2-arg AL form).
+    /// ALSession.ALStartSession(DataError, ByRef&lt;int&gt; sessionId, int codeunitId)
+    /// Equivalent to calling the 3-arg form with the current company name.
+    /// </summary>
+    public static bool ALStartSession(DataError errorLevel, ByRef<int> sessionId, int codeunitId)
+    {
+        return ALStartSession(errorLevel, sessionId, codeunitId, _companyName);
+    }
+
+    /// <summary>
     /// StartSession without record parameter.
     /// ALSession.ALStartSession(DataError, ByRef&lt;int&gt; sessionId, int codeunitId, string companyName)
     /// Dispatches the codeunit synchronously and returns true.
@@ -152,6 +162,16 @@ public static class MockSession
     public static void ALStopSession(DataError errorLevel, int sessionId)
     {
         // No-op: session already completed synchronously.
+    }
+
+    /// <summary>
+    /// StopSession with comment — no-op (session already completed synchronously).
+    /// Maps to the AL <c>StopSession(SessionId, Comment)</c> 2-arg overload.
+    /// The comment parameter is accepted but ignored in standalone mode.
+    /// </summary>
+    public static void ALStopSession(DataError errorLevel, int sessionId, string comment)
+    {
+        // No-op: session already completed synchronously; comment is ignored.
     }
 
     /// <summary>

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -7079,6 +7079,14 @@ Session.SetDocumentServiceToken (Text):
   status: stub
   notes: . Stripped via StripEntireCallMethods — OneDrive integration; no-op standalone. No explicit test (no return value to assert).
 
+Session.StartSession (Integer, Integer):
+  layer: runtime-api
+  category: Session
+  status: covered
+  tests:
+    - tests/bucket-1/codeunit-runtime/311435-startsession-2arg
+  notes: 2-arg AL form (no Company). MockSession.ALStartSession(DataError, ByRef<int>, int) delegates to the 4-arg overload with the current company name; closes #1435
+
 Session.StartSession (Integer, Integer, Duration, Text, Table):
   layer: runtime-api
   category: Session

--- a/tests/bucket-1/codeunit-runtime/311435-startsession-2arg/src/StartSession2ArgApi.al
+++ b/tests/bucket-1/codeunit-runtime/311435-startsession-2arg/src/StartSession2ArgApi.al
@@ -1,0 +1,43 @@
+// Supporting codeunit that writes a known value so the test can verify
+// the session codeunit actually ran (not a no-op).
+codeunit 1312001 "StartSession2Arg Counter"
+{
+    trigger OnRun()
+    begin
+        // Increment the shared counter so the caller can detect execution.
+        Counter += 1;
+    end;
+
+    var
+        Counter: Integer;
+
+    procedure GetCount(): Integer
+    begin
+        exit(Counter);
+    end;
+}
+
+codeunit 1312002 "StartSession2Arg Api"
+{
+    procedure TryStartSessionNoCompany(var SessionId: Integer): Boolean
+    begin
+        // 2-arg form: StartSession(var SessionId, CodeunitID) — no Company arg.
+        exit(StartSession(SessionId, Codeunit::"StartSession2Arg Worker"));
+    end;
+
+    procedure TryStartSessionMissingCU(var SessionId: Integer): Boolean
+    begin
+        // Negative test: pass a user-range codeunit ID that does not exist in the assembly
+        // (50xxx range). The runner throws for missing user codeunits; StartSession traps
+        // the error and returns false.
+        exit(StartSession(SessionId, 59999));
+    end;
+}
+
+codeunit 1312003 "StartSession2Arg Worker"
+{
+    trigger OnRun()
+    begin
+        // No-op worker dispatched via 2-arg StartSession.
+    end;
+}

--- a/tests/bucket-1/codeunit-runtime/311435-startsession-2arg/test/StartSession2ArgTest.al
+++ b/tests/bucket-1/codeunit-runtime/311435-startsession-2arg/test/StartSession2ArgTest.al
@@ -1,0 +1,42 @@
+codeunit 1312004 "StartSession 2-Arg Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    [Test]
+    procedure StartSession_2Arg_ReturnsTrue()
+    var
+        Api: Codeunit "StartSession2Arg Api";
+        SessionId: Integer;
+    begin
+        // Positive: 2-arg StartSession(var SessionId, CodeunitID) dispatches
+        // synchronously and returns true; SessionId is set to a non-zero value.
+        Assert.IsTrue(Api.TryStartSessionNoCompany(SessionId), 'StartSession(2-arg) should return true');
+        Assert.IsTrue(SessionId > 0, 'SessionId must be positive after 2-arg StartSession');
+    end;
+
+    [Test]
+    procedure StartSession_2Arg_SessionIdIsNonZero()
+    var
+        Api: Codeunit "StartSession2Arg Api";
+        SessionId: Integer;
+    begin
+        // StartSession must assign a fresh session ID (> 0).
+        SessionId := 0;
+        Api.TryStartSessionNoCompany(SessionId);
+        Assert.IsTrue(SessionId > 0, 'SessionId should be non-zero after 2-arg StartSession');
+    end;
+
+    [Test]
+    procedure StartSession_2Arg_MissingUserCU_ReturnsFalse()
+    var
+        Api: Codeunit "StartSession2Arg Api";
+        SessionId: Integer;
+    begin
+        // Negative: a user-range codeunit ID (59999) that does not exist in the assembly
+        // causes the synchronous dispatch to throw; StartSession traps it and returns false.
+        Assert.IsFalse(Api.TryStartSessionMissingCU(SessionId), 'StartSession with missing user CU should return false');
+    end;
+}


### PR DESCRIPTION
Closes #1435

## Summary
- Add `MockSession.ALStartSession(DataError, ByRef<int>, int)` — the missing 3-arg C# overload corresponding to the 2-arg AL form `StartSession(var SessionId, CodeunitID)` (without Company parameter)
- The new overload delegates to the existing 4-arg overload with the current company name, matching BC behaviour
- Add TDD tests in `tests/bucket-1/codeunit-runtime/311435-startsession-2arg/` covering positive (returns true + assigns SessionId) and negative (missing user-range codeunit returns false) cases
- Update `docs/coverage.yaml` with `Session.StartSession (Integer, Integer): covered`

## Test plan
- [ ] Red: compilation fails with `CS1501: No overload for 'ALStartSession' takes 3 arguments` before the fix
- [ ] Green: 3 tests pass after the fix — `StartSession_2Arg_ReturnsTrue`, `StartSession_2Arg_SessionIdIsNonZero`, `StartSession_2Arg_MissingUserCU_ReturnsFalse`
- [ ] Full bucket-1 and bucket-2 pass (excluding pre-existing unrelated failures)