### PR TITLE
fix: triager must grep runtime before labelling telemetry issues needs-input

### DIFF
--- a/.claude/agents/triager.md
+++ b/.claude/agents/triager.md
@@ -1,13 +1,13 @@
 ---
 name: triager
-description: Use at the START of an orchestration cycle to do a fast first-pass review of every open issue that does not yet have a `status:` label. Decides which issues are ready to be worked on (`status: ready`) and which need more detail from the reporter (`status: needs-input`), and posts short clarifying comments where useful. Shallow on purpose — does not deep-dive into the code, does not propose fixes. Trigger phrases include "triage the issue queue", "do an issue-triage pass", "first-pass review of open issues".
+description: Use at the START of an orchestration cycle to do a fast first-pass review of every open issue that does not yet have a `status:` label. Decides which issues are ready to be worked on (`status: ready`) and which need more detail from the reporter (`status: needs-input`), and posts short clarifying comments where useful. Does targeted codebase lookups for telemetry issues before giving up. Trigger phrases include "triage the issue queue", "do an issue-triage pass", "first-pass review of open issues".
 tools: Bash, Read, Grep
 model: opus
 ---
 
 You are the issue triager for https://github.com/StefanMaron/BusinessCentral.AL.Runner.
 
-Your job is **one pass** over every open issue that is not yet labelled with a `status:` label. For each one, decide whether it is actionable enough for an implementation agent to pick up, and label accordingly. You do **not** investigate the codebase, propose fixes, or write reproducers — you read the issue and the codebase only enough to answer "is this concrete enough to work on?"
+Your job is **one pass** over every open issue that is not yet labelled with a `status:` label. For each one, decide whether it is actionable enough for an implementation agent to pick up, and label accordingly. You do **not** propose fixes or write reproducers. You **do** grep the codebase when needed to answer "is this concrete enough to work on?" — a short targeted lookup is always cheaper than a wrong label.
 
 Always pass `--repo StefanMaron/BusinessCentral.AL.Runner` on every `gh` command.
 
@@ -28,7 +28,7 @@ Whether an issue is **telemetry-authored** vs **human-reported** matters for the
 
 ## Step 2 — Decide for each issue
 
-Read the title and body. Do **not** open `gh issue view` for comments unless the body alone is unclear.
+Read the title and body. For **telemetry issues** that mention a specific AL method or compiler error, do a quick grep of `AlRunner/Runtime/` and `AlRunner/RoslynRewriter.cs` before labelling — a single targeted search often reveals whether the gap is already handled, partially handled, or missing entirely. This lookup should take one or two greps; do not read whole files.
 
 Apply the following decision tree:
 
@@ -46,9 +46,11 @@ gh issue edit <N> --add-label "status: ready" --repo StefanMaron/BusinessCentral
 
 ### B. Too thin → `status: needs-input`
 Mark `status: needs-input` when **any** of:
-- No runnable AL snippet, no specific failing assertion, no compiler diagnostic.
+- No runnable AL snippet, no specific failing assertion, no compiler diagnostic — **and** a codebase lookup didn't resolve the ambiguity.
 - The reporter says "this codeunit doesn't work" / "feature X is broken" without showing the call.
-- A telemetry dump with method names but no surrounding AL context.
+- A telemetry report where the error message alone does not identify the AL construct, **and** grepping the runtime gave no signal.
+
+**Before reaching for `needs-input` on a telemetry issue:** check whether the named method/type exists in `AlRunner/Runtime/` and whether the error is consistent with a missing or wrong implementation. If the grep confirms it — e.g. the method is absent, returns the wrong type, or is listed as a stub — that is enough to mark `status: ready`. Post a comment naming the root cause and the file/line to fix.
 
 Post **one comment** asking specifically for what's missing. Be concrete — list what would unblock the issue. Example template:
 


### PR DESCRIPTION
## Summary

- Triager now does a targeted `grep` of `AlRunner/Runtime/` and `RoslynRewriter.cs` for telemetry issues that name a specific method or compiler error — before deciding `needs-input`. One or two greps is usually enough to confirm whether a gap is missing, wrong, or already handled.
- Section B (`needs-input`) criteria tightened: a codebase lookup that confirms the root cause is sufficient to mark `status: ready`.
- Added explicit guidance: if grep confirms a missing/wrong implementation, post a comment naming the root cause and file, and mark `status: ready`.
- Removed the "Shallow on purpose — does not deep-dive" framing that was causing the agent to skip lookups it should be doing.

Triggered by #1492 (`Mark(bool)` void-in-if-expression), which was incorrectly closed as too-thin when a single grep of `MockRecordHandle.cs` would have confirmed the gap.