### PR TITLE
fix: exclude PagePartSyntax from usercontrol stub injection guard (issue #1597)

### DIFF
--- a/AlRunner/Pipeline.cs
+++ b/AlRunner/Pipeline.cs
@@ -2305,6 +2305,15 @@ public class AlRunnerPipeline
                     var ln = uc.Name?.Identifier.ValueText;
                     if (!string.IsNullOrEmpty(ln)) existingControls.Add(ln);
                 }
+                // Also exclude page parts — CurrPage.PartName.Page.Method() uses the same
+                // two-level access syntax as usercontrols, but must not trigger stub injection
+                // because the part is already declared. Without this guard, the runner injects
+                // a conflicting usercontrol(PartName; ...) and produces AL0155. (issue #1597)
+                foreach (var pp in root.DescendantNodes().OfType<PagePartSyntax>())
+                {
+                    var ln = pp.Name?.Identifier.ValueText;
+                    if (!string.IsNullOrEmpty(ln)) existingControls.Add(ln);
+                }
                 if (existingControls.Count > 0)
                     pageExistingControls[i] = existingControls;
 

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -1013,6 +1013,20 @@ usercontrol_auto_stub:
   tests:
     - tests/bucket-2/page-report/314000-usercontrol-auto-stub
 
+pagepart_stub_injection_guard:
+  layer: syntax
+  category: page
+  status: covered
+  notes: >
+    Pipeline.InjectUserControlStubs() now also adds PagePartSyntax local names to the
+    existingControls guard set. CurrPage.PartName.Page.Method() access on a declared
+    part(PartName; ...) is syntactically identical at the two-level match point to a
+    usercontrol call, so without this guard the injector incorrectly injects a stub
+    usercontrol — producing AL0155 (duplicate member) or AL0132 (wrong return type).
+    Fixed in issue #1597.
+  tests:
+    - tests/bucket-2/page-report/314100-pagepart-currpage-stub
+
 view_definition:
   layer: syntax
   category: page

--- a/tests/bucket-2/page-report/314100-pagepart-currpage-stub/src/PpcsPage.al
+++ b/tests/bucket-2/page-report/314100-pagepart-currpage-stub/src/PpcsPage.al
@@ -1,0 +1,35 @@
+// Regression test for issue #1597.
+// A page that has a real part(MySubPage; ...) declaration and calls
+// CurrPage.MySubPage.Page.DoSomething() in a trigger. The runner must NOT
+// inject a stub usercontrol for MySubPage — it is already a PagePart.
+// Without the fix, the runner injects a conflicting usercontrol and either
+// produces AL0155 (duplicate member) or AL0132 (wrong return type).
+
+page 1320100 "Ppcs Host Page"
+{
+    PageType = Card;
+
+    layout
+    {
+        area(Content)
+        {
+            part(MySubPage; "Ppcs Sub Page") { ApplicationArea = All; }
+        }
+    }
+
+    trigger OnOpenPage()
+    begin
+        // Three-level access: CurrPage.<part>.<Page>.<method>()
+        // The runner must recognise MySubPage as an existing part, not a missing usercontrol.
+        CurrPage.MySubPage.Page.DoSomething();
+    end;
+}
+
+page 1320101 "Ppcs Sub Page"
+{
+    PageType = ListPart;
+
+    procedure DoSomething()
+    begin
+    end;
+}

--- a/tests/bucket-2/page-report/314100-pagepart-currpage-stub/test/PpcsTest.al
+++ b/tests/bucket-2/page-report/314100-pagepart-currpage-stub/test/PpcsTest.al
@@ -1,0 +1,25 @@
+// Tests for issue #1597: page parts must not trigger stub usercontrol injection.
+// When a page has part(X; SomePage) and calls CurrPage.X.Page.Method(), the runner
+// must not inject a stub usercontrol for X — it is already declared as a PagePart.
+codeunit 1320102 "Ppcs Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    [Test]
+    procedure HostPage_WithPartAndCurrPageCall_CompilesWithoutAL0155_IsNoOp()
+    var
+        TestPage: TestPage "Ppcs Host Page";
+    begin
+        // [GIVEN] A page with part(MySubPage; "Ppcs Sub Page") that calls
+        //         CurrPage.MySubPage.Page.DoSomething() in OnOpenPage
+        // [WHEN]  The page is opened (triggers auto-stub injection guard)
+        TestPage.OpenView();
+        // [THEN]  No AL0155 (no duplicate member) and no AL0132 (no wrong return type).
+        //         DoSomething() is a no-op via the runtime part-page stub.
+        TestPage.Close();
+        Assert.IsTrue(true, 'Page with part must open without AL0155 or AL0132');
+    end;
+}


### PR DESCRIPTION
Closes #1597

## Problem

When a BC page declares `part(MyPart; TargetPage)` and calls `CurrPage.MyPart.Page.DoSomething()` in a trigger, `al-runner` incorrectly injects a stub `usercontrol(MyPart; "AL Runner Stub MyPart")`. This produces AL0155 (duplicate member) because `MyPart` is already declared as a `PagePart`.

The root cause: the guard in `Pipeline.InjectUserControlStubs()` that prevents re-injection collects only `PageUserControlSyntax` node names into `existingControls`. `PagePartSyntax` names were not included, so `part(MyPart; TargetPage)` didn't protect `MyPart` from stub injection.

The scanner detects `CurrPage.MyPart.Page.DoSomething()` as `CurrPage.<MyPart>.<Page>` (2-level access), interprets `MyPart` as an addin name and `Page` as a method — then injects a conflicting stub.

## Fix

Added `PagePartSyntax` local identifiers to the `existingControls` guard set in `AlRunner/Pipeline.cs` (~line 2308-2316). Now any declared `part(Name; ...)` blocks stub injection for that name, matching the behavior already in place for `usercontrol(Name; ...)`.

## Tests

- `tests/bucket-2/page-report/314100-pagepart-currpage-stub/` — regression test for the exact pattern from the issue: a page with `part(MySubPage; "Ppcs Sub Page")` that calls `CurrPage.MySubPage.Page.DoSomething()`. The test verifies the page compiles and opens without AL0155 or AL0132.
- Genuine usercontrol auto-stubs continue to inject correctly (confirmed by existing test at `tests/bucket-2/page-report/314000-usercontrol-auto-stub/`).