### PR TITLE
fix(tests): final-cycle window must exclude earlier burst cycles

### DIFF
--- a/AlRunner.Tests/WatchBurstSwitchTests.cs
+++ b/AlRunner.Tests/WatchBurstSwitchTests.cs
@@ -243,7 +243,12 @@ public class WatchBurstSwitchTests
             // correct, fully-settled version B result — the FINAL cycle observed once the
             // watch goes quiet again, regardless of how many quiescence windows the burst
             // happened to split into on this machine.
-            var finalCycle = Segment(m1 + 1, markers[^1]);
+            // #1936 follow-up: the window must start after the SECOND-TO-LAST marker, not
+            // after m1 — otherwise it spans every cycle the burst produced and an earlier
+            // mid-burst cycle's phantom FAIL is read as the final cycle's, which is the
+            // load-dependent failure this relaxation exists to tolerate. See
+            // WatchOutputSlicing.FinalCycleStart and its deterministic tests.
+            var finalCycle = Segment(WatchOutputSlicing.FinalCycleStart(markers, m1), markers[^1]);
             Assert.Contains(TestName, finalCycle);
             Assert.DoesNotContain("FAIL", finalCycle);
             Assert.Contains("PASS", finalCycle);

--- a/AlRunner.Tests/WatchOutputSlicing.cs
+++ b/AlRunner.Tests/WatchOutputSlicing.cs
@@ -60,6 +60,8 @@
 // that predicate; the polling loop that uses it lives in WatchTests.cs (WaitForWarmTimingCount)
 // since it needs the live process's cancellation/timeout plumbing, but the predicate itself is
 // unit-tested here.
+using System;
+using System.Collections.Generic;
 using System.Text;
 using System.Text.RegularExpressions;
 
@@ -92,6 +94,28 @@ public static class WatchOutputSlicing
             if (lines[i].Stream == OutputStream.Stdout && lines[i].Text.Contains(marker))
                 result.Add(i);
         return result;
+    }
+
+    /// <summary>
+    /// Start index (inclusive) of the LAST watch cycle among <paramref name="markers"/>.
+    /// Each marker ENDS a cycle, so the final cycle begins just after the SECOND-TO-LAST
+    /// marker. Only when the burst produced a single cycle does it begin just after
+    /// <paramref name="afterIndex"/> — the marker that ended the preceding, pre-burst cycle.
+    ///
+    /// #1936 dropped WatchBurstSwitchTests' `markers.Count == 1` assertion so that a burst
+    /// which CI load legitimately splits into several quiescence windows still passes. That
+    /// relaxation is defeated by slicing from <paramref name="afterIndex"/> to the LAST
+    /// marker: the window then spans EVERY cycle the burst produced, so an early mid-burst
+    /// cycle's phantom FAIL lands inside the text the final-cycle assertions read, and the
+    /// test fails for precisely the load-dependent reason the relaxation exists to tolerate.
+    /// Observed on the BC 27.5 leg of PR #1949: "Assert.DoesNotContain() Failure: Sub-string
+    /// found ... FAIL  Codeunit60210".
+    /// </summary>
+    public static int FinalCycleStart(IReadOnlyList<int> markers, int afterIndex)
+    {
+        if (markers.Count == 0)
+            throw new ArgumentOutOfRangeException(nameof(markers), "no cycle markers — cannot delimit a final cycle");
+        return markers.Count >= 2 ? markers[^2] + 1 : afterIndex + 1;
     }
 
     /// <summary>

--- a/AlRunner.Tests/WatchOutputSlicingTests.cs
+++ b/AlRunner.Tests/WatchOutputSlicingTests.cs
@@ -1,6 +1,8 @@
 // WatchOutputSlicingTests — deterministic RED/GREEN proof for #1843, over a synthetic line
 // sequence instead of a live-process race. See WatchOutputSlicing.cs's header for the full
 // mechanism (stdout/stderr pumps racing into one merged list).
+using System;
+using System.Collections.Generic;
 using Xunit;
 
 namespace AlRunner.Tests;
@@ -229,5 +231,77 @@ public sealed class WatchOutputSlicingTests
 
         Assert.True(WatchOutputSlicing.HasAtLeastWarmTimingMatches(lines, 2));
         Assert.Equal(2, WatchOutputSlicing.CountWarmTimingMatches(lines));
+    }
+
+    // ── #1936 follow-up: the final-cycle window must exclude EARLIER burst cycles ──────
+    //
+    // A burst that CI load splits into two quiescence windows produces two markers. The
+    // FIRST of those cycles ran against a half-applied tree and reports FAIL; the SECOND
+    // ran against the settled tree and reports PASS. Slicing (afterIndex, lastMarker)
+    // spans BOTH, so the phantom FAIL is inside the text the final-cycle assertions read.
+    // FinalCycleStart must start the window after the second-to-last marker instead.
+
+    /// <summary>
+    /// Pre-burst cold cycle ends at m1. The burst then splits into two cycles: cycle A
+    /// (phantom, FAIL against a half-applied tree) ending at mA, and cycle B (settled,
+    /// PASS) ending at mB.
+    /// </summary>
+    private static (List<CapturedLine> lines, int m1, List<int> markers) SplitBurstScenario()
+    {
+        var lines = new List<CapturedLine>
+        {
+            new(OutputStream.Stdout, "PASS  Codeunit60210.Sum_OfAllValues_MatchesExpectedTotal"),
+        };
+        int m1 = lines.Count;
+        lines.Add(new(OutputStream.Stdout, WatchOutputSlicing.WaitingForSourceMarker + "… (Ctrl+C to quit)"));
+
+        lines.Add(new(OutputStream.Stdout, "[watch] change detected — re-running…"));
+        lines.Add(new(OutputStream.Stdout, "FAIL  Codeunit60210.Sum_OfAllValues_MatchesExpectedTotal"));
+        int mA = lines.Count;
+        lines.Add(new(OutputStream.Stdout, WatchOutputSlicing.WaitingForSourceMarker + "… (Ctrl+C to quit)"));
+
+        lines.Add(new(OutputStream.Stdout, "[watch] change detected — re-running…"));
+        lines.Add(new(OutputStream.Stdout, "PASS  Codeunit60210.Sum_OfAllValues_MatchesExpectedTotal"));
+        int mB = lines.Count;
+        lines.Add(new(OutputStream.Stdout, WatchOutputSlicing.WaitingForSourceMarker + "… (Ctrl+C to quit)"));
+
+        return (lines, m1, new List<int> { mA, mB });
+    }
+
+    [Fact]
+    public void FinalCycleStart_SplitBurst_WindowExcludesTheEarlierPhantomFailCycle()
+    {
+        var (lines, m1, markers) = SplitBurstScenario();
+
+        var start = WatchOutputSlicing.FinalCycleStart(markers, m1);
+        var finalCycle = WatchOutputSlicing.MergedJoin(lines, start, markers[^1]);
+
+        Assert.DoesNotContain("FAIL", finalCycle);
+        Assert.Contains("PASS", finalCycle);
+        Assert.Contains("Sum_OfAllValues_MatchesExpectedTotal", finalCycle);
+
+        // The window must begin after the SECOND-TO-LAST marker, not after the pre-burst one.
+        Assert.Equal(markers[^2] + 1, start);
+    }
+
+    [Fact]
+    public void FinalCycleStart_SingleCycleBurst_WindowStartsAfterThePreBurstMarker()
+    {
+        var (lines, m1, markers) = SplitBurstScenario();
+        var single = new List<int> { markers[^1] };
+
+        var start = WatchOutputSlicing.FinalCycleStart(single, m1);
+
+        // With one cycle there is no earlier burst cycle to exclude, so the window is the
+        // whole span after the pre-burst marker — the pre-#1936 behaviour, unchanged.
+        Assert.Equal(m1 + 1, start);
+        Assert.Contains("PASS", WatchOutputSlicing.MergedJoin(lines, start, single[^1]));
+    }
+
+    [Fact]
+    public void FinalCycleStart_NoMarkers_Throws()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => WatchOutputSlicing.FinalCycleStart(new List<int>(), 0));
     }
 }


### PR DESCRIPTION
#1945 removed `WatchBurstSwitchTests`'s `markers.Count == 1` assertion so that a burst which CI load splits into several quiescence windows still passes. It kept slicing the assertion window as `(m1, markers[^1])`, which spans every cycle the burst produced. An earlier mid-burst cycle reports a phantom FAIL against a half-applied tree, that FAIL lands inside the text the final-cycle assertions read, and `DoesNotContain("FAIL")` fires — the exact load-dependent failure the relaxation was meant to tolerate. It showed up on the BC 27.5 leg of #1949.

## Fix

Adds `WatchOutputSlicing.FinalCycleStart(markers, afterIndex)`. Each marker ends a cycle, so the final cycle starts after the second-to-last marker. With a single cycle it starts after `afterIndex`, which is the pre-#1936 behavior.

## RED to GREEN

With the helper returning `afterIndex + 1` (the pre-fix behavior), `FinalCycleStart_SplitBurst_WindowExcludesTheEarlierPhantomFailCycle` fails and the two unchanged-behavior guards pass. After the fix: 12/12 in `WatchOutputSlicingTests`.

The proof is deterministic, over a synthetic line sequence — no real clock, matching how #1843 and #1921 proved the same file's other claims.
