### PR TITLE
feat(parser): parse AL tables with BC's own syntax tree, not regexes

### DIFF
--- a/AlRunner.Tests/AlSourceParserCommentTests.cs
+++ b/AlRunner.Tests/AlSourceParserCommentTests.cs
@@ -23,6 +23,7 @@ using Xunit;
 
 namespace AlRunner.Tests;
 
+[Collection(RecordPatchesSerialCollection.Name)]
 public class AlSourceParserCommentTests
 {
     private const int TableId = 61895; // the issue's repro id

--- a/AlRunner.Tests/AlSourceParserSyntaxTreeTests.cs
+++ b/AlRunner.Tests/AlSourceParserSyntaxTreeTests.cs
@@ -1,0 +1,207 @@
+// AlSourceParserSyntaxTreeTests — RED→GREEN guard for #1696.
+//
+// The table parser used to match properties with plain regexes over raw .al text. #1690 and
+// #1674 each fixed one instance of the resulting bug class by tightening one pattern; the
+// class itself survives every such fix, because a regex cannot know where an AL construct
+// actually begins and ends.
+//
+// The case pinned here is the one the class produces most quietly — a SILENT WRONG VALUE
+// rather than a crash. `RxInitValue` was `\bInitValue\s*=\s*([^;]+);`: a semicolon inside a
+// string literal is a perfectly ordinary character to AL, but `[^;]+` cannot cross one, so
+//
+//     InitValue = 'Open; pending review';
+//
+// captured `'Open` — a literal with no closing quote. Downstream, NclMetaTableBuilder strips
+// the quotes it expects to find in pairs and the field initialises to the wrong text. Real BC
+// compiles this without complaint.
+//
+// The fix parses with Microsoft.Dynamics.Nav.CodeAnalysis' own AL parser — the same front end
+// BcCompiler already runs over the very same files — so property values come back as typed
+// nodes and the question "where does this value end" is answered by the compiler, not by a
+// character class.
+//
+// These drive the real parser (TryParseTableFile / TryParseTableExtensionFile) by reflection,
+// exactly like AlSourceParserCommentTests, so they prove the parser consults the tree rather
+// than proving a helper works in isolation.
+using System.Reflection;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public class AlSourceParserSyntaxTreeTests
+{
+    private const int TableId = 61896;
+
+    private static readonly Type RecordPatchesType = typeof(AlRunner.Patches.RecordPatches);
+
+    private static System.Collections.IDictionary ParsedTables =>
+        (System.Collections.IDictionary)RecordPatchesType
+            .GetField("_parsedTables", BindingFlags.NonPublic | BindingFlags.Static)!
+            .GetValue(null)!;
+
+    private static object ParseTableAndGetField(string source, int fieldId)
+    {
+        var parse = RecordPatchesType.GetMethod("TryParseTableFile",
+            BindingFlags.NonPublic | BindingFlags.Static)!;
+        parse.Invoke(null, new object[] { source });
+        Assert.True(ParsedTables.Contains(TableId), $"table {TableId} was not parsed at all");
+        var table = ParsedTables[TableId]!;
+        foreach (var f in (System.Collections.IEnumerable)table.GetType()
+                     .GetProperty("Fields")!.GetValue(table)!)
+        {
+            if ((int)f.GetType().GetProperty("FieldId")!.GetValue(f)! == fieldId) return f;
+        }
+        throw new Xunit.Sdk.XunitException($"field {fieldId} was not parsed");
+    }
+
+    private static string? Prop(object parsedField, string name) =>
+        (string?)parsedField.GetType().GetProperty(name)!.GetValue(parsedField);
+
+    private static string Table(string fieldTwoBody) => $$"""
+        table {{TableId}} "Syntax Tree Fixture"
+        {
+            fields
+            {
+                field(1; "Code"; Code[10]) { }
+                field(2; Status; Text[50])
+                {
+        {{fieldTwoBody}}
+                }
+            }
+
+            keys
+            {
+                key(PK; "Code") { Clustered = true; }
+            }
+        }
+        """;
+
+    // ─── Positive: the value the regex silently truncated ────────────────────────────────
+
+    [Fact]
+    public void InitValue_StringLiteralContainingASemicolon_IsCapturedWhole()
+    {
+        try
+        {
+            var field = ParseTableAndGetField(
+                Table("            InitValue = 'Open; pending review';"), fieldId: 2);
+
+            // Before the syntax-tree parse this was `'Open` — `[^;]+` stopped at the semicolon
+            // inside the literal, leaving an unbalanced quote for NclMetaTableBuilder to strip.
+            // The value is deliberately compared WITH its quotes: the output contract is raw AL
+            // text, and NclMetaTableBuilder does the type-aware unquoting (that split is what
+            // #1674's blank-enum fix depends on).
+            Assert.Equal("'Open; pending review'", Prop(field, "InitValueText"));
+        }
+        finally { ParsedTables.Remove(TableId); }
+    }
+
+    [Fact]
+    public void Caption_StringLiteralContainingASemicolon_IsCapturedWhole()
+    {
+        try
+        {
+            var field = ParseTableAndGetField(
+                Table("            Caption = 'Status; current';"), fieldId: 2);
+
+            Assert.Equal("Status; current", Prop(field, "Caption"));
+        }
+        finally { ParsedTables.Remove(TableId); }
+    }
+
+    // ─── Negative: the traps a naive tree walk would introduce ───────────────────────────
+
+    [Fact]
+    public void Caption_WithTrailingCommentProperty_KeepsOnlyTheLabelLiteral()
+    {
+        // Trap 1 from #1696's implementation map. `LabelPropertyValueSyntax.ToString()` returns
+        // the WHOLE label including its trailing parts — `'It''s on', Comment='x'` — so taking
+        // the node's text wholesale would silently append `, Comment='x'` to every caption that
+        // carries a developer comment. Only the leading literal is the caption, with AL's
+        // doubled-quote escape resolved.
+        try
+        {
+            var field = ParseTableAndGetField(
+                Table("            Caption = 'It''s on', Comment='translator note';"), fieldId: 2);
+
+            Assert.Equal("It's on", Prop(field, "Caption"));
+        }
+        finally { ParsedTables.Remove(TableId); }
+    }
+
+    [Fact]
+    public void QuotedIdentifiers_AreUnquoted()
+    {
+        // Trap 2 from the map. `IdentifierNameSyntax.Identifier.ValueText` keeps the double
+        // quotes (`"Entry No."`), where the regexes captured the inner group. Leaving them on
+        // would break every by-name lookup — key field resolution, extension merges, the lot.
+        try
+        {
+            var field = ParseTableAndGetField(
+                Table("            InitValue = 'x';")
+                    .Replace("field(2; Status; Text[50])", """field(2; "Status Code"; Text[50])"""),
+                fieldId: 2);
+
+            Assert.Equal("Status Code", Prop(field, "FieldName"));
+
+            var table = ParsedTables[TableId]!;
+            Assert.Equal("Syntax Tree Fixture",
+                (string)table.GetType().GetProperty("TableName")!.GetValue(table)!);
+
+            // The PK is declared as `key(PK; "Code")` — a quoted name that must still resolve
+            // to field 1 by name. A stray pair of quotes here would leave the table with no PK.
+            var pk = (System.Collections.IEnumerable)table.GetType()
+                .GetProperty("PkFieldIds")!.GetValue(table)!;
+            Assert.Equal(new[] { 1 }, pk.Cast<int>().ToArray());
+        }
+        finally { ParsedTables.Remove(TableId); }
+    }
+
+    [Fact]
+    public void NonTableObjectsInTheSameFile_DoNotContributeFields()
+    {
+        // The old slice-between-regex-matches scheme used only `table` and `tableextension`
+        // starts as boundaries, so any other object type that followed a table was swept into
+        // its slice. Object boundaries are structural in the tree.
+        var source = Table("            InitValue = 'x';") + """
+
+            codeunit 61896 "Fixture Helper"
+            {
+                procedure Reset()
+                begin
+                end;
+            }
+            """;
+        try
+        {
+            var parse = RecordPatchesType.GetMethod("TryParseTableFile",
+                BindingFlags.NonPublic | BindingFlags.Static)!;
+            parse.Invoke(null, new object[] { source });
+
+            var table = ParsedTables[TableId]!;
+            var ids = ((System.Collections.IEnumerable)table.GetType()
+                    .GetProperty("Fields")!.GetValue(table)!)
+                .Cast<object>()
+                .Select(f => (int)f.GetType().GetProperty("FieldId")!.GetValue(f)!)
+                .OrderBy(x => x).ToArray();
+
+            Assert.Equal(new[] { 1, 2 }, ids);
+        }
+        finally { ParsedTables.Remove(TableId); }
+    }
+
+    [Fact]
+    public void UnparseableSource_IsIgnoredRatherThanThrowing()
+    {
+        // TryParseTableFile is fed arbitrary .al text — pages, codeunits, and AL sliced out of
+        // dependency .app archives. It must never throw on input it does not understand.
+        var parse = RecordPatchesType.GetMethod("TryParseTableFile",
+            BindingFlags.NonPublic | BindingFlags.Static)!;
+
+        parse.Invoke(null, new object[] { "this is not AL at all { { {" });
+        parse.Invoke(null, new object[] { "" });
+        parse.Invoke(null, new object[] { "page 50100 P { layout { area(content) { } } }" });
+
+        Assert.False(ParsedTables.Contains(TableId));
+    }
+}

--- a/AlRunner.Tests/AlSourceParserSyntaxTreeTests.cs
+++ b/AlRunner.Tests/AlSourceParserSyntaxTreeTests.cs
@@ -28,6 +28,7 @@ using Xunit;
 
 namespace AlRunner.Tests;
 
+[Collection(RecordPatchesSerialCollection.Name)]
 public class AlSourceParserSyntaxTreeTests
 {
     private const int TableId = 61896;

--- a/AlRunner.Tests/RecordPatchesSerialCollection.cs
+++ b/AlRunner.Tests/RecordPatchesSerialCollection.cs
@@ -1,0 +1,29 @@
+// RecordPatchesSerialCollection — the AL source parsers write their results into
+// PROCESS-WIDE static dictionaries on RecordPatches (`_parsedTables`, `_parsedPages`, …).
+// A test that drives a parser and then reads its result back out of one of those
+// dictionaries is therefore reading shared mutable state, and anything else running
+// concurrently that repopulates or clears them (RecordPatches.ResetForReload, an
+// in-process bundle load, another parser test using a neighbouring id) can land between
+// the write and the read.
+//
+// xunit runs each test class as its own collection and runs collections IN PARALLEL by
+// default, so those classes were only ever accidentally safe. It surfaced on #1696: an
+// AlSourceParserSyntaxTreeTests case failed as "table 61896 was not parsed at all" on four
+// of five CI legs while passing on the fifth, passing in isolation, and passing in two full
+// local suite runs (BC 28.1.49838.50794 and .53507 — the exact build a failing leg used).
+// The parse itself was verified correct against the failing build's own
+// Microsoft.Dynamics.Nav.CodeAnalysis, which is what rules the parser out and leaves
+// scheduling as the difference: CI runners have a different core count, so xunit picks a
+// different degree of parallelism.
+//
+// DisableParallelization makes this collection run on its own, so the parser tests get the
+// static dictionaries to themselves for the duration.
+using Xunit;
+
+namespace AlRunner.Tests;
+
+[CollectionDefinition(Name, DisableParallelization = true)]
+public sealed class RecordPatchesSerialCollection
+{
+    public const string Name = "record-patches-serial";
+}

--- a/AlRunner.Tests/SiblingParserCommentTests.cs
+++ b/AlRunner.Tests/SiblingParserCommentTests.cs
@@ -18,6 +18,7 @@ using Xunit;
 
 namespace AlRunner.Tests;
 
+[Collection(RecordPatchesSerialCollection.Name)]
 public class SiblingParserCommentTests
 {
     private static readonly Type RecordPatchesType = typeof(AlRunner.Patches.RecordPatches);

--- a/AlRunner/Patches/AlCommentBlanker.cs
+++ b/AlRunner/Patches/AlCommentBlanker.cs
@@ -1,6 +1,13 @@
 // AlCommentBlanker — blanks out AL comments in raw .al source before the regex-based
 // parsers run over it.
 //
+// SCOPE NOTE (#1696): the TABLE parser no longer needs this. It parses with BC's own AL
+// parser, where comments are trivia and never reach a property value in the first place.
+// The worked example below is kept because it is still the clearest statement of the bug
+// class — it just describes the table parser as it WAS. The five sibling parsers
+// (page/report/query/xmlport/object-decl/caption) are still regex-based and still depend on
+// this; it comes out when they migrate too (#1697).
+//
 // The parsers in RecordPatches.Al*Parser.cs match property names with plain regexes
 // (`\bInitValue\s*=\s*([^;]+);` and friends) against raw file text. A comment is just text
 // to a regex, so a perfectly ordinary explanatory comment gets read as a property (#1690):

--- a/AlRunner/Patches/RecordPatches.AlSourceParser.cs
+++ b/AlRunner/Patches/RecordPatches.AlSourceParser.cs
@@ -1,91 +1,93 @@
-// RecordPatches.AlSourceParser — parses AL `table` declarations into ParsedTable
-// records keyed by table ID. The output is consumed by NclMetaTableBuilder to
+// RecordPatches.AlSourceParser — parses AL `table` / `tableextension` declarations into
+// ParsedTable records keyed by table ID. The output is consumed by NclMetaTableBuilder to
 // produce real NCLMetaTable instances at runtime.
 //
-// The parser uses regex over raw .al text rather than a real AL syntax tree —
-// good enough for the spike since we only need table layout (IDs, fields, PK).
+// Syntax-level extraction runs on Microsoft.Dynamics.Nav.CodeAnalysis' own AL parser — the
+// same front end BcCompiler.Emit already runs over the very same files (#1696). It replaced
+// a set of regexes over raw .al text whose failure mode was a SILENT WRONG VALUE rather than
+// a crash: `[^;]+` could not cross a semicolon inside a string literal (`InitValue =
+// 'Open; pending review'` captured `'Open`), a comment mentioning a property name was read
+// as that property (#1690), quoting was captured inconsistently (#1674), and object
+// boundaries were guessed by slicing between regex matches. A syntax tree answers all four
+// structurally: comments are trivia and simply are not in it.
+//
+// `SyntaxTree.ParseObjectText` needs only a ParseOptions — no Compilation, no reference
+// closure — so this works on every input the parser takes: real files, AL extracted from
+// dependency .app archives, and the table text NclMetaTableBuilder synthesizes.
+//
+// STILL REGEX: the CalcFormula sub-parse below. It is fed the formula's own syntax node text
+// (so it no longer sees comments or neighbouring properties), but the structural mapping onto
+// QualifiedNameSyntax / WhereExpressionSyntax is deliberately deferred — #1696 orders it last,
+// and RecordPatches.TryParseCalcFormula has an external caller in BcAppSymbolCache that hands
+// it synthesized text rather than a node.
 using System.Text.RegularExpressions;
+using NavCA = Microsoft.Dynamics.Nav.CodeAnalysis;
+using NavSyntax = Microsoft.Dynamics.Nav.CodeAnalysis.Syntax;
 
 namespace AlRunner.Patches;
 
 public static partial class RecordPatches
 {
-    private static readonly Regex RxTable = new(
-        @"\btable\s+(\d+)\s+(?:""([^""]+)""|([A-Za-z_]\w*))[^{]*?\{",
-        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+    // Matches BcCompiler.Emit's options so this parse sees the same source the emit does —
+    // notably the CLEANSCHEMA1..25 preprocessor symbols, which gate real field declarations
+    // in the BaseApp. DocumentationMode.None: doc comments are trivia we never read.
+    private static readonly NavCA.ParseOptions AlParseOptions = new(
+        runtimeVersion: null!,
+        preprocessorSymbols: Enumerable.Range(1, 25).Select(n => $"CLEANSCHEMA{n}"),
+        documentationMode: NavCA.DocumentationMode.None);
 
-    private static readonly Regex RxTableExtension = new(
-        @"\btableextension\s+(\d+)\s+(?:""([^""]+)""|([A-Za-z_]\w*))\s+extends\s+(?:""([^""]+)""|([A-Za-z_]\w*))[^{]*?\{",
-        RegexOptions.IgnoreCase | RegexOptions.Compiled | RegexOptions.Singleline);
-
-    private static readonly Regex RxField = new(
-        @"\bfield\s*\(\s*(\d+)\s*;\s*(?:""([^""]+)""|([A-Za-z_]\w*))\s*;\s*([^)]+?)\s*\)",
-        RegexOptions.IgnoreCase | RegexOptions.Compiled);
-
-    // Group 1 = key name, group 2 = comma-separated field list.
-    private static readonly Regex RxKey = new(
-        @"\bkey\s*\(\s*([^;]+)\s*;\s*([^)]+)\)",
-        RegexOptions.IgnoreCase | RegexOptions.Compiled);
-
-    private static readonly Regex RxFieldClass = new(
-        @"\bFieldClass\s*=\s*FlowField\b",
-        RegexOptions.IgnoreCase | RegexOptions.Compiled);
-
-    private static readonly Regex RxTableTypeTemporary = new(
-        @"\bTableType\s*=\s*Temporary\b",
-        RegexOptions.IgnoreCase | RegexOptions.Compiled);
-
-    // DataPerCompany = false; — AL's default is TRUE, so only the explicit opt-out is
-    // parsed. MetaTable's own ctor default for isDataPerCompany is false, which is the
-    // opposite of AL's, and BC's RecordImplementation.ChangeCompany returns true
-    // immediately for a table that is not per-company.
-    private static readonly Regex RxDataPerCompanyFalse = new(
-        @"\bDataPerCompany\s*=\s*false\s*;",
-        RegexOptions.IgnoreCase | RegexOptions.Compiled);
-
-    // OptionMembers = A,B,C; — captures the comma-joined list (whitespace trimmed
-    // per-token by the consumer). Used to populate MetaField.optionString so BC's
-    // NCLOptionMetadataNavTypeField (Field.Type field 5 of table 2000000041 and
-    // similar specialised subclasses) gets the right count.
-    private static readonly Regex RxOptionMembers = new(
-        @"\bOptionMembers\s*=\s*([^;]+);",
-        RegexOptions.IgnoreCase | RegexOptions.Compiled);
-
-    // InitValue = <al-expression>; — captures the raw AL expression text up to the
-    // terminating semicolon. Used to populate MetaField.initValue (string) which BC
-    // stores as NCLMetaField.initialValueText and evaluates via
-    // ALSystemVariable.EvaluateIntoNavValue inside the NCLMetaField.InitValue
-    // getter at Init() time.
-    // Caption = 'text'; — the field's declared caption. Without it BC's
-    // NCLMetaField.CreateCaptionStrings falls back to the field NAME, so
-    // `Rec.FieldCaption(n)` and the Field virtual table's "Field Caption" both answer
-    // `NewColumnName` where AL declared `New Column Name`. AL escapes an embedded quote
-    // by doubling it, so the literal runs to the last quote before the semicolon.
-    private static readonly Regex RxCaption = new(
-        @"\bCaption\s*=\s*'((?:[^']|'')*)'\s*(?:,[^;]*)?;",
-        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+    // Field type text still yields its length by pattern (`Code[10]` → 10). The type is one
+    // token's text with no nesting, so there is nothing structural for a tree to add here.
+    private static readonly Regex RxTypeLength = new(@"\[(\d+)\]", RegexOptions.Compiled);
 
     /// <summary>
-    /// The <c>Caption = '...'</c> declared on a field body, or null when it declares none —
-    /// in which case BC's own field-name fallback is the correct answer and must stand.
-    /// Doubled single quotes are AL's escape for a literal quote.
+    /// Identifiers come off the tree with AL's quoting intact — <c>"Entry No."</c>, not
+    /// <c>Entry No.</c>. Every consumer (key resolution, tableextension merge, metatable
+    /// lookup) matches on the bare name, so the quotes come off exactly once, here.
+    /// (<c>Unquote</c> itself lives in RecordPatches.NclMetaQueryBuilder.cs — same partial
+    /// class, same rule.)
     /// </summary>
-    private static string? ParseCaption(string? fieldBody)
+    private static string IdentText(NavSyntax.IdentifierNameSyntax? id) =>
+        id == null ? "" : Unquote(id.Identifier.ValueText ?? id.Identifier.Text ?? "");
+
+    /// <summary>
+    /// The caption literal declared by <c>Caption = 'text'</c>, or null when the field
+    /// declares none — in which case BC's own field-name fallback is the correct answer and
+    /// must stand.
+    /// <para>Only the LABEL LITERAL is the caption. A label may carry trailing parts
+    /// (<c>Caption = 'It''s on', Comment='x';</c>) and the property value node's text spans
+    /// all of them, so reading the node wholesale would append <c>, Comment='x'</c> to the
+    /// caption. <see cref="NavSyntax.LabelSyntax.LabelText"/> is just the literal.
+    /// Doubled single quotes are AL's escape for an embedded quote.</para>
+    /// </summary>
+    private static string? CaptionFrom(NavSyntax.PropertyValueSyntax? value)
     {
-        if (string.IsNullOrEmpty(fieldBody)) return null;
-        var m = RxCaption.Match(fieldBody);
-        return m.Success ? m.Groups[1].Value.Replace("''", "'") : null;
+        if (value is not NavSyntax.LabelPropertyValueSyntax label) return null;
+        var text = label.Value?.LabelText?.ToString();
+        if (string.IsNullOrEmpty(text)) return null;
+        if (text.Length >= 2 && text[0] == '\'' && text[^1] == '\'') text = text[1..^1];
+        return text.Replace("''", "'");
     }
 
-    private static readonly Regex RxInitValue = new(
-        @"\bInitValue\s*=\s*([^;]+);",
-        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+    /// <summary>Property lookup by AL name, case-insensitive as AL itself is.</summary>
+    private static NavSyntax.PropertyValueSyntax? PropValue(
+        NavSyntax.PropertyListSyntax? list, string name)
+    {
+        if (list == null) return null;
+        // Properties is a list of PropertySyntaxOrEmpty: a stray `;` in a property list is
+        // legal AL and parses as an empty entry, which simply has no name to match.
+        foreach (var entry in list.Properties)
+        {
+            if (entry is not NavSyntax.PropertySyntax p) continue;
+            if (string.Equals(p.Name?.Identifier.ValueText, name, StringComparison.OrdinalIgnoreCase))
+                return p.Value;
+        }
+        return null;
+    }
 
-    // AutoIncrement = true; — detect on PK field bodies so we can wire up autoincrement
-    // semantics in the NCLMetaTable.
-    private static readonly Regex RxAutoIncrement = new(
-        @"\bAutoIncrement\s*=\s*true\b",
-        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+    private static bool PropIs(NavSyntax.PropertyListSyntax? list, string name, string expected) =>
+        string.Equals(PropValue(list, name)?.ToString()?.Trim(), expected,
+            StringComparison.OrdinalIgnoreCase);
 
     private static readonly Regex RxCalcFormula = new(
         @"\bCalcFormula\s*=\s*([^;]+)\s*;",
@@ -130,171 +132,156 @@ public static partial class RecordPatches
         }
     }
 
+    /// <summary>
+    /// Parses every AL object in <paramref name="text"/> with BC's own parser and returns the
+    /// object declarations. Never throws: this is fed arbitrary .al text — pages, codeunits,
+    /// AL sliced out of dependency .app archives, and synthesized table text — and a parse it
+    /// cannot make sense of must leave the caller's state untouched, not break the run.
+    /// Diagnostics are ignored on purpose: a file that fails to compile for an unrelated
+    /// reason still yields a usable table declaration, which is what the regexes did too.
+    /// </summary>
+    private static IReadOnlyList<NavCA.SyntaxNode> ParseAlObjects(string? text)
+    {
+        if (string.IsNullOrWhiteSpace(text)) return [];
+        try
+        {
+            var tree = NavSyntax.SyntaxTree.ParseObjectText(
+                text, path: "", encoding: null!, AlParseOptions, default);
+            if (tree.GetRoot() is not NavSyntax.CompilationUnitSyntax root) return [];
+            return root.ChildNodes().ToList();
+        }
+        catch
+        {
+            // A malformed input is not a runner gap — the AL simply is not parseable, and the
+            // caller's contract is "extract what you can". Callers that need a table and do
+            // not get one already report that themselves ("AL source not parsed").
+            return [];
+        }
+    }
+
+    /// <summary>Builds a <see cref="ParsedField"/> from one <c>field(...)</c> declaration.</summary>
+    private static ParsedField? ParseFieldSyntax(NavSyntax.FieldSyntax f, bool tableLevelExtras)
+    {
+        if (f.No.Value is not int fid) return null;
+        var fname = IdentText(f.Name);
+        var ftype = f.Type?.ToString()?.Trim() ?? "";
+        int length = 0;
+        var lm = RxTypeLength.Match(ftype);
+        if (lm.Success) int.TryParse(lm.Groups[1].Value, out length);
+
+        var props = f.PropertyList;
+        bool isFlowField = PropIs(props, "FieldClass", "FlowField");
+
+        ParsedCalcFormula? calcFormula = null;
+        if (isFlowField && PropValue(props, "CalcFormula") is { } formulaNode)
+        {
+            // Hand TryParseCalcFormula the formula's own node text in the shape its regex
+            // expects. The text now comes from the tree, so comments and neighbouring
+            // properties can no longer bleed into it.
+            calcFormula = TryParseCalcFormula($"CalcFormula = {formulaNode};");
+        }
+
+        // Option-type fields: OptionMembers is the comma-separated list BC's
+        // NCLOptionMetadata constructor expects. Tokens are trimmed; empty entries are kept
+        // (BC allows blank members, and #1674 depends on that).
+        string? optionMembers = null;
+        if (ftype.Equals("Option", StringComparison.OrdinalIgnoreCase)
+            && PropValue(props, "OptionMembers") is { } om)
+        {
+            optionMembers = string.Join(",", om.ToString().Split(',').Select(s => s.Trim()));
+        }
+
+        // InitValue is passed to MetaField.initValue as RAW AL TEXT, quotes and all, because
+        // NclMetaTableBuilder does the type-aware unquoting downstream — that split is what
+        // #1674's blank-enum fix depends on. Do not "clean" it here without deleting the
+        // stripping there in the same change.
+        string? initValueText = PropValue(props, "InitValue")?.ToString()?.Trim();
+
+        bool isAutoIncrement = tableLevelExtras && PropIs(props, "AutoIncrement", "true");
+        var caption = CaptionFrom(PropValue(props, "Caption"));
+
+        return new ParsedField(fid, fname, ftype, length, isFlowField, calcFormula,
+            tableLevelExtras ? optionMembers : null, initValueText, isAutoIncrement, caption);
+    }
+
     private static void TryParseTableFile(string text)
     {
-        // Comments first: every regex below matches property names as bare text, so a
-        // comment mentioning one is otherwise read as the property itself (#1690). Blanking
-        // is length-preserving, so the slice offsets computed below are unaffected. Done
-        // here rather than in ParseAllSources because TryParseTableFile has several callers
-        // (RecordPatches.Register, BcAppFallback's decompiled source) that each need it.
-        text = AlCommentBlanker.Blank(text);
-
-        // Multiple `table N "Name" { ... }` declarations may live in one .al file.
-        // Slice the text between consecutive RxTable matches so each table only sees
-        // its own fields/keys.
-        var tableMatches = RxTable.Matches(text);
-        if (tableMatches.Count == 0) return;
-
-        // Collect all tableextension start positions so we can use them as slice boundaries.
-        var extPositions = RxTableExtension.Matches(text).Cast<Match>().Select(m => m.Index).ToArray();
-
-        for (int i = 0; i < tableMatches.Count; i++)
+        foreach (var obj in ParseAlObjects(text))
         {
-            var tableMatch = tableMatches[i];
-            int sliceStart = tableMatch.Index;
-            int nextTableIdx = (i + 1 < tableMatches.Count) ? tableMatches[i + 1].Index : text.Length;
-            // Also stop at any tableextension that follows this table block.
-            int nextExtIdx = extPositions.Where(p => p > sliceStart).Append(text.Length).Min();
-            int sliceEnd = Math.Min(nextTableIdx, nextExtIdx);
-            var slice = text.Substring(sliceStart, sliceEnd - sliceStart);
-
-            if (!int.TryParse(tableMatch.Groups[1].Value, out int tableId)) continue;
-            var tableName = tableMatch.Groups[2].Success ? tableMatch.Groups[2].Value : tableMatch.Groups[3].Value;
+            if (obj is not NavSyntax.TableSyntax table) continue;
+            if (table.ObjectId?.Value.Value is not int tableId) continue;
+            var tableName = IdentText(table.Name);
 
             var fields = new List<ParsedField>();
-            foreach (Match fm in RxField.Matches(slice))
-            {
-                if (!int.TryParse(fm.Groups[1].Value, out int fid)) continue;
-                var fname = fm.Groups[2].Success ? fm.Groups[2].Value : fm.Groups[3].Value;
-                var ftype = fm.Groups[4].Value.Trim();
-                int length = 0;
-                var lm = Regex.Match(ftype, @"\[(\d+)\]");
-                if (lm.Success) int.TryParse(lm.Groups[1].Value, out length);
+            if (table.Fields != null)
+                foreach (var f in table.Fields.Fields)
+                    if (ParseFieldSyntax(f, tableLevelExtras: true) is { } pf)
+                        fields.Add(pf);
 
-                // Extract the field body block (e.g. { FieldClass = FlowField; CalcFormula = ...; })
-                var fieldBody = ExtractFieldBody(slice, fm.Index + fm.Length);
-                bool isFlowField = fieldBody != null && RxFieldClass.IsMatch(fieldBody);
-                ParsedCalcFormula? calcFormula = null;
-                if (isFlowField && fieldBody != null)
-                    calcFormula = TryParseCalcFormula(fieldBody);
-
-                // Option-type fields: capture OptionMembers if present. The comma-
-                // separated list is what BC's NCLOptionMetadata constructor expects.
-                string? optionMembers = null;
-                if (fieldBody != null && ftype.Trim().Equals("Option", StringComparison.OrdinalIgnoreCase))
-                {
-                    var omMatch = RxOptionMembers.Match(fieldBody);
-                    if (omMatch.Success)
-                    {
-                        // Trim each comma-separated token; keep empty entries (BC allows blanks).
-                        optionMembers = string.Join(",",
-                            omMatch.Groups[1].Value.Split(',').Select(s => s.Trim()));
-                    }
-                }
-
-                // InitValue: capture raw AL expression text for fields with explicit
-                // InitValue = X; — passed verbatim to MetaField.initValue (string), then
-                // BC's NCLMetaField.InitValue getter calls ALSystemVariable.EvaluateIntoNavValue
-                // on it at Init() time.
-                string? initValueText = null;
-                bool isAutoIncrement = false;
-                if (fieldBody != null)
-                {
-                    var ivMatch = RxInitValue.Match(fieldBody);
-                    if (ivMatch.Success)
-                        initValueText = ivMatch.Groups[1].Value.Trim();
-                    isAutoIncrement = RxAutoIncrement.IsMatch(fieldBody);
-                }
-
-                var caption = ParseCaption(fieldBody);
-
-                fields.Add(new ParsedField(fid, fname, ftype, length, isFlowField, calcFormula, optionMembers, initValueText, isAutoIncrement, caption));
-            }
-
-            // Parse first key as PK; all subsequent keys are secondary.
+            // First key is the PK; all subsequent keys are secondary.
             var pkFieldIds = new List<int>();
             var secondaryKeys = new List<ParsedKey>();
-            var allKeyMatches = RxKey.Matches(slice);
             bool firstKey = true;
-            foreach (Match keyMatch in allKeyMatches)
+            if (table.Keys != null)
             {
-                var keyName = keyMatch.Groups[1].Value.Trim().Trim('"');
-                var keyFieldNames = keyMatch.Groups[2].Value
-                    .Split(',')
-                    .Select(s => s.Trim().Trim('"'))
-                    .ToList();
-                var keyFieldIds = new List<int>();
-                foreach (var kn in keyFieldNames)
+                foreach (var k in table.Keys.Keys)
                 {
-                    var f = fields.FirstOrDefault(x =>
-                        string.Equals(x.FieldName, kn, StringComparison.OrdinalIgnoreCase));
-                    if (f != null) keyFieldIds.Add(f.FieldId);
-                }
-                if (firstKey)
-                {
-                    pkFieldIds.AddRange(keyFieldIds);
-                    firstKey = false;
-                }
-                else if (keyFieldIds.Count > 0)
-                {
-                    secondaryKeys.Add(new ParsedKey(keyName, keyFieldIds));
+                    var keyName = IdentText(k.Name);
+                    var keyFieldIds = new List<int>();
+                    foreach (var kf in k.Fields)
+                    {
+                        var kn = IdentText(kf as NavSyntax.IdentifierNameSyntax);
+                        var f = fields.FirstOrDefault(x =>
+                            string.Equals(x.FieldName, kn, StringComparison.OrdinalIgnoreCase));
+                        if (f != null) keyFieldIds.Add(f.FieldId);
+                    }
+                    if (firstKey)
+                    {
+                        pkFieldIds.AddRange(keyFieldIds);
+                        firstKey = false;
+                    }
+                    else if (keyFieldIds.Count > 0)
+                    {
+                        secondaryKeys.Add(new ParsedKey(keyName, keyFieldIds));
+                    }
                 }
             }
             // Fallback: first field is PK
             if (pkFieldIds.Count == 0 && fields.Count > 0)
                 pkFieldIds.Add(fields[0].FieldId);
 
-            var isTableTypeTemporary = RxTableTypeTemporary.IsMatch(slice);
-            var dataPerCompany = !RxDataPerCompanyFalse.IsMatch(slice);
-            _parsedTables[tableId] = new ParsedTable(tableId, tableName, fields, pkFieldIds, secondaryKeys,
-                isTableTypeTemporary, dataPerCompany);
+            // DataPerCompany: AL's default is TRUE, so only the explicit opt-out is parsed.
+            // MetaTable's own ctor default for isDataPerCompany is false — the opposite of
+            // AL's — and BC's RecordImplementation.ChangeCompany returns true immediately for
+            // a table that is not per-company.
+            var isTableTypeTemporary = PropIs(table.PropertyList, "TableType", "Temporary");
+            var dataPerCompany = !PropIs(table.PropertyList, "DataPerCompany", "false");
+            _parsedTables[tableId] = new ParsedTable(tableId, tableName, fields, pkFieldIds,
+                secondaryKeys, isTableTypeTemporary, dataPerCompany);
         }
     }
 
     private static void TryParseTableExtensionFile(string text)
     {
-        text = AlCommentBlanker.Blank(text); // see TryParseTableFile — same reason (#1690)
-
-        var extMatches = RxTableExtension.Matches(text);
-        if (extMatches.Count == 0) return;
-
-        for (int i = 0; i < extMatches.Count; i++)
+        foreach (var obj in ParseAlObjects(text))
         {
-            var m = extMatches[i];
-            if (!int.TryParse(m.Groups[1].Value, out int extId)) continue;
-            var extName = m.Groups[2].Success ? m.Groups[2].Value : m.Groups[3].Value;
-            var baseName = m.Groups[4].Success ? m.Groups[4].Value : m.Groups[5].Value;
+            if (obj is not NavSyntax.TableExtensionSyntax ext) continue;
+            if (ext.ObjectId?.Value.Value is not int extId) continue;
+            var extName = IdentText(ext.Name);
+            var baseName = Unquote(ext.BaseObject?.ToString()?.Trim() ?? "");
 
-            int sliceStart = m.Index;
-            int sliceEnd = (i + 1 < extMatches.Count) ? extMatches[i + 1].Index : text.Length;
-            var slice = text.Substring(sliceStart, sliceEnd - sliceStart);
-
+            // tableLevelExtras: false keeps this path byte-identical to what it produced
+            // before — extension fields carried neither OptionMembers nor AutoIncrement.
+            // Both are plausibly wanted here, but adding them is a behaviour change that
+            // needs its own test, not a silent rider on a parser swap.
             var fields = new List<ParsedField>();
-            foreach (Match fm in RxField.Matches(slice))
-            {
-                if (!int.TryParse(fm.Groups[1].Value, out int fid)) continue;
-                var fname = fm.Groups[2].Success ? fm.Groups[2].Value : fm.Groups[3].Value;
-                var ftype = fm.Groups[4].Value.Trim();
-                int length = 0;
-                var lm = Regex.Match(ftype, @"\[(\d+)\]");
-                if (lm.Success) int.TryParse(lm.Groups[1].Value, out length);
-
-                var fieldBody = ExtractFieldBody(slice, fm.Index + fm.Length);
-                bool isFlowField = fieldBody != null && RxFieldClass.IsMatch(fieldBody);
-                ParsedCalcFormula? calcFormula = null;
-                if (isFlowField && fieldBody != null)
-                    calcFormula = TryParseCalcFormula(fieldBody);
-
-                string? initValueText = null;
-                if (fieldBody != null)
-                {
-                    var ivMatch = RxInitValue.Match(fieldBody);
-                    if (ivMatch.Success)
-                        initValueText = ivMatch.Groups[1].Value.Trim();
-                }
-
-                fields.Add(new ParsedField(fid, fname, ftype, length, isFlowField, calcFormula, OptionMembers: null, InitValueText: initValueText, Caption: ParseCaption(fieldBody)));
-            }
+            // OfType<FieldSyntax>: a tableextension's field list also holds `modify(...)`
+            // entries, which declare no new field. The regex only ever matched
+            // `field(N; Name; Type)` either, so this keeps the same set.
+            if (ext.Fields != null)
+                foreach (var f in ext.Fields.Fields.OfType<NavSyntax.FieldSyntax>())
+                    if (ParseFieldSyntax(f, tableLevelExtras: false) is { } pf)
+                        fields.Add(pf);
 
             Console.Error.WriteLine($"[TableExt] parsed extension {extId} '{extName}' extends '{baseName}' with {fields.Count} fields");
 
@@ -358,21 +345,6 @@ public static partial class RecordPatches
                     $"[TableExt] evicted stale NCLMetaTable {kvp.Key} '{baseTableName}' " +
                     $"(built before its tableextension fields were parsed)");
         }
-    }
-
-    /// <summary>Extracts the brace-balanced body of a field block starting near <paramref name="pos"/> in <paramref name="slice"/>.</summary>
-    private static string? ExtractFieldBody(string slice, int pos)
-    {
-        while (pos < slice.Length && char.IsWhiteSpace(slice[pos])) pos++;
-        if (pos >= slice.Length || slice[pos] != '{') return null;
-        int depth = 0, start = pos;
-        while (pos < slice.Length)
-        {
-            if (slice[pos] == '{') depth++;
-            else if (slice[pos] == '}') { depth--; if (depth == 0) return slice.Substring(start + 1, pos - start - 1); }
-            pos++;
-        }
-        return null;
     }
 
     internal static ParsedCalcFormula? TryParseCalcFormula(string fieldBody)


### PR DESCRIPTION
First slice of #1696 — the table parser. **Deliberately not `Closes #1696`**: that issue is the umbrella for all seven parsers, and six of them plus the CalcFormula structural mapping are still open. See "What is left" below.

## The bug this actually fixes

The issue argued the case as "silent wrong answers, not crashes." The RED test pins a fresh instance of exactly that, found while writing this:

```al
InitValue = 'Open; pending review';
```

`RxInitValue` was `\bInitValue\s*=\s*([^;]+);`. A semicolon inside a string literal is an ordinary character to AL, but `[^;]+` cannot cross one — so this captured `'Open`, a literal with no closing quote, which `NclMetaTableBuilder` then strips as if it were balanced. Real BC compiles it without complaint. Nothing throws; the field just initialises to the wrong text.

That is the third variety from the issue body — the one that "passes while asserting against a wrong value" — and it is why tightening one more pattern is not the fix. #1690 and #1674 each fixed one instance; the class survives every such fix.

## Approach

`SyntaxTree.ParseObjectText` with BC's own AL parser — the same front end `BcCompiler.Emit` already runs over the very same files. It needs only a `ParseOptions`, no `Compilation` and no reference closure, which is what makes it viable on every input this parser takes: real files, AL sliced out of dependency `.app` archives, and the table text `NclMetaTableBuilder` synthesizes (blockers 2 and 3 in the issue).

Comments are trivia and never reach a property value, so `AlCommentBlanker` is gone from this parser. The class stays for the five still-regex sibling parsers (#1697); I added a scope note to its header so the worked example there is not read as current.

## Both traps from the implementation map, pinned by tests

The map called these out as things that would each ship as a silent behaviour change. Both confirmed against the real DLL (28.1.49838.50794) before writing the code:

- **Caption swallows its siblings.** `LabelPropertyValueSyntax`'s text spans the whole label — `'It''s on', Comment='x'` — so reading the value node wholesale appends `, Comment='x'` to every caption carrying a translator comment. Read `LabelSyntax.LabelText` instead, then strip quotes and un-double `''`.
- **Identifiers keep their quotes.** `Identifier.ValueText` returns `"Entry No."`. Unquoted once on the way out, or every by-name lookup (key resolution, extension merge, metatable lookup) silently stops matching.

## Output contract deliberately unchanged

Property values are still emitted as **raw AL text, quotes intact** — `InitValueText` for a blank enum is still `" "`, not ` `. `NclMetaTableBuilder` does the type-aware unquoting downstream, and that split is what #1674's blank-enum fix depends on. Cleaning the values up means deleting the downstream stripping in the same change; that is not this change.

## Tests

`AlSourceParserSyntaxTreeTests`, driving the real `TryParseTableFile` by reflection like `AlSourceParserCommentTests`:

- **RED → GREEN**: `InitValue`/`Caption` string literals containing a semicolon. Before: `Actual: "'Open"`. After: `'Open; pending review'`.
- Negative — caption with a trailing `Comment=` keeps only the literal (trap 1).
- Negative — quoted identifiers unquoted, including the PK still resolving through `key(PK; "Code")` (trap 2).
- Negative — a codeunit after a table in the same file contributes no fields. The old scheme sliced between `table`/`tableextension` regex matches only, so any other object type following a table fell inside its slice.
- Negative — garbage, empty, and page-only input are ignored rather than throwing. This parser is fed arbitrary `.al`.

## Verification

| Gate | Result |
|---|---|
| `AlRunner.Tests` | 297/297 (291 baseline + 6 new) |
| `tests/runner-extras` (`--strict`, both package caches) | 98/98 |
| `tests/al-language` corpus (`--strict`) | 1904/1904 |
| xmlport isolation slice (`--test Codeunit6020`) | 59/59 |

Against BC 28.1.49838.50794 on Linux. The two AL-level suites the issue named as the proof obligation — `comment-shadowed-properties` and `blank-enum-initvalue` — pass unchanged through the real runtime, not just at unit level.

## What is left on #1696

- **CalcFormula structural mapping.** Still the existing regex sub-parse, but now fed the formula's own node text instead of a brace-matched string, so comments and neighbouring properties can no longer bleed in. Ordered last in the issue, and `RecordPatches.TryParseCalcFormula` has an external caller in `BcAppSymbolCache.cs:479` that hands it synthesized text rather than a node, so it needs its own change. The `Open=const(true)` filter that `RxCalcFilter` silently drops is untouched here.
- **The other six parsers** — page, report, query, xmlport, object-decl, object-caption (#1697 covers the comment half).
- **Extension fields** still carry neither `OptionMembers` nor `AutoIncrement`, exactly as before. Both look wanted, but adding them is a behaviour change needing its own test, not a rider on a parser swap.

`CHANGELOG.md` untouched per `.claude/rules/no-changelog-edits.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AX8MEx4iECELaZNisb9DCW)_