### PR TITLE
fix(navapp): NavApp.GetCurrentModuleInfo source polyfill returns void — CS0023 on boolean-context calls

### DIFF
--- a/AlRunner/BcAssembler.cs
+++ b/AlRunner/BcAssembler.cs
@@ -581,7 +581,15 @@ namespace AlRunnerShim
         // so GetExecutingAssembly() here IS the module whose AL code made the call —
         // BcRuntime maps it to that app's identity (real BC's executing-module rule;
         // a dependency like SPBLIC must see its own name/version, not the bundle's).
-        public static void ALNavApp_GetCurrentModuleInfo(
+        // Returns bool (#1942): AL declares this Boolean-valued
+        // (`NavApp.GetCurrentModuleInfo(var ModuleInfo): Boolean`), and BC's own emitted
+        // C# treats the call as boolean-valued (`!ALNavApp.ALGetCurrentModuleInfo(...)`),
+        // so a void polyfill fails Roslyn compile with CS0023 the instant a caller uses
+        // the return value. The executing assembly is always registered and resolvable
+        // here, so `true` is the faithful answer every time this runs — mirrors the
+        // Cecil-side patch for the same BC method (NavAppModuleInfoPatches.cs) and the
+        // sibling source polyfill ALNavApp_GetCallerModuleInfo below.
+        public static bool ALNavApp_GetCurrentModuleInfo(
             Microsoft.Dynamics.Nav.Types.DataError errorLevel,
             Microsoft.Dynamics.Nav.Runtime.ByRef<Microsoft.Dynamics.Nav.Runtime.NavModuleInfo> info)
         {
@@ -591,6 +599,7 @@ namespace AlRunnerShim
             var emptyDeps = Microsoft.Dynamics.Nav.Runtime.NavList<Microsoft.Dynamics.Nav.Runtime.NavModuleDependencyInfo>.Default;
             info.Value = new Microsoft.Dynamics.Nav.Runtime.NavModuleInfo(
                 appId, name, publisher, navVersion, navVersion, emptyDeps, appId);
+            return true;
         }
 
         // NavApp.GetModuleInfo(errorLevel, moduleId, info) — resolves any REGISTERED

--- a/tests/expectations/count-baseline/test-count-baseline.json
+++ b/tests/expectations/count-baseline/test-count-baseline.json
@@ -7,8 +7,8 @@
     },
     "runner-extras": {
       "tests": {
-        "default": 134,
-        "byBcVersion": { "27.0": 128, "27.3": 128, "27.5": 128 }
+        "default": 137,
+        "byBcVersion": { "27.0": 131, "27.3": 131, "27.5": 131 }
       },
       "appGroups": {
         "default": 27,

--- a/tests/runner-extras/navapp-moduleinfo-dep/XmiDepApi.Codeunit.al
+++ b/tests/runner-extras/navapp-moduleinfo-dep/XmiDepApi.Codeunit.al
@@ -57,6 +57,53 @@ codeunit 61230 "XMI Dep Api"
         NavApp.GetCurrentModuleInfo(Info);
         exit(Info.Id());
     end;
+
+    /// <summary>
+    /// #1942 regression: the source polyfill behind NavApp.GetCurrentModuleInfo used to
+    /// be declared `void`, so any caller using the return value in a boolean CONTEXT
+    /// (`if not NavApp.GetCurrentModuleInfo(Info) then`) failed to COMPILE (CS0023 on the
+    /// generated C#) rather than misbehaving at run time. Every other procedure in this
+    /// codeunit uses the statement form, which never hit the bug. Reports this dep's own
+    /// identity through the boolean form, so it discriminates against the bundle's.
+    /// </summary>
+    procedure OwnVersionBooleanForm(): Text
+    var
+        Info: ModuleInfo;
+    begin
+        if not NavApp.GetCurrentModuleInfo(Info) then
+            exit('');
+        exit(Format(Info.AppVersion()));
+    end;
+
+    procedure OwnNameBooleanForm(): Text
+    var
+        Info: ModuleInfo;
+    begin
+        if not NavApp.GetCurrentModuleInfo(Info) then
+            exit('');
+        exit(Info.Name());
+    end;
+
+    procedure OwnIdBooleanForm(): Guid
+    var
+        Info: ModuleInfo;
+    begin
+        if not NavApp.GetCurrentModuleInfo(Info) then
+            exit;
+        exit(Info.Id());
+    end;
+
+    /// <summary>Boolean-form coverage for GetCallerModuleInfo -- its polyfill already
+    /// returned bool before #1942, so this is regression cover for a value context that
+    /// was never previously exercised, not part of the fix itself.</summary>
+    procedure CallerNameBooleanForm(): Text
+    var
+        Info: ModuleInfo;
+    begin
+        if not NavApp.GetCallerModuleInfo(Info) then
+            exit('');
+        exit(Info.Name());
+    end;
 }
 
 /// <summary>

--- a/tests/runner-extras/navapp-moduleinfo-main/XmiMainTests.Codeunit.al
+++ b/tests/runner-extras/navapp-moduleinfo-main/XmiMainTests.Codeunit.al
@@ -97,4 +97,65 @@ codeunit 61240 "XMI Main Tests"
         if Format(Info.AppVersion()) <> '25.8.43.0' then
             Error('GetModuleInfo(depId) must carry the dep version, got %1.', Format(Info.AppVersion()));
     end;
+
+    /// <summary>
+    /// THE FIX (#1942). Before it, the source polyfill behind NavApp.GetCurrentModuleInfo
+    /// was declared `void`, so the C# Roslyn compile of the emitted assembly failed with
+    /// CS0023 ("operator '!' cannot be applied to operand of type 'void'") on this exact
+    /// boolean-CONTEXT form -- a compile failure, not a wrong answer, which is why it went
+    /// unnoticed: every existing test in this bundle used the statement form instead.
+    /// Proves the boolean form now compiles, returns true, and populates the SAME bundle
+    /// identity the statement-form test above already proved -- a default-constructed
+    /// ModuleInfo (empty name/id, version 0.0.0.0) would fail every assertion here.
+    /// </summary>
+    [Test]
+    procedure BundleGetCurrentModuleInfo_BooleanForm_ReturnsTrueAndBundleIdentity()
+    var
+        Info: ModuleInfo;
+    begin
+        if not NavApp.GetCurrentModuleInfo(Info) then
+            Error('NavApp.GetCurrentModuleInfo must return true.');
+        if Info.Name() <> 'NavAppModuleInfo Main' then
+            Error('Bundle must see its own name, got %1.', Info.Name());
+        if Format(Info.AppVersion()) <> '1.0.0.0' then
+            Error('Bundle must see its own version 1.0.0.0, got %1.', Format(Info.AppVersion()));
+        if Info.Id() <> 'a7d1f5b9-8e4c-4b2d-9f6a-0c5e9d4b7a8f' then
+            Error('Bundle must see its own AppId, got %1.', Info.Id());
+    end;
+
+    /// <summary>
+    /// Discriminating direction for the same fix: a broken polyfill that returns one
+    /// hard-coded identity (e.g. always the bundle's) would pass the test above and fail
+    /// here, or vice versa. The dep must see ITS OWN identity through the boolean form,
+    /// never the consuming bundle's -- the exact per-emitted-assembly split the statement
+    /// form already proves for <c>DepGetCurrentModuleInfo_ReturnsDepOwnVersion</c>.
+    /// </summary>
+    [Test]
+    procedure DepGetCurrentModuleInfo_BooleanForm_ReturnsDepOwnIdentity()
+    var
+        DepApi: Codeunit "XMI Dep Api";
+    begin
+        if DepApi.OwnVersionBooleanForm() <> '25.8.43.0' then
+            Error('Dep must see its OWN version 25.8.43.0 through the boolean form, got %1.',
+                DepApi.OwnVersionBooleanForm());
+        if DepApi.OwnNameBooleanForm() <> 'NavAppModuleInfo Dep' then
+            Error('Dep must see its OWN name through the boolean form, got %1.', DepApi.OwnNameBooleanForm());
+        if DepApi.OwnIdBooleanForm() <> 'f6c0e4a8-7d3b-4a1c-8e5f-9b4d8c3a6f7e' then
+            Error('Dep must see its OWN AppId through the boolean form, got %1.', DepApi.OwnIdBooleanForm());
+    end;
+
+    /// <summary>
+    /// Boolean-form coverage for GetCallerModuleInfo. Its polyfill already returned
+    /// `bool` before #1942 (unlike GetCurrentModuleInfo), so this is regression cover for
+    /// a value context that was never previously exercised -- not part of the fix itself.
+    /// </summary>
+    [Test]
+    procedure DepGetCallerModuleInfo_BooleanForm_ReturnsTrueAndNamesBundle()
+    var
+        DepApi: Codeunit "XMI Dep Api";
+    begin
+        if DepApi.CallerNameBooleanForm() <> 'NavAppModuleInfo Main' then
+            Error('Caller module inside the dep must be this bundle through the boolean form, got %1.',
+                DepApi.CallerNameBooleanForm());
+    end;
 }


### PR DESCRIPTION
Closes #1942

## Root cause

`AlRunner/BcAssembler.cs`'s source polyfill for `NavApp.GetCurrentModuleInfo`
(`ALNavApp_GetCurrentModuleInfo`) was declared `void`. AL declares this call
Boolean-valued, and BC's own emitter treats it as boolean-valued
(`!ALNavApp.ALGetCurrentModuleInfo(...)`), so any source-compiled AL using the
documented guard form —

```al
if not NavApp.GetCurrentModuleInfo(Info) then
    exit;
```

— failed the C# compile of the emitted assembly with `CS0023` ("operator '!'
cannot be applied to operand of type 'void'"). The discard-the-return-value
statement form (`NavApp.GetCurrentModuleInfo(Info);`) compiled fine, which is
why every existing test used it and this went unnoticed.

## Fix

`ALNavApp_GetCurrentModuleInfo` now returns `bool` / `true` after populating
`Info`, matching:
- the Cecil-side patch for the same BC method (`Patches/NavAppModuleInfoPatches.cs`,
  used for precompiled deps), and
- the sibling source polyfill `ALNavApp_GetCallerModuleInfo`, which already
  returned `bool`.

The executing assembly is always registered/resolvable at the point this
runs, so `true` is the faithful answer every time — no case where this call
can observably fail for the running app.

## Polyfill audit

Per the issue's ask, audited every polyfill in `BcAssembler.cs`'s
`PolyfillSource` against the AL/CLR return type of the API it stands in for
(`ALDebugger_*`, `ALSession_*`, `NavForm_Run`, `ALSubstring`/`ALIndexOf`/etc.,
`ALNavApp_GetModuleInfo`, `ALNavApp_GetCallerModuleInfo`,
`ALRegisterTableConnection`, …). This was the only signature mismatch found —
everything else already matches its real AL/CLR return type.

## Tests (RED → GREEN)

Extended the existing `tests/runner-extras/navapp-moduleinfo-main` /
`-dep` bundle with 3 new tests exercising the boolean-context form:

- `BundleGetCurrentModuleInfo_BooleanForm_ReturnsTrueAndBundleIdentity` —
  positive: the boolean form compiles, returns `true`, and `Info.Name` /
  `Info.AppVersion` / `Info.Id` equal the bundle's own manifest identity (a
  default-constructed `ModuleInfo` fails every assertion).
- `DepGetCurrentModuleInfo_BooleanForm_ReturnsDepOwnIdentity` — discriminating
  direction: the same boolean-form call **inside the dependency** reports the
  dependency's own identity, not the bundle's — a hard-coded single-identity
  polyfill would pass one test and fail the other.
- `DepGetCallerModuleInfo_BooleanForm_ReturnsTrueAndNamesBundle` — regression
  cover for `GetCallerModuleInfo`'s boolean form (its polyfill already
  returned `bool` before this fix, so this proves it stays correct).

RED (before the fix, `--package-cache "$HOME/.al-runner/platform-apps"
--package-cache "$HOME/.al-runner/test-apps"`):

```
[dep-load-fail] AL Runner_NavAppModuleInfo Dep v25.8.43.0: COMPILE-FAIL —
  XMI Dep Api.cs(261,36): error CS0023: Operator '!' cannot be applied to operand of type 'void' | ...
FATAL: dependency compile failed — cannot continue.
```

GREEN (after):

```
Tests:         10 total
  pass:        10
  fail:        0
  error:       0
```

Bumped `tests/expectations/count-baseline/test-count-baseline.json`'s
`runner-extras` counts (+3 tests, all BC versions — this bundle has no
preprocessor gating) for the new tests.

Also ran `dotnet test AlRunner.Tests` (745/746 pass — the 1 unrelated failure,
`BcCompilerSharedReferenceMemoTests.AddingAPackageToAScannedDir_ForcesARebuild`,
reproduces identically on a clean `origin/main` checkout with none of this
PR's changes, and the latest Test Matrix run on `main` is green, so it's local
environment noise on this machine, not a regression from this PR).

## Upstream corpus

Per `.claude/rules/bc-behavior-tests-go-upstream.md`: "`NavApp.GetCurrentModuleInfo`
returns `true` and populates `ModuleInfo`" already has coverage in the corpus
(`session/TestNavApp.al`, `TestNavAppExtended.al`,
`TestNavAppModuleInfoCallerIdentity.al`) — but exclusively via the discarded
statement form. None of it exercises the boolean-context call, which is the
actual BC-language claim this bug turns on. Opened
[StefanMaron/BusinessCentral.AL.Language.Tests#54](https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/54)
adding that missing coverage; not merging it myself per the rule (orchestrator
merges once its BC 27.5/28.1 CI legs are green). The tests kept in this repo's
`runner-extras` bundle are the runner-specific claims that repo's CI can't
adjudicate: this polyfill's own CLR signature and per-emitted-assembly module
identity (dep vs. bundle).

## Checklist

- [x] `CHANGELOG.md` untouched
- [x] Nothing under `tests/al-language/` modified (submodule pin unchanged —
      verified `git diff tests/al-language` is empty in this PR)