### PR TITLE
docs: the documented build command fails on a fresh clone

### DIFF
--- a/AlRunner/AlRunner.csproj
+++ b/AlRunner/AlRunner.csproj
@@ -284,8 +284,10 @@
        version's artifact dir (BcArtifacts.ServiceTierDir) on demand — so the runner
        serves whichever minor the target project actually needs, from BC's own shipped
        copy, instead of a build-time-pinned one. One engine binary spans a major's minors.
-       (The 5 BC references themselves — Ncl/Types/Common/Language/CodeAnalysis — stay in
-       bin: those ARE the engine and are covered by the MAJOR-only consistency contract.)
+       (Ncl/Types/Common/Language stay in bin: those ARE the engine and are covered by the
+       MAJOR-only consistency contract. CodeAnalysis is the exception — MS stamps it with a
+       full 4-part version PER BC BUILD, so it is stripped too and served from the selected
+       artifact dir like the closure above; see Directory.Build.targets and #1700.)
 
        Cross-MAJOR still needs a matching engine build; this only relaxes the minors. -->
   <!-- StripBcAppClosureFromCopyLocal moved to the repo-root Directory.Build.targets so it

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,11 +49,32 @@ git submodule update --init --recursive
 
 ### Build
 
+The build references the BC service-tier DLLs, which are not in the repo. The runner
+**never auto-downloads** them: on a fresh clone the build fails loud, naming the exact
+download command. Provision them once, either as part of the build:
+
+```bash
+dotnet build AlRunner.slnx -c Release -p:AllowBcArtifactDownload=true
+```
+
+or explicitly, ahead of the build:
+
+```bash
+dotnet run --project tools/DownloadArtifacts -- service-tier <version> <artifact-dir>
+```
+
+The version is `_BCVersion` in `AlRunner/AlRunner.csproj`, and the default artifact dir is
+`<user-home>/.local/share/al-runner/artifacts/<version>` (that same layout on Windows, under
+`%USERPROFILE%`). You do not have to look either up — the failing build prints the whole
+command, filled in, ready to paste. Set `-p:ServiceTierPath=...` to point at an artifact dir
+you already have instead.
+
+Once the DLLs are present neither provisioning target runs, and the plain build is all
+you need from then on:
+
 ```bash
 dotnet build AlRunner.slnx -c Release
 ```
-
-The build target auto-downloads the BC service-tier DLLs and the AL compiler the first time. No manual setup.
 
 ### Run the al-language corpus
 

--- a/README.md
+++ b/README.md
@@ -146,9 +146,14 @@ This dispatches the single-app compile-to-DLL path. The output DLL is bit-compat
 
 ```bash
 git clone --recurse-submodules https://github.com/StefanMaron/BusinessCentral.AL.Runner
-dotnet build AlRunner.slnx -c Release
+dotnet build AlRunner.slnx -c Release -p:AllowBcArtifactDownload=true
 dotnet run --project AlRunner -c Release -- tests/al-language/tests/al-language
 ```
+
+`-p:AllowBcArtifactDownload=true` is needed only until the BC service-tier DLLs are
+present — the runner never downloads them implicitly, so without the opt-in a fresh
+clone fails the build with the explicit download command. Later builds can drop it.
+See [CONTRIBUTING.md](CONTRIBUTING.md#dev-loop) for provisioning them as a separate step.
 
 ## CLI Flags
 

--- a/docs/v1-to-v2-migration.md
+++ b/docs/v1-to-v2-migration.md
@@ -108,9 +108,14 @@ The full ruleset for the new layout lives in
 git fetch
 git checkout main
 git submodule update --init --recursive
-dotnet build AlRunner.slnx -c Release
+dotnet build AlRunner.slnx -c Release -p:AllowBcArtifactDownload=true
 dotnet run --project AlRunner -c Release -- tests/al-language/tests/al-language
 ```
+
+v2 pins a different `_BCVersion` than v1, so the first v2 build usually needs artifacts
+your v1 checkout does not have. `-p:AllowBcArtifactDownload=true` permits that one fetch;
+without it the build fails loud with the explicit download command, because the runner
+never downloads implicitly. Drop the flag once the DLLs are provisioned.
 
 If you install via NuGet:
 


### PR DESCRIPTION
Closes #1702

## What

README.md, CONTRIBUTING.md and `docs/v1-to-v2-migration.md` all tell contributors to run `dotnet build AlRunner.slnx -c Release`. On a fresh clone that hard-errors — `FailIfBCServiceTierDllsMissing` (`AlRunner/AlRunner.csproj:262`) refuses to build when the BC service-tier DLLs are absent and `-p:AllowBcArtifactDownload=true` is not set.

CONTRIBUTING was the furthest off, asserting the inverse of what the build does:

> The build target auto-downloads the BC service-tier DLLs and the AL compiler the first time. No manual setup.

Both halves are wrong under v2. The runner never auto-downloads — that opt-in gate is deliberate, per the `AlRunner.csproj:243` comment and `BcArtifacts`' class doc. And the build-time AL compiler download no longer exists at all: `_ALToolVersion` is gone from the csproj, nothing in the build fetches a compiler.

CI never trips over this because `test-matrix.yml` and `publish.yml` both pass the flag explicitly — it is present everywhere except the docs aimed at humans.

## Changes

- **CONTRIBUTING.md** — replace the false auto-download claim with both provisioning routes (in-build opt-in, or an explicit `tools/DownloadArtifacts` call), and note that the plain build is correct once the DLLs are present. Points at the failing build's own output as the source of the filled-in command rather than restating a path that can drift, and mentions `-p:ServiceTierPath=` for an existing artifact dir.
- **README.md** — add the flag to the "Build from source" snippet, with one line on why and a pointer to CONTRIBUTING.
- **docs/v1-to-v2-migration.md** — same, noting v2 pins a different `_BCVersion`, so the first v2 build usually needs artifacts a v1 checkout does not have.
- **AlRunner/AlRunner.csproj** — refresh the comment still claiming all five BC engine references stay in bin. CodeAnalysis stopped being one of them in #1700.

## Testing

Docs plus one comment; no behaviour change, so no test accompanies it (`.claude/rules/tdd.md` covers features, fixes and mock changes).

Verified by reading the MSBuild targets rather than by building: the `Error` in `FailIfBCServiceTierDllsMissing` is unconditional given `!Exists(ServiceTierPath/Microsoft.Dynamics.Nav.Types.dll)` and `AllowBcArtifactDownload != true`. **I could not run the build** — the session had no .NET SDK — so the exact wording of the emitted error is quoted from the target, not from a captured run. The claim that the plain build is fine once artifacts exist follows from the same two `Condition`s, both of which go false.

## Notes

- This is the gap #1637 set out to fill. That PR predates the v2 cutover so its diff no longer applies, but the motivation was right; suggest closing it with credit to @kant2002 once this lands.
- `CHANGELOG.md` untouched per `.claude/rules/no-changelog-edits.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AX8MEx4iECELaZNisb9DCW)_