### PR TITLE
feat(server): execute accepts inline AL 'code' via a synthesized bundle

### DIFF
--- a/AlRunner.Tests/ServerTests.cs
+++ b/AlRunner.Tests/ServerTests.cs
@@ -184,15 +184,109 @@ public class ServerTests : IClassFixture<SharedCliServer>
         Assert.Contains("executed-onrun-boom", tests[0].GetProperty("message").GetString());
     }
 
+    // #1917: 'captureValues' still needs the Cecil instrumentation pass tracked
+    // on #1640 — that half of v1 parity stays a loud, structured error.
     [SkippableFact]
-    public async Task Execute_InlineCode_NotSupported_ReturnsError()
+    public async Task Execute_CaptureValues_NotSupported_ReturnsError()
     {
         TestArtifacts.SkipIfMissing();
         var server = await _fixture.GetAsync();
-        var r = await server.SendAsync("{\"command\":\"execute\",\"code\":\"Message('hi');\"}");
+        var r = await server.SendAsync(
+            "{\"command\":\"execute\",\"code\":\"Message('hi');\",\"captureValues\":true}");
         var d = JsonSerializer.Deserialize<JsonElement>(r);
         Assert.True(d.TryGetProperty("error", out var err));
-        Assert.Contains("inline AL", err.GetString());
+        Assert.Contains("captureValues", err.GetString());
+    }
+
+    // #1917: inline `code` that is a bare statement list (no leading `codeunit`/
+    // `table`) is wrapped in a scratch OnRun trigger and actually executed — the
+    // failure message below carries a value AL computed (6 * 7), which a stub
+    // that always answered "no error" or always answered the same fixed string
+    // could not reproduce. This is the "positive" half of the compile path: the
+    // codeunit compiles and its trigger genuinely runs.
+    [SkippableFact]
+    public async Task Execute_InlineCode_BareStatements_ComputesRealValue()
+    {
+        TestArtifacts.SkipIfMissing();
+        var server = await _fixture.GetAsync();
+        var r = await server.SendAsync(JsonSerializer.Serialize(new
+        {
+            command = "execute",
+            code = "Error('computed %1', 6 * 7);"
+        }));
+        var d = JsonSerializer.Deserialize<JsonElement>(r);
+        Assert.False(d.TryGetProperty("error", out _), $"unexpected error response: {r}");
+        Assert.Equal(1, d.GetProperty("exitCode").GetInt32());
+        var tests = d.GetProperty("tests");
+        Assert.Equal(1, tests.GetArrayLength());
+        Assert.Equal("fail", tests[0].GetProperty("status").GetString());
+        Assert.Contains("computed 42", tests[0].GetProperty("message").GetString());
+    }
+
+    // A bare statement list with no error at all must compile+run to a genuine
+    // pass — proves the "no exception" path isn't itself a swallowed failure.
+    [SkippableFact]
+    public async Task Execute_InlineCode_BareStatements_PassesWhenNoError()
+    {
+        TestArtifacts.SkipIfMissing();
+        var server = await _fixture.GetAsync();
+        var r = await server.SendAsync(JsonSerializer.Serialize(new
+        {
+            command = "execute",
+            code = "if 6 * 7 <> 42 then Error('math is broken');"
+        }));
+        var d = JsonSerializer.Deserialize<JsonElement>(r);
+        Assert.False(d.TryGetProperty("error", out _), $"unexpected error response: {r}");
+        Assert.Equal(0, d.GetProperty("exitCode").GetInt32());
+        var tests = d.GetProperty("tests");
+        Assert.Equal(1, tests.GetArrayLength());
+        Assert.Equal("pass", tests[0].GetProperty("status").GetString());
+    }
+
+    // #1917: inline `code` that is already a full AL object definition (starts
+    // with "codeunit") is used verbatim, not double-wrapped — matches v1's CLI
+    // `-e` shape (fixes #12).
+    [SkippableFact]
+    public async Task Execute_InlineCode_FullObjectDefinition_UsedVerbatim()
+    {
+        TestArtifacts.SkipIfMissing();
+        var server = await _fixture.GetAsync();
+        var r = await server.SendAsync(JsonSerializer.Serialize(new
+        {
+            command = "execute",
+            code = "codeunit 60170 \"Inline Full Object SX\" { trigger OnRun() begin " +
+                   "Error('full-object %1', 100 + 1); end; }"
+        }));
+        var d = JsonSerializer.Deserialize<JsonElement>(r);
+        Assert.False(d.TryGetProperty("error", out _), $"unexpected error response: {r}");
+        Assert.Equal(1, d.GetProperty("exitCode").GetInt32());
+        var tests = d.GetProperty("tests");
+        Assert.Equal(1, tests.GetArrayLength());
+        Assert.Equal("fail", tests[0].GetProperty("status").GetString());
+        Assert.Contains("full-object 101", tests[0].GetProperty("message").GetString());
+    }
+
+    // Negative: inline code that fails to COMPILE must surface a real compiler
+    // diagnostic, not be silently swallowed into a false "success".
+    [SkippableFact]
+    public async Task Execute_InlineCode_CompileError_ReturnsCompilationErrors()
+    {
+        TestArtifacts.SkipIfMissing();
+        var server = await _fixture.GetAsync();
+        var r = await server.SendAsync(JsonSerializer.Serialize(new
+        {
+            command = "execute",
+            // UndeclaredInlineVariable is never declared — a real AL compile error.
+            code = "if UndeclaredInlineVariable then Error('unreachable');"
+        }));
+        var d = JsonSerializer.Deserialize<JsonElement>(r);
+        Assert.False(d.TryGetProperty("error", out _), $"unexpected top-level error response: {r}");
+        Assert.NotEqual(0, d.GetProperty("exitCode").GetInt32());
+        Assert.True(d.TryGetProperty("compilationErrors", out var compileErrors),
+            $"expected compilationErrors on a compile failure: {r}");
+        Assert.True(compileErrors.GetArrayLength() > 0);
+        var tests = d.GetProperty("tests");
+        Assert.Equal(0, tests.GetArrayLength());
     }
 
     // Reproduces #1658: a request naming an app bundle + its separate test-app

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -2541,41 +2541,97 @@ int RunServerLoop(System.IO.TextReader input, System.IO.TextWriter output)
     }
 
     // ── execute: run every requested bundle's first OnRun-bearing codeunit
-    // (run-mode), aggregating the results. v1 also accepted an inline `code`
-    // string; v2 has no inline-AL compile path yet, so that case fails LOUD
-    // (never a silent fake) per .claude/rules/loud-failures.md.
+    // (run-mode), aggregating the results. #1917: v1 also accepted an inline
+    // `code` string — a temp single-file bundle is synthesised from it (see
+    // SynthesizeInlineCodeBundle) and run through the SAME compile pipeline a
+    // sourcePaths-based execute already uses (RunAllBundlesForServer →
+    // RunBundleForServer → RunFirstCodeunitOnRun), rather than inventing a
+    // second execution path. `captureValues` stays out of scope — it needs the
+    // Cecil instrumentation pass tracked on #1640 — so that case still fails
+    // LOUD (never a silent fake) per .claude/rules/loud-failures.md.
     string HandleServerExecute(AlRunner.ServerRequest req)
     {
-        if (!string.IsNullOrWhiteSpace(req.Code))
-            return AlRunner.ServerProtocol.Error(
-                "execute: inline AL 'code' is not yet supported in v2 — pass 'sourcePaths' "
-                + "to run the bundle's OnRun codeunit. See docs/server-mode.md.");
         if (req.CaptureValues == true)
             return AlRunner.ServerProtocol.Error(
                 "execute: 'captureValues' is not yet supported in v2. See docs/server-mode.md.");
-        if (req.SourcePaths == null || req.SourcePaths.Length == 0)
-            return AlRunner.ServerProtocol.Error("sourcePaths is required");
-        foreach (var p in req.SourcePaths)
-            if (!Directory.Exists(p))
-                return AlRunner.ServerProtocol.Error($"bundle directory not found: {p}");
+
+        string? scratchDir = null;
+        string[] sourcePaths;
+        if (!string.IsNullOrWhiteSpace(req.Code))
+        {
+            if (req.SourcePaths != null && req.SourcePaths.Length > 0)
+                return AlRunner.ServerProtocol.Error(
+                    "execute: 'code' and 'sourcePaths' are mutually exclusive — pass one or the other.");
+            scratchDir = SynthesizeInlineCodeBundle(req.Code!);
+            sourcePaths = new[] { scratchDir };
+        }
+        else
+        {
+            if (req.SourcePaths == null || req.SourcePaths.Length == 0)
+                return AlRunner.ServerProtocol.Error("sourcePaths is required");
+            foreach (var p in req.SourcePaths)
+                if (!Directory.Exists(p))
+                    return AlRunner.ServerProtocol.Error($"bundle directory not found: {p}");
+            sourcePaths = req.SourcePaths;
+        }
 
         var isolationError = ApplyRequestIsolation(req);
         if (isolationError != null) return isolationError;
 
-        var runs = RunAllBundlesForServer(req.SourcePaths, req.PackagePaths, RunFirstCodeunitOnRun);
+        try
+        {
+            var runs = RunAllBundlesForServer(sourcePaths, req.PackagePaths, RunFirstCodeunitOnRun);
 
-        var allTests = runs.SelectMany(r => r.Tests).ToList();
-        var allCompileErrors = runs.SelectMany(r => r.CompileErrors ?? Array.Empty<CompilationErrorGroup>()).ToList();
-        var exitCode = runs.Count > 0 ? runs.Max(r => r.ExitCode) : 0;
+            var allTests = runs.SelectMany(r => r.Tests).ToList();
+            var allCompileErrors = runs.SelectMany(r => r.CompileErrors ?? Array.Empty<CompilationErrorGroup>()).ToList();
+            var exitCode = runs.Count > 0 ? runs.Max(r => r.ExitCode) : 0;
 
-        var combinedHashes = new Dictionary<string, string>();
-        foreach (var r in runs)
-            foreach (var kv in r.FileHashes)
-                combinedHashes[kv.Key] = kv.Value;
-        lastFileHashes = combinedHashes;
+            var combinedHashes = new Dictionary<string, string>();
+            foreach (var r in runs)
+                foreach (var kv in r.FileHashes)
+                    combinedHashes[kv.Key] = kv.Value;
+            lastFileHashes = combinedHashes;
 
-        return AlRunner.ServerProtocol.Execute(allTests, exitCode, null,
-            allCompileErrors.Count > 0 ? allCompileErrors : null);
+            return AlRunner.ServerProtocol.Execute(allTests, exitCode, null,
+                allCompileErrors.Count > 0 ? allCompileErrors : null);
+        }
+        finally
+        {
+            // Best-effort cleanup: the scratch dir's contents are fully consumed
+            // once RunBundleForServer has emitted+compiled them into an in-memory
+            // assembly (or failed trying) — nothing downstream needs the files on
+            // disk after this call returns, and a leaked temp dir per `execute`
+            // call would otherwise accumulate for the life of the server process.
+            if (scratchDir != null)
+            {
+                try { Directory.Delete(scratchDir, recursive: true); }
+                catch { /* not fatal — OS temp cleanup will catch it eventually */ }
+            }
+        }
+    }
+
+    // #1917: synthesise a temp single-file AL bundle from an inline `code`
+    // string so `execute`'s "code" field can go through the same compile
+    // pipeline as a sourcePaths-based execute, instead of a separate inline-AL
+    // execution path. v1 parity (see git history for e1a22f84, "fixes #12"):
+    // `code` that already looks like a full AL object definition (starts with
+    // `codeunit` or `table`, case-insensitive) is used verbatim; anything else
+    // is treated as a bare statement list and wrapped in a scratch codeunit's
+    // OnRun trigger body, matching v1's CLI `-e` shape.
+    static string SynthesizeInlineCodeBundle(string code)
+    {
+        var trimmed = code.TrimStart();
+        var isFullObject =
+            trimmed.StartsWith("codeunit", StringComparison.OrdinalIgnoreCase) ||
+            trimmed.StartsWith("table", StringComparison.OrdinalIgnoreCase);
+        var source = isFullObject
+            ? code
+            : $"codeunit 50100 \"AL Runner Inline Execute\" {{ trigger OnRun() begin {code} end; }}";
+
+        var dir = Path.Combine(Path.GetTempPath(), "al-runner-server-inline", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "Scratch.al"), source);
+        return dir;
     }
 
     // Runs every bundle in sourcePaths in order and returns one ServerRunResult per

--- a/docs/server-mode.md
+++ b/docs/server-mode.md
@@ -39,7 +39,7 @@ al-runner --server [--package-cache PATH ...] [--cache DIR]
                                  // the CLI (inter-bundle deps get wired first)
   "packagePaths": ["/extra"],   // optional: extra .app caches, augment server defaults
   "stubPaths": [],              // v1 field, ignored in v2 (no stubs layer)
-  "code": "...",                // execute only (inline AL) — not yet supported
+  "code": "...",                // execute only (inline AL); mutually exclusive with sourcePaths
   "captureValues": false,       // execute only — not yet supported
   "testIsolation": "codeunit"   // optional: "codeunit" (default) | "test"/"method" | "disabled"
                                  // — see #1616. Applies to this request only; a later
@@ -146,12 +146,28 @@ this is **not** streamed — one v1-shaped response line, no `type` discriminato
 ```
 
 v1's `execute` also accepted an inline `code` string and a `captureValues` flag.
-v2 has no inline-AL compile path and no value capture (the latter needs the
-Cecil instrumentation pass on #1640), so both fail loudly with a structured
-error rather than a silent fake, per `.claude/rules/loud-failures.md`:
+v2 now supports `code` too (#1917): a temp single-file bundle is synthesised
+from it and run through the same compile pipeline `sourcePaths` uses. `code`
+that already starts with `codeunit` or `table` (case-insensitive) is used
+verbatim as a full AL object definition; anything else is treated as a bare
+statement list and wrapped in a scratch codeunit's `OnRun` trigger body —
+matching v1's CLI `-e` shape:
 
 ```json
-{"error":"execute: inline AL 'code' is not yet supported in v2 — pass 'sourcePaths' to run the bundle's OnRun codeunit. See docs/server-mode.md."}
+{"command":"execute","code":"Message('hi');"}
+```
+
+```json
+{"exitCode":0,"tests":[{"name":"AL Runner Inline Execute.OnRun","status":"pass","durationMs":4}]}
+```
+
+`code` and `sourcePaths` are mutually exclusive — sending both is a
+request-level error. Value capture (`captureValues`) still needs the Cecil
+instrumentation pass on #1640, so that flag alone still fails loudly with a
+structured error rather than a silent fake, per `.claude/rules/loud-failures.md`:
+
+```json
+{"error":"execute: 'captureValues' is not yet supported in v2. See docs/server-mode.md."}
 ```
 
 ### `shutdown`


### PR DESCRIPTION
Closes #1917

## What

`--server`'s `execute` command's `code` field (inline AL) returned a loud "not yet supported" error for every request — a real v1 parity gap. This adds the compile path the issue asked for.

## How

- `SynthesizeInlineCodeBundle` (new, in `AlRunner/Program.cs`) writes the inline `code` string to a temp single-file directory. Matching v1's CLI `-e` shape (see commit `e1a22f84`, "fixes #12"): text that already starts with `codeunit`/`table` (case-insensitive) is used verbatim as a full AL object definition; anything else is a bare statement list, wrapped in a scratch codeunit's `OnRun` trigger body.
- `HandleServerExecute` now feeds that temp dir into the SAME pipeline a `sourcePaths`-based `execute` already uses — `RunAllBundlesForServer` → `RunBundleForServer` → `RunFirstCodeunitOnRun` — no separate inline-AL execution path. The temp dir is deleted (best-effort) once the run completes.
- `code` and `sourcePaths` are now mutually exclusive on one request (a request carrying both is a request-level error).
- `captureValues` is unchanged and still out of scope (#1640) — that check is still the first thing `HandleServerExecute` does, and still returns the same structured error.

## Why the existing pipeline was reusable

The issue's assumed shape held up: `RunBundleForServer` already treats "a directory with `.al` files and no `app.json`" as a valid flat bundle (`EnumerateSuites`'s fallback case), so no app.json synthesis was needed for the common case. `RunFirstCodeunitOnRun` already existed for the `sourcePaths` run-mode path and needed zero changes.

## Tests (`AlRunner.Tests/ServerTests.cs`)

- `Execute_InlineCode_BareStatements_ComputesRealValue` — positive: `code` is a bare statement (`Error('computed %1', 6 * 7);`), asserts the failure message contains `computed 42` — proves the arithmetic genuinely ran, not a stub.
- `Execute_InlineCode_BareStatements_PassesWhenNoError` — positive: a bare statement with no error compiles+runs to a genuine pass.
- `Execute_InlineCode_FullObjectDefinition_UsedVerbatim` — positive: `code` starting with `codeunit` is used verbatim (not double-wrapped), asserts a computed value in the failure message.
- `Execute_InlineCode_CompileError_ReturnsCompilationErrors` — negative: `code` referencing an undeclared identifier surfaces real `compilationErrors`, not a false success.
- `Execute_CaptureValues_NotSupported_ReturnsError` — replaces the old `Execute_InlineCode_NotSupported_ReturnsError` (which encoded the now-removed behavior); confirms `captureValues` alone still errors loudly.

RED confirmed against `main` before the fix (all 5 failed with the old "not yet supported" error / wrong assertion); GREEN after.

## Docs

`docs/server-mode.md`'s `execute` section updated to document the new `code` shape and the `code`/`sourcePaths` mutual-exclusivity rule.

## Scope notes

- `captureValues` is untouched — still #1640.
- No AL corpus / `tests/runner-extras` changes — this is server-protocol C# only, so `tests/expectations/count-baseline/test-count-baseline.json` doesn't need a bump (its suites are `al-language` and `runner-extras`, neither touched).