### PR TITLE
fix(ci): Tests-updated gate now also matches AlRunner.Tests/

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Check that tests/ was updated when AlRunner/ changed
+      - name: Check that tests/ or AlRunner.Tests/ was updated when AlRunner/ changed
         run: |
           BASE=${{ github.event.pull_request.base.sha }}
           HEAD=${{ github.event.pull_request.head.sha }}
@@ -37,11 +37,11 @@ jobs:
           echo "$SOURCE_CHANGED"
 
           # Did any test file also change?
-          TESTS_CHANGED=$(echo "$CHANGED" | grep -E '^tests/' || true)
+          TESTS_CHANGED=$(echo "$CHANGED" | grep -E '^(tests/|AlRunner\.Tests/)' || true)
 
           if [ -z "$TESTS_CHANGED" ]; then
             echo ""
-            echo "ERROR: AlRunner/ was modified but no files under tests/ were updated."
+            echo "ERROR: AlRunner/ was modified but no files under tests/ or AlRunner.Tests/ were updated."
             echo ""
             echo "Every change that affects behavior, mocks, or rewriter rules must include"
             echo "a test. See CONTRIBUTING.md for the requirements."


### PR DESCRIPTION
Closes #1663

## Summary
The "Tests updated" gate in `.github/workflows/pr-check.yml` only recognized changes under `tests/`. That path holds the AL-language corpus, expectations manifest, and runner-extras — not the C# unit-test project. The actual unit tests for `AlRunner/` source live in `AlRunner.Tests/` at repo root, which the regex never matched. Any PR that added a legitimate C# unit test still failed this gate.

Confirmed via PR #1662, which added `AlRunner.Tests/ServerTests.cs` alongside its `AlRunner/Program.cs` change and still failed with "no files under tests/ were updated."

## Change
Extended the regex from `^tests/` to `^(tests/|AlRunner\.Tests/)`.

## Test plan
- [x] CI-infra-only change, no AlRunner/ source touched — the gate itself doesn't apply to this PR
- N/A local repro: confirmed by inspecting PR #1662's failing check output