### PR TITLE
fix(runtime): construct Page{id} for static Page.RunModal(id, Record)

### DIFF
--- a/AlRunner/Infrastructure/NclCecilRewrite.cs
+++ b/AlRunner/Infrastructure/NclCecilRewrite.cs
@@ -19,7 +19,7 @@ namespace AlRunner.Infrastructure;
 
 public static class NclCecilRewrite
 {
-    private const int CACHE_VERSION = 124;
+    private const int CACHE_VERSION = 125;
 
     // ─────────────────────────────────────────────────────────────────────────
     // Cecil-owned skip registry (JmpHook→Cecil migration enabler).
@@ -88,6 +88,12 @@ public static class NclCecilRewrite
         // NCLMetaQuery.CreateObjectInstance — same null-ApplicationObjectConstructor story,
         // for the STATIC Query.SaveAsXml/Csv/Json(id, …) forms.
         "Microsoft.Dynamics.Nav.Runtime.NCLMetaQuery::CreateObjectInstance/2",
+        // NCLMetaForm.CreateObjectInstance(NavRecord) — #1897, the form/page twin of the
+        // XmlPort/Query pair above. Static Page.RunModal(id[, Record]) (and, transitively,
+        // Base App Codeunit 700 "Page Management".PageRunModal/PageRun) reach this instead
+        // of NavFormHandle.CreateTarget (the AL-variable path, which already had its own
+        // construction) and NRE on the null ApplicationObjectConstructor delegate.
+        "Microsoft.Dynamics.Nav.Runtime.NCLMetaForm::CreateObjectInstance/1",
         // ALSystemOperatingSystem.get_ALGuiAllowed — AL's GuiAllowed(). True, because the
         // runner registers a client callback and dispatches UI to test handlers.
         "Microsoft.Dynamics.Nav.Runtime.ALSystemOperatingSystem::get_ALGuiAllowed/0",
@@ -1380,6 +1386,45 @@ public static class NclCecilRewrite
 
             ReplaceBodyWithHelper(asm.MainModule, qCreate, qHelper);
             Console.Error.WriteLine("[Cecil] Rewrote NCLMetaQuery.CreateObjectInstance → BcRuntime.NCLMetaQuery_CreateObjectInstance");
+        }
+
+        // 8b2. NCLMetaForm.CreateObjectInstance(NavRecord) — #1897, the form/page twin of
+        //      the XmlPort/Query pair above. The AL-variable page form
+        //      (`P: Page "X"; P.SetRecord(Rec); P.RunModal();`) already has its own working
+        //      construction path (NavFormHandle.CreateTarget); the STATIC forms
+        //      (Page.RunModal(id[, Record]), and transitively Base App Codeunit 700
+        //      "Page Management".PageRunModal/PageRun) reach NavForm.RunModalAsync
+        //      (static) → NCLMetadata.GetMetaFormById(id).CreateObjectInstance(record)
+        //      instead, and NRE on the null ApplicationObjectConstructor delegate.
+        //      NCLMetaForm declares THREE CreateObjectInstance overloads — (), (NavRecord),
+        //      (string personalizationId) — only the (NavRecord) one is rewritten here; the
+        //      0-arg overload chains to it (`CreateObjectInstance((NavRecord)null)`, covered
+        //      automatically) and the personalizationId overload is unrelated.
+        {
+            var metaFormType = asm.MainModule.Types
+                .FirstOrDefault(t => t.FullName == "Microsoft.Dynamics.Nav.Runtime.NCLMetaForm")
+                ?? throw new InvalidOperationException(
+                    "[Cecil] NCLMetaForm type not found — Ncl shape changed; do not commit");
+
+            var fCreate = metaFormType.Methods
+                .FirstOrDefault(m => m.Name == "CreateObjectInstance" && m.HasBody
+                    && m.Parameters.Count == 1
+                    && m.Parameters[0].ParameterType.FullName == "Microsoft.Dynamics.Nav.Runtime.NavRecord")
+                ?? throw new InvalidOperationException(
+                    "[Cecil] NCLMetaForm.CreateObjectInstance(NavRecord) not found — Ncl shape changed; do not commit");
+
+            var fHelper = typeof(AlRunner.BcRuntime).GetMethod(
+                nameof(AlRunner.BcRuntime.NCLMetaForm_CreateObjectInstance),
+                BindingFlags.Public | BindingFlags.Static)
+                ?? throw new InvalidOperationException(
+                    "[Cecil] BcRuntime.NCLMetaForm_CreateObjectInstance not found");
+
+            if (fCreate.ReturnType.FullName != fHelper.ReturnType.FullName)
+                throw new InvalidOperationException(
+                    "[Cecil] NCLMetaForm.CreateObjectInstance/helper return type mismatch — do not commit");
+
+            ReplaceBodyWithHelper(asm.MainModule, fCreate, fHelper);
+            Console.Error.WriteLine("[Cecil] Rewrote NCLMetaForm.CreateObjectInstance(NavRecord) → BcRuntime.NCLMetaForm_CreateObjectInstance");
         }
 
         // 8c. ALSystemOperatingSystem.get_ALGuiAllowed → true. This is AL's GuiAllowed().

--- a/AlRunner/Patches/FormStaticRunModalPatches.cs
+++ b/AlRunner/Patches/FormStaticRunModalPatches.cs
@@ -1,0 +1,141 @@
+// FormStaticRunModalPatches — NCLMetaForm.CreateObjectInstance(NavRecord), the
+// construction path the STATIC Page.RunModal(id[, Record]) / Page.RunModal(id, isLookup, …)
+// overloads reach (and, transitively, any Base App code that calls through them, e.g.
+// Codeunit 700 "Page Management".PageRunModal/PageRun).
+//
+// Issue #1897: BC's real NCLMetaForm.CreateObjectInstance(NavRecord) body is
+//
+//     Delegate applicationObjectConstructor = base.ApplicationObjectConstructor;
+//     NavForm navForm = ((CreateNavForm)applicationObjectConstructor)(
+//         NavCurrentThread.Session.Company.SharedObjects, record, base.StaticMetadata);
+//     ...
+//
+// and NCLMetaApplicationObject.ApplicationObjectConstructor is forced null for every
+// object type on the runner's skeleton (see RecordPatches.CreateObjectInstance.cs /
+// XmlPortPatches.cs / CodeunitPatches.cs's NCLMetaReport/NCLMetaQuery siblings) — so this
+// NREs on the invoke. Even with a non-null delegate, NavCurrentThread.Session.Company is
+// also null on the skeleton (see the RequestPageBase ctor rewrite in NclCecilRewrite.cs),
+// so the body would NRE a second way.
+//
+// The AL-variable form (`P: Page "X"; P.SetRecord(Rec); P.RunModal();`) never reaches this
+// method — NavFormHandle.CreateTarget (CodeunitPatches.NavFormHandle_CreateTarget) already
+// has its own, working per-type construction path for that case. The STATIC forms reach
+// NCLMetaForm.CreateObjectInstance directly from NavForm.RunModalAsync(bool, bool, int,
+// NavRecord, int) — `NCLMetadata.GetMetaFormById(formId, true).CreateObjectInstance(record)`
+// — so they need the identical construction, just entered from a different caller and
+// without a NavFormHandle already in hand to serve as the parent ITreeObject.
+//
+// Only NCLMetaForm.CreateObjectInstance(NavRecord) is Cecil-rewritten (see
+// NclCecilRewrite.cs). The 0-arg overload chains to it (`CreateObjectInstance((NavRecord)
+// null)`), so it is covered automatically; the string-personalizationId overload is
+// unrelated (Session-level personalization, out of scope here) and left untouched.
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using AlRunner.Patches;
+using Microsoft.Dynamics.Nav.Runtime;
+
+namespace AlRunner;
+
+public static partial class BcRuntime
+{
+    /// <summary>
+    /// Replacement for <c>NCLMetaForm.CreateObjectInstance(NavRecord)</c>.
+    ///
+    /// Constructs the AL-emitted <c>Page{id}</c> instance the same way
+    /// <c>CodeunitPatches.NavFormHandle_CreateTarget</c> does for the AL-variable path —
+    /// through the (ITreeObject, NavRecord) ctor when the page's source table is
+    /// resolvable, falling back to the (ITreeObject) ctor otherwise — except the record
+    /// this method receives (if any) is the one the caller already supplied, so it is
+    /// bound directly instead of a freshly-built blank one. There is no NavFormHandle to
+    /// serve as the parent ITreeObject here (unlike the page-variable path — construction
+    /// happens BEFORE NavForm.RunModalAsync wraps the result in one), so the skeleton
+    /// session is used instead — the same "no handle for a static-by-id call" approach
+    /// NavReportSync.CreateReportForRequestPage already takes for the static Report
+    /// RunRequestPage overloads.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static Microsoft.Dynamics.Nav.Runtime.NavForm NCLMetaForm_CreateObjectInstance(
+        object self, NavRecord? record)
+    {
+        int id = ReadMetaObjectNumber(self);
+        if (id == 0)
+            throw new InvalidOperationException(
+                "NCLMetaForm.CreateObjectInstance: could not read the page's object id from " +
+                "its metadata — constructing the wrong page would silently open the wrong " +
+                "list/card.");
+
+        return (Microsoft.Dynamics.Nav.Runtime.NavForm)ConstructFormForStaticEntry(id, record);
+    }
+
+    private static object ConstructFormForStaticEntry(int id, NavRecord? record)
+    {
+        var formType = _formTypeCache.GetOrAdd(id, FindFormType);
+        if (formType == null)
+            throw new InvalidOperationException(
+                $"Page{id} is not present in the test assembly or any loaded dependency.");
+
+        var parent = SkeletonSession as Microsoft.Dynamics.Nav.Runtime.ITreeObject
+            ?? throw new InvalidOperationException(
+                "NCLMetaForm.CreateObjectInstance: the skeleton session is not initialized yet.");
+
+        var ctors = formType.GetConstructors(
+            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+        var twoArgCtor = ctors.FirstOrDefault(c => c.GetParameters().Length == 2
+            && typeof(Microsoft.Dynamics.Nav.Runtime.ITreeObject).IsAssignableFrom(c.GetParameters()[0].ParameterType)
+            && typeof(NavRecord).IsAssignableFrom(c.GetParameters()[1].ParameterType));
+
+        var boundRecord = record;
+        if (twoArgCtor != null)
+        {
+            if (boundRecord == null)
+            {
+                // The 0-arg overload (CreateObjectInstance() → CreateObjectInstance(null))
+                // has no caller-supplied record. Build a blank one, same as the
+                // page-variable path (NavFormHandle_CreateTarget), so a page whose
+                // OnInit/OnOpenPage reads Rec before the caller ever calls SetSourceTable
+                // does not NRE.
+                var tableId = RecordPatches.ResolveSourceTableIdForAnyPage(id);
+                if (tableId != 0)
+                {
+                    var isTemporary = RecordPatches.ResolveSourceTableTemporaryForAnyPage(id);
+                    boundRecord = TestPageFactory.TryBuildBlankRecord(parent, tableId, isTemporary, out _);
+                }
+            }
+
+            if (boundRecord != null)
+            {
+                var instance = twoArgCtor.Invoke(new object?[] { parent, boundRecord });
+                BindPageSourceObjectId(instance, boundRecord.TableID);
+
+                // NavForm.SetSourceTable(record, clone: false) is BC's own binding step —
+                // reused rather than reimplemented, same rationale as
+                // NavFormHandle_CreateTarget. NavForm.RunModalAsync(record, fieldNo) (the
+                // real, unmodified body this construction feeds into) calls
+                // SetSourceTable(record, clone: true, ...) again itself once
+                // CreateObjectInstance returns, so this first bind only has to make the
+                // freshly-constructed instance safe to touch before that point.
+                var setSourceTable = instance.GetType().GetMethod("SetSourceTable",
+                    BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
+                    binder: null, types: new[] { typeof(NavRecord), typeof(bool) }, modifiers: null);
+                try { setSourceTable?.Invoke(instance, new object?[] { boundRecord, false }); }
+                catch (TargetInvocationException tie) when (tie.InnerException != null)
+                {
+                    Console.Error.WriteLine(
+                        $"[BcRuntime] Page{id}: SetSourceTable failed after binding SourceTable "
+                        + $"{boundRecord.TableID} ({tie.InnerException.GetType().Name}: {tie.InnerException.Message}); "
+                        + "Rec stays unbound, as before this fix.");
+                }
+                return instance;
+            }
+        }
+
+        var oneArgCtor = ctors.FirstOrDefault(c => c.GetParameters().Length == 1 &&
+                typeof(Microsoft.Dynamics.Nav.Runtime.ITreeObject)
+                    .IsAssignableFrom(c.GetParameters()[0].ParameterType));
+        if (oneArgCtor == null)
+            throw new InvalidOperationException(
+                $"Page{id} has no single-arg ITreeObject constructor");
+        return oneArgCtor.Invoke(new object[] { parent });
+    }
+}

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -87,7 +87,14 @@ dispatch, and report/request-page variables support a limited standalone surface
   the last row. Tracked in
   [#1755](https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/1755).
 - `Page.Run()` is a no-op. `Page.RunModal()` dispatches to `[ModalPageHandler]` if
-  registered, otherwise throws.
+  registered, otherwise throws — both the page-variable form
+  (`P.SetRecord(Rec); P.RunModal();`) and the static-by-id forms
+  (`Page.RunModal(id, Record)`, `Page.RunModal(Page::"X", Record)`, and Base App
+  `Codeunit 700 "Page Management"` code that routes through them). The static
+  `Page.RunModal(0, Record)` form, which real BC resolves via the record table's
+  `LookupPageId`, is not yet implemented and throws
+  [#1918](https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/1918); pass an
+  explicit page id in the meantime.
 - Request pages can be handled via `[RequestPageHandler]`, but this is handler dispatch
   only, not real request-page rendering.
 - Report variables support `Run()`, `RunRequestPage()`, `SetTableView()`, and

--- a/tests/expectations/count-baseline/test-count-baseline.json
+++ b/tests/expectations/count-baseline/test-count-baseline.json
@@ -7,12 +7,12 @@
     },
     "runner-extras": {
       "tests": {
-        "default": 123,
-        "byBcVersion": { "27.0": 117, "27.3": 117, "27.5": 117 }
+        "default": 126,
+        "byBcVersion": { "27.0": 120, "27.3": 120, "27.5": 120 }
       },
       "appGroups": {
-        "default": 25,
-        "byBcVersion": { "27.0": 23, "27.3": 23, "27.5": 23 }
+        "default": 26,
+        "byBcVersion": { "27.0": 24, "27.3": 24, "27.5": 24 }
       }
     }
   }

--- a/tests/runner-extras/static-runmodal-record/SrmrModal.Page.al
+++ b/tests/runner-extras/static-runmodal-record/SrmrModal.Page.al
@@ -1,0 +1,32 @@
+page 64501 "Srmr Modal"
+{
+    PageType = StandardDialog;
+    SourceTable = "Srmr Row";
+    ApplicationArea = All;
+
+    layout
+    {
+        area(Content)
+        {
+            field(Descr; Rec.Descr)
+            {
+                ApplicationArea = All;
+            }
+        }
+    }
+
+    actions
+    {
+        area(Processing)
+        {
+            action(OK)
+            {
+                ApplicationArea = All;
+            }
+            action(Cancel)
+            {
+                ApplicationArea = All;
+            }
+        }
+    }
+}

--- a/tests/runner-extras/static-runmodal-record/SrmrRow.Table.al
+++ b/tests/runner-extras/static-runmodal-record/SrmrRow.Table.al
@@ -1,0 +1,15 @@
+table 64500 "Srmr Row"
+{
+    DataClassification = CustomerContent;
+
+    fields
+    {
+        field(1; "No."; Code[20]) { }
+        field(2; Descr; Text[50]) { }
+    }
+
+    keys
+    {
+        key(PK; "No.") { Clustered = true; }
+    }
+}

--- a/tests/runner-extras/static-runmodal-record/SrmrTests.Codeunit.al
+++ b/tests/runner-extras/static-runmodal-record/SrmrTests.Codeunit.al
@@ -1,0 +1,125 @@
+codeunit 64502 "Srmr Tests"
+{
+    // Regression for issue #1897. Real BC's NCLMetaForm.CreateObjectInstance(NavRecord)
+    // constructs the page via `base.ApplicationObjectConstructor` — a delegate the runner
+    // forces null for EVERY object type (same story as the sibling NCLMetaXmlPort/
+    // NCLMetaQuery CreateObjectInstance fixes: RecordPatches.CreateObjectInstance.cs /
+    // XmlPortPatches.cs). The AL-page-VARIABLE form of RunModal
+    // (`P: Page "Srmr Modal"; P.SetRecord(Rec); P.RunModal();`) never reaches this method —
+    // NavFormHandle.CreateTarget already has its own working construction path for that
+    // case — so only the STATIC-by-id form (Page.RunModal(id, Record), and transitively
+    // Base App Codeunit 700 "Page Management".PageRunModal/PageRun) is affected. Before the
+    // fix this NREs at:
+    //
+    //   NCLMetaApplicationObject.get_ApplicationObjectLegacyConstructor()
+    //   NCLMetaForm.CreateObjectInstance(NavRecord record)
+    //   NavForm.RunModalAsync(bool isInLookupTrigger, bool isLookup, int formId, NavRecord record, int fieldNo)
+    //
+    // The 2-arg (PageId, Record) overload runs in LOOKUP mode (verified against real BC and
+    // reflected here): the handler's OK/Cancel reads back as LookupOK/LookupCancel, not
+    // OK/Cancel.
+    Subtype = Test;
+
+    local procedure Initialize()
+    var
+        Row: Record "Srmr Row";
+    begin
+        Row.DeleteAll();
+    end;
+
+    // Positive: the static Page.RunModal(id, Record) form reaches the [ModalPageHandler]
+    // (no NRE), and the handler's OK reaches the calling AL as LookupOK.
+    [Test]
+    [HandlerFunctions('OkHandler')]
+    procedure StaticRunModal_ExplicitId_HandlerRunsAndReturnsLookupOk()
+    var
+        Row: Record "Srmr Row";
+        Result: Action;
+    begin
+        Initialize();
+        Row.Init();
+        Row."No." := 'A';
+        Row.Descr := 'Alpha';
+        Row.Insert();
+
+        Result := Page.RunModal(Page::"Srmr Modal", Row);
+
+        if not Row.Get('HANDLER') then
+            Error('the [ModalPageHandler] must have run for the static Page.RunModal(id, Record) form');
+        if Format(Result) <> Format(Action::LookupOK) then
+            Error('Page.RunModal(id, Record) must return the handler''s OK as LookupOK (lookup-mode overload), got %1', Format(Result));
+    end;
+
+    // Negative: a cancelling handler must NOT read back as LookupOK. Without this, a fix
+    // that always reported success (e.g. mapping every construction success straight to
+    // LookupOK) would pass the positive test above and hide the same bug in reverse.
+    [Test]
+    [HandlerFunctions('CancelHandler')]
+    procedure StaticRunModal_ExplicitId_CancelReturnsLookupCancel()
+    var
+        Row: Record "Srmr Row";
+        Result: Action;
+    begin
+        Initialize();
+        Row.Init();
+        Row."No." := 'B';
+        Row.Descr := 'Bravo';
+        Row.Insert();
+
+        Result := Page.RunModal(Page::"Srmr Modal", Row);
+
+        if not Row.Get('HANDLER') then
+            Error('the [ModalPageHandler] must have run for the static Page.RunModal(id, Record) form');
+        if Format(Result) <> Format(Action::LookupCancel) then
+            Error('Page.RunModal(id, Record) must return the handler''s Cancel as LookupCancel, not LookupOK, got %1', Format(Result));
+    end;
+
+    // Sibling proof: the AL-page-VARIABLE form must keep working exactly as before this
+    // fix — construction for that path goes through NavFormHandle.CreateTarget, a
+    // different, already-working mechanism this change does not touch.
+    [Test]
+    [HandlerFunctions('OkHandler')]
+    procedure InstanceRunModal_SetRecord_StillDispatchesHandler()
+    var
+        Row: Record "Srmr Row";
+        Modal: Page "Srmr Modal";
+    begin
+        Initialize();
+        Row.Init();
+        Row."No." := 'C';
+        Row.Descr := 'Charlie';
+        Row.Insert();
+
+        Modal.SetRecord(Row);
+        Modal.RunModal();
+
+        if not Row.Get('HANDLER') then
+            Error('the [ModalPageHandler] must have run for the AL-page-variable RunModal form');
+    end;
+
+    [ModalPageHandler]
+    procedure OkHandler(var Modal: TestPage "Srmr Modal")
+    var
+        Stamp: Record "Srmr Row";
+    begin
+        Stamp.Init();
+        Stamp."No." := 'HANDLER';
+        Stamp.Descr := 'ran';
+        if not Stamp.Insert() then
+            Stamp.Modify();
+        Modal.OK().Invoke();
+    end;
+
+    [ModalPageHandler]
+    procedure CancelHandler(var Modal: TestPage "Srmr Modal")
+    var
+        Stamp: Record "Srmr Row";
+    begin
+        Stamp.Init();
+        Stamp."No." := 'HANDLER';
+        Stamp.Descr := 'ran';
+        if not Stamp.Insert() then
+            Stamp.Modify();
+        Modal.Cancel().Invoke();
+    end;
+}

--- a/tests/runner-extras/static-runmodal-record/app.json
+++ b/tests/runner-extras/static-runmodal-record/app.json
@@ -1,0 +1,19 @@
+{
+  "id": "7a5f0e21-8c4a-4e6b-9f3a-2c8b6d1e4f57",
+  "name": "Runner Extras - Static RunModal Record",
+  "publisher": "AL Runner",
+  "version": "1.0.0.0",
+  "brief": "Regression for issue #1897: static Page.RunModal(id, Record) NREs at NCLMetaForm.CreateObjectInstance while the AL-page-variable form (P.SetRecord(Rec); P.RunModal();) already works.",
+  "description": "The general BC-language contract this exercises — static Page.RunModal(id, Record) reaches a [ModalPageHandler], same as the page-variable form — is a plain BC-behaviour claim and belongs upstream in the al-language corpus (see the runner repo's bc-behavior-tests-go-upstream.md); a corpus test/PR for it was prepared alongside this fix. This suite is the runner-repo-local stopgap: it pins the runner-INTERNAL defect directly (NCLMetaForm.CreateObjectInstance(NavRecord) NREing because the runner forces NCLMetaApplicationObject.ApplicationObjectConstructor to null for every object type, same story as the sibling NCLMetaXmlPort/NCLMetaQuery CreateObjectInstance fixes), so this repo's own CI gates the fix now, without waiting on the corpus PR to merge and the submodule pin to bump. Once that upstream test lands and the pin moves, this suite's claim is fully covered there too and this one may be retired.",
+  "dependencies": [],
+  "idRanges": [
+    {
+      "from": 64500,
+      "to": 64509
+    }
+  ],
+  "platform": "1.0.0.0",
+  "application": "27.0.0.0",
+  "runtime": "14.0",
+  "features": []
+}


### PR DESCRIPTION
Closes #1897

## Root cause

`NCLMetaForm.CreateObjectInstance(NavRecord)` NREs on the runner because
`NCLMetaApplicationObject.ApplicationObjectConstructor` is forced null for
every object type on the skeleton (same story as the sibling
`NCLMetaXmlPort`/`NCLMetaQuery` `CreateObjectInstance` fixes — see
`RecordPatches.CreateObjectInstance.cs` / `XmlPortPatches.cs`). The
AL-page-**variable** `RunModal` form (`P: Page "X"; P.SetRecord(Rec);
P.RunModal();`) never reaches this method at all — `NavFormHandle.CreateTarget`
already has its own, working per-type construction path for that case — so
only the **static-by-id** forms hit the null-delegate NRE:
`Page.RunModal(id, Record)`, `Page.RunModal(Page::"X", Record)`, and
transitively Base App `Codeunit 700 "Page Management".PageRunModal`/`PageRun`.

This confirms the issue's own framing: the instance-page-variable path
already worked, and only the construct-from-id-with-record path NREd.

## Fix

Cecil-rewrite `NCLMetaForm.CreateObjectInstance(NavRecord)` (only that one
overload — the 0-arg overload chains to it and is covered automatically;
the `string personalizationId` overload is unrelated and untouched) to
construct `Page{id}` directly, mirroring `NavFormHandle_CreateTarget`'s ctor
selection ((ITreeObject, NavRecord) when the source table is resolvable,
falling back to (ITreeObject) otherwise) and binding the caller-supplied
record via `SetSourceTable`. There is no `NavFormHandle` to serve as the
parent `ITreeObject` at this point in construction (unlike the
page-variable path — construction happens *before* `NavForm.RunModalAsync`
wraps the result in one), so the skeleton session is used instead — the
same "no handle for a static-by-id call" approach
`NavReportSync.CreateReportForRequestPage` already takes for the static
Report `RunRequestPage` overloads.

Verified against real BC while writing the test: the 2-arg `(PageId,
Record)` overload runs the page in **lookup mode**, so a
`[ModalPageHandler]`'s `OK`/`Cancel` reads back as `LookupOK`/`LookupCancel`,
not `OK`/`Cancel` — the new tests assert that, not the plain values.

## Scope note: `Page.RunModal(0, Record)`

While reproducing the issue's exact repro table, arm 2 (`Page.RunModal(0,
Row)`, which real BC resolves via the record table's `LookupPageId`) turned
out to be a **separate** gap: it fails before `NCLMetaForm.CreateObjectInstance`
is ever reached (`NCLMetaTable.LookupFormId` isn't populated from the AL
`LookupPageId` property on the runner's synthesized metadata). Per
`no-assumption-fixes.md` I kept this PR scoped to the NRE the issue is titled
after and split the `id=0` gap out to #1918, updating `docs/limitations.md`
to name both.

## Test

`tests/runner-extras/static-runmodal-record` — RED confirmed against the
pre-fix binary (exact NRE stack from the issue), GREEN after the fix. Three
tests: the static form's positive (`LookupOK`) and negative (`LookupCancel`,
proving a "always report success" fake would fail) cases, plus a sibling
proof that the page-variable form — which this change does not touch —
still works.

`tests/expectations/count-baseline/test-count-baseline.json` bumped for the
3 new tests / 1 new app group (`runner-extras`: 123→126 tests / 25→26 app
groups on BC 28.x, 117→120 / 23→24 on 27.0/27.3/27.5, matching the existing
`byBcVersion` pattern for a suite with no preprocessor gating).

Full `tests/al-language` corpus (2076/2076) and `tests/runner-extras`
re-run clean after the change; the one pre-existing `runner-extras` failure
and 7 suite errors (missing `Tests-TestLibraries v28.0.0.0` in my local
package cache) are unchanged from `main` — confirmed by diffing a run before
and after this change on the same cache.

## Upstream corpus test — needs a decision

The general BC-language claim this fixes — static `Page.RunModal(id,
Record)` reaches a `[ModalPageHandler]`, same as the page-variable form — is
plain BC behaviour with nothing runner-specific in it, so per this repo's
`bc-behavior-tests-go-upstream.md` it belongs in the al-language corpus, not
as a runner-local test. I wrote and pushed that test
(`TestPageModalHandlerStatic_Tests.al`, codeunit 60717) to a branch on
`StefanMaron/BusinessCentral.AL.Language.Tests` —
[`runner-issue-1897-static-runmodal-record`](https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/compare/main...runner-issue-1897-static-runmodal-record) —
and verified it locally (RED against the pre-fix runner binary with the same
NRE stack, GREEN after the fix), but did not open the PR: opening a PR on a
different repo wasn't something my task authorized, so I'm surfacing the
branch here instead of unilaterally publishing it. If someone opens that PR,
lets it go green on both BC legs (27.5 + 28.1), and merges it, the runner
submodule pin can bump and `tests/runner-extras/static-runmodal-record`
retired per its own app.json description — it says as much.

## Follow-up

#1918 — `Page.RunModal(0, Record)` resolve-from-record-via-LookupPageId,
split out of this issue's repro table.