### PR TITLE
fix(events): honor EventSubscriberInstance = Manual in codeunit-event dispatch

### DIFF
--- a/AlRunner/Patches/CodeunitEventDispatcher.cs
+++ b/AlRunner/Patches/CodeunitEventDispatcher.cs
@@ -96,7 +96,24 @@ public static partial class BcRuntime
         foreach (var sub in subs)
         {
             if (!seen.Add(SubscriberAlIdentity(sub))) continue;
-            try { InvokeOneSubscriber(publisherScope, scopeType, pubObj, sub); }
+            try
+            {
+                if (IsManualBindingCodeunitType(sub.DeclaringType!))
+                {
+                    // EventSubscriberInstance = Manual: BC dispatches only to instances
+                    // currently bound via BindSubscription — on those very instances, so
+                    // the binder observes their state afterwards. Unbound → no fire at
+                    // all (container-verified; the unbound default state must never leak
+                    // into an event, e.g. System Application Test Library's 132513
+                    // "Confirm Test Library" answering OnBeforeGuiAllowed with false).
+                    foreach (var bound in BoundInstancesOf(ExtractCodeunitIdFromTypeName(sub.DeclaringType!)))
+                        InvokeOneSubscriber(publisherScope, scopeType, pubObj, sub, bound);
+                }
+                else
+                {
+                    InvokeOneSubscriber(publisherScope, scopeType, pubObj, sub, null);
+                }
+            }
             catch (TargetInvocationException tie)
             {
                 if (Environment.GetEnvironmentVariable("ALRUNNER_DISPATCH_TRACE") == "1")
@@ -106,6 +123,79 @@ public static partial class BcRuntime
                 throw tie.InnerException ?? tie;
             }
         }
+    }
+
+    private static readonly System.Collections.Concurrent.ConcurrentDictionary<Type, bool> _manualBindingTypeCache = new();
+
+    /// <summary>Drop the manual-binding type cache on a server-mode bundle reload — its keys
+    /// are Types from the previous bundle's emitted assembly (same reason
+    /// EventSubscriberPatches.ResetForReload clears its codeunit-type cache).</summary>
+    internal static void ResetManualBindingCacheForReload() => _manualBindingTypeCache.Clear();
+
+    /// <summary>
+    /// Does this AL-emitted Codeunit{N} class declare <c>EventSubscriberInstance = Manual</c>?
+    /// Read off [NavCodeunitOptionsAttribute] exactly like
+    /// <see cref="NCLMetaCodeunit_get_IsEventManualBinding"/> (which serves BC's own
+    /// BindSubscription path) so both sides agree on what "manual" is.
+    /// </summary>
+    private static bool IsManualBindingCodeunitType(Type codeunitClrType)
+        => _manualBindingTypeCache.GetOrAdd(codeunitClrType, static t =>
+        {
+            foreach (var attr in t.GetCustomAttributes(inherit: false))
+            {
+                var at = attr.GetType();
+                if (at.Name != "NavCodeunitOptionsAttribute") continue;
+                var isManual = at.GetProperty("IsEventManualBinding",
+                    BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+                if (isManual != null)
+                {
+                    try { return (bool)isManual.GetValue(attr)!; } catch { }
+                }
+                var optionsProp = at.GetProperty("Options",
+                    BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+                var v = optionsProp?.GetValue(attr);
+                if (v != null)
+                    return (Convert.ToInt32(v) & 1) != 0; // EventManualBinding flag = 1
+            }
+            return false;
+        });
+
+    private static PropertyInfo? _piSessionEventBindings;
+    private static bool _eventBindingsLookupFailed;
+
+    /// <summary>
+    /// Instances of codeunit <paramref name="codeunitId"/> currently bound via AL
+    /// BindSubscription. BC's own NavCodeunit.BindSubscription/UnbindSubscription bodies
+    /// maintain <c>Session.EventBindings</c> (a List&lt;NavCodeunit&gt; seeded on the
+    /// skeleton session); reading that list keeps bind/unbind/double-bind semantics BC's
+    /// business, not ours. Snapshot before invoking — a subscriber body may bind/unbind.
+    /// </summary>
+    private static List<object> BoundInstancesOf(int codeunitId)
+    {
+        var result = new List<object>();
+        if (codeunitId == 0) return result;
+        var session = SkeletonSession;
+        if (session == null) return result;
+        if (_piSessionEventBindings == null && !_eventBindingsLookupFailed)
+        {
+            _piSessionEventBindings = session.GetType().GetProperty("EventBindings",
+                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+            if (_piSessionEventBindings == null)
+            {
+                _eventBindingsLookupFailed = true;
+                Console.Error.WriteLine(
+                    "[Dispatch] NavSession.EventBindings NOT FOUND — Ncl shape changed; "
+                    + "manually-bound event subscribers will never fire");
+            }
+        }
+        if (_piSessionEventBindings?.GetValue(session) is not System.Collections.IEnumerable bindings)
+            return result;
+        foreach (var bound in bindings)
+        {
+            if (bound != null && ExtractCodeunitIdFromTypeName(bound.GetType()) == codeunitId)
+                result.Add(bound);
+        }
+        return result;
     }
 
     /// <summary>
@@ -166,7 +256,8 @@ public static partial class BcRuntime
     private static ConstructorInfo? _ciNavCodeunitHandleByInstance;
     private static PropertyInfo? _pNavCodeunitHandle_Target;
 
-    private static void InvokeOneSubscriber(object publisherScope, Type scopeType, object treeObj, MethodInfo subscriberMethod)
+    private static void InvokeOneSubscriber(object publisherScope, Type scopeType, object treeObj, MethodInfo subscriberMethod,
+        object? boundInstance)
     {
         EnsureCodeunitHandleReflection();
 
@@ -174,17 +265,21 @@ public static partial class BcRuntime
         int subscriberCodeunitId = ExtractCodeunitIdFromTypeName(subscriberClrType);
         if (subscriberCodeunitId == 0) return;
 
-        // The subscriber handle is parented on the PUBLISHER, and a publisher can outlive the
-        // scope it was created in — a SingleInstance codeunit is cached for the whole test, so
-        // by the time it publishes again its original tree may be disposed. Everything that
-        // reads the tree off it then throws ObjectDisposedException("Tree"), which took out
-        // event dispatch for the rest of the run (measured on Base App codeunit 43 publishing
-        // OnGetLanguageIdOrDefault). Parenting on the session instead is what BC's own
-        // "resolve this codeunit in the current session" amounts to, and the session is alive
-        // for exactly as long as dispatch can be running.
-        var handle = _ciNavCodeunitHandleByIdInt!.Invoke(
-            new object?[] { LiveParentFor(treeObj), subscriberCodeunitId });
-        var subscriberInstance = _pNavCodeunitHandle_Target!.GetValue(handle);
+        object? subscriberInstance = boundInstance;
+        if (subscriberInstance == null)
+        {
+            // The subscriber handle is parented on the PUBLISHER, and a publisher can outlive the
+            // scope it was created in — a SingleInstance codeunit is cached for the whole test, so
+            // by the time it publishes again its original tree may be disposed. Everything that
+            // reads the tree off it then throws ObjectDisposedException("Tree"), which took out
+            // event dispatch for the rest of the run (measured on Base App codeunit 43 publishing
+            // OnGetLanguageIdOrDefault). Parenting on the session instead is what BC's own
+            // "resolve this codeunit in the current session" amounts to, and the session is alive
+            // for exactly as long as dispatch can be running.
+            var handle = _ciNavCodeunitHandleByIdInt!.Invoke(
+                new object?[] { LiveParentFor(treeObj), subscriberCodeunitId });
+            subscriberInstance = _pNavCodeunitHandle_Target!.GetValue(handle);
+        }
         if (subscriberInstance == null) return;
 
         // Cross-assembly type mismatch: the registry may hold this MethodInfo from a

--- a/AlRunner/Patches/EventSubscriberPatches.cs
+++ b/AlRunner/Patches/EventSubscriberPatches.cs
@@ -259,6 +259,7 @@ public static class EventSubscriberPatches
             _seededScopeTypes.Clear();
             _lastScannedCount = 0;
         }
+        AlRunner.BcRuntime.ResetManualBindingCacheForReload();
     }
 
     private static Type? FindCodeunitClrType(int codeunitId)

--- a/tests/runner-extras/manual-binding-dep/ManualBindGuardedHeader.Table.al
+++ b/tests/runner-extras/manual-binding-dep/ManualBindGuardedHeader.Table.al
@@ -1,0 +1,28 @@
+table 62210 "Manual Bind Guarded Header"
+{
+    // Mirrors the reproducer table from issue #1729: a field OnValidate guarded by
+    // Confirm Management.GetResponseOrDefault, so the confirm is raised from inside
+    // the record-trigger execution path.
+    fields
+    {
+        field(1; "No."; Code[20]) { }
+        field(2; Template; Boolean)
+        {
+            InitValue = true;
+
+            trigger OnValidate()
+            var
+                ConfirmManagement: Codeunit "Confirm Management";
+            begin
+                if not Template or xRec.Template then
+                    exit;
+                if "Template Used" = '' then
+                    exit;
+                if not ConfirmManagement.GetResponseOrDefault('Clear Template Used?', false) then
+                    Template := xRec.Template;
+            end;
+        }
+        field(3; "Template Used"; Code[20]) { }
+    }
+    keys { key(PK; "No.") { Clustered = true; } }
+}

--- a/tests/runner-extras/manual-binding-dep/ManualBindingDepTests.Codeunit.al
+++ b/tests/runner-extras/manual-binding-dep/ManualBindingDepTests.Codeunit.al
@@ -1,0 +1,66 @@
+codeunit 62211 "Manual Binding Dep Tests"
+{
+    // Regression for issue #1729. With Tests-TestLibraries declared as a dependency, the
+    // dep closure contains codeunit 132513 "Confirm Test Library" (System Application
+    // Test Library): EventSubscriberInstance = Manual, subscribed to Confirm Management
+    // Impl.OnBeforeGuiAllowed, unbound default state GuiAllowed=false + Handled=true.
+    // A runner that dispatches Manual subscribers without a BindSubscription would let
+    // that unbound default flip IsGuiAllowed() to false, so GetResponseOrDefault returns
+    // its default WITHOUT raising the confirm and the [ConfirmHandler] never fires.
+    Subtype = Test;
+
+    var
+        ConfirmWasRaised: Boolean;
+
+    [Test]
+    [HandlerFunctions('YesHandler')]
+    procedure TriggerConfirm_WithTestLibrariesDep_ReachesHandler()
+    var
+        Row: Record "Manual Bind Guarded Header";
+    begin
+        ConfirmWasRaised := false;
+        Row.Init();
+        Row."No." := 'INST';
+        Row.Template := false;
+        Row."Template Used" := 'TMPL';
+        Row.Insert(true);
+
+        Row.Validate(Template, true);
+
+        if not ConfirmWasRaised then
+            Error('The [ConfirmHandler] never fired: GetResponseOrDefault returned the default instead of dispatching the confirm (issue #1729 regressed).');
+        if not Row.Template then
+            Error('Handler replied Yes but Template was reverted - the reply did not reach the trigger.');
+    end;
+
+    [Test]
+    [HandlerFunctions('YesHandler')]
+    procedure DirectGetResponseOrDefault_WithTestLibrariesDep_ReachesHandler()
+    var
+        ConfirmManagement: Codeunit "Confirm Management";
+    begin
+        ConfirmWasRaised := false;
+        if not ConfirmManagement.GetResponseOrDefault('Direct?', false) then
+            Error('GetResponseOrDefault returned the default: the unbound Manual subscriber 132513 answered OnBeforeGuiAllowed (issue #1729 regressed).');
+        if not ConfirmWasRaised then
+            Error('GetResponseOrDefault returned true but the [ConfirmHandler] never ran.');
+    end;
+
+    [Test]
+    [HandlerFunctions('YesHandler')]
+    procedure DirectConfirm_WithTestLibrariesDep_ReachesHandler()
+    begin
+        ConfirmWasRaised := false;
+        if not Confirm('Proceed?', false) then
+            Error('Direct Confirm() returned false - the [ConfirmHandler] did not answer.');
+        if not ConfirmWasRaised then
+            Error('Direct Confirm() returned true but the handler never ran.');
+    end;
+
+    [ConfirmHandler]
+    procedure YesHandler(Question: Text[1024]; var Reply: Boolean)
+    begin
+        ConfirmWasRaised := true;
+        Reply := true;
+    end;
+}

--- a/tests/runner-extras/manual-binding-dep/app.json
+++ b/tests/runner-extras/manual-binding-dep/app.json
@@ -1,0 +1,26 @@
+{
+  "id": "9c5e1f83-7d24-4a6e-b1f0-3e8a52c96d47",
+  "name": "Runner Extras - Manual Binding Via Dependency",
+  "publisher": "AL Runner",
+  "version": "1.0.0.0",
+  "brief": "Regression for issue #1729: a Manual event subscriber inside a DEPENDENCY app must not fire unbound.",
+  "description": "The BC-language contract (EventSubscriberInstance = Manual fires only while bound) is proven upstream in the al-language corpus (Test Event Manual Binding, 60240) where the subscriber lives in the SAME emitted bundle. This suite pins the runner-specific half: the Manual flag must survive the runner's DEPENDENCY-compile pipeline. It declares the exact app.json dependency from issue #1729 (Microsoft Tests-TestLibraries), whose transitive dep System Application Test Library ships codeunit 132513 'Confirm Test Library' - a Manual subscriber to Confirm Management Impl.OnBeforeGuiAllowed whose unbound default answers GuiAllowed=false. If the runner ever again dispatches it unbound, Confirm Management.GetResponseOrDefault silently returns its default instead of raising the confirm, and these [ConfirmHandler] tests go red. Tests-TestLibraries first ships in BC 28.0, hence the floor.",
+  "dependencies": [
+    {
+      "id": "5d86850b-0d76-4eca-bd7b-951ad998e997",
+      "name": "Tests-TestLibraries",
+      "publisher": "Microsoft",
+      "version": "28.0.0.0"
+    }
+  ],
+  "idRanges": [
+    {
+      "from": 62210,
+      "to": 62219
+    }
+  ],
+  "platform": "28.0.0.0",
+  "application": "28.0.0.0",
+  "runtime": "17.0",
+  "target": "Cloud"
+}


### PR DESCRIPTION
Closes #1729

## Root cause

Not the trigger path, and not handler dispatch. The codeunit-event dispatcher fired **every** registered `[EventSubscriber]`, ignoring `EventSubscriberInstance = Manual`. Declaring the Tests-TestLibraries dependency pulls in System Application Test Library''s codeunit 132513 "Confirm Test Library" — a Manual subscriber to `Confirm Management Impl.OnBeforeGuiAllowed` whose unbound default state answers `GuiAllowed := false, Handled := true`. Dispatched unbound, it made `IsGuiAllowed()` false, so `GetResponseOrDefault` took its early-exit and returned the default **without ever raising the confirm** — hence "UI handlers were not executed" while a direct `Confirm()` (which bypasses Confirm Management) kept working. The A/B in the issue tracked the dependency, not the trigger: a `GetResponseOrDefault` called directly from the test method fails identically with the dep present.

## The BC contract (container-verified on real BC 28.3)

Corpus PR StefanMaron/BusinessCentral.AL.Language.Tests#22 pins it upstream (codeunit 60240 "Test Event Manual Binding", fixture 60033; verified 7/7 on a real service tier): unbound Manual subscriber never fires; `BindSubscription` → true and delivery targets the **bound instance** (state visible to the binder); unbind stops delivery; double-bind → false; bind on static → false; unbind on never-bound Manual instance → **true**; two bound instances each fire once.

## Fix (dispatch-side only)

`CodeunitEventDispatcher.DispatchCore` classifies the subscriber''s declaring type via `NavCodeunitOptionsAttribute` — the same read BC''s own BindSubscription path uses via `NCLMetaCodeunit_get_IsEventManualBinding` — and for Manual codeunits fires once per instance found in `Session.EventBindings` (the list BC''s own `NavCodeunit.BindSubscription`/`UnbindSubscription` bodies maintain), skipping entirely when nothing is bound. Bind/unbind return semantics stay BC''s code and were already correct (they passed RED).

## Proof

| Check | Before | After |
|---|---|---|
| Corpus 60240 (manual-binding contracts) | 3P/**4F** | **7P**/0F |
| Issue #1729 reproducer (Tests-TestLibraries dep) | 1P/**1F** (handler never fires) | **4P**/0F |
| Full corpus (pin c1a6733) | 1945/1945 | 1945/1945 |
| runner-extras | 114/114 | **117/117** (new `manual-binding-dep` bundle, BC 28.0 floor) |
| AlRunner.Tests | 401P + 3 pre-existing Windows-local encoding failures (fail identically on unmodified main) | same |

`tests/runner-extras/manual-binding-dep` pins the runner-specific half of #1729 — the Manual flag surviving the **dependency**-compile pipeline — using the exact `app.json` configuration from the issue; the language contract itself lives upstream.

## Not in this PR

The table-trigger event path has the same class of gap through a different mechanism (`AlEventSubscriberAdapter` hard-codes `IsEventManualBinding => false`); filed as #1749 with a standalone repro.

## Draft until

Corpus PR #22 merges → then the `tests/al-language` pin bump lands here as its own commit and this converts to ready, showing corpus 60240 RED→GREEN in CI against the new pin (same shape as #1745).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RqB1zkfaWrFP6hcSNVdAW6
