### PR TITLE
fix(MockFile): ALOpen/ALErase/ALCopy return bool to fix CS0023 in boolean contexts

### DIFF
--- a/AlRunner/Runtime/MockFile.cs
+++ b/AlRunner/Runtime/MockFile.cs
@@ -45,15 +45,15 @@ public class MockFile
     /// <summary>File.Exists with DataError overload.</summary>
     public static bool ALExists(DataError errorLevel, string name) => false;
 
-    /// <summary>File.Copy — no-op in standalone mode.</summary>
-    public static void ALCopy(string fromName, string toName) { }
+    /// <summary>File.Copy — no-op in standalone mode. Returns true (BC returns Boolean).</summary>
+    public static bool ALCopy(string fromName, string toName) => true;
 
-    public static void ALCopy(DataError errorLevel, string fromName, string toName) { }
+    public static bool ALCopy(DataError errorLevel, string fromName, string toName) => true;
 
-    /// <summary>File.Erase — no-op in standalone mode.</summary>
-    public static void ALErase(string name) { }
+    /// <summary>File.Erase — no-op in standalone mode. Returns true (BC returns Boolean).</summary>
+    public static bool ALErase(string name) => true;
 
-    public static void ALErase(DataError errorLevel, string name) { }
+    public static bool ALErase(DataError errorLevel, string name) => true;
 
     /// <summary>File.Rename — no-op in standalone mode.</summary>
     public static void ALRename(string oldName, string newName) { }
@@ -79,14 +79,15 @@ public class MockFile
 
     public bool ALCreate(object? parent, string name) => ALCreate(parent, DataError.ThrowError, name);
 
-    /// <summary>ALOpen — opens an in-memory buffer for reading.</summary>
-    public void ALOpen(object? parent, DataError errorLevel, string name)
+    /// <summary>ALOpen — opens an in-memory buffer for reading. Returns true (BC File.Open returns Boolean).</summary>
+    public bool ALOpen(object? parent, DataError errorLevel, string name)
     {
         _name = name;
         _pos = 0;
+        return true;
     }
 
-    public void ALOpen(object? parent, string name) => ALOpen(parent, DataError.ThrowError, name);
+    public bool ALOpen(object? parent, string name) => ALOpen(parent, DataError.ThrowError, name);
 
     /// <summary>ALClose — resets stream position.</summary>
     public void ALClose()

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -2748,7 +2748,9 @@ File.Copy (Text, Text):
   layer: runtime-api
   category: File
   status: covered
-  notes: MockFile.ALCopy() no-op in standalone
+  tests:
+    - tests/bucket-1/codeunit-runtime/320-file-bool-returns
+  notes: MockFile.ALCopy() returns bool true in standalone (issue #1530)
 
 File.Create (Text, TextEncoding):
   layer: runtime-api
@@ -2792,7 +2794,9 @@ File.Erase (Text):
   layer: runtime-api
   category: File
   status: covered
-  notes: MockFile.ALErase() no-op in standalone
+  tests:
+    - tests/bucket-1/codeunit-runtime/320-file-bool-returns
+  notes: MockFile.ALErase() returns bool true in standalone (issue #1530)
 
 File.Exists (Text):
   layer: runtime-api
@@ -2828,7 +2832,9 @@ File.Open (Text, TextEncoding):
   layer: runtime-api
   category: File
   status: covered
-  notes: MockFile.ALOpen() resets position for reading
+  tests:
+    - tests/bucket-1/codeunit-runtime/320-file-bool-returns
+  notes: MockFile.ALOpen() returns bool true in standalone; used in boolean context (issue #1530)
 
 File.Pos ():
   layer: runtime-api

--- a/tests/bucket-1/codeunit-runtime/320-file-bool-returns/test/FileBoolReturnsTest.al
+++ b/tests/bucket-1/codeunit-runtime/320-file-bool-returns/test/FileBoolReturnsTest.al
@@ -1,0 +1,72 @@
+/// Tests for File.Open / File.Create / File.Erase returning Boolean (issue #1530).
+///
+/// BC's File.Open and File.Erase return Boolean so they can be called in
+/// boolean contexts: if not f.Open('x') then Error(...).
+/// MockFile must match that signature; void-returning methods fail CS0023.
+codeunit 1320001 "File Bool Returns Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    // ── File.Open bool return ────────────────────────────────────────────────
+
+    /// Positive: Open returns a boolean that can be tested.
+    [Test]
+    procedure Open_ReturnsBool_IsTrue()
+    var
+        f: File;
+        ok: Boolean;
+    begin
+        ok := f.Open('dummy.txt');
+        // MockFile.ALOpen always succeeds (in-memory, no real FS) → returns true
+        Assert.AreEqual(true, ok, 'File.Open must return Boolean true in stub');
+    end;
+
+    /// Positive: Open can be used directly in an if condition (boolean context).
+    [Test]
+    procedure Open_BoolContext_NoError()
+    var
+        f: File;
+    begin
+        // This pattern fails with CS0023 if ALOpen returns void.
+        if not f.Open('dummy.txt') then
+            Error('open should succeed in stub');
+        // [THEN] No error raised — mock returned true
+    end;
+
+    // ── File.Erase bool return ────────────────────────────────────────────────
+
+    /// Positive: Erase returns a boolean (no real FS, always succeeds stub-wise).
+    [Test]
+    procedure Erase_ReturnsBool_IsTrue()
+    var
+        ok: Boolean;
+    begin
+        ok := File.Erase('dummy.txt');
+        Assert.AreEqual(true, ok, 'File.Erase must return Boolean true in stub');
+    end;
+
+    /// Positive: Erase in boolean context must compile and run.
+    [Test]
+    procedure Erase_BoolContext_NoError()
+    begin
+        // This pattern fails with CS0023 if ALErase returns void.
+        if not File.Erase('nonexistent.txt') then
+            Error('Erase should return true in stub');
+        // [THEN] No error raised
+    end;
+
+    // ── File.Copy bool return ────────────────────────────────────────────────
+
+    /// Positive: Copy returns a boolean.
+    [Test]
+    procedure Copy_ReturnsBool_IsTrue()
+    var
+        ok: Boolean;
+    begin
+        ok := File.Copy('a.txt', 'b.txt');
+        Assert.AreEqual(true, ok, 'File.Copy must return Boolean true in stub');
+    end;
+}


### PR DESCRIPTION
Closes #1530

## Summary

- `MockFile.ALOpen` changed from `void` to `bool` (returns `true` — stub always succeeds)
- `MockFile.ALErase` changed from `void` to `bool` (returns `true`)
- `MockFile.ALCopy` changed from `void` to `bool` (returns `true`)
- Added AL test suite `320-file-bool-returns` with 5 tests covering boolean-context usage (`ok := f.Open(...)` and `if not f.Open(...) then`)
- Updated `docs/coverage.yaml` for File.Open, File.Erase, and File.Copy entries

## Test plan
- [x] RED: 5 CS0023/CS0029 errors confirmed before fix
- [x] GREEN: all 5 tests pass after fix
- [x] Full matrix: pre-existing 3 failures only, no regressions