### PR TITLE
fix(cli): --test-isolation method maps to per-test reset, not codeunit isolation

### DIFF
--- a/AlRunner.Tests/TestIsolationMethodAliasTests.cs
+++ b/AlRunner.Tests/TestIsolationMethodAliasTests.cs
@@ -1,0 +1,215 @@
+// TestIsolationMethodAliasTests — RED->GREEN guard for issue #1647.
+//
+// v1's `--test-isolation method` reset AL table/session state before EVERY [Test]
+// procedure. v2 kept `method` as a backward-compat alias but pointed it at
+// TestIsolation.Codeunit — state shared within a codeunit, reset only between
+// codeunits — instead of the mode that actually does a per-test reset
+// (TestIsolation.Test). Callers that pass the v1-idiomatic `--test-isolation method`
+// (including external tooling built against v1, e.g. the AL mutation-testing tool
+// LethAL) silently got weaker isolation than v1 gave them, with no error.
+//
+// Ghost-test trap avoided: the fixture below has two [Test] procedures in ONE
+// codeunit. Step1 inserts a row and commits implicitly at the end of the method
+// (BC always commits between test methods). Step2 asserts the row count is
+// UNCONDITIONALLY 0 — under `--test-isolation codeunit` (the true "shared within a
+// codeunit" mode) that assertion is FALSE, so a no-op fix that keeps `method`
+// pointed at Codeunit isolation makes this test FAIL, not vacuously pass.
+using System.Diagnostics;
+using System.Text;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+// Serialized with the other runner-subprocess integration tests — see
+// DefineFlagIntegrationTests for why (shared native BC engine state, SIGBUS flakes
+// under xUnit's default parallelization).
+[Collection("server-serial")]
+public sealed class TestIsolationMethodAliasTests : IDisposable
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+    private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
+
+    private readonly string _root;
+
+    public TestIsolationMethodAliasTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "al-runner-isolation-method-alias", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+        WriteFixture(_root);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { }
+    }
+
+    private static bool ArtifactsPresent()
+    {
+        var home = Environment.GetEnvironmentVariable("HOME")
+            ?? Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        var stdCache = Path.Combine(home, ".local", "share", "al-runner", "artifacts");
+        return Directory.Exists(stdCache) &&
+               Directory.EnumerateDirectories(stdCache).Any();
+    }
+
+    /// <summary>
+    /// Writes a minimal AL package to <paramref name="dir"/>:
+    ///   - app.json (no dependencies, id range 62110..62119)
+    ///   - a one-field table
+    ///   - a test codeunit with two [Test] procedures, declared in this order:
+    ///       Step1_InsertsRow inserts one row.
+    ///       Step2_ExpectsFreshTable asserts the table is empty (UNCONDITIONALLY).
+    ///     Under real per-test isolation (v1's `method`, v2's `test`), Step2 always
+    ///     sees an empty table because state resets before every [Test]. Under
+    ///     per-codeunit isolation (v2's true `codeunit` mode), the row from Step1
+    ///     survives into Step2 and the assertion fails.
+    /// </summary>
+    private static void WriteFixture(string dir)
+    {
+        File.WriteAllText(Path.Combine(dir, "app.json"), """
+        {
+          "id": "a1b2c3d4-e5f6-7890-1234-567890abcdef",
+          "name": "Isolation Method Alias Test Fixture",
+          "publisher": "AL Runner",
+          "version": "1.0.0.0",
+          "dependencies": [],
+          "platform": "1.0.0.0",
+          "application": "1.0.0.0",
+          "idRanges": [ { "from": 62110, "to": 62119 } ],
+          "runtime": "14.0"
+        }
+        """);
+
+        File.WriteAllText(Path.Combine(dir, "Assert.Codeunit.al"), """
+        codeunit 62111 "IMA Assert"
+        {
+            procedure AreEqual(Expected: Integer; Actual: Integer; Msg: Text)
+            begin
+                if Expected <> Actual then
+                    Error('Expected:<%1> Actual:<%2> %3', Expected, Actual, Msg);
+            end;
+        }
+        """);
+
+        File.WriteAllText(Path.Combine(dir, "Marker.Table.al"), """
+        table 62110 "IMA Marker"
+        {
+            fields
+            {
+                field(1; Id; Integer) { }
+            }
+            keys
+            {
+                key(PK; Id) { Clustered = true; }
+            }
+        }
+        """);
+
+        File.WriteAllText(Path.Combine(dir, "IsolationTest.Codeunit.al"), """
+        codeunit 62112 "Isolation Method Alias Tests"
+        {
+            Subtype = Test;
+
+            var
+                Assert: Codeunit "IMA Assert";
+
+            [Test]
+            procedure Step1_InsertsRow()
+            var
+                Marker: Record "IMA Marker";
+            begin
+                Marker.Init();
+                Marker.Id := 1;
+                Marker.Insert();
+                Assert.AreEqual(1, Marker.Count(), 'row must be inserted');
+            end;
+
+            [Test]
+            procedure Step2_ExpectsFreshTable()
+            var
+                Marker: Record "IMA Marker";
+            begin
+                Assert.AreEqual(0, Marker.Count(), 'table must be reset before this test — per-method isolation must have fired');
+            end;
+        }
+        """);
+    }
+
+    private (string output, int exit) RunRunner(params string[] extraArgs)
+    {
+        var args = new StringBuilder(TestBuildConfig.RunArgs(ProjectPath));
+        args.Append(TestBuildConfig.BcVersionArg);
+        args.Append(" --strict");
+        args.Append($" \"{_root}\"");
+        foreach (var a in extraArgs) args.Append($" {a}");
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet", Arguments = args.ToString(),
+            RedirectStandardOutput = true, RedirectStandardError = true,
+            UseShellExecute = false, CreateNoWindow = true, WorkingDirectory = RepoRoot,
+        };
+        var sb = new StringBuilder();
+        var p = Process.Start(psi)!;
+        p.OutputDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.ErrorDataReceived  += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.BeginOutputReadLine();
+        p.BeginErrorReadLine();
+        if (!p.WaitForExit(240_000)) { try { p.Kill(true); } catch { } throw new TimeoutException("runner hung"); }
+        p.WaitForExit();
+        lock (sb) return (sb.ToString(), p.ExitCode);
+    }
+
+    /// <summary>
+    /// Positive: `--test-isolation method` must behave like v1 — a fresh reset before
+    /// every [Test] procedure. Before the fix (method aliased to Codeunit isolation)
+    /// Step2 sees the row Step1 inserted and fails; this is the RED proof.
+    /// </summary>
+    [Fact]
+    public void TestIsolationMethod_ResetsStateBetweenTestMethods()
+    {
+        if (!ArtifactsPresent()) { Console.Error.WriteLine("[skip] BC artifacts not present"); return; }
+
+        var (output, exit) = RunRunner("--test-isolation method");
+
+        Assert.Equal(0, exit);
+        Assert.DoesNotContain("FAIL  Codeunit", output);
+        Assert.Contains("Step1_InsertsRow", output);
+        Assert.Contains("Step2_ExpectsFreshTable", output);
+    }
+
+    /// <summary>
+    /// Same assertion via the short `--isolation` flag spelling, which shares the
+    /// same alias-mapping switch.
+    /// </summary>
+    [Fact]
+    public void IsolationMethod_ResetsStateBetweenTestMethods()
+    {
+        if (!ArtifactsPresent()) { Console.Error.WriteLine("[skip] BC artifacts not present"); return; }
+
+        var (output, exit) = RunRunner("--isolation method");
+
+        Assert.Equal(0, exit);
+        Assert.DoesNotContain("FAIL  Codeunit", output);
+    }
+
+    /// <summary>
+    /// Negative / contrast case: real `--test-isolation codeunit` shares state within
+    /// a codeunit (BC's "Isol. Codeunit" 130450), so the row Step1 inserted survives
+    /// into Step2 and its unconditional "table must be empty" assertion fails. This
+    /// proves the fixture actually exercises the isolation boundary — a no-op fix
+    /// that keeps `method` pointed at Codeunit isolation would make this outcome
+    /// identical to the `method` runs above, not just "some test passes".
+    /// </summary>
+    [Fact]
+    public void TestIsolationCodeunit_SharesStateBetweenTestMethods()
+    {
+        if (!ArtifactsPresent()) { Console.Error.WriteLine("[skip] BC artifacts not present"); return; }
+
+        var (output, exit) = RunRunner("--test-isolation codeunit");
+
+        Assert.NotEqual(0, exit);
+        Assert.Contains("Step2_ExpectsFreshTable", output);
+        Assert.Contains("table must be reset before this test", output);
+    }
+}

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -294,11 +294,18 @@ for (int i = 0; i < args.Length; i++)
         var mode = args[++i].ToLowerInvariant();
         isolation = mode switch
         {
-            "codeunit" or "method" => AlRunner.TestIsolation.Codeunit,
-            "test"                 => AlRunner.TestIsolation.Test,
+            // v1's --test-isolation method reset AL table/session state before every
+            // [Test] procedure (per-v1 Program.cs: doTableReset = testIsolation ==
+            // TestIsolation.Method). That is v2's TestIsolation.Test, NOT
+            // TestIsolation.Codeunit — see issue #1647. Map 'method' onto the mode
+            // that actually reproduces v1's behavior so callers that still pass the
+            // v1-idiomatic flag value (e.g. LethAL) don't silently get weaker
+            // isolation than they asked for.
+            "codeunit"             => AlRunner.TestIsolation.Codeunit,
+            "test" or "method"     => AlRunner.TestIsolation.Test,
             "disabled"             => AlRunner.TestIsolation.Disabled,
             _ => throw new ArgumentException(
-                $"--isolation: unknown mode '{mode}' (codeunit|test|disabled; 'method' accepted as v1 alias for codeunit)")
+                $"--isolation: unknown mode '{mode}' (codeunit|test|disabled; 'method' accepted as v1 alias for test)")
         };
         continue;
     }
@@ -2434,7 +2441,7 @@ static void PrintHelp(TextWriter w)
     w.WriteLine("                                      (default; BC's \"Isol. Codeunit\" 130450)");
     w.WriteLine("                            test      every [Test] gets a fresh state (BC's 130452)");
     w.WriteLine("                            disabled  no resets at all (BC's 130453)");
-    w.WriteLine("                            method    accepted as v1 alias for codeunit");
+    w.WriteLine("                            method    v1 alias for 'test' (v1's per-method reset)");
     w.WriteLine();
     w.WriteLine("EXECUTION");
     w.WriteLine("  --bc-version X          Select the BC artifact version (e.g. \"28.1\" or a full");

--- a/docs/v1-to-v2-migration.md
+++ b/docs/v1-to-v2-migration.md
@@ -34,7 +34,7 @@ allowed and forbidden.
 | `--out PATH` | ✓ | ✓ | Failure-classification JSON. |
 | `--package-cache PATH` (repeatable) | ✓ | ✓ | Same scan order. |
 | `--cache DIR` | ✓ | ✓ | AL-output cache. |
-| `--isolation MODE` / `--test-isolation MODE` | `--test-isolation` only | both work | v2 accepts the v1 name. `method` accepted as alias for `codeunit`. |
+| `--isolation MODE` / `--test-isolation MODE` | `--test-isolation` only | both work | v2 accepts the v1 name. `method` accepted as alias for `test` (v1's `--test-isolation method` reset state before every `[Test]` procedure — that is v2's `test` mode, not `codeunit`; see #1647). |
 | `--verbose` | ✓ | ✓ | Same. |
 | `--show-pass` | ✓ | accepted (no-op) | v2 prints PASS lines by default. |
 | `--failures-only` / `--quiet` | (no flag — was default) | ✓ | New v2 opt-out to suppress PASS lines. |


### PR DESCRIPTION
Closes #1647

v1's `--test-isolation method` reset AL table/session state before every `[Test]` procedure. v2 kept `method` as a backward-compat alias but pointed it at `TestIsolation.Codeunit` — state shared within a codeunit, reset only between codeunits — instead of `TestIsolation.Test`, which is what actually does a per-test reset. Callers that still pass the v1-idiomatic flag value (including external tooling built against v1, e.g. LethAL) silently got weaker isolation than v1 gave them, with no error.

## Fix

- `AlRunner/Program.cs`: `method` now maps to `TestIsolation.Test` for both `--isolation` and `--test-isolation`. Updated the `--help` text and the unknown-mode error message to match.
- `docs/v1-to-v2-migration.md`: fixed the stale claim that `method` is an alias for `codeunit`.

## Test plan

- Added `AlRunner.Tests/TestIsolationMethodAliasTests.cs`: a two-method AL test codeunit where method 1 inserts a row and method 2 asserts the table is empty.
  - `--test-isolation method` / `--isolation method`: both methods pass (per-test reset fires) — RED before the fix (method 2 saw the row from method 1 and failed), GREEN after.
  - `--test-isolation codeunit` (contrast case): method 2 fails because the row survives within the codeunit, proving the fixture actually exercises the isolation boundary rather than passing vacuously.
- Ran `dotnet test AlRunner.Tests --filter TestIsolationMethodAliasTests` — 3/3 pass on the fix, 2/3 fail (RED) with the fix reverted.
- Ran `CliDocumentationTests` and `DefineFlagIntegrationTests` for regressions — all pass.