### PR TITLE
Fix source-dependency compile to honour dep's app.json manifest (AL0543 exit 134)

### DIFF
--- a/AlRunner.Tests/LayeredDepManifestTests.cs
+++ b/AlRunner.Tests/LayeredDepManifestTests.cs
@@ -1,0 +1,205 @@
+using System.Diagnostics;
+using System.Text;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// #1898: the layered source-dependency compile (<c>Program.RunLayeredPrePass</c> →
+/// <c>BcCompiler.EmitDepSymbols</c>) used to build the dep's <c>Compilation</c> from
+/// identity + <c>internalsVisibleTo</c> only, never from the dep's own app.json. So a
+/// dependency that legitimately sets <c>contextSensitiveHelpUrl</c> and has a page
+/// setting <c>ContextSensitiveHelpPage</c> failed AL0543 — "manifest property
+/// 'contextSensitiveHelpUrl' must be set" — against a manifest that DOES set it. The
+/// resulting <c>InvalidOperationException</c> was thrown from a call site outside every
+/// try/catch in Main, so it reached the CLR's default handler and aborted the whole
+/// process (exit 134, no al-runner-formatted output) before a single test in EITHER
+/// bundle ran — including tests unrelated to help links.
+///
+/// Two tests, both directions:
+///   - Positive: the dep's app.json genuinely sets contextSensitiveHelpUrl → the
+///     layered build must honour it, AL0543 must not fire, and both bundles' tests run.
+///   - Negative: the dep's app.json genuinely OMITS contextSensitiveHelpUrl (an actually
+///     invalid manifest, given the page's ContextSensitiveHelpPage) → AL0543 must still
+///     fire (the fix must not just make the diagnostic disappear unconditionally — that
+///     would hide a real manifest error, same trap as #1899/AL0327), but now as a
+///     formatted "<layered-deps>: COMPILE-FAIL" line with the documented exit code 3
+///     (docs/server-mode.md's compile-error ladder), never an unhandled-exception
+///     stack trace and exit 134.
+///
+/// Spawns the real runner; needs the BC artifact cache. Skips (no-op) when absent.
+/// See DefineFlagIntegrationTests for why this used to be
+/// [Collection("server-serial")] and no longer is — #1809.
+/// </summary>
+public class LayeredDepManifestTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+    private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
+
+    private static (string output, int exit) RunRunner(params string[] bundles)
+    {
+        var args = new StringBuilder(TestBuildConfig.RunArgs(ProjectPath));
+        args.Append(TestBuildConfig.BcVersionArg);
+        foreach (var b in bundles) args.Append(" \"").Append(b).Append('"');
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet", Arguments = args.ToString(),
+            RedirectStandardOutput = true, RedirectStandardError = true,
+            UseShellExecute = false, CreateNoWindow = true, WorkingDirectory = RepoRoot,
+        };
+        var sb = new StringBuilder();
+        var p = Process.Start(psi)!;
+        p.OutputDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.ErrorDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.BeginOutputReadLine();
+        p.BeginErrorReadLine();
+        if (!p.WaitForExit(180_000)) { try { p.Kill(true); } catch { } throw new TimeoutException("runner hung"); }
+        p.WaitForExit();
+        lock (sb) return (sb.ToString(), p.ExitCode);
+    }
+
+    private static void WriteDep(string dir, string id, string name, int idFrom,
+        int pageId, int codeunitId, string? contextSensitiveHelpUrl)
+    {
+        Directory.CreateDirectory(dir);
+        var helpUrlLine = contextSensitiveHelpUrl == null
+            ? ""
+            : $"\n  \"contextSensitiveHelpUrl\": \"{contextSensitiveHelpUrl}\",";
+        File.WriteAllText(Path.Combine(dir, "app.json"), $$"""
+        {
+          "id": "{{id}}",
+          "name": "{{name}}",
+          "publisher": "AL Runner",
+          "version": "1.0.0.0",{{helpUrlLine}}
+          "dependencies": [],
+          "platform": "1.0.0.0",
+          "application": "1.0.0.0",
+          "idRanges": [ { "from": {{idFrom}}, "to": {{idFrom + 19}} } ],
+          "runtime": "14.0"
+        }
+        """);
+        // A page that requires contextSensitiveHelpUrl to be set (AL0543 otherwise), plus
+        // a plain codeunit the dependent bundle actually exercises.
+        File.WriteAllText(Path.Combine(dir, "HelpAware.Page.al"), $$"""
+        page {{pageId}} "LDM Help Aware Page"
+        {
+            PageType = Card;
+            ContextSensitiveHelpPage = 'sales-invoice';
+
+            layout
+            {
+                area(Content)
+                {
+                    field(Dummy; DummyValue) { ApplicationArea = All; Caption = 'Dummy'; }
+                }
+            }
+
+            var
+                DummyValue: Text[30];
+        }
+        """);
+        File.WriteAllText(Path.Combine(dir, "Answer.Codeunit.al"), $$"""
+        codeunit {{codeunitId}} "LDM Answer"
+        {
+            procedure Answer(): Integer
+            begin
+                exit(42);
+            end;
+        }
+        """);
+    }
+
+    private static void WriteMain(string dir, string id, string name, int idFrom,
+        int testCodeunitId, string depId, string depName, string answerCodeunitRef)
+    {
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "app.json"), $$"""
+        {
+          "id": "{{id}}",
+          "name": "{{name}}",
+          "publisher": "AL Runner",
+          "version": "1.0.0.0",
+          "dependencies": [
+            { "id": "{{depId}}", "name": "{{depName}}", "publisher": "AL Runner", "version": "1.0.0.0" }
+          ],
+          "platform": "1.0.0.0",
+          "application": "1.0.0.0",
+          "idRanges": [ { "from": {{idFrom}}, "to": {{idFrom + 19}} } ],
+          "runtime": "14.0"
+        }
+        """);
+        File.WriteAllText(Path.Combine(dir, "Tests.Codeunit.al"), $$"""
+        codeunit {{testCodeunitId}} "LDM Tests"
+        {
+            Subtype = Test;
+
+            [Test]
+            procedure DepCodeunit_Answer_Returns42()
+            var
+                Answer: Codeunit "{{answerCodeunitRef}}";
+                Actual: Integer;
+            begin
+                Actual := Answer.Answer();
+                if Actual <> 42 then
+                    Error('Expected 42 but got %1', Actual);
+            end;
+        }
+        """);
+    }
+
+    [SkippableFact]
+    public void DepManifestSetsContextSensitiveHelpUrl_LayeredBuildHonoursIt_BothBundlesRun()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var root = Path.Combine(Path.GetTempPath(), "al-runner-layered-ctxhelp-pos", Guid.NewGuid().ToString("N"));
+        var depDir = Path.Combine(root, "dep");
+        var mainDir = Path.Combine(root, "main");
+        var depId = "c1a20000-0000-4000-8000-0000000000a1";
+        var mainId = "c1a20000-0000-4000-8000-0000000000a2";
+
+        WriteDep(depDir, depId, "LDM Pos Dep", 60900, 60900, 60901,
+            contextSensitiveHelpUrl: "https://example.com/docs/");
+        WriteMain(mainDir, mainId, "LDM Pos Main", 60910, 60910, depId, "LDM Pos Dep", "LDM Answer");
+
+        var (output, exit) = RunRunner(depDir, mainDir);
+
+        // Precondition: this really took the layered two-bundle source-dependency path,
+        // not a degenerate single-bundle one.
+        Assert.Contains("[layered]", output);
+        Assert.DoesNotContain("AL0543", output);
+        Assert.DoesNotContain("Unhandled exception", output);
+        Assert.True(exit == 0 && output.Contains("1P/0F/0E"),
+            $"a dependency whose manifest genuinely sets contextSensitiveHelpUrl must compile and run (exit {exit}):\n{output}");
+    }
+
+    [SkippableFact]
+    public void DepManifestOmitsContextSensitiveHelpUrl_StillFailsAL0543_AsFormattedCompileFailNotCrash()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var root = Path.Combine(Path.GetTempPath(), "al-runner-layered-ctxhelp-neg", Guid.NewGuid().ToString("N"));
+        var depDir = Path.Combine(root, "dep");
+        var mainDir = Path.Combine(root, "main");
+        var depId = "c1a20000-0000-4000-8000-0000000000b1";
+        var mainId = "c1a20000-0000-4000-8000-0000000000b2";
+
+        WriteDep(depDir, depId, "LDM Neg Dep", 60920, 60920, 60921,
+            contextSensitiveHelpUrl: null); // genuinely unset — a real manifest error
+        WriteMain(mainDir, mainId, "LDM Neg Main", 60930, 60930, depId, "LDM Neg Dep", "LDM Answer");
+
+        var (output, exit) = RunRunner(depDir, mainDir);
+
+        // The fix must not make AL0543 unconditionally disappear — a manifest that
+        // genuinely omits the property is genuinely invalid, and BC would reject it too.
+        Assert.Contains("AL0543", output);
+        // But the failure must be a formatted, documented runner outcome, never the raw
+        // CLR unhandled-exception path (which — pre-fix — produced this exact stack:
+        // "Unhandled exception. System.InvalidOperationException: [layered] Failed to
+        // emit symbols…" and exit code 134/SIGABRT).
+        Assert.DoesNotContain("Unhandled exception", output);
+        Assert.Contains("COMPILE-FAIL", output);
+        Assert.Equal(3, exit);
+    }
+}

--- a/AlRunner/BcCompiler.cs
+++ b/AlRunner/BcCompiler.cs
@@ -1879,17 +1879,36 @@ public sealed class BcCompiler
             var src = File.ReadAllText(alFiles[i]);
             trees[i] = NavSyntax.SyntaxTree.ParseObjectText(src, path: alFiles[i], encoding: null!, parseOpts, default);
         });
+        // Locate the dep's own app.json BEFORE building CompilationOptions — both
+        // internalsVisibleTo (below) and contextSensitiveHelpUrl (#1898) are read from
+        // it, and the latter has to be in hand for the CompilationOptions ctor itself.
+        var foundAppJson = dirs.Select(d => Path.Combine(d, "app.json")).FirstOrDefault(File.Exists);
         var compOpts = new NavCA.CompilationOptions(
             continueBuildOnError: true,
             target: NavCA.CompilationTarget.OnPrem,
             generateOptions:
-                NavCA.CompilationGenerationOptions.Code | NavCA.CompilationGenerationOptions.Navigation);
+                NavCA.CompilationGenerationOptions.Code | NavCA.CompilationGenerationOptions.Navigation,
+            // #1898: BC's AL0543 check ("The manifest property 'contextSensitiveHelpUrl'
+            // must be set in order to use the property 'ContextSensitiveHelpPage'") reads
+            // THIS CompilationOptions field directly — there is no separate "give the
+            // compiler the manifest" API on Compilation/Compilation.Create (confirmed via
+            // reflection over Compilation's public surface: no WithManifest, and
+            // CompilationOptions' ctor takes contextSensitiveHelpUrl as a plain string
+            // param, default ""). Leaving it unset here — as EmitDepSymbols always did
+            // before this fix — makes BC treat the property as unset even when the dep's
+            // own app.json genuinely sets it, so a dependency using
+            // ContextSensitiveHelpPage always failed AL0543 regardless of its manifest.
+            // Reading the real value here restores parity with what alc.exe does (and
+            // with what the primary bundle-compile path already tolerates via its own,
+            // separate leniency — see the Emit() docs above). A dep whose manifest
+            // genuinely omits the URL still gets "" here and AL0543 still fires,
+            // preserving the diagnostic for an actually-invalid manifest.
+            contextSensitiveHelpUrl: ReadContextSensitiveHelpUrl(foundAppJson));
         // Propagate the dep's own `internalsVisibleTo` (from its app.json) into the
         // Compilation. BC populates IModuleSymbol.InternalsVisibleToModules ONLY from
         // this dedicated Create parameter — not from the manifest — so without it a
         // dependent app hits AL0161 on the dep's Access=Internal members even when the
         // grant exists. (main:Program.cs BuildInternalsVisibleToRefs.)
-        var foundAppJson = dirs.Select(d => Path.Combine(d, "app.json")).FirstOrDefault(File.Exists);
         var ivtRefs = ReadInternalsVisibleToRefs(foundAppJson);
 
         var compilation = NavCA.Compilation.Create(
@@ -1984,6 +2003,28 @@ public sealed class BcCompiler
             return refs.Count > 0 ? refs : null;
         }
         catch { return null; }
+    }
+
+    /// <summary>
+    /// Read <c>contextSensitiveHelpUrl</c> from an app.json, for the dedicated
+    /// <c>contextSensitiveHelpUrl</c> parameter of <see cref="NavCA.CompilationOptions"/>
+    /// (see #1898). Empty string — BC's own default for the parameter — when the
+    /// manifest is missing, unreadable, or genuinely omits the property, so an
+    /// actually-unset manifest still trips AL0543 on a page/report/etc. using
+    /// <c>ContextSensitiveHelpPage</c>, exactly as real BC does.
+    /// </summary>
+    private static string ReadContextSensitiveHelpUrl(string? appJsonPath)
+    {
+        if (appJsonPath == null || !File.Exists(appJsonPath)) return "";
+        try
+        {
+            using var json = System.Text.Json.JsonDocument.Parse(File.ReadAllText(appJsonPath));
+            if (json.RootElement.TryGetProperty("contextSensitiveHelpUrl", out var v)
+                && v.ValueKind == System.Text.Json.JsonValueKind.String)
+                return v.GetString() ?? "";
+        }
+        catch { /* fall through to the "unset" default below */ }
+        return "";
     }
 
     /// <summary>

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -784,13 +784,44 @@ var results = new List<BucketResult>();
 // (symbols.json-only scan) instead of _packageCacheDirs. See BcCompiler
 // GetSharedReferences for the _extraSymbolDirs contract.
 var layeredWorkspaceDirs = new List<string>();
+// #1898: RunLayeredPrePass/BuildSiblingSourceDeps run BEFORE a single object of ANY
+// bundle compiles or a single test runs — a genuine dependency-compile failure inside
+// either (e.g. an impl app whose app.json really omits a manifest property its AL
+// needs, so AL0543 legitimately fires) throws InvalidOperationException, and this call
+// site sat outside every try/catch in Main. That let the exception reach the CLR's
+// default unhandled-exception handler, which prints a raw .NET stack trace and aborts
+// the process with SIGABRT (exit 134) — no al-runner-formatted diagnostic, no
+// documented exit code, and EVERY bundle in the invocation lost, not just the one
+// whose dependency is broken. Catch here and report it the same way every other
+// compile-time failure in this file does: a "<layered-deps>: COMPILE-FAIL" line on
+// stderr and the documented exit code 3 (docs/server-mode.md's "3 compilation error"
+// ladder — same code EMIT-ZERO/COMPILE-FAIL already return elsewhere in Main).
 if (bundles.Count > 1)
-    packageCacheDirs = RunLayeredPrePass(bundles, packageCacheDirs, layeredWorkspaceDirs);
+{
+    try
+    {
+        packageCacheDirs = RunLayeredPrePass(bundles, packageCacheDirs, layeredWorkspaceDirs);
+    }
+    catch (Exception ex)
+    {
+        Console.Error.WriteLine($"<layered-deps>: COMPILE-FAIL — {ex.Message}");
+        return 3;
+    }
+}
 // Discover + compile sibling source-only dependency apps. Some apps declare a
 // dependency that ships ONLY as AL source in a sibling directory (not a compiled
 // .app in any cache) — e.g. the corpus internalsVisibleTo fixture next to the
 // main test app. Inert when no declared dep matches a sibling source app.
-packageCacheDirs = BuildSiblingSourceDeps(bundles, packageCacheDirs, layeredWorkspaceDirs);
+// Same unhandled-exception exposure as RunLayeredPrePass above (#1898) — same fix.
+try
+{
+    packageCacheDirs = BuildSiblingSourceDeps(bundles, packageCacheDirs, layeredWorkspaceDirs);
+}
+catch (Exception ex)
+{
+    Console.Error.WriteLine($"<sibling-source-deps>: COMPILE-FAIL — {ex.Message}");
+    return 3;
+}
 
 // Dirs the COMPILE-time .app scanner may safely enumerate: everything except the
 // synthetic workspace dirs (whose source-only .apps would trip AL1023).


### PR DESCRIPTION
Closes #1898

## Problem

`BcCompiler.EmitDepSymbols` — the compile step for a source dependency in the
layered/sibling-source-dep pre-passes — built its `Compilation` from identity
and `internalsVisibleTo` only, never from the dependency's own `app.json`. A
dependency that legitimately declares `contextSensitiveHelpUrl` and has a page
setting `ContextSensitiveHelpPage` therefore always failed `AL0543` ("The
manifest property 'contextSensitiveHelpUrl' must be set...") — against a
manifest that DOES set it.

That `InvalidOperationException` was thrown from a call site
(`Program.RunLayeredPrePass`) that sat outside every `try`/`catch` in `Main`,
so it reached the CLR's default unhandled-exception handler: raw stack trace
on stderr, process aborted with SIGABRT (**exit 134**), zero al-runner output
(no JSON, no JUnit) — and every bundle in the invocation lost, not just the
one with the affected dependency.

## Root cause (confirmed via reflection over `Compilation`'s public surface)

`Microsoft.Dynamics.Nav.CodeAnalysis.CompilationOptions` has a dedicated
`contextSensitiveHelpUrl` constructor parameter (default `""`) — that's what
BC's AL0543 check reads. There is no separate "give the compiler the
manifest" API on `Compilation`/`Compilation.Create` (no `WithManifest`
overload exists). `EmitDepSymbols` never set it, so BC always treated the
property as unset regardless of what the dep's own `app.json` said.

Note: I also found that the **primary** bundle-compile path (`BcCompiler.Emit`)
has the identical gap (never passes `contextSensitiveHelpUrl` either) but
tolerates the resulting AL0543 diagnostic silently — it only fails a bundle
when `Sources.Count == 0` or the C# compile itself fails, and AL0543 doesn't
zero out either. That's a separate, pre-existing divergence from real `alc`
(a manifest error that should legitimately block compilation is silently
accepted) and is out of scope for this issue — flagging it here rather than
silently discovering-and-ignoring it, per this repo's own rules. Happy to
file a follow-up if wanted.

## Fix

1. **`AlRunner/BcCompiler.cs`** — `EmitDepSymbols` now reads
   `contextSensitiveHelpUrl` from the dep's `app.json` (the same file
   `ReadInternalsVisibleToRefs` already locates two lines above) and passes it
   into `CompilationOptions`. A manifest that genuinely omits the property
   still gets `""` and AL0543 still fires — the fix doesn't make the
   diagnostic unconditionally disappear (same trap #1899 had with AL0327).
2. **`AlRunner/Program.cs`** — wrapped the top-level `RunLayeredPrePass` and
   `BuildSiblingSourceDeps` calls (both previously unguarded) so a genuine
   dependency-compile failure is reported as a formatted
   `<layered-deps>: COMPILE-FAIL` / `<sibling-source-deps>: COMPILE-FAIL` line
   with the documented exit code `3` (`docs/server-mode.md`'s compile-error
   ladder), never an unhandled-exception stack trace and exit 134.

## Where the proving test lives

This is runner-specific compile-wiring behaviour (how the layered
source-dependency pre-pass builds a `Compilation`, and how a compile failure
there is reported), not a claim about what BC itself does with a given
manifest — so per `bc-behavior-tests-go-upstream.md` it belongs in
`AlRunner.Tests`, not the upstream corpus. Added
`AlRunner.Tests/LayeredDepManifestTests.cs` (spawns the real runner, same
shape as `LayeredCacheTests`/`SourceDepSymbolsWithoutPackageCacheTests`):

- **Positive** — dep's `app.json` genuinely sets `contextSensitiveHelpUrl` →
  layered build honours it, no AL0543, both bundles' tests run, exit 0.
- **Negative** — dep's `app.json` genuinely omits it → AL0543 still fires,
  but now as `<layered-deps>: COMPILE-FAIL`, exit 3, no `Unhandled exception`
  text anywhere in the output.

## Verification

- Manually reproduced the issue's exact two-app repro pre-fix: `AL0543` →
  unhandled exception → exit 134. Confirmed post-fix: both tests pass, exit 0.
- Manually built a negative variant (dep genuinely omits the property):
  pre-fix exit 134 with a raw stack trace; post-fix `AL0543` still fires,
  now as a formatted compile-fail, exit 3.
- Stashed the fix and re-ran the two new `AlRunner.Tests` cases — both failed
  for the expected reasons (RED). Restored the fix — both pass (GREEN).
- `dotnet test AlRunner.Tests` — full suite: 693 passed, 26 skipped
  (pre-existing, environment-gated), 0 failed.
- `tests/runner-extras` (all 25 app groups, same invocation CI uses,
  `--package-cache` for both platform-apps and test-apps): 123/123 tests
  pass, exit 0 — no regression in the sibling-source-dep / layered-dep paths
  this change touches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EU4fwyWDu5CiUrhbPoxAhb


---
_Generated by [Claude Code](https://claude.ai/code/session_01EU4fwyWDu5CiUrhbPoxAhb)_