### PR TITLE
perf(startup): drop two JmpHook-era JIT guards, ~27% off every runner spawn

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,11 @@ AlRunner/Win32Stubs/*.so
 # leave one behind — ignore it so a stray copy never shows up as untracked or gets
 # swept into a `git add -A`.
 /.build-determinism-probe-*/
+
+# The DOTNET_STARTUP_HOOKS runsettings for the in-process BC engine tests is GENERATED,
+# never authored: test-matrix.yml writes it fresh per leg (see its "Generate .runsettings"
+# step) and anyone running the suite locally writes their own. It embeds ABSOLUTE paths to
+# AlRunner.Tests' bin dir, so a committed copy would be wrong on every machine but the one
+# that produced it — and CI would silently overwrite it anyway. Same rationale as #1881
+# above: keep a stray copy from showing up as untracked or being swept into `git add -A`.
+/engine.runsettings

--- a/AlRunner.Tests/PhaseLogIntegrationTests.cs
+++ b/AlRunner.Tests/PhaseLogIntegrationTests.cs
@@ -285,26 +285,30 @@ public sealed class PhaseLogIntegrationTests : IDisposable
         Assert.All(bundleRows, r =>
             Assert.Equal(proc.GetProperty("pid").GetInt32(), r.GetProperty("pid").GetInt32()));
 
-        // One "runner spawn" is not one OS process. The runner re-execs itself with
-        // DOTNET_ReadyToRun=0 on every invocation that does not already have it set
-        // (the [r2r] branch), and again after a fresh Cecil rewrite of Ncl.dll — so a
-        // cold spawn is up to THREE processes, each waiting on the next. Every outer
-        // process's wall clock contains its child's, so summing them all under
-        // kind=="process" would multiply every total the aggregate reports. They are
-        // kept, under a distinct kind, because outer − inner is the real cost of an
-        // extra process start — a per-spawn tax worth sizing, not worth hiding.
+        // One "runner spawn" is not necessarily one OS process. The runner re-execs itself
+        // after a fresh Cecil rewrite of Ncl.dll, so a COLD spawn is two processes, each
+        // waiting on the next. Every outer process's wall clock contains its child's, so
+        // summing them all under kind=="process" would multiply every total the aggregate
+        // reports. They are kept, under a distinct kind, because outer − inner is the real
+        // cost of an extra process start — a per-spawn tax worth sizing, not worth hiding.
         //
         // Asserted against the re-exec markers the runner prints rather than a fixed
         // count: EVERY re-exec path must be labelled, and this fails if a new one is
         // added without labelling it, or an existing label is dropped.
+        //
+        // There used to be a second, unconditional re-exec here (the [r2r] branch, which
+        // restarted the process with DOTNET_ReadyToRun=0). It is gone, so on a warm
+        // ncl-cecil cache a spawn is legitimately ONE process and both sides of this
+        // equality are 0. That is why the old `expectedParents >= 1` guard — which existed
+        // to stop the equality being vacuous, and relied on the [r2r] branch firing every
+        // time — could not be kept. The labelled-re-exec invariant it protected is now
+        // covered directly by StartupJitModeTests, which asserts the [r2r] marker is absent
+        // AND the run still passes, so a silently-reintroduced unlabelled re-exec fails
+        // there rather than passing quietly here.
         var expectedParents =
             CountOccurrences(output, "[r2r] re-execing")
             + CountOccurrences(output, "[Cecil] Fresh rewrite done");
         var parents = ReadRecords(_logPath, "process-reexec-parent");
-        // Not vacuous: the DOTNET_ReadyToRun=0 re-exec fires on every invocation that
-        // does not already have it preset, so there is always at least one.
-        Assert.True(expectedParents >= 1,
-            $"no re-exec marker in the runner output — the assertion below would be vacuous:\n{output}");
         Assert.Equal(expectedParents, parents.Count);
         Assert.All(parents, parent =>
         {

--- a/AlRunner.Tests/StartupJitModeTests.cs
+++ b/AlRunner.Tests/StartupJitModeTests.cs
@@ -57,7 +57,7 @@ public sealed class StartupJitModeTests : IDisposable
     /// absent. Asserting on the marker rather than a process count keeps it independent of
     /// the ncl-cecil cache state, which legitimately adds its own labelled re-exec when cold.
     /// </summary>
-    [Fact]
+    [SkippableFact]
     public void Runner_DoesNotReexecToDisableReadyToRun()
     {
         TestArtifacts.SkipIfMissing();
@@ -88,7 +88,7 @@ public sealed class StartupJitModeTests : IDisposable
     /// all, and the FullOpts ceiling catches a partial regression that still admitted some
     /// tier-0 code.
     /// </summary>
-    [Fact]
+    [SkippableFact]
     public void Runner_JitsAtTier0_NotFullOpts()
     {
         TestArtifacts.SkipIfMissing();

--- a/AlRunner.Tests/StartupJitModeTests.cs
+++ b/AlRunner.Tests/StartupJitModeTests.cs
@@ -1,0 +1,187 @@
+// StartupJitModeTests — pins the two JIT-mode decisions that dominate runner startup.
+//
+// Both were installed to protect JmpHook and both outlived it:
+//
+//   * AlRunner.csproj set <TieredCompilation>false</TieredCompilation> because "JMP-hook
+//     patches written at tier-0 addresses are overwritten when .NET promotes hot methods
+//     to tier-1". Cecil patches live in the IL, so every tier compiles the patched body —
+//     promotion cannot undo them.
+//   * Program.cs re-exec'd the whole process with DOTNET_ReadyToRun=0 so "hooks fire
+//     deterministically". JmpHook.ComputeDisabled() now hard-returns true and a real run
+//     reports "STARTUP-READY: 0 hooks applied", so there is no hook left to bypass. BC's
+//     service-tier DLLs are IL-only anyway (machine=0x14c, zero R2R native bytes), so the
+//     flag never protected Ncl — it only suppressed the FRAMEWORK's precompiled code.
+//
+// Together they made ~93% of the 9,264 methods a one-test run compiles go through the JIT
+// at FULL optimisation, single-threaded, before the first test executes. Measured on a
+// 4-vCPU box, one cached test: 9.50s -> 6.97s (-26.7%) warm, 14.4s -> 10.8s cold, and the
+// 2076-test corpus run went 156.0s -> 133.7s. Fail-set identical (2076/2076) in every
+// configuration.
+//
+// These assertions are behavioural on purpose. A test that only read AlRunner.csproj would
+// pass against a runner whose runtimeconfig still disabled tiering for some other reason.
+using System.Diagnostics;
+using System.Text;
+using System.Text.Json;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class StartupJitModeTests : IDisposable
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+    private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
+    private static readonly string Fixture =
+        Path.Combine(RepoRoot, "AlRunner.Tests", "Fixtures", "RecordTriggerXRec");
+
+    private readonly string _scratch;
+
+    public StartupJitModeTests()
+    {
+        _scratch = Path.Combine(Path.GetTempPath(), "al-runner-jitmode", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_scratch);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_scratch, recursive: true); } catch { }
+    }
+
+    /// <summary>
+    /// The runner must not spawn a second OS process just to set DOTNET_ReadyToRun=0.
+    ///
+    /// Positive half: the run still passes 1/1, so this cannot go green by breaking
+    /// execution. Negative half: the `[r2r] re-execing` marker — which the removed branch
+    /// printed on EVERY invocation that did not already have the variable set — must be
+    /// absent. Asserting on the marker rather than a process count keeps it independent of
+    /// the ncl-cecil cache state, which legitimately adds its own labelled re-exec when cold.
+    /// </summary>
+    [Fact]
+    public void Runner_DoesNotReexecToDisableReadyToRun()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var (output, exit) = Spawn($"{TestBuildConfig.BcVersionArg} \"{Fixture}\"", jitLogPath: null);
+
+        Assert.DoesNotContain("[r2r] re-exec", output);
+        Assert.DoesNotContain("DOTNET_ReadyToRun=0", output);
+        Assert.Equal(0, exit);
+        // Proves the run actually executed the fixture rather than exiting early: the
+        // bundle has exactly one test and it must pass.
+        Assert.Contains("pass:        1", output);
+        Assert.Contains("fail:        0", output);
+    }
+
+    /// <summary>
+    /// The runner process must JIT at tier-0, not full-opt.
+    ///
+    /// DOTNET_JitDisasmSummary emits one line per compiled method carrying its tier. The
+    /// two modes are cleanly separable in that output, measured on the same fixture:
+    ///
+    ///   tiering OFF -> 8662 of 9264 methods "[FullOpts" (93.5%), and ZERO "[Tier0"
+    ///                  (the 601 "[Tier-0 switched MinOpts" entries are a different label —
+    ///                  note the hyphen — and appear in both modes)
+    ///   tiering ON  -> 15082 "[Tier0" + 4508 "[Instrumented Tier0" of 20906, 142 FullOpts
+    ///
+    /// So "at least one thousand [Tier0 entries" cannot be satisfied by the disabled mode at
+    /// all, and the FullOpts ceiling catches a partial regression that still admitted some
+    /// tier-0 code.
+    /// </summary>
+    [Fact]
+    public void Runner_JitsAtTier0_NotFullOpts()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var jitLog = Path.Combine(_scratch, "jit.txt");
+        var (output, exit) = Spawn($"{TestBuildConfig.BcVersionArg} --quiet \"{Fixture}\"", jitLog);
+        Assert.Equal(0, exit);
+
+        // The JIT summary knob is a runtime diagnostic, not runner behaviour: if the host
+        // runtime does not honour it there is nothing to assert and failing would blame the
+        // runner for the runtime. Skipping is loud about which check was lost.
+        TestArtifacts.SkipIf(!File.Exists(jitLog) || new FileInfo(jitLog).Length == 0,
+            "DOTNET_JitDisasmSummary produced no output on this runtime — tier attribution unavailable");
+
+        var lines = File.ReadAllLines(jitLog).Where(l => l.Contains("JIT compiled")).ToList();
+        Assert.NotEmpty(lines);
+
+        var tier0 = lines.Count(l => l.Contains("[Tier0") || l.Contains("[Instrumented Tier0"));
+        var fullOpts = lines.Count(l => l.Contains("[FullOpts"));
+
+        Assert.True(tier0 >= 1000,
+            $"expected tier-0 JIT to dominate startup, saw {tier0} tier-0 of {lines.Count} compiled " +
+            $"methods ({fullOpts} FullOpts) — tiered compilation looks disabled.\n{output}");
+        Assert.True(fullOpts * 5 < lines.Count,
+            $"expected FullOpts to be a small minority under tiering, saw {fullOpts} of {lines.Count}");
+    }
+
+    /// <summary>
+    /// The emitted runtimeconfig must not carry the disable switch. This is the exact
+    /// artifact the CLR reads, so re-adding &lt;TieredCompilation&gt;false&lt;/TieredCompilation&gt;
+    /// to AlRunner.csproj fails here with a message naming the property — a faster and more
+    /// specific signal than watching the tier histogram above invert.
+    /// </summary>
+    [Fact]
+    public void RunnerRuntimeConfig_DoesNotDisableTieredCompilation()
+    {
+        var configPath = Path.Combine(
+            ProjectPath, "bin", TestBuildConfig.Configuration, TestBuildConfig.Framework,
+            "al-runner.runtimeconfig.json");
+        Assert.True(File.Exists(configPath), $"runner runtimeconfig not found at '{configPath}'");
+
+        using var doc = JsonDocument.Parse(File.ReadAllText(configPath));
+        if (doc.RootElement.TryGetProperty("runtimeOptions", out var opts)
+            && opts.TryGetProperty("configProperties", out var props)
+            && props.TryGetProperty("System.Runtime.TieredCompilation", out var tiered))
+        {
+            Assert.True(tiered.GetBoolean(),
+                "al-runner.runtimeconfig.json sets System.Runtime.TieredCompilation=false — " +
+                "the <TieredCompilation> property is back in AlRunner.csproj. It was a JmpHook-era " +
+                "guard; Cecil patches live in the IL and survive tier promotion.");
+        }
+    }
+
+    private (string Output, int Exit) Spawn(string runnerArgs, string? jitLogPath)
+    {
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            Arguments = TestBuildConfig.RunArgs(ProjectPath) + " " + runnerArgs,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            WorkingDirectory = RepoRoot,
+        };
+        // Verbose so re-exec markers reach stdout/stderr: AlRunner/Log.cs installs a
+        // FilteredWriter that drops `[Component]`-tagged lines at default verbosity.
+        // Without this the absence asserted above would be indistinguishable from the
+        // marker simply being filtered out — a vacuous pass.
+        psi.Environment["AL_RUNNER_VERBOSE"] = "1";
+        // Never inherit an ambient override: the removed branch skipped itself when
+        // DOTNET_ReadyToRun was already set, so an inherited value would make the
+        // no-re-exec assertion pass without the code change.
+        psi.Environment.Remove("DOTNET_ReadyToRun");
+        psi.Environment.Remove("AL_RUNNER_ENABLE_R2R");
+        psi.Environment.Remove("AL_RUNNER_R2R_REEXECED");
+        // Same for the tier histogram: an inherited DOTNET_TieredCompilation=1 would make
+        // the tier-0 assertion pass against a runtimeconfig that still disables tiering.
+        psi.Environment.Remove("DOTNET_TieredCompilation");
+        if (jitLogPath != null)
+        {
+            psi.Environment["DOTNET_JitDisasmSummary"] = "1";
+            psi.Environment["DOTNET_JitStdOutFile"] = jitLogPath;
+        }
+
+        var sb = new StringBuilder();
+        using var p = Process.Start(psi)!;
+        p.OutputDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.ErrorDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.BeginOutputReadLine();
+        p.BeginErrorReadLine();
+        Assert.True(p.WaitForExit(300_000), "runner did not exit within 300s");
+        p.WaitForExit();
+        return (sb.ToString(), p.ExitCode);
+    }
+}

--- a/AlRunner/AlRunner.csproj
+++ b/AlRunner/AlRunner.csproj
@@ -19,10 +19,23 @@
     <AssemblyName>al-runner</AssemblyName>
     <RootNamespace>AlRunner</RootNamespace>
 
-    <!-- v2 stability constraint: JMP-hook patches written at tier-0 addresses are
-         overwritten when .NET promotes hot methods to tier-1. Tiered compilation
-         must stay off until every JmpHook has been migrated to Cecil IL rewriting. -->
-    <TieredCompilation>false</TieredCompilation>
+    <!-- Tiered compilation is ON (the .NET default — deliberately not restated here).
+         It used to be disabled: "JMP-hook patches written at tier-0 addresses are
+         overwritten when .NET promotes hot methods to tier-1. Tiered compilation must
+         stay off until every JmpHook has been migrated to Cecil IL rewriting."
+
+         That migration is done — JmpHook.ComputeDisabled() hard-returns true and a real
+         run reports "STARTUP-READY: 0 hooks applied" — and the premise no longer applies
+         either way: Cecil patches live in the IL, so tier-0 and tier-1 both compile the
+         already-patched body and promotion cannot undo them.
+
+         Leaving it off cost real time. With tiering disabled, 8662 of the 9264 methods a
+         single cached test compiles went through the JIT at FULL optimisation (93.5%);
+         with it on, 15082 compile at tier-0 and only 142 at FullOpts. Measured on 4 vCPU:
+         9.50s -> 8.29s warm on its own, 6.97s combined with the removal of the
+         DOTNET_ReadyToRun=0 re-exec (see Program.cs), and the 2076-test corpus run also
+         improved (156.0s -> 133.7s) with an unchanged fail-set.
+         Regression cover: AlRunner.Tests/StartupJitModeTests. -->
 
     <!-- dotnet tool packaging -->
     <PackAsTool>true</PackAsTool>

--- a/AlRunner/Infrastructure/RunnerFingerprint.cs
+++ b/AlRunner/Infrastructure/RunnerFingerprint.cs
@@ -123,10 +123,12 @@ internal static class RunnerFingerprint
     /// <item><description><b>Environment variables</b>: audited every
     /// <c>Environment.GetEnvironmentVariable</c> read reachable from the emit/compile path
     /// (<c>AL_RUNNER_EMIT_TIMEOUT_SEC</c>, <c>BCCOMPILER_TIMING</c>/<c>_DIAG</c>/
-    /// <c>_TRACE</c>/<c>_DUMP_CS</c>, <c>AL_RUNNER_ENABLE_R2R</c>/<c>_R2R_REEXECED</c>).
-    /// All are diagnostics, timing output, a debug dump-to-disk side effect, or control
-    /// the runner PROCESS's own R2R execution mode — none alter what bytes
-    /// <c>compilation.Emit</c> produces. None found that qualify.</description></item>
+    /// <c>_TRACE</c>/<c>_DUMP_CS</c>). All are diagnostics, timing output or a debug
+    /// dump-to-disk side effect — none alter what bytes <c>compilation.Emit</c> produces.
+    /// None found that qualify. (This list also covered <c>AL_RUNNER_ENABLE_R2R</c> and
+    /// <c>AL_RUNNER_R2R_REEXECED</c>, which controlled the runner PROCESS's own R2R
+    /// execution mode and likewise did not qualify; both were removed with the
+    /// DOTNET_ReadyToRun=0 re-exec — see Program.cs.)</description></item>
     /// <item><description><b>BC artifact content vs. the version string</b> — this is the
     /// one real gap, narrow and CI-safe. <see cref="BcArtifacts.SelectedVersion"/> is
     /// always the FULL four-part version (<c>System.Version.Parse</c> of the matched

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -61,7 +61,7 @@ if (args[0] == "--version")
 }
 
 // ── Early validation of the BC selection flags ────────────────────────────────
-// Must run BEFORE the R2R re-exec below, because that re-exec rewrites
+// Must run BEFORE the Cecil re-exec below, because that re-exec rewrites
 // `--artifact-path <std-cache>` into `--bc-version` for the child (see
 // RewriteArtifactPathArg) — which would otherwise mask the mutual-exclusion error.
 if (args.Contains("--bc-version") && args.Contains("--artifact-path"))
@@ -70,47 +70,26 @@ if (args.Contains("--bc-version") && args.Contains("--artifact-path"))
     return 2;
 }
 
-// ── Disable ReadyToRun before any BC type loads ───────────────────────────────
-// BC's R2R-precompiled native images bypass our Cecil/runtime hooks: when a hot
-// caller (e.g. RecordImplementation.IssueFindRequestAsync) is R2R, the JIT inlines
-// the call past the method we rewrote, so the interception silently no-ops and the
-// skeleton re-enters BC's native find/calc state machines — which AV because they
-// expect service-tier transactional/cache state we don't have (virtual Field table
-// find, multi-dataitem query find, FlowField calc, …). DOTNET_ReadyToRun=0 forces
-// JIT-from-IL, which is byte-identical in behaviour (corpus is the same 1663/69/0
-// fail-set either way) and routes every call through our hooks deterministically.
-// The setting is read at CLR init, so it can only be applied by re-execing once
-// with it set. Escape hatch: AL_RUNNER_ENABLE_R2R=1 keeps R2R on (e.g. for an
-// apples-to-apples perf comparison). Guard prevents an infinite re-exec loop.
-if (Environment.GetEnvironmentVariable("DOTNET_ReadyToRun") is null
-    && Environment.GetEnvironmentVariable("AL_RUNNER_ENABLE_R2R") != "1"
-    && Environment.GetEnvironmentVariable("AL_RUNNER_R2R_REEXECED") != "1")
-{
-    var psi = new System.Diagnostics.ProcessStartInfo(Environment.ProcessPath!)
-    {
-        UseShellExecute = false,
-    };
-    var argv0 = RewriteArtifactPathArg(Environment.GetCommandLineArgs());
-    // Under the `dotnet` muxer, ProcessPath is dotnet and argv[0] (the managed dll)
-    // must be forwarded; under the native apphost it must NOT be (see the Cecil
-    // re-exec below for the same rule).
-    var underDotnet0 = System.IO.Path.GetFileNameWithoutExtension(Environment.ProcessPath!)
-        .Equals("dotnet", StringComparison.OrdinalIgnoreCase);
-    foreach (var a in (underDotnet0 ? argv0 : argv0.Skip(1)))
-        psi.ArgumentList.Add(a);
-    psi.Environment["DOTNET_ReadyToRun"] = "0";
-    psi.Environment["AL_RUNNER_R2R_REEXECED"] = "1";
-    Console.Error.WriteLine("[r2r] re-execing with DOTNET_ReadyToRun=0 (hooks fire deterministically; AL_RUNNER_ENABLE_R2R=1 to disable)");
-    // Every invocation without DOTNET_ReadyToRun preset takes this branch, so the
-    // "one runner spawn" the tests believe they made is really two OS processes.
-    // Keep the outer one's row (its wall clock minus the child's IS the cost of the
-    // extra process start, which is a real per-spawn tax worth sizing) but label it
-    // so aggregates summing `kind=="process"` do not count the child's time twice.
-    AlRunner.Infrastructure.PhaseLog.MarkReexecParent();
-    using var r2rChild = System.Diagnostics.Process.Start(psi)!;
-    r2rChild.WaitForExit();
-    return r2rChild.ExitCode;
-}
+// NOTE: there used to be a second re-exec here, before the Cecil one, whose only job was
+// to restart the process with DOTNET_ReadyToRun=0 so that "hooks fire deterministically" —
+// the concern being that R2R-precompiled native code inlines past a patched method and the
+// interception silently no-ops. It was removed once it was measured to be defending
+// nothing:
+//
+//   * There are no JmpHooks left to bypass. JmpHook.ComputeDisabled() hard-returns true
+//     and a real run prints "STARTUP-READY: 0 hooks applied". Cecil patches live IN THE IL,
+//     so any tier and any precompiled image compiles the already-patched body.
+//   * BC's service-tier DLLs carry no R2R native code to inline from in the first place.
+//     Microsoft ships them IL-only — Ncl.dll and Types.dll both read machine=0x14c with a
+//     zero-size CorHeader.ManagedNativeHeader on every BC version checked. The rewritten
+//     Ncl is byte-array loaded and additionally header-stripped (NclCecilRewrite
+//     .StripR2RHeader), so it could not use precompiled code even if MS shipped it.
+//
+// What the flag DID do was suppress the .NET framework's own R2R images, forcing ~3,300
+// extra methods through the JIT on every spawn, plus one whole extra OS process. Removing
+// it: 2076/2076 corpus fail-set unchanged, one cached test 9.50s -> 8.61s warm. See
+// AlRunner.Tests/StartupJitModeTests. Anyone needing the old behaviour can still preset
+// DOTNET_ReadyToRun=0 in the environment — the CLR honours it without our help.
 
 // ── --server mode: long-running JSON-RPC daemon over stdin/stdout (the VS Code
 // extension depends on this flag). The protocol requires stdout to carry ONLY the

--- a/docs/cecil-migration.md
+++ b/docs/cecil-migration.md
@@ -83,7 +83,22 @@ Each migration: ~5-30 lines of Cecil + delete the corresponding JmpHook code. Pe
 ### Phase 5 — Remove JmpHook infrastructure
 Once no callers remain:
 - Delete JmpHook implementation
-- Re-enable tiered JIT (`<TieredCompilation>true</TieredCompilation>`)
+- [x] Re-enable tiered JIT — done by *removing* `<TieredCompilation>false</TieredCompilation>`
+  from `AlRunner.csproj` rather than restating the .NET default. `JmpHook.ComputeDisabled()`
+  hard-returns true and a real run reports `STARTUP-READY: 0 hooks applied`, so the
+  tier-promotion hazard has no target; Cecil patches live in the IL and every tier compiles
+  the already-patched body.
+- [x] Removed the companion `DOTNET_ReadyToRun=0` re-exec in `Program.cs`. Same root cause,
+  and additionally moot: BC ships its service-tier DLLs IL-only (`Ncl.dll`/`Types.dll` read
+  `machine=0x14c` with a zero-size `CorHeader.ManagedNativeHeader`), so there was never any
+  precompiled BC code for the JIT to inline past. The flag only suppressed the .NET
+  framework's own R2R images, costing ~3,300 extra JIT compilations plus one OS process
+  per spawn.
+
+Measured together on 4 vCPU, one cached test: **9.50s → 6.97s warm (−26.7%)**, 14.4s → 10.8s
+cold, and the 2076-test corpus run 156.0s → 133.7s — with the fail-set unchanged at 2076/2076
+in every configuration. Of the 9,264 methods that run compiled, 93.5% were at `FullOpts`
+before and 0.7% after. Regression cover: `AlRunner.Tests/StartupJitModeTests`.
 
 ## Cross-cutting rules that still apply
 


### PR DESCRIPTION
Closes #1893

Removes two settings that were installed to protect JmpHook and outlived it. Together they sent almost all of the runner's startup code through the JIT at **full optimisation**, single-threaded, before the first test ran — and added an extra OS process to every spawn.

## What changed

- **`AlRunner/AlRunner.csproj`** — removed `<TieredCompilation>false</TieredCompilation>`. Its own comment said it "must stay off until every JmpHook has been migrated to Cecil IL rewriting"; that migration is done (`JmpHook.ComputeDisabled()` hard-returns `true`, and a real run prints `STARTUP-READY: 0 hooks applied`). Cecil patches live in the IL, so every tier compiles the already-patched body and promotion cannot undo them.
- **`AlRunner/Program.cs`** — removed the `DOTNET_ReadyToRun=0` re-exec (−63 lines net).

## Why the R2R guard was doubly moot

It existed to stop R2R native code inlining past a patched method. Two independent reasons that can't happen:

1. There are no JmpHooks left to bypass.
2. **BC ships its service-tier DLLs IL-only.** `Ncl.dll` and `Types.dll` both read `machine=0x14c` with a zero-size `CorHeader.ManagedNativeHeader` on every BC version checked — there is no precompiled BC code to inline *from*. The Cecil-rewritten Ncl is additionally header-stripped and byte-array loaded, so it couldn't use R2R even if Microsoft shipped it.

What the flag actually suppressed was the **.NET framework's** R2R images — ~3,300 extra JIT compilations per spawn, plus a whole extra process.

## Measurements

4 vCPU, medians of interleaved runs, one cached test:

| Config | Warm spawn |
|---|---:|
| before | 9.50s |
| tiering on | 8.29s (+12.8%) |
| tiering on + R2R on | **6.97s (+26.7%)** |

Cold spawn 14.4s → 10.8s. Of the 9,264 methods that run compiles, **8,662 (93.5%) were `FullOpts`**; after, 15,082 are `Tier0` and 142 `FullOpts`.

This is not a startup-vs-throughput trade — the long single-process workload improves too: the 2076-test corpus run went **156.0s → 133.7s** (same platform-app build, same post-provisioning cache state, flags the only difference).

## Correctness

Corpus fail-set unchanged at **2076/2076, exit 0** across default, R2R-on, and tiering+R2R-on.

## Tests

New `AlRunner.Tests/StartupJitModeTests` — all three failed before the change, pass after:

- `Runner_DoesNotReexecToDisableReadyToRun` — the `[r2r]` marker is absent **and** the run still passes 1/1, so it can't go green by breaking execution.
- `Runner_JitsAtTier0_NotFullOpts` — behavioural, via `DOTNET_JitDisasmSummary`. Tiering-off emits **zero** `[Tier0` entries (its 601 are `[Tier-0 switched MinOpts`, a different label), so the old configuration cannot satisfy this.
- `RunnerRuntimeConfig_DoesNotDisableTieredCompilation` — fails with a message naming the property if the csproj setting returns.

`PhaseLogIntegrationTests` guarded `expectedParents >= 1` to keep its equality check non-vacuous, and that relied on the r2r re-exec firing on every spawn. With a warm ncl-cecil cache a spawn is now legitimately one process, so the guard is dropped — the equality still catches an *unlabelled* re-exec, and the non-vacuity coverage moves to the new suite. Calling that out explicitly since it is a small reduction in what that assertion proves on a warm cache.

## Scope / caveats

- All numbers are **BC 28.1 on one machine** — this matrix run is what adjudicates the other seven versions.
- I did not run `runner-extras` or the server-mode integrations locally; CI covers them.
- `CHANGELOG.md` untouched.

## Not in this PR

- `PublishReadyToRun=true` for the runner's own closure — version-independent, and only useful now that the R2R re-exec is gone (Cecil and Roslyn ship IL-only from NuGet and currently full-opt-JIT before they can rewrite anything).
- Moving the Cecil rewrite into provisioning (`--warm-cache`) to collapse the remaining cold-vs-warm gap.
- crossgen2 of the rewritten Ncl — the residual per-version slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EU4fwyWDu5CiUrhbPoxAhb

---
_Generated by [Claude Code](https://claude.ai/code/session_01EU4fwyWDu5CiUrhbPoxAhb)_