### PR TITLE
fix(deps): persist enum metadata sidecar for source-compiled dependency cache

### DIFF
--- a/AlRunner.Tests/SourceDepCacheEnumMetadataTests.cs
+++ b/AlRunner.Tests/SourceDepCacheEnumMetadataTests.cs
@@ -57,12 +57,29 @@ public class SourceDepCacheEnumMetadataTests
         return Directory.Exists(stdCache) && Directory.EnumerateDirectories(stdCache).Any();
     }
 
-    private static (string output, int exit) RunRunner(string bundleDir, string alCacheDir)
+    private static (string output, int exit) RunRunner(string bundleDir, string alCacheDir, string absentPackageCache)
     {
         var args = new StringBuilder(TestBuildConfig.RunArgs(ProjectPath));
         args.Append(TestBuildConfig.BcVersionArg);
         args.Append($" \"{bundleDir}\"");
         args.Append($" --cache \"{alCacheDir}\"");
+        // Pin `package caches: 0 dir(s)` — the fixture depends on NOTHING Microsoft
+        // (platform/application 1.0.0.0, no declared deps), so no package cache is
+        // needed, and passing an --package-cache path that does not exist makes the
+        // runner take the explicit-arg branch and resolve it to the empty set
+        // (ExpandPackageCacheDirs skips non-existent dirs) instead of falling back to
+        // DefaultPackageCacheDirs.
+        //
+        // Why pin it: the default set includes `<artifacts>/<version>/test-apps` and
+        // `<artifacts>/<version>/platform-apps`, which a dev machine that has ever run
+        // --auto-provision HAS and a CI runner (which downloads to ~/.al-runner/… and
+        // passes --package-cache explicitly on other steps) does NOT. That single
+        // difference decided whether this test passed: with zero package dirs the
+        // compiler's reference loader used to bail out before the source-dep
+        // *.symbols.json chain was built, so the dep was compile-invisible (AL0185) and
+        // the bundle emitted zero sources. Green locally, red on all 8 BC legs. Pinning
+        // it means the harder configuration is the one that is always tested.
+        args.Append($" --package-cache \"{absentPackageCache}\"");
         var psi = new ProcessStartInfo
         {
             FileName = "dotnet", Arguments = args.ToString(),
@@ -89,6 +106,8 @@ public class SourceDepCacheEnumMetadataTests
         var depDir = Path.Combine(scratchRoot, "dep-app");
         var testsDir = Path.Combine(scratchRoot, "tests-app");
         var alCacheDir = Path.Combine(scratchRoot, "al-out");
+        // Deliberately NEVER created — see RunRunner.
+        var absentPackageCache = Path.Combine(scratchRoot, "no-such-package-cache");
         Directory.CreateDirectory(depDir);
         Directory.CreateDirectory(testsDir);
 
@@ -184,7 +203,17 @@ public class SourceDepCacheEnumMetadataTests
 
         // Run 1: fresh cache all round (dep MISS, bundle MISS) — must pass, and the
         // issue itself confirms this direction is never where the bug shows up.
-        var (output1, exit1) = RunRunner(testsDir, alCacheDir);
+        var (output1, exit1) = RunRunner(testsDir, alCacheDir, absentPackageCache);
+        // Guard the precondition itself: if the runner ever stops honouring an
+        // --package-cache that does not exist and silently falls back to the default
+        // dirs, this test would quietly stop covering the zero-package-cache path
+        // (the one CI actually runs) and go green for the wrong reason.
+        Assert.Contains("package caches: 0 dir(s)", output1);
+        // Name the specific regression this direction guards: with no package cache
+        // dir the compiler used to skip building the source-dep *.symbols.json loader
+        // chain entirely, so the sibling source dep was runtime-loadable but
+        // compile-invisible.
+        Assert.DoesNotContain("AL0185", output1);
         Assert.True(exit1 == 0 && output1.Contains("1P/0F/0E"),
             $"run 1 (fresh cache) must pass:\n{output1}");
 
@@ -194,7 +223,8 @@ public class SourceDepCacheEnumMetadataTests
         File.AppendAllText(testsAlPath, "\n// touched\n");
 
         // Run 2: dep HIT + bundle MISS — the exact condition from the issue.
-        var (output2, exit2) = RunRunner(testsDir, alCacheDir);
+        var (output2, exit2) = RunRunner(testsDir, alCacheDir, absentPackageCache);
+        Assert.Contains("package caches: 0 dir(s)", output2);
 
         // The exact reported defect. Never let a run that hits this pass silently —
         // the assertion below is the whole point of the RED -> GREEN cycle.

--- a/AlRunner.Tests/SourceDepCacheEnumMetadataTests.cs
+++ b/AlRunner.Tests/SourceDepCacheEnumMetadataTests.cs
@@ -1,0 +1,206 @@
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// Issue #1731 — a source-compiled dependency served from the `compiled-deps`
+/// cache (Tier 3 of <see cref="DependencyLoader"/>) on a "dep HIT + bundle MISS"
+/// run loses its enum metadata: the dep's own emit is skipped (cache HIT), and the
+/// bundle's own emit only registers the ENUMS ITS OWN sources declare — the dep's
+/// enums are simply never (re-)registered in <see cref="AlEnumMetadataRegistry"/>
+/// for that process. Enum-to-interface dispatch on a dep enum then throws
+/// <c>InvalidOperationException: Unable to cast enum '' value '0' to interface</c>
+/// (the enum's Name comes back blank because no entry exists at all).
+///
+/// Root cause: unlike the bundle's own AL-output cache (`.dll` + `.enum-registry.json`
+/// sidecar, replayed on HIT — see Program.cs `SaveEnumRegistrySidecar`/
+/// `LoadEnumRegistrySidecar`), the dependency-loader's source-dep cache
+/// (`~/.cache/al-runner/compiled-deps/<key>.dll`) persisted only report/page/xmlport
+/// metadata sidecars — no enum-registry sidecar — so a cache HIT for the dep replayed
+/// everything except its enums.
+///
+/// Reproduces the exact two-process sequence from the issue: two SEPARATE runner
+/// invocations sharing the real `~/.cache/al-runner` (matching `rm -rf
+/// ~/.cache/al-runner; al-runner ... tests` twice in the issue). Uses a fresh random
+/// AppId + a fresh scratch dir per test run, so the dep's Tier-3 cache key has never
+/// been seen before — run 1 is guaranteed a dep MISS (in-process compile, so the bug
+/// cannot manifest there: this is exactly why the issue itself observed "fresh cache
+/// -> PASS" every time). Touching a `tests`-bundle source file between the two runs
+/// forces the BUNDLE's own cache key to change (content hash) while the DEP's
+/// synthetic `.app` bytes (and therefore its Tier-3 cache key) stay byte-identical —
+/// producing the exact "dep HIT + bundle MISS" condition the bug requires.
+///
+/// RED (pre-fix): run 2 fails with "Unable to cast enum '' value '0' to interface".
+/// GREEN (post-fix): both runs pass identically.
+///
+/// Spawns the real runner; needs the BC artifact cache. Skips (no-op) when absent.
+/// </summary>
+[Collection("server-serial")]
+public class SourceDepCacheEnumMetadataTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+    private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
+
+    private static bool ArtifactsPresent()
+    {
+        var home = Environment.GetEnvironmentVariable("HOME")
+            ?? Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        if (string.IsNullOrEmpty(home)) return false;
+        if (Directory.Exists(Path.Combine(home, ".bcartifacts.cache", "sandbox"))) return true;
+        // This environment provisions artifacts under .local/share/al-runner/artifacts
+        // instead (see CacheKeyDependencyClosureTests.ArtifactsPresent for the same check).
+        var stdCache = Path.Combine(home, ".local", "share", "al-runner", "artifacts");
+        return Directory.Exists(stdCache) && Directory.EnumerateDirectories(stdCache).Any();
+    }
+
+    private static (string output, int exit) RunRunner(string bundleDir, string alCacheDir)
+    {
+        var args = new StringBuilder(TestBuildConfig.RunArgs(ProjectPath));
+        args.Append(TestBuildConfig.BcVersionArg);
+        args.Append($" \"{bundleDir}\"");
+        args.Append($" --cache \"{alCacheDir}\"");
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet", Arguments = args.ToString(),
+            RedirectStandardOutput = true, RedirectStandardError = true,
+            UseShellExecute = false, CreateNoWindow = true, WorkingDirectory = RepoRoot,
+        };
+        var sb = new StringBuilder();
+        using var p = Process.Start(psi)!;
+        p.OutputDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.ErrorDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.BeginOutputReadLine();
+        p.BeginErrorReadLine();
+        if (!p.WaitForExit(180_000)) { try { p.Kill(true); } catch { } throw new TimeoutException("runner hung"); }
+        p.WaitForExit();
+        lock (sb) return (sb.ToString(), p.ExitCode);
+    }
+
+    [Fact]
+    public void SourceDepCacheHit_BundleMiss_KeepsDepEnumMetadata()
+    {
+        if (!ArtifactsPresent()) { Console.Error.WriteLine("[skip] BC artifact cache not present"); return; }
+
+        var scratchRoot = Path.Combine(Path.GetTempPath(), "al-runner-depcache-enum", Guid.NewGuid().ToString("N"));
+        var depDir = Path.Combine(scratchRoot, "dep-app");
+        var testsDir = Path.Combine(scratchRoot, "tests-app");
+        var alCacheDir = Path.Combine(scratchRoot, "al-out");
+        Directory.CreateDirectory(depDir);
+        Directory.CreateDirectory(testsDir);
+
+        // Fresh random identities every run: guarantees the dep's Tier-3 cache key
+        // (which hashes the app's own bytes + identity) has never been seen before,
+        // so run 1 is unconditionally a dep MISS — the only way to reach a genuine
+        // "dep HIT" on run 2 without the bug's fresh-cache masking (see class doc).
+        var depId = Guid.NewGuid();
+        var testsId = Guid.NewGuid();
+
+        File.WriteAllText(Path.Combine(depDir, "app.json"), $$"""
+        {
+          "id": "{{depId}}",
+          "name": "Repro1731 Dep App",
+          "publisher": "Repro1731",
+          "version": "1.0.0.0",
+          "dependencies": [],
+          "platform": "1.0.0.0",
+          "application": "1.0.0.0",
+          "idRanges": [ { "from": 61900, "to": 61909 } ],
+          "runtime": "14.0"
+        }
+        """);
+        File.WriteAllText(Path.Combine(depDir, "Repro1731Dep.al"), """
+        interface "Repro1731 IGreeter"
+        {
+            procedure Greet(): Text;
+        }
+
+        codeunit 61900 "Repro1731 Greeter" implements "Repro1731 IGreeter"
+        {
+            procedure Greet(): Text
+            begin
+                exit('hello');
+            end;
+        }
+
+        enum 61901 "Repro1731 Greeter Kind" implements "Repro1731 IGreeter"
+        {
+            value(0; Default)
+            {
+                Implementation = "Repro1731 IGreeter" = "Repro1731 Greeter";
+            }
+        }
+
+        codeunit 61902 "Repro1731 Service"
+        {
+            procedure GreetViaEnum(): Text
+            var
+                Greeter: Interface "Repro1731 IGreeter";
+                Kind: Enum "Repro1731 Greeter Kind";
+            begin
+                Kind := Kind::Default;
+                Greeter := Kind;
+                exit(Greeter.Greet());
+            end;
+        }
+        """);
+
+        File.WriteAllText(Path.Combine(testsDir, "app.json"), $$"""
+        {
+          "id": "{{testsId}}",
+          "name": "Repro1731 Tests",
+          "publisher": "Repro1731",
+          "version": "1.0.0.0",
+          "dependencies": [
+            { "id": "{{depId}}", "name": "Repro1731 Dep App", "publisher": "Repro1731", "version": "1.0.0.0" }
+          ],
+          "platform": "1.0.0.0",
+          "application": "1.0.0.0",
+          "idRanges": [ { "from": 61910, "to": 61919 } ],
+          "runtime": "14.0"
+        }
+        """);
+        var testsAlPath = Path.Combine(testsDir, "Repro1731Tests.al");
+        File.WriteAllText(testsAlPath, """
+        codeunit 61910 "Repro1731 Poison Test"
+        {
+            Subtype = Test;
+
+            [Test]
+            procedure EnumInterfaceDispatchWorks()
+            var
+                Service: Codeunit "Repro1731 Service";
+                Result: Text;
+            begin
+                Result := Service.GreetViaEnum();
+                if Result <> 'hello' then
+                    Error('Expected hello, got ''%1''', Result);
+            end;
+        }
+        """);
+
+        // Run 1: fresh cache all round (dep MISS, bundle MISS) — must pass, and the
+        // issue itself confirms this direction is never where the bug shows up.
+        var (output1, exit1) = RunRunner(testsDir, alCacheDir);
+        Assert.True(exit1 == 0 && output1.Contains("1P/0F/0E"),
+            $"run 1 (fresh cache) must pass:\n{output1}");
+
+        // Touch only the TESTS bundle's own source — changes the bundle's cache key
+        // (forces bundle MISS) while leaving the dep's synthesized .app byte-identical
+        // (dep stays a cache HIT).
+        File.AppendAllText(testsAlPath, "\n// touched\n");
+
+        // Run 2: dep HIT + bundle MISS — the exact condition from the issue.
+        var (output2, exit2) = RunRunner(testsDir, alCacheDir);
+
+        // The exact reported defect. Never let a run that hits this pass silently —
+        // the assertion below is the whole point of the RED -> GREEN cycle.
+        Assert.DoesNotContain("Unable to cast enum", output2);
+        Assert.True(exit2 == 0 && output2.Contains("1P/0F/0E"),
+            $"run 2 (dep HIT, bundle MISS) must ALSO pass — dep enum metadata must " +
+            $"survive being served from the compiled-deps cache:\n{output2}");
+    }
+}

--- a/AlRunner.Tests/SourceDepSymbolsWithoutPackageCacheTests.cs
+++ b/AlRunner.Tests/SourceDepSymbolsWithoutPackageCacheTests.cs
@@ -1,0 +1,193 @@
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// A bundle whose only dependency is a SIBLING SOURCE app must compile against that
+/// dep even when the run has <b>no package-cache directory at all</b>.
+///
+/// The sibling source-dependency pre-pass (Program.cs <c>BuildSiblingSourceDeps</c>)
+/// splits the handoff in two: a synthetic <c>.app</c> carries the RUNTIME half, and a
+/// <c>*.symbols.json</c> sidecar written by <c>BcCompiler.EmitDepSymbols</c> carries the
+/// COMPILE half (the synthetic .app has no <c>SymbolReference.json</c>, so BC's own .app
+/// scanner cannot serve it). <c>GetSharedReferences</c> is what wires that sidecar in, via
+/// a <c>JsonSymbolReferenceLoader</c> chain over <c>_extraSymbolDirs</c>.
+///
+/// It used to build that chain only AFTER an early
+/// <c>if (loaderScanDirs.Count == 0) return (null, empty)</c> bail-out — so with zero
+/// package dirs the sidecar was never read. The dep loaded fine at runtime
+/// (<c>loaded 1 dep assembl(ies)</c>) and was invisible to the compiler:
+/// <code>
+///   error AL0185: Codeunit 'X' is missing
+///   emit-crash: … — Unexpected value 'None' of type NavTypeKind
+///   &lt;bundled&gt;: EMIT-ZERO — 0 sources emitted
+/// </code>
+/// (the emit-crash is BC's emitter meeting the now-unresolved local variable type; the
+/// AL0185 above it is the real cause).
+///
+/// Zero package dirs is not exotic — it is exactly what CI does. The default set is
+/// <c>~/.bcartifacts.cache/sandbox/&lt;ver&gt;/…</c>,
+/// <c>~/.local/share/al-runner/symbols/&lt;ver&gt;</c> and the provisioned
+/// <c>&lt;artifacts&gt;/&lt;ver&gt;/{test-apps,platform-apps}</c>; a CI runner has none of
+/// them (it downloads to <c>~/.al-runner/…</c> and passes <c>--package-cache</c> explicitly
+/// on the steps that need it), while a dev box that once ran <c>--auto-provision</c> has
+/// them and silently took the working path.
+///
+/// Spawns the real runner; needs the BC artifact cache. Skips (no-op) when absent.
+/// </summary>
+[Collection("server-serial")]
+public class SourceDepSymbolsWithoutPackageCacheTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+    private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
+
+    private static bool ArtifactsPresent()
+    {
+        var home = Environment.GetEnvironmentVariable("HOME")
+            ?? Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        if (string.IsNullOrEmpty(home)) return false;
+        if (Directory.Exists(Path.Combine(home, ".bcartifacts.cache", "sandbox"))) return true;
+        var stdCache = Path.Combine(home, ".local", "share", "al-runner", "artifacts");
+        return Directory.Exists(stdCache) && Directory.EnumerateDirectories(stdCache).Any();
+    }
+
+    [Fact]
+    public void SiblingSourceDep_CompilesWithZeroPackageCacheDirs()
+    {
+        if (!ArtifactsPresent()) { Console.Error.WriteLine("[skip] BC artifact cache not present"); return; }
+
+        var scratchRoot = Path.Combine(
+            Path.GetTempPath(), "al-runner-srcdep-nopkgcache", Guid.NewGuid().ToString("N"));
+        var depDir = Path.Combine(scratchRoot, "dep-app");
+        var testsDir = Path.Combine(scratchRoot, "tests-app");
+        var alCacheDir = Path.Combine(scratchRoot, "al-out");
+        // Deliberately NEVER created: ExpandPackageCacheDirs drops non-existent dirs, so
+        // passing it takes the explicit-arg branch and resolves to the EMPTY set rather
+        // than falling back to DefaultPackageCacheDirs. That reproduces CI's
+        // "package caches: 0 dir(s)" on any machine, provisioned or not.
+        var absentPackageCache = Path.Combine(scratchRoot, "no-such-package-cache");
+        Directory.CreateDirectory(depDir);
+        Directory.CreateDirectory(testsDir);
+
+        // Fresh identities per run so no cache (workspace-deps, compiled-deps, AL output)
+        // from a previous run of this test can answer for the dep.
+        var depId = Guid.NewGuid();
+        var testsId = Guid.NewGuid();
+
+        // Nothing Microsoft is referenced (platform/application 1.0.0.0, no declared
+        // deps), so zero package caches is a legitimate configuration for this bundle.
+        File.WriteAllText(Path.Combine(depDir, "app.json"), $$"""
+        {
+          "id": "{{depId}}",
+          "name": "Repro1731B Dep App",
+          "publisher": "Repro1731B",
+          "version": "1.0.0.0",
+          "dependencies": [],
+          "platform": "1.0.0.0",
+          "application": "1.0.0.0",
+          "idRanges": [ { "from": 61930, "to": 61939 } ],
+          "runtime": "14.0"
+        }
+        """);
+        File.WriteAllText(Path.Combine(depDir, "Repro1731BDep.al"), """
+        codeunit 61930 "Repro1731B Service"
+        {
+            procedure Echo(Input: Text): Text
+            begin
+                exit('dep:' + Input);
+            end;
+
+            procedure Boom()
+            begin
+                Error('dep exploded');
+            end;
+        }
+        """);
+
+        File.WriteAllText(Path.Combine(testsDir, "app.json"), $$"""
+        {
+          "id": "{{testsId}}",
+          "name": "Repro1731B Tests",
+          "publisher": "Repro1731B",
+          "version": "1.0.0.0",
+          "dependencies": [
+            { "id": "{{depId}}", "name": "Repro1731B Dep App", "publisher": "Repro1731B", "version": "1.0.0.0" }
+          ],
+          "platform": "1.0.0.0",
+          "application": "1.0.0.0",
+          "idRanges": [ { "from": 61940, "to": 61949 } ],
+          "runtime": "14.0"
+        }
+        """);
+        // Positive: the dep procedure returns its REAL value (not '' from a blank
+        // auto-generated shell). Negative: the dep's Error surfaces with its exact text.
+        // Both fail loudly rather than silently degrading, so neither passes against a
+        // stubbed-out dependency.
+        File.WriteAllText(Path.Combine(testsDir, "Repro1731BTests.al"), """
+        codeunit 61940 "Repro1731B Tests"
+        {
+            Subtype = Test;
+
+            [Test]
+            procedure DepProcedureReturnsRealValue()
+            var
+                Svc: Codeunit "Repro1731B Service";
+                Actual: Text;
+            begin
+                Actual := Svc.Echo('abc');
+                if Actual <> 'dep:abc' then
+                    Error('Expected ''dep:abc'', got ''%1''', Actual);
+            end;
+
+            [Test]
+            procedure DepProcedureErrorSurfaces()
+            var
+                Svc: Codeunit "Repro1731B Service";
+                Actual: Text;
+            begin
+                asserterror Svc.Boom();
+                Actual := GetLastErrorText();
+                if Actual <> 'dep exploded' then
+                    Error('Expected ''dep exploded'', got ''%1''', Actual);
+            end;
+        }
+        """);
+
+        var args = new StringBuilder(TestBuildConfig.RunArgs(ProjectPath));
+        args.Append(TestBuildConfig.BcVersionArg);
+        args.Append($" \"{testsDir}\"");
+        args.Append($" --cache \"{alCacheDir}\"");
+        args.Append($" --package-cache \"{absentPackageCache}\"");
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet", Arguments = args.ToString(),
+            RedirectStandardOutput = true, RedirectStandardError = true,
+            UseShellExecute = false, CreateNoWindow = true, WorkingDirectory = RepoRoot,
+        };
+        var sb = new StringBuilder();
+        using var p = Process.Start(psi)!;
+        p.OutputDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.ErrorDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.BeginOutputReadLine();
+        p.BeginErrorReadLine();
+        if (!p.WaitForExit(180_000)) { try { p.Kill(true); } catch { } throw new TimeoutException("runner hung"); }
+        p.WaitForExit();
+        string output;
+        lock (sb) output = sb.ToString();
+
+        // Precondition: the configuration under test really is the zero-package-cache
+        // one. If the runner ever falls back to the default dirs here, this test would
+        // stop covering the CI path and go green for the wrong reason.
+        Assert.Contains("package caches: 0 dir(s)", output);
+        // The dep must be BOTH runtime-loadable and compile-visible.
+        Assert.Contains("loaded 1 dep assembl(ies)", output);
+        Assert.DoesNotContain("AL0185", output);
+        Assert.DoesNotContain("EMIT-ZERO", output);
+        Assert.True(p.ExitCode == 0 && output.Contains("2P/0F/0E"),
+            $"sibling source dep must compile + run with zero package-cache dirs:\n{output}");
+    }
+}

--- a/AlRunner/BcCompiler.cs
+++ b/AlRunner/BcCompiler.cs
@@ -783,10 +783,6 @@ public sealed class BcCompiler
             var loaderSig = ComputeLoaderSignature(loaderScanDirs, _extraSymbolDirs, _resolvedDeps, _currentAppId);
             if (_refLoader == null || loaderSig != _loaderSignature)
             {
-                if (loaderScanDirs.Count == 0) return (null, Array.Empty<NavCA.SymbolReferenceSpecification>());
-
-                _refLoader = NavSymRef.ReferenceLoaderFactory.CreateReferenceLoader(loaderScanDirs);
-
                 // Chain JSON-symbols loaders for any `*.symbols.json` in the package dirs
                 // (written by EmitDepSymbols for source dependencies we compiled ourselves).
                 // The standard scanner only reads a .app's SymbolReference.json, which a
@@ -800,19 +796,48 @@ public sealed class BcCompiler
                 // because they may contain synthetic .app files with no SymbolReference.json
                 // (written by RunLayeredPrePass). If such an .app ends up in the .app scanner,
                 // BC reports AL1023 "package not valid" for every compilation.
+                //
+                // This block is built BEFORE the .app scanner and independently of it: with
+                // no package-cache dir at all (a bundle whose only dependency is a SIBLING
+                // SOURCE app — no .alpackages, no ~/.bcartifacts.cache, no provisioned
+                // test-apps/platform-apps dir; exactly CI's `package caches: 0 dir(s)`), the
+                // old `loaderScanDirs.Count == 0` early-return bailed out here and the
+                // source dep's freshly written *.symbols.json was never consulted. The dep
+                // loaded fine at RUNTIME and was invisible at COMPILE time — AL0185
+                // "Codeunit 'X' is missing", after which BC's emitter crashes on the
+                // now-unresolved local variable type ("Unexpected value 'None' of type
+                // NavTypeKind") and the whole bundle emits zero sources.
                 var jsonScanDirs = packageDirs.ToList();
                 if (_extraSymbolDirs != null)
                     foreach (var d in _extraSymbolDirs)
                         if (Directory.Exists(d) && !jsonScanDirs.Contains(d, StringComparer.OrdinalIgnoreCase))
                             jsonScanDirs.Add(d);
 
-                _cachedJsonLoaders = jsonScanDirs
+                var jsonLoaders = jsonScanDirs
                     .Select(d => new JsonSymbolReferenceLoader(d))
                     .Where(l => l.HasAny)
                     .ToList();
-                if (_cachedJsonLoaders.Count > 0)
-                    _refLoader = new CompositeSymbolReferenceLoader(
-                        _cachedJsonLoaders.Cast<NavCA.ISymbolReferenceLoader>().Append(_refLoader).ToList());
+
+                // Nothing to serve references from at all — same no-op result as before.
+                // (Deliberately leaves _refLoader / _loaderSignature untouched, as the
+                // original early-return did.)
+                if (loaderScanDirs.Count == 0 && jsonLoaders.Count == 0)
+                    return (null, Array.Empty<NavCA.SymbolReferenceSpecification>());
+
+                _cachedJsonLoaders = jsonLoaders;
+                NavCA.ISymbolReferenceLoader? packageLoader = loaderScanDirs.Count > 0
+                    ? NavSymRef.ReferenceLoaderFactory.CreateReferenceLoader(loaderScanDirs)
+                    : null;
+                if (jsonLoaders.Count > 0)
+                {
+                    var chain = jsonLoaders.Cast<NavCA.ISymbolReferenceLoader>().ToList();
+                    if (packageLoader != null) chain.Add(packageLoader);
+                    _refLoader = new CompositeSymbolReferenceLoader(chain);
+                }
+                else
+                {
+                    _refLoader = packageLoader!;
+                }
 
                 // Pre-warm the loader's internal package caches SEQUENTIALLY before the
                 // compiler's parallel reference-loading runs. BC's ReferenceManager fans

--- a/AlRunner/DependencyLoader.cs
+++ b/AlRunner/DependencyLoader.cs
@@ -268,6 +268,14 @@ public sealed class DependencyLoader
         // access to its page-variable-bound controls fails only on warm runs.
         var pageMetadataSidecar = Path.Combine(cacheDir, cacheKey + ".page-metadata.json");
         var xmlPortMetadataSidecar = Path.Combine(cacheDir, cacheKey + ".xmlport-metadata.json");
+        // Sidecar for this dep's enum metadata (AlEnumMetadataRegistry) — see issue
+        // #1731. Without it, a HIT here (dep skips emit) combined with a bundle
+        // recompile (which only registers ITS OWN sources' enums) left this dep's
+        // enums completely unregistered for the rest of the process: enum-to-interface
+        // dispatch (ALCompiler_ToInterfaceFromOption) and option evaluation on a dep
+        // enum then failed with a blank enum name / empty option list. Mirrors the
+        // bundle-level `.enum-registry.json` sidecar (Program.cs SaveEnumRegistrySidecar).
+        var enumRegistrySidecar = Path.Combine(cacheDir, cacheKey + ".enum-registry.json");
         if (File.Exists(cachedDll))
         {
             try
@@ -284,8 +292,11 @@ public sealed class DependencyLoader
                     AlPageMetadataRegistry.LoadSidecar(pageMetadataSidecar);
                 if (File.Exists(xmlPortMetadataSidecar))
                     AlXmlPortMetadataRegistry.LoadSidecar(xmlPortMetadataSidecar);
+                int replayedEnums = 0;
+                if (File.Exists(enumRegistrySidecar))
+                    replayedEnums = AlEnumMetadataRegistry.LoadSidecar(enumRegistrySidecar);
                 Console.Error.WriteLine(
-                    $"[deps] source-cache HIT: {m.Name} v{m.Version} key={cacheKey[..12]} ({cachedBytes.Length} bytes, {replayedReports} report-metadata entries)");
+                    $"[deps] source-cache HIT: {m.Name} v{m.Version} key={cacheKey[..12]} ({cachedBytes.Length} bytes, {replayedReports} report-metadata entries, {replayedEnums} enum-registry entries)");
                 return Assembly.Load(cachedBytes);
             }
             catch (Exception ex)
@@ -330,6 +341,7 @@ public sealed class DependencyLoader
         var reportIdsBeforeEmit = new HashSet<int>(AlReportMetadataRegistry.Ids);
         var pageIdsBeforeEmit = new HashSet<int>(AlPageMetadataRegistry.Ids);
         var xmlPortIdsBeforeEmit = new HashSet<int>(AlXmlPortMetadataRegistry.Ids);
+        var enumIdsBeforeEmit = new HashSet<int>(AlEnumMetadataRegistry.Ids);
         // Scope _currentAppId to the dep's own identity for the duration of this compile.
         // GetSharedReferences uses _currentAppId to exclude the "current app" from its
         // reference specs. Without this, the dep's resolved spec (from _resolvedDeps of
@@ -387,8 +399,10 @@ public sealed class DependencyLoader
                 AlPageMetadataRegistry.Ids.Where(i => !pageIdsBeforeEmit.Contains(i)).ToArray());
             AlXmlPortMetadataRegistry.SaveSidecar(xmlPortMetadataSidecar,
                 AlXmlPortMetadataRegistry.Ids.Where(i => !xmlPortIdsBeforeEmit.Contains(i)).ToArray());
+            int enumSidecarCount = AlEnumMetadataRegistry.SaveSidecar(enumRegistrySidecar,
+                AlEnumMetadataRegistry.Ids.Where(i => !enumIdsBeforeEmit.Contains(i)));
             Console.Error.WriteLine(
-                $"[deps] source-cache WROTE: {m.Name} v{m.Version} key={cacheKey[..12]} ({compile.AssemblyBytes!.Length} bytes, {sidecarCount} report-metadata entries)");
+                $"[deps] source-cache WROTE: {m.Name} v{m.Version} key={cacheKey[..12]} ({compile.AssemblyBytes!.Length} bytes, {sidecarCount} report-metadata entries, {enumSidecarCount} enum-registry entries)");
         }
         catch (Exception ex)
         {

--- a/AlRunner/Patches/EnumMetadataPatches.cs
+++ b/AlRunner/Patches/EnumMetadataPatches.cs
@@ -196,6 +196,107 @@ public static class AlEnumMetadataRegistry
         return result.OrderBy(e => e.Id).ToList();
     }
 
+    /// <summary>Every enum id currently registered (base ids ∪ enumextension target
+    /// ids) — used by <see cref="DependencyLoader"/> to snapshot "before this dep's
+    /// emit" / "after this dep's emit" sets so a source-dep compile can persist only
+    /// the entries IT contributed to its own cache sidecar (issue #1731's fix).</summary>
+    public static int[] Ids
+    {
+        get
+        {
+            var ids = new HashSet<int>(_byId.Keys);
+            ids.UnionWith(_extByTargetId.Keys);
+            return ids.ToArray();
+        }
+    }
+
+    /// <summary>
+    /// Serialize the given enum ids' MERGED entries (base + enumextension values
+    /// already flattened by <see cref="TryGet"/>) to a sidecar file. Mirrors
+    /// Program.cs's bundle-level <c>SaveEnumRegistrySidecar</c> (schema v3), but
+    /// scoped to <paramref name="onlyIds"/> so the dependency-loader's per-dep
+    /// cache sidecar does not leak sibling-app/bundle entries into its own file —
+    /// same convention as <see cref="AlReportMetadataRegistry.SaveSidecar(string, IEnumerable{int})"/>.
+    /// Returns the number of entries written.
+    /// </summary>
+    public static int SaveSidecar(string path, IEnumerable<int> onlyIds)
+    {
+        var idSet = new HashSet<int>(onlyIds);
+        var entries = new List<Entry>(idSet.Count);
+        foreach (var id in idSet)
+            if (TryGet(id, out var merged))
+                entries.Add(merged);
+        entries = entries.OrderBy(e => e.Id).ToList();
+
+        var dto = new
+        {
+            enums = entries.Select(e => new
+            {
+                id = e.Id,
+                name = e.Name,
+                options = e.Options,
+                indexes = e.Indexes,
+                implementations = e.Implementations,
+            }).ToArray(),
+        };
+        var json = System.Text.Json.JsonSerializer.Serialize(dto);
+        File.WriteAllText(path, json);
+        return entries.Count;
+    }
+
+    /// <summary>
+    /// Replay entries from a sidecar written by <see cref="SaveSidecar"/>. Each
+    /// entry is already the merged base+extension set, so replay uses plain
+    /// <see cref="Register"/> (never <see cref="RegisterExtension"/>) — matching
+    /// how Program.cs's bundle-level sidecar replay works. Throws on corrupt JSON;
+    /// callers treat that as a cache MISS and rebuild. Returns replayed entry count.
+    /// </summary>
+    public static int LoadSidecar(string path)
+    {
+        var json = File.ReadAllText(path);
+        using var doc = System.Text.Json.JsonDocument.Parse(json);
+        if (!doc.RootElement.TryGetProperty("enums", out var arr)
+            || arr.ValueKind != System.Text.Json.JsonValueKind.Array)
+            throw new InvalidDataException("enum-registry.json: missing 'enums' array");
+        int count = 0;
+        foreach (var e in arr.EnumerateArray())
+        {
+            int id = e.GetProperty("id").GetInt32();
+            string name = e.GetProperty("name").GetString() ?? string.Empty;
+            var optsEl = e.GetProperty("options");
+            var idxEl = e.GetProperty("indexes");
+            var opts = new string[optsEl.GetArrayLength()];
+            int oi = 0;
+            foreach (var o in optsEl.EnumerateArray()) opts[oi++] = o.GetString() ?? string.Empty;
+            var idxs = new int[idxEl.GetArrayLength()];
+            int ii = 0;
+            foreach (var x in idxEl.EnumerateArray()) idxs[ii++] = x.GetInt32();
+            int[][] implementations = Array.Empty<int[]>();
+            if (e.TryGetProperty("implementations", out var implEl)
+                && implEl.ValueKind == System.Text.Json.JsonValueKind.Array
+                && implEl.GetArrayLength() == opts.Length)
+            {
+                implementations = new int[implEl.GetArrayLength()][];
+                int vi = 0;
+                foreach (var valueImplEl in implEl.EnumerateArray())
+                {
+                    if (valueImplEl.ValueKind != System.Text.Json.JsonValueKind.Array)
+                    {
+                        implementations = Array.Empty<int[]>();
+                        break;
+                    }
+                    var ids = new int[valueImplEl.GetArrayLength()];
+                    int idi = 0;
+                    foreach (var implId in valueImplEl.EnumerateArray())
+                        ids[idi++] = implId.GetInt32();
+                    implementations[vi++] = ids;
+                }
+            }
+            Register(id, name, opts, idxs, implementations);
+            count++;
+        }
+        return count;
+    }
 }
 
 /// <summary>


### PR DESCRIPTION
Closes #1731

## Problem

A source-compiled dependency served from the `compiled-deps` cache (Tier 3 of `DependencyLoader`) while the test bundle itself recompiles (any bundle edit changes the bundle's own cache key) lost its enum metadata entirely for that process:

- The dep's own emit is skipped on a cache HIT, so `AlEnumMetadataRegistry` never gets (re-)populated from the dep's enum declarations.
- The recompiling bundle's own emit only registers the enums **its own** sources declare — never the dep's.

Enum-to-interface dispatch on a dep enum then threw:
```
InvalidOperationException: Unable to cast enum '' value '0' to interface at index 0.
```
(blank enum name, because no registry entry existed at all), and the same empty-metadata state also surfaced as `NavNCLInvalidOptionStringException` during option evaluation.

## Root cause

The bundle's own AL-output cache already solves this with a `.enum-registry.json` sidecar (`Program.cs` `SaveEnumRegistrySidecar`/`LoadEnumRegistrySidecar`), replayed on a bundle cache HIT. The dependency loader's Tier-3 `compiled-deps` cache persisted report/page/xmlport metadata sidecars for exactly this reason ("mirrors the bundle enum-registry sidecar" — see the pre-existing comment in `DependencyLoader.cs`) — but never actually added the enum sidecar itself. So a dep cache HIT replayed everything except its own enums.

## Fix

- `AlEnumMetadataRegistry` gains `Ids`, `SaveSidecar(path, onlyIds)`, and `LoadSidecar(path)` — mirroring `AlReportMetadataRegistry`'s existing scoped-sidecar convention (`SaveSidecar(path, IEnumerable<int> onlyIds)` so a dep's sidecar carries only the entries **it** contributed, never sibling-app/bundle entries).
- `DependencyLoader.LoadOne`'s Tier-3 path now snapshots `AlEnumMetadataRegistry.Ids` before/after the dep's own emit (same pattern already used for report/page/xmlport ids), and:
  - on a cache **HIT**, replays `<key>.enum-registry.json` via `LoadSidecar` alongside the existing report/page/xmlport sidecars,
  - on a cache **WRITE**, persists just the ids this dep's emit newly contributed via `SaveSidecar`.

## Testing (RED → GREEN)

`AlRunner.Tests/SourceDepCacheEnumMetadataTests.cs` — spawns the real runner twice against a real, shared `~/.cache/al-runner`, reproducing the exact two-invocation sequence from the issue:

1. Fresh random `AppId`s + a fresh scratch dir per run (so the dep's Tier-3 cache key has never been seen before — run 1 is unconditionally a dep MISS, matching the issue's own observation that a fresh cache always passes).
2. Run 1 (dep MISS, bundle MISS) — asserts PASS.
3. Touch only the tests-bundle's own source (forces the bundle's cache key to change while the dep's synthesized `.app` stays byte-identical, so the dep's Tier-3 key stays the same).
4. Run 2 (dep **HIT**, bundle **MISS** — the exact condition from the issue) — asserts PASS, and asserts the output does **not** contain `Unable to cast enum` (the reported defect).

Confirmed RED before the fix (run 2 fails with `Unable to cast enum ''`), GREEN after.

Also ran the full `AlRunner.Tests` suite (374/374 passing) plus the `tests/runner-extras/enum-extension-metadata` bundle (9/9 passing) to confirm no regression on the existing enum-metadata paths (base + enumextension merge, bundle-level sidecar).

## Scope note on where this test lives

This is runner-internal caching/plumbing behaviour (source-dep compile cache correctness across process invocations), not a claim about what BC itself does — per `bc-behavior-tests-go-upstream.md` it belongs in this repo, not the upstream corpus. It's placed as an `AlRunner.Tests` xunit test (spawning the real runner subprocess) rather than under `tests/runner-extras/` because it needs to control two *separate* runner process invocations sharing a real on-disk cache directory — the same pattern already used by `CrossBundleModuleIdentityDedupTests` and `CacheKeyDependencyClosureTests` for this class of cache-behaviour regression.


---
_Generated by [Claude Code](https://claude.ai/code/session_01G3KPXYQnfoL1ogXLXo823n)_

---

## Follow-up: what was actually red on all 8 BC legs (Closes #1748)

The first revision of this PR failed **every** BC leg on the *first, unfiltered*
`dotnet test AlRunner.Tests` step — and it was **not** the enum sidecar and **not**
BC-version dependent. It was a second, independent runner gap that the new test
happened to be the first thing in the repo to hit.

### Symptom (run 1, the "fresh cache" invocation that is supposed to be unconditional)

```
  [source-dep] WROTE Repro1731 Dep App 1.0.0.0 -> ... (+symbols, 741 bytes)
  [.../tests-app] resolved 1 dep(s)
  [.../tests-app] loaded 1 dep assembl(ies)
<bundled>: EMIT-ZERO -- 0 sources emitted, 2 AL error(s):
  SourceFile(.../Repro1731Tests.al@8:18): error AL0185: Codeunit 'Repro1731 Service' is missing
  emit-crash: ... -- Unexpected value 'None' of type 'Microsoft.Dynamics.Nav.CodeAnalysis.NavTypeKind'
```

Verdict: **a real runner gap, not a fixture bug.** The dep *is* built and *is*
loaded (`loaded 1 dep assembl(ies)`); it is only invisible to the compiler. The
`emit-crash` is downstream — BC's emitter meeting the local variable whose type
failed to bind. `AL0185` above it is the cause.

### Root cause

`BcCompiler.GetSharedReferences` bailed out with

```csharp
if (loaderScanDirs.Count == 0) return (null, Array.Empty<SymbolReferenceSpecification>());
```

**before** constructing the `JsonSymbolReferenceLoader` chain over `_extraSymbolDirs`.
That chain is the only route by which a sibling source dependency's `*.symbols.json`
(written by `EmitDepSymbols`; the synthetic `.app` carries no `SymbolReference.json`)
reaches the compiler. With no package-cache dir to scan, the sidecar was never read.

### Why it was green locally and red on all 8 legs

`DefaultPackageCacheDirs()` includes the provisioned `<artifacts>/<ver>/test-apps`
and `<artifacts>/<ver>/platform-apps`. A dev box that has ever run `--auto-provision`
has them -> `package caches: 1 dir(s)` -> the JSON chain is built -> green. CI
downloads to `$HOME/.al-runner/{platform-apps,test-apps}` and passes
`--package-cache` explicitly only on the corpus / runner-extras steps, so a runner
spawned from `dotnet test` sees `package caches: 0 dir(s)` -> red.

Proof it is not the BC build: moving `<artifacts>/28.1.49838.50794/test-apps` aside
reproduces the CI failure **byte for byte** on the local BC version.

### Fix

- `BcCompiler.GetSharedReferences` builds the JSON symbol-loader chain first and
  independently of the `.app` scanner; the empty result is returned only when there
  is neither a package dir nor a JSON symbols dir. Behaviour with >= 1 package dir
  is unchanged (same loaders, same order: JSON first, package scanner last).
- Both source-dep tests now **pin** the zero-package-cache configuration (an
  `--package-cache` path that does not exist resolves to the empty set) and assert
  `package caches: 0 dir(s)`, so they can never again pass locally while failing on CI.
- New `AlRunner.Tests/SourceDepSymbolsWithoutPackageCacheTests.cs` isolates the gap
  from the enum story: a sibling source dep with a plain codeunit, one run, asserting
  a real returned value (`'dep:abc'`, not `''` from a blank shell) and a real error
  text (`'dep exploded'` via `asserterror` + `GetLastErrorText`).

### RED -> GREEN evidence (both fixes independently load-bearing)

| configuration | run 1 | run 2 |
|---|---|---|
| enum sidecar fixed, `BcCompiler` **unfixed** | FAIL `AL0185` / EMIT-ZERO (= the CI failure) | not reached |
| both fixed | PASS | PASS |
| `BcCompiler` fixed, enum sidecar **reverted** | PASS | FAIL `InvalidOperationException: Unable to cast enum '' value '0' to interface at index 0` |

The last row is the check that the original #1731 fix is still doing work: revert
`DependencyLoader`'s enum sidecar and run 2 goes red with the exact reported defect.

### Local verification

`AlRunner.Tests` 406/406, al-language corpus 1945/1945 `--strict`, xmlport isolation
slice 59/59, runner-extras 108/108 `--strict`, server-mode integration green.

### On the `NavTypeKind.None` emit-crash

Not filed separately: it is BC's own emitter throwing on an AL tree that already has
a hard binder error, and the runner surfaces it *alongside* the real `AL0185`
diagnostic rather than instead of it — so the output is loud and points at the cause.
With the fix, this fixture no longer reaches it.


---
_Generated by [Claude Code](https://claude.ai/code)_