### PR TITLE
fix: MaxStrLen(Record.Field) returns declared length after InitValue/Get

### DIFF
--- a/AlRunner/Runtime/MockRecordHandle.cs
+++ b/AlRunner/Runtime/MockRecordHandle.cs
@@ -400,14 +400,26 @@ public class MockRecordHandle : IConvertible
         // "Unable to cast NavBoolean to NavText". Convert using AL's standard Boolean→Text
         // representation: true → "Yes", false → "No".
         if (expectedType == NavType.Text && value is NavBoolean nb)
-            return new NavText((bool)nb ? "Yes" : "No");
+            value = new NavText((bool)nb ? "Yes" : "No");
         // When an Option/Enum value (NavOption) ends up in a Text field slot — e.g. via
         // FieldRef.Value := EnumFieldRef.Value — the BC runtime casts the stored value
         // to NavText with (NavText)GetFieldValueSafe(fieldNo, NavType.Text), which throws
         // "Unable to cast NavOption to NavText" (issue #1199).
         // Convert using the ordinal integer as a string, consistent with AlCompat.Format().
-        if (expectedType == NavType.Text && value is NavOption nopt)
-            return new NavText(nopt.Value.ToString(System.Globalization.CultureInfo.InvariantCulture));
+        else if (expectedType == NavType.Text && value is NavOption nopt)
+            value = new NavText(nopt.Value.ToString(System.Globalization.CultureInfo.InvariantCulture));
+        // When a NavText is stored in a Text field slot but was created without an explicit
+        // MaxLength (e.g. from InitValue parsing, FieldRef cross-type assignment, or other
+        // paths that call new NavText(string)), MaxStrLen() would return Int32.MaxValue
+        // instead of the declared field length (issue #1506).
+        // Fix: if the stored NavText.MaxLength doesn't match the declared field length,
+        // re-wrap with the correct length from the schema registry.
+        if (expectedType == NavType.Text && value is NavText ntText)
+        {
+            var declaredLen = TableFieldRegistry.GetFieldLength(_tableId, fieldNo);
+            if (declaredLen.HasValue && ntText.MaxLength != declaredLen.Value)
+                return new NavText(declaredLen.Value, (string)ntText);
+        }
         return value;
     }
 

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -9868,7 +9868,9 @@ Text.MaxStrLen (Text):
   layer: runtime-api
   category: Text
   status: covered
-  notes: . Static Text.MaxStrLen form covered — returns the declared Text[N] length.
+  tests:
+    - tests/bucket-1/codeunit-runtime/112-maxstrlen
+  notes: Returns the declared Text[N]/Code[N] length from GetFieldValueSafe (field not yet in _fields) and after Init()/Insert/Get (field in _fields with InitValue or after round-trip). Fixed issue #1506 — CoerceToExpectedType now re-wraps NavText with declared MaxLength when stored without one.
 
 Text.MaxStrLen (Variant):
   layer: runtime-api

--- a/tests/bucket-1/codeunit-runtime/112-maxstrlen/src/MaxStrLenInitValueTable.al
+++ b/tests/bucket-1/codeunit-runtime/112-maxstrlen/src/MaxStrLenInitValueTable.al
@@ -1,0 +1,17 @@
+table 296003 "MaxStrLen InitValue Test"
+{
+    // Table with Text/Code fields that have InitValue declarations.
+    // Used to test that MaxStrLen() returns the declared field length
+    // even after Init() has populated _fields from the InitValue registry
+    // (issue #1506: stored NavText without explicit MaxLength returned Int32.MaxValue).
+    fields
+    {
+        field(1; PK; Integer) { }
+        field(2; Msg; Text[100]) { InitValue = 'default'; }
+        field(3; ShortCode; Code[10]) { InitValue = 'INIT'; }
+    }
+    keys
+    {
+        key(PK; PK) { Clustered = true; }
+    }
+}

--- a/tests/bucket-1/codeunit-runtime/112-maxstrlen/test/MaxStrLenTest.al
+++ b/tests/bucket-1/codeunit-runtime/112-maxstrlen/test/MaxStrLenTest.al
@@ -42,4 +42,48 @@ codeunit 296002 "MaxStrLen Test"
         // [THEN] Returns 100
         Assert.AreEqual(100, MaxStrLen(BoundedVar), 'MaxStrLen(Text[100] variable) should be 100');
     end;
+
+    // --- Tests for issue #1506: MaxStrLen on record field after Init() with InitValue ---
+    // Before the fix, TableInitValueRegistry.BuildInitValue stored NavText without an
+    // explicit MaxLength, so GetFieldValueSafe returned a NavText with MaxLength=Int32.MaxValue
+    // instead of the declared field length.
+
+    [Test]
+    procedure MaxStrLen_TextFieldAfterInit_ReturnsFieldLength()
+    var
+        Rec: Record "MaxStrLen InitValue Test";
+    begin
+        // [GIVEN] A table with Text[100] field that has InitValue = 'default'
+        // [WHEN] Init() is called and MaxStrLen is evaluated on the field
+        // [THEN] Returns 100, not Int32.MaxValue (2147483647)
+        Rec.Init();
+        Assert.AreEqual(100, MaxStrLen(Rec.Msg), 'MaxStrLen(Text[100] with InitValue) should be 100');
+    end;
+
+    [Test]
+    procedure MaxStrLen_CodeFieldAfterInit_ReturnsFieldLength()
+    var
+        Rec: Record "MaxStrLen InitValue Test";
+    begin
+        // [GIVEN] A table with Code[10] field that has InitValue = 'INIT'
+        // [WHEN] Init() is called and MaxStrLen is evaluated on the field
+        // [THEN] Returns 10
+        Rec.Init();
+        Assert.AreEqual(10, MaxStrLen(Rec.ShortCode), 'MaxStrLen(Code[10] with InitValue) should be 10');
+    end;
+
+    [Test]
+    procedure MaxStrLen_TextFieldAfterInsertGet_ReturnsFieldLength()
+    var
+        Rec: Record "MaxStrLen InitValue Test";
+    begin
+        // [GIVEN] A record inserted with a Text[100] field value then re-read via Get
+        // [WHEN] MaxStrLen is evaluated on the field from the retrieved record
+        // [THEN] Returns 100 — not the MaxLength of the stored NavText value
+        Rec.PK := 9999;
+        Rec.Msg := 'Hello World';
+        Rec.Insert();
+        Rec.Get(9999);
+        Assert.AreEqual(100, MaxStrLen(Rec.Msg), 'MaxStrLen(Text[100] after Get) should be 100');
+    end;
 }


### PR DESCRIPTION
Closes #1506

## Summary

`MaxStrLen(Rec.FieldName)` returned `Int32.MaxValue` (2147483647) instead of the declared field length in scenarios where the field value was stored in `_fields` without an explicit NavText `MaxLength`. The primary trigger was a Text field with `InitValue = '...'` — after `Init()`, `TableInitValueRegistry` stored `new NavText(string)` (which has `MaxLength = Int32.MaxValue`) and subsequent `MaxStrLen()` calls read that unbounded value.

## Root Cause

`CoerceToExpectedType` in `MockRecordHandle` already fixed Code fields by re-wrapping with the declared length, but did not apply the same fix for Text fields. When `GetFieldValueSafe` returned a stored `NavText` with `MaxLength = Int32.MaxValue`, `ALSystemString.ALMaxStrLen()` correctly reported that sentinel value.

## Fix

`CoerceToExpectedType` now checks Text fields too: if the stored `NavText.MaxLength` differs from the declared field length (looked up via `TableFieldRegistry`), it re-wraps the value with `new NavText(declaredLen, value)`. This covers all storage paths — InitValue, FieldRef cross-type assignment, or any other path that creates `NavText` without an explicit length.

## Tests

Added to `tests/bucket-1/codeunit-runtime/112-maxstrlen/`:

- `MaxStrLen_TextFieldAfterInit_ReturnsFieldLength` — Text[100] with InitValue after Init() returns 100 (RED before fix, GREEN after)
- `MaxStrLen_CodeFieldAfterInit_ReturnsFieldLength` — Code[10] with InitValue after Init() returns 10
- `MaxStrLen_TextFieldAfterInsertGet_ReturnsFieldLength` — Text[100] field after Insert + Get round-trip returns 100

All 7 tests in the suite pass. Pre-existing bucket-1/bucket-2 failures are unchanged.