### PR TITLE
fix(testpage): pageextension-contributed action Invoke() dispatches its own OnAction

### DIFF
--- a/AlRunner/Patches/MockTestPage.cs
+++ b/AlRunner/Patches/MockTestPage.cs
@@ -286,10 +286,22 @@ internal class LiveNavTestPage : MockITestPage
     /// trigger. The base mock returns a MockITestAction whose Invoke() is a literal no-op,
     /// so an invoked action silently did nothing and the test failed a step later
     /// complaining about the missing effect rather than about the action.
+    ///
+    /// Issue #1923: <c>_page</c> is null whenever the base page has no compiled type/captured
+    /// metadata for the runner to build a RunnerPageInstance from — the case for a page that
+    /// ships PRECOMPILED (e.g. Base App "Item Attributes"). A pageextension THIS bundle
+    /// compiled can still own <paramref name="actionId"/>'s OnAction even though the base page
+    /// itself is unreachable, so that case gets one more chance (ExtensionOnlyTestAction)
+    /// before falling all the way back to the no-op mock.
     /// </summary>
     public override ITestAction GetAction(int actionId)
     {
-        if (_page == null) return base.GetAction(actionId);
+        if (_page == null)
+        {
+            if (_owner != null && RecordPatches.GetPageExtensionIdsForPage(_pageId).Count > 0)
+                return new ExtensionOnlyTestAction(this, _owner, _record, _pageId, actionId);
+            return base.GetAction(actionId);
+        }
         if (!_liveActions.TryGetValue(actionId, out var action))
             _liveActions[actionId] = action = new LiveNavTestAction(this, _page, actionId);
         return action;
@@ -1558,6 +1570,42 @@ internal sealed class MockITestAction : ITestAction
     public void Invoke()         { }
     public bool Visible          => true;
     public bool Enabled          => true;
+}
+
+/// <summary>
+/// Dispatches an action against a pageextension's own OnAction trigger when there is no
+/// live RunnerPageInstance for the base page to route LiveNavTestAction through (issue
+/// #1923 — see RunnerPageInstance.TryRaiseExtensionOnlyAction's remarks for why that
+/// happens and what it can and cannot faithfully do). Falls back to a silent no-op, exactly
+/// matching MockITestAction, when no compiled pageextension actually owns this action id —
+/// an id belonging to the (unbuildable) precompiled base page itself, the pre-existing,
+/// narrower gap this deliberately leaves alone rather than expanding scope.
+/// </summary>
+internal sealed class ExtensionOnlyTestAction : ITestAction
+{
+    private readonly LiveNavTestPage _testPage;
+    private readonly object _owner;
+    private readonly NavRecord _record;
+    private readonly int _pageId;
+    private readonly int _actionId;
+
+    public ExtensionOnlyTestAction(LiveNavTestPage testPage, object owner, NavRecord record, int pageId, int actionId)
+    {
+        _testPage = testPage;
+        _owner = owner;
+        _record = record;
+        _pageId = pageId;
+        _actionId = actionId;
+    }
+
+    public void Invoke()
+    {
+        _testPage.SaveCurrentRow();
+        RunnerPageInstance.TryRaiseExtensionOnlyAction(_owner, _record, _pageId, _actionId);
+    }
+
+    public bool Visible => true;
+    public bool Enabled => true;
 }
 
 /// <summary>

--- a/AlRunner/Patches/RecordPatches.AlPageParser.cs
+++ b/AlRunner/Patches/RecordPatches.AlPageParser.cs
@@ -137,6 +137,42 @@ public static partial class RecordPatches
     }
 
     /// <summary>
+    /// Every AL-source-parsed <c>pageextension</c> that extends <paramref name="pageId"/>, by
+    /// its OWN object id — the id space a control/action it declares is hashed in (see the
+    /// remarks on <see cref="GetPageControlFieldMap"/>). <paramref name="pageId"/> is resolved
+    /// to a NAME via the runner's own AL-source-parsed pages first, then (issue #1923) a loaded
+    /// dependency .app's SymbolReference.json (<see cref="RecordPatches.TryGetAnyPageName"/>) —
+    /// a pageextension over a page that ships PRECOMPILED (e.g. Base Application "Item
+    /// Attributes") is exactly as much a real extension as one over a page compiled in this
+    /// bundle, and the trigger-dispatch gap that motivated this method (#1923) hit that arm
+    /// hardest: nothing threw at all, so a test only caught the miss on the effect the missing
+    /// action was supposed to have.
+    /// </summary>
+    internal static List<int> GetPageExtensionIdsForPage(int pageId)
+    {
+        var baseName = TryGetAnyPageName(pageId);
+        if (string.IsNullOrEmpty(baseName)) return new List<int>();
+
+        var result = new List<int>();
+        foreach (var ext in _parsedPageExtensions.Values)
+            if (NamesEqual(ext.BaseName, baseName))
+                result.Add(ext.Id);
+        result.Sort();
+        return result;
+    }
+
+    /// <summary>
+    /// <paramref name="pageId"/>'s declared NAME — the runner's own AL-source-parsed pages
+    /// first, then (for a page that ships precompiled in a dependency .app, never AL-source-
+    /// parsed here) the dependency's SymbolReference.json. Null when neither knows the page.
+    /// </summary>
+    internal static string? TryGetAnyPageName(int pageId)
+    {
+        if (_parsedPages.TryGetValue(pageId, out var page)) return page.Name;
+        return TryGetDependencyPageSymbol(pageId)?.Name;
+    }
+
+    /// <summary>
     /// Control id → source-table field number for every field control on the page, INCLUDING
     /// the ones contributed by pageextensions that extend it.
     /// <para>An extension's controls are keyed in the EXTENSION's own id space, because BC's

--- a/AlRunner/Patches/RunnerPageInstance.cs
+++ b/AlRunner/Patches/RunnerPageInstance.cs
@@ -40,12 +40,21 @@ namespace AlRunner.Patches;
 internal sealed class RunnerPageInstance
 {
     private readonly object _form;
+    private readonly object _owner;
+    private readonly NavRecord? _record;
     private readonly int _pageId;
     private readonly System.Collections.IDictionary _sourceExpressions;
 
-    private RunnerPageInstance(object form, int pageId, System.Collections.IDictionary sourceExpressions)
+    // Lazily-constructed NavFormExtension instances for the pageextensions that extend
+    // this page (issue #1923) — one per extension id, built on first trigger lookup and
+    // reused after that. See FindTrigger/GetOrCreateExtensionInstance.
+    private readonly Dictionary<int, object?> _extensionInstances = new();
+
+    private RunnerPageInstance(object form, object owner, NavRecord? record, int pageId, System.Collections.IDictionary sourceExpressions)
     {
         _form = form;
+        _owner = owner;
+        _record = record;
         _pageId = pageId;
         _sourceExpressions = sourceExpressions;
     }
@@ -157,7 +166,7 @@ internal sealed class RunnerPageInstance
                 Console.Out.WriteLine(
                     $"[RunnerPageInstance] page {pageId}: built, {expressions.Count} source expression(s): "
                     + string.Join(", ", expressions.Keys.Cast<object>().Select(k => k?.ToString())));
-            return new RunnerPageInstance(form, pageId, expressions);
+            return new RunnerPageInstance(form, parent, record, pageId, expressions);
         }
         catch (Exception ex)
         {
@@ -192,7 +201,14 @@ internal sealed class RunnerPageInstance
     {
         var expressions = ReadProperty(form, "SourceExpressions") as System.Collections.IDictionary
                           ?? new System.Collections.Hashtable();
-        return new RunnerPageInstance(form, pageId, expressions);
+        // No caller-supplied owner/record for an already-live form — the form is itself a
+        // real NavForm, which implements ITreeObject, and its own bound record (BC's
+        // "SourceTable" property, same one SetSourceTable populates in TryCreate) is the
+        // best available substitute for constructing a pageextension instance later
+        // (issue #1923's extension-trigger dispatch). A form with neither yet (unbound) is
+        // the pre-existing "no page object" case FindTrigger already tolerates.
+        var record = ReadProperty(form, "SourceTable") as NavRecord;
+        return new RunnerPageInstance(form, form, record, pageId, expressions);
     }
 
     /// <summary>
@@ -524,7 +540,7 @@ internal sealed class RunnerPageInstance
     {
         var trigger = FindTrigger(controlId, "_OnValidate", "OnValidate");
         // A control with no OnValidate simply has no such method, which is not an error.
-        if (trigger != null) Invoke(trigger);
+        if (trigger != null) Invoke(trigger.Value);
     }
 
     /// <summary>
@@ -535,6 +551,16 @@ internal sealed class RunnerPageInstance
     /// another page/report), which the runner cannot perform, so it refuses by name rather
     /// than doing nothing — silently doing nothing is what made an unrun action surface one
     /// step later as an assertion about its missing effect.
+    ///
+    /// Issue #1923: an action a PAGEEXTENSION contributes is compiled onto the extension's
+    /// OWN type (<c>PageExtension{extId}</c>), not the base page's, and its member id hashes
+    /// from the extension's OWN object id — never the page's. FindTrigger now also searches
+    /// every pageextension that extends this page (own-bundle-source-compiled or a real
+    /// PRECOMPILED dependency page, e.g. Base App "Item Attributes") before giving up. Before
+    /// this fix a source-compiled base page's extension action was misclassified as this very
+    /// RunnerOutOfScopeException (a real, dispatchable action reported as unsupported
+    /// RunObject); a precompiled base page's extension action reached nowhere to throw
+    /// against at all — Invoke() silently did nothing, in violation of loud-failures.md.
     /// </summary>
     internal void RaiseOnAction(int actionId)
     {
@@ -585,7 +611,7 @@ internal sealed class RunnerPageInstance
         var byRef = new ByRef<NavText>(() => value, v => value = v);
 
         object? result;
-        try { result = trigger.Invoke(_form, new object?[] { byRef }); }
+        try { result = trigger.Method.Invoke(trigger.Target, new object?[] { byRef }); }
         catch (TargetInvocationException tie) when (tie.InnerException != null)
         {
             System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(tie.InnerException).Throw();
@@ -613,7 +639,7 @@ internal sealed class RunnerPageInstance
         var trigger = FindTrigger(controlId, "_OnDrillDown", "OnDrillDown");
         if (trigger == null)
             throw AlRunner.BcRuntime.MakeNavDrilldownActionNotSupportedException();
-        Invoke(trigger);
+        Invoke(trigger.Value);
     }
 
     /// <summary>
@@ -825,19 +851,63 @@ internal sealed class RunnerPageInstance
     }
 
     /// <summary>
-    /// The page method carrying the trigger for <paramref name="memberId"/>.
-    ///
-    /// The AL compiler emits triggers as <c>{MemberName}_a{n}{suffix}</c> on the page class,
-    /// carrying the NAME but not the id. The member is identified by RE-DERIVING BC's own id
-    /// from each candidate's name — <c>IdSpace.GetMemberId(pageId, name)</c>, i.e. abs(FNV-1a
-    /// over the UTF-16 bytes of pageId + name) — and comparing it to the id being driven.
-    /// Matching a control on its source expression's Name does not work: that is the bound
-    /// VARIABLE's name (SelectedMode), not the control's (Mode), and they routinely differ.
+    /// A resolved trigger method plus the OBJECT to invoke it on. Before issue #1923 every
+    /// trigger lived on the base page's own <c>_form</c>, so a bare MethodInfo was enough; a
+    /// pageextension's trigger lives on that extension's own compiled instance instead (see
+    /// FindTrigger), so the target has to travel with the method from here on.
     /// </summary>
-    private MethodInfo? FindTrigger(int memberId, string suffix, string surface, int arity = 0)
+    private readonly struct TriggerMatch
+    {
+        internal readonly object Target;
+        internal readonly MethodInfo Method;
+        internal TriggerMatch(object target, MethodInfo method) { Target = target; Method = method; }
+    }
+
+    /// <summary>
+    /// The method (and the object to invoke it on) carrying the trigger for
+    /// <paramref name="memberId"/>.
+    ///
+    /// The AL compiler emits triggers as <c>{MemberName}_a{n}{suffix}</c> on the DECLARING
+    /// object's class, carrying the NAME but not the id. The member is identified by
+    /// RE-DERIVING BC's own id from each candidate's name —
+    /// <c>IdSpace.GetMemberId(declaringObjectId, name)</c>, i.e. abs(FNV-1a over the UTF-16
+    /// bytes of declaringObjectId + name) — and comparing it to the id being driven. Matching
+    /// a control on its source expression's Name does not work: that is the bound VARIABLE's
+    /// name (SelectedMode), not the control's (Mode), and they routinely differ.
+    ///
+    /// Issue #1923: a control/action a PAGEEXTENSION declares is compiled onto the extension's
+    /// OWN type (<c>PageExtension{extId}</c>, a <c>NavFormExtension</c> subclass), not the base
+    /// page's — and its id hashes from the EXTENSION's own object id, never the page's (see
+    /// RecordPatches.GetPageControlFieldMap, which already documents and relies on this same
+    /// id-space rule for field controls: <c>GetMemberId(64301, "NoteField")</c> is the id BC
+    /// actually asks for, <c>GetMemberId(64300, "NoteField")</c> — the base page's id — never
+    /// appears). So after the base page's own type comes up empty, this now also searches
+    /// every pageextension that extends this page, in each one's own id space.
+    /// </summary>
+    private TriggerMatch? FindTrigger(int memberId, string suffix, string surface, int arity = 0)
+    {
+        var own = FindTriggerOnTarget(_form, _pageId, memberId, suffix, surface, arity);
+        if (own != null) return own;
+
+        foreach (var extensionId in RecordPatches.GetPageExtensionIdsForPage(_pageId))
+        {
+            var extInstance = GetOrCreateExtensionInstance(extensionId);
+            if (extInstance == null) continue;
+            var extMatch = FindTriggerOnTarget(extInstance, extensionId, memberId, suffix, surface, arity);
+            if (extMatch != null) return extMatch;
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// FindTrigger's inner scan, over ONE declaring object (the base page or one
+    /// pageextension instance) and its own id space (<paramref name="declaringObjectId"/>).
+    /// </summary>
+    private static TriggerMatch? FindTriggerOnTarget(
+        object target, int declaringObjectId, int memberId, string suffix, string surface, int arity)
     {
         MethodInfo? match = null;
-        foreach (var m in _form.GetType()
+        foreach (var m in target.GetType()
             .GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance))
         {
             if (m.GetParameters().Length != arity) continue;
@@ -845,22 +915,154 @@ internal sealed class RunnerPageInstance
 
             var memberName = MemberNameFromTriggerMethod(m.Name, suffix);
             if (memberName == null) continue;
-            if (MemberId(_pageId, memberName) != memberId) continue;
+            if (MemberId(declaringObjectId, memberName) != memberId) continue;
 
             if (match != null)
                 throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
                     $"TestPage {surface} (member {memberId})",
                     $"testpage-{surface.ToLowerInvariant()} — both '{match.Name}' and '{m.Name}' on "
-                    + $"{_form.GetType().Name} resolve to member {memberId}; the runner cannot "
+                    + $"{target.GetType().Name} resolve to member {memberId}; the runner cannot "
                     + "tell which trigger belongs to it. See docs/scope.md");
             match = m;
         }
-        return match;
+        return match == null ? null : new TriggerMatch(target, match);
     }
 
-    private void Invoke(MethodInfo trigger)
+    /// <summary>
+    /// The live instance of a pageextension's compiled <c>PageExtension{extensionId}</c>
+    /// class, constructed once per RunnerPageInstance and cached — never rebuilt per trigger
+    /// lookup, so an extension whose type could not be found or built stays a fast negative
+    /// on every later call instead of retrying (and re-logging) the same failure.
+    ///
+    /// Constructed the same way <see cref="TryCreate"/> constructs the base page itself: the
+    /// AL-compiler-emitted <c>(ITreeObject, NavRecord)</c> ctor (verified via IL: it just
+    /// forwards to <c>NavFormExtension(ITreeObject, int extId, NavRecord, NCLStaticMetadata)</c>
+    /// with the extension's own object id baked in) — then <c>ParentObject</c> is set to this
+    /// page's own <c>_form</c>, because the extension's OWN <c>get_Rec</c>/<c>get_CurrPage</c>
+    /// overrides route through <c>ParentObject</c> (also verified via IL), not through the
+    /// record the ctor was handed. Real BC wires this by adding the extension to the page's
+    /// own <c>PageExtensions</c> list during metadata load; the runner's skeleton always keeps
+    /// that list empty (see NclCecilRewrite.cs's <c>get_PageExtensions</c> rewrite), so this
+    /// is the runner-owned substitute for that step — the trigger DISPATCH here has always
+    /// been the runner's own reflection scheme (see FindTrigger's remarks), never BC's real
+    /// action-invoke machinery, so this is consistent with the existing architecture, not a
+    /// new shortcut.
+    /// </summary>
+    private object? GetOrCreateExtensionInstance(int extensionId)
     {
-        try { trigger.Invoke(_form, null); }
+        if (_extensionInstances.TryGetValue(extensionId, out var cached)) return cached;
+
+        object? instance = null;
+        if (_record != null)
+        {
+            var extType = FindPageExtensionType(extensionId);
+            var ctor = extType?.GetConstructors(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
+                .FirstOrDefault(c => c.GetParameters().Length == 2
+                                  && typeof(NavRecord).IsAssignableFrom(c.GetParameters()[1].ParameterType));
+            if (ctor != null)
+            {
+                try
+                {
+                    instance = ctor.Invoke(new object?[] { _owner, _record });
+                    var parentObjectProp = instance.GetType().GetProperty("ParentObject",
+                        BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+                    parentObjectProp?.SetValue(instance, _form);
+                }
+                catch (Exception ex)
+                {
+                    var inner = ex is TargetInvocationException tie ? tie.InnerException ?? ex : ex;
+                    // Loud, but not fatal: FindTrigger treats a null instance exactly like "this
+                    // extension declares no matching trigger", which for OnAction/OnLookup still
+                    // surfaces as a refusal (never a silent no-op) once every extension has been
+                    // tried. stdout on purpose — see TryCreate's identical reasoning above.
+                    Console.Out.WriteLine(
+                        $"[RunnerPageInstance] pageextension {extensionId} on page {_pageId}: could not "
+                        + $"construct the AL page extension object ({inner.GetType().Name}: "
+                        + $"{inner.Message}); its triggers stay unreachable");
+                }
+            }
+        }
+
+        _extensionInstances[extensionId] = instance;
+        return instance;
+    }
+
+    private static Type? FindPageExtensionType(int extensionId)
+    {
+        var name = "PageExtension" + extensionId;
+        foreach (var asm in AppDomain.CurrentDomain.GetAssemblies())
+        {
+            try
+            {
+                var t = AlRunner.Infrastructure.AssemblyTypeIndex.For(asm)
+                    .FindFirst(name, typeof(Microsoft.Dynamics.Nav.Runtime.Extensions.NavFormExtension).IsAssignableFrom);
+                if (t != null) return t;
+            }
+            catch { }
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Dispatch <paramref name="actionId"/> against a pageextension's own OnAction trigger
+    /// with NO live RunnerPageInstance for the base page to route through — issue #1923's
+    /// most dangerous arm: a pageextension over a page that ships PRECOMPILED (e.g. Base App
+    /// "Item Attributes") extends a page with no compiled <c>Page{id}</c> .NET type and no
+    /// emit-captured metadata XML, so <see cref="TryCreate"/> returns null (see its SCOPE
+    /// remarks) and the caller (MockTestPage.cs's LiveNavTestPage) had nowhere to route
+    /// Invoke() except a permanently no-op MockITestAction — a real, dispatchable action
+    /// silently doing nothing.
+    ///
+    /// Returns false when no compiled pageextension owns <paramref name="actionId"/> — an id
+    /// that genuinely belongs to the (unbuildable) precompiled base page itself, which the
+    /// caller is expected to keep treating exactly as it did before this method existed
+    /// (that half of the gap is pre-existing and out of #1923's scope: dispatching an action
+    /// on a page the runner never compiled needs a control tree the runner has no way to
+    /// build at all, unlike a pageextension's own trigger, which needs nothing from the base
+    /// page besides its record).
+    /// </summary>
+    internal static bool TryRaiseExtensionOnlyAction(object owner, NavRecord record, int pageId, int actionId)
+    {
+        foreach (var extensionId in RecordPatches.GetPageExtensionIdsForPage(pageId))
+        {
+            var extType = FindPageExtensionType(extensionId);
+            var ctor = extType?.GetConstructors(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
+                .FirstOrDefault(c => c.GetParameters().Length == 2
+                                  && typeof(NavRecord).IsAssignableFrom(c.GetParameters()[1].ParameterType));
+            if (ctor == null) continue;
+
+            object instance;
+            try { instance = ctor.Invoke(new object?[] { owner, record }); }
+            catch (Exception ex)
+            {
+                var inner = ex is TargetInvocationException tie ? tie.InnerException ?? ex : ex;
+                Console.Out.WriteLine(
+                    $"[RunnerPageInstance] pageextension {extensionId} on page {pageId} (no live base page "
+                    + $"object): could not construct the AL page extension object "
+                    + $"({inner.GetType().Name}: {inner.Message})");
+                continue;
+            }
+
+            // No base NavForm exists to set ParentObject to (that is exactly why we are on
+            // this path) — an OnAction trigger that only touches its own locals still runs
+            // faithfully; one that reads Rec/CurrPage NREs, which surfaces as a genuine
+            // runner-internal error rather than a silently wrong answer.
+            var match = FindTriggerOnTarget(instance, extensionId, actionId, "_OnAction", "OnAction", arity: 0);
+            if (match == null) continue;
+
+            try { match.Value.Method.Invoke(match.Value.Target, null); }
+            catch (TargetInvocationException tie) when (tie.InnerException != null)
+            {
+                System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(tie.InnerException).Throw();
+            }
+            return true;
+        }
+        return false;
+    }
+
+    private void Invoke(TriggerMatch trigger)
+    {
+        try { trigger.Method.Invoke(trigger.Target, null); }
         catch (TargetInvocationException tie) when (tie.InnerException != null)
         {
             // An Error() inside the AL trigger is the trigger's own outcome, not a runner

--- a/tests/expectations/count-baseline/test-count-baseline.json
+++ b/tests/expectations/count-baseline/test-count-baseline.json
@@ -7,12 +7,12 @@
     },
     "runner-extras": {
       "tests": {
-        "default": 137,
-        "byBcVersion": { "27.0": 131, "27.3": 131, "27.5": 131 }
+        "default": 141,
+        "byBcVersion": { "27.0": 135, "27.3": 135, "27.5": 135 }
       },
       "appGroups": {
-        "default": 27,
-        "byBcVersion": { "27.0": 25, "27.3": 25, "27.5": 25 }
+        "default": 28,
+        "byBcVersion": { "27.0": 26, "27.3": 26, "27.5": 26 }
       }
     }
   }

--- a/tests/runner-extras/pageext-action-dispatch/PadAssert.Codeunit.al
+++ b/tests/runner-extras/pageext-action-dispatch/PadAssert.Codeunit.al
@@ -1,0 +1,16 @@
+/// Thin standalone assert helper — no dependency on Library Assert, mirroring the
+/// dep-tableext-platform-base / EOM suites' own local wrapper convention.
+codeunit 64525 "Pad Assert"
+{
+    procedure IsTrue(Value: Boolean; Msg: Text)
+    begin
+        if not Value then
+            Error('Assert.IsTrue failed: %1', Msg);
+    end;
+
+    procedure IsFalse(Value: Boolean; Msg: Text)
+    begin
+        if Value then
+            Error('Assert.IsFalse failed: %1', Msg);
+    end;
+}

--- a/tests/runner-extras/pageext-action-dispatch/PadHostPage.Page.al
+++ b/tests/runner-extras/pageext-action-dispatch/PadHostPage.Page.al
@@ -1,0 +1,39 @@
+/// Control arm: an action declared DIRECTLY on the page. Must already dispatch — proves the
+/// suite's own Invoke()/handler plumbing works before the pageextension arms are trusted.
+page 64521 "Pad Host Page"
+{
+    PageType = List;
+    SourceTable = "Pad Row";
+    ApplicationArea = All;
+    UsageCategory = Lists;
+
+    layout
+    {
+        area(Content)
+        {
+            repeater(Rows)
+            {
+                field("No."; Rec."No.") { ApplicationArea = All; }
+            }
+        }
+    }
+
+    actions
+    {
+        area(Processing)
+        {
+            action(DirectAction)
+            {
+                ApplicationArea = All;
+                Caption = 'Direct Action';
+
+                trigger OnAction()
+                var
+                    Row: Record "Pad Row";
+                begin
+                    Row.Log('DIRECT');
+                end;
+            }
+        }
+    }
+}

--- a/tests/runner-extras/pageext-action-dispatch/PadHostPageExt.PageExt.al
+++ b/tests/runner-extras/pageext-action-dispatch/PadHostPageExt.PageExt.al
@@ -1,0 +1,24 @@
+/// Arm 2: an action a pageextension adds to a page COMPILED FROM SOURCE in this same bundle
+/// (#1923's "misclassified OOS" symptom — the old code threw RunnerOutOfScopeException
+/// naming a valid RunObject-less action as unsupported).
+pageextension 64522 "Pad Host Page Ext" extends "Pad Host Page"
+{
+    actions
+    {
+        addlast(Processing)
+        {
+            action(ExtActionOnOwnPage)
+            {
+                ApplicationArea = All;
+                Caption = 'Ext Action On Own Page';
+
+                trigger OnAction()
+                var
+                    Row: Record "Pad Row";
+                begin
+                    Row.Log('EXT-OWN-PAGE');
+                end;
+            }
+        }
+    }
+}

--- a/tests/runner-extras/pageext-action-dispatch/PadItemAttrExt.PageExt.al
+++ b/tests/runner-extras/pageext-action-dispatch/PadItemAttrExt.PageExt.al
@@ -1,0 +1,25 @@
+/// Arm 3: an action a pageextension adds to a page that ships PRECOMPILED inside Base
+/// Application (#1923's "silent no-op" symptom — the more dangerous half: nothing threw at
+/// Invoke() time at all, so a test only caught the miss one step later on the effect the
+/// action was supposed to have).
+pageextension 64523 "Pad Item Attr Ext" extends "Item Attributes"
+{
+    actions
+    {
+        addlast(Processing)
+        {
+            action(ExtActionOnBaseAppPage)
+            {
+                ApplicationArea = All;
+                Caption = 'Ext Action On Base App Page';
+
+                trigger OnAction()
+                var
+                    Row: Record "Pad Row";
+                begin
+                    Row.Log('EXT-BASEAPP-PAGE');
+                end;
+            }
+        }
+    }
+}

--- a/tests/runner-extras/pageext-action-dispatch/PadRow.Table.al
+++ b/tests/runner-extras/pageext-action-dispatch/PadRow.Table.al
@@ -1,0 +1,36 @@
+/// Backing table for the pageextension-action-dispatch suite. Log() rows are the observable
+/// proof an OnAction trigger actually ran (and which one) — the whole point per #1923: a
+/// silent no-op passes "no exception thrown" but writes nothing here.
+table 64520 "Pad Row"
+{
+    DataClassification = CustomerContent;
+
+    fields
+    {
+        field(1; "No."; Code[20]) { }
+        field(2; Descr; Text[100]) { }
+    }
+
+    keys
+    {
+        key(PK; "No.") { Clustered = true; }
+    }
+
+    procedure Log(Tag: Code[20])
+    var
+        Row: Record "Pad Row";
+    begin
+        if not Row.Get(Tag) then begin
+            Row.Init();
+            Row."No." := Tag;
+            Row.Insert();
+        end;
+    end;
+
+    procedure HasMessage(Tag: Code[20]): Boolean
+    var
+        Row: Record "Pad Row";
+    begin
+        exit(Row.Get(Tag));
+    end;
+}

--- a/tests/runner-extras/pageext-action-dispatch/PadTests.Codeunit.al
+++ b/tests/runner-extras/pageext-action-dispatch/PadTests.Codeunit.al
@@ -1,0 +1,111 @@
+/// Regression suite for #1923: TestPage Invoke() of a pageextension-contributed action never
+/// dispatched its OnAction trigger.
+///
+/// RED (without the fix):
+///   - DirectActionRuns:              passes (control arm, unaffected)
+///   - ExtActionOnOwnPageRuns:        throws RunnerOutOfScopeException naming
+///                                    "testpage-action — the page declares no OnAction
+///                                    trigger for this action ..." for an action that
+///                                    plainly declares one, in the pageextension
+///   - ExtActionOnBaseAppPageRuns:    Invoke() raises nothing at all (silent no-op); only
+///                                    this test's own Assert.IsTrue catches that the row was
+///                                    never logged
+///
+/// GREEN (with the fix): all three log their own tag, and only their own tag — proving each
+/// arm's OnAction genuinely ran, not merely that Invoke() returned without throwing.
+codeunit 64524 "Pad Tests"
+{
+    Subtype = Test;
+    TestPermissions = Disabled;
+
+    var
+        Assert: Codeunit "Pad Assert";
+
+    local procedure Initialize()
+    var
+        Row: Record "Pad Row";
+    begin
+        Row.DeleteAll();
+    end;
+
+    // Control: an action declared directly on the page dispatches. If this fails, the
+    // other two tests' failures would be meaningless (broken plumbing, not #1923).
+    [Test]
+    procedure DirectActionRuns()
+    var
+        Row: Record "Pad Row";
+        HostPage: TestPage "Pad Host Page";
+    begin
+        Initialize();
+
+        HostPage.OpenEdit();
+        HostPage.DirectAction.Invoke();
+        HostPage.Close();
+
+        Assert.IsTrue(Row.Get('DIRECT'), 'Invoke() must have run the page''s own OnAction trigger');
+    end;
+
+    // Positive, arm 2: a pageextension's action on a page compiled from SOURCE in this
+    // bundle must dispatch its OWN OnAction — the trigger body lives on the extension's
+    // compiled type, not the base page's, and its member id hashes from the EXTENSION's
+    // object id (64522), not the page's (64521). A stub that fell back to "does nothing"
+    // would leave EXT-OWN-PAGE unlogged; a stub that matched the wrong trigger by name
+    // prefix would still fail DirectActionOnlyLogsItsOwnTag below.
+    [Test]
+    procedure ExtActionOnOwnPageRuns()
+    var
+        Row: Record "Pad Row";
+        HostPage: TestPage "Pad Host Page";
+    begin
+        Initialize();
+
+        HostPage.OpenEdit();
+        HostPage.ExtActionOnOwnPage.Invoke();
+        HostPage.Close();
+
+        Assert.IsTrue(Row.Get('EXT-OWN-PAGE'),
+            'Invoke() must have run the pageextension''s OnAction trigger for an action added to a source-compiled page');
+    end;
+
+    // Positive, arm 3 — the dangerous half: a pageextension's action on a page that ships
+    // PRECOMPILED inside Base Application (Item Attributes) must dispatch its OnAction too.
+    // Before the fix this raised NOTHING at Invoke() time; only this assert on the concrete
+    // effect (the logged row) catches the miss, exactly like it would silently do on real AL
+    // test code whose first step is such an action.
+    [Test]
+    procedure ExtActionOnBaseAppPageRuns()
+    var
+        Row: Record "Pad Row";
+        ItemAttrPage: TestPage "Item Attributes";
+    begin
+        Initialize();
+
+        ItemAttrPage.OpenEdit();
+        ItemAttrPage.ExtActionOnBaseAppPage.Invoke();
+        ItemAttrPage.Close();
+
+        Assert.IsTrue(Row.Get('EXT-BASEAPP-PAGE'),
+            'Invoke() must have run the pageextension''s OnAction trigger for an action added to a precompiled Base App page');
+    end;
+
+    // Negative / isolation: invoking one arm must not run either of the other two triggers.
+    // A dispatcher that resolved the FIRST OnAction-suffixed method it found on the base
+    // page type (rather than the one matching this specific member id) would pass the three
+    // positives above by coincidence while actually always running the same trigger; this
+    // test catches that.
+    [Test]
+    procedure ExtActionOnOwnPageRunsOnlyItsOwnTrigger()
+    var
+        Row: Record "Pad Row";
+        HostPage: TestPage "Pad Host Page";
+    begin
+        Initialize();
+
+        HostPage.OpenEdit();
+        HostPage.ExtActionOnOwnPage.Invoke();
+        HostPage.Close();
+
+        Assert.IsTrue(Row.Get('EXT-OWN-PAGE'), 'the invoked action must have run');
+        Assert.IsFalse(Row.Get('DIRECT'), 'invoking the extension action must not run the page''s own action');
+    end;
+}

--- a/tests/runner-extras/pageext-action-dispatch/app.json
+++ b/tests/runner-extras/pageext-action-dispatch/app.json
@@ -1,0 +1,19 @@
+{
+  "id": "7c9e3a1f-2b4d-4e6a-8f0c-1d3b5a7c9e21",
+  "name": "Runner Extras - PageExtension Action Dispatch",
+  "publisher": "AL Runner",
+  "version": "1.0.0.0",
+  "brief": "Regression for issue #1923: TestPage Invoke() of a pageextension-contributed action never dispatched its OnAction trigger.",
+  "description": "The general BC-language claim this exercises — invoking a TestPage action that was CONTRIBUTED BY A PAGEEXTENSION runs that extension's own OnAction trigger, exactly like an action declared directly on the page — is plain BC behaviour and belongs upstream in the al-language corpus (see the runner repo's bc-behavior-tests-go-upstream.md); a corpus test (tests/al-language/tests/al-language/handlers/TestPageExtensionActionInvoke*.al) was prepared alongside this fix. This suite is the runner-repo-local stopgap that pins the runner-INTERNAL defect directly, so this repo's own CI gates the fix now without waiting on the corpus PR to merge and the submodule pin to bump: RunnerPageInstance.FindTrigger (AlRunner/Patches/RunnerPageInstance.cs) resolved an action's OnAction trigger method (a) only against the base page's OWN compiled .NET type, and (b) by re-deriving the member id with IdSpace.GetMemberId(pageId, name) using the BASE PAGE's id — never the pageextension's. A pageextension's action body is compiled onto the EXTENSION's own type and its member id is hashed from the EXTENSION's id (GetPageControlFieldMap in RecordPatches.AlPageParser.cs already documents and relies on this same id-space rule for field controls), so the old code could never find it: on a SOURCE-COMPILED base page it threw RunnerOutOfScopeException misclassifying a real, dispatchable action as unsupported RunObject; on a PRECOMPILED base page (e.g. Base App 'Item Attributes') Invoke() found nothing to throw against and silently did nothing, in violation of loud-failures.md. Three tests below cover: an action declared directly on the page (control, must already have worked), an action a pageextension adds to a page compiled in THIS bundle, and an action a pageextension adds to a page that ships PRECOMPILED in Base Application. Once the upstream test lands and the pin moves, this suite's claim is fully covered there too and it may be retired.",
+  "dependencies": [],
+  "idRanges": [
+    {
+      "from": 64520,
+      "to": 64529
+    }
+  ],
+  "platform": "27.0.0.0",
+  "application": "27.0.0.0",
+  "runtime": "15.0",
+  "target": "Cloud"
+}


### PR DESCRIPTION
Closes #1923

## Root cause

`RunnerPageInstance.FindTrigger` (`AlRunner/Patches/RunnerPageInstance.cs`) resolved an action's `OnAction` trigger only against the base page's OWN compiled .NET type, re-deriving the member id via `IdSpace.GetMemberId(pageId, name)` using the **base page's** object id. A pageextension's action is compiled onto the **extension's own type** (`PageExtension{extId}`, verified by inspecting the emitted IL) and its member id hashes from the **extension's own** object id — the exact id-space rule `RecordPatches.GetPageControlFieldMap` already documents and relies on for field controls (`GetMemberId(64301, "NoteField")` is the id BC actually asks for; `GetMemberId(64300, ...)`, the base page's id, never appears). So `FindTrigger` could never find it, and the two symptoms in the issue title are one root cause surfacing two ways:

- **Source-compiled base page**: `Invoke()` threw `RunnerOutOfScopeException` (`testpage-action — the page declares no OnAction trigger...`), misclassifying a real, dispatchable action as unsupported `RunObject`.
- **Precompiled base page** (e.g. Base App "Item Attributes"): there is no compiled `Page{id}` .NET type and no emit-captured metadata for the runner to build a `RunnerPageInstance` from at all, so `TestPageFactory`/`LiveNavTestPage` fell back to a permanently no-op `MockITestAction` — `Invoke()` silently did nothing, in direct violation of `loud-failures.md`. This is the more dangerous half: nothing threw, and a test's own assert on the missing effect was the only thing that caught it.

## Fix

- `RunnerPageInstance.FindTrigger` now also searches every pageextension that extends the page (`RecordPatches.GetPageExtensionIdsForPage`, new — resolves the base page's name via AL-source-parsed pages OR, for a precompiled dependency page, its `SymbolReference.json`), each in its OWN id space. A pageextension instance (a real `NavFormExtension` subclass) is constructed lazily via the same `(ITreeObject, NavRecord)` ctor pattern the base page itself already uses, with `ParentObject` wired to the base page's form so the extension's own `Rec`/`CurrPage` getters resolve faithfully (verified via IL: both route through `ParentObject`).
- For the precompiled-base-page arm, where no live `RunnerPageInstance` exists to route an action through at all, `MockTestPage.cs`'s `LiveNavTestPage.GetAction` gets one more chance (`RunnerPageInstance.TryRaiseExtensionOnlyAction` / new `ExtensionOnlyTestAction`) to dispatch a pageextension-owned action directly, constructing the extension instance standalone (no base `ParentObject` to wire — a trigger that only touches its own locals still runs faithfully; one that reads `Rec`/`CurrPage` NREs loudly rather than silently doing nothing). An action id that genuinely belongs to the unbuildable precompiled base page itself is untouched — same pre-existing graceful fallback as before, deliberately out of this issue's scope.

## Tests

**Runner-side (`tests/runner-extras/pageext-action-dispatch/`)** — pins the runner-internal defect directly so this repo's CI gates the fix without waiting on the corpus pin bump. Mirrors the issue's own three-arm repro:
- `DirectActionRuns` — control: an action declared directly on the page (unaffected by this bug).
- `ExtActionOnOwnPageRuns` / `ExtActionOnOwnPageRunsOnlyItsOwnTrigger` — a pageextension's action on a page compiled from source in the same bundle.
- `ExtActionOnBaseAppPageRuns` — a pageextension's action on Base Application's precompiled "Item Attributes" page (the silent-no-op arm).

RED (before the fix): `ExtActionOnOwnPageRuns`/`ExtActionOnOwnPageRunsOnlyItsOwnTrigger` threw the misclassified `RunnerOutOfScopeException`; `ExtActionOnBaseAppPageRuns` raised nothing at `Invoke()` and failed only on its own `Assert.IsTrue` against the missing log row. GREEN (after): all 4 pass, cold and warm-cache.

**Corpus (BC-behaviour half)** — "invoking a pageextension-contributed action runs its OnAction" is plain BC behaviour per `bc-behavior-tests-go-upstream.md`, so the proving test for the own-page arm is upstream: [StefanMaron/BusinessCentral.AL.Language.Tests#56](https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/56), companion to the existing `TestPageActionInvoke` suite. Verified locally against the runner by pointing the bundle run at the branch that PR is built from (same object shapes as this PR's own runner-extras suite) — not merged/pin-bumped here, per the submodule rules.

## Verification run

`dotnet test AlRunner.Tests` — 752 passed, 37 skipped, 1 pre-existing unrelated failure (`BcCompilerSharedReferenceMemoTests.AddingAPackageToAScannedDir_ForcesARebuild`, confirmed failing identically on unmodified `main` via `git stash`).