### PR TITLE
fix(pages): resolve real MasterPage for a precompiled dependency page

### DIFF
--- a/AlRunner.Tests/DependencyPageMetadataXmlTests.cs
+++ b/AlRunner.Tests/DependencyPageMetadataXmlTests.cs
@@ -1,0 +1,140 @@
+// DependencyPageMetadataXmlTests — pins the runner's own C# mechanism for issue #1939:
+// reconstructing a real PageDefinition metadata document for a page declared only by a
+// PRECOMPILED dependency .app's SymbolReference.json (RecordPatches.TryBuildDependencyPageMetadata
+// / HasDependencyPageMetadata, AlRunner/Patches/DependencyPageMetadataXml.cs).
+//
+// What this proves, and what it deliberately does NOT
+// -----------------------------------------------------
+// The actual BC-observable claim — that a [ModalPageHandler] now fires for
+// `Page "Error Messages".RunModal()` instead of NavTestExecution.FindPageType NREing on a
+// null MasterPage — is plain BC behaviour and belongs upstream against a real service tier
+// (see .claude/rules/bc-behavior-tests-go-upstream.md); it is proved there, not here. This
+// file pins the narrower, runner-only mechanism claim underneath it: given a dependency
+// .app's SymbolReference.json, the synthesized XML actually carries the PageType and
+// SourceObject a real page's metadata carries, and an unknown page id gets neither a
+// document nor a false "yes" from the opt-in check — the same shape as
+// BcAppSymbolCachePageMetadataTests one layer down, just proving the XML BUILDER rather
+// than the SymbolReference.json PARSER.
+
+using System.IO.Compression;
+using System.Text;
+using System.Xml;
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+// Same reason as BcAppSymbolCachePageMetadataTests: BcAppSymbolCache.Get() resolves through
+// the process-global CacheRoots override.
+[Collection(CacheRootsSerialCollection.Name)]
+public class DependencyPageMetadataXmlTests
+{
+    private static string WriteApp(string dir, string symbolReferenceJson)
+    {
+        var appPath = Path.Combine(dir, Guid.NewGuid().ToString("N") + ".app");
+        using var zip = new FileStream(appPath, FileMode.Create);
+        using var za = new ZipArchive(zip, ZipArchiveMode.Create);
+        var entry = za.CreateEntry("SymbolReference.json");
+        using var w = new StreamWriter(entry.Open(), Encoding.UTF8);
+        w.Write(symbolReferenceJson);
+        return appPath;
+    }
+
+    // Distinctive, unlikely-to-collide ids: RecordPatches' dependency-page state
+    // (_bcAppPaths, the per-id metadata-xml cache) is process-global, so reusing an id
+    // another test/fixture might also declare (e.g. Base Application's real 700/456, or
+    // BcAppSymbolCachePageMetadataTests' 21/22/23) would risk reading back another test's
+    // cached answer instead of this one's.
+    private const int ListPageId = 88123401;
+    private const int UnknownPageId = 88123409;
+
+    private const string SymbolReference = """
+        {
+          "RuntimeVersion": "15.1",
+          "Pages": [
+            {
+              "Id": 88123401,
+              "Name": "DPX Test List Page",
+              "Properties": [
+                { "Name": "Caption", "Value": "DPX Test Caption" },
+                { "Name": "PageType", "Value": "List" },
+                { "Name": "SourceTable", "Value": "700" },
+                { "Name": "SourceTableTemporary", "Value": "true" }
+              ]
+            }
+          ]
+        }
+        """;
+
+    [Fact]
+    public void TryBuildDependencyPageMetadata_KnownPage_ProducesPageDefinitionWithRealPageTypeAndSourceTable()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var appPath = WriteApp(dir, SymbolReference);
+            RecordPatches.AddBcAppPath(appPath);
+
+            Assert.True(RecordPatches.HasDependencyPageMetadata(ListPageId),
+                "a page declared by a loaded dependency .app must be recognised as having metadata to build from");
+
+            var xml = RecordPatches.TryBuildDependencyPageMetadata(ListPageId);
+            Assert.NotNull(xml);
+
+            var doc = new XmlDocument();
+            doc.LoadXml(xml!);
+            var ns = new XmlNamespaceManager(doc.NameTable);
+            ns.AddNamespace("m", "urn:schemas-microsoft-com:dynamics:NAV:MetaObjects");
+
+            var root = doc.DocumentElement!;
+            Assert.Equal("PageDefinition", root.LocalName);
+            Assert.Equal(ListPageId.ToString(), root.GetAttribute("ID"));
+            Assert.Equal("DPX Test List Page", root.GetAttribute("Name"));
+
+            var properties = (XmlElement)root.SelectSingleNode("m:Properties", ns)!;
+            // This is the actual value NavTestExecution.FindPageType reads
+            // (form.MasterPage.PageProperties.PageType) to decide ModalPage vs
+            // RequestPage vs FilterPage dispatch — the whole reason this file exists.
+            Assert.Equal("List", properties.GetAttribute("PageType"));
+
+            var sourceObject = (XmlElement)properties.SelectSingleNode("m:SourceObject", ns)!;
+            Assert.Equal("700", sourceObject.GetAttribute("SourceTable"));
+            Assert.Equal("1", sourceObject.GetAttribute("SourceTableTemporary"));
+
+            // Content must be PRESENT (even though empty — see the file header for why: a
+            // missing <Content> element NREs one call deeper, inside NCLMetaForm's own
+            // post-load control-id-uniqueness check).
+            var content = root.SelectSingleNode("m:Content", ns);
+            Assert.NotNull(content);
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void TryBuildDependencyPageMetadata_UnknownPage_ReturnsNullAndIsNotFlaggedAsHavingMetadata()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var appPath = WriteApp(dir, SymbolReference);
+            RecordPatches.AddBcAppPath(appPath);
+
+            // A page id no loaded dependency describes must get neither a synthesized
+            // document nor a false "yes" from the opt-in check RunnerFormInit.
+            // ShouldResolveMasterPage relies on — a wrong "yes" here would send BC's own
+            // GetMasterPage() down its real path for a page with no XML to load, which
+            // fails loudly elsewhere, but the OPT-IN ITSELF must stay honest.
+            Assert.False(RecordPatches.HasDependencyPageMetadata(UnknownPageId));
+            Assert.Null(RecordPatches.TryBuildDependencyPageMetadata(UnknownPageId));
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+}

--- a/AlRunner/Patches/DependencyPageMetadataXml.cs
+++ b/AlRunner/Patches/DependencyPageMetadataXml.cs
@@ -1,0 +1,141 @@
+// RecordPatches.DependencyPageMetadataXml — runtime PageDefinition XML for pages that live
+// in a PRECOMPILED dependency .app, which the runner never source-compiles.
+//
+// THE GAP (issue #1939)
+//   NavForm.GetMasterPage() -> NavGlobal.MetadataProvider.GetMasterPage(...) ->
+//   GetMergedMasterPage() -> GetPageDefinition(id) is BC's only route to a page's real
+//   PageProperties (PageType, SourceObject, ...). NavTestExecution.FindPageType reads
+//   exactly one of those — form.MasterPage.PageProperties.PageType — to decide whether a
+//   modal page's [ModalPageHandler] is a FilterPage/RequestPage/ModalPage handler, BEFORE
+//   the handler ever runs. RunnerFormInit.ShouldResolveMasterPage only let that real lookup
+//   run for a page the runner captured emit-time metadata XML for (AlPageMetadataRegistry —
+//   populated only by BcCompiler.Emit, which never runs for a page shipped compiled inside a
+//   dependency .app). Every other page got GetMasterPage() short-circuited to null, and
+//   FindPageType NRE'd on the null MasterPage before the handler dispatch it exists to gate.
+//
+//   Same root cause, same fix shape, as DependencyReportMetadata.cs one file up: an R2R
+//   .app ships no compiled metadata form of its objects (that only exists at real-BC
+//   PUBLISH time, which the runner never performs), so the runner reconstructs a runtime
+//   metadata document from what the .app DOES ship.
+//
+// WHAT IS RECONSTRUCTED, AND FROM WHAT
+//   SymbolReference.json alone (via BcAppSymbolCache.PageSymbol) — the same typed slice
+//   #1769/#1779 already parse for the Page Metadata virtual table. Nothing here is inferred
+//   from behaviour or defaulted to something convenient: Id / Name / PageType / Caption /
+//   Editable / SourceObject (SourceTable + SourceTableTemporary) come straight off the
+//   symbol file's own Properties array.
+//
+// WHAT IS DELIBERATELY OMITTED, AND WHY THAT IS SAFE HERE
+//   Content/Controls, ActionContainers, ViewContainers, AnalysisViewContainers — the page's
+//   full control tree and action ribbon. Two independent reasons neither is needed for the
+//   gap this file closes:
+//     1. NavTestExecution.FindPageType — the NRE site — reads exactly one property,
+//        form.MasterPage.PageProperties.PageType, which Properties above already states.
+//     2. A precompiled page's control -> value BINDINGS are not read from this XML at all.
+//        They come from the page's OWN CallInitializeComponentExtensionMethod /
+//        RegisterSourceExpression IL inside the .app's DLL, gated by
+//        RunnerFormInit.ShouldRunRealFormInit — a NARROWER, per-instance opt-in that only
+//        the runner's own TestPage construction path sets (RunnerPageInstance.MarkRealInit).
+//        A page AL opens itself via `SomePage.RunModal()` — this issue's shape — is never
+//        marked, so that IL stays no-op'd exactly as it already was; this file's XML cannot
+//        change that. Reconstructing a control tree from SymbolReference.json (whose
+//        SourceExpression is AL text, e.g. `Rec."No."`, not the compiled field-number
+//        DataColumnName the real XML carries) without a way to exercise it would only add
+//        guessed data with no path to prove it faithful — the loud-failures rule's
+//        anti-pattern. Field-level TestPage control resolution for a page the runner did not
+//        compile itself stays out of scope (RunnerPageInstance.cs already documents this),
+//        unchanged by this fix — a modal page whose handler drives a field it does not
+//        recognise still refuses loudly, exactly as it did before.
+using System.Text;
+using System.Xml;
+
+namespace AlRunner.Patches;
+
+public static partial class RecordPatches
+{
+    private static readonly System.Collections.Concurrent.ConcurrentDictionary<int, string?> _depPageMetadataXml = new();
+
+    /// <summary>
+    /// Whether some loaded dependency .app's SymbolReference.json describes
+    /// <paramref name="pageId"/> — the opt-in condition <see cref="Patches.RunnerFormInit"/>
+    /// and <see cref="EnsureRealPageMetadata"/> widen for, alongside the runner's own
+    /// AlPageMetadataRegistry entries.
+    /// </summary>
+    internal static bool HasDependencyPageMetadata(int pageId) => TryGetDependencyPageSymbol(pageId) != null;
+
+    /// <summary>
+    /// Runtime PageDefinition metadata XML for a page declared by a precompiled dependency,
+    /// or null when no loaded dependency .app describes that page. Result cached per id
+    /// (including the null), since the answer is a property of the loaded dependency set.
+    /// </summary>
+    internal static string? TryBuildDependencyPageMetadata(int pageId)
+        => _depPageMetadataXml.GetOrAdd(pageId, BuildDependencyPageMetadata);
+
+    private static string? BuildDependencyPageMetadata(int pageId)
+    {
+        var page = TryGetDependencyPageSymbol(pageId);
+        if (page == null) return null;
+
+        var xml = EmitPageXml(page);
+        Console.Error.WriteLine(
+            $"[RecordPatches] dependency page metadata: synthesized Page {pageId} \"{page.Name}\" "
+            + $"(PageType={page.PageType}, SourceTable={page.SourceTableId})");
+        return xml;
+    }
+
+    private static string EmitPageXml(BcAppSymbolCache.PageSymbol page)
+    {
+        var settings = new XmlWriterSettings { Indent = true, Encoding = new UTF8Encoding(false) };
+        var sb = new StringBuilder();
+        using (var w = XmlWriter.Create(sb, settings))
+        {
+            w.WriteStartElement("PageDefinition", "urn:schemas-microsoft-com:dynamics:NAV:MetaObjects");
+            w.WriteAttributeString("xmlns", "xsi", null, "http://www.w3.org/2001/XMLSchema-instance");
+            w.WriteAttributeString("MetadataVersion", "130000");
+            w.WriteAttributeString("ID", page.Id.ToString(System.Globalization.CultureInfo.InvariantCulture));
+            w.WriteAttributeString("Name", page.Name);
+            w.WriteAttributeString("ALNamespace", string.Empty);
+
+            w.WriteStartElement("Properties");
+            w.WriteAttributeString("SourceExtensionType", "ModernDev");
+            w.WriteAttributeString("PageType", page.PageType);
+            w.WriteAttributeString("Editable", page.Editable ? "1" : "0");
+            w.WriteAttributeString("Extensible", "1");
+            if (!string.IsNullOrEmpty(page.Caption))
+            {
+                w.WriteStartElement("CaptionML");
+                w.WriteStartElement("Caption");
+                w.WriteAttributeString("Id", "1033");
+                w.WriteString(page.Caption);
+                w.WriteEndElement();
+                w.WriteEndElement();
+            }
+            if (page.SourceTableId > 0)
+            {
+                w.WriteStartElement("SourceObject");
+                w.WriteAttributeString("SourceTable",
+                    page.SourceTableId.ToString(System.Globalization.CultureInfo.InvariantCulture));
+                if (page.SourceTableTemporary)
+                    w.WriteAttributeString("SourceTableTemporary", "1");
+                if (!page.InsertAllowed) w.WriteAttributeString("InsertAllowed", "0");
+                if (!page.ModifyAllowed) w.WriteAttributeString("ModifyAllowed", "0");
+                if (!page.DeleteAllowed) w.WriteAttributeString("DeleteAllowed", "0");
+                w.WriteEndElement();
+            }
+            w.WriteEndElement(); // Properties
+
+            // An empty (but present) Content element, not an absent one: NCLMetaForm.
+            // LoadPageMetadata()'s own post-load check (EnsureNoControlIdAppearsMoreThanOnce)
+            // unconditionally iterates page.Content.Containers, and MetaPageDefinition
+            // deserializes a MISSING <Content> element to a null Content rather than an
+            // empty one — so leaving the element out entirely NREs there, one call deeper
+            // than the FindPageType gap this file exists to close. No control tree is
+            // reconstructed (see the file header), so this iterates zero containers.
+            w.WriteStartElement("Content");
+            w.WriteEndElement();
+
+            w.WriteEndElement(); // PageDefinition
+        }
+        return sb.ToString();
+    }
+}

--- a/AlRunner/Patches/RecordPatches.NclMetaFormReportBuilder.cs
+++ b/AlRunner/Patches/RecordPatches.NclMetaFormReportBuilder.cs
@@ -110,8 +110,13 @@ public static partial class RecordPatches
         // Existence check only — nothing below reads the parsed object. Pageextension ids are
         // accepted too, because they used to live in _parsedPages and therefore used to get a
         // skeleton; #1710's split decides which object WINS a shared id, it does not withdraw
-        // the skeleton from ids only a pageextension claims.
-        if (!_parsedPages.ContainsKey(pageId) && !_parsedPageExtensions.ContainsKey(pageId))
+        // the skeleton from ids only a pageextension claims. A page living in a precompiled
+        // dependency (Base Application "Error Messages", say) needs this skeleton just as
+        // much as one we compiled — see #1939: without it, NavForm.GetMasterPage's own
+        // NCLMetadata.GetMetaApplicationObject lookup throws not-found for a page whose
+        // metadata HasDependencyPageMetadata can otherwise supply.
+        if (!_parsedPages.ContainsKey(pageId) && !_parsedPageExtensions.ContainsKey(pageId)
+            && !HasDependencyPageMetadata(pageId))
             return null;
         EnsureFormReportReflection();
         if (_mCreateEmptyNCLMetaForm == null) return null;

--- a/AlRunner/Patches/RecordPatches.RealPageMetadata.cs
+++ b/AlRunner/Patches/RecordPatches.RealPageMetadata.cs
@@ -8,11 +8,15 @@
 //   "already loaded", so LoadMetadata() never runs.
 //
 //   Flipping it for every page at build time is not possible (the metadata does not exist
-//   yet) and flipping it for every page later is not desirable: pages living in a
-//   precompiled dependency have no captured XML, and forcing a load for them would turn a
-//   currently-harmless skeleton into a hard RunnerOutOfScopeException from the loader.
-//   So the load is requested by the one caller that actually needs a control tree — the
-//   TestPage path — and only for pages the runner compiled itself.
+//   yet) and flipping it for every page unconditionally is not desirable: a page neither
+//   the runner nor any loaded dependency describes still has no XML to load, and forcing an
+//   attempt for it would turn a currently-harmless skeleton into a hard
+//   RunnerOutOfScopeException from the loader. So the load is requested by callers that
+//   actually need real PageProperties — the TestPage path, and (#1939)
+//   RunnerFormInit.ShouldResolveMasterPage on AL's own `Page.RunModal()` — gated on the
+//   page having SOME source of real metadata: the runner's own emit-captured XML
+//   (AlPageMetadataRegistry) or a loaded dependency .app's SymbolReference.json
+//   (HasDependencyPageMetadata — see DependencyPageMetadataXml.cs).
 //
 // WHAT A REAL LOAD BUYS
 //   NCLMetaForm.LoadMetadata() -> LoadPageMetadata() -> CreatePageDefinitionWithExtensions()
@@ -46,7 +50,7 @@ public static partial class RecordPatches
     /// </summary>
     internal static object? EnsureRealPageMetadata(int pageId)
     {
-        if (!AlPageMetadataRegistry.TryGet(pageId, out _)) return null;
+        if (!AlPageMetadataRegistry.TryGet(pageId, out _) && !HasDependencyPageMetadata(pageId)) return null;
 
         var meta = _metaFormCache.GetOrAdd(pageId, BuildNCLMetaForm);
         if (meta == null) return null;

--- a/AlRunner/Patches/RunnerFormInit.cs
+++ b/AlRunner/Patches/RunnerFormInit.cs
@@ -76,9 +76,19 @@ public static class RunnerFormInit
     /// looks up a handler, so every modal page raised a NullReferenceException instead of
     /// reaching its [ModalPageHandler]. Thirty Pageworks tests declare HandlerFunctions.
     ///
-    /// The condition is "the runner compiled this page, so it HAS metadata to build a real
-    /// MasterPage from" — which is exactly when the lookup can succeed. A page with no
-    /// captured XML still returns null, as before, rather than throwing from the loader.
+    /// The condition is "the runner has SOME real metadata to build a MasterPage from" —
+    /// which is exactly when the lookup can succeed. That covers two sources: a page the
+    /// runner itself source-compiled (AlPageMetadataRegistry, emit-captured XML), and
+    /// (#1939) a page living in a precompiled dependency .app (Base Application "Error
+    /// Messages", "No. Series", ...) — reconstructed from that .app's own
+    /// SymbolReference.json, see DependencyPageMetadataXml.cs. Without the latter, EVERY
+    /// modal page opened by `SomePage.RunModal()` against a Base App/System App/ISV page
+    /// (never a page the runner compiled) got GetMasterPage() short-circuited to null, and
+    /// NavTestExecution.FindPageType NRE'd on the null MasterPage before its
+    /// [ModalPageHandler] handler dispatch ever ran — the identical shape with a
+    /// source-compiled page passed, because only source-compiled pages had an
+    /// AlPageMetadataRegistry entry. A page neither source knows about still returns null,
+    /// as before, rather than throwing from the loader.
     ///
     /// Request pages stay excluded: that is the path the original blanket no-op existed to
     /// protect, it is keyed by report rather than page id, and nothing here needs it.
@@ -91,7 +101,8 @@ public static class RunnerFormInit
             if (ShouldRunRealFormInit(form)) return true;
             if (form is not Microsoft.Dynamics.Nav.Runtime.NavForm navForm) return false;
             if (navForm.IsRequestPage) return false;
-            return AlPageMetadataRegistry.TryGet(navForm.FormId, out _);
+            return AlPageMetadataRegistry.TryGet(navForm.FormId, out _)
+                   || RecordPatches.HasDependencyPageMetadata(navForm.FormId);
         }
         catch { return false; }
     }

--- a/AlRunner/Patches/RunnerXmlMetadataLoader.cs
+++ b/AlRunner/Patches/RunnerXmlMetadataLoader.cs
@@ -72,6 +72,15 @@ public sealed class RunnerXmlMetadataLoader : INCLObjectXmlMetadataLoader
             && AlPageMetadataRegistry.TryGet(objectId.ObjectNumber, out var pageXml))
             return Wrap(pageXml, $"runner-page-{objectId.ObjectNumber}");
 
+        // Pages living in a PRECOMPILED dependency .app: never source-compiled, so the
+        // emit registry above never holds them. Reconstruct a minimal, honest metadata
+        // document (PageType + SourceObject only) from the .app's own SymbolReference.json
+        // rather than refuse — see DependencyPageMetadataXml.cs for exactly what is read
+        // and what is deliberately left unstated.
+        if (objectId.ObjectType == ObjectType.Page
+            && RecordPatches.TryBuildDependencyPageMetadata(objectId.ObjectNumber) is { } depPageXml)
+            return Wrap(depPageXml, $"runner-dep-page-{objectId.ObjectNumber}");
+
         // XmlPorts: same emit-captured metadata XML, feeding NCLMetaXmlPort.LoadMetadata()
         // so BC's own XmlPort engine imports/exports against the port's real node schema
         // instead of NREing on an empty skeleton.


### PR DESCRIPTION
Closes #1939

## Root cause

`NavForm.GetMasterPage()` is Cecil-guarded: it only runs its real body (`NavGlobal.MetadataProvider.GetMasterPage` -> ... -> `NCLMetadata.GetMetaApplicationObject(Page, id)`) when `RunnerFormInit.ShouldResolveMasterPage` says yes. That guard checked only `AlPageMetadataRegistry` — populated exclusively by `BcCompiler.Emit`, i.e. only for pages the runner source-compiled. A page shipped inside a precompiled dependency .app (Base Application `Page "Error Messages"` / `Page "No. Series"`, any ISV page) has no registry entry, so `GetMasterPage()` returned null, and `NavTestExecution.FindPageType` NRE'd on `form.MasterPage.PageProperties.PageType` before the modal's `[ModalPageHandler]` handler dispatch it exists to gate. The identical AL shape with a source-compiled page (registry entry present) passed.

Confirmed by decompiling `Microsoft.Dynamics.Nav.Ncl.dll` (`NavTestExecution.FindPageType`, `NavForm.GetMasterPage`, `MetadataProvider.GetMergedMasterPage`/`GetPageDefinition`/`GetFrozenPageDefinitionWithExtensionWithoutMergedMultiLanguage`) and by reproducing the issue's own four-arm repro locally.

## Fix

Mirror the existing `DependencyReportMetadata.cs` mechanism (already used for precompiled-dependency reports) for pages:

- `AlRunner/Patches/DependencyPageMetadataXml.cs` (new) — reconstructs a minimal, honest `PageDefinition` metadata document (`PageType` + `SourceObject` only) from a loaded dependency `.app`'s `SymbolReference.json` (`BcAppSymbolCache.PageSymbol`, already parsed for the Page Metadata virtual table). An empty-but-present `<Content>` element is required — `NCLMetaForm.LoadPageMetadata()`'s own post-load check (`EnsureNoControlIdAppearsMoreThanOnce`) unconditionally reads `page.Content.Containers`, and a *missing* `<Content>` element deserializes to `null` there, one call deeper than the original NRE. Field-level control tree reconstruction is deliberately **not** attempted — see the file header for why that stays out of scope and safe to omit (a precompiled page's own control bindings come from its own compiled IL, gated by the narrower per-instance `ShouldRunRealFormInit` the runner's TestPage construction path sets, which `SomePage.RunModal()` never triggers — so the field-binding path is unaffected by this fix either way).
- `RunnerXmlMetadataLoader.cs` — Page branch now falls back to the new builder, same pattern as the existing Report fallback.
- `RecordPatches.NclMetaFormReportBuilder.cs` (`BuildNCLMetaForm`) — existence check widened to admit dependency pages, mirroring `KnownReportIdSet()` for reports.
- `RecordPatches.RealPageMetadata.cs` (`EnsureRealPageMetadata`) — opt-in gate widened the same way.
- `RunnerFormInit.cs` (`ShouldResolveMasterPage`) — opt-in widened to admit a page `RecordPatches.HasDependencyPageMetadata` recognises, alongside the existing `AlPageMetadataRegistry` check.

## Tests

**RED -> GREEN, AL level** (the actual BC-observable claim): opened [StefanMaron/BusinessCentral.AL.Language.Tests#55](https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/55) (now green on both BC 27.5 and 28.3 CI legs) — `TestPageModalHandler_PrecompiledPage.al`, 3 tests (`RunModal` on `Page "Error Messages"`/`Page "No. Series"` returning the concrete `Action::OK` the handler invoked, plus the missing-handler negative). An initial 4th test asserting a `Cancel` scenario on `Page "Error Messages"` was dropped after real BC CI reported that page declares no built-in Cancel action at all (`"The built-in action = Cancel is not found on the page."`) — not a runner concern, a fact about that specific page's declared actions. Ran against this runner build pointed at the PR branch checkout (not the pinned submodule — never bumped here):
- Without this fix: 0/3 pass, all failing with the exact reported `NullReferenceException` at `NavTestExecution.FindPageType` (the missing-handler negative fails too, for the same wrong reason instead of the expected `Unhandled UI`).
- With this fix: 3/3 pass.

Full corpus (`tests/al-language/tests/al-language`, same branch checkout) stays green: **2099/2099**, both cold (fresh `--cache` dir, AL emit + C# compile from scratch) and warm (cache HIT) runs — the dependency-page-metadata path is exercised by both.

**RED -> GREEN, runner-mechanism level** (satisfies the "Tests updated" CI gate — the AL corpus test lives in the read-only submodule, not bumped in this PR): `AlRunner.Tests/DependencyPageMetadataXmlTests.cs`, pinning `RecordPatches.TryBuildDependencyPageMetadata`/`HasDependencyPageMetadata` directly — a synthesized `.app` declaring a page produces a `PageDefinition` with the real `PageType`/`SourceObject`, and an unrecognised page id gets neither a document nor a false "yes" from the opt-in check.

`dotnet test AlRunner.Tests` — 749 passed, 1 pre-existing unrelated failure (`BcCompilerSharedReferenceMemoTests.AddingAPackageToAScannedDir_ForcesARebuild`, reproduced identically with this PR's changes stashed out, so unrelated to this change).

## Notes for reviewers

- Object ID: no new AL objects in this repo (the corpus test's new codeunit id `60902` is in the corpus repo, checked against that repo's `idRanges` and open PRs before allocating).
- `tests/al-language` is untouched here — no pin bump, per the submodule rule. The corpus PR is a prerequisite the orchestrator should merge and then bump the pin in its own PR; this runner fix does not depend on that order to be independently correct and tested.
