### PR TITLE
Table Metadata virtual table, pr-check bypass fix, and the upstream-BC-tests rule

### DIFF
--- a/.claude/rules/al-language-submodule.md
+++ b/.claude/rules/al-language-submodule.md
@@ -42,8 +42,14 @@ If a test must assert runner-only behaviour (e.g. that a specific surface
 throws `RunnerOutOfScopeException` with reason `email-smtp`), it goes in
 `tests/runner-extras/`, not in the corpus.
 
+The converse is a hard rule too: a test asserting plain BC behaviour may **not**
+be written as a runner-local test just because that is quicker — it goes upstream
+so a real service tier can adjudicate it. See
+`bc-behavior-tests-go-upstream.md`.
+
 ## Sister rules
 
+- `bc-behavior-tests-go-upstream.md` — which repo a new test belongs in, and why
 - `precompiled-dll-respect.md` — what we may not rewrite in BC DLLs
 - `loud-failures.md` — when to throw `RunnerOutOfScopeException`
 - `no-assumption-fixes.md` — investigate before patching

--- a/.claude/rules/bc-behavior-tests-go-upstream.md
+++ b/.claude/rules/bc-behavior-tests-go-upstream.md
@@ -1,0 +1,76 @@
+# Tests of plain BC behaviour belong upstream, not in this repo
+
+A test that asserts **what Business Central does** — with nothing runner-specific
+in the claim — MUST live in the upstream corpus
+[`StefanMaron/BusinessCentral.AL.Language.Tests`](https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests)
+(the `tests/al-language/` submodule), where it is validated against a **running BC
+service tier**. It must not be written as a runner-local test in
+`tests/runner-extras/`.
+
+## Why — a runner-local BC test proves nothing
+
+The corpus is the spec *because* every test in it has been run against real BC.
+A BC-behaviour test that has only ever run against AL Runner is not evidence about
+BC; it is a transcript of **our belief** about BC, written by the same reasoning
+that wrote the runtime.
+
+So when the runner is wrong, such a test does not fail — it was authored to match
+what the runner did. It goes green, the bug is now pinned as intended behaviour,
+and every future change is measured against the wrong baseline. The suite gets
+louder and less trustworthy at the same time.
+
+That is the whole argument in one line: **an unvalidated BC test cannot prove the
+runner correct, because it inherits the runner's errors as its expectations.**
+Green means "the runner agrees with itself".
+
+## The test
+
+Ask: *if AL Runner did not exist, would this test still be a meaningful statement
+about AL/BC?*
+
+- **Yes → upstream.** `Record.Insert` semantics, FlowField calculation, key
+  handling, `TestPage` field validation, `Report.Run` execution order, virtual
+  tables such as `AllObj` / `Table Metadata` / `Report Metadata` answering
+  truthfully, Base App codeunits resolving what they resolve. All of it is BC
+  behaviour that a service tier can adjudicate — so a service tier must.
+- **No → `tests/runner-extras/`.** The claim only makes sense *because* this is
+  the runner: `RunnerOutOfScopeException` thrown with a specific reason on a
+  specific surface, AL-output cache HIT/MISS, provisioning-gap messages,
+  multi-bundle/server-mode wiring, per-emitted-assembly module identity, exit
+  codes.
+
+Mixed suite? Split it. The BC assertions go upstream; only the runner-specific
+ones stay. The repo already does this — see the LEAVE-BEHIND note at the top of
+`tests/al-language/.../TestReportRunExecution.al`, which migrated the execution
+tests upstream and deliberately kept exactly one runner-specific
+OOS-classification test behind in `tests/runner-extras/report-run-execution`.
+
+## Workflow when a fix needs a BC-behaviour test
+
+1. Write the test in the **corpus repo** and validate it against a real BC
+   service tier. That run is the proof; without it the test is not admissible.
+2. Land it there, then **bump the submodule pin** in this repo (its own PR — see
+   `al-language-submodule.md`).
+3. Implement the runner fix here and show the corpus test going RED → GREEN
+   against the new pin.
+
+**If you cannot reach a service tier**, you may not substitute a runner-local
+BC-behaviour test to unblock yourself. Say so plainly in the PR/issue and stop at
+the boundary: land the runner fix with whatever runner-specific coverage is
+legitimately available, and record the missing upstream test as follow-up. An
+unvalidated stand-in is worse than an acknowledged gap, because it looks like
+coverage.
+
+## Not a licence to skip TDD
+
+`tdd.md` still applies in full. This rule decides **where** the proving test
+lives, never whether one exists. "It belongs upstream and I could not run a
+service tier" is not an exemption from writing a test — it is a reason the change
+may not be provable yet, which is information the reviewer needs.
+
+## Sister rules
+
+- `al-language-submodule.md` — the corpus is read-only here; how to bump the pin
+- `tdd.md` — every fix needs a RED → GREEN, and tests must prove, not just pass
+- `no-assumption-fixes.md` — understand the AL pattern before patching
+- `file-issues-for-gaps.md` — gaps get tracked, never silently worked around

--- a/.claude/rules/bc-behavior-tests-go-upstream.md
+++ b/.claude/rules/bc-behavior-tests-go-upstream.md
@@ -47,19 +47,36 @@ OOS-classification test behind in `tests/runner-extras/report-run-execution`.
 
 ## Workflow when a fix needs a BC-behaviour test
 
-1. Write the test in the **corpus repo** and validate it against a real BC
-   service tier. That run is the proof; without it the test is not admissible.
-2. Land it there, then **bump the submodule pin** in this repo (its own PR — see
-   `al-language-submodule.md`).
-3. Implement the runner fix here and show the corpus test going RED → GREEN
-   against the new pin.
+The order matters, and step 3 is the one that is never optional.
 
-**If you cannot reach a service tier**, you may not substitute a runner-local
-BC-behaviour test to unblock yourself. Say so plainly in the PR/issue and stop at
-the boundary: land the runner fix with whatever runner-specific coverage is
-legitimately available, and record the missing upstream test as follow-up. An
-unvalidated stand-in is worse than an acknowledged gap, because it looks like
-coverage.
+1. **Write the test** against the corpus repo's conventions (fixtures, `Assert`,
+   file layout) — not as a `runner-extras` bundle you intend to move later.
+2. **Verify it against real BC.** A local BC container with the BC repository is
+   a perfectly good way to do this: publish the app, run the test, confirm it
+   passes for the reason you think it does. This step exists to stop you sending
+   a broken or wrongly-asserted test upstream — it does *not* by itself put the
+   test in the corpus.
+3. **Open a pull request into
+   [`StefanMaron/BusinessCentral.AL.Language.Tests`](https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests).**
+   This is the mandatory step. A test only becomes part of the corpus by being
+   merged into that repo's `main` — a test verified locally and never PR'd is
+   not published, not reviewed, and not available to anyone else.
+4. **After that PR merges, bump the submodule pin** in this repo — its own PR,
+   diff inspected first (see `al-language-submodule.md`).
+5. **Then merge the runner change here**, showing the corpus test going
+   RED → GREEN against the new pin.
+
+So a runner fix for a BC-behaviour gap is normally **two PRs in two repos, in
+that order**: corpus first, runner second. Do not merge the runner change and
+leave the upstream test as a promise — once the fix is in, nothing forces the
+test to follow, and the gap quietly becomes untested behaviour.
+
+**If you cannot verify against real BC at all** (no container, no service tier),
+you may not substitute a runner-local BC-behaviour test to unblock yourself. Say
+so plainly in the PR/issue and stop at the boundary: land the runner fix with
+whatever runner-specific coverage is legitimately available, and record the
+missing upstream test as follow-up. An unvalidated stand-in is worse than an
+acknowledged gap, because it looks like coverage.
 
 ## Not a licence to skip TDD
 

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -3,6 +3,13 @@ name: PR Check
 on:
   pull_request:
     branches: [main]
+    # 'labeled'/'unlabeled' are not in the default event set (opened, synchronize,
+    # reopened), so without them applying the bypass label below triggers no new
+    # run and the stale red X stays -- re-running the failed job just replays the
+    # pre-label payload. 'unlabeled' re-asserts the guard when the label is
+    # removed, so the bypass cannot be applied and then silently withdrawn while
+    # the check still reads green.
+    types: [opened, synchronize, reopened, labeled, unlabeled]
 
 jobs:
   require-tests:

--- a/AlRunner/Patches/BcAppSymbolCache.cs
+++ b/AlRunner/Patches/BcAppSymbolCache.cs
@@ -24,7 +24,11 @@ internal static partial class BcAppSymbolCache
     // v8: Reports carry their per-data-item Columns and their ReferenceSourceFileName,
     //     which together let DependencyReportMetadata synthesize the runtime metadata XML
     //     a precompiled dependency's report ships no compiled form of.
-    private const int CacheVersion = 8;
+    // v9: ParsedTable gained LookupPageName / DrillDownPageName for the Table Metadata
+    // (2000000136) virtual table. A v8 payload deserialises cleanly with both null, so
+    // without this bump every cached dependency would report "declares no lookup page"
+    // for tables that plainly declare one — a silent wrong answer, not a cache miss.
+    private const int CacheVersion = 9;
     private static readonly ConcurrentDictionary<string, AppSymbols> ProcessCache = new(StringComparer.OrdinalIgnoreCase);
 
     internal sealed record AppSymbols(List<ParsedTable> Tables, List<EnumSymbol> Enums, List<QuerySymbol> Queries,
@@ -524,7 +528,17 @@ internal static partial class BcAppSymbolCache
         var tableProps = SymbolProperties(table);
         var isTemporary = tableProps.TryGetValue("TableType", out var tableType)
             && string.Equals(tableType, "Temporary", StringComparison.OrdinalIgnoreCase);
-        return new ParsedTable(tableId, tableName, fields, pkFieldIds, secondaryKeys, isTemporary);
+        // Page-resolution properties for the Table Metadata (2000000136) virtual table. The
+        // symbol file states these as the page's NAME, not its id, and is inconsistent about
+        // the trailing casing — Base Application 28.1 carries both "LookupPageID" and
+        // "LookupPageId" across different tables. SymbolProperties is case-insensitive, so
+        // one lookup covers both spellings; the name is resolved to an id at row-build time.
+        tableProps.TryGetValue("LookupPageId", out var lookupPageName);
+        tableProps.TryGetValue("DrillDownPageId", out var drillDownPageName);
+        return new ParsedTable(tableId, tableName, fields, pkFieldIds, secondaryKeys, isTemporary,
+            DataPerCompany: true,
+            LookupPageName: string.IsNullOrWhiteSpace(lookupPageName) ? null : lookupPageName,
+            DrillDownPageName: string.IsNullOrWhiteSpace(drillDownPageName) ? null : drillDownPageName);
     }
 
     private static EnumSymbol? TryParseEnumSymbol(JsonElement enumType)

--- a/AlRunner/Patches/RecordPatches.AlSourceParser.cs
+++ b/AlRunner/Patches/RecordPatches.AlSourceParser.cs
@@ -152,6 +152,21 @@ public static partial class RecordPatches
         return null;
     }
 
+    /// <summary>
+    /// A page-valued table property (<c>LookupPageId</c> / <c>DrillDownPageId</c>) as written:
+    /// the last name segment of a page reference (<c>Microsoft.Sales."Customer List"</c> →
+    /// <c>Customer List</c>), or the digits when the AL declared a bare id. Null when the
+    /// property is absent — "declares none", which the Table Metadata provider turns into 0
+    /// rather than a guess.
+    /// </summary>
+    private static string? PageRefText(NavSyntax.PropertyValueSyntax? value)
+    {
+        var text = value?.ToString()?.Trim();
+        if (string.IsNullOrEmpty(text)) return null;
+        var segment = LastNameSegment(text);
+        return string.IsNullOrWhiteSpace(segment) ? null : segment;
+    }
+
     private static bool PropIs(NavSyntax.PropertyListSyntax? list, string name, string expected) =>
         string.Equals(PropValue(list, name)?.ToString()?.Trim(), expected,
             StringComparison.OrdinalIgnoreCase);
@@ -297,8 +312,13 @@ public static partial class RecordPatches
             // a table that is not per-company.
             var isTableTypeTemporary = PropIs(table.PropertyList, "TableType", "Temporary");
             var dataPerCompany = !PropIs(table.PropertyList, "DataPerCompany", "false");
+            // LookupPageId / DrillDownPageId feed the Table Metadata (2000000136) virtual
+            // table. Kept as the written reference and resolved later: a page declared after
+            // this table in compile order is not in the page inventory yet.
+            var lookupPage = PageRefText(PropValue(table.PropertyList, "LookupPageId"));
+            var drillDownPage = PageRefText(PropValue(table.PropertyList, "DrillDownPageId"));
             _parsedTables[tableId] = new ParsedTable(tableId, tableName, fields, pkFieldIds,
-                secondaryKeys, isTableTypeTemporary, dataPerCompany);
+                secondaryKeys, isTableTypeTemporary, dataPerCompany, lookupPage, drillDownPage);
         }
     }
 
@@ -590,6 +610,15 @@ internal record ParsedCalcFormula(string FormulaType, string SourceTableName, st
 
 internal record ParsedField(int FieldId, string FieldName, string TypeName, int Length, bool IsFlowField = false, ParsedCalcFormula? CalcFormula = null, string? OptionMembers = null, string? InitValueText = null, bool IsAutoIncrement = false, string? Caption = null);
 internal record ParsedKey(string Name, List<int> FieldIds);
+/// <param name="LookupPageName">The table's declared <c>LookupPageId</c> as WRITTEN — a page
+/// name (<c>"Customer List"</c>) or a bare id in text form. Both sources state it by name:
+/// AL source writes the reference, and a dependency's SymbolReference.json records
+/// <c>LookupPageID</c>/<c>LookupPageId</c> as the page's NAME, never its number (measured
+/// against Base Application 28.1). Resolution to an id is therefore deferred to row-build
+/// time, where the full page inventory is known. Null means the table declares none, which
+/// is not the same as 0 — see <c>RecordPatches.TableMetadataVirtualTable.cs</c>.</param>
+/// <param name="DrillDownPageName">Same, for <c>DrillDownPageId</c>.</param>
 internal record ParsedTable(int TableId, string TableName,
     List<ParsedField> Fields, List<int> PkFieldIds, List<ParsedKey>? SecondaryKeys = null,
-    bool IsTableTypeTemporary = false, bool DataPerCompany = true);
+    bool IsTableTypeTemporary = false, bool DataPerCompany = true,
+    string? LookupPageName = null, string? DrillDownPageName = null);

--- a/AlRunner/Patches/RecordPatches.TableMetadataVirtualTable.cs
+++ b/AlRunner/Patches/RecordPatches.TableMetadataVirtualTable.cs
@@ -1,0 +1,278 @@
+// RecordPatches.TableMetadataVirtualTable — managed provider for the
+// "Table Metadata" (2000000136) system virtual table.
+//
+// WHY THIS EXISTS
+//   Table Metadata is virtual on the service tier: its rows are computed from the
+//   metadata of every table in the application. It routed to the same empty
+//   in-memory store as every other table here, so:
+//
+//     Table Metadata.Get(<any id>)  -> false, always
+//
+//   That is a silent wrong answer, not an error. AL takes its not-found branch and
+//   reports something misleading one level up, and the damage is not confined to AL
+//   that reads the table directly: Base Application "Page Management" (codeunit 700)
+//   resolves a record's lookup/card page through it, so GetPageID / PageRun /
+//   PageRunModal on a custom table died with
+//     NavCSideRecordNotFoundException: The Table Metadata does not exist.
+//     Identification fields and values: ID='50150'
+//   inside GetDefaultLookupPageID, even for a table plainly declaring LookupPageId.
+//
+// WHERE THE ROWS COME FROM (two sources, neither invented)
+//   1. Tables the runner compiles itself — parsed from their AL source
+//      (RecordPatches.AlSourceParser.cs: name, TableType, DataPerCompany and the
+//      LookupPageId / DrillDownPageId references).
+//   2. Tables living in a PRECOMPILED dependency (Base Application, System
+//      Application, ISV apps) — read from that .app's SymbolReference.json
+//      (BcAppSymbolCache.TryParseTableSymbol). This is the only route for an R2R
+//      app: it ships no metadata XML.
+//   Source-compiled tables win over symbol-derived ones for the same id — the source
+//   is what this run actually compiled.
+//
+//   Captions come from the same inventory AllObjWithCaption uses
+//   (EnumerateKnownAlObjects), so a table's caption here and its caption there cannot
+//   drift apart.
+//
+// PAGE IDS ARE RESOLVED, NOT GUESSED
+//   Both sources state the page BY NAME — AL source writes the reference, and
+//   SymbolReference.json records LookupPageID/LookupPageId as the page's name (measured
+//   against Base Application 28.1; note both spellings occur). So the name is resolved
+//   against the run's own page inventory at row-build time.
+//
+//   0 is a MEANINGFUL value in these two columns: it is how Page Management recognises
+//   "this table declares no lookup/drilldown page" and falls through to its next rule.
+//   So a table that DOES declare one whose page the runner cannot resolve must not be
+//   handed out as 0 — that would assert something false about the table. Such a table
+//   keeps its other columns and reports the unresolved page as 0 only after the miss is
+//   counted in a single stderr line naming the tables affected, so the gap is visible
+//   rather than silently answered.
+//
+// PRECOMPILED-DLL RESPECT
+//   Runtime-engine types only (VirtualDataProvider, NCLMetaTable, NavValue,
+//   ReadOnlyRecordBuffer, TempTableDataProvider), reached through the same helpers the
+//   AllObj provider resolves. No AL business-logic body is touched.
+
+using System.Collections.Concurrent;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using AlRunner.Infrastructure;
+using Microsoft.Dynamics.Nav.Runtime;
+
+namespace AlRunner.Patches;
+
+public static partial class RecordPatches
+{
+    internal const int TableMetadataVirtualTableId = 2000000136;
+
+    private static readonly ConditionalWeakTable<object, ConcurrentDictionary<int, byte>> _tmvPopulatedByProvider = new();
+
+    private static bool IsTableMetadataVirtualTable(NCLMetaTable? table)
+        => table != null && table.TableId == TableMetadataVirtualTableId;
+
+    /// <summary>
+    /// One table as Table Metadata exposes it. <see cref="LookupPageId"/> /
+    /// <see cref="DrillDownPageId"/> are already resolved to real page ids (0 only when
+    /// the table genuinely declares none, or when the declared page could not be
+    /// resolved — which is reported, never silent).
+    /// </summary>
+    private sealed record TableMetadataRow(
+        int Id, string Name, string Caption, bool DataPerCompany, bool IsTemporary,
+        int LookupPageId, int DrillDownPageId);
+
+    // Cached inventory, rebuilt whenever the runner has learned about more source-parsed
+    // tables or registered another dependency .app since the last build. The FIRST handout
+    // can happen before the bundle's dependencies are registered, and a snapshot taken then
+    // would permanently hide every Base Application table — the same trap the Report
+    // Metadata provider documents.
+    private static List<TableMetadataRow>? _tableMetadataRows;
+    private static (int Apps, int Parsed, int Pages) _tableMetadataRowsBuiltFrom = (-1, -1, -1);
+    private static readonly object _tableMetadataRowsLock = new();
+
+    /// <summary>
+    /// Populate the in-memory store behind Table Metadata (2000000136) with one row per
+    /// table the runner knows about. Idempotent per (provider, table id); called on every
+    /// handout so tables registered later in the run still show up.
+    /// </summary>
+    private static void PopulateTableMetadataVirtualTable(object dataAccess, NCLMetaTable metaTable)
+    {
+        EnsureAllObjReflection(metaTable);
+        EnsureReportMetadataReflection(metaTable);   // NavBoolean.Create(bool)
+        EnsureDataAccessProviderReflection(dataAccess);
+
+        var provider = _pDataAccessDataProvider!.GetValue(dataAccess)
+            ?? throw new RunnerOutOfScopeException(
+                "Table Metadata (virtual table 2000000136)",
+                "table-metadata-virtual-table — data access has no in-memory provider; see docs/scope.md");
+
+        var done = _tmvPopulatedByProvider.GetValue(provider, static _ => new ConcurrentDictionary<int, byte>());
+
+        foreach (var row in EnumerateKnownTableMetadata())
+        {
+            if (!done.TryAdd(row.Id, 0)) continue;
+            InsertVirtualRow(provider, metaTable,
+                new object[] { TableMetadataVirtualTableId, row.Id, 0, 0 },
+                field => BuildTableMetadataValue(field, row));
+        }
+    }
+
+    /// <summary>
+    /// One column of a Table Metadata row, matched by the metatable's own FIELD NAME so the
+    /// mapping tracks whatever the System package in the resolved artifact declares rather
+    /// than a hardcoded field-number table. Columns the runner cannot answer truthfully
+    /// (ObsoleteState/Reason, ReplicateData, ExtensionID, TableType beyond temporary, …) get
+    /// BC's own default — which is also what a real row carries for a table declaring none
+    /// of them.
+    /// </summary>
+    private static object? BuildTableMetadataValue(NCLMetaField field, TableMetadataRow row)
+    {
+        object? Text(string s) => _aovNavTextCreateTruncated!.Invoke(null, new object?[] { field.FieldDefinedLength, s ?? string.Empty });
+
+        switch (NormalizeObjectTypeName(field.FieldName ?? string.Empty))
+        {
+            case "id":
+                return _aovNavIntegerCreate!.Invoke(null, new object?[] { row.Id });
+            case "name":
+                return Text(row.Name);
+            case "caption":
+                return Text(row.Caption);
+            case "lookuppageid":
+                return _aovNavIntegerCreate!.Invoke(null, new object?[] { row.LookupPageId });
+            case "drilldownpageid":
+                return _aovNavIntegerCreate!.Invoke(null, new object?[] { row.DrillDownPageId });
+            case "datapercompany":
+                return NavBoolean(row.DataPerCompany);
+            case "temporarytable":
+                return NavBoolean(row.IsTemporary);
+            default:
+                return _aovGetDefaultNavValue!.Invoke(null, new object?[] { field, false });
+        }
+    }
+
+    /// <summary>
+    /// Every table the runner has real metadata for: source-parsed tables of the app under
+    /// test and of any source-compiled dependency first, then tables declared by the
+    /// SymbolReference.json of every registered precompiled dependency .app.
+    /// </summary>
+    private static List<TableMetadataRow> EnumerateKnownTableMetadata()
+    {
+        var generation = (_bcAppPaths.Count, _parsedTables.Count, _parsedPages.Count);
+        if (_tableMetadataRows != null && _tableMetadataRowsBuiltFrom == generation) return _tableMetadataRows;
+        lock (_tableMetadataRowsLock)
+        {
+            generation = (_bcAppPaths.Count, _parsedTables.Count, _parsedPages.Count);
+            if (_tableMetadataRows != null && _tableMetadataRowsBuiltFrom == generation) return _tableMetadataRows;
+
+            var (pageIdsByName, tableCaptionsById) = BuildObjectIndexes();
+            var unresolvedPages = new List<string>();
+
+            // A page reference as written: a bare id stays that id, otherwise the run's own
+            // page inventory answers. An unresolvable NAME is reported, never quietly 0.
+            int ResolvePage(string? reference, int tableId, string propertyName)
+            {
+                if (string.IsNullOrWhiteSpace(reference)) return 0;   // declares none — truthful 0
+                if (int.TryParse(reference, out var literal) && literal > 0) return literal;
+                if (pageIdsByName.TryGetValue(reference, out var id)) return id;
+                unresolvedPages.Add($"table {tableId} {propertyName} -> page '{reference}'");
+                return 0;
+            }
+
+            var rows = new Dictionary<int, TableMetadataRow>();
+
+            TableMetadataRow Build(ParsedTable t) => new(
+                t.TableId,
+                t.TableName,
+                // AL's own default caption is the object name — applied once, here.
+                tableCaptionsById.TryGetValue(t.TableId, out var c) && c.Length > 0 ? c : t.TableName,
+                t.DataPerCompany,
+                t.IsTableTypeTemporary,
+                ResolvePage(t.LookupPageName, t.TableId, "LookupPageId"),
+                ResolvePage(t.DrillDownPageName, t.TableId, "DrillDownPageId"));
+
+            // 1. Tables the runner source-compiled.
+            foreach (var parsed in _parsedTables.Values)
+                rows[parsed.TableId] = Build(parsed);
+
+            // 2. Tables declared by precompiled dependency .app packages.
+            foreach (var symbol in EnumerateBcAppTableSymbols())
+            {
+                if (rows.ContainsKey(symbol.TableId)) continue;   // source-compiled wins
+                rows[symbol.TableId] = Build(symbol);
+            }
+
+            if (unresolvedPages.Count > 0)
+                Console.Error.WriteLine(
+                    $"[RecordPatches] Table Metadata: {unresolvedPages.Count} declared page reference(s) "
+                    + "could not be resolved to a page id and are reported as 0; Page Management will treat "
+                    + "those tables as declaring no page: "
+                    + string.Join("; ", unresolvedPages.Take(10))
+                    + (unresolvedPages.Count > 10 ? $" (+{unresolvedPages.Count - 10} more)" : string.Empty));
+
+            _tableMetadataRows = rows.Values.ToList();
+            _tableMetadataRowsBuiltFrom = generation;
+
+            var trace = Environment.GetEnvironmentVariable("AL_RUNNER_TRACE_TABLE_METADATA");
+            if (!string.IsNullOrEmpty(trace))
+            {
+                Console.Out.WriteLine(
+                    $"[table-metadata] {_tableMetadataRows.Count} table(s) known "
+                    + $"({_parsedTables.Count} source-parsed, {_bcAppPaths.Count} dependency .app(s))");
+                if (int.TryParse(trace, out var probeId) && probeId > 1)
+                    Console.Out.WriteLine(rows.TryGetValue(probeId, out var probe)
+                        ? $"[table-metadata] {probeId}: name='{probe.Name}' caption='{probe.Caption}' "
+                          + $"lookupPage={probe.LookupPageId} drillDownPage={probe.DrillDownPageId} "
+                          + $"dataPerCompany={probe.DataPerCompany} temporary={probe.IsTemporary}"
+                        : $"[table-metadata] {probeId}: NOT KNOWN");
+            }
+            return _tableMetadataRows;
+        }
+    }
+
+    /// <summary>
+    /// Two indexes off ONE pass over the object inventory AllObj/AllObjWithCaption publish:
+    /// page name → page id, and table id → declared caption. Sharing that inventory is what
+    /// keeps a page listed there resolvable here, and a table's caption here identical to
+    /// its caption there — including for tables that live in a precompiled dependency,
+    /// whose captions only the symbol file states.
+    /// <para>Page names are compared case-insensitively, as AL itself compares object names.
+    /// The FIRST id wins for a duplicated name, matching the inventory's own source
+    /// precedence (source-compiled before dependency symbols).</para>
+    /// </summary>
+    private static (Dictionary<string, int> PageIdsByName, Dictionary<int, string> TableCaptionsById) BuildObjectIndexes()
+    {
+        var pages = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        var captions = new Dictionary<int, string>();
+        foreach (var (kind, id, name, caption) in EnumerateKnownAlObjects())
+        {
+            if (id <= 0 || string.IsNullOrEmpty(name)) continue;
+            switch (NormalizeObjectTypeName(kind))
+            {
+                case "page":
+                    pages.TryAdd(name, id);
+                    break;
+                case "table":
+                    if (!string.IsNullOrEmpty(caption)) captions.TryAdd(id, caption);
+                    break;
+            }
+        }
+        return (pages, captions);
+    }
+
+    private static IEnumerable<ParsedTable> EnumerateBcAppTableSymbols()
+    {
+        foreach (var appPath in _bcAppPaths.ToArray())
+        {
+            List<ParsedTable> tables;
+            try
+            {
+                tables = BcAppSymbolCache.Get(appPath).Tables;
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine(
+                    $"[RecordPatches] Table Metadata: SymbolReference read failed for {Path.GetFileName(appPath)}: {ex.Message}");
+                continue;
+            }
+            foreach (var t in tables)
+                yield return t;
+        }
+    }
+}

--- a/AlRunner/Patches/RecordPatches.cs
+++ b/AlRunner/Patches/RecordPatches.cs
@@ -1284,6 +1284,22 @@ public static partial class RecordPatches
                 return reportDiDa;
             }
 
+            // ── Table Metadata (2000000136) ──────────────────────────────────────────────
+            // Virtual on the service tier too: one row per table in the application. An
+            // empty store makes every lookup answer "no such table", which is what broke
+            // Base App "Page Management".GetDefaultLookupPageID on custom tables.
+            // See RecordPatches.TableMetadataVirtualTable.cs.
+            if (IsTableMetadataVirtualTable(table))
+            {
+                if (!perTable.TryGetValue(tableId, out var tableMetaDa))
+                {
+                    var createdTableMeta = _mCreateTempDataAccess!.Invoke(self, new object[] { table })!;
+                    tableMetaDa = perTable.GetOrAdd(tableId, createdTableMeta);
+                }
+                PopulateTableMetadataVirtualTable(tableMetaDa, table);
+                return tableMetaDa;
+            }
+
             if (perTable.TryGetValue(tableId, out var cached))
             {
                 return cached;

--- a/tests/runner-extras/table-metadata-virtual-table/TmvtSrc.al
+++ b/tests/runner-extras/table-metadata-virtual-table/TmvtSrc.al
@@ -1,0 +1,98 @@
+/// <summary>
+/// The probe table. Declares BOTH page-resolution properties, and a Caption that
+/// differs from the object name -- so a provider that filled Caption from Name,
+/// or that echoed one page id into both slots, fails on this table alone.
+/// </summary>
+table 62100 "TMVT Row"
+{
+    Caption = 'TMVT Probe Row';
+    DataClassification = CustomerContent;
+    LookupPageId = "TMVT Row List";
+    DrillDownPageId = "TMVT Row Card";
+
+    fields
+    {
+        field(1; "No."; Code[20])
+        {
+            DataClassification = CustomerContent;
+        }
+    }
+
+    keys
+    {
+        key(PK; "No.")
+        {
+            Clustered = true;
+        }
+    }
+}
+
+/// <summary>
+/// A table declaring NEITHER LookupPageId NOR DrillDownPageId. Its row must carry
+/// 0 in both slots: 0 is the meaningful "this table declares no page" answer that
+/// Page Management branches on, so a provider that invented a page id here would
+/// be a silent wrong answer, not a harmless one.
+/// </summary>
+table 62103 "TMVT Plain"
+{
+    Caption = 'TMVT Plain Row';
+    DataClassification = CustomerContent;
+
+    fields
+    {
+        field(1; "No."; Code[20])
+        {
+            DataClassification = CustomerContent;
+        }
+    }
+
+    keys
+    {
+        key(PK; "No.")
+        {
+            Clustered = true;
+        }
+    }
+}
+
+page 62101 "TMVT Row List"
+{
+    PageType = List;
+    SourceTable = "TMVT Row";
+    UsageCategory = None;
+
+    layout
+    {
+        area(Content)
+        {
+            repeater(Rows)
+            {
+                field("No."; Rec."No.")
+                {
+                    ApplicationArea = All;
+                }
+            }
+        }
+    }
+}
+
+page 62102 "TMVT Row Card"
+{
+    PageType = Card;
+    SourceTable = "TMVT Row";
+    UsageCategory = None;
+
+    layout
+    {
+        area(Content)
+        {
+            group(General)
+            {
+                field("No."; Rec."No.")
+                {
+                    ApplicationArea = All;
+                }
+            }
+        }
+    }
+}

--- a/tests/runner-extras/table-metadata-virtual-table/TmvtTests.Codeunit.al
+++ b/tests/runner-extras/table-metadata-virtual-table/TmvtTests.Codeunit.al
@@ -1,0 +1,131 @@
+/// <summary>
+/// Pins the Table Metadata (2000000136) system virtual table.
+///
+/// The metatable is parsed out of the System package so the table exists, but
+/// nothing provides rows for it, so <c>Table Metadata.Get(id)</c> returns false
+/// for every table in the application -- including tables the runner compiled
+/// moments earlier. Real BC has a row for every table.
+///
+/// The consequence is not confined to AL that reads the table directly. Base
+/// Application "Page Management" (codeunit 700) resolves a record's lookup/card
+/// page through it, so <c>GetPageID</c> / <c>PageRun</c> / <c>PageRunModal</c> on
+/// a custom table fail with "The Table Metadata does not exist. Identification
+/// fields and values: ID='...'" even when the table plainly declares
+/// LookupPageId.
+///
+/// The negative tests carry as much weight as the positive ones. A provider that
+/// answered true to every Get, that ignored the ID filter, or that fabricated a
+/// non-zero LookupPageID for a table declaring none would satisfy the positive
+/// cases alone -- and the last of those would be the worst kind of failure here,
+/// because 0 is exactly the value Page Management branches on.
+/// </summary>
+codeunit 62104 "TMVT Tests"
+{
+    Subtype = Test;
+
+    [Test]
+    procedure TableMetadataGet_ReturnsRowForACompiledTable()
+    var
+        TableMetadata: Record "Table Metadata";
+    begin
+        if not TableMetadata.Get(Database::"TMVT Row") then
+            Error('Table Metadata.Get(%1) returned false, but table 62100 is defined in this app and was just compiled.',
+                Database::"TMVT Row");
+
+        if TableMetadata.ID <> Database::"TMVT Row" then
+            Error('Table Metadata.ID was %1, expected %2.', TableMetadata.ID, Database::"TMVT Row");
+
+        if TableMetadata.Name <> 'TMVT Row' then
+            Error('Table Metadata.Name was "%1", expected "TMVT Row".', TableMetadata.Name);
+
+        // Caption is deliberately DIFFERENT from the object name, so a provider
+        // that filled Caption from Name would fail right here.
+        if TableMetadata.Caption <> 'TMVT Probe Row' then
+            Error('Table Metadata.Caption was "%1", expected "TMVT Probe Row".', TableMetadata.Caption);
+    end;
+
+    [Test]
+    procedure TableMetadataGet_CarriesTheDeclaredLookupAndDrillDownPages()
+    var
+        TableMetadata: Record "Table Metadata";
+    begin
+        if not TableMetadata.Get(Database::"TMVT Row") then
+            Error('Table Metadata.Get(%1) returned false, but table 62100 is defined in this app.',
+                Database::"TMVT Row");
+
+        if TableMetadata.LookupPageID <> Page::"TMVT Row List" then
+            Error('Table Metadata.LookupPageID was %1, expected %2 (the declared LookupPageId).',
+                TableMetadata.LookupPageID, Page::"TMVT Row List");
+
+        // Distinct from LookupPageID on purpose: a provider echoing one page id
+        // into both slots passes the assertion above and fails this one.
+        if TableMetadata.DrillDownPageID <> Page::"TMVT Row Card" then
+            Error('Table Metadata.DrillDownPageID was %1, expected %2 (the declared DrillDownPageId).',
+                TableMetadata.DrillDownPageID, Page::"TMVT Row Card");
+    end;
+
+    [Test]
+    procedure TableMetadataGet_ReportsZeroPagesForATableDeclaringNone()
+    var
+        TableMetadata: Record "Table Metadata";
+    begin
+        if not TableMetadata.Get(Database::"TMVT Plain") then
+            Error('Table Metadata.Get(%1) returned false, but table 62103 is defined in this app.',
+                Database::"TMVT Plain");
+
+        // 0 is the meaningful answer Page Management branches on. Inventing a page
+        // id here would be a silent wrong answer, so it is pinned explicitly.
+        if TableMetadata.LookupPageID <> 0 then
+            Error('Table Metadata.LookupPageID was %1 for a table declaring no LookupPageId, expected 0.',
+                TableMetadata.LookupPageID);
+
+        if TableMetadata.DrillDownPageID <> 0 then
+            Error('Table Metadata.DrillDownPageID was %1 for a table declaring no DrillDownPageId, expected 0.',
+                TableMetadata.DrillDownPageID);
+    end;
+
+    [Test]
+    procedure TableMetadataGet_ReturnsFalseForATableIdThatDoesNotExist()
+    var
+        TableMetadata: Record "Table Metadata";
+    begin
+        // 62119 is inside this app's id range and deliberately unused. A provider
+        // that answered true to every Get -- or that ignored the ID filter and
+        // handed back whatever row it had -- fails here.
+        if TableMetadata.Get(62119) then
+            Error('Table Metadata.Get(62119) returned true, but no table 62119 exists in this application.');
+    end;
+
+    [Test]
+    procedure TableMetadataFindSet_IsFilteredByTheIdRange()
+    var
+        TableMetadata: Record "Table Metadata";
+    begin
+        // Proves the rows are real filterable rows rather than a single row
+        // synthesised per Get: exactly the two tables this app declares fall in
+        // the range, and 62119 (asserted absent above) does not.
+        TableMetadata.SetRange(ID, 62100, 62119);
+        if TableMetadata.Count() <> 2 then
+            Error('Table Metadata had %1 row(s) in id range 62100..62119, expected exactly 2 (tables 62100 and 62103).',
+                TableMetadata.Count());
+    end;
+
+    [Test]
+    procedure PageManagementGetPageID_ResolvesTheDeclaredLookupPage()
+    var
+        TmvtRow: Record "TMVT Row";
+        PageManagement: Codeunit "Page Management";
+        PageId: Integer;
+    begin
+        // The reported symptom: Base App Page Management reads Table Metadata to
+        // resolve a record's page, and threw
+        // NavCSideRecordNotFoundException "The Table Metadata does not exist"
+        // before this table had rows. This runs the real, unmodified Base App
+        // codeunit against the provider.
+        PageId := PageManagement.GetPageID(TmvtRow);
+
+        if PageId <> Page::"TMVT Row List" then
+            Error('Page Management.GetPageID returned %1, expected %2 (the table''s declared LookupPageId).',
+                PageId, Page::"TMVT Row List");
+    end;
+}

--- a/tests/runner-extras/table-metadata-virtual-table/app.json
+++ b/tests/runner-extras/table-metadata-virtual-table/app.json
@@ -1,0 +1,25 @@
+{
+  "id": "3c9b7e14-2a6d-4f81-b05c-7e91d4a83b26",
+  "name": "Runner Extras - Table Metadata virtual table",
+  "publisher": "AL Runner",
+  "version": "1.0.0.0",
+  "brief": "Proves the Table Metadata (2000000136) system virtual table answers truthfully for tables the runner compiled.",
+  "description": "The Table Metadata metatable is parsed out of the System package so the table exists, but nothing provides rows for it -- so Table Metadata.Get(<any id>) returns false for every table in the application, including ones the runner compiled moments earlier. Base Application 'Page Management' (codeunit 700) reads this table to resolve a record's lookup/card page, so GetPageID/PageRun/PageRunModal on a custom table fail with 'The Table Metadata does not exist' even when the table plainly declares LookupPageId. The negative cases carry as much weight as the positive ones: a provider that answered true to every Get, or that fabricated a non-zero LookupPageID for a table declaring none, would satisfy the positive cases alone.",
+  "privacyStatement": "",
+  "EULA": "",
+  "help": "",
+  "url": "",
+  "logo": "",
+  "dependencies": [],
+  "screenshots": [],
+  "platform": "27.0.0.0",
+  "application": "27.0.0.0",
+  "idRanges": [
+    {
+      "from": 62100,
+      "to": 62119
+    }
+  ],
+  "runtime": "17.0",
+  "features": []
+}


### PR DESCRIPTION
Four commits from a triage + implementation pass over the ready/untriaged queue.

## `feat(metadata)`: populate the Table Metadata virtual table — `Closes #1720`

`Table Metadata` (2000000136) is virtual on the service tier — one row per table in the application — but routed to the same empty in-memory store as every other table, so `Get(<any id>)` returned false for every table, including ones the runner compiled moments earlier.

That is a silent wrong answer, and the damage was not confined to AL reading the table directly: Base App `Page Management` (codeunit 700) resolves a record's lookup/card page through it, so `GetPageID` / `PageRun` / `PageRunModal` on a custom table died inside `GetDefaultLookupPageID` with `NavCSideRecordNotFoundException: The Table Metadata does not exist`.

Rows come from the two sources that already know: source-compiled tables, and tables declared by a registered dependency's `SymbolReference.json`. Source-compiled wins for the same id. Captions reuse the AllObj/AllObjWithCaption inventory so the two surfaces can't drift.

Two details worth a reviewer's eye:

- **Page ids are resolved, not guessed.** I checked the shipped Base Application symbol file rather than assuming: it stores `LookupPageID` as the page's *name*, never its number, and uses both `LookupPageID` and `LookupPageId` spellings across different tables. Names resolve against the run's own page inventory at row-build time. `0` stays meaningful — it is how Page Management recognises "declares no page" — so a declared-but-unresolvable page is reported on stderr rather than quietly handed out as 0.
- **bc-symbols cache bumped v8 → v9.** `ParsedTable` gained `LookupPageName`/`DrillDownPageName`, and a v8 payload deserialises cleanly with both null, which would have reported "declares no lookup page" for every cached dependency table.

## `fix(ci)`: make the docs-only bypass actually work — `Closes #1704`

`pr-check.yml` told contributors to add `docs-only` / `no-tests-needed` to bypass the "Tests updated" job, but declared `on: pull_request` with no `types:`, so it only fired on the default set. Applying the label triggered no run and the red X stayed. Adds `labeled` and `unlabeled` — the latter so the bypass can't be applied and then silently withdrawn while the check still reads green.

## `docs(rules)`: BC-behaviour tests must go upstream (2 commits)

New `.claude/rules/bc-behavior-tests-go-upstream.md`, cross-linked from `al-language-submodule.md`. A test asserting plain BC behaviour must live in the al-language corpus, validated against a real service tier — an unvalidated BC test inherits the runner's errors as its expectations, so when the runner is wrong it doesn't fail, and green only means the runner agrees with itself. Includes the sorting question, the two-PR flow (corpus PR → pin bump → runner change), and closes the "no service tier" loophole.

## Verification

Environment built from scratch for this (.NET 8 + 9 SDKs, BC 28.1.49838.50794 artifacts, R2R platform apps + test toolkit, submodule init):

- `tests/runner-extras` — **120/120 pass**
- `AlRunner.Tests` — **373/373 pass**

## Known follow-up

The `table-metadata-virtual-table` bundle added here asserts plain BC behaviour, so under the new rule it belongs upstream. It is staying put only until the corpus PR migrating the post-cutover drift lands; it is on that list and will be trimmed to whatever is genuinely runner-specific when the pin moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G3KPXYQnfoL1ogXLXo823n

---
_Generated by [Claude Code](https://claude.ai/code/session_01G3KPXYQnfoL1ogXLXo823n)_