### PR TITLE
feat(win32stubs): ship a prebuilt libwin32_stubs.so so Linux needs no C compiler

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -182,12 +182,22 @@ jobs:
         with:
           dotnet-version: '8.0.x'
 
+      - name: Install the aarch64 cross-compiler (#1672)
+        run: |
+          # This runner is linux-x64; AlRunner.csproj's BuildWin32PrebuiltStubs target
+          # uses the native `cc` for linux-x64 (always present) and this cross
+          # toolchain for linux-arm64, so a single x64 job ships prebuilt Win32
+          # stubs for both RIDs without needing an arm64 runner.
+          sudo apt-get update && sudo apt-get install -y gcc-aarch64-linux-gnu
+
       - name: Build and pack
         run: |
           # Packing also needs the BC service tier present (RAR resolves against it),
           # so the same download switch applies here. This job builds once at the
           # csproj's default _BCVersion, which is the version the package is stamped
-          # with (AssemblyMetadata BcEngineVersion).
+          # with (AssemblyMetadata BcEngineVersion). It also runs
+          # BuildWin32PrebuiltStubs (see AlRunner.csproj) which ships the prebuilt
+          # libwin32_stubs.linux-{x64,arm64}.so shims in the resulting nupkg.
           dotnet build AlRunner/ -p:AllowBcArtifactDownload=true
           dotnet pack AlRunner/ -p:AllowBcArtifactDownload=true -p:Version=${{ inputs.version }} -o ./nupkg
 

--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,7 @@ tests/.claude/
 # permanently red on Linux). See project_dotnet_sspw_resolution_hard memory.
 tests/runner-extras/dotnet-interop/
 .serena/
+
+# #1672: prebuilt Win32 stub shims are build artifacts, produced fresh per-arch by
+# AlRunner.csproj's BuildWin32PrebuiltStubs target — never committed as binaries.
+AlRunner/Win32Stubs/*.so

--- a/AlRunner.Tests/Win32StubsLoudFailureTests.cs
+++ b/AlRunner.Tests/Win32StubsLoudFailureTests.cs
@@ -146,4 +146,140 @@ public class Win32StubsLoudFailureTests
             Win32Stubs.ResetForTests();
         }
     }
+
+    // ---------------------------------------------------------------------------------
+    // #1672: shipped prebuilt libwin32_stubs.so — no C compiler required on Linux.
+    // ---------------------------------------------------------------------------------
+
+    /// <summary>
+    /// Pure lookup: the current RID's filename must be present when a fixture file with
+    /// that exact name exists. Would a stub that always returns null (or always returns
+    /// some hardcoded path regardless of the `exists` probe) pass this? No — this asserts
+    /// the exact composed path, keyed off <see cref="Win32Stubs.PrebuiltStubFileName"/>,
+    /// which is itself keyed off the live <c>RuntimeInformation.ProcessArchitecture</c> so
+    /// the test can't fake a mismatched RID past it.
+    /// </summary>
+    [Fact]
+    public void LocatePrebuiltSo_ReturnsComposedPath_WhenFileExists()
+    {
+        var name = Win32Stubs.PrebuiltStubFileName();
+        if (name is null) return; // unsupported RID (e.g. not Linux, or non-x64/arm64) — nothing to assert
+        var expected = Path.Combine("/fake/base", "Win32Stubs", name);
+
+        var found = Win32Stubs.LocatePrebuiltSo("/fake/base", path => path == expected);
+
+        Assert.Equal(expected, found);
+    }
+
+    /// <summary>
+    /// Negative: when the file genuinely isn't there, LocatePrebuiltSo must return null
+    /// (not throw, not fall back to some default) — GetOrBuild relies on that null to know
+    /// it should proceed to the compile-from-source path.
+    /// </summary>
+    [Fact]
+    public void LocatePrebuiltSo_ReturnsNull_WhenFileMissing()
+    {
+        var found = Win32Stubs.LocatePrebuiltSo("/fake/base", _ => false);
+        Assert.Null(found);
+    }
+
+    /// <summary>
+    /// PrebuiltStubFileName must actually vary by architecture — pinning that x64 and
+    /// arm64 produce different filenames catches a copy-paste bug that would silently load
+    /// the wrong architecture's shim (an ELF class mismatch that fails at NativeLibrary.Load
+    /// time with a confusing "wrong ELF class" error, not at compile time).
+    /// </summary>
+    [Fact]
+    public void PrebuiltStubFileName_NamesTheRidExplicitly_WhenSupported()
+    {
+        var name = Win32Stubs.PrebuiltStubFileName();
+        if (name is null) return; // e.g. running this test suite on macOS/Windows
+        Assert.True(name is "libwin32_stubs.linux-x64.so" or "libwin32_stubs.linux-arm64.so",
+            $"Unexpected prebuilt stub filename: {name}");
+    }
+
+    /// <summary>
+    /// GREEN, end-to-end: with a fixture .so dropped at the exact beside-the-binary path
+    /// GetOrBuild probes (via the BaseDirectoryForTests test seam), GetOrBuild must load it
+    /// directly — with zero compiler invocation. Proven here by additionally stripping PATH
+    /// down to nothing: if GetOrBuild fell through to the compile-from-source path instead of
+    /// using the prebuilt stub, it would throw (no compiler on PATH) rather than return a
+    /// valid handle.
+    /// </summary>
+    [Fact]
+    public void GetOrBuild_LoadsShippedPrebuiltStub_WithoutInvokingAnyCompiler()
+    {
+        var ridName = Win32Stubs.PrebuiltStubFileName();
+        if (ridName is null) return; // no prebuilt convention for this OS/arch — nothing to prove here
+
+        var dir = Path.Combine(Path.GetTempPath(), "win32stubs-prebuilt-test-" + Guid.NewGuid());
+        var stubDir = Path.Combine(dir, "Win32Stubs");
+        Directory.CreateDirectory(stubDir);
+        var cFile = Path.Combine(dir, "trivial.c");
+        var soFile = Path.Combine(stubDir, ridName);
+        File.WriteAllText(cFile, "int dummy_export(void) { return 42; }\n");
+
+        var psi = new System.Diagnostics.ProcessStartInfo("cc", $"-shared -fPIC -o \"{soFile}\" \"{cFile}\"")
+        { RedirectStandardError = true, UseShellExecute = false };
+        using var proc = System.Diagnostics.Process.Start(psi)!;
+        proc.WaitForExit(10000);
+        // Skip (not fail) on a machine with no compiler — building the FIXTURE needs cc,
+        // but the behaviour under test (GetOrBuild not needing cc at RUN time) doesn't.
+        if (proc.ExitCode != 0) { try { Directory.Delete(dir, true); } catch { } return; }
+
+        var savedPath = Environment.GetEnvironmentVariable("PATH");
+        var savedOverride = Environment.GetEnvironmentVariable("AL_RUNNER_WIN32_STUBS_SO");
+        try
+        {
+            Environment.SetEnvironmentVariable("AL_RUNNER_WIN32_STUBS_SO", null);
+            Environment.SetEnvironmentVariable("PATH", ""); // no compiler reachable at all
+            Win32Stubs.BaseDirectoryForTests = dir;
+            Win32Stubs.ResetForTests();
+
+            var handle = Win32Stubs.GetOrBuild("kernel32.dll");
+            Assert.NotEqual(IntPtr.Zero, handle);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("PATH", savedPath);
+            Environment.SetEnvironmentVariable("AL_RUNNER_WIN32_STUBS_SO", savedOverride);
+            Win32Stubs.BaseDirectoryForTests = null;
+            Win32Stubs.ResetForTests();
+            try { Directory.Delete(dir, recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    /// <summary>
+    /// Negative direction for the new load-order step: with no prebuilt stub AND no
+    /// compiler on PATH, GetOrBuild must still fail loudly with #1669's message — the new
+    /// "check for a prebuilt" step must not itself swallow the absence and return a
+    /// default/zero handle.
+    /// </summary>
+    [Fact]
+    public void GetOrBuild_StillThrows_WhenNoPrebuiltAndNoCompiler()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "win32stubs-no-prebuilt-test-" + Guid.NewGuid());
+        Directory.CreateDirectory(dir); // deliberately no Win32Stubs/ subfolder inside it
+
+        var savedPath = Environment.GetEnvironmentVariable("PATH");
+        var savedOverride = Environment.GetEnvironmentVariable("AL_RUNNER_WIN32_STUBS_SO");
+        try
+        {
+            Environment.SetEnvironmentVariable("AL_RUNNER_WIN32_STUBS_SO", null);
+            Environment.SetEnvironmentVariable("PATH", "");
+            Win32Stubs.BaseDirectoryForTests = dir;
+            Win32Stubs.ResetForTests();
+
+            var ex = Assert.Throws<InvalidOperationException>(() => Win32Stubs.GetOrBuild("kernel32.dll"));
+            Assert.Contains("kernel32.dll", ex.Message);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("PATH", savedPath);
+            Environment.SetEnvironmentVariable("AL_RUNNER_WIN32_STUBS_SO", savedOverride);
+            Win32Stubs.BaseDirectoryForTests = null;
+            Win32Stubs.ResetForTests();
+            try { Directory.Delete(dir, recursive: true); } catch { /* best effort */ }
+        }
+    }
 }

--- a/AlRunner/AlRunner.csproj
+++ b/AlRunner/AlRunner.csproj
@@ -89,6 +89,51 @@
     </Content>
   </ItemGroup>
 
+  <!-- #1672: ship a prebuilt libwin32_stubs.<rid>.so beside win32_stubs.c so a Linux
+       install with no C toolchain still resolves Win32 imports (Win32Stubs.GetOrBuild
+       tries this before falling back to compiling from source). Built once per
+       architecture, here, at build/pack time — never committed to source control
+       (see .gitignore) since it's a native binary artifact of the build, not source.
+       Best-effort per compiler:
+         - native `cc`, labelled by the host's own `uname -m`, covers whatever
+           architecture actually runs this build (the linux-x64 GH Actions runner
+           in publish.yml, or a dev box).
+         - the `aarch64-linux-gnu-gcc` cross toolchain, if present, additionally
+           produces linux-arm64 regardless of host arch (installed explicitly by
+           publish.yml so a single x64 CI runner can ship both RIDs).
+       Neither Exec fails the build if its compiler is missing (ContinueOnError):
+       Win32Stubs.GetOrBuild's compile-from-source fallback (and #1669's loud
+       failure if that has no compiler either) still covers whatever RID didn't
+       get a prebuilt here. Windows-only guard: `cc`/cross-gcc/bash aren't
+       reliably present there and this whole subsystem targets Linux Win32 shims. -->
+  <!-- BeforeTargets="PrepareForBuild" (not "Build"): "Build" is a thin alias whose
+       own DependsOnTargets chain (…;CopyFilesToOutputDirectory;…) already runs before
+       a "BeforeTargets=Build" hook fires, so the .so wouldn't exist yet when Content
+       items get copied to the output dir. PrepareForBuild runs at the very start of
+       that chain. -->
+  <Target Name="BuildWin32PrebuiltStubs" BeforeTargets="PrepareForBuild;Pack;GenerateNuspec"
+          Condition="'$(OS)' != 'Windows_NT'">
+    <!-- Delegates to a standalone script rather than an inline command — MSBuild's
+         Exec task re-quotes inline shell strings in a way that breaks backtick/${var}
+         substitution (see build-prebuilt.sh's header comment for the concrete
+         failure this sidesteps). -->
+    <Exec Command="bash Win32Stubs/build-prebuilt.sh"
+          WorkingDirectory="$(MSBuildProjectDirectory)"
+          ContinueOnError="WarnAndContinue" />
+    <ItemGroup>
+      <Content Include="Win32Stubs/libwin32_stubs.linux-x64.so" Condition="Exists('Win32Stubs/libwin32_stubs.linux-x64.so')">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        <Pack>true</Pack>
+        <PackagePath>tools/$(TargetFramework)/any/Win32Stubs/</PackagePath>
+      </Content>
+      <Content Include="Win32Stubs/libwin32_stubs.linux-arm64.so" Condition="Exists('Win32Stubs/libwin32_stubs.linux-arm64.so')">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        <Pack>true</Pack>
+        <PackagePath>tools/$(TargetFramework)/any/Win32Stubs/</PackagePath>
+      </Content>
+    </ItemGroup>
+  </Target>
+
   <!-- Bake the BC version this binary was BUILT against into the assembly.
        Microsoft stamps Ncl.dll's assembly version as major.0.0.0 only (28.0.0.0), so the
        MINOR is unrecoverable from the engine DLLs at runtime — yet the minor is what

--- a/AlRunner/Win32Stubs.cs
+++ b/AlRunner/Win32Stubs.cs
@@ -52,6 +52,14 @@ internal static class Win32Stubs
         _handle = IntPtr.Zero;
     }
 
+    /// <summary>Test-only seam: when set, <see cref="GetOrBuild"/> probes for the
+    /// shipped prebuilt stub under this directory instead of <see
+    /// cref="AppContext.BaseDirectory"/>, so a unit test can drop a fixture .so
+    /// somewhere temporary without touching the real install layout. Null in
+    /// production. Never read from production code paths other than
+    /// <see cref="GetOrBuild"/>'s own base-directory resolution below.</summary>
+    internal static string? BaseDirectoryForTests;
+
     private static void TryRegister(Assembly asm)
     {
         var n = asm.GetName().Name ?? "";
@@ -89,6 +97,19 @@ internal static class Win32Stubs
             return _handle;
         }
 
+        // #1672: try the shipped prebuilt stub (beside the binary, one per RID —
+        // see AlRunner.csproj's BuildWin32PrebuiltStubs target) before falling back
+        // to compiling from source. This is what lets a fresh Linux install with no
+        // C toolchain resolve Win32 imports out of the box; the compile-from-source
+        // path below still exists for RIDs the release pipeline didn't prebuild for
+        // (or a dev tree running straight from `dotnet run`).
+        var prebuilt = LocatePrebuiltSo(BaseDirectoryForTests ?? AppContext.BaseDirectory, File.Exists);
+        if (prebuilt != null)
+        {
+            _handle = NativeLibrary.Load(prebuilt);
+            return _handle;
+        }
+
         var compiler = FindCompiler(cmd => IsOnPath(cmd));
         if (compiler == null)
             throw new InvalidOperationException(BuildNoCompilerMessage(library));
@@ -109,6 +130,40 @@ internal static class Win32Stubs
                 + $"'{library}' (required by {src}). Compiler output:\n{proc.StandardError.ReadToEnd()}");
         _handle = NativeLibrary.Load(soFile);
         return _handle;
+    }
+
+    /// <summary>The filename of the shipped prebuilt stub for the current process's
+    /// RID, or null if this architecture has no shipped prebuilt (falls back to
+    /// compile-from-source in that case). Named after the standard RID convention
+    /// (<c>linux-x64</c>, <c>linux-arm64</c>) even though the file lives beside the
+    /// binary rather than under a NuGet <c>runtimes/&lt;rid&gt;/native/</c> folder —
+    /// PackAsTool nupkgs only extract <c>tools/&lt;tfm&gt;/any/</c>, so the RID lives
+    /// in the filename instead of the directory structure. Linux-only: this whole
+    /// resolver exists to redirect Win32 P/Invokes to a Linux .so (see the file
+    /// header), so other OSes never reach here in practice, but the explicit guard
+    /// keeps the contract obvious.</summary>
+    internal static string? PrebuiltStubFileName()
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) return null;
+        return RuntimeInformation.ProcessArchitecture switch
+        {
+            Architecture.X64 => "libwin32_stubs.linux-x64.so",
+            Architecture.Arm64 => "libwin32_stubs.linux-arm64.so",
+            _ => null,
+        };
+    }
+
+    /// <summary>Pure/injectable lookup for the shipped prebuilt stub beside the
+    /// binary: <c>&lt;baseDirectory&gt;/Win32Stubs/libwin32_stubs.&lt;rid&gt;.so</c>.
+    /// Returns null (never throws) when there is no prebuilt for this RID or the
+    /// file isn't there — both are legitimate "fall through to compile-from-source"
+    /// cases, not errors.</summary>
+    internal static string? LocatePrebuiltSo(string baseDirectory, Func<string, bool> exists)
+    {
+        var name = PrebuiltStubFileName();
+        if (name is null) return null;
+        var candidate = Path.Combine(baseDirectory, "Win32Stubs", name);
+        return exists(candidate) ? candidate : null;
     }
 
     /// <summary>Returns the first name in <see cref="CandidateCompilers"/> for which

--- a/AlRunner/Win32Stubs/build-prebuilt.sh
+++ b/AlRunner/Win32Stubs/build-prebuilt.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# #1672: build the prebuilt libwin32_stubs.<rid>.so shims shipped beside win32_stubs.c
+# so a Linux install with no C toolchain still resolves Win32 imports (see
+# Win32Stubs.GetOrBuild's load order). Invoked by AlRunner.csproj's
+# BuildWin32PrebuiltStubs MSBuild target, from AlRunner/ as the working directory.
+#
+# Kept as a standalone script (rather than an inline <Exec Command="bash -c ...">)
+# because MSBuild's Exec task re-quotes inline commands in a way that breaks
+# backtick/${var} shell substitution — see the #1672 PR description for the
+# concrete failure (rid resolved empty) this sidesteps.
+#
+# Best-effort per compiler; a missing compiler for a given RID is not an error
+# here — the caller (BuildWin32PrebuiltStubs) only packs whichever .so files
+# actually got produced, and Win32Stubs.GetOrBuild's compile-from-source
+# fallback (#1669's loud failure if even that has no compiler) covers the rest.
+set -uo pipefail
+cd "$(dirname "$0")"
+
+case "$(uname -m)" in
+  x86_64)  native_rid=linux-x64 ;;
+  aarch64) native_rid=linux-arm64 ;;
+  *)       native_rid= ;;
+esac
+
+if [ -n "$native_rid" ] && command -v cc >/dev/null 2>&1; then
+  cc -shared -fPIC -o "libwin32_stubs.${native_rid}.so" win32_stubs.c
+fi
+
+if command -v aarch64-linux-gnu-gcc >/dev/null 2>&1; then
+  aarch64-linux-gnu-gcc -shared -fPIC -o libwin32_stubs.linux-arm64.so win32_stubs.c
+fi
+
+exit 0

--- a/README.md
+++ b/README.md
@@ -46,13 +46,16 @@ This is the **precompiled-DLL contract** described in `.claude/rules/precompiled
 
 .NET SDK 9 or 10 — download from [https://aka.ms/dotnet/download](https://aka.ms/dotnet/download).
 
-**Linux only:** a C compiler (`cc`, `gcc`, or `clang`) on `PATH`. The BC service-tier
-DLLs contain a handful of genuine Win32 P/Invokes (e.g. `kernel32`'s locale APIs,
-reached by anything that evaluates a `TextConstant`, including the standard
-upgrade-tag install-trigger pattern) that the runner redirects to a small shim
-compiled on first use from `AlRunner/Win32Stubs/win32_stubs.c`. Without a compiler
-this fails loudly and names the missing tool and the two ways to fix it — install one
-(e.g. `apt install build-essential`) or build the shim yourself and point
+**Linux:** none — the BC service-tier DLLs contain a handful of genuine Win32
+P/Invokes (e.g. `kernel32`'s locale APIs, reached by anything that evaluates a
+`TextConstant`, including the standard upgrade-tag install-trigger pattern) that
+the runner redirects to a small shim. A prebuilt `libwin32_stubs.so` for `linux-x64`
+and `linux-arm64` ships with the tool, so no C toolchain is required out of the box.
+If you're on a RID the release pipeline didn't prebuild for, the runner falls back
+to compiling `AlRunner/Win32Stubs/win32_stubs.c` on first use, which does need a C
+compiler (`cc`, `gcc`, or `clang`) on `PATH`; without one it fails loudly and names
+the missing tool and the two ways to fix it — install one (e.g.
+`apt install build-essential`) or build the shim yourself and point
 `AL_RUNNER_WIN32_STUBS_SO` at the resulting `.so`. Not needed on Windows or macOS.
 
 ### Install


### PR DESCRIPTION
Closes #1672

## Problem

On Linux, the first Win32 P/Invoke shells out to `cc` to build the shim (see #1651/#1669), so a fresh AL Runner install still requires a C toolchain on PATH — a surprising prerequisite for containers/CI images that don't ship `build-essential`.

## Change

- `Win32Stubs.GetOrBuild`'s load order gains a step: (1) `AL_RUNNER_WIN32_STUBS_SO` override, unchanged; (2) **new** — a shipped prebuilt `libwin32_stubs.<rid>.so` beside the binary; (3) compile-from-source, unchanged (with #1669's loud failure if no compiler exists either).
- `AlRunner.csproj` gains a `BuildWin32PrebuiltStubs` target that builds `libwin32_stubs.linux-x64.so` (native `cc`, labelled by `uname -m`) and, best-effort, `libwin32_stubs.linux-arm64.so` (via the `aarch64-linux-gnu-gcc` cross toolchain if present) at build/pack time, and packs both into the tool's `tools/<tfm>/any/Win32Stubs/` — the same layout `win32_stubs.c` already uses. Neither `.so` is committed to source control (they're native build artifacts); `publish.yml` now installs the aarch64 cross-compiler on the linux-x64 release runner so a single CI job ships both RIDs.
- README's prerequisites section updated to reflect that a C compiler is now only needed as a fallback for RIDs the release pipeline didn't prebuild for.

## Tests

`AlRunner.Tests/Win32StubsLoudFailureTests.cs` gains:
- `LocatePrebuiltSo_ReturnsComposedPath_WhenFileExists` / `_ReturnsNull_WhenFileMissing` — pure lookup logic.
- `PrebuiltStubFileName_NamesTheRidExplicitly_WhenSupported` — pins the RID-specific filenames so a copy-paste bug can't silently load the wrong architecture's shim.
- `GetOrBuild_LoadsShippedPrebuiltStub_WithoutInvokingAnyCompiler` — end-to-end, with `PATH` stripped to nothing, proving the prebuilt path is used without ever invoking a compiler.
- `GetOrBuild_StillThrows_WhenNoPrebuiltAndNoCompiler` — negative direction: the new step must not itself swallow the "no prebuilt" case and silently return a default handle.

Verified locally: `dotnet build`/`dotnet pack` produce and pack `libwin32_stubs.linux-x64.so`; the targeted test file passes 14/14.

## Test plan

- [x] `dotnet test AlRunner.Tests --filter Win32StubsLoudFailureTests` — 14/14 passed
- [x] `dotnet build AlRunner/AlRunner.csproj` produces `Win32Stubs/libwin32_stubs.linux-x64.so`
- [x] `dotnet pack AlRunner/AlRunner.csproj` packs it under `tools/net8.0/any/Win32Stubs/`
- [ ] CI green (test-matrix + publish dry-run via the `test` job's build step)