### PR TITLE
fix(server): stale-green multi-bundle requests — per-request reset, content-stamped cache key, loud EMIT-EXCLUDED

### DIFF
--- a/.github/workflows/test-matrix.yml
+++ b/.github/workflows/test-matrix.yml
@@ -217,6 +217,19 @@ jobs:
               --strict \
               --out runner-extras-results.json
 
+      - name: Server-mode integration (multi-bundle contract)
+        # always() for the same reason as runner-extras: an independent gate.
+        # Drives a real --server daemon over stdin/stdout NDJSON against the
+        # server-multibundle fixture pair and asserts the app + test-app request
+        # shape works warm: dep-table CRUD green, then a dep schema edit MISSes
+        # the AL-output cache and fails loudly (exitCode 3, EMIT-EXCLUDED) —
+        # never a stale-cache runtime failure or a silently-green shrunken run.
+        if: ${{ always() && hashFiles('scripts/tests/server-mode-test.sh') != '' }}
+        run: |
+          scripts/tests/server-mode-test.sh \
+              --package-cache "$HOME/.al-runner/platform-apps" \
+              --package-cache "$HOME/.al-runner/test-apps"
+
       - name: Upload result artifacts
         if: always()
         uses: actions/upload-artifact@v4

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -1980,6 +1980,16 @@ int RunServerLoop(System.IO.TextReader input, System.IO.TextWriter output)
     List<ServerRunResult> RunAllBundlesForServer(string[] sourcePaths, string[]? requestPackagePaths,
         Func<Assembly, IReadOnlyList<TestResult>> runStep)
     {
+        // Drop the previous REQUEST's bundle-derived caches so a reloaded same-named
+        // bundle resolves the freshly-emitted Record/Codeunit types and starts with
+        // empty in-memory tables. Once per request, NOT per bundle: the CLI bucket
+        // loop never resets between bundles, so AddSourceDir accumulates across an
+        // app + test-app pair — resetting per bundle wiped the app bundle's parsed
+        // table schemas before the test bundle ran, and every Record op on an
+        // app-defined table died with "no NCLMetaTable for table N (AL source not
+        // parsed)" while the identical CLI invocation passed.
+        BcRuntime.ResetForNewBundleReload();
+
         if (sourcePaths.Length > 1)
         {
             var bundleList = sourcePaths.ToList();
@@ -2014,10 +2024,8 @@ int RunServerLoop(System.IO.TextReader input, System.IO.TextWriter output)
     ServerRunResult RunBundleForServer(string bundleDir, string[]? requestPackagePaths,
         Func<Assembly, IReadOnlyList<TestResult>> runStep)
     {
-        // CRITICAL: drop the previous request's bundle-derived caches so a reloaded
-        // same-named bundle resolves the freshly-emitted Record/Codeunit types and
-        // starts with empty in-memory tables. See BcRuntime.ResetForNewBundleReload.
-        BcRuntime.ResetForNewBundleReload();
+        // Cache reset happens once per request in RunAllBundlesForServer, not here —
+        // see the comment there for why per-bundle resetting breaks sibling bundles.
 
         var bundleAbs = Path.GetFullPath(bundleDir);
         var bucketRoot = FindBucketRoot(bundleAbs) ?? bundleAbs;
@@ -2128,15 +2136,36 @@ int RunServerLoop(System.IO.TextReader input, System.IO.TextWriter output)
         {
             IReadOnlyList<EmittedSource> sources;
             IReadOnlyList<string> alDiagnostics;
+            IReadOnlyList<string> excludedObjects;
             try
             {
                 var emitOutput = emitter.Emit(allPaths, moduleName);
                 sources = emitOutput.Sources;
                 alDiagnostics = emitOutput.Diagnostics;
+                excludedObjects = emitOutput.ExcludedObjects;
             }
             catch (Exception ex)
             {
                 return ServerRunResult.Failure(3, moduleName, $"EMIT-FAIL: {ex.Message.Split('\n')[0]}", fileHashes);
+            }
+            // An emit-retry exclusion means one or more AL objects are NOT in the
+            // compiled module, so any tests they declare silently vanish and the
+            // request looks green. Fail loudly with the same classification the CLI's
+            // bundled-mode EMIT-EXCLUDED guard uses (.claude/rules/loud-failures.md);
+            // without this the server path ran the surviving objects and reported
+            // exitCode 0 while e.g. a whole test codeunit was missing from the run.
+            if (excludedObjects.Count > 0)
+            {
+                var names = string.Join(", ", excludedObjects);
+                compileErrors.Add(
+                    $"EMIT-EXCLUDED: {excludedObjects.Count} object(s) dropped from the module — " +
+                    $"tests they declare are missing: [{names}]." +
+                    (alDiagnostics.Count > 0
+                        ? " The AL diagnostics that identified them follow."
+                        : " Re-run with --verbose for the AL diagnostics that identified them."));
+                foreach (var d in alDiagnostics) compileErrors.Add(d);
+                return new ServerRunResult(Array.Empty<TestResult>(), 3, false,
+                    new List<CompilationErrorGroup> { new(moduleName, compileErrors) }, fileHashes);
             }
             if (sources.Count == 0)
             {
@@ -4599,7 +4628,25 @@ static IReadOnlyList<string> GetOrderedDepIds(
             bundlePkgDirs.Concat(packageCacheDirs).Distinct().ToList());
         var ordered = resolver.Resolve(roots);
         return ordered
-            .Select(d => $"{d.Manifest.AppId:N}:{d.Manifest.Version}")
+            // Id:Version alone is NOT a content identity: a sibling source app keeps
+            // its app.json version while its schema evolves during development, so a
+            // key without the winning .app's file stamp served the test bundle a
+            // stale compiled assembly after e.g. a field removal — a runtime
+            // NavNCLFieldNotFoundException where a fresh compile correctly fails.
+            // mtime+size (not a content hash) keeps big platform .apps cheap to
+            // stamp; the layered pre-pass only rewrites a synthesized sibling .app
+            // when its source actually changed, so stamps are stable across runs.
+            .Select(d =>
+            {
+                string stamp = "?";
+                try
+                {
+                    var fi = new FileInfo(d.AppPath);
+                    if (fi.Exists) stamp = $"{fi.LastWriteTimeUtc.Ticks}:{fi.Length}";
+                }
+                catch { /* unreadable path keys as "?" and simply cannot HIT */ }
+                return $"{d.Manifest.AppId:N}:{d.Manifest.Version}:{stamp}";
+            })
             .OrderBy(s => s, StringComparer.Ordinal)
             .ToList();
     }

--- a/scripts/tests/server-mode-test.sh
+++ b/scripts/tests/server-mode-test.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+# Integration test for --server mode's multi-bundle (app + test-app) contract.
+#
+# Drives a real `al-runner --server` daemon over its stdin/stdout NDJSON
+# protocol (docs/server-mode.md) using the tests/runner-extras/server-multibundle
+# fixture pair, and asserts three behaviours that each regressed independently:
+#
+#   1. A runTests request naming [dep, main] runs the main bundle's CRUD tests
+#      against the table defined in the DEP bundle's AL source. (A per-bundle
+#      cache reset used to wipe the dep's parsed table schema first — every
+#      test died with "no NCLMetaTable for table 64300".)
+#   2. After a schema edit in the dep bundle, the next request must MISS the
+#      AL-output cache. (An Id:Version-only dep cache key served the main
+#      bundle's STALE compiled assembly — a runtime NavNCLFieldNotFoundException
+#      where a fresh compile correctly fails.)
+#   3. That fresh compile must fail LOUDLY: exitCode 3 with an EMIT-EXCLUDED
+#      compilation error naming the dropped object. (The server emit path used
+#      to drop the object and report a green exitCode 0 with its tests missing.)
+#
+# Usage:
+#   scripts/tests/server-mode-test.sh [--runner "CMD"] [extra runner args...]
+#
+#   --runner CMD   Command line that invokes the runner (default:
+#                  "dotnet run --no-build --project AlRunner -c Release --framework net8.0 --").
+#   Everything else (e.g. --package-cache DIR, --bc-version X) is passed to the
+#   server invocation verbatim.
+#
+# Requires: jq. Exit 0 = all assertions hold; exit 1 = at least one failed.
+set -euo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+RUNNER="dotnet run --no-build --project $REPO/AlRunner -c Release --framework net8.0 --"
+if [[ "${1:-}" == "--runner" ]]; then
+    RUNNER="$2"
+    shift 2
+fi
+EXTRA_ARGS=("$@")
+
+READY_TIMEOUT="${SERVER_TEST_READY_TIMEOUT:-300}"
+RUN_TIMEOUT="${SERVER_TEST_RUN_TIMEOUT:-600}"
+
+WORK="$(mktemp -d)"
+FIFO="$WORK/in.fifo"
+OUT="$WORK/out.ndjson"
+LOG="$WORK/server.log"
+SERVER_PID=""
+FAILURES=0
+
+cleanup() {
+    if [[ -n "$SERVER_PID" ]] && kill -0 "$SERVER_PID" 2>/dev/null; then
+        printf '{"command":"shutdown"}\n' > "$FIFO" 2>/dev/null || true
+        for _ in 1 2 3 4 5; do kill -0 "$SERVER_PID" 2>/dev/null || break; sleep 1; done
+        kill "$SERVER_PID" 2>/dev/null || true
+    fi
+    [[ -n "${HOLDER_PID:-}" ]] && kill "$HOLDER_PID" 2>/dev/null || true
+    rm -rf "$WORK"
+}
+trap cleanup EXIT
+
+fail() { echo "FAIL: $1" >&2; FAILURES=$((FAILURES + 1)); }
+pass() { echo "  ok: $1"; }
+
+# The fixture pair is copied so assertion 2 can mutate the dep table's schema
+# without touching the checked-in suite.
+cp -r "$REPO/tests/runner-extras/server-multibundle-dep" "$WORK/dep"
+cp -r "$REPO/tests/runner-extras/server-multibundle-main" "$WORK/main"
+
+mkfifo "$FIFO"
+# Private AL-output cache: assertion 2 is ABOUT cache behaviour, so the test
+# must own the cache directory it warms.
+# shellcheck disable=SC2086
+$RUNNER --server --cache "$WORK/al-out" "${EXTRA_ARGS[@]}" < "$FIFO" > "$OUT" 2> "$LOG" &
+SERVER_PID=$!
+sleep infinity > "$FIFO" &
+HOLDER_PID=$!
+
+echo "waiting for server readiness (timeout ${READY_TIMEOUT}s)..."
+waited=0
+until grep -q '"ready"[[:space:]]*:[[:space:]]*true' "$OUT" 2>/dev/null; do
+    if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+        echo "server died during startup — last stderr:" >&2
+        tail -30 "$LOG" >&2
+        exit 1
+    fi
+    if (( waited >= READY_TIMEOUT )); then
+        echo "server not ready within ${READY_TIMEOUT}s — last stderr:" >&2
+        tail -30 "$LOG" >&2
+        exit 1
+    fi
+    sleep 1; waited=$((waited + 1))
+done
+
+# Sends one runTests request for the fixture pair and echoes the summary line.
+# The response stream is `{"type":"test"}* {"type":"summary"}` (one final
+# summary per request), so waiting for the NEXT summary line is the request
+# boundary.
+request_and_summary() {
+    local before summaries
+    before=$(grep -c '"type":"summary"' "$OUT" 2>/dev/null || true)
+    printf '{"command":"runTests","sourcePaths":["%s","%s"]}\n' "$WORK/dep" "$WORK/main" > "$FIFO"
+    local waited=0
+    while :; do
+        summaries=$(grep -c '"type":"summary"' "$OUT" 2>/dev/null || true)
+        if (( summaries > before )); then
+            grep '"type":"summary"' "$OUT" | tail -1
+            return 0
+        fi
+        if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+            echo "server died mid-request — last stderr:" >&2
+            tail -30 "$LOG" >&2
+            return 1
+        fi
+        if (( waited >= RUN_TIMEOUT )); then
+            echo "no summary within ${RUN_TIMEOUT}s — last stderr:" >&2
+            tail -30 "$LOG" >&2
+            return 1
+        fi
+        sleep 1; waited=$((waited + 1))
+    done
+}
+
+echo "── assertion 1: dep-table CRUD runs green through --server ──"
+summary=$(request_and_summary) || exit 1
+exit_code=$(jq -r '.exitCode' <<<"$summary")
+failed=$(jq -r '.failed + .errors' <<<"$summary")
+total=$(jq -r '.total' <<<"$summary")
+if [[ "$exit_code" == "0" && "$failed" == "0" && "$total" -ge 4 ]]; then
+    pass "exitCode 0, $total tests, 0 failed"
+else
+    fail "expected exitCode 0 with >=4 passing tests, got: $summary"
+    grep '"type":"test"' "$OUT" | tail -6 >&2
+fi
+
+echo "── assertions 2+3: schema edit must MISS the cache and fail loudly ──"
+# Remove the Description field the main bundle's tests reference. A correct
+# runner recompiles (cache key changed with the dep's content) and the emit
+# drops the test codeunit -> exitCode 3 + EMIT-EXCLUDED. A stale-cache runner
+# instead reruns the OLD assembly: runtime FieldNotFound, exitCode 1 — or,
+# without the emit guard, a green exitCode 0 with the tests silently missing.
+python3 - "$WORK/dep/SmbItem.Table.al" <<'EOF'
+import sys
+p = sys.argv[1]
+s = open(p).read()
+needle = '        field(2; Description; Text[100]) { }\n'
+assert needle in s, "fixture drifted: Description field line not found"
+open(p, 'w').write(s.replace(needle, ''))
+EOF
+summary=$(request_and_summary) || exit 1
+exit_code=$(jq -r '.exitCode' <<<"$summary")
+compile_errors=$(jq -r '(.compilationErrors // []) | tostring' <<<"$summary")
+if [[ "$exit_code" == "3" ]]; then
+    pass "exitCode 3 (compile failure, not stale-cache runtime failure)"
+else
+    fail "expected exitCode 3 after dep schema edit, got: $summary"
+fi
+if grep -q "EMIT-EXCLUDED" <<<"$compile_errors"; then
+    pass "compilationErrors carry EMIT-EXCLUDED naming the dropped object"
+else
+    fail "expected an EMIT-EXCLUDED compilation error, got: $compile_errors"
+fi
+
+if (( FAILURES > 0 )); then
+    echo "$FAILURES assertion(s) failed" >&2
+    exit 1
+fi
+echo "all server-mode assertions passed"

--- a/tests/runner-extras/server-multibundle-dep/SmbItem.Table.al
+++ b/tests/runner-extras/server-multibundle-dep/SmbItem.Table.al
@@ -1,0 +1,27 @@
+/// <summary>
+/// A plain data table defined in the DEPENDENCY app. The sibling main app's
+/// tests CRUD records of this table, so its NCLMetaTable must be built from
+/// this bundle's parsed AL source and must survive until the sibling bundle
+/// actually runs (server mode used to reset it away between bundles).
+///
+/// The "Description" field is the schema-change probe for the server-mode
+/// integration script (scripts/tests/server-mode-test.sh): the script deletes
+/// it between two warm requests and expects the next compile to MISS the
+/// AL-output cache and fail loudly.
+/// </summary>
+table 64300 "SMB Item"
+{
+    DataClassification = SystemMetadata;
+
+    fields
+    {
+        field(1; "Code"; Code[20]) { }
+        field(2; Description; Text[100]) { }
+        field(3; Quantity; Integer) { }
+    }
+
+    keys
+    {
+        key(PK; "Code") { Clustered = true; }
+    }
+}

--- a/tests/runner-extras/server-multibundle-dep/app.json
+++ b/tests/runner-extras/server-multibundle-dep/app.json
@@ -1,0 +1,18 @@
+{
+  "id": "dd5ce849-299f-40fd-9bce-40c1782276e9",
+  "name": "Server MultiBundle Dep",
+  "publisher": "AL Runner",
+  "version": "1.0.0.0",
+  "brief": "Dependency app: defines the table the sibling test app CRUDs.",
+  "description": "Cross-bundle half of server-multibundle. Defines a plain table with no code of its own. The consuming test app performs record CRUD on it, so every NCLMetaTable for this table must come from THIS bundle's parsed AL source — the exact state that server mode's per-bundle cache reset used to wipe before the sibling test bundle ran.",
+  "privacyStatement": "",
+  "EULA": "",
+  "help": "",
+  "url": "",
+  "logo": "",
+  "dependencies": [],
+  "screenshots": [],
+  "idRanges": [ { "from": 64300, "to": 64349 } ],
+  "runtime": "14.0",
+  "features": []
+}

--- a/tests/runner-extras/server-multibundle-main/SmbAssert.Codeunit.al
+++ b/tests/runner-extras/server-multibundle-main/SmbAssert.Codeunit.al
@@ -1,0 +1,26 @@
+codeunit 64350 "SMB Assert"
+{
+    procedure AreEqual(Expected: Integer; Actual: Integer; Msg: Text)
+    begin
+        if Expected <> Actual then
+            Error('Expected %1 but got %2: %3', Expected, Actual, Msg);
+    end;
+
+    procedure AreEqualText(Expected: Text; Actual: Text; Msg: Text)
+    begin
+        if Expected <> Actual then
+            Error('Expected ''%1'' but got ''%2'': %3', Expected, Actual, Msg);
+    end;
+
+    procedure IsFalse(Actual: Boolean; Msg: Text)
+    begin
+        if Actual then
+            Error('Expected FALSE: %1', Msg);
+    end;
+
+    procedure ExpectedError(Fragment: Text)
+    begin
+        if StrPos(GetLastErrorText(), Fragment) = 0 then
+            Error('Expected error containing ''%1'' but got ''%2''', Fragment, GetLastErrorText());
+    end;
+}

--- a/tests/runner-extras/server-multibundle-main/SmbTableCrudTests.Codeunit.al
+++ b/tests/runner-extras/server-multibundle-main/SmbTableCrudTests.Codeunit.al
@@ -1,0 +1,98 @@
+/// <summary>
+/// Proves that record CRUD on a table defined in a DEPENDENCY app's AL source
+/// works when the app + test-app pair runs as two bundles of one invocation —
+/// both on the CLI and (via scripts/tests/server-mode-test.sh) through
+/// --server, where a per-bundle cache reset used to wipe the dep bundle's
+/// parsed table schema before this bundle ran and every test here died with
+/// "NavRecordHandle.CreateTarget: no NCLMetaTable for table 64300 (AL source
+/// not parsed)".
+///
+/// RED (without fix): every test fails with the NCLMetaTable error under --server.
+/// GREEN (with fix): concrete inserted values read back on both paths.
+/// </summary>
+codeunit 64351 "SMB Table CRUD Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit "SMB Assert";
+
+    /// <summary>
+    /// Positive: Insert then Get reads back the exact field values written —
+    /// proves the dep table's fields are materialized from its AL source, not
+    /// defaulted.
+    /// </summary>
+    [Test]
+    procedure Insert_ThenGet_ReadsBackConcreteValues()
+    var
+        Item: Record "SMB Item";
+    begin
+        Item.Init();
+        Item."Code" := 'ALPHA';
+        Item.Description := 'First item';
+        Item.Quantity := 5;
+        Item.Insert();
+
+        Item.Get('ALPHA');
+        Assert.AreEqualText('First item', Item.Description, 'Description must round-trip through Insert/Get');
+        Assert.AreEqual(5, Item.Quantity, 'Quantity must round-trip through Insert/Get');
+    end;
+
+    /// <summary>
+    /// Positive: Modify persists the new value — a re-Get returns 42, not the
+    /// originally inserted 1.
+    /// </summary>
+    [Test]
+    procedure Modify_PersistsNewQuantity()
+    var
+        Item: Record "SMB Item";
+    begin
+        Item.Init();
+        Item."Code" := 'BETA';
+        Item.Quantity := 1;
+        Item.Insert();
+
+        Item.Quantity := 42;
+        Item.Modify();
+
+        Item.Get('BETA');
+        Assert.AreEqual(42, Item.Quantity, 'Modify must persist Quantity=42 over the inserted 1');
+    end;
+
+    /// <summary>
+    /// Positive: Delete removes the row — a subsequent Get returns the concrete
+    /// value FALSE (not an error), proving the row is gone rather than unreadable.
+    /// </summary>
+    [Test]
+    procedure Delete_ThenGet_ReturnsFalse()
+    var
+        Item: Record "SMB Item";
+    begin
+        Item.Init();
+        Item."Code" := 'GAMMA';
+        Item.Insert();
+
+        Item.Delete();
+        Assert.IsFalse(Item.Get('GAMMA'), 'Get after Delete must return false');
+    end;
+
+    /// <summary>
+    /// Negative: inserting the same primary key twice fails with the specific
+    /// "already exists" error — proves key enforcement runs against the dep
+    /// table's real schema instead of silently overwriting.
+    /// </summary>
+    [Test]
+    procedure DuplicateInsert_FailsWithAlreadyExists()
+    var
+        Item: Record "SMB Item";
+    begin
+        Item.Init();
+        Item."Code" := 'DUP';
+        Item.Insert();
+
+        Item.Init();
+        Item."Code" := 'DUP';
+        asserterror Item.Insert();
+        Assert.ExpectedError('already exists');
+    end;
+}

--- a/tests/runner-extras/server-multibundle-main/app.json
+++ b/tests/runner-extras/server-multibundle-main/app.json
@@ -1,0 +1,25 @@
+{
+  "id": "67ae2d9c-efca-4003-a9d8-81c45532790f",
+  "name": "Server MultiBundle Main",
+  "publisher": "AL Runner",
+  "version": "1.0.0.0",
+  "brief": "Main test app: CRUDs a table defined in the sibling dependency app.",
+  "description": "Cross-bundle half of server-multibundle. Every test performs record operations on 'SMB Item', which is defined in the DEPENDENCY app's AL source — so the run only works when the dep bundle's parsed table schema is still registered when this bundle executes. This is the regression fixture for the server-mode per-bundle reset defect, and the fixture the server-mode integration script drives over --server.",
+  "privacyStatement": "",
+  "EULA": "",
+  "help": "",
+  "url": "",
+  "logo": "",
+  "dependencies": [
+    {
+      "id": "dd5ce849-299f-40fd-9bce-40c1782276e9",
+      "name": "Server MultiBundle Dep",
+      "publisher": "AL Runner",
+      "version": "1.0.0.0"
+    }
+  ],
+  "screenshots": [],
+  "idRanges": [ { "from": 64350, "to": 64399 } ],
+  "runtime": "14.0",
+  "features": []
+}


### PR DESCRIPTION
Closes #1706

`--server` mode mishandled the documented app + test-app request shape: after a schema edit in the app bundle, a warm `runTests` request either reran the test bundle's **stale cached assembly against the old schema** (green exitCode 0, edit invisible) or ran with the test codeunit **silently dropped from the module** (green exitCode 0, `total` shrunk). The identical CLI invocation fails loudly with `COMPILE FAIL (EMIT-EXCLUDED)`, exit 3.

## The three fixes (all `AlRunner/Program.cs`)

1. **Reset once per request, not per bundle.** `ResetForNewBundleReload()` moved from `RunBundleForServer` to `RunAllBundlesForServer`. The reset clears `RecordPatches._sourceDirs` and the parsed table schemas; doing it per bundle wiped the app bundle's parsed AL state before the sibling test bundle ran — the CLI bucket loop never resets between bundles (`AddSourceDir` accumulates). On the v2.1.2-dev line this crashed every dep-table record op with `no NCLMetaTable for table N (AL source not parsed)`.
2. **Dep content in the AL-output cache key.** `GetOrderedDepIds` stamped deps as `AppId:Version` only; a sibling source app keeps its version while its schema evolves, so the dependent bundle's cache entry HIT stale after a schema edit. Each dep is now stamped with the winning `.app`'s mtime+size (cheap for the big platform apps; the layered pre-pass only rewrites a synthesized sibling `.app` when its source actually changed, so stamps are stable across unchanged runs).
3. **EMIT-EXCLUDED is loud in server mode.** The server emit path now mirrors the CLI's bundled-mode guard: if `emitOutput.ExcludedObjects` is non-empty the request returns `exitCode 3` with a `compilationErrors` entry naming the dropped objects, instead of running the surviving objects and reporting a green run with tests missing (`.claude/rules/loud-failures.md`).

## Tests

- **`tests/runner-extras/server-multibundle-dep` + `-main`** — cross-bundle table CRUD fixture pair (positive `AreEqual`s on concrete round-tripped values, negative `asserterror` + `ExpectedError('already exists')`). Runs on the existing CLI runner-extras leg and pins the multi-bundle contract; it is also the fixture the server test drives.
- **`scripts/tests/server-mode-test.sh`** — integration test driving a real `--server` daemon over its stdin/stdout NDJSON protocol; wired into `test-matrix.yml` next to the runner-extras step. Asserts:
  1. `runTests [dep, main]` → exitCode 0, ≥4 tests, 0 failed;
  2. after deleting a dep table field the same warm request → exitCode 3 (cache MISS + fresh compile, not a stale rerun);
  3. the summary's `compilationErrors` carry `EMIT-EXCLUDED` naming the dropped object.

## RED → GREEN (measured on `main` @ 97840a13)

| Scenario | unfixed `main` | with this PR |
|---|---|---|
| fixture pair, warm request after dep field deleted | **exitCode 0, `"passed":4` — stale assembly, edit invisible** | exitCode 3 + EMIT-EXCLUDED |
| real-world pair with a stale symbols-only dep `.app` in `.alpackages` | **exitCode 0, CRUD codeunit silently missing (`total:1`)** | exitCode 3 + EMIT-EXCLUDED naming it |
| same pair, correct package staleness detection | n/a | exitCode 0, 6/6 pass |
| `scripts/tests/server-mode-test.sh` | assertions 2+3 FAIL | all assertions pass (18s) |

Corpus: `tests/al-language` run locally with the fix — 1904/1904 pass, exit 0 (runner-extras: 108/108 including the new pair).

The cache-key change (fix 2) intentionally invalidates existing AL-output cache entries once (key format changed); the first run after upgrade recompiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
