### PR TITLE
perf(tests): share one --server process per class instead of one per fact

### DIFF
--- a/AlRunner.Tests/CliServer.cs
+++ b/AlRunner.Tests/CliServer.cs
@@ -25,6 +25,19 @@ public sealed class CliServer : IAsyncDisposable
     private readonly Process _process;
     private readonly StringBuilder _stderr = new();
 
+    /// <summary>
+    /// #1804: how many times <see cref="StartAsync"/> has actually called
+    /// <c>Process.Start</c> in this test-worker process, since assembly load.
+    /// Process-wide, so it is a diagnostic only — xUnit runs different test
+    /// classes' spawns concurrently with each other (different collections),
+    /// so a delta read around one test's own spawns can be inflated by another
+    /// class spawning at the same moment. The actual proving assertion in
+    /// SharedCliServerTests.cs uses <see cref="SharedCliServer.SpawnCount"/>
+    /// instead, which is scoped to one fixture instance and immune to that.
+    /// </summary>
+    public static int StartCount => _startCount;
+    private static int _startCount;
+
     private CliServer(Process process)
     {
         _process = process;
@@ -79,6 +92,7 @@ public sealed class CliServer : IAsyncDisposable
                 psi.EnvironmentVariables[kv.Key] = kv.Value;
 
         var proc = Process.Start(psi)!;
+        System.Threading.Interlocked.Increment(ref _startCount);
 
         var server = new CliServer(proc);
         // Drain stderr on a background task so its pipe buffer never fills and

--- a/AlRunner.Tests/ServerStreamingTests.cs
+++ b/AlRunner.Tests/ServerStreamingTests.cs
@@ -18,10 +18,18 @@ namespace AlRunner.Tests;
 /// [Collection("server-serial")] and no longer is — #1809.
 ///
 /// #1804: all three facts share ONE server process via SharedCliServer instead
-/// of spawning their own — each uses a distinct fixed app ID, none needs a
-/// different --cache/startup flag from the others, and none tears the process
-/// down, so the three conditions SharedCliServer's doc comment requires all
-/// hold here.
+/// of spawning their own. None needs a different --cache/startup flag from the
+/// others and none tears the process down (conditions (a)/(b) of
+/// SharedCliServer's doc comment). Condition (c) — distinct app IDs — is
+/// enforced by giving <see cref="MakeMixedBundle"/> a <c>variant</c>: a shared
+/// server process caches a compiled module by AppId for the process's whole
+/// lifetime (<c>DependencyLoader.TryGetByAppId</c>) and reuses it for ANY later
+/// request whose bundle reports the same AppId at a different SourcePath,
+/// regardless of content — so two facts calling this bundle generator with the
+/// SAME AppId would (harmlessly, while the content happens to stay identical,
+/// but not safely in general) share one compiled module instead of each
+/// genuinely compiling its own. See ServerTestIsolationTests' class doc
+/// comment for the same point made at more length.
 /// </summary>
 public class ServerStreamingTests : IClassFixture<SharedCliServer>
 {
@@ -31,25 +39,28 @@ public class ServerStreamingTests : IClassFixture<SharedCliServer>
 
     // One passing test, one failing test (with a recognisable Error() message) —
     // exercises both status branches of the streamed `test` event shape.
-    private static string MakeMixedBundle()
+    // `variant` gives each call site its own AppId (last hex digit) and object
+    // ID (offset by variant*10 from 60200) — see the class doc comment.
+    private static string MakeMixedBundle(int variant)
     {
         var dir = Path.Combine(Path.GetTempPath(), "al-runner-server-streaming", Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(dir);
-        File.WriteAllText(Path.Combine(dir, "app.json"), """
+        var baseId = 60200 + variant * 10;
+        File.WriteAllText(Path.Combine(dir, "app.json"), $$"""
         {
-          "id": "a1b2c3d4-e5f6-4708-a9ba-cbdcedfe0f11",
-          "name": "Runner Extras - Server Streaming Probe",
+          "id": "a1b2c3d4-e5f6-4708-a9ba-cbdcedfe0f1{{variant:x1}}",
+          "name": "Runner Extras - Server Streaming Probe {{variant}}",
           "publisher": "AL Runner",
           "version": "1.0.0.0",
           "dependencies": [],
           "platform": "1.0.0.0",
           "application": "1.0.0.0",
-          "idRanges": [ { "from": 60200, "to": 60209 } ],
+          "idRanges": [ { "from": {{baseId}}, "to": {{baseId + 9}} } ],
           "runtime": "14.0"
         }
         """);
-        File.WriteAllText(Path.Combine(dir, "StreamingTest.Codeunit.al"), """
-        codeunit 60200 "Server Streaming Probe SX"
+        File.WriteAllText(Path.Combine(dir, "StreamingTest.Codeunit.al"), $$"""
+        codeunit {{baseId}} "Server Streaming Probe SX {{variant}}"
         {
             Subtype = Test;
 
@@ -81,7 +92,7 @@ public class ServerStreamingTests : IClassFixture<SharedCliServer>
     {
         TestArtifacts.SkipIfMissing();
 
-        var bundle = MakeMixedBundle();
+        var bundle = MakeMixedBundle(variant: 0);
         var server = await _fixture.GetAsync();
 
         var lines = await server.SendRequestStreamingAsync(RunTestsReq(bundle));
@@ -110,7 +121,7 @@ public class ServerStreamingTests : IClassFixture<SharedCliServer>
         Assert.Equal("runtime", fail.GetProperty("errorKind").GetString());
         var frames = fail.GetProperty("stackFrames");
         Assert.Equal(1, frames.GetArrayLength());
-        Assert.Equal("\"Server Streaming Probe SX\"(CodeUnit 60200).FailingTest",
+        Assert.Equal("\"Server Streaming Probe SX 0\"(CodeUnit 60200).FailingTest",
                      frames[0].GetProperty("name").GetString());
         Assert.Equal(2, frames[0].GetProperty("line").GetInt32());
         Assert.Equal("normal", frames[0].GetProperty("presentationHint").GetString());
@@ -145,7 +156,7 @@ public class ServerStreamingTests : IClassFixture<SharedCliServer>
     {
         TestArtifacts.SkipIfMissing();
 
-        var bundle = MakeMixedBundle();
+        var bundle = MakeMixedBundle(variant: 1);
         var server = await _fixture.GetAsync();
 
         // execute (run-mode) is unaffected by the streaming change — still one

--- a/AlRunner.Tests/ServerStreamingTests.cs
+++ b/AlRunner.Tests/ServerStreamingTests.cs
@@ -16,9 +16,18 @@ namespace AlRunner.Tests;
 ///
 /// See DefineFlagIntegrationTests for why this used to be
 /// [Collection("server-serial")] and no longer is — #1809.
+///
+/// #1804: all three facts share ONE server process via SharedCliServer instead
+/// of spawning their own — each uses a distinct fixed app ID, none needs a
+/// different --cache/startup flag from the others, and none tears the process
+/// down, so the three conditions SharedCliServer's doc comment requires all
+/// hold here.
 /// </summary>
-public class ServerStreamingTests
+public class ServerStreamingTests : IClassFixture<SharedCliServer>
 {
+    private readonly SharedCliServer _fixture;
+
+    public ServerStreamingTests(SharedCliServer fixture) => _fixture = fixture;
 
     // One passing test, one failing test (with a recognisable Error() message) —
     // exercises both status branches of the streamed `test` event shape.
@@ -73,8 +82,7 @@ public class ServerStreamingTests
         TestArtifacts.SkipIfMissing();
 
         var bundle = MakeMixedBundle();
-        var cacheDir = Path.Combine(Path.GetTempPath(), "al-runner-server-streaming-cache", Guid.NewGuid().ToString("N"));
-        await using var server = await CliServer.StartAsync(new[] { "--cache", cacheDir });
+        var server = await _fixture.GetAsync();
 
         var lines = await server.SendRequestStreamingAsync(RunTestsReq(bundle));
 
@@ -121,7 +129,7 @@ public class ServerStreamingTests
     {
         TestArtifacts.SkipIfMissing();
 
-        await using var server = await CliServer.StartAsync();
+        var server = await _fixture.GetAsync();
         var lines = await server.SendRequestStreamingAsync(
             JsonSerializer.Serialize(new { command = "runTests" }));
 
@@ -138,8 +146,7 @@ public class ServerStreamingTests
         TestArtifacts.SkipIfMissing();
 
         var bundle = MakeMixedBundle();
-        var cacheDir = Path.Combine(Path.GetTempPath(), "al-runner-server-streaming-exec-cache", Guid.NewGuid().ToString("N"));
-        await using var server = await CliServer.StartAsync(new[] { "--cache", cacheDir });
+        var server = await _fixture.GetAsync();
 
         // execute (run-mode) is unaffected by the streaming change — still one
         // v1-shaped response line, no "type" discriminator.

--- a/AlRunner.Tests/ServerTestIsolationTests.cs
+++ b/AlRunner.Tests/ServerTestIsolationTests.cs
@@ -13,16 +13,26 @@ namespace AlRunner.Tests;
 /// See DefineFlagIntegrationTests for why this used to be
 /// [Collection("server-serial")] and no longer is — #1809.
 ///
-/// #1804: all four facts share ONE server process via SharedCliServer. The
-/// third fact (RunTests_TestIsolationDoesNotStickAcrossRequests) already
-/// proved same-process, multiple-request behaviour is correct before this
-/// change — this class extends that same proven pattern to all four facts,
-/// not a new risk. Every fact's bundle carries the same fixed app ID
-/// (MakeIsolationBundle), which is fine: the AL-output compile cache keys on
-/// content, testIsolation is a per-request runtime field never baked into the
-/// compiled cache entry, so repeat compiles of identical content across facts
-/// just mean later facts get compile-cache HITs — it does not change what any
-/// assertion observes.
+/// #1804: all four facts share ONE server process via SharedCliServer.
+///
+/// #1804 review follow-up: this class's bundle generator now takes a
+/// <c>variant</c> so each of the five call sites (four facts, one of them —
+/// RunTests_TestIsolationDoesNotStickAcrossRequests — calling it twice)
+/// produces a DISTINCT app ID and object-ID range, not the one originally
+/// hardcoded id shared by all of them. That is not cosmetic:
+/// <c>DependencyLoader.TryGetByAppId</c> (see DependencyLoader.cs) caches a
+/// compiled module by AppId for the lifetime of the SERVER PROCESS, and
+/// returns the cached module for any LATER request whose bundle reports a
+/// matching AppId at a DIFFERENT SourcePath — regardless of whether that
+/// bundle's actual source content differs. Sharing one server process across
+/// facts (this class's whole point) means every fact's request now runs
+/// through that same process-lifetime cache, so a shared AppId across facts
+/// would mean fact 2+ silently gets fact 1's compiled module back instead of
+/// its own — harmless today only because every call site happened to produce
+/// byte-identical content, and a live bug the moment anyone edits one call
+/// site's table/codeunit body without also touching the others. Distinct
+/// AppIds per call site route every fact through a genuine fresh compile
+/// instead of resting on that coincidence.
 /// </summary>
 public class ServerTestIsolationTests : IClassFixture<SharedCliServer>
 {
@@ -35,25 +45,31 @@ public class ServerTestIsolationTests : IClassFixture<SharedCliServer>
     // inside one codeunit), the second Insert must fail with a duplicate-key error.
     // Under TestIsolation.Test ("test"/"method"), state resets before every [Test]
     // proc, so both Insert calls succeed independently.
-    private static string MakeIsolationBundle()
+    //
+    // `variant` gives each call site its own AppId (last hex digit) and its own
+    // object-ID range (offset by variant*10 from the base 60170) — see the class
+    // doc comment for why a shared AppId across call sites is unsafe once facts
+    // share a server process.
+    private static string MakeIsolationBundle(int variant)
     {
         var dir = Path.Combine(Path.GetTempPath(), "al-runner-server-isolation", Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(dir);
-        File.WriteAllText(Path.Combine(dir, "app.json"), """
+        var baseId = 60170 + variant * 10;
+        File.WriteAllText(Path.Combine(dir, "app.json"), $$"""
         {
-          "id": "f3a4b5c6-d7e8-4f90-a1b2-c3d4e5f60718",
-          "name": "Runner Extras - Server Isolation Probe",
+          "id": "f3a4b5c6-d7e8-4f90-a1b2-c3d4e5f6071{{variant:x1}}",
+          "name": "Runner Extras - Server Isolation Probe {{variant}}",
           "publisher": "AL Runner",
           "version": "1.0.0.0",
           "dependencies": [],
           "platform": "1.0.0.0",
           "application": "1.0.0.0",
-          "idRanges": [ { "from": 60170, "to": 60179 } ],
+          "idRanges": [ { "from": {{baseId}}, "to": {{baseId + 9}} } ],
           "runtime": "14.0"
         }
         """);
-        File.WriteAllText(Path.Combine(dir, "IsoTable.Table.al"), """
-        table 60170 "Server Isolation Probe Tbl"
+        File.WriteAllText(Path.Combine(dir, "IsoTable.Table.al"), $$"""
+        table {{baseId}} "Server Isolation Probe Tbl {{variant}}"
         {
             fields
             {
@@ -62,15 +78,15 @@ public class ServerTestIsolationTests : IClassFixture<SharedCliServer>
             keys { key(PK; "Code") { Clustered = true; } }
         }
         """);
-        File.WriteAllText(Path.Combine(dir, "IsoTest.Codeunit.al"), """
-        codeunit 60170 "Server Isolation Probe SX"
+        File.WriteAllText(Path.Combine(dir, "IsoTest.Codeunit.al"), $$"""
+        codeunit {{baseId}} "Server Isolation Probe SX {{variant}}"
         {
             Subtype = Test;
 
             [Test]
             procedure InsertsFixedKey_First()
             var
-                Rec: Record "Server Isolation Probe Tbl";
+                Rec: Record "Server Isolation Probe Tbl {{variant}}";
             begin
                 Rec.Init();
                 Rec."Code" := 'FIXED';
@@ -80,7 +96,7 @@ public class ServerTestIsolationTests : IClassFixture<SharedCliServer>
             [Test]
             procedure InsertsFixedKey_Second()
             var
-                Rec: Record "Server Isolation Probe Tbl";
+                Rec: Record "Server Isolation Probe Tbl {{variant}}";
             begin
                 Rec.Init();
                 Rec."Code" := 'FIXED';
@@ -105,7 +121,7 @@ public class ServerTestIsolationTests : IClassFixture<SharedCliServer>
     {
         TestArtifacts.SkipIfMissing();
 
-        var bundle = MakeIsolationBundle();
+        var bundle = MakeIsolationBundle(variant: 0);
         var server = await _fixture.GetAsync();
 
         var lines = await server.SendRequestStreamingAsync(Req(bundle, testIsolation: null));
@@ -121,7 +137,7 @@ public class ServerTestIsolationTests : IClassFixture<SharedCliServer>
     {
         TestArtifacts.SkipIfMissing();
 
-        var bundle = MakeIsolationBundle();
+        var bundle = MakeIsolationBundle(variant: 1);
         var server = await _fixture.GetAsync();
 
         var lines = await server.SendRequestStreamingAsync(Req(bundle, testIsolation: "method"));
@@ -141,8 +157,8 @@ public class ServerTestIsolationTests : IClassFixture<SharedCliServer>
         // request 1.
         TestArtifacts.SkipIfMissing();
 
-        var bundle1 = MakeIsolationBundle();
-        var bundle2 = MakeIsolationBundle();
+        var bundle1 = MakeIsolationBundle(variant: 2);
+        var bundle2 = MakeIsolationBundle(variant: 3);
         var server = await _fixture.GetAsync();
 
         var lines1 = await server.SendRequestStreamingAsync(Req(bundle1, testIsolation: "method"));
@@ -160,7 +176,7 @@ public class ServerTestIsolationTests : IClassFixture<SharedCliServer>
     {
         TestArtifacts.SkipIfMissing();
 
-        var bundle = MakeIsolationBundle();
+        var bundle = MakeIsolationBundle(variant: 4);
         var server = await _fixture.GetAsync();
 
         var r = await server.SendAsync(Req(bundle, testIsolation: "bogus"));

--- a/AlRunner.Tests/ServerTestIsolationTests.cs
+++ b/AlRunner.Tests/ServerTestIsolationTests.cs
@@ -12,9 +12,23 @@ namespace AlRunner.Tests;
 ///
 /// See DefineFlagIntegrationTests for why this used to be
 /// [Collection("server-serial")] and no longer is — #1809.
+///
+/// #1804: all four facts share ONE server process via SharedCliServer. The
+/// third fact (RunTests_TestIsolationDoesNotStickAcrossRequests) already
+/// proved same-process, multiple-request behaviour is correct before this
+/// change — this class extends that same proven pattern to all four facts,
+/// not a new risk. Every fact's bundle carries the same fixed app ID
+/// (MakeIsolationBundle), which is fine: the AL-output compile cache keys on
+/// content, testIsolation is a per-request runtime field never baked into the
+/// compiled cache entry, so repeat compiles of identical content across facts
+/// just mean later facts get compile-cache HITs — it does not change what any
+/// assertion observes.
 /// </summary>
-public class ServerTestIsolationTests
+public class ServerTestIsolationTests : IClassFixture<SharedCliServer>
 {
+    private readonly SharedCliServer _fixture;
+
+    public ServerTestIsolationTests(SharedCliServer fixture) => _fixture = fixture;
 
     // Two [Test] procs in the SAME codeunit both insert a row with the SAME primary
     // key. Under TestIsolation.Codeunit (the default — no reset between methods
@@ -92,8 +106,7 @@ public class ServerTestIsolationTests
         TestArtifacts.SkipIfMissing();
 
         var bundle = MakeIsolationBundle();
-        var cacheDir = Path.Combine(Path.GetTempPath(), "al-runner-server-isolation-cache", Guid.NewGuid().ToString("N"));
-        await using var server = await CliServer.StartAsync(new[] { "--cache", cacheDir });
+        var server = await _fixture.GetAsync();
 
         var lines = await server.SendRequestStreamingAsync(Req(bundle, testIsolation: null));
         var (_, d) = ProtocolV2Streaming.Split(lines);
@@ -109,8 +122,7 @@ public class ServerTestIsolationTests
         TestArtifacts.SkipIfMissing();
 
         var bundle = MakeIsolationBundle();
-        var cacheDir = Path.Combine(Path.GetTempPath(), "al-runner-server-isolation-cache2", Guid.NewGuid().ToString("N"));
-        await using var server = await CliServer.StartAsync(new[] { "--cache", cacheDir });
+        var server = await _fixture.GetAsync();
 
         var lines = await server.SendRequestStreamingAsync(Req(bundle, testIsolation: "method"));
         var (_, d) = ProtocolV2Streaming.Split(lines);
@@ -131,8 +143,7 @@ public class ServerTestIsolationTests
 
         var bundle1 = MakeIsolationBundle();
         var bundle2 = MakeIsolationBundle();
-        var cacheDir = Path.Combine(Path.GetTempPath(), "al-runner-server-isolation-cache3", Guid.NewGuid().ToString("N"));
-        await using var server = await CliServer.StartAsync(new[] { "--cache", cacheDir });
+        var server = await _fixture.GetAsync();
 
         var lines1 = await server.SendRequestStreamingAsync(Req(bundle1, testIsolation: "method"));
         var (_, d1) = ProtocolV2Streaming.Split(lines1);
@@ -150,8 +161,7 @@ public class ServerTestIsolationTests
         TestArtifacts.SkipIfMissing();
 
         var bundle = MakeIsolationBundle();
-        var cacheDir = Path.Combine(Path.GetTempPath(), "al-runner-server-isolation-cache4", Guid.NewGuid().ToString("N"));
-        await using var server = await CliServer.StartAsync(new[] { "--cache", cacheDir });
+        var server = await _fixture.GetAsync();
 
         var r = await server.SendAsync(Req(bundle, testIsolation: "bogus"));
         var d = JsonSerializer.Deserialize<JsonElement>(r);

--- a/AlRunner.Tests/ServerTests.cs
+++ b/AlRunner.Tests/ServerTests.cs
@@ -15,9 +15,24 @@ namespace AlRunner.Tests;
 ///
 /// See DefineFlagIntegrationTests for why this used to be
 /// [Collection("server-serial")] and no longer is — #1809.
+///
+/// #1804: four of the five facts share ONE server process via SharedCliServer.
+/// <see cref="Shutdown_RespondsThenProcessExits"/> is the deliberate exception:
+/// it exists specifically to prove the shutdown protocol command tears the
+/// process down, so it cannot use the shared instance (doing so would kill the
+/// process the other facts in this class still need) and keeps its own
+/// dedicated <c>CliServer.StartAsync</c> call. It used to be the tail end of
+/// <see cref="RunTests_Then_EditTable_Then_RunAgain_PicksUpChange"/>, which
+/// combined a cache-behaviour claim and a process-lifecycle claim in one
+/// method; splitting them is what makes the cache-behaviour half safe to move
+/// onto a server other facts also use.
 /// </summary>
-public class ServerTests
+public class ServerTests : IClassFixture<SharedCliServer>
 {
+    private readonly SharedCliServer _fixture;
+
+    public ServerTests(SharedCliServer fixture) => _fixture = fixture;
+
     // The fixture bundle: a table whose OnInsert trigger reads xRec and a test
     // that asserts the resulting Counter value. Copied to a temp dir per test so
     // edits never touch the repo.
@@ -50,10 +65,9 @@ public class ServerTests
         TestArtifacts.SkipIfMissing();
 
         var bundle = MakeTempBundle();
-        var cacheDir = Path.Combine(Path.GetTempPath(), "al-runner-server-tests-cache", Guid.NewGuid().ToString("N"));
         var tablePath = Path.Combine(bundle, "XRecProbe.Table.al");
 
-        await using var server = await CliServer.StartAsync(new[] { "--cache", cacheDir });
+        var server = await _fixture.GetAsync();
 
         // ── Phase 1: first run — must PASS (Counter 0 -> 1), cache MISS ──────────
         var lines1 = await server.SendRequestStreamingAsync(Req("runTests", bundle));
@@ -88,8 +102,19 @@ public class ServerTests
         // The failure message proves the NEW trigger ran: Counter became 9, not 1.
         var failMsg = events3[0].GetProperty("message").GetString() ?? "";
         Assert.Contains("9", failMsg);
+    }
 
-        // ── Phase 4: shutdown — response then process exit ──────────────────────
+    // Split out of RunTests_Then_EditTable_Then_RunAgain_PicksUpChange (#1804):
+    // that test used to end with this same shutdown check, which meant it could
+    // never share a process with the class's other facts (shutting the server
+    // down would break whichever fact ran after it). This owns its own
+    // dedicated server precisely BECAUSE killing it is the point.
+    [SkippableFact]
+    public async Task Shutdown_RespondsThenProcessExits()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        await using var server = await CliServer.StartAsync();
         var rs = await server.SendAsync("{\"command\":\"shutdown\"}");
         var ds = JsonSerializer.Deserialize<JsonElement>(rs);
         Assert.Equal("shutting down", ds.GetProperty("status").GetString());
@@ -133,8 +158,7 @@ public class ServerTests
     {
         TestArtifacts.SkipIfMissing();
         var bundle = MakeExecuteBundle();
-        var cacheDir = Path.Combine(Path.GetTempPath(), "al-runner-server-exec-cache", Guid.NewGuid().ToString("N"));
-        await using var server = await CliServer.StartAsync(new[] { "--cache", cacheDir });
+        var server = await _fixture.GetAsync();
 
         var r = await server.SendAsync(Req("execute", bundle));
         var d = JsonSerializer.Deserialize<JsonElement>(r);
@@ -152,7 +176,7 @@ public class ServerTests
     public async Task Execute_InlineCode_NotSupported_ReturnsError()
     {
         TestArtifacts.SkipIfMissing();
-        await using var server = await CliServer.StartAsync();
+        var server = await _fixture.GetAsync();
         var r = await server.SendAsync("{\"command\":\"execute\",\"code\":\"Message('hi');\"}");
         var d = JsonSerializer.Deserialize<JsonElement>(r);
         Assert.True(d.TryGetProperty("error", out var err));
@@ -238,8 +262,7 @@ public class ServerTests
         TestArtifacts.SkipIfMissing();
 
         MakeAppTestPair(out var appDir, out var testDir);
-        var cacheDir = Path.Combine(Path.GetTempPath(), "al-runner-server-multi-cache", Guid.NewGuid().ToString("N"));
-        await using var server = await CliServer.StartAsync(new[] { "--cache", cacheDir });
+        var server = await _fixture.GetAsync();
 
         var req = JsonSerializer.Serialize(new
         {
@@ -265,7 +288,7 @@ public class ServerTests
     public async Task UnknownCommand_ReturnsError()
     {
         TestArtifacts.SkipIfMissing();
-        await using var server = await CliServer.StartAsync();
+        var server = await _fixture.GetAsync();
         var r = await server.SendAsync("{\"command\":\"bogus\"}");
         var d = JsonSerializer.Deserialize<JsonElement>(r);
         Assert.True(d.TryGetProperty("error", out var err));

--- a/AlRunner.Tests/ServerTests.cs
+++ b/AlRunner.Tests/ServerTests.cs
@@ -26,6 +26,18 @@ namespace AlRunner.Tests;
 /// combined a cache-behaviour claim and a process-lifecycle claim in one
 /// method; splitting them is what makes the cache-behaviour half safe to move
 /// onto a server other facts also use.
+///
+/// Condition (c) of SharedCliServer's doc comment (distinct AppId per call
+/// site sharing this process — see its comment for why a shared AppId is
+/// unsafe via <c>DependencyLoader.TryGetByAppId</c>'s cross-request reuse):
+/// verified, not just assumed. Each bundle generator's AppId here
+/// (<c>MakeTempBundle</c>'s fixture, <c>MakeExecuteBundle</c>,
+/// <c>MakeAppTestPair</c>'s two apps) is used by exactly ONE fact in this
+/// class, so no two facts sharing this server ever present the same AppId at
+/// two different SourcePaths. <c>RunTests_Then_EditTable_Then_RunAgain_PicksUpChange</c>'s
+/// three requests reuse the SAME bundle/SourcePath repeatedly on purpose —
+/// TryGetByAppId's own same-SourcePath carve-out means that is never treated
+/// as a reuse, it is the edit-and-rerun contract the test exists to prove.
 /// </summary>
 public class ServerTests : IClassFixture<SharedCliServer>
 {

--- a/AlRunner.Tests/SharedCliServer.cs
+++ b/AlRunner.Tests/SharedCliServer.cs
@@ -38,11 +38,26 @@ namespace AlRunner.Tests;
 ///  (b) don't tear the process down (shutdown/kill) as part of what they're
 ///      proving — a fact that shuts the shared server down would break every
 ///      fact that runs after it in the same class;
-///  (c) use bundle content unique enough (distinct app IDs / distinct
-///      table+codeunit bodies) that one fact's compiled-and-cached AL output
-///      cannot masquerade as another fact's expected-fresh compile — each
-///      converted class in this repo satisfies this today because every
-///      fixture bundle already carries its own fixed, distinct app ID.
+///  (c) give each bundle-generating call site its OWN app ID, distinct from
+///      every other call site sharing this server — not merely "distinct
+///      content". <c>DependencyLoader.TryGetByAppId</c> (see
+///      DependencyLoader.cs) caches a compiled module by AppId for the
+///      lifetime of the SERVER PROCESS and returns that cached module for
+///      ANY later request whose bundle reports a MATCHING AppId at a
+///      DIFFERENT SourcePath, regardless of whether the bundle's actual
+///      source content differs — it is not the AL-output content cache, and
+///      content equality does not make a shared AppId safe, only
+///      coincidentally harmless until someone edits one call site's AL
+///      without also editing the others. (The one exception:
+///      <c>TryGetByAppId</c> deliberately does NOT reuse when the cached
+///      entry's SourcePath equals the one being asked about — that is one
+///      fact re-running the SAME bundle path more than once, e.g.
+///      ServerTests' edit-and-rerun test, which is fine.) Every converted
+///      class's bundle generator in this repo now takes a variant/index
+///      parameter for exactly this reason — see ServerTestIsolationTests and
+///      ServerStreamingTests. SharedCliServerTests deliberately does the
+///      opposite on purpose, reusing one fixed AppId across two calls, to
+///      prove isolation holds even when this cross-request reuse fires.
 ///
 /// ServerTests' shutdown-lifecycle fact and all of ServerCancelTests (each
 /// fact independently exercises a fresh `cancel`/`runTests` race that #1809

--- a/AlRunner.Tests/SharedCliServer.cs
+++ b/AlRunner.Tests/SharedCliServer.cs
@@ -1,0 +1,95 @@
+using Xunit;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// #1804: one BC cold start per test CLASS, not one per <c>[Fact]</c>. Wraps a
+/// single lazily-started <see cref="CliServer"/> so multiple facts in the same
+/// class can share the one BC boot (measured ~4-7s, mostly BC metadata
+/// construction inside BcRuntime.EnsureApplied — see the issue for the
+/// measurements that ruled out shaving the cold start itself) instead of each
+/// paying it independently via its own <c>CliServer.StartAsync</c> call.
+///
+/// Used as an xUnit <c>IClassFixture&lt;SharedCliServer&gt;</c>: xUnit constructs
+/// exactly one instance per test class and passes the SAME instance to every
+/// fact's constructor, then disposes it once after the last fact in the class
+/// finishes. xUnit runs facts WITHIN one class sequentially by default (only
+/// DIFFERENT classes/collections run in parallel with each other) — see #1809's
+/// own reasoning for why the per-class collection split is what buys
+/// cross-class parallelism, which this class deliberately does not touch. So
+/// there is no concurrent-access race on <see cref="GetAsync"/> to guard beyond
+/// the one-time startup.
+///
+/// Lazy, not eager: <see cref="InitializeAsync"/> does NOT spawn — a class whose
+/// every fact skips (<c>TestArtifacts.SkipIfMissing()</c> runs before any fact
+/// ever calls <see cref="GetAsync"/>) must not pay for a server nobody used.
+/// The first <see cref="GetAsync"/> call spawns; every later call (from any
+/// fact in the class) returns the SAME process.
+///
+/// Not a blanket replacement for <c>CliServer.StartAsync</c> everywhere. Safe to
+/// share ONLY across facts that:
+///  (a) don't need a DIFFERENT server-startup flag from each other — flags like
+///      <c>--cache</c>/<c>--package-cache</c> are supplied at server STARTUP,
+///      not per request (ServerProtocol's request shape exposes only
+///      <c>command</c>, <c>sourcePaths</c>, <c>packagePaths</c>, <c>stubPaths</c>,
+///      <c>code</c>, <c>captureValues</c>, <c>testIsolation</c> — no cache
+///      override), so two facts wanting two different startup flags cannot
+///      share one process;
+///  (b) don't tear the process down (shutdown/kill) as part of what they're
+///      proving — a fact that shuts the shared server down would break every
+///      fact that runs after it in the same class;
+///  (c) use bundle content unique enough (distinct app IDs / distinct
+///      table+codeunit bodies) that one fact's compiled-and-cached AL output
+///      cannot masquerade as another fact's expected-fresh compile — each
+///      converted class in this repo satisfies this today because every
+///      fixture bundle already carries its own fixed, distinct app ID.
+///
+/// ServerTests' shutdown-lifecycle fact and all of ServerCancelTests (each
+/// fact independently exercises a fresh `cancel`/`runTests` race that #1809
+/// deliberately de-serialized) are NOT converted — see #1804's PR description
+/// for why.
+/// </summary>
+public sealed class SharedCliServer : IAsyncLifetime
+{
+    private readonly SemaphoreSlim _gate = new(1, 1);
+    private CliServer? _server;
+
+    /// <summary>
+    /// How many times THIS fixture instance has actually spawned a server
+    /// process — 0 or 1, never more. Instance-scoped rather than reading
+    /// <see cref="CliServer.StartCount"/>'s process-wide count, specifically
+    /// so the proving test in SharedCliServerTests.cs is immune to other test
+    /// classes spawning their own servers concurrently (xUnit runs different
+    /// classes' tests in parallel with each other by default).
+    /// </summary>
+    public int SpawnCount => _spawnCount;
+    private int _spawnCount;
+
+    public Task InitializeAsync() => Task.CompletedTask;
+
+    /// <summary>Returns the shared server, starting it on the first call only.</summary>
+    public async Task<CliServer> GetAsync()
+    {
+        if (_server != null) return _server;
+        await _gate.WaitAsync();
+        try
+        {
+            if (_server == null)
+            {
+                _server = await CliServer.StartAsync();
+                _spawnCount++;
+            }
+            return _server;
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_server != null)
+            await _server.DisposeAsync();
+    }
+}

--- a/AlRunner.Tests/SharedCliServerTests.cs
+++ b/AlRunner.Tests/SharedCliServerTests.cs
@@ -19,13 +19,22 @@ namespace AlRunner.Tests;
 ///     a noisy CI runner and, worse, would not fail if the saving regressed on
 ///     a fast box (see the issue's own noise-floor measurements: a 25% swing
 ///     between two runs of the SAME commit is normal here).
-///  2. Sharing does not leak state — running the SAME bundle identity twice
-///     through the SAME shared server must give the SECOND run the SAME fresh
-///     company/database state the FIRST run got, not the first run's leftover
-///     rows. If TestExecutor's per-bundle company reset only ran once per OS
-///     process (rather than once per request) — the exact regression a naive
-///     "just don't restart the process" change could introduce — this test
-///     fails, not passes.
+///  2. Sharing does not leak state — running the SAME bundle identity (same
+///     AppId) twice through the SAME shared server must give the SECOND run
+///     the SAME fresh company/database state the FIRST run got, not the
+///     first run's leftover rows. This deliberately keeps ONE fixed AppId
+///     across both calls (unlike ServerTestIsolationTests/ServerStreamingTests,
+///     which now give every call site its own AppId — see SharedCliServer's
+///     class doc comment on condition (c)) specifically to exercise
+///     <c>DependencyLoader.TryGetByAppId</c>'s real cross-request reuse path:
+///     the second call's bundle sits at a different SourcePath but the same
+///     AppId, so the server reuses run 1's ALREADY-COMPILED module for run 2
+///     (asserted below via the response's own <c>cached</c> field) rather than
+///     compiling a second, distinct one. If TestExecutor's per-request company
+///     reset only ran once per OS process (rather than once per request) — the
+///     exact regression a naive "just don't restart the process" change could
+///     introduce, and the exact shape the review that hardened this test was
+///     about — this test fails, not passes.
 /// </summary>
 public class SharedCliServerTests
 {
@@ -33,6 +42,11 @@ public class SharedCliServerTests
     // bundle must report the SAME shape (table starts empty, ends with 3 rows).
     // If a prior run's rows leaked forward, the "table must start EMPTY" guard
     // inside the AL test itself fires and the run FAILS instead of PASSING.
+    //
+    // Fixed AppId on every call — see the class doc comment on why that is
+    // deliberate here (this test exists specifically to prove isolation holds
+    // THROUGH DependencyLoader.TryGetByAppId's cross-request module reuse, not
+    // to avoid it).
     private static string MakeIsolationProbeBundle()
     {
         var dir = Path.Combine(Path.GetTempPath(), "al-runner-shared-server-isolation", Guid.NewGuid().ToString("N"));
@@ -176,6 +190,16 @@ public class SharedCliServerTests
             var (_, d2) = ProtocolV2Streaming.Split(lines2);
             Assert.Equal(1, d2.GetProperty("passed").GetInt32());
             Assert.Equal(0, d2.GetProperty("failed").GetInt32());
+            // Confirms this test actually exercised the risky path rather than
+            // incidentally getting a fresh compile: run 2's SourcePath differs
+            // from run 1's, so a `cached:true` here can only come from
+            // DependencyLoader.TryGetByAppId serving run 1's already-compiled
+            // module (see RunBundleForServer's `cached = reusedAsm != null`) —
+            // the exact mechanism named in the class doc comment above.
+            Assert.True(d2.GetProperty("cached").GetBoolean(),
+                "expected run 2 to be served via AppId-based module reuse (same AppId, " +
+                "different SourcePath) — if this is false the test is no longer proving " +
+                "isolation survives that specific reuse path.");
             Assert.Equal(1, shared.SpawnCount); // still one process — the isolation is per-REQUEST, not per-process.
         }
         finally

--- a/AlRunner.Tests/SharedCliServerTests.cs
+++ b/AlRunner.Tests/SharedCliServerTests.cs
@@ -1,0 +1,186 @@
+using System.Text.Json;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// #1804 proving tests for <see cref="SharedCliServer"/>.
+///
+/// Two claims, deliberately kept as SEPARATE tests rather than folded into
+/// one, because they are two different risks and either failing on its own
+/// must say so unambiguously — the issue's own framing: "a test proving
+/// isolation is preserved... or this trades minutes for intermittent false
+/// greens":
+///
+///  1. Sharing actually saves spawns — <see cref="SharedCliServer.GetAsync"/>
+///     called N times costs exactly ONE <c>Process.Start</c>, not N. Asserted
+///     against a real, observable spawn counter (<see cref="SharedCliServer.SpawnCount"/>),
+///     never inferred from wall-clock timing — timing assertions are flaky on
+///     a noisy CI runner and, worse, would not fail if the saving regressed on
+///     a fast box (see the issue's own noise-floor measurements: a 25% swing
+///     between two runs of the SAME commit is normal here).
+///  2. Sharing does not leak state — running the SAME bundle identity twice
+///     through the SAME shared server must give the SECOND run the SAME fresh
+///     company/database state the FIRST run got, not the first run's leftover
+///     rows. If TestExecutor's per-bundle company reset only ran once per OS
+///     process (rather than once per request) — the exact regression a naive
+///     "just don't restart the process" change could introduce — this test
+///     fails, not passes.
+/// </summary>
+public class SharedCliServerTests
+{
+    // Table starts empty and inserts exactly 3 rows — every fresh run of this
+    // bundle must report the SAME shape (table starts empty, ends with 3 rows).
+    // If a prior run's rows leaked forward, the "table must start EMPTY" guard
+    // inside the AL test itself fires and the run FAILS instead of PASSING.
+    private static string MakeIsolationProbeBundle()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "al-runner-shared-server-isolation", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "app.json"), """
+        {
+          "id": "c4d5e6f7-0819-4a2b-bc3d-4e5f60718293",
+          "name": "Runner Extras - Shared Server Isolation Probe",
+          "publisher": "AL Runner",
+          "version": "1.0.0.0",
+          "dependencies": [],
+          "platform": "1.0.0.0",
+          "application": "1.0.0.0",
+          "idRanges": [ { "from": 60400, "to": 60409 } ],
+          "runtime": "14.0"
+        }
+        """);
+        File.WriteAllText(Path.Combine(dir, "ProbeTbl.Table.al"), """
+        table 60400 "Shared Server Isolation Tbl"
+        {
+            fields
+            {
+                field(1; "Code"; Code[20]) { }
+            }
+            keys { key(PK; "Code") { Clustered = true; } }
+        }
+        """);
+        File.WriteAllText(Path.Combine(dir, "ProbeTest.Codeunit.al"), """
+        codeunit 60400 "Shared Server Isolation SX"
+        {
+            Subtype = Test;
+
+            [Test]
+            procedure InsertsThreeRows_TableStartsEmpty()
+            var
+                Rec: Record "Shared Server Isolation Tbl";
+                CountBefore: Integer;
+            begin
+                CountBefore := Rec.Count();
+                if CountBefore <> 0 then
+                    Error('table must start EMPTY on every fresh run, found %1 row(s) already present', CountBefore);
+
+                Rec.Init(); Rec."Code" := '1'; Rec.Insert();
+                Rec.Init(); Rec."Code" := '2'; Rec.Insert();
+                Rec.Init(); Rec."Code" := '3'; Rec.Insert();
+
+                if Rec.Count() <> 3 then
+                    Error('expected 3 rows after inserting 3, got %1', Rec.Count());
+            end;
+        }
+        """);
+        return dir;
+    }
+
+    private static string RunTestsReq(string bundleDir)
+        => JsonSerializer.Serialize(new
+        {
+            command = "runTests",
+            sourcePaths = new[] { bundleDir },
+            packagePaths = Array.Empty<string>(),
+        });
+
+    [SkippableFact]
+    public async Task GetAsync_CalledManyTimesSequentially_SpawnsExactlyOneProcess()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var shared = new SharedCliServer();
+        try
+        {
+            var s1 = await shared.GetAsync();
+            var s2 = await shared.GetAsync();
+            var s3 = await shared.GetAsync();
+
+            Assert.Equal(1, shared.SpawnCount);
+            // Same OS process, not merely the same C# object reference.
+            Assert.Equal(s1.Pid, s2.Pid);
+            Assert.Equal(s1.Pid, s3.Pid);
+            Assert.Same(s1, s2);
+            Assert.Same(s1, s3);
+        }
+        finally
+        {
+            await shared.DisposeAsync();
+        }
+    }
+
+    [SkippableFact]
+    public async Task GetAsync_ConcurrentFirstCalls_StillSpawnsExactlyOneProcess()
+    {
+        // Guards the fixture's own startup gate: N callers racing GetAsync()
+        // for the FIRST time (not the sequential-by-construction case above —
+        // xUnit runs facts within one class sequentially, but a class fixture
+        // is still just a plain object with no guarantee callers serialize
+        // themselves) must still converge on ONE spawn, not one per racer.
+        TestArtifacts.SkipIfMissing();
+
+        var shared = new SharedCliServer();
+        try
+        {
+            var tasks = Enumerable.Range(0, 8).Select(_ => shared.GetAsync()).ToArray();
+            var servers = await Task.WhenAll(tasks);
+
+            Assert.Equal(1, shared.SpawnCount);
+            Assert.True(servers.All(s => s.Pid == servers[0].Pid),
+                $"expected every racer to observe the SAME pid, got: {string.Join(",", servers.Select(s => s.Pid))}");
+        }
+        finally
+        {
+            await shared.DisposeAsync();
+        }
+    }
+
+    [SkippableFact]
+    public async Task TwoRunsOfSameBundleIdentity_ThroughSameSharedServer_BothSeeFreshState_NoLeakedRows()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var shared = new SharedCliServer();
+        try
+        {
+            var server = await shared.GetAsync();
+
+            // Run 1 (stands in for "test case 1" in a class sharing this
+            // server): inserts 3 rows into a table that must start empty.
+            var bundle1 = MakeIsolationProbeBundle();
+            var lines1 = await server.SendRequestStreamingAsync(RunTestsReq(bundle1));
+            var (_, d1) = ProtocolV2Streaming.Split(lines1);
+            Assert.Equal(1, d1.GetProperty("passed").GetInt32());
+            Assert.Equal(0, d1.GetProperty("failed").GetInt32());
+
+            // Run 2 (stands in for "test case 2"): SAME shared OS process,
+            // SAME app identity/table, brand new bundle directory. If run 1's
+            // 3 rows (or any other company state) leaked forward into this
+            // request, the AL test's own "must start EMPTY" guard fires and
+            // THIS run fails. It must pass — the decisive proof that the
+            // second test case through a shared process gets the SAME fresh
+            // company reset the first one got, not the first one's leftovers.
+            var bundle2 = MakeIsolationProbeBundle();
+            var lines2 = await server.SendRequestStreamingAsync(RunTestsReq(bundle2));
+            var (_, d2) = ProtocolV2Streaming.Split(lines2);
+            Assert.Equal(1, d2.GetProperty("passed").GetInt32());
+            Assert.Equal(0, d2.GetProperty("failed").GetInt32());
+            Assert.Equal(1, shared.SpawnCount); // still one process — the isolation is per-REQUEST, not per-process.
+        }
+        finally
+        {
+            await shared.DisposeAsync();
+        }
+    }
+}


### PR DESCRIPTION
Closes #1804

## Summary

#1804's own investigation history (19 comments, several corrections along the way) converged on: the unit-test step's cost is a per-process BC cold start tax paid up to 91 times, the cold start itself is near its measurable floor (~4s of it is BC metadata construction a fresh process structurally can't inherit — see PR #1894's already-landed 27% cut and the diminishing-returns numbers in the issue), and the remaining lever is **spawning fewer processes**, not shaving each spawn further. Direction 1 from the issue body: *"Share one server process across tests in a class via an xUnit class/collection fixture, instead of `StartAsync` per `[Fact]`."*

This PR does exactly that for the three classes where it's safe, and explicitly does **not** touch the fourth (`ServerCancelTests`) — see "Deliberately out of scope" below.

## What changed

- **`AlRunner.Tests/SharedCliServer.cs`** (new) — a lazy `IClassFixture` wrapping one `CliServer`. First `GetAsync()` call spawns; every later call (from any fact in the class) returns the same OS process. xUnit runs facts *within* one class sequentially by default (only different classes/collections run in parallel with each other — the mechanism #1809 relies on for cross-class parallelism), so sharing within a class costs no parallelism #1809 established.
- **`ServerStreamingTests`** (3 facts) and **`ServerTestIsolationTests`** (4 facts) — converted wholesale.
- **`ServerTests`** (5 facts) — 4 converted; `Shutdown_RespondsThenProcessExits` is split out of `RunTests_Then_EditTable_Then_RunAgain_PicksUpChange` (which used to end with the same shutdown check) into its own dedicated test, since it exists specifically to prove the shutdown command kills the process — it can't share an instance the other facts still need.
- **`AlRunner.Tests/CliServer.cs`** — adds a diagnostic process-wide spawn counter (`StartCount`), doc-commented as *not* what the proving tests rely on (a process-wide counter is polluted by other classes spawning concurrently under xUnit's cross-class parallelism).
- **`AlRunner.Tests/SharedCliServerTests.cs`** (new) — the proving tests, deliberately two separate claims:
  1. **Spawn count**: `GetAsync()` called many times (sequentially, and 8-way racing on the very first call) spawns exactly **one** process — asserted against `SharedCliServer.SpawnCount`, an instance-scoped counter, never wall-clock timing (timing assertions are flaky in CI; the issue's own noise-floor comment measured a 25% swing between two runs of the *same* commit).
  2. **Isolation preserved**: running the *same* bundle identity twice through the *same* shared server gives the second run the same fresh company/database state the first run got, not the first run's leftover rows — and, since #1892 landed while this PR was in flight, this deliberately exercises `DependencyLoader.TryGetByAppId`'s real cross-request module-reuse path (see "Review fix" below), asserting `cached:true` on the second run to prove it.

## Condition (c): every bundle sharing a server process needs its own AppId

**Update, addressed a review finding after initial submission (commit `6303bd63`):** `DependencyLoader.TryGetByAppId` (changed by #1892, merged to `main` while this PR was open) reuses an earlier-compiled module for any later request reporting a matching AppId at a different SourcePath, regardless of content — a process-lifetime cache keyed on AppId, not the AL-output content cache. `ServerTestIsolationTests.MakeIsolationBundle` (4 call sites) and `ServerStreamingTests.MakeMixedBundle` (2 call sites) originally hardcoded one AppId reused across different SourcePaths within the same shared process — safe today only because every call site's content happened to be byte-identical, and a live bug the moment anyone edits one call site's AL without touching the others.

Fixed by giving both bundle generators a `variant` parameter so every call site gets its own AppId and object-ID range — a genuine independent compile per fact, not reliance on content-equality-by-coincidence. `ServerTests` audited against the same lens and documented in its class comment: every generator there is used by exactly one fact, and the one repeated-SourcePath case (`RunTests_Then_EditTable_Then_RunAgain_PicksUpChange`'s three requests against the same bundle) is `TryGetByAppId`'s documented same-SourcePath carve-out (never a reuse) — the edit-and-rerun contract that test proves, not a violation. `SharedCliServerTests`'s isolation test deliberately keeps ONE fixed AppId across its two calls on purpose (see above) and is now strengthened to prove it.

## Deliberately out of scope

- **`ServerCancelTests`** (8 spawn sites) is untouched. Its own doc comment explains it was deliberately de-serialized in #1809 for cross-class parallelism, one fact uses a barrier env var scoped to its own subprocess, and forcing all 8 facts through one shared process would reintroduce exactly the kind of coupling #1809 removed. Left as a template for a follow-up with more care, not folded in here.
- `ServerCrossBundleModuleIdentityDedupTests` and `PhaseLogServerKillTests` (also `CliServer.StartAsync`-based) — untouched, no time to audit their per-fact independence claims this pass.
- The other ~70 spawn sites census'd in the issue's thread (`dotnet <dll>` one-shot CLI invocations, not `--server`) are a different shape of problem — most of them are asserting CLI *flag* behavior itself and the `ServerProtocol` request surface has no equivalent for most of those flags (`--cache`, `--test-timeout`, `--count-baseline`, etc. — confirmed against `AlRunner/ServerProtocol.cs`'s 7-field request shape), so they can't share a `--server` process without a protocol change. Not attempted here.

## Proving the tests are not vacuous

Per `tdd.md`, I RED-checked the proving tests against my own new code rather than trusting them on inspection alone:

- **Spawn-count test**: temporarily made `SharedCliServer.GetAsync()` always spawn (bypassing its own cache check). Both spawn-count facts failed correctly — `Expected: 1, Actual: 3` and `Expected: 1, Actual: 8` — then reverted.
- **Isolation test**: initially attempted to break it by disabling `TestExecutor`'s `RecordPatches.ResetPerTestState()` call and `RestoreInstallBaselineSnapshot`'s `resetFirst` wipe — it kept passing under both. My first write-up attributed that to fresh CLR `Type` identity per `Assembly.Load`; **that attribution was wrong**, caught by review — the real reason is a different cache (`DependencyLoader.TryGetByAppId`) reuses the same compiled module (same `Type`s) across requests sharing an AppId, so "fresh Type identity" was never the actual guarantee for this shared-process scenario. The test's PASS result was still real signal (the isolation genuinely holds), just for a mechanism I'd misidentified — now corrected and the test strengthened to assert the exact reuse path it exercises (`cached:true`) rather than relying on it happening to occur. `git diff` against `AlRunner/` (production runtime) is empty — no runtime code was changed by this PR, only the two experimental edits made during red-checking, both reverted.

## Measured

Targeted run, the 3 converted classes only, before vs after:

| | facts | processes spawned | wall clock |
|---|---:|---:|---:|
| Before | 12 | 12 | 57.5s |
| After (12 original facts + 4 new meta-test facts = 16) | 16 | 7 (4 for the 12 original facts + 3 for the new meta tests) | ~21-26s |

Full `AlRunner.Tests` suite locally: 0 failed, 691 passed, 26 skipped, 5m37s (post-rebase onto `main` @ `7be4b261` / #1912) — confirms no regressions from touching the shared `CliServer.cs` helper (used by `ServerCrossBundleModuleIdentityDedupTests` and `PhaseLogServerKillTests` too) or from the AppId/object-ID changes in the two fixed bundle generators.

**Honest scope statement**: this converts 12 of the ~91 spawn sites census'd in the issue thread down to 4 real spawns (net -8 spawns × ~4-7s ≈ 32-56s locally, × 8 CI legs). It is a real, provable slice of the issue, not the whole thing — the issue's own investigation already substantially revised its "~9-12 min per leg" framing upward over the course of the thread (to a "unit tests ~50-58% of a 12-20 min leg" picture with `ServerCancelTests`/barrier-based tests and the ~70 one-shot CLI spawns as the larger remaining share), and this PR does not claim to close that whole gap — see the issue thread's own corrections for where the bulk of the remaining cost actually is.

## Test plan

- [x] `AlRunner.Tests/SharedCliServerTests.cs` — new proving tests, RED-checked against real regressions before reverting to GREEN
- [x] `ServerStreamingTests`, `ServerTestIsolationTests`, `ServerTests` — all facts pass under the shared-process model, with per-call-site distinct AppIds
- [x] Full `AlRunner.Tests` suite — 0 failed / 691 passed / 26 skipped locally, post-rebase
- [x] No changes under `AlRunner/` (production runtime) — confirmed via `git diff --stat`, so the `require-tests` CI gate doesn't even trigger on this diff
- [x] `git merge-tree` against `origin/main` — clean, no conflicts

---
_Generated by [Claude Code](https://claude.ai/code/session_01EU4fwyWDu5CiUrhbPoxAhb)_