### PR TITLE
fix(MockHttpClient): add NavSecretText overloads for UseWindowsAuthentication and AddCertificate to fix CS1503

### DIFF
--- a/AlRunner/Runtime/MockHttpClient.cs
+++ b/AlRunner/Runtime/MockHttpClient.cs
@@ -139,14 +139,26 @@ public class MockHttpClient
     /// <summary>UseWindowsAuthentication(username, password) — no-op stub.</summary>
     public void ALUseWindowsAuthentication(DataError errorLevel, NavText username, NavText password) { }
 
+    /// <summary>UseWindowsAuthentication(username, password) — SecretText overload (issue #1533).</summary>
+    public void ALUseWindowsAuthentication(DataError errorLevel, NavSecretText username, NavSecretText password) { }
+
     /// <summary>UseWindowsAuthentication(username, password, domain) — no-op stub.</summary>
     public void ALUseWindowsAuthentication(DataError errorLevel, NavText username, NavText password, NavText domain) { }
+
+    /// <summary>UseWindowsAuthentication(username, password, domain) — SecretText overload (issue #1533).</summary>
+    public void ALUseWindowsAuthentication(DataError errorLevel, NavSecretText username, NavSecretText password, NavSecretText domain) { }
 
     /// <summary>AddCertificate(thumbprint) — no-op stub.</summary>
     public void ALAddCertificate(DataError errorLevel, NavText thumbprint) { }
 
+    /// <summary>AddCertificate(thumbprint) — SecretText overload (issue #1533).</summary>
+    public void ALAddCertificate(DataError errorLevel, NavSecretText thumbprint) { }
+
     /// <summary>AddCertificate(thumbprint, password) — no-op stub.</summary>
     public void ALAddCertificate(DataError errorLevel, NavText thumbprint, NavText password) { }
+
+    /// <summary>AddCertificate(thumbprint, password) — SecretText overload (issue #1533).</summary>
+    public void ALAddCertificate(DataError errorLevel, NavSecretText thumbprint, NavSecretText password) { }
 
     // ── ALAssign (issue #1447) ─────────────────────────────────────────────
 

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -3167,6 +3167,9 @@ HttpClient.AddCertificate (SecretText, SecretText):
   layer: runtime-api
   category: HttpClient
   status: covered
+  tests:
+    - tests/bucket-1/codeunit-runtime/323-secrettext-navtext-conv
+  notes: ALAddCertificate(DataError, NavSecretText, NavSecretText) overload added to fix CS1503 (issue #1533)
 
 HttpClient.AddCertificate (Text, Text):
   layer: runtime-api
@@ -3258,6 +3261,9 @@ HttpClient.UseWindowsAuthentication (SecretText, SecretText, SecretText):
   layer: runtime-api
   category: HttpClient
   status: covered
+  tests:
+    - tests/bucket-1/codeunit-runtime/323-secrettext-navtext-conv
+  notes: ALUseWindowsAuthentication(DataError, NavSecretText, NavSecretText[, NavSecretText]) overloads added to fix CS1503 (issue #1533)
 
 HttpClient.UseWindowsAuthentication (Text, Text, Text):
   layer: runtime-api

--- a/tests/bucket-1/codeunit-runtime/323-secrettext-navtext-conv/src/SecretTextNavTextSrc.al
+++ b/tests/bucket-1/codeunit-runtime/323-secrettext-navtext-conv/src/SecretTextNavTextSrc.al
@@ -1,0 +1,59 @@
+/// Source helper for SecretText → NavText conversion tests (issue #1533).
+///
+/// These procedures exercise patterns where BC emits NavSecretText where
+/// MockHttpClient methods expect NavText. The rewriter passes NavSecretText;
+/// overloads accepting NavSecretText must exist in the mock.
+codeunit 1320002 "STN Src"
+{
+    /// UseWindowsAuthentication called with SecretText variables.
+    /// BC emits: client.ALUseWindowsAuthentication(DataError, NavSecretText, NavSecretText)
+    procedure UseWindowsAuthWithSecret(plainUser: Text; plainPass: Text)
+    var
+        client: HttpClient;
+        username: SecretText;
+        password: SecretText;
+    begin
+        username := plainUser;
+        password := plainPass;
+        client.UseWindowsAuthentication(username, password);
+    end;
+
+    /// UseWindowsAuthentication 3-param called with SecretText variables.
+    /// BC emits: client.ALUseWindowsAuthentication(DataError, NavSecretText, NavSecretText, NavSecretText)
+    procedure UseWindowsAuthDomainWithSecret(plainUser: Text; plainPass: Text; plainDomain: Text)
+    var
+        client: HttpClient;
+        username: SecretText;
+        password: SecretText;
+        domain: SecretText;
+    begin
+        username := plainUser;
+        password := plainPass;
+        domain := plainDomain;
+        client.UseWindowsAuthentication(username, password, domain);
+    end;
+
+    /// AddCertificate(SecretText) — thumbprint as SecretText.
+    /// BC emits: client.ALAddCertificate(DataError, NavSecretText)
+    procedure AddCertWithSecret(plainThumbprint: Text)
+    var
+        client: HttpClient;
+        thumbprint: SecretText;
+    begin
+        thumbprint := plainThumbprint;
+        client.AddCertificate(thumbprint);
+    end;
+
+    /// AddCertificate(SecretText, SecretText) — thumbprint + password as SecretText.
+    /// BC emits: client.ALAddCertificate(DataError, NavSecretText, NavSecretText)
+    procedure AddCertWithPasswordSecret(plainThumbprint: Text; plainCertPass: Text)
+    var
+        client: HttpClient;
+        thumbprint: SecretText;
+        certPass: SecretText;
+    begin
+        thumbprint := plainThumbprint;
+        certPass := plainCertPass;
+        client.AddCertificate(thumbprint, certPass);
+    end;
+}

--- a/tests/bucket-1/codeunit-runtime/323-secrettext-navtext-conv/test/SecretTextNavTextTest.al
+++ b/tests/bucket-1/codeunit-runtime/323-secrettext-navtext-conv/test/SecretTextNavTextTest.al
@@ -1,0 +1,48 @@
+/// Tests for SecretText → NavText conversion in MockHttpClient (issue #1533).
+///
+/// BC emits NavSecretText where MockHttpClient mock methods expect NavText.
+/// Overloads accepting NavSecretText must exist in the mock.
+codeunit 1320001 "STN Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "STN Src";
+
+    // ── UseWindowsAuthentication with SecretText ─────────────────────────────
+
+    /// Positive: UseWindowsAuthentication(SecretText, SecretText) must not throw.
+    [Test]
+    procedure UseWindowsAuth_SecretText_NoError()
+    begin
+        Src.UseWindowsAuthWithSecret('user1', 'pass1');
+        // [THEN] No error — NavSecretText overload exists
+    end;
+
+    /// Positive: UseWindowsAuthentication(SecretText, SecretText, SecretText) must not throw.
+    [Test]
+    procedure UseWindowsAuthDomain_SecretText_NoError()
+    begin
+        Src.UseWindowsAuthDomainWithSecret('user1', 'pass1', 'CORP');
+        // [THEN] No error
+    end;
+
+    // ── AddCertificate with SecretText ────────────────────────────────────────
+
+    /// Positive: AddCertificate(SecretText) must not throw.
+    [Test]
+    procedure AddCert_SecretText_NoError()
+    begin
+        Src.AddCertWithSecret('abc123thumbprint');
+        // [THEN] No error
+    end;
+
+    /// Positive: AddCertificate(SecretText, SecretText) must not throw.
+    [Test]
+    procedure AddCertWithPassword_SecretText_NoError()
+    begin
+        Src.AddCertWithPasswordSecret('abc123thumbprint', 'certpass');
+        // [THEN] No error
+    end;
+}


### PR DESCRIPTION
Closes #1533

## Summary

BC compiles calls where `SecretText` variables are passed to `UseWindowsAuthentication` and `AddCertificate` as `NavSecretText` arguments in C#. `MockHttpClient` only had `NavText` overloads, causing CS1503 from per-app SA DLL compile.

Added `NavSecretText` overloads (no-op stubs) for:
- `ALUseWindowsAuthentication(DataError, NavSecretText, NavSecretText)` — 2-param form
- `ALUseWindowsAuthentication(DataError, NavSecretText, NavSecretText, NavSecretText)` — 3-param (with domain) form
- `ALAddCertificate(DataError, NavSecretText)` — 1-param form
- `ALAddCertificate(DataError, NavSecretText, NavSecretText)` — 2-param (with password) form

Added AL test suite `323-secrettext-navtext-conv` with `src` helper + 4 test methods. Updated `docs/coverage.yaml`.

## Test plan
- [x] RED: 8 CS1503 errors confirmed before fix
- [x] GREEN: 4 tests pass after fix
- [x] Full matrix: pre-existing 3 failures only, no regressions