### PR TITLE
fix(win32stubs): never intercept Win32 imports on Windows

### DIFF
--- a/AlRunner.Tests/Win32StubsLoudFailureTests.cs
+++ b/AlRunner.Tests/Win32StubsLoudFailureTests.cs
@@ -282,4 +282,40 @@ public class Win32StubsLoudFailureTests
             try { Directory.Delete(dir, recursive: true); } catch { /* best effort */ }
         }
     }
+
+    /// <summary>
+    /// Issue #1673 (regression from #1669): on Windows, kernel32/user32/etc. are the *real*
+    /// Win32 libraries — the Linux-only shim resolver must never intercept them at all.
+    /// Before #1669 an unconditional interception was harmless because the resolver's failure
+    /// was swallowed and the default loader took over; after #1669 it throws directly, which
+    /// on Windows means every AL install trigger that touches WindowsLanguageHelper (e.g. a
+    /// bare TextConstant, see #1651) now dies with a Linux-shim error on a platform that never
+    /// needed the shim. <see cref="Win32Stubs.Register(bool)"/> must skip registration entirely
+    /// when told it's running on Windows, and — critically — must do so *before* setting the
+    /// "already registered" flag, so a later non-Windows call in the same process still works.
+    /// </summary>
+    [Fact]
+    public void Register_OnWindows_NeverMarksItselfRegistered()
+    {
+        Win32Stubs.ResetForTests();
+        Win32Stubs.Register(isWindows: true);
+        Assert.False(Win32Stubs.IsRegisteredForTests,
+            "Register(isWindows: true) must no-op without setting the registered flag, " +
+            "so the Win32 shim resolver is never installed for Nav.* assemblies on Windows.");
+    }
+
+    /// <summary>
+    /// Positive counterpart: the non-Windows path must be unaffected by the platform guard —
+    /// it still marks itself registered exactly as before #1673's fix. A guard that always
+    /// no-ops (e.g. `return;` unconditionally) would make the negative test above pass too,
+    /// so this positive case is required to prove the guard is actually platform-conditional.
+    /// </summary>
+    [Fact]
+    public void Register_OnNonWindows_StillMarksItselfRegistered()
+    {
+        Win32Stubs.ResetForTests();
+        Win32Stubs.Register(isWindows: false);
+        Assert.True(Win32Stubs.IsRegisteredForTests,
+            "Register(isWindows: false) must behave exactly as before #1673 and register normally.");
+    }
 }

--- a/AlRunner/Win32Stubs.cs
+++ b/AlRunner/Win32Stubs.cs
@@ -34,8 +34,25 @@ internal static class Win32Stubs
         "psapi", "psapi.dll", "ws2_32", "ws2_32.dll", "shlwapi", "shlwapi.dll",
     };
 
-    public static void Register()
+    /// <summary>
+    /// Issue #1673: kernel32/user32/etc. are the *real* Win32 libraries on Windows — this
+    /// shim exists purely to fake them on Linux (see the type-level comment). Intercepting
+    /// them on Windows too used to be harmless (the resolver's failure was swallowed and the
+    /// default loader took over), but #1669 made the resolver throw directly, so on Windows
+    /// that interception now breaks every AL codepath that touches one of these libraries
+    /// (e.g. any install trigger reaching WindowsLanguageHelper via a bare TextConstant, see
+    /// #1651) even though Windows never needed the shim in the first place.
+    /// </summary>
+    public static void Register() => Register(OperatingSystem.IsWindows());
+
+    /// <summary>internal (not private) purely so <c>AlRunner.Tests</c> can exercise the
+    /// Windows-vs-Linux branch deterministically without depending on the OS the test happens
+    /// to run on — see Win32StubsLoudFailureTests.cs.</summary>
+    internal static void Register(bool isWindows)
     {
+        // Checked before touching _registered so a Register(isWindows: true) no-op call never
+        // blocks a later, real Register() call in the same process from registering normally.
+        if (isWindows) return;
         if (_registered) return;
         _registered = true;
 
@@ -44,12 +61,17 @@ internal static class Win32Stubs
         AppDomain.CurrentDomain.AssemblyLoad += (_, e) => TryRegister(e.LoadedAssembly);
     }
 
+    /// <summary>Test-only: observes whether <see cref="Register(bool)"/> has completed
+    /// registration in this process. Never read from production code paths.</summary>
+    internal static bool IsRegisteredForTests => _registered;
+
     /// <summary>Test-only: forget the cached handle/registration so a unit test can
-    /// exercise <see cref="GetOrBuild"/> from a clean slate. Never called from
-    /// production code paths.</summary>
+    /// exercise <see cref="GetOrBuild"/> or <see cref="Register(bool)"/> from a clean slate.
+    /// Never called from production code paths.</summary>
     internal static void ResetForTests()
     {
         _handle = IntPtr.Zero;
+        _registered = false;
     }
 
     /// <summary>Test-only seam: when set, <see cref="GetOrBuild"/> probes for the


### PR DESCRIPTION
Closes #1673

## Problem

`Win32Stubs.Register()` runs unconditionally on every platform, so on Windows the Linux-only P/Invoke shim resolver also intercepted `kernel32`/`user32`/etc. imports from `Nav.*` assemblies. Before #1669 this was harmless — a failed shim build was swallowed and the resolver returned `IntPtr.Zero`, letting .NET's default loader find the real Windows libraries. After #1669 (which made the resolver throw loudly instead of swallowing, per `docs/loud-failures.md`), the same interception on Windows now throws the Linux-shim error directly, breaking every AL install trigger that touches one of those libraries (e.g. `WindowsLanguageHelper` via a bare `TextConstant`, see #1651) — even though Windows never needed the shim to begin with.

## Fix

`Win32Stubs.Register()` now checks `OperatingSystem.IsWindows()` (via an internal, test-injectable `Register(bool isWindows)` overload) and no-ops before marking itself registered. The platform check happens before the "already registered" flag is set, so a later non-Windows `Register()` call in the same process still registers normally — the guard can't accidentally wedge the resolver off forever.

On Linux, behavior is unchanged: #1669's loud failure still fires when no C compiler is on `PATH`.

## Tests (RED -> GREEN)

Added to `AlRunner.Tests/Win32StubsLoudFailureTests.cs`:
- `Register_OnWindows_NeverMarksItselfRegistered` — proves the Windows path no-ops without setting the registered flag (so the shim resolver is never installed for `Nav.*` assemblies on Windows).
- `Register_OnNonWindows_StillMarksItselfRegistered` — positive counterpart proving the guard is actually platform-conditional, not an unconditional no-op that would make the negative test above pass trivially.

Both new tests fail to compile at RED (no `Register(bool)` / `IsRegisteredForTests` yet), and pass at GREEN. Full `AlRunner.Tests` suite: 223/223 passing.

No `docs/coverage.yaml` update — this is a runner infra/platform-guard fix, not an AL-language feature (consistent with #1650/#1657/#1669, the related prior infra fixes in this area, none of which touched it either).