### PR TITLE
fix: ALMark(bool) returns bool — resolves CS0019 in if-expression context

### DIFF
--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -820,7 +820,7 @@ public object ALReadIsolation { get => Rec.ALReadIsolation; set => Rec.ALReadIso
 public void Clear() => Rec.Clear();
 public void ALTransferFields(MockRecordHandle source, bool initPrimaryKey = true) => Rec.ALTransferFields(source, initPrimaryKey);
 public void ALTransferFields(MockRecordHandle source, bool initPrimaryKey, bool validateFields) => Rec.ALTransferFields(source, initPrimaryKey, validateFields);
-public void ALMark(bool mark) => Rec.ALMark(mark);
+public bool ALMark(bool mark) => Rec.ALMark(mark);
 public bool ALMark() => Rec.ALMark();
 public void ALClearMarks() => Rec.ALClearMarks();
 public bool ALMarkedOnly { get => Rec.ALMarkedOnly; set => Rec.ALMarkedOnly = value; }

--- a/AlRunner/Runtime/MockRecordHandle.cs
+++ b/AlRunner/Runtime/MockRecordHandle.cs
@@ -3214,12 +3214,17 @@ public class MockRecordHandle : IConvertible
     /// <summary>AL Mark() — returns whether the current record is marked.</summary>
     public bool ALMark() => _markedRecords.Contains(GetCurrentPkKey());
 
-    /// <summary>AL Mark(bool) — marks or unmarks the current record.</summary>
-    public void ALMark(bool mark)
+    /// <summary>
+    /// AL Mark(bool) — marks or unmarks the current record.
+    /// Returns <c>mark</c> (the value just set) so that BC-generated code of the form
+    /// <c>CStmtHit(N) &amp; rec.ALMark(true)</c> compiles without CS0019 (#1492).
+    /// </summary>
+    public bool ALMark(bool mark)
     {
         var key = GetCurrentPkKey();
         if (mark) _markedRecords.Add(key);
         else _markedRecords.Remove(key);
+        return mark;
     }
 
     /// <summary>

--- a/AlRunner/Runtime/MockRecordRef.cs
+++ b/AlRunner/Runtime/MockRecordRef.cs
@@ -529,14 +529,17 @@ public class MockRecordRef
 
     /// <summary>
     /// ALMark(bool) — marks or unmarks the current record.
+    /// Returns <c>mark</c> (the value just set) so that BC-generated code of the form
+    /// <c>CStmtHit(N) &amp; rec.ALMark(true)</c> compiles without CS0019 (#1492).
     /// </summary>
-    public void ALMark(bool mark)
+    public bool ALMark(bool mark)
     {
         var key = GetCurrentPkKey();
         if (mark)
             _markedRecords.Add(key);
         else
             _markedRecords.Remove(key);
+        return mark;
     }
 
     /// <summary>

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -6526,6 +6526,7 @@ RecordRef.Mark (Boolean):
   layer: runtime-api
   category: RecordRef
   status: covered
+  notes: ALMark(bool) returns bool (matching Table.Mark fix for CS0019 #1492).
 
 RecordRef.MarkedOnly (Boolean):
   layer: runtime-api
@@ -8363,6 +8364,7 @@ Table.Mark (Boolean):
   status: covered
   tests:
     - tests/bucket-1/record-table/37-record-mark
+  notes: ALMark(bool) returns bool (the value just set) so BC-generated "CStmtHit(N) & rec.ALMark(true)" compiles without CS0019 (#1492). ALMark() (no-arg getter) returns bool as before.
 
 Table.MarkedOnly (Boolean):
   layer: runtime-api

--- a/tests/bucket-1/record-table/37-record-mark/test/TestRecordMark.al
+++ b/tests/bucket-1/record-table/37-record-mark/test/TestRecordMark.al
@@ -100,6 +100,31 @@ codeunit 54000 "Test Record Mark"
         Assert.AreEqual(3, Count, 'MarkedOnly(false) should return all records');
     end;
 
+    [Test]
+    procedure MarkBoolInIfCondition_CompileAndRun()
+    var
+        Rec: Record "Record Mark Table";
+        Hit: Boolean;
+    begin
+        // Regression #1492: CS0019 "Operator '&' cannot be applied to operands of type 'bool' and 'void'"
+        // BC emits "CStmtHit(N) & rec.ALMark(true)" for "if Rec.Mark(true) then", which requires
+        // ALMark(bool) to return bool (not void).
+        // The return value after marking should be truthy (mark was just set to true).
+        InsertRow('Z1', 'Zulu', 99);
+        Rec.Get('Z1');
+
+        Hit := false;
+        if Rec.Mark(true) then
+            Hit := true;
+        Assert.IsTrue(Hit, 'Branch must be taken: Mark(true) used in if-condition');
+
+        // Negative: Mark(false) must return false so the branch is not taken
+        Hit := true;
+        if Rec.Mark(false) then
+            Hit := false;
+        Assert.IsTrue(Hit, 'Branch must NOT be taken: Mark(false) used in if-condition');
+    end;
+
     local procedure InsertRow("No.": Code[20]; Name: Text[50]; Amount: Decimal)
     var
         Rec: Record "Record Mark Table";


### PR DESCRIPTION
Closes #1492

## Summary
- BC emits `CStmtHit(N) & rec.ALMark(true)` for `if Rec.Mark(true) then` in AL
- `ALMark(bool)` was returning `void`, causing CS0019 "Operator '&' cannot be applied to operands of type 'bool' and 'void'"
- Changed `MockRecordHandle.ALMark(bool)`, `MockRecordRef.ALMark(bool)`, and the proxy in `RoslynRewriter.cs` from `void` to `bool` (returning the mark value just set)
- Regression test added to `37-record-mark` covering `Mark(true)` and `Mark(false)` used directly in `if`-conditions

## Test plan
- [ ] New test `MarkBoolInIfCondition_CompileAndRun` in `37-record-mark` verifies: (1) `if Rec.Mark(true) then` compiles and branch is taken, (2) `if Rec.Mark(false) then` compiles and branch is not taken
- [ ] All pre-existing tests in `37-record-mark` still pass
- [ ] Full matrix: 2170 passed, 3 failed (all 3 pre-existing failures unrelated to this change)