### PR TITLE
chore(corpus): bump al-language pin dadffa2 -> 848831a

### DIFF
--- a/tests/expectations/known-gaps-record.json
+++ b/tests/expectations/known-gaps-record.json
@@ -1,0 +1,18 @@
+[
+  {
+    "codeunitId": 60994,
+    "CodeunitName": "Test TableExt Field Validate",
+    "Method": "TableExtField_Validate_TriggerlessBaseTable_RunsOnValidate",
+    "Mode": "expect-fail-known-gap",
+    "Issue": "https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/1835",
+    "Note": "Arrived with corpus pin 848831a (upstream PR #46). Rec.Validate on a field ADDED by a tableextension does not run that field's OnValidate — the trigger log stays empty (Expected:<1> Actual:<0>). A tableextension-added field's OnValidate is a first-class field trigger, distinct from the modify() OnBefore/OnAfterValidate wrappers around a BASE field's trigger, which do work. PR #1853 is the fix; remove this entry in that PR so the manifest's drift check proves the test went green."
+  },
+  {
+    "codeunitId": 60994,
+    "CodeunitName": "Test TableExt Field Validate",
+    "Method": "TableExtField_Validate_BaseTableWithFieldTriggers_RunsOnValidate",
+    "Mode": "expect-fail-known-gap",
+    "Issue": "https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/1835",
+    "Note": "Same gap as the entry above, on a base table that DOES declare its own field triggers — so the failure is not 'the runner ignores field triggers on this table', it is specific to fields the extension adds. Remove in PR #1853.\n\nNote the third test in this codeunit, TableExtField_Assign_DoesNotRunOnValidate, is NOT listed here: it passes today, but only vacuously — it asserts the trigger does NOT run on direct assignment, and the runner currently never runs it in either direction. It starts proving its claim only once #1835 is fixed, so it must stay unlisted and green throughout."
+  }
+]


### PR DESCRIPTION
Rung 3 of the #1835 ladder. Upstream corpus PR [#46](https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/46) merged as `848831a`, so the pin moves and the new tests are declared. Unblocks runner PR #1853.

## What the corpus added

Inspected before bumping, per `.claude/rules/al-language-submodule.md`:

| File | Change |
|---|---|
| `record/TestTableExtFieldValidate.al` | new — codeunit 60994, 3 tests |
| `_fixtures/tables/ALTUniversalValidated.TableExt.al` | new — tableextension 60025 on a base table with **no** field triggers |
| `_fixtures/tables/ALTTriggeredOrder.TableExt.al` | adds an `"Ext Validated"` field (with `OnValidate`) to existing tableextension 60024 |

Both BC legs (27.5, 28.3) were green upstream, so this is service-tier-adjudicated behaviour rather than a claim about what BC ought to do.

## Classification

Two of the three tests fail against the runner today, declared `expect-fail-known-gap` against #1835 in the new `tests/expectations/known-gaps-record.json`:

```
FAIL Codeunit60994.TableExtField_Validate_TriggerlessBaseTable_RunsOnValidate
     Expected:<1> (Integer). Actual:<0> (Integer).
FAIL Codeunit60994.TableExtField_Validate_BaseTableWithFieldTriggers_RunsOnValidate
     Expected:<1> (Integer). Actual:<0> (Integer).
```

Both fail identically on a base table with no field triggers **and** on one that has them, which localizes the gap to fields the extension *adds* rather than to field triggers in general — the `modify()` `OnBefore`/`OnAfterValidate` wrappers around a **base** field's trigger already work.

**The third test is deliberately not declared.** `TableExtField_Assign_DoesNotRunOnValidate` passes today, but only vacuously: it asserts the trigger does *not* fire on direct assignment, and the runner currently never fires it in either direction. Declaring it would be wrong twice over — it isn't failing, and it only starts proving its claim once #1835 is fixed. It must stay green throughout.

## Verification (local, BC 28.1)

- Before the manifest entries: `1P/2F/0E` across the 3 new tests — the RED is real and reproduced, not assumed.
- After: `3P/0F/0E`, reported as `pass-known-gap: 2`, `--strict` exit 0. The entries actually match; a non-matching entry would leave the run red.
- **Full corpus: 2076 pass / 0 fail / 0 error** under `--strict` (2073 before the bump + 3 new). The added field on the shared `ALT Triggered Order Ext` fixture perturbs no existing test — worth checking explicitly, since that fixture is shared with `TestTriggerDispatchOrder`.

## Follow-up owned by #1853

PR #1853 should **delete** `tests/expectations/known-gaps-record.json` as part of landing, so the manifest's own drift check — "a test that starts passing despite an entry fails the run with 'remove the entry'" — is what proves the tests went green, rather than anyone's say-so.

---
_Generated by [Claude Code](https://claude.ai/code/session_01G3KPXYQnfoL1ogXLXo823n)_