### PR TITLE
fix: raise platform error when Record.Get receives more key values than PK fields — closes #1630

### DIFF
--- a/AlRunner.Tests/GetKeyArityGuardTests.cs
+++ b/AlRunner.Tests/GetKeyArityGuardTests.cs
@@ -1,0 +1,151 @@
+using AlRunner.Runtime;
+using Microsoft.Dynamics.Nav.Runtime;
+using Microsoft.Dynamics.Nav.Types;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// The over-arity guard in MockRecordHandle.ALGet ("Too many key fields were
+/// specified...") must only fire when the runner affirmatively knows the
+/// table's primary key width. Sources of an understated PK width that must
+/// NOT trigger the guard:
+///  - quoted PK field names containing parentheses (e.g. "Amount (LCY)"),
+///    which the key parser must handle without truncating the key list;
+///  - tables never registered with the field registry (fallback PK [1]);
+///  - auto-stub tables, whose synthesized single-field PK says nothing about
+///    the real table's PK.
+/// </summary>
+public class GetKeyArityGuardTests
+{
+    private const int ParenPkTableId = 99761;
+    private const int UnregisteredTableId = 99762;
+    private const int StubTableId = 99763;
+    private const int RegisteredTableId = 99764;
+
+    [Fact]
+    public void ParseAndRegister_QuotedPkFieldNameWithParens_RegistersFullPkWidth()
+    {
+        TableFieldRegistry.ParseAndRegister($$"""
+            table {{ParenPkTableId}} "Paren Guard Table"
+            {
+                fields
+                {
+                    field(1; "Code (Main)"; Code[20]) { }
+                    field(2; "Line No."; Integer) { }
+                }
+                keys
+                {
+                    key(PK; "Code (Main)", "Line No.") { Clustered = true; }
+                }
+            }
+            """);
+
+        var handle = new MockRecordHandle(ParenPkTableId);
+        Assert.Equal(2, handle.GetPrimaryKeyFieldNos().Length);
+    }
+
+    [Fact]
+    public void ALGet_UnregisteredTable_MoreValuesThanFallbackPk_DoesNotThrow()
+    {
+        var handle = new MockRecordHandle(UnregisteredTableId);
+
+        // The [1] fallback PK is a guess, not the table's real PK width —
+        // the guard must not reject a call the real table may well accept.
+        var found = handle.ALGet(DataError.TrapError, new NavText("A"), NavInteger.Create(1));
+
+        Assert.False(found);
+    }
+
+    [Fact]
+    public void ALGet_AutoStubTable_MoreValuesThanSynthesizedPk_DoesNotThrow()
+    {
+        // Exact shape DepExtractor.GenerateStub emits for a missing table.
+        TableFieldRegistry.ParseAndRegister(
+            $"table {StubTableId} \"Stub Guard Table\" {{ /* {TableFieldRegistry.SynthesizedSchemaMarker} */ fields {{ field(1; \"DummyKey\"; Code[20]) {{}} }} keys {{ key(PK; \"DummyKey\") {{}} }} }}");
+
+        var handle = new MockRecordHandle(StubTableId);
+        var found = handle.ALGet(DataError.TrapError, new NavText("A"), NavInteger.Create(1));
+
+        Assert.False(found);
+    }
+
+    [Fact]
+    public void ALGet_RegisteredPk_MoreValuesThanPkFields_StillThrowsPlatformError()
+    {
+        TableFieldRegistry.ParseAndRegister($$"""
+            table {{RegisteredTableId}} "Known PK Table"
+            {
+                fields
+                {
+                    field(1; "Code 1"; Code[20]) { }
+                    field(2; "Int 1"; Integer) { }
+                }
+                keys
+                {
+                    key(PK; "Code 1", "Int 1") { Clustered = true; }
+                }
+            }
+            """);
+
+        var handle = new MockRecordHandle(RegisteredTableId);
+        var ex = Assert.Throws<Exception>(() =>
+            handle.ALGet(DataError.TrapError, new NavText("A"), NavInteger.Create(1), NavInteger.Create(42)));
+
+        Assert.Contains("Too many key fields were specified", ex.Message);
+        Assert.Contains("The number of fields in the primary key is 2.", ex.Message);
+    }
+
+    [Fact]
+    public void ExtractDeps_MissingTableStub_CarriesSynthesizedSchemaMarker()
+    {
+        // Missing-object detection runs in the trial-compile fixup rounds,
+        // so this scenario needs alc (same skip rule as DuplicatePackageTests).
+        if (AlcPathResolver.Default == null) return;
+
+        var depRoot = Path.Combine(Path.GetTempPath(), "al-dep-mark-" + Guid.NewGuid().ToString("N")[..8]);
+        var outDir = Path.Combine(Path.GetTempPath(), "al-out-mark-" + Guid.NewGuid().ToString("N")[..8]);
+        var extDir = Path.Combine(Path.GetTempPath(), "al-ext-mark-" + Guid.NewGuid().ToString("N")[..8]);
+        try
+        {
+            // App-structured dep layout — stub emission requires a consumer
+            // app to attach the generated file to.
+            var depDir = Path.Combine(depRoot, "DepApp");
+            Directory.CreateDirectory(depDir);
+            Directory.CreateDirectory(extDir);
+
+            // Dependency codeunit references a table that exists nowhere —
+            // DepExtractor must emit a stub for it.
+            File.WriteAllText(Path.Combine(depDir, "Consumer.al"), """
+                codeunit 50020 "Ghost Consumer"
+                {
+                    procedure Run()
+                    var Ghost: Record "Ghost Guard Table";
+                    begin Ghost.FindFirst(); end;
+                }
+                """);
+            File.WriteAllText(Path.Combine(extDir, "MyExt.al"), """
+                codeunit 50021 "Marker Ext"
+                {
+                    procedure Run()
+                    var C: Codeunit "Ghost Consumer";
+                    begin C.Run(); end;
+                }
+                """);
+
+            int rc = DepExtractor.ExtractDeps(extDir, new[] { depRoot }, outDir);
+
+            Assert.Equal(0, rc);
+            var files = Directory.GetFiles(outDir, "*.al", SearchOption.AllDirectories);
+            var stub = files.Select(File.ReadAllText)
+                .SingleOrDefault(t => t.Contains("Ghost Guard Table") && t.Contains("table "));
+            Assert.NotNull(stub);
+            Assert.Contains(TableFieldRegistry.SynthesizedSchemaMarker, stub);
+        }
+        finally
+        {
+            foreach (var d in new[] { depRoot, outDir, extDir })
+                if (Directory.Exists(d)) Directory.Delete(d, true);
+        }
+    }
+}

--- a/AlRunner/DepExtractor.cs
+++ b/AlRunner/DepExtractor.cs
@@ -820,7 +820,7 @@ public static class DepExtractor
     private static string GenerateStub(string typeName, string objectName, int id) =>
         typeName switch
         {
-            "Table"     => $"table {id} \"{objectName}\" {{ fields {{ field(1; \"DummyKey\"; Code[20]) {{}} }} keys {{ key(PK; \"DummyKey\") {{}} }} }}",
+            "Table"     => $"table {id} \"{objectName}\" {{ /* {Runtime.TableFieldRegistry.SynthesizedSchemaMarker} */ fields {{ field(1; \"DummyKey\"; Code[20]) {{}} }} keys {{ key(PK; \"DummyKey\") {{}} }} }}",
             "Page"      => $"page {id} \"{objectName}\" {{ }}",
             "Codeunit"  => $"codeunit {id} \"{objectName}\" {{ }}",
             "Enum"      => $"enum {id} \"{objectName}\" {{ value(0; Default) {{}} }}",
@@ -878,7 +878,7 @@ public static class DepExtractor
             fieldDecls.Add($"field({nextFieldId++}; \"{f}\"; Text[250]) {{}}");
         }
         var fields = string.Join(" ", fieldDecls);
-        return $"table {id} \"{objectName}\" {{ fields {{ {fields} }} keys {{ key(PK; \"DummyKey\") {{}} }} }}";
+        return $"table {id} \"{objectName}\" {{ /* {Runtime.TableFieldRegistry.SynthesizedSchemaMarker} */ fields {{ {fields} }} keys {{ key(PK; \"DummyKey\") {{}} }} }}";
     }
 
     /// <summary>

--- a/AlRunner/Pipeline.cs
+++ b/AlRunner/Pipeline.cs
@@ -1708,7 +1708,7 @@ public class AlRunnerPipeline
             var stubAl = compilation != null
                 ? RenderTableStubFromSymbols(compilation, id)
                 : null;
-            alStubs.Add(stubAl ?? $"table {id} \"AutoStub{id}\" {{ fields {{ field(1; PK; Integer) {{ }} }} keys {{ key(PK; PK) {{ Clustered = true; }} }} }}");
+            alStubs.Add(stubAl ?? $"table {id} \"AutoStub{id}\" {{ /* {Runtime.TableFieldRegistry.SynthesizedSchemaMarker} */ fields {{ field(1; PK; Integer) {{ }} }} keys {{ key(PK; PK) {{ Clustered = true; }} }} }}");
         }
 
         // Register table stubs with field/init-value registries so runtime mocks

--- a/AlRunner/Runtime/MockRecordHandle.cs
+++ b/AlRunner/Runtime/MockRecordHandle.cs
@@ -949,6 +949,13 @@ public class MockRecordHandle : IConvertible
     {
         var table = GetRows();
         var pkFields = GetPrimaryKeyFields();
+        if (keyValues.Length > pkFields.Length)
+        {
+            // The platform raises this unconditionally — even when Get's return
+            // value is consumed — and quotes the table name, not the caption.
+            string overKeyedTableName = TableFieldRegistry.GetTableName(_tableId) ?? $"table {_tableId}";
+            throw new Exception($"Too many key fields were specified, so \"{overKeyedTableName}\" could not be retrieved. The number of fields in the primary key is {pkFields.Length}.");
+        }
         foreach (var row in table)
         {
             bool match = true;

--- a/AlRunner/Runtime/MockRecordHandle.cs
+++ b/AlRunner/Runtime/MockRecordHandle.cs
@@ -45,6 +45,13 @@ public class MockRecordHandle : IConvertible
     // Primary key field numbers per table (registered via RegisterPrimaryKey)
     private static readonly Dictionary<int, int[]> _primaryKeys = new();
 
+    // Tables whose registered PK width is authoritative — parsed from a fully
+    // resolved keys block of real table source, or registered explicitly.
+    // Tables outside this set (unregistered fallback [1], synthesized stubs,
+    // partially resolved key declarations) may understate the real PK width,
+    // so arity enforcement must skip them.
+    private static readonly HashSet<int> _authoritativePks = new();
+
     // All declared keys per table, in declaration order. Index 0 = primary key.
     // Used by ALCurrentKeyIndex get/set to switch iteration sort order.
     private static readonly Dictionary<int, List<int[]>> _tableKeys = new();
@@ -213,6 +220,7 @@ public class MockRecordHandle : IConvertible
     public static void RegisterPrimaryKey(int tableId, params int[] fieldNos)
     {
         _primaryKeys[tableId] = fieldNos;
+        _authoritativePks.Add(tableId);
         // Keep _tableKeys[0] in sync with primary key for ALCurrentKeyIndex resolution.
         if (!_tableKeys.TryGetValue(tableId, out var list))
             _tableKeys[tableId] = list = new List<int[]>();
@@ -227,11 +235,15 @@ public class MockRecordHandle : IConvertible
     /// The first entry is the clustered primary key. Subsequent entries are
     /// secondary keys referenced by <c>RecRef.CurrentKeyIndex := N</c>.
     /// </summary>
-    public static void RegisterKeys(int tableId, List<int[]> keys)
+    public static void RegisterKeys(int tableId, List<int[]> keys, bool pkAuthoritative = true)
     {
         if (keys == null || keys.Count == 0) return;
         _tableKeys[tableId] = new List<int[]>(keys);
         _primaryKeys[tableId] = keys[0];
+        if (pkAuthoritative)
+            _authoritativePks.Add(tableId);
+        else
+            _authoritativePks.Remove(tableId);
     }
 
     internal static List<int[]> GetKeysForTable(int tableId)
@@ -949,12 +961,13 @@ public class MockRecordHandle : IConvertible
     {
         var table = GetRows();
         var pkFields = GetPrimaryKeyFields();
-        if (keyValues.Length > pkFields.Length)
+        if (keyValues.Length > pkFields.Length && _authoritativePks.Contains(_tableId))
         {
             // The platform raises this unconditionally — even when Get's return
             // value is consumed — and quotes the table name, not the caption.
-            string overKeyedTableName = TableFieldRegistry.GetTableName(_tableId) ?? $"table {_tableId}";
-            throw new Exception($"Too many key fields were specified, so \"{overKeyedTableName}\" could not be retrieved. The number of fields in the primary key is {pkFields.Length}.");
+            // Enforced only for authoritative PKs: an understated fallback or
+            // stub PK width would reject calls the real table accepts.
+            throw new Exception($"Too many key fields were specified, so \"{ALTableName}\" could not be retrieved. The number of fields in the primary key is {pkFields.Length}.");
         }
         foreach (var row in table)
         {

--- a/AlRunner/Runtime/TableFieldRegistry.cs
+++ b/AlRunner/Runtime/TableFieldRegistry.cs
@@ -52,8 +52,10 @@ public static class TableFieldRegistry
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
     // key(Name; Field1, "Quoted Field 2", Field3)  — only the fields we need.
+    // Quoted names may contain ')' (e.g. "Amount (LCY)"), so consume quoted
+    // chunks whole instead of stopping at the first ')'.
     private static readonly Regex KeyDecl = new(
-        @"\bkey\s*\(\s*[^;]+;\s*([^)]+)\)",
+        @"\bkey\s*\(\s*[^;]+;\s*((?:""[^""]*""|[^)""])+)\)",
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
     // AL escapes embedded apostrophes by doubling them, e.g. 'Vendor''s Name'.
@@ -118,8 +120,17 @@ public static class TableFieldRegistry
         _pageSourceTableTemporary.Clear();
     }
 
+    /// <summary>
+    /// Marker embedded (as an AL block comment) in auto-generated table stubs
+    /// whose schema is synthesized rather than taken from real table source.
+    /// A synthesized primary key says nothing about the real table's PK, so
+    /// arity checks must not be enforced against it.
+    /// </summary>
+    public const string SynthesizedSchemaMarker = "alrunner-synthesized-schema";
+
     public static void ParseAndRegister(string alSource)
     {
+        bool synthesizedSchema = alSource.Contains(SynthesizedSchemaMarker, StringComparison.Ordinal);
         foreach (Match tm in TableHeader.Matches(alSource))
         {
             if (!int.TryParse(tm.Groups[1].Value, out var tableId)) continue;
@@ -228,24 +239,37 @@ public static class TableFieldRegistry
 
             // Extract all declared keys (primary + secondary) and register them
             // so RecRef.CurrentKeyIndex := N can switch the active sort key.
-            // The first matched key is the clustered primary key.
+            // The first matched key is the clustered primary key. The PK is
+            // only "authoritative" (safe to enforce arity against) when every
+            // declared field of that first key resolved to a field id and the
+            // source is not a synthesized stub — otherwise the registered
+            // width can understate the real table's PK.
             var keys = new List<int[]>();
+            bool firstKeyFullyResolved = false;
+            bool isFirstKeyDecl = true;
             foreach (Match km in KeyDecl.Matches(body))
             {
                 var keyList = km.Groups[1].Value;
                 var keyFieldIds = new List<int>();
+                int declaredParts = 0;
                 foreach (var rawPart in keyList.Split(','))
                 {
                     var part = rawPart.Trim().Trim('"').Trim();
                     if (part.Length == 0) continue;
+                    declaredParts++;
                     if (fields.TryGetValue(part, out var fid))
                         keyFieldIds.Add(fid);
+                }
+                if (isFirstKeyDecl)
+                {
+                    firstKeyFullyResolved = declaredParts > 0 && keyFieldIds.Count == declaredParts;
+                    isFirstKeyDecl = false;
                 }
                 if (keyFieldIds.Count > 0)
                     keys.Add(keyFieldIds.ToArray());
             }
             if (keys.Count > 0)
-                MockRecordHandle.RegisterKeys(tableId, keys);
+                MockRecordHandle.RegisterKeys(tableId, keys, pkAuthoritative: firstKeyFullyResolved && !synthesizedSchema);
         }
 
         // Parse tableextension and page declarations: both need a name→ID reverse map.

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -8911,8 +8911,9 @@ Table.Get (Joker):
   tests:
     - tests/bucket-1/record-table/02-record-operations
     - tests/bucket-1/record-table/188-table-crud
+    - tests/bucket-1/record-table/102-get-key-arity
     - tests/bucket-2/data-formats/96-object-to-navvalue
-  notes: ALGet(DataError, params NavValue[]) plus object catch-all overloads for 1–4 keys (issue #1260, NavComplexValue→object rewrite).
+  notes: ALGet(DataError, params NavValue[]) plus object catch-all overloads for 1–4 keys (issue #1260, NavComplexValue→object rewrite). Raises the platform "Too many key fields were specified" error when more values than PK fields are supplied, unconditionally and quoting the table name — container-verified on BC 28.1 (issue #1630).
 
 Table.GetAscending (Joker):
   layer: runtime-api

--- a/docs/coverage.yaml
+++ b/docs/coverage.yaml
@@ -8913,7 +8913,7 @@ Table.Get (Joker):
     - tests/bucket-1/record-table/188-table-crud
     - tests/bucket-1/record-table/102-get-key-arity
     - tests/bucket-2/data-formats/96-object-to-navvalue
-  notes: ALGet(DataError, params NavValue[]) plus object catch-all overloads for 1–4 keys (issue #1260, NavComplexValue→object rewrite). Raises the platform "Too many key fields were specified" error when more values than PK fields are supplied, unconditionally and quoting the table name — container-verified on BC 28.1 (issue #1630).
+  notes: ALGet(DataError, params NavValue[]) plus object catch-all overloads for 1–4 keys (issue #1260, NavComplexValue→object rewrite). Raises the platform "Too many key fields were specified" error when more values than PK fields are supplied, unconditionally and quoting the table name — container-verified on BC 28.1 (issue #1630). Enforced only when the registered PK width is authoritative (fully parsed keys block of real table source, incl. quoted names containing parens); auto-stubbed tables, unregistered tables, and partially resolved key declarations fail open so an understated PK width never rejects a call real BC accepts.
 
 Table.GetAscending (Joker):
   layer: runtime-api

--- a/tests/bucket-1/record-table/102-get-key-arity/src/ParenPkTable.al
+++ b/tests/bucket-1/record-table/102-get-key-arity/src/ParenPkTable.al
@@ -1,0 +1,28 @@
+table 50136 "Paren PK Table"
+{
+    DataClassification = ToBeClassified;
+
+    fields
+    {
+        field(1; "Code (Main)"; Code[20])
+        {
+            DataClassification = ToBeClassified;
+        }
+        field(2; "Line No."; Integer)
+        {
+            DataClassification = ToBeClassified;
+        }
+        field(3; "Payload"; Text[50])
+        {
+            DataClassification = ToBeClassified;
+        }
+    }
+
+    keys
+    {
+        key(PK; "Code (Main)", "Line No.")
+        {
+            Clustered = true;
+        }
+    }
+}

--- a/tests/bucket-1/record-table/102-get-key-arity/src/TwoKeyTable.al
+++ b/tests/bucket-1/record-table/102-get-key-arity/src/TwoKeyTable.al
@@ -1,0 +1,29 @@
+table 50134 "Two Key Arity Table"
+{
+    Caption = 'Two Key Arity Caption';
+    DataClassification = ToBeClassified;
+
+    fields
+    {
+        field(1; "Code 1"; Code[20])
+        {
+            DataClassification = ToBeClassified;
+        }
+        field(2; "Int 1"; Integer)
+        {
+            DataClassification = ToBeClassified;
+        }
+        field(3; "Payload"; Text[50])
+        {
+            DataClassification = ToBeClassified;
+        }
+    }
+
+    keys
+    {
+        key(PK; "Code 1", "Int 1")
+        {
+            Clustered = true;
+        }
+    }
+}

--- a/tests/bucket-1/record-table/102-get-key-arity/test/GetKeyArityTest.al
+++ b/tests/bucket-1/record-table/102-get-key-arity/test/GetKeyArityTest.al
@@ -1,0 +1,85 @@
+codeunit 50135 "Get Key Arity Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit Assert;
+
+    [Test]
+    procedure GetWithExactKeyArityRetrievesRow()
+    var
+        Rec: Record "Two Key Arity Table";
+    begin
+        // [GIVEN] A row keyed by the 2-field primary key
+        Rec.Init();
+        Rec."Code 1" := 'A';
+        Rec."Int 1" := 1;
+        Rec.Payload := 'hello';
+        Rec.Insert(false);
+
+        // [WHEN] Getting with exactly as many values as PK fields
+        Clear(Rec);
+        Assert.IsTrue(Rec.Get('A', 1), 'Get with exact key arity must retrieve the row');
+
+        // [THEN] The retrieved row carries the non-key payload
+        Assert.AreEqual('hello', Rec.Payload, 'Retrieved row must carry the payload');
+    end;
+
+    [Test]
+    procedure GetWithTooManyKeyValuesErrors()
+    var
+        Rec: Record "Two Key Arity Table";
+    begin
+        // [GIVEN] A row keyed by the 2-field primary key
+        Rec.Init();
+        Rec."Code 1" := 'A';
+        Rec."Int 1" := 1;
+        Rec.Insert(false);
+
+        // [WHEN] Getting with 3 values against a 2-field PK
+        // [THEN] The platform error fires, quoting the table NAME (not the
+        // Caption — verified on a real BC 28.1 container)
+        asserterror Rec.Get('A', 1, 42);
+        Assert.ExpectedError('Too many key fields were specified, so "Two Key Arity Table" could not be retrieved. The number of fields in the primary key is 2.');
+    end;
+
+    [Test]
+    procedure ConsumedOverKeyedGetAlsoErrors()
+    var
+        Rec: Record "Two Key Arity Table";
+    begin
+        // [GIVEN] A row keyed by the 2-field primary key
+        Rec.Init();
+        Rec."Code 1" := 'A';
+        Rec."Int 1" := 1;
+        Rec.Insert(false);
+
+        // [WHEN] The over-keyed Get's return value is consumed by an if
+        // [THEN] The error still fires — real BC raises it unconditionally,
+        // it is not a "record not found" condition (container-verified)
+        asserterror
+            if Rec.Get('A', 1, 42) then;
+        Assert.ExpectedError('Too many key fields were specified');
+    end;
+
+    [Test]
+    procedure GetWithFewerKeyValuesStillSucceeds()
+    var
+        Rec: Record "Two Key Arity Table";
+    begin
+        // [GIVEN] A row whose trailing PK field is the type default
+        Rec.Init();
+        Rec."Code 1" := 'D';
+        Rec."Int 1" := 0;
+        Rec.Payload := 'default-int';
+        Rec.Insert(false);
+
+        // [WHEN] Getting with fewer values than PK fields
+        // [THEN] No arity error fires and the default-keyed row is found —
+        // guards the over-arity check against overshooting into rejecting
+        // under-arity calls, which real BC accepts
+        Clear(Rec);
+        Assert.IsTrue(Rec.Get('D'), 'Under-arity Get must not raise the too-many-key-fields error');
+        Assert.AreEqual('default-int', Rec.Payload, 'Under-arity Get must retrieve the row keyed by defaults');
+    end;
+}

--- a/tests/bucket-1/record-table/102-get-key-arity/test/GetKeyArityTest.al
+++ b/tests/bucket-1/record-table/102-get-key-arity/test/GetKeyArityTest.al
@@ -75,11 +75,13 @@ codeunit 50135 "Get Key Arity Tests"
         Rec.Insert(false);
 
         // [WHEN] Getting with fewer values than PK fields
-        // [THEN] No arity error fires and the default-keyed row is found —
+        // [THEN] No arity error fires and the call still finds the row —
         // guards the over-arity check against overshooting into rejecting
-        // under-arity calls, which real BC accepts
+        // under-arity calls, which real BC accepts. Deliberately does not
+        // pin HOW the missing trailing value binds; with a single row the
+        // lookup semantics are indistinguishable.
         Clear(Rec);
         Assert.IsTrue(Rec.Get('D'), 'Under-arity Get must not raise the too-many-key-fields error');
-        Assert.AreEqual('default-int', Rec.Payload, 'Under-arity Get must retrieve the row keyed by defaults');
+        Assert.AreEqual('default-int', Rec.Payload, 'Under-arity Get must still find the row');
     end;
 }

--- a/tests/bucket-1/record-table/102-get-key-arity/test/GetKeyArityTest.al
+++ b/tests/bucket-1/record-table/102-get-key-arity/test/GetKeyArityTest.al
@@ -84,4 +84,42 @@ codeunit 50135 "Get Key Arity Tests"
         Assert.IsTrue(Rec.Get('D'), 'Under-arity Get must not raise the too-many-key-fields error');
         Assert.AreEqual('default-int', Rec.Payload, 'Under-arity Get must still find the row');
     end;
+
+    [Test]
+    procedure GetOnParenNamedPkWithExactAritySucceeds()
+    var
+        Rec: Record "Paren PK Table";
+    begin
+        // [GIVEN] A row in a table whose first PK field name contains
+        // parentheses (cf. BaseApp names like "Amount (LCY)")
+        Rec.Init();
+        Rec."Code (Main)" := 'X';
+        Rec."Line No." := 7;
+        Rec.Payload := 'paren-row';
+        Rec.Insert(false);
+
+        // [WHEN] Getting with exactly as many values as the 2-field PK
+        // [THEN] The call succeeds — the paren in the quoted field name must
+        // not shrink the PK the arity check compares against
+        Clear(Rec);
+        Assert.IsTrue(Rec.Get('X', 7), 'Exact-arity Get on a paren-named PK field must retrieve the row');
+        Assert.AreEqual('paren-row', Rec.Payload, 'Retrieved row must carry the payload');
+    end;
+
+    [Test]
+    procedure GetOnParenNamedPkOverArityErrors()
+    var
+        Rec: Record "Paren PK Table";
+    begin
+        // [GIVEN] A row in the paren-named-PK table
+        Rec.Init();
+        Rec."Code (Main)" := 'X';
+        Rec."Line No." := 7;
+        Rec.Insert(false);
+
+        // [WHEN] Getting with 3 values against the 2-field PK
+        // [THEN] The platform error fires and reports the true PK width, 2
+        asserterror Rec.Get('X', 7, 42);
+        Assert.ExpectedError('Too many key fields were specified, so "Paren PK Table" could not be retrieved. The number of fields in the primary key is 2.');
+    end;
 }


### PR DESCRIPTION
Closes #1630

## What

`MockRecordHandle.ALGet` now raises the platform error when more key values are supplied than the primary key has fields:

```
Too many key fields were specified, so "<Table>" could not be retrieved. The number of fields in the primary key is N.
```

The previous loop bound `i < keyValues.Length && i < pkFields.Length` silently dropped surplus values — and since `alc.exe` (with CodeCop/UICop/AppSourceCop enabled) emits no diagnostic for the over-keyed call, the runtime check is the only enforcement point in the entire toolchain.

## Container-verified semantics

Two behaviors were probed on a fresh BC 28.1 sandbox container (BcContainerHelper 6.1.10, artifact `onprem/28.1.49838.49886/w1`) before implementing, byte-identical repro codeunits on both runtimes:

| Question | Real BC 28.1 answer | Fix |
|---|---|---|
| Does the error fire when `Get`'s return value is consumed (`if Rec.Get('A',1,42) then`)? | **Yes** — probe test `ConsumedOverKeyedGetStillThrows` passed with `asserterror` around the if-form | Throw unconditionally, before the row scan, regardless of `DataError` level |
| Does the message quote the table Caption or name? | **Name** — a table with `Caption = 'Arity Probe Caption'` reported `so "Arity Probe Table" could not be retrieved` | Message uses `TableFieldRegistry.GetTableName` |

## Tests (`tests/bucket-1/record-table/102-get-key-arity/`)

- `GetWithExactKeyArityRetrievesRow` — positive: exact-arity Get retrieves the row and its payload
- `GetWithTooManyKeyValuesErrors` — negative: 3 values vs 2-field PK raises the full platform error text (RED before fix: "no error occurred"; GREEN after)
- `ConsumedOverKeyedGetAlsoErrors` — the error also fires when the return value is consumed
- `GetWithFewerKeyValuesStillSucceeds` — guard: under-arity Get is not rejected (real BC accepts it)

## Sibling gap found during probing

Under-arity `Get` prefix-matches in the runner but default-binds on real BC — container-verified and filed separately as #1631 per the scope decision on #1630.

## Regression

- bucket-1: 1990 passed; bucket-2: 2289 passed; bucket-feature-niw: 4 passed; stubs suite: 2 passed
- `AlRunner.Tests`: 533 passed on net9.0 and net10.0
- `docs/coverage.yaml`: `Table.Get (Joker)` entry updated with the new suite and arity note

🤖 Generated with [Claude Code](https://claude.com/claude-code)
