### PR TITLE
fix: drop event subscribers targeting missing codeunit to prevent CS0131 / BadExpression crash

### DIFF
--- a/AlRunner.Tests/DepCompilerTests.cs
+++ b/AlRunner.Tests/DepCompilerTests.cs
@@ -1511,4 +1511,185 @@ codeunit 1525004 ""PP Test No Symbol""
         for (int n = 2; n <= 35; n++)
             Assert.Equal(n - 1, AlTranspiler.GetCleanSchemaDefaultMaxForBCVersion(n));
     }
+
+    // ------------------------------------------------------------------ //
+    // Issue #1596: event subscriber targeting codeunit outside slice
+    //              emits CS0131 (Roslyn LHS-of-assignment)
+    // ------------------------------------------------------------------ //
+
+    /// <summary>
+    /// When AL has an event subscriber whose target codeunit is NOT in the
+    /// compiled slice or packages, BC's C# emitter generates a BadExpression
+    /// node for the codeunit ID.  After rewriting that C# passes to Roslyn
+    /// which rejects it with CS0131 ("The left-hand side of an assignment
+    /// must be a variable, property or indexer").
+    ///
+    /// compile-dep must:
+    ///   • detect those CS0131 errors,
+    ///   • strip the offending subscriber method bodies (replacing them with
+    ///     empty stubs),
+    ///   • recompile and exit 0,
+    ///   • log a warning for each stripped subscriber.
+    ///
+    /// The other codeunit in the same app (which has no bad subscriber) must
+    /// still be present in the output DLL.
+    ///
+    /// Issue #1596.
+    /// </summary>
+    [Fact]
+    public void CompileDep_ExitsZero_WhenEventSubscriberTargetsMissingCodeunit()
+    {
+        // App contains two codeunits:
+        //   1. "EvtPub1596" — a publisher codeunit (always in slice)
+        //   2. "EvtSub1596" — a subscriber codeunit whose [EventSubscriber]
+        //      targets "Missing Codeunit 1596 XYZ" which is NOT in any package.
+        //      This causes BC's emitter to generate a BadExpression (→ CS0131).
+        //
+        // The app also contains a second clean codeunit ("EvtClean1596") with no
+        // bad subscriber, to verify the DLL is produced for the compilable parts.
+
+        const string alPublisher = """
+            codeunit 159600 "EvtPub1596"
+            {
+                [IntegrationEvent(false, false)]
+                procedure OnSomethingHappened()
+                begin
+                end;
+
+                procedure TriggerEvent()
+                begin
+                    OnSomethingHappened();
+                end;
+            }
+            """;
+
+        // This subscriber targets "Missing Codeunit 1596 XYZ" which is NOT
+        // available.  BC's C# emitter will generate a BadExpression for the
+        // codeunit ID — the test verifies compile-dep survives that.
+        const string alBadSubscriber = """
+            codeunit 159601 "EvtSub1596"
+            {
+                [EventSubscriber(ObjectType::Codeunit, Codeunit::"Missing Codeunit 1596 XYZ", 'OnMissingEvent', '', false, false)]
+                local procedure HandleMissing()
+                begin
+                    // body referencing missing codeunit event
+                end;
+            }
+            """;
+
+        const string alClean = """
+            codeunit 159602 "EvtClean1596"
+            {
+                procedure GetAnswer(): Integer
+                begin
+                    exit(42);
+                end;
+            }
+            """;
+
+        var rootDir = Path.Combine(Path.GetTempPath(), "al-runner-cs0131-" + Guid.NewGuid().ToString("N")[..8]);
+        var appDir = Path.Combine(rootDir, "App1596");
+        var outputDir = Path.Combine(rootDir, "out");
+        try
+        {
+            Directory.CreateDirectory(appDir);
+            Directory.CreateDirectory(outputDir);
+
+            File.WriteAllText(Path.Combine(appDir, "app.json"), $$"""
+            {
+              "id": "15960000-1596-1596-1596-159600001596",
+              "name": "App1596",
+              "publisher": "Test",
+              "version": "1.0.0.0"
+            }
+            """);
+            File.WriteAllText(Path.Combine(appDir, "Publisher.al"), alPublisher);
+            File.WriteAllText(Path.Combine(appDir, "BadSubscriber.al"), alBadSubscriber);
+            File.WriteAllText(Path.Combine(appDir, "Clean.al"), alClean);
+
+            var origErr = Console.Error;
+            using var errCapture = new StringWriter();
+            Console.SetError(errCapture);
+            int rc;
+            try
+            {
+                rc = DepCompiler.CompileDepMultiApp(rootDir, outputDir, new List<string>());
+            }
+            finally
+            {
+                Console.SetError(origErr);
+            }
+
+            var stderr = errCapture.ToString();
+
+            // compile-dep must exit 0 — the bad subscriber is dropped, not fatal.
+            Assert.Equal(0, rc);
+
+            // A DLL must have been produced.
+            var dlls = Directory.GetFiles(outputDir, "*.dll");
+            Assert.True(dlls.Length > 0,
+                $"At least one DLL must be produced.\nStderr:\n{stderr}");
+
+            // A warning about the dropped subscriber must be logged.
+            Assert.Contains("CS0131", stderr, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            if (Directory.Exists(rootDir)) Directory.Delete(rootDir, true);
+        }
+    }
+
+    /// <summary>
+    /// Negative case for issue #1596: genuine CS0131 errors that are NOT from
+    /// BadExpression event-subscriber emission (i.e. invalid user C# that the
+    /// runner should not silently suppress) must still cause compile-dep to fail.
+    ///
+    /// We verify this by calling <see cref="DepCompiler.CompileToDisk"/> directly
+    /// with a Roslyn syntax tree that has a real CS0131 error (assigning to a
+    /// method-call result) and asserting it returns false.
+    ///
+    /// Note: the CompileDep pipeline only invokes CompileToDisk on rewritten C#
+    /// from the BC transpiler; user AL never reaches CompileToDisk directly with
+    /// raw C#.  This test covers the contract of CompileToDisk itself.
+    /// </summary>
+    [Fact]
+    public void CompileToDisk_ReturnsFalse_OnGenuineCS0131()
+    {
+        // C# that has a real CS0131: assigning to a method-call result.
+        // This is NOT a BadExpression from a missing codeunit — it is a genuine
+        // programmer error that must not be silently swallowed.
+        const string badCs = """
+            namespace TestNs1596Neg
+            {
+                public class Foo
+                {
+                    private static int GetNum() => 42;
+                    public void Bad()
+                    {
+                        GetNum() = 5;   // CS0131: lvalue required
+                    }
+                }
+            }
+            """;
+
+        var tree = Microsoft.CodeAnalysis.CSharp.CSharpSyntaxTree.ParseText(badCs);
+        var refs = RoslynCompiler.LoadReferences();
+        var outPath = Path.Combine(Path.GetTempPath(), $"alrunner-cs0131-neg-{Guid.NewGuid():N}.dll");
+        try
+        {
+            var errors = new List<string>();
+            var result = DepCompiler.CompileToDisk(
+                new List<Microsoft.CodeAnalysis.SyntaxTree> { tree },
+                refs, outPath, errors);
+
+            // The genuine CS0131 must cause failure
+            Assert.False(result, "CompileToDisk must return false for genuine CS0131");
+            Assert.True(errors.Count > 0, "Error sink must contain the CS0131 diagnostic");
+            Assert.Contains(errors, e => e.Contains("CS0131"));
+        }
+        finally
+        {
+            if (File.Exists(outPath)) File.Delete(outPath);
+        }
+    }
 }

--- a/AlRunner/DepCompiler.cs
+++ b/AlRunner/DepCompiler.cs
@@ -549,6 +549,11 @@ public static class DepCompiler
 
     /// <summary>
     /// Compile syntax trees to a DLL file on disk (instead of in-memory like CompileFromTrees).
+    ///
+    /// When Roslyn reports CS0131 ("The left-hand side of an assignment must be a variable,
+    /// property or indexer") errors, those are caused by BadExpression nodes that BC's C# emitter
+    /// wrote for unresolvable codeunit references in [EventSubscriber] attributes (issue #1596).
+    /// The fix: strip the containing method declarations from their syntax trees and retry once.
     /// </summary>
     internal static bool CompileToDisk(List<SyntaxTree> syntaxTrees, List<MetadataReference> references,
         string outputPath, IList<string>? errorSink = null)
@@ -567,6 +572,49 @@ public static class DepCompiler
             var errors = result.Diagnostics
                 .Where(d => d.Severity == DiagnosticSeverity.Error)
                 .ToList();
+
+            // Issue #1596: CS0131 from BadExpression nodes injected by BC's
+            // EventSubscriberAttributeEmitter when the target codeunit is not in the
+            // slice.  Strip the offending method bodies and retry — these subscribers
+            // will never fire at runtime anyway (their target object is absent).
+            var cs0131Errors = errors.Where(d => d.Id == "CS0131").ToList();
+            if (cs0131Errors.Count > 0)
+            {
+                var strippedTrees = StripMethodsWithCS0131(syntaxTrees, cs0131Errors);
+                if (strippedTrees != null)
+                {
+                    Console.Error.WriteLine(
+                        $"  Warning: {cs0131Errors.Count} CS0131 error(s) from BadExpression event-subscriber attribute(s) — " +
+                        $"offending subscriber method(s) dropped and DLL retried (issue #1596).");
+
+                    // Remove the non-CS0131 errors and retry with cleaned trees.
+                    var nonCS0131Errors = errors.Where(d => d.Id != "CS0131").ToList();
+                    if (nonCS0131Errors.Count == 0)
+                    {
+                        // Only CS0131 errors — retry with stripped trees
+                        var retryCompilation = CSharpCompilation.Create(
+                            Path.GetFileNameWithoutExtension(outputPath),
+                            strippedTrees,
+                            references,
+                            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary)
+                                .WithAllowUnsafe(true));
+                        var retryResult = retryCompilation.Emit(outputPath);
+                        if (retryResult.Success)
+                            return true;
+                        // Retry failed — fall through to report the retry errors
+                        errors = retryResult.Diagnostics
+                            .Where(d => d.Severity == DiagnosticSeverity.Error)
+                            .ToList();
+                    }
+                    else
+                    {
+                        // Mixed errors — CS0131 are likely from bad subscribers but there
+                        // are other genuine errors too. Report the non-CS0131 ones.
+                        errors = nonCS0131Errors;
+                    }
+                }
+            }
+
             foreach (var d in errors)
                 errorSink?.Add(d.ToString());
             // DEBUG: dump rewritten trees on failure
@@ -591,6 +639,103 @@ public static class DepCompiler
         }
 
         return true;
+    }
+
+    /// <summary>
+    /// Given a list of CS0131 Roslyn diagnostics, determine whether any of them originate
+    /// from BC's EventSubscriberAttributeEmitter — identified by being in an
+    /// <see cref="Microsoft.CodeAnalysis.CSharp.Syntax.AttributeArgumentSyntax"/> node
+    /// rather than in a method body statement.
+    ///
+    /// For those, identify the containing method declarations, replace each method body
+    /// with an empty stub (so the class still compiles), and return a new list of patched
+    /// trees.  Returns null if no attribute-level CS0131 errors were found.
+    ///
+    /// Genuine CS0131 errors (assigning to a non-lvalue in a method body) are left in the
+    /// error list and cause the compilation to fail as expected.
+    /// </summary>
+    private static List<SyntaxTree>? StripMethodsWithCS0131(
+        List<SyntaxTree> syntaxTrees,
+        List<Diagnostic> cs0131Errors)
+    {
+        // Filter: only process CS0131 errors that are inside attribute argument lists.
+        // BC's EventSubscriberAttributeEmitter generates BadExpression nodes as attribute
+        // arguments; genuine CS0131 errors occur in method bodies (statement expressions).
+        var attributeCS0131 = cs0131Errors.Where(d =>
+        {
+            var tree = d.Location.SourceTree;
+            if (tree == null) return false;
+            var span = d.Location.SourceSpan;
+            var node = tree.GetRoot().FindNode(span, getInnermostNodeForTie: true);
+            // Walk ancestors: if we reach an AttributeArgumentSyntax before a
+            // StatementSyntax, this is an attribute-level error (BC-generated).
+            while (node != null)
+            {
+                if (node is Microsoft.CodeAnalysis.CSharp.Syntax.AttributeArgumentSyntax)
+                    return true;
+                if (node is Microsoft.CodeAnalysis.CSharp.Syntax.StatementSyntax)
+                    return false;
+                node = node.Parent;
+            }
+            return false;
+        }).ToList();
+
+        if (attributeCS0131.Count == 0) return null;
+
+        // Group by containing syntax tree
+        var errorsByTree = new Dictionary<SyntaxTree, List<Diagnostic>>(ReferenceEqualityComparer.Instance);
+        foreach (var d in attributeCS0131)
+        {
+            var tree = d.Location.SourceTree!;
+            if (!errorsByTree.TryGetValue(tree, out var list))
+                errorsByTree[tree] = list = new List<Diagnostic>();
+            list.Add(d);
+        }
+
+        // Patch each affected tree by removing the offending methods (those whose
+        // attribute lists contain the CS0131 errors)
+        var patchedTrees = new List<SyntaxTree>(syntaxTrees.Count);
+        bool anyPatched = false;
+        foreach (var tree in syntaxTrees)
+        {
+            if (!errorsByTree.TryGetValue(tree, out var treeDiags))
+            {
+                patchedTrees.Add(tree);
+                continue;
+            }
+
+            // Collect the text spans of the error locations
+            var errorSpanStarts = new HashSet<int>(treeDiags.Select(d => d.Location.SourceSpan.Start));
+            var root = tree.GetRoot();
+
+            // Find method declarations that contain one of the erroneous attribute arguments
+            var methodsToStrip = root.DescendantNodes()
+                .OfType<Microsoft.CodeAnalysis.CSharp.Syntax.MethodDeclarationSyntax>()
+                .Where(m => m.AttributeLists.Count > 0 &&
+                    errorSpanStarts.Any(pos =>
+                        pos >= m.FullSpan.Start && pos <= m.FullSpan.End))
+                .ToList();
+
+            if (methodsToStrip.Count == 0)
+            {
+                patchedTrees.Add(tree);
+                continue;
+            }
+
+            // Replace each offending method's attribute list and body with empty stubs
+            var newRoot = root.ReplaceNodes(
+                methodsToStrip,
+                (orig, _) => orig
+                    .WithBody(Microsoft.CodeAnalysis.CSharp.SyntaxFactory.Block())
+                    .WithAttributeLists(
+                        Microsoft.CodeAnalysis.CSharp.SyntaxFactory.List<
+                            Microsoft.CodeAnalysis.CSharp.Syntax.AttributeListSyntax>()));
+
+            patchedTrees.Add(tree.WithRootAndOptions(newRoot, tree.Options));
+            anyPatched = true;
+        }
+
+        return anyPatched ? patchedTrees : null;
     }
 
     /// <summary>
@@ -1033,6 +1178,44 @@ public static class DepCompiler
             }
         }
 
+        // Phase 3 (issue #1596): event subscriber targeting codeunit outside slice.
+        //
+        // When an [EventSubscriber] attribute references a codeunit whose name is not
+        // in the compiled slice or packages, BC's C# emitter throws
+        // "Unexpected value 'BadExpression'" during MethodCodeGenerator.EmitMethod.
+        // This exception is caught in TranspileMulti (issue #1554 handler), but because
+        // the exception aborts before any C# is captured, TranspileMulti returns null.
+        //
+        // Fix: detect AL0118 ("The name '...' does not exist") on the codeunit
+        // reference inside an EventSubscriber attribute.  Strip the AL files that
+        // contain those bad subscribers and retry transpilation.  The stripped
+        // subscriber is logged as a warning — it will never fire at runtime anyway
+        // (its target object doesn't exist in this build).
+        if ((csharpList == null || csharpList.Count == 0) && compilableSources.Count > 0)
+        {
+            var badSubscriberFiles = FindBadEventSubscriberFiles(compilableSources, compilableFilePaths);
+            if (badSubscriberFiles.Count > 0)
+            {
+                var badSet = new HashSet<int>(badSubscriberFiles.Select(x => x.Index));
+                var retained = compilableSources
+                    .Zip(compilableFilePaths, (s, p) => (s, p))
+                    .Select((pair, i) => (pair.s, pair.p, i))
+                    .Where(x => !badSet.Contains(x.i))
+                    .ToList();
+
+                Console.Error.WriteLine($"  Warning: {badSubscriberFiles.Count} AL file(s) contain [EventSubscriber] targeting a codeunit not in the slice — subscribers dropped (CS0131 guard, issue #1596):");
+                foreach (var f in badSubscriberFiles)
+                {
+                    var label = f.FilePath != null ? Path.GetFileName(f.FilePath) : $"source[{f.Index}]";
+                    Console.Error.WriteLine($"    {label}: {f.SubscriberName}");
+                }
+
+                compilableSources = retained.Select(x => x.s).ToList();
+                compilableFilePaths = retained.Select(x => x.p).ToList();
+                csharpList = AlTranspiler.TranspileMulti(compilableSources, effectivePackages, inputPaths, sourceFilePaths: compilableFilePaths, extraRefs: extraRefs, extraDefines: effectiveExtraDefines);
+            }
+        }
+
         if (csharpList == null || csharpList.Count == 0)
         {
             // Re-run capturing stderr so we can surface specific compilation diagnostics
@@ -1208,5 +1391,86 @@ public static class DepCompiler
         }
         catch { }
         return missing;
+    }
+
+    /// <summary>
+    /// Result record returned by <see cref="FindBadEventSubscriberFiles"/>.
+    /// </summary>
+    internal record BadSubscriberFile(int Index, string? FilePath, string SubscriberName);
+
+    /// <summary>
+    /// Detect AL source files that contain [EventSubscriber] attributes targeting
+    /// codeunits that are not in the compiled slice (issue #1596).
+    ///
+    /// Strategy: after a failed TranspileMulti, query
+    /// <see cref="AlTranspiler.LastCompilation"/> for AL0118 ("does not exist in
+    /// the current context") declaration errors.  For each such error, extract
+    /// the unresolved name and find which source files contain an [EventSubscriber]
+    /// attribute that references that name.  Those files are the ones to drop and
+    /// retry without.
+    ///
+    /// The check uses text matching (not full AST analysis) to keep it fast and
+    /// side-effect free.
+    /// </summary>
+    internal static List<BadSubscriberFile> FindBadEventSubscriberFiles(
+        List<string> sources,
+        List<string?> filePaths)
+    {
+        var result = new List<BadSubscriberFile>();
+
+        var lastComp = AlTranspiler.LastCompilation;
+        if (lastComp == null) return result;
+
+        // Collect unresolved names from AL0118 diagnostics.
+        // Message format: The name '"Some Name"' does not exist in the current context.
+        // Note: d.Severity is Microsoft.Dynamics.Nav.CodeAnalysis.Diagnostics.DiagnosticSeverity
+        // (BC type), which differs from the Roslyn DiagnosticSeverity imported at top of file.
+        // Use ToString() comparison to avoid namespace ambiguity.
+        var al0118 = lastComp.GetDeclarationDiagnostics()
+            .Where(d => d.Severity.ToString() == "Error" && d.Id == "AL0118")
+            .ToList();
+
+        if (al0118.Count == 0) return result;
+
+        // Regex: extract the quoted name from the AL0118 message.
+        // Typical message: The name '"License Management Starter"' does not exist in the current context.
+        var nameRx = new System.Text.RegularExpressions.Regex(
+            @"The name '""([^""]+)""' does not exist",
+            System.Text.RegularExpressions.RegexOptions.IgnoreCase);
+
+        var unresolvedNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var d in al0118)
+        {
+            var m = nameRx.Match(d.GetMessage());
+            if (m.Success)
+                unresolvedNames.Add(m.Groups[1].Value);
+        }
+
+        if (unresolvedNames.Count == 0) return result;
+
+        // For each source, check if it contains an [EventSubscriber] attribute that
+        // mentions one of the unresolved names.
+        // AL syntax: [EventSubscriber(ObjectType::Codeunit, Codeunit::"SomeName", ...)]
+        // We do a simple text search for the codeunit name next to EventSubscriber.
+        for (int i = 0; i < sources.Count; i++)
+        {
+            var src = sources[i];
+            if (!src.Contains("EventSubscriber", StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            foreach (var name in unresolvedNames)
+            {
+                // Check the combination of EventSubscriber and the unresolved name appearing
+                // in the same source (exact match of the name string)
+                if (src.Contains($"\"{name}\"", StringComparison.OrdinalIgnoreCase))
+                {
+                    var fp = i < filePaths.Count ? filePaths[i] : null;
+                    result.Add(new BadSubscriberFile(i, fp, name));
+                    break; // one match per file is enough
+                }
+            }
+        }
+
+        return result;
     }
 }

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -13676,6 +13676,27 @@ DepCompiler.PartialSymbolsJsonOnEmitFailure:
     Tests: CompileDepMultiApp_WritesSymbolsJson_FromLastCompilation_WhenAppFailsAtEmit.
     Fixed in #1554.
 
+DepCompiler.BadExpressionEventSubscriberDrop:
+  layer: syntax
+  category: compile-dep
+  status: covered
+  tests:
+    - AlRunner.Tests/DepCompilerTests.cs
+  notes: >
+    When an [EventSubscriber] attribute references a codeunit that is NOT in the
+    compiled slice or packages, BC's EventSubscriberAttributeEmitter.EmitObjectId
+    throws "Unexpected value 'BadExpression'" during MethodCodeGenerator.EmitMethod.
+    TranspileMulti catches the exception but returns null (zero captured objects).
+    DepCompiler now detects this pattern (AL0118 declaration error + BadExpression
+    emit exception) via FindBadEventSubscriberFiles, removes the offending AL files,
+    and retries TranspileMulti — producing a valid DLL with a warning logged.
+    A secondary guard in CompileToDisk handles the alternate path where BC emits C#
+    with BadExpression attribute arguments that Roslyn rejects with CS0131 — those
+    are stripped at the method level (StripMethodsWithCS0131) and retried.
+    Tests: CompileDep_ExitsZero_WhenEventSubscriberTargetsMissingCodeunit,
+           CompileToDisk_ReturnsFalse_OnGenuineCS0131 (negative).
+    Fixed in #1596.
+
 # ── extract-deps: --packages dir auto-discovery ──────────────────
 
 DepExtractor.PackagesDirAutoDiscovery:

--- a/tests/bucket-1/codeunit-runtime/1596-subscriber-to-missing-cu/src/SubscriberToMissingCu.al
+++ b/tests/bucket-1/codeunit-runtime/1596-subscriber-to-missing-cu/src/SubscriberToMissingCu.al
@@ -1,0 +1,97 @@
+// Source for the "subscriber to in-slice publisher fires correctly" test (issue #1596).
+//
+// Issue #1596: compile-dep now drops [EventSubscriber] attributes that reference
+// codeunits not in the slice.  These tests verify that when the publisher IS in
+// the slice, the subscriber still fires correctly at runtime.
+//
+// Object IDs 159600-159602 (table 159600).
+
+table 159600 "SMC Event Log"
+{
+    fields
+    {
+        field(1; PK; Integer) { }
+        field(2; AfterFireCount; Integer) { }
+        field(3; LastInput; Integer) { }
+        field(4; LastResult; Integer) { }
+    }
+    keys { key(PK; PK) { Clustered = true; } }
+}
+
+codeunit 159600 "SMC Publisher"
+{
+    [IntegrationEvent(false, false)]
+    procedure OnAfterCalculate(Input: Integer; Result: Integer)
+    begin
+    end;
+
+    procedure Calculate(Input: Integer): Integer
+    var
+        Output: Integer;
+    begin
+        Output := Input * 2;
+        OnAfterCalculate(Input, Output);
+        exit(Output);
+    end;
+}
+
+codeunit 159601 "SMC Subscriber"
+{
+    // Normal subscriber to a publisher that IS in the slice — must fire at runtime.
+    [EventSubscriber(ObjectType::Codeunit, Codeunit::"SMC Publisher", 'OnAfterCalculate', '', true, true)]
+    local procedure OnAfterCalculateHandler(Input: Integer; Result: Integer)
+    var
+        Log: Record "SMC Event Log";
+    begin
+        if not Log.Get(1) then begin
+            Log.PK := 1;
+            Log.AfterFireCount := 1;
+            Log.LastInput := Input;
+            Log.LastResult := Result;
+            Log.Insert();
+        end else begin
+            Log.AfterFireCount += 1;
+            Log.LastInput := Input;
+            Log.LastResult := Result;
+            Log.Modify();
+        end;
+    end;
+}
+
+codeunit 159602 "SMC Log Helper"
+{
+    procedure Reset()
+    var
+        Log: Record "SMC Event Log";
+    begin
+        if Log.Get(1) then
+            Log.Delete();
+    end;
+
+    procedure GetFireCount(): Integer
+    var
+        Log: Record "SMC Event Log";
+    begin
+        if Log.Get(1) then
+            exit(Log.AfterFireCount);
+        exit(0);
+    end;
+
+    procedure GetLastInput(): Integer
+    var
+        Log: Record "SMC Event Log";
+    begin
+        if Log.Get(1) then
+            exit(Log.LastInput);
+        exit(0);
+    end;
+
+    procedure GetLastResult(): Integer
+    var
+        Log: Record "SMC Event Log";
+    begin
+        if Log.Get(1) then
+            exit(Log.LastResult);
+        exit(0);
+    end;
+}

--- a/tests/bucket-1/codeunit-runtime/1596-subscriber-to-missing-cu/test/SubscriberToMissingCuTest.al
+++ b/tests/bucket-1/codeunit-runtime/1596-subscriber-to-missing-cu/test/SubscriberToMissingCuTest.al
@@ -1,0 +1,81 @@
+// Tests for the "in-slice subscriber fires correctly" scenario (issue #1596).
+//
+// Issue #1596: compile-dep now drops [EventSubscriber] attributes that reference
+// codeunits NOT in the slice.  These AL end-to-end tests verify that when the
+// publisher IS in the slice, the subscriber fires correctly — i.e. the fix does
+// not break the working subscriber path.
+//
+// Test codeunit ID: 159603.
+
+codeunit 159603 "SMC Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+        Publisher: Codeunit "SMC Publisher";
+        Helper: Codeunit "SMC Log Helper";
+
+    [Test]
+    procedure Calculate_FiresOnAfterCalculate_Subscriber()
+    begin
+        // Positive: Calculate must fire the OnAfterCalculate subscriber, which
+        // records the event in the SMC Event Log table.
+        Helper.Reset();
+
+        Publisher.Calculate(5);
+
+        Assert.AreEqual(1, Helper.GetFireCount(),
+            'OnAfterCalculate subscriber must fire exactly once');
+        Assert.AreEqual(5, Helper.GetLastInput(),
+            'Subscriber must record Input=5');
+        Assert.AreEqual(10, Helper.GetLastResult(),
+            'Subscriber must record Result=10 (5*2)');
+    end;
+
+    [Test]
+    procedure Calculate_MultipleCallsFireSubscriberEachTime()
+    begin
+        // Positive: each Calculate call fires the subscriber once.
+        Helper.Reset();
+
+        Publisher.Calculate(3);
+        Publisher.Calculate(7);
+
+        Assert.AreEqual(2, Helper.GetFireCount(),
+            'Subscriber must fire once per Calculate call');
+        // Last call wins for Input/Result
+        Assert.AreEqual(7, Helper.GetLastInput(),
+            'Last subscriber call must record Input=7');
+        Assert.AreEqual(14, Helper.GetLastResult(),
+            'Last subscriber call must record Result=14 (7*2)');
+    end;
+
+    [Test]
+    procedure Calculate_ZeroInput_SubscriberReceivesZero()
+    begin
+        // Edge case: Calculate(0) → Result=0; subscriber receives both as zero.
+        Helper.Reset();
+
+        Publisher.Calculate(0);
+
+        Assert.AreEqual(1, Helper.GetFireCount(),
+            'Subscriber must fire even for zero input');
+        Assert.AreEqual(0, Helper.GetLastInput(), 'Last Input must be 0');
+        Assert.AreEqual(0, Helper.GetLastResult(), 'Last Result must be 0');
+    end;
+
+    [Test]
+    procedure Calculate_NegativeInput_SubscriberReceivesNegativeResult()
+    begin
+        // Negative direction: Calculate(-4) → Result=-8.
+        Helper.Reset();
+
+        Publisher.Calculate(-4);
+
+        Assert.AreEqual(1, Helper.GetFireCount(),
+            'Subscriber must fire for negative input');
+        Assert.AreEqual(-4, Helper.GetLastInput(), 'Last Input must be -4');
+        Assert.AreEqual(-8, Helper.GetLastResult(), 'Last Result must be -8');
+    end;
+}


### PR DESCRIPTION
Closes #1596

## Summary

- Adds **Phase-3 retry** in `CompileDepFromDir`: after the existing DotNet-exclusion retry fails, detects AL0118 errors on `Codeunit::` references inside `[EventSubscriber]` attributes (via new `FindBadEventSubscriberFiles`). Removes the offending AL files and retries `TranspileMulti`. Logs a warning naming each dropped subscriber.

- Adds **CS0131 guard** in `CompileToDisk` (secondary path): when Roslyn emits CS0131 errors that originate inside attribute argument lists (the alternate case where BC's emitter writes malformed C# with BadExpression nodes rather than throwing), strips the containing method declarations via new `StripMethodsWithCS0131` and retries. Genuine CS0131 errors in method bodies still fail as before.

- Adds `docs/coverage.yaml` entry `DepCompiler.BadExpressionEventSubscriberDrop`.

## Tests

Two new C# unit tests in `DepCompilerTests.cs`:

| Test | Direction |
|---|---|
| `CompileDep_ExitsZero_WhenEventSubscriberTargetsMissingCodeunit` | **positive**: AL with bad event subscriber exits 0, DLL produced, warning logged |
| `CompileToDisk_ReturnsFalse_OnGenuineCS0131` | **negative**: genuine CS0131 in method body still causes failure |

All 531 existing tests pass on net8.0/9.0/10.0.

## Test plan

- [x] `CompileDep_ExitsZero_WhenEventSubscriberTargetsMissingCodeunit` passes (rc=0, DLL produced, CS0131 warning in stderr)
- [x] `CompileToDisk_ReturnsFalse_OnGenuineCS0131` passes (genuine error is not swallowed)
- [x] Full test suite: 531/531 pass on all three .NET TFMs
- [x] AL test matrix (bucket-1, bucket-2): no new failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)