### PR TITLE
fix(runtime): TestField's navigate-action lookup no longer hijacks the real TestField error

### DIFF
--- a/AlRunner.Tests/NavRecordTestFieldNavigationPatchesTests.cs
+++ b/AlRunner.Tests/NavRecordTestFieldNavigationPatchesTests.cs
@@ -1,0 +1,151 @@
+// NavRecordTestFieldNavigationPatchesTests — issue #1938.
+//
+// Pins the C# CONTRACT the fix depends on — not "what BC does" (that's the job of the
+// companion corpus PR, StefanMaron/BusinessCentral.AL.Language.Tests#53, which proves the
+// AL-observable TestField message is unaffected by LookupPageId against real BC). What's
+// provable here without a full AL test run is the actual mechanism: NavRecord_GetPageToOpen
+// (the Cecil-replaced NavRecord.GetPageToOpen) must swallow a NavMetadataNotFoundException
+// raised while resolving the OPTIONAL CardFormID follow-through, and fall back to the
+// table's plain LookupFormId, rather than letting the exception propagate — exactly the
+// hijack #1938 reported (a table's LookupPageId pointing at a page the runner never built).
+//
+// The table under test declares LookupPageId as a raw, unresolvable page id (999999) — no
+// page with that id exists anywhere the runner could build one, so NCLMetadata's own
+// GetMetaApplicationObject(Page, 999999, ...) is guaranteed to throw
+// NavMetadataNotFoundException. That guarantee is asserted directly (first test) so the
+// "GetPageToOpen doesn't throw" assertion (second test) is provably not vacuous: if the
+// precondition it relies on ever stopped throwing, the first test would fail and flag it.
+using AlRunner.Patches;
+using Microsoft.Dynamics.Nav.Runtime;
+using Microsoft.Dynamics.Nav.Types;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+[Collection(BcEngineCollection.Name)]
+public sealed class NavRecordTestFieldNavigationPatchesTests : IDisposable
+{
+    private readonly string _root;
+    private readonly BcEngineFixture _engine;
+
+    public NavRecordTestFieldNavigationPatchesTests(BcEngineFixture engine)
+    {
+        _engine = engine;
+        _root = Path.Combine(Path.GetTempPath(), "al-runner-testfield-nav-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { /* best-effort cleanup */ }
+    }
+
+    private string WriteTableDir(int tableId, string name, int lookupPageId)
+    {
+        var dir = Path.Combine(_root, name);
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, $"{name}.al"), $$"""
+            table {{tableId}} "TestFieldNav {{name}}"
+            {
+                LookupPageId = {{lookupPageId}};
+                fields
+                {
+                    field(1; "No."; Code[20]) { }
+                }
+                keys
+                {
+                    key(PK; "No.") { Clustered = true; }
+                }
+            }
+            """);
+        return dir;
+    }
+
+    private static NCLMetaTable? TryResolveTable(int tableId)
+    {
+        var skeleton = AlRunner.BcRuntime.SkeletonNCLMetadata;
+        if (skeleton == null) return null;
+        try
+        {
+            return RecordPatches.NCLMetadata_GetMetaTableById(skeleton, tableId, false, 0);
+        }
+        catch (InvalidOperationException)
+        {
+            return null;
+        }
+    }
+
+    // Precondition guarantee: an id nothing built (999999) really does make the shared
+    // NCLMetadata lookup throw. If a future change made unresolvable pages return some
+    // sentinel object instead of throwing, this test — not the guard test below — is the
+    // one that would catch it, keeping the guard test's own "doesn't throw" claim honest.
+    [SkippableFact]
+    public void UnresolvablePageId_MakesNCLMetadataLookup_ThrowNavMetadataNotFoundException()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready,
+            _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        var skeleton = AlRunner.BcRuntime.SkeletonNCLMetadata;
+        Assert.NotNull(skeleton);
+
+        Assert.Throws<NavMetadataNotFoundException>(() =>
+            RecordPatches.NCLMetadata_GetMetaApplicationObjectByType(
+                skeleton!, ObjectType.Page, 999999, requireCompiled: true, emitVersion: 0));
+    }
+
+    [SkippableFact]
+    public void GetPageToOpen_UnresolvablePageId_DegradesToPlainLookupFormId_InsteadOfThrowing()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready,
+            _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        var dir = WriteTableDir(93720, "GetPageToOpenGuard", 999999);
+        RecordPatches.AddSourceDirs(new[] { dir });
+
+        var meta = TryResolveTable(93720);
+        Assert.NotNull(meta);
+        // Sanity: the table's LookupPageId really did resolve to the raw literal — the
+        // exact NCLMetaTable.LookupFormId shape #1926 started populating.
+        Assert.Equal(999999, meta!.LookupFormId);
+
+        // The mechanism under test (#1938's fix): resolving the OPTIONAL CardFormID
+        // follow-through for an unbuildable page must not throw — it degrades to the
+        // table's own plain LookupFormId, exactly like the "no CardFormID upgrade
+        // available" branch NavRecord.GetPageToOpen already had for a page it CAN load.
+        // Before the fix this call throws NavMetadataNotFoundException.
+        var pageToOpen = RecordPatches.NavRecord_GetPageToOpen(meta);
+        Assert.Equal(999999, pageToOpen);
+    }
+
+    // Negative-shaped control: a table declaring NO LookupPageId/DrillDownPageId at all
+    // (both default to 0) must still report 0 — the guard must not turn "genuinely no
+    // lookup page" into some other value by mistake.
+    [SkippableFact]
+    public void GetPageToOpen_NoLookupPageIdDeclared_ReturnsZero()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready,
+            _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        var dir = Path.Combine(_root, "NoLookup");
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "NoLookup.al"), """
+            table 93721 "TestFieldNav NoLookup"
+            {
+                fields
+                {
+                    field(1; "No."; Code[20]) { }
+                }
+                keys
+                {
+                    key(PK; "No.") { Clustered = true; }
+                }
+            }
+            """);
+        RecordPatches.AddSourceDirs(new[] { dir });
+
+        var meta = TryResolveTable(93721);
+        Assert.NotNull(meta);
+        Assert.Equal(0, meta!.LookupFormId);
+        Assert.Equal(0, RecordPatches.NavRecord_GetPageToOpen(meta));
+    }
+}

--- a/AlRunner/Infrastructure/NclCecilRewrite.cs
+++ b/AlRunner/Infrastructure/NclCecilRewrite.cs
@@ -6667,6 +6667,18 @@ public static class NclCecilRewrite
                 ByParams(Rt + "NCLMetaTable", "GetFieldByNo", "Int32", "Int32"),
                 H(recordPatches, "NCLMetaTable_GetFieldByNoExt"));
 
+            // ── NavRecord TestField navigation-action guards (#1938) ──────────────
+            // See NavRecordTestFieldNavigationPatches.cs for the full mechanism. Both
+            // GetPageToOpen and TryAddTestFieldAction can independently throw
+            // NavMetadataNotFoundException for a Base App page the runner never loaded,
+            // hijacking the real TestField error the caller was about to throw — guard both.
+            ReplaceBodyWithHelper(nclMod,
+                ByParams(Rt + "NavRecord", "GetPageToOpen", "NCLMetaTable"),
+                H(recordPatches, "NavRecord_GetPageToOpen"));
+            ReplaceBodyWithHelper(nclMod,
+                ByParams(Rt + "NavRecord", "TryAddTestFieldAction", "NCLMetaField"),
+                H(recordPatches, "NavRecord_TryAddTestFieldAction"));
+
             // ── NavSession getters / DataAccessSource (RecordWritePatches.cs:84-104,482) ──
             ReplaceBodyWithHelper(nclMod,
                 FindNclMethod(nclMod, Rt + "NavSession", "get_DataAccessSource", 0),

--- a/AlRunner/Patches/NavRecordTestFieldNavigationPatches.cs
+++ b/AlRunner/Patches/NavRecordTestFieldNavigationPatches.cs
@@ -1,0 +1,151 @@
+// NavRecordTestFieldNavigationPatches — issue #1938 (regression from #1926).
+//
+// Real BC's NavRecord.TestFieldNotBlank / TestFieldError (both AL-triggered — e.g. a plain
+// `SalesSetup.TestField("Order Nos.")`) call the private helper
+// TryAddTestFieldAction(NCLMetaField) BEFORE throwing the real NavTestFieldException, to
+// optionally attach a "navigate to related record" ErrorInfo action pointing at the table's
+// LookupPageId/DrillDownPageId. TryAddTestFieldAction in turn calls the private static
+// GetPageToOpen(NCLMetaTable), which may resolve the page's CardFormID via
+// NavGlobal.MetadataProvider.GetPageDefinition(pageId), and then (back in
+// TryAddTestFieldAction) NavGlobal.NCLMetadata.GetMetaFormById(pageId, requireCompiled: true).
+//
+// On real BC both calls always succeed for a valid page id — Base App/System App/every
+// installed extension is always FULLY compiled together, so "the table's declared lookup page
+// doesn't exist" never happens there. The runner does not eagerly build NCLMetaForm /
+// PageDefinition metadata for every Base App page a table's LookupPageId might reference —
+// only pages the test bundle itself compiled (RecordPatches.NclMetaFormReportBuilder, gated on
+// _parsedPages/_parsedPageExtensions) or explicitly probed (RecordPatches.RealPageMetadata).
+// #1926 started resolving NCLMetaTable.LookupFormId faithfully (#1918), which means this
+// convenience-action code path is now reached far more often, and for a Base App page the
+// runner never loaded it throws NavMetadataNotFoundException — a real BC exception type, but
+// one this specific call site (unlike its sibling NCLMetadata.TryGetMetaApplicationObject)
+// does not catch. That exception then propagates OUT of TryAddTestFieldAction and pre-empts
+// the `throw NavTestFieldException.CreateNonblank(...)` statement it was only supposed to be
+// an ARGUMENT to — so BC's own AL-exception remap (ALMethodScope.ALException) sees the
+// metadata failure instead of the TestField failure, and the test sees "You tried to invoke
+// the Page object with the ID …" instead of the real "… must have a value …" message.
+//
+// The navigate action is a pure UI convenience: it attaches a clickable "Show <page>" action
+// to the ErrorInfo for rich clients. It never changes NavTestFieldException's own message text
+// (built separately, from the field/table captions and the primary key), so a headless runner
+// — which has no UI to click that action in anyway (page rendering is out of scope, see
+// docs/scope.md) — loses nothing observable by treating "can't resolve the navigate target"
+// the same way the ORIGINAL BC method already treats "wrong table" / "wrong page type" / "no
+// permission": silently skip the action, return null, and let the real error surface.
+//
+// Both guarded call sites are patched (GetPageToOpen for the CardFormID follow-through,
+// TryAddTestFieldAction for the GetMetaFormById lookup) — guarding only one still lets the
+// other throw and reproduce the bug, since either can independently hit an unbuilt page.
+using System.Reflection;
+using Microsoft.Dynamics.Nav.Runtime;
+using Microsoft.Dynamics.Nav.Types;
+using Microsoft.Dynamics.Nav.Types.Metadata;
+
+namespace AlRunner.Patches;
+
+public static partial class RecordPatches
+{
+    private static MethodInfo? _mNavRecordCreateErrorInfoData;
+    private static MethodInfo? _mNavUserPermissionsGetEffectivePermissionForObject;
+
+    /// <summary>
+    /// Replacement for the private static <c>NavRecord.GetPageToOpen(NCLMetaTable)</c> — see
+    /// file header. Guards ONLY the optional CardFormID follow-through; a table's plain
+    /// LookupFormId/DrillDownPageId is always returned even when that follow-through can't be
+    /// resolved on this run.
+    /// </summary>
+    public static int NavRecord_GetPageToOpen(NCLMetaTable metaTable)
+    {
+        int num = metaTable.LookupFormId > 0 ? metaTable.LookupFormId : metaTable.DrillDownPageId;
+        if (num > 0)
+        {
+            try
+            {
+                int cardFormId = NavGlobal.MetadataProvider.GetPageDefinition(num).Properties.CardFormID;
+                if (cardFormId > 0) num = cardFormId;
+            }
+            catch (NavMetadataNotFoundException)
+            {
+                // Runner gap (#1938): the runner has no NCLMetaForm/PageDefinition for
+                // page `num` — it was never compiled by the test bundle and is not one of
+                // the pages RealPageMetadata probes. Degrade exactly like the
+                // cardFormId <= 0 case already does: keep the plain page id.
+            }
+        }
+        return num;
+    }
+
+    /// <summary>
+    /// Replacement for the private instance <c>NavRecord.TryAddTestFieldAction(NCLMetaField)</c>
+    /// — see file header. Reimplements BC's own guard chain verbatim (temporary/blank record,
+    /// no page to open, already on that page, page not resolvable, wrong source table, wrong
+    /// page type, no read/execute permission) and additionally treats a metadata-resolution
+    /// failure for the navigate target as one more reason to skip the action, instead of
+    /// letting it propagate and replace the caller's real TestField error.
+    ///
+    /// The one difference from BC's real body: the platform diagnostics trace tag
+    /// (`Session.Diagnostics.SendTraceTag(...)`) is dropped. It is pure telemetry with no AL-
+    /// or test-observable effect, and `Session.Diagnostics` is null on the runner's skeleton
+    /// session (see HelperShims.cs's NavNotification_ALSend for the same, already-accepted gap
+    /// elsewhere) — keeping the call would trade one crash for another with nothing to show
+    /// for it.
+    /// </summary>
+    public static ErrorInfoData? NavRecord_TryAddTestFieldAction(NavRecord self, NCLMetaField metaField)
+    {
+        var recordId = self.ALRecordId;
+        if (recordId == null || recordId.IsZeroOrEmpty || self.IsTemporary)
+            return null;
+
+        int pageToOpen;
+        try
+        {
+            pageToOpen = NavRecord_GetPageToOpen(self.MetaTable);
+        }
+        catch (NavMetadataNotFoundException)
+        {
+            return null;
+        }
+        if (pageToOpen == 0)
+            return null;
+
+        if (self.Session.CurrentMethodScope.TopLevelApplicationObject is not NavForm navForm)
+            return null;
+        if (navForm.FormId == pageToOpen)
+            return null;
+
+        NCLMetaForm? metaFormById;
+        try
+        {
+            metaFormById = NavGlobal.NCLMetadata.GetMetaFormById(pageToOpen, requireCompiled: true);
+        }
+        catch (NavMetadataNotFoundException)
+        {
+            // Runner gap (#1938) — see file header. No navigate target available; skip the
+            // action exactly like every other guard condition in this method already does.
+            return null;
+        }
+        if (metaFormById == null || metaFormById.SourceTableTemporary
+            || metaFormById.SourceTable != recordId.TableNo
+            || (metaFormById.PageType != PageType.Card && metaFormById.PageType != PageType.Document))
+            return null;
+
+        EnsureTestFieldActionReflection();
+        if (_mNavUserPermissionsGetEffectivePermissionForObject == null || _mNavRecordCreateErrorInfoData == null)
+            return null;
+
+        var perm = (PermissionMask)_mNavUserPermissionsGetEffectivePermissionForObject.Invoke(
+            self.Session.Permissions, new object[] { self.Session.CompanyName, metaFormById.ApplicationObjectId })!;
+        if (!perm.HasFlag(PermissionMask.Read) && !perm.HasFlag(PermissionMask.Execute))
+            return null;
+
+        return (ErrorInfoData?)_mNavRecordCreateErrorInfoData.Invoke(self, new object[] { metaField, metaFormById });
+    }
+
+    private static void EnsureTestFieldActionReflection()
+    {
+        _mNavUserPermissionsGetEffectivePermissionForObject ??= typeof(NavUserPermissions).GetMethod(
+            "GetEffectivePermissionForObject", BindingFlags.NonPublic | BindingFlags.Instance);
+        _mNavRecordCreateErrorInfoData ??= typeof(NavRecord).GetMethod(
+            "CreateErrorInfoData", BindingFlags.NonPublic | BindingFlags.Instance);
+    }
+}


### PR DESCRIPTION
Closes #1938

## Root cause

Regression from #1926 (`9b36af40`). Once `NCLMetaTable.LookupFormId` started
resolving faithfully (#1918's fix), real BC's `NavRecord.TestFieldNotBlank`
(unmodified framework code, in `Ncl.dll`) began reaching its private
`TryAddTestFieldAction(NCLMetaField)` helper's `GetPageToOpen(NCLMetaTable)` /
`NavGlobal.NCLMetadata.GetMetaFormById(pageId, requireCompiled: true)` calls far
more often than before -- these resolve an *optional* "navigate to related
record" ErrorInfo action from the table's `LookupPageId`/`DrillDownPageId`.

On real BC neither call ever fails: Base App/System App/every installed
extension is always fully compiled together. The runner does not eagerly build
`NCLMetaForm`/`PageDefinition` metadata for every Base App page a table's
`LookupPageId` might reference -- only pages the test bundle itself compiled or
explicitly probed. For an unbuilt page id, `NCLMetadata.GetMetaApplicationObject`
throws `NavMetadataNotFoundException` -- a real BC exception type, but one this
specific call site (unlike its sibling `NCLMetadata.TryGetMetaApplicationObject`)
does not catch. That exception propagated out of the "attach an optional
navigate action" helper and pre-empted the
`throw NavTestFieldException.CreateNonblank(...)` it was only supposed to be an
*argument* to -- so BC's own AL-exception remap saw the metadata failure instead
of the TestField failure, replacing the real `TestField` error with "You tried to
invoke the Page object with the ID 459 ...".

Confirmed via `AL_RUNNER_DIAG_FIRSTCHANCE=NavMetadataNotFound` tracing the actual
throw site through `NavRecord.GetPageToOpen` -> `MetadataProvider.GetPageDefinition`
-> `NCLMetadata.TryGetMetaApplicationObject` (caught) -> a fresh
`NavMetadataNotFoundException` re-thrown by
`GetFrozenPageDefinitionWithExtensionWithoutMergedMultiLanguage` (uncaught) ->
propagates through `TryAddTestFieldAction` into `Record36.TestNoSeries`'s AL
exception remap.

## Fix

`NavRecord_GetPageToOpen` / `NavRecord_TryAddTestFieldAction` (Cecil-replaced --
same mechanism `NCLMetadata_GetMetaTableById` etc. already use) reimplement BC's
own guard chain verbatim (temporary/blank record, no page to open, already on
that page, wrong source table, wrong page type, no read/execute permission) and
additionally treat a metadata-resolution failure for the navigate target as one
more reason to skip the action -- exactly like every other guard condition in
the original method already does -- instead of letting it propagate. The
convenience action never affects `NavTestFieldException`'s own message text
(built separately, from the field/table captions and the primary key), so
nothing AL-observable is lost; a headless runner has no UI to click that action
in anyway (page rendering is out of scope, see `docs/scope.md`).

Both #1926's behaviour (static `Page.RunModal(0, Record)` resolves via
LookupFormId when the page IS present/buildable) and #1938's behaviour (TestField
surfaces its own message when the lookup page is absent) hold at the end -- see
Test plan.

## Test plan

- **RED -> GREEN, the exact #1938 repro** (Sales Header insert with blank Order
  Nos., no Order Nos. series on Sales & Receivables Setup): before the fix,
  `GetLastErrorText()` was `"You tried to invoke the Page object with the ID
  459 ..."`; after the fix it is the real `"Order Nos. must have a value ..."`.
- **`AlRunner.Tests/NavRecordTestFieldNavigationPatchesTests.cs`** -- pins the C#
  mechanism directly against the in-process BC engine: an unresolvable
  `LookupPageId` reliably makes the shared `NCLMetadata` lookup throw
  `NavMetadataNotFoundException` (precondition test), and
  `NavRecord_GetPageToOpen` degrades to the table's plain `LookupFormId` instead
  of propagating it (mechanism test). Verified RED with the guard's `try/catch`
  temporarily removed, then GREEN with it restored.
- **`tests/runner-extras/static-runmodal-record`** (#1926/#1918's own suite,
  unchanged) -- all 5 tests still pass, including
  `StaticRunModal_ById0_ResolvesPageFromTableLookupPageId` (direction (a): the
  feature #1926 added keeps working when the lookup page IS buildable) and
  `StaticRunModal_ById0_NoLookupPageId_FailsLoudly` (a table declaring no
  lookup page still fails loudly, not silently).
- **Upstream corpus PR**:
  [StefanMaron/BusinessCentral.AL.Language.Tests#53](https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/53)
  -- "TestField's error message is unaffected by the table's LookupPageId", a
  plain-BC-behaviour claim per `bc-behavior-tests-go-upstream.md`. Green on real
  BC 27.5 and 28.1 CI. Not merging the submodule pin in this PR -- verified
  locally by pointing `al-runner` at the corpus branch directly (both new tests
  pass against this fix).
- `dotnet test AlRunner.Tests` (with the in-process BC engine warmed, mirroring
  `test-matrix.yml`'s "Warm the Ncl Cecil rewrite cache" step): 777 tests, 776
  pass. The one failure
  (`BcCompilerSharedReferenceMemoTests.AddingAPackageToAScannedDir_ForcesARebuild`)
  reproduces identically on a clean `origin/main` checkout with none of this
  PR's changes applied -- confirmed pre-existing and unrelated.