### PR TITLE
Give BC's compiler a file system so ControlAddIn resources resolve

### DIFF
--- a/AlRunner.Tests/ControlAddInFileSystemTests.cs
+++ b/AlRunner.Tests/ControlAddInFileSystemTests.cs
@@ -1,0 +1,133 @@
+// ControlAddInFileSystemTests — BcCompiler.Emit must resolve ControlAddIn resource files.
+//
+// Root cause being guarded
+// -------------------------
+// BC's compiler reads non-AL files (Scripts/StartupScript/StyleSheets/Images) through an
+// injected IFileSystem. BcCompiler.Emit never supplied one, so the compiler could not
+// resolve ANY control-add-in resource path — AL0327 "Missing file" fired for every such
+// declaration EVEN WHEN THE FILE EXISTS at the declared path, case-exact. This is latent
+// on a healthy project (Emit succeeds anyway, so it goes unnoticed), but it turns fatal
+// the moment any unrelated object fails to bind: the emit-retry loop treats the add-in's
+// AL0327 as a real compile error and excludes its whole source tree along with the
+// genuinely broken one, so the add-in's tests silently vanish from the run. See issue
+// #1899 for the full reproduction (COMPILE FAIL, 0 tests run, exit 3, for a project where
+// only ONE object was actually broken).
+//
+// Fix: BcCompiler.Emit / EmitDepSymbols now accept an `appRootDir` (the directory holding
+// the app's own app.json — NOT the src/ subfolder `alFolders` carries) and attach
+// `compilation.WithFileSystem(new NavCA.RelativeFileSystem(appRootDir))` at every
+// Compilation.Create site (primary compile, emit-retry compile, dependency-symbol
+// compile), so resource paths declared relative to the app root resolve correctly.
+//
+// Test strategy
+// -------------
+// Exercise BcCompiler.Emit directly (mirrors BcCompilerEmitRetryTests) with a minimal
+// ControlAddIn declaring both `StartupScript` and `Scripts`, and assert on the returned
+// BcEmitOutput.Diagnostics — which carries every AL0327 the compile produced (BcCompiler.cs
+// folds compilation.GetDeclarationDiagnostics() into it unconditionally, not just under a
+// diagnostic env var). Both directions:
+//   - Positive: files present at the declared paths, app root supplied -> no AL0327 at all.
+//   - Negative: a declaration pointing at a file that genuinely does not exist must still
+//     raise AL0327 naming that file — a fix that unconditionally silences AL0327 (instead
+//     of resolving real paths) would pass the positive case AND hide real typos, which is
+//     explicitly worse than the original bug.
+//   - Regression guard: the SAME valid-resource fixture with appRootDir omitted (null)
+//     must still raise AL0327 — proving the fix is the file system wiring itself, not
+//     some incidental change that would make the positive test pass on its own.
+
+using Xunit;
+
+namespace AlRunner.Tests;
+
+[Collection(BcEngineCollection.Name)]
+public sealed class ControlAddInFileSystemTests : IDisposable
+{
+    private readonly string _root;
+    private readonly BcEngineFixture _engine;
+
+    public ControlAddInFileSystemTests(BcEngineFixture engine)
+    {
+        _engine = engine;
+        _root = Path.Combine(Path.GetTempPath(), "al-runner-controladdin-fs-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { /* best-effort cleanup */ }
+    }
+
+    private void WriteControlAddIn(string startupScriptRelPath, string scriptsRelPath)
+    {
+        File.WriteAllText(Path.Combine(_root, "Widget.al"), $$"""
+            controladdin "CAS Widget"
+            {
+                StartupScript = '{{startupScriptRelPath}}';
+                Scripts = '{{scriptsRelPath}}';
+
+                RequestedHeight = 100;
+                RequestedWidth = 200;
+
+                procedure Refresh(Payload: Text);
+                event OnWidgetReady();
+            }
+            """);
+    }
+
+    [SkippableFact]
+    public void Emit_ValidControlAddInResources_ProducesNoAL0327()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready,
+            _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        Directory.CreateDirectory(Path.Combine(_root, "addin"));
+        File.WriteAllText(Path.Combine(_root, "addin", "startup.js"), "function StartupScriptMarker() { return 'cas'; }");
+        File.WriteAllText(Path.Combine(_root, "addin", "widget.js"), "function WidgetMarker() { return 'cas'; }");
+        WriteControlAddIn("addin/startup.js", "addin/widget.js");
+
+        var output = new BcCompiler().Emit(new[] { _root }, "ControlAddInFsTestModule", _root);
+
+        Assert.DoesNotContain(output.Diagnostics, d => d.Contains("AL0327"));
+    }
+
+    [SkippableFact]
+    public void Emit_MissingControlAddInResource_StillRaisesAL0327()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready,
+            _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        Directory.CreateDirectory(Path.Combine(_root, "addin"));
+        // Only widget.js exists; startup.js is a genuine typo/missing file.
+        File.WriteAllText(Path.Combine(_root, "addin", "widget.js"), "function WidgetMarker() { return 'cas'; }");
+        WriteControlAddIn("addin/does-not-exist.js", "addin/widget.js");
+
+        var output = new BcCompiler().Emit(new[] { _root }, "ControlAddInFsTestModule", _root);
+
+        var al0327 = output.Diagnostics.Where(d => d.Contains("AL0327")).ToList();
+        Assert.True(al0327.Count > 0,
+            $"Expected AL0327 for a genuinely missing resource file, got none. All diagnostics: " +
+            $"{string.Join(" | ", output.Diagnostics)}");
+        Assert.Contains(al0327, d => d.Contains("does-not-exist.js"));
+    }
+
+    [SkippableFact]
+    public void Emit_ValidControlAddInResources_WithoutAppRootDir_StillRaisesAL0327()
+    {
+        // Regression guard: proves the fix is the file-system wiring (anchored at the app
+        // root), not something that happens to make AL0327 disappear unconditionally. With
+        // NO app root supplied (the pre-fix call shape), the SAME valid-resource fixture
+        // that passes above must still fail — otherwise the fix could be a no-op stub that
+        // always suppresses AL0327, which would hide real missing-file typos.
+        TestArtifacts.SkipIf(!_engine.Ready,
+            _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        Directory.CreateDirectory(Path.Combine(_root, "addin"));
+        File.WriteAllText(Path.Combine(_root, "addin", "startup.js"), "function StartupScriptMarker() { return 'cas'; }");
+        File.WriteAllText(Path.Combine(_root, "addin", "widget.js"), "function WidgetMarker() { return 'cas'; }");
+        WriteControlAddIn("addin/startup.js", "addin/widget.js");
+
+        var output = new BcCompiler().Emit(new[] { _root }, "ControlAddInFsTestModule"); // appRootDir omitted
+
+        Assert.Contains(output.Diagnostics, d => d.Contains("AL0327"));
+    }
+}

--- a/AlRunner/BcCompiler.cs
+++ b/AlRunner/BcCompiler.cs
@@ -1288,7 +1288,19 @@ public sealed class BcCompiler
         catch { /* best-effort warm — never block compilation */ }
     }
 
-    public BcEmitOutput Emit(IEnumerable<string> alFolders, string moduleName)
+    /// <param name="appRootDir">
+    /// The directory containing this app's own app.json — NOT <paramref name="alFolders"/>
+    /// (which is typically the src/ subdirectory). BC's compiler needs an <c>IFileSystem</c>
+    /// to resolve ControlAddIn resource paths (<c>Scripts</c>, <c>StartupScript</c>,
+    /// <c>StyleSheets</c>, <c>Images</c>) — those are declared relative to the app root, e.g.
+    /// <c>src/addin/startup.js</c>, not relative to the src/ folder itself. Without a file
+    /// system, BC cannot resolve ANY such path and raises AL0327 "Missing file" for every
+    /// declaration, even when the file is present at the declared path — see issue #1899.
+    /// Null is accepted (skips WithFileSystem entirely) for callers that don't have a known
+    /// app root, e.g. dependency compiles staging synthetic AL into a temp dir with no
+    /// resource files anyway.
+    /// </param>
+    public BcEmitOutput Emit(IEnumerable<string> alFolders, string moduleName, string? appRootDir = null)
     {
         var dirs = alFolders.Where(Directory.Exists).Distinct().ToList();
         if (dirs.Count == 0)
@@ -1345,6 +1357,15 @@ public sealed class BcCompiler
             appId: appId,
             syntaxTrees: trees,
             options: compOpts);
+
+        // #1899: give the compiler a file-access abstraction anchored at the APP ROOT
+        // (where app.json lives), not `dirs` (the src/ subdirectory this method receives
+        // as alFolders). Without an IFileSystem, BC's compiler cannot resolve ANY
+        // ControlAddIn resource path (Scripts/StartupScript/StyleSheets/Images) and raises
+        // AL0327 "Missing file" for every declaration, even when the file exists exactly
+        // where declared. RelativeFileSystem is a public BC API — no new dependency.
+        if (appRootDir != null && Directory.Exists(appRootDir))
+            compilation = compilation.WithFileSystem(new NavCA.RelativeFileSystem(appRootDir));
 
         // Suite-local .alpackages (rare in v2's corpus today, but cheap to honour).
         var bundleAlpackages = dirs
@@ -1526,6 +1547,11 @@ public sealed class BcCompiler
                     appId: appId,
                     syntaxTrees: retryTrees,
                     options: compOpts);
+                // #1899: same file system as the primary compile above — without it, a
+                // retry after excluding an unrelated broken object would still raise AL0327
+                // for a perfectly-resolvable ControlAddIn resource and could exclude it too.
+                if (appRootDir != null && Directory.Exists(appRootDir))
+                    retryCompilation = retryCompilation.WithFileSystem(new NavCA.RelativeFileSystem(appRootDir));
                 if (refLoader != null)
                 {
                     retryCompilation = retryCompilation.WithReferenceLoader(refLoader);
@@ -1822,9 +1848,17 @@ public sealed class BcCompiler
     /// only shipped a symbol-less synthetic .app before, hence AL0185). The
     /// Compilation is created with the dep's REAL identity so the loader indexes it.
     /// </summary>
+    /// <param name="appRootDir">
+    /// The directory containing this dep's own app.json — see the identically-named
+    /// parameter on <see cref="Emit"/> for why (#1899). When omitted, falls back to
+    /// whichever of <paramref name="alFolders"/> already carries an app.json — the same
+    /// directory <c>ivtRefs</c> below is read from — since every current caller of this
+    /// overload passes a single flat directory that already IS the app root.
+    /// </param>
     public void EmitDepSymbols(
         IEnumerable<string> alFolders, string moduleName,
-        Guid appId, string publisher, Version version, string symbolsJsonPath)
+        Guid appId, string publisher, Version version, string symbolsJsonPath,
+        string? appRootDir = null)
     {
         var dirs = alFolders.Where(Directory.Exists).Distinct().ToList();
         var alFiles = dirs
@@ -1855,12 +1889,20 @@ public sealed class BcCompiler
         // this dedicated Create parameter — not from the manifest — so without it a
         // dependent app hits AL0161 on the dep's Access=Internal members even when the
         // grant exists. (main:Program.cs BuildInternalsVisibleToRefs.)
-        var ivtRefs = ReadInternalsVisibleToRefs(
-            dirs.Select(d => Path.Combine(d, "app.json")).FirstOrDefault(File.Exists));
+        var foundAppJson = dirs.Select(d => Path.Combine(d, "app.json")).FirstOrDefault(File.Exists);
+        var ivtRefs = ReadInternalsVisibleToRefs(foundAppJson);
 
         var compilation = NavCA.Compilation.Create(
             moduleName: moduleName, publisher: publisher, version: version,
             appId: appId, internalsVisibleTo: ivtRefs, syntaxTrees: trees, options: compOpts);
+
+        // #1899: same rationale as Emit's appRootDir — without an IFileSystem, a
+        // ControlAddIn inside a source dependency raises AL0327 for every resource path.
+        // Falls back to the directory the manifest was already found in (foundAppJson)
+        // when the caller didn't pass one explicitly.
+        var effectiveAppRoot = appRootDir ?? (foundAppJson != null ? Path.GetDirectoryName(foundAppJson) : null);
+        if (effectiveAppRoot != null && Directory.Exists(effectiveAppRoot))
+            compilation = compilation.WithFileSystem(new NavCA.RelativeFileSystem(effectiveAppRoot));
 
         var bundleAlpackages = dirs
             .SelectMany(d => Directory.EnumerateDirectories(d, ".alpackages", SearchOption.AllDirectories))

--- a/AlRunner/DependencyLoader.cs
+++ b/AlRunner/DependencyLoader.cs
@@ -406,7 +406,7 @@ public sealed class DependencyLoader
         // the PARENT bundle) would be both in the reference list AND in the primary AL
         // source → AL0275 "ambiguous reference". The scope is restored on dispose.
         try { using (BcCompiler.ScopeCurrentAppIdentity(m.AppId, m.Publisher, m.Version))
-                  emitted = _compiler.Emit(new[] { tempDir }, m.Name).Sources; }
+                  emitted = _compiler.Emit(new[] { tempDir }, m.Name, tempDir).Sources; }
         catch (Exception ex)
         {
             // EMIT-FAIL: the BC Compilation.Emit() call threw (e.g. "Unexpected value 'None'

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -1430,7 +1430,7 @@ foreach (var bundle in bundles)
             // .deps-bin path, neither of which this scope touches. Same filter EmitDepSymbols
             // already applies — see BcCompiler.ScopeSymbolBearingDepsOnly.
             using var bundleDepScope = BcCompiler.ScopeSymbolBearingDepsOnly();
-            var emitTask = Task.Run(() => emitter.Emit(allPaths, moduleName));
+            var emitTask = Task.Run(() => emitter.Emit(allPaths, moduleName, appGroup.SuiteDir));
             try
             {
                 if (!emitTask.Wait(TimeSpan.FromSeconds(emitTimeoutSec)))
@@ -1810,7 +1810,7 @@ foreach (var bundle in bundles)
             IReadOnlyList<string> suiteAlDiagnostics = Array.Empty<string>();
             try
             {
-                var emitOutput = emitter.Emit(suitePaths, $"V2_{Path.GetFileName(suite)}");
+                var emitOutput = emitter.Emit(suitePaths, $"V2_{Path.GetFileName(suite)}", suite);
                 sources = emitOutput.Sources;
                 suiteAlDiagnostics = emitOutput.Diagnostics;
             }
@@ -2803,7 +2803,7 @@ int RunServerLoop(System.IO.TextReader input, System.IO.TextWriter output)
                 var et = System.Diagnostics.Stopwatch.StartNew();
                 try
                 {
-                    var emitOutput = emitter.Emit(allPaths, moduleName);
+                    var emitOutput = emitter.Emit(allPaths, moduleName, bucketRoot);
                     sources = emitOutput.Sources;
                     alDiagnostics = emitOutput.Diagnostics;
                     excludedObjects = emitOutput.ExcludedObjects;
@@ -3562,7 +3562,7 @@ static int RunPrecompile(string[] subArgs)
     BcEmitOutput emitOut;
     try
     {
-        emitOut = compiler.Emit(new[] { tempDir }, manifest.Name);
+        emitOut = compiler.Emit(new[] { tempDir }, manifest.Name, tempDir);
     }
     catch (Exception ex)
     {
@@ -3880,7 +3880,7 @@ static List<string> RunLayeredPrePass(List<string> bundles, List<string> package
                 var implDeps = implResolver.Resolve(implId.Dependencies);
                 BcCompiler.SetResolvedDeps(implDeps, implSymbolDirs);
                 using (BcCompiler.ScopeCurrentAppIdentity(implId.AppId, implId.Publisher, implId.Version))
-                    new BcCompiler().EmitDepSymbols(new[] { implPath }, implId.Name, implId.AppId, implId.Publisher, implId.Version, symbolsPath);
+                    new BcCompiler().EmitDepSymbols(new[] { implPath }, implId.Name, implId.AppId, implId.Publisher, implId.Version, symbolsPath, implPath);
                 // Declare the FULL compile closure — the resolved deps (real AppIds/versions)
                 // UNIONed with the Microsoft platform apps vendored in the impl's own
                 // .alpackages. Filtering to non-Optional declared deps drops the implicit
@@ -4143,7 +4143,7 @@ static List<string> BuildSiblingSourceDeps(List<string> bundles, List<string> pa
             try
             {
                 using (BcCompiler.ScopeCurrentAppIdentity(sid.AppId, sid.Publisher, sid.Version))
-                    new BcCompiler().EmitDepSymbols(new[] { dir }, sid.Name, sid.AppId, sid.Publisher, sid.Version, symbolsPath);
+                    new BcCompiler().EmitDepSymbols(new[] { dir }, sid.Name, sid.AppId, sid.Publisher, sid.Version, symbolsPath, dir);
                 // Full compile closure (resolved deps ∪ vendored platform apps) — see the
                 // impl-bundle site above and #1546. Filtering to non-Optional declared deps
                 // would drop the implicit platform roots whose types appear in this dep's
@@ -4492,7 +4492,7 @@ static void EmitSiblingSymbols(
                 new BcCompiler().EmitDepSymbols(
                     group.Paths, group.ModuleName, group.AppId.Value,
                     group.Publisher ?? "AlRunner", group.Version ?? new Version(1, 0, 0, 0),
-                    symbolsPath);
+                    symbolsPath, group.SuiteDir);
             // The dependency closure this app compiled against, so BC's ReferenceManager can
             // link types from it that appear in the sibling's public surface — same reason as
             // the source-dep sidecar (#1546); without it those types are __MissingTypeSymbol__.


### PR DESCRIPTION
Closes #1899

## Problem

`BcCompiler` never passed an `IFileSystem` into `Compilation.Create`, so BC's compiler could not resolve any control-add-in resource path (`Scripts`, `StartupScript`, `StyleSheets`, `Images`). AL0327 "Missing file" fired for **every** such declaration, even when the file existed exactly where declared. This was latent on a healthy project (the diagnostic is tolerated, `Emit` still succeeds), but turns fatal the moment any unrelated object fails to bind: the emit-retry loop treats AL0327 as a real compile error and excludes the add-in's whole source tree alongside the genuinely broken object, so the add-in's tests silently vanish from the run.

## Fix

Threaded an `appRootDir` parameter (the directory holding the app's own `app.json` — **not** the `src/` subfolder `alFolders` carries) through `BcCompiler.Emit` and `BcCompiler.EmitDepSymbols`, and attached `compilation.WithFileSystem(new NavCA.RelativeFileSystem(appRootDir))` at all three `Compilation.Create` sites named in the issue:

- `BcCompiler.cs` primary compile
- `BcCompiler.cs` emit-retry compile (so a retry after excluding an unrelated broken object doesn't *also* raise AL0327 for the add-in and drag it down too)
- `BcCompiler.cs` `EmitDepSymbols` (dependency-symbol compile)

Updated every call site that knows its app root to pass it: the per-`AppGroup` bundled-CLI loop (`appGroup.SuiteDir`), the non-bundled/per-suite loop (`suite`), server mode (`bucketRoot`), `--precompile`, `DependencyLoader`, and the two `EmitDepSymbols` sibling/impl callers. `EmitDepSymbols` also falls back to the app.json directory it already discovers internally (for `ivtRefs`) when no explicit root is passed, so no caller regresses.

`RelativeFileSystem` is a public BC API (`Microsoft.Dynamics.Nav.CodeAnalysis.RelativeFileSystem(string root)`) — no new dependency, nothing hand-implemented.

## Testing

`AlRunner.Tests/ControlAddInFileSystemTests.cs` (alongside `BcCompilerEmitRetryTests`/`EmitExclusionLoudnessTests`), exercising `BcCompiler.Emit` directly:

- **Positive** (`Emit_ValidControlAddInResources_ProducesNoAL0327`): a `ControlAddIn` with `StartupScript`/`Scripts` pointing at files that exist, app root supplied — asserts `BcEmitOutput.Diagnostics` contains no `AL0327`. RED before the fix (verified locally by temporarily neutering the primary `WithFileSystem` call — the positive test failed with `AL0327` present, the other two below still passed), GREEN after.
- **Negative** (`Emit_MissingControlAddInResource_StillRaisesAL0327`): same shape but `StartupScript` points at a genuinely missing file — asserts `AL0327` naming that specific file is still raised. A fix that unconditionally suppressed AL0327 (instead of resolving real paths) would pass the positive case and hide real path typos — this test rules that out.
- **Regression guard** (`Emit_ValidControlAddInResources_WithoutAppRootDir_StillRaisesAL0327`): the same valid-resource fixture with `appRootDir` omitted still raises `AL0327` — proves the fix is the file-system wiring itself, not an incidental change.

Ran locally (BC 28.1.49838.50794):
- `dotnet test AlRunner.Tests` (with the in-process BC engine wired via `DOTNET_STARTUP_HOOKS`, mirroring `test-matrix.yml`): **709/709 pass**, 0 skipped.
- The exact issue reproduction (Run 1 + Run 2 from the issue body): Run 1 (clean project) now shows `declDiags=0` — the previously-always-present AL0327 is gone, both tests pass, exit 0. Run 2 (clean project + one genuinely broken unrelated codeunit) now excludes **only** `Broken.Codeunit`, not `Widget.ControlAddIn` — the core bug (the add-in getting wrongly swept up in the exclusion) is fixed.
- Full `tests/al-language` corpus: **2076/2076 pass**, exit 0.
- Full `tests/runner-extras`: **123/123 pass**, exit 0.

### One deliberate divergence from the issue's acceptance-criteria wording

The issue's acceptance criteria say Run 2 should "exit 0 with both tests passing." With this fix, Run 2 still exits non-zero (`COMPILE FAIL`) because the runner's `EMIT-EXCLUDED` policy (see `EmitExclusionLoudnessTests.cs` and `.claude/rules/loud-failures.md`) treats **any** excluded object as a hard bucket failure, unconditionally — not only when the excluded object itself declared tests. That policy is intentional, pre-existing, and orthogonal to this fix: excluding `Broken.Codeunit` (a real compile error, unrelated to the add-in) is still correctly reported as a failure, exactly as it would be for any other genuinely broken object in a bundle. What this fix eliminates is the **spurious** exclusion of `Widget.ControlAddIn` alongside it — verified above, only one object is now excluded instead of two, and the clean-project case (no broken object) exits 0 with both tests passing, matching the first acceptance-criteria bullet exactly.

## Scope

Per `docs/scope.md`/`loud-failures.md`, this only makes the compiler **resolve and validate** declared resource paths — it does not attempt to execute add-in JS/CSS in-process (no browser, no page rendering; that remains out of scope).


---
_Generated by [Claude Code](https://claude.ai/code/session_01EU4fwyWDu5CiUrhbPoxAhb)_