### PR TITLE
feat(extract-deps): strip DotNet-interop procedures and skip pure assembly files

### DIFF
--- a/AlRunner.Tests/DepExtractorTests.cs
+++ b/AlRunner.Tests/DepExtractorTests.cs
@@ -2221,4 +2221,286 @@ public class DepExtractorTests
         }
     }
 
+    // -----------------------------------------------------------------------
+    // StripDotNetProcedures — unit tests (issue #1524)
+    // -----------------------------------------------------------------------
+
+    /// <summary>
+    /// A codeunit with no DotNet references is returned unchanged, with 0 stripped.
+    /// </summary>
+    [Fact]
+    public void StripDotNet_NoDotNetContent_ReturnsUnchanged()
+    {
+        const string source = """
+            codeunit 99900 "MyCodeunit"
+            {
+                procedure Run()
+                begin
+                    Message('Hello');
+                end;
+            }
+            """;
+
+        var (result, stripped) = DepExtractor.StripDotNetProcedures(source, "test.al");
+
+        // Positive: result is the original source unchanged
+        Assert.Equal(source, result);
+        // Positive: nothing was stripped
+        Assert.Equal(0, stripped);
+    }
+
+    /// <summary>
+    /// A procedure that uses a DotNet-typed local variable has its body replaced with Error().
+    /// The Error message must contain the procedure name and mention DotNet interop.
+    /// </summary>
+    [Fact]
+    public void StripDotNet_ProcedureWithDotNetLocalVar_BodyReplacedWithError()
+    {
+        const string source = """
+            codeunit 99901 "DotNetUser"
+            {
+                procedure BuildXml(): Text
+                var
+                    XmlDoc: DotNet XmlDocument;
+                begin
+                    XmlDoc := XmlDoc.XmlDocument();
+                    exit(XmlDoc.OuterXml);
+                end;
+            }
+            """;
+
+        var (result, stripped) = DepExtractor.StripDotNetProcedures(source, "test.al");
+
+        Assert.NotNull(result);
+        // Positive: at least 1 replacement was made
+        Assert.True(stripped > 0, $"Expected stripped > 0, got {stripped}");
+        // Positive: the result contains Error() with the procedure name
+        Assert.Contains("Error(", result, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("BuildXml", result, StringComparison.OrdinalIgnoreCase);
+        // Positive: DotNet interop is mentioned in the error message
+        Assert.Contains("DotNet interop", result, StringComparison.OrdinalIgnoreCase);
+        // Negative: the original DotNet body code is NOT in the result
+        Assert.DoesNotContain("XmlDoc.XmlDocument()", result, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// A procedure that returns a DotNet type gets its return type replaced with Text.
+    /// </summary>
+    [Fact]
+    public void StripDotNet_ProcedureWithDotNetReturnType_ReturnTypeReplacedWithText()
+    {
+        const string source = """
+            codeunit 99902 "DotNetReturn"
+            {
+                procedure GetNode(): DotNet XmlNode
+                begin
+                end;
+            }
+            """;
+
+        var (result, stripped) = DepExtractor.StripDotNetProcedures(source, "test.al");
+
+        Assert.NotNull(result);
+        Assert.True(stripped > 0, $"Expected stripped > 0, got {stripped}");
+        // Positive: DotNet return type was replaced with Text
+        Assert.Contains(": Text", result, StringComparison.Ordinal);
+        // Negative: the DotNet return type is gone
+        Assert.DoesNotContain("DotNet XmlNode", result, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// A procedure that has a DotNet-typed parameter gets it replaced with Variant.
+    /// </summary>
+    [Fact]
+    public void StripDotNet_ProcedureWithDotNetParameter_ParamReplacedWithVariant()
+    {
+        const string source = """
+            codeunit 99903 "DotNetParam"
+            {
+                procedure Process(Node: DotNet XmlNode)
+                begin
+                end;
+            }
+            """;
+
+        var (result, stripped) = DepExtractor.StripDotNetProcedures(source, "test.al");
+
+        Assert.NotNull(result);
+        Assert.True(stripped > 0, $"Expected stripped > 0, got {stripped}");
+        // Positive: DotNet parameter type was replaced with Variant
+        Assert.Contains("Variant", result, StringComparison.Ordinal);
+        // Negative: the DotNet parameter type is gone
+        Assert.DoesNotContain("DotNet XmlNode", result, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// A codeunit-level global DotNet variable declaration is removed entirely.
+    /// Procedures that reference it via their body get their body replaced with Error().
+    /// </summary>
+    [Fact]
+    public void StripDotNet_GlobalDotNetVar_IsRemoved()
+    {
+        const string source = """
+            codeunit 99904 "GlobalDotNetVar"
+            {
+                var
+                    XmlDoc: DotNet XmlDocument;
+
+                procedure ReadXml(Path: Text): Text
+                begin
+                    exit(XmlDoc.OuterXml);
+                end;
+
+                procedure SetPath(Path: Text)
+                begin
+                    Message(Path);
+                end;
+            }
+            """;
+
+        var (result, stripped) = DepExtractor.StripDotNetProcedures(source, "test.al");
+
+        Assert.NotNull(result);
+        Assert.True(stripped > 0, $"Expected stripped > 0, got {stripped}");
+        // Positive: the global DotNet var declaration is removed
+        Assert.DoesNotContain("XmlDoc: DotNet", result, StringComparison.OrdinalIgnoreCase);
+        // Positive: the procedure that uses the DotNet var gets Error()
+        Assert.Contains("Error(", result, StringComparison.OrdinalIgnoreCase);
+        // Positive: the pure AL procedure (no DotNet) is preserved
+        Assert.Contains("Message(Path)", result, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// A pure dotnet assembly declaration file (no BC objects, only dotnet type mappings)
+    /// is detected and returns null — the file should be skipped entirely.
+    /// </summary>
+    [Fact]
+    public void StripDotNet_PureAssemblyDeclaration_ReturnsNull()
+    {
+        // A typical BC AL dotnet package declaration file — no codeunit/table/page objects
+        const string source = """
+            dotnet
+            {
+                assembly("mscorlib")
+                {
+                    Culture = 'neutral';
+                    PublicKeyToken = 'b77a5c561934e089';
+                    Version = '4.0.0.0';
+
+                    type("System.String"; "DotNet_String") { }
+                    type("System.Text.StringBuilder"; "DotNet_StringBuilder") { }
+                }
+            }
+            """;
+
+        var (result, stripped) = DepExtractor.StripDotNetProcedures(source, "DotNetDeclarations.al");
+
+        // Positive: null means "skip this file" — pure assembly files have no callable AL interface
+        Assert.Null(result);
+        // Positive: nothing was "stripped" (the whole file is skipped, not procedure-by-procedure)
+        Assert.Equal(0, stripped);
+    }
+
+    /// <summary>
+    /// The Error() message injected into a stripped procedure contains the exact procedure name.
+    /// This verifies the "fails loudly and names the procedure" acceptance criterion.
+    /// </summary>
+    [Fact]
+    public void StripDotNet_ErrorMessageContainsProcedureName()
+    {
+        const string source = """
+            codeunit 99905 "NamedProcCodeunit"
+            {
+                procedure ConvertToXmlDocument(Input: Text): DotNet XmlDocument
+                var
+                    Doc: DotNet XmlDocument;
+                begin
+                    exit(Doc);
+                end;
+            }
+            """;
+
+        var (result, _) = DepExtractor.StripDotNetProcedures(source, "test.al");
+
+        Assert.NotNull(result);
+        // Positive: the exact procedure name appears in the Error() call body
+        Assert.Contains("ConvertToXmlDocument", result, StringComparison.Ordinal);
+        // Positive: the error message uses AL single-quote string format
+        Assert.Contains("'AL Runner:", result, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// End-to-end: ExtractDeps writes DotNet-stripped AL files to the output directory.
+    /// Procedures with DotNet references have their bodies replaced with Error();
+    /// pure AL procedures in the same codeunit are preserved.
+    /// </summary>
+    [Fact]
+    public void ExtractDeps_DotNetProceduresStripped_InOutputDirectory()
+    {
+        var depRoot = Path.Combine(Path.GetTempPath(), "al-dotnet-dep-" + Guid.NewGuid().ToString("N")[..8]);
+        var outDir  = Path.Combine(Path.GetTempPath(), "al-dotnet-out-" + Guid.NewGuid().ToString("N")[..8]);
+        var extDir  = Path.Combine(Path.GetTempPath(), "al-dotnet-ext-" + Guid.NewGuid().ToString("N")[..8]);
+        try
+        {
+            Directory.CreateDirectory(Path.Combine(depRoot, "AppA"));
+            Directory.CreateDirectory(extDir);
+
+            // Dep: a codeunit with one DotNet procedure and one normal procedure
+            File.WriteAllText(Path.Combine(depRoot, "AppA", "XmlHelper.al"), """
+                codeunit 60200 XmlHelper
+                {
+                    procedure ParseXml(Input: Text): DotNet XmlDocument
+                    var
+                        Doc: DotNet XmlDocument;
+                    begin
+                        exit(Doc);
+                    end;
+
+                    procedure GetVersion(): Text
+                    begin
+                        exit('1.0');
+                    end;
+                }
+                """);
+
+            // Extension references XmlHelper
+            File.WriteAllText(Path.Combine(extDir, "Consumer.al"), """
+                codeunit 60299 Consumer
+                {
+                    procedure Run()
+                    var
+                        Helper: Codeunit XmlHelper;
+                    begin
+                        Message(Helper.GetVersion());
+                    end;
+                }
+                """);
+
+            int rc = DepExtractor.ExtractDeps(extDir, new[] { depRoot }, outDir);
+            Assert.Equal(0, rc);
+
+            // Find the extracted XmlHelper file
+            var extractedFiles = Directory.GetFiles(outDir, "*.al", SearchOption.AllDirectories);
+            var xmlHelperFile = extractedFiles.FirstOrDefault(f =>
+                File.ReadAllText(f).Contains("XmlHelper", StringComparison.OrdinalIgnoreCase)
+                && !f.Contains("__GeneratedStubs__"));
+            Assert.NotNull(xmlHelperFile);
+
+            var content = File.ReadAllText(xmlHelperFile!);
+            // Positive: the DotNet procedure body was replaced with Error()
+            Assert.Contains("Error(", content, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("ParseXml", content, StringComparison.OrdinalIgnoreCase);
+            // Positive: the normal procedure is preserved unchanged
+            Assert.Contains("GetVersion", content, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("'1.0'", content, StringComparison.OrdinalIgnoreCase);
+            // Negative: the original DotNet body is gone
+            Assert.DoesNotContain("exit(Doc)", content, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            foreach (var d in new[] { depRoot, outDir, extDir })
+                if (Directory.Exists(d)) Directory.Delete(d, true);
+        }
+    }
+
 }

--- a/AlRunner/DepExtractor.cs
+++ b/AlRunner/DepExtractor.cs
@@ -1875,7 +1875,7 @@ public static class DepExtractor
         typeName.Equals("DotNet", StringComparison.OrdinalIgnoreCase)
         || typeName.Equals("ControlAddIn", StringComparison.OrdinalIgnoreCase);
 
-    private static (string? Source, int Stripped) StripDotNetProcedures(string source, string fileName)
+    internal static (string? Source, int Stripped) StripDotNetProcedures(string source, string fileName)
     {
         // Fast path: neither keyword anywhere, nothing to do.
         if (!source.Contains("DotNet", StringComparison.OrdinalIgnoreCase)
@@ -1886,6 +1886,23 @@ public static class DepExtractor
         {
             var tree = SyntaxTree.ParseObjectText(source);
             var root = tree.GetRoot();
+
+            // Pure assembly declaration check: if the file contains DotNet/ControlAddIn
+            // content but has NO callable BC objects (codeunit/table/page/etc.), it is
+            // a pure dotnet assembly declaration file (only declares .NET type mappings).
+            // Such files have no callable AL interface and must be skipped entirely.
+            // Return null so the caller (ExtractDeps) omits the file from the output.
+            //
+            // A pure dotnet block file parses as a CompilationUnitSyntax where every top-level
+            // object is a DotNetPackageSyntax (kind == DotNetPackage). These are NOT callable
+            // BC objects — they only declare .NET type aliases for use in AL code.
+            if (root is CompilationUnitSyntax compUnit && compUnit.Objects.Count > 0
+                && compUnit.Objects.All(o => o.Kind == SyntaxKind.DotNetPackage))
+            {
+                if (!string.IsNullOrEmpty(fileName))
+                    Console.Error.WriteLine($"  Skipping pure assembly declaration file: {fileName}");
+                return (null, 0);
+            }
 
             // Collect (start, end, replacement) for each DotNet-referencing procedure.
             var replacements = new List<(int Start, int End, string Text)>();

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -49,7 +49,19 @@ dotnet_declaration:
   layer: syntax
   category: object
   status: out-of-scope
-  notes: .NET interop — requires BC runtime; see 'No DotNet interop' in docs/limitations.md
+  notes: >
+    .NET interop — requires BC runtime; see 'No DotNet interop' in docs/limitations.md.
+    extract-deps automatically strips DotNet-referencing procedure bodies (replaced with Error()
+    calls) and skips pure dotnet-assembly declaration files so the extracted slice compiles
+    cleanly. Test coverage in AlRunner.Tests.DepExtractorTests:
+    StripDotNet_NoDotNetContent_ReturnsUnchanged,
+    StripDotNet_ProcedureWithDotNetLocalVar_BodyReplacedWithError,
+    StripDotNet_ProcedureWithDotNetReturnType_ReturnTypeReplacedWithText,
+    StripDotNet_ProcedureWithDotNetParameter_ParamReplacedWithVariant,
+    StripDotNet_GlobalDotNetVar_IsRemoved,
+    StripDotNet_PureAssemblyDeclaration_ReturnsNull,
+    StripDotNet_ErrorMessageContainsProcedureName,
+    ExtractDeps_DotNetProceduresStripped_InOutputDirectory. Closes #1524.
 
 entitlement_declaration:
   layer: syntax


### PR DESCRIPTION
Closes #1524

## Summary

- `StripDotNetProcedures` made `internal` so unit tests can exercise it directly
- Pure `dotnet { assembly(...) { } }` declaration files are now detected (they parse as `CompilationUnitSyntax` with only `DotNetPackage` objects) and returned as `null` — the caller skips writing them since they have no callable AL interface
- 8 new unit tests in `DepExtractorTests` covering all branches: no-op fast path, procedure body → `Error()`, return type → `Text`, parameter → `Variant`, global var removal, pure assembly null-return, procedure name in error message, and end-to-end via `ExtractDeps`
- `docs/coverage.yaml` `dotnet_declaration` entry updated with test references

## Acceptance criteria met

- Extracted output compiles cleanly for projects whose only compile errors are DotNet-related: DotNet procedure bodies are replaced with `Error()` calls, pure assembly files are skipped
- Calling a stripped procedure produces a clear error naming the procedure and citing DotNet interop
- A summary line on stderr reports how many procedures were stripped
- The stripping is automatic — no flag needed

## Test plan

- [x] `StripDotNet_NoDotNetContent_ReturnsUnchanged` — fast path, no changes
- [x] `StripDotNet_ProcedureWithDotNetLocalVar_BodyReplacedWithError` — body → Error()
- [x] `StripDotNet_ProcedureWithDotNetReturnType_ReturnTypeReplacedWithText` — return type → Text
- [x] `StripDotNet_ProcedureWithDotNetParameter_ParamReplacedWithVariant` — param → Variant
- [x] `StripDotNet_GlobalDotNetVar_IsRemoved` — global DotNet var removed, dependent body → Error()
- [x] `StripDotNet_PureAssemblyDeclaration_ReturnsNull` — pure `dotnet {}` block → null (skip)
- [x] `StripDotNet_ErrorMessageContainsProcedureName` — Error() includes procedure name
- [x] `ExtractDeps_DotNetProceduresStripped_InOutputDirectory` — end-to-end integration test
- [x] All 3 target frameworks: net8.0, net9.0, net10.0
- [x] Full AL matrix: 1959 + 2283 + 4 = 4246 tests pass, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)