### PR TITLE
fix(moduleinfo): GetCallerModuleInfo must name the caller across an app boundary (#1722)

### DIFF
--- a/AlRunner/BcRuntime.cs
+++ b/AlRunner/BcRuntime.cs
@@ -214,7 +214,8 @@ public static partial class BcRuntime
             Assembly? currentAlFrame = null;
             for (int i = 0; i < trace.FrameCount; i++)
             {
-                var type = trace.GetFrame(i)?.GetMethod()?.DeclaringType;
+                var method = trace.GetFrame(i)?.GetMethod();
+                var type = method?.DeclaringType;
                 var asm = type?.Assembly;
                 if (asm == null || !_moduleInfoByAssembly.ContainsKey(asm)) continue;
                 // The polyfill shim is compiled INTO each AL assembly, so its frames pass
@@ -224,6 +225,19 @@ public static partial class BcRuntime
                     && type.Namespace.StartsWith("AlRunnerShim", StringComparison.Ordinal)) continue;
                 // Same AL method, not a caller: fold away the emitted scope frame object.
                 if (type.Name.Contains("_Scope", StringComparison.Ordinal)) continue;
+                // #1722 — the CROSS-APP invocation path. Calling an AL procedure in another
+                // app does not land as one managed frame: the AL emit routes it through a
+                // compiler-generated `Codeunit<N>.OnInvoke` dispatcher, and that dispatcher
+                // lives in the CALLEE's own assembly, one frame above the callee's real
+                // method. It is the same AL method invocation, not a caller — exactly what
+                // `_Scope` frames are folded for — but it is a plain method on the codeunit
+                // type, so neither rule above catches it. Left unfolded it is accepted as
+                // "the immediate caller" and the walk answers with the callee's own module,
+                // making GetCallerModuleInfo indistinguishable from GetCurrentModuleInfo for
+                // every library invoked across an app boundary. `OnInvoke` is emitted by the
+                // AL compiler, never authored (AL's codeunit trigger is `OnRun`), so folding
+                // it cannot swallow a genuine AL caller frame.
+                if (method!.Name == "OnInvoke") continue;
 
                 if (currentAlFrame == null) { currentAlFrame = asm; continue; }
                 // BC breaks on the FIRST frame after the skipped one — even when it

--- a/tests/runner-extras/navapp-callermodule-dispatch-dep/NcdLibApi.Codeunit.al
+++ b/tests/runner-extras/navapp-callermodule-dispatch-dep/NcdLibApi.Codeunit.al
@@ -1,0 +1,46 @@
+/// <summary>
+/// Library half of the #1722 reproducer. Mirrors the idiom Microsoft's
+/// System.AI."Copilot Capability".RegisterCapability uses: a SHARED library asks
+/// NavApp.GetCallerModuleInfo() so it can register state keyed on the module of
+/// whoever called into it — never on its own module.
+/// </summary>
+codeunit 64280 "NCD Lib Api"
+{
+    Access = Public;
+
+    /// <summary>AppId of the module that called INTO this library procedure.</summary>
+    procedure CallerModuleId(): Guid
+    var
+        CallerModuleInfo: ModuleInfo;
+    begin
+        NavApp.GetCallerModuleInfo(CallerModuleInfo);
+        exit(CallerModuleInfo.Id());
+    end;
+
+    /// <summary>Name of the module that called INTO this library procedure.</summary>
+    procedure CallerModuleName(): Text
+    var
+        CallerModuleInfo: ModuleInfo;
+    begin
+        NavApp.GetCallerModuleInfo(CallerModuleInfo);
+        exit(CallerModuleInfo.Name());
+    end;
+
+    /// <summary>This library's OWN module id, for contrast with the caller's.</summary>
+    procedure OwnModuleId(): Guid
+    var
+        CurrentModuleInfo: ModuleInfo;
+    begin
+        NavApp.GetCurrentModuleInfo(CurrentModuleInfo);
+        exit(CurrentModuleInfo.Id());
+    end;
+
+    /// <summary>This library's OWN module name.</summary>
+    procedure OwnModuleName(): Text
+    var
+        CurrentModuleInfo: ModuleInfo;
+    begin
+        NavApp.GetCurrentModuleInfo(CurrentModuleInfo);
+        exit(CurrentModuleInfo.Name());
+    end;
+}

--- a/tests/runner-extras/navapp-callermodule-dispatch-dep/app.json
+++ b/tests/runner-extras/navapp-callermodule-dispatch-dep/app.json
@@ -1,0 +1,25 @@
+{
+  "id": "b4e7c2a1-9d63-4f85-a017-2c8b6e5d1f39",
+  "name": "NavAppCallerModule Dispatch Dep",
+  "publisher": "AL Runner",
+  "version": "2.4.7.0",
+  "brief": "Library half of the GetCallerModuleInfo cross-app dispatch reproducer (#1722): a public procedure that reports who called INTO it.",
+  "description": "RED before the fix: NavApp.GetCallerModuleInfo() called from inside this library returned THIS library's own module instead of the direct caller's, because the runner's frame walk counted the compiler-generated Codeunit<N>.OnInvoke dispatch wrapper — emitted in the callee's own assembly on the cross-app invocation path — as if it were the caller's frame. Mirrors the Microsoft 'Copilot Capability'.RegisterCapability idiom, where a shared library registers state keyed on its caller's module.",
+  "privacyStatement": "",
+  "EULA": "",
+  "help": "",
+  "url": "",
+  "logo": "",
+  "dependencies": [],
+  "screenshots": [],
+  "platform": "1.0.0.0",
+  "application": "27.0.0.0",
+  "idRanges": [
+    {
+      "from": 64280,
+      "to": 64289
+    }
+  ],
+  "runtime": "14.0",
+  "features": []
+}

--- a/tests/runner-extras/navapp-callermodule-dispatch-main/NcdMainTests.Codeunit.al
+++ b/tests/runner-extras/navapp-callermodule-dispatch-main/NcdMainTests.Codeunit.al
@@ -1,0 +1,78 @@
+/// <summary>
+/// #1722 — NavApp.GetCallerModuleInfo() must name the DIRECT CALLER's module.
+///
+/// On the cross-app invocation path the AL emit routes the call through a
+/// compiler-generated <c>Codeunit&lt;N&gt;.OnInvoke</c> dispatch wrapper that lives in the
+/// CALLEE's own assembly. The runner's frame walk folded away the shim and
+/// <c>*_Scope</c> frames but not that wrapper, so it accepted the callee's own
+/// dispatch frame as "the immediate caller" and answered with the library's own
+/// module — indistinguishable from GetCurrentModuleInfo.
+///
+/// Measured consequence: Microsoft's System.AI."Copilot Capability".RegisterCapability
+/// keys its registration on GetCallerModuleInfo().Id(). With the library's own id
+/// returned instead of the calling app's, the row lands under the wrong key, the
+/// test library's later Get misses, and every subsequent call in the same codeunit
+/// reports "Capability has already been registered."
+/// </summary>
+codeunit 64290 "NCD Main Tests"
+{
+    Subtype = Test;
+
+    /// <summary>
+    /// THE REGRESSION, positive direction: the id the dep observes is THIS bundle's.
+    /// </summary>
+    [Test]
+    procedure DepGetCallerModuleInfo_AcrossApps_ReturnsTheCallingBundleId()
+    var
+        LibApi: Codeunit "NCD Lib Api";
+        MyOwnModuleInfo: ModuleInfo;
+    begin
+        NavApp.GetCurrentModuleInfo(MyOwnModuleInfo);
+
+        if LibApi.CallerModuleId() <> MyOwnModuleInfo.Id() then
+            Error('GetCallerModuleInfo() inside the dep must return the DIRECT CALLER''s module id (this bundle, %1), got %2.',
+                MyOwnModuleInfo.Id(), LibApi.CallerModuleId());
+    end;
+
+    /// <summary>
+    /// THE REGRESSION, negative direction. This is the assertion that fails on the
+    /// broken build. Kept separate from the positive one because an implementation
+    /// that answers "the executing module" satisfies neither, but an implementation
+    /// that merely returns a non-empty GUID would slip past a weaker check.
+    /// </summary>
+    [Test]
+    procedure DepGetCallerModuleInfo_AcrossApps_IsNotTheDepsOwnModuleId()
+    var
+        LibApi: Codeunit "NCD Lib Api";
+    begin
+        if LibApi.CallerModuleId() = LibApi.OwnModuleId() then
+            Error('GetCallerModuleInfo() inside the dep returned the dep''s OWN module id (%1) — it must name the caller, not the callee.',
+                LibApi.OwnModuleId());
+    end;
+
+    /// <summary>The same claim by name, so a failure reads without resolving GUIDs.</summary>
+    [Test]
+    procedure DepGetCallerModuleInfo_AcrossApps_NamesTheCallingBundle()
+    var
+        LibApi: Codeunit "NCD Lib Api";
+    begin
+        if LibApi.CallerModuleName() <> 'NavAppCallerModule Dispatch Main' then
+            Error('GetCallerModuleInfo() inside the dep must name this bundle, got ''%1''.',
+                LibApi.CallerModuleName());
+    end;
+
+    /// <summary>
+    /// Guards the fix from overshooting: folding the dispatch wrapper must not also
+    /// fold the callee's real frame, which would make the dep see its own CURRENT
+    /// module wrongly. GetCurrentModuleInfo inside the dep still answers the dep.
+    /// </summary>
+    [Test]
+    procedure DepGetCurrentModuleInfo_AcrossApps_StillNamesTheDep()
+    var
+        LibApi: Codeunit "NCD Lib Api";
+    begin
+        if LibApi.OwnModuleName() <> 'NavAppCallerModule Dispatch Dep' then
+            Error('GetCurrentModuleInfo() inside the dep must still name the dep itself, got ''%1''.',
+                LibApi.OwnModuleName());
+    end;
+}

--- a/tests/runner-extras/navapp-callermodule-dispatch-main/app.json
+++ b/tests/runner-extras/navapp-callermodule-dispatch-main/app.json
@@ -1,0 +1,32 @@
+{
+  "id": "c5f8d3b2-0e74-4a96-b128-3d9c7f6e2a40",
+  "name": "NavAppCallerModule Dispatch Main",
+  "publisher": "AL Runner",
+  "version": "1.0.0.0",
+  "brief": "Consuming bundle of the GetCallerModuleInfo cross-app dispatch reproducer (#1722): calls into the dep and pins that the dep sees THIS bundle as its caller.",
+  "description": "Companion of navapp-callermodule-dispatch-dep. Pins both directions of NavApp.GetCallerModuleInfo() across a cross-app call: the id the dep observes must equal this bundle's own id AND must differ from the dep's own id. The second assertion is what fails on the broken build — GetCallerModuleInfo answered with the dep's own module, so a library keying state on its caller wrote it under its own id.",
+  "privacyStatement": "",
+  "EULA": "",
+  "help": "",
+  "url": "",
+  "logo": "",
+  "dependencies": [
+    {
+      "id": "b4e7c2a1-9d63-4f85-a017-2c8b6e5d1f39",
+      "name": "NavAppCallerModule Dispatch Dep",
+      "publisher": "AL Runner",
+      "version": "2.4.7.0"
+    }
+  ],
+  "screenshots": [],
+  "platform": "1.0.0.0",
+  "application": "27.0.0.0",
+  "idRanges": [
+    {
+      "from": 64290,
+      "to": 64299
+    }
+  ],
+  "runtime": "14.0",
+  "features": []
+}


### PR DESCRIPTION
NavApp.GetCallerModuleInfo() returned the EXECUTING module instead of the
direct caller's whenever the call crossed an app boundary, making it
indistinguishable from GetCurrentModuleInfo for any shared library.

Root cause: a cross-app AL call does not land as one managed frame. The AL
emit routes it through a compiler-generated `Codeunit<N>.OnInvoke`
dispatcher, and that dispatcher lives in the CALLEE's own assembly, one
frame above the callee's real method:

     Codeunit90200.GetCallerModuleId   asm=ReproLib   <- callee (self)
     Codeunit90200.OnInvoke            asm=ReproLib   <- generated dispatcher
     NavApplicationObjectBase.Invoke   asm=Ncl
     <test>_Scope__2143400277.OnRun    asm=ReproCaller <- true caller

TryGetImmediateCallerModule folds away the AlRunnerShim frames and the
emitted `*_Scope` frame objects to keep "one frame per AL method
invocation", but `OnInvoke` is a plain method on the codeunit type, so
neither rule caught it. It was accepted as the immediate caller and the
walk answered with the callee's own module.

Fix: fold `OnInvoke` alongside `*_Scope`. It is emitted by the AL compiler
and can never be authored (AL's codeunit trigger is `OnRun`), so folding it
cannot swallow a genuine AL caller frame. The walk still breaks on the very
next frame, so a same-app hop keeps answering "this app" as BC does.

Measured consequence of the bug: Microsoft's System.AI."Copilot Capability"
.RegisterCapability keys its registration on GetCallerModuleInfo().Id().
With the library's own id returned instead of the calling app's, the row
landed under the wrong key and every later call in the same codeunit
reported "Capability has already been registered."

Test: tests/runner-extras/navapp-callermodule-dispatch-{dep,main} - a
library app plus a consuming bundle. Pins both directions (the observed id
IS the caller's, and is NOT the callee's own) so an implementation that
answers "the executing module" fails, and adds a guard that
GetCurrentModuleInfo inside the dep still names the dep, so the frame fold
cannot overshoot.

  RED  (before): 2 pass / 2 fail
  GREEN (after): 4 pass / 0 fail
  tests/runner-extras --strict: 114/114 -> 118/118, no regressions
  Reporter's original two-app reproducer: FAIL -> PASS

Closes #1722

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01H8WingkJisHemwnF5jYr6D