### PR TITLE
fix(page): RunModal on a page with an Enum-typed page-global control

### DIFF
--- a/AlRunner.Tests/AlRunner.Tests.csproj
+++ b/AlRunner.Tests/AlRunner.Tests.csproj
@@ -100,6 +100,14 @@
       <HintPath>$(ServiceTierPath)/Microsoft.Dynamics.Nav.Ncl.dll</HintPath>
       <Private>true</Private>
     </Reference>
+    <!-- Needed for PageEnumFieldMetadataPatchesTests.cs (issue #1896) to construct real
+         Microsoft.Dynamics.Nav.Types.Metadata.MetaPageDefinition/PageDefinition/
+         MetaDataFieldDefinition/DataFieldDefinition objects directly, matching AlRunner.csproj's
+         own reference to the same DLL. -->
+    <Reference Include="Microsoft.Dynamics.Nav.Types">
+      <HintPath>$(ServiceTierPath)/Microsoft.Dynamics.Nav.Types.dll</HintPath>
+      <Private>true</Private>
+    </Reference>
   </ItemGroup>
 
 </Project>

--- a/AlRunner.Tests/PageEnumFieldMetadataPatchesTests.cs
+++ b/AlRunner.Tests/PageEnumFieldMetadataPatchesTests.cs
@@ -1,0 +1,153 @@
+// PageEnumFieldMetadataPatchesTests — issue #1896 (Page.RunModal() on a page with a
+// page-global control bound to an Enum-typed variable threw NavALException at form
+// materialisation because NCLMetaForm.ApplyAppGroupAwareEnumMetadataToPageExpressions calls
+// NCLMetadata.TryGetMetaApplicationObject(ObjectType.Enum, ...), which the runner never
+// populated for Enum objects).
+//
+// This is a RUNNER-MECHANISM test: it pins the Cecil-rewritten replacement bodies
+// (BcRuntime.NCLMetaForm_ApplyEnumMetadataToMetaPageExpressions /
+// NCLMetaForm_ApplyEnumMetadataToPageExpressions, AlRunner/Patches/PageEnumFieldMetadataPatches.cs)
+// directly against AlEnumMetadataRegistry, without needing the BC engine or a real page —
+// exactly the boundary the Cecil rewrite crosses (real BC's own MetaPageDefinition/
+// PageDefinition/MetaDataFieldDefinition/DataFieldDefinition types are still real BC types;
+// only the enum-metadata LOOKUP source changed). The BEHAVIOURAL claim ("Page.RunModal on a
+// page with an Enum-typed page-global control works, and the control's real value round-trips")
+// is proven upstream against a live BC service tier — see
+// StefanMaron/BusinessCentral.AL.Language.Tests handlers/TestPageEnumVariableControl_*.al, per
+// docs/rules/bc-behavior-tests-go-upstream.md — and locally end-to-end in
+// tests/runner-extras/page-enum-control-modal. This test exists so a regression in OUR OWN
+// lookup-substitution logic fails loudly here, in milliseconds.
+using System.Collections.Generic;
+using System.Linq;
+using AlRunner;
+using Microsoft.Dynamics.Nav.Types;
+using Microsoft.Dynamics.Nav.Types.Metadata;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class PageEnumFieldMetadataPatchesTests : IDisposable
+{
+    public PageEnumFieldMetadataPatchesTests()
+    {
+        AlEnumMetadataRegistry.Clear();
+    }
+
+    public void Dispose()
+    {
+        AlEnumMetadataRegistry.Clear();
+    }
+
+    private const int EnumId = 90340;
+
+    private static void RegisterTestEnum()
+    {
+        AlEnumMetadataRegistry.Register(
+            EnumId, "PemTest Kind",
+            options: new[] { "Field", "Block", "Image" },
+            indexes: new[] { 0, 1, 2 },
+            captions: new string?[] { "Fields", "Blocks", "Images" });
+    }
+
+    // Positive: MetaPageDefinition overload (the frozen/cached path NavForm.GetMasterPage
+    // reaches) computes OptionString/OptionCaption/OptionValues from the registry, in BC's own
+    // comma-joined shape — the exact three strings NCLMetaForm.ApplyAppGroupAwareEnumMetadataToPageExpressions's
+    // real (unmodified) body would have produced from a genuine NCLEnumMetadata.
+    [Fact]
+    public void MetaPageDefinitionOverload_EnumField_ComputesOptionStringCaptionAndValuesFromRegistry()
+    {
+        RegisterTestEnum();
+
+        var page = new MetaPageDefinition(expressions: new List<MetaDataFieldDefinition>
+        {
+            new MetaDataFieldDefinition(name: "Combi", enumId: EnumId),
+        });
+
+        var result = BcRuntime.NCLMetaForm_ApplyEnumMetadataToMetaPageExpressions(page);
+
+        var expr = Assert.Single(result.Expressions);
+        Assert.Equal("Field,Block,Image", expr.OptionString);
+        Assert.Equal("Fields,Blocks,Images", expr.OptionCaption);
+        Assert.Equal("0,1,2", expr.OptionValues);
+    }
+
+    // Positive: a field with NO enum id (EnumIdSpecified = false) passes through completely
+    // untouched — proves the fix is selective, not a blanket rewrite of every field. If the
+    // implementation always ran ResolveEnumOptionStrings regardless of EnumIdSpecified, this
+    // would throw (no enum registered for a field that declares none).
+    [Fact]
+    public void MetaPageDefinitionOverload_NonEnumField_PassesThroughUnchanged()
+    {
+        var plainField = new MetaDataFieldDefinition(name: "PlainText");
+        var page = new MetaPageDefinition(expressions: new List<MetaDataFieldDefinition> { plainField });
+
+        var result = BcRuntime.NCLMetaForm_ApplyEnumMetadataToMetaPageExpressions(page);
+
+        // No enum-typed expressions found -> real BC's body (and this rewrite) returns the
+        // SAME instance, not a rebuilt clone.
+        Assert.Same(page, result);
+        Assert.False(result.Expressions.Single().EnumIdSpecified);
+    }
+
+    // Positive: PageDefinition overload (the mutable/thawed sibling) mutates the
+    // DataFieldDefinition in place, matching real BC's body shape, with the same data.
+    [Fact]
+    public void PageDefinitionOverload_EnumField_MutatesOptionStringCaptionAndValuesInPlace()
+    {
+        RegisterTestEnum();
+
+        var field = new DataFieldDefinition(name: "Combi", enumId: EnumId);
+        var page = new PageDefinition(expressions: new List<DataFieldDefinition> { field });
+
+        var result = BcRuntime.NCLMetaForm_ApplyEnumMetadataToPageExpressions(page);
+
+        Assert.Same(page, result);
+        Assert.Equal("Field,Block,Image", field.OptionString);
+        Assert.Equal("Fields,Blocks,Images", field.OptionCaption);
+        Assert.Equal("0,1,2", field.OptionValues);
+    }
+
+    // Negative — the load-bearing claim: a GENUINELY unknown enum id (never registered — not
+    // source-compiled, not in a loaded dependency) must still fail LOUDLY with BC's own
+    // NavMetadataNotFoundException naming the exact object type and id, not silently resolve to
+    // an empty/default OptionString. A fix that swallowed the miss (e.g. defaulting to "") would
+    // pass every test above and hide the same bug in reverse.
+    [Fact]
+    public void MetaPageDefinitionOverload_UnregisteredEnumId_ThrowsNavMetadataNotFoundException()
+    {
+        const int unregisteredId = 90341;
+        Assert.False(AlEnumMetadataRegistry.TryGet(unregisteredId, out _),
+            "test setup invariant: this id must not be registered");
+
+        var page = new MetaPageDefinition(expressions: new List<MetaDataFieldDefinition>
+        {
+            new MetaDataFieldDefinition(name: "Combi", enumId: unregisteredId),
+        });
+
+        var ex = Assert.Throws<NavMetadataNotFoundException>(
+            () => BcRuntime.NCLMetaForm_ApplyEnumMetadataToMetaPageExpressions(page));
+
+        Assert.Equal(ObjectType.Enum, ex.ObjectType);
+        Assert.Equal(unregisteredId, ex.ObjectId);
+    }
+
+    // Negative, PageDefinition overload — same claim, other overload.
+    [Fact]
+    public void PageDefinitionOverload_UnregisteredEnumId_ThrowsNavMetadataNotFoundException()
+    {
+        const int unregisteredId = 90342;
+        Assert.False(AlEnumMetadataRegistry.TryGet(unregisteredId, out _),
+            "test setup invariant: this id must not be registered");
+
+        var page = new PageDefinition(expressions: new List<DataFieldDefinition>
+        {
+            new DataFieldDefinition(name: "Combi", enumId: unregisteredId),
+        });
+
+        var ex = Assert.Throws<NavMetadataNotFoundException>(
+            () => BcRuntime.NCLMetaForm_ApplyEnumMetadataToPageExpressions(page));
+
+        Assert.Equal(ObjectType.Enum, ex.ObjectType);
+        Assert.Equal(unregisteredId, ex.ObjectId);
+    }
+}

--- a/AlRunner/Infrastructure/NclCecilRewrite.cs
+++ b/AlRunner/Infrastructure/NclCecilRewrite.cs
@@ -19,7 +19,7 @@ namespace AlRunner.Infrastructure;
 
 public static class NclCecilRewrite
 {
-    private const int CACHE_VERSION = 126;
+    private const int CACHE_VERSION = 127;
 
     // ─────────────────────────────────────────────────────────────────────────
     // Cecil-owned skip registry (JmpHook→Cecil migration enabler).
@@ -105,6 +105,13 @@ public static class NclCecilRewrite
         // of NavFormHandle.CreateTarget (the AL-variable path, which already had its own
         // construction) and NRE on the null ApplicationObjectConstructor delegate.
         "Microsoft.Dynamics.Nav.Runtime.NCLMetaForm::CreateObjectInstance/1",
+        // NCLMetaForm.ApplyAppGroupAwareEnumMetadataToPageExpressions — #1896. Real BC
+        // resolves each Enum-typed page control's OptionString/OptionCaption/OptionValues via
+        // NCLMetadata.TryGetMetaApplicationObject(ObjectType.Enum, ...), which the runner
+        // never populates (AL enums are served through the separate NCLEnumMetadata.Create(int)
+        // hook, a different codepath page materialisation never calls). Both overloads
+        // (MetaPageDefinition and PageDefinition) share this Name+paramCount key.
+        "Microsoft.Dynamics.Nav.Runtime.NCLMetaForm::ApplyAppGroupAwareEnumMetadataToPageExpressions/1",
         // ALSystemOperatingSystem.get_ALGuiAllowed — AL's GuiAllowed(). True, because the
         // runner registers a client callback and dispatches UI to test handlers.
         "Microsoft.Dynamics.Nav.Runtime.ALSystemOperatingSystem::get_ALGuiAllowed/0",
@@ -1436,6 +1443,67 @@ public static class NclCecilRewrite
 
             ReplaceBodyWithHelper(asm.MainModule, fCreate, fHelper);
             Console.Error.WriteLine("[Cecil] Rewrote NCLMetaForm.CreateObjectInstance(NavRecord) → BcRuntime.NCLMetaForm_CreateObjectInstance");
+        }
+
+        // 8b3. NCLMetaForm.ApplyAppGroupAwareEnumMetadataToPageExpressions — #1896. Real BC
+        //      resolves each Enum-typed page control's OptionString/OptionCaption/OptionValues
+        //      through NCLMetadata.TryGetMetaApplicationObject(ObjectType.Enum, ...), which the
+        //      runner never populates for Enum objects (see PageEnumFieldMetadataPatches.cs for
+        //      the full root-cause writeup). Two overloads share the name — MetaPageDefinition
+        //      (the frozen/cached path NavForm.GetMasterPage reaches) and PageDefinition (the
+        //      thawed/mutable sibling) — both rewritten here.
+        {
+            var metaFormType2 = asm.MainModule.Types
+                .FirstOrDefault(t => t.FullName == "Microsoft.Dynamics.Nav.Runtime.NCLMetaForm")
+                ?? throw new InvalidOperationException(
+                    "[Cecil] NCLMetaForm type not found — Ncl shape changed; do not commit");
+
+            var enumMetaCandidates = metaFormType2.Methods
+                .Where(m => m.Name == "ApplyAppGroupAwareEnumMetadataToPageExpressions" && m.HasBody
+                    && m.Parameters.Count == 1)
+                .ToList();
+            if (enumMetaCandidates.Count != 2)
+                throw new InvalidOperationException(
+                    $"[Cecil] NCLMetaForm.ApplyAppGroupAwareEnumMetadataToPageExpressions: expected "
+                    + $"exactly 2 overloads (MetaPageDefinition, PageDefinition), found "
+                    + $"{enumMetaCandidates.Count} — Ncl shape changed; do not commit");
+
+            var metaOverload = enumMetaCandidates.FirstOrDefault(m =>
+                m.Parameters[0].ParameterType.FullName == "Microsoft.Dynamics.Nav.Types.Metadata.MetaPageDefinition")
+                ?? throw new InvalidOperationException(
+                    "[Cecil] NCLMetaForm.ApplyAppGroupAwareEnumMetadataToPageExpressions(MetaPageDefinition) "
+                    + "not found — Ncl shape changed; do not commit");
+            var pageOverload = enumMetaCandidates.FirstOrDefault(m =>
+                m.Parameters[0].ParameterType.FullName == "Microsoft.Dynamics.Nav.Types.Metadata.PageDefinition")
+                ?? throw new InvalidOperationException(
+                    "[Cecil] NCLMetaForm.ApplyAppGroupAwareEnumMetadataToPageExpressions(PageDefinition) "
+                    + "not found — Ncl shape changed; do not commit");
+
+            var metaHelper = typeof(AlRunner.BcRuntime).GetMethod(
+                nameof(AlRunner.BcRuntime.NCLMetaForm_ApplyEnumMetadataToMetaPageExpressions),
+                BindingFlags.Public | BindingFlags.Static)
+                ?? throw new InvalidOperationException(
+                    "[Cecil] BcRuntime.NCLMetaForm_ApplyEnumMetadataToMetaPageExpressions not found");
+            var pageHelper = typeof(AlRunner.BcRuntime).GetMethod(
+                nameof(AlRunner.BcRuntime.NCLMetaForm_ApplyEnumMetadataToPageExpressions),
+                BindingFlags.Public | BindingFlags.Static)
+                ?? throw new InvalidOperationException(
+                    "[Cecil] BcRuntime.NCLMetaForm_ApplyEnumMetadataToPageExpressions not found");
+
+            if (metaOverload.ReturnType.FullName != NormalizeTypeName(metaHelper.ReturnType.FullName ?? ""))
+                throw new InvalidOperationException(
+                    "[Cecil] NCLMetaForm.ApplyAppGroupAwareEnumMetadataToPageExpressions(MetaPageDefinition)"
+                    + "/helper return type mismatch — do not commit");
+            if (pageOverload.ReturnType.FullName != NormalizeTypeName(pageHelper.ReturnType.FullName ?? ""))
+                throw new InvalidOperationException(
+                    "[Cecil] NCLMetaForm.ApplyAppGroupAwareEnumMetadataToPageExpressions(PageDefinition)"
+                    + "/helper return type mismatch — do not commit");
+
+            ReplaceBodyWithHelper(asm.MainModule, metaOverload, metaHelper);
+            ReplaceBodyWithHelper(asm.MainModule, pageOverload, pageHelper);
+            Console.Error.WriteLine(
+                "[Cecil] Rewrote NCLMetaForm.ApplyAppGroupAwareEnumMetadataToPageExpressions"
+                + "(MetaPageDefinition|PageDefinition) → BcRuntime.NCLMetaForm_ApplyEnumMetadataTo*Expressions");
         }
 
         // 8c. ALSystemOperatingSystem.get_ALGuiAllowed → true. This is AL's GuiAllowed().

--- a/AlRunner/Patches/PageEnumFieldMetadataPatches.cs
+++ b/AlRunner/Patches/PageEnumFieldMetadataPatches.cs
@@ -1,0 +1,161 @@
+// PageEnumFieldMetadataPatches — NCLMetaForm.ApplyAppGroupAwareEnumMetadataToPageExpressions
+// (both overloads), the step real BC runs while materialising a page's control tree that
+// stamps each Enum-typed field's OptionString/OptionCaption/OptionValues from the enum's own
+// metadata.
+//
+// Issue #1896: a page with a global control bound to an Enum-typed variable
+// (`field(Combi; CombiVar)` where `CombiVar: Enum "Repro Combi"`) throws
+//
+//   NavALException: You tried to invoke the Enum object with the ID 60040 from the object
+//   Repro Enum Modal Test. An object with that ID does not exist in the current application
+//   compiled with emit version 28014.
+//
+// on Page.RunModal() — even though the SAME page variable's procedures already work fine
+// without materialising the form (the enum is compiled and reachable; only form
+// materialisation fails), and even though the exception NAMES THE CALLING TEST CODEUNIT
+// rather than the page. That misattribution is a genuine clue, not noise (see below) — it is
+// how NavALException reports metadata failures with no page-scoped NavMethodScope on the
+// stack yet.
+//
+// Root cause (verified via ilspycmd decompile of Ncl.dll + a full C# stack trace captured
+// with AL_RUNNER_DIAG_FIRSTCHANCE=MetadataNotFound):
+//
+//   NavFormHandle.RunModalAsync(record, fieldNo)
+//    -> NavForm.RunModalAsync(record, fieldNo)
+//     -> NavTestExecution.FindPageType(form) -> NavForm.get_MasterPage()
+//      -> NavForm.EnsureMetadataLoaded() -> ApplicationObjectRootScope.AddApplicationObjectRootScope(this, ...)
+//       -> NavForm.GetMasterPage() -> MetadataProvider.GetMasterPage(...) -> ...GetMergedMasterPage
+//        -> MetadataProvider.GetPageDefinition -> NCLMetaForm.GetFrozenPageDefinitionWithExtensionWithoutMergedMultiLanguage()
+//         -> NCLMetaForm.ApplyAppGroupAwareEnumMetadataToPageExpressions(MetaPageDefinition)
+//
+// This ENTIRE chain runs synchronously, still inside the CALLING codeunit's own
+// NavMethodScope — NavForm.RunModalAsync does not push a page-scoped NavMethodScope until
+// AFTER metadata is loaded. So when ApplyAppGroupAwareEnumMetadataToPageExpressions's real
+// (unmodified) body does:
+//
+//   if (!NavGlobal.NCLMetadata.TryGetMetaApplicationObject(ObjectType.Enum, enumId, out var meta, requireCompiled: false))
+//       throw new NavMetadataNotFoundException(ObjectType.Enum, enumId);
+//
+// the NavMetadataNotFoundException that results is caught by NavMethodScope.Run() —
+// specifically the CALLING codeunit's scope, because no page-scoped NavMethodScope exists
+// yet — and remapped to NavALException with the object name read from the CURRENT scope
+// (RemapToALExceptionAndThrow: `text2 = ApplicationObject.ObjectName` when
+// `ParentScope?.ApplicationObject` is null). That IS the test codeunit's name. The
+// misattribution is therefore a correct symptom of "this failed before the page's own scope
+// existed", exactly matching what materialisation-time-only failure implies.
+//
+// The actual gap: NCLMetadata.TryGetMetaApplicationObject(ObjectType.Enum, ...) can NEVER
+// succeed on the runner. Every other object type the runner constructs (Table, Page, Report,
+// Query, XmlPort) is registered into NCLMetadata's real cache dictionary by
+// RecordPatches.NclMetadataCachePopulator (see NCLMetadata_GetMetaApplicationObjectByType) —
+// but Enum objects never were; AL enums are served entirely through the
+// NCLEnumMetadata.Create(int) hook (EnumMetadataPatches.cs), a DIFFERENT codepath that
+// NavForm's page-materialisation step never calls. Same class of bug as #1926's
+// CallMetaTableCtor finding: a metadata object the runner builds that never gets its
+// object/enum inventory populated, so a by-id lookup at a DIFFERENT consumption point finds
+// nothing.
+//
+// Fix: rather than growing NCLMetadata's real per-app-group NCLMetaEnum/NCLEnumMetadata
+// object graph (which would need a genuine MultiLanguage-backed caption-resolution pipeline —
+// itself dependent on tenant/session infrastructure the skeleton runtime does not have, the
+// same reason NCLEnumMetadata.Create(int) was hooked away in the first place), Cecil-rewrite
+// ApplyAppGroupAwareEnumMetadataToPageExpressions directly: reuse AlEnumMetadataRegistry (the
+// SAME emit-captured (name, options[], indexes[], captions[]) data already used, and already
+// accepted as faithful, for Enum::"X".Ordinals()/.Names()/Format() via
+// NCLEnumMetadata_CreateByIdAlAware) to compute the OptionString/OptionCaption/OptionValues
+// strings directly, in the exact comma-joined shape real BC's NCLEnumMetadata produces (see
+// the decompiled body this mirrors). A genuinely unknown enum id (never compiled, never a
+// loaded dependency) still throws the SAME NavMetadataNotFoundException real BC would throw —
+// this is a substitution for the lookup's data source, not a "never fail" shortcut.
+//
+// Allowed surface per .claude/rules/precompiled-dll-respect.md: NCLMetaForm lives in Ncl.dll
+// (runtime engine), not an AL-business-logic DLL.
+using System.Globalization;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using Microsoft.Dynamics.Nav.Types;
+using Microsoft.Dynamics.Nav.Types.Metadata;
+
+namespace AlRunner;
+
+public static partial class BcRuntime
+{
+    /// <summary>
+    /// Replacement for <c>NCLMetaForm.ApplyAppGroupAwareEnumMetadataToPageExpressions(MetaPageDefinition)</c>.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static MetaPageDefinition NCLMetaForm_ApplyEnumMetadataToMetaPageExpressions(MetaPageDefinition pageDefinition)
+    {
+        if (pageDefinition == null) return pageDefinition!;
+
+        bool any = false;
+        var result = new System.Collections.Generic.List<MetaDataFieldDefinition>(pageDefinition.Expressions.Count);
+        foreach (var expr in pageDefinition.Expressions)
+        {
+            if (expr.EnumIdSpecified)
+            {
+                any = true;
+                var (optionString, optionCaption, optionValues) = ResolveEnumOptionStrings(expr.EnumId);
+                result.Add(expr.With(
+                    optionString: optionString,
+                    optionCaption: optionCaption,
+                    optionValues: optionValues));
+            }
+            else
+            {
+                result.Add(expr);
+            }
+        }
+
+        return any ? pageDefinition.WithExpressions(result) : pageDefinition;
+    }
+
+    /// <summary>
+    /// Replacement for <c>NCLMetaForm.ApplyAppGroupAwareEnumMetadataToPageExpressions(PageDefinition)</c>
+    /// — the mutable (thawed) sibling of the frozen overload above. <c>DataFieldDefinition</c>
+    /// has plain settable properties (unlike the immutable <c>MetaDataFieldDefinition</c>'s
+    /// <c>With</c> builder), matching the real body's in-place mutation.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static PageDefinition NCLMetaForm_ApplyEnumMetadataToPageExpressions(PageDefinition pageDefinition)
+    {
+        if (pageDefinition == null) return pageDefinition!;
+
+        foreach (var expr in pageDefinition.Expressions)
+        {
+            if (!expr.EnumIdSpecified) continue;
+            var (optionString, optionCaption, optionValues) = ResolveEnumOptionStrings(expr.EnumId);
+            expr.OptionString = optionString;
+            expr.OptionCaption = optionCaption;
+            expr.OptionValues = optionValues;
+        }
+
+        return pageDefinition;
+    }
+
+    /// <summary>
+    /// (OptionString, OptionCaption, OptionValues) for enum <paramref name="enumId"/>, in the
+    /// same comma-joined shape real BC's <c>NCLEnumMetadata</c> produces (see
+    /// <c>ApplyAppGroupAwareEnumMetadataToPageExpressions</c>'s decompiled body:
+    /// <c>string.Join(",", nCLEnumMetadata.OrdinalValues...)</c> etc.) — sourced from
+    /// <see cref="AlEnumMetadataRegistry"/>, the SAME emit-captured data already used (and
+    /// already accepted as faithful) for <c>Enum::"X".Ordinals()/.Names()</c> via
+    /// <see cref="NCLEnumMetadata_CreateByIdAlAware"/>.
+    ///
+    /// Throws the SAME <c>NavMetadataNotFoundException</c> real BC's own body throws for an
+    /// enum id with no registered metadata — a genuinely-unknown enum id must still fail
+    /// loudly, not silently resolve to something.
+    /// </summary>
+    private static (string OptionString, string OptionCaption, string OptionValues) ResolveEnumOptionStrings(int enumId)
+    {
+        if (!AlEnumMetadataRegistry.TryGet(enumId, out var entry))
+            throw new NavMetadataNotFoundException(ObjectType.Enum, enumId);
+
+        var optionString = string.Join(",", entry.Options.Select(o => o ?? string.Empty));
+        var optionCaption = string.Join(",", entry.Options.Select((o, i) =>
+            (entry.Captions != null && i < entry.Captions.Length ? entry.Captions[i] : null) ?? o ?? string.Empty));
+        var optionValues = string.Join(",", entry.Indexes.Select(v => v.ToString(CultureInfo.InvariantCulture)));
+
+        return (optionString, optionCaption, optionValues);
+    }
+}

--- a/tests/expectations/count-baseline/test-count-baseline.json
+++ b/tests/expectations/count-baseline/test-count-baseline.json
@@ -7,12 +7,12 @@
     },
     "runner-extras": {
       "tests": {
-        "default": 128,
-        "byBcVersion": { "27.0": 122, "27.3": 122, "27.5": 122 }
+        "default": 131,
+        "byBcVersion": { "27.0": 125, "27.3": 125, "27.5": 125 }
       },
       "appGroups": {
-        "default": 26,
-        "byBcVersion": { "27.0": 24, "27.3": 24, "27.5": 24 }
+        "default": 27,
+        "byBcVersion": { "27.0": 25, "27.3": 25, "27.5": 25 }
       }
     }
   }

--- a/tests/runner-extras/page-enum-control-modal/PecmKind.Enum.al
+++ b/tests/runner-extras/page-enum-control-modal/PecmKind.Enum.al
@@ -1,0 +1,8 @@
+enum 64511 "Pecm Kind"
+{
+    Extensible = false;
+
+    value(0; Field) { Caption = 'Fields'; }
+    value(1; Block) { Caption = 'Blocks'; }
+    value(2; Image) { Caption = 'Images'; }
+}

--- a/tests/runner-extras/page-enum-control-modal/PecmModal.Page.al
+++ b/tests/runner-extras/page-enum-control-modal/PecmModal.Page.al
@@ -1,0 +1,44 @@
+page 64512 "Pecm Modal"
+{
+    // Issue #1896: a page-global control bound to an Enum-typed variable must not block
+    // RunModal's form materialisation.
+    PageType = List;
+    SourceTable = "Pecm Row";
+    ApplicationArea = All;
+    UsageCategory = None;
+
+    layout
+    {
+        area(Content)
+        {
+            field(KindSelector; SelectedKind)
+            {
+                ApplicationArea = All;
+                Caption = 'Kind';
+
+                trigger OnValidate()
+                var
+                    Echo: Record "Pecm Row";
+                begin
+                    if not Echo.Get('KIND') then begin
+                        Echo.Init();
+                        Echo."No." := 'KIND';
+                        Echo.Insert();
+                    end;
+                end;
+            }
+            repeater(Rows)
+            {
+                field("No."; Rec."No.") { ApplicationArea = All; }
+            }
+        }
+    }
+
+    procedure GetSelectedKindOrdinal(): Integer
+    begin
+        exit(SelectedKind.AsInteger());
+    end;
+
+    var
+        SelectedKind: Enum "Pecm Kind";
+}

--- a/tests/runner-extras/page-enum-control-modal/PecmRow.Table.al
+++ b/tests/runner-extras/page-enum-control-modal/PecmRow.Table.al
@@ -1,0 +1,14 @@
+table 64510 "Pecm Row"
+{
+    DataClassification = CustomerContent;
+
+    fields
+    {
+        field(1; "No."; Code[20]) { }
+    }
+
+    keys
+    {
+        key(PK; "No.") { Clustered = true; }
+    }
+}

--- a/tests/runner-extras/page-enum-control-modal/PecmTests.Codeunit.al
+++ b/tests/runner-extras/page-enum-control-modal/PecmTests.Codeunit.al
@@ -1,0 +1,87 @@
+codeunit 64513 "Pecm Tests"
+{
+    // Regression for issue #1896: Page.RunModal() on a page whose layout binds a control to a
+    // page-GLOBAL variable of type Enum threw
+    //
+    //   NavALException: You tried to invoke the Enum object with the ID <id> from the object
+    //   <the CALLING codeunit's own name>. An object with that ID does not exist in the
+    //   current application compiled with emit version <N>.
+    //
+    // at form materialisation — NCLMetaForm.ApplyAppGroupAwareEnumMetadataToPageExpressions
+    // calls NCLMetadata.TryGetMetaApplicationObject(ObjectType.Enum, ...), which the runner
+    // never populated for Enum objects (AL enums were only ever served through the SEPARATE
+    // NCLEnumMetadata.Create(int) hook, a codepath page materialisation never reaches). See
+    // AlRunner/Patches/PageEnumFieldMetadataPatches.cs for the full root-cause writeup.
+    //
+    // The "from the object <test codeunit>" misattribution in the original error is a genuine
+    // clue, not noise: no page-scoped NavMethodScope exists yet at the point the lookup fails
+    // (NavForm.RunModalAsync loads metadata BEFORE pushing one), so NavMethodScope.Run()'s
+    // remap reports the CALLING scope's own object name.
+    Subtype = Test;
+
+    local procedure Initialize()
+    var
+        Row: Record "Pecm Row";
+    begin
+        Row.DeleteAll();
+    end;
+
+    // Positive: RunModal materialises the page at all (before the fix, this line alone threw),
+    // the [ModalPageHandler] runs, and the handler's SetValue reaches the page's own OnValidate
+    // trigger — proof the enum-bound control is a live, functioning part of the page, not just
+    // a construction that happens to not crash.
+    [Test]
+    [HandlerFunctions('KindHandler')]
+    procedure RunModal_EnumGlobalControl_HandlerSetsValueAndOnValidateSeesIt()
+    var
+        Echo: Record "Pecm Row";
+        Modal: Page "Pecm Modal";
+    begin
+        Initialize();
+
+        Modal.RunModal();
+
+        if not Echo.Get('KIND') then
+            Error('the [ModalPageHandler] must have run and OnValidate must have fired');
+    end;
+
+    // Positive, concrete value: after RunModal returns, the page variable itself holds the
+    // SPECIFIC member the handler chose (Block, ordinal 1) — not the field's zero default, and
+    // not some other member. A fix that made materialisation "succeed" by falling back to a
+    // blank/default enum value would pass the test above (Echo row still gets written) but
+    // fail this one.
+    [Test]
+    [HandlerFunctions('KindHandler')]
+    procedure RunModal_EnumGlobalControl_ProcedureReadsBackTheHandlerChosenValue()
+    var
+        Modal: Page "Pecm Modal";
+    begin
+        Initialize();
+
+        Modal.RunModal();
+
+        if Modal.GetSelectedKindOrdinal() <> 1 then
+            Error('the page variable must hold the handler-set member (Block = 1), got %1 — expected the real value, not the default (Field = 0)', Modal.GetSelectedKindOrdinal());
+    end;
+
+    // Control: WITHOUT RunModal, the same page variable's procedure still works and reads the
+    // declared default. This is the exact split the original report described — the enum
+    // itself is always compiled and reachable; only FORM MATERIALISATION could regress.
+    [Test]
+    procedure GetSelectedKindOrdinal_WithoutRunModal_ReadsTheDeclaredDefault()
+    var
+        Modal: Page "Pecm Modal";
+    begin
+        Initialize();
+
+        if Modal.GetSelectedKindOrdinal() <> 0 then
+            Error('without RunModal the page variable never left its declared default (Field = 0), got %1', Modal.GetSelectedKindOrdinal());
+    end;
+
+    [ModalPageHandler]
+    procedure KindHandler(var Modal: TestPage "Pecm Modal")
+    begin
+        Modal.KindSelector.SetValue('Block');
+        Modal.OK().Invoke();
+    end;
+}

--- a/tests/runner-extras/page-enum-control-modal/app.json
+++ b/tests/runner-extras/page-enum-control-modal/app.json
@@ -1,0 +1,19 @@
+{
+  "id": "9ab65fe4-bb26-4c49-99f9-bb16bde9bb77",
+  "name": "Runner Extras - Page Enum Control Modal",
+  "publisher": "AL Runner",
+  "version": "1.0.0.0",
+  "brief": "Regression for issue #1896: Page.RunModal() on a page with a page-global control bound to an Enum-typed variable throws NavALException (\"You tried to invoke the Enum object with the ID N ... does not exist in the current application\") at form materialisation.",
+  "description": "The general BC-language contract this exercises — a page with a page-global Enum-typed variable control can be RunModal'd, its [ModalPageHandler] runs, and the control's real value round-trips — is a plain BC-behaviour claim and belongs upstream in the al-language corpus (see the runner repo's bc-behavior-tests-go-upstream.md); a corpus test/PR (tests/al-language/tests/al-language/handlers/TestPageEnumVariableControl_*.al) was prepared alongside this fix. This suite is the runner-repo-local stopgap: it pins the runner-INTERNAL defect directly (NCLMetaForm.ApplyAppGroupAwareEnumMetadataToPageExpressions calling NCLMetadata.TryGetMetaApplicationObject(ObjectType.Enum, ...), which the runner never populates for Enum objects — see AlRunner/Patches/PageEnumFieldMetadataPatches.cs), so this repo's own CI gates the fix now, without waiting on the corpus PR to merge and the submodule pin to bump. Once that upstream test lands and the pin moves, this suite's claim is fully covered there too and it may be retired.",
+  "dependencies": [],
+  "idRanges": [
+    {
+      "from": 64510,
+      "to": 64519
+    }
+  ],
+  "platform": "1.0.0.0",
+  "application": "27.0.0.0",
+  "runtime": "14.0",
+  "features": []
+}


### PR DESCRIPTION
Closes #1896

## Root cause

`Page.RunModal()` on a page whose layout binds a control to a page-**global variable** of type `Enum` threw

```
NavALException: You tried to invoke the Enum object with the ID 60040 from the object
Repro Enum Modal Test. An object with that ID does not exist in the current application
compiled with emit version 28014.
```

Verified via `ilspycmd` decompile of `Microsoft.Dynamics.Nav.Ncl.dll` plus a captured C# stack trace (`AL_RUNNER_DIAG_FIRSTCHANCE=MetadataNotFound`):

```
NavFormHandle.RunModalAsync -> NavForm.RunModalAsync -> NavTestExecution.FindPageType
 -> NavForm.get_MasterPage() -> NavForm.EnsureMetadataLoaded() -> NavForm.GetMasterPage()
  -> MetadataProvider...GetPageDefinition -> NCLMetaForm.GetFrozenPageDefinitionWithExtensionWithoutMergedMultiLanguage()
   -> NCLMetaForm.ApplyAppGroupAwareEnumMetadataToPageExpressions(MetaPageDefinition)
```

That real (unmodified) BC method resolves each Enum-typed field's `OptionString`/`OptionCaption`/`OptionValues` via `NavGlobal.NCLMetadata.TryGetMetaApplicationObject(ObjectType.Enum, enumId, ...)`. The runner never populates `NCLMetadata`'s object-graph cache for Enum objects — unlike Table/Page/Report/Query/XmlPort (`RecordPatches.NclMetadataCachePopulator`), AL enums are served entirely through the *separate* `NCLEnumMetadata.Create(int)` hook (`EnumMetadataPatches.cs`), a codepath page materialisation never calls. So the lookup always threw `NavMetadataNotFoundException`, which `NavMethodScope.Run()`'s `RemapToALExceptionAndThrow` turns into the `NavALException` above — naming the **calling scope's own object** (the test codeunit) because no page-scoped `NavMethodScope` exists yet at that point in `NavForm.RunModalAsync`. Confirmed: **the misattribution in the error message is a genuine clue, not a red herring** — it's exactly how BC reports a metadata failure with no page scope on the stack.

This only affects **page-global variable** Enum controls, not Rec-bound Enum fields (`field(Grade; Rec.Grade)`) — the existing corpus test `TestPageEnumField_Tests.al` already exercises the latter and passes, because a Rec-bound field's type resolves via the table's own (already-populated) metadata rather than a standalone `EnumId` lookup.

## Fix

Cecil-rewrites both `NCLMetaForm.ApplyAppGroupAwareEnumMetadataToPageExpressions` overloads (`MetaPageDefinition` and `PageDefinition`) to compute `OptionString`/`OptionCaption`/`OptionValues` from `AlEnumMetadataRegistry` — the same emit-captured per-enum data already used (and already accepted as faithful) for `Enum::"X".Ordinals()/.Names()`/`Format()` via `NCLEnumMetadata_CreateByIdAlAware`. A genuinely unregistered enum id still throws BC's own `NavMetadataNotFoundException`. `AlRunner/Patches/PageEnumFieldMetadataPatches.cs` has the full writeup. `CACHE_VERSION` bumped to 127.

## Tests

- **Runner mechanism** (`AlRunner.Tests/PageEnumFieldMetadataPatchesTests.cs`): both overloads, positive (concrete `OptionString`/`OptionCaption`/`OptionValues` from a registered enum) + negative (unregistered id throws `NavMetadataNotFoundException` naming the exact type/id) + a non-enum-field passthrough case.
- **Runner-extras stopgap** (`tests/runner-extras/page-enum-control-modal/`): full RunModal -> `[ModalPageHandler]` -> concrete-value round-trip, plus a without-RunModal control case proving the split the issue described.
- **Corpus** (upstream, not yet merged/pinned): pushed branch `agent/impl-8/issue-1896-enum-var-control` to `StefanMaron/BusinessCentral.AL.Language.Tests` (`tests/al-language/tests/al-language/handlers/TestPageEnumVariableControl_*.al`) — this is the first corpus coverage of "page-global variable" + "Enum" together (existing coverage only had Rec-bound Enum fields, or page-global variables typed Option/Text). Verified RED->GREEN locally against this branch (full corpus 2076->2079, all pass) but **not opening that PR myself** per this repo's `bc-behavior-tests-go-upstream.md` — orchestrator to review/merge.
- Full local corpus run (`tests/al-language`) with the fix: **2076/2076 pass**, no regressions.
- `tests/expectations/count-baseline/test-count-baseline.json` bumped (+3 tests / +1 appGroup, all BC versions — this bundle has no BC-28-only surface).

## Separate gap found while writing tests

Filed #1928: `TestPage.SetValue` on an Enum-typed control (Rec-bound or page-global) can only be driven by the enum's member **name**, never its declared **Caption** — only `Option`'s control-level `OptionCaption` AL property is consulted today. Scoped out of this PR; the new tests here (and the corpus test) deliberately drive `SetValue` by member name to stay within #1896's actual claim.