### PR TITLE
fix: add ALEvaluate(ByRef<char>) overload for Evaluate(Char, Text)

### DIFF
--- a/AlRunner/Runtime/AlScope.cs
+++ b/AlRunner/Runtime/AlScope.cs
@@ -3167,6 +3167,13 @@ public static class AlCompat
         return false;
     }
 
+    public static bool ALEvaluate(ByRef<char> result, NavText text) => ALEvaluate(result, text.ToString());
+    public static bool ALEvaluate(ByRef<char> result, string text)
+    {
+        if (text != null && text.Length == 1) { result.Value = text[0]; return true; }
+        return false;
+    }
+
     /// <summary>
     /// MockVersion Evaluate overload: parses a dotted version string (e.g. "25.1.30000.12345")
     /// into a <see cref="MockVersion"/> stored in the provided <see cref="ByRef{T}"/>.

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -7691,6 +7691,18 @@ System.Evaluate (Version, Text) [ALSystemVariable.ALEvaluate path]:
     plus a class-constrained generic fallback that delegates back to ALSystemVariable for reference types.
     Closes #1429.
 
+System.Evaluate (Char, Text) [ALEvaluate char overload]:
+  layer: runtime-api
+  category: System
+  status: covered
+  tests:
+    - tests/bucket-1/codeunit-runtime/314-evaluate-char
+  notes: >
+    AL Char lowers to C# char (value type), so the generic ALEvaluate<T> where T : class overload
+    fails with CS0452. Fix: explicit non-generic overload ALEvaluate(ByRef<char>, NavText/string)
+    in AlScope.cs — single-char input assigns the character and returns true; any other length
+    returns false. Closes #1483.
+
 System.ExportEncryptionKey (Text):
   layer: runtime-api
   category: System

--- a/tests/bucket-1/codeunit-runtime/314-evaluate-char/src/CharEvaluateRepro.al
+++ b/tests/bucket-1/codeunit-runtime/314-evaluate-char/src/CharEvaluateRepro.al
@@ -1,0 +1,7 @@
+codeunit 1314001 "Char Evaluate Repro"
+{
+    procedure TryParseChar(Input: Text; var Result: Char): Boolean
+    begin
+        exit(Evaluate(Result, Input));
+    end;
+}

--- a/tests/bucket-1/codeunit-runtime/314-evaluate-char/test/CharEvaluateReproTest.al
+++ b/tests/bucket-1/codeunit-runtime/314-evaluate-char/test/CharEvaluateReproTest.al
@@ -1,0 +1,55 @@
+codeunit 1314002 "Char Evaluate Repro Tests"
+{
+    Subtype = Test;
+
+    var
+        Repro: Codeunit "Char Evaluate Repro";
+        Assert: Codeunit Assert;
+
+    [Test]
+    procedure EvaluateChar_SingleChar_ReturnsTrue()
+    var
+        Result: Char;
+        Ok: Boolean;
+    begin
+        // [SCENARIO] Evaluate a single-character text into a Char variable returns true
+        // and assigns the correct character value
+        Ok := Repro.TryParseChar('A', Result);
+        Assert.IsTrue(Ok, 'Evaluate(Char, ''A'') should return true');
+        Assert.AreEqual('A', Format(Result), 'Evaluate(Char, ''A'') should yield A');
+    end;
+
+    [Test]
+    procedure EvaluateChar_NumericChar_ReturnsTrue()
+    var
+        Result: Char;
+        Ok: Boolean;
+    begin
+        // [SCENARIO] Evaluate a single digit character succeeds
+        Ok := Repro.TryParseChar('5', Result);
+        Assert.IsTrue(Ok, 'Evaluate(Char, ''5'') should return true');
+        Assert.AreEqual('5', Format(Result), 'Evaluate(Char, ''5'') should yield 5');
+    end;
+
+    [Test]
+    procedure EvaluateChar_MultiCharText_ReturnsFalse()
+    var
+        Result: Char;
+        Ok: Boolean;
+    begin
+        // [SCENARIO] Evaluate a multi-character text returns false
+        Ok := Repro.TryParseChar('multi', Result);
+        Assert.IsFalse(Ok, 'Evaluate(Char, ''multi'') should return false');
+    end;
+
+    [Test]
+    procedure EvaluateChar_EmptyText_ReturnsFalse()
+    var
+        Result: Char;
+        Ok: Boolean;
+    begin
+        // [SCENARIO] Evaluate an empty text returns false
+        Ok := Repro.TryParseChar('', Result);
+        Assert.IsFalse(Ok, 'Evaluate(Char, '''') should return false');
+    end;
+}


### PR DESCRIPTION
Closes #1483

## Summary

- AL `Char` lowers to C# `char` (value type), causing `Evaluate(CharVar, Text)` to fail with CS0452 since the generic `ALEvaluate<T> where T : class` overload cannot accept struct types.
- Adds explicit non-generic overloads `ALEvaluate(ByRef<char>, NavText)` and `ALEvaluate(ByRef<char>, string)` in `AlScope.cs`, matching the existing pattern for other value types (int, bool, Decimal18, long, Guid, MockVersion).
- Behavior: single-char input assigns the character and returns `true`; empty or multi-char input returns `false`.

## Test plan

- [ ] RED confirmed: CS0452 on `tests/bucket-1/codeunit-runtime/314-evaluate-char/` before fix
- [ ] GREEN confirmed: 4 tests pass after fix (single char, numeric char, multi-char false, empty false)
- [ ] Full regression matrix passes (bucket-2: 2168 passed, 3 pre-existing failures unrelated to this PR)