### PR TITLE
fix(server): runTests/execute honour every sourcePaths entry

### DIFF
--- a/AlRunner.Tests/ServerTests.cs
+++ b/AlRunner.Tests/ServerTests.cs
@@ -163,6 +163,109 @@ public class ServerTests
         Assert.Contains("inline AL", err.GetString());
     }
 
+    // Reproduces #1658: a request naming an app bundle + its separate test-app
+    // bundle (the shape --guide recommends) must run BOTH — not silently drop
+    // everything after sourcePaths[0]. App exposes a procedure; the test bundle
+    // depends on the app and asserts the procedure's return value, so a green
+    // result here PROVES the test bundle actually compiled against the app's
+    // real symbols, not just that some non-empty test list came back.
+    private static string MakeAppTestPair(out string appDir, out string testDir)
+    {
+        var root = Path.Combine(Path.GetTempPath(), "al-runner-server-multi", Guid.NewGuid().ToString("N"));
+        appDir = Path.Combine(root, "App");
+        testDir = Path.Combine(root, "Test");
+        Directory.CreateDirectory(appDir);
+        Directory.CreateDirectory(testDir);
+
+        const string appId = "d1e2f3a4-b5c6-4d7e-8f90-a1b2c3d4e5f6";
+        File.WriteAllText(Path.Combine(appDir, "app.json"), $$"""
+        {
+          "id": "{{appId}}",
+          "name": "Runner Extras - Server Multi App",
+          "publisher": "AL Runner",
+          "version": "1.0.0.0",
+          "dependencies": [],
+          "platform": "1.0.0.0",
+          "application": "1.0.0.0",
+          "idRanges": [ { "from": 60150, "to": 60159 } ],
+          "runtime": "14.0"
+        }
+        """);
+        File.WriteAllText(Path.Combine(appDir, "AppLogic.Codeunit.al"), """
+        codeunit 60150 "Server Multi App Logic SX"
+        {
+            procedure Answer(): Integer
+            begin
+                exit(42);
+            end;
+        }
+        """);
+
+        File.WriteAllText(Path.Combine(testDir, "app.json"), $$"""
+        {
+          "id": "e2f3a4b5-c6d7-4e8f-90a1-b2c3d4e5f6a7",
+          "name": "Runner Extras - Server Multi Test",
+          "publisher": "AL Runner",
+          "version": "1.0.0.0",
+          "dependencies": [
+            { "id": "{{appId}}", "name": "Runner Extras - Server Multi App", "publisher": "AL Runner", "version": "1.0.0.0" }
+          ],
+          "platform": "1.0.0.0",
+          "application": "1.0.0.0",
+          "idRanges": [ { "from": 60160, "to": 60169 } ],
+          "runtime": "14.0"
+        }
+        """);
+        File.WriteAllText(Path.Combine(testDir, "AppLogicTest.Codeunit.al"), """
+        codeunit 60160 "Server Multi Test SX"
+        {
+            Subtype = Test;
+
+            [Test]
+            procedure AnswerIs42()
+            var
+                Logic: Codeunit "Server Multi App Logic SX";
+                Result: Integer;
+            begin
+                Result := Logic.Answer();
+                if Result <> 42 then
+                    Error('expected the app codeunit''s real answer 42, got %1', Result);
+            end;
+        }
+        """);
+        return root;
+    }
+
+    [Fact]
+    public async Task RunTests_MultipleSourcePaths_RunsAppAndTestBundle()
+    {
+        if (!ArtifactsPresent()) { Console.Error.WriteLine("[skip] BC artifact cache not present"); return; }
+
+        MakeAppTestPair(out var appDir, out var testDir);
+        var cacheDir = Path.Combine(Path.GetTempPath(), "al-runner-server-multi-cache", Guid.NewGuid().ToString("N"));
+        await using var server = await CliServer.StartAsync(new[] { "--cache", cacheDir });
+
+        var req = JsonSerializer.Serialize(new
+        {
+            command = "runTests",
+            sourcePaths = new[] { appDir, testDir },
+            packagePaths = Array.Empty<string>(),
+        });
+        var r = await server.SendAsync(req, TimeSpan.FromSeconds(180));
+        var d = JsonSerializer.Deserialize<JsonElement>(r);
+
+        // Bundle 1 (the app) has zero tests; bundle 2 (the test app) has exactly
+        // one. Honouring only sourcePaths[0] would report total == 0, exitCode 0.
+        Assert.Equal(1, d.GetProperty("total").GetInt32());
+        Assert.Equal(1, d.GetProperty("passed").GetInt32());
+        Assert.Equal(0, d.GetProperty("failed").GetInt32());
+        Assert.Equal(0, d.GetProperty("errors").GetInt32());
+        Assert.Equal(0, d.GetProperty("exitCode").GetInt32());
+        var tests = d.GetProperty("tests");
+        Assert.Equal(1, tests.GetArrayLength());
+        Assert.Equal("AnswerIs42", tests[0].GetProperty("name").GetString()!.Split('.').Last());
+    }
+
     [Fact]
     public async Task UnknownCommand_ReturnsError()
     {

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -1698,32 +1698,44 @@ int RunServerLoop(System.IO.TextReader input, System.IO.TextWriter output)
     // EOF — client disconnected.
     return 0;
 
-    // ── runTests: re-emit + run the requested bundle in-process. ───────────────
+    // ── runTests: re-emit + run every requested bundle in-process, aggregating the
+    // results. ──────────────────────────────────────────────────────────────────
     string HandleServerRunTests(AlRunner.ServerRequest req)
     {
         if (req.SourcePaths == null || req.SourcePaths.Length == 0)
             return AlRunner.ServerProtocol.Error("sourcePaths is required");
 
-        // v2 runs a single bundle per request; the extension passes one app root.
-        var bundleDir = req.SourcePaths[0];
-        if (!Directory.Exists(bundleDir))
-            return AlRunner.ServerProtocol.Error($"bundle directory not found: {bundleDir}");
+        foreach (var p in req.SourcePaths)
+            if (!Directory.Exists(p))
+                return AlRunner.ServerProtocol.Error($"bundle directory not found: {p}");
 
-        var run = RunBundleForServer(bundleDir, req.PackagePaths, asm => executor.Run(asm));
+        var runs = RunAllBundlesForServer(req.SourcePaths, req.PackagePaths, asm => executor.Run(asm));
+
+        var allTests = runs.SelectMany(r => r.Tests).ToList();
+        var allCompileErrors = runs.SelectMany(r => r.CompileErrors ?? Array.Empty<CompilationErrorGroup>()).ToList();
+        // Same priority as the CLI's computedExitCode: 3 (compile) > 2 (exec) > 1 (test fail) > 0.
+        var exitCode = runs.Count > 0 ? runs.Max(r => r.ExitCode) : 0;
+        var cached = runs.Count > 0 && runs.All(r => r.Cached);
+
+        var combinedHashes = new Dictionary<string, string>();
+        foreach (var r in runs)
+            foreach (var kv in r.FileHashes)
+                combinedHashes[kv.Key] = kv.Value;
 
         // changedFiles is only meaningful on a cache miss (a hit means nothing changed).
         List<string>? changed = null;
-        if (!run.Cached)
-            changed = DiffServerFiles(lastFileHashes, run.FileHashes);
-        lastFileHashes = run.FileHashes;
+        if (!cached)
+            changed = DiffServerFiles(lastFileHashes, combinedHashes);
+        lastFileHashes = combinedHashes;
 
         return AlRunner.ServerProtocol.RunTests(
-            run.Tests, run.ExitCode, run.Cached, changed, run.CompileErrors);
+            allTests, exitCode, cached, changed, allCompileErrors.Count > 0 ? allCompileErrors : null);
     }
 
-    // ── execute: run the bundle's first OnRun-bearing codeunit (run-mode). v1 also
-    // accepted an inline `code` string; v2 has no inline-AL compile path yet, so
-    // that case fails LOUD (never a silent fake) per .claude/rules/loud-failures.md.
+    // ── execute: run every requested bundle's first OnRun-bearing codeunit
+    // (run-mode), aggregating the results. v1 also accepted an inline `code`
+    // string; v2 has no inline-AL compile path yet, so that case fails LOUD
+    // (never a silent fake) per .claude/rules/loud-failures.md.
     string HandleServerExecute(AlRunner.ServerRequest req)
     {
         if (!string.IsNullOrWhiteSpace(req.Code))
@@ -1735,13 +1747,66 @@ int RunServerLoop(System.IO.TextReader input, System.IO.TextWriter output)
                 "execute: 'captureValues' is not yet supported in v2. See docs/server-mode.md.");
         if (req.SourcePaths == null || req.SourcePaths.Length == 0)
             return AlRunner.ServerProtocol.Error("sourcePaths is required");
-        var bundleDir = req.SourcePaths[0];
-        if (!Directory.Exists(bundleDir))
-            return AlRunner.ServerProtocol.Error($"bundle directory not found: {bundleDir}");
+        foreach (var p in req.SourcePaths)
+            if (!Directory.Exists(p))
+                return AlRunner.ServerProtocol.Error($"bundle directory not found: {p}");
 
-        var run = RunBundleForServer(bundleDir, req.PackagePaths, RunFirstCodeunitOnRun);
-        lastFileHashes = run.FileHashes;
-        return AlRunner.ServerProtocol.Execute(run.Tests, run.ExitCode, null, run.CompileErrors);
+        var runs = RunAllBundlesForServer(req.SourcePaths, req.PackagePaths, RunFirstCodeunitOnRun);
+
+        var allTests = runs.SelectMany(r => r.Tests).ToList();
+        var allCompileErrors = runs.SelectMany(r => r.CompileErrors ?? Array.Empty<CompilationErrorGroup>()).ToList();
+        var exitCode = runs.Count > 0 ? runs.Max(r => r.ExitCode) : 0;
+
+        var combinedHashes = new Dictionary<string, string>();
+        foreach (var r in runs)
+            foreach (var kv in r.FileHashes)
+                combinedHashes[kv.Key] = kv.Value;
+        lastFileHashes = combinedHashes;
+
+        return AlRunner.ServerProtocol.Execute(allTests, exitCode, null,
+            allCompileErrors.Count > 0 ? allCompileErrors : null);
+    }
+
+    // Runs every bundle in sourcePaths in order and returns one ServerRunResult per
+    // bundle. Restores v1's "honour every sourcePaths entry" behaviour (v1 fed them
+    // all into a single compile; v2 keeps one bundle = one compile, so it runs each
+    // sequentially instead — the same shape the CLI already uses for multiple
+    // <bundle-dir> arguments). See #1658: honouring only sourcePaths[0] silently
+    // dropped the rest, returning a green empty result for an app + separate
+    // test-app request.
+    //
+    // When more than one path is given, first wire any inter-bundle dependency (the
+    // app + test-app shape --guide recommends) the same way the CLI does before its
+    // per-bundle loop: compile whichever bundle a sibling bundle depends on into a
+    // package cache the sibling can resolve against.
+    List<ServerRunResult> RunAllBundlesForServer(string[] sourcePaths, string[]? requestPackagePaths,
+        Func<Assembly, IReadOnlyList<TestResult>> runStep)
+    {
+        if (sourcePaths.Length > 1)
+        {
+            var bundleList = sourcePaths.ToList();
+            var workspaceScratch = new List<string>();
+            try
+            {
+                packageCacheDirs = RunLayeredPrePass(bundleList, packageCacheDirs, workspaceScratch);
+                packageCacheDirs = BuildSiblingSourceDeps(bundleList, packageCacheDirs, workspaceScratch);
+            }
+            catch (Exception ex)
+            {
+                // Loud per-bundle failure below (dep resolution during the per-bundle
+                // compile) already covers the "can't resolve" case; a failure in the
+                // wiring pre-pass itself must not silently fall back to unwired compiles.
+                return new List<ServerRunResult>
+                {
+                    ServerRunResult.Failure(3, "<inter-bundle-deps>", $"LAYERED-PREPASS-FAIL: {ex.Message}", new())
+                };
+            }
+        }
+
+        var results = new List<ServerRunResult>(sourcePaths.Length);
+        foreach (var bundleDir in sourcePaths)
+            results.Add(RunBundleForServer(bundleDir, requestPackagePaths, runStep));
+        return results;
     }
 
     // Compile + run one bundle, resetting bundle-derived caches first so an edited

--- a/docs/server-mode.md
+++ b/docs/server-mode.md
@@ -31,7 +31,10 @@ al-runner --server [--package-cache PATH ...] [--cache DIR]
 ```jsonc
 {
   "command": "runTests",        // runTests | execute | shutdown (case-insensitive)
-  "sourcePaths": ["/path/app"], // bundle dir(s); uses the first
+  "sourcePaths": ["/path/app"], // bundle dir(s); ALL are run and aggregated —
+                                 // e.g. an app + its separate test app, same
+                                 // shape as `al-runner MyApp MyApp.Test` on
+                                 // the CLI (inter-bundle deps get wired first)
   "packagePaths": ["/extra"],   // optional: extra .app caches, augment server defaults
   "stubPaths": [],              // v1 field, ignored in v2 (no stubs layer)
   "code": "...",                // execute only (inline AL) — not yet supported


### PR DESCRIPTION
Closes #1658

## Summary
- `--server` mode's `runTests` and `execute` handlers only read `sourcePaths[0]`, silently dropping the rest. An app + separate test-app request (the shape `--guide` recommends) returned `exitCode: 0` with zero tests instead of running the test bundle.
- Restores the CLI's multi-bundle behaviour: when more than one `sourcePaths` entry is given, wire any inter-bundle dependency first (reusing the existing `RunLayeredPrePass` / `BuildSiblingSourceDeps` pre-pass the CLI already uses for multiple `<bundle-dir>` arguments), then run every bundle in order and aggregate tests, exit code, cache/changed-files, and compilation errors.
- Aggregation rules mirror the CLI's `computedExitCode`: exit code is the max across bundles (3 compile > 2 exec > 1 test-fail > 0 ok); `cached` is true only when every bundle hit the cache; `changedFiles` is the union diff against the prior request.
- Updated `docs/server-mode.md`'s `sourcePaths` comment, which documented the old "uses the first" behaviour.

## Test plan
- [x] RED: added `ServerTests.RunTests_MultipleSourcePaths_RunsAppAndTestBundle` (app bundle exposing a procedure + separate dependent test bundle asserting its real return value) — failed before the fix (`total: 0` instead of `1`).
- [x] GREEN: same test passes after the fix.
- [x] Existing `ServerTests` (4 other tests) still pass — single-`sourcePaths` requests unaffected.
- [x] `LayeredCacheTests` still passes — confirms reusing `RunLayeredPrePass`/`BuildSiblingSourceDeps` from the server path didn't regress the CLI path.