### PR TITLE
fix(cache): stop keying ncl-cecil cache on the runner assembly's mtime

### DIFF
--- a/.github/workflows/test-matrix.yml
+++ b/.github/workflows/test-matrix.yml
@@ -149,9 +149,10 @@ jobs:
           # covering nothing. Pre-copy the ALREADY-rewritten copy from AlRunner's own bin dir
           # above so the bootstrap below sees a no-op instead of a cold rewrite. This is NOT
           # about the Cecil disk cache under ~/.cache/al-runner/ncl-cecil (that cache is keyed
-          # off the SERVICE-TIER Ncl's own bytes + the runner assembly's mtime via
-          # NclCecilRewrite.ComputeCacheKey — the bin copy's path/mtime never enters that key,
-          # so a plain `cp`, which does not preserve mtime, cannot affect it either way).
+          # off the SERVICE-TIER Ncl's own bytes + the runner assembly's own CONTENT hash
+          # (#1871 — previously its mtime, see NclCecilRewrite.ComputeCacheKey) — the bin
+          # copy's own path/mtime never enters that key, so a plain `cp` cannot affect it
+          # either way).
           # What actually makes this pre-copy work is BcEngineBootstrap's own
           # before/after SHA-256 CONTENT hash of the bin copy (see the `FileHash` calls around
           # `RewriteInPlace` in BcEngineCollection.cs): once the bin copy is already

--- a/AlRunner.Tests/NclCecilRewriteCacheKeyTests.cs
+++ b/AlRunner.Tests/NclCecilRewriteCacheKeyTests.cs
@@ -1,0 +1,116 @@
+// NclCecilRewriteCacheKeyTests — pins issue #1871's fix to NclCecilRewrite.ComputeCacheKey.
+//
+// Same defect family as #1815 (al-out) / #1820 (bc-symbols): the ncl-cecil cache key used
+// to fold in `File.GetLastWriteTimeUtc(typeof(NclCecilRewrite).Assembly.Location).Ticks` —
+// the RUNNER's own build-output mtime. CI rebuilds the runner fresh on every run, so that
+// line changed on every run even when the runner's bytes (and therefore the Cecil rewrite
+// it produces) were byte-for-byte identical to a prior run. A `ncl-cecil` cache entry
+// persisted across CI runs (actions/cache) would therefore MISS unconditionally.
+//
+// Fix: replace the mtime line with RunnerFingerprint.ComputeContentHash of the runner
+// assembly's own bytes — the same helper #1817/#1820 already use for this exact purpose.
+//
+// Positive: same Ncl bytes + same runner assembly BYTES, different runner assembly MTIMES
+// -> equal keys.
+// Negative: same Ncl bytes, different runner assembly BYTES -> different keys (guards
+// against a fix that drops the runner-version dependency entirely rather than just
+// de-mtime-ing it).
+using AlRunner.Infrastructure;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class NclCecilRewriteCacheKeyTests
+{
+    private static string NewTempDir()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "ncl-cecil-cachekey-tests-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    /// <summary>
+    /// Positive: two "runner assembly" files with byte-identical content but DIFFERENT
+    /// mtimes must fold into the SAME ncl-cecil cache key when paired with the same Ncl
+    /// bytes. This is the actual #1871 bug — a key built from
+    /// File.GetLastWriteTimeUtc(runnerAssembly).Ticks would differ here and could never
+    /// hit across a CI rebuild, even though the rewritten output would be identical.
+    /// </summary>
+    [Fact]
+    public void ComputeCacheKey_SameRunnerBytesDifferentMtime_ProducesEqualKey()
+    {
+        var dir = NewTempDir();
+        try
+        {
+            var nclBytes = new byte[] { 0x4D, 0x5A, 10, 20, 30, 40, 50 }; // fake "PE-ish" Ncl bytes
+
+            var runnerPathA = Path.Combine(dir, "al-runner-a.dll");
+            var runnerPathB = Path.Combine(dir, "al-runner-b.dll");
+            var runnerBytes = new byte[] { 0x4D, 0x5A, 1, 2, 3, 4, 5, 6, 7, 8 };
+            File.WriteAllBytes(runnerPathA, runnerBytes);
+            File.WriteAllBytes(runnerPathB, runnerBytes);
+
+            // Force genuinely different mtimes (some filesystems truncate resolution to
+            // 1s or 2s, so a "just write twice quickly" race wouldn't reliably differ).
+            File.SetLastWriteTimeUtc(runnerPathA, new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+            File.SetLastWriteTimeUtc(runnerPathB, new DateTime(2026, 6, 15, 12, 34, 56, DateTimeKind.Utc));
+            Assert.NotEqual(File.GetLastWriteTimeUtc(runnerPathA), File.GetLastWriteTimeUtc(runnerPathB));
+
+            var runnerContentHashA = RunnerFingerprint.ComputeContentHash(runnerPathA);
+            var runnerContentHashB = RunnerFingerprint.ComputeContentHash(runnerPathB);
+
+            var keyA = NclCecilRewrite.ComputeCacheKeyCore(nclBytes, runnerContentHashA);
+            var keyB = NclCecilRewrite.ComputeCacheKeyCore(nclBytes, runnerContentHashB);
+
+            Assert.Equal(keyA, keyB);
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    /// <summary>
+    /// Negative: same Ncl bytes, DIFFERENT runner assembly bytes (i.e. the Cecil-rewrite
+    /// logic itself changed between runner builds) must still produce DIFFERENT keys.
+    /// Guards against a fix that accidentally drops the runner-version dependency
+    /// entirely rather than just de-mtime-ing it — which would let a stale rewrite from
+    /// an old runner build survive a runner upgrade.
+    /// </summary>
+    [Fact]
+    public void ComputeCacheKey_DifferentRunnerBytes_ProducesDifferentKey()
+    {
+        var dir = NewTempDir();
+        try
+        {
+            var nclBytes = new byte[] { 0x4D, 0x5A, 10, 20, 30, 40, 50 };
+
+            var runnerPathA = Path.Combine(dir, "al-runner-a.dll");
+            var runnerPathB = Path.Combine(dir, "al-runner-b.dll");
+            File.WriteAllBytes(runnerPathA, new byte[] { 1, 2, 3, 4 });
+            File.WriteAllBytes(runnerPathB, new byte[] { 1, 2, 3, 5 }); // one byte different
+
+            var runnerContentHashA = RunnerFingerprint.ComputeContentHash(runnerPathA);
+            var runnerContentHashB = RunnerFingerprint.ComputeContentHash(runnerPathB);
+            Assert.NotEqual(runnerContentHashA, runnerContentHashB);
+
+            var keyA = NclCecilRewrite.ComputeCacheKeyCore(nclBytes, runnerContentHashA);
+            var keyB = NclCecilRewrite.ComputeCacheKeyCore(nclBytes, runnerContentHashB);
+
+            Assert.NotEqual(keyA, keyB);
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    /// <summary>
+    /// Companion negative: same runner content hash, DIFFERENT Ncl bytes must still
+    /// produce different keys — the Ncl-content dependency the issue explicitly says is
+    /// fine already must survive the fix untouched.
+    /// </summary>
+    [Fact]
+    public void ComputeCacheKey_DifferentNclBytes_ProducesDifferentKey()
+    {
+        var runnerContentHash = "deadbeef";
+        var keyA = NclCecilRewrite.ComputeCacheKeyCore(new byte[] { 1, 2, 3, 4 }, runnerContentHash);
+        var keyB = NclCecilRewrite.ComputeCacheKeyCore(new byte[] { 1, 2, 3, 5 }, runnerContentHash);
+
+        Assert.NotEqual(keyA, keyB);
+    }
+}

--- a/AlRunner/Infrastructure/NclCecilRewrite.cs
+++ b/AlRunner/Infrastructure/NclCecilRewrite.cs
@@ -11,6 +11,7 @@ using System.Reflection;
 using System.Reflection.Metadata.Ecma335;
 using System.Reflection.PortableExecutable;
 using System.Security.Cryptography;
+using System.Text;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
 
@@ -7916,7 +7917,10 @@ public static class NclCecilRewrite
     /// bin path (overwriting the build-time copy). Runs BEFORE the CLR's TPA probe
     /// resolves Ncl, so when CLR loads Ncl by name it gets our rewritten bytes.
     /// Results are cached in $HOME/.cache/al-runner/ncl-cecil/ keyed by a SHA256 of
-    /// the source Ncl bytes, runner assembly mtime, and CACHE_VERSION. Set
+    /// the source Ncl bytes, the runner assembly's own CONTENT hash (issue #1871 —
+    /// previously the runner assembly's mtime, which changes on every CI rebuild even
+    /// when the runner's bytes, and therefore the rewrite it produces, are unchanged;
+    /// see RunnerFingerprint.ComputeContentHash), and CACHE_VERSION. Set
     /// AL_RUNNER_NCL_CACHE=0 to force a fresh rewrite without reading or writing cache.
     /// </summary>
     /// <summary>
@@ -8063,13 +8067,39 @@ public static class NclCecilRewrite
         return true;
     }
 
+    /// <summary>
+    /// #1871: the runner-identity component of this key used to be
+    /// <c>File.GetLastWriteTimeUtc(typeof(NclCecilRewrite).Assembly.Location).Ticks</c> —
+    /// the RUNNER assembly's own build-output mtime, which changes on every fresh
+    /// `dotnet build`/`dotnet publish` (including every CI run) even when the runner's
+    /// bytes, and therefore the Cecil rewrite it produces, are byte-for-byte identical to
+    /// a prior run. A `ncl-cecil` entry persisted across CI runs would therefore MISS
+    /// unconditionally — same defect family as #1815 (al-out) / #1820 (bc-symbols).
+    /// Replaced with <see cref="RunnerFingerprint.ContentHash"/>: stable across rebuilds
+    /// of unchanged source, still sensitive to any change in the runner's own
+    /// Cecil-rewrite logic. No `bc:` line is needed here (unlike RunnerFingerprint's
+    /// WriteKeyLines) — the rewrite only depends on the source Ncl bytes (already hashed
+    /// below) and the runner's own rewrite logic, neither of which vary by BC version
+    /// within one build.
+    /// </summary>
     private static string ComputeCacheKey(string nclPath)
     {
         var nclBytes = File.ReadAllBytes(nclPath);
-        var runnerMtimeTicks = File.GetLastWriteTimeUtc(typeof(NclCecilRewrite).Assembly.Location).Ticks;
+        return ComputeCacheKeyCore(nclBytes, RunnerFingerprint.ContentHash);
+    }
+
+    /// <summary>
+    /// Testable core of <see cref="ComputeCacheKey(string)"/>: takes the Ncl bytes and
+    /// runner content hash explicitly so a test can vary either independently without
+    /// needing to swap out the actual running assembly on disk (mirrors
+    /// <c>RunnerFingerprint.WriteKeyLines(Action{string}, string, Version)</c>'s
+    /// explicit-parameter testable-core pattern).
+    /// </summary>
+    internal static string ComputeCacheKeyCore(byte[] nclBytes, string runnerContentHash)
+    {
         using var hash = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
         hash.AppendData(nclBytes);
-        hash.AppendData(BitConverter.GetBytes(runnerMtimeTicks));
+        hash.AppendData(Encoding.UTF8.GetBytes(runnerContentHash));
         hash.AppendData(BitConverter.GetBytes(CACHE_VERSION));
         return Convert.ToHexString(hash.GetHashAndReset()).ToLowerInvariant();
     }


### PR DESCRIPTION
Closes #1871

## Problem

`NclCecilRewrite.ComputeCacheKey(string nclPath)` folded in
`File.GetLastWriteTimeUtc(typeof(NclCecilRewrite).Assembly.Location).Ticks` — the
**runner's own build-output mtime**. That mtime changes on every fresh
`dotnet build`/`dotnet publish` (including every CI run) even when the runner's
bytes — and therefore the Cecil rewrite it produces — are byte-for-byte identical
to a prior run. A `ncl-cecil` cache entry persisted across CI runs (e.g. via
`actions/cache`) would therefore MISS unconditionally, same defect family as
#1815 (`al-out`) / #1820 (`bc-symbols`), both already fixed with the same
pattern.

## Fix

Replace the mtime component with `RunnerFingerprint.ContentHash` — SHA-256 of
the runner assembly's own bytes, the same helper #1817/#1820 already use for
this exact purpose. Stable across rebuilds of unchanged source, still sensitive
to any change in the runner's own Cecil-rewrite logic. No `bc:` line is needed
here (unlike `RunnerFingerprint.WriteKeyLines`) — the rewrite only depends on
the source Ncl bytes (already hashed) and the runner's own rewrite logic,
neither of which vary by BC version within one build.

Factored the hash computation into a testable `ComputeCacheKeyCore(byte[]
nclBytes, string runnerContentHash)` core (mirrors
`RunnerFingerprint.WriteKeyLines`'s explicit-parameter testable-core pattern)
so the fix can be proven without depending on the real running assembly's disk
mtime.

## Tests (RED → GREEN, `AlRunner.Tests/NclCecilRewriteCacheKeyTests.cs`)

- **Positive** — `ComputeCacheKey_SameRunnerBytesDifferentMtime_ProducesEqualKey`:
  two "runner assembly" files with byte-identical content but different mtimes
  produce the SAME `ncl-cecil` key when paired with the same Ncl bytes (this is
  the actual #1871 bug reproduced).
- **Negative** — `ComputeCacheKey_DifferentRunnerBytes_ProducesDifferentKey`:
  same Ncl bytes, different runner assembly *bytes*, produce DIFFERENT keys
  (guards against a fix that drops the runner-version dependency entirely
  rather than just de-mtime-ing it).
- **Companion negative** — `ComputeCacheKey_DifferentNclBytes_ProducesDifferentKey`:
  the pre-existing Ncl-content dependency the issue calls out as already
  correct survives the fix untouched.

All three fail to compile before the fix (RED — `ComputeCacheKeyCore` didn't
exist) and pass after (GREEN). Also ran the full `AlRunner.Tests` suite:
681 passed, 22 skipped, 0 failed.

Per `bc-behavior-tests-go-upstream.md`, cache HIT/MISS is explicitly named as
runner-specific — a runner-local C# unit test is the correct home, not the
`tests/al-language` corpus.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01EU4fwyWDu5CiUrhbPoxAhb

---
_Generated by [Claude Code](https://claude.ai/code/session_01EU4fwyWDu5CiUrhbPoxAhb)_