### PR TITLE
fix(reporter): --output-json crashed when two bundles shared a basename

### DIFF
--- a/AlRunner.Tests/ReporterDuplicateBucketNameTests.cs
+++ b/AlRunner.Tests/ReporterDuplicateBucketNameTests.cs
@@ -1,0 +1,89 @@
+// ReporterDuplicateBucketNameTests — RED→GREEN guard for #1692.
+//
+// SerializeJsonOutput used to build a Dictionary keyed on Path.GetFileName(BucketPath)
+// for the compile-failed buckets. Two bundles sharing a last path segment
+// (`al-runner ./appA/src ./appB/src`, or the same directory passed twice) collided on
+// that key and threw an unhandled ArgumentException — "An item with the same key has
+// already been added. Key: src" — during report serialisation, i.e. AFTER the tests had
+// already run, so a completed run's results were discarded with a raw stack trace.
+//
+// These assert the two collision shapes serialise, that each bucket keeps its OWN
+// errors under a distinguishable full path, and that the field stays absent when
+// nothing failed to compile.
+using System.Text.Json;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public class ReporterDuplicateBucketNameTests
+{
+    private static BucketResult CompileFailed(string path, params string[] errors) =>
+        new(path, BucketStage.CompileFailed, errors, null, Array.Empty<TestResult>(),
+            TimeSpan.Zero, TimeSpan.Zero, TimeSpan.Zero);
+
+    private static JsonElement Serialize(params BucketResult[] buckets)
+    {
+        var json = Reporter.SerializeJsonOutput(buckets, exitCode: 3);
+        return JsonDocument.Parse(json).RootElement.Clone();
+    }
+
+    private static List<(string File, List<string> Errors)> CompilationErrors(JsonElement root) =>
+        root.GetProperty("compilationErrors").EnumerateArray()
+            .Select(e => (
+                e.GetProperty("file").GetString()!,
+                e.GetProperty("errors").EnumerateArray().Select(x => x.GetString()!).ToList()))
+            .ToList();
+
+    [Fact]
+    public void SerializeJsonOutput_DistinctBundlesSharingBasename_KeepsBothDistinguishable()
+    {
+        var a = Path.Combine(Path.DirectorySeparatorChar + "work", "appA", "src");
+        var b = Path.Combine(Path.DirectorySeparatorChar + "work", "appB", "src");
+
+        var root = Serialize(
+            CompileFailed(a, "Tests.al: COMPILE-FAIL (1): CS0246 appA"),
+            CompileFailed(b, "Tests.al: COMPILE-FAIL (1): CS0103 appB"));
+
+        var groups = CompilationErrors(root);
+        Assert.Equal(2, groups.Count);
+        // Full paths, not the shared "src" basename — otherwise the two bundles are
+        // indistinguishable in the output even once the crash is gone.
+        Assert.Equal(new[] { a, b }, groups.Select(g => g.File).ToArray());
+        // Each bucket keeps its OWN errors — no merging, no cross-contamination.
+        Assert.Equal(new[] { "Tests.al: COMPILE-FAIL (1): CS0246 appA" }, groups[0].Errors);
+        Assert.Equal(new[] { "Tests.al: COMPILE-FAIL (1): CS0103 appB" }, groups[1].Errors);
+    }
+
+    [Fact]
+    public void SerializeJsonOutput_SameBundlePassedTwice_EmitsOneEntryPerBucket()
+    {
+        var dir = Path.Combine(Path.DirectorySeparatorChar + "work", "broken3");
+
+        var root = Serialize(
+            CompileFailed(dir, "CS0246 first pass"),
+            CompileFailed(dir, "CS0246 second pass"));
+
+        var groups = CompilationErrors(root);
+        Assert.Equal(2, groups.Count);
+        Assert.All(groups, g => Assert.Equal(dir, g.File));
+        Assert.Equal(new[] { "CS0246 first pass" }, groups[0].Errors);
+        Assert.Equal(new[] { "CS0246 second pass" }, groups[1].Errors);
+    }
+
+    // Negative direction: nothing compile-failed → the field must be ABSENT, not an
+    // empty array, and a bucket that ran must never leak into it.
+    [Fact]
+    public void SerializeJsonOutput_NoCompileFailures_OmitsCompilationErrors()
+    {
+        var ran = new BucketResult(
+            Path.Combine(Path.DirectorySeparatorChar + "work", "appA", "src"),
+            BucketStage.Ran, Array.Empty<string>(), null,
+            new[] { new TestResult("CU", "T", TestOutcome.Pass, null, null, TimeSpan.Zero) },
+            TimeSpan.Zero, TimeSpan.Zero, TimeSpan.Zero);
+
+        var root = Serialize(ran);
+
+        Assert.False(root.TryGetProperty("compilationErrors", out _));
+        Assert.Equal(1, root.GetProperty("passed").GetInt32());
+    }
+}

--- a/AlRunner/Reporter.cs
+++ b/AlRunner/Reporter.cs
@@ -177,11 +177,20 @@ public static class Reporter
             .SelectMany(b => b.Tests)
             .ToList();
 
+        // One entry per compile-failed bucket, identified by its FULL path. This used to
+        // build a Dictionary keyed on Path.GetFileName(BucketPath), which threw an
+        // unhandled ArgumentException ("An item with the same key has already been added")
+        // whenever two bundles shared a last path segment — `al-runner ./appA/src
+        // ./appB/src`, or the same directory passed twice. That fired here, during report
+        // serialisation and AFTER the tests had already run, so a completed run's results
+        // were discarded with a raw stack trace. The dictionary bought nothing: the result
+        // is projected straight back into an array. Full paths also keep same-named
+        // bundles distinguishable in the output — same field name as WriteClassification's
+        // `bucket`. See #1692.
         var compileErrors = buckets
             .Where(b => b.Stage == BucketStage.CompileFailed)
-            .ToDictionary(
-                b => Path.GetFileName(b.BucketPath),
-                b => b.CompileErrors.ToList());
+            .Select(b => new { file = b.BucketPath, errors = b.CompileErrors.ToList() })
+            .ToList();
 
         var output = new
         {
@@ -198,9 +207,7 @@ public static class Reporter
             errors = tests.Count(t => t.Outcome == TestOutcome.Error),
             total = tests.Count,
             exitCode,
-            compilationErrors = compileErrors.Count > 0
-                ? compileErrors.Select(kvp => new { file = kvp.Key, errors = kvp.Value })
-                : null,
+            compilationErrors = compileErrors.Count > 0 ? compileErrors : null,
         };
 
         return JsonSerializer.Serialize(output, new JsonSerializerOptions


### PR DESCRIPTION
Closes #1692

## Root cause

`Reporter.SerializeJsonOutput` built a `Dictionary` from the compile-failed buckets keyed on `Path.GetFileName(b.BucketPath)`. Two bundle directories sharing a last path segment collide on that key and `ToDictionary` throws:

```
Unhandled exception. System.ArgumentException: An item with the same key has already been added. Key: broken3
   at System.Linq.Enumerable.ToDictionary[...]
   at AlRunner.Reporter.SerializeJsonOutput(...)
```

Two ways to hit it, neither requiring a mistake by the caller in the second case:

- `al-runner ./some/broken3 ./some/broken3` — same directory twice
- `al-runner ./appA/src ./appB/src` — two projects with a conventional layout

It fires during report serialisation, i.e. **after** the tests have already executed, so a completed run's results are discarded and replaced by a raw stack trace — the opposite of the loud, named failures `--help` and the guide promise.

## Fix

The dictionary bought nothing: its contents were projected straight back into an array via `.Select(kvp => new { file, errors })`. It never needed to be keyed at all.

Now one `{file, errors}` entry per compile-failed bucket, identified by the bucket's **full** path. That is the issue's preferred option — it also keeps same-named bundles distinguishable in the output, and matches the `bucket` field `WriteClassification` already emits. A full-path *key* alone would still have collided on the same-directory-twice case; emitting per bucket handles both.

Only `--output-json`'s serialiser changes. Server mode's `compilationErrors` goes through a separate `CompilationErrorGroup` path and is untouched, as is the JUnit writer (already a `GroupBy`, no dictionary).

## Tests

New `AlRunner.Tests/ReporterDuplicateBucketNameTests.cs`, strict RED → GREEN:

| Test | Before | After |
| --- | --- | --- |
| distinct bundles sharing a basename (`/work/appA/src`, `/work/appB/src`) | `ArgumentException: ... Key: src` | 2 entries, full paths, each keeping its own errors |
| same bundle passed twice (`/work/broken3` ×2) | `ArgumentException: ... Key: broken3` | one entry per bucket, errors not merged |
| no compile failures (negative) | passed | still passes — field absent, not an empty array |

The first two reproduce the reported exception verbatim against the pre-fix code. Assertions are on concrete paths and concrete error strings, so they cannot pass against a serialiser that returns defaults or merges the groups.

## Verification note

The environment this was developed in has no BC artifacts, so the full `AlRunner.Tests` suite could not be run locally. `Reporter` has no BC dependencies, so the new tests were executed against the real `AlRunner/Reporter.cs` compiled into a standalone harness (RED confirmed, then GREEN). CI covers the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BHg4dcEzJ7i5Aeo7hKyfFW

---
_Generated by [Claude Code](https://claude.ai/code/session_01BHg4dcEzJ7i5Aeo7hKyfFW)_