### PR TITLE
fix: add MockVariant overloads to MockFieldRef.ALValidate/ALValidateSafe

### DIFF
--- a/AlRunner/Runtime/MockFieldRef.cs
+++ b/AlRunner/Runtime/MockFieldRef.cs
@@ -203,8 +203,22 @@ public class MockFieldRef
             _owner.ValidateFieldValue(_fieldNo, ALValue);
     }
 
+    /// <summary>ALValidate — object/Variant overload; unwraps to NavValue then validates.</summary>
+    public void ALValidate(object value)
+        => ALValidate(AlCompat.ToNavValue(value));
+
+    /// <summary>ALValidate — MockVariant overload; unwraps to NavValue via AlCompat then validates.</summary>
+    public void ALValidate(MockVariant value)
+        => ALValidate(AlCompat.ToNavValue(value));
+
     /// <summary>ALValidateSafe — safe variant of Validate.</summary>
     public void ALValidateSafe(NavValue value) => ALValidate(value);
+
+    /// <summary>ALValidateSafe — MockVariant overload; unwraps to NavValue via AlCompat then validates.</summary>
+    public void ALValidateSafe(MockVariant value) => ALValidate(AlCompat.ToNavValue(value));
+
+    /// <summary>ALValidateSafe — object/Variant overload; unwraps to NavValue then validates.</summary>
+    public void ALValidateSafe(object value) => ALValidate(AlCompat.ToNavValue(value));
 
     /// <summary>ALValidateSafe — no-arg overload (re-validate current value).</summary>
     public void ALValidateSafe() => ALValidate();

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -2599,6 +2599,18 @@ FieldRef.Validate (Joker):
   category: FieldRef
   status: covered
 
+FieldRef.Validate (Variant):
+  layer: runtime-api
+  category: FieldRef
+  status: covered
+  notes: >
+    MockVariant-specific overload on MockFieldRef.ALValidate / ALValidateSafe unwraps
+    the Variant to its underlying NavValue via AlCompat.ToNavValue before firing the
+    OnValidate trigger. Fixes NullReferenceException when BC emits fr.Validate(v)
+    with a Variant argument (closes #1487).
+  tests:
+    - tests/bucket-1/record-table/1313-fieldref-validate-variant
+
 FieldRef.Value (Joker):
   layer: runtime-api
   category: FieldRef

--- a/tests/bucket-1/record-table/1313-fieldref-validate-variant/src/ReproFRValVarTab.Table.al
+++ b/tests/bucket-1/record-table/1313-fieldref-validate-variant/src/ReproFRValVarTab.Table.al
@@ -1,0 +1,22 @@
+table 1313100 "Repro FRValVar Tab"
+{
+    DataClassification = CustomerContent;
+
+    fields
+    {
+        field(1; "No."; Integer) { }
+        field(2; Amount; Decimal)
+        {
+            trigger OnValidate()
+            begin
+                if Amount < 0 then
+                    Error('Amount must be non-negative');
+            end;
+        }
+    }
+
+    keys
+    {
+        key(PK; "No.") { Clustered = true; }
+    }
+}

--- a/tests/bucket-1/record-table/1313-fieldref-validate-variant/test/ReproFRValVarTest.Codeunit.al
+++ b/tests/bucket-1/record-table/1313-fieldref-validate-variant/test/ReproFRValVarTest.Codeunit.al
@@ -1,0 +1,49 @@
+codeunit 1313101 "Repro FRValVar Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    [Test]
+    procedure FieldRef_Validate_Variant_PositiveValue_Persists()
+    var
+        ReproRec: Record "Repro FRValVar Tab";
+        Rr: RecordRef;
+        Fr: FieldRef;
+        V: Variant;
+    begin
+        ReproRec.Init();
+        ReproRec."No." := 1;
+        ReproRec.Insert();
+        Rr.GetTable(ReproRec);
+        Fr := Rr.Field(2);
+
+        V := 12.5;
+        Fr.Validate(V);
+        Rr.Modify();
+        Rr.Close();
+
+        ReproRec.Get(1);
+        Assert.AreEqual(12.5, ReproRec.Amount, 'FieldRef.Validate(Variant) must write the value');
+    end;
+
+    [Test]
+    procedure FieldRef_Validate_Variant_NegativeValue_FiresOnValidateError()
+    var
+        ReproRec: Record "Repro FRValVar Tab";
+        Rr: RecordRef;
+        Fr: FieldRef;
+        V: Variant;
+    begin
+        ReproRec.Init();
+        ReproRec."No." := 2;
+        ReproRec.Insert();
+        Rr.GetTable(ReproRec);
+        Fr := Rr.Field(2);
+
+        V := -1.0;
+        asserterror Fr.Validate(V);
+        Assert.ExpectedError('Amount must be non-negative');
+    end;
+}


### PR DESCRIPTION
Closes #1487

## Summary

- `FieldRef.Validate(Variant)` was throwing `NullReferenceException` because no `MockVariant`-specific overload existed on `MockFieldRef.ALValidate` / `ALValidateSafe`.
- Without the overload, C# resolved the call via the implicit `MockVariant → NavValue?` conversion which mishandles `Decimal18` values (falls to `default:` returning `NavText` instead of `NavDecimal`), or returns `null` when the variant is uninitialized.
- Fix adds `ALValidate(MockVariant)`, `ALValidateSafe(MockVariant)`, and `object` catch-all overloads that unwrap via `AlCompat.ToNavValue`, mirroring the pattern in `MockRecordHandle`.

## Tests

New suite `tests/bucket-1/record-table/1313-fieldref-validate-variant/` with:
- Positive case: `FieldRef.Validate(Variant)` writes value to underlying record and persists via `RecordRef.Modify()`.
- Negative case: `FieldRef.Validate(Variant)` with value triggering `OnValidate` error propagates the correct error message.

RED confirmed before fix, GREEN after fix.