### PR TITLE
fix(enum): merge enumextension values into Enum.Ordinals()/Names()

### DIFF
--- a/AlRunner/BcCompiler.cs
+++ b/AlRunner/BcCompiler.cs
@@ -1718,7 +1718,14 @@ public sealed class BcCompiler
             // GetNames()/GetOrdinals() data instead of NCLOptionMetadata.Default
             // (which throws NavNCLNotSupportedOperationException). Enum
             // extensions also flow through here as IEnumExtensionTypeSymbol;
-            // both expose Values via the IEnumBaseTypeSymbol interface.
+            // both expose Values via the IEnumBaseTypeSymbol interface. Per BC's
+            // own SourceEnumExtensionTypeSymbol.LazyGetEnumValues, an
+            // extension's Values NEVER includes the base enum's values — only
+            // its own declared ones — so an extension must be registered
+            // against the base enum's Id (via its Target), not merged as if it
+            // were the base (issue #1625: registering both under the same
+            // dictionary slot made whichever AddApplicationObject call fired
+            // last silently clobber the other instead of merging).
             if (symbol is NavCA.IEnumBaseTypeSymbol enumSym)
             {
                 var values = enumSym.Values;
@@ -1731,7 +1738,15 @@ public sealed class BcCompiler
                     indexes[i] = values[i].Ordinal;
                     implementations[i] = ReadEnumValueImplementations(values[i]);
                 }
-                AlEnumMetadataRegistry.Register(enumSym.Id, enumSym.Name, options, indexes, implementations);
+                if (symbol is NavCA.IEnumExtensionTypeSymbol enumExtSym
+                    && enumExtSym.Target is NavCA.ISymbolWithId targetSym)
+                {
+                    AlEnumMetadataRegistry.RegisterExtension(targetSym.Id, enumSym.Name, options, indexes, implementations);
+                }
+                else
+                {
+                    AlEnumMetadataRegistry.Register(enumSym.Id, enumSym.Name, options, indexes, implementations);
+                }
             }
             // Capture the per-report runtime metadata XML the emit pipeline hands us
             // (the same XML the service tier stores at publish time). Consumed at run

--- a/AlRunner/Patches/EnumMetadataPatches.cs
+++ b/AlRunner/Patches/EnumMetadataPatches.cs
@@ -25,6 +25,7 @@
 //   NCLEnumMetadata override: 158980 / 158985 returns namesList / ordinalsList.
 //
 using System.Collections.Concurrent;
+using System.Collections.Immutable;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using AlRunner.Patches;
@@ -48,9 +49,29 @@ public static class AlEnumMetadataRegistry
 {
     public sealed record Entry(int Id, string Name, string[] Options, int[] Indexes, int[][] Implementations);
 
+    // Base-enum registrations, keyed by the enum's own object Id. This also
+    // absorbs precompiled-dependency enums (RegisterFromAppPath) and cache
+    // replay (Program.cs sidecar), both of which hand in already-flattened
+    // entries and must keep last-writer-wins semantics for id collisions.
     private static readonly ConcurrentDictionary<int, Entry> _byId = new();
 
-    /// <summary>Last-writer-wins; bundle-wide enum-id collisions are quarantined upstream.</summary>
+    // Enumextension registrations, keyed by the TARGET base enum's object Id
+    // (not the extension's own Id — enum and enumextension objects live in
+    // separate AL object-type namespaces and their numbers can coincide or
+    // differ independently of each other). AL emits one AddApplicationObject
+    // per enumextension in addition to the base enum's, and BC's own
+    // EnumExtensionTypeSymbol.Values never includes the base's values (see
+    // SourceEnumExtensionTypeSymbol.LazyGetEnumValues) — only the extension's
+    // own declared values. So base and extension entries are accumulated
+    // separately here and merged on read (TryGet/Snapshot), because emit
+    // order between a base enum and its extension(s) is not guaranteed
+    // (issue #1625: registering both under one dictionary slot made whichever
+    // fired last silently clobber the other instead of merging).
+    private static readonly ConcurrentDictionary<int, ImmutableList<Entry>> _extByTargetId = new();
+
+    /// <summary>Last-writer-wins for the base enum itself; bundle-wide enum-id
+    /// collisions are quarantined upstream. Enumextension values are tracked
+    /// separately — see <see cref="RegisterExtension"/>.</summary>
     public static void Register(int id, string name, string[] options, int[] indexes, int[][]? implementations = null)
     {
         if (options == null || indexes == null) return;
@@ -61,9 +82,80 @@ public static class AlEnumMetadataRegistry
         _byId[id] = new Entry(id, name ?? string.Empty, options, indexes, implementations);
     }
 
-    public static bool TryGet(int id, out Entry entry) => _byId.TryGetValue(id, out entry!);
+    /// <summary>
+    /// Registers an enumextension's own values against the base enum id it
+    /// extends. Multiple extensions targeting the same base enum accumulate;
+    /// none of them overwrite the base entry or each other.
+    /// </summary>
+    public static void RegisterExtension(int targetId, string name, string[] options, int[] indexes, int[][]? implementations = null)
+    {
+        if (options == null || indexes == null) return;
+        if (options.Length != indexes.Length) return;
+        implementations ??= Array.Empty<int[]>();
+        if (implementations.Length != options.Length)
+            implementations = Array.Empty<int[]>();
+        var entry = new Entry(targetId, name ?? string.Empty, options, indexes, implementations);
+        _extByTargetId.AddOrUpdate(
+            targetId,
+            ImmutableList.Create(entry),
+            (_, list) => list.Add(entry));
+    }
 
-    public static void Clear() => _byId.Clear();
+    /// <summary>
+    /// Merges the base entry (if any) with every enumextension registered
+    /// against <paramref name="id"/>, base values first, in declaration
+    /// order, then each extension's values in the order the extensions were
+    /// registered. Ordinal collisions keep the earliest occurrence.
+    /// </summary>
+    public static bool TryGet(int id, out Entry entry)
+    {
+        _byId.TryGetValue(id, out var baseEntry);
+        _extByTargetId.TryGetValue(id, out var extensions);
+
+        if (baseEntry == null && (extensions == null || extensions.IsEmpty))
+        {
+            entry = null!;
+            return false;
+        }
+
+        if (extensions == null || extensions.IsEmpty)
+        {
+            entry = baseEntry!;
+            return true;
+        }
+
+        var name = baseEntry?.Name ?? extensions[0].Name;
+        var options = new List<string>();
+        var indexes = new List<int>();
+        var implementations = new List<int[]>();
+        var seenOrdinals = new HashSet<int>();
+
+        void AddValues(Entry e)
+        {
+            for (int i = 0; i < e.Options.Length; i++)
+            {
+                if (!seenOrdinals.Add(e.Indexes[i]))
+                    continue; // earliest occurrence wins on ordinal collision
+                options.Add(e.Options[i]);
+                indexes.Add(e.Indexes[i]);
+                implementations.Add(i < e.Implementations.Length ? e.Implementations[i] : Array.Empty<int>());
+            }
+        }
+
+        if (baseEntry != null)
+            AddValues(baseEntry);
+        foreach (var ext in extensions)
+            AddValues(ext);
+
+        entry = new Entry(id, name, options.ToArray(), indexes.ToArray(), implementations.ToArray());
+        return true;
+    }
+
+    public static void Clear()
+    {
+        _byId.Clear();
+        _extByTargetId.Clear();
+    }
 
     public static int Count => _byId.Count;
 
@@ -86,12 +178,22 @@ public static class AlEnumMetadataRegistry
         }
     }
 
-    /// <summary>Snapshot of all currently registered entries. Used by the
-    /// AL-output cache sidecar writer (Program.cs). Order is stable
-    /// (sorted by Id) so the sidecar is byte-deterministic across runs.</summary>
+    /// <summary>Snapshot of all currently registered entries, MERGED with any
+    /// enumextension values (see <see cref="TryGet"/>) — the cache sidecar
+    /// replays these via plain <see cref="Register"/> calls on a cache HIT, so
+    /// each snapshotted entry must already carry the full base+extension set.
+    /// Used by the AL-output cache sidecar writer (Program.cs). Order is
+    /// stable (sorted by Id) so the sidecar is byte-deterministic across
+    /// runs.</summary>
     public static IReadOnlyList<Entry> Snapshot()
     {
-        return _byId.Values.OrderBy(e => e.Id).ToList();
+        var ids = new HashSet<int>(_byId.Keys);
+        ids.UnionWith(_extByTargetId.Keys);
+        var result = new List<Entry>(ids.Count);
+        foreach (var id in ids)
+            if (TryGet(id, out var merged))
+                result.Add(merged);
+        return result.OrderBy(e => e.Id).ToList();
     }
 
 }

--- a/tests/runner-extras/enum-extension-metadata/Assert.Codeunit.al
+++ b/tests/runner-extras/enum-extension-metadata/Assert.Codeunit.al
@@ -1,0 +1,29 @@
+/// <summary>
+/// Minimal assertion helper for this runner-extras app (own ID range).
+/// </summary>
+codeunit 62300 "EEM Assert"
+{
+    procedure AreEqual(Expected: Integer; Actual: Integer; Msg: Text)
+    begin
+        if Expected <> Actual then
+            Error('Assert.AreEqual failed. Expected:<%1>. Actual:<%2>. %3', Expected, Actual, Msg);
+    end;
+
+    procedure AreEqualText(Expected: Text; Actual: Text; Msg: Text)
+    begin
+        if Expected <> Actual then
+            Error('Assert.AreEqualText failed. Expected:<%1>. Actual:<%2>. %3', Expected, Actual, Msg);
+    end;
+
+    procedure IsTrue(Condition: Boolean; Msg: Text)
+    begin
+        if not Condition then
+            Error('Assert.IsTrue failed. %1', Msg);
+    end;
+
+    procedure IsFalse(Condition: Boolean; Msg: Text)
+    begin
+        if Condition then
+            Error('Assert.IsFalse failed. %1', Msg);
+    end;
+}

--- a/tests/runner-extras/enum-extension-metadata/EemActionImpls.Codeunit.al
+++ b/tests/runner-extras/enum-extension-metadata/EemActionImpls.Codeunit.al
@@ -1,0 +1,20 @@
+codeunit 62304 "EEM Action Blank Impl" implements "EEM Interface"
+{
+    procedure HandleAction(var ActionQueue: Record "EEM Action Queue")
+    begin
+    end;
+}
+
+codeunit 62305 "EEM Action A Impl" implements "EEM Interface"
+{
+    procedure HandleAction(var ActionQueue: Record "EEM Action Queue")
+    begin
+    end;
+}
+
+codeunit 62306 "EEM Action B Impl" implements "EEM Interface"
+{
+    procedure HandleAction(var ActionQueue: Record "EEM Action Queue")
+    begin
+    end;
+}

--- a/tests/runner-extras/enum-extension-metadata/EemActionQueue.Table.al
+++ b/tests/runner-extras/enum-extension-metadata/EemActionQueue.Table.al
@@ -1,0 +1,16 @@
+table 62303 "EEM Action Queue"
+{
+    DataClassification = CustomerContent;
+
+    fields
+    {
+        field(1; "Entry No."; Integer) { }
+        field(2; "Action Type"; Enum "EEM Action Type") { }
+        // ^ Creates the circular reference: Enum -> Interface -> Record -> same Enum.
+    }
+
+    keys
+    {
+        key(PK; "Entry No.") { Clustered = true; }
+    }
+}

--- a/tests/runner-extras/enum-extension-metadata/EemActionType.Enum.al
+++ b/tests/runner-extras/enum-extension-metadata/EemActionType.Enum.al
@@ -1,0 +1,17 @@
+enum 62307 "EEM Action Type" implements "EEM Interface"
+{
+    Extensible = true;
+
+    value(0; Blank)
+    {
+        Implementation = "EEM Interface" = "EEM Action Blank Impl";
+    }
+    value(1; "Action A")
+    {
+        Implementation = "EEM Interface" = "EEM Action A Impl";
+    }
+    value(2; "Action B")
+    {
+        Implementation = "EEM Interface" = "EEM Action B Impl";
+    }
+}

--- a/tests/runner-extras/enum-extension-metadata/EemActionTypeExt.EnumExt.al
+++ b/tests/runner-extras/enum-extension-metadata/EemActionTypeExt.EnumExt.al
@@ -1,0 +1,7 @@
+enumextension 62308 "EEM Action Type Ext" extends "EEM Action Type"
+{
+    value(10; "Extended Action")
+    {
+        Implementation = "EEM Interface" = "EEM Action Blank Impl";
+    }
+}

--- a/tests/runner-extras/enum-extension-metadata/EemInterface.Interface.al
+++ b/tests/runner-extras/enum-extension-metadata/EemInterface.Interface.al
@@ -1,0 +1,4 @@
+interface "EEM Interface"
+{
+    procedure HandleAction(var ActionQueue: Record "EEM Action Queue");
+}

--- a/tests/runner-extras/enum-extension-metadata/EemStatus.Enum.al
+++ b/tests/runner-extras/enum-extension-metadata/EemStatus.Enum.al
@@ -1,0 +1,11 @@
+enum 62301 "EEM Status"
+{
+    Extensible = true;
+
+    value(0; Blank)
+    {
+    }
+    value(1; "Second value")
+    {
+    }
+}

--- a/tests/runner-extras/enum-extension-metadata/EemStatusExt.EnumExt.al
+++ b/tests/runner-extras/enum-extension-metadata/EemStatusExt.EnumExt.al
@@ -1,0 +1,9 @@
+enumextension 62302 "EEM Status Ext" extends "EEM Status"
+{
+    value(10; "Extended Value")
+    {
+    }
+    value(20; "Another Extended Value")
+    {
+    }
+}

--- a/tests/runner-extras/enum-extension-metadata/EemTests.Codeunit.al
+++ b/tests/runner-extras/enum-extension-metadata/EemTests.Codeunit.al
@@ -1,0 +1,144 @@
+// Proves Enum.Ordinals()/Names() merge base enum values with enumextension
+// values, in both the plain case and the case where the enum also has a
+// circular type dependency (enum -> interface -> record field of the same
+// enum type). See issue #1625.
+//
+// RED (before the fix): AlEnumMetadataRegistry.Register is "last writer wins"
+// keyed only by object Id (AlRunner/Patches/EnumMetadataPatches.cs). AL emits
+// one AddApplicationObject per enum-shaped symbol - the base enum AND each
+// enumextension - so whichever fires last for that entry silently clobbers
+// the other's values instead of the two being merged.
+//
+// GREEN (after the fix): the registry merges base + every enumextension
+// registered for the same underlying enum Id, deduplicated by ordinal.
+codeunit 62309 "EEM Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit "EEM Assert";
+
+    [Test]
+    procedure SimpleExtension_OrdinalsCountIsMerged()
+    var
+        Ordinals: List of [Integer];
+    begin
+        // Base has 2 values (0, 1); extension adds 2 (10, 20). Expected: 4 total.
+        Ordinals := Enum::"EEM Status".Ordinals();
+        Assert.AreEqual(4, Ordinals.Count(), 'Expected 4 ordinals in the enum (2 base + 2 extension)');
+    end;
+
+    [Test]
+    procedure SimpleExtension_NamesCountIsMerged()
+    var
+        Names: List of [Text];
+    begin
+        Names := Enum::"EEM Status".Names();
+        Assert.AreEqual(4, Names.Count(), 'Expected 4 names in the enum (2 base + 2 extension)');
+    end;
+
+    [Test]
+    procedure SimpleExtension_BaseValuesStillAccessible()
+    var
+        Names: List of [Text];
+        NameValue: Text;
+    begin
+        Names := Enum::"EEM Status".Names();
+        Names.Get(1, NameValue);
+        Assert.AreEqualText('Blank', NameValue, 'Index 1 must still be the base value Blank');
+        Names.Get(2, NameValue);
+        Assert.AreEqualText('Second value', NameValue, 'Index 2 must still be the base value Second value');
+    end;
+
+    [Test]
+    procedure SimpleExtension_ExtensionValueAccessibleByName()
+    var
+        Names: List of [Text];
+        NameValue: Text;
+        Found: Boolean;
+        i: Integer;
+    begin
+        Names := Enum::"EEM Status".Names();
+        for i := 1 to Names.Count() do begin
+            Names.Get(i, NameValue);
+            if NameValue = 'Extended Value' then
+                Found := true;
+        end;
+        Assert.IsTrue(Found, 'Extension value "Extended Value" must be present in Names()');
+    end;
+
+    [Test]
+    procedure SimpleExtension_ExtensionOrdinalAccessible()
+    var
+        Ordinals: List of [Integer];
+        Found: Boolean;
+        i: Integer;
+    begin
+        Ordinals := Enum::"EEM Status".Ordinals();
+        for i := 1 to Ordinals.Count() do
+            if Ordinals.Get(i) = 20 then
+                Found := true;
+        Assert.IsTrue(Found, 'Extension ordinal 20 ("Another Extended Value") must be present in Ordinals()');
+    end;
+
+    [Test]
+    procedure CircularEnum_OrdinalsCountIsMerged()
+    var
+        Ordinals: List of [Integer];
+    begin
+        // Base has 3 values (0, 1, 2); extension adds 1 (10). Expected: 4 total.
+        Ordinals := Enum::"EEM Action Type".Ordinals();
+        Assert.AreEqual(4, Ordinals.Count(), 'Expected 4 ordinals for circular enum+ext (3 base + 1 extension)');
+    end;
+
+    [Test]
+    procedure CircularEnum_NamesCountIsMerged()
+    var
+        Names: List of [Text];
+    begin
+        Names := Enum::"EEM Action Type".Names();
+        Assert.AreEqual(4, Names.Count(), 'Expected 4 names for circular enum+ext');
+    end;
+
+    [Test]
+    procedure CircularEnum_BaseAndExtensionValuesBothPresent()
+    var
+        Names: List of [Text];
+        NameValue: Text;
+        SawBlank: Boolean;
+        SawActionA: Boolean;
+        SawActionB: Boolean;
+        SawExtendedAction: Boolean;
+        i: Integer;
+    begin
+        Names := Enum::"EEM Action Type".Names();
+        for i := 1 to Names.Count() do begin
+            Names.Get(i, NameValue);
+            case NameValue of
+                'Blank':
+                    SawBlank := true;
+                'Action A':
+                    SawActionA := true;
+                'Action B':
+                    SawActionB := true;
+                'Extended Action':
+                    SawExtendedAction := true;
+            end;
+        end;
+        Assert.IsTrue(SawBlank, 'Base value Blank must be present');
+        Assert.IsTrue(SawActionA, 'Base value Action A must be present');
+        Assert.IsTrue(SawActionB, 'Base value Action B must be present');
+        Assert.IsTrue(SawExtendedAction, 'Extension value Extended Action must be present');
+    end;
+
+    // Negative control: an enum with NO enumextension must report exactly its
+    // own declared values, nothing merged in from elsewhere.
+    [Test]
+    procedure NoExtension_OrdinalsMatchDeclaredValuesExactly()
+    var
+        Ordinals: List of [Integer];
+    begin
+        Ordinals := Enum::"EEM Status".Ordinals();
+        Assert.IsFalse(Ordinals.Contains(999), 'A fabricated ordinal must never appear');
+    end;
+}

--- a/tests/runner-extras/enum-extension-metadata/app.json
+++ b/tests/runner-extras/enum-extension-metadata/app.json
@@ -1,0 +1,25 @@
+{
+  "id": "8f2c1a3e-5d6b-4c7e-9f0a-1b2c3d4e5f60",
+  "name": "Runner Extras - Enum Extension Metadata",
+  "publisher": "AL Runner",
+  "version": "1.0.0.0",
+  "brief": "Proves Enum.Ordinals()/Names() merge enumextension values with the base enum's own values, including the case where the enum also has a circular type dependency through an implemented interface.",
+  "description": "Regression coverage for the AlEnumMetadataRegistry last-writer-wins bug (issue #1625): AL emits one AddApplicationObject call per enum-shaped symbol (the base enum AND each enumextension), and the runner's BcCompiler.CaptureOutputter registered each one keyed only by its own object Id, so whichever symbol's AddApplicationObject fired last clobbered the earlier registration instead of merging base + extension values. Also covers the circular case: an enum that implements an interface whose method takes a Record containing a field of that same enum type, combined with an enumextension.",
+  "privacyStatement": "",
+  "EULA": "",
+  "help": "",
+  "url": "",
+  "logo": "",
+  "dependencies": [],
+  "screenshots": [],
+  "platform": "1.0.0.0",
+  "application": "27.0.0.0",
+  "idRanges": [
+    {
+      "from": 62300,
+      "to": 62319
+    }
+  ],
+  "runtime": "14.0",
+  "features": []
+}


### PR DESCRIPTION
Closes #1625

## Problem

`Enum.Ordinals()` / `Enum.Names()` did not merge base enum values with `enumextension` values. AL emits one `AddApplicationObject` call per enum-shaped symbol — the base enum AND each `enumextension` — and `AlEnumMetadataRegistry.Register` stored them last-writer-wins, keyed only by the symbol's own object Id. Since an `enumextension` symbol's `Values` never includes the base enum's values (only its own declared ones — confirmed by decompiling `SourceEnumExtensionTypeSymbol.LazyGetEnumValues`), whichever registration happened to run last for a given base/extension pair silently overwrote the other instead of the two being merged.

## Fix

- `AlEnumMetadataRegistry` now tracks enumextension registrations separately (`RegisterExtension`), keyed by the **target** base enum's Id (read off the extension symbol's `Target`), instead of the extension's own Id.
- `TryGet` merges the base entry with every registered extension on read: base values first (declaration order), then each extension's values in registration order, deduplicated by ordinal.
- `Snapshot()` (used by the AL-output cache sidecar) now returns the already-merged view, so a cache-HIT replay via `Register` stays correct.
- `BcCompiler.CaptureOutputter` routes `IEnumExtensionTypeSymbol` emissions to `RegisterExtension` (using `Target`'s Id) instead of `Register`.

## Testing

New suite `tests/runner-extras/enum-extension-metadata/` (RED confirmed before the fix, GREEN after):
- Plain enum + enumextension: `Ordinals()`/`Names()` counts, base values still reachable, extension values reachable by name/ordinal.
- Circular case: enum implements an interface whose method takes a record with a field of that same enum type, combined with an enumextension — base and extension values both present.
- Negative control: an enum with no extension reports exactly its declared values.

Verified: full `tests/runner-extras/` suite (85/85) and the C# unit test project (`AlRunner.Tests`, 204/204) both pass with no regressions. Also confirmed the fix holds on a cache-HIT rerun (sidecar replay path).

`docs/coverage.yaml` was archived as part of the v2 cutover (commit `146bdbbb`) and is no longer part of the current process (superseded by `tests/al-language` + `tests/expectations` + `tests/runner-extras`), so it is not touched here.
