### PR TITLE
fix: close the seven gaps split out of the parser migration (#1708-#1714)

### DIFF
--- a/AlRunner.Tests/AlSourceParserSyntaxTreeTests.cs
+++ b/AlRunner.Tests/AlSourceParserSyntaxTreeTests.cs
@@ -207,8 +207,11 @@ public class AlSourceParserSyntaxTreeTests
         var t = calcFormula.GetType();
         var filters = new List<(string, string)>();
         foreach (var f in (System.Collections.IEnumerable)t.GetProperty("Filters")!.GetValue(calcFormula)!)
+            // ParentFieldName is set only for the `field(Y)` shape now that const/filter
+            // conditions are carried too (#1709); their parent link is null. CalcFormulaSyntaxTests
+            // asserts each shape's own contract — here they read as "(source, <no parent>)".
             filters.Add(((string)f.GetType().GetProperty("SourceFieldName")!.GetValue(f)!,
-                         (string)f.GetType().GetProperty("ParentFieldName")!.GetValue(f)!));
+                         (string?)f.GetType().GetProperty("ParentFieldName")!.GetValue(f) ?? ""));
         return ((string)t.GetProperty("FormulaType")!.GetValue(calcFormula)!,
                 (string)t.GetProperty("SourceTableName")!.GetValue(calcFormula)!,
                 (string?)t.GetProperty("SourceFieldName")!.GetValue(calcFormula),
@@ -229,8 +232,10 @@ public class AlSourceParserSyntaxTreeTests
         Assert.Equal("sum", type);
         Assert.Equal("Sales Line", table);
         Assert.Equal("Amount", field);
-        // filter(...) conditions are excluded, exactly as RxCalcFilter excluded them.
-        Assert.Equal(new[] { ("Document No.", "Code") }, filters);
+        // Both conditions are carried now (#1709). The filter() one has no parent link — its
+        // own shape (kind + expression text) is asserted in CalcFormulaSyntaxTests; what this
+        // test pins is that the semicolon inside the literal did not truncate the formula.
+        Assert.Equal(new[] { ("Document No.", "Code"), ("Description", "") }, filters);
     }
 
     [Fact]
@@ -261,16 +266,21 @@ public class AlSourceParserSyntaxTreeTests
     }
 
     [Fact]
-    public void CalcFormula_SignedFormula_IsRefusedRatherThanParsedWithoutItsSign()
+    public void CalcFormula_SignedFormula_IsParsedWithItsSign()
     {
-        // Negative direction. ParsedCalcFormula cannot carry the sign, so returning a formula
-        // here would mean a FlowField silently computing +sum where AL wrote -sum. Refusing
-        // preserves the old behaviour (the anchored regex never matched a leading sign).
+        // #1708. This used to be pinned as a REFUSAL: ParsedCalcFormula had nowhere to carry
+        // the sign, so a `-sum(...)` was dropped entirely and the FlowField read back as 0.
+        // The sign now rides through to MetaCalcFormula.reverseSign →
+        // NCLMetaCalculationFormula.NegateResult, so the formula is parsed rather than lost.
         var parsed = typeof(AlRunner.Patches.RecordPatches)
             .GetMethod("TryParseCalcFormula", BindingFlags.NonPublic | BindingFlags.Static)!
-            .Invoke(null, new object[] { """CalcFormula = -sum("Sales Line".Amount);""" });
+            .Invoke(null, new object[] { """CalcFormula = -sum("Sales Line".Amount);""" })!;
 
-        Assert.Null(parsed);
+        var (type, table, field, _) = Read(parsed);
+        Assert.Equal("sum", type);
+        Assert.Equal("Sales Line", table);
+        Assert.Equal("Amount", field);
+        Assert.True((bool)parsed.GetType().GetProperty("Negated")!.GetValue(parsed)!);
     }
 
     [Fact]

--- a/AlRunner.Tests/BundleRootValidationTests.cs
+++ b/AlRunner.Tests/BundleRootValidationTests.cs
@@ -1,0 +1,255 @@
+// BundleRootValidationTests — RED->GREEN guard for issue #1713.
+//
+// The bug: a positional bundle path that does not exist reached EnumerateSuites /
+// EnumerateSuitesBelow unchecked, so `Directory.EnumerateDirectories` threw a raw
+// System.IO.DirectoryNotFoundException out of Main. The process died with a .NET
+// stack trace and exit code 134 — the same code the CI matrix documents as "crash"
+// (`1=test failure, 2=exec fail, 3=compile fail, 134/139=crash`), so a mistyped path
+// was indistinguishable from a real runtime crash in a CI log. Worse, the crash landed
+// AFTER ~6s of BC patch application, and after a `WARN: no app.json under …` line that
+// had already noticed the directory was unusable and continued anyway.
+//
+// The fix validates the positional roots at argument-parse time (before the BC
+// artifact selection, the Cecil re-exec and the patch pass) and fails with the
+// documented exit code 2 — "a bundle could not execute (process-level error)", the
+// same code every other CLI usage error in Program.cs already returns.
+//
+// Ghost-test trap avoided in both directions:
+//   * a no-op "fix" that only swallows the exception (returning no suites) still fails
+//     ExistingAndMissingRoot_* / NonexistentBundlePath_*, because those assert the
+//     named message text and exit 2, not merely "did not crash";
+//   * an over-eager guard that rejects valid inputs — the obvious way to get this
+//     wrong — fails ExistingBundlePath_StillRuns_AndIsNotRejected and
+//     Validate_ReturnsNull_* plus SubmoduleHint_IsOmitted_WhenSubmoduleIsCheckedOut.
+using System.Diagnostics;
+using System.Text;
+using AlRunner.Infrastructure;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+// See DefineFlagIntegrationTests for why the subprocess tests are serialized with the
+// other runner-subprocess integration tests.
+[Collection("server-serial")]
+public sealed class BundleRootValidationTests : IDisposable
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+    private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
+
+    private readonly string _root;
+
+    public BundleRootValidationTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "al-runner-bundle-root", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { }
+    }
+
+    private static bool ArtifactsPresent()
+    {
+        var home = Environment.GetEnvironmentVariable("HOME")
+            ?? Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        var stdCache = Path.Combine(home, ".local", "share", "al-runner", "artifacts");
+        return Directory.Exists(stdCache) && Directory.EnumerateDirectories(stdCache).Any();
+    }
+
+    private static (int ExitCode, string StdOut, string StdErr) RunCli(params string[] args)
+    {
+        var argLine = TestBuildConfig.RunArgs(ProjectPath)
+            + " " + string.Join(' ', args.Select(a => $"\"{a}\""));
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            Arguments = argLine,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            WorkingDirectory = RepoRoot,
+        };
+        using var p = Process.Start(psi)!;
+        var so = new StringBuilder();
+        var se = new StringBuilder();
+        p.OutputDataReceived += (_, e) => { if (e.Data != null) so.AppendLine(e.Data); };
+        p.ErrorDataReceived += (_, e) => { if (e.Data != null) se.AppendLine(e.Data); };
+        p.BeginOutputReadLine();
+        p.BeginErrorReadLine();
+        if (!p.WaitForExit(300_000)) { try { p.Kill(entireProcessTree: true); } catch { } }
+        p.WaitForExit();
+        return (p.ExitCode, so.ToString(), se.ToString());
+    }
+
+    // ── Positive direction: the missing path must be named, and the exit code must be
+    // the documented 2 — never 134 and never a raw .NET stack trace. ──────────────
+
+    [Fact]
+    public void NonexistentBundlePath_FailsLoudlyWithExitCode2()
+    {
+        // Exactly the shape from the issue: a doubled prefix under an existing root.
+        const string bad = "tests/al-language/tests/al-language";
+        var (exit, stdout, stderr) = RunCli(bad);
+        var all = stdout + stderr;
+
+        Assert.Equal(2, exit);
+        Assert.Contains($"al-runner: no such directory: {bad}", all);
+        Assert.DoesNotContain("DirectoryNotFoundException", all);
+        Assert.DoesNotContain("Unhandled exception", all);
+        // The failure must land before the BC patch pass — that is the whole point of
+        // validating at argument-parse time rather than only inside EnumerateSuites.
+        Assert.DoesNotContain("BC runtime patches applied", all);
+        Assert.DoesNotContain("WARN: no app.json under", all);
+    }
+
+    [Fact]
+    public void NonexistentBundlePath_NamesDeepestExistingParent()
+    {
+        var (_, stdout, stderr) = RunCli("tests/al-language/tests/al-language");
+        var all = stdout + stderr;
+        Assert.Contains(
+            $"deepest existing parent: {Path.Combine(RepoRoot, "tests", "al-language")}",
+            all);
+    }
+
+    // ── Negative direction: a valid path must be completely unaffected. ───────────
+
+    [Fact]
+    public void ExistingAndMissingRoot_RejectsOnlyTheMissingOne()
+    {
+        // Siblings, not nested — so "no such directory: <good>" cannot accidentally match
+        // as a prefix of the bad path's own line.
+        var good = Path.Combine(_root, "good");
+        Directory.CreateDirectory(good);
+        var bad = Path.Combine(_root, "definitely-not-here");
+        var (exit, stdout, stderr) = RunCli(good, bad);
+        var all = stdout + stderr;
+
+        Assert.Equal(2, exit);
+        Assert.Contains($"al-runner: no such directory: {bad}", all);
+        Assert.DoesNotContain($"no such directory: {good}", all);
+    }
+
+    [Fact]
+    public void ExistingBundlePath_StillRuns_AndIsNotRejected()
+    {
+        if (!ArtifactsPresent()) { Console.Error.WriteLine("[skip] BC artifacts not present"); return; }
+
+        // An existing but empty directory is a valid invocation: the runner must get all
+        // the way through to its own "SKIP (no suites)" outcome and exit 0. An over-eager
+        // guard (e.g. one that also rejects a directory with no app.json/.al files) turns
+        // this green run red, which is exactly the regression this test exists to catch.
+        var args = new List<string> { _root };
+        args.AddRange(TestBuildConfig.BcVersionArg
+            .Split(' ', StringSplitOptions.RemoveEmptyEntries));
+        var (exit, stdout, stderr) = RunCli(args.ToArray());
+        var all = stdout + stderr;
+
+        Assert.DoesNotContain("no such directory", all);
+        Assert.DoesNotContain("not a directory", all);
+        Assert.Contains("SKIP (no suites)", all);
+        Assert.Equal(0, exit);
+    }
+
+    // ── Unit-level coverage of the extracted validator. ───────────────────────────
+
+    [Fact]
+    public void Validate_ReturnsNull_ForExistingDirectory()
+        => Assert.Null(BundleRootValidation.Validate(new[] { _root }));
+
+    [Fact]
+    public void Validate_ReturnsNull_ForNoRoots()
+        => Assert.Null(BundleRootValidation.Validate(Array.Empty<string>()));
+
+    [Fact]
+    public void Validate_NamesMissingDirectoryAndDeepestExistingParent()
+    {
+        var missing = Path.Combine(_root, "a", "b", "c");
+        var msg = BundleRootValidation.Validate(new[] { missing });
+
+        Assert.NotNull(msg);
+        Assert.Contains($"al-runner: no such directory: {missing}", msg);
+        Assert.Contains($"deepest existing parent: {_root}", msg);
+    }
+
+    [Fact]
+    public void Validate_ReportsFileAsNotADirectory()
+    {
+        var file = Path.Combine(_root, "app.json");
+        File.WriteAllText(file, "{}");
+        var msg = BundleRootValidation.Validate(new[] { file });
+
+        Assert.NotNull(msg);
+        Assert.Contains($"al-runner: not a directory: {file}", msg);
+        // A file is not a missing path — do not emit the misleading "no such directory".
+        Assert.DoesNotContain("no such directory", msg);
+    }
+
+    [Fact]
+    public void Validate_WalksPastAGoodRoot_AndReportsTheBadOneAfterIt()
+    {
+        var good = Path.Combine(_root, "good");
+        Directory.CreateDirectory(good);
+        var missing = Path.Combine(_root, "gone");
+        var msg = BundleRootValidation.Validate(new[] { good, missing });
+
+        Assert.NotNull(msg);
+        Assert.Contains($"al-runner: no such directory: {missing}", msg);
+        Assert.DoesNotContain($"no such directory: {good}", msg);
+    }
+
+    [Fact]
+    public void SubmoduleHint_IsEmitted_WhenSubmoduleIsNotCheckedOut()
+    {
+        // A repo whose .gitmodules declares tests/al-language, with the submodule
+        // directory present but EMPTY — exactly what `git clone` without
+        // `--recurse-submodules` leaves behind.
+        var repo = Path.Combine(_root, "repo");
+        Directory.CreateDirectory(Path.Combine(repo, "tests", "al-language"));
+        File.WriteAllText(Path.Combine(repo, ".gitmodules"), """
+        [submodule "tests/al-language"]
+        	path = tests/al-language
+        	url = https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests.git
+        """);
+
+        var target = Path.Combine(repo, "tests", "al-language", "tests");
+        var msg = BundleRootValidation.Validate(new[] { target });
+
+        Assert.NotNull(msg);
+        Assert.Contains("git submodule update --init --recursive", msg);
+        Assert.Contains(Path.Combine(repo, "tests", "al-language"), msg);
+    }
+
+    [Fact]
+    public void SubmoduleHint_IsOmitted_WhenSubmoduleIsCheckedOut()
+    {
+        // Same repo shape, but the submodule HAS content — so the missing path is a
+        // typo, not an uninitialised submodule, and the hint would send the user down
+        // the wrong road. This is the doubled-prefix case from issue #1713 itself.
+        var repo = Path.Combine(_root, "repo2");
+        var sub = Path.Combine(repo, "tests", "al-language");
+        Directory.CreateDirectory(sub);
+        File.WriteAllText(Path.Combine(sub, "app.json"), "{}");
+        File.WriteAllText(Path.Combine(repo, ".gitmodules"), """
+        [submodule "tests/al-language"]
+        	path = tests/al-language
+        	url = https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests.git
+        """);
+
+        var msg = BundleRootValidation.Validate(
+            new[] { Path.Combine(sub, "tests", "al-language") });
+
+        Assert.NotNull(msg);
+        Assert.DoesNotContain("git submodule update", msg);
+    }
+
+    [Fact]
+    public void SubmoduleHint_IsOmitted_WhenNoGitmodulesDeclaresThePath()
+    {
+        var msg = BundleRootValidation.Validate(new[] { Path.Combine(_root, "nope") });
+        Assert.NotNull(msg);
+        Assert.DoesNotContain("git submodule update", msg);
+    }
+}

--- a/AlRunner.Tests/BundleRootValidationTests.cs
+++ b/AlRunner.Tests/BundleRootValidationTests.cs
@@ -86,11 +86,28 @@ public sealed class BundleRootValidationTests : IDisposable
     // ── Positive direction: the missing path must be named, and the exit code must be
     // the documented 2 — never 134 and never a raw .NET stack trace. ──────────────
 
+    /// <summary>
+    /// Builds the issue's exact shape — a doubled prefix under an existing root — inside
+    /// this test's temp directory, and returns (existingRoot, missingPath).
+    /// <para>Deliberately NOT the literal repo path `tests/al-language/tests/al-language`
+    /// from the issue: the corpus really does live at that nested path, so once the
+    /// submodule is checked out (as it is in CI, and in any `--recurse-submodules` clone)
+    /// that directory EXISTS and the runner runs it. A test asserting "no such directory"
+    /// against it passes only where the submodule is missing — which is how it was written,
+    /// in a worktree that had no submodule. The shape is what matters, not the name.</para>
+    /// </summary>
+    private (string ExistingRoot, string Missing) DoubledPrefix()
+    {
+        var existingRoot = Path.Combine(_root, "tests", "al-language");
+        Directory.CreateDirectory(existingRoot);
+        return (existingRoot, Path.Combine(existingRoot, "tests", "al-language"));
+    }
+
     [Fact]
     public void NonexistentBundlePath_FailsLoudlyWithExitCode2()
     {
         // Exactly the shape from the issue: a doubled prefix under an existing root.
-        const string bad = "tests/al-language/tests/al-language";
+        var (_, bad) = DoubledPrefix();
         var (exit, stdout, stderr) = RunCli(bad);
         var all = stdout + stderr;
 
@@ -107,11 +124,12 @@ public sealed class BundleRootValidationTests : IDisposable
     [Fact]
     public void NonexistentBundlePath_NamesDeepestExistingParent()
     {
-        var (_, stdout, stderr) = RunCli("tests/al-language/tests/al-language");
+        // The line that makes a doubled prefix obvious: the user sees where the path
+        // stopped being real. See DoubledPrefix() for why this is a temp tree.
+        var (existingRoot, bad) = DoubledPrefix();
+        var (_, stdout, stderr) = RunCli(bad);
         var all = stdout + stderr;
-        Assert.Contains(
-            $"deepest existing parent: {Path.Combine(RepoRoot, "tests", "al-language")}",
-            all);
+        Assert.Contains($"deepest existing parent: {existingRoot}", all);
     }
 
     // ── Negative direction: a valid path must be completely unaffected. ───────────

--- a/AlRunner.Tests/CalcFormulaSyntaxTests.cs
+++ b/AlRunner.Tests/CalcFormulaSyntaxTests.cs
@@ -1,0 +1,283 @@
+// CalcFormulaSyntaxTests — RED→GREEN guard for #1708 (a signed FlowField formula) and
+// #1709 (const()/filter() where-conditions).
+//
+// Both are the same failure class #1696 exists to remove: a SILENT WRONG VALUE. #1696 moved
+// the parse onto BC's own AL syntax tree but deliberately left both behaviours alone, because
+// changing either one changes what a FlowField COMPUTES rather than how it is parsed.
+//
+//   #1708  CalcFormula = -sum("Sales Line".Amount where(...));
+//          `CalcFormulaFrom` refused the formula outright (`if (signText.Length > 0) return
+//          null;`) because ParsedCalcFormula had nowhere to put the sign. The FlowField's
+//          CalculationFormula stayed EmptyFormula, CalcFields() left the field at 0, and
+//          nothing threw. 100 of the Base Application's 2055 CalcFormulas are signed
+//          (95 `-sum`, 5 `-exist`).
+//
+//   #1709  CalcFormula = sum("Sales Line".Amount where(Open = const(true)));
+//          `if (cond is not SimpleFieldExpressionSyntax) continue;` — so `Open = const(true)`
+//          was dropped and the FlowField summed BOTH open and closed lines: a plausible wrong
+//          number. The Base Application writes 1215 const and 285 filter conditions.
+//
+// Each where-condition is its own node type (SimpleFieldExpressionSyntax /
+// ConstExpressionSyntax / FilterExpressionSyntax / the two FlowFilter forms) and the sign is a
+// token on the formula node, so all of this is selected structurally.
+//
+// These tests cover the PARSE. That the parsed sign and conditions actually change the value
+// CalcFields() computes is proved end to end by tests/runner-extras/calcformula-sign-and-filters.
+//
+// These drive the real parser (TryParseTableFile) by reflection, exactly like
+// AlSourceParserSyntaxTreeTests, so they prove the parser produces the formula rather than
+// proving a helper works in isolation.
+using System.Reflection;
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+[Collection(RecordPatchesSerialCollection.Name)]
+public class CalcFormulaSyntaxTests
+{
+    private const int TableId = 61897;
+
+    private static readonly Type RecordPatchesType = typeof(RecordPatches);
+
+    private static System.Collections.IDictionary ParsedTables =>
+        (System.Collections.IDictionary)RecordPatchesType
+            .GetField("_parsedTables", BindingFlags.NonPublic | BindingFlags.Static)!
+            .GetValue(null)!;
+
+    /// <summary>
+    /// A two-field fixture table whose field 2 is the FlowField under test. Field 1 is the
+    /// PK and doubles as the parent field a <c>field(...)</c> condition can point at.
+    /// </summary>
+    private static string Table(string calcFormula) => $$"""
+        table {{TableId}} "Calc Formula Fixture"
+        {
+            fields
+            {
+                field(1; "Code"; Code[10]) { }
+                field(2; Total; Decimal)
+                {
+                    FieldClass = FlowField;
+                    CalcFormula = {{calcFormula}};
+                }
+            }
+
+            keys
+            {
+                key(PK; "Code") { Clustered = true; }
+            }
+        }
+        """;
+
+    private static ParsedCalcFormula? ParseFormula(string calcFormula)
+    {
+        var parse = RecordPatchesType.GetMethod("TryParseTableFile",
+            BindingFlags.NonPublic | BindingFlags.Static)!;
+        parse.Invoke(null, new object[] { Table(calcFormula) });
+        Assert.True(ParsedTables.Contains(TableId), $"table {TableId} was not parsed at all");
+        var table = (ParsedTable)ParsedTables[TableId]!;
+        var field = table.Fields.Single(f => f.FieldId == 2);
+        Assert.True(field.IsFlowField, "field 2 was not recognised as a FlowField");
+        return field.CalcFormula;
+    }
+
+    private static ParsedCalcFormula ParseFormulaRequired(string calcFormula) =>
+        ParseFormula(calcFormula)
+        ?? throw new Xunit.Sdk.XunitException($"CalcFormula was refused: {calcFormula}");
+
+    // ─── #1708 — the sign ────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void SignedSumFormula_CarriesItsSign()
+    {
+        try
+        {
+            var f = ParseFormulaRequired(
+                """-sum("Sales Line".Amount where("Document No." = field("Code")))""");
+
+            Assert.Equal("sum", f.FormulaType, ignoreCase: true);
+            Assert.Equal("Sales Line", f.SourceTableName);
+            Assert.Equal("Amount", f.SourceFieldName);
+            Assert.True(f.Negated,
+                "a `-sum(...)` formula must be carried as negated; dropping the sign turns a " +
+                "visible 0 into a plausible wrong (positive) number");
+        }
+        finally { ParsedTables.Remove(TableId); }
+    }
+
+    [Fact]
+    public void UnsignedSumFormula_IsNotNegated()
+    {
+        // The other direction: Negated must come from the source, not be hard-coded.
+        try
+        {
+            var f = ParseFormulaRequired(
+                """sum("Sales Line".Amount where("Document No." = field("Code")))""");
+
+            Assert.Equal("sum", f.FormulaType, ignoreCase: true);
+            Assert.False(f.Negated);
+        }
+        finally { ParsedTables.Remove(TableId); }
+    }
+
+    [Fact]
+    public void SignedCountFormula_CarriesItsSignAndHasNoSourceField()
+    {
+        // count/exist parse to TableCalculationFormulaSyntax — a different node type from
+        // sum/lookup/min/max/average (FieldCalculationFormulaSyntax), with a Table instead
+        // of a qualified Field. Both carry a Sign token.
+        try
+        {
+            var f = ParseFormulaRequired(
+                """-count("Sales Line" where("Document No." = field("Code")))""");
+
+            Assert.Equal("count", f.FormulaType, ignoreCase: true);
+            Assert.Equal("Sales Line", f.SourceTableName);
+            Assert.Null(f.SourceFieldName);
+            Assert.True(f.Negated);
+        }
+        finally { ParsedTables.Remove(TableId); }
+    }
+
+    // ─── #1709 — const() and filter() conditions ─────────────────────────────────────────
+
+    [Fact]
+    public void ConstCondition_IsCarriedAsAConstFilter()
+    {
+        try
+        {
+            var f = ParseFormulaRequired(
+                """sum("Sales Line".Amount where("Document No." = field("Code"), Open = const(true)))""");
+
+            Assert.Equal(2, f.Filters.Count);
+
+            var link = f.Filters[0];
+            Assert.Equal(ParsedCalcFilterKind.Field, link.Kind);
+            Assert.Equal("Document No.", link.SourceFieldName);
+            Assert.Equal("Code", link.ParentFieldName);
+
+            var open = f.Filters[1];
+            Assert.Equal(ParsedCalcFilterKind.Const, open.Kind);
+            Assert.Equal("Open", open.SourceFieldName);
+            Assert.Equal("true", open.Value);
+            Assert.Null(open.ParentFieldName);
+        }
+        finally { ParsedTables.Remove(TableId); }
+    }
+
+    [Fact]
+    public void QuotedConstValue_IsUnquoted()
+    {
+        // AL quotes an option/code const value that needs it — `const("On Hold")`. The value
+        // handed on must be the member text itself, because NCLMetaFilterConst evaluates it
+        // against the source field's own type (option string / code), where a stray pair of
+        // quotes matches nothing. Same rule as InitValue (#1674).
+        try
+        {
+            var f = ParseFormulaRequired(
+                """sum("Sales Line".Amount where(Status = const("On Hold")))""");
+
+            var c = Assert.Single(f.Filters);
+            Assert.Equal(ParsedCalcFilterKind.Const, c.Kind);
+            Assert.Equal("Status", c.SourceFieldName);
+            Assert.Equal("On Hold", c.Value);
+        }
+        finally { ParsedTables.Remove(TableId); }
+    }
+
+    [Fact]
+    public void FilterCondition_IsCarriedAsAFilterFilterWithItsExpressionText()
+    {
+        try
+        {
+            var f = ParseFormulaRequired(
+                """count("Sales Line" where(Status = filter(Open|Released)))""");
+
+            var c = Assert.Single(f.Filters);
+            Assert.Equal(ParsedCalcFilterKind.Filter, c.Kind);
+            Assert.Equal("Status", c.SourceFieldName);
+            // The filter expression text is passed through to BC's own filter parser, so it
+            // must arrive intact — an alternation is a single expression, not three filters.
+            Assert.Equal("Open|Released", c.Value);
+            Assert.Null(c.ParentFieldName);
+        }
+        finally { ParsedTables.Remove(TableId); }
+    }
+
+    [Fact]
+    public void RangeFilterCondition_KeepsItsRangeExpressionVerbatim()
+    {
+        // The expression text is handed to BC's own filter parser untouched — deliberately
+        // NOT whitespace-normalised. An option member may legally contain spaces
+        // (`filter(Initial Entry|Application)`), so collapsing whitespace would silently
+        // rewrite the member being filtered on. AL's own spacing is what BC sees.
+        try
+        {
+            var f = ParseFormulaRequired(
+                """sum("Sales Line".Amount where("Line No." = filter(10000 .. 20000)))""");
+
+            var c = Assert.Single(f.Filters);
+            Assert.Equal(ParsedCalcFilterKind.Filter, c.Kind);
+            Assert.Equal("Line No.", c.SourceFieldName);
+            Assert.Equal("10000 .. 20000", c.Value);
+        }
+        finally { ParsedTables.Remove(TableId); }
+    }
+
+    [Fact]
+    public void FieldCondition_StillLinksTheParentField()
+    {
+        // Regression guard: the field-to-field link is the form that already worked, and it
+        // must keep its exact (unquoted, both sides) shape.
+        try
+        {
+            var f = ParseFormulaRequired(
+                """sum("Sales Line".Amount where("Document No." = field("Code")))""");
+
+            var c = Assert.Single(f.Filters);
+            Assert.Equal(ParsedCalcFilterKind.Field, c.Kind);
+            Assert.Equal("Document No.", c.SourceFieldName);
+            Assert.Equal("Code", c.ParentFieldName);
+            Assert.Null(c.Value);
+        }
+        finally { ParsedTables.Remove(TableId); }
+    }
+
+    // ─── Negative: forms that must NOT be invented ───────────────────────────────────────
+
+    [Fact]
+    public void FlowFilterCondition_IsNotMistakenForAPlainFieldLink()
+    {
+        // `field(filter(X))` and `field(upperlimit(X))` are FlowFilter forms
+        // (NCLMetaFilterModes.ValueIsFilter / .OnlyMaxLimit) which the runner does not
+        // evaluate. The danger is not that they are unsupported — it is reading them as the
+        // plain `field(X)` link, which would silently apply an equality filter BC never
+        // meant. They must be carried as their own kind, never as Field.
+        try
+        {
+            var f = ParseFormulaRequired(
+                """sum("Sales Line".Amount where("Posting Date" = field(upperlimit("Code")), "Account No." = field(filter("Code"))))""");
+
+            Assert.Equal(2, f.Filters.Count);
+            Assert.All(f.Filters, c =>
+            {
+                Assert.Equal(ParsedCalcFilterKind.FlowFilter, c.Kind);
+                Assert.Null(c.ParentFieldName);
+            });
+        }
+        finally { ParsedTables.Remove(TableId); }
+    }
+
+    [Fact]
+    public void NonFormulaPropertyValue_YieldsNoFormula()
+    {
+        // A CalcFormula the AL parser cannot read as a calculation formula must leave the
+        // field with NO formula at all. Returning a half-parsed one would be the silent
+        // wrong value this whole file exists to prevent.
+        try
+        {
+            Assert.Null(ParseFormula("'not a formula at all'"));
+        }
+        finally { ParsedTables.Remove(TableId); }
+    }
+}

--- a/AlRunner.Tests/PageExtensionParserTests.cs
+++ b/AlRunner.Tests/PageExtensionParserTests.cs
@@ -1,0 +1,333 @@
+// PageExtensionParserTests — RED→GREEN guards for #1710 and #1711.
+//
+// #1710  `_parsedPages` was keyed on the object id ALONE for both `page` and
+//        `pageextension`. AL gives those two SEPARATE id namespaces, so `page 50100` and
+//        `pageextension 50100` are both legal in one app — and both wrote key 50100.
+//        Extensions were written second, so the extension won, bringing SourceTableName = ""
+//        and an empty control map with it: the real page's source table and every
+//        control→field binding vanished, silently. `AlReportParser` had the same bug and
+//        fixed it with two dictionaries; the page parser never got the same treatment.
+//
+// #1711  Extension objects were parsed less completely than base objects:
+//        (a) `ParseFieldSyntax` ran with `tableLevelExtras: false` for tableextension
+//            fields, dropping OptionMembers (wrong NCLOptionMetadata member count — the
+//            defect class #1674 fixed for base tables) and AutoIncrement.
+//        (b) `TryParsePageFile` stored an empty control map for every pageextension, so a
+//            field control added by `addfirst`/`addlast` was invisible to
+//            GetPageControlFieldMap and a TestPage could not resolve it.
+//
+// CONTROL IDS ARE NOT GUESSED HERE. BC derives a control's id with
+// IdSpace.GetMemberId(ancestorObjectId, name) — and for a control declared inside a
+// pageextension the ancestor is the PAGEEXTENSION's object id, not the base page's. That was
+// established empirically, not assumed: a probe bundle (page 64300 "PXP Card",
+// pageextension 64301 adding `field(NoteField; Rec."Note")` via addlast, a test reading
+// Card.NoteField.Value()) failed in the runner with
+//
+//     out-of-scope: TestPage control 788108655 — testpage-control-binding …
+//
+// and 788108655 == MemberId(64301, "NoteField") while MemberId(64300, "NoteField") is
+// 321499490. MemberIdMatchesTheIdBcActuallyEmitted below pins that observation so the helper
+// here cannot drift away from BC's own hash.
+//
+// The parsers are private statics reached by reflection (same approach as
+// SiblingParserSyntaxTreeTests); assertions otherwise go through the internal accessors the
+// runtime itself calls, so these pin observable behaviour rather than a private field's shape.
+using System.Reflection;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+[Collection(RecordPatchesSerialCollection.Name)]
+public class PageExtensionParserTests
+{
+    private static readonly Type RP = typeof(AlRunner.Patches.RecordPatches);
+
+    // 61950–61964 belong to SiblingParserSyntaxTreeTests; this class owns 61970–61979.
+    private const int TableId = 61971;
+    private const int PageId = 61970;          // a page AND a pageextension both use this id
+    private const int PageExtId = 61972;       // the pageextension that really extends PageId
+
+    private static void Parse(string method, string source) =>
+        RP.GetMethod(method, BindingFlags.NonPublic | BindingFlags.Static)!
+          .Invoke(null, new object[] { source });
+
+    private static System.Collections.IDictionary Dict(string field) =>
+        (System.Collections.IDictionary)RP
+            .GetField(field, BindingFlags.NonPublic | BindingFlags.Static)!.GetValue(null)!;
+
+    private static object? Get(string field, object key)
+    {
+        var d = Dict(field);
+        return d.Contains(key) ? d[key] : null;
+    }
+
+    private static object? Prop(object o, string name) => o.GetType().GetProperty(name)!.GetValue(o);
+
+    private static void Cleanup()
+    {
+        Dict("_parsedTables").Remove(TableId);
+        Dict("_parsedPages").Remove(PageId);
+        Dict("_parsedPageExtensions").Remove(PageId);
+        Dict("_parsedPageExtensions").Remove(PageExtId);
+        Dict("_parsedExtensionFields").Remove("px base table");
+    }
+
+    /// <summary>BC's IdSpace.GetMemberId, reached on the real implementation by reflection so
+    /// this cannot drift from the hash the runtime resolves controls with.</summary>
+    private static int MemberId(int ancestorObjectId, string name)
+    {
+        var t = RP.Assembly.GetType("AlRunner.Patches.RunnerPageInstance")
+            ?? throw new InvalidOperationException("AlRunner.Patches.RunnerPageInstance not found.");
+        var m = t.GetMethod("MemberId", BindingFlags.NonPublic | BindingFlags.Static)
+            ?? throw new InvalidOperationException("RunnerPageInstance.MemberId not found.");
+        return (int)m.Invoke(null, new object[] { ancestorObjectId, name })!;
+    }
+
+    private static readonly string TableSource = $$"""
+        table {{TableId}} "PX Base Table"
+        {
+            fields
+            {
+                field(1; "Code"; Code[20]) { }
+                field(2; "Description"; Text[100]) { }
+                field(3; "Note"; Text[100]) { }
+            }
+            keys { key(PK; "Code") { Clustered = true; } }
+        }
+        """;
+
+    // ─── #1710: `page N` and `pageextension N` are different objects ─────────────────────
+
+    [Fact]
+    public void PageAndPageExtensionWithTheSameId_DoNotOverwriteEachOther()
+    {
+        try
+        {
+            Parse("TryParseTableFile", TableSource);
+            Parse("TryParsePageFile", $$"""
+                page {{PageId}} "PX Card"
+                {
+                    PageType = Card;
+                    SourceTable = "PX Base Table";
+                    layout { area(content) { field(CodeField; Rec."Code") { } } }
+                }
+
+                pageextension {{PageId}} "PX Unrelated Ext" extends "Some Other Page"
+                {
+                    layout { addlast(content) { field(Ghost; Rec."Note") { } } }
+                }
+                """);
+
+            // The page keeps everything the pageextension used to erase.
+            Assert.True(AlRunner.Patches.RecordPatches.IsPageParsed(PageId));
+            Assert.True(AlRunner.Patches.RecordPatches.PageDeclaresSourceTable(PageId),
+                "a pageextension sharing the id must not erase the page's SourceTable");
+            Assert.Equal(TableId, AlRunner.Patches.RecordPatches.GetSourceTableIdForPage(PageId));
+
+            var map = AlRunner.Patches.RecordPatches.GetPageControlFieldMap(PageId);
+            Assert.Equal(1, map[MemberId(PageId, "CodeField")]);
+
+            // …and the unrelated extension's control does NOT leak onto this page: it extends
+            // a different base page, so binding it here would fabricate a binding the AL
+            // never declared.
+            Assert.False(map.ContainsKey(MemberId(PageId, "Ghost")),
+                "a pageextension of a DIFFERENT base page must not contribute controls here");
+        }
+        finally { Cleanup(); }
+    }
+
+    [Fact]
+    public void PageExtensionOnlyId_IsNotReportedAsAParsedPage()
+    {
+        try
+        {
+            Parse("TryParsePageFile", $$"""
+                pageextension {{PageExtId}} "PX Card Ext" extends "PX Card"
+                {
+                    layout { addlast(content) { field(NoteField; Rec."Note") { } } }
+                }
+                """);
+
+            // A pageextension is not a page. Answering IsPageParsed(extId) = true is what let a
+            // pageextension stand in for a page of the same number in the first place.
+            Assert.False(AlRunner.Patches.RecordPatches.IsPageParsed(PageExtId),
+                "a pageextension id must not be reported as a parsed PAGE");
+
+            // Opposite direction: it must still be recorded, in its own namespace, with the
+            // base object it extends — otherwise the split has simply thrown the data away.
+            var ext = Get("_parsedPageExtensions", PageExtId)!;
+            Assert.Equal("PX Card", Prop(ext, "BaseName"));
+            Assert.Equal("PX Card Ext", Prop(ext, "Name"));
+        }
+        finally { Cleanup(); }
+    }
+
+    // ─── #1711(b): a pageextension's field controls ──────────────────────────────────────
+
+    [Fact]
+    public void PageExtension_AddLastFieldControl_BindsIntoTheBasePagesControlMap()
+    {
+        try
+        {
+            Parse("TryParseTableFile", TableSource);
+            Parse("TryParsePageFile", $$"""
+                page {{PageId}} "PX Card"
+                {
+                    PageType = Card;
+                    SourceTable = "PX Base Table";
+                    layout { area(content) { field(CodeField; Rec."Code") { } } }
+                }
+
+                pageextension {{PageExtId}} "PX Card Ext" extends "PX Card"
+                {
+                    layout
+                    {
+                        addlast(content) { field(NoteField; Rec."Note") { } }
+                        modify(CodeField) { Editable = false; }
+                    }
+                }
+                """);
+
+            var map = AlRunner.Patches.RecordPatches.GetPageControlFieldMap(PageId);
+
+            // The control the extension added, keyed in the EXTENSION's id space (see header).
+            Assert.Equal(3, map[MemberId(PageExtId, "NoteField")]);
+            // The base page's own control is still bound.
+            Assert.Equal(1, map[MemberId(PageId, "CodeField")]);
+            // `modify(...)` declares no new control, so nothing else appears.
+            Assert.Equal(2, map.Count);
+        }
+        finally { Cleanup(); }
+    }
+
+    [Fact]
+    public void PageExtensionControl_IsNotKeyedInTheBasePagesIdSpace()
+    {
+        try
+        {
+            Parse("TryParseTableFile", TableSource);
+            Parse("TryParsePageFile", $$"""
+                page {{PageId}} "PX Card"
+                {
+                    SourceTable = "PX Base Table";
+                    layout { area(content) { field(CodeField; Rec."Code") { } } }
+                }
+
+                pageextension {{PageExtId}} "PX Card Ext" extends "PX Card"
+                {
+                    layout { addfirst(content) { field(NoteField; Rec."Note") { } } }
+                }
+                """);
+
+            // Keying the extension's control on the BASE page id is the plausible-looking
+            // wrong answer: the entry exists, the map is non-empty, and the id never matches
+            // the one BC hands GetField — so the failure lands as a loud but misleading
+            // "control not bound to any field" instead of the value the test asked for.
+            var map = AlRunner.Patches.RecordPatches.GetPageControlFieldMap(PageId);
+            Assert.True(map.ContainsKey(MemberId(PageExtId, "NoteField")),
+                "the extension-added control must be bound at all");
+            Assert.False(map.ContainsKey(MemberId(PageId, "NoteField")),
+                "an extension-added control must not be keyed in the base page's id space");
+        }
+        finally { Cleanup(); }
+    }
+
+    [Fact]
+    public void MemberIdMatchesTheIdBcActuallyEmitted()
+    {
+        // Pins the live observation quoted in this file's header: running a bundle with
+        // page 64300 "PXP Card" + pageextension 64301 adding `field(NoteField; Rec."Note")`
+        // made BC ask LiveNavTestPage.GetField for control 788108655.
+        Assert.Equal(788108655, MemberId(64301, "NoteField"));
+        Assert.Equal(321499490, MemberId(64300, "NoteField"));
+    }
+
+    // ─── #1711(a): a tableextension's field properties ───────────────────────────────────
+
+    [Fact]
+    public void TableExtensionOptionField_CarriesItsOptionMembers()
+    {
+        try
+        {
+            Parse("TryParseTableExtensionFile", $$"""
+                tableextension {{PageExtId}} "PX Base Table Ext" extends "PX Base Table"
+                {
+                    fields
+                    {
+                        field(50000; "PX Status"; Option)
+                        {
+                            OptionMembers = ,Open,Released;
+                        }
+                        field(50001; "PX Count"; Integer) { }
+                    }
+                }
+                """);
+
+            var fields = ExtensionFields("PX Base Table");
+
+            // Blank first member kept, tokens trimmed — the exact string BC's
+            // NCLOptionMetadata ctor is handed. Dropping it gave the option the wrong member
+            // COUNT, not just the wrong names, which is #1674's defect class.
+            Assert.Equal(",Open,Released", FieldProp(fields, 50000, "OptionMembers"));
+
+            // Opposite direction: a non-Option field must NOT acquire an option string.
+            Assert.Null(FieldProp(fields, 50001, "OptionMembers"));
+        }
+        finally { Cleanup(); }
+    }
+
+    /// <summary>
+    /// The AutoIncrement half of #1711(a), pinned HERE and not in an AL bundle: today's AL
+    /// compiler rejects the property inside a tableextension outright — AL0404, "Property
+    /// 'AutoIncrement' is not allowed on a table extension" (verified against BC
+    /// 28.1.49838.50794 by compiling exactly this shape) — so no legal AL reaches it. It still
+    /// matters because it is not the only producer of extension fields:
+    /// BcAppSymbolCache.TableExtensions reads AutoIncrement out of a precompiled .app's
+    /// SymbolReference.json and always has, so the source path was the odd one out, silently
+    /// disagreeing with the symbol path about the same field shape.
+    /// </summary>
+    [Fact]
+    public void TableExtensionAutoIncrementField_CarriesAutoIncrement()
+    {
+        try
+        {
+            Parse("TryParseTableExtensionFile", $$"""
+                tableextension {{PageExtId}} "PX Base Table Ext" extends "PX Base Table"
+                {
+                    fields
+                    {
+                        field(50000; "PX Entry No."; Integer) { AutoIncrement = true; }
+                        field(50001; "PX Count"; Integer) { }
+                    }
+                }
+                """);
+
+            var fields = ExtensionFields("PX Base Table");
+
+            Assert.Equal(true, FieldProp(fields, 50000, "IsAutoIncrement"));
+            // Opposite direction: a field that declares nothing stays non-autoincrement — a
+            // table has exactly one AI counter, so a blanket true would hand it to the wrong
+            // field.
+            Assert.Equal(false, FieldProp(fields, 50001, "IsAutoIncrement"));
+        }
+        finally { Cleanup(); }
+    }
+
+    // ─── helpers ─────────────────────────────────────────────────────────────────────────
+
+    private static System.Collections.IEnumerable ExtensionFields(string baseTableName)
+    {
+        var key = baseTableName.ToLowerInvariant();
+        var fields = Get("_parsedExtensionFields", key);
+        Assert.True(fields != null, $"_parsedExtensionFields has no entry for '{key}'");
+        return (System.Collections.IEnumerable)fields!;
+    }
+
+    private static object? FieldProp(System.Collections.IEnumerable fields, int fieldId, string property)
+    {
+        foreach (var f in fields)
+            if ((int)Prop(f, "FieldId")! == fieldId)
+                return Prop(f, property);
+        throw new Xunit.Sdk.XunitException($"no parsed extension field {fieldId}");
+    }
+}

--- a/AlRunner.Tests/ParserStaticsIsolationGuardTests.cs
+++ b/AlRunner.Tests/ParserStaticsIsolationGuardTests.cs
@@ -1,0 +1,394 @@
+// ParserStaticsIsolationGuardTests — meta-guard for #1712.
+//
+// The AL source parsers on RecordPatches publish their results into PROCESS-WIDE static
+// dictionaries (`_parsedTables`, `_parsedPages`, `_parsedReports`, …). A test that drives a
+// parser and then reads the result back out of one of those dictionaries is reading shared
+// mutable state across a window, and xunit runs test COLLECTIONS in parallel — so anything
+// concurrent that repopulates or clears them (RecordPatches.ResetForReload, an in-process
+// bundle load, a neighbouring parser test) can land between the write and the read.
+//
+// That is exactly what #1696 hit: AlSourceParserSyntaxTreeTests.Caption_WithTrailingComment-
+// Property failed as "table 61896 was not parsed at all" on four of five CI legs while passing
+// on the fifth, passing in isolation, and passing in two full local suite runs. It presented as
+// a cross-BC-version parser difference and was not one — the parse was verified correct against
+// the failing leg's own Microsoft.Dynamics.Nav.CodeAnalysis. The only difference was scheduling:
+// CI runners have a different core count, so xunit picks a different degree of parallelism.
+//
+// RecordPatchesSerialCollection fixes it, but only for classes that REMEMBER to join it. This
+// file is the enforcement: it finds test classes that reach the parse statics and fails if any
+// of them is missing [Collection(RecordPatchesSerialCollection.Name)].
+//
+// #1712 also lists the real fix — make the parse entry points RETURN their result instead of
+// publishing into a dictionary, with the registration path doing the storing. That removes the
+// class of bug outright; this guard only makes forgetting the workaround loud. It is a stopgap.
+//
+// ── How the detection works, and what it does NOT catch ──────────────────────────────────────
+//
+// The offending pattern is reflection BY NAME: `GetField("_parsedTables", NonPublic|Static)` /
+// `GetMethod("TryParseTableFile", NonPublic|Static)`. Those names only exist in the test
+// assembly as string literals — there is no IL-level reference to the private field or method to
+// walk, because the members are private and the call goes through System.Reflection. So the
+// detector scans test SOURCE for the quoted marker literals, and uses reflection over the test
+// assembly only for the part reflection is exact about: which types are test classes and what
+// [Collection] they carry.
+//
+// Caught:
+//   * "_parsed…" / "TryParse…File" as a quoted string literal (the reflection-by-name pattern),
+//   * a direct `RecordPatches.ResetForReload` call (clears every parse dictionary).
+// NOT caught:
+//   * a class that reaches the statics through the PUBLIC accessors only (e.g.
+//     RecordPatches.IsPageParsed) with no marker literal anywhere in its source,
+//   * a helper in a different file doing the reflection on the test class's behalf — the scan is
+//     per source file, so the marker has to be in the same file as the class declaration,
+//   * a marker that appears only in a computed/concatenated string.
+// Those are the honest limits. The guard narrows the footgun; #1712 closes it.
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public class ParserStaticsIsolationGuardTests
+{
+    // ── the detector, as pure functions over (class name, [Collection] name, source text) ─────
+
+    // A quoted "_parsedSomething" / "TryParseSomethingFile" literal, or a ResetForReload call.
+    // Quoting matters: BcAppSymbolCacheTableExtTests mentions `_parsedExtensionFields` in a
+    // PROSE COMMENT without ever touching it, and must not be flagged for that.
+    private static readonly Regex MarkerRegex = new(
+        "\"(?:_parsed[A-Za-z]+|TryParse[A-Za-z]*File)\"" +
+        @"|\bRecordPatches\s*\.\s*ResetForReload\b",
+        RegexOptions.Compiled);
+
+    internal static bool TouchesParseStatics(string sourceText) => MarkerRegex.IsMatch(sourceText);
+
+    /// <summary>
+    /// Returns an actionable violation message, or null when the class is fine.
+    /// </summary>
+    internal static string? FindViolation(string className, string? collectionName, string sourceText)
+    {
+        if (!TouchesParseStatics(sourceText)) return null;
+        if (collectionName == RecordPatchesSerialCollection.Name) return null;
+
+        return $"{className} reaches the RecordPatches AL parse statics (a \"_parsed…\" / " +
+               $"\"TryParse…File\" reflection literal, or ResetForReload) but is " +
+               (collectionName is null
+                   ? "in no xunit collection"
+                   : $"in collection \"{collectionName}\"") +
+               $". Add [Collection(RecordPatchesSerialCollection.Name)] to it — the parsers " +
+               "publish into process-wide static dictionaries on RecordPatches and xunit runs " +
+               "collections in parallel, so a concurrent class can clear or repopulate them " +
+               "between your write and your read (see #1696 for the four-of-five-CI-legs " +
+               "failure this produced, and #1712 for the real fix).";
+    }
+
+    // This file necessarily CONTAINS the marker literals — the synthetic fixtures below spell
+    // out the exact pattern the detector must recognise — but it never reflects on the statics
+    // at runtime, so serialising it would be pointless. The exclusion is not a free pass:
+    // TheDetectorFiresOnThisOwnFile_WhichIsWhyItIsExcluded pins that this file really does trip
+    // the detector, so the exclusion stays justified rather than becoming a silent hole.
+    private static readonly string[] SelfExcludedClasses =
+    {
+        nameof(ParserStaticsIsolationGuardTests),
+    };
+
+    // ── RED: the detector catches a real violation ────────────────────────────────────────────
+
+    // Positive control. Without this, every assertion in this file would still pass if
+    // FindViolation were hard-wired to return null — i.e. the whole guard would be noise.
+    private const string ViolatingClassSource = """
+        [Collection("some-other-collection")]
+        public class HypotheticalNewParserTests
+        {
+            [Fact]
+            public void ParsesATable()
+            {
+                var parse = typeof(AlRunner.Patches.RecordPatches).GetMethod("TryParseTableFile",
+                    BindingFlags.NonPublic | BindingFlags.Static)!;
+                parse.Invoke(null, new object[] { "table 61896 T { }" });
+                var tables = typeof(AlRunner.Patches.RecordPatches)
+                    .GetField("_parsedTables", BindingFlags.NonPublic | BindingFlags.Static)!
+                    .GetValue(null)!;
+            }
+        }
+        """;
+
+    [Fact]
+    public void Detector_ClassTouchingTheStaticsInAnotherCollection_IsReported()
+    {
+        var violation = FindViolation(
+            "HypotheticalNewParserTests", "some-other-collection", ViolatingClassSource);
+
+        Assert.NotNull(violation);
+        Assert.Contains("HypotheticalNewParserTests", violation);
+        Assert.Contains("[Collection(RecordPatchesSerialCollection.Name)]", violation);
+        Assert.Contains("some-other-collection", violation);
+    }
+
+    [Fact]
+    public void Detector_ClassTouchingTheStaticsInNoCollection_IsReported()
+    {
+        var violation = FindViolation("HypotheticalNewParserTests", null, ViolatingClassSource);
+
+        Assert.NotNull(violation);
+        Assert.Contains("HypotheticalNewParserTests", violation);
+        Assert.Contains("in no xunit collection", violation);
+        Assert.Contains("[Collection(RecordPatchesSerialCollection.Name)]", violation);
+    }
+
+    [Fact]
+    public void Detector_ClassTouchingTheStaticsInTheSerialCollection_IsNotReported()
+    {
+        Assert.Null(FindViolation(
+            "HypotheticalNewParserTests", RecordPatchesSerialCollection.Name, ViolatingClassSource));
+    }
+
+    // Negative direction: an over-eager detector that flagged every test class would be useless
+    // and would "pass" the assembly-wide assertion for the wrong reason. The fixture is modelled
+    // on BcAppSymbolCacheTableExtTests, which names a parse static in prose and nothing else.
+    [Fact]
+    public void Detector_ClassThatOnlyMentionsAStaticInProse_IsNotReported()
+    {
+        const string innocentSource = """
+            // A table extension whose fields never reached _parsedExtensionFields, causing the
+            // symbol cache to drop them. TryParseTableExtensionFile is where the fix landed.
+            public class BcAppSymbolCacheTableExtLikeTests
+            {
+                [Fact]
+                public void ExtensionFieldsSurviveTheSymbolCache()
+                {
+                    Assert.Equal(2, Cache.ExtensionFieldsOf(61896).Count);
+                }
+            }
+            """;
+
+        Assert.Null(FindViolation("BcAppSymbolCacheTableExtLikeTests", null, innocentSource));
+        Assert.False(TouchesParseStatics(innocentSource));
+    }
+
+    [Fact]
+    public void Detector_OrdinaryTestClass_IsNotReported()
+    {
+        const string ordinarySource = """
+            public class ErrorClassifierLikeTests
+            {
+                [Fact]
+                public void ClassifiesACompileError()
+                {
+                    Assert.Equal(ErrorKind.Compile, Classify("AL0118: unknown type"));
+                }
+            }
+            """;
+
+        Assert.Null(FindViolation("ErrorClassifierLikeTests", null, ordinarySource));
+    }
+
+    [Theory]
+    [InlineData("_parsedTables")]
+    [InlineData("_parsedPages")]
+    [InlineData("_parsedReports")]
+    [InlineData("_parsedReportExtensions")]
+    [InlineData("_parsedQueries")]
+    [InlineData("_parsedXmlPorts")]
+    [InlineData("_parsedObjectDecls")]
+    [InlineData("_parsedObjectCaptions")]
+    [InlineData("_parsedExtensionFields")]
+    [InlineData("TryParseTableFile")]
+    [InlineData("TryParseTableExtensionFile")]
+    [InlineData("TryParsePageFile")]
+    [InlineData("TryParseReportFile")]
+    [InlineData("TryParseQueryFile")]
+    [InlineData("TryParseXmlPortFile")]
+    [InlineData("TryParseObjectDeclFile")]
+    [InlineData("TryParseObjectCaptionFile")]
+    public void Detector_RecognisesEveryParseStaticAndEntryPointByName(string memberName)
+    {
+        Assert.True(TouchesParseStatics($$"""
+            RecordPatchesType.GetMember("{{memberName}}", BindingFlags.NonPublic | BindingFlags.Static);
+            """),
+            $"the detector must recognise reflection by the name \"{memberName}\"");
+
+        // …and the bare name in prose must still not trip it.
+        Assert.False(TouchesParseStatics($"// a note about {memberName} and nothing more"));
+    }
+
+    [Fact]
+    public void Detector_RecognisesResetForReload()
+    {
+        Assert.True(TouchesParseStatics("AlRunner.Patches.RecordPatches.ResetForReload();"));
+        Assert.False(TouchesParseStatics("// ResetForReload wipes the parse dictionaries"));
+    }
+
+    // ── GREEN: the real assembly is clean, and the detector really fires on real source ───────
+
+    [Fact]
+    public void EveryTestClassTouchingTheParseStatics_IsInTheSerialCollection()
+    {
+        var sources = TestSourceByTypeName();
+        var violations = new List<string>();
+
+        foreach (var type in TestClasses())
+        {
+            if (SelfExcludedClasses.Contains(type.Name)) continue;
+            if (!sources.TryGetValue(type.Name, out var source))
+            {
+                throw new Xunit.Sdk.XunitException(
+                    $"no source file under {TestSourceDirectory()} declares test class " +
+                    $"{type.Name}. The parser-statics guard cannot vouch for a class it cannot " +
+                    "read, and a guard that silently skips classes is worse than no guard.");
+            }
+
+            var violation = FindViolation(type.Name, CollectionNameOf(type), source.Text);
+            if (violation is not null) violations.Add($"{source.Path}: {violation}");
+        }
+
+        Assert.True(violations.Count == 0, string.Join("\n\n", violations));
+    }
+
+    // Proves the assertion above is not passing because the detector never fires. These three
+    // classes DO drive the parsers by reflection today; if the detector stopped recognising the
+    // pattern, this fails instead of the guard quietly going green forever.
+    [Theory]
+    [InlineData(nameof(AlSourceParserSyntaxTreeTests))]
+    [InlineData(nameof(AlSourceParserCommentTests))]
+    [InlineData(nameof(SiblingParserCommentTests))]
+    public void TheKnownParserTestClasses_AreDetectedAsTouchingTheStatics_AndAreAttributed(
+        string className)
+    {
+        var sources = TestSourceByTypeName();
+        Assert.True(sources.ContainsKey(className), $"source for {className} was not found");
+
+        Assert.True(TouchesParseStatics(sources[className].Text),
+            $"{className} drives the parsers by reflection, so the detector must flag it as " +
+            "touching the parse statics — if it does not, the assembly-wide guard is vacuous");
+
+        var type = TestClasses().Single(t => t.Name == className);
+        Assert.Equal(RecordPatchesSerialCollection.Name, CollectionNameOf(type));
+    }
+
+    // The other half of "not vacuous": the detector must also say NO a lot. If it flagged every
+    // test class, the assembly-wide assertion would only be measuring how diligent we were about
+    // sprinkling the attribute everywhere.
+    [Fact]
+    public void MostTestClasses_AreNotDetectedAsTouchingTheStatics()
+    {
+        var sources = TestSourceByTypeName();
+        var testClasses = TestClasses().Select(t => t.Name).ToArray();
+        Assert.True(testClasses.Length >= 20,
+            $"expected the test assembly to hold at least 20 test classes, found {testClasses.Length}");
+
+        var untouched = testClasses
+            .Where(n => sources.TryGetValue(n, out var s) && !TouchesParseStatics(s.Text))
+            .ToArray();
+
+        Assert.True(untouched.Length >= 20,
+            $"only {untouched.Length} of {testClasses.Length} test classes are detected as NOT " +
+            "touching the parse statics — the detector is over-eager and the guard proves nothing");
+    }
+
+    [Fact]
+    public void TheDetectorFiresOnThisOwnFile_WhichIsWhyItIsExcluded()
+    {
+        // Documents the one exclusion honestly: this file contains the marker literals as test
+        // fixtures, so the detector flags it, and it is exempt for that reason only.
+        var sources = TestSourceByTypeName();
+        Assert.True(TouchesParseStatics(sources[nameof(ParserStaticsIsolationGuardTests)].Text));
+        Assert.Equal(new[] { nameof(ParserStaticsIsolationGuardTests) }, SelfExcludedClasses);
+    }
+
+    // ── source + reflection plumbing (fails loudly rather than finding nothing to check) ──────
+
+    private sealed record TestSource(string Path, string Text);
+
+    private static string ThisFilePath([CallerFilePath] string path = "") => path;
+
+    private static string TestSourceDirectory()
+    {
+        // Preferred: the compile-time path of this very file. Exact when the assembly is built
+        // and tested on the same checkout, which is how CI and every dev box run it.
+        var compileTimeDir = Path.GetDirectoryName(ThisFilePath());
+        if (compileTimeDir is not null &&
+            File.Exists(Path.Combine(compileTimeDir, "AlRunner.Tests.csproj")))
+        {
+            return compileTimeDir;
+        }
+
+        // Fallback: walk up from the loaded assembly (bin/<cfg>/<tfm>/ → the project dir).
+        for (var dir = new DirectoryInfo(AppContext.BaseDirectory); dir is not null; dir = dir.Parent)
+        {
+            if (File.Exists(Path.Combine(dir.FullName, "AlRunner.Tests.csproj"))) return dir.FullName;
+            var nested = Path.Combine(dir.FullName, "AlRunner.Tests", "AlRunner.Tests.csproj");
+            if (File.Exists(nested)) return Path.GetDirectoryName(nested)!;
+        }
+
+        throw new Xunit.Sdk.XunitException(
+            "the AlRunner.Tests source directory could not be located (compile-time path was " +
+            $"'{ThisFilePath()}', assembly base was '{AppContext.BaseDirectory}'). The parser-" +
+            "statics guard scans source, so with no source it would check nothing and read as a " +
+            "passing guard — failing instead.");
+    }
+
+    // Matches a type declaration at the start of a line, optionally preceded by attributes and
+    // modifiers. Anchoring at line start keeps prose like "…the bug class itself survives…" in a
+    // `//` comment from registering as a declaration.
+    private static readonly Regex TypeDeclRegex = new(
+        @"^[ \t]*(?:\[[^\]]*\][ \t]*)*(?:public|internal|private|protected|file)?[ \t]*" +
+        @"(?:(?:sealed|abstract|static|partial|unsafe|readonly|ref)[ \t]+)*" +
+        @"(?:class|record|struct)[ \t]+(?<name>[A-Za-z_]\w*)",
+        RegexOptions.Compiled | RegexOptions.Multiline);
+
+    private static Dictionary<string, TestSource> TestSourceByTypeName()
+    {
+        var root = TestSourceDirectory();
+        var files = Directory.EnumerateFiles(root, "*.cs", SearchOption.AllDirectories)
+            .Where(p => !p.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}")
+                     && !p.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}"))
+            .ToArray();
+
+        if (files.Length == 0)
+        {
+            throw new Xunit.Sdk.XunitException(
+                $"no .cs files found under '{root}' — the parser-statics guard would check " +
+                "nothing and still go green. Failing loudly instead.");
+        }
+
+        var map = new Dictionary<string, TestSource>(StringComparer.Ordinal);
+        foreach (var path in files)
+        {
+            var text = File.ReadAllText(path);
+            foreach (Match m in TypeDeclRegex.Matches(text))
+            {
+                map[m.Groups["name"].Value] = new TestSource(path, text);
+            }
+        }
+        return map;
+    }
+
+    private static IEnumerable<Type> TestClasses() =>
+        typeof(ParserStaticsIsolationGuardTests).Assembly
+            .GetTypes()
+            .Where(t => t is { IsClass: true, IsAbstract: false })
+            .Where(t => t.GetMethods(BindingFlags.Public | BindingFlags.Instance |
+                                     BindingFlags.Static | BindingFlags.DeclaredOnly)
+                .Any(m => m.GetCustomAttributes(typeof(FactAttribute), inherit: true).Length > 0))
+            .OrderBy(t => t.Name, StringComparer.Ordinal);
+
+    // xunit 2.x's CollectionAttribute exposes its name only through the constructor argument.
+    private static string? CollectionNameOf(Type type)
+    {
+        for (var t = type; t is not null && t != typeof(object); t = t.BaseType)
+        {
+            foreach (var attr in CustomAttributeData.GetCustomAttributes(t))
+            {
+                if (attr.AttributeType.FullName != "Xunit.CollectionAttribute") continue;
+                if (attr.ConstructorArguments.Count > 0 &&
+                    attr.ConstructorArguments[0].Value is string name)
+                {
+                    return name;
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/AlRunner.Tests/RecordPatchesSerialCollection.cs
+++ b/AlRunner.Tests/RecordPatchesSerialCollection.cs
@@ -18,6 +18,12 @@
 //
 // DisableParallelization makes this collection run on its own, so the parser tests get the
 // static dictionaries to themselves for the duration.
+//
+// This is a STOPGAP, and it only works for classes that remember to join. #1712 tracks the real
+// fix — make the parse entry points RETURN their result instead of publishing into a process-wide
+// dictionary — which removes the class of bug rather than fencing it off. Until then,
+// ParserStaticsIsolationGuardTests fails the build if a test class reaches the parse statics
+// without carrying [Collection(RecordPatchesSerialCollection.Name)].
 using Xunit;
 
 namespace AlRunner.Tests;

--- a/AlRunner.Tests/ReportCaptionConsolidationTests.cs
+++ b/AlRunner.Tests/ReportCaptionConsolidationTests.cs
@@ -1,0 +1,224 @@
+// ReportCaptionConsolidationTests — RED→GREEN guard for #1714.
+//
+// A report's Caption used to be parsed TWICE by two independent passes:
+//   * AlReportParser  → ParsedReport.Caption (read by the Report Metadata virtual
+//     table and, via EnumerateKnownAlObjects, by AllObjWithCaption),
+//   * AlObjectCaptionParser → _parsedObjectCaptions[("Report", id)] (written on every
+//     parse and read by nobody — AllObjVirtualTable's "Report" branch was the one kind
+//     that bypassed SourceCaptionFor).
+//
+// The two agreed, but nothing enforced it, and "make AllObjVirtualTable use
+// SourceCaptionFor uniformly" LOOKED like pure cleanup while actually switching which
+// of two independently-computed values was authoritative for reports.
+//
+// The consolidation: AlReportParser is the ONLY pass that reads a report's Caption (it
+// already holds the report's PropertyList for ProcessingOnly and UseRequestPage, so name
+// and caption necessarily come off the same syntax node), AlObjectCaptionParser skips the
+// Report kind entirely, and SourceCaptionFor("Report", id) reads through to that single
+// fact so every AllObj/AllObjWithCaption kind can go through one accessor.
+//
+// These tests pin all three halves. The parsers are private statics reached by
+// reflection (same approach as SiblingParserCommentTests); the assertions use concrete
+// captions that DIFFER from the object name, so an implementation that answered with
+// the name — the single most likely wrong answer here — fails.
+using System.Collections;
+using System.Reflection;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+[Collection(RecordPatchesSerialCollection.Name)]
+public class ReportCaptionConsolidationTests
+{
+    private static readonly Type RecordPatchesType = typeof(AlRunner.Patches.RecordPatches);
+
+    // Ids picked well outside every other parser test's range so a leak is obvious.
+    private const int ReportId = 61974;
+    private const int NoCaptionReportId = 61975;
+    private const int TableId = 61976;
+
+    private const string ReportName = "RCC Doc Report";
+    private const string ReportCaption = "RCC Document Report";
+
+    // A report whose Caption is deliberately different from its name, a report that
+    // declares no Caption at all, and a table that DOES declare one (the control: it
+    // proves the object-caption parser really ran over this source, so "no Report
+    // entry" is an observation and not a vacuous assertion).
+    private static string Fixture() => $$"""
+        table {{TableId}} "RCC Anchor"
+        {
+            Caption = 'RCC Anchor Caption';
+            fields { field(1; "No."; Code[20]) { } }
+        }
+
+        report {{ReportId}} "{{ReportName}}"
+        {
+            Caption = '{{ReportCaption}}';
+            dataset { dataitem(Header; "RCC Anchor") { column(No; Header."No.") { } } }
+        }
+
+        report {{NoCaptionReportId}} "RCC Silent Report"
+        {
+            dataset { dataitem(Header; "RCC Anchor") { column(No; Header."No.") { } } }
+        }
+        """;
+
+    // ── the duplicate write is gone ──────────────────────────────────────────
+
+    [Fact]
+    public void ObjectCaptionParser_RecordsNoEntryForAReport()
+    {
+        try
+        {
+            Invoke("TryParseObjectCaptionFile", Fixture());
+
+            // Control: the same source's TABLE caption IS recorded, so the parser
+            // demonstrably ran and the Report assertions below are not vacuous.
+            Assert.True(HasObjectCaption("Table", TableId),
+                "the object-caption parser did not record the control table — the fixture or the parser changed");
+            Assert.Equal("RCC Anchor Caption", ObjectCaption("Table", TableId));
+
+            // The report's caption belongs to AlReportParser alone. A second, independently
+            // computed copy here is exactly the duplicated fact #1714 removed.
+            Assert.False(HasObjectCaption("Report", ReportId),
+                "a report's Caption must be parsed by AlReportParser only — _parsedObjectCaptions must not hold a second copy");
+            Assert.False(HasObjectCaption("Report", NoCaptionReportId),
+                "a report's Caption must be parsed by AlReportParser only — _parsedObjectCaptions must not hold a second copy");
+        }
+        finally { ForgetObjectCaptions(); }
+    }
+
+    // ── the single accessor reads the single fact ────────────────────────────
+
+    [Fact]
+    public void SourceCaptionFor_Report_ReturnsTheCaptionAlReportParserRead()
+    {
+        try
+        {
+            // ONLY the report parser runs. Before the consolidation SourceCaptionFor
+            // answered out of _parsedObjectCaptions and returned null here.
+            Invoke("TryParseReportFile", Fixture());
+
+            Assert.Equal(ReportCaption, SourceCaptionFor("Report", ReportId));
+            // The caption differs from the object name on purpose: an implementation that
+            // fell back to the name (or to string.Empty) fails right here.
+            Assert.NotEqual(ReportName, SourceCaptionFor("Report", ReportId));
+            // ...and it is the very same value ParsedReport carries — one fact, one place.
+            Assert.Equal(ParsedReportCaption(ReportId), SourceCaptionFor("Report", ReportId));
+        }
+        finally { ForgetReports(); }
+    }
+
+    [Fact]
+    public void SourceCaptionFor_Report_IsNullWhenTheReportDeclaresNoCaption()
+    {
+        try
+        {
+            Invoke("TryParseReportFile", Fixture());
+
+            // "declares no Caption" must stay distinguishable from "declared as the name"
+            // and from "declared empty": AL's default caption (the object name) is applied
+            // by the CONSUMER — AllObjWithCaption's populate and Report Metadata's
+            // `parsed.Caption ?? parsed.Name` — never invented here.
+            Assert.Null(SourceCaptionFor("Report", NoCaptionReportId));
+            Assert.Null(ParsedReportCaption(NoCaptionReportId));
+        }
+        finally { ForgetReports(); }
+    }
+
+    [Fact]
+    public void SourceCaptionFor_UnknownReportId_IsNull()
+    {
+        try
+        {
+            Invoke("TryParseReportFile", Fixture());
+
+            // Negative: no report 61999 was ever parsed, so there is nothing to report.
+            // An implementation that manufactured a caption would fail here.
+            Assert.Null(SourceCaptionFor("Report", 61999));
+        }
+        finally { ForgetReports(); }
+    }
+
+    // ── the consumer (AllObj / AllObjWithCaption row inventory) ──────────────
+
+    [Fact]
+    public void KnownAlObjects_CarryTheReportCaptionAlReportParserRead()
+    {
+        try
+        {
+            Invoke("TryParseReportFile", Fixture());
+
+            var captioned = KnownAlObject("Report", ReportId);
+            Assert.Equal(ReportName, captioned.Name);
+            Assert.Equal(ReportCaption, captioned.Caption);
+
+            // The undeclared case reaches the consumer as null, which is what lets
+            // AllObjWithCaption apply AL's own default (the object name) exactly once.
+            var silent = KnownAlObject("Report", NoCaptionReportId);
+            Assert.Equal("RCC Silent Report", silent.Name);
+            Assert.Null(silent.Caption);
+        }
+        finally { ForgetReports(); }
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    private static void Invoke(string method, string source)
+    {
+        var m = RecordPatchesType.GetMethod(method, BindingFlags.NonPublic | BindingFlags.Static)
+            ?? throw new InvalidOperationException(
+                $"RecordPatches.{method} not found by reflection — signature may have changed.");
+        m.Invoke(null, new object[] { source });
+    }
+
+    private static string? SourceCaptionFor(string kind, int id)
+    {
+        var m = RecordPatchesType.GetMethod("SourceCaptionFor", BindingFlags.NonPublic | BindingFlags.Static)
+            ?? throw new InvalidOperationException("RecordPatches.SourceCaptionFor not found by reflection.");
+        return (string?)m.Invoke(null, new object[] { kind, id });
+    }
+
+    private static (string Kind, int Id, string Name, string? Caption) KnownAlObject(string kind, int id)
+    {
+        var m = RecordPatchesType.GetMethod("EnumerateKnownAlObjects", BindingFlags.NonPublic | BindingFlags.Static)
+            ?? throw new InvalidOperationException("RecordPatches.EnumerateKnownAlObjects not found by reflection.");
+        var rows = (IEnumerable<(string Kind, int Id, string Name, string? Caption)>)m.Invoke(null, null)!;
+        var match = rows.Where(r => r.Kind == kind && r.Id == id).ToList();
+        Assert.True(match.Count == 1, $"expected exactly one {kind} {id} row, got {match.Count}");
+        return match[0];
+    }
+
+    private static IDictionary ObjectCaptions() => (IDictionary)RecordPatchesType
+        .GetField("_parsedObjectCaptions", BindingFlags.NonPublic | BindingFlags.Static)!.GetValue(null)!;
+
+    private static bool HasObjectCaption(string kind, int id) => ObjectCaptions().Contains((kind, id));
+
+    private static string? ObjectCaption(string kind, int id) => (string?)ObjectCaptions()[(kind, id)];
+
+    private static string? ParsedReportCaption(int id)
+    {
+        var d = (IDictionary)RecordPatchesType
+            .GetField("_parsedReports", BindingFlags.NonPublic | BindingFlags.Static)!.GetValue(null)!;
+        Assert.True(d.Contains(id), $"_parsedReports has no entry for {id}");
+        var entry = d[id]!;
+        return (string?)entry.GetType().GetProperty("Caption")!.GetValue(entry);
+    }
+
+    // Drop the fixtures out of the process-wide parser state so they cannot leak.
+    private static void ForgetReports()
+    {
+        var d = (IDictionary)RecordPatchesType
+            .GetField("_parsedReports", BindingFlags.NonPublic | BindingFlags.Static)!.GetValue(null)!;
+        d.Remove(ReportId);
+        d.Remove(NoCaptionReportId);
+    }
+
+    private static void ForgetObjectCaptions()
+    {
+        var d = ObjectCaptions();
+        foreach (var kind in new[] { "Report", "Table" })
+            foreach (var id in new[] { ReportId, NoCaptionReportId, TableId })
+                d.Remove((kind, id));
+    }
+}

--- a/AlRunner/Infrastructure/BundleRootValidation.cs
+++ b/AlRunner/Infrastructure/BundleRootValidation.cs
@@ -1,0 +1,179 @@
+// BundleRootValidation — up-front validation of the positional bundle paths (#1713).
+//
+// Before this, a positional path that did not exist travelled all the way to
+// EnumerateSuites/EnumerateSuitesBelow, where Directory.EnumerateDirectories threw a
+// raw System.IO.DirectoryNotFoundException out of Main: a .NET stack trace and exit
+// code 134 — the code the CI matrix documents as "crash" — for the single most
+// ordinary user error there is, and only AFTER ~6s of BC patch application.
+//
+// The runner is otherwise disciplined about loud, named failures (BcArtifacts names
+// the exact download command; ProvisioningCheck prints the command to run). This is
+// the same rule applied to argument handling: name the path that failed, show what
+// part of it does exist, and — when the evidence actually supports it — name the fix.
+
+namespace AlRunner.Infrastructure;
+
+/// <summary>
+/// Validates the positional bundle directories handed to the CLI. Called at
+/// argument-parse time, before the BC artifact selection, the Cecil re-exec and the
+/// patch pass, so a mistyped path costs milliseconds instead of seconds.
+/// </summary>
+internal static class BundleRootValidation
+{
+    /// <summary>
+    /// Returns <c>null</c> when every root names an existing directory; otherwise the
+    /// complete multi-line failure message for the FIRST unusable root, ready to write
+    /// to stderr. The caller exits 2 ("a bundle could not execute", the ladder every
+    /// other CLI usage error in Program.cs already uses — see PrintHelp).
+    /// </summary>
+    public static string? Validate(IReadOnlyList<string> bundleRoots)
+    {
+        foreach (var root in bundleRoots)
+        {
+            var problem = Describe(root);
+            if (problem != null) return problem;
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// The message for one root, or <c>null</c> when it is a usable directory.
+    /// Split out from <see cref="Validate"/> so the "first bad root wins" policy and
+    /// the per-root diagnosis are independently testable.
+    /// </summary>
+    public static string? Describe(string root)
+    {
+        if (string.IsNullOrWhiteSpace(root)) return null;   // nothing to diagnose
+
+        string abs;
+        try { abs = Path.GetFullPath(root); }
+        catch (Exception ex)
+        {
+            // An unparseable path (invalid characters, a path longer than the platform
+            // allows) is still a user error, not a crash: name it the same way.
+            return $"al-runner: not a usable path: {root}" + Environment.NewLine
+                 + $"  {ex.GetType().Name}: {ex.Message}" + Environment.NewLine
+                 + PositionalArgumentReminder;
+        }
+
+        if (Directory.Exists(abs)) return null;              // the ONLY success path
+
+        var lines = new List<string>();
+        if (File.Exists(abs))
+        {
+            // Distinct from "no such directory": the path is there, it is just the wrong
+            // kind of thing (pointing at app.json instead of the folder holding it is the
+            // usual way to land here). Saying "no such directory" would send the reader
+            // looking for a typo that isn't there.
+            lines.Add($"al-runner: not a directory: {root}");
+            if (!PathsEqual(root, abs)) lines.Add($"  resolved to: {abs}");
+        }
+        else
+        {
+            lines.Add($"al-runner: no such directory: {root}");
+            if (!PathsEqual(root, abs)) lines.Add($"  resolved to:             {abs}");
+            var parent = DeepestExistingParent(abs);
+            if (parent != null)
+                lines.Add($"  deepest existing parent: {parent}");
+        }
+
+        lines.Add(PositionalArgumentReminder);
+
+        var hint = UninitialisedSubmoduleHint(abs);
+        if (hint != null) lines.Add(hint);
+
+        return string.Join(Environment.NewLine, lines);
+    }
+
+    private const string PositionalArgumentReminder =
+        "  Positional arguments are bundle directories (each holds app.json and/or .al files).";
+
+    private static bool PathsEqual(string a, string b) =>
+        string.Equals(
+            a.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar),
+            b.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar),
+            StringComparison.Ordinal);
+
+    /// <summary>
+    /// The nearest ancestor of <paramref name="abs"/> that does exist. This is what makes
+    /// the doubled-prefix typo from #1713 (`tests/al-language/tests/al-language`) obvious
+    /// at a glance: the parent stops exactly where the duplication begins.
+    /// </summary>
+    private static string? DeepestExistingParent(string abs)
+    {
+        try
+        {
+            var dir = Directory.GetParent(abs);
+            while (dir != null)
+            {
+                if (dir.Exists) return dir.FullName;
+                dir = dir.Parent;
+            }
+        }
+        catch { /* an unreadable ancestor simply yields no extra context */ }
+        return null;
+    }
+
+    /// <summary>
+    /// A hint naming `git submodule update --init --recursive` — but ONLY when the
+    /// evidence supports it: a `.gitmodules` in some ancestor declares a submodule whose
+    /// path contains the requested one, AND that submodule directory is missing or empty
+    /// (what `git clone` without `--recurse-submodules` leaves behind).
+    ///
+    /// Deliberately silent when the submodule IS checked out — that is the #1713 repro
+    /// itself, where the path is simply mistyped and the hint would be a wrong lead.
+    /// </summary>
+    private static string? UninitialisedSubmoduleHint(string abs)
+    {
+        try
+        {
+            var dir = Directory.GetParent(abs);
+            while (dir != null)
+            {
+                var gitmodules = Path.Combine(dir.FullName, ".gitmodules");
+                if (File.Exists(gitmodules))
+                {
+                    foreach (var declared in ReadSubmodulePaths(gitmodules))
+                    {
+                        var subAbs = Path.GetFullPath(Path.Combine(dir.FullName, declared));
+                        if (!IsAtOrUnder(abs, subAbs)) continue;
+                        if (Directory.Exists(subAbs)
+                            && Directory.EnumerateFileSystemEntries(subAbs).Any())
+                            continue;   // checked out — the path is just wrong
+                        return $"  {subAbs} is a git submodule and is not checked out — run:"
+                             + Environment.NewLine
+                             + "    git submodule update --init --recursive";
+                    }
+                    return null;   // nearest .gitmodules decides; do not keep climbing
+                }
+                dir = dir.Parent;
+            }
+        }
+        catch { /* a hint is a nicety; never let it become the failure */ }
+        return null;
+    }
+
+    /// <summary>Reads the `path = …` values out of a .gitmodules file.</summary>
+    private static IEnumerable<string> ReadSubmodulePaths(string gitmodules)
+    {
+        foreach (var raw in File.ReadLines(gitmodules))
+        {
+            var line = raw.Trim();
+            if (!line.StartsWith("path", StringComparison.Ordinal)) continue;
+            var eq = line.IndexOf('=');
+            if (eq < 0) continue;
+            // Guard against a key such as "pathspec" that merely starts with "path".
+            if (line[..eq].Trim() != "path") continue;
+            var value = line[(eq + 1)..].Trim();
+            if (value.Length > 0) yield return value;
+        }
+    }
+
+    private static bool IsAtOrUnder(string candidate, string ancestor)
+    {
+        var a = ancestor.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        var c = candidate.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        return string.Equals(a, c, StringComparison.Ordinal)
+            || c.StartsWith(a + Path.DirectorySeparatorChar, StringComparison.Ordinal);
+    }
+}

--- a/AlRunner/Patches/FlowFieldPatches.cs
+++ b/AlRunner/Patches/FlowFieldPatches.cs
@@ -75,8 +75,11 @@ public static class FlowFieldPatches
     private static PropertyInfo? _pCalcFormulaFilters;
     private static PropertyInfo? _pNclMetaFilterFilterType;   // NCLMetaFilter.FilterType
     private static object? _filterTypeField;                  // NCLMetaFilterType.Field
+    private static PropertyInfo? _pNclMetaFilterExpression;   // NCLMetaFilter.Expression
+    private static MethodInfo? _mFilterExprEvaluate;          // FilterExpression.Evaluate(NavValue, ISortingRulesProvider)
     private static PropertyInfo? _pCalcFormulaSourceField;
     private static PropertyInfo? _pCalcFormulaNegateResult;
+    private static MethodInfo? _mCalcFormulaNegateValue;      // NCLMetaCalculationFormula.NegateValue(NavValue)
     private static PropertyInfo? _pCalcFormulaTableId;
     private static PropertyInfo? _pCalcFormulaFieldId;
     private static PropertyInfo? _pFilterSourceField;          // NCLMetaFilter.SourceField
@@ -200,6 +203,8 @@ public static class FlowFieldPatches
         _pCalcFormulaFilters = _tNCLMetaCalcFormula.GetProperty("Filters");
         _pCalcFormulaSourceField = _tNCLMetaCalcFormula.GetProperty("SourceField");
         _pCalcFormulaNegateResult = _tNCLMetaCalcFormula.GetProperty("NegateResult");
+        _mCalcFormulaNegateValue = _tNCLMetaCalcFormula.GetMethod("NegateValue",
+            BindingFlags.Public | BindingFlags.Instance);
         _pCalcFormulaTableId = _tNCLMetaCalcFormula.GetProperty("TableId");
         _pCalcFormulaFieldId = _tNCLMetaCalcFormula.GetProperty("FieldId");
         _fCalcFormulaEmpty = _tNCLMetaCalcFormula.GetField("EmptyFormula",
@@ -215,6 +220,14 @@ public static class FlowFieldPatches
         var tFilterTypeEnum = nclAsm.GetType("Microsoft.Dynamics.Nav.Runtime.NCLMetaFilterType");
         if (tFilterTypeEnum != null)
             _filterTypeField = Enum.Parse(tFilterTypeEnum, "Field");
+        // NCLMetaFilter.Expression — the FilterExpression BC builds for a Const (an equality
+        // against the literal) or an Expression (a parsed filter string) condition. Both are
+        // evaluated with FilterExpression.Evaluate, so one property covers both. #1709.
+        _pNclMetaFilterExpression = _tNCLMetaFilter.GetProperty("Expression",
+            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+        var tFilterExpr = nclAsm.GetType("Microsoft.Dynamics.Nav.Runtime.FilterExpression");
+        _mFilterExprEvaluate = tFilterExpr?.GetMethod("Evaluate",
+            BindingFlags.Public | BindingFlags.Instance);
 
         // Enum values
         _cmNone   = Enum.Parse(_tNCLMetaCalcMethod, "None");
@@ -438,41 +451,70 @@ public static class FlowFieldPatches
                 catch { }
                 if (srcTtdp == null) continue;
 
-                // Resolve filters: list of (sourceFieldColumnIndex, parentFieldColumnIndex)
+                // Resolve the formula's where-conditions into row predicates.
+                //
+                // Two shapes reach here (#1709). A FIELD condition compares the source row's
+                // field against the PARENT record's field — that value is read once, below. A
+                // CONST or EXPRESSION condition (`Open = const(true)`,
+                // `Status = filter(Open|Released)`) carries its own FilterExpression, built by
+                // BC from the metadata, and is evaluated against the source row's value with
+                // BC's own FilterExpression.Evaluate — so range / alternation / `<>` semantics
+                // match real BC instead of being re-implemented here.
+                //
+                // Anything that resolves to neither is DROPPED, and dropping a condition makes
+                // the FlowField aggregate rows AL excluded, so it is reported rather than
+                // ignored.
                 var filters = _pCalcFormulaFilters!.GetValue(formula) as IEnumerable;
                 var filterPairs = new List<(int srcCol, int parentCol, NCLMetaField srcField, NCLMetaField parentField)>();
+                var filterExprs = new List<(int srcCol, NCLMetaField srcField, object expr)>();
                 if (filters != null)
                 {
                     foreach (var fObj in filters)
                     {
                         if (fObj == null) continue;
-                        if ((_tNCLMetaFilter != null && !_tNCLMetaFilter.IsInstanceOfType(fObj))
-                            && (_tNCLMetaFilterField != null && !_tNCLMetaFilterField.IsInstanceOfType(fObj)))
-                            continue;
+                        if (_tNCLMetaFilter != null && !_tNCLMetaFilter.IsInstanceOfType(fObj)) continue;
 
                         object? fSrc = null;
-                        object? fVal = null;
-                        try
+                        try { fSrc = _pFilterSourceField?.GetValue(fObj); } catch { }
+                        if (fSrc is not NCLMetaField srcFilterField)
                         {
-                            fSrc = _pFilterSourceField?.GetValue(fObj);
-                            fVal = _pFilterFieldValueField?.GetValue(fObj);
-                        }
-                        catch
-                        {
+                            Console.Error.WriteLine(
+                                $"[FlowFieldPatches] where-condition dropped: source field unresolved on " +
+                                $"{fObj.GetType().Name}; FlowField may aggregate excluded rows");
                             continue;
                         }
-                        if (fSrc == null || fVal == null) continue;
-                        if (fSrc is not NCLMetaField srcFilterField || fVal is not NCLMetaField parentFilterField)
-                            continue;
 
-                        int sCol = srcFilterField.ColumnIndex;
-                        int pCol = parentFilterField.ColumnIndex;
-                        filterPairs.Add((sCol, pCol, srcFilterField, parentFilterField));
+                        // FIELD → compare against the parent record's field.
+                        if (_tNCLMetaFilterField != null && _tNCLMetaFilterField.IsInstanceOfType(fObj))
+                        {
+                            object? fVal = null;
+                            try { fVal = _pFilterFieldValueField?.GetValue(fObj); } catch { }
+                            if (fVal is NCLMetaField parentFilterField)
+                            {
+                                filterPairs.Add((srcFilterField.ColumnIndex, parentFilterField.ColumnIndex,
+                                    srcFilterField, parentFilterField));
+                                continue;
+                            }
+                        }
+
+                        // CONST / EXPRESSION → evaluate BC's own FilterExpression per row.
+                        object? expr = null;
+                        try { expr = _pNclMetaFilterExpression?.GetValue(fObj); } catch { }
+                        if (expr != null && _mFilterExprEvaluate != null)
+                        {
+                            filterExprs.Add((srcFilterField.ColumnIndex, srcFilterField, expr));
+                            continue;
+                        }
+
+                        Console.Error.WriteLine(
+                            $"[FlowFieldPatches] where-condition dropped on field " +
+                            $"no. {srcFilterField.FieldNo} ({fObj.GetType().Name}, " +
+                            $"{_pNclMetaFilterFilterType?.GetValue(fObj)}); FlowField may aggregate excluded rows");
                     }
 
                 }
 
-                // Pre-read parent values for each filter
+                // Pre-read parent values for each field-to-field filter
                 var parentFilterValues = new NavValue?[filterPairs.Count];
                 for (int i = 0; i < filterPairs.Count; i++)
                     parentFilterValues[i] = ReadBufferFieldValue(parentBuffer, bufferIndexer, filterPairs[i].parentCol, filterPairs[i].parentField);
@@ -524,6 +566,23 @@ public static class FlowFieldPatches
                     }
                     if (!pass) continue;
 
+                    // const(...) / filter(...) conditions — BC's own filter evaluation. The
+                    // session is the ISortingRulesProvider BC passes on its real WHERE path
+                    // (it is only consulted for Text/Code collation).
+                    for (int i = 0; i < filterExprs.Count && pass; i++)
+                    {
+                        var rowVal = ReadBufferFieldValue(row, rowIndexer, filterExprs[i].srcCol, filterExprs[i].srcField);
+                        // No readable value for the constrained field means the row cannot be
+                        // shown to satisfy the condition, so it is excluded — the same answer
+                        // the field-to-field branch above gives (NavValuesEqual(null, v) is
+                        // false). Excluding is the safe direction: including would widen the
+                        // aggregate, which is the bug this condition exists to prevent.
+                        if (rowVal == null) { pass = false; break; }
+                        pass = (bool)_mFilterExprEvaluate!.Invoke(
+                            filterExprs[i].expr, new object?[] { rowVal, session })!;
+                    }
+                    if (!pass) continue;
+
                     anyMatch = true;
                     matchCount++;
 
@@ -561,7 +620,7 @@ public static class FlowFieldPatches
 
                 // Build result
                 bool negate = (bool)(_pCalcFormulaNegateResult?.GetValue(formula) ?? false);
-                NavValue? result = null;
+                NavValue? result;
                 int targetColumn = (int)_pNclMetaFieldColumnIndex!.GetValue(fieldObj)!;
 
                 if (Equals(calcMethod, _cmCount))
@@ -569,16 +628,10 @@ public static class FlowFieldPatches
                 else if (Equals(calcMethod, _cmExist))
                     result = NavValue.CreateNavValueFromObject((NCLMetaField)fieldObj, anyMatch);
                 else if (Equals(calcMethod, _cmSum))
-                {
-                    var v = negate ? -sum : sum;
-                    result = NavValue.CreateNavValueFromObject((NCLMetaField)fieldObj, CoerceSumResult(v));
-                }
+                    result = NavValue.CreateNavValueFromObject((NCLMetaField)fieldObj, CoerceSumResult(sum));
                 else if (Equals(calcMethod, _cmAverage))
-                {
-                    var v = matchCount > 0 ? sum / matchCount : 0m;
-                    if (negate) v = -v;
-                    result = NavValue.CreateNavValueFromObject((NCLMetaField)fieldObj, v);
-                }
+                    result = NavValue.CreateNavValueFromObject((NCLMetaField)fieldObj,
+                        matchCount > 0 ? sum / matchCount : 0m);
                 else if (Equals(calcMethod, _cmMin))
                     result = minV ?? TypedDefaultForField(fieldObj) ?? NavValue.CreateNavValueFromObject((NCLMetaField)fieldObj, 0);
                 else if (Equals(calcMethod, _cmMax))
@@ -589,6 +642,22 @@ public static class FlowFieldPatches
                 {
                     Console.Error.WriteLine($"[FlowFieldPatches] unsupported CalculationMethod {calcMethod}");
                     continue;
+                }
+
+                // #1708 — `CalcFormula = -sum(...)`. The negation is BC's own
+                // NCLMetaCalculationFormula.NegateValue rather than a local `-x`, so every
+                // CalculationMethod gets the semantics BC gives it (the Base Application ships
+                // both `-sum(...)` and `-exist(...)`, and negating a Boolean is not arithmetic).
+                if (negate && result != null)
+                {
+                    if (_mCalcFormulaNegateValue == null)
+                        // Writing the POSITIVE aggregate instead would be the exact silent
+                        // wrong value #1708 is about, so this is loud rather than best-effort.
+                        AlRunner.Infrastructure.RunnerScope.ThrowNotYetImplemented(
+                            "CalcFormula = -sum(...) (NCLMetaCalculationFormula.NegateValue)",
+                            "BC's own value negation is not present on this build, so a signed " +
+                            "FlowField cannot be computed faithfully — issue #1708");
+                    result = (NavValue?)_mCalcFormulaNegateValue.Invoke(formula, new object?[] { result });
                 }
 
                 bufferIndexer.SetValue(parentBuffer, result, new object[] { targetColumn });

--- a/AlRunner/Patches/RecordPatches.AlObjectCaptionParser.cs
+++ b/AlRunner/Patches/RecordPatches.AlObjectCaptionParser.cs
@@ -10,9 +10,16 @@
 //   (kind, id, name) triple.
 //
 //   Rather than teach five parsers the same property, this one sweeps the same source
-//   dirs for every AL object declaration of ANY kind and reads its top-level Caption.
-//   Doing it in one place also means a kind added to AllObj later gets its caption for
-//   free.
+//   dirs for every AL object declaration and reads its top-level Caption. Doing it in
+//   one place also means a kind added to AllObj later gets its caption for free.
+//
+//   REPORTS ARE THE ONE EXCEPTION (#1714). AlReportParser already holds the report's own
+//   PropertyList — it reads ProcessingOnly and UseRequestPage off it — and takes Caption
+//   from there into ParsedReport.Caption, which the Report Metadata virtual table consumes
+//   directly. Recording a second, independently-walked copy here produced a duplicated fact
+//   with nothing enforcing that the two agreed, and this copy was read by nobody.
+//   SourceCaptionFor below answers "Report" out of ParsedReport instead: one accessor for
+//   every kind, over exactly one read of the fact.
 //
 // WHAT "NO CAPTION" MEANS
 //   A null entry here is "the AL source declares no Caption property", which is NOT the
@@ -68,6 +75,10 @@ public static partial class RecordPatches
         foreach (var obj in ParseAlObjects(text))
         {
             if (AlObjectKindName(obj) is not string kind) continue;
+            // Reports are AlReportParser's (#1714) — see the header. Skipping the kind here
+            // rather than filtering the walk keeps every OTHER kind generic: a kind added to
+            // AlObjectKindName later still gets its caption for free.
+            if (kind == "Report") continue;
             // id <= 0 stays rejected, as before.
             if (ObjectIdOf(obj) is not int id || id <= 0) continue;
             // The object's OWN Caption: a caption on a nested field/control/column belongs to
@@ -82,7 +93,16 @@ public static partial class RecordPatches
     /// The Caption the AL source declares for this object, or null when it declares none
     /// (or the runner never saw its source). Callers apply AL's default — the object name
     /// — themselves.
+    ///
+    /// Reports are answered out of <see cref="ParsedReport.Caption"/> rather than
+    /// <see cref="_parsedObjectCaptions"/>: AlReportParser is the single pass that reads a
+    /// report's Caption, off the same PropertyList it reads the report's ProcessingOnly and
+    /// UseRequestPage from (#1714). Routing through here keeps ONE accessor for every
+    /// AllObj/AllObjWithCaption kind while there is still only ONE read of the fact — and it
+    /// is ordering-safe, because ParseAllReportSources runs before this parser does.
     /// </summary>
     private static string? SourceCaptionFor(string kind, int id)
-        => _parsedObjectCaptions.TryGetValue((kind, id), out var caption) ? caption : null;
+        => string.Equals(kind, "Report", StringComparison.OrdinalIgnoreCase)
+            ? (_parsedReports.TryGetValue(id, out var report) ? report.Caption : null)
+            : _parsedObjectCaptions.TryGetValue((kind, id), out var caption) ? caption : null;
 }

--- a/AlRunner/Patches/RecordPatches.AlPageParser.cs
+++ b/AlRunner/Patches/RecordPatches.AlPageParser.cs
@@ -34,13 +34,14 @@ public static partial class RecordPatches
     {
         var objects = ParseAlObjects(text);
 
-        // Pages first, then pageextensions — deliberately, because `_parsedPages` is keyed on
-        // the object id ALONE. AL gives `page` and `pageextension` separate id namespaces, so
-        // a page 50100 and a pageextension 50100 may both exist and the second one written
-        // wins. That is pre-existing behaviour (the report parser hit the same problem and was
-        // given two dictionaries; this one never was), and preserving the write order keeps
-        // this migration behaviour-preserving rather than quietly changing which entry
-        // survives. Splitting the dictionary is the real fix and belongs in its own change.
+        // Pages and pageextensions go into SEPARATE dictionaries, mirroring
+        // _parsedReports / _parsedReportExtensions. AL gives `page` and `pageextension`
+        // separate id namespaces, so a page 50100 and a pageextension 50100 may both exist —
+        // and while they shared one dictionary the extension (written second) won, bringing
+        // SourceTableName = "" and an empty control map with it. The real page's source table
+        // and every one of its control→field bindings vanished silently: GetSourceTableIdForPage
+        // answered 0 and GetPageControlFieldMap answered empty (#1710). Write order therefore
+        // no longer carries any meaning here.
         foreach (var obj in objects)
         {
             if (obj is not NavSyntax.PageSyntax p) continue;
@@ -60,14 +61,18 @@ public static partial class RecordPatches
         {
             if (obj is not NavSyntax.PageExtensionSyntax pe) continue;
             if (ObjectIdOf(pe) is not int id) continue;
-            // Extensions carry no source table and no control map, exactly as before. Their
-            // addfirst/addlast field controls ARE reachable now (same PageFieldSyntax type
-            // under PageExtensionLayoutSyntax), so populating the map is newly possible — but
-            // it would change what GetPageControlFieldMap returns for every pageextension-backed
-            // TestPage, which needs its own test rather than riding along on a parser swap.
-            _parsedPages[id] = new ParsedPage(id, IdentText(pe.Name), IsExtension: true,
-                SourceTableName: string.Empty, ControlIdToFieldName: new Dictionary<int, string>(),
-                InsertAllowed: !PropIs(pe.PropertyList, "InsertAllowed", "false"));
+            // An extension has no source table of its own — it inherits the base page's — but it
+            // DOES declare field controls, via addfirst/addlast. Those are PageFieldSyntax nodes
+            // exactly like a base page's, just hanging off PageExtensionLayoutSyntax, and they
+            // used to be dropped on the floor (#1711): every pageextension stored an empty map,
+            // so a TestPage driven through an extension-added control could not resolve it.
+            // GetPageControlFieldMap merges them into the BASE page's map, which is where a
+            // TestPage looks.
+            _parsedPageExtensions[id] = new ParsedPage(id, IdentText(pe.Name), IsExtension: true,
+                SourceTableName: string.Empty,
+                ControlIdToFieldName: ParsePageFieldBindings(id, pe.Layout),
+                InsertAllowed: !PropIs(pe.PropertyList, "InsertAllowed", "false"),
+                BaseName: Unquote(pe.BaseObject?.ToString()?.Trim() ?? ""));
         }
     }
 
@@ -80,10 +85,13 @@ public static partial class RecordPatches
         => !_parsedPages.TryGetValue(pageId, out var page) || page.InsertAllowed;
 
     /// <summary>
-    /// Whether the AL source parser has seen this page at all. Lets callers tell
+    /// Whether the AL source parser has seen this PAGE at all. Lets callers tell
     /// "the page genuinely declares no SourceTable" (BC's SourceTable==0 case, a legal
     /// AL page) apart from "we never parsed this page", which is a runner gap and must
     /// be reported loudly rather than answered with a default.
+    /// <para>A pageextension of the same number is deliberately NOT an answer here: it is a
+    /// different object in a different id namespace, and letting one stand in for a page is
+    /// what #1710 was.</para>
     /// </summary>
     internal static bool IsPageParsed(int pageId) => _parsedPages.ContainsKey(pageId);
 
@@ -107,6 +115,16 @@ public static partial class RecordPatches
         return 0;
     }
 
+    /// <summary>
+    /// Control id → source-table field number for every field control on the page, INCLUDING
+    /// the ones contributed by pageextensions that extend it.
+    /// <para>An extension's controls are keyed in the EXTENSION's own id space, because BC's
+    /// IdSpace.GetMemberId hashes the id of the object the member is DECLARED in. Verified,
+    /// not assumed: a bundle with `page 64300 "PXP Card"` and `pageextension 64301` adding
+    /// `field(NoteField; Rec."Note")` made BC ask LiveNavTestPage.GetField for control
+    /// 788108655 == GetMemberId(64301, "NoteField"); GetMemberId(64300, "NoteField") is
+    /// 321499490 and never appears.</para>
+    /// </summary>
     internal static IReadOnlyDictionary<int, int> GetPageControlFieldMap(int pageId)
     {
         if (!_parsedPages.TryGetValue(pageId, out var page) || string.IsNullOrWhiteSpace(page.SourceTableName))
@@ -116,12 +134,22 @@ public static partial class RecordPatches
         if (table == null) return new Dictionary<int, int>();
 
         var result = new Dictionary<int, int>();
-        foreach (var kvp in page.ControlIdToFieldName)
-        {
-            var field = table.Fields.FirstOrDefault(f => NamesEqual(f.FieldName, kvp.Value));
-            if (field != null) result[kvp.Key] = field.FieldId;
-        }
+        BindControls(page.ControlIdToFieldName);
+        // Only extensions of THIS page. Binding every extension's controls onto every page
+        // would fabricate bindings that the AL never declared.
+        foreach (var ext in _parsedPageExtensions.Values)
+            if (NamesEqual(ext.BaseName, page.Name))
+                BindControls(ext.ControlIdToFieldName);
         return result;
+
+        void BindControls(IReadOnlyDictionary<int, string> controls)
+        {
+            foreach (var kvp in controls)
+            {
+                var field = table.Fields.FirstOrDefault(f => NamesEqual(f.FieldName, kvp.Value));
+                if (field != null) result[kvp.Key] = field.FieldId;
+            }
+        }
     }
 
     internal static int[] GetPrimaryKeyFieldIdsForTable(int tableId)
@@ -141,9 +169,18 @@ public static partial class RecordPatches
     /// looked for the text <c>Rec.</c> anywhere after the semicolon, so
     /// <c>field(Total; Rec.Amount + 1)</c> bound the control to <c>Amount</c> — a control that is
     /// not bound to that field at all. A compound expression now yields no binding.</para>
+    /// <para><paramref name="layout"/> is a <c>PageLayoutSyntax</c> for a base page and a
+    /// <c>PageExtensionLayoutSyntax</c> for a pageextension — two unrelated node types (the
+    /// latter derives straight from SyntaxNode and holds ControlChangeBaseSyntax entries), but
+    /// the field controls under both are the SAME <c>PageFieldSyntax</c>, so one subtree walk
+    /// serves both. <c>modify(...)</c> declares no control and contributes nothing;
+    /// <c>movefirst</c>/<c>moveafter</c> only reference controls by name.</para>
+    /// <para><paramref name="declaringObjectId"/> is the object the controls are DECLARED in —
+    /// the page for a base layout, the PAGEEXTENSION for controls it adds. That is what BC's
+    /// IdSpace.GetMemberId hashes; see GetPageControlFieldMap for the live evidence.</para>
     /// </summary>
     private static Dictionary<int, string> ParsePageFieldBindings(
-        int pageId, NavSyntax.PageLayoutSyntax? layout)
+        int declaringObjectId, SyntaxNode? layout)
     {
         var result = new Dictionary<int, string>();
         if (layout == null) return result;
@@ -158,7 +195,7 @@ public static partial class RecordPatches
             var controlName = IdentText(field.Name);
             var fieldName = IdentText(access.Name as NavSyntax.IdentifierNameSyntax);
             if (controlName.Length == 0 || fieldName.Length == 0) continue;
-            result[IdSpace.GetMemberId(pageId, controlName)] = fieldName;
+            result[IdSpace.GetMemberId(declaringObjectId, controlName)] = fieldName;
         }
 
         return result;
@@ -174,4 +211,6 @@ internal record ParsedPage(
     bool IsExtension,
     string SourceTableName,
     IReadOnlyDictionary<int, string> ControlIdToFieldName,
-    bool InsertAllowed = true);
+    bool InsertAllowed = true,
+    /// <summary>The object a pageextension extends; empty for a plain page.</summary>
+    string BaseName = "");

--- a/AlRunner/Patches/RecordPatches.AlSourceParser.cs
+++ b/AlRunner/Patches/RecordPatches.AlSourceParser.cs
@@ -197,8 +197,16 @@ public static partial class RecordPatches
         }
     }
 
-    /// <summary>Builds a <see cref="ParsedField"/> from one <c>field(...)</c> declaration.</summary>
-    private static ParsedField? ParseFieldSyntax(NavSyntax.FieldSyntax f, bool tableLevelExtras)
+    /// <summary>
+    /// Builds a <see cref="ParsedField"/> from one <c>field(...)</c> declaration.
+    /// <para>Identical for a `table` field and a `tableextension` field: AL declares them the
+    /// same way and BC gives them the same metadata. They used to differ — extension fields
+    /// were parsed without OptionMembers and without AutoIncrement (#1711), which left an
+    /// Option field added by a tableextension with no option string, so NCLOptionMetadata saw
+    /// the wrong member count (#1674's defect class), and an AutoIncrement field added by a
+    /// tableextension with no autoincrement semantics at all.</para>
+    /// </summary>
+    private static ParsedField? ParseFieldSyntax(NavSyntax.FieldSyntax f)
     {
         if (f.No.Value is not int fid) return null;
         var fname = IdentText(f.Name);
@@ -230,11 +238,11 @@ public static partial class RecordPatches
         // stripping there in the same change.
         string? initValueText = PropValue(props, "InitValue")?.ToString()?.Trim();
 
-        bool isAutoIncrement = tableLevelExtras && PropIs(props, "AutoIncrement", "true");
+        bool isAutoIncrement = PropIs(props, "AutoIncrement", "true");
         var caption = CaptionFrom(PropValue(props, "Caption"));
 
         return new ParsedField(fid, fname, ftype, length, isFlowField, calcFormula,
-            tableLevelExtras ? optionMembers : null, initValueText, isAutoIncrement, caption);
+            optionMembers, initValueText, isAutoIncrement, caption);
     }
 
     private static void TryParseTableFile(string text)
@@ -248,7 +256,7 @@ public static partial class RecordPatches
             var fields = new List<ParsedField>();
             if (table.Fields != null)
                 foreach (var f in table.Fields.Fields)
-                    if (ParseFieldSyntax(f, tableLevelExtras: true) is { } pf)
+                    if (ParseFieldSyntax(f) is { } pf)
                         fields.Add(pf);
 
             // First key is the PK; all subsequent keys are secondary.
@@ -303,17 +311,15 @@ public static partial class RecordPatches
             var extName = IdentText(ext.Name);
             var baseName = Unquote(ext.BaseObject?.ToString()?.Trim() ?? "");
 
-            // tableLevelExtras: false keeps this path byte-identical to what it produced
-            // before — extension fields carried neither OptionMembers nor AutoIncrement.
-            // Both are plausibly wanted here, but adding them is a behaviour change that
-            // needs its own test, not a silent rider on a parser swap.
+            // Extension fields are parsed exactly like base-table fields — see
+            // ParseFieldSyntax for what they used to lose (#1711).
             var fields = new List<ParsedField>();
             // OfType<FieldSyntax>: a tableextension's field list also holds `modify(...)`
             // entries, which declare no new field. The regex only ever matched
             // `field(N; Name; Type)` either, so this keeps the same set.
             if (ext.Fields != null)
                 foreach (var f in ext.Fields.Fields.OfType<NavSyntax.FieldSyntax>())
-                    if (ParseFieldSyntax(f, tableLevelExtras: false) is { } pf)
+                    if (ParseFieldSyntax(f) is { } pf)
                         fields.Add(pf);
 
             Console.Error.WriteLine($"[TableExt] parsed extension {extId} '{extName}' extends '{baseName}' with {fields.Count} fields");

--- a/AlRunner/Patches/RecordPatches.AlSourceParser.cs
+++ b/AlRunner/Patches/RecordPatches.AlSourceParser.cs
@@ -415,36 +415,105 @@ public static partial class RecordPatches
                 return null;
         }
 
-        // A SIGNED formula (`-sum(...)`) is refused rather than parsed. ParsedCalcFormula has
-        // nowhere to carry the sign, so returning it would hand NclMetaTableBuilder a POSITIVE
-        // formula for a negative one — a wrong value, silently, which is the exact failure class
-        // this migration exists to remove. Returning null keeps the pre-existing behaviour (the
-        // old regex was anchored at the formula keyword, so a leading sign never matched and the
-        // FlowField was left at EmptyFormula). Supporting it means adding a sign to
-        // ParsedCalcFormula and honouring it downstream — its own change, with its own test.
-        if (signText.Length > 0) return null;
+        // #1708 — the sign. `-sum(...)` is a negated formula; AL also accepts the no-op `+`.
+        // The sign is now carried on ParsedCalcFormula and honoured by NclMetaTableBuilder
+        // (MetaCalcFormula.reverseSign) and FlowFieldPatches (NegateResult), so parsing it is
+        // no longer a silent lie about the value. A sign token this code has never seen is
+        // still refused rather than guessed at.
+        bool negated;
+        if (signText.Length == 0 || signText == "+") negated = false;
+        else if (signText == "-") negated = true;
+        else
+        {
+            Console.Error.WriteLine($"[CalcFormula] REFUSED {sourceTableName}: unrecognised sign '{signText}'");
+            return null;
+        }
 
         if (string.IsNullOrEmpty(sourceTableName)) return null;
 
-        // Only `X = field(Y)` conditions become filters. The parser gives each condition shape
-        // its own node type, so `const(...)` and `filter(...)` conditions are excluded by type
-        // rather than by a pattern that happened not to match them — same set as before, but now
-        // deliberately. (Honouring const/filter conditions would change which rows a FlowField
-        // sums; that is a semantic change needing real-BC validation, not a parser refactor.)
+        // #1709 — every condition shape, selected BY NODE TYPE. Dropping `const(...)` and
+        // `filter(...)` made the FlowField aggregate rows AL had excluded: a plausible wrong
+        // number, silently (the Base Application writes 1215 const and 285 filter conditions).
         var filters = new List<ParsedCalcFilter>();
         if (where?.Filter != null)
         {
             foreach (var cond in where.Filter.Conditions)
             {
-                if (cond is not NavSyntax.SimpleFieldExpressionSyntax sfe) continue;
-                filters.Add(new ParsedCalcFilter(
-                    Unquote(sfe.LeftHandSide?.ToString()?.Trim() ?? ""),
-                    Unquote(sfe.Identifier?.ToString()?.Trim() ?? "")));
+                switch (cond)
+                {
+                    // "Document No." = field("Code")
+                    case NavSyntax.SimpleFieldExpressionSyntax sfe:
+                        filters.Add(new ParsedCalcFilter(
+                            Unquote(sfe.LeftHandSide?.ToString()?.Trim() ?? ""),
+                            ParsedCalcFilterKind.Field,
+                            ParentFieldName: Unquote(sfe.Identifier?.ToString()?.Trim() ?? "")));
+                        break;
+
+                    // Open = const(true)
+                    case NavSyntax.ConstExpressionSyntax ce:
+                        filters.Add(new ParsedCalcFilter(
+                            Unquote(ce.LeftHandSide?.ToString()?.Trim() ?? ""),
+                            ParsedCalcFilterKind.Const,
+                            Value: ConstValueText(ce.Identifier?.ToString())));
+                        break;
+
+                    // Status = filter(Open|Released)
+                    case NavSyntax.FilterExpressionSyntax fe:
+                        filters.Add(new ParsedCalcFilter(
+                            Unquote(fe.LeftHandSide?.ToString()?.Trim() ?? ""),
+                            ParsedCalcFilterKind.Filter,
+                            Value: fe.Filter?.ToString()?.Trim() ?? ""));
+                        break;
+
+                    // "Account No." = field(filter(Totaling))          → ValueIsFilter
+                    // "Posting Date" = field(upperlimit("Date Filter")) → OnlyMaxLimit
+                    //
+                    // Carried as their own kind so nothing can read them as a plain `field(X)`
+                    // link (which would apply an equality BC never wrote), but NOT applied —
+                    // see BuildMetaCalcFormula. Leaving them unapplied is what the parser has
+                    // always done; turning that into a refusal of the whole formula changes
+                    // the value of the ~105 Base Application FlowFields that use these shapes
+                    // and needs its own issue, test and service-tier validation.
+                    case NavSyntax.FieldFilterExpressionSyntax ffe:
+                        filters.Add(new ParsedCalcFilter(
+                            Unquote(ffe.LeftHandSide?.ToString()?.Trim() ?? ""),
+                            ParsedCalcFilterKind.FlowFilter));
+                        break;
+                    case NavSyntax.FieldUpperLimitExpressionSyntax ule:
+                        filters.Add(new ParsedCalcFilter(
+                            Unquote(ule.LeftHandSide?.ToString()?.Trim() ?? ""),
+                            ParsedCalcFilterKind.FlowFilter));
+                        break;
+
+                    default:
+                        // A condition shape this code has never seen. Refuse the WHOLE formula:
+                        // aggregating over only the conditions we did understand silently
+                        // widens the row set.
+                        Console.Error.WriteLine(
+                            $"[CalcFormula] REFUSED {sourceTableName}: unsupported where-condition " +
+                            $"{cond?.GetType().Name} ({cond})");
+                        return null;
+                }
             }
         }
 
-        Console.Error.WriteLine($"[CalcFormula] parsed {sourceTableName}.{sourceFieldName ?? "*"} type={formulaType} filters={filters.Count}");
-        return new ParsedCalcFormula(formulaType, sourceTableName, sourceFieldName, filters);
+        Console.Error.WriteLine($"[CalcFormula] parsed {sourceTableName}.{sourceFieldName ?? "*"} type={formulaType} negated={negated} filters={filters.Count}");
+        return new ParsedCalcFormula(formulaType, sourceTableName, sourceFieldName, filters, negated);
+    }
+
+    /// <summary>
+    /// The literal of a <c>const(...)</c> condition, as text.
+    /// <para>Quotes come off for the same reason they do on InitValue (#1674):
+    /// <c>NCLMetaFilterConst</c> evaluates this text against the SOURCE field's own type, and
+    /// an option member named <c>On Hold</c> is never matched by the 9-character
+    /// <c>"On Hold"</c>. AL's doubled-quote escape is resolved with it.</para>
+    /// </summary>
+    private static string ConstValueText(string? text)
+    {
+        var s = (text ?? "").Trim();
+        if (s.Length >= 2 && s[0] == '"' && s[^1] == '"') return s[1..^1].Replace("\"\"", "\"");
+        if (s.Length >= 2 && s[0] == '\'' && s[^1] == '\'') return s[1..^1].Replace("''", "'");
+        return s;
     }
 
     /// <summary>
@@ -471,8 +540,47 @@ public static partial class RecordPatches
 
 // ─── Data holders ────────────────────────────────────────────────────────────
 
-internal record ParsedCalcFilter(string SourceFieldName, string ParentFieldName);
-internal record ParsedCalcFormula(string FormulaType, string SourceTableName, string? SourceFieldName, List<ParsedCalcFilter> Filters);
+/// <summary>
+/// Which shape of <c>where(...)</c> condition a <see cref="ParsedCalcFilter"/> carries. AL
+/// writes four, they are NOT interchangeable, and reading one as another is a silent wrong
+/// value (#1709).
+/// </summary>
+internal enum ParsedCalcFilterKind
+{
+    /// <summary><c>"Document No." = field("No.")</c> — link to a field of the PARENT record.
+    /// Becomes a <c>MetaFilter</c> of FilterType FIELD whose filterValue is the parent field
+    /// id.</summary>
+    Field,
+    /// <summary><c>Open = const(true)</c> — compare against a literal. Becomes FilterType
+    /// CONST, filterValue = the literal's text, which <c>NCLMetaFilterConst</c> evaluates
+    /// against the SOURCE field's own type.</summary>
+    Const,
+    /// <summary><c>Status = filter(Open|Released)</c> — a filter EXPRESSION. Becomes
+    /// FilterType FILTER, filterValue = the expression text, parsed by BC's own filter parser
+    /// (<c>NCLMetaFilterExpression</c>).</summary>
+    Filter,
+    /// <summary><c>"Account No." = field(filter(Totaling))</c> and <c>"Posting Date" =
+    /// field(upperlimit("Date Filter"))</c> — the FlowFilter forms
+    /// (<c>NCLMetaFilterModes.ValueIsFilter</c> / <c>.OnlyMaxLimit</c>). Parsed so nothing can
+    /// mistake them for a plain <see cref="Field"/> link; not applied — see
+    /// <c>BuildMetaCalcFormula</c>.</summary>
+    FlowFilter,
+}
+
+/// <param name="SourceFieldName">Field of the FlowField's SOURCE table being constrained.</param>
+/// <param name="Kind">Which of AL's condition shapes this is.</param>
+/// <param name="ParentFieldName">Set only for <see cref="ParsedCalcFilterKind.Field"/>.</param>
+/// <param name="Value">Const literal / filter expression text — set for
+/// <see cref="ParsedCalcFilterKind.Const"/> and <see cref="ParsedCalcFilterKind.Filter"/>.</param>
+internal record ParsedCalcFilter(
+    string SourceFieldName,
+    ParsedCalcFilterKind Kind = ParsedCalcFilterKind.Field,
+    string? ParentFieldName = null,
+    string? Value = null);
+
+/// <param name="Negated">The formula's leading <c>-</c> (#1708), carried through to
+/// <c>MetaCalcFormula.reverseSign</c> → <c>NCLMetaCalculationFormula.NegateResult</c>.</param>
+internal record ParsedCalcFormula(string FormulaType, string SourceTableName, string? SourceFieldName, List<ParsedCalcFilter> Filters, bool Negated = false);
 
 internal record ParsedField(int FieldId, string FieldName, string TypeName, int Length, bool IsFlowField = false, ParsedCalcFormula? CalcFormula = null, string? OptionMembers = null, string? InitValueText = null, bool IsAutoIncrement = false, string? Caption = null);
 internal record ParsedKey(string Name, List<int> FieldIds);

--- a/AlRunner/Patches/RecordPatches.AllObjVirtualTable.cs
+++ b/AlRunner/Patches/RecordPatches.AllObjVirtualTable.cs
@@ -141,7 +141,10 @@ public static partial class RecordPatches
             yield return (kind, p.Id, p.Name, SourceCaptionFor(kind, p.Id));
         }
         foreach (var r in _parsedReports.Values)
-            yield return ("Report", r.Id, r.Name, r.Caption);
+            // SourceCaptionFor("Report", …) reads r.Caption itself — AlReportParser is the
+            // only pass that parses a report's Caption (#1714). Going through the same
+            // accessor as every other kind is what keeps that single source uniform.
+            yield return ("Report", r.Id, r.Name, SourceCaptionFor("Report", r.Id));
         foreach (var r in _parsedReportExtensions.Values)
             yield return ("ReportExtension", r.Id, r.Name, SourceCaptionFor("ReportExtension", r.Id));
         foreach (var q in _parsedQueries.Values)

--- a/AlRunner/Patches/RecordPatches.AllObjVirtualTable.cs
+++ b/AlRunner/Patches/RecordPatches.AllObjVirtualTable.cs
@@ -135,11 +135,14 @@ public static partial class RecordPatches
     {
         foreach (var t in _parsedTables.Values)
             yield return ("Table", t.TableId, t.TableName, SourceCaptionFor("Table", t.TableId));
+        // Pages and pageextensions live in separate dictionaries because AL gives them
+        // separate id namespaces (#1710) — both are enumerated, so an app declaring
+        // `page N` and `pageextension N` reports BOTH rows instead of only whichever
+        // one was parsed last.
         foreach (var p in _parsedPages.Values)
-        {
-            var kind = p.IsExtension ? "PageExtension" : "Page";
-            yield return (kind, p.Id, p.Name, SourceCaptionFor(kind, p.Id));
-        }
+            yield return ("Page", p.Id, p.Name, SourceCaptionFor("Page", p.Id));
+        foreach (var p in _parsedPageExtensions.Values)
+            yield return ("PageExtension", p.Id, p.Name, SourceCaptionFor("PageExtension", p.Id));
         foreach (var r in _parsedReports.Values)
             // SourceCaptionFor("Report", …) reads r.Caption itself — AlReportParser is the
             // only pass that parses a report's Caption (#1714). Going through the same

--- a/AlRunner/Patches/RecordPatches.AllObjWithCaptionVirtualTable.cs
+++ b/AlRunner/Patches/RecordPatches.AllObjWithCaptionVirtualTable.cs
@@ -24,8 +24,12 @@
 //   only addition is the caption.
 //
 // WHERE CAPTIONS COME FROM (two sources, neither invented)
-//   1. Objects the runner compiles itself — the Caption property read off their AL source
-//      (RecordPatches.AlObjectCaptionParser.cs).
+//   1. Objects the runner compiles itself — the Caption property read off their AL source,
+//      reached through SourceCaptionFor (RecordPatches.AlObjectCaptionParser.cs). Reports
+//      are the one kind whose Caption is parsed by their own parser instead
+//      (ParsedReport.Caption, RecordPatches.AlReportParser.cs, which needs it for the
+//      Report Metadata virtual table anyway); SourceCaptionFor routes "Report" there, so
+//      it is still one parse of the fact behind one accessor — see #1714.
 //   2. Objects in a PRECOMPILED dependency — the Caption property recorded in that .app's
 //      SymbolReference.json (BcAppSymbolCache.ObjectSymbol.Caption).
 //   An object that declares NO Caption gets its object name, because that is AL's own

--- a/AlRunner/Patches/RecordPatches.NclMetaFormReportBuilder.cs
+++ b/AlRunner/Patches/RecordPatches.NclMetaFormReportBuilder.cs
@@ -28,6 +28,8 @@ public static partial class RecordPatches
 {
     // Parsed page/report/query/xmlport tables, mirror of _parsedTables.
     private static readonly Dictionary<int, ParsedPage> _parsedPages = new();
+    // Separate id namespace: pageextension N may legally reuse a `page` id (#1710).
+    private static readonly Dictionary<int, ParsedPage> _parsedPageExtensions = new();
     private static readonly Dictionary<int, ParsedReport> _parsedReports = new();
     // Separate id namespace: reportextension N may legally reuse a `report` id.
     private static readonly Dictionary<int, ParsedReport> _parsedReportExtensions = new();
@@ -105,7 +107,12 @@ public static partial class RecordPatches
     [MethodImpl(MethodImplOptions.NoInlining)]
     private static object? BuildNCLMetaForm(int pageId)
     {
-        if (!_parsedPages.TryGetValue(pageId, out var parsed)) return null;
+        // Existence check only — nothing below reads the parsed object. Pageextension ids are
+        // accepted too, because they used to live in _parsedPages and therefore used to get a
+        // skeleton; #1710's split decides which object WINS a shared id, it does not withdraw
+        // the skeleton from ids only a pageextension claims.
+        if (!_parsedPages.ContainsKey(pageId) && !_parsedPageExtensions.ContainsKey(pageId))
+            return null;
         EnsureFormReportReflection();
         if (_mCreateEmptyNCLMetaForm == null) return null;
 

--- a/AlRunner/Patches/RecordPatches.NclMetaTableBuilder.cs
+++ b/AlRunner/Patches/RecordPatches.NclMetaTableBuilder.cs
@@ -202,8 +202,13 @@ public static partial class RecordPatches
                 // ordinal) using data captured by BcCompiler at AL emit time.
                 FixupEnumFieldOptionMetadata(built, parsed, extFields);
 
-                // Register any AutoIncrement fields so NavRecord_ALInsertAsync3 assigns counters.
-                foreach (var f in parsed.Fields)
+                // Register any AutoIncrement fields so NavRecord_ALInsertAsync3 assigns
+                // counters. `allParsed` rather than `parsed.Fields`: a tableextension may
+                // declare the AutoIncrement field, and since #1711 that property survives the
+                // parse. Registering only base-table fields would be the silent half-fix —
+                // the NCLMetaField would say autoIncrement=true while no counter ever
+                // advanced, so every Insert left the field at 0 and the second row collided.
+                foreach (var f in allParsed)
                     if (f.IsAutoIncrement)
                         AlRunner.BcRuntime.RegisterAutoIncrementField(tableId, f.FieldId);
             }

--- a/AlRunner/Patches/RecordPatches.NclMetaTableBuilder.cs
+++ b/AlRunner/Patches/RecordPatches.NclMetaTableBuilder.cs
@@ -483,25 +483,59 @@ public static partial class RecordPatches
             srcFieldId = srcField.FieldId;
         }
 
-        // Build MetaFilter[] for each FIELD-type filter
+        // Build a MetaFilter per where-condition. BC turns each one into the matching
+        // NCLMetaFilter subclass on its own (NCLMetaFilterCollection.CreateFromMetaFilter):
+        // FIELD → NCLMetaFilterField, CONST → NCLMetaFilterConst, FILTER →
+        // NCLMetaFilterExpression. The const literal / filter expression is handed over as
+        // TEXT and evaluated by BC against the source field's own type, exactly as it is for
+        // a user-typed filter.
         var filterObjects = new List<object>();
         foreach (var filter in cf.Filters)
         {
             var srcFilterField = srcTable.Fields.FirstOrDefault(f =>
                 string.Equals(f.FieldName, filter.SourceFieldName, StringComparison.OrdinalIgnoreCase));
-            var parentFilterField = parentTable.Fields.FirstOrDefault(f =>
-                string.Equals(f.FieldName, filter.ParentFieldName, StringComparison.OrdinalIgnoreCase));
             if (srcFilterField == null)
             {
                 Console.Error.WriteLine($"[RecordPatches] BuildMetaCalcFormula: filter source field '{filter.SourceFieldName}' not found in '{cf.SourceTableName}'");
                 continue;
             }
-            if (parentFilterField == null)
+
+            switch (filter.Kind)
             {
-                Console.Error.WriteLine($"[RecordPatches] BuildMetaCalcFormula: filter parent field '{filter.ParentFieldName}' not found in '{parentTable.TableName}'");
-                continue;
+                case ParsedCalcFilterKind.Field:
+                    var parentFilterField = parentTable.Fields.FirstOrDefault(f =>
+                        string.Equals(f.FieldName, filter.ParentFieldName, StringComparison.OrdinalIgnoreCase));
+                    if (parentFilterField == null)
+                    {
+                        Console.Error.WriteLine($"[RecordPatches] BuildMetaCalcFormula: filter parent field '{filter.ParentFieldName}' not found in '{parentTable.TableName}'");
+                        continue;
+                    }
+                    filterObjects.Add(BuildMetaFilter(srcFilterField.FieldId, "FIELD",
+                        parentFilterField.FieldId.ToString()));
+                    break;
+
+                case ParsedCalcFilterKind.Const:
+                    filterObjects.Add(BuildMetaFilter(srcFilterField.FieldId, "CONST", filter.Value ?? ""));
+                    break;
+
+                case ParsedCalcFilterKind.Filter:
+                    filterObjects.Add(BuildMetaFilter(srcFilterField.FieldId, "FILTER", filter.Value ?? ""));
+                    break;
+
+                case ParsedCalcFilterKind.FlowFilter:
+                    // `field(filter(X))` / `field(upperlimit(X))` — MetaFilter models these as
+                    // FIELD plus valueIsFilter / onlyMaxLimit, but evaluating them means
+                    // reading the PARENT field as a filter string (or as the upper bound of
+                    // one), which FlowFieldPatches does not do. Emitting a plain FIELD filter
+                    // instead would apply an equality BC never wrote — the silent wrong value
+                    // this is all about — so the condition is left out, as it always has been,
+                    // and said out loud. Runner gap, not an AL problem.
+                    Console.Error.WriteLine(
+                        $"[RecordPatches] BuildMetaCalcFormula: RUNNER GAP — FlowFilter condition on " +
+                        $"'{cf.SourceTableName}'.'{filter.SourceFieldName}' is not applied; " +
+                        $"'{parentTable.TableName}' FlowField may aggregate more rows than AL declared");
+                    break;
             }
-            filterObjects.Add(BuildMetaFilter(srcFilterField.FieldId, parentFilterField.FieldId));
         }
 
         // Construct MetaCalcFormula(int tableId, int fieldId, string flowFieldType, bool reverseSign, ImmutableArray<MetaFilter> filters)
@@ -515,7 +549,9 @@ public static partial class RecordPatches
             if (p.Name == "tableId") { args[i] = srcTable.TableId; continue; }
             if (p.Name == "fieldId") { args[i] = srcFieldId; continue; }
             if (p.Name == "flowFieldType") { args[i] = cf.FormulaType.ToUpperInvariant(); continue; }
-            if (p.Name == "reverseSign") { args[i] = false; continue; }
+            // #1708: `CalcFormula = -sum(...)`. BC's own NCLMetaCalculationFormula.NegateResult
+            // is built from this flag, and FlowFieldPatches negates the aggregate with it.
+            if (p.Name == "reverseSign") { args[i] = cf.Negated; continue; }
             if (p.Name == "filters")
             {
                 args[i] = MakeImmutableArray(_tMetaFilter!, filterObjects.ToArray());
@@ -536,7 +572,15 @@ public static partial class RecordPatches
         }
     }
 
-    private static object BuildMetaFilter(int sourceFieldId, int parentFieldId)
+    /// <summary>
+    /// One <c>MetaFilter</c> — BC's metadata form of a single CalcFormula where-condition.
+    /// <para><paramref name="filterTypeName"/> is a <c>FilterType</c> member (FIELD / CONST /
+    /// FILTER) and <paramref name="filterValue"/> is what that type means: the parent field's
+    /// id for FIELD, the literal's text for CONST, the filter expression's text for FILTER.
+    /// This is the same shape BC's compiled table metadata carries, which is why NCL can build
+    /// the right NCLMetaFilter subclass from it without any further help.</para>
+    /// </summary>
+    private static object BuildMetaFilter(int sourceFieldId, string filterTypeName, string filterValue)
     {
         // MetaFilter(int fieldId, FilterType filterType, string filterValue, ...)
         var ctor = _tMetaFilter!.GetConstructors()
@@ -547,8 +591,8 @@ public static partial class RecordPatches
         {
             var p = ps[i];
             if (p.Name == "fieldId") { args[i] = sourceFieldId; continue; }
-            if (p.Name == "filterType") { args[i] = Enum.Parse(_tFilterType!, "FIELD"); continue; }
-            if (p.Name == "filterValue") { args[i] = parentFieldId.ToString(); continue; }
+            if (p.Name == "filterType") { args[i] = Enum.Parse(_tFilterType!, filterTypeName); continue; }
+            if (p.Name == "filterValue") { args[i] = filterValue; continue; }
             if (p.HasDefaultValue) { args[i] = p.DefaultValue; continue; }
             args[i] = p.ParameterType.IsValueType ? Activator.CreateInstance(p.ParameterType) : null;
         }

--- a/AlRunner/Patches/RecordPatches.NclMetadataCachePopulator.cs
+++ b/AlRunner/Patches/RecordPatches.NclMetadataCachePopulator.cs
@@ -68,7 +68,11 @@ public static partial class RecordPatches
             id => _metaTableCache.GetOrAdd(id, BuildNCLMetaTable), "Table");
 
         // Pages — §P, mirror via BuildNCLMetaForm using NCLMetaForm.CreateEmptyNCLMetaForm.
-        PopulateOneObjectType(arr, objectTypePage, _parsedPages.Keys.ToArray(),
+        // Pageextension ids are included alongside page ids: they used to share _parsedPages
+        // and therefore used to get a slot here. #1710's split is about which object wins a
+        // shared id, not about withdrawing the skeleton from ids only a pageextension claims.
+        PopulateOneObjectType(arr, objectTypePage,
+            _parsedPages.Keys.Concat(_parsedPageExtensions.Keys).Distinct().ToArray(),
             id => _metaFormCache.GetOrAdd(id, BuildNCLMetaForm), "Page");
 
         // Reports — §P, mirror via BuildNCLMetaReport using NCLMetaReport.CreateEmptyNCLMetaReport.

--- a/AlRunner/Patches/RecordPatches.cs
+++ b/AlRunner/Patches/RecordPatches.cs
@@ -119,6 +119,7 @@ public static partial class RecordPatches
         _bcSymbolExtensionIndexBuilt = false; // re-merge BC precompiled extensions on next build
         _fieldTriggersWiredTables.Clear();
         _parsedPages.Clear();
+        _parsedPageExtensions.Clear();
         _parsedReports.Clear();
         _parsedReportExtensions.Clear();
         _parsedQueries.Clear();

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -323,6 +323,22 @@ if (serverMode && watchMode)
     Console.Error.WriteLine("--server and --watch are mutually exclusive (both stay warm in-process; pick one).");
     return 2;
 }
+// ── Positional bundle roots must exist (#1713) ────────────────────────────────
+// Checked HERE — at argument-parse time, before the BC artifact selection, the Cecil
+// re-exec and the ~6s patch pass — so a mistyped path costs milliseconds. Before this,
+// a nonexistent path travelled all the way into EnumerateSuitesBelow and threw a raw
+// DirectoryNotFoundException out of Main: exit 134, the code the CI matrix documents as
+// "crash", for the most ordinary user error there is. Exit 2 is the existing ladder
+// entry for "could not execute (process-level error)" and is what every other CLI usage
+// error above already returns — no new code introduced.
+{
+    var rootProblem = AlRunner.Infrastructure.BundleRootValidation.Validate(bundles);
+    if (rootProblem != null)
+    {
+        Console.Error.WriteLine(rootProblem);
+        return 2;
+    }
+}
 // --output-json: stdout must be JSON-only, matching the documented contract ("Replace
 // the normal text output with per-test JSON on stdout") and the convention --server
 // already follows. Redirect ALL human-readable progress (bundle/suite banners, [layered]
@@ -2719,7 +2735,9 @@ static void PrintHelp(TextWriter w)
     w.WriteLine("                          cut. Exit codes:");
     w.WriteLine("                            0  all tests passed");
     w.WriteLine("                            1  at least one test FAILED or ERRORED");
-    w.WriteLine("                            2  a bundle could not execute (process-level error)");
+    w.WriteLine("                            2  a bundle could not execute (process-level error;");
+    w.WriteLine("                               also a bad invocation — unknown flag, or a bundle");
+    w.WriteLine("                               path that does not exist)");
     w.WriteLine("                            3  a bundle could not compile");
     w.WriteLine("  --no-strict-exit        Always exit 0 regardless of test outcome, so callers can");
     w.WriteLine("                          parse the JSON output without the process failing the step.");
@@ -4667,6 +4685,14 @@ static IReadOnlyList<string> GetOrderedDepIds(
 
 static IEnumerable<string> EnumerateSuites(string root)
 {
+    // Defence in depth for #1713. The CLI validates the positional roots up front, but
+    // this runs again per watch-mode cycle and per bundle, and a directory can vanish
+    // between the check and the walk (a watch session while the tree is being moved, a
+    // submodule being re-checked-out). Yielding nothing lets the caller print its own
+    // loud "SKIP (no suites)" line instead of throwing DirectoryNotFoundException out
+    // of Main with exit 134 — the crash code, for a merely absent directory.
+    if (!Directory.Exists(root)) yield break;
+
     // Root first: a directory that is itself one app (app.json at its root, or a
     // src//test/ split) is ONE bucket, however many category sub-directories it
     // holds. This is the al-language corpus shape — checking the root before
@@ -4691,6 +4717,10 @@ static IEnumerable<string> EnumerateSuites(string root)
 
 static IEnumerable<string> EnumerateSuitesBelow(string dir)
 {
+    // Same guard as EnumerateSuites — this is the frame that actually threw in #1713,
+    // and it also recurses into directories that may disappear mid-walk.
+    if (!Directory.Exists(dir)) yield break;
+
     foreach (var child in Directory.EnumerateDirectories(dir))
     {
         if (LooksLikeSuite(child))

--- a/tests/runner-extras/calcformula-sign-and-filters/CfsAssert.Codeunit.al
+++ b/tests/runner-extras/calcformula-sign-and-filters/CfsAssert.Codeunit.al
@@ -1,7 +1,7 @@
 /// <summary>
 /// Minimal assertion helper for this runner-extras app (own ID range).
 /// </summary>
-codeunit 64225 "CFS Assert"
+codeunit 64265 "CFS Assert"
 {
     procedure AreEqual(Expected: Decimal; Actual: Decimal; Msg: Text)
     begin

--- a/tests/runner-extras/calcformula-sign-and-filters/CfsAssert.Codeunit.al
+++ b/tests/runner-extras/calcformula-sign-and-filters/CfsAssert.Codeunit.al
@@ -1,0 +1,29 @@
+/// <summary>
+/// Minimal assertion helper for this runner-extras app (own ID range).
+/// </summary>
+codeunit 64225 "CFS Assert"
+{
+    procedure AreEqual(Expected: Decimal; Actual: Decimal; Msg: Text)
+    begin
+        if Expected <> Actual then
+            Error('Assert.AreEqual failed. Expected:<%1>. Actual:<%2>. %3', Expected, Actual, Msg);
+    end;
+
+    procedure AreNotEqual(NotExpected: Decimal; Actual: Decimal; Msg: Text)
+    begin
+        if NotExpected = Actual then
+            Error('Assert.AreNotEqual failed. Value:<%1>. %2', Actual, Msg);
+    end;
+
+    procedure IsTrue(Condition: Boolean; Msg: Text)
+    begin
+        if not Condition then
+            Error('Assert.IsTrue failed. %1', Msg);
+    end;
+
+    procedure ExpectedError(Expected: Text; Actual: Text)
+    begin
+        if StrPos(Actual, Expected) = 0 then
+            Error('Assert.ExpectedError failed. Expected substring:<%1>. Actual:<%2>.', Expected, Actual);
+    end;
+}

--- a/tests/runner-extras/calcformula-sign-and-filters/CfsHeader.Table.al
+++ b/tests/runner-extras/calcformula-sign-and-filters/CfsHeader.Table.al
@@ -3,7 +3,7 @@
 /// every one of them lands on a different value, so an implementation that ignored the
 /// sign, ignored the where-conditions, or returned the type default cannot satisfy them.
 /// </summary>
-table 64221 "CFS Header"
+table 64261 "CFS Header"
 {
     DataClassification = CustomerContent;
 

--- a/tests/runner-extras/calcformula-sign-and-filters/CfsHeader.Table.al
+++ b/tests/runner-extras/calcformula-sign-and-filters/CfsHeader.Table.al
@@ -1,0 +1,85 @@
+/// <summary>
+/// One FlowField per CalcFormula shape under test. With the seeded rows (see "CFS Tests")
+/// every one of them lands on a different value, so an implementation that ignored the
+/// sign, ignored the where-conditions, or returned the type default cannot satisfy them.
+/// </summary>
+table 64221 "CFS Header"
+{
+    DataClassification = CustomerContent;
+
+    fields
+    {
+        field(1; "No."; Code[20]) { }
+
+        /// The baseline: no condition beyond the parent link. 100 + 20 + 3 = 123.
+        field(10; "Total Amount"; Decimal)
+        {
+            FieldClass = FlowField;
+            CalcFormula = sum("CFS Line".Amount where("Doc No." = field("No.")));
+        }
+
+        /// #1708 — the same aggregate with AL's leading sign. Must be -123, not 123 and
+        /// not 0 (0 is what the refused-formula behaviour produced).
+        field(11; "Negated Total"; Decimal)
+        {
+            FieldClass = FlowField;
+            CalcFormula = -sum("CFS Line".Amount where("Doc No." = field("No.")));
+        }
+
+        /// #1709 — const() on a Boolean. Only the two Open rows: 100 + 3 = 103.
+        field(12; "Open Total"; Decimal)
+        {
+            FieldClass = FlowField;
+            CalcFormula = sum("CFS Line".Amount where("Doc No." = field("No."),
+                                                     Open = const(true)));
+        }
+
+        /// #1709 — const() driving a count. Exactly one row is not Open.
+        field(13; "Closed Count"; Integer)
+        {
+            FieldClass = FlowField;
+            CalcFormula = count("CFS Line" where("Doc No." = field("No."),
+                                                 Open = const(false)));
+        }
+
+        /// #1709 — filter() alternation on an Option field: Open|Released = 100 + 20 = 120.
+        field(14; "Active Total"; Decimal)
+        {
+            FieldClass = FlowField;
+            CalcFormula = sum("CFS Line".Amount where("Doc No." = field("No."),
+                                                     Status = filter(Open | Released)));
+        }
+
+        /// #1709 — filter() range on an Integer field: entries 2..3 = 20 + 3 = 23.
+        field(15; "Range Total"; Decimal)
+        {
+            FieldClass = FlowField;
+            CalcFormula = sum("CFS Line".Amount where("Doc No." = field("No."),
+                                                     "Entry No." = filter(2 .. 3)));
+        }
+
+        /// #1709, the exclusion direction — two const conditions that no row satisfies
+        /// together (the only Closed row is Open). Must be 0, which only holds if BOTH
+        /// conditions are applied and ANDed.
+        field(16; "Unmatched Total"; Decimal)
+        {
+            FieldClass = FlowField;
+            CalcFormula = sum("CFS Line".Amount where("Doc No." = field("No."),
+                                                     Status = const(Closed),
+                                                     Open = const(false)));
+        }
+
+        /// #1708 + #1709 together: the negated sum of the Released rows only = -20.
+        field(17; "Negated Released Total"; Decimal)
+        {
+            FieldClass = FlowField;
+            CalcFormula = -sum("CFS Line".Amount where("Doc No." = field("No."),
+                                                      Status = const(Released)));
+        }
+    }
+
+    keys
+    {
+        key(PK; "No.") { Clustered = true; }
+    }
+}

--- a/tests/runner-extras/calcformula-sign-and-filters/CfsLine.Table.al
+++ b/tests/runner-extras/calcformula-sign-and-filters/CfsLine.Table.al
@@ -2,7 +2,7 @@
 /// The source table the FlowFields in "CFS Header" aggregate. The seeded rows differ in
 /// Amount, Open and Status so that each where-condition shape selects a DIFFERENT subset.
 /// </summary>
-table 64220 "CFS Line"
+table 64260 "CFS Line"
 {
     DataClassification = CustomerContent;
 

--- a/tests/runner-extras/calcformula-sign-and-filters/CfsLine.Table.al
+++ b/tests/runner-extras/calcformula-sign-and-filters/CfsLine.Table.al
@@ -1,0 +1,25 @@
+/// <summary>
+/// The source table the FlowFields in "CFS Header" aggregate. The seeded rows differ in
+/// Amount, Open and Status so that each where-condition shape selects a DIFFERENT subset.
+/// </summary>
+table 64220 "CFS Line"
+{
+    DataClassification = CustomerContent;
+
+    fields
+    {
+        field(1; "Entry No."; Integer) { }
+        field(2; "Doc No."; Code[20]) { }
+        field(3; Amount; Decimal) { }
+        field(4; Open; Boolean) { }
+        field(5; Status; Option)
+        {
+            OptionMembers = Open,Released,Closed;
+        }
+    }
+
+    keys
+    {
+        key(PK; "Entry No.") { Clustered = true; }
+    }
+}

--- a/tests/runner-extras/calcformula-sign-and-filters/CfsTests.Codeunit.al
+++ b/tests/runner-extras/calcformula-sign-and-filters/CfsTests.Codeunit.al
@@ -8,7 +8,7 @@
 // The seed rows are chosen so that every FlowField lands on a DIFFERENT value. An
 // implementation that ignores the sign, ignores the conditions, or returns the type default
 // fails at least one assertion in every test below.
-codeunit 64226 "CFS Tests"
+codeunit 64266 "CFS Tests"
 {
     Subtype = Test;
 

--- a/tests/runner-extras/calcformula-sign-and-filters/CfsTests.Codeunit.al
+++ b/tests/runner-extras/calcformula-sign-and-filters/CfsTests.Codeunit.al
@@ -1,0 +1,140 @@
+// Issues #1708 (a signed FlowField formula) and #1709 (const()/filter() where-conditions).
+//
+// Before the fix both failed SILENTLY: `-sum(...)` was refused by the CalcFormula parser, so
+// the FlowField's CalculationFormula stayed EmptyFormula and CalcFields() left the field at 0;
+// const()/filter() conditions were dropped, so the FlowField aggregated rows AL had excluded
+// and returned a plausible wrong number. Nothing threw in either case.
+//
+// The seed rows are chosen so that every FlowField lands on a DIFFERENT value. An
+// implementation that ignores the sign, ignores the conditions, or returns the type default
+// fails at least one assertion in every test below.
+codeunit 64226 "CFS Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit "CFS Assert";
+
+    local procedure Seed(): Code[20]
+    var
+        CfsLine: Record "CFS Line";
+        CfsHeader: Record "CFS Header";
+    begin
+        CfsLine.DeleteAll();
+        CfsHeader.DeleteAll();
+
+        CfsHeader.Init();
+        CfsHeader."No." := 'D1';
+        CfsHeader.Insert(false);
+
+        // Entry 1: Open, Status Open,     100
+        // Entry 2: not Open, Status Released, 20
+        // Entry 3: Open, Status Closed,     3
+        AddLine(1, 'D1', 100, true, CfsLine.Status::Open);
+        AddLine(2, 'D1', 20, false, CfsLine.Status::Released);
+        AddLine(3, 'D1', 3, true, CfsLine.Status::Closed);
+
+        // A second document, never asserted on: proves the parent link still filters.
+        AddLine(4, 'D2', 999, true, CfsLine.Status::Open);
+
+        exit('D1');
+    end;
+
+    local procedure AddLine(EntryNo: Integer; DocNo: Code[20]; Amt: Decimal; IsOpen: Boolean; Sts: Option)
+    var
+        CfsLine: Record "CFS Line";
+    begin
+        CfsLine.Init();
+        CfsLine."Entry No." := EntryNo;
+        CfsLine."Doc No." := DocNo;
+        CfsLine.Amount := Amt;
+        CfsLine.Open := IsOpen;
+        CfsLine.Status := Sts;
+        CfsLine.Insert(false);
+    end;
+
+    [Test]
+    procedure SignedFormulaNegatesTheAggregate()
+    var
+        CfsHeader: Record "CFS Header";
+    begin
+        // [GIVEN] Three lines on D1 totalling 123, plus 999 on another document.
+        CfsHeader.Get(Seed());
+
+        // [WHEN] Both the plain and the signed sum of the same rows are calculated.
+        CfsHeader.CalcFields("Total Amount", "Negated Total");
+
+        // [THEN] The unsigned formula is unchanged...
+        Assert.AreEqual(123, CfsHeader."Total Amount",
+            'the unsigned sum must aggregate only this document''s lines');
+
+        // [THEN] ...and the signed one is its negation. 0 is the pre-fix value (the formula
+        // was refused outright), 123 is the value a dropped sign would give.
+        Assert.AreEqual(-123, CfsHeader."Negated Total",
+            '-sum(...) must negate the aggregate, not drop the sign and not stay at 0');
+    end;
+
+    [Test]
+    procedure ConstConditionExcludesRows()
+    var
+        CfsHeader: Record "CFS Header";
+    begin
+        // [GIVEN] Two of the three D1 lines are Open (100 and 3); one is not (20).
+        CfsHeader.Get(Seed());
+
+        // [WHEN]
+        CfsHeader.CalcFields("Total Amount", "Open Total", "Closed Count");
+
+        // [THEN] const(true) keeps only the Open rows — a dropped condition would give 123.
+        Assert.AreEqual(103, CfsHeader."Open Total",
+            'Open = const(true) must exclude the non-Open line');
+        Assert.AreNotEqual(CfsHeader."Total Amount", CfsHeader."Open Total",
+            'the const condition must actually change which rows are summed');
+
+        // [THEN] const(false) selects the complement, through a count formula.
+        Assert.AreEqual(1, CfsHeader."Closed Count",
+            'Open = const(false) must count exactly the one non-Open line');
+    end;
+
+    [Test]
+    procedure FilterConditionAppliesAlternationAndRange()
+    var
+        CfsHeader: Record "CFS Header";
+    begin
+        // [GIVEN] Statuses Open / Released / Closed on entries 1 / 2 / 3.
+        CfsHeader.Get(Seed());
+
+        // [WHEN]
+        CfsHeader.CalcFields("Active Total", "Range Total");
+
+        // [THEN] filter(Open|Released) is one expression selecting two option members.
+        Assert.AreEqual(120, CfsHeader."Active Total",
+            'Status = filter(Open|Released) must sum the Open and Released lines only');
+
+        // [THEN] filter(2..3) is a range over the entry numbers.
+        Assert.AreEqual(23, CfsHeader."Range Total",
+            '"Entry No." = filter(2..3) must sum entries 2 and 3 only');
+    end;
+
+    [Test]
+    procedure ConditionsAreAndedSoAnImpossibleCombinationSumsToZero()
+    var
+        CfsHeader: Record "CFS Header";
+    begin
+        // [GIVEN] The only Closed line (entry 3) IS Open, so no line is both Closed and
+        // not Open.
+        CfsHeader.Get(Seed());
+
+        // [WHEN]
+        CfsHeader.CalcFields("Unmatched Total", "Negated Released Total");
+
+        // [THEN] Both conditions apply, and they narrow together — dropping either one
+        // would yield 3 or 20 rather than nothing.
+        Assert.AreEqual(0, CfsHeader."Unmatched Total",
+            'Status = const(Closed) AND Open = const(false) must select no line at all');
+
+        // [THEN] Sign and const condition compose: only the Released line, negated.
+        Assert.AreEqual(-20, CfsHeader."Negated Released Total",
+            '-sum(... Status = const(Released)) must negate the filtered subtotal');
+    end;
+}

--- a/tests/runner-extras/calcformula-sign-and-filters/app.json
+++ b/tests/runner-extras/calcformula-sign-and-filters/app.json
@@ -1,0 +1,25 @@
+{
+  "id": "3f6c1d92-5a47-4e18-9b2c-7d0e4a6f8b51",
+  "name": "Runner Extras - CalcFormula Sign And Filters",
+  "publisher": "AL Runner",
+  "version": "1.0.0.0",
+  "brief": "Proves a signed FlowField formula (-sum) negates its aggregate and that const()/filter() where-conditions actually exclude rows.",
+  "description": "Issues #1708 and #1709. A `-sum(...)` CalcFormula was refused by the parser, so the FlowField stayed at EmptyFormula and read back as 0 with nothing thrown; `const(...)` and `filter(...)` where-conditions were dropped, so the FlowField aggregated rows AL had excluded — a plausible wrong number. Both are now parsed, carried on ParsedCalcFormula, built into MetaCalcFormula (reverseSign / FilterType CONST + FILTER) and applied at CalcFields time (NCLMetaCalculationFormula.NegateValue and FilterExpression.Evaluate). Every FlowField here is asserted to a DIFFERENT concrete value, so neither 'sum everything' nor 'return 0' can pass.",
+  "privacyStatement": "",
+  "EULA": "",
+  "help": "",
+  "url": "",
+  "logo": "",
+  "dependencies": [],
+  "screenshots": [],
+  "platform": "1.0.0.0",
+  "application": "27.0.0.0",
+  "idRanges": [
+    {
+      "from": 64220,
+      "to": 64239
+    }
+  ],
+  "runtime": "14.0",
+  "features": []
+}

--- a/tests/runner-extras/calcformula-sign-and-filters/app.json
+++ b/tests/runner-extras/calcformula-sign-and-filters/app.json
@@ -16,8 +16,8 @@
   "application": "27.0.0.0",
   "idRanges": [
     {
-      "from": 64220,
-      "to": 64239
+      "from": 64260,
+      "to": 64279
     }
   ],
   "runtime": "14.0",

--- a/tests/runner-extras/extension-object-metadata/EomAssert.Codeunit.al
+++ b/tests/runner-extras/extension-object-metadata/EomAssert.Codeunit.al
@@ -1,0 +1,21 @@
+/// <summary>Minimal assertion helper for this runner-extras app (own ID range).</summary>
+codeunit 64226 "EOM Assert"
+{
+    procedure AreEqual(Expected: Variant; Actual: Variant; Msg: Text)
+    begin
+        if Format(Expected) <> Format(Actual) then
+            Error('Assert.AreEqual failed. Expected:<%1>. Actual:<%2>. %3', Expected, Actual, Msg);
+    end;
+
+    procedure IsTrue(Condition: Boolean; Msg: Text)
+    begin
+        if not Condition then
+            Error('Assert.IsTrue failed. %1', Msg);
+    end;
+
+    procedure ExpectedError(Expected: Text; Actual: Text)
+    begin
+        if StrPos(Actual, Expected) = 0 then
+            Error('Assert.ExpectedError failed. Expected substring:<%1>. Actual:<%2>.', Expected, Actual);
+    end;
+}

--- a/tests/runner-extras/extension-object-metadata/EomCard.Page.al
+++ b/tests/runner-extras/extension-object-metadata/EomCard.Page.al
@@ -1,0 +1,31 @@
+/// The page whose id a pageextension in this bundle deliberately reuses (#1710).
+page 64223 "EOM Card"
+{
+    PageType = Card;
+    SourceTable = "EOM Item";
+
+    layout
+    {
+        area(content)
+        {
+            field(CodeField; Rec."Code") { ApplicationArea = All; }
+            field(DescField; Rec."Description") { ApplicationArea = All; }
+        }
+    }
+}
+
+/// A second page, extended by `pageextension 64223` below so that the id collision is
+/// between objects that genuinely have nothing to do with each other.
+page 64224 "EOM Other"
+{
+    PageType = Card;
+    SourceTable = "EOM Item";
+
+    layout
+    {
+        area(content)
+        {
+            field(OtherCodeField; Rec."Code") { ApplicationArea = All; }
+        }
+    }
+}

--- a/tests/runner-extras/extension-object-metadata/EomItem.Table.al
+++ b/tests/runner-extras/extension-object-metadata/EomItem.Table.al
@@ -1,0 +1,14 @@
+/// Base table behind the page and the pageextension in this bundle.
+table 64220 "EOM Item"
+{
+    DataClassification = CustomerContent;
+
+    fields
+    {
+        field(1; "Code"; Code[20]) { }
+        field(2; "Description"; Text[100]) { }
+        field(3; "Note"; Text[100]) { }
+    }
+
+    keys { key(PK; "Code") { Clustered = true; } }
+}

--- a/tests/runner-extras/extension-object-metadata/EomItemExt.TableExt.al
+++ b/tests/runner-extras/extension-object-metadata/EomItemExt.TableExt.al
@@ -1,0 +1,22 @@
+/// #1711(a): an Option field ADDED BY A TABLEEXTENSION.
+///
+/// The extension-field parse used to drop OptionMembers, so this field reached
+/// NCLOptionMetadata with an empty option string and Format() of any value answered
+/// with nothing to answer from — the same defect class #1674 fixed for base tables.
+/// The blank first member is deliberate: it is what makes the member COUNT, not just
+/// the member names, observable.
+tableextension 64221 "EOM Item Ext" extends "EOM Item"
+{
+    fields
+    {
+        field(50000; "EOM Status"; Option)
+        {
+            DataClassification = CustomerContent;
+            OptionMembers = ,Open,Released;
+        }
+        field(50001; "EOM Plain"; Integer)
+        {
+            DataClassification = CustomerContent;
+        }
+    }
+}

--- a/tests/runner-extras/extension-object-metadata/EomPageExts.PageExt.al
+++ b/tests/runner-extras/extension-object-metadata/EomPageExts.PageExt.al
@@ -1,0 +1,29 @@
+/// #1710: a pageextension whose object id is ALSO the id of `page 64223 "EOM Card"`.
+/// AL gives `page` and `pageextension` separate id namespaces, so this is legal — and it
+/// used to overwrite the page's entry, taking the page's SourceTable and its whole
+/// control map with it.
+pageextension 64223 "EOM Other Ext" extends "EOM Other"
+{
+    layout
+    {
+        addlast(content)
+        {
+            field(OtherNoteField; Rec."Note") { ApplicationArea = All; }
+        }
+    }
+}
+
+/// #1711(b): a field control added to "EOM Card" by a pageextension. Its control id lives
+/// in THIS object's id space (BC's IdSpace.GetMemberId hashes the declaring object's id),
+/// which is what a TestPage asks for when the test drives NoteField.
+pageextension 64225 "EOM Card Ext" extends "EOM Card"
+{
+    layout
+    {
+        addlast(content)
+        {
+            field(NoteField; Rec."Note") { ApplicationArea = All; }
+        }
+        modify(DescField) { Editable = false; }
+    }
+}

--- a/tests/runner-extras/extension-object-metadata/EomTests.Codeunit.al
+++ b/tests/runner-extras/extension-object-metadata/EomTests.Codeunit.al
@@ -1,0 +1,175 @@
+/// AL-level RED→GREEN for #1710 and #1711(b), plus the OptionMembers half of #1711(a).
+///
+/// The AutoIncrement half of #1711(a) has no AL-level test on purpose: the AL compiler
+/// rejects `AutoIncrement` inside a tableextension outright (AL0404 — "Property
+/// 'AutoIncrement' is not allowed on a table extension"), so no legal AL can reach it.
+/// It is pinned at parser level in AlRunner.Tests/PageExtensionParserTests.cs instead.
+codeunit 64227 "EOM Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit "EOM Assert";
+
+    /// Leaves exactly ONE row in the table, so `TestPage.First()` lands on it. Tests share the
+    /// in-memory table, and First() sorts by the primary key — without this, a row seeded by an
+    /// earlier test wins and every assertion reads the wrong record.
+    local procedure SeedItem(ItemCode: Code[20]; Note: Text[100])
+    var
+        Item: Record "EOM Item";
+    begin
+        Item.DeleteAll();
+        Item.Init();
+        Item."Code" := ItemCode;
+        Item."Description" := 'desc of ' + ItemCode;
+        Item."Note" := Note;
+        Item.Insert();
+    end;
+
+    // ── #1710: page 64223 and pageextension 64223 are different objects ───────
+
+    [Test]
+    procedure PageKeepsItsSourceTable_WhenAPageExtensionSharesItsId()
+    var
+        Card: TestPage "EOM Card";
+    begin
+        // [GIVEN] page 64223 "EOM Card" (SourceTable = "EOM Item") and, in the same app,
+        //         pageextension 64223 "EOM Other Ext" extending a DIFFERENT page
+        SeedItem('ITEM-A', 'note-a');
+
+        // [WHEN] the page is opened as a TestPage
+        Card.OpenView();
+        Assert.IsTrue(Card.First(), 'the page must find the seeded row');
+
+        // [THEN] it is still bound to "EOM Item" and its own controls still resolve.
+        // Before the split the pageextension's entry won and brought SourceTableName = ""
+        // plus an empty control map, so the page resolved no source table at all.
+        Assert.AreEqual('ITEM-A', Card.CodeField.Value(), 'the page''s own control must resolve');
+        Assert.AreEqual('desc of ITEM-A', Card.DescField.Value(), 'the second control must resolve');
+        Card.Close();
+    end;
+
+    [Test]
+    procedure PageOfTheOtherObject_IsStillItsOwnPage()
+    var
+        Other: TestPage "EOM Other";
+    begin
+        // Opposite direction: fixing the collision must not cost "EOM Other" the control its
+        // pageextension 64223 adds. Both pages resolve, each with its own controls.
+        SeedItem('ITEM-B', 'note-b');
+        Other.OpenView();
+        Assert.IsTrue(Other.First(), 'the other page must find the seeded row');
+        Assert.AreEqual('ITEM-B', Other.OtherCodeField.Value(), 'its own control must resolve');
+        Assert.AreEqual('note-b', Other.OtherNoteField.Value(),
+            'the control its pageextension adds must resolve');
+        Other.Close();
+    end;
+
+    // ── #1711(b): a control added by a pageextension ─────────────────────────
+
+    [Test]
+    procedure PageExtensionAddedControl_ResolvesToItsTableField()
+    var
+        Card: TestPage "EOM Card";
+    begin
+        // [GIVEN] pageextension 64225 adds `field(NoteField; Rec."Note")` via addlast
+        SeedItem('ITEM-C', 'note-c');
+
+        // [WHEN] the test drives that control
+        Card.OpenView();
+        Assert.IsTrue(Card.First(), 'the page must find the seeded row');
+
+        // [THEN] it reads the row's Note. Before the fix every pageextension stored an empty
+        // control map, so this threw "testpage-control-binding — this control is bound
+        // neither to a field of the page's source table nor to a page variable".
+        Assert.AreEqual('note-c', Card.NoteField.Value(), 'extension-added control must read Rec.Note');
+        Card.Close();
+    end;
+
+    [Test]
+    procedure PageExtensionAddedControl_WritesThroughToTheRecord()
+    var
+        Item: Record "EOM Item";
+        Card: TestPage "EOM Card";
+    begin
+        SeedItem('ITEM-D', 'before');
+
+        Card.OpenEdit();
+        Assert.IsTrue(Card.First(), 'the page must find the seeded row');
+        Card.NoteField.SetValue('after');
+        Card.Close();
+
+        Item.Get('ITEM-D');
+        Assert.AreEqual('after', Item."Note", 'the extension-added control must write to Rec.Note');
+    end;
+
+    [Test]
+    procedure PageExtensionModifyBlock_DoesNotReKeyTheBaseControl()
+    var
+        Card: TestPage "EOM Card";
+    begin
+        // Opposite direction: `modify(DescField)` in pageextension 64225 declares no NEW
+        // control, so DescField must still resolve in the BASE page's id space. Keying every
+        // control seen inside an extension under the extension's id would break exactly this.
+        SeedItem('ITEM-E', 'note-e');
+        Card.OpenView();
+        Assert.IsTrue(Card.First(), 'the page must find the seeded row');
+        Assert.AreEqual('desc of ITEM-E', Card.DescField.Value(), 'modify() must not re-key the control');
+        Card.Close();
+    end;
+
+    // ── #1711(a): a tableextension's Option field keeps its OptionMembers ────
+
+    [Test]
+    procedure TableExtensionOptionField_FormatsItsMemberNames()
+    var
+        Item: Record "EOM Item";
+    begin
+        // [GIVEN] tableextension 64221 adds `field(50000; "EOM Status"; Option)` with
+        //         OptionMembers = ,Open,Released  (blank member first)
+        SeedItem('ITEM-F', 'note-f');
+        Item.Get('ITEM-F');
+
+        // [THEN] the member COUNT is right, not just the names. `::Released` compiles to
+        // ordinal 2, which only formats as 'Released' if the blank first member is present in
+        // the runner's option string too — drop it and ordinal 2 runs off the end. Without
+        // the extension field's OptionMembers at all there was no name to format to.
+        Item."EOM Status" := Item."EOM Status"::Released;
+        Item.Modify();
+        Item.Get('ITEM-F');
+        Assert.AreEqual('Released', Format(Item."EOM Status"), 'ordinal 2 must format as Released');
+
+        Item."EOM Status" := Item."EOM Status"::Open;
+        Assert.AreEqual('Open', Format(Item."EOM Status"), 'ordinal 1 must format as Open');
+    end;
+
+    [Test]
+    procedure TableExtensionOptionField_RejectsAMemberItDoesNotDeclare()
+    var
+        Item: Record "EOM Item";
+    begin
+        // Opposite direction: OptionMembers establishes the member SET, so a name outside it
+        // must not evaluate. An empty option string would reject everything, which is why the
+        // accepted name is pinned in the same test.
+        SeedItem('ITEM-G', 'note-g');
+        Item.Get('ITEM-G');
+
+        Assert.IsTrue(not Evaluate(Item."EOM Status", 'Archived'),
+            'Evaluate must reject a member the field does not declare');
+        Assert.IsTrue(Evaluate(Item."EOM Status", 'Open'),
+            'Evaluate must accept a declared member');
+        Assert.AreEqual('Open', Format(Item."EOM Status"), 'the accepted member must round-trip');
+    end;
+
+    [Test]
+    procedure TableExtensionPlainField_KeepsItsTypeDefault()
+    var
+        Item: Record "EOM Item";
+    begin
+        // Opposite direction for the parse as a whole: giving extension fields their full
+        // property set must not give a field properties it never declared.
+        SeedItem('ITEM-H', 'note-h');
+        Item.Get('ITEM-H');
+        Assert.AreEqual(0, Item."EOM Plain", 'a plain extension field must stay at its type default');
+    end;
+}

--- a/tests/runner-extras/extension-object-metadata/app.json
+++ b/tests/runner-extras/extension-object-metadata/app.json
@@ -1,0 +1,25 @@
+{
+  "id": "b41d7e60-2c8f-4a95-9d31-6f0a7c25e8b4",
+  "name": "Runner Extras - Extension Object Metadata",
+  "publisher": "AL Runner",
+  "version": "1.0.0.0",
+  "brief": "Proves a pageextension no longer clobbers a page of the same id, and that tableextension/pageextension fields keep the properties the parser used to drop.",
+  "description": "Issues #1710 and #1711. #1710: page and pageextension share an AL id namespace in the runner's _parsedPages, so `page 64223` and `pageextension 64223` collided — the extension was written second and brought SourceTableName = \"\" and an empty control map, erasing the real page's source table and every control binding. #1711: tableextension fields were parsed without OptionMembers (wrong NCLOptionMetadata member count, #1674's defect class) and without AutoIncrement, and pageextension field controls were not parsed at all, so a TestPage could not resolve a control added by addfirst/addlast.",
+  "privacyStatement": "",
+  "EULA": "",
+  "help": "",
+  "url": "",
+  "logo": "",
+  "dependencies": [],
+  "screenshots": [],
+  "platform": "1.0.0.0",
+  "application": "27.0.0.0",
+  "idRanges": [
+    {
+      "from": 64220,
+      "to": 64249
+    }
+  ],
+  "runtime": "14.0",
+  "features": []
+}


### PR DESCRIPTION
Closes #1708
Closes #1709
Closes #1710
Closes #1711
Closes #1712
Closes #1713
Closes #1714

Every issue split out of #1696 when the parser migration deliberately preserved behaviour rather than changing it inside a refactor, plus the two found while doing that work. Each was implemented independently and then integrated and re-verified together — two defects only the combined run exposed are described at the bottom.

## What changed

### #1708 + #1709 — signed CalcFormulas and `const()` / `filter()` conditions (`c5bfb8b4`)

A `-sum(...)` was refused, so the FlowField stayed at `EmptyFormula` and read back as **0**. `const()` / `filter()` where-conditions were dropped, so FlowFields aggregated rows AL had excluded — a plausible wrong number.

Both are now parsed (`ParsedCalcFormula.Negated`; `ParsedCalcFilter.Kind` ∈ Field/Const/Filter/FlowFilter), built into `MetaCalcFormula` (`reverseSign`, one `MetaFilter` per condition with FilterType FIELD/CONST/FILTER), and **applied at CalcFields time**.

Two things worth calling out:

- **`FlowFieldPatches` was the missing half.** It ignored non-FIELD filters entirely, so wiring only the parser and `NclMetaTableBuilder` — which is all the issues asked for — would have produced correct metadata and still summed unfiltered rows.
- Negation now uses BC's own `NCLMetaCalculationFormula.NegateValue`. A local `-x` covers Sum/Average but is wrong for `-exist`, of which BaseApp ships 5.

Scale of the bug, measured by parsing all **2055** BaseApp CalcFormulas through the tree: **100 signed, 1215 const, 285 filter** conditions were being silently mishandled.

An unrecognised condition shape or sign token now refuses the **whole** formula rather than aggregating over the subset it understood.

### #1710 + #1711 — pageextensions clobbering pages, extension fields losing properties (`11582dc3`)

`_parsedPages` was keyed on object id alone for both `page` and `pageextension`, which AL gives separate id namespaces. Extensions were written second and won, taking the real page's SourceTable and control map with them. Split into `_parsedPages` / `_parsedPageExtensions`, mirroring the two-dictionary fix `AlReportParser` already had. Readers updated include two the issue did not list: `EnumerateKnownAlObjects` and `PopulateNCLMetadataCache` / `BuildNCLMetaForm`.

`ParsePageFieldBindings` now takes a `SyntaxNode?` so one subtree walk serves both `PageLayoutSyntax` and `PageExtensionLayoutSyntax`, and `GetPageControlFieldMap` merges an extension's controls into the base page. `ParseFieldSyntax` lost `tableLevelExtras`, so extension fields keep `OptionMembers` and `AutoIncrement`.

The id space an extension-added control lives in was **determined empirically, not assumed**: BC asks `LiveNavTestPage.GetField` for `GetMemberId(<pageextension id>, "NoteField")`, never the base page's. Pinned by `MemberIdMatchesTheIdBcActuallyEmitted`.

**Two corrections to the issue text**, both found while implementing:
- AL **forbids** `AutoIncrement` on a tableextension (`AL0404`), so that half of #1711(a) is unreachable from AL and is pinned at parser level only. It still matters: `BcAppSymbolCache.TableExtensions` reads it off precompiled `.app` symbols and always has.
- The AL compiler already enforces that a pageextension of page X contributes no control to page Y (`AL0132`), so that negative cannot be written in AL and moved to a parser-level test.

### #1714 — a report's Caption parsed twice, one copy never read (`6251caa3`)

`_parsedObjectCaptions[("Report", id)]` was computed on every parse and never read. Consolidated onto `ParsedReport.Caption` with `SourceCaptionFor` reading through, so `AllObjVirtualTable` can treat Report like every other kind — the "make it uniform" cleanup is now a no-op instead of a silent authority switch.

The audit was re-verified against the post-#1696 code rather than carried over, which mattered: `AlObjectDeclParser` now derives its kind from the shared `AlObjectKindName`, which *does* return `"Report"`, so `AllObjVirtualTable` could have become a Report reader the original audit never had. It has not — the new `ObjectDeclKinds` set excludes it.

### #1713 — raw `DirectoryNotFoundException`, exit 134 (`5f9daa72`)

Bundle roots are validated at argument-parse time, before BC artifact selection and the patch pass, so a mistyped path fails in under a second instead of crashing after ~6s. Exit **2** — not a new code; it is what every other CLI usage error in `Program.cs` already returns and what `--help` already documents.

The submodule hint is evidence-based: it fires only when a `.gitmodules` in an ancestor declares the missing path. A typo *inside* a checked-out submodule gets no hint, because that would send the reader down the wrong road.

### #1712 — parser tests silently depending on a serial collection (`5bbaad36`)

Option 3 from the issue: a guard that fails when a test class touching the `RecordPatches` parse statics omits `[Collection(RecordPatchesSerialCollection.Name)]`.

Detection is deliberately hybrid — reflection for which types are test classes and what `[Collection]` they carry, source scanning for whether they touch the statics. Those statics are `private static` reached via `System.Reflection`, so there is **no IL-level reference to walk**; the names exist only as string literals. The scan throws if it cannot resolve the source directory, because a detector that silently checks nothing reads as a passing guard.

Verified by two live RED runs (stripping the attribute off an existing class; adding a fresh unattributed offender), not merely by asserting the current tree is clean.

**Option 1 in that issue — making parse entry points return their results instead of publishing to statics — is NOT done here.** It rewrites every parser entry point and would have collided with the four other changes. This is the stopgap the issue itself calls "worth having regardless"; #1712's real fix remains open.

## Two defects only the combined run found

Both are recorded because each passed in isolation:

1. **`f9ba025d`** — #1713's two end-to-end tests asserted "no such directory" against the literal path from the issue, `tests/al-language/tests/al-language`. The corpus genuinely lives at that nested path, so with the submodule checked out — as in CI — that directory **exists** and the runner ran it (1904 tests, exit 0). They passed only in a worktree with no submodule. Rebuilt as the same doubled-prefix shape in a temp tree.
2. **`c60d4a75`** — the two new runner-extras fixtures independently picked ids from 64220, so `table 64220` and `codeunit 64226` were each declared twice. Each bundle passes alone, but the suite runs the whole tree as **one merged bundle**, where extension-object-metadata's tests read the calcformula bundle's table. Moved calcformula to 64260-64279.

## Verification

All three gates, on the fully integrated tree, against BC 28.1.49838.50794 on Linux:

| Gate | Result |
|---|---|
| `AlRunner.Tests` | **373/373** |
| `tests/runner-extras` (`--strict`, both package caches) | **114/114** |
| `tests/al-language` corpus (`--strict`) | **1904/1904** |

114 reconciles as 102 before this PR + 4 (calcformula) + 8 (extension-object-metadata). 373 as 310 + 29 + 12 + 5 + 10 + 7.

## Reviewer should know

- **Two semantic changes without service-tier validation.** FlowFields using `const`/`filter` now return different (correct-per-AL) values, and `GetPageControlFieldMap` returns more entries for every page a pageextension extends. Both are proven by new runner-extras bundles, but #1708/#1709/#1711 asked for al-language corpus tests validated against real BC — `tests/al-language/` is read-only here and there is no service tier, so those still want adding.
- **New issue #1716** filed for `field(filter(X))` / `field(upperlimit(X))` conditions (~105 in BaseApp), which are now parsed as their own kind and log `RUNNER GAP` rather than being silently dropped — a visible gap, not a plausible wrong number.
- `IsPageParsed(N)` now returns **false** for an id that is only a pageextension; reachable only via a path not expressible in AL.
- **AllObj** now lists both a `Page N` and a `PageExtension N` row where it previously listed whichever parsed last.
- A pageextension's own `InsertAllowed` is parsed and stored but not consulted; previously it applied only by accident, on id collision. Making it genuinely affect the base page is a separate change, left alone.

`CHANGELOG.md` untouched per `.claude/rules/no-changelog-edits.md`. Nothing under `tests/al-language/` was modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AX8MEx4iECELaZNisb9DCW)_