### PR TITLE
fix: add ClearReference() to MockInterfaceHandle

### DIFF
--- a/AlRunner/Runtime/MockInterfaceHandle.cs
+++ b/AlRunner/Runtime/MockInterfaceHandle.cs
@@ -80,6 +80,18 @@ public class MockInterfaceHandle : ITreeObject, IALAssignable<MockInterfaceHandl
     }
 
     /// <summary>
+    /// BC lowers <c>Clear(IfaceVar)</c> to <c>IfaceVar.ClearReference()</c>.
+    /// Delegates to <see cref="Clear"/> to reset the implementation reference,
+    /// matching the pattern in <see cref="MockCodeunitHandle.ClearReference"/>,
+    /// <see cref="MockArray{T}.ClearReference"/>, and
+    /// <see cref="MockTestPageHandle.ClearReference"/>.
+    /// </summary>
+    public void ClearReference()
+    {
+        Clear();
+    }
+
+    /// <summary>
     /// Invoke a method on the interface implementation by member ID.
     /// Similar to MockCodeunitHandle.Invoke but via the interface dispatch pattern.
     /// In BC, InvokeInterfaceMethod dispatches through the codeunit's IsInterfaceMethod table.

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -8023,6 +8023,17 @@ System.Clear (Joker):
     - tests/bucket-1/codeunit-runtime/309-system-missing-overloads
   notes: BC emits v.Value.Clear() for Variant and the default-assignment pattern for other value types. Tested via Clear(Variant) in suite 309.
 
+System.Clear (Interface):
+  layer: runtime-api
+  category: System
+  status: covered
+  tests:
+    - tests/bucket-1/codeunit-runtime/341-interface-clear
+  notes: >
+    BC lowers Clear(IfaceVar) to IfaceVar.ClearReference() on the underlying MockInterfaceHandle.
+    Added ClearReference() to MockInterfaceHandle delegating to Clear() — matching the pattern
+    in MockCodeunitHandle, MockArray<T>, and MockTestPageHandle (issue #1565).
+
 System.Clear (SecretText):
   layer: runtime-api
   category: System

--- a/tests/bucket-1/codeunit-runtime/341-interface-clear/src/ISourceList.al
+++ b/tests/bucket-1/codeunit-runtime/341-interface-clear/src/ISourceList.al
@@ -1,0 +1,31 @@
+interface "IC Source List"
+{
+    procedure GetCount(): Integer;
+    procedure GetName(): Text;
+}
+
+codeunit 1900004 "IC Source List Impl A" implements "IC Source List"
+{
+    procedure GetCount(): Integer
+    begin
+        exit(42);
+    end;
+
+    procedure GetName(): Text
+    begin
+        exit('ImplA');
+    end;
+}
+
+codeunit 1900005 "IC Source List Impl B" implements "IC Source List"
+{
+    procedure GetCount(): Integer
+    begin
+        exit(99);
+    end;
+
+    procedure GetName(): Text
+    begin
+        exit('ImplB');
+    end;
+}

--- a/tests/bucket-1/codeunit-runtime/341-interface-clear/test/InterfaceClearTest.al
+++ b/tests/bucket-1/codeunit-runtime/341-interface-clear/test/InterfaceClearTest.al
@@ -1,0 +1,68 @@
+/// <summary>
+/// Tests that Clear() on an interface variable compiles and runs.
+/// BC lowers Clear(IfaceVar) to IfaceVar.ClearReference() — this requires
+/// MockInterfaceHandle.ClearReference() which was missing (issue #1565).
+/// </summary>
+codeunit 1900006 "IC Interface Clear Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    [Test]
+    procedure ClearInterfaceVar_NoThrow()
+    var
+        SourceList: Interface "IC Source List";
+        ImplA: Codeunit "IC Source List Impl A";
+    begin
+        // [GIVEN] An interface variable assigned to an implementation
+        SourceList := ImplA;
+
+        // [WHEN] Clear() is called on the interface variable — BC emits ClearReference()
+        Clear(SourceList);
+
+        // [THEN] No exception is thrown (Clear is always a no-op / reset to default)
+    end;
+
+    [Test]
+    procedure ClearInterfaceVar_ReassignAfterClear()
+    var
+        SourceList: Interface "IC Source List";
+        ImplA: Codeunit "IC Source List Impl A";
+        ImplB: Codeunit "IC Source List Impl B";
+        Count: Integer;
+    begin
+        // [GIVEN] An interface variable assigned to ImplA, then cleared, then reassigned to ImplB
+        SourceList := ImplA;
+        Clear(SourceList);
+        SourceList := ImplB;
+
+        // [WHEN] A method is called on the reassigned interface variable
+        Count := SourceList.GetCount();
+
+        // [THEN] The result is from ImplB (99), not ImplA (42)
+        Assert.AreEqual(99, Count, 'After Clear and reassign to ImplB, GetCount must return 99');
+    end;
+
+    [Test]
+    procedure ClearInterfaceVar_MultipleClears()
+    var
+        SourceList: Interface "IC Source List";
+        ImplA: Codeunit "IC Source List Impl A";
+        Name: Text;
+    begin
+        // [GIVEN] An interface variable that is assigned, cleared, reassigned, and cleared again
+        SourceList := ImplA;
+        Clear(SourceList);
+        SourceList := ImplA;
+        Clear(SourceList);
+        SourceList := ImplA;
+
+        // [WHEN] A method is called after the final assignment
+        Name := SourceList.GetName();
+
+        // [THEN] The result is from ImplA
+        Assert.AreEqual('ImplA', Name, 'After multiple clears and final assign to ImplA, GetName must return ImplA');
+    end;
+}


### PR DESCRIPTION
Closes #1565

## Summary

- BC lowers `Clear(IfaceVar)` to `IfaceVar.ClearReference()` on the generated `MockInterfaceHandle` type
- `MockInterfaceHandle` had `Clear()` but was missing `ClearReference()`, causing `CS1061` compilation failures for any AL code that calls `Clear()` on an interface variable (e.g. `Clear(PriceSourceList)`)
- Added `ClearReference()` to `MockInterfaceHandle` delegating to `Clear()`, matching the identical pattern already in `MockCodeunitHandle`, `MockArray<T>`, and `MockTestPageHandle`

## Test plan

- [ ] New AL test suite `341-interface-clear` with 3 tests:
  - `ClearInterfaceVar_NoThrow` — confirms `Clear()` on an assigned interface variable doesn't throw
  - `ClearInterfaceVar_ReassignAfterClear` — confirms interface dispatch works correctly after clear + reassign (asserts `GetCount()` returns 99 from ImplB, not 42 from ImplA)
  - `ClearInterfaceVar_MultipleClears` — confirms repeated clear + reassign sequences work
- [ ] All 3 tests pass with `--strict --test-isolation method`
- [ ] Existing interface test suites (03, 31, 32, 53, 68, 287) all continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)