### PR TITLE
Fix FieldRef.Validate overload ambiguity

### DIFF
--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -1572,6 +1572,14 @@ public void Unbind() { AlRunner.Runtime.EventSubscriberRegistry.Unbind(this); }
             return SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.ObjectKeyword))
                 .WithTriviaFrom(node);
 
+        // NavIndirectValue -> object
+        // BC uses NavIndirectValue as a base type for Variant-like parameters.
+        // MockVariant does not extend NavIndirectValue, so rewrite to object
+        // to accept mock values at call sites.
+        if (text == "NavIndirectValue")
+            return SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.ObjectKeyword))
+                .WithTriviaFrom(node);
+
         // NavScope — context-sensitive rewrite:
         //
         //   Role 1 (ObjectCreationExpression): "new NavScope(this)"

--- a/AlRunner/Runtime/MockFieldRef.cs
+++ b/AlRunner/Runtime/MockFieldRef.cs
@@ -207,15 +207,8 @@ public class MockFieldRef
     public void ALValidate(object value)
         => ALValidate(AlCompat.ToNavValue(value));
 
-    /// <summary>ALValidate — MockVariant overload; unwraps to NavValue via AlCompat then validates.</summary>
-    public void ALValidate(MockVariant value)
-        => ALValidate(AlCompat.ToNavValue(value));
-
     /// <summary>ALValidateSafe — safe variant of Validate.</summary>
     public void ALValidateSafe(NavValue value) => ALValidate(value);
-
-    /// <summary>ALValidateSafe — MockVariant overload; unwraps to NavValue via AlCompat then validates.</summary>
-    public void ALValidateSafe(MockVariant value) => ALValidate(AlCompat.ToNavValue(value));
 
     /// <summary>ALValidateSafe — object/Variant overload; unwraps to NavValue then validates.</summary>
     public void ALValidateSafe(object value) => ALValidate(AlCompat.ToNavValue(value));

--- a/AlRunner/Runtime/MockFieldRef.cs
+++ b/AlRunner/Runtime/MockFieldRef.cs
@@ -207,8 +207,27 @@ public class MockFieldRef
     public void ALValidate(object value)
         => ALValidate(AlCompat.ToNavValue(value));
 
-    /// <summary>ALValidateSafe — safe variant of Validate.</summary>
-    public void ALValidateSafe(NavValue value) => ALValidate(value);
+    /// <summary>ALValidate — MockVariant overload; unwraps to NavValue via AlCompat then validates.</summary>
+    public void ALValidate(MockVariant value)
+    {
+        if (value == null)
+        {
+            ALValidate();
+            return;
+        }
+        ALValidate(AlCompat.ToNavValue(value));
+    }
+
+    /// <summary>ALValidateSafe — MockVariant overload; unwraps to NavValue via AlCompat then validates.</summary>
+    public void ALValidateSafe(MockVariant value)
+    {
+        if (value == null)
+        {
+            ALValidate();
+            return;
+        }
+        ALValidate(AlCompat.ToNavValue(value));
+    }
 
     /// <summary>ALValidateSafe — object/Variant overload; unwraps to NavValue then validates.</summary>
     public void ALValidateSafe(object value) => ALValidate(AlCompat.ToNavValue(value));

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -2724,8 +2724,9 @@ FieldRef.Validate (Variant):
   notes: >
     FieldRef.Validate(Variant) flows through the object/Variant overload on
     MockFieldRef.ALValidate / ALValidateSafe, which unwraps the Variant via
-    AlCompat.ToNavValue before firing OnValidate. MockVariant-specific overloads
-    were removed to avoid CS0121 ambiguity when BC emits Validate with a null
+    AlCompat.ToNavValue before firing OnValidate. MockVariant overloads handle
+    null variants by re-validating the current value, and the NavValue overload
+    was removed to avoid CS0121 ambiguity when BC emits Validate with a null
     or indirect value.
   tests:
     - tests/bucket-1/record-table/1313-fieldref-validate-variant

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -2714,16 +2714,19 @@ FieldRef.Validate (Joker):
   layer: runtime-api
   category: FieldRef
   status: covered
+  tests:
+    - tests/bucket-1/codeunit-runtime/100-fieldref-validate-no-arg
 
 FieldRef.Validate (Variant):
   layer: runtime-api
   category: FieldRef
   status: covered
   notes: >
-    MockVariant-specific overload on MockFieldRef.ALValidate / ALValidateSafe unwraps
-    the Variant to its underlying NavValue via AlCompat.ToNavValue before firing the
-    OnValidate trigger. Fixes NullReferenceException when BC emits fr.Validate(v)
-    with a Variant argument (closes #1487).
+    FieldRef.Validate(Variant) flows through the object/Variant overload on
+    MockFieldRef.ALValidate / ALValidateSafe, which unwraps the Variant via
+    AlCompat.ToNavValue before firing OnValidate. MockVariant-specific overloads
+    were removed to avoid CS0121 ambiguity when BC emits Validate with a null
+    or indirect value.
   tests:
     - tests/bucket-1/record-table/1313-fieldref-validate-variant
 

--- a/tests/bucket-1/codeunit-runtime/100-fieldref-validate-no-arg/src/FieldRefValidateNoArg.al
+++ b/tests/bucket-1/codeunit-runtime/100-fieldref-validate-no-arg/src/FieldRefValidateNoArg.al
@@ -1,0 +1,22 @@
+table 1320513 "FR Validate NoArg"
+{
+    fields
+    {
+        field(1; "No."; Integer) { }
+        field(2; Amount; Decimal)
+        {
+            trigger OnValidate()
+            begin
+                if Amount < 0 then
+                    Error('Amount must be non-negative');
+                Validated := true;
+            end;
+        }
+        field(3; Validated; Boolean) { }
+    }
+
+    keys
+    {
+        key(PK; "No.") { Clustered = true; }
+    }
+}

--- a/tests/bucket-1/codeunit-runtime/100-fieldref-validate-no-arg/test/FieldRefValidateNoArgTest.al
+++ b/tests/bucket-1/codeunit-runtime/100-fieldref-validate-no-arg/test/FieldRefValidateNoArgTest.al
@@ -1,0 +1,77 @@
+codeunit 1320512 "FR Validate NoArg Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    [Test]
+    procedure FieldRef_Validate_NoArg_UsesCurrentValue()
+    var
+        ReproRec: Record "FR Validate NoArg";
+        Rr: RecordRef;
+        Fr: FieldRef;
+    begin
+        ReproRec.Init();
+        ReproRec."No." := 1;
+        ReproRec.Insert();
+        Rr.GetTable(ReproRec);
+        Fr := Rr.Field(2);
+
+        Fr.Value(12.5);
+        Fr.Validate();
+        Rr.Modify();
+        Rr.Close();
+
+        ReproRec.Get(1);
+        Assert.AreEqual(12.5, ReproRec.Amount, 'FieldRef.Validate() must keep the current value');
+        Assert.IsTrue(ReproRec.Validated, 'FieldRef.Validate() must invoke OnValidate');
+    end;
+
+    [Test]
+    procedure FieldRef_Validate_NoArg_InvalidValue_Errors()
+    var
+        ReproRec: Record "FR Validate NoArg";
+        Rr: RecordRef;
+        Fr: FieldRef;
+    begin
+        ReproRec.Init();
+        ReproRec."No." := 2;
+        ReproRec.Insert();
+        Rr.GetTable(ReproRec);
+        Fr := Rr.Field(2);
+
+        Fr.Value(-1);
+        asserterror Fr.Validate();
+        Assert.ExpectedError('Amount must be non-negative');
+    end;
+
+    [Test]
+    procedure FieldRef_Validate_NoArg_ChainedCall_UsesCurrentValue()
+    var
+        ReproRec: Record "FR Validate NoArg";
+        Rr: RecordRef;
+    begin
+        ReproRec.Init();
+        ReproRec."No." := 3;
+        ReproRec.Insert();
+        Rr.GetTable(ReproRec);
+        GetFieldRef(Rr, 2).Value(7.5);
+        GetFieldRef(Rr, 2).Validate();
+        Rr.Modify();
+        Rr.Close();
+
+        ReproRec.Get(3);
+        Assert.AreEqual(7.5, ReproRec.Amount, 'Chained FieldRef.Validate() must keep the current value');
+        Assert.IsTrue(ReproRec.Validated, 'Chained FieldRef.Validate() must invoke OnValidate');
+    end;
+
+
+    local procedure GetFieldRef(var RecRef: RecordRef; FieldNo: Integer): FieldRef
+    var
+        Fr: FieldRef;
+    begin
+        Fr := RecRef.Field(FieldNo);
+        exit(Fr);
+    end;
+}


### PR DESCRIPTION
Closes #1547

- remove MockVariant overloads for MockFieldRef.ALValidate/ALValidateSafe to avoid CS0121
- rewrite NavIndirectValue types to object so MockVariant arguments compile
- add FieldRef.Validate() no-arg tests and update coverage