### PR TITLE
perf(boot): remove ~18s of fixed per-invocation overhead (GetTypes scan, install-baseline reseed, manifest re-reads)

### DIFF
--- a/AlRunner.Tests/AppLoaderManifestCacheTests.cs
+++ b/AlRunner.Tests/AppLoaderManifestCacheTests.cs
@@ -1,0 +1,293 @@
+// AppLoaderManifestCacheTests — proves AppLoader.ReadManifest's two-level cache (issue
+// #perf-B): an in-process memo, and — on a memo miss — a small on-disk index under
+// CacheRoots.Resolve("app-manifests"), both keyed by (full path, length, last-write-time
+// UTC) rather than a content hash (hashing a 98MB Base Application .app just to answer
+// "have I seen this file before" would reintroduce the exact cost this cache exists to
+// avoid).
+//
+// Decisive proof, not just "returns something": every positive assertion below is paired
+// with AppLoader.ManifestParseInvocationCountForTests(appPath), the same
+// "did a REAL parse happen" counter pattern BcAppSymbolCacheContentAddressedKeyTests uses
+// for BcAppSymbolCache. A test asserting only that the returned manifest looks right would
+// pass against an implementation that quietly reparses every time (correct but not the
+// perf fix); the counter is what tells "served from cache" apart from "reparsed to the
+// same answer".
+using System.IO.Compression;
+using System.Text;
+using AlRunner.Infrastructure;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+// AppLoader's manifest memo + CacheRoots override are both process-wide mutable static
+// state — joins CacheRootsSerialCollection alongside CacheRootsTests/BcAppSymbolCache*Tests
+// so this class's CacheRoots.SetOverride calls never race another collection's (see that
+// collection's header for the full rationale).
+[Collection(CacheRootsSerialCollection.Name)]
+public sealed class AppLoaderManifestCacheTests
+{
+    private static string NewTempDir(string suffix)
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "app-loader-manifest-cache-tests-" + suffix + "-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    /// <summary>Writes a minimal NAVX .app (header + ZIP with NavxManifest.xml), including
+    /// a dependency and Application/Platform attributes so every AppManifest field the
+    /// on-disk payload must round-trip is actually exercised.</summary>
+    private static string WriteApp(
+        string dir, string fileName, Guid appId, string name, string publisher, string version,
+        Guid depId, string depName, string depPublisher, string depVersion,
+        string application, string platform)
+    {
+        var xml = $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <Package xmlns="http://schemas.microsoft.com/navx/2015/manifest">
+              <App Id="{appId}" Name="{name}" Publisher="{publisher}" Version="{version}"
+                   Application="{application}" Platform="{platform}"/>
+              <Dependencies>
+                <Dependency Id="{depId}" Name="{depName}" Publisher="{depPublisher}" MinVersion="{depVersion}"/>
+              </Dependencies>
+            </Package>
+            """;
+
+        using var ms = new MemoryStream();
+        using (var zip = new ZipArchive(ms, ZipArchiveMode.Create, leaveOpen: true))
+        {
+            var entry = zip.CreateEntry("NavxManifest.xml");
+            using var es = entry.Open();
+            es.Write(Encoding.UTF8.GetBytes(xml));
+        }
+        var zipBytes = ms.ToArray();
+
+        // NAVX wrapper: magic "NAVX" + LE uint32 ZIP offset (8) + ZIP bytes.
+        var result = new byte[8 + zipBytes.Length];
+        result[0] = (byte)'N'; result[1] = (byte)'A'; result[2] = (byte)'V'; result[3] = (byte)'X';
+        BitConverter.TryWriteBytes(result.AsSpan(4, 4), (uint)8);
+        zipBytes.CopyTo(result, 8);
+
+        var appPath = Path.Combine(dir, fileName);
+        File.WriteAllBytes(appPath, result);
+        return appPath;
+    }
+
+    /// <summary>Deep field-by-field comparison — AppManifest is a record, but its
+    /// Dependencies list does NOT get structural equality from the record's own
+    /// auto-generated Equals (List&lt;T&gt; has reference equality), so a plain
+    /// Assert.Equal(a, b) would not actually prove the dependency list round-tripped.</summary>
+    private static void AssertManifestEqual(AppManifest expected, AppManifest actual)
+    {
+        Assert.Equal(expected.Publisher, actual.Publisher);
+        Assert.Equal(expected.Name, actual.Name);
+        Assert.Equal(expected.Version, actual.Version);
+        Assert.Equal(expected.AppId, actual.AppId);
+        Assert.Equal(expected.Application, actual.Application);
+        Assert.Equal(expected.Platform, actual.Platform);
+        Assert.Equal(expected.Dependencies.Count, actual.Dependencies.Count);
+        for (int i = 0; i < expected.Dependencies.Count; i++)
+        {
+            Assert.Equal(expected.Dependencies[i].AppId, actual.Dependencies[i].AppId);
+            Assert.Equal(expected.Dependencies[i].Name, actual.Dependencies[i].Name);
+            Assert.Equal(expected.Dependencies[i].Publisher, actual.Dependencies[i].Publisher);
+            Assert.Equal(expected.Dependencies[i].Version, actual.Dependencies[i].Version);
+            Assert.Equal(expected.Dependencies[i].Optional, actual.Dependencies[i].Optional);
+        }
+    }
+
+    /// <summary>
+    /// THE decisive positive test: three ReadManifest() calls for the SAME file — a cold
+    /// call (memo empty, disk empty: a genuine parse), a call with only the in-process memo
+    /// cleared (must be served from the on-disk index), and a call with nothing cleared
+    /// (must be served from the in-process memo) — all return content that agrees on every
+    /// field, and only the FIRST call is a genuine parse.
+    /// </summary>
+    [Fact]
+    public void ReadManifest_MemoDiskAndFreshParse_AllProduceIdenticalContentAndOnlyOneRealParse()
+    {
+        var cacheRoot = NewTempDir("cache");
+        var srcDir = NewTempDir("src");
+        CacheRoots.SetOverride(cacheRoot);
+        AppLoader.ResetManifestMemoForTests();
+        try
+        {
+            var appId = Guid.NewGuid();
+            var depId = Guid.NewGuid();
+            var appPath = WriteApp(srcDir, "app.app", appId, "My App", "My Publisher", "1.2.3.4",
+                depId, "My Dep", "Dep Publisher", "5.6.7.8", "24.0.0.0", "25.0.0.0");
+
+            Assert.Equal(0, AppLoader.ManifestParseInvocationCountForTests(appPath));
+
+            // 1. Cold: memo empty, disk empty -> genuine parse.
+            var fresh = AppLoader.ReadManifest(appPath);
+            Assert.NotNull(fresh);
+            Assert.Equal(1, AppLoader.ManifestParseInvocationCountForTests(appPath));
+            Assert.Equal("My App", fresh!.Name);
+            Assert.Equal("My Publisher", fresh.Publisher);
+            Assert.Equal(new Version(1, 2, 3, 4), fresh.Version);
+            Assert.Equal(appId, fresh.AppId);
+            Assert.Equal(new Version(24, 0, 0, 0), fresh.Application);
+            Assert.Equal(new Version(25, 0, 0, 0), fresh.Platform);
+            Assert.Single(fresh.Dependencies);
+            Assert.Equal(depId, fresh.Dependencies[0].AppId);
+            Assert.Equal("My Dep", fresh.Dependencies[0].Name);
+            Assert.Equal("Dep Publisher", fresh.Dependencies[0].Publisher);
+            Assert.Equal(new Version(5, 6, 7, 8), fresh.Dependencies[0].Version);
+
+            // The on-disk index must now exist for this exact key.
+            var indexPath = AppLoader.ManifestIndexPathForTests(appPath);
+            Assert.True(File.Exists(indexPath));
+
+            // 2. Clear ONLY the in-process memo -> must be served from the on-disk index,
+            //    not a second parse.
+            AppLoader.ResetManifestMemoForTests();
+            var fromDisk = AppLoader.ReadManifest(appPath);
+            Assert.NotNull(fromDisk);
+            Assert.Equal(1, AppLoader.ManifestParseInvocationCountForTests(appPath)); // still 1 — no reparse
+            AssertManifestEqual(fresh, fromDisk!);
+
+            // 3. Call again with NOTHING cleared -> must be served from the in-process memo.
+            var fromMemo = AppLoader.ReadManifest(appPath);
+            Assert.NotNull(fromMemo);
+            Assert.Equal(1, AppLoader.ManifestParseInvocationCountForTests(appPath)); // still 1
+            AssertManifestEqual(fresh, fromMemo!);
+        }
+        finally
+        {
+            CacheRoots.ResetForTests();
+            AppLoader.ResetManifestMemoForTests();
+            Directory.Delete(cacheRoot, recursive: true);
+            Directory.Delete(srcDir, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// A file touched to a materially different mtime (or size) at the SAME path must be
+    /// reparsed, never served the stale cached content — even though nothing about the
+    /// PATH changed. This is what "keyed by length+mtime, not just path" buys: a package
+    /// re-downloaded/rebuilt in place is picked up, not silently ignored.
+    /// </summary>
+    [Fact]
+    public void ReadManifest_TouchedMtime_IsReparsedNotServedStale()
+    {
+        var cacheRoot = NewTempDir("cache");
+        var srcDir = NewTempDir("src");
+        CacheRoots.SetOverride(cacheRoot);
+        AppLoader.ResetManifestMemoForTests();
+        try
+        {
+            var appId = Guid.NewGuid();
+            var depId = Guid.NewGuid();
+            var appPath = WriteApp(srcDir, "app.app", appId, "V1 Name", "Pub", "1.0.0.0",
+                depId, "Dep", "DepPub", "1.0.0.0", "1.0.0.0", "1.0.0.0");
+
+            var v1 = AppLoader.ReadManifest(appPath);
+            Assert.Equal("V1 Name", v1!.Name);
+            Assert.Equal(1, AppLoader.ManifestParseInvocationCountForTests(appPath));
+
+            // Overwrite the SAME path with genuinely different content, then force the
+            // mtime to something materially different (WriteApp's own File.WriteAllBytes
+            // already changes mtime on most filesystems, but pin it explicitly so the test
+            // is not filesystem-timestamp-resolution-dependent).
+            var newAppId = Guid.NewGuid();
+            WriteApp(srcDir, "app.app", newAppId, "V2 Name", "Pub", "2.0.0.0",
+                depId, "Dep", "DepPub", "1.0.0.0", "1.0.0.0", "1.0.0.0");
+            File.SetLastWriteTimeUtc(appPath, DateTime.UtcNow.AddDays(1));
+
+            // Even with the in-process memo still warm (NOT reset), the new stat must miss
+            // the old memo key and reparse.
+            var v2 = AppLoader.ReadManifest(appPath);
+            Assert.NotNull(v2);
+            Assert.Equal("V2 Name", v2!.Name);
+            Assert.Equal(newAppId, v2.AppId);
+            Assert.Equal(2, AppLoader.ManifestParseInvocationCountForTests(appPath)); // reparsed, not stale
+        }
+        finally
+        {
+            CacheRoots.ResetForTests();
+            AppLoader.ResetManifestMemoForTests();
+            Directory.Delete(cacheRoot, recursive: true);
+            Directory.Delete(srcDir, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// A corrupt/unreadable on-disk index entry must never propagate a wrong answer or
+    /// throw — it is silently (well, verbose-logged) ignored, and the caller falls through
+    /// to a fresh, correct reparse. Loud-failures.md's "a cache that falls back to
+    /// recomputing on miss/corruption is fine" clause, applied to this cache.
+    /// </summary>
+    [Fact]
+    public void ReadManifest_CorruptIndexEntry_IsIgnoredAndReparsed()
+    {
+        var cacheRoot = NewTempDir("cache");
+        var srcDir = NewTempDir("src");
+        CacheRoots.SetOverride(cacheRoot);
+        AppLoader.ResetManifestMemoForTests();
+        try
+        {
+            var appId = Guid.NewGuid();
+            var depId = Guid.NewGuid();
+            var appPath = WriteApp(srcDir, "app.app", appId, "Real Name", "Pub", "3.0.0.0",
+                depId, "Dep", "DepPub", "1.0.0.0", "1.0.0.0", "1.0.0.0");
+
+            var first = AppLoader.ReadManifest(appPath);
+            Assert.Equal("Real Name", first!.Name);
+            Assert.Equal(1, AppLoader.ManifestParseInvocationCountForTests(appPath));
+
+            // Corrupt the exact on-disk index entry this file's current stat maps to.
+            var indexPath = AppLoader.ManifestIndexPathForTests(appPath);
+            Assert.True(File.Exists(indexPath));
+            File.WriteAllText(indexPath, "{ not valid json this is garbage !!! ");
+
+            // Memo cleared so the corrupted disk entry is actually consulted, not skipped.
+            AppLoader.ResetManifestMemoForTests();
+            var second = AppLoader.ReadManifest(appPath);
+
+            Assert.NotNull(second);
+            Assert.Equal("Real Name", second!.Name);
+            Assert.Equal(appId, second.AppId);
+            // The corrupt entry forced a genuine reparse — never a null, never a throw, never
+            // a silently wrong answer.
+            Assert.Equal(2, AppLoader.ManifestParseInvocationCountForTests(appPath));
+
+            // And the reparse must have repaired the index (self-healing): a THIRD call with
+            // the memo cleared again should now hit the disk index without reparsing.
+            AppLoader.ResetManifestMemoForTests();
+            var third = AppLoader.ReadManifest(appPath);
+            Assert.NotNull(third);
+            Assert.Equal(2, AppLoader.ManifestParseInvocationCountForTests(appPath)); // no third reparse
+        }
+        finally
+        {
+            CacheRoots.ResetForTests();
+            AppLoader.ResetManifestMemoForTests();
+            Directory.Delete(cacheRoot, recursive: true);
+            Directory.Delete(srcDir, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// Negative control on ReadManifest's existing (pre-cache) contract: a missing file
+    /// still returns null, never throws — the memo/index machinery must not change this.
+    /// </summary>
+    [Fact]
+    public void ReadManifest_MissingFile_ReturnsNullNotThrow()
+    {
+        var cacheRoot = NewTempDir("cache");
+        CacheRoots.SetOverride(cacheRoot);
+        AppLoader.ResetManifestMemoForTests();
+        try
+        {
+            var missingPath = Path.Combine(Path.GetTempPath(), "app-loader-manifest-cache-tests-missing-" + Guid.NewGuid().ToString("N") + ".app");
+            var result = AppLoader.ReadManifest(missingPath);
+            Assert.Null(result);
+        }
+        finally
+        {
+            CacheRoots.ResetForTests();
+            AppLoader.ResetManifestMemoForTests();
+            Directory.Delete(cacheRoot, recursive: true);
+        }
+    }
+}

--- a/AlRunner.Tests/AppLoaderR2rChunkCacheTests.cs
+++ b/AlRunner.Tests/AppLoaderR2rChunkCacheTests.cs
@@ -1,0 +1,143 @@
+// AppLoaderR2rChunkCacheTests — proves AppLoader.ExtractAllDllPaths (issue #perf-B):
+// extracts a real R2R .app's publishedartifacts/*.dll chunks to a content-addressed cache
+// directory ONCE and returns file paths, instead of re-inflating the zip into byte[] on
+// every call the way ExtractAllDlls (still used internally on a cache MISS) does.
+//
+// Two decisive claims, each with its own proof:
+//   1. The chunk(s) written to the cache dir are IDENTICAL in content to what the existing
+//      byte[]-based ExtractAllDlls produces — proven via PE metadata identity (assembly
+//      name + MVID read straight off the bytes/file via System.Reflection.Metadata, the
+//      same low-risk technique RecordPatches.ReportMetadataVirtualTable.cs already uses
+//      for report-id pre-warming) rather than Assembly.Load, which would load a real BC
+//      platform assembly into THIS test process's default ALC twice over and risk
+//      polluting shared AppDomain state other tests in the same collection depend on.
+//   2. A second ExtractAllDllPaths call for the SAME file is a genuine cache HIT, not a
+//      re-extract that happens to produce the same files — proven via
+//      AppLoader.R2rExtractInvocationCountForTests, the same "did real work actually
+//      happen" counter pattern BcAppSymbolCache/AppLoaderManifestCacheTests use.
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using AlRunner.Infrastructure;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+// CacheRoots is process-wide mutable static state (see CacheRootsSerialCollection's header).
+[Collection(CacheRootsSerialCollection.Name)]
+public sealed class AppLoaderR2rChunkCacheTests
+{
+    private static (string? Name, Guid Mvid)? ReadPeIdentity(Stream peStream)
+    {
+        try
+        {
+            using var reader = new PEReader(peStream, PEStreamOptions.LeaveOpen);
+            if (!reader.HasMetadata) return null;
+            var mr = reader.GetMetadataReader();
+            var asmDef = mr.GetAssemblyDefinition();
+            var name = mr.GetString(asmDef.Name);
+            var mvid = mr.GetGuid(mr.GetModuleDefinition().Mvid);
+            return (name, mvid);
+        }
+        catch { return null; }
+    }
+
+    private static List<(string? Name, Guid Mvid)> ReadPeIdentitiesFromBytes(IReadOnlyList<byte[]> dlls)
+    {
+        var result = new List<(string?, Guid)>();
+        foreach (var dll in dlls)
+        {
+            using var ms = new MemoryStream(dll, writable: false);
+            var id = ReadPeIdentity(ms);
+            Assert.NotNull(id);
+            result.Add(id!.Value);
+        }
+        return result.OrderBy(x => x.Item1, StringComparer.Ordinal).ToList();
+    }
+
+    private static List<(string? Name, Guid Mvid)> ReadPeIdentitiesFromPaths(IReadOnlyList<string> paths)
+    {
+        var result = new List<(string?, Guid)>();
+        foreach (var path in paths)
+        {
+            using var fs = File.OpenRead(path);
+            var id = ReadPeIdentity(fs);
+            Assert.NotNull(id);
+            result.Add(id!.Value);
+        }
+        return result.OrderBy(x => x.Item1, StringComparer.Ordinal).ToList();
+    }
+
+    /// <summary>Finds a small-but-real R2R platform .app to keep the test fast — "Business
+    /// Foundation" is a single ~700KB publishedartifacts/*.dll chunk (verified locally),
+    /// unlike Base Application's ~98MB/5-chunk package.</summary>
+    private static string? FindSmallR2RPlatformApp(string platformDir)
+        => Directory.Exists(platformDir)
+            ? Directory.EnumerateFiles(platformDir, "*Business Foundation*.app").FirstOrDefault(AppLoader.IsR2R)
+            : null;
+
+    [SkippableFact]
+    public void ExtractAllDllPaths_MatchesExtractAllDllsByPeIdentity_AndSecondCallIsACacheHit()
+    {
+        var platformDir = TestArtifacts.PlatformAppsDir();
+        var appPath = FindSmallR2RPlatformApp(platformDir);
+        TestArtifacts.SkipIf(appPath == null,
+            $"No R2R 'Business Foundation' .app found under '{platformDir}' — provision platform apps first.");
+
+        var cacheRoot = Path.Combine(Path.GetTempPath(), "app-loader-r2r-chunk-cache-tests-" + Guid.NewGuid().ToString("N"));
+        CacheRoots.SetOverride(cacheRoot);
+        try
+        {
+            // Baseline identity: the existing byte[]-based extraction path (unchanged).
+            var byteDlls = AppLoader.ExtractAllDlls(appPath!);
+            Assert.NotEmpty(byteDlls);
+            var byteIdentities = ReadPeIdentitiesFromBytes(byteDlls);
+
+            Assert.Equal(0, AppLoader.R2rExtractInvocationCountForTests(appPath!));
+
+            // First ExtractAllDllPaths call: cache MISS, must genuinely extract.
+            var paths1 = AppLoader.ExtractAllDllPaths(appPath!);
+            Assert.Equal(byteDlls.Count, paths1.Count);
+            Assert.Equal(1, AppLoader.R2rExtractInvocationCountForTests(appPath!));
+            foreach (var p in paths1) Assert.True(File.Exists(p), $"expected cached chunk at {p}");
+
+            // Claim 1: same PE identity (name + MVID) as the byte[] path — the cached copy
+            // is genuinely the same content, not a placeholder or truncated write.
+            var pathIdentities1 = ReadPeIdentitiesFromPaths(paths1);
+            Assert.Equal(byteIdentities, pathIdentities1);
+
+            // Claim 2: a second call for the SAME file is a cache HIT — no re-extract, same
+            // file paths returned, and the completion marker + every chunk file are intact.
+            var paths2 = AppLoader.ExtractAllDllPaths(appPath!);
+            Assert.Equal(1, AppLoader.R2rExtractInvocationCountForTests(appPath!)); // still 1 — no re-extract
+            Assert.Equal(paths1.OrderBy(p => p, StringComparer.Ordinal),
+                         paths2.OrderBy(p => p, StringComparer.Ordinal));
+            foreach (var p in paths2) Assert.True(File.Exists(p));
+
+            var pathIdentities2 = ReadPeIdentitiesFromPaths(paths2);
+            Assert.Equal(byteIdentities, pathIdentities2);
+        }
+        finally
+        {
+            CacheRoots.ResetForTests();
+            if (Directory.Exists(cacheRoot)) Directory.Delete(cacheRoot, recursive: true);
+        }
+    }
+
+    [SkippableFact]
+    public void ExtractAllDllPaths_UnknownOrNonR2RFile_ReturnsEmpty()
+    {
+        var cacheRoot = Path.Combine(Path.GetTempPath(), "app-loader-r2r-chunk-cache-tests-" + Guid.NewGuid().ToString("N"));
+        CacheRoots.SetOverride(cacheRoot);
+        try
+        {
+            var missing = Path.Combine(Path.GetTempPath(), "does-not-exist-" + Guid.NewGuid().ToString("N") + ".app");
+            var result = AppLoader.ExtractAllDllPaths(missing);
+            Assert.Empty(result);
+        }
+        finally
+        {
+            CacheRoots.ResetForTests();
+            if (Directory.Exists(cacheRoot)) Directory.Delete(cacheRoot, recursive: true);
+        }
+    }
+}

--- a/AlRunner.Tests/AssemblyTypeIndexTests.cs
+++ b/AlRunner.Tests/AssemblyTypeIndexTests.cs
@@ -1,0 +1,410 @@
+// AssemblyTypeIndexTests — the proving tests for the metadata-backed type/subscriber lookup
+// that replaced Assembly.GetTypes() across the runner's boot path.
+//
+// The claim being proven is NOT "the new scan finds some subscribers". It is "the new scan
+// finds EXACTLY the same subscribers the old reflection scan found, on the same assemblies".
+// So every test here diffs the new mechanism against the OLD one
+// (EventSubscriberPatches.LegacyReflectionScan, kept verbatim for this purpose) rather than
+// against a hand-written expectation that could quietly encode the new code's own bugs:
+//
+//   * In-process, on synthetic assemblies (this file) — covers both shapes of custom-attribute
+//     constructor handle the metadata reader has to understand: a MethodDefinition (attribute
+//     applied inside its own defining assembly) and a MemberReference (attribute applied in an
+//     assembly that references the definer, which is the real BC shape —
+//     NavEventSubscriberAttribute lives in Ncl and is applied in AL-emitted assemblies).
+//     Also covers arity-disambiguated overloads, nested types, prefix gating, and the
+//     negatives: a non-"Codeunit" type contributes nothing, an un-attributed method
+//     contributes nothing, a missing name resolves to null.
+//
+//   * Out-of-process, on the REAL Base Application + System Application (see
+//     EventSubscriberScanEquivalenceTests below) — the only place the ~3,400-subscriber claim
+//     can honestly be made, since those assemblies only exist inside a real runner invocation.
+//
+// Would these still pass against a gutted implementation? No: an AssemblyTypeIndex that
+// returned nothing fails the positive assertions AND the set-equality against the legacy scan;
+// one that returned everything fails the negatives.
+
+using System.Diagnostics;
+using System.Reflection;
+using System.Text;
+using System.Text.RegularExpressions;
+using AlRunner.Infrastructure;
+using AlRunner.Patches;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+[Collection(BcEngineCollection.Name)]
+public sealed class AssemblyTypeIndexTests
+{
+    /// <summary>The attribute type + a few decoys, in their own assembly. Applying the
+    /// attribute HERE makes its CustomAttribute constructor a MethodDefinition handle.</summary>
+    private const string DefinerSource = """
+        using System;
+        namespace Fx.Defs
+        {
+            public sealed class NavEventSubscriberAttribute : Attribute
+            {
+                public NavEventSubscriberAttribute(int objectType, int objectId, string methodName) { }
+            }
+
+            public class Codeunit90001
+            {
+                [NavEventSubscriber(1, 18, "OnAfterInsertEvent")]
+                public void HandleInsert() { }
+
+                [NavEventSubscriber(1, 18, "OnAfterModifyEvent")]
+                internal static void HandleModify(int a, string b) { }
+
+                public void NotASubscriber() { }
+
+                public class OnFooEvent_Scope
+                {
+                    public class Deeper { }
+                }
+                public class Decoy_Scope { }
+            }
+
+            public class Record90001 { }
+            public class Record90002 { }
+            public class RecordNotNumeric { }
+
+            // Decoy: carries the attribute but is NOT a Codeunit* type, so the scan must skip it.
+            public class Helper90003
+            {
+                [NavEventSubscriber(1, 18, "OnAfterInsertEvent")]
+                public void Ignored() { }
+            }
+        }
+
+        // Deliberately in the global namespace and carrying two attributed overloads with the
+        // SAME name and DIFFERENT arity — the case the metadata scan disambiguates on the
+        // signature's parameter count.
+        public class Codeunit90002
+        {
+            [Fx.Defs.NavEventSubscriber(5, 42, "OnBar")]
+            public void HandleBar() { }
+
+            [Fx.Defs.NavEventSubscriber(5, 42, "OnBar")]
+            public void HandleBar(string only) { }
+        }
+        """;
+
+    /// <summary>A second assembly that REFERENCES the definer, so its attribute constructor is
+    /// a MemberReference into a TypeReference — the shape every AL-emitted BC assembly has.</summary>
+    private const string ConsumerSource = """
+        using Fx.Defs;
+        namespace Fx.Uses
+        {
+            public class Codeunit90101
+            {
+                [NavEventSubscriber(5, 99, "OnSomething")]
+                public void Handle() { }
+
+                public void Plain() { }
+            }
+
+            public class NotACodeunit90102
+            {
+                [NavEventSubscriber(5, 99, "OnSomething")]
+                public void Handle() { }
+            }
+        }
+        """;
+
+    private static byte[] Compile(string assemblyName, string source, params byte[][] references)
+    {
+        var refs = new List<MetadataReference>
+        {
+            MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+            MetadataReference.CreateFromFile(
+                Path.Combine(Path.GetDirectoryName(typeof(object).Assembly.Location)!, "System.Runtime.dll")),
+        };
+        foreach (var r in references) refs.Add(MetadataReference.CreateFromImage(r));
+
+        var compilation = CSharpCompilation.Create(
+            assemblyName,
+            new[] { CSharpSyntaxTree.ParseText(source) },
+            refs,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        using var ms = new MemoryStream();
+        var result = compilation.Emit(ms);
+        Assert.True(result.Success,
+            string.Join("; ", result.Diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error)));
+        return ms.ToArray();
+    }
+
+    /// <summary>
+    /// The definer alone, loaded the way DependencyLoader loads BC's R2R chunks — from a
+    /// byte[], with no file on disk and therefore an empty <c>Assembly.Location</c>. That is
+    /// precisely the case <c>AssemblyExtensions.TryGetRawMetadata</c> exists to cover, so the
+    /// tests below double as proof the index works on that shape.
+    /// </summary>
+    private static Assembly LoadDefinerFromBytes()
+        => Assembly.Load(Compile($"al-runner-ti-def-{Guid.NewGuid():N}", DefinerSource));
+
+    /// <summary>
+    /// Definer + consumer, both written to a temp directory and loaded with
+    /// <see cref="Assembly.LoadFrom(string)"/>.
+    ///
+    /// Deliberately NOT Assembly.Load(byte[]) for this pair: a byte-loaded assembly is not
+    /// registered for simple-name binding in the default load context, so the consumer's
+    /// [NavEventSubscriber] usage cannot materialise (FileNotFoundException inside
+    /// GetCustomAttributes) and BOTH scans would report nothing — an equivalence test that
+    /// compares empty to empty and proves nothing. LoadFrom probes the requesting assembly's
+    /// own directory, so the cross-assembly attribute really resolves here, which is what the
+    /// MemberReference-constructor case needs in order to be a real test.
+    /// </summary>
+    private static (Assembly Definer, Assembly Consumer) LoadPairFromDisk()
+    {
+        var tag = Guid.NewGuid().ToString("N");
+        var dir = Path.Combine(Path.GetTempPath(), "al-runner-type-index", tag);
+        Directory.CreateDirectory(dir);
+        var definerBytes = Compile($"al-runner-ti-def-{tag}", DefinerSource);
+        var consumerBytes = Compile($"al-runner-ti-use-{tag}", ConsumerSource, definerBytes);
+        var definerPath = Path.Combine(dir, $"al-runner-ti-def-{tag}.dll");
+        var consumerPath = Path.Combine(dir, $"al-runner-ti-use-{tag}.dll");
+        File.WriteAllBytes(definerPath, definerBytes);
+        File.WriteAllBytes(consumerPath, consumerBytes);
+        return (Assembly.LoadFrom(definerPath), Assembly.LoadFrom(consumerPath));
+    }
+
+    private static HashSet<string> Describe(IEnumerable<MethodInfo> methods)
+        => new(methods.Select(EventSubscriberPatches.DescribeSubscriberMethod), StringComparer.Ordinal);
+
+    // ------------------------------------------------------------------
+    // Attributed-method discovery
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void FindAttributedMethods_MethodDefCtor_MatchesLegacyReflectionScanExactly()
+    {
+        var definer = LoadDefinerFromBytes();
+        var index = AssemblyTypeIndex.For(definer);
+        Assert.True(index.IsMetadataBacked,
+            "an Assembly.Load(byte[]) assembly must still expose raw metadata via TryGetRawMetadata");
+
+        var viaMetadata = Describe(index.FindAttributedMethods("Codeunit", "NavEventSubscriberAttribute"));
+        var viaReflection = Describe(EventSubscriberPatches.LegacyReflectionScan(definer));
+
+        // POSITIVE — the exact set, named. Both attributed overloads of HandleBar are present
+        // and distinguished by arity; HandleModify is found although it is internal+static.
+        var expected = new HashSet<string>(StringComparer.Ordinal)
+        {
+            "Fx.Defs.Codeunit90001.HandleInsert/0",
+            "Fx.Defs.Codeunit90001.HandleModify/2",
+            "Codeunit90002.HandleBar/0",
+            "Codeunit90002.HandleBar/1",
+        };
+        Assert.Equal(expected, viaMetadata);
+
+        // EQUIVALENCE — and the pre-existing reflection scan agrees, member for member.
+        Assert.Equal(viaReflection, viaMetadata);
+
+        // NEGATIVES — an attributed method on a non-"Codeunit" type, and an un-attributed
+        // method on a Codeunit type, contribute nothing to either scan.
+        Assert.DoesNotContain("Fx.Defs.Helper90003.Ignored/0", viaMetadata);
+        Assert.DoesNotContain("Fx.Defs.Codeunit90001.NotASubscriber/0", viaMetadata);
+    }
+
+    [Fact]
+    public void FindAttributedMethods_MemberRefCtor_MatchesLegacyReflectionScanExactly()
+    {
+        // The cross-assembly shape: the attribute is defined in another assembly, so the
+        // CustomAttribute row's Constructor is a MemberReference whose Parent is a TypeReference.
+        // This is how EVERY [NavEventSubscriber] in a BC AL-emitted assembly is encoded.
+        var (_, consumer) = LoadPairFromDisk();
+
+        var viaMetadata = Describe(
+            AssemblyTypeIndex.For(consumer).FindAttributedMethods("Codeunit", "NavEventSubscriberAttribute"));
+        var viaReflection = Describe(EventSubscriberPatches.LegacyReflectionScan(consumer));
+
+        Assert.Equal(new HashSet<string>(StringComparer.Ordinal) { "Fx.Uses.Codeunit90101.Handle/0" },
+                     viaMetadata);
+        Assert.Equal(viaReflection, viaMetadata);
+        Assert.DoesNotContain("Fx.Uses.NotACodeunit90102.Handle/0", viaMetadata);
+    }
+
+    [Fact]
+    public void FindAttributedMethods_UnknownAttributeName_FindsNothing()
+    {
+        var definer = LoadDefinerFromBytes();
+        // Matching is on the attribute type's simple name, not "has any attribute at all".
+        Assert.Empty(AssemblyTypeIndex.For(definer)
+            .FindAttributedMethods("Codeunit", "SomeOtherAttribute"));
+    }
+
+    // ------------------------------------------------------------------
+    // Type lookup by name
+    // ------------------------------------------------------------------
+
+    [Fact]
+    public void FindFirst_ResolvesRealTypes_AndAnswersNullForNamesThatAreNotThere()
+    {
+        var definer = LoadDefinerFromBytes();
+        var index = AssemblyTypeIndex.For(definer);
+
+        // POSITIVE — the same Type object Array.Find(asm.GetTypes(), x => x.Name == n) returns.
+        var expected = definer.GetTypes().First(t => t.Name == "Codeunit90001");
+        Assert.Same(expected, index.FindFirst("Codeunit90001"));
+
+        // Nested types are in the index too, addressed by their simple name, and resolve
+        // through the Outer+Inner reflection name.
+        var nested = definer.GetTypes().First(t => t.Name == "OnFooEvent_Scope");
+        Assert.Same(nested, index.FindFirst("OnFooEvent_Scope"));
+        var deeper = definer.GetTypes().First(t => t.Name == "Deeper");
+        Assert.Same(deeper, index.FindFirst("Deeper"));
+
+        // NEGATIVE — a name that does not exist, and a name that exists but fails the caller's
+        // predicate, both answer null rather than "something close".
+        Assert.Null(index.FindFirst("Codeunit99999"));
+        Assert.Null(index.FindFirst("Codeunit90001", t => t.Name == "somethingElse"));
+        Assert.NotNull(index.FindFirst("Codeunit90001", t => t.IsPublic));
+    }
+
+    [Fact]
+    public void EnumerateWithPrefix_AndTypeNamesWithPrefix_AgreeWithGetTypes()
+    {
+        var definer = LoadDefinerFromBytes();
+        var index = AssemblyTypeIndex.For(definer);
+
+        var viaGetTypes = new HashSet<string>(
+            definer.GetTypes().Where(t => t.Name.StartsWith("Record", StringComparison.Ordinal))
+                              .Select(t => t.Name),
+            StringComparer.Ordinal);
+        Assert.Equal(new HashSet<string>(StringComparer.Ordinal)
+                     { "Record90001", "Record90002", "RecordNotNumeric" }, viaGetTypes);
+
+        Assert.Equal(viaGetTypes,
+            new HashSet<string>(index.EnumerateWithPrefix("Record").Select(t => t.Name), StringComparer.Ordinal));
+        Assert.Equal(viaGetTypes,
+            new HashSet<string>(index.TypeNamesWithPrefix("Record"), StringComparer.Ordinal));
+
+        // NEGATIVE — a prefix nothing matches yields nothing (not "everything").
+        Assert.Empty(index.EnumerateWithPrefix("NoSuchPrefix"));
+        Assert.Empty(index.TypeNamesWithPrefix("NoSuchPrefix"));
+    }
+
+    [Fact]
+    public void FindNestedType_ResolvesByNameAndAnswersNullWhenAbsent()
+    {
+        var definer = LoadDefinerFromBytes();
+        var index = AssemblyTypeIndex.For(definer);
+        var outer = definer.GetType("Fx.Defs.Codeunit90001")!;
+
+        // POSITIVE — same answer as GetNestedTypes().FirstOrDefault(name), which is what this
+        // replaced on the event-scope seeding path.
+        var expected = outer.GetNestedTypes(BindingFlags.Public | BindingFlags.NonPublic)
+                            .First(t => t.Name == "OnFooEvent_Scope");
+        Assert.Same(expected, index.FindNestedType(outer, "OnFooEvent_Scope"));
+
+        // NEGATIVE — a nested name that is not declared on THIS type answers null. "Deeper" is
+        // nested inside OnFooEvent_Scope, not inside Codeunit90001, so the search must not
+        // flatten the nesting chain.
+        Assert.Null(index.FindNestedType(outer, "OnMissingEvent_Scope"));
+        Assert.Null(index.FindNestedType(outer, "Deeper"));
+        Assert.Same(definer.GetType("Fx.Defs.Codeunit90001+OnFooEvent_Scope+Deeper"),
+                    index.FindNestedType(expected, "Deeper"));
+    }
+}
+
+/// <summary>
+/// The equivalence claim on the assemblies that actually matter: the real Base Application and
+/// System Application R2R chunks, with their ~3,400 [NavEventSubscriber] methods.
+///
+/// Those assemblies only exist inside a real runner invocation (DependencyLoader loads them from
+/// the .app packages via Assembly.Load(byte[])), so this drives the runner binary itself with
+/// AL_RUNNER_SUBSCRIBER_SCAN_AUDIT=1, which makes EventSubscriberPatches run BOTH the metadata
+/// scan and the pre-existing reflection scan over every assembly it discovers and print the
+/// comparison. See EventSubscriberPatches.AuditAssemblyScan.
+/// </summary>
+public sealed class EventSubscriberScanEquivalenceTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+    private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
+    private static readonly string Fixture = Path.Combine(
+        RepoRoot, "AlRunner.Tests", "Fixtures", "RecordTriggerXRec");
+
+    private static readonly Regex AuditLine = new(
+        @"scan-audit (?<asm>\S+): metadata=(?<md>\d+) reflection=(?<rf>\d+) identical=(?<same>true|false)",
+        RegexOptions.Compiled);
+
+    [SkippableFact]
+    public void MetadataScan_FindsExactlyTheSameSubscribersAsTheOldReflectionScan_OnRealBcAssemblies()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var args = new StringBuilder(TestBuildConfig.RunArgs(ProjectPath));
+        args.Append(TestBuildConfig.BcVersionArg);
+        var platformApps = TestArtifacts.PlatformAppsDir();
+        if (Directory.Exists(platformApps)) args.Append($" --package-cache \"{platformApps}\"");
+        args.Append($" --quiet \"{Fixture}\"");
+
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            Arguments = args.ToString(),
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            WorkingDirectory = RepoRoot,
+        };
+        psi.Environment["AL_RUNNER_SUBSCRIBER_SCAN_AUDIT"] = "1";
+        // The audit lines are `[Subscribers]`-tagged, which AlRunner/Log.cs drops at default
+        // verbosity.
+        psi.Environment["AL_RUNNER_VERBOSE"] = "1";
+
+        var sb = new StringBuilder();
+        using var p = Process.Start(psi)!;
+        p.OutputDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.ErrorDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.BeginOutputReadLine();
+        p.BeginErrorReadLine();
+        if (!p.WaitForExit(600_000)) { try { p.Kill(true); } catch { } throw new TimeoutException("runner hung"); }
+        p.WaitForExit();
+        string output;
+        lock (sb) output = sb.ToString();
+
+        Assert.True(p.ExitCode == 0, $"runner exited {p.ExitCode}. Output:\n{output}");
+
+        var rows = AuditLine.Matches(output)
+            .Select(m => (
+                Asm: m.Groups["asm"].Value,
+                Md: int.Parse(m.Groups["md"].Value),
+                Rf: int.Parse(m.Groups["rf"].Value),
+                Same: m.Groups["same"].Value == "true"))
+            .ToList();
+
+        Assert.True(rows.Count > 0,
+            $"the audit produced no scan-audit lines at all — the env var is not wired. Output:\n{output}");
+
+        // THE CLAIM: every assembly the runner discovered subscribers in reports the identical
+        // (declaring type, method, arity) SET from both scans.
+        var mismatched = rows.Where(r => !r.Same).ToList();
+        Assert.True(mismatched.Count == 0,
+            "the metadata scan and the legacy reflection scan disagree on: " +
+            string.Join(", ", mismatched.Select(r => $"{r.Asm} (metadata={r.Md} reflection={r.Rf})")) +
+            "\n" + output);
+
+        int totalMd = rows.Sum(r => r.Md);
+        int totalRf = rows.Sum(r => r.Rf);
+        Assert.Equal(totalRf, totalMd);
+
+        // A run that scanned nothing but empty assemblies would satisfy "identical=true"
+        // everywhere, so pin the magnitude too: Base Application + System Application carry
+        // well over 3,000 [NavEventSubscriber] methods between them (3,447 on BC 28.1).
+        Assert.True(totalMd > 3000,
+            $"expected >3000 subscribers across the real BC assemblies, found {totalMd}. Output:\n{output}");
+
+        // ...and that at least one SINGLE assembly is a genuinely large one, so the total
+        // cannot be reached by summing many trivial assemblies.
+        Assert.True(rows.Max(r => r.Md) > 500,
+            $"no single assembly contributed >500 subscribers (max {rows.Max(r => r.Md)}); " +
+            $"the Base Application chunks were not scanned. Output:\n{output}");
+    }
+}

--- a/AlRunner.Tests/CollectionCostOrderer.cs
+++ b/AlRunner.Tests/CollectionCostOrderer.cs
@@ -99,7 +99,15 @@ public sealed class CollectionCostOrderer : ITestCollectionOrderer
     public static readonly IReadOnlyDictionary<string, int> MeasuredWeightSeconds =
         new Dictionary<string, int>(StringComparer.Ordinal)
         {
+            // perf/boot-overhead: added with the on-disk install-baseline tier. Measured
+            // 125.6s on the first CI run of that branch (BC 28.4 leg), where it was absent
+            // from this table, fell back to UnmeasuredWeightSeconds and was dispatched at
+            // t=181s of a 309s run — a 77s single-threaded tail, the #1887 pattern again.
+            ["InstallBaselineDiskCacheTests"] = 125,
             ["ServerCancelTests"] = 285,
+            // perf/boot-overhead: 37.8s measured on the same run; below the 60s freshness
+            // threshold, listed so it is dispatched by measured cost, not by the fallback.
+            ["EventSubscriberScanEquivalenceTests"] = 37,
             // #1851/#1857 cut this from 292s to 196s (--print-cache-key skips the four cold
             // AL compiles the class used to pay for). #1887 caught the table still saying
             // 292 — harmless for ordering (it already ranked at the top either way), but it

--- a/AlRunner.Tests/InstallBaselineDiskCacheTests.cs
+++ b/AlRunner.Tests/InstallBaselineDiskCacheTests.cs
@@ -1,0 +1,384 @@
+using System.Diagnostics;
+using System.Text;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// Cross-PROCESS persistence of the #1867 dependency+company install baseline.
+///
+/// #1867 stopped the dependency Install triggers + Company-Initialize (codeunit 2) from
+/// being re-run for every app group inside ONE process. What it could not remove is the
+/// per-process cost: the in-memory dictionary dies with the process, so every new
+/// `al-runner` invocation recomputed the whole thing — measured at 5.9s of a 23.3s warm
+/// single-fixture run (96.1% of that app group's run_ms). The result is a pure function of
+/// (dependency assembly set, runner build, BC version), so it is now serialised to
+/// <c>&lt;cache-root&gt;/install-baseline/&lt;sha256&gt;.bin</c> and reloaded by the next
+/// process (see AlRunner/Infrastructure/InstallBaselineDiskCache.cs and
+/// AlRunner/Patches/RecordPatches.InstallBaselineDisk.cs).
+///
+/// A cache that merely runs faster is not the claim under test. The claims are:
+///
+///   1. ROUND TRIP — what the second process restores from disk is the SAME state the first
+///      process captured, value for value. Asserted on the <c>digest=</c> the two processes
+///      log: a SHA-256 over every persisted table's every row's every field slot, carrying
+///      that value's own NclType, its own defined length, its NULL flag and the exact bytes
+///      BC's <c>NavValue.GetBytes()</c> produces, plus the isolated-storage / record-link /
+///      auto-increment state. Two independent fresh computations do NOT produce the same
+///      digest (BC assigns a new SystemId GUID and SystemCreatedAt on every Insert), so an
+///      equal digest across two processes is only obtainable by genuinely reloading the
+///      first one's values — it cannot be faked by recomputing.
+///   2. KILL SWITCH — AL_RUNNER_NO_DEP_COMPANY_CACHE=1 disables the disk tier in BOTH
+///      directions: no read (a present entry is not consulted) and no write (the entry on
+///      disk is left byte-identical).
+///   3. CORRUPTION — a damaged entry is detected, deleted, recomputed and rewritten, and the
+///      rewritten entry is itself usable by the run after it.
+///   4. SCOPING — two app groups whose dependency closures differ get two different keys and
+///      therefore two different files; a baseline is never shared across closures.
+///
+/// Every case also asserts the app group's own AL test still passes against REAL
+/// Company-Initialize-seeded data (Company Information's singleton row), so a "cache" that
+/// restored nothing at all would fail the assertion rather than merely run fast.
+///
+/// Spawns the real runner; needs the BC artifact cache. Skips (no-op) when absent.
+/// </summary>
+public class InstallBaselineDiskCacheTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+    private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
+
+    private static (string output, int exit) RunRunner(
+        IDictionary<string, string>? extraEnv, params string[] bundles)
+    {
+        var args = new StringBuilder(TestBuildConfig.RunArgs(ProjectPath));
+        args.Append(TestBuildConfig.BcVersionArg);
+        args.Append(" --package-cache \"").Append(TestArtifacts.PlatformAppsDir()).Append('"');
+        foreach (var b in bundles) args.Append(" \"").Append(b).Append('"');
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet", Arguments = args.ToString(),
+            RedirectStandardOutput = true, RedirectStandardError = true,
+            UseShellExecute = false, CreateNoWindow = true, WorkingDirectory = RepoRoot,
+            // PERF gives the DepCompanyCache markers (and the digest); VERBOSE lets the
+            // [InstallBaselineDisk] component lines through Log.cs's tag filter, which is how
+            // these tests learn which file on disk the run used.
+            Environment = { ["AL_RUNNER_PERF"] = "1", ["AL_RUNNER_VERBOSE"] = "1" },
+        };
+        if (extraEnv != null)
+            foreach (var (k, v) in extraEnv) psi.Environment[k] = v;
+        var sb = new StringBuilder();
+        var p = Process.Start(psi)!;
+        p.OutputDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.ErrorDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.BeginOutputReadLine();
+        p.BeginErrorReadLine();
+        if (!p.WaitForExit(300_000)) { try { p.Kill(true); } catch { } throw new TimeoutException("runner hung"); }
+        p.WaitForExit();
+        lock (sb) return (sb.ToString(), p.ExitCode);
+    }
+
+    /// <summary>
+    /// A two-app closure whose dependency set is unique to this test invocation: the main app
+    /// depends on a private dependency app whose id AND source text carry a fresh GUID, so the
+    /// dependency assembly it compiles to has an MVID no other run has ever produced — and
+    /// therefore an InstallTriggerRunner.CurrentDependencySetKey(), and an on-disk baseline
+    /// entry, that starts out guaranteed absent. Without that these tests could not tell a
+    /// genuine first-run MISS from a hit on an entry some earlier run left behind.
+    /// </summary>
+    private static (string dep, string main) WriteUniqueClosure(string root, int baseId, string tag)
+    {
+        var depId = Guid.NewGuid().ToString();
+        var marker = Guid.NewGuid().ToString("N");
+        var depDir = Path.Combine(root, tag + "-dep");
+        var mainDir = Path.Combine(root, tag + "-main");
+
+        Directory.CreateDirectory(depDir);
+        File.WriteAllText(Path.Combine(depDir, "app.json"), $$"""
+        {
+          "id": "{{depId}}",
+          "name": "IBDisk {{tag}} Dep",
+          "publisher": "InstallBaselineDiskTest",
+          "version": "1.0.0.0",
+          "dependencies": [],
+          "platform": "1.0.0.0",
+          "application": "1.0.0.0",
+          "idRanges": [ { "from": {{baseId}}, "to": {{baseId + 4}} } ],
+          "runtime": "14.0"
+        }
+        """);
+        File.WriteAllText(Path.Combine(depDir, "Dep.al"), $$"""
+        codeunit {{baseId}} "IBDisk {{tag}} Dep Cu"
+        {
+            procedure Marker(): Text
+            begin
+                exit('{{marker}}');
+            end;
+        }
+        """);
+
+        Directory.CreateDirectory(mainDir);
+        File.WriteAllText(Path.Combine(mainDir, "app.json"), $$"""
+        {
+          "id": "{{Guid.NewGuid()}}",
+          "name": "IBDisk {{tag}} Main",
+          "publisher": "InstallBaselineDiskTest",
+          "version": "1.0.0.0",
+          "dependencies": [
+            { "id": "{{depId}}", "name": "IBDisk {{tag}} Dep", "publisher": "InstallBaselineDiskTest", "version": "1.0.0.0" }
+          ],
+          "platform": "1.0.0.0",
+          "application": "1.0.0.0",
+          "idRanges": [ { "from": {{baseId + 5}}, "to": {{baseId + 9}} } ],
+          "runtime": "14.0"
+        }
+        """);
+        File.WriteAllText(Path.Combine(mainDir, "Tests.al"), $$"""
+        codeunit {{baseId + 5}} "IBDisk {{tag}} Test"
+        {
+            Subtype = Test;
+
+            [Test]
+            procedure CompanyInitializeSeededRealData()
+            var
+                CompanyInformation: Record "Company Information";
+            begin
+                // [THEN] Whether this app group computed the dependency+company baseline or
+                // restored it from disk, the real Base App codeunit 2 "Company-Initialize"
+                // result is present: Company Information's singleton row exists. A disk
+                // restore that dropped rows fails here rather than merely being fast.
+                CompanyInformation.Get();
+            end;
+        }
+        """);
+        return (depDir, mainDir);
+    }
+
+    // ── log parsing ────────────────────────────────────────────────────────────────────
+
+    private static readonly Regex WriteLine = new(
+        @"InstallBaseline\.DepCompanyCache DISK-WRITE (\S+) (\d+)B digest=(\S+)", RegexOptions.Compiled);
+    private static readonly Regex HitLine = new(
+        @"InstallBaseline\.DepCompanyCache DISK-HIT (\S+) digest=(\S+)", RegexOptions.Compiled);
+    private static readonly Regex WrotePathLine = new(
+        @"\[InstallBaselineDisk\] wrote \d+ byte\(s\) to (.+)$", RegexOptions.Compiled | RegexOptions.Multiline);
+
+    private static Dictionary<string, string> WriteDigests(string output) =>
+        WriteLine.Matches(output).ToDictionary(m => m.Groups[1].Value, m => m.Groups[3].Value);
+
+    private static Dictionary<string, string> HitDigests(string output) =>
+        HitLine.Matches(output).ToDictionary(m => m.Groups[1].Value, m => m.Groups[2].Value);
+
+    private static List<string> WrittenPaths(string output) =>
+        WrotePathLine.Matches(output).Select(m => m.Groups[1].Value.Trim()).Distinct().ToList();
+
+    private static int Count(string haystack, string needle)
+    {
+        int count = 0, idx = 0;
+        while ((idx = haystack.IndexOf(needle, idx, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            idx += needle.Length;
+        }
+        return count;
+    }
+
+    // ── 1. round trip across processes ─────────────────────────────────────────────────
+
+    [SkippableFact]
+    public void SecondProcess_RestoresByteEquivalentBaselineFromDisk()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var root = Path.Combine(Path.GetTempPath(), "al-runner-ib-disk-roundtrip", Guid.NewGuid().ToString("N"));
+        try
+        {
+            var (dep, main) = WriteUniqueClosure(root, 62000, "rt");
+
+            var (out1, exit1) = RunRunner(null, dep, main);
+            Assert.Equal(0, exit1);
+            Assert.True(Count(out1, "1P/0F/0E") >= 1, $"main app group should pass, got:\n{out1}");
+
+            // [THEN] First process: this closure has never been seen, so its key is computed
+            // fresh and persisted — and it is NOT among the keys this run restored from disk.
+            // (The bundle's plain MS-platform app group may legitimately hit an entry an
+            // earlier run left; the assertion is about THIS closure's key, not about the
+            // process having no hits at all.)
+            var written = WriteDigests(out1);
+            Assert.True(written.Count >= 1, $"expected at least one DISK-WRITE, got:\n{out1}");
+            Assert.Empty(HitDigests(out1).Keys.Intersect(written.Keys));
+            Assert.True(Count(out1, "InstallBaseline.DepCompanyCache MISS") >= 1,
+                $"expected at least one fresh computation, got:\n{out1}");
+
+            var (out2, exit2) = RunRunner(null, dep, main);
+            Assert.Equal(0, exit2);
+            Assert.True(Count(out2, "1P/0F/0E") >= 1, $"main app group should pass, got:\n{out2}");
+
+            // [THEN] Second process: no fresh computation for ANY key in the bundle, and
+            // nothing rewritten.
+            Assert.Equal(0, Count(out2, "InstallBaseline.DepCompanyCache MISS"));
+            Assert.Empty(WriteDigests(out2));
+
+            // [THEN] Every key the first process wrote came back in the second, with the
+            // IDENTICAL value-level digest — same tables, same rows, same field slots, same
+            // NclTypes, same defined lengths, same NULL flags, same NavValue.GetBytes(). A
+            // recomputation could not produce this: BC stamps a new SystemId GUID and
+            // SystemCreatedAt on every Insert, so two fresh captures always differ.
+            var hits = HitDigests(out2);
+            foreach (var (key, digest) in written)
+            {
+                Assert.True(hits.ContainsKey(key), $"key {key} was written but not restored:\n{out2}");
+                Assert.Equal(digest, hits[key]);
+            }
+        }
+        finally
+        {
+            try { Directory.Delete(root, true); } catch { }
+        }
+    }
+
+    // ── 2. kill switch: no read AND no write ───────────────────────────────────────────
+
+    [SkippableFact]
+    public void KillSwitch_SkipsBothTheDiskReadAndTheDiskWrite()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var root = Path.Combine(Path.GetTempPath(), "al-runner-ib-disk-killswitch", Guid.NewGuid().ToString("N"));
+        try
+        {
+            var (dep, main) = WriteUniqueClosure(root, 62020, "ks");
+
+            // Seed an entry that the kill-switched run would hit if the switch did nothing.
+            var (out1, exit1) = RunRunner(null, dep, main);
+            Assert.Equal(0, exit1);
+            var paths = WrittenPaths(out1);
+            Assert.True(paths.Count >= 1, $"expected the first run to write an entry, got:\n{out1}");
+            var before = paths.ToDictionary(p => p, File.ReadAllBytes);
+
+            var (out2, exit2) = RunRunner(
+                new Dictionary<string, string> { ["AL_RUNNER_NO_DEP_COMPANY_CACHE"] = "1" }, dep, main);
+
+            // [THEN] Seeding still happened — the switch disables the cache, not the work.
+            Assert.Equal(0, exit2);
+            Assert.True(Count(out2, "1P/0F/0E") >= 1, $"main app group should still pass, got:\n{out2}");
+
+            // [THEN] Read side off: the entry that exists was not consulted (no DISK-HIT, and
+            // no lookup was even attempted — the path line is emitted on every lookup).
+            Assert.Empty(HitDigests(out2));
+            Assert.DoesNotContain("[InstallBaselineDisk] entry path:", out2);
+            Assert.True(Count(out2, "InstallBaseline.DepCompanyCache MISS") >= 1,
+                $"expected fresh computation under the kill switch, got:\n{out2}");
+
+            // [THEN] Write side off: the file on disk is byte-for-byte what the previous run
+            // left. A switch that only skipped the read would have overwritten it here.
+            Assert.Empty(WriteDigests(out2));
+            foreach (var (path, bytes) in before)
+                Assert.Equal(bytes, File.ReadAllBytes(path));
+        }
+        finally
+        {
+            try { Directory.Delete(root, true); } catch { }
+        }
+    }
+
+    // ── 3. corrupt entry: detected, replaced, and the replacement works ────────────────
+
+    [SkippableFact]
+    public void CorruptEntry_IsRejectedRecomputedAndRewrittenUsable()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var root = Path.Combine(Path.GetTempPath(), "al-runner-ib-disk-corrupt", Guid.NewGuid().ToString("N"));
+        try
+        {
+            var (dep, main) = WriteUniqueClosure(root, 62040, "cx");
+
+            var (out1, exit1) = RunRunner(null, dep, main);
+            Assert.Equal(0, exit1);
+            var paths = WrittenPaths(out1);
+            Assert.True(paths.Count >= 1, $"expected the first run to write an entry, got:\n{out1}");
+
+            // Damage every entry this closure wrote: right magic, wrong everything after it,
+            // so the run has to get past File.Exists and fail inside the decoder.
+            foreach (var path in paths)
+            {
+                var junk = new byte[512];
+                junk[0] = (byte)'A'; junk[1] = (byte)'L'; junk[2] = (byte)'I'; junk[3] = (byte)'B';
+                for (var i = 4; i < junk.Length; i++) junk[i] = 0x5A;
+                File.WriteAllBytes(path, junk);
+            }
+
+            var (out2, exit2) = RunRunner(null, dep, main);
+
+            // [THEN] The damage was noticed, not swallowed and not fatal.
+            Assert.Equal(0, exit2);
+            Assert.True(Count(out2, "1P/0F/0E") >= 1, $"main app group should still pass, got:\n{out2}");
+            Assert.Contains("[InstallBaselineDisk] cannot restore:", out2);
+            Assert.True(Count(out2, "InstallBaseline.DepCompanyCache MISS") >= 1,
+                $"expected a fresh computation after the corrupt entry, got:\n{out2}");
+
+            // [THEN] It was replaced, not merely skipped — every damaged file is now longer
+            // than the 512-byte junk and no longer reads as junk.
+            var rewritten = WriteDigests(out2);
+            Assert.True(rewritten.Count >= 1, $"expected the corrupt entry to be rewritten, got:\n{out2}");
+            foreach (var path in paths)
+                Assert.True(new FileInfo(path).Length > 512, $"{path} was not rewritten");
+
+            // [THEN] And the replacement is genuinely usable: a third process restores from it
+            // with the digest the rewriting process recorded.
+            var (out3, exit3) = RunRunner(null, dep, main);
+            Assert.Equal(0, exit3);
+            Assert.Equal(0, Count(out3, "InstallBaseline.DepCompanyCache MISS"));
+            var hits = HitDigests(out3);
+            foreach (var (key, digest) in rewritten)
+            {
+                Assert.True(hits.ContainsKey(key), $"rewritten key {key} was not restored:\n{out3}");
+                Assert.Equal(digest, hits[key]);
+            }
+        }
+        finally
+        {
+            try { Directory.Delete(root, true); } catch { }
+        }
+    }
+
+    // ── 4. scoping: a different dependency closure gets a different file ───────────────
+
+    [SkippableFact]
+    public void DifferentDependencyClosures_GetDifferentKeysAndDifferentFiles()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var root = Path.Combine(Path.GetTempPath(), "al-runner-ib-disk-scope", Guid.NewGuid().ToString("N"));
+        try
+        {
+            var (depA, mainA) = WriteUniqueClosure(root, 62060, "sa");
+            var (depB, mainB) = WriteUniqueClosure(root, 62080, "sb");
+
+            var (output, exit) = RunRunner(null, depA, mainA, depB, mainB);
+
+            Assert.Equal(0, exit);
+            Assert.True(Count(output, "1P/0F/0E") >= 2,
+                $"expected both main app groups to pass, got:\n{output}");
+
+            // [THEN] Two closures that differ by one dependency assembly produced two distinct
+            // cache keys and two distinct files. A key that ignored the dependency set (or a
+            // path that collided) would show one.
+            var written = WriteDigests(output);
+            Assert.True(written.Count >= 2,
+                $"expected at least 2 distinct dependency-closure keys to be persisted, got "
+                + $"{written.Count}:\n{output}");
+            Assert.True(WrittenPaths(output).Count >= 2,
+                $"expected at least 2 distinct on-disk entries, got:\n{output}");
+
+            // [THEN] …and neither closure reused the other's baseline.
+            Assert.Empty(HitDigests(output).Keys.Intersect(written.Keys));
+        }
+        finally
+        {
+            try { Directory.Delete(root, true); } catch { }
+        }
+    }
+}

--- a/AlRunner.Tests/InstallSeedDepCompanyCacheTests.cs
+++ b/AlRunner.Tests/InstallSeedDepCompanyCacheTests.cs
@@ -131,14 +131,22 @@ public class InstallSeedDepCompanyCacheTests
             Assert.True(passLines >= 2,
                 $"expected both app groups to report 1P/0F/0E, got:\n{output}");
 
-            // [THEN] Exactly one fresh computation (MISS) and at least one reuse (HIT) for
-            // the shared MS-platform-only dependency closure — proving the SECOND app group
-            // genuinely reused the first's result instead of re-running dependency Install
-            // triggers + Company-Initialize from scratch.
+            // [THEN] The shared MS-platform-only dependency closure was resolved exactly ONCE
+            // in this process — and the second app group reused that result rather than
+            // re-running dependency Install triggers + Company-Initialize from scratch.
+            //
+            // "Resolved once" is MISS + DISK-HIT, not MISS alone: since the cross-process
+            // on-disk tier landed (InstallBaselineDiskCacheTests), the first app group's
+            // lookup answers from disk whenever an earlier invocation on this machine already
+            // computed the same closure, and from a fresh computation otherwise. Which of the
+            // two it is depends on the state of ~/.cache/al-runner/install-baseline and is not
+            // what THIS test is about; that exactly one of them happened, and that the second
+            // app group took neither, is.
             var missCount = CountOccurrences(output, "InstallBaseline.DepCompanyCache MISS");
+            var diskHitCount = CountOccurrences(output, "InstallBaseline.DepCompanyCache DISK-HIT");
             var hitCount = CountOccurrences(output, "InstallBaseline.DepCompanyCache HIT");
-            Assert.Equal(1, missCount);
-            Assert.True(hitCount >= 1, $"expected at least one cache HIT, got:\n{output}");
+            Assert.Equal(1, missCount + diskHitCount);
+            Assert.True(hitCount >= 1, $"expected at least one in-memory cache HIT, got:\n{output}");
         }
         finally
         {
@@ -178,13 +186,18 @@ public class InstallSeedDepCompanyCacheTests
             Assert.True(passLines >= 2,
                 $"expected both app groups to report 1P/0F/0E, got:\n{output}");
 
-            // [THEN] Exactly two fresh computations (MISS) and zero reuse (HIT) — with the
-            // kill switch set, the SAME dependency closure that produced 1 MISS + >=1 HIT in
-            // the positive test above must now produce 2 MISSes and 0 HITs.
+            // [THEN] Exactly two fresh computations (MISS) and zero reuse of any kind — with
+            // the kill switch set, the SAME dependency closure that produced 1 resolution +
+            // >=1 HIT in the positive test above must now produce 2 MISSes, 0 in-memory HITs
+            // and 0 DISK-HITs. The last of those is the switch's cross-process half: it must
+            // bypass the on-disk tier too, or a run set up to re-measure the uncached path
+            // would silently keep reading yesterday's answer.
             var missCount = CountOccurrences(output, "InstallBaseline.DepCompanyCache MISS");
             var hitCount = CountOccurrences(output, "InstallBaseline.DepCompanyCache HIT");
+            var diskHitCount = CountOccurrences(output, "InstallBaseline.DepCompanyCache DISK-HIT");
             Assert.Equal(2, missCount);
             Assert.Equal(0, hitCount);
+            Assert.Equal(0, diskHitCount);
         }
         finally
         {
@@ -271,12 +284,18 @@ public class InstallSeedDepCompanyCacheTests
 
         // [THEN] Two DIFFERENT dependency closures (AppA's MS-platform-only closure vs.
         // the extra-dep app's closure, which includes one more dependency assembly) each
-        // get their OWN fresh computation — never a cross-key HIT. A cache keyed
-        // incorrectly (e.g. ignoring the dependency set entirely) would show only one
-        // MISS total; this must show at least two.
+        // get their OWN resolution — never a cross-key in-memory HIT. A cache keyed
+        // incorrectly (e.g. ignoring the dependency set entirely) would show one resolution
+        // and one HIT; this must show at least two resolutions.
+        //
+        // As above, a resolution is MISS or DISK-HIT: the on-disk tier may answer AppA's
+        // MS-platform closure from an earlier invocation. The claim is that the two closures
+        // are resolved SEPARATELY, not which tier answered either of them.
         var missCount = CountOccurrences(output, "InstallBaseline.DepCompanyCache MISS");
-        Assert.True(missCount >= 2,
-            $"expected at least 2 distinct-dependency-closure MISSes, got {missCount}:\n{output}");
+        var diskHitCount = CountOccurrences(output, "InstallBaseline.DepCompanyCache DISK-HIT");
+        Assert.True(missCount + diskHitCount >= 2,
+            $"expected at least 2 distinct-dependency-closure resolutions, got "
+            + $"{missCount} MISS + {diskHitCount} DISK-HIT:\n{output}");
         }
         finally
         {

--- a/AlRunner.Tests/ServerCancelTests.cs
+++ b/AlRunner.Tests/ServerCancelTests.cs
@@ -26,9 +26,35 @@ namespace AlRunner.Tests;
 /// could observe the summary and fire `cancel` — is fixed at the source (see the
 /// #1809 comment in Program.cs's HandleServerRunTests) rather than papered over
 /// by serializing the tests that happened to be likely to notice it.
+///
+/// #1936: seven facts here each independently paid a cold `--server` boot
+/// (~30-40s under CI contention; a warm request is ~1.6s), for 287s total in
+/// CI. #1913/#1804 explicitly declined to share a server across THIS class's
+/// facts ("they tear the process down or race it as part of what they
+/// prove") — true for exactly one of the seven, not all: only
+/// <see cref="RunTests_CancelDuringRun_StopsEarly_AckNoopFalse_SummaryCancelledTrue"/>
+/// starts its server with a fact-specific env var
+/// (<c>AL_RUNNER_TEST_BARRIER_DIR</c>) to deliberately block it mid-run — a
+/// DIFFERENT startup flag per SharedCliServer rule (a), so it cannot share and
+/// keeps its own dedicated <c>CliServer.StartAsync</c> call, unmodified. Every
+/// other fact here neither blocks nor kills the server and wants the exact
+/// same (optional) startup flags every time (<see cref="ExtraServerArgs"/>
+/// always resolves to the same value), so they now share ONE server via
+/// <see cref="SharedCliServer"/> — facts within a class already run
+/// sequentially by default (see that fixture's own doc comment), so this
+/// changes nothing about ordering, only about how many times BC cold-boots.
+/// Each shared-server bundle generator call site got its own AppId/variant
+/// (SharedCliServer doc condition (c)) even though the bundle CONTENT is
+/// identical across variants, to route every call through a genuine fresh
+/// compile rather than <c>DependencyLoader.TryGetByAppId</c>'s cross-path
+/// module-identity cache.
 /// </summary>
-public class ServerCancelTests
+public class ServerCancelTests : IClassFixture<SharedCliServer>
 {
+    private readonly SharedCliServer _shared;
+
+    public ServerCancelTests(SharedCliServer shared) => _shared = shared;
+
     private static string[] ExtraServerArgs()
     {
         var platformApps = TestArtifacts.PlatformAppsDir();
@@ -40,26 +66,34 @@ public class ServerCancelTests
     /// <summary>
     /// One trivial passing test — enough to prove "a run happened and finished",
     /// nothing more. Used by the tests that don't care about run duration.
+    ///
+    /// <paramref name="variant"/> (#1936): three call sites now share ONE server
+    /// process (see class doc comment) — each gets its own AppId (last hex
+    /// digit) and object-ID range (offset by variant*10 from the base 60310),
+    /// same convention as ServerTestIsolationTests' MakeIsolationBundle, so
+    /// every call routes through a genuine fresh compile instead of
+    /// DependencyLoader.TryGetByAppId's cross-path module-identity cache.
     /// </summary>
-    private static string MakeFastBundle()
+    private static string MakeFastBundle(int variant)
     {
         var dir = Path.Combine(Path.GetTempPath(), "al-runner-server-cancel-fast", Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(dir);
-        File.WriteAllText(Path.Combine(dir, "app.json"), """
+        var baseId = 60310 + variant * 10;
+        File.WriteAllText(Path.Combine(dir, "app.json"), $$"""
         {
-          "id": "d1b2c3d4-e5f6-4708-a9ba-cbdcedfe0f33",
-          "name": "Runner Extras - Server Cancel Fast Probe",
+          "id": "d1b2c3d4-e5f6-4708-a9ba-cbdcedfe0f3{{variant:x1}}",
+          "name": "Runner Extras - Server Cancel Fast Probe {{variant}}",
           "publisher": "AL Runner",
           "version": "1.0.0.0",
           "dependencies": [],
           "platform": "1.0.0.0",
           "application": "1.0.0.0",
-          "idRanges": [ { "from": 60310, "to": 60319 } ],
+          "idRanges": [ { "from": {{baseId}}, "to": {{baseId + 9}} } ],
           "runtime": "14.0"
         }
         """);
-        File.WriteAllText(Path.Combine(dir, "FastProbe.Codeunit.al"), """
-        codeunit 60310 "Server Cancel Fast Probe SX"
+        File.WriteAllText(Path.Combine(dir, "FastProbe.Codeunit.al"), $$"""
+        codeunit {{baseId}} "Server Cancel Fast Probe SX {{variant}}"
         {
             Subtype = Test;
 
@@ -148,7 +182,7 @@ public class ServerCancelTests
     [Fact]
     public async Task Cancel_NoActiveRequest_AcksAsNoop()
     {
-        await using var server = await CliServer.StartAsync(ExtraServerArgs());
+        var server = await _shared.GetAsync(ExtraServerArgs());
         var response = await server.SendAsync("{\"command\":\"cancel\"}");
         var doc = JsonDocument.Parse(response).RootElement;
         Assert.Equal("ack", doc.GetProperty("type").GetString());
@@ -159,7 +193,7 @@ public class ServerCancelTests
     [Fact]
     public async Task Cancel_TwiceWithoutActiveRequest_BothNoop()
     {
-        await using var server = await CliServer.StartAsync(ExtraServerArgs());
+        var server = await _shared.GetAsync(ExtraServerArgs());
         var r1 = JsonDocument.Parse(await server.SendAsync("{\"command\":\"cancel\"}")).RootElement;
         var r2 = JsonDocument.Parse(await server.SendAsync("{\"command\":\"cancel\"}")).RootElement;
         Assert.True(r1.GetProperty("noop").GetBoolean());
@@ -171,7 +205,7 @@ public class ServerCancelTests
     {
         // Forward-compat: a future protocol addition may put more fields on the
         // cancel request; the server must tolerate and still answer with the ack shape.
-        await using var server = await CliServer.StartAsync(ExtraServerArgs());
+        var server = await _shared.GetAsync(ExtraServerArgs());
         var response = await server.SendAsync(
             "{\"command\":\"cancel\",\"reason\":\"user clicked stop\",\"requestId\":42}");
         var doc = JsonDocument.Parse(response).RootElement;
@@ -185,8 +219,8 @@ public class ServerCancelTests
     {
         TestArtifacts.SkipIfMissing();
 
-        var bundle = MakeFastBundle();
-        await using var server = await CliServer.StartAsync(ExtraServerArgs());
+        var bundle = MakeFastBundle(variant: 0);
+        var server = await _shared.GetAsync(ExtraServerArgs());
 
         // The single-test bundle finishes and returns its summary before we ever
         // send cancel — by construction (SendRequestStreamingAsync only returns
@@ -237,8 +271,8 @@ public class ServerCancelTests
         TestArtifacts.SkipIfMissing();
 
         const int iterationCount = 5; // see this test's own doc comment for why 5, not 20.
-        var bundle = MakeFastBundle();
-        await using var server = await CliServer.StartAsync(ExtraServerArgs());
+        var bundle = MakeFastBundle(variant: 1);
+        var server = await _shared.GetAsync(ExtraServerArgs());
         var failures = new List<string>();
 
         for (var i = 0; i < iterationCount; i++)
@@ -355,8 +389,8 @@ public class ServerCancelTests
         // all (never a literal false — see ServerProtocol.Summary's doc comment).
         TestArtifacts.SkipIfMissing();
 
-        var bundle = MakeFastBundle();
-        await using var server = await CliServer.StartAsync(ExtraServerArgs());
+        var bundle = MakeFastBundle(variant: 2);
+        var server = await _shared.GetAsync(ExtraServerArgs());
 
         var lines = await server.SendRequestStreamingAsync(RunTestsReq(bundle));
         var summary = JsonDocument.Parse(lines[^1]).RootElement;

--- a/AlRunner.Tests/SharedCliServer.cs
+++ b/AlRunner.Tests/SharedCliServer.cs
@@ -59,10 +59,15 @@ namespace AlRunner.Tests;
 ///      opposite on purpose, reusing one fixed AppId across two calls, to
 ///      prove isolation holds even when this cross-request reuse fires.
 ///
-/// ServerTests' shutdown-lifecycle fact and all of ServerCancelTests (each
-/// fact independently exercises a fresh `cancel`/`runTests` race that #1809
-/// deliberately de-serialized) are NOT converted — see #1804's PR description
-/// for why.
+/// ServerTests' shutdown-lifecycle fact is NOT converted (it tears the process
+/// down as part of what it proves). #1804/#1913 originally also excluded ALL of
+/// ServerCancelTests on the same blanket rationale, but #1936 found that only
+/// one of its seven facts — the one that starts its server with a fact-specific
+/// <c>AL_RUNNER_TEST_BARRIER_DIR</c> env var to deliberately block it mid-run —
+/// actually needs a dedicated process; the other six neither block nor kill the
+/// server and now share one via this fixture. See ServerCancelTests' own class
+/// doc comment for the per-fact breakdown, and PhaseLogServerKillTests (SIGKILLs
+/// its server) for another class that genuinely cannot share.
 /// </summary>
 public sealed class SharedCliServer : IAsyncLifetime
 {
@@ -82,8 +87,17 @@ public sealed class SharedCliServer : IAsyncLifetime
 
     public Task InitializeAsync() => Task.CompletedTask;
 
-    /// <summary>Returns the shared server, starting it on the first call only.</summary>
-    public async Task<CliServer> GetAsync()
+    /// <summary>
+    /// Returns the shared server, starting it on the first call only.
+    /// <paramref name="extraArgs"/> is only consulted on that first (spawning)
+    /// call — per rule (a) above, every fact sharing this fixture must want the
+    /// SAME startup flags, so a caller passes a fixed, non-per-test value here
+    /// (e.g. ServerCancelTests' <c>ExtraServerArgs()</c>, which always resolves
+    /// to the same optional <c>--package-cache</c> pointer regardless of which
+    /// fact calls it) — never one that varies by test, which would silently be
+    /// ignored on every call after the first.
+    /// </summary>
+    public async Task<CliServer> GetAsync(IEnumerable<string>? extraArgs = null)
     {
         if (_server != null) return _server;
         await _gate.WaitAsync();
@@ -91,7 +105,7 @@ public sealed class SharedCliServer : IAsyncLifetime
         {
             if (_server == null)
             {
-                _server = await CliServer.StartAsync();
+                _server = await CliServer.StartAsync(extraArgs);
                 _spawnCount++;
             }
             return _server;

--- a/AlRunner.Tests/SummaryWallClockTests.cs
+++ b/AlRunner.Tests/SummaryWallClockTests.cs
@@ -1,0 +1,149 @@
+// SummaryWallClockTests — #1936: the plain-text summary's `total:` line is only
+// AL-emit + C#-compile + test-run seconds. It does NOT include the fixed
+// per-process costs paid before any of those phases start (BC runtime patch
+// application, package-cache indexing, install-seed-dep company baseline, …).
+// A warm run of a single-test fixture can print "total: 6.3s" while the process
+// actually took ~23s wall clock — a number that reads as a lie to anyone timing
+// the CLI from the outside (see COMMON.md's boot-overhead profile).
+//
+// This adds a `wall:` line — real OS-process wall-clock, start to summary print —
+// printed right after `total:`, and a `wallSeconds` field on --output-json's JSON
+// summary. Both are strictly additive: `total:`'s existing value/semantics and
+// every existing JSON field are unchanged (proven by the exact "total:" and
+// existing-field assertions below, not just presence of the new one).
+using System.Diagnostics;
+using System.Text;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class SummaryWallClockTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+    private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
+    private static readonly string Fixture =
+        Path.Combine(RepoRoot, "AlRunner.Tests", "Fixtures", "RecordTriggerXRec");
+
+    /// <summary>
+    /// Positive: the plain-text summary prints a `wall:` line, in the same
+    /// "  label:       N.Ns" style as the existing `total:` line right above it,
+    /// whose value is both &gt; 0 (a real duration was measured, not a zeroed
+    /// stub) and &gt;= `total:`'s own value (wall clock covers strictly more than
+    /// the three phases `total:` sums — it can never read LOWER than their sum).
+    /// A gutted implementation that always printed "wall:        0.0s" would fail
+    /// the &gt; 0 half; one that echoed `total:`'s own value under a new label
+    /// would still fail the &gt;= comparison here for any fixture with non-zero
+    /// fixed boot cost, which this fixture reliably has (BC runtime patch
+    /// application alone is multiple seconds — see COMMON.md).
+    /// </summary>
+    [SkippableFact]
+    public void PlainTextSummary_PrintsWallLine_AtLeastAsLargeAsTotal()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var (output, exit) = Run($"{TestBuildConfig.BcVersionArg} \"{Fixture}\"");
+        Assert.Equal(0, exit);
+
+        var totalMatch = Regex.Match(output, @"total:\s+([\d.]+)s");
+        Assert.True(totalMatch.Success, $"expected a 'total:' line in output:\n{output}");
+        var total = double.Parse(totalMatch.Groups[1].Value);
+
+        var wallMatch = Regex.Match(output, @"wall:\s+([\d.]+)s");
+        Assert.True(wallMatch.Success, $"expected a 'wall:' line in output:\n{output}");
+        var wall = double.Parse(wallMatch.Groups[1].Value);
+
+        Assert.True(wall > 0, $"expected wall: > 0, got {wall}");
+        Assert.True(wall >= total,
+            $"expected wall: ({wall}) >= total: ({total}) — wall clock covers strictly " +
+            $"more than the emit+compile+run phases total: sums.\n{output}");
+
+        // wall: must appear directly after total: (same block, same formatting style),
+        // not floating somewhere unrelated in the output.
+        Assert.True(wallMatch.Index > totalMatch.Index,
+            "expected 'wall:' to appear after 'total:' in the summary block");
+    }
+
+    /// <summary>
+    /// Positive: --output-json carries the same real duration as a numeric
+    /// `wallSeconds` field, additive to the existing schema — every field the
+    /// JSON output already carried (exitCode, total, passed, failed) is asserted
+    /// unchanged alongside it, so this cannot pass against a change that broke
+    /// the existing shape while bolting the new field on.
+    /// </summary>
+    [SkippableFact]
+    public void JsonSummary_CarriesWallSecondsField_Numeric()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        // stdout-only: --output-json's contract is "stdout is JSON-only" (see
+        // OutputFormatTests) — [bc]/[cache] banner lines go to stderr, so mixing
+        // the two streams into one buffer would break JSON parsing.
+        var (output, exit) = RunStdoutOnly($"{TestBuildConfig.BcVersionArg} --output-json \"{Fixture}\"");
+        Assert.Equal(0, exit);
+
+        using var doc = JsonDocument.Parse(output.Trim());
+        var root = doc.RootElement;
+
+        // Existing fields still present and correct — proves the schema stayed additive.
+        Assert.Equal(0, root.GetProperty("exitCode").GetInt32());
+        Assert.Equal(1, root.GetProperty("total").GetInt32());
+        Assert.Equal(1, root.GetProperty("passed").GetInt32());
+        Assert.Equal(0, root.GetProperty("failed").GetInt32());
+
+        Assert.True(root.TryGetProperty("wallSeconds", out var wallSecondsProp),
+            $"expected a numeric 'wallSeconds' field in JSON output:\n{output}");
+        Assert.Equal(JsonValueKind.Number, wallSecondsProp.ValueKind);
+        var wallSeconds = wallSecondsProp.GetDouble();
+        Assert.True(wallSeconds > 0, $"expected wallSeconds > 0, got {wallSeconds}");
+    }
+
+    private static (string output, int exit) Run(string runnerArgs)
+    {
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            Arguments = TestBuildConfig.RunArgs(ProjectPath) + " " + runnerArgs,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            WorkingDirectory = RepoRoot,
+        };
+        var sb = new StringBuilder();
+        using var p = Process.Start(psi)!;
+        p.OutputDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.ErrorDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.BeginOutputReadLine();
+        p.BeginErrorReadLine();
+        if (!p.WaitForExit(240_000)) { try { p.Kill(true); } catch { } throw new TimeoutException("runner hung"); }
+        p.WaitForExit();
+        lock (sb) return (sb.ToString(), p.ExitCode);
+    }
+
+    private static (string output, int exit) RunStdoutOnly(string runnerArgs)
+    {
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            Arguments = TestBuildConfig.RunArgs(ProjectPath) + " " + runnerArgs,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            WorkingDirectory = RepoRoot,
+        };
+        var sb = new StringBuilder();
+        using var p = Process.Start(psi)!;
+        p.OutputDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.BeginOutputReadLine();
+        // Keep stderr separate — see OutputFormatTests' identical rationale.
+        p.ErrorDataReceived += (_, __) => { };
+        p.BeginErrorReadLine();
+        if (!p.WaitForExit(240_000)) { try { p.Kill(true); } catch { } throw new TimeoutException("runner hung"); }
+        p.WaitForExit();
+        lock (sb) return (sb.ToString(), p.ExitCode);
+    }
+}

--- a/AlRunner/AppLoader.cs
+++ b/AlRunner/AppLoader.cs
@@ -16,9 +16,13 @@
 //
 // Reference for NAVX wrapper handling: AlRunner/Program.cs:4540
 // (AppPackageReader.ExtractAlSources in v1).
+using System.Collections.Concurrent;
 using System.IO.Compression;
+using System.Security.Cryptography;
 using System.Text;
+using System.Text.Json;
 using System.Xml.Linq;
+using AlRunner.Infrastructure;
 
 namespace AlRunner;
 
@@ -39,19 +43,186 @@ public sealed record AppManifest(
 
 public static class AppLoader
 {
+    // Process-wide memo for ReadManifest, keyed by (full path, length, mtime) — cheap to
+    // compute (a single FileInfo stat, never touches file content) so a repeat ReadManifest
+    // call for the SAME file within this process is a dictionary lookup, not a re-parse.
+    // Measured: this method is called ~113 times across ProvisioningCheck.CheckPlatformApps,
+    // DependencyResolver.EnsureIndexed/Resolve and BcCompiler for the SAME package caches,
+    // often for the SAME files more than once per process — see AppLoaderManifestCacheTests.
+    private static readonly ConcurrentDictionary<string, AppManifest?> _manifestMemo = new(StringComparer.Ordinal);
+
+    /// <summary>Test-only: clears the in-process memo so a test can simulate a fresh process.</summary>
+    internal static void ResetManifestMemoForTests() => _manifestMemo.Clear();
+
+    // Test-only: counts genuine ReadManifestUncached invocations (i.e. BOTH the memo AND
+    // the disk index missed) per full .app path — mirrors BcAppSymbolCache
+    // .ParseInvocationCountByPath so a test can assert a given ReadManifest call was
+    // served from a cache rather than a re-parse that happens to produce equal content.
+    private static readonly ConcurrentDictionary<string, int> _manifestParseInvocationCountByPath =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    internal static int ManifestParseInvocationCountForTests(string appPath)
+        => _manifestParseInvocationCountByPath.TryGetValue(Path.GetFullPath(appPath), out var c) ? c : 0;
+
+    /// <summary>Test-only: the exact on-disk index path <see cref="ReadManifest"/> would use
+    /// for <paramref name="appPath"/> AT ITS CURRENT length/mtime — lets a test corrupt/inspect
+    /// that specific entry directly.</summary>
+    internal static string ManifestIndexPathForTests(string appPath)
+    {
+        var fullPath = Path.GetFullPath(appPath);
+        var fi = new FileInfo(fullPath);
+        var memoKey = $"{fullPath}|{fi.Length}|{fi.LastWriteTimeUtc.Ticks}";
+        return ManifestIndexPath(memoKey);
+    }
+
     /// <summary>
     /// Reads NavxManifest.xml from an `.app` package and returns the App element's
     /// Publisher / Name / Version / Id. Returns null if the file is malformed or
     /// missing the manifest.
+    ///
+    /// Backed by a two-level cache (issue #perf-B): an in-process memo, and — on a memo
+    /// miss — a small on-disk index under <c>CacheRoots.Resolve("app-manifests")</c> so a
+    /// SEPARATE process (a later `al-runner` invocation, or one of the 4 that run in
+    /// parallel in CI) can skip re-parsing too. Both are keyed by (full path, length,
+    /// last-write-time-UTC) — a plain stat, not a content hash: the whole point is to avoid
+    /// touching a 98MB Base Application .app's bytes just to answer "have I seen this
+    /// exact file before". A file that changes on disk (new size or mtime — e.g. CI
+    /// re-downloading a package) gets a different key and is simply reparsed; this is not
+    /// a correctness hazard, only a cache miss (see AppLoaderManifestCacheTests
+    /// .ReadManifest_TouchedMtime_IsReparsedNotServedStale).
     /// </summary>
     public static AppManifest? ReadManifest(string appPath)
     {
+        string fullPath;
+        long length;
+        long mtimeTicks;
         try
         {
-            var bytes = File.ReadAllBytes(appPath);
-            return ReadManifestFromBytes(bytes);
+            fullPath = Path.GetFullPath(appPath);
+            var fi = new FileInfo(fullPath);
+            if (!fi.Exists) return null;
+            length = fi.Length;
+            mtimeTicks = fi.LastWriteTimeUtc.Ticks;
+        }
+        catch
+        {
+            // Can't even stat the path (invalid chars, permission error, ...) — fall back
+            // to a plain uncached read so behaviour matches the pre-cache contract exactly
+            // (any failure here returns null, never throws).
+            return ReadManifestUncached(appPath);
+        }
+
+        var memoKey = $"{fullPath}|{length}|{mtimeTicks}";
+        if (_manifestMemo.TryGetValue(memoKey, out var memoized))
+            return memoized;
+
+        var indexed = TryReadManifestIndex(memoKey);
+        if (indexed != null)
+        {
+            PerfTrace.Log($"app-manifests HIT {Path.GetFileName(fullPath)}");
+            _manifestMemo[memoKey] = indexed;
+            return indexed;
+        }
+
+        _manifestParseInvocationCountByPath.AddOrUpdate(fullPath, 1, static (_, c) => c + 1);
+        var parsed = ReadManifestUncached(fullPath);
+        PerfTrace.Log($"app-manifests MISS {Path.GetFileName(fullPath)}");
+        _manifestMemo[memoKey] = parsed;
+        if (parsed != null)
+            TryWriteManifestIndex(memoKey, parsed);
+        return parsed;
+    }
+
+    /// <summary>The actual parse, with no caching — streams the .app straight off disk via
+    /// <see cref="OpenAppZip"/> rather than reading the whole file into memory first (the
+    /// dominant cost this cache exists to avoid on a cold/uncached call).</summary>
+    private static AppManifest? ReadManifestUncached(string appPath)
+    {
+        try
+        {
+            using var zip = OpenAppZip(appPath);
+            return ReadManifestFromZip(zip);
         }
         catch { return null; }
+    }
+
+    // ── on-disk manifest index (issue #perf-B) ─────────────────────────────────
+
+    private static string ManifestIndexPath(string memoKey)
+    {
+        var hash = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(memoKey))).ToLowerInvariant();
+        return Path.Combine(CacheRoots.Resolve("app-manifests"), hash + ".json");
+    }
+
+    private static AppManifest? TryReadManifestIndex(string memoKey)
+    {
+        var path = ManifestIndexPath(memoKey);
+        if (!File.Exists(path)) return null;
+        try
+        {
+            var payload = JsonSerializer.Deserialize<ManifestCachePayload>(File.ReadAllText(path));
+            var manifest = payload == null ? null : FromPayload(payload);
+            if (manifest == null)
+                PerfTrace.Log($"app-manifests index entry unusable {Path.GetFileName(path)}: payload malformed — reparsing");
+            return manifest;
+        }
+        catch (Exception ex)
+        {
+            // Corrupt/unreadable index entry: never throw, never propagate a wrong answer —
+            // just log (verbose) and let the caller fall through to a fresh parse.
+            PerfTrace.Log($"app-manifests index read failed {Path.GetFileName(path)}: {ex.Message} — reparsing");
+            return null;
+        }
+    }
+
+    private static void TryWriteManifestIndex(string memoKey, AppManifest manifest)
+    {
+        try
+        {
+            var path = ManifestIndexPath(memoKey);
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+            var payload = ToPayload(manifest);
+            // Atomic (temp file + rename) — 4 CI processes can race a write to the SAME
+            // key for the SAME shared package cache; a torn write must never be visible.
+            AlCacheWriter.AtomicPublish(path, tmp => File.WriteAllText(tmp, JsonSerializer.Serialize(payload)));
+        }
+        catch (Exception ex)
+        {
+            PerfTrace.Log($"app-manifests index write failed: {ex.Message}");
+        }
+    }
+
+    // JSON-serializable mirror of AppManifest/DependencyRef — Version/Guid round-trip as
+    // strings (System.Text.Json has no default converter for System.Version, and keeping
+    // Guid as text sidesteps ever depending on that assumption changing).
+    private sealed record ManifestCachePayload(
+        string Publisher, string Name, string Version, string AppId,
+        List<DependencyCachePayload> Dependencies,
+        string? Application, string? Platform);
+
+    private sealed record DependencyCachePayload(
+        string AppId, string Name, string Publisher, string Version, bool Optional);
+
+    private static ManifestCachePayload ToPayload(AppManifest m) => new(
+        m.Publisher, m.Name, m.Version.ToString(), m.AppId.ToString("D"),
+        m.Dependencies.Select(d => new DependencyCachePayload(
+            d.AppId.ToString("D"), d.Name, d.Publisher, d.Version.ToString(), d.Optional)).ToList(),
+        m.Application?.ToString(), m.Platform?.ToString());
+
+    private static AppManifest? FromPayload(ManifestCachePayload p)
+    {
+        if (!Guid.TryParse(p.AppId, out var appId)) return null;
+        if (!Version.TryParse(p.Version, out var version)) return null;
+        var deps = new List<DependencyRef>(p.Dependencies.Count);
+        foreach (var d in p.Dependencies)
+        {
+            Guid.TryParse(d.AppId, out var depId); // Guid.Empty is itself a legitimate stored value
+            if (!Version.TryParse(d.Version, out var depVer)) depVer = new Version(0, 0, 0, 0);
+            deps.Add(new DependencyRef(depId, d.Name, d.Publisher, depVer, d.Optional));
+        }
+        Version? appVer = p.Application != null && Version.TryParse(p.Application, out var av) ? av : null;
+        Version? platVer = p.Platform != null && Version.TryParse(p.Platform, out var pv) ? pv : null;
+        return new AppManifest(p.Publisher, p.Name, version, appId, deps, appVer, platVer);
     }
 
     /// <summary>
@@ -83,69 +254,99 @@ public static class AppLoader
         catch { return false; }
     }
 
+    /// <summary>
+    /// Byte[]-backed entry point — used to recurse into a nested R2R .app once its (small,
+    /// unavoidably-buffered — see <see cref="ReadManifestFromZip"/>) bytes are already in
+    /// hand. Not used for the outer .app anymore; that path goes through
+    /// <see cref="OpenAppZip"/> so it never reads the whole (potentially 100+MB) file.
+    /// </summary>
     private static AppManifest? ReadManifestFromBytes(byte[] bytes)
     {
         try
         {
             using var zip = OpenZipFromNavx(bytes);
-            var entry = zip.Entries.FirstOrDefault(e =>
-                string.Equals(e.FullName, "NavxManifest.xml", StringComparison.OrdinalIgnoreCase));
-            if (entry == null)
-            {
-                // R2R outer .app — recurse into nested .app
-                var nested = zip.Entries.FirstOrDefault(e =>
-                    e.FullName.EndsWith(".app", StringComparison.OrdinalIgnoreCase)
-                    && !e.FullName.Contains('/'));
-                if (nested == null) return null;
-                using var nestedStream = nested.Open();
-                using var nms = new MemoryStream();
-                nestedStream.CopyTo(nms);
-                return ReadManifestFromBytes(nms.ToArray());
-            }
-            using var s = entry.Open();
-            var doc = XDocument.Load(s);
-            XNamespace ns = "http://schemas.microsoft.com/navx/2015/manifest";
-            var app = doc.Root?.Element(ns + "App");
-            if (app == null) return null;
-            var idStr = app.Attribute("Id")?.Value;
-            var name = app.Attribute("Name")?.Value ?? "";
-            var publisher = app.Attribute("Publisher")?.Value ?? "";
-            var verStr = app.Attribute("Version")?.Value ?? "1.0.0.0";
-            if (idStr == null || !Guid.TryParse(idStr, out var id)) return null;
-            if (!Version.TryParse(verStr, out var ver)) return null;
-
-            // <Dependencies><Dependency Id="..." Name="..." Publisher="..."
-            //   MinVersion="..." CompatibilityId="..." /></Dependencies>
-            var deps = new List<DependencyRef>();
-            var depsRoot = doc.Root?.Element(ns + "Dependencies");
-            if (depsRoot != null)
-            {
-                foreach (var dep in depsRoot.Elements(ns + "Dependency"))
-                {
-                    var depIdStr = dep.Attribute("Id")?.Value;
-                    var depName = dep.Attribute("Name")?.Value ?? "";
-                    var depPub = dep.Attribute("Publisher")?.Value ?? "";
-                    var depVerStr = dep.Attribute("MinVersion")?.Value
-                        ?? dep.Attribute("Version")?.Value
-                        ?? "0.0.0.0";
-                    Guid depId = Guid.Empty;
-                    if (!string.IsNullOrEmpty(depIdStr))
-                        Guid.TryParse(depIdStr, out depId);
-                    if (!Version.TryParse(depVerStr, out var depVer))
-                        depVer = new Version(0, 0, 0, 0);
-                    deps.Add(new DependencyRef(depId, depName, depPub, depVer));
-                }
-            }
-            // Implicit first-party deps: the `Application` / `Platform` attributes
-            // on <App>. Modern apps do NOT list Microsoft apps under <Dependencies>;
-            // the real `al` compiler injects them from these attributes. Capture the
-            // versions so callers resolving a ROOT app can synthesize the matching
-            // Microsoft/Application + Microsoft/System roots (see ImplicitRoots).
-            Version.TryParse(app.Attribute("Application")?.Value, out var appVer);
-            Version.TryParse(app.Attribute("Platform")?.Value, out var platVer);
-            return new AppManifest(publisher, name, ver, id, deps, appVer, platVer);
+            return ReadManifestFromZip(zip);
         }
         catch { return null; }
+    }
+
+    /// <summary>
+    /// Core manifest lookup shared by the streamed (<see cref="OpenAppZip"/>, outer .app)
+    /// and byte[]-backed (<see cref="ReadManifestFromBytes"/>, nested .app) entry points —
+    /// only the ZipArchive's backing stream differs between callers.
+    /// </summary>
+    private static AppManifest? ReadManifestFromZip(ZipArchive zip)
+    {
+        var entry = zip.Entries.FirstOrDefault(e =>
+            string.Equals(e.FullName, "NavxManifest.xml", StringComparison.OrdinalIgnoreCase));
+        if (entry != null)
+        {
+            using var s = entry.Open();
+            return ParseManifestXml(s);
+        }
+
+        // R2R outer .app — recurse into the nested .app. Unlike the outer zip (read
+        // straight off disk, central-directory-only, via OpenAppZip), a zip ENTRY's
+        // Open() stream is forward-only/compressed, and ZipArchive needs its central
+        // directory readable from the end of a seekable stream — so the nested .app's
+        // bytes are still buffered fully here, same as before this cache existed. That
+        // remains a large net win: the nested .app carries no publishedartifacts/*.dll
+        // (those live only in the OUTER zip, which this path never touches), so it is
+        // far smaller than the whole package — e.g. nowhere near Base Application's ~98MB.
+        var nested = zip.Entries.FirstOrDefault(e =>
+            e.FullName.EndsWith(".app", StringComparison.OrdinalIgnoreCase) && !e.FullName.Contains('/'));
+        if (nested == null) return null;
+        using var nestedStream = nested.Open();
+        using var nms = new MemoryStream();
+        nestedStream.CopyTo(nms);
+        return ReadManifestFromBytes(nms.ToArray());
+    }
+
+    /// <summary>Parses a NavxManifest.xml stream into an <see cref="AppManifest"/>. Pure XML
+    /// parse — no I/O beyond what the caller's already-open <paramref name="xmlStream"/> does.</summary>
+    private static AppManifest? ParseManifestXml(Stream xmlStream)
+    {
+        var doc = XDocument.Load(xmlStream);
+        XNamespace ns = "http://schemas.microsoft.com/navx/2015/manifest";
+        var app = doc.Root?.Element(ns + "App");
+        if (app == null) return null;
+        var idStr = app.Attribute("Id")?.Value;
+        var name = app.Attribute("Name")?.Value ?? "";
+        var publisher = app.Attribute("Publisher")?.Value ?? "";
+        var verStr = app.Attribute("Version")?.Value ?? "1.0.0.0";
+        if (idStr == null || !Guid.TryParse(idStr, out var id)) return null;
+        if (!Version.TryParse(verStr, out var ver)) return null;
+
+        // <Dependencies><Dependency Id="..." Name="..." Publisher="..."
+        //   MinVersion="..." CompatibilityId="..." /></Dependencies>
+        var deps = new List<DependencyRef>();
+        var depsRoot = doc.Root?.Element(ns + "Dependencies");
+        if (depsRoot != null)
+        {
+            foreach (var dep in depsRoot.Elements(ns + "Dependency"))
+            {
+                var depIdStr = dep.Attribute("Id")?.Value;
+                var depName = dep.Attribute("Name")?.Value ?? "";
+                var depPub = dep.Attribute("Publisher")?.Value ?? "";
+                var depVerStr = dep.Attribute("MinVersion")?.Value
+                    ?? dep.Attribute("Version")?.Value
+                    ?? "0.0.0.0";
+                Guid depId = Guid.Empty;
+                if (!string.IsNullOrEmpty(depIdStr))
+                    Guid.TryParse(depIdStr, out depId);
+                if (!Version.TryParse(depVerStr, out var depVer))
+                    depVer = new Version(0, 0, 0, 0);
+                deps.Add(new DependencyRef(depId, depName, depPub, depVer));
+            }
+        }
+        // Implicit first-party deps: the `Application` / `Platform` attributes
+        // on <App>. Modern apps do NOT list Microsoft apps under <Dependencies>;
+        // the real `al` compiler injects them from these attributes. Capture the
+        // versions so callers resolving a ROOT app can synthesize the matching
+        // Microsoft/Application + Microsoft/System roots (see ImplicitRoots).
+        Version.TryParse(app.Attribute("Application")?.Value, out var appVer);
+        Version.TryParse(app.Attribute("Platform")?.Value, out var platVer);
+        return new AppManifest(publisher, name, ver, id, deps, appVer, platVer);
     }
 
     /// <summary>
@@ -265,6 +466,130 @@ public static class AppLoader
         return result;
     }
 
+    // Test-only: counts genuine ExtractAllDlls invocations (i.e. an r2r-chunks on-disk
+    // cache MISS that required re-inflating the zip), per full .app path — mirrors
+    // BcAppSymbolCache.ParseInvocationCountByPath so a test can assert the SECOND
+    // ExtractAllDllPaths call for the same file was a genuine disk HIT, not a re-extract
+    // that happens to produce the same bytes.
+    private static readonly ConcurrentDictionary<string, int> _r2rExtractInvocationCountByPath =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    internal static int R2rExtractInvocationCountForTests(string appPath)
+        => _r2rExtractInvocationCountByPath.TryGetValue(Path.GetFullPath(appPath), out var c) ? c : 0;
+
+    /// <summary>
+    /// Like <see cref="ExtractAllDlls"/>, but extracts each R2R DLL chunk to a
+    /// content-addressed cache directory on disk (once) and returns file paths instead of
+    /// byte[] blobs (issue #perf-B). Callers can then
+    /// <c>AssemblyLoadContext.LoadFromAssemblyPath</c> — which memory-maps the file
+    /// instead of duplicating it on the GC heap the way <c>Assembly.Load(byte[])</c> does —
+    /// and a warm cache skips the zip inflate entirely on every subsequent process, not
+    /// just within one. Measured: Base Application alone ships 5 chunks totalling ~210MB;
+    /// re-inflating and re-copying that on every single `al-runner` invocation was 0.9s
+    /// wall + hundreds of MB of transient RSS, paid again by every one of the 4 parallel
+    /// CI processes.
+    ///
+    /// Cache key is path+size+mtime (the same cheap-stat approach <see cref="ReadManifest"/>'s
+    /// index uses), not a content hash of the chunk bytes: hashing 200+MB just to decide
+    /// HIT-or-MISS would reintroduce the exact "read the whole file" cost this exists to
+    /// avoid. A stale key (the .app replaced with a new mtime, e.g. CI re-downloading it)
+    /// just re-extracts under a new cache-dir name — safe, not a correctness issue, only a
+    /// forgone warm-cache saving for that one file.
+    /// </summary>
+    public static IReadOnlyList<string> ExtractAllDllPaths(string appPath)
+    {
+        string fullPath;
+        FileInfo fi;
+        try
+        {
+            fullPath = Path.GetFullPath(appPath);
+            fi = new FileInfo(fullPath);
+            if (!fi.Exists) return Array.Empty<string>();
+        }
+        catch { return Array.Empty<string>(); }
+
+        var keyInput = $"{fullPath}|{fi.Length}|{fi.LastWriteTimeUtc.Ticks}";
+        var hash = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(keyInput))).ToLowerInvariant();
+        var cacheDir = Path.Combine(CacheRoots.Resolve("r2r-chunks"), hash);
+        // Published LAST by the writer below — its presence is the commit point that
+        // guarantees every *.dll beside it is a complete, non-torn set (same convention as
+        // AlCacheSidecars.IsCompleteEntry / BcAppSymbolCache's DLL-published-last rule).
+        var marker = Path.Combine(cacheDir, "complete.marker");
+
+        if (File.Exists(marker))
+        {
+            var cached = TryReadCachedDllPaths(cacheDir, marker);
+            if (cached != null)
+            {
+                PerfTrace.Log($"r2r-chunks HIT {Path.GetFileName(fullPath)} {cached.Count} chunk(s)");
+                return cached;
+            }
+        }
+
+        _r2rExtractInvocationCountByPath.AddOrUpdate(fullPath, 1, static (_, c) => c + 1);
+        var dlls = ExtractAllDlls(fullPath);
+        if (dlls.Count == 0) return Array.Empty<string>();
+
+        try
+        {
+            Directory.CreateDirectory(cacheDir);
+            var paths = new List<string>(dlls.Count);
+            for (int i = 0; i < dlls.Count; i++)
+            {
+                var dllPath = Path.Combine(cacheDir, $"{i:D3}.dll");
+                AlCacheWriter.AtomicPublish(dllPath, tmp => File.WriteAllBytes(tmp, dlls[i]));
+                paths.Add(dllPath);
+            }
+            AlCacheWriter.AtomicPublish(marker, tmp => File.WriteAllText(tmp, dlls.Count.ToString()));
+            PerfTrace.Log($"r2r-chunks MISS {Path.GetFileName(fullPath)} wrote {paths.Count} chunk(s)");
+            return paths;
+        }
+        catch (Exception ex)
+        {
+            // Cache write failed (read-only cache dir, disk full, ...) — not fatal: fall
+            // back to a per-process temp dir so the return contract (file paths that exist
+            // and stay valid for the process's lifetime) still holds. Never silently drop
+            // a chunk the caller asked for.
+            PerfTrace.Log($"r2r-chunks write failed for {Path.GetFileName(fullPath)}: {ex.Message} — using temp fallback");
+            return WriteDllsToTempFallback(dlls);
+        }
+    }
+
+    private static List<string>? TryReadCachedDllPaths(string cacheDir, string marker)
+    {
+        try
+        {
+            var countText = File.ReadAllText(marker);
+            if (!int.TryParse(countText, out var expectedCount) || expectedCount <= 0) return null;
+            var files = Directory.GetFiles(cacheDir, "*.dll").OrderBy(f => f, StringComparer.Ordinal).ToList();
+            if (files.Count != expectedCount) return null;
+            return files;
+        }
+        catch (Exception ex)
+        {
+            // Corrupt/unreadable cache entry (partial write from a crashed process, torn
+            // read, ...) — log (verbose) and let the caller re-extract, same "cache that
+            // falls back to recomputing on miss/corruption is fine, but log it" contract
+            // ReadManifest's index follows.
+            PerfTrace.Log($"r2r-chunks index read failed {Path.GetFileName(cacheDir)}: {ex.Message} — re-extracting");
+            return null;
+        }
+    }
+
+    private static List<string> WriteDllsToTempFallback(IReadOnlyList<byte[]> dlls)
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "al-runner-r2r-chunks-fallback", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        var paths = new List<string>(dlls.Count);
+        for (int i = 0; i < dlls.Count; i++)
+        {
+            var p = Path.Combine(dir, $"{i:D3}.dll");
+            File.WriteAllBytes(p, dlls[i]);
+            paths.Add(p);
+        }
+        return paths;
+    }
+
     /// <summary>
     /// Returns the per-AL-object C# sources from an alc `/generatecode+` `.app`
     /// (the `bin/*.cs` entries). Empty list if the package contains no `bin/*.cs`.
@@ -365,10 +690,109 @@ public static class AppLoader
 
     // ── internals ────────────────────────────────────────────────────────────
 
+    /// <summary>
+    /// Opens the given .app's outer ZIP straight off disk via a <see cref="FileStream"/>,
+    /// WITHOUT reading the whole file into memory first (issue #perf-B — was
+    /// <c>File.ReadAllBytes</c>, the dominant cost of every caller of this method:
+    /// <see cref="ReadManifest"/>, <see cref="IsR2R"/>, <see cref="ExtractAllDlls"/>,
+    /// <see cref="ExtractDll"/>). ZipArchive's Read-mode constructor only parses the
+    /// central directory + whichever entries the caller actually <c>.Open()</c>s, so this
+    /// alone turns "read all N MB of a package" into "read the directory, then only the
+    /// bytes of the entries actually touched" for every one of those callers, not just the
+    /// manifest path. The returned archive owns the FileStream (disposed transitively
+    /// through <see cref="NavxZipView"/> when the caller disposes the archive).
+    /// </summary>
     private static ZipArchive OpenAppZip(string appPath)
     {
-        var bytes = File.ReadAllBytes(appPath);
-        return OpenZipFromNavx(bytes);
+        var fs = new FileStream(appPath, FileMode.Open, FileAccess.Read, FileShare.Read, bufferSize: 65536, useAsync: false);
+        try
+        {
+            var offset = ReadNavxOffsetFromStream(fs);
+            var view = new NavxZipView(fs, offset);
+            return new ZipArchive(view, ZipArchiveMode.Read, leaveOpen: false);
+        }
+        catch
+        {
+            fs.Dispose();
+            throw;
+        }
+    }
+
+    private static int ReadNavxOffsetFromStream(FileStream fs)
+    {
+        fs.Position = 0;
+        Span<byte> header = stackalloc byte[8];
+        int total = 0;
+        while (total < 8)
+        {
+            int n = fs.Read(header.Slice(total));
+            if (n == 0) break; // shorter than 8 bytes — not NAVX-prefixed
+            total += n;
+        }
+        if (total == 8 && header[0] == (byte)'N' && header[1] == (byte)'A'
+            && header[2] == (byte)'V' && header[3] == (byte)'X')
+            return (int)BitConverter.ToUInt32(header.Slice(4, 4));
+        return 0;
+    }
+
+    /// <summary>
+    /// Read-only, offset view of a seekable stream: makes byte <paramref name="offset"/> of
+    /// the wrapped stream appear as position 0 to a consumer. ZipArchive parses a ZIP's
+    /// central directory via absolute <c>Seek(..., SeekOrigin.Begin)</c> calls that must
+    /// land at "start of the zip data" — but a BC .app's zip payload starts a few bytes
+    /// into the physical file (the NAVX magic + offset header), so reading a FileStream for
+    /// the whole file directly would misalign every central-directory offset. This view is
+    /// what lets <see cref="OpenAppZip"/> hand ZipArchive a stream where position 0 really
+    /// is the zip's start, without ever copying the file's bytes into memory. Only the
+    /// members ZipArchive's Read-mode constructor actually calls are implemented.
+    /// </summary>
+    private sealed class NavxZipView : Stream
+    {
+        private readonly Stream _inner;
+        private readonly long _offset;
+
+        internal NavxZipView(Stream inner, long offset)
+        {
+            _inner = inner;
+            _offset = offset;
+            _inner.Position = offset;
+        }
+
+        public override bool CanRead => true;
+        public override bool CanSeek => true;
+        public override bool CanWrite => false;
+        public override long Length => _inner.Length - _offset;
+        public override long Position
+        {
+            get => _inner.Position - _offset;
+            set => _inner.Position = _offset + value;
+        }
+
+        public override int Read(byte[] buffer, int offset, int count) => _inner.Read(buffer, offset, count);
+        public override int Read(Span<byte> buffer) => _inner.Read(buffer);
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            long absolute = origin switch
+            {
+                SeekOrigin.Begin => _offset + offset,
+                SeekOrigin.Current => _inner.Position + offset,
+                SeekOrigin.End => _offset + Length + offset,
+                _ => throw new ArgumentOutOfRangeException(nameof(origin)),
+            };
+            _inner.Position = absolute;
+            return absolute - _offset;
+        }
+
+        public override void Flush() { }
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing) _inner.Dispose();
+            base.Dispose(disposing);
+        }
     }
 
     private static ZipArchive OpenZipFromNavx(byte[] bytes)

--- a/AlRunner/BcRuntime.cs
+++ b/AlRunner/BcRuntime.cs
@@ -532,9 +532,10 @@ public static partial class BcRuntime
             BindingFlags.Public | BindingFlags.Static)!;
         try
         {
-            foreach (var t in asm.GetTypes())
+            // Only XmlPort* types are candidates, and AssemblyTypeIndex resolves exactly those
+            // out of the TypeDef table — no whole-assembly type load just to reject the rest.
+            foreach (var t in AlRunner.Infrastructure.AssemblyTypeIndex.For(asm).EnumerateWithPrefix("XmlPort"))
             {
-                if (!t.Name.StartsWith("XmlPort")) continue;
                 var m = t.GetMethod("InitializeComponent",
                     BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly,
                     null, Type.EmptyTypes, null);

--- a/AlRunner/DependencyLoader.cs
+++ b/AlRunner/DependencyLoader.cs
@@ -248,20 +248,29 @@ public sealed class DependencyLoader
         // the Resolving handler can serve cross-chunk references.
         if (AppLoader.IsR2R(appPath))
         {
-            var dlls = AppLoader.ExtractAllDlls(appPath);
-            if (dlls.Count > 0)
+            // #perf-B: extract each chunk once into a content-addressed on-disk cache
+            // (AppLoader.ExtractAllDllPaths) and load from PATH via
+            // AssemblyLoadContext.LoadFromAssemblyPath rather than re-inflating the zip and
+            // Assembly.Load(byte[])-ing every chunk on every single invocation. Base
+            // Application alone is ~210MB across 5 chunks; LoadFromAssemblyPath memory-maps
+            // the file instead of duplicating it on the GC heap, and a warm r2r-chunks cache
+            // skips the zip inflate entirely on repeat runs (including across processes —
+            // the 4 that run in parallel in CI share the same cache root).
+            var dllPaths = AppLoader.ExtractAllDllPaths(appPath);
+            if (dllPaths.Count > 0)
             {
                 Assembly? primary = null;
                 int loaded = 0;
-                foreach (var dll in dlls)
+                foreach (var dllPath in dllPaths)
                 {
                     try
                     {
-                        var asm = Assembly.Load(dll);
-                        // #1852: same pre-warm as Tier 1 — these R2R chunks are exactly the
-                        // multi-thousand-type BaseApplication/SystemApplication assemblies
-                        // whose GetTypes() cost was measured at 0.7s-4.3s EACH.
-                        AlRunner.Patches.RecordPatches.SeedCompiledReportIdsFromPEBytes(asm, dll);
+                        var asm = AssemblyLoadContext.Default.LoadFromAssemblyPath(dllPath);
+                        // #1852 (path variant, #perf-B): same pre-warm as Tier 1, but reads
+                        // the TypeDef table straight off disk — the bytes are no longer held
+                        // in memory after a path-based load, so re-reading them as byte[]
+                        // just for this would reintroduce the cost #1852 removed.
+                        AlRunner.Patches.RecordPatches.SeedCompiledReportIdsFromPeFile(asm, dllPath);
                         var n = asm.GetName().Name ?? "";
                         _byName[n] = asm;
                         primary ??= asm;

--- a/AlRunner/Infrastructure/AssemblyTypeIndex.cs
+++ b/AlRunner/Infrastructure/AssemblyTypeIndex.cs
@@ -1,0 +1,510 @@
+// AssemblyTypeIndex — resolve types (and attributed methods) in a loaded assembly by reading
+// its ECMA-335 metadata tables instead of calling Assembly.GetTypes().
+//
+// WHY THIS EXISTS
+// ---------------
+// Assembly.GetTypes() does not "list the types"; it materialises a RuntimeType for EVERY
+// TypeDef row in the module — resolving base types, interfaces and generic constraints as it
+// goes. On the R2R chunk assemblies DependencyLoader loads for Base Application / System
+// Application that is 132,541 types, and it was measured (dotnet-trace, warm cache HIT run of
+// AlRunner.Tests/Fixtures/RecordTriggerXRec, 2026-08-17) at 6.5s for the five Base App chunks
+// alone — 8.4s inclusive inside EventSubscriberPatches.EnsureRegistryFresh plus another 1.5s
+// in RecordPatches.Register, i.e. ~40% of a 23.4s warm invocation, spent to answer questions
+// like "is there a type called Codeunit50100 in here".
+//
+// The metadata tables answer exactly those questions without loading a single type:
+//   * TypeDef.Name          → the simple name Type.Name would return.
+//   * TypeDef.Namespace     → combined with the nesting chain, the name Assembly.GetType wants.
+//   * MethodDef + CustomAttribute → which methods carry [NavEventSubscriberAttribute].
+// Measured on the same five chunks: full TypeDef/MethodDef/CustomAttribute walk = 60ms, and
+// asm.GetType(fullName) for the 3,270 types that actually matched = 5ms. Two orders of
+// magnitude, and the CLR still only ever loads the types we genuinely use.
+//
+// System.Reflection.Metadata.AssemblyExtensions.TryGetRawMetadata hands back a pointer into
+// the already-mapped PE image, so this works for Assembly.Load(byte[]) assemblies too — which
+// matters because that is exactly how DependencyLoader loads the big ones and their
+// asm.Location is empty, ruling out re-opening the file.
+//
+// FIDELITY
+// --------
+// Every lookup here returns a real CLR Type/MethodInfo obtained through asm.GetType(...) /
+// Type.GetMethod(...) — the metadata is used only to decide WHICH names to ask for, never to
+// synthesise an answer. A name the metadata says is present but the CLR then refuses to load
+// is reported on stderr, never silently swallowed (see .claude/rules/loud-failures.md).
+//
+// FALLBACK
+// --------
+// A dynamic (Reflection.Emit) assembly has no raw metadata to read. Those fall back to the
+// pre-existing Assembly.GetTypes() path, which is correct and — for a dynamic assembly, which
+// has a handful of types, not 132k — also cheap. The fallback logs once per assembly under
+// AL_RUNNER_VERBOSE so it can never become an invisible perf cliff.
+
+using System.Collections.Concurrent;
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
+using System.Runtime.CompilerServices;
+using System.Text;
+
+namespace AlRunner.Infrastructure;
+
+internal sealed class AssemblyTypeIndex
+{
+    private static readonly ConditionalWeakTable<Assembly, AssemblyTypeIndex> _cache = new();
+
+    private readonly Assembly _asm;
+
+    /// <summary>Metadata reader over the assembly's mapped PE image; null when the assembly
+    /// is dynamic (no raw metadata) — see <see cref="_fallbackTypes"/>.</summary>
+    private readonly MetadataReader? _mr;
+
+    /// <summary>Simple type name → TypeDef row number, or a <see cref="List{T}"/> of them when
+    /// one assembly declares several types with the same simple name (different namespaces or
+    /// different enclosing types). Row numbers, not full-name strings: a distinct-simple-name
+    /// keyed dictionary is a fraction of the memory a 132k-entry full-name map would cost, and
+    /// the full name is only ever needed for the handful of rows we actually resolve.</summary>
+    private readonly Dictionary<string, object>? _byName;
+
+    /// <summary>Only populated for dynamic assemblies (see class header).</summary>
+    private readonly Type[]? _fallbackTypes;
+
+    private readonly ConcurrentDictionary<int, Type?> _resolvedByRow = new();
+
+    /// <summary>
+    /// Serialises every <see cref="MetadataReader"/> access. The reader itself is only read
+    /// from, but it lazily materialises parts of the string/virtual heap on first touch, so
+    /// concurrent readers are not safe. Lookups reach this class from several patch classes
+    /// with no shared lock ordering (that is also why <see cref="_resolvedByRow"/> is a
+    /// ConcurrentDictionary), and the guarded regions are microseconds of table walking, so an
+    /// uncontended monitor is the right trade.
+    /// </summary>
+    private readonly object _mrLock = new();
+
+    private unsafe AssemblyTypeIndex(Assembly asm)
+    {
+        _asm = asm;
+        byte* blob;
+        int length;
+        bool haveMetadata;
+        try { haveMetadata = asm.TryGetRawMetadata(out blob, out length); }
+        catch { haveMetadata = false; blob = null; length = 0; }
+
+        if (haveMetadata && blob != null && length > 0)
+        {
+            try
+            {
+                _mr = new MetadataReader(blob, length);
+                _byName = BuildNameIndex(_mr);
+                return;
+            }
+            catch (Exception ex)
+            {
+                // Not a silent default: the fallback below is the pre-existing, correct
+                // path, and the reason it was taken is on the record (bracket-tagged, so
+                // visible under --verbose / AL_RUNNER_VERBOSE=1).
+                Console.Error.WriteLine(
+                    $"[type-index] metadata unreadable for {asm.GetName().Name}: " +
+                    $"{ex.GetType().Name}: {ex.Message} — falling back to Assembly.GetTypes()");
+                _mr = null;
+                _byName = null;
+            }
+        }
+        else
+        {
+            Console.Error.WriteLine(
+                $"[type-index] no raw metadata for {asm.GetName().Name} " +
+                "(dynamic assembly?) — falling back to Assembly.GetTypes()");
+        }
+
+        try { _fallbackTypes = asm.GetTypes(); }
+        catch (ReflectionTypeLoadException ex) { _fallbackTypes = ex.Types.Where(t => t != null).ToArray()!; }
+        catch { _fallbackTypes = Array.Empty<Type>(); }
+    }
+
+    private static Dictionary<string, object> BuildNameIndex(MetadataReader mr)
+    {
+        var map = new Dictionary<string, object>(mr.TypeDefinitions.Count, StringComparer.Ordinal);
+        foreach (var handle in mr.TypeDefinitions)
+        {
+            var name = mr.GetString(mr.GetTypeDefinition(handle).Name);
+            int row = MetadataTokens.GetRowNumber(handle);
+            if (!map.TryGetValue(name, out var existing)) { map[name] = row; continue; }
+            if (existing is List<int> list) { list.Add(row); continue; }
+            map[name] = new List<int> { (int)existing, row };
+        }
+        return map;
+    }
+
+    internal static AssemblyTypeIndex For(Assembly asm)
+        => _cache.GetValue(asm, static a => new AssemblyTypeIndex(a));
+
+    /// <summary>True when this index was built from metadata rather than the GetTypes() fallback.</summary>
+    internal bool IsMetadataBacked => _mr != null;
+
+    /// <summary>
+    /// The metadata-backed equivalent of
+    /// <c>Array.Find(asm.GetTypes(), x =&gt; x.Name == simpleName &amp;&amp; predicate(x))</c>,
+    /// including its ordering: candidates are considered in TypeDef-table order, which is the
+    /// order <c>Assembly.GetTypes()</c> itself yields, so a caller relying on "first match wins"
+    /// gets the same match it got before.
+    /// </summary>
+    internal Type? FindFirst(string simpleName, Func<Type, bool>? predicate = null)
+    {
+        if (_byName == null || _mr == null)
+        {
+            foreach (var t in _fallbackTypes!)
+                if (t.Name == simpleName && (predicate == null || Safe(predicate, t))) return t;
+            return null;
+        }
+        if (!_byName.TryGetValue(simpleName, out var rows)) return null;
+        if (rows is int single) return Accept(single, predicate);
+        foreach (var row in (List<int>)rows)
+        {
+            var hit = Accept(row, predicate);
+            if (hit != null) return hit;
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Every type in this assembly whose simple name starts with <paramref name="prefix"/>,
+    /// resolved to a real CLR <see cref="Type"/>. Used by bulk pre-warms (e.g.
+    /// RecordPatches' Record{id} cache) that previously walked all of
+    /// <c>Assembly.GetTypes()</c> to pick out a few hundred names.
+    /// </summary>
+    internal IEnumerable<Type> EnumerateWithPrefix(string prefix)
+    {
+        if (_byName == null || _mr == null)
+        {
+            foreach (var t in _fallbackTypes!)
+                if (t.Name.StartsWith(prefix, StringComparison.Ordinal)) yield return t;
+            yield break;
+        }
+        foreach (var kv in _byName)
+        {
+            if (!kv.Key.StartsWith(prefix, StringComparison.Ordinal)) continue;
+            if (kv.Value is int single)
+            {
+                var t = Accept(single, null);
+                if (t != null) yield return t;
+                continue;
+            }
+            foreach (var row in (List<int>)kv.Value)
+            {
+                var t = Accept(row, null);
+                if (t != null) yield return t;
+            }
+        }
+    }
+
+    /// <summary>
+    /// The simple NAMES of every type in this assembly starting with <paramref name="prefix"/>,
+    /// read straight out of the TypeDef table — no <see cref="Type"/> is resolved and no type is
+    /// loaded. For callers whose whole question is about the name (e.g. "which Report{id} types
+    /// exist here"), this is the cheapest possible answer and, unlike a Type-resolving walk, it
+    /// has no partial-load failure mode: the metadata either reads or it does not.
+    /// Only valid when <see cref="IsMetadataBacked"/> — throws otherwise, so a caller cannot
+    /// silently receive an empty answer for a dynamic assembly.
+    /// </summary>
+    internal IEnumerable<string> TypeNamesWithPrefix(string prefix)
+    {
+        if (_byName == null)
+            throw new InvalidOperationException(
+                $"TypeNamesWithPrefix is metadata-only; {_asm.GetName().Name} has no readable metadata. " +
+                "Guard the call with IsMetadataBacked.");
+        foreach (var kv in _byName)
+        {
+            if (!kv.Key.StartsWith(prefix, StringComparison.Ordinal)) continue;
+            int copies = kv.Value is int ? 1 : ((List<int>)kv.Value).Count;
+            for (int i = 0; i < copies; i++) yield return kv.Key;
+        }
+    }
+
+    /// <summary>
+    /// The type nested directly inside <paramref name="declaringType"/> whose simple name is
+    /// <paramref name="nestedSimpleName"/>, resolved without loading its siblings.
+    ///
+    /// <c>Type.GetNestedTypes()</c> — and, because the CLR resolves each nested type handle
+    /// BEFORE applying the name filter, <c>Type.GetNestedType(name)</c> too — materialises
+    /// EVERY nested type of the declaring type. On BC's AL-emitted codeunits that means every
+    /// async state machine and every &lt;Event&gt;_Scope class, for each of the ~1,700
+    /// publisher keys the event-scope seeding walks: measured at 1.9s of a 15.3s warm
+    /// invocation. The NestedClass metadata table answers the same question by name first, so
+    /// only the one type that matches is ever resolved.
+    /// </summary>
+    internal Type? FindNestedType(Type declaringType, string nestedSimpleName)
+    {
+        if (_mr != null && ReferenceEquals(declaringType.Assembly, _asm))
+        {
+            try
+            {
+                int? matchedRow = null;
+                lock (_mrLock)
+                {
+                    var td = _mr.GetTypeDefinition(
+                        (TypeDefinitionHandle)MetadataTokens.EntityHandle(declaringType.MetadataToken));
+                    foreach (var nh in td.GetNestedTypes())
+                    {
+                        if (!string.Equals(_mr.GetString(_mr.GetTypeDefinition(nh).Name),
+                                           nestedSimpleName, StringComparison.Ordinal)) continue;
+                        matchedRow = MetadataTokens.GetRowNumber(nh);
+                        break;
+                    }
+                }
+                return matchedRow is int row ? ResolveRow(row) : null;
+            }
+            catch
+            {
+                // A type whose metadata token we cannot map (dynamic/constructed edge cases)
+                // falls through to the reflection answer below rather than being reported absent.
+            }
+        }
+        try { return declaringType.GetNestedType(nestedSimpleName, BindingFlags.Public | BindingFlags.NonPublic); }
+        catch { return null; }
+    }
+
+    private Type? Accept(int row, Func<Type, bool>? predicate)
+    {
+        var t = ResolveRow(row);
+        if (t == null) return null;
+        if (predicate != null && !Safe(predicate, t)) return null;
+        return t;
+    }
+
+    private static bool Safe(Func<Type, bool> predicate, Type t)
+    {
+        try { return predicate(t); }
+        catch { return false; }
+    }
+
+    private Type? ResolveRow(int row) => _resolvedByRow.GetOrAdd(row, r =>
+    {
+        string? fullName;
+        lock (_mrLock) fullName = BuildFullName(MetadataTokens.TypeDefinitionHandle(r));
+        if (fullName == null) return null;
+        try { return _asm.GetType(fullName, throwOnError: false); }
+        catch { return null; }
+    });
+
+    /// <summary>
+    /// Reflection-name for a TypeDef row: <c>Namespace.Outer+Inner</c>, with the characters
+    /// <c>Assembly.GetType</c>'s parser treats as syntax escaped inside each name part. Returns
+    /// null if the nesting chain cannot be walked.
+    /// </summary>
+    private string? BuildFullName(TypeDefinitionHandle handle)
+    {
+        var mr = _mr!;
+        var parts = new List<string>(2);
+        var cursor = handle;
+        for (int guard = 0; guard < 64; guard++)
+        {
+            TypeDefinition td;
+            try { td = mr.GetTypeDefinition(cursor); }
+            catch { return null; }
+            parts.Add(mr.GetString(td.Name));
+            var declaring = td.GetDeclaringType();
+            if (declaring.IsNil)
+            {
+                var ns = mr.GetString(td.Namespace);
+                var sb = new StringBuilder();
+                if (ns.Length != 0) { sb.Append(ns); sb.Append('.'); }
+                for (int i = parts.Count - 1; i >= 0; i--)
+                {
+                    AppendEscaped(sb, parts[i]);
+                    if (i > 0) sb.Append('+');
+                }
+                return sb.ToString();
+            }
+            cursor = declaring;
+        }
+        return null;
+    }
+
+    private static void AppendEscaped(StringBuilder sb, string namePart)
+    {
+        foreach (var c in namePart)
+        {
+            // The characters Type.GetType/Assembly.GetType's grammar reserves. AL/BC object
+            // type names never contain them, but a compiler-generated or ISV type might.
+            if (c is '\\' or ',' or '[' or ']' or '&' or '*' or '+') sb.Append('\\');
+            sb.Append(c);
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Attributed-method discovery
+    // ------------------------------------------------------------------
+
+    /// <summary>
+    /// Every method declared on a type whose simple name starts with
+    /// <paramref name="declaringTypeNamePrefix"/> and that carries a custom attribute whose
+    /// attribute type's simple name is <paramref name="attributeSimpleName"/> — decided from
+    /// the CustomAttribute table, so no type outside the matches is ever loaded.
+    ///
+    /// The returned <see cref="MethodInfo"/>s are the real reflection objects the caller then
+    /// reads the real attribute instance off; this method decides only WHICH methods to hand
+    /// back, never what the attribute says.
+    /// </summary>
+    internal List<MethodInfo> FindAttributedMethods(string declaringTypeNamePrefix, string attributeSimpleName)
+    {
+        var result = new List<MethodInfo>();
+        if (_byName == null || _mr == null)
+        {
+            foreach (var t in _fallbackTypes!)
+            {
+                if (!t.Name.StartsWith(declaringTypeNamePrefix, StringComparison.Ordinal)) continue;
+                MethodInfo[] methods;
+                try { methods = t.GetMethods(DeclaredMethodFlags); }
+                catch { continue; }
+                foreach (var m in methods)
+                {
+                    bool hit;
+                    try
+                    {
+                        hit = CustomAttributeData.GetCustomAttributes(m)
+                            .Any(a => a.AttributeType.Name == attributeSimpleName);
+                    }
+                    catch { continue; }
+                    if (hit) result.Add(m);
+                }
+            }
+            return result;
+        }
+
+        // Phase 1 — pure metadata: which TypeDef rows declare attributed methods, and with what
+        // name/arity. Nothing is loaded here, so the whole walk stays inside the reader lock.
+        var perType = new List<(int Row, string TypeName, List<(string Name, int ParamCount)> Hits)>();
+        lock (_mrLock)
+        {
+            var mr = _mr;
+            foreach (var tdh in mr.TypeDefinitions)
+            {
+                TypeDefinition td;
+                try { td = mr.GetTypeDefinition(tdh); }
+                catch { continue; }
+                var typeName = mr.GetString(td.Name);
+                if (!typeName.StartsWith(declaringTypeNamePrefix, StringComparison.Ordinal)) continue;
+
+                List<(string Name, int ParamCount)>? hits = null;
+                foreach (var mdh in td.GetMethods())
+                {
+                    MethodDefinition md;
+                    try { md = mr.GetMethodDefinition(mdh); }
+                    catch { continue; }
+                    if (!HasAttribute(mr, md.GetCustomAttributes(), attributeSimpleName)) continue;
+                    (hits ??= new()).Add((mr.GetString(md.Name), ReadParameterCount(mr, md)));
+                }
+                if (hits != null) perType.Add((MetadataTokens.GetRowNumber(tdh), typeName, hits));
+            }
+        }
+
+        // Phase 2 — resolve only the types that actually matched, and read their real methods.
+        foreach (var (row, typeName, hits) in perType)
+        {
+            var clrType = ResolveRow(row);
+            if (clrType == null)
+            {
+                Console.Error.WriteLine(
+                    $"[type-index] {_asm.GetName().Name}: metadata says {typeName} declares " +
+                    $"{hits.Count} [{attributeSimpleName}] method(s) but the CLR would not load the type — " +
+                    "those subscribers cannot be registered.");
+                continue;
+            }
+            MethodInfo[] declared;
+            try { declared = clrType.GetMethods(DeclaredMethodFlags); }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine(
+                    $"[type-index] {_asm.GetName().Name}: GetMethods failed on {clrType.FullName}: " +
+                    $"{ex.GetType().Name}: {ex.Message}");
+                continue;
+            }
+            var used = new HashSet<MethodInfo>();
+            foreach (var (name, paramCount) in hits)
+            {
+                // Overloads are disambiguated on arity (read straight out of the metadata
+                // signature). Two same-name same-arity overloads that BOTH carry the
+                // attribute are then taken in declaration order via `used`.
+                MethodInfo? match = declared.FirstOrDefault(
+                    m => m.Name == name && !used.Contains(m) && m.GetParameters().Length == paramCount);
+                // paramCount == -1 means the signature blob was unreadable; fall back to
+                // name-only so the subscriber is still registered rather than dropped.
+                match ??= declared.FirstOrDefault(m => m.Name == name && !used.Contains(m));
+                if (match == null)
+                {
+                    Console.Error.WriteLine(
+                        $"[type-index] {_asm.GetName().Name}: {clrType.FullName}.{name}/{paramCount} carries " +
+                        $"[{attributeSimpleName}] in metadata but no matching declared MethodInfo was found.");
+                    continue;
+                }
+                used.Add(match);
+                result.Add(match);
+            }
+        }
+        return result;
+    }
+
+    internal const BindingFlags DeclaredMethodFlags =
+        BindingFlags.DeclaredOnly | BindingFlags.Public | BindingFlags.NonPublic
+        | BindingFlags.Instance | BindingFlags.Static;
+
+    private static bool HasAttribute(MetadataReader mr, CustomAttributeHandleCollection attrs, string attributeSimpleName)
+    {
+        foreach (var cah in attrs)
+        {
+            CustomAttribute ca;
+            try { ca = mr.GetCustomAttribute(cah); }
+            catch { continue; }
+            if (AttributeTypeName(mr, ca.Constructor) == attributeSimpleName) return true;
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Simple name of the type declaring a CustomAttribute's constructor. The constructor is a
+    /// MemberRef when the attribute type lives in another assembly (the normal case for
+    /// [NavEventSubscriber], defined in Ncl and applied in AL-emitted assemblies) and a
+    /// MethodDef when the attribute is applied inside its own defining assembly.
+    /// </summary>
+    private static string? AttributeTypeName(MetadataReader mr, EntityHandle ctor)
+    {
+        try
+        {
+            switch (ctor.Kind)
+            {
+                case HandleKind.MemberReference:
+                {
+                    var parent = mr.GetMemberReference((MemberReferenceHandle)ctor).Parent;
+                    return parent.Kind switch
+                    {
+                        HandleKind.TypeReference => mr.GetString(mr.GetTypeReference((TypeReferenceHandle)parent).Name),
+                        HandleKind.TypeDefinition => mr.GetString(mr.GetTypeDefinition((TypeDefinitionHandle)parent).Name),
+                        _ => null, // TypeSpec (generic attribute) — not a shape BC emits
+                    };
+                }
+                case HandleKind.MethodDefinition:
+                {
+                    var declaring = mr.GetMethodDefinition((MethodDefinitionHandle)ctor).GetDeclaringType();
+                    return mr.GetString(mr.GetTypeDefinition(declaring).Name);
+                }
+                default:
+                    return null;
+            }
+        }
+        catch { return null; }
+    }
+
+    /// <summary>Parameter count straight out of the MethodDef signature blob (ECMA-335 II.23.2.1:
+    /// calling-convention byte, optional generic arity, then the parameter count).</summary>
+    private static int ReadParameterCount(MetadataReader mr, MethodDefinition md)
+    {
+        try
+        {
+            var reader = mr.GetBlobReader(md.Signature);
+            var header = reader.ReadSignatureHeader();
+            if (header.IsGeneric) reader.ReadCompressedInteger();
+            return reader.ReadCompressedInteger();
+        }
+        catch { return -1; }
+    }
+}

--- a/AlRunner/Infrastructure/InstallBaselineDiskCache.cs
+++ b/AlRunner/Infrastructure/InstallBaselineDiskCache.cs
@@ -1,0 +1,117 @@
+// InstallBaselineDiskCache — the on-disk half of the #1867 dependency+company install-baseline
+// cache. The in-memory dictionary in TestExecutor.Run removes the repeat inside one process;
+// this removes it across processes, which is where the remaining cost lives (every CI test
+// spawn, every corpus/runner-extras invocation, every --watch rebuild pays the same 5.9s).
+//
+// Layout: <cache-root>/install-baseline/<sha256-of-key>.bin, written atomically (temp file in
+// the same directory + File.Move(overwrite)) because CI runs four runner processes in
+// parallel and they all key on the same MS-platform dependency closure.
+//
+// The KEY is everything the snapshot's content depends on:
+//   * the dependency assembly set, by Module Version ID (InstallTriggerRunner
+//     .CurrentDependencySetKey) — MVIDs move whenever the underlying IL does, so a dependency
+//     recompiled after a source edit re-keys instead of hitting a stale entry. This also
+//     covers the dependency .app bytes: what is loaded and fires Install triggers is the DLL
+//     extracted from the .app, and its MVID is that DLL's identity.
+//   * the runner build + selected BC version (RunnerFingerprint.WriteKeyLines) — the snapshot
+//     is produced by runner patch code executing BC bodies, so both sides can change it
+//     without any dependency changing.
+//   * the codec's schema version — a layout change must not read an old file.
+//
+// Failure policy: every disk operation is best-effort. A read that cannot produce a valid
+// snapshot deletes the entry and reports a miss; a write that fails logs and is dropped. The
+// caller always has the fresh-computation path available, so the cache can never be the
+// reason a run fails — but every fallback is logged (never silent).
+namespace AlRunner.Infrastructure;
+
+internal static class InstallBaselineDiskCache
+{
+    internal const string CacheName = "install-baseline";
+
+    /// <summary>Kill switch shared with the in-memory cache: forces a full recompute and skips
+    /// BOTH the disk read and the disk write, so the fresh-computation path can be re-run on
+    /// demand without a patched rebuild and without a poisoned file surviving the diagnosis.</summary>
+    internal static bool Disabled
+        => Environment.GetEnvironmentVariable("AL_RUNNER_NO_DEP_COMPANY_CACHE") == "1";
+
+    /// <summary>The full, human-readable key text. Hashed for the filename, and embedded in the
+    /// file itself so a hash collision or a hand-copied file cannot be mistaken for a hit.</summary>
+    internal static string BuildKeyText(string dependencySetKey, int schemaVersion)
+    {
+        var sb = new System.Text.StringBuilder();
+        sb.Append("install-baseline-schema:").Append(schemaVersion).Append('\n');
+        RunnerFingerprint.WriteKeyLines(line => sb.Append(line).Append('\n'));
+        sb.Append("deps:").Append(dependencySetKey).Append('\n');
+        return sb.ToString();
+    }
+
+    internal static string HashKey(string keyText)
+    {
+        using var sha = System.Security.Cryptography.SHA256.Create();
+        return Convert.ToHexString(sha.ComputeHash(System.Text.Encoding.UTF8.GetBytes(keyText)))
+            .ToLowerInvariant();
+    }
+
+    internal static string PathForKey(string keyText)
+        => Path.Combine(CacheRoots.Resolve(CacheName), HashKey(keyText) + ".bin");
+
+    /// <summary>Read the raw bytes for a key, or null when there is no usable entry. Deletes an
+    /// entry it could not read so the next run rewrites it instead of failing again.</summary>
+    internal static byte[]? TryRead(string keyText)
+    {
+        var path = PathForKey(keyText);
+        // Logged unconditionally (verbose-gated by Log.cs's [Component] filter) on every
+        // lookup: "which file did this run consult" is the first question of any cache
+        // investigation, and it is also how the cross-process tests locate the entry they
+        // then corrupt or diff.
+        Console.Error.WriteLine($"[InstallBaselineDisk] entry path: {path}");
+        try
+        {
+            if (!File.Exists(path)) return null;
+            return File.ReadAllBytes(path);
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"[InstallBaselineDisk] unreadable entry {path}: {ex.GetType().Name}: {ex.Message}");
+            Delete(keyText);
+            return null;
+        }
+    }
+
+    /// <summary>Delete the entry for a key. Used when the bytes are present but do not decode —
+    /// a corrupt or truncated file (a process killed mid-write on a filesystem without atomic
+    /// rename, say) must not make every subsequent run pay the decode failure.</summary>
+    internal static void Delete(string keyText)
+    {
+        try { File.Delete(PathForKey(keyText)); }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"[InstallBaselineDisk] could not delete stale entry: {ex.GetType().Name}: {ex.Message}");
+        }
+    }
+
+    /// <summary>Write the entry atomically. A temp file in the SAME directory keeps the rename
+    /// on one filesystem, and File.Move(overwrite: true) is the atomic replace — so a reader in
+    /// a parallel CI process sees either the previous complete file or the new complete file,
+    /// never a half-written one.</summary>
+    internal static bool TryWrite(string keyText, byte[] payload)
+    {
+        var path = PathForKey(keyText);
+        var dir = Path.GetDirectoryName(path)!;
+        var tmp = path + "." + Environment.ProcessId + "." + Guid.NewGuid().ToString("N")[..8] + ".tmp";
+        try
+        {
+            Directory.CreateDirectory(dir);
+            File.WriteAllBytes(tmp, payload);
+            File.Move(tmp, path, overwrite: true);
+            Console.Error.WriteLine($"[InstallBaselineDisk] wrote {payload.Length} byte(s) to {path}");
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"[InstallBaselineDisk] could not write entry {path}: {ex.GetType().Name}: {ex.Message}");
+            try { if (File.Exists(tmp)) File.Delete(tmp); } catch { /* best effort */ }
+            return false;
+        }
+    }
+}

--- a/AlRunner/Infrastructure/ServiceTierDllIndex.cs
+++ b/AlRunner/Infrastructure/ServiceTierDllIndex.cs
@@ -59,7 +59,8 @@ public static class ServiceTierDllIndex
         if (!Available) return null;
         var asm = _loadedByType.GetOrAdd(objectTypeName, LoadOwningAssembly);
         if (asm == null) return null;
-        try { return Array.Find(asm.GetTypes(), t => t.Name == objectTypeName); }
+        // Metadata-backed lookup — see AlRunner/Infrastructure/AssemblyTypeIndex.cs.
+        try { return AssemblyTypeIndex.For(asm).FindFirst(objectTypeName); }
         catch { return null; }
     }
 

--- a/AlRunner/InstallTriggerRunner.cs
+++ b/AlRunner/InstallTriggerRunner.cs
@@ -194,14 +194,18 @@ public static class InstallTriggerRunner
             if (_scanCache.TryGetValue(asm, out var cached)) return cached;
         }
 
-        Type?[] types;
-        try { types = asm.GetTypes(); }
-        catch (ReflectionTypeLoadException ex) { types = ex.Types; }
+        // Only Codeunit* types can carry an install trigger, and AssemblyTypeIndex resolves
+        // exactly those out of the TypeDef table — so scanning a Base Application chunk no
+        // longer forces all 132k of its types to load just to reject them. See
+        // AlRunner/Infrastructure/AssemblyTypeIndex.cs.
+        IEnumerable<Type> types;
+        try { types = AlRunner.Infrastructure.AssemblyTypeIndex.For(asm).EnumerateWithPrefix("Codeunit"); }
+        catch { types = Array.Empty<Type>(); }
 
         var found = new List<InstallCodeunit>();
         foreach (var t in types)
         {
-            if (t == null || !t.Name.StartsWith("Codeunit", StringComparison.Ordinal)) continue;
+            if (t == null) continue;
             var perCompany = InstallTriggerMethod(t, "OnInstallAppPerCompany");
             var perDatabase = InstallTriggerMethod(t, "OnInstallAppPerDatabase");
             if (perCompany == null && perDatabase == null) continue;

--- a/AlRunner/Patches/CodeunitPatches.cs
+++ b/AlRunner/Patches/CodeunitPatches.cs
@@ -969,8 +969,8 @@ public static partial class BcRuntime
         {
             try
             {
-                var t = Array.Find(_currentTestAssembly.GetTypes(),
-                    x => x.Name == name && (queryBase == null || queryBase.IsAssignableFrom(x)));
+                var t = AlRunner.Infrastructure.AssemblyTypeIndex.For(_currentTestAssembly)
+                    .FindFirst(name, x => (queryBase == null || queryBase.IsAssignableFrom(x)));
                 if (t != null) return t;
             }
             catch { }
@@ -985,8 +985,8 @@ public static partial class BcRuntime
             if (IsStaleBundleAssembly(asm)) continue;
             try
             {
-                var t = Array.Find(asm.GetTypes(),
-                    x => x.Name == name && (queryBase == null || queryBase.IsAssignableFrom(x)));
+                var t = AlRunner.Infrastructure.AssemblyTypeIndex.For(asm)
+                    .FindFirst(name, x => (queryBase == null || queryBase.IsAssignableFrom(x)));
                 if (t != null) return t;
             }
             catch { }
@@ -1004,8 +1004,8 @@ public static partial class BcRuntime
         {
             try
             {
-                var t = Array.Find(_currentTestAssembly.GetTypes(),
-                    x => x.Name == name && (reportBase == null || reportBase.IsAssignableFrom(x)));
+                var t = AlRunner.Infrastructure.AssemblyTypeIndex.For(_currentTestAssembly)
+                    .FindFirst(name, x => (reportBase == null || reportBase.IsAssignableFrom(x)));
                 if (t != null) return t;
             }
             catch { }
@@ -1020,8 +1020,8 @@ public static partial class BcRuntime
             if (IsStaleBundleAssembly(asm)) continue;
             try
             {
-                var t = Array.Find(asm.GetTypes(),
-                    x => x.Name == name && (reportBase == null || reportBase.IsAssignableFrom(x)));
+                var t = AlRunner.Infrastructure.AssemblyTypeIndex.For(asm)
+                    .FindFirst(name, x => (reportBase == null || reportBase.IsAssignableFrom(x)));
                 if (t != null) return t;
             }
             catch { }
@@ -1042,8 +1042,8 @@ public static partial class BcRuntime
         {
             try
             {
-                var t = Array.Find(_currentTestAssembly.GetTypes(),
-                    x => x.Name == name && (formBase == null || formBase.IsAssignableFrom(x)));
+                var t = AlRunner.Infrastructure.AssemblyTypeIndex.For(_currentTestAssembly)
+                    .FindFirst(name, x => (formBase == null || formBase.IsAssignableFrom(x)));
                 if (t != null) return t;
             }
             catch { }
@@ -1058,8 +1058,8 @@ public static partial class BcRuntime
             if (IsStaleBundleAssembly(asm)) continue;
             try
             {
-                var t = Array.Find(asm.GetTypes(),
-                    x => x.Name == name && (formBase == null || formBase.IsAssignableFrom(x)));
+                var t = AlRunner.Infrastructure.AssemblyTypeIndex.For(asm)
+                    .FindFirst(name, x => (formBase == null || formBase.IsAssignableFrom(x)));
                 if (t != null) return t;
             }
             catch { }
@@ -1081,8 +1081,8 @@ public static partial class BcRuntime
         {
             try
             {
-                var t = Array.Find(_currentTestAssembly.GetTypes(),
-                    x => x.Name == name && (testPageBase == null || testPageBase.IsAssignableFrom(x)));
+                var t = AlRunner.Infrastructure.AssemblyTypeIndex.For(_currentTestAssembly)
+                    .FindFirst(name, x => (testPageBase == null || testPageBase.IsAssignableFrom(x)));
                 if (t != null) return t;
             }
             catch { }
@@ -1097,8 +1097,8 @@ public static partial class BcRuntime
             if (IsStaleBundleAssembly(asm)) continue;
             try
             {
-                var t = Array.Find(asm.GetTypes(),
-                    x => x.Name == name && (testPageBase == null || testPageBase.IsAssignableFrom(x)));
+                var t = AlRunner.Infrastructure.AssemblyTypeIndex.For(asm)
+                    .FindFirst(name, x => (testPageBase == null || testPageBase.IsAssignableFrom(x)));
                 if (t != null) return t;
             }
             catch { }
@@ -1160,8 +1160,8 @@ public static partial class BcRuntime
         {
             try
             {
-                var t = Array.Find(_currentTestAssembly.GetTypes(),
-                    x => x.Name == name && baseCu.IsAssignableFrom(x));
+                var t = AlRunner.Infrastructure.AssemblyTypeIndex.For(_currentTestAssembly)
+                    .FindFirst(name, baseCu.IsAssignableFrom);
                 if (t != null) return t;
             }
             catch { }
@@ -1177,8 +1177,8 @@ public static partial class BcRuntime
             if (IsStaleBundleAssembly(asm)) continue;
             try
             {
-                var t = Array.Find(asm.GetTypes(),
-                    x => x.Name == name && baseCu.IsAssignableFrom(x));
+                var t = AlRunner.Infrastructure.AssemblyTypeIndex.For(asm)
+                    .FindFirst(name, baseCu.IsAssignableFrom);
                 if (t != null) return t;
             }
             catch { /* skip dynamic/reflection-only assemblies */ }

--- a/AlRunner/Patches/EventSubscriberPatches.cs
+++ b/AlRunner/Patches/EventSubscriberPatches.cs
@@ -125,6 +125,17 @@ public static class EventSubscriberPatches
     }
     private static readonly HashSet<MethodInfo> _injectedSubscriberMethods = new();
     private static int _lastScannedCount = 0;
+
+    /// <summary>
+    /// Assemblies whose [NavEventSubscriberAttribute] methods have already been discovered.
+    /// The <c>_lastScannedCount</c> gate only tells us that SOMETHING new loaded; without this
+    /// set every re-scan re-walked every assembly, so the Base Application chunks were rescanned
+    /// each time the AppDomain grew. Reference identity, deliberately: a reloaded bundle
+    /// generation is a DIFFERENT Assembly object, so it is not in this set and IS scanned, while
+    /// the superseded generation it replaces is pruned by <see cref="PruneStaleSubscribers"/>
+    /// (issue #1901) — neither behaviour depends on this set forgetting anything.
+    /// </summary>
+    private static readonly HashSet<Assembly> _scannedAssemblies = new(ReferenceEqualityComparer.Instance);
     private static bool _registered = false;
     private static bool _reflectionFailed = false;
 
@@ -349,8 +360,11 @@ public static class EventSubscriberPatches
             {
                 var clrType = resolveClrType(publisherId);
                 if (clrType == null) { missing++; if (!diagLogged) { diagLogged = true; Console.Error.WriteLine($"[Subscribers] seed-miss: {publisherKindLabel}{publisherId} type not found"); } continue; }
-                var scopeType = clrType.GetNestedTypes(BindingFlags.Public | BindingFlags.NonPublic)
-                    .FirstOrDefault(t => t.Name == eventMethodName + "_Scope");
+                // Metadata-backed nested-type lookup: same answer as
+                // GetNestedTypes().FirstOrDefault(name), without resolving every OTHER nested
+                // type on the publisher (see AssemblyTypeIndex.FindNestedType).
+                var scopeType = AssemblyTypeIndex.For(clrType.Assembly)
+                    .FindNestedType(clrType, eventMethodName + "_Scope");
                 if (scopeType == null)
                 {
                     missing++;
@@ -399,6 +413,7 @@ public static class EventSubscriberPatches
             _objectEventTypeCache.Clear();
             _injectedSubscriberMethods.Clear();
             _seededScopeTypes.Clear();
+            _scannedAssemblies.Clear();
             _lastScannedCount = 0;
         }
         AlRunner.BcRuntime.ResetManualBindingCacheForReload();
@@ -743,10 +758,102 @@ public static class EventSubscriberPatches
         _validateSubs.RemoveAll(v => BcRuntime.IsStaleBundleAssembly(v.Handle.Method.DeclaringType!.Assembly));
     }
 
+    // ------------------------------------------------------------------
+    // Discovery-scan equivalence audit (AL_RUNNER_SUBSCRIBER_SCAN_AUDIT=1)
+    // ------------------------------------------------------------------
+    //
+    // The metadata scan replaced an Assembly.GetTypes()-based walk that had been the sole
+    // discovery mechanism since this class was written. "Same registry contents" is the whole
+    // correctness claim of that swap, and it can only be proven against the assemblies that
+    // actually matter — the real Base Application / System Application R2R chunks with their
+    // ~3,400 subscribers — not against a synthetic fixture.
+    //
+    // So the old walk is kept, verbatim, as LegacyReflectionScan and can be run alongside the
+    // new one: with AL_RUNNER_SUBSCRIBER_SCAN_AUDIT=1 every scanned assembly emits
+    //   [Subscribers] scan-audit <asm>: metadata=N reflection=M identical=true|false
+    // and any difference is listed. AlRunner.Tests/AssemblyTypeIndexTests's EventSubscriberScanEquivalenceTests drives
+    // a real runner invocation with that variable set and asserts identical=true everywhere
+    // plus a >3000 Base App count, which is the proving test for this change. Off by default
+    // it costs nothing (the GetTypes() call is exactly what the change exists to avoid).
+
+    private static bool? _scanAuditEnabled;
+
+    internal static bool ScanAuditEnabled =>
+        _scanAuditEnabled ??= Environment.GetEnvironmentVariable("AL_RUNNER_SUBSCRIBER_SCAN_AUDIT") == "1";
+
+    /// <summary>
+    /// The pre-metadata-scan discovery walk, kept verbatim so the metadata scan can be diffed against
+    /// it on real assemblies. Not used in production: <see cref="EnsureRegistryFresh"/> calls
+    /// it only under <see cref="ScanAuditEnabled"/>.
+    /// </summary>
+    internal static List<MethodInfo> LegacyReflectionScan(Assembly asm)
+    {
+        var found = new List<MethodInfo>();
+        Type?[] types;
+        try { types = asm.GetTypes(); }
+        catch (ReflectionTypeLoadException ex) { types = ex.Types; }
+        catch { return found; }
+        foreach (var t in types)
+        {
+            if (t == null) continue;
+            if (!t.Name.StartsWith("Codeunit", StringComparison.Ordinal)) continue;
+            MethodInfo[] methods;
+            try { methods = t.GetMethods(BindingFlags.Public | BindingFlags.NonPublic
+                                          | BindingFlags.Instance | BindingFlags.Static); }
+            catch { continue; }
+            foreach (var m in methods)
+            {
+                object? attr;
+                try
+                {
+                    attr = m.GetCustomAttributes(inherit: false)
+                        .FirstOrDefault(a => a.GetType().Name == "NavEventSubscriberAttribute");
+                }
+                catch { continue; }
+                if (attr != null) found.Add(m);
+            }
+        }
+        return found;
+    }
+
+    /// <summary>Stable identity of a discovered subscriber: declaring type full name, method
+    /// name and arity — the tuple that decides what lands in the registries.</summary>
+    internal static string DescribeSubscriberMethod(MethodInfo m)
+        => $"{m.DeclaringType?.FullName ?? "<null>"}.{m.Name}/{m.GetParameters().Length}";
+
+    private static void AuditAssemblyScan(Assembly asm, string asmName, List<MethodInfo> viaMetadata)
+    {
+        var viaReflection = LegacyReflectionScan(asm);
+        var mdSet = new HashSet<string>(viaMetadata.Select(DescribeSubscriberMethod), StringComparer.Ordinal);
+        var rfSet = new HashSet<string>(viaReflection.Select(DescribeSubscriberMethod), StringComparer.Ordinal);
+        bool identical = mdSet.SetEquals(rfSet);
+        Console.Error.WriteLine(
+            $"[Subscribers] scan-audit {asmName}: metadata={mdSet.Count} reflection={rfSet.Count} " +
+            $"identical={identical.ToString().ToLowerInvariant()}");
+        if (identical) return;
+        foreach (var only in mdSet.Except(rfSet).OrderBy(x => x, StringComparer.Ordinal).Take(20))
+            Console.Error.WriteLine($"[Subscribers] scan-audit {asmName}: metadata-only {only}");
+        foreach (var only in rfSet.Except(mdSet).OrderBy(x => x, StringComparer.Ordinal).Take(20))
+            Console.Error.WriteLine($"[Subscribers] scan-audit {asmName}: reflection-only {only}");
+    }
+
     /// <summary>
     /// Discovery: walk loaded assemblies for [NavEventSubscriberAttribute] methods, index
-    /// by (publisher id, NavTriggerEventType ordinal). Incremental — only re-scans when the
-    /// assembly count grows.
+    /// by (publisher id, NavTriggerEventType ordinal).
+    ///
+    /// Incremental in two layers: the cheap <c>_lastScannedCount</c> gate skips the whole
+    /// pass while no assembly has loaded since the last one, and <c>_scannedAssemblies</c>
+    /// then makes each individual assembly's scan happen exactly ONCE for its lifetime.
+    /// Before the boot-overhead perf pass this re-walked EVERY loaded assembly from scratch on every
+    /// count change — including the five Base Application R2R chunks — so the dominant cost
+    /// was paid several times per invocation.
+    ///
+    /// Discovery itself reads the assembly's ECMA-335 metadata
+    /// (<see cref="AssemblyTypeIndex.FindAttributedMethods"/>) instead of calling
+    /// <c>Assembly.GetTypes()</c>: same methods, same order, without materialising a
+    /// RuntimeType for all 132,541 types in the Base App chunks (measured 6.5s → 60ms).
+    /// The attribute VALUES are still read off the real attribute instance through ordinary
+    /// reflection below — metadata only decides which methods to look at.
     /// </summary>
     private static void EnsureRegistryFresh()
     {
@@ -777,6 +884,7 @@ public static class EventSubscriberPatches
             int scannedAttrs = 0;
             foreach (var asm in asms)
             {
+                if (_scannedAssemblies.Contains(asm)) continue;
                 var name = asm.GetName().Name ?? "";
                 if (name.StartsWith("System.") || name.StartsWith("Microsoft.Extensions.")
                     || name.StartsWith("Microsoft.Dynamics.Nav.") || name == "netstandard"
@@ -786,110 +894,133 @@ public static class EventSubscriberPatches
                 // Skip a previous bundle assembly still loaded after a server reload —
                 // otherwise its [EventSubscriber] codeunits re-register alongside the
                 // new ones and events fire twice. No-op in normal one-shot mode.
+                //
+                // Deliberately NOT marked as scanned: staleness is decided by BcRuntime's
+                // current generation bookkeeping, and this pass must keep re-asking rather
+                // than freezing today's answer into the once-only set.
                 if (BcRuntime.IsStaleBundleAssembly(asm)) continue;
-                Type[] types;
-                try { types = asm.GetTypes(); }
-                catch (ReflectionTypeLoadException ex) { types = ex.Types.Where(t => t != null).ToArray()!; }
-                catch { continue; }
-                foreach (var t in types)
+
+                // Only AL codeunits can host [NavEventSubscriberAttribute] methods, so the
+                // scan is scoped to types whose simple name starts with "Codeunit" — exactly
+                // the gate the previous GetTypes()-based walk applied, now applied against
+                // the TypeDef table so the thousands of Record<N>/Table<N>/Page<N>/Enum<N>
+                // types in an emitted assembly are never loaded to be rejected.
+                List<MethodInfo> subscriberMethods;
+                try
                 {
-                    if (t == null) continue;
-                    // Only AL codeunits can host [NavEventSubscriberAttribute] methods. The emitted
-                    // test assembly contains thousands of generated types (Record<N>, Table<N>,
-                    // Page<N>, Enum<N>, ...) that are guaranteed to have no subscribers — walking
-                    // their methods + reading custom attributes on each was the bulk of the cost
-                    // (this scan was ~35% inclusive in the bucket-1 bundled profile).
-                    if (!t.Name.StartsWith("Codeunit", StringComparison.Ordinal)) continue;
-                    MethodInfo[] methods;
-                    try { methods = t.GetMethods(BindingFlags.Public | BindingFlags.NonPublic
-                                                  | BindingFlags.Instance | BindingFlags.Static); }
-                    catch { continue; }
-                    int codeunitId = -1; // lazy: only read when first subscriber found
-                    foreach (var m in methods)
+                    subscriberMethods = AssemblyTypeIndex.For(asm)
+                        .FindAttributedMethods("Codeunit", "NavEventSubscriberAttribute");
+                }
+                catch (Exception ex)
+                {
+                    Console.Error.WriteLine(
+                        $"[Subscribers] discovery scan failed for {name}: {ex.GetType().Name}: {ex.Message}");
+                    continue;
+                }
+                if (ScanAuditEnabled) AuditAssemblyScan(asm, name, subscriberMethods);
+
+                // Codeunit id is read once per declaring type, not once per subscriber —
+                // the same laziness the per-type loop had before.
+                var codeunitIdByType = new Dictionary<Type, int>();
+                // Metadata says these methods carry the attribute; materialising the attribute
+                // INSTANCE can still fail transiently (an assembly can be loaded before every
+                // assembly its attributes reference is). The old scan re-walked everything on
+                // every pass and so retried by accident; the once-per-assembly set would turn
+                // that transient into a permanent drop, so an assembly with any unreadable hit
+                // is deliberately left unmarked and re-scanned next time.
+                int unreadable = 0;
+                foreach (var m in subscriberMethods)
+                {
+                    var t = m.DeclaringType;
+                    if (t == null) { unreadable++; continue; }
+                    object? attr;
+                    try
                     {
-                        object? attr;
-                        try
+                        attr = m.GetCustomAttributes(inherit: false)
+                            .FirstOrDefault(a => a.GetType().Name == "NavEventSubscriberAttribute");
+                    }
+                    catch { unreadable++; continue; }
+                    if (attr == null) { unreadable++; continue; }
+                    if (!codeunitIdByType.TryGetValue(t, out int codeunitId))
+                        codeunitIdByType[t] = codeunitId = TryReadCodeunitId(t);
+                    scannedAttrs++;
+                    if (!TryReadAttribute(attr, out int publisherObjType,
+                                          out int publisherId, out string methodName))
+                    { Console.Error.WriteLine($"[Subscribers] could not read attr on {t.Name}.{m.Name}"); continue; }
+                    if (publisherObjType == 1) // Table → existing trigger path
+                    {
+                        int ord = ResolveEventOrdinalFromName(methodName);
+                        if (ord == 9 || ord == 10) // OnBefore/OnAfterValidateEvent — field-scoped
                         {
-                            attr = m.GetCustomAttributes(inherit: false)
-                                .FirstOrDefault(a => a.GetType().Name == "NavEventSubscriberAttribute");
+                            if (_validateSubs.Any(v => v.Handle.Method == m)) continue;
+                            ReadFieldTarget(attr, out int vFieldId, out string vFieldName);
+                            var vHandle = new SubscriberHandle(t, codeunitId, m, publisherId, ord,
+                                $"{t.Name}.{m.Name} → Table {publisherId}/{methodName}('{vFieldName}')");
+                            _validateSubs.Add(new ValidateSub(vHandle, vFieldId, vFieldName));
+                            added++;
+                            continue;
                         }
-                        catch { continue; }
-                        if (attr == null) continue;
-                        if (codeunitId < 0) codeunitId = TryReadCodeunitId(t);
-                        scannedAttrs++;
-                        if (!TryReadAttribute(attr, out int publisherObjType,
-                                              out int publisherId, out string methodName))
-                        { Console.Error.WriteLine($"[Subscribers] could not read attr on {t.Name}.{m.Name}"); continue; }
-                        if (publisherObjType == 1) // Table → existing trigger path
+                        if (ord == 0)
                         {
-                            int ord = ResolveEventOrdinalFromName(methodName);
-                            if (ord == 9 || ord == 10) // OnBefore/OnAfterValidateEvent — field-scoped
+                            // Not one of BC's 8 implicit trigger-event names — a manually-
+                            // declared [IntegrationEvent]/[BusinessEvent] raised from inside
+                            // the table's own code (issue #1770). It cannot go through
+                            // NavTableTriggerEventHandler (ordinal-keyed, fixed set); dispatch
+                            // it via the same universal <EventName>_Scope path codeunit
+                            // publishers use — see GetTableEventSubscribers.
+                            var tkey = new TableEventKey(publisherId, methodName);
+                            if (!_byTableEventKey.TryGetValue(tkey, out var tlst))
+                                _byTableEventKey[tkey] = tlst = new List<MethodInfo>();
+                            if (!tlst.Contains(m))
                             {
-                                if (_validateSubs.Any(v => v.Handle.Method == m)) continue;
-                                ReadFieldTarget(attr, out int vFieldId, out string vFieldName);
-                                var vHandle = new SubscriberHandle(t, codeunitId, m, publisherId, ord,
-                                    $"{t.Name}.{m.Name} → Table {publisherId}/{methodName}('{vFieldName}')");
-                                _validateSubs.Add(new ValidateSub(vHandle, vFieldId, vFieldName));
+                                tlst.Add(m);
                                 added++;
-                                continue;
                             }
-                            if (ord == 0)
-                            {
-                                // Not one of BC's 8 implicit trigger-event names — a manually-
-                                // declared [IntegrationEvent]/[BusinessEvent] raised from inside
-                                // the table's own code (issue #1770). It cannot go through
-                                // NavTableTriggerEventHandler (ordinal-keyed, fixed set); dispatch
-                                // it via the same universal <EventName>_Scope path codeunit
-                                // publishers use — see GetTableEventSubscribers.
-                                var tkey = new TableEventKey(publisherId, methodName);
-                                if (!_byTableEventKey.TryGetValue(tkey, out var tlst))
-                                    _byTableEventKey[tkey] = tlst = new List<MethodInfo>();
-                                if (!tlst.Contains(m))
-                                {
-                                    tlst.Add(m);
-                                    added++;
-                                }
-                                continue;
-                            }
-                            var key = new Key(publisherId, ord);
-                            if (!_byKey.TryGetValue(key, out var lst))
-                                _byKey[key] = lst = new List<SubscriberHandle>();
-                            if (lst.Any(h => h.Method == m)) continue;
-                            lst.Add(new SubscriberHandle(t, codeunitId, m, publisherId, ord,
-                                $"{t.Name}.{m.Name} → Table {publisherId}/{methodName}"));
-                            added++;
+                            continue;
                         }
-                        else if (publisherObjType == 5) // Codeunit → new universal dispatch path
-                        {
-                            var ckey = new CodeunitEventKey(publisherId, methodName);
-                            if (!_byCodeunitKey.TryGetValue(ckey, out var clst))
-                                _byCodeunitKey[ckey] = clst = new List<MethodInfo>();
-                            if (clst.Contains(m)) continue;
-                            clst.Add(m);
-                            added++;
-                        }
-                        else if (ObjectTypeToEventPublisherKind(publisherObjType) is string okind)
-                        {
-                            // Page(8)/Report(3)/Query(9)/XmlPort(6): a manually-declared
-                            // [IntegrationEvent]/[BusinessEvent] on one of these object kinds
-                            // (issue #1794 — the gap #1770's table fix deliberately left open).
-                            // None of them has BC's fixed NavTriggerEventType ordinal set (that's
-                            // table-trigger-only), so unlike the Table branch above there is no
-                            // ordinal check to fall through first — every event from these kinds
-                            // is dispatched via the same universal <EventName>_Scope path codeunit
-                            // publishers use. Before this branch existed, subscribers to these
-                            // events were read off the assembly (scannedAttrs still counted them)
-                            // and then silently discarded — never added to any registry, the
-                            // silent-drop shape loud-failures.md warns about.
-                            var okey = new ObjectEventKey(okind, publisherId, methodName);
-                            if (!_byObjectEventKey.TryGetValue(okey, out var olst))
-                                _byObjectEventKey[okey] = olst = new List<MethodInfo>();
-                            if (olst.Contains(m)) continue;
-                            olst.Add(m);
-                            added++;
-                        }
+                        var key = new Key(publisherId, ord);
+                        if (!_byKey.TryGetValue(key, out var lst))
+                            _byKey[key] = lst = new List<SubscriberHandle>();
+                        if (lst.Any(h => h.Method == m)) continue;
+                        lst.Add(new SubscriberHandle(t, codeunitId, m, publisherId, ord,
+                            $"{t.Name}.{m.Name} → Table {publisherId}/{methodName}"));
+                        added++;
+                    }
+                    else if (publisherObjType == 5) // Codeunit → new universal dispatch path
+                    {
+                        var ckey = new CodeunitEventKey(publisherId, methodName);
+                        if (!_byCodeunitKey.TryGetValue(ckey, out var clst))
+                            _byCodeunitKey[ckey] = clst = new List<MethodInfo>();
+                        if (clst.Contains(m)) continue;
+                        clst.Add(m);
+                        added++;
+                    }
+                    else if (ObjectTypeToEventPublisherKind(publisherObjType) is string okind)
+                    {
+                        // Page(8)/Report(3)/Query(9)/XmlPort(6): a manually-declared
+                        // [IntegrationEvent]/[BusinessEvent] on one of these object kinds
+                        // (issue #1794 — the gap #1770's table fix deliberately left open).
+                        // None of them has BC's fixed NavTriggerEventType ordinal set (that's
+                        // table-trigger-only), so unlike the Table branch above there is no
+                        // ordinal check to fall through first — every event from these kinds
+                        // is dispatched via the same universal <EventName>_Scope path codeunit
+                        // publishers use. Before this branch existed, subscribers to these
+                        // events were read off the assembly (scannedAttrs still counted them)
+                        // and then silently discarded — never added to any registry, the
+                        // silent-drop shape loud-failures.md warns about.
+                        var okey = new ObjectEventKey(okind, publisherId, methodName);
+                        if (!_byObjectEventKey.TryGetValue(okey, out var olst))
+                            _byObjectEventKey[okey] = olst = new List<MethodInfo>();
+                        if (olst.Contains(m)) continue;
+                        olst.Add(m);
+                        added++;
                     }
                 }
+                if (unreadable == 0) _scannedAssemblies.Add(asm);
+                else
+                    Console.Error.WriteLine(
+                        $"[Subscribers] {name}: {unreadable} of {subscriberMethods.Count} " +
+                        "[NavEventSubscriber] attribute instance(s) could not be read — will re-scan.");
             }
             _lastScannedCount = asms.Length;
             int total = _byKey.Values.Sum(v => v.Count);

--- a/AlRunner/Patches/RecordLinkPatches.cs
+++ b/AlRunner/Patches/RecordLinkPatches.cs
@@ -72,6 +72,69 @@ public static class RecordLinkPatches
         }
     }
 
+    /// <summary>Write the record-link half of an install baseline to the on-disk baseline
+    /// cache (see RecordPatches.InstallBaselineDisk). Lives here because <see cref="Entry"/>
+    /// and the id counter are private to this store. NavRecordId keys go through BC's own
+    /// GetBytes/CreateFromBytes pair, the same encoding the service tier uses for a RecordId
+    /// field value.</summary>
+    internal static void SerializeInstallBaseline(BinaryWriter w, object? snapshot)
+    {
+        if (snapshot is not ValueTuple<Dictionary<NavRecordId, List<Entry>>, int> state)
+        {
+            w.Write(-1);
+            return;
+        }
+        w.Write(state.Item1.Count);
+        foreach (var (recordId, entries) in state.Item1)
+        {
+            var idBytes = recordId.GetBytes();
+            w.Write(idBytes.Length);
+            w.Write(idBytes);
+            w.Write(entries.Count);
+            foreach (var e in entries)
+            {
+                w.Write(e.Id);
+                w.Write(e.Url);
+                w.Write(e.Description);
+            }
+        }
+        w.Write(state.Item2);
+    }
+
+    /// <summary>Sorted, fully-expanded text form of the record-link half of an install
+    /// baseline — see TenantStoragePatches.DescribeInstallBaseline for why this exists.</summary>
+    internal static IEnumerable<string> DescribeInstallBaseline(object? snapshot)
+    {
+        if (snapshot is not ValueTuple<Dictionary<NavRecordId, List<Entry>>, int> state)
+            return new[] { "link|<none>" };
+        return state.Item1
+            .SelectMany(pair => pair.Value.Select(e =>
+                $"link|{Convert.ToHexString(pair.Key.GetBytes())}|{e.Id}|{e.Url}|{e.Description}"))
+            .Append($"link-next-id|{state.Item2}")
+            .OrderBy(x => x, StringComparer.Ordinal);
+    }
+
+    /// <summary>Counterpart of <see cref="SerializeInstallBaseline"/>, producing exactly the
+    /// tuple shape <see cref="CaptureInstallBaseline"/> produces.</summary>
+    internal static object? DeserializeInstallBaseline(BinaryReader r)
+    {
+        var count = r.ReadInt32();
+        if (count < 0) return null;
+        var links = new Dictionary<NavRecordId, List<Entry>>(EqualityComparer<NavRecordId>.Default);
+        for (var i = 0; i < count; i++)
+        {
+            var idBytes = r.ReadBytes(r.ReadInt32());
+            var recordId = NavRecordId.CreateFromBytes(idBytes, 0, idBytes.Length);
+            var entryCount = r.ReadInt32();
+            var entries = new List<Entry>(entryCount);
+            for (var j = 0; j < entryCount; j++)
+                entries.Add(new Entry(r.ReadInt32(), r.ReadString(), r.ReadString()));
+            links[recordId] = entries;
+        }
+        var nextId = r.ReadInt32();
+        return (links, nextId);
+    }
+
     // TEMPORARY (memory-census diagnostic) — total link entries across all records.
     // See MemoryCensus.cs.
     internal static int CensusEntryCount()

--- a/AlRunner/Patches/RecordPatches.CreateObjectInstance.cs
+++ b/AlRunner/Patches/RecordPatches.CreateObjectInstance.cs
@@ -255,12 +255,13 @@ public static partial class RecordPatches
         return null;
     }
 
+    // Metadata-backed lookup — see FindRecordTypeIn in RecordPatches.NclMetaTableBuilder.cs.
     private static Type? FindTableExtensionTypeIn(Assembly asm, string name)
     {
         try
         {
-            return Array.Find(asm.GetTypes(),
-                x => x.Name == name && typeof(NavRecordExtension).IsAssignableFrom(x));
+            return AlRunner.Infrastructure.AssemblyTypeIndex.For(asm)
+                .FindFirst(name, x => typeof(NavRecordExtension).IsAssignableFrom(x));
         }
         catch { return null; }
     }

--- a/AlRunner/Patches/RecordPatches.InstallBaselineDisk.cs
+++ b/AlRunner/Patches/RecordPatches.InstallBaselineDisk.cs
@@ -1,0 +1,575 @@
+// RecordPatches.InstallBaselineDisk — cross-PROCESS persistence of the dependency+company
+// install baseline that RecordPatches.InstallBaseline.cs captures in memory.
+//
+// WHY
+//   #1867 made the dependency Install triggers + Company-Initialize run ONCE per process and
+//   cached the resulting InstallBaselineSnapshot in a process-lifetime dictionary keyed by
+//   InstallTriggerRunner.CurrentDependencySetKey(). That removes the repeat inside one
+//   process, but every NEW process still pays it in full: measured at 5.9s of a 23.3s warm
+//   single-fixture run (96.1% of the app group's run_ms), ~177s of the CI unit-test step, and
+//   8-10s each on the corpus / runner-extras suites. The computation is deterministic given
+//   (dependency assembly set, runner build, BC version), so it can be computed once and
+//   reloaded from disk.
+//
+// WHAT IS PERSISTED
+//   Exactly the four things InstallBaselineSnapshot holds — table rows, isolated storage,
+//   record links, auto-increment counters — MINUS the self-populating virtual system tables
+//   (see IsSelfPopulatingVirtualTableId). Everything else round-trips through BC's OWN
+//   NavValue byte codec (NavValue.GetBytes / NavValue.CreateNavValueFromBytes, the pair the
+//   service tier itself uses to move field values in and out of binary), so the runner is not
+//   inventing a second, divergent encoding of AL values.
+//
+// WHY THE VIRTUAL TABLES ARE EXCLUDED — deliberate, not an oversight
+//   AllObj (2000000038), AllObjWithCaption (2000000058), Field (2000000041) and their
+//   siblings are not install-trigger output at all: they are process-wide projections of the
+//   assemblies currently loaded, and RecordPatches.GetDataAccessForTableCore re-populates
+//   each of them on EVERY access as an idempotent top-up. Inside one process, letting a
+//   second app group inherit the first's rows is harmless precisely because of that top-up
+//   (see the #1867 field doc in TestExecutor.cs). Across processes it is not the same bet:
+//   the file would carry one bundle's object inventory into an unrelated bundle's run, keyed
+//   by a dependency-set key that says nothing about which test assemblies were loaded, and a
+//   top-up only ADDS rows — it never removes the foreign ones. So they are dropped on write
+//   and rebuilt on demand after a disk restore, which is the same state the very first app
+//   group of an uncached process has. On the measured Base Application closure this also
+//   removes 23,367 of 23,645 rows from the file.
+//
+// FAITHFULNESS / REFUSAL
+//   Serialisation is all-or-nothing. Any value this codec cannot prove it can rebuild
+//   identically (an unknown NavValue kind, a wrapper value, a value whose type disagrees with
+//   its field's, an Option whose NCLOptionMetadata is not the field's, a lazily-loaded
+//   DB-backed BLOB, more than one DataAccessSource, a source that is not the skeleton one)
+//   aborts the whole write with a verbose line naming the table and the value type. Nothing
+//   partial is ever written, and the in-memory path is unaffected — a refusal costs only the
+//   persistence, never correctness. On read, any magic/version/shape mismatch or decode error
+//   deletes the entry, logs, and recomputes.
+using System.Reflection;
+using AlRunner.Infrastructure;
+using Microsoft.Dynamics.Nav.Runtime;
+
+namespace AlRunner.Patches;
+
+public static partial class RecordPatches
+{
+    // "ALIB" — little-endian magic, and the schema version. BUMP THE VERSION whenever the
+    // byte layout or the set of encodable value kinds changes: an old file that still
+    // deserialises cleanly under new semantics is the one failure mode a cache cannot
+    // detect for itself.
+    private const uint InstallBaselineDiskMagic = 0x42494C41;
+    internal const int InstallBaselineDiskSchemaVersion = 1;
+
+    // Pool-entry kinds. Kind is stored per DISTINCT NavValue instance, not per row slot.
+    private const byte KindBytes = 1;       // NavValue.GetBytes() + NavValue.CreateNavValueFromBytes
+    private const byte KindNullString = 2;  // NavText/NavCode with IsNull (DB NULL, GetBytes cannot say so)
+    private const byte KindBlob = 3;        // NavBLOB — GetBytes has no CreateNavValueFromBytes counterpart
+
+    /// <summary>Table ids whose rows are a projection of the loaded-assembly set rather than
+    /// install-trigger output, and which
+    /// <see cref="GetDataAccessForTableCore"/> re-populates on every access. Excluded from the
+    /// on-disk baseline — see the file header for why that is a correctness decision and not
+    /// just a size one.</summary>
+    internal static bool IsSelfPopulatingVirtualTableId(int tableId) => tableId switch
+    {
+        AllObjVirtualTableId or AllObjWithCaptionVirtualTableId or FieldVirtualTableId
+            or IntegerVirtualTableId or ReportLayoutListVirtualTableId
+            or PageMetadataVirtualTableId or ReportMetadataVirtualTableId
+            or ReportDataItemsVirtualTableId or PageControlFieldVirtualTableId
+            or TableMetadataVirtualTableId => true,
+        _ => false,
+    };
+
+    private static void DiskLog(string message)
+        => Console.Error.WriteLine($"[InstallBaselineDisk] {message}");
+
+    /// <summary>The one DataAccessSource the skeleton session hands to every AL record
+    /// operation. A disk restore has no captured source object to key
+    /// <c>_dataAccessByTable</c> by, so it re-attaches the restored tables to this one — and
+    /// the writer refuses to persist a snapshot whose source is anything else, so the two
+    /// can never disagree.</summary>
+    internal static object? ResolveSkeletonDataAccessSource()
+    {
+        var session = AlRunner.BcRuntime.SkeletonSession;
+        if (session == null || _fSessionDataAccessSource == null) return null;
+        return _fSessionDataAccessSource.GetValue(session);
+    }
+
+    private sealed record PoolEntry(
+        byte Kind, int NclType, int DefinedLength, int Flags, int TableIndex, int FieldIndex, byte[] Bytes);
+
+    // ── NavBLOB private state (Ncl.dll = runtime engine, ours to poke — see
+    //    .claude/rules/precompiled-dll-respect.md). NavBLOB.DeepCopy(), the deep copy the
+    //    in-memory baseline already uses, carries exactly these three, so a persisted BLOB
+    //    that carries the same three is equivalent to a deep copy of the original.
+    //    The contents stream itself is not poked: NavBLOB's public (byte[]) constructor
+    //    installs it the same way AssignFromStream does, so only the two flags need direct
+    //    access. Resolved eagerly together (and loudly, per loud-failures.md) so a BC shape
+    //    change surfaces as a named MissingFieldException rather than a BLOB that quietly
+    //    round-trips without its state.
+    private static FieldInfo? _blobSizeWhenNoContents, _blobIsDirty;
+
+    private static void EnsureBlobFields()
+    {
+        if (_blobIsDirty != null) return;
+        const BindingFlags F = BindingFlags.NonPublic | BindingFlags.Instance;
+        _blobSizeWhenNoContents = typeof(NavBLOB).GetField("sizeWhenNoContents", F)
+            ?? throw new MissingFieldException(nameof(NavBLOB), "sizeWhenNoContents");
+        _blobIsDirty = typeof(NavBLOB).GetField("isDirty", F)
+            ?? throw new MissingFieldException(nameof(NavBLOB), "isDirty");
+    }
+
+    /// <summary>INavValueMetadata carrying the metadata of one CAPTURED value rather than of
+    /// its field. The distinction is load-bearing: a NavText remembers its own maxLength and
+    /// BC's <see cref="NavValue.CreateNavValueFromBytes"/> applies whatever length the
+    /// metadata it is handed reports, so rebuilding with the field's metadata would silently
+    /// re-length values. Option metadata is the one part that cannot be serialised (it is a
+    /// live NCLOptionMetadata graph), so it comes from the field — and the writer refuses any
+    /// Option value whose own metadata is not reference-equal to its field's.</summary>
+    private sealed class CapturedValueMetadata : INavValueMetadata
+    {
+        public CapturedValueMetadata(NavNclType nclType, int definedLength, NCLOptionMetadata? optionMetadata)
+        {
+            NclType = nclType;
+            NavDefinedLengthMetadata = definedLength;
+            _optionMetadata = optionMetadata;
+        }
+
+        private readonly NCLOptionMetadata? _optionMetadata;
+        public NavNclType NclType { get; }
+        public int NavDefinedLengthMetadata { get; }
+        public Microsoft.Dynamics.Nav.Types.NavType NavType => NavNclTypeHelper.GetNavTypeFromNclType(NclType);
+        public NCLOptionMetadata NavOptionMetadata => _optionMetadata
+            ?? throw new InvalidOperationException(
+                $"install-baseline disk codec: no option metadata captured for {NclType}");
+    }
+
+    // ────────────────────────────────────────────────────────────── write ──
+
+    /// <summary>Encode a snapshot for disk, or return null (having logged the reason) when any
+    /// part of it cannot be proven to round-trip. Never throws for content reasons — a refusal
+    /// is a normal outcome that costs only the persistence.</summary>
+    internal static byte[]? TrySerializeInstallBaselineSnapshot(InstallBaselineSnapshot snapshot, string cacheKey)
+    {
+        if (snapshot.Sources.Count != 1)
+        {
+            DiskLog($"not persisting: snapshot has {snapshot.Sources.Count} DataAccessSource(s), expected exactly 1");
+            return null;
+        }
+        var source = snapshot.Sources[0];
+        var skeleton = ResolveSkeletonDataAccessSource();
+        if (skeleton == null || !ReferenceEquals(skeleton, source.Source))
+        {
+            DiskLog("not persisting: the captured DataAccessSource is not the skeleton session's, "
+                  + "so a disk restore could not re-attach the rows to the source AL will read through");
+            return null;
+        }
+
+        var tables = source.Tables.Where(t => !IsSelfPopulatingVirtualTableId(t.TableId)).ToList();
+        var pool = new List<PoolEntry>();
+        var poolIndex = new Dictionary<object, int>(ReferenceEqualityComparer.Instance);
+        var rowIndices = new List<int[][]>(tables.Count);
+        var fieldCounts = new List<int>(tables.Count);
+
+        for (var ti = 0; ti < tables.Count; ti++)
+        {
+            var table = tables[ti];
+            if (table.MetaTable is not NCLMetaTable meta)
+            {
+                DiskLog($"not persisting: table {table.TableId}'s MetaTable is "
+                      + $"{table.MetaTable?.GetType().Name ?? "null"}, not NCLMetaTable");
+                return null;
+            }
+            fieldCounts.Add(meta.FieldCount);
+            var rows = new int[table.Rows.Length][];
+            for (var ri = 0; ri < table.Rows.Length; ri++)
+            {
+                var values = table.Rows[ri];
+                var indices = new int[values.Length];
+                for (var fi = 0; fi < values.Length; fi++)
+                {
+                    var value = values[fi];
+                    if (value == null) { indices[fi] = -1; continue; }
+                    if (poolIndex.TryGetValue(value, out var existing)) { indices[fi] = existing; continue; }
+                    var entry = TryEncodeValue(value, meta, table.TableId, ti, fi);
+                    if (entry == null) return null;   // TryEncodeValue already logged the reason
+                    poolIndex[value] = pool.Count;
+                    indices[fi] = pool.Count;
+                    pool.Add(entry);
+                }
+                rows[ri] = indices;
+            }
+            rowIndices.Add(rows);
+        }
+
+        using var ms = new MemoryStream();
+        using (var w = new BinaryWriter(ms, System.Text.Encoding.UTF8, leaveOpen: true))
+        {
+            w.Write(InstallBaselineDiskMagic);
+            w.Write(InstallBaselineDiskSchemaVersion);
+            w.Write(cacheKey);
+
+            w.Write(tables.Count);
+            for (var ti = 0; ti < tables.Count; ti++)
+            {
+                w.Write(tables[ti].TableId);
+                w.Write(fieldCounts[ti]);
+                w.Write(tables[ti].Rows.Length);
+            }
+
+            w.Write(pool.Count);
+            foreach (var e in pool)
+            {
+                w.Write(e.Kind);
+                w.Write(e.NclType);
+                w.Write(e.DefinedLength);
+                w.Write(e.Flags);
+                w.Write(e.TableIndex);
+                w.Write(e.FieldIndex);
+                w.Write(e.Bytes.Length);
+                w.Write(e.Bytes);
+            }
+
+            foreach (var rows in rowIndices)
+                foreach (var indices in rows)
+                {
+                    w.Write(indices.Length);
+                    foreach (var i in indices) w.Write(i);
+                }
+
+            TenantStoragePatches.SerializeInstallBaseline(w, snapshot.IsolatedStorage);
+            RecordLinkPatches.SerializeInstallBaseline(w, snapshot.RecordLinks);
+
+            var ai = snapshot.AutoIncrement;
+            w.Write(ai?.Count ?? 0);
+            if (ai != null)
+                foreach (var (k, v) in ai) { w.Write(k); w.Write(v); }
+        }
+        return ms.ToArray();
+    }
+
+    private static PoolEntry? TryEncodeValue(
+        NavValue value, NCLMetaTable meta, int tableId, int tableIndex, int fieldIndex)
+    {
+        if (fieldIndex >= meta.FieldCount)
+        {
+            DiskLog($"not persisting: table {tableId} row has {fieldIndex + 1}+ values but the "
+                  + $"metatable declares {meta.FieldCount} fields");
+            return null;
+        }
+        var field = (INavValueMetadata)meta.GetFieldByIndex(fieldIndex);
+        var self = (INavValueMetadata)value;
+
+        if (value.IsWrapper)
+        {
+            DiskLog($"not persisting: table {tableId} field index {fieldIndex} holds a wrapper "
+                  + $"{value.GetType().Name}, whose inner value this codec cannot rebuild");
+            return null;
+        }
+        if (self.NclType != field.NclType)
+        {
+            DiskLog($"not persisting: table {tableId} field index {fieldIndex} holds a "
+                  + $"{self.NclType} value in a {field.NclType} field");
+            return null;
+        }
+
+        if (self.NclType == NavNclType.NavBlob)
+        {
+            if (value is not NavBLOB blob)
+            {
+                DiskLog($"not persisting: table {tableId} field index {fieldIndex} is NavBlob but "
+                      + $"the value is {value.GetType().Name}");
+                return null;
+            }
+            EnsureBlobFields();
+            var size = (int)_blobSizeWhenNoContents!.GetValue(blob)!;
+            var dirty = (bool)_blobIsDirty!.GetValue(blob)!;
+            var inMemory = blob.IsInMemory;
+            if (!inMemory && size != 0)
+            {
+                DiskLog($"not persisting: table {tableId} field index {fieldIndex} holds a "
+                      + "DB-backed NavBLOB with no in-memory contents; its bytes live outside the snapshot");
+                return null;
+            }
+            var bytes = inMemory ? blob.GetBytes() : Array.Empty<byte>();
+            return new PoolEntry(KindBlob, (int)self.NclType, size, (inMemory ? 1 : 0) | (dirty ? 2 : 0),
+                tableIndex, fieldIndex, bytes);
+        }
+
+        var isStringLike = self.NclType is NavNclType.NavText or NavNclType.NavCode;
+        if (value.IsNull)
+        {
+            if (!isStringLike)
+            {
+                DiskLog($"not persisting: table {tableId} field index {fieldIndex} holds a NULL "
+                      + $"{self.NclType} ({value.GetType().Name}); only NavText/NavCode NULLs are encodable");
+                return null;
+            }
+            return new PoolEntry(KindNullString, (int)self.NclType, self.NavDefinedLengthMetadata, 0,
+                tableIndex, fieldIndex, Array.Empty<byte>());
+        }
+
+        // Every kind below is one BC's own NavValue.CreateNavValueFromBytes switch can rebuild
+        // from NavValue.GetBytes(). Kinds absent from that switch (Media, MediaSet, ByteArray,
+        // Char, …) fall through to the refusal at the bottom rather than being guessed at.
+        var encodable = self.NclType is NavNclType.NavBigInteger or NavNclType.NavBigText
+            or NavNclType.NavBoolean or NavNclType.NavByte or NavNclType.NavCode
+            or NavNclType.NavDate or NavNclType.NavDateFormula or NavNclType.NavDateTime
+            or NavNclType.NavDecimal or NavNclType.NavDuration or NavNclType.NavGuid
+            or NavNclType.NavInteger or NavNclType.NavOption or NavNclType.NavRecordId
+            or NavNclType.NavOemText or NavNclType.NavOemCode or NavNclType.NavTime
+            or NavNclType.NavTableFilter or NavNclType.NavText;
+        if (!encodable)
+        {
+            DiskLog($"not persisting: table {tableId} field index {fieldIndex} holds "
+                  + $"{self.NclType} ({value.GetType().Name}), which has no BC byte round-trip");
+            return null;
+        }
+
+        if (self.NclType == NavNclType.NavOption
+            && !ReferenceEquals(self.NavOptionMetadata, field.NavOptionMetadata))
+        {
+            DiskLog($"not persisting: table {tableId} field index {fieldIndex} holds an Option whose "
+                  + "NCLOptionMetadata is not the field's, so a restore could not recover its option set");
+            return null;
+        }
+
+        int definedLength;
+        try { definedLength = self.NavDefinedLengthMetadata; }
+        catch (NotSupportedException) { definedLength = 0; }
+
+        return new PoolEntry(KindBytes, (int)self.NclType, definedLength, 0,
+            tableIndex, fieldIndex, value.GetBytes());
+    }
+
+    // ─────────────────────────────────────────────────────────────── read ──
+
+    /// <summary>Decode a snapshot previously written by
+    /// <see cref="TrySerializeInstallBaselineSnapshot"/>. Returns null (logged) on any
+    /// mismatch — the caller deletes the file and recomputes. Never partially restores: the
+    /// whole snapshot object is built before the caller touches the live store.</summary>
+    internal static InstallBaselineSnapshot? TryDeserializeInstallBaselineSnapshot(byte[] blob, string cacheKey)
+    {
+        var sourceObject = ResolveSkeletonDataAccessSource();
+        if (sourceObject == null)
+        {
+            DiskLog("cannot restore: the skeleton session has no DataAccessSource yet");
+            return null;
+        }
+        try
+        {
+            using var ms = new MemoryStream(blob, writable: false);
+            using var r = new BinaryReader(ms, System.Text.Encoding.UTF8);
+
+            if (r.ReadUInt32() != InstallBaselineDiskMagic) { DiskLog("cannot restore: bad magic"); return null; }
+            var version = r.ReadInt32();
+            if (version != InstallBaselineDiskSchemaVersion)
+            {
+                DiskLog($"cannot restore: schema version {version}, this build writes {InstallBaselineDiskSchemaVersion}");
+                return null;
+            }
+            var storedKey = r.ReadString();
+            if (!string.Equals(storedKey, cacheKey, StringComparison.Ordinal))
+            {
+                DiskLog("cannot restore: the file's embedded cache key does not match the key it was looked up by");
+                return null;
+            }
+
+            var tableCount = r.ReadInt32();
+            var tableIds = new int[tableCount];
+            var fieldCounts = new int[tableCount];
+            var rowCounts = new int[tableCount];
+            for (var i = 0; i < tableCount; i++)
+            {
+                tableIds[i] = r.ReadInt32();
+                fieldCounts[i] = r.ReadInt32();
+                rowCounts[i] = r.ReadInt32();
+            }
+
+            // Rebuild each table's NCLMetaTable through the SAME lookup the live path uses, so
+            // a table whose metadata this process has not built yet gets built (and inserted
+            // into the skeleton NCLMetadata cache) exactly as a live capture would have.
+            var metaTables = new NCLMetaTable[tableCount];
+            for (var i = 0; i < tableCount; i++)
+            {
+                var meta = EnsureTableInMetadataCache(tableIds[i]);
+                if (meta == null)
+                {
+                    DiskLog($"cannot restore: no NCLMetaTable for table {tableIds[i]} in this process");
+                    return null;
+                }
+                if (meta.FieldCount != fieldCounts[i])
+                {
+                    DiskLog($"cannot restore: table {tableIds[i]} now has {meta.FieldCount} fields, "
+                          + $"the file was written against {fieldCounts[i]}");
+                    return null;
+                }
+                metaTables[i] = meta;
+            }
+
+            var poolCount = r.ReadInt32();
+            var pool = new NavValue[poolCount];
+            for (var i = 0; i < poolCount; i++)
+            {
+                var kind = r.ReadByte();
+                var nclType = (NavNclType)r.ReadInt32();
+                var definedLength = r.ReadInt32();
+                var flags = r.ReadInt32();
+                var tableIndex = r.ReadInt32();
+                var fieldIndex = r.ReadInt32();
+                var bytes = r.ReadBytes(r.ReadInt32());
+                if (tableIndex < 0 || tableIndex >= tableCount) { DiskLog("cannot restore: pool entry table index out of range"); return null; }
+                var meta = metaTables[tableIndex];
+                if (fieldIndex < 0 || fieldIndex >= meta.FieldCount) { DiskLog("cannot restore: pool entry field index out of range"); return null; }
+                pool[i] = DecodeValue(kind, nclType, definedLength, flags, meta, fieldIndex, bytes);
+            }
+
+            var baselineTables = new List<BaselineTable>(tableCount);
+            for (var ti = 0; ti < tableCount; ti++)
+            {
+                var rows = new NavValue[rowCounts[ti]][];
+                for (var ri = 0; ri < rows.Length; ri++)
+                {
+                    var n = r.ReadInt32();
+                    var values = new NavValue[n];
+                    for (var fi = 0; fi < n; fi++)
+                    {
+                        var idx = r.ReadInt32();
+                        if (idx == -1) continue;
+                        if (idx < 0 || idx >= poolCount) { DiskLog("cannot restore: row value index out of range"); return null; }
+                        values[fi] = pool[idx];
+                    }
+                    rows[ri] = values;
+                }
+                baselineTables.Add(new BaselineTable(tableIds[ti], metaTables[ti], rows));
+            }
+
+            var isolatedStorage = TenantStoragePatches.DeserializeInstallBaseline(r);
+            var recordLinks = RecordLinkPatches.DeserializeInstallBaseline(r);
+
+            var aiCount = r.ReadInt32();
+            var autoIncrement = new Dictionary<int, long>(aiCount);
+            for (var i = 0; i < aiCount; i++)
+            {
+                var k = r.ReadInt32();
+                autoIncrement[k] = r.ReadInt64();
+            }
+
+            if (ms.Position != ms.Length)
+            {
+                DiskLog($"cannot restore: {ms.Length - ms.Position} trailing byte(s) after the payload");
+                return null;
+            }
+
+            return new InstallBaselineSnapshot(
+                new[] { new BaselineSource(sourceObject, baselineTables) },
+                isolatedStorage, recordLinks, autoIncrement);
+        }
+        catch (Exception ex)
+        {
+            DiskLog($"cannot restore: {ex.GetType().Name}: {ex.Message}");
+            return null;
+        }
+    }
+
+    private static NavValue DecodeValue(
+        byte kind, NavNclType nclType, int definedLength, int flags,
+        NCLMetaTable meta, int fieldIndex, byte[] bytes)
+    {
+        switch (kind)
+        {
+            case KindNullString:
+                return nclType switch
+                {
+                    NavNclType.NavText => new NavText(definedLength, (string?)null),
+                    NavNclType.NavCode => new NavCode(definedLength, (string?)null),
+                    _ => throw new InvalidDataException($"NULL {nclType} is not an encodable kind"),
+                };
+
+            case KindBlob:
+            {
+                EnsureBlobFields();
+                var inMemory = (flags & 1) != 0;
+                var blob = inMemory ? new NavBLOB(bytes) : new NavBLOB();
+                _blobSizeWhenNoContents!.SetValue(blob, definedLength);
+                _blobIsDirty!.SetValue(blob, (flags & 2) != 0);
+                return blob;
+            }
+
+            case KindBytes:
+            {
+                var field = (INavValueMetadata)meta.GetFieldByIndex(fieldIndex);
+                var optionMetadata = nclType == NavNclType.NavOption ? field.NavOptionMetadata : null;
+                var valueMetadata = new CapturedValueMetadata(nclType, definedLength, optionMetadata);
+                return NavValue.CreateNavValueFromBytes(valueMetadata, bytes, 0, bytes.Length);
+            }
+
+            default:
+                throw new InvalidDataException($"unknown pool-entry kind {kind}");
+        }
+    }
+
+    /// <summary>Value-level digest of everything an on-disk baseline carries, in the order it
+    /// carries it: for every persistable table, every row, every field slot — the value's own
+    /// NclType, its own defined length, its NULL flag and the exact bytes BC's
+    /// <c>GetBytes()</c> produces — plus the isolated-storage, record-link and auto-increment
+    /// state (sorted, since those stores' enumeration order is not meaningful).
+    ///
+    /// This is the ROUND-TRIP PROOF the cross-process test asserts on: the writing process
+    /// logs it for the snapshot it captured, the reading process logs it for the snapshot it
+    /// decoded, and the two must be the same string. It deliberately does not go through
+    /// <c>ToString()</c> (which would hide a lost maxLength, a lost NULL flag or a lost
+    /// NavCode alpha index) and deliberately does not compare the serialised payload byte for
+    /// byte (which would be sensitive to how BC happens to intern equal values on decode, a
+    /// property of BC's caches rather than of this codec's fidelity).
+    ///
+    /// Computed only when PerfTrace is on — it walks every value in the snapshot.</summary>
+    internal static string ComputeRoundTripDigest(InstallBaselineSnapshot snapshot)
+    {
+        var sb = new System.Text.StringBuilder();
+        foreach (var source in snapshot.Sources)
+            foreach (var table in source.Tables)
+            {
+                if (IsSelfPopulatingVirtualTableId(table.TableId)) continue;
+                for (var ri = 0; ri < table.Rows.Length; ri++)
+                {
+                    var row = table.Rows[ri];
+                    for (var fi = 0; fi < row.Length; fi++)
+                    {
+                        sb.Append(table.TableId).Append('|').Append(ri).Append('|').Append(fi).Append('|');
+                        var v = row[fi];
+                        if (v == null) { sb.Append("<null>\n"); continue; }
+                        var meta = (INavValueMetadata)v;
+                        int definedLength;
+                        try { definedLength = meta.NavDefinedLengthMetadata; }
+                        catch (NotSupportedException) { definedLength = -1; }
+                        sb.Append(meta.NclType).Append('|').Append(definedLength).Append('|')
+                          .Append(v.IsNull ? 'N' : '-').Append('|');
+                        try { sb.Append(Convert.ToHexString(v.GetBytes())); }
+                        catch (Exception ex) { sb.Append("<nobytes:").Append(ex.GetType().Name).Append('>'); }
+                        sb.Append('\n');
+                    }
+                }
+            }
+        foreach (var line in TenantStoragePatches.DescribeInstallBaseline(snapshot.IsolatedStorage))
+            sb.Append(line).Append('\n');
+        foreach (var line in RecordLinkPatches.DescribeInstallBaseline(snapshot.RecordLinks))
+            sb.Append(line).Append('\n');
+        foreach (var (k, v) in (snapshot.AutoIncrement ?? new Dictionary<int, long>()).OrderBy(p => p.Key))
+            sb.Append("ai|").Append(k).Append('|').Append(v).Append('\n');
+
+        using var sha = System.Security.Cryptography.SHA256.Create();
+        return Convert.ToHexString(sha.ComputeHash(System.Text.Encoding.UTF8.GetBytes(sb.ToString())))[..16];
+    }
+
+    /// <summary>Order-independent digest over the tables an on-disk baseline actually carries
+    /// (i.e. excluding <see cref="IsSelfPopulatingVirtualTableId"/> tables). Same hashing as
+    /// <see cref="ComputeContentDigest"/>; the point of the narrower scope is that it is the
+    /// scope in which "restored from disk" and "captured in memory" must be identical, which
+    /// is what the round-trip test asserts.</summary>
+    internal static string ComputePersistableContentDigest(InstallBaselineSnapshot snapshot)
+    {
+        var narrowed = snapshot.Sources
+            .Select(s => new BaselineSource(s.Source,
+                s.Tables.Where(t => !IsSelfPopulatingVirtualTableId(t.TableId)).ToList()))
+            .ToList();
+        return ComputeContentDigest(narrowed);
+    }
+}

--- a/AlRunner/Patches/RecordPatches.NclMetaTableBuilder.cs
+++ b/AlRunner/Patches/RecordPatches.NclMetaTableBuilder.cs
@@ -47,12 +47,16 @@ public static partial class RecordPatches
         return null;
     }
 
+    // Metadata-backed lookup (AssemblyTypeIndex) rather than Array.Find(asm.GetTypes(), ...):
+    // identical match and identical "first TypeDef row wins" ordering, without materialising a
+    // RuntimeType for every type in the assembly just to compare its Name. See
+    // AlRunner/Infrastructure/AssemblyTypeIndex.cs for the measurement that motivated it.
     private static Type? FindRecordTypeIn(System.Reflection.Assembly asm, string name)
     {
         try
         {
-            return Array.Find(asm.GetTypes(),
-                x => x.Name == name && typeof(NavRecord).IsAssignableFrom(x));
+            return AlRunner.Infrastructure.AssemblyTypeIndex.For(asm)
+                .FindFirst(name, x => typeof(NavRecord).IsAssignableFrom(x));
         }
         catch { return null; }
     }
@@ -1066,13 +1070,16 @@ public static partial class RecordPatches
             : (IEnumerable<System.Reflection.Assembly>)loaded;
         foreach (var asm in ordered)
         {
-            Type[] types;
-            try { types = asm.GetTypes(); }
+            IEnumerable<Type> candidates;
+            try { candidates = AlRunner.Infrastructure.AssemblyTypeIndex.For(asm).EnumerateWithPrefix("Record"); }
             catch { continue; }
-            foreach (var t in types)
+            // EnumerateWithPrefix resolves ONLY the Record* names out of the TypeDef table, so
+            // the prewarm no longer forces the whole assembly's types to load (the Base App
+            // chunks alone are 132k types); the id/base-type gates below are unchanged.
+            foreach (var t in candidates)
             {
                 var name = t.Name;
-                if (name.Length < 7 || !name.StartsWith("Record", StringComparison.Ordinal)) continue;
+                if (name.Length < 7) continue;
                 if (!int.TryParse(name.AsSpan(6), out var id)) continue;
                 if (!typeof(NavRecord).IsAssignableFrom(t)) continue;
                 _recordTypeCache.TryAdd(id, t);

--- a/AlRunner/Patches/RecordPatches.ReportMetadataVirtualTable.cs
+++ b/AlRunner/Patches/RecordPatches.ReportMetadataVirtualTable.cs
@@ -461,6 +461,29 @@ public static partial class RecordPatches
                 continue;
             }
 
+            // Metadata-first: the question this method asks — "does a type called
+            // Report{id} exist in this assembly" — is answerable from the TypeDef table's Name
+            // column alone, which is EXACTLY what SeedCompiledReportIdsFromPEBytes already does
+            // for DependencyLoader-loaded assemblies (and what #1852's equivalence test proved
+            // agrees with the GetTypes() path on the identical TypeDef set). Doing the same for
+            // every OTHER loaded assembly removes the last Assembly.GetTypes() call on this
+            // path: measured at 2.0s of a 16.4s warm invocation, all of it type-loading the
+            // Base App chunks that nothing else in the run ever needed loaded.
+            //
+            // It also has no partial-load failure mode at all — there is no
+            // ReflectionTypeLoadException to half-answer — so the result is always complete
+            // and always safe to cache.
+            var index = AlRunner.Infrastructure.AssemblyTypeIndex.For(asm);
+            if (index.IsMetadataBacked)
+            {
+                var mdIds = ExtractReportIdsFromNames(index.TypeNamesWithPrefix("Report"));
+                _compiledReportIdsByAssembly[asm] = mdIds;
+                foreach (var id in mdIds) yield return id;
+                continue;
+            }
+
+            // Dynamic assemblies have no metadata to read; they keep the original reflection
+            // path (and its deliberate no-cache-on-exception semantics) unchanged.
             Type[]? types;
             int[]? partialIdsOnException = null;
             try
@@ -532,6 +555,23 @@ public static partial class RecordPatches
     /// scan and <see cref="ScanReportIdsFromPeBytes"/>'s <c>MetadataReader</c> scan) via
     /// <see cref="TryParseReportId"/> — see that method's remarks for the shared gate.
     /// </summary>
+    /// <summary>
+    /// Name-only sibling of <see cref="ExtractReportIds"/>, applying the identical
+    /// <see cref="TryParseReportId"/> gate to raw TypeDef names — used by the metadata path in
+    /// <see cref="CompiledReportIds"/> and equivalent by construction to
+    /// <see cref="ScanReportIdsFromPeBytes"/>.
+    /// </summary>
+    private static int[] ExtractReportIdsFromNames(IEnumerable<string> typeNames)
+    {
+        List<int>? ids = null;
+        foreach (var name in typeNames)
+        {
+            if (!TryParseReportId(name, out var id)) continue;
+            (ids ??= new List<int>()).Add(id);
+        }
+        return ids?.ToArray() ?? Array.Empty<int>();
+    }
+
     private static int[] ExtractReportIds(IEnumerable<Type?> types)
     {
         List<int>? ids = null;

--- a/AlRunner/Patches/RecordPatches.ReportMetadataVirtualTable.cs
+++ b/AlRunner/Patches/RecordPatches.ReportMetadataVirtualTable.cs
@@ -614,11 +614,57 @@ public static partial class RecordPatches
     }
 
     /// <summary>
+    /// Path-based sibling of <see cref="SeedCompiledReportIdsFromPEBytes"/> (issue #perf-B):
+    /// DependencyLoader's R2R chunk path now loads each chunk via
+    /// <c>AssemblyLoadContext.LoadFromAssemblyPath</c> (memory-mapped, on-disk cache) rather
+    /// than <c>Assembly.Load(byte[])</c>, so it no longer holds the chunk's bytes in memory
+    /// after the load — reading them back out just to pre-warm this cache would reintroduce
+    /// the exact per-invocation cost #1852 removed. <see cref="System.Reflection.PortableExecutable.PEReader"/>
+    /// accepts a <see cref="Stream"/> directly and reads metadata lazily off it, so this scans
+    /// the SAME TypeDef table straight from the file on disk, never materializing the whole
+    /// DLL as a byte[].
+    /// </summary>
+    internal static void SeedCompiledReportIdsFromPeFile(Assembly asm, string dllPath)
+    {
+        if (_compiledReportIdsByAssembly.ContainsKey(asm)) return;
+        var ids = ScanReportIdsFromPeFile(dllPath);
+        if (ids is null) return; // unreadable — leave unseeded, CompiledReportIds() falls back to GetTypes() lazily
+        _compiledReportIdsByAssembly[asm] = ids;
+    }
+
+    private static int[]? ScanReportIdsFromPeFile(string path)
+    {
+        try
+        {
+            using var fs = File.OpenRead(path);
+            using var peReader = new System.Reflection.PortableExecutable.PEReader(fs);
+            if (!peReader.HasMetadata) return null;
+            var mr = peReader.GetMetadataReader();
+            List<int>? ids = null;
+            foreach (var th in mr.TypeDefinitions)
+            {
+                var name = mr.GetString(mr.GetTypeDefinition(th).Name);
+                if (!TryParseReportId(name, out var id)) continue;
+                (ids ??= new List<int>()).Add(id);
+            }
+            return ids?.ToArray() ?? Array.Empty<int>();
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
     /// Test-only: exercises the exact same PE-byte/<c>MetadataReader</c> scan
     /// <see cref="SeedCompiledReportIdsFromPEBytes"/> uses, without touching the cache.
     /// See <see cref="ReadReportIdsViaGetTypesForTest"/> for the counterpart on the other path.
     /// </summary>
     internal static int[] ReadReportIdsFromPeBytesForTest(byte[] peBytes) => ScanReportIdsFromPeBytes(peBytes) ?? Array.Empty<int>();
+
+    /// <summary>Test-only: the file-based counterpart of <see cref="ReadReportIdsFromPeBytesForTest"/>,
+    /// exercising <see cref="ScanReportIdsFromPeFile"/> directly.</summary>
+    internal static int[] ReadReportIdsFromPeFileForTest(string path) => ScanReportIdsFromPeFile(path) ?? Array.Empty<int>();
 
     private static IEnumerable<BcAppSymbolCache.ReportSymbol> EnumerateBcAppReportSymbols()
     {

--- a/AlRunner/Patches/RecordPatches.cs
+++ b/AlRunner/Patches/RecordPatches.cs
@@ -1507,13 +1507,14 @@ public static partial class RecordPatches
         };
     }
 
+    // Metadata-backed lookup — see FindRecordTypeIn in RecordPatches.NclMetaTableBuilder.cs.
     private static Type? FindClrTypeByName(string name)
     {
         foreach (var asm in AppDomain.CurrentDomain.GetAssemblies())
         {
             try
             {
-                var t = Array.Find(asm.GetTypes(), x => x.Name == name);
+                var t = AlRunner.Infrastructure.AssemblyTypeIndex.For(asm).FindFirst(name);
                 if (t != null) return t;
             }
             catch { }

--- a/AlRunner/Patches/RunnerPageInstance.cs
+++ b/AlRunner/Patches/RunnerPageInstance.cs
@@ -907,15 +907,16 @@ internal sealed class RunnerPageInstance
     private static Type? FindPageType(int pageId)
     {
         var name = "Page" + pageId;
+        // Metadata-backed lookup — see AlRunner/Infrastructure/AssemblyTypeIndex.cs.
         foreach (var asm in AppDomain.CurrentDomain.GetAssemblies())
         {
-            Type?[] types;
-            try { types = asm.GetTypes(); }
-            catch (ReflectionTypeLoadException ex) { types = ex.Types; }
-            catch { continue; }
-            foreach (var t in types)
-                if (t != null && t.Name == name && typeof(NavForm).IsAssignableFrom(t))
-                    return t;
+            try
+            {
+                var t = AlRunner.Infrastructure.AssemblyTypeIndex.For(asm)
+                    .FindFirst(name, typeof(NavForm).IsAssignableFrom);
+                if (t != null) return t;
+            }
+            catch { }
         }
         return null;
     }

--- a/AlRunner/Patches/TenantStoragePatches.cs
+++ b/AlRunner/Patches/TenantStoragePatches.cs
@@ -65,6 +65,55 @@ public static class TenantStoragePatches
             _store[entry.Key] = entry.Value;
     }
 
+    /// <summary>Write the isolated-storage half of an install baseline to the on-disk
+    /// baseline cache (see RecordPatches.InstallBaselineDisk). Lives here, not in the codec,
+    /// because <see cref="Entry"/> is private to this store — the codec should not have to
+    /// know its shape, and this way a field added to Entry cannot be silently dropped from
+    /// the persisted form.</summary>
+    internal static void SerializeInstallBaseline(BinaryWriter w, object? snapshot)
+    {
+        var entries = snapshot as KeyValuePair<string, Entry>[] ?? Array.Empty<KeyValuePair<string, Entry>>();
+        w.Write(entries.Length);
+        foreach (var (key, entry) in entries)
+        {
+            w.Write(key);
+            w.Write(entry.Ciphertext);
+            w.Write((int)entry.Status);
+            w.Write(entry.IsSecret);
+        }
+    }
+
+    /// <summary>Sorted, fully-expanded text form of the isolated-storage half of an install
+    /// baseline — the input to the round-trip digest the on-disk cache logs, so a restored
+    /// snapshot can be compared against the captured one field by field rather than by count.
+    /// Sorted because the underlying store is a ConcurrentDictionary and its enumeration order
+    /// is not meaningful.</summary>
+    internal static IEnumerable<string> DescribeInstallBaseline(object? snapshot)
+    {
+        var entries = snapshot as KeyValuePair<string, Entry>[] ?? Array.Empty<KeyValuePair<string, Entry>>();
+        return entries
+            .Select(e => $"iso|{e.Key}|{e.Value.Ciphertext}|{(int)e.Value.Status}|{e.Value.IsSecret}")
+            .OrderBy(x => x, StringComparer.Ordinal);
+    }
+
+    /// <summary>Counterpart of <see cref="SerializeInstallBaseline"/>. Returns a value shaped
+    /// exactly like <see cref="CaptureInstallBaseline"/>'s, so
+    /// <see cref="RestoreInstallBaseline"/> cannot tell the two apart.</summary>
+    internal static object DeserializeInstallBaseline(BinaryReader r)
+    {
+        var count = r.ReadInt32();
+        var entries = new KeyValuePair<string, Entry>[count];
+        for (var i = 0; i < count; i++)
+        {
+            var key = r.ReadString();
+            var ciphertext = r.ReadString();
+            var status = (Encryption)r.ReadInt32();
+            var isSecret = r.ReadBoolean();
+            entries[i] = new KeyValuePair<string, Entry>(key, new Entry(ciphertext, status, isSecret));
+        }
+        return entries;
+    }
+
     // TEMPORARY (memory-census diagnostic) — total stored entries. See MemoryCensus.cs.
     internal static int CensusEntryCount() => _store.Count;
 

--- a/AlRunner/Patches/XmlPortPatches.cs
+++ b/AlRunner/Patches/XmlPortPatches.cs
@@ -151,8 +151,8 @@ public static partial class BcRuntime
         {
             try
             {
-                var t = Array.Find(_currentTestAssembly.GetTypes(),
-                    x => x.Name == name && (xmlPortBase == null || xmlPortBase.IsAssignableFrom(x)));
+                var t = AlRunner.Infrastructure.AssemblyTypeIndex.For(_currentTestAssembly)
+                    .FindFirst(name, x => xmlPortBase == null || xmlPortBase.IsAssignableFrom(x));
                 if (t != null) return t;
             }
             catch { }
@@ -162,8 +162,8 @@ public static partial class BcRuntime
             if (asm == _currentTestAssembly) continue;
             try
             {
-                var t = Array.Find(asm.GetTypes(),
-                    x => x.Name == name && (xmlPortBase == null || xmlPortBase.IsAssignableFrom(x)));
+                var t = AlRunner.Infrastructure.AssemblyTypeIndex.For(asm)
+                    .FindFirst(name, x => xmlPortBase == null || xmlPortBase.IsAssignableFrom(x));
                 if (t != null) return t;
             }
             catch { }

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -2427,6 +2427,13 @@ int RunServerLoop(System.IO.TextReader input, System.IO.TextWriter output)
     // ─────────────────────────────────────────────────────────────────────────
     void HandleServerRunTests(AlRunner.ServerRequest req, System.IO.TextWriter output)
     {
+        // #1936: real wall-clock duration of THIS request (received → summary
+        // written), for the `wallSeconds` field on the terminal summary line. Not
+        // the process's total uptime — a warm server serves many requests, so
+        // "since process start" is only meaningful for the very first one. Started
+        // here (before the sourcePaths/isolation validation below) so it also
+        // captures those cheap up-front checks, not just the run itself.
+        var reqSw = System.Diagnostics.Stopwatch.StartNew();
         if (req.SourcePaths == null || req.SourcePaths.Length == 0)
         {
             lock (outputLock)
@@ -2526,7 +2533,7 @@ int RunServerLoop(System.IO.TextReader input, System.IO.TextWriter output)
                 output.WriteLine(AlRunner.ServerProtocol.Summary(
                     allTests, exitCode, cached, changed,
                     allCompileErrors.Count > 0 ? allCompileErrors : null,
-                    cancelled: cancelled));
+                    cancelled: cancelled, wallSeconds: reqSw.Elapsed.TotalSeconds));
                 output.Flush();
             }
         }

--- a/AlRunner/Reporter.cs
+++ b/AlRunner/Reporter.cs
@@ -78,6 +78,18 @@ public static class Reporter
         w.WriteLine($"  C# compile:  {comp.TotalSeconds:F1}s");
         w.WriteLine($"  test run:    {run.TotalSeconds:F1}s");
         w.WriteLine($"  total:       {(emit + comp + run).TotalSeconds:F1}s");
+        // #1936: `total:` above is only emit+compile+run — it does NOT include the
+        // per-process fixed costs paid before any of those phases start (BC runtime
+        // patch application, dependency/package-cache indexing, install-seed-dep
+        // company baseline, etc. — see COMMON.md's boot-overhead profile). A warm run
+        // of a single-test fixture can report "total: 6.3s" while the process actually
+        // took ~23s wall clock, which reads as a lie to anyone timing the CLI from the
+        // outside. `wall:` is the real process wall-clock — OS process start time to
+        // this print — so the two numbers together show both "how long the phases we
+        // measure took" and "how long the process actually took", instead of only the
+        // former pretending to be the latter.
+        var wall = DateTime.Now - System.Diagnostics.Process.GetCurrentProcess().StartTime;
+        w.WriteLine($"  wall:        {wall.TotalSeconds:F1}s");
         w.WriteLine("=================================================================");
     }
 
@@ -255,6 +267,10 @@ public static class Reporter
             total = tests.Count,
             exitCode,
             compilationErrors = compileErrors.Count > 0 ? compileErrors : null,
+            // #1936: same "real wall clock, not just the measured phases" gap as the
+            // `wall:` line in PrintSummary — see that comment. Additive field, so
+            // existing consumers reading this JSON are unaffected.
+            wallSeconds = (DateTime.Now - System.Diagnostics.Process.GetCurrentProcess().StartTime).TotalSeconds,
         };
 
         return JsonSerializer.Serialize(output, new JsonSerializerOptions

--- a/AlRunner/ServerProtocol.cs
+++ b/AlRunner/ServerProtocol.cs
@@ -15,7 +15,8 @@ namespace AlRunner;
 ///             finishes, followed by exactly one terminal
 ///             {"type":"summary", exitCode, passed, failed, errors,
 ///             total, cached, cancelled|omitted, changedFiles|omitted,
-///             compilationErrors|omitted, protocolVersion:2} line.
+///             compilationErrors|omitted, wallSeconds|omitted,
+///             protocolVersion:2} line.
 ///             `cancelled` (true) is present only when a concurrent `cancel`
 ///             command actually stopped the run before every test ran; omitted
 ///             (never `false`) otherwise — see the `cancel` command below.
@@ -154,6 +155,12 @@ public static class ServerProtocol
     /// emitted as a literal <c>false</c>, matching every other optional field on
     /// this line (WhenWritingNull serialization; "not cancelled" and "cancellation
     /// wasn't asked for" both read as "absent").
+    /// <paramref name="wallSeconds"/> (#1936) is the real wall-clock duration of
+    /// THIS request — set by the caller from a <c>Stopwatch</c> started when
+    /// <c>runtests</c> was received — not the process's total uptime (a warm server
+    /// serves many requests, so "since process start" would be meaningless past the
+    /// first one). Omitted (never 0) when the caller does not supply it, same
+    /// null-omission convention as every other optional field here.
     /// </summary>
     public static string Summary(
         IReadOnlyList<TestResult> tests,
@@ -161,7 +168,8 @@ public static class ServerProtocol
         bool cached,
         IReadOnlyList<string>? changedFiles = null,
         IReadOnlyList<CompilationErrorGroup>? compilationErrors = null,
-        bool cancelled = false)
+        bool cancelled = false,
+        double? wallSeconds = null)
     {
         var payload = new
         {
@@ -177,6 +185,7 @@ public static class ServerProtocol
             compilationErrors = compilationErrors is { Count: > 0 }
                 ? compilationErrors.Select(g => new { file = g.File, errors = g.Errors })
                 : null,
+            wallSeconds,
             protocolVersion = 2,
         };
         return JsonSerializer.Serialize(payload, Opts);

--- a/AlRunner/TestExecutor.cs
+++ b/AlRunner/TestExecutor.cs
@@ -168,10 +168,44 @@ public sealed class TestExecutor
     // the cache-or-compute call site below). Exists for diagnostic blast radius — this cache
     // is process-lifetime and shared across every app group in the process, so it is
     // hypothesis #1 for any future "passes alone, fails in the suite" report, and without a
-    // switch the only way to test that hypothesis is a patched rebuild.
+    // switch the only way to test that hypothesis is a patched rebuild. The same switch also
+    // disables the on-disk tier below, in BOTH directions (no read AND no write) — a switch
+    // that only skipped the read would leave the run writing entries derived from the state
+    // it was set to isolate.
     private static readonly Dictionary<string, AlRunner.Patches.RecordPatches.InstallBaselineSnapshot>
         _depCompanyBaselineCache = new();
     private static readonly object _depCompanyBaselineCacheLock = new();
+
+    // ── Second tier: the same snapshot, persisted across PROCESSES ──────────────────────
+    // The dictionary above dies with the process, and the cost it removes is per-process:
+    // 5.9s of a 23.3s warm single-fixture run, ~177s of the CI unit-test step, 8-10s on each
+    // corpus / runner-extras invocation. Nothing about the computation is process-specific —
+    // it is a pure function of (dependency assembly set, runner build, BC version) — so
+    // InstallBaselineDiskCache stores it under exactly that key and
+    // RecordPatches.InstallBaselineDisk encodes/decodes it through BC's own NavValue byte
+    // codec (see those two files for the encoding, the refusal rules and why the
+    // self-populating virtual system tables are deliberately left out).
+    //
+    // Ordering is in-memory first, disk second: within one process the dictionary is both
+    // faster and strictly more faithful (it hands back the very objects that were captured),
+    // so disk is consulted only on an in-memory miss. A disk hit is promoted into the
+    // dictionary so later app groups in the same process take the in-memory path.
+    private static AlRunner.Patches.RecordPatches.InstallBaselineSnapshot? TryLoadDepCompanyBaselineFromDisk(
+        string keyText)
+    {
+        var bytes = AlRunner.Infrastructure.InstallBaselineDiskCache.TryRead(keyText);
+        if (bytes == null) return null;
+        var snapshot = AlRunner.Patches.RecordPatches.TryDeserializeInstallBaselineSnapshot(bytes, keyText);
+        if (snapshot == null)
+        {
+            // Present but unusable (truncated, written by an older codec, a table whose shape
+            // moved). Drop it so the write below replaces it instead of every future run
+            // paying the same failed decode.
+            AlRunner.Infrastructure.InstallBaselineDiskCache.Delete(keyText);
+            return null;
+        }
+        return snapshot;
+    }
 
     /// <summary>
     /// Runs every [Test] method in <paramref name="assembly"/>. When
@@ -281,22 +315,68 @@ public sealed class TestExecutor
             else
                 lock (_depCompanyBaselineCacheLock)
                     _depCompanyBaselineCache.TryGetValue(depKey, out cached);
+            var shortKey = depKey[..Math.Min(8, depKey.Length)];
             if (cached != null)
             {
                 AlRunner.Patches.RecordPatches.RestoreInstallBaselineSnapshot(cached);
                 // #1867 proving-test hook: a stable, directly-assertable signal that this app
                 // group reused a prior computation instead of re-running dependency Install
                 // triggers + Company-Initialize. See InstallSeedDepCompanyCacheTests.
-                PerfTrace.Log($"InstallBaseline.DepCompanyCache HIT {depKey[..Math.Min(8, depKey.Length)]}");
+                PerfTrace.Log($"InstallBaseline.DepCompanyCache HIT {shortKey}");
             }
             else
             {
-                InstallTriggerRunner.RunDependenciesOnly();
-                CompanyInitializer.EnsureCompanyInitialized();
-                var snapshot = AlRunner.Patches.RecordPatches.CaptureInstallBaselineSnapshot();
-                lock (_depCompanyBaselineCacheLock)
-                    _depCompanyBaselineCache[depKey] = snapshot;
-                PerfTrace.Log($"InstallBaseline.DepCompanyCache MISS {depKey[..Math.Min(8, depKey.Length)]}");
+                // In-memory miss. Before paying for the dependency Install triggers +
+                // Company-Initialize, look for the same snapshot on disk — a previous PROCESS
+                // with the same dependency set, runner build and BC version already computed
+                // it. Distinct marker (DISK-HIT, not HIT) so a run's log says which tier
+                // answered, and so a test can assert the cross-process path specifically.
+                // Key built only when the disk tier is actually in play: under the kill
+                // switch nothing should read, write, or even resolve a path.
+                var diskEnabled = !AlRunner.Infrastructure.InstallBaselineDiskCache.Disabled;
+                var diskKey = diskEnabled
+                    ? AlRunner.Infrastructure.InstallBaselineDiskCache.BuildKeyText(
+                        depKey, AlRunner.Patches.RecordPatches.InstallBaselineDiskSchemaVersion)
+                    : null;
+                var fromDisk = diskKey == null ? null : TryLoadDepCompanyBaselineFromDisk(diskKey);
+                if (fromDisk != null)
+                {
+                    AlRunner.Patches.RecordPatches.RestoreInstallBaselineSnapshot(fromDisk);
+                    lock (_depCompanyBaselineCacheLock)
+                        _depCompanyBaselineCache[depKey] = fromDisk;
+                    // digest= is the round-trip PROOF, not decoration: the writing process
+                    // logs the same digest for the snapshot it captured, so a test comparing
+                    // the two strings across processes is asserting that every value in every
+                    // row came back with the same type, length, NULL flag and bytes. Computed
+                    // only under AL_RUNNER_PERF (it walks the whole snapshot).
+                    PerfTrace.Log($"InstallBaseline.DepCompanyCache DISK-HIT {shortKey}"
+                        + (PerfTrace.Enabled
+                            ? $" digest={AlRunner.Patches.RecordPatches.ComputeRoundTripDigest(fromDisk)}"
+                            : ""));
+                }
+                else
+                {
+                    InstallTriggerRunner.RunDependenciesOnly();
+                    CompanyInitializer.EnsureCompanyInitialized();
+                    var snapshot = AlRunner.Patches.RecordPatches.CaptureInstallBaselineSnapshot();
+                    lock (_depCompanyBaselineCacheLock)
+                        _depCompanyBaselineCache[depKey] = snapshot;
+                    PerfTrace.Log($"InstallBaseline.DepCompanyCache MISS {shortKey}");
+
+                    // Persist for the next process. Refusals are logged by the codec and cost
+                    // only the persistence — this run already has its snapshot either way.
+                    if (diskKey != null)
+                    {
+                        var payload = AlRunner.Patches.RecordPatches.TrySerializeInstallBaselineSnapshot(
+                            snapshot, diskKey);
+                        if (payload != null
+                            && AlRunner.Infrastructure.InstallBaselineDiskCache.TryWrite(diskKey, payload))
+                            PerfTrace.Log($"InstallBaseline.DepCompanyCache DISK-WRITE {shortKey} {payload.Length}B"
+                                + (PerfTrace.Enabled
+                                    ? $" digest={AlRunner.Patches.RecordPatches.ComputeRoundTripDigest(snapshot)}"
+                                    : ""));
+                    }
+                }
             }
         }
         // Genuinely per-app-group — the bundle's own Install codeunits (if any) are never

--- a/README.md
+++ b/README.md
@@ -97,6 +97,15 @@ al-runner --out results.json ./my-bundle
 al-runner --verbose ./my-bundle
 ```
 
+Besides the AL-output cache above, the runner keeps the result of the dependency apps'
+`Install` triggers plus `Company-Initialize` (codeunit 2) at
+`~/.cache/al-runner/install-baseline/<key>.bin`, keyed by the dependency assembly set, the
+runner build and the BC version. It is the same seeding either way — reloading it just
+skips re-running those AL bodies in every new process (measured: 6.3s → 0.8s on a warm
+single-fixture run). `--cache <dir>` relocates it with the other caches; set
+`AL_RUNNER_NO_DEP_COMPANY_CACHE=1` to bypass it entirely (no read, no write) and force the
+full computation.
+
 ### Watch mode (live dashboard)
 
 ```bash

--- a/protocol-v2.schema.json
+++ b/protocol-v2.schema.json
@@ -117,6 +117,7 @@
           "type": "array",
           "items": { "$ref": "#/definitions/FileCoverage" }
         },
+        "wallSeconds": { "type": "number", "minimum": 0 },
         "protocolVersion": { "const": 2 }
       }
     },


### PR DESCRIPTION
Perf branch to compare CI step times against main. Reference point: run 31956381384 on main, BC 28.2 leg — unit-test step 468s, corpus 139s, runner-extras 130s.

## What this changes

A warm, cache-hit run of `AlRunner.Tests/Fixtures/RecordTriggerXRec` took 23.4s of wall clock for about 50ms of AL test execution (the summary printed `total: 6.3s`, which only counts run time). A `dotnet-trace` profile put the fixed cost in three places, all in the runner's boot path. This branch removes them:

1. **`Assembly.GetTypes()` scans** (~10s per run). `EventSubscriberPatches.EnsureRegistryFresh` and about 15 `Find*Type` sites called `GetTypes()` on the Base Application R2R chunks, which loads all 132k types, and the subscriber scan repeated whenever the assembly count grew. Now a per-assembly index built from the ECMA-335 metadata (`AssemblyTypeIndex`) decides which type names to ask for; the CLR only loads the hits. Equivalence with the old scan is proven in-process on the real 3,447 subscribers, and `AL_RUNNER_SUBSCRIBER_SCAN_AUDIT=1` runs both scans and prints the diff.
2. **Base App install-trigger reseed** (~5.6s per run). The #1867 dep+company baseline cache was in-memory only, so every process re-ran the Base Application `OnInstallAppPerCompany` codeunits and codeunit 2. The snapshot is now also written to disk (`~/.cache/al-runner/install-baseline`), encoded with BC's own `NavValue.GetBytes`/`CreateNavValueFromBytes`, keyed by dependency MVIDs + runner fingerprint + BC version. All-or-nothing: any value the codec can't represent means the snapshot is not persisted (logged). Virtual system tables (AllObj, Field, …) are excluded on purpose. Kill switch `AL_RUNNER_NO_DEP_COMPANY_CACHE=1` still forces a full recompute.
3. **`.app` manifest re-reads** (~4.4s per run). `ReadManifest` read the whole `.app` (Base App: 98MB) and inflated the nested R2R package on every call, from several call sites, over ~113 package-cache files. Now: process-wide memo, JSON index under `app-manifests`, stream-based zip open. R2R DLL chunks are extracted once into `r2r-chunks/<hash>` and loaded from path (memory-mapped) instead of `Assembly.Load(byte[])` after a fresh inflate.
4. The summary prints a `wall:` line (process wall clock) after `total:`, and the JSON/server summaries carry `wallSeconds`. `ServerCancelTests` share one server across the six tests that don't block or kill it.

## Numbers (local, 12 cores, warm caches)

| | before | after |
|---|---|---|
| RecordTriggerXRec warm run, wall | 23.4s | 5.0s |
| al-language corpus, 2076 tests | 66s | 65s cold caches / 15s warm |
| runner-extras, 133 tests | ~70s | 70s cold / 27s warm |
| ServerCancelTests class | 2m06s | 1m04s |
| peak RSS, trivial fixture | 2.1 GB | 1.7 GB |

Corpus 2076/2076 and runner-extras 133/133, exit 0, each run twice (second run is the disk-cache path). 60/60 across the touched and heavy unit-test classes.

## Tests added

`AssemblyTypeIndexTests`, `EventSubscriberScanEquivalenceTests`, `InstallBaselineDiskCacheTests`, `AppLoaderManifestCacheTests`, `AppLoaderR2rChunkCacheTests`, `SummaryWallClockTests`; `InstallSeedDepCompanyCacheTests` updated for the disk tier.

https://claude.ai/code/session_01SseX9zAfzsP31oepzC9YXR
