### PR TITLE
feat(server): populate protocol-v2 errorKind + stackFrames on streamed test events

### DIFF
--- a/AlRunner.Tests/ServerProtocolTestEventTests.cs
+++ b/AlRunner.Tests/ServerProtocolTestEventTests.cs
@@ -1,0 +1,162 @@
+using System.Text.Json;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// #1641 (errorKind + stackFrames slice): the streaming <c>runTests</c>
+/// <c>test</c> event must carry the two structured-diagnostics fields
+/// <c>protocol-v2.schema.json</c> defines — <c>errorKind</c> (the
+/// <see cref="ErrorClassifier"/> bucket) and <c>stackFrames</c> (the
+/// <see cref="StackFrameMapper"/> parse of the captured AL call stack) — so the
+/// VS Code extension can vary its failure UI and offer clickable frames instead
+/// of re-parsing the free-form <c>stackTrace</c> string.
+///
+/// These drive <see cref="ServerProtocol.TestEvent"/> directly (no BC runtime
+/// needed), so they run everywhere and pin the exact wire shape.
+/// </summary>
+public class ServerProtocolTestEventTests
+{
+    private const string SampleStack =
+        "\"Sales-Post\"(CodeUnit 80).OnRun(Trigger) line 42 - Base Application by Microsoft version 26.0\n"
+        + "\"My Test CU\"(CodeUnit 60200).PostIt line 7";
+
+    private static JsonElement Event(TestResult t)
+        => JsonSerializer.Deserialize<JsonElement>(ServerProtocol.TestEvent(t));
+
+    private static TestResult Failing(Exception ex, string? alStack = SampleStack)
+        => new("Codeunit60200", "PostIt", TestOutcome.Fail,
+               $"{ex.GetType().Name}: {ex.Message}", ex.ToString(),
+               TimeSpan.FromMilliseconds(5), alStack, "My Test CU", ex);
+
+    // ── errorKind ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void PassingTest_HasNoErrorKindAndNoStackFrames()
+    {
+        var t = new TestResult("Codeunit60200", "Ok", TestOutcome.Pass,
+            null, null, TimeSpan.FromMilliseconds(3), null, "My Test CU");
+
+        var e = Event(t);
+        Assert.Equal("pass", e.GetProperty("status").GetString());
+        // A pass has no error to classify: emitting errorKind:"unknown" here would
+        // read as "we failed and don't know why". The field must be absent.
+        Assert.False(e.TryGetProperty("errorKind", out _));
+        Assert.False(e.TryGetProperty("stackFrames", out _));
+    }
+
+    [Fact]
+    public void FailureInsideTestProc_IsRuntime()
+    {
+        var e = Event(Failing(new InvalidOperationException("boom")));
+        Assert.Equal("runtime", e.GetProperty("errorKind").GetString());
+    }
+
+    [Fact]
+    public void CtorFailure_IsSetup()
+    {
+        // The `<ctor>` result TestExecutor produces when InstantiateCodeunit throws:
+        // nothing inside a [Test] proc ever ran, so this is a setup failure, not a
+        // test-runtime one.
+        var ex = new InvalidOperationException("cannot instantiate");
+        var t = new TestResult("Codeunit60200", "<ctor>", TestOutcome.Error,
+            ex.Message, ex.ToString(), TimeSpan.Zero, null, null, ex,
+            InsideTestProc: false);
+
+        Assert.Equal("setup", Event(t).GetProperty("errorKind").GetString());
+    }
+
+    [Fact]
+    public void TimedOutTest_IsTimeout()
+    {
+        // The timeout path carries no caught exception (the runaway thread is
+        // abandoned, nothing was thrown back), so the TimedOut flag — not the
+        // exception type — is what makes this classifiable.
+        var t = new TestResult("Codeunit60200", "Hangs", TestOutcome.Error,
+            "Test exceeded 60s timeout.", null, TimeSpan.FromSeconds(60),
+            SampleStack, "My Test CU", null, TimedOut: true);
+
+        Assert.Equal("timeout", Event(t).GetProperty("errorKind").GetString());
+    }
+
+    [Fact]
+    public void ErrorWithoutException_IsUnknown()
+    {
+        // e.g. the "unsupported test signature" result — an error we produced
+        // ourselves with no exception behind it. `unknown` is the honest answer.
+        var t = new TestResult("Codeunit60200", "TakesArgs", TestOutcome.Error,
+            "unsupported test signature (1 params)", null, TimeSpan.Zero, null, "My Test CU");
+
+        Assert.Equal("unknown", Event(t).GetProperty("errorKind").GetString());
+    }
+
+    [Fact]
+    public void SkippedTest_HasNoErrorKind()
+    {
+        var t = new TestResult("Codeunit60200", "Skipped", TestOutcome.Skipped,
+            "skipped — declared in known-gaps.json", null, TimeSpan.Zero, null, "My Test CU",
+            null, Infrastructure.ExpectationResult.Skipped);
+
+        var e = Event(t);
+        Assert.Equal("skipped", e.GetProperty("status").GetString());
+        Assert.False(e.TryGetProperty("errorKind", out _));
+    }
+
+    // ── stackFrames ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public void StackFrames_AreStructuredDeepestFirst_MatchingTheSchema()
+    {
+        var frames = Event(Failing(new InvalidOperationException("boom")))
+            .GetProperty("stackFrames");
+
+        Assert.Equal(2, frames.GetArrayLength());
+
+        var deepest = frames[0];
+        Assert.Equal("\"Sales-Post\"(CodeUnit 80).OnRun(Trigger)", deepest.GetProperty("name").GetString());
+        Assert.Equal(42, deepest.GetProperty("line").GetInt32());
+        Assert.Equal("normal", deepest.GetProperty("presentationHint").GetString());
+        // File is unknown for a BC call-stack frame — the schema's `source` object
+        // must be omitted rather than filled with an invented path.
+        Assert.False(deepest.TryGetProperty("source", out _));
+        Assert.False(deepest.TryGetProperty("column", out _));
+
+        var caller = frames[1];
+        Assert.Equal("\"My Test CU\"(CodeUnit 60200).PostIt", caller.GetProperty("name").GetString());
+        Assert.Equal(7, caller.GetProperty("line").GetInt32());
+    }
+
+    [Fact]
+    public void StackFrames_OmittedWhenNoAlCallStackWasCaptured()
+    {
+        // A runner-internal failure has a C# stackTrace but no AL stack. Emitting
+        // an empty array would imply "AL stack captured, zero frames deep".
+        var e = Event(Failing(new InvalidOperationException("boom"), alStack: null));
+        Assert.False(e.TryGetProperty("stackFrames", out _));
+        Assert.Contains("boom", e.GetProperty("stackTrace").GetString());
+    }
+
+    [Fact]
+    public void StackFrames_KeepAnUnparsableLineVerbatimAsName()
+    {
+        var e = Event(Failing(new InvalidOperationException("boom"), alStack: "not a BC frame at all"));
+        var frames = e.GetProperty("stackFrames");
+        Assert.Equal(1, frames.GetArrayLength());
+        Assert.Equal("not a BC frame at all", frames[0].GetProperty("name").GetString());
+        Assert.False(frames[0].TryGetProperty("line", out _));
+    }
+
+    // ── the pre-existing fields must not have shifted ────────────────────────
+
+    [Fact]
+    public void ExistingTestEventFieldsAreUnchanged()
+    {
+        var e = Event(Failing(new InvalidOperationException("boom")));
+        Assert.Equal("test", e.GetProperty("type").GetString());
+        Assert.Equal("Codeunit60200.PostIt", e.GetProperty("name").GetString());
+        Assert.Equal("fail", e.GetProperty("status").GetString());
+        Assert.Equal(5, e.GetProperty("durationMs").GetInt64());
+        Assert.Contains("boom", e.GetProperty("message").GetString());
+        Assert.Equal(SampleStack, e.GetProperty("stackTrace").GetString());
+    }
+}

--- a/AlRunner.Tests/ServerStreamingTests.cs
+++ b/AlRunner.Tests/ServerStreamingTests.cs
@@ -91,10 +91,25 @@ public class ServerStreamingTests
         var pass = events.Single(e => e.GetProperty("name").GetString()!.EndsWith("PassingTest"));
         Assert.Equal("pass", pass.GetProperty("status").GetString());
         Assert.True(pass.GetProperty("durationMs").GetInt64() >= 0);
+        // A pass carries no diagnostics fields at all (#1641).
+        Assert.False(pass.TryGetProperty("errorKind", out _));
+        Assert.False(pass.TryGetProperty("stackFrames", out _));
 
         var fail = events.Single(e => e.GetProperty("name").GetString()!.EndsWith("FailingTest"));
         Assert.Equal("fail", fail.GetProperty("status").GetString());
         Assert.Contains("streaming-probe-boom", fail.GetProperty("message").GetString());
+
+        // #1641 errorKind + stackFrames, end-to-end through the real server rather
+        // than through ServerProtocol.TestEvent alone: an AL Error() inside a [Test]
+        // body classifies as `runtime`, and the captured AL call stack arrives as
+        // ONE structured frame naming the AL object and the in-procedure line.
+        Assert.Equal("runtime", fail.GetProperty("errorKind").GetString());
+        var frames = fail.GetProperty("stackFrames");
+        Assert.Equal(1, frames.GetArrayLength());
+        Assert.Equal("\"Server Streaming Probe SX\"(CodeUnit 60200).FailingTest",
+                     frames[0].GetProperty("name").GetString());
+        Assert.Equal(2, frames[0].GetProperty("line").GetInt32());
+        Assert.Equal("normal", frames[0].GetProperty("presentationHint").GetString());
 
         // Summary carries the protocol-v2 contract and matches the streamed events.
         Assert.Equal(2, summary.GetProperty("protocolVersion").GetInt32());

--- a/AlRunner/ErrorClassifier.cs
+++ b/AlRunner/ErrorClassifier.cs
@@ -66,4 +66,26 @@ public static class ErrorClassifier
 
         return AlErrorKind.Runtime;
     }
+
+    /// <summary>
+    /// Classify a completed <see cref="TestResult"/> for the protocol-v2
+    /// <c>errorKind</c> field (#1641). Returns <c>null</c> when there is no error
+    /// to classify — a pass or a skip. Emitting <c>unknown</c> in those cases would
+    /// read on the wire as "this failed and we don't know why", so the field is
+    /// omitted instead.
+    ///
+    /// This is the single place that knows how a v2 <see cref="TestResult"/> maps
+    /// onto a bucket, so the CLI and the server can never drift apart:
+    ///   <see cref="TestResult.TimedOut"/> is checked first because the timeout path
+    ///   carries no exception at all (see the TestResult remarks) — without the flag
+    ///   a hung test would come out as <see cref="AlErrorKind.Unknown"/>.
+    ///   An error we raised ourselves with no exception behind it (e.g. "unsupported
+    ///   test signature") also lands on Unknown, which is the honest answer.
+    /// </summary>
+    public static AlErrorKind? Classify(TestResult result)
+    {
+        if (result.Outcome is TestOutcome.Pass or TestOutcome.Skipped) return null;
+        if (result.TimedOut) return AlErrorKind.Timeout;
+        return Classify(result.Exception, new TestExecutionContext(result.InsideTestProc));
+    }
 }

--- a/AlRunner/ServerProtocol.cs
+++ b/AlRunner/ServerProtocol.cs
@@ -10,13 +10,14 @@ namespace AlRunner;
 /// One JSON object per line. stdin = requests, stdout = responses.
 ///   request : {command, sourcePaths[], packagePaths[], stubPaths[], code, captureValues, testIsolation}
 ///   runTests: STREAMING (protocol-v2.schema.json — see #1641) — zero or more
-///             {"type":"test", name, status, durationMs, message, stackTrace}
-///             lines, one per completed test as it finishes, followed by exactly
-///             one terminal {"type":"summary", exitCode, passed, failed, errors,
+///             {"type":"test", name, status, durationMs, message, errorKind,
+///             stackFrames, stackTrace} lines, one per completed test as it
+///             finishes, followed by exactly one terminal
+///             {"type":"summary", exitCode, passed, failed, errors,
 ///             total, cached, changedFiles|omitted, compilationErrors|omitted,
-///             protocolVersion:2} line. `errorKind`/`stackFrames` on the test
-///             event and `cancelled` on the summary are schema-defined but not
-///             yet populated — separate follow-up slices of #1641.
+///             protocolVersion:2} line. `cancelled` on the summary is
+///             schema-defined but not yet populated — it lands with the `cancel`
+///             command, a separate follow-up slice of #1641.
 ///   execute : {exitCode, tests:[{name,status,durationMs,message,stackTrace}],
 ///              messages|null, compilationErrors|null} — single response, not
 ///              streamed (matches v1: only runTests streams).
@@ -81,11 +82,18 @@ public static class ServerProtocol
     /// <summary>
     /// Serialize one protocol-v2 <c>test</c> NDJSON line for a single completed
     /// test (the streaming <c>runTests</c> shape — see #1641 / protocol-v2.schema.json's
-    /// <c>TestEvent</c>). <c>errorKind</c>/<c>stackFrames</c> are schema-defined
-    /// but not populated here — that wiring is a separate follow-up slice of #1641.
+    /// <c>TestEvent</c>), including the two structured-diagnostics fields:
+    /// <c>errorKind</c> (<see cref="ErrorClassifier"/>) and <c>stackFrames</c>
+    /// (<see cref="StackFrameMapper"/>'s parse of the captured AL call stack).
+    /// Both are OMITTED rather than emitted empty when there is nothing to say —
+    /// a pass has no error kind, and a failure with no captured AL stack has no
+    /// frames (an empty array would claim "AL stack captured, zero frames deep").
+    /// <c>capturedValues</c>/<c>alSourceFile</c>/<c>alSourceLine</c> stay
+    /// schema-only: they need the Cecil instrumentation pass tracked on #1640.
     /// </summary>
     public static string TestEvent(TestResult t)
     {
+        var frames = StackFrameMapper.Walk(t.AlCallStack);
         var payload = new
         {
             type = "test",
@@ -93,10 +101,26 @@ public static class ServerProtocol
             status = t.Outcome.ToString().ToLowerInvariant(),
             durationMs = (long)t.Duration.TotalMilliseconds,
             message = t.Message,
+            errorKind = ErrorClassifier.Classify(t)?.ToString().ToLowerInvariant(),
+            stackFrames = frames.Count > 0 ? frames.Select(ToWire) : null,
             stackTrace = (t.AlCallStack ?? t.FullException)?.TrimEnd(),
         };
         return JsonSerializer.Serialize(payload, Opts);
     }
+
+    // One AL stack frame on the wire, in protocol-v2.schema.json's `AlStackFrame`
+    // shape. `source` is only emitted when the frame actually carries a file —
+    // BC's service-tier call-stack format does not include one, so it is normally
+    // absent rather than invented (.claude/rules/loud-failures.md). Line/column are
+    // likewise null-omitted, so a frame BC gave no line for does not gain a fake 0.
+    private static object ToWire(AlStackFrame f) => new
+    {
+        name = f.Name,
+        source = f.File != null ? new { path = f.File, name = Path.GetFileName(f.File) } : null,
+        line = f.Line,
+        column = f.Column,
+        presentationHint = f.Hint.ToString().ToLowerInvariant(),
+    };
 
     /// <summary>
     /// Serialize the single terminal <c>summary</c> NDJSON line that ends a

--- a/AlRunner/TestExecutor.cs
+++ b/AlRunner/TestExecutor.cs
@@ -54,12 +54,24 @@ public static class TestIsolationParser
 // reason) that string messages cannot carry. Expectation is set only when the
 // manifest reclassified this result (pass-oos / pass-known-gap / pass-divergence /
 // skipped / manifest drift); null means a plain pass/fail untouched by the manifest.
+//
+// InsideTestProc / TimedOut exist so the failure can be BUCKETED without re-deriving
+// the bucket from Message text — see ErrorClassifier.Classify(TestResult) and the
+// protocol-v2 `errorKind` field (#1641):
+//   InsideTestProc = false marks a failure raised before any [Test] body ran
+//     (codeunit instantiation) → AlErrorKind.Setup rather than Runtime.
+//   TimedOut = true marks the per-test timeout path. That path deliberately carries
+//     NO Exception (the runaway thread is abandoned, nothing is thrown back), so the
+//     flag is the only truthful signal that it was a timeout; synthesising a fake
+//     exception into Exception would corrupt the expectations classifier's input.
 public sealed record TestResult(string Codeunit, string Method, TestOutcome Outcome,
                                 string? Message, string? FullException, TimeSpan Duration,
                                 string? AlCallStack = null,
                                 string? CodeunitDisplayName = null,
                                 Exception? Exception = null,
-                                Infrastructure.ExpectationResult? Expectation = null);
+                                Infrastructure.ExpectationResult? Expectation = null,
+                                bool InsideTestProc = true,
+                                bool TimedOut = false);
 
 public sealed class TestExecutor
 {
@@ -197,9 +209,12 @@ public sealed class TestExecutor
             try { instance = InstantiateCodeunit(t); }
             catch (Exception ex)
             {
+                // InsideTestProc: false — instantiation blew up, so no [Test] body
+                // ever ran. That is what makes this a `setup` errorKind on the wire
+                // rather than a test-runtime failure (see ErrorClassifier).
                 var ctorResult = new TestResult(t.Name, "<ctor>", TestOutcome.Error,
                     Unwrap(ex).Message, ex.ToString(), TimeSpan.Zero,
-                    Exception: Unwrap(ex));
+                    Exception: Unwrap(ex), InsideTestProc: false);
                 results.Add(ctorResult);
                 onTestComplete?.Invoke(ctorResult);
                 continue;
@@ -431,7 +446,8 @@ public sealed class TestExecutor
                 PerfTrace.Log($"TestExecutor.RunOne TIMEOUT {codeunit}.{m.Name} {sw.ElapsedMilliseconds}ms");
                 var alStack = AlRunner.Infrastructure.AlCallStackCapture.CaptureCurrent();
                 return new TestResult(codeunit, m.Name, TestOutcome.Error,
-                    $"Test exceeded {(int)timeout.TotalSeconds}s timeout.", null, sw.Elapsed, alStack, displayName);
+                    $"Test exceeded {(int)timeout.TotalSeconds}s timeout.", null, sw.Elapsed, alStack, displayName,
+                    TimedOut: true);
             }
             invokeResult.Exception?.Throw();
             // The body succeeded — now BC's own check that every handler the test DECLARED was
@@ -498,10 +514,11 @@ public sealed class TestExecutor
         return thread.Join(timeout) ? (true, exception) : (false, null);
     }
 
-    private static bool IsTimeout(TestResult result)
-        => result.Outcome == TestOutcome.Error
-           && result.Message != null
-           && result.Message.StartsWith("Test exceeded ", StringComparison.Ordinal);
+    // Reads the flag the timeout path sets rather than re-deriving the verdict from
+    // the message text: the message is a v1-compatibility STRING contract (see
+    // TestTimeoutFlagTests), not a classification channel, and the same fact now has
+    // to be answered for protocol-v2's `errorKind` too. One source of truth.
+    private static bool IsTimeout(TestResult result) => result.TimedOut;
 
     private static Exception Unwrap(Exception ex)
     {

--- a/docs/server-mode.md
+++ b/docs/server-mode.md
@@ -61,16 +61,33 @@ streams `test` lines across all of them before the one final `summary`.
 
 ```jsonc
 {"type":"test","name":"Codeunit60110.MyTest","status":"pass","durationMs":12}
-{"type":"test","name":"Codeunit60110.OtherTest","status":"fail","durationMs":3,"message":"...","stackTrace":"..."}
+{"type":"test","name":"Codeunit60110.OtherTest","status":"fail","durationMs":3,
+ "message":"NavNCLDialogException: boom","errorKind":"runtime",
+ "stackFrames":[{"name":"\"My Test CU\"(CodeUnit 60110).OtherTest","line":2,
+                 "presentationHint":"normal"}],
+ "stackTrace":"..."}
 {"type":"summary","exitCode":1,"passed":1,"failed":1,"errors":0,"total":2,
  "cached":false,"changedFiles":["XRecProbe.Table.al"],"compilationErrors":null,
  "protocolVersion":2}
 ```
 
-- `status` is `pass` | `fail` | `error`.
+- `status` is `pass` | `fail` | `error` | `skipped`.
 - `stackTrace` is the AL call stack for AL-originated errors, falling back to
   the raw C# exception for runner-internal failures (matching the normal-mode
   rule). `message`/`stackTrace` are omitted (not `null`) on a passing test.
+- `errorKind` buckets the failure so a client can vary its UI:
+  `runtime` · `setup` (thrown before any `[Test]` body ran — codeunit
+  instantiation) · `timeout` (the per-test `--test-timeout` guard fired) ·
+  `compile` · `assertion` · `unknown` (an error with no exception behind it).
+  Omitted entirely on a `pass`/`skipped` — there is no error to bucket.
+  Note: BC's `Assert` codeunits ultimately call AL `Error()`, which surfaces as
+  the same `NavNCLDialogException` as any other AL error, so assertion failures
+  currently report `runtime`; see the note in `AlRunner/ErrorClassifier.cs`.
+- `stackFrames` is `stackTrace` parsed into structured frames — same order
+  (deepest first), one object per frame, with `name`, and `line` when BC
+  supplied one. Omitted when no AL call stack was captured (a runner-internal
+  failure); never emitted as an empty array, and `source`/`column` are omitted
+  rather than invented, since BC's call-stack format carries no file path.
 - `exitCode`: `0` ok · `1` test fail · `2` exec · `3` compile (same ladder as
   normal mode).
 - `changedFiles` is only present on a cache miss (a hit means nothing changed);
@@ -80,24 +97,31 @@ streams `test` lines across all of them before the one final `summary`.
 - A bundle that fails to compile short-circuits straight to the `summary` line
   with `exitCode: 3` and `compilationErrors` set — no `test` lines for that
   bundle (there was nothing to run).
-- `errorKind` (per-test) and `cancelled` (on the summary) are defined by
-  `protocol-v2.schema.json` but not populated yet — separate follow-up slices
-  of #1641, along with the `cancel` command.
+- `cancelled` (on the summary) is defined by `protocol-v2.schema.json` but not
+  populated yet — it lands with the `cancel` command, a separate follow-up
+  slice of #1641. `capturedValues` and `coverage` need the Cecil instrumentation
+  pass tracked on #1640.
 
 A request-level problem (e.g. a missing `sourcePaths`) returns the usual single
 `{"error":"..."}` line instead of a `test`/`summary` sequence — see Errors below.
 
 ### `execute`
 
-Not yet implemented in v2. Returns a structured error rather than a silent
-fake (per `.claude/rules/loud-failures.md`):
+Runs each bundle's first `OnRun`-bearing codeunit (run-mode). Unlike `runTests`
+this is **not** streamed — one v1-shaped response line, no `type` discriminator:
 
 ```json
-{"error":"execute: inline AL execution / run-mode is not yet implemented in v2 — use 'runTests'. See docs/server-mode.md."}
+{"exitCode":0,"tests":[{"name":"Codeunit60110.OnRun","status":"pass","durationMs":7}]}
 ```
 
-v1's `execute` ran inline AL or the first codeunit's `OnRun`. v2 has no inline-AL
-execution / run-mode pipeline yet; this is tracked as a follow-up.
+v1's `execute` also accepted an inline `code` string and a `captureValues` flag.
+v2 has no inline-AL compile path and no value capture (the latter needs the
+Cecil instrumentation pass on #1640), so both fail loudly with a structured
+error rather than a silent fake, per `.claude/rules/loud-failures.md`:
+
+```json
+{"error":"execute: inline AL 'code' is not yet supported in v2 — pass 'sourcePaths' to run the bundle's OnRun codeunit. See docs/server-mode.md."}
+```
 
 ### `shutdown`
 

--- a/protocol-v2.schema.json
+++ b/protocol-v2.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/StefanMaron/BusinessCentral.AL.Runner/schemas/protocol-v2.json",
   "title": "AL.Runner Server Protocol v2",
-  "description": "Newline-delimited JSON. A `runtests` request emits zero or more `test` lines, optional `progress` lines, then exactly one `summary` line. Each line is a separate JSON document. NOTE (as ported for #1641): the v2 architecture's --server loop does not emit this shape yet — it still returns one v1-compatible response line per request (see AlRunner/ServerProtocol.cs). This file is the target contract for the streaming port; the NDJSON emitter that produces it is tracked as follow-up work on #1641.",
+  "description": "Newline-delimited JSON. A `runtests` request emits zero or more `test` lines, optional `progress` lines, then exactly one `summary` line. Each line is a separate JSON document. STATUS on v2 (#1641): --server streams this shape for `runTests`, and each `test` line carries `errorKind` and `stackFrames`. Still schema-only, in separate slices: `cancelled` and the `ack`/`progress` lines (they land with the `cancel` command), and `capturedValues`/`coverage`/`alSourceFile`/`alSourceLine`, which need the Cecil instrumentation pass tracked on #1640. Absent optional fields mean 'not known', never 'empty'.",
   "definitions": {
     "AlStackFrame": {
       "type": "object",


### PR DESCRIPTION
Partial slice of #1641 — **does not close it**. Third slice: slices 1 (#1681, building blocks + `testIsolation`) and 2 (#1684, NDJSON streaming) landed, but left `ErrorClassifier` and `StackFrameMapper` referenced by nothing outside their own unit tests. The streamed `test` event carried only a free-form `stackTrace` string, so a client had to re-parse BC's call-stack text itself and had no way to tell a setup failure from a timeout from an ordinary AL error.

This slice populates the two schema-defined fields that close that gap. Deliberately small and self-contained; `cancel`, `progress`/`ack` and inline-`code` `execute` are separate slices (see below).

## What changed

**`errorKind`** — a new `ErrorClassifier.Classify(TestResult)` overload becomes the single place mapping a v2 `TestResult` onto a bucket, so the CLI and the server cannot drift onto different answers. It returns `null` (field omitted on the wire) for `pass`/`skipped`: emitting `errorKind:"unknown"` on a passing test would read as *"this failed and we don't know why"*.

**`stackFrames`** — `StackFrameMapper`'s parse of the captured AL call stack, in the schema's `AlStackFrame` shape. Omitted rather than emitted empty when no AL stack was captured (an empty array would claim "AL stack captured, zero frames deep"), and `source`/`column` are omitted rather than invented, since BC's call-stack format carries no file path.

**Two new `TestResult` flags**, so the bucket is read from a real signal instead of sniffed out of message text:

- `InsideTestProc` — false on the `<ctor>` path, where instantiation blew up and no `[Test]` body ever ran → `setup`, not `runtime`.
- `TimedOut` — true on the per-test timeout path. That path deliberately carries **no** `Exception` (the runaway thread is abandoned; nothing is thrown back), so the flag is the only truthful signal. Synthesising a fake exception into `TestResult.Exception` would corrupt the expectations classifier's input, which reads that field. `TestExecutor.IsTimeout` now reads the flag instead of re-deriving the verdict from the v1-compatibility message string — one source of truth for a fact two consumers now need.

**Docs** — `protocol-v2.schema.json`'s note still said *"the v2 architecture's --server loop does not emit this shape yet"* (untrue since #1684), and `docs/server-mode.md` still said `execute` was *"not yet implemented"* while quoting an error string the code no longer produces. Both corrected to what the code actually does.

## Explicitly not in this slice

- `cancelled` on the summary, plus the `ack`/`progress` line types — they land with the `cancel` command, which needs a stdin reader thread (the loop is synchronous today, so a `cancel` arriving mid-run is not read until the run finishes). Own PR.
- `capturedValues`, `coverage`, `alSourceFile`/`alSourceLine` — blocked on the Cecil instrumentation pass in #1640, per the issue's own scoping.
- Inline-`code` `execute` — needs an inline-AL compile path that v2 does not have. Fails loudly today.

One known honest limitation, documented in `ErrorClassifier.cs` and now in `docs/server-mode.md`: BC's `Assert` codeunits ultimately call AL `Error()`, which surfaces as the same `NavNCLDialogException` as any other AL error, so assertion failures currently bucket as `runtime` rather than `assertion`. Distinguishing them needs AL-call-stack inspection for a known assert-helper frame.

## Tests — RED → GREEN

New `AlRunner.Tests/ServerProtocolTestEventTests.cs` (10 tests) drives `ServerProtocol.TestEvent` directly, so it needs no BC runtime and pins the exact wire shape. It asserts concrete values, not shapes: `errorKind` is `runtime`/`setup`/`timeout`/`unknown` per input, frame `name` is the exact `"Sales-Post"(CodeUnit 80).OnRun(Trigger)` string and `line` is `42`. Four of the ten assert *absence* (no `errorKind` on a pass, no empty `stackFrames`), which guards the other direction — over-emission.

**RED** (after adding only the inert record fields, so it compiles): `Failed: 6, Passed: 4, Total: 10`. The 4 passing were exactly the absence assertions, which held trivially before the wiring existed.

**GREEN** — actually observed, not predicted:

| Gate | Result |
|---|---|
| `ServerProtocolTestEventTests` + `ErrorClassifierTests` + `StackFrameMapperTests` | `Failed: 0, Passed: 30, Total: 30` |
| Full unit suite | `Failed: 0, Passed: 417, Total: 417` (9m22s) |
| `tests/runner-extras` (`--strict`) | 111/111 pass, 0 fail, 0 error |
| `scripts/tests/server-mode-test.sh` | all 3 assertions pass — including exitCode 3 + `EMIT-EXCLUDED` on the dep-schema-edit cache MISS |
| `tests/al-language` corpus (`--strict`) | reported in a comment below |

The `server-mode-test.sh` result matters specifically: the cache assertion still fails loudly with exit code 3 and `EMIT-EXCLUDED` rather than degrading into a stale-cache runtime failure.

`ServerStreamingTests` also gained end-to-end assertions on the real server output. Those skip without a BC artifact cache, so I verified the wire by hand against a live `--server` daemon first and wrote the assertions from the observed bytes:

```json
{"type":"test","name":"Codeunit60200.FailingTest","status":"fail","durationMs":35,
 "message":"NavNCLDialogException: streaming-probe-boom","errorKind":"runtime",
 "stackFrames":[{"name":"\"Server Streaming Probe SX\"(CodeUnit 60200).FailingTest",
                 "line":2,"presentationHint":"normal"}],
 "stackTrace":"..."}
{"type":"test","name":"Codeunit60200.PassingTest","status":"pass","durationMs":2}
```

Note the passing test carries neither field, and the summary line is byte-identical to before this change.

Refs #1641