### PR TITLE
fix(MockFile): add 7-arg ALUpload overload to fix CS1501

### DIFF
--- a/AlRunner/Runtime/MockFile.cs
+++ b/AlRunner/Runtime/MockFile.cs
@@ -203,6 +203,24 @@ public class MockFile
 
     public void ALUpload(object? parent, string name) { }
 
+    /// <summary>
+    /// ALUpload 7-arg overload — BC emits for the 5-param AL form:
+    ///   File.Upload(DialogTitle, FromFolder, FilterText, FromFile, var ToFile)
+    /// BC emits: ALUpload(DataError, dialogTitle, fromFolder, filterText, fromFile, ByRef&lt;NavText&gt; toFile, Guid extra)
+    /// No-op in standalone (no UI/browser). ToFile is set to empty (no file selected).
+    /// Fixes CS1501 surfaced by per-app DLL compile (issue #1531).
+    /// </summary>
+    public static void ALUpload(DataError errorLevel, string dialogTitle, string fromFolder, string filterText, string fromFile, ByRef<NavText> toFile, Guid extra)
+    {
+        toFile.Value = NavText.Empty;
+    }
+
+    /// <summary>Fallback without Guid for older/newer BC emit variants.</summary>
+    public static void ALUpload(DataError errorLevel, string dialogTitle, string fromFolder, string filterText, string fromFile, ByRef<NavText> toFile)
+    {
+        toFile.Value = NavText.Empty;
+    }
+
     /// <summary>ALView — no-op; no UI in standalone mode.</summary>
     public void ALView(object? parent) { }
 

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -2876,7 +2876,9 @@ File.Upload (Text, Text, Text, Text, Text):
   layer: runtime-api
   category: File
   status: covered
-  notes: MockFile.ALUpload() no-op (no browser/UI in standalone)
+  tests:
+    - tests/bucket-1/codeunit-runtime/321-file-upload-overload
+  notes: MockFile.ALUpload() no-op (no browser/UI in standalone); 7-arg overload (DataError, title, folder, filter, fromFile, ByRef ToFile, Guid) added for CS1501 fix (issue #1531)
 
 File.UploadIntoStream (Text, InStream):
   layer: runtime-api

--- a/tests/bucket-1/codeunit-runtime/321-file-upload-overload/test/FileUploadOverloadTest.al
+++ b/tests/bucket-1/codeunit-runtime/321-file-upload-overload/test/FileUploadOverloadTest.al
@@ -1,0 +1,38 @@
+/// Tests for File.Upload 5-param AL form (issue #1531).
+///
+/// BC AL: File.Upload(DialogTitle, FromFolder, FilterText, FromFile, var ToFile)
+/// This is a static method. BC emits in C#:
+///   MockFile.ALUpload(scope, DataError, dialogTitle, fromFolder, filterText, fromFile, ByRef NavText toFile)
+/// = 7 args. MockFile only had 1- and 2-arg overloads, so CS1501 resulted.
+codeunit 1320001 "File Upload Overload Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    // ── File.Upload 5-param static form ─────────────────────────────────────
+
+    /// Positive: Upload with all 5 AL params must compile and run without error.
+    /// In standalone mode there is no UI so var ToFile is set to empty.
+    [Test]
+    procedure Upload_FiveParam_SetsToFileEmpty()
+    var
+        toFile: Text;
+    begin
+        toFile := 'original';
+        File.Upload('Choose File', 'C:\temp', '*.txt', 'source.txt', toFile);
+        // In standalone mode (no UI) the upload is a no-op; ToFile is cleared
+        Assert.AreEqual('', toFile, 'File.Upload 5-param: ToFile must be empty string in stub (no UI)');
+    end;
+
+    /// Positive: Upload called with empty strings must not throw.
+    [Test]
+    procedure Upload_FiveParam_NoError()
+    var
+        toFile: Text;
+    begin
+        File.Upload('My Dialog', '', 'All Files|*.*', '', toFile);
+        Assert.AreEqual('', toFile, 'File.Upload 5-param stub must succeed without error');
+    end;
+}


### PR DESCRIPTION
Closes #1531

## Summary

BC compiles `File.Upload(DialogTitle, FromFolder, FilterText, FromFile, var ToFile)` to `MockFile.ALUpload(DataError, title, folder, filter, fromFile, ByRef<NavText> toFile, Guid)` — 7 arguments. `MockFile` only had 1- and 2-arg overloads, causing CS1501.

- Added `MockFile.ALUpload(DataError, string, string, string, string, ByRef<NavText>, Guid)` — 7-arg static overload (no-op, sets `toFile` to empty)
- Added 6-arg fallback without trailing `Guid` for older BC emit variants
- Added AL test suite `321-file-upload-overload` with 2 tests
- Updated `docs/coverage.yaml`

## Test plan
- [x] RED: CS1501 errors confirmed before fix
- [x] GREEN: 2 tests pass after fix