### PR TITLE
fix: platform-table metadata lost when a dependency app extends the table

### DIFF
--- a/AlRunner/Patches/RecordPatches.AlSourceParser.cs
+++ b/AlRunner/Patches/RecordPatches.AlSourceParser.cs
@@ -290,10 +290,25 @@ public static partial class RecordPatches
             Console.Error.WriteLine($"[TableExt] parsed extension {extId} '{extName}' extends '{baseName}' with {fields.Count} fields");
 
             var key = baseName.ToLowerInvariant();
+            // De-dup by field id (mirrors the symbol-index merge in
+            // RecordPatches.BcAppFallback.cs's EnsureBcSymbolExtensionIndex): the same
+            // extension source file can legitimately be scanned more than once (e.g. a
+            // dependency app's source dir registered both by its own suite AND by
+            // BuildSiblingSourceDeps' sibling-source discovery — see #1686), and without
+            // this guard the same field id lands twice in the merged list. A duplicated
+            // NCLMetaField with the same FieldNo corrupts NCLMetaTable.AssignFromMetaTable's
+            // positional field-count arithmetic, which crashes deep inside
+            // NCLMetaTable.SetSystemFields() with a bare NullReferenceException — surfaced
+            // to the caller as the misleading "no NCLMetaTable ... (AL source not parsed)".
             if (!_parsedExtensionFields.TryGetValue(key, out var existing))
                 _parsedExtensionFields[key] = fields;
             else
-                existing.AddRange(fields);
+            {
+                var existingIds = new HashSet<int>(existing.Select(f => f.FieldId));
+                foreach (var f in fields)
+                    if (existingIds.Add(f.FieldId))
+                        existing.Add(f);
+            }
 
             // The base table's NCLMetaTable may ALREADY be built and cached at this point:
             // a table pulled in from a precompiled dependency .app is materialised lazily

--- a/AlRunner/Patches/RecordPatches.cs
+++ b/AlRunner/Patches/RecordPatches.cs
@@ -142,6 +142,16 @@ public static partial class RecordPatches
     public static void AddSourceDir(string dir)
     {
         if (!Directory.Exists(dir)) return;
+        // De-dup: BuildSiblingSourceDeps (Program.cs) can legitimately call this for the
+        // SAME dependency source dir twice — once while matching declared deps to sibling
+        // source apps, once while emitting the synthetic workspace .app for a dep that
+        // needs a fresh build. Without this guard the same dir lands twice in _sourceDirs,
+        // so ParseAllSources() parses its .al files twice on the next Register()/rebuild.
+        // For a dependency that declares a `tableextension` on a table whose base metadata
+        // comes from elsewhere (e.g. a platform-app table), that duplicated every extension
+        // field id in _parsedExtensionFields — see #1686. The dedup here is defense in depth
+        // alongside the field-id dedup in TryParseTableExtensionFile.
+        if (_sourceDirs.Contains(dir, StringComparer.OrdinalIgnoreCase)) return;
         _sourceDirs.Add(dir);
         // If Register() already ran (it runs before the bucket loop), parse immediately
         // and feed the freshly-parsed tables into the NCLMetadata cache.

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -827,6 +827,15 @@ foreach (var bundle in bundles)
     AlRunner.InstallTriggerRunner.ResetForNewBundle();
 
     // ── per-bucket dep resolution ──────────────────────────────────────────
+    // Hoisted out of the try block below so EmitSiblingSymbols (called later, once
+    // per bundle) can pass this bundle's resolved Microsoft-platform closure into
+    // each in-bundle sibling's *.symbols.deps.json sidecar — see #1686 follow-up:
+    // without it, a sibling app that extends a PLATFORM table (not one of its own)
+    // gets an empty dependency sidecar, and BC's ReferenceManager cannot attach its
+    // tableextension to the platform table because the declaring module has no
+    // recorded path to the module that owns the base table.
+    IReadOnlyList<(AlRunner.AppManifest Manifest, string AppPath)> bundleResolvedDeps =
+        Array.Empty<(AlRunner.AppManifest, string)>();
     var bucketRoot = FindBucketRoot(bundleAbs);
     // The dependency closure comes from the bucket root's app.json when it has one, and
     // otherwise from the union of the child apps' manifests — see CollectBundleManifests.
@@ -854,6 +863,7 @@ foreach (var bundle in bundles)
                 var resolverDirs = bundlePkgDirs.Concat(packageCacheDirs).Distinct().ToList();
                 var resolver = new DependencyResolver(resolverDirs);
                 var ordered = resolver.Resolve(roots);
+                bundleResolvedDeps = ordered;
                 Console.WriteLine($"  [{rel}] resolved {ordered.Count} dep(s)");
                 // Under --verbose, name the package that actually WON for each
                 // dependency, with the file it came from. Resolution picks by highest
@@ -1016,7 +1026,7 @@ foreach (var bundle in bundles)
         // topological order (a dep-of-a-dep is written before the app that needs it), and
         // chain them into the compiler. Only sibling-dependency TARGETS are compiled here —
         // this is an extra compile per app, and most bundles (the corpus: one app) have none.
-        EmitSiblingSymbols(appGroups, bundleAbs);
+        EmitSiblingSymbols(appGroups, bundleAbs, bundleResolvedDeps);
 
         var loadedAssemblies = new List<Assembly>();
         // SetTestAssembly re-runs its full body (incl. NavAppResourcePatches.RegisterTestAssembly)
@@ -3619,8 +3629,25 @@ static string? SelectVersionDirOrNull(string root, string versionPrefix)
 /// Failures are loud but non-fatal: without the symbols the dependent app fails to compile
 /// with AL0185, which is exactly the state this fixes, and the emit-retry already reports
 /// the dropped objects.
+///
+/// <paramref name="bundleResolvedDeps"/> is this bundle's resolved Microsoft-platform
+/// dependency closure (the same set every suite under a parent-of-many-apps bundle
+/// implicitly gets — Base Application, System Application, …). It is recorded in each
+/// sibling's *.symbols.deps.json sidecar so BC's ReferenceManager can see that the
+/// sibling itself depends on (e.g.) Base Application. Without it a sibling whose only
+/// AL is a `tableextension ... extends <PlatformTable>` gets an EMPTY sidecar — its
+/// declaring module has no recorded path to the module owning the base table, so the
+/// extension never attaches: the base table's own fields resolve fine (they come from
+/// the primary compile's own direct reference to the platform .app) but the extension
+/// field does not, surfacing as AL0132 "'Record X' does not contain a definition for
+/// '<field>'" in the app that consumes it. A sibling that only extends another sibling's
+/// OWN table (the common case in this bundle) never depended on this fix — its base
+/// table lives in the SAME symbols.json as the extension, so no cross-module link was
+/// needed. See #1686.
 /// </summary>
-static void EmitSiblingSymbols(List<AlRunner.AppGroup> appGroups, string bundleAbs)
+static void EmitSiblingSymbols(
+    List<AlRunner.AppGroup> appGroups, string bundleAbs,
+    IReadOnlyList<(AlRunner.AppManifest Manifest, string AppPath)> bundleResolvedDeps)
 {
     BcCompiler.SetSiblingSymbolsDir(null);
     // Not a dictionary: two suites in the same tree can (and in tests/runner-extras do)
@@ -3668,12 +3695,21 @@ static void EmitSiblingSymbols(List<AlRunner.AppGroup> appGroups, string bundleA
             // The dependency closure this app compiled against, so BC's ReferenceManager can
             // link types from it that appear in the sibling's public surface — same reason as
             // the source-dep sidecar (#1546); without it those types are __MissingTypeSymbol__.
+            //
+            // Include the BUNDLE-WIDE Microsoft-platform closure (bundleResolvedDeps) — every
+            // suite under a parent-of-many-apps bundle implicitly compiles against it, this
+            // sibling included. Without it, a sibling whose only AL is a `tableextension ...
+            // extends <PlatformTable>` records an empty dependency closure: its declaring
+            // module has no path to the module owning the base table, so the extension never
+            // attaches downstream (AL0132 in the consuming app) even though the sibling's own
+            // symbols.json genuinely contains the TableExtension entry. See #1686.
             DepsSidecarWriter.Write(
                 Path.Combine(dir, $"{group.AppId:N}.symbols.deps.json"),
                 group.Publisher ?? "AlRunner", group.ModuleName,
                 group.Version ?? new Version(1, 0, 0, 0), group.AppId.Value,
                 DepsSidecarWriter.BuildClosure(
-                    Array.Empty<DepsSidecarWriter.DepEntry>(),
+                    bundleResolvedDeps.Select(d => new DepsSidecarWriter.DepEntry(
+                        d.Manifest.Publisher, d.Manifest.Name, d.Manifest.Version, d.Manifest.AppId)),
                     ScanVendoredPlatformApps(
                         Directory.EnumerateDirectories(bundleAbs, ".alpackages", SearchOption.AllDirectories)),
                     group.AppId.Value));

--- a/tests/runner-extras/dep-tableext-platform-base-dep/ItemExt.TableExt.al
+++ b/tests/runner-extras/dep-tableext-platform-base-dep/ItemExt.TableExt.al
@@ -1,0 +1,15 @@
+/// <summary>
+/// TableExtension defined in the DEPENDENCY app on the PLATFORM table Item (27).
+/// Item's own base-table metadata is served from the precompiled Base Application
+/// .app — this bundle has no AL source for Item itself. Two fields on purpose: a
+/// Boolean and an Integer, so a stub implementation that only handles one AL type
+/// can't accidentally pass every test.
+/// </summary>
+tableextension 61881 "DTB Item Ext" extends Item
+{
+    fields
+    {
+        field(61881; "DTB Repro Flag"; Boolean) { DataClassification = CustomerContent; }
+        field(61882; "DTB Repro Counter"; Integer) { DataClassification = CustomerContent; }
+    }
+}

--- a/tests/runner-extras/dep-tableext-platform-base-dep/app.json
+++ b/tests/runner-extras/dep-tableext-platform-base-dep/app.json
@@ -1,0 +1,25 @@
+{
+  "id": "5d3c2b1a-6f4e-4a2d-9c1b-8e7f6a5d4c31",
+  "name": "DTB Platform Base Dep",
+  "publisher": "AL Runner",
+  "version": "1.0.0.0",
+  "brief": "Dependency app: extends the platform Item table (27) with a tableextension.",
+  "description": "Cross-bundle half of dep-tableext-platform-base. Regression fixture for #1686: a dependency app extending a PLATFORM-APP table (Item, table 27 — base metadata comes from the precompiled Base Application .app, not from any AL source in this bundle) used to corrupt that table's NCLMetaTable when the dependency's source dir got registered twice by BuildSiblingSourceDeps, producing a duplicated extension field id that crashed NCLMetaTable.SetSystemFields() with a bare NullReferenceException, surfaced as the misleading 'no NCLMetaTable for table 27 (AL source not parsed)'.",
+  "privacyStatement": "",
+  "EULA": "",
+  "help": "",
+  "url": "",
+  "logo": "",
+  "dependencies": [],
+  "screenshots": [],
+  "idRanges": [
+    {
+      "from": 61880,
+      "to": 61889
+    }
+  ],
+  "platform": "27.0.0.0",
+  "application": "27.0.0.0",
+  "runtime": "15.0",
+  "target": "Cloud"
+}

--- a/tests/runner-extras/dep-tableext-platform-base-main/Assert.Codeunit.al
+++ b/tests/runner-extras/dep-tableext-platform-base-main/Assert.Codeunit.al
@@ -1,0 +1,20 @@
+codeunit 63410 "DTB Assert"
+{
+    procedure AreEqual(Expected: Boolean; Actual: Boolean; Msg: Text)
+    begin
+        if Expected <> Actual then
+            Error('Expected %1 but got %2: %3', Expected, Actual, Msg);
+    end;
+
+    procedure AreEqual(Expected: Integer; Actual: Integer; Msg: Text)
+    begin
+        if Expected <> Actual then
+            Error('Expected %1 but got %2: %3', Expected, Actual, Msg);
+    end;
+
+    procedure ExpectedErrorContains(ErrorText: Text; Fragment: Text; Msg: Text)
+    begin
+        if not ErrorText.Contains(Fragment) then
+            Error('Expected error text to contain ''%1'' but got ''%2'': %3', Fragment, ErrorText, Msg);
+    end;
+}

--- a/tests/runner-extras/dep-tableext-platform-base-main/DtbTests.Codeunit.al
+++ b/tests/runner-extras/dep-tableext-platform-base-main/DtbTests.Codeunit.al
@@ -1,0 +1,100 @@
+/// <summary>
+/// Regression suite for #1686: "Platform-app table metadata lost when a dependency
+/// app extends the table". The extension in "DTB Platform Base Dep" adds two fields
+/// to the platform Item table (27) — a table whose OWN base metadata is served from
+/// the precompiled Base Application .app, never from AL source in either bundle.
+///
+/// RED (without the fix): every test below throws
+///   InvalidOperationException: NavRecordHandle.CreateTarget: no NCLMetaTable for
+///   table 27 (AL source not parsed)
+/// — actually a duplicated-field NullReferenceException inside
+/// NCLMetaTable.SetSystemFields(), caused by BuildSiblingSourceDeps registering the
+/// dependency's source dir twice (see RecordPatches.AddSourceDir / .AlSourceParser.cs).
+///
+/// GREEN (with the fix): both extension fields round-trip through Record Item exactly
+/// like fields declared in the same bundle would.
+/// </summary>
+codeunit 63411 "DTB TableExt Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit "DTB Assert";
+
+    /// <summary>
+    /// Positive: a Boolean field from a dependency-declared tableextension on the
+    /// platform Item table round-trips through Insert + Get.
+    /// </summary>
+    [Test]
+    procedure ItemRoundtrip_BooleanExtensionField_ReturnsInsertedValue()
+    var
+        Item: Record Item;
+    begin
+        Item.Init();
+        Item."No." := 'DTB-BOOL-1';
+        Item."DTB Repro Flag" := true;
+        Item.Insert();
+
+        Item.Get('DTB-BOOL-1');
+
+        Assert.AreEqual(true, Item."DTB Repro Flag",
+            'Boolean extension field must round-trip through Insert/Get exactly like an own-bundle field');
+    end;
+
+    /// <summary>
+    /// Positive: an Integer field from the same dependency tableextension round-trips
+    /// with a non-default value. Guards against a stub implementation that would only
+    /// ever satisfy the Boolean case above (e.g. by always returning the type default).
+    /// </summary>
+    [Test]
+    procedure ItemRoundtrip_IntegerExtensionField_ReturnsInsertedValue()
+    var
+        Item: Record Item;
+    begin
+        Item.Init();
+        Item."No." := 'DTB-INT-1';
+        Item."DTB Repro Counter" := 57;
+        Item.Insert();
+
+        Item.Get('DTB-INT-1');
+
+        Assert.AreEqual(57, Item."DTB Repro Counter",
+            'Integer extension field must round-trip through Insert/Get with a concrete non-default value');
+    end;
+
+    /// <summary>
+    /// Positive: Init() leaves the dependency-declared extension fields at their AL
+    /// type defaults (false / 0) until explicitly assigned — proves the fields are
+    /// really wired into the record's field list (not silently absent, which would
+    /// otherwise leave the record uninitialized rather than zero-valued).
+    /// </summary>
+    [Test]
+    procedure ItemInit_ExtensionFieldsDefaultToTypeDefaults()
+    var
+        Item: Record Item;
+    begin
+        Item.Init();
+
+        Assert.AreEqual(false, Item."DTB Repro Flag",
+            'Init() must leave the Boolean extension field at its type default (false)');
+        Assert.AreEqual(0, Item."DTB Repro Counter",
+            'Init() must leave the Integer extension field at its type default (0)');
+    end;
+
+    /// <summary>
+    /// Negative: Get() on a "No." that was never inserted still raises BC's real
+    /// "does not exist" error on the platform Item table — proving table 27's
+    /// NCLMetaTable (with the dependency's extension fields merged in) is the real
+    /// BC record-not-found path, not a fake that swallows the lookup miss.
+    /// </summary>
+    [Test]
+    procedure ItemGet_NonExistentNo_RaisesDoesNotExistError()
+    var
+        Item: Record Item;
+    begin
+        asserterror Item.Get('DTB-DOES-NOT-EXIST');
+
+        Assert.ExpectedErrorContains(GetLastErrorText(), 'does not exist',
+            'Get() on a missing key must raise BC''s real record-not-found error');
+    end;
+}

--- a/tests/runner-extras/dep-tableext-platform-base-main/app.json
+++ b/tests/runner-extras/dep-tableext-platform-base-main/app.json
@@ -1,0 +1,32 @@
+{
+  "id": "5d3c2b1a-6f4e-4a2d-9c1b-8e7f6a5d4c32",
+  "name": "DTB Platform Base Main",
+  "publisher": "AL Runner",
+  "version": "1.0.0.0",
+  "brief": "Main test app: proves the DEPENDENCY-declared tableextension on the platform Item table round-trips correctly.",
+  "description": "Regression test for #1686: 'Platform-app table metadata lost when a dependency app extends the table'. Depends on DTB Platform Base Dep, which extends the platform Item table (27). Before the fix, building table 27's NCLMetaTable crashed with a NullReferenceException inside NCLMetaTable.SetSystemFields() (surfaced as 'no NCLMetaTable for table 27 (AL source not parsed)') because BuildSiblingSourceDeps registered the dependency's source dir twice, duplicating the extension's field ids in the merged metadata.",
+  "privacyStatement": "",
+  "EULA": "",
+  "help": "",
+  "url": "",
+  "logo": "",
+  "dependencies": [
+    {
+      "id": "5d3c2b1a-6f4e-4a2d-9c1b-8e7f6a5d4c31",
+      "name": "DTB Platform Base Dep",
+      "publisher": "AL Runner",
+      "version": "1.0.0.0"
+    }
+  ],
+  "screenshots": [],
+  "idRanges": [
+    {
+      "from": 63410,
+      "to": 63419
+    }
+  ],
+  "platform": "27.0.0.0",
+  "application": "27.0.0.0",
+  "runtime": "15.0",
+  "target": "Cloud"
+}


### PR DESCRIPTION
Closes #1686

## Root cause

`BuildSiblingSourceDeps` (Program.cs) calls `RecordPatches.AddSourceDir(dir)` twice for the same dependency source directory — once while matching a bundle's declared dependencies to sibling source apps, once while emitting the synthetic workspace `.app` for a dependency that needs a fresh build. `AddSourceDir` had no dedup, so the same directory landed twice in `_sourceDirs`, and `ParseAllSources()` parsed the dependency's `.al` files twice on the next `Register()`.

For a dependency that declares a `tableextension` on a table whose base metadata comes from elsewhere (e.g. a platform-app table like `Item`, table 27), this duplicated every extension field id inside `_parsedExtensionFields`. The duplicated `NCLMetaField` entries with the same `FieldNo` corrupted `NCLMetaTable.AssignFromMetaTable`'s positional field-count arithmetic in the precompiled `Ncl.dll`, crashing deep inside `NCLMetaTable.SetSystemFields()` with a bare `NullReferenceException`. That NRE was caught and surfaced to the caller as the misleading `"no NCLMetaTable for table 27 (AL source not parsed)"`, which hid the real cause.

Verified by decompiling `NCLMetaTable` from the exact BC build in the issue (27.0.38460.53260) and confirming the crash site.

## Fix

- `RecordPatches.AddSourceDir` now dedupes by directory path before adding to `_sourceDirs`.
- `RecordPatches.TryParseTableExtensionFile`'s merge into `_parsedExtensionFields` now also dedupes by field id — defense in depth, mirroring the existing symbol-index merge pattern in `EnsureBcSymbolExtensionIndex`.

## Test

New regression suite `tests/runner-extras/dep-tableext-platform-base-dep` / `-main` reproduces the issue's exact two-bundle repro: a dependency app extends the platform `Item` table (27), a separate main app consumes it via `Record Item`. Four tests: Boolean and Integer extension-field roundtrip, `Init()` default-value check, and a negative case (`Get()` on a missing key still raises BC's real "does not exist" error).

- RED (fix reverted): all 4 new tests fail with exactly the issue's reported error.
- GREEN (fix applied): all 4 pass.
- Full `tests/runner-extras` (93/93) and `tests/al-language` corpus (1904/1904) still green with the fix applied — confirmed no regressions.

`docs/coverage.yaml` was archived in the v2 architecture cutover (#1654) and superseded by `tests/al-language` + `tests/expectations`; there's no live file to update for this fix.