### PR TITLE
Fix mock gaps for System Application compile

### DIFF
--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -3740,6 +3740,16 @@ public void Unbind() { AlRunner.Runtime.EventSubscriberRegistry.Unbind(this); }
                         SyntaxFactory.IdentifierName("NavIndirectValueToInt32")));
             }
 
+            // ALCompiler.NavIndirectValueToGuid(x) -> AlCompat.NavIndirectValueToGuid(x)
+            if (exprText == "ALCompiler" && methodName == "NavIndirectValueToGuid")
+            {
+                return visited.WithExpression(
+                    SyntaxFactory.MemberAccessExpression(
+                        SyntaxKind.SimpleMemberAccessExpression,
+                        SyntaxFactory.IdentifierName("AlCompat"),
+                        SyntaxFactory.IdentifierName("NavIndirectValueToGuid")));
+            }
+
             // ALCompiler.NavIndirectValueToNavValue<T>(x) -> AlCompat.NavIndirectValueToNavValue<T>(x)
             // Special case: T=MockRecordRef (NavRecordRef after rewriting) — MockRecordRef does not
             // implement NavValue and cannot satisfy the generic constraint. Emit a direct cast

--- a/AlRunner/Runtime/AlScope.cs
+++ b/AlRunner/Runtime/AlScope.cs
@@ -1319,6 +1319,29 @@ public static class AlCompat
     }
 
     /// <summary>
+    /// Replacement for ALCompiler.NavIndirectValueToGuid.
+    /// Extracts a Guid from a variant/indirect value holder.
+    /// </summary>
+    public static Guid NavIndirectValueToGuid(object? value)
+    {
+        if (value is MockVariant mv) return NavIndirectValueToGuid(mv.Value);
+        if (value is Guid guid) return guid;
+        if (value is NavGuid navGuid) return navGuid.Value;
+        if (value is string text && Guid.TryParse(text, out var parsed)) return parsed;
+        if (value is NavText navText && Guid.TryParse(navText.ToString(), out var parsedText)) return parsedText;
+        if (value != null && value.GetType().Name == "NavGuid")
+        {
+            var toGuidMethod = value.GetType().GetMethod("ToGuid", Type.EmptyTypes);
+            if (toGuidMethod != null)
+                return (Guid)toGuidMethod.Invoke(value, null)!;
+            var valueProp = value.GetType().GetProperty("Value");
+            if (valueProp?.PropertyType == typeof(Guid))
+                return (Guid)valueProp.GetValue(value)!;
+        }
+        throw new InvalidCastException($"Cannot convert {value?.GetType().Name ?? "null"} to Guid");
+    }
+
+    /// <summary>
     /// Replacement for ALCompiler.NavIndirectValueToNavValue.
     /// Extracts the NavValue from a variant/indirect value holder.
     /// </summary>

--- a/AlRunner/Runtime/MockHttpContent.cs
+++ b/AlRunner/Runtime/MockHttpContent.cs
@@ -50,6 +50,16 @@ public class MockHttpContent
     }
 
     /// <summary>
+    /// SecretText overload for <c>HttpContent.ReadAs(var SecretText)</c>.
+    /// Returns the stored body wrapped as SecretText.
+    /// </summary>
+    public bool ALReadAs(DataError errorLevel, ByRef<NavSecretText> text)
+    {
+        text.Value = NavSecretText.Create(_textContent);
+        return true;
+    }
+
+    /// <summary>
     /// Content headers. BC emits <c>content.ALGetHeaders(errorLevel, byref headers)</c>
     /// as a method call with a ByRef out parameter. The headers collection is shared
     /// with the content so later mutations round-trip.

--- a/AlRunner/Runtime/MockHttpHeaders.cs
+++ b/AlRunner/Runtime/MockHttpHeaders.cs
@@ -28,8 +28,9 @@ public class MockHttpHeaders
     /// <summary>
     /// BC emits: <c>headers.ALAdd(DataError, key, value)</c>
     /// for <c>HttpHeaders.Add(key, value)</c> (Text overload).
+    /// Returns <c>true</c> so call sites can use the bool result.
     /// </summary>
-    public void ALAdd(DataError errorLevel, string key, string value)
+    public bool ALAdd(DataError errorLevel, string key, string value)
     {
         if (!_headers.TryGetValue(key, out var list))
         {
@@ -37,6 +38,7 @@ public class MockHttpHeaders
             _headers[key] = list;
         }
         list.Add(value);
+        return true;
     }
 
     /// <summary>
@@ -45,7 +47,7 @@ public class MockHttpHeaders
     /// In standalone mode secrets are treated as plain text — the value
     /// is extracted via <see cref="AlCompat.Unwrap"/> and stored normally.
     /// </summary>
-    public void ALAdd(DataError errorLevel, string key, NavSecretText secretValue)
+    public bool ALAdd(DataError errorLevel, string key, NavSecretText secretValue)
         => ALAdd(errorLevel, key, (string)AlCompat.Unwrap(secretValue));
 
     /// <summary>

--- a/AlRunner/Runtime/MockHttpRequestMessage.cs
+++ b/AlRunner/Runtime/MockHttpRequestMessage.cs
@@ -73,12 +73,27 @@ public class MockHttpRequestMessage
     /// <summary>
     /// BC emits: <c>req.ALSetCookie(DataError, name, value)</c>
     /// for <c>HttpRequestMessage.SetCookie(name, value)</c>.
-    /// Stores a MockCookie keyed by name (case-insensitive).
+    /// Stores a MockCookie keyed by name (case-insensitive) and returns true.
     /// </summary>
-    public void ALSetCookie(DataError errorLevel, string name, string value)
+    public bool ALSetCookie(DataError errorLevel, string name, string value)
     {
         var cookie = new MockCookie { ALName = name, ALValue = value };
         _cookies[name] = cookie;
+        return true;
+    }
+
+    /// <summary>
+    /// BC emits: <c>req.ALSetCookie(DataError, cookie)</c>
+    /// for <c>HttpRequestMessage.SetCookie(cookie)</c>.
+    /// Stores the cookie keyed by its name and returns true.
+    /// </summary>
+    public bool ALSetCookie(DataError errorLevel, MockCookie cookie)
+    {
+        if (cookie == null) return false;
+        var stored = new MockCookie();
+        stored.ALAssign(cookie);
+        _cookies[stored.ALName] = stored;
+        return true;
     }
 
     /// <summary>
@@ -100,12 +115,10 @@ public class MockHttpRequestMessage
     /// <summary>
     /// BC emits: <c>req.ALRemoveCookie(DataError, name)</c>
     /// for <c>HttpRequestMessage.RemoveCookie(name)</c>.
-    /// Removes the named cookie; no-op if not found.
+    /// Removes the named cookie; returns true if removed.
     /// </summary>
-    public void ALRemoveCookie(DataError errorLevel, string name)
-    {
-        _cookies.Remove(name);
-    }
+    public bool ALRemoveCookie(DataError errorLevel, string name)
+        => _cookies.Remove(name);
 
     /// <summary>
     /// BC emits: <c>req.ALGetCookieNames()</c>

--- a/AlRunner/Runtime/MockObjectList.cs
+++ b/AlRunner/Runtime/MockObjectList.cs
@@ -1,5 +1,7 @@
 using System.Collections;
 using System.Collections.Generic;
+using System.Reflection;
+using Microsoft.Dynamics.Nav.Types;
 
 namespace AlRunner.Runtime;
 
@@ -29,6 +31,35 @@ public class MockObjectList<T> : IEnumerable<T>
     public int Count => _items.Count;
 
     public T ALGet(int oneBasedIndex) => _items[oneBasedIndex - 1];
+
+    /// <summary>
+    /// ALGet with out-parameter (DataError, index, handle) — used by lists of ITreeObject
+    /// values (e.g., List of [Codeunit]) where the caller passes the handle directly.
+    /// </summary>
+    public bool ALGet(DataError errorLevel, int oneBasedIndex, T handle)
+    {
+        if (oneBasedIndex < 1 || oneBasedIndex > _items.Count)
+        {
+            if (errorLevel == DataError.ThrowError)
+                throw new InvalidOperationException(
+                    $"The list does not contain an element at position {oneBasedIndex}.");
+            return false;
+        }
+
+        var stored = _items[oneBasedIndex - 1];
+        if (handle != null && stored != null)
+        {
+            var method = handle.GetType().GetMethod(
+                "ALAssign",
+                BindingFlags.Public | BindingFlags.Instance,
+                null,
+                new[] { stored.GetType() },
+                null);
+            method?.Invoke(handle, new object[] { stored });
+        }
+
+        return true;
+    }
 
     public bool ALContains(T item) => _items.Contains(item);
 

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -3322,8 +3322,10 @@ HttpContent.ReadAs (InStream):
 HttpContent.ReadAs (SecretText):
   layer: runtime-api
   category: HttpContent
-  status: not-possible
-  notes: Runner gap — SecretText ReadAs requires HTTP response body infrastructure not available in standalone mode.
+  status: covered
+  tests:
+    - tests/bucket-1/codeunit-runtime/335-httpcontent-readas-secrettext
+  notes: MockHttpContent.ALReadAs returns stored body as SecretText and returns true.
 
 HttpContent.ReadAs (Text):
   layer: runtime-api
@@ -3367,7 +3369,8 @@ HttpHeaders.Add (Text, Text):
   status: covered
   tests:
     - tests/bucket-2/data-formats/1318-sweep-misc-overloads
-  notes: MockHttpHeaders.ALAdd(DataError, string, string) — proven via HttpHeaders.Add. Closes #1400.
+    - tests/bucket-1/codeunit-runtime/333-httpheaders-cookies-bool
+  notes: MockHttpHeaders.ALAdd(DataError, string, string) returns true; proven via HttpHeaders.Add. Closes #1400.
 
 HttpHeaders.Clear ():
   layer: runtime-api
@@ -3494,7 +3497,8 @@ HttpRequestMessage.RemoveCookie (Text):
   status: covered
   tests:
     - tests/bucket-2/data-formats/186-httprequestmessage-cookies
-  notes: ALRemoveCookie(DataError, string) removes cookie by name, no-op if not found.
+    - tests/bucket-1/codeunit-runtime/333-httpheaders-cookies-bool
+  notes: ALRemoveCookie(DataError, string) removes cookie by name; returns true when removed, false when missing.
 
 HttpRequestMessage.SetCookie (Cookie):
   layer: runtime-api
@@ -3502,13 +3506,16 @@ HttpRequestMessage.SetCookie (Cookie):
   status: covered
   tests:
     - tests/bucket-2/data-formats/186-httprequestmessage-cookies
-  notes: ALSetCookie(DataError, string, string) stores MockCookie keyed by name (case-insensitive).
+    - tests/bucket-1/codeunit-runtime/334-httprequestmessage-setcookie-cookie
+  notes: ALSetCookie(DataError, MockCookie) stores a cookie keyed by name and returns true.
 
 HttpRequestMessage.SetCookie (Text, Text):
   layer: runtime-api
   category: HttpRequestMessage
   status: covered
-  notes: No-op stub or pass-through; compiles and runs without error. Closes #1400 sweep.
+  tests:
+    - tests/bucket-1/codeunit-runtime/333-httpheaders-cookies-bool
+  notes: ALSetCookie(DataError, string, string) stores MockCookie keyed by name and returns true.
 
 HttpRequestMessage.SetRequestUri (Text):
   layer: runtime-api
@@ -5590,6 +5597,17 @@ Label.TrimStart (Text):
     - tests/bucket-2/data-formats/186-label-string-methods
   notes: . Covered via NavText native — leading strip only.
 
+# ── List ────────────────────────────────────────────────────────
+
+List.Get (Integer, Codeunit):
+  layer: runtime-api
+  category: List
+  status: covered
+  tests:
+    - tests/bucket-1/codeunit-runtime/337-codeunit-list-get-negation
+    - tests/bucket-1/codeunit-runtime/338-codeunit-list-get-assign
+  notes: MockObjectList.ALGet(DataError, int, MockCodeunitHandle) assigns via ALAssign and returns bool.
+
 # ── Media ───────────────────────────────────────────────────────
 
 Media.ExportFile (Text):
@@ -6840,6 +6858,8 @@ RecordRef.GetBySystemId (Guid):
   layer: runtime-api
   category: RecordRef
   status: covered
+  tests:
+    - tests/bucket-1/codeunit-runtime/336-variant-guid-conversion
 
 RecordRef.GetFilters ():
   layer: runtime-api

--- a/tests/bucket-1/codeunit-runtime/333-httpheaders-cookies-bool/src/HttpHeadersCookiesBoolSrc.al
+++ b/tests/bucket-1/codeunit-runtime/333-httpheaders-cookies-bool/src/HttpHeadersCookiesBoolSrc.al
@@ -1,0 +1,33 @@
+codeunit 1320500 "HH Cookie Bool Src"
+{
+    procedure AddHeaderReturnsTrue(): Boolean
+    var
+        req: HttpRequestMessage;
+        headers: HttpHeaders;
+    begin
+        req.GetHeaders(headers);
+        exit(headers.Add('X-Test', 'value'));
+    end;
+
+    procedure SetCookieReturnsTrue(): Boolean
+    var
+        req: HttpRequestMessage;
+    begin
+        exit(req.SetCookie('Session', 'abc'));
+    end;
+
+    procedure RemoveCookieReturnsTrue(): Boolean
+    var
+        req: HttpRequestMessage;
+    begin
+        req.SetCookie('Session', 'abc');
+        exit(req.RemoveCookie('Session'));
+    end;
+
+    procedure RemoveCookieMissingReturnsFalse(): Boolean
+    var
+        req: HttpRequestMessage;
+    begin
+        exit(req.RemoveCookie('Missing'));
+    end;
+}

--- a/tests/bucket-1/codeunit-runtime/333-httpheaders-cookies-bool/test/HttpHeadersCookiesBoolTest.al
+++ b/tests/bucket-1/codeunit-runtime/333-httpheaders-cookies-bool/test/HttpHeadersCookiesBoolTest.al
@@ -1,0 +1,36 @@
+codeunit 1320501 "HH Cookie Bool Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "HH Cookie Bool Src";
+
+    [Test]
+    procedure AddHeader_ReturnsTrue()
+    begin
+        Assert.IsTrue(Src.AddHeaderReturnsTrue(),
+            'HttpHeaders.Add should return true when header is added');
+    end;
+
+    [Test]
+    procedure SetCookie_ReturnsTrue()
+    begin
+        Assert.IsTrue(Src.SetCookieReturnsTrue(),
+            'HttpRequestMessage.SetCookie(Text, Text) should return true');
+    end;
+
+    [Test]
+    procedure RemoveCookie_ReturnsTrue()
+    begin
+        Assert.IsTrue(Src.RemoveCookieReturnsTrue(),
+            'HttpRequestMessage.RemoveCookie should return true when cookie exists');
+    end;
+
+    [Test]
+    procedure RemoveCookie_Missing_ReturnsFalse()
+    begin
+        Assert.IsFalse(Src.RemoveCookieMissingReturnsFalse(),
+            'HttpRequestMessage.RemoveCookie should return false when cookie is missing');
+    end;
+}

--- a/tests/bucket-1/codeunit-runtime/334-httprequestmessage-setcookie-cookie/src/HttpRequestMessageCookieSrc.al
+++ b/tests/bucket-1/codeunit-runtime/334-httprequestmessage-setcookie-cookie/src/HttpRequestMessageCookieSrc.al
@@ -1,0 +1,34 @@
+codeunit 1320502 "HRM Cookie Src"
+{
+    procedure SetCookieObjectReturnsTrue(): Boolean
+    var
+        req: HttpRequestMessage;
+        cookie: Cookie;
+    begin
+        cookie.Name := 'SessionId';
+        cookie.Value := 'abc-123';
+        exit(req.SetCookie(cookie));
+    end;
+
+    procedure SetCookieObjectRoundTrip(): Text
+    var
+        req: HttpRequestMessage;
+        cookieIn: Cookie;
+        cookieOut: Cookie;
+    begin
+        cookieIn.Name := 'SessionId';
+        cookieIn.Value := 'abc-123';
+        req.SetCookie(cookieIn);
+        if req.GetCookie('SessionId', cookieOut) then
+            exit(cookieOut.Value);
+        exit('');
+    end;
+
+    procedure GetCookieMissingReturnsFalse(): Boolean
+    var
+        req: HttpRequestMessage;
+        cookieOut: Cookie;
+    begin
+        exit(req.GetCookie('MissingCookie', cookieOut));
+    end;
+}

--- a/tests/bucket-1/codeunit-runtime/334-httprequestmessage-setcookie-cookie/test/HttpRequestMessageCookieTest.al
+++ b/tests/bucket-1/codeunit-runtime/334-httprequestmessage-setcookie-cookie/test/HttpRequestMessageCookieTest.al
@@ -1,0 +1,29 @@
+codeunit 1320503 "HRM Cookie Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "HRM Cookie Src";
+
+    [Test]
+    procedure SetCookieObject_ReturnsTrue()
+    begin
+        Assert.IsTrue(Src.SetCookieObjectReturnsTrue(),
+            'HttpRequestMessage.SetCookie(Cookie) should return true');
+    end;
+
+    [Test]
+    procedure SetCookieObject_RoundTripValue()
+    begin
+        Assert.AreEqual('abc-123', Src.SetCookieObjectRoundTrip(),
+            'SetCookie(Cookie) should allow GetCookie to return the stored value');
+    end;
+
+    [Test]
+    procedure GetCookie_Missing_ReturnsFalse()
+    begin
+        Assert.IsFalse(Src.GetCookieMissingReturnsFalse(),
+            'GetCookie should return false when the cookie does not exist');
+    end;
+}

--- a/tests/bucket-1/codeunit-runtime/335-httpcontent-readas-secrettext/src/HttpContentReadAsSecretSrc.al
+++ b/tests/bucket-1/codeunit-runtime/335-httpcontent-readas-secrettext/src/HttpContentReadAsSecretSrc.al
@@ -1,0 +1,31 @@
+codeunit 1320504 "HC ReadAs Secret Src"
+{
+    procedure ReadAsSecretRoundTrip(body: Text): Text
+    var
+        content: HttpContent;
+        secret: SecretText;
+    begin
+        content.WriteFrom(body);
+        content.ReadAs(secret);
+        exit(secret.Unwrap());
+    end;
+
+    procedure ReadAsSecretReturnsTrue(): Boolean
+    var
+        content: HttpContent;
+        secret: SecretText;
+    begin
+        content.WriteFrom('payload');
+        exit(content.ReadAs(secret));
+    end;
+
+    procedure ReadAsSecretIsEmpty(body: Text): Boolean
+    var
+        content: HttpContent;
+        secret: SecretText;
+    begin
+        content.WriteFrom(body);
+        content.ReadAs(secret);
+        exit(secret.Unwrap() = '');
+    end;
+}

--- a/tests/bucket-1/codeunit-runtime/335-httpcontent-readas-secrettext/test/HttpContentReadAsSecretTest.al
+++ b/tests/bucket-1/codeunit-runtime/335-httpcontent-readas-secrettext/test/HttpContentReadAsSecretTest.al
@@ -1,0 +1,29 @@
+codeunit 1320505 "HC ReadAs Secret Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "HC ReadAs Secret Src";
+
+    [Test]
+    procedure ReadAsSecret_RoundTrip()
+    begin
+        Assert.AreEqual('secret-body', Src.ReadAsSecretRoundTrip('secret-body'),
+            'HttpContent.ReadAs(SecretText) should return the stored body');
+    end;
+
+    [Test]
+    procedure ReadAsSecret_ReturnsTrue()
+    begin
+        Assert.IsTrue(Src.ReadAsSecretReturnsTrue(),
+            'HttpContent.ReadAs(SecretText) should return true');
+    end;
+
+    [Test]
+    procedure ReadAsSecret_IsEmpty_FalseForNonEmpty()
+    begin
+        Assert.IsFalse(Src.ReadAsSecretIsEmpty('not-empty'),
+            'ReadAs(SecretText) must not return empty for non-empty content');
+    end;
+}

--- a/tests/bucket-1/codeunit-runtime/336-variant-guid-conversion/src/VariantGuidSrc.al
+++ b/tests/bucket-1/codeunit-runtime/336-variant-guid-conversion/src/VariantGuidSrc.al
@@ -1,0 +1,10 @@
+codeunit 1320506 "VG Src"
+{
+    procedure GetBySystemIdFromVariant(reference: Variant): Boolean
+    var
+        rr: RecordRef;
+    begin
+        rr.Open(Database::"VG Table");
+        exit(rr.GetBySystemId(reference));
+    end;
+}

--- a/tests/bucket-1/codeunit-runtime/336-variant-guid-conversion/src/VariantGuidTable.al
+++ b/tests/bucket-1/codeunit-runtime/336-variant-guid-conversion/src/VariantGuidTable.al
@@ -1,0 +1,14 @@
+table 1320600 "VG Table"
+{
+    DataClassification = ToBeClassified;
+
+    fields
+    {
+        field(1; Id; Integer) { }
+    }
+
+    keys
+    {
+        key(PK; Id) { Clustered = true; }
+    }
+}

--- a/tests/bucket-1/codeunit-runtime/336-variant-guid-conversion/test/VariantGuidTest.al
+++ b/tests/bucket-1/codeunit-runtime/336-variant-guid-conversion/test/VariantGuidTest.al
@@ -1,0 +1,34 @@
+codeunit 1320507 "VG Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "VG Src";
+
+    [Test]
+    procedure GetBySystemId_FromVariant_ReturnsTrue()
+    var
+        rec: Record "VG Table";
+        v: Variant;
+    begin
+        rec.Init();
+        rec.Id := 1;
+        rec.Insert();
+        v := rec.SystemId;
+
+        Assert.IsTrue(Src.GetBySystemIdFromVariant(v),
+            'RecordRef.GetBySystemId should accept a Variant holding a Guid');
+    end;
+
+    [Test]
+    procedure GetBySystemId_FromVariant_Missing_ReturnsFalse()
+    var
+        v: Variant;
+    begin
+        v := CreateGuid();
+
+        Assert.IsFalse(Src.GetBySystemIdFromVariant(v),
+            'RecordRef.GetBySystemId should return false for a missing SystemId');
+    end;
+}

--- a/tests/bucket-1/codeunit-runtime/337-codeunit-list-get-negation/src/CodeunitListNegationSrc.al
+++ b/tests/bucket-1/codeunit-runtime/337-codeunit-list-get-negation/src/CodeunitListNegationSrc.al
@@ -1,0 +1,7 @@
+codeunit 1320508 "CLN Worker"
+{
+    procedure GetValue(): Integer
+    begin
+        exit(42);
+    end;
+}

--- a/tests/bucket-1/codeunit-runtime/337-codeunit-list-get-negation/test/CodeunitListNegationTest.al
+++ b/tests/bucket-1/codeunit-runtime/337-codeunit-list-get-negation/test/CodeunitListNegationTest.al
@@ -1,0 +1,28 @@
+codeunit 1320509 "CLN Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    [Test]
+    procedure ListGet_NegatedMissing_ReturnsTrue()
+    var
+        list: List of [Codeunit "CLN Worker"];
+        worker: Codeunit "CLN Worker";
+    begin
+        Assert.IsTrue(not list.Get(1, worker),
+            'Negating List.Get should work for missing entries');
+    end;
+
+    [Test]
+    procedure ListGet_NegatedPresent_ReturnsFalse()
+    var
+        list: List of [Codeunit "CLN Worker"];
+        worker: Codeunit "CLN Worker";
+    begin
+        list.Add(worker);
+        Assert.IsFalse(not list.Get(1, worker),
+            'Negating List.Get should be false when the entry exists');
+    end;
+}

--- a/tests/bucket-1/codeunit-runtime/338-codeunit-list-get-assign/src/CodeunitListGetSrc.al
+++ b/tests/bucket-1/codeunit-runtime/338-codeunit-list-get-assign/src/CodeunitListGetSrc.al
@@ -1,0 +1,7 @@
+codeunit 1320510 "CLG Worker"
+{
+    procedure GetValue(): Integer
+    begin
+        exit(99);
+    end;
+}

--- a/tests/bucket-1/codeunit-runtime/338-codeunit-list-get-assign/test/CodeunitListGetTest.al
+++ b/tests/bucket-1/codeunit-runtime/338-codeunit-list-get-assign/test/CodeunitListGetTest.al
@@ -1,0 +1,32 @@
+codeunit 1320511 "CLG Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    [Test]
+    procedure ListGet_AssignsCodeunit()
+    var
+        list: List of [Codeunit "CLG Worker"];
+        stored: Codeunit "CLG Worker";
+        result: Codeunit "CLG Worker";
+        value: Integer;
+    begin
+        list.Add(stored);
+        if list.Get(1, result) then
+            value := result.GetValue();
+        Assert.AreEqual(99, value,
+            'List.Get should assign the stored codeunit handle');
+    end;
+
+    [Test]
+    procedure ListGet_Missing_ReturnsFalse()
+    var
+        list: List of [Codeunit "CLG Worker"];
+        result: Codeunit "CLG Worker";
+    begin
+        Assert.IsFalse(list.Get(1, result),
+            'List.Get should return false when the index is missing');
+    end;
+}


### PR DESCRIPTION
## Summary
- return bools for HttpHeaders.Add and HttpRequestMessage cookie helpers (incl. Cookie overload)
- add SecretText ReadAs, List.Get(DataError, index, codeunit) and NavIndirectValueToGuid rewrite
- add six focused test suites + coverage updates

Closes #1542