### PR TITLE
fix(expectations): wire the ExpectationManifest into the run — declarations now reach counts, exit codes and drift enforcement

### DIFF
--- a/AlRunner.Tests/ExpectationManifestWiringTests.cs
+++ b/AlRunner.Tests/ExpectationManifestWiringTests.cs
@@ -1,0 +1,177 @@
+// ExpectationManifestWiringTests — tests/expectations must actually reach the run.
+//
+// Issue #1734: AlRunner/Infrastructure/ExpectationManifest.cs implemented the whole
+// classification table in docs/expectations.md and NOTHING ever called it. Every
+// expectation entry was inert: an expect-oos test still failed the run, drift in either
+// direction could never fire, and the documented escape hatch for corpus tests the
+// runner cannot support did not exist.
+//
+// These tests spawn the real CLI against Fixtures/ExpectationsBundle (one codeunit,
+// one method per classification path) plus Fixtures/ExpectationsManifest and pin the
+// contract end-to-end:
+//   - the reclassifying paths (pass-oos / pass-known-gap / skipped) reach the exit code,
+//   - both drift directions fail the run with the documented diagnostics,
+//   - a malformed manifest aborts startup loudly,
+//   - without a manifest, behaviour is unchanged.
+
+using System.Diagnostics;
+using System.Text;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+// See DefineFlagIntegrationTests for why runner-subprocess tests are serialized.
+[Collection("server-serial")]
+public sealed class ExpectationManifestWiringTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+    private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
+    private static readonly string SuitePath = Path.Combine(
+        RepoRoot, "AlRunner.Tests", "Fixtures", "ExpectationsBundle", "suite");
+    private static readonly string ManifestDir = Path.Combine(
+        RepoRoot, "AlRunner.Tests", "Fixtures", "ExpectationsManifest");
+    private static readonly string MalformedManifestDir = Path.Combine(
+        RepoRoot, "AlRunner.Tests", "Fixtures", "ExpectationsManifestMalformed");
+
+    private static bool ArtifactsPresent()
+    {
+        var home = Environment.GetEnvironmentVariable("HOME")
+            ?? Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        var stdCache = Path.Combine(home, ".local", "share", "al-runner", "artifacts");
+        return Directory.Exists(stdCache) && Directory.EnumerateDirectories(stdCache).Any();
+    }
+
+    private static (string Output, int Exit) RunRunner(string runnerArgs, string? workingDir = null)
+    {
+        var args = new StringBuilder(TestBuildConfig.RunArgs(ProjectPath));
+        args.Append(TestBuildConfig.BcVersionArg);
+        args.Append(' ').Append(runnerArgs);
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet", Arguments = args.ToString(),
+            RedirectStandardOutput = true, RedirectStandardError = true,
+            UseShellExecute = false, CreateNoWindow = true,
+            WorkingDirectory = workingDir ?? RepoRoot,
+        };
+        var sb = new StringBuilder();
+        using var p = Process.Start(psi)!;
+        p.OutputDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.ErrorDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.BeginOutputReadLine();
+        p.BeginErrorReadLine();
+        if (!p.WaitForExit(240_000)) { try { p.Kill(true); } catch { } throw new TimeoutException("runner hung"); }
+        p.WaitForExit();
+        lock (sb) return (sb.ToString(), p.ExitCode);
+    }
+
+    private static void AssertCount(string output, string label, int expected)
+    {
+        var m = Regex.Match(output, Regex.Escape(label) + @"\s*(\d+)");
+        Assert.True(m.Success, $"summary must report a '{label}' count.\n{output}");
+        Assert.True(int.Parse(m.Groups[1].Value) == expected,
+            $"expected {label} {expected}, got {m.Groups[1].Value}.\n{output}");
+    }
+
+    /// <summary>
+    /// The reclassifying paths in one run: a plain pass, a declared OOS throw, a
+    /// declared known-gap failure, and a declared skip. All four must land the run at
+    /// exit 0, with each reclassified count reported DISTINCTLY (a green run that got
+    /// there via quarantined tests must not read as an unqualified green), and the
+    /// skip-declared body must never execute.
+    /// </summary>
+    [Fact]
+    public void DeclaredExpectations_ReclassifyToGreen_AndReachTheExitCode()
+    {
+        if (!ArtifactsPresent()) { Console.Error.WriteLine("[skip] BC artifacts not provisioned"); return; }
+
+        var (output, exit) = RunRunner(
+            $"--expectations \"{ManifestDir}\" --test GreenPath \"{SuitePath}\"");
+
+        // The skip entry must prevent INVOCATION, not just hide the result.
+        Assert.DoesNotContain("SKIP-DECLARED TEST BODY RAN", output, StringComparison.Ordinal);
+
+        // Each reclassified bucket is reported distinctly, per docs/expectations.md.
+        AssertCount(output, "pass-oos:", 1);
+        AssertCount(output, "pass-known-gap:", 1);
+        AssertCount(output, "skipped:", 1);
+        AssertCount(output, "  fail:", 0);
+
+        // The whole point of #1734: the reclassification reaches the exit code.
+        Assert.True(exit == 0,
+            $"declared expectations must reclassify to a green run. exit={exit}\n{output}");
+    }
+
+    /// <summary>
+    /// Both drift directions, in one run: entries whose tests now pass (expect-oos and
+    /// expect-fail-known-gap) and an OOS throw with no entry. Each must surface its
+    /// documented diagnostic and the run must exit non-zero — manifest drift is loud.
+    /// </summary>
+    [Fact]
+    public void ManifestDrift_BothDirections_FailTheRunLoudly()
+    {
+        if (!ArtifactsPresent()) { Console.Error.WriteLine("[skip] BC artifacts not provisioned"); return; }
+
+        var (output, exit) = RunRunner($"--expectations \"{ManifestDir}\" \"{SuitePath}\"");
+
+        // Direction 1a: expect-oos entry whose test passes → remove the entry.
+        Assert.Contains("runner now supports this surface", output, StringComparison.Ordinal);
+        // Direction 1b: known-gap entry whose test passes → remove the entry, close the issue.
+        Assert.Contains("close the linked issue", output, StringComparison.Ordinal);
+        // Direction 2: undeclared OOS throw → add an entry.
+        Assert.Contains("Add an expect-oos entry", output, StringComparison.Ordinal);
+
+        // The three drift methods are the only failures; the green-path methods still
+        // reclassify (drift must not disable classification for the rest of the run).
+        AssertCount(output, "pass-oos:", 1);
+        AssertCount(output, "pass-known-gap:", 1);
+        AssertCount(output, "skipped:", 1);
+        AssertCount(output, "  fail:", 3);
+
+        Assert.True(exit == 1,
+            $"manifest drift must fail the run (exit 1 = test failures). exit={exit}\n{output}");
+    }
+
+    /// <summary>
+    /// A malformed manifest (unknown Mode) must abort startup loudly, naming the file
+    /// and the bad value — never run tests against a manifest it could not parse.
+    /// </summary>
+    [Fact]
+    public void MalformedManifest_AbortsStartupLoudly()
+    {
+        if (!ArtifactsPresent()) { Console.Error.WriteLine("[skip] BC artifacts not provisioned"); return; }
+
+        var (output, exit) = RunRunner(
+            $"--expectations \"{MalformedManifestDir}\" \"{SuitePath}\"");
+
+        Assert.Contains("unknown Mode 'expect-magic'", output, StringComparison.Ordinal);
+        Assert.True(exit == 2,
+            $"a malformed manifest is a bad invocation and must exit 2 without running tests. exit={exit}\n{output}");
+        // Startup aborted — nothing may have run. The loader's diagnostic quotes the
+        // entry by AL object name, so probe for the CLR type name ("Codeunit60810"),
+        // which only per-test run output produces.
+        Assert.DoesNotContain("Codeunit60810", output, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Negative direction: with NO manifest (cwd without tests/expectations and no
+    /// --expectations flag), behaviour is unchanged — an uncaught OOS throw is a plain
+    /// FAIL without any drift diagnostic. Without this, the assertions above would
+    /// still hold if classification ran unconditionally and rewrote every user-facing
+    /// OOS failure into manifest advice.
+    /// </summary>
+    [Fact]
+    public void NoManifest_UnchangedBehaviour_OosIsAPlainFail()
+    {
+        if (!ArtifactsPresent()) { Console.Error.WriteLine("[skip] BC artifacts not provisioned"); return; }
+
+        var (output, exit) = RunRunner(
+            $"--test Drift_OosThrownButNoEntry \"{SuitePath}\"",
+            workingDir: Path.Combine(RepoRoot, "AlRunner.Tests", "Fixtures"));
+
+        Assert.DoesNotContain("Add an expect-oos entry", output, StringComparison.Ordinal);
+        AssertCount(output, "  fail:", 1);
+        Assert.True(exit == 1, $"an uncaught OOS throw stays a failing test. exit={exit}\n{output}");
+    }
+}

--- a/AlRunner.Tests/Fixtures/ExpectationsBundle/suite/ExpectationTests.Codeunit.al
+++ b/AlRunner.Tests/Fixtures/ExpectationsBundle/suite/ExpectationTests.Codeunit.al
@@ -1,0 +1,83 @@
+/// <summary>
+/// One method per ExpectationManifest classification path (#1734). Method names
+/// are the selection mechanism: the integration test runs `--test GreenPath` to
+/// prove the reclassifying paths exit 0, then the whole codeunit to prove both
+/// drift directions fail the run loudly.
+/// </summary>
+codeunit 60810 "Expct Fixture Tests"
+{
+    Subtype = Test;
+
+    // ── Green paths: with the paired manifest these four must land the run at exit 0 ──
+
+    [Test]
+    procedure GreenPath_PlainPass()
+    begin
+        // No manifest entry; a normal pass. Concrete assertion so the method
+        // cannot pass vacuously.
+        if 1 + 2 <> 3 then
+            Error('arithmetic broke: 1 + 2 <> 3');
+    end;
+
+    [Test]
+    procedure GreenPath_OosDeclared()
+    begin
+        // Manifest declares expect-oos with the matching reason → pass-oos.
+        OpenRightOuterJoinQuery();
+    end;
+
+    [Test]
+    procedure GreenPath_KnownGapDeclared()
+    begin
+        // Manifest declares expect-fail-known-gap → pass-known-gap.
+        Error('simulated known gap: surface not yet implemented in the runner');
+    end;
+
+    [Test]
+    procedure GreenPath_SkipDeclared()
+    begin
+        // Manifest declares skip → the runner must never invoke this body.
+        // The integration test asserts this marker is ABSENT from the output.
+        Error('SKIP-DECLARED TEST BODY RAN - skip must prevent invocation');
+    end;
+
+    // ── Drift paths: each must FAIL the run with the documented diagnostic ──
+
+    [Test]
+    procedure Drift_OosEntryButPasses()
+    begin
+        // Manifest declares expect-oos but the test passes cleanly →
+        // "Remove the entry … runner now supports this surface."
+        if 2 * 2 <> 4 then
+            Error('arithmetic broke: 2 * 2 <> 4');
+    end;
+
+    [Test]
+    procedure Drift_KnownGapEntryButPasses()
+    begin
+        // Manifest declares expect-fail-known-gap but the test passes cleanly →
+        // "Remove the entry … and close the linked issue."
+        if 10 div 2 <> 5 then
+            Error('arithmetic broke: 10 div 2 <> 5');
+    end;
+
+    [Test]
+    procedure Drift_OosThrownButNoEntry()
+    begin
+        // No manifest entry, but the runner throws RunnerOutOfScopeException →
+        // "Add an expect-oos entry … or implement the surface."
+        OpenRightOuterJoinQuery();
+    end;
+
+    local procedure OpenRightOuterJoinQuery()
+    var
+        RightJoin: Query "Expct Right Join";
+    begin
+        // Deliberately NOT wrapped in asserterror: the typed
+        // RunnerOutOfScopeException must reach the test executor uncaught so
+        // the manifest classification sees it.
+        RightJoin.Open();
+        RightJoin.Read();
+        Error('RightOuterJoin query unexpectedly opened - the OOS surface is gone');
+    end;
+}

--- a/AlRunner.Tests/Fixtures/ExpectationsBundle/suite/Query.al
+++ b/AlRunner.Tests/Fixtures/ExpectationsBundle/suite/Query.al
@@ -1,0 +1,25 @@
+// RightOuterJoin: the runner's in-memory nested-loop join executor cannot
+// faithfully reproduce it, so opening this query throws a typed
+// RunnerOutOfScopeException (see AlRunner.QueryJoin/JoinExecutor.cs). The
+// fixture tests below open it WITHOUT asserterror so the throw reaches the
+// test executor and can be classified against the manifest.
+query 60802 "Expct Right Join"
+{
+    QueryType = Normal;
+
+    elements
+    {
+        dataitem(Customer; "Expct Customer")
+        {
+            column(CustNo; "No.") { }
+
+            dataitem(Ord; "Expct Order")
+            {
+                DataItemLink = "Customer No." = Customer."No.";
+                SqlJoinType = RightOuterJoin;
+
+                column(EntryNo; "Entry No.") { }
+            }
+        }
+    }
+}

--- a/AlRunner.Tests/Fixtures/ExpectationsBundle/suite/Tables.al
+++ b/AlRunner.Tests/Fixtures/ExpectationsBundle/suite/Tables.al
@@ -1,0 +1,36 @@
+// Parent + child tables backing the RightOuterJoin query. The query is the
+// fixture's deterministic typed-OOS surface: the in-memory join executor throws
+// RunnerOutOfScopeException with reason "query-join-rightouterjoin-not-implemented"
+// (permanently out of scope, so this fixture cannot rot into a passing test).
+
+table 60800 "Expct Customer"
+{
+    DataClassification = CustomerContent;
+
+    fields
+    {
+        field(1; "No."; Code[20]) { }
+        field(2; "Name"; Text[50]) { }
+    }
+
+    keys
+    {
+        key(PK; "No.") { Clustered = true; }
+    }
+}
+
+table 60801 "Expct Order"
+{
+    DataClassification = CustomerContent;
+
+    fields
+    {
+        field(1; "Entry No."; Integer) { }
+        field(2; "Customer No."; Code[20]) { }
+    }
+
+    keys
+    {
+        key(PK; "Entry No.") { Clustered = true; }
+    }
+}

--- a/AlRunner.Tests/Fixtures/ExpectationsBundle/suite/app.json
+++ b/AlRunner.Tests/Fixtures/ExpectationsBundle/suite/app.json
@@ -1,0 +1,25 @@
+{
+  "id": "a7c1d2e3-8f90-4b1c-9d2e-3f4a5b6c7d80",
+  "name": "Runner Tests Fixture - Expectations Bundle",
+  "publisher": "AL Runner",
+  "version": "1.0.0.0",
+  "brief": "Exercises every ExpectationManifest classification path (#1734).",
+  "description": "One test codeunit whose methods cover the green reclassification paths (pass, pass-oos, pass-known-gap, skipped) and the drift directions (stale expect-oos entry, stale known-gap entry, undeclared out-of-scope throw). The paired manifest lives in Fixtures/ExpectationsManifest.",
+  "privacyStatement": "",
+  "EULA": "",
+  "help": "",
+  "url": "",
+  "logo": "",
+  "dependencies": [],
+  "screenshots": [],
+  "platform": "1.0.0.0",
+  "application": "1.0.0.0",
+  "idRanges": [
+    {
+      "from": 60800,
+      "to": 60849
+    }
+  ],
+  "runtime": "14.0",
+  "features": []
+}

--- a/AlRunner.Tests/Fixtures/ExpectationsManifest/fixture-expectations.json
+++ b/AlRunner.Tests/Fixtures/ExpectationsManifest/fixture-expectations.json
@@ -1,0 +1,43 @@
+[
+  {
+    "codeunitId": 60810,
+    "CodeunitName": "Expct Fixture Tests",
+    "Method": "GreenPath_OosDeclared",
+    "Mode": "expect-oos",
+    "Reason": "query-join-rightouterjoin-not-implemented",
+    "Doc": "docs/scope.md#queries",
+    "Note": "Fixture entry: matching reason anchor, so the OOS throw reclassifies to pass-oos."
+  },
+  {
+    "codeunitId": 60810,
+    "CodeunitName": "Expct Fixture Tests",
+    "Method": "GreenPath_KnownGapDeclared",
+    "Mode": "expect-fail-known-gap",
+    "Issue": "https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/1734",
+    "Note": "Fixture entry: the test fails by design, so it reclassifies to pass-known-gap."
+  },
+  {
+    "codeunitId": 60810,
+    "CodeunitName": "Expct Fixture Tests",
+    "Method": "GreenPath_SkipDeclared",
+    "Mode": "skip",
+    "Note": "Fixture entry: the test body errors with a marker if it ever runs; skip must prevent invocation."
+  },
+  {
+    "codeunitId": 60810,
+    "CodeunitName": "Expct Fixture Tests",
+    "Method": "Drift_OosEntryButPasses",
+    "Mode": "expect-oos",
+    "Reason": "query-join-rightouterjoin-not-implemented",
+    "Doc": "docs/scope.md#queries",
+    "Note": "Fixture entry: deliberately stale — the test passes, so the run must fail with 'Remove the entry'."
+  },
+  {
+    "codeunitId": 60810,
+    "CodeunitName": "Expct Fixture Tests",
+    "Method": "Drift_KnownGapEntryButPasses",
+    "Mode": "expect-fail-known-gap",
+    "Issue": "https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/1734",
+    "Note": "Fixture entry: deliberately stale — the test passes, so the run must fail with 'Remove the entry … close the linked issue'."
+  }
+]

--- a/AlRunner.Tests/Fixtures/ExpectationsManifestMalformed/bad.json
+++ b/AlRunner.Tests/Fixtures/ExpectationsManifestMalformed/bad.json
@@ -1,0 +1,9 @@
+[
+  {
+    "codeunitId": 60810,
+    "CodeunitName": "Expct Fixture Tests",
+    "Method": "GreenPath_PlainPass",
+    "Mode": "expect-magic",
+    "Note": "Malformed on purpose: unknown Mode must abort runner startup loudly."
+  }
+]

--- a/AlRunner/Infrastructure/ExpectationManifest.cs
+++ b/AlRunner/Infrastructure/ExpectationManifest.cs
@@ -267,7 +267,7 @@ public static class ExpectationClassifier
 
                 if (outcome.Exception is RunnerOutOfScopeException oos)
                 {
-                    if (oos.Reason == entry.Reason)
+                    if (ReasonAnchor(oos.Reason) == ReasonAnchor(entry.Reason!))
                         return new Classification(ExpectationResult.PassOos, null);
                     return new Classification(
                         ExpectationResult.FailManifestDrift,
@@ -293,5 +293,14 @@ public static class ExpectationClassifier
             default:
                 throw new InvalidOperationException($"Unhandled ExpectationMode: {entry.Mode}");
         }
+    }
+
+    // Manifest entries hold the bare docs/scope.md anchor ("query-join-rightouterjoin-
+    // not-implemented"), while throw sites append free-text detail after an em-dash
+    // ("<anchor> — only InnerJoin and …"). Reasons match on the anchor.
+    private static string ReasonAnchor(string reason)
+    {
+        int sep = reason.IndexOf(" — ", StringComparison.Ordinal);
+        return (sep >= 0 ? reason[..sep] : reason).Trim();
     }
 }

--- a/AlRunner/JUnitReport.cs
+++ b/AlRunner/JUnitReport.cs
@@ -26,6 +26,7 @@ public static class JUnitReport
         int totalTests = tests.Count;
         int totalFailures = tests.Count(t => t.Outcome == TestOutcome.Fail);
         int totalErrors = tests.Count(t => t.Outcome == TestOutcome.Error);
+        int totalSkipped = tests.Count(t => t.Outcome == TestOutcome.Skipped);
 
         using var writer = XmlWriter.Create(outputPath, new XmlWriterSettings
         {
@@ -38,6 +39,7 @@ public static class JUnitReport
         writer.WriteAttributeString("tests", totalTests.ToString());
         writer.WriteAttributeString("failures", totalFailures.ToString());
         writer.WriteAttributeString("errors", totalErrors.ToString());
+        writer.WriteAttributeString("skipped", totalSkipped.ToString());
         writer.WriteAttributeString("time", totalSeconds.ToString("F3", System.Globalization.CultureInfo.InvariantCulture));
 
         foreach (var suite in suites)
@@ -46,12 +48,14 @@ public static class JUnitReport
             double suiteSeconds = suiteTests.Sum(t => t.Duration.TotalSeconds);
             int suiteFailures = suiteTests.Count(t => t.Outcome == TestOutcome.Fail);
             int suiteErrors = suiteTests.Count(t => t.Outcome == TestOutcome.Error);
+            int suiteSkipped = suiteTests.Count(t => t.Outcome == TestOutcome.Skipped);
 
             writer.WriteStartElement("testsuite");
             writer.WriteAttributeString("name", suite.Key);
             writer.WriteAttributeString("tests", suiteTests.Count.ToString());
             writer.WriteAttributeString("failures", suiteFailures.ToString());
             writer.WriteAttributeString("errors", suiteErrors.ToString());
+            writer.WriteAttributeString("skipped", suiteSkipped.ToString());
             writer.WriteAttributeString("time", suiteSeconds.ToString("F3", System.Globalization.CultureInfo.InvariantCulture));
 
             foreach (var test in suiteTests)
@@ -74,6 +78,12 @@ public static class JUnitReport
                     writer.WriteAttributeString("message", test.Message ?? "Runner error");
                     writer.WriteString(BuildBody(test));
                     writer.WriteEndElement(); // error
+                }
+                else if (test.Outcome == TestOutcome.Skipped)
+                {
+                    writer.WriteStartElement("skipped");
+                    writer.WriteAttributeString("message", test.Message ?? "Skipped by expectations manifest");
+                    writer.WriteEndElement(); // skipped
                 }
 
                 writer.WriteEndElement(); // testcase

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -231,6 +231,11 @@ string? artifactPathArg = null;
 // Extra preprocessor symbols supplied via --define SYM / --preprocessor-symbols A,B,C.
 // Validated as AL identifiers and merged with CLEANSCHEMA1..25 in BcCompiler.
 var extraPreprocessorSymbols = new List<string>();
+// --expectations DIR: test-expectations manifest directory (issue #1734; schema in
+// docs/expectations.md). Null = probe the default ./tests/expectations below; only an
+// existing directory activates classification, so ordinary runs outside this repo are
+// untouched.
+string? expectationsDirArg = null;
 // `provision` subcommand: `al-runner provision [<project>]` provisions the BC artifacts
 // for the project's version and exits (no test run). `--auto-provision` provisions on the
 // fly when artifacts are missing, then continues the normal run. Both are the opt-in that
@@ -250,6 +255,7 @@ for (int i = 0; i < args.Length; i++)
     if (args[i] == "--package-cache" && i + 1 < args.Length) { packageCacheArgs.Add(args[++i]); continue; }
     if (args[i] == "--per-suite") { bundledMode = false; continue; }
     if (args[i] == "--bundled") { bundledMode = true; continue; }
+    if (args[i] == "--expectations" && i + 1 < args.Length) { expectationsDirArg = args[++i]; continue; }
     if (args[i] == "--cache" && i + 1 < args.Length) { alCacheDir = args[++i]; continue; }
     if (args[i] == "--no-cache") { alCacheDir = null; continue; }
     if (args[i] == "--watch") { watchMode = true; continue; }
@@ -337,6 +343,36 @@ if (serverMode && watchMode)
     {
         Console.Error.WriteLine(rootProblem);
         return 2;
+    }
+}
+// ── Test-expectations manifest (issue #1734; docs/expectations.md) ────────────────
+// Loaded HERE — at parse time, before BC init — so a malformed manifest aborts the
+// invocation (exit 2, the "bad invocation" ladder entry) without running a single
+// test. An explicit --expectations dir must exist; without the flag, the documented
+// default ./tests/expectations activates only when present (this repo's corpus CI),
+// leaving every other invocation exactly as before.
+AlRunner.Infrastructure.ExpectationManifest? expectations = null;
+{
+    var expectationsDir = expectationsDirArg;
+    if (expectationsDir != null && !Directory.Exists(expectationsDir))
+    {
+        Console.Error.WriteLine($"--expectations: directory not found: {expectationsDir}");
+        return 2;
+    }
+    expectationsDir ??= Directory.Exists(Path.Combine(Environment.CurrentDirectory, "tests", "expectations"))
+        ? Path.Combine(Environment.CurrentDirectory, "tests", "expectations")
+        : null;
+    if (expectationsDir != null)
+    {
+        try
+        {
+            expectations = AlRunner.Infrastructure.ExpectationManifest.LoadFromDirectory(expectationsDir);
+        }
+        catch (InvalidOperationException ex)
+        {
+            Console.Error.WriteLine($"expectations manifest ({expectationsDir}): {ex.Message}");
+            return 2;
+        }
     }
 }
 // --output-json: stdout must be JSON-only, matching the documented contract ("Replace
@@ -678,7 +714,7 @@ AlRunner.PerfTrace.Log($"BcRuntime.EnsureApplied {t0.ElapsedMilliseconds}ms");
 
 var emitter = new BcCompiler();
 var assembler = new BcAssembler();
-var executor = new TestExecutor { Isolation = isolation, TestFilter = testFilter, TimeoutSeconds = testTimeoutSeconds };
+var executor = new TestExecutor { Isolation = isolation, TestFilter = testFilter, TimeoutSeconds = testTimeoutSeconds, Expectations = expectations };
 var depLoader = new DependencyLoader(emitter, assembler);
 var results = new List<BucketResult>();
 
@@ -2744,6 +2780,14 @@ static void PrintHelp(TextWriter w)
     w.WriteLine("  --dump-csharp DIR       Write the intermediate C# emitted by BC's Compilation.Emit");
     w.WriteLine("                          (one .cs file per AL object) under DIR/<moduleName>/.");
     w.WriteLine("                          Useful for diagnosing codegen issues.");
+    w.WriteLine("  --expectations DIR      Load the test-expectations manifest from DIR (schema:");
+    w.WriteLine("                          docs/expectations.md). Defaults to ./tests/expectations");
+    w.WriteLine("                          when that directory exists; otherwise off. Declared");
+    w.WriteLine("                          outcomes reclassify: expect-oos -> pass-oos,");
+    w.WriteLine("                          expect-fail-known-gap -> pass-known-gap, skip -> not");
+    w.WriteLine("                          invoked. Manifest drift is loud: an entry whose test now");
+    w.WriteLine("                          passes, or an out-of-scope throw with no entry, fails");
+    w.WriteLine("                          the run with a diagnostic naming the entry to fix.");
     w.WriteLine();
     w.WriteLine("SUBCOMMANDS");
     w.WriteLine("  provision [<bundle-dir>] Download and install the BC artifacts matching the");

--- a/AlRunner/Reporter.cs
+++ b/AlRunner/Reporter.cs
@@ -16,7 +16,8 @@ public static class Reporter
 {
     public static void PrintSummary(IReadOnlyList<BucketResult> buckets, TextWriter w)
     {
-        int totalTests = 0, pass = 0, fail = 0, err = 0;
+        int totalTests = 0, pass = 0, fail = 0, err = 0, skipped = 0;
+        int passOos = 0, passKnownGap = 0;
         int compileFailed = 0, execFailed = 0;
         TimeSpan emit = TimeSpan.Zero, comp = TimeSpan.Zero, run = TimeSpan.Zero;
         foreach (var b in buckets)
@@ -27,8 +28,14 @@ public static class Reporter
             foreach (var t in b.Tests)
             {
                 totalTests++;
-                if (t.Outcome == TestOutcome.Pass) pass++;
+                if (t.Outcome == TestOutcome.Pass)
+                {
+                    pass++;
+                    if (t.Expectation == Infrastructure.ExpectationResult.PassOos) passOos++;
+                    else if (t.Expectation == Infrastructure.ExpectationResult.PassKnownGap) passKnownGap++;
+                }
                 else if (t.Outcome == TestOutcome.Fail) fail++;
+                else if (t.Outcome == TestOutcome.Skipped) skipped++;
                 else err++;
             }
         }
@@ -42,8 +49,17 @@ public static class Reporter
         w.WriteLine($"  exec-fail:   {execFailed}");
         w.WriteLine($"Tests:         {totalTests} total");
         w.WriteLine($"  pass:        {pass}");
+        // Manifest reclassifications (docs/expectations.md) are surfaced DISTINCTLY so
+        // a green run that got there via quarantined tests does not read as an
+        // unqualified green. Zero-count lines are omitted: no manifest, no noise.
+        if (passOos > 0)
+            w.WriteLine($"    pass-oos:        {passOos}");
+        if (passKnownGap > 0)
+            w.WriteLine($"    pass-known-gap:  {passKnownGap}");
         w.WriteLine($"  fail:        {fail}");
         w.WriteLine($"  error:       {err}");
+        if (skipped > 0)
+            w.WriteLine($"  skipped:     {skipped}");
         w.WriteLine($"Time:");
         w.WriteLine($"  AL emit:     {emit.TotalSeconds:F1}s");
         w.WriteLine($"  C# compile:  {comp.TotalSeconds:F1}s");
@@ -84,9 +100,12 @@ public static class Reporter
             {
                 var label = t.Outcome switch
                 {
+                    TestOutcome.Pass when t.Expectation == Infrastructure.ExpectationResult.PassOos => "PASS (oos)",
+                    TestOutcome.Pass when t.Expectation == Infrastructure.ExpectationResult.PassKnownGap => "PASS (known-gap)",
                     TestOutcome.Pass => "PASS ",
                     TestOutcome.Fail => "FAIL ",
                     TestOutcome.Error => "ERROR",
+                    TestOutcome.Skipped => "SKIP ",
                     _ => "?    "
                 };
                 long ms = (long)t.Duration.TotalMilliseconds;
@@ -119,7 +138,7 @@ public static class Reporter
     {
         var groups = buckets
             .Where(b => b.Stage == BucketStage.Ran)
-            .SelectMany(b => b.Tests.Where(t => t.Outcome != TestOutcome.Pass))
+            .SelectMany(b => b.Tests.Where(t => t.Outcome is TestOutcome.Fail or TestOutcome.Error))
             .GroupBy(t => ClassifyTest(t.Message ?? "", t.FullException ?? ""))
             .Select(g => (Classification: g.Key, Count: g.Count(),
                           Sample: g.First()))
@@ -201,10 +220,22 @@ public static class Reporter
                 durationMs = (long)t.Duration.TotalMilliseconds,
                 message = t.Message,
                 stackTrace = (t.AlCallStack ?? t.FullException)?.TrimEnd(),
+                // Manifest reclassification (docs/expectations.md): "pass-oos",
+                // "pass-known-gap", "skipped" or "fail-manifest-drift". Omitted
+                // (null) for results the manifest did not touch.
+                expectation = t.Expectation switch
+                {
+                    Infrastructure.ExpectationResult.PassOos => "pass-oos",
+                    Infrastructure.ExpectationResult.PassKnownGap => "pass-known-gap",
+                    Infrastructure.ExpectationResult.Skipped => "skipped",
+                    Infrastructure.ExpectationResult.FailManifestDrift => "fail-manifest-drift",
+                    _ => null,
+                },
             }),
             passed = tests.Count(t => t.Outcome == TestOutcome.Pass),
             failed = tests.Count(t => t.Outcome == TestOutcome.Fail),
             errors = tests.Count(t => t.Outcome == TestOutcome.Error),
+            skipped = tests.Count(t => t.Outcome == TestOutcome.Skipped),
             total = tests.Count,
             exitCode,
             compilationErrors = compileErrors.Count > 0 ? compileErrors : null,
@@ -244,7 +275,7 @@ public static class Reporter
             }
             else
             {
-                foreach (var t in b.Tests.Where(t => t.Outcome != TestOutcome.Pass))
+                foreach (var t in b.Tests.Where(t => t.Outcome is TestOutcome.Fail or TestOutcome.Error))
                 {
                     failures.Add(new
                     {

--- a/AlRunner/TestExecutor.cs
+++ b/AlRunner/TestExecutor.cs
@@ -8,7 +8,7 @@ using System.Runtime.ExceptionServices;
 
 namespace AlRunner;
 
-public enum TestOutcome { Pass, Fail, Error }
+public enum TestOutcome { Pass, Fail, Error, Skipped }
 
 /// <summary>
 /// Test-isolation granularity. Mirrors the BC "Test Runner" codeunits:
@@ -49,10 +49,17 @@ public static class TestIsolationParser
     }
 }
 
+// Exception is the caught exception object (null for Pass/Skipped) — kept so the
+// expectations manifest can classify typed throws (RunnerOutOfScopeException +
+// reason) that string messages cannot carry. Expectation is set only when the
+// manifest reclassified this result (pass-oos / pass-known-gap / skipped /
+// manifest drift); null means a plain pass/fail untouched by the manifest.
 public sealed record TestResult(string Codeunit, string Method, TestOutcome Outcome,
                                 string? Message, string? FullException, TimeSpan Duration,
                                 string? AlCallStack = null,
-                                string? CodeunitDisplayName = null);
+                                string? CodeunitDisplayName = null,
+                                Exception? Exception = null,
+                                Infrastructure.ExpectationResult? Expectation = null);
 
 public sealed class TestExecutor
 {
@@ -76,6 +83,18 @@ public sealed class TestExecutor
     /// Explicit CLI value takes precedence over the env var.
     /// </summary>
     public int? TimeoutSeconds { get; set; }
+
+    /// <summary>
+    /// Expectations manifest (issue #1734). Null = no manifest active, behaviour
+    /// unchanged. Non-null: skip-declared tests are never invoked, and every other
+    /// result runs through <see cref="Infrastructure.ExpectationClassifier.Classify"/>
+    /// here — the one chokepoint the CLI, --watch and --server paths all share — so
+    /// reclassification (pass-oos / pass-known-gap) and manifest-drift failures reach
+    /// every counter and exit code identically. Lookup is by the codeunit's AL object
+    /// name (the manifest's Microsoft-compatible CodeunitName field), falling back to
+    /// the CLR type name ("CodeunitNNNN") when the display name could not be resolved.
+    /// </summary>
+    public Infrastructure.ExpectationManifest? Expectations { get; set; }
 
     /// <summary>
     /// Runs every [Test] method in <paramref name="assembly"/>. When
@@ -179,7 +198,8 @@ public sealed class TestExecutor
             catch (Exception ex)
             {
                 var ctorResult = new TestResult(t.Name, "<ctor>", TestOutcome.Error,
-                    Unwrap(ex).Message, ex.ToString(), TimeSpan.Zero);
+                    Unwrap(ex).Message, ex.ToString(), TimeSpan.Zero,
+                    Exception: Unwrap(ex));
                 results.Add(ctorResult);
                 onTestComplete?.Invoke(ctorResult);
                 continue;
@@ -202,12 +222,31 @@ public sealed class TestExecutor
                 {
                     if (!IsTestMethod(m)) continue;
                     if (filter != null && !MethodMatchesFilter(t.Name, m.Name, filter)) continue;
+                    var entry = LookupExpectation(t.Name, displayName, m.Name);
+                    if (entry is { Mode: Infrastructure.ExpectationMode.Skip })
+                    {
+                        // skip = "must not be invoked" (docs/expectations.md), so the
+                        // decision has to sit HERE, before the body runs — a post-run
+                        // classification could only hide the result, not the side effects.
+                        var skippedResult = new TestResult(t.Name, m.Name, TestOutcome.Skipped,
+                            $"skipped — declared in {entry.SourceFile}", null, TimeSpan.Zero,
+                            null, displayName, null, Infrastructure.ExpectationResult.Skipped);
+                        results.Add(skippedResult);
+                        onTestComplete?.Invoke(skippedResult);
+                        continue;
+                    }
                     stageSw.Restart();
-                    var result = RunOne(t.Name, m, instance, displayName);
+                    var raw = RunOne(t.Name, m, instance, displayName);
                     methodsMs += stageSw.ElapsedMilliseconds;
+                    var result = Expectations != null
+                        ? ApplyExpectation(raw, displayName, entry)
+                        : raw;
                     results.Add(result);
                     onTestComplete?.Invoke(result);
-                    if (IsTimeout(result))
+                    // Timeout is judged on the RAW outcome: even if a manifest entry
+                    // reclassifies the hung test, its runaway thread still poisons the
+                    // process, so the suite must stop either way.
+                    if (IsTimeout(raw))
                         return results;
                 }
                 methodLoopMs += loopSw.ElapsedMilliseconds;
@@ -233,6 +272,62 @@ public sealed class TestExecutor
         PerfTrace.Log($"TestExecutor stages scan={scanMs}ms instantiate={instMs}ms displayName={dispMs}ms runOneOuter={methodsMs}ms dispose={disposeMs}ms methodLoop={methodLoopMs}ms");
         PerfTrace.Log($"TestExecutor total {results.Count} test(s) {totalSw.ElapsedMilliseconds}ms");
         return results;
+    }
+
+    private Infrastructure.ExpectationEntry? LookupExpectation(
+        string typeName, string displayName, string method)
+    {
+        if (Expectations == null) return null;
+        // Manifest entries hold the AL object name (Microsoft's CodeunitName field);
+        // the CLR type name ("CodeunitNNNN") is the fallback identity when display-name
+        // resolution failed, so honour entries written against either.
+        return Expectations.Lookup(displayName, method)
+            ?? (displayName != typeName ? Expectations.Lookup(typeName, method) : null);
+    }
+
+    private static TestResult ApplyExpectation(
+        TestResult raw, string displayName, Infrastructure.ExpectationEntry? entry)
+    {
+        // The classifier wants the typed exception; BC's error machinery may have
+        // wrapped the RunnerOutOfScopeException on its way out, so surface it from
+        // anywhere in the chain.
+        var oos = FindOutOfScope(raw.Exception);
+        var observed = new Infrastructure.TestOutcome(displayName, raw.Method,
+            raw.Outcome == TestOutcome.Pass, (Exception?)oos ?? raw.Exception);
+        var classified = Infrastructure.ExpectationClassifier.Classify(observed, entry);
+        switch (classified.Result)
+        {
+            case Infrastructure.ExpectationResult.Pass:
+            case Infrastructure.ExpectationResult.Fail:
+                return raw;   // no entry, no drift — untouched
+            case Infrastructure.ExpectationResult.PassOos:
+            case Infrastructure.ExpectationResult.PassKnownGap:
+                // Counts as a pass everywhere (totals, exit code, --strict), reported
+                // distinctly via Expectation so the summary can subdivide.
+                return raw with { Outcome = TestOutcome.Pass, Expectation = classified.Result };
+            case Infrastructure.ExpectationResult.FailManifestDrift:
+                return raw with
+                {
+                    Outcome = TestOutcome.Fail,
+                    Expectation = classified.Result,
+                    Message = raw.Message == null
+                        ? classified.Diagnostic
+                        : $"{classified.Diagnostic} (original result: {raw.Message})",
+                };
+            default:
+                throw new InvalidOperationException(
+                    $"Unhandled ExpectationResult: {classified.Result}");
+        }
+    }
+
+    private static Infrastructure.RunnerOutOfScopeException? FindOutOfScope(Exception? ex)
+    {
+        for (int depth = 0; ex != null && depth < 16; depth++)
+        {
+            if (ex is Infrastructure.RunnerOutOfScopeException oos) return oos;
+            ex = ex.InnerException;
+        }
+        return null;
     }
 
     private static string? NormaliseFilter(string? raw)
@@ -365,14 +460,16 @@ public sealed class TestExecutor
             // We can't classify Pass/Fail vs Error perfectly without knowing all of them,
             // so for now: any thrown exception is Fail.
             return new TestResult(codeunit, m.Name, TestOutcome.Fail,
-                $"{inner.GetType().Name}: {inner.Message}", inner.ToString(), sw.Elapsed, alStack, displayName);
+                $"{inner.GetType().Name}: {inner.Message}", inner.ToString(), sw.Elapsed, alStack, displayName,
+                inner);
         }
         catch (Exception ex)
         {
             PerfTrace.Log($"TestExecutor.RunOne ERROR {codeunit}.{m.Name} {sw.ElapsedMilliseconds}ms {ex.GetType().Name}: {ex.Message}");
             var alStack = AlRunner.Infrastructure.AlCallStackCapture.GetCaptured(ex);
             return new TestResult(codeunit, m.Name, TestOutcome.Error,
-                ex.Message, ex.ToString(), sw.Elapsed, alStack, displayName);
+                ex.Message, ex.ToString(), sw.Elapsed, alStack, displayName,
+                ex);
         }
         finally
         {

--- a/AlRunner/WatchDashboard.cs
+++ b/AlRunner/WatchDashboard.cs
@@ -120,6 +120,7 @@ public static class WatchDashboard
                         TestOutcome.Pass => ("PASS", "green"),
                         TestOutcome.Fail => ("FAIL", "red"),
                         TestOutcome.Error => ("ERROR", "yellow"),
+                        TestOutcome.Skipped => ("SKIP", "grey"),
                         _ => ("?", "grey"),
                     };
                     long ms = (long)t.Duration.TotalMilliseconds;
@@ -193,6 +194,7 @@ public static class WatchDashboard
                 {
                     case TestOutcome.Pass: pass++; break;
                     case TestOutcome.Fail: fail++; break;
+                    case TestOutcome.Skipped: break;   // manifest-declared skip; not an error
                     default: err++; break;
                 }
             }

--- a/docs/expectations.md
+++ b/docs/expectations.md
@@ -8,6 +8,16 @@ support in-process (report rendering, SMTP, HTTP egress, real task scheduler,
 etc.). The runner does not modify the corpus to make those tests pass; instead
 it declares its expectations about them in this directory.
 
+## Activation
+
+The manifest loads once at startup, before any BC initialisation. Without the
+flag, the runner probes `./tests/expectations` relative to the working
+directory and activates classification only when that directory exists — a run
+outside this repo behaves exactly as if the mechanism did not exist. Pass
+`--expectations <dir>` to point at another manifest directory explicitly (the
+directory must exist). A malformed manifest aborts the invocation with exit
+code 2 before a single test runs.
+
 ## Layout
 
 ```
@@ -65,6 +75,12 @@ when only some tests in a codeunit are affected.
 | `expect-oos` | throw `RunnerOutOfScopeException` with matching `Reason` | `pass-oos` | Surface is OOS by design (see `docs/scope.md`) — runner will never support it in-process |
 | `expect-fail-known-gap` | fail (any exception or assertion mismatch) | `pass-known-gap` | Surface is in scope but not yet implemented; `Issue` tracks the work |
 | `skip` | n/a — runner does not invoke the test | `skipped` | Test cannot compile against the current AL output, or otherwise must not run |
+
+`Reason` matches on the anchor: throw sites may append free-text detail after
+an ` — ` (em-dash) separator, while the entry holds only the leading
+`docs/scope.md` anchor (e.g. a throw site's
+`query-join-rightouterjoin-not-implemented — only InnerJoin and …` matches an
+entry declaring `query-join-rightouterjoin-not-implemented`).
 
 ### Result classification table
 

--- a/protocol-v2.schema.json
+++ b/protocol-v2.schema.json
@@ -34,7 +34,7 @@
       "properties": {
         "type": { "const": "test" },
         "name": { "type": "string" },
-        "status": { "enum": ["pass", "fail", "error"] },
+        "status": { "enum": ["pass", "fail", "error", "skipped"] },
         "durationMs": { "type": "integer", "minimum": 0 },
         "message": { "type": "string" },
         "errorKind": { "$ref": "#/definitions/ErrorKind" },


### PR DESCRIPTION
## Summary

`tests/expectations/` now reaches the run. `ExpectationManifest` had the whole classification table from `docs/expectations.md` implemented — `LoadFromDirectory`, `Lookup`, `Classify` — and nothing ever called it, so every expectation entry was inert. This PR wires it end-to-end:

1. **Loaded once at startup**, before BC init: `--expectations <dir>` explicitly, else the documented default `./tests/expectations` when that directory exists (this repo's corpus CI), else off — runs outside this repo are byte-identical to before. A malformed manifest aborts the invocation with exit 2 before a single test runs.
2. **Every outcome routed through `Classify`** at the one chokepoint all paths share (`TestExecutor.Run` — CLI, `--watch`, `--server`): `expect-oos` with matching reason → **pass-oos**, `expect-fail-known-gap` → **pass-known-gap**, `skip` → never invoked. Reclassified results count as passes everywhere, so the totals and the `--strict` exit code see them without touching any counter site.
3. **Both drift directions are loud test failures**: an entry whose test now passes fails with "Remove the entry …" (expect-oos and known-gap variants), and an undeclared `RunnerOutOfScopeException` fails with "Add an expect-oos entry … or implement the surface."
4. **Reclassified counts report distinctly**: the summary subdivides `pass` into `pass-oos` / `pass-known-gap` and adds `skipped` (zero-count lines omitted), per-test lines get `PASS (oos)` / `PASS (known-gap)` / `SKIP` labels, `--output-json` gains `skipped` + per-test `expectation`, JUnit gains `skipped` counts + `<skipped/>` elements.

Two supporting fixes the wiring surfaced:
- **Reason matching compares the leading anchor.** Real throw sites emit `Reason` as `"<anchor> — <free-text detail>"` (e.g. `query-join-rightouterjoin-not-implemented — only InnerJoin and …`), while `docs/expectations.md` says entries hold the bare `docs/scope.md` anchor. Exact string equality could never match; documented in `docs/expectations.md`.
- **The typed exception now travels on `TestResult`.** `Classify` needs `RunnerOutOfScopeException.Reason`; message strings can't carry it, and BC's error machinery may wrap the throw, so classification walks the inner-exception chain.

`protocol-v2.schema.json`'s `status` enum gains `"skipped"` (additive) so a manifest-skipped test streamed over `--server` stays schema-valid.

## Tests (RED → GREEN)

`AlRunner.Tests/ExpectationManifestWiringTests.cs` + `Fixtures/ExpectationsBundle` (one method per classification path; the deterministic OOS surface is a `RightOuterJoin` query — permanently out of scope, so the fixture cannot rot into a passing test) + `Fixtures/ExpectationsManifest` / `ExpectationsManifestMalformed`:

- `DeclaredExpectations_ReclassifyToGreen_AndReachTheExitCode` — pass-oos + pass-known-gap + skipped in one run, exit 0, skip-declared body proven never invoked, each count reported distinctly.
- `ManifestDrift_BothDirections_FailTheRunLoudly` — stale expect-oos entry, stale known-gap entry, and an undeclared OOS throw each surface their documented diagnostic; exit 1; classification keeps working for the rest of the run.
- `MalformedManifest_AbortsStartupLoudly` — unknown `Mode` → exit 2, file + value named, nothing ran.
- `NoManifest_UnchangedBehaviour_OosIsAPlainFail` — negative direction: without a manifest an uncaught OOS stays a plain FAIL with no manifest advice (guards against classification running unconditionally).

All four confirmed failing before the wiring (RED) and passing after (GREEN). The full `AlRunner.Tests` suite passes apart from `SuiteEnumerationTests.ParentDirWithFlatAppJsonChildren_RunsEverySuite` / `SingleAppWithCategorySubdirs_StaysOneBucket`, which fail identically on a clean `main` checkout in this environment (pre-existing, unrelated).

Closes #1734

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RqB1zkfaWrFP6hcSNVdAW6
