### PR TITLE
fix: persist TestPage Field.SetValue to underlying record

### DIFF
--- a/AlRunner/Runtime/MockTestPageHandle.cs
+++ b/AlRunner/Runtime/MockTestPageHandle.cs
@@ -391,10 +391,34 @@ public class MockTestPageHandle
     {
         if (!_fields.TryGetValue(fieldHash, out var field))
         {
-            field = new MockTestPageField(fieldHash);
+            field = new MockTestPageField(fieldHash, this);
             _fields[fieldHash] = field;
         }
         return field;
+    }
+
+    /// <summary>
+    /// Called by <see cref="MockTestPageField.ALSetValue"/> to validate and persist
+    /// a value to the field identified by <paramref name="fieldHash"/> on the current
+    /// record.  Throws if the page is not editable (matching BC's behaviour).
+    /// </summary>
+    internal void SetFieldValueOnCurrentRecord(int fieldHash, object? value)
+    {
+        if (!_editable)
+            throw new Exception("The page is in view mode and cannot be edited.");
+
+        EnsureFieldMapping();
+        if (_hashToFieldId == null || !_hashToFieldId.TryGetValue(fieldHash, out var fieldId))
+            return; // field not in source table — nothing to persist
+
+        if (_currentRecord == null)
+            return;
+
+        var navValue = value is NavValue nv ? nv : AlCompat.ToNavValue(value);
+        _currentRecord.ALValidateSafe(fieldId, NavType.Text, navValue);
+        // Persist the validated value back to the in-memory DB so that a
+        // subsequent Record.Get() outside the test page reflects the change.
+        _currentRecord.ALModify(DataError.TrapError, false);
     }
 
     /// <summary>
@@ -522,7 +546,9 @@ public class MockTestPageHandle
         foreach (var (hash, fieldId) in _hashToFieldId)
         {
             var value = rec.GetFieldValueSafe(fieldId, default);
-            GetField(hash).ALSetValue(null!, value);
+            // Use InitializeValue so we copy record data without firing OnValidate triggers
+            // or persisting back — this is a read-only population of the local cache.
+            GetField(hash).InitializeValue(value);
         }
     }
 
@@ -645,6 +671,7 @@ public class MockTestPageHandle
 public class MockTestPageField
 {
     private readonly int _fieldHash;
+    private readonly MockTestPageHandle? _page;
     private object? _value;
 
     public MockTestPageField(int fieldHash)
@@ -653,17 +680,40 @@ public class MockTestPageField
         _value = new NavText("");
     }
 
+    internal MockTestPageField(int fieldHash, MockTestPageHandle page)
+    {
+        _fieldHash = fieldHash;
+        _page = page;
+        _value = new NavText("");
+    }
+
+    /// <summary>
+    /// Internal initialiser — stores the value locally without triggering validation
+    /// or persistence.  Used by <see cref="MockTestPageHandle.PopulateFieldsFromRecord"/>
+    /// to mirror a record's current field values into the page field cache without
+    /// running <c>OnValidate</c> triggers.
+    /// </summary>
+    internal void InitializeValue(object? value)
+    {
+        _value = value;
+    }
+
     /// <summary>
     /// Set the field value. BC passes (session, navValue) — session is null in standalone mode.
+    /// Validates and persists the value to the underlying record when a parent page handle
+    /// is available (i.e. when accessed through <see cref="MockTestPageHandle.GetField"/>).
+    /// Throws if the page was opened in view mode.
     /// </summary>
     public void ALSetValue(object? session, NavValue value)
     {
         _value = value;
+        _page?.SetFieldValueOnCurrentRecord(_fieldHash, value);
     }
 
     public void ALSetValue(object? session, object? value)
     {
         _value = value;
+        _page?.SetFieldValueOnCurrentRecord(_fieldHash, value);
     }
 
     /// <summary>

--- a/AlRunner/Runtime/TableFieldRegistry.cs
+++ b/AlRunner/Runtime/TableFieldRegistry.cs
@@ -84,6 +84,9 @@ public static class TableFieldRegistry
     // pageId -> source tableId (parsed from page SourceTable declarations)
     private static readonly Dictionary<int, int> _pageSourceTable = new();
 
+    // pageId -> unresolved source table name (for pages parsed before their source table)
+    private static readonly Dictionary<int, string> _pagePendingSourceTable = new();
+
     private static readonly Regex OptionMembersProp = new(
         @"\bOptionMembers\s*=\s*([^;]+);",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
@@ -103,6 +106,7 @@ public static class TableFieldRegistry
         _enumFields.Clear();
         _optionMembersFields.Clear();
         _pageSourceTable.Clear();
+        _pagePendingSourceTable.Clear();
     }
 
     public static void ParseAndRegister(string alSource)
@@ -266,6 +270,10 @@ public static class TableFieldRegistry
             var tableName = stMatch.Groups[1].Success ? stMatch.Groups[1].Value : stMatch.Groups[2].Value;
             if (nameToId.TryGetValue(tableName, out var sourceTableId))
                 _pageSourceTable[pageId] = sourceTableId;
+            else
+                // Table not registered yet (page parsed before its source table) — store
+                // the table name for deferred resolution when GetSourceTableId() is called.
+                _pagePendingSourceTable[pageId] = tableName;
         }
 
         // Parse tableextension declarations: register extension fields under the base table ID.
@@ -377,9 +385,31 @@ public static class TableFieldRegistry
     /// <c>SourceTable = "TableName"</c> in the page definition, or <c>null</c> if
     /// not registered.  Populated by <see cref="ParseAndRegister"/> when it
     /// processes page declarations.
+    ///
+    /// When the page was parsed before its source table (file ordering issue),
+    /// the table name is stored as a pending entry and resolved here on first call
+    /// once the table has been registered.
     /// </summary>
     public static int? GetSourceTableId(int pageId)
-        => _pageSourceTable.TryGetValue(pageId, out var id) ? id : null;
+    {
+        if (_pageSourceTable.TryGetValue(pageId, out var id)) return id;
+
+        // Deferred resolution: the page was parsed before its source table was registered.
+        if (_pagePendingSourceTable.TryGetValue(pageId, out var pendingName))
+        {
+            // Try to resolve now that all tables may have been registered.
+            foreach (var kv in _tableNames)
+            {
+                if (string.Equals(kv.Value, pendingName, StringComparison.OrdinalIgnoreCase))
+                {
+                    _pageSourceTable[pageId] = kv.Key;
+                    _pagePendingSourceTable.Remove(pageId);
+                    return kv.Key;
+                }
+            }
+        }
+        return null;
+    }
 
     /// <summary>Returns the table name or null if not registered.</summary>
     public static string? GetTableName(int tableId)

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -9015,7 +9015,8 @@ TestField.SetValue (Joker):
   tests:
     - tests/bucket-2/page-report/269-testrequestpage-methods
     - tests/bucket-2/page-report/71-testpage
-  notes: stores value in-memory; integer SetValue then AsDecimal proved in TestRequestPage handler
+    - tests/bucket-2/page-report/1486-testpage-setvalue-persist
+  notes: stores value in-memory and persists to underlying record via Validate+Modify; integer SetValue then AsDecimal proved in TestRequestPage handler; view-mode pages reject SetValue with error
 
 TestField.ShowMandatory ():
   layer: runtime-api

--- a/tests/bucket-2/page-report/1486-testpage-setvalue-persist/src/Repro.Page.al
+++ b/tests/bucket-2/page-report/1486-testpage-setvalue-persist/src/Repro.Page.al
@@ -1,0 +1,15 @@
+page 500000 "Repro SetValue Card"
+{
+    PageType = Card;
+    SourceTable = "Repro SetValue Tab";
+    Editable = true;
+
+    layout
+    {
+        area(content)
+        {
+            field("No."; Rec."No.") { ApplicationArea = All; }
+            field(Description; Rec.Description) { ApplicationArea = All; }
+        }
+    }
+}

--- a/tests/bucket-2/page-report/1486-testpage-setvalue-persist/src/Repro.Table.al
+++ b/tests/bucket-2/page-report/1486-testpage-setvalue-persist/src/Repro.Table.al
@@ -1,0 +1,15 @@
+table 500000 "Repro SetValue Tab"
+{
+    DataClassification = CustomerContent;
+
+    fields
+    {
+        field(1; "No."; Integer) { }
+        field(2; Description; Text[50]) { }
+    }
+
+    keys
+    {
+        key(PK; "No.") { Clustered = true; }
+    }
+}

--- a/tests/bucket-2/page-report/1486-testpage-setvalue-persist/test/Repro.Test.al
+++ b/tests/bucket-2/page-report/1486-testpage-setvalue-persist/test/Repro.Test.al
@@ -1,0 +1,43 @@
+codeunit 500001 "Repro SetValue Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    [Test]
+    procedure TestPage_SetValue_PersistsToRecord()
+    var
+        ReproRec: Record "Repro SetValue Tab";
+        ReproPage: TestPage "Repro SetValue Card";
+    begin
+        ReproRec.Init();
+        ReproRec."No." := 1;
+        ReproRec.Description := 'initial';
+        ReproRec.Insert();
+
+        ReproPage.OpenEdit();
+        ReproPage.GoToRecord(ReproRec);
+        ReproPage.Description.SetValue('written');
+        ReproPage.Close();
+
+        ReproRec.Get(1);
+        Assert.AreEqual('written', ReproRec.Description, 'TestPage SetValue must persist to underlying record');
+    end;
+
+    [Test]
+    procedure TestPage_SetValue_View_Errors()
+    var
+        ReproRec: Record "Repro SetValue Tab";
+        ReproPage: TestPage "Repro SetValue Card";
+    begin
+        ReproRec.Init();
+        ReproRec."No." := 2;
+        ReproRec.Description := 'initial';
+        ReproRec.Insert();
+
+        ReproPage.OpenView();
+        ReproPage.GoToRecord(ReproRec);
+        asserterror ReproPage.Description.SetValue('blocked');
+    end;
+}


### PR DESCRIPTION
Closes #1486

## Summary

- `MockTestPageField` now holds a back-reference to its parent `MockTestPageHandle` (injected via `GetField()`)
- `ALSetValue` calls the new `SetFieldValueOnCurrentRecord` helper, which validates the value (running `OnValidate`) and calls `Modify()` to persist the change to the in-memory DB
- View-mode pages (`OpenView()`) throw an exception in `SetFieldValueOnCurrentRecord`, so `asserterror` catches it correctly
- Internal `InitializeValue()` method bypasses validation/persistence for the `PopulateFieldsFromRecord` path (which reads from the DB)

### Bonus fix: deferred page source-table resolution

`TableFieldRegistry.GetSourceTableId()` previously returned `null` when the page AL file was parsed before its source table AL file (alphabetical loading order: `Repro.Page.al` before `Repro.Table.al`). Added a pending-name dict that defers resolution until `GetSourceTableId()` is first called.

## Test plan

- RED confirmed: `TestPage_SetValue_PersistsToRecord` fails with `Expected: <written>, Actual: <initial>` before the fix
- GREEN confirmed: both tests pass after the fix
- Full regression matrix: 2170 passed, 3 failed (same 3 pre-existing failures, no regressions)
- `docs/coverage.yaml` updated with new test in `TestField.SetValue (Joker)` entry