### PR TITLE
feat: add --fail-on-stub flag to catch blank-shell stub and no-op test passes

### DIFF
--- a/AlRunner.Tests/FailOnStubTests.cs
+++ b/AlRunner.Tests/FailOnStubTests.cs
@@ -1,0 +1,235 @@
+using AlRunner;
+using AlRunner.Runtime;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// Integration tests for the --fail-on-stub flag (issue #1519).
+///
+/// Each test runs the pipeline with AL source written to temp dirs and verifies:
+/// - Without FailOnStub: stub calls and no-ops silently pass (existing behavior).
+/// - With FailOnStub: stub calls and no-ops fail with a RunnerGapException message.
+/// </summary>
+[Collection("Pipeline")]
+public class FailOnStubTests
+{
+    // ────────────────────────────────────────────────────────────────────────
+    // Helpers
+    // ────────────────────────────────────────────────────────────────────────
+
+    /// Write AL source to a temp directory and return the dir path.
+    private static string WriteTempAl(string fileName, string source)
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, fileName), source);
+        return dir;
+    }
+
+    /// Run the pipeline with a single AL source written to a temp dir.
+    private static PipelineResult RunWithAl(string al, bool failOnStub = false, int? timeoutSec = null)
+    {
+        var dir = WriteTempAl("Test.al", al);
+        var pipeline = new AlRunnerPipeline();
+        var opts = new PipelineOptions
+        {
+            TestIsolation = TestIsolation.Method,
+            FailOnStub = failOnStub,
+            InputPaths = { dir }
+        };
+        if (timeoutSec.HasValue)
+            opts.TestTimeoutSeconds = timeoutSec.Value;
+        return pipeline.Run(opts);
+    }
+
+    // ────────────────────────────────────────────────────────────────────────
+    // AL snippets
+    // ────────────────────────────────────────────────────────────────────────
+
+    private const string CommitTestAl = """
+        codeunit 99001 "Commit Test"
+        {
+            Subtype = Test;
+            var Assert: Codeunit Assert;
+
+            [Test]
+            procedure CallCommit()
+            begin
+                Commit();
+                Assert.IsTrue(true, 'Commit must not throw');
+            end;
+        }
+        """;
+
+    private const string RealHelperAl = """
+        codeunit 99010 "Real Helper Source"
+        {
+            procedure GetValue(): Integer
+            begin
+                exit(42);
+            end;
+        }
+
+        codeunit 99011 "Real Helper Test"
+        {
+            Subtype = Test;
+            var Assert: Codeunit Assert;
+
+            [Test]
+            procedure CallRealHelper()
+            var
+                H: Codeunit "Real Helper Source";
+            begin
+                Assert.AreEqual(42, H.GetValue(), 'Real helper must return 42');
+            end;
+        }
+        """;
+
+    // ────────────────────────────────────────────────────────────────────────
+    // Commit() no-op tests
+    // ────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Commit_WithoutFailOnStub_Passes()
+    {
+        // Without the flag, Commit() is a silent no-op — existing behavior must not change.
+        var result = RunWithAl(CommitTestAl, failOnStub: false);
+        Assert.Equal(0, result.ExitCode);
+        Assert.True(result.Passed >= 1, "Expected at least 1 passing test");
+    }
+
+    [Fact]
+    public void Commit_WithFailOnStub_FailsWithRunnerGapException()
+    {
+        // With --fail-on-stub, Commit() must fail the test with a message naming the call.
+        var result = RunWithAl(CommitTestAl, failOnStub: true);
+        Assert.NotEqual(0, result.ExitCode);
+        // The failure output must name what was called
+        var allOutput = result.StdOut + result.StdErr;
+        Assert.Contains("Commit()", allOutput);
+    }
+
+    [Fact]
+    public void Commit_WithFailOnStub_NoTimeout_FailsWithRunnerGapException()
+    {
+        // Verify the synchronous path (no background thread) also propagates FailOnStub.
+        var result = RunWithAl(CommitTestAl, failOnStub: true, timeoutSec: 0);
+        Assert.NotEqual(0, result.ExitCode);
+        var allOutput = result.StdOut + result.StdErr;
+        Assert.Contains("Commit()", allOutput);
+    }
+
+    // ────────────────────────────────────────────────────────────────────────
+    // Real helper (non-stub) — must always pass regardless of the flag
+    // ────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void RealHelper_WithFailOnStub_StillPasses()
+    {
+        // A codeunit compiled from source is never registered as an auto-stub.
+        // --fail-on-stub must not block calls to real compiled codeunits.
+        var result = RunWithAl(RealHelperAl, failOnStub: true);
+        Assert.Equal(0, result.ExitCode);
+        Assert.True(result.Passed >= 1, "Real helper tests must pass");
+    }
+
+    [Fact]
+    public void RealHelper_ReturnsConcreteValue_WithFailOnStub()
+    {
+        // Positive: the real helper returns 42, not a default value.
+        var result = RunWithAl(RealHelperAl, failOnStub: true);
+        Assert.Equal(0, result.ExitCode);
+        // All tests in the helper suite pass
+        Assert.Equal(0, result.Failed);
+    }
+
+    // ────────────────────────────────────────────────────────────────────────
+    // StubCallGuard unit tests (no pipeline overhead)
+    // ────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void StubCallGuard_CheckNoOp_ThrowsWhenFlagSet()
+    {
+        StubCallGuard.FailOnStub = true;
+        try
+        {
+            var ex = Assert.Throws<RunnerGapException>(
+                () => StubCallGuard.CheckNoOp("Commit()"));
+            Assert.Contains("Commit()", ex.Message);
+            Assert.Contains("no-op", ex.Message);
+        }
+        finally
+        {
+            StubCallGuard.FailOnStub = false;
+        }
+    }
+
+    [Fact]
+    public void StubCallGuard_CheckNoOp_DoesNotThrowWhenFlagNotSet()
+    {
+        StubCallGuard.FailOnStub = false;
+        // Must not throw
+        StubCallGuard.CheckNoOp("Commit()");
+    }
+
+    [Fact]
+    public void StubCallGuard_CheckStub_ThrowsWhenFlagSet()
+    {
+        StubCallGuard.FailOnStub = true;
+        try
+        {
+            var ex = Assert.Throws<RunnerGapException>(
+                () => StubCallGuard.CheckStub("My Codeunit", "DoWork"));
+            Assert.Contains("My Codeunit", ex.Message);
+            Assert.Contains("DoWork", ex.Message);
+            Assert.Contains("blank shell", ex.Message);
+        }
+        finally
+        {
+            StubCallGuard.FailOnStub = false;
+        }
+    }
+
+    [Fact]
+    public void StubCallGuard_CheckStub_DoesNotThrowWhenFlagNotSet()
+    {
+        StubCallGuard.FailOnStub = false;
+        // Must not throw
+        StubCallGuard.CheckStub("My Codeunit", "DoWork");
+    }
+
+    [Fact]
+    public void StubCallGuard_CheckStubById_ThrowsForRegisteredId()
+    {
+        StubCallGuard.FailOnStub = true;
+        StubCallGuard.AutoStubbedCodeunitNames[99999] = "Registered Stub";
+        try
+        {
+            var ex = Assert.Throws<RunnerGapException>(
+                () => StubCallGuard.CheckStubById(99999, "DoWork"));
+            Assert.Contains("Registered Stub", ex.Message);
+            Assert.Contains("blank shell", ex.Message);
+        }
+        finally
+        {
+            StubCallGuard.FailOnStub = false;
+            StubCallGuard.AutoStubbedCodeunitNames.TryRemove(99999, out _);
+        }
+    }
+
+    [Fact]
+    public void StubCallGuard_CheckStubById_DoesNotThrowForUnregisteredId()
+    {
+        StubCallGuard.FailOnStub = true;
+        try
+        {
+            // ID 88888 is not in AutoStubbedCodeunitNames — should not throw
+            StubCallGuard.CheckStubById(88888, "DoWork");
+        }
+        finally
+        {
+            StubCallGuard.FailOnStub = false;
+        }
+    }
+}

--- a/AlRunner/Pipeline.cs
+++ b/AlRunner/Pipeline.cs
@@ -33,6 +33,13 @@ public class PipelineOptions
     public string? OutputJunitPath { get; set; }
     /// <summary>When true, promote exit code 2 (runner limitations) to exit code 1 (failure).</summary>
     public bool Strict { get; set; }
+    /// <summary>
+    /// When true, any call to a blank shell auto-stub or documented runtime no-op causes
+    /// the test to fail with a <see cref="Runtime.RunnerGapException"/> that names the
+    /// offending call. This surfaces false-positive test passes caused by stubs silently
+    /// returning default values instead of real behavior.
+    /// </summary>
+    public bool FailOnStub { get; set; }
     /// <summary>Per-test timeout in seconds. Tests exceeding this are reported as errors
     /// and the runner moves to the next test. Default: 5 seconds. Set to 0 to disable.</summary>
     public int TestTimeoutSeconds { get; set; } = 5;
@@ -363,6 +370,7 @@ public class AlRunnerPipeline
 
         // Apply configurable session properties
         Runtime.AlScope.UserId = options.UserId ?? "TESTUSER";
+        Runtime.StubCallGuard.FailOnStub = options.FailOnStub;
 
         var alSources = new List<string>();
         var sourceFilePaths = new List<string?>(); // parallel to alSources: file path or null
@@ -1630,11 +1638,17 @@ public class AlRunnerPipeline
             result.Add(($"AutoStub_Record{id}", fallback));
         }
 
-        // Track for test output annotation
+        // Track for test output annotation and --fail-on-stub guard
         foreach (var id in missingCodeunits)
+        {
             AutoStubbedCodeunits.TryAdd(id, $"Codeunit {id}");
+            Runtime.StubCallGuard.AutoStubbedCodeunitNames.TryAdd(id, $"Codeunit {id}");
+        }
         foreach (var id in missingTables)
+        {
             AutoStubbedCodeunits.TryAdd(id, $"Table {id}");
+            Runtime.StubCallGuard.AutoStubbedCodeunitNames.TryAdd(id, $"Table {id}");
+        }
 
         // 7. Report
         int total = missingCodeunits.Count + missingTables.Count;
@@ -1786,8 +1800,9 @@ public class AlRunnerPipeline
 
             sb.AppendLine("}");
 
-            // Track the name for reporting
+            // Track the name for reporting and --fail-on-stub guard
             AutoStubbedCodeunits[codeunitId] = foundName;
+            Runtime.StubCallGuard.AutoStubbedCodeunitNames[codeunitId] = foundName;
 
             return sb.ToString();
         }

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -257,6 +257,10 @@ while (argIdx < args.Length)
             options.Strict = true;
             argIdx++;
             break;
+        case "--fail-on-stub":
+            options.FailOnStub = true;
+            argIdx++;
+            break;
         case "--test-timeout":
             argIdx++;
             if (argIdx >= args.Length || !int.TryParse(args[argIdx], out var timeoutSec))
@@ -3025,8 +3029,14 @@ public static class Executor
                     Exception? threadEx = null;
                     (string, int)? threadLastStmt = null;
                     Dictionary<string, int>? threadScopeTracking = null;
+                    // Capture ThreadStatic values from the current thread before spawning
+                    // the background thread. [ThreadStatic] fields start at their CLR default
+                    // (false/null) on every new thread, so we must propagate them explicitly.
+                    var capturedFailOnStub = AlRunner.Runtime.StubCallGuard.FailOnStub;
                     var thread = new Thread(() =>
                     {
+                        // Propagate per-run ThreadStatic flags from the runner thread.
+                        AlRunner.Runtime.StubCallGuard.FailOnStub = capturedFailOnStub;
                         try
                         {
                             if (collectingTest)

--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -52,6 +52,17 @@ public class RoslynRewriter : CSharpSyntaxRewriter
     // Methods on BC types that accept ITreeObject/NavRecord but should be no-ops in standalone mode.
     // NOTE: RunEvent is NOT stripped here anymore — it's intercepted specifically in the
     // statement-level rewriter so we can dispatch to registered event subscribers (#32).
+    /// <summary>
+    /// Stripped methods that have meaningful side-effects in real BC and should fire
+    /// <see cref="AlRunner.Runtime.StubCallGuard.CheckNoOp"/> when --fail-on-stub is active.
+    /// Maps the C# method name to a human-readable BC description.
+    /// </summary>
+    private static readonly Dictionary<string, string> FailOnStubNoOpMethods =
+        new(StringComparer.Ordinal)
+    {
+        { "ALCommit", "Commit()" },   // SQL transaction commit — commits DB writes in real BC
+    };
+
     private static readonly HashSet<string> StripEntireCallMethods = new(StringComparer.Ordinal)
     {
         "ALCommit",   // ALDatabase.ALCommit() — SQL transaction commit, no-op standalone
@@ -5154,10 +5165,35 @@ public void Unbind() { AlRunner.Runtime.EventSubscriberRegistry.Unbind(this); }
         if (node.Expression is InvocationExpressionSyntax invocation)
         {
 
-            // Remove calls to BC-only methods (ALGetTable, ALClose, RunEvent) that can't work standalone
+            // Remove calls to BC-only methods (ALGetTable, ALClose, RunEvent) that can't work standalone.
+            // For methods in FailOnStubNoOpMethods, redirect to StubCallGuard.CheckNoOp() so that
+            // --fail-on-stub mode can detect test passes that silently skipped meaningful BC operations.
             if (invocation.Expression is MemberAccessExpressionSyntax stripMa &&
                 StripEntireCallMethods.Contains(stripMa.Name.Identifier.Text))
             {
+                if (FailOnStubNoOpMethods.TryGetValue(stripMa.Name.Identifier.Text, out var noOpDesc))
+                {
+                    // Redirect to StubCallGuard.CheckNoOp("Commit()") — a no-op when FailOnStub is false,
+                    // throws RunnerGapException when FailOnStub is true.
+                    var checkCall = SyntaxFactory.InvocationExpression(
+                        SyntaxFactory.MemberAccessExpression(
+                            SyntaxKind.SimpleMemberAccessExpression,
+                            SyntaxFactory.MemberAccessExpression(
+                                SyntaxKind.SimpleMemberAccessExpression,
+                                SyntaxFactory.MemberAccessExpression(
+                                    SyntaxKind.SimpleMemberAccessExpression,
+                                    SyntaxFactory.IdentifierName("AlRunner"),
+                                    SyntaxFactory.IdentifierName("Runtime")),
+                                SyntaxFactory.IdentifierName("StubCallGuard")),
+                            SyntaxFactory.IdentifierName("CheckNoOp")),
+                        SyntaxFactory.ArgumentList(
+                            SyntaxFactory.SingletonSeparatedList(
+                                SyntaxFactory.Argument(
+                                    SyntaxFactory.LiteralExpression(
+                                        SyntaxKind.StringLiteralExpression,
+                                        SyntaxFactory.Literal(noOpDesc))))));
+                    return SyntaxFactory.ExpressionStatement(checkCall);
+                }
                 // Return empty statement instead of null to avoid crash inside using blocks
                 return SyntaxFactory.EmptyStatement();
             }

--- a/AlRunner/Runtime/AlScope.cs
+++ b/AlRunner/Runtime/AlScope.cs
@@ -472,8 +472,14 @@ public class MockCurrPage
     /// <summary>
     /// CurrPage.CancelBackgroundTask — no-op in standalone mode (task already ran synchronously).
     /// </summary>
-    public void CancelBackgroundTask(int taskId) { }
-    public void CancelBackgroundTask(DataError errorLevel, int taskId) { }
+    public void CancelBackgroundTask(int taskId)
+    {
+        StubCallGuard.CheckNoOp("CurrPage.CancelBackgroundTask");
+    }
+    public void CancelBackgroundTask(DataError errorLevel, int taskId)
+    {
+        StubCallGuard.CheckNoOp("CurrPage.CancelBackgroundTask");
+    }
 
     /// <summary>
     /// CurrPage.GetPart(partHash) — used by page extension code when accessing subpages

--- a/AlRunner/Runtime/MockCodeunitHandle.cs
+++ b/AlRunner/Runtime/MockCodeunitHandle.cs
@@ -226,7 +226,9 @@ public class MockCodeunitHandle
         // Track codeunit access for timeout diagnostics
         try { AccessedAutoStubs?.Add(_codeunitId); } catch { }
 
-
+        // Fail-on-stub: if --fail-on-stub is active and this codeunit is a blank shell,
+        // throw immediately instead of silently returning a default value.
+        StubCallGuard.CheckStubById(_codeunitId);
 
         var assembly = CurrentAssembly ?? Assembly.GetExecutingAssembly();
         var codeunitType = FindCodeunitType(assembly);
@@ -478,6 +480,9 @@ public class MockCodeunitHandle
 
     private static void RunCodeunitCore(int codeunitId, MockRecordHandle? record = null)
     {
+        // Fail-on-stub: if --fail-on-stub is active and this codeunit is a blank shell, throw.
+        StubCallGuard.CheckStubById(codeunitId, "OnRun");
+
         var handle = new MockCodeunitHandle(codeunitId);
         // Invoke the OnRun scope (member ID 0 or find OnRun explicitly)
         var assembly = CurrentAssembly ?? Assembly.GetExecutingAssembly();

--- a/AlRunner/Runtime/StubCallGuard.cs
+++ b/AlRunner/Runtime/StubCallGuard.cs
@@ -1,0 +1,76 @@
+namespace AlRunner.Runtime;
+
+/// <summary>
+/// Thrown when --fail-on-stub is active and a blank shell stub or documented
+/// runtime no-op is called. Allows callers to catch specifically.
+/// </summary>
+public class RunnerGapException : Exception
+{
+    public RunnerGapException(string message) : base(message) { }
+}
+
+/// <summary>
+/// Guards against accidental test passes caused by blank shell stubs or runtime no-ops.
+/// When <see cref="FailOnStub"/> is true (set by --fail-on-stub), any call to a
+/// generated blank shell or a documented no-op throws <see cref="RunnerGapException"/>.
+/// </summary>
+public static class StubCallGuard
+{
+    /// <summary>
+    /// When true, blank-shell calls and runtime no-ops throw rather than silently succeeding.
+    /// Set to <c>options.FailOnStub</c> at the start of each pipeline run.
+    /// Thread-static so concurrent tests in different threads don't interfere.
+    /// </summary>
+    [ThreadStatic]
+    public static bool FailOnStub;
+
+    /// <summary>
+    /// Maps auto-stubbed codeunit IDs to their display name (e.g. "Sales Header").
+    /// Populated by the pipeline when auto-stubs are generated.
+    /// Used by <see cref="MockCodeunitHandle"/> to report the correct name in the error message.
+    /// </summary>
+    public static readonly System.Collections.Concurrent.ConcurrentDictionary<int, string>
+        AutoStubbedCodeunitNames = new();
+
+    /// <summary>
+    /// Check whether the given object/procedure is a blank shell auto-stub.
+    /// Call this at the top of every generated auto-stub body.
+    /// </summary>
+    public static void CheckStub(string objectName, string procedureName)
+    {
+        if (!FailOnStub) return;
+        throw new RunnerGapException(
+            $"'{objectName}.{procedureName}' is a blank shell — " +
+            $"add this object to your compiled dependency slice or remove --fail-on-stub.");
+    }
+
+    /// <summary>
+    /// Check whether the codeunit with the given ID is an auto-stubbed blank shell.
+    /// Called by <see cref="MockCodeunitHandle"/> before dispatching to a stub codeunit.
+    /// </summary>
+    /// <param name="codeunitId">The codeunit ID being invoked.</param>
+    /// <param name="procedureName">The procedure name being called (for the error message).</param>
+    public static void CheckStubById(int codeunitId, string? procedureName = null)
+    {
+        if (!FailOnStub) return;
+        if (!AutoStubbedCodeunitNames.TryGetValue(codeunitId, out var name))
+            return;
+        var proc = procedureName != null ? $".{procedureName}" : "";
+        throw new RunnerGapException(
+            $"'{name}{proc}' (codeunit {codeunitId}) is a blank shell — " +
+            $"add this object to your compiled dependency slice or remove --fail-on-stub.");
+    }
+
+    /// <summary>
+    /// Check whether the named operation is a documented runtime no-op.
+    /// Call this at the top of any runtime method that does nothing but would have
+    /// real side-effects in live BC.
+    /// </summary>
+    public static void CheckNoOp(string description)
+    {
+        if (!FailOnStub) return;
+        throw new RunnerGapException(
+            $"'{description}' is a no-op in the runner — " +
+            $"this call has no effect here but does in real BC. Remove --fail-on-stub or adjust the test.");
+    }
+}

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -13307,6 +13307,24 @@ DiagnosticSuppression.Case3.CrossExtensionExtensionObject:
     Same-extension dups are caught by DetectSameExtensionDuplicates pre-scan (exit 3).
     Non-extension types (Codeunit, Table, Page) are always forwarded. Audited in #1365.
 
+CLIFlag.FailOnStub:
+  layer: syntax
+  category: runner-flag
+  status: covered
+  tests:
+    - tests/bucket-1/codeunit-runtime/319-fail-on-stub
+    - AlRunner.Tests/FailOnStubTests.cs
+  notes: >
+    --fail-on-stub causes any call to a blank-shell auto-stub or a documented
+    runtime no-op (e.g. Commit()) to throw RunnerGapException instead of
+    silently returning a default value. This surfaces false-positive test
+    passes caused by stubs. Implemented in issue #1519:
+    PipelineOptions.FailOnStub → StubCallGuard.FailOnStub (ThreadStatic, propagated
+    to per-test background threads). Commit() redirected in RoslynRewriter from
+    EmptyStatement to StubCallGuard.CheckNoOp. Auto-stub codeunit calls guarded in
+    MockCodeunitHandle.Invoke and RunCodeunitCore via StubCallGuard.CheckStubById.
+    CurrPage.CancelBackgroundTask guarded in AlScope.cs MockCurrPage.
+
 DiagnosticSuppression.Backfill.SameExtProfileextDuplicate:
   layer: syntax
   category: diagnostic-suppression

--- a/tests/bucket-1/codeunit-runtime/319-fail-on-stub/src/FailOnStubHelper.al
+++ b/tests/bucket-1/codeunit-runtime/319-fail-on-stub/src/FailOnStubHelper.al
@@ -1,0 +1,23 @@
+/// Helper codeunit used by fail-on-stub tests.
+/// This codeunit is compiled from source (not auto-stubbed), so calling it
+/// must always succeed regardless of --fail-on-stub.
+codeunit 1319001 "FOS Real Helper"
+{
+    procedure GetValue(): Integer
+    begin
+        exit(42);
+    end;
+
+    procedure DoWork()
+    begin
+        // Real implementation — not a stub.
+    end;
+
+    procedure CallCommit()
+    begin
+        // Commit() is a no-op in the runner. Without --fail-on-stub it silently
+        // passes; with --fail-on-stub it throws RunnerGapException.
+        // This helper lets the AL test call Commit() indirectly.
+        Commit();
+    end;
+}

--- a/tests/bucket-1/codeunit-runtime/319-fail-on-stub/test/FailOnStubTest.al
+++ b/tests/bucket-1/codeunit-runtime/319-fail-on-stub/test/FailOnStubTest.al
@@ -1,0 +1,59 @@
+// Tests for --fail-on-stub behavior (issue #1519).
+// These tests run WITHOUT --fail-on-stub in the normal matrix, so they verify
+// that stub calls and no-ops silently pass (existing behavior unchanged).
+// The complementary tests that verify --fail-on-stub CAUSES failures live in
+// AlRunner.Tests/FailOnStubTests.cs (C# pipeline tests).
+codeunit 1319002 "Fail On Stub Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    [Test]
+    procedure RealHelper_ReturnsValue_WithoutFailOnStub()
+    var
+        Helper: Codeunit "FOS Real Helper";
+        Result: Integer;
+    begin
+        // [GIVEN] A real (non-stub) codeunit compiled from source
+        // [WHEN]  Its method is called
+        Result := Helper.GetValue();
+        // [THEN]  Returns the concrete value — not a default
+        Assert.AreEqual(42, Result, 'Real helper must return 42');
+    end;
+
+    [Test]
+    procedure RealHelper_VoidCall_DoesNotThrow_WithoutFailOnStub()
+    var
+        Helper: Codeunit "FOS Real Helper";
+    begin
+        // [GIVEN] A real (non-stub) codeunit
+        // [WHEN]  Its void method is called
+        Helper.DoWork();
+        // [THEN]  No exception — real implementations are never blocked by the guard
+        Assert.IsTrue(true, 'DoWork must not throw');
+    end;
+
+    [Test]
+    procedure Commit_IsNoOp_WithoutFailOnStub()
+    var
+        Helper: Codeunit "FOS Real Helper";
+    begin
+        // [GIVEN] --fail-on-stub is NOT active (normal run)
+        // [WHEN]  Commit() is called (via helper to keep the test codeunit itself simple)
+        Helper.CallCommit();
+        // [THEN]  No exception — Commit() is silently stripped in the runner
+        Assert.IsTrue(true, 'Commit must not throw without --fail-on-stub');
+    end;
+
+    [Test]
+    procedure Commit_Direct_IsNoOp_WithoutFailOnStub()
+    begin
+        // [GIVEN] --fail-on-stub is NOT active
+        // [WHEN]  Commit() is called directly from the test codeunit
+        Commit();
+        // [THEN]  No exception
+        Assert.IsTrue(true, 'Direct Commit must not throw without --fail-on-stub');
+    end;
+}


### PR DESCRIPTION
## Summary

- Adds `--fail-on-stub` CLI flag (and `PipelineOptions.FailOnStub`) that causes any call to a blank-shell auto-stub or documented runtime no-op to throw `RunnerGapException` instead of silently returning default values
- Redirects `Commit()` through `StubCallGuard.CheckNoOp` in the rewriter (no-op when flag is off, throws when on); `CurrPage.CancelBackgroundTask` gets the same treatment in `AlScope.cs`
- `MockCodeunitHandle.Invoke` and `RunCodeunitCore` call `StubCallGuard.CheckStubById` to block blank-shell auto-stub calls in strict mode
- `[ThreadStatic]` flag is propagated to per-test background threads so the default-5s timeout path also works

## Test plan

- [x] `AlRunner.Tests/FailOnStubTests.cs` — 11 new C# pipeline tests: `Commit()` fails with flag, passes without; real compiled codeunit always passes; `StubCallGuard` unit tests for all three check methods
- [x] `tests/bucket-1/codeunit-runtime/319-fail-on-stub/` — 4 AL tests confirming normal behavior (without `--fail-on-stub`) is unchanged
- [x] Full bucket-1 (1880 tests + 1 pre-existing blocked) and bucket-2 (2276 tests) pass unmodified
- [x] All 404 `AlRunner.Tests` C# tests pass
- [x] `docs/coverage.yaml` updated with `CLIFlag.FailOnStub` entry

Closes #1519