### PR TITLE
fix(server): dedup a sourcePaths app's own module against a sibling's dependency compile

### DIFF
--- a/AlRunner.Tests/ServerCrossBundleModuleIdentityDedupTests.cs
+++ b/AlRunner.Tests/ServerCrossBundleModuleIdentityDedupTests.cs
@@ -1,0 +1,201 @@
+using System.Text.Json;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// Issue #1892 — the SAME defect #1683 fixed for the CLI bundle loop
+/// (<see cref="CrossBundleModuleIdentityDedupTests"/>), reproduced through
+/// <c>--server</c>'s <c>runTests</c> multi-<c>sourcePaths</c> path instead of the CLI's
+/// multiple positional bundle args.
+///
+/// A <c>runTests</c> request whose <c>sourcePaths</c> name an app bundle AND a
+/// sibling test bundle that depends on it used to compile the app bundle TWICE:
+/// once via <see cref="Program"/>'s per-bundle server compile (its own module,
+/// <c>V2_&lt;dir&gt;</c>) and once more via <c>DependencyLoader.LoadAll</c>
+/// resolving the SAME AppId as the test bundle's dependency (a
+/// Tier-3-compiled <c>Dep_...</c> module) — because <c>RunBundleForServer</c>
+/// never registered its own freshly-compiled module into
+/// <c>DependencyLoader</c>'s cross-bundle cache the way the CLI's per-AppGroup
+/// loop does. Two live modules for one AL app identity means the event-subscriber
+/// registry pairs a subscriber <c>MethodInfo</c> discovered from one module's
+/// <c>Type</c> with a <c>subscriberInstance</c> BC's own dispatcher materialized
+/// from the OTHER module's <c>Type</c>, and <c>RuntimeMethodInfo.Invoke</c> throws
+/// <c>TargetException: Object does not match target type</c> inside
+/// <c>NavEventScope.CallEventSubscriberInternalAsync</c> → <c>ValidateInvokeTarget</c>
+/// — exactly the CLI's own #1683 signature, but only over <c>--server</c>.
+///
+/// RED (pre-fix): the request aborts — the app bundle's OWN compile is never
+/// registered, so the test bundle's dependency resolution re-compiles it into a
+/// second module and the install trigger's <c>Modify(true)</c> throws
+/// <c>TargetException</c> the instant it dispatches to the mismatched subscriber.
+/// GREEN (post-fix): <c>RunBundleForServer</c> checks
+/// <c>DependencyLoader.TryGetByAppId</c> before compiling and calls
+/// <c>DependencyLoader.RegisterLoaded</c> after — one loaded module per AL app
+/// identity, same as the CLI — so the install trigger's subscriber fires cleanly
+/// and both tests in the dependent bundle pass.
+///
+/// Spawns the real runner in --server mode; needs the BC artifact cache. Skips
+/// (no-op) when absent.
+/// </summary>
+public class ServerCrossBundleModuleIdentityDedupTests
+{
+    private static (string appDir, string testDir) MakeAppTestPair()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "al-runner-server-xbundle-dedup", Guid.NewGuid().ToString("N"));
+        var appDir = Path.Combine(root, "app");
+        var testDir = Path.Combine(root, "tests");
+        Directory.CreateDirectory(appDir);
+        Directory.CreateDirectory(testDir);
+
+        const string appId = "c3d4e5f6-1892-4a1b-9c3d-000000000001";
+
+        File.WriteAllText(Path.Combine(appDir, "app.json"), $$"""
+        {
+          "id": "{{appId}}",
+          "name": "SX1892 Repro App",
+          "publisher": "Repro1892",
+          "version": "1.0.0.0",
+          "dependencies": [],
+          "platform": "1.0.0.0",
+          "application": "1.0.0.0",
+          "idRanges": [ { "from": 61990, "to": 61999 } ],
+          "runtime": "14.0"
+        }
+        """);
+        File.WriteAllText(Path.Combine(appDir, "SX1892App.al"), """
+        table 61990 "SX1892 Row"
+        {
+            DataClassification = SystemMetadata;
+            fields
+            {
+                field(1; "No."; Code[20]) { }
+                field(2; Description; Text[50]) { }
+            }
+            keys { key(PK; "No.") { Clustered = true; } }
+        }
+
+        table 61991 "SX1892 Marker"
+        {
+            DataClassification = SystemMetadata;
+            fields { field(1; "No."; Code[20]) { } }
+            keys { key(PK; "No.") { Clustered = true; } }
+        }
+
+        codeunit 61992 "SX1892 Subscriber"
+        {
+            [EventSubscriber(ObjectType::Table, Database::"SX1892 Row", 'OnAfterModifyEvent', '', false, false)]
+            local procedure OnAfterModifyRow(var Rec: Record "SX1892 Row"; var xRec: Record "SX1892 Row"; RunTrigger: Boolean)
+            var
+                Marker: Record "SX1892 Marker";
+            begin
+                if Marker.Get('FIRED') then
+                    exit;
+                Marker."No." := 'FIRED';
+                Marker.Insert();
+            end;
+        }
+
+        codeunit 61993 "SX1892 Install"
+        {
+            Subtype = Install;
+
+            trigger OnInstallAppPerCompany()
+            var
+                Row: Record "SX1892 Row";
+            begin
+                Row."No." := 'SEED';
+                Row.Insert();
+                Row.Description := 'seeded';
+                Row.Modify(true);
+            end;
+        }
+        """);
+
+        File.WriteAllText(Path.Combine(testDir, "app.json"), $$"""
+        {
+          "id": "d4e5f6a7-1892-4a1b-9c3d-000000000002",
+          "name": "SX1892 Repro Tests",
+          "publisher": "Repro1892",
+          "version": "1.0.0.0",
+          "dependencies": [
+            { "id": "{{appId}}", "name": "SX1892 Repro App", "publisher": "Repro1892", "version": "1.0.0.0" }
+          ],
+          "platform": "1.0.0.0",
+          "application": "1.0.0.0",
+          "idRanges": [ { "from": 62050, "to": 62059 } ],
+          "runtime": "14.0"
+        }
+        """);
+        File.WriteAllText(Path.Combine(testDir, "SX1892Tests.al"), """
+        codeunit 62050 "SX1892 Test"
+        {
+            Subtype = Test;
+
+            [Test]
+            procedure InstallSeedRowExists()
+            var
+                Row: Record "SX1892 Row";
+            begin
+                Row.Get('SEED');
+                if Row.Description <> 'seeded' then
+                    Error('install trigger did not run the Modify: Description=%1', Row.Description);
+            end;
+
+            [Test]
+            procedure SubscriberFiredDuringInstall()
+            var
+                Marker: Record "SX1892 Marker";
+            begin
+                if not Marker.Get('FIRED') then
+                    Error('OnAfterModifyEvent subscriber did not fire during OnInstallAppPerCompany');
+            end;
+        }
+        """);
+
+        return (appDir, testDir);
+    }
+
+    [SkippableFact]
+    public async Task RunTests_AppThenDependentTestBundle_InstallTriggerSubscriberFiresCleanly_NoSecondModule()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var (appDir, testDir) = MakeAppTestPair();
+        var cacheDir = Path.Combine(Path.GetTempPath(), "al-runner-server-xbundle-dedup-cache", Guid.NewGuid().ToString("N"));
+        await using var server = await CliServer.StartAsync(new[] { "--cache", cacheDir });
+
+        // Same order as the issue's Leg 2 (`sourcePaths [app, tests]`) — the exact
+        // shape that crashed under --server while the identical pair passed via the
+        // CLI (`al-runner app tests`).
+        var req = JsonSerializer.Serialize(new
+        {
+            command = "runTests",
+            sourcePaths = new[] { appDir, testDir },
+            packagePaths = Array.Empty<string>(),
+        });
+        var lines = await server.SendRequestStreamingAsync(req, TimeSpan.FromSeconds(180));
+        var (events, d) = ProtocolV2Streaming.Split(lines);
+
+        // The exact defect: two loaded modules for one AL app identity produced a
+        // subscriber MethodInfo/instance mismatch inside the install trigger's
+        // Modify(true) dispatch. Never silently pass a run that hit this — this
+        // assertion is the whole point of the RED->GREEN cycle, and matches what
+        // CrossBundleModuleIdentityDedupTests pins for the CLI path.
+        var allOutput = string.Join(" | ", lines) + " " + server.StdErr;
+        Assert.DoesNotContain("TargetException", allOutput);
+        Assert.DoesNotContain("Object does not match target type", allOutput);
+
+        // Both tests in the dependent bundle must actually have run and passed —
+        // not merely "no crash". The app bundle itself declares zero [Test]
+        // codeunits, so total == 2 proves the test bundle's dependency on the app
+        // resolved to a SINGLE working module (install trigger ran AND its
+        // subscriber fired), matching the CLI's 2/2 result for the identical pair.
+        Assert.Equal(2, d.GetProperty("total").GetInt32());
+        Assert.Equal(2, d.GetProperty("passed").GetInt32());
+        Assert.Equal(0, d.GetProperty("failed").GetInt32());
+        Assert.Equal(0, d.GetProperty("errors").GetInt32());
+        Assert.Equal(0, d.GetProperty("exitCode").GetInt32());
+        Assert.Equal(2, events.Count);
+    }
+}

--- a/AlRunner/DependencyLoader.cs
+++ b/AlRunner/DependencyLoader.cs
@@ -659,24 +659,39 @@ public sealed class DependencyLoader
 
     /// <summary>
     /// Lookup helper for the bundle loop's own-AppGroup dedup check (Program.cs,
-    /// issue #1683): "was this AppId already compiled/loaded earlier in this
-    /// process?" Returns the cached Assembly when <paramref name="name"/>/
-    /// <paramref name="publisher"/>/<paramref name="version"/> match the identity
-    /// already cached for <paramref name="appId"/> — the legitimate same-app-twice
-    /// case, safe to reuse. Returns null when nothing is cached yet for this AppId.
+    /// issue #1683 for the CLI loop, #1892 for --server's per-request bundle loop):
+    /// "was this AppId already compiled/loaded earlier in this process?" Returns
+    /// the cached Assembly when <paramref name="name"/>/<paramref name="publisher"/>/
+    /// <paramref name="version"/> match the identity already cached for
+    /// <paramref name="appId"/> — the legitimate same-app-twice case, safe to reuse.
+    /// Returns null when nothing is cached yet for this AppId.
     /// Throws <see cref="AlRunner.Infrastructure.AppIdCollisionException"/> when an
     /// entry IS cached but its identity does NOT match — two different apps
     /// declaring the same app.json id (issue #1850): silently reusing the earlier
     /// module here would drop every test in <paramref name="sourcePath"/>'s app,
     /// exactly as it did before this check existed.
+    ///
+    /// Also returns null — deliberately NOT a reuse — when the cached entry's own
+    /// <c>SourcePath</c> equals <paramref name="sourcePath"/> (#1892 follow-up,
+    /// caught by ServerTests.RunTests_Then_EditTable_Then_RunAgain_PicksUpChange):
+    /// that is not a genuinely different sibling bundle providing this AppId, it is
+    /// THIS SAME bundle directory being asked about again — server mode's core
+    /// edit-and-rerun contract, where the SAME sourcePath is compiled repeatedly in
+    /// one warm session and each rerun must see any source edit since the last one.
+    /// The CLI loop never hits this branch (a single non-watch invocation visits
+    /// each SuiteDir at most once), so this only narrows the check for the
+    /// caller that genuinely needs it.
     /// </summary>
     public static Assembly? TryGetByAppId(Guid appId, string name, string publisher, string version, string sourcePath)
     {
         if (!_cache.TryGetValue(appId, out var entry)) return null;
-        if (IdentityMatches(entry, name, publisher, version)) return entry.Asm;
-        throw new AlRunner.Infrastructure.AppIdCollisionException(
-            appId, entry.Name, entry.Publisher, entry.Version, entry.SourcePath,
-            name, publisher, version, sourcePath);
+        if (!IdentityMatches(entry, name, publisher, version))
+            throw new AlRunner.Infrastructure.AppIdCollisionException(
+                appId, entry.Name, entry.Publisher, entry.Version, entry.SourcePath,
+                name, publisher, version, sourcePath);
+        if (string.Equals(entry.SourcePath, sourcePath, StringComparison.OrdinalIgnoreCase))
+            return null;
+        return entry.Asm;
     }
 
     /// <summary>
@@ -689,11 +704,21 @@ public sealed class DependencyLoader
     /// issue #1683 (event-subscriber dispatch pairs a MethodInfo from one module's
     /// Type with a subscriberInstance from the other module's Type, throwing
     /// TargetException at ValidateInvokeTarget). First registration for a given AppId
-    /// wins when the identity matches (the earlier module is the one every other
-    /// bundle should keep resolving to). When it does NOT match — a genuine GUID
-    /// collision between two different apps (#1850) that the caller's own
-    /// <see cref="TryGetByAppId"/> check raced past — this throws instead of
-    /// silently keeping the wrong module registered.
+    /// wins when the identity matches AND the registration is for a DIFFERENT
+    /// <paramref name="sourcePath"/> than the one already cached (the earlier module
+    /// is the one every other bundle should keep resolving to). When it does NOT
+    /// match — a genuine GUID collision between two different apps (#1850) that the
+    /// caller's own <see cref="TryGetByAppId"/> check raced past — this throws instead
+    /// of silently keeping the wrong module registered.
+    ///
+    /// When the identity matches AND <paramref name="sourcePath"/> equals the cached
+    /// entry's own SourcePath, this OVERWRITES the entry instead (#1892 follow-up):
+    /// that is not two different bundles racing to register the same AppId, it is the
+    /// SAME bundle re-registering itself after a fresh compile — server mode's
+    /// edit-and-rerun contract, where <see cref="TryGetByAppId"/> deliberately never
+    /// serves a stale reuse for a same-sourcePath lookup (see its own doc comment), so
+    /// each rerun's freshly-compiled module must become the one a LATER sibling
+    /// bundle in a subsequent request resolves to, not whatever compiled first.
     /// </summary>
     public static void RegisterLoaded(Guid appId, Assembly asm, string name, string publisher, string version, string sourcePath)
     {
@@ -704,5 +729,7 @@ public sealed class DependencyLoader
             throw new AlRunner.Infrastructure.AppIdCollisionException(
                 appId, existing.Name, existing.Publisher, existing.Version, existing.SourcePath,
                 name, publisher, version, sourcePath);
+        if (string.Equals(existing.SourcePath, sourcePath, StringComparison.OrdinalIgnoreCase))
+            _cache[appId] = newEntry;
     }
 }

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -2632,6 +2632,12 @@ int RunServerLoop(System.IO.TextReader input, System.IO.TextWriter output)
         IReadOnlyList<(AlRunner.AppManifest Manifest, string AppPath)> ordered =
             Array.Empty<(AlRunner.AppManifest, string)>();
         var appJsonPath = Path.Combine(bucketRoot, "app.json");
+        // Hoisted out of the `if (File.Exists(appJsonPath))` block below so the
+        // cross-bundle module identity dedup (#1892) can read it after this block:
+        // this bundle's OWN identity, used both to check whether an earlier bundle
+        // in this request/session already loaded the same AppId, and to register
+        // THIS bundle's freshly-compiled module under its AppId once loaded.
+        AlRunner.Infrastructure.BundleIdentity? bundleId = null;
         if (File.Exists(appJsonPath))
         {
             try
@@ -2656,7 +2662,7 @@ int RunServerLoop(System.IO.TextReader input, System.IO.TextWriter output)
                     AlRunner.Patches.RecordPatches.AddBcAppPath(appPath);
                 AlRunner.Patches.RecordPatches.RegisterBundleSymbolApps(bucketRoot);
                 SetBundleInfoFromAppJson(appJsonPath);
-                var bundleId = AlRunner.Infrastructure.InProcessAppPackager.ReadIdentity(appJsonPath);
+                bundleId = AlRunner.Infrastructure.InProcessAppPackager.ReadIdentity(appJsonPath);
                 if (bundleId != null)
                     BcCompiler.SetCurrentAppIdentity(bundleId.AppId, bundleId.Publisher, bundleId.Version);
                 else
@@ -2694,6 +2700,45 @@ int RunServerLoop(System.IO.TextReader input, System.IO.TextWriter output)
 
         var moduleName = $"V2_{Path.GetFileName(bundleAbs)}";
 
+        // ── cross-bundle module identity dedup (#1892, mirrors the CLI bundle
+        // loop's own #1683 fix) ──────────────────────────────────────────────
+        // RunAllBundlesForServer runs every sourcePaths entry through THIS method
+        // in order, in the SAME process, sharing the SAME DependencyLoader. If an
+        // earlier bundle in this request already compiled+loaded this bundle's
+        // AppId — either as ITS OWN bundle (this same method, an earlier
+        // iteration) or as a resolved dependency (DependencyLoader.LoadAll) —
+        // reuse that exact Assembly instead of emitting+compiling a second,
+        // distinct module for the same AL app identity. Without this, a sibling
+        // bundle that declares a dependency on THIS bundle's app resolves it via
+        // DependencyLoader's Tier-3 source-compile (a "Dep_..." module) BEFORE
+        // this bundle's own iteration ever runs, or vice versa — either order
+        // ends with two live modules for one AL identity, which is exactly the
+        // TargetException at NavEventSubscription's ValidateInvokeTarget #1683
+        // fixed for the CLI loop: a subscriber MethodInfo discovered from one
+        // module's Type paired with a subscriberInstance BC's dispatcher
+        // materialized from the OTHER module's Type.
+        Assembly? reusedAsm = null;
+        if (bundleId != null)
+        {
+            try
+            {
+                reusedAsm = DependencyLoader.TryGetByAppId(
+                    bundleId.AppId, bundleId.Name, bundleId.Publisher,
+                    bundleId.Version.ToString(), bundleAbs);
+            }
+            catch (AlRunner.Infrastructure.AppIdCollisionException ex)
+            {
+                // Two different apps declare the same app.json id (#1850) — never
+                // silently reuse one app's module for the other's tests.
+                return ServerRunResult.Failure(3, moduleName, $"FATAL: {ex.Message}", fileHashes);
+            }
+            if (reusedAsm != null)
+                Console.Error.WriteLine(
+                    $"  [server] {moduleName}: AppId {bundleId.AppId} already loaded earlier in " +
+                    "this request/session — reusing that module instead of recompiling " +
+                    "(see issue #1683/#1892).");
+        }
+
         // #1888: one app row per server-mode module (this mode never groups several
         // AL apps into one bundled compile the way the CLI's bundled mode does, so
         // "1 of 1" is always correct here). EndApp in the finally below closes it on
@@ -2703,12 +2748,17 @@ int RunServerLoop(System.IO.TextReader input, System.IO.TextWriter output)
         try
         {
             // AL-output cache: HIT short-circuits Emit+Compile, like the normal loop.
+            // Skipped entirely when reusedAsm is already set (see the cross-bundle
+            // dedup check above) — nothing to cache-check, emit, or compile.
             byte[]? assemblyBytes = null;
-            bool cached = false;
+            // A cross-bundle reuse (reusedAsm != null) is "cached" in the sense the
+            // caller cares about — nothing changed for THIS bundle's contribution to
+            // the request, exactly like an AL-output cache hit.
+            bool cached = reusedAsm != null;
             string? cacheKey = null, cachePath = null, sidecarPath = null, querySidecarPath = null;
             // See AlCacheSidecars: a query bundle without its query-symbols sidecar must MISS.
             bool bundleDeclaresQuery = BcCompiler.BundleDeclaresQuery(allPaths);
-            if (alCacheDir != null)
+            if (reusedAsm == null && alCacheDir != null)
             {
                 cacheKey = ComputeAlCacheKey(allPaths, moduleName,
                     ordered: GetOrderedDepIds(bucketRoot, effectivePkgDirs));
@@ -2743,7 +2793,7 @@ int RunServerLoop(System.IO.TextReader input, System.IO.TextWriter output)
             }
 
             var compileErrors = new List<string>();
-            if (assemblyBytes == null)
+            if (reusedAsm == null && assemblyBytes == null)
             {
                 if (alCacheDir != null)
                     AlRunner.Infrastructure.PhaseLog.NoteCacheMiss();
@@ -2826,14 +2876,48 @@ int RunServerLoop(System.IO.TextReader input, System.IO.TextWriter output)
                 }
             }
 
-            if (assemblyBytes == null)
-                return ServerRunResult.Failure(2, moduleName, "no assembly produced", fileHashes);
+            Assembly asm;
+            if (reusedAsm != null)
+            {
+                // See the cross-bundle module identity dedup comment above: this
+                // bundle's AppId was already loaded earlier in this request/session,
+                // so run with that exact Assembly instead of Assembly.Load-ing a
+                // second, distinct module for the same AL identity.
+                asm = reusedAsm;
+            }
+            else
+            {
+                if (assemblyBytes == null)
+                    return ServerRunResult.Failure(2, moduleName, "no assembly produced", fileHashes);
+                asm = Assembly.Load(assemblyBytes);
+                // Register this freshly-loaded module under its AppId so a LATER
+                // bundle in this request/session that resolves the same AppId —
+                // either as its own bundle (this same method, a later iteration) or
+                // as a dependency (DependencyLoader.LoadAll) — reuses this exact
+                // Assembly instead of re-emitting/re-compiling a second module for
+                // the same AL identity (#1892, mirrors the CLI loop's #1683 fix).
+                if (bundleId != null)
+                {
+                    try
+                    {
+                        DependencyLoader.RegisterLoaded(
+                            bundleId.AppId, asm, bundleId.Name, bundleId.Publisher,
+                            bundleId.Version.ToString(), bundleAbs);
+                    }
+                    catch (AlRunner.Infrastructure.AppIdCollisionException ex)
+                    {
+                        // Same defence as the TryGetByAppId check above, for the (in
+                        // this process, one request at a time) race window between
+                        // that check and this registration — see loud-failures.md.
+                        return ServerRunResult.Failure(3, moduleName, $"FATAL: {ex.Message}", fileHashes);
+                    }
+                }
+            }
 
             IReadOnlyList<TestResult> tests;
             var rt = System.Diagnostics.Stopwatch.StartNew();
             try
             {
-                var asm = Assembly.Load(assemblyBytes);
                 BcRuntime.SetTestAssembly(asm);
                 BcRuntime.RegisterTestAssemblyInfo(asm);
                 BcRuntime.OosHooksActive = true;


### PR DESCRIPTION
Closes #1892

## Root cause

`--server`'s `RunBundleForServer` compiles every `sourcePaths` bundle inline via its own `emitter.Emit` + `assembler.Compile` call, but — unlike the CLI's per-`AppGroup` loop (issue #1683) — it never registered the resulting module into `DependencyLoader`'s cross-bundle `AppId` cache. So when one `sourcePaths` entry is an app and a sibling entry declares a dependency on it, the app's own server-mode compile and the sibling's dependency resolution (`DependencyLoader.LoadAll`, via the `RunLayeredPrePass`/`BuildSiblingSourceDeps` pre-pass that stages a synthetic source-only `.app` for the sibling to resolve against) produced **two distinct modules for the same AL app identity** — even though the identical pair compiles into a single module via `al-runner app tests` (CLI mode).

Two live modules for one AL identity is exactly the #1683 signature: the event-subscriber registry pairs a subscriber `MethodInfo` discovered from one module's `Type` with a `subscriberInstance` BC's own dispatcher materializes from the *other* module's `Type`, and `RuntimeMethodInfo.Invoke` throws `TargetException: Object does not match target type` inside `NavEventScope.CallEventSubscriberInternalAsync` → `ValidateInvokeTarget` the moment an install trigger's `Modify(true)` dispatches to the mismatched subscriber.

## Fix

`RunBundleForServer` now:
1. Checks `DependencyLoader.TryGetByAppId` before compiling — if an earlier bundle in the same request/session already loaded this exact AppId, reuse that Assembly.
2. Calls `DependencyLoader.RegisterLoaded` after a fresh compile — so a *later* sibling bundle's dependency resolution reuses this bundle's own module instead of re-compiling a second copy.

This exactly mirrors the CLI loop's existing #1683 machinery, just wired into the server's per-bundle compile path where it was previously missing entirely.

### Regression found and fixed in the same pass

Naively reusing `TryGetByAppId`/`RegisterLoaded` as-is broke server mode's core **edit-and-rerun** contract (`ServerTests.RunTests_Then_EditTable_Then_RunAgain_PicksUpChange`): re-running the *same* bundle directory in a warm session (with source edits since the last run) was wrongly treated as "already loaded, reuse the stale module" — because the same bundle path re-registers its own AppId every time it recompiles, and the CLI's dedup was never exercised against that shape (a single non-watch CLI invocation visits each bundle path at most once).

Fixed by adding a `SourcePath` comparison to both `TryGetByAppId` and `RegisterLoaded`:
- `TryGetByAppId` never serves a reuse when the cached entry's own `SourcePath` equals the caller's `sourcePath` — that's the bundle asking about *itself*, not a genuinely different sibling providing the same AppId.
- `RegisterLoaded` now *overwrites* (rather than first-wins) when the existing entry's `SourcePath` matches the new one — so a same-bundle rerun's freshly-compiled module becomes what a *later* sibling resolves to, not whatever compiled first in the session.

The CLI loop's own behaviour is unaffected — a single non-watch invocation never revisits the same `SuiteDir` for the same AppId, so this narrower check only activates for the caller that needs it.

## Testing

- **RED → GREEN**: added `AlRunner.Tests/ServerCrossBundleModuleIdentityDedupTests.cs`, a runner-specific mechanism test (server-mode multi-bundle wiring / per-emitted-assembly module identity — explicitly named as runner-specific in `bc-behavior-tests-go-upstream.md`, not a corpus concern). It spawns the real runner in `--server` mode with the exact `sourcePaths [app, tests]` shape from the issue (install-trigger + `OnAfterModifyEvent` subscriber). Confirmed RED against the pre-fix binary — fails with `TargetException: Object does not match target type`, naming a `Dep_...` module, matching the issue's own stderr transcript. GREEN after the fix — both tests in the dependent bundle pass, `exitCode: 0`.
- Ran the full server/dedup regression set after the follow-up fix: `ServerTests`, `ServerCrossBundleModuleIdentityDedupTests`, `CrossBundleModuleIdentityDedupTests` (CLI), `ServerStreamingTests`, `ServerCancelTests`, `ServerTestIsolationTests`, `AppIdCollisionLoudFailureTests` — all green (27 tests), including the edit-reload regression that first caught the follow-up bug.

## Protocol / observable-behaviour note

No change to the `--server` JSON-RPC protocol or any client-observable field. The only externally-visible difference is that a `runTests` `sourcePaths` request naming an app + a dependent sibling now returns the same result the identical pair returns via the CLI, instead of `EXEC-FAIL`.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01EU4fwyWDu5CiUrhbPoxAhb

---
_Generated by [Claude Code](https://claude.ai/code/session_01EU4fwyWDu5CiUrhbPoxAhb)_