### PR TITLE
fix: prevent ByRef<int> CS1503 in auto-stub var-param signatures — closes #1433

### DIFF
--- a/AlRunner/Pipeline.cs
+++ b/AlRunner/Pipeline.cs
@@ -1713,7 +1713,15 @@ public class AlRunnerPipeline
                             var pType = p.GetType().GetProperty("ParameterType")?.GetValue(p)
                                      ?? p.GetType().GetProperty("Type")?.GetValue(p);
                             var typeName = pType != null ? RenderSymbolTypeViaReflection(pType) : "Variant";
-                            var prefix = pIsVar ? "var " : "";
+                            // Strip "var" from primitive numeric/boolean params in auto-stubs.
+                            // "var Integer" → ByRef<int> and "var Boolean" → ByRef<bool> in the
+                            // generated C#.  When the stub has ByRef<int> but the caller passes
+                            // ByRef<Decimal18> (because the real codeunit has a Decimal overload),
+                            // Roslyn rejects the call with CS1503.  Auto-stubs have empty bodies
+                            // so they never actually use by-reference semantics; stripping "var"
+                            // makes the stub use value params and avoids the ByRef mismatch.
+                            var effectiveIsVar = pIsVar && !IsCSharpPrimitiveMappedType(typeName);
+                            var prefix = effectiveIsVar ? "var " : "";
                             paramParts.Add($"{prefix}{pName}: {typeName}");
                         }
                     }
@@ -1925,5 +1933,15 @@ public class AlRunnerPipeline
             _ => "Variant", // Use Variant for complex/unknown types to avoid syntax errors
         };
     }
+
+    /// <summary>
+    /// Returns true for AL type names that map to C# primitive types (int, bool, etc.).
+    /// These types produce <c>ByRef&lt;int&gt;</c>/<c>ByRef&lt;bool&gt;</c> when used as
+    /// <c>var</c> parameters, which causes CS1503 when the caller passes a
+    /// <c>ByRef&lt;Decimal18&gt;</c> or other concrete BC value type.  Auto-stubs have
+    /// empty bodies so stripping <c>var</c> from these types is safe.
+    /// </summary>
+    private static bool IsCSharpPrimitiveMappedType(string typeName) => typeName is
+        "Integer" or "BigInteger" or "Boolean" or "Char" or "Byte";
 
 }

--- a/AlRunner/Runtime/MockCodeunitHandle.cs
+++ b/AlRunner/Runtime/MockCodeunitHandle.cs
@@ -1104,6 +1104,24 @@ public class MockCodeunitHandle
                 return false;
         }
 
+        // ByRef<T> → U (non-ByRef): unwrap the ByRef and convert the inner value.
+        // When an auto-stub has a non-var Integer param (after the "strip var from primitives"
+        // fix) but the caller was compiled against a "var Decimal" overload, the Invoke args
+        // array may still contain a ByRef<Decimal18>.  Unwrapping it lets the existing
+        // NavValue → primitive conversions below do the right thing.
+        if (arg != null
+            && arg.GetType().IsGenericType
+            && arg.GetType().GetGenericTypeDefinition() == typeof(ByRef<>)
+            && !targetType.IsGenericType)
+        {
+            var valueProp = arg.GetType().GetProperty("Value");
+            if (valueProp != null)
+            {
+                var innerVal = valueProp.GetValue(arg);
+                return ConvertArgInternal(innerVal, targetType);
+            }
+        }
+
         // any value -> ByRef<T>: when target is ByRef<T>, convert arg to T first then wrap.
         if (targetType.IsGenericType
             && targetType.GetGenericTypeDefinition() == typeof(ByRef<>))

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -595,6 +595,8 @@ parameter:
     - tests/bucket-1/codeunit-runtime/01-pure-function
     - tests/bucket-1/codeunit-runtime/32-interface-param
     - tests/bucket-2/data-formats/83-list-byref
+    - tests/bucket-1/codeunit-runtime/312600-assert-byref-coercion
+  notes: var-param (ByRef<T>) coercion through Assert.AreEqual covered; auto-stub generator strips "var" from Integer/Boolean params to prevent CS1503 ByRef mismatch; ConvertArgInternal unwraps ByRef<T> for non-ByRef targets; closes #1433
 
 parameter_list:
   layer: syntax

--- a/tests/bucket-1/codeunit-runtime/312600-assert-byref-coercion/src/AssertByRefSrc.al
+++ b/tests/bucket-1/codeunit-runtime/312600-assert-byref-coercion/src/AssertByRefSrc.al
@@ -1,0 +1,32 @@
+/// Helper codeunit for the assert-byref-coercion test suite.
+/// Exercises the scenario from issue #1433: Assert.AreEqual called inside a
+/// procedure that receives its operands as var Decimal params.  The BC
+/// transpiler wraps these as ByRef<Decimal18>, and the runner must correctly
+/// unwrap them before passing to the assertion.
+codeunit 1312600 "Assert ByRef Helper"
+{
+    /// Call Assert.AreEqual with two values received as var Decimal parameters.
+    /// Mirrors the pattern from issue #1433:
+    ///   "CS1503: 'ByRef<Decimal18>' → 'ByRef<int>' (2×) [AL: Assert.AreEqual(Amount1, Amt, '...')]"
+    procedure AssertDecimalEqual(var Amount1: Decimal; var Amt: Decimal; Msg: Text)
+    var
+        Assert: Codeunit Assert;
+    begin
+        Assert.AreEqual(Amount1, Amt, Msg);
+    end;
+
+    /// Same pattern but returning a Boolean instead of asserting, so the negative
+    /// branch can be tested without asserterror.
+    procedure DecimalsAreEqual(var Amount1: Decimal; var Amt: Decimal): Boolean
+    begin
+        exit(Amount1 = Amt);
+    end;
+
+    /// Var Integer variant: exercises ByRef<int> arg path through the helper.
+    procedure AssertIntegerEqual(var Expected: Integer; var Actual: Integer; Msg: Text)
+    var
+        Assert: Codeunit Assert;
+    begin
+        Assert.AreEqual(Expected, Actual, Msg);
+    end;
+}

--- a/tests/bucket-1/codeunit-runtime/312600-assert-byref-coercion/test/AssertByRefTest.al
+++ b/tests/bucket-1/codeunit-runtime/312600-assert-byref-coercion/test/AssertByRefTest.al
@@ -1,0 +1,108 @@
+/// Regression test for issue #1433 — CS1503: ByRef conversion error in Assert.AreEqual.
+///
+/// When Assert.AreEqual is called inside a procedure that receives its operands
+/// as "var Decimal" params, the BC transpiler wraps those as ByRef<Decimal18>.
+/// The runner must compile and execute that pattern without CS1503.
+///
+/// Covers both directions:
+///   Positive — equal values → assertion passes.
+///   Negative — unequal values → assertion fires the expected error.
+codeunit 1312601 "Assert ByRef Coercion Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Helper: Codeunit "Assert ByRef Helper";
+
+    // ── Decimal var-param path ─────────────────────────────────────────────────
+
+    [Test]
+    procedure AssertAreEqual_VarDecimal_EqualValues_Passes()
+    var
+        Amount1: Decimal;
+        Amt: Decimal;
+    begin
+        // [GIVEN] Two equal Decimal locals that will be passed as var params
+        Amount1 := 123.45;
+        Amt := 123.45;
+        // [WHEN] AreEqual is invoked through a procedure with var Decimal params
+        // [THEN] No error is raised — the ByRef<Decimal18> coercion must succeed
+        Helper.AssertDecimalEqual(Amount1, Amt, 'Decimals should be equal');
+    end;
+
+    [Test]
+    procedure AssertAreEqual_VarDecimal_UnequalValues_Fails()
+    var
+        Amount1: Decimal;
+        Amt: Decimal;
+    begin
+        // [GIVEN] Two unequal Decimal locals passed as var params
+        Amount1 := 100;
+        Amt := 200;
+        // [WHEN/THEN] AreEqual fires the mismatch error
+        asserterror Helper.AssertDecimalEqual(Amount1, Amt, 'Expected 100 = 200');
+        Assert.ExpectedError('Expected 100 = 200');
+    end;
+
+    [Test]
+    procedure DecimalsAreEqual_VarDecimal_SameValue_ReturnsTrue()
+    var
+        Amount1: Decimal;
+        Amt: Decimal;
+        Result: Boolean;
+    begin
+        // [GIVEN] Equal Decimal vars
+        Amount1 := 42.5;
+        Amt := 42.5;
+        // [WHEN] Compared through helper with var Decimal params
+        Result := Helper.DecimalsAreEqual(Amount1, Amt);
+        // [THEN] Returns true (non-default value proves mock is working)
+        Assert.IsTrue(Result, 'Equal decimals must return true');
+    end;
+
+    [Test]
+    procedure DecimalsAreEqual_VarDecimal_DifferentValues_ReturnsFalse()
+    var
+        Amount1: Decimal;
+        Amt: Decimal;
+        Result: Boolean;
+    begin
+        // [GIVEN] Different Decimal vars
+        Amount1 := 1;
+        Amt := 2;
+        // [WHEN] Compared through helper
+        Result := Helper.DecimalsAreEqual(Amount1, Amt);
+        // [THEN] Returns false
+        Assert.IsFalse(Result, 'Unequal decimals must return false');
+    end;
+
+    // ── Integer var-param path ─────────────────────────────────────────────────
+
+    [Test]
+    procedure AssertAreEqual_VarInteger_EqualValues_Passes()
+    var
+        Expected: Integer;
+        Actual: Integer;
+    begin
+        // [GIVEN] Equal Integer locals passed as var params
+        Expected := 7;
+        Actual := 7;
+        // [WHEN/THEN] No error (ByRef<int> must be coerced correctly)
+        Helper.AssertIntegerEqual(Expected, Actual, 'Integers should match');
+    end;
+
+    [Test]
+    procedure AssertAreEqual_VarInteger_UnequalValues_Fails()
+    var
+        Expected: Integer;
+        Actual: Integer;
+    begin
+        // [GIVEN] Unequal Integer locals passed as var params
+        Expected := 3;
+        Actual := 9;
+        // [WHEN/THEN] AreEqual fires
+        asserterror Helper.AssertIntegerEqual(Expected, Actual, 'Expected 3 = 9');
+        Assert.ExpectedError('Expected 3 = 9');
+    end;
+}


### PR DESCRIPTION
## Summary

- **Pipeline.cs**: In `RenderCodeunitStubFromSymbols`, strip the `var` prefix from `Integer`, `BigInteger`, `Boolean`, `Char`, and `Byte` parameters when generating auto-stubs. These types map to C# primitives (`int`, `bool`, etc.); using them as `var` params produces `ByRef<int>`/`ByRef<bool>` signatures. When the caller was compiled against a Decimal or other BC value-type overload, Roslyn rejects the call with `CS1503: 'ByRef<Decimal18>' → 'ByRef<int>'`. Auto-stubs have empty bodies so stripping `var` is safe.
- **MockCodeunitHandle.cs**: Add `ByRef<T>` → `U` unwrapping in `ConvertArgInternal`. If a caller compiled against a `var`-param overload passes a `ByRef<T>` wrapper where the stub expects a non-ByRef value, the inner value is now extracted before conversion.
- **Test suite 312600-assert-byref-coercion** (IDs 1312600–1312601): 6 tests exercising positive and negative cases for `var Decimal` and `var Integer` params threaded through a helper into `Assert.AreEqual`.

## Test plan

- [x] `AssertAreEqual_VarDecimal_EqualValues_Passes` — equal Decimal var-params compile and assert correctly
- [x] `AssertAreEqual_VarDecimal_UnequalValues_Fails` — unequal Decimal var-params fire the expected error
- [x] `DecimalsAreEqual_VarDecimal_SameValue_ReturnsTrue` — returns non-default true
- [x] `DecimalsAreEqual_VarDecimal_DifferentValues_ReturnsFalse` — returns false
- [x] `AssertAreEqual_VarInteger_EqualValues_Passes` — Integer var-param path works
- [x] `AssertAreEqual_VarInteger_UnequalValues_Fails` — Integer var-param negative case works
- [x] All bucket-1 tests still pass (1803 passed)

Closes #1433