### PR TITLE
fix: initialize page Rec as temporary when SourceTableTemporary=true

### DIFF
--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -1236,6 +1236,7 @@ public void Unbind() { AlRunner.Runtime.EventSubscriberRegistry.Unbind(this); }
                     int.TryParse(typeName.Substring("Record".Length), out var idFromType))
                     tableId = idFromType;
             }
+            bool isSourceTableTemporary = false;
             if (tableId == 0 && _currentClassName != null && _currentClassName.StartsWith("Page"))
             {
                 // Fallback 2: for page classes (Page<N>), BC emits "NavRecord Rec => this.SourceTable"
@@ -1246,8 +1247,24 @@ public void Unbind() { AlRunner.Runtime.EventSubscriberRegistry.Unbind(this); }
                     var sourceTableId = AlRunner.Runtime.TableFieldRegistry.GetSourceTableId(pageId);
                     if (sourceTableId.HasValue)
                         tableId = sourceTableId.Value;
+                    isSourceTableTemporary = AlRunner.Runtime.TableFieldRegistry.GetIsSourceTableTemporary(pageId);
                 }
             }
+            else if (_currentClassName != null && _currentClassName.StartsWith("Page"))
+            {
+                // tableId was resolved from the property type name, but we still need to check
+                // whether the page declared SourceTableTemporary = true.
+                if (int.TryParse(_currentClassName.AsSpan(4), out var pageId))
+                    isSourceTableTemporary = AlRunner.Runtime.TableFieldRegistry.GetIsSourceTableTemporary(pageId);
+            }
+
+            // Emit new MockRecordHandle(tableId) or new MockRecordHandle(tableId, true)
+            // depending on whether the page declared SourceTableTemporary = true.
+            // The temporary flag ensures the page's Rec uses its own private row store,
+            // isolated from the global table — matching real BC behaviour (issue #1490).
+            var recInitExpr = isSourceTableTemporary
+                ? $"new MockRecordHandle({tableId}, true)"
+                : $"new MockRecordHandle({tableId})";
 
             // Parse a simple auto-property with a default value
             var stubProp = SyntaxFactory.PropertyDeclaration(
@@ -1260,7 +1277,7 @@ public void Unbind() { AlRunner.Runtime.EventSubscriberRegistry.Unbind(this); }
                         SyntaxFactory.AccessorDeclaration(SyntaxKind.GetAccessorDeclaration)
                             .WithSemicolonToken(SyntaxFactory.Token(SyntaxKind.SemicolonToken)))))
                 .WithInitializer(SyntaxFactory.EqualsValueClause(
-                    SyntaxFactory.ParseExpression($"new MockRecordHandle({tableId})")))
+                    SyntaxFactory.ParseExpression(recInitExpr)))
                 .WithSemicolonToken(SyntaxFactory.Token(SyntaxKind.SemicolonToken));
             return stubProp;
         }

--- a/AlRunner/Runtime/MockFormHandle.cs
+++ b/AlRunner/Runtime/MockFormHandle.cs
@@ -148,6 +148,7 @@ public class MockFormHandle
             // the page ID via TableFieldRegistry, rather than the default table-0 fallback
             // in AlCompat.InitializeUninitializedObject (issue #1422).
             var sourceTableId = TableFieldRegistry.GetSourceTableId(PageId) ?? 0;
+            var sourceTableTemporary = TableFieldRegistry.GetIsSourceTableTemporary(PageId);
             foreach (var field in pageType.GetFields(
                 BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic))
             {
@@ -155,7 +156,7 @@ public class MockFormHandle
                 if (field.GetValue(_pageInstance) != null) continue;
                 if (field.FieldType == typeof(MockRecordHandle))
                 {
-                    field.SetValue(_pageInstance, new MockRecordHandle(sourceTableId));
+                    field.SetValue(_pageInstance, new MockRecordHandle(sourceTableId, sourceTableTemporary));
                     continue;
                 }
                 try

--- a/AlRunner/Runtime/TableFieldRegistry.cs
+++ b/AlRunner/Runtime/TableFieldRegistry.cs
@@ -36,6 +36,11 @@ public static class TableFieldRegistry
         @"\bSourceTable\s*=\s*(?:""([^""]+)""|([A-Za-z_][A-Za-z0-9_]*))\s*;",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
+    // SourceTableTemporary = true
+    private static readonly Regex SourceTableTemporaryProp = new(
+        @"\bSourceTableTemporary\s*=\s*true\b",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
     // tableextension Id "Name" extends "BaseTableName" { fields { ... } }
     private static readonly Regex TableExtHeader = new(
         @"\btableextension\s+\d+\s+(?:""[^""]*""|[A-Za-z_][A-Za-z0-9_]*)\s+extends\s+(?:""([^""]+)""|([A-Za-z_][A-Za-z0-9_]*))[^{]*?\{",
@@ -87,6 +92,9 @@ public static class TableFieldRegistry
     // pageId -> unresolved source table name (for pages parsed before their source table)
     private static readonly Dictionary<int, string> _pagePendingSourceTable = new();
 
+    // pageIds that declare SourceTableTemporary = true
+    private static readonly HashSet<int> _pageSourceTableTemporary = new();
+
     private static readonly Regex OptionMembersProp = new(
         @"\bOptionMembers\s*=\s*([^;]+);",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
@@ -107,6 +115,7 @@ public static class TableFieldRegistry
         _optionMembersFields.Clear();
         _pageSourceTable.Clear();
         _pagePendingSourceTable.Clear();
+        _pageSourceTableTemporary.Clear();
     }
 
     public static void ParseAndRegister(string alSource)
@@ -274,6 +283,11 @@ public static class TableFieldRegistry
                 // Table not registered yet (page parsed before its source table) — store
                 // the table name for deferred resolution when GetSourceTableId() is called.
                 _pagePendingSourceTable[pageId] = tableName;
+
+            // Track SourceTableTemporary = true so the rewriter can emit
+            // new MockRecordHandle(tableId, true) for the page's Rec property.
+            if (SourceTableTemporaryProp.IsMatch(pageBody))
+                _pageSourceTableTemporary.Add(pageId);
         }
 
         // Parse tableextension declarations: register extension fields under the base table ID.
@@ -410,6 +424,14 @@ public static class TableFieldRegistry
         }
         return null;
     }
+
+    /// <summary>
+    /// Returns <c>true</c> when the page declared <c>SourceTableTemporary = true</c>.
+    /// Used by the rewriter to emit <c>new MockRecordHandle(tableId, true)</c>
+    /// for the page's <c>Rec</c> property.
+    /// </summary>
+    public static bool GetIsSourceTableTemporary(int pageId)
+        => _pageSourceTableTemporary.Contains(pageId);
 
     /// <summary>Returns the table name or null if not registered.</summary>
     public static string? GetTableName(int tableId)

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -5862,6 +5862,27 @@ Page.Rec (page-as-component public procedures):
     fields to new MockRecordHandle(sourceTableId) after GetUninitializedObject +
     InitializeComponent, covering any remaining null Rec fields.
 
+Page.SourceTableTemporary (Rec isolation):
+  layer: runtime-api
+  category: Page
+  status: covered
+  tests:
+    - tests/bucket-2/page-report/313400-page-sttemp-rec-assign
+  notes: >
+    Pages with SourceTableTemporary = true must have their Rec backed by a private
+    temporary store, not the shared global table. Without this, two Page variables
+    of the same page type in the same test share the global table: the second
+    SetConditions/DeleteAll wipes the first page's rows.
+    Fix (issue #1490):
+    1. TableFieldRegistry.ParseAndRegister now detects SourceTableTemporary = true and
+       stores the page ID in _pageSourceTableTemporary; GetIsSourceTableTemporary(pageId)
+       exposes the flag to callers.
+    2. RoslynRewriter emits new MockRecordHandle(tableId, true) for Rec/xRec auto-properties
+       on pages where SourceTableTemporary is true.
+    3. MockFormHandle.EnsurePageInstance initialises null MockRecordHandle backing fields as
+       new MockRecordHandle(sourceTableId, sourceTableTemporary), so the GetUninitializedObject
+       path also produces a properly isolated Rec.
+
 Page.LookupMode (Boolean):
   layer: runtime-api
   category: Page

--- a/tests/bucket-2/page-report/313400-page-sttemp-rec-assign/src/PageSTTempRecAssign.al
+++ b/tests/bucket-2/page-report/313400-page-sttemp-rec-assign/src/PageSTTempRecAssign.al
@@ -1,0 +1,59 @@
+table 313400 "PSTRA Demo Tbl"
+{
+    DataClassification = CustomerContent;
+
+    fields
+    {
+        field(1; "Template ID"; Code[20]) { }
+        field(2; "Set ID"; Integer) { }
+        field(3; "Line No."; Integer) { }
+        field(10; "Attribute ID"; Integer) { }
+        field(11; Description; Text[50]) { }
+    }
+
+    keys
+    {
+        key(PK; "Template ID", "Set ID", "Line No.") { Clustered = true; }
+    }
+}
+
+page 313400 "PSTRA Demo ListPart"
+{
+    PageType = ListPart;
+    SourceTable = "PSTRA Demo Tbl";
+    SourceTableTemporary = true;
+    Editable = true;
+
+    layout
+    {
+        area(content)
+        {
+            repeater(Group)
+            {
+                field("Line No."; Rec."Line No.") { ApplicationArea = All; }
+                field("Attribute ID"; Rec."Attribute ID") { ApplicationArea = All; }
+                field(Description; Rec.Description) { ApplicationArea = All; }
+            }
+        }
+    }
+
+    internal procedure SetConditions(var Tmp: Record "PSTRA Demo Tbl" temporary)
+    begin
+        Rec.DeleteAll();
+
+        Tmp.SetFilter("Attribute ID", '<>%1', 0);
+
+        if Tmp.FindSet() then
+            repeat
+                Rec := Tmp;
+                Rec.Insert();
+            until Tmp.Next() = 0;
+
+        Tmp.SetRange("Attribute ID");
+    end;
+
+    internal procedure CountRows(): Integer
+    begin
+        exit(Rec.Count());
+    end;
+}

--- a/tests/bucket-2/page-report/313400-page-sttemp-rec-assign/test/PageSTTempRecAssignTest.al
+++ b/tests/bucket-2/page-report/313400-page-sttemp-rec-assign/test/PageSTTempRecAssignTest.al
@@ -1,0 +1,126 @@
+codeunit 313400 "PSTRA Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    local procedure AddBufferLine(var TempBuf: Record "PSTRA Demo Tbl" temporary; TemplID: Code[20]; SetID: Integer; LineNo: Integer; AttrID: Integer; Descr: Text[50])
+    begin
+        TempBuf.Init();
+        TempBuf."Template ID" := TemplID;
+        TempBuf."Set ID" := SetID;
+        TempBuf."Line No." := LineNo;
+        TempBuf."Attribute ID" := AttrID;
+        TempBuf.Description := Descr;
+        TempBuf.Insert();
+    end;
+
+    [Test]
+    procedure SetConditions_AllValidLines_PreservesAll()
+    var
+        Tmp: Record "PSTRA Demo Tbl" temporary;
+        ListPart: Page "PSTRA Demo ListPart";
+    begin
+        // Three rows all with non-zero Attribute ID — all should survive the filter
+        AddBufferLine(Tmp, 'TEMPL1', 1, 10000, 5, 'Wood');
+        AddBufferLine(Tmp, 'TEMPL1', 1, 20000, 10, '100');
+        AddBufferLine(Tmp, 'TEMPL1', 1, 30000, 15, 'Red');
+
+        ListPart.SetConditions(Tmp);
+
+        Assert.AreEqual(3, ListPart.CountRows(), 'Page must contain all 3 valid rows');
+    end;
+
+    [Test]
+    procedure SetConditions_FiltersEmptyLines()
+    var
+        Tmp: Record "PSTRA Demo Tbl" temporary;
+        ListPart: Page "PSTRA Demo ListPart";
+    begin
+        // Middle row has Attribute ID = 0 and should be excluded by the filter
+        AddBufferLine(Tmp, 'TEMPL1', 1, 10000, 5, 'Wood');
+        AddBufferLine(Tmp, 'TEMPL1', 1, 20000, 0, '');
+        AddBufferLine(Tmp, 'TEMPL1', 1, 30000, 10, '100');
+
+        ListPart.SetConditions(Tmp);
+
+        Assert.AreEqual(2, ListPart.CountRows(), 'Page must contain only the 2 non-empty rows');
+    end;
+
+    [Test]
+    procedure SetConditions_EmptySource_YieldsZeroRows()
+    var
+        Tmp: Record "PSTRA Demo Tbl" temporary;
+        ListPart: Page "PSTRA Demo ListPart";
+    begin
+        // No rows in source → page must have zero rows
+        ListPart.SetConditions(Tmp);
+
+        Assert.AreEqual(0, ListPart.CountRows(), 'Page must contain zero rows for empty source');
+    end;
+
+    [Test]
+    procedure SetConditions_AllFilteredOut_YieldsZeroRows()
+    var
+        Tmp: Record "PSTRA Demo Tbl" temporary;
+        ListPart: Page "PSTRA Demo ListPart";
+    begin
+        // All rows have Attribute ID = 0 — all filtered out
+        AddBufferLine(Tmp, 'TEMPL1', 1, 10000, 0, 'Zero');
+        AddBufferLine(Tmp, 'TEMPL1', 1, 20000, 0, 'ZeroTwo');
+
+        ListPart.SetConditions(Tmp);
+
+        Assert.AreEqual(0, ListPart.CountRows(), 'Page must contain zero rows when all are filtered out');
+    end;
+
+    [Test]
+    procedure TwoPageInstances_HaveSeparateStores()
+    // This test exposes the SourceTableTemporary=true bug:
+    // if the page Rec is backed by the shared global table (isTemporary=false),
+    // PageB.SetConditions deletes PageA's rows (via DeleteAll on the shared table),
+    // so PageA.CountRows() would return 0 instead of 3.
+    var
+        TmpA: Record "PSTRA Demo Tbl" temporary;
+        TmpB: Record "PSTRA Demo Tbl" temporary;
+        PageA: Page "PSTRA Demo ListPart";
+        PageB: Page "PSTRA Demo ListPart";
+    begin
+        // PageA: 3 rows with unique PKs
+        AddBufferLine(TmpA, 'TEMPL-A', 1, 10000, 5, 'Wood');
+        AddBufferLine(TmpA, 'TEMPL-A', 1, 20000, 10, 'Steel');
+        AddBufferLine(TmpA, 'TEMPL-A', 1, 30000, 15, 'Iron');
+
+        // PageB: 1 row (different Template ID)
+        AddBufferLine(TmpB, 'TEMPL-B', 2, 10000, 7, 'Copper');
+
+        PageA.SetConditions(TmpA);
+        PageB.SetConditions(TmpB);
+
+        // If Rec is NOT properly temporary, PageB.SetConditions (which calls DeleteAll)
+        // wipes PageA's rows from the shared store. PageA would then return 0.
+        Assert.AreEqual(3, PageA.CountRows(), 'PageA must retain its 3 rows after PageB is populated');
+        Assert.AreEqual(1, PageB.CountRows(), 'PageB must have exactly 1 row');
+    end;
+
+    [Test]
+    procedure SetConditions_CalledTwice_SecondCallUpdates()
+    var
+        Tmp1: Record "PSTRA Demo Tbl" temporary;
+        Tmp2: Record "PSTRA Demo Tbl" temporary;
+        ListPart: Page "PSTRA Demo ListPart";
+    begin
+        // First call: 3 rows
+        AddBufferLine(Tmp1, 'TEMPL1', 1, 10000, 5, 'Wood');
+        AddBufferLine(Tmp1, 'TEMPL1', 1, 20000, 10, 'Steel');
+        AddBufferLine(Tmp1, 'TEMPL1', 1, 30000, 15, 'Iron');
+        ListPart.SetConditions(Tmp1);
+        Assert.AreEqual(3, ListPart.CountRows(), 'After first call: 3 rows expected');
+
+        // Second call: 1 row — DeleteAll() must clear previous rows, then insert new
+        AddBufferLine(Tmp2, 'TEMPL1', 1, 10000, 5, 'Brass');
+        ListPart.SetConditions(Tmp2);
+        Assert.AreEqual(1, ListPart.CountRows(), 'After second call: 1 row expected');
+    end;
+}


### PR DESCRIPTION
Closes #1490

## Summary

- Pages with `SourceTableTemporary = true` must back their `Rec` with a private temporary store, not the shared global table — matching real BC behaviour.
- Without this fix, two `Page` variables of the same page type in the same test codeunit share the global store: `SetConditions`/`DeleteAll` on one page wipes the other page's rows.

## Three-point fix

1. **`TableFieldRegistry`** — `ParseAndRegister` now detects `SourceTableTemporary = true` in the page body and records the page ID in a new `_pageSourceTableTemporary` set; `GetIsSourceTableTemporary(pageId)` exposes the flag.
2. **`RoslynRewriter`** — `VisitPropertyDeclaration` emits `new MockRecordHandle(tableId, true)` for `Rec`/`xRec` auto-properties on pages where the source table is temporary (covers the normal compilation path).
3. **`MockFormHandle.EnsurePageInstance`** — initialises null `MockRecordHandle` backing fields as `new MockRecordHandle(sourceTableId, sourceTableTemporary)`, so the `GetUninitializedObject` path (which skips constructors/initializers) also produces a properly isolated `Rec`.

## Test plan

- `TwoPageInstances_HaveSeparateStores` — RED before fix (PageA count was 1 instead of 3 after PageB was populated), GREEN after.
- `SetConditions_AllValidLines_PreservesAll`, `SetConditions_FiltersEmptyLines`, `SetConditions_EmptySource_YieldsZeroRows`, `SetConditions_AllFilteredOut_YieldsZeroRows`, `SetConditions_CalledTwice_SecondCallUpdates` — all GREEN.
- Full regression (bucket-1 + bucket-2): no new failures introduced.