### PR TITLE
fix(pkgdedup): transient Windows staging-move failure no longer kills the run

### DIFF
--- a/AlRunner.Tests/PkgDedupStagingPublishTests.cs
+++ b/AlRunner.Tests/PkgDedupStagingPublishTests.cs
@@ -1,0 +1,144 @@
+// PkgDedupStagingPublishTests — RED→GREEN guard for #1691.
+//
+// BcCompiler's package-dedup staging used to end in a bare
+//
+//     try { Directory.Move(tmp, stage); }
+//     catch { if (!Directory.Exists(stage)) throw; ... }
+//
+// On Windows that move intermittently fails with "Access to the path '...tmp-...' is
+// denied" when the staged files were written moments earlier (AV/indexer handle), so the
+// rethrow killed the run with `EMIT-FAIL — IOException` — roughly 1 run in 5 on a
+// non-admin box, where every staged entry is a full copy rather than a symlink.
+//
+// The failing move cannot be provoked portably by holding a handle, so these drive the
+// same code path with a blocker that makes Directory.Move throw while leaving `stage`
+// non-existent as a DIRECTORY: a plain file sitting at the stage path. That is exactly the
+// state the old rethrow branch keyed on (`!Directory.Exists(stage)` → throw), so it
+// exercises the real fallback, and the injected backoff hook drives the retry
+// deterministically instead of relying on timing.
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public class PkgDedupStagingPublishTests : IDisposable
+{
+    private readonly string _root;
+
+    public PkgDedupStagingPublishTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "al-runner-pkgdedup-tests",
+                             Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { }
+    }
+
+    // A scratch dir shaped like the real one: one staged .app per picked package.
+    private string StagedTmp(params string[] appNames)
+    {
+        var tmp = Path.Combine(_root, "key.tmp-" + Guid.NewGuid().ToString("N")[..8]);
+        Directory.CreateDirectory(tmp);
+        foreach (var name in appNames)
+            File.WriteAllText(Path.Combine(tmp, name), "staged:" + name);
+        return tmp;
+    }
+
+    private string StagePath => Path.Combine(_root, "key");
+
+    [Fact]
+    public void Publish_MoveSucceeds_ReturnsStageWithContentAndRemovesTmp()
+    {
+        var tmp = StagedTmp("A.app", "B.app");
+
+        var used = AlRunner.Infrastructure.PkgDedupStaging.Publish(tmp, StagePath);
+
+        Assert.Equal(StagePath, used);
+        Assert.False(Directory.Exists(tmp), "scratch dir should be gone after a clean move");
+        Assert.Equal(new[] { "A.app", "B.app" }, Directory.GetFiles(used)
+            .Select(Path.GetFileName).OrderBy(x => x, StringComparer.Ordinal).ToArray());
+        Assert.Equal("staged:A.app", File.ReadAllText(Path.Combine(used, "A.app")));
+    }
+
+    [Fact]
+    public void Publish_StageAlreadyPublished_AdoptsItAndDropsTmp()
+    {
+        // A concurrent compile won the race for the same content-addressed key.
+        Directory.CreateDirectory(StagePath);
+        File.WriteAllText(Path.Combine(StagePath, "A.app"), "published-by-the-racer");
+        var tmp = StagedTmp("A.app");
+
+        var used = AlRunner.Infrastructure.PkgDedupStaging.Publish(tmp, StagePath);
+
+        Assert.Equal(StagePath, used);
+        Assert.False(Directory.Exists(tmp), "the duplicate scratch dir should be cleaned up");
+        // The winner's directory is left exactly as it was — not merged, not overwritten.
+        Assert.Equal("published-by-the-racer", File.ReadAllText(Path.Combine(used, "A.app")));
+    }
+
+    [Fact]
+    public void Publish_TransientFailure_RetriesAndStillPublishesStage()
+    {
+        var blocker = StagePath;
+        File.WriteAllText(blocker, "not a directory"); // makes Directory.Move throw
+        var tmp = StagedTmp("A.app");
+
+        var attemptsSeen = new List<int>();
+        var used = AlRunner.Infrastructure.PkgDedupStaging.Publish(
+            tmp, StagePath, warn: null, attempts: 5,
+            // Clear the blocker after the first failure — the transient-handle case.
+            backoff: attempt => { attemptsSeen.Add(attempt); if (attempt == 1) File.Delete(blocker); });
+
+        // Retried exactly once, then succeeded: the shared reusable dir IS published, which
+        // is the whole point of retrying rather than falling straight back to the scratch dir.
+        Assert.Equal(new[] { 1 }, attemptsSeen.ToArray());
+        Assert.Equal(StagePath, used);
+        Assert.False(Directory.Exists(tmp));
+        Assert.Equal("staged:A.app", File.ReadAllText(Path.Combine(used, "A.app")));
+    }
+
+    // Negative direction: the move never succeeds. The old code threw here (killing a run
+    // whose tests had not even started); the contract now is a usable directory + a notice.
+    [Fact]
+    public void Publish_PersistentFailure_FallsBackToTmpAndWarnsInsteadOfThrowing()
+    {
+        File.WriteAllText(StagePath, "not a directory"); // never cleared
+        var tmp = StagedTmp("A.app", "B.app");
+        var warn = new StringWriter();
+
+        var used = AlRunner.Infrastructure.PkgDedupStaging.Publish(
+            tmp, StagePath, warn, attempts: 3, backoff: _ => { });
+
+        // Falls back to the scratch dir — which carries the identical staged set, so the
+        // compile that consumes it sees exactly what the published dir would have held.
+        Assert.Equal(tmp, used);
+        Assert.True(Directory.Exists(tmp), "the fallback directory must survive");
+        Assert.Equal(new[] { "A.app", "B.app" }, Directory.GetFiles(used)
+            .Select(Path.GetFileName).OrderBy(x => x, StringComparer.Ordinal).ToArray());
+
+        // And it says so, naming both paths — a silent fallback would hide a real cache miss.
+        var text = warn.ToString();
+        Assert.Contains("[pkgdedup]", text);
+        Assert.Contains(StagePath, text);
+        Assert.Contains(tmp, text);
+        Assert.Contains("3 attempt(s)", text);
+    }
+
+    [Fact]
+    public void Publish_PersistentFailure_ExhaustsEveryAttemptBeforeGivingUp()
+    {
+        File.WriteAllText(StagePath, "not a directory");
+        var tmp = StagedTmp("A.app");
+
+        var attemptsSeen = new List<int>();
+        var used = AlRunner.Infrastructure.PkgDedupStaging.Publish(
+            tmp, StagePath, warn: null, attempts: 4,
+            backoff: attempt => attemptsSeen.Add(attempt));
+
+        // 4 attempts → backoff after 1,2,3 and none after the last: no wasted final sleep.
+        Assert.Equal(new[] { 1, 2, 3 }, attemptsSeen.ToArray());
+        Assert.Equal(tmp, used);
+    }
+}

--- a/AlRunner/BcCompiler.cs
+++ b/AlRunner/BcCompiler.cs
@@ -685,8 +685,14 @@ public sealed class BcCompiler
                     try { File.CreateSymbolicLink(dst, src); }
                     catch { try { File.Copy(src, dst, overwrite: true); } catch { } }
                 }
-                try { Directory.Move(tmp, stage); }
-                catch { if (!Directory.Exists(stage)) throw; try { Directory.Delete(tmp, true); } catch { } }
+                // Publishing the scratch dir under its content-addressed name is best-effort:
+                // on Windows the move of a just-written tree intermittently hits a transient
+                // "Access to the path ... is denied", and rethrowing there killed whole runs
+                // at emit time (#1691). Publish retries, then falls back to the scratch dir —
+                // same staged files, so the compile is unaffected; only the cross-compile
+                // reuse of this key is lost.
+                return new List<string> {
+                    AlRunner.Infrastructure.PkgDedupStaging.Publish(tmp, stage, Console.Error) };
             }
             return new List<string> { stage };
         }

--- a/AlRunner/Infrastructure/PkgDedupStaging.cs
+++ b/AlRunner/Infrastructure/PkgDedupStaging.cs
@@ -1,0 +1,91 @@
+// PkgDedupStaging — publishes BcCompiler's package-dedup staging directory from its
+// per-run `<key>.tmp-<rand>` scratch name to the shared, content-addressed `<key>` name.
+//
+// Split out of BcCompiler.DeduplicateAppPackageDirs so the publish step can be unit
+// tested on its own: BcCompiler drags the whole BC service-tier reference chain in with
+// it, while this is plain filesystem logic.
+//
+// Why it is not a bare Directory.Move (#1691): on Windows the move of a directory whose
+// files were written moments earlier intermittently fails with
+//
+//     IOException: Access to the path 'C:\...\Temp\al-runner-pkgdedup\<key>.tmp-<rand>' is denied.
+//
+// consistent with an AV scanner or the search indexer briefly holding a handle inside the
+// freshly-written tree. It is transient — an immediate re-run of the same command always
+// passes — but the old code rethrew, which surfaced as `EMIT-FAIL — IOException` and killed
+// the whole run (reported at ~1 in 5 runs on a non-admin Windows box, where symlink creation
+// is unavailable so every staged entry is a full file copy and the write volume is highest).
+//
+// Two changes make that non-fatal, in order of preference:
+//   1. Retry the move a few times with a short backoff, so the common transient handle
+//      clears and the shared, reusable `<key>` dir still gets published.
+//   2. If it still will not move, fall back to using the scratch directory itself. Its
+//      contents are exactly what the move would have published — same files, staged by the
+//      same code path — so the compile that consumes it behaves identically. All that is
+//      lost is cross-compile reuse of this one key, which is a cache miss, not a wrong
+//      answer. That is strictly better than discarding a run that is already half done.
+using System.Diagnostics;
+
+namespace AlRunner.Infrastructure;
+
+internal static class PkgDedupStaging
+{
+    internal const int DefaultAttempts = 5;
+
+    /// <summary>
+    /// Move <paramref name="tmp"/> onto <paramref name="stage"/> and return the directory
+    /// callers should scan. That is <paramref name="stage"/> whenever it can be published or
+    /// already exists, and <paramref name="tmp"/> when it cannot — never an exception, and
+    /// never a directory that is missing the staged packages.
+    /// </summary>
+    /// <param name="warn">Where the fallback notice goes; null suppresses it.</param>
+    /// <param name="attempts">Total move attempts, including the first.</param>
+    /// <param name="backoff">
+    /// Called with the 1-based attempt number after each failed attempt except the last.
+    /// Tests inject it to drive the retry deterministically; production uses a short sleep.
+    /// </param>
+    internal static string Publish(string tmp, string stage, TextWriter? warn = null,
+                                   int attempts = DefaultAttempts, Action<int>? backoff = null)
+    {
+        Debug.Assert(attempts >= 1);
+        for (int attempt = 1; attempt <= attempts; attempt++)
+        {
+            try
+            {
+                Directory.Move(tmp, stage);
+                return stage;
+            }
+            catch (Exception ex)
+            {
+                // Another compile — in this process or a concurrent al-runner — published the
+                // same key first. The key is a hash of the picked .app set, so their directory
+                // is ours by construction: adopt it and drop the duplicate.
+                if (Directory.Exists(stage))
+                {
+                    TryDelete(tmp);
+                    return stage;
+                }
+                if (attempt == attempts)
+                {
+                    warn?.WriteLine(
+                        $"  [pkgdedup] could not publish staging dir to '{stage}' after " +
+                        $"{attempts} attempt(s) ({ex.GetType().Name}: {ex.Message}) — " +
+                        $"using '{tmp}' for this run");
+                    return tmp;
+                }
+            }
+            // Between attempts only. The caller holds BcCompiler's staging lock here, so this
+            // is deliberately bounded and short (150ms total at the default 5 attempts) — the
+            // handle this waits on is held by a scanner for milliseconds, and the alternative
+            // being traded against is losing the run outright.
+            if (backoff != null) backoff(attempt);
+            else Thread.Sleep(10 * attempt);
+        }
+        return tmp; // not reachable: the attempts==attempt branch above always returns
+    }
+
+    private static void TryDelete(string dir)
+    {
+        try { Directory.Delete(dir, recursive: true); } catch { }
+    }
+}


### PR DESCRIPTION
Closes #1691

## Root cause

`BcCompiler.DeduplicateAppPackageDirs` staged the picked `.app` set into `<key>.tmp-<rand>` and published it with a bare move:

```csharp
try { Directory.Move(tmp, stage); }
catch { if (!Directory.Exists(stage)) throw; try { Directory.Delete(tmp, true); } catch { } }
```

When the move fails and `stage` does not exist, that rethrows — surfacing as `EMIT-FAIL — IOException: Access to the path '...tmp-...' is denied` and killing the run.

The report's evidence points squarely at the move rather than the staging copy: the orphaned `.tmp-*` dir left behind held all 118 staged `.app` files, fully written, and that orphan-without-a-sibling state is only reachable through the rethrow branch. The trigger is transient — an immediate re-run always passes — and it concentrates where write volume is highest (non-admin Windows, no Developer Mode → `File.CreateSymbolicLink` throws and every entry becomes a full `File.Copy`).

I have not proven the handle-holder either, and the fix does not depend on which one it is: what it fixes is that a *recoverable* condition was terminal.

## Fix

The publish step moves to `AlRunner/Infrastructure/PkgDedupStaging.cs` — plain filesystem logic, testable without dragging in `BcCompiler`'s BC service-tier reference chain. Two changes, in order of preference:

1. **Retry** the move a few times with a short bounded backoff (150 ms total at the default 5 attempts), so the common transient handle clears and the shared, reusable `<key>` dir still gets published.
2. **Fall back to the scratch directory** if it still will not move. Its contents are exactly what the move would have published — same files, staged by the same code path — so the compile that consumes it behaves identically. What is lost is cross-compile reuse of that one key: a cache miss, not a wrong answer, and strictly better than discarding a run at emit time.

The fallback writes a `[pkgdedup]` notice naming both paths — per `loud-failures.md` this degradation is visible, not silent. The race branch (another compile published the same content-addressed key first) keeps its existing adopt-and-delete behaviour.

## Tests

New `AlRunner.Tests/PkgDedupStagingPublishTests.cs`. A held file handle can't be provoked portably, so the tests drive the same code path with a blocker that makes `Directory.Move` throw while leaving `stage` non-existent *as a directory* — a plain file at the stage path. That is exactly the state the old rethrow branch keyed on (`!Directory.Exists(stage)` → `throw`), and an injected backoff hook drives the retry deterministically rather than by timing.

Verified RED against a verbatim copy of the pre-fix two-liner, then GREEN against the new helper:

| Test | Pre-fix | After |
| --- | --- | --- |
| clean move | pass | pass — returns `stage`, content intact, scratch gone |
| stage already published by a racer | pass | pass — adopts the winner's dir untouched, drops the duplicate |
| transient failure, blocker cleared after attempt 1 | **throws** | retries exactly once, still publishes `stage` |
| persistent failure | **throws** | returns the scratch dir with all staged files + warns, naming both paths |
| persistent failure, attempt accounting | **throws** | backs off after attempts 1,2,3 of 4 — no wasted final sleep |

Assertions are on concrete file contents, the exact returned path, and the exact attempt sequence, so they cannot pass against a stub that returns a default.

## Verification note

This environment has no BC artifacts, so the full `AlRunner.Tests` suite could not be run locally; the new helper and its tests were compiled and executed standalone (RED → GREEN as above). The one-line `BcCompiler` call site is unverified locally — CI covers it, including the existing `BcCompilerPkgDedupRelativePathTests` / `BcCompilerLoaderSelfExclusionTests` which exercise `DeduplicateAppPackageDirs` end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BHg4dcEzJ7i5Aeo7hKyfFW

---
_Generated by [Claude Code](https://claude.ai/code/session_01BHg4dcEzJ7i5Aeo7hKyfFW)_