### PR TITLE
fix: prevent CS0101 duplicate-class collision when source-dir input also exists in package cache

### DIFF
--- a/AlRunner.Tests/AutoDiscoverDuplicateTests.cs
+++ b/AlRunner.Tests/AutoDiscoverDuplicateTests.cs
@@ -1,0 +1,241 @@
+using AlRunner;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// Regression tests for the CS0101 "already contains a definition for 'CodeunitN'"
+/// collision that fires when:
+///   1. The user provides App A as a SOURCE DIRECTORY input (with codeunit N),
+///   2. The user also provides App B (test .app) that depends on App A,
+///   3. App A's compiled .app is in the --packages directory.
+///
+/// Under those conditions the old <c>AutoDiscoverDependencies</c> code would
+/// re-extract App A's AL from the packages cache and add it to the compilation
+/// a second time, producing two Roslyn syntax trees for the same class (CS0101).
+///
+/// The fix: read app.json from source-directory inputs and treat their AppIds as
+/// "already present" so the package-cache copy is never re-added. Additionally,
+/// the multi-group compilation path now deduplicates identical class names before
+/// feeding them to the Roslyn compiler (#1566).
+///
+/// Tests skip when alc.exe is unavailable (CI environments without a BC SDK).
+/// </summary>
+[Collection("Pipeline")]
+public class AutoDiscoverDuplicateTests
+{
+    private static readonly string? AlcPath = AlcPathResolver.Default;
+
+    /// <summary>
+    /// Verify that supplying App A as a source directory + App B test.app (depending on A)
+    /// + App A compiled in packages does NOT produce CS0101.
+    ///
+    /// Before the fix this produced:
+    ///   CS0101 on 'Microsoft.Dynamics.Nav.BusinessApplication': The namespace
+    ///   'Microsoft.Dynamics.Nav.BusinessApplication' already contains a definition
+    ///   for 'Codeunit50105'
+    /// because AutoDiscoverDependencies re-extracted App A's AL from the packages cache,
+    /// adding a second Codeunit50105 syntax tree to the Roslyn compilation.
+    /// </summary>
+    [Fact]
+    public async Task SourceDirPlusPackageCopy_AppBDotApp_NoDuplicateCS0101()
+    {
+        if (AlcPath == null) return; // skip when alc is not installed
+
+        await RunScenario(async (srcDir, testDir, pkgDir) =>
+        {
+            var libGuid = Guid.NewGuid();
+            var testGuid = Guid.NewGuid();
+
+            // --- App A (library with codeunit 50105) ---
+            File.WriteAllText(Path.Combine(srcDir, "app.json"), $$"""
+                {
+                  "id": "{{libGuid}}",
+                  "name": "MZ2Lib",
+                  "publisher": "AlRunnerTest",
+                  "version": "1.0.0.0",
+                  "runtime": "14.0"
+                }
+                """);
+            File.WriteAllText(Path.Combine(srcDir, "MyCodeMgmt.al"), """
+                codeunit 50105 "MZ2 MyCode Management"
+                {
+                    procedure Add(Num1: Integer; Num2: Integer): Integer
+                    begin
+                        exit(Num1 + Num2);
+                    end;
+                }
+                """);
+
+            // Compile App A to a .app and put it in the packages dir so that
+            // AutoDiscoverDependencies can find and extract it.
+            var libAppPath = await CompileAlApp(srcDir);
+            if (libAppPath == null)
+                throw new InvalidOperationException("Failed to compile library .app via alc");
+            File.Copy(libAppPath, Path.Combine(pkgDir, Path.GetFileName(libAppPath)));
+
+            // --- App B (test app, depends on App A — compiled to .app) ---
+            File.WriteAllText(Path.Combine(testDir, "app.json"), $$"""
+                {
+                  "id": "{{testGuid}}",
+                  "name": "MZ2Test",
+                  "publisher": "AlRunnerTest",
+                  "version": "1.0.0.0",
+                  "runtime": "14.0",
+                  "dependencies": [
+                    {
+                      "id": "{{libGuid}}",
+                      "name": "MZ2Lib",
+                      "publisher": "AlRunnerTest",
+                      "version": "1.0.0.0"
+                    }
+                  ]
+                }
+                """);
+            // Write App B test without using Assert (Assert codeunit is not available
+            // to the alc compiler — it is only a runner-internal stub).
+            // The test just calls Add() and verifies it does not error.
+            File.WriteAllText(Path.Combine(testDir, "Tests.al"), """
+                codeunit 50200 "MZ2 Tests"
+                {
+                    Subtype = Test;
+
+                    [Test]
+                    procedure AddDoesNotError()
+                    var
+                        Mgmt: Codeunit "MZ2 MyCode Management";
+                        Result: Integer;
+                    begin
+                        Result := Mgmt.Add(3, 4);
+                    end;
+                }
+                """);
+
+            // Compile App B to .app (it depends on App A from pkgDir)
+            var testAppPath = await CompileAlApp(testDir, pkgDir);
+            if (testAppPath == null)
+                throw new InvalidOperationException("Failed to compile test .app via alc");
+
+            // Run: App A SOURCE dir + App B as .app, packages = pkgDir
+            // (App A compiled .app is also in pkgDir — this is the trigger for the bug)
+            // AutoDiscoverDependencies sees App B.app depends on App A,
+            // finds App A.app in pkgDir, and (before the fix) re-extracts App A's AL.
+            var pipeline = new AlRunnerPipeline();
+            var result = pipeline.Run(new PipelineOptions
+            {
+                TestIsolation = TestIsolation.Method,
+                InputPaths = { srcDir, testAppPath },
+                PackagePaths = { pkgDir },
+                Strict = false,
+            });
+
+            // Must not produce CS0101 and must pass the test
+            if (result.StdErr.Contains("CS0101"))
+                Assert.Fail($"Expected no CS0101 but got:\n{result.StdErr}");
+            Assert.Equal(0, result.ExitCode);
+            Assert.Equal(1, result.Passed);
+            Assert.Equal(0, result.Failed);
+        });
+    }
+
+    /// <summary>
+    /// Positive control: when App A is provided as ONLY a source directory (no compiled
+    /// .app in packages), no duplication occurs and the test passes as expected.
+    /// </summary>
+    [Fact]
+    public void SourceDirOnly_TestPasses()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "al-runner-autodisco-ctrl-" + Guid.NewGuid().ToString("N")[..8]);
+        try
+        {
+            var srcDir = Path.Combine(root, "src");
+            var testDir = Path.Combine(root, "test");
+            Directory.CreateDirectory(srcDir);
+            Directory.CreateDirectory(testDir);
+
+            File.WriteAllText(Path.Combine(srcDir, "MyCodeMgmt.al"), """
+                codeunit 50105 "MZ2 MyCode Management"
+                {
+                    procedure Add(Num1: Integer; Num2: Integer): Integer
+                    begin
+                        exit(Num1 + Num2);
+                    end;
+                }
+                """);
+            File.WriteAllText(Path.Combine(testDir, "Tests.al"), """
+                codeunit 50200 "MZ2 Tests"
+                {
+                    Subtype = Test;
+
+                    [Test]
+                    procedure AddReturnsSum()
+                    var
+                        Assert: Codeunit Assert;
+                        Mgmt: Codeunit "MZ2 MyCode Management";
+                        Result: Integer;
+                    begin
+                        Result := Mgmt.Add(3, 4);
+                        Assert.AreEqual(7, Result, 'Add should return 3+4=7');
+                    end;
+                }
+                """);
+
+            var pipeline = new AlRunnerPipeline();
+            var result = pipeline.Run(new PipelineOptions
+            {
+                TestIsolation = TestIsolation.Method,
+                InputPaths = { srcDir, testDir },
+            });
+
+            Assert.Equal(0, result.ExitCode);
+            Assert.Equal(1, result.Passed);
+        }
+        finally
+        {
+            if (Directory.Exists(root)) Directory.Delete(root, true);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+
+    private static async Task RunScenario(Func<string, string, string, Task> body)
+    {
+        var root = Path.Combine(Path.GetTempPath(), "al-runner-autodisco-" + Guid.NewGuid().ToString("N")[..8]);
+        try
+        {
+            var srcDir = Path.Combine(root, "src");
+            var testDir = Path.Combine(root, "test");
+            var pkgDir = Path.Combine(root, "pkg");
+            Directory.CreateDirectory(srcDir);
+            Directory.CreateDirectory(testDir);
+            Directory.CreateDirectory(pkgDir);
+
+            await body(srcDir, testDir, pkgDir);
+        }
+        finally
+        {
+            if (Directory.Exists(root)) Directory.Delete(root, true);
+        }
+    }
+
+    private static async Task<string?> CompileAlApp(string projectDir, string? packageCachePath = null)
+    {
+        if (AlcPath == null) return null;
+
+        var pkgArg = packageCachePath != null
+            ? $" /packagecachepath:\"{packageCachePath}\""
+            : $" /packagecachepath:\"{projectDir}\"";
+        var psi = new System.Diagnostics.ProcessStartInfo
+        {
+            FileName = AlcPath,
+            Arguments = $"/project:\"{projectDir}\" /outfolder:\"{projectDir}\"{pkgArg}",
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false
+        };
+        using var proc = System.Diagnostics.Process.Start(psi)!;
+        await proc.WaitForExitAsync();
+        if (proc.ExitCode != 0) return null;
+        return Directory.GetFiles(projectDir, "*.app").FirstOrDefault();
+    }
+}

--- a/AlRunner/Pipeline.cs
+++ b/AlRunner/Pipeline.cs
@@ -941,6 +941,25 @@ public class AlRunnerPipeline
             catch { }
         }
 
+        // Also collect AppIds from source-directory inputs (via app.json).
+        // Without this, a source-dir input whose compiled .app is in the package cache
+        // would be re-discovered as a transitive dependency and its AL extracted a second
+        // time, causing Roslyn CS0101 "already contains a definition" errors (#1566).
+        foreach (var group in inputGroups)
+        {
+            if (group.Path.EndsWith(".app", StringComparison.OrdinalIgnoreCase)) continue;
+            try
+            {
+                var appJsonPath = Path.Combine(group.Path, "app.json");
+                if (!File.Exists(appJsonPath)) continue;
+                var doc = System.Text.Json.JsonDocument.Parse(File.ReadAllText(appJsonPath));
+                if (doc.RootElement.TryGetProperty("id", out var idProp) &&
+                    Guid.TryParse(idProp.GetString(), out var guid))
+                    inputAppGuids.Add(guid);
+            }
+            catch { }
+        }
+
         var toProcess = new Queue<Guid>();
         var discovered = new HashSet<Guid>(inputAppGuids);
 
@@ -1467,6 +1486,28 @@ public class AlRunnerPipeline
                 stderr.WriteLine("Error: no C# code generated from any input group");
                 return null;
             }
+
+            // Deduplicate: when multiple groups each compile the same AL object (e.g.
+            // shared runner stubs added by LoadAssertStubs, or a source-dir app that was
+            // also re-discovered from the package cache), keep only the first occurrence.
+            // Without this, Roslyn sees two syntax trees declaring the same class in the
+            // same namespace and reports CS0101 (#1566).
+            var seenClassKeys = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var dedupePattern = new System.Text.RegularExpressions.Regex(
+                @"class\s+(Codeunit|Record|Page|Report|XmlPort|Query)(\d+)\b",
+                System.Text.RegularExpressions.RegexOptions.Compiled);
+            var deduped = new List<(string Name, string Code)>(generatedCSharpList.Count);
+            foreach (var item in generatedCSharpList)
+            {
+                // Use the primary class name (e.g. "Codeunit50105") as the deduplication key.
+                var m = dedupePattern.Match(item.Code);
+                var key = m.Success ? $"{m.Groups[1].Value}{m.Groups[2].Value}" : item.Name;
+                if (seenClassKeys.Add(key))
+                    deduped.Add(item);
+                else
+                    Log.Info($"  Deduplicating duplicate object '{item.Name}' (class {key}) from multi-group compilation");
+            }
+            generatedCSharpList = deduped;
         }
         else
         {

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -13537,6 +13537,24 @@ DiagnosticSuppression.Case3.CrossExtensionExtensionObject:
     Same-extension dups are caught by DetectSameExtensionDuplicates pre-scan (exit 3).
     Non-extension types (Codeunit, Table, Page) are always forwarded. Audited in #1365.
 
+MultiGroupTranspile.SourceDirVsPackageCacheDedup:
+  layer: syntax
+  category: diagnostic-suppression
+  status: covered
+  tests:
+    - AlRunner.Tests/AutoDiscoverDuplicateTests.cs
+  notes: >
+    When a source-directory input (App A) is provided alongside a compiled .app input
+    (App B that depends on App A), AutoDiscoverDependencies used to re-extract App A's
+    AL from the package cache, causing two Roslyn syntax trees for the same class
+    (CS0101 "already contains a definition for 'CodeunitN'") — issue #1566.
+    Fix 1: AutoDiscoverDependencies reads app.json from source-directory inputs and
+    adds their AppIds to inputAppGuids so the package-cache copy is never re-added.
+    Fix 2: the multi-group Transpile path deduplicates generatedCSharpList by primary
+    class name after aggregating all group results, guarding against any remaining
+    duplicate (e.g. runner stubs compiled into multiple groups by LoadAssertStubs).
+    Tests: SourceDirPlusPackageCopy_AppBDotApp_NoDuplicateCS0101 (requires alc).
+
 CLIFlag.FailOnStub:
   layer: syntax
   category: runner-flag

--- a/tests/excluded/140-source-dir-plus-package-cache-dup/README.md
+++ b/tests/excluded/140-source-dir-plus-package-cache-dup/README.md
@@ -1,0 +1,40 @@
+# 140 — Source-dir input + package-cache copy → CS0101
+
+Regression test for issue #1566: when the user provides App A as a source
+directory input AND App A's compiled .app is also in the --packages cache,
+`AutoDiscoverDependencies` used to re-extract App A's AL and add it to the
+compilation a second time, causing Roslyn CS0101 errors.
+
+## Why excluded
+
+This test requires the BC compiler (alc.exe) to build the .app files. It is
+covered by the C# integration test
+`AlRunner.Tests/AutoDiscoverDuplicateTests.SourceDirPlusPackageCopy_AppBDotApp_NoDuplicateCS0101`,
+which skips automatically when alc is not available.
+
+## Trigger scenario
+
+```
+al-runner --packages .pkg src/ test.app
+```
+
+Where:
+- `src/` contains `codeunit 50105 "MZ2 MyCode Management"` (with `app.json`)
+- `test.app` is a compiled test app that depends on App A
+- `.pkg/` contains App A's compiled `.app`
+
+Before the fix, Roslyn reported:
+```
+CS0101: The namespace 'Microsoft.Dynamics.Nav.BusinessApplication' already
+contains a definition for 'Codeunit50105'
+```
+
+## Fix
+
+1. `AutoDiscoverDependencies` now reads `app.json` from source-directory
+   inputs and marks their AppIds as already-present, preventing the
+   package-cache copy from being re-extracted.
+
+2. The multi-group `Transpile` path deduplicates `generatedCSharpList` by
+   primary class name after aggregating all groups, as a belt-and-suspenders
+   guard against duplicate runner stubs compiled by `LoadAssertStubs`.


### PR DESCRIPTION
Closes #1566

## Root cause

When the user runs the runner with **both** a source directory input for App A
(containing e.g. `codeunit 50105 "MZ2 MyCode Management"`) **and** a compiled
`.app` input for App B (which depends on App A), and App A's compiled `.app` is
also in the `--packages` directory, `AutoDiscoverDependencies` would:

1. Scan App B's dependencies and find App A's GUID.
2. Look up App A in the packages index and find its compiled `.app`.
3. Extract App A's AL source and add it to `alSources` / `inputGroups` as a
   **second** group — even though App A is already in the inputs as a source dir.

This triggered the multi-group compilation path, which compiled App A's source
**twice** (once from the source dir, once from the re-extracted package copy).
Roslyn then saw two syntax trees declaring `Codeunit50105` in the same namespace
and reported CS0101. The `LoadAssertStubs` function compounded this by adding
runner stubs (LibraryAssert, LibraryRandom, …) to every input group's sources,
causing further CS0101s for those stubs.

## Fixes

**Fix 1 (`AutoDiscoverDependencies`):** After collecting AppIds from `.app`
input groups, also read `app.json` from source-directory inputs and add their
AppIds to `inputAppGuids`. This seeds the `discovered` set so the package-cache
copy of a source-dir input is never enqueued as a new dependency.

**Fix 2 (multi-group deduplication):** After aggregating `generatedCSharpList`
from all groups in the multi-group Transpile path, deduplicate the list by
primary class name (e.g. `Codeunit50105`). This is a belt-and-suspenders guard
for any remaining duplicates (e.g. runner stubs compiled independently into
multiple groups by `LoadAssertStubs`).

## Tests

New C# test `AutoDiscoverDuplicateTests`:
- `SourceDirPlusPackageCopy_AppBDotApp_NoDuplicateCS0101`: uses `alc` to build
  App A and App B as real `.app` files, then runs the pipeline with App A source
  dir + App B `.app` + packages dir (containing App A's compiled `.app`). Before
  the fix this produced CS0101 for `Codeunit50105` and all runner stubs. After
  the fix it compiles cleanly and the test passes (skipped if `alc` is absent).
- `SourceDirOnly_TestPasses`: positive control — source-dir only, no packages,
  no duplication, test passes as expected.

All 513 existing C# tests continue to pass. Bucket-1 and bucket-2 AL tests are
unaffected (bucket-1's pre-existing exit-1 from the 317-fail-on-stub rewriter gap
is unchanged).