### PR TITLE
fix(dispatch): dedupe module identity across bundles to fix event-subscriber TargetException

### DIFF
--- a/AlRunner.Tests/CrossBundleModuleIdentityDedupTests.cs
+++ b/AlRunner.Tests/CrossBundleModuleIdentityDedupTests.cs
@@ -1,0 +1,173 @@
+using System.Diagnostics;
+using System.Text;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// Issue #1683 — a real app + its separate test app (the README's "usual shape",
+/// `al-runner MyApp MyApp.Test`) passed as two bundle args in ONE invocation. The dep
+/// app has a table-event subscriber that fires during its own install trigger (a
+/// common setup-table pattern). Bundle 1 compiles the dep app as its OWN emitted
+/// module; bundle 2 (the test app) resolves the SAME dep app as an external package
+/// dependency via the layered pre-pass + DependencyLoader, which — before the fix —
+/// re-emitted/re-compiled it into a SECOND, distinct module. The event-subscription
+/// registry then paired a subscriber MethodInfo discovered from one module's Type
+/// with a subscriberInstance BC's own dispatcher materialized from the OTHER module's
+/// Type, and `RuntimeMethodInfo.Invoke` threw `TargetException: Object does not match
+/// target type` inside `NavEventScope.CallEventSubscriberInternalAsync` →
+/// `ValidateInvokeTarget`.
+///
+/// RED (pre-fix): the run aborts with a bundle-level EXEC-FAIL naming
+/// "TargetException: Object does not match target type" and the test app's own test
+/// never gets to assert anything.
+/// GREEN (post-fix): one loaded module per AL app identity — the dep app's own-bundle
+/// module is reused as the test app's dependency, so the install trigger's Modify()
+/// fires the real (single, matched) subscriber cleanly and the test app's test passes.
+///
+/// Spawns the real runner; needs the BC artifact cache. Skips (no-op) when absent.
+/// </summary>
+[Collection("server-serial")]
+public class CrossBundleModuleIdentityDedupTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+    private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
+
+    private static bool ArtifactsPresent()
+    {
+        var home = Environment.GetEnvironmentVariable("HOME");
+        return !string.IsNullOrEmpty(home) && Directory.Exists(Path.Combine(home, ".bcartifacts.cache", "sandbox"));
+    }
+
+    private static (string output, int exit) RunRunner(params string[] bundles)
+    {
+        var args = new StringBuilder(TestBuildConfig.RunArgs(ProjectPath));
+        args.Append(TestBuildConfig.BcVersionArg);
+        foreach (var b in bundles) args.Append(" \"").Append(b).Append('"');
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet", Arguments = args.ToString(),
+            RedirectStandardOutput = true, RedirectStandardError = true,
+            UseShellExecute = false, CreateNoWindow = true, WorkingDirectory = RepoRoot,
+        };
+        var sb = new StringBuilder();
+        var p = Process.Start(psi)!;
+        p.OutputDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.ErrorDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.BeginOutputReadLine();
+        p.BeginErrorReadLine();
+        if (!p.WaitForExit(180_000)) { try { p.Kill(true); } catch { } throw new TimeoutException("runner hung"); }
+        p.WaitForExit();
+        lock (sb) return (sb.ToString(), p.ExitCode);
+    }
+
+    [Fact]
+    public void DepAppOwnBundlePlusDependentTestApp_InstallTriggerSubscriberFiresCleanly()
+    {
+        if (!ArtifactsPresent()) { Console.Error.WriteLine("[skip] BC artifact cache not present"); return; }
+
+        var root = Path.Combine(Path.GetTempPath(), "al-runner-xbundle-dedup", Guid.NewGuid().ToString("N"));
+        var depDir = Path.Combine(root, "dep-app");
+        var testDir = Path.Combine(root, "test-app");
+        Directory.CreateDirectory(depDir);
+        Directory.CreateDirectory(testDir);
+
+        var depId = "a1b2c3d4-1683-4a1b-9c3d-000000000001";
+
+        File.WriteAllText(Path.Combine(depDir, "app.json"), $$"""
+        {
+          "id": "{{depId}}",
+          "name": "TE Dep App 1683",
+          "publisher": "Repro1683",
+          "version": "1.0.0.0",
+          "dependencies": [],
+          "platform": "1.0.0.0",
+          "application": "1.0.0.0",
+          "idRanges": [ { "from": 61860, "to": 61869 } ],
+          "runtime": "14.0"
+        }
+        """);
+        File.WriteAllText(Path.Combine(depDir, "TeDep.al"), """
+        table 61860 "TE Setup 1683"
+        {
+            DataClassification = SystemMetadata;
+            fields
+            {
+                field(1; "Primary Key"; Code[10]) { }
+                field(2; "Value"; Integer) { }
+            }
+            keys { key(PK; "Primary Key") { Clustered = true; } }
+        }
+
+        codeunit 61861 "TE Subscriber 1683"
+        {
+            [EventSubscriber(ObjectType::Table, Database::"TE Setup 1683", 'OnAfterModifyEvent', '', false, false)]
+            local procedure OnAfterModifyTeSetup(var Rec: Record "TE Setup 1683")
+            begin
+            end;
+        }
+
+        codeunit 61862 "TE Install 1683"
+        {
+            Subtype = Install;
+            trigger OnInstallAppPerCompany()
+            var
+                Setup: Record "TE Setup 1683";
+            begin
+                if not Setup.Get('X') then begin
+                    Setup."Primary Key" := 'X';
+                    Setup.Insert();
+                end;
+                Setup.Value += 1;
+                Setup.Modify(true); // fires OnAfterModifyEvent -> "TE Subscriber 1683"
+            end;
+        }
+        """);
+
+        File.WriteAllText(Path.Combine(testDir, "app.json"), $$"""
+        {
+          "id": "b2c3d4e5-1683-4a1b-9c3d-000000000002",
+          "name": "TE Main Tests 1683",
+          "publisher": "Repro1683",
+          "version": "1.0.0.0",
+          "dependencies": [
+            { "id": "{{depId}}", "name": "TE Dep App 1683", "publisher": "Repro1683", "version": "1.0.0.0" }
+          ],
+          "platform": "1.0.0.0",
+          "application": "1.0.0.0",
+          "idRanges": [ { "from": 61870, "to": 61879 } ],
+          "runtime": "14.0"
+        }
+        """);
+        File.WriteAllText(Path.Combine(testDir, "TeMainTests.al"), """
+        codeunit 61870 "TE Main Tests 1683"
+        {
+            Subtype = Test;
+
+            [Test]
+            procedure DepInstallTriggerRan()
+            var
+                Setup: Record "TE Setup 1683";
+            begin
+                if not Setup.Get('X') then
+                    Error('TE Setup "X" missing - dep install trigger did not run');
+                if Setup.Value < 1 then
+                    Error('TE Setup "X" Value is %1 - Modify(true) did not commit', Setup.Value);
+            end;
+        }
+        """);
+
+        var (output, exitCode) = RunRunner(depDir, testDir);
+
+        // The exact defect: two loaded modules for one AL app identity produced a
+        // subscriber MethodInfo/instance mismatch. Never silently pass a run that hit
+        // this — the assertion below is the whole point of the RED→GREEN cycle.
+        Assert.DoesNotContain("TargetException", output);
+        Assert.DoesNotContain("Object does not match target type", output);
+        // The test app's own test must actually have run and passed — not merely
+        // "no crash". 1P/0F/0E is TestExecutor's own per-bundle summary line.
+        Assert.Contains("1P/0F/0E", output);
+        Assert.Equal(0, exitCode);
+    }
+}

--- a/AlRunner/DependencyLoader.cs
+++ b/AlRunner/DependencyLoader.cs
@@ -508,4 +508,20 @@ public sealed class DependencyLoader
     /// </summary>
     public static Assembly? TryGetByAppId(Guid appId)
         => _cache.TryGetValue(appId, out var asm) ? asm : null;
+
+    /// <summary>
+    /// Record that <paramref name="asm"/> is the loaded module for AL app identity
+    /// <paramref name="appId"/> — used by the bundle loop's own-AppGroup compile path
+    /// (Program.cs) so an app compiled as ITS OWN bundle is visible here too, not just
+    /// apps that arrived through <see cref="LoadAll"/>. Without this, a later bundle
+    /// that resolves the same AppId as a *dependency* would MISS this cache and
+    /// re-emit/re-compile a second, distinct module for the same AL identity — see
+    /// issue #1683 (event-subscriber dispatch pairs a MethodInfo from one module's
+    /// Type with a subscriberInstance from the other module's Type, throwing
+    /// TargetException at ValidateInvokeTarget). First registration for a given AppId
+    /// wins; a duplicate call for an AppId already present is a no-op (the earlier
+    /// module is the one every other bundle should keep resolving to).
+    /// </summary>
+    public static void RegisterLoaded(Guid appId, Assembly asm)
+        => _cache.TryAdd(appId, asm);
 }

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -1045,6 +1045,35 @@ foreach (var bundle in bundles)
         // seeding resolve per app instead of per bundle.
         BcCompiler.SetCurrentAppIdentity(appGroup.AppId, appGroup.Publisher, appGroup.Version);
 
+        // ── cross-bundle module identity dedup (issue #1683) ────────────────
+        // If this app's identity (AppId) was already compiled and loaded earlier in
+        // THIS process — either as an earlier bundle's own AppGroup (this same code
+        // path) or as an earlier bundle's resolved dependency (DependencyLoader) —
+        // reuse that exact Assembly/Type set instead of emitting+compiling a second,
+        // distinct module for the same AL app. Two live modules for one AL identity
+        // is what produced the TargetException in #1683: EventSubscriberPatches'
+        // registry paired a subscriber MethodInfo discovered from one module's Type
+        // with a subscriberInstance BC's dispatcher materialized from the OTHER
+        // module's Type at CallEventSubscriberInternalAsync → ValidateInvokeTarget.
+        // One AL app identity must resolve to exactly one loaded compilation.
+        //
+        // Disabled under --watch: watch mode re-runs this SAME per-AppGroup loop on every
+        // edit cycle for the SAME bundle set, and its whole point is to pick up the edited
+        // source on each iteration. Reusing "the module already loaded for this AppId"
+        // there would mean iteration 2 replays iteration 1's stale pre-edit assembly
+        // forever — ResetForNewBundleReload() does not (and must not, for the unrelated
+        // deps-stay-warm reason documented there) clear DependencyLoader's cross-bundle
+        // cache, so this dedup stays scoped to genuinely distinct bundle args in one
+        // one-shot invocation, never a same-bundle reload.
+        Assembly? reusedAsm = (!watchMode && appGroup.AppId is { } reuseCheckId)
+            ? DependencyLoader.TryGetByAppId(reuseCheckId)
+            : null;
+        bool needCompile = reusedAsm == null;
+        if (reusedAsm != null)
+            Console.Error.WriteLine(
+                $"  [{rel}] {moduleName}: AppId {appGroup.AppId} already loaded earlier in this " +
+                "process — reusing that module instead of recompiling (see issue #1683).");
+
         // ── AL-output cache check (Spike B keystone) ───────────────────────
         // Sidecar `<key>.enum-registry.json` carries the AlEnumMetadataRegistry
         // entries that emit would have populated as a side effect — see
@@ -1062,7 +1091,7 @@ foreach (var bundle in bundles)
         // emit produces. Serving a HIT without it leaves NCLMetaQuery null and every
         // query Find NREs inside BC's NavQuery.ValidateTablesNotVirtual.
         bool bundleDeclaresQuery = BcCompiler.BundleDeclaresQuery(allPaths);
-        if (alCacheDir != null)
+        if (needCompile && alCacheDir != null)
         {
             cacheKey = ComputeAlCacheKey(allPaths, moduleName, ordered: GetOrderedDepIds(bucketRoot, packageCacheDirs, bundleAbs));
             cachePath = Path.Combine(alCacheDir, cacheKey + ".dll");
@@ -1087,7 +1116,7 @@ foreach (var bundle in bundles)
         }
 
         byte[]? assemblyBytes = null;
-        if (cachedBytes != null)
+        if (needCompile && cachedBytes != null)
         {
             // Replay the enum-registry sidecar BEFORE Assembly.Load. Test
             // execution is what reads the registry (via the
@@ -1115,7 +1144,7 @@ foreach (var bundle in bundles)
                 assemblyBytes = cachedBytes;
             }
         }
-        if (assemblyBytes == null)
+        if (needCompile && assemblyBytes == null)
         {
             if (alCacheDir != null) Console.Error.WriteLine($"  [cache] MISS key={cacheKey} — running Emit+Compile");
             var et = System.Diagnostics.Stopwatch.StartNew();
@@ -1320,12 +1349,33 @@ foreach (var bundle in bundles)
         // Load and register each module as it is built, but do NOT run yet: the
         // test run happens once, after every app in the bundle is loaded, so that
         // an app can call into a sibling it depends on.
-        if (assemblyBytes != null)
+        if (reusedAsm != null || assemblyBytes != null)
         {
-            var loadSw = System.Diagnostics.Stopwatch.StartNew();
-            var asm = Assembly.Load(assemblyBytes);
-            loadSw.Stop();
-            AlRunner.PerfTrace.Log($"test assembly load {rel}/{moduleName} {loadSw.ElapsedMilliseconds}ms");
+            Assembly asm;
+            if (reusedAsm != null)
+            {
+                // See the "cross-bundle module identity dedup" comment above: this app's
+                // AppId was already loaded earlier in this process, so run with that exact
+                // Assembly instead of Assembly.Load-ing a second, distinct module for the
+                // same AL identity.
+                asm = reusedAsm;
+            }
+            else
+            {
+                var loadSw = System.Diagnostics.Stopwatch.StartNew();
+                asm = Assembly.Load(assemblyBytes!);
+                loadSw.Stop();
+                AlRunner.PerfTrace.Log($"test assembly load {rel}/{moduleName} {loadSw.ElapsedMilliseconds}ms");
+                // Register this freshly-loaded module by AppId so a LATER bundle that
+                // resolves the same app as a dependency (via DependencyLoader) reuses this
+                // exact Assembly instead of re-emitting/re-compiling a second module for the
+                // same AL identity — see the dedup comment above (issue #1683). Skipped under
+                // --watch: TryAdd is first-wins, so iteration 2's freshly-edited asm would
+                // never overwrite iteration 1's stale entry, and any sibling bundle that
+                // later resolves this AppId as a real dependency would get the stale copy.
+                if (!watchMode && appGroup.AppId is { } newlyLoadedId)
+                    DependencyLoader.RegisterLoaded(newlyLoadedId, asm);
+            }
             var registerSw = System.Diagnostics.Stopwatch.StartNew();
             // wireFieldTriggers:false — WireFieldTriggerHandlersAll walks EVERY table
             // registered so far, not just this assembly's. Calling it here, per app,


### PR DESCRIPTION
Closes #1683

## Root cause

Confirmed the issue's hypothesis by reading `EventSubscriberPatches` and the
bundle-loop / `DependencyLoader` compile paths in `Program.cs`.

When two bundle args are passed in one invocation and one depends on the other
(the README's usual `al-runner MyApp MyApp.Test` shape), the shared dep app was
compiled **twice** in the same process:

1. Once as its own bundle's `AppGroup` (the bundle loop's per-app.json
   Emit+Compile+`Assembly.Load`).
2. Once again as the dependent bundle's resolved package dependency, via the
   layered pre-pass's synthesized workspace `.app` + `DependencyLoader`'s
   Tier-3 source compile (`DependencyLoader._cache`, keyed by AppId — but the
   bundle loop's own-AppGroup path never populated or consulted that cache).

That produced two distinct CLR `Type`s for the same AL app identity.
`EventSubscriberPatches`'s table-trigger registry (`_byKey` / `DoInject`) then
paired a subscriber `MethodInfo` discovered from one module's `Type` with a
`subscriberInstance` BC's own dispatcher (`NavEventScope.CallEventSubscriberInternalAsync`)
materialized from the *other* module's `Type` — `RuntimeMethodInfo.Invoke` threw
`TargetException: Object does not match target type` at `ValidateInvokeTarget`
whenever the shared app's install trigger fired a table-event subscriber.

## Fix

`DependencyLoader` gets a `RegisterLoaded(appId, asm)` that adds to its existing
`_cache` (previously only written by `LoadAll`). The bundle loop's own-AppGroup
compile path now:

- Checks `DependencyLoader.TryGetByAppId(appGroup.AppId)` before compiling —
  if this app's identity was already loaded earlier in the process (either as
  another bundle's own AppGroup, or as another bundle's resolved dependency),
  it reuses that exact `Assembly` instead of emitting/compiling a second module.
- Calls `DependencyLoader.RegisterLoaded` after a fresh compile, so a *later*
  bundle that resolves this AppId as a dependency reuses this module too.

Both directions are covered regardless of which bundle arg is passed first.

Disabled under `--watch`: watch mode re-runs the same per-AppGroup loop on every
edit cycle for the *same* bundle set, and reusing "already loaded for this
AppId" there would replay the pre-edit assembly forever instead of picking up
the hot-reloaded source — `ResetForNewBundleReload()` intentionally does not
clear `DependencyLoader`'s cross-bundle cache (that's what keeps deps warm
across watch iterations), so the dedup only applies to genuinely distinct
bundle args in a one-shot invocation.

## Testing (TDD)

Added `AlRunner.Tests/CrossBundleModuleIdentityDedupTests.cs`, spawning the real
runner against the issue's exact two-app repro (a dep app with a table-event
subscriber firing during its own install trigger, plus a dependent test app).

- **RED** (confirmed against the pre-fix code, via `git stash`): the run emits
  `TargetException: Object does not match target type` and the assertion fails.
- **GREEN** (with the fix): no `TargetException`, the test app's own test
  passes (`1P/0F/0E`), and the process exits 0.

Also re-ran the existing dependency/bundling regression surface to check for
side effects: `LayeredCacheTests`, `DependencyResolverTests`,
`DependencyShadowDiagnosticTests`, `JsonLoaderDependencyFallthroughTests` (25
tests), and the full `AlRunner.Tests` suite including `ServerTests` /
`ServerTestIsolationTests` (server-mode reload) and `WatchTests` (watch-mode
hot reload) — all green, no regressions.

## Docs

`docs/coverage.yaml` is v1-era and archived (`docs/archive/coverage.yaml`) per
`docs/v1-to-v2-migration.md` — v2's coverage tracking is the `tests/al-language/`
corpus itself. This is a runtime-engine dispatch fix, not a new AL-language
surface, so no coverage entry applies.