### PR TITLE
fix(provisioning): DownloadArtifacts fails loud, not with a raw stack trace, on a 404

### DIFF
--- a/AlRunner.Provisioning/ArtifactDownloader.cs
+++ b/AlRunner.Provisioning/ArtifactDownloader.cs
@@ -13,9 +13,13 @@
 // selects its NuGet package by RID instead of hardcoding .linux.
 
 using System.IO.Compression;
+using System.Net;
 using System.Net.Http.Headers;
 using System.Runtime.InteropServices;
 using System.Text;
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("AlRunner.Tests")]
 
 namespace AlRunner.Provisioning;
 
@@ -104,7 +108,7 @@ public static class ArtifactDownloader
         using var http = new HttpClient { Timeout = TimeSpan.FromMinutes(5) };
 
         logf($"Resolving artifact size for BC {version}...");
-        long totalSize = HeadContentLength(http, artifactUrl);
+        if (!TryHeadContentLength(http, artifactUrl, version, "platform", logf, out long totalSize)) return 1;
         if (totalSize == 0) { logf("Error: unknown size"); return 1; }
         logf($"Platform artifact: {totalSize / 1048576} MB");
 
@@ -173,7 +177,7 @@ public static class ArtifactDownloader
         using var http = new HttpClient { Timeout = TimeSpan.FromMinutes(10) };
 
         logf($"Resolving artifact size for BC {version} (platform)...");
-        long totalSize = HeadContentLength(http, artifactUrl);
+        if (!TryHeadContentLength(http, artifactUrl, version, "platform", logf, out long totalSize)) return 1;
         if (totalSize == 0) { logf("Error: unknown size"); return 1; }
 
         logf("Downloading ZIP directory...");
@@ -230,7 +234,7 @@ public static class ArtifactDownloader
         using var http = new HttpClient { Timeout = TimeSpan.FromMinutes(10) };
 
         logf($"Resolving artifact size for BC {version} (w1)...");
-        long totalSize = HeadContentLength(http, artifactUrl);
+        if (!TryHeadContentLength(http, artifactUrl, version, "w1", logf, out long totalSize)) return 1;
         if (totalSize == 0) { logf("Error: unknown size"); return 1; }
         logf($"w1 artifact: {totalSize / 1048576} MB");
 
@@ -318,7 +322,11 @@ public static class ArtifactDownloader
         using var http = new HttpClient { Timeout = TimeSpan.FromMinutes(10) };
 
         logf($"Resolving platform artifact for System.app (BC {version})...");
-        long totalSize = HeadContentLength(http, artifactUrl);
+        if (!TryHeadContentLength(http, artifactUrl, version, "platform", logf, out long totalSize))
+        {
+            logf("Warning: skipping System.app");
+            return 0;
+        }
         if (totalSize == 0) { logf("Warning: could not size the platform artifact — skipping System.app"); return 0; }
 
         if (!TryReadCentralDirectory(http, artifactUrl, totalSize, logf, out var cdData, out var cdStart, out var entryCount))
@@ -405,6 +413,40 @@ public static class ArtifactDownloader
         using var headResp = http.Send(new HttpRequestMessage(HttpMethod.Head, url));
         headResp.EnsureSuccessStatusCode();
         return headResp.Content.Headers.ContentLength ?? 0;
+    }
+
+    /// <summary>
+    /// Sizes a remote artifact and turns a failure into a named, actionable log message
+    /// instead of letting <see cref="HttpRequestException"/> propagate as an unhandled
+    /// exception with a raw .NET stack trace. A 404 (no artifact published for that exact
+    /// version) gets the <c>resolve-version</c> pointer; any other transport failure
+    /// (DNS, TLS, timeout, 5xx) gets a distinct "could not reach the CDN" message so the
+    /// caller can tell "your version is wrong" from "the network/tool is broken" — the
+    /// two categories the raw stack trace collapsed into one indistinguishable crash.
+    /// </summary>
+    internal static bool TryHeadContentLength(
+        HttpClient http, string url, string version, string channel, Action<string> logf, out long size)
+    {
+        try
+        {
+            size = HeadContentLength(http, url);
+            return true;
+        }
+        catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+        {
+            var prefix = string.Join(".", version.Split('.').Take(2));
+            logf($"Error: no BC artifact published for {version} ({channel}).");
+            logf("       Check the version, or resolve the latest for a prefix:");
+            logf($"         dotnet run --project tools/DownloadArtifacts -- resolve-version {prefix}");
+            size = 0;
+            return false;
+        }
+        catch (HttpRequestException ex)
+        {
+            logf($"Error: could not reach the BC artifact CDN for {version} ({channel}): {ex.Message}");
+            size = 0;
+            return false;
+        }
     }
 
     // Read the ZIP End-Of-Central-Directory + central directory bytes for a remote

--- a/AlRunner.Tests/ArtifactDownloader404Tests.cs
+++ b/AlRunner.Tests/ArtifactDownloader404Tests.cs
@@ -1,0 +1,86 @@
+// Issue #1659: tools/DownloadArtifacts platform-apps (and its ServiceTier/TestApps/SystemApp
+// siblings) crashed with an unhandled HttpRequestException + raw .NET stack trace when the
+// requested BC version had no artifact on the CDN. ArtifactDownloader.TryHeadContentLength is
+// the shared choke point all four download modes route through (HeadContentLength itself stays
+// private and unchanged) — it must turn a 404 into a named, actionable log message instead of
+// letting the exception propagate, and must not swallow a genuinely-sized successful response.
+using System.Net;
+using AlRunner.Provisioning;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class ArtifactDownloader404Tests
+{
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        private readonly HttpStatusCode _status;
+        private readonly long? _contentLength;
+
+        public StubHandler(HttpStatusCode status, long? contentLength = null)
+        {
+            _status = status;
+            _contentLength = contentLength;
+        }
+
+        protected override HttpResponseMessage Send(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var resp = new HttpResponseMessage(_status) { Content = new ByteArrayContent(Array.Empty<byte>()) };
+            if (_contentLength is long len)
+                resp.Content.Headers.ContentLength = len;
+            return resp;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            => Task.FromResult(Send(request, cancellationToken));
+    }
+
+    [Fact]
+    public void TryHeadContentLength_404_ReturnsFalseWithNamedResolveVersionHint_NoUnhandledException()
+    {
+        using var http = new HttpClient(new StubHandler(HttpStatusCode.NotFound));
+        var logs = new List<string>();
+
+        // The exact repro from the issue: a real, plausible version+channel that simply has
+        // no published artifact. This must not throw — that is the whole bug.
+        var ok = ArtifactDownloader.TryHeadContentLength(
+            http, "https://bcartifacts.example/sandbox/28.0.46665.47126/w1",
+            "28.0.46665.47126", "w1", logs.Add, out long size);
+
+        Assert.False(ok);
+        Assert.Equal(0, size);
+        Assert.Contains(logs, l => l == "Error: no BC artifact published for 28.0.46665.47126 (w1).");
+        Assert.Contains(logs, l => l.Contains("dotnet run --project tools/DownloadArtifacts -- resolve-version 28.0"));
+    }
+
+    [Fact]
+    public void TryHeadContentLength_ServerError_ReturnsFalseWithCdnReachabilityMessage_DistinctFrom404()
+    {
+        using var http = new HttpClient(new StubHandler(HttpStatusCode.InternalServerError));
+        var logs = new List<string>();
+
+        var ok = ArtifactDownloader.TryHeadContentLength(
+            http, "https://bcartifacts.example/sandbox/28.1.0.0/platform",
+            "28.1.0.0", "platform", logs.Add, out long size);
+
+        Assert.False(ok);
+        Assert.Equal(0, size);
+        // Must NOT claim the version is unpublished — a 500 is a CDN problem, not a bad version.
+        Assert.DoesNotContain(logs, l => l.Contains("no BC artifact published"));
+        Assert.Contains(logs, l => l.Contains("could not reach the BC artifact CDN") && l.Contains("28.1.0.0"));
+    }
+
+    [Fact]
+    public void TryHeadContentLength_Success_ReturnsTrueWithRealContentLength()
+    {
+        using var http = new HttpClient(new StubHandler(HttpStatusCode.OK, contentLength: 123456789));
+        var logs = new List<string>();
+
+        var ok = ArtifactDownloader.TryHeadContentLength(
+            http, "https://bcartifacts.example/sandbox/28.1.49838.53220/w1",
+            "28.1.49838.53220", "w1", logs.Add, out long size);
+
+        Assert.True(ok);
+        Assert.Equal(123456789, size);
+    }
+}


### PR DESCRIPTION
Closes #1659

## Summary
- `tools/DownloadArtifacts platform-apps <version> <dir>` (and `service-tier` / `test-apps`, which route through the same code) died with an unhandled `HttpRequestException` and a raw .NET stack trace when the requested BC version had no artifact on the CDN.
- Routed all four `ArtifactDownloader` download modes (`ServiceTier`, `TestApps`, `PlatformApps`, `SystemApp`) through a new `TryHeadContentLength` helper that turns a 404 into a named, actionable message pointing at `resolve-version`, and turns any other transport failure (DNS/TLS/5xx) into a distinct "could not reach the CDN" message — so a bad version and a broken network no longer look identical.
- `SystemApp` keeps its existing non-fatal "skip and continue" behavior on failure; the other three now return exit code 1 with the friendly message instead of crashing.

## Test plan
- [x] RED: `AlRunner.Tests/ArtifactDownloader404Tests.cs` written first; confirmed compile failure (`TryHeadContentLength` didn't exist) against the pre-fix code.
- [x] GREEN: 3 new tests pass — 404 → friendly `resolve-version` message, 500 → distinct "could not reach the CDN" message, 200 → real `Content-Length` still returned correctly (proves the success path isn't broken by the refactor).
- [x] Manual repro from the issue: `dotnet run --project tools/DownloadArtifacts -- platform-apps 28.0.46665.47126 <dir>` now prints the named error and exits 1 instead of an unhandled exception.
- [x] `dotnet build AlRunner.Tests/AlRunner.Tests.csproj` — 0 errors, 0 warnings.