### PR TITLE
feat(coverage): add CoverageReport.ToJson + extract shared aggregator

### DIFF
--- a/AlRunner.Tests/CoverageReportToJsonTests.cs
+++ b/AlRunner.Tests/CoverageReportToJsonTests.cs
@@ -1,0 +1,363 @@
+using AlRunner;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// Unit tests for CoverageReport.ToJson.
+/// Uses [Collection("Pipeline")] because SourceFileMapper is a static singleton;
+/// we must run sequentially and Clear() in the constructor to avoid cross-test pollution.
+/// Object names are prefixed with "T6_" as an extra guard so these tests don't
+/// interfere with names registered by other Pipeline-collection tests.
+/// </summary>
+[Collection("Pipeline")]
+public class CoverageReportToJsonTests
+{
+    public CoverageReportToJsonTests()
+    {
+        SourceFileMapper.Clear();
+    }
+
+    // -----------------------------------------------------------------------
+    // 1. Happy path: two scopes → two different files, partial hits
+    // -----------------------------------------------------------------------
+    [Fact]
+    public void ToJson_BuildsFileEntries_OnePerScopeWithFile()
+    {
+        SourceFileMapper.Register("T6_CodeunitA", "src/CodeunitA.al");
+        SourceFileMapper.Register("T6_CodeunitB", "src/CodeunitB.al");
+
+        var sourceSpans = new Dictionary<(string Scope, int StmtIndex), int>
+        {
+            [("T6_ScopeA", 0)] = 10,
+            [("T6_ScopeA", 1)] = 20,
+            [("T6_ScopeB", 0)] = 5,
+        };
+
+        var totalStatements = new HashSet<(string Type, int Id)>
+        {
+            ("T6_ScopeA", 0),
+            ("T6_ScopeA", 1),
+            ("T6_ScopeB", 0),
+        };
+
+        var hitStatements = new HashSet<(string Type, int Id)>
+        {
+            ("T6_ScopeA", 0), // hit
+            // ScopeA stmtIdx 1 not hit
+            ("T6_ScopeB", 0), // hit
+        };
+
+        var scopeToObject = new Dictionary<string, string>
+        {
+            ["T6_ScopeA"] = "T6_CodeunitA",
+            ["T6_ScopeB"] = "T6_CodeunitB",
+        };
+
+        var result = CoverageReport.ToJson(sourceSpans, hitStatements, totalStatements, scopeToObject);
+
+        Assert.Equal(2, result.Count);
+
+        // Files should be sorted by path
+        var fileA = result.Find(f => f.File == "src/CodeunitA.al");
+        var fileB = result.Find(f => f.File == "src/CodeunitB.al");
+        Assert.NotNull(fileA);
+        Assert.NotNull(fileB);
+
+        Assert.Equal(2, fileA.TotalStatements);
+        Assert.Equal(1, fileA.HitStatements);
+        Assert.Equal(2, fileA.Lines.Count);
+
+        Assert.Equal(1, fileB.TotalStatements);
+        Assert.Equal(1, fileB.HitStatements);
+        Assert.Single(fileB.Lines);
+    }
+
+    // -----------------------------------------------------------------------
+    // 2. Line deduplication: multiple stmtIndexes on the same AL line sum hits
+    // -----------------------------------------------------------------------
+    [Fact]
+    public void ToJson_LineDeduplication_SumsHitsPerLine()
+    {
+        SourceFileMapper.Register("T6_MultiStmt", "src/Multi.al");
+
+        // Two statements on line 7 (both hit), one statement on line 8 (not hit)
+        var sourceSpans = new Dictionary<(string Scope, int StmtIndex), int>
+        {
+            [("T6_MultiScope", 0)] = 7,
+            [("T6_MultiScope", 1)] = 7,
+            [("T6_MultiScope", 2)] = 8,
+        };
+
+        var totalStatements = new HashSet<(string Type, int Id)>
+        {
+            ("T6_MultiScope", 0),
+            ("T6_MultiScope", 1),
+            ("T6_MultiScope", 2),
+        };
+
+        var hitStatements = new HashSet<(string Type, int Id)>
+        {
+            ("T6_MultiScope", 0),
+            ("T6_MultiScope", 1),
+            // stmtIdx 2 not hit
+        };
+
+        var scopeToObject = new Dictionary<string, string>
+        {
+            ["T6_MultiScope"] = "T6_MultiStmt",
+        };
+
+        var result = CoverageReport.ToJson(sourceSpans, hitStatements, totalStatements, scopeToObject);
+
+        Assert.Single(result);
+        var file = result[0];
+
+        Assert.Equal(2, file.Lines.Count);
+
+        var line7 = file.Lines.Find(l => l.Line == 7);
+        var line8 = file.Lines.Find(l => l.Line == 8);
+        Assert.NotNull(line7);
+        Assert.NotNull(line8);
+
+        // Both statements on line 7 were hit → Hits = 2 (summed, not max-1)
+        Assert.Equal(2, line7.Hits);
+        // Statement on line 8 not hit → Hits = 0
+        Assert.Equal(0, line8.Hits);
+    }
+
+    // -----------------------------------------------------------------------
+    // 3. No hits: all reachable lines still present with Hits = 0
+    // -----------------------------------------------------------------------
+    [Fact]
+    public void ToJson_NoHits_AllLinesPresentWithZero()
+    {
+        SourceFileMapper.Register("T6_NoHitObj", "src/NoHit.al");
+
+        var sourceSpans = new Dictionary<(string Scope, int StmtIndex), int>
+        {
+            [("T6_NoHitScope", 0)] = 3,
+            [("T6_NoHitScope", 1)] = 7,
+            [("T6_NoHitScope", 2)] = 12,
+        };
+
+        var totalStatements = new HashSet<(string Type, int Id)>
+        {
+            ("T6_NoHitScope", 0),
+            ("T6_NoHitScope", 1),
+            ("T6_NoHitScope", 2),
+        };
+
+        var hitStatements = new HashSet<(string Type, int Id)>(); // empty
+
+        var scopeToObject = new Dictionary<string, string>
+        {
+            ["T6_NoHitScope"] = "T6_NoHitObj",
+        };
+
+        var result = CoverageReport.ToJson(sourceSpans, hitStatements, totalStatements, scopeToObject);
+
+        Assert.Single(result);
+        var file = result[0];
+
+        Assert.Equal(3, file.TotalStatements);
+        Assert.Equal(0, file.HitStatements);
+        Assert.Equal(3, file.Lines.Count);
+
+        // Every line should be present with Hits = 0
+        Assert.All(file.Lines, l => Assert.Equal(0, l.Hits));
+        Assert.Contains(file.Lines, l => l.Line == 3);
+        Assert.Contains(file.Lines, l => l.Line == 7);
+        Assert.Contains(file.Lines, l => l.Line == 12);
+    }
+
+    // -----------------------------------------------------------------------
+    // 4. Empty input → empty output
+    // -----------------------------------------------------------------------
+    [Fact]
+    public void ToJson_EmptyInput_ReturnsEmptyList()
+    {
+        var result = CoverageReport.ToJson(
+            new Dictionary<(string Scope, int StmtIndex), int>(),
+            new HashSet<(string Type, int Id)>(),
+            new HashSet<(string Type, int Id)>(),
+            new Dictionary<string, string>());
+
+        Assert.Empty(result);
+    }
+
+    // -----------------------------------------------------------------------
+    // 5. Non-total statements (var-decls, blank lines) must be skipped
+    // -----------------------------------------------------------------------
+    [Fact]
+    public void ToJson_SkipsNonTotalStatements()
+    {
+        SourceFileMapper.Register("T6_FilterObj", "src/Filter.al");
+
+        // sourceSpans has 3 entries: stmtIdx 0 and 2 are real stmts; stmtIdx 1 is a var-decl (not in totalStatements)
+        var sourceSpans = new Dictionary<(string Scope, int StmtIndex), int>
+        {
+            [("T6_FilterScope", 0)] = 5,
+            [("T6_FilterScope", 1)] = 6, // var-decl: NOT in totalStatements
+            [("T6_FilterScope", 2)] = 10,
+        };
+
+        var totalStatements = new HashSet<(string Type, int Id)>
+        {
+            ("T6_FilterScope", 0),
+            // stmtIdx 1 intentionally absent (simulates var-decl)
+            ("T6_FilterScope", 2),
+        };
+
+        var hitStatements = new HashSet<(string Type, int Id)>
+        {
+            ("T6_FilterScope", 0),
+            ("T6_FilterScope", 2),
+        };
+
+        var scopeToObject = new Dictionary<string, string>
+        {
+            ["T6_FilterScope"] = "T6_FilterObj",
+        };
+
+        var result = CoverageReport.ToJson(sourceSpans, hitStatements, totalStatements, scopeToObject);
+
+        Assert.Single(result);
+        var file = result[0];
+
+        // Only 2 real statements, not 3
+        Assert.Equal(2, file.TotalStatements);
+        Assert.Equal(2, file.HitStatements);
+
+        // Line 6 (the var-decl) must NOT appear in Lines
+        Assert.Equal(2, file.Lines.Count);
+        Assert.DoesNotContain(file.Lines, l => l.Line == 6);
+        Assert.Contains(file.Lines, l => l.Line == 5);
+        Assert.Contains(file.Lines, l => l.Line == 10);
+    }
+
+    // -----------------------------------------------------------------------
+    // 6. Library/stub scopes with no file mapping → entirely excluded
+    // -----------------------------------------------------------------------
+    [Fact]
+    public void ToJson_SkipsLibraryScopes_NoFileMapping()
+    {
+        SourceFileMapper.Register("T6_UserObj", "src/User.al");
+        // "T6_LibScope" is NOT in scopeToObject → library/stub → must be excluded
+
+        var sourceSpans = new Dictionary<(string Scope, int StmtIndex), int>
+        {
+            [("T6_UserScope", 0)] = 15,
+            [("T6_LibScope", 0)] = 99, // library stub
+        };
+
+        var totalStatements = new HashSet<(string Type, int Id)>
+        {
+            ("T6_UserScope", 0),
+            ("T6_LibScope", 0),
+        };
+
+        var hitStatements = new HashSet<(string Type, int Id)>
+        {
+            ("T6_UserScope", 0),
+            ("T6_LibScope", 0),
+        };
+
+        var scopeToObject = new Dictionary<string, string>
+        {
+            ["T6_UserScope"] = "T6_UserObj",
+            // T6_LibScope deliberately absent
+        };
+
+        var result = CoverageReport.ToJson(sourceSpans, hitStatements, totalStatements, scopeToObject);
+
+        Assert.Single(result);
+        var file = result[0];
+        Assert.Equal("src/User.al", file.File);
+        Assert.Equal(1, file.TotalStatements);
+        Assert.Equal(1, file.HitStatements);
+    }
+
+    // -----------------------------------------------------------------------
+    // 7. Null scopeToObject → no statements can be mapped → empty result
+    // -----------------------------------------------------------------------
+    [Fact]
+    public void ToJson_NullScopeToObject_ReturnsEmpty()
+    {
+        SourceFileMapper.Register("T6_SomeObj", "src/Some.al");
+
+        var sourceSpans = new Dictionary<(string Scope, int StmtIndex), int>
+        {
+            [("T6_SomeScope", 0)] = 42,
+        };
+
+        var totalStatements = new HashSet<(string Type, int Id)>
+        {
+            ("T6_SomeScope", 0),
+        };
+
+        var hitStatements = new HashSet<(string Type, int Id)>
+        {
+            ("T6_SomeScope", 0),
+        };
+
+        // Pass null for scopeToObject — no mapping possible
+        var result = CoverageReport.ToJson(sourceSpans, hitStatements, totalStatements, scopeToObject: null);
+
+        Assert.Empty(result);
+    }
+
+    // -----------------------------------------------------------------------
+    // 8. Deterministic ordering: files by path, lines by number within file
+    // -----------------------------------------------------------------------
+    [Fact]
+    public void ToJson_DeterministicOrdering_FilesByPathLinesByNumber()
+    {
+        SourceFileMapper.Register("T6_ObjZ", "src/zzz.al");
+        SourceFileMapper.Register("T6_ObjA", "src/aaa.al");
+
+        // Intentionally register spans in reverse order to verify sorting
+        var sourceSpans = new Dictionary<(string Scope, int StmtIndex), int>
+        {
+            [("T6_ZScope", 0)] = 30,
+            [("T6_ZScope", 1)] = 10,
+            [("T6_ZScope", 2)] = 20,
+            [("T6_AScope", 0)] = 5,
+        };
+
+        var totalStatements = new HashSet<(string Type, int Id)>
+        {
+            ("T6_ZScope", 0),
+            ("T6_ZScope", 1),
+            ("T6_ZScope", 2),
+            ("T6_AScope", 0),
+        };
+
+        var hitStatements = new HashSet<(string Type, int Id)>
+        {
+            ("T6_ZScope", 0),
+            ("T6_AScope", 0),
+        };
+
+        var scopeToObject = new Dictionary<string, string>
+        {
+            ["T6_ZScope"] = "T6_ObjZ",
+            ["T6_AScope"] = "T6_ObjA",
+        };
+
+        var result = CoverageReport.ToJson(sourceSpans, hitStatements, totalStatements, scopeToObject);
+
+        Assert.Equal(2, result.Count);
+
+        // Files in alphabetical path order: aaa.al before zzz.al
+        Assert.Equal("src/aaa.al", result[0].File);
+        Assert.Equal("src/zzz.al", result[1].File);
+
+        // Lines within zzz.al in ascending order: 10, 20, 30
+        var linesZ = result[1].Lines;
+        Assert.Equal(3, linesZ.Count);
+        Assert.Equal(10, linesZ[0].Line);
+        Assert.Equal(20, linesZ[1].Line);
+        Assert.Equal(30, linesZ[2].Line);
+    }
+}

--- a/AlRunner.Tests/CoverageReportToJsonTests.cs
+++ b/AlRunner.Tests/CoverageReportToJsonTests.cs
@@ -311,6 +311,54 @@ public class CoverageReportToJsonTests
     // 8. Deterministic ordering: files by path, lines by number within file
     // -----------------------------------------------------------------------
     [Fact]
+    public void ToJson_RecordsSerializeWithCamelCasePropertyNames()
+    {
+        SourceFileMapper.Register("T6_S_Cam", "src/Cam.al");
+        var sourceSpans = new Dictionary<(string Scope, int StmtIndex), int>
+        {
+            [("T6_S_Cam_Scope", 0)] = 5,
+        };
+        var hit = new HashSet<(string Type, int Id)> { ("T6_S_Cam_Scope", 0) };
+        var total = new HashSet<(string Type, int Id)> { ("T6_S_Cam_Scope", 0) };
+        var scopeToObject = new Dictionary<string, string> { ["T6_S_Cam_Scope"] = "T6_S_Cam" };
+
+        var result = CoverageReport.ToJson(sourceSpans, hit, total, scopeToObject);
+        var json = System.Text.Json.JsonSerializer.Serialize(result);
+
+        // Schema-mandated camelCase shape
+        Assert.Contains("\"file\":", json);
+        Assert.Contains("\"lines\":", json);
+        Assert.Contains("\"totalStatements\":", json);
+        Assert.Contains("\"hitStatements\":", json);
+        Assert.Contains("\"line\":", json);
+        Assert.Contains("\"hits\":", json);
+        // PascalCase MUST NOT appear (would happen with default options + no attributes)
+        Assert.DoesNotContain("\"File\":", json);
+        Assert.DoesNotContain("\"Lines\":", json);
+        Assert.DoesNotContain("\"TotalStatements\":", json);
+    }
+
+    [Fact]
+    public void ToJson_ScopeMappedButObjectNotRegistered_SkipsScope()
+    {
+        // scopeToObject has the scope; the AL object name is NOT in SourceFileMapper.
+        // GetFile returns null, scope is silently skipped.
+        var sourceSpans = new Dictionary<(string Scope, int StmtIndex), int>
+        {
+            [("T6_GhostScope", 0)] = 1,
+        };
+        var hit = new HashSet<(string Type, int Id)>();
+        var total = new HashSet<(string Type, int Id)> { ("T6_GhostScope", 0) };
+        var scopeToObject = new Dictionary<string, string>
+        {
+            ["T6_GhostScope"] = "T6_NonexistentObject",  // never registered
+        };
+
+        var result = CoverageReport.ToJson(sourceSpans, hit, total, scopeToObject);
+        Assert.Empty(result);
+    }
+
+    [Fact]
     public void ToJson_DeterministicOrdering_FilesByPathLinesByNumber()
     {
         SourceFileMapper.Register("T6_ObjZ", "src/zzz.al");

--- a/AlRunner.Tests/ErrorClassifierTests.cs
+++ b/AlRunner.Tests/ErrorClassifierTests.cs
@@ -1,14 +1,17 @@
-using AlRunner;
+using AlRunner.Runtime;
 using Xunit;
 
 namespace AlRunner.Tests;
 
 public class ErrorClassifierTests
 {
+    // ----- Original tests (retained / upgraded) -----
+
     [Fact]
     public void Classify_AssertionException_IsAssertion()
     {
-        var ex = new MockAssertException("expected 1 got 2");
+        // Uses the real AlRunner.Runtime.AssertException — the type actually thrown by MockAssert.
+        var ex = new AssertException("expected 1 got 2");
         var ctx = new TestExecutionContext(InsideTestProc: true);
         Assert.Equal(AlErrorKind.Assertion, ErrorClassifier.Classify(ex, ctx));
     }
@@ -24,7 +27,7 @@ public class ErrorClassifierTests
     [Fact]
     public void Classify_CompilationFailedException_IsCompile()
     {
-        var ex = new CompilationFailedExceptionStub("compile error");
+        var ex = new MyDomainCompilationFailedException("compile error");
         var ctx = new TestExecutionContext(InsideTestProc: true);
         Assert.Equal(AlErrorKind.Compile, ErrorClassifier.Classify(ex, ctx));
     }
@@ -49,16 +52,94 @@ public class ErrorClassifierTests
     public void Classify_NullException_IsUnknown()
     {
         var ctx = new TestExecutionContext(InsideTestProc: true);
-        Assert.Equal(AlErrorKind.Unknown, ErrorClassifier.Classify(null!, ctx));
+        Assert.Equal(AlErrorKind.Unknown, ErrorClassifier.Classify(null, ctx));
     }
 
-    private sealed class MockAssertException : Exception
+    // ----- New branch-coverage tests -----
+
+    [Fact]
+    public void Classify_AssertionExceptionEnding_IsAssertion()
     {
-        public MockAssertException(string m) : base(m) { }
+        // Verifies the EndsWith("AssertException") branch fires on its own.
+        var ex = new MyDomainAssertException("oops");
+        var ctx = new TestExecutionContext(InsideTestProc: true);
+        Assert.Equal(AlErrorKind.Assertion, ErrorClassifier.Classify(ex, ctx));
     }
 
-    private sealed class CompilationFailedExceptionStub : Exception
+    [Fact]
+    public void Classify_AssertionExceptionFullSuffix_IsAssertion()
     {
-        public CompilationFailedExceptionStub(string m) : base(m) { }
+        // Verifies the EndsWith("AssertionException") branch fires.
+        var ex = new MyDomainAssertionException("oops");
+        var ctx = new TestExecutionContext(InsideTestProc: true);
+        Assert.Equal(AlErrorKind.Assertion, ErrorClassifier.Classify(ex, ctx));
+    }
+
+    [Fact]
+    public void Classify_TaskCanceledException_IsTimeout()
+    {
+        // TaskCanceledException is a subclass of OperationCanceledException — most common cancellation type in .NET.
+        var ex = new TaskCanceledException("cancelled");
+        var ctx = new TestExecutionContext(InsideTestProc: true);
+        Assert.Equal(AlErrorKind.Timeout, ErrorClassifier.Classify(ex, ctx));
+    }
+
+    [Fact]
+    public void Classify_OperationCanceledDuringSetup_IsTimeoutNotSetup()
+    {
+        // Pins ordering: timeout takes precedence over the InsideTestProc gate.
+        var ex = new OperationCanceledException("cancelled in setup");
+        var ctx = new TestExecutionContext(InsideTestProc: false);
+        Assert.Equal(AlErrorKind.Timeout, ErrorClassifier.Classify(ex, ctx));
+    }
+
+    [Fact]
+    public void Classify_CompileErrorEnding_IsCompile()
+    {
+        var ex = new MyDomainCompileErrorException("bad emit");
+        var ctx = new TestExecutionContext(InsideTestProc: true);
+        Assert.Equal(AlErrorKind.Compile, ErrorClassifier.Classify(ex, ctx));
+    }
+
+    [Fact]
+    public void Classify_AggregateExceptionWrappingAssertion_IsRuntime()
+    {
+        // Documents that unwrapping AggregateException is the caller's job.
+        // Future change: if Executor unwraps before classifying, this expectation moves.
+        var inner = new MyDomainAssertException("inner");
+        var ex = new AggregateException(inner);
+        var ctx = new TestExecutionContext(InsideTestProc: true);
+        Assert.Equal(AlErrorKind.Runtime, ErrorClassifier.Classify(ex, ctx));
+    }
+
+    [Fact]
+    public void Classify_BareException_DuringTest_IsRuntime()
+    {
+        // Verifies the default-Runtime fallthrough on the base Exception type.
+        var ex = new Exception("base");
+        var ctx = new TestExecutionContext(InsideTestProc: true);
+        Assert.Equal(AlErrorKind.Runtime, ErrorClassifier.Classify(ex, ctx));
+    }
+
+    // ----- Private stubs (name-based matching only) -----
+
+    private sealed class MyDomainAssertException : Exception
+    {
+        public MyDomainAssertException(string m) : base(m) { }
+    }
+
+    private sealed class MyDomainAssertionException : Exception
+    {
+        public MyDomainAssertionException(string m) : base(m) { }
+    }
+
+    private sealed class MyDomainCompilationFailedException : Exception
+    {
+        public MyDomainCompilationFailedException(string m) : base(m) { }
+    }
+
+    private sealed class MyDomainCompileErrorException : Exception
+    {
+        public MyDomainCompileErrorException(string m) : base(m) { }
     }
 }

--- a/AlRunner.Tests/ErrorClassifierTests.cs
+++ b/AlRunner.Tests/ErrorClassifierTests.cs
@@ -1,0 +1,64 @@
+using AlRunner;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public class ErrorClassifierTests
+{
+    [Fact]
+    public void Classify_AssertionException_IsAssertion()
+    {
+        var ex = new MockAssertException("expected 1 got 2");
+        var ctx = new TestExecutionContext(InsideTestProc: true);
+        Assert.Equal(AlErrorKind.Assertion, ErrorClassifier.Classify(ex, ctx));
+    }
+
+    [Fact]
+    public void Classify_OperationCanceled_IsTimeout()
+    {
+        var ex = new OperationCanceledException("test exceeded timeout");
+        var ctx = new TestExecutionContext(InsideTestProc: true);
+        Assert.Equal(AlErrorKind.Timeout, ErrorClassifier.Classify(ex, ctx));
+    }
+
+    [Fact]
+    public void Classify_CompilationFailedException_IsCompile()
+    {
+        var ex = new CompilationFailedExceptionStub("compile error");
+        var ctx = new TestExecutionContext(InsideTestProc: true);
+        Assert.Equal(AlErrorKind.Compile, ErrorClassifier.Classify(ex, ctx));
+    }
+
+    [Fact]
+    public void Classify_GenericException_DuringSetup_IsSetup()
+    {
+        var ex = new InvalidOperationException("setup failed");
+        var ctx = new TestExecutionContext(InsideTestProc: false);
+        Assert.Equal(AlErrorKind.Setup, ErrorClassifier.Classify(ex, ctx));
+    }
+
+    [Fact]
+    public void Classify_GenericException_DuringTest_IsRuntime()
+    {
+        var ex = new InvalidOperationException("runtime error");
+        var ctx = new TestExecutionContext(InsideTestProc: true);
+        Assert.Equal(AlErrorKind.Runtime, ErrorClassifier.Classify(ex, ctx));
+    }
+
+    [Fact]
+    public void Classify_NullException_IsUnknown()
+    {
+        var ctx = new TestExecutionContext(InsideTestProc: true);
+        Assert.Equal(AlErrorKind.Unknown, ErrorClassifier.Classify(null!, ctx));
+    }
+
+    private sealed class MockAssertException : Exception
+    {
+        public MockAssertException(string m) : base(m) { }
+    }
+
+    private sealed class CompilationFailedExceptionStub : Exception
+    {
+        public CompilationFailedExceptionStub(string m) : base(m) { }
+    }
+}

--- a/AlRunner.Tests/StackFrameMapperTests.cs
+++ b/AlRunner.Tests/StackFrameMapperTests.cs
@@ -116,6 +116,55 @@ public class StackFrameMapperTests
             StackFrameMapper.ClassifyHint(null, null));
     }
 
+    [Fact]
+    public void ClassifyHint_AlScopeRuntimeIsSubtle()
+    {
+        Assert.Equal(FramePresentationHint.Subtle,
+            StackFrameMapper.ClassifyHint("scope.cs", "AlRunner.Runtime.AlScope.Push"));
+    }
+
+    [Fact]
+    public void ClassifyHint_UserMethodNamedMock_IsNotSubtle()
+    {
+        // Regression: previous heuristics had a bare "Mock" prefix rule that would dim
+        // legitimate user code whose qualified name happened to start with "Mock".
+        var hint = StackFrameMapper.ClassifyHint("src/MockAccountTest.al", "Acme.MockAccountTest.Run");
+        Assert.Equal(FramePresentationHint.Normal, hint);
+    }
+
+    [Fact]
+    public void ClassifyHint_NullFileWithUserMethod_IsDeemphasize()
+    {
+        Assert.Equal(FramePresentationHint.Deemphasize,
+            StackFrameMapper.ClassifyHint(null, "MainApp.Foo.Bar"));
+    }
+
+    [Fact]
+    public void Walk_UppercaseAlExtensionIsUserCode()
+    {
+        var trace = "   at Foo.Bar() in src/Foo.AL:line 5\n";
+        var ex = MakeExceptionWithStackTrace(trace);
+        var frames = StackFrameMapper.Walk(ex);
+        Assert.Single(frames);
+        Assert.True(frames[0].IsUserCode);
+        Assert.Equal(FramePresentationHint.Normal, frames[0].Hint);
+    }
+
+    [Fact]
+    public void Walk_MultipleFramesPreserveOrder()
+    {
+        var trace =
+            "   at Foo.Bar() in src/A.al:line 1\n" +
+            "   at Foo.Baz() in src/B.al:line 2\n" +
+            "   at Foo.Qux() in src/C.al:line 3\n";
+        var ex = MakeExceptionWithStackTrace(trace);
+        var frames = StackFrameMapper.Walk(ex);
+        Assert.Equal(3, frames.Count);
+        Assert.Equal("src/A.al", frames[0].File);
+        Assert.Equal("src/B.al", frames[1].File);
+        Assert.Equal("src/C.al", frames[2].File);
+    }
+
     private static Exception MakeExceptionWithStackTrace(string trace)
         => new ExceptionWithFakeStackTrace(trace);
 

--- a/AlRunner.Tests/StackFrameMapperTests.cs
+++ b/AlRunner.Tests/StackFrameMapperTests.cs
@@ -1,0 +1,125 @@
+using AlRunner;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public class StackFrameMapperTests
+{
+    [Fact]
+    public void Walk_ParsesAlFilenames_AsUserCode()
+    {
+        var trace = "   at Foo.Bar.RunTest() in src/Foo.al:line 42\n";
+        var ex = MakeExceptionWithStackTrace(trace);
+        var frames = StackFrameMapper.Walk(ex);
+        Assert.Single(frames);
+        Assert.Equal("src/Foo.al", frames[0].File);
+        Assert.Equal(42, frames[0].Line);
+        Assert.True(frames[0].IsUserCode);
+        Assert.Equal(FramePresentationHint.Normal, frames[0].Hint);
+    }
+
+    [Fact]
+    public void Walk_DimsRuntimeFrames()
+    {
+        var trace = "   at AlRunner.Runtime.MockRecord.Insert() in mock.cs:line 15\n";
+        var ex = MakeExceptionWithStackTrace(trace);
+        var frames = StackFrameMapper.Walk(ex);
+        Assert.Single(frames);
+        Assert.False(frames[0].IsUserCode);
+        Assert.Equal(FramePresentationHint.Subtle, frames[0].Hint);
+    }
+
+    [Fact]
+    public void Walk_HandlesUnknownFrames()
+    {
+        var trace = "   at SomeMethod()\n";
+        var ex = MakeExceptionWithStackTrace(trace);
+        var frames = StackFrameMapper.Walk(ex);
+        Assert.Single(frames);
+        Assert.Null(frames[0].File);
+        Assert.Null(frames[0].Line);
+        Assert.False(frames[0].IsUserCode);
+    }
+
+    [Fact]
+    public void FindDeepestUserFrame_ReturnsLastUserFrame()
+    {
+        var trace =
+            "   at AlRunner.Runtime.MockRecord.Insert() in mock.cs:line 5\n" +
+            "   at MainApp.AlertEngine.New() in src/AlertEngine.Codeunit.al:line 30\n" +
+            "   at AlRunner.Runtime.MockCodeunit.Invoke() in mock2.cs:line 10\n" +
+            "   at MainApp.Tests.NewReturnsTrue() in test/AlertEngineTest.al:line 17\n";
+        var ex = MakeExceptionWithStackTrace(trace);
+        var frames = StackFrameMapper.Walk(ex);
+        var deepest = StackFrameMapper.FindDeepestUserFrame(frames);
+        Assert.NotNull(deepest);
+        Assert.Equal("test/AlertEngineTest.al", deepest!.File);
+        Assert.Equal(17, deepest.Line);
+    }
+
+    [Fact]
+    public void FindDeepestUserFrame_NoUserFrames_ReturnsNull()
+    {
+        var trace = "   at AlRunner.Runtime.MockRecord.Insert() in mock.cs:line 5\n";
+        var ex = MakeExceptionWithStackTrace(trace);
+        var frames = StackFrameMapper.Walk(ex);
+        Assert.Null(StackFrameMapper.FindDeepestUserFrame(frames));
+    }
+
+    [Fact]
+    public void Walk_EmptyOrNullStackTrace_ReturnsEmptyList()
+    {
+        var ex = new InvalidOperationException("test");
+        var frames = StackFrameMapper.Walk(ex);
+        Assert.NotNull(frames);
+    }
+
+    [Fact]
+    public void Walk_QuotedPathsWithSpaces()
+    {
+        var trace = "   at Foo.Bar() in src/Some Folder/Customer Score.Codeunit.al:line 99\n";
+        var ex = MakeExceptionWithStackTrace(trace);
+        var frames = StackFrameMapper.Walk(ex);
+        Assert.Single(frames);
+        Assert.Equal("src/Some Folder/Customer Score.Codeunit.al", frames[0].File);
+        Assert.Equal(99, frames[0].Line);
+    }
+
+    [Fact]
+    public void ClassifyHint_MockTypeIsSubtle()
+    {
+        Assert.Equal(FramePresentationHint.Subtle,
+            StackFrameMapper.ClassifyHint("mock.cs", "AlRunner.Runtime.MockRecord.Insert"));
+    }
+
+    [Fact]
+    public void ClassifyHint_MicrosoftDynamicsIsSubtle()
+    {
+        Assert.Equal(FramePresentationHint.Subtle,
+            StackFrameMapper.ClassifyHint("nav.cs", "Microsoft.Dynamics.Nav.Some.Method"));
+    }
+
+    [Fact]
+    public void ClassifyHint_UserCodeIsNormal()
+    {
+        Assert.Equal(FramePresentationHint.Normal,
+            StackFrameMapper.ClassifyHint("src/Foo.al", "MainApp.Foo.Method"));
+    }
+
+    [Fact]
+    public void ClassifyHint_UnknownDeemphasize()
+    {
+        Assert.Equal(FramePresentationHint.Deemphasize,
+            StackFrameMapper.ClassifyHint(null, null));
+    }
+
+    private static Exception MakeExceptionWithStackTrace(string trace)
+        => new ExceptionWithFakeStackTrace(trace);
+
+    private sealed class ExceptionWithFakeStackTrace : Exception
+    {
+        private readonly string _trace;
+        public ExceptionWithFakeStackTrace(string trace) : base("fake") => _trace = trace;
+        public override string? StackTrace => _trace;
+    }
+}

--- a/AlRunner.Tests/StackFrameMapperTests.cs
+++ b/AlRunner.Tests/StackFrameMapperTests.cs
@@ -42,7 +42,7 @@ public class StackFrameMapperTests
     }
 
     [Fact]
-    public void FindDeepestUserFrame_ReturnsLastUserFrame()
+    public void FindDeepestUserFrame_ReturnsUserFrameClosestToThrow()
     {
         var trace =
             "   at AlRunner.Runtime.MockRecord.Insert() in mock.cs:line 5\n" +
@@ -53,8 +53,11 @@ public class StackFrameMapperTests
         var frames = StackFrameMapper.Walk(ex);
         var deepest = StackFrameMapper.FindDeepestUserFrame(frames);
         Assert.NotNull(deepest);
-        Assert.Equal("test/AlertEngineTest.al", deepest!.File);
-        Assert.Equal(17, deepest.Line);
+        // The user frame nearest the throw site (mock.cs:5) is AlertEngine.New at line 30,
+        // NOT the test-entry method at line 17. ALchemist surfaces this line as the inline
+        // error decoration so the user lands on the call that triggered the failure.
+        Assert.Equal("src/AlertEngine.Codeunit.al", deepest!.File);
+        Assert.Equal(30, deepest.Line);
     }
 
     [Fact]

--- a/AlRunner/AlStackFrame.cs
+++ b/AlRunner/AlStackFrame.cs
@@ -1,0 +1,28 @@
+namespace AlRunner;
+
+public enum FramePresentationHint
+{
+    Normal,
+    Subtle,
+    Deemphasize,
+    Label
+}
+
+public enum AlErrorKind
+{
+    Assertion,
+    Runtime,
+    Compile,
+    Setup,
+    Timeout,
+    Unknown
+}
+
+public record AlStackFrame(
+    string? File,
+    int? Line,
+    int? Column,
+    bool IsUserCode,
+    string? Name,
+    FramePresentationHint Hint
+);

--- a/AlRunner/CoverageReport.cs
+++ b/AlRunner/CoverageReport.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Text.Json.Serialization;
 using System.Xml;
 using AlRunner;
 
@@ -110,6 +111,77 @@ public static class CoverageReport
     }
 
     /// <summary>
+    /// Walks the (scope, stmtIdx) statement set, resolves each to a file path, and
+    /// builds a per-file dictionary mapping AL line number → hit count.
+    ///
+    /// Filters out statements not present in <paramref name="totalStatements"/>
+    /// (var decls / structural spans) and scopes that don't resolve to a user file
+    /// via <paramref name="scopeToObject"/> + SourceFileMapper.GetFile.
+    /// </summary>
+    /// <param name="sumHits">
+    /// true → per-line hits are SUMMED across statements (structured JSON shape).
+    /// false → per-line hits are clamped to 1 if any statement on that line was hit
+    /// (cobertura shape).
+    /// </param>
+    /// <returns>
+    /// A tuple of:
+    /// <list type="bullet">
+    ///   <item>fileLines — per-file map of line → hit count.</item>
+    ///   <item>fileTotals — per-file (totalStatements, hitStatements) counts.</item>
+    /// </list>
+    /// </returns>
+    private static (Dictionary<string, Dictionary<int, int>> FileLines,
+                    Dictionary<string, (int Total, int Hit)> FileTotals)
+        AggregatePerFileLines(
+            Dictionary<(string Scope, int StmtIndex), int> sourceSpans,
+            HashSet<(string Type, int Id)> hitStatements,
+            HashSet<(string Type, int Id)> totalStatements,
+            Dictionary<string, string>? scopeToObject,
+            bool sumHits)
+    {
+        var fileLines = new Dictionary<string, Dictionary<int, int>>();
+        var fileTotals = new Dictionary<string, (int Total, int Hit)>();
+
+        foreach (var ((scope, stmtIdx), line) in sourceSpans)
+        {
+            if (!totalStatements.Contains((scope, stmtIdx))) continue;
+
+            string? filePath = null;
+            if (scopeToObject != null && scopeToObject.TryGetValue(scope, out var objectName))
+            {
+                filePath = SourceFileMapper.GetFile(objectName);
+            }
+            if (filePath == null) continue;
+
+            bool hit = hitStatements.Contains((scope, stmtIdx));
+
+            if (!fileLines.TryGetValue(filePath, out var lines))
+            {
+                lines = new Dictionary<int, int>();
+                fileLines[filePath] = lines;
+            }
+
+            if (sumHits)
+            {
+                lines[line] = lines.GetValueOrDefault(line, 0) + (hit ? 1 : 0);
+            }
+            else
+            {
+                // Cobertura: any hit counts as covered (clamp to 1).
+                if (!lines.ContainsKey(line))
+                    lines[line] = hit ? 1 : 0;
+                else if (hit)
+                    lines[line] = 1;
+            }
+
+            fileTotals.TryGetValue(filePath, out var totals);
+            fileTotals[filePath] = (totals.Total + 1, totals.Hit + (hit ? 1 : 0));
+        }
+
+        return (fileLines, fileTotals);
+    }
+
+    /// <summary>
     /// Write a Cobertura XML coverage report.
     /// </summary>
     public static void WriteCobertura(
@@ -119,41 +191,8 @@ public static class CoverageReport
         HashSet<(string Type, int Id)> totalStatements,
         Dictionary<string, string>? scopeToObject = null)
     {
-        // Group coverage data by source file
-        var fileLines = new Dictionary<string, Dictionary<int, int>>(); // file -> line -> hitCount
-
-        foreach (var ((scope, stmtIdx), line) in sourceSpans)
-        {
-            // Only include lines that correspond to actual executable statements
-            // (i.e., statements with StmtHit/CStmtHit calls in the generated C#).
-            // This filters out variable declarations, blank lines, and structural
-            // keywords that the BC compiler includes in SourceSpans for error mapping.
-            if (!totalStatements.Contains((scope, stmtIdx)))
-                continue;
-
-            // Find which file this scope belongs to using SourceFileMapper
-            string? filePath = null;
-            if (scopeToObject != null && scopeToObject.TryGetValue(scope, out var objectName))
-            {
-                filePath = SourceFileMapper.GetFile(objectName);
-            }
-            // If scope doesn't match any user file, skip it entirely.
-            // This prevents library/stub scopes (Assert, etc.) from
-            // bleeding into the user's coverage report.
-            if (filePath == null) continue;
-
-            if (!fileLines.TryGetValue(filePath, out var lines))
-            {
-                lines = new Dictionary<int, int>();
-                fileLines[filePath] = lines;
-            }
-
-            bool hit = hitStatements.Contains((scope, stmtIdx));
-            if (!lines.ContainsKey(line))
-                lines[line] = hit ? 1 : 0;
-            else if (hit)
-                lines[line] = 1; // Any hit counts as covered
-        }
+        var (fileLines, _) = AggregatePerFileLines(
+            sourceSpans, hitStatements, totalStatements, scopeToObject, sumHits: false);
 
         // Write Cobertura XML
         using var writer = XmlWriter.Create(outputPath, new XmlWriterSettings
@@ -257,40 +296,8 @@ public static class CoverageReport
         HashSet<(string Type, int Id)> totalStatements,
         Dictionary<string, string>? scopeToObject = null)
     {
-        // file → line → summed hit count
-        var fileLines = new Dictionary<string, Dictionary<int, int>>();
-        // file → (totalStmts, hitStmts)
-        var fileTotals = new Dictionary<string, (int Total, int Hit)>();
-
-        foreach (var ((scope, stmtIdx), line) in sourceSpans)
-        {
-            // Skip var-decls and other non-executable spans
-            if (!totalStatements.Contains((scope, stmtIdx)))
-                continue;
-
-            // Resolve file path via scopeToObject + SourceFileMapper
-            if (scopeToObject == null)
-                continue;
-            if (!scopeToObject.TryGetValue(scope, out var objectName))
-                continue;
-            var filePath = SourceFileMapper.GetFile(objectName);
-            if (filePath == null)
-                continue;
-
-            bool hit = hitStatements.Contains((scope, stmtIdx));
-
-            // Aggregate per-line hit counts (sum, not max-1)
-            if (!fileLines.TryGetValue(filePath, out var lines))
-            {
-                lines = new Dictionary<int, int>();
-                fileLines[filePath] = lines;
-            }
-            lines[line] = lines.GetValueOrDefault(line, 0) + (hit ? 1 : 0);
-
-            // Accumulate file-level totals
-            fileTotals.TryGetValue(filePath, out var totals);
-            fileTotals[filePath] = (totals.Total + 1, totals.Hit + (hit ? 1 : 0));
-        }
+        var (fileLines, fileTotals) = AggregatePerFileLines(
+            sourceSpans, hitStatements, totalStatements, scopeToObject, sumHits: true);
 
         // Build sorted result
         return fileLines
@@ -316,11 +323,17 @@ public static class CoverageReport
 /// Every executable line is included even if its hit count is zero.</param>
 /// <param name="TotalStatements">Number of executable statements in this file.</param>
 /// <param name="HitStatements">Number of those statements that were executed.</param>
+/// <remarks>
+/// Record value-equality compares <paramref name="Lines"/> by reference (since
+/// <see cref="List{T}"/> does not override <see cref="object.Equals(object)"/>), so two
+/// structurally-identical instances with distinct list instances will compare unequal;
+/// compare line-by-line for structural equality.
+/// </remarks>
 public record FileCoverage(
-    string File,
-    List<LineCoverage> Lines,
-    int TotalStatements,
-    int HitStatements
+    [property: JsonPropertyName("file")] string File,
+    [property: JsonPropertyName("lines")] List<LineCoverage> Lines,
+    [property: JsonPropertyName("totalStatements")] int TotalStatements,
+    [property: JsonPropertyName("hitStatements")] int HitStatements
 );
 
 /// <summary>
@@ -329,4 +342,7 @@ public record FileCoverage(
 /// <param name="Line">1-based AL source line number.</param>
 /// <param name="Hits">Number of statements on this line that were executed during the run.
 /// Multiple statements on the same line sum their individual 0/1 hits.</param>
-public record LineCoverage(int Line, int Hits);
+public record LineCoverage(
+    [property: JsonPropertyName("line")] int Line,
+    [property: JsonPropertyName("hits")] int Hits
+);

--- a/AlRunner/CoverageReport.cs
+++ b/AlRunner/CoverageReport.cs
@@ -224,4 +224,109 @@ public static class CoverageReport
         writer.WriteEndElement(); // packages
         writer.WriteEndElement(); // coverage
     }
+
+    /// <summary>
+    /// Build structured coverage data as a list of <see cref="FileCoverage"/> records,
+    /// one per AL source file that contains at least one executable statement.
+    ///
+    /// Mirrors the grouping logic of <see cref="WriteCobertura"/> but returns structured
+    /// data instead of writing XML. Key differences from Cobertura output:
+    /// <list type="bullet">
+    ///   <item>Hit counts per line are <b>summed</b> across all statements on that line
+    ///         (not clamped to max 1), preserving multi-statement detail for callers.</item>
+    ///   <item>Every reachable line (i.e., every line that maps to a totalStatement with
+    ///         a resolvable file) is included, even when its hit count is zero, so callers
+    ///         can tell which lines are executable but uncovered.</item>
+    ///   <item>Output is deterministic: files ordered by path, lines within each file
+    ///         ordered by line number.</item>
+    /// </list>
+    ///
+    /// Library and stub scopes (those with no entry in <paramref name="scopeToObject"/>
+    /// or whose mapped object has no registered file) are silently excluded.
+    /// </summary>
+    /// <param name="sourceSpans">Maps (scope class name, statement index) to 1-based AL line number.</param>
+    /// <param name="hitStatements">Set of (scope, stmtIdx) tuples that executed during the test run.</param>
+    /// <param name="totalStatements">Set of (scope, stmtIdx) tuples that are real executable statements.
+    /// Entries absent from this set (e.g. var-decls, blank-line spans) are skipped.</param>
+    /// <param name="scopeToObject">Scope class name → AL object name. Pass <c>null</c> when no
+    /// file-mapping information is available; in that case the result will always be empty.</param>
+    /// <returns>Sorted list of <see cref="FileCoverage"/> records.</returns>
+    public static List<FileCoverage> ToJson(
+        Dictionary<(string Scope, int StmtIndex), int> sourceSpans,
+        HashSet<(string Type, int Id)> hitStatements,
+        HashSet<(string Type, int Id)> totalStatements,
+        Dictionary<string, string>? scopeToObject = null)
+    {
+        // file → line → summed hit count
+        var fileLines = new Dictionary<string, Dictionary<int, int>>();
+        // file → (totalStmts, hitStmts)
+        var fileTotals = new Dictionary<string, (int Total, int Hit)>();
+
+        foreach (var ((scope, stmtIdx), line) in sourceSpans)
+        {
+            // Skip var-decls and other non-executable spans
+            if (!totalStatements.Contains((scope, stmtIdx)))
+                continue;
+
+            // Resolve file path via scopeToObject + SourceFileMapper
+            if (scopeToObject == null)
+                continue;
+            if (!scopeToObject.TryGetValue(scope, out var objectName))
+                continue;
+            var filePath = SourceFileMapper.GetFile(objectName);
+            if (filePath == null)
+                continue;
+
+            bool hit = hitStatements.Contains((scope, stmtIdx));
+
+            // Aggregate per-line hit counts (sum, not max-1)
+            if (!fileLines.TryGetValue(filePath, out var lines))
+            {
+                lines = new Dictionary<int, int>();
+                fileLines[filePath] = lines;
+            }
+            lines[line] = lines.GetValueOrDefault(line, 0) + (hit ? 1 : 0);
+
+            // Accumulate file-level totals
+            fileTotals.TryGetValue(filePath, out var totals);
+            fileTotals[filePath] = (totals.Total + 1, totals.Hit + (hit ? 1 : 0));
+        }
+
+        // Build sorted result
+        return fileLines
+            .OrderBy(kv => kv.Key, StringComparer.Ordinal)
+            .Select(kv =>
+            {
+                var (total, hitCount) = fileTotals[kv.Key];
+                var sortedLines = kv.Value
+                    .OrderBy(lv => lv.Key)
+                    .Select(lv => new LineCoverage(lv.Key, lv.Value))
+                    .ToList();
+                return new FileCoverage(kv.Key, sortedLines, total, hitCount);
+            })
+            .ToList();
+    }
 }
+
+/// <summary>
+/// Structured coverage data for a single AL source file.
+/// </summary>
+/// <param name="File">Relative path to the AL source file.</param>
+/// <param name="Lines">Per-line coverage entries, ordered by line number.
+/// Every executable line is included even if its hit count is zero.</param>
+/// <param name="TotalStatements">Number of executable statements in this file.</param>
+/// <param name="HitStatements">Number of those statements that were executed.</param>
+public record FileCoverage(
+    string File,
+    List<LineCoverage> Lines,
+    int TotalStatements,
+    int HitStatements
+);
+
+/// <summary>
+/// Hit count for a single AL source line.
+/// </summary>
+/// <param name="Line">1-based AL source line number.</param>
+/// <param name="Hits">Number of statements on this line that were executed during the run.
+/// Multiple statements on the same line sum their individual 0/1 hits.</param>
+public record LineCoverage(int Line, int Hits);

--- a/AlRunner/ErrorClassifier.cs
+++ b/AlRunner/ErrorClassifier.cs
@@ -1,0 +1,49 @@
+namespace AlRunner;
+
+/// <summary>
+/// Execution-time signals about whether an exception was thrown inside a [Test] proc
+/// (vs. setup / [OnRun] before any test ran). Drives Setup-vs-Runtime classification.
+/// </summary>
+public record TestExecutionContext(bool InsideTestProc);
+
+/// <summary>
+/// Classifies a managed Exception into an <see cref="AlErrorKind"/> bucket so the
+/// IDE can vary the failure UI (assertion diff, runtime stack, compile errors, etc.).
+/// </summary>
+public static class ErrorClassifier
+{
+    /// <summary>
+    /// Classify the exception. A null exception maps to <see cref="AlErrorKind.Unknown"/>.
+    /// </summary>
+    public static AlErrorKind Classify(Exception ex, TestExecutionContext ctx)
+    {
+        if (ex == null) return AlErrorKind.Unknown;
+
+        // Assertion: AlRunner.Runtime.MockAssert throws subclasses with "AssertException"
+        // or "AssertionException" in the type name. Match on suffix to avoid hard
+        // coupling to the runtime's exact type identity.
+        var typeName = ex.GetType().Name;
+        if (typeName.Contains("AssertException", StringComparison.Ordinal)
+            || typeName.Contains("AssertionException", StringComparison.Ordinal)
+            || typeName.Contains("MockAssert", StringComparison.Ordinal))
+        {
+            return AlErrorKind.Assertion;
+        }
+
+        // Timeout: cancellation thrown by the cooperative timeout mechanism.
+        if (ex is OperationCanceledException) return AlErrorKind.Timeout;
+
+        // Compile: Roslyn pipeline wraps emit/compile errors in a custom exception.
+        // Match on type-name suffix (same rationale as Assertion).
+        if (typeName.Contains("CompilationFailed", StringComparison.Ordinal)
+            || typeName.Contains("CompileError", StringComparison.Ordinal))
+        {
+            return AlErrorKind.Compile;
+        }
+
+        // Anything thrown before we entered a [Test] proc is a setup/init failure.
+        if (!ctx.InsideTestProc) return AlErrorKind.Setup;
+
+        return AlErrorKind.Runtime;
+    }
+}

--- a/AlRunner/ErrorClassifier.cs
+++ b/AlRunner/ErrorClassifier.cs
@@ -4,6 +4,9 @@ namespace AlRunner;
 /// Execution-time signals about whether an exception was thrown inside a [Test] proc
 /// (vs. setup / [OnRun] before any test ran). Drives Setup-vs-Runtime classification.
 /// </summary>
+/// <remarks>
+/// Single-bool today; T8 will expand to carry per-test messages and capturedValues via AsyncLocal.
+/// </remarks>
 public record TestExecutionContext(bool InsideTestProc);
 
 /// <summary>
@@ -15,17 +18,16 @@ public static class ErrorClassifier
     /// <summary>
     /// Classify the exception. A null exception maps to <see cref="AlErrorKind.Unknown"/>.
     /// </summary>
-    public static AlErrorKind Classify(Exception ex, TestExecutionContext ctx)
+    public static AlErrorKind Classify(Exception? ex, TestExecutionContext ctx)
     {
         if (ex == null) return AlErrorKind.Unknown;
 
-        // Assertion: AlRunner.Runtime.MockAssert throws subclasses with "AssertException"
-        // or "AssertionException" in the type name. Match on suffix to avoid hard
-        // coupling to the runtime's exact type identity.
+        // Assertion: match on suffix so we don't hard-couple to the runtime's exact type
+        // identity. AlRunner.Runtime.AssertException ends with "AssertException";
+        // third-party runners may use "AssertionException".
         var typeName = ex.GetType().Name;
-        if (typeName.Contains("AssertException", StringComparison.Ordinal)
-            || typeName.Contains("AssertionException", StringComparison.Ordinal)
-            || typeName.Contains("MockAssert", StringComparison.Ordinal))
+        if (typeName.EndsWith("AssertException", StringComparison.Ordinal)
+            || typeName.EndsWith("AssertionException", StringComparison.Ordinal))
         {
             return AlErrorKind.Assertion;
         }
@@ -35,8 +37,8 @@ public static class ErrorClassifier
 
         // Compile: Roslyn pipeline wraps emit/compile errors in a custom exception.
         // Match on type-name suffix (same rationale as Assertion).
-        if (typeName.Contains("CompilationFailed", StringComparison.Ordinal)
-            || typeName.Contains("CompileError", StringComparison.Ordinal))
+        if (typeName.EndsWith("CompilationFailedException", StringComparison.Ordinal)
+            || typeName.EndsWith("CompileErrorException", StringComparison.Ordinal))
         {
             return AlErrorKind.Compile;
         }

--- a/AlRunner/SourceFileMapper.cs
+++ b/AlRunner/SourceFileMapper.cs
@@ -36,6 +36,23 @@ public static class SourceFileMapper
     /// Falls back to prefix matching when the scope name is a method name
     /// without the _Scope suffix (e.g. ValueCapture uses bare method names).
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Use this method only when <paramref name="scopeName"/> may arrive as a bare
+    /// method name without the <c>_Scope_HASH</c> suffix — for example, when
+    /// <c>IterationTracker</c> stores the parent class name rather than the fully-qualified
+    /// scope class name.  The prefix-match fallback finds the first
+    /// <c>scopeToObject</c> key that starts with <c>scopeName + "_"</c> so those callers
+    /// still resolve to the correct file.
+    /// </para>
+    /// <para>
+    /// <see cref="WriteCobertura"/> and <see cref="CoverageReport.ToJson"/> always receive
+    /// fully-qualified scope names built by <see cref="CoverageReport.BuildScopeToObjectMap"/>
+    /// (which parses actual <c>class … _Scope…</c> declarations), so they use the direct
+    /// <c>scopeToObject.TryGetValue</c> + <see cref="GetFile"/> path and do NOT need this
+    /// method — the prefix fallback would add no coverage for them.
+    /// </para>
+    /// </remarks>
     public static string? GetFileForScope(
         string scopeName,
         Dictionary<string, string> scopeToObject)

--- a/AlRunner/StackFrameMapper.cs
+++ b/AlRunner/StackFrameMapper.cs
@@ -2,6 +2,10 @@ using System.Text.RegularExpressions;
 
 namespace AlRunner;
 
+/// <summary>
+/// Maps .NET exception stack traces to AL stack frames.
+/// Classifies each frame as user code, subtle runtime code, or de-emphasized infrastructure.
+/// </summary>
 public static class StackFrameMapper
 {
     // Matches "   at Namespace.Class.Method(args) in path/to/file.al:line 42"
@@ -14,6 +18,9 @@ public static class StackFrameMapper
         @"^\s*at\s+(?<method>[^\s][^()]*)(?:\([^)]*\))?\s*$",
         RegexOptions.Compiled | RegexOptions.Multiline);
 
+    /// <summary>
+    /// Parse all stack frames from an exception's stack trace into <see cref="AlStackFrame"/> records.
+    /// </summary>
     public static List<AlStackFrame> Walk(Exception ex)
     {
         var result = new List<AlStackFrame>();
@@ -61,6 +68,9 @@ public static class StackFrameMapper
         return result;
     }
 
+    /// <summary>
+    /// Return the first user-code frame in the list, which is the frame closest to the throw site.
+    /// </summary>
     public static AlStackFrame? FindDeepestUserFrame(IReadOnlyList<AlStackFrame> frames)
     {
         // .NET stack traces list the throw site first, then each caller out to the
@@ -74,22 +84,19 @@ public static class StackFrameMapper
         return null;
     }
 
+    /// <summary>
+    /// Classify a stack frame as Normal, Subtle, or Deemphasize based on file extension and method namespace.
+    /// </summary>
     public static FramePresentationHint ClassifyHint(string? file, string? methodName)
     {
         if (file != null && file.EndsWith(".al", StringComparison.OrdinalIgnoreCase))
             return FramePresentationHint.Normal;
 
-        if (methodName != null)
+        if (methodName != null
+            && (methodName.StartsWith("AlRunner.Runtime.", StringComparison.Ordinal)
+                || methodName.StartsWith("Microsoft.Dynamics.", StringComparison.Ordinal)))
         {
-            if (methodName.StartsWith("AlRunner.Runtime.", StringComparison.Ordinal)
-                || methodName.StartsWith("AlRunner.Runtime", StringComparison.Ordinal)
-                || methodName.Contains(".Mock", StringComparison.Ordinal)
-                || methodName.StartsWith("Mock", StringComparison.Ordinal)
-                || methodName.StartsWith("AlScope", StringComparison.Ordinal)
-                || methodName.StartsWith("Microsoft.Dynamics.", StringComparison.Ordinal))
-            {
-                return FramePresentationHint.Subtle;
-            }
+            return FramePresentationHint.Subtle;
         }
 
         return FramePresentationHint.Deemphasize;

--- a/AlRunner/StackFrameMapper.cs
+++ b/AlRunner/StackFrameMapper.cs
@@ -63,10 +63,11 @@ public static class StackFrameMapper
 
     public static AlStackFrame? FindDeepestUserFrame(IReadOnlyList<AlStackFrame> frames)
     {
-        // Walk from the end of the list (outermost / entry-point frame) backwards.
-        // The last user-code frame in the list is the deepest entry point into user code
-        // (e.g. the test method that triggered the call chain).
-        for (var i = frames.Count - 1; i >= 0; i--)
+        // .NET stack traces list the throw site first, then each caller out to the
+        // entry point. The user frame *closest to the throw* is therefore the FIRST
+        // user-code frame in the list — that is the line ALchemist surfaces as the
+        // inline error decoration.
+        for (var i = 0; i < frames.Count; i++)
         {
             if (frames[i].IsUserCode) return frames[i];
         }

--- a/AlRunner/StackFrameMapper.cs
+++ b/AlRunner/StackFrameMapper.cs
@@ -1,0 +1,96 @@
+using System.Text.RegularExpressions;
+
+namespace AlRunner;
+
+public static class StackFrameMapper
+{
+    // Matches "   at Namespace.Class.Method(args) in path/to/file.al:line 42"
+    private static readonly Regex FrameWithSource = new Regex(
+        @"^\s*at\s+(?<method>[^\s][^()]*)(?:\([^)]*\))?\s+in\s+(?<file>.+?):line\s+(?<line>\d+)\s*$",
+        RegexOptions.Compiled | RegexOptions.Multiline);
+
+    // Matches "   at Namespace.Class.Method(args)" without source info.
+    private static readonly Regex FrameNoSource = new Regex(
+        @"^\s*at\s+(?<method>[^\s][^()]*)(?:\([^)]*\))?\s*$",
+        RegexOptions.Compiled | RegexOptions.Multiline);
+
+    public static List<AlStackFrame> Walk(Exception ex)
+    {
+        var result = new List<AlStackFrame>();
+        var trace = ex.StackTrace;
+        if (string.IsNullOrEmpty(trace)) return result;
+
+        var lines = trace.Split('\n');
+        foreach (var rawLine in lines)
+        {
+            var line = rawLine.TrimEnd('\r');
+            if (string.IsNullOrWhiteSpace(line)) continue;
+
+            var withSource = FrameWithSource.Match(line);
+            if (withSource.Success)
+            {
+                var file = withSource.Groups["file"].Value.Trim();
+                var lineNum = int.Parse(withSource.Groups["line"].Value);
+                var method = withSource.Groups["method"].Value.Trim();
+                var isUser = file.EndsWith(".al", StringComparison.OrdinalIgnoreCase);
+                var hint = isUser ? FramePresentationHint.Normal : ClassifyHint(file, method);
+                result.Add(new AlStackFrame(
+                    File: file,
+                    Line: lineNum,
+                    Column: null,
+                    IsUserCode: isUser,
+                    Name: method,
+                    Hint: hint));
+                continue;
+            }
+
+            var noSource = FrameNoSource.Match(line);
+            if (noSource.Success)
+            {
+                var method = noSource.Groups["method"].Value.Trim();
+                result.Add(new AlStackFrame(
+                    File: null,
+                    Line: null,
+                    Column: null,
+                    IsUserCode: false,
+                    Name: method,
+                    Hint: ClassifyHint(null, method)));
+            }
+        }
+
+        return result;
+    }
+
+    public static AlStackFrame? FindDeepestUserFrame(IReadOnlyList<AlStackFrame> frames)
+    {
+        // Walk from the end of the list (outermost / entry-point frame) backwards.
+        // The last user-code frame in the list is the deepest entry point into user code
+        // (e.g. the test method that triggered the call chain).
+        for (var i = frames.Count - 1; i >= 0; i--)
+        {
+            if (frames[i].IsUserCode) return frames[i];
+        }
+        return null;
+    }
+
+    public static FramePresentationHint ClassifyHint(string? file, string? methodName)
+    {
+        if (file != null && file.EndsWith(".al", StringComparison.OrdinalIgnoreCase))
+            return FramePresentationHint.Normal;
+
+        if (methodName != null)
+        {
+            if (methodName.StartsWith("AlRunner.Runtime.", StringComparison.Ordinal)
+                || methodName.StartsWith("AlRunner.Runtime", StringComparison.Ordinal)
+                || methodName.Contains(".Mock", StringComparison.Ordinal)
+                || methodName.StartsWith("Mock", StringComparison.Ordinal)
+                || methodName.StartsWith("AlScope", StringComparison.Ordinal)
+                || methodName.StartsWith("Microsoft.Dynamics.", StringComparison.Ordinal))
+            {
+                return FramePresentationHint.Subtle;
+            }
+        }
+
+        return FramePresentationHint.Deemphasize;
+    }
+}

--- a/AlRunner/TestFilter.cs
+++ b/AlRunner/TestFilter.cs
@@ -1,0 +1,11 @@
+namespace AlRunner;
+
+/// <summary>
+/// Filter passed to <see cref="Executor.RunTests"/> to limit which tests execute.
+/// Both fields are optional; nulls = no constraint.
+/// When both are set, a test must match both filters (AND).
+/// </summary>
+public record TestFilter(
+    IReadOnlySet<string>? CodeunitNames,
+    IReadOnlySet<string>? ProcNames
+);

--- a/protocol-v2.schema.json
+++ b/protocol-v2.schema.json
@@ -1,0 +1,148 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/StefanMaron/BusinessCentral.AL.Runner/schemas/protocol-v2.json",
+  "title": "AL.Runner Server Protocol v2",
+  "description": "Newline-delimited JSON. A `runtests` request emits zero or more `test` lines, optional `progress` lines, then exactly one `summary` line. Each line is a separate JSON document.",
+  "definitions": {
+    "AlStackFrame": {
+      "type": "object",
+      "required": ["name"],
+      "properties": {
+        "name": { "type": "string" },
+        "source": {
+          "type": "object",
+          "properties": {
+            "path": { "type": "string" },
+            "name": { "type": "string" }
+          }
+        },
+        "line": { "type": "integer", "minimum": 1 },
+        "column": { "type": "integer", "minimum": 1 },
+        "presentationHint": {
+          "type": "string",
+          "enum": ["normal", "subtle", "deemphasize", "label"]
+        }
+      }
+    },
+    "ErrorKind": {
+      "type": "string",
+      "enum": ["assertion", "runtime", "compile", "setup", "timeout", "unknown"]
+    },
+    "TestEvent": {
+      "type": "object",
+      "required": ["type", "name", "status"],
+      "properties": {
+        "type": { "const": "test" },
+        "name": { "type": "string" },
+        "status": { "enum": ["pass", "fail", "error"] },
+        "durationMs": { "type": "integer", "minimum": 0 },
+        "message": { "type": "string" },
+        "errorKind": { "$ref": "#/definitions/ErrorKind" },
+        "alSourceFile": { "type": "string" },
+        "alSourceLine": { "type": "integer", "minimum": 1 },
+        "alSourceColumn": { "type": "integer", "minimum": 1 },
+        "stackFrames": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/AlStackFrame" }
+        },
+        "stackTrace": { "type": "string" },
+        "messages": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "capturedValues": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "scopeName": { "type": "string" },
+              "variableName": { "type": "string" },
+              "value": {},
+              "statementId": { "type": "integer" }
+            }
+          }
+        }
+      }
+    },
+    "FileCoverage": {
+      "type": "object",
+      "required": ["file", "lines", "totalStatements", "hitStatements"],
+      "properties": {
+        "file": { "type": "string" },
+        "lines": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["line", "hits"],
+            "properties": {
+              "line": { "type": "integer", "minimum": 1 },
+              "hits": { "type": "integer", "minimum": 0 }
+            }
+          }
+        },
+        "totalStatements": { "type": "integer", "minimum": 0 },
+        "hitStatements": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "Summary": {
+      "type": "object",
+      "required": ["type", "exitCode", "passed", "failed", "errors", "total", "protocolVersion"],
+      "properties": {
+        "type": { "const": "summary" },
+        "exitCode": { "type": "integer" },
+        "passed": { "type": "integer", "minimum": 0 },
+        "failed": { "type": "integer", "minimum": 0 },
+        "errors": { "type": "integer", "minimum": 0 },
+        "total": { "type": "integer", "minimum": 0 },
+        "cached": { "type": "boolean" },
+        "cancelled": { "type": "boolean" },
+        "changedFiles": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "compilationErrors": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "file": { "type": "string" },
+              "errors": {
+                "type": "array",
+                "items": { "type": "string" }
+              }
+            }
+          }
+        },
+        "coverage": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/FileCoverage" }
+        },
+        "protocolVersion": { "const": 2 }
+      }
+    },
+    "Ack": {
+      "type": "object",
+      "required": ["type", "command"],
+      "properties": {
+        "type": { "const": "ack" },
+        "command": { "type": "string" },
+        "noop": { "type": "boolean" }
+      }
+    },
+    "Progress": {
+      "type": "object",
+      "required": ["type"],
+      "properties": {
+        "type": { "const": "progress" },
+        "completed": { "type": "integer", "minimum": 0 },
+        "total": { "type": "integer", "minimum": 0 }
+      }
+    }
+  },
+  "oneOf": [
+    { "$ref": "#/definitions/TestEvent" },
+    { "$ref": "#/definitions/Summary" },
+    { "$ref": "#/definitions/Ack" },
+    { "$ref": "#/definitions/Progress" }
+  ]
+}


### PR DESCRIPTION
## Summary

PR 4 of 9 — Protocol v2 split per [#1568 review](https://github.com/StefanMaron/BusinessCentral.AL.Runner/pull/1568#issuecomment-4274937532).

**Depends on PRs #1607–#1609 (merge those first).**

- `CoverageReport.ToJson()` — structured `FileCoverage[]` for inline emission. Mirrors `WriteCobertura` resolution logic but **sums hits** (vs. clamp-to-1 in Cobertura) for multi-statement line granularity.
- `AggregatePerFileLines` private helper extracted — both `WriteCobertura` and `ToJson` delegate to it, eliminating duplicate resolution loops.
- `SourceFileMapper.cs` — `GetFileForScope` with prefix-fallback documented via `<remarks>` block.
- `FileCoverage`/`LineCoverage` records with `[JsonPropertyName]` attributes for camelCase wire format.

Tests (11 new in `CoverageReportToJsonTests.cs`):
- Happy path, line deduplication (summed hits), no-hits, empty input, non-total stmts skipped, library/stub scope exclusion, null scopeToObject, deterministic ordering, camelCase serialization, scope-mapped-but-unregistered exclusion.

**Incremental commits**:
- `feat(coverage): add CoverageReport.ToJson`
- `refactor(CoverageReport): extract shared aggregator + camelCase JSON props`

## PR stack

1. #1607 — schema + types
2. #1608 — StackFrameMapper
3. #1609 — ErrorClassifier
4. **→ This PR** — CoverageReport.ToJson
5–9. (see #1568 rationale)

## Test plan

- [ ] 11 new CoverageReport tests pass
- [ ] Existing Cobertura tests still pass (shared aggregator)