### PR TITLE
chore: bump tests/al-language submodule pin to eb300810

### DIFF
--- a/AlRunner/Patches/MethodScopePatches.cs
+++ b/AlRunner/Patches/MethodScopePatches.cs
@@ -245,11 +245,38 @@ public static partial class BcRuntime
         try { body(); }
         catch (Exception ex)
         {
-            // Store the caught exception in skeleton session.lastException so that
-            // ALSystemErrorHandling.get_ALGetLastErrorText (and the patched override
+            // Real BC's own AssertError body (decompiled) is:
+            //
+            //     try { body(); }
+            //     catch (Exception ex) when (RemapToALExceptionAndThrow(ex, out mapped)) { throw mapped; }
+            //     ...
+            //     catch (NavBaseException) { session.Rollback(); return; }
+            //
+            // i.e. it ALWAYS passes the caught exception through the real, unmodified
+            // NavMethodScope.RemapToALExceptionAndThrow(Exception, out NavALException) before
+            // deciding pass/fail. For most exception types that only rewraps the same
+            // `.Message` text (DivideByZeroException, IndexOutOfRangeException,
+            // FormatException, OverflowException) so skipping it was harmless. But for
+            // NavMetadataNotFoundException it produces a DIFFERENT message — "You tried to
+            // invoke the {type} object with the ID {id} from the object {caller}. ..."
+            // (Lang.ObjectNotFoundError) — naming the calling AL object, instead of the raw
+            // "The metadata object {type} {id} was not found" NavMetadataNotFoundException
+            // carries. A static Page.RunModal(0, Record) on a table with no LookupPageId hits
+            // exactly this: real BC's error names the page id and caller, ours (without this
+            // remap) leaked the generic metadata-lookup message instead.
+            //
+            // RemapToALExceptionAndThrow is real BC's own method body (not Cecil-rewritten,
+            // not a runner reimplementation) — call it via reflection on the real `self` so we
+            // reuse it exactly rather than re-deriving the message text ourselves. Best-effort:
+            // if invoking it throws (e.g. some scope-internal state the skeleton never
+            // populates), fall back to the original exception unchanged, matching this
+            // method's prior behaviour.
+            var effectiveEx = TryRemapToALException(self, ex) ?? ex;
+            // Store the (possibly remapped) exception in skeleton session.lastException so
+            // that ALSystemErrorHandling.get_ALGetLastErrorText (and the patched override
             // in MiscPatches) can return its message — Assert.ExpectedError / Library
             // Assert depend on this round-trip.
-            StoreLastExceptionOnSkeletonSession(ex);
+            StoreLastExceptionOnSkeletonSession(effectiveEx);
             // BC's own AssertError ends its catch with session.Rollback(): an AL error
             // unwinds the database to the last COMMIT. This replacement exists because the
             // real body's rollback path NREs on the skeleton session, not because the
@@ -258,6 +285,36 @@ public static partial class BcRuntime
             return; /* asserterror passed: body threw something */
         }
         throw new Microsoft.Dynamics.Nav.Types.Exceptions.NavNCLAssertErrorException();
+    }
+
+    private static System.Reflection.MethodInfo? _mRemapToALExceptionAndThrow;
+
+    /// <summary>
+    /// Best-effort invocation of the real, unmodified NavMethodScope.RemapToALExceptionAndThrow
+    /// (internal bool RemapToALExceptionAndThrow(Exception, out NavALException)) on the actual
+    /// scope instance. Returns the mapped exception real BC would have thrown, or null if the
+    /// method declined to remap (returned false) or the reflective call itself failed.
+    /// </summary>
+    private static Exception? TryRemapToALException(object self, Exception ex)
+    {
+        try
+        {
+            _mRemapToALExceptionAndThrow ??= self.GetType().GetMethod(
+                "RemapToALExceptionAndThrow",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            if (_mRemapToALExceptionAndThrow == null) return null;
+
+            var args = new object?[] { ex, null };
+            var remapped = (bool)_mRemapToALExceptionAndThrow.Invoke(self, args)!;
+            return remapped ? args[1] as Exception : null;
+        }
+        catch
+        {
+            // Reflective call failed (e.g. some scope-internal state the skeleton doesn't
+            // populate for this scope type) — fall back to the original exception, exactly
+            // this method's behaviour before this fix existed.
+            return null;
+        }
     }
 
     private static System.Reflection.FieldInfo? _fSessLastException;

--- a/tests/expectations/count-baseline/test-count-baseline.json
+++ b/tests/expectations/count-baseline/test-count-baseline.json
@@ -2,7 +2,7 @@
   "_comment": "Consumed by --count-baseline (AlRunner/Infrastructure/CountBaseline.cs), a DIFFERENT schema from the oos-/known-gaps-/divergence-/disabled- files in this directory: those declare the expected CLASSIFICATION of one named test, this declares the expected EXACT COUNT of a whole suite -- an exact match, not a floor: a mismatch in EITHER direction (drop OR growth) fails the run (exit 4). See #1880 and PR #1882's review for why growth is also a hard failure, not just a notice. Suite keys are the basename of the bundle directory CI passes on the command line (tests/al-language/tests/al-language -> 'al-language', tests/runner-extras -> 'runner-extras'), matching the '--out <name>-results.json' convention CI already uses. Values below are read off actual Test Matrix CI runs (see PR discussion for run URLs), not guessed: al-language's 2073->2076 bump reflects 3 corpus tests merged upstream between when the local baseline was drafted and when CI first ran against it. runner-extras' appGroups 23->21 byBcVersion override on 27.0/27.3/27.5 is the SAME preprocessor-gated-surface split that already explains its tests count divergence: fewer AL surfaces compile pre-28.0, which drops whole app groups, not just individual tests within a group. ANY PR that changes a suite's test or app-group count -- growth included -- MUST bump the matching number here in the SAME PR, or that PR's CI goes red with a [count-baseline] DROP or GROWTH diagnostic naming the exact expected/actual numbers to use.",
   "suites": {
     "al-language": {
-      "tests": { "default": 2076 },
+      "tests": { "default": 2087 },
       "appGroups": { "default": 1 }
     },
     "runner-extras": {


### PR DESCRIPTION
## What

Bumps `tests/al-language` from `848831aa` to upstream `master` `eb300810`. Pulls in four upstream corpus files, all written this session as the proving tests for runner fixes already merged here:

| Upstream | Runner fix already merged | New `[Test]`s |
|---|---|---|
| #47 static `Page.RunModal(id, Record)` reaches `[ModalPageHandler]` | #1919 | 2 |
| #48 `Page.RunModal(0, Record)` resolves via the table's `LookupPageId` | #1926 | 2 |
| #49 report `GetFilter()` in `OnPreReport`/`OnPreDataItem` | #1927 | 3 |
| #50 `Page.RunModal` on a page with an Enum-typed global variable control | #1929 + #1932 | 4 |

None of the ten new/changed files carry `BC27PLUS`/`BC28PLUS` preprocessor guards, so the +11 test-count delta is expected to hold identically across all 8 BC-version legs — no `byBcVersion` override needed for `al-language` (there is none today).

## Test-count delta

`tests/expectations/count-baseline/test-count-baseline.json`: `al-language.tests.default` `2076 -> 2087` (+11, read off an actual local run — see below, not guessed).

## Result: 3 commits, not 2

Running the full corpus against the new pin (BC 27.0, `--package-cache` pointed at a local 27.0 platform-apps cache) surfaced exactly **one** failure out of 2087:

```
FAIL  Codeunit60997.RunModal_ById0_TableWithNoLookupPageId_IsRefused
NavNCLDialogException: Assert.ExpectedError failed.
  Expected: You tried to invoke the Page object with the ID 0
  Actual:   The metadata object Page 0 was not found. The application might be
            incompatible with the current compiler. Please unpublish the
            application that contains the application object Page 0 and
            republish it. Or, run a technical upgrade of the application
            database with the 'Force' flag set.
```

**Root cause (confirmed by decompiling the shipped `Microsoft.Dynamics.Nav.Ncl.dll`/`.Types.dll`/`.Language.dll`, not guessed):** real BC's `NavMethodScope.AssertError(Action)` always routes the caught exception through its own `RemapToALExceptionAndThrow(Exception, out NavALException)` before deciding asserterror pass/fail. For a `NavMetadataNotFoundException` that remap replaces the generic "metadata object not found" text with a caller-aware message — `Lang.ObjectNotFoundError`, "You tried to invoke the {type} object with the ID {id} from the object {caller}. ..." — read straight out of the `Microsoft.Dynamics.Nav.Language.dll` resource table.

The runner's `NavMethodScope_AssertError` (`AlRunner/Patches/MethodScopePatches.cs`) is a full Cecil replacement for BC's own body — needed because the real body's `session.Rollback()` NREs on the skeleton session — and it never called that remap step, so the raw, unremapped message leaked through. `RemapToALExceptionAndThrow` itself is real, unmodified BC framework code (not Cecil-rewritten); the fix calls it via reflection on the live scope instance so the message text is BC's own, with a best-effort fallback to the original exception if the reflective call fails for any reason.

Classification: **small, obviously-correct runner fix** (a gap in an existing Cecil replacement, not a new capability) — landed in this PR rather than deferred to `expect-fail-known-gap`, since `RunModal_ById0_TableWithNoLookupPageId_IsRefused` *is* the RED -> GREEN proof for it.

After the fix: **2087/2087 pass** on BC 27.0 (`pass-oos: 2`, `pass-known-gap: 1`, `pass-divergence: 1` — all four pre-existing expectation entries, unrelated to this bump, no drift in either direction).

**All four of the session's fixes (#1919, #1926, #1927, #1929+#1932) now pass from the corpus itself**, not from runner-local copies — including #1929's enum-`SetValue`-by-member-name assertion, the one the task flagged as the reason this bump matters.

## Local verification

- `dotnet build AlRunner.slnx -c Release` — clean.
- `dotnet run --project AlRunner -c Release -- --package-cache ~/.al-runner/platform-apps tests/al-language/tests/al-language` — BC 27.0: 2087/2087 pass, 0 fail, 0 error (post-fix).
- BC 28.0 local run hit an unrelated local provisioning gap (stale `test-apps`/`_BCVersion` mismatch in this environment, not reproducible from the diff) — not chased further; CI's matrix is the authoritative cross-version check, and the absence of any preprocessor guard in the new files makes a per-leg count difference unlikely.
- Did not run `AlRunner.Tests` or `tests/runner-extras` locally end-to-end (environment-specific BC-artifact/test-app mismatches unrelated to this change); the change is narrowly scoped to one AssertError-remap helper and is proven by the corpus run above. CI's 8-leg matrix covers both.

## Known flake (not hit this run)

Watching for [`StefanMaron/BusinessCentral.AL.Language.Tests#39`](https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/issues/39) — codeunit 60942 `CFV Tests` intermittently aborting the BC 28.3 leg. Did not occur in the local 27.0 run.