### PR TITLE
Handle NavIndirectValueToGenericType

### DIFF
--- a/AlRunner/RoslynRewriter.cs
+++ b/AlRunner/RoslynRewriter.cs
@@ -3796,6 +3796,16 @@ public void Unbind() { AlRunner.Runtime.EventSubscriberRegistry.Unbind(this); }
                         memberAccess.Name)); // keep GenericNameSyntax with type args
             }
 
+            // ALCompiler.NavIndirectValueToGenericType<T>(x) -> AlCompat.NavIndirectValueToGenericType<T>(x)
+            if (exprText == "ALCompiler" && methodName == "NavIndirectValueToGenericType")
+            {
+                return visited.WithExpression(
+                    SyntaxFactory.MemberAccessExpression(
+                        SyntaxKind.SimpleMemberAccessExpression,
+                        SyntaxFactory.IdentifierName("AlCompat"),
+                        memberAccess.Name)); // keep GenericNameSyntax with type args
+            }
+
             // ALCompiler.NavIndirectValueToINavRecordHandle(x) -> (MockRecordHandle)x
             if (exprText == "ALCompiler" && methodName == "NavIndirectValueToINavRecordHandle")
             {

--- a/AlRunner/Runtime/AlScope.cs
+++ b/AlRunner/Runtime/AlScope.cs
@@ -1342,6 +1342,17 @@ public static class AlCompat
     }
 
     /// <summary>
+    /// Replacement for ALCompiler.NavIndirectValueToGenericType&lt;T&gt;.
+    /// Extracts a typed value from a variant/indirect value holder.
+    /// </summary>
+    public static T NavIndirectValueToGenericType<T>(object? value)
+    {
+        if (value is MockVariant mv) return NavIndirectValueToGenericType<T>(mv.Value);
+        if (value is null) return default!;
+        return (T)value;
+    }
+
+    /// <summary>
     /// Replacement for ALCompiler.NavIndirectValueToNavValue.
     /// Extracts the NavValue from a variant/indirect value holder.
     /// </summary>

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -10847,6 +10847,14 @@ Variant.IsDictionary ():
   status: covered
   notes: checks NavDictionary open generic via AlCompat.ALIsDictionary
 
+Variant.GetGenericType (Dictionary):
+  layer: runtime-api
+  category: Variant
+  status: covered
+  tests:
+    - tests/bucket-1/codeunit-runtime/339-variant-dictionary-conversion
+  notes: typed Variant→Dictionary assignment rewritten via ALCompiler.NavIndirectValueToGenericType<T> → AlCompat.NavIndirectValueToGenericType<T>
+
 Variant.IsDotNet ():
   layer: runtime-api
   category: Variant

--- a/tests/bucket-1/codeunit-runtime/339-variant-dictionary-conversion/src/VariantDictionarySrc.al
+++ b/tests/bucket-1/codeunit-runtime/339-variant-dictionary-conversion/src/VariantDictionarySrc.al
@@ -1,0 +1,20 @@
+codeunit 1320514 "Variant Dict Src"
+{
+    procedure GetDictFromVariant(reference: Variant): Dictionary of [Text, Integer]
+    var
+        dict: Dictionary of [Text, Integer];
+    begin
+        dict := reference;
+        exit(dict);
+    end;
+
+    procedure GetDictFromVariantChecked(reference: Variant): Dictionary of [Text, Integer]
+    var
+        dict: Dictionary of [Text, Integer];
+    begin
+        if not reference.IsDictionary() then
+            Error('Expected dictionary');
+        dict := reference;
+        exit(dict);
+    end;
+}

--- a/tests/bucket-1/codeunit-runtime/339-variant-dictionary-conversion/test/VariantDictionaryTest.al
+++ b/tests/bucket-1/codeunit-runtime/339-variant-dictionary-conversion/test/VariantDictionaryTest.al
@@ -1,0 +1,36 @@
+codeunit 1320515 "Variant Dict Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Src: Codeunit "Variant Dict Src";
+
+    [Test]
+    procedure Variant_ToDictionary_Roundtrip()
+    var
+        v: Variant;
+        dict: Dictionary of [Text, Integer];
+        result: Dictionary of [Text, Integer];
+        value: Integer;
+    begin
+        dict.Add('A', 42);
+        v := dict;
+
+        result := Src.GetDictFromVariant(v);
+
+        Assert.IsTrue(result.Get('A', value), 'Dictionary should contain key A');
+        Assert.AreEqual(42, value, 'Variant-to-Dictionary conversion should preserve entries');
+    end;
+
+    [Test]
+    procedure Variant_ToDictionary_InvalidType_Throws()
+    var
+        v: Variant;
+    begin
+        v := 'not a dictionary';
+
+        asserterror Src.GetDictFromVariantChecked(v);
+        Assert.ExpectedError('Expected dictionary');
+    end;
+}


### PR DESCRIPTION
## Summary\n- rewrite ALCompiler.NavIndirectValueToGenericType<T> to AlCompat and add generic conversion helper\n- add Variant→Dictionary roundtrip test and negative case\n- update coverage.yaml for Variant.GetGenericType(Dictionary)\n\n## Testing\n- dotnet test AlRunner.Tests/AlRunner.Tests.csproj\n- dotnet run --project AlRunner --framework net10.0 -- --strict --test-isolation method (bucket-1) *(fails locally: AL0791 in 45-unknown-namespace-using, AL0112 in 49-var-attributes, AL0288 in 225-db-event-byref-params)*\n\nCloses #1549