### PR TITLE
fix: tighten triager closing rule + impl-agent claim race-condition check

### DIFF
--- a/.claude/agents/impl-agent.md
+++ b/.claude/agents/impl-agent.md
@@ -30,7 +30,16 @@ Claim the first eligible `status: ready` issue with no `agent:` label by labelli
 gh issue edit <N> --add-label "agent: <AGENT-ID>" --add-label "status: in-progress" --remove-label "status: ready" --add-assignee @me --repo StefanMaron/BusinessCentral.AL.Runner
 ```
 
-If the assign step fails (e.g. the issue was just grabbed by another user), drop the labels you just added and pick a different issue.
+**Immediately verify the claim** — two agents can race on the same issue:
+```
+gh issue view <N> --json labels --repo StefanMaron/BusinessCentral.AL.Runner \
+  | jq '[.labels[].name | select(startswith("agent:"))]'
+```
+If the output contains **more than one** `agent:` label, you lost the race. Drop your labels and pick a different issue:
+```
+gh issue edit <N> --remove-label "agent: <AGENT-ID>" --remove-label "status: in-progress" --add-label "status: ready" --remove-assignee @me --repo StefanMaron/BusinessCentral.AL.Runner
+```
+Then repeat Step 2 on the next eligible issue.
 
 Read it: `gh issue view <N> --repo StefanMaron/BusinessCentral.AL.Runner`.
 

--- a/.claude/agents/triager.md
+++ b/.claude/agents/triager.md
@@ -75,14 +75,16 @@ gh issue edit <N> --add-label "status: needs-input" --repo StefanMaron/BusinessC
 - Quick search for an obvious duplicate (`gh issue list --search "<keyword>" --state all`). If a duplicate exists, comment linking to it.
 - If a recent commit clearly shipped the fix, comment linking the commit/PR.
 
-### Closing rule (applies to C and D)
+### Closing rule
 
-**Close issues that have the `telemetry` label** (auto-reported crashes from runner telemetry — no human reporter to manage). Use:
+**Close an issue only when it is a confirmed duplicate** (you found the exact prior issue or merged PR that covers it). Close applies equally to telemetry-authored and human-reported issues — but only for duplicates. Use:
 ```
-gh issue close <N> --comment "<one-sentence reason>" --repo StefanMaron/BusinessCentral.AL.Runner
+gh issue close <N> --comment "Duplicate of #<M> — closing." --repo StefanMaron/BusinessCentral.AL.Runner
 ```
 
-**For human-reported issues** (no `telemetry` label), leave the comment but **do not close** — let a human maintainer make that call. Add the `wontfix` label if it's clearly out of scope, otherwise just leave the comment and move on.
+**Thin telemetry issues** (single AL line, no surrounding context) are **not** a reason to close. A telemetry report with only one line might be perfectly reproducible once the pattern is understood. Treat them like any other thin issue: add `status: needs-input`, post the standard comment asking for a minimal AL reproducer and surrounding context, and leave them open.
+
+**Out-of-scope issues** (C above): leave the comment and optionally add `wontfix`, but **do not close** — a human maintainer makes that call.
 
 ## Step 3 — Exit
 After one pass over all untriaged issues, print a short summary:
@@ -100,7 +102,7 @@ Then stop. The orchestrator picks up from `status: ready` and merges PRs; the tr
 - **Shallow pass only.** No code investigation beyond what's needed to decide ready vs. needs-input. No fix proposals.
 - **One comment per issue maximum.** Do not start a back-and-forth.
 - **No relabelling or commenting on issues that already carry a `status:` or `agent:` label** — those are owned by someone else.
-- **Close only `telemetry`-labelled issues.** Human-reported issues get a comment (and optionally `wontfix`) but stay open for a human maintainer to close.
+- **Close only confirmed duplicates.** Everything else — thin context, out-of-scope, telemetry with a single line — gets a comment (and optionally `needs-input` or `wontfix`) but stays open for a human maintainer to close.
 - **Do not close issues silently.** Every close gets a one-sentence comment explaining why.
 - **Never edit code, branches, or PRs.** This agent reads issues and writes labels/comments — nothing else.
 - `--repo StefanMaron/BusinessCentral.AL.Runner` on every `gh` command.


### PR DESCRIPTION
## Summary

- **Triager closing rule**: previously closed telemetry issues with thin context (single AL line) by treating them as near-duplicates. New rule: **close only confirmed duplicates**. Thin context → `status: needs-input` + comment; out-of-scope → `wontfix` comment only; human maintainer closes everything else.
- **Impl-agent race condition**: after claiming an issue, agents now immediately re-read the issue labels. If more than one `agent:` label is present the agent yields — drops its labels, restores `status: ready`, and picks the next eligible issue. Prevents two agents from implementing the same issue in parallel.

## Test plan
- [ ] Triager: re-run triage on the previously-closed telemetry issues (#1451, #1449, etc.) — expect `status: needs-input` + comment instead of close.
- [ ] Impl-agent: next work-cycle with two agents should not pick the same issue.