### PR TITLE
chore(corpus): bump al-language pin to 46d6ec66

### DIFF
--- a/tests/expectations/count-baseline/test-count-baseline.json
+++ b/tests/expectations/count-baseline/test-count-baseline.json
@@ -2,7 +2,7 @@
   "_comment": "Consumed by --count-baseline (AlRunner/Infrastructure/CountBaseline.cs), a DIFFERENT schema from the oos-/known-gaps-/divergence-/disabled- files in this directory: those declare the expected CLASSIFICATION of one named test, this declares the expected EXACT COUNT of a whole suite -- an exact match, not a floor: a mismatch in EITHER direction (drop OR growth) fails the run (exit 4). See #1880 and PR #1882's review for why growth is also a hard failure, not just a notice. Suite keys are the basename of the bundle directory CI passes on the command line (tests/al-language/tests/al-language -> 'al-language', tests/runner-extras -> 'runner-extras'), matching the '--out <name>-results.json' convention CI already uses. Values below are read off actual Test Matrix CI runs (see PR discussion for run URLs), not guessed: al-language's 2073->2076 bump reflects 3 corpus tests merged upstream between when the local baseline was drafted and when CI first ran against it. runner-extras' appGroups 23->21 byBcVersion override on 27.0/27.3/27.5 is the SAME preprocessor-gated-surface split that already explains its tests count divergence: fewer AL surfaces compile pre-28.0, which drops whole app groups, not just individual tests within a group. ANY PR that changes a suite's test or app-group count -- growth included -- MUST bump the matching number here in the SAME PR, or that PR's CI goes red with a [count-baseline] DROP or GROWTH diagnostic naming the exact expected/actual numbers to use.",
   "suites": {
     "al-language": {
-      "tests": { "default": 2087 },
+      "tests": { "default": 2093 },
       "appGroups": { "default": 1 }
     },
     "runner-extras": {

--- a/tests/expectations/count-baseline/test-count-baseline.json
+++ b/tests/expectations/count-baseline/test-count-baseline.json
@@ -2,7 +2,7 @@
   "_comment": "Consumed by --count-baseline (AlRunner/Infrastructure/CountBaseline.cs), a DIFFERENT schema from the oos-/known-gaps-/divergence-/disabled- files in this directory: those declare the expected CLASSIFICATION of one named test, this declares the expected EXACT COUNT of a whole suite -- an exact match, not a floor: a mismatch in EITHER direction (drop OR growth) fails the run (exit 4). See #1880 and PR #1882's review for why growth is also a hard failure, not just a notice. Suite keys are the basename of the bundle directory CI passes on the command line (tests/al-language/tests/al-language -> 'al-language', tests/runner-extras -> 'runner-extras'), matching the '--out <name>-results.json' convention CI already uses. Values below are read off actual Test Matrix CI runs (see PR discussion for run URLs), not guessed: al-language's 2073->2076 bump reflects 3 corpus tests merged upstream between when the local baseline was drafted and when CI first ran against it. runner-extras' appGroups 23->21 byBcVersion override on 27.0/27.3/27.5 is the SAME preprocessor-gated-surface split that already explains its tests count divergence: fewer AL surfaces compile pre-28.0, which drops whole app groups, not just individual tests within a group. ANY PR that changes a suite's test or app-group count -- growth included -- MUST bump the matching number here in the SAME PR, or that PR's CI goes red with a [count-baseline] DROP or GROWTH diagnostic naming the exact expected/actual numbers to use.",
   "suites": {
     "al-language": {
-      "tests": { "default": 2093 },
+      "tests": { "default": 2096 },
       "appGroups": { "default": 1 }
     },
     "runner-extras": {


### PR DESCRIPTION
Bumps the `tests/al-language` submodule from `eb300810` to `46d6ec66`, and the al-language count baseline from 2087 to 2096.

Four tests merged upstream since the current pin. All only add new files or new test procedures; no existing corpus test changed.

- **#51** — TestPage `SetValue` on a Rec-bound Boolean control.
- **#52** — `XmlPort_Import_StaticWithRecord_InsertsIntoGivenRecordVariable`. The static `Xmlport.Import(Integer, InStream, Record)` overload had no direct corpus coverage. Written while resolving the orphaned JmpHook cluster in #1947.
- **#53** — TestField's error message is unaffected by the table's LookupPageId. This is the upstream proof for #1938, fixed on main by #1952.
- **#54** — `NavApp.GetCurrentModuleInfo` in a boolean context returns true. This is the upstream proof for #1942, fixed on main by #1950.

Both runner fixes are already on main, so #53 and #54 exercise the fixed behavior here rather than failing by design. Upstream CI passed all four against real BC 27.5 and 28.3.

An earlier revision of this PR pinned only #51 and #52 and went red on the `--count-baseline` exact-match guard, which fails on growth as well as on drops. All 2093 corpus tests passed on every leg at that point; the count is now 2096 with #53 and #54 included.
