### PR TITLE
fix(testpage): SetValue(Boolean) works on Rec-bound Boolean controls

### DIFF
--- a/AlRunner.Tests/CollectionCostOrderer.cs
+++ b/AlRunner.Tests/CollectionCostOrderer.cs
@@ -122,6 +122,9 @@ public sealed class CollectionCostOrderer : ITestCollectionOrderer
             ["CountBaselineIntegrationTests"] = 84,
             ["ServerTests"] = 81,
             ["TestPageDrillDownDispatchTests"] = 75,
+            // #1870: one test, spawning a real runner subprocess against an AL fixture
+            // (BC engine cold-start + AL emit/compile once). Measured 63.9s in CI.
+            ["TestPageBooleanRecBoundDispatchTests"] = 63,
             ["ServerTestIsolationTests"] = 69,
             ["ServerStreamingTests"] = 50,
             ["ExpectationManifestWiringTests"] = 47,

--- a/AlRunner.Tests/TestPageBooleanRecBoundDispatchTests.cs
+++ b/AlRunner.Tests/TestPageBooleanRecBoundDispatchTests.cs
@@ -1,0 +1,242 @@
+// TestPageBooleanRecBoundDispatchTests — issue #1870, the Rec-bound half of #1837/#1869.
+//
+// This is a RUNNER-MECHANISM test, not a claim about what real BC does: it proves that OUR
+// OWN wiring — LiveNavTestField.Value's setter in MockTestPage.cs, the Rec-bound sibling of
+// PageVariableTestField.ToBoundValue that #1869 already fixed — routes a Boolean-typed
+// control's TestPage.SetValue(<Boolean>) through TestPageBooleanValue.Resolve when the source
+// table field is Boolean, instead of falling through to ALCompiler.ToNavValue(value) (which
+// always produces a NavText and made NavTestField.ALSetValue's own ALValidateAsync reject it
+// with "The value \"True\" can't be evaluated into type Boolean").
+//
+// The BEHAVIORAL claim ("SetValue(true)/SetValue(false) on a Rec-bound Boolean control sets
+// and persists the underlying table field, round-tripping both directions, and a text that is
+// not a valid Boolean spelling is rejected and not persisted") is proven upstream against a
+// live BC service tier — see StefanMaron/BusinessCentral.AL.Language.Tests, codeunit 60997
+// "TP Boolean Rec Bound Tests" — per .claude/rules/bc-behavior-tests-go-upstream.md. This test
+// exists so a regression in OUR OWN dispatch mechanism fails loudly here, in seconds, without
+// needing the corpus's al-language submodule pin bumped (deliberately deferred to a separate
+// centralized PR, same reasoning as TestPageDrillDownDispatchTests).
+//
+// RED/GREEN proof: reverting LiveNavTestField.Value's setter to the pre-fix
+// `CurrentOption() is { } option ? ... : ALCompiler.ToNavValue(value)` (dropping the
+// `FieldType == NavType.Boolean` branch) makes the positive test below fail with exactly the
+// NavNCLEvaluateException the issue reported, reproduced against a real BC engine here (not a
+// mock of one).
+
+using System.Diagnostics;
+using System.Text;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class TestPageBooleanRecBoundDispatchTests : IDisposable
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+    private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
+
+    private readonly string _root;
+
+    public TestPageBooleanRecBoundDispatchTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "al-runner-bool-recbound-dispatch", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { /* best-effort cleanup */ }
+    }
+
+    private static string[] ExtraPackageCacheArgs()
+    {
+        var platformApps = TestArtifacts.PlatformAppsDir();
+        return Directory.Exists(platformApps)
+            ? new[] { "--package-cache", platformApps }
+            : Array.Empty<string>();
+    }
+
+    /// <summary>
+    /// Mirrors the issue's own minimal reproducer: a Boolean table field bound directly to a
+    /// card control (field(RecFlag; Rec.Flag)), as opposed to a page-variable-bound one.
+    /// </summary>
+    private void WriteBundle()
+    {
+        Directory.CreateDirectory(_root);
+        File.WriteAllText(Path.Combine(_root, "app.json"), """
+        {
+          "id": "c9d1e3a5-4b6f-4890-9a1b-6c7d8e9f0a2c",
+          "name": "Runner Mechanism - TestPage Boolean Rec Bound Dispatch",
+          "publisher": "AL Runner",
+          "version": "1.0.0.0",
+          "dependencies": [],
+          "platform": "1.0.0.0",
+          "application": "1.0.0.0",
+          "idRanges": [ { "from": 62390, "to": 62399 } ],
+          "runtime": "14.0"
+        }
+        """);
+
+        File.WriteAllText(Path.Combine(_root, "BrbRow.Table.al"), """
+        table 62390 "Brb Row"
+        {
+            DataClassification = CustomerContent;
+
+            fields
+            {
+                field(1; PK; Code[10]) { }
+                field(2; Value; Text[30]) { }
+                field(3; Flag; Boolean) { }
+            }
+
+            keys
+            {
+                key(K; PK) { Clustered = true; }
+            }
+        }
+        """);
+
+        File.WriteAllText(Path.Combine(_root, "BrbCard.Page.al"), """
+        page 62391 "Brb Card"
+        {
+            PageType = Card;
+            SourceTable = "Brb Row";
+            ApplicationArea = All;
+            UsageCategory = Administration;
+
+            layout
+            {
+                area(Content)
+                {
+                    field(RecValue; Rec.Value) { ApplicationArea = All; }
+                    field(RecFlag; Rec.Flag) { ApplicationArea = All; }
+                }
+            }
+        }
+        """);
+
+        File.WriteAllText(Path.Combine(_root, "BrbTests.Codeunit.al"), """
+        codeunit 62392 "Brb Tests"
+        {
+            Subtype = Test;
+            TestPermissions = Disabled;
+
+            local procedure Seed(Flag: Boolean)
+            var
+                Row: Record "Brb Row";
+            begin
+                Row.DeleteAll();
+                Row.Init();
+                Row.PK := 'R1';
+                Row.Value := 'V';
+                Row.Flag := Flag;
+                Row.Insert();
+            end;
+
+            [Test]
+            procedure SetValueTrue_RecBoundBooleanControl_PersistsToTheRow()
+            var
+                Row: Record "Brb Row";
+                Card: TestPage "Brb Card";
+            begin
+                Seed(false);
+
+                Card.OpenEdit();
+                Card.First();
+                Card.RecFlag.SetValue(true);
+                if Card.RecFlag.AsBoolean() <> true then
+                    Error('the control must read back true immediately after SetValue(true)');
+                Card.Close();
+
+                Row.Get('R1');
+                if Row.Flag <> true then
+                    Error('SetValue(true) must persist Flag = true to the row, got %1', Row.Flag);
+            end;
+
+            [Test]
+            procedure SetValueFalse_RecBoundBooleanControl_ClearsAPreviouslyTrueField()
+            var
+                Row: Record "Brb Row";
+                Card: TestPage "Brb Card";
+            begin
+                Seed(true);
+
+                Card.OpenEdit();
+                Card.First();
+                Card.RecFlag.SetValue(false);
+                if Card.RecFlag.AsBoolean() <> false then
+                    Error('the control must read back false immediately after SetValue(false)');
+                Card.Close();
+
+                Row.Get('R1');
+                if Row.Flag <> false then
+                    Error('SetValue(false) must persist Flag = false to the row, got %1', Row.Flag);
+            end;
+
+            [Test]
+            procedure SetValue_NotABooleanSpelling_IsRejectedAndNotPersisted()
+            var
+                Row: Record "Brb Row";
+                Card: TestPage "Brb Card";
+            begin
+                Seed(false);
+                Commit();
+
+                Card.OpenEdit();
+                Card.First();
+                asserterror Card.RecFlag.SetValue('Maybe');
+                if StrPos(GetLastErrorText(), 'Maybe') = 0 then
+                    Error('expected the rejected value named in the error, got: %1', GetLastErrorText());
+                Card.Close();
+
+                Row.Get('R1');
+                if Row.Flag <> false then
+                    Error('a rejected value must not have been persisted to the row');
+            end;
+        }
+        """);
+    }
+
+    private (string output, int exit) RunBundled()
+    {
+        var args = new StringBuilder(
+            TestBuildConfig.RunArgs(ProjectPath) + TestBuildConfig.BcVersionArg + $" \"{_root}\"");
+        foreach (var a in ExtraPackageCacheArgs()) args.Append($" \"{a}\"");
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet", Arguments = args.ToString(),
+            RedirectStandardOutput = true, RedirectStandardError = true,
+            UseShellExecute = false, CreateNoWindow = true, WorkingDirectory = RepoRoot,
+        };
+        var sb = new StringBuilder();
+        var p = Process.Start(psi)!;
+        p.OutputDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.ErrorDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.BeginOutputReadLine();
+        p.BeginErrorReadLine();
+        if (!p.WaitForExit(600_000)) { try { p.Kill(true); } catch { } throw new TimeoutException("runner hung"); }
+        p.WaitForExit();
+        lock (sb) return (sb.ToString(), p.ExitCode);
+    }
+
+    /// <summary>
+    /// Both round-trip directions plus the negative: a Rec-bound Boolean control's
+    /// SetValue must actually reach the underlying table field (not just the control's own
+    /// in-memory copy), in both directions, and must reject text that is not a Boolean
+    /// spelling rather than silently coercing or crashing with an unrelated exception.
+    /// </summary>
+    [SkippableFact]
+    public void SetValue_RecBoundBooleanControl_RoundTripsAndRejectsInvalidText()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        WriteBundle();
+        var (output, exit) = RunBundled();
+
+        Assert.True(exit == 0, $"Expected the bundle to pass; exit={exit}\n{output}");
+        Assert.Contains("PASS  Codeunit62392.SetValueTrue_RecBoundBooleanControl_PersistsToTheRow", output);
+        Assert.Contains("PASS  Codeunit62392.SetValueFalse_RecBoundBooleanControl_ClearsAPreviouslyTrueField", output);
+        Assert.Contains("PASS  Codeunit62392.SetValue_NotABooleanSpelling_IsRejectedAndNotPersisted", output);
+        Assert.DoesNotContain("FAIL", output);
+    }
+}

--- a/AlRunner/Patches/MockTestPage.cs
+++ b/AlRunner/Patches/MockTestPage.cs
@@ -1188,8 +1188,10 @@ internal static class TestPageOptionValue
 }
 
 /// <summary>
-/// Boolean values as a TestPage sees them, on a page-variable-bound control
-/// (<c>field(Flag; ShowFlag)</c> where <c>ShowFlag: Boolean</c>).
+/// Boolean values as a TestPage sees them, on either shape of control: a page-variable-bound
+/// one (<c>field(Flag; ShowFlag)</c> where <c>ShowFlag: Boolean</c>) or a Rec-bound one
+/// (<c>field(Flag; Rec.Flag)</c> where the source table field is <c>Boolean</c>) — see issue
+/// #1870, the Rec-bound half of #1837 that #1869 (the page-variable half) left open.
 ///
 /// <c>NavTestField.ALSetValue</c> — the real, precompiled BC method the AL compiler emits for
 /// every <c>TestPage.&lt;field&gt;.SetValue(&lt;Boolean&gt;)</c> call — never hands a NavValue
@@ -1198,7 +1200,9 @@ internal static class TestPageOptionValue
 /// <c>NavValueMetadata</c>) and then <see cref="ITestField.ValueToString"/> (both OUR OWN mock
 /// methods) to turn the boolean back into a string before ever reaching <see cref="ITestField.Value"/>'s
 /// setter — see the doc comment on <see cref="PageVariableTestField.FieldType"/> for why that
-/// matters here.
+/// matters here. <see cref="LiveNavTestField.FieldType"/> is sourced from the source table
+/// field's own declared type instead, but reaches the same <c>NavType.Boolean</c> answer for a
+/// <c>Boolean</c> field, so the round trip is identical on both sides.
 ///
 /// Because both ends of that round trip are code THIS runner owns (<see cref="ITestField.ValueToString"/>
 /// always answers with <c>Convert.ToString(boolValue)</c>, i.e. exactly "True" or "False"), accepting
@@ -1263,10 +1267,20 @@ internal sealed class LiveNavTestField : ITestField
                ?? string.Empty;
         set
         {
+            // Issue #1870 — the Rec-bound half of #1837 that #1869 (the page-variable half)
+            // left open. FieldType (sourced from the source table field's own declared type,
+            // see TryGetMetaFieldType) answers Boolean for a `field(Flag; Rec.Flag)` control
+            // over a `Boolean` table field; falling through to ALCompiler.ToNavValue(value)
+            // there always produced a NavText, which NavTestField.ALSetValue's own Boolean
+            // ALValidateAsync then rejected with "The value 'True' can't be evaluated into
+            // type Boolean" — the same shape of bug TestPageBooleanValue already fixed for
+            // PageVariableTestField.
             var navValue = CurrentOption() is { } option
                 ? TestPageOptionValue.Resolve(option, value, OptionCaptions(),
                     $"TestPage SetValue (field {_fieldNo})")
-                : ALCompiler.ToNavValue(value);
+                : FieldType == NavType.Boolean
+                    ? TestPageBooleanValue.Resolve(value, $"TestPage SetValue (field {_fieldNo})")
+                    : ALCompiler.ToNavValue(value);
 
             // Setting a field on a page is a VALIDATE, not an assignment. That is what fills in
             // the caption when a user picks an id, and what lets a field refuse a value outright.


### PR DESCRIPTION
Closes #1870

## Problem

`TestPage.<field>.SetValue(<Boolean>)` still failed when the control is bound directly to a **record field** (`field(RecFlag; Rec.Flag)`), as opposed to a page variable (`field(VarFlag; ShowDynamic)`) — the case #1869 already fixed. The Rec-bound path threw:

```
NavNCLEvaluateException: The value "True" can't be evaluated into type Boolean.
```

## Root cause

`AlRunner/Patches/MockTestPage.cs`, `LiveNavTestField.Value`'s setter (the Rec-bound sibling of `PageVariableTestField`) special-cased `NavOption` but fell through to `ALCompiler.ToNavValue(value)` for everything else, which always produces a `NavText`. `NavTestField.ALSetValue` — the precompiled BC method the AL compiler emits for `SetValue` — then hands that `NavText("True")` to `ALValidateAsync` against a `Boolean` field, and BC's own evaluate rejects the literal string the same way it would reject it in AL source.

## Fix

`FieldType` already reports the real underlying `NavType` for a Rec-bound control (`TryGetMetaFieldType`, sourced from the source table field's own declared type). The setter now routes through the existing `TestPageBooleanValue.Resolve` helper — the same one #1869 introduced for the page-variable-bound path — whenever `FieldType == NavType.Boolean`, exactly mirroring that fix.

## What real BC accepts for a Boolean control

Per the #1869 investigation (still valid here, since `TestPageBooleanValue` is unchanged and shared by both paths): `NavTestField.ALSetValue`'s round trip goes through `ITestField.FieldType`/`ITestField.ValueToString`, both of which are the runner's own mock methods. `ValueToString` always answers `Convert.ToString(boolValue)` — exactly `"True"`/`"False"`. Accepting only that spelling is therefore not a narrowing of what `SetValue(Boolean)` can express: it is the only spelling that overload ever produces. Whether real BC's own text-to-Boolean evaluate accepts other spellings (`"Yes"`/`"No"`, `"1"`/`"0"`, locale forms) on this surface is a separate, upstream-unvalidated question — out of scope here, and still throws `RunnerOutOfScopeException` naming `testpage-boolean-value` for anything else, per `loud-failures.md`.

## Testing

**RED → GREEN, two ways:**

1. `AlRunner.Tests/TestPageBooleanRecBoundDispatchTests.cs` — a runner-mechanism test that spawns the runner against a self-contained bundle reproducing the issue's own reproducer. Reverting the `FieldType == NavType.Boolean` branch reproduces the exact reported `NavNCLEvaluateException` (verified locally).
2. An upstream corpus PR proving the same round trip against a real BC service tier — branch `agent/impl-11/issue-1870-rec-bound-boolean-setvalue` pushed to `StefanMaron/BusinessCentral.AL.Language.Tests` (not opened as a PR by me, per `bc-behavior-tests-go-upstream.md` — the orchestrator reviews and merges corpus PRs). Adds `TP Boolean Rec Bound Row`/`Card`/`Tests` (codeunits 60995-60997): `SetValue(true)`/`SetValue(false)` both round-trip and persist to the underlying record after `Close()`, an unrelated sibling field is untouched, and a non-Boolean text is rejected (naming the value) without being persisted. Verified locally by pointing this repo's runner at that corpus branch directly (not via the pinned submodule) — RED before the fix, GREEN after, full corpus (2081/2081) unaffected.

Also ran the full `tests/al-language` corpus against this fix (pointed at the local submodule checkout, not the corpus branch) to check for regressions in shared `LiveNavTestField` plumbing: 2081/2081 pass, no regressions.

No `tests/al-language` submodule pin change in this PR (verified: `git ls-tree origin/main tests/al-language` unchanged). No `count-baseline` bump needed — neither the `al-language` nor `runner-extras` suite's counts changed.