### PR TITLE
fix(provision): fold bundle .alpackages into the platform-app R2R gate

### DIFF
--- a/.github/workflows/test-matrix.yml
+++ b/.github/workflows/test-matrix.yml
@@ -267,7 +267,17 @@ jobs:
           # any cross-app tableextension there fails to resolve (AL0185/AL0247) and aborts
           # the whole emit. The crash-gate purpose (cold Cecil rewrite + emit + run) is
           # fully exercised by the canonical app. --strict tolerated codes are 0|1|2 below.
-          ./AlRunner/bin/Release/${{ matrix.tfm }}/al-runner --strict --quiet tests/al-language/tests/al-language > smoke.log 2>&1
+          #
+          # --auto-provision: as of #1678 the platform-app R2R gate also scans the target
+          # bundle's OWN .alpackages (not just the home-rooted default caches) — and the
+          # corpus vendors symbol-only Base/System Application/Business Foundation there
+          # (the standard "symbol download, no R2R" shape). On a genuinely cold cache with
+          # no package-cache and no prior provisioning, the gate now correctly fails loud
+          # BEFORE any emit/run, which is the fix's whole point (see #1678) but means this
+          # job's crash-gate (cold Cecil rewrite + emit + run) would never even start.
+          # --auto-provision downloads the corpus's platform apps once so the rest of the
+          # smoke test still exercises what it always exercised.
+          ./AlRunner/bin/Release/${{ matrix.tfm }}/al-runner --strict --quiet --auto-provision tests/al-language/tests/al-language > smoke.log 2>&1
           rc=$?
           cat smoke.log
           case "$rc" in

--- a/AlRunner.Tests/ProvisioningCheckTests.cs
+++ b/AlRunner.Tests/ProvisioningCheckTests.cs
@@ -485,4 +485,114 @@ public sealed class ProvisioningCheckTests : IDisposable
         Assert.NotEqual(platform, testApps);
         Assert.Equal(Path.GetDirectoryName(platform), Path.GetDirectoryName(testApps));
     }
+
+    // ── CollectBundleAlpackagesDirs (issue #1678) ─────────────────────────────
+    // The startup gate that decides whether --auto-provision fires (or the run fails
+    // loud without it) used to scan ONLY the home-rooted default package caches, never
+    // the target bundles' own `.alpackages` — exactly where a standard AL project's
+    // symbol download lives. This helper is the fix's single source of truth for the
+    // bundle-rooted half of that scan; these tests pin its exact contract.
+
+    [Fact]
+    public void CollectBundleAlpackagesDirs_FindsNestedAlpackagesDir()
+    {
+        var bundle = Path.Combine(_dir, "bundle1");
+        var pkgDir = Path.Combine(bundle, ".alpackages");
+        Directory.CreateDirectory(pkgDir);
+
+        var found = ProvisioningCheck.CollectBundleAlpackagesDirs(new[] { bundle });
+
+        Assert.Single(found);
+        Assert.Equal(pkgDir, found[0]);
+    }
+
+    [Fact]
+    public void CollectBundleAlpackagesDirs_ParentOfManySuites_FindsEveryNestedAlpackagesDir()
+    {
+        var bundle = Path.Combine(_dir, "parent");
+        var pkg1 = Path.Combine(bundle, "suite1", ".alpackages");
+        var pkg2 = Path.Combine(bundle, "suite2", ".alpackages");
+        Directory.CreateDirectory(pkg1);
+        Directory.CreateDirectory(pkg2);
+
+        var found = ProvisioningCheck.CollectBundleAlpackagesDirs(new[] { bundle });
+
+        Assert.Equal(2, found.Count);
+        Assert.Contains(pkg1, found);
+        Assert.Contains(pkg2, found);
+    }
+
+    [Fact]
+    public void CollectBundleAlpackagesDirs_NoAlpackagesAnywhere_ReturnsEmpty()
+    {
+        var bundle = Path.Combine(_dir, "bundle-no-pkgs");
+        Directory.CreateDirectory(bundle);
+
+        var found = ProvisioningCheck.CollectBundleAlpackagesDirs(new[] { bundle });
+
+        Assert.Empty(found);
+    }
+
+    [Fact]
+    public void CollectBundleAlpackagesDirs_NonexistentBundlePath_SkippedNotThrown()
+    {
+        var gone = Path.Combine(_dir, "does-not-exist");
+
+        var found = ProvisioningCheck.CollectBundleAlpackagesDirs(new[] { gone });
+
+        Assert.Empty(found);
+    }
+
+    [Fact]
+    public void CollectBundleAlpackagesDirs_DuplicateAcrossBundles_DeduplicatedOnce()
+    {
+        var bundle = Path.Combine(_dir, "bundle-dup");
+        var pkgDir = Path.Combine(bundle, ".alpackages");
+        Directory.CreateDirectory(pkgDir);
+
+        // The SAME bundle passed twice (e.g. a caller-supplied bundle list with an
+        // accidental duplicate) must not duplicate the result.
+        var found = ProvisioningCheck.CollectBundleAlpackagesDirs(new[] { bundle, bundle });
+
+        Assert.Single(found);
+    }
+
+    [Fact]
+    public void CollectBundleAlpackagesDirs_EmptyBundleList_ReturnsEmpty()
+    {
+        var found = ProvisioningCheck.CollectBundleAlpackagesDirs(Array.Empty<string>());
+
+        Assert.Empty(found);
+    }
+
+    // ── End-to-end composition (issue #1678) ──────────────────────────────────
+    // Reproduces the exact defect at the unit level: a standard AL project's bundle
+    // carries a symbol-only Microsoft platform app in its OWN .alpackages (never in any
+    // home-rooted default cache). Before the fix, feeding CheckPlatformApps only the
+    // default caches reported "Ok" vacuously for this shape; the fix folds the bundle's
+    // own .alpackages into the scanned set via CollectBundleAlpackagesDirs, so the gate
+    // now sees the same symbol-only package the real dependency loader trips over deep in
+    // dispatch — and can act on it (fail loud, or --auto-provision) BEFORE that happens.
+    [Fact]
+    public void CollectBundleAlpackagesDirs_FeedsIntoCheckPlatformApps_DetectsBundleOnlyGap()
+    {
+        var bundle = Path.Combine(_dir, "project");
+        var pkgDir = Path.Combine(bundle, ".alpackages");
+        Directory.CreateDirectory(pkgDir);
+        WriteSymbolOnlyApp(pkgDir, "microsoft_system application_28.1.0.0.app",
+            "00000000-0000-0000-0000-000000001678", "System Application", "Microsoft", "28.1.0.0");
+
+        // Simulates the OLD, buggy call site: only the (empty) default caches, no bundle
+        // .alpackages folded in. Must be vacuously Ok — this IS the bug being fixed.
+        var withoutBundleDirs = ProvisioningCheck.CheckPlatformApps("28.1.49838.50794", Array.Empty<string>());
+        Assert.True(withoutBundleDirs.Ok);
+
+        // The fix: fold CollectBundleAlpackagesDirs(bundles) into the scanned set.
+        var bundleAlpackagesDirs = ProvisioningCheck.CollectBundleAlpackagesDirs(new[] { bundle });
+        var withBundleDirs = ProvisioningCheck.CheckPlatformApps("28.1.49838.50794", bundleAlpackagesDirs);
+
+        Assert.False(withBundleDirs.Ok);
+        Assert.Single(withBundleDirs.Issues);
+        Assert.Equal("System Application", withBundleDirs.Issues[0].Name);
+    }
 }

--- a/AlRunner/Infrastructure/ProvisioningCheck.cs
+++ b/AlRunner/Infrastructure/ProvisioningCheck.cs
@@ -119,6 +119,42 @@ public static class ProvisioningCheck
         }
     }
 
+    // ── Bundle .alpackages discovery (issue #1678) ────────────────────────────
+    // The startup gate that decides whether to fire --auto-provision (or fail loud
+    // without it) used to scan ONLY the home-rooted default package caches
+    // (~/.bcartifacts.cache, ~/.local/share/al-runner/{symbols,artifacts}) — never the
+    // target bundles' own `.alpackages`. That is exactly where every standard AL project's
+    // symbol download lives, so for the ordinary shape (symbol-only Microsoft platform
+    // apps vendored in the project) the gate saw an EMPTY set, reported "Ok" vacuously, and
+    // neither the loud failure nor the --auto-provision download ever fired — the run
+    // limped all the way to a cryptic NavNCLMissingMethodException deep in dispatch. This
+    // helper is the single source of truth for the bundle-rooted half of that scan, shared
+    // by the startup gate, the `provision` subcommand, and any other caller that needs to
+    // reason about what a bundle's own package cache actually vendors.
+
+    /// <summary>
+    /// Every `.alpackages` directory nested under any of <paramref name="bundlePaths"/>
+    /// (recursively — a bundle can be a parent of many suites, each with its own
+    /// `.alpackages`). Nonexistent paths are skipped; the result has no duplicates.
+    /// Pure filesystem scan — no network, no manifest parsing.
+    /// </summary>
+    public static IReadOnlyList<string> CollectBundleAlpackagesDirs(IEnumerable<string> bundlePaths)
+    {
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var result = new List<string>();
+        foreach (var bundle in bundlePaths)
+        {
+            if (string.IsNullOrEmpty(bundle) || !Directory.Exists(bundle)) continue;
+            IEnumerable<string> found;
+            try { found = Directory.EnumerateDirectories(bundle, ".alpackages", SearchOption.AllDirectories); }
+            catch { continue; }
+            foreach (var dir in found)
+                if (seen.Add(dir))
+                    result.Add(dir);
+        }
+        return result;
+    }
+
     /// <summary>
     /// Scan <paramref name="packageCacheDirs"/> for known Microsoft platform runtime apps
     /// (System Application, Base Application, Business Foundation). If any are found as

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -505,22 +505,34 @@ var packageCacheDirs = packageCacheArgs.Count > 0
     : DefaultPackageCacheDirs().ToList();
 Console.WriteLine($"  package caches: {packageCacheDirs.Count} dir(s)");
 
+// Issue #1678: the platform-app R2R gate below used to scan ONLY packageCacheDirs
+// (the home-rooted default caches / explicit --package-cache dirs) — never the target
+// bundles' own `.alpackages`, which is exactly where every standard AL project's symbol
+// download lives. For that ordinary shape the gate saw an empty set, reported "Ok"
+// vacuously, and neither the loud failure nor --auto-provision's download ever fired —
+// the run limped all the way to a cryptic NavNCLMissingMethodException deep in dispatch
+// instead of hitting either remediation the "[provision-gap]" message promises. Fold the
+// bundles' own .alpackages into the dirs the gate scans (recomputed via PlatformCheckDirs
+// below so it picks up anything --auto-provision adds to packageCacheDirs afterward).
+var bundleAlpackagesDirs = AlRunner.Infrastructure.ProvisioningCheck.CollectBundleAlpackagesDirs(bundles);
+List<string> PlatformCheckDirs() => packageCacheDirs.Concat(bundleAlpackagesDirs).Distinct().ToList();
+
 // Platform-app R2R check: scan the package cache for known Microsoft platform runtime apps
 // (System Application, Base Application, Business Foundation). If any are present as
 // symbol-only (non-R2R) packages, the runner CANNOT execute their codeunits at runtime —
 // the EMIT-ZERO crash is a provisioning gap, not a user-code error. Fail loud here before
 // any bundle compile, naming the fix, instead of deep inside the dep-load pipeline.
 // (--auto-provision downloads the R2R apps and clears the check.)
-if (!provisionSubcommand && packageCacheDirs.Count > 0)
+if (!provisionSubcommand && (packageCacheDirs.Count > 0 || bundleAlpackagesDirs.Count > 0))
 {
     var version = AlRunner.Infrastructure.BcArtifacts.SelectedVersion.ToString();
     var platformReport = AlRunner.Infrastructure.ProvisioningCheck.CheckPlatformApps(
-        version, packageCacheDirs);
+        version, PlatformCheckDirs());
     // Test-toolkit apps (Business Foundation Test Libraries, Application Test Library, …)
     // are a SEPARATE artifact set from the w1 platform apps (they live under the
     // `platform` artifact, not `w1`) — a cache can have complete R2R platform apps and
     // still be missing the whole test toolkit, which fails compiling any test bundle.
-    var toolkitPresent = AlRunner.Infrastructure.ProvisioningCheck.TestToolkitPresent(packageCacheDirs);
+    var toolkitPresent = AlRunner.Infrastructure.ProvisioningCheck.TestToolkitPresent(PlatformCheckDirs());
 
     if (!platformReport.Ok && !autoProvision)
     {
@@ -539,7 +551,7 @@ if (!provisionSubcommand && packageCacheDirs.Count > 0)
         // (only the toolkit is missing); (c) else fall back to the engine's own version.
         var mm = !platformReport.Ok
             ? AlRunner.Infrastructure.ProvisioningCheck.DeriveProvisionMajorMinor(platformReport, version)
-            : AlRunner.Infrastructure.ProvisioningCheck.DerivePresentPlatformMajorMinor(packageCacheDirs, version);
+            : AlRunner.Infrastructure.ProvisioningCheck.DerivePresentPlatformMajorMinor(PlatformCheckDirs(), version);
         var full = AlRunner.Provisioning.ArtifactDownloader.ResolveVersion(
             mm, m => Console.Error.WriteLine($"[provision] {m}"));
         if (full == null)
@@ -572,7 +584,7 @@ if (!provisionSubcommand && packageCacheDirs.Count > 0)
                 packageCacheDirs.Add(platformAppsOut);
             // Re-check: never silently continue on a partial/failed provision.
             platformReport = AlRunner.Infrastructure.ProvisioningCheck.CheckPlatformApps(
-                version, packageCacheDirs);
+                version, PlatformCheckDirs());
             if (!platformReport.Ok)
             {
                 var stillMissing = string.Join(", ", platformReport.Issues.Select(i => i.Name));
@@ -596,7 +608,7 @@ if (!provisionSubcommand && packageCacheDirs.Count > 0)
             if (!packageCacheDirs.Contains(testAppsOut))
                 packageCacheDirs.Add(testAppsOut);
             // Re-check: never silently continue on a partial/failed provision.
-            toolkitPresent = AlRunner.Infrastructure.ProvisioningCheck.TestToolkitPresent(packageCacheDirs);
+            toolkitPresent = AlRunner.Infrastructure.ProvisioningCheck.TestToolkitPresent(PlatformCheckDirs());
             if (!toolkitPresent)
             {
                 Console.Error.WriteLine("[provision] test-toolkit apps still missing after download.");
@@ -3876,9 +3888,64 @@ static int RunProvisioning(string? bcVersionArg, string? artifactPathArg,
     else if (!AlRunner.Infrastructure.ProvisioningCheck.AutoProvision(full, serviceTierDir))
         return 1;
 
+    EnsurePlatformAppsProvisioned(full, bundles);
     EnsureTestToolkitProvisioned(full);
     provisionedVersion = full;
     return 0;
+}
+
+// Issue #1678: `provision` used to stop at the engine closure + test toolkit, so its half
+// of the "[provision-gap]" fix text ("al-runner provision") was wrong — the subcommand
+// never touched platform apps at all, and re-running it after the gap message reported the
+// engine "already complete" and exited without ever creating <artifacts>/<version>/platform-apps.
+// Detect the gap the same way the --auto-provision path does: scan the TARGET bundles'
+// own `.alpackages` (the standard shape any AL project's symbol download produces) for
+// symbol-only Microsoft platform apps, and download the R2R package set for THEIR version
+// (which can be a different minor than <paramref name="full"/>, the engine's own version —
+// see DeriveProvisionMajorMinor) into the runner-owned platform-apps dir for that version.
+// No-op when no bundle is given (`al-runner provision` with no target) or the bundle(s)
+// carry no symbol-only platform apps.
+static void EnsurePlatformAppsProvisioned(string engineVersion, List<string> bundles)
+{
+    var bundleAlpackagesDirs = AlRunner.Infrastructure.ProvisioningCheck.CollectBundleAlpackagesDirs(bundles);
+    if (bundleAlpackagesDirs.Count == 0)
+        return;
+
+    var platformReport = AlRunner.Infrastructure.ProvisioningCheck.CheckPlatformApps(
+        engineVersion, bundleAlpackagesDirs);
+    if (platformReport.Ok)
+    {
+        Console.Error.WriteLine("[provision] platform R2R apps already present for the target bundle(s).");
+        return;
+    }
+
+    var mm = AlRunner.Infrastructure.ProvisioningCheck.DeriveProvisionMajorMinor(platformReport, engineVersion);
+    var platformFull = AlRunner.Provisioning.ArtifactDownloader.ResolveVersion(
+        mm, m => Console.Error.WriteLine($"[provision] {m}"));
+    if (platformFull == null)
+    {
+        Console.Error.WriteLine(
+            $"[provision] warning: could not resolve a full BC artifact version for platform apps '{mm}'. " +
+            $"Symbol-only Microsoft platform apps found: {string.Join(", ", platformReport.Issues.Select(i => i.Name))}.");
+        return;
+    }
+    var platformAppsOut = AlRunner.Infrastructure.ProvisioningCheck.PlatformAppsDirFor(
+        AlRunner.Infrastructure.BcArtifacts.ArtifactsRootDir, platformFull);
+    Console.Error.WriteLine($"[provision] fetching Microsoft platform R2R apps for BC {platformFull} → {platformAppsOut}");
+    try
+    {
+        var rc = AlRunner.Provisioning.ArtifactDownloader.PlatformApps(
+            platformFull, platformAppsOut, m => Console.Error.WriteLine($"[provision] {m}"));
+        if (rc != 0)
+            Console.Error.WriteLine(
+                $"[provision] warning: could not fetch platform apps for BC {platformFull}. " +
+                $"Test bundles calling into Base Application / System Application / Business Foundation " +
+                $"codeunits will need --package-cache <dir-with-those-apps>.");
+    }
+    catch (Exception ex)
+    {
+        Console.Error.WriteLine($"[provision] warning: platform-apps download failed: {ex.Message}");
+    }
 }
 
 // The MS test toolkit (Any, Library Assert, Library Variable Storage, Test Runner,


### PR DESCRIPTION
Closes #1678

## Problem

The startup gate that decides whether `--auto-provision` fires (or the run fails loud without it) scanned only the home-rooted default package caches (`~/.bcartifacts.cache`, `~/.local/share/al-runner/{symbols,artifacts}`) — never the target bundles' own `.alpackages`, which is exactly where a standard AL project's symbol download lives (the shape every AL-extension project has). For that shape the gate saw an empty set, reported "Ok" vacuously, and neither remediation the printed `[provision-gap]` message promises ever fired:

- `al-runner --auto-provision <bundle>` downloaded nothing (the gate that triggers the download never saw a gap).
- `al-runner provision <bundle>` never had a platform-apps step at all.

The run instead limped all the way to a cryptic `NavNCLMissingMethodException` deep in dispatch.

## Fix

- Added `ProvisioningCheck.CollectBundleAlpackagesDirs(bundles)` — a pure helper that recursively finds every `.alpackages` dir nested under the target bundle path(s).
- Folded its result into the dirs scanned by the startup platform-app gate (`Program.cs`), via a small `PlatformCheckDirs()` local function so it also picks up whatever `--auto-provision` adds to `packageCacheDirs` mid-flow (the platform-apps dir it just downloaded).
- Added an `EnsurePlatformAppsProvisioned` step to `RunProvisioning` (the `provision` subcommand's driver), so `al-runner provision <bundle>` now also detects a bundle's symbol-only platform apps and downloads their R2R package set into `<artifacts>/<version>/platform-apps/` — matching what its own "Fix:" text has always promised.

## Verification (manual, against real BC 28.1 artifacts)

Built a repro bundle whose `.alpackages` held the real symbol-only `System Application` / `Base Application` / `Business Foundation` packages from the `tests/al-language` corpus (the standard "symbol download, no R2R" shape), with a test codeunit calling a Base Application procedure (`Codeunit 9015 "Application System Constants".ApplicationVersion()` — Base Application has no engine-bundled fallback DLL, so this deterministically reproduces the dispatch failure without relying on version skew).

- **RED (before fix, no `--auto-provision`)**: `NavNCLMissingMethodException: Function ID … was called. The object with ID 0 does not have a member with that ID.`
- **GREEN (after fix, no `--auto-provision`)**: exits 2 with the full `[provision-gap]`-style detailed message naming the symbol-only apps + both remediations, instead of crashing.
- **GREEN (after fix, `--auto-provision`)**: downloads the R2R platform apps for the bundle's own symbol version (independently of the engine's version) and the test then passes.
- **GREEN (after fix, `al-runner provision <bundle>`)**: creates `<artifacts>/<version>/platform-apps/` populated with the R2R `.app` files, without running any tests.

All three acceptance criteria from #1678 are satisfied.

## Tests

- `AlRunner.Tests/ProvisioningCheckTests.cs`: unit tests for `CollectBundleAlpackagesDirs` (nested dirs, parent-of-many-suites, no-alpackages, nonexistent path, dedup, empty list) plus a composition test that reproduces the exact bug at the unit level — `CheckPlatformApps` over the default (empty) caches reports vacuously `Ok` for a bundle-only symbol package, but reports the gap once `CollectBundleAlpackagesDirs` is folded in.
- Full `AlRunner.Tests` suite: 262/262 passing (`dotnet test AlRunner.Tests/AlRunner.Tests.csproj`).

## Test plan

- [x] `CollectBundleAlpackagesDirs` unit tests pass
- [x] Full `AlRunner.Tests` suite passes (262/262)
- [x] Manual RED→GREEN verified against real BC 28.1 engine + real corpus symbol-only platform packages, all three acceptance criteria confirmed