### PR TITLE
fix: handle Duration to Integer implicit conversion in HttpClient.Timeout

### DIFF
--- a/AlRunner/Runtime/MockHttpClient.cs
+++ b/AlRunner/Runtime/MockHttpClient.cs
@@ -84,8 +84,16 @@ public class MockHttpClient
         throw new NotSupportedException(HttpNotSupportedMessage);
     }
 
-    /// <summary>Timeout property stub (seconds). No-op in standalone mode.</summary>
-    public int ALTimeout { get; set; } = 30;
+    /// <summary>
+    /// Timeout property stub (milliseconds). No-op in standalone mode.
+    /// BC's HttpClient.Timeout is Integer (milliseconds), but AL allows assigning
+    /// a Duration value directly (Duration → Integer implicit conversion in AL).
+    /// The BC compiler emits <c>client.ALTimeout = navDuration</c> without any explicit
+    /// cast, so this property uses NavDuration to accept either form.
+    /// NavDuration has implicit conversions from long and to long, covering Integer
+    /// assignments too (ALCompiler.ToInt32(NavDuration) resolves via long overload).
+    /// </summary>
+    public NavDuration ALTimeout { get; set; } = 30L;
 
     /// <summary>DefaultRequestHeaders property stub.</summary>
     public MockHttpHeaders ALDefaultRequestHeaders => _defaultHeaders;
@@ -114,7 +122,7 @@ public class MockHttpClient
     {
         _baseAddress = string.Empty;
         _defaultHeaders = new MockHttpHeaders();
-        ALTimeout = 30;
+        ALTimeout = 30L;
         ALUseDefaultNetworkWindowsAuthentication = false;
         ALUseServerCertificateValidation = false;
     }

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -3025,6 +3025,9 @@ HttpClient.Timeout (Duration):
   layer: runtime-api
   category: HttpClient
   status: covered
+  notes: ALTimeout changed from int to NavDuration so Duration→Integer assignment compiles — issue #1445
+  tests:
+    - tests/bucket-2/data-formats/313-duration-to-integer
 
 HttpClient.UseDefaultNetworkWindowsAuthentication ():
   layer: runtime-api

--- a/tests/bucket-2/data-formats/313-duration-to-integer/test/DurationToIntegerTest.al
+++ b/tests/bucket-2/data-formats/313-duration-to-integer/test/DurationToIntegerTest.al
@@ -1,0 +1,46 @@
+codeunit 1313001 "Duration To Integer Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit "Library Assert";
+
+    // Positive: Duration → Integer implicit conversion preserves millisecond value
+    [Test]
+    procedure DurationToInteger_AssignsMilliseconds()
+    var
+        d: Duration;
+        i: Integer;
+    begin
+        d := 5000; // 5 seconds in ms
+        i := d;
+        Assert.AreEqual(5000, i, 'Duration→Integer must preserve millisecond value');
+    end;
+
+    // Positive: HttpClient.Timeout := Duration compiles and round-trips
+    [Test]
+    procedure HttpClientTimeout_SetFromDuration()
+    var
+        Client: HttpClient;
+        Timeout: Duration;
+        Retrieved: Integer;
+    begin
+        Timeout := 30000; // 30 seconds in ms
+        Client.Timeout := Timeout;
+        Retrieved := Client.Timeout;
+        Assert.AreEqual(30000, Retrieved, 'HttpClient.Timeout must store Duration as Integer milliseconds');
+    end;
+
+    // Positive: Integer → Duration assignment works too (round-trip)
+    [Test]
+    procedure IntegerToDuration_Compiles()
+    var
+        d: Duration;
+        i: Integer;
+    begin
+        i := 7500;
+        d := i;
+        i := d;
+        Assert.AreEqual(7500, i, 'Integer→Duration→Integer round-trip must preserve value');
+    end;
+}


### PR DESCRIPTION
Closes #1445

## Problem

BC emits `client.ALTimeout = navDuration` when AL code assigns a `Duration` variable to `HttpClient.Timeout`. `MockHttpClient.ALTimeout` was typed as `int`, but `NavDuration` only has an implicit conversion to `long` (not `int`), causing CS0266.

## Fix

Changed `MockHttpClient.ALTimeout` from `int` to `NavDuration`. This means:
- `client.ALTimeout = navDuration` — `NavDuration = NavDuration` ✓
- `ALCompiler.ToInt32(client.ALTimeout)` — resolves via implicit `NavDuration → long → ToInt32(long)` ✓
- Default value updated from `30` to `30L` (works via `implicit operator NavDuration(long)`)

## Tests

Added `tests/bucket-2/data-formats/313-duration-to-integer/` with 3 proving tests:
- `DurationToInteger_AssignsMilliseconds` — `i := d` compiles and preserves ms value
- `HttpClientTimeout_SetFromDuration` — `Client.Timeout := Duration` compiles and round-trips
- `IntegerToDuration_Compiles` — Integer → Duration → Integer round-trip