### PR TITLE
test: regression suite for Format(Rec.EnumField) enum-type resolution

### DIFF
--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -7797,6 +7797,7 @@ System.Format (Option):
   status: covered
   tests:
     - tests/bucket-2/data-formats/318-format-option
+    - tests/bucket-2/data-formats/319-format-enum-record
   notes: >
     Format(NavOption) now returns the member name (e.g. "Attention") rather than the ordinal
     integer. AlCompat.FormatNavOption uses NCLOptionMetadata.GetOptionFromIndex(ordinal, false)
@@ -7805,6 +7806,11 @@ System.Format (Option):
     which NREs standalone). Test codeunit OnClear() is now called after InitializeComponent()
     so NavOption fields with inline metadata are properly initialised before tests run.
     Closes #1488.
+    Format(Rec.EnumField) correctly resolves the caption from the field's own enum type even
+    when multiple enums share the same ordinal values. The NavOption stored in the record field
+    bag carries the enum-id tag from CreateTaggedOption; after Insert/Get the same object
+    reference is returned so FormatNavOption looks up the correct enum in EnumRegistry.
+    Regression tests in suite 319 cover the exact pattern from #1507.
 
 System.Text.GreaterThan (Text, Text):
   layer: runtime-api

--- a/tests/bucket-2/data-formats/319-format-enum-record/src/FormatEnumRecord.EnumA.al
+++ b/tests/bucket-2/data-formats/319-format-enum-record/src/FormatEnumRecord.EnumA.al
@@ -1,0 +1,5 @@
+enum 1316001 "FER My Action"
+{
+    value(0; " ") { Caption = ' '; }
+    value(1; SendOrder) { Caption = 'SendOrder'; }
+}

--- a/tests/bucket-2/data-formats/319-format-enum-record/src/FormatEnumRecord.EnumB.al
+++ b/tests/bucket-2/data-formats/319-format-enum-record/src/FormatEnumRecord.EnumB.al
@@ -1,0 +1,5 @@
+enum 1316002 "FER My Status"
+{
+    value(0; " ") { Caption = ' '; }
+    value(1; Success) { Caption = 'Success'; }
+}

--- a/tests/bucket-2/data-formats/319-format-enum-record/src/FormatEnumRecord.Table.al
+++ b/tests/bucket-2/data-formats/319-format-enum-record/src/FormatEnumRecord.Table.al
@@ -1,0 +1,13 @@
+table 1316001 "FER Log"
+{
+    DataClassification = SystemMetadata;
+    fields
+    {
+        field(1; PK; Integer) { }
+        field(2; ActionType; Enum "FER My Action") { }
+    }
+    keys
+    {
+        key(K; PK) { Clustered = true; }
+    }
+}

--- a/tests/bucket-2/data-formats/319-format-enum-record/test/FormatEnumRecord.Test.al
+++ b/tests/bucket-2/data-formats/319-format-enum-record/test/FormatEnumRecord.Test.al
@@ -1,0 +1,77 @@
+codeunit 1316002 "FER Format Enum Record Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    [Test]
+    procedure EnumField_FormatsWithOwnCaption()
+    var
+        Rec: Record "FER Log";
+        StoredCaption: Text;
+        LiteralCaption: Text;
+    begin
+        // RED: Format(Rec.EnumField) must use the field's own enum type,
+        // not another enum that happens to share the same ordinal value.
+        Rec.Init();
+        Rec.PK := 1;
+        Rec.ActionType := "FER My Action"::SendOrder;
+        Rec.Insert(false);
+        Rec.Get(1);
+
+        StoredCaption := Format(Rec.ActionType);
+        LiteralCaption := Format("FER My Action"::SendOrder);
+
+        // Both must return 'SendOrder' — NOT 'Success' (from "FER My Status" ordinal 1)
+        Assert.AreEqual(LiteralCaption, StoredCaption,
+            'Format(Rec.ActionType) must return the same caption as Format("FER My Action"::SendOrder)');
+        Assert.AreEqual('SendOrder', StoredCaption,
+            'Format(Rec.ActionType) must return SendOrder, not a caption from another enum');
+    end;
+
+    [Test]
+    procedure EnumField_ZeroOrdinal_FormatsWithOwnCaption()
+    var
+        Rec: Record "FER Log";
+        StoredCaption: Text;
+    begin
+        // Ordinal 0 edge case: both enums have value(0;" "), caption ' '.
+        // The stored field must still format correctly.
+        Rec.Init();
+        Rec.PK := 2;
+        Rec.ActionType := "FER My Action"::" ";
+        Rec.Insert(false);
+        Rec.Get(2);
+
+        StoredCaption := Format(Rec.ActionType);
+        Assert.AreEqual(' ', StoredCaption,
+            'Format(Rec.ActionType) for ordinal 0 must return the space caption');
+    end;
+
+    [Test]
+    procedure EnumField_LiteralAndFieldAgreement_BothEnums()
+    var
+        LogRec: Record "FER Log";
+        ActionFmt: Text;
+        StatusFmt: Text;
+    begin
+        // Verify that having two enums with the same ordinals in scope does
+        // not corrupt each other's Format output.
+        LogRec.Init();
+        LogRec.PK := 3;
+        LogRec.ActionType := "FER My Action"::SendOrder;
+        LogRec.Insert(false);
+        LogRec.Get(3);
+
+        ActionFmt := Format(LogRec.ActionType);           // must be 'SendOrder'
+        StatusFmt := Format("FER My Status"::Success);    // must be 'Success'
+
+        Assert.AreEqual('SendOrder', ActionFmt,
+            'Format of "FER My Action" field must be SendOrder');
+        Assert.AreEqual('Success', StatusFmt,
+            'Format of "FER My Status" literal must be Success');
+        Assert.AreNotEqual(ActionFmt, StatusFmt,
+            'Two different enums at same ordinal must format differently');
+    end;
+}


### PR DESCRIPTION
Closes #1507

## Summary

- The bug reported in #1507 — `Format(Rec.EnumField)` resolving the caption from the wrong enum type when multiple enums share the same ordinal — was already fixed by commit 151b608 (#1499), which was merged on the same day the issue was filed.
- The fix works because `SetFieldValueSafe` stores the `NavOption` produced by `AlCompat.CreateTaggedOption(enumId, ordinal)`, which tags the option in a `ConditionalWeakTable` with the correct enum object ID. The tag survives `Insert`/`Get` because the stored row holds the same object reference. `FormatNavOption` then resolves the member name from the correct enum via `EnumRegistry.GetMembers(enumId)`.
- This PR adds suite `319-format-enum-record` to prevent future regressions.

## Tests added (`tests/bucket-2/data-formats/319-format-enum-record`)

Three tests covering the exact repro pattern from #1507:
- `EnumField_FormatsWithOwnCaption` — two enums with ordinal 1 (`SendOrder` vs `Success`), asserts `Format(Rec.ActionType)` returns `'SendOrder'`, not `'Success'`
- `EnumField_ZeroOrdinal_FormatsWithOwnCaption` — ordinal 0 edge case
- `EnumField_LiteralAndFieldAgreement_BothEnums` — asserts that two enums with the same ordinals format as different strings

## Test plan

- [x] New suite passes: 3/3 green
- [x] Full bucket-2 run: 2192 passed (3 pre-existing failures unchanged)
- [x] `docs/coverage.yaml` updated with the new test suite reference and explanation