### PR TITLE
fix(record): an uncommitted BLOB write no longer reaches a database-backed row

### DIFF
--- a/AlRunner/Infrastructure/NclCecilRewrite.cs
+++ b/AlRunner/Infrastructure/NclCecilRewrite.cs
@@ -6192,6 +6192,35 @@ public static class NclCecilRewrite
                 ByParams(Rt + "TempTableDataProvider", "CalcNumeric", "CalcNumericProviderRequest"),
                 H(recordPatches, "TempTableDataProvider_CalcNumeric"));
 
+            // ── BLOB store isolation for database-backed tables (issue #1751) ──────
+            // Ncl's TempTableDataProvider.Insert copies the record's NavBLOB into the
+            // stored row BY REFERENCE and only CloneBlobs()es the dirty ones, so a BLOB
+            // that carried no value at Insert stays shared with the record variable —
+            // and a later `CreateOutStream`+write with no Modify() mutates the stored
+            // row. Real BC does exactly this for a `temporary` record and the opposite
+            // for a database-backed one (corpus 60940, green on BC 27.5 and 28.3), so
+            // the runner cannot simply always copy: every runner table is backed by
+            // this same provider.
+            //
+            // Two prepends. The first latches which kind of provider this insert is
+            // for; the second detaches the stored row's BLOBs when it is the SQL
+            // stand-in. Both leave the original bodies intact, so the dirty-BLOB clone
+            // Ncl already performs is unchanged. See Patches/BlobStoreIsolationPatches.cs.
+            {
+                var blobIsolation = typeof(AlRunner.Patches.BlobStoreIsolationPatches);
+
+                PrependStaticCall(nclMod,
+                    ByParams(Rt + "TempTableDataProvider", "Insert",
+                        "Int32", "MutableRecordBuffer", "InsertOptions", "ReadOnlyRecordBuffer&"),
+                    H(blobIsolation, "OnBeforeStoreInsert"),
+                    argSlots: 1); // `this` — the provider
+
+                PrependStaticCall(nclMod,
+                    ByParams(Rt + "TempTableRecordBuffer", "CloneBlobs", "MutableRecordBuffer"),
+                    H(blobIsolation, "DetachStoredBlobs"),
+                    argSlots: 1); // `this` — the freshly stored row
+            }
+
             // ── TempTableDataProvider.Find / FindFromPosition (query column projection) ──
             // Single-dataitem query reads route through GetDataAccessForQuery → the same
             // in-memory TempTableDataProvider that holds the inserted rows. The provider is
@@ -7009,6 +7038,46 @@ public static class NclCecilRewrite
             ?? throw new InvalidOperationException(
                 $"[Cecil] BcRuntime.{bcRuntimeHelperName} not found");
         ReplaceBodyWithHelper(module, target, helperMi);
+    }
+
+    /// <summary>
+    /// Emit `ldarg.0..argSlots-1; call helper;` BEFORE <paramref name="target"/>'s existing
+    /// first instruction, leaving the original body — and every branch target in it —
+    /// untouched. Use when the patch is an observer/side-effect that must run first and
+    /// BC's own behaviour must still happen (as opposed to ReplaceBodyWithHelper, which
+    /// discards the body entirely).
+    ///
+    /// The helper must return void and take exactly <paramref name="argSlots"/> reference-typed
+    /// parameters, taken from the front of the IL arg list (slot 0 is `this` on an instance
+    /// method). No boxing is emitted, so only reference-typed slots may be forwarded.
+    /// </summary>
+    private static void PrependStaticCall(
+        ModuleDefinition module, MethodDefinition target, MethodInfo helperMi, int argSlots)
+    {
+        if (helperMi.ReturnType != typeof(void))
+            throw new InvalidOperationException(
+                $"[Cecil] prepend helper {helperMi.DeclaringType?.Name}.{helperMi.Name} must return void");
+        if (helperMi.GetParameters().Length != argSlots)
+            throw new InvalidOperationException(
+                $"[Cecil] prepend helper {helperMi.DeclaringType?.Name}.{helperMi.Name} takes "
+                + $"{helperMi.GetParameters().Length} parameter(s) but {argSlots} arg slot(s) were requested");
+        int available = target.Parameters.Count + (target.HasThis ? 1 : 0);
+        if (argSlots > available)
+            throw new InvalidOperationException(
+                $"[Cecil] {target.DeclaringType.Name}.{target.Name} has only {available} arg slot(s), "
+                + $"{argSlots} requested — Ncl shape changed; do not commit");
+
+        var helperRef = module.ImportReference(helperMi);
+        var body = target.Body;
+        var il = body.GetILProcessor();
+        var first = body.Instructions[0];
+        for (int i = 0; i < argSlots; i++)
+            il.InsertBefore(first, il.Create(OpCodes.Ldarg, i));
+        il.InsertBefore(first, il.Create(OpCodes.Call, helperRef));
+        if (body.MaxStackSize < argSlots) body.MaxStackSize = argSlots;
+        Console.Error.WriteLine(
+            $"[Cecil] Prepended {helperMi.DeclaringType?.Name}.{helperMi.Name} to "
+            + $"{target.DeclaringType.Name}.{target.Name}");
     }
 
     /// <summary>

--- a/AlRunner/Patches/BlobStoreIsolationPatches.cs
+++ b/AlRunner/Patches/BlobStoreIsolationPatches.cs
@@ -1,0 +1,147 @@
+// BlobStoreIsolationPatches — keeps a database-backed row's BLOB out of the
+// record variable that inserted it, without disturbing the temporary-table shape.
+//
+// ── The divergence this exists for (issue #1751) ─────────────────────────────
+//
+// Both halves below are measured against a real service tier by corpus codeunit
+// 60940 "Test Blob Uncomm Isolation", green on BC 27.5 and 28.3:
+//
+//   * Database-backed record — a BLOB written through CreateOutStream with NO
+//     following Modify() is invisible to the stored row. A second Record instance
+//     that Get()s the row reads it empty, and a re-Get() on the writing instance
+//     discards the write.
+//
+//   * `temporary` record — the very same write IS visible through the store.
+//     Get() reads the unpersisted bytes straight back, and so does a second
+//     variable sharing the buffer via Copy(..., true).
+//
+// The corpus file was originally written asserting isolation for BOTH shapes;
+// real BC rejected exactly the two temporary assertions and passed every control.
+// So this is not a BC bug we may normalise away — it is two different contracts,
+// and a blanket copy at the store boundary would fix one by breaking the other.
+//
+// ── Why the runner leaks the database case ───────────────────────────────────
+//
+// Every table in the runner is backed by Ncl's TempTableDataProvider (see
+// RecordPatches.NavDataAccessSource_GetDataAccessForTable). That provider is the
+// same code real BC runs for `temporary` records, so the runner inherits the
+// temporary contract for database-backed tables too. Concretely, in Ncl:
+//
+//   TempTableDataProvider.Insert
+//     items = recordBuffer.ToArray()                  // BLOB copied BY REFERENCE
+//     new TempTableRecordBuffer(metaTable, items)
+//     value.CloneBlobs(recordBuffer)                  // clones ONLY dirty BLOBs
+//   DataAccess.InsertAsync
+//     CreateNewBufferFromOutputBufferTransferBlobValuesFromOldRecord
+//       newBuffer[i] = oldRecord.GetChangedFieldValue(i)   // SAME object again
+//
+// A BLOB that carried no value at Insert is not dirty, so CloneBlobs skips it and
+// the stored row keeps the record's own NavBLOB — which the record then goes on
+// using. `Content.CreateOutStream(o); o.WriteText(...)` mutates that one object
+// and the stored row changes with it. On real BC this only ever happens for
+// temporary records, because a database-backed row lives in SQL and there is no
+// shared object to mutate.
+//
+// ── The fix ──────────────────────────────────────────────────────────────────
+//
+// Give the store its own NavBLOB at Insert, but ONLY for the providers that stand
+// in for SQL. Two Cecil prepends (see NclCecilRewrite):
+//
+//   1. TempTableDataProvider.Insert  → OnBeforeStoreInsert(provider) records, for
+//      the duration of this insert, whether the provider is database-backed.
+//   2. TempTableRecordBuffer.CloneBlobs → DetachStoredBlobs(stored) deep-copies
+//      every NavBLOB the stored row holds, so it shares none with the record.
+//
+// Prepends, not replacements: Ncl's own CloneBlobs body still runs afterwards and
+// re-clones the dirty BLOBs exactly as before, so the write-before-Insert shape is
+// untouched. For a temporary provider the flag is false, nothing is detached, and
+// the aliasing real BC exhibits is preserved verbatim.
+//
+// Modify() needs no equivalent: TempTableDataProvider.Modify already stores
+// `new NavBLOB(navBLOB.GetBytes(), useContentInstance: true)` — a distinct NavBLOB
+// — so a second uncommitted write after Modify() does not reach the row. Verified
+// by probe before this patch was written, and pinned by 60940's committed controls.
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using Microsoft.Dynamics.Nav.Runtime;
+using Microsoft.Dynamics.Nav.Types;
+
+namespace AlRunner.Patches;
+
+public static class BlobStoreIsolationPatches
+{
+    // Providers that stand in for SQL (i.e. were handed out for a NON-temporary
+    // table). Weak so a provider is collectable with its DataAccess; the value is
+    // an unused sentinel — membership is the whole signal.
+    private static readonly ConditionalWeakTable<object, object> _databaseBackedProviders = new();
+    private static readonly object _sentinel = new();
+
+    // Set by the TempTableDataProvider.Insert prepend and read by the CloneBlobs
+    // prepend. CloneBlobs is called from exactly one place — synchronously, from
+    // inside Insert — so the value cannot be observed by any other insert, and a
+    // thread-static keeps concurrent sessions from seeing each other's flag.
+    [ThreadStatic] private static bool _currentInsertIsDatabaseBacked;
+
+    private static MethodInfo? _mNavBlobDeepCopy;
+
+    /// <summary>
+    /// Records that <paramref name="dataAccess"/> serves a non-temporary table, so
+    /// rows inserted through it must not share BLOB objects with the record that
+    /// inserted them. Called from RecordPatches.NavDataAccessSource_GetDataAccessForTable
+    /// on every non-temporary hand-out (the same DataAccess may be handed out many
+    /// times — registration is idempotent).
+    /// </summary>
+    public static void MarkDatabaseBacked(object? dataAccess)
+    {
+        if (dataAccess == null) return;
+        var provider = dataAccess.GetType()
+            .GetProperty("DataProvider", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
+            ?.GetValue(dataAccess);
+        if (provider == null) return;
+        // AddOrUpdate rather than Add: GetDataAccessForTable is called per Record
+        // construction and returns the same cached DataAccess every time.
+        _databaseBackedProviders.AddOrUpdate(provider, _sentinel);
+    }
+
+    /// <summary>
+    /// Cecil prepend on TempTableDataProvider.Insert. Latches whether the row about
+    /// to be stored belongs to a database-backed table.
+    /// </summary>
+    public static void OnBeforeStoreInsert(object? provider)
+    {
+        _currentInsertIsDatabaseBacked =
+            provider != null && _databaseBackedProviders.TryGetValue(provider, out _);
+    }
+
+    /// <summary>
+    /// Cecil prepend on TempTableRecordBuffer.CloneBlobs. For a database-backed
+    /// table, replaces every NavBLOB in the freshly stored row with a deep copy, so
+    /// the row shares no BLOB object with the record variable that inserted it.
+    ///
+    /// Observable equivalence: the copy holds exactly the bytes the record's BLOB
+    /// held at Insert, so every read of the stored row answers as before. What
+    /// changes is only what real BC also refuses to do — later in-memory writes on
+    /// the inserting record no longer reach the row without Modify(). Corpus 60940
+    /// pins both directions.
+    ///
+    /// Scanning values rather than metadata (`stored[i] is NavBLOB`) is deliberate:
+    /// only BLOB fields ever hold a NavBLOB, and it avoids depending on the shape of
+    /// NCLMetaTable.BlobFields.
+    /// </summary>
+    public static void DetachStoredBlobs(TempTableRecordBuffer? stored)
+    {
+        if (!_currentInsertIsDatabaseBacked || stored == null) return;
+
+        for (var i = 0; i < stored.FieldCount; i++)
+        {
+            if (stored[i] is not NavBLOB blob) continue;
+
+            _mNavBlobDeepCopy ??= blob.GetType().GetMethod("DeepCopy",
+                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
+                binder: null, types: Type.EmptyTypes, modifiers: null)
+                ?? throw new MissingMethodException(blob.GetType().FullName, "DeepCopy()");
+
+            stored[i] = (NavValue)_mNavBlobDeepCopy.Invoke(blob, null)!;
+        }
+    }
+}

--- a/AlRunner/Patches/BlobStoreIsolationPatches.cs
+++ b/AlRunner/Patches/BlobStoreIsolationPatches.cs
@@ -57,10 +57,12 @@
 // untouched. For a temporary provider the flag is false, nothing is detached, and
 // the aliasing real BC exhibits is preserved verbatim.
 //
-// Modify() needs no equivalent: TempTableDataProvider.Modify already stores
-// `new NavBLOB(navBLOB.GetBytes(), useContentInstance: true)` — a distinct NavBLOB
-// — so a second uncommitted write after Modify() does not reach the row. Verified
-// by probe before this patch was written, and pinned by 60940's committed controls.
+// Modify() needs no equivalent. TempTableDataProvider.Modify itself constructs no
+// NavBLOB; the construction is in TempTableDataProvider.ModifyAllTrees, which Modify
+// calls and is its only caller — and it stores
+// `new NavBLOB(navBLOB.GetBytes(), useContentInstance: true)`, a distinct NavBLOB.
+// So a second uncommitted write after Modify() does not reach the row. Verified by
+// probe before this patch was written, and pinned by 60940's committed controls.
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using Microsoft.Dynamics.Nav.Runtime;
@@ -77,9 +79,16 @@ public static class BlobStoreIsolationPatches
     private static readonly object _sentinel = new();
 
     // Set by the TempTableDataProvider.Insert prepend and read by the CloneBlobs
-    // prepend. CloneBlobs is called from exactly one place — synchronously, from
-    // inside Insert — so the value cannot be observed by any other insert, and a
-    // thread-static keeps concurrent sessions from seeing each other's flag.
+    // prepend, so it is never reset — which is safe only because CloneBlobs has
+    // exactly ONE call site in the whole of Ncl: TempTableDataProvider.Insert, called
+    // synchronously. Nothing else can observe a stale value, and every insert sets it
+    // afresh. That is measured, not assumed — the call sites were counted by scanning
+    // Microsoft.Dynamics.Nav.Ncl.dll (28.1) with Cecil, not read off a decompile.
+    //
+    // The whole patch's correctness rests on that count, so re-check it if a future BC
+    // version changes shape: a second CloneBlobs caller outside Insert would read a
+    // flag left over from an unrelated insert. Thread-static rather than static so
+    // concurrent sessions cannot see each other's latch either.
     [ThreadStatic] private static bool _currentInsertIsDatabaseBacked;
 
     private static MethodInfo? _mNavBlobDeepCopy;

--- a/AlRunner/Patches/FlowFieldPatches.cs
+++ b/AlRunner/Patches/FlowFieldPatches.cs
@@ -776,11 +776,13 @@ public static class FlowFieldPatches
             // Skipping keeps CalcFields observably equivalent to real BC for this shape,
             // and leaves every non-aliased load (Get() → CalcFields()) on the copy path.
             //
-            // The aliasing itself is a separate divergence — it also makes an uncommitted
-            // BLOB write visible to a second Record instance that Get()s the same row,
-            // which real BC would not do. Tracked in #1751; deliberately NOT fixed here,
-            // because deep-copying at the store boundary is a much wider behavioural
-            // change that needs its own service-tier-adjudicated corpus test first.
+            // Since #1751 the aliasing only ever happens for a `temporary` record, which
+            // is exactly the shape real BC aliases too: corpus 60940 pins that a temporary
+            // row DOES observe an uncommitted BLOB write while a database-backed row does
+            // not. BlobStoreIsolationPatches detaches the stored BLOB at Insert for
+            // database-backed providers only, so this guard is now the temporary path's
+            // guard — and it stays correct for exactly the reason above: when both sides
+            // are the same object the buffer already holds the bytes a copy would produce.
             if (ReferenceEquals(storedBLOB, navBLOB)) return;
 
             navBLOB.AssignFromStream(storedBLOB.GetStream());

--- a/AlRunner/Patches/RecordPatches.cs
+++ b/AlRunner/Patches/RecordPatches.cs
@@ -1133,6 +1133,21 @@ public static partial class RecordPatches
 
     public static object NavDataAccessSource_GetDataAccessForTable(object self, NCLMetaTable table, bool isTemporary)
     {
+        var dataAccess = GetDataAccessForTableCore(self, table, isTemporary);
+
+        // Both branches below land on a TempTableDataProvider, so the provider alone
+        // cannot say whether it is standing in for SQL or genuinely serving a
+        // `temporary` record — and the two shapes disagree about whether an
+        // uncommitted BLOB write reaches the stored row (corpus 60940, issue #1751).
+        // This is the one place that still knows, so record it here.
+        if (!isTemporary)
+            BlobStoreIsolationPatches.MarkDatabaseBacked(dataAccess);
+
+        return dataAccess;
+    }
+
+    private static object GetDataAccessForTableCore(object self, NCLMetaTable table, bool isTemporary)
+    {
         try
         {
             if (isTemporary)


### PR DESCRIPTION
Closes #1751. Also bumps the `tests/al-language` pin to `68dfbe4` (corpus PR [#27](https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/27), codeunit 60940), which carries the proving test.

## The corpus decided the shape of this fix, and it is not the obvious one

The corpus test went upstream first and it originally asserted isolation for **both** a database-backed and a `temporary` record. Real BC 27.5 and 28.3 rejected **exactly** the two temporary assertions and passed all five others, including every control. The two shapes genuinely disagree:

| | uncommitted BLOB write visible to the stored row? |
|---|---|
| database-backed record | **No** |
| `temporary` record | **Yes** — the temp store holds the record's own `NavBLOB` |

So a blanket deep-copy at the store boundary is provably wrong: it would close this issue and break `TempBlob_UncommittedWrite_SameInstanceReGet_KeepsWrite` in the same commit. The copy has to be conditional on the record being database-backed, and the temporary path has to keep sharing the object.

## Cause

Ncl, unmodified:

```
TempTableDataProvider.Insert
  items = recordBuffer.ToArray()               // BLOB copied BY REFERENCE
  new TempTableRecordBuffer(metaTable, items)
  value.CloneBlobs(recordBuffer)               // clones only the DIRTY BLOBs
DataAccess.InsertAsync
  CreateNewBufferFromOutputBufferTransferBlobValuesFromOldRecord
    newBuffer[i] = oldRecord.GetChangedFieldValue(i)   // hands the SAME object back
```

A BLOB that carried no value at `Insert` is not dirty, so `CloneBlobs` skips it, the stored row keeps the record's own `NavBLOB`, and the record goes on using it. `Content.CreateOutStream(o); o.WriteText(...)` then mutates one object that both sides observe.

On real BC only `temporary` records reach this code — a database-backed row lives in SQL, and there is no shared object to mutate. The runner inherits the temporary contract for *every* table because every table is `TempTableDataProvider`-backed (`RecordPatches.NavDataAccessSource_GetDataAccessForTable`).

That also explains why `ReferenceEquals(storedBLOB, navBLOB)` in `FlowFieldPatches` — the #1724 guard from #1753 — was ever true. It is now the temporary path's guard, and its comment says so.

## Fix

Conditional by construction, in `AlRunner/Patches/BlobStoreIsolationPatches.cs` plus two Cecil prepends:

1. `GetDataAccessForTable` is the last place that still knows temp from non-temp, so it registers the providers handed out for a **non-temporary** table (weak-keyed, so nothing is kept alive).
2. Prepend on `TempTableDataProvider.Insert` — latches whether this insert is for one of those providers.
3. Prepend on `TempTableRecordBuffer.CloneBlobs` — when it is, deep-copies every `NavBLOB` in the freshly stored row so it shares none with the record.

Prepends rather than body replacements: Ncl's own dirty-BLOB clone still runs afterwards, so the write-before-`Insert` shape is untouched. For a temporary provider the flag is false, nothing is detached, and BC's aliasing is preserved verbatim.

`Modify` needs no counterpart — `TempTableDataProvider.Modify` already stores `new NavBLOB(bytes, useContentInstance: true)`, a distinct object. Confirmed by probe before writing the patch (a second uncommitted write after `Modify()` does not reach the row) and pinned by 60940's two committed-write controls.

`PrependStaticCall` is added next to `ReplaceBodyWithHelper` in `NclCecilRewrite` — it loud-fails if the helper is non-void, if its arity disagrees with the requested arg slots, or if the target has fewer slots than asked for.

## Numbers, all measured at the new pin

**Codeunit 60940 — 5 pass / 2 fail → 7 pass / 0 fail.** The two it turns green are exactly the database-backed isolation cases:

| Test | before | after |
|---|---|---|
| `Blob_UncommittedWrite_SecondInstanceGet_ReadsEmpty` | FAIL | PASS |
| `Blob_UncommittedWrite_SameInstanceReGet_DiscardsWrite` | FAIL | PASS |
| `Blob_CommittedWrite_SecondInstanceGet_ReadsWrittenBytes` | PASS | PASS |
| `Blob_UncommittedScalarWrite_SecondInstanceGet_ReadsEmpty` | PASS | PASS |
| `TempBlob_UncommittedWrite_SameInstanceReGet_KeepsWrite` | PASS | PASS |
| `TempBlob_UncommittedWrite_SharedBufferInstance_SeesWrite` | PASS | PASS |
| `TempBlob_CommittedWrite_SameInstanceReGet_ReadsWrittenBytes` | PASS | PASS |

Both temporary cases passing *before* the fix is the point: the runner was already faithful there, and the fix must not disturb it.

**Retention — codeunit 60915 (the #1724 / #1753 tests) 4/4 before, 4/4 after.** Retention and isolation pull in opposite directions on the same object, so this is the pair most likely to break; it does not, because a database-backed row's detached BLOB is empty at `Insert` and `LoadBlobField` already declines to load an empty stored blob.

**Suites:** full corpus **1990/1990** exit 0 · runner-extras **111/111** · AlRunner.Tests **407/407**.

---
_Generated by [Claude Code](https://claude.ai/code/session_01G3KPXYQnfoL1ogXLXo823n)_