### PR TITLE
feat(server): stream runTests as protocol-v2 NDJSON (second slice of #1641)

### DIFF
--- a/AlRunner.Tests/CliServer.cs
+++ b/AlRunner.Tests/CliServer.cs
@@ -110,6 +110,48 @@ public sealed class CliServer : IAsyncDisposable
             ?? throw new Exception($"Server closed stdout before responding to: {jsonRequest}\n--- stderr ---\n{StdErr}");
     }
 
+    /// <summary>
+    /// Send a JSON request and read lines until the streaming terminator: either
+    /// the protocol-v2 <c>{"type":"summary"}</c> line (runTests' streaming shape —
+    /// see #1641), or the first line that isn't <c>type: test</c>/<c>progress</c>
+    /// (a single-line error/ack response from a command that doesn't stream).
+    /// Returns every line read, in order, including the terminator.
+    /// </summary>
+    public async Task<List<string>> SendRequestStreamingAsync(string jsonRequest, TimeSpan? timeout = null)
+    {
+        await _process.StandardInput.WriteLineAsync(jsonRequest);
+        await _process.StandardInput.FlushAsync();
+
+        var t = timeout ?? TimeSpan.FromSeconds(120);
+        var lines = new List<string>();
+        while (true)
+        {
+            var readTask = _process.StandardOutput.ReadLineAsync();
+            var completed = await Task.WhenAny(readTask, Task.Delay(t));
+            if (completed != readTask)
+                throw new TimeoutException(
+                    $"No response within {t.TotalSeconds:F0}s to: {jsonRequest}\n--- stderr ---\n{StdErr}");
+            var line = await readTask
+                ?? throw new Exception($"Server closed stdout before completing: {jsonRequest}\n--- stderr ---\n{StdErr}");
+            lines.Add(line);
+
+            string? type = null;
+            try
+            {
+                using var doc = System.Text.Json.JsonDocument.Parse(line);
+                if (doc.RootElement.TryGetProperty("type", out var tEl))
+                    type = tEl.GetString();
+            }
+            catch (System.Text.Json.JsonException)
+            {
+                // Not JSON (shouldn't happen) — treat as terminal so callers see it.
+            }
+            if (type == "summary") break;
+            if (type != "test" && type != "progress") break; // single-line error/ack response
+        }
+        return lines;
+    }
+
     public async Task<bool> WaitForExitAsync(TimeSpan timeout)
     {
         using var cts = new CancellationTokenSource(timeout);

--- a/AlRunner.Tests/ProtocolV2Streaming.cs
+++ b/AlRunner.Tests/ProtocolV2Streaming.cs
@@ -1,0 +1,29 @@
+using System.Text.Json;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// Shared assertion helper for the protocol-v2 streaming <c>runTests</c> shape
+/// (see #1641 / protocol-v2.schema.json) — splits a line sequence returned by
+/// <see cref="CliServer.SendRequestStreamingAsync"/> into its per-test
+/// <c>{"type":"test"}</c> events and the single terminal
+/// <c>{"type":"summary"}</c> line.
+/// </summary>
+internal static class ProtocolV2Streaming
+{
+    public static (List<JsonElement> TestEvents, JsonElement Summary) Split(IReadOnlyList<string> lines)
+    {
+        var events = new List<JsonElement>();
+        JsonElement? summary = null;
+        foreach (var line in lines)
+        {
+            var el = JsonSerializer.Deserialize<JsonElement>(line);
+            var type = el.TryGetProperty("type", out var t) ? t.GetString() : null;
+            if (type == "summary") summary = el;
+            else if (type == "test") events.Add(el);
+        }
+        Assert.True(summary.HasValue, $"no summary line in: {string.Join(" | ", lines)}");
+        return (events, summary!.Value);
+    }
+}

--- a/AlRunner.Tests/ServerStreamingTests.cs
+++ b/AlRunner.Tests/ServerStreamingTests.cs
@@ -1,0 +1,147 @@
+using System.Text.Json;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// #1641 (streaming runTests slice): --server's <c>runTests</c> now emits the
+/// protocol-v2 NDJSON shape (<c>protocol-v2.schema.json</c>) — one
+/// <c>{"type":"test"}</c> line per completed test, then exactly one
+/// <c>{"type":"summary", protocolVersion:2}</c> terminator — instead of a single
+/// v1-shaped response object. <c>execute</c>/<c>shutdown</c>/unknown-command
+/// responses are unaffected (still one line).
+///
+/// These spawn the real runner and need the BC artifact caches present
+/// (~/.bcartifacts.cache); when absent, they skip rather than fail.
+/// </summary>
+[Collection("server-serial")]
+public class ServerStreamingTests
+{
+    private static bool ArtifactsPresent()
+    {
+        var home = Environment.GetEnvironmentVariable("HOME");
+        if (string.IsNullOrEmpty(home)) return false;
+        return Directory.Exists(Path.Combine(home, ".bcartifacts.cache", "sandbox"));
+    }
+
+    // One passing test, one failing test (with a recognisable Error() message) —
+    // exercises both status branches of the streamed `test` event shape.
+    private static string MakeMixedBundle()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "al-runner-server-streaming", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "app.json"), """
+        {
+          "id": "a1b2c3d4-e5f6-4708-a9ba-cbdcedfe0f11",
+          "name": "Runner Extras - Server Streaming Probe",
+          "publisher": "AL Runner",
+          "version": "1.0.0.0",
+          "dependencies": [],
+          "platform": "1.0.0.0",
+          "application": "1.0.0.0",
+          "idRanges": [ { "from": 60200, "to": 60209 } ],
+          "runtime": "14.0"
+        }
+        """);
+        File.WriteAllText(Path.Combine(dir, "StreamingTest.Codeunit.al"), """
+        codeunit 60200 "Server Streaming Probe SX"
+        {
+            Subtype = Test;
+
+            [Test]
+            procedure PassingTest()
+            begin
+            end;
+
+            [Test]
+            procedure FailingTest()
+            begin
+                Error('streaming-probe-boom');
+            end;
+        }
+        """);
+        return dir;
+    }
+
+    private static string RunTestsReq(string bundleDir)
+        => JsonSerializer.Serialize(new
+        {
+            command = "runTests",
+            sourcePaths = new[] { bundleDir },
+            packagePaths = Array.Empty<string>(),
+        });
+
+    [Fact]
+    public async Task RunTests_StreamsOneTestEventPerTest_ThenSummary()
+    {
+        if (!ArtifactsPresent()) { Console.Error.WriteLine("[skip] BC artifact cache not present"); return; }
+
+        var bundle = MakeMixedBundle();
+        var cacheDir = Path.Combine(Path.GetTempPath(), "al-runner-server-streaming-cache", Guid.NewGuid().ToString("N"));
+        await using var server = await CliServer.StartAsync(new[] { "--cache", cacheDir });
+
+        var lines = await server.SendRequestStreamingAsync(RunTestsReq(bundle));
+
+        // Exactly 2 test events (proves streaming happened per-test, not a
+        // single batch line), each BEFORE the summary terminator.
+        var (events, summary) = ProtocolV2Streaming.Split(lines);
+        Assert.Equal(2, events.Count);
+        Assert.Equal("summary", JsonSerializer.Deserialize<JsonElement>(lines[^1]).GetProperty("type").GetString());
+
+        var pass = events.Single(e => e.GetProperty("name").GetString()!.EndsWith("PassingTest"));
+        Assert.Equal("pass", pass.GetProperty("status").GetString());
+        Assert.True(pass.GetProperty("durationMs").GetInt64() >= 0);
+
+        var fail = events.Single(e => e.GetProperty("name").GetString()!.EndsWith("FailingTest"));
+        Assert.Equal("fail", fail.GetProperty("status").GetString());
+        Assert.Contains("streaming-probe-boom", fail.GetProperty("message").GetString());
+
+        // Summary carries the protocol-v2 contract and matches the streamed events.
+        Assert.Equal(2, summary.GetProperty("protocolVersion").GetInt32());
+        Assert.Equal(1, summary.GetProperty("passed").GetInt32());
+        Assert.Equal(1, summary.GetProperty("failed").GetInt32());
+        Assert.Equal(0, summary.GetProperty("errors").GetInt32());
+        Assert.Equal(2, summary.GetProperty("total").GetInt32());
+        Assert.Equal(1, summary.GetProperty("exitCode").GetInt32());
+    }
+
+    [Fact]
+    public async Task RunTests_MissingSourcePaths_ReturnsSingleErrorLine_NoTestOrSummaryLines()
+    {
+        if (!ArtifactsPresent()) { Console.Error.WriteLine("[skip] BC artifact cache not present"); return; }
+
+        await using var server = await CliServer.StartAsync();
+        var lines = await server.SendRequestStreamingAsync(
+            JsonSerializer.Serialize(new { command = "runTests" }));
+
+        Assert.Single(lines);
+        var d = JsonSerializer.Deserialize<JsonElement>(lines[0]);
+        Assert.True(d.TryGetProperty("error", out var err));
+        Assert.Contains("sourcePaths", err.GetString());
+        Assert.False(d.TryGetProperty("type", out _));
+    }
+
+    [Fact]
+    public async Task Execute_StillReturnsSingleLine_NotStreamed()
+    {
+        if (!ArtifactsPresent()) { Console.Error.WriteLine("[skip] BC artifact cache not present"); return; }
+
+        var bundle = MakeMixedBundle();
+        var cacheDir = Path.Combine(Path.GetTempPath(), "al-runner-server-streaming-exec-cache", Guid.NewGuid().ToString("N"));
+        await using var server = await CliServer.StartAsync(new[] { "--cache", cacheDir });
+
+        // execute (run-mode) is unaffected by the streaming change — still one
+        // v1-shaped response line, no "type" discriminator.
+        var lines = await server.SendRequestStreamingAsync(JsonSerializer.Serialize(new
+        {
+            command = "execute",
+            sourcePaths = new[] { bundle },
+            packagePaths = Array.Empty<string>(),
+        }));
+
+        Assert.Single(lines);
+        var d = JsonSerializer.Deserialize<JsonElement>(lines[0]);
+        Assert.True(d.TryGetProperty("exitCode", out _));
+        Assert.False(d.TryGetProperty("type", out _));
+    }
+}

--- a/AlRunner.Tests/ServerTestIsolationTests.cs
+++ b/AlRunner.Tests/ServerTestIsolationTests.cs
@@ -99,8 +99,8 @@ public class ServerTestIsolationTests
         var cacheDir = Path.Combine(Path.GetTempPath(), "al-runner-server-isolation-cache", Guid.NewGuid().ToString("N"));
         await using var server = await CliServer.StartAsync(new[] { "--cache", cacheDir });
 
-        var r = await server.SendAsync(Req(bundle, testIsolation: null));
-        var d = JsonSerializer.Deserialize<JsonElement>(r);
+        var lines = await server.SendRequestStreamingAsync(Req(bundle, testIsolation: null));
+        var (_, d) = ProtocolV2Streaming.Split(lines);
 
         Assert.Equal(2, d.GetProperty("total").GetInt32());
         Assert.Equal(1, d.GetProperty("passed").GetInt32());
@@ -116,8 +116,8 @@ public class ServerTestIsolationTests
         var cacheDir = Path.Combine(Path.GetTempPath(), "al-runner-server-isolation-cache2", Guid.NewGuid().ToString("N"));
         await using var server = await CliServer.StartAsync(new[] { "--cache", cacheDir });
 
-        var r = await server.SendAsync(Req(bundle, testIsolation: "method"));
-        var d = JsonSerializer.Deserialize<JsonElement>(r);
+        var lines = await server.SendRequestStreamingAsync(Req(bundle, testIsolation: "method"));
+        var (_, d) = ProtocolV2Streaming.Split(lines);
 
         Assert.Equal(2, d.GetProperty("total").GetInt32());
         Assert.Equal(2, d.GetProperty("passed").GetInt32());
@@ -138,12 +138,12 @@ public class ServerTestIsolationTests
         var cacheDir = Path.Combine(Path.GetTempPath(), "al-runner-server-isolation-cache3", Guid.NewGuid().ToString("N"));
         await using var server = await CliServer.StartAsync(new[] { "--cache", cacheDir });
 
-        var r1 = await server.SendAsync(Req(bundle1, testIsolation: "method"));
-        var d1 = JsonSerializer.Deserialize<JsonElement>(r1);
+        var lines1 = await server.SendRequestStreamingAsync(Req(bundle1, testIsolation: "method"));
+        var (_, d1) = ProtocolV2Streaming.Split(lines1);
         Assert.Equal(2, d1.GetProperty("passed").GetInt32());
 
-        var r2 = await server.SendAsync(Req(bundle2, testIsolation: null));
-        var d2 = JsonSerializer.Deserialize<JsonElement>(r2);
+        var lines2 = await server.SendRequestStreamingAsync(Req(bundle2, testIsolation: null));
+        var (_, d2) = ProtocolV2Streaming.Split(lines2);
         Assert.Equal(1, d2.GetProperty("passed").GetInt32());
         Assert.Equal(1, d2.GetProperty("failed").GetInt32());
     }

--- a/AlRunner.Tests/ServerTests.cs
+++ b/AlRunner.Tests/ServerTests.cs
@@ -60,19 +60,19 @@ public class ServerTests
         await using var server = await CliServer.StartAsync(new[] { "--cache", cacheDir });
 
         // ── Phase 1: first run — must PASS (Counter 0 -> 1), cache MISS ──────────
-        var r1 = await server.SendAsync(Req("runTests", bundle));
-        var d1 = JsonSerializer.Deserialize<JsonElement>(r1);
+        var lines1 = await server.SendRequestStreamingAsync(Req("runTests", bundle));
+        var (_, d1) = ProtocolV2Streaming.Split(lines1);
         Assert.Equal(1, d1.GetProperty("passed").GetInt32());
         Assert.Equal(0, d1.GetProperty("failed").GetInt32());
         Assert.Equal(0, d1.GetProperty("errors").GetInt32());
         Assert.False(d1.GetProperty("cached").GetBoolean());
 
         // ── Phase 2: re-run with NO edit — must HIT the cache, still PASS ────────
-        var r2 = await server.SendAsync(Req("runTests", bundle));
-        var d2 = JsonSerializer.Deserialize<JsonElement>(r2);
+        var lines2 = await server.SendRequestStreamingAsync(Req("runTests", bundle));
+        var (_, d2) = ProtocolV2Streaming.Split(lines2);
         Assert.Equal(1, d2.GetProperty("passed").GetInt32());
         Assert.True(d2.GetProperty("cached").GetBoolean(),
-            $"second identical run should be a cache hit. Response: {r2}");
+            $"second identical run should be a cache hit. Lines: {string.Join(" | ", lines2)}");
 
         // ── Phase 3: edit ONLY the table trigger (+1 -> +9). The test codeunit is
         //    unchanged and still asserts Counter == '1', so the run MUST now FAIL.
@@ -83,14 +83,14 @@ public class ServerTests
         Assert.NotEqual(table, edited); // guard: the substitution actually applied
         await File.WriteAllTextAsync(tablePath, edited);
 
-        var r3 = await server.SendAsync(Req("runTests", bundle));
-        var d3 = JsonSerializer.Deserialize<JsonElement>(r3);
+        var lines3 = await server.SendRequestStreamingAsync(Req("runTests", bundle));
+        var (events3, d3) = ProtocolV2Streaming.Split(lines3);
         Assert.False(d3.GetProperty("cached").GetBoolean(),
-            $"run after an edit must be a cache miss. Response: {r3}");
+            $"run after an edit must be a cache miss. Lines: {string.Join(" | ", lines3)}");
         Assert.Equal(0, d3.GetProperty("passed").GetInt32());
         Assert.Equal(1, d3.GetProperty("failed").GetInt32());
         // The failure message proves the NEW trigger ran: Counter became 9, not 1.
-        var failMsg = d3.GetProperty("tests")[0].GetProperty("message").GetString() ?? "";
+        var failMsg = events3[0].GetProperty("message").GetString() ?? "";
         Assert.Contains("9", failMsg);
 
         // ── Phase 4: shutdown — response then process exit ──────────────────────
@@ -251,8 +251,8 @@ public class ServerTests
             sourcePaths = new[] { appDir, testDir },
             packagePaths = Array.Empty<string>(),
         });
-        var r = await server.SendAsync(req, TimeSpan.FromSeconds(180));
-        var d = JsonSerializer.Deserialize<JsonElement>(r);
+        var lines = await server.SendRequestStreamingAsync(req, TimeSpan.FromSeconds(180));
+        var (events, d) = ProtocolV2Streaming.Split(lines);
 
         // Bundle 1 (the app) has zero tests; bundle 2 (the test app) has exactly
         // one. Honouring only sourcePaths[0] would report total == 0, exitCode 0.
@@ -261,9 +261,8 @@ public class ServerTests
         Assert.Equal(0, d.GetProperty("failed").GetInt32());
         Assert.Equal(0, d.GetProperty("errors").GetInt32());
         Assert.Equal(0, d.GetProperty("exitCode").GetInt32());
-        var tests = d.GetProperty("tests");
-        Assert.Equal(1, tests.GetArrayLength());
-        Assert.Equal("AnswerIs42", tests[0].GetProperty("name").GetString()!.Split('.').Last());
+        Assert.Single(events);
+        Assert.Equal("AnswerIs42", events[0].GetProperty("name").GetString()!.Split('.').Last());
     }
 
     [Fact]

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -1709,7 +1709,11 @@ int RunServerLoop(System.IO.TextReader input, System.IO.TextWriter output)
     while ((line = input.ReadLine()) != null)
     {
         if (line.Length == 0) continue;
-        string response;
+        // Null means "already fully written to output" — currently only the
+        // streaming runTests path (see HandleServerRunTests below), which emits
+        // its own {"type":"test"}* + {"type":"summary"} lines directly instead of
+        // going through the single-response write below.
+        string? response;
         bool shuttingDown = false;
         try
         {
@@ -1720,7 +1724,8 @@ int RunServerLoop(System.IO.TextReader input, System.IO.TextWriter output)
                     response = AlRunner.ServerProtocol.Error("Invalid request (missing 'command')");
                     break;
                 case "runtests":
-                    response = HandleServerRunTests(req);
+                    HandleServerRunTests(req, output);
+                    response = null;
                     break;
                 case "execute":
                     response = HandleServerExecute(req);
@@ -1739,8 +1744,11 @@ int RunServerLoop(System.IO.TextReader input, System.IO.TextWriter output)
             response = AlRunner.ServerProtocol.Error(ex.Message);
         }
 
-        output.WriteLine(response);
-        output.Flush();
+        if (response != null)
+        {
+            output.WriteLine(response);
+            output.Flush();
+        }
         if (shuttingDown) return 0;
     }
     // EOF — client disconnected.
@@ -1767,21 +1775,49 @@ int RunServerLoop(System.IO.TextReader input, System.IO.TextWriter output)
         }
     }
 
-    // ── runTests: re-emit + run every requested bundle in-process, aggregating the
-    // results. ──────────────────────────────────────────────────────────────────
-    string HandleServerRunTests(AlRunner.ServerRequest req)
+    // ── runTests: re-emit + run every requested bundle in-process, STREAMING one
+    // {"type":"test"} NDJSON line per completed test (via TestExecutor.Run's
+    // onTestComplete hook) as it finishes, then exactly one terminal
+    // {"type":"summary"} line once every bundle has run — protocol-v2
+    // (protocol-v2.schema.json), see #1641. Writes directly to `output` rather
+    // than returning a single response string, unlike every other command.
+    // ─────────────────────────────────────────────────────────────────────────
+    void HandleServerRunTests(AlRunner.ServerRequest req, System.IO.TextWriter output)
     {
         if (req.SourcePaths == null || req.SourcePaths.Length == 0)
-            return AlRunner.ServerProtocol.Error("sourcePaths is required");
+        {
+            output.WriteLine(AlRunner.ServerProtocol.Error("sourcePaths is required"));
+            output.Flush();
+            return;
+        }
 
         foreach (var p in req.SourcePaths)
             if (!Directory.Exists(p))
-                return AlRunner.ServerProtocol.Error($"bundle directory not found: {p}");
+            {
+                output.WriteLine(AlRunner.ServerProtocol.Error($"bundle directory not found: {p}"));
+                output.Flush();
+                return;
+            }
 
         var isolationError = ApplyRequestIsolation(req);
-        if (isolationError != null) return isolationError;
+        if (isolationError != null)
+        {
+            output.WriteLine(isolationError);
+            output.Flush();
+            return;
+        }
 
-        var runs = RunAllBundlesForServer(req.SourcePaths, req.PackagePaths, asm => executor.Run(asm));
+        // Flushed after every line so a client watching stdout sees each test the
+        // instant it finishes, not batched behind the whole bundle (or worse, every
+        // bundle in a multi-sourcePaths request).
+        void OnTestComplete(TestResult t)
+        {
+            output.WriteLine(AlRunner.ServerProtocol.TestEvent(t));
+            output.Flush();
+        }
+
+        var runs = RunAllBundlesForServer(req.SourcePaths, req.PackagePaths,
+            asm => executor.Run(asm, OnTestComplete));
 
         var allTests = runs.SelectMany(r => r.Tests).ToList();
         var allCompileErrors = runs.SelectMany(r => r.CompileErrors ?? Array.Empty<CompilationErrorGroup>()).ToList();
@@ -1800,8 +1836,9 @@ int RunServerLoop(System.IO.TextReader input, System.IO.TextWriter output)
             changed = DiffServerFiles(lastFileHashes, combinedHashes);
         lastFileHashes = combinedHashes;
 
-        return AlRunner.ServerProtocol.RunTests(
-            allTests, exitCode, cached, changed, allCompileErrors.Count > 0 ? allCompileErrors : null);
+        output.WriteLine(AlRunner.ServerProtocol.Summary(
+            allTests, exitCode, cached, changed, allCompileErrors.Count > 0 ? allCompileErrors : null));
+        output.Flush();
     }
 
     // ── execute: run every requested bundle's first OnRun-bearing codeunit

--- a/AlRunner/ServerProtocol.cs
+++ b/AlRunner/ServerProtocol.cs
@@ -7,13 +7,19 @@ namespace AlRunner;
 /// Wire types and (de)serialization for <c>--server</c> mode — the
 /// newline-delimited JSON protocol the VS Code extension depends on.
 ///
-/// One JSON object per line. stdin = requests, stdout = responses. The shape is
-/// kept byte-compatible with the v1 <c>AlRunnerServer</c> protocol so the
-/// existing extension keeps working:
-///   request : {command, sourcePaths[], packagePaths[], stubPaths[], code, captureValues}
-///   runTests: {tests:[{name,status,durationMs,message,stackTrace}],
-///              passed,failed,errors,total,exitCode,compilationErrors|null,
-///              cached,changedFiles|null}
+/// One JSON object per line. stdin = requests, stdout = responses.
+///   request : {command, sourcePaths[], packagePaths[], stubPaths[], code, captureValues, testIsolation}
+///   runTests: STREAMING (protocol-v2.schema.json — see #1641) — zero or more
+///             {"type":"test", name, status, durationMs, message, stackTrace}
+///             lines, one per completed test as it finishes, followed by exactly
+///             one terminal {"type":"summary", exitCode, passed, failed, errors,
+///             total, cached, changedFiles|omitted, compilationErrors|omitted,
+///             protocolVersion:2} line. `errorKind`/`stackFrames` on the test
+///             event and `cancelled` on the summary are schema-defined but not
+///             yet populated — separate follow-up slices of #1641.
+///   execute : {exitCode, tests:[{name,status,durationMs,message,stackTrace}],
+///              messages|null, compilationErrors|null} — single response, not
+///              streamed (matches v1: only runTests streams).
 ///   error   : {error}
 ///   shutdown: {status}
 /// </summary>
@@ -73,11 +79,34 @@ public static class ServerProtocol
         => JsonSerializer.Serialize(new { status = "shutting down" }, Opts);
 
     /// <summary>
-    /// Serialize a runTests response. <paramref name="changedFiles"/> is only
-    /// emitted on a cache miss (cache hits have no diff). <paramref name="compilationErrors"/>
-    /// is null when there were none.
+    /// Serialize one protocol-v2 <c>test</c> NDJSON line for a single completed
+    /// test (the streaming <c>runTests</c> shape — see #1641 / protocol-v2.schema.json's
+    /// <c>TestEvent</c>). <c>errorKind</c>/<c>stackFrames</c> are schema-defined
+    /// but not populated here — that wiring is a separate follow-up slice of #1641.
     /// </summary>
-    public static string RunTests(
+    public static string TestEvent(TestResult t)
+    {
+        var payload = new
+        {
+            type = "test",
+            name = $"{t.Codeunit}.{t.Method}",
+            status = t.Outcome.ToString().ToLowerInvariant(),
+            durationMs = (long)t.Duration.TotalMilliseconds,
+            message = t.Message,
+            stackTrace = (t.AlCallStack ?? t.FullException)?.TrimEnd(),
+        };
+        return JsonSerializer.Serialize(payload, Opts);
+    }
+
+    /// <summary>
+    /// Serialize the single terminal <c>summary</c> NDJSON line that ends a
+    /// streaming <c>runTests</c> response (protocol-v2.schema.json's <c>Summary</c>).
+    /// <paramref name="changedFiles"/> is only emitted on a cache miss (cache hits
+    /// have no diff). <paramref name="compilationErrors"/> is omitted when there
+    /// were none. <c>cancelled</c> is schema-defined but not populated here — the
+    /// <c>cancel</c> command is a separate follow-up slice of #1641.
+    /// </summary>
+    public static string Summary(
         IReadOnlyList<TestResult> tests,
         int exitCode,
         bool cached,
@@ -86,17 +115,18 @@ public static class ServerProtocol
     {
         var payload = new
         {
-            tests = tests.Select(ToWire),
+            type = "summary",
+            exitCode,
             passed = tests.Count(t => t.Outcome == TestOutcome.Pass),
             failed = tests.Count(t => t.Outcome == TestOutcome.Fail),
             errors = tests.Count(t => t.Outcome == TestOutcome.Error),
             total = tests.Count,
-            exitCode,
+            cached,
+            changedFiles = cached ? null : changedFiles,
             compilationErrors = compilationErrors is { Count: > 0 }
                 ? compilationErrors.Select(g => new { file = g.File, errors = g.Errors })
                 : null,
-            cached,
-            changedFiles = cached ? null : changedFiles,
+            protocolVersion = 2,
         };
         return JsonSerializer.Serialize(payload, Opts);
     }

--- a/AlRunner/TestExecutor.cs
+++ b/AlRunner/TestExecutor.cs
@@ -77,7 +77,16 @@ public sealed class TestExecutor
     /// </summary>
     public int? TimeoutSeconds { get; set; }
 
-    public IReadOnlyList<TestResult> Run(Assembly assembly)
+    /// <summary>
+    /// Runs every [Test] method in <paramref name="assembly"/>. When
+    /// <paramref name="onTestComplete"/> is supplied it fires synchronously right
+    /// after each <see cref="TestResult"/> is appended to the returned list — the
+    /// hook <c>--server</c>'s streaming <c>runTests</c> uses to emit one NDJSON
+    /// <c>test</c> line per completed test instead of waiting for the whole
+    /// bundle (see #1641). Null (the CLI's default) is a no-op; behaviour and the
+    /// returned list are otherwise unchanged either way.
+    /// </summary>
+    public IReadOnlyList<TestResult> Run(Assembly assembly, Action<TestResult>? onTestComplete = null)
     {
         var totalSw = System.Diagnostics.Stopwatch.StartNew();
         var results = new List<TestResult>();
@@ -169,8 +178,10 @@ public sealed class TestExecutor
             try { instance = InstantiateCodeunit(t); }
             catch (Exception ex)
             {
-                results.Add(new TestResult(t.Name, "<ctor>", TestOutcome.Error,
-                    Unwrap(ex).Message, ex.ToString(), TimeSpan.Zero));
+                var ctorResult = new TestResult(t.Name, "<ctor>", TestOutcome.Error,
+                    Unwrap(ex).Message, ex.ToString(), TimeSpan.Zero);
+                results.Add(ctorResult);
+                onTestComplete?.Invoke(ctorResult);
                 continue;
             }
             instMs += stageSw.ElapsedMilliseconds;
@@ -195,6 +206,7 @@ public sealed class TestExecutor
                     var result = RunOne(t.Name, m, instance, displayName);
                     methodsMs += stageSw.ElapsedMilliseconds;
                     results.Add(result);
+                    onTestComplete?.Invoke(result);
                     if (IsTimeout(result))
                         return results;
                 }

--- a/docs/server-mode.md
+++ b/docs/server-mode.md
@@ -3,8 +3,9 @@
 `al-runner --server` is a long-running JSON-RPC daemon over stdin/stdout. It loads
 the BC runtime patches and the dependency symbol set **once**, then serves many
 test runs in the same warm process — turning a ~19 s cold run into ~4 s per
-request. The VS Code extension depends on this flag; the protocol below is kept
-byte-compatible with the v1 server so the existing extension keeps working.
+request. The VS Code extension depends on this flag. `runTests` streams the
+protocol-v2 NDJSON shape (`protocol-v2.schema.json`, see #1641); every other
+command (`execute`, `shutdown`, errors) is a single response line.
 
 ```
 al-runner --server [--package-cache PATH ...] [--cache DIR]
@@ -49,24 +50,42 @@ al-runner --server [--package-cache PATH ...] [--cache DIR]
 
 ## Responses
 
-### `runTests`
+### `runTests` — streaming (protocol-v2)
+
+Unlike every other command, `runTests` is **not** a single response line. It
+emits zero or more `test` lines — one per completed test, in the order each
+test finishes, flushed immediately so a client sees results as they happen
+instead of waiting for the whole bundle — followed by exactly one terminal
+`summary` line. A request naming multiple `sourcePaths` runs them in order and
+streams `test` lines across all of them before the one final `summary`.
 
 ```jsonc
-{
-  "tests": [
-    { "name": "Codeunit60110.MyTest", "status": "pass",   // pass | fail | error
-      "durationMs": 12, "message": null, "stackTrace": null }
-  ],
-  "passed": 1, "failed": 0, "errors": 0, "total": 1,
-  "exitCode": 0,                          // 0 ok · 1 test fail · 2 exec · 3 compile
-  "compilationErrors": null,              // or [{ "file": "...", "errors": [...] }]
-  "cached": false,                        // true = served from the AL-output cache
-  "changedFiles": ["XRecProbe.Table.al"] // miss only: files changed vs the prior request
-}
+{"type":"test","name":"Codeunit60110.MyTest","status":"pass","durationMs":12}
+{"type":"test","name":"Codeunit60110.OtherTest","status":"fail","durationMs":3,"message":"...","stackTrace":"..."}
+{"type":"summary","exitCode":1,"passed":1,"failed":1,"errors":0,"total":2,
+ "cached":false,"changedFiles":["XRecProbe.Table.al"],"compilationErrors":null,
+ "protocolVersion":2}
 ```
 
-`stackTrace` is the AL call stack for AL-originated errors, falling back to the
-raw C# exception for runner-internal failures (matching the normal-mode rule).
+- `status` is `pass` | `fail` | `error`.
+- `stackTrace` is the AL call stack for AL-originated errors, falling back to
+  the raw C# exception for runner-internal failures (matching the normal-mode
+  rule). `message`/`stackTrace` are omitted (not `null`) on a passing test.
+- `exitCode`: `0` ok · `1` test fail · `2` exec · `3` compile (same ladder as
+  normal mode).
+- `changedFiles` is only present on a cache miss (a hit means nothing changed);
+  `compilationErrors` is only present when non-empty.
+- `cached: true` means the AL-output compile was skipped (assembly served from
+  the on-disk cache) — the tests still ran for real and still streamed.
+- A bundle that fails to compile short-circuits straight to the `summary` line
+  with `exitCode: 3` and `compilationErrors` set — no `test` lines for that
+  bundle (there was nothing to run).
+- `errorKind` (per-test) and `cancelled` (on the summary) are defined by
+  `protocol-v2.schema.json` but not populated yet — separate follow-up slices
+  of #1641, along with the `cancel` command.
+
+A request-level problem (e.g. a missing `sourcePaths`) returns the usual single
+`{"error":"..."}` line instead of a `test`/`summary` sequence — see Errors below.
 
 ### `execute`
 


### PR DESCRIPTION
Partial slice of #1641 — does **not** close it. Remaining scope: the `cancel` command, and wiring `ErrorClassifier`/`StackFrameMapper` output into the wire protocol's `errorKind`/`stackFrames` fields.

## What's in this PR

- **`AlRunner/TestExecutor.cs`** — `TestExecutor.Run` gained an optional `Action<TestResult>? onTestComplete` parameter, fired synchronously right after each `TestResult` is appended (both the normal per-method path and the constructor-failure path). Null (the CLI's default) is a no-op — no behavior change for the CLI.
- **`AlRunner/ServerProtocol.cs`** — replaced the single-object `RunTests(...)` serializer with two protocol-v2 NDJSON line builders: `TestEvent(TestResult)` (`{"type":"test",...}`) and `Summary(...)` (`{"type":"summary", protocolVersion:2, ...}`), matching `protocol-v2.schema.json`'s `TestEvent`/`Summary` definitions.
- **`AlRunner/Program.cs`** — `--server`'s `runtests` dispatch now writes directly to the output stream: one `test` line per completed test (via the new `onTestComplete` hook), flushed immediately, then one terminal `summary` line once every requested bundle has run. Request-level errors (missing `sourcePaths`, bad `testIsolation`, etc.) still return the existing single-line `{"error":...}` shape. `execute`/`shutdown` are untouched — only `runTests` streams.
- **`docs/server-mode.md`** — rewrote the `runTests` response section to document the streaming shape, the compile-failure short-circuit (straight to `summary`, no `test` lines), and which schema fields (`errorKind`, `cancelled`) aren't populated yet.
- **Test infra**: `AlRunner.Tests/CliServer.SendRequestStreamingAsync` reads lines until the `summary` terminator (or a single-line non-`test`/`progress` response); `AlRunner.Tests/ProtocolV2Streaming.Split` is a shared helper that splits a line sequence into its `test` events + `summary`. Existing e2e tests (`ServerTests.cs`, `ServerTestIsolationTests.cs`) that exercised `runTests` were migrated to the new shape.

## Testing

- RED: new `AlRunner.Tests/ServerStreamingTests.cs` against the pre-change code failed with `no summary line in: {"tests":[...],"passed":1,...}` — proving the old single-line shape was still in effect.
- GREEN: same test now asserts exactly 2 streamed `test` lines (one `pass`, one `fail` with the real AL `Error()` message) followed by a `summary` line with `protocolVersion:2` and matching counts; plus a negative case (missing `sourcePaths` → single error line, no `test`/`summary`) and a control case (`execute` still single-line, unaffected).
- `ServerStreamingTests`, `ServerTests`, `ServerTestIsolationTests`: 12/12 passed locally (needs `~/.bcartifacts.cache`, skip otherwise).
- Full `AlRunner.Tests` suite: 258/259 passed locally. The one failure (`WatchTests.Watch_PicksUpEdit_InProcess_OnNextCycle`) is pre-existing flakiness unrelated to this change — confirmed by running it against the pre-change code (passed) and by re-running it in isolation against this branch afterward (also passed); it touches `--watch` mode, a different code path from `--server`.

Claude-Session: https://claude.ai/code/session_01MQHZTkoumsmZz1J7KDJShy