### PR TITLE
fix: merge same-arity overloads in auto-stub generator to prevent NavOption/NavCode cast

### DIFF
--- a/AlRunner.Tests/AutoStubEnumParamTests.cs
+++ b/AlRunner.Tests/AutoStubEnumParamTests.cs
@@ -199,6 +199,162 @@ public class AutoStubEnumParamTests
             """);
     }
 
+    /// <summary>
+    /// Regression test for issue #1501: auto-stubbed multi-overload codeunit with same
+    /// parameter count but different types (Enum vs Code[20]) must be handled without a
+    /// NavOption->NavCode cast error.  Before the fix, first-seen-wins dedup kept the
+    /// Code-typed overload, causing InvalidCastException on any Enum-literal call.
+    /// The fix merges same-arity overloads by widening differing positions to Variant.
+    /// </summary>
+    [Fact]
+    public async Task AutoStub_MultiOverload_EnumAndCodeSameArity_EnumCallDoesNotThrow()
+    {
+        if (AlcPath == null) return;
+
+        await RunAutoStubEnumScenario(async (testDir, pkgDir) =>
+        {
+            var libGuid = Guid.NewGuid();
+            var testGuid = Guid.NewGuid();
+            await BuildMultiOverloadLibraryApp(libGuid, pkgDir);
+
+            File.WriteAllText(Path.Combine(testDir, "app.json"), $$"""
+                {
+                  "id": "{{testGuid}}",
+                  "name": "MultiOLTest",
+                  "publisher": "AlRunnerTest",
+                  "version": "1.0.0.0",
+                  "runtime": "14.0",
+                  "dependencies": [
+                    {
+                      "id": "{{libGuid}}",
+                      "name": "MultiOLLib",
+                      "publisher": "AlRunnerTest",
+                      "version": "1.0.0.0"
+                    }
+                  ]
+                }
+                """);
+
+            // The library has two CreateHeader overloads with 3 params each:
+            //   CreateHeader(var Rec; DocType: Enum "..."; CustomerNo: Code[20])
+            //   CreateHeader(var Rec; TemplateCode: Code[20]; SeriesCode: Code[20])
+            // Before the fix, first-seen-wins kept Code-typed overload, causing
+            // NavOption->NavCode cast error on Enum calls.
+            // After the fix, the second param is widened to Variant, accepting both callers.
+            File.WriteAllText(Path.Combine(testDir, "Test.al"), """
+                codeunit 50301 "Multi Overload Stub Tests"
+                {
+                    Subtype = Test;
+
+                    var Assert: Codeunit Assert;
+
+                    [Test]
+                    procedure CallEnumOverload_Order_NoError()
+                    var
+                        Lib: Codeunit "Multi OL Lib";
+                        Hdr: Record "Multi OL Header";
+                    begin
+                        // [GIVEN] An Enum-typed call on a multi-overload auto-stubbed codeunit
+                        // [WHEN]  Called with an Enum literal (NavOption at runtime)
+                        // [THEN]  No NavOption->NavCode cast error (Variant accepts NavOption)
+                        Lib.CreateHeader(Hdr, "Multi OL Doc Type 2"::Order, 'C0001');
+                        Assert.IsTrue(true, 'Enum overload must not throw a cast error');
+                    end;
+
+                    [Test]
+                    procedure CallEnumOverload_Quote_NoError()
+                    var
+                        Lib: Codeunit "Multi OL Lib";
+                        Hdr: Record "Multi OL Header";
+                    begin
+                        // [GIVEN] Same codeunit, different Enum value
+                        // [WHEN]  Called with a different Enum literal
+                        // [THEN]  No error
+                        Lib.CreateHeader(Hdr, "Multi OL Doc Type 2"::Quote, 'C0002');
+                        Assert.IsTrue(true, 'Enum overload with Quote must not throw a cast error');
+                    end;
+
+                    [Test]
+                    procedure CallCodeOverload_NoError()
+                    var
+                        Lib: Codeunit "Multi OL Lib";
+                        Hdr: Record "Multi OL Header";
+                    begin
+                        // [GIVEN] The Code-typed overload on the same codeunit
+                        // [WHEN]  Called with Code literals
+                        // [THEN]  No error -- Variant also accepts NavCode
+                        Lib.CreateHeader(Hdr, 'TPL', 'SER');
+                        Assert.IsTrue(true, 'Code call must also work after dedup fix');
+                    end;
+                }
+                """);
+
+            var result = RunPipeline(testDir, pkgDir);
+
+            AssertPipelinePassed(result);
+            Assert.Equal(3, result.Passed);
+        });
+    }
+
+    private async Task BuildMultiOverloadLibraryApp(Guid libGuid, string pkgDir)
+    {
+        var libDir = Path.Combine(Path.GetDirectoryName(pkgDir)!, "lib-multioverload");
+        Directory.CreateDirectory(libDir);
+
+        // Table + enum + codeunit with two same-arity overloads differing in second param type.
+        File.WriteAllText(Path.Combine(libDir, "MultiOLLib.al"), """
+            enum 50200 "Multi OL Doc Type 2"
+            {
+                Extensible = false;
+                value(0; " ") { Caption = ' '; }
+                value(1; Order) { Caption = 'Order'; }
+                value(2; Quote) { Caption = 'Quote'; }
+            }
+
+            table 50200 "Multi OL Header"
+            {
+                DataClassification = SystemMetadata;
+                fields
+                {
+                    field(1; PK; Integer) { }
+                    field(2; "Customer No"; Code[20]) { }
+                }
+                keys { key(PK; PK) { Clustered = true; } }
+            }
+
+            codeunit 50200 "Multi OL Lib"
+            {
+                // Enum-typed overload -- same arity as the Code overload below.
+                procedure CreateHeader(var Hdr: Record "Multi OL Header"; DocType: Enum "Multi OL Doc Type 2"; CustomerNo: Code[20])
+                begin
+                    Hdr."Customer No" := CustomerNo;
+                end;
+
+                // Code-typed overload -- same arity, different second-param type.
+                procedure CreateHeader(var Hdr: Record "Multi OL Header"; TemplateCode: Code[20]; SeriesCode: Code[20])
+                begin
+                    Hdr."Customer No" := TemplateCode;
+                end;
+            }
+            """);
+
+        File.WriteAllText(Path.Combine(libDir, "app.json"), $$"""
+            {
+              "id": "{{libGuid}}",
+              "name": "MultiOLLib",
+              "publisher": "AlRunnerTest",
+              "version": "1.0.0.0",
+              "runtime": "14.0"
+            }
+            """);
+
+        var libAppPath = await CompileAlApp(libDir);
+        if (libAppPath == null)
+            throw new InvalidOperationException("Failed to compile MultiOLLib .app via alc.");
+
+        File.Copy(libAppPath, Path.Combine(pkgDir, Path.GetFileName(libAppPath)));
+    }
+
     private static PipelineResult RunPipeline(string testDir, string pkgDir)
     {
         var pipeline = new AlRunnerPipeline();

--- a/AlRunner/Pipeline.cs
+++ b/AlRunner/Pipeline.cs
@@ -1695,7 +1695,13 @@ public class AlRunnerPipeline
             var members = getMembersMethod.Invoke(found, null) as System.Collections.IEnumerable;
             if (members == null) { sb.AppendLine("}"); return sb.ToString(); }
 
-            var emittedSigs = new HashSet<string>();
+            // Dedup by (name, paramCount): AL does not support method overloads, so only
+            // one procedure can be emitted per (name, arity) pair.
+            // When same-arity overloads differ in a parameter type (e.g. Enum vs Code[20]),
+            // MERGE them by widening differing positions to Variant — fixes #1501.
+            // Variant accepts both NavOption (Enum callers) and NavCode (Code callers),
+            // preventing the NavOption→NavCode InvalidCastException at runtime.
+            var mergedMethods = new Dictionary<string, (string methodName, List<string> types, List<string> prefixedNames, string returnPart)>();
 
             foreach (var member in members)
             {
@@ -1707,7 +1713,8 @@ public class AlRunnerPipeline
 
                 // Get parameters
                 var paramsProp = member.GetType().GetProperty("Parameters");
-                var paramParts = new List<string>();
+                var typeNames = new List<string>();
+                var prefixedNames = new List<string>();
                 if (paramsProp != null)
                 {
                     var parms = paramsProp.GetValue(member) as System.Collections.IEnumerable;
@@ -1732,12 +1739,11 @@ public class AlRunnerPipeline
                             // makes the stub use value params and avoids the ByRef mismatch.
                             var effectiveIsVar = pIsVar && !IsCSharpPrimitiveMappedType(typeName);
                             var prefix = effectiveIsVar ? "var " : "";
-                            paramParts.Add($"{prefix}{pName}: {typeName}");
+                            typeNames.Add(typeName);
+                            prefixedNames.Add($"{prefix}{pName}");
                         }
                     }
                 }
-
-                var paramStr = string.Join("; ", paramParts);
 
                 // Get return type
                 var returnPart = "";
@@ -1753,13 +1759,26 @@ public class AlRunnerPipeline
                     }
                 }
 
-                // Dedup by (name, paramCount): overloaded methods with different
-                // interface/complex types all collapse to Variant in the stub, producing
-                // identical C# signatures and Roslyn CS0121 ambiguity errors.
-                var sig = $"{methodName}/{paramParts.Count}";
-                if (!emittedSigs.Add(sig)) continue;
+                var sig = $"{methodName}/{typeNames.Count}";
+                if (!mergedMethods.TryGetValue(sig, out var existing))
+                {
+                    mergedMethods[sig] = (methodName, new List<string>(typeNames), new List<string>(prefixedNames), returnPart);
+                }
+                else
+                {
+                    // Merge: widen any position where types differ to Variant.
+                    for (var i = 0; i < typeNames.Count && i < existing.types.Count; i++)
+                    {
+                        if (existing.types[i] != typeNames[i])
+                            existing.types[i] = "Variant";
+                    }
+                }
+            }
 
-                sb.AppendLine($"    procedure {methodName}({paramStr}){returnPart}");
+            foreach (var (_, (mName, types, names, rPart)) in mergedMethods)
+            {
+                var paramStr = string.Join("; ", names.Zip(types, (n, t) => $"{n}: {t}"));
+                sb.AppendLine($"    procedure {mName}({paramStr}){rPart}");
                 sb.AppendLine("    begin");
                 sb.AppendLine("    end;");
                 sb.AppendLine();

--- a/AlRunner/StubGenerator.cs
+++ b/AlRunner/StubGenerator.cs
@@ -625,7 +625,10 @@ public static class StubGenerator
                 var members = getMembersMethod.Invoke(cuSymbol, null) as System.Collections.IEnumerable;
                 if (members != null)
                 {
-                    var emittedSigs = new HashSet<string>();
+                    // Dedup by (name, paramCount): AL does not support method overloads.
+                    // Same-arity overloads that differ in a parameter type (e.g. Enum vs Code[20])
+                    // are MERGED by widening differing positions to Variant — fixes #1501.
+                    var mergedMethods = new Dictionary<string, (string methodName, List<string> types, List<string> prefixedNames, string returnPart)>();
                     foreach (var member in members)
                     {
                         var memberKind = member.GetType().GetProperty("Kind")?.GetValue(member);
@@ -641,7 +644,8 @@ public static class StubGenerator
                             continue;
 
                         var paramsProp = member.GetType().GetProperty("Parameters");
-                        var paramParts = new List<string>();
+                        var typeNames = new List<string>();
+                        var prefixedNames = new List<string>();
                         if (paramsProp != null)
                         {
                             var parms = paramsProp.GetValue(member) as System.Collections.IEnumerable;
@@ -657,12 +661,11 @@ public static class StubGenerator
                                              ?? p.GetType().GetProperty("Type")?.GetValue(p);
                                     var typeName = pType != null ? RenderSymbolTypeViaReflection(pType) : "Variant";
                                     var prefix = pIsVar ? "var " : "";
-                                    paramParts.Add($"{prefix}{pName}: {typeName}");
+                                    typeNames.Add(typeName);
+                                    prefixedNames.Add($"{prefix}{pName}");
                                 }
                             }
                         }
-
-                        var paramStr = string.Join("; ", paramParts);
 
                         var returnPart = "";
                         var retType = member.GetType().GetProperty("ReturnValueType")?.GetValue(member)
@@ -674,11 +677,25 @@ public static class StubGenerator
                                 returnPart = $": {RenderSymbolTypeViaReflection(retType)}";
                         }
 
-                        // Dedup by (name, paramCount) to avoid overloaded identical C# signatures
-                        var sig = $"{methodName}/{paramParts.Count}";
-                        if (!emittedSigs.Add(sig)) continue;
+                        var sig = $"{methodName}/{typeNames.Count}";
+                        if (!mergedMethods.TryGetValue(sig, out var existing))
+                        {
+                            mergedMethods[sig] = (methodName, new List<string>(typeNames), new List<string>(prefixedNames), returnPart);
+                        }
+                        else
+                        {
+                            for (var i = 0; i < typeNames.Count && i < existing.types.Count; i++)
+                            {
+                                if (existing.types[i] != typeNames[i])
+                                    existing.types[i] = "Variant";
+                            }
+                        }
+                    }
 
-                        sb.AppendLine($"    procedure {methodName}({paramStr}){returnPart}");
+                    foreach (var (_, (mName, types, pNames, rPart)) in mergedMethods)
+                    {
+                        var paramStr = string.Join("; ", pNames.Zip(types, (n, t) => $"{n}: {t}"));
+                        sb.AppendLine($"    procedure {mName}({paramStr}){rPart}");
                         sb.AppendLine("    begin");
                         sb.AppendLine("    end;");
                         sb.AppendLine();

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -644,6 +644,21 @@ StubGen.EnumOptionParam:
     literals) no longer get NavOption→NavInteger cast errors. Enum uses "Option" because
     stubs compile without package references (so Enum "X" would fail). Closes #1419.
 
+StubGen.MultiOverloadEnumMerge:
+  layer: syntax
+  category: auto-stub
+  status: covered
+  tests:
+    - tests/bucket-1/codeunit-runtime/315-stubgen-enum-multioverload
+    - AlRunner.Tests/AutoStubEnumParamTests.cs (AutoStub_MultiOverload_EnumAndCodeSameArity_EnumCallDoesNotThrow)
+  notes: >
+    Regression #1501: when a codeunit has same-arity overloads differing in a parameter
+    type (e.g. Enum vs Code[20] for the second param), the first-seen dedup kept only
+    the first overload encountered.  If that was the Code-typed one, calling with an Enum
+    literal caused NavOption→NavCode InvalidCastException.  Fix: same-arity overloads are
+    now MERGED — differing parameter positions are widened to Variant, which accepts both
+    NavOption (Enum callers) and NavCode (Code callers) without a cast error.
+
 var_attribute_item:
   layer: syntax
   category: variable

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -650,7 +650,7 @@ StubGen.MultiOverloadEnumMerge:
   status: covered
   tests:
     - tests/bucket-1/codeunit-runtime/315-stubgen-enum-multioverload
-    - AlRunner.Tests/AutoStubEnumParamTests.cs (AutoStub_MultiOverload_EnumAndCodeSameArity_EnumCallDoesNotThrow)
+    - AlRunner.Tests/AutoStubEnumParamTests.cs
   notes: >
     Regression #1501: when a codeunit has same-arity overloads differing in a parameter
     type (e.g. Enum vs Code[20] for the second param), the first-seen dedup kept only

--- a/tests/bucket-1/codeunit-runtime/315-stubgen-enum-multioverload/src/EnumMultiOverloadSrc.al
+++ b/tests/bucket-1/codeunit-runtime/315-stubgen-enum-multioverload/src/EnumMultiOverloadSrc.al
@@ -1,0 +1,61 @@
+/// Regression fixture for issue #1501.
+///
+/// Simulates the multi-overload pattern that triggers the NavOption/NavCode cast error
+/// in auto-stubbed codeunits: a codeunit with two CreateHeader overloads that share
+/// the same parameter count but differ in the second parameter type
+/// (Enum "Doc Type" vs Code[20]).
+///
+/// The fix in Pipeline.cs / StubGenerator.cs changes the dedup strategy from
+/// first-seen-wins to type-merge: when the same (name, arity) pair appears with
+/// different types, the differing positions are widened to Variant so that both
+/// NavOption (Enum callers) and NavCode (Code callers) pass without a cast error.
+
+enum 1315001 "Multi OL Doc Type"
+{
+    Extensible = false;
+
+    value(0; " ") { Caption = ' '; }
+    value(1; Order) { Caption = 'Order'; }
+    value(2; Quote) { Caption = 'Quote'; }
+    value(3; Invoice) { Caption = 'Invoice'; }
+}
+
+/// Codeunit that deliberately overloads CreateHeader with (Enum, Code) and (Code, Code).
+/// In production use this would come from an auto-stubbed library package.
+codeunit 1315002 "Multi OL Sales Lib"
+{
+    /// Enum-typed overload — call site emits NavOption for the second arg.
+    procedure CreateHeader(var DocHeader: Record "Multi OL Doc Header"; DocType: Enum "Multi OL Doc Type"; CustomerNo: Code[20])
+    begin
+        DocHeader."Doc Type Ordinal" := DocType.AsInteger();
+        DocHeader."Customer No" := CustomerNo;
+    end;
+
+    /// Code-typed overload — same arity as the Enum overload.
+    procedure CreateHeader(var DocHeader: Record "Multi OL Doc Header"; TemplateCode: Code[20]; SeriesCode: Code[20])
+    begin
+        DocHeader."Customer No" := TemplateCode + SeriesCode;
+    end;
+
+    /// Returns the stored ordinal so tests can assert a non-default value.
+    procedure GetDocTypeOrdinal(var DocHeader: Record "Multi OL Doc Header"): Integer
+    begin
+        exit(DocHeader."Doc Type Ordinal");
+    end;
+}
+
+/// Minimal table used as the var-record parameter in CreateHeader.
+table 1315003 "Multi OL Doc Header"
+{
+    DataClassification = SystemMetadata;
+    fields
+    {
+        field(1; PK; Integer) { }
+        field(2; "Doc Type Ordinal"; Integer) { }
+        field(3; "Customer No"; Code[20]) { }
+    }
+    keys
+    {
+        key(PK; PK) { Clustered = true; }
+    }
+}

--- a/tests/bucket-1/codeunit-runtime/315-stubgen-enum-multioverload/test/EnumMultiOverloadTest.al
+++ b/tests/bucket-1/codeunit-runtime/315-stubgen-enum-multioverload/test/EnumMultiOverloadTest.al
@@ -1,0 +1,89 @@
+/// Regression tests for issue #1501.
+///
+/// Before the fix, the auto-stub generator dedup'd overloads by (name, paramCount).
+/// When "CreateHeader" had two 3-param overloads — one with Enum "Doc Type" and one
+/// with Code[20] for the second parameter — only the first overload encountered was
+/// emitted. If the Code[20] overload was seen first, the Enum overload was dropped,
+/// causing a NavOption->NavCode cast error at the call site.
+///
+/// The fix changes the strategy: same-arity overloads that differ in a parameter type
+/// are MERGED, with differing positions widened to Variant. Variant accepts both
+/// NavOption (Enum callers) and NavCode (Code callers) without a cast error.
+///
+/// Note: These tests compile both callee overloads from source (not auto-stubbed),
+/// exercising the runtime dispatch layer. The C# test AutoStubEnumParamTests covers
+/// the actual stub generator path end-to-end when alc.exe is available.
+codeunit 1315004 "Multi OL Enum Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        SalesLib: Codeunit "Multi OL Sales Lib";
+
+    // ---- Positive cases -------------------------------------------------------
+
+    [Test]
+    procedure CreateHeader_EnumOverload_Order_StoresCorrectOrdinal()
+    var
+        DocHeader: Record "Multi OL Doc Header";
+    begin
+        // [GIVEN] An Enum literal for the Order value (ordinal 1)
+        // [WHEN]  CreateHeader is called with the Enum-typed overload
+        // [THEN]  Ordinal 1 is stored — proves the Enum overload was dispatched,
+        //         not dropped in favour of the Code-typed overload
+        DocHeader.Init();
+        SalesLib.CreateHeader(DocHeader, "Multi OL Doc Type"::Order, 'C0001');
+        Assert.AreEqual(1, SalesLib.GetDocTypeOrdinal(DocHeader),
+            'Order enum (ordinal 1) must be stored via the Enum-typed CreateHeader overload');
+        Assert.AreEqual('C0001', DocHeader."Customer No",
+            'Customer No must be set from the Enum overload CustomerNo parameter');
+    end;
+
+    [Test]
+    procedure CreateHeader_EnumOverload_Quote_StoresCorrectOrdinal()
+    var
+        DocHeader: Record "Multi OL Doc Header";
+    begin
+        // [GIVEN] An Enum literal for the Quote value (ordinal 2)
+        // [WHEN]  CreateHeader is called with the Enum-typed overload
+        // [THEN]  The ordinal 2 is stored
+        DocHeader.Init();
+        SalesLib.CreateHeader(DocHeader, "Multi OL Doc Type"::Quote, 'C0002');
+        Assert.AreEqual(2, SalesLib.GetDocTypeOrdinal(DocHeader),
+            'Quote enum (ordinal 2) must be stored via the Enum-typed CreateHeader overload');
+    end;
+
+    [Test]
+    procedure CreateHeader_EnumOverload_Invoice_StoresOrdinal3()
+    var
+        DocHeader: Record "Multi OL Doc Header";
+    begin
+        // [GIVEN] An Enum literal for the Invoice value (ordinal 3)
+        // [WHEN]  CreateHeader is called with the Enum-typed overload
+        // [THEN]  Ordinal 3 is stored
+        DocHeader.Init();
+        SalesLib.CreateHeader(DocHeader, "Multi OL Doc Type"::Invoice, 'C0003');
+        Assert.AreEqual(3, SalesLib.GetDocTypeOrdinal(DocHeader),
+            'Invoice enum (ordinal 3) must be stored via the Enum-typed CreateHeader overload');
+    end;
+
+    // ---- Negative / edge cases ------------------------------------------------
+
+    [Test]
+    procedure CreateHeader_EnumOverload_DefaultEnum_StoresZeroOrdinal()
+    var
+        DocHeader: Record "Multi OL Doc Header";
+        DefaultDocType: Enum "Multi OL Doc Type";
+    begin
+        // [GIVEN] The default enum value (ordinal 0)
+        // [WHEN]  CreateHeader is called with the default enum variable
+        // [THEN]  Ordinal 0 is stored and CustomerNo is set — proves dispatch reached the method
+        DocHeader.Init();
+        SalesLib.CreateHeader(DocHeader, DefaultDocType, 'C0000');
+        Assert.AreEqual(0, SalesLib.GetDocTypeOrdinal(DocHeader),
+            'Default enum (ordinal 0) must dispatch to the Enum overload without a cast error');
+        Assert.AreEqual('C0000', DocHeader."Customer No",
+            'Customer No must be set even for the default enum value');
+    end;
+}


### PR DESCRIPTION
Closes #1501

## Summary

- Auto-stub generator previously deduped same-name same-arity overloads using first-seen-wins. When a codeunit had two 3-param overloads — one with Enum and one with Code[20] for the same position — whichever was encountered first won. If the Code[20] overload was first, any Enum-literal call at the call site threw NavOption->NavCode InvalidCastException at runtime.
- Fix: same-arity overloads are now merged. Parameter positions where types differ across overloads are widened to Variant in the emitted stub. Variant accepts both NavOption (Enum callers) and NavCode (Code callers) without a cast error.
- Adds AL regression fixture 315-stubgen-enum-multioverload and C# end-to-end test AutoStub_MultiOverload_EnumAndCodeSameArity_EnumCallDoesNotThrow that builds a real multi-overload .app via alc and verifies both Enum and Code callers succeed.
- Updates docs/coverage.yaml with StubGen.MultiOverloadEnumMerge entry.

## Test plan

- [x] RED confirmed: AutoStub_MultiOverload_EnumAndCodeSameArity_EnumCallDoesNotThrow failed with NavOption->NavCode before the fix
- [x] GREEN confirmed: all 3 sub-tests pass after the fix
- [x] Regression: StubGen.EnumOptionParam tests (#1419) still pass
- [x] StubGeneratorTests: all 28 pass
- [x] Bucket-2 matrix: 2176 passed, 3 pre-existing failures (unrelated to this PR)