### PR TITLE
feat(protocol): add protocol-v2 schema + type definitions

### DIFF
--- a/AlRunner/AlStackFrame.cs
+++ b/AlRunner/AlStackFrame.cs
@@ -1,0 +1,28 @@
+namespace AlRunner;
+
+public enum FramePresentationHint
+{
+    Normal,
+    Subtle,
+    Deemphasize,
+    Label
+}
+
+public enum AlErrorKind
+{
+    Assertion,
+    Runtime,
+    Compile,
+    Setup,
+    Timeout,
+    Unknown
+}
+
+public record AlStackFrame(
+    string? File,
+    int? Line,
+    int? Column,
+    bool IsUserCode,
+    string? Name,
+    FramePresentationHint Hint
+);

--- a/AlRunner/TestFilter.cs
+++ b/AlRunner/TestFilter.cs
@@ -1,0 +1,11 @@
+namespace AlRunner;
+
+/// <summary>
+/// Filter passed to <see cref="Executor.RunTests"/> to limit which tests execute.
+/// Both fields are optional; nulls = no constraint.
+/// When both are set, a test must match both filters (AND).
+/// </summary>
+public record TestFilter(
+    IReadOnlySet<string>? CodeunitNames,
+    IReadOnlySet<string>? ProcNames
+);

--- a/protocol-v2.schema.json
+++ b/protocol-v2.schema.json
@@ -1,0 +1,148 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/StefanMaron/BusinessCentral.AL.Runner/schemas/protocol-v2.json",
+  "title": "AL.Runner Server Protocol v2",
+  "description": "Newline-delimited JSON. A `runtests` request emits zero or more `test` lines, optional `progress` lines, then exactly one `summary` line. Each line is a separate JSON document.",
+  "definitions": {
+    "AlStackFrame": {
+      "type": "object",
+      "required": ["name"],
+      "properties": {
+        "name": { "type": "string" },
+        "source": {
+          "type": "object",
+          "properties": {
+            "path": { "type": "string" },
+            "name": { "type": "string" }
+          }
+        },
+        "line": { "type": "integer", "minimum": 1 },
+        "column": { "type": "integer", "minimum": 1 },
+        "presentationHint": {
+          "type": "string",
+          "enum": ["normal", "subtle", "deemphasize", "label"]
+        }
+      }
+    },
+    "ErrorKind": {
+      "type": "string",
+      "enum": ["assertion", "runtime", "compile", "setup", "timeout", "unknown"]
+    },
+    "TestEvent": {
+      "type": "object",
+      "required": ["type", "name", "status"],
+      "properties": {
+        "type": { "const": "test" },
+        "name": { "type": "string" },
+        "status": { "enum": ["pass", "fail", "error"] },
+        "durationMs": { "type": "integer", "minimum": 0 },
+        "message": { "type": "string" },
+        "errorKind": { "$ref": "#/definitions/ErrorKind" },
+        "alSourceFile": { "type": "string" },
+        "alSourceLine": { "type": "integer", "minimum": 1 },
+        "alSourceColumn": { "type": "integer", "minimum": 1 },
+        "stackFrames": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/AlStackFrame" }
+        },
+        "stackTrace": { "type": "string" },
+        "messages": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "capturedValues": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "scopeName": { "type": "string" },
+              "variableName": { "type": "string" },
+              "value": {},
+              "statementId": { "type": "integer" }
+            }
+          }
+        }
+      }
+    },
+    "FileCoverage": {
+      "type": "object",
+      "required": ["file", "lines", "totalStatements", "hitStatements"],
+      "properties": {
+        "file": { "type": "string" },
+        "lines": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["line", "hits"],
+            "properties": {
+              "line": { "type": "integer", "minimum": 1 },
+              "hits": { "type": "integer", "minimum": 0 }
+            }
+          }
+        },
+        "totalStatements": { "type": "integer", "minimum": 0 },
+        "hitStatements": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "Summary": {
+      "type": "object",
+      "required": ["type", "exitCode", "passed", "failed", "errors", "total", "protocolVersion"],
+      "properties": {
+        "type": { "const": "summary" },
+        "exitCode": { "type": "integer" },
+        "passed": { "type": "integer", "minimum": 0 },
+        "failed": { "type": "integer", "minimum": 0 },
+        "errors": { "type": "integer", "minimum": 0 },
+        "total": { "type": "integer", "minimum": 0 },
+        "cached": { "type": "boolean" },
+        "cancelled": { "type": "boolean" },
+        "changedFiles": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "compilationErrors": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "file": { "type": "string" },
+              "errors": {
+                "type": "array",
+                "items": { "type": "string" }
+              }
+            }
+          }
+        },
+        "coverage": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/FileCoverage" }
+        },
+        "protocolVersion": { "const": 2 }
+      }
+    },
+    "Ack": {
+      "type": "object",
+      "required": ["type", "command"],
+      "properties": {
+        "type": { "const": "ack" },
+        "command": { "type": "string" },
+        "noop": { "type": "boolean" }
+      }
+    },
+    "Progress": {
+      "type": "object",
+      "required": ["type"],
+      "properties": {
+        "type": { "const": "progress" },
+        "completed": { "type": "integer", "minimum": 0 },
+        "total": { "type": "integer", "minimum": 0 }
+      }
+    }
+  },
+  "oneOf": [
+    { "$ref": "#/definitions/TestEvent" },
+    { "$ref": "#/definitions/Summary" },
+    { "$ref": "#/definitions/Ack" },
+    { "$ref": "#/definitions/Progress" }
+  ]
+}


### PR DESCRIPTION
## Summary

PR 1 of 9 — Protocol v2 split per [#1568 review](https://github.com/StefanMaron/BusinessCentral.AL.Runner/pull/1568#issuecomment-4274937532).

Pure additions — no existing files modified.

- `protocol-v2.schema.json` — shared type definitions for the AL.Runner ↔ ALchemist protocol v2 wire format
- `AlRunner/AlStackFrame.cs` — `AlStackFrame` record (DAP-aligned), `AlErrorKind` enum, `FramePresentationHint` enum
- `AlRunner/TestFilter.cs` — `TestFilter` record for narrowing test runs by codeunit/procedure name

These types are the foundation for PRs 2–9. No behavioral change to existing code.

Closes #10 (partial — protocol v2 layer 1/9)

## PR stack

1. **→ This PR** — schema + types
2. `StackFrameMapper` — exception → structured frames
3. `ErrorClassifier` — exception → error-kind enum
4. `CoverageReport.ToJson` — structured coverage for inline emission
5. `#line` directive injector + portable PDB
6. `Executor.RunTests` revised — filter, streaming, cancellation
7. Server `cancel` command
8. Server NDJSON streaming + protocol v2
9. Per-capture `alSourceFile` + iteration fixes

## Test plan

- [ ] CI green — pure additions, no existing tests affected
- [ ] Schema validates (consumed by PR 8's schema validation test)