### PR TITLE
fix: skip AL string literals when counting braces in StripPatternedBlock/StripNamedBlock

### DIFF
--- a/AlRunner/Pipeline.cs
+++ b/AlRunner/Pipeline.cs
@@ -1233,25 +1233,15 @@ public class AlRunnerPipeline
             if (openBrace < 0)
                 break;
 
-            // Brace-depth counting to find the matching closing brace.
-            int depth = 0;
-            int i = openBrace;
-            for (; i < source.Length; i++)
-            {
-                if (source[i] == '{')
-                    depth++;
-                else if (source[i] == '}')
-                {
-                    depth--;
-                    if (depth == 0)
-                        break;
-                }
-            }
-
-            if (i >= source.Length)
+            // Brace-depth counting respects AL single-quoted string literals and
+            // line comments so that a '}' inside e.g. ToolTip = 'Upload } a file'
+            // does not prematurely stop the scan and corrupt subsequent source.
+            // (issue #1600: fileupload block with '}' in ToolTip string)
+            int closeBrace = FindMatchingCloseBrace(source, openBrace);
+            if (closeBrace < 0)
                 break;
 
-            source = source.Substring(0, blockStart) + source.Substring(i + 1);
+            source = source.Substring(0, blockStart) + source.Substring(closeBrace + 1);
             // Don't advance searchIndex so we catch multiple consecutive blocks.
         }
 
@@ -1274,34 +1264,89 @@ public class AlRunnerPipeline
             if (openBrace < 0)
                 break;
 
-            // Simple brace-depth counting. Does not skip braces inside
-            // single-quoted AL string literals or comments, so a caption like
-            //   Caption = 'Some {brace} text'
-            // would confuse the counter. This is acceptable for `rendering`
-            // blocks which don't contain string literals with braces.
-            int depth = 0;
-            int i = openBrace;
-            for (; i < source.Length; i++)
-            {
-                if (source[i] == '{')
-                    depth++;
-                else if (source[i] == '}')
-                {
-                    depth--;
-                    if (depth == 0)
-                        break;
-                }
-            }
-
-            if (i >= source.Length)
+            // Brace-depth counting respects AL single-quoted string literals and
+            // line comments so that a '}' inside e.g. Caption = 'Some } text'
+            // does not prematurely stop the scan and corrupt subsequent source.
+            // (issue #1600: consistent fix for both StripPatternedBlock and StripNamedBlock)
+            int closeBrace = FindMatchingCloseBrace(source, openBrace);
+            if (closeBrace < 0)
                 break;
 
             var replacement = $"{blockName}{Environment.NewLine}{{{Environment.NewLine}}}";
-            source = source.Substring(0, blockStart) + replacement + source.Substring(i + 1);
+            source = source.Substring(0, blockStart) + replacement + source.Substring(closeBrace + 1);
             searchIndex = blockStart + replacement.Length;
         }
 
         return source;
+    }
+
+    /// <summary>
+    /// Given a source string and the index of an opening <c>'{'</c>, returns the index of
+    /// the matching closing <c>'}'</c> using brace-depth counting that correctly skips AL
+    /// single-quoted string literals (<c>'...'</c>) and line comments (<c>//...</c>).
+    ///
+    /// Braces inside string literals or comments do not affect the depth counter, so a
+    /// property value like <c>ToolTip = 'Upload } a file';</c> does not prematurely stop
+    /// the scan. Without this, <see cref="StripPatternedBlock"/> and
+    /// <see cref="StripNamedBlock"/> would corrupt the source after the stripped block,
+    /// producing AL0104/AL0124 parse errors at unrelated <c>part()</c> declarations.
+    /// (issue #1600)
+    ///
+    /// Returns -1 if no matching close brace is found before the end of the string.
+    /// </summary>
+    private static int FindMatchingCloseBrace(string source, int openBraceIndex)
+    {
+        int depth = 0;
+        int i = openBraceIndex;
+        while (i < source.Length)
+        {
+            char c = source[i];
+
+            // Skip single-quoted AL string literals ('...').
+            // AL represents a literal single-quote inside a string as '' (doubled).
+            if (c == '\'')
+            {
+                i++;
+                while (i < source.Length)
+                {
+                    if (source[i] == '\'')
+                    {
+                        // Doubled single-quote '' is an escaped quote inside the literal.
+                        if (i + 1 < source.Length && source[i + 1] == '\'')
+                            i += 2; // skip both quotes and stay inside the string
+                        else
+                        {
+                            i++; // skip the closing quote and exit the string
+                            break;
+                        }
+                    }
+                    else
+                        i++;
+                }
+                continue;
+            }
+
+            // Skip line comments (//...\n).
+            if (c == '/' && i + 1 < source.Length && source[i + 1] == '/')
+            {
+                i += 2;
+                while (i < source.Length && source[i] != '\n')
+                    i++;
+                continue;
+            }
+
+            if (c == '{')
+                depth++;
+            else if (c == '}')
+            {
+                depth--;
+                if (depth == 0)
+                    return i;
+            }
+
+            i++;
+        }
+        return -1; // unmatched open brace
     }
 
     // Regex to detect extension object declarations: captures type and name.

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -921,6 +921,23 @@ fileuploadaction_declaration:
   tests:
     - tests/bucket-2/page-report/206-fileupload-action
 
+fileupload_brace_in_string_strip:
+  layer: syntax
+  category: page
+  status: covered
+  notes: >
+    Pipeline.StripPatternedBlock() and StripNamedBlock() used a naive brace-depth counter
+    that did not skip AL single-quoted string literals or line comments. A '}' inside a
+    property string like ToolTip = 'Upload } a document' caused the scanner to stop too
+    early, leaving the actual closing '}' of the fileupload block in the source. This
+    corrupted subsequent part(UnquotedName; "Page Name With Spaces") declarations,
+    producing AL0104/AL0124 parse errors ("The property 'X' cannot be used in this
+    context") at the quoted page-reference start position.
+    Fixed in issue #1600 by FindMatchingCloseBrace() which properly skips string literals
+    (handling escaped '' within strings) and // line comments.
+  tests:
+    - tests/bucket-2/page-report/314200-page-part-quoted-name
+
 grid_section:
   layer: syntax
   category: page

--- a/tests/bucket-2/page-report/314200-page-part-quoted-name/src/QuotedPartPage.al
+++ b/tests/bucket-2/page-report/314200-page-part-quoted-name/src/QuotedPartPage.al
@@ -1,0 +1,112 @@
+// Regression test for issue #1600.
+// A page with:
+//   - fileupload() block containing '}' inside a string literal (the bug trigger)
+//   - part(UnquotedName; "Page Name With Spaces") declarations (the affected area)
+//   - angle-bracket action identifiers like group("<Action...>") (from the reporter's file)
+//
+// Before the fix, StripPatternedBlock's brace-depth counter did not skip AL
+// single-quoted string literals. A '}' inside a ToolTip/Caption like
+//   ToolTip = 'Upload } a document';
+// caused the scanner to stop too early, stripping only part of the fileupload
+// block and leaving the closing '}' in the source. This corrupted subsequent
+// part() declarations, producing AL0104/AL0124 parse errors.
+//
+// The fix (FindMatchingCloseBrace) properly skips single-quoted string literals
+// and line comments when scanning for the matching closing brace.
+page 1320200 "Quoted Part Host Page"
+{
+    PageType = Card;
+
+    layout
+    {
+        area(Content)
+        {
+            field(DummyField; '')
+            {
+                ApplicationArea = All;
+                Caption = 'Info';
+            }
+        }
+        area(FactBoxes)
+        {
+            // These two parts use the exact syntax pattern from the reporter's file:
+            // unquoted control name, double-quoted page reference with spaces.
+            part(QuotedPartFactboxA; "Quoted Part Factbox A")
+            {
+                ApplicationArea = All;
+            }
+            part(QuotedPartFactboxB; "Quoted Part Factbox B")
+            {
+                ApplicationArea = All;
+            }
+        }
+    }
+
+    actions
+    {
+        area(Processing)
+        {
+            // fileupload() is stripped by PrepareSourceForStandalone.
+            // The ToolTip contains a '}' character — this is the trigger for the
+            // old brace-counting bug: the naive counter would stop at this '}' and
+            // leave the actual closing '}' of the fileupload block in the source,
+            // corrupting the part() declarations that follow.
+            fileupload(DocUpload)
+            {
+                ToolTip = 'Click to upload } a document';
+                ApplicationArea = All;
+            }
+            // Angle-bracket identifiers exactly as in the reporter's CheckLABTestResults.page.al
+            group("<Action1000000017>")
+            {
+                Caption = 'Functions';
+                action("<Action1000000043>")
+                {
+                    Caption = 'Do Something';
+                    ApplicationArea = All;
+
+                    trigger OnAction()
+                    begin
+                        CurrPage.Update(false);
+                    end;
+                }
+            }
+        }
+    }
+}
+
+// Two minimal factbox pages whose names contain spaces — the exact pattern
+// that was misidentified as a parse error by the corrupted source.
+page 1320201 "Quoted Part Factbox A"
+{
+    PageType = ListPart;
+
+    layout
+    {
+        area(Content)
+        {
+            field(InfoA; 'FactboxA')
+            {
+                ApplicationArea = All;
+                Caption = 'Info A';
+            }
+        }
+    }
+}
+
+page 1320202 "Quoted Part Factbox B"
+{
+    PageType = ListPart;
+
+    layout
+    {
+        area(Content)
+        {
+            field(InfoB; 'FactboxB')
+            {
+                ApplicationArea = All;
+                Caption = 'Info B';
+            }
+        }
+    }
+}

--- a/tests/bucket-2/page-report/314200-page-part-quoted-name/test/QuotedPartTest.al
+++ b/tests/bucket-2/page-report/314200-page-part-quoted-name/test/QuotedPartTest.al
@@ -1,0 +1,72 @@
+// Tests for issue #1600: page part with double-quoted page reference containing spaces
+// when the same page also has a fileupload block with '}' inside a string literal.
+//
+// Root cause: StripPatternedBlock's brace-depth counter did not skip AL single-quoted
+// string literals. A '}' inside ToolTip = 'Upload } a file' caused the scanner to stop
+// prematurely, corrupting the source after the fileupload block. The subsequent
+// part(UnquotedName; "Page Name With Spaces") declarations then produced AL0104/AL0124
+// parse errors because the quoted page reference appeared to start mid-expression.
+//
+// Fix: FindMatchingCloseBrace skips single-quoted strings and line comments.
+codeunit 1320203 "Quoted Part Test"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    /// <summary>
+    /// RED test: before the fix, StripPatternedBlock stopped at the '}' inside
+    /// ToolTip = 'Upload } a document', leaving the actual closing '}' of the
+    /// fileupload block in the source. The AL parser then reported AL0104/AL0124
+    /// at the part() declarations: "The property 'Quoted' cannot be used..."
+    /// GREEN test: FindMatchingCloseBrace skips the string-literal brace, so
+    /// the fileupload block is stripped correctly and part() declarations parse fine.
+    /// </summary>
+    [Test]
+    procedure Page_FileuploadBraceInString_PartWithSpacesParses_IsNoOp()
+    var
+        TestPage: TestPage "Quoted Part Host Page";
+    begin
+        // [GIVEN] A page with:
+        //         - fileupload() block whose ToolTip contains '}' inside a string
+        //         - part(QuotedPartFactboxA; "Quoted Part Factbox A") declarations
+        //         - angle-bracket group/action identifiers
+        // [WHEN]  The page is opened as a TestPage
+        TestPage.OpenView();
+        // [THEN]  No AL0104/AL0124 parse errors: the fileupload block was stripped
+        //         with correct brace matching (string-literal brace skipped), and the
+        //         quoted part page references were parsed as identifiers, not split.
+        TestPage.Close();
+        Assert.IsTrue(true, 'Page with fileupload ToolTip-brace + quoted part refs must open without parse errors');
+    end;
+
+    [Test]
+    procedure FactboxA_QuotedNameWithSpaces_CompilesStandalone_IsNoOp()
+    var
+        TestPage: TestPage "Quoted Part Factbox A";
+    begin
+        // [GIVEN] "Quoted Part Factbox A" — referenced by the host via
+        //         part(QuotedPartFactboxA; "Quoted Part Factbox A")
+        // [WHEN]  Opened directly as a TestPage
+        TestPage.OpenView();
+        // [THEN]  The page with spaces in its name compiles and opens.
+        //         This verifies the double-quoted identifier with spaces is correctly
+        //         parsed as a page name, not split into separate tokens.
+        TestPage.Close();
+        Assert.IsTrue(true, 'Factbox page "Quoted Part Factbox A" must compile with spaces in name');
+    end;
+
+    [Test]
+    procedure FactboxB_QuotedNameWithSpaces_CompilesStandalone_IsNoOp()
+    var
+        TestPage: TestPage "Quoted Part Factbox B";
+    begin
+        // [GIVEN] "Quoted Part Factbox B" — second factbox referenced by host
+        // [WHEN]  Opened as a TestPage
+        TestPage.OpenView();
+        // [THEN]  Second page with spaces also compiles correctly.
+        TestPage.Close();
+        Assert.IsTrue(true, 'Factbox page "Quoted Part Factbox B" must compile with spaces in name');
+    end;
+}


### PR DESCRIPTION
Closes #1600

## Root cause

`StripPatternedBlock()` (used to strip `fileupload()` blocks) and `StripNamedBlock()` (used for `rendering` blocks) both used a naive brace-depth counter that did not skip AL single-quoted string literals or comments.

A `}` inside a property string such as:
```al
fileupload(DocUpload)
{
    ToolTip = 'Click to upload } a document';
}
```

caused the scanner to stop counting at the `}` inside the string literal, leaving the actual closing `}` of the `fileupload` block in the source. Everything from that `}` onward was shifted backward, corrupting subsequent `part(UnquotedName; "Page Name With Spaces")` declarations. The AL parser then saw the page reference `"Attestzinnen per Soort Factbox"` starting mid-expression and reported:

```
(79,75): error AL0104: Syntax error, ')' expected
(79,75): error AL0124: The property 'Actiezinnen' cannot be used in this context
```

## Fix

Introduces `FindMatchingCloseBrace(source, openBraceIndex)` which properly skips:
- AL single-quoted string literals `'...'` (with `''` escape for embedded quotes inside the string)
- `//` line comments

Both `StripPatternedBlock` and `StripNamedBlock` now use `FindMatchingCloseBrace()` instead of the naive brace counter.

## Test

New test suite `314200-page-part-quoted-name`:
- **src**: A page with a `fileupload()` block containing `ToolTip = 'Click to upload } a document'` followed by `part(QuotedPartFactboxA; "Quoted Part Factbox A")` declarations and angle-bracket action identifiers `group("<Action1000000017>")` — the exact pattern from the reporter's `CheckLABTestResults.page.al`
- **test**: 3 tests confirming the host page and both factbox pages compile and open without AL0104/AL0124 parse errors

Confirmed RED (AL0104/AL0124 parse errors at the `part()` declarations) without the fix, GREEN (3 passed) with it.