### PR TITLE
fix(cli): --output-json redirects progress banners to stderr

### DIFF
--- a/AlRunner.Tests/OutputFormatTests.cs
+++ b/AlRunner.Tests/OutputFormatTests.cs
@@ -139,11 +139,11 @@ public sealed class OutputFormatTests : IDisposable
 
         Assert.Equal(1, exit); // strict-by-default: a failing test means nonzero exit
 
-        // stdout carries banner lines ahead of the JSON payload; the JSON itself
-        // starts at the first '{' and is everything from there to EOF.
-        int jsonStart = output.IndexOf('{');
-        Assert.True(jsonStart >= 0, $"no JSON object found in output:\n{output}");
-        using var doc = JsonDocument.Parse(output[jsonStart..]);
+        // stdout must be JSON-only, per --help's documented contract ("Replace the normal
+        // text output with per-test JSON on stdout") — no bundle/suite progress banners,
+        // no [layered]/[bc] lines ahead of it. The whole trimmed stream must parse as one
+        // JSON object; a caller doing JSON.parse(stdout) must succeed with no preprocessing.
+        using var doc = JsonDocument.Parse(output.Trim());
         var root = doc.RootElement;
 
         Assert.Equal(1, root.GetProperty("passed").GetInt32());

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -321,6 +321,17 @@ if (serverMode && watchMode)
     Console.Error.WriteLine("--server and --watch are mutually exclusive (both stay warm in-process; pick one).");
     return 2;
 }
+// --output-json: stdout must be JSON-only, matching the documented contract ("Replace
+// the normal text output with per-test JSON on stdout") and the convention --server
+// already follows. Redirect ALL human-readable progress (bundle/suite banners, [layered]
+// cache lines, [bc] selection notices, etc.) to stderr from here on; capture the real
+// stdout so the single final JSON write below can go straight to it, un-interleaved.
+System.IO.TextWriter? outputJsonStdout = null;
+if (outputJson && !serverMode)
+{
+    outputJsonStdout = Console.Out;
+    Console.SetOut(Console.Error);
+}
 // ── BC artifact/version selection (must run BEFORE the Cecil block below, which
 // reads BcArtifacts.ServiceTierDir, and before any dependency/symbol resolver). Sets
 // the process-global selection that resolvers A (engine), B (deps), C (symbols) all
@@ -1638,7 +1649,12 @@ int computedExitCode = 0;
 
 if (outputJson)
 {
-    Console.WriteLine(Reporter.SerializeJsonOutput(results, computedExitCode));
+    var json = Reporter.SerializeJsonOutput(results, computedExitCode);
+    // Restore the real stdout (captured above) so this is the ONLY thing ever
+    // written to it — every banner/progress line up to this point went to stderr
+    // instead. See the redirect right after arg parsing for why.
+    if (outputJsonStdout != null) Console.SetOut(outputJsonStdout);
+    Console.WriteLine(json);
 }
 else
 {
@@ -1650,7 +1666,9 @@ else
 if (outPath != null)
 {
     Reporter.WriteClassification(results, outPath);
-    Console.WriteLine($"Classification → {outPath}");
+    // In --output-json mode this must not land on stdout (it already printed the
+    // JSON above and restored the real stdout writer) — route to stderr there.
+    (outputJson ? Console.Error : Console.Out).WriteLine($"Classification → {outPath}");
 }
 if (outputJunitPath != null)
 {


### PR DESCRIPTION
Closes #1649

`--help` documents `--output-json` as replacing the normal text output with
per-test JSON on stdout, but progress banners (bundle/suite counts,
`[layered]` cache lines, `[bc]` selection notices, etc.) were still printed
to stdout ahead of the JSON object. A caller doing `JSON.parse(stdout)`
against the full captured stream would throw on the banner text.

Fix: once `--output-json` is set (and we're not already in `--server` mode,
which does the same thing for its own protocol), redirect `Console.Out` to
`Console.Error` right after arg parsing, so every progress line goes to
stderr instead. Just before the final JSON write, restore the real stdout
and write the JSON object — the only thing that ever reaches stdout.

## Test plan
- Strengthened `OutputFormatTests.OutputJson_MixedResults_EmitsExpectedShape`
  to parse the *entire* trimmed stdout stream as one JSON document (previously
  it skipped to the first `{`, tolerating banner noise ahead of it).
- Confirmed RED against the pre-fix code (`JsonReaderException: 'a' is an
  invalid start of a value` — the banner text).
- Confirmed GREEN after the fix; ran the full `OutputFormatTests`,
  `CliServer`, `CliDocumentationTests`, and `DefineFlagIntegrationTests`
  suites (9/9 pass) to rule out a `--server` regression.