### PR TITLE
fix: make TableFieldRegistry.GetSourceTableId a pure reader to remove rewrite-phase race

### DIFF
--- a/AlRunner.Tests/TableFieldRegistryConcurrencyTests.cs
+++ b/AlRunner.Tests/TableFieldRegistryConcurrencyTests.cs
@@ -1,0 +1,67 @@
+using System.Text;
+using AlRunner.Runtime;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// Thread-safety regression for <see cref="TableFieldRegistry.GetSourceTableId"/>.
+///
+/// The method used to mutate two non-concurrent dictionaries on its deferred-resolution
+/// branch. Those writes ran on the parallel rewrite path (Parallel.For in Pipeline.cs),
+/// so two threads resolving still-pending pages at once threw
+/// "Operations that change non-concurrent collections must have exclusive access...".
+/// Resolution now happens serially in ParseAndRegister, leaving GetSourceTableId a pure reader.
+///
+/// Placed in the Pipeline collection because TableFieldRegistry static state is process-global
+/// and shared with every other in-process pipeline test; the collection serializes them so no
+/// sibling test mutates the registry while this test's own Parallel.For runs.
+/// </summary>
+[Collection("Pipeline")]
+public class TableFieldRegistryConcurrencyTests
+{
+    [Fact]
+    public void GetSourceTableId_ParallelReadsOnPendingPages_NoRaceAndResolvesCorrectly()
+    {
+        const int count = 1000;
+        const int firstPageId = 50000;
+        const int firstTableId = 60000;
+
+        TableFieldRegistry.Clear();
+        try
+        {
+            // Parse the pages FIRST, before any table is registered, so every page's
+            // SourceTable is unresolved and gets parked in the pending map.
+            var pages = new StringBuilder();
+            for (int i = 0; i < count; i++)
+                pages.Append($"page {firstPageId + i} \"Page {i}\" {{ SourceTable = \"Tbl {i}\"; }}\n");
+            TableFieldRegistry.ParseAndRegister(pages.ToString());
+
+            // Now register the matching tables.
+            var tables = new StringBuilder();
+            for (int i = 0; i < count; i++)
+                tables.Append($"table {firstTableId + i} \"Tbl {i}\" {{ fields {{ field(1; PK; Integer) {{ }} }} }}\n");
+            TableFieldRegistry.ParseAndRegister(tables.ToString());
+
+            // Hammer GetSourceTableId concurrently for every page id. Each index is written by
+            // exactly one iteration, so the result array itself is race-free.
+            var results = new int?[count];
+            var ex = Record.Exception(() =>
+                Parallel.For(0, count, i => results[i] = TableFieldRegistry.GetSourceTableId(firstPageId + i)));
+
+            // No concurrent-collection exception ...
+            Assert.Null(ex);
+            // ... and every page resolves to its declared source table.
+            for (int i = 0; i < count; i++)
+                Assert.Equal(firstTableId + i, results[i]);
+
+            // Negative direction: an unregistered page id returns null, not a bogus id.
+            Assert.Null(TableFieldRegistry.GetSourceTableId(firstPageId + count + 1));
+        }
+        finally
+        {
+            // Leave the shared static registry clean for sibling tests in this collection.
+            TableFieldRegistry.Clear();
+        }
+    }
+}

--- a/AlRunner.Tests/TableFieldRegistryConcurrencyTests.cs
+++ b/AlRunner.Tests/TableFieldRegistryConcurrencyTests.cs
@@ -55,8 +55,13 @@ public class TableFieldRegistryConcurrencyTests
             for (int i = 0; i < count; i++)
                 Assert.Equal(firstTableId + i, results[i]);
 
-            // Negative direction: an unregistered page id returns null, not a bogus id.
-            Assert.Null(TableFieldRegistry.GetSourceTableId(firstPageId + count + 1));
+            // Negative direction: a page whose SourceTable names a table that is never
+            // registered stays unresolved — the sweep must not fabricate an id, and
+            // GetSourceTableId must return null rather than a bogus mapping.
+            const int orphanPageId = firstPageId + count;
+            TableFieldRegistry.ParseAndRegister(
+                $"page {orphanPageId} \"Orphan\" {{ SourceTable = \"NoSuchTable\"; }}\n");
+            Assert.Null(TableFieldRegistry.GetSourceTableId(orphanPageId));
         }
         finally
         {

--- a/AlRunner.Tests/TableFieldRegistryConcurrencyTests.cs
+++ b/AlRunner.Tests/TableFieldRegistryConcurrencyTests.cs
@@ -7,11 +7,12 @@ namespace AlRunner.Tests;
 /// <summary>
 /// Thread-safety regression for <see cref="TableFieldRegistry.GetSourceTableId"/>.
 ///
-/// The method used to mutate two non-concurrent dictionaries on its deferred-resolution
-/// branch. Those writes ran on the parallel rewrite path (Parallel.For in Pipeline.cs),
-/// so two threads resolving still-pending pages at once threw
+/// GetSourceTableId is called from the parallel rewrite path (Parallel.For in Pipeline.cs)
+/// and must stay a pure reader: a dictionary write on that path throws
 /// "Operations that change non-concurrent collections must have exclusive access...".
-/// Resolution now happens serially in ParseAndRegister, leaving GetSourceTableId a pure reader.
+/// Pending page→source-table entries are therefore resolved serially inside
+/// ParseAndRegister; this test parks 1000 pending pages, resolves them, and hammers
+/// GetSourceTableId concurrently to guard that invariant.
 ///
 /// Placed in the Pipeline collection because TableFieldRegistry static state is process-global
 /// and shared with every other in-process pipeline test; the collection serializes them so no

--- a/AlRunner/Runtime/TableFieldRegistry.cs
+++ b/AlRunner/Runtime/TableFieldRegistry.cs
@@ -277,13 +277,9 @@ public static class TableFieldRegistry
             if (!stMatch.Success) continue;
 
             var tableName = stMatch.Groups[1].Success ? stMatch.Groups[1].Value : stMatch.Groups[2].Value;
-            if (nameToId.TryGetValue(tableName, out var sourceTableId))
-                _pageSourceTable[pageId] = sourceTableId;
-            else
-                // Table not registered yet (page parsed before its source table) — park the
-                // table name; it is resolved by the eager sweep at the end of ParseAndRegister
-                // (every parse pass runs serially before the parallel rewrite).
-                _pagePendingSourceTable[pageId] = tableName;
+            // Park the name unconditionally; the sweep at the end of this call is the single
+            // resolution path for page→source-table mappings.
+            _pagePendingSourceTable[pageId] = tableName;
 
             // Track SourceTableTemporary = true so the rewriter can emit
             // new MockRecordHandle(tableId, true) for the page's Rec property.
@@ -373,24 +369,18 @@ public static class TableFieldRegistry
             }
         }
 
-        // Eagerly resolve any pending page→source-table entries now that this file's tables
-        // are registered. ParseAndRegister runs serially for every source file before the
-        // parallel rewrite, so resolving here keeps GetSourceTableId a pure, lock-free reader —
-        // no dictionary writes on the parallel hot path.
-        if (_pagePendingSourceTable.Count > 0)
+        // Resolve pending page→source-table entries against the tables registered so far.
+        // ParseAndRegister runs serially for every source file before the parallel rewrite,
+        // so resolving here keeps GetSourceTableId a pure, lock-free reader — no dictionary
+        // writes on the parallel hot path. Removing while enumerating is safe: on the
+        // net8.0+ targets, Dictionary.Remove does not invalidate active enumerators.
+        foreach (var pending in _pagePendingSourceTable)
         {
-            List<int>? resolvedPages = null;
-            foreach (var pending in _pagePendingSourceTable)
+            if (nameToId.TryGetValue(pending.Value, out var resolvedTableId))
             {
-                if (nameToId.TryGetValue(pending.Value, out var resolvedTableId))
-                {
-                    _pageSourceTable[pending.Key] = resolvedTableId;
-                    (resolvedPages ??= new()).Add(pending.Key);
-                }
+                _pageSourceTable[pending.Key] = resolvedTableId;
+                _pagePendingSourceTable.Remove(pending.Key);
             }
-            if (resolvedPages != null)
-                foreach (var pageId in resolvedPages)
-                    _pagePendingSourceTable.Remove(pageId);
         }
     }
 
@@ -420,8 +410,8 @@ public static class TableFieldRegistry
     /// <c>SourceTable = "TableName"</c> in the page definition, or <c>null</c> if
     /// not registered.
     ///
-    /// Pages whose source table is parsed after the page itself are parked as pending
-    /// entries during <see cref="ParseAndRegister"/> and resolved at the end of each
+    /// Page→source-table mappings are parked as pending entries during
+    /// <see cref="ParseAndRegister"/> and resolved by the sweep at the end of each
     /// parse pass — all of which run serially before the parallel rewrite. This method
     /// is therefore a pure reader with no writes, safe to call concurrently.
     /// </summary>

--- a/AlRunner/Runtime/TableFieldRegistry.cs
+++ b/AlRunner/Runtime/TableFieldRegistry.cs
@@ -280,8 +280,9 @@ public static class TableFieldRegistry
             if (nameToId.TryGetValue(tableName, out var sourceTableId))
                 _pageSourceTable[pageId] = sourceTableId;
             else
-                // Table not registered yet (page parsed before its source table) — store
-                // the table name for deferred resolution when GetSourceTableId() is called.
+                // Table not registered yet (page parsed before its source table) — park the
+                // table name; it is resolved by the eager sweep at the end of ParseAndRegister
+                // (every parse pass runs serially before the parallel rewrite).
                 _pagePendingSourceTable[pageId] = tableName;
 
             // Track SourceTableTemporary = true so the rewriter can emit

--- a/AlRunner/Runtime/TableFieldRegistry.cs
+++ b/AlRunner/Runtime/TableFieldRegistry.cs
@@ -371,6 +371,26 @@ public static class TableFieldRegistry
                 _optionMembersFields[(baseTableId, fieldId)] = om.Groups[2].Value.Trim();
             }
         }
+
+        // Eagerly resolve any pending page→source-table entries now that this file's tables
+        // are registered. ParseAndRegister runs serially for every source file before the
+        // parallel rewrite, so resolving here keeps GetSourceTableId a pure, lock-free reader —
+        // no dictionary writes on the parallel hot path.
+        if (_pagePendingSourceTable.Count > 0)
+        {
+            List<int>? resolvedPages = null;
+            foreach (var pending in _pagePendingSourceTable)
+            {
+                if (nameToId.TryGetValue(pending.Value, out var resolvedTableId))
+                {
+                    _pageSourceTable[pending.Key] = resolvedTableId;
+                    (resolvedPages ??= new()).Add(pending.Key);
+                }
+            }
+            if (resolvedPages != null)
+                foreach (var pageId in resolvedPages)
+                    _pagePendingSourceTable.Remove(pageId);
+        }
     }
 
     public static int? GetFieldId(int tableId, string fieldName)
@@ -397,33 +417,15 @@ public static class TableFieldRegistry
     /// <summary>
     /// Returns the source table ID for the given page, as declared by
     /// <c>SourceTable = "TableName"</c> in the page definition, or <c>null</c> if
-    /// not registered.  Populated by <see cref="ParseAndRegister"/> when it
-    /// processes page declarations.
+    /// not registered.
     ///
-    /// When the page was parsed before its source table (file ordering issue),
-    /// the table name is stored as a pending entry and resolved here on first call
-    /// once the table has been registered.
+    /// Pages whose source table is parsed after the page itself are parked as pending
+    /// entries during <see cref="ParseAndRegister"/> and resolved at the end of each
+    /// parse pass — all of which run serially before the parallel rewrite. This method
+    /// is therefore a pure reader with no writes, safe to call concurrently.
     /// </summary>
     public static int? GetSourceTableId(int pageId)
-    {
-        if (_pageSourceTable.TryGetValue(pageId, out var id)) return id;
-
-        // Deferred resolution: the page was parsed before its source table was registered.
-        if (_pagePendingSourceTable.TryGetValue(pageId, out var pendingName))
-        {
-            // Try to resolve now that all tables may have been registered.
-            foreach (var kv in _tableNames)
-            {
-                if (string.Equals(kv.Value, pendingName, StringComparison.OrdinalIgnoreCase))
-                {
-                    _pageSourceTable[pageId] = kv.Key;
-                    _pagePendingSourceTable.Remove(pageId);
-                    return kv.Key;
-                }
-            }
-        }
-        return null;
-    }
+        => _pageSourceTable.TryGetValue(pageId, out var id) ? id : (int?)null;
 
     /// <summary>
     /// Returns <c>true</c> when the page declared <c>SourceTableTemporary = true</c>.


### PR DESCRIPTION
## Problem
`TableFieldRegistry.GetSourceTableId(int pageId)` looked like an accessor but, on its deferred-resolution branch, **mutated** two non-concurrent `Dictionary<,>` fields (`_pageSourceTable`, `_pagePendingSourceTable`). The rewriter calls it from the page-`Rec` fallback inside `Pipeline`'s `Parallel.For`, so two threads resolving still-pending pages mutated the same dictionary at once → `InvalidOperationException: Operations that change non-concurrent collections must have exclusive access...`. The rewriter caught it, emitted an empty fallback class, and counted a rewrite failure → exit 2 → `--strict` → exit 1 → phantom red CI.

## Fix
Resolve pending page→source-table entries **eagerly at the end of `ParseAndRegister`**. `ParseAndRegister` runs serially for every source file before the parallel rewrite, so all tables are registered by then and `GetSourceTableId` becomes a pure, lock-free reader with **no writes on any parallel path**. This also closes the same latent race for the two runtime callers (`MockFormHandle`, `MockTestPageHandle`). `GetIsSourceTableTemporary` (read-only `HashSet.Contains`) was already safe and is untouched.

## Tests (red → green)
New `AlRunner.Tests/TableFieldRegistryConcurrencyTests.cs`:
- Parks 1000 pending pages (pages parsed before their tables), then hammers `GetSourceTableId` from `Parallel.For`.
- **RED** (before fix): fails with the concurrent-collection `InvalidOperationException` thrown from `GetSourceTableId`.
- **GREEN** (after fix): no exception, every page resolves to its declared source table, unregistered page returns `null`.
- Lives in the `Pipeline` collection (`DisableParallelization = true`) because `TableFieldRegistry` static state is process-global.

## Validation
- `dotnet test AlRunner.Tests/` — **534 passed**.
- AL e2e matrix (net10.0): bucket-1 **1986**, bucket-2 **2289**, bucket-feature-niw **4**, stubs **2** — all green.

Internal-only change, no externally visible behavior → no `README`/`--guide`/`coverage.yaml` updates; `CHANGELOG.md` untouched (auto-generated).

Closes #1626

🤖 Generated with [Claude Code](https://claude.com/claude-code)