### PR TITLE
fix(runtime): resolve AL objects against the current generation across a cross-app cycle boundary

### DIFF
--- a/AlRunner.Tests/ServerCrossAppStaleGenerationTests.cs
+++ b/AlRunner.Tests/ServerCrossAppStaleGenerationTests.cs
@@ -1,0 +1,259 @@
+using System.Text.Json;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// Issue #1901 — a warm process that re-runs the SAME multi-bundle set more than once
+/// (server mode's edit-and-rerun contract; <c>--watch</c> shares the identical
+/// in-process reload mechanism) can serve a cross-app call the PREVIOUS cycle's code.
+/// .NET cannot unload assemblies, so editing only a DEPENDENCY app between two
+/// <c>runTests</c> requests in the same session leaves both the old and the new
+/// generation of that app's assembly resident. The type finders that resolve an AL
+/// object dynamically by id (<c>CodeunitPatches.FindCodeunitType</c> et al.) used to
+/// prefer <c>CurrentTestAssembly</c> — which only ever covers the app CURRENTLY
+/// executing — and otherwise scan every loaded assembly with no notion of "which
+/// generation is current", so a call from the dependent app's test code into the
+/// edited dependency could bind to whichever generation
+/// <c>AppDomain.CurrentDomain.GetAssemblies()</c> happened to enumerate first: in
+/// practice, the STALE one. The test kept reporting PASS against pre-edit behaviour —
+/// silent, no crash, no diagnostic.
+///
+/// RED (pre-fix): request 2 below still reports PASS after the dependency's answer
+/// changed from 42 to 43 — the stale generation served the call.
+/// GREEN (post-fix): request 2 FAILS with a message naming the real (43) answer —
+/// proof the freshly-edited generation actually ran.
+///
+/// A companion test below proves the sibling failure mode named in #1901's "Likely
+/// fix" list: a missed supersede in the event-subscriber registry. It uses a
+/// manually-declared codeunit-to-codeunit event (dispatched by
+/// <c>CodeunitEventDispatcher</c> off <c>EventSubscriberPatches.GetCodeunitSubscribers</c>,
+/// re-scanned fresh on every call) rather than a table trigger, so the proof is
+/// isolated to the subscriber registry itself and does not also exercise the
+/// SEPARATE, already-documented table-metadata-reload limitation in
+/// <c>docs/server-mode.md</c> (BC's own skeleton <c>NCLMetadata.metadataCacheEntries</c>
+/// is deliberately not cleared across a reload, so a table declared in a dependency
+/// app can lag).
+///
+/// RED (pre-fix) here is "fires ZERO times", not "fires twice": a discovery scan can
+/// run BEFORE the dependency app's fresh generation has (re)registered for THIS cycle
+/// (<c>EventSubscriberPatches.EnsureRegistryFresh</c> is re-entered from several call
+/// sites, and the very first one in a cycle can land ahead of the dependency's own
+/// <c>SetTestAssembly</c>). <c>EventSubscriberPatches</c>' own publisher-type lookup
+/// (<c>FindClrType</c>/<c>_codeunitTypeCache</c>) then permanently caches the STALE
+/// generation resolved at that early moment, so the sentinel <c>γeventScope</c> field
+/// gets seeded on the WRONG (previous-cycle) generation's <c>OnFire_Scope</c> class.
+/// The freshly-edited generation Test's code actually calls into never gets its own
+/// <c>γeventScope</c> seeded, so BC's own generated guard
+/// (<c>if (γeventScope == null &amp;&amp; !recorder) return;</c>) skips dispatch
+/// entirely — the subscriber never runs, silently. <c>DispatchCore</c> already
+/// deduplicates by AL identity (codeunit id + method name), which is why this
+/// specific dispatch path cannot manifest as a literal double-fire even when a stale
+/// generation's [EventSubscriber] method is (redundantly, harmlessly) rediscovered
+/// alongside the fresh one — the fix (superseding stale cache entries and pruning
+/// stale discovery-registry entries) closes the under-fire failure mode, which is the
+/// one this specific fixture can actually observe going wrong.
+///
+/// Spawns the real runner in --server mode; needs the BC artifact cache. Skips
+/// (no-op) when absent.
+/// </summary>
+public class ServerCrossAppStaleGenerationTests
+{
+    private static (string libDir, string testDir, string answerFile) MakeLibTestPair(string rootName)
+    {
+        var root = Path.Combine(Path.GetTempPath(), rootName, Guid.NewGuid().ToString("N"));
+        var libDir = Path.Combine(root, "Lib");
+        var testDir = Path.Combine(root, "Test");
+        Directory.CreateDirectory(libDir);
+        Directory.CreateDirectory(testDir);
+
+        const string libId = "d1a2b3c4-d5e6-4f70-8a91-b2c3d4e5f701";
+
+        File.WriteAllText(Path.Combine(libDir, "app.json"), $$"""
+        {
+          "id": "{{libId}}",
+          "name": "WS Lib",
+          "publisher": "AL Runner Repro",
+          "version": "1.0.0.0",
+          "dependencies": [],
+          "idRanges": [ { "from": 60960, "to": 60969 } ],
+          "platform": "1.0.0.0",
+          "application": "1.0.0.0",
+          "runtime": "14.0"
+        }
+        """);
+        var answerFile = Path.Combine(libDir, "Answer.Codeunit.al");
+        File.WriteAllText(answerFile, """
+        codeunit 60960 "WS Answer"
+        {
+            procedure Answer(): Integer
+            begin
+                exit(42);
+            end;
+        }
+        """);
+        File.WriteAllText(Path.Combine(libDir, "FireEvent.Codeunit.al"), """
+        codeunit 60963 "WS Fire Event"
+        {
+            [IntegrationEvent(false, false)]
+            local procedure OnFire(var FireCount: Integer)
+            begin
+            end;
+
+            procedure Fire(var FireCount: Integer)
+            begin
+                OnFire(FireCount);
+            end;
+        }
+
+        codeunit 60964 "WS Fire Sub"
+        {
+            [EventSubscriber(ObjectType::Codeunit, Codeunit::"WS Fire Event", 'OnFire', '', false, false)]
+            local procedure OnFireHandler(var FireCount: Integer)
+            begin
+                FireCount += 1;
+            end;
+        }
+        """);
+
+        File.WriteAllText(Path.Combine(testDir, "app.json"), $$"""
+        {
+          "id": "d1a2b3c4-d5e6-4f70-8a91-b2c3d4e5f702",
+          "name": "WS Test",
+          "publisher": "AL Runner Repro",
+          "version": "1.0.0.0",
+          "dependencies": [
+            { "id": "{{libId}}", "name": "WS Lib", "publisher": "AL Runner Repro", "version": "1.0.0.0" }
+          ],
+          "idRanges": [ { "from": 60970, "to": 60979 } ],
+          "platform": "1.0.0.0",
+          "application": "1.0.0.0",
+          "runtime": "14.0"
+        }
+        """);
+        File.WriteAllText(Path.Combine(testDir, "WsTests.Codeunit.al"), """
+        codeunit 60970 "WS Tests"
+        {
+            Subtype = Test;
+
+            [Test]
+            procedure LibAnswer_Is42()
+            var
+                Ans: Codeunit "WS Answer";
+                Actual: Integer;
+            begin
+                Actual := Ans.Answer();
+                if Actual <> 42 then
+                    Error('Expected 42 but got %1', Actual);
+            end;
+        }
+
+        codeunit 60971 "WS Sub Test"
+        {
+            Subtype = Test;
+
+            [Test]
+            procedure Fire_SubscriberFiresExactlyOnce()
+            var
+                FireEvt: Codeunit "WS Fire Event";
+                Count: Integer;
+            begin
+                Count := 0;
+                FireEvt.Fire(Count);
+                if Count <> 1 then
+                    Error('subscriber fired %1 time(s), expected exactly 1 — a stale generation of WS Fire Sub is still registered', Count);
+            end;
+        }
+        """);
+
+        return (libDir, testDir, answerFile);
+    }
+
+    private static string Req(string libDir, string testDir)
+        => JsonSerializer.Serialize(new
+        {
+            command = "runTests",
+            sourcePaths = new[] { libDir, testDir },
+            packagePaths = Array.Empty<string>(),
+        });
+
+    [SkippableFact]
+    public async Task RunTests_Then_EditDependencyOnly_Rerun_ObservesTheEditNotTheStaleGeneration()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var (libDir, testDir, answerFile) = MakeLibTestPair("al-runner-xapp-stale-gen");
+        var cacheDir = Path.Combine(Path.GetTempPath(), "al-runner-xapp-stale-gen-cache", Guid.NewGuid().ToString("N"));
+        await using var server = await CliServer.StartAsync(new[] { "--cache", cacheDir });
+
+        // ── Cycle 1: fresh generation of WS Lib, Answer() == 42 — must PASS ──────
+        var lines1 = await server.SendRequestStreamingAsync(Req(libDir, testDir), TimeSpan.FromSeconds(180));
+        var (events1, d1) = ProtocolV2Streaming.Split(lines1);
+        Assert.Equal(0, d1.GetProperty("failed").GetInt32());
+        Assert.Equal(0, d1.GetProperty("errors").GetInt32());
+        var answerEvent1 = events1.Single(e => e.GetProperty("name").GetString()!.EndsWith("LibAnswer_Is42"));
+        Assert.Equal("pass", answerEvent1.GetProperty("status").GetString());
+
+        // ── Edit ONLY the dependency (WS Lib). The test codeunit is untouched and
+        //    still asserts 42, so a correctly-superseded rerun MUST now FAIL. ─────
+        var source = await File.ReadAllTextAsync(answerFile);
+        var edited = source.Replace("exit(42);", "exit(43);");
+        Assert.NotEqual(source, edited); // guard: the substitution actually applied
+        await File.WriteAllTextAsync(answerFile, edited);
+
+        // ── Cycle 2: SAME warm session, SAME request. The library now returns 43;
+        //    a stale-generation resolution would still see 42 and report PASS. ────
+        var lines2 = await server.SendRequestStreamingAsync(Req(libDir, testDir), TimeSpan.FromSeconds(180));
+        var (events2, d2) = ProtocolV2Streaming.Split(lines2);
+        var answerEvent2 = events2.Single(e => e.GetProperty("name").GetString()!.EndsWith("LibAnswer_Is42"));
+
+        // The whole point of the RED->GREEN cycle: a PASS here means the runner served
+        // the previous cycle's library code. Never silently accept that.
+        Assert.Equal("fail", answerEvent2.GetProperty("status").GetString());
+        var failMsg = answerEvent2.GetProperty("message").GetString() ?? "";
+        // Proves the NEW generation actually ran (returned 43), not just "any failure".
+        Assert.Contains("Expected 42 but got 43", failMsg);
+        // The dependent app's OTHER test (unrelated to the edit) must still pass —
+        // proof this is a targeted resolution fix, not a wholesale "everything after
+        // an edit now fails" regression.
+        Assert.Equal(1, d2.GetProperty("failed").GetInt32());
+    }
+
+    [SkippableFact]
+    public async Task RunTests_Then_EditDependency_EventSubscriberSupersedes_FiresExactlyOnce()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var (libDir, testDir, answerFile) = MakeLibTestPair("al-runner-xapp-stale-gen-sub");
+        var cacheDir = Path.Combine(Path.GetTempPath(), "al-runner-xapp-stale-gen-sub-cache", Guid.NewGuid().ToString("N"));
+        await using var server = await CliServer.StartAsync(new[] { "--cache", cacheDir });
+
+        // ── Cycle 1: fresh generation of WS Lib — the subscriber must fire exactly
+        //    once (sanity: the mechanism works at all). ───────────────────────────
+        var lines1 = await server.SendRequestStreamingAsync(Req(libDir, testDir), TimeSpan.FromSeconds(180));
+        var (events1, d1) = ProtocolV2Streaming.Split(lines1);
+        var subEvent1 = events1.Single(e => e.GetProperty("name").GetString()!.EndsWith("Fire_SubscriberFiresExactlyOnce"));
+        Assert.Equal("pass", subEvent1.GetProperty("status").GetString());
+
+        // ── Edit the dependency (any textual change forces a fresh compile — a NEW
+        //    "WS Fire Sub" generation, distinct from cycle 1's, both resident). ────
+        var source = await File.ReadAllTextAsync(answerFile);
+        var edited = source.Replace("exit(42);", "exit(42); // touched for cycle 2");
+        Assert.NotEqual(source, edited);
+        await File.WriteAllTextAsync(answerFile, edited);
+
+        // ── Cycle 2: SAME warm session, SAME request, ONE Fire() call. A missed
+        //    supersede in EventSubscriberPatches' own publisher-type cache seeds
+        //    BC's γeventScope sentinel on the STALE generation's OnFire_Scope class
+        //    instead of the fresh one Test's code actually calls into — so the fresh
+        //    generation's dispatch guard never opens and the byref counter stays at
+        //    0, not 1 (see the class doc comment for why this manifests as
+        //    under-firing rather than double-firing for this dispatch path). ───────
+        var lines2 = await server.SendRequestStreamingAsync(Req(libDir, testDir), TimeSpan.FromSeconds(180));
+        var (events2, d2) = ProtocolV2Streaming.Split(lines2);
+        var subEvent2 = events2.Single(e => e.GetProperty("name").GetString()!.EndsWith("Fire_SubscriberFiresExactlyOnce"));
+
+        Assert.Equal("pass", subEvent2.GetProperty("status").GetString());
+        Assert.Equal(0, d2.GetProperty("failed").GetInt32());
+    }
+}

--- a/AlRunner/BcRuntime.cs
+++ b/AlRunner/BcRuntime.cs
@@ -301,19 +301,66 @@ public static partial class BcRuntime
     internal static Assembly? CurrentTestAssembly => _currentTestAssembly;
 
     /// <summary>
-    /// True when <paramref name="asm"/> is a previous bundle assembly that is still
-    /// loaded after a server reload — same simple name as the current bundle
-    /// assembly (we re-emit under the identical module name) but a different
-    /// instance. AL-output scans that enumerate every loaded assembly (e.g. the
-    /// event-subscriber registry) must skip these so stale triggers/subscribers
-    /// don't double-register. Returns false in normal one-shot mode (no reload).
+    /// For every bundle-emitted assembly's simple name, the assembly instance from the
+    /// MOST RECENT compile of that app within this process — populated by
+    /// <see cref="SetTestAssembly"/> for every app it loads, not only the one currently
+    /// executing. .NET cannot unload assemblies, so a warm process that re-runs the same
+    /// bundle SET more than once (server mode / <c>--watch</c>) leaves every earlier
+    /// generation of EVERY app resident under its identical simple name (we re-emit under
+    /// the same module name each cycle).
+    ///
+    /// This is what makes <see cref="IsStaleBundleAssembly"/> correct for a cross-app
+    /// call: comparing only against <see cref="CurrentTestAssembly"/> (the old
+    /// implementation) can identify a stale generation of the app that is CURRENTLY
+    /// executing, but is blind to a stale generation of a SIBLING/dependency app that is
+    /// not the one currently executing — e.g. app B's tests running while app A (a
+    /// dependency B just called into) was edited and recompiled since the last cycle.
+    /// That gap is issue #1901: a call from B's test code into A's just-edited codeunit
+    /// resolved whichever generation of A's assembly <c>AppDomain.CurrentDomain
+    /// .GetAssemblies()</c> happened to enumerate first — unspecified order, and in
+    /// practice the OLDEST (first-loaded) generation — so the test kept passing against
+    /// A's pre-edit behaviour.
+    /// </summary>
+    private static readonly ConcurrentDictionary<string, Assembly> _latestGenerationByAssemblyName =
+        new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Records <paramref name="asm"/> as the current generation for its own simple name,
+    /// superseding whatever this process previously registered under that name. Called
+    /// from <see cref="SetTestAssembly"/> for every app it loads (own bundle AND every
+    /// sibling in a multi-bundle invocation), so the registry stays accurate for apps
+    /// that are not currently executing too — see <see cref="_latestGenerationByAssemblyName"/>.
+    /// </summary>
+    private static void RegisterAssemblyGeneration(Assembly asm)
+    {
+        var name = asm.GetName().Name;
+        if (name != null) _latestGenerationByAssemblyName[name] = asm;
+    }
+
+    /// <summary>
+    /// True when <paramref name="asm"/> is a previous-cycle generation of a bundle
+    /// assembly that is still resident after a server/watch reload — same simple name as
+    /// SOME app's current generation (we re-emit under the identical module name) but a
+    /// different instance. AL-output scans that enumerate every loaded assembly (the
+    /// event-subscriber registry, the Record/Codeunit/Page/… type finders) must skip
+    /// these so a stale generation can never answer for an AL object name — whether that
+    /// object still exists in the new generation or was deleted between cycles (the
+    /// "tombstone" case from #1901: skipping every type in a stale assembly means a
+    /// removed object can never be found there either).
+    ///
+    /// Backed by <see cref="_latestGenerationByAssemblyName"/> so this is accurate for
+    /// EVERY app registered via <see cref="SetTestAssembly"/>, not only whichever one is
+    /// <see cref="CurrentTestAssembly"/> right now (see that field's registration comment
+    /// for why the old current-assembly-only check missed cross-app calls). Returns false
+    /// for an assembly whose simple name was never registered (e.g. a genuine
+    /// service-tier/dependency DLL, or normal one-shot mode with no reload).
     /// </summary>
     internal static bool IsStaleBundleAssembly(Assembly asm)
     {
-        var cur = _currentTestAssembly;
-        return cur != null
-            && !ReferenceEquals(asm, cur)
-            && asm.GetName().Name == cur.GetName().Name;
+        var name = asm.GetName().Name;
+        return name != null
+            && _latestGenerationByAssemblyName.TryGetValue(name, out var latest)
+            && !ReferenceEquals(asm, latest);
     }
 
     /// <param name="wireFieldTriggers">
@@ -339,6 +386,11 @@ public static partial class BcRuntime
             return;
         }
         _currentTestAssembly = asm;
+        // Superseding registration for asm's OWN simple name — see
+        // _latestGenerationByAssemblyName's doc comment (#1901). Unconditional: this must
+        // happen for every app SetTestAssembly loads, not only whichever one ends up being
+        // CurrentTestAssembly when a cross-app call actually needs to resolve it.
+        RegisterAssemblyGeneration(asm);
         _codeunitTypeCache.Clear();
         // NavApp.GetResource: bind this emitted assembly to the current bundle dir
         // (its app.json resourceFolders are where the app's resource bytes live).

--- a/AlRunner/Patches/CodeunitPatches.cs
+++ b/AlRunner/Patches/CodeunitPatches.cs
@@ -978,6 +978,11 @@ public static partial class BcRuntime
         foreach (var asm in AppDomain.CurrentDomain.GetAssemblies())
         {
             if (asm == _currentTestAssembly) continue;
+            // Skip a previous-cycle generation of a SIBLING/dependency app —
+            // otherwise a cross-app call can bind to the stale generation even
+            // though CurrentTestAssembly correctly points at the fresh copy of the
+            // app actually executing right now (issue #1901).
+            if (IsStaleBundleAssembly(asm)) continue;
             try
             {
                 var t = Array.Find(asm.GetTypes(),
@@ -1008,6 +1013,11 @@ public static partial class BcRuntime
         foreach (var asm in AppDomain.CurrentDomain.GetAssemblies())
         {
             if (asm == _currentTestAssembly) continue;
+            // Skip a previous-cycle generation of a SIBLING/dependency app —
+            // otherwise a cross-app call can bind to the stale generation even
+            // though CurrentTestAssembly correctly points at the fresh copy of the
+            // app actually executing right now (issue #1901).
+            if (IsStaleBundleAssembly(asm)) continue;
             try
             {
                 var t = Array.Find(asm.GetTypes(),
@@ -1041,6 +1051,11 @@ public static partial class BcRuntime
         foreach (var asm in AppDomain.CurrentDomain.GetAssemblies())
         {
             if (asm == _currentTestAssembly) continue;
+            // Skip a previous-cycle generation of a SIBLING/dependency app —
+            // otherwise a cross-app call can bind to the stale generation even
+            // though CurrentTestAssembly correctly points at the fresh copy of the
+            // app actually executing right now (issue #1901).
+            if (IsStaleBundleAssembly(asm)) continue;
             try
             {
                 var t = Array.Find(asm.GetTypes(),
@@ -1075,6 +1090,11 @@ public static partial class BcRuntime
         foreach (var asm in AppDomain.CurrentDomain.GetAssemblies())
         {
             if (asm == _currentTestAssembly) continue;
+            // Skip a previous-cycle generation of a SIBLING/dependency app —
+            // otherwise a cross-app call can bind to the stale generation even
+            // though CurrentTestAssembly correctly points at the fresh copy of the
+            // app actually executing right now (issue #1901).
+            if (IsStaleBundleAssembly(asm)) continue;
             try
             {
                 var t = Array.Find(asm.GetTypes(),
@@ -1150,6 +1170,11 @@ public static partial class BcRuntime
         foreach (var asm in AppDomain.CurrentDomain.GetAssemblies())
         {
             if (asm == _currentTestAssembly) continue;
+            // Skip a previous-cycle generation of a SIBLING/dependency app —
+            // otherwise a cross-app call can bind to the stale generation even
+            // though CurrentTestAssembly correctly points at the fresh copy of the
+            // app actually executing right now (issue #1901).
+            if (IsStaleBundleAssembly(asm)) continue;
             try
             {
                 var t = Array.Find(asm.GetTypes(),

--- a/AlRunner/Patches/EventSubscriberPatches.cs
+++ b/AlRunner/Patches/EventSubscriberPatches.cs
@@ -421,7 +421,10 @@ public static class EventSubscriberPatches
     // serves all four object kinds.
     private static Type? FindObjectEventClrType(string publisherKind, int publisherId)
     {
-        if (_objectEventTypeCache.TryGetValue((publisherKind, publisherId), out var cached)) return cached;
+        // See FindClrType's matching comment — same self-healing requirement (#1901).
+        if (_objectEventTypeCache.TryGetValue((publisherKind, publisherId), out var cached)
+            && (cached == null || !BcRuntime.IsStaleBundleAssembly(cached.Assembly)))
+            return cached;
         var found = ResolveBusinessApplicationType(publisherKind + publisherId);
         _objectEventTypeCache[(publisherKind, publisherId)] = found;
         return found;
@@ -429,7 +432,15 @@ public static class EventSubscriberPatches
 
     private static Type? FindClrType(Dictionary<int, Type?> cache, string namePrefix, int objectId)
     {
-        if (cache.TryGetValue(objectId, out var cached)) return cached;
+        // A cached hit is only trustworthy while its assembly is still the CURRENT
+        // generation. A lookup that ran early in a cycle (before every app had
+        // (re)compiled — see PruneStaleSubscribers' doc comment) can cache the
+        // PREVIOUS cycle's Type; that entry never expires on its own, so without this
+        // check it would keep answering with a stale Type for the rest of the
+        // process even after the fresh generation registers (issue #1901).
+        if (cache.TryGetValue(objectId, out var cached)
+            && (cached == null || !BcRuntime.IsStaleBundleAssembly(cached.Assembly)))
+            return cached;
         var found = ResolveBusinessApplicationType(namePrefix + objectId);
         cache[objectId] = found;
         return found;
@@ -713,6 +724,26 @@ public static class EventSubscriberPatches
     }
 
     /// <summary>
+    /// Remove every subscriber entry whose declaring type's assembly is currently a stale
+    /// bundle generation (<see cref="BcRuntime.IsStaleBundleAssembly"/>) from every
+    /// discovery dictionary. Must be called with <see cref="_lock"/> already held. See the
+    /// call site in <see cref="EnsureRegistryFresh"/> for why this needs to run on every
+    /// re-scan, not just be relied on to never happen in the first place.
+    /// </summary>
+    private static void PruneStaleSubscribers()
+    {
+        foreach (var kv in _byKey)
+            kv.Value.RemoveAll(h => BcRuntime.IsStaleBundleAssembly(h.Method.DeclaringType!.Assembly));
+        foreach (var kv in _byCodeunitKey)
+            kv.Value.RemoveAll(m => BcRuntime.IsStaleBundleAssembly(m.DeclaringType!.Assembly));
+        foreach (var kv in _byTableEventKey)
+            kv.Value.RemoveAll(m => BcRuntime.IsStaleBundleAssembly(m.DeclaringType!.Assembly));
+        foreach (var kv in _byObjectEventKey)
+            kv.Value.RemoveAll(m => BcRuntime.IsStaleBundleAssembly(m.DeclaringType!.Assembly));
+        _validateSubs.RemoveAll(v => BcRuntime.IsStaleBundleAssembly(v.Handle.Method.DeclaringType!.Assembly));
+    }
+
+    /// <summary>
     /// Discovery: walk loaded assemblies for [NavEventSubscriberAttribute] methods, index
     /// by (publisher id, NavTriggerEventType ordinal). Incremental — only re-scans when the
     /// assembly count grows.
@@ -725,6 +756,22 @@ public static class EventSubscriberPatches
         {
             asms = AppDomain.CurrentDomain.GetAssemblies();
             if (asms.Length == _lastScannedCount) return;
+
+            // A discovery scan can run BEFORE every app in the current cycle has
+            // (re)compiled — e.g. PopulateNclMetadataCache's own InjectAll call fires
+            // during a dependency app's source-registration pass, ahead of that same
+            // app's own SetTestAssembly for THIS cycle. At that instant the previous
+            // cycle's generation is still the only (and therefore "latest") one
+            // BcRuntime knows about, so it is correctly, but only TEMPORARILY, not
+            // stale — the scan below adds its [EventSubscriber] methods faithfully.
+            // Once the dependency's fresh generation registers moments later, that
+            // earlier entry becomes stale but nothing before this line ever revisits
+            // it: dictionaries only ever grow. Prune every entry whose declaring
+            // assembly IS stale RIGHT NOW, before adding anything new, so a
+            // superseded generation's subscriber can never coexist with (and
+            // double-fire alongside) the fresh one, or survive alone if the fresh
+            // scan hasn't found its replacement yet (issue #1901).
+            PruneStaleSubscribers();
 
             int added = 0;
             int scannedAttrs = 0;


### PR DESCRIPTION
Closes #1901

## Problem

In a multi-bundle `--watch` (and equally `--server`) session, a call from one app into another dependency app could execute the **previous cycle's** code. .NET cannot unload assemblies, so once a bundle recompiles mid-session, every earlier generation of every app stays resident under the same emitted simple name. The type finders that resolve an AL object dynamically by id (`CodeunitPatches.FindCodeunitType`, `FindReportType`, `FindFormType`, `FindTestPageType`, `FindQueryType`) only ever preferred `BcRuntime.CurrentTestAssembly` — which covers the app *currently executing*, not a dependency it calls into — and otherwise fell back to an unordered scan of every loaded assembly. In practice that scan returned the *oldest* (first-loaded) generation, so a test kept reporting PASS against pre-edit dependency behaviour: silent, no crash, no diagnostic.

## Root cause and fix

Added a process-wide "latest generation per assembly simple name" registry (`BcRuntime._latestGenerationByAssemblyName`, a `ConcurrentDictionary`), populated by every `SetTestAssembly` call — i.e. for every app a cycle loads, not only whichever ends up being `CurrentTestAssembly`. `BcRuntime.IsStaleBundleAssembly` is rewritten to consult this registry instead of comparing only against `CurrentTestAssembly`, which makes it correct for a sibling/dependency app that isn't the one currently executing. The five `CodeunitPatches` type finders now skip a stale generation via this check in their assembly-scan fallback.

The same class of gap also existed one layer deeper, in `EventSubscriberPatches`:
- Its own publisher-type caches (`FindClrType`/`FindObjectEventClrType`) could permanently cache a **stale** CLR type if a discovery scan happened to run before a dependency's fresh generation had registered for the cycle (this does happen — `PopulateNclMetadataCache`'s own `InjectAll` call can fire during a dependency's source-registration pass, ahead of that same app's `SetTestAssembly` for the current cycle). That stale cache entry never expired, which meant BC's own `γeventScope` sentinel got seeded on the wrong (previous-cycle) generation's `<EventName>_Scope` class — the fresh generation's own dispatch guard was never opened, so the subscriber silently stopped firing entirely after a dependency edit.
- `EnsureRegistryFresh`'s discovery dictionaries (`_byKey`, `_byCodeunitKey`, `_byTableEventKey`, `_byObjectEventKey`, `_validateSubs`) only ever grew — an entry discovered from a since-superseded generation was never pruned, which is the double-registration shape the issue's "Likely fix" section calls out explicitly.

Both are fixed: `FindClrType`/`FindObjectEventClrType` now revalidate a cached `Type` against the current generation before trusting it (falls through to a fresh resolve if stale), and `EnsureRegistryFresh` now prunes any already-discovered entry whose declaring assembly is currently stale on every re-scan, before adding anything new.

## Tests

`AlRunner.Tests/ServerCrossAppStaleGenerationTests.cs` — two `--server`-mode tests (the identical in-process warm-reload mechanism `--watch` uses, chosen over spawning `--watch` end-to-end for iteration speed; both share the exact `SetTestAssembly`/`EnsureRegistryFresh` code paths):

1. `RunTests_Then_EditDependencyOnly_Rerun_ObservesTheEditNotTheStaleGeneration` — a `WS Lib`/`WS Test` app pair (`WS Test` depends on `WS Lib`, calls `WS Lib`'s codeunit). Cycle 1 passes (`Answer()` returns 42). Edit *only* `WS Lib`'s codeunit to return 43, rerun in the same warm session — the test still asserts 42, so it must now FAIL naming 43. **RED before the fix: cycle 2 still reports PASS** (served the stale generation). **GREEN after: FAILS with `Expected 42 but got 43`**, proving the freshly-edited generation actually ran; the sibling test unaffected by the edit still passes (`failed == 1`, not a wholesale regression).

2. `RunTests_Then_EditDependency_EventSubscriberSupersedes_FiresExactlyOnce` — same app pair, `WS Lib` additionally declares a manually-published codeunit event (`WS Fire Event`) and a subscriber (`WS Fire Sub`) that increments a byref counter. Cycle 1 fires once. Edit `WS Lib` (forcing a fresh compile of the whole module, including the subscriber codeunit), rerun — one `Fire()` call must still increment the counter to exactly 1. **RED before the fix: fires 0 times** (the stale-cache-seeding gap silenced dispatch entirely for this specific dispatch path — see the class doc comment for why the failure mode here is under-firing rather than double-firing: `CodeunitEventDispatcher.DispatchCore` already dedupes by AL identity, which happens to mask a literal double-fire for codeunit-to-codeunit events even when a stale generation's subscriber is briefly rediscovered). **GREEN after: fires exactly once.**

Both isolated against reverting only the `EventSubscriberPatches.cs` half of the fix (keeping the `BcRuntime`/`CodeunitPatches` half): test 2 stays RED, confirming the `PruneStaleSubscribers`/self-healing-cache changes are independently load-bearing, not redundant with the primary fix.

## Verification

- `dotnet build` — 0 errors, both `AlRunner` and `AlRunner.Tests`.
- New tests: RED confirmed pre-fix (both, and isolated per file), GREEN confirmed post-fix.
- Full `AlRunner.Tests` suite: `Passed! - Failed: 0, Passed: 689, Skipped: 23, Total: 712` (skips are the usual environment-conditional ones, e.g. Windows-only reflection paths).
- Rebased cleanly onto current `main` (post #1910/#1911/#1912/#1913) and reran both proving tests green after rebase.

No `tests/al-language` submodule changes — this is runner-specific behaviour (`--watch`/`--server` cycle semantics, per-emitted-assembly module identity), which `bc-behavior-tests-go-upstream.md` explicitly names as belonging in `AlRunner.Tests`, not the upstream corpus.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EU4fwyWDu5CiUrhbPoxAhb)_