### PR TITLE
fix(parser): AL comments no longer read as table/field properties

### DIFF
--- a/AlRunner.Tests/AlSourceParserCommentTests.cs
+++ b/AlRunner.Tests/AlSourceParserCommentTests.cs
@@ -1,0 +1,189 @@
+// AlSourceParserCommentTests — RED→GREEN guard for #1690.
+//
+// The AL source parser matches table/field properties with plain regexes over raw file
+// text, so an ordinary explanatory comment that happens to mention a property name was
+// read AS that property. The reported shape:
+//
+//     // InitValue = true: new rows default to accepted. A consumer filters on
+//     // Accept = true before writing anything.
+//     InitValue = true;
+//
+// RxInitValue matched inside the comment first and `[^;]+` ran on to the semicolon four
+// words later, so the field's InitValue became the comment prose and the real declaration
+// below was never reached. Every Insert of the table then died with
+// `NavNCLEvaluateException: The value "true: new rows default to accepted. ..." can not be
+// evaluated into type Boolean`.
+//
+// These drive the real parser (TryParseTableFile) rather than the comment blanker alone —
+// the blanker passing in isolation would not prove the parser actually consults it. Like
+// BcCompilerLoaderSelfExclusionTests, the private static entry point is reached by
+// reflection; it is pure text/regex logic with no BC runtime involved.
+using System.Reflection;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public class AlSourceParserCommentTests
+{
+    private const int TableId = 61895; // the issue's repro id
+
+    private static readonly Type RecordPatchesType =
+        typeof(AlRunner.Patches.RecordPatches);
+
+    // Parses `source` and returns the ParsedField for `fieldId`, reflected into a tuple so
+    // the test does not need the internal record type's shape.
+    private static (string? InitValueText, string? Caption, string FieldName) ParseField(
+        string source, int fieldId)
+    {
+        var parse = RecordPatchesType.GetMethod("TryParseTableFile",
+            BindingFlags.NonPublic | BindingFlags.Static)
+            ?? throw new InvalidOperationException(
+                "RecordPatches.TryParseTableFile not found by reflection — signature may have changed.");
+        var tablesField = RecordPatchesType.GetField("_parsedTables",
+            BindingFlags.NonPublic | BindingFlags.Static)
+            ?? throw new InvalidOperationException("RecordPatches._parsedTables not found.");
+        var tables = (System.Collections.IDictionary)tablesField.GetValue(null)!;
+
+        try
+        {
+            parse.Invoke(null, new object[] { source });
+            Assert.True(tables.Contains(TableId), $"table {TableId} was not parsed at all");
+            var table = tables[TableId]!;
+            var fields = (System.Collections.IEnumerable)table.GetType()
+                .GetProperty("Fields")!.GetValue(table)!;
+            foreach (var f in fields)
+            {
+                var t = f.GetType();
+                if ((int)t.GetProperty("FieldId")!.GetValue(f)! != fieldId) continue;
+                return ((string?)t.GetProperty("InitValueText")!.GetValue(f),
+                        (string?)t.GetProperty("Caption")!.GetValue(f),
+                        (string)t.GetProperty("FieldName")!.GetValue(f)!);
+            }
+            throw new Xunit.Sdk.XunitException($"field {fieldId} was not parsed");
+        }
+        finally
+        {
+            // Don't leave this fixture table in the process-wide parser state.
+            tables.Remove(TableId);
+        }
+    }
+
+    private static string Table(string acceptFieldBody) => $$"""
+        table {{TableId}} "IC Flag Table"
+        {
+            fields
+            {
+                field(1; "Code"; Code[10]) { }
+                field(2; Accept; Boolean)
+                {
+        {{acceptFieldBody}}
+                }
+            }
+
+            keys
+            {
+                key(PK; "Code") { Clustered = true; }
+            }
+        }
+        """;
+
+    [Fact]
+    public void InitValue_MentionedInLineComment_TakesTheRealDeclaration()
+    {
+        var (initValue, _, _) = ParseField(Table("""
+                    // Per-row user flag bound by a list page to an accept/skip checkbox.
+                    // InitValue = true: new rows default to accepted. A consumer filters on
+                    // Accept = true before writing anything.
+                    Caption = 'Accept';
+                    InitValue = true;
+        """), fieldId: 2);
+
+        // Before the fix this was "true: new rows default to accepted. A consumer filters on
+        // // Accept = true before writing anything." — the comment prose, glued together.
+        Assert.Equal("true", initValue);
+    }
+
+    [Fact]
+    public void InitValue_MentionedInBlockComment_TakesTheRealDeclaration()
+    {
+        var (initValue, _, _) = ParseField(Table("""
+                    /* legacy: InitValue = false; kept here for the migration note */
+                    InitValue = true;
+        """), fieldId: 2);
+
+        Assert.Equal("true", initValue);
+    }
+
+    [Fact]
+    public void Caption_MentionedInComment_TakesTheRealDeclaration()
+    {
+        // Same class of bug on a different property — proves the fix is in the shared text
+        // pass, not a special case bolted onto InitValue.
+        var (_, caption, _) = ParseField(Table("""
+                    // Caption = 'Do not use this one';
+                    Caption = 'Accept';
+        """), fieldId: 2);
+
+        Assert.Equal("Accept", caption);
+    }
+
+    [Fact]
+    public void CommentedOutField_IsNotParsedAsAField()
+    {
+        var source = Table("""
+                    InitValue = true;
+        """).Replace("""
+                field(1; "Code"; Code[10]) { }
+        """, """
+                field(1; "Code"; Code[10]) { }
+                // field(3; Obsolete; Integer) { InitValue = 42; }
+        """);
+
+        var parse = RecordPatchesType.GetMethod("TryParseTableFile",
+            BindingFlags.NonPublic | BindingFlags.Static)!;
+        var tables = (System.Collections.IDictionary)RecordPatchesType
+            .GetField("_parsedTables", BindingFlags.NonPublic | BindingFlags.Static)!
+            .GetValue(null)!;
+        try
+        {
+            parse.Invoke(null, new object[] { source });
+            var table = tables[TableId]!;
+            var ids = ((System.Collections.IEnumerable)table.GetType()
+                    .GetProperty("Fields")!.GetValue(table)!)
+                .Cast<object>()
+                .Select(f => (int)f.GetType().GetProperty("FieldId")!.GetValue(f)!)
+                .OrderBy(x => x).ToArray();
+
+            // A phantom field id 3 would desync this table's metadata from the DLL the AL
+            // compiler actually emitted for it.
+            Assert.Equal(new[] { 1, 2 }, ids);
+        }
+        finally { tables.Remove(TableId); }
+    }
+
+    // Negative direction: the fix must not over-reach. `//` inside a string literal is
+    // literal text, not a comment — blanking it would truncate the caption instead.
+    [Fact]
+    public void DoubleSlashInsideAStringLiteral_IsNotTreatedAsAComment()
+    {
+        var (initValue, caption, _) = ParseField(Table("""
+                    Caption = 'Ratio // Net of returns';
+                    InitValue = true;
+        """), fieldId: 2);
+
+        Assert.Equal("Ratio // Net of returns", caption);
+        Assert.Equal("true", initValue);
+    }
+
+    [Fact]
+    public void QuotedIdentifierContainingSlashes_SurvivesAndStillParses()
+    {
+        var (initValue, _, name) = ParseField(Table("""
+                    InitValue = true;
+        """).Replace("field(2; Accept; Boolean)", """field(2; "Accept // Skip"; Boolean)"""),
+            fieldId: 2);
+
+        Assert.Equal("Accept // Skip", name);
+        Assert.Equal("true", initValue);
+    }
+}

--- a/AlRunner/Patches/AlCommentBlanker.cs
+++ b/AlRunner/Patches/AlCommentBlanker.cs
@@ -1,0 +1,89 @@
+// AlCommentBlanker — blanks out AL comments in raw .al source before the regex-based
+// parsers run over it.
+//
+// The parsers in RecordPatches.Al*Parser.cs match property names with plain regexes
+// (`\bInitValue\s*=\s*([^;]+);` and friends) against raw file text. A comment is just text
+// to a regex, so a perfectly ordinary explanatory comment gets read as a property (#1690):
+//
+//     field(2; Accept; Boolean)
+//     {
+//         // InitValue = true: new rows default to accepted. A consumer filters on
+//         // Accept = true before writing anything.
+//         InitValue = true;
+//     }
+//
+// `RxInitValue` matched inside the comment first — `[^;]+` ran to the semicolon four words
+// later — so the field's InitValue became the comment prose, the real `InitValue = true;`
+// below was never reached, and every Insert of the table died with
+// `NavNCLEvaluateException: The value "true: new rows default to accepted. ..." can not be
+// evaluated into type Boolean`. Real BC compiles both variants identically, of course:
+// comments are not properties.
+//
+// Comments are replaced with spaces rather than removed so every character index in the
+// returned string still lines up with the original. The table parser slices between
+// regex-match offsets, so a length-preserving transform keeps that arithmetic — and any
+// future offset-based logic — correct by construction.
+//
+// String-literal aware in both directions: `'...'` (with AL's doubled-quote escape) and
+// `"..."` quoted identifiers are copied through untouched, so a caption like
+// `Caption = 'see http://example.com';` does not lose its tail. If the source has an
+// unterminated literal (not valid AL), the scan simply stays inside it and the text is
+// returned unchanged — the pre-existing behaviour, never something worse.
+namespace AlRunner.Patches;
+
+internal static class AlCommentBlanker
+{
+    internal static string Blank(string? text)
+    {
+        if (string.IsNullOrEmpty(text)) return text ?? "";
+        // Cheap bail-out for the overwhelmingly common case of source with no comment
+        // markers at all — no allocation, no scan bookkeeping.
+        if (text.IndexOf("//", StringComparison.Ordinal) < 0 &&
+            text.IndexOf("/*", StringComparison.Ordinal) < 0)
+            return text;
+
+        var buf = new char[text.Length];
+        text.CopyTo(0, buf, 0, text.Length);
+
+        const int Code = 0, SingleQuote = 1, DoubleQuote = 2, LineComment = 3, BlockComment = 4;
+        int state = Code;
+
+        for (int i = 0; i < text.Length; i++)
+        {
+            char c = text[i];
+            char next = i + 1 < text.Length ? text[i + 1] : '\0';
+
+            switch (state)
+            {
+                case Code:
+                    if (c == '\'') state = SingleQuote;
+                    else if (c == '"') state = DoubleQuote;
+                    else if (c == '/' && next == '/') { state = LineComment; buf[i] = buf[i + 1] = ' '; i++; }
+                    else if (c == '/' && next == '*') { state = BlockComment; buf[i] = buf[i + 1] = ' '; i++; }
+                    break;
+
+                case SingleQuote:
+                    // '' is AL's escape for a literal quote: closing then re-opening the
+                    // literal lands back in this same state, so no special case is needed.
+                    if (c == '\'') state = Code;
+                    break;
+
+                case DoubleQuote:
+                    if (c == '"') state = Code;
+                    break;
+
+                case LineComment:
+                    if (c == '\n') state = Code;   // keep the newline itself
+                    else if (c != '\r') buf[i] = ' ';
+                    break;
+
+                case BlockComment:
+                    if (c == '*' && next == '/') { state = Code; buf[i] = buf[i + 1] = ' '; i++; }
+                    else if (c != '\n' && c != '\r') buf[i] = ' ';
+                    break;
+            }
+        }
+
+        return new string(buf);
+    }
+}

--- a/AlRunner/Patches/RecordPatches.AlSourceParser.cs
+++ b/AlRunner/Patches/RecordPatches.AlSourceParser.cs
@@ -132,6 +132,13 @@ public static partial class RecordPatches
 
     private static void TryParseTableFile(string text)
     {
+        // Comments first: every regex below matches property names as bare text, so a
+        // comment mentioning one is otherwise read as the property itself (#1690). Blanking
+        // is length-preserving, so the slice offsets computed below are unaffected. Done
+        // here rather than in ParseAllSources because TryParseTableFile has several callers
+        // (RecordPatches.Register, BcAppFallback's decompiled source) that each need it.
+        text = AlCommentBlanker.Blank(text);
+
         // Multiple `table N "Name" { ... }` declarations may live in one .al file.
         // Slice the text between consecutive RxTable matches so each table only sees
         // its own fields/keys.
@@ -246,6 +253,8 @@ public static partial class RecordPatches
 
     private static void TryParseTableExtensionFile(string text)
     {
+        text = AlCommentBlanker.Blank(text); // see TryParseTableFile — same reason (#1690)
+
         var extMatches = RxTableExtension.Matches(text);
         if (extMatches.Count == 0) return;
 

--- a/tests/runner-extras/comment-shadowed-properties/CsfpAssert.Codeunit.al
+++ b/tests/runner-extras/comment-shadowed-properties/CsfpAssert.Codeunit.al
@@ -1,0 +1,17 @@
+/// <summary>
+/// Minimal assertion helper for this runner-extras app (own ID range).
+/// </summary>
+codeunit 62400 "CSFP Assert"
+{
+    procedure AreEqual(Expected: Text; Actual: Text; Msg: Text)
+    begin
+        if Expected <> Actual then
+            Error('Assert.AreEqual failed. Expected:<%1>. Actual:<%2>. %3', Expected, Actual, Msg);
+    end;
+
+    procedure IsTrue(Condition: Boolean; Msg: Text)
+    begin
+        if not Condition then
+            Error('Assert.IsTrue failed. %1', Msg);
+    end;
+}

--- a/tests/runner-extras/comment-shadowed-properties/CsfpFlag.Table.al
+++ b/tests/runner-extras/comment-shadowed-properties/CsfpFlag.Table.al
@@ -1,0 +1,41 @@
+// Mirror of the issue #1690 repro table. Every comment below is ordinary explanatory
+// prose that happens to name a property the parser looks for; before the fix each one
+// was captured as the property itself, and the real declaration underneath was ignored.
+table 62401 "CSFP Flag Table"
+{
+    DataClassification = CustomerContent;
+
+    fields
+    {
+        field(1; "Code"; Code[10])
+        {
+            DataClassification = CustomerContent;
+        }
+        field(2; Accept; Boolean)
+        {
+            DataClassification = CustomerContent;
+            // Per-row user flag bound by a list page to an accept/skip checkbox.
+            // InitValue = true: new rows default to accepted. A consumer filters on
+            // Accept = true before writing anything.
+            Caption = 'Accept';
+            InitValue = true;
+        }
+        field(3; Ratio; Code[20])
+        {
+            DataClassification = CustomerContent;
+            /* legacy note: Caption = 'Old Ratio'; kept for the migration write-up */
+            // The literal below contains '//' INSIDE a string — that is text, not a
+            // comment, and must survive the comment pass intact.
+            Caption = 'Ratio // Net';
+        }
+        // field(4; Obsolete; Integer) { InitValue = 42; }  <- commented out; not a field
+    }
+
+    keys
+    {
+        key(PK; "Code")
+        {
+            Clustered = true;
+        }
+    }
+}

--- a/tests/runner-extras/comment-shadowed-properties/CsfpTests.Codeunit.al
+++ b/tests/runner-extras/comment-shadowed-properties/CsfpTests.Codeunit.al
@@ -1,0 +1,50 @@
+// Issue #1690: a comment mentioning 'InitValue =' was parsed as the field's InitValue,
+// so Insert threw NavNCLEvaluateException with the comment prose as the value. These
+// pin the concrete parsed values, not just "it did not crash".
+codeunit 62402 "CSFP Comment Shadow Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit "CSFP Assert";
+
+    [Test]
+    procedure InsertAppliesTheDeclaredInitValueNotTheCommentText()
+    var
+        Flag: Record "CSFP Flag Table";
+    begin
+        // [WHEN] A row is inserted without touching Accept.
+        Flag.Init();
+        Flag."Code" := 'A';
+        Flag.Insert(false);
+
+        // [THEN] It carries the DECLARED InitValue. Before the fix this line was never
+        // reached: Insert threw NavNCLEvaluateException because the field's InitValue was
+        // the comment prose ('true: new rows default to accepted. ...').
+        Flag.Get('A');
+        Assert.IsTrue(Flag.Accept, 'Accept must default to true via the declared InitValue');
+    end;
+
+    [Test]
+    procedure CommentMentioningCaptionDoesNotOverrideTheDeclaredCaption()
+    var
+        Flag: Record "CSFP Flag Table";
+    begin
+        // [THEN] The block comment naming a different Caption is prose, not a property.
+        Assert.AreEqual('Ratio // Net', Flag.FieldCaption(Ratio),
+            'the declared Caption must win over the one named in the comment');
+    end;
+
+    [Test]
+    procedure SlashesInsideAStringLiteralAreNotTreatedAsAComment()
+    var
+        Flag: Record "CSFP Flag Table";
+    begin
+        // [THEN] Negative direction: the comment pass must not over-reach. Truncating at
+        // the '//' would leave 'Ratio ' here.
+        Assert.AreEqual('Ratio // Net', Flag.FieldCaption(Ratio),
+            'a // inside a string literal is literal text, not a comment');
+        Assert.AreEqual('Accept', Flag.FieldCaption(Accept),
+            'an ordinary caption on a commented field is still parsed');
+    end;
+}

--- a/tests/runner-extras/comment-shadowed-properties/app.json
+++ b/tests/runner-extras/comment-shadowed-properties/app.json
@@ -1,0 +1,25 @@
+{
+  "id": "3f8c1d27-6e94-4b52-a1d8-7c05e93b4f16",
+  "name": "Runner Extras - Comment Shadowed Properties",
+  "publisher": "AL Runner",
+  "version": "1.0.0.0",
+  "brief": "Proves an AL comment that mentions InitValue/Caption is not parsed as the property itself.",
+  "description": "Issue #1690: the AL source parser matched property regexes against raw file text, so a comment mentioning 'InitValue = true' was captured as the field's InitValue - with '[^;]+' running on into the surrounding prose. Every Insert of the table then died with NavNCLEvaluateException: The value \"true: new rows default to accepted. ...\" can not be evaluated into type Boolean. RED before the fix: CsfpInsertAppliesInitValueTrue errors on Insert. GREEN after: the real declaration wins for both InitValue and Caption, a commented-out field never becomes metadata, and a '//' inside a string literal is still literal text.",
+  "privacyStatement": "",
+  "EULA": "",
+  "help": "",
+  "url": "",
+  "logo": "",
+  "dependencies": [],
+  "screenshots": [],
+  "platform": "1.0.0.0",
+  "application": "27.0.0.0",
+  "idRanges": [
+    {
+      "from": 62400,
+      "to": 62419
+    }
+  ],
+  "runtime": "14.0",
+  "features": []
+}


### PR DESCRIPTION
Closes #1690

## Root cause

`RecordPatches.AlSourceParser` matches property names with plain regexes over raw `.al` text. A comment is just text to a regex, so a comment that mentions a property is read *as* that property:

```al
// InitValue = true: new rows default to accepted. A consumer filters on
// Accept = true before writing anything.
InitValue = true;
```

`RxInitValue` (`\bInitValue\s*=\s*([^;]+);`) matched inside the comment first, and `[^;]+` ran on to the semicolon four words later. The field's InitValue became the comment prose, the real declaration below was never reached, and every `Insert` died in `NCLMetaField.get_InitValue`:

```
NavNCLEvaluateException: The value "true: new rows default to accepted. A consumer filters on
// Accept = true before writing anything." can not be evaluated into type Boolean
```

**This was never InitValue-specific.** Every regex in that parser reads raw text, so `Caption`, `OptionMembers`, `CalcFormula`, `FieldClass`, `AutoIncrement` — and the `field(...)` / `key(...)` declarations themselves — were all readable out of comments. A commented-out `field(4; Obsolete; Integer)` became real table metadata.

## Fix

New `AlRunner/Patches/AlCommentBlanker.cs`: a string-literal-aware pass that replaces AL line (`//`) and block (`/* */`) comments with spaces before the regexes run.

- **Blanked, not removed**, so every character index still lines up with the original — the table parser slices between regex-match offsets, and a length-preserving transform keeps that arithmetic correct by construction.
- **String-aware in both directions**: `'...'` (including AL's doubled-quote escape) and `"..."` quoted identifiers pass through untouched, so `Caption = 'see http://example.com';` does not lose its tail.
- **Degrades to today's behaviour** on unterminated literals (not valid AL): the scan stays inside the literal and the text comes back unchanged.
- Cheap bail-out when the source contains no `//` or `/*` at all — no allocation on the common path.

Applied at the top of `TryParseTableFile` and `TryParseTableExtensionFile` rather than in `ParseAllSources`, because both have several callers (`RecordPatches.Register`, `BcAppFallback`'s decompiled source) that each need it.

**Scope note:** the sibling `AlPageParser` / `AlQueryParser` / `AlReportParser` / `AlObjectCaptionParser` / `AlObjectDeclParser` read files the same way and have the same exposure. They are not touched here — no reported failure, and I could not run their tests locally. The blanker is reusable when someone takes that on.

## Tests

**`AlRunner.Tests/AlSourceParserCommentTests.cs`** drives the real `TryParseTableFile` via reflection (same approach as `BcCompilerLoaderSelfExclusionTests`; it is pure text/regex logic, no BC runtime). Testing the blanker alone would not prove the parser consults it. Verified RED against `main`'s parser, GREEN against this branch:

| Test | Pre-fix | After |
| --- | --- | --- |
| `InitValue` named in a line comment | **`"true: new rows default to accepted. A con"…`** — the reported value, verbatim | `"true"` |
| `InitValue` named in a block comment | fails | `"true"` |
| `Caption` named in a comment | fails | declared caption wins |
| commented-out `field(3; …)` | **parsed as a real field** (ids `1,2,3`) | ids `1,2` |
| `//` inside a string literal (negative) | passes | still passes — caption keeps its `//` |
| quoted identifier containing `//` (negative) | passes | still passes |

The two negatives guard over-reach: they pass both before and after by design, and would fail a naive "strip everything after `//`" fix.

**`tests/runner-extras/comment-shadowed-properties/`** is the end-to-end proof, mirroring the issue's repro table: `Insert` must apply the declared `InitValue`, and `FieldCaption` must return the declared caption rather than the one named in a block comment. Before the fix the first test errors on `Insert`. CI runs every suite under `runner-extras/` automatically.

I dropped a fourth AL test that would have used `RecordRef.FieldExist` to assert the commented-out field is absent — that API appears nowhere in the runner or the corpus, so it risked failing for an unrelated reason. The C# test covers that case directly against the parsed metadata.

## Verification note

No BC artifacts in this environment, so the full suite and the AL suite could not be run locally. The parser and its tests were compiled and executed standalone against shims for `RecordPatches`' static state (RED → GREEN as tabled above); CI covers the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BHg4dcEzJ7i5Aeo7hKyfFW

---
_Generated by [Claude Code](https://claude.ai/code/session_01BHg4dcEzJ7i5Aeo7hKyfFW)_