### PR TITLE
fix(win32stubs): never intercept Win32 imports on Windows

### DIFF
--- a/AlRunner.Tests/Win32StubsLoudFailureTests.cs
+++ b/AlRunner.Tests/Win32StubsLoudFailureTests.cs
@@ -124,6 +124,35 @@ public class Win32StubsLoudFailureTests
     }
 
     /// <summary>
+    /// Issue #1673: Register() must be a no-op on Windows. There, kernel32/user32 ARE the
+    /// real libraries and the default loader is the correct resolution — intercepting them
+    /// turned #1669's loud Linux failure into a Windows regression (WindowsLanguageHelper's
+    /// cctor dies on the first TextConstant, killing every install trigger). The shim exists
+    /// to fake Win32 on Linux; on Windows the real thing is the answer. Asserted via the
+    /// registration latch because the resolver event is not observable from outside.
+    /// </summary>
+    [Fact]
+    public void Register_OnWindows_IsNoOp()
+    {
+        if (!OperatingSystem.IsWindows()) return;
+        Win32Stubs.Register();
+        Assert.False(Win32Stubs.RegisteredForTests);
+    }
+
+    /// <summary>
+    /// Companion direction: on non-Windows the shim must still register — #1673's fix is an
+    /// early return for Windows, not a disable. Would this pass if Register() were gutted to
+    /// always return? No — this asserts the latch flips on Linux/macOS.
+    /// </summary>
+    [Fact]
+    public void Register_OnNonWindows_Registers()
+    {
+        if (OperatingSystem.IsWindows()) return;
+        Win32Stubs.Register();
+        Assert.True(Win32Stubs.RegisteredForTests);
+    }
+
+    /// <summary>
     /// RED-shaped negative: an override pointing at a nonexistent path must fail loudly and
     /// name the bad path, not silently fall through to trying to build from source.
     /// </summary>

--- a/AlRunner/Win32Stubs.cs
+++ b/AlRunner/Win32Stubs.cs
@@ -36,6 +36,13 @@ internal static class Win32Stubs
 
     public static void Register()
     {
+        // Issue #1673: never intercept on Windows. kernel32/user32 etc. are the REAL
+        // libraries there and the default loader is the correct resolution; the shim
+        // exists solely to fake Win32 on Linux. Note the compiler probe below could
+        // never succeed on Windows anyway (IsOnPath checks for files named exactly
+        // "cc"/"gcc"/"clang" — never "clang.exe"), and "fixing" that probe instead
+        // would be worse: it would build and load a fake kernel32 over the real one.
+        if (OperatingSystem.IsWindows()) return;
         if (_registered) return;
         _registered = true;
 
@@ -59,6 +66,10 @@ internal static class Win32Stubs
     /// production. Never read from production code paths other than
     /// <see cref="GetOrBuild"/>'s own base-directory resolution below.</summary>
     internal static string? BaseDirectoryForTests;
+
+    /// <summary>Test-only: whether <see cref="Register"/> actually installed the resolver.
+    /// The resolver hook itself is not observable from outside, so tests assert the latch.</summary>
+    internal static bool RegisteredForTests => _registered;
 
     private static void TryRegister(Assembly asm)
     {


### PR DESCRIPTION
Closes #1673

## What

`Win32Stubs.Register()` now returns immediately on Windows. The shim exists solely to fake Win32 libraries on Linux; on Windows `kernel32`/`user32` are the real libraries and the default loader is the correct resolution.

## Why the fix is the early return and not a probe repair

Two findings beyond the issue:

1. **The compiler probe is unsatisfiable on Windows.** `IsOnPath` checks `File.Exists(Path.Combine(dir, "clang"))` — never `clang.exe` — so even a machine with LLVM installed and on PATH gets "none of [cc, gcc, clang] is on PATH" (verified live: `C:\Program Files\LLVM\bin\clang.exe` present, identical error). The error message's remediation #1 is a dead end on Windows.
2. **"Fixing" the probe would be worse.** If it found `clang.exe`, the runner would build the Linux stub shim and load it *over the real `kernel32.dll`* — locale APIs answering with canned stub data instead of Windows' real answers, silently. The probe bug is currently the only thing preventing that. The early return removes the whole hazard.

A code comment in `Register()` pins both points so a future probe "improvement" doesn't reintroduce the interception.

## RED → GREEN

**Unit pair** (`Win32StubsLoudFailureTests`), asserting the registration latch:

- `Register_OnWindows_IsNoOp` — FAIL at `67359170` on Windows, PASS with fix
- `Register_OnNonWindows_Registers` — pins that the fix is an early return for Windows, not a disable; PASS on Linux before and after

**Acceptance criteria from #1673**, all verified on Windows 11 / net8.0 / BC 28.1.49838.50794:

| Criterion | Before (stock `67359170`) | After |
|---|---|---|
| `tests/runner-extras/install-trigger-text-constant` on Windows | `0P/0F/0E across 0 tests, 1 suite errors`, exit 3, inner exception = `Win32Stubs: cannot resolve the Win32 import 'kernel32.dll'` | `2P/0F/0E across 2 tests, 0 suite errors`, exit 0 |
| Empty-dir startup probe logs no `NCLManagedAdapter` `TypeInitializationException` | 1 occurrence | 0 occurrences |
| #1669's loud failure still fires on Linux without a compiler | — | message content + compiler-selection logic pinned by the existing `Win32StubsLoudFailureTests`, all 11 green on WSL2 Ubuntu at this commit |

Full `AlRunner.Tests` on Windows: 221 passed, 3 failed — the same 3 fail at stock `67359170` (`GetOrBuild_HonoursSoOverride_WhenFileExists` spawns `cc` via `Process.Start`, which throws on Windows instead of hitting the exit-code skip guard; two `SuiteEnumerationTests`). Pre-existing Windows-only failures, untouched by this change; happy to file them separately.

Note for running the reproducer bundle locally: it needs `Microsoft/Application` + `Microsoft/System` resolvable via `--package-cache` (see #1678 for why `--auto-provision` doesn't cover this today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FxZ3j5PWcgtPSCL2mEMy3W
