### PR TITLE
Fix mock gaps for System Application compile

### DIFF
--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -964,6 +964,9 @@ public NavText ObjectID(bool withCaption = false) {{ return NavText.Empty; }}
 // SetRecord — BC lowers CurrPage.SetRecord(rec) to this.SetRecord(rec.Target).
 // NavForm provided this; after stripping it we need a stub (issue #1262).
 public void SetRecord(MockRecordHandle rec) {{ }}
+// GetRecord — BC lowers CurrPage.GetRecord(rec) to this.GetRecord(rec.Target).
+// NavForm provided this; after stripping it we need a stub (issue #1540).
+public void GetRecord(MockRecordHandle rec) {{ }}
 // BookmarkType — BC emits this.BookmarkType = BookmarkType.Temporary on pages with
 // SourceTableTemporary = true. The BookmarkType enum lives in Microsoft.Dynamics.Nav.Types.
 // NavForm provided this property; after stripping it we need a stub (issue #1262).

--- a/AlRunner/Runtime/MockFieldRef.cs
+++ b/AlRunner/Runtime/MockFieldRef.cs
@@ -498,6 +498,13 @@ public class MockFieldRef
     public MockFieldRef ALByValue() => this;
 
     /// <summary>
+    /// Implicit conversion to NavValue — returns the field's current value.
+    /// Enables passing FieldRef directly where a NavValue is expected (e.g. StrSubstNo args).
+    /// </summary>
+    public static implicit operator NavValue(MockFieldRef fieldRef)
+        => fieldRef?.ALValue ?? NavText.Default(0);
+
+    /// <summary>
     /// ALSetTable — some BC-generated code (notably page API extensions) emits
     /// <c>fieldRef.ALSetTable(record, shareTable)</c>. NavFieldRef in the SDK does
     /// not have this method, but the emitted code references it on the MockFieldRef

--- a/AlRunner/Runtime/MockInStream.cs
+++ b/AlRunner/Runtime/MockInStream.cs
@@ -94,8 +94,17 @@ public class MockInStream
     /// <summary>ALLength — BC's InStream.Length property. Returns total byte length.</summary>
     public int ALLength => _data.Length;
 
-    /// <summary>ALPosition — BC's InStream.Position property. Returns current read position.</summary>
-    public int ALPosition => _pos;
+    /// <summary>ALPosition — BC's InStream.Position property. Gets/sets current read position.</summary>
+    public int ALPosition
+    {
+        get => _pos;
+        set
+        {
+            if (value < 0 || value > _data.Length)
+                throw new Exception($"InStream.Position {value} is outside the bounds of the stream.");
+            _pos = value;
+        }
+    }
 
     /// <summary>ALResetPosition — BC's InStream.ResetPosition(). Resets read position to 0.</summary>
     public void ALResetPosition(DataError errorLevel = DataError.ThrowError)

--- a/AlRunner/Runtime/MockJsonHelper.cs
+++ b/AlRunner/Runtime/MockJsonHelper.cs
@@ -639,6 +639,27 @@ public static class MockJsonHelper
     }
 
     /// <summary>
+    /// Replacement for NavJsonObject.ALGetObject(key, requireValueExists).
+    /// Returns the nested JsonObject value of the named property, with optional existence check.
+    /// AL: JsonObject.GetObject('key', true)  →  MockJsonHelper.GetObject(token, key, requireValueExists)
+    /// </summary>
+    public static NavJsonObject GetObject(NavJsonToken token, string key, bool requireValueExists)
+    {
+        var backingToken = GetBackingToken(token);
+        if (backingToken is not JObject obj)
+            throw new Exception("The JSON token is not an object.");
+        if (!obj.TryGetValue(key, out var val))
+        {
+            if (requireValueExists)
+                throw new Exception($"The JSON object does not contain a property with the name '{key}'.");
+            return CreateJsonToken<NavJsonObject>(new JObject());
+        }
+        if (val is not JObject jObj)
+            throw new Exception($"The value of JSON property '{key}' is not an object.");
+        return CreateJsonToken<NavJsonObject>(jObj);
+    }
+
+    /// <summary>
     /// Replacement for NavJsonArray.ALGetObject(index).
     /// Returns the JsonObject element at the given integer index.
     /// AL: JsonArray.GetObject(0)  →  MockJsonHelper.GetObject(token, 0)
@@ -668,6 +689,27 @@ public static class MockJsonHelper
             throw new Exception("The JSON token is not an object.");
         if (!obj.TryGetValue(key, out var val))
             throw new Exception($"The JSON object does not contain a property with the name '{key}'.");
+        if (val is not JArray jArr)
+            throw new Exception($"The value of JSON property '{key}' is not an array.");
+        return CreateJsonToken<NavJsonArray>(jArr);
+    }
+
+    /// <summary>
+    /// Replacement for NavJsonObject.ALGetArray(key, requireValueExists).
+    /// Returns the nested JsonArray value of the named property, with optional existence check.
+    /// AL: JsonObject.GetArray('key', true)  →  MockJsonHelper.GetArray(token, key, requireValueExists)
+    /// </summary>
+    public static NavJsonArray GetArray(NavJsonToken token, string key, bool requireValueExists)
+    {
+        var backingToken = GetBackingToken(token);
+        if (backingToken is not JObject obj)
+            throw new Exception("The JSON token is not an object.");
+        if (!obj.TryGetValue(key, out var val))
+        {
+            if (requireValueExists)
+                throw new Exception($"The JSON object does not contain a property with the name '{key}'.");
+            return CreateJsonToken<NavJsonArray>(new JArray());
+        }
         if (val is not JArray jArr)
             throw new Exception($"The value of JSON property '{key}' is not an array.");
         return CreateJsonToken<NavJsonArray>(jArr);

--- a/AlRunner/Runtime/MockPagePartHandle.cs
+++ b/AlRunner/Runtime/MockPagePartHandle.cs
@@ -73,6 +73,13 @@ public class MockPartFormHandle
     public void GetRecord(MockRecordHandle rec) { }
 
     /// <summary>
+    /// SetRecord — no-op in standalone mode.
+    /// BC generates <c>CurrPage.SubPart.Page.SetRecord(rec)</c> as
+    /// <c>CurrPage.GetPart(hash).CreateNavFormHandle(scope).SetRecord(rec.Target)</c>.
+    /// </summary>
+    public void SetRecord(MockRecordHandle rec) { }
+
+    /// <summary>
     /// SetTableView — no-op in standalone mode.
     /// BC generates <c>CurrPage.SubPart.Page.SetTableView(rec)</c> as
     /// <c>CurrPage.GetPart(hash).CreateNavFormHandle(scope).SetTableView(rec.Target)</c>.

--- a/AlRunner/Runtime/MockRecordRef.cs
+++ b/AlRunner/Runtime/MockRecordRef.cs
@@ -147,7 +147,19 @@ public class MockRecordRef
     /// ALAddLink — adds a link to the record. No-op in standalone mode (no BC link service).
     /// Returns 0 as the link ID.
     /// </summary>
-    public int ALAddLink(string url, string description = "") => 0;
+    public int ALAddLink(string url, string description = "")
+    {
+        _handle?.ALAddLink(url, description);
+        return 0;
+    }
+
+    /// <summary>
+    /// ALDeleteLinks — removes all links on the record. No-op if no record is open.
+    /// </summary>
+    public void ALDeleteLinks() => _handle?.ALDeleteLinks();
+
+    /// <summary>ALHasLinks — returns whether the record has any links.</summary>
+    public bool ALHasLinks => _handle?.ALHasLinks ?? false;
 
     // -- ReadConsistency — no SQL transactions in standalone --
 

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -3588,6 +3588,9 @@ InStream.Position (BigInteger):
   layer: runtime-api
   category: InStream
   status: covered
+  tests:
+    - tests/bucket-1/codeunit-runtime/331-instream-position-setter
+  notes: MockInStream.ALPosition getter/setter updates read cursor; throws when set out of bounds.
 
 InStream.Read (BigInteger, Integer):
   layer: runtime-api
@@ -4707,7 +4710,8 @@ JsonObject.GetArray (Text, Boolean):
   status: covered
   tests:
     - tests/bucket-2/data-formats/268-jsonobject-methods
-  notes: rewriter redirects ALGetArray to MockJsonHelper.GetArray
+    - tests/bucket-1/codeunit-runtime/330-jsonobject-getarray-bool
+  notes: 2-arg overload (key, requireValueExists); returns empty array when key is missing and requireValueExists=false
 
 JsonObject.GetBigInteger (Text, Boolean):
   layer: runtime-api
@@ -4790,7 +4794,8 @@ JsonObject.GetObject (Text, Boolean):
   status: covered
   tests:
     - tests/bucket-2/data-formats/268-jsonobject-methods
-  notes: rewriter redirects ALGetObject to MockJsonHelper.GetObject
+    - tests/bucket-1/codeunit-runtime/330-jsonobject-getarray-bool
+  notes: 2-arg overload (key, requireValueExists); returns empty object when key is missing and requireValueExists=false
 
 JsonObject.GetOption (Text, Boolean):
   layer: runtime-api
@@ -6210,6 +6215,8 @@ Page.GetRecord (Table):
   layer: runtime-api
   category: Page
   status: covered
+  tests:
+    - tests/bucket-1/codeunit-runtime/329-recref-links-currpage
 
 Page.Rec (page-as-component public procedures):
   layer: runtime-api
@@ -6393,6 +6400,8 @@ Page.SetRecord (Table):
   layer: runtime-api
   category: Page
   status: covered
+  tests:
+    - tests/bucket-1/codeunit-runtime/329-recref-links-currpage
 
 Page.SetSelectionFilter (Table):
   layer: runtime-api
@@ -6733,6 +6742,9 @@ RecordRef.DeleteLinks ():
   layer: runtime-api
   category: RecordRef
   status: covered
+  tests:
+    - tests/bucket-1/codeunit-runtime/329-recref-links-currpage
+  notes: MockRecordRef.ALDeleteLinks clears link state on the bound record handle.
 
 RecordRef.Duplicate ():
   layer: runtime-api
@@ -6862,6 +6874,9 @@ RecordRef.HasLinks ():
   layer: runtime-api
   category: RecordRef
   status: covered
+  tests:
+    - tests/bucket-1/codeunit-runtime/329-recref-links-currpage
+  notes: MockRecordRef.ALHasLinks forwards to the bound record handle.
 
 RecordRef.Init ():
   layer: runtime-api
@@ -10330,7 +10345,9 @@ Text.StrSubstNo (Text, Joker):
   layer: runtime-api
   category: Text
   status: covered
-  notes: (variadic). Static Text.StrSubstNo form covered — no-placeholder passthrough, single %1, multiple placeholders with mixed Text/Integer args.
+  tests:
+    - tests/bucket-1/codeunit-runtime/332-fieldref-navvalue-conversion
+  notes: (variadic). Static Text.StrSubstNo form covered — no-placeholder passthrough, single %1, multiple placeholders with mixed Text/Integer args; FieldRef arguments supported via MockFieldRef → NavValue conversion.
 
 Text.Substring (Integer, Integer):
   layer: runtime-api

--- a/tests/bucket-1/codeunit-runtime/329-recref-links-currpage/src/RecRefLinksCurrPageSrc.al
+++ b/tests/bucket-1/codeunit-runtime/329-recref-links-currpage/src/RecRefLinksCurrPageSrc.al
@@ -1,0 +1,89 @@
+table 1320420 "RR Link Table"
+{
+    fields
+    {
+        field(1; "No."; Code[20]) { }
+    }
+
+    keys
+    {
+        key(PK; "No.") { }
+    }
+}
+
+page 1320421 "RR Child Page"
+{
+    PageType = ListPart;
+    SourceTable = "RR Link Table";
+
+    layout
+    {
+        area(content)
+        {
+            repeater(Group)
+            {
+                field("No."; "No.") { }
+            }
+        }
+    }
+}
+
+page 1320422 "RR Parent Page"
+{
+    PageType = Card;
+    SourceTable = "RR Link Table";
+
+    layout
+    {
+        area(content)
+        {
+            group(General)
+            {
+                field("No."; "No.") { }
+            }
+            part(ChildPart; "RR Child Page")
+            {
+                SubPageLink = "No." = field("No.");
+            }
+        }
+    }
+
+    procedure ExerciseCurrPageMethods(): Boolean
+    var
+        Rec: Record "RR Link Table";
+    begin
+        Rec."No." := 'P1';
+        CurrPage.GetRecord(Rec);
+        CurrPage.ChildPart.Page.SetRecord(Rec);
+        exit(Rec."No." = 'P1');
+    end;
+}
+
+codeunit 1320414 "RR Links CurrPage Src"
+{
+    procedure RecordRefHasLinksAfterAdd(): Boolean
+    var
+        RecRef: RecordRef;
+    begin
+        RecRef.Open(Database::"RR Link Table");
+        RecRef.AddLink('https://example.com');
+        exit(RecRef.HasLinks());
+    end;
+
+    procedure RecordRefDeleteLinksClears(): Boolean
+    var
+        RecRef: RecordRef;
+    begin
+        RecRef.Open(Database::"RR Link Table");
+        RecRef.AddLink('https://example.com');
+        RecRef.DeleteLinks();
+        exit(RecRef.HasLinks());
+    end;
+
+    procedure PageCurrPageCalls(): Boolean
+    var
+        PageRef: Page "RR Parent Page";
+    begin
+        exit(PageRef.ExerciseCurrPageMethods());
+    end;
+}

--- a/tests/bucket-1/codeunit-runtime/329-recref-links-currpage/test/RecRefLinksCurrPageTest.al
+++ b/tests/bucket-1/codeunit-runtime/329-recref-links-currpage/test/RecRefLinksCurrPageTest.al
@@ -1,0 +1,53 @@
+codeunit 1320415 "RR Links CurrPage Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "RR Links CurrPage Src";
+
+    [Test]
+    procedure RecordRef_HasLinks_AfterAdd()
+    begin
+        Assert.IsTrue(Src.RecordRefHasLinksAfterAdd(),
+            'RecordRef.HasLinks should return true after AddLink');
+    end;
+
+    [Test]
+    procedure RecordRef_HasLinks_WrongExpectationFails()
+    begin
+        asserterror Assert.AreEqual(false, Src.RecordRefHasLinksAfterAdd(),
+            'RecordRef.HasLinks should not return false after AddLink');
+        Assert.ExpectedError('AreEqual');
+    end;
+
+    [Test]
+    procedure RecordRef_DeleteLinks_Clears()
+    begin
+        Assert.IsFalse(Src.RecordRefDeleteLinksClears(),
+            'RecordRef.HasLinks should be false after DeleteLinks');
+    end;
+
+    [Test]
+    procedure RecordRef_DeleteLinks_WrongExpectationFails()
+    begin
+        asserterror Assert.AreEqual(true, Src.RecordRefDeleteLinksClears(),
+            'RecordRef.HasLinks should not return true after DeleteLinks');
+        Assert.ExpectedError('AreEqual');
+    end;
+
+    [Test]
+    procedure CurrPage_GetRecord_And_Part_SetRecord_NoOp()
+    begin
+        Assert.IsTrue(Src.PageCurrPageCalls(),
+            'CurrPage.GetRecord and CurrPage.Part.Page.SetRecord should compile and not change record');
+    end;
+
+    [Test]
+    procedure CurrPage_GetRecord_And_Part_SetRecord_WrongExpectationFails()
+    begin
+        asserterror Assert.AreEqual(false, Src.PageCurrPageCalls(),
+            'CurrPage.GetRecord and CurrPage.Part.Page.SetRecord should not return false');
+        Assert.ExpectedError('AreEqual');
+    end;
+}

--- a/tests/bucket-1/codeunit-runtime/330-jsonobject-getarray-bool/src/JsonObjectGetArrayBoolSrc.al
+++ b/tests/bucket-1/codeunit-runtime/330-jsonobject-getarray-bool/src/JsonObjectGetArrayBoolSrc.al
@@ -1,0 +1,59 @@
+codeunit 1320416 "JsonObject Bool Src"
+{
+    procedure GetObjectRequireExists(): Boolean
+    var
+        Obj: JsonObject;
+        Child: JsonObject;
+    begin
+        Child.Add('flag', true);
+        Obj.Add('child', Child);
+        exit(Obj.GetObject('child', true).Contains('flag'));
+    end;
+
+    procedure GetObjectRequireExistsMissing(): Boolean
+    var
+        Obj: JsonObject;
+        Child: JsonObject;
+    begin
+        Child := Obj.GetObject('missing', true);
+        exit(Child.Contains('flag'));
+    end;
+
+    procedure GetObjectMissingNoError(): Boolean
+    var
+        Obj: JsonObject;
+        Child: JsonObject;
+    begin
+        Child := Obj.GetObject('missing', false);
+        exit(Child.Contains('flag'));
+    end;
+
+    procedure GetArrayRequireExists(): Integer
+    var
+        Obj: JsonObject;
+        Arr: JsonArray;
+    begin
+        Arr.Add(1);
+        Arr.Add(2);
+        Obj.Add('nums', Arr);
+        exit(Obj.GetArray('nums', true).Count());
+    end;
+
+    procedure GetArrayRequireExistsMissing(): Integer
+    var
+        Obj: JsonObject;
+        Arr: JsonArray;
+    begin
+        Arr := Obj.GetArray('missing', true);
+        exit(Arr.Count());
+    end;
+
+    procedure GetArrayMissingNoError(): Integer
+    var
+        Obj: JsonObject;
+        Arr: JsonArray;
+    begin
+        Arr := Obj.GetArray('missing', false);
+        exit(Arr.Count());
+    end;
+}

--- a/tests/bucket-1/codeunit-runtime/330-jsonobject-getarray-bool/test/JsonObjectGetArrayBoolTest.al
+++ b/tests/bucket-1/codeunit-runtime/330-jsonobject-getarray-bool/test/JsonObjectGetArrayBoolTest.al
@@ -1,0 +1,50 @@
+codeunit 1320417 "JsonObject Bool Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "JsonObject Bool Src";
+
+    [Test]
+    procedure GetObject_RequireExists_ReturnsNested()
+    begin
+        Assert.IsTrue(Src.GetObjectRequireExists(),
+            'GetObject(key, true) should return the nested object');
+    end;
+
+    [Test]
+    procedure GetObject_RequireExists_MissingThrows()
+    begin
+        asserterror Src.GetObjectRequireExistsMissing();
+        Assert.ExpectedError('does not contain a property with the name');
+    end;
+
+    [Test]
+    procedure GetObject_Missing_ReturnsEmptyObject()
+    begin
+        Assert.IsFalse(Src.GetObjectMissingNoError(),
+            'GetObject(key, false) should return an empty object for missing keys');
+    end;
+
+    [Test]
+    procedure GetArray_RequireExists_ReturnsArray()
+    begin
+        Assert.AreEqual(2, Src.GetArrayRequireExists(),
+            'GetArray(key, true) should return the array value');
+    end;
+
+    [Test]
+    procedure GetArray_RequireExists_MissingThrows()
+    begin
+        asserterror Src.GetArrayRequireExistsMissing();
+        Assert.ExpectedError('does not contain a property with the name');
+    end;
+
+    [Test]
+    procedure GetArray_Missing_ReturnsEmptyArray()
+    begin
+        Assert.AreEqual(0, Src.GetArrayMissingNoError(),
+            'GetArray(key, false) should return an empty array for missing keys');
+    end;
+}

--- a/tests/bucket-1/codeunit-runtime/331-instream-position-setter/src/InStreamPositionSetterSrc.al
+++ b/tests/bucket-1/codeunit-runtime/331-instream-position-setter/src/InStreamPositionSetterSrc.al
@@ -1,0 +1,46 @@
+table 1320423 "IS Position Data"
+{
+    fields
+    {
+        field(1; "Entry No."; Integer) { }
+        field(2; Content; Blob) { }
+    }
+
+    keys
+    {
+        key(PK; "Entry No.") { }
+    }
+}
+
+codeunit 1320418 "InStream Position Src"
+{
+    procedure ReadFromPosition(): Text
+    var
+        Rec: Record "IS Position Data";
+        InStr: InStream;
+        OutStr: OutStream;
+        Result: Text;
+    begin
+        Rec."Entry No." := 1;
+        Rec.Content.CreateOutStream(OutStr);
+        OutStr.WriteText('Hello World');
+        Rec.Content.CreateInStream(InStr);
+        InStr.Position := 6;
+        InStr.ReadText(Result);
+        exit(Result);
+    end;
+
+    procedure SetPositionOutOfRange(): Text
+    var
+        Rec: Record "IS Position Data";
+        InStr: InStream;
+        OutStr: OutStream;
+    begin
+        Rec."Entry No." := 1;
+        Rec.Content.CreateOutStream(OutStr);
+        OutStr.WriteText('Hi');
+        Rec.Content.CreateInStream(InStr);
+        InStr.Position := 100;
+        exit('done');
+    end;
+}

--- a/tests/bucket-1/codeunit-runtime/331-instream-position-setter/test/InStreamPositionSetterTest.al
+++ b/tests/bucket-1/codeunit-runtime/331-instream-position-setter/test/InStreamPositionSetterTest.al
@@ -1,0 +1,22 @@
+codeunit 1320419 "InStream Position Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "InStream Position Src";
+
+    [Test]
+    procedure Position_Setter_ReadsFromOffset()
+    begin
+        Assert.AreEqual('World', Src.ReadFromPosition(),
+            'Setting InStream.Position should move the read cursor');
+    end;
+
+    [Test]
+    procedure Position_Setter_OutOfRange_Throws()
+    begin
+        asserterror Src.SetPositionOutOfRange();
+        Assert.ExpectedError('outside the bounds of the stream');
+    end;
+}

--- a/tests/bucket-1/codeunit-runtime/332-fieldref-navvalue-conversion/src/FieldRefNavValueSrc.al
+++ b/tests/bucket-1/codeunit-runtime/332-fieldref-navvalue-conversion/src/FieldRefNavValueSrc.al
@@ -1,0 +1,27 @@
+table 1320424 "FieldRef Conv Table"
+{
+    fields
+    {
+        field(1; "No."; Code[20]) { }
+    }
+
+    keys
+    {
+        key(PK; "No.") { }
+    }
+}
+
+codeunit 1320425 "FieldRef NavValue Src"
+{
+    procedure StrSubstNo_WithFieldRef(): Text
+    var
+        Rec: Record "FieldRef Conv Table";
+        RecRef: RecordRef;
+        FRef: FieldRef;
+    begin
+        Rec."No." := 'FR1';
+        RecRef.GetTable(Rec);
+        FRef := RecRef.Field(1);
+        exit(StrSubstNo('%1', FRef));
+    end;
+}

--- a/tests/bucket-1/codeunit-runtime/332-fieldref-navvalue-conversion/test/FieldRefNavValueTest.al
+++ b/tests/bucket-1/codeunit-runtime/332-fieldref-navvalue-conversion/test/FieldRefNavValueTest.al
@@ -1,0 +1,23 @@
+codeunit 1320426 "FieldRef NavValue Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "FieldRef NavValue Src";
+
+    [Test]
+    procedure StrSubstNo_WithFieldRef_FormatsValue()
+    begin
+        Assert.AreEqual('FR1', Src.StrSubstNo_WithFieldRef(),
+            'FieldRef should format via StrSubstNo when passed as argument');
+    end;
+
+    [Test]
+    procedure StrSubstNo_WithFieldRef_WrongExpectationFails()
+    begin
+        asserterror Assert.AreEqual('WRONG', Src.StrSubstNo_WithFieldRef(),
+            'FieldRef formatting should not match the wrong value');
+        Assert.ExpectedError('AreEqual');
+    end;
+}


### PR DESCRIPTION
## Summary\n- add RecordRef.HasLinks/DeleteLinks plus CurrPage.GetRecord and part Page.SetRecord stubs\n- add JsonObject.GetObject/GetArray (key, requireValueExists) overloads\n- allow InStream.Position setter with bounds checks\n- add MockFieldRef → NavValue conversion for StrSubstNo\n- add tests + coverage updates\n\nCloses #1540