### PR TITLE
feat(coverage): --coverage via BC's own StmtHit/CStmtHit instrumentation

### DIFF
--- a/.github/workflows/coverage-demo.yml
+++ b/.github/workflows/coverage-demo.yml
@@ -1,0 +1,62 @@
+name: Coverage Demo
+
+on:
+  workflow_dispatch:
+
+env:
+  DOTNET_NOLOGO: true
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: true
+
+      - uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '8.0.x'
+
+      # --coverage (issue #1922) needs no dependency-app provisioning: it's a runtime
+      # hook on Microsoft.Dynamics.Nav.Ncl.dll, auto-downloaded by the build itself.
+      - name: Build (auto-downloads BC 28.1 DLLs)
+        run: |
+          dotnet build AlRunner.slnx \
+            -p:_BCVersion=28.1 \
+            -p:AllowBcArtifactDownload=true \
+            -c Release
+
+      - name: Run self-contained fixtures with --coverage
+        run: |
+          echo "## AL Runner Coverage" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+
+          for fixture in RecordTriggerXRec CoverageBranch; do
+            echo "::group::${fixture}"
+            OUTPUT=$(./AlRunner/bin/Release/net8.0/al-runner \
+              --coverage --coverage-out "cobertura-${fixture}.xml" \
+              "AlRunner.Tests/Fixtures/${fixture}" 2>&1) || true
+            echo "$OUTPUT"
+            echo "::endgroup::"
+
+            # Console coverage table + the test-run summary block (see Reporter.cs /
+            # AlCoverageReport.FormatConsoleTable — the table rows are `  <file>  n/m  pct%`,
+            # the summary block prints `pass:`/`fail:`).
+            COVERAGE_LINES=$(echo "$OUTPUT" | grep -E "^  (TOTAL|[A-Za-z])" | head -20)
+            RESULT_LINES=$(echo "$OUTPUT" | grep -E "^  (pass|fail|error):")
+
+            echo "### ${fixture}" >> "$GITHUB_STEP_SUMMARY"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+            echo "$RESULT_LINES" >> "$GITHUB_STEP_SUMMARY"
+            echo "$COVERAGE_LINES" >> "$GITHUB_STEP_SUMMARY"
+            echo '```' >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+          done
+
+      - name: Upload coverage artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-reports
+          path: cobertura-*.xml

--- a/AlRunner.Tests/CollectionCostOrderer.cs
+++ b/AlRunner.Tests/CollectionCostOrderer.cs
@@ -113,6 +113,9 @@ public sealed class CollectionCostOrderer : ITestCollectionOrderer
             ["InstallSeedDepCompanyCacheTests"] = 196,
             ["TestFilterFlagTests"] = 99,
             ["PhaseLogIntegrationTests"] = 85,
+            // #1922: 6 tests, each spawning a real runner subprocess against an AL fixture
+            // (--coverage twice, --output-junit twice, table-trigger fixture once).
+            ["CoverageTests"] = 85,
             // #1887: added by #1882 (--count-baseline), absent from this table since — same
             // fallback-to-30 failure as InstallSeedDepCompanyCacheTests above, dispatched at
             // t=400s.

--- a/AlRunner.Tests/CoverageTests.cs
+++ b/AlRunner.Tests/CoverageTests.cs
@@ -1,0 +1,229 @@
+// CoverageTests — RED→GREEN guard for --coverage (issue #1922, first slice of #1640).
+//
+// AlRunner.Tests/Fixtures/CoverageBranch has a known statement layout (see the fixture's
+// own AL files): CovProbe.Codeunit.al's `if Flag then ... else ...` gives one TAKEN
+// branch (Result := 2) and one guaranteed-UNTAKEN branch (Result := 3) in the same run,
+// so the "did not execute" half of coverage cannot pass vacuously — a no-op
+// implementation that always reports 0 would fail the positive assertions below, and an
+// implementation that always reports 1 would fail the negative ones.
+//
+// Ghost-test guard: every assertion below names a SPECIFIC AL source line and a SPECIFIC
+// hit count (never just "coverage ran without crashing"), and the untaken-branch and
+// stack-trace-line-preservation checks assert the actual runtime-observed values are
+// EXACTLY what the fixture's source lines say — not merely "cobertura.xml exists".
+using System.Diagnostics;
+using System.Text;
+using System.Xml.Linq;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class CoverageTests : IDisposable
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+    private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
+    private static readonly string Fixture =
+        Path.Combine(RepoRoot, "AlRunner.Tests", "Fixtures", "CoverageBranch");
+
+    private readonly string _scratch;
+
+    public CoverageTests()
+    {
+        _scratch = Path.Combine(Path.GetTempPath(), "al-runner-coverage-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_scratch);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_scratch, recursive: true); } catch { }
+    }
+
+    private (string Output, int Exit) Spawn(params string[] extraArgs)
+    {
+        var args = new StringBuilder(TestBuildConfig.RunArgs(ProjectPath));
+        args.Append(TestBuildConfig.BcVersionArg);
+        args.Append(" --no-cache"); // every run below must actually re-emit/re-instrument, not replay an al-out cache HIT from a prior test
+        foreach (var a in extraArgs) args.Append(' ').Append(a);
+        args.Append(" \"").Append(Fixture).Append('"');
+
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            Arguments = args.ToString(),
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            WorkingDirectory = RepoRoot,
+        };
+        var sb = new StringBuilder();
+        using var p = Process.Start(psi)!;
+        p.OutputDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.ErrorDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.BeginOutputReadLine();
+        p.BeginErrorReadLine();
+        Assert.True(p.WaitForExit(240_000), "runner did not exit within 240s");
+        p.WaitForExit();
+        return (sb.ToString(), p.ExitCode);
+    }
+
+    /// <summary>Parses a Cobertura <line number=".." hits=".."/> element's hit count for
+    /// a given source file (matched by filename suffix) and line number.</summary>
+    private static int HitsFor(XDocument cobertura, string fileNameSuffix, int line)
+    {
+        var cls = cobertura.Descendants("class")
+            .Single(c => c.Attribute("filename")!.Value.Replace('\\', '/').EndsWith(fileNameSuffix, StringComparison.Ordinal));
+        var lineEl = cls.Descendants("line").Single(l => (int)l.Attribute("number")! == line);
+        return (int)lineEl.Attribute("hits")!;
+    }
+
+    [SkippableFact]
+    public void Coverage_TakenBranchStatement_ReportsNonZeroHit()
+    {
+        TestArtifacts.SkipIfMissing();
+        var coveragePath = Path.Combine(_scratch, "cobertura.xml");
+        var (output, exit) = Spawn("--coverage", $"--coverage-out \"{coveragePath}\"");
+
+        Assert.Equal(1, exit); // one test in the fixture deliberately fails
+        Assert.True(File.Exists(coveragePath), $"cobertura.xml was not written.\n{output}");
+        var doc = XDocument.Load(coveragePath);
+
+        // CovProbe.Codeunit.al line 14 is `Result := 2;` inside `if Flag then` — the test
+        // calls Run(true), so this line MUST have executed.
+        Assert.Equal(1, HitsFor(doc, "CovProbe.Codeunit.al", 14));
+        // Line 13 is the `if Flag then` condition itself (CStmtHit, not StmtHit) — also
+        // must have executed exactly because the method was called at all.
+        Assert.Equal(1, HitsFor(doc, "CovProbe.Codeunit.al", 13));
+    }
+
+    [SkippableFact]
+    public void Coverage_UntakenBranchStatement_ReportsZeroHit()
+    {
+        TestArtifacts.SkipIfMissing();
+        var coveragePath = Path.Combine(_scratch, "cobertura.xml");
+        var (output, exit) = Spawn("--coverage", $"--coverage-out \"{coveragePath}\"");
+        Assert.Equal(1, exit);
+        Assert.True(File.Exists(coveragePath), $"cobertura.xml was not written.\n{output}");
+        var doc = XDocument.Load(coveragePath);
+
+        // CovProbe.Codeunit.al line 16 is `Result := 3;` — the `else` branch of `if Flag
+        // then`. The only call in the fixture is Run(true), so this line NEVER executes.
+        // If the implementation always reported 1 (vacuous "coverage"), this fails.
+        Assert.Equal(0, HitsFor(doc, "CovProbe.Codeunit.al", 16));
+
+        // Same shape one level up: CovAssert.Codeunit.al line 7 is the Error() call
+        // inside `if Expected <> Actual` — the fixture's assertion always passes, so the
+        // failure branch inside the assert helper itself never runs either.
+        Assert.Equal(0, HitsFor(doc, "CovAssert.Codeunit.al", 7));
+        // ...but the condition on line 6 that GUARDS it did run (CStmtHit again) — proves
+        // the zero above is a real "didn't take this branch", not "scope never touched".
+        Assert.Equal(1, HitsFor(doc, "CovAssert.Codeunit.al", 6));
+    }
+
+    [SkippableFact]
+    public void Coverage_ReportedLine_MatchesTableTriggerSource()
+    {
+        // Guards the CLR class-naming fix this issue's investigation surfaced: table
+        // trigger scopes are nested in a class named Record<N>, not Table<N>, and would
+        // silently vanish from coverage without it (id resolves to 0 -> scope skipped).
+        // CoverageBranch has no table, so this reuses RecordTriggerXRec instead — its
+        // OnInsert trigger's single statement is documented at AL line 29.
+        TestArtifacts.SkipIfMissing();
+        var tableFixture = Path.Combine(RepoRoot, "AlRunner.Tests", "Fixtures", "RecordTriggerXRec");
+        var coveragePath = Path.Combine(_scratch, "table-cobertura.xml");
+
+        var args = new StringBuilder(TestBuildConfig.RunArgs(ProjectPath));
+        args.Append(TestBuildConfig.BcVersionArg);
+        args.Append(" --no-cache --coverage --coverage-out \"").Append(coveragePath).Append('"');
+        args.Append(" \"").Append(tableFixture).Append('"');
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet", Arguments = args.ToString(),
+            RedirectStandardOutput = true, RedirectStandardError = true,
+            UseShellExecute = false, CreateNoWindow = true, WorkingDirectory = RepoRoot,
+        };
+        var sb = new StringBuilder();
+        using (var p = Process.Start(psi)!)
+        {
+            p.OutputDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+            p.ErrorDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+            p.BeginOutputReadLine();
+            p.BeginErrorReadLine();
+            Assert.True(p.WaitForExit(240_000), "runner did not exit within 240s");
+            p.WaitForExit();
+            Assert.Equal(0, p.ExitCode);
+        }
+
+        Assert.True(File.Exists(coveragePath), $"cobertura.xml was not written.\n{sb}");
+        var doc = XDocument.Load(coveragePath);
+        Assert.Equal(1, HitsFor(doc, "XRecProbe.Table.al", 29));
+    }
+
+    [SkippableFact]
+    public void Coverage_Disabled_ProducesNoCoberturaFile()
+    {
+        TestArtifacts.SkipIfMissing();
+        var coveragePath = Path.Combine(_scratch, "cobertura.xml");
+        // --coverage-out on its own (no --coverage) must not turn coverage on.
+        var (_, exit) = Spawn($"--coverage-out \"{coveragePath}\"");
+        Assert.Equal(1, exit); // the fixture's deliberate failure still fails the run
+        Assert.False(File.Exists(coveragePath),
+            "cobertura.xml was written even though --coverage was not passed");
+    }
+
+    [SkippableFact]
+    public void Coverage_Disabled_TestOutcomesIdenticalToEnabled()
+    {
+        TestArtifacts.SkipIfMissing();
+        var (offOutput, offExit) = Spawn();
+        var (onOutput, onExit) = Spawn("--coverage",
+            $"--coverage-out \"{Path.Combine(_scratch, "cobertura.xml")}\"");
+
+        Assert.Equal(offExit, onExit);
+        Assert.Contains("pass:        1", offOutput);
+        Assert.Contains("fail:        1", offOutput);
+        Assert.Contains("pass:        1", onOutput);
+        Assert.Contains("fail:        1", onOutput);
+    }
+
+    /// <summary>
+    /// The regression this issue calls out as most likely and least likely to be
+    /// noticed: NavMethodScope.StatementNumber backs AlCallStackCapture's "line L" in
+    /// every AL stack trace. The Cecil rewrite PREPENDS the coverage hook before
+    /// StmtHit/CStmtHit's existing body instead of replacing it, so this must be
+    /// byte-identical whether or not --coverage (and therefore the rewrite's hook call)
+    /// is exercised.
+    /// </summary>
+    [SkippableFact]
+    public void Coverage_DoesNotChange_AlStackTraceLineNumber()
+    {
+        TestArtifacts.SkipIfMissing();
+        var junitOff = Path.Combine(_scratch, "off.junit.xml");
+        var junitOn = Path.Combine(_scratch, "on.junit.xml");
+
+        Spawn($"--output-junit \"{junitOff}\"");
+        Spawn("--coverage", $"--coverage-out \"{Path.Combine(_scratch, "on-cobertura.xml")}\"",
+            $"--output-junit \"{junitOn}\"");
+
+        Assert.True(File.Exists(junitOff));
+        Assert.True(File.Exists(junitOn));
+
+        var failureOff = FailureText(junitOff);
+        var failureOn = FailureText(junitOn);
+
+        // Not just "non-null" — the specific line BC's own stack-trace convention would
+        // print for a one-statement [Test] procedure body.
+        Assert.Contains("DeliberateFailure_ForStackTraceLineRegression line 2", failureOff);
+        Assert.Equal(failureOff, failureOn);
+    }
+
+    private static string FailureText(string junitPath)
+    {
+        var doc = XDocument.Load(junitPath);
+        var failure = doc.Descendants("testcase")
+            .Single(tc => (string)tc.Attribute("name")! == "DeliberateFailure_ForStackTraceLineRegression")
+            .Descendants("failure").Single();
+        return failure.Value;
+    }
+}

--- a/AlRunner.Tests/Fixtures/CoverageBranch/CovAssert.Codeunit.al
+++ b/AlRunner.Tests/Fixtures/CoverageBranch/CovAssert.Codeunit.al
@@ -1,0 +1,9 @@
+/// <summary>Minimal assertion helper for this fixture app (own ID range).</summary>
+codeunit 50920 "Cov Assert RXT"
+{
+    procedure AreEqual(Expected: Integer; Actual: Integer; Msg: Text)
+    begin
+        if Expected <> Actual then
+            Error('AreEqual failed: %1 <> %2. %3', Expected, Actual, Msg);
+    end;
+}

--- a/AlRunner.Tests/Fixtures/CoverageBranch/CovProbe.Codeunit.al
+++ b/AlRunner.Tests/Fixtures/CoverageBranch/CovProbe.Codeunit.al
@@ -1,0 +1,20 @@
+/// <summary>
+/// One `if`/`else` with a known taken branch (Flag=true -> Result:=2) and a known
+/// untaken branch (Result:=3) — proves the "did not execute" half of --coverage is not
+/// vacuous. Statement line numbers are pinned by AlRunner.Tests/CoverageTests.cs.
+/// </summary>
+codeunit 50921 "Cov Probe RXT"
+{
+    procedure Run(Flag: Boolean): Integer
+    var
+        Result: Integer;
+    begin
+        Result := 1;
+        if Flag then begin
+            Result := 2;
+        end else begin
+            Result := 3;
+        end;
+        exit(Result);
+    end;
+}

--- a/AlRunner.Tests/Fixtures/CoverageBranch/CovProbeTests.Codeunit.al
+++ b/AlRunner.Tests/Fixtures/CoverageBranch/CovProbeTests.Codeunit.al
@@ -1,0 +1,27 @@
+codeunit 50922 "Cov Probe Tests RXT"
+{
+    Subtype = Test;
+    TestPermissions = Disabled;
+
+    var
+        Assert: Codeunit "Cov Assert RXT";
+
+    [Test]
+    procedure Run_FlagTrue_ReturnsTwo()
+    var
+        Probe: Codeunit "Cov Probe RXT";
+    begin
+        Assert.AreEqual(2, Probe.Run(true), 'expected 2');
+    end;
+
+    // Deliberately fails: AlRunner.Tests/CoverageTests.cs pins this Error call to a
+    // specific AL source line and asserts the "line L" AL Runner prints in the stack
+    // trace is identical whether or not --coverage (and therefore the StmtHit/CStmtHit
+    // Cecil rewrite) is active — the regression this issue calls out as most likely to
+    // break and least likely to be noticed.
+    [Test]
+    procedure DeliberateFailure_ForStackTraceLineRegression()
+    begin
+        Error('deliberate failure for stack-trace-line regression check');
+    end;
+}

--- a/AlRunner.Tests/Fixtures/CoverageBranch/app.json
+++ b/AlRunner.Tests/Fixtures/CoverageBranch/app.json
@@ -1,0 +1,25 @@
+{
+  "id": "c2c3d4e5-f6a7-4809-9b1c-2c3d4e5f6082",
+  "name": "Runner Tests Fixture - Coverage Branch",
+  "publisher": "AL Runner",
+  "version": "1.0.0.0",
+  "brief": "--coverage (issue #1922) proof fixture: one taken branch, one untaken branch, one deliberate failure for the AL stack-trace-line regression check.",
+  "description": "Used by AlRunner.Tests/CoverageTests.cs.",
+  "privacyStatement": "",
+  "EULA": "",
+  "help": "",
+  "url": "",
+  "logo": "",
+  "dependencies": [],
+  "screenshots": [],
+  "platform": "1.0.0.0",
+  "application": "1.0.0.0",
+  "idRanges": [
+    {
+      "from": 50920,
+      "to": 50939
+    }
+  ],
+  "runtime": "14.0",
+  "features": []
+}

--- a/AlRunner/Infrastructure/AlCallStackCapture.cs
+++ b/AlRunner/Infrastructure/AlCallStackCapture.cs
@@ -260,7 +260,9 @@ public static class AlCallStackCapture
     /// <see cref="Type.DeclaringType"/> when needed.
     /// Returns ("CodeUnit"|"Page"|…, number) or ("?", 0) if unknown.
     /// </summary>
-    private static (string, int) ParseObjectTypeAndId(Type type)
+    /// <summary>Internal (not private): also used by AlCoverageTracker to resolve a
+    /// scope's declaring AL object identity for the cobertura file mapping.</summary>
+    internal static (string, int) ParseObjectTypeAndId(Type type)
     {
         // Walk up to the outermost non-nested type (scope classes are nested).
         var t = type;
@@ -275,6 +277,14 @@ public static class AlCallStackCapture
             ("NavTestCodeunit","CodeUnit"),
             ("Codeunit",      "CodeUnit"),
             ("Table",         "Table"),
+            // Table TRIGGER scopes (OnInsert/OnModify/…) are nested inside the table's
+            // generated record wrapper class, named Record<N> — NOT Table<N> (confirmed
+            // via DUMP_CS=1 on AlRunner.Tests/Fixtures/RecordTriggerXRec: `public sealed
+            // class Record60100 : NavRecord { ... class OnInsert_Scope : ... }`). Without
+            // this, every table trigger's scope resolved to ("?", 0) — id==0 — so
+            // AlCoverageTracker silently dropped ALL table-trigger coverage, and any AL
+            // stack trace originating inside a table trigger printed no object identity.
+            ("Record",        "Table"),
             ("Page",          "Page"),
             ("Report",        "Report"),
             ("Query",         "Query"),
@@ -341,13 +351,8 @@ public static class AlCallStackCapture
             var encodedSpan    = encodedSpans[idx];
             var encodedSigSpan = (long)(_piSigEncodedSpan?.GetValue(sigAttr) ?? 0L);
 
-            // SourceSpan layout (StructLayout.Explicit, little-endian):
-            //   [0..1] = to.column, [2..3] = to.line, [4..5] = from.column, [6..7] = from.line
-            // As a long: from.line occupies bits 48-63.
-            ushort absLine = (ushort)((ulong)encodedSpan >> 48);
-            ushort sigLine = (ushort)((ulong)encodedSigSpan >> 48);
-
-            return (ushort)(absLine - sigLine);
+            // Bit layout is shared with AlCoverageTracker — see AlSourceSpanCodec.
+            return AlSourceSpanCodec.RelativeLine(encodedSpan, encodedSigSpan);
         }
         catch { return -1; }
     }

--- a/AlRunner/Infrastructure/AlCoverageInstrumentedStatements.cs
+++ b/AlRunner/Infrastructure/AlCoverageInstrumentedStatements.cs
@@ -1,0 +1,162 @@
+// AlCoverageInstrumentedStatements — determines which SourceSpans indices a scope class
+// actually backs with a runtime hit call (NavMethodScope.StmtHit or .CStmtHit), as
+// opposed to indices SourceSpans carries for error-mapping only.
+//
+// Empirically confirmed (DUMP_CS=1 against two fixtures — AlRunner.Tests/Fixtures/
+// RecordTriggerXRec and a scratch if/else probe): BC's compiler always emits one extra
+// SourceSpans entry beyond the highest index any StmtHit/CStmtHit call uses (a trailing
+// sentinel — observed at the method's closing `end;`). That entry can never register a
+// hit no matter what the test does, so including it in a coverage report would
+// permanently show one line at 0% regardless of execution — not a real "did not run"
+// signal. Filtering to indices this scan actually finds keeps the report honest.
+//
+// This also finds indices only reachable via CStmtHit, which is the instrumentation an
+// `if`/`while`/`repeat` CONDITION gets (its call is folded into the boolean expression:
+// `if (CStmtHit(1) & (this.flag))`) as opposed to the StmtHit a plain statement gets.
+// Without this, every conditional expression's own line would read permanently 0.
+using System.Reflection;
+using System.Reflection.Emit;
+
+namespace AlRunner.Infrastructure;
+
+public static class AlCoverageInstrumentedStatements
+{
+    private static readonly Dictionary<byte, OpCode> SingleByteOpCodes = typeof(OpCodes)
+        .GetFields(BindingFlags.Public | BindingFlags.Static)
+        .Where(f => f.FieldType == typeof(OpCode))
+        .Select(f => (OpCode)f.GetValue(null)!)
+        .Where(op => op.Size == 1)
+        .ToDictionary(op => unchecked((byte)op.Value));
+
+    private static readonly Dictionary<byte, OpCode> DoubleByteOpCodes = typeof(OpCodes)
+        .GetFields(BindingFlags.Public | BindingFlags.Static)
+        .Where(f => f.FieldType == typeof(OpCode))
+        .Select(f => (OpCode)f.GetValue(null)!)
+        .Where(op => op.Size == 2 && ((ushort)op.Value >> 8) == 0xFE)
+        .ToDictionary(op => unchecked((byte)op.Value));
+
+    /// <summary>
+    /// Scans <paramref name="scopeType"/>'s OnRun/OnRunAsync/OnRunEventAsync method body
+    /// (whichever is present — BC emits exactly one per scope class) for
+    /// StmtHit(int)/CStmtHit(int[, bool]) call sites and returns the set of statement
+    /// indices actually instrumented.
+    /// </summary>
+    public static HashSet<int> Find(Type scopeType)
+    {
+        var result = new HashSet<int>();
+        foreach (var m in scopeType.GetMethods(
+            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly))
+        {
+            if (m.Name is not ("OnRun" or "OnRunAsync" or "OnRunEventAsync")) continue;
+            byte[]? il;
+            try { il = m.GetMethodBody()?.GetILAsByteArray(); }
+            catch (Exception) { continue; } // e.g. a method with no body to reflect over
+            if (il == null) continue;
+            Scan(m.Module, il, result);
+        }
+        return result;
+    }
+
+    private static void Scan(Module module, byte[] il, HashSet<int> result)
+    {
+        long? lastConst = null;
+        int offset = 0;
+        while (offset < il.Length)
+        {
+            byte first = il[offset++];
+            OpCode op;
+            if (first == 0xFE)
+            {
+                if (offset >= il.Length || !DoubleByteOpCodes.TryGetValue(il[offset++], out op)) return;
+            }
+            else if (!SingleByteOpCodes.TryGetValue(first, out op))
+            {
+                return; // unrecognised opcode — stop scanning defensively; coverage is
+                        // best-effort diagnostics, never allowed to crash a test run.
+            }
+
+            long? thisConst = null;
+            switch (op.OperandType)
+            {
+                case OperandType.InlineNone:
+                    thisConst = ConstFromInlineNone(op);
+                    break;
+                case OperandType.ShortInlineI:
+                    if (offset >= il.Length) return;
+                    if (op == OpCodes.Ldc_I4_S) thisConst = unchecked((sbyte)il[offset]);
+                    offset += 1;
+                    break;
+                case OperandType.ShortInlineBrTarget:
+                case OperandType.ShortInlineVar:
+                    offset += 1;
+                    break;
+                case OperandType.InlineVar:
+                    offset += 2;
+                    break;
+                case OperandType.InlineI:
+                    if (offset + 4 > il.Length) return;
+                    if (op == OpCodes.Ldc_I4) thisConst = BitConverter.ToInt32(il, offset);
+                    offset += 4;
+                    break;
+                case OperandType.InlineBrTarget:
+                case OperandType.ShortInlineR: // 4 bytes despite the name (float32; InlineR is the 8-byte double)
+                    offset += 4;
+                    break;
+                case OperandType.InlineI8:
+                case OperandType.InlineR:
+                    offset += 8;
+                    break;
+                case OperandType.InlineSwitch:
+                    if (offset + 4 > il.Length) return;
+                    int caseCount = BitConverter.ToInt32(il, offset);
+                    offset += 4 + caseCount * 4;
+                    break;
+                case OperandType.InlineMethod:
+                {
+                    if (offset + 4 > il.Length) return;
+                    int token = BitConverter.ToInt32(il, offset);
+                    offset += 4;
+                    if ((op == OpCodes.Call || op == OpCodes.Callvirt) && lastConst.HasValue)
+                    {
+                        MethodBase? resolved;
+                        try { resolved = module.ResolveMethod(token); }
+                        catch (Exception) { resolved = null; }
+                        if (resolved != null && IsStmtHitFamily(resolved))
+                            result.Add(checked((int)lastConst.Value));
+                    }
+                    break;
+                }
+                case OperandType.InlineField:
+                case OperandType.InlineSig:
+                case OperandType.InlineString:
+                case OperandType.InlineTok:
+                case OperandType.InlineType:
+                    offset += 4;
+                    break;
+                default:
+                    return;
+            }
+
+            lastConst = thisConst;
+        }
+    }
+
+    private static long? ConstFromInlineNone(OpCode op)
+    {
+        if (op == OpCodes.Ldc_I4_M1) return -1;
+        if (op == OpCodes.Ldc_I4_0) return 0;
+        if (op == OpCodes.Ldc_I4_1) return 1;
+        if (op == OpCodes.Ldc_I4_2) return 2;
+        if (op == OpCodes.Ldc_I4_3) return 3;
+        if (op == OpCodes.Ldc_I4_4) return 4;
+        if (op == OpCodes.Ldc_I4_5) return 5;
+        if (op == OpCodes.Ldc_I4_6) return 6;
+        if (op == OpCodes.Ldc_I4_7) return 7;
+        if (op == OpCodes.Ldc_I4_8) return 8;
+        return null;
+    }
+
+    private static bool IsStmtHitFamily(MethodBase m) =>
+        m.DeclaringType?.Namespace == "Microsoft.Dynamics.Nav.Runtime"
+        && (m.Name == "StmtHit" || m.Name == "CStmtHit");
+}

--- a/AlRunner/Infrastructure/AlCoverageReport.cs
+++ b/AlRunner/Infrastructure/AlCoverageReport.cs
@@ -1,0 +1,128 @@
+// AlCoverageReport — turns AlCoverageTracker.Collect()'s flat statement list into
+// Cobertura XML (consumed by VS Code Coverage Gutters, GitHub Actions annotations, most
+// CI coverage tools) and a console summary table.
+using System.Globalization;
+using System.Text;
+using System.Xml;
+
+namespace AlRunner.Infrastructure;
+
+public static class AlCoverageReport
+{
+    /// <summary>Per-file coverage totals, used by both the console table and as the
+    /// return value so callers (tests, --output-json) can assert on numbers directly
+    /// instead of parsing XML.</summary>
+    public readonly record struct FileCoverage(string FilePath, int CoveredLines, int TotalLines);
+
+    /// <summary>
+    /// Groups statements by file and AL source line (summing hit counts of statements
+    /// that share a line — e.g. two short statements on one line), then writes Cobertura
+    /// XML to <paramref name="outputPath"/>. Returns the per-file totals actually written.
+    /// </summary>
+    public static List<FileCoverage> WriteCobertura(string outputPath, IReadOnlyList<AlCoverageStatement> statements)
+    {
+        var byFile = new Dictionary<string, SortedDictionary<int, int>>(); // file -> line -> summed hits
+        foreach (var s in statements)
+        {
+            if (!byFile.TryGetValue(s.FilePath, out var lines))
+                byFile[s.FilePath] = lines = new SortedDictionary<int, int>();
+            lines.TryGetValue(s.Line, out var existing);
+            lines[s.Line] = existing + s.HitCount;
+        }
+
+        var fileCoverages = new List<FileCoverage>();
+        int totalLines = 0, coveredLines = 0;
+        foreach (var (file, lines) in byFile)
+        {
+            int fCovered = lines.Count(kv => kv.Value > 0);
+            fileCoverages.Add(new FileCoverage(file, fCovered, lines.Count));
+            totalLines += lines.Count;
+            coveredLines += fCovered;
+        }
+        double lineRate = totalLines > 0 ? (double)coveredLines / totalLines : 0;
+
+        using (var writer = XmlWriter.Create(outputPath, new XmlWriterSettings
+        {
+            Indent = true,
+            Encoding = new UTF8Encoding(false),
+        }))
+        {
+            writer.WriteStartDocument();
+            writer.WriteDocType("coverage", null, "http://cobertura.sourceforge.net/xml/coverage-04.dtd", null);
+
+            writer.WriteStartElement("coverage");
+            writer.WriteAttributeString("line-rate", lineRate.ToString("F4", CultureInfo.InvariantCulture));
+            writer.WriteAttributeString("branch-rate", "0");
+            writer.WriteAttributeString("lines-covered", coveredLines.ToString(CultureInfo.InvariantCulture));
+            writer.WriteAttributeString("lines-valid", totalLines.ToString(CultureInfo.InvariantCulture));
+            writer.WriteAttributeString("version", "1.0");
+            writer.WriteAttributeString("timestamp", DateTimeOffset.UtcNow.ToUnixTimeSeconds().ToString(CultureInfo.InvariantCulture));
+
+            writer.WriteStartElement("sources");
+            writer.WriteStartElement("source");
+            writer.WriteString(".");
+            writer.WriteEndElement();
+            writer.WriteEndElement(); // sources
+
+            writer.WriteStartElement("packages");
+            writer.WriteStartElement("package");
+            writer.WriteAttributeString("name", "al-source");
+            writer.WriteAttributeString("line-rate", lineRate.ToString("F4", CultureInfo.InvariantCulture));
+            writer.WriteAttributeString("branch-rate", "0");
+
+            writer.WriteStartElement("classes");
+            foreach (var (file, lines) in byFile.OrderBy(kv => kv.Key, StringComparer.Ordinal))
+            {
+                var fileName = Path.GetFileName(file);
+                int fCovered = lines.Count(kv => kv.Value > 0);
+                double fRate = lines.Count > 0 ? (double)fCovered / lines.Count : 0;
+
+                writer.WriteStartElement("class");
+                writer.WriteAttributeString("name", Path.GetFileNameWithoutExtension(fileName));
+                writer.WriteAttributeString("filename", file);
+                writer.WriteAttributeString("line-rate", fRate.ToString("F4", CultureInfo.InvariantCulture));
+                writer.WriteAttributeString("branch-rate", "0");
+
+                writer.WriteStartElement("lines");
+                foreach (var (lineNum, hits) in lines)
+                {
+                    writer.WriteStartElement("line");
+                    writer.WriteAttributeString("number", lineNum.ToString(CultureInfo.InvariantCulture));
+                    writer.WriteAttributeString("hits", hits.ToString(CultureInfo.InvariantCulture));
+                    writer.WriteEndElement();
+                }
+                writer.WriteEndElement(); // lines
+                writer.WriteEndElement(); // class
+            }
+            writer.WriteEndElement(); // classes
+            writer.WriteEndElement(); // package
+            writer.WriteEndElement(); // packages
+            writer.WriteEndElement(); // coverage
+        }
+
+        return fileCoverages;
+    }
+
+    /// <summary>Console table rows: `  <file>  <covered>/<total>  <pct>%` plus a TOTAL row.
+    /// Both the file-name and TOTAL rows start with two spaces then an uppercase letter,
+    /// matching the grep pattern the coverage-demo workflow extracts for its job summary.</summary>
+    public static string FormatConsoleTable(IReadOnlyList<FileCoverage> files)
+    {
+        var sb = new StringBuilder();
+        int totalCovered = 0, totalLines = 0;
+        foreach (var f in files.OrderBy(f => f.FilePath, StringComparer.Ordinal))
+        {
+            totalCovered += f.CoveredLines;
+            totalLines += f.TotalLines;
+            double pct = f.TotalLines > 0 ? 100.0 * f.CoveredLines / f.TotalLines : 0;
+            sb.Append("  ").Append(Path.GetFileName(f.FilePath).PadRight(40))
+              .Append(f.CoveredLines).Append('/').Append(f.TotalLines).Append("  ")
+              .Append(pct.ToString("F1", CultureInfo.InvariantCulture)).Append('%').Append('\n');
+        }
+        double totalPct = totalLines > 0 ? 100.0 * totalCovered / totalLines : 0;
+        sb.Append("  TOTAL").Append(new string(' ', 34))
+          .Append(totalCovered).Append('/').Append(totalLines).Append("  ")
+          .Append(totalPct.ToString("F1", CultureInfo.InvariantCulture)).Append('%');
+        return sb.ToString();
+    }
+}

--- a/AlRunner/Infrastructure/AlCoverageSourceMap.cs
+++ b/AlRunner/Infrastructure/AlCoverageSourceMap.cs
@@ -1,0 +1,64 @@
+// AlCoverageSourceMap — maps (AL object type label, AL object id) back to the .al file
+// that declares it, for --coverage's cobertura output. Coverage-only utility: it does
+// not touch AL parsing/compilation, just scans header lines of the same .al files the
+// bundle was already compiled from, the same way v1's SourceFileMapper did.
+using System.Text.RegularExpressions;
+
+namespace AlRunner.Infrastructure;
+
+public static class AlCoverageSourceMap
+{
+    // Matches an AL object declaration header: `<keyword> <id> <name>`. Anchored to the
+    // start of a (trimmed) line so it does not fire inside comments/strings later in the
+    // file. Only the keyword + numeric id are needed; the label mapping below must match
+    // AlCallStackCapture.ParseObjectTypeAndId's labels exactly, since that is the other
+    // half of the (label, id) key this map is looked up by.
+    private static readonly Regex ObjectHeaderPattern = new(
+        @"^\s*(codeunit|table|page|report|xmlport|query|enum)\s+(\d+)\b",
+        RegexOptions.IgnoreCase | RegexOptions.Multiline);
+
+    private static readonly Dictionary<string, string> KeywordToLabel = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["codeunit"] = "CodeUnit",
+        ["table"] = "Table",
+        ["page"] = "Page",
+        ["report"] = "Report",
+        ["query"] = "Query",
+        ["xmlport"] = "XmlPort",
+        ["enum"] = "Enum",
+    };
+
+    /// <summary>
+    /// Scans every *.al file under <paramref name="roots"/> (recursively) and returns a
+    /// map from (object label, object id) to the file's path, relative to
+    /// <paramref name="relativeTo"/> when given (else absolute). Only the FIRST object
+    /// header found per file is registered — AL files declare exactly one top-level
+    /// object, matching the compiler's own constraint.
+    /// </summary>
+    public static Dictionary<(string Label, int Id), string> Build(
+        IEnumerable<string> roots, string? relativeTo = null)
+    {
+        var map = new Dictionary<(string, int), string>();
+        foreach (var root in roots)
+        {
+            if (!Directory.Exists(root)) continue;
+            foreach (var file in Directory.EnumerateFiles(root, "*.al", SearchOption.AllDirectories))
+            {
+                string content;
+                try { content = File.ReadAllText(file); }
+                catch (IOException) { continue; }
+
+                var m = ObjectHeaderPattern.Match(content);
+                if (!m.Success) continue;
+                if (!KeywordToLabel.TryGetValue(m.Groups[1].Value, out var label)) continue;
+                if (!int.TryParse(m.Groups[2].Value, out var id)) continue;
+
+                var path = relativeTo != null
+                    ? Path.GetRelativePath(relativeTo, file).Replace('\\', '/')
+                    : file.Replace('\\', '/');
+                map[(label, id)] = path;
+            }
+        }
+        return map;
+    }
+}

--- a/AlRunner/Infrastructure/AlCoverageTracker.cs
+++ b/AlRunner/Infrastructure/AlCoverageTracker.cs
@@ -1,0 +1,132 @@
+// AlCoverageTracker — the runtime side of --coverage (issue #1922, first slice of the
+// #1640 umbrella). Records a hit per (scope type, AL statement index) via a Cecil-rewrite
+// hook on Microsoft.Dynamics.Nav.Ncl.dll's NavMethodScope.StmtHit(int) — see
+// NclCecilRewrite.RewriteStmtHit — and turns the result into a Cobertura XML report.
+//
+// StmtHit already maintains NavMethodScope.StatementNumber (decompiled and confirmed;
+// see the #1922 investigation notes), which AlCallStackCapture depends on for AL
+// stack-trace "line L". The Cecil rewrite PREPENDS the hook call before StmtHit's
+// existing body — it does not replace or touch that assignment — so stack traces are
+// unaffected whether or not --coverage is passed.
+//
+// Counters are only recorded when Enabled is set (by --coverage); the hook call itself
+// is unconditional in the rewritten IL (so the cached, rewritten Ncl.dll is identical
+// whether or not a given run passes --coverage), but OnStmtHit no-ops immediately when
+// Enabled is false. Observable behaviour on the default path — test results, timing,
+// output — is therefore unchanged.
+using System.Reflection;
+using Microsoft.Dynamics.Nav.Runtime;
+
+namespace AlRunner.Infrastructure;
+
+/// <summary>One AL statement's coverage record, resolved to its AL source location.</summary>
+public readonly record struct AlCoverageStatement(
+    string ObjectLabel, int ObjectId, string FilePath, int Line, int HitCount);
+
+public static class AlCoverageTracker
+{
+    /// <summary>True only while a --coverage run is executing tests. Gates OnStmtHit;
+    /// the Cecil-rewritten StmtHit call is unconditional, this flag is not.</summary>
+    public static volatile bool Enabled;
+
+    private static readonly System.Collections.Concurrent.ConcurrentDictionary<(Type ScopeType, int Stmt), int> _hits = new();
+
+    /// <summary>Reset between coverage collections (tests). Exposed for test isolation.</summary>
+    public static void Reset() => _hits.Clear();
+
+    /// <summary>
+    /// Hook target for the Cecil-rewritten NavMethodScope.StmtHit(int). Public static,
+    /// exactly (NavMethodScope, int) so the rewrite can forward `ldarg.0; ldarg.1; call`
+    /// without boxing the int. Must stay side-effect-free beyond counting: it runs on
+    /// every AL statement of every test, coverage or not.
+    /// </summary>
+    public static void OnStmtHit(NavMethodScope scope, int currentStatementNumber)
+    {
+        if (!Enabled) return;
+        // NavMethodScope.ExitStatementNumber (int.MaxValue) is written directly by
+        // Exit(), never passed to StmtHit by generated code — guarded defensively so a
+        // future BC emit change can't corrupt the dictionary with a giant fake index.
+        if (currentStatementNumber == int.MaxValue) return;
+        _hits.AddOrUpdate((scope.GetType(), currentStatementNumber), 1, static (_, c) => c + 1);
+    }
+
+    /// <summary>Hit count recorded for one (scope type, statement index). 0 if never hit.</summary>
+    public static int GetHitCount(Type scopeType, int stmt) =>
+        _hits.TryGetValue((scopeType, stmt), out var c) ? c : 0;
+
+    private static Type? _tSourceSpansAttr;
+    private static PropertyInfo? _piEncodedSpans;
+
+    private static void EnsureReflInit()
+    {
+        if (_tSourceSpansAttr != null) return;
+        var nclAsm = AppDomain.CurrentDomain.GetAssemblies()
+            .FirstOrDefault(a => a.GetName().Name == "Microsoft.Dynamics.Nav.Ncl")
+            ?? throw new InvalidOperationException(
+                "[coverage] Microsoft.Dynamics.Nav.Ncl.dll not loaded — cannot resolve SourceSpansAttribute");
+
+        _tSourceSpansAttr = nclAsm.GetType("Microsoft.Dynamics.Nav.Runtime.SourceSpansAttribute")
+            ?? throw new InvalidOperationException(
+                "[coverage] Microsoft.Dynamics.Nav.Runtime.SourceSpansAttribute not found in Ncl.dll — BC changed shape, do not ship silently");
+        _piEncodedSpans = _tSourceSpansAttr.GetProperty("EncodedSpans", BindingFlags.Public | BindingFlags.Instance)
+            ?? throw new InvalidOperationException(
+                "[coverage] SourceSpansAttribute.EncodedSpans not found — BC changed shape, do not ship silently");
+        // SignatureSpanAttribute is not needed here (coverage uses absolute lines, not
+        // AlCallStackCapture's signature-relative ones), but validate its presence too
+        // so a BC-shape drift on either attribute fails loudly instead of only breaking
+        // the other call site silently.
+        _ = nclAsm.GetType("Microsoft.Dynamics.Nav.Runtime.SignatureSpanAttribute")
+            ?? throw new InvalidOperationException(
+                "[coverage] Microsoft.Dynamics.Nav.Runtime.SignatureSpanAttribute not found in Ncl.dll — BC changed shape, do not ship silently");
+    }
+
+    /// <summary>
+    /// Enumerates every AL-compiled NavMethodScope subclass currently loaded — identified
+    /// by carrying BC's own [SourceSpansAttribute] (only the AL compiler emits it; Ncl's
+    /// own scope classes, e.g. RootMethodScope, never do) — decodes each statement's
+    /// absolute AL source line via the shared AlSourceSpanCodec, and cross-references the
+    /// hit counts from OnStmtHit. Statements that never executed are included with hit
+    /// count 0 because this is a reflection scan over the compiled shape, not a replay of
+    /// what ran — the "did not execute" half of coverage is not vacuous.
+    ///
+    /// <paramref name="sourceMap"/> resolves (object label, object id) to a file path
+    /// (see AlCoverageSourceMap.Build); scopes whose owning object is not in the map are
+    /// skipped, e.g. framework/library assemblies outside the bundle under test.
+    /// </summary>
+    public static List<AlCoverageStatement> Collect(IReadOnlyDictionary<(string Label, int Id), string> sourceMap)
+    {
+        EnsureReflInit();
+        var result = new List<AlCoverageStatement>();
+
+        foreach (var asm in AppDomain.CurrentDomain.GetAssemblies())
+        {
+            Type[] types;
+            try { types = asm.GetTypes(); }
+            catch (ReflectionTypeLoadException ex) { types = ex.Types.Where(t => t != null).Cast<Type>().ToArray(); }
+
+            foreach (var t in types)
+            {
+                if (Attribute.GetCustomAttribute(t, _tSourceSpansAttr!) is not object srcAttr) continue;
+                if (_piEncodedSpans!.GetValue(srcAttr) is not long[] spans || spans.Length == 0) continue;
+
+                var (label, id) = AlCallStackCapture.ParseObjectTypeAndId(t);
+                if (id == 0) continue;
+                if (!sourceMap.TryGetValue((label, id), out var filePath)) continue;
+
+                // Only indices BC's compiler actually backed with a StmtHit/CStmtHit call
+                // are real, coverable statements — see AlCoverageInstrumentedStatements
+                // for why the raw SourceSpans array is not that set on its own (it
+                // carries a trailing, never-instrumented sentinel entry).
+                var instrumented = AlCoverageInstrumentedStatements.Find(t);
+                foreach (var i in instrumented)
+                {
+                    if (i < 0 || i >= spans.Length) continue; // defensive: BC shape drift
+                    int line = AlSourceSpanCodec.AbsoluteFromLine(spans[i]);
+                    result.Add(new AlCoverageStatement(label, id, filePath, line, GetHitCount(t, i)));
+                }
+            }
+        }
+
+        return result;
+    }
+}

--- a/AlRunner/Infrastructure/AlSourceSpanCodec.cs
+++ b/AlRunner/Infrastructure/AlSourceSpanCodec.cs
@@ -1,0 +1,56 @@
+// AlSourceSpanCodec — decodes the `long` values BC's AL compiler packs into the
+// [SourceSpans(...)] / [SignatureSpan(...)] attributes it emits on every generated
+// NavMethodScope subclass (one entry per AL statement, plus one for the method
+// signature). Two call sites need this: AlCallStackCapture (relative "line L" in AL
+// stack traces) and AlCoverageTracker (absolute AL source line for --coverage). Both
+// used to decode the bit layout independently; this is the single place it happens now
+// — see .claude/rules — "Lift the span-decoding ... into a shared helper ... Do not
+// duplicate the bit layout."
+//
+// Layout (StructLayout.Explicit on BC's side, little-endian in the packed long):
+//   bits 48-63 = from.line     bits 32-47 = from.column
+//   bits 16-31 = to.line       bits  0-15 = to.column
+// All four values are 0-based. Confirmed empirically (not assumed) via DUMP_CS=1 on
+// AlRunner.Tests/Fixtures/RecordTriggerXRec: the decoded from.line for statement 0 is
+// 25, and "Rec.Init();" — the statement BC actually instruments there — is on AL source
+// line 26 (1-based). So an absolute, human-facing AL line is decoded-from-line + 1. A
+// *relative* line (the "line L" BC's own stack traces print) is statement.from-line
+// minus signature.from-line; because both operands are 0-based, the +1 offset cancels
+// in the subtraction and no adjustment is needed there.
+namespace AlRunner.Infrastructure;
+
+public static class AlSourceSpanCodec
+{
+    /// <summary>
+    /// Decodes one packed SourceSpans/SignatureSpan entry into its four 0-based
+    /// (line, column) components.
+    /// </summary>
+    public static (ushort FromLine, ushort FromColumn, ushort ToLine, ushort ToColumn) Decode(long encodedSpan)
+    {
+        ulong v = unchecked((ulong)encodedSpan);
+        var toColumn = (ushort)v;
+        var toLine = (ushort)(v >> 16);
+        var fromColumn = (ushort)(v >> 32);
+        var fromLine = (ushort)(v >> 48);
+        return (fromLine, fromColumn, toLine, toColumn);
+    }
+
+    /// <summary>
+    /// The AL stack-trace "line L" for a statement: its from-line relative to the
+    /// enclosing method's SignatureSpan from-line. Matches BC's own service-tier output
+    /// format exactly (verified against AlCallStackCapture's pre-existing behaviour,
+    /// which this replaces without changing output).
+    /// </summary>
+    public static int RelativeLine(long statementSpan, long signatureSpan)
+    {
+        var stmt = Decode(statementSpan);
+        var sig = Decode(signatureSpan);
+        return (ushort)(stmt.FromLine - sig.FromLine);
+    }
+
+    /// <summary>
+    /// The absolute, 1-based AL source line a statement span starts on — what a coverage
+    /// report or an editor gutter needs, as opposed to RelativeLine's stack-trace format.
+    /// </summary>
+    public static int AbsoluteFromLine(long statementSpan) => Decode(statementSpan).FromLine + 1;
+}

--- a/AlRunner/Infrastructure/NclCecilRewrite.cs
+++ b/AlRunner/Infrastructure/NclCecilRewrite.cs
@@ -19,7 +19,7 @@ namespace AlRunner.Infrastructure;
 
 public static class NclCecilRewrite
 {
-    private const int CACHE_VERSION = 125;
+    private const int CACHE_VERSION = 126;
 
     // ─────────────────────────────────────────────────────────────────────────
     // Cecil-owned skip registry (JmpHook→Cecil migration enabler).
@@ -68,6 +68,17 @@ public static class NclCecilRewrite
         "Microsoft.Dynamics.Nav.Runtime.NavMethodScope::ProcessException/1",
         "Microsoft.Dynamics.Nav.Runtime.ALMethodScope::AssignScopeId/0",
         "Microsoft.Dynamics.Nav.Runtime.NavMethodScope::ThrowStackOverflow/1",
+        // StmtHit/CStmtHit — --coverage hook (issue #1922). Not previously JmpHook'd
+        // (grep for StmtHit across AlRunner/ was empty before this), listed for symmetry
+        // with the rest of the NavMethodScope cluster and to guard against a future
+        // JmpHook targeting them by name. CStmtHit is the inline-expression form BC uses
+        // for if/while/repeat CONDITIONS (`if (CStmtHit(1) & (this.flag))`) — confirmed
+        // by decompiling generated C# for a scratch if/else fixture; without hooking it
+        // too, every conditional's own line would read permanently 0 regardless of
+        // whether it ran.
+        "Microsoft.Dynamics.Nav.Runtime.NavMethodScope::StmtHit/1",
+        "Microsoft.Dynamics.Nav.Runtime.NavMethodScope::CStmtHit/1",
+        "Microsoft.Dynamics.Nav.Runtime.NavMethodScope::CStmtHit/2",
         // ALFunctionTimingExecutionListener (Batch 2).
         "Microsoft.Dynamics.Nav.Runtime.ALFunctionTimingExecutionListener::EnsureRegistered/0",
         "Microsoft.Dynamics.Nav.Runtime.ALFunctionTimingExecutionListener::Start/1",
@@ -6311,6 +6322,70 @@ public static class NclCecilRewrite
                     throw new InvalidOperationException(
                         $"[Cecil] NavMethodScope.ThrowStackOverflow returns {tso.ReturnType.FullName}, expected void — Ncl shape changed; do not commit");
                 ReplaceBodyConst(tso, ConstResult.Void);
+            }
+        }
+
+        // ─────────────────────────────────────────────────────────────────────
+        // NavMethodScope.StmtHit(int) / CStmtHit(int[, bool]) — --coverage hook (issue
+        // #1922, first slice of #1640).
+        //
+        // BC's own AL compiler already instruments every AL statement with a StmtHit(N)
+        // (plain statements) or CStmtHit(N) (if/while/repeat CONDITIONS, folded into the
+        // boolean expression: `if (CStmtHit(1) & (this.flag))`) call, where N indexes the
+        // scope class's [SourceSpans] attribute. Decompiling StmtHit confirmed it does
+        // exactly two things (CStmtHit's two overloads are the same shape, returning bool
+        // so they compose into an expression):
+        //
+        //   public void StmtHit(int currentStatementNumber)
+        //   {
+        //       statementNumber = currentStatementNumber;
+        //       ExecutionListener.Instance?.ProcessStatementHit(this);
+        //   }
+        //
+        // `statementNumber` backs NavMethodScope.StatementNumber, which
+        // AlCallStackCapture reads to produce "line L" in every AL stack trace — so this
+        // rewrite MUST NOT replace or reorder that assignment. It only PREPENDS a call to
+        // AlCoverageTracker.OnStmtHit(this, currentStatementNumber) before each method's
+        // existing first instruction, leaving the rest of the body — and therefore
+        // StatementNumber tracking — completely untouched. Regression-tested by
+        // AlCallStackLineRegressionTests (stack-trace lines identical with the rewrite
+        // active, --coverage on or off).
+        //
+        // (ExecutionListener.Instance is permanently null in this runtime — its cctor and
+        // AddListener/RemoveListener are already no-op'd elsewhere in this file/BcRuntime
+        // for R2R-stability reasons predating this issue — so that line was already inert
+        // before this rewrite and stays inert after it.)
+        //
+        // PrependStaticCall (used elsewhere in this file) can't be reused here: it only
+        // forwards reference-typed arg slots (to avoid boxing), and the second argument
+        // here is `int currentStatementNumber` — a value type that must reach
+        // OnStmtHit's `int` parameter unboxed. So this block emits its own
+        // `ldarg.0; ldarg.1; call` prologue instead.
+        {
+            var nclMod = asm.MainModule;
+            const string MsType = "Microsoft.Dynamics.Nav.Runtime.NavMethodScope";
+            var hookMi = typeof(AlRunner.Infrastructure.AlCoverageTracker).GetMethod(
+                nameof(AlRunner.Infrastructure.AlCoverageTracker.OnStmtHit), BindingFlags.Public | BindingFlags.Static)
+                ?? throw new InvalidOperationException(
+                    "[Cecil] AlCoverageTracker.OnStmtHit not found — runner-side rename?");
+            var hookRef = nclMod.ImportReference(hookMi);
+
+            foreach (var (name, paramCount) in new[] { ("StmtHit", 1), ("CStmtHit", 1), ("CStmtHit", 2) })
+            {
+                var target = FindNclMethod(nclMod, MsType, name, paramCount);
+                if (target.Parameters[0].ParameterType.FullName != "System.Int32")
+                    throw new InvalidOperationException(
+                        $"[Cecil] NavMethodScope.{name}/{paramCount}'s first parameter is "
+                        + $"{target.Parameters[0].ParameterType.FullName}, expected System.Int32 — Ncl shape changed; do not commit");
+
+                var body = target.Body;
+                var il = body.GetILProcessor();
+                var first = body.Instructions[0];
+                il.InsertBefore(first, il.Create(OpCodes.Ldarg_0));
+                il.InsertBefore(first, il.Create(OpCodes.Ldarg_1));
+                il.InsertBefore(first, il.Create(OpCodes.Call, hookRef));
+                if (body.MaxStackSize < 2) body.MaxStackSize = 2;
+                Console.Error.WriteLine($"[Cecil] Prepended AlCoverageTracker.OnStmtHit to NavMethodScope.{name}/{paramCount}");
             }
         }
 

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -173,6 +173,11 @@ bool printClassification = false;
 // --output-junit PATH: additionally write a JUnit XML report — independent of --output-json.
 bool outputJson = false;
 string? outputJunitPath = null;
+// --coverage: statement-level coverage via BC's own StmtHit instrumentation (issue
+// #1922, first slice of #1640). Writes Cobertura XML to --coverage-out (default
+// cobertura.xml in the working directory) after the run, plus a console table.
+bool coverageEnabled = false;
+string coverageOutputPath = "cobertura.xml";
 var bundles = new List<string>();
 var packageCacheArgs = new List<string>();
 // Bundled mode is the canonical fast path (5-7× faster, parity-verified across
@@ -264,6 +269,13 @@ for (int i = 0; i < args.Length; i++)
     if (args[i] == "--classify") { printClassification = true; continue; }
     if (args[i] == "--output-json") { outputJson = true; continue; }
     if (args[i] == "--output-junit" && i + 1 < args.Length) { outputJunitPath = args[++i]; continue; }
+    if (args[i] == "--coverage")
+    {
+        coverageEnabled = true;
+        AlRunner.Infrastructure.AlCoverageTracker.Enabled = true;
+        continue;
+    }
+    if (args[i] == "--coverage-out" && i + 1 < args.Length) { coverageOutputPath = args[++i]; continue; }
     if (args[i] == "--package-cache" && i + 1 < args.Length) { packageCacheArgs.Add(args[++i]); continue; }
     if (args[i] == "--per-suite") { bundledMode = false; continue; }
     if (args[i] == "--bundled") { bundledMode = true; continue; }
@@ -2194,6 +2206,22 @@ if (outputJunitPath != null)
     JUnitReport.WriteJUnit(outputJunitPath, results);
     if (!outputJson) Console.WriteLine($"JUnit XML → {outputJunitPath}");
 }
+if (coverageEnabled)
+{
+    // Source map keyed by (AL object label, object id) → file path, scanned from the
+    // same bundle roots the run compiled — see AlCoverageSourceMap. relativeTo the
+    // working directory so cobertura's <source> (".") lines up with the filename
+    // attributes, matching v1's convention.
+    var coverageSourceMap = AlRunner.Infrastructure.AlCoverageSourceMap.Build(
+        bundles, relativeTo: Directory.GetCurrentDirectory());
+    var coverageStatements = AlRunner.Infrastructure.AlCoverageTracker.Collect(coverageSourceMap);
+    var coverageFiles = AlRunner.Infrastructure.AlCoverageReport.WriteCobertura(
+        coverageOutputPath, coverageStatements);
+    var coverageOut = outputJson ? Console.Error : Console.Out;
+    coverageOut.WriteLine();
+    coverageOut.WriteLine(AlRunner.Infrastructure.AlCoverageReport.FormatConsoleTable(coverageFiles));
+    coverageOut.WriteLine($"Cobertura → {coverageOutputPath}");
+}
 
 // Exit non-zero if anything failed — the default since the v2 cut, matching main/v1.
 // --no-strict-exit restores the old always-0 behaviour for JSON-only consumers.
@@ -3407,6 +3435,12 @@ static void PrintHelp(TextWriter w)
     w.WriteLine("                          classification JSON.");
     w.WriteLine("  --output-junit PATH     Write a JUnit XML report to PATH, grouped by codeunit.");
     w.WriteLine("                          Independent of --output-json — works with either mode.");
+    w.WriteLine("  --coverage              Statement-level coverage via BC's own StmtHit");
+    w.WriteLine("                          instrumentation (no rewrite of emitted AL output —");
+    w.WriteLine("                          the hook lives in Ncl.dll). Writes Cobertura XML");
+    w.WriteLine("                          (default ./cobertura.xml) plus a console table after");
+    w.WriteLine("                          the run. Off by default; --coverage-out PATH overrides");
+    w.WriteLine("                          the Cobertura output path.");
     w.WriteLine("  --failures-only, --quiet");
     w.WriteLine("                          Print only FAIL/ERROR per-test lines. Default prints both");
     w.WriteLine("                          PASS and FAIL with stack traces (matches v1).");
@@ -3512,9 +3546,6 @@ static void PrintHelp(TextWriter w)
     w.WriteLine("                          source map the compile pipeline does not currently");
     w.WriteLine("                          expose; tracked as a separate workstream. Distinct from");
     w.WriteLine("                          the JSON-RPC daemon in EXECUTION above, which IS supported.");
-    w.WriteLine("  --coverage              Cobertura coverage output. There is currently no rewrite");
-    w.WriteLine("                          pass over emitted AL output to instrument; a Cecil-based");
-    w.WriteLine("                          implementation is feasible (2-4 d) but not yet built.");
     w.WriteLine("  --stubs DIR             v1's stub-merge path. Real MS DLLs load in-process so the");
     w.WriteLine("                          original use case mostly evaporated; still possible to");
     w.WriteLine("                          add as an extra source-root merge if needed.");

--- a/docs/v1-to-v2-migration.md
+++ b/docs/v1-to-v2-migration.md
@@ -43,6 +43,7 @@ allowed and forbidden.
 | `--test-timeout SECONDS` | ✓ (built the failure message `"Test exceeded {N}s timeout."`) | ✓ | Restored in v2 (previously hardcoded to 60s with no CLI override — see #1648). Also settable via the `AL_RUNNER_TEST_TIMEOUT_SEC` env var; the CLI flag takes precedence. Failure-message text is v1-compatible (`"Test exceeded {N}s timeout."`), so external tooling matching on that text (e.g. LethAL) keeps working unchanged. |
 | `--output-json` | ✓ | ✓ | v1-shaped per-test `status: pass/fail/error` JSON to stdout, distinct from `--out`'s failure-classification JSON. `capturedValues`/`iterations` fields omitted — those need a shared Cecil-instrumentation prerequisite, tracked separately. |
 | `--output-junit PATH` | ✓ | ✓ | JUnit XML report, grouped by codeunit as `<testsuite>`. |
+| `--coverage` | ✓ (Roslyn-rewriter hit-counters) | ✓ | Different mechanism, same Cobertura XML output. v2 does not rewrite emitted AL output at all — BC's own compiler already calls `NavMethodScope.StmtHit(N)` once per AL statement; v2 Cecil-rewrites that one method in `Ncl.dll` (the runtime engine, not AL business logic) to record hits. `--coverage-out PATH` overrides the default `./cobertura.xml`. See #1922. |
 | `--dump-csharp DIR` | ✓ | ✓ | v2 dumps BC `Compilation.Emit`'s intermediate C# per AL object. |
 | `--precompile <in> --out <out>` | ✓ | ✓ | Same. |
 | `--bundled` / `--per-suite` | (n/a) | ✓ | v2's pipeline mode toggle. Default `--bundled`. |
@@ -58,7 +59,6 @@ typical "compile and run AL tests" workflow.
 | Flag / feature | Why deferred | Estimated lift |
 |---|---|---|
 | DAP debug adapter | v1's `DapServer.cs`. Needs an AL→C# source map BC's `Compilation.Emit` does not currently expose — without that, breakpoints would land on C# lines, not AL. Distinct from `--server`, the JSON-RPC daemon, which IS implemented (see below). | 1-2 wk (research-heavy) |
-| `--coverage` (cobertura XML) | v1 hooked the Roslyn rewriter to inject hit-counters. v2 has no rewrite pass on AL output. A Cecil post-pass over the emitted DLL is feasible. | 2-4 d |
 | `--stubs DIR` | v1's stub-merge path. v2 loads real MS DLLs in-process so the original use case mostly evaporates, but the "extra source roots" capability still has value for partial extensions. | <1 d |
 | Telemetry / crash reporter | v1's `TelemetryReporter.cs` phoned home to App Insights. `tools/telemetry-triage/` still exists. Needs a secret-handling decision before re-enabling. | 1 d |
 
@@ -73,7 +73,6 @@ unless a concrete user need surfaces.
 | In-tree stubs (`AlRunner/stubs/*.al`, `AlRunner/Runtime/MockX.cs`) | v1 needed stubs because the rewriter couldn't satisfy MS DLL signatures otherwise. v2 satisfies them by loading the MS DLLs as-is. |
 | Roslyn rewriter / type-rename pass | The premise — that BC types could be safely renamed — was incompatible with linking against MS R2R DLLs. v2's only rewriter is `Rewriters/CallSiteArgWrap.cs` (121 LOC, IL-byte-equivalent to BC's own emit). |
 | `docs/coverage.yaml` / `docs/coverage.md` | v1 tracked AL-language coverage in a hand-curated YAML; the orchestrator blocked merges if the YAML wasn't updated. v2's spec is the `tests/al-language/` corpus itself — every AL surface that needs coverage has a test there. Both files are archived under `docs/archive/`. |
-| `coverage-demo.yml` GitHub workflow | Demonstrated v1's `--coverage` flag. Re-enable when v2 implements coverage. |
 | .NET 9 / .NET 10 target frameworks | v1 multi-targeted; v2 targets `net8.0` only, to run on BC's own real .NET 8 runtime rather than reimplementing its runtime-dependent behavior on a newer BCL. net10's BCL drift breaks BC's `UnsafeAccessor`/precode assumptions; net9 can't satisfy BC's `System.Text.Json` 10 bind. Breaking change for any consumer targeting net9/net10 exclusively. |
 
 ## Layout change


### PR DESCRIPTION
Closes #1922

## Summary

Implements `--coverage` (first slice of #1640) using BC's own AL-compiler
instrumentation instead of a Cecil pass over emitted AL output. BC's compiler
already calls `NavMethodScope.StmtHit(N)` / `.CStmtHit(N[, bool])` once per AL
statement, where `N` indexes the scope class's `[SourceSpans]` attribute — so
the only rewrite needed is inside `Microsoft.Dynamics.Nav.Ncl.dll` (the
runtime engine, explicitly the "modify freely" layer per
`.claude/rules/precompiled-dll-respect.md`), never the emitted AL DLL.

## Step 1 investigation (blocking, done before any code)

Decompiled `NavMethodScope.StmtHit` from `Microsoft.Dynamics.Nav.Ncl.dll`:

```csharp
public void StmtHit(int currentStatementNumber)
{
    statementNumber = currentStatementNumber;
    ExecutionListener.Instance?.ProcessStatementHit(this);
}
```

It does maintain `NavMethodScope.StatementNumber` (`AlCallStackCapture` reads
this for every AL stack trace's `line L`). The Cecil rewrite therefore
**prepends** the coverage hook before `StmtHit`'s existing body instead of
replacing it — `statementNumber = currentStatementNumber;` is untouched.

I also checked whether the pre-existing `IExecutionListener`/`ExecutionListener.AddListener`
extensibility hook (which `StmtHit` already calls) could avoid a Cecil rewrite
entirely. It can't: `ExecutionListener..cctor` and its static methods are
already permanently no-op'd elsewhere in this codebase (`BcRuntime.cs`) for
R2R-stability reasons (SIGSEGV under large bundles) predating this issue, so
`ExecutionListener.Instance` is always null. Reusing it would mean undoing
that safety fix, so the Cecil rewrite on `StmtHit` (as the issue's "Proposed
first slice" specifies) is the right approach after all.

Two more things this investigation surfaced empirically (via `DUMP_CS=1`),
neither anticipated in the issue body:

- **`if`/`while`/`repeat` conditions are instrumented via `CStmtHit`, not
  `StmtHit`** — folded into the boolean expression:
  `if (CStmtHit(1) & (this.flag))`. Without hooking `CStmtHit` too, every
  conditional's own line would read permanently 0 regardless of whether it
  ran. Confirmed against a scratch `if`/`else` fixture, then fixed by hooking
  both `CStmtHit(int)` and `CStmtHit(int, bool)` the same way.
- **Table trigger scopes are nested in a class named `Record<N>`, not
  `Table<N>`** — the shared `AlCallStackCapture.ParseObjectTypeAndId` prefix
  map didn't recognize it, so every table trigger's scope resolved to `("?",
  0)` and was silently dropped from coverage (and, as a side effect, from AL
  stack-trace object attribution too). Added `"Record" → "Table"` to the
  prefix map; regression-tested against `AlRunner.Tests/Fixtures/RecordTriggerXRec`.

## Statement-index correctness

`SourceSpans` carries one extra "trailing sentinel" entry per method beyond
the highest index any `StmtHit`/`CStmtHit` call uses (observed at the
method's closing `end;`) — that entry can never register a hit no matter
what runs, so blindly reporting on every `SourceSpans` index would show one
permanently-0 fake line per method. `AlCoverageInstrumentedStatements` scans
each scope's `OnRun`/`OnRunAsync` IL for the actual `StmtHit`/`CStmtHit` call
sites (constant-load immediately followed by `call`) and only reports on
those indices.

## What's new

- `AlRunner/Infrastructure/AlSourceSpanCodec.cs` — the shared span-decoding
  helper `AlCallStackCapture.GetRelativeLine` now delegates to (single bit
  layout, one place, per the issue's explicit requirement).
- `AlRunner/Infrastructure/AlCoverageTracker.cs` — the hit-counter store, gated
  by `Enabled` (`--coverage`).
- `AlRunner/Infrastructure/AlCoverageInstrumentedStatements.cs` — the IL scan
  described above.
- `AlRunner/Infrastructure/AlCoverageSourceMap.cs` — maps AL object
  (type, id) back to its `.al` file for Cobertura's `filename`.
- `AlRunner/Infrastructure/AlCoverageReport.cs` — Cobertura XML + console table.
- `NclCecilRewrite.cs` — `CACHE_VERSION` 125→126, `StmtHit`/`CStmtHit`
  rewrite block, `CecilOwned` registry entries.
- `--coverage` / `--coverage-out PATH` CLI flags, `--help` text, `docs/v1-to-v2-migration.md`.
- `.github/workflows/coverage-demo.yml` re-enabled against the new mechanism.
- `AlRunner.Tests/Fixtures/CoverageBranch/` — new fixture: a taken branch, an
  untaken branch, and a deliberate failure for the stack-trace-line
  regression check.
- `AlRunner.Tests/CoverageTests.cs` — 6 tests (all spawn the real runner
  subprocess against the fixture above):
  - taken-branch statement reports a non-zero hit, at the exact AL source line
  - untaken-branch statement reports zero (not vacuous: the branch's own
    guarding condition on the line above it DOES report non-zero)
  - table-trigger coverage (the `Record<N>` fix) reports correctly against
    `RecordTriggerXRec`
  - `--coverage-out` alone (no `--coverage`) writes no file
  - test pass/fail counts and exit code are identical with `--coverage` on vs off
  - **AL stack-trace `line L` is byte-identical** between a `--coverage`
    run and a plain run against the same deliberately-failing test

## Not in scope (explicitly, per the issue)

`--capture-values` / `--iteration-tracking` — separate issues, same hook.

## Test plan

- [x] `dotnet build AlRunner.slnx -c Debug` — clean
- [x] `dotnet test AlRunner.Tests -c Debug --filter CoverageTests` — 6/6 pass
- [x] Full `AlRunner.Tests` suite — 704/705 pass; the one pre-existing failure
      (`BcCompilerSharedReferenceMemoTests.AddingAPackageToAScannedDir_ForcesARebuild`)
      reproduces identically on unmodified `main` (verified via `git stash`),
      unrelated to this change
- [x] Manual runs against two hand-built fixtures (a scratch `if`/`else`
      probe, and `RecordTriggerXRec`) cross-checked line-by-line against the
      actual `.al` source before writing the automated tests