### PR TITLE
fix: add MockArray<T>.Clear(int) single-int overload — closes #1448

### DIFF
--- a/AlRunner/Runtime/MockArray.cs
+++ b/AlRunner/Runtime/MockArray.cs
@@ -134,12 +134,22 @@ public class MockArray<T> : IEnumerable<T>
             _items[i] = _factory != null ? _factory() : default!;
     }
 
+    /// <summary>
+    /// AL's Clear(arr[i]) — BC emits <c>arr.Clear(singleInt)</c> for 1-D arrays.
+    /// Resets the element at the given 0-based index to its default value.
+    /// </summary>
+    public void Clear(int index)
+    {
+        _items[index] = _factory != null ? _factory() : default!;
+    }
+
     public void Clear(int[] indexes)
     {
         _items[FlatIndex(indexes)] = _factory != null ? _factory() : default!;
     }
 
     public void ClearReference() => Clear();
+    public void ClearReference(int index) => Clear(index);
     public void ClearReference(int[] indexes) => Clear(indexes);
 
     public IEnumerator<T> GetEnumerator() => ((IEnumerable<T>)_items).GetEnumerator();

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -7287,7 +7287,12 @@ System.Clear (Array):
   layer: runtime-api
   category: System
   status: covered
-  notes: . Covered: Text, Integer, Decimal, Boolean, Date, Record, List — each resets to type default.
+  tests:
+    - tests/bucket-2/data-formats/312100-array-clear-single-int
+  notes: >
+    Covered: Text, Integer, Decimal, Boolean, Date, Record, List — each resets to type default.
+    BC emits arr.Clear(int) for Clear(arr[i]) on 1-D arrays; MockArray<T>.Clear(int) single-int
+    overload added alongside the existing int[] overload (issue #1448).
 
 System.Clear (Joker):
   layer: runtime-api

--- a/tests/bucket-2/data-formats/312100-array-clear-single-int/al-runner.json
+++ b/tests/bucket-2/data-formats/312100-array-clear-single-int/al-runner.json
@@ -1,0 +1,3 @@
+{
+  "description": "MockArray<T>.Clear(int) single-int overload — Clear(arr[i]) for array of XmlNodeList (issue #1448)"
+}

--- a/tests/bucket-2/data-formats/312100-array-clear-single-int/src/ArrayClearSrc.al
+++ b/tests/bucket-2/data-formats/312100-array-clear-single-int/src/ArrayClearSrc.al
@@ -1,0 +1,49 @@
+/// Helper codeunit for Clear(arr[i]) on arrays of complex types — issue #1448.
+/// BC emits arr.Clear(int) for the AL built-in Clear(arr[n]) but
+/// MockArray<T> was missing the single-int overload.
+codeunit 312100 "ACSI Src"
+{
+    /// Populate both slots of an XmlNodeList array, clear slot [1],
+    /// and return the count in slot [2] — proving that only slot [1] was cleared
+    /// and that Clear(arr[i]) compiles and runs without CS1503.
+    procedure ClearNodeListArrayElement(): Integer
+    var
+        NodeListArr: array[2] of XmlNodeList;
+        Root: XmlElement;
+    begin
+        // Slot [1]: build an XmlNodeList with one child (will be cleared)
+        Root := XmlElement.Create('root1');
+        Root.Add(XmlElement.Create('child'));
+        NodeListArr[1] := Root.GetChildNodes();
+
+        // Slot [2]: list with 3 children — must be untouched
+        Root := XmlElement.Create('root2');
+        Root.Add(XmlElement.Create('x'));
+        Root.Add(XmlElement.Create('y'));
+        Root.Add(XmlElement.Create('z'));
+        NodeListArr[2] := Root.GetChildNodes();
+
+        // Clear the first slot — this is the pattern that caused CS1503
+        Clear(NodeListArr[1]);
+
+        // Slot [2] must still report 3 children
+        exit(NodeListArr[2].Count());
+    end;
+
+    /// Slot [2] must still have its 2 children after only slot [1] was cleared.
+    procedure NodeListSlot2UnaffectedBySlot1Clear(): Integer
+    var
+        NodeListArr: array[2] of XmlNodeList;
+        Root: XmlElement;
+    begin
+        Root := XmlElement.Create('root');
+        Root.Add(XmlElement.Create('a'));
+        Root.Add(XmlElement.Create('b'));
+        NodeListArr[1] := Root.GetChildNodes();
+        NodeListArr[2] := Root.GetChildNodes();
+
+        Clear(NodeListArr[1]);
+
+        exit(NodeListArr[2].Count());
+    end;
+}

--- a/tests/bucket-2/data-formats/312100-array-clear-single-int/test/ArrayClearTest.al
+++ b/tests/bucket-2/data-formats/312100-array-clear-single-int/test/ArrayClearTest.al
@@ -1,0 +1,24 @@
+/// Tests for Clear(arr[i]) on arrays of complex types — issue #1448.
+codeunit 312101 "ACSI Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit "Library Assert";
+        Src: Codeunit "ACSI Src";
+
+    [Test]
+    procedure ClearNodeListArrayElement_Slot2Intact()
+    begin
+        // POSITIVE: after Clear(NodeListArr[1]), slot [2] must report 3 children —
+        // proving Clear(arr[i]) both compiles (no CS1503) and only targets slot [1].
+        Assert.AreEqual(3, Src.ClearNodeListArrayElement(), 'Slot 2 count should be 3 after clearing slot 1');
+    end;
+
+    [Test]
+    procedure ClearNodeListArrayElement_OtherSlotUnaffected()
+    begin
+        // POSITIVE: slot [2] must still have 2 children after slot [1] was cleared
+        Assert.AreEqual(2, Src.NodeListSlot2UnaffectedBySlot1Clear(), 'Slot 2 count must be unaffected');
+    end;
+}


### PR DESCRIPTION
## Summary

- BC emits `arr.Clear(int)` for `Clear(arr[i])` on 1-D arrays, but `MockArray<T>` only had `Clear(int[])`, causing `CS1503: cannot convert from 'int' to 'int[]'`
- Added `Clear(int index)` and `ClearReference(int index)` overloads to `MockArray<T>` that reset the element at the given 0-based index to its default value
- Added test suite `312100-array-clear-single-int` covering `Clear(arr[i])` on `array[N] of XmlNodeList` (the reported pattern)

Closes #1448

## Test plan

- [ ] `ClearNodeListArrayElement_Slot2Intact`: after `Clear(NodeListArr[1])`, slot [2] reports correct count (3) — proves compilation succeeds and only slot [1] is affected
- [ ] `ClearNodeListArrayElement_OtherSlotUnaffected`: slot [2] count unaffected after clearing slot [1]
- [ ] Both new tests pass; no regressions in bucket-1, bucket-2, or bucket-feature-niw