### PR TITLE
fix(page): bind Rec on a plain page-variable, not just TestPage

### DIFF
--- a/AlRunner/Patches/BcAppSymbolCache.cs
+++ b/AlRunner/Patches/BcAppSymbolCache.cs
@@ -28,11 +28,32 @@ internal static partial class BcAppSymbolCache
     // (2000000136) virtual table. A v8 payload deserialises cleanly with both null, so
     // without this bump every cached dependency would report "declares no lookup page"
     // for tables that plainly declare one — a silent wrong answer, not a cache miss.
-    private const int CacheVersion = 9;
+    // v10: added Pages — just Id/Name/SourceTable, feeding
+    // RecordPatches.TryGetDependencySourceTableIdForPage (issue #1719): a plain `Page X`
+    // variable over a precompiled dependency's page needs its SourceTable to bind Rec, and
+    // the runner's own AL-source page parser never sees a page it did not compile.
+    // v11: PageSymbol gained SourceTableTemporary. A v10 payload deserialises with it
+    // defaulted to false, so without this bump a temporary-source-table page (Page 700
+    // "Error Messages") would silently get a NON-temporary Rec, and its own body's
+    // Rec.Copy(source, shareTable: true) would throw NavNCLArgumentException — a correctness
+    // regression, not a cache miss.
+    private const int CacheVersion = 11;
     private static readonly ConcurrentDictionary<string, AppSymbols> ProcessCache = new(StringComparer.OrdinalIgnoreCase);
 
     internal sealed record AppSymbols(List<ParsedTable> Tables, List<EnumSymbol> Enums, List<QuerySymbol> Queries,
-        List<ObjectSymbol> Objects, List<ReportSymbol> Reports);
+        List<ObjectSymbol> Objects, List<ReportSymbol> Reports, List<PageSymbol> Pages);
+
+    /// <summary>
+    /// A precompiled dependency's page, as far as SymbolReference.json states it — just
+    /// enough to bind a plain page variable's Rec (issue #1719). <c>SourceTableId</c> is 0
+    /// when the page declares no SourceTable (a legal AL page with no bound record).
+    /// <c>SourceTableTemporary</c> matters for the SAME bind: Page 700 "Error Messages"
+    /// declares <c>SourceTableTemporary = true</c>, and its own SetRecords body does
+    /// <c>Rec.Copy(TempErrorMessage, true)</c> — real BC's Copy(shareTable: true) requires
+    /// BOTH sides temporary, so a page whose SourceTable is declared temporary needs its
+    /// bound Rec built temporary too, not just any record of the right table.
+    /// </summary>
+    internal sealed record PageSymbol(int Id, string Name, int SourceTableId, bool SourceTableTemporary);
 
     /// <summary>
     /// A precompiled dependency's report, as far as SymbolReference.json states it. Feeds
@@ -116,7 +137,7 @@ internal static partial class BcAppSymbolCache
 
     private sealed record CachePayload(long Length, long LastWriteUtcTicks,
         List<ParsedTable> Tables, List<EnumSymbol> Enums, List<QuerySymbol> Queries,
-        List<ObjectSymbol>? Objects, List<ReportSymbol>? Reports);
+        List<ObjectSymbol>? Objects, List<ReportSymbol>? Reports, List<PageSymbol>? Pages);
 
     /// <summary>
     /// Parse a loose <c>SymbolReference.json</c> file (the raw module JSON, NOT a .app
@@ -132,10 +153,11 @@ internal static partial class BcAppSymbolCache
         var queries = new Dictionary<int, QuerySymbol>();
         var objects = new Dictionary<(string, int), ObjectSymbol>();
         var reports = new Dictionary<int, ReportSymbol>();
+        var pages = new Dictionary<int, PageSymbol>();
         using var doc = JsonDocument.Parse(File.ReadAllText(jsonPath));
-        VisitSymbolContainer(doc.RootElement, tables, enums, queries, objects, reports);
+        VisitSymbolContainer(doc.RootElement, tables, enums, queries, objects, reports, pages);
         return new AppSymbols(tables.Values.ToList(), enums.Values.ToList(), queries.Values.ToList(),
-            objects.Values.ToList(), reports.Values.ToList());
+            objects.Values.ToList(), reports.Values.ToList(), pages.Values.ToList());
     }
 
     internal static AppSymbols Get(string appPath)
@@ -173,7 +195,8 @@ internal static partial class BcAppSymbolCache
                 || payload.LastWriteUtcTicks != appInfo.LastWriteTimeUtc.Ticks)
                 return null;
             return new AppSymbols(payload.Tables, payload.Enums, payload.Queries ?? new List<QuerySymbol>(),
-                payload.Objects ?? new List<ObjectSymbol>(), payload.Reports ?? new List<ReportSymbol>());
+                payload.Objects ?? new List<ObjectSymbol>(), payload.Reports ?? new List<ReportSymbol>(),
+                payload.Pages ?? new List<PageSymbol>());
         }
         catch (Exception ex)
         {
@@ -187,7 +210,7 @@ internal static partial class BcAppSymbolCache
         try
         {
             Directory.CreateDirectory(Path.GetDirectoryName(cachePath)!);
-            var payload = new CachePayload(appInfo.Length, appInfo.LastWriteTimeUtc.Ticks, symbols.Tables, symbols.Enums, symbols.Queries, symbols.Objects, symbols.Reports);
+            var payload = new CachePayload(appInfo.Length, appInfo.LastWriteTimeUtc.Ticks, symbols.Tables, symbols.Enums, symbols.Queries, symbols.Objects, symbols.Reports, symbols.Pages);
             File.WriteAllText(cachePath, JsonSerializer.Serialize(payload));
         }
         catch (Exception ex)
@@ -203,16 +226,17 @@ internal static partial class BcAppSymbolCache
         var queries = new Dictionary<int, QuerySymbol>();
         var objects = new Dictionary<(string, int), ObjectSymbol>();
         var reports = new Dictionary<int, ReportSymbol>();
+        var pages = new Dictionary<int, PageSymbol>();
         foreach (var json in ReadSymbolReferences(appPath))
         {
             using var doc = JsonDocument.Parse(json);
-            VisitSymbolContainer(doc.RootElement, tables, enums, queries, objects, reports);
+            VisitSymbolContainer(doc.RootElement, tables, enums, queries, objects, reports, pages);
         }
         return new AppSymbols(tables.Values.ToList(), enums.Values.ToList(), queries.Values.ToList(),
-            objects.Values.ToList(), reports.Values.ToList());
+            objects.Values.ToList(), reports.Values.ToList(), pages.Values.ToList());
     }
 
-    private static void VisitSymbolContainer(JsonElement container, Dictionary<int, ParsedTable> tables, Dictionary<int, EnumSymbol> enums, Dictionary<int, QuerySymbol> queries, Dictionary<(string, int), ObjectSymbol> objects, Dictionary<int, ReportSymbol> reports)
+    private static void VisitSymbolContainer(JsonElement container, Dictionary<int, ParsedTable> tables, Dictionary<int, EnumSymbol> enums, Dictionary<int, QuerySymbol> queries, Dictionary<(string, int), ObjectSymbol> objects, Dictionary<int, ReportSymbol> reports, Dictionary<int, PageSymbol> pages)
     {
         // Flat (kind, id, name) sweep for AllObj. Independent of the typed parsing below
         // so a kind we do not model in depth still shows up as an existing object.
@@ -271,11 +295,46 @@ internal static partial class BcAppSymbolCache
             }
         }
 
+        if (container.TryGetProperty("Pages", out var pageArray) && pageArray.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var p in pageArray.EnumerateArray())
+            {
+                var parsed = TryParsePageSymbol(p);
+                if (parsed != null && !pages.ContainsKey(parsed.Id))
+                    pages[parsed.Id] = parsed;
+            }
+        }
+
         if (container.TryGetProperty("Namespaces", out var namespaces) && namespaces.ValueKind == JsonValueKind.Array)
         {
             foreach (var ns in namespaces.EnumerateArray())
-                VisitSymbolContainer(ns, tables, enums, queries, objects, reports);
+                VisitSymbolContainer(ns, tables, enums, queries, objects, reports, pages);
         }
+    }
+
+    /// <summary>
+    /// Parse one entry of a SymbolReference.json <c>Pages</c> array. Only <c>SourceTable</c>
+    /// is needed (issue #1719: binding a plain page variable's Rec) — everything else about
+    /// a precompiled page (its control tree) is out of reach without parsing its AL source,
+    /// which <see cref="RunnerPageInstance"/> already declines to do for a page the runner
+    /// did not compile itself.
+    /// <para><c>SourceTable</c>'s Properties value is the table's numeric ID as text (see
+    /// e.g. Base Application's Page 700 "Error Messages": <c>SourceTable = "700"</c>), unlike
+    /// <c>LookupPageId</c>/<c>DrillDownPageId</c> on a table, which are page NAMES — so this
+    /// needs no name-to-id resolution pass.</para>
+    /// </summary>
+    private static PageSymbol? TryParsePageSymbol(JsonElement page)
+    {
+        if (!page.TryGetProperty("Id", out var idProp) || !idProp.TryGetInt32(out var pageId) || pageId <= 0)
+            return null;
+        var name = page.TryGetProperty("Name", out var nameProp) ? nameProp.GetString() : null;
+        if (string.IsNullOrEmpty(name)) return null;
+
+        var props = SymbolProperties(page);
+        int sourceTableId = props.TryGetValue("SourceTable", out var st) && int.TryParse(st, out var stId) ? stId : 0;
+        bool sourceTableTemporary = props.TryGetValue("SourceTableTemporary", out var stt)
+            && (stt == "1" || string.Equals(stt, "true", StringComparison.OrdinalIgnoreCase));
+        return new PageSymbol(pageId, name!, sourceTableId, sourceTableTemporary);
     }
 
     /// <summary>

--- a/AlRunner/Patches/CodeunitPatches.cs
+++ b/AlRunner/Patches/CodeunitPatches.cs
@@ -481,7 +481,18 @@ public static partial class BcRuntime
     /// Replacement for NavFormHandle.CreateTarget().
     /// Same shape as NavCodeunitHandle/NavTestPageHandle — bypass NavGlobal.NCLMetadata
     /// by scanning the loaded test assembly for `Form{ID}` and constructing via the
-    /// 1-arg ITreeObject ctor.
+    /// (ITreeObject, NavRecord) ctor when the page's SourceTable is resolvable, falling
+    /// back to the 1-arg ITreeObject ctor otherwise.
+    ///
+    /// The 2-arg ctor matters for issue #1719: a plain `Page X` variable (as opposed to a
+    /// TestPage, which already goes through RunnerPageInstance/TestPageFactory) built via
+    /// the 1-arg ctor alone never gets its Rec bound — probed directly, `Rec` and the base
+    /// `SourceTable` getter both read back null, no exception — so any Base App/System App
+    /// page method that reads Rec before the page is ever "opened" (e.g. Page 700
+    /// "Error Messages".SetRecords: `Rec.Copy(TempErrorMessage, true)`) NREs inside BC's own
+    /// unmodified body before AL gets a chance to run. Binding Rec here, the same way
+    /// RunnerPageInstance already does for TestPage, is a construction-time fix in our own
+    /// dispatch — not a change to that body — per precompiled-dll-respect.md.
     /// </summary>
     [MethodImpl(MethodImplOptions.NoInlining)]
     public static object NavFormHandle_CreateTarget(object self)
@@ -497,14 +508,86 @@ public static partial class BcRuntime
         if (formType == null)
             throw new InvalidOperationException(
                 $"Page{id} is not present in the test assembly or any loaded dependency.");
-        var ctor = formType.GetConstructors()
-            .FirstOrDefault(c => c.GetParameters().Length == 1 &&
+
+        var ctors = formType.GetConstructors(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+        var twoArgCtor = ctors.FirstOrDefault(c => c.GetParameters().Length == 2
+            && typeof(Microsoft.Dynamics.Nav.Runtime.ITreeObject).IsAssignableFrom(c.GetParameters()[0].ParameterType)
+            && typeof(NavRecord).IsAssignableFrom(c.GetParameters()[1].ParameterType));
+        if (twoArgCtor != null)
+        {
+            var tableId = RecordPatches.ResolveSourceTableIdForAnyPage(id);
+            if (tableId != 0)
+            {
+                var isTemporary = RecordPatches.ResolveSourceTableTemporaryForAnyPage(id);
+                var record = TestPageFactory.TryBuildBlankRecord(self, tableId, isTemporary, out var why);
+                if (record != null)
+                {
+                    var instance = twoArgCtor.Invoke(new object?[] { self, record });
+                    BindPageSourceObjectId(instance, tableId);
+
+                    // NavForm.SetSourceTable(record, clone: false) is BC's own binding
+                    // step — it stores `record` as Rec, wires the Notify handler and
+                    // computes auto-calc fields. Reused rather than reimplemented so a
+                    // page's real construction-time behaviour runs, not our guess at it.
+                    var setSourceTable = instance.GetType().GetMethod("SetSourceTable",
+                        BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
+                        binder: null, types: new[] { typeof(NavRecord), typeof(bool) }, modifiers: null);
+                    try { setSourceTable?.Invoke(instance, new object?[] { record, false }); }
+                    catch (TargetInvocationException tie) when (tie.InnerException != null)
+                    {
+                        // Loud, not fatal: the instance is still usable exactly as it was
+                        // before this fix (Rec unbound) — a page method that never touches
+                        // Rec keeps working, and one that does gets the SAME NRE it always
+                        // threw, not a new, worse failure from a half-bound instance.
+                        Console.Error.WriteLine(
+                            $"[BcRuntime] Page{id}: SetSourceTable failed after binding SourceTable {tableId} "
+                            + $"({tie.InnerException.GetType().Name}: {tie.InnerException.Message}); "
+                            + "Rec stays unbound, as before this fix.");
+                    }
+                    return instance;
+                }
+                if (Environment.GetEnvironmentVariable("AL_RUNNER_TRACE_PAGE_METADATA") == "1")
+                    Console.Out.WriteLine($"[NavFormHandle_CreateTarget] Page{id}: {why}; falling back to the 1-arg ctor");
+            }
+        }
+
+        var ctor = ctors.FirstOrDefault(c => c.GetParameters().Length == 1 &&
                 typeof(Microsoft.Dynamics.Nav.Runtime.ITreeObject)
                     .IsAssignableFrom(c.GetParameters()[0].ParameterType));
         if (ctor == null)
             throw new InvalidOperationException(
                 $"Page{id} has no single-arg ITreeObject constructor");
         return ctor.Invoke(new object[] { self });
+    }
+
+    /// <summary>
+    /// Stamp <c>NavForm.navSourceObject.SourceObjectId</c> to <paramref name="tableId"/>
+    /// before <c>SetSourceTable</c> validates against it.
+    ///
+    /// Real BC resolves that field via <c>NavGlobal.NCLMetadata</c> at page construction —
+    /// the same provider every other CreateTarget bypass in this file avoids because it NREs
+    /// on a skeleton meta. Left unset it stays at its CLR default (0), and
+    /// <c>SetSourceTable</c>'s own validation (`record.TableID == navSourceObject.
+    /// SourceObjectId`) then throws <c>NavNCLTableIdMismatchException</c> before Rec is ever
+    /// bound — this fills in exactly the state that provider would have supplied, using the
+    /// SAME table id already resolved from the page's own AL/SymbolReference.json (never
+    /// guessed), not a change to SetSourceTable's own logic.
+    ///
+    /// <c>NavForm.NavSourceObject</c> is a value type: a plain <c>FieldInfo.GetValue</c> +
+    /// <c>PropertyInfo.SetValue</c> mutates a boxed COPY that is never written back, so the
+    /// poke must be re-stamped onto the instance field explicitly.
+    /// </summary>
+    private static void BindPageSourceObjectId(object formInstance, int tableId)
+    {
+        var navSourceObjField = FindFieldUpHierarchy(formInstance.GetType(), "navSourceObject");
+        var navSourceObj = navSourceObjField?.GetValue(formInstance);
+        var sourceObjectIdProp = navSourceObj?.GetType().GetProperty("SourceObjectId",
+            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+        if (navSourceObjField == null || navSourceObj == null || sourceObjectIdProp is not { CanWrite: true })
+            return;
+        sourceObjectIdProp.SetValue(navSourceObj, tableId);
+        if (navSourceObjField.FieldType.IsValueType)
+            navSourceObjField.SetValue(formInstance, navSourceObj);
     }
 
     // One-time hook: NavReport..ctor(ITreeObject, Int32, NCLStaticMetadata) → same replacement

--- a/AlRunner/Patches/RecordPatches.AlPageParser.cs
+++ b/AlRunner/Patches/RecordPatches.AlPageParser.cs
@@ -54,7 +54,12 @@ public static partial class RecordPatches
                 ControlIdToFieldName: ParsePageFieldBindings(id, p.Layout),
                 // AL's default when the property is absent is TRUE, so only an explicit
                 // `false` flips it. Drives ITestPage.Creatable via NavTestPageBase.New().
-                InsertAllowed: !PropIs(props, "InsertAllowed", "false"));
+                InsertAllowed: !PropIs(props, "InsertAllowed", "false"),
+                // AL's default is false — only an explicit `true` flips it. See issue #1719:
+                // a page-variable's Rec must be built temporary when this is true, or its
+                // own AL body's Rec.Copy(source, shareTable: true) refuses ("both records
+                // must be temporary").
+                SourceTableTemporary: PropIs(props, "SourceTableTemporary", "true"));
         }
 
         foreach (var obj in objects)
@@ -213,4 +218,6 @@ internal record ParsedPage(
     IReadOnlyDictionary<int, string> ControlIdToFieldName,
     bool InsertAllowed = true,
     /// <summary>The object a pageextension extends; empty for a plain page.</summary>
-    string BaseName = "");
+    string BaseName = "",
+    /// <summary>AL's <c>SourceTableTemporary</c> property; see issue #1719.</summary>
+    bool SourceTableTemporary = false);

--- a/AlRunner/Patches/RecordPatches.DependencyPageMetadata.cs
+++ b/AlRunner/Patches/RecordPatches.DependencyPageMetadata.cs
@@ -1,0 +1,76 @@
+// RecordPatches.DependencyPageMetadata — SourceTable lookup for pages that live in a
+// PRECOMPILED dependency .app, which the runner never source-compiles.
+//
+// THE GAP (issue #1719)
+//   NavFormHandle.CreateTarget (a plain `Page X` variable, as opposed to a TestPage) needs
+//   to bind Rec to a real record of the page's own SourceTable before handing the instance
+//   to AL — otherwise any Base App/System App page method that reads Rec (e.g. Page 700
+//   "Error Messages".SetRecords: `Rec.Copy(TempErrorMessage, true)`) NREs before AL ever
+//   runs. RecordPatches.GetSourceTableIdForPage answers that ONLY for a page the runner
+//   AL-source-parsed itself (AlPageParser scans `_sourceDirs`, which is the bundle's own
+//   .al files) — a precompiled dependency's page has no entry there at all.
+//
+// WHAT IS RECONSTRUCTED, AND FROM WHAT
+//   The dependency .app's own SymbolReference.json states the page's SourceTable property
+//   verbatim as the table's numeric ID (see BcAppSymbolCache.TryParsePageSymbol) — this is
+//   the same file DependencyReportMetadata already reads for a dependency report's dataset
+//   shape, so nothing new is inferred here, only a second typed slice of the same source.
+namespace AlRunner.Patches;
+
+public static partial class RecordPatches
+{
+    /// <summary>
+    /// A precompiled dependency's SourceTable table id for <paramref name="pageId"/>, or 0
+    /// when no loaded dependency .app describes that page (or the page declares no
+    /// SourceTable at all — a legal AL page with no bound record).
+    /// </summary>
+    internal static int TryGetDependencySourceTableIdForPage(int pageId)
+        => TryGetDependencyPageSymbol(pageId)?.SourceTableId ?? 0;
+
+    /// <summary>
+    /// <paramref name="pageId"/>'s SourceTable table id, checking the runner's own
+    /// AL-source-parsed pages first, then any loaded dependency .app's SymbolReference.json.
+    /// 0 when neither knows the page or the page declares no SourceTable.
+    /// </summary>
+    internal static int ResolveSourceTableIdForAnyPage(int pageId)
+    {
+        var tableId = GetSourceTableIdForPage(pageId);
+        return tableId != 0 ? tableId : TryGetDependencySourceTableIdForPage(pageId);
+    }
+
+    /// <summary>
+    /// Whether <paramref name="pageId"/> declares <c>SourceTableTemporary = true</c> —
+    /// checking the runner's own AL-source-parsed pages first, then any loaded dependency
+    /// .app. False (including "unknown page") is the safe default — it is also AL's own
+    /// default, so a page the runner cannot find gets exactly the record shape a page with
+    /// no such declaration would. See issue #1719: Page 700 "Error Messages" declares it
+    /// true, and its own SetRecords body's <c>Rec.Copy(TempErrorMessage, true)</c> requires
+    /// a temporary Rec to match.
+    /// </summary>
+    internal static bool ResolveSourceTableTemporaryForAnyPage(int pageId)
+        => (IsPageParsed(pageId) && _parsedPages.TryGetValue(pageId, out var page) && page.SourceTableTemporary)
+           || TryGetDependencyPageSymbol(pageId)?.SourceTableTemporary == true;
+
+    private static BcAppSymbolCache.PageSymbol? TryGetDependencyPageSymbol(int pageId)
+    {
+        foreach (var appPath in _bcAppPaths.ToArray())
+        {
+            List<BcAppSymbolCache.PageSymbol> pages;
+            try
+            {
+                pages = BcAppSymbolCache.Get(appPath).Pages;
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine(
+                    $"[RecordPatches] dependency page metadata: SymbolReference read failed for "
+                    + $"{Path.GetFileName(appPath)}: {ex.Message}");
+                continue;
+            }
+            foreach (var p in pages)
+                if (p.Id == pageId)
+                    return p;
+        }
+        return null;
+    }
+}

--- a/AlRunner/Patches/TestPageFactory.cs
+++ b/AlRunner/Patches/TestPageFactory.cs
@@ -29,33 +29,69 @@ internal static class TestPageFactory
         // control bound to a page VARIABLE (rather than to a Rec field) resolves through.
         RecordPatches.EnsureRealPageMetadata(pageId);
 
+        // GetSourceTableIdForPage only knows pages the runner AL-source-parsed itself; a
+        // precompiled dependency's page (Base App / System App / an ISV .app) falls back to
+        // its SymbolReference.json's own SourceTable property — see
+        // RecordPatches.TryGetDependencySourceTableIdForPage.
         var tableId = RecordPatches.GetSourceTableIdForPage(pageId);
+        if (tableId == 0)
+            tableId = RecordPatches.TryGetDependencySourceTableIdForPage(pageId);
         if (tableId == 0)
         {
             why = $"page {pageId} declares no SourceTable";
             return null;
         }
 
+        // isTemporary: false — TestPage over a temporary-source-table page is not this
+        // path's concern today; only the plain-page-variable caller below currently needs
+        // it (issue #1719's Page 700 "Error Messages"), and changing this one's shape is
+        // out of scope for that fix.
+        var record = TryBuildBlankRecord(owner, tableId, isTemporary: false, out var recordWhy);
+        if (record == null)
+        {
+            why = $"page {pageId}: {recordWhy}";
+            return null;
+        }
+
+        return new Built(record, RunnerPageInstance.TryCreate(owner, pageId, record), tableId);
+    }
+
+    /// <summary>
+    /// A blank (unpositioned) cursor over <paramref name="tableId"/>, owned by
+    /// <paramref name="owner"/> — the same shape BC's real page construction binds Rec to
+    /// before any row is read. Shared by the TestPage path above and by
+    /// <c>CodeunitPatches.NavFormHandle_CreateTarget</c>, which needs the identical record
+    /// to bind a plain <c>Page X</c> variable's Rec (see issue #1719: a page variable built
+    /// via the single-arg ctor never gets one, so any Base App page method reading Rec NREs
+    /// before AL ever runs).
+    /// <para><paramref name="isTemporary"/> must match the page's own
+    /// <c>SourceTableTemporary</c> declaration — Page 700 "Error Messages" declares it
+    /// true, and its SetRecords body does <c>Rec.Copy(TempErrorMessage, true)</c>, which
+    /// real BC's Copy(shareTable: true) refuses unless BOTH records are temporary
+    /// ("The COPY function can only be used with the shareTable argument set to true if
+    /// both records are temporary").</para>
+    /// </summary>
+    internal static NavRecord? TryBuildBlankRecord(object owner, int tableId, bool isTemporary, out string? why)
+    {
+        why = null;
         var metaTable = RecordPatches.GetOrBuildNCLMetaTable(tableId);
         var recordType = RecordPatches.FindRecordType(tableId);
         if (metaTable == null || recordType == null)
         {
-            why = $"page {pageId}: source table {tableId} has no runtime record type here";
+            why = $"source table {tableId} has no runtime record type here";
             return null;
         }
 
         var ctor = recordType.GetConstructors().FirstOrDefault(c => c.GetParameters().Length == 6);
         if (ctor == null)
         {
-            why = $"page {pageId}: Record{tableId} has no 6-arg constructor";
+            why = $"Record{tableId} has no 6-arg constructor";
             return null;
         }
 
-        var record = (NavRecord)ctor.Invoke(new object?[]
+        return (NavRecord)ctor.Invoke(new object?[]
         {
-            owner, metaTable, false, null, null, SecurityFiltering.Ignored
+            owner, metaTable, isTemporary, null, null, SecurityFiltering.Ignored
         });
-
-        return new Built(record, RunnerPageInstance.TryCreate(owner, pageId, record), tableId);
     }
 }

--- a/tests/runner-extras/errormessages-page-setrecords/EMSRAssert.Codeunit.al
+++ b/tests/runner-extras/errormessages-page-setrecords/EMSRAssert.Codeunit.al
@@ -1,0 +1,20 @@
+codeunit 62140 "EMSR Assert"
+{
+    procedure IsTrue(Condition: Boolean; Msg: Text)
+    begin
+        if not Condition then
+            Error('Assert.IsTrue failed. %1', Msg);
+    end;
+
+    procedure AreEqual(Expected: Integer; Actual: Integer; Msg: Text)
+    begin
+        if Expected <> Actual then
+            Error('Assert.AreEqual failed. Expected:<%1>. Actual:<%2>. %3', Expected, Actual, Msg);
+    end;
+
+    procedure AreEqualText(Expected: Text; Actual: Text; Msg: Text)
+    begin
+        if Expected <> Actual then
+            Error('Assert.AreEqual failed. Expected:<%1>. Actual:<%2>. %3', Expected, Actual, Msg);
+    end;
+}

--- a/tests/runner-extras/errormessages-page-setrecords/EMSRTests.Codeunit.al
+++ b/tests/runner-extras/errormessages-page-setrecords/EMSRTests.Codeunit.al
@@ -1,0 +1,75 @@
+codeunit 62141 "EMSR Tests"
+{
+    // Regression for issue #1719: Page "Error Messages" (System Application page 700), used
+    // as a plain page variable, NREd inside its own precompiled SetRecords body:
+    //
+    //   procedure SetRecords(var TempErrorMessage: Record "Error Message" temporary)
+    //   begin
+    //       if TempErrorMessage.FindFirst() then;
+    //       if TempErrorMessage.IsTemporary then
+    //           Rec.Copy(TempErrorMessage, true)
+    //       else
+    //           TempErrorMessage.CopyToTemp(Rec);
+    //   end;
+    //
+    // Root cause: a plain `Page "Error Messages"` variable is built via
+    // NavFormHandle.CreateTarget, which (before the fix) constructed the page through the
+    // single-arg ITreeObject ctor and never bound a source record — so `Rec` on the page
+    // instance stayed null, and `Rec.Copy(...)` NREd. The TestPage construction path
+    // (RunnerPageInstance.TryCreate) already selects the two-arg (ITreeObject, NavRecord)
+    // ctor and binds a real record; the page-variable path needs the same treatment.
+    //
+    // RED (before fix): both tests below throw NullReferenceException at the SetRecords call.
+    // GREEN (after fix): SetRecords runs its real Base App body and the temp record set
+    // handed to it round-trips correctly, for both a populated set and an empty one — so a
+    // fix keyed on "the set happens to be non-empty" cannot pass both directions.
+    Subtype = Test;
+
+    var
+        Assert: Codeunit "EMSR Assert";
+
+    [Test]
+    procedure SetRecords_StoresTheTempRecordSetOnThePageInstance()
+    var
+        TempErrorMessage: Record "Error Message" temporary;
+        ErrorMessagesPage: Page "Error Messages";
+    begin
+        // [GIVEN] A temporary Error Message set with one row.
+        TempErrorMessage.ID := 1;
+        TempErrorMessage."Message" := CopyStr('EMSR probe message', 1, MaxStrLen(TempErrorMessage."Message"));
+        TempErrorMessage.Insert();
+
+        // [WHEN] SetRecords hands the set to the page. Before the fix this NREs inside the
+        // unmodified Base App body (Rec.Copy(TempErrorMessage, true) against a null Rec).
+        ErrorMessagesPage.SetRecords(TempErrorMessage);
+
+        // [THEN] The caller's own temporary set must survive the handover untouched — BC's
+        // real body branches on TempErrorMessage.IsTemporary and copies INTO Rec, never
+        // mutating the caller's variable.
+        Assert.AreEqual(1, TempErrorMessage.Count(),
+            'Caller''s temporary Error Message set must still hold its row after SetRecords.');
+        Assert.IsTrue(TempErrorMessage.Get(1),
+            'Caller''s temporary Error Message row 1 must still be readable after SetRecords.');
+        Assert.AreEqualText('EMSR probe message', TempErrorMessage."Message",
+            'Caller''s Error Message text must be unchanged after SetRecords.');
+    end;
+
+    [Test]
+    procedure SetRecords_AcceptsAnEmptyTempRecordSet()
+    var
+        TempErrorMessage: Record "Error Message" temporary;
+        ErrorMessagesPage: Page "Error Messages";
+    begin
+        // [GIVEN] No rows at all — the negative-direction companion. A fix keyed on "the set
+        // is non-empty" (e.g. only binding Rec when FindFirst succeeds) would pass the test
+        // above and still NRE, or silently swallow, here.
+        Assert.IsTrue(TempErrorMessage.IsEmpty(), 'A freshly declared temporary Error Message set must start empty.');
+
+        // [WHEN]
+        ErrorMessagesPage.SetRecords(TempErrorMessage);
+
+        // [THEN] Still empty, no exception.
+        Assert.AreEqual(0, TempErrorMessage.Count(),
+            'Caller''s temporary Error Message set must still be empty after SetRecords of an empty set.');
+    end;
+}

--- a/tests/runner-extras/errormessages-page-setrecords/app.json
+++ b/tests/runner-extras/errormessages-page-setrecords/app.json
@@ -1,0 +1,25 @@
+{
+  "id": "7e6d5c4b-3a29-4f18-9e07-6d5c4b3a2f19",
+  "name": "Runner Extras - Error Messages page SetRecords",
+  "publisher": "AL Runner",
+  "version": "1.0.0.0",
+  "brief": "Proves Page \"Error Messages\" (System Application page 700), used as a plain page variable, can run its precompiled SetRecords body without a NullReferenceException.",
+  "description": "Regression for issue #1719: calling SetRecords() on a Page \"Error Messages\" variable NREd inside the unmodified Base App page method because the plain page-variable construction path (NavFormHandle.CreateTarget) never binds Rec to a source record, unlike the TestPage path. Fixed by giving the page-variable path the same record binding TestPage already gets.",
+  "privacyStatement": "",
+  "EULA": "",
+  "help": "",
+  "url": "",
+  "logo": "",
+  "dependencies": [],
+  "screenshots": [],
+  "platform": "1.0.0.0",
+  "application": "27.0.0.0",
+  "idRanges": [
+    {
+      "from": 62140,
+      "to": 62149
+    }
+  ],
+  "runtime": "14.0",
+  "features": []
+}


### PR DESCRIPTION
Closes #1719

## Problem

`NavFormHandle.CreateTarget` (the plain `Page X` variable path — as opposed to `TestPage`) built the page instance through only the single-arg `ITreeObject` ctor, which never binds `Rec`. Probed directly: `Rec` and the base `SourceTable` getter both read back `null`, with no exception. So any Base App / System App page method that reads `Rec` before the page is ever "opened" via `Run()` NREs inside BC's own unmodified precompiled body. `Page "Error Messages".SetRecords()` (Base App page 700) is the reported case.

## Root cause (confirmed via reflection probes + IL disassembly of `NavForm`, not guessed)

1. `NavForm` has a second, `(ITreeObject, NavRecord)` ctor that binds `Rec` — the same one `RunnerPageInstance`/`TestPageFactory` already use for the `TestPage` path — but `NavFormHandle_CreateTarget` never looked for it.
2. Even switching to that ctor isn't enough: `NavForm.SetSourceTable` validates the caller's record's table id against `navSourceObject.SourceObjectId`, a field real BC populates via `NavGlobal.NCLMetadata` at construction — a provider this runner deliberately never wires up (it NREs on the skeleton meta, the same reason the `CreateTarget` bypass exists in the first place). Left at its CLR default (0), `SetSourceTable` throws `NavNCLTableIdMismatchException` before `Rec` is ever bound.
3. `NavForm.NavSourceObject` is a **value type** — `FieldInfo.GetValue` + `PropertyInfo.SetValue` mutates a boxed copy that's never written back unless the field is re-stamped explicitly.
4. Page 700 also declares `SourceTableTemporary = true`; its own body does `Rec.Copy(TempErrorMessage, true)`, and real BC's `Copy(shareTable: true)` requires **both** sides temporary — so the record built for `Rec` has to be temporary too, not just any record of the right table.

## Fix

- `NavFormHandle_CreateTarget` now prefers the `(ITreeObject, NavRecord)` ctor when the page's `SourceTable` is resolvable, stamps `navSourceObject.SourceObjectId` (writing the value-type field back), then calls BC's own `SetSourceTable(record, clone: false)` — reusing real BC binding logic rather than reimplementing it. Falls back to the old single-arg-ctor shape on any failure, so nothing regresses for pages this can't resolve.
- `SourceTable`/`SourceTableTemporary` resolution now works for a page the runner never source-compiled too: new `BcAppSymbolCache.PageSymbol`, populated from the dependency `.app`'s own `SymbolReference.json` (same file `DependencyReportMetadata` already reads for reports) — `RecordPatches.ResolveSourceTableIdForAnyPage` / `ResolveSourceTableTemporaryForAnyPage` check the runner's own AL-parsed pages first, then fall back to this.
- `TestPageFactory.TryBuildBlankRecord` gained an explicit `isTemporary` parameter (shared by both the `TestPage` and plain-page-variable paths); the `TestPage` path keeps its existing `false` behaviour unchanged — this fix only widens the plain-page-variable path.

## Testing

`tests/runner-extras/errormessages-page-setrecords` — RED before the fix (both tests reproduce the exact reported `NullReferenceException` at `Page700.SetRecords`), GREEN after:
- `SetRecords_StoresTheTempRecordSetOnThePageInstance` — a populated temp record set round-trips through `SetRecords` unchanged.
- `SetRecords_AcceptsAnEmptyTempRecordSet` — the negative direction (empty set), so a fix keyed on "the set happens to be non-empty" can't pass both.

```
dotnet run --project AlRunner -c Release -- --package-cache ~/.al-runner/platform-apps tests/runner-extras/errormessages-page-setrecords
  → 2P/0F/0E across 2 tests
```

Full regression sweep, no failures:
- `tests/runner-extras/**` (all 126 tests, including the existing `TestPage`/pageextension suites) — unaffected.
- `AlRunner.Tests` (373 unit tests) — unaffected.

## Scope note on where this test lives

This asserts a real Base App precompiled method's behaviour (`Page700.SetRecords`), which per `bc-behavior-tests-go-upstream.md` would normally belong in the corpus. I judged this as `tests/runner-extras/` instead, following the existing precedent in `tests/runner-extras/microsoft-dependencies` / `microsoft-test-library` (e.g. `BaseAppCodeunit_NoSeries_GetNextNo_Completes`, `Query777_RoleCenterFromPlans_*`) — suites that assert concrete values from real precompiled Base/System App code specifically to prove the runner's own construction/dispatch plumbing works, not to re-adjudicate already-settled BC business logic. The three-line `SetRecords` body itself isn't in question here; the bug and the fix are entirely in the runner's page-construction path. I don't have access to a real BC service tier in this session to independently verify against — happy to move this upstream if a maintainer prefers.


---
_Generated by [Claude Code](https://claude.ai/code/session_01G3KPXYQnfoL1ogXLXo823n)_