### PR TITLE
fix(report): Record.GetFilter() must read the caller-applied filter in OnPreReport

### DIFF
--- a/AlRunner.Tests/NavReportSyncApplySetTableViewReflectionTests.cs
+++ b/AlRunner.Tests/NavReportSyncApplySetTableViewReflectionTests.cs
@@ -1,0 +1,94 @@
+// NavReportSyncApplySetTableViewReflectionTests — pins the C# reflection CONTRACT the
+// #1895 fix depends on, not "what BC does" (that claim is the companion corpus PR,
+// StefanMaron/BusinessCentral.AL.Language.Tests, branch
+// agent/impl-7/issue-1895-report-getfilter, which proves the AL-observable behavior
+// against real BC).
+//
+// Root cause (see AlRunner/Patches/NavReportSync.cs,
+// ApplyCallerTableViewBeforePreReport's doc comment): BC's own
+// RunReportInternalCoreAsync calls DataItemIterator.ApplySetTableViewForAllDataItems()
+// right after applying the caller's record parameter and BEFORE OnPreReport runs. The
+// runner skipped that call, so Report.SetTableView(Rec) / the record-parameter static
+// Report.Run/RunModal overload left DataItem.Record (what Record.GetFilter() reads)
+// unsynced through OnPreReport — the filter only reached it once the data-item loop's
+// own ApplyDataItemTableViewAndRequestFormFilters call ran, later.
+//
+// The fix reaches this method purely by reflection (NavReportSync.SyncRun resolves it
+// off DataItemIterator, NavReport's own base type, once and caches the MethodInfo) —
+// there is no compile-time reference, so nothing stops a future BC artifact from
+// renaming or removing it out from under the cast. What's provable here without
+// compiling and running an AL report (the corpus test does that) is that this exact
+// reflection binding — the one NavReportSync's cache actually performs — still resolves
+// against the real, loaded Ncl.dll for the BC version this binary was built against.
+// If it stops resolving, ApplyCallerTableViewBeforePreReport's `if (... == null) return;`
+// guard means the fix silently reverts to the pre-#1895 (broken) behavior instead of
+// failing loudly — so this is exactly the kind of drift that must be caught here, not
+// discovered downstream as a quietly-reintroduced #1895.
+using System.Reflection;
+using Microsoft.Dynamics.Nav.Runtime;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+// Loads Ncl types in-process (must share the serial bc-engine collection — see
+// BcEngineCollection.cs comment header).
+[Collection(BcEngineCollection.Name)]
+public class NavReportSyncApplySetTableViewReflectionTests
+{
+    private readonly BcEngineFixture _engine;
+
+    public NavReportSyncApplySetTableViewReflectionTests(BcEngineFixture engine) => _engine = engine;
+
+    private static Type NavReportType => typeof(ITreeObject).Assembly
+        .GetType("Microsoft.Dynamics.Nav.Runtime.NavReport")!;
+
+    [SkippableFact]
+    public void DataItemIterator_ApplySetTableViewForAllDataItems_StillResolvesByTheExactBindingNavReportSyncUses()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready,
+            _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        // Mirror NavReportSync.SyncRun's own walk exactly: NavReport's base type IS the
+        // DataItemIterator the real ApplySetTableViewForAllDataItems() lives on — not a
+        // type found by name search, because that is what the shipped code does.
+        var dataItemIteratorBase = NavReportType.BaseType;
+        Assert.NotNull(dataItemIteratorBase);
+
+        var applySetTableViewForAllDataItems = dataItemIteratorBase!.GetMethod(
+            "ApplySetTableViewForAllDataItems",
+            BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public,
+            null, Type.EmptyTypes, null);
+
+        Assert.NotNull(applySetTableViewForAllDataItems);
+        Assert.Equal(typeof(void), applySetTableViewForAllDataItems!.ReturnType);
+        Assert.Empty(applySetTableViewForAllDataItems.GetParameters());
+    }
+
+    [SkippableFact]
+    public void OnPreReport_StillResolvesOnNavReportItself_SoTheOrderingFixCanReachBoth()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready,
+            _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        // The fix's whole claim is an ORDERING one: ApplySetTableViewForAllDataItems must
+        // resolve off the base type reached from NavReport BEFORE OnPreReport (declared on
+        // NavReport itself) runs. Pinning that OnPreReport is still found the same way
+        // NavReportSync.SyncRun finds it (walking to the "NavReport"-named type) protects
+        // the other half of that ordering claim from silently going stale the same way.
+        Type? navReportBase = NavReportType;
+        while (navReportBase != null && navReportBase.Name != "NavReport")
+            navReportBase = navReportBase.BaseType;
+        Assert.NotNull(navReportBase);
+
+        var onPreReport = navReportBase!.GetMethod("OnPreReport",
+            BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public,
+            null, Type.EmptyTypes, null);
+        Assert.NotNull(onPreReport);
+
+        // And it must live on a DIFFERENT type than ApplySetTableViewForAllDataItems —
+        // that's what makes this an ordering bug in the first place (two separate steps on
+        // two separate levels of the hierarchy) rather than something a single virtual
+        // override could have fixed.
+        Assert.NotEqual(onPreReport!.DeclaringType, navReportBase.BaseType);
+    }
+}

--- a/AlRunner/Patches/NavReportSync.cs
+++ b/AlRunner/Patches/NavReportSync.cs
@@ -52,6 +52,7 @@ public static class NavReportSync
     private static FieldInfo? _dataItemsField;     // DataItemIterator.dataItems : List<DataItem>
     private static MethodInfo? _onPreReport;       // NavReport.OnPreReport()  (protected virtual)
     private static MethodInfo? _onPostReport;      // NavReport.OnPostReport() (protected virtual)
+    private static MethodInfo? _applySetTableViewForAllDataItems; // DataItemIterator.ApplySetTableViewForAllDataItems()
     private static MethodInfo? _onInitReport;      // NavReport.OnInitReport() (protected virtual)
     private static PropertyInfo? _objectIdProp;    // NavApplicationObjectBase.ObjectId : ApplicationObjectId
     private static PropertyInfo? _objectNumberProp;// ApplicationObjectId.ObjectNumber : int
@@ -615,6 +616,12 @@ public static class NavReportSync
             _onPostReport = navReportBase.GetMethod("OnPostReport",
                 BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public,
                 null, Type.EmptyTypes, null);
+        if (dataItemIteratorBase != null && _applySetTableViewForAllDataItems == null)
+        {
+            _applySetTableViewForAllDataItems = dataItemIteratorBase.GetMethod("ApplySetTableViewForAllDataItems",
+                BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public,
+                null, Type.EmptyTypes, null);
+        }
 
         TryRunOrControlFlow(navReport, navReportBase);
     }
@@ -627,6 +634,7 @@ public static class NavReportSync
         try
         {
             InvokeVirtual(_onInitReport, navReport);
+            ApplyCallerTableViewBeforePreReport(navReport);
             InvokeVirtual(_onPreReport, navReport);
             InvokeDataItems(navReport);
             InvokeVirtual(_onPostReport, navReport);
@@ -655,6 +663,32 @@ public static class NavReportSync
                 Console.Error.WriteLine($"[NavReportSync] SyncRun: report terminated by {ex.GetType().Name} (control-flow)");
             return true;
         }
+    }
+
+    /// <summary>
+    /// Copy the caller-applied table view (<c>Report.SetTableView(Rec)</c> on the instance,
+    /// or the record parameter of the static <c>Report.Run/RunModal(id, ..., Rec)</c>
+    /// overloads — both land the view on <c>DataItem.TableViewRecord</c> via BC's own
+    /// unmodified <c>DataItemIterator.SetTableView</c>) onto each data item's actual
+    /// <c>Record</c> — the object AL's data-item variable is bound to and
+    /// <c>GetFilter()</c>/<c>GetFilters()</c> read from.
+    ///
+    /// This is what BC's real <c>RunReportInternalCoreAsync</c> calls
+    /// (<c>ApplySetTableViewForAllDataItems()</c>) immediately after applying the record
+    /// parameter and BEFORE any trigger runs. Skipping it left <c>DataItem.Record</c>
+    /// unfiltered through <c>OnPreReport</c> — <c>SetTableView</c> itself only populates
+    /// <c>TableViewRecord</c>, a separate scratch record; the copy onto the record AL code
+    /// actually sees is a distinct step that only otherwise happens inside
+    /// <c>ExecuteDataItemLoopAsync</c>, i.e. once the data-item loop for that item starts —
+    /// too late for a report-level <c>OnPreReport</c> guard, and (since real BC also does
+    /// this same copy first) not something later code should skip either. Calling BC's own
+    /// method here — rather than re-copying filters ourselves — keeps this faithful to
+    /// whatever DataItemLink/DataItemTableView reconciliation that method does today.
+    /// </summary>
+    private static void ApplyCallerTableViewBeforePreReport(object navReport)
+    {
+        if (_applySetTableViewForAllDataItems == null) return;
+        Invoke(_applySetTableViewForAllDataItems, navReport, Array.Empty<object?>());
     }
 
     // NavControlException lives in Microsoft.Dynamics.Nav.Types and is


### PR DESCRIPTION
Closes #1895

## Root cause

BC's own `RunReportInternalCoreAsync` calls `DataItemIterator.ApplySetTableViewForAllDataItems()` right after applying the caller's record parameter and BEFORE `OnPreReport` runs. The runner skipped that call — `Report.SetTableView(Rec)` (and the record-parameter static `Report.Run/RunModal` overload) only populated `DataItem.TableViewRecord`, a scratch record; the copy onto `DataItem.Record` (what `Record.GetFilter()`/`GetFilters()` actually read) only happened later, inside `InvokeDataItems`'s own `ApplyDataItemTableViewAndRequestFormFilters` call — too late for `OnPreReport`.

**One correction to the inherited root-cause writeup this PR is a handoff of** (see #1895 discussion): I verified with an ordering probe that `OnPreDataItem` was *not* actually affected pre-fix — `ApplyDataItemTableViewAndRequestFormFilters` already runs before the data-item loop starts, so `OnPreDataItem`'s `GetFilter()` already read the applied filter correctly before this patch. Only `OnPreReport` (which runs before any data-item-level sync at all) was broken. The fix and its test still cover both triggers explicitly, so this is proven rather than assumed either way.

## Fix

`AlRunner/Patches/NavReportSync.cs`: call BC's own (unmodified) `DataItemIterator.ApplySetTableViewForAllDataItems()` right after `OnInitReport` and before `OnPreReport`, mirroring BC's own `RunReportInternalCoreAsync` sequencing — reusing real BC filtering/reconciliation logic rather than re-implementing the copy.

## Tests

- **Upstream (BC-behaviour) proof**, not part of this diff: pushed as branch `agent/impl-7/issue-1895-report-getfilter` on `StefanMaron/BusinessCentral.AL.Language.Tests` (not yet a PR — per workflow, the orchestrator opens/merges corpus PRs). Three scenarios, each asserting the concrete filter text (not just non-empty) in both `OnPreReport` and `OnPreDataItem` independently, plus a no-filter-applied control:
  - `Report_InstanceSetTableView_GetFilter_ReadsAppliedFilter_InOnPreReportAndOnPreDataItem`
  - `Report_StaticRunModalRecordParam_GetFilter_ReadsAppliedFilter_InOnPreReportAndOnPreDataItem`
  - `Report_NoFilterApplied_GetFilter_ReadsEmpty_InOnPreReportAndOnPreDataItem`

  Verified RED (all assertions on `OnPreReport` fail with `got ""` pre-patch) → GREEN locally against my own corpus branch, via `--package-cache` pointed at the checked-out branch (not the pinned submodule). Full corpus (2081 tests, that branch's HEAD) still green with the fix applied — no regressions.

- **Runner-side mechanism test** (this diff, `AlRunner.Tests/NavReportSyncApplySetTableViewReflectionTests.cs`): pins the reflection binding contract the fix depends on — `DataItemIterator.ApplySetTableViewForAllDataItems()` still resolves off `NavReport`'s base type by the exact lookup `NavReportSync.SyncRun` performs, and `OnPreReport` still resolves on a *different* type (the reason this was an ordering bug rather than something a single override could fix). Verified passing (non-skipped) against the real in-process BC engine locally, mirroring the CI `BcEngineCollection` setup.

No submodule pin bump in this PR — the corpus test lives only on the pushed upstream branch for now.