### PR TITLE
perf(parser): parse each .al file once for all eight extractors, not eight times

### DIFF
--- a/AlRunner.Tests/RecordPatchesAddSourceDirsParseOnceTests.cs
+++ b/AlRunner.Tests/RecordPatchesAddSourceDirsParseOnceTests.cs
@@ -1,0 +1,94 @@
+// RecordPatchesAddSourceDirsParseOnceTests — integration-level companion to
+// RecordPatchesParseOnceTests.cs for #1903.
+//
+// Pins the "N registered files cost N real parses, not 8N" claim at the actual public entry
+// point #1903 names, RecordPatches.AddSourceDirs, through the real BC engine bootstrap — the
+// same engine-backed style RecordPatchesSourceDirBatchTests used for #1833's batching fix.
+// Uses only the public AddSourceDirs API and RecordPatches.ParseObjectTextCallCount (internal,
+// via InternalsVisibleTo — not reflection), so it needs no reflection-by-name access into the
+// parse statics and does not join RecordPatchesSerialCollection.
+//
+// Deliberately kept in ITS OWN FILE, separate from RecordPatchesParseOnceTests.cs:
+// ParserStaticsIsolationGuardTests scans whole FILE text for "TryParse…File" / "_parsed…"
+// reflection-by-name markers and requires every class declared in a flagged file to join
+// RecordPatchesSerialCollection. This class needs BcEngineCollection instead (for
+// BcEngineFixture, which bootstraps the in-process BC engine), so sharing a file with the
+// reflection-driven tests would either force a collection this class doesn't want or trip the
+// guard.
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+[Collection(BcEngineCollection.Name)]
+public sealed class RecordPatchesAddSourceDirsParseOnceTests : IDisposable
+{
+    private readonly string _root;
+    private readonly BcEngineFixture _engine;
+
+    public RecordPatchesAddSourceDirsParseOnceTests(BcEngineFixture engine)
+    {
+        _engine = engine;
+        _root = Path.Combine(Path.GetTempPath(), "al-runner-parse-once-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { /* best-effort cleanup */ }
+    }
+
+    private string WriteTableDir(int tableId, string name)
+    {
+        var dir = Path.Combine(_root, name);
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, $"{name}.al"), $$"""
+            table {{tableId}} "Parse Once Dir {{name}}"
+            {
+                fields
+                {
+                    field(1; "No."; Code[20]) { }
+                }
+                keys
+                {
+                    key(PK; "No.") { Clustered = true; }
+                }
+            }
+            """);
+        return dir;
+    }
+
+    [SkippableFact]
+    public void AddSourceDirs_ParsesEachRegisteredFileOnce_NotEightTimes()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready,
+            _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        var dirs = new[]
+        {
+            WriteTableDir(93750, "A"),
+            WriteTableDir(93751, "B"),
+            WriteTableDir(93752, "C"),
+            WriteTableDir(93753, "D"),
+            WriteTableDir(93754, "E"),
+        };
+
+        var before = RecordPatches.ParseObjectTextCallCount;
+        RecordPatches.AddSourceDirs(dirs);
+        var after = RecordPatches.ParseObjectTextCallCount;
+
+        // 5 files, run through all eight extractors each: before #1903 this cost 40 real
+        // parses (8 per file). The fix brings it to 5 — one real parse per file.
+        Assert.Equal(5, after - before);
+
+        // Content: every file's table is genuinely resolvable — proves the reduced count is
+        // real memoization, not a bug that silently skipped extracting some of the files.
+        var skeleton = AlRunner.BcRuntime.SkeletonNCLMetadata;
+        Assert.NotNull(skeleton);
+        foreach (var id in new[] { 93750, 93751, 93752, 93753, 93754 })
+        {
+            var table = RecordPatches.NCLMetadata_GetMetaTableById(skeleton!, id, false, 0);
+            Assert.Equal(id, table.TableId);
+        }
+    }
+}

--- a/AlRunner.Tests/RecordPatchesParseOnceTests.cs
+++ b/AlRunner.Tests/RecordPatchesParseOnceTests.cs
@@ -1,0 +1,201 @@
+// RecordPatchesParseOnceTests — RED→GREEN guard for #1903.
+//
+// RecordPatches.AddSourceDirs hands each .al file's TEXT to eight extractors
+// (TryParseTableFile / TryParseTableExtensionFile / TryParsePageFile / TryParseReportFile /
+// TryParseQueryFile / TryParseXmlPortFile / TryParseObjectDeclFile / TryParseObjectCaptionFile).
+// Each one is a thin foreach over ParseAlObjects(text), and ParseAlObjects used to build a
+// brand-new BC syntax tree from `text` on EVERY call — so eight IDENTICAL trees were built
+// per file. Measured on a 7,339-file real-world corpus: ~59,000 parses / 29.7s per pass
+// instead of 7,339 parses, and --watch pays that cost every cycle (Register() runs the
+// one-shot pass once; AddSourceDirs' _registered branch is what a watch cycle re-enters).
+//
+// The fix: ParseAlObjects now memoizes the single most-recently-built tree, keyed on
+// (text, active preprocessor symbols). All eight TryParse*File extractors funnel through it
+// on the SAME file text back-to-back (RecordPatches.ParseSourceFileIntoAllExtractors is the
+// shared per-file call site both AddSourceDirs and Register() route every file through), so
+// the second through eighth calls for a given file are cache hits.
+//
+// What these tests pin
+// ---------------------
+//  * MECHANISM (positive) — eight extractors called on the identical text build exactly ONE
+//    real syntax tree (RecordPatches.ParseObjectTextCallCount), not eight. A COUNT, never a
+//    duration — mirrors the discipline RecordPatchesSourceDirBatchTests established for #1833
+//    (PopulateNclMetadataCacheCallCount) and BcCompilerWarmLoaderReuseTests for #1832.
+//  * MECHANISM (negative, the "always answer 1" trap) — the memo is keyed on TEXT, not just
+//    "how many times has this been called": two DIFFERENT files parsed back-to-back still cost
+//    two real parses. An implementation that counted calls instead of comparing text (or that
+//    cached the FIRST tree forever) would pass the positive test above while silently feeding
+//    every file after the first the WRONG parsed content.
+//  * MECHANISM (content) — the memoized path still yields the REAL parsed table, not an empty
+//    stub that would make the call count trivially low for the wrong reason.
+//  * CORRECTNESS (the #1900 regression this exists to prevent) — the SAME text parsed under
+//    two DIFFERENT --define / preprocessor-symbol sets produces two DIFFERENT results. #1900
+//    was a parser that silently stopped seeing --define symbols because AlParseOptions was a
+//    `static readonly` field frozen before BcCompiler.SetExtraPreprocessorSymbols ran (#1907
+//    fixed it by making AlParseOptions a property recomputed per call). A #1903 memo keyed on
+//    text ALONE would reintroduce exactly that bug through a different door: the second call
+//    would silently return the FIRST call's cached tree instead of re-parsing under the new
+//    symbol set. Keying the memo on (text, symbols) — not text alone — is what this test
+//    actually exercises.
+//
+// See RecordPatchesAddSourceDirsParseOnceTests.cs for the companion integration-level test
+// that pins the same claim at the actual public entry point #1903 names (AddSourceDirs),
+// through the real BC engine. It lives in a SEPARATE file on purpose: ParserStaticsIsolation-
+// GuardTests scans whole FILE text for the "TryParse…File" reflection markers below and
+// requires every class in a flagged file to join RecordPatchesSerialCollection — the
+// integration test needs BcEngineCollection (for BcEngineFixture) instead, so it cannot share
+// a file with a class that drives the parsers by reflection.
+//
+// This file drives the real parser via reflection (TryParseTableFile /
+// TryParseTableExtensionFile / …), exactly like AlSourceParserSyntaxTreeTests /
+// AlSourceParserCommentTests, so RecordPatchesParseOnceTests joins RecordPatchesSerialCollection
+// — see ParserStaticsIsolationGuardTests for why: the parsers publish into process-wide static
+// dictionaries and xUnit runs collections in parallel.
+using System.Reflection;
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+[Collection(RecordPatchesSerialCollection.Name)]
+public sealed class RecordPatchesParseOnceTests : IDisposable
+{
+    private static readonly Type RecordPatchesType = typeof(RecordPatches);
+
+    public RecordPatchesParseOnceTests()
+    {
+        // Start every test from a known, empty preprocessor-symbol state so a leftover
+        // --define from another test sharing this serialized collection can't leak in.
+        BcCompiler.SetExtraPreprocessorSymbols(Array.Empty<string>());
+    }
+
+    public void Dispose() => BcCompiler.SetExtraPreprocessorSymbols(Array.Empty<string>());
+
+    private static void InvokeTryParse(string methodName, string text)
+    {
+        var method = RecordPatchesType.GetMethod(methodName, BindingFlags.NonPublic | BindingFlags.Static)!;
+        method.Invoke(null, new object[] { text });
+    }
+
+    private static Dictionary<int, ParsedTable> ParsedTables =>
+        (Dictionary<int, ParsedTable>)RecordPatchesType
+            .GetField("_parsedTables", BindingFlags.NonPublic | BindingFlags.Static)!
+            .GetValue(null)!;
+
+    private static string TableSource(int id, string name) => $$"""
+        table {{id}} "{{name}}"
+        {
+            fields
+            {
+                field(1; "No."; Code[20]) { }
+            }
+            keys
+            {
+                key(PK; "No.") { Clustered = true; }
+            }
+        }
+        """;
+
+    // ── Mechanism ────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void EightExtractors_OnTheSameText_BuildOneSyntaxTree_NotEight()
+    {
+        const int tableId = 61897;
+        var text = TableSource(tableId, "Parse Once Test");
+
+        var before = RecordPatches.ParseObjectTextCallCount;
+
+        // Exactly the eight extractors AddSourceDirs / Register run over one file's text, in
+        // the same order RecordPatches.ParseSourceFileIntoAllExtractors calls them.
+        InvokeTryParse("TryParseTableFile", text);
+        InvokeTryParse("TryParseTableExtensionFile", text);
+        InvokeTryParse("TryParsePageFile", text);
+        InvokeTryParse("TryParseReportFile", text);
+        InvokeTryParse("TryParseQueryFile", text);
+        InvokeTryParse("TryParseXmlPortFile", text);
+        InvokeTryParse("TryParseObjectDeclFile", text);
+        InvokeTryParse("TryParseObjectCaptionFile", text);
+
+        var after = RecordPatches.ParseObjectTextCallCount;
+
+        // Before #1903's fix this was 8 — one SyntaxTree.ParseObjectText build per extractor,
+        // all building the IDENTICAL tree from the IDENTICAL text.
+        Assert.Equal(1, after - before);
+
+        // The memoized path still returns the REAL parsed table — rules out an implementation
+        // that made the count small by returning nothing.
+        Assert.True(ParsedTables.ContainsKey(tableId), $"table {tableId} was not parsed at all");
+        Assert.Contains(ParsedTables[tableId].Fields, f => f.FieldId == 1 && f.FieldName == "No.");
+    }
+
+    [Fact]
+    public void DifferentTextBetweenCalls_StillCostsOneRealParseEach()
+    {
+        const int tableIdA = 61898;
+        const int tableIdB = 61899;
+        var textA = TableSource(tableIdA, "Parse Once A");
+        var textB = TableSource(tableIdB, "Parse Once B");
+
+        var before = RecordPatches.ParseObjectTextCallCount;
+        InvokeTryParse("TryParseTableFile", textA);
+        InvokeTryParse("TryParseTableFile", textB);
+        var after = RecordPatches.ParseObjectTextCallCount;
+
+        // Two DIFFERENT files cost two real parses — the single-slot memo must key on the
+        // TEXT, not merely remember "a parse already happened". An implementation that cached
+        // the first tree forever (or counted calls instead of comparing text) would pass the
+        // positive test above while corrupting every file parsed after the first — this is
+        // exactly that trap, made visible.
+        Assert.Equal(2, after - before);
+        Assert.True(ParsedTables.ContainsKey(tableIdA));
+        Assert.True(ParsedTables.ContainsKey(tableIdB));
+        Assert.Equal("Parse Once A", ParsedTables[tableIdA].TableName);
+        Assert.Equal("Parse Once B", ParsedTables[tableIdB].TableName);
+    }
+
+    // ── Correctness: the memo must not regress #1900 ────────────────────────────────────
+
+    [Fact]
+    public void SameText_DifferentDefineSets_ProducesDifferentFields_NotAStaleCachedTree()
+    {
+        const int tableId = 61900;
+        var text = $$"""
+            table {{tableId}} "Parse Once Define Gated"
+            {
+                fields
+                {
+                    field(1; "No."; Code[20]) { }
+            #if PARSEONCE1903TEST
+                    field(20; "Active Branch"; Text[10]) { }
+            #else
+                    field(21; "Dead Branch"; Text[10]) { }
+            #endif
+                }
+                keys
+                {
+                    key(PK; "No.") { Clustered = true; }
+                }
+            }
+            """;
+
+        // First parse: symbol NOT defined -> the #else branch (field 21) is active.
+        BcCompiler.SetExtraPreprocessorSymbols(Array.Empty<string>());
+        InvokeTryParse("TryParseTableFile", text);
+        var withoutDefine = ParsedTables[tableId];
+        Assert.Contains(withoutDefine.Fields, f => f.FieldId == 21);
+        Assert.DoesNotContain(withoutDefine.Fields, f => f.FieldId == 20);
+
+        // Second parse: the EXACT SAME text string, but the active preprocessor symbol set
+        // has changed -> the #if branch (field 20) must now be active. If the #1903 memo
+        // were keyed on text alone, this call would incorrectly serve the FIRST call's
+        // cached tree (the #else branch) instead of re-parsing — reproducing #1900 (a parser
+        // that silently ignored a changed --define set) through a cache instead of a frozen
+        // field.
+        BcCompiler.SetExtraPreprocessorSymbols(new[] { "PARSEONCE1903TEST" });
+        InvokeTryParse("TryParseTableFile", text);
+        var withDefine = ParsedTables[tableId];
+        Assert.Contains(withDefine.Fields, f => f.FieldId == 20);
+        Assert.DoesNotContain(withDefine.Fields, f => f.FieldId == 21);
+    }
+}

--- a/AlRunner/Patches/RecordPatches.AlObjectCaptionParser.cs
+++ b/AlRunner/Patches/RecordPatches.AlObjectCaptionParser.cs
@@ -63,12 +63,10 @@ public static partial class RecordPatches
     /// </summary>
     private static readonly Dictionary<(string Kind, int Id), string?> _parsedObjectCaptions = new();
 
-    private static void ParseAllObjectCaptionSources()
-    {
-        foreach (var dir in _sourceDirs)
-            foreach (var file in Directory.GetFiles(dir, "*.al", SearchOption.AllDirectories))
-                TryParseObjectCaptionFile(File.ReadAllText(file));
-    }
+    // Register()-time sweep folded into RecordPatches.ParseAllRegisteredSourceFiles (#1903)
+    // — that shared loop calls TryParseObjectCaptionFile alongside the other seven
+    // extractors, one file read per file, instead of this file doing its own separate
+    // directory walk.
 
     private static void TryParseObjectCaptionFile(string text)
     {
@@ -99,7 +97,11 @@ public static partial class RecordPatches
     /// report's Caption, off the same PropertyList it reads the report's ProcessingOnly and
     /// UseRequestPage from (#1714). Routing through here keeps ONE accessor for every
     /// AllObj/AllObjWithCaption kind while there is still only ONE read of the fact — and it
-    /// is ordering-safe, because ParseAllReportSources runs before this parser does.
+    /// is ordering-safe regardless of parse order, because this is a LAZY read of
+    /// _parsedReports at consumption time (some later virtual-table query), well after every
+    /// source dir has finished parsing (#1903 changed HOW parsing is batched — per-file
+    /// across all eight extractors, rather than one global pass per extractor kind — but
+    /// every report is still fully parsed before any caller reaches this accessor).
     /// </summary>
     private static string? SourceCaptionFor(string kind, int id)
         => string.Equals(kind, "Report", StringComparison.OrdinalIgnoreCase)

--- a/AlRunner/Patches/RecordPatches.AlObjectDeclParser.cs
+++ b/AlRunner/Patches/RecordPatches.AlObjectDeclParser.cs
@@ -40,15 +40,9 @@ public static partial class RecordPatches
     // per-object-type (codeunit 50100 and enum 50100 may coexist).
     private static readonly Dictionary<(string Kind, int Id), ParsedAlObjectDecl> _parsedObjectDecls = new();
 
-    private static void ParseAllObjectDeclSources()
-    {
-        foreach (var dir in _sourceDirs)
-        {
-            var files = Directory.GetFiles(dir, "*.al", SearchOption.AllDirectories);
-            foreach (var file in files)
-                TryParseObjectDeclFile(File.ReadAllText(file));
-        }
-    }
+    // Register()-time sweep folded into RecordPatches.ParseAllRegisteredSourceFiles (#1903)
+    // — that shared loop calls TryParseObjectDeclFile alongside the other seven extractors,
+    // one file read per file, instead of this file doing its own separate directory walk.
 
     private static void TryParseObjectDeclFile(string text)
     {

--- a/AlRunner/Patches/RecordPatches.AlPageParser.cs
+++ b/AlRunner/Patches/RecordPatches.AlPageParser.cs
@@ -25,15 +25,9 @@ namespace AlRunner.Patches;
 
 public static partial class RecordPatches
 {
-    private static void ParseAllPageSources()
-    {
-        foreach (var dir in _sourceDirs)
-        {
-            var files = Directory.GetFiles(dir, "*.al", SearchOption.AllDirectories);
-            foreach (var file in files)
-                TryParsePageFile(File.ReadAllText(file));
-        }
-    }
+    // Register()-time sweep folded into RecordPatches.ParseAllRegisteredSourceFiles (#1903)
+    // — that shared loop calls TryParsePageFile alongside the other seven extractors, one
+    // file read per file, instead of this file doing its own separate directory walk.
 
     private static void TryParsePageFile(string text)
     {

--- a/AlRunner/Patches/RecordPatches.AlQueryParser.cs
+++ b/AlRunner/Patches/RecordPatches.AlQueryParser.cs
@@ -16,15 +16,9 @@ namespace AlRunner.Patches;
 
 public static partial class RecordPatches
 {
-    private static void ParseAllQuerySources()
-    {
-        foreach (var dir in _sourceDirs)
-        {
-            var files = Directory.GetFiles(dir, "*.al", SearchOption.AllDirectories);
-            foreach (var file in files)
-                TryParseQueryFile(File.ReadAllText(file));
-        }
-    }
+    // Register()-time sweep folded into RecordPatches.ParseAllRegisteredSourceFiles (#1903)
+    // — that shared loop calls TryParseQueryFile alongside the other seven extractors, one
+    // file read per file, instead of this file doing its own separate directory walk.
 
     private static void TryParseQueryFile(string text)
     {

--- a/AlRunner/Patches/RecordPatches.AlReportParser.cs
+++ b/AlRunner/Patches/RecordPatches.AlReportParser.cs
@@ -19,15 +19,9 @@ namespace AlRunner.Patches;
 
 public static partial class RecordPatches
 {
-    private static void ParseAllReportSources()
-    {
-        foreach (var dir in _sourceDirs)
-        {
-            var files = Directory.GetFiles(dir, "*.al", SearchOption.AllDirectories);
-            foreach (var file in files)
-                TryParseReportFile(File.ReadAllText(file));
-        }
-    }
+    // Register()-time sweep folded into RecordPatches.ParseAllRegisteredSourceFiles (#1903)
+    // — that shared loop calls TryParseReportFile alongside the other seven extractors, one
+    // file read per file, instead of this file doing its own separate directory walk.
 
 
     private static void TryParseReportFile(string text)

--- a/AlRunner/Patches/RecordPatches.AlSourceParser.cs
+++ b/AlRunner/Patches/RecordPatches.AlSourceParser.cs
@@ -183,19 +183,36 @@ public static partial class RecordPatches
         string.Equals(PropValue(list, name)?.ToString()?.Trim(), expected,
             StringComparison.OrdinalIgnoreCase);
 
-    private static void ParseAllSources()
-    {
-        foreach (var dir in _sourceDirs)
-        {
-            var files = Directory.GetFiles(dir, "*.al", SearchOption.AllDirectories);
-            foreach (var file in files)
-            {
-                var text = File.ReadAllText(file);
-                TryParseTableFile(text);
-                TryParseTableExtensionFile(text);
-            }
-        }
-    }
+    // Single-slot memo of the most recently built syntax tree's object list, keyed on the
+    // exact (text, active preprocessor symbols) pair that produced it. #1903: the eight
+    // TryParse*File extractors (table, tableextension, page, report, query, xmlport,
+    // object-decl, object-caption) each call ParseAlObjects on the SAME file text
+    // back-to-back — RecordPatches.ParseSourceFileIntoAllExtractors is the shared call
+    // site both AddSourceDirs and Register() route every file through — so remembering
+    // only the LAST parse turns 8 identical tree builds per file into 1 real build plus 7
+    // cache hits, with no change to AlParseOptions, to any TryParse*File signature, or to
+    // the eight extractors' own code.
+    //
+    // The key is (text, symbols), never text alone. #1900 was exactly a parser that
+    // silently stopped seeing --define symbols (a `static readonly` field froze the
+    // preprocessor set at type-init before BcCompiler.SetExtraPreprocessorSymbols ran). A
+    // memo keyed on text alone would reproduce that bug through a different door: two
+    // calls for the same text under two different --define sets would incorrectly share
+    // one cached tree. AlParseOptions (see above) is still recomputed on every miss:
+    // caching here changes WHEN a tree is (re)built, never what determines whether it
+    // must be.
+    private static string? _lastParsedText;
+    private static string[]? _lastParsedSymbols;
+    private static IReadOnlyList<NavCA.SyntaxNode> _lastParsedObjects = Array.Empty<NavCA.SyntaxNode>();
+
+    /// <summary>
+    /// Number of times <see cref="ParseAlObjects"/> has actually built a syntax tree (a real
+    /// <c>SyntaxTree.ParseObjectText</c> call), as opposed to serving the single-slot memo
+    /// above. #1903's proving test asserts THIS — a count, never a duration — to pin that N
+    /// files registered through the eight extractors costs N tree builds, not 8N. Mirrors
+    /// the discipline <see cref="PopulateNclMetadataCacheCallCount"/> established for #1833.
+    /// </summary>
+    internal static int ParseObjectTextCallCount { get; private set; }
 
     /// <summary>
     /// Parses every AL object in <paramref name="text"/> with BC's own parser and returns the
@@ -208,18 +225,41 @@ public static partial class RecordPatches
     private static IReadOnlyList<NavCA.SyntaxNode> ParseAlObjects(string? text)
     {
         if (string.IsNullOrWhiteSpace(text)) return [];
+
+        // GetExtraPreprocessorSymbols() is a lock plus a sorted copy of a handful of
+        // strings (see AlParseOptions above) — cheap enough to call on every ParseAlObjects
+        // invocation just to test the memo key, including on the 7-out-of-8 calls that end
+        // up being cache hits.
+        var symbols = AlRunner.BcCompiler.GetExtraPreprocessorSymbols().ToArray();
+        if (_lastParsedText == text && _lastParsedSymbols != null &&
+            symbols.AsSpan().SequenceEqual(_lastParsedSymbols))
+        {
+            return _lastParsedObjects;
+        }
+
         try
         {
+            ParseObjectTextCallCount++;
             var tree = NavSyntax.SyntaxTree.ParseObjectText(
                 text, path: "", encoding: null!, AlParseOptions, default);
-            if (tree.GetRoot() is not NavSyntax.CompilationUnitSyntax root) return [];
-            return root.ChildNodes().ToList();
+            IReadOnlyList<NavCA.SyntaxNode> objects = tree.GetRoot() is NavSyntax.CompilationUnitSyntax root
+                ? root.ChildNodes().ToList()
+                : Array.Empty<NavCA.SyntaxNode>();
+            _lastParsedText = text;
+            _lastParsedSymbols = symbols;
+            _lastParsedObjects = objects;
+            return objects;
         }
         catch
         {
             // A malformed input is not a runner gap — the AL simply is not parseable, and the
             // caller's contract is "extract what you can". Callers that need a table and do
-            // not get one already report that themselves ("AL source not parsed").
+            // not get one already report that themselves ("AL source not parsed"). Don't let
+            // a failed parse poison the memo as if it were this (text, symbols) pair's real
+            // answer — clear the slot so the NEXT call (for unrelated input) can't accidentally
+            // key-match leftover state from before the exception.
+            _lastParsedText = null;
+            _lastParsedSymbols = null;
             return [];
         }
     }

--- a/AlRunner/Patches/RecordPatches.AlXmlPortParser.cs
+++ b/AlRunner/Patches/RecordPatches.AlXmlPortParser.cs
@@ -11,15 +11,9 @@ namespace AlRunner.Patches;
 
 public static partial class RecordPatches
 {
-    private static void ParseAllXmlPortSources()
-    {
-        foreach (var dir in _sourceDirs)
-        {
-            var files = Directory.GetFiles(dir, "*.al", SearchOption.AllDirectories);
-            foreach (var file in files)
-                TryParseXmlPortFile(File.ReadAllText(file));
-        }
-    }
+    // Register()-time sweep folded into RecordPatches.ParseAllRegisteredSourceFiles (#1903)
+    // — that shared loop calls TryParseXmlPortFile alongside the other seven extractors, one
+    // file read per file, instead of this file doing its own separate directory walk.
 
     private static void TryParseXmlPortFile(string text)
     {

--- a/AlRunner/Patches/RecordPatches.NclMetadataCachePopulator.cs
+++ b/AlRunner/Patches/RecordPatches.NclMetadataCachePopulator.cs
@@ -9,7 +9,7 @@
 //      pre-allocates empty ConcurrentDictionary entries per ObjectType.
 //   2. RecordPatches.Register() parses every .al source dir registered so far
 //      via TryParseTableFile → _parsedTables.
-//   3. After ParseAllSources, this populator iterates _parsedTables, calls the
+//   3. After ParseAllRegisteredSourceFiles, this populator iterates _parsedTables, calls the
 //      existing BuildNCLMetaTable(int) factory (which uses NCLMetaTable's
 //      internal CreateFromMetaTable), wraps each result in
 //      NCLMetadataCacheEntry.CreateWithBase, and inserts it into the skeleton

--- a/AlRunner/Patches/RecordPatches.cs
+++ b/AlRunner/Patches/RecordPatches.cs
@@ -148,6 +148,55 @@ public static partial class RecordPatches
     public static void AddSourceDir(string dir) => AddSourceDirs(new[] { dir });
 
     /// <summary>
+    /// Runs all eight source extractors (table, tableextension, page, report, query,
+    /// xmlport, object-decl, object-caption) over ONE already-read file's text (#1903).
+    /// <para>
+    /// Before this, <see cref="AddSourceDirs"/>' per-file loop called all eight directly —
+    /// each extractor is a thin foreach over <c>ParseAlObjects(text)</c>, which built its
+    /// OWN full AL syntax tree from the same text. A source tree of N files therefore cost
+    /// 8N parses of eight IDENTICAL trees, measured on a 7,339-file real-world corpus as
+    /// ~59,000 parses / 29.7s per pass instead of 7,339 parses. <see cref="ParseAlObjects"/>
+    /// now memoizes its most-recently-built tree keyed on (text, active preprocessor
+    /// symbols) — see the comment there — so calling the eight extractors back-to-back on
+    /// the SAME text, as both callers below do, costs one real parse plus seven cache hits.
+    /// </para>
+    /// <para>
+    /// The (text, symbols) key is deliberate, not an oversight: #1900 was caused by a
+    /// parser that stopped seeing <c>--define</c> symbols because a field FROZE at
+    /// type-init before <c>BcCompiler.SetExtraPreprocessorSymbols</c> ran. A cache keyed on
+    /// text alone would reintroduce that bug silently — two calls for the same text under
+    /// different <c>--define</c> sets are a genuinely different parse, not a cache hit.
+    /// </para>
+    /// </summary>
+    private static void ParseSourceFileIntoAllExtractors(string text)
+    {
+        TryParseTableFile(text);
+        TryParseTableExtensionFile(text);
+        TryParsePageFile(text);
+        TryParseReportFile(text);
+        TryParseQueryFile(text);
+        TryParseXmlPortFile(text);
+        TryParseObjectDeclFile(text);
+        TryParseObjectCaptionFile(text);
+    }
+
+    /// <summary>
+    /// The Register()-time equivalent of <see cref="AddSourceDirs"/>' per-file loop: one
+    /// pass over every registered source dir, reading each file's text exactly once and
+    /// running all eight extractors on it via <see cref="ParseSourceFileIntoAllExtractors"/>
+    /// (#1903). This replaced seven independent sweeps (one per extractor kind), each of
+    /// which re-walked every source dir and re-read every file from disk on its own — 7
+    /// directory walks + 7 file reads + (with the old un-memoized parser) 8 tree builds per
+    /// file, instead of 1 of each.
+    /// </summary>
+    private static void ParseAllRegisteredSourceFiles()
+    {
+        foreach (var dir in _sourceDirs)
+            foreach (var file in Directory.GetFiles(dir, "*.al", SearchOption.AllDirectories))
+                ParseSourceFileIntoAllExtractors(File.ReadAllText(file));
+    }
+
+    /// <summary>
     /// Register N source dirs and populate the NCLMetadata cache ONCE for the whole
     /// batch, instead of once per dir (#1833). <see cref="AddSourceDir"/> delegates
     /// here with a single-element array so its per-call-populate semantics are
@@ -181,30 +230,23 @@ public static partial class RecordPatches
             // SAME dependency source dir twice — once while matching declared deps to sibling
             // source apps, once while emitting the synthetic workspace .app for a dep that
             // needs a fresh build. Without this guard the same dir lands twice in _sourceDirs,
-            // so ParseAllSources() parses its .al files twice on the next Register()/rebuild.
-            // For a dependency that declares a `tableextension` on a table whose base metadata
-            // comes from elsewhere (e.g. a platform-app table), that duplicated every extension
-            // field id in _parsedExtensionFields — see #1686. The dedup here is defense in depth
-            // alongside the field-id dedup in TryParseTableExtensionFile.
+            // so ParseAllRegisteredSourceFiles() parses its .al files twice on the next
+            // Register()/rebuild. For a dependency that declares a `tableextension` on a
+            // table whose base metadata comes from elsewhere (e.g. a platform-app table),
+            // that duplicated every extension field id in _parsedExtensionFields — see #1686.
+            // The dedup here is defense in depth alongside the field-id dedup in
+            // TryParseTableExtensionFile.
             if (_sourceDirs.Contains(dir, StringComparer.OrdinalIgnoreCase)) continue;
             _sourceDirs.Add(dir);
             // If Register() already ran (it runs before the bucket loop), parse immediately.
             // The NCLMetadata cache is populated once below, after every dir in this batch
-            // has been parsed — see the batching rationale on the doc comment above.
+            // has been parsed — see the batching rationale on the doc comment above. Every
+            // .al file's text is read ONCE and handed to all eight extractors together
+            // (#1903) — see ParseSourceFileIntoAllExtractors.
             if (_registered)
             {
                 foreach (var file in Directory.GetFiles(dir, "*.al", SearchOption.AllDirectories))
-                {
-                    var text = File.ReadAllText(file);
-                    TryParseTableFile(text);
-                    TryParseTableExtensionFile(text);
-                    TryParsePageFile(text);
-                    TryParseReportFile(text);
-                    TryParseQueryFile(text);
-                    TryParseXmlPortFile(text);
-                    TryParseObjectDeclFile(text);
-                    TryParseObjectCaptionFile(text);
-                }
+                    ParseSourceFileIntoAllExtractors(File.ReadAllText(file));
                 parsedAny = true;
             }
         }
@@ -396,18 +438,11 @@ public static partial class RecordPatches
         _collationComparer = BuildCollationAwareComparer();
         Console.Error.WriteLine($"[RecordPatches] Collation comparer built: {_collationComparer?.GetType().Name ?? "null"}");
 
-        // Parse AL source files (tables + pages + reports — same set of dirs).
-        ParseAllSources();
-        ParseAllPageSources();
-        ParseAllReportSources();
-        ParseAllQuerySources();
-        ParseAllXmlPortSources();
-        // Codeunits / enums / *extension objects — (id, name) only, for AllObj
-        // (2000000038). See RecordPatches.AlObjectDeclParser.cs.
-        ParseAllObjectDeclSources();
-        // Caption property of every source object of any kind, for AllObjWithCaption
-        // (2000000058). See RecordPatches.AlObjectCaptionParser.cs.
-        ParseAllObjectCaptionSources();
+        // Parse AL source files (tables + tableextensions + pages + reports + queries +
+        // xmlports + object decls (AllObj) + object captions (AllObjWithCaption)) — see
+        // ParseAllRegisteredSourceFiles for why this is ONE pass over _sourceDirs rather
+        // than seven (#1903).
+        ParseAllRegisteredSourceFiles();
 
         // NCL-internal system tables (RecordLink=2000000068, Field=2000000041, …)
         // live as AL source embedded in Microsoft.BusinessCentral.SystemApp.dll's

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -4011,8 +4011,8 @@ static List<string> BuildSiblingSourceDeps(List<string> bundles, List<string> pa
         // field to "Item Journal Batch") get merged into the base table's NCLMetaTable.
         // Without this, runtime field lookup throws "extension field N not found in
         // NCLMetaTable". This runs before RecordPatches.Register(), so the dir is parsed
-        // by ParseAllSources during Register (not immediately). Compile-time visibility is
-        // handled separately by the symbols.json emit below.
+        // during Register (not immediately) — see ParseAllRegisteredSourceFiles.
+        // Compile-time visibility is handled separately by the symbols.json emit below.
         AlRunner.Patches.RecordPatches.AddSourceDir(dir);
         var appFileName = $"{Sanitize(sid.Publisher)}_{Sanitize(sid.Name)}_{sid.Version.ToString().Replace('.', '_')}.app";
         var outPath = Path.Combine(wsDir, appFileName);


### PR DESCRIPTION
Closes #1903

## Problem

`RecordPatches.AddSourceDirs` handed each `.al` file's text to eight
extractors (`TryParseTableFile` / `TryParseTableExtensionFile` /
`TryParsePageFile` / `TryParseReportFile` / `TryParseQueryFile` /
`TryParseXmlPortFile` / `TryParseObjectDeclFile` / `TryParseObjectCaptionFile`).
Each one is a thin `foreach` over `ParseAlObjects(text)`, and `ParseAlObjects`
built a brand-new BC syntax tree from `text` on **every** call — eight
identical trees per file. `Register()`'s one-shot startup pass made this
worse: it ran seven independent sweeps, each re-walking every source dir and
re-reading every file from disk on its own (7 directory walks + 7 file reads
+ 8×N tree builds, instead of 1 of each).

Since `_registered` never resets and `--watch` clears/re-adds `_sourceDirs`
every cycle, `AddSourceDirs`' `_registered` branch is what a warm watch cycle
re-enters — so this cost was paid on every cycle, not just once per process.

## Fix

`ParseAlObjects` now memoizes the single most-recently-built tree, keyed on
**(text, active preprocessor symbols)**. All eight extractors — via a new
shared per-file call site, `RecordPatches.ParseSourceFileIntoAllExtractors`
— call `ParseAlObjects` on the same file's text back-to-back, so the first
call is a real parse and the other seven are cache hits. `Register()`'s
seven separate sweeps were folded into one shared loop,
`ParseAllRegisteredSourceFiles`, that routes through the same call site —
so its one-time startup pass gets the same win, plus drops the 6 redundant
directory walks / file reads.

No `TryParse*File` signature changed (all still take `string text`), so the
~15 existing test files that drive them by reflection are untouched.

**The (text, symbols) key is deliberate**, not incidental: #1900 (fixed in
#1907, merged just before this PR was opened) was a parser that silently
stopped seeing `--define` symbols because `AlParseOptions` was a
`static readonly` field frozen before `BcCompiler.SetExtraPreprocessorSymbols`
ran. A memo keyed on text alone would reintroduce that exact bug through a
different door — two calls for the same text under different `--define` sets
would incorrectly share one cached tree. `AlParseOptions` itself is untouched
(still recomputed on every real parse); the memo only changes *when* a tree
is rebuilt, never *whether* it must be.

## Tests

- `AlRunner.Tests/RecordPatchesParseOnceTests.cs` (joins
  `RecordPatchesSerialCollection`, no BC engine needed):
  - `EightExtractors_OnTheSameText_BuildOneSyntaxTree_NotEight` — RED→GREEN
    mechanism proof via `RecordPatches.ParseObjectTextCallCount` (a count,
    never a duration, mirroring `PopulateNclMetadataCacheCallCount` from
    #1833). **Verified RED**: temporarily disabling the memo check locally
    reproduces `Expected: 1, Actual: 8` — exactly the issue's claimed 8×.
  - `DifferentTextBetweenCalls_StillCostsOneRealParseEach` — negative
    control: the memo must key on the actual text, not just "a parse
    happened" — two different files still cost two real parses.
  - `SameText_DifferentDefineSets_ProducesDifferentFields_NotAStaleCachedTree`
    — the #1900 regression guard this task called out: the identical text
    string parsed under two different `--define` sets must produce two
    different results (a `#if`/`#else` field-number swap), never a stale
    cached tree from the first call.
- `AlRunner.Tests/RecordPatchesAddSourceDirsParseOnceTests.cs` (separate
  file — see its header comment for why; `ParserStaticsIsolationGuardTests`
  scans whole-file text for the reflection markers above and would otherwise
  force this class into the wrong collection): integration-level proof at
  the actual `AddSourceDirs` entry point named in the issue, through the
  real BC engine (mirrors `RecordPatchesSourceDirBatchTests`' style for
  #1833). Skips locally (BC engine bootstrap fails in this sandbox — same
  pre-existing skip as `RecordPatchesSourceDirBatchTests`), runs for real in
  CI where the engine is provisioned.

Full `AlRunner.Tests` suite: **686 passed, 0 failed, 23 skipped** (same skip
set as `origin/main`, all engine-provisioning related).

## Measured numbers

I do not have the reporter's 7,339-file NP Retail corpus available in this
environment, so I can't reproduce the headline 29.7s→7.0–7.9s figure
directly. What I could measure locally, honestly reported as a lower bound
(a minimal 3-field synthetic table is cheaper to tree-build than a typical
real file, so the relative win understates the real-corpus number):

- 2000 synthetic 3-field table files, run through all eight extractors each
  (matching `AddSourceDirs`' per-file dispatch exactly):
  - Memo disabled (8 real parses/file, the pre-fix shape): **1078ms**
  - Memo enabled (1 real parse/file + 7 cache hits, this PR): **426ms**
  - ~2.5× on this synthetic file; real `.al` files (more fields, comments,
    actual page/report/query bodies) cost more per tree build, so the
    relative win should be larger on the reporter's corpus, consistent with
    the reported ~4× — but that is inference, not something I measured
    directly.

## Sanity check against a real bundle

Ran the built runner (`--bc-version 28.1.49838.50794 --package-cache
~/.al-runner/platform-apps`) against `tests/runner-extras/esm-xapp-table`,
`install-trigger-seed`, `install-trigger-text-constant` (all involving
dependency loading / tableextension-adjacent parsing): 4/4 tests pass,
identical output to before the change.

I also hit a pre-existing failure in `tests/runner-extras/dep-tableext-invoke-main`
("extension field 10 from extension 60701 not found in NCLMetaTable DEX Base
Table") — verified this reproduces **identically** on unmodified `origin/main`
(same error, same behavior, just a different source line number), so it is
unrelated to this change and not something this PR should fix or hide.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EU4fwyWDu5CiUrhbPoxAhb)_