### PR TITLE
fix: correct filter-only query-column slot aliasing in multi-dataitem joins

### DIFF
--- a/AlRunner.QueryJoin/JoinExecutor.cs
+++ b/AlRunner.QueryJoin/JoinExecutor.cs
@@ -40,6 +40,7 @@ public static class JoinExecutor
     private static PropertyInfo? _pLinkSourceDataItemName;
     private static PropertyInfo? _pColSourceTableField;
     private static PropertyInfo? _pColColumnIndex;
+    private static PropertyInfo? _pColColumnType;
     private static PropertyInfo? _pColParentDataItem;
     private static PropertyInfo? _pFieldColumnIndex;
     private static PropertyInfo? _pFieldFieldClass;
@@ -74,6 +75,13 @@ public static class JoinExecutor
         _pLinkSourceDataItemName = tLink.GetProperty("SourceDataItemName", F)!;
         _pColSourceTableField = tCol.GetProperty("SourceTableField", F)!;
         _pColColumnIndex = tCol.GetProperty("ColumnIndex", F)!;
+        // NCLMetaQueryColumn.ColumnType (QueryColumnType enum: Normal/FilterOnly/ConstValue) —
+        // NOT the design-time MetaQueryColumn.ColumnType (a NavType). ColumnIndex alone cannot
+        // tell a filter-only column from a genuinely-projected column at slot 0: the runtime
+        // ctor only assigns ColumnIndex when ColumnType != FilterOnly, so a filter-only column's
+        // ColumnIndex is left at its CLR default (0) — indistinguishable from a real slot-0
+        // column by value alone. See BuildJoinProjectionPlan below.
+        _pColColumnType = tCol.GetProperty("ColumnType", F);
         _pColParentDataItem = tCol.GetProperty("ParentDataItem", F)!;
         _pFieldColumnIndex = tField.GetProperty("ColumnIndex", F)!;
         _pFieldFieldClass = tField.GetProperty("FieldClass", F);
@@ -356,34 +364,75 @@ public static class JoinExecutor
         public List<JoinColumn> Columns = new();
     }
 
+    /// <summary>True when the runtime NCLMetaQueryColumn was created FilterOnly (a
+    /// `filter(...)` element with no result `column(...)`) — ColumnIndex alone cannot tell
+    /// this apart from a genuinely-projected slot-0 column (see the ColumnType reflection
+    /// comment in EnsureReflection); QUERY-COLUMN.ColumnType is the only reliable signal.
+    /// Falls back to false (treat as a normal/projected column) if the runtime type predates
+    /// this property.</summary>
+    private static bool IsFilterOnlyColumn(object col)
+        => _pColColumnType?.GetValue(col)?.ToString() == "FilterOnly";
+
     private static JoinProjectionPlan BuildJoinProjectionPlan(JoinContext ctx, object queryDef)
     {
         var plan = new JoinProjectionPlan();
         int maxSlot = -1;
         var dataItems = ((IEnumerable)_pQueryDefDataItems!.GetValue(queryDef)!).Cast<object>().ToList();
+
+        // Pass 1: genuinely-projected (non-filter-only) columns get their real ColumnIndex slot.
         foreach (var di in dataItems)
         {
             var name = (string)_pDataItemName!.GetValue(di)!;
             var cols = ((IEnumerable?)_pDataItemQueryColumns!.GetValue(di))?.Cast<object>() ?? Enumerable.Empty<object>();
             foreach (var col in cols)
             {
+                if (IsFilterOnlyColumn(col)) continue; // handled in pass 2 below.
                 int querySlot = (int)_pColColumnIndex!.GetValue(col)!;
-                if (querySlot < 0) continue; // filter-only column (no result slot)
+                if (querySlot < 0) continue; // defensive: shouldn't happen for a non-filter-only column.
                 if (querySlot > maxSlot) maxSlot = querySlot;
-                int tableSlot = -1;
-                object? srcField = null;
-                try
-                {
-                    srcField = _pColSourceTableField!.GetValue(col);
-                    if (srcField != null)
-                        tableSlot = (int)_pFieldColumnIndex!.GetValue(srcField)!;
-                }
-                catch { tableSlot = -1; srcField = null; }
-                plan.Columns.Add(new JoinColumn { QuerySlot = querySlot, OwnerName = name, TableSlot = tableSlot, SourceField = srcField });
+                plan.Columns.Add(new JoinColumn { QuerySlot = querySlot, OwnerName = name, TableSlot = ResolveTableSlot(col, out var srcField), SourceField = srcField });
             }
         }
-        plan.SlotCount = maxSlot + 1;
+
+        // Pass 2: filter-only columns (referenced only via `filter(...)`, never `column(...)`,
+        // and — Query 777's own shape — join-key fields with no declared column at all) get NO
+        // real ColumnIndex slot from BC, so mint dedicated EXTRA slots past every projected
+        // column, in the SAME deterministic (dataitem, then declaration) order that
+        // RecordPatches.QueryProjection.ApplyJoinRuntimeFilters recomputes independently (the two
+        // live in separate assemblies and cannot share a single source of truth for this map —
+        // see the comment there). This is what lets a runtime SetRange/SetFilter on a
+        // non-projected column (e.g. Query 777's "User Security ID") be evaluated post-join
+        // instead of either aliasing onto an unrelated real column's slot (the original bug —
+        // NavNCLInvalidComparisonException comparing the filter's NavGuid against whatever
+        // happened to land in slot 0) or being silently dropped.
+        int nextExtraSlot = maxSlot + 1;
+        foreach (var di in dataItems)
+        {
+            var name = (string)_pDataItemName!.GetValue(di)!;
+            var cols = ((IEnumerable?)_pDataItemQueryColumns!.GetValue(di))?.Cast<object>() ?? Enumerable.Empty<object>();
+            foreach (var col in cols)
+            {
+                if (!IsFilterOnlyColumn(col)) continue;
+                plan.Columns.Add(new JoinColumn { QuerySlot = nextExtraSlot++, OwnerName = name, TableSlot = ResolveTableSlot(col, out var srcField), SourceField = srcField });
+            }
+        }
+
+        plan.SlotCount = Math.Max(maxSlot + 1, nextExtraSlot);
         return plan;
+    }
+
+    private static int ResolveTableSlot(object col, out object? srcField)
+    {
+        int tableSlot = -1;
+        srcField = null;
+        try
+        {
+            srcField = _pColSourceTableField!.GetValue(col);
+            if (srcField != null)
+                tableSlot = (int)_pFieldColumnIndex!.GetValue(srcField)!;
+        }
+        catch { tableSlot = -1; srcField = null; }
+        return tableSlot;
     }
 
     // Apply the query's OrderBy (top-level result ordering) over the projected result rows.

--- a/AlRunner/Patches/RecordPatches.QueryProjection.cs
+++ b/AlRunner/Patches/RecordPatches.QueryProjection.cs
@@ -266,6 +266,16 @@ public static partial class RecordPatches
     private static Type? _tNavFieldMetadata;
     private static bool _filterReflectionReady;
 
+    // For the extended-slot recomputation in ApplyJoinRuntimeFilters — mirrors
+    // AlRunner.QueryJoin.JoinExecutor's own DataItems/QueryColumns/ColumnType reflection
+    // (a SEPARATE, isolated assembly that cannot share these PropertyInfo handles).
+    private static Type? _tNCLMetaQueryDefinition;
+    private static Type? _tNCLMetaQueryDataItem;
+    private static PropertyInfo? _pQueryDefDataItemsQ;
+    private static PropertyInfo? _pDataItemQueryColumnsQ;
+    private static PropertyInfo? _pColColumnTypeQ;
+    private static PropertyInfo? _pColColumnIndexQ2;
+
     private static void EnsureFilterReflection()
     {
         if (_filterReflectionReady) return;
@@ -278,8 +288,67 @@ public static partial class RecordPatches
         _tFilterExpr = asm.GetType(rt + "FilterExpression");
         _tNavFieldMetadata = asm.GetType(rt + "INavFieldMetadata");
         _tNCLMetaQueryColumn = asm.GetType(rt + "NCLMetaQueryColumn");
+        _tNCLMetaQueryDefinition = asm.GetType(rt + "NCLMetaQueryDefinition");
+        _tNCLMetaQueryDataItem = asm.GetType(rt + "NCLMetaQueryDataItem");
+        const BindingFlags anyInstance = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance;
+        _pQueryDefDataItemsQ = _tNCLMetaQueryDefinition?.GetProperty("DataItems", anyInstance);
+        _pDataItemQueryColumnsQ = _tNCLMetaQueryDataItem?.GetProperty("QueryColumns", anyInstance);
+        _pColColumnTypeQ = _tNCLMetaQueryColumn?.GetProperty("ColumnType", anyInstance);
         _filterReflectionReady = true;
     }
+
+    /// <summary>
+    /// Recompute, for every QueryColumn across every DataItem of <paramref name="queryDef"/>, the
+    /// slot it occupies in the join-projected row buffer AlRunner.QueryJoin.JoinExecutor
+    /// produces — by reference identity, since neither assembly can hand the other a
+    /// PropertyInfo/slot map directly (JoinExecutor is loaded in an isolated ALC specifically so
+    /// its assembly never leaks an Ncl type into al-runner's own startup surface).
+    ///
+    /// MUST mirror JoinExecutor.BuildJoinProjectionPlan's two-pass algorithm EXACTLY (same
+    /// dataitem enumeration order, same "normal columns first at their real ColumnIndex, then
+    /// filter-only columns at sequential extra slots past the projected max" rule) — that
+    /// algorithm is duplicated rather than shared for the isolation reason above, and duplicated
+    /// logic that drifts is exactly the failure mode SCOPE-AUDIT-style comments warn about, so
+    /// change both together.
+    /// </summary>
+    private static Dictionary<object, int> ComputeJoinColumnSlotMap(object queryDef)
+    {
+        var map = new Dictionary<object, int>();
+        if (_pQueryDefDataItemsQ == null || _pDataItemQueryColumnsQ == null) return map;
+        var dataItems = ((System.Collections.IEnumerable)_pQueryDefDataItemsQ.GetValue(queryDef)!).Cast<object>().ToList();
+
+        int maxSlot = -1;
+        foreach (var di in dataItems)
+        {
+            var cols = (_pDataItemQueryColumnsQ.GetValue(di) as System.Collections.IEnumerable)?.Cast<object>()
+                ?? Enumerable.Empty<object>();
+            foreach (var col in cols)
+            {
+                if (IsFilterOnlyColumnQ(col)) continue;
+                _pColColumnIndexQ2 ??= _tNCLMetaQueryColumn!.GetProperty("ColumnIndex", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)!;
+                var idx = (int)_pColColumnIndexQ2.GetValue(col)!;
+                if (idx < 0) continue;
+                map[col] = idx;
+                if (idx > maxSlot) maxSlot = idx;
+            }
+        }
+
+        int nextExtraSlot = maxSlot + 1;
+        foreach (var di in dataItems)
+        {
+            var cols = (_pDataItemQueryColumnsQ.GetValue(di) as System.Collections.IEnumerable)?.Cast<object>()
+                ?? Enumerable.Empty<object>();
+            foreach (var col in cols)
+            {
+                if (!IsFilterOnlyColumnQ(col)) continue;
+                map[col] = nextExtraSlot++;
+            }
+        }
+        return map;
+    }
+
+    private static bool IsFilterOnlyColumnQ(object col)
+        => _pColColumnTypeQ?.GetValue(col)?.ToString() == "FilterOnly";
 
     /// <summary>
     /// If <paramref name="request"/> targets a query and carries query-column-keyed
@@ -473,7 +542,7 @@ public static partial class RecordPatches
             // STATIC metadata filters, so runtime filters must be evaluated against the projected
             // rows here. Without this the join returns UNFILTERED rows (a correctness bug). Done
             // before Top so the cap applies to the filtered set, matching SQL TOP-after-WHERE.
-            joined = ApplyJoinRuntimeFilters(metaAppObj, request, joined);
+            joined = ApplyJoinRuntimeFilters(metaAppObj, queryDef, request, joined);
             var topJ = _pReqTopNumberOfRows!.GetValue(request);
             int topNJ = topJ == null ? 0 : Convert.ToInt32(topJ);
             return topNJ > 0 ? joined.Take(topNJ) : joined;
@@ -492,7 +561,6 @@ public static partial class RecordPatches
     }
 
     private static MethodInfo? _mFilterExprEvaluate;
-    private static PropertyInfo? _pColColumnIndexQ;
 
     /// <summary>
     /// Apply the live NavQuery's runtime filters (the request's FiltersAndMarks, keyed by
@@ -505,7 +573,7 @@ public static partial class RecordPatches
     /// rather than silently return wrong rows (loud-failures rule).
     /// </summary>
     private static IEnumerable<ReadOnlyRecordBuffer> ApplyJoinRuntimeFilters(
-        object nclMetaQuery, object request, IEnumerable<ReadOnlyRecordBuffer> rows)
+        object nclMetaQuery, object queryDef, object request, IEnumerable<ReadOnlyRecordBuffer> rows)
     {
         EnsureFilterReflection();
         var fam = request.GetType().GetProperty("FiltersAndMarks", BindingFlags.Public | BindingFlags.Instance)?
@@ -518,8 +586,21 @@ public static partial class RecordPatches
             .GetValue(filters);
         if (items == null || items.Length == 0) return rows; // no runtime filters → unchanged.
 
-        // Build (projectionSlot, FilterExpression) pairs. Loud-fail on any non-projected column.
-        _pColColumnIndexQ ??= _tNCLMetaQueryColumn!.GetProperty("ColumnIndex", BindingFlags.Public | BindingFlags.Instance)!;
+        // Build (projectionSlot, FilterExpression) pairs.
+        //
+        // NCLMetaQueryColumn.ColumnIndex CANNOT distinguish a filter-only column (one declared
+        // only via `filter(...)`, or a bare join-key field with no declared column at all — see
+        // Query 777's own "User Security ID") from a genuinely-projected column at slot 0: BC's
+        // own runtime ctor only assigns ColumnIndex when the column isn't FilterOnly, so a
+        // filter-only column's ColumnIndex is left at the CLR default (0) — the same value a
+        // real slot-0 column has. Reading it naively made every runtime filter on a filter-only
+        // column alias onto whatever real column happened to land in slot 0, so a Guid-typed
+        // filter (Query 777's "User Security ID") got compared against an unrelated Integer
+        // column's value and threw NavNCLInvalidComparisonException instead of ever being
+        // evaluated as a filter. ComputeJoinColumnSlotMap gives filter-only columns their OWN
+        // dedicated extra slots (mirroring the ones JoinExecutor.BuildJoinProjectionPlan already
+        // populates them into), so this now evaluates against the real filtered value.
+        var slotMap = ComputeJoinColumnSlotMap(queryDef);
         var conds = new List<(int slot, object expr)>();
         foreach (var item in items)
         {
@@ -533,12 +614,14 @@ public static partial class RecordPatches
                     "NavQuery (multi-dataitem join)",
                     "query-join-runtime-filter-on-nonprojected-column — a runtime filter is keyed by a " +
                     $"non-query-column ({key?.GetType().Name ?? "null"}); cannot evaluate post-projection; see docs/scope.md");
-            int slot = (int)_pColColumnIndexQ.GetValue(key)!;
-            if (slot < 0)
+            if (!slotMap.TryGetValue(key, out var slot))
+                // The filtered column isn't in ANY dataitem's QueryColumns of this query
+                // definition — should not occur (the filter dictionary is keyed by columns that
+                // came from this same query), but refuse to guess rather than silently drop it.
                 throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
                     "NavQuery (multi-dataitem join)",
-                    "query-join-runtime-filter-on-nonprojected-column — a runtime filter targets a query " +
-                    "column with no result slot (filter-only column); cannot evaluate post-projection; see docs/scope.md");
+                    "query-join-runtime-filter-unresolved-column — a runtime filter's column could not be " +
+                    "located in the query's own DataItems/QueryColumns; see docs/scope.md");
             conds.Add((slot, expr));
         }
         if (conds.Count == 0) return rows;

--- a/tests/runner-extras/microsoft-dependencies/MicrosoftDependencyTests.Codeunit.al
+++ b/tests/runner-extras/microsoft-dependencies/MicrosoftDependencyTests.Codeunit.al
@@ -259,4 +259,125 @@ codeunit 61001 "Microsoft Dependency Tests"
         Assert.Contains(GetLastErrorText(), '99999999',
             'A report id no loaded dependency declares must raise a real error naming the id, not return an empty schema.');
     end;
+
+    // ── Precompiled BaseApp query execution (NavQuery.FindDataImplAsync) ─────
+    //
+    // Codeunit 9170 "Conf./Personalization Mgt." (Base Application) resolves the current
+    // user's default profile by opening Query 777 "Role Center from Plans" (System
+    // Application) filtered by user security ID, joining table "User Plan" to table "Plan".
+    // "User Security ID" is a `filter(...)` on the query — referenced only via SetRange, never
+    // projected as a result `column(...)` — which is Query 777's own shape and exactly the
+    // case that broke: NCLMetaQueryColumn.ColumnIndex is only assigned by BC's own runtime
+    // factory for non-filter-only columns, so a filter-only column's ColumnIndex is left at
+    // its CLR default (0) — indistinguishable, by value, from a genuinely-projected column at
+    // real slot 0. AlRunner.QueryJoin.JoinExecutor's multi-dataitem join projector and
+    // RecordPatches.QueryProjection.ApplyJoinRuntimeFilters both read that ColumnIndex naively,
+    // so a runtime SetRange on "User Security ID" (Guid) got aliased onto whatever real column
+    // happened to land in slot 0 (Query 777's "Role Center ID", an Integer) — comparing a Guid
+    // filter value against an Integer row value, which threw NavNCLInvalidComparisonException
+    // ("Unable to compare operands of type NavInteger with NavGuid") instead of ever being
+    // evaluated as the filter it actually was.
+    //
+    // Both tests below drive Query 777 directly (bypassing Codeunit 9170's business logic)
+    // so the assertion is squarely about the query engine itself: does the real InnerJoin
+    // between "User Plan" and "Plan" execute against the in-memory provider for real Guid
+    // filter values, or does it throw resolving the precompiled query's metadata.
+    //
+    // RED (before fix): the positive test (seeded matching row) throws
+    // NavNCLInvalidComparisonException the moment the aliased Guid-vs-Integer comparison runs.
+    // The negative test (no seeded rows at all) happens not to reproduce the bug on its own —
+    // an empty in-memory join never enumerates a row to compare against — so it is kept here
+    // as the literal "faithful expected behavior" acceptance criterion from the reported issue,
+    // not as independent proof of the fix.
+    // GREEN (after fix): both tests pass — filter-only columns get their own dedicated
+    // projection slot (see JoinExecutor.BuildJoinProjectionPlan /
+    // QueryProjection.ComputeJoinColumnSlotMap), so the Guid filter is evaluated against the
+    // real filtered value instead of an unrelated column.
+    [Test]
+    procedure Query777_RoleCenterFromPlans_NoMatchingPlan_ReturnsNoRows()
+    var
+        RoleCenterFromPlans: Query "Role Center from Plans";
+    begin
+        // [GIVEN] No AAD-plan mapping exists for this (freshly generated, guaranteed unused)
+        // user security ID.
+        RoleCenterFromPlans.SetRange(User_Security_ID, CreateGuid());
+        RoleCenterFromPlans.Open();
+
+        // [WHEN] / [THEN] Reading the query must faithfully report "no rows" — never a
+        // NullReferenceException while resolving the precompiled query's metadata.
+        Assert.IsTrue(not RoleCenterFromPlans.Read(),
+            'Query 777 ("Role Center from Plans") must return zero rows when no AAD plan links this user to a Plan, not throw a NullReferenceException in NavQuery.FindDataImplAsync.');
+        RoleCenterFromPlans.Close();
+    end;
+
+    // Positive companion, same fix (the filter-only-column projection-slot aliasing bug
+    // described above) — this is the case that actually reproduces it: a real Guid filter
+    // value compared against a real joined row. "Plan" and "User Plan" are `Access = Internal`
+    // on System Application, so this third-party test app cannot reference them via
+    // `RecordRef.Open(Database::Plan)` (AL0161 — the enum literal itself needs table access) —
+    // but a plain `Record Plan` / `Record "User Plan"` local variable declaration, and
+    // Init/field-assign/Insert on it, compiles and runs fine (AL only restricts the handful of
+    // surfaces that name the table by symbol at the point of use; a local variable of that
+    // type is not one of them). That is enough to seed real joined data and prove the fix past
+    // the empty-table case above.
+    [Test]
+    procedure Query777_RoleCenterFromPlans_MatchingPlan_ReturnsJoinedRoleCenterID()
+    var
+        Plan: Record Plan;
+        UserPlan: Record "User Plan";
+        RoleCenterFromPlans: Query "Role Center from Plans";
+        TestUserSecurityID: Guid;
+    begin
+        // [GIVEN] A Plan mapped to Role Center 9022, and this user linked to it via an AAD
+        // plan assignment — the exact join "User Plan" -> "Plan" Query 777 performs.
+        TestUserSecurityID := CreateGuid();
+
+        Plan.Init();
+        Plan."Plan ID" := CreateGuid();
+        Plan.Name := 'AL Runner Test Plan';
+        Plan."Role Center ID" := 9022;
+        Plan.Insert();
+
+        UserPlan.Init();
+        UserPlan."User Security ID" := TestUserSecurityID;
+        UserPlan."Plan ID" := Plan."Plan ID";
+        UserPlan."User Name" := 'alrunner';
+        UserPlan.Insert();
+
+        // [WHEN] Query 777 is opened filtered to this user and read.
+        RoleCenterFromPlans.SetRange(User_Security_ID, TestUserSecurityID);
+        RoleCenterFromPlans.Open();
+
+        // [THEN] The real InnerJoin executes against the in-memory tables and projects the
+        // linked Plan's Role Center ID — proving NavQuery.FindDataImplAsync runs the
+        // precompiled query's actual business logic end to end, not a stub.
+        Assert.IsTrue(RoleCenterFromPlans.Read(),
+            'Query 777 must return the joined row for a user with a matching AAD-plan-to-Plan link.');
+        Assert.AreEqual(9022, RoleCenterFromPlans.Role_Center_ID,
+            'Query 777''s Role_Center_ID column must reflect the joined Plan''s "Role Center ID" (9022), proving the InnerJoin ran for real.');
+        RoleCenterFromPlans.Close();
+    end;
+
+    // Integration-level companion, matching the exact frame the reported stack trace names
+    // (Codeunit9170.GetCurrentProfileNoError -> TryGetDefaultProfileForCurrentUser ->
+    // GetDefaultProfileID -> Query 777). This is a *_NoThrow-shaped claim only: per real BC's
+    // [TryFunction] codegen, GetCurrentProfileNoError's Boolean return reports "completed
+    // without an unhandled AL error", not "a profile was found" — decompiling Codeunit9170
+    // confirms the Boolean is threaded straight from the try-wrapper's success flag, and with
+    // no AAD-plan/profile data configured it legitimately returns true while leaving
+    // AllProfile unpopulated. The row-level proof that the query itself runs (rather than
+    // throwing on a real Guid filter) is the two Query777_* tests above.
+    [Test]
+    procedure BaseAppCodeunit_ConfPersonalizationMgt_GetCurrentProfileNoError_NoThrow()
+    var
+        ConfPersonalizationMgt: Codeunit "Conf./Personalization Mgt.";
+        AllProfile: Record "All Profile";
+    begin
+        // RED (before fix): NullReferenceException in NavQuery.FindDataImplAsync while
+        // Codeunit9170.GetDefaultProfileID opens the precompiled Query 777.
+        // GREEN (after fix): completes normally.
+        ConfPersonalizationMgt.GetCurrentProfileNoError(AllProfile);
+        Assert.IsTrue(true,
+            'GetCurrentProfileNoError must not throw a NullReferenceException while resolving the default profile via the precompiled Query 777.');
+    end;
 }


### PR DESCRIPTION
Closes #1622

## Root cause

Query 777 ("Role Center from Plans", System Application) filters on `"User Security ID"` (a `Guid`) as a `filter(...)`-only column — it is never projected as a result `column(...)`. BC's own `NCLMetaQueryColumn` runtime constructor only assigns `ColumnIndex` to non-filter-only columns, so a filter-only column's `ColumnIndex` is left at its CLR default (`0`) — indistinguishable, by value, from a genuinely-projected column at real slot 0.

Both `AlRunner.QueryJoin.JoinExecutor`'s multi-dataitem join projector and `RecordPatches.QueryProjection.ApplyJoinRuntimeFilters` read `ColumnIndex` naively, so a runtime `SetRange` on the Guid filter got aliased onto whatever real column happened to land in slot 0 (Query 777's Integer `"Role Center ID"`). Comparing the Guid filter value against that Integer column threw `NavNCLInvalidComparisonException` ("Unable to compare operands of type NavInteger with NavGuid") instead of ever evaluating the filter — the mechanism behind the reported crash in `NavQuery.FindDataImplAsync` (Codeunit9170.GetDefaultProfileID → Query 777).

Root-caused by decompiling the precompiled `Microsoft.Dynamics.Nav.Ncl.dll` (`NCLMetaQueryColumn.CreateFromDesignMetadata`, `NCLMetaQuery.ParseMetadata`) rather than guessing.

## Fix

Detect filter-only columns via `NCLMetaQueryColumn.ColumnType` and give them dedicated extra projection slots, past every genuinely-projected column. This is implemented independently (and documented as such) in both `AlRunner.QueryJoin/JoinExecutor.cs` (an isolated ALC assembly) and `AlRunner/Patches/RecordPatches.QueryProjection.cs` (the main assembly), since the two cannot share reflection state across the isolation boundary.

## Tests

`tests/runner-extras/microsoft-dependencies/MicrosoftDependencyTests.Codeunit.al`:
- `Query777_RoleCenterFromPlans_NoMatchingPlan_ReturnsNoRows` — the issue's literal "faithful expected behavior" acceptance criterion (empty tables → zero rows, no crash).
- `Query777_RoleCenterFromPlans_MatchingPlan_ReturnsJoinedRoleCenterID` — the test that actually reproduces the bug (RED before the fix, seeded matching row across the real InnerJoin, GREEN after).
- `BaseAppCodeunit_ConfPersonalizationMgt_GetCurrentProfileNoError_NoThrow` — integration-level companion matching the exact reported stack trace frame.

## Verification

- RED confirmed via decompiled-DLL analysis and a temporary revert.
- GREEN: new AL tests pass; full `tests/al-language` corpus (1904/1904) still green; `runner-extras/query-join` and the rest of `runner-extras` (76 tests) still green.
- An earlier attempted fix in `RecordPatches.NclMetaQueryBuilder.cs` (setting a design-model `ColumnType`) turned out to be a no-op once the real bug was found (BC's own factory ignores that property) — removed rather than shipped as dead/misleading code.

`docs/coverage.yaml` is a v1-only mechanism, archived under `docs/archive/` and superseded by the corpus/expectations model in v2 — no update needed there.

Claude-Session: https://claude.ai/code/session_01MQHZTkoumsmZz1J7KDJShy