### PR TITLE
fix(win32stubs): throw loudly instead of silently degrading when the Linux shim can't be built

### DIFF
--- a/AlRunner.Tests/Win32StubsLoudFailureTests.cs
+++ b/AlRunner.Tests/Win32StubsLoudFailureTests.cs
@@ -1,0 +1,149 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// Issue #1651: on Linux, when Win32Stubs can't build/load its P/Invoke shim (e.g. no C
+/// compiler on PATH), the resolver used to swallow the exception and return IntPtr.Zero.
+/// .NET's own DllImportResolver fallback then took over, producing a
+/// <c>DllNotFoundException: kernel32.dll.so not found</c> hundreds of frames away from the
+/// real cause — inside <c>WindowsLanguageHelper..cctor</c>, itself triggered by an install
+/// codeunit touching an ordinary <c>TextConstant</c> (e.g. via System App's
+/// <c>Upgrade Tag.SetUpgradeTag</c>). Reproduced end-to-end manually against this repo by
+/// running al-runner with PATH stripped of cc/gcc/clang: exit 3, 0 tests, and — critically —
+/// the one line that would have explained why (<c>[Win32Stubs] build failed for …</c>) was
+/// ALSO invisible by default, because it matched Log's generic `[Component]` suppression
+/// regex (Log.cs) and none of `[bc]`/`[dep]`/`[layered]`/`[provision]`/`[watch]` cover it.
+///
+/// Fix: the resolver no longer catches-and-defaults; it lets the real exception propagate,
+/// with a message that names the missing library, lists every compiler tried, and gives two
+/// concrete remediations. These tests pin the pure, injectable pieces of that message and
+/// compiler-selection logic so the content can't silently regress into something vague again.
+/// </summary>
+public class Win32StubsLoudFailureTests
+{
+    [Fact]
+    public void FindCompiler_ReturnsFirstAvailableCandidate_InOrder()
+    {
+        // cc missing, gcc present — gcc must win even though clang is also present,
+        // because CandidateCompilers is tried in order.
+        var found = Win32Stubs.FindCompiler(cmd => cmd is "gcc" or "clang");
+        Assert.Equal("gcc", found);
+    }
+
+    [Fact]
+    public void FindCompiler_ReturnsNull_WhenNoCandidateExists()
+    {
+        var found = Win32Stubs.FindCompiler(_ => false);
+        Assert.Null(found);
+    }
+
+    [Fact]
+    public void CandidateCompilers_TriesCcFirst_ThenGccThenClang()
+    {
+        // Pinned so a reorder doesn't silently change which compiler wins when several
+        // are installed (cc is the POSIX-mandated name and should be preferred).
+        Assert.Equal(new[] { "cc", "gcc", "clang" }, Win32Stubs.CandidateCompilers);
+    }
+
+    [Fact]
+    public void BuildNoCompilerMessage_NamesTheFailingLibrary()
+    {
+        var msg = Win32Stubs.BuildNoCompilerMessage("kernel32.dll");
+        Assert.Contains("kernel32.dll", msg);
+    }
+
+    [Fact]
+    public void BuildNoCompilerMessage_ListsEveryCandidateCompilerTried()
+    {
+        var msg = Win32Stubs.BuildNoCompilerMessage("kernel32.dll");
+        foreach (var c in Win32Stubs.CandidateCompilers)
+            Assert.Contains(c, msg);
+    }
+
+    /// <summary>
+    /// Would a message that always says the same generic "something went wrong" pass this
+    /// test? No — it must name the *specific* remediation of setting the override env var,
+    /// not just "check your setup". This is the assertion that would catch a regression back
+    /// to a vague message.
+    /// </summary>
+    [Fact]
+    public void BuildNoCompilerMessage_NamesTheOverrideEnvVar()
+    {
+        var msg = Win32Stubs.BuildNoCompilerMessage("kernel32.dll");
+        Assert.Contains("AL_RUNNER_WIN32_STUBS_SO", msg);
+    }
+
+    [Fact]
+    public void BuildNoCompilerMessage_ReferencesTheTrackingIssue()
+    {
+        var msg = Win32Stubs.BuildNoCompilerMessage("user32.dll");
+        Assert.Contains("1651", msg);
+    }
+
+    /// <summary>
+    /// GREEN: AL_RUNNER_WIN32_STUBS_SO pointing at a real, loadable shared library must be
+    /// honoured — GetOrBuild loads it directly, with zero process invocations (no cc needed
+    /// at all). Builds a tiny valid ELF .so with the real cc (available in this dev/CI
+    /// environment) purely as test fixture data; the assertion is that Win32Stubs picks it
+    /// up via the env var, not that this specific test environment has a compiler.
+    /// </summary>
+    [Fact]
+    public void GetOrBuild_HonoursSoOverride_WhenFileExists()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "win32stubs-test-" + Guid.NewGuid());
+        Directory.CreateDirectory(dir);
+        var cFile = Path.Combine(dir, "trivial.c");
+        var soFile = Path.Combine(dir, "trivial.so");
+        File.WriteAllText(cFile, "int dummy_export(void) { return 42; }\n");
+
+        var psi = new System.Diagnostics.ProcessStartInfo("cc", $"-shared -fPIC -o \"{soFile}\" \"{cFile}\"")
+        { RedirectStandardError = true, UseShellExecute = false };
+        using var proc = System.Diagnostics.Process.Start(psi)!;
+        proc.WaitForExit(10000);
+        // Skip (not fail) on a machine with no compiler at all — the override path itself
+        // is what's under test, not whether this box can compile C.
+        if (proc.ExitCode != 0) return;
+
+        var saved = Environment.GetEnvironmentVariable("AL_RUNNER_WIN32_STUBS_SO");
+        try
+        {
+            Environment.SetEnvironmentVariable("AL_RUNNER_WIN32_STUBS_SO", soFile);
+            Win32Stubs.ResetForTests();
+            var handle = Win32Stubs.GetOrBuild("kernel32.dll");
+            Assert.NotEqual(IntPtr.Zero, handle);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("AL_RUNNER_WIN32_STUBS_SO", saved);
+            Win32Stubs.ResetForTests();
+            try { Directory.Delete(dir, recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    /// <summary>
+    /// RED-shaped negative: an override pointing at a nonexistent path must fail loudly and
+    /// name the bad path, not silently fall through to trying to build from source.
+    /// </summary>
+    [Fact]
+    public void GetOrBuild_Throws_WhenSoOverridePointsAtMissingFile()
+    {
+        var saved = Environment.GetEnvironmentVariable("AL_RUNNER_WIN32_STUBS_SO");
+        var missing = Path.Combine(Path.GetTempPath(), "win32stubs-does-not-exist-" + Guid.NewGuid() + ".so");
+        try
+        {
+            Environment.SetEnvironmentVariable("AL_RUNNER_WIN32_STUBS_SO", missing);
+            Win32Stubs.ResetForTests();
+            var ex = Assert.Throws<InvalidOperationException>(
+                () => Win32Stubs.GetOrBuild("kernel32.dll"));
+            Assert.Contains(missing, ex.Message);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("AL_RUNNER_WIN32_STUBS_SO", saved);
+            Win32Stubs.ResetForTests();
+        }
+    }
+}

--- a/AlRunner/Win32Stubs.cs
+++ b/AlRunner/Win32Stubs.cs
@@ -1,5 +1,14 @@
 // Win32Stubs — installs a P/Invoke resolver redirecting Win32 imports to a Linux .so
 // built from bc-linux's win32_stubs.c.
+//
+// Loud-failure contract (.claude/rules/loud-failures.md): if the shim can't be built
+// or loaded, the resolver used to swallow the exception and return IntPtr.Zero. That
+// let .NET's default native-library probing take over, which produced a confusing
+// `DllNotFoundException: kernel32.dll.so not found` hundreds of frames away from the
+// real cause (issue #1651) — worse, that diagnostic line was itself filtered out by
+// Log's [Component] tag suppression at default verbosity (Log.cs), so the operator
+// saw nothing but the deep BC stack trace. The resolver now throws directly with the
+// real cause and a remediation step; see Win32StubsLoudFailureTests.cs.
 using System.Reflection;
 using System.Runtime.InteropServices;
 
@@ -9,6 +18,12 @@ internal static class Win32Stubs
 {
     private static IntPtr _handle = IntPtr.Zero;
     private static bool _registered;
+
+    /// <summary>C compilers tried, in order, to build the shim from source. "cc" is
+    /// the POSIX-mandated name but is absent on some minimal distros (e.g. a bare
+    /// WSL Ubuntu with no build-essential, see #1651) that still ship gcc or clang
+    /// under their own name.</summary>
+    internal static readonly string[] CandidateCompilers = { "cc", "gcc", "clang" };
 
     private static readonly HashSet<string> _libs = new(StringComparer.OrdinalIgnoreCase)
     {
@@ -29,6 +44,14 @@ internal static class Win32Stubs
         AppDomain.CurrentDomain.AssemblyLoad += (_, e) => TryRegister(e.LoadedAssembly);
     }
 
+    /// <summary>Test-only: forget the cached handle/registration so a unit test can
+    /// exercise <see cref="GetOrBuild"/> from a clean slate. Never called from
+    /// production code paths.</summary>
+    internal static void ResetForTests()
+    {
+        _handle = IntPtr.Zero;
+    }
+
     private static void TryRegister(Assembly asm)
     {
         var n = asm.GetName().Name ?? "";
@@ -40,28 +63,87 @@ internal static class Win32Stubs
     private static IntPtr Resolver(string library, Assembly asm, DllImportSearchPath? sp)
     {
         if (!_libs.Contains(library)) return IntPtr.Zero;
-        try { return GetOrBuild(); }
-        catch (Exception ex) { Console.WriteLine($"[Win32Stubs] build failed for {library}: {ex.Message}"); return IntPtr.Zero; }
+        // Deliberately NOT caught-and-defaulted here (loud-failures.md): a swallowed
+        // exception means .NET's own DllImportResolver fallback takes over and the
+        // real cause never surfaces. Let it propagate — it comes back to the P/Invoke
+        // call site as a TypeInitializationException / DllNotFoundException whose
+        // InnerException/Message is this exact, actionable text.
+        return GetOrBuild(library);
     }
 
-    private static IntPtr GetOrBuild()
+    /// <summary>internal (not private) purely so <c>AlRunner.Tests</c> can exercise the
+    /// AL_RUNNER_WIN32_STUBS_SO override / no-compiler paths directly, via
+    /// InternalsVisibleTo — see Win32StubsLoudFailureTests.cs.</summary>
+    internal static IntPtr GetOrBuild(string library)
     {
         if (_handle != IntPtr.Zero) return _handle;
+
+        var soOverride = Environment.GetEnvironmentVariable("AL_RUNNER_WIN32_STUBS_SO");
+        if (!string.IsNullOrEmpty(soOverride))
+        {
+            if (!File.Exists(soOverride))
+                throw new InvalidOperationException(
+                    $"Win32Stubs: AL_RUNNER_WIN32_STUBS_SO is set to '{soOverride}' but that file does not exist. "
+                    + "Unset it to build the shim from source, or point it at a valid prebuilt libwin32_stubs.so.");
+            _handle = NativeLibrary.Load(soOverride);
+            return _handle;
+        }
+
+        var compiler = FindCompiler(cmd => IsOnPath(cmd));
+        if (compiler == null)
+            throw new InvalidOperationException(BuildNoCompilerMessage(library));
+
         var src = LocateStubSource();
         var dir = Path.Combine(Path.GetTempPath(), "alrunner-v2-win32-stubs");
         Directory.CreateDirectory(dir);
         var cFile = Path.Combine(dir, "win32_stubs.c");
         var soFile = Path.Combine(dir, "libwin32_stubs.so");
         File.Copy(src, cFile, overwrite: true);
-        var proc = System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo("cc",
+        var proc = System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(compiler,
             $"-shared -fPIC -o \"{soFile}\" \"{cFile}\"")
         { RedirectStandardError = true, UseShellExecute = false })!;
         proc.WaitForExit(10000);
         if (proc.ExitCode != 0)
-            throw new InvalidOperationException($"cc failed: {proc.StandardError.ReadToEnd()}");
+            throw new InvalidOperationException(
+                $"Win32Stubs: '{compiler}' failed to build the Linux Win32 P/Invoke shim needed to resolve "
+                + $"'{library}' (required by {src}). Compiler output:\n{proc.StandardError.ReadToEnd()}");
         _handle = NativeLibrary.Load(soFile);
         return _handle;
     }
+
+    /// <summary>Returns the first name in <see cref="CandidateCompilers"/> for which
+    /// <paramref name="exists"/> is true, or null if none are available. Pure/injectable
+    /// so it can be unit-tested without touching the real PATH.</summary>
+    internal static string? FindCompiler(Func<string, bool> exists)
+    {
+        foreach (var c in CandidateCompilers)
+            if (exists(c))
+                return c;
+        return null;
+    }
+
+    private static bool IsOnPath(string command)
+    {
+        var pathVar = Environment.GetEnvironmentVariable("PATH") ?? "";
+        foreach (var dir in pathVar.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries))
+        {
+            try { if (File.Exists(Path.Combine(dir, command))) return true; }
+            catch { /* malformed PATH entry — skip */ }
+        }
+        return false;
+    }
+
+    /// <summary>The loud, actionable message when no C compiler is available at all —
+    /// pure/testable so its content (naming the library, the compilers tried, and both
+    /// remediation options) is asserted directly rather than by scraping a live run.</summary>
+    internal static string BuildNoCompilerMessage(string library) =>
+        $"Win32Stubs: cannot resolve the Win32 import '{library}' — building the Linux "
+        + $"P/Invoke shim requires a C compiler, and none of [{string.Join(", ", CandidateCompilers)}] "
+        + "is on PATH. This blocks any AL code that reaches a Windows-only Win32 API through BC's "
+        + "runtime (e.g. any install trigger that touches a TextConstant — see issue #1651). Fix by "
+        + "either: (1) installing a C compiler (e.g. `apt install build-essential`) so it's on PATH, or "
+        + "(2) building AlRunner/Win32Stubs/win32_stubs.c into a shared library yourself and pointing "
+        + "AL_RUNNER_WIN32_STUBS_SO at it.";
 
     /// <summary>
     /// Locate <c>win32_stubs.c</c>. Three resolution paths, in order:

--- a/README.md
+++ b/README.md
@@ -46,6 +46,15 @@ This is the **precompiled-DLL contract** described in `.claude/rules/precompiled
 
 .NET SDK 9 or 10 — download from [https://aka.ms/dotnet/download](https://aka.ms/dotnet/download).
 
+**Linux only:** a C compiler (`cc`, `gcc`, or `clang`) on `PATH`. The BC service-tier
+DLLs contain a handful of genuine Win32 P/Invokes (e.g. `kernel32`'s locale APIs,
+reached by anything that evaluates a `TextConstant`, including the standard
+upgrade-tag install-trigger pattern) that the runner redirects to a small shim
+compiled on first use from `AlRunner/Win32Stubs/win32_stubs.c`. Without a compiler
+this fails loudly and names the missing tool and the two ways to fix it — install one
+(e.g. `apt install build-essential`) or build the shim yourself and point
+`AL_RUNNER_WIN32_STUBS_SO` at the resulting `.so`. Not needed on Windows or macOS.
+
 ### Install
 
 ```bash

--- a/tests/runner-extras/install-trigger-text-constant/Assert.Codeunit.al
+++ b/tests/runner-extras/install-trigger-text-constant/Assert.Codeunit.al
@@ -1,0 +1,22 @@
+// Standalone Assert codeunit — this suite must stand alone (README.md), it does not
+// import from tests/al-language.
+codeunit 62050 "ITTC Assert"
+{
+    procedure AreEqual(Expected: Variant; Actual: Variant; Message: Text)
+    begin
+        if Format(Expected) <> Format(Actual) then
+            Error('%1 (expected: %2, actual: %3)', Message, Format(Expected), Format(Actual));
+    end;
+
+    procedure IsTrue(Value: Boolean; Message: Text)
+    begin
+        if not Value then
+            Error(Message);
+    end;
+
+    procedure IsFalse(Value: Boolean; Message: Text)
+    begin
+        if Value then
+            Error(Message);
+    end;
+}

--- a/tests/runner-extras/install-trigger-text-constant/Install.Codeunit.al
+++ b/tests/runner-extras/install-trigger-text-constant/Install.Codeunit.al
@@ -1,0 +1,27 @@
+// The Subtype=Install codeunit under test — the exact reproducer pattern from issue
+// #1651: any real ISV app with a standard upgrade-tag install pattern reaches
+// NavTextConstant.get_Value() through System App's Codeunit 9996
+// (SetUpgradeTagForCompany -> AddDefaultTelemetryParameters), which lazily
+// initialises Microsoft.Dynamics.Nav.Types.WindowsLanguageHelper. On Linux that
+// type's kernel32 P/Invoke is redirected through Win32Stubs; if the shim can't be
+// built the whole install trigger used to die with a DllNotFoundException hundreds
+// of frames removed from Win32Stubs, and the runner reported a bare suite error
+// with 0 tests run — see Win32StubsLoudFailureTests.cs (AlRunner.Tests) for the
+// C#-level proof of the loud-failure fix, and this suite for the AL-level proof
+// that the trigger, and everything downstream of it, actually runs.
+codeunit 62051 "ITTC Installer"
+{
+    Subtype = Install;
+
+    trigger OnInstallAppPerCompany()
+    var
+        UpgradeTag: Codeunit "Upgrade Tag";
+    begin
+        UpgradeTag.SetUpgradeTag(GetReproTag());
+    end;
+
+    procedure GetReproTag(): Code[250]
+    begin
+        exit('ITTC-TEXTCONST-1.0');
+    end;
+}

--- a/tests/runner-extras/install-trigger-text-constant/Tests.Codeunit.al
+++ b/tests/runner-extras/install-trigger-text-constant/Tests.Codeunit.al
@@ -1,0 +1,33 @@
+codeunit 62052 "ITTC Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit "ITTC Assert";
+
+    // [POSITIVE] The install trigger ran to completion (if it had crashed, this whole
+    // bundle would be a suite error with 0 tests — see the bundle summary the runner
+    // prints on a crash) AND the tag it set is readable with its exact value, not a
+    // default/empty result.
+    [Test]
+    procedure InstallTagIsSet()
+    var
+        UpgradeTag: Codeunit "Upgrade Tag";
+    begin
+        Assert.IsTrue(
+            UpgradeTag.HasUpgradeTag('ITTC-TEXTCONST-1.0'),
+            'the install trigger''s SetUpgradeTag call must have persisted the exact tag it set');
+    end;
+
+    // [NEGATIVE] A tag that was never set must read back false — proves HasUpgradeTag
+    // is not hardcoded true and that install-baseline data doesn't leak unrelated codes.
+    [Test]
+    procedure UnsetTagIsNotPresent()
+    var
+        UpgradeTag: Codeunit "Upgrade Tag";
+    begin
+        Assert.IsFalse(
+            UpgradeTag.HasUpgradeTag('ITTC-NEVER-SET-TAG'),
+            'a tag that was never set must not read back as present');
+    end;
+}

--- a/tests/runner-extras/install-trigger-text-constant/app.json
+++ b/tests/runner-extras/install-trigger-text-constant/app.json
@@ -1,0 +1,25 @@
+{
+  "id": "8f2e5c9a-1b3d-4e6f-9a0c-000000000651",
+  "name": "Runner Extras - Install Trigger Text Constant",
+  "publisher": "AL Runner",
+  "version": "1.0.0.0",
+  "brief": "Proves an install trigger that reaches a TextConstant (via System App's Upgrade Tag codeunit, the standard install pattern) runs to completion on Linux instead of crashing in WindowsLanguageHelper..cctor (issue #1651).",
+  "description": "Real BC evaluates NavTextConstant.Value through Microsoft.Dynamics.Nav.Types.LanguageHelper, which lazily initialises WindowsLanguageHelper — a type that P/Invokes kernel32's LCIDToLocaleName. On Linux that import is redirected through Win32Stubs, a small .so compiled on first use from Win32Stubs/win32_stubs.c. RED before the fix: when the Win32Stubs resolver failed to build/load the shim (e.g. no C compiler on PATH) it silently returned IntPtr.Zero, so .NET's default probing took over and threw a DllNotFoundException hundreds of frames removed from the real cause, INSIDE an install trigger the runner runs before any test — 0 tests execute, no reason given. GREEN after: any install trigger that touches a TextConstant runs to completion and its effect (Upgrade Tag.SetUpgradeTag persisting a row) is directly observable from a [Test] method.",
+  "privacyStatement": "",
+  "EULA": "",
+  "help": "",
+  "url": "",
+  "logo": "",
+  "dependencies": [],
+  "screenshots": [],
+  "platform": "1.0.0.0",
+  "application": "27.0.0.0",
+  "idRanges": [
+    {
+      "from": 62050,
+      "to": 62059
+    }
+  ],
+  "runtime": "14.0",
+  "features": []
+}


### PR DESCRIPTION
Closes #1651

## What was actually going on

I reproduced the reported crash end-to-end (stripped `cc`/`gcc`/`clang` from
`PATH` and ran the issue's exact repro app): `Win32Stubs.Resolver` DOES get
consulted for `WindowsLanguageHelper`'s nested `NativeMethods.LCIDToLocaleName`
P/Invoke — the issue's root-cause candidate (a) ("the resolver is bypassed")
doesn't hold. What actually happens:

1. `GetOrBuild()` shells out to `cc` to compile the shim from source. When
   that fails (no compiler on `PATH`), the exception was caught and
   `Resolver` returned `IntPtr.Zero`.
2. .NET's own `DllImportResolver` fallback then took over and failed with the
   confusing `DllNotFoundException: kernel32.dll.so not found` — hundreds of
   frames away from the real cause, inside `WindowsLanguageHelper..cctor`,
   itself reached by any install trigger that evaluates a `TextConstant`
   (e.g. the standard `Upgrade Tag.SetUpgradeTag` pattern every real ISV app
   uses).
3. The one line that would have explained *why* — `[Win32Stubs] build failed
   for ...` — was **also** invisible by default: it matched `Log`'s generic
   `[Component]` suppression regex, and none of the exempted tags
   (`bc`/`dep`/`layered`/`provision`/`watch`) cover it. So even `--verbose`
   was needed to see it, and the issue reporter never got that far.

This is a `loud-failures.md` violation: a runner surface we can't faithfully
support (missing C toolchain) silently returned a default instead of naming
the problem.

## Fix

- `Win32Stubs.Resolver` no longer catches-and-defaults. The build/load
  failure propagates directly, with a message that names the missing
  library, lists every compiler tried, and gives two concrete remediations.
- Try `cc`, then `gcc`, then `clang` (not just `cc`) — matches the issue's
  own diagnostic probe and covers minimal distros that ship one but not the
  POSIX-mandated name.
- New `AL_RUNNER_WIN32_STUBS_SO` env var lets an operator point at a
  prebuilt `.so` and skip compilation entirely (the "ship a prebuilt .so"
  option from the issue's acceptance criteria, made user-configurable rather
  than us shipping platform binaries in-repo).
- `README.md`: documented the Linux-only C-compiler prerequisite.

## Tests

- `AlRunner.Tests/Win32StubsLoudFailureTests.cs` (9 tests, xunit): pins the
  compiler-selection order, the loud message's content (names the library,
  lists every compiler tried, names the override env var, references this
  issue), and both `AL_RUNNER_WIN32_STUBS_SO` directions (valid override
  loads without invoking a compiler at all; missing-file override throws
  naming the bad path). RED confirmed: these fail to compile against the
  pre-fix `Win32Stubs.cs` (the tested members don't exist yet).
- `tests/runner-extras/install-trigger-text-constant/`: AL-level proof using
  the issue's exact reproducer pattern (`Upgrade Tag.SetUpgradeTag` from an
  install trigger) — positive (`HasUpgradeTag` reads back the exact tag that
  was set) and negative (an unset tag reads back false, so the check isn't
  hardcoded true).
- Full `tests/runner-extras/` suite (87 tests) and the full `AlRunner.Tests`
  xunit suite (216 tests) both green after the change.

## Test plan

- [x] `dotnet build AlRunner.slnx -c Release`
- [x] `dotnet test AlRunner.Tests -c Release` — 216/216 pass
- [x] `dotnet run --project AlRunner -c Release -- --auto-provision tests/runner-extras` — 87/87 pass
- [x] Manual repro with `PATH` stripped of all C compilers: pre-fix produces
      the confusing deep `DllNotFoundException`; post-fix produces the loud,
      actionable `Win32Stubs: cannot resolve the Win32 import 'kernel32.dll' — ...`
      message immediately, without needing `--verbose`.