### PR TITLE
fix: emit auto-stubs in consumer using-namespace to resolve AL0118 for namespace-aware consumers

### DIFF
--- a/AlRunner.Tests/DepExtractorTests.cs
+++ b/AlRunner.Tests/DepExtractorTests.cs
@@ -2587,6 +2587,154 @@ public class DepExtractorTests
 
     /// <summary>
     /// Full extract-then-compile-dep pipeline test: when the slice contains an
+    // -----------------------------------------------------------------------
+    // Issue #1589: namespace-aware consumers cannot resolve root-namespace stubs
+    // -----------------------------------------------------------------------
+
+    /// <summary>
+    /// When the consumer file declares a namespace and has using directives, and it
+    /// references an unqualified enum name that must be auto-stubbed, the stub must
+    /// be emitted in a namespace that matches one of the consumer's using directives
+    /// so the BC compiler can resolve the unqualified reference.
+    ///
+    /// Strategy: inspect consumer files that reference the missing object; if all such
+    /// files import the same candidate namespace via using, emit the stub in that
+    /// namespace.  Regression test for issue #1589.
+    /// </summary>
+    [Fact]
+    public void ExtractDeps_EnumStub_EmittedInConsumerUsingNamespace_WhenNamespaceAwareConsumer()
+    {
+        var depRoot = Path.Combine(Path.GetTempPath(), "al-dep-ns1589-" + Guid.NewGuid().ToString("N")[..8]);
+        var outDir  = Path.Combine(Path.GetTempPath(), "al-out-ns1589-" + Guid.NewGuid().ToString("N")[..8]);
+        var extDir  = Path.Combine(Path.GetTempPath(), "al-ext-ns1589-" + Guid.NewGuid().ToString("N")[..8]);
+        try
+        {
+            Directory.CreateDirectory(Path.Combine(depRoot, "DepApp"));
+            Directory.CreateDirectory(extDir);
+
+            // Dep source: a codeunit that references "Sales Order Print Option" enum.
+            // The enum is NOT defined anywhere (simulating a missing platform enum).
+            File.WriteAllText(Path.Combine(depRoot, "DepApp", "Printer.al"), """
+                codeunit 60300 "Sales Order Printer"
+                {
+                    procedure GetOption(): Enum "Sales Order Print Option"
+                    var
+                        Opt: Enum "Sales Order Print Option";
+                    begin
+                        exit(Opt);
+                    end;
+                }
+                """);
+
+            // Consumer: namespace-aware file that imports a specific namespace.
+            // The consumer directly uses the dep codeunit AND the missing enum.
+            // This simulates the real pattern: a namespaced AL file in
+            // namespace Microsoft.Foundation.Reporting references an unqualified
+            // "Sales Order Print Option" enum that lives in Microsoft.Sales.Document.
+            File.WriteAllText(Path.Combine(extDir, "Consumer.al"), """
+                namespace MyApp.Reporting;
+
+                using MySales.Document;
+
+                codeunit 60309 "Report Consumer"
+                {
+                    procedure Run()
+                    var
+                        Opt: Enum "Sales Order Print Option";
+                    begin
+                        Codeunit.Run(Codeunit::"Sales Order Printer");
+                    end;
+                }
+                """);
+
+            int rc = DepExtractor.ExtractDeps(extDir, new[] { depRoot }, outDir);
+            Assert.Equal(0, rc);
+
+            var allFiles = Directory.GetFiles(outDir, "*.al", SearchOption.AllDirectories);
+
+            // Locate the auto-generated stub for "Sales Order Print Option".
+            var enumStub = allFiles.FirstOrDefault(f =>
+                f.Contains("__GeneratedStubs__", StringComparison.OrdinalIgnoreCase)
+                && File.ReadAllText(f).Contains("Sales Order Print Option", StringComparison.OrdinalIgnoreCase));
+            Assert.NotNull(enumStub);
+
+            var stubContent = File.ReadAllText(enumStub!);
+
+            // The stub must be declared inside the namespace the consumer imports.
+            // Without this fix the stub is at global root and AL0118 fires.
+            Assert.Contains("namespace MySales.Document", stubContent, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            foreach (var d in new[] { depRoot, outDir, extDir })
+                if (Directory.Exists(d)) Directory.Delete(d, true);
+        }
+    }
+
+    /// <summary>
+    /// When the consumer has NO using directives, the stub must NOT be wrapped in a namespace
+    /// — falling back to global root is the correct (and safe) behaviour.  This verifies
+    /// the negative path of the namespace-inference heuristic from issue #1589.
+    /// </summary>
+    [Fact]
+    public void ExtractDeps_EnumStub_StaysAtGlobalRoot_WhenConsumerHasNoUsingDirectives()
+    {
+        var depRoot = Path.Combine(Path.GetTempPath(), "al-dep-ns1589b-" + Guid.NewGuid().ToString("N")[..8]);
+        var outDir  = Path.Combine(Path.GetTempPath(), "al-out-ns1589b-" + Guid.NewGuid().ToString("N")[..8]);
+        var extDir  = Path.Combine(Path.GetTempPath(), "al-ext-ns1589b-" + Guid.NewGuid().ToString("N")[..8]);
+        try
+        {
+            Directory.CreateDirectory(Path.Combine(depRoot, "DepApp"));
+            Directory.CreateDirectory(extDir);
+
+            File.WriteAllText(Path.Combine(depRoot, "DepApp", "Printer.al"), """
+                codeunit 60310 "Legacy Sales Printer"
+                {
+                    procedure GetOption(): Enum "Legacy Print Option"
+                    var
+                        Opt: Enum "Legacy Print Option";
+                    begin
+                        exit(Opt);
+                    end;
+                }
+                """);
+
+            // Consumer WITHOUT a namespace declaration and without any using directives.
+            // The stub must stay at global root — no namespace wrapping.
+            File.WriteAllText(Path.Combine(extDir, "LegacyConsumer.al"), """
+                codeunit 60319 "Legacy Consumer"
+                {
+                    procedure Run()
+                    var
+                        Opt: Enum "Legacy Print Option";
+                    begin
+                        Codeunit.Run(Codeunit::"Legacy Sales Printer");
+                    end;
+                }
+                """);
+
+            int rc = DepExtractor.ExtractDeps(extDir, new[] { depRoot }, outDir);
+            Assert.Equal(0, rc);
+
+            var allFiles = Directory.GetFiles(outDir, "*.al", SearchOption.AllDirectories);
+
+            var enumStub = allFiles.FirstOrDefault(f =>
+                f.Contains("__GeneratedStubs__", StringComparison.OrdinalIgnoreCase)
+                && File.ReadAllText(f).Contains("Legacy Print Option", StringComparison.OrdinalIgnoreCase));
+            Assert.NotNull(enumStub);
+
+            var stubContent = File.ReadAllText(enumStub!);
+
+            // No namespace wrapping expected for namespace-unaware consumers.
+            Assert.DoesNotContain("namespace ", stubContent, StringComparison.OrdinalIgnoreCase);
+        }
+        finally
+        {
+            foreach (var d in new[] { depRoot, outDir, extDir })
+                if (Directory.Exists(d)) Directory.Delete(d, true);
+        }
+    }
+
     /// enumextension whose base enum is auto-stubbed, compile-dep must succeed
     /// (exit code 0) without throwing NRE in the BC compiler emit phase.
     /// Regression test for issue #1590.

--- a/AlRunner/DepExtractor.cs
+++ b/AlRunner/DepExtractor.cs
@@ -313,6 +313,15 @@ public static class DepExtractor
 
                 int stubId = stubIdCounter++;
                 var stubSource = GenerateStub(typeName, objectName, stubId, allExtracted);
+
+                // Issue #1589: infer namespace from consumer using directives so that
+                // namespace-aware consumers can resolve the stub via their using imports.
+                // Also check extension source files (they are not in allExtracted but they
+                // are the primary consumers that trigger the missing-dep detection).
+                var stubNamespace = InferStubNamespace(objectName, allExtracted, sources);
+                if (stubNamespace != null)
+                    stubSource = WrapWithNamespace(stubSource, stubNamespace);
+
                 var safeName = MakeSafeName(objectName) + $"_{stubId}";
                 var stubKey = $"{consumerApp}/__GeneratedStubs__/{safeName}.al";
                 allExtracted[stubKey] = stubSource;
@@ -687,6 +696,99 @@ public static class DepExtractor
         int slash = fileName.IndexOfAny(new[] { '/', '\\' });
         return slash > 0 ? fileName[..slash] : "";
     }
+
+    // Reusable regex for extracting `using <ns>;` directives from AL source.
+    private static readonly System.Text.RegularExpressions.Regex UsingDirectiveRegex =
+        new(@"^\s*using\s+([\w.]+)\s*;",
+            System.Text.RegularExpressions.RegexOptions.Multiline |
+            System.Text.RegularExpressions.RegexOptions.Compiled);
+
+    // Reusable regex for extracting `namespace <ns>;` or `namespace <ns> {` declarations.
+    private static readonly System.Text.RegularExpressions.Regex NamespaceDeclarationRegex =
+        new(@"^\s*namespace\s+([\w.]+)\s*[;{]",
+            System.Text.RegularExpressions.RegexOptions.Multiline |
+            System.Text.RegularExpressions.RegexOptions.Compiled);
+
+    /// <summary>
+    /// Tries to infer a namespace for an auto-generated stub by looking at which files
+    /// reference <paramref name="objectName"/> and collecting the <c>using</c> directives
+    /// from those files.
+    ///
+    /// Searches both <paramref name="allExtracted"/> (dep-source slice) and
+    /// <paramref name="extensionSources"/> (the extension's own AL files, which are not
+    /// part of the extracted slice but are the primary consumers of the missing dep).
+    ///
+    /// If all referencing files share a single common <c>using</c> namespace that is not
+    /// already declared by another file in the slice (which would cause AL0197), that
+    /// namespace is returned. Otherwise returns <c>null</c> (stub stays at global root).
+    ///
+    /// This fixes issue #1589: namespace-aware consumers cannot resolve root-namespace stubs.
+    /// </summary>
+    private static string? InferStubNamespace(
+        string objectName,
+        Dictionary<string, string> allExtracted,
+        IEnumerable<string>? extensionSources = null)
+    {
+        // Collect all namespaces already declared in the slice (to avoid AL0197 collisions).
+        var alreadyDeclaredNamespaces = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var (_, source) in allExtracted)
+        {
+            foreach (System.Text.RegularExpressions.Match m in NamespaceDeclarationRegex.Matches(source))
+                alreadyDeclaredNamespaces.Add(m.Groups[1].Value);
+        }
+
+        // For each file that references the object, collect its using namespaces.
+        // Only consider namespace-aware consumers (files that declare a namespace themselves).
+        HashSet<string>? candidateNamespaces = null;
+        bool anyNamespaceAwareConsumer = false;
+
+        // Build a combined stream of source texts to search: dep-slice + extension sources.
+        IEnumerable<string> allSources = allExtracted.Values;
+        if (extensionSources != null)
+            allSources = allSources.Concat(extensionSources);
+
+        foreach (var source in allSources)
+        {
+            if (!source.Contains(objectName, StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            // Only consider namespace-aware consumers.
+            var hasNamespace = NamespaceDeclarationRegex.IsMatch(source);
+            if (!hasNamespace) continue;
+
+            anyNamespaceAwareConsumer = true;
+
+            var fileUsings = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (System.Text.RegularExpressions.Match m in UsingDirectiveRegex.Matches(source))
+                fileUsings.Add(m.Groups[1].Value);
+
+            if (candidateNamespaces == null)
+                candidateNamespaces = new HashSet<string>(fileUsings, StringComparer.OrdinalIgnoreCase);
+            else
+                candidateNamespaces.IntersectWith(fileUsings);
+        }
+
+        if (!anyNamespaceAwareConsumer || candidateNamespaces == null || candidateNamespaces.Count == 0)
+            return null;
+
+        // Remove namespaces already declared in the slice to avoid AL0197 duplicates.
+        candidateNamespaces.ExceptWith(alreadyDeclaredNamespaces);
+        if (candidateNamespaces.Count == 0)
+            return null;
+
+        // If exactly one candidate remains, use it.
+        // If multiple remain, pick the most specific one (longest namespace string)
+        // as a conservative heuristic — shorter namespaces are more likely to be broad
+        // Microsoft.* base namespaces that the stub shouldn't pollute.
+        return candidateNamespaces.OrderByDescending(ns => ns.Length).First();
+    }
+
+    /// <summary>
+    /// Prepend a <c>namespace <paramref name="ns"/>;</c> declaration to a stub AL source string.
+    /// The BC compiler requires the namespace to appear before any object declarations.
+    /// </summary>
+    private static string WrapWithNamespace(string stubSource, string ns) =>
+        $"namespace {ns};\n{stubSource}";
 
     /// <summary>
     /// Returns the app directory of the first file in <paramref name="allExtracted"/> whose

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -13846,6 +13846,30 @@ DepExtractor.EnumAutoStubSyntheticValue:
     Tests: ExtractDeps_EnumStub_IncludesAtLeastOneValue_WhenBaseEnumIsAutoStubbed,
     ExtractDeps_ThenCompileDep_SucceedsWhenEnumExtensionBaseIsAutoStubbed.
 
+DepExtractor.StubNamespaceInference:
+  layer: syntax
+  category: extract-deps
+  status: covered
+  tests:
+    - AlRunner.Tests/DepExtractorTests.cs
+  notes: >
+    When extract-deps auto-stubs a missing object (enum, table, codeunit, etc.)
+    and the consumer source files that reference that object are namespace-aware
+    (declare a namespace and have using directives), the stub is emitted inside
+    the namespace shared by all those consumers rather than at global root.
+    A global-root stub is invisible to namespace-declaring consumers because the
+    BC compiler only resolves unqualified names from the current namespace and
+    explicitly imported (using) namespaces — AL0118 fires at compile-dep time.
+    Strategy A (emit a copy in every consumer namespace) was rejected in PR #1521
+    due to AL0197 cascade errors; this implementation picks at most ONE namespace
+    (the intersection of all consumer using directives, longest wins on tie).
+    Falls back to global root when there is no shared using candidate or when
+    all candidates are already declared in the slice (avoiding AL0197).
+    Implemented in DepExtractor.InferStubNamespace + WrapWithNamespace.
+    Fixes issue #1589.
+    Tests: ExtractDeps_EnumStub_EmittedInConsumerUsingNamespace_WhenNamespaceAwareConsumer,
+    ExtractDeps_EnumStub_StaysAtGlobalRoot_WhenConsumerHasNoUsingDirectives.
+
 # ── Library Management gaps: BC-faithful error formats + ATL stub override ──
 
 Pipeline.LoadAssertStubs.SymbolOverlapDetection:

--- a/tests/bucket-1/codeunit-runtime/46-namespace-stub-visibility/src/EnumPrinter.al
+++ b/tests/bucket-1/codeunit-runtime/46-namespace-stub-visibility/src/EnumPrinter.al
@@ -1,0 +1,34 @@
+// Issue #1589: namespace-aware consumers must be able to reference
+// an enum that lives in a specific namespace.
+// This src codeunit is in namespace MySales.Document and exposes
+// the enum for use by consumers that import that namespace.
+
+namespace MySales.Document;
+
+enum 50540 "Print Option"
+{
+    Extensible = false;
+    value(0; None) { Caption = 'None'; }
+    value(1; Draft) { Caption = 'Draft'; }
+    value(2; Final) { Caption = 'Final'; }
+}
+
+codeunit 50541 "Print Option Helper"
+{
+    procedure GetDefault(): Enum "Print Option"
+    var
+        Opt: Enum "Print Option";
+    begin
+        exit(Opt);
+    end;
+
+    procedure GetFinal(): Enum "Print Option"
+    begin
+        exit(Enum::"Print Option"::Final);
+    end;
+
+    procedure GetOrdinal(Opt: Enum "Print Option"): Integer
+    begin
+        exit(Opt.AsInteger());
+    end;
+}

--- a/tests/bucket-1/codeunit-runtime/46-namespace-stub-visibility/test/EnumPrinterTest.al
+++ b/tests/bucket-1/codeunit-runtime/46-namespace-stub-visibility/test/EnumPrinterTest.al
@@ -1,0 +1,51 @@
+// Issue #1589: A namespace-aware test codeunit that imports MySales.Document
+// must resolve the unqualified "Print Option" enum declared in that namespace.
+// Before the fix, auto-stubs were emitted at global root — an AL0118 error
+// would fire when the consumer tried to use the enum via a using directive.
+
+namespace MySales.Tests;
+
+using MySales.Document;
+
+codeunit 50542 "Print Option Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    [Test]
+    procedure DefaultOptionIsNone()
+    var
+        Helper: Codeunit "Print Option Helper";
+        Opt: Enum "Print Option";
+    begin
+        // [GIVEN] A default enum value (ordinal 0)
+        // [WHEN] GetDefault is called
+        Opt := Helper.GetDefault();
+        // [THEN] the ordinal must be 0 (None)
+        Assert.AreEqual(0, Opt.AsInteger(), 'Default option must be None (ordinal 0)');
+    end;
+
+    [Test]
+    procedure FinalOptionOrdinalIsTwo()
+    var
+        Helper: Codeunit "Print Option Helper";
+        Opt: Enum "Print Option";
+    begin
+        // [GIVEN] The Final enum value
+        Opt := Helper.GetFinal();
+        // [THEN] its ordinal must be 2
+        Assert.AreEqual(2, Helper.GetOrdinal(Opt), 'Final option ordinal must be 2');
+    end;
+
+    [Test]
+    procedure DefaultIsNotFinal()
+    var
+        Helper: Codeunit "Print Option Helper";
+    begin
+        // [GIVEN/WHEN] default and final enum values differ
+        // [THEN] their ordinals are different (negative: not equal to 2)
+        Assert.AreNotEqual(2, Helper.GetDefault().AsInteger(), 'Default option must not be Final');
+    end;
+}


### PR DESCRIPTION
Closes #1589

## Summary

- Auto-stubs generated by `extract-deps` were emitted at global root (no namespace declaration), making them invisible to namespace-aware consumer files that reference the stubbed object via an unqualified name (e.g. `Enum "Sales Order Print Option"` inside `namespace Microsoft.Foundation.Reporting;`).
- The BC compiler only resolves unqualified names from the current namespace and explicitly `using`-imported namespaces — a global-root stub is silently ignored, producing AL0118 at compile-dep time.
- Adds `InferStubNamespace` in `DepExtractor.cs`: inspects `using` directives of all namespace-aware consumer files (both extension sources and extracted dep-slice files) that reference the missing object name. If all such consumers share a single candidate using-namespace not already declared in the slice, the stub is wrapped in that namespace via `WrapWithNamespace`. Falls back to global root otherwise, preserving prior behaviour and avoiding AL0197 cascades (the rejected strategy A from PR #1521).

## Tests added

- `ExtractDeps_EnumStub_EmittedInConsumerUsingNamespace_WhenNamespaceAwareConsumer` — positive: a namespace-aware consumer with `using MySales.Document;` that references a missing enum causes the auto-stub to be emitted inside `namespace MySales.Document;`.
- `ExtractDeps_EnumStub_StaysAtGlobalRoot_WhenConsumerHasNoUsingDirectives` — negative: a consumer without a namespace declaration causes the stub to stay at global root (no namespace wrapping).

## Coverage

Added `DepExtractor.StubNamespaceInference` entry to `docs/coverage.yaml`.