### PR TITLE
fix(record): Rename propagates to validated TableRelation fields

### DIFF
--- a/AlRunner/Infrastructure/NclCecilRewrite.cs
+++ b/AlRunner/Infrastructure/NclCecilRewrite.cs
@@ -18,7 +18,7 @@ namespace AlRunner.Infrastructure;
 
 public static class NclCecilRewrite
 {
-    private const int CACHE_VERSION = 123;
+    private const int CACHE_VERSION = 124;
 
     // ─────────────────────────────────────────────────────────────────────────
     // Cecil-owned skip registry (JmpHook→Cecil migration enabler).
@@ -151,6 +151,10 @@ public static class NclCecilRewrite
         "Microsoft.Dynamics.Nav.Runtime.NCLMetadata::GetMetaApplicationObject/4",
         "Microsoft.Dynamics.Nav.Runtime.NCLMetadata::GetMetaApplicationObject/3",
         "Microsoft.Dynamics.Nav.Runtime.NCLMetaTable::GetFieldByNo/2",
+        // Referencing-relations reverse index (rename propagation, #1730) — Cecil-forwarded
+        // to RecordPatches.NCLMetaTable_ComputeReferencingRelations over the runner's
+        // metatable cache (BC's body reads the null ObjectLoader and NREs).
+        "Microsoft.Dynamics.Nav.Runtime.NCLMetaTable::ComputeReferencingRelations/2",
         // NavSession getters
         "Microsoft.Dynamics.Nav.Runtime.NavSession::get_DataAccessSource/0",
         "Microsoft.Dynamics.Nav.Runtime.NavSession::get_Database/0",
@@ -169,7 +173,8 @@ public static class NclCecilRewrite
         "Microsoft.Dynamics.Nav.Runtime.NavRecordId::get_CollationAwareStringComparer/0",
         // NavRecord no-ops
         "Microsoft.Dynamics.Nav.Runtime.NavRecord::Dispose/1",
-        "Microsoft.Dynamics.Nav.Runtime.NavRecord::UpdateReferencesOnRenameAsync/2",
+        // NavRecord::UpdateReferencesOnRenameAsync/2 is deliberately NOT here: BC's real
+        // body runs (rename propagation to validated TableRelation fields, issue #1730).
         // RecordLink / management
         "Microsoft.Dynamics.Nav.Runtime.RecordLink::MoveLinksAsync/2",
         "Microsoft.Dynamics.Nav.Runtime.NavManagementTasks::CopyCompany/2",
@@ -6241,9 +6246,8 @@ public static class NclCecilRewrite
                 Console.Error.WriteLine($"[Cecil] NavDialog: {dialogNoOps} progress-dialog method(s) → headless no-op");
             }
 
-            // ── NavRecord no-ops (Dispose / UpdateRefs) ──
-            // Dispose(bool) → NoOp2;
-            // UpdateReferencesOnRenameAsync(List,NavRecord) instance overload → ReturnValueTask3.
+            // ── NavRecord no-ops (Dispose) ──
+            // Dispose(bool) → NoOp2.
             ReplaceBodyWithHelper(nclMod,
                 ByParams(Rt + "NavRecord", "Dispose", "Boolean"),
                 H(helperShims, "NoOp2"));
@@ -6251,14 +6255,26 @@ public static class NclCecilRewrite
             // `(GlobalTriggers.GetTriggersOnTable(TableID) & wanted) != 0`, which now works
             // because GetTriggersOnTable is real again. It used to be forced to false, so
             // the write pipeline skipped global-trigger dispatch entirely.
-            {
-                var navRec = nclMod.GetType(Rt + "NavRecord")!;
-                var updRefs = navRec.Methods.FirstOrDefault(m =>
-                    m.Name == "UpdateReferencesOnRenameAsync" && m.HasBody && m.HasThis
-                    && m.Parameters.Count == 2 && m.Parameters[1].ParameterType.Name == "NavRecord")
-                    ?? throw new InvalidOperationException("[Cecil] NavRecord.UpdateReferencesOnRenameAsync(List,NavRecord) not found — do not commit");
-                ReplaceBodyWithHelper(nclMod, updRefs, H(helperShims, "ReturnValueTask3"));
-            }
+            //
+            // NavRecord.UpdateReferencesOnRenameAsync(List,NavRecord) is NOT rewritten
+            // either (it was a ReturnValueTask3 no-op until issue #1730): BC's real body
+            // implements rename propagation — for every validated TableRelation pointing
+            // at the renamed table it rewrites the referencing rows via ModifyAllAsync /
+            // RenameAsync with triggers off. That path runs entirely on metaTable relation
+            // metadata and the in-memory DataAccess, both of which the runner populates,
+            // so the real body is the faithful behaviour. No-opping it silently left child
+            // rows pointing at the old key.
+            //
+            // ── NCLMetaTable.ComputeReferencingRelations(NavAppGroup,NCLMetaTable) ──
+            // The one thing that real body needs and the skeleton cannot give it: BC
+            // computes the referencing-relations reverse index over
+            // ObjectLoader.MetadataCache.GetSnapshotOfAllNonVirtualMetaTables(...), and
+            // ObjectLoader is null on runner-built meta tables (NRE). The replacement
+            // computes the identical index over the runner's metatable cache — see the
+            // equivalence note on RecordPatches.NCLMetaTable_ComputeReferencingRelations.
+            ReplaceBodyWithHelper(nclMod,
+                ByParams(Rt + "NCLMetaTable", "ComputeReferencingRelations", "NavAppGroup", "NCLMetaTable"),
+                H(recordPatches, "NCLMetaTable_ComputeReferencingRelations"));
 
             // ── RecordLink.MoveLinksAsync(NavRecord,NavRecord) static → ReturnValueTask2 ──
             ReplaceBodyWithHelper(nclMod,

--- a/AlRunner/Patches/RecordPatches.AlSourceParser.cs
+++ b/AlRunner/Patches/RecordPatches.AlSourceParser.cs
@@ -241,8 +241,54 @@ public static partial class RecordPatches
         bool isAutoIncrement = PropIs(props, "AutoIncrement", "true");
         var caption = CaptionFrom(PropValue(props, "Caption"));
 
+        // TableRelation: only the UNCONDITIONAL, UNFILTERED `Table` / `Table.Field` shapes
+        // are captured — those are the ones NavRecord.UpdateReferencesOnRenameAsync needs to
+        // propagate a parent Rename (#1730). A relation with an if/else arm or a where(...)
+        // filter is deliberately NOT captured: building it without its conditions would make
+        // Rename propagate rows real BC leaves alone, which is worse than the old behaviour
+        // (no propagation). Conditional/filtered relations remain a tracked gap.
+        string? relationTableName = null, relationFieldName = null;
+        bool relationValidate = !PropIs(props, "ValidateTableRelation", "false");
+        if (!isFlowField && !PropIs(props, "FieldClass", "FlowFilter")
+            && PropValue(props, "TableRelation") is NavSyntax.TableRelationPropertyValueSyntax
+                { IfExpression: null, TableFilter: null, ElseExpression: null } tr)
+        {
+            var parts = NameParts(tr.RelatedTableField);
+            // 1 part = table; 2 parts = table + field. A 3+-part (namespace-qualified) name
+            // is ambiguous without symbol resolution, so it stays uncaptured.
+            if (parts.Count is 1 or 2)
+            {
+                relationTableName = parts[0];
+                relationFieldName = parts.Count == 2 ? parts[1] : null;
+            }
+        }
+
         return new ParsedField(fid, fname, ftype, length, isFlowField, calcFormula,
-            optionMembers, initValueText, isAutoIncrement, caption);
+            optionMembers, initValueText, isAutoIncrement, caption,
+            relationTableName, relationFieldName, relationValidate);
+    }
+
+    /// <summary>Flattens a (possibly qualified) name into its unquoted identifier parts:
+    /// <c>"ALT Relation Parent"."Code"</c> → ["ALT Relation Parent", "Code"].</summary>
+    private static List<string> NameParts(NavSyntax.NameSyntax? name)
+    {
+        var parts = new List<string>();
+        void Walk(NavSyntax.NameSyntax? n)
+        {
+            switch (n)
+            {
+                case NavSyntax.QualifiedNameSyntax q:
+                    Walk(q.Left);
+                    if (q.Right != null)
+                        parts.Add(Unquote(q.Right.Identifier.ValueText ?? q.Right.Identifier.Text ?? ""));
+                    break;
+                case NavSyntax.SimpleNameSyntax s:
+                    parts.Add(Unquote(s.Identifier.ValueText ?? s.Identifier.Text ?? ""));
+                    break;
+            }
+        }
+        Walk(name);
+        return parts;
     }
 
     private static void TryParseTableFile(string text)
@@ -588,7 +634,7 @@ internal record ParsedCalcFilter(
 /// <c>MetaCalcFormula.reverseSign</c> → <c>NCLMetaCalculationFormula.NegateResult</c>.</param>
 internal record ParsedCalcFormula(string FormulaType, string SourceTableName, string? SourceFieldName, List<ParsedCalcFilter> Filters, bool Negated = false);
 
-internal record ParsedField(int FieldId, string FieldName, string TypeName, int Length, bool IsFlowField = false, ParsedCalcFormula? CalcFormula = null, string? OptionMembers = null, string? InitValueText = null, bool IsAutoIncrement = false, string? Caption = null);
+internal record ParsedField(int FieldId, string FieldName, string TypeName, int Length, bool IsFlowField = false, ParsedCalcFormula? CalcFormula = null, string? OptionMembers = null, string? InitValueText = null, bool IsAutoIncrement = false, string? Caption = null, string? RelationTableName = null, string? RelationFieldName = null, bool RelationValidate = true);
 internal record ParsedKey(string Name, List<int> FieldIds);
 internal record ParsedTable(int TableId, string TableName,
     List<ParsedField> Fields, List<int> PkFieldIds, List<ParsedKey>? SecondaryKeys = null,

--- a/AlRunner/Patches/RecordPatches.NclMetaTableBuilder.cs
+++ b/AlRunner/Patches/RecordPatches.NclMetaTableBuilder.cs
@@ -365,6 +365,13 @@ public static partial class RecordPatches
             ? BuildMetaCalcFormula(f.CalcFormula, parentTable)
             : null;
 
+        // TableRelation → ImmutableArray<MetaFieldRelation> (one element). NCLMetaField turns
+        // it into the NCLMetaFieldRelation that GetReferencingRelations' reverse index — and
+        // therefore Rename propagation (#1730) — is built from.
+        object? relationsObj = f.RelationTableName != null
+            ? BuildMetaFieldRelations(f.RelationTableName, f.RelationFieldName)
+            : null;
+
         for (int i = 0; i < ps.Length; i++)
         {
             var p = ps[i];
@@ -399,6 +406,20 @@ public static partial class RecordPatches
             if (p.Name == "calcFormula" && calcFormulaObj != null)
             {
                 args[i] = calcFormulaObj;
+                continue;
+            }
+            if (p.Name == "relations" && relationsObj != null)
+            {
+                args[i] = relationsObj;
+                continue;
+            }
+            // ValidateTableRelation: AL's default is true (MetaField's own null-default also
+            // resolves to true), so only the explicit opt-out needs passing. It matters even
+            // when the relation itself was not captured — the flag alone is what suppresses
+            // rename propagation on a field whose relation a tableextension adds later.
+            if (p.Name == "validateRelation" && !f.RelationValidate)
+            {
+                args[i] = (bool?)false;
                 continue;
             }
             if (p.Name == "optionString" && !string.IsNullOrEmpty(f.OptionMembers))
@@ -450,6 +471,70 @@ public static partial class RecordPatches
             args[i] = p.ParameterType.IsValueType ? Activator.CreateInstance(p.ParameterType) : null;
         }
         return ctor.Invoke(args)!;
+    }
+
+    /// <summary>
+    /// Builds the ImmutableArray&lt;MetaFieldRelation&gt; for a field's parsed TableRelation.
+    /// The parser hands over 1 or 2 name parts; two parts are AL-ambiguous between
+    /// `Table.Field` and `Namespace.Table`, so resolution tries `Table.Field` first and falls
+    /// back to treating the last part as a namespace-qualified table. Returns null (relation
+    /// dropped, pre-#1730 behaviour: no rename propagation) when nothing resolves — a name
+    /// that cannot be resolved must not guess, because fieldId 0 means "the primary key"
+    /// and would propagate renames real BC does not.
+    /// </summary>
+    private static object? BuildMetaFieldRelations(string tableName, string? fieldName)
+    {
+        if (_tMetaFieldRelation == null) return null;
+
+        ParsedTable? Resolve(string name) =>
+            _parsedTables.Values.FirstOrDefault(t =>
+                string.Equals(t.TableName, name, StringComparison.OrdinalIgnoreCase))
+            ?? TryPopulateParsedTableByName(name);
+
+        var target = Resolve(tableName);
+        int fieldId = 0;
+        if (target != null && fieldName != null)
+        {
+            var tf = target.Fields.FirstOrDefault(x =>
+                string.Equals(x.FieldName, fieldName, StringComparison.OrdinalIgnoreCase));
+            if (tf != null)
+            {
+                fieldId = tf.FieldId;
+            }
+            else
+            {
+                // `A.B` where A is a table but B is not its field — try B as the table
+                // (`Namespace.Table` reading) before giving up.
+                target = null;
+            }
+        }
+        if (target == null && fieldName != null)
+        {
+            target = Resolve(fieldName);
+            fieldId = 0;
+        }
+        if (target == null)
+        {
+            Console.Error.WriteLine(
+                $"[RecordPatches] TableRelation target '{tableName}{(fieldName != null ? "." + fieldName : "")}' did not resolve to a parsed table — relation dropped");
+            return null;
+        }
+
+        var ctor = _tMetaFieldRelation.GetConstructors()
+            .OrderByDescending(c => c.GetParameters().Length)
+            .First();
+        var ps = ctor.GetParameters();
+        var args = new object?[ps.Length];
+        for (int i = 0; i < ps.Length; i++)
+        {
+            var p = ps[i];
+            if (p.Name == "tableId") { args[i] = target.TableId; continue; }
+            if (p.Name == "tableName") { args[i] = target.TableName; continue; }
+            if (p.Name == "fieldId") { args[i] = fieldId; continue; }
+            if (p.HasDefaultValue) { args[i] = p.DefaultValue; continue; }
+            args[i] = p.ParameterType.IsValueType ? Activator.CreateInstance(p.ParameterType) : null;
+        }
+        return MakeImmutableArray(_tMetaFieldRelation, new[] { ctor.Invoke(args)! });
     }
 
     private static object? BuildMetaCalcFormula(ParsedCalcFormula cf, ParsedTable parentTable)

--- a/AlRunner/Patches/RecordPatches.NclMetadataCachePopulator.cs
+++ b/AlRunner/Patches/RecordPatches.NclMetadataCachePopulator.cs
@@ -356,4 +356,38 @@ public static partial class RecordPatches
         _fNCLMetaAppObjMetadataLoaded = tNclMetaAppObj?.GetField("metadataLoaded",
             BindingFlags.NonPublic | BindingFlags.Instance);
     }
+
+    /// <summary>
+    /// Cecil-rewritten body for NCLMetaTable.ComputeReferencingRelations(NavAppGroup,
+    /// NCLMetaTable) — the reverse index Rename propagation reads (#1730). BC's own body
+    /// computes the identical index over
+    /// ObjectLoader.MetadataCache.GetSnapshotOfAllNonVirtualMetaTables(...), but ObjectLoader
+    /// is null on every runner-built NCLMetaTable, so the original NREs.
+    /// <para>Observable equivalence: the snapshot BC iterates is "every table that exists in
+    /// the application"; the runner's equivalent universe is _metaTableCache —
+    /// PopulateNclMetadataCache eagerly builds every parsed table into it, and .app-fallback
+    /// tables enter it the moment anything touches them. A table absent from the cache has
+    /// never been instantiated in this run, therefore holds no rows, and BC's propagation
+    /// over it would find nothing to update anyway. Virtual tables (id ≥ 2,000,000,000) are
+    /// excluded exactly as GetSnapshotOfAllNonVirtualMetaTables excludes them.</para>
+    /// </summary>
+    public static NCLMetaFieldRelation[] NCLMetaTable_ComputeReferencingRelations(
+        object appGroup, NCLMetaTable context)
+    {
+        var result = new List<NCLMetaFieldRelation>();
+        foreach (var value in _metaTableCache.Values)
+        {
+            if (value is not NCLMetaTable child) continue;
+            if (child.TableId >= 2000000000) continue;
+            foreach (var field in child.Fields)
+            {
+                var relations = field?.FieldRelations;
+                if (relations == null || relations.Count == 0) continue;
+                foreach (var rel in relations)
+                    if (rel.SourceTableId == context.TableId)
+                        result.Add(rel);
+            }
+        }
+        return result.ToArray();
+    }
 }

--- a/AlRunner/Patches/RecordPatches.cs
+++ b/AlRunner/Patches/RecordPatches.cs
@@ -32,6 +32,7 @@ public static partial class RecordPatches
     private static Type? _tFieldClass;
     private static Type? _tMetaCalcFormula;
     private static Type? _tMetaFilter;
+    private static Type? _tMetaFieldRelation;
     private static Type? _tFilterType;
     private static Type? _tNCLMetaTable;
     private static MethodInfo? _mCreateFromMetaTable;
@@ -197,6 +198,7 @@ public static partial class RecordPatches
         _tFieldClass = typesAsm.GetType("Microsoft.Dynamics.Nav.Types.Metadata.FieldClass")!;
         _tMetaCalcFormula = typesAsm.GetType("Microsoft.Dynamics.Nav.Types.Metadata.MetaCalcFormula")!;
         _tMetaFilter  = typesAsm.GetType("Microsoft.Dynamics.Nav.Types.Metadata.MetaFilter")!;
+        _tMetaFieldRelation = typesAsm.GetType("Microsoft.Dynamics.Nav.Types.Metadata.MetaFieldRelation")!;
         _tFilterType  = typesAsm.GetType("Microsoft.Dynamics.Nav.Types.Metadata.FilterType")!;
 
         // NCLMetaTable and factory (Microsoft.Dynamics.Nav.Runtime / Ncl)


### PR DESCRIPTION
Closes #1730

## What

Renaming a record's primary key now propagates to rows in other tables holding a validated `TableRelation` to it, matching real BC. `ValidateTableRelation = false` and relation-less fields are untouched, exactly as the corpus pins it.

## Root cause

`NavRecord.UpdateReferencesOnRenameAsync(List, NavRecord)` — BC's own rename-propagation body — was Cecil-rewritten to a `ReturnValueTask3` no-op, so every rename silently left child rows pointing at the old key.

## Fix (three parts)

1. **Un-no-op `UpdateReferencesOnRenameAsync`** — BC's real body runs. It walks the referencing-relations reverse index and rewrites child rows via `ModifyAllAsync` / `RenameAsync` with triggers off; everything it needs is relation metadata + the in-memory DataAccess.
2. **Relation metadata** — the AL source parser now captures the simple `TableRelation = Table` / `Table."Field"` shapes (and `ValidateTableRelation = false`) and builds them into `MetaField.relations`, so `NCLMetaField.FieldRelations` materializes. Conditional (`if/else`) and `where(...)`-filtered relations are deliberately **not** captured: building them without their conditions would make Rename rewrite rows real BC leaves alone. They keep the pre-fix behaviour (no propagation) — tracked in #1737.
3. **`NCLMetaTable.ComputeReferencingRelations`** — BC computes the reverse index over `ObjectLoader.MetadataCache.GetSnapshotOfAllNonVirtualMetaTables(...)`; `ObjectLoader` is null on runner-built meta tables (NRE). Cecil-forwarded to a runner helper computing the identical index over the runner's metatable cache. Equivalence: a table absent from that cache was never instantiated in the run, holds no rows, and BC's propagation over it would find nothing to update; virtual tables are excluded exactly as BC excludes them.

## Proof (RED → GREEN)

Proving test: `tests/al-language/tests/al-language/record/TestRenamePropagation.al` (codeunit 60236, corpus PR #17, validated against a real BC service tier), which arrives with the pin bump in #1735.

- RED (before, corpus at `294f65e`): `Record_Rename_ValidatedRelation_PropagatesToReferencingRecords` fails `Expected:<NEWCODE> Actual:<OLDCODE>`; the two negative cases pass.
- GREEN (after): all 3 tests in codeunit 60236 pass — including the two negative directions (`ValidateTableRelation = false` must not propagate; no-relation control must never propagate).

## Regression runs

- Corpus at the pinned `484c961`: **1904/1904 pass**.
- Corpus at `294f65e` (the #1735 pin bump): **1923/1926 pass** — the 3 remaining failures are the separately tracked gaps 60235 (#1732), 60877 (#1733), and 60874 (declared `oos-http` in #1735).

## Coordination with #1735

Once this merges, #1735's `tests/expectations/known-gaps-record.json` entry for codeunit 60236 must be dropped — after #1734 wires the manifest, a stale entry fails the run with "remove the entry".

No `CHANGELOG.md` or `tests/al-language/` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RqB1zkfaWrFP6hcSNVdAW6
