### PR TITLE
fix(record-metadata): strip quoted-identifier InitValue on enum fields so blank-named values evaluate

### DIFF
--- a/AlRunner/Patches/RecordPatches.NclMetaTableBuilder.cs
+++ b/AlRunner/Patches/RecordPatches.NclMetaTableBuilder.cs
@@ -416,6 +416,28 @@ public static partial class RecordPatches
                 {
                     iv = iv.Substring(1, iv.Length - 2).Replace("''", "'");
                 }
+                // Enum-typed fields: a quoted-identifier InitValue (e.g. the blank
+                // value `InitValue = " ";`, or any member name needing quotes) is
+                // captured by the source parser with its quotes intact, but enum
+                // member names are captured UNQUOTED at emit time (BcCompiler reads
+                // IEnumValueSymbol.Name) and NavOptionEvaluator.InternalEvaluate
+                // matches the text exactly (GetIndexFromCaption/GetIndexFromOption,
+                // ordinal compare, no trimming) — so `" "` (three chars) could never
+                // match the member named ` ` and every Init/Insert of the table threw
+                // NavNCLInvalidOptionStringException (#1674). Real BC's compiled
+                // metadata stores the member name unquoted — Base App symbol packages
+                // carry {"Name":"InitValue","Value":" "} for exactly this shape — so
+                // stripping the outer quotes (and un-doubling AL's "" escape) is
+                // observably equivalent to real BC. Symbol-loaded fields already
+                // arrive unquoted and pass through unchanged; classic Option fields
+                // are untouched (their OptionMembers are captured with the same
+                // quoting as their InitValue, so the pair stays internally
+                // consistent).
+                else if (tn.StartsWith("Enum", StringComparison.OrdinalIgnoreCase)
+                    && iv.Length >= 2 && iv.StartsWith("\"") && iv.EndsWith("\""))
+                {
+                    iv = iv.Substring(1, iv.Length - 2).Replace("\"\"", "\"");
+                }
                 args[i] = iv;
                 continue;
             }

--- a/tests/runner-extras/blank-enum-initvalue/BeiAssert.Codeunit.al
+++ b/tests/runner-extras/blank-enum-initvalue/BeiAssert.Codeunit.al
@@ -1,0 +1,23 @@
+/// <summary>
+/// Minimal assertion helper for this runner-extras app (own ID range).
+/// </summary>
+codeunit 64205 "BEI Assert"
+{
+    procedure AreEqual(Expected: Integer; Actual: Integer; Msg: Text)
+    begin
+        if Expected <> Actual then
+            Error('Assert.AreEqual failed. Expected:<%1>. Actual:<%2>. %3', Expected, Actual, Msg);
+    end;
+
+    procedure IsTrue(Condition: Boolean; Msg: Text)
+    begin
+        if not Condition then
+            Error('Assert.IsTrue failed. %1', Msg);
+    end;
+
+    procedure ExpectedError(Expected: Text; Actual: Text)
+    begin
+        if StrPos(Actual, Expected) = 0 then
+            Error('Assert.ExpectedError failed. Expected substring:<%1>. Actual:<%2>.', Expected, Actual);
+    end;
+}

--- a/tests/runner-extras/blank-enum-initvalue/BeiBlankLogging.Enum.al
+++ b/tests/runner-extras/blank-enum-initvalue/BeiBlankLogging.Enum.al
@@ -1,0 +1,13 @@
+// The exact shape from issue #1674: an enum whose ONLY value is blank-named.
+// The lone blank name is what made the mismatch fatal — with no other members,
+// nothing in the options list could ever match, so every InitValue evaluation
+// threw instead of falling back.
+enum 64200 "BEI Blank Logging"
+{
+    Extensible = true;
+
+    value(0; " ")
+    {
+        Caption = ' ', Locked = true;
+    }
+}

--- a/tests/runner-extras/blank-enum-initvalue/BeiInstaller.Codeunit.al
+++ b/tests/runner-extras/blank-enum-initvalue/BeiInstaller.Codeunit.al
@@ -1,0 +1,15 @@
+// Faithful to the issue #1674 repro: the failing Insert happened inside a
+// Subtype=Install trigger (MutableRecordBuffer.MarkAllFieldsAsChanged on the
+// install path), so the whole bundle EXEC-FAILed before a single test ran.
+codeunit 64204 "BEI Installer"
+{
+    Subtype = Install;
+
+    trigger OnInstallAppPerCompany()
+    var
+        BeiSetup: Record "BEI Setup";
+    begin
+        BeiSetup.Init();
+        BeiSetup.Insert(false);
+    end;
+}

--- a/tests/runner-extras/blank-enum-initvalue/BeiMixed.Table.al
+++ b/tests/runner-extras/blank-enum-initvalue/BeiMixed.Table.al
@@ -1,0 +1,40 @@
+// Locks the healthy paths that must stay green next to the #1674 fix:
+// - blank InitValue on an enum that also has named values,
+// - a NAMED InitValue on the same sparse enum (must evaluate to ordinal 5),
+// - the classic Option-field blank InitValue (worked before the fix and after).
+table 64203 "BEI Mixed"
+{
+    DataClassification = CustomerContent;
+
+    fields
+    {
+        field(1; "Primary Key"; Code[10])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(2; "Blank Init"; Enum "BEI Mixed Level")
+        {
+            DataClassification = CustomerContent;
+            InitValue = " ";
+        }
+        field(3; "Named Init"; Enum "BEI Mixed Level")
+        {
+            DataClassification = CustomerContent;
+            InitValue = Verbose;
+        }
+        field(4; "Option Blank"; Option)
+        {
+            DataClassification = CustomerContent;
+            OptionMembers = " ",Alpha;
+            InitValue = " ";
+        }
+    }
+
+    keys
+    {
+        key(PK; "Primary Key")
+        {
+            Clustered = true;
+        }
+    }
+}

--- a/tests/runner-extras/blank-enum-initvalue/BeiMixedLevel.Enum.al
+++ b/tests/runner-extras/blank-enum-initvalue/BeiMixedLevel.Enum.al
@@ -1,0 +1,17 @@
+// Blank first value plus a SPARSE named value. The named ordinal (5, not 1)
+// proves InitValue evaluation resolves through the enum's true ordinal values,
+// not a 0..Count-1 array index, and that a named InitValue on the same enum
+// stays healthy next to the blank one.
+enum 64201 "BEI Mixed Level"
+{
+    Extensible = true;
+
+    value(0; " ")
+    {
+        Caption = ' ', Locked = true;
+    }
+    value(5; Verbose)
+    {
+        Caption = 'Verbose';
+    }
+}

--- a/tests/runner-extras/blank-enum-initvalue/BeiSetup.Table.al
+++ b/tests/runner-extras/blank-enum-initvalue/BeiSetup.Table.al
@@ -1,0 +1,28 @@
+// Mirror of the issue #1674 repro table: enum-typed field with a quoted blank
+// InitValue. Before the fix, ANY Init/Insert of this table threw
+// NavNCLInvalidOptionStringException from NCLMetaField.get_InitValue.
+table 64202 "BEI Setup"
+{
+    DataClassification = CustomerContent;
+
+    fields
+    {
+        field(1; "Primary Key"; Code[10])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(2; "Logging Type"; Enum "BEI Blank Logging")
+        {
+            DataClassification = CustomerContent;
+            InitValue = " ";
+        }
+    }
+
+    keys
+    {
+        key(PK; "Primary Key")
+        {
+            Clustered = true;
+        }
+    }
+}

--- a/tests/runner-extras/blank-enum-initvalue/BeiTests.Codeunit.al
+++ b/tests/runner-extras/blank-enum-initvalue/BeiTests.Codeunit.al
@@ -1,0 +1,89 @@
+// Issue #1674: enum value named " " with InitValue = " " — before the fix,
+// every Insert of such a table threw NavNCLInvalidOptionStringException
+// ('" "' is not an option. The existing options are:) from
+// NCLMetaField.get_InitValue via MarkAllFieldsAsChanged, killing the bundle
+// at the install trigger. These tests only being REACHED already proves the
+// install-path Insert (BEI Installer) survived; the assertions then pin the
+// concrete evaluated values so a silent default-0 fallback cannot pass the
+// named-ordinal check.
+codeunit 64206 "BEI Blank Enum Init Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit "BEI Assert";
+
+    [Test]
+    procedure InstallInsertSucceededAndBlankEnumReadsBackAsOrdinalZero()
+    var
+        BeiSetup: Record "BEI Setup";
+    begin
+        // [THEN] The row the install trigger inserted (blank PK, exactly as in
+        // the #1674 repro) exists — on main this codeunit never ran at all.
+        Assert.IsTrue(BeiSetup.Get(''), 'the install-trigger-inserted row must exist');
+        Assert.AreEqual(0, BeiSetup."Logging Type".AsInteger(),
+            'InitValue = " " must initialize the enum field to the blank ordinal-0 value');
+        Assert.IsTrue(BeiSetup."Logging Type" = BeiSetup."Logging Type"::" ",
+            'the field must equal the blank-named enum value');
+    end;
+
+    [Test]
+    procedure InTestInsertInitializesBlankEnumToOrdinalZero()
+    var
+        BeiSetup: Record "BEI Setup";
+    begin
+        // [WHEN] The same Init+Insert path runs inside a test.
+        BeiSetup.Init();
+        BeiSetup."Primary Key" := 'T1';
+        BeiSetup.Insert(false);
+
+        // [THEN] The row round-trips with the blank ordinal-0 value.
+        BeiSetup.Get('T1');
+        Assert.AreEqual(0, BeiSetup."Logging Type".AsInteger(),
+            'inserted row must read back the blank ordinal-0 enum value');
+    end;
+
+    [Test]
+    procedure NamedInitValueOnSparseEnumEvaluatesToTrueOrdinal()
+    var
+        BeiMixed: Record "BEI Mixed";
+    begin
+        // [WHEN] Init applies InitValue to every field.
+        BeiMixed.Init();
+
+        // [THEN] Blank InitValue -> 0; NAMED InitValue -> the enum's true sparse
+        // ordinal 5 (a silent default-0 fallback fails here); Option-field blank
+        // InitValue (the pre-fix healthy path) -> 0.
+        Assert.AreEqual(0, BeiMixed."Blank Init".AsInteger(),
+            'blank InitValue on a mixed enum must initialize to ordinal 0');
+        Assert.AreEqual(5, BeiMixed."Named Init".AsInteger(),
+            'InitValue = Verbose must evaluate to the sparse ordinal 5, not a default');
+        Assert.AreEqual(0, BeiMixed."Option Blank",
+            'blank InitValue on a classic Option field must stay at ordinal 0');
+
+        // [THEN] The values survive Insert + Get.
+        BeiMixed."Primary Key" := 'M1';
+        BeiMixed.Insert(false);
+        BeiMixed.Get('M1');
+        Assert.AreEqual(5, BeiMixed."Named Init".AsInteger(),
+            'the named-InitValue ordinal must round-trip through Insert');
+    end;
+
+    [Test]
+    procedure EvaluateMatchesBlankMemberAndRejectsNonMember()
+    var
+        BeiSetup: Record "BEI Setup";
+    begin
+        // [THEN] The blank member name matches through the SAME evaluator path
+        // (NavOptionEvaluator -> GetIndexFromCaption/GetIndexFromOption) that
+        // InitValue uses...
+        Evaluate(BeiSetup."Logging Type", ' ');
+        Assert.AreEqual(0, BeiSetup."Logging Type".AsInteger(),
+            'Evaluate('' '') must resolve to the blank ordinal-0 member');
+
+        // [THEN] ...and a non-member is still rejected loudly, proving the
+        // matcher is a real matcher and not an always-succeed default.
+        asserterror Evaluate(BeiSetup."Logging Type", 'Bogus');
+        Assert.ExpectedError('is not an option', GetLastErrorText());
+    end;
+}

--- a/tests/runner-extras/blank-enum-initvalue/app.json
+++ b/tests/runner-extras/blank-enum-initvalue/app.json
@@ -1,0 +1,25 @@
+{
+  "id": "7c2e9f41-8b5a-4d3c-9e6f-1a4b8d2c5e93",
+  "name": "Runner Extras - Blank Enum InitValue",
+  "publisher": "AL Runner",
+  "version": "1.0.0.0",
+  "brief": "Proves a table field typed on an enum with a blank-named value (value(0; \" \")) and InitValue = \" \" initializes to ordinal 0 on Init/Insert instead of throwing NavNCLInvalidOptionStringException.",
+  "description": "Issue #1674: the AL source parser captured InitValue = \" \" as the raw quoted text '\" \"' (three characters), but enum option names are captured unquoted at emit time, so NCLMetaField.get_InitValue -> NavOptionEvaluator could never match and every Insert of the table died with NavNCLInvalidOptionStringException at the install trigger. RED before the fix: the whole bundle EXEC-FAILs at OnInstallAppPerCompany. GREEN after: the install insert succeeds, the field reads back as the blank ordinal-0 value, a named InitValue on a sparse enum still evaluates to its true ordinal, and the classic Option-field blank InitValue path keeps working.",
+  "privacyStatement": "",
+  "EULA": "",
+  "help": "",
+  "url": "",
+  "logo": "",
+  "dependencies": [],
+  "screenshots": [],
+  "platform": "1.0.0.0",
+  "application": "27.0.0.0",
+  "idRanges": [
+    {
+      "from": 64200,
+      "to": 64219
+    }
+  ],
+  "runtime": "14.0",
+  "features": []
+}


### PR DESCRIPTION
## Problem

A table field typed on an enum whose value list includes a blank-named value (`value(0; " ")`), with `InitValue = " "`, killed every `Insert`/`Init` of the table with `NavNCLInvalidOptionStringException: '" "' is not an option. The existing options are:` (empty), thrown from `NCLMetaField.get_InitValue()` → `NavOptionEvaluator.InternalEvaluate` inside `MarkAllFieldsAsChanged`. Real BC accepts this pattern — the blank first value is the standard "no selection" idiom.

## Root cause

Two capture paths disagree on quoting. The source parser (`RxInitValue`) captures the raw AL expression, so a quoted identifier keeps its quotes — `" "` is stored as three characters. Enum member names, however, are captured **unquoted** at emit time (`BcCompiler` reads `IEnumValueSymbol.Name`). Verified against the decompiled Ncl runtime: `NavOptionEvaluator.InternalEvaluate` matches via `GetIndexFromCaption`/`GetIndexFromOption` with exact ordinal comparison and no trimming — so the quoted text can never match the bare member name, and the lone-blank enum leaves nothing else to match.

This also explains the measured asymmetry in the issue: classic Option fields worked because `RxOptionMembers` keeps quotes too (both sides symmetric), and unquoted enum InitValues (`InitValue = HTML`) never had the problem.

## Fix

In `BuildMetaField` — the single choke point both source-parsed and symbol-loaded fields flow through — strip the outer double quotes (and un-double AL's `""` escape) from a quoted-identifier InitValue on enum-typed fields, mirroring the existing single-quote strip for Text/Code literals. Observably equivalent to real BC: compiled metadata stores the member name unquoted (Base App symbol packages carry `{"Name":"InitValue","Value":" "}` for exactly this shape). Symbol-loaded fields already arrive unquoted (no-op); classic Option fields are untouched.

## Proving test

`tests/runner-extras/blank-enum-initvalue/` — RED on main (`EXEC-FAIL: '" "' is not an option` at the install trigger, exactly the issue repro), GREEN after. Four tests: install-trigger insert + ordinal-0 read-back, in-test Insert round-trip, a sparse named `InitValue = Verbose` that must evaluate to true ordinal 5 (a silent default-0 fallback fails it), the pre-existing Option-blank healthy path, and positive/negative `Evaluate` through the same matcher.

## Verification

- New suite 4P/0F/0E on Linux and Windows, cold caches
- `AlRunner.Tests` 219/219 (Linux)
- al-language corpus: failure set identical to main (17 pre-existing, names diffed)
- runner-extras in full: 91/91 (Linux)
- Issue reproducer: `1P/0F/0E`, exit 0, cold caches (acceptance criteria met)

Closes #1674

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DsUxnhjgvEStfjMant69E9
