### PR TITLE
fix(watch): debounce on quiescence, not a fixed post-first-event sleep

### DIFF
--- a/AlRunner.Tests/Fixtures/WatchBurstSwitch/Assert.Codeunit.al
+++ b/AlRunner.Tests/Fixtures/WatchBurstSwitch/Assert.Codeunit.al
@@ -1,0 +1,13 @@
+/// <summary>
+/// Minimal assertion helper for this fixture app (own ID range so it
+/// stands alone from the corpus Assert). Identical in both "versions" —
+/// WatchBurstSwitchTests never edits this file.
+/// </summary>
+codeunit 60250 "Burst Assert RXT"
+{
+    procedure AreEqual(Expected: Text; Actual: Text; Msg: Text)
+    begin
+        if Expected <> Actual then
+            Error('Assert.AreEqual failed. Expected:<%1>. Actual:<%2>. %3', Expected, Actual, Msg);
+    end;
+}

--- a/AlRunner.Tests/Fixtures/WatchBurstSwitch/app.json
+++ b/AlRunner.Tests/Fixtures/WatchBurstSwitch/app.json
@@ -1,0 +1,25 @@
+{
+  "id": "b2c3d4e5-f607-4819-ab2c-3d4e5f607182",
+  "name": "Runner Tests Fixture - Watch Burst Switch",
+  "publisher": "AL Runner",
+  "version": "1.0.0.0",
+  "brief": "Regression fixture for #1904: a bulk multi-file rewrite (simulating a branch switch) must produce exactly one --watch cycle, against the fully-settled tree, not a phantom cycle mid-rewrite.",
+  "description": "Six addend codeunits (F0..F5) plus a sum test whose expected total is spread across a seventh file. 'Version A' has every addend return 1 and the test expect 6; 'version B' has every addend return 10 and the test expect 60. A half-applied mix of A/B files sums to neither 6 nor 60, so a watch cycle that reads the tree mid-rewrite reports a wrong (phantom) result even though both A and B, fully applied, pass. Used by AlRunner.Tests' WatchBurstSwitchTests.",
+  "privacyStatement": "",
+  "EULA": "",
+  "help": "",
+  "url": "",
+  "logo": "",
+  "dependencies": [],
+  "screenshots": [],
+  "platform": "1.0.0.0",
+  "application": "1.0.0.0",
+  "idRanges": [
+    {
+      "from": 60200,
+      "to": 60299
+    }
+  ],
+  "runtime": "14.0",
+  "features": []
+}

--- a/AlRunner.Tests/Fixtures/WatchBurstSwitch/v1/F0.Codeunit.al
+++ b/AlRunner.Tests/Fixtures/WatchBurstSwitch/v1/F0.Codeunit.al
@@ -1,0 +1,9 @@
+/// <summary>Version A addend #0: always returns 1. WatchBurstSwitchTests overwrites
+/// this file's content to the "version B" value (10) as part of the burst switch.</summary>
+codeunit 60201 "Burst F0 RXT"
+{
+    procedure GetValue(): Integer
+    begin
+        exit(1);
+    end;
+}

--- a/AlRunner.Tests/Fixtures/WatchBurstSwitch/v1/F1.Codeunit.al
+++ b/AlRunner.Tests/Fixtures/WatchBurstSwitch/v1/F1.Codeunit.al
@@ -1,0 +1,8 @@
+/// <summary>Version A addend #1: always returns 1.</summary>
+codeunit 60202 "Burst F1 RXT"
+{
+    procedure GetValue(): Integer
+    begin
+        exit(1);
+    end;
+}

--- a/AlRunner.Tests/Fixtures/WatchBurstSwitch/v1/F2.Codeunit.al
+++ b/AlRunner.Tests/Fixtures/WatchBurstSwitch/v1/F2.Codeunit.al
@@ -1,0 +1,8 @@
+/// <summary>Version A addend #2: always returns 1.</summary>
+codeunit 60203 "Burst F2 RXT"
+{
+    procedure GetValue(): Integer
+    begin
+        exit(1);
+    end;
+}

--- a/AlRunner.Tests/Fixtures/WatchBurstSwitch/v1/F3.Codeunit.al
+++ b/AlRunner.Tests/Fixtures/WatchBurstSwitch/v1/F3.Codeunit.al
@@ -1,0 +1,8 @@
+/// <summary>Version A addend #3: always returns 1.</summary>
+codeunit 60204 "Burst F3 RXT"
+{
+    procedure GetValue(): Integer
+    begin
+        exit(1);
+    end;
+}

--- a/AlRunner.Tests/Fixtures/WatchBurstSwitch/v1/F4.Codeunit.al
+++ b/AlRunner.Tests/Fixtures/WatchBurstSwitch/v1/F4.Codeunit.al
@@ -1,0 +1,8 @@
+/// <summary>Version A addend #4: always returns 1.</summary>
+codeunit 60205 "Burst F4 RXT"
+{
+    procedure GetValue(): Integer
+    begin
+        exit(1);
+    end;
+}

--- a/AlRunner.Tests/Fixtures/WatchBurstSwitch/v1/F5.Codeunit.al
+++ b/AlRunner.Tests/Fixtures/WatchBurstSwitch/v1/F5.Codeunit.al
@@ -1,0 +1,8 @@
+/// <summary>Version A addend #5: always returns 1.</summary>
+codeunit 60206 "Burst F5 RXT"
+{
+    procedure GetValue(): Integer
+    begin
+        exit(1);
+    end;
+}

--- a/AlRunner.Tests/Fixtures/WatchBurstSwitch/v1/Sum.Codeunit.al
+++ b/AlRunner.Tests/Fixtures/WatchBurstSwitch/v1/Sum.Codeunit.al
@@ -1,0 +1,40 @@
+/// <summary>
+/// Version A: sums F0..F5 (each 1) and expects 6. WatchBurstSwitchTests overwrites this
+/// file's expected total to 60 (matching version B's addends) as the LAST write of the
+/// burst switch — so a watch cycle that fires before every F-file AND this file have all
+/// settled to version B reads a mismatched mix and reports a phantom FAIL, even though
+/// both version A (all files at 1/6) and version B (all files at 10/60), fully applied,
+/// pass on their own.
+/// </summary>
+codeunit 60210 "Burst Sum Tests RXT"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit "Burst Assert RXT";
+        F0: Codeunit "Burst F0 RXT";
+        F1: Codeunit "Burst F1 RXT";
+        F2: Codeunit "Burst F2 RXT";
+        F3: Codeunit "Burst F3 RXT";
+        F4: Codeunit "Burst F4 RXT";
+        F5: Codeunit "Burst F5 RXT";
+
+    [Test]
+    procedure Sum_OfAllValues_MatchesExpectedTotal()
+    var
+        Total: Integer;
+    begin
+        // [GIVEN] six addend codeunits
+        // [WHEN] their values are summed
+        Total := F0.GetValue() + F1.GetValue() + F2.GetValue() + F3.GetValue()
+            + F4.GetValue() + F5.GetValue();
+
+        // [THEN] the total matches this version's expectation. Every addend AND this
+        // expected value live in SEPARATE files, so a half-applied file set (some
+        // addends switched, some not, or this file switched but an addend not) sums to
+        // neither this version's total nor the other version's — a value that cannot
+        // occur once the whole switch has settled.
+        Assert.AreEqual('6', Format(Total),
+            'sum of six addends did not match version A''s expected total');
+    end;
+}

--- a/AlRunner.Tests/Fixtures/WatchBurstSwitch/v2/F0.Codeunit.al
+++ b/AlRunner.Tests/Fixtures/WatchBurstSwitch/v2/F0.Codeunit.al
@@ -1,0 +1,8 @@
+/// <summary>Version B addend #0: always returns 10.</summary>
+codeunit 60201 "Burst F0 RXT"
+{
+    procedure GetValue(): Integer
+    begin
+        exit(10);
+    end;
+}

--- a/AlRunner.Tests/Fixtures/WatchBurstSwitch/v2/F1.Codeunit.al
+++ b/AlRunner.Tests/Fixtures/WatchBurstSwitch/v2/F1.Codeunit.al
@@ -1,0 +1,8 @@
+/// <summary>Version B addend #1: always returns 10.</summary>
+codeunit 60202 "Burst F1 RXT"
+{
+    procedure GetValue(): Integer
+    begin
+        exit(10);
+    end;
+}

--- a/AlRunner.Tests/Fixtures/WatchBurstSwitch/v2/F2.Codeunit.al
+++ b/AlRunner.Tests/Fixtures/WatchBurstSwitch/v2/F2.Codeunit.al
@@ -1,0 +1,8 @@
+/// <summary>Version B addend #2: always returns 10.</summary>
+codeunit 60203 "Burst F2 RXT"
+{
+    procedure GetValue(): Integer
+    begin
+        exit(10);
+    end;
+}

--- a/AlRunner.Tests/Fixtures/WatchBurstSwitch/v2/F3.Codeunit.al
+++ b/AlRunner.Tests/Fixtures/WatchBurstSwitch/v2/F3.Codeunit.al
@@ -1,0 +1,8 @@
+/// <summary>Version B addend #3: always returns 10.</summary>
+codeunit 60204 "Burst F3 RXT"
+{
+    procedure GetValue(): Integer
+    begin
+        exit(10);
+    end;
+}

--- a/AlRunner.Tests/Fixtures/WatchBurstSwitch/v2/F4.Codeunit.al
+++ b/AlRunner.Tests/Fixtures/WatchBurstSwitch/v2/F4.Codeunit.al
@@ -1,0 +1,8 @@
+/// <summary>Version B addend #4: always returns 10.</summary>
+codeunit 60205 "Burst F4 RXT"
+{
+    procedure GetValue(): Integer
+    begin
+        exit(10);
+    end;
+}

--- a/AlRunner.Tests/Fixtures/WatchBurstSwitch/v2/F5.Codeunit.al
+++ b/AlRunner.Tests/Fixtures/WatchBurstSwitch/v2/F5.Codeunit.al
@@ -1,0 +1,8 @@
+/// <summary>Version B addend #5: always returns 10.</summary>
+codeunit 60206 "Burst F5 RXT"
+{
+    procedure GetValue(): Integer
+    begin
+        exit(10);
+    end;
+}

--- a/AlRunner.Tests/Fixtures/WatchBurstSwitch/v2/Sum.Codeunit.al
+++ b/AlRunner.Tests/Fixtures/WatchBurstSwitch/v2/Sum.Codeunit.al
@@ -1,0 +1,31 @@
+/// <summary>Version B: sums F0..F5 (each 10) and expects 60.</summary>
+codeunit 60210 "Burst Sum Tests RXT"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit "Burst Assert RXT";
+        F0: Codeunit "Burst F0 RXT";
+        F1: Codeunit "Burst F1 RXT";
+        F2: Codeunit "Burst F2 RXT";
+        F3: Codeunit "Burst F3 RXT";
+        F4: Codeunit "Burst F4 RXT";
+        F5: Codeunit "Burst F5 RXT";
+
+    [Test]
+    procedure Sum_OfAllValues_MatchesExpectedTotal()
+    var
+        Total: Integer;
+    begin
+        // [GIVEN] six addend codeunits
+        // [WHEN] their values are summed
+        Total := F0.GetValue() + F1.GetValue() + F2.GetValue() + F3.GetValue()
+            + F4.GetValue() + F5.GetValue();
+
+        // [THEN] the total matches this version's expectation — see v1/Sum.Codeunit.al's
+        // header for why every addend AND this expectation living in separate files
+        // matters for the #1904 reproduction.
+        Assert.AreEqual('60', Format(Total),
+            'sum of six addends did not match version B''s expected total');
+    end;
+}

--- a/AlRunner.Tests/WatchBurstSwitchTests.cs
+++ b/AlRunner.Tests/WatchBurstSwitchTests.cs
@@ -1,0 +1,183 @@
+using System.Diagnostics;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// #1904's own proof: drives the REAL `--watch` process (not the debounce loop in
+/// isolation — WatchSourceTests covers that deterministically) through a bulk multi-file
+/// switch that mimics a branch checkout, and asserts the phantom failure the issue reports
+/// does NOT appear.
+///
+/// The fixture (see Fixtures/WatchBurstSwitch) spreads a version switch over seven files:
+/// six addend codeunits (F0..F5) and a Sum test whose expected total is a SEPARATE file
+/// from every addend. "Version A" (all addends 1, expects 6) and "version B" (all addends
+/// 10, expects 60) each pass on their own; any half-applied mix of the two files sums to
+/// neither 6 nor 60. Under the pre-fix fixed `Thread.Sleep(250)` debounce, delivering the
+/// seven writes with gaps below the quiet window released mid-burst — a wrong result,
+/// reported as a real test failure, for a codeunit that is fine in both versions — and
+/// then picked the burst's tail up as a SECOND cycle once it settled: two cycles for one
+/// switch, the first one a phantom. Quiescence must produce exactly ONE cycle for the whole
+/// switch, and its result must be the correct, fully-settled version B PASS.
+///
+/// Spawns the real runner; needs the BC artifact cache. Skips (no-op) when absent.
+/// </summary>
+public class WatchBurstSwitchTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+    private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
+    private static readonly string FixtureRoot = Path.GetFullPath(Path.Combine(
+        AppContext.BaseDirectory, "..", "..", "..", "Fixtures", "WatchBurstSwitch"));
+
+    private const string TestName = "Sum_OfAllValues_MatchesExpectedTotal";
+
+    [SkippableFact]
+    public async Task Watch_BulkFileSwitch_ProducesExactlyOneCycle_AgainstSettledTree()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var bundle = Path.Combine(Path.GetTempPath(), "al-runner-watch-burst", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(bundle);
+        File.Copy(Path.Combine(FixtureRoot, "app.json"), Path.Combine(bundle, "app.json"));
+        File.Copy(Path.Combine(FixtureRoot, "Assert.Codeunit.al"), Path.Combine(bundle, "Assert.Codeunit.al"));
+        var v1Dir = Path.Combine(FixtureRoot, "v1");
+        var v2Dir = Path.Combine(FixtureRoot, "v2");
+        foreach (var f in Directory.GetFiles(v1Dir))
+            File.Copy(f, Path.Combine(bundle, Path.GetFileName(f)));
+        var cacheDir = Path.Combine(bundle, ".cache");
+
+        // Same merged stdout/stderr capture shape as WatchTests.cs — see its header and
+        // WatchOutputSlicing.cs for why two independent pumps only preserve WITHIN-stream
+        // order, not cross-stream order (irrelevant here: every assertion below is
+        // stdout-only, found via FindStdoutMarkerIndices).
+        var lines = new List<CapturedLine>();
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            Arguments = TestBuildConfig.RunArgs(ProjectPath) + TestBuildConfig.BcVersionArg
+                + $" \"{bundle}\" --watch --cache \"{cacheDir}\"",
+            RedirectStandardOutput = true, RedirectStandardError = true,
+            UseShellExecute = false, CreateNoWindow = true, WorkingDirectory = RepoRoot,
+        };
+        using var p = Process.Start(psi)!;
+        void Pump(StreamReader r, OutputStream stream) => Task.Run(async () =>
+        {
+            string? l;
+            while ((l = await r.ReadLineAsync()) != null) lock (lines) lines.Add(new CapturedLine(stream, l));
+        });
+        Pump(p.StandardOutput, OutputStream.Stdout);
+        Pump(p.StandardError, OutputStream.Stderr);
+
+        string ProcessLiveness() => p.HasExited ? $"process alive=false exit={p.ExitCode}" : "process alive=true";
+        string DumpTail() { lock (lines) return string.Join("\n", lines.TakeLast(60).Select(l => $"[{l.Stream}] {l.Text}")); }
+
+        async Task<int> WaitForMarkerAfter(int fromIndex, TimeSpan timeout)
+        {
+            var deadline = DateTime.UtcNow + timeout;
+            while (DateTime.UtcNow < deadline)
+            {
+                List<int> found;
+                lock (lines)
+                    found = WatchOutputSlicing.FindStdoutMarkerIndices(lines, WatchOutputSlicing.WaitingForSourceMarker, fromIndex);
+                if (found.Count > 0) return found[0];
+                if (p.HasExited)
+                {
+                    await Task.Delay(500);
+                    throw new TimeoutException(
+                        $"watch marker not seen — subprocess exited early ({ProcessLiveness()}).\n--- last output ---\n{DumpTail()}");
+                }
+                await Task.Delay(200);
+            }
+            if (p.HasExited) await Task.Delay(500);
+            throw new TimeoutException($"watch marker not seen. {ProcessLiveness()}\n--- last output ---\n{DumpTail()}");
+        }
+
+        // Poll until no NEW "waiting for AL source" marker has appeared for `settleWindow`
+        // — i.e. the watch has genuinely gone idle again, not just momentarily between two
+        // back-to-back cycles. Returns every marker index found after `afterIndex`, in
+        // order: its COUNT is the number of watch cycles the burst produced, and the LAST
+        // one delimits the final (should-be-correct) cycle's output.
+        async Task<List<int>> WaitForMarkersToSettle(int afterIndex, TimeSpan settleWindow, TimeSpan overallTimeout)
+        {
+            var deadline = DateTime.UtcNow + overallTimeout;
+            List<int> found = new();
+            var lastGrowth = DateTime.UtcNow;
+            var lastCount = 0;
+            while (DateTime.UtcNow < deadline)
+            {
+                lock (lines)
+                    found = WatchOutputSlicing.FindStdoutMarkerIndices(lines, WatchOutputSlicing.WaitingForSourceMarker, afterIndex + 1);
+                if (found.Count != lastCount) { lastCount = found.Count; lastGrowth = DateTime.UtcNow; }
+                else if (found.Count > 0 && DateTime.UtcNow - lastGrowth >= settleWindow)
+                    return found;
+                if (p.HasExited)
+                {
+                    await Task.Delay(500);
+                    throw new TimeoutException(
+                        $"subprocess exited early while waiting for cycles to settle ({ProcessLiveness()}).\n" +
+                        $"--- last output ---\n{DumpTail()}");
+                }
+                await Task.Delay(300);
+            }
+            throw new TimeoutException(
+                $"watch cycles never settled within {overallTimeout.TotalSeconds}s (found {found.Count} marker(s) " +
+                $"so far). {ProcessLiveness()}\n--- last output ---\n{DumpTail()}");
+        }
+
+        string Segment(int from, int to) { lock (lines) return WatchOutputSlicing.MergedJoin(lines, from, to); }
+
+        try
+        {
+            // Cycle 1 (cold): version A settles and passes (sum 6).
+            int m1 = await WaitForMarkerAfter(0, TimeSpan.FromSeconds(150));
+            var cycle1 = Segment(0, m1);
+            Assert.Contains("PASS", cycle1);
+            Assert.Contains(TestName, cycle1);
+            Assert.DoesNotContain("FAIL  Codeunit", cycle1);
+
+            // The burst switch: seven writes (F0..F5, then Sum LAST) with gaps well below
+            // the 250ms default quiet window, spread over ~900ms total — the same shape as
+            // #1904's reproduction (many events, gaps shorter than the debounce, total
+            // burst longer than it). Sum is written LAST on purpose: while any addend has
+            // already flipped to version B but Sum still expects version A's total (or vice
+            // versa for a cycle that starts even later in the burst), the sum matches
+            // NEITHER 6 nor 60 — a phantom mismatch that cannot occur once the whole switch
+            // has settled.
+            const int gapMs = 150;
+            for (int i = 0; i < 6; i++)
+            {
+                File.Copy(Path.Combine(v2Dir, $"F{i}.Codeunit.al"), Path.Combine(bundle, $"F{i}.Codeunit.al"), overwrite: true);
+                await Task.Delay(gapMs);
+            }
+            File.Copy(Path.Combine(v2Dir, "Sum.Codeunit.al"), Path.Combine(bundle, "Sum.Codeunit.al"), overwrite: true);
+
+            // Let the watch run to completion and settle. Warm re-emits of this tiny
+            // fixture are fast (milliseconds to low seconds per WatchTests.cs), so a 5s
+            // quiet window comfortably distinguishes "no more cycles are coming" from
+            // "the next cycle just hasn't finished yet", within a generous overall budget.
+            var markers = await WaitForMarkersToSettle(m1, TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(120));
+
+            // The core #1904 claim: exactly ONE cycle for the whole burst, not two. Two
+            // would mean a phantom cycle ran mid-switch (the old fixed-debounce bug) before
+            // the correct, fully-settled cycle.
+            Assert.True(markers.Count == 1,
+                $"expected exactly 1 watch cycle for the whole burst switch, saw {markers.Count} " +
+                "— a bulk multi-file rewrite must debounce to ONE cycle against the settled tree, " +
+                "not fire early against a half-applied mix (the #1904 phantom-failure bug: two " +
+                "cycles for one switch, the first against a tree that was still part-old / " +
+                $"part-new).\n--- output between m1 and settle ---\n{Segment(m1 + 1, markers.Count > 0 ? markers[^1] : lines.Count)}");
+
+            // And that one cycle must report the CORRECT, fully-settled version B result —
+            // not a phantom failure for a test that is fine in both version A and version B.
+            var finalCycle = Segment(m1 + 1, markers[0]);
+            Assert.Contains(TestName, finalCycle);
+            Assert.DoesNotContain("FAIL", finalCycle);
+            Assert.Contains("PASS", finalCycle);
+        }
+        finally
+        {
+            try { p.Kill(true); } catch { }
+        }
+    }
+}

--- a/AlRunner.Tests/WatchSourceTests.cs
+++ b/AlRunner.Tests/WatchSourceTests.cs
@@ -68,7 +68,7 @@ public sealed class WatchSourceTests
         var savedErr = Console.Error;
         var captured = new StringWriter();
         Console.SetError(captured);
-        (System.Threading.ManualResetEventSlim Signal, List<FileSystemWatcher> Watchers)? armed;
+        (System.Threading.ManualResetEventSlim Signal, List<FileSystemWatcher> Watchers, AlRunner.WatchSource.WatchActivity Activity)? armed;
         try
         {
             armed = AlRunner.WatchSource.ArmSourceWatch(
@@ -98,7 +98,7 @@ public sealed class WatchSourceTests
         try
         {
             Assert.NotNull(armed);
-            var (signal, watchers) = armed!.Value;
+            var (signal, watchers, _) = armed!.Value;
             Assert.NotEmpty(watchers);
             Assert.All(watchers, w => Assert.True(w.EnableRaisingEvents));
             Assert.Equal(1, onArmedCount);
@@ -110,5 +110,159 @@ public sealed class WatchSourceTests
                 foreach (var w in armed.Value.Watchers) { w.EnableRaisingEvents = false; w.Dispose(); }
             armed?.Signal.Dispose();
         }
+    }
+
+    // #1904: a fixed `Thread.Sleep(250)` after only the FIRST watcher event cannot tell
+    // "one save, done" apart from "checkout in progress, more events coming" — it releases
+    // 250ms after the first event regardless. A branch switch / bulk rewrite delivers many
+    // file events spread over seconds, so the old debounce started a cycle mid-checkout,
+    // against a tree that was still part-old / part-new.
+    //
+    // This test reproduces that shape deterministically WITHOUT a real BC compile: a burst
+    // of 12 file writes with a 120ms gap between each (below the 250ms quiet window, so
+    // each one re-arms it — exactly what a bulk git operation looks like from inotify's
+    // side) spread over ~1.3s. Under the OLD fixed-sleep debounce, WaitForSourceChange
+    // would return ~250ms after the FIRST write — i.e. around write #2 of 12, with 10 more
+    // writes still to come. Under quiescence it must not return until `QuietMs` has passed
+    // with NO further write, i.e. strictly after the LAST write of the burst.
+    [Fact]
+    public async Task WaitForSourceChange_BurstBelowQuietWindow_ReleasesOnlyAfterBurstSettles()
+    {
+        var dir = NewTempDir();
+        const int fileCount = 12;
+        const int gapMs = 120;
+        Assert.True(gapMs < AlRunner.WatchSource.QuietMs,
+            "the reproduction depends on each write re-arming quiescence — the gap must be " +
+            "smaller than the quiet window.");
+
+        var sw = new System.Diagnostics.Stopwatch();
+        long lastWriteMs = -1;
+        var burstDone = new System.Threading.ManualResetEventSlim(false);
+
+        var task = Task.Run(() => AlRunner.WatchSource.WaitForSourceChange(
+            new List<string> { dir },
+            onArmed: () =>
+            {
+                sw.Start();
+                _ = Task.Run(async () =>
+                {
+                    for (int i = 0; i < fileCount; i++)
+                    {
+                        File.WriteAllText(Path.Combine(dir, $"F{i}.Table.al"), $"table {60000 + i} F{i} {{ }}");
+                        lastWriteMs = sw.ElapsedMilliseconds;
+                        if (i < fileCount - 1) await Task.Delay(gapMs);
+                    }
+                    burstDone.Set();
+                });
+            }));
+
+        var winner = await Task.WhenAny(task, Task.Delay(TimeSpan.FromSeconds(20)));
+        Assert.True(ReferenceEquals(task, winner),
+            "WaitForSourceChange did not return within 20s of the burst starting.");
+        Assert.True(await task, "WaitForSourceChange must report a change was detected.");
+        var returnedAtMs = sw.ElapsedMilliseconds;
+
+        // The writer keeps running independently of WaitForSourceChange/the watchers (it
+        // just writes files on its own timer) — wait for it to finish on its OWN terms
+        // before reading lastWriteMs, rather than requiring it to already be done by the
+        // time `task` returns. Requiring that here would conflate two different claims:
+        // this wait proves the burst genuinely ran to completion (test-setup sanity); the
+        // timing assertions below prove WHEN WaitForSourceChange released relative to it —
+        // which, under the bug, is BEFORE the burst finishes. That is the defect, not a
+        // reason to fail this wait.
+        Assert.True(burstDone.Wait(TimeSpan.FromSeconds(5)),
+            "the writer burst did not complete within 5s of WaitForSourceChange returning — " +
+            "test setup is broken (unrelated to the #1904 timing claim below).");
+        Assert.True(lastWriteMs >= 0, "the writer never wrote a file — the test setup is broken.");
+
+        // The phantom-failure assertion: must not release before the burst's LAST write —
+        // that is precisely "started a cycle mid-checkout". Fails under the old fixed
+        // Thread.Sleep(250), which returns ~250ms after the FIRST write (~1070ms early here).
+        Assert.True(returnedAtMs >= lastWriteMs,
+            $"WaitForSourceChange returned at {returnedAtMs}ms, BEFORE the burst's last write " +
+            $"at {lastWriteMs}ms — released mid-burst against a half-applied tree (the #1904 " +
+            "phantom-failure bug: a fixed post-first-event debounce cannot distinguish a " +
+            "settling save from an in-progress bulk rewrite).");
+
+        // And it must not stall indefinitely either — a single quiet window plus generous
+        // scheduling slack after the last write, not the 10s cap.
+        Assert.True(returnedAtMs <= lastWriteMs + 3_000,
+            $"WaitForSourceChange returned {returnedAtMs - lastWriteMs}ms after the burst's " +
+            "last write — quiescence should release promptly once the burst settles, not " +
+            "stall toward the cap.");
+    }
+
+    // The companion negative-latency check: a SINGLE save (no burst) must still release
+    // close to one quiet window, not be delayed by the quiescence machinery itself. This is
+    // the "must not make the common case feel worse" requirement from #1904 — a fix that
+    // only ever waited for the 10s cap would "solve" the phantom failure by making every
+    // save feel broken.
+    [Fact]
+    public async Task WaitForSourceChange_SingleSave_ReleasesWithinOneQuietWindow()
+    {
+        var dir = NewTempDir();
+        var file = Path.Combine(dir, "Single.Table.al");
+        var sw = new System.Diagnostics.Stopwatch();
+
+        var task = Task.Run(() => AlRunner.WatchSource.WaitForSourceChange(
+            new List<string> { dir },
+            onArmed: () =>
+            {
+                sw.Start();
+                File.WriteAllText(file, "table 60001 Single { }");
+            }));
+
+        var winner = await Task.WhenAny(task, Task.Delay(TimeSpan.FromSeconds(15)));
+        Assert.True(ReferenceEquals(task, winner), "a single save must not approach the 10s cap.");
+        Assert.True(await task);
+        var elapsedMs = sw.ElapsedMilliseconds;
+
+        Assert.True(elapsedMs <= AlRunner.WatchSource.QuietMs + 2_000,
+            $"a single save took {elapsedMs}ms to release — quiescence must not add noticeable " +
+            $"latency beyond one quiet window ({AlRunner.WatchSource.QuietMs}ms) for the common case.");
+    }
+
+    // #1904's second exposure: a watcher-buffer overflow used to be silently swallowed
+    // (no Error subscriber at all). Force one deterministically via reflection against the
+    // protected FileSystemWatcher.OnError — flooding a directory with enough real events to
+    // overflow InternalBufferSize would be slow and racy, and isn't needed to prove the
+    // handling contract: given an overflow, the session must (a) not crash, (b) say so
+    // (loud, not swallowed), and (c) mark the activity as overflowed so a consumer knows any
+    // changed-path list it might have built is incomplete, not empty.
+    [Fact]
+    public void ArmSourceWatch_WatcherBufferOverflow_IsHandledLoudly_NotSwallowed()
+    {
+        var dir = NewTempDir();
+        var armed = AlRunner.WatchSource.ArmSourceWatch(new List<string> { dir });
+        Assert.NotNull(armed);
+        var (signal, watchers, activity) = armed!.Value;
+
+        var savedErr = Console.Error;
+        var captured = new StringWriter();
+        Console.SetError(captured);
+        try
+        {
+            Assert.False(activity.Overflowed, "must not report overflow before one occurs.");
+
+            var onError = typeof(FileSystemWatcher).GetMethod(
+                "OnError", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+            Assert.NotNull(onError);
+            var ex = new InternalBufferOverflowException("simulated overflow for #1904 test");
+            onError!.Invoke(watchers[0], new object[] { new ErrorEventArgs(ex) });
+        }
+        finally
+        {
+            Console.SetError(savedErr);
+        }
+
+        Assert.True(activity.Overflowed,
+            "a watcher Error event must mark the session as overflowed — not be swallowed.");
+        Assert.True(signal.IsSet,
+            "an overflow must force a cycle (set the signal) rather than leave the loop " +
+            "asleep on a tree that may have changed underneath it.");
+        Assert.Contains("buffer overflow", captured.ToString(), StringComparison.OrdinalIgnoreCase);
+
+        foreach (var w in watchers) { w.EnableRaisingEvents = false; w.Dispose(); }
+        signal.Dispose();
     }
 }

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -1975,7 +1975,7 @@ if (watchUi)
             watchScroll = PaintWatchViewport(lines, watchScroll);
         });
     if (armed == null) return 0;
-    var (signal, watchers) = armed.Value;
+    var (signal, watchers, watchActivity) = armed.Value;
     bool changed = false;
     // Console.KeyAvailable throws InvalidOperationException when stdin is redirected
     // (a pipe/file rather than a real terminal). We still want the dashboard + file
@@ -1985,7 +1985,10 @@ if (watchUi)
     {
         while (true)
         {
-            if (signal.IsSet) { System.Threading.Thread.Sleep(250); changed = true; break; }
+            // #1904: quiescence, not a fixed sleep after only the first event — a branch
+            // switch/bulk rewrite keeps this re-armed until the tree actually stops
+            // changing, instead of starting a cycle against a half-applied checkout.
+            if (signal.IsSet) { WatchSource.WaitForQuiescence(watchActivity); changed = true; break; }
 
             if (keyboard && SafeKeyAvailable())
             {

--- a/AlRunner/WatchSource.cs
+++ b/AlRunner/WatchSource.cs
@@ -15,15 +15,87 @@
 // after every FileSystemWatcher has EnableRaisingEvents = true. The caller can no
 // longer announce "watching" before the watch is actually live, because the class
 // controls when the announcement runs, not the caller.
+//
+// #1904: the debounce after the FIRST event used to be a fixed `Thread.Sleep(250)`.
+// A single save fits comfortably inside that window, but a branch switch / rebase /
+// bulk rename delivers dozens-to-thousands of file events over SECONDS, so the fixed
+// wait released while the tree was still part-old / part-new — a cycle ran against a
+// half-applied checkout and reported a phantom test result. The fix replaces the fixed
+// sleep with quiescence: keep resetting the wait on every subsequent event and release
+// only once `quietMs` has passed with NO further event, capped at `maxWaitMs` from the
+// first event so a continuously-writing process cannot stall the loop forever. A single
+// save still releases after one `quietMs` wait, same latency as before.
 namespace AlRunner;
 
 internal static class WatchSource
 {
     /// <summary>
+    /// How long the watch must see NO further `.al` event before a cycle is allowed to
+    /// start — the quiescence window. Configurable via <c>AL_RUNNER_WATCH_QUIET_MS</c>
+    /// (the right value depends on the machine and the size of the tree being switched);
+    /// defaults to 250ms, the same latency a single save always paid before #1904.
+    /// </summary>
+    internal static int QuietMs { get; } = ReadPositiveIntEnv("AL_RUNNER_WATCH_QUIET_MS", 250);
+
+    /// <summary>
+    /// Hard cap, measured from the FIRST event of a burst, on how long quiescence will
+    /// keep extending the wait. Without this a process that writes continuously (a huge
+    /// checkout, a runaway build watcher) could keep the quiet window from ever being
+    /// reached and starve the loop forever. Configurable via
+    /// <c>AL_RUNNER_WATCH_MAX_WAIT_MS</c>; defaults to 10s, comfortably above the ~1.4s
+    /// bulk-switch reproduction in #1904 but bounded so a stuck writer still yields a
+    /// cycle eventually.
+    /// </summary>
+    internal static int MaxWaitMs { get; } = ReadPositiveIntEnv("AL_RUNNER_WATCH_MAX_WAIT_MS", 10_000);
+
+    /// <summary>How often the quiescence loop polls for further activity.</summary>
+    private const int PollIntervalMs = 25;
+
+    private static int ReadPositiveIntEnv(string name, int fallback)
+    {
+        var raw = Environment.GetEnvironmentVariable(name);
+        return !string.IsNullOrEmpty(raw) && int.TryParse(raw, out var v) && v > 0 ? v : fallback;
+    }
+
+    /// <summary>
+    /// Mutable activity tracker shared between a watch session's event handlers and
+    /// whoever is waiting on it. Deliberately a class (not a struct/tuple) so the
+    /// `OnChanged`/`OnRenamed`/`OnError` closures in <see cref="ArmSourceWatch"/> and the
+    /// caller's wait loop observe the SAME instance — the whole point of quiescence is
+    /// that a late event, arriving after the caller started waiting, is still seen.
+    /// </summary>
+    internal sealed class WatchActivity
+    {
+        private long _lastEventTicks = Environment.TickCount64;
+        private int _overflowed;
+
+        /// <summary><see cref="Environment.TickCount64"/> of the most recent watcher event.</summary>
+        internal long LastEventTicks => System.Threading.Volatile.Read(ref _lastEventTicks);
+
+        /// <summary>
+        /// True once any watcher's internal buffer has overflowed (<see
+        /// cref="FileSystemWatcher.Error"/>) during this session — see <see
+        /// cref="ArmSourceWatch"/>'s <c>OnError</c> handler. A buffer overflow means the
+        /// watcher dropped events, so any "which paths changed" list built from the event
+        /// stream is a strict subset of what actually changed and must not be trusted as
+        /// complete.
+        /// </summary>
+        internal bool Overflowed => System.Threading.Volatile.Read(ref _overflowed) != 0;
+
+        internal void Touch() => System.Threading.Volatile.Write(ref _lastEventTicks, Environment.TickCount64);
+
+        internal void MarkOverflow()
+        {
+            System.Threading.Interlocked.Exchange(ref _overflowed, 1);
+            Touch(); // an overflow is itself activity — it must not let quiescence release early
+        }
+    }
+
+    /// <summary>
     /// Arm FileSystemWatchers over the bundles' source roots and return a settable
-    /// signal + the watchers so the caller can interleave the file-change wait with
-    /// other work (e.g. the interactive dashboard's keyboard polling). Returns null
-    /// if there are no source dirs to watch — in that case the
+    /// signal + the watchers + an activity tracker, so the caller can interleave the
+    /// file-change wait with other work (e.g. the interactive dashboard's keyboard
+    /// polling). Returns null if there are no source dirs to watch — in that case the
     /// "[watch] no source directories to watch." diagnostic is printed and
     /// <paramref name="onArmed"/> is NOT invoked. The caller owns disposal of both
     /// the signal and the watchers.
@@ -33,7 +105,7 @@ internal static class WatchSource
     /// genuinely live. Pass the "waiting for changes" print / dashboard paint here so
     /// it can never race the watcher (see file header — this is the #1822 fix).
     /// </summary>
-    internal static (System.Threading.ManualResetEventSlim Signal, List<FileSystemWatcher> Watchers)? ArmSourceWatch(
+    internal static (System.Threading.ManualResetEventSlim Signal, List<FileSystemWatcher> Watchers, WatchActivity Activity)? ArmSourceWatch(
         List<string> bundles, Action? onArmed = null)
     {
         var dirs = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
@@ -50,13 +122,33 @@ internal static class WatchSource
         }
 
         var signal = new System.Threading.ManualResetEventSlim(false);
+        var activity = new WatchActivity();
         void OnChanged(object _, FileSystemEventArgs e)
         {
-            if (e.FullPath.EndsWith(".al", StringComparison.OrdinalIgnoreCase)) signal.Set();
+            if (!e.FullPath.EndsWith(".al", StringComparison.OrdinalIgnoreCase)) return;
+            activity.Touch();
+            signal.Set();
         }
         void OnRenamed(object _, RenamedEventArgs e)
         {
-            if (e.FullPath.EndsWith(".al", StringComparison.OrdinalIgnoreCase)) signal.Set();
+            if (!e.FullPath.EndsWith(".al", StringComparison.OrdinalIgnoreCase)) return;
+            activity.Touch();
+            signal.Set();
+        }
+        // #1904 second exposure: the Error event used to be unhandled, so a watcher-buffer
+        // overflow (InternalBufferSize's 8KB default fills fast during a bulk rewrite) was
+        // silently swallowed — the watcher keeps running but drops events, which can leave
+        // the loop asleep on a tree that changed (reads to a developer as "watch stopped
+        // working"). Handle it: log it so it's visible, mark the session as overflowed, and
+        // treat it as activity so quiescence does not release on a partial event picture.
+        void OnError(object _, ErrorEventArgs e)
+        {
+            activity.MarkOverflow();
+            signal.Set();
+            Console.Error.WriteLine(
+                "[watch] warning: file watcher buffer overflow ("
+                + e.GetException().Message + ") — some change events may have been "
+                + "dropped; forcing a re-scan.");
         }
 
         var watchers = new List<FileSystemWatcher>();
@@ -67,9 +159,16 @@ internal static class WatchSource
                 IncludeSubdirectories = true,
                 Filter = "*.al",
                 NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.FileName | NotifyFilters.Size,
+                // 64KB is the practical ceiling FileSystemWatcher accepts without editing
+                // the OS's inotify/registry limits (values above it are silently clamped on
+                // Windows; Linux's inotify backing has no such cap but there is no harm in
+                // asking for more here). 8x the 8KB default buys real headroom against the
+                // burst a branch switch / bulk rewrite produces before OnError even matters.
+                InternalBufferSize = 65536,
                 EnableRaisingEvents = true,
             };
             w.Changed += OnChanged; w.Created += OnChanged; w.Deleted += OnChanged; w.Renamed += OnRenamed;
+            w.Error += OnError;
             watchers.Add(w);
         }
 
@@ -77,7 +176,34 @@ internal static class WatchSource
         // time control reaches here the watch is genuinely live. onArmed runs ONLY now —
         // never before this point — which is the whole fix for #1822.
         onArmed?.Invoke();
-        return (signal, watchers);
+        return (signal, watchers, activity);
+    }
+
+    /// <summary>
+    /// Block until <paramref name="activity"/> has been quiet (no touch) for <see
+    /// cref="QuietMs"/>, capped at <see cref="MaxWaitMs"/> measured from the moment this
+    /// method is entered (i.e. from the first event that woke the caller — the caller is
+    /// expected to call this immediately after its own <c>signal.Wait()</c>/`IsSet` check
+    /// returns, so "entered" and "first event" are the same instant to within a poll
+    /// interval). This is the #1904 fix: releasing on quiescence rather than a fixed delay
+    /// after only the first event means a burst of events (a branch switch, a bulk
+    /// rewrite) keeps re-arming the wait until the tree actually stops changing, instead of
+    /// letting a cycle start against a half-applied checkout.
+    /// </summary>
+    internal static void WaitForQuiescence(WatchActivity activity, int? quietMs = null, int? maxWaitMs = null)
+    {
+        var quiet = quietMs ?? QuietMs;
+        var maxWait = maxWaitMs ?? MaxWaitMs;
+        var deadline = Environment.TickCount64 + maxWait;
+        while (true)
+        {
+            var now = Environment.TickCount64;
+            var sinceLastEvent = now - activity.LastEventTicks;
+            if (sinceLastEvent >= quiet) return;      // settled: no event for a full quiet window
+            if (now >= deadline) return;               // cap hit: force a cycle regardless
+            var sleepFor = Math.Min(quiet - sinceLastEvent, PollIntervalMs);
+            System.Threading.Thread.Sleep((int)Math.Max(1, sleepFor));
+        }
     }
 
     /// <summary>
@@ -90,11 +216,11 @@ internal static class WatchSource
     {
         var armed = ArmSourceWatch(bundles, onArmed);
         if (armed == null) return false;
-        var (signal, watchers) = armed.Value;
+        var (signal, watchers, activity) = armed.Value;
         try
         {
-            signal.Wait();                       // block until the first .al change
-            System.Threading.Thread.Sleep(250);  // debounce: let a save storm settle
+            signal.Wait();                  // block until the first .al change
+            WaitForQuiescence(activity);     // #1904: quiescence, not a fixed post-first-event sleep
             return true;
         }
         finally

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md#dev-loop) for provisioning them as a separ
 | `--package-cache PATH` | Extra `.app`-package cache directory. Repeatable. |
 | `--cache PATH` | Cache compiled AL output keyed on source + dep set + runner mtime. |
 | `--isolation codeunit\|test\|disabled` | Test isolation mode. Default `codeunit`. |
-| `--watch` | Stay resident with warm dependencies; on every `.al` change reset + re-emit + run **in-process** (~seconds/save). |
+| `--watch` | Stay resident with warm dependencies; on every `.al` change reset + re-emit + run **in-process** (~seconds/save). Debounces on quiescence (default 250ms of no further `.al` event, capped at 10s) so a bulk multi-file rewrite — a branch switch, a rebase, a formatter run — settles before a cycle starts, instead of firing mid-checkout. Tune with `AL_RUNNER_WATCH_QUIET_MS` / `AL_RUNNER_WATCH_MAX_WAIT_MS`. |
 | `--server` | Long-running JSON-RPC daemon over stdin/stdout (warm deps → ~19s→~4s/run). See [docs/server-mode.md](docs/server-mode.md). |
 | `--per-suite` | Legacy per-suite compile mode (diagnostic). Default is bundled-per-bucket. |
 | `--bundled` | No-op alias for backwards compatibility. |


### PR DESCRIPTION
Closes #1904

## Problem

`--watch`'s debounce was a fixed `Thread.Sleep(250)` after only the FIRST `FileSystemWatcher` event (`AlRunner/WatchSource.cs`). A single save fits comfortably inside that window, but a branch switch, rebase, bulk rename, or formatter run delivers dozens-to-thousands of file events spread over *seconds* — the fixed sleep released while the tree was still part-old / part-new, starting a compile+run cycle against a half-applied checkout and reporting a wrong test result for a codeunit that is actually fine in both the before and after state.

Why "just wait longer" isn't the fix: a larger constant still can't tell "checkout finished" from "checkout paused" — it only shrinks the window in which the bug fires, at the cost of latency on every single save. The fix needs to detect settledness, not guess a bigger number.

## Fix

Replaced the fixed sleep with **quiescence**: `WatchSource.WaitForQuiescence` tracks the timestamp of the most recent watcher event (`WatchActivity`, shared between the event handlers and the waiter) and only releases once `QuietMs` (default 250ms — same latency a single save always paid) has passed with **no further event**. Every new event during a burst re-arms the wait. A hard cap, `MaxWaitMs` (default 10s), bounds how long quiescence will keep extending so a continuously-writing process can't stall the loop forever. Both are configurable via `AL_RUNNER_WATCH_QUIET_MS` / `AL_RUNNER_WATCH_MAX_WAIT_MS` — the right value depends on the machine and the size of the tree.

Applied to **both** watch paths that shared the bug: the plain `WaitForSourceChange` loop (piped/non-interactive mode) and the interactive dashboard's poll loop (`Program.cs`'s `signal.IsSet` check), which had its own copy of the identical fixed-sleep pattern.

**Second exposure fixed in the same file**: `FileSystemWatcher.Error` was previously unhandled — a buffer overflow (`InternalBufferSize`'s 8KB default filling during a bulk rewrite) was silently swallowed, which can leave the loop asleep on a tree that changed (reads to a developer as "watch stopped working"). It's now handled: logged loudly, marks the session `Overflowed`, and is itself treated as activity so quiescence doesn't release on a partial event picture. `InternalBufferSize` is also raised from the 8KB default to 64KB (the practical ceiling) to reduce how often this fires at all.

This builds on #1901's generation bookkeeping (`BcRuntime._latestGenerationByAssemblyName` / `IsStaleBundleAssembly`) without touching it — this fix changes *when* a cycle starts, not how a cycle resolves stale assemblies once it does; the two compose independently.

## Tests (strict RED → GREEN, both confirmed locally)

1. **`WatchSourceTests.WaitForSourceChange_BurstBelowQuietWindow_ReleasesOnlyAfterBurstSettles`** — deterministic, no BC compile: a burst of 12 file writes with 120ms gaps (below the 250ms quiet window) spread over ~1.3s. Asserts `WaitForSourceChange` does not return before the burst's last write. RED against the old fixed-sleep shape: `WaitForSourceChange returned at 252ms, BEFORE the burst's last write at 1319ms`. GREEN with the fix.
2. **`WatchSourceTests.WaitForSourceChange_SingleSave_ReleasesWithinOneQuietWindow`** — the negative-direction / "don't make the common case worse" check: a lone save still releases within one quiet window, not the 10s cap.
3. **`WatchSourceTests.ArmSourceWatch_WatcherBufferOverflow_IsHandledLoudly_NotSwallowed`** — forces `FileSystemWatcher.OnError` via reflection (deterministic; flooding real events to trigger a genuine overflow would be slow and racy) and asserts it's logged, marks `Overflowed`, and forces a cycle rather than being swallowed.
4. **`WatchBurstSwitchTests.Watch_BulkFileSwitch_ProducesExactlyOneCycle_AgainstSettledTree`** — drives the **real `--watch` subprocess**, not the loop in isolation, per the issue's explicit ask. New fixture (`AlRunner.Tests/Fixtures/WatchBurstSwitch`): six addend codeunits (F0..F5) plus a Sum test whose expected total lives in a *separate* file from every addend — "version A" (all addends 1, expects 6) and "version B" (all addends 10, expects 60) each pass on their own, but any half-applied mix sums to neither. The test switches all seven files in a burst (150ms gaps, Sum written last) and asserts **exactly one** watch cycle runs, with the correct settled-B `PASS` result. RED against the old debounce: the single reported cycle showed `FAIL` (the phantom — sum computed from a stale/new file mix, neither 6 nor 60) even before the "how many cycles" question was reached. GREEN with the fix: exactly one cycle, `PASS`, in ~19s.

Also ran the full `AlRunner.Tests` suite locally after the fix: 697 passed, 26 skipped (pre-existing environment-gated skips), 0 failed.

## Scope notes

The issue's third "what fixed looks like" bullet (report the changed-path list as `unknown`, not empty, on overflow, so a future fast-path consumer doesn't treat overflow as "nothing changed") doesn't have a consumer to wire up yet — `--watch` currently does a full `BcRuntime.ResetForNewBundleReload()` + re-emit every cycle regardless of which paths changed (no changed-path fast path exists in `Program.cs` today; `PrepareBundleReload` named in the issue doesn't currently exist under that name). `WatchActivity.Overflowed` is exposed so that future fast-path work (tracked separately, e.g. #1905's performance work) has the signal available without re-deriving it.

## Files
- `AlRunner/WatchSource.cs` — quiescence tracker + `WaitForQuiescence`, `Error` handling, `InternalBufferSize`
- `AlRunner/Program.cs` — interactive dashboard loop now calls the shared quiescence helper
- `AlRunner.Tests/WatchSourceTests.cs` — new deterministic tests (+ updated 2-tuple → 3-tuple destructuring for the existing #1822 tests)
- `AlRunner.Tests/WatchBurstSwitchTests.cs` — new real-process integration test
- `AlRunner.Tests/Fixtures/WatchBurstSwitch/` — new two-version fixture
- `README.md` — documents the new env vars

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01EU4fwyWDu5CiUrhbPoxAhb

---
_Generated by [Claude Code](https://claude.ai/code/session_01EU4fwyWDu5CiUrhbPoxAhb)_