### PR TITLE
fix(deps): name the dependency no loader tier can implement

### DIFF
--- a/AlRunner.Tests/DependencyResolverTests.cs
+++ b/AlRunner.Tests/DependencyResolverTests.cs
@@ -505,6 +505,10 @@ public sealed class DependencyResolverTests : IDisposable
         => MakeMinimalApp(appId, name, publisher, version, r2r: false);
 
     private static byte[] MakeMinimalApp(string appId, string name, string publisher, string version, bool r2r)
+        => MakeMinimalApp(appId, name, publisher, version, r2r, alSource: false);
+
+    private static byte[] MakeMinimalApp(string appId, string name, string publisher, string version,
+        bool r2r, bool alSource)
     {
         var xml = $"""
             <?xml version="1.0" encoding="utf-8"?>
@@ -527,6 +531,14 @@ public sealed class DependencyResolverTests : IDisposable
                 using var ds = dll.Open();
                 ds.Write(new byte[] { 0x4D, 0x5A });
             }
+            if (alSource)
+            {
+                // AppLoader.HasAlSource only looks for a src/*.al entry. This is the shape of
+                // Microsoft's real test toolkit: no DLL, but AL the Tier-3 compile can build.
+                var al = zip.CreateEntry("src/" + name + ".al");
+                using var als = al.Open();
+                als.Write(Encoding.UTF8.GetBytes("codeunit 130002 \"" + name + "\" { }"));
+            }
         }
         var zipBytes = ms.ToArray();
 
@@ -536,5 +548,124 @@ public sealed class DependencyResolverTests : IDisposable
         BitConverter.TryWriteBytes(result.AsSpan(4, 4), (uint)8);
         zipBytes.CopyTo(result, 8);
         return result;
+    }
+
+    // ── #1689: a resolved package that NO loader tier can implement ───────────
+    //
+    // Reported shape: a symbols-only `Library Assert` in .alpackages satisfies resolution,
+    // the bundle compiles green, and every call into it dies with "Function ID N was
+    // called. The object with ID 0 does not have a member with that ID" — naming neither
+    // the app nor the codeunit.
+    //
+    // The pre-existing symbols-only diagnostic could not catch it twice over: it only fired
+    // when OTHER code-bearing copies existed below the minimum version (here there are no
+    // other copies at all), and it was printed only under --verbose.
+    //
+    // The discriminator is NOT !IsR2R. Microsoft's real toolkit ships no publishedartifacts
+    // DLL but DOES ship src/*.al, and the loader's Tier-3 source compile implements it —
+    // verified against the real 28.1.49838.53479 artifact, where `Microsoft_Library
+    // Assert.app` is 22 KB with IsR2R=false and one src/*.al, and a bundle resolving it
+    // scores 2/2 PASS. Gating on !IsR2R alone would fire on every healthy toolkit run.
+
+    /// <summary>
+    /// Neither R2R nor AL source, no other copy anywhere: unservable. Must be reported,
+    /// naming the app and the winning path.
+    /// </summary>
+    [Fact]
+    public void SymbolsOnlyWithNoAlSource_AndNoOtherCopy_IsReportedAsUnservable()
+    {
+        var appId = "dd0be2ea-f733-4d65-bb34-a28f4624fb14";
+        var dir = MakeDir("symbols-only-alone");
+        WriteApp(dir, "Microsoft_Library Assert.app", appId, "Library Assert", "Microsoft",
+            "28.1.49838.53479", r2r: false);
+
+        var resolver = new DependencyResolver(new[] { dir });
+        var result = resolver.Resolve(new[] { new DependencyRef(Guid.Parse(appId), "Library Assert", "Microsoft", new Version(22, 0, 0, 0)) });
+        Assert.Single(result);
+
+        var report = Assert.Single(resolver.UnservableDependencies);
+        Assert.Contains("Microsoft/Library Assert", report);
+        Assert.Contains("NO IMPLEMENTATION", report);
+        Assert.Contains(Path.Combine(dir, "Microsoft_Library Assert.app"), report);
+        // Names the failure the developer would otherwise meet unexplained.
+        Assert.Contains("object with ID 0", report);
+    }
+
+    /// <summary>
+    /// NEGATIVE — the healthy Microsoft test-toolkit shape: no DLL, but AL source present.
+    /// Tier-3 compiles it, so this must stay silent. This is the regression guard that
+    /// stops the fix from breaking every working toolkit resolution.
+    /// </summary>
+    [Fact]
+    public void SymbolsOnlyButShipsAlSource_IsNotReported()
+    {
+        var appId = "dd0be2ea-f733-4d65-bb34-a28f4624fb14";
+        var dir = MakeDir("no-dll-but-al");
+        File.WriteAllBytes(Path.Combine(dir, "Microsoft_Library Assert.app"),
+            MakeMinimalApp(appId, "Library Assert", "Microsoft", "28.1.49838.53479",
+                r2r: false, alSource: true));
+
+        var resolver = new DependencyResolver(new[] { dir });
+        var result = resolver.Resolve(new[] { new DependencyRef(Guid.Parse(appId), "Library Assert", "Microsoft", new Version(22, 0, 0, 0)) });
+        Assert.Single(result);
+
+        Assert.Empty(resolver.UnservableDependencies);
+    }
+
+    /// <summary>
+    /// NEGATIVE — Microsoft platform apps are legitimately symbols-only; their runtime comes
+    /// from the service tier. The existing carve-out must survive.
+    /// </summary>
+    [Fact]
+    public void SymbolsOnlyMicrosoftPlatformApp_IsNotReported()
+    {
+        var appId = "eeeeeeee-0000-0000-0000-000000000001";
+        var dir = MakeDir("platform-symbols-only");
+        WriteApp(dir, "SysApp.app", appId, "System Application", "Microsoft",
+            "28.1.49838.53479", r2r: false);
+
+        var resolver = new DependencyResolver(new[] { dir });
+        var result = resolver.Resolve(new[] { new DependencyRef(Guid.Parse(appId), "System Application", "Microsoft", new Version(28, 0, 0, 0)) });
+        Assert.Single(result);
+
+        Assert.Empty(resolver.UnservableDependencies);
+    }
+
+    /// <summary>
+    /// NEGATIVE — an executable winner is servable by definition.
+    /// </summary>
+    [Fact]
+    public void ExecutableWinner_IsNotReported()
+    {
+        var appId = "ffffffff-0000-0000-0000-000000000001";
+        var dir = MakeDir("r2r-winner");
+        WriteApp(dir, "Lib.app", appId, "SomeLib", "SomeVendor", "28.1.49838.53479", r2r: true);
+
+        var resolver = new DependencyResolver(new[] { dir });
+        var result = resolver.Resolve(new[] { new DependencyRef(Guid.Parse(appId), "SomeLib", "SomeVendor", new Version(1, 0, 0, 0)) });
+        Assert.Single(result);
+
+        Assert.Empty(resolver.UnservableDependencies);
+    }
+
+    /// <summary>
+    /// The pre-existing "code-bearing copies exist but are below the minimum" diagnostic
+    /// still fires, and stays on the verbose-only Diagnostics channel rather than being
+    /// promoted to the always-on one.
+    /// </summary>
+    [Fact]
+    public void CodeBearingCopiesBelowMinimum_StillUseTheVersionDiagnostic()
+    {
+        var appId = "aaaaaaaa-1111-0000-0000-000000000001";
+        var dir = MakeDir("below-min");
+        WriteApp(dir, "Lib_v28_symbols.app", appId, "SomeLib", "SomeVendor", "28.0.0.0", r2r: false);
+        WriteApp(dir, "Lib_v5_r2r.app",      appId, "SomeLib", "SomeVendor", "5.0.0.0",  r2r: true);
+
+        var resolver = new DependencyResolver(new[] { dir });
+        var result = resolver.Resolve(new[] { new DependencyRef(Guid.Parse(appId), "SomeLib", "SomeVendor", new Version(28, 0, 0, 0)) });
+        Assert.Single(result);
+
+        Assert.Empty(resolver.UnservableDependencies);
+        Assert.Contains(resolver.Diagnostics, d => d.Contains("SYMBOLS-ONLY"));
     }
 }

--- a/AlRunner/AppLoader.cs
+++ b/AlRunner/AppLoader.cs
@@ -189,6 +189,44 @@ public static class AppLoader
 
 
     /// <summary>
+    /// True if the package ships AL source under <c>src/*.al</c> — i.e. the loader's
+    /// Tier-3 on-the-fly source compile can produce an implementation from it.
+    ///
+    /// This is the other half of "can this package supply runnable code", and it is NOT
+    /// implied by <see cref="IsR2R"/>. Microsoft ships its test toolkit (Library Assert,
+    /// Library Variable Storage, …) with NO <c>publishedartifacts/*.dll</c> but WITH AL
+    /// source: verified against the real 28.1.49838.53479 test-apps artifact, where
+    /// `Microsoft_Library Assert.app` is 22 KB with IsR2R=false and one `src/*.al`.
+    /// Treating !IsR2R alone as "carries no implementation" therefore misclassifies the
+    /// entire healthy test toolkit — see #1689 and DependencyResolver.SelectBestVersion.
+    ///
+    /// Entry-name scan only: nothing is decompressed, so this stays cheap on packages
+    /// with thousands of sources.
+    /// </summary>
+    public static bool HasAlSource(string appPath)
+    {
+        static bool AnyAl(ZipArchive zip) => zip.Entries.Any(e =>
+            e.FullName.StartsWith("src/", StringComparison.OrdinalIgnoreCase)
+            && e.FullName.EndsWith(".al", StringComparison.OrdinalIgnoreCase));
+        try
+        {
+            var bytes = File.ReadAllBytes(appPath);
+            using var zip = OpenZipFromNavx(bytes);
+            if (AnyAl(zip)) return true;
+            // R2R nested case: the inner .app carries the source, mirroring HasSymbolReference.
+            var nested = zip.Entries.FirstOrDefault(e =>
+                e.FullName.EndsWith(".app", StringComparison.OrdinalIgnoreCase) && !e.FullName.Contains('/'));
+            if (nested == null) return false;
+            using var ns = nested.Open();
+            using var nms = new MemoryStream();
+            ns.CopyTo(nms);
+            using var innerZip = OpenZipFromNavx(nms.ToArray());
+            return AnyAl(innerZip);
+        }
+        catch { return false; }
+    }
+
+    /// <summary>
     /// Returns the IL DLL bytes from a Microsoft R2R `.app` package, or null
     /// if no `publishedartifacts/*.dll` is present (i.e. the package is not R2R).
     /// Returns only the first DLL — kept for backwards-compat callers that

--- a/AlRunner/DependencyResolver.cs
+++ b/AlRunner/DependencyResolver.cs
@@ -27,6 +27,10 @@ public sealed class DependencyResolver
         _byNamePub = new(NamePublisherComparer.Instance);
     private bool _indexed;
     private readonly List<string> _diagnostics = new();
+    // Kept separate from _diagnostics because these are printed UNCONDITIONALLY, not just
+    // under --verbose: a dependency that no loader tier can implement is a certain runtime
+    // failure, and the whole point of #1689 is that the developer never saw it coming.
+    private readonly List<string> _unservable = new();
 
     /// <summary>
     /// Problems detected while resolving that are NOT fatal but almost certainly wrong —
@@ -37,6 +41,14 @@ public sealed class DependencyResolver
     /// happens instead of being reconstructed by hand from the whole dependency set.
     /// </summary>
     public IReadOnlyList<string> Diagnostics => _diagnostics;
+
+    /// <summary>
+    /// Resolved dependencies that no loader tier can supply an implementation for (neither
+    /// an R2R payload nor AL source, and not a Microsoft platform app served by the service
+    /// tier). Unlike <see cref="Diagnostics"/> these are always surfaced — each one is a
+    /// call that will end in "The object with ID 0 does not have a member with that ID".
+    /// </summary>
+    public IReadOnlyList<string> UnservableDependencies => _unservable;
 
     public DependencyResolver(IReadOnlyList<string> cacheDirs)
     {
@@ -232,14 +244,46 @@ public sealed class DependencyResolver
             // legitimate for those, whose runtime can come from the service-tier DLLs (see
             // IsMicrosoftPlatformApp). Warning on them would fire on healthy runs and teach
             // readers to ignore this.
+            // "Cannot execute" is NOT the same as "carries no implementation". A package with
+            // no publishedartifacts DLL but WITH src/*.al is served by the loader's Tier-3
+            // on-the-fly source compile — which is exactly how Microsoft ships its test
+            // toolkit. Verified against the real 28.1.49838.53479 test-apps artifact:
+            // `Microsoft_Library Assert.app` is 22 KB, IsR2R=false, one src/*.al. Gating on
+            // !Executable alone would fire on every healthy toolkit resolution, which is the
+            // answer to the open question this diagnostic carried (#1689): the healthy run
+            // tolerates a symbols-only winner because that winner still ships AL.
+            //
+            // The genuinely unservable shape is neither R2R nor AL — symbols and a manifest
+            // and nothing else, as produced by a symbol-only package download. No loader tier
+            // can implement it, so every call into it ends at
+            // "The object with ID 0 does not have a member with that ID".
             if (!Executable(best.Path)
+                && !AppLoader.HasAlSource(best.Path)
                 && !IsMicrosoftPlatformApp(best.Manifest.Name, best.Manifest.Publisher))
             {
                 var tooOld = candidates
                     .Where(c => c.Manifest.Version < dep.Version && Executable(c.Path))
                     .OrderByDescending(c => c.Manifest.Version)
                     .ToList();
-                if (tooOld.Count > 0)
+                if (tooOld.Count == 0)
+                {
+                    // No other copy exists at all — the case #1689 reported, and the one this
+                    // block used to fall straight through in silence. Nothing downstream can
+                    // name the app: DependencyLoader's symbol-only branch says it is "relying
+                    // on service-tier/already-loaded assembly" (true for platform apps, false
+                    // here), and the runtime error that follows names neither app nor codeunit.
+                    _unservable.Add(
+                        $"[dep] {best.Manifest.Publisher}/{best.Manifest.Name} v{best.Manifest.Version} "
+                        + "resolved to a package with NO IMPLEMENTATION (no publishedartifacts DLL,"
+                        + "\n      no src/*.al) and no other copy was found in the package caches:"
+                        + $"\n      winner: {best.Path}"
+                        + "\n      Calls into this app will fail with \"The object with ID 0 does not"
+                        + "\n      have a member with that ID\". Provision a package that carries an"
+                        + "\n      implementation — `al-runner provision`, or re-run with --auto-provision;"
+                        + "\n      for the Microsoft test toolkit specifically:"
+                        + $"\n        dotnet run --project tools/DownloadArtifacts -- test-apps {best.Manifest.Version} \"<dir>\"");
+                }
+                else
                     _diagnostics.Add(
                         $"[dep] note: {best.Manifest.Publisher}/{best.Manifest.Name} resolved to a "
                         + $"SYMBOLS-ONLY package v{best.Manifest.Version} (no publishedartifacts DLL):"

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -896,12 +896,26 @@ foreach (var bundle in bundles)
                 //
                 // It is still the right thing to look at when execution dies with an
                 // object-ID-0 MissingMethod, which is why it is retained and printed under
-                // --verbose. Making it a reliable failure signal needs the open question
-                // answered first: why does the healthy run tolerate a symbols-only winner?
-                // Until then this is evidence to weigh, not a verdict.
+                // --verbose.
+                //
+                // The open question this used to carry — why does the healthy run tolerate a
+                // symbols-only winner? — is answered (#1689): because "symbols-only" here means
+                // "no publishedartifacts DLL", and Microsoft's test toolkit ships no DLL but DOES
+                // ship src/*.al, so the loader's Tier-3 source compile implements it. Verified
+                // against the real 28.1.49838.53479 artifact: `Microsoft_Library Assert.app` is
+                // 22 KB, IsR2R=false, one src/*.al. That is exactly the 7 packages measured above.
+                //
+                // So this list stays evidence rather than a verdict, and the verdict moved to
+                // UnservableDependencies below, which applies the discriminator that actually
+                // separates the two: neither a DLL nor AL source.
                 if (AlRunner.Log.Verbose)
                     foreach (var d in resolver.Diagnostics)
                         Console.Error.WriteLine(d);
+                // Always-on, unlike the above: a dependency no loader tier can implement is a
+                // certain object-ID-0 failure later, and #1689 is precisely the report that
+                // nothing named it. One line per app, and only for a shape that cannot work.
+                foreach (var u in resolver.UnservableDependencies)
+                    Console.Error.WriteLine(u);
                 // Compiler sees only non-workspace dirs in its .app scanner; the
                 // synthetic workspace dirs are registered as symbols.json-only
                 // sources via SetExtraSymbolDirs (called AFTER SetResolvedDeps,


### PR DESCRIPTION
Closes #1689

Implements the "check the resolved winner" discriminator. Along the way it answers the open question `Program.cs` recorded next to this very diagnostic — *"why does the healthy run tolerate a symbols-only winner?"*

## Root cause: a conflation

The resolver already detected symbols-only winners. It could not catch this one, twice over:

1. The diagnostic fired **only when other code-bearing copies existed below the required minimum version**. In the reported shape there is no other copy at all, so `tooOld.Count == 0` and the block fell straight through in silence.
2. It printed **only under `--verbose`**.

And the discriminator itself was wrong. "Symbols-only" meant *no `publishedartifacts/*.dll`* — but that is not the same as "carries no implementation". Measured against the real 28.1.49838.53479 artifacts:

| Package | R2R | `src/*.al` | Servable? |
| --- | --- | --- | --- |
| `Microsoft_Library Assert.app` (22 KB, real toolkit) | no | **1** | yes — Tier-3 source compile |
| same package with `src/` stripped (9 KB) | no | **0** | **no** — this is #1689 |
| `Microsoft_System Application.app` | yes | 0 | yes — Tier-2 |

So the healthy run tolerates a symbols-only winner because that winner still ships AL. This matches the measurement already in the `Program.cs` comment — 7 toolkit packages resolving symbols-only on a run scoring 1041P/35F/0E. Gating on `!IsR2R` alone would fire on every one of them.

## Fix

- **`AppLoader.HasAlSource`** — entry-name scan only, nothing decompressed, so it stays cheap on packages with thousands of sources. Handles the R2R-nested case, mirroring `HasSymbolReference`.
- **`SelectBestVersion`** — the gate becomes `!IsR2R && !HasAlSource && !IsMicrosoftPlatformApp`, and the previously-missing `tooOld.Count == 0` branch reports. The platform-app carve-out and the existing below-minimum-version diagnostic are unchanged.
- **`DependencyResolver.UnservableDependencies`** — a new channel, printed **unconditionally**. A dependency no tier can implement is a certain runtime failure, and the whole point of the report is that nothing named it. Kept separate from `Diagnostics` so the verbose-only "evidence to weigh" list stays exactly that.

The message names the app, the winning path, the error it is about to cause, and the provisioning command.

## Verification

**Live, against the real runner and real artifacts.** I provisioned BC 28.1.49838.53479 (service tier + platform apps + the 107-app toolkit) and rebuilt the issue's repro, using a symbols-only `Library Assert` produced by stripping `src/` from the genuine package.

Before — resolver silent, then the misleading downstream NOTE:

```
[dep] Microsoft/Library Assert 28.1.49838.53479  <- .alpackages/Microsoft_Library Assert.app
[deps] NOTE: Microsoft_Library Assert v28.1.49838.53479 is symbol-only (no runtime code in
       package); relying on service-tier/already-loaded assembly
```

After — no `--verbose` needed:

```
[dep] Microsoft/Library Assert v28.1.49838.53479 resolved to a package with NO IMPLEMENTATION
      (no publishedartifacts DLL, no src/*.al) and no other copy was found in the package caches:
      winner: /root/repro-1689/.alpackages/Microsoft_Library Assert.app
      Calls into this app will fail with "The object with ID 0 does not have a member with that ID".
      Provision a package that carries an implementation — `al-runner provision`, or ...
```

And the healthy configuration — same bundle, real toolkit on the package cache — emits **zero** occurrences and passes 2/2.

**Unit tests** (`DependencyResolverTests`, +5; the fixture builder gained AL-source control). Two independent RED variants, each failing exactly the test that pins its mistake:

| Variant | Failing test |
| --- | --- |
| pre-fix behaviour | `SymbolsOnlyWithNoAlSource_AndNoOtherCopy_IsReportedAsUnservable` |
| naive `!IsR2R`-only fix | `SymbolsOnlyButShipsAlSource_IsNotReported` |

The second is the one that matters: it demonstrates the AL-source clause is load-bearing, not decoration — without it this PR would warn on every healthy toolkit resolution.

Negatives cover the real-toolkit shape, the Microsoft platform carve-out, an executable winner, and that the pre-existing below-minimum diagnostic still fires on the verbose-only channel.

**Full suite: 286/286 pass, 0 failed** (7m19s) against real BC artifacts — the merged-`main` baseline of 281 plus exactly these 5.

## One judgement call

This reports loudly; it does **not** fail the run. Escalating to fatal is a one-line change, but it would break any project that resolves such a package and never calls into it, and `IsMicrosoftPlatformApp` is a name-based carve-out I would rather not have gating a fatal path. Happy to make it fatal in this PR if you want that instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BHg4dcEzJ7i5Aeo7hKyfFW

---
_Generated by [Claude Code](https://claude.ai/code/session_01BHg4dcEzJ7i5Aeo7hKyfFW)_