### PR TITLE
fix(xmlport): delete 3 more orphaned JmpHook registrations (#1883)

### DIFF
--- a/AlRunner/BcRuntime.cs
+++ b/AlRunner/BcRuntime.cs
@@ -1936,39 +1936,19 @@ public static partial class BcRuntime
         var navXmlPortType = navNcl.GetType("Microsoft.Dynamics.Nav.Runtime.NavXmlPort");
         if (navXmlPortType != null)
         {
-            var tDataError = navNcl.GetType("Microsoft.Dynamics.Nav.Types.DataError")
-                ?? AppDomain.CurrentDomain.GetAssemblies()
-                    .SelectMany(a => { try { return a.GetTypes(); } catch { return Array.Empty<Type>(); } })
-                    .FirstOrDefault(t => t.Name == "DataError");
             var xmlPortNavRecordType = navNcl.GetType("Microsoft.Dynamics.Nav.Runtime.NavRecord");
 
-            // Static XMLPORT.EXPORT(id, stream) / XMLPORT.IMPORT(id, stream) overloads — NOT
-            // covered by the #1800 investigation above (that was scoped to the four instance
-            // methods; no corpus test was found exercising this static surface either way), so
-            // left as-is pending a dedicated follow-up. See tests/runner-extras/standalone-suites
-            // /xmlport-cluster-hooks-1800 and the #1800 PR body for the full orphan inventory.
-            if (tDataError != null)
-            {
-                var tNavOutStream = navNcl.GetType("Microsoft.Dynamics.Nav.Runtime.NavOutStream");
-                var tNavInStream  = navNcl.GetType("Microsoft.Dynamics.Nav.Runtime.NavInStream");
-                var tNavRecord    = navNcl.GetType("Microsoft.Dynamics.Nav.Runtime.NavRecord");
-                if (tNavOutStream != null && tNavRecord != null)
-                {
-                    var staticExport = navXmlPortType.GetMethod("Export",
-                        BindingFlags.Public | BindingFlags.Static, null,
-                        new[] { tDataError, typeof(int), tNavOutStream, tNavRecord }, null);
-                    if (staticExport != null)
-                        Hook(staticExport, nameof(NavXmlPort_StaticExport), "NavXmlPort.Export(DataError,int,NavOutStream,NavRecord)");
-                }
-                if (tNavInStream != null && tNavRecord != null)
-                {
-                    var staticImport = navXmlPortType.GetMethod("Import",
-                        BindingFlags.Public | BindingFlags.Static, null,
-                        new[] { tDataError, typeof(int), tNavInStream, tNavRecord }, null);
-                    if (staticImport != null)
-                        Hook(staticImport, nameof(NavXmlPort_StaticImport), "NavXmlPort.Import(DataError,int,NavInStream,NavRecord)");
-                }
-            }
+            // #1883: static XMLPORT.EXPORT(id, stream[, record]) / XMLPORT.IMPORT(id, stream[,
+            // record]) overloads — NOT covered by the #1800 investigation above (that was scoped
+            // to the four instance methods). Investigated separately: BC's real, unpatched
+            // static Export(DataError,int,NavOutStream,NavRecord) is exercised end-to-end by the
+            // al-language corpus (xmlport/TestXmlPortObject.al —
+            // XmlPort_Export_StaticWithRecord_RespectsFilters) and passes; the matching static
+            // Import(DataError,int,NavInStream,NavRecord) overload was verified empirically the
+            // same way (tests/runner-extras/standalone-suites/xmlport-static-import-with-record —
+            // #1883) and also just works. So — same conclusion as the #1800 cluster above — there
+            // is nothing to redirect to; the Hook(...) call sites and their throw-stub bodies
+            // (NavXmlPort_StaticExport/StaticImport) were deleted outright rather than left dead.
 
             // DISABLED: NavXmlPort.RunXmlPort() is R2R-compiled/inlined; RuntimeHelpers.PrepareMethod
             // SIGSEGVs the process during patch installation. Cecil migration pending.
@@ -2028,25 +2008,16 @@ public static partial class BcRuntime
             // 14 corpus tests before being reverted) lives once, canonically, in the big comment
             // block above NavXmlPort_StaticRun1..4 in AlRunner/Patches/XmlPortPatches.cs — see
             // there, not here.
-            var nclAssembly = navXmlPortType.Assembly;
-            var tableNodeType = nclAssembly.GetType("Microsoft.Dynamics.Nav.Runtime.NavXmlPortTableNode");
 
-            // NavXmlPortTableNode(NavRecordHandle) constructor — called from the generated
-            // XmlPort{ID}.InitializeComponent() for each tableelement. Calls record.Target which
-            // triggers NavRecordHandle.CreateTarget → NCLMetaTable.CreateObjectInstance → the
-            // generated Table{ID} ctor → record initialization that NREs before reaching Add().
-            // Since Add is already a no-op and we never use the node list, stub ctor as no-op.
-            if (tableNodeType != null)
-            {
-                var xmlPortHandleNavRecordType = nclAssembly.GetType("Microsoft.Dynamics.Nav.Runtime.NavRecordHandle");
-                if (xmlPortHandleNavRecordType != null)
-                {
-                    var tableNodeCtor = tableNodeType.GetConstructor(
-                        BindingFlags.Public | BindingFlags.Instance, null, new[] { xmlPortHandleNavRecordType }, null);
-                    if (tableNodeCtor != null)
-                        Hook(tableNodeCtor, nameof(NavXmlPortTableNode_Ctor), "NavXmlPortTableNode.ctor(NavRecordHandle)");
-                }
-            }
+            // #1883: NavXmlPortTableNode(NavRecordHandle) constructor — called from the generated
+            // XmlPort{ID}.InitializeComponent() for each tableelement — used to be a Hook(...)
+            // call site right here too, on the belief that record.Target NREs before reaching
+            // Add(). Also orphaned (JmpHook disabled by default), and also a misdiagnosis of the
+            // same shape as BeginInitialization above: every al-language corpus xmlport test uses
+            // a tableelement-bound fixture (xmlport/_fixtures/xmlports/ALTUniversalXmlPort.al) and
+            // all of them pass, so BC's real, unpatched ctor already constructs correctly on the
+            // skeleton. Deleted outright along with NavXmlPortTableNode_Ctor/EnsureXmlPortNodeFields
+            // in XmlPortPatches.cs — there is nothing to redirect to.
         }
 
         // NavFile.ALUpload / ALDownload — browser round-trip (§3.4 file-storage OOS).

--- a/AlRunner/Patches/XmlPortPatches.cs
+++ b/AlRunner/Patches/XmlPortPatches.cs
@@ -25,10 +25,6 @@ public static partial class BcRuntime
 {
     private static readonly ConcurrentDictionary<int, Type?> _xmlPortTypeCache = new();
 
-    // Lazily resolved reflection handles for NavXmlPortNode base-class private list fields.
-    private static System.Reflection.FieldInfo? _fXmlPortNodeAttrChildren;
-    private static System.Reflection.FieldInfo? _fXmlPortNodeElemChildren;
-
     // ──────────────────────────────────────────────────────────────────
     // NavXmlPortHandle.CreateTarget — bypass GetMetaXmlPortById +
     // CreateObjectInstance (which NREs on null delegate). Construct
@@ -263,31 +259,11 @@ public static partial class BcRuntime
         RunnerScope.ThrowOutOfScope("NavXmlPort.Run", "browser-roundtrip", "file-storage");
     }
 
-    // ──────────────────────────────────────────────────────────────────
-    // NavXmlPort static Export/Import — XMLPORT.EXPORT(id, stream) and
-    // XMLPORT.IMPORT(id, stream) in AL compile to these static overloads.
-    // In-memory XmlPort serialization is in scope eventually (scope.md §4
-    // TODO) but not yet implemented; throw loud failure so tests cannot
-    // silently pass without real serialization.
-    // ──────────────────────────────────────────────────────────────────
-
-    [MethodImpl(MethodImplOptions.NoInlining)]
-    public static bool NavXmlPort_StaticExport(int errorLevel, int xmlPortId, object outStream, object record)
-    {
-        RunnerScope.ThrowNotYetImplemented(
-            "NavXmlPort.StaticExport",
-            "in-memory XmlPort serialization not yet implemented — see HANDOFF.md and SCOPE-AUDIT.md");
-        return default;
-    }
-
-    [MethodImpl(MethodImplOptions.NoInlining)]
-    public static bool NavXmlPort_StaticImport(int errorLevel, int xmlPortId, object inStream, object record)
-    {
-        RunnerScope.ThrowNotYetImplemented(
-            "NavXmlPort.StaticImport",
-            "in-memory XmlPort serialization not yet implemented — see HANDOFF.md and SCOPE-AUDIT.md");
-        return default;
-    }
+    // NavXmlPort static Export/Import — XMLPORT.EXPORT(id, stream[, record]) and
+    // XMLPORT.IMPORT(id, stream[, record]) in AL compile to static overloads on NavXmlPort.
+    // #1883: no runner replacement here (or anywhere) — see the big comment block below,
+    // same conclusion as the #1800 instance-method cluster: BC's real, unpatched static
+    // Export/Import bodies already handle well-formed AL usage correctly.
 
     // Export(DataError) / Import(DataError) / Run() / RunXmlPort() (private) /
     // SetTableView(NavRecord) / BeginInitialization() / EndInitialization() /
@@ -323,9 +299,17 @@ public static partial class BcRuntime
     // (NavXmlPort_StaticRun1..4) and the matching Cecil ownership in NclCecilRewrite.cs for the
     // decompiled-source evidence and the docs/scope.md#file-storage classification.
     //
-    // XmlPort{ID}.InitializeComponent() (below) and NavXmlPortTableNode..ctor (further down)
-    // are a separate mechanism — JmpHook.Apply against methods on the test assembly's own
-    // BC-generated types, not NCL — and were not part of this investigation; left unchanged.
+    // XmlPort{ID}.InitializeComponent() (below) is a separate mechanism — JmpHook.Apply
+    // against a method on the test assembly's own BC-generated type, not NCL — and was not
+    // part of this investigation; left unchanged.
+    //
+    // #1883: NavXmlPortTableNode(NavRecordHandle)'s ctor used to be hooked here too
+    // (NavXmlPortTableNode_Ctor, further down), on the belief that BC's real ctor NREs before
+    // reaching Add(). Also orphaned, also a misdiagnosis of the same shape: every al-language
+    // corpus xmlport test constructs a tableelement-bound XmlPort (see BcRuntime.cs's
+    // NavXmlPortTableNode note near the Run-overload hook block) and all of them pass, so BC's
+    // real, unpatched ctor already constructs correctly. Deleted outright along with
+    // EnsureXmlPortNodeFields — there is nothing to redirect to.
 
     /// <summary>
     /// XmlPort{ID}.InitializeComponent() — the BC-generated override that calls
@@ -341,43 +325,5 @@ public static partial class BcRuntime
     [MethodImpl(MethodImplOptions.NoInlining)]
     public static void NavXmlPort_InitializeComponent(object self)
     {
-    }
-
-    // Skeleton ctor-time scaffolding — required so XmlPort{ID} construction succeeds;
-    // no observable AL-test behavior to fake. Initializes the attribute/element child
-    // lists so node-traversal code does not NRE on an uninitialized collection.
-    [MethodImpl(MethodImplOptions.NoInlining)]
-    public static void NavXmlPortTableNode_Ctor(object self, object record)
-    {
-        EnsureXmlPortNodeFields(self.GetType());
-        if (_fXmlPortNodeAttrChildren != null)
-        {
-            _fXmlPortNodeAttrChildren.SetValue(self, Activator.CreateInstance(_xmlPortNodeListType!));
-            _fXmlPortNodeElemChildren!.SetValue(self, Activator.CreateInstance(_xmlPortNodeListType!));
-        }
-    }
-
-    private static System.Type? _xmlPortNodeListType;
-
-    private static void EnsureXmlPortNodeFields(Type derivedType)
-    {
-        if (_fXmlPortNodeAttrChildren != null) return;
-        var t = derivedType;
-        while (t != null)
-        {
-            var attr = t.GetField("attributeChildren",
-                BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly);
-            var elem = t.GetField("elementChildren",
-                BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly);
-            if (attr != null && elem != null)
-            {
-                var listType = typeof(System.Collections.Generic.List<>).MakeGenericType(attr.FieldType.GetGenericArguments()[0]);
-                System.Threading.Interlocked.CompareExchange(ref _xmlPortNodeListType, listType, null);
-                System.Threading.Interlocked.CompareExchange(ref _fXmlPortNodeAttrChildren, attr, null);
-                System.Threading.Interlocked.CompareExchange(ref _fXmlPortNodeElemChildren, elem, null);
-                return;
-            }
-            t = t.BaseType;
-        }
     }
 }

--- a/tests/expectations/count-baseline/test-count-baseline.json
+++ b/tests/expectations/count-baseline/test-count-baseline.json
@@ -7,8 +7,8 @@
     },
     "runner-extras": {
       "tests": {
-        "default": 132,
-        "byBcVersion": { "27.0": 126, "27.3": 126, "27.5": 126 }
+        "default": 134,
+        "byBcVersion": { "27.0": 128, "27.3": 128, "27.5": 128 }
       },
       "appGroups": {
         "default": 27,

--- a/tests/runner-extras/standalone-suites/xmlport-cluster-hooks-1800/XhcTests.Codeunit.al
+++ b/tests/runner-extras/standalone-suites/xmlport-cluster-hooks-1800/XhcTests.Codeunit.al
@@ -205,4 +205,91 @@ codeunit 62182 "XHC Tests"
         if not Ok then
             Error('XHC Port.Import() reported failure against a correctly-set-up InStream source.');
     end;
+
+    // ── #1883 follow-up: static XMLPORT.EXPORT(id, stream, record) / XMLPORT.IMPORT(id,
+    // stream, record) — NOT covered by the #1800 investigation above (that was scoped to the
+    // instance methods). Also found orphaned (JmpHook disabled by default, hook never fired)
+    // with a "not-yet-implemented" throw stub that would have fired had the hook worked. BC's
+    // real, unpatched static Export/Import bodies were verified empirically to handle
+    // well-formed usage correctly, same conclusion and same shape as the #1800 cluster: there
+    // is nothing to redirect to, so the orphaned Hook(...) call sites and throw stubs
+    // (NavXmlPort_StaticExport/StaticImport in AlRunner/Patches/XmlPortPatches.cs) were
+    // deleted outright. The actual BC-behaviour claim ("does the static overload populate /
+    // export the given record correctly") is proven upstream in the corpus, not here — see
+    // bc-behavior-tests-go-upstream.md and xmlport/TestXmlPortObject.al's
+    // XmlPort_Export_StaticWithRecord_RespectsFilters /
+    // XmlPort_Import_StaticWithRecord_InsertsIntoGivenRecordVariable. These two tests are
+    // narrower regression guards, same framing as InstanceExportImportRoundTrip_RealBcBody_NoThrow
+    // above: a correctly-set-up static call completes without throwing, with no runner redirect
+    // installed on this surface. (NavXmlPortTableNode.ctor, the third #1883 orphan in this
+    // cluster, needs no separate test here — every XmlPort construction in this file, including
+    // InstanceConstruction_DoesNotThrow above, already goes through it since "XHC Port" is
+    // tableelement-bound.)
+    // Entry Nos 101/102 are deliberately disjoint from the other tests in this codeunit
+    // (which use Entry No. 1): "XHC Row" persists across test procedures in this suite (see
+    // the "legitimate duplicate-key failure" comment above InstanceExportImportRoundTrip_
+    // RealBcBody_NoThrow), so reusing 1 here would collide with whatever an earlier test in
+    // the same run left behind. Each test below deletes its own row at the end so it does
+    // not leak into whichever test runs after it.
+    [Test]
+    procedure StaticExport_WithRecordArg_RealBcBody_NoThrow()
+    var
+        Row_: Record "XHC Row";
+        TempBlob: Codeunit "Temp Blob";
+        DocumentOutStream: OutStream;
+        Ok: Boolean;
+    begin
+        if Row_.Get(101) then
+            Row_.Delete();
+        Row_.Init();
+        Row_."Entry No." := 101;
+        Row_.Name := 'First';
+        Row_.Insert();
+
+        TempBlob.CreateOutStream(DocumentOutStream);
+        Ok := XmlPort.Export(62181, DocumentOutStream, Row_);
+        if not Ok then
+            Error('Static XmlPort.Export(Integer, OutStream, Record) reported failure against a correctly-set-up OutStream destination.');
+
+        Row_.Delete();
+    end;
+
+    // Entry No. 103 is deliberately disjoint from every other Entry No. used elsewhere in
+    // this codeunit (1, 101) — "XHC Row" persists across test procedures in this suite (see
+    // the "legitimate duplicate-key failure" comment above InstanceExportImportRoundTrip_
+    // RealBcBody_NoThrow), so reusing an already-used key here would collide with whatever an
+    // earlier test in the same run left behind.
+    [Test]
+    procedure StaticImport_WithRecordArg_RealBcBody_NoThrow()
+    var
+        TargetRow: Record "XHC Row";
+        TempBlob: Codeunit "Temp Blob";
+        DocumentOutStream: OutStream;
+        DocumentInStream: InStream;
+        Ok: Boolean;
+    begin
+        // Hand-written payload matching "XHC Port"'s schema (root/Row/EntryNo/RowName) —
+        // sidesteps any uncertainty about what XmlPort.Export's own output shape is, since
+        // that is already covered by StaticExport_WithRecordArg_RealBcBody_NoThrow above.
+        TempBlob.CreateOutStream(DocumentOutStream);
+        DocumentOutStream.WriteText('<?xml version="1.0" encoding="utf-8"?><root><Row><EntryNo>103</EntryNo><RowName>First</RowName></Row></root>');
+        TempBlob.CreateInStream(DocumentInStream);
+
+        ClearLastError();
+        Ok := XmlPort.Import(62181, DocumentInStream, TargetRow);
+        if not Ok then
+            Error('Static XmlPort.Import(Integer, InStream, Record) reported failure. LastError=%1', GetLastErrorText());
+
+        // Verify via a fresh Get() rather than deleting TargetRow directly — see
+        // AL Runner#1946 (filed while writing this test): whether this call succeeds was
+        // observed to depend on an unrelated LATER statement's shape in the same procedure
+        // (Get()-then-read vs a bare Delete() on the same variable), which is a separate,
+        // pre-existing runner gap unrelated to the #1883 fix this test guards. Get()-then-read
+        // is the confirmed-reliable shape.
+        if not TargetRow.Get(103) then
+            Error('Static XmlPort.Import(Integer, InStream, Record) reported success but Entry No. 103 was not actually inserted.');
+        if TargetRow.Name <> 'First' then
+            Error('Static XmlPort.Import(Integer, InStream, Record) inserted the wrong Name: %1', TargetRow.Name);
+        TargetRow.Delete();
+    end;
 }


### PR DESCRIPTION
Refs #1883 — resolves ONE cluster (3 of 131 orphaned registrations). #1883 stays OPEN for the remaining 128, per its own "one cluster per follow-up PR" plan.

## What this covers

#1883 is the follow-up to #1800 tracking ~90 (currently 131, per a fresh `AL_RUNNER_HOOK_AUDIT=1` run) remaining orphaned `Hook(...)` registrations across many unrelated target types. Per the issue's own suggested approach ("group the remaining `Hook(...)` sites ... take one cluster per follow-up issue/PR"), this PR resolves one concrete cluster left explicitly flagged as a follow-up by #1800's own code comments — the rest of the 128-remaining inventory needs the same per-cluster empirical triage in separate PRs.

### The cluster: NavXmlPort static Export/Import(record) + NavXmlPortTableNode.ctor

Three `Hook(...)` call sites in `AlRunner/BcRuntime.cs` were registered but never fired (JmpHook is disabled by default):
- `NavXmlPort.Export(DataError,int,NavOutStream,NavRecord)` (static `XmlPort.Export(id, stream, record)`)
- `NavXmlPort.Import(DataError,int,NavInStream,NavRecord)` (static `XmlPort.Import(id, stream, record)`)
- `NavXmlPortTableNode..ctor(NavRecordHandle)`

All three were explicitly called out in code comments as "NOT covered by the #1800 investigation ... left as-is pending a dedicated follow-up." This PR does that investigation.

**Empirical findings (same discipline #1800 used — no guessing):**
- Static `Export`-with-record is already exercised end-to-end by the al-language corpus (`XmlPort_Export_StaticWithRecord_RespectsFilters`) and passes today, with the hook orphaned. BC's real, unpatched body is already correct.
- `NavXmlPortTableNode.ctor` is exercised by every xmlport test that uses the tableelement-bound `ALTUniversalXmlPort` fixture (most of `xmlport/TestXmlPortObject.al`), all passing today with the hook orphaned.
- Static `Import`-with-record had **no** direct corpus coverage (only the 3-arg no-record overload was tested). Added `XmlPort_Import_StaticWithRecord_InsertsIntoGivenRecordVariable` upstream: StefanMaron/BusinessCentral.AL.Language.Tests#52, verified locally against the runner (passes, 2093/2093 including the new test) before relying on it here.

Per #1800's own precedent for methods where "BC's real body is already correct," the three `Hook(...)` call sites and their now-dead throw-stub/no-op replacement bodies (`NavXmlPort_StaticExport`, `NavXmlPort_StaticImport`, `NavXmlPortTableNode_Ctor` + its `EnsureXmlPortNodeFields` helper) were **deleted outright**, not left dead.

### Proof this is a true no-op change

Since JmpHook is disabled by default in every configuration CI uses, a `Hook(...)` call site with no matching Cecil ownership has **zero** runtime effect before this change — so deleting it cannot change any test's outcome. Verified both ways:
- `AL_RUNNER_HOOK_AUDIT=1` orphan count: **131 → 128** (exactly the 3 deleted; the 4 intentional `NavXmlPort.Run` redundant-defense-in-depth registrations, explicitly documented as deliberate, are untouched).
- al-language corpus result is **byte-identical** before/after: 2087/2087 pass (`pass-oos: 2, pass-known-gap: 1, pass-divergence: 1` unchanged in both runs).

### Regression-guard tests

Added `StaticExport_WithRecordArg_RealBcBody_NoThrow` and `StaticImport_WithRecordArg_RealBcBody_NoThrow` to the existing `tests/runner-extras/standalone-suites/xmlport-cluster-hooks-1800/XhcTests.Codeunit.al` (the same suite #1800 landed), same framing as its existing `InstanceExportImportRoundTrip_RealBcBody_NoThrow`: a narrower runner-mechanism claim ("no redirect fires, BC's real body completes without throwing") than the full BC-behaviour claim, which lives upstream per `bc-behavior-tests-go-upstream.md`. Bumped `tests/expectations/count-baseline/test-count-baseline.json`'s `runner-extras` counts by 2 (no new app group).

### A genuinely separate finding, filed not fixed here

While writing the `StaticImport` regression-guard test I hit a real, reproducible runner gap unrelated to this fix: whether `Xmlport.Import(id, InStream, Record)` succeeds against a fresh `Record` variable appears to depend on an *unrelated later statement's shape* in the same procedure (`Delete()` vs. `Get()`-then-read after the call). Reproduces in a from-scratch standalone bundle with zero connection to this PR's diff. Filed as #1946 with a minimal repro; the test in this PR uses the confirmed-reliable shape and documents the gap inline rather than silently working around it.

## Test plan

- [x] `AL_RUNNER_HOOK_AUDIT=1` against the al-language corpus: orphan count 131 → 128, the 3 target entries gone, redundant set (4) unchanged.
- [x] al-language corpus: 2087/2087 pass, identical before/after.
- [x] New corpus test verified locally against the runner (upstream PR: StefanMaron/BusinessCentral.AL.Language.Tests#52, not merged/pinned in this repo yet).
- [x] `tests/runner-extras/standalone-suites` (contains the modified suite): 67/67 pass, run 3x for reliability (the two new tests included).
- [x] `dotnet test AlRunner.Tests`: 744 pass, 1 pre-existing unrelated failure (`BcCompilerSharedReferenceMemoTests.AddingAPackageToAScannedDir_ForcesARebuild`) confirmed present on unmodified `main` too (stashed my diff and reran — same failure).
