### PR TITLE
fix(MockHttpClient): replace ALUseDefaultNetworkWindowsAuthentication property with method to fix CS1955

### DIFF
--- a/AlRunner/Runtime/MockHttpClient.cs
+++ b/AlRunner/Runtime/MockHttpClient.cs
@@ -99,8 +99,19 @@ public class MockHttpClient
     public MockHttpHeaders ALDefaultRequestHeaders => _defaultHeaders;
     private MockHttpHeaders _defaultHeaders = new();
 
-    /// <summary>UseDefaultNetworkWindowsAuthentication property stub.</summary>
-    public bool ALUseDefaultNetworkWindowsAuthentication { get; set; }
+    // Backing field for UseDefaultNetworkWindowsAuthentication state.
+    private bool _useDefaultNetworkWindowsAuthentication = false;
+
+    /// <summary>
+    /// UseDefaultNetworkWindowsAuthentication() — BC emits as a method call
+    /// (0 AL args → 1 C# arg: DataError).  Declares Windows auth should be used.
+    /// No-op in standalone mode; records the flag for <see cref="ALAssign"/>.
+    /// Fixes CS1955 that arose when this was declared as a property (issue #1532).
+    /// </summary>
+    public void ALUseDefaultNetworkWindowsAuthentication(DataError errorLevel = DataError.ThrowError)
+    {
+        _useDefaultNetworkWindowsAuthentication = true;
+    }
 
     // ── Configuration methods (issue #732) ────────────────────────────────
 
@@ -123,7 +134,7 @@ public class MockHttpClient
         _baseAddress = string.Empty;
         _defaultHeaders = new MockHttpHeaders();
         ALTimeout = 30L;
-        ALUseDefaultNetworkWindowsAuthentication = false;
+        _useDefaultNetworkWindowsAuthentication = false;
         ALUseServerCertificateValidation = false;
     }
 
@@ -163,7 +174,7 @@ public class MockHttpClient
         _baseAddress = other._baseAddress;
         _defaultHeaders = other._defaultHeaders;
         ALTimeout = other.ALTimeout;
-        ALUseDefaultNetworkWindowsAuthentication = other.ALUseDefaultNetworkWindowsAuthentication;
+        _useDefaultNetworkWindowsAuthentication = other._useDefaultNetworkWindowsAuthentication;
         ALUseServerCertificateValidation = other.ALUseServerCertificateValidation;
     }
 }

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -3243,6 +3243,9 @@ HttpClient.UseDefaultNetworkWindowsAuthentication ():
   layer: runtime-api
   category: HttpClient
   status: covered
+  tests:
+    - tests/bucket-1/codeunit-runtime/322-httpclient-usedefaultnetwork
+  notes: ALUseDefaultNetworkWindowsAuthentication changed from property to method (DataError arg) to fix CS1955 (issue #1532)
 
 HttpClient.UseResponseCookies (Boolean):
   layer: runtime-api

--- a/tests/bucket-1/codeunit-runtime/322-httpclient-usedefaultnetwork/test/HttpClientUseDefaultNetworkTest.al
+++ b/tests/bucket-1/codeunit-runtime/322-httpclient-usedefaultnetwork/test/HttpClientUseDefaultNetworkTest.al
@@ -1,0 +1,27 @@
+/// Tests for HttpClient.UseDefaultNetworkWindowsAuthentication (issue #1532).
+///
+/// BC's HttpClient.UseDefaultNetworkWindowsAuthentication() is a 0-arg method
+/// (a setter-style call with no boolean parameter in AL).
+/// MockHttpClient had it as a property — BC's emit calls it as a method,
+/// causing CS1955: Non-invocable member cannot be used like a method.
+codeunit 1320001 "HC UseDefaultNetwork Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    // ── UseDefaultNetworkWindowsAuthentication ───────────────────────────────
+
+    /// Positive: Calling UseDefaultNetworkWindowsAuthentication() must not throw.
+    [Test]
+    procedure UseDefaultNetwork_Call_NoError()
+    var
+        client: HttpClient;
+    begin
+        // BC emits: client.ALUseDefaultNetworkWindowsAuthentication(DataError)
+        // as a method call (0 AL args). Was a property — CS1955.
+        client.UseDefaultNetworkWindowsAuthentication();
+        // [THEN] No error — method call succeeds
+    end;
+}


### PR DESCRIPTION
Closes #1532

## Summary

BC compiles `HttpClient.UseDefaultNetworkWindowsAuthentication()` as a method call: `client.ALUseDefaultNetworkWindowsAuthentication(DataError.ThrowError)`. `MockHttpClient` had this declared as a `bool` auto-property, causing CS1955: Non-invocable member cannot be used like a method.

- Replaced `public bool ALUseDefaultNetworkWindowsAuthentication { get; set; }` with a `void` method `ALUseDefaultNetworkWindowsAuthentication(DataError errorLevel)` + private backing field `_useDefaultNetworkWindowsAuthentication`
- Updated `Clear()` and `ALAssign()` to use the backing field directly
- Added AL test `322-httpclient-usedefaultnetwork`
- Updated `docs/coverage.yaml`

## Test plan
- [x] RED: CS1955 confirmed before fix
- [x] GREEN: 1 test passes after fix
- [x] Full matrix: pre-existing 3 failures only, no regressions