### PR TITLE
fix(events): unwrap ByRef-wrapped publisher scope args for by-value subscriber parameters

### DIFF
--- a/AlRunner.Tests/DispatchCoerceArgByRefTests.cs
+++ b/AlRunner.Tests/DispatchCoerceArgByRefTests.cs
@@ -1,0 +1,84 @@
+using AlRunner;
+using Microsoft.Dynamics.Nav.Runtime;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// Pins <see cref="BcRuntime.CoerceArg"/> — the seam that adapts a publisher event-scope
+/// field value to the subscriber parameter's CLR type before MethodInfo.Invoke.
+///
+/// Issue #1816: a PRECOMPILED application DLL stores a publisher-scope event argument
+/// ByRef&lt;T&gt;-wrapped whenever the value slot was captured by reference inside the
+/// publishing method (Base App table 27 Item.CheckDocuments does this with
+/// <c>currentFieldNo</c> — it passes the slot to a <c>var</c> helper before raising
+/// OnAfterCheckDocuments). The subscriber's parameter is declared by value (Int32), and
+/// MethodInfo.Invoke refuses the ByRef`1[Int32] → Int32 bind with an ArgumentException,
+/// killing the whole dispatch before any subscriber runs. Bundle-compiled publishers never
+/// hit this because our emit stores the scope field by value — so the shape is only
+/// reachable through precompiled DLLs, which is why the defect is pinned here at the seam
+/// (the pattern DispatchEventPublisherDeclTypeTests.cs and DispatchObserveAsyncResultTests.cs
+/// established): the end-to-end proof needs a real Base App publisher and lives in the
+/// corpus (StefanMaron/BusinessCentral.AL.Language.Tests).
+///
+/// A ByRef&lt;T&gt; is a getter/setter pair over the captured slot, so the faithful
+/// by-value observation is the slot's CURRENT value at dispatch time — exactly what a
+/// real service tier hands the subscriber.
+/// </summary>
+public class DispatchCoerceArgByRefTests
+{
+    [Fact]
+    public void ByRefWrappedInt_ByValueIntParameter_UnwrapsValue()
+    {
+        int slot = 42;
+        var wrapped = new ByRef<int>(() => slot, v => slot = v);
+
+        var coerced = BcRuntime.CoerceArg(wrapped, typeof(int));
+
+        Assert.Equal(42, coerced);
+    }
+
+    [Fact]
+    public void ByRefWrappedInt_ByValueIntParameter_ReadsCurrentSlotValueNotCaptureTimeValue()
+    {
+        int slot = 1;
+        var wrapped = new ByRef<int>(() => slot, v => slot = v);
+        slot = 7; // publisher body mutated the slot after the scope captured it
+
+        var coerced = BcRuntime.CoerceArg(wrapped, typeof(int));
+
+        Assert.Equal(7, coerced);
+    }
+
+    [Fact]
+    public void ByRefWrappedString_ByValueStringParameter_UnwrapsValue()
+    {
+        string slot = "FIELD CAPTION";
+        var wrapped = new ByRef<string>(() => slot, v => slot = v);
+
+        var coerced = BcRuntime.CoerceArg(wrapped, typeof(string));
+
+        Assert.Equal("FIELD CAPTION", coerced);
+    }
+
+    [Fact]
+    public void ByRefWrappedInt_ByRefParameter_PassesSameInstanceThrough()
+    {
+        // Subscriber declares the parameter var → emitted as ByRef<int>. The wrapper must
+        // pass through IDENTICALLY so subscriber writes still reach the publisher's slot.
+        int slot = 42;
+        var wrapped = new ByRef<int>(() => slot, v => slot = v);
+
+        var coerced = BcRuntime.CoerceArg(wrapped, typeof(ByRef<int>));
+
+        Assert.Same(wrapped, coerced);
+    }
+
+    [Fact]
+    public void PlainInt_ByValueIntParameter_PassesThroughUnchanged()
+    {
+        var coerced = BcRuntime.CoerceArg(42, typeof(int));
+
+        Assert.Equal(42, coerced);
+    }
+}

--- a/AlRunner/Patches/CodeunitEventDispatcher.cs
+++ b/AlRunner/Patches/CodeunitEventDispatcher.cs
@@ -509,13 +509,33 @@ public static partial class BcRuntime
     /// be unwrapped to its ordinal here. The mirror case (subscriber declares the param as
     /// the NavOption carrier, field is an int) is handled too. This is faithful: a NavOption
     /// is exactly its integer ordinal as far as an AL Option/Integer parameter observes.
+    ///
+    /// A precompiled application DLL additionally stores a scope field
+    /// <c>ByRef&lt;T&gt;</c>-wrapped when the publishing method captured the value slot by
+    /// reference before raising the event (issue #1816: Base App
+    /// <c>Item.CheckDocuments</c>'s <c>currentFieldNo</c>), while the subscriber's
+    /// parameter is by value. The wrapper is a getter/setter pair over the slot, so the
+    /// faithful by-value observation is the slot's current value at dispatch time —
+    /// unwrap it and re-coerce (the inner value may itself be a NavOption). When the
+    /// subscriber's parameter IS the ByRef&lt;T&gt; (AL <c>var</c>), the assignability
+    /// early-return above already passed the wrapper through untouched, keeping writeback.
+    ///
     /// All other types pass through unchanged.
     /// </summary>
-    private static object? CoerceArg(object? value, Type paramType)
+    internal static object? CoerceArg(object? value, Type paramType)
     {
         if (value == null) return null;
         var vt = value.GetType();
         if (paramType.IsAssignableFrom(vt)) return value;
+
+        if (vt.IsGenericType
+            && vt.GetGenericTypeDefinition() == typeof(Microsoft.Dynamics.Nav.Runtime.ByRef<>))
+        {
+            object? inner = vt
+                .GetProperty("Value", BindingFlags.Public | BindingFlags.Instance)!
+                .GetValue(value);
+            return CoerceArg(inner, paramType);
+        }
 
         EnsureNavOptionReflection();
 


### PR DESCRIPTION
Closes #1816

## What

`CodeunitEventDispatcher.CoerceArg` now unwraps a `Microsoft.Dynamics.Nav.Runtime.ByRef<T>`-wrapped publisher scope field to the slot's current value before binding it to a by-value subscriber parameter, then re-coerces (the inner value may itself be a `NavOption`). A subscriber that declares the parameter `var` still receives the wrapper itself through the existing assignability early-return, so writeback semantics are untouched.

## Why

A precompiled application DLL stores a publisher event-scope arg ByRef-wrapped whenever the publishing method captured the value slot by reference before raising the event — Base App `Item.CheckDocuments` does this with `currentFieldNo`. The subscriber's parameter is by value, and `MethodInfo.Invoke` refuses the ``ByRef`1[Int32]`` → `Int32` bind with an `ArgumentException` that kills the whole dispatch before any subscriber runs, including Microsoft's own Base App subscribers (codeunit 9131 "Check Assembly Document"). Bundle-compiled publishers never hit this — our emit stores scope fields by value — so the shape is only reachable through precompiled DLLs.

Unwrapping to the slot's current value at dispatch time is faithful: the wrapper is a getter/setter pair over the captured slot, and that current value is exactly what a real service tier hands a by-value subscriber parameter.

## Test

`AlRunner.Tests/DispatchCoerceArgByRefTests.cs` pins the seam (the `DispatchEventPublisherDeclTypeTests` pattern): RED on main — 3 unwrap cases fail with the raw wrapper passed through — GREEN with the fix; plus 2 guards proving `ByRef`-param passthrough (writeback) and plain-value passthrough are unchanged.

End-to-end: the #1816 repro bundle goes 2/3 → 3/3 (`BaseAppIntEventArgReachesSubscriber` was the failing case). The full dispatch path through a precompiled Base App publisher can't be exercised from a plain unit test; an end-to-end corpus test for BusinessCentral.AL.Language.Tests is noted in #1816 as follow-up.

## Verification

- al-language corpus @ `dadffa2`: 2073 pass / 0 fail / 0 error
- `tests/runner-extras`: 0 fail / 0 error
- `AlRunner.Tests`: no new failures (the handful of local failures reproduce identically on clean `main` — pre-existing, environment-specific)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013KUrwwL3UyCQYAfWcnGxXw