### PR TITLE
fix(transactions): a failed Delete() no longer wipes rows a nested BC transaction already committed

### DIFF
--- a/AlRunner/Infrastructure/NclCecilRewrite.cs
+++ b/AlRunner/Infrastructure/NclCecilRewrite.cs
@@ -1688,6 +1688,56 @@ public static class NclCecilRewrite
             Console.Error.WriteLine("[Cecil] Rewrote SessionTransactionExtensions.Rollback → row-store rollback");
         }
 
+        // 8g. SessionTransactionExtensions.EndTransaction / EndTransactionWorldAndTransaction —
+        //     see RecordPatches.NoteTransactionEnd.
+        //
+        //     AL Runner#1946: BC's own APIs wrap their internal work in an explicit nested
+        //     transaction (decompiled, unmodified Ncl body of the static overload of
+        //     NavXmlPort.Import — the one the corpus proved this against:
+        //     Session.BeginTransaction(); ...; finally { Session.EndTransaction(commit); } for
+        //     DataError.ThrowError, or Session.BeginTransactionWorldAndTransaction(); ...;
+        //     finally { Session.EndTransactionWorldAndTransaction(commit); } for
+        //     DataError.TrapError — AL's compiler picks TrapError whenever the call's boolean
+        //     result is captured into a variable, e.g. `Ok := XmlPort.Import(...)`, which is
+        //     the common, idiomatic AL shape and the one that actually reaches this bug).
+        //     A real commit there is exactly as durable, from AL's point of view, as an
+        //     explicit Commit() statement — but only MarkCommitPoint's two existing call sites
+        //     (AL's own Commit() and the per-test isolation boundary) ever advanced the
+        //     rollback baseline, so a LATER, unrelated asserterror in the caller rolled all the
+        //     way back to test-method start, wiping out rows a nested BC API had already
+        //     committed. Reproducible with no XmlPort involved at all — see
+        //     RecordPatches.NoteTransactionEnd's doc comment.
+        //
+        //     Prepend, not replace: the original bodies (SessionTransactionManager.EndTransaction
+        //     / EndTransactionWorldAndTransaction) already run safely today (every passing
+        //     XmlPort Export/Import test goes through one of them), so this only adds the
+        //     missing commit-point bookkeeping alongside them.
+        {
+            var sessTxType2 = asm.MainModule.Types
+                .FirstOrDefault(t => t.FullName == "Microsoft.Dynamics.Nav.Runtime.SessionTransactionExtensions")
+                ?? throw new InvalidOperationException(
+                    "[Cecil] SessionTransactionExtensions type not found — Ncl shape changed; do not commit");
+
+            var noteTransactionEndHelper = typeof(AlRunner.Patches.RecordPatches).GetMethod(
+                nameof(AlRunner.Patches.RecordPatches.NoteTransactionEnd),
+                BindingFlags.Public | BindingFlags.Static)
+                ?? throw new InvalidOperationException(
+                    "[Cecil] RecordPatches.NoteTransactionEnd not found");
+
+            foreach (var methodName in new[] { "EndTransaction", "EndTransactionWorldAndTransaction" })
+            {
+                var endTransactionMethod = sessTxType2.Methods
+                    .FirstOrDefault(m => m.Name == methodName && m.IsStatic
+                                         && m.Parameters.Count == 2 && m.HasBody
+                                         && m.Parameters[1].ParameterType.FullName == "System.Boolean")
+                    ?? throw new InvalidOperationException(
+                        $"[Cecil] SessionTransactionExtensions.{methodName}(NavSession, bool) not found — Ncl shape changed; do not commit");
+
+                PrependStaticCall(asm.MainModule, endTransactionMethod, noteTransactionEndHelper, argSlots: 2);
+            }
+        }
+
+
         // 9b. TreeHandler.get_Session — see BcRuntime.TreeHandler_get_Session.
         //     The real body is `=> session`, a readonly field set in the ctor from
         //     `parentHandler.session ?? (hostObject as NavSession)`. The runner's root tree

--- a/AlRunner/Patches/RecordPatches.TransactionSnapshot.cs
+++ b/AlRunner/Patches/RecordPatches.TransactionSnapshot.cs
@@ -19,6 +19,11 @@
 //   made before it in place. Green either way for a test that only checks the error text —
 //   and silently wrong for one that checks what is in the table afterwards.
 //
+//   BC's own APIs establish additional, NESTED commit points too — a real
+//   Session.EndTransaction(commit: true) (or EndTransactionWorldAndTransaction) inside a BC
+//   API is exactly as durable, from AL's point of view, as an explicit Commit() statement.
+//   See NoteTransactionEnd below (AlRunner#1946).
+//
 // HOW IT IS DONE HERE
 //   The runner's tables are BC TempTableDataProviders held in _dataAccessByTable, and
 //   RecordPatches.InstallBaseline already knows how to copy rows out of them and put rows
@@ -48,6 +53,46 @@ public static partial class RecordPatches
     /// Called at each test-method boundary and from AL's <c>Commit()</c>.
     /// </summary>
     public static void MarkCommitPoint() => _txCommitPoint.Clear();
+
+    /// <summary>
+    /// Prepended to SessionTransactionExtensions.EndTransaction(NavSession, bool commit) and
+    /// .EndTransactionWorldAndTransaction(NavSession, bool commit) — see AlRunner#1946.
+    ///
+    /// BC's own APIs run their internal work inside an explicit nested transaction. The
+    /// static overload of <c>NavXmlPort.Import</c> is one — decompiled, unmodified Ncl body:
+    /// <c>Session.BeginTransaction(); ...; finally { Session.EndTransaction(commit); }</c> for
+    /// <c>DataError.ThrowError</c>, or <c>Session.BeginTransactionWorldAndTransaction(); ...;
+    /// finally { Session.EndTransactionWorldAndTransaction(commit); }</c> for
+    /// <c>DataError.TrapError</c>. AL's compiler picks <c>TrapError</c> whenever the call's
+    /// boolean result is captured into a variable — e.g. <c>Ok := XmlPort.Import(...)</c> —
+    /// which is the common, idiomatic AL shape, so both extension methods need the hook, not
+    /// just the more obviously-named one.
+    ///
+    /// A real <c>commit == true</c> there is exactly as durable, from AL's point of view, as
+    /// an explicit <c>Commit()</c> statement: a later, unrelated <c>asserterror</c> in the
+    /// CALLER must not roll back work an inner API already committed.
+    ///
+    /// Before this hook, only AL's own <c>Commit()</c> and the per-test isolation boundary
+    /// called <see cref="MarkCommitPoint"/>, so <see cref="RollbackToCommitPoint"/> rolled
+    /// all the way back to test-method start on ANY later trapped error — including rows a
+    /// nested BC API (like XmlPort.Import) had already committed inside its own transaction.
+    /// Observably: <c>XmlPort.Import(id, Stream, Rec)</c> inserts a row, a LATER, unrelated
+    /// statement in the same test method throws (even caught by <c>asserterror</c>), and the
+    /// earlier insert vanished — reproducible with no XmlPort involved at all, just a plain
+    /// <c>Record.Insert()</c> followed by an unrelated failing <c>Record.Delete()</c>.
+    ///
+    /// This must NOT fire for a plain <c>Record.Insert/Modify/Delete/Rename</c> call — those
+    /// never call <c>EndTransaction</c> themselves (see <see cref="ALDatabasePatches.NoteRecordWrite"/>);
+    /// they just participate in whatever transaction is already open, ended by the test
+    /// framework's own boundary or an explicit AL <c>Commit()</c>. So this only ever marks a
+    /// commit point for a real nested-transaction completion, not for every write — the
+    /// corpus's <c>OnModify_Throws_ValueNotModified</c> (an uncommitted plain
+    /// <c>Insert()</c> IS rolled back by a later trapped error) still holds.
+    /// </summary>
+    public static void NoteTransactionEnd(object? session, bool commit)
+    {
+        if (commit) MarkCommitPoint();
+    }
 
     /// <summary>
     /// Snapshot the record's table if this is its first write since the last commit point.

--- a/tests/expectations/count-baseline/test-count-baseline.json
+++ b/tests/expectations/count-baseline/test-count-baseline.json
@@ -7,8 +7,8 @@
     },
     "runner-extras": {
       "tests": {
-        "default": 141,
-        "byBcVersion": { "27.0": 135, "27.3": 135, "27.5": 135 }
+        "default": 142,
+        "byBcVersion": { "27.0": 136, "27.3": 136, "27.5": 136 }
       },
       "appGroups": {
         "default": 28,

--- a/tests/runner-extras/standalone-suites/xmlport-cluster-hooks-1800/XhcTests.Codeunit.al
+++ b/tests/runner-extras/standalone-suites/xmlport-cluster-hooks-1800/XhcTests.Codeunit.al
@@ -280,16 +280,80 @@ codeunit 62182 "XHC Tests"
         if not Ok then
             Error('Static XmlPort.Import(Integer, InStream, Record) reported failure. LastError=%1', GetLastErrorText());
 
-        // Verify via a fresh Get() rather than deleting TargetRow directly — see
-        // AL Runner#1946 (filed while writing this test): whether this call succeeds was
-        // observed to depend on an unrelated LATER statement's shape in the same procedure
-        // (Get()-then-read vs a bare Delete() on the same variable), which is a separate,
-        // pre-existing runner gap unrelated to the #1883 fix this test guards. Get()-then-read
-        // is the confirmed-reliable shape.
+        // Verify via a fresh Get() rather than deleting TargetRow directly — see AL Runner#1946
+        // (filed while writing this test, resolved below in
+        // StaticImport_ThenUnrelatedFailedDelete_DoesNotWipeCommittedRow). Static
+        // XmlPort.Import(Integer, InStream, Record) never populates the GIVEN record
+        // variable's own fields -- confirmed against real BC (corpus PR
+        // StefanMaron/BusinessCentral.AL.Language.Tests#57,
+        // XmlPort_Import_StaticWithRecord_GivenVariableUnchangedWithoutExplicitGet, green on
+        // BC 27.5 and 28.3): the record argument only ever seeds SetTableView's row filter,
+        // never the reverse. A bare Delete() on the still-unpopulated TargetRow (key still at
+        // its Init() default) correctly throws "does not exist" on BOTH real BC and the
+        // runner -- that part of #1946's original reproducer was never a bug. Get()-then-read
+        // is simply the only way to read back a row a static Import(Record) call inserted.
         if not TargetRow.Get(103) then
             Error('Static XmlPort.Import(Integer, InStream, Record) reported success but Entry No. 103 was not actually inserted.');
         if TargetRow.Name <> 'First' then
             Error('Static XmlPort.Import(Integer, InStream, Record) inserted the wrong Name: %1', TargetRow.Name);
+        TargetRow.Delete();
+    end;
+
+    // The ACTUAL #1946 bug, isolated: a Delete() that legitimately fails (its own record
+    // variable's primary key is still at its Init() default, matching no row) must have NO
+    // side effect on the database -- but the runner's write-transaction rollback machinery
+    // (RecordPatches.TransactionSnapshot.cs) captured its "roll back to here" snapshot of
+    // this table BEFORE Import's own row-201 insert had happened (taken by Import's OWN
+    // internal Row_.Insert(), the first write since the last commit point), and NOTHING ever
+    // advanced that commit point past the insert -- so the later failed Delete()'s rollback
+    // (NavMethodScope.AssertError -> session.Rollback()) restored the table to its
+    // BEFORE-Import state, silently deleting the row Import had already, durably committed.
+    // Reproducible with no XmlPort involved at all: a plain Record.Insert() followed by an
+    // unrelated failing Record.Delete() shows the SAME wipe on an uncommitted plain write
+    // (matching real, INTENTIONAL BC behaviour -- see
+    // TestTriggerRollback.OnModify_Throws_ValueNotModified in the corpus) -- what made this
+    // one a genuine bug is that XmlPort.Import runs its own internal
+    // Session.BeginTransaction()/EndTransaction(commit: true) (decompiled, unmodified Ncl
+    // body), which real BC treats as a real, nested commit point that survives a later,
+    // unrelated rollback. The fix hooks
+    // SessionTransactionExtensions.EndTransaction/EndTransactionWorldAndTransaction (AL's
+    // compiler picks the WorldAndTransaction overload whenever the call's boolean result is
+    // captured into a variable, e.g. `Ok := XmlPort.Import(...)` -- the common, idiomatic
+    // shape, and the one that actually reaches this bug) to advance the runner's own commit
+    // point on every real `commit: true` completion, not just AL's own Commit() statement.
+    [Test]
+    procedure StaticImport_ThenUnrelatedFailedDelete_DoesNotWipeCommittedRow()
+    var
+        TargetRow: Record "XHC Row";
+        NeverTouched: Record "XHC Row";
+        TempBlob: Codeunit "Temp Blob";
+        DocumentOutStream: OutStream;
+        DocumentInStream: InStream;
+        Ok: Boolean;
+    begin
+        // Entry No. 201 is deliberately disjoint from every other Entry No. used elsewhere in
+        // this codeunit (1, 101, 103) -- see the "legitimate duplicate-key failure" comment
+        // above InstanceExportImportRoundTrip_RealBcBody_NoThrow.
+        TempBlob.CreateOutStream(DocumentOutStream);
+        DocumentOutStream.WriteText('<?xml version="1.0" encoding="utf-8"?><root><Row><EntryNo>201</EntryNo><RowName>Committed</RowName></Row></root>');
+        TempBlob.CreateInStream(DocumentInStream);
+
+        Ok := XmlPort.Import(62181, DocumentInStream, TargetRow);
+        if not Ok then
+            Error('Static XmlPort.Import(Integer, InStream, Record) reported failure ahead of the unrelated-delete assertion this test exists to prove.');
+
+        // NeverTouched is a completely separate, never-Get()'d record variable of the SAME
+        // table -- its own primary key is still at Init()'s default (0), so Delete() on it
+        // legitimately throws "does not exist". That failure itself is correct, expected BC
+        // behaviour (see the comment on StaticImport_WithRecordArg_RealBcBody_NoThrow above)
+        // -- the claim this test proves is narrower: that failure must not touch row 201.
+        asserterror NeverTouched.Delete();
+
+        if not TargetRow.Get(201) then
+            Error('The row XmlPort.Import(Integer, InStream, Record) committed did not survive an unrelated, legitimately-failing Delete() elsewhere.');
+        if TargetRow.Name <> 'Committed' then
+            Error('Row 201 survived the unrelated failed Delete() but with the wrong Name: %1', TargetRow.Name);
+
         TargetRow.Delete();
     end;
 }


### PR DESCRIPTION
Closes #1946

## Root cause

Not what the issue's own reproducer suggested. `XmlPort.Import(id, InStream, Record)`'s given record variable is genuinely never populated by the call — confirmed against real BC via [corpus PR #57](https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/57), which went GREEN on both BC 27.5 and 28.3 for the assertion "the given record variable stays at its Init() defaults, a bare `Delete()` on it throws `does not exist`". That part of the original reproducer was never a bug.

The real, and much more serious, bug: that same "legitimately fails" `Delete()` was silently **deleting an unrelated, already-committed row** as a side effect. Reproducible with no XmlPort at all — a plain `Record.Insert()` followed by an unrelated failing `Record.Delete()` shows the identical wipe.

Traced it to `RecordPatches.TransactionSnapshot.cs`, the write-transaction-rollback mechanism backing AL's "an error rolls the database back to the last commit" contract. It only ever advanced its commit point from AL's own `Commit()` statement and the per-test isolation boundary. BC's own APIs establish additional, *nested* commit points internally — `Session.BeginTransaction()` / `Session.EndTransaction(commit: true)` (decompiled, unmodified `Ncl.dll` body of `NavXmlPort.Import`'s static overload) — and AL's compiler picks the `...WorldAndTransaction` sibling overloads whenever the call's boolean result is captured into a variable, which is the common `Ok := XmlPort.Import(...)` shape and the one that actually reaches this bug. Nothing told the runner's commit-point tracking about those nested completions, so a later, unrelated trapped error rolled all the way back to test-method start, wiping out rows a nested BC transaction had already, durably committed.

## Fix

Prepend a hook to `SessionTransactionExtensions.EndTransaction` and `.EndTransactionWorldAndTransaction` that advances the commit point whenever `commit == true`, exactly as AL's own `Commit()` statement already does. `AlRunner/Infrastructure/NclCecilRewrite.cs` / `AlRunner/Patches/RecordPatches.TransactionSnapshot.cs`.

## Tests

- `tests/runner-extras/standalone-suites/xmlport-cluster-hooks-1800/XhcTests.Codeunit.al`: new `StaticImport_ThenUnrelatedFailedDelete_DoesNotWipeCommittedRow` — RED before the fix (row vanishes), GREEN after (row survives an unrelated failed `Delete()` elsewhere). Also updates the stale comment on the neighboring test that had (incorrectly) attributed this to "Get() vs bare Delete() codegen".
- Upstream corpus: [`StefanMaron/BusinessCentral.AL.Language.Tests#57`](https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/57) — `XmlPort_Import_StaticWithRecord_GivenVariableUnchangedWithoutExplicitGet`, green on real BC 27.5 and 28.3. This proves the "given record variable is never auto-populated" behavior; it does not by itself prove the data-loss fix (that's runner-only behavior, not a BC-behaviour claim, so it stays in `runner-extras`).
- Full `tests/al-language` corpus: 2096/2096 pass, no regressions (this change touches a broadly-used transaction primitive).
- `dotnet test AlRunner.Tests`: 754 passed, 1 pre-existing unrelated failure (`BcCompilerSharedReferenceMemoTests.AddingAPackageToAScannedDir_ForcesARebuild`, confirmed failing identically on the tree with this fix reverted — a package-cache memo test, nothing to do with transactions).

## Test plan

- [x] RED confirmed before the fix (new runner-extras test fails; row is wiped)
- [x] GREEN confirmed after the fix
- [x] Full al-language corpus green (2096/2096)
- [x] Upstream corpus PR opened and green on both BC legs
- [x] Pre-existing, unrelated `AlRunner.Tests` failure confirmed not caused by this change