### PR TITLE
fix(parser): AL comments no longer read as properties in the sibling parsers

### DIFF
--- a/AlRunner.Tests/SiblingParserCommentTests.cs
+++ b/AlRunner.Tests/SiblingParserCommentTests.cs
@@ -1,0 +1,174 @@
+// SiblingParserCommentTests — RED→GREEN guard for #1697.
+//
+// #1690 fixed comment-shadowed properties in the TABLE parser only: AlCommentBlanker was
+// applied at the top of TryParseTableFile / TryParseTableExtensionFile and nowhere else.
+// The page/report/query/xmlport/object-decl/object-caption parsers read raw text the same
+// way and have the same exposure — an ordinary comment that happens to name a property is
+// matched AS that property.
+//
+// These are quieter than #1690's failure, which is what makes them worth pinning: nothing
+// throws. `SourceTable` rebinds the page to a different table and `InsertAllowed` flips a
+// behaviour flag, so a test can pass while asserting against metadata a comment supplied.
+//
+// The parsers are private statics reached by reflection (same approach as
+// AlSourceParserCommentTests); the assertions use the internal accessors the runtime
+// itself calls, so these pin observable behaviour rather than a private field's shape.
+using System.Reflection;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public class SiblingParserCommentTests
+{
+    private static readonly Type RecordPatchesType = typeof(AlRunner.Patches.RecordPatches);
+
+    private static void Invoke(string method, string source)
+    {
+        var m = RecordPatchesType.GetMethod(method, BindingFlags.NonPublic | BindingFlags.Static)
+            ?? throw new InvalidOperationException(
+                $"RecordPatches.{method} not found by reflection — signature may have changed.");
+        m.Invoke(null, new object[] { source });
+    }
+
+    // Drops the fixture out of the process-wide parser state so these cannot leak into
+    // other tests in the same run.
+    private static void Forget(string dictField, int id)
+    {
+        var f = RecordPatchesType.GetField(dictField, BindingFlags.NonPublic | BindingFlags.Static);
+        if (f?.GetValue(null) is System.Collections.IDictionary d) d.Remove(id);
+    }
+
+    // ── pages ────────────────────────────────────────────────────────────────
+
+    private const int PageId = 61931;
+
+    [Fact]
+    public void Page_SourceTableNamedInAComment_DoesNotRebindThePage()
+    {
+        try
+        {
+            Invoke("TryParsePageFile", $$"""
+                page {{PageId}} "CSP Flag List"
+                {
+                    // Migration note: this used to be SourceTable = Customer; before the split.
+                    SourceTable = "CSP Flag Table";
+                    layout { area(content) { repeater(g) { field(Accept; Rec.Accept) { } } } }
+                }
+                """);
+
+            // Before the fix RxPageSourceTable matched inside the comment first, so the page
+            // bound to Customer — a different table entirely.
+            Assert.True(AlRunner.Patches.RecordPatches.IsPageParsed(PageId));
+            Assert.True(AlRunner.Patches.RecordPatches.PageDeclaresSourceTable(PageId));
+            Assert.Equal("CSP Flag Table", SourceTableNameOf(PageId));
+        }
+        finally { Forget("_parsedPages", PageId); }
+    }
+
+    [Fact]
+    public void Page_InsertAllowedNamedInAComment_DoesNotFlipTheFlag()
+    {
+        try
+        {
+            Invoke("TryParsePageFile", $$"""
+                page {{PageId}} "CSP Flag List"
+                {
+                    // Historically we set InsertAllowed = false; here. Re-enabled in v2.
+                    SourceTable = "CSP Flag Table";
+                    layout { area(content) { repeater(g) { field(Accept; Rec.Accept) { } } } }
+                }
+                """);
+
+            // The silent one: AL's default is true and the page declares nothing, but the
+            // comment used to be read as an explicit `false`, making the page non-creatable.
+            Assert.True(AlRunner.Patches.RecordPatches.GetInsertAllowedForPage(PageId),
+                "a commented-out InsertAllowed must not make the page non-creatable");
+        }
+        finally { Forget("_parsedPages", PageId); }
+    }
+
+    [Fact]
+    public void Page_CommentedOutPageDeclaration_IsNotParsedAsAPage()
+    {
+        const int ghostId = 61932;
+        try
+        {
+            Invoke("TryParsePageFile", $$"""
+                page {{PageId}} "CSP Flag List"
+                {
+                    SourceTable = "CSP Flag Table";
+                    layout { area(content) { repeater(g) { field(Accept; Rec.Accept) { } } } }
+                }
+                // page {{ghostId}} "CSP Retired List" { SourceTable = Customer; }
+                """);
+
+            Assert.True(AlRunner.Patches.RecordPatches.IsPageParsed(PageId));
+            Assert.False(AlRunner.Patches.RecordPatches.IsPageParsed(ghostId),
+                "a commented-out page declaration must not become page metadata");
+        }
+        finally { Forget("_parsedPages", PageId); Forget("_parsedPages", ghostId); }
+    }
+
+    // Negative direction: the fix must not over-reach. `//` inside a string literal is
+    // literal text — blanking it would truncate the value.
+    [Fact]
+    public void Page_SlashesInsideAStringLiteral_AreNotTreatedAsAComment()
+    {
+        try
+        {
+            Invoke("TryParsePageFile", $$"""
+                page {{PageId}} "CSP Flag List"
+                {
+                    Caption = 'Ratio // Net';
+                    SourceTable = "CSP Flag Table";
+                    layout { area(content) { repeater(g) { field(Accept; Rec.Accept) { } } } }
+                }
+                """);
+
+            // Truncating at the '//' would swallow the rest of the object, including the
+            // SourceTable declaration that follows it.
+            Assert.True(AlRunner.Patches.RecordPatches.PageDeclaresSourceTable(PageId));
+            Assert.Equal("CSP Flag Table", SourceTableNameOf(PageId));
+        }
+        finally { Forget("_parsedPages", PageId); }
+    }
+
+    // ── reports ──────────────────────────────────────────────────────────────
+
+    private const int ReportId = 61933;
+
+    [Fact]
+    public void Report_ProcessingOnlyNamedInAComment_DoesNotFlipTheFlag()
+    {
+        try
+        {
+            Invoke("TryParseReportFile", $$"""
+                report {{ReportId}} "CSP Flag Report"
+                {
+                    // Was ProcessingOnly = true; until we added the layout.
+                    dataset { dataitem(Item; "CSP Flag Table") { column(Code; "Code") { } } }
+                }
+                """);
+
+            Assert.False(ProcessingOnlyOf(ReportId),
+                "a commented-out ProcessingOnly must not mark the report processing-only");
+        }
+        finally { Forget("_parsedReports", ReportId); }
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    private static string? SourceTableNameOf(int pageId) => (string?)Entry("_parsedPages", pageId, "SourceTableName");
+
+    private static bool ProcessingOnlyOf(int reportId)
+        => Entry("_parsedReports", reportId, "ProcessingOnly") as bool? ?? false;
+
+    private static object? Entry(string dictField, int id, string property)
+    {
+        var d = (System.Collections.IDictionary)RecordPatchesType
+            .GetField(dictField, BindingFlags.NonPublic | BindingFlags.Static)!.GetValue(null)!;
+        Assert.True(d.Contains(id), $"{dictField} has no entry for {id}");
+        var entry = d[id]!;
+        return entry.GetType().GetProperty(property)!.GetValue(entry);
+    }
+}

--- a/AlRunner/Patches/RecordPatches.AlObjectCaptionParser.cs
+++ b/AlRunner/Patches/RecordPatches.AlObjectCaptionParser.cs
@@ -82,6 +82,8 @@ public static partial class RecordPatches
 
     private static void TryParseObjectCaptionFile(string text)
     {
+        text = AlCommentBlanker.Blank(text); // see AlPageParser — same reason (#1690/#1697)
+
         foreach (var (kind, rx) in RxCaptionObjectDecls)
         {
             foreach (Match m in rx.Matches(text))

--- a/AlRunner/Patches/RecordPatches.AlObjectDeclParser.cs
+++ b/AlRunner/Patches/RecordPatches.AlObjectDeclParser.cs
@@ -59,6 +59,8 @@ public static partial class RecordPatches
 
     private static void TryParseObjectDeclFile(string text)
     {
+        text = AlCommentBlanker.Blank(text); // see AlPageParser — same reason (#1690/#1697)
+
         foreach (var (kind, rx) in RxObjectDecls)
         {
             foreach (Match m in rx.Matches(text))

--- a/AlRunner/Patches/RecordPatches.AlPageParser.cs
+++ b/AlRunner/Patches/RecordPatches.AlPageParser.cs
@@ -49,6 +49,15 @@ public static partial class RecordPatches
 
     private static void TryParsePageFile(string text)
     {
+        // Comments first — every regex below matches property names and object headers as
+        // bare text, so a comment naming one is otherwise read as the declaration itself.
+        // #1690 fixed this for the table parser; the sibling parsers had the same exposure
+        // (#1697): a comment mentioning SourceTable rebound the page, one mentioning
+        // InsertAllowed flipped a behaviour flag, and a commented-out `page N "X" {` became
+        // real metadata. Blanking is length-preserving, so every SliceObjectText / match-offset
+        // calculation below is unaffected.
+        text = AlCommentBlanker.Blank(text);
+
         // `page N "Name"` — plain pages
         foreach (Match m in RxPage.Matches(text))
         {

--- a/AlRunner/Patches/RecordPatches.AlQueryParser.cs
+++ b/AlRunner/Patches/RecordPatches.AlQueryParser.cs
@@ -31,6 +31,8 @@ public static partial class RecordPatches
 
     private static void TryParseQueryFile(string text)
     {
+        text = AlCommentBlanker.Blank(text); // see AlPageParser — same reason (#1690/#1697)
+
         foreach (Match m in RxQuery.Matches(text))
         {
             if (!int.TryParse(m.Groups[1].Value, out int id)) continue;

--- a/AlRunner/Patches/RecordPatches.AlReportParser.cs
+++ b/AlRunner/Patches/RecordPatches.AlReportParser.cs
@@ -43,6 +43,8 @@ public static partial class RecordPatches
 
     private static void TryParseReportFile(string text)
     {
+        text = AlCommentBlanker.Blank(text); // see AlPageParser — same reason (#1690/#1697)
+
         foreach (Match m in RxReport.Matches(text))
         {
             if (!int.TryParse(m.Groups[1].Value, out int id)) continue;

--- a/AlRunner/Patches/RecordPatches.AlXmlPortParser.cs
+++ b/AlRunner/Patches/RecordPatches.AlXmlPortParser.cs
@@ -26,6 +26,8 @@ public static partial class RecordPatches
 
     private static void TryParseXmlPortFile(string text)
     {
+        text = AlCommentBlanker.Blank(text); // see AlPageParser — same reason (#1690/#1697)
+
         foreach (Match m in RxXmlPort.Matches(text))
         {
             if (!int.TryParse(m.Groups[1].Value, out int id)) continue;


### PR DESCRIPTION
Closes #1697

Finishes what #1690 started. That PR applied `AlCommentBlanker` to `TryParseTableFile` / `TryParseTableExtensionFile` and nowhere else; the sibling parsers match property names and object headers as bare text the same way.

**Six parsers, not five** — I'd missed `AlObjectCaptionParser` when filing the issue: page, report, query, xmlport, object-decl, object-caption.

## Why these are worth fixing even though nothing throws

That is precisely what makes them worse than #1690's failure. #1690 died loudly at `Insert` with `NavNCLEvaluateException`. These return a wrong answer quietly:

| Comment | Effect before this PR |
| --- | --- |
| `// ...this used to be SourceTable = Customer; before the split.` | page rebinds to a **different table** |
| `// Historically we set InsertAllowed = false; here.` | page becomes non-creatable — `ITestPage.Creatable` false, `NavTestPageBase.New()` refuses |
| `// page 61932 "CSP Retired List" { ... }` | commented-out page becomes **real page metadata** |
| `// Was ProcessingOnly = true; until we added the layout.` | report marked processing-only |

A test can pass while asserting against metadata a comment supplied.

## Fix

One `AlCommentBlanker.Blank(text)` at each parser's entry point, exactly as the table parser already does. Blanking is length-preserving, so `SliceObjectText` and every match-offset calculation are unaffected, and the blanker is string-literal aware so a `//` inside a caption stays literal text.

No new mechanism — this is the existing #1690 fix reaching the rest of its blast radius.

## Tests

New `AlRunner.Tests/SiblingParserCommentTests.cs`. The parsers are private statics reached by reflection (same approach as `AlSourceParserCommentTests`), but the assertions go through the **internal accessors the runtime itself calls** — `IsPageParsed`, `PageDeclaresSourceTable`, `GetInsertAllowedForPage` — so they pin observable behaviour rather than a private field's shape. Each test removes its fixture from the process-wide parser state in a `finally`, so nothing leaks into other tests in the same run.

Verified RED → GREEN:

| Test | Before | After |
| --- | --- | --- |
| page `SourceTable` named in a comment | **FAIL** — bound to the commented table | binds to the declared one |
| page `InsertAllowed` named in a comment | **FAIL** — flag flipped to false | stays AL's default `true` |
| commented-out `page N "X" {` | **FAIL** — parsed as a page | not parsed |
| report `ProcessingOnly` named in a comment | **FAIL** — marked processing-only | not marked |
| `//` inside a string literal (negative) | passes | still passes |

4 of 5 failed before, 5/5 after. The negative is the over-reach guard: it passes both before and after by design, and would fail a naive "strip everything after `//`" fix — its page declares `Caption = 'Ratio // Net';` **above** the `SourceTable`, so truncating at the `//` would swallow the declaration that follows.

**Full suite: 291/291 pass, 0 failed** (10m24s) against real BC 28.1.49838.53479 artifacts — main's 286 baseline plus exactly these 5.

## Relationship to #1696

This is the holding action described in #1697. If the `SyntaxTree.ParseObjectText` migration lands, `AlCommentBlanker` and all eight of its call sites come out together — the comment class stops existing rather than being defended against. Until then these six parsers are exposed, and the migration is not imminent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BHg4dcEzJ7i5Aeo7hKyfFW

---
_Generated by [Claude Code](https://claude.ai/code/session_01BHg4dcEzJ7i5Aeo7hKyfFW)_