### PR TITLE
feat(runtime): add ErrorClassifier — Exception → AlErrorKind heuristics

### DIFF
--- a/AlRunner.Tests/ErrorClassifierTests.cs
+++ b/AlRunner.Tests/ErrorClassifierTests.cs
@@ -1,14 +1,17 @@
-using AlRunner;
+using AlRunner.Runtime;
 using Xunit;
 
 namespace AlRunner.Tests;
 
 public class ErrorClassifierTests
 {
+    // ----- Original tests (retained / upgraded) -----
+
     [Fact]
     public void Classify_AssertionException_IsAssertion()
     {
-        var ex = new MockAssertException("expected 1 got 2");
+        // Uses the real AlRunner.Runtime.AssertException — the type actually thrown by MockAssert.
+        var ex = new AssertException("expected 1 got 2");
         var ctx = new TestExecutionContext(InsideTestProc: true);
         Assert.Equal(AlErrorKind.Assertion, ErrorClassifier.Classify(ex, ctx));
     }
@@ -24,7 +27,7 @@ public class ErrorClassifierTests
     [Fact]
     public void Classify_CompilationFailedException_IsCompile()
     {
-        var ex = new CompilationFailedExceptionStub("compile error");
+        var ex = new MyDomainCompilationFailedException("compile error");
         var ctx = new TestExecutionContext(InsideTestProc: true);
         Assert.Equal(AlErrorKind.Compile, ErrorClassifier.Classify(ex, ctx));
     }
@@ -49,16 +52,94 @@ public class ErrorClassifierTests
     public void Classify_NullException_IsUnknown()
     {
         var ctx = new TestExecutionContext(InsideTestProc: true);
-        Assert.Equal(AlErrorKind.Unknown, ErrorClassifier.Classify(null!, ctx));
+        Assert.Equal(AlErrorKind.Unknown, ErrorClassifier.Classify(null, ctx));
     }
 
-    private sealed class MockAssertException : Exception
+    // ----- New branch-coverage tests -----
+
+    [Fact]
+    public void Classify_AssertionExceptionEnding_IsAssertion()
     {
-        public MockAssertException(string m) : base(m) { }
+        // Verifies the EndsWith("AssertException") branch fires on its own.
+        var ex = new MyDomainAssertException("oops");
+        var ctx = new TestExecutionContext(InsideTestProc: true);
+        Assert.Equal(AlErrorKind.Assertion, ErrorClassifier.Classify(ex, ctx));
     }
 
-    private sealed class CompilationFailedExceptionStub : Exception
+    [Fact]
+    public void Classify_AssertionExceptionFullSuffix_IsAssertion()
     {
-        public CompilationFailedExceptionStub(string m) : base(m) { }
+        // Verifies the EndsWith("AssertionException") branch fires.
+        var ex = new MyDomainAssertionException("oops");
+        var ctx = new TestExecutionContext(InsideTestProc: true);
+        Assert.Equal(AlErrorKind.Assertion, ErrorClassifier.Classify(ex, ctx));
+    }
+
+    [Fact]
+    public void Classify_TaskCanceledException_IsTimeout()
+    {
+        // TaskCanceledException is a subclass of OperationCanceledException — most common cancellation type in .NET.
+        var ex = new TaskCanceledException("cancelled");
+        var ctx = new TestExecutionContext(InsideTestProc: true);
+        Assert.Equal(AlErrorKind.Timeout, ErrorClassifier.Classify(ex, ctx));
+    }
+
+    [Fact]
+    public void Classify_OperationCanceledDuringSetup_IsTimeoutNotSetup()
+    {
+        // Pins ordering: timeout takes precedence over the InsideTestProc gate.
+        var ex = new OperationCanceledException("cancelled in setup");
+        var ctx = new TestExecutionContext(InsideTestProc: false);
+        Assert.Equal(AlErrorKind.Timeout, ErrorClassifier.Classify(ex, ctx));
+    }
+
+    [Fact]
+    public void Classify_CompileErrorEnding_IsCompile()
+    {
+        var ex = new MyDomainCompileErrorException("bad emit");
+        var ctx = new TestExecutionContext(InsideTestProc: true);
+        Assert.Equal(AlErrorKind.Compile, ErrorClassifier.Classify(ex, ctx));
+    }
+
+    [Fact]
+    public void Classify_AggregateExceptionWrappingAssertion_IsRuntime()
+    {
+        // Documents that unwrapping AggregateException is the caller's job.
+        // Future change: if Executor unwraps before classifying, this expectation moves.
+        var inner = new MyDomainAssertException("inner");
+        var ex = new AggregateException(inner);
+        var ctx = new TestExecutionContext(InsideTestProc: true);
+        Assert.Equal(AlErrorKind.Runtime, ErrorClassifier.Classify(ex, ctx));
+    }
+
+    [Fact]
+    public void Classify_BareException_DuringTest_IsRuntime()
+    {
+        // Verifies the default-Runtime fallthrough on the base Exception type.
+        var ex = new Exception("base");
+        var ctx = new TestExecutionContext(InsideTestProc: true);
+        Assert.Equal(AlErrorKind.Runtime, ErrorClassifier.Classify(ex, ctx));
+    }
+
+    // ----- Private stubs (name-based matching only) -----
+
+    private sealed class MyDomainAssertException : Exception
+    {
+        public MyDomainAssertException(string m) : base(m) { }
+    }
+
+    private sealed class MyDomainAssertionException : Exception
+    {
+        public MyDomainAssertionException(string m) : base(m) { }
+    }
+
+    private sealed class MyDomainCompilationFailedException : Exception
+    {
+        public MyDomainCompilationFailedException(string m) : base(m) { }
+    }
+
+    private sealed class MyDomainCompileErrorException : Exception
+    {
+        public MyDomainCompileErrorException(string m) : base(m) { }
     }
 }

--- a/AlRunner.Tests/ErrorClassifierTests.cs
+++ b/AlRunner.Tests/ErrorClassifierTests.cs
@@ -1,0 +1,64 @@
+using AlRunner;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public class ErrorClassifierTests
+{
+    [Fact]
+    public void Classify_AssertionException_IsAssertion()
+    {
+        var ex = new MockAssertException("expected 1 got 2");
+        var ctx = new TestExecutionContext(InsideTestProc: true);
+        Assert.Equal(AlErrorKind.Assertion, ErrorClassifier.Classify(ex, ctx));
+    }
+
+    [Fact]
+    public void Classify_OperationCanceled_IsTimeout()
+    {
+        var ex = new OperationCanceledException("test exceeded timeout");
+        var ctx = new TestExecutionContext(InsideTestProc: true);
+        Assert.Equal(AlErrorKind.Timeout, ErrorClassifier.Classify(ex, ctx));
+    }
+
+    [Fact]
+    public void Classify_CompilationFailedException_IsCompile()
+    {
+        var ex = new CompilationFailedExceptionStub("compile error");
+        var ctx = new TestExecutionContext(InsideTestProc: true);
+        Assert.Equal(AlErrorKind.Compile, ErrorClassifier.Classify(ex, ctx));
+    }
+
+    [Fact]
+    public void Classify_GenericException_DuringSetup_IsSetup()
+    {
+        var ex = new InvalidOperationException("setup failed");
+        var ctx = new TestExecutionContext(InsideTestProc: false);
+        Assert.Equal(AlErrorKind.Setup, ErrorClassifier.Classify(ex, ctx));
+    }
+
+    [Fact]
+    public void Classify_GenericException_DuringTest_IsRuntime()
+    {
+        var ex = new InvalidOperationException("runtime error");
+        var ctx = new TestExecutionContext(InsideTestProc: true);
+        Assert.Equal(AlErrorKind.Runtime, ErrorClassifier.Classify(ex, ctx));
+    }
+
+    [Fact]
+    public void Classify_NullException_IsUnknown()
+    {
+        var ctx = new TestExecutionContext(InsideTestProc: true);
+        Assert.Equal(AlErrorKind.Unknown, ErrorClassifier.Classify(null!, ctx));
+    }
+
+    private sealed class MockAssertException : Exception
+    {
+        public MockAssertException(string m) : base(m) { }
+    }
+
+    private sealed class CompilationFailedExceptionStub : Exception
+    {
+        public CompilationFailedExceptionStub(string m) : base(m) { }
+    }
+}

--- a/AlRunner.Tests/StackFrameMapperTests.cs
+++ b/AlRunner.Tests/StackFrameMapperTests.cs
@@ -116,6 +116,55 @@ public class StackFrameMapperTests
             StackFrameMapper.ClassifyHint(null, null));
     }
 
+    [Fact]
+    public void ClassifyHint_AlScopeRuntimeIsSubtle()
+    {
+        Assert.Equal(FramePresentationHint.Subtle,
+            StackFrameMapper.ClassifyHint("scope.cs", "AlRunner.Runtime.AlScope.Push"));
+    }
+
+    [Fact]
+    public void ClassifyHint_UserMethodNamedMock_IsNotSubtle()
+    {
+        // Regression: previous heuristics had a bare "Mock" prefix rule that would dim
+        // legitimate user code whose qualified name happened to start with "Mock".
+        var hint = StackFrameMapper.ClassifyHint("src/MockAccountTest.al", "Acme.MockAccountTest.Run");
+        Assert.Equal(FramePresentationHint.Normal, hint);
+    }
+
+    [Fact]
+    public void ClassifyHint_NullFileWithUserMethod_IsDeemphasize()
+    {
+        Assert.Equal(FramePresentationHint.Deemphasize,
+            StackFrameMapper.ClassifyHint(null, "MainApp.Foo.Bar"));
+    }
+
+    [Fact]
+    public void Walk_UppercaseAlExtensionIsUserCode()
+    {
+        var trace = "   at Foo.Bar() in src/Foo.AL:line 5\n";
+        var ex = MakeExceptionWithStackTrace(trace);
+        var frames = StackFrameMapper.Walk(ex);
+        Assert.Single(frames);
+        Assert.True(frames[0].IsUserCode);
+        Assert.Equal(FramePresentationHint.Normal, frames[0].Hint);
+    }
+
+    [Fact]
+    public void Walk_MultipleFramesPreserveOrder()
+    {
+        var trace =
+            "   at Foo.Bar() in src/A.al:line 1\n" +
+            "   at Foo.Baz() in src/B.al:line 2\n" +
+            "   at Foo.Qux() in src/C.al:line 3\n";
+        var ex = MakeExceptionWithStackTrace(trace);
+        var frames = StackFrameMapper.Walk(ex);
+        Assert.Equal(3, frames.Count);
+        Assert.Equal("src/A.al", frames[0].File);
+        Assert.Equal("src/B.al", frames[1].File);
+        Assert.Equal("src/C.al", frames[2].File);
+    }
+
     private static Exception MakeExceptionWithStackTrace(string trace)
         => new ExceptionWithFakeStackTrace(trace);
 

--- a/AlRunner.Tests/StackFrameMapperTests.cs
+++ b/AlRunner.Tests/StackFrameMapperTests.cs
@@ -1,0 +1,125 @@
+using AlRunner;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public class StackFrameMapperTests
+{
+    [Fact]
+    public void Walk_ParsesAlFilenames_AsUserCode()
+    {
+        var trace = "   at Foo.Bar.RunTest() in src/Foo.al:line 42\n";
+        var ex = MakeExceptionWithStackTrace(trace);
+        var frames = StackFrameMapper.Walk(ex);
+        Assert.Single(frames);
+        Assert.Equal("src/Foo.al", frames[0].File);
+        Assert.Equal(42, frames[0].Line);
+        Assert.True(frames[0].IsUserCode);
+        Assert.Equal(FramePresentationHint.Normal, frames[0].Hint);
+    }
+
+    [Fact]
+    public void Walk_DimsRuntimeFrames()
+    {
+        var trace = "   at AlRunner.Runtime.MockRecord.Insert() in mock.cs:line 15\n";
+        var ex = MakeExceptionWithStackTrace(trace);
+        var frames = StackFrameMapper.Walk(ex);
+        Assert.Single(frames);
+        Assert.False(frames[0].IsUserCode);
+        Assert.Equal(FramePresentationHint.Subtle, frames[0].Hint);
+    }
+
+    [Fact]
+    public void Walk_HandlesUnknownFrames()
+    {
+        var trace = "   at SomeMethod()\n";
+        var ex = MakeExceptionWithStackTrace(trace);
+        var frames = StackFrameMapper.Walk(ex);
+        Assert.Single(frames);
+        Assert.Null(frames[0].File);
+        Assert.Null(frames[0].Line);
+        Assert.False(frames[0].IsUserCode);
+    }
+
+    [Fact]
+    public void FindDeepestUserFrame_ReturnsLastUserFrame()
+    {
+        var trace =
+            "   at AlRunner.Runtime.MockRecord.Insert() in mock.cs:line 5\n" +
+            "   at MainApp.AlertEngine.New() in src/AlertEngine.Codeunit.al:line 30\n" +
+            "   at AlRunner.Runtime.MockCodeunit.Invoke() in mock2.cs:line 10\n" +
+            "   at MainApp.Tests.NewReturnsTrue() in test/AlertEngineTest.al:line 17\n";
+        var ex = MakeExceptionWithStackTrace(trace);
+        var frames = StackFrameMapper.Walk(ex);
+        var deepest = StackFrameMapper.FindDeepestUserFrame(frames);
+        Assert.NotNull(deepest);
+        Assert.Equal("test/AlertEngineTest.al", deepest!.File);
+        Assert.Equal(17, deepest.Line);
+    }
+
+    [Fact]
+    public void FindDeepestUserFrame_NoUserFrames_ReturnsNull()
+    {
+        var trace = "   at AlRunner.Runtime.MockRecord.Insert() in mock.cs:line 5\n";
+        var ex = MakeExceptionWithStackTrace(trace);
+        var frames = StackFrameMapper.Walk(ex);
+        Assert.Null(StackFrameMapper.FindDeepestUserFrame(frames));
+    }
+
+    [Fact]
+    public void Walk_EmptyOrNullStackTrace_ReturnsEmptyList()
+    {
+        var ex = new InvalidOperationException("test");
+        var frames = StackFrameMapper.Walk(ex);
+        Assert.NotNull(frames);
+    }
+
+    [Fact]
+    public void Walk_QuotedPathsWithSpaces()
+    {
+        var trace = "   at Foo.Bar() in src/Some Folder/Customer Score.Codeunit.al:line 99\n";
+        var ex = MakeExceptionWithStackTrace(trace);
+        var frames = StackFrameMapper.Walk(ex);
+        Assert.Single(frames);
+        Assert.Equal("src/Some Folder/Customer Score.Codeunit.al", frames[0].File);
+        Assert.Equal(99, frames[0].Line);
+    }
+
+    [Fact]
+    public void ClassifyHint_MockTypeIsSubtle()
+    {
+        Assert.Equal(FramePresentationHint.Subtle,
+            StackFrameMapper.ClassifyHint("mock.cs", "AlRunner.Runtime.MockRecord.Insert"));
+    }
+
+    [Fact]
+    public void ClassifyHint_MicrosoftDynamicsIsSubtle()
+    {
+        Assert.Equal(FramePresentationHint.Subtle,
+            StackFrameMapper.ClassifyHint("nav.cs", "Microsoft.Dynamics.Nav.Some.Method"));
+    }
+
+    [Fact]
+    public void ClassifyHint_UserCodeIsNormal()
+    {
+        Assert.Equal(FramePresentationHint.Normal,
+            StackFrameMapper.ClassifyHint("src/Foo.al", "MainApp.Foo.Method"));
+    }
+
+    [Fact]
+    public void ClassifyHint_UnknownDeemphasize()
+    {
+        Assert.Equal(FramePresentationHint.Deemphasize,
+            StackFrameMapper.ClassifyHint(null, null));
+    }
+
+    private static Exception MakeExceptionWithStackTrace(string trace)
+        => new ExceptionWithFakeStackTrace(trace);
+
+    private sealed class ExceptionWithFakeStackTrace : Exception
+    {
+        private readonly string _trace;
+        public ExceptionWithFakeStackTrace(string trace) : base("fake") => _trace = trace;
+        public override string? StackTrace => _trace;
+    }
+}

--- a/AlRunner.Tests/StackFrameMapperTests.cs
+++ b/AlRunner.Tests/StackFrameMapperTests.cs
@@ -42,7 +42,7 @@ public class StackFrameMapperTests
     }
 
     [Fact]
-    public void FindDeepestUserFrame_ReturnsLastUserFrame()
+    public void FindDeepestUserFrame_ReturnsUserFrameClosestToThrow()
     {
         var trace =
             "   at AlRunner.Runtime.MockRecord.Insert() in mock.cs:line 5\n" +
@@ -53,8 +53,11 @@ public class StackFrameMapperTests
         var frames = StackFrameMapper.Walk(ex);
         var deepest = StackFrameMapper.FindDeepestUserFrame(frames);
         Assert.NotNull(deepest);
-        Assert.Equal("test/AlertEngineTest.al", deepest!.File);
-        Assert.Equal(17, deepest.Line);
+        // The user frame nearest the throw site (mock.cs:5) is AlertEngine.New at line 30,
+        // NOT the test-entry method at line 17. ALchemist surfaces this line as the inline
+        // error decoration so the user lands on the call that triggered the failure.
+        Assert.Equal("src/AlertEngine.Codeunit.al", deepest!.File);
+        Assert.Equal(30, deepest.Line);
     }
 
     [Fact]

--- a/AlRunner/AlStackFrame.cs
+++ b/AlRunner/AlStackFrame.cs
@@ -1,0 +1,28 @@
+namespace AlRunner;
+
+public enum FramePresentationHint
+{
+    Normal,
+    Subtle,
+    Deemphasize,
+    Label
+}
+
+public enum AlErrorKind
+{
+    Assertion,
+    Runtime,
+    Compile,
+    Setup,
+    Timeout,
+    Unknown
+}
+
+public record AlStackFrame(
+    string? File,
+    int? Line,
+    int? Column,
+    bool IsUserCode,
+    string? Name,
+    FramePresentationHint Hint
+);

--- a/AlRunner/ErrorClassifier.cs
+++ b/AlRunner/ErrorClassifier.cs
@@ -1,0 +1,49 @@
+namespace AlRunner;
+
+/// <summary>
+/// Execution-time signals about whether an exception was thrown inside a [Test] proc
+/// (vs. setup / [OnRun] before any test ran). Drives Setup-vs-Runtime classification.
+/// </summary>
+public record TestExecutionContext(bool InsideTestProc);
+
+/// <summary>
+/// Classifies a managed Exception into an <see cref="AlErrorKind"/> bucket so the
+/// IDE can vary the failure UI (assertion diff, runtime stack, compile errors, etc.).
+/// </summary>
+public static class ErrorClassifier
+{
+    /// <summary>
+    /// Classify the exception. A null exception maps to <see cref="AlErrorKind.Unknown"/>.
+    /// </summary>
+    public static AlErrorKind Classify(Exception ex, TestExecutionContext ctx)
+    {
+        if (ex == null) return AlErrorKind.Unknown;
+
+        // Assertion: AlRunner.Runtime.MockAssert throws subclasses with "AssertException"
+        // or "AssertionException" in the type name. Match on suffix to avoid hard
+        // coupling to the runtime's exact type identity.
+        var typeName = ex.GetType().Name;
+        if (typeName.Contains("AssertException", StringComparison.Ordinal)
+            || typeName.Contains("AssertionException", StringComparison.Ordinal)
+            || typeName.Contains("MockAssert", StringComparison.Ordinal))
+        {
+            return AlErrorKind.Assertion;
+        }
+
+        // Timeout: cancellation thrown by the cooperative timeout mechanism.
+        if (ex is OperationCanceledException) return AlErrorKind.Timeout;
+
+        // Compile: Roslyn pipeline wraps emit/compile errors in a custom exception.
+        // Match on type-name suffix (same rationale as Assertion).
+        if (typeName.Contains("CompilationFailed", StringComparison.Ordinal)
+            || typeName.Contains("CompileError", StringComparison.Ordinal))
+        {
+            return AlErrorKind.Compile;
+        }
+
+        // Anything thrown before we entered a [Test] proc is a setup/init failure.
+        if (!ctx.InsideTestProc) return AlErrorKind.Setup;
+
+        return AlErrorKind.Runtime;
+    }
+}

--- a/AlRunner/ErrorClassifier.cs
+++ b/AlRunner/ErrorClassifier.cs
@@ -4,6 +4,9 @@ namespace AlRunner;
 /// Execution-time signals about whether an exception was thrown inside a [Test] proc
 /// (vs. setup / [OnRun] before any test ran). Drives Setup-vs-Runtime classification.
 /// </summary>
+/// <remarks>
+/// Single-bool today; T8 will expand to carry per-test messages and capturedValues via AsyncLocal.
+/// </remarks>
 public record TestExecutionContext(bool InsideTestProc);
 
 /// <summary>
@@ -15,17 +18,16 @@ public static class ErrorClassifier
     /// <summary>
     /// Classify the exception. A null exception maps to <see cref="AlErrorKind.Unknown"/>.
     /// </summary>
-    public static AlErrorKind Classify(Exception ex, TestExecutionContext ctx)
+    public static AlErrorKind Classify(Exception? ex, TestExecutionContext ctx)
     {
         if (ex == null) return AlErrorKind.Unknown;
 
-        // Assertion: AlRunner.Runtime.MockAssert throws subclasses with "AssertException"
-        // or "AssertionException" in the type name. Match on suffix to avoid hard
-        // coupling to the runtime's exact type identity.
+        // Assertion: match on suffix so we don't hard-couple to the runtime's exact type
+        // identity. AlRunner.Runtime.AssertException ends with "AssertException";
+        // third-party runners may use "AssertionException".
         var typeName = ex.GetType().Name;
-        if (typeName.Contains("AssertException", StringComparison.Ordinal)
-            || typeName.Contains("AssertionException", StringComparison.Ordinal)
-            || typeName.Contains("MockAssert", StringComparison.Ordinal))
+        if (typeName.EndsWith("AssertException", StringComparison.Ordinal)
+            || typeName.EndsWith("AssertionException", StringComparison.Ordinal))
         {
             return AlErrorKind.Assertion;
         }
@@ -35,8 +37,8 @@ public static class ErrorClassifier
 
         // Compile: Roslyn pipeline wraps emit/compile errors in a custom exception.
         // Match on type-name suffix (same rationale as Assertion).
-        if (typeName.Contains("CompilationFailed", StringComparison.Ordinal)
-            || typeName.Contains("CompileError", StringComparison.Ordinal))
+        if (typeName.EndsWith("CompilationFailedException", StringComparison.Ordinal)
+            || typeName.EndsWith("CompileErrorException", StringComparison.Ordinal))
         {
             return AlErrorKind.Compile;
         }

--- a/AlRunner/StackFrameMapper.cs
+++ b/AlRunner/StackFrameMapper.cs
@@ -2,6 +2,10 @@ using System.Text.RegularExpressions;
 
 namespace AlRunner;
 
+/// <summary>
+/// Maps .NET exception stack traces to AL stack frames.
+/// Classifies each frame as user code, subtle runtime code, or de-emphasized infrastructure.
+/// </summary>
 public static class StackFrameMapper
 {
     // Matches "   at Namespace.Class.Method(args) in path/to/file.al:line 42"
@@ -14,6 +18,9 @@ public static class StackFrameMapper
         @"^\s*at\s+(?<method>[^\s][^()]*)(?:\([^)]*\))?\s*$",
         RegexOptions.Compiled | RegexOptions.Multiline);
 
+    /// <summary>
+    /// Parse all stack frames from an exception's stack trace into <see cref="AlStackFrame"/> records.
+    /// </summary>
     public static List<AlStackFrame> Walk(Exception ex)
     {
         var result = new List<AlStackFrame>();
@@ -61,6 +68,9 @@ public static class StackFrameMapper
         return result;
     }
 
+    /// <summary>
+    /// Return the first user-code frame in the list, which is the frame closest to the throw site.
+    /// </summary>
     public static AlStackFrame? FindDeepestUserFrame(IReadOnlyList<AlStackFrame> frames)
     {
         // .NET stack traces list the throw site first, then each caller out to the
@@ -74,22 +84,19 @@ public static class StackFrameMapper
         return null;
     }
 
+    /// <summary>
+    /// Classify a stack frame as Normal, Subtle, or Deemphasize based on file extension and method namespace.
+    /// </summary>
     public static FramePresentationHint ClassifyHint(string? file, string? methodName)
     {
         if (file != null && file.EndsWith(".al", StringComparison.OrdinalIgnoreCase))
             return FramePresentationHint.Normal;
 
-        if (methodName != null)
+        if (methodName != null
+            && (methodName.StartsWith("AlRunner.Runtime.", StringComparison.Ordinal)
+                || methodName.StartsWith("Microsoft.Dynamics.", StringComparison.Ordinal)))
         {
-            if (methodName.StartsWith("AlRunner.Runtime.", StringComparison.Ordinal)
-                || methodName.StartsWith("AlRunner.Runtime", StringComparison.Ordinal)
-                || methodName.Contains(".Mock", StringComparison.Ordinal)
-                || methodName.StartsWith("Mock", StringComparison.Ordinal)
-                || methodName.StartsWith("AlScope", StringComparison.Ordinal)
-                || methodName.StartsWith("Microsoft.Dynamics.", StringComparison.Ordinal))
-            {
-                return FramePresentationHint.Subtle;
-            }
+            return FramePresentationHint.Subtle;
         }
 
         return FramePresentationHint.Deemphasize;

--- a/AlRunner/StackFrameMapper.cs
+++ b/AlRunner/StackFrameMapper.cs
@@ -63,10 +63,11 @@ public static class StackFrameMapper
 
     public static AlStackFrame? FindDeepestUserFrame(IReadOnlyList<AlStackFrame> frames)
     {
-        // Walk from the end of the list (outermost / entry-point frame) backwards.
-        // The last user-code frame in the list is the deepest entry point into user code
-        // (e.g. the test method that triggered the call chain).
-        for (var i = frames.Count - 1; i >= 0; i--)
+        // .NET stack traces list the throw site first, then each caller out to the
+        // entry point. The user frame *closest to the throw* is therefore the FIRST
+        // user-code frame in the list — that is the line ALchemist surfaces as the
+        // inline error decoration.
+        for (var i = 0; i < frames.Count; i++)
         {
             if (frames[i].IsUserCode) return frames[i];
         }

--- a/AlRunner/StackFrameMapper.cs
+++ b/AlRunner/StackFrameMapper.cs
@@ -1,0 +1,96 @@
+using System.Text.RegularExpressions;
+
+namespace AlRunner;
+
+public static class StackFrameMapper
+{
+    // Matches "   at Namespace.Class.Method(args) in path/to/file.al:line 42"
+    private static readonly Regex FrameWithSource = new Regex(
+        @"^\s*at\s+(?<method>[^\s][^()]*)(?:\([^)]*\))?\s+in\s+(?<file>.+?):line\s+(?<line>\d+)\s*$",
+        RegexOptions.Compiled | RegexOptions.Multiline);
+
+    // Matches "   at Namespace.Class.Method(args)" without source info.
+    private static readonly Regex FrameNoSource = new Regex(
+        @"^\s*at\s+(?<method>[^\s][^()]*)(?:\([^)]*\))?\s*$",
+        RegexOptions.Compiled | RegexOptions.Multiline);
+
+    public static List<AlStackFrame> Walk(Exception ex)
+    {
+        var result = new List<AlStackFrame>();
+        var trace = ex.StackTrace;
+        if (string.IsNullOrEmpty(trace)) return result;
+
+        var lines = trace.Split('\n');
+        foreach (var rawLine in lines)
+        {
+            var line = rawLine.TrimEnd('\r');
+            if (string.IsNullOrWhiteSpace(line)) continue;
+
+            var withSource = FrameWithSource.Match(line);
+            if (withSource.Success)
+            {
+                var file = withSource.Groups["file"].Value.Trim();
+                var lineNum = int.Parse(withSource.Groups["line"].Value);
+                var method = withSource.Groups["method"].Value.Trim();
+                var isUser = file.EndsWith(".al", StringComparison.OrdinalIgnoreCase);
+                var hint = isUser ? FramePresentationHint.Normal : ClassifyHint(file, method);
+                result.Add(new AlStackFrame(
+                    File: file,
+                    Line: lineNum,
+                    Column: null,
+                    IsUserCode: isUser,
+                    Name: method,
+                    Hint: hint));
+                continue;
+            }
+
+            var noSource = FrameNoSource.Match(line);
+            if (noSource.Success)
+            {
+                var method = noSource.Groups["method"].Value.Trim();
+                result.Add(new AlStackFrame(
+                    File: null,
+                    Line: null,
+                    Column: null,
+                    IsUserCode: false,
+                    Name: method,
+                    Hint: ClassifyHint(null, method)));
+            }
+        }
+
+        return result;
+    }
+
+    public static AlStackFrame? FindDeepestUserFrame(IReadOnlyList<AlStackFrame> frames)
+    {
+        // Walk from the end of the list (outermost / entry-point frame) backwards.
+        // The last user-code frame in the list is the deepest entry point into user code
+        // (e.g. the test method that triggered the call chain).
+        for (var i = frames.Count - 1; i >= 0; i--)
+        {
+            if (frames[i].IsUserCode) return frames[i];
+        }
+        return null;
+    }
+
+    public static FramePresentationHint ClassifyHint(string? file, string? methodName)
+    {
+        if (file != null && file.EndsWith(".al", StringComparison.OrdinalIgnoreCase))
+            return FramePresentationHint.Normal;
+
+        if (methodName != null)
+        {
+            if (methodName.StartsWith("AlRunner.Runtime.", StringComparison.Ordinal)
+                || methodName.StartsWith("AlRunner.Runtime", StringComparison.Ordinal)
+                || methodName.Contains(".Mock", StringComparison.Ordinal)
+                || methodName.StartsWith("Mock", StringComparison.Ordinal)
+                || methodName.StartsWith("AlScope", StringComparison.Ordinal)
+                || methodName.StartsWith("Microsoft.Dynamics.", StringComparison.Ordinal))
+            {
+                return FramePresentationHint.Subtle;
+            }
+        }
+
+        return FramePresentationHint.Deemphasize;
+    }
+}

--- a/AlRunner/TestFilter.cs
+++ b/AlRunner/TestFilter.cs
@@ -1,0 +1,11 @@
+namespace AlRunner;
+
+/// <summary>
+/// Filter passed to <see cref="Executor.RunTests"/> to limit which tests execute.
+/// Both fields are optional; nulls = no constraint.
+/// When both are set, a test must match both filters (AND).
+/// </summary>
+public record TestFilter(
+    IReadOnlySet<string>? CodeunitNames,
+    IReadOnlySet<string>? ProcNames
+);

--- a/protocol-v2.schema.json
+++ b/protocol-v2.schema.json
@@ -1,0 +1,148 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/StefanMaron/BusinessCentral.AL.Runner/schemas/protocol-v2.json",
+  "title": "AL.Runner Server Protocol v2",
+  "description": "Newline-delimited JSON. A `runtests` request emits zero or more `test` lines, optional `progress` lines, then exactly one `summary` line. Each line is a separate JSON document.",
+  "definitions": {
+    "AlStackFrame": {
+      "type": "object",
+      "required": ["name"],
+      "properties": {
+        "name": { "type": "string" },
+        "source": {
+          "type": "object",
+          "properties": {
+            "path": { "type": "string" },
+            "name": { "type": "string" }
+          }
+        },
+        "line": { "type": "integer", "minimum": 1 },
+        "column": { "type": "integer", "minimum": 1 },
+        "presentationHint": {
+          "type": "string",
+          "enum": ["normal", "subtle", "deemphasize", "label"]
+        }
+      }
+    },
+    "ErrorKind": {
+      "type": "string",
+      "enum": ["assertion", "runtime", "compile", "setup", "timeout", "unknown"]
+    },
+    "TestEvent": {
+      "type": "object",
+      "required": ["type", "name", "status"],
+      "properties": {
+        "type": { "const": "test" },
+        "name": { "type": "string" },
+        "status": { "enum": ["pass", "fail", "error"] },
+        "durationMs": { "type": "integer", "minimum": 0 },
+        "message": { "type": "string" },
+        "errorKind": { "$ref": "#/definitions/ErrorKind" },
+        "alSourceFile": { "type": "string" },
+        "alSourceLine": { "type": "integer", "minimum": 1 },
+        "alSourceColumn": { "type": "integer", "minimum": 1 },
+        "stackFrames": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/AlStackFrame" }
+        },
+        "stackTrace": { "type": "string" },
+        "messages": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "capturedValues": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "scopeName": { "type": "string" },
+              "variableName": { "type": "string" },
+              "value": {},
+              "statementId": { "type": "integer" }
+            }
+          }
+        }
+      }
+    },
+    "FileCoverage": {
+      "type": "object",
+      "required": ["file", "lines", "totalStatements", "hitStatements"],
+      "properties": {
+        "file": { "type": "string" },
+        "lines": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["line", "hits"],
+            "properties": {
+              "line": { "type": "integer", "minimum": 1 },
+              "hits": { "type": "integer", "minimum": 0 }
+            }
+          }
+        },
+        "totalStatements": { "type": "integer", "minimum": 0 },
+        "hitStatements": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "Summary": {
+      "type": "object",
+      "required": ["type", "exitCode", "passed", "failed", "errors", "total", "protocolVersion"],
+      "properties": {
+        "type": { "const": "summary" },
+        "exitCode": { "type": "integer" },
+        "passed": { "type": "integer", "minimum": 0 },
+        "failed": { "type": "integer", "minimum": 0 },
+        "errors": { "type": "integer", "minimum": 0 },
+        "total": { "type": "integer", "minimum": 0 },
+        "cached": { "type": "boolean" },
+        "cancelled": { "type": "boolean" },
+        "changedFiles": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "compilationErrors": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "file": { "type": "string" },
+              "errors": {
+                "type": "array",
+                "items": { "type": "string" }
+              }
+            }
+          }
+        },
+        "coverage": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/FileCoverage" }
+        },
+        "protocolVersion": { "const": 2 }
+      }
+    },
+    "Ack": {
+      "type": "object",
+      "required": ["type", "command"],
+      "properties": {
+        "type": { "const": "ack" },
+        "command": { "type": "string" },
+        "noop": { "type": "boolean" }
+      }
+    },
+    "Progress": {
+      "type": "object",
+      "required": ["type"],
+      "properties": {
+        "type": { "const": "progress" },
+        "completed": { "type": "integer", "minimum": 0 },
+        "total": { "type": "integer", "minimum": 0 }
+      }
+    }
+  },
+  "oneOf": [
+    { "$ref": "#/definitions/TestEvent" },
+    { "$ref": "#/definitions/Summary" },
+    { "$ref": "#/definitions/Ack" },
+    { "$ref": "#/definitions/Progress" }
+  ]
+}


### PR DESCRIPTION
## Summary

PR 3 of 9 — Protocol v2 split per [#1568 review](https://github.com/StefanMaron/BusinessCentral.AL.Runner/pull/1568#issuecomment-4274937532).

Pure additions — new files only. **Depends on PRs #1607, #1608 (merge those first).**

- `AlRunner/ErrorClassifier.cs` — classifies a managed `Exception` into `AlErrorKind`: Assertion, Timeout, Compile, Setup, Runtime, Unknown. Uses type-name suffix matching (not type identity) to avoid hard coupling to concrete exception types.
- `AlRunner.Tests/ErrorClassifierTests.cs` — 13 tests covering all error-kind branches, real `AssertException` type, `TaskCanceledException` polymorphism, cancellation-during-setup ordering, `AggregateException` non-unwrapping, base-Exception fallthrough.

Key design decisions:
- **Suffix matching** (`EndsWith`) over type-identity checks — decouples from concrete types that may change.
- **Setup vs Runtime** resolved by `TestExecutionContext.InsideTestProc` flag — set by the executor (PR 6) via AsyncLocal.
- **`TestExecutionContext`** is a forward-compat static class — expanded in PR 6 with per-test scope.

**Incremental commits** (review these):
- `feat(runtime): add ErrorClassifier`
- `refactor(ErrorClassifier): suffix matching, real-type test, branch coverage`

## PR stack

1. #1607 — schema + types
2. #1608 — StackFrameMapper
3. **→ This PR** — ErrorClassifier
4. CoverageReport.ToJson
5–9. (see #1568 rationale)

## Test plan

- [ ] 13 new ErrorClassifier tests pass
- [ ] No existing tests affected