### PR TITLE
Port protocol-v2 building blocks + testIsolation (first slice of #1641)

### DIFF
--- a/AlRunner.Tests/ErrorClassifierTests.cs
+++ b/AlRunner.Tests/ErrorClassifierTests.cs
@@ -1,0 +1,130 @@
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public class ErrorClassifierTests
+{
+    [Fact]
+    public void Classify_NullException_IsUnknown()
+    {
+        var ctx = new TestExecutionContext(InsideTestProc: true);
+        Assert.Equal(AlErrorKind.Unknown, ErrorClassifier.Classify(null, ctx));
+    }
+
+    [Fact]
+    public void Classify_OperationCanceled_IsTimeout()
+    {
+        var ex = new OperationCanceledException("test exceeded timeout");
+        var ctx = new TestExecutionContext(InsideTestProc: true);
+        Assert.Equal(AlErrorKind.Timeout, ErrorClassifier.Classify(ex, ctx));
+    }
+
+    [Fact]
+    public void Classify_TaskCanceledException_IsTimeout()
+    {
+        // TaskCanceledException derives from OperationCanceledException.
+        var ex = new TaskCanceledException("cancelled");
+        var ctx = new TestExecutionContext(InsideTestProc: true);
+        Assert.Equal(AlErrorKind.Timeout, ErrorClassifier.Classify(ex, ctx));
+    }
+
+    [Fact]
+    public void Classify_OperationCanceledDuringSetup_IsTimeoutNotSetup()
+    {
+        // Pins ordering: timeout takes precedence over the InsideTestProc gate.
+        var ex = new OperationCanceledException("cancelled in setup");
+        var ctx = new TestExecutionContext(InsideTestProc: false);
+        Assert.Equal(AlErrorKind.Timeout, ErrorClassifier.Classify(ex, ctx));
+    }
+
+    [Fact]
+    public void Classify_GenericException_DuringSetup_IsSetup()
+    {
+        var ex = new InvalidOperationException("ctor failed");
+        var ctx = new TestExecutionContext(InsideTestProc: false);
+        Assert.Equal(AlErrorKind.Setup, ErrorClassifier.Classify(ex, ctx));
+    }
+
+    [Fact]
+    public void Classify_GenericException_DuringTest_IsRuntime()
+    {
+        var ex = new InvalidOperationException("runtime error");
+        var ctx = new TestExecutionContext(InsideTestProc: true);
+        Assert.Equal(AlErrorKind.Runtime, ErrorClassifier.Classify(ex, ctx));
+    }
+
+    // v2-specific: real BC's Error()-based Assert failures throw
+    // Microsoft.Dynamics.Nav.Types.NavNCLDialogException — the SAME type a plain
+    // Error() call throws — so there is no type-based signal to bucket them as
+    // Assertion today. Pin that they fall through to Runtime rather than silently
+    // being misclassified as Setup or Compile.
+    [Fact]
+    public void Classify_NavStyleDialogException_DuringTest_FallsThroughToRuntime()
+    {
+        var ex = new InvalidOperationException("boom") { };
+        var ctx = new TestExecutionContext(InsideTestProc: true);
+        Assert.Equal(AlErrorKind.Runtime, ErrorClassifier.Classify(ex, ctx));
+    }
+
+    [Fact]
+    public void Classify_AssertionExceptionSuffix_IsAssertion()
+    {
+        var ex = new MyDomainAssertException("oops");
+        var ctx = new TestExecutionContext(InsideTestProc: true);
+        Assert.Equal(AlErrorKind.Assertion, ErrorClassifier.Classify(ex, ctx));
+    }
+
+    [Fact]
+    public void Classify_AssertionExceptionFullSuffix_IsAssertion()
+    {
+        var ex = new MyDomainAssertionException("oops");
+        var ctx = new TestExecutionContext(InsideTestProc: true);
+        Assert.Equal(AlErrorKind.Assertion, ErrorClassifier.Classify(ex, ctx));
+    }
+
+    [Fact]
+    public void Classify_CompilationFailedException_IsCompile()
+    {
+        var ex = new MyDomainCompilationFailedException("compile error");
+        var ctx = new TestExecutionContext(InsideTestProc: true);
+        Assert.Equal(AlErrorKind.Compile, ErrorClassifier.Classify(ex, ctx));
+    }
+
+    [Fact]
+    public void Classify_CompileErrorEnding_IsCompile()
+    {
+        var ex = new MyDomainCompileErrorException("bad emit");
+        var ctx = new TestExecutionContext(InsideTestProc: true);
+        Assert.Equal(AlErrorKind.Compile, ErrorClassifier.Classify(ex, ctx));
+    }
+
+    [Fact]
+    public void Classify_AggregateExceptionWrappingAssertion_IsRuntime()
+    {
+        // Documents that unwrapping AggregateException is the caller's job.
+        var inner = new MyDomainAssertException("inner");
+        var ex = new AggregateException(inner);
+        var ctx = new TestExecutionContext(InsideTestProc: true);
+        Assert.Equal(AlErrorKind.Runtime, ErrorClassifier.Classify(ex, ctx));
+    }
+
+    private sealed class MyDomainAssertException : Exception
+    {
+        public MyDomainAssertException(string m) : base(m) { }
+    }
+
+    private sealed class MyDomainAssertionException : Exception
+    {
+        public MyDomainAssertionException(string m) : base(m) { }
+    }
+
+    private sealed class MyDomainCompilationFailedException : Exception
+    {
+        public MyDomainCompilationFailedException(string m) : base(m) { }
+    }
+
+    private sealed class MyDomainCompileErrorException : Exception
+    {
+        public MyDomainCompileErrorException(string m) : base(m) { }
+    }
+}

--- a/AlRunner.Tests/ServerTestIsolationTests.cs
+++ b/AlRunner.Tests/ServerTestIsolationTests.cs
@@ -1,0 +1,165 @@
+using System.Text.Json;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// #1616: --server's `runTests` had no way to ask for per-method test isolation
+/// (the CLI's `--test-isolation method` equivalent), so tests that depend on a
+/// per-method reset cross-pollute under --server even though the identical CLI
+/// invocation passes. These spawn the real runner and need the BC artifact caches
+/// present (~/.bcartifacts.cache); when absent, they skip rather than fail.
+/// </summary>
+[Collection("server-serial")]
+public class ServerTestIsolationTests
+{
+    private static bool ArtifactsPresent()
+    {
+        var home = Environment.GetEnvironmentVariable("HOME");
+        if (string.IsNullOrEmpty(home)) return false;
+        return Directory.Exists(Path.Combine(home, ".bcartifacts.cache", "sandbox"));
+    }
+
+    // Two [Test] procs in the SAME codeunit both insert a row with the SAME primary
+    // key. Under TestIsolation.Codeunit (the default — no reset between methods
+    // inside one codeunit), the second Insert must fail with a duplicate-key error.
+    // Under TestIsolation.Test ("test"/"method"), state resets before every [Test]
+    // proc, so both Insert calls succeed independently.
+    private static string MakeIsolationBundle()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "al-runner-server-isolation", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "app.json"), """
+        {
+          "id": "f3a4b5c6-d7e8-4f90-a1b2-c3d4e5f60718",
+          "name": "Runner Extras - Server Isolation Probe",
+          "publisher": "AL Runner",
+          "version": "1.0.0.0",
+          "dependencies": [],
+          "platform": "1.0.0.0",
+          "application": "1.0.0.0",
+          "idRanges": [ { "from": 60170, "to": 60179 } ],
+          "runtime": "14.0"
+        }
+        """);
+        File.WriteAllText(Path.Combine(dir, "IsoTable.Table.al"), """
+        table 60170 "Server Isolation Probe Tbl"
+        {
+            fields
+            {
+                field(1; "Code"; Code[20]) { }
+            }
+            keys { key(PK; "Code") { Clustered = true; } }
+        }
+        """);
+        File.WriteAllText(Path.Combine(dir, "IsoTest.Codeunit.al"), """
+        codeunit 60170 "Server Isolation Probe SX"
+        {
+            Subtype = Test;
+
+            [Test]
+            procedure InsertsFixedKey_First()
+            var
+                Rec: Record "Server Isolation Probe Tbl";
+            begin
+                Rec.Init();
+                Rec."Code" := 'FIXED';
+                Rec.Insert();
+            end;
+
+            [Test]
+            procedure InsertsFixedKey_Second()
+            var
+                Rec: Record "Server Isolation Probe Tbl";
+            begin
+                Rec.Init();
+                Rec."Code" := 'FIXED';
+                Rec.Insert();
+            end;
+        }
+        """);
+        return dir;
+    }
+
+    private static string Req(string bundleDir, string? testIsolation)
+        => JsonSerializer.Serialize(new
+        {
+            command = "runTests",
+            sourcePaths = new[] { bundleDir },
+            packagePaths = Array.Empty<string>(),
+            testIsolation,
+        });
+
+    [Fact]
+    public async Task RunTests_NoTestIsolationField_DefaultsToCodeunit_SecondInsertFails()
+    {
+        if (!ArtifactsPresent()) { Console.Error.WriteLine("[skip] BC artifact cache not present"); return; }
+
+        var bundle = MakeIsolationBundle();
+        var cacheDir = Path.Combine(Path.GetTempPath(), "al-runner-server-isolation-cache", Guid.NewGuid().ToString("N"));
+        await using var server = await CliServer.StartAsync(new[] { "--cache", cacheDir });
+
+        var r = await server.SendAsync(Req(bundle, testIsolation: null));
+        var d = JsonSerializer.Deserialize<JsonElement>(r);
+
+        Assert.Equal(2, d.GetProperty("total").GetInt32());
+        Assert.Equal(1, d.GetProperty("passed").GetInt32());
+        Assert.Equal(1, d.GetProperty("failed").GetInt32());
+    }
+
+    [Fact]
+    public async Task RunTests_TestIsolationMethod_BothInsertsSucceed()
+    {
+        if (!ArtifactsPresent()) { Console.Error.WriteLine("[skip] BC artifact cache not present"); return; }
+
+        var bundle = MakeIsolationBundle();
+        var cacheDir = Path.Combine(Path.GetTempPath(), "al-runner-server-isolation-cache2", Guid.NewGuid().ToString("N"));
+        await using var server = await CliServer.StartAsync(new[] { "--cache", cacheDir });
+
+        var r = await server.SendAsync(Req(bundle, testIsolation: "method"));
+        var d = JsonSerializer.Deserialize<JsonElement>(r);
+
+        Assert.Equal(2, d.GetProperty("total").GetInt32());
+        Assert.Equal(2, d.GetProperty("passed").GetInt32());
+        Assert.Equal(0, d.GetProperty("failed").GetInt32());
+    }
+
+    [Fact]
+    public async Task RunTests_TestIsolationDoesNotStickAcrossRequests()
+    {
+        // Request 1 asks for "method" (both pass). Request 2 (fresh bundle copy,
+        // same server process) omits testIsolation and must fall back to the
+        // server's own default (Codeunit) — not silently inherit "method" from
+        // request 1.
+        if (!ArtifactsPresent()) { Console.Error.WriteLine("[skip] BC artifact cache not present"); return; }
+
+        var bundle1 = MakeIsolationBundle();
+        var bundle2 = MakeIsolationBundle();
+        var cacheDir = Path.Combine(Path.GetTempPath(), "al-runner-server-isolation-cache3", Guid.NewGuid().ToString("N"));
+        await using var server = await CliServer.StartAsync(new[] { "--cache", cacheDir });
+
+        var r1 = await server.SendAsync(Req(bundle1, testIsolation: "method"));
+        var d1 = JsonSerializer.Deserialize<JsonElement>(r1);
+        Assert.Equal(2, d1.GetProperty("passed").GetInt32());
+
+        var r2 = await server.SendAsync(Req(bundle2, testIsolation: null));
+        var d2 = JsonSerializer.Deserialize<JsonElement>(r2);
+        Assert.Equal(1, d2.GetProperty("passed").GetInt32());
+        Assert.Equal(1, d2.GetProperty("failed").GetInt32());
+    }
+
+    [Fact]
+    public async Task RunTests_UnknownTestIsolationMode_ReturnsError()
+    {
+        if (!ArtifactsPresent()) { Console.Error.WriteLine("[skip] BC artifact cache not present"); return; }
+
+        var bundle = MakeIsolationBundle();
+        var cacheDir = Path.Combine(Path.GetTempPath(), "al-runner-server-isolation-cache4", Guid.NewGuid().ToString("N"));
+        await using var server = await CliServer.StartAsync(new[] { "--cache", cacheDir });
+
+        var r = await server.SendAsync(Req(bundle, testIsolation: "bogus"));
+        var d = JsonSerializer.Deserialize<JsonElement>(r);
+        Assert.True(d.TryGetProperty("error", out var err));
+        Assert.Contains("bogus", err.GetString());
+    }
+}

--- a/AlRunner.Tests/StackFrameMapperTests.cs
+++ b/AlRunner.Tests/StackFrameMapperTests.cs
@@ -1,0 +1,115 @@
+using Xunit;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// StackFrameMapper parses the BC service-tier call-stack STRING format that
+/// AlRunner.Infrastructure.AlCallStackCapture.BuildStack produces:
+///   "ObjectName"(ObjectType N).MethodName[(Trigger)][ line L][ - App by Pub version V]
+/// one frame per line, deepest (closest to the throw) first — NOT a .NET exception
+/// stack trace (v1's StackFrameMapper parsed ".NET at ... in file:line N" text; v2's
+/// AlCallStackCapture already produces AL-only frames in BC's own format, so the
+/// parser targets that format instead. See #1641).
+/// </summary>
+public class StackFrameMapperTests
+{
+    [Fact]
+    public void Walk_ParsesSingleFrame_WithLineAndApp()
+    {
+        var stack = "\"Probe Test\"(CodeUnit 90999).FailsOnPurpose line 2 - Probe by Probe version 1.0.0.0";
+        var frames = StackFrameMapper.Walk(stack);
+
+        Assert.Single(frames);
+        Assert.Equal("\"Probe Test\"(CodeUnit 90999).FailsOnPurpose", frames[0].Name);
+        Assert.Equal(2, frames[0].Line);
+        Assert.Null(frames[0].File);
+        Assert.True(frames[0].IsUserCode);
+        Assert.Equal(FramePresentationHint.Normal, frames[0].Hint);
+    }
+
+    [Fact]
+    public void Walk_ParsesMultiFrame_DeepestFirst()
+    {
+        var stack =
+            "\"Alert Engine\"(CodeUnit 60021).New line 30 - MainApp by Contoso version 1.0.0.0\n" +
+            "\"Alert Engine Test\"(CodeUnit 60022).NewReturnsTrue line 17 - MainApp Test by Contoso version 1.0.0.0";
+        var frames = StackFrameMapper.Walk(stack);
+
+        Assert.Equal(2, frames.Count);
+        Assert.Equal("\"Alert Engine\"(CodeUnit 60021).New", frames[0].Name);
+        Assert.Equal(30, frames[0].Line);
+        Assert.Equal("\"Alert Engine Test\"(CodeUnit 60022).NewReturnsTrue", frames[1].Name);
+        Assert.Equal(17, frames[1].Line);
+    }
+
+    [Fact]
+    public void Walk_HandlesTriggerSuffix()
+    {
+        var stack = "\"Sales Line\"(Table 37).OnInsert(Trigger) line 5 - Base Application by Microsoft version 28.0.0.0";
+        var frames = StackFrameMapper.Walk(stack);
+
+        Assert.Single(frames);
+        Assert.Equal("\"Sales Line\"(Table 37).OnInsert(Trigger)", frames[0].Name);
+        Assert.Equal(5, frames[0].Line);
+    }
+
+    [Fact]
+    public void Walk_HandlesMissingLineNumber()
+    {
+        // Real BC omits the line segment for some frames (e.g. GetRelativeLine returns -1).
+        var stack = "\"Foo\"(CodeUnit 1).Bar - Foo by Bar version 1.0.0.0";
+        var frames = StackFrameMapper.Walk(stack);
+
+        Assert.Single(frames);
+        Assert.Equal("\"Foo\"(CodeUnit 1).Bar", frames[0].Name);
+        Assert.Null(frames[0].Line);
+    }
+
+    [Fact]
+    public void Walk_UnescapesDoubledQuotesInObjectName()
+    {
+        // BC doubles embedded quotes: AppendQuoted does name.Replace("\"", "\"\"").
+        var stack = "\"Say \"\"Hi\"\"\"(CodeUnit 2).Run line 1 - App by Pub version 1.0.0.0";
+        var frames = StackFrameMapper.Walk(stack);
+
+        Assert.Single(frames);
+        // The Name carries the still-quoted-for-display object segment; only
+        // the caller-facing helper below is expected to unescape for display.
+        Assert.Equal("Say \"Hi\"", StackFrameMapper.UnquoteObjectName(frames[0]));
+    }
+
+    [Fact]
+    public void Walk_NullOrEmptyStack_ReturnsEmptyList()
+    {
+        Assert.Empty(StackFrameMapper.Walk(null));
+        Assert.Empty(StackFrameMapper.Walk(""));
+        Assert.Empty(StackFrameMapper.Walk("   "));
+    }
+
+    [Fact]
+    public void Walk_UnparsableLine_FallsBackToRawNameWithoutLying()
+    {
+        // A line that doesn't match BC's format at all must not be silently dropped,
+        // but must also not invent a line number or file it doesn't have.
+        var stack = "some unexpected diagnostic text";
+        var frames = StackFrameMapper.Walk(stack);
+
+        Assert.Single(frames);
+        Assert.Equal("some unexpected diagnostic text", frames[0].Name);
+        Assert.Null(frames[0].Line);
+        Assert.Null(frames[0].File);
+    }
+
+    [Fact]
+    public void Walk_AllFramesAreUserCode_NoCSharpNoiseInV2Capture()
+    {
+        // AlCallStackCapture.BuildStack only ever records scopes with a non-null
+        // ApplicationObject (real AL frames); there is no C# infra frame to dim,
+        // unlike v1's mixed .NET stack traces.
+        var stack = "\"A\"(CodeUnit 1).M line 1 - App by Pub version 1.0.0.0";
+        var frames = StackFrameMapper.Walk(stack);
+
+        Assert.All(frames, f => Assert.True(f.IsUserCode));
+        Assert.All(frames, f => Assert.Equal(FramePresentationHint.Normal, f.Hint));
+    }
+}

--- a/AlRunner.Tests/TestFilterTests.cs
+++ b/AlRunner.Tests/TestFilterTests.cs
@@ -1,0 +1,37 @@
+using Xunit;
+
+namespace AlRunner.Tests;
+
+// Pins the shape ported from protocol-v2 (#1607/#1641): both fields optional/null
+// = no constraint, value equality on the record. Not yet wired into the runTests
+// request/executor — see #1641 follow-up.
+public class TestFilterTests
+{
+    [Fact]
+    public void DefaultConstruction_BothFieldsNull_MeansNoConstraint()
+    {
+        var filter = new TestFilter(null, null);
+        Assert.Null(filter.CodeunitNames);
+        Assert.Null(filter.ProcNames);
+    }
+
+    [Fact]
+    public void RecordEquality_SameSets_AreEqual()
+    {
+        var a = new TestFilter(new HashSet<string> { "Foo" }, new HashSet<string> { "Bar" });
+        var b = new TestFilter(new HashSet<string> { "Foo" }, new HashSet<string> { "Bar" });
+        // Records compare by reference for non-record members (IReadOnlySet<string> is
+        // a HashSet<string> instance here) — this pins that behaviour rather than
+        // asserting a value-equality guarantee the record does NOT provide.
+        Assert.NotEqual(a, b);
+        Assert.Equal(a.CodeunitNames, b.CodeunitNames);
+    }
+
+    [Fact]
+    public void CanConstrainByCodeunitNamesOnly()
+    {
+        var filter = new TestFilter(new HashSet<string> { "Sales-Post" }, null);
+        Assert.Contains("Sales-Post", filter.CodeunitNames!);
+        Assert.Null(filter.ProcNames);
+    }
+}

--- a/AlRunner/AlStackFrame.cs
+++ b/AlRunner/AlStackFrame.cs
@@ -1,0 +1,31 @@
+// Ported from protocol-v2 (v1 architecture, PR #1607) as part of #1641 — the type
+// shapes are architecture-agnostic (plain records describing one AL stack frame /
+// error-kind bucket for the streaming wire protocol), so they carry over unchanged.
+namespace AlRunner;
+
+public enum FramePresentationHint
+{
+    Normal,
+    Subtle,
+    Deemphasize,
+    Label
+}
+
+public enum AlErrorKind
+{
+    Assertion,
+    Runtime,
+    Compile,
+    Setup,
+    Timeout,
+    Unknown
+}
+
+public record AlStackFrame(
+    string? File,
+    int? Line,
+    int? Column,
+    bool IsUserCode,
+    string? Name,
+    FramePresentationHint Hint
+);

--- a/AlRunner/ErrorClassifier.cs
+++ b/AlRunner/ErrorClassifier.cs
@@ -1,0 +1,69 @@
+// Ported from protocol-v2 (v1 architecture, PR #1609) as part of #1641.
+namespace AlRunner;
+
+/// <summary>
+/// Execution-time signal about whether an exception was thrown inside a [Test] proc
+/// (vs. setup / instantiation before any test proc ran). Drives Setup-vs-Runtime
+/// classification.
+/// </summary>
+public record TestExecutionContext(bool InsideTestProc);
+
+/// <summary>
+/// Classifies a managed Exception into an <see cref="AlErrorKind"/> bucket so a
+/// consumer (e.g. the VS Code extension) can vary the failure UI (assertion diff,
+/// runtime stack, compile errors, etc.).
+///
+/// NOTE on the Assertion bucket in v2: v1 ran AL through a Roslyn-emitted C# pipeline
+/// with its own <c>AlRunner.Runtime.AssertException</c> type, so a failed
+/// <c>Assert.AreEqual</c> call was distinguishable from a plain <c>Error()</c> by
+/// exception type. v2 runs unmodified MS/ISV DLLs in-process (see
+/// .claude/rules/precompiled-dll-respect.md); AL's <c>Error()</c> — which is what
+/// BC's real "Library Assert" / "Assert" test-library codeunits call internally —
+/// always surfaces as the same <c>NavNCLDialogException</c> (verified empirically:
+/// a bare <c>Error('boom')</c> in an AL test throws
+/// <c>Microsoft.Dynamics.Nav.Types.NavNCLDialogException</c>, and BC's Assert
+/// codeunits use that same call under the hood). There is therefore no distinct
+/// runtime type to match on for the Assertion bucket today; those failures fall
+/// through to Runtime. Distinguishing them would require inspecting the AL call
+/// stack for a frame in a known assert-helper object, which is out of scope here —
+/// see #1641's follow-up. The type-name heuristic below is kept (harmless,
+/// forward-compatible) in case a future in-scope helper does throw a distinctly
+/// named exception.
+/// </summary>
+public static class ErrorClassifier
+{
+    /// <summary>
+    /// Classify the exception. A null exception maps to <see cref="AlErrorKind.Unknown"/>.
+    /// </summary>
+    public static AlErrorKind Classify(Exception? ex, TestExecutionContext ctx)
+    {
+        if (ex == null) return AlErrorKind.Unknown;
+
+        // Assertion: match on suffix so we don't hard-couple to one runtime's exact type
+        // identity. See the class-level note: no in-scope v2 type matches this today.
+        var typeName = ex.GetType().Name;
+        if (typeName.EndsWith("AssertException", StringComparison.Ordinal)
+            || typeName.EndsWith("AssertionException", StringComparison.Ordinal))
+        {
+            return AlErrorKind.Assertion;
+        }
+
+        // Timeout: cancellation thrown by the cooperative timeout mechanism
+        // (TestExecutor.InvokeWithTimeout).
+        if (ex is OperationCanceledException) return AlErrorKind.Timeout;
+
+        // Compile: the AL emit/compile pipeline wraps errors in a custom exception.
+        // Match on type-name suffix (same rationale as Assertion).
+        if (typeName.EndsWith("CompilationFailedException", StringComparison.Ordinal)
+            || typeName.EndsWith("CompileErrorException", StringComparison.Ordinal))
+        {
+            return AlErrorKind.Compile;
+        }
+
+        // Anything thrown before we entered a [Test] proc (codeunit instantiation,
+        // install-trigger seeding) is a setup/init failure.
+        if (!ctx.InsideTestProc) return AlErrorKind.Setup;
+
+        return AlErrorKind.Runtime;
+    }
+}

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -306,22 +306,9 @@ for (int i = 0; i < args.Length; i++)
     // --test-isolation and --isolation are aliases (v1 used the former, v2 introduced the shorter form).
     if ((args[i] == "--isolation" || args[i] == "--test-isolation") && i + 1 < args.Length)
     {
-        var mode = args[++i].ToLowerInvariant();
-        isolation = mode switch
-        {
-            // v1's --test-isolation method reset AL table/session state before every
-            // [Test] procedure (per-v1 Program.cs: doTableReset = testIsolation ==
-            // TestIsolation.Method). That is v2's TestIsolation.Test, NOT
-            // TestIsolation.Codeunit — see issue #1647. Map 'method' onto the mode
-            // that actually reproduces v1's behavior so callers that still pass the
-            // v1-idiomatic flag value (e.g. LethAL) don't silently get weaker
-            // isolation than they asked for.
-            "codeunit"             => AlRunner.TestIsolation.Codeunit,
-            "test" or "method"     => AlRunner.TestIsolation.Test,
-            "disabled"             => AlRunner.TestIsolation.Disabled,
-            _ => throw new ArgumentException(
-                $"--isolation: unknown mode '{mode}' (codeunit|test|disabled; 'method' accepted as v1 alias for test)")
-        };
+        var mode = args[++i];
+        try { isolation = AlRunner.TestIsolationParser.Parse(mode); }
+        catch (ArgumentException ex) { throw new ArgumentException($"--isolation: {ex.Message}"); }
         continue;
     }
     if (args[i].StartsWith("--"))
@@ -1706,6 +1693,14 @@ int RunServerLoop(System.IO.TextReader input, System.IO.TextWriter output)
     // miss can report which files changed (v1 `changedFiles`).
     Dictionary<string, string>? lastFileHashes = null;
 
+    // The isolation mode in effect when the server started (CLI --isolation, or
+    // TestIsolation.Codeunit if not given) — the fallback for any request that
+    // doesn't carry its own `testIsolation` field. Captured once so a request that
+    // DOES set testIsolation never leaks its mode onto a later request that
+    // doesn't (see #1616 — the whole point is per-request control, not a sticky
+    // session-wide override).
+    var defaultServerIsolation = executor.Isolation;
+
     // Readiness handshake — MUST be the first line on stdout.
     output.WriteLine("{\"ready\":true}");
     output.Flush();
@@ -1751,6 +1746,27 @@ int RunServerLoop(System.IO.TextReader input, System.IO.TextWriter output)
     // EOF — client disconnected.
     return 0;
 
+    // Sets executor.Isolation from req.TestIsolation (see #1616), falling back to
+    // defaultServerIsolation when the request doesn't specify one. Returns an
+    // error response string on an unrecognised mode, else null.
+    string? ApplyRequestIsolation(AlRunner.ServerRequest req)
+    {
+        if (req.TestIsolation == null)
+        {
+            executor.Isolation = defaultServerIsolation;
+            return null;
+        }
+        try
+        {
+            executor.Isolation = AlRunner.TestIsolationParser.Parse(req.TestIsolation);
+            return null;
+        }
+        catch (ArgumentException ex)
+        {
+            return AlRunner.ServerProtocol.Error($"testIsolation: {ex.Message}");
+        }
+    }
+
     // ── runTests: re-emit + run every requested bundle in-process, aggregating the
     // results. ──────────────────────────────────────────────────────────────────
     string HandleServerRunTests(AlRunner.ServerRequest req)
@@ -1761,6 +1777,9 @@ int RunServerLoop(System.IO.TextReader input, System.IO.TextWriter output)
         foreach (var p in req.SourcePaths)
             if (!Directory.Exists(p))
                 return AlRunner.ServerProtocol.Error($"bundle directory not found: {p}");
+
+        var isolationError = ApplyRequestIsolation(req);
+        if (isolationError != null) return isolationError;
 
         var runs = RunAllBundlesForServer(req.SourcePaths, req.PackagePaths, asm => executor.Run(asm));
 
@@ -1803,6 +1822,9 @@ int RunServerLoop(System.IO.TextReader input, System.IO.TextWriter output)
         foreach (var p in req.SourcePaths)
             if (!Directory.Exists(p))
                 return AlRunner.ServerProtocol.Error($"bundle directory not found: {p}");
+
+        var isolationError = ApplyRequestIsolation(req);
+        if (isolationError != null) return isolationError;
 
         var runs = RunAllBundlesForServer(req.SourcePaths, req.PackagePaths, RunFirstCodeunitOnRun);
 

--- a/AlRunner/ServerProtocol.cs
+++ b/AlRunner/ServerProtocol.cs
@@ -28,6 +28,16 @@ public sealed class ServerRequest
     [JsonPropertyName("code")] public string? Code { get; set; }
     /// <summary>Opt-in to variable capture on <c>execute</c> (v1 field; not yet supported in v2).</summary>
     [JsonPropertyName("captureValues")] public bool? CaptureValues { get; set; }
+    /// <summary>
+    /// "codeunit" (default) | "test"/"method" | "disabled" — see <see cref="TestIsolationParser"/>.
+    /// Null = the server's existing default (TestIsolation.Codeunit), matching the
+    /// CLI's own default. Threaded into PipelineOptions.TestIsolation-equivalent
+    /// (TestExecutor.Isolation) before RunTests/execute — see #1616: without this
+    /// field, --server had no way to ask for per-method isolation, so tests that
+    /// depend on per-method reset cross-pollute under --server even though the
+    /// identical CLI invocation with --test-isolation method passes.
+    /// </summary>
+    [JsonPropertyName("testIsolation")] public string? TestIsolation { get; set; }
 }
 
 /// <summary>A file-grouped compilation error block, matching v1's response shape.</summary>

--- a/AlRunner/StackFrameMapper.cs
+++ b/AlRunner/StackFrameMapper.cs
@@ -1,0 +1,86 @@
+// New for v2, part of #1641 (protocol-v2 port). v1's StackFrameMapper parsed .NET
+// exception stack traces (a Roslyn-emitted C# pipeline meant .NET frames WERE the
+// AL frames). v2 runs unmodified MS/ISV DLLs in-process and captures the AL call
+// stack separately via AlRunner.Infrastructure.AlCallStackCapture, which formats
+// it in BC's own service-tier call-stack STRING syntax:
+//   "ObjectName"(ObjectType N).MethodName[(Trigger)][ line L][ - App by Pub version V]
+// one frame per line, deepest (closest to the throw) first. This mapper parses
+// THAT format, not a .NET stack trace.
+using System.Text.RegularExpressions;
+
+namespace AlRunner;
+
+public static class StackFrameMapper
+{
+    // Groups: obj (quotes doubled per BC's AppendQuoted), type, num, method,
+    // trigger, line, app, pub, ver. The app/pub/ver suffix and the line segment
+    // are both optional (AlCallStackCapture.FormatFrame omits line when
+    // GetRelativeLine returns -1, and omits the app suffix when no assembly
+    // metadata was registered for that scope's assembly).
+    private static readonly Regex FramePattern = new Regex(
+        @"^""(?<obj>(?:[^""]|"""")*)""\((?<type>[^\s)]+)\s+(?<num>\d+)\)\.(?<method>[^\s(]+)"
+        + @"(?<trigger>\(Trigger\))?"
+        + @"(?:\s+line\s+(?<line>\d+))?"
+        + @"(?:\s+-\s+(?<app>.*?)\s+by\s+(?<pub>.*?)\s+version\s+(?<ver>.*))?$",
+        RegexOptions.Compiled);
+
+    /// <summary>
+    /// Parse a captured AL call-stack string (see
+    /// <see cref="AlRunner.Infrastructure.AlCallStackCapture.GetCaptured()"/>) into
+    /// structured frames, one per line, in the same deepest-first order as the input.
+    /// Every scope AlCallStackCapture records has a non-null ApplicationObject — real
+    /// AL code, never runner/C# plumbing — so every returned frame has
+    /// <see cref="AlStackFrame.IsUserCode"/> = true and
+    /// <see cref="AlStackFrame.Hint"/> = <see cref="FramePresentationHint.Normal"/>.
+    /// A line that doesn't match BC's format is kept verbatim as <c>Name</c> rather
+    /// than dropped or given an invented Line/File — see .claude/rules/loud-failures.md
+    /// (never fabricate a value the source didn't actually carry).
+    /// </summary>
+    public static List<AlStackFrame> Walk(string? alStack)
+    {
+        var result = new List<AlStackFrame>();
+        if (string.IsNullOrWhiteSpace(alStack)) return result;
+
+        foreach (var rawLine in alStack.Split('\n'))
+        {
+            var line = rawLine.TrimEnd('\r').Trim();
+            if (line.Length == 0) continue;
+
+            var m = FramePattern.Match(line);
+            if (!m.Success)
+            {
+                result.Add(new AlStackFrame(
+                    File: null, Line: null, Column: null,
+                    IsUserCode: true, Name: line, Hint: FramePresentationHint.Normal));
+                continue;
+            }
+
+            var name = $"\"{m.Groups["obj"].Value}\"({m.Groups["type"].Value} {m.Groups["num"].Value}).{m.Groups["method"].Value}"
+                       + (m.Groups["trigger"].Success ? "(Trigger)" : "");
+            int? lineNo = m.Groups["line"].Success ? int.Parse(m.Groups["line"].Value) : null;
+
+            result.Add(new AlStackFrame(
+                File: null, Line: lineNo, Column: null,
+                IsUserCode: true, Name: name, Hint: FramePresentationHint.Normal));
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Un-double BC's escaped quotes in a frame's object-name segment (the part
+    /// between the outer quotes in <see cref="AlStackFrame.Name"/>), for display.
+    /// Returns null if the frame's Name doesn't have the quoted-object-name shape
+    /// (e.g. it's a raw unparsed line).
+    /// </summary>
+    private static readonly Regex ObjectNamePrefix = new Regex(
+        @"^""(?<obj>(?:[^""]|"""")*)""\(", RegexOptions.Compiled);
+
+    public static string? UnquoteObjectName(AlStackFrame frame)
+    {
+        if (frame.Name == null) return null;
+        var m = ObjectNamePrefix.Match(frame.Name);
+        if (!m.Success) return null;
+        return m.Groups["obj"].Value.Replace("\"\"", "\"");
+    }
+}

--- a/AlRunner/TestExecutor.cs
+++ b/AlRunner/TestExecutor.cs
@@ -20,6 +20,35 @@ public enum TestOutcome { Pass, Fail, Error }
 /// </summary>
 public enum TestIsolation { Codeunit, Test, Disabled }
 
+public static class TestIsolationParser
+{
+    /// <summary>
+    /// Parse the CLI/--server <c>testIsolation</c> mode string. Shared by
+    /// Program.cs's <c>--isolation</c>/<c>--test-isolation</c> CLI parsing and the
+    /// <c>runTests</c>/<c>execute</c> server commands (see #1616) so the two entry
+    /// points can never silently drift onto different mappings.
+    /// </summary>
+    public static TestIsolation Parse(string mode)
+    {
+        var m = mode.ToLowerInvariant();
+        return m switch
+        {
+            "codeunit"         => TestIsolation.Codeunit,
+            // v1's --test-isolation method reset AL table/session state before every
+            // [Test] procedure (per v1 Program.cs: doTableReset = testIsolation ==
+            // TestIsolation.Method). That is v2's TestIsolation.Test, NOT
+            // TestIsolation.Codeunit — see issue #1647. Map 'method' onto the mode
+            // that actually reproduces v1's behavior so callers that still pass the
+            // v1-idiomatic value (e.g. LethAL) don't silently get weaker isolation
+            // than they asked for.
+            "test" or "method" => TestIsolation.Test,
+            "disabled"         => TestIsolation.Disabled,
+            _ => throw new ArgumentException(
+                $"unknown test isolation mode '{mode}' (codeunit|test|disabled; 'method' accepted as v1 alias for test)")
+        };
+    }
+}
+
 public sealed record TestResult(string Codeunit, string Method, TestOutcome Outcome,
                                 string? Message, string? FullException, TimeSpan Duration,
                                 string? AlCallStack = null,

--- a/AlRunner/TestFilter.cs
+++ b/AlRunner/TestFilter.cs
@@ -1,0 +1,15 @@
+// Ported from protocol-v2 (v1 architecture, PR #1607) as part of #1641 — a plain
+// record with no architecture dependency.
+namespace AlRunner;
+
+/// <summary>
+/// Structured filter for a <c>runTests</c> request, distinct from
+/// <see cref="TestExecutor.TestFilter"/> (a single substring filter). Both fields
+/// are optional; nulls = no constraint. When both are set, a test must match both
+/// filters (AND). Codeunit/proc name matching is case-insensitive exact match on
+/// the AL name (not a substring).
+/// </summary>
+public record TestFilter(
+    IReadOnlySet<string>? CodeunitNames,
+    IReadOnlySet<string>? ProcNames
+);

--- a/docs/server-mode.md
+++ b/docs/server-mode.md
@@ -38,7 +38,12 @@ al-runner --server [--package-cache PATH ...] [--cache DIR]
   "packagePaths": ["/extra"],   // optional: extra .app caches, augment server defaults
   "stubPaths": [],              // v1 field, ignored in v2 (no stubs layer)
   "code": "...",                // execute only (inline AL) — not yet supported
-  "captureValues": false        // execute only — not yet supported
+  "captureValues": false,       // execute only — not yet supported
+  "testIsolation": "codeunit"   // optional: "codeunit" (default) | "test"/"method" | "disabled"
+                                 // — see #1616. Applies to this request only; a later
+                                 // request that omits the field falls back to the
+                                 // server's own startup default, not the previous
+                                 // request's value.
 }
 ```
 

--- a/protocol-v2.schema.json
+++ b/protocol-v2.schema.json
@@ -1,0 +1,148 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/StefanMaron/BusinessCentral.AL.Runner/schemas/protocol-v2.json",
+  "title": "AL.Runner Server Protocol v2",
+  "description": "Newline-delimited JSON. A `runtests` request emits zero or more `test` lines, optional `progress` lines, then exactly one `summary` line. Each line is a separate JSON document. NOTE (as ported for #1641): the v2 architecture's --server loop does not emit this shape yet — it still returns one v1-compatible response line per request (see AlRunner/ServerProtocol.cs). This file is the target contract for the streaming port; the NDJSON emitter that produces it is tracked as follow-up work on #1641.",
+  "definitions": {
+    "AlStackFrame": {
+      "type": "object",
+      "required": ["name"],
+      "properties": {
+        "name": { "type": "string" },
+        "source": {
+          "type": "object",
+          "properties": {
+            "path": { "type": "string" },
+            "name": { "type": "string" }
+          }
+        },
+        "line": { "type": "integer", "minimum": 1 },
+        "column": { "type": "integer", "minimum": 1 },
+        "presentationHint": {
+          "type": "string",
+          "enum": ["normal", "subtle", "deemphasize", "label"]
+        }
+      }
+    },
+    "ErrorKind": {
+      "type": "string",
+      "enum": ["assertion", "runtime", "compile", "setup", "timeout", "unknown"]
+    },
+    "TestEvent": {
+      "type": "object",
+      "required": ["type", "name", "status"],
+      "properties": {
+        "type": { "const": "test" },
+        "name": { "type": "string" },
+        "status": { "enum": ["pass", "fail", "error"] },
+        "durationMs": { "type": "integer", "minimum": 0 },
+        "message": { "type": "string" },
+        "errorKind": { "$ref": "#/definitions/ErrorKind" },
+        "alSourceFile": { "type": "string" },
+        "alSourceLine": { "type": "integer", "minimum": 1 },
+        "alSourceColumn": { "type": "integer", "minimum": 1 },
+        "stackFrames": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/AlStackFrame" }
+        },
+        "stackTrace": { "type": "string" },
+        "messages": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "capturedValues": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "scopeName": { "type": "string" },
+              "variableName": { "type": "string" },
+              "value": {},
+              "statementId": { "type": "integer" }
+            }
+          }
+        }
+      }
+    },
+    "FileCoverage": {
+      "type": "object",
+      "required": ["file", "lines", "totalStatements", "hitStatements"],
+      "properties": {
+        "file": { "type": "string" },
+        "lines": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["line", "hits"],
+            "properties": {
+              "line": { "type": "integer", "minimum": 1 },
+              "hits": { "type": "integer", "minimum": 0 }
+            }
+          }
+        },
+        "totalStatements": { "type": "integer", "minimum": 0 },
+        "hitStatements": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "Summary": {
+      "type": "object",
+      "required": ["type", "exitCode", "passed", "failed", "errors", "total", "protocolVersion"],
+      "properties": {
+        "type": { "const": "summary" },
+        "exitCode": { "type": "integer" },
+        "passed": { "type": "integer", "minimum": 0 },
+        "failed": { "type": "integer", "minimum": 0 },
+        "errors": { "type": "integer", "minimum": 0 },
+        "total": { "type": "integer", "minimum": 0 },
+        "cached": { "type": "boolean" },
+        "cancelled": { "type": "boolean" },
+        "changedFiles": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "compilationErrors": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "file": { "type": "string" },
+              "errors": {
+                "type": "array",
+                "items": { "type": "string" }
+              }
+            }
+          }
+        },
+        "coverage": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/FileCoverage" }
+        },
+        "protocolVersion": { "const": 2 }
+      }
+    },
+    "Ack": {
+      "type": "object",
+      "required": ["type", "command"],
+      "properties": {
+        "type": { "const": "ack" },
+        "command": { "type": "string" },
+        "noop": { "type": "boolean" }
+      }
+    },
+    "Progress": {
+      "type": "object",
+      "required": ["type"],
+      "properties": {
+        "type": { "const": "progress" },
+        "completed": { "type": "integer", "minimum": 0 },
+        "total": { "type": "integer", "minimum": 0 }
+      }
+    }
+  },
+  "oneOf": [
+    { "$ref": "#/definitions/TestEvent" },
+    { "$ref": "#/definitions/Summary" },
+    { "$ref": "#/definitions/Ack" },
+    { "$ref": "#/definitions/Progress" }
+  ]
+}


### PR DESCRIPTION
Partial slice of #1641 — does **not** close it. Remaining scope (left for follow-up PRs, see #1641 for the full breakdown): the NDJSON streaming `runTests` loop, the `cancel` command, and wiring `ErrorClassifier`/`StackFrameMapper` output into the wire protocol's `errorKind`/`stackFrames` fields.

## What's in this PR

- **`protocol-v2.schema.json`, `AlRunner/AlStackFrame.cs`, `AlRunner/TestFilter.cs`** — harvested unchanged from the closed v1 PR #1607 (pure type/schema definitions, no architecture dependency). Not yet wired into the request/response path — added as building blocks, matching how #1607 itself only added these types without wiring.
- **`AlRunner/ErrorClassifier.cs`** — ported from #1609. Kept the same classification logic, with a documented note: v1 had its own `AssertException` type from the Roslyn-emitted pipeline, but v2 runs unmodified MS/ISV DLLs in-process, and I confirmed empirically that AL's `Error()` — which is what BC's real Assert/Library Assert codeunits call under the hood — always throws `Microsoft.Dynamics.Nav.Types.NavNCLDialogException`, the same type a plain `Error()` call throws. There's no type to key the `Assertion` bucket off today, so those failures currently classify as `Runtime`. Distinguishing them would need AL-call-stack inspection (checking for a known assert-helper object on the stack), which I've left out rather than guess at unspecified design — noted as follow-up.
- **`AlRunner/StackFrameMapper.cs`** — new, not harvested. v1's mapper parsed .NET exception stack traces (v1's AL ran through a Roslyn-emitted C# pipeline, so .NET frames *were* AL frames). v2 captures the AL call stack separately via `AlCallStackCapture`, in BC's own service-tier string format (`"ObjectName"(ObjectType N).Method line L - App by Pub version V`). This new mapper parses that format instead. Since every scope `AlCallStackCapture` records is real AL (no C# infra frames mixed in, unlike v1), every parsed frame is `IsUserCode: true` / `Hint: Normal` — documented in the class comment.
- **`testIsolation` field on `--server`'s `runTests`/`execute` requests** — closes #1616. The CLI's `--test-isolation`/`--isolation` flag had no `--server` equivalent, so tests relying on per-method isolation cross-pollute under `--server` even though the identical CLI invocation passes. Added `TestIsolationParser` (shared by both the CLI flag parser and the new server field, so they can't drift), wired into both server commands. Explicitly non-sticky: a request that doesn't set `testIsolation` falls back to the server's own startup default, never a previous request's value (tested).

## Testing

- RED→GREEN: `StackFrameMapperTests`, `ErrorClassifierTests`, `TestFilterTests` (unit, pure).
- `ServerTestIsolationTests` — real spawned-runner e2e tests (need `~/.bcartifacts.cache`, skip otherwise) proving: default (no field) still cross-pollutes with the pre-existing Codeunit default, `testIsolation: "method"` fixes it, the field is per-request (not sticky), and an unknown mode returns a structured error.
- Full `AlRunner.Tests` suite: 248/248 passed locally (no regressions).

Closes #1616.