### PR TITLE
fix(scheduler): CreateTask hits the documented NavCreateScheduledTasksNotAllowedException, not a codeunit-resolution error

### DIFF
--- a/AlRunner/BcRuntime.cs
+++ b/AlRunner/BcRuntime.cs
@@ -1433,18 +1433,14 @@ public static partial class BcRuntime
             }
         }
 
-        // ALTaskScheduler.CheckCodeUnit — calls NCLMetadata.GetMetaCodeunitById to verify the
-        // codeunit exists. We resolve codeunits via assembly-scan in CreateTarget; the metadata
-        // verification is redundant. No-op so ALCreateTaskAsync proceeds.
-        var alTaskSchedType = navNcl.GetType("Microsoft.Dynamics.Nav.Runtime.ALTaskScheduler");
-        if (alTaskSchedType != null && sessType != null)
-        {
-            var checkCu = alTaskSchedType.GetMethod("CheckCodeUnit",
-                BindingFlags.NonPublic | BindingFlags.Static, null,
-                new[] { sessType, typeof(int) }, null);
-            if (checkCu != null)
-                Hook(checkCu, nameof(NoOp2), "ALTaskScheduler.CheckCodeUnit");
-        }
+        // ALTaskScheduler.CheckCodeUnit / ALCanCreateTask / CanCreateTask (scope.md §3.6,
+        // #1733) are now Cecil-owned (see NclCecilRewrite.cs, CecilOwned + the ALTaskScheduler
+        // block in RewriteNcl). This JmpHook registration used to live here as a no-op for
+        // CheckCodeUnit, but JmpHook is off by default (Cecil-only) — the registration was
+        // silently dead, and BC's real CheckCodeUnit body ran and threw a codeunit-resolution
+        // error before ever reaching CanCreateTask. Deleted rather than left as a redundant
+        // Hook(...) call site (JmpHook.Apply auto-skips Cecil-owned keys anyway, but a call
+        // site with no effect either way is dead code the audit would just flag).
 
         // ALMethodScope.AssignScopeId is Cecil-owned (see NclCecilRewrite.cs, "NavMethodScope
         // cluster") — chains through Session.NCLMetadata which is null; no-op leaves scopeId =
@@ -1839,18 +1835,11 @@ public static partial class BcRuntime
             if (lockTODurGet != null) Hook(lockTODurGet, nameof(ReturnZero_0Args), "ALDatabase.get_ALLockTimeoutDuration");
         }
 
-        // ALTaskScheduler.CanCreateTask(NavSession) — checks permissions via the
-        // session that is null on skeleton. Returning true lets the task-scheduler
-        // calls proceed; ALCreateTaskAsync still NREs further in but the immediate
-        // CanCreateTask cluster is drained.
-        var alTaskSchedType_b = navNcl.GetType("Microsoft.Dynamics.Nav.Runtime.ALTaskScheduler");
-        if (alTaskSchedType_b != null)
-        {
-            var canCreate = alTaskSchedType_b.GetMethod("CanCreateTask",
-                BindingFlags.NonPublic | BindingFlags.Static);
-            if (canCreate != null)
-                Hook(canCreate, nameof(ReturnTrue_OneArg), "ALTaskScheduler.CanCreateTask");
-        }
+        // ALTaskScheduler.CanCreateTask(NavSession) is Cecil-owned (see NclCecilRewrite.cs,
+        // scope.md §3.6, #1733): rewritten to return false — faithful, the runner has no
+        // scheduler. A JmpHook registration used to live here trying to make it return TRUE
+        // instead, which directly contradicted the documented/Cecil behaviour; it was always
+        // dead (JmpHook is off by default), which is exactly how it went unnoticed.
 
         // NavDialog.ALClose() / ALUpdateAsync are Cecil-owned (see NclCecilRewrite.cs).
 
@@ -1905,19 +1894,12 @@ public static partial class BcRuntime
             // was also wrong: BC's @@DBTS is strictly positive.
         }
 
-        // ALTaskScheduler.ALCreateTaskAsync — 8-arg ValueTask<Guid> static. Hook
-        // to return a fresh Guid; AL test code typically only verifies the
-        // returned id is non-zero or stores it for later cancellation.
-        if (alTaskSchedType_b != null)
-        {
-            foreach (var m in alTaskSchedType_b.GetMethods(
-                         BindingFlags.Public | BindingFlags.Static))
-            {
-                if (m.Name != "ALCreateTaskAsync") continue;
-                if (m.GetParameters().Length == 8)
-                    Hook(m, nameof(ReturnValueTaskGuid_8Args), "ALTaskScheduler.ALCreateTaskAsync");
-            }
-        }
+        // ALTaskScheduler.ALCreateTaskAsync is deliberately LEFT UNMODIFIED (see
+        // NclCecilRewrite.cs, scope.md §3.6, #1733): its real body already throws BC's own
+        // NavCreateScheduledTasksNotAllowedException once CanCreateTask/CheckCodeUnit are
+        // patched to let it reach that gate. A JmpHook registration used to live here trying
+        // to make it return a fresh Guid instead — a silent fake suppressing BC's own guard —
+        // and was always dead (JmpHook is off by default).
 
         // SessionTransactionExtensions.SetRecordConsistent / SetRecordInconsistent
         // — extension methods on NavSession that reach DataAccessSource (null on

--- a/AlRunner/Infrastructure/NclCecilRewrite.cs
+++ b/AlRunner/Infrastructure/NclCecilRewrite.cs
@@ -289,6 +289,14 @@ public static class NclCecilRewrite
         // NavNCLDotNetCreateException (which is trappable and would be silently swallowed
         // by TryInvokeAsync → TryInitializeFromCurrentApp returns false with no OOS signal).
         "Microsoft.Dynamics.Nav.Runtime.NavDotNet::CreateDotNet/1",
+        // ALTaskScheduler cluster (scope.md §3.6, #1733) — CanCreateTask/ALCanCreateTask
+        // rewritten to return false (no scheduler headlessly) and CheckCodeUnit no-op'd so
+        // ALCreateTaskAsync's real body reaches that CanCreateTask gate instead of throwing
+        // a codeunit-resolution error first. See the RewriteNcl block below for detail.
+        "Microsoft.Dynamics.Nav.Runtime.ALTaskScheduler::ALCanCreateTask/0",
+        "Microsoft.Dynamics.Nav.Runtime.ALTaskScheduler::ALCanCreateTask/1",
+        "Microsoft.Dynamics.Nav.Runtime.ALTaskScheduler::CanCreateTask/1",
+        "Microsoft.Dynamics.Nav.Runtime.ALTaskScheduler::CheckCodeUnit/2",
     };
 
     /// <summary>
@@ -2120,6 +2128,34 @@ public static class NclCecilRewrite
                     ilc.Append(ilc.Create(OpCodes.Ret));
                     body.MaxStackSize = 1;
                     Console.Error.WriteLine($"[Cecil] Rewrote ALTaskScheduler.{m.Name} → return false");
+                }
+
+                // ALTaskScheduler.CheckCodeUnit(NavSession, int) — the ALCreateTaskAsync
+                // state machine calls this TWICE (codeunitId, then failureCodeunitId) BEFORE
+                // it ever reaches the CanCreateTask gate above (#1733). Its real body calls
+                // NCLMetadata.GetMetaCodeunitById, which does not know about a freshly
+                // compiled test bundle's own codeunits, and throws a codeunit-resolution
+                // NavALException naming the calling test codeunit itself — CanCreateTask is
+                // never reached, so the documented scope.md §3.6 contract (unguarded CreateTask
+                // hits BC's own NavCreateScheduledTasksNotAllowedException) never manifests.
+                // The runner resolves codeunits via assembly-scan elsewhere (CreateTarget), so
+                // this metadata check is redundant here; no-op lets execution fall through to
+                // the CanCreateTask gate. A JmpHook no-op for this used to live in BcRuntime.cs
+                // but JmpHook is off by default (Cecil-only) — that registration was silently
+                // dead, which is exactly how this bug presented.
+                foreach (var m in alTaskSchedulerType.Methods
+                    .Where(x => x.Name == "CheckCodeUnit"
+                                && x.ReturnType.FullName == "System.Void"
+                                && x.HasBody))
+                {
+                    var body = m.Body;
+                    body.Instructions.Clear();
+                    body.Variables.Clear();
+                    body.ExceptionHandlers.Clear();
+                    var ilc = body.GetILProcessor();
+                    ilc.Append(ilc.Create(OpCodes.Ret));
+                    body.MaxStackSize = 0;
+                    Console.Error.WriteLine($"[Cecil] Rewrote ALTaskScheduler.{m.Name} → no-op");
                 }
             }
         }

--- a/tests/runner-extras/task-scheduler-create-task/TscAssert.Codeunit.al
+++ b/tests/runner-extras/task-scheduler-create-task/TscAssert.Codeunit.al
@@ -1,0 +1,14 @@
+codeunit 64300 "TSC Assert"
+{
+    procedure IsFalse(Value: Boolean; Msg: Text)
+    begin
+        if Value then
+            Error('Assert.IsFalse failed. %1', Msg);
+    end;
+
+    procedure IsTrue(Value: Boolean; Msg: Text)
+    begin
+        if not Value then
+            Error('Assert.IsTrue failed. %1', Msg);
+    end;
+}

--- a/tests/runner-extras/task-scheduler-create-task/TscTests.Codeunit.al
+++ b/tests/runner-extras/task-scheduler-create-task/TscTests.Codeunit.al
@@ -1,0 +1,43 @@
+/// <summary>
+/// docs/scope.md §3.6: no scheduler is available headlessly. ALTaskScheduler.CanCreateTask
+/// is made to faithfully return false, and unguarded TaskScheduler.CreateTask is meant to hit
+/// BC's own body throwing NavCreateScheduledTasksNotAllowedException (not a runner substitute).
+/// This is a deliberate runner-scoping decision, not adjudicable real-BC behaviour (a real BC
+/// server's CanCreateTask answer depends on live authentication/license context) -- it belongs
+/// here, not in the upstream corpus.
+/// </summary>
+codeunit 64301 "TSC Tests"
+{
+    Subtype = Test;
+
+    var
+        TscAssert: Codeunit "TSC Assert";
+
+    [Test]
+    procedure CanCreateTask_ReturnsFalse()
+    begin
+        // The headless runner has no scheduler: scope.md §3.6 documents CanCreateTask as
+        // faithfully false so guarded AL (`if TaskScheduler.CanCreateTask then ...`) skips
+        // creation cleanly.
+        TscAssert.IsFalse(TaskScheduler.CanCreateTask(), 'CanCreateTask must be false: the runner has no scheduler.');
+    end;
+
+    [Test]
+    procedure CreateTask_Unguarded_ThrowsBCsOwnNotAllowedException_NotACodeunitResolutionError()
+    begin
+        // Regression for #1733: before the fix, ALTaskScheduler.CheckCodeUnit ran BC's real
+        // (unpatched) body first -- because its no-op was registered on the disabled JmpHook
+        // layer, never the live Cecil layer -- and threw a codeunit-resolution NavALException
+        // naming this very test codeunit's own id, never reaching the documented
+        // NavCreateScheduledTasksNotAllowedException gate.
+        asserterror TaskScheduler.CreateTask(CODEUNIT::"TSC Tests", 0, true);
+
+        // BC's own NavCreateScheduledTasksNotAllowedException resource string (Lang.
+        // ScheduledTasksNotAllowed). A codeunit-resolution NavALException instead would read
+        // "...CodeUnit object with the ID... does not exist..." -- a different message entirely,
+        // so this pins the exact documented exception, not merely "something failed".
+        TscAssert.IsTrue(
+            GetLastErrorText() = 'You do not have permission to create or run scheduled tasks.',
+            StrSubstNo('Expected BC''s NavCreateScheduledTasksNotAllowedException text, got: %1', GetLastErrorText()));
+    end;
+}

--- a/tests/runner-extras/task-scheduler-create-task/app.json
+++ b/tests/runner-extras/task-scheduler-create-task/app.json
@@ -1,0 +1,19 @@
+{
+  "id": "161b28d9-22b2-418b-af40-70961b85a112",
+  "name": "Runner Extras - TaskScheduler CreateTask",
+  "publisher": "AL Runner",
+  "version": "1.0.0.0",
+  "brief": "Proves TaskScheduler.CreateTask surfaces BC's own NavCreateScheduledTasksNotAllowedException (scope.md §3.6), not a codeunit-resolution NavALException.",
+  "description": "docs/scope.md §3.6 documents ALTaskScheduler.CanCreateTask as faithfully returning false (the headless runner cannot schedule tasks) and unguarded CreateTask hitting BC's own NavCreateScheduledTasksNotAllowedException. Before this fix, ALTaskScheduler.CheckCodeUnit's JmpHook no-op was dead (JmpHook is off by default, Cecil-only), so BC's real CheckCodeUnit body ran first and threw a codeunit-resolution NavALException naming the calling test codeunit's own id -- never reaching the documented CanCreateTask gate.",
+  "dependencies": [],
+  "idRanges": [
+    {
+      "from": 64300,
+      "to": 64309
+    }
+  ],
+  "platform": "27.0.0.0",
+  "application": "27.0.0.0",
+  "runtime": "17.0",
+  "target": "Cloud"
+}


### PR DESCRIPTION
Closes #1733

## Root cause

`docs/scope.md` §3.6 documents a specific contract: `ALTaskScheduler.CanCreateTask` returns `false` (faithful — the runner has no scheduler), and unguarded `TaskScheduler.CreateTask` hits BC's own `NavCreateScheduledTasksNotAllowedException`.

Decompiling `ALTaskScheduler`'s real async state machine (`<ALCreateTaskAsync>d__1.MoveNext`) shows the actual call order:

1. `CheckCodeUnit(session, codeunitId)`
2. `CheckCodeUnit(session, failureCodeunitId)`
3. `CanCreateTask(session)` → throws `NavCreateScheduledTasksNotAllowedException` if false

`CheckCodeUnit`'s real body calls `NCLMetadata.GetMetaCodeunitById`, which the runner never populates for a freshly-compiled test bundle's own codeunits, so it throws a codeunit-resolution error — **before execution ever reaches the `CanCreateTask` gate**. A no-op for `CheckCodeUnit` existed in `BcRuntime.cs`, but it was only ever registered on the legacy JmpHook layer, which is off by default (Cecil-only, see `AlRunner/Infrastructure/JmpHook.cs`). The registration was silently dead — exactly the failure mode `.claude/rules/loud-failures.md` warns about (a documented behaviour that quietly stopped happening).

## Fix

- Migrated the `CheckCodeUnit` no-op onto the live Cecil IL-rewrite layer (`NclCecilRewrite.cs`), in the same block that already rewrites `CanCreateTask`/`ALCanCreateTask` to return `false`.
- Registered the `ALTaskScheduler` cluster (`ALCanCreateTask/0`, `ALCanCreateTask/1`, `CanCreateTask/1`, `CheckCodeUnit/2`) in `CecilOwned`, per the file's maintenance rule.
- Removed the now-dead (and, for `CanCreateTask`/`ALCreateTaskAsync`, actively contradictory) JmpHook registrations in `BcRuntime.cs` — one tried to make `CanCreateTask` return `true`, the other tried to fake `ALCreateTaskAsync` into returning a fresh `Guid`, both silently inert but wrong if JmpHook were ever re-enabled.

## Tests

New `tests/runner-extras/task-scheduler-create-task/` bundle (runner-specific: a real BC server's `CanCreateTask` answer depends on live authentication/license context, so "always false" is a documented runner-scoping decision, not adjudicable real-BC behaviour — see `.claude/rules/bc-behavior-tests-go-upstream.md`):

- `CanCreateTask_ReturnsFalse` — positive, already passed (the `CanCreateTask` Cecil rewrite was already correct).
- `CreateTask_Unguarded_ThrowsBCsOwnNotAllowedException_NotACodeunitResolutionError` — regression for #1733. RED before the fix (`NavNCLDialogException: The metadata object CodeUnit 64301 was not found...`), GREEN after, asserting the exact BC resource string (`Lang.ScheduledTasksNotAllowed`).

Verified no regressions:
- Full `tests/al-language` corpus: 1904/1904 passing.
- `AlRunner.Tests` (C#): 373/373 passing.


---
_Generated by [Claude Code](https://claude.ai/code/session_01G3KPXYQnfoL1ogXLXo823n)_