### PR TITLE
fix(watch): make WatchBurstSwitchTests's burst assertion deterministic

### DIFF
--- a/AlRunner.Tests/WatchBurstSwitchTests.cs
+++ b/AlRunner.Tests/WatchBurstSwitchTests.cs
@@ -4,26 +4,95 @@ using Xunit;
 namespace AlRunner.Tests;
 
 /// <summary>
-/// #1904's own proof: drives the REAL `--watch` process (not the debounce loop in
-/// isolation — WatchSourceTests covers that deterministically) through a bulk multi-file
-/// switch that mimics a branch checkout, and asserts the phantom failure the issue reports
-/// does NOT appear.
+/// #1904's own proof, in two parts split per #1936 (the same real-clock-dependence #1920 /
+/// #1921 diagnosed and fixed in the sibling <c>WatchSourceTests</c> burst test, which this
+/// file did not originally get converted along with):
 ///
 /// The fixture (see Fixtures/WatchBurstSwitch) spreads a version switch over seven files:
 /// six addend codeunits (F0..F5) and a Sum test whose expected total is a SEPARATE file
 /// from every addend. "Version A" (all addends 1, expects 6) and "version B" (all addends
 /// 10, expects 60) each pass on their own; any half-applied mix of the two files sums to
-/// neither 6 nor 60. Under the pre-fix fixed `Thread.Sleep(250)` debounce, delivering the
+/// neither 6 nor 60. Under the pre-#1904 fixed `Thread.Sleep(250)` debounce, delivering the
 /// seven writes with gaps below the quiet window released mid-burst — a wrong result,
-/// reported as a real test failure, for a codeunit that is fine in both versions — and
-/// then picked the burst's tail up as a SECOND cycle once it settled: two cycles for one
-/// switch, the first one a phantom. Quiescence must produce exactly ONE cycle for the whole
-/// switch, and its result must be the correct, fully-settled version B PASS.
+/// reported as a real test failure, for a codeunit that is fine in both versions.
 ///
-/// Spawns the real runner; needs the BC artifact cache. Skips (no-op) when absent.
+/// 1. <see cref="WaitForQuiescence_MirrorsBulkFileSwitchFixture_ReleasesOnlyAfterBurstSettles_Deterministic"/>
+///    — the algorithmic claim ("exactly one cycle, never released mid-burst") driven
+///    through <c>WatchSource.WatchActivity(nowTicks:)</c> / <c>WaitForQuiescence(nowTicks:,
+///    sleep:)</c>'s injected virtual clock, mirroring this fixture's exact write shape (F0..F5
+///    then Sum, 150ms gaps, default 250ms quiet window) with zero real elapsed time anywhere.
+///    THIS is now the regression proof: it fails if quiescence reverts to a fixed
+///    post-first-event debounce (verified by hand — see the PR description), and it cannot
+///    flake under CI load because nothing in it depends on wall-clock time.
+/// 2. <see cref="Watch_BulkFileSwitch_SettlesToCorrectResult"/> — kept on REAL time,
+///    spawning the actual `--watch` process against a real `FileSystemWatcher`, because the
+///    algorithmic proof above says nothing about whether the real subprocess wiring (process
+///    spawn, real file events, re-emit, PASS/FAIL reporting) actually works end to end. It no
+///    longer asserts an exact cycle count — under CI load a real correct implementation can
+///    legitimately split one intended burst into more than one quiescence window (the same
+///    ambiguity #1920 described), so an exact count is not a claim real time can prove either
+///    way. It asserts only that the run eventually converges to the correct, fully-settled
+///    version B PASS — real end-to-end coverage, not a timing assertion.
 /// </summary>
 public class WatchBurstSwitchTests
 {
+    // #1936: the algorithmic "exactly one cycle" claim, driven through WatchSource's
+    // injected virtual clock instead of the real process below — see the class doc comment.
+    // Mirrors WatchBurstSwitchTests's own fixture write loop exactly: F0..F5 copied with a
+    // 150ms delay after each, then Sum copied last with no further delay — i.e. seven events
+    // at virtual t = 0, 150, 300, 450, 600, 750, 900ms, all comfortably below the default
+    // 250ms quiet window between consecutive events (so a CORRECT quiescence implementation
+    // must keep re-arming through the whole burst and release only once, after the last one).
+    [Fact]
+    public void WaitForQuiescence_MirrorsBulkFileSwitchFixture_ReleasesOnlyAfterBurstSettles_Deterministic()
+    {
+        const int quietMs = 250;
+        var eventTimes = new long[] { 0, 150, 300, 450, 600, 750, 900 }; // F0, F1, F2, F3, F4, F5, Sum
+        var lastEventTime = eventTimes[^1];
+
+        long fakeNow = 0;
+        Func<long> nowTicks = () => fakeNow;
+        var activity = new AlRunner.WatchSource.WatchActivity(nowTicks);
+
+        // Event #0 (F0) is delivered synchronously up front — models `signal.Wait()`
+        // returning after the first real watcher event, exactly as WaitForSourceChange does
+        // immediately before calling WaitForQuiescence in production.
+        activity.Touch();
+        var nextEventIndex = 1;
+
+        void FakeSleep(int ms)
+        {
+            var target = fakeNow + ms;
+            while (nextEventIndex < eventTimes.Length && eventTimes[nextEventIndex] <= target)
+            {
+                fakeNow = eventTimes[nextEventIndex]; // land exactly on the event's own virtual time
+                activity.Touch();
+                nextEventIndex++;
+            }
+            fakeNow = target;
+        }
+
+        AlRunner.WatchSource.WaitForQuiescence(
+            activity, quietMs: quietMs, maxWaitMs: 10_000, nowTicks: nowTicks, sleep: FakeSleep);
+
+        // The phantom-failure assertion: must not release before the burst's LAST event (Sum,
+        // written last on purpose — see the fixture's own doc comment) — that is precisely
+        // "started a cycle mid-switch". A reverted fixed-post-first-event debounce releases
+        // ~250ms after F0 (virtual t=250), long before Sum's virtual t=900, and fails here.
+        Assert.True(fakeNow >= lastEventTime,
+            $"WaitForQuiescence returned at virtual {fakeNow}ms, BEFORE the burst's last event " +
+            $"(Sum, written last) at {lastEventTime}ms — released mid-switch against a " +
+            "half-applied tree (the #1904 phantom-failure bug: a fixed post-first-event " +
+            "debounce cannot distinguish a settling save from an in-progress bulk switch).");
+
+        // And it must not stall indefinitely either — one quiet window plus generous slack
+        // after the last event, not the 10s cap.
+        Assert.True(fakeNow <= lastEventTime + quietMs + 500,
+            $"WaitForQuiescence returned {fakeNow - lastEventTime}ms after the burst's last " +
+            "event — quiescence should release promptly once the burst settles, not stall " +
+            "toward the cap.");
+    }
+
     private static readonly string RepoRoot = Path.GetFullPath(
         Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
     private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
@@ -33,7 +102,7 @@ public class WatchBurstSwitchTests
     private const string TestName = "Sum_OfAllValues_MatchesExpectedTotal";
 
     [SkippableFact]
-    public async Task Watch_BulkFileSwitch_ProducesExactlyOneCycle_AgainstSettledTree()
+    public async Task Watch_BulkFileSwitch_SettlesToCorrectResult()
     {
         TestArtifacts.SkipIfMissing();
 
@@ -158,19 +227,23 @@ public class WatchBurstSwitchTests
             // "the next cycle just hasn't finished yet", within a generous overall budget.
             var markers = await WaitForMarkersToSettle(m1, TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(120));
 
-            // The core #1904 claim: exactly ONE cycle for the whole burst, not two. Two
-            // would mean a phantom cycle ran mid-switch (the old fixed-debounce bug) before
-            // the correct, fully-settled cycle.
-            Assert.True(markers.Count == 1,
-                $"expected exactly 1 watch cycle for the whole burst switch, saw {markers.Count} " +
-                "— a bulk multi-file rewrite must debounce to ONE cycle against the settled tree, " +
-                "not fire early against a half-applied mix (the #1904 phantom-failure bug: two " +
-                "cycles for one switch, the first against a tree that was still part-old / " +
-                $"part-new).\n--- output between m1 and settle ---\n{Segment(m1 + 1, markers.Count > 0 ? markers[^1] : lines.Count)}");
-
-            // And that one cycle must report the CORRECT, fully-settled version B result —
-            // not a phantom failure for a test that is fine in both version A and version B.
-            var finalCycle = Segment(m1 + 1, markers[0]);
+            // #1936: this used to additionally assert `markers.Count == 1` here — exactly
+            // one cycle for the whole burst. That claim is real-clock dependent (the same
+            // class #1920/#1921 diagnosed in the sibling WatchSourceTests burst test): under
+            // CI load, real event delivery for one of the seven writes above can be delayed
+            // past the 250ms quiet window even though quiescence is implemented correctly,
+            // legitimately splitting one intended burst into more than one real quiescence
+            // window — indistinguishable, from a bare "saw 2 cycles" symptom, from the actual
+            // #1904 bug this test exists to catch. A real-clock test cannot tell those two
+            // apart, so it must not gate on an exact count. That algorithmic claim now lives
+            // in WaitForQuiescence_MirrorsBulkFileSwitchFixture_ReleasesOnlyAfterBurstSettles_Deterministic
+            // above, proven with zero real elapsed time via the injected virtual clock.
+            //
+            // What DOES stay provable on real time: the run must eventually converge to the
+            // correct, fully-settled version B result — the FINAL cycle observed once the
+            // watch goes quiet again, regardless of how many quiescence windows the burst
+            // happened to split into on this machine.
+            var finalCycle = Segment(m1 + 1, markers[^1]);
             Assert.Contains(TestName, finalCycle);
             Assert.DoesNotContain("FAIL", finalCycle);
             Assert.Contains("PASS", finalCycle);


### PR DESCRIPTION
Closes #1936

## Summary

`WatchBurstSwitchTests`'s real-subprocess test asserted `markers.Count == 1` against real elapsed time — the same class of flake #1920/#1921 fixed in the sibling `WatchSourceTests` burst test, which this file was not converted along with at the time.

## Root cause

Under CI load, real event delivery for one of the burst's seven file writes can be delayed past the 250ms quiet window even though `WaitForQuiescence` is implemented correctly — legitimately splitting one intended burst into more than one real quiescence window. That is indistinguishable, from a bare "saw 2 cycles" symptom, from the actual #1904 fixed-debounce bug the test exists to catch. A real-clock test cannot tell the two apart, so asserting an exact cycle count against real time cannot gate `main`.

## Fix — same split #1921 used

- **Algorithmic claim → deterministic.** New test `WaitForQuiescence_MirrorsBulkFileSwitchFixture_ReleasesOnlyAfterBurstSettles_Deterministic` drives `WatchSource`'s existing injected virtual clock (`WatchActivity(nowTicks:)` / `WaitForQuiescence(nowTicks:, sleep:)`, both added by #1921 and defaulting to the real clock in production) with the exact write shape of the real fixture — F0..F5 then Sum, 150ms gaps, default 250ms quiet window — and zero real elapsed time anywhere. This is now the regression proof.
- **Real end-to-end wiring stays real.** The subprocess test (renamed `Watch_BulkFileSwitch_SettlesToCorrectResult`) still spawns the real `--watch` process against a real `FileSystemWatcher` and drives the burst with real `Task.Delay`, but no longer asserts an exact cycle count — only that the run eventually converges to the correct, fully-settled version B PASS.

No production code changed — `AlRunner/WatchSource.cs` is untouched. This is a pure test-determinism fix, matching #1921's shape exactly.

## RED → GREEN evidence

Temporarily reverted `WaitForQuiescence`'s body to a fixed post-first-event debounce (`doSleep(quiet); return;`):

```
Failed AlRunner.Tests.WatchBurstSwitchTests.WaitForQuiescence_MirrorsBulkFileSwitchFixture_ReleasesOnlyAfterBurstSettles_Deterministic
  Error Message:
   WaitForQuiescence returned at virtual 250ms, BEFORE the burst's last event (Sum, written last)
   at 900ms — released mid-switch against a half-applied tree (the #1904 phantom-failure bug...)
```

Restored the original implementation, reran: GREEN again — confirms the new test genuinely discriminates the #1904 regression and cannot flake on machine load.

## Test plan

- [x] `dotnet build AlRunner.Tests/AlRunner.Tests.csproj -c Release`
- [x] New deterministic test: PASS (9ms) against current code
- [x] RED-check: reverted `WaitForQuiescence`, confirmed the exact predicted failure, restored
- [x] `dotnet test --filter "FullyQualifiedName~WatchSourceTests|FullyQualifiedName~WatchBurstSwitchTests|FullyQualifiedName~WatchTests"` — 9/9 pass (31s; the real-subprocess test ran, not skipped — BC artifact cache present locally)
- [x] Full `AlRunner.Tests` suite locally — 745 passed, 1 unrelated pre-existing failure (`BcCompilerSharedReferenceMemoTests.AddingAPackageToAScannedDir_ForcesARebuild`), confirmed to fail identically on unmodified `main` (unrelated to this change — likely tied to the separate `perf/boot-overhead` memo/disk-index work)
- [ ] CI green on all 8 required BC legs
