### PR TITLE
fix: case-insensitive SubType = Test gate in test codeunit discovery

### DIFF
--- a/AlRunner/Pipeline.cs
+++ b/AlRunner/Pipeline.cs
@@ -793,7 +793,7 @@ public class AlRunnerPipeline
 
         Executor.RegisterStatements(GetRewrittenStrings());
 
-        bool hasTests = alSources.Any(s => s.Contains("Subtype = Test"));
+        bool hasTests = alSources.Any(s => s.Contains("Subtype = Test", StringComparison.OrdinalIgnoreCase));
         bool explicitRunCodeunit = options.RunCodeunit != null;
         bool isInlineMode = options.InlineCode != null;
 

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -1346,6 +1346,14 @@ navtest_attribute_discovery:
   tests:
     - tests/bucket-1/codeunit-runtime/312700-navtest-attribute-discovery
 
+subtype_casing_discovery:
+  layer: syntax
+  category: attribute
+  status: covered
+  notes: Test codeunit discovery gate at Pipeline.cs:796 uses StringComparison.OrdinalIgnoreCase so camelCase (SubType = Test) and all-lowercase (subtype = test) spellings are both recognized — issue #1520.
+  tests:
+    - tests/bucket-1/codeunit-runtime/312800-subtype-casing-discovery
+
 
 # ══════════════════════════════════════════════════════════════
 # Layer: runtime-api

--- a/tests/bucket-1/codeunit-runtime/312800-subtype-casing-discovery/src/SubtypeCasingSrc.al
+++ b/tests/bucket-1/codeunit-runtime/312800-subtype-casing-discovery/src/SubtypeCasingSrc.al
@@ -1,0 +1,19 @@
+/// <summary>
+/// Suite 312800 (bucket-1/codeunit-runtime): case-insensitive SubType property discovery.
+///
+/// Reproduces issue #1520: the gate check at Pipeline.cs:796 used a case-sensitive
+/// string comparison, which caused codeunits written with the camelCase spelling
+/// (SubType = Test) or all-lowercase spelling (subtype = test) to be silently
+/// skipped. The runner exited 0 with "No test codeunits found" instead of running.
+///
+/// This src codeunit is a plain helper so there is always a compilable src target.
+/// The actual test codeunits (using camelCase and lowercase spellings) live in test/.
+/// </summary>
+
+codeunit 1312800 "SCD Helper"
+{
+    procedure Add(A: Integer; B: Integer): Integer
+    begin
+        exit(A + B);
+    end;
+}

--- a/tests/bucket-1/codeunit-runtime/312800-subtype-casing-discovery/test/SubtypeCasingTest.al
+++ b/tests/bucket-1/codeunit-runtime/312800-subtype-casing-discovery/test/SubtypeCasingTest.al
@@ -1,0 +1,95 @@
+/// <summary>
+/// Suite 312800 (bucket-1/codeunit-runtime): case-insensitive SubType property discovery.
+///
+/// Proves that the runner discovers test codeunits regardless of the casing
+/// used for the property value:
+///   SubType = Test;   (camelCase — Microsoft Learn canonical spelling, issue #1520)
+///   subtype = test;   (all lowercase)
+///
+/// RED before fix: runner prints "No test codeunits found" and exits 0.
+/// GREEN after fix: all four tests below run and pass.
+///
+/// IMPORTANT: Neither this file nor the src file must contain the exact literal
+/// "Subtype" + " = Test" (capital-S, lower-case 't') in a comment, because the
+/// pre-fix gate check is a case-sensitive substring search on the raw file text.
+/// A comment containing that sequence would make the gate pass for the wrong
+/// reason, hiding the RED phase.
+///
+/// The test codeunits assert non-default values (e.g. Add(3,4)=7, not 0) so a
+/// no-op implementation cannot accidentally produce a green run.
+/// </summary>
+
+// -----------------------------------------------------------------
+// Test codeunit using camelCase spelling  (SubType = Test)
+// This is the exact spelling shown in Microsoft Learn docs.
+// -----------------------------------------------------------------
+codeunit 1312801 "SCD CamelCase Tests"
+{
+    SubType = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    [Test]
+    procedure CamelCase_Add_ReturnsCorrectSum()
+    var
+        Helper: Codeunit "SCD Helper";
+    begin
+        // [GIVEN] Two positive integers
+        // [WHEN]  Add is called via the helper
+        // [THEN]  The sum is 7 (non-default, proves the test actually ran)
+        Assert.AreEqual(7, Helper.Add(3, 4), 'CamelCase SubType: Add(3,4) must return 7');
+    end;
+
+    [Test]
+    procedure CamelCase_Add_NegativeCase()
+    var
+        Helper: Codeunit "SCD Helper";
+        Result: Integer;
+    begin
+        // [GIVEN] Two positive integers whose sum is 7
+        Result := Helper.Add(3, 4);
+
+        // [WHEN]  We assert a wrong expected value
+        // [THEN]  Assert raises an error containing the message
+        asserterror Assert.AreEqual(99, Result, 'Sum must not be 99');
+        Assert.ExpectedError('Sum must not be 99');
+    end;
+}
+
+// -----------------------------------------------------------------
+// Test codeunit using all-lowercase spelling  (subtype = test)
+// -----------------------------------------------------------------
+codeunit 1312802 "SCD Lowercase Tests"
+{
+    subtype = test;
+
+    var
+        Assert: Codeunit Assert;
+
+    [Test]
+    procedure Lowercase_Add_ReturnsCorrectSum()
+    var
+        Helper: Codeunit "SCD Helper";
+    begin
+        // [GIVEN] Two positive integers
+        // [WHEN]  Add is called via the helper
+        // [THEN]  The sum is 10 (non-default, proves the test actually ran)
+        Assert.AreEqual(10, Helper.Add(6, 4), 'Lowercase subtype: Add(6,4) must return 10');
+    end;
+
+    [Test]
+    procedure Lowercase_Add_NegativeCase()
+    var
+        Helper: Codeunit "SCD Helper";
+        Result: Integer;
+    begin
+        // [GIVEN] Two positive integers whose sum is 10
+        Result := Helper.Add(6, 4);
+
+        // [WHEN]  We assert a wrong expected value
+        // [THEN]  Assert raises an error containing the message
+        asserterror Assert.AreEqual(0, Result, 'Sum must not be 0');
+        Assert.ExpectedError('Sum must not be 0');
+    end;
+}


### PR DESCRIPTION
Closes #1520

## Summary

- `Pipeline.cs:796` used a case-sensitive `Contains("Subtype = Test")` as the gate that determines whether any test codeunits exist. Codeunits written with `SubType = Test` (camelCase — the spelling shown in Microsoft Learn) or `subtype = test` (all lowercase) did not match, causing the runner to print "No test codeunits found" and exit 0 without running any tests.
- Fix: added `StringComparison.OrdinalIgnoreCase` to the gate check, matching the convention already used 269 lines later at `Pipeline.cs:1065–1066`.
- Added test suite `312800-subtype-casing-discovery` with two test codeunits — one using `SubType = Test` and one using `subtype = test` — each asserting non-default computed values (7 and 10) to prove the tests actually ran.

## Test plan

- [x] RED confirmed before fix: `dotnet run ... -- tests/.../312800-subtype-casing-discovery/src tests/.../312800-subtype-casing-discovery/test` printed "No test codeunits found (Subtype = Test). Source compiled successfully." and exited 0.
- [x] GREEN confirmed after fix: 4 tests pass across both camelCase and lowercase codeunits.
- [x] Existing `312700-navtest-attribute-discovery` suite: 4 passed (unchanged).
- [x] Full bucket-1 matrix: 1960 passed.
- [x] Full bucket-2 matrix: 2276 passed.
- [x] `docs/coverage.yaml` updated with `subtype_casing_discovery` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)