### PR TITLE
fix(loader): serve Microsoft.Dynamics.Nav.CodeAnalysis from the selected artifact dir, not bin

### DIFF
--- a/AlRunner.Tests/VersionAgnosticClosureTests.cs
+++ b/AlRunner.Tests/VersionAgnosticClosureTests.cs
@@ -38,6 +38,13 @@ public sealed class VersionAgnosticClosureTests
         "Microsoft.IdentityModel.Tokens.dll",
         "System.IdentityModel.Tokens.Jwt.dll",
         "Azure.Core.dll",
+        // The one engine reference Microsoft stamps with a full 4-part assembly version
+        // PER BC BUILD (17.0.36.40629 in 28.1.49838.50794, 17.0.40.3339 in 28.3.52162.53506)
+        // instead of the MAJOR.0.0.0 contract the other engine DLLs honour. A bin copy
+        // occupies the default ALC's slot for the simple name, so a different-build BC
+        // requesting ITS CodeAnalysis version dies with FileLoadException 0x80131621 —
+        // pinning the binary to the exact build it was compiled against.
+        "Microsoft.Dynamics.Nav.CodeAnalysis.dll",
     };
 
     [Fact]

--- a/AlRunner/DependencyLoader.cs
+++ b/AlRunner/DependencyLoader.cs
@@ -471,6 +471,18 @@ public sealed class DependencyLoader
     /// </summary>
     public static void EnsureResolverInstalled_Public() => EnsureResolverInstalled();
 
+    /// <summary>
+    /// Install the resolver the moment this assembly loads, in EVERY host (runner,
+    /// xunit test host, server mode, future embedders). Microsoft.Dynamics.Nav.CodeAnalysis
+    /// is no longer CopyLocal'd into bin (its assembly version is stamped per BC BUILD,
+    /// which pinned the binary to one build — see Directory.Build.targets), so the FIRST
+    /// touch of a CodeAnalysis-typed member anywhere needs this handler already in place.
+    /// Safe this early because the handler resolves the artifact dir lazily per request
+    /// and never triggers version selection for non-BC assembly names.
+    /// </summary>
+    [System.Runtime.CompilerServices.ModuleInitializer]
+    internal static void InstallResolverOnModuleLoad() => EnsureResolverInstalled();
+
     private static void EnsureResolverInstalled()
     {
         if (Interlocked.Exchange(ref _resolverInstalled, 1) != 0) return;
@@ -483,8 +495,6 @@ public sealed class DependencyLoader
         // .TableProxyBuilder), it fails to load and the call NREs deep in MS code. The
         // probe below catches every Microsoft.Dynamics.Nav.* assembly request and serves
         // it from the artifact dir.
-        // Single source of truth for the artifact dir (tracks AlRunner.csproj's _BCVersion).
-        var serviceTierPath = AlRunner.Infrastructure.BcArtifacts.ServiceTierDir;
         AssemblyLoadContext.Default.Resolving += (ctx, name) =>
         {
             if (name.Name == null) return null;
@@ -495,6 +505,19 @@ public sealed class DependencyLoader
             // IdentityModel) beyond the Microsoft.Dynamics.Nav.* set; all ship in the artifact
             // dir. This handler only fires after default resolution fails, so serving BC's own
             // shipped copy is the faithful choice.
+            //
+            // The artifact dir is resolved LAZILY, per request, not captured at install time:
+            // this handler may be installed before the BC version selection has run (module
+            // initializer, test host). A request for a Microsoft.Dynamics.* assembly
+            // legitimately triggers the lazy default selection; any other name must not —
+            // probing for e.g. a satellite assembly would silently commit the process to
+            // latest-in-cache before --bc-version was parsed.
+            if (!AlRunner.Infrastructure.BcArtifacts.IsSelected
+                && !name.Name.StartsWith("Microsoft.Dynamics.", StringComparison.Ordinal))
+                return null;
+            string serviceTierPath;
+            try { serviceTierPath = AlRunner.Infrastructure.BcArtifacts.ServiceTierDir; }
+            catch { return null; } // no artifacts provisioned — let the default binder fail loud
             var probe = Path.Combine(serviceTierPath, name.Name + ".dll");
             if (File.Exists(probe))
                 return ctx.LoadFromAssemblyPath(probe);

--- a/AlRunner/Infrastructure/BcArtifacts.cs
+++ b/AlRunner/Infrastructure/BcArtifacts.cs
@@ -52,6 +52,12 @@ public static class BcArtifacts
         get { EnsureSelected(); return _selectedRoot!; }
     }
 
+    /// <summary>Whether a version has been selected, WITHOUT triggering the lazy
+    /// default selection. Lets early-installed resolvers decide if probing the
+    /// artifact dir is safe yet (probing before selection would silently commit
+    /// the process to latest-in-cache).</summary>
+    public static bool IsSelected => _selectedVersion != null;
+
     private static readonly object _lock = new();
 
     private static string ArtifactsRoot => Path.Combine(

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -29,7 +29,8 @@
       <ReferenceCopyLocalPaths Remove="@(ReferenceCopyLocalPaths)"
         Condition="$([System.String]::Copy('%(Filename)').StartsWith('Microsoft.Identity'))
                    OR $([System.String]::Copy('%(Filename)').StartsWith('System.IdentityModel'))
-                   OR $([System.String]::Copy('%(Filename)').StartsWith('Azure.'))" />
+                   OR $([System.String]::Copy('%(Filename)').StartsWith('Azure.'))
+                   OR '%(Filename)' == 'Microsoft.Dynamics.Nav.CodeAnalysis'" />
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
Closes #1700

## What

`Microsoft.Dynamics.Nav.CodeAnalysis` is the one engine reference Microsoft stamps with a full 4-part assembly version **per BC build** (17.0.36.40629 in 28.1.49838.50794, 17.0.40.3339 in 28.3.52162.53506) instead of the `MAJOR.0.0.0` contract the other five engine DLLs honour. CopyLocal'd into bin it occupies the default ALC's slot for that simple name, so selecting any other BC build dies at startup with `FileLoadException 0x80131621` — pinning the released binary to the exact build it was compiled against and defeating the "one engine binary spans a major's minors" design. Full mechanism and repro in #1700.

Three changes, same pattern as the existing Azure/Identity closure fix:

1. **`Directory.Build.targets`** — extend `StripBcAppClosureFromCopyLocal` to `Microsoft.Dynamics.Nav.CodeAnalysis`, so the `Resolving` handler serves the SELECTED build's own copy from the artifact dir. Compile-time reference and build-time provisioning are unchanged.
2. **`DependencyLoader`** — install the `Resolving` handler via `[ModuleInitializer]`. The first CodeAnalysis touch is the Ncl Cecil rewrite in `Program.cs`, which runs before the old install site; the xunit test host touches CodeAnalysis with no `Program.cs` at all (three `JsonLoaderDependencyFallthroughTests` fail order-dependently with the strip alone). Module-init installation covers every host deterministically. The old explicit install site remains a no-op (idempotent).
3. **`BcArtifacts` / handler laziness** — the handler used to capture `ServiceTierDir` at install time; at module-init that would trigger the lazy default selection before `--bc-version` is parsed. It now resolves the artifact dir lazily per request, and only `Microsoft.Dynamics.*` requests may trigger selection, guarded by a new side-effect-free `BcArtifacts.IsSelected`. When no artifacts are provisioned the handler returns null so the default binder's loud failure surfaces unchanged.

## Test (red → green)

`VersionAgnosticClosureTests.MustNotBeCopyLocal` gains `Microsoft.Dynamics.Nav.CodeAnalysis.dll`:

- **RED** — with the targets/loader change stashed, `BcAppClosure_IsNotCopiedIntoAppBaseDir` fails: the DLL leaks into bin.
- **GREEN** — with the fix, full `AlRunner.Tests` suite passes 291/291, deterministically (the order-dependent `JsonLoaderDependencyFallthroughTests` flakiness observed mid-prototype is gone).

## Verification beyond the suite

Binary built at the default `_BCVersion=28.1.49838.50794`, Linux x64:

| Scenario | Before | After |
|---|---|---|
| `--bc-version 28.3` against a real AL app + test app | FileLoadException at startup | all tests pass |
| `--bc-version 28.1.49838.50794` (matching build) | passes | passes |

The source also compiles unchanged with `-p:_BCVersion=28.3.52162.53506`, so a 28.1-compiled binary binding CodeAnalysis 17.0.40 is exercised against a real API surface.

Local al-language corpus run stops at the documented cross-major gate (corpus pins BC 27.5 platform apps; this dev box builds a 28 engine), so corpus coverage rides on the CI matrix, which builds a matching `-p:_BCVersion` per leg.

## Not in scope

- The exact-build/major.minor default-selection tiers in `BcArtifacts.DefaultVersionPrefix` are untouched — loadability is not fidelity, and the measured cross-minor behavioural drift they guard against still exists. Their doc comments (and the `Program.cs` warning text) cite the CodeAnalysis crash as rationale and could be relaxed in a follow-up once this lands.
- `CHANGELOG.md` untouched per `.claude/rules/no-changelog-edits.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
