### PR TITLE
fix: only discover tests with [NavTest] attribute, not by name — closes #1420

### DIFF
--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -2763,7 +2763,11 @@ public static class Executor
                 }
             }
 
-            // Find corresponding scope classes for test methods
+            // Find corresponding scope classes for test methods.
+            // Only include scopes whose parent method bears [NavTest] — the
+            // StartsWith("Test") fallback caused phantom tests for any
+            // procedure named Test* on tables, pages, or non-test codeunits
+            // (issue #1420).
             foreach (var nested in type.GetNestedTypes(BindingFlags.NonPublic | BindingFlags.Public))
             {
                 var name = nested.Name;
@@ -2771,9 +2775,8 @@ public static class Executor
                 {
                     var scopeIdx = name.IndexOf("_Scope_");
                     var testName = name.Substring(0, scopeIdx);
-                    // Include if method has [NavTest] attribute OR starts with "Test" (fallback)
-                    if (testMethodNames.Contains(testName) ||
-                        testName.StartsWith("Test", StringComparison.OrdinalIgnoreCase))
+                    // Include ONLY if the parent method has [NavTest] attribute.
+                    if (testMethodNames.Contains(testName))
                     {
                         testScopes.Add((testName, nested, type));
                     }

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -190,7 +190,7 @@ reportextension_declaration:
   notes: >
 
 ReportExtension.GetGlobalVariable (int, NavType):
-  layer: runtime
+  layer: runtime-api
   category: report
   status: covered
   tests:
@@ -202,7 +202,7 @@ ReportExtension.GetGlobalVariable (int, NavType):
     stub returning NavInteger.Default. Issue #1450.
 
 ReportExtension.SetGlobalVariable (int, NavType, object):
-  layer: runtime
+  layer: runtime-api
   category: report
   status: covered
   tests:
@@ -1252,6 +1252,14 @@ attribute_item:
     - tests/bucket-1/codeunit-runtime/100-bind-subscription
     - tests/bucket-1/codeunit-runtime/41-try-function
     - tests/bucket-1/codeunit-runtime/66-event-subscribers
+
+navtest_attribute_discovery:
+  layer: syntax
+  category: attribute
+  status: covered
+  notes: Executor discovers only methods bearing [NavTest]/[Test]; procedures named Test* on tables, pages, or non-test codeunits are NOT picked up as test cases (issue #1420 — removed StartsWith("Test") fallback from RunTests()).
+  tests:
+    - tests/bucket-1/codeunit-runtime/312700-navtest-attribute-discovery
 
 
 # ══════════════════════════════════════════════════════════════

--- a/tests/bucket-1/codeunit-runtime/312700-navtest-attribute-discovery/src/NavTestDiscoverySrc.al
+++ b/tests/bucket-1/codeunit-runtime/312700-navtest-attribute-discovery/src/NavTestDiscoverySrc.al
@@ -1,0 +1,58 @@
+/// <summary>
+/// Suite 312700 (bucket-1/codeunit-runtime): [NavTest] attribute-only discovery.
+///
+/// Reproduces issue #1420: the executor has a "StartsWith('Test')" fallback that
+/// picks up ANY procedure named Test* as a test, including local procedures on
+/// tables, non-test codeunits, and pages. Those procedures crash with NRE when
+/// run without context.
+///
+/// This table and non-test codeunit each define a procedure whose name starts
+/// with "Test". Neither bears [Test]. They must NOT be discovered as test cases.
+/// </summary>
+
+// -------------------------------------------------------------------
+// A table with a local procedure called TestSomething — reproduces the
+// exact shape from the bug report (NALICF Component Line, etc.).
+// -------------------------------------------------------------------
+table 1312700 "NAD Demo Table"
+{
+    fields
+    {
+        field(1; "No."; Code[20]) { }
+        field(2; Description; Text[50]) { }
+    }
+    keys
+    {
+        key(PK; "No.") { Clustered = true; }
+    }
+
+    trigger OnInsert()
+    begin
+        TestSomething();
+    end;
+
+    local procedure TestSomething()
+    begin
+        // Local procedure prefixed with "Test" — must NEVER be discovered as [Test].
+        // Called only from OnInsert with a valid Rec context.
+        if "No." = '' then
+            Error('NAD Demo Table: No. must not be empty on insert.');
+    end;
+}
+
+// -------------------------------------------------------------------
+// A plain (non-Test) codeunit with a public Test* procedure — another
+// shape that caused false positives.
+// -------------------------------------------------------------------
+codeunit 1312701 "NAD Helper"
+{
+    /// <summary>
+    /// A public helper procedure whose name starts with "Test".
+    /// It is NOT tagged [Test] and the codeunit has no Subtype = Test.
+    /// Must NOT be discovered as a test by the executor.
+    /// </summary>
+    procedure TestComputeSum(A: Integer; B: Integer): Integer
+    begin
+        exit(A + B);
+    end;
+}

--- a/tests/bucket-1/codeunit-runtime/312700-navtest-attribute-discovery/test/NavTestDiscoveryTest.al
+++ b/tests/bucket-1/codeunit-runtime/312700-navtest-attribute-discovery/test/NavTestDiscoveryTest.al
@@ -1,0 +1,97 @@
+/// <summary>
+/// Suite 312700 (bucket-1/codeunit-runtime): [NavTest] attribute-only discovery.
+///
+/// Proves that the executor discovers ONLY methods tagged [Test] (i.e. bearing
+/// [NavTestAttribute] in the emitted C#). Procedures named Test* on tables or
+/// non-test codeunits must be silently ignored — not run as phantom tests.
+///
+/// RED before fix: the bucket run would show an additional "ERROR TestSomething"
+/// entry (NRE from the table procedure) alongside PASS InsertViaOnInsert.
+///
+/// GREEN after fix: exactly one test is reported; no phantom TestSomething entry.
+/// </summary>
+codeunit 1312702 "NAD Discovery Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    // -----------------------------------------------------------------
+    // Positive: a record Insert that goes through OnInsert (which calls
+    // the local TestSomething procedure) works correctly.
+    // This test ALSO proves that TestSomething is not separately run:
+    // if the executor ran TestSomething as a test, it would NRE before
+    // reaching this line, failing the whole suite.
+    // -----------------------------------------------------------------
+
+    [Test]
+    procedure InsertViaOnInsert_ReturnsCorrectNo()
+    var
+        Rec: Record "NAD Demo Table";
+    begin
+        // [GIVEN] A fresh record with a valid No.
+        Rec.Init();
+        Rec."No." := 'X001';
+        Rec.Description := 'Test fixture';
+
+        // [WHEN] Insert with trigger fires OnInsert → TestSomething()
+        Rec.Insert(true);
+
+        // [THEN] Record persisted with the correct No.
+        Assert.AreEqual('X001', Rec."No.", 'Insert via OnInsert must retain No.');
+    end;
+
+    // -----------------------------------------------------------------
+    // Negative: inserting with an empty No. triggers the guard in
+    // TestSomething (called via OnInsert) and raises the expected error.
+    // -----------------------------------------------------------------
+
+    [Test]
+    procedure InsertWithEmptyNo_RaisesError()
+    var
+        Rec: Record "NAD Demo Table";
+    begin
+        // [GIVEN] A record with an empty No.
+        Rec.Init();
+        Rec."No." := '';
+
+        // [WHEN/THEN] Insert fires OnInsert → TestSomething() → Error(...)
+        asserterror Rec.Insert(true);
+        Assert.ExpectedError('No. must not be empty on insert.');
+    end;
+
+    // -----------------------------------------------------------------
+    // Positive: the helper codeunit's Test* procedure works as a normal
+    // helper — called by test code, not "discovered" by the executor.
+    // -----------------------------------------------------------------
+
+    [Test]
+    procedure HelperTestComputeSum_ReturnsCorrectValue()
+    var
+        Helper: Codeunit "NAD Helper";
+        Result: Integer;
+    begin
+        // [GIVEN] Two positive integers
+        // [WHEN] Called through the helper codeunit
+        Result := Helper.TestComputeSum(3, 4);
+
+        // [THEN] Sum is 7 — a non-default value so a no-op stub cannot pass
+        Assert.AreEqual(7, Result, 'TestComputeSum(3,4) must return 7');
+    end;
+
+    [Test]
+    procedure HelperTestComputeSum_Negative_WrongExpectation()
+    var
+        Helper: Codeunit "NAD Helper";
+        Result: Integer;
+    begin
+        // [GIVEN] Two integers whose sum is known (3+4=7)
+        Result := Helper.TestComputeSum(3, 4);
+
+        // [WHEN] We assert a wrong value
+        // [THEN] Assert fails with the right message
+        asserterror Assert.AreEqual(99, Result, 'Sum must not be 99');
+        Assert.ExpectedError('Sum must not be 99');
+    end;
+}


### PR DESCRIPTION
## Summary

- Removes the `StartsWith("Test", ...)` fallback from `Executor.RunTests()` in `AlRunner/Program.cs`. Test methods are now discovered exclusively by the presence of `[NavTestAttribute]` on the method.
- Adds test suite `312700-navtest-attribute-discovery` with a table containing a `local procedure TestSomething()` and a non-test codeunit with a `TestComputeSum()` helper — both named `Test*` but neither bearing `[Test]`. The suite has 4 AL tests exercising both positive and negative paths.
- Updates `docs/coverage.yaml` with a `navtest_attribute_discovery` entry under the `attribute` category.

## Test plan

- [x] RED confirmed: before fix, the runner produced `ERROR TestSomething` (NRE) and `PASS TestComputeSum` as phantom tests alongside the 4 real tests
- [x] GREEN confirmed: after fix, exactly 4 tests pass, no phantom entries
- [x] Suite `01-executor-ctor-params` (existing Test*-named helper with params) still passes
- [x] Full bucket-1 and bucket-2 regression: no new failures introduced

Closes #1420