### PR TITLE
Fix void mocks in bool contexts

### DIFF
--- a/AlRunner/Runtime/MockFile.cs
+++ b/AlRunner/Runtime/MockFile.cs
@@ -226,21 +226,30 @@ public class MockFile
     public void ALView(object? parent) { }
 
     /// <summary>ALViewFromStream — no-op; no UI in standalone mode.</summary>
-    public void ALViewFromStream(object? parent, MockInStream inStream) { }
+    public bool ALViewFromStream(object? parent, MockInStream inStream)
+    {
+        return true;
+    }
 
     /// <summary>
     /// ALViewFromStream static 3-arg overload — BC emits this for the 2-arg AL form:
     ///   File.ViewFromStream(InStream, FileName).
     /// BC passes DataError as the first arg. No-op; no UI in standalone mode.
     /// </summary>
-    public static void ALViewFromStream(object? scope, MockInStream inStream, string fileName) { }
+    public static bool ALViewFromStream(object? scope, MockInStream inStream, string fileName)
+    {
+        return true;
+    }
 
     /// <summary>
     /// ALViewFromStream static 4-arg overload — BC emits this for the 3-arg AL form:
     ///   File.ViewFromStream(InStream, FileName, IsEditable).
     /// BC passes DataError as the first arg. No-op; no UI in standalone mode.
     /// </summary>
-    public static void ALViewFromStream(object? scope, MockInStream inStream, string fileName, bool isEditable) { }
+    public static bool ALViewFromStream(object? scope, MockInStream inStream, string fileName, bool isEditable)
+    {
+        return true;
+    }
 
     /// <summary>
     /// ALUploadIntoStream — BC standalone UploadIntoStream maps here as a static.

--- a/AlRunner/Runtime/MockHttpClient.cs
+++ b/AlRunner/Runtime/MockHttpClient.cs
@@ -108,9 +108,10 @@ public class MockHttpClient
     /// No-op in standalone mode; records the flag for <see cref="ALAssign"/>.
     /// Fixes CS1955 that arose when this was declared as a property (issue #1532).
     /// </summary>
-    public void ALUseDefaultNetworkWindowsAuthentication(DataError errorLevel = DataError.ThrowError)
+    public bool ALUseDefaultNetworkWindowsAuthentication(DataError errorLevel = DataError.ThrowError)
     {
         _useDefaultNetworkWindowsAuthentication = true;
+        return true;
     }
 
     // ── Configuration methods (issue #732) ────────────────────────────────

--- a/AlRunner/Runtime/MockHttpContent.cs
+++ b/AlRunner/Runtime/MockHttpContent.cs
@@ -54,9 +54,10 @@ public class MockHttpContent
     /// as a method call with a ByRef out parameter. The headers collection is shared
     /// with the content so later mutations round-trip.
     /// </summary>
-    public void ALGetHeaders(DataError errorLevel, ByRef<MockHttpHeaders> headers)
+    public bool ALGetHeaders(DataError errorLevel, ByRef<MockHttpHeaders> headers)
     {
         headers.Value = _headers;
+        return true;
     }
 
     /// <summary>

--- a/AlRunner/Runtime/MockHttpRequestMessage.cs
+++ b/AlRunner/Runtime/MockHttpRequestMessage.cs
@@ -32,9 +32,10 @@ public class MockHttpRequestMessage
     /// BC emits: <c>request.ALSetRequestUri(DataError, url)</c>
     /// for <c>HttpRequestMessage.SetRequestUri(url)</c>.
     /// </summary>
-    public void ALSetRequestUri(DataError errorLevel, string uri)
+    public bool ALSetRequestUri(DataError errorLevel, string uri)
     {
         ALGetRequestUri = uri;
+        return true;
     }
 
     /// <summary>Request content. BC emits <c>request.ALContent</c> get/set.</summary>
@@ -49,9 +50,10 @@ public class MockHttpRequestMessage
     /// for <c>HttpRequestMessage.GetHeaders(headers)</c>.
     /// Sets the out-parameter to the stored headers instance.
     /// </summary>
-    public void ALGetHeaders(DataError errorLevel, ByRef<MockHttpHeaders> headers)
+    public bool ALGetHeaders(DataError errorLevel, ByRef<MockHttpHeaders> headers)
     {
         headers.Value = _headers;
+        return true;
     }
 
     /// <summary>

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -2908,7 +2908,9 @@ File.ViewFromStream (InStream, Text, Boolean):
   layer: runtime-api
   category: File
   status: covered
-  notes: static overload (scope, InStream, FileName, IsEditable); 3-arg AL form File.ViewFromStream(InStream, FileName, IsEditable); fixes CS1501 telemetry gap
+  tests:
+    - tests/bucket-1/codeunit-runtime/328-file-viewfromstream-bool
+  notes: static overload (scope, InStream, FileName, IsEditable); 3-arg AL form File.ViewFromStream(InStream, FileName, IsEditable); returns bool for 'if not' contexts (issue #1538); fixes CS1501 telemetry gap
 
 File.Write (BigInteger):
   layer: runtime-api
@@ -3256,7 +3258,8 @@ HttpClient.UseDefaultNetworkWindowsAuthentication ():
   status: covered
   tests:
     - tests/bucket-1/codeunit-runtime/322-httpclient-usedefaultnetwork
-  notes: ALUseDefaultNetworkWindowsAuthentication changed from property to method (DataError arg) to fix CS1955 (issue #1532)
+    - tests/bucket-1/codeunit-runtime/324-httpclient-usedefaultnetwork-bool
+  notes: ALUseDefaultNetworkWindowsAuthentication changed from property to method (DataError arg) to fix CS1955 (issue #1532); returns bool for 'if not' contexts (issue #1538)
 
 HttpClient.UseResponseCookies (Boolean):
   layer: runtime-api
@@ -3300,7 +3303,9 @@ HttpContent.GetHeaders (HttpHeaders):
   layer: runtime-api
   category: HttpContent
   status: covered
-  notes: . MockHttpContent.ALGetHeaders is now a method (was a property; BC emits it as a method call with a ByRef out parameter).
+  tests:
+    - tests/bucket-1/codeunit-runtime/326-httpcontent-getheaders-bool
+  notes: MockHttpContent.ALGetHeaders is now a method (was a property; BC emits it as a method call with a ByRef out parameter); returns bool for 'if not' contexts (issue #1538).
 
 HttpContent.IsSecretContent ():
   layer: runtime-api
@@ -3461,6 +3466,9 @@ HttpRequestMessage.GetHeaders (HttpHeaders):
   layer: runtime-api
   category: HttpRequestMessage
   status: covered
+  tests:
+    - tests/bucket-1/codeunit-runtime/327-httprequestmessage-getheaders-bool
+  notes: ALGetHeaders returns bool for 'if not' contexts (issue #1538).
 
 HttpRequestMessage.GetRequestUri ():
   layer: runtime-api
@@ -3506,6 +3514,9 @@ HttpRequestMessage.SetRequestUri (Text):
   layer: runtime-api
   category: HttpRequestMessage
   status: covered
+  tests:
+    - tests/bucket-1/codeunit-runtime/325-httprequestmessage-setrequesturi-bool
+  notes: ALSetRequestUri returns bool for 'if not' contexts (issue #1538).
 
 HttpRequestMessage.SetSecretRequestUri (SecretText):
   layer: runtime-api

--- a/tests/bucket-1/codeunit-runtime/320-file-bool-returns/test/FileBoolReturnsTest.al
+++ b/tests/bucket-1/codeunit-runtime/320-file-bool-returns/test/FileBoolReturnsTest.al
@@ -3,7 +3,7 @@
 /// BC's File.Open and File.Erase return Boolean so they can be called in
 /// boolean contexts: if not f.Open('x') then Error(...).
 /// MockFile must match that signature; void-returning methods fail CS0023.
-codeunit 1320001 "File Bool Returns Test"
+codeunit 1320410 "File Bool Returns Test"
 {
     Subtype = Test;
 

--- a/tests/bucket-1/codeunit-runtime/321-file-upload-overload/test/FileUploadOverloadTest.al
+++ b/tests/bucket-1/codeunit-runtime/321-file-upload-overload/test/FileUploadOverloadTest.al
@@ -4,7 +4,7 @@
 /// This is a static method. BC emits in C#:
 ///   MockFile.ALUpload(scope, DataError, dialogTitle, fromFolder, filterText, fromFile, ByRef NavText toFile)
 /// = 7 args. MockFile only had 1- and 2-arg overloads, so CS1501 resulted.
-codeunit 1320001 "File Upload Overload Test"
+codeunit 1320411 "File Upload Overload Test"
 {
     Subtype = Test;
 

--- a/tests/bucket-1/codeunit-runtime/322-httpclient-usedefaultnetwork/test/HttpClientUseDefaultNetworkTest.al
+++ b/tests/bucket-1/codeunit-runtime/322-httpclient-usedefaultnetwork/test/HttpClientUseDefaultNetworkTest.al
@@ -4,7 +4,7 @@
 /// (a setter-style call with no boolean parameter in AL).
 /// MockHttpClient had it as a property — BC's emit calls it as a method,
 /// causing CS1955: Non-invocable member cannot be used like a method.
-codeunit 1320001 "HC UseDefaultNetwork Test"
+codeunit 1320412 "HC UseDefaultNetwork Test"
 {
     Subtype = Test;
 

--- a/tests/bucket-1/codeunit-runtime/323-secrettext-navtext-conv/test/SecretTextNavTextTest.al
+++ b/tests/bucket-1/codeunit-runtime/323-secrettext-navtext-conv/test/SecretTextNavTextTest.al
@@ -2,7 +2,7 @@
 ///
 /// BC emits NavSecretText where MockHttpClient mock methods expect NavText.
 /// Overloads accepting NavSecretText must exist in the mock.
-codeunit 1320001 "STN Test"
+codeunit 1320413 "STN Test"
 {
     Subtype = Test;
 

--- a/tests/bucket-1/codeunit-runtime/324-httpclient-usedefaultnetwork-bool/src/HttpClientUseDefaultNetworkBoolSrc.al
+++ b/tests/bucket-1/codeunit-runtime/324-httpclient-usedefaultnetwork-bool/src/HttpClientUseDefaultNetworkBoolSrc.al
@@ -1,0 +1,14 @@
+codeunit 1320400 "HC UseDefaultNetwork Bool Src"
+{
+    /// <summary>
+    /// Exercises UseDefaultNetworkWindowsAuthentication() in a boolean context.
+    /// </summary>
+    procedure UseDefaultNetworkInIf(): Boolean
+    var
+        Client: HttpClient;
+    begin
+        if not Client.UseDefaultNetworkWindowsAuthentication() then
+            exit(false);
+        exit(true);
+    end;
+}

--- a/tests/bucket-1/codeunit-runtime/324-httpclient-usedefaultnetwork-bool/test/HttpClientUseDefaultNetworkBoolTest.al
+++ b/tests/bucket-1/codeunit-runtime/324-httpclient-usedefaultnetwork-bool/test/HttpClientUseDefaultNetworkBoolTest.al
@@ -1,0 +1,26 @@
+codeunit 1320401 "HC UseDefaultNetwork Bool Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    [Test]
+    procedure UseDefaultNetwork_ReturnsTrue()
+    var
+        Helper: Codeunit "HC UseDefaultNetwork Bool Src";
+    begin
+        Assert.AreEqual(true, Helper.UseDefaultNetworkInIf(),
+            'UseDefaultNetworkWindowsAuthentication must return true in bool context');
+    end;
+
+    [Test]
+    procedure UseDefaultNetwork_WrongExpectationFails()
+    var
+        Helper: Codeunit "HC UseDefaultNetwork Bool Src";
+    begin
+        asserterror Assert.AreEqual(false, Helper.UseDefaultNetworkInIf(),
+            'UseDefaultNetworkWindowsAuthentication should not return false');
+        Assert.ExpectedError('AreEqual');
+    end;
+}

--- a/tests/bucket-1/codeunit-runtime/325-httprequestmessage-setrequesturi-bool/src/HttpRequestMessageSetRequestUriBoolSrc.al
+++ b/tests/bucket-1/codeunit-runtime/325-httprequestmessage-setrequesturi-bool/src/HttpRequestMessageSetRequestUriBoolSrc.al
@@ -1,0 +1,14 @@
+codeunit 1320402 "HRM SetRequestUri Bool Src"
+{
+    /// <summary>
+    /// Exercises SetRequestUri() in a boolean context.
+    /// </summary>
+    procedure SetRequestUriInIf(Uri: Text): Boolean
+    var
+        Request: HttpRequestMessage;
+    begin
+        if not Request.SetRequestUri(Uri) then
+            exit(false);
+        exit(true);
+    end;
+}

--- a/tests/bucket-1/codeunit-runtime/325-httprequestmessage-setrequesturi-bool/test/HttpRequestMessageSetRequestUriBoolTest.al
+++ b/tests/bucket-1/codeunit-runtime/325-httprequestmessage-setrequesturi-bool/test/HttpRequestMessageSetRequestUriBoolTest.al
@@ -1,0 +1,26 @@
+codeunit 1320403 "HRM SetRequestUri Bool Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    [Test]
+    procedure SetRequestUri_ReturnsTrue()
+    var
+        Helper: Codeunit "HRM SetRequestUri Bool Src";
+    begin
+        Assert.AreEqual(true, Helper.SetRequestUriInIf('https://example.com'),
+            'HttpRequestMessage.SetRequestUri must return true in bool context');
+    end;
+
+    [Test]
+    procedure SetRequestUri_WrongExpectationFails()
+    var
+        Helper: Codeunit "HRM SetRequestUri Bool Src";
+    begin
+        asserterror Assert.AreEqual(false, Helper.SetRequestUriInIf('https://example.com'),
+            'SetRequestUri should not return false');
+        Assert.ExpectedError('AreEqual');
+    end;
+}

--- a/tests/bucket-1/codeunit-runtime/326-httpcontent-getheaders-bool/src/HttpContentGetHeadersBoolSrc.al
+++ b/tests/bucket-1/codeunit-runtime/326-httpcontent-getheaders-bool/src/HttpContentGetHeadersBoolSrc.al
@@ -1,0 +1,15 @@
+codeunit 1320404 "HC GetHeaders Bool Src"
+{
+    /// <summary>
+    /// Exercises HttpContent.GetHeaders() in a boolean context.
+    /// </summary>
+    procedure GetHeadersInIf(): Boolean
+    var
+        Content: HttpContent;
+        Headers: HttpHeaders;
+    begin
+        if not Content.GetHeaders(Headers) then
+            exit(false);
+        exit(true);
+    end;
+}

--- a/tests/bucket-1/codeunit-runtime/326-httpcontent-getheaders-bool/test/HttpContentGetHeadersBoolTest.al
+++ b/tests/bucket-1/codeunit-runtime/326-httpcontent-getheaders-bool/test/HttpContentGetHeadersBoolTest.al
@@ -1,0 +1,26 @@
+codeunit 1320405 "HC GetHeaders Bool Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    [Test]
+    procedure GetHeaders_ReturnsTrue()
+    var
+        Helper: Codeunit "HC GetHeaders Bool Src";
+    begin
+        Assert.AreEqual(true, Helper.GetHeadersInIf(),
+            'HttpContent.GetHeaders must return true in bool context');
+    end;
+
+    [Test]
+    procedure GetHeaders_WrongExpectationFails()
+    var
+        Helper: Codeunit "HC GetHeaders Bool Src";
+    begin
+        asserterror Assert.AreEqual(false, Helper.GetHeadersInIf(),
+            'GetHeaders should not return false');
+        Assert.ExpectedError('AreEqual');
+    end;
+}

--- a/tests/bucket-1/codeunit-runtime/327-httprequestmessage-getheaders-bool/src/HttpRequestMessageGetHeadersBoolSrc.al
+++ b/tests/bucket-1/codeunit-runtime/327-httprequestmessage-getheaders-bool/src/HttpRequestMessageGetHeadersBoolSrc.al
@@ -1,0 +1,15 @@
+codeunit 1320406 "HRM GetHeaders Bool Src"
+{
+    /// <summary>
+    /// Exercises HttpRequestMessage.GetHeaders() in a boolean context.
+    /// </summary>
+    procedure GetHeadersInIf(): Boolean
+    var
+        Request: HttpRequestMessage;
+        Headers: HttpHeaders;
+    begin
+        if not Request.GetHeaders(Headers) then
+            exit(false);
+        exit(true);
+    end;
+}

--- a/tests/bucket-1/codeunit-runtime/327-httprequestmessage-getheaders-bool/test/HttpRequestMessageGetHeadersBoolTest.al
+++ b/tests/bucket-1/codeunit-runtime/327-httprequestmessage-getheaders-bool/test/HttpRequestMessageGetHeadersBoolTest.al
@@ -1,0 +1,26 @@
+codeunit 1320407 "HRM GetHeaders Bool Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    [Test]
+    procedure GetHeaders_ReturnsTrue()
+    var
+        Helper: Codeunit "HRM GetHeaders Bool Src";
+    begin
+        Assert.AreEqual(true, Helper.GetHeadersInIf(),
+            'HttpRequestMessage.GetHeaders must return true in bool context');
+    end;
+
+    [Test]
+    procedure GetHeaders_WrongExpectationFails()
+    var
+        Helper: Codeunit "HRM GetHeaders Bool Src";
+    begin
+        asserterror Assert.AreEqual(false, Helper.GetHeadersInIf(),
+            'GetHeaders should not return false');
+        Assert.ExpectedError('AreEqual');
+    end;
+}

--- a/tests/bucket-1/codeunit-runtime/328-file-viewfromstream-bool/src/FileViewFromStreamBoolSrc.al
+++ b/tests/bucket-1/codeunit-runtime/328-file-viewfromstream-bool/src/FileViewFromStreamBoolSrc.al
@@ -1,0 +1,26 @@
+codeunit 1320408 "File ViewFromStream Bool Src"
+{
+    /// <summary>
+    /// Exercises File.ViewFromStream(InStream, FileName) in a boolean context.
+    /// </summary>
+    procedure ViewFromStreamInIf(): Boolean
+    var
+        InStr: InStream;
+    begin
+        if not File.ViewFromStream(InStr, 'test.txt') then
+            exit(false);
+        exit(true);
+    end;
+
+    /// <summary>
+    /// Exercises File.ViewFromStream(InStream, FileName, IsEditable) in a boolean context.
+    /// </summary>
+    procedure ViewFromStreamEditableInIf(): Boolean
+    var
+        InStr: InStream;
+    begin
+        if not File.ViewFromStream(InStr, 'test.txt', true) then
+            exit(false);
+        exit(true);
+    end;
+}

--- a/tests/bucket-1/codeunit-runtime/328-file-viewfromstream-bool/test/FileViewFromStreamBoolTest.al
+++ b/tests/bucket-1/codeunit-runtime/328-file-viewfromstream-bool/test/FileViewFromStreamBoolTest.al
@@ -1,0 +1,28 @@
+codeunit 1320409 "File ViewFromStream Bool Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    [Test]
+    procedure ViewFromStream_ReturnsTrue()
+    var
+        Helper: Codeunit "File ViewFromStream Bool Src";
+    begin
+        Assert.AreEqual(true, Helper.ViewFromStreamInIf(),
+            'File.ViewFromStream (2-arg) must return true in bool context');
+        Assert.AreEqual(true, Helper.ViewFromStreamEditableInIf(),
+            'File.ViewFromStream (3-arg) must return true in bool context');
+    end;
+
+    [Test]
+    procedure ViewFromStream_WrongExpectationFails()
+    var
+        Helper: Codeunit "File ViewFromStream Bool Src";
+    begin
+        asserterror Assert.AreEqual(false, Helper.ViewFromStreamInIf(),
+            'ViewFromStream should not return false');
+        Assert.ExpectedError('AreEqual');
+    end;
+}


### PR DESCRIPTION
## Summary
- return bool from MockHttpClient.ALUseDefaultNetworkWindowsAuthentication
- return bool from MockHttpRequestMessage.ALSetRequestUri/ALGetHeaders and MockHttpContent.ALGetHeaders
- return bool from MockFile.ALViewFromStream overloads
- add bool-context AL tests for each fix and update coverage.yaml
- deduplicate bucket-1 test codeunit IDs in 320-323 suites (all were 1320001)

## Audit notes
Already-returning-bool or not present in this repo:
- ALCanCreateTask (no mock found)
- ALConfirm, ALContains, ALContainsKey, ALDelete, ALDownloadFromStream, ALEvaluate, ALFindFirst/Last/Set, ALGet, ALGetBySystemId, ALGetModuleInfo, ALInsert, ALIsBigInteger/Code/Empty/Guid/Integer/Record/RecordRef, ALModify, ALOpen (MockQueryHandle), ALReadAs, ALRunModal, ALSend, ALTaskExists, ALUploadIntoStream
- ALStartsWith / ALEndsWith (no mock found)

Closes #1538