### PR TITLE
feat: extract-deps --packages <dir> auto-discovers .app dep sources

### DIFF
--- a/AlRunner.Tests/DepExtractorTests.cs
+++ b/AlRunner.Tests/DepExtractorTests.cs
@@ -1971,4 +1971,254 @@ public class DepExtractorTests
         }
     }
 
+    // -----------------------------------------------------------------------
+    // --packages <dir> as dep source for --extract-deps (issue #1522)
+    // -----------------------------------------------------------------------
+
+    /// <summary>
+    /// Helper: create a synthetic NAVX .app file whose ZIP contains SymbolReference.json
+    /// AND src/&lt;name&gt;.al so it can be used both as a symbol package and as a dep source.
+    /// </summary>
+    private static byte[] MakeSyntheticApp(string appId, string appName, string publisher, string version,
+        IReadOnlyList<(string Name, string Source)> alFiles,
+        string? symRefJson = null)
+    {
+        using var ms = new System.IO.MemoryStream();
+        using (var zip = new System.IO.Compression.ZipArchive(ms, System.IO.Compression.ZipArchiveMode.Create, leaveOpen: true))
+        {
+            // SymbolReference.json (required for CollectPackageDeclaredObjects)
+            var symRef = symRefJson ?? $$$"""
+                {
+                  "Id": "{{{appId}}}",
+                  "Name": "{{{appName}}}",
+                  "Publisher": "{{{publisher}}}",
+                  "Version": "{{{version}}}"
+                }
+                """;
+            var symRefEntry = zip.CreateEntry("SymbolReference.json");
+            using (var es = symRefEntry.Open())
+            {
+                var bytes = System.Text.Encoding.UTF8.GetBytes(symRef);
+                es.Write(bytes, 0, bytes.Length);
+            }
+
+            // src/<name>.al entries (read by AppPackageReader.ExtractAlSources)
+            foreach (var (name, source) in alFiles)
+            {
+                var srcEntry = zip.CreateEntry($"src/{name}");
+                using var ses = srcEntry.Open();
+                var bytes = System.Text.Encoding.UTF8.GetBytes(source);
+                ses.Write(bytes, 0, bytes.Length);
+            }
+        }
+
+        var zipBytes = ms.ToArray();
+        var appBytes = new byte[8 + zipBytes.Length];
+        appBytes[0] = (byte)'N'; appBytes[1] = (byte)'A'; appBytes[2] = (byte)'V'; appBytes[3] = (byte)'X';
+        System.BitConverter.GetBytes((uint)8).CopyTo(appBytes, 4);
+        zipBytes.CopyTo(appBytes, 8);
+        return appBytes;
+    }
+
+    /// <summary>
+    /// ExtractDeps must accept a packages directory as a dep source — objects from .app files
+    /// in that directory should be indexed for BFS extraction. This proves the underlying
+    /// machinery works: passing the .app file path (discovered from the --packages dir by the
+    /// CLI) to depSources extracts the object correctly.
+    /// </summary>
+    [Fact]
+    public void ExtractDeps_AppFileFromPackagesDir_IsIndexedAsDepSource()
+    {
+        var pkgDir = Path.Combine(Path.GetTempPath(), "al-pkg-src-" + Guid.NewGuid().ToString("N")[..8]);
+        var outDir = Path.Combine(Path.GetTempPath(), "al-out-src-" + Guid.NewGuid().ToString("N")[..8]);
+        var extDir = Path.Combine(Path.GetTempPath(), "al-ext-src-" + Guid.NewGuid().ToString("N")[..8]);
+        try
+        {
+            Directory.CreateDirectory(pkgDir);
+            Directory.CreateDirectory(extDir);
+
+            // Create a synthetic .app with a Customer table inside src/
+            var appBytes = MakeSyntheticApp(
+                "12345678-1234-1234-1234-123456789012",
+                "MyDepApp",
+                "TestPublisher",
+                "1.0.0.0",
+                new[]
+                {
+                    ("Customer.al", "table 18 Customer { fields { field(1; \"No.\"; Code[20]) { } } }")
+                });
+            var appPath = Path.Combine(pkgDir, "TestPublisher_MyDepApp_1.0.0.0.app");
+            File.WriteAllBytes(appPath, appBytes);
+
+            // Extension references Customer
+            File.WriteAllText(Path.Combine(extDir, "MyExt.al"), """
+                codeunit 50010 "My Codeunit"
+                {
+                    procedure Run()
+                    var Cust: Record Customer;
+                    begin Cust.FindFirst(); end;
+                }
+                """);
+
+            // Simulate what the fixed CLI does: expand pkg dir to .app files, pass as depSources
+            var appFilesFromPkgDir = Directory.GetFiles(pkgDir, "*.app", SearchOption.TopDirectoryOnly);
+            int rc = DepExtractor.ExtractDeps(extDir, appFilesFromPkgDir, outDir);
+
+            Assert.Equal(0, rc);
+
+            // Positive: Customer table was extracted from the .app
+            var files = Directory.GetFiles(outDir, "*.al", SearchOption.AllDirectories);
+            Assert.Contains(files, f => File.ReadAllText(f).Contains("table 18 Customer"));
+
+            // Negative: no "Customer" stub generated (it was found in the .app)
+            var stubs = files.Where(f => f.Contains("__GeneratedStubs__", StringComparison.OrdinalIgnoreCase)
+                                      && Path.GetFileName(f).StartsWith("Customer", StringComparison.OrdinalIgnoreCase)).ToList();
+            Assert.Empty(stubs);
+        }
+        finally
+        {
+            foreach (var d in new[] { pkgDir, outDir, extDir })
+                if (Directory.Exists(d)) Directory.Delete(d, true);
+        }
+    }
+
+    /// <summary>
+    /// The CLI must accept --extract-deps ./src ./out --packages &lt;dir&gt; without any explicit
+    /// .app paths. The .app files in the packages dir should be auto-discovered and used as
+    /// dep sources. This test fails before the Program.cs fix (currently returns exit code 1
+    /// with "requires at least one &lt;app&gt; path").
+    /// </summary>
+    [Fact]
+    public async Task ExtractDeps_Cli_PackagesDirWithNoExplicitApps_Succeeds()
+    {
+        var pkgDir = Path.Combine(Path.GetTempPath(), "al-cli-pkg-" + Guid.NewGuid().ToString("N")[..8]);
+        var outDir = Path.Combine(Path.GetTempPath(), "al-cli-out-" + Guid.NewGuid().ToString("N")[..8]);
+        var extDir = Path.Combine(Path.GetTempPath(), "al-cli-ext-" + Guid.NewGuid().ToString("N")[..8]);
+        try
+        {
+            Directory.CreateDirectory(pkgDir);
+            Directory.CreateDirectory(extDir);
+
+            // Create a synthetic .app with a Customer table inside src/
+            var appBytes = MakeSyntheticApp(
+                "aaaabbbb-cccc-dddd-eeee-ffffffffffff",
+                "CliPkgTest",
+                "Test",
+                "1.0.0.0",
+                new[]
+                {
+                    ("Customer.al", "table 18 Customer { fields { field(1; \"No.\"; Code[20]) { } } }")
+                });
+            File.WriteAllBytes(Path.Combine(pkgDir, "Test_CliPkgTest_1.0.0.0.app"), appBytes);
+
+            // Extension references Customer
+            File.WriteAllText(Path.Combine(extDir, "MyExt.al"), """
+                codeunit 50010 "My Codeunit"
+                {
+                    procedure Run()
+                    var Cust: Record Customer;
+                    begin Cust.FindFirst(); end;
+                }
+                """);
+
+            // This should succeed after the fix; currently fails with exit code 1
+            var result = await CliRunner.RunAsync(
+                $"--extract-deps \"{extDir}\" \"{outDir}\" --packages \"{pkgDir}\"",
+                timeoutMs: 60_000);
+
+            // Positive: CLI exits successfully
+            Assert.Equal(0, result.ExitCode);
+
+            // Positive: Customer table was extracted
+            var files = Directory.GetFiles(outDir, "*.al", SearchOption.AllDirectories);
+            Assert.Contains(files, f => File.ReadAllText(f).Contains("table 18 Customer"));
+        }
+        finally
+        {
+            foreach (var d in new[] { pkgDir, outDir, extDir })
+                if (Directory.Exists(d)) Directory.Delete(d, true);
+        }
+    }
+
+    /// <summary>
+    /// Composability: explicit .app paths AND --packages &lt;dir&gt; must both work together.
+    /// Objects from both sources should be indexed and extractable.
+    /// </summary>
+    [Fact]
+    public async Task ExtractDeps_Cli_PackagesDirPlusExplicitApp_BothIndexed()
+    {
+        var pkgDir  = Path.Combine(Path.GetTempPath(), "al-cli-pkg2-" + Guid.NewGuid().ToString("N")[..8]);
+        var appDir  = Path.Combine(Path.GetTempPath(), "al-cli-app2-" + Guid.NewGuid().ToString("N")[..8]);
+        var outDir  = Path.Combine(Path.GetTempPath(), "al-cli-out2-" + Guid.NewGuid().ToString("N")[..8]);
+        var extDir  = Path.Combine(Path.GetTempPath(), "al-cli-ext2-" + Guid.NewGuid().ToString("N")[..8]);
+        try
+        {
+            Directory.CreateDirectory(pkgDir);
+            Directory.CreateDirectory(appDir);
+            Directory.CreateDirectory(extDir);
+
+            // Packages dir contains a Customer table
+            var pkgAppBytes = MakeSyntheticApp(
+                "11112222-3333-4444-5555-666677778888",
+                "PkgDirApp",
+                "Test",
+                "1.0.0.0",
+                new[]
+                {
+                    ("Customer.al", "table 18 Customer { fields { field(1; \"No.\"; Code[20]) { } } }")
+                });
+            File.WriteAllBytes(Path.Combine(pkgDir, "Test_PkgDirApp_1.0.0.0.app"), pkgAppBytes);
+
+            // Explicit .app contains a Sales Header table
+            var explicitAppBytes = MakeSyntheticApp(
+                "aaaabbbb-cccc-dddd-eeee-111122223333",
+                "ExplicitApp",
+                "Test",
+                "1.0.0.0",
+                new[]
+                {
+                    ("SalesHeader.al", "table 36 \"Sales Header\" { fields { field(1; \"No.\"; Code[20]) { } } }")
+                });
+            var explicitAppPath = Path.Combine(appDir, "Test_ExplicitApp_1.0.0.0.app");
+            File.WriteAllBytes(explicitAppPath, explicitAppBytes);
+
+            // Extension references both Customer and Sales Header
+            File.WriteAllText(Path.Combine(extDir, "MyExt.al"), """
+                codeunit 50011 "My Composite Codeunit"
+                {
+                    procedure Run()
+                    var
+                        Cust: Record Customer;
+                        SH: Record "Sales Header";
+                    begin
+                        Cust.FindFirst();
+                        SH.FindFirst();
+                    end;
+                }
+                """);
+
+            // CLI with both --packages <dir> and an explicit .app path
+            var result = await CliRunner.RunAsync(
+                $"--extract-deps \"{extDir}\" \"{outDir}\" --packages \"{pkgDir}\" \"{explicitAppPath}\"",
+                timeoutMs: 60_000);
+
+            // Positive: CLI exits successfully
+            Assert.Equal(0, result.ExitCode);
+
+            var files = Directory.GetFiles(outDir, "*.al", SearchOption.AllDirectories);
+
+            // Positive: Customer (from packages dir) was extracted
+            Assert.Contains(files, f => File.ReadAllText(f).Contains("table 18 Customer"));
+
+            // Positive: Sales Header (from explicit .app) was extracted
+            Assert.Contains(files, f => File.ReadAllText(f).Contains("table 36") &&
+                                        File.ReadAllText(f).Contains("Sales Header"));
+        }
+        finally
+        {
+            foreach (var d in new[] { pkgDir, appDir, outDir, extDir })
+                if (Directory.Exists(d)) Directory.Delete(d, true);
+        }
+    }
+
 }

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -35,10 +35,12 @@ if (args.Length == 0 || args.Any(a => a is "-h" or "--help"))
     Console.Error.WriteLine("  --dep-dlls <dir>      Load pre-compiled dependency DLLs for runtime execution");
     Console.Error.WriteLine("  --compile-dep <app> <out-dir> [--packages <dir>]");
     Console.Error.WriteLine("                        Compile a .app dependency to a rewritten DLL on disk");
-    Console.Error.WriteLine("  --extract-deps <src-dir> <out-dir> <app1> [<app2> ...]");
+    Console.Error.WriteLine("  --extract-deps <src-dir> <out-dir> [<app1> ...] [--packages <dir>]");
     Console.Error.WriteLine("                        Extract the minimal reachable dependency slice from .app");
     Console.Error.WriteLine("                        artifacts for the extension source in <src-dir> and write");
-    Console.Error.WriteLine("                        extracted AL files to <out-dir>");
+    Console.Error.WriteLine("                        extracted AL files to <out-dir>.");
+    Console.Error.WriteLine("                        --packages <dir> auto-discovers all *.app files in <dir>");
+    Console.Error.WriteLine("                        and uses them as dep sources (composable with explicit paths).");
     Console.Error.WriteLine("  --stubs <dir>         Override dependency objects with stub AL files");
     Console.Error.WriteLine("  --init-events         Fire BC lifecycle integration events once at runner startup");
     Console.Error.WriteLine("                        (OnCompanyInitialize from CU 2/27, OnInstallAppPerCompany from CU 2)");
@@ -304,10 +306,10 @@ while (argIdx < args.Length)
         case "--extract-deps":
         {
             argIdx++;
-            if (argIdx >= args.Length) { Console.Error.WriteLine("Error: --extract-deps requires <src-dir> <out-dir> <app1> [<app2> ...]"); return 1; }
+            if (argIdx >= args.Length) { Console.Error.WriteLine("Error: --extract-deps requires <src-dir> <out-dir> [<app1> ...] [--packages <dir>]"); return 1; }
             var edSrcDir = Path.GetFullPath(args[argIdx]);
             argIdx++;
-            if (argIdx >= args.Length) { Console.Error.WriteLine("Error: --extract-deps requires <src-dir> <out-dir> <app1> [<app2> ...]"); return 1; }
+            if (argIdx >= args.Length) { Console.Error.WriteLine("Error: --extract-deps requires <src-dir> <out-dir> [<app1> ...] [--packages <dir>]"); return 1; }
             var edOutDir = Path.GetFullPath(args[argIdx]);
             argIdx++;
             var edApps = new List<string>();
@@ -330,9 +332,25 @@ while (argIdx < args.Length)
                     argIdx++;
                 }
             }
+            // Expand --packages dirs: discover all *.app files in each packages directory
+            // and add them to edApps so they are indexed as dep sources (BFS extraction).
+            // This allows "al-runner --extract-deps ./src ./out --packages .alpackages" without
+            // listing individual .app file paths. Explicit .app paths and --packages dirs are
+            // composable; edApps may already contain explicit paths from positional args.
+            foreach (var pkgDir in edPkgPaths)
+            {
+                if (Directory.Exists(pkgDir))
+                {
+                    foreach (var appFile in Directory.GetFiles(pkgDir, "*.app", SearchOption.TopDirectoryOnly))
+                    {
+                        if (!edApps.Contains(appFile, StringComparer.OrdinalIgnoreCase))
+                            edApps.Add(appFile);
+                    }
+                }
+            }
             if (edApps.Count == 0)
             {
-                Console.Error.WriteLine("Error: --extract-deps requires at least one <app> path");
+                Console.Error.WriteLine("Error: --extract-deps requires at least one <app> path or --packages <dir> containing .app files");
                 return 1;
             }
             return AlRunner.DepExtractor.ExtractDeps(edSrcDir, edApps, edOutDir, edPkgPaths.Count > 0 ? edPkgPaths : null);

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -13576,3 +13576,23 @@ DepCompiler.ComputeDirectoryHash:
     Internal helper: stable SHA-256 over all files in a directory (sorted by
     relative path, filename included in hash input). Deterministic and change-sensitive.
     Test: ComputeAppHash_IsDeterministicAndChangeSensitive. Fixed in #1517.
+
+# ── extract-deps: --packages dir auto-discovery ──────────────────
+
+DepExtractor.PackagesDirAutoDiscovery:
+  layer: syntax
+  category: extract-deps
+  status: covered
+  tests:
+    - AlRunner.Tests/DepExtractorTests.cs
+  notes: >
+    --extract-deps accepts --packages <dir> to auto-discover all *.app files in a
+    directory and use them as dep sources (BFS indexing), in addition to their role
+    as symbol-resolution packages. This allows "al-runner --extract-deps ./src ./out
+    --packages .alpackages" without listing individual .app file paths. Multiple
+    --packages dirs and explicit .app paths are composable. Implemented by expanding
+    --packages dirs into .app file paths in the --extract-deps CLI case before calling
+    DepExtractor.ExtractDeps. Fixed in #1522.
+    Tests: ExtractDeps_AppFileFromPackagesDir_IsIndexedAsDepSource,
+    ExtractDeps_Cli_PackagesDirWithNoExplicitApps_Succeeds,
+    ExtractDeps_Cli_PackagesDirPlusExplicitApp_BothIndexed.


### PR DESCRIPTION
Closes #1522

## Summary

- `--extract-deps` now accepts `--packages <dir>` to auto-discover all `*.app` files in a directory and use them as dep sources (indexed for BFS extraction), in addition to their existing role as symbol-resolution packages.
- Explicit `.app` paths and `--packages <dir>` are composable: both can be used together.
- The "requires at least one <app> path" error is updated to also accept `--packages <dir>` with `.app` files.
- Help text updated to reflect the new optional usage pattern.
- `docs/coverage.yaml` updated with `DepExtractor.PackagesDirAutoDiscovery` entry.

## New usage

```sh
# Auto-discover all .app files from a packages directory
al-runner --extract-deps ./src ./out --packages .alpackages

# Composable with explicit .app paths
al-runner --extract-deps ./src ./out --packages .alpackages /path/to/MyCustomApp.app
```

## Implementation

In `Program.cs` `--extract-deps` argument parsing: after collecting `--packages` directory paths (`edPkgPaths`), each directory is expanded to its `*.app` files and those paths are added to `edApps` (dep sources). This feeds `LoadDepSources` → index build → BFS extraction. `DepExtractor.ExtractDeps` API is unchanged.

## Test plan

- `ExtractDeps_AppFileFromPackagesDir_IsIndexedAsDepSource`: proves the underlying machinery works — `.app` files passed via dep sources are indexed and objects are extracted correctly.
- `ExtractDeps_Cli_PackagesDirWithNoExplicitApps_Succeeds`: proves the CLI-level fix — `--extract-deps ./src ./out --packages <dir>` succeeds without explicit `.app` paths (was: exit code 1 "requires at least one <app> path").
- `ExtractDeps_Cli_PackagesDirPlusExplicitApp_BothIndexed`: proves composability — objects from both `--packages` dir and explicit `.app` paths are extracted.

All 57 `DepExtractorTests` pass. Pre-existing failures (6 tests requiring `alc` binary with execute permissions) are unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)