### PR TITLE
fix: add MockJsonHelper integer-index overloads for JsonArray typed getters — closes #1426

### DIFF
--- a/AlRunner/Runtime/MockJsonHelper.cs
+++ b/AlRunner/Runtime/MockJsonHelper.cs
@@ -356,6 +356,25 @@ public static class MockJsonHelper
     }
 
     /// <summary>
+    /// Replacement for NavJsonArray.ALGetBoolean(index).
+    /// Returns the boolean value at the given integer index.
+    /// AL: JsonArray.GetBoolean(index)  →  MockJsonHelper.GetBoolean(token, index)
+    /// Issue #1426: BC emits ALGetBoolean(Int32) for JsonArray — adds int overload.
+    /// </summary>
+    public static bool GetBoolean(NavJsonToken token, int index)
+    {
+        var backingToken = GetBackingToken(token);
+        if (backingToken is not JArray arr)
+            throw new Exception("The JSON token is not an array.");
+        if (index < 0 || index >= arr.Count)
+            throw new Exception($"The index {index} is outside the bounds of the JSON array.");
+        var elem = arr[index];
+        if (elem.Type != JTokenType.Boolean)
+            throw new Exception($"The element at index {index} cannot be converted to a Boolean value.");
+        return elem.Value<bool>();
+    }
+
+    /// <summary>
     /// Replacement for NavJsonToken.ALPath(DataError).
     /// Returns the BC-style JSON path for the token (e.g. "$" for root, "$.foo" for a field).
     /// Newtonsoft.Json uses "" for root and "foo" for a field — this converts to BC format.
@@ -467,6 +486,23 @@ public static class MockJsonHelper
     }
 
     /// <summary>
+    /// Replacement for NavJsonArray.ALGetText(index).
+    /// Returns the string value at the given integer index.
+    /// AL: JsonArray.GetText(index)  →  MockJsonHelper.GetText(token, index)
+    /// Issue #1426: BC emits ALGetText(Int32 index) for JsonArray — adds int overload
+    /// so the rewriter redirect does not produce CS1503 int→string.
+    /// </summary>
+    public static NavText GetText(NavJsonToken token, int index)
+    {
+        var backingToken = GetBackingToken(token);
+        if (backingToken is not JArray arr)
+            throw new Exception("The JSON token is not an array.");
+        if (index < 0 || index >= arr.Count)
+            throw new Exception($"The index {index} is outside the bounds of the JSON array.");
+        return new NavText(arr[index].Value<string>() ?? string.Empty);
+    }
+
+    /// <summary>
     /// Replacement for NavJsonObject.ALGetText(key, requireValueExists).
     /// Returns the string value of the named property, with optional existence check.
     /// AL: JsonObject.GetText('key', true)  →  MockJsonHelper.GetText(token, key, requireValueExists)
@@ -501,6 +537,22 @@ public static class MockJsonHelper
     }
 
     /// <summary>
+    /// Replacement for NavJsonArray.ALGetInteger(index).
+    /// Returns the integer value at the given integer index.
+    /// AL: JsonArray.GetInteger(index)  →  MockJsonHelper.GetInteger(token, index)
+    /// Issue #1426: BC emits ALGetInteger(Int32) for JsonArray — adds int overload.
+    /// </summary>
+    public static int GetInteger(NavJsonToken token, int index)
+    {
+        var backingToken = GetBackingToken(token);
+        if (backingToken is not JArray arr)
+            throw new Exception("The JSON token is not an array.");
+        if (index < 0 || index >= arr.Count)
+            throw new Exception($"The index {index} is outside the bounds of the JSON array.");
+        return arr[index].Value<int>();
+    }
+
+    /// <summary>
     /// Replacement for NavJsonObject.ALGetInteger(key, requireValueExists).
     /// Returns the integer value of the named property, with optional existence check.
     /// AL: JsonObject.GetInteger('key', true)  →  MockJsonHelper.GetInteger(token, key, requireValueExists)
@@ -532,6 +584,22 @@ public static class MockJsonHelper
         if (!obj.TryGetValue(key, out var val))
             throw new Exception($"The JSON object does not contain a property with the name '{key}'.");
         return NavDecimal.Create(new Decimal18(val.Value<decimal>()));
+    }
+
+    /// <summary>
+    /// Replacement for NavJsonArray.ALGetDecimal(index).
+    /// Returns the decimal value at the given integer index.
+    /// AL: JsonArray.GetDecimal(index)  →  MockJsonHelper.GetDecimal(token, index)
+    /// Issue #1426: BC emits ALGetDecimal(Int32) for JsonArray — adds int overload.
+    /// </summary>
+    public static NavDecimal GetDecimal(NavJsonToken token, int index)
+    {
+        var backingToken = GetBackingToken(token);
+        if (backingToken is not JArray arr)
+            throw new Exception("The JSON token is not an array.");
+        if (index < 0 || index >= arr.Count)
+            throw new Exception($"The index {index} is outside the bounds of the JSON array.");
+        return NavDecimal.Create(new Decimal18(arr[index].Value<decimal>()));
     }
 
     /// <summary>
@@ -602,6 +670,25 @@ public static class MockJsonHelper
             throw new Exception($"The JSON object does not contain a property with the name '{key}'.");
         if (val is not JArray jArr)
             throw new Exception($"The value of JSON property '{key}' is not an array.");
+        return CreateJsonToken<NavJsonArray>(jArr);
+    }
+
+    /// <summary>
+    /// Replacement for NavJsonArray.ALGetArray(index).
+    /// Returns the nested JsonArray element at the given integer index.
+    /// AL: JsonArray.GetArray(index)  →  MockJsonHelper.GetArray(token, index)
+    /// Issue #1426: BC emits ALGetArray(Int32) for JsonArray — adds int overload.
+    /// </summary>
+    public static NavJsonArray GetArray(NavJsonToken token, int index)
+    {
+        var backingToken = GetBackingToken(token);
+        if (backingToken is not JArray arr)
+            throw new Exception("The JSON token is not an array.");
+        if (index < 0 || index >= arr.Count)
+            throw new Exception($"The index {index} is outside the bounds of the JSON array.");
+        var elem = arr[index];
+        if (elem is not JArray jArr)
+            throw new Exception($"The element at index {index} is not a JSON array.");
         return CreateJsonToken<NavJsonArray>(jArr);
     }
 

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -3734,7 +3734,9 @@ JsonArray.GetArray (Integer):
   layer: runtime-api
   category: JsonArray
   status: covered
-  notes: . Indirectly covered via JsonArray.Get + JsonToken.AsArray(). The BC 21+ typed GetArray(idx) overload is not present in the AL 16.2 compiler bundled with the runner.
+  tests:
+    - tests/bucket-2/data-formats/316-jsonarray-gettext-integer-index
+  notes: MockJsonHelper.GetArray(token, int index) added — issue #1426. BC 17+ (AL compiler 17.0) emits ALGetArray(Int32) which the rewriter redirects to MockJsonHelper.GetArray; without this overload Roslyn rejects with CS1503 int→string.
 
 JsonArray.GetBigInteger (Integer):
   layer: runtime-api
@@ -3748,7 +3750,9 @@ JsonArray.GetBoolean (Integer):
   layer: runtime-api
   category: JsonArray
   status: covered
-  notes: . Indirectly covered via JsonArray.Get + JsonToken.AsValue().AsBoolean(). The BC 21+ typed GetBoolean(idx) overload is not present in the AL 16.2 compiler bundled with the runner.
+  tests:
+    - tests/bucket-2/data-formats/316-jsonarray-gettext-integer-index
+  notes: MockJsonHelper.GetBoolean(token, int index) added — issue #1426. BC 17+ emits ALGetBoolean(Int32) which the rewriter redirects; without this overload Roslyn rejects with CS1503 int→string.
 
 JsonArray.GetByte (Integer):
   layer: runtime-api
@@ -3786,7 +3790,9 @@ JsonArray.GetDecimal (Integer):
   layer: runtime-api
   category: JsonArray
   status: covered
-  notes: . Indirectly covered via JsonArray.Get + JsonToken.AsValue().AsDecimal(). The BC 21+ typed GetDecimal(idx) overload is not present in the AL 16.2 compiler bundled with the runner.
+  tests:
+    - tests/bucket-2/data-formats/316-jsonarray-gettext-integer-index
+  notes: MockJsonHelper.GetDecimal(token, int index) added — issue #1426. BC 17+ emits ALGetDecimal(Int32) which the rewriter redirects; without this overload Roslyn rejects with CS1503 int→string.
 
 JsonArray.GetDuration (Integer):
   layer: runtime-api
@@ -3800,7 +3806,9 @@ JsonArray.GetInteger (Integer):
   layer: runtime-api
   category: JsonArray
   status: covered
-  notes: . Indirectly covered via JsonArray.Get + JsonToken.AsValue().AsInteger(). The BC 21+ typed GetInteger(idx) overload is not present in the AL 16.2 compiler bundled with the runner.
+  tests:
+    - tests/bucket-2/data-formats/316-jsonarray-gettext-integer-index
+  notes: MockJsonHelper.GetInteger(token, int index) added — issue #1426. BC 17+ emits ALGetInteger(Int32) which the rewriter redirects; without this overload Roslyn rejects with CS1503 int→string.
 
 JsonArray.GetObject (Integer):
   layer: runtime-api
@@ -3823,7 +3831,9 @@ JsonArray.GetText (Integer):
   layer: runtime-api
   category: JsonArray
   status: covered
-  notes: . Indirectly covered via JsonArray.Get + JsonToken.AsValue().AsText(). The BC 21+ typed GetText(idx) overload is not present in the AL 16.2 compiler bundled with the runner.
+  tests:
+    - tests/bucket-2/data-formats/316-jsonarray-gettext-integer-index
+  notes: MockJsonHelper.GetText(token, int index) added — issue #1426. BC 17+ (AL compiler 17.0) emits ALGetText(Int32) for JsonArray.GetText(idx); the rewriter redirects to MockJsonHelper.GetText which previously only had a string-key overload, causing CS1503 int→string.
 
 JsonArray.GetTime (Integer):
   layer: runtime-api

--- a/tests/bucket-2/data-formats/316-jsonarray-gettext-integer-index/src/JsonArrayIndexedSrc.al
+++ b/tests/bucket-2/data-formats/316-jsonarray-gettext-integer-index/src/JsonArrayIndexedSrc.al
@@ -1,0 +1,35 @@
+/// Source helpers for JsonArray integer-index GetText/GetInteger/GetDecimal/GetBoolean/GetArray
+/// overloads. Reproduces issue #1426: CS1503 int→string when passing an Integer index
+/// to JsonArray.GetText() / GetInteger() / GetDecimal() / GetBoolean() / GetArray().
+codeunit 316100 "Json Array Indexed Src"
+{
+    /// JsonArray.GetText(Integer index) — reproduces CS1503 from issue #1426.
+    procedure GetTextAtIndex(Cols: JsonArray; Index: Integer): Text
+    begin
+        exit(Cols.GetText(Index));
+    end;
+
+    /// JsonArray.GetInteger(Integer index)
+    procedure GetIntegerAtIndex(Arr: JsonArray; Index: Integer): Integer
+    begin
+        exit(Arr.GetInteger(Index));
+    end;
+
+    /// JsonArray.GetDecimal(Integer index)
+    procedure GetDecimalAtIndex(Arr: JsonArray; Index: Integer): Decimal
+    begin
+        exit(Arr.GetDecimal(Index));
+    end;
+
+    /// JsonArray.GetBoolean(Integer index)
+    procedure GetBooleanAtIndex(Arr: JsonArray; Index: Integer): Boolean
+    begin
+        exit(Arr.GetBoolean(Index));
+    end;
+
+    /// JsonArray.GetArray(Integer index) — nested array
+    procedure GetArrayAtIndex(Arr: JsonArray; Index: Integer): JsonArray
+    begin
+        exit(Arr.GetArray(Index));
+    end;
+}

--- a/tests/bucket-2/data-formats/316-jsonarray-gettext-integer-index/test/JsonArrayIndexedTest.al
+++ b/tests/bucket-2/data-formats/316-jsonarray-gettext-integer-index/test/JsonArrayIndexedTest.al
@@ -1,0 +1,167 @@
+/// Tests for JsonArray integer-index overloads: GetText, GetInteger, GetDecimal, GetBoolean, GetArray.
+/// Regression for issue #1426: CS1503 'int' → 'string' when passing Integer index to JsonArray.GetText(Integer).
+codeunit 316101 "Json Array Indexed Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Helper: Codeunit "Json Array Indexed Src";
+
+    // ── GetText(Integer) ──────────────────────────────────────────────────────
+
+    [Test]
+    procedure GetTextAtIndex_Positive()
+    var
+        Arr: JsonArray;
+        Result: Text;
+    begin
+        // [GIVEN] A JSON array with two string elements
+        Arr.Add('Hello');
+        Arr.Add('World');
+
+        // [WHEN] Getting text at index 0 (first element)
+        Result := Helper.GetTextAtIndex(Arr, 0);
+
+        // [THEN] Returns the correct string value
+        Assert.AreEqual('Hello', Result, 'GetText(0) should return first element');
+    end;
+
+    [Test]
+    procedure GetTextAtIndex_SecondElement()
+    var
+        Arr: JsonArray;
+        Result: Text;
+    begin
+        // [GIVEN] A JSON array with two string elements
+        Arr.Add('Alpha');
+        Arr.Add('Beta');
+
+        // [WHEN] Getting text at index 1 (second element)
+        Result := Helper.GetTextAtIndex(Arr, 1);
+
+        // [THEN] Returns the second element
+        Assert.AreEqual('Beta', Result, 'GetText(1) should return second element');
+    end;
+
+    [Test]
+    procedure GetTextAtIndex_OutOfBounds()
+    var
+        Arr: JsonArray;
+    begin
+        // [GIVEN] An empty JSON array
+        // [WHEN] Getting text at an out-of-bounds index
+        asserterror Helper.GetTextAtIndex(Arr, 5);
+
+        // [THEN] An error is raised
+        Assert.ExpectedError('');
+    end;
+
+    // ── GetInteger(Integer) ───────────────────────────────────────────────────
+
+    [Test]
+    procedure GetIntegerAtIndex_Positive()
+    var
+        Arr: JsonArray;
+        Result: Integer;
+    begin
+        // [GIVEN] A JSON array with integer elements
+        Arr.Add(10);
+        Arr.Add(42);
+
+        // [WHEN] Getting integer at index 1
+        Result := Helper.GetIntegerAtIndex(Arr, 1);
+
+        // [THEN] Returns 42 (not zero — proving the value is read correctly)
+        Assert.AreEqual(42, Result, 'GetInteger(1) should return 42');
+    end;
+
+    [Test]
+    procedure GetIntegerAtIndex_OutOfBounds()
+    var
+        Arr: JsonArray;
+    begin
+        asserterror Helper.GetIntegerAtIndex(Arr, 0);
+        Assert.ExpectedError('');
+    end;
+
+    // ── GetDecimal(Integer) ───────────────────────────────────────────────────
+
+    [Test]
+    procedure GetDecimalAtIndex_Positive()
+    var
+        Arr: JsonArray;
+        Result: Decimal;
+    begin
+        Arr.Add(3.14);
+        Arr.Add(2.72);
+
+        Result := Helper.GetDecimalAtIndex(Arr, 0);
+
+        Assert.AreEqual(3.14, Result, 'GetDecimal(0) should return 3.14');
+    end;
+
+    [Test]
+    procedure GetDecimalAtIndex_OutOfBounds()
+    var
+        Arr: JsonArray;
+    begin
+        asserterror Helper.GetDecimalAtIndex(Arr, 0);
+        Assert.ExpectedError('');
+    end;
+
+    // ── GetBoolean(Integer) ───────────────────────────────────────────────────
+
+    [Test]
+    procedure GetBooleanAtIndex_Positive()
+    var
+        Arr: JsonArray;
+        Result: Boolean;
+    begin
+        Arr.Add(false);
+        Arr.Add(true);
+
+        Result := Helper.GetBooleanAtIndex(Arr, 1);
+
+        // Proves the value is read correctly (not default false)
+        Assert.IsTrue(Result, 'GetBoolean(1) should return true');
+    end;
+
+    [Test]
+    procedure GetBooleanAtIndex_OutOfBounds()
+    var
+        Arr: JsonArray;
+    begin
+        asserterror Helper.GetBooleanAtIndex(Arr, 0);
+        Assert.ExpectedError('');
+    end;
+
+    // ── GetArray(Integer) ─────────────────────────────────────────────────────
+
+    [Test]
+    procedure GetArrayAtIndex_Positive()
+    var
+        OuterArr: JsonArray;
+        InnerArr: JsonArray;
+        Retrieved: JsonArray;
+    begin
+        // [GIVEN] A nested JSON array
+        InnerArr.Add('nested');
+        OuterArr.Add(InnerArr);
+
+        // [WHEN] Getting the inner array at index 0
+        Retrieved := Helper.GetArrayAtIndex(OuterArr, 0);
+
+        // [THEN] The inner array has the expected element count
+        Assert.AreEqual(1, Retrieved.Count(), 'Retrieved inner array should have 1 element');
+    end;
+
+    [Test]
+    procedure GetArrayAtIndex_OutOfBounds()
+    var
+        Arr: JsonArray;
+    begin
+        asserterror Helper.GetArrayAtIndex(Arr, 0);
+        Assert.ExpectedError('');
+    end;
+}


### PR DESCRIPTION
Closes #1426

## Root cause

`JsonArray.GetText(ColNumber)` where `ColNumber: Integer` — BC 17.0 (AL compiler 17.0) emits `cols.ALGetText(colNumber)` which the rewriter redirects to `MockJsonHelper.GetText(cols, colNumber)`. `MockJsonHelper.GetText` only had `(NavJsonToken token, string key)` overloads (for `JsonObject.GetText`), so Roslyn rejected the call with:

```
CS1503: Argument 2: cannot convert from 'int' to 'string'
```

The source-span lookup happened to return the nearby `GetRecRef(...)` AL line (~394), which is why the telemetry showed that line rather than the `ColValue := Cols.GetText(ColNumber)` line.

The same gap existed for all five typed array getters: `GetText`, `GetInteger`, `GetDecimal`, `GetBoolean`, and `GetArray`.

## Fix

Added integer-index overloads to `MockJsonHelper` for all five typed JsonArray getters:

- `GetText(NavJsonToken token, int index)` — returns `NavText`
- `GetInteger(NavJsonToken token, int index)` — returns `int`
- `GetDecimal(NavJsonToken token, int index)` — returns `NavDecimal`
- `GetBoolean(NavJsonToken token, int index)` — returns `bool`
- `GetArray(NavJsonToken token, int index)` — returns `NavJsonArray`

Each overload validates bounds and throws a descriptive error on out-of-range access.

## Tests

New suite `tests/bucket-2/data-formats/316-jsonarray-gettext-integer-index` (codeunits 316100–316101):
- 11 tests covering all 5 overloads
- Positive: asserts specific non-default values (e.g. `GetText(1)` returns `'Beta'`, `GetInteger(1)` returns `42`)
- Negative: out-of-bounds access throws an error

All 1800 bucket-1 and 2171 bucket-2 tests pass.