### PR TITLE
fix(compiler): thread --define preprocessor symbols into the table-metadata parser

### DIFF
--- a/AlRunner.Tests/DefineFlagIntegrationTests.cs
+++ b/AlRunner.Tests/DefineFlagIntegrationTests.cs
@@ -15,6 +15,23 @@
 // Test B proves the flag works (GREEN with --define).
 // Test C proves the alias --preprocessor-symbols works (GREEN).
 // Reverting the .Concat line makes B and C fail → real guard.
+//
+// #1900 — coverage for a #if-gated TABLE FIELD, not just a #if-gated procedure.
+// BcCompiler.Emit's two ParseOptions sites merged --define with the compiler, but
+// RecordPatches.AlSourceParser's ParseOptions (used to build table metadata for the
+// in-memory record provider) did not — the compiler and the metadata parser disagreed
+// about which #if branch was live. Two shapes:
+//   - loud: FieldExist(20)/FieldExist(21)/RecordRef.Get round-trip on a field whose
+//     NUMBER differs per branch — this throws NavNCLFieldNotFoundException outright.
+//   - quiet: a field whose declared TYPE differs per branch (Enum vs. Option) but whose
+//     field NUMBER is the same in both branches — this round-trips a value fine even
+//     against the wrong branch's metadata (the ordinals happen to coincide), so only
+//     FieldRef.OptionMembers (which differs: the Enum's member names vs. the dead
+//     branch's option literals) catches the divergence.
+// Both shapes are gated on the SAME --define symbol as the existing procedure test, so
+// WithDefine_TestPasses / WithPreprocessorSymbols_TestPasses already prove they pass
+// together with the pre-existing procedure test; FieldGatedByDefine_* below additionally
+// names the shapes explicitly, per issue #1900's acceptance criteria.
 
 using System.Diagnostics;
 using System.Text;
@@ -58,12 +75,17 @@ public sealed class DefineFlagIntegrationTests : IDisposable
 
     /// <summary>
     /// Writes a minimal AL package to <paramref name="dir"/>:
-    ///   - app.json (no dependencies, id range 62100..62109)
+    ///   - app.json (no dependencies, id range 62100..62119)
     ///   - Assert codeunit (integer AreEqual)
     ///   - Test codeunit: asserts UNCONDITIONALLY that GetCompiledBranch() == 1.
     ///     Only the helper (GetCompiledBranch) is #if-gated.
     ///     Without MY_TEST_SYMBOL: #else → exit(0) → 1≠0 → FAIL.
     ///     With    MY_TEST_SYMBOL: #if  → exit(1) → 1=1 → PASS.
+    ///   - Table 62102 "PPD Define Gated": field 20 in the #if branch, field 21 in the
+    ///     #else branch — the "loud" #1900 shape (a missing/extra field NUMBER).
+    ///   - Enum 62104 "PPD Status" + Table 62103 "PPD Type Gated": field 10's declared
+    ///     TYPE differs per branch (Enum vs. Option) but its NUMBER does not — the
+    ///     "quiet" #1900 shape.
     /// </summary>
     private static void WriteFixture(string dir)
     {
@@ -76,7 +98,7 @@ public sealed class DefineFlagIntegrationTests : IDisposable
           "dependencies": [],
           "platform": "1.0.0.0",
           "application": "1.0.0.0",
-          "idRanges": [ { "from": 62100, "to": 62109 } ],
+          "idRanges": [ { "from": 62100, "to": 62119 } ],
           "runtime": "14.0"
         }
         """);
@@ -89,6 +111,70 @@ public sealed class DefineFlagIntegrationTests : IDisposable
                 if Expected <> Actual then
                     Error('Expected:<%1> Actual:<%2> %3', Expected, Actual, Msg);
             end;
+        }
+        """);
+
+        // "Loud" #1900 shape: field 20 exists only in the #if branch, field 21 only in
+        // the #else branch. If the metadata parser and the compiler disagree about which
+        // branch is live, either FieldExist(20) is false when it must be true, or
+        // FieldExist(21) is true when it must be false, or the round trip throws
+        // NavNCLFieldNotFoundException outright.
+        File.WriteAllText(Path.Combine(dir, "DefineGated.Table.al"), """
+        table 62102 "PPD Define Gated"
+        {
+            DataClassification = CustomerContent;
+
+            fields
+            {
+                field(1; "No."; Code[20]) { }
+        #if MY_TEST_SYMBOL
+                field(20; "Active Branch"; Text[30]) { }
+        #else
+                field(21; "Dead Branch"; Text[30]) { }
+        #endif
+            }
+
+            keys
+            {
+                key(PK; "No.") { Clustered = true; }
+            }
+        }
+        """);
+
+        // "Quiet" #1900 shape: field 10 exists in BOTH branches with the SAME number, so
+        // a value written through the #if branch's Enum type round-trips fine even
+        // against the #else branch's wrong Option metadata (matching ordinals). Only
+        // FieldRef.OptionMembers — which differs (the enum's member names vs. the dead
+        // branch's literal option strings) — catches the wrong branch having been parsed.
+        File.WriteAllText(Path.Combine(dir, "TypeGated.Enum.al"), """
+        enum 62104 "PPD Status"
+        {
+            Extensible = true;
+
+            value(0; Open) { }
+            value(1; Closed) { }
+        }
+        """);
+
+        File.WriteAllText(Path.Combine(dir, "TypeGated.Table.al"), """
+        table 62103 "PPD Type Gated"
+        {
+            DataClassification = CustomerContent;
+
+            fields
+            {
+                field(1; "No."; Code[20]) { }
+        #if MY_TEST_SYMBOL
+                field(10; "Status"; Enum "PPD Status") { }
+        #else
+                field(10; "Status"; Option) { OptionMembers = Dead0,Dead1; }
+        #endif
+            }
+
+            keys
+            {
+                key(PK; "No.") { Clustered = true; }
+            }
         }
         """);
 
@@ -117,6 +203,86 @@ public sealed class DefineFlagIntegrationTests : IDisposable
         #else
                 exit(0);
         #endif
+            end;
+
+            /// Positive: field 20 is in the branch the COMPILER took, so it must exist
+            /// at runtime too.
+            [Test]
+            procedure ActiveBranchFieldIsPresentInTableMetadata()
+            var
+                Rec: Record "PPD Define Gated";
+                RecRef: RecordRef;
+            begin
+                RecRef.GetTable(Rec);
+                if not RecRef.FieldExist(20) then
+                    Error('Field 20 belongs to the ACTIVE #if MY_TEST_SYMBOL branch but is absent from table 62102 metadata.');
+                RecRef.Close();
+            end;
+
+            /// Negative: field 21 is in the branch the compiler DISCARDED, so it must
+            /// not exist.
+            [Test]
+            procedure DeadBranchFieldIsAbsentFromTableMetadata()
+            var
+                Rec: Record "PPD Define Gated";
+                RecRef: RecordRef;
+            begin
+                RecRef.GetTable(Rec);
+                if RecRef.FieldExist(21) then
+                    Error('Field 21 belongs to the INACTIVE #else branch but is PRESENT in table 62102 metadata.');
+                RecRef.Close();
+            end;
+
+            /// Positive: the active-branch field is usable end to end. Deliberately
+            /// written through RecordRef/FieldRef rather than the strongly-typed
+            /// `Rec."Active Branch"` accessor — the strongly-typed name only exists in
+            /// the #if MY_TEST_SYMBOL branch, and this codeunit must still COMPILE
+            /// without --define too (so the pre-existing SymbolDefinedBranchMustBe1
+            /// RED/GREEN pair keeps working). RecRef.Field(20) resolves at runtime, so
+            /// without --define it throws NavNCLFieldNotFoundException — a real FAIL,
+            /// not a compile error — exactly the exception the #1900 issue reports.
+            [Test]
+            procedure ActiveBranchFieldRoundTrips()
+            var
+                Rec: Record "PPD Define Gated";
+                RecRef: RecordRef;
+                ActiveValue: Text;
+            begin
+                RecRef.GetTable(Rec);
+                RecRef.Field(1).Value := 'D1';
+                RecRef.Field(20).Value := 'active-value';
+                RecRef.Insert();
+                RecRef.Close();
+
+                Clear(RecRef);
+                RecRef.GetTable(Rec);
+                RecRef.Field(1).SetRange('D1');
+                if not RecRef.FindFirst() then
+                    Error('Row ''D1'' not found after insert.');
+                ActiveValue := Format(RecRef.Field(20).Value);
+                if ActiveValue <> 'active-value' then
+                    Error('Expected ''active-value'' but got ''%1''', ActiveValue);
+                RecRef.Close();
+            end;
+
+            /// The "quiet" #1900 shape: field 10 exists in both branches with the same
+            /// number, so a naive round-trip test would pass even against the wrong
+            /// branch's metadata. FieldRef.OptionMembers carries the DECLARED TYPE's
+            /// member names, which differ per branch (the Enum's Open/Closed vs. the
+            /// dead branch's Dead0/Dead1 literals) — this is what actually distinguishes
+            /// "metadata parsed the active branch" from "metadata parsed the dead one".
+            [Test]
+            procedure ActiveBranchFieldOptionMembersMatchEnum()
+            var
+                Rec: Record "PPD Type Gated";
+                RecRef: RecordRef;
+                FldRef: FieldRef;
+            begin
+                RecRef.GetTable(Rec);
+                FldRef := RecRef.Field(10);
+                if FldRef.OptionMembers <> 'Open,Closed' then
+                    Error('Field 10 metadata must carry the ACTIVE #if MY_TEST_SYMBOL branch''s Enum "PPD Status" member names (Open,Closed), got ''%1''', FldRef.OptionMembers);
+                RecRef.Close();
             end;
         }
         """);
@@ -196,6 +362,51 @@ public sealed class DefineFlagIntegrationTests : IDisposable
 
         Assert.Equal(0, exit);
         Assert.Contains("PASS", output);
+        Assert.DoesNotContain("FAIL  Codeunit", output);
+    }
+
+    /// <summary>
+    /// Without --define, compiler and metadata parser agree (both take the #else
+    /// branch for every #if in the fixture) — the #1900 defect only shows up once the
+    /// two DISAGREE, which needs --define to be passed. What's still true without the
+    /// flag: the fixture's UNCONDITIONAL procedure-branch assertion
+    /// (SymbolDefinedBranchMustBe1) fails, so the runner exits non-zero. This is the
+    /// RED half of the pair, mirroring WithoutDefine_TestFails but naming the exact
+    /// failing test for this fixture's expanded #1900 coverage.
+    /// </summary>
+    [SkippableFact]
+    public void FieldGatedByDefine_WithoutFlag_ProcedureBranchFails()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var (output, exit) = RunRunner();
+
+        Assert.NotEqual(0, exit);
+        Assert.Contains("FAIL  Codeunit62100.SymbolDefinedBranchMustBe1", output);
+    }
+
+    /// <summary>
+    /// #1900 GREEN: with --define MY_TEST_SYMBOL, BOTH the "loud" shape (field 20/21 —
+    /// a field NUMBER that only exists in the #if branch) and the "quiet" shape (field
+    /// 10's declared TYPE, Enum vs. Option, with the SAME number in both branches) pass.
+    /// Reverting RecordPatches.AlSourceParser's AlParseOptions to the pre-fix
+    /// `static readonly` field (or a `.Concat` bolted onto it, per the issue's warning)
+    /// makes all four of these named assertions fail while the pre-existing procedure
+    /// test (SymbolDefinedBranchMustBe1) keeps passing — proving the fix is not
+    /// redundant with the procedure-level guard the class already had.
+    /// </summary>
+    [SkippableFact]
+    public void FieldGatedByDefine_WithFlag_LoudAndQuietShapesBothPass()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var (output, exit) = RunRunner("--define MY_TEST_SYMBOL");
+
+        Assert.Equal(0, exit);
+        Assert.Contains("PASS  Codeunit62100.ActiveBranchFieldIsPresentInTableMetadata", output);
+        Assert.Contains("PASS  Codeunit62100.DeadBranchFieldIsAbsentFromTableMetadata", output);
+        Assert.Contains("PASS  Codeunit62100.ActiveBranchFieldRoundTrips", output);
+        Assert.Contains("PASS  Codeunit62100.ActiveBranchFieldOptionMembersMatchEnum", output);
         Assert.DoesNotContain("FAIL  Codeunit", output);
     }
 }

--- a/AlRunner/Patches/RecordPatches.AlSourceParser.cs
+++ b/AlRunner/Patches/RecordPatches.AlSourceParser.cs
@@ -30,10 +30,22 @@ public static partial class RecordPatches
 {
     // Matches BcCompiler.Emit's options so this parse sees the same source the emit does —
     // notably the CLEANSCHEMA1..25 preprocessor symbols, which gate real field declarations
-    // in the BaseApp. DocumentationMode.None: doc comments are trivia we never read.
-    private static readonly NavCA.ParseOptions AlParseOptions = new(
+    // in the BaseApp, PLUS whatever the caller passed via --define / --preprocessor-symbols.
+    // DocumentationMode.None: doc comments are trivia we never read.
+    //
+    // This MUST be a property recomputed on every call, not a `static readonly` field.
+    // BcCompiler.SetExtraPreprocessorSymbols(...) runs at Program.cs:727, after this type
+    // may already have been touched elsewhere in the same process — a `static readonly`
+    // field would freeze at type-init with the empty symbol set, and a `.Concat(...)`
+    // bolted onto that frozen field would look like a fix while changing nothing (#1900:
+    // the compiler's two ParseOptions sites already merge `_extraPreprocessorSymbols` per
+    // call; this parser was the one site that didn't). GetExtraPreprocessorSymbols() is
+    // cheap (a lock plus a sorted copy of a handful of strings), so recomputing it per
+    // parse call costs nothing worth caching.
+    private static NavCA.ParseOptions AlParseOptions => new(
         runtimeVersion: null!,
-        preprocessorSymbols: Enumerable.Range(1, 25).Select(n => $"CLEANSCHEMA{n}"),
+        preprocessorSymbols: Enumerable.Range(1, 25).Select(n => $"CLEANSCHEMA{n}")
+            .Concat(AlRunner.BcCompiler.GetExtraPreprocessorSymbols()),
         documentationMode: NavCA.DocumentationMode.None);
 
     // Field type text still yields its length by pattern (`Code[10]` → 10). The type is one


### PR DESCRIPTION
Closes #1900

## Problem

`--define` / `--preprocessor-symbols` reached `BcCompiler.Emit`'s two `ParseOptions` construction sites (primary compile + dependency-symbol compile), but not `RecordPatches.AlSourceParser`'s `AlParseOptions`, which builds the in-memory table metadata the record provider serves at runtime. The compiler and the metadata parser could therefore disagree about which `#if` branch was live:

- **Loud shape:** a field number that exists only in the taken `#if` branch is missing from the table's runtime metadata (`FieldExist` returns false, or a round trip throws `NavNCLFieldNotFoundException`).
- **Quiet shape:** a field whose declared *type* differs per branch (e.g. `Enum` vs `Option`) but whose field *number* is the same in both branches round-trips a value fine even against the wrong branch's metadata, because the ordinals happen to coincide — nothing announces the mismatch.

## Root cause

`AlParseOptions` in `AlRunner/Patches/RecordPatches.AlSourceParser.cs` was a `private static readonly` field frozen at type-init with only the built-in `CLEANSCHEMA1..25` symbols. `BcCompiler.SetExtraPreprocessorSymbols(...)` (wired from `--define` at `Program.cs:727`) runs later, so a naive `.Concat(...)` bolted onto the static field would capture the empty symbol set at type-init and look fixed while changing nothing.

## Fix

Turned `AlParseOptions` into a property, recomputed per parse call from `BcCompiler.GetExtraPreprocessorSymbols()` (already public, already used for the AL cache key) — matching the pattern the compiler's own two `ParseOptions` sites already use.

## Tests

Extended `AlRunner.Tests/DefineFlagIntegrationTests` (which previously only proved `--define` reaches the compiler, via a `#if`-gated *procedure*) with:

- A `#if`-gated table field (`PPD Define Gated`, table 62102): asserts the active branch's field exists, the dead branch's field number does not, and the field round-trips a value end to end via `RecordRef`/`FieldRef` (this reaches an unconditional `NavNCLFieldNotFoundException` when the flag is missing, matching the issue's exact reported exception).
- The quiet shape (`PPD Type Gated`, table 62103 + `PPD Status` enum, 62104): a field whose type is `Enum "PPD Status"` in the `#if` branch and a plain `Option` in the `#else` branch, both sharing field number 10. Asserts `FieldRef.OptionMembers` carries the active branch's Enum member names — this is what actually distinguishes "the parser read the active branch" from "the parser read the dead branch," since a plain value round trip would pass either way (that's the "quiet" part).

RED → GREEN verified two ways:
1. Manual repro matching the issue body exactly: `--define BC28` on a standalone fixture went 0P/3F → 3P/0F.
2. `git stash` on just the runtime fix (keeping the new tests) reproduces RED in the C# suite: `WithDefine_TestPasses`, `WithPreprocessorSymbols_TestPasses`, and the new `FieldGatedByDefine_WithFlag_LoudAndQuietShapesBothPass` all fail with the pre-fix parser and pass again once the fix is restored.

Full `AlRunner.Tests` suite: 680 passed, 0 failed (22 not-executed/skipped are pre-existing artifact-dependent skips unrelated to this change).

## Test plan

- [x] `AlRunner.Tests/DefineFlagIntegrationTests` — 5/5 passing, including the 2 new field-metadata tests
- [x] Confirmed RED against the pre-fix parser (both the manual repro and the C# suite)
- [x] Full `AlRunner.Tests` suite — 680 passed / 0 failed
- [ ] CI matrix (corpus + runner-extras + xmlport isolation guard across supported BC versions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EU4fwyWDu5CiUrhbPoxAhb

---
_Generated by [Claude Code](https://claude.ai/code/session_01EU4fwyWDu5CiUrhbPoxAhb)_