### PR TITLE
fix(provisioning): --auto-provision downloads into the runner artifact cache, not the project's package cache

### DIFF
--- a/AlRunner.Tests/ProvisioningCheckTests.cs
+++ b/AlRunner.Tests/ProvisioningCheckTests.cs
@@ -439,4 +439,50 @@ public sealed class ProvisioningCheckTests : IDisposable
         var mm = ProvisioningCheck.DerivePresentPlatformMajorMinor(new[] { dir }, "28.1.49838.50794");
         Assert.Equal("28.4", mm);
     }
+
+    // ── Issue #1653: --auto-provision download destination ──────────────────
+    // --auto-provision was writing platform R2R apps + the MS test toolkit into whichever
+    // --package-cache dir the caller passed first (the project's own .alpackages), instead
+    // of the runner-owned artifact cache the standalone `provision` command already uses.
+    // These two helpers are the single source of truth for that destination — they must
+    // resolve under the runner's artifact root, NEVER under a caller-supplied package-cache
+    // path, regardless of what package-cache dirs happen to be in scope.
+
+    [Fact]
+    public void PlatformAppsDirFor_IsUnderArtifactsRoot_NotAProjectPackageCacheDir()
+    {
+        var artifactsRoot = Path.Combine(_dir, "artifacts");
+        var projectPackageCache = Path.Combine(_dir, "app", ".alpackages"); // what a caller's --package-cache[0] would be
+
+        var dir = ProvisioningCheck.PlatformAppsDirFor(artifactsRoot, "28.1.49838.50794");
+
+        Assert.Equal(Path.Combine(artifactsRoot, "28.1.49838.50794", "platform-apps"), dir);
+        Assert.NotEqual(projectPackageCache, dir);
+        Assert.StartsWith(artifactsRoot, dir);
+    }
+
+    [Fact]
+    public void TestAppsDirFor_IsUnderArtifactsRoot_NotAProjectPackageCacheDir()
+    {
+        var artifactsRoot = Path.Combine(_dir, "artifacts");
+        var projectPackageCache = Path.Combine(_dir, "app", ".alpackages");
+
+        var dir = ProvisioningCheck.TestAppsDirFor(artifactsRoot, "28.1.49838.50794");
+
+        Assert.Equal(Path.Combine(artifactsRoot, "28.1.49838.50794", "test-apps"), dir);
+        Assert.NotEqual(projectPackageCache, dir);
+        Assert.StartsWith(artifactsRoot, dir);
+    }
+
+    [Fact]
+    public void PlatformAppsDirFor_And_TestAppsDirFor_AreDistinctSiblingDirs()
+    {
+        var artifactsRoot = Path.Combine(_dir, "artifacts");
+
+        var platform = ProvisioningCheck.PlatformAppsDirFor(artifactsRoot, "28.1.49838.50794");
+        var testApps = ProvisioningCheck.TestAppsDirFor(artifactsRoot, "28.1.49838.50794");
+
+        Assert.NotEqual(platform, testApps);
+        Assert.Equal(Path.GetDirectoryName(platform), Path.GetDirectoryName(testApps));
+    }
 }

--- a/AlRunner/Infrastructure/ProvisioningCheck.cs
+++ b/AlRunner/Infrastructure/ProvisioningCheck.cs
@@ -284,6 +284,31 @@ public static class ProvisioningCheck
         return parts.Length >= 2 ? string.Join(".", parts.Take(2)) : fallbackVersion;
     }
 
+    // ── Auto-provision download destination (issue #1653) ────────────────────
+    // `--auto-provision` used to download platform R2R apps + the MS test toolkit into
+    // whichever `--package-cache` dir the caller passed first — i.e. into the *project's*
+    // .alpackages (up to ~135 MB / 112 files). That directory is the user's; the runner
+    // must never write into it unasked. These two helpers are the single source of truth
+    // for the correct destination: the runner-owned artifact cache, exactly mirroring the
+    // layout the standalone `al-runner provision` step already uses for the test toolkit
+    // (`<artifacts-root>/<version>/test-apps`). Pure path composition — no I/O, so callers
+    // can create the dir, or add it as a search root, as needed.
+
+    /// <summary>
+    /// Runner-owned directory to download Microsoft platform R2R runtime apps (System
+    /// Application, Base Application, Business Foundation) into. Sibling of
+    /// <see cref="TestAppsDirFor"/> under the same per-version artifact root.
+    /// </summary>
+    public static string PlatformAppsDirFor(string artifactsRootDir, string fullVersion)
+        => Path.Combine(artifactsRootDir, fullVersion, "platform-apps");
+
+    /// <summary>
+    /// Runner-owned directory to download the Microsoft test toolkit (Business Foundation
+    /// Test Libraries, Application Test Library, Library Assert, Test Runner, …) into.
+    /// </summary>
+    public static string TestAppsDirFor(string artifactsRootDir, string fullVersion)
+        => Path.Combine(artifactsRootDir, fullVersion, "test-apps");
+
     public sealed record Report(string Version, string ServiceTierDir, IReadOnlyList<string> MissingFiles)
     {
         public bool Ok => MissingFiles.Count == 0;

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -527,20 +527,29 @@ if (!provisionSubcommand && packageCacheDirs.Count > 0)
             Console.Error.WriteLine($"[provision] could not resolve a full BC artifact version for '{mm}'; cannot continue.");
             return 2;
         }
-        // Pick first writable cache dir.
-        var pkgCacheOut = packageCacheDirs.FirstOrDefault(Directory.Exists)
-            ?? packageCacheDirs[0];
+        // Runner-owned artifact-cache destinations — NEVER a caller-supplied --package-cache
+        // dir (issue #1653: this used to pick packageCacheDirs[0], writing ~135 MB of
+        // downloaded apps straight into the project's .alpackages). Mirrors the destination
+        // the standalone `al-runner provision` step already uses for the test toolkit.
+        var platformAppsOut = AlRunner.Infrastructure.ProvisioningCheck.PlatformAppsDirFor(
+            AlRunner.Infrastructure.BcArtifacts.ArtifactsRootDir, full);
+        var testAppsOut = AlRunner.Infrastructure.ProvisioningCheck.TestAppsDirFor(
+            AlRunner.Infrastructure.BcArtifacts.ArtifactsRootDir, full);
 
         if (!platformReport.Ok)
         {
             Console.Error.WriteLine("[provision] platform R2R apps missing — downloading...");
             var rc = AlRunner.Provisioning.ArtifactDownloader.PlatformApps(
-                full, pkgCacheOut, m => Console.Error.WriteLine($"[provision] {m}"));
+                full, platformAppsOut, m => Console.Error.WriteLine($"[provision] {m}"));
             if (rc != 0)
             {
                 Console.Error.WriteLine("[provision] platform-apps download failed; cannot continue.");
                 return 2;
             }
+            // Make the downloaded apps visible to resolution: add the artifact-cache dir as
+            // an additional search root rather than copying its contents into the project.
+            if (!packageCacheDirs.Contains(platformAppsOut))
+                packageCacheDirs.Add(platformAppsOut);
             // Re-check: never silently continue on a partial/failed provision.
             platformReport = AlRunner.Infrastructure.ProvisioningCheck.CheckPlatformApps(
                 version, packageCacheDirs);
@@ -556,12 +565,16 @@ if (!provisionSubcommand && packageCacheDirs.Count > 0)
         {
             Console.Error.WriteLine("[provision] test-toolkit apps missing — downloading...");
             var rc = AlRunner.Provisioning.ArtifactDownloader.TestApps(
-                full, pkgCacheOut, m => Console.Error.WriteLine($"[provision] {m}"));
+                full, testAppsOut, m => Console.Error.WriteLine($"[provision] {m}"));
             if (rc != 0)
             {
                 Console.Error.WriteLine("[provision] test-toolkit download failed; cannot continue.");
                 return 2;
             }
+            // Make the downloaded apps visible to resolution: add the artifact-cache dir as
+            // an additional search root rather than copying its contents into the project.
+            if (!packageCacheDirs.Contains(testAppsOut))
+                packageCacheDirs.Add(testAppsOut);
             // Re-check: never silently continue on a partial/failed provision.
             toolkitPresent = AlRunner.Infrastructure.ProvisioningCheck.TestToolkitPresent(packageCacheDirs);
             if (!toolkitPresent)
@@ -3457,9 +3470,16 @@ static IEnumerable<string> DefaultPackageCacheDirs()
     // The provisioned MS test toolkit for the SELECTED version (see
     // EnsureTestToolkitProvisioned). Scanned by default so a test bundle whose app.json
     // depends on Library Assert / Test Runner / Any resolves them without --package-cache.
-    var testApps = Path.Combine(AlRunner.Infrastructure.BcArtifacts.ArtifactsRootDir,
-        sel.ToString(), "test-apps");
+    var testApps = AlRunner.Infrastructure.ProvisioningCheck.TestAppsDirFor(
+        AlRunner.Infrastructure.BcArtifacts.ArtifactsRootDir, sel.ToString());
     if (Directory.Exists(testApps)) yield return testApps;
+
+    // The provisioned Microsoft platform R2R runtime apps for the SELECTED version (see
+    // --auto-provision, issue #1653). Scanned by default so a --auto-provision run on one
+    // invocation is visible on a later run that omits --auto-provision.
+    var platformApps = AlRunner.Infrastructure.ProvisioningCheck.PlatformAppsDirFor(
+        AlRunner.Infrastructure.BcArtifacts.ArtifactsRootDir, sel.ToString());
+    if (Directory.Exists(platformApps)) yield return platformApps;
 }
 
 // Highest version-named child of <root> matching <versionPrefix> (System.Version sort),
@@ -3829,7 +3849,8 @@ static void EnsureTestToolkitProvisioned(string fullVersion)
 }
 
 static string TestAppsDirFor(string fullVersion)
-    => Path.Combine(AlRunner.Infrastructure.BcArtifacts.ArtifactsRootDir, fullVersion, "test-apps");
+    => AlRunner.Infrastructure.ProvisioningCheck.TestAppsDirFor(
+        AlRunner.Infrastructure.BcArtifacts.ArtifactsRootDir, fullVersion);
 
 static void SetBundleInfoFromAppJson(string appJsonPath)
 {


### PR DESCRIPTION
Closes #1653

## Problem

`--auto-provision` picked `packageCacheDirs[0]` as the download target for
the Microsoft platform R2R runtime apps (System Application, Base
Application, Business Foundation) and the MS test toolkit. When
`--package-cache` pointed at a project directory (the common case), that
wrote ~135 MB / 112 `.app` files straight into the project's `.alpackages`
instead of the runner-owned artifact cache the standalone `al-runner
provision` step already uses.

## Fix

- Added `ProvisioningCheck.PlatformAppsDirFor` / `TestAppsDirFor` — pure
  path helpers that always resolve under the runner's artifact root
  (`<artifacts-root>/<version>/platform-apps` and `/test-apps`), never
  under a caller-supplied `--package-cache` dir.
- `--auto-provision` now downloads into those dirs and adds them to the
  in-memory `packageCacheDirs` search list so the provisioned apps still
  resolve for the current run — no copy into the project.
- `DefaultPackageCacheDirs()` now also scans the platform-apps dir by
  default (mirroring the existing test-apps scan), so a later run without
  `--package-cache` still finds a previously auto-provisioned platform app.
- The standalone `provision` subcommand's `TestAppsDirFor` now delegates
  to the same helper (single source of truth for both code paths).

## Test plan

- [x] RED: `AlRunner.Tests/ProvisioningCheckTests.cs` — new tests for
  `PlatformAppsDirFor` / `TestAppsDirFor` failed to compile before the
  helpers existed.
- [x] GREEN: added the helpers, tests pass.
- [x] Full `dotnet test AlRunner.Tests` — 207/207 passed, no regressions.