### PR TITLE
fix(events): honor EventSubscriberInstance = Manual for table-event subscribers

### DIFF
--- a/AlRunner/Patches/CodeunitEventDispatcher.cs
+++ b/AlRunner/Patches/CodeunitEventDispatcher.cs
@@ -137,8 +137,14 @@ public static partial class BcRuntime
     /// Read off [NavCodeunitOptionsAttribute] exactly like
     /// <see cref="NCLMetaCodeunit_get_IsEventManualBinding"/> (which serves BC's own
     /// BindSubscription path) so both sides agree on what "manual" is.
+    ///
+    /// The single definition of "Manual" in the runner: the codeunit-event dispatcher below
+    /// consults it directly, and the table-event path reports it out of
+    /// <c>EventSubscriberPatches.AlEventSubscriberAdapter.IsEventManualBinding</c> so BC's own
+    /// NavEventScope dispatch classifies the subscription the same way. Two answers here would
+    /// let the two paths drift on what Manual means.
     /// </summary>
-    private static bool IsManualBindingCodeunitType(Type codeunitClrType)
+    internal static bool IsManualBindingCodeunitType(Type codeunitClrType)
         => _manualBindingTypeCache.GetOrAdd(codeunitClrType, static t =>
         {
             foreach (var attr in t.GetCustomAttributes(inherit: false))

--- a/AlRunner/Patches/EventSubscriberPatches.cs
+++ b/AlRunner/Patches/EventSubscriberPatches.cs
@@ -906,9 +906,8 @@ public static class EventSubscriberPatches
     }
 
     /// <summary>
-    /// Adapter implementing <see cref="INavEventSubscriber"/>. The publisher dispatch path only
-    /// reads ApplicationObjectId.ObjectNumber + IsEventManualBinding off the subscriber object
-    /// (other members are consumed by manual-binding / sender-validation paths we don't take).
+    /// Adapter implementing <see cref="INavEventSubscriber"/>. The publisher dispatch path
+    /// reads ApplicationObjectId.ObjectNumber + IsEventManualBinding off the subscriber object.
     /// </summary>
     internal sealed class AlEventSubscriberAdapter : INavEventSubscriber
     {
@@ -918,11 +917,21 @@ public static class EventSubscriberPatches
             ApplicationObjectClrType = clrType;
             ApplicationObjectId = new ApplicationObjectId(ObjectType.CodeUnit, codeunitId);
             _wrapper = new NavEventSubscriberReflectionWrapper(clrType);
+            // NavEventSubscription's ctor freezes this into its status flags
+            // (NavEventSubscriptionStatus.ManualBinding), which is what makes BC's own
+            // NavEventScope.ProcessCallToTypeAndManualSubscriptionsAsync take the manual
+            // branch: dispatch once per Session.EventBindings entry matching this codeunit,
+            // on that bound instance, and not at all when nothing is bound. Hard-coding
+            // false here meant BC could never engage that branch, so Manual table-event
+            // subscribers fired unbound and the bound instance never received (issue #1749).
+            // Same classifier the codeunit-event dispatcher uses, so both paths agree on
+            // what "Manual" means.
+            IsEventManualBinding = BcRuntime.IsManualBindingCodeunitType(clrType);
         }
         public bool OriginatesFromBase => false;
         public NavEventSubscriberReflectionWrapper SubscriberReflectionWrapper => _wrapper;
         public Type ApplicationObjectClrType { get; }
         public ApplicationObjectId ApplicationObjectId { get; }
-        public bool IsEventManualBinding => false;
+        public bool IsEventManualBinding { get; }
     }
 }


### PR DESCRIPTION
Closes #1749

## Root cause

`AlEventSubscriberAdapter` — the `INavEventSubscriber` the runner hands to BC's `NavEventSubscription` ctor when injecting a table-event subscriber into the table's `NavEventScope` — hard-coded `IsEventManualBinding => false`.

That ctor freezes the flag into `NavEventSubscriptionStatus.ManualBinding`:

```csharp
if (this.subscriber.IsEventManualBinding)
    status = NavEventSubscriptionStatus.ManualBinding;
```

and `NavEventScope.ProcessCallToTypeAndManualSubscriptionsAsync` branches on it. With the flag stuck at `false` BC could never take its manual branch, so every Manual table-event subscriber went down the *static* branch instead — resolved through `new NavCodeunitHandle(scope, subscriberId).Target` and invoked. Both halves of the reported defect follow from that one line: it fired with nothing bound, and it fired on a throwaway instance, so the instance the test had bound never received anything.

## The fix

The adapter reports the truth, read through `BcRuntime.IsManualBindingCodeunitType` — the classifier #1750 introduced for the codeunit-event path, widened `private` → `internal`. It reads `IsEventManualBinding` off `NavCodeunitOptionsAttribute`, the same property BC's own `BindSubscription` path consults via `NCLMetaCodeunit_get_IsEventManualBinding`. **One definition of "Manual" for both dispatch paths**, so they cannot drift.

**"Which instances are bound?" is not answered a second time here either.** Once the subscription carries the right flag, BC's own body does that walk:

```csharp
foreach (NavCodeunit item in callerApplicationObject.Session.EventBindings.ToList())
{
    if (subscriberCodeunitId != item.ObjectId.ObjectNumber) continue;
    if (item.GetType() != subscription.SubscriberMethodInfo.DeclaringType) { /* stale-subscriber trace */ }
    else await CallEventSubscriberAsync(callerApplicationObject, subscription, item, parameters);
}
```

`Session.EventBindings` is the same list `CodeunitEventDispatcher.BoundInstancesOf` reads and the same list `NavCodeunit.BindSubscription`/`UnbindSubscription` maintain. Delivery, per-instance targeting, staleness detection and unbind semantics all stay BC's code — the runner just stops lying about the flag. Net diff is two files, +19/−6.

## Test placement

Per `bc-behavior-tests-go-upstream.md` the proving tests are BC behaviour and went upstream first: corpus PR StefanMaron/BusinessCentral.AL.Language.Tests#26, merged as `3c5a8b5`, verified on real **BC 27.5** and **BC 28.3**. It adds codeunit **60241 `Test Table Event Manual Bind`** and fixture **`ALT Manual Table Event Sub` (60034)**, mirroring 60240's seven contracts onto `ALT Universal`'s `OnAfterInsertEvent`.

`tests/al-language` is bumped **386e14b → 3c5a8b5**; the pin diff is exactly those two files and nothing else.

Two contracts are worth calling out because they constrain the shape of the fix:

- **Contract 1** (unbound never fires) is falsifiable only because the fixture also writes an `ALT Trigger Log` row — with nothing bound there is no instance to interrogate, so instance state alone could not tell "did not fire" from "fired somewhere else". Under this fix no row appears.
- **Contract 3** (unbind freezes state) asserts `LastEntryNo` stays at the pre-unbind value, not merely that the count stopped. A fix that stopped counting but left a stale reference receiving updates would still fail it.

## Verification (observed, at the new pin)

| Run | RED (fix reverted) | GREEN |
|---|---|---|
| `Codeunit60241` | **3 pass / 4 fail / 0 error** | **7 pass / 0 fail / 0 error** |
| corpus `--strict` | — | **1983 / 1983** (2 oos, 3 known-gap, 1 divergence) |
| `tests/runner-extras --strict` | — | **111 / 111** |
| `dotnet test AlRunner.Tests` | — | **407 / 407** |

The four RED failures were exactly the dispatch contracts — `ManualTableSub_NotBound_DoesNotFire` (log count 1, expected 0), `ManualTableSub_Bound_FiresOnBoundInstance` (fire count 0, expected 1), `ManualTableSub_Unbind_StopsFiring`, `ManualTableSub_TwoBoundInstances_EachFiresOnce`. The three bind/unbind return-semantics contracts passed before and after, as expected — those are BC's `NavCodeunit` bodies, which #1750 already left alone.

No expectations-manifest entry is needed in either direction: nothing was declared for these tests, and none of them raise an out-of-scope signal.

---
_Generated by [Claude Code](https://claude.ai/code/session_01G3KPXYQnfoL1ogXLXo823n)_