### PR TITLE
fix(server): classify inline code objects via BC's own parser, not a keyword prefix

### DIFF
--- a/AlRunner.Tests/ServerTests.cs
+++ b/AlRunner.Tests/ServerTests.cs
@@ -266,6 +266,157 @@ public class ServerTests : IClassFixture<SharedCliServer>
         Assert.Contains("full-object 101", tests[0].GetProperty("message").GetString());
     }
 
+    // #1931: the old classifier only matched `trimmed.StartsWith("codeunit"/
+    // "table")`, so a `page`/`enum`/`report` (or any other AL object type) fell
+    // through to the bare-statement branch and got nested INSIDE a scratch
+    // codeunit's OnRun trigger body — invalid AL, a syntax error pointing at the
+    // wrapper. Each fact below pairs the object type under test with a companion
+    // codeunit in the SAME inline `code` string (BC's own parser handles
+    // multiple objects per file — see ParseObjectText probe backing this PR).
+    // Under the fix, IsFullAlObjectDeclaration recognises the whole text as
+    // object declarations via BC's own parser (not a keyword list) and uses it
+    // verbatim, so both objects compile as siblings and RunFirstCodeunitOnRun
+    // finds and runs the companion's OnRun — a distinct computed value in the
+    // failure message is proof the trigger genuinely ran, not that compilation
+    // merely didn't error.
+    [SkippableFact]
+    public async Task Execute_InlineCode_FullPageDefinition_CompanionCodeunitRuns()
+    {
+        TestArtifacts.SkipIfMissing();
+        var server = await _fixture.GetAsync();
+        var r = await server.SendAsync(JsonSerializer.Serialize(new
+        {
+            command = "execute",
+            code = "page 60180 \"Inline Full Page SX\" { layout { area(content) { } } } " +
+                   "codeunit 60181 \"Inline Full Page Companion SX\" { trigger OnRun() begin " +
+                   "Error('page-companion-ran %1', 200 + 1); end; }"
+        }));
+        var d = JsonSerializer.Deserialize<JsonElement>(r);
+        Assert.False(d.TryGetProperty("error", out _), $"unexpected error response: {r}");
+        Assert.False(d.TryGetProperty("compilationErrors", out _), $"unexpected compile error: {r}");
+        Assert.Equal(1, d.GetProperty("exitCode").GetInt32());
+        var tests = d.GetProperty("tests");
+        Assert.Equal(1, tests.GetArrayLength());
+        Assert.Equal("fail", tests[0].GetProperty("status").GetString());
+        Assert.Contains("page-companion-ran 201", tests[0].GetProperty("message").GetString());
+    }
+
+    [SkippableFact]
+    public async Task Execute_InlineCode_FullEnumDefinition_CompanionCodeunitRuns()
+    {
+        TestArtifacts.SkipIfMissing();
+        var server = await _fixture.GetAsync();
+        var r = await server.SendAsync(JsonSerializer.Serialize(new
+        {
+            command = "execute",
+            code = "enum 60182 \"Inline Full Enum SX\" { value(0; A) { } } " +
+                   "codeunit 60183 \"Inline Full Enum Companion SX\" { trigger OnRun() begin " +
+                   "Error('enum-companion-ran %1', 300 + 1); end; }"
+        }));
+        var d = JsonSerializer.Deserialize<JsonElement>(r);
+        Assert.False(d.TryGetProperty("error", out _), $"unexpected error response: {r}");
+        Assert.False(d.TryGetProperty("compilationErrors", out _), $"unexpected compile error: {r}");
+        Assert.Equal(1, d.GetProperty("exitCode").GetInt32());
+        var tests = d.GetProperty("tests");
+        Assert.Equal(1, tests.GetArrayLength());
+        Assert.Equal("fail", tests[0].GetProperty("status").GetString());
+        Assert.Contains("enum-companion-ran 301", tests[0].GetProperty("message").GetString());
+    }
+
+    [SkippableFact]
+    public async Task Execute_InlineCode_FullReportDefinition_CompanionCodeunitRuns()
+    {
+        TestArtifacts.SkipIfMissing();
+        var server = await _fixture.GetAsync();
+        var r = await server.SendAsync(JsonSerializer.Serialize(new
+        {
+            command = "execute",
+            code = "report 60184 \"Inline Full Report SX\" { dataset { } } " +
+                   "codeunit 60185 \"Inline Full Report Companion SX\" { trigger OnRun() begin " +
+                   "Error('report-companion-ran %1', 400 + 1); end; }"
+        }));
+        var d = JsonSerializer.Deserialize<JsonElement>(r);
+        Assert.False(d.TryGetProperty("error", out _), $"unexpected error response: {r}");
+        Assert.False(d.TryGetProperty("compilationErrors", out _), $"unexpected compile error: {r}");
+        Assert.Equal(1, d.GetProperty("exitCode").GetInt32());
+        var tests = d.GetProperty("tests");
+        Assert.Equal(1, tests.GetArrayLength());
+        Assert.Equal("fail", tests[0].GetProperty("status").GetString());
+        Assert.Contains("report-companion-ran 401", tests[0].GetProperty("message").GetString());
+    }
+
+    // #1931: `TrimStart()` leaves a leading `//` comment in place, so the old
+    // `StartsWith("codeunit")` check never matched a codeunit preceded by one —
+    // it silently fell through to wrapping, nesting a full object declaration
+    // inside a trigger body. BC's own parser treats the comment as leading
+    // trivia on the `codeunit` token, so IsFullAlObjectDeclaration recognises it
+    // regardless. The computed failure value again proves real execution.
+    [SkippableFact]
+    public async Task Execute_InlineCode_CommentPrefixedCodeunit_UsedVerbatim()
+    {
+        TestArtifacts.SkipIfMissing();
+        var server = await _fixture.GetAsync();
+        var r = await server.SendAsync(JsonSerializer.Serialize(new
+        {
+            command = "execute",
+            code = "// setup note the caller left on their inline snippet\n" +
+                   "codeunit 60186 \"Inline Comment Prefixed CU SX\" { trigger OnRun() begin " +
+                   "Error('comment-prefixed-ran %1', 500 + 1); end; }"
+        }));
+        var d = JsonSerializer.Deserialize<JsonElement>(r);
+        Assert.False(d.TryGetProperty("error", out _), $"unexpected error response: {r}");
+        Assert.False(d.TryGetProperty("compilationErrors", out _), $"unexpected compile error: {r}");
+        Assert.Equal(1, d.GetProperty("exitCode").GetInt32());
+        var tests = d.GetProperty("tests");
+        Assert.Equal(1, tests.GetArrayLength());
+        Assert.Equal("fail", tests[0].GetProperty("status").GetString());
+        Assert.Contains("comment-prefixed-ran 501", tests[0].GetProperty("message").GetString());
+    }
+
+    // #1931 negative: a malformed-but-recognisable object (here a `report`
+    // whose dataset references a table that doesn't exist) is still used
+    // verbatim, so the compile diagnostic that comes back is the REAL semantic
+    // error about the caller's actual object — it names the caller's own
+    // undeclared table text — rather than a generic "unexpected token 'report'"
+    // syntax error a mis-wrap into the scratch OnRun body would have produced.
+    // That distinguishes "recognised as an object, then failed to compile" from
+    // "not recognised, wrapped, then failed to compile for an unrelated reason".
+    [SkippableFact]
+    public async Task Execute_InlineCode_MalformedObject_CompileErrorNamesRealProblem()
+    {
+        TestArtifacts.SkipIfMissing();
+        var server = await _fixture.GetAsync();
+        var r = await server.SendAsync(JsonSerializer.Serialize(new
+        {
+            command = "execute",
+            code = "report 60187 \"Inline Malformed Report SX\" { dataset { " +
+                   "dataitem(NoSuchTable; \"This Table Does Not Exist SX\") { } } }"
+        }));
+        var d = JsonSerializer.Deserialize<JsonElement>(r);
+        Assert.False(d.TryGetProperty("error", out _), $"unexpected top-level error response: {r}");
+        Assert.NotEqual(0, d.GetProperty("exitCode").GetInt32());
+        Assert.True(d.TryGetProperty("compilationErrors", out var compileErrors),
+            $"expected compilationErrors on a compile failure: {r}");
+        Assert.True(compileErrors.GetArrayLength() > 0);
+        var allErrorText = string.Join(" | ", compileErrors.EnumerateArray()
+            .SelectMany(g => g.GetProperty("errors").EnumerateArray().Select(e => e.GetString())));
+        // Positive: the real semantic diagnostic — the caller's own undeclared
+        // table name — is present, so the caller can actually see their bug.
+        Assert.Contains("This Table Does Not Exist SX", allErrorText);
+        // Negative (the actual RED/GREEN discriminator): a mis-wrap nests the
+        // report's `report`/`dataset`/`dataitem` keywords as bare-expression
+        // statements inside the scratch OnRun body, and once that body's closing
+        // `end;`/`}` is reached the leftover text triggers a FRESH top-level
+        // object parse attempt — which fails with AL0198 ("expected one of the
+        // application object keywords"). That code never appears when the report
+        // is recognised and compiled verbatim, because it is a syntactically
+        // complete, single object with nothing left over to mis-parse. Its
+        // presence here would mean classification took the wrong branch.
+        Assert.DoesNotContain("AL0198", allErrorText);
+        var tests = d.GetProperty("tests");
+        Assert.Equal(0, tests.GetArrayLength());
+    }
+
     // Negative: inline code that fails to COMPILE must surface a real compiler
     // diagnostic, not be silently swallowed into a false "success".
     [SkippableFact]

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -15,6 +15,8 @@
 //   Runner --precompile <input.app> --out <output.dll>
 using System.Reflection;
 using AlRunner;
+using NavCA = Microsoft.Dynamics.Nav.CodeAnalysis;
+using NavSyntax = Microsoft.Dynamics.Nav.CodeAnalysis.Syntax;
 
 // Diagnostic: AL_RUNNER_DIAG_FIRSTCHANCE=<substring> prints the FULL stack of
 // every first-chance exception whose type name contains the substring (use e.g.
@@ -2614,16 +2616,19 @@ int RunServerLoop(System.IO.TextReader input, System.IO.TextWriter output)
     // string so `execute`'s "code" field can go through the same compile
     // pipeline as a sourcePaths-based execute, instead of a separate inline-AL
     // execution path. v1 parity (see git history for e1a22f84, "fixes #12"):
-    // `code` that already looks like a full AL object definition (starts with
-    // `codeunit` or `table`, case-insensitive) is used verbatim; anything else
-    // is treated as a bare statement list and wrapped in a scratch codeunit's
-    // OnRun trigger body, matching v1's CLI `-e` shape.
+    // `code` that already looks like a full AL object definition is used
+    // verbatim; anything else is treated as a bare statement list and wrapped
+    // in a scratch codeunit's OnRun trigger body, matching v1's CLI `-e` shape.
+    //
+    // #1931: "already looks like a full AL object" used to be
+    // `trimmed.StartsWith("codeunit"/"table")` — a two-keyword allowlist that
+    // misclassified every other object type (page/enum/report/query/xmlport/
+    // interface/...) AND any codeunit behind a leading `//` comment (TrimStart
+    // leaves the `//` in place, so it never matched). See IsFullAlObjectDeclaration
+    // for the fix: ask BC's own parser instead of maintaining a keyword list.
     static string SynthesizeInlineCodeBundle(string code)
     {
-        var trimmed = code.TrimStart();
-        var isFullObject =
-            trimmed.StartsWith("codeunit", StringComparison.OrdinalIgnoreCase) ||
-            trimmed.StartsWith("table", StringComparison.OrdinalIgnoreCase);
+        var isFullObject = IsFullAlObjectDeclaration(code);
         var source = isFullObject
             ? code
             : $"codeunit 50100 \"AL Runner Inline Execute\" {{ trigger OnRun() begin {code} end; }}";
@@ -2632,6 +2637,76 @@ int RunServerLoop(System.IO.TextReader input, System.IO.TextWriter output)
         Directory.CreateDirectory(dir);
         File.WriteAllText(Path.Combine(dir, "Scratch.al"), source);
         return dir;
+    }
+
+    // #1931: is `code` already a full AL object declaration (should be used
+    // verbatim), or a bare statement list (needs wrapping in a scratch OnRun
+    // body)? Answered by asking BC's OWN parser rather than maintaining a
+    // keyword allowlist that drifts as AL gains object types — the same
+    // approach RecordPatches.AlSourceParser.ParseAlObjects already uses for
+    // table/tableextension extraction (#1696). SyntaxTree.ParseObjectText needs
+    // only a ParseOptions, no Compilation and no reference closure, so this is
+    // cheap and side-effect-free.
+    //
+    // Every top-level AL object syntax type shares one common base,
+    // Microsoft.Dynamics.Nav.CodeAnalysis.Syntax.ObjectSyntax — verified via
+    // reflection over the shipped CodeAnalysis DLL: table/codeunit/page/report/
+    // query/xmlport/enum/(+ extension variants) all derive from
+    // ApplicationObjectSyntax : ObjectSyntax, while interface/controladdin/
+    // profile/dotnet/entitlement derive from ObjectSyntax directly (they have no
+    // object id, so they don't go through ApplicationObjectSyntax) — so "did the
+    // compilation-unit root produce at least one ObjectSyntax child" answers
+    // "is this a full object declaration" for the whole AL object-keyword set at
+    // once, with no list to keep in sync.
+    //
+    // Leading trivia (a `//` comment, a blank line, a `#pragma`) needs no manual
+    // skipping: comments/blank lines are trivia the parser already attaches to
+    // the first real token when it scans for the object keyword, so a
+    // `//`-prefixed codeunit still yields a CodeunitSyntax child.
+    //
+    // A malformed-but-recognisable object (e.g. `codeunit 50100 "X" { trigger
+    // OnRun() begin Error(` with an unclosed paren) still parses to exactly one
+    // ObjectSyntax child — BC's parser recovers past the syntax error and still
+    // recognises the object shape — so it is STILL used verbatim. That is
+    // deliberate: the caller's real compile error then names the caller's real
+    // code (via the normal `compilationErrors` channel `execute` already
+    // returns), not a wrapper the caller never wrote. A genuine bare statement
+    // list, or text that isn't AL at all, produces zero children (BC's parser
+    // reports AL0198 "expected one of the application object keywords" and
+    // recovers to an empty compilation unit) and falls through to wrapping.
+    //
+    // Never throws: this is fed arbitrary text a human may have typed by hand,
+    // and a parse ParseObjectText itself cannot make sense of must fall back to
+    // "not a full object" (wrap it) rather than blow up the request — the same
+    // never-throw contract RecordPatches.AlSourceParser.ParseAlObjects documents
+    // for the identical call.
+    //
+    // Classification is deterministic (yes/no), never ambiguous, so there is no
+    // third "couldn't tell" state to surface as a request-level protocol error:
+    // whichever branch is chosen, a real problem in the caller's AL still comes
+    // back through the existing `compilationErrors` channel that
+    // Execute_InlineCode_CompileError_ReturnsCompilationErrors already proves —
+    // exactly where every other AL-content problem in this protocol surfaces.
+    // The top-level `error` field stays reserved for request-shape problems
+    // (unknown command, missing sourcePaths, mutually exclusive fields) that
+    // have nothing to do with what the AL says.
+    static bool IsFullAlObjectDeclaration(string code)
+    {
+        try
+        {
+            var parseOpts = new NavCA.ParseOptions(
+                runtimeVersion: null!,
+                preprocessorSymbols: Enumerable.Range(1, 25).Select(n => $"CLEANSCHEMA{n}")
+                    .Concat(AlRunner.BcCompiler.GetExtraPreprocessorSymbols()),
+                documentationMode: NavCA.DocumentationMode.None);
+            var tree = NavSyntax.SyntaxTree.ParseObjectText(code, path: "", encoding: null!, parseOpts, default);
+            return tree.GetRoot() is NavSyntax.CompilationUnitSyntax root &&
+                   root.ChildNodes().Any(n => n is NavSyntax.ObjectSyntax);
+        }
+        catch
+        {
+            return false;
+        }
     }
 
     // Runs every bundle in sourcePaths in order and returns one ServerRunResult per

--- a/docs/server-mode.md
+++ b/docs/server-mode.md
@@ -148,10 +148,14 @@ this is **not** streamed — one v1-shaped response line, no `type` discriminato
 v1's `execute` also accepted an inline `code` string and a `captureValues` flag.
 v2 now supports `code` too (#1917): a temp single-file bundle is synthesised
 from it and run through the same compile pipeline `sourcePaths` uses. `code`
-that already starts with `codeunit` or `table` (case-insensitive) is used
-verbatim as a full AL object definition; anything else is treated as a bare
-statement list and wrapped in a scratch codeunit's `OnRun` trigger body —
-matching v1's CLI `-e` shape:
+that already parses as a full AL object declaration — any object keyword
+(`table`, `codeunit`, `page`, `enum`, `report`, `query`, `xmlport`,
+`interface`, ... the whole AL object-keyword set, including behind a leading
+`//` comment) — is used verbatim; anything else is treated as a bare statement
+list and wrapped in a scratch codeunit's `OnRun` trigger body — matching v1's
+CLI `-e` shape. Classification asks BC's own parser
+(`SyntaxTree.ParseObjectText`) rather than matching a keyword prefix, so it
+covers every object type BC supports, not just `codeunit`/`table` (#1931):
 
 ```json
 {"command":"execute","code":"Message('hi');"}


### PR DESCRIPTION
Closes #1931

## Problem

`SynthesizeInlineCodeBundle` in `AlRunner/Program.cs` decided whether an inline `code` string passed to `--server execute` was a full AL object or a bare statement list with:

```csharp
var isFullObject =
    trimmed.StartsWith("codeunit", StringComparison.OrdinalIgnoreCase) ||
    trimmed.StartsWith("table", StringComparison.OrdinalIgnoreCase);
```

Everything else — `page`, `enum`, `report`, `query`, `xmlport`, `interface`, `permissionset`, ..., and any `codeunit`/`table` behind a leading `//` comment (`TrimStart()` leaves the `//` in place) — fell through to the bare-statement branch and got nested inside a scratch codeunit's `OnRun` trigger body. That's invalid AL, so it failed loudly with a compile error, but the error pointed at the wrapper the caller never wrote, not at the caller's actual object.

## Fix

Classification now asks BC's own parser instead of maintaining a keyword allowlist:

```csharp
var tree = NavSyntax.SyntaxTree.ParseObjectText(code, path: "", encoding: null!, parseOpts, default);
return tree.GetRoot() is NavSyntax.CompilationUnitSyntax root &&
       root.ChildNodes().Any(n => n is NavSyntax.ObjectSyntax);
```

`ParseObjectText` needs only a `ParseOptions` — no `Compilation`, no reference closure — matching how `BcCompiler.Emit` and `RecordPatches.AlSourceParser.ParseAlObjects` already use it (#1696). I verified via reflection over the shipped `Microsoft.Dynamics.Nav.CodeAnalysis.dll` that every AL object-declaration syntax type shares one common base, `Syntax.ObjectSyntax`:

- `table`/`codeunit`/`page`/`report`/`query`/`xmlport`/`enum` (+ their extension variants) derive from `ApplicationObjectSyntax : ObjectSyntax`
- `interface`/`controladdin`/`profile`/`dotnet`/`entitlement` derive from `ObjectSyntax` directly (no object id, so they skip `ApplicationObjectSyntax`)

So "did the compilation-unit root produce at least one `ObjectSyntax` child" answers the classification question for the entire AL object-keyword set at once, with nothing to keep in sync as AL adds object types. Leading trivia (`//` comments, blank lines, `#pragma`) needs no manual skipping — the parser already treats it as trivia attached to the real first token.

A malformed-but-recognisable object (e.g. a `codeunit` with an unclosed paren) still parses to one `ObjectSyntax` child — BC's parser recovers past the syntax error and still recognises the object shape — so it's still used verbatim, and the real compile diagnostic names the caller's actual code.

## The compile-error-vs-request-error decision

The issue asked me to decide deliberately whether a classification failure should stay a compile error or become a request-level protocol error. I chose **compile error, unchanged**: `ParseObjectText` never returns an ambiguous "couldn't tell" state — it's a deterministic yes/no (does the root have an `ObjectSyntax` child or not) — so there's no third state to surface as a new request-level error type. Whichever branch is chosen, any real problem in the caller's AL still comes back through the existing `compilationErrors` channel that `Execute_InlineCode_CompileError_ReturnsCompilationErrors` already covers, which is where every other AL-content problem in this protocol surfaces. The top-level `error` field stays reserved for request-shape problems (unknown command, missing `sourcePaths`, mutually exclusive fields) that have nothing to do with what the AL says.

## Tests (`AlRunner.Tests/ServerTests.cs`, extending the set PR #1930 added)

- `Execute_InlineCode_FullPageDefinition_CompanionCodeunitRuns`
- `Execute_InlineCode_FullEnumDefinition_CompanionCodeunitRuns`
- `Execute_InlineCode_FullReportDefinition_CompanionCodeunitRuns`
- `Execute_InlineCode_CommentPrefixedCodeunit_UsedVerbatim`
- `Execute_InlineCode_MalformedObject_CompileErrorNamesRealProblem` (negative)

Each page/enum/report test pairs the object under test with a companion codeunit in the *same* inline `code` string (BC's parser supports multiple objects per file) so the proof is genuine execution — a distinct computed value in the failure message — not just "compilation didn't error." The malformed-object test asserts both that the real semantic diagnostic (the caller's own undeclared table name) is present, and that the "wrong branch" tell (`AL0198`, the syntax error a mis-wrap produces) is absent.

Verified strict RED → GREEN by stashing the `Program.cs` fix, confirming all 5 new tests fail for the expected reasons, then restoring the fix and confirming all 9 inline-code tests (5 new + 4 pre-existing) and the full 18-test `ServerTests` class pass.

## Docs

Updated `docs/server-mode.md`'s `execute` section, which documented the old `codeunit`/`table` prefix behavior.