### PR TITLE
fix: implement TestRequestPage.GetDataItem — closes #1457

### DIFF
--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -467,6 +467,9 @@ test executor that needs no BC service tier, Docker, SQL Server, or license.
   FindPreviousField(field,value), GetField() (stubs; First/GoToRecord/GoToKey/FindFirstField
   return true; all others return false/0/empty; parts share MockTestPageHandle with TestPage;
   TestPart.Prev removed in BC runtime 13.0 / BC 26+ — not supported)
+- TestRequestPage.GetDataItem(name) — BC emits GetDataItem("Report{N}DataItem{I}TableView")
+  when AL accesses a report data-item property (e.g. RequestPage.Customer.SetFilter(Id,'1..10')).
+  Returns a per-name MockTestPageFilter; supports SetFilter/GetFilter/SetCurrentKey/Ascending.
 - Request page handler dispatch — [RequestPageHandler] intercepts Report.RunRequestPage() calls
 - Report handler dispatch — [ReportHandler] intercepts Report.Run()/Report.RunModal() and
   report variable .Run()/.RunModal() calls. Handler receives TestRequestPage parameter.

--- a/AlRunner/Runtime/MockTestPageHandle.cs
+++ b/AlRunner/Runtime/MockTestPageHandle.cs
@@ -25,6 +25,7 @@ public class MockTestPageHandle
 
     private readonly Dictionary<int, MockTestPageField> _fields = new();
     private readonly Dictionary<int, MockTestPageHandle> _parts = new();
+    private readonly Dictionary<string, MockTestPageFilter> _dataItems = new();
 
     // ── Custom action dispatch ────────────────────────────────────────────────
     // Lazily created page instance (Page{N}) used to invoke compiled OnAction triggers.
@@ -355,6 +356,31 @@ public class MockTestPageHandle
     ///   tP.ALFilter.ALSetFilter(fieldNo, filterValue)
     /// </summary>
     public MockTestPageFilter ALFilter { get; } = new();
+
+    /// <summary>
+    /// Returns the filter object for a report data item by its internal name.
+    ///
+    /// BC emits <c>tP.Target.GetDataItem("Report{N}DataItem{I}TableView")</c>
+    /// when AL code accesses a report data-item property on a
+    /// <c>TestRequestPage</c> (e.g. <c>RequestPage.Customer.SetFilter(Id, '1..10')</c>).
+    /// The same string is used for both the <c>SetFilter</c> and the subsequent
+    /// <c>GetFilter</c> call, so a per-name dictionary is required to make the
+    /// round-trip work.
+    ///
+    /// The returned <see cref="MockTestPageFilter"/> exposes <c>ALSetFilter</c> /
+    /// <c>ALGetFilter</c> / <c>ALAscending</c> / <c>ALCurrentKey</c> /
+    /// <c>ALSetCurrentKey</c> which match BC's real <c>NavTestFilter</c> API.
+    /// Fixes CS1061 issue #1457.
+    /// </summary>
+    public MockTestPageFilter GetDataItem(string name)
+    {
+        if (!_dataItems.TryGetValue(name, out var filter))
+        {
+            filter = new MockTestPageFilter();
+            _dataItems[name] = filter;
+        }
+        return filter;
+    }
 
     /// <summary>
     /// Returns a MockTestPageField for the given field hash.

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -9433,6 +9433,12 @@ TestRequestPage.ValidationErrorCount ():
   status: covered
   notes: ALValidationErrorCount() returns 0
 
+TestRequestPage.GetDataItem (Text):
+  layer: runtime-api
+  category: TestRequestPage
+  status: covered
+  notes: GetDataItem(string name) on MockTestPageHandle returns a per-name MockTestPageFilter; ALSetFilter/ALGetFilter round-trip proved; two independent data items proved; fixes CS1061 issue #1457.
+
 # ── Text ────────────────────────────────────────────────────────
 
 Text.Contains (Text):

--- a/tests/bucket-2/page-report/311900-testrequestpage-getdataitem/src/TrpGdiSrc.al
+++ b/tests/bucket-2/page-report/311900-testrequestpage-getdataitem/src/TrpGdiSrc.al
@@ -1,0 +1,75 @@
+/// Report with data items used to exercise TestRequestPage.GetDataItem.
+/// The data items expose filters that tests can set and verify via GetDataItem().
+report 311900 "TRP GDI Report"
+{
+    Caption = 'TRP GDI Report';
+    dataset
+    {
+        dataitem(Customer; "TRP GDI Cust")
+        {
+            column(CustNo; Id) { }
+            dataitem(Entry; "TRP GDI Entry")
+            {
+                DataItemLink = CustId = field(Id);
+                column(EntryAmt; Amount) { }
+            }
+        }
+    }
+
+    requestpage
+    {
+        layout
+        {
+            area(Content)
+            {
+                group(Options)
+                {
+                    Caption = 'Options';
+                    field(FilterFld; FilterValue)
+                    {
+                        Caption = 'Filter';
+                        ApplicationArea = All;
+                    }
+                }
+            }
+        }
+    }
+
+    var
+        FilterValue: Text[50];
+}
+
+table 311901 "TRP GDI Cust"
+{
+    fields
+    {
+        field(1; Id; Integer) { }
+        field(2; Name; Text[50]) { }
+    }
+    keys
+    {
+        key(PK; Id) { Clustered = true; }
+    }
+}
+
+table 311902 "TRP GDI Entry"
+{
+    fields
+    {
+        field(1; EntryNo; Integer) { }
+        field(2; CustId; Integer) { }
+        field(3; Amount; Decimal) { }
+    }
+    keys
+    {
+        key(PK; EntryNo) { Clustered = true; }
+    }
+}
+
+codeunit 99800 "TRP GDI Src"
+{
+    procedure RunReport()
+    begin
+        Report.Run(311900);
+    end;
+}

--- a/tests/bucket-2/page-report/311900-testrequestpage-getdataitem/test/TrpGdiTest.al
+++ b/tests/bucket-2/page-report/311900-testrequestpage-getdataitem/test/TrpGdiTest.al
@@ -1,0 +1,87 @@
+/// Tests for issue #1457: TestRequestPage.GetDataItem missing on MockTestPageHandle.
+/// BC generates tP.Target.GetDataItem("Customer") when AL code accesses a report
+/// data item (e.g. RequestPage.Customer) from inside a RequestPageHandler.
+/// The Mock must expose GetDataItem(string) returning an object that supports
+/// ALSetFilter / ALGetFilter so that the generated C# compiles and runs.
+codeunit 99801 "TRP GDI Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "TRP GDI Src";
+        GotFilter: Text;
+        GotFilter2: Text;
+
+    // ── SetFilter / GetFilter round-trip via data item property ───────────────
+    [Test]
+    [HandlerFunctions('SetFilter_Handler')]
+    procedure GetDataItem_SetFilter_Roundtrips()
+    begin
+        // Positive: accessing a data item and calling SetFilter on it must store
+        // the filter so GetFilter returns the exact value.
+        // A no-op stub that discards SetFilter would return '' instead of '10..20'.
+        Src.RunReport();
+        Assert.AreEqual('10..20', GotFilter, 'Data item SetFilter/GetFilter round-trip must preserve the filter value');
+    end;
+
+    [RequestPageHandler]
+    procedure SetFilter_Handler(var RequestPage: TestRequestPage "TRP GDI Report")
+    begin
+        RequestPage.Customer.SetFilter(Id, '10..20');
+        GotFilter := RequestPage.Customer.GetFilter(Id);
+    end;
+
+    [Test]
+    [HandlerFunctions('SetFilter_NotDefault_Handler')]
+    procedure GetDataItem_GetFilter_NotDefaultWhenSet()
+    begin
+        // Negative: proves the mock is not a no-op that always returns ''.
+        // If GetFilter always returned '' this assertion would fail.
+        Src.RunReport();
+        Assert.AreNotEqual('', GotFilter2, 'GetFilter must return the value that was set, not the default empty string');
+    end;
+
+    [RequestPageHandler]
+    procedure SetFilter_NotDefault_Handler(var RequestPage: TestRequestPage "TRP GDI Report")
+    begin
+        RequestPage.Customer.SetFilter(Id, '>=5');
+        GotFilter2 := RequestPage.Customer.GetFilter(Id);
+    end;
+
+    // ── Nested data item ───────────────────────────────────────────────────────
+    [Test]
+    [HandlerFunctions('NestedDataItem_Handler')]
+    procedure GetDataItem_NestedDataItem_DoesNotCrash()
+    begin
+        // Positive: accessing a nested data item compiles and runs without error.
+        Src.RunReport();
+        Assert.IsTrue(true, 'Nested data item access must not crash');
+    end;
+
+    [RequestPageHandler]
+    procedure NestedDataItem_Handler(var RequestPage: TestRequestPage "TRP GDI Report")
+    begin
+        RequestPage.Entry.SetFilter(CustId, '42');
+    end;
+
+    // ── Two data items are independent ────────────────────────────────────────
+    [Test]
+    [HandlerFunctions('TwoDataItems_Handler')]
+    procedure GetDataItem_TwoDataItems_AreIndependent()
+    begin
+        // Positive: filters set on two different data items do not bleed over.
+        Src.RunReport();
+        Assert.AreEqual('A', GotFilter, 'Customer data item filter must equal the value set for Customer');
+        Assert.AreEqual('B', GotFilter2, 'Entry data item filter must equal the value set for Entry');
+    end;
+
+    [RequestPageHandler]
+    procedure TwoDataItems_Handler(var RequestPage: TestRequestPage "TRP GDI Report")
+    begin
+        RequestPage.Customer.SetFilter(Id, 'A');
+        RequestPage.Entry.SetFilter(CustId, 'B');
+        GotFilter := RequestPage.Customer.GetFilter(Id);
+        GotFilter2 := RequestPage.Entry.GetFilter(CustId);
+    end;
+}


### PR DESCRIPTION
## Summary

- Adds `GetDataItem(string name)` method to `MockTestPageHandle`
- BC emits `tP.Target.GetDataItem("Report{N}DataItem{I}TableView")` when AL code accesses a report data-item property on a `TestRequestPage` (e.g. `RequestPage.Customer.SetFilter(Id, '1..10')`)
- Returns a per-name `MockTestPageFilter` so `ALSetFilter`/`ALGetFilter`/`ALAscending`/`ALCurrentKey`/`ALSetCurrentKey` work correctly
- Fixes CS1061 gap reported in telemetry

Closes #1457

## Test plan

- [x] RED: Roslyn CS1061 error confirmed before fix (`MockTestPageHandle` has no `GetDataItem`)
- [x] GREEN: 4 tests pass — SetFilter/GetFilter round-trip, non-empty after set, nested data item, two independent data items
- [x] `docs/coverage.yaml` updated with `TestRequestPage.GetDataItem (Text)`
- [x] `PrintGuide()` in `Program.cs` updated
- [x] All existing buckets pass without regression