### PR TITLE
perf(watch): incremental recompile for a single content-edited object

### DIFF
--- a/AlRunner.Tests/BcCompilerIncrementalTests.cs
+++ b/AlRunner.Tests/BcCompilerIncrementalTests.cs
@@ -1,0 +1,301 @@
+// BcCompilerIncrementalTests — RED/GREEN proof for issue #1902.
+//
+// #1902: every --watch cycle called the SAME Emit() a one-shot run uses — full re-parse,
+// re-bind, re-codegen of every object, every save. BcCompiler.TryEmitIncremental (see
+// BcCompiler.Incremental.cs) is the fix: an edit to one already-tracked, id-bearing object's
+// CONTENT recompiles only that object via BC's own Compilation.CreateForRad, reusing cached C#
+// for everything else, and the final result must be indistinguishable from a full rebuild of
+// the same source tree.
+//
+// What each test proves (tdd.md: must prove, not just pass):
+//   - Proportional: editing ONE codeunit leaves every OTHER object's emitted C# text BYTE-
+//     IDENTICAL to what the ORIGINAL full compile produced — not just "still compiles", the
+//     actual cached bytes are reused. A no-op fast path that quietly re-emitted everything
+//     would still pass a weaker "same object count" assertion; it would NOT pass this one.
+//   - Correct: the incremental result's object set and C# for the CHANGED object matches a
+//     completely independent full rebuild of the SAME post-edit source tree, byte for byte.
+//   - Multi-cycle: three sequential incremental cycles, each touching a DIFFERENT object, must
+//     all be reflected in the final result — proving the baseline MERGE (not just "trust the
+//     delta compile's own conversion") described in BcCompiler.Incremental.cs's header comment.
+//     Without that merge this class of bug is silent: cycle 2 would compile fine but quietly
+//     forget cycle 1's edit the next time anything referencing it needed a rebuild.
+//   - Every disqualifying condition (no baseline yet, a file added, app.json changed, an
+//     id-less object kind touched) returns null (never a stale result) and the caller-visible
+//     contract — an ordinary Emit(..., trackIncrementalBaseline: true) — still produces the
+//     correct answer.
+using Xunit;
+using AlRunner;
+
+namespace AlRunner.Tests;
+
+[Collection(BcEngineCollection.Name)]
+public sealed class BcCompilerIncrementalTests : IDisposable
+{
+    private readonly string _root;
+    private readonly BcEngineFixture _engine;
+
+    public BcCompilerIncrementalTests(BcEngineFixture engine)
+    {
+        _engine = engine;
+        _root = Path.Combine(Path.GetTempPath(), "al-runner-incremental-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { /* best-effort cleanup */ }
+    }
+
+    private void WriteAl(string fileName, string content) => File.WriteAllText(Path.Combine(_root, fileName), content);
+
+    private static string CodeunitSrc(int id, string name, int returnValue) => $$"""
+        codeunit {{id}} "{{name}}"
+        {
+            procedure GetValue(): Integer
+            begin
+                exit({{returnValue}});
+            end;
+        }
+        """;
+
+    private static Dictionary<string, string> ByName(BcEmitOutput output)
+        => output.Sources.ToDictionary(s => s.Name, s => s.Code);
+
+    [SkippableFact]
+    public void TryEmitIncremental_EditingOneCodeunit_LeavesOthersByteIdentical_AndMatchesFullRebuild()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready, _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        WriteAl("A.al", CodeunitSrc(90210, "Incr A", 1));
+        WriteAl("B.al", CodeunitSrc(90211, "Incr B", 2));
+        WriteAl("C.al", CodeunitSrc(90212, "Incr C", 3));
+
+        var compiler = new BcCompiler();
+        var baselineOut = compiler.Emit(new[] { _root }, "IncrModule", trackIncrementalBaseline: true);
+        Assert.Empty(baselineOut.Diagnostics);
+        var baselineByName = ByName(baselineOut);
+        Assert.Equal(3, baselineByName.Count);
+
+        // Edit ONLY B's content.
+        WriteAl("B.al", CodeunitSrc(90211, "Incr B", 999));
+
+        var incrOut = compiler.TryEmitIncremental(new[] { _root }, "IncrModule", appRootDir: null, out var fallbackReason);
+        Assert.True(incrOut != null, $"expected the fast path to apply; fell back instead: {fallbackReason}");
+        var incrByName = ByName(incrOut!);
+
+        // Proportional: A and C's C# is byte-identical to the ORIGINAL full compile — proves
+        // they were served from cache, not regenerated.
+        Assert.Equal(baselineByName["Incr A"], incrByName["Incr A"]);
+        Assert.Equal(baselineByName["Incr C"], incrByName["Incr C"]);
+        // B actually changed.
+        Assert.NotEqual(baselineByName["Incr B"], incrByName["Incr B"]);
+        Assert.Contains("999", incrByName["Incr B"]);
+
+        // Correct: matches an independent full rebuild of the SAME post-edit tree.
+        var freshOut = new BcCompiler().Emit(new[] { _root }, "IncrModuleFresh");
+        var freshByName = ByName(freshOut);
+        Assert.Equal(freshByName["Incr A"], incrByName["Incr A"]);
+        Assert.Equal(freshByName["Incr B"], incrByName["Incr B"]);
+        Assert.Equal(freshByName["Incr C"], incrByName["Incr C"]);
+    }
+
+    [SkippableFact]
+    public void TryEmitIncremental_TouchWithIdenticalBytes_ReplaysLastOutputAtZeroCost()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready, _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        WriteAl("A.al", CodeunitSrc(90220, "Touch A", 1));
+        var compiler = new BcCompiler();
+        var baselineOut = compiler.Emit(new[] { _root }, "TouchModule", trackIncrementalBaseline: true);
+
+        // Touch: rewrite the SAME bytes (a save with no actual edit, or an mtime-only touch).
+        WriteAl("A.al", CodeunitSrc(90220, "Touch A", 1));
+
+        var incrOut = compiler.TryEmitIncremental(new[] { _root }, "TouchModule", appRootDir: null, out var fallbackReason);
+        Assert.True(incrOut != null, $"expected the fast path on an identical-bytes touch; fell back: {fallbackReason}");
+        Assert.Same(baselineOut, incrOut);
+    }
+
+    [SkippableFact]
+    public void TryEmitIncremental_ThreeSequentialCycles_EachTouchingADifferentObject_AllEditsSurviveInFinalResult()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready, _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        WriteAl("A.al", CodeunitSrc(90230, "Chain A", 1));
+        WriteAl("B.al", CodeunitSrc(90231, "Chain B", 2));
+        WriteAl("C.al", CodeunitSrc(90232, "Chain C", 3));
+
+        var compiler = new BcCompiler();
+        compiler.Emit(new[] { _root }, "ChainModule", trackIncrementalBaseline: true);
+
+        // Cycle 1: edit A.
+        WriteAl("A.al", CodeunitSrc(90230, "Chain A", 111));
+        var out1 = compiler.TryEmitIncremental(new[] { _root }, "ChainModule", appRootDir: null, out var reason1);
+        Assert.True(out1 != null, $"cycle 1 fell back: {reason1}");
+
+        // Cycle 2: edit B (a DIFFERENT object — this is the case that silently loses cycle 1's
+        // edit if the next baseline is built from the delta compile alone instead of merged).
+        WriteAl("B.al", CodeunitSrc(90231, "Chain B", 222));
+        var out2 = compiler.TryEmitIncremental(new[] { _root }, "ChainModule", appRootDir: null, out var reason2);
+        Assert.True(out2 != null, $"cycle 2 fell back: {reason2}");
+
+        // Cycle 3: edit C.
+        WriteAl("C.al", CodeunitSrc(90232, "Chain C", 333));
+        var out3 = compiler.TryEmitIncremental(new[] { _root }, "ChainModule", appRootDir: null, out var reason3);
+        Assert.True(out3 != null, $"cycle 3 fell back: {reason3}");
+
+        var finalByName = ByName(out3!);
+        Assert.Contains("111", finalByName["Chain A"]);
+        Assert.Contains("222", finalByName["Chain B"]);
+        Assert.Contains("333", finalByName["Chain C"]);
+
+        // Matches an independent full rebuild of the final tree, object for object.
+        var freshOut = new BcCompiler().Emit(new[] { _root }, "ChainModuleFresh");
+        var freshByName = ByName(freshOut);
+        Assert.Equal(freshByName["Chain A"], finalByName["Chain A"]);
+        Assert.Equal(freshByName["Chain B"], finalByName["Chain B"]);
+        Assert.Equal(freshByName["Chain C"], finalByName["Chain C"]);
+    }
+
+    [SkippableFact]
+    public void TryEmitIncremental_CrossObjectCall_UnmodifiedCallerAutomaticallySeesCalleesNewBehaviour()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready, _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        WriteAl("Callee.al", CodeunitSrc(90240, "Callee X", 10));
+        WriteAl("Caller.al", """
+            codeunit 90241 "Caller X"
+            {
+                procedure CallIt(): Integer
+                var
+                    Callee: Codeunit "Callee X";
+                begin
+                    exit(Callee.GetValue());
+                end;
+            }
+            """);
+
+        var compiler = new BcCompiler();
+        var baselineOut = compiler.Emit(new[] { _root }, "CrossCallModule", trackIncrementalBaseline: true);
+        var baselineByName = ByName(baselineOut);
+
+        // Only the CALLEE changes — the caller's file is never touched.
+        WriteAl("Callee.al", CodeunitSrc(90240, "Callee X", 20));
+
+        var incrOut = compiler.TryEmitIncremental(new[] { _root }, "CrossCallModule", appRootDir: null, out var fallbackReason);
+        Assert.True(incrOut != null, $"expected the fast path to apply; fell back instead: {fallbackReason}");
+        var incrByName = ByName(incrOut!);
+
+        // Caller's C# is untouched — served from cache, byte-identical.
+        Assert.Equal(baselineByName["Caller X"], incrByName["Caller X"]);
+        // Callee's C# reflects the edit.
+        Assert.NotEqual(baselineByName["Callee X"], incrByName["Callee X"]);
+        Assert.Contains("20", incrByName["Callee X"]);
+    }
+
+    [SkippableFact]
+    public void TryEmitIncremental_NoBaselineYet_FallsBack()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready, _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        WriteAl("A.al", CodeunitSrc(90250, "NoBaseline A", 1));
+        var compiler = new BcCompiler();
+        var result = compiler.TryEmitIncremental(new[] { _root }, "NeverEmittedModule", appRootDir: null, out var reason);
+        Assert.Null(result);
+        Assert.Contains("no incremental baseline", reason, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [SkippableFact]
+    public void TryEmitIncremental_FileAdded_FallsBack_AndSubsequentFullRebuildIsStillCorrect()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready, _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        WriteAl("A.al", CodeunitSrc(90260, "AddA A", 1));
+        var compiler = new BcCompiler();
+        compiler.Emit(new[] { _root }, "AddModule", trackIncrementalBaseline: true);
+
+        WriteAl("B.al", CodeunitSrc(90261, "AddA B", 2));
+
+        var incrResult = compiler.TryEmitIncremental(new[] { _root }, "AddModule", appRootDir: null, out var reason);
+        Assert.Null(incrResult);
+        Assert.Contains("added/removed/renamed", reason, StringComparison.OrdinalIgnoreCase);
+
+        // The caller's contract: fall back to Emit(), which must still produce the correct,
+        // complete result — never silently missing the added object.
+        var fullOut = compiler.Emit(new[] { _root }, "AddModule", trackIncrementalBaseline: true);
+        var byName = ByName(fullOut);
+        Assert.Equal(2, byName.Count);
+        Assert.True(byName.ContainsKey("AddA A"));
+        Assert.True(byName.ContainsKey("AddA B"));
+    }
+
+    [SkippableFact]
+    public void TryEmitIncremental_AppJsonChanged_FallsBack()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready, _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        WriteAl("A.al", CodeunitSrc(90270, "ManifestA A", 1));
+        File.WriteAllText(Path.Combine(_root, "app.json"), """
+            { "id": "b1a2b3c4-d5e6-4f70-8a91-b2c3d4e5f710", "name": "IncrManifest", "publisher": "Test",
+              "version": "1.0.0.0", "idRanges": [ { "from": 90270, "to": 90279 } ], "runtime": "14.0" }
+            """);
+
+        var compiler = new BcCompiler();
+        compiler.Emit(new[] { _root }, "ManifestModule", appRootDir: _root, trackIncrementalBaseline: true);
+
+        // Edit A's content AND bump the manifest version in the same cycle.
+        WriteAl("A.al", CodeunitSrc(90270, "ManifestA A", 2));
+        File.WriteAllText(Path.Combine(_root, "app.json"), """
+            { "id": "b1a2b3c4-d5e6-4f70-8a91-b2c3d4e5f710", "name": "IncrManifest", "publisher": "Test",
+              "version": "1.0.0.1", "idRanges": [ { "from": 90270, "to": 90279 } ], "runtime": "14.0" }
+            """);
+
+        var result = compiler.TryEmitIncremental(new[] { _root }, "ManifestModule", appRootDir: _root, out var reason);
+        Assert.Null(result);
+        Assert.Contains("app.json", reason, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [SkippableFact]
+    public void TryEmitIncremental_IdlessObjectKindTouched_FallsBack()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready, _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        WriteAl("A.al", CodeunitSrc(90280, "IfaceHost A", 1));
+        WriteAl("IFace.al", """
+            interface "Incr IFace"
+            {
+                procedure DoIt(): Integer;
+            }
+            """);
+
+        var compiler = new BcCompiler();
+        var baselineOut = compiler.Emit(new[] { _root }, "IfaceModule", trackIncrementalBaseline: true);
+        Assert.Empty(baselineOut.Diagnostics);
+
+        // Edit the interface itself — an id-less kind, must always fall back.
+        WriteAl("IFace.al", """
+            interface "Incr IFace"
+            {
+                procedure DoIt(): Integer;
+                procedure DoItAgain(): Integer;
+            }
+            """);
+
+        var result = compiler.TryEmitIncremental(new[] { _root }, "IfaceModule", appRootDir: null, out var reason);
+        Assert.Null(result);
+        // BC's Compilation.GetDeclaredApplicationObjectSymbols() (ISymbolWithId, non-nullable
+        // Id) never returns an interface at all, so RecordIncrementalBaseline has no (Kind,Id)
+        // to track it under — the baseline correctly reports the file as untracked rather than
+        // classifying it "id-less". Either wording is a safe outcome: what matters is that an
+        // id-less kind can NEVER take the fast path.
+        Assert.True(
+            reason.Contains("id-less", StringComparison.OrdinalIgnoreCase)
+                || reason.Contains("not tracked", StringComparison.OrdinalIgnoreCase),
+            $"expected a safe, explained fallback; got: {reason}");
+
+        // The caller's contract still holds: a full rebuild after the fallback is correct.
+        var fullOut = compiler.Emit(new[] { _root }, "IfaceModule", trackIncrementalBaseline: true);
+        Assert.Empty(fullOut.Diagnostics);
+        Assert.Equal(1, fullOut.Sources.Count); // only the codeunit emits C#; the interface never does.
+    }
+}

--- a/AlRunner/BcCompiler.Incremental.cs
+++ b/AlRunner/BcCompiler.Incremental.cs
@@ -1,0 +1,556 @@
+// BcCompiler.Incremental — --watch's fast path (issue #1902).
+//
+// Every prior --watch cycle called the SAME BcCompiler.Emit a one-shot run uses: parse every
+// .al file, bind the WHOLE module, generate C# for every object, every cycle — so a one-line
+// edit to one codeunit costs the same as a cold build. Measured on a 7,053-file app: 761–862s
+// per save.
+//
+// BC's own compiler exposes the fix: Compilation.CreateForRad — the same public factory BC's
+// own RAD (VS Code F5 "publish") uses. Given a change model (which objects were Added/
+// Modified/Removed) and the PREVIOUS cycle's compiled symbol picture (a
+// SymbolReference.ModuleDefinition — the same shape SymbolJsonWriter already produces for
+// cross-app dependency resolution), it binds and generates C# for ONLY the touched objects,
+// resolving everything else from the baseline instead of re-parsing/re-binding it.
+//
+// This file wires that in, restricted to the single case that can be proven safe without also
+// solving the much larger "hot-swap a live .NET module" problem BC's own service-tier RAD
+// solves at runtime (out of scope here — see the class doc below):
+//
+//   A file that already declared exactly one id-bearing object (Codeunit/Table/Page/Report/
+//   XmlPort/Query/Enum/TableExtension/PageExtension/ReportExtension/EnumExtension/
+//   PermissionSet/PermissionSetExtension) had its CONTENT edited — same (Kind,Id,Name) as
+//   before. Everything else (add/remove/rename any file, an id-less object kind such as
+//   interface/controladdin/profile/pagecustomization/profileextension/entitlement, an app.json
+//   or dependency-set change, more/fewer than one object in a touched file, ANY diagnostic or
+//   exception from the delta compile) falls back to the ordinary, already-correct, whole-module
+//   Emit() — never a stale or wrong result, just not accelerated for that cycle.
+//
+// Why this is safe to reuse UNCHANGED cached C# for every object that was not touched
+// -----------------------------------------------------------------------------------
+// Confirmed by inspecting BC's own generated C# (`al-runner --dump-csharp`): a call from one AL
+// object to another does NOT compile to a direct C# type reference. It compiles to
+// `new NavCodeunitHandle(this, <object id>).Target.Invoke(<memberId>, args)` — an ID + a
+// deterministic hash of the called procedure's name+signature, computed independently at BOTH
+// the call site and the callee's own OnInvoke dispatch switch. Neither side's C# encodes the
+// other's class name. So:
+//   - An unmodified caller's cached C# is unaffected by ANY change to a callee's shape — it
+//     dispatches by (object id, member hash) at RUNTIME, against whichever type is CURRENTLY
+//     registered for that id in the SAME final assembly this cycle produces (built from the
+//     UNION of every object's C# — changed objects freshly generated, everything else served
+//     from the cache). It automatically sees the callee's NEW behaviour without being touched.
+//   - A genuinely breaking edit (e.g. a renamed procedure an unmodified caller still calls by
+//     its old name) is NOT a silent wrong answer: the caller's unchanged member-hash no longer
+//     matches any case in the callee's regenerated OnInvoke switch, so the call throws
+//     NavNCLMissingMethodException at the call site — loud, not silent, satisfying
+//     loud-failures.md. It is also not the common case: it is a signature change to something an
+//     UNMODIFIED file calls, since a MODIFIED caller would already have its own fresh call site
+//     hash from the classify step below.
+//   - The final union of cached + freshly-generated C# still goes through ONE ordinary Roslyn
+//     C#-to-IL build and ONE ordinary module load — completely unchanged from today's full-
+//     rebuild path. There is no multi-generation-assembly runtime merge anywhere in this design;
+//     that is what keeps the correctness surface no larger than the existing full-rebuild path's.
+//
+// What CreateForRad needs beyond `packagedModuleDefinition`
+// -----------------------------------------------------------
+// Empirically (`Compilation.CreateForRad` is undocumented outside BC's own source), passing only
+// `packagedModuleDefinition` is NOT enough for the changed object to resolve a reference to an
+// untouched sibling — it throws deep inside codegen with "Unexpected value 'None' of type
+// NavTypeKind" (the SAME crash class BcCompiler.Emit's DotNet-resolver comment documents for an
+// unresolved DotNet type, but here caused by an unresolved AL cross-object reference instead).
+// The fix is to ALSO register a self-referencing ISymbolReferenceLoader/SymbolReferenceSpecification
+// (same AppId/Publisher/Version as the module itself) exposing the SAME baseline objects, with
+// the objects actually being changed THIS cycle excluded from it (leaving them in would raise
+// "already declared" duplicate-object errors, since packagedModuleDefinition already carries
+// their OLD shape). See BuildSelfLoader below.
+//
+// Why the next baseline is a MERGE, not just "convert the RAD compilation"
+// --------------------------------------------------------------------------
+// Also confirmed empirically: converting a RAD Compilation via the same SerializableSymbolModelConverter
+// SymbolJsonWriter uses returns ONLY the objects that were actually source-compiled THIS cycle —
+// not the untouched baseline objects pulled in via packagedModuleDefinition/the self-loader. A
+// second incremental cycle chained naively off that (unmerged) module would silently forget every
+// object from 2+ cycles back — exactly the kind of stale-cache bug this repo has been burned by
+// before. MergeModuleDefinition below is the fix: the next baseline is (old baseline minus the
+// objects just changed) UNION (freshly converted definitions for exactly those objects) — built by
+// this code, never assumed from a BC API.
+using System.Collections.Immutable;
+using System.Reflection;
+using System.Security.Cryptography;
+using NavCA = Microsoft.Dynamics.Nav.CodeAnalysis;
+using NavSyntax = Microsoft.Dynamics.Nav.CodeAnalysis.Syntax;
+using NavEmit = Microsoft.Dynamics.Nav.CodeAnalysis.Emit;
+using NavSymRef = Microsoft.Dynamics.Nav.CodeAnalysis.SymbolReference;
+
+namespace AlRunner;
+
+/// <summary>
+/// (Kind, Id) identity of an AL application object — the unit CreateForRad's
+/// ObjectChangeModelDefinition classifies changes by. Id-less kinds (interface, controladdin,
+/// profile, pagecustomization, profileextension, entitlement) are never represented here — see
+/// <see cref="BcCompiler.IdlessSymbolKinds"/>.
+/// </summary>
+internal readonly record struct RadObjectIdentity(NavCA.SymbolKind Kind, int Id, string Name);
+
+/// <summary>Per-module (--watch bundle) incremental compile state, kept warm on the BcCompiler instance.</summary>
+internal sealed class RadBaseline
+{
+    public required Guid AppId;
+    public required string Publisher;
+    public required Version Version;
+    public required string ManifestFingerprint;
+    public required string SharedRefsFingerprint;
+    public required NavSymRef.ModuleDefinition ModuleDef;
+    public required Dictionary<string, string> FileHashByPath;
+    public required Dictionary<string, RadObjectIdentity> ObjectByPath;
+    public required Dictionary<string, EmittedSource> SourceByKey;
+    public required BcEmitOutput LastOutput;
+}
+
+public sealed partial class BcCompiler
+{
+    private readonly Dictionary<string, RadBaseline> _radBaselines = new();
+
+    /// <summary>
+    /// Object kinds with no numeric Id — a (Kind,Id) pair can never identify them, so any file
+    /// declaring one always takes the full-rebuild path. Matches issue #1902's own enumeration.
+    /// </summary>
+    internal static readonly IReadOnlySet<NavCA.SymbolKind> IdlessSymbolKinds = new HashSet<NavCA.SymbolKind>
+    {
+        NavCA.SymbolKind.Interface, NavCA.SymbolKind.ControlAddIn, NavCA.SymbolKind.Profile,
+        NavCA.SymbolKind.PageCustomization, NavCA.SymbolKind.ProfileExtension, NavCA.SymbolKind.Entitlement,
+    };
+
+    private static string RadObjKey(NavCA.SymbolKind kind, int id) => $"{kind}:{id}";
+
+    private static string HashFile(string path)
+    {
+        using var stream = File.OpenRead(path);
+        return Convert.ToHexString(SHA256.HashData(stream));
+    }
+
+    /// <summary>
+    /// Includes the app.json file's own bytes (id/version/publisher/dependencies/idRanges/…),
+    /// not just the compiler-input-relevant subset ManifestCompilerInputs.CacheKeyFragment
+    /// reads — a caller that never wired _currentAppId/_currentPublisher/_currentVersion from
+    /// the manifest would otherwise let a real app.json edit (a version bump, a new dependency)
+    /// through undetected. Cheap: one file, hashed once per cycle only when the fast path is
+    /// even attempted.
+    /// </summary>
+    private static string RadManifestFingerprint(
+        Guid appId, string publisher, Version version, ManifestCompilerInputs manifestInputs, string? manifestAppJsonPath)
+    {
+        var appJsonHash = manifestAppJsonPath != null && File.Exists(manifestAppJsonPath)
+            ? HashFile(manifestAppJsonPath) : "<none>";
+        return $"{appId}|{publisher}|{version}|{manifestInputs.CacheKeyFragment}|{appJsonHash}";
+    }
+
+    /// <summary>
+    /// Attempts a --watch-only incremental (BC RAD) recompile against the baseline
+    /// <see cref="Emit"/> recorded on this instance for <paramref name="moduleName"/> (see its
+    /// <c>trackIncrementalBaseline</c> parameter). Returns null — the caller MUST fall back to
+    /// an ordinary <c>Emit(..., trackIncrementalBaseline: true)</c> — for any condition this path
+    /// cannot prove safe; <paramref name="fallbackReason"/> names it. On success, this instance's
+    /// baseline for <paramref name="moduleName"/> is already updated for the NEXT cycle.
+    /// </summary>
+    public BcEmitOutput? TryEmitIncremental(
+        IEnumerable<string> alFolders, string moduleName, string? appRootDir, out string fallbackReason)
+    {
+        fallbackReason = "";
+        if (!_radBaselines.TryGetValue(moduleName, out var baseline))
+        {
+            fallbackReason = "no incremental baseline yet for this bundle (first --watch cycle, or the previous cycle fell back)";
+            return null;
+        }
+
+        var dirs = alFolders.Where(Directory.Exists).Distinct().ToList();
+        var alFiles = dirs.SelectMany(d => Directory.EnumerateFiles(d, "*.al", SearchOption.AllDirectories)).Distinct().ToList();
+
+        var manifestAppJsonPath = (appRootDir != null && File.Exists(Path.Combine(appRootDir, "app.json")))
+            ? Path.Combine(appRootDir, "app.json")
+            : dirs.Select(d => Path.Combine(d, "app.json")).FirstOrDefault(File.Exists);
+        var manifestInputs = ReadManifestCompilerInputs(manifestAppJsonPath);
+        var appId = _currentAppId ?? DeterministicGuid(moduleName);
+        var publisher = _currentPublisher ?? "AlRunner";
+        var version = _currentVersion ?? new Version(1, 0, 0, 0);
+        var manifestFingerprint = RadManifestFingerprint(appId, publisher, version, manifestInputs, manifestAppJsonPath);
+        if (manifestFingerprint != baseline.ManifestFingerprint)
+        {
+            fallbackReason = "app.json (identity/version/preprocessor symbols/features/help url) changed since the last cycle";
+            return null;
+        }
+
+        var bundleAlpackages = dirs.SelectMany(d => Directory.EnumerateDirectories(d, ".alpackages", SearchOption.AllDirectories)).Distinct();
+        var (refLoader, specs) = GetSharedReferences(bundleAlpackages);
+        var sharedRefsFingerprint = string.Join(",", specs.Select(s => $"{s.AppId}:{s.Version}").OrderBy(s => s, StringComparer.Ordinal));
+        if (sharedRefsFingerprint != baseline.SharedRefsFingerprint)
+        {
+            fallbackReason = "resolved dependency set changed since the last cycle";
+            return null;
+        }
+
+        var currentHashes = new Dictionary<string, string>();
+        foreach (var f in alFiles) currentHashes[f] = HashFile(f);
+
+        var addedOrRemoved = new List<string>();
+        var modifiedPaths = new List<string>();
+        foreach (var kv in currentHashes)
+        {
+            if (!baseline.FileHashByPath.TryGetValue(kv.Key, out var oldHash)) { addedOrRemoved.Add(kv.Key); continue; }
+            if (!string.Equals(oldHash, kv.Value, StringComparison.Ordinal)) modifiedPaths.Add(kv.Key);
+        }
+        foreach (var oldPath in baseline.FileHashByPath.Keys)
+            if (!currentHashes.ContainsKey(oldPath)) addedOrRemoved.Add(oldPath);
+
+        if (addedOrRemoved.Count > 0)
+        {
+            fallbackReason = $"{addedOrRemoved.Count} file(s) added/removed/renamed since the last cycle " +
+                $"(fast path only handles a content edit to an already-tracked object): {string.Join(", ", addedOrRemoved.Take(5))}";
+            return null;
+        }
+
+        if (modifiedPaths.Count == 0)
+        {
+            // Every file hashes identical to the last cycle — including a touch-with-identical-
+            // bytes. Genuinely zero work: replay the last cycle's result verbatim.
+            return baseline.LastOutput;
+        }
+
+        var parseOpts = RadParseOptions(manifestInputs);
+        var compOpts = RadCompilationOptions(manifestInputs);
+
+        var changeElements = new List<NavCA.ObjectChangeElement>();
+        var changedIdentities = new HashSet<RadObjectIdentity>();
+        var changedTrees = new List<NavSyntax.SyntaxTree>();
+        foreach (var path in modifiedPaths)
+        {
+            if (!baseline.ObjectByPath.TryGetValue(path, out var oldIdentity))
+            {
+                fallbackReason = $"'{path}' was not tracked as a single-object file by the previous baseline";
+                return null;
+            }
+            if (IdlessSymbolKinds.Contains(oldIdentity.Kind))
+            {
+                fallbackReason = $"'{path}' declares a {oldIdentity.Kind} — id-less object kinds always take the full-rebuild path";
+                return null;
+            }
+
+            var src = File.ReadAllText(path);
+            var tree = NavSyntax.SyntaxTree.ParseObjectText(src, path: path, encoding: null!, parseOpts, default);
+            var classify = NavCA.Compilation.Create(moduleName: "__rad_classify", syntaxTrees: new[] { tree }, options: compOpts);
+            var declared = classify.GetDeclaredApplicationObjectSymbols();
+            if (declared.Length != 1)
+            {
+                fallbackReason = $"'{path}' now declares {declared.Length} object(s) (fast path requires exactly 1)";
+                return null;
+            }
+            var sym = declared[0];
+            var newId = (sym as NavCA.ISymbolWithId)?.Id;
+            if (newId == null || IdlessSymbolKinds.Contains(sym.Kind))
+            {
+                fallbackReason = $"'{path}' declares a {sym.Kind} — id-less object kinds always take the full-rebuild path";
+                return null;
+            }
+            if (sym.Kind != oldIdentity.Kind || newId.Value != oldIdentity.Id || !string.Equals(sym.Name, oldIdentity.Name, StringComparison.Ordinal))
+            {
+                fallbackReason = $"'{path}' object identity changed (was {oldIdentity.Kind} {oldIdentity.Id} \"{oldIdentity.Name}\", " +
+                    $"now {sym.Kind} {newId} \"{sym.Name}\") — that is an add+remove, not an edit";
+                return null;
+            }
+
+            changeElements.Add(new NavCA.ObjectChangeElement { Id = newId.Value, Kind = sym.Kind, Name = sym.Name });
+            changedIdentities.Add(new RadObjectIdentity(sym.Kind, newId.Value, sym.Name));
+            changedTrees.Add(tree);
+        }
+
+        var changeModel = new NavCA.ObjectChangeModelDefinition
+        {
+            Added = Array.Empty<NavCA.ObjectChangeElement>(),
+            Modified = changeElements.ToArray(),
+            Removed = Array.Empty<NavCA.ObjectChangeElement>(),
+        };
+
+        var selfSpec = new NavCA.SymbolReferenceSpecification(
+            publisher: publisher, name: moduleName, version: version,
+            exact: false, appId: appId, isPropagated: false, alternateIds: ImmutableArray<Guid>.Empty);
+        var selfModule = ExcludeObjects(baseline.ModuleDef, changedIdentities);
+        var selfLoader = new RadSelfBaselineLoader(appId, selfModule);
+        var combinedLoader = refLoader != null
+            ? new CompositeSymbolReferenceLoader(new NavCA.ISymbolReferenceLoader[] { selfLoader, refLoader })
+            : (NavCA.ISymbolReferenceLoader)selfLoader;
+        var combinedSpecs = specs.Append(selfSpec).ToArray();
+
+        NavCA.Compilation radComp;
+        try
+        {
+            radComp = NavCA.Compilation.CreateForRad(
+                moduleName: moduleName,
+                objectChangeModelDefinition: changeModel,
+                packagedModuleDefinition: baseline.ModuleDef,
+                symbolReferenceLoader: combinedLoader,
+                symbolReferences: combinedSpecs,
+                publisher: publisher, version: version, appId: appId,
+                syntaxTrees: changedTrees, options: compOpts);
+        }
+        catch (Exception ex)
+        {
+            fallbackReason = $"CreateForRad threw: {ex.GetType().Name}: {ex.Message}";
+            return null;
+        }
+        if (appRootDir != null && Directory.Exists(appRootDir))
+            radComp = radComp.WithFileSystem(new NavCA.RelativeFileSystem(appRootDir));
+        radComp = radComp.WithDotNetResolverFactory(GetOrCreateDotNetFactory());
+
+        var radOut = new CaptureOutputter();
+        NavEmit.EmitResult? radResult;
+        try { radResult = radComp.Emit(NavCA.EmitOptions.Default, radOut); }
+        catch (Exception ex)
+        {
+            fallbackReason = $"RAD Emit threw: {ex.GetType().Name}: {ex.Message}";
+            return null;
+        }
+        if (!radResult.Success)
+        {
+            fallbackReason = "RAD Emit failed: " + string.Join(
+                " | ", radResult.Diagnostics.Where(d => d.Severity == NavCA.Diagnostics.DiagnosticSeverity.Error).Select(d => d.GetMessage()));
+            return null;
+        }
+
+        var newByKey = new Dictionary<string, EmittedSource>();
+        foreach (var src in radOut.Captured)
+        {
+            var match = changeElements.FirstOrDefault(e => string.Equals(e.Name, src.Name, StringComparison.Ordinal));
+            if (match == null)
+            {
+                fallbackReason = $"RAD Emit produced an unexpected object '{src.Name}'";
+                return null;
+            }
+            newByKey[RadObjKey(match.Kind, match.Id!.Value)] = src;
+        }
+        if (newByKey.Count != changeElements.Count)
+        {
+            fallbackReason = $"RAD Emit produced {newByKey.Count} object(s), expected {changeElements.Count}";
+            return null;
+        }
+
+        var unionedSources = new List<EmittedSource>(baseline.SourceByKey.Count);
+        foreach (var kv in baseline.SourceByKey)
+            unionedSources.Add(newByKey.TryGetValue(kv.Key, out var fresh) ? fresh : kv.Value);
+        foreach (var kv in newByKey)
+            if (!baseline.SourceByKey.ContainsKey(kv.Key)) unionedSources.Add(kv.Value);
+
+        var deltaModuleDef = SymbolJsonWriter.GetModuleDefinition(radComp);
+        var mergedModuleDef = MergeModuleDefinition(baseline.ModuleDef, changedIdentities, deltaModuleDef);
+
+        var newFileHashByPath = new Dictionary<string, string>(baseline.FileHashByPath, StringComparer.Ordinal);
+        foreach (var path in modifiedPaths) newFileHashByPath[path] = currentHashes[path];
+        // ObjectByPath and the set of (Kind,Id) keys are unchanged — the fast path only allows
+        // a CONTENT edit to an object whose (Kind,Id,Name,Path) are all unchanged.
+
+        var newSourceByKey = new Dictionary<string, EmittedSource>(baseline.SourceByKey.Count, StringComparer.Ordinal);
+        foreach (var kv in baseline.SourceByKey)
+            newSourceByKey[kv.Key] = newByKey.TryGetValue(kv.Key, out var fresh) ? fresh : kv.Value;
+
+        var output = new BcEmitOutput(unionedSources, Array.Empty<string>(), Array.Empty<string>());
+
+        _radBaselines[moduleName] = new RadBaseline
+        {
+            AppId = appId, Publisher = publisher, Version = version,
+            ManifestFingerprint = manifestFingerprint, SharedRefsFingerprint = sharedRefsFingerprint,
+            ModuleDef = mergedModuleDef,
+            FileHashByPath = newFileHashByPath,
+            ObjectByPath = baseline.ObjectByPath,
+            SourceByKey = newSourceByKey,
+            LastOutput = output,
+        };
+
+        return output;
+    }
+
+    /// <summary>
+    /// Called by <see cref="Emit"/> after a clean success, when its caller passed
+    /// <c>trackIncrementalBaseline: true</c>. Builds the (Kind,Id)-keyed state
+    /// <see cref="TryEmitIncremental"/> needs for the NEXT cycle.
+    /// </summary>
+    private void RecordIncrementalBaseline(
+        string moduleName, NavCA.Compilation compilation, IReadOnlyList<string> alFiles,
+        IReadOnlyList<EmittedSource> captured, NavCA.SymbolReferenceSpecification[] specs,
+        ManifestCompilerInputs manifestInputs, string? manifestAppJsonPath, Guid appId, string publisher, Version version,
+        BcEmitOutput fullOutput)
+    {
+        var declared = compilation.GetDeclaredApplicationObjectSymbols();
+        var byName = new Dictionary<string, List<(NavCA.SymbolKind Kind, int? Id, string? Path)>>(StringComparer.Ordinal);
+        foreach (var sym in declared)
+        {
+            var id = (sym as NavCA.ISymbolWithId)?.Id;
+            var path = sym.Location?.SourceTree?.FilePath;
+            if (!byName.TryGetValue(sym.Name, out var list)) byName[sym.Name] = list = new();
+            list.Add((sym.Kind, id, path));
+        }
+
+        // ObjectByPath is built from EVERY declared object (including id-less kinds like
+        // interface/controladdin/…), not just the ones with captured C#: an id-less kind never
+        // reaches AddApplicationObject (no runtime type to emit), so if this only walked
+        // `captured` those files would never be tracked at all, and a later touch would report
+        // the vaguer "not tracked" fallback instead of the specific "id-less" one.
+        var objectByPath = new Dictionary<string, RadObjectIdentity>(StringComparer.Ordinal);
+        var claimedPaths = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var sym in declared)
+        {
+            var path = sym.Location?.SourceTree?.FilePath;
+            if (path == null) continue;
+            var id = (sym as NavCA.ISymbolWithId)?.Id ?? 0; // sentinel for id-less kinds — never dispatched on, see IdlessSymbolKinds gate below.
+            if (!claimedPaths.Add(path))
+            {
+                // A second object claimed a path already seen this pass — that file declares
+                // more than one object; the fast path requires exactly one, so untrack the path
+                // entirely rather than record a misleading single identity for it.
+                objectByPath.Remove(path);
+                continue;
+            }
+            objectByPath[path] = new RadObjectIdentity(sym.Kind, id, sym.Name);
+        }
+
+        var sourceByKey = new Dictionary<string, EmittedSource>(StringComparer.Ordinal);
+        foreach (var src in captured)
+        {
+            if (!byName.TryGetValue(src.Name, out var candidates) || candidates.Count != 1)
+                continue; // ambiguous (name shared across kinds, or unresolved) — leave untracked, not fatal.
+            var (kind, id, path) = candidates[0];
+            if (id == null || IdlessSymbolKinds.Contains(kind))
+                continue; // id-less kind, or unresolved — no (Kind,Id) key to cache under.
+            sourceByKey[RadObjKey(kind, id.Value)] = src;
+        }
+
+        var fileHashByPath = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var f in alFiles) fileHashByPath[f] = HashFile(f);
+
+        var moduleDef = SymbolJsonWriter.GetModuleDefinition(compilation);
+        var manifestFingerprint = RadManifestFingerprint(appId, publisher, version, manifestInputs, manifestAppJsonPath);
+        var sharedRefsFingerprint = string.Join(",", specs.Select(s => $"{s.AppId}:{s.Version}").OrderBy(s => s, StringComparer.Ordinal));
+
+        _radBaselines[moduleName] = new RadBaseline
+        {
+            AppId = appId, Publisher = publisher, Version = version,
+            ManifestFingerprint = manifestFingerprint, SharedRefsFingerprint = sharedRefsFingerprint,
+            ModuleDef = moduleDef,
+            FileHashByPath = fileHashByPath,
+            ObjectByPath = objectByPath,
+            SourceByKey = sourceByKey,
+            LastOutput = fullOutput,
+        };
+    }
+
+    /// <summary>Drops the current baseline for a bundle — used when a caller knows the next cycle must be a full rebuild regardless (e.g. a watched suite set changed).</summary>
+    public void ClearIncrementalBaseline(string moduleName) => _radBaselines.Remove(moduleName);
+
+    private static NavCA.ParseOptions RadParseOptions(ManifestCompilerInputs manifestInputs) => new(
+        runtimeVersion: null!,
+        preprocessorSymbols: Enumerable.Range(1, 25).Select(n => $"CLEANSCHEMA{n}"),
+        documentationMode: NavCA.DocumentationMode.None);
+
+    private static NavCA.CompilationOptions RadCompilationOptions(ManifestCompilerInputs manifestInputs) => new(
+        continueBuildOnError: true,
+        target: NavCA.CompilationTarget.OnPrem,
+        generateOptions: NavCA.CompilationGenerationOptions.Code | NavCA.CompilationGenerationOptions.Navigation,
+        compilerFeatures: manifestInputs.CompilerFeatures,
+        contextSensitiveHelpUrl: manifestInputs.ContextSensitiveHelpUrl);
+
+    /// <summary>Shallow-clones a ModuleDefinition with the given (Kind,Id) objects removed from every id-bearing array property.</summary>
+    private static NavSymRef.ModuleDefinition ExcludeObjects(NavSymRef.ModuleDefinition module, IReadOnlySet<RadObjectIdentity> exclude)
+    {
+        var clone = CloneModuleDefinition(module);
+        foreach (var (propName, kind) in RadMergeablePropertiesByKind)
+        {
+            var idsToExclude = new HashSet<int>(exclude.Where(e => e.Kind == kind).Select(e => e.Id));
+            if (idsToExclude.Count == 0) continue;
+            var prop = typeof(NavSymRef.ModuleDefinition).GetProperty(propName)!;
+            if (prop.GetValue(module) is not Array arr) continue;
+            var elemType = prop.PropertyType.GetElementType()!;
+            var idProp = elemType.GetProperty("Id")!;
+            var kept = arr.Cast<object>().Where(item => !idsToExclude.Contains((int)idProp.GetValue(item)!)).ToList();
+            var result = Array.CreateInstance(elemType, kept.Count);
+            for (int i = 0; i < kept.Count; i++) result.SetValue(kept[i], i);
+            prop.SetValue(clone, result);
+        }
+        return clone;
+    }
+
+    /// <summary>
+    /// (old module, minus the just-changed objects) UNION (delta module's definitions for
+    /// exactly those objects) — see this file's header comment for why this must be a manual
+    /// merge rather than trusting the delta compilation's own conversion to be complete.
+    /// </summary>
+    private static NavSymRef.ModuleDefinition MergeModuleDefinition(
+        NavSymRef.ModuleDefinition oldModule, IReadOnlySet<RadObjectIdentity> changed, NavSymRef.ModuleDefinition delta)
+    {
+        var merged = CloneModuleDefinition(oldModule);
+        foreach (var (propName, kind) in RadMergeablePropertiesByKind)
+        {
+            var changedIds = new HashSet<int>(changed.Where(c => c.Kind == kind).Select(c => c.Id));
+            var prop = typeof(NavSymRef.ModuleDefinition).GetProperty(propName)!;
+            var elemType = prop.PropertyType.GetElementType()!;
+            var idProp = elemType.GetProperty("Id")!;
+
+            var kept = new List<object>();
+            if (prop.GetValue(oldModule) is Array oldArr)
+                foreach (var item in oldArr)
+                    if (!changedIds.Contains((int)idProp.GetValue(item)!)) kept.Add(item);
+            if (changedIds.Count > 0 && prop.GetValue(delta) is Array deltaArr)
+                foreach (var item in deltaArr)
+                    if (changedIds.Contains((int)idProp.GetValue(item)!)) kept.Add(item);
+
+            var result = Array.CreateInstance(elemType, kept.Count);
+            for (int i = 0; i < kept.Count; i++) result.SetValue(kept[i], i);
+            prop.SetValue(merged, result);
+        }
+        return merged;
+    }
+
+    private static NavSymRef.ModuleDefinition CloneModuleDefinition(NavSymRef.ModuleDefinition module)
+        => (NavSymRef.ModuleDefinition)typeof(NavSymRef.ModuleDefinition)
+            .GetMethod("Clone", BindingFlags.NonPublic | BindingFlags.Instance)!.Invoke(module, null)!;
+
+    /// <summary>
+    /// ModuleDefinition array properties that carry an id-bearing object kind, and the
+    /// SymbolKind each corresponds to. Every kind NOT listed here is either id-less (see
+    /// <see cref="IdlessSymbolKinds"/>, always full-rebuild) or not something this fast path's
+    /// (Kind,Id) classification step can ever produce.
+    /// </summary>
+    private static readonly (string PropertyName, NavCA.SymbolKind Kind)[] RadMergeablePropertiesByKind =
+    {
+        ("Tables", NavCA.SymbolKind.Table),
+        ("Codeunits", NavCA.SymbolKind.Codeunit),
+        ("Pages", NavCA.SymbolKind.Page),
+        ("PageExtensions", NavCA.SymbolKind.PageExtension),
+        ("TableExtensions", NavCA.SymbolKind.TableExtension),
+        ("Reports", NavCA.SymbolKind.Report),
+        ("ReportExtensions", NavCA.SymbolKind.ReportExtension),
+        ("XmlPorts", NavCA.SymbolKind.XmlPort),
+        ("Queries", NavCA.SymbolKind.Query),
+        ("EnumTypes", NavCA.SymbolKind.Enum),
+        ("EnumExtensionTypes", NavCA.SymbolKind.EnumExtension),
+        ("PermissionSets", NavCA.SymbolKind.PermissionSet),
+        ("PermissionSetExtensions", NavCA.SymbolKind.PermissionSetExtension),
+    };
+
+    /// <summary>
+    /// Resolves CreateForRad's mandatory <c>symbolReferenceLoader</c>/<c>symbolReferences</c> for
+    /// THIS module's own baseline objects — see this file's header comment for why
+    /// packagedModuleDefinition alone does not resolve them.
+    /// </summary>
+    private sealed class RadSelfBaselineLoader : NavCA.ISymbolReferenceLoader
+    {
+        private readonly Guid _appId;
+        private readonly NavSymRef.ModuleDefinition _module;
+        public RadSelfBaselineLoader(Guid appId, NavSymRef.ModuleDefinition module) { _appId = appId; _module = module; }
+
+        public NavSymRef.ModuleDefinition? LoadModule(NavCA.SymbolReferenceSpecification reference, IList<NavCA.Diagnostics.Diagnostic> diagnostics)
+            => reference.AppId == _appId ? _module : null;
+
+        public NavCA.ModuleInfo LoadModuleInfo(NavCA.SymbolReferenceSpecification reference, IList<NavCA.Diagnostics.Diagnostic> diagnostics, NavCA.LoadModuleInfoFlags flags)
+            => reference.AppId == _appId ? new NavCA.ModuleInfo(_module, documentationProvider: null) : null!;
+
+        public IEnumerable<NavCA.SymbolReferenceSpecification> GetDependencies(NavCA.SymbolReferenceSpecification reference, IList<NavCA.Diagnostics.Diagnostic> diagnostics)
+            => Enumerable.Empty<NavCA.SymbolReferenceSpecification>();
+    }
+}

--- a/AlRunner/BcCompiler.Incremental.cs
+++ b/AlRunner/BcCompiler.Incremental.cs
@@ -180,7 +180,15 @@ public sealed partial class BcCompiler
         }
 
         var bundleAlpackages = dirs.SelectMany(d => Directory.EnumerateDirectories(d, ".alpackages", SearchOption.AllDirectories)).Distinct();
+        // Same BCCOMPILER_TIMING=1 diagnostic convention Emit() uses (see its own
+        // GetSharedReferences _mark call) — WatchTests' warm-vs-cold regression guard scrapes
+        // this exact "[emit-timing] GetSharedReferences (...): <n>ms" shape on stderr, and this
+        // path calls GetSharedReferences too, so it must keep emitting it or that guard goes
+        // blind the moment a cycle takes the fast path instead of Emit().
+        bool timing = Environment.GetEnvironmentVariable("BCCOMPILER_TIMING") == "1";
+        var refsSw = timing ? System.Diagnostics.Stopwatch.StartNew() : null;
         var (refLoader, specs) = GetSharedReferences(bundleAlpackages);
+        if (timing) Console.Error.WriteLine($"[emit-timing] GetSharedReferences ({specs.Length} specs): {refsSw!.ElapsedMilliseconds}ms");
         var sharedRefsFingerprint = string.Join(",", specs.Select(s => $"{s.AppId}:{s.Version}").OrderBy(s => s, StringComparer.Ordinal));
         if (sharedRefsFingerprint != baseline.SharedRefsFingerprint)
         {

--- a/AlRunner/BcCompiler.cs
+++ b/AlRunner/BcCompiler.cs
@@ -55,7 +55,7 @@ public sealed record BcEmitOutput(
     IReadOnlyList<string> Diagnostics,
     IReadOnlyList<string> ExcludedObjects);
 
-public sealed class BcCompiler
+public sealed partial class BcCompiler
 {
     /// <summary>
     /// Compile every .al file under <paramref name="alFolders"/> into a single
@@ -1300,7 +1300,17 @@ public sealed class BcCompiler
     /// app root, e.g. dependency compiles staging synthetic AL into a temp dir with no
     /// resource files anyway.
     /// </param>
-    public BcEmitOutput Emit(IEnumerable<string> alFolders, string moduleName, string? appRootDir = null)
+    /// <param name="trackIncrementalBaseline">
+    /// When true and this Emit succeeds cleanly (no excluded objects), record a RAD baseline
+    /// for <paramref name="moduleName"/> so a LATER call to <see cref="TryEmitIncremental"/> can
+    /// recompile a single changed file's worth of work instead of the whole module (issue
+    /// #1902). Only <c>--watch</c> passes true — every other caller keeps Emit's existing cost
+    /// profile unchanged (the extra ModuleDefinition conversion + file hashing this does is
+    /// wasted work for a one-shot run that will never call TryEmitIncremental).
+    /// </param>
+    public BcEmitOutput Emit(
+        IEnumerable<string> alFolders, string moduleName, string? appRootDir = null,
+        bool trackIncrementalBaseline = false)
     {
         var dirs = alFolders.Where(Directory.Exists).Distinct().ToList();
         if (dirs.Count == 0)
@@ -1753,7 +1763,33 @@ public sealed class BcCompiler
             }
         }
 
-        return new BcEmitOutput(outputter.Captured, alDiags, excludedObjects);
+        var emitOutput = new BcEmitOutput(outputter.Captured, alDiags, excludedObjects);
+
+        // #1902: only a CLEAN success (nothing excluded, every source captured) is trustworthy
+        // as a RAD baseline — a module that only compiled after dropping broken objects must
+        // not let a later incremental cycle silently treat those objects as "still there".
+        if (trackIncrementalBaseline && caught == null && excludedObjects.Count == 0 && outputter.Captured.Count > 0)
+        {
+            try
+            {
+                RecordIncrementalBaseline(
+                    moduleName, compilation, alFiles, outputter.Captured, specs,
+                    manifestInputs, manifestAppJsonPath, appId, _currentPublisher ?? "AlRunner", _currentVersion ?? new Version(1, 0, 0, 0),
+                    emitOutput);
+            }
+            catch (Exception ex)
+            {
+                // Never fail the run for this — losing the baseline just means the NEXT --watch
+                // cycle falls back to a full rebuild instead of going incremental. Say so; a
+                // developer staring at an unexpectedly slow warm cycle needs the reason.
+                Console.Error.WriteLine(
+                    $"[BcCompiler] {moduleName}: failed to record an incremental (RAD) baseline — " +
+                    $"the next --watch cycle will do a full rebuild: {ex.GetType().Name}: {ex.Message}");
+                _radBaselines.Remove(moduleName);
+            }
+        }
+
+        return emitOutput;
     }
 
     // Cheap text probe: does any source file declare an AL `query` object? Avoids

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -1475,7 +1475,25 @@ foreach (var bundle in bundles)
             // .deps-bin path, neither of which this scope touches. Same filter EmitDepSymbols
             // already applies — see BcCompiler.ScopeSymbolBearingDepsOnly.
             using var bundleDepScope = BcCompiler.ScopeSymbolBearingDepsOnly();
-            var emitTask = Task.Run(() => emitter.Emit(allPaths, moduleName, appGroup.SuiteDir));
+
+            // #1902: in --watch, try the incremental (RAD) path first — a content edit to one
+            // already-tracked, id-bearing object recompiles just that object instead of the
+            // whole module. Falls back to the ordinary full Emit() (still tracking a baseline
+            // for the NEXT cycle) for anything it cannot prove safe: the first cycle for this
+            // bundle, an added/removed/renamed file, an app.json/dependency change, an id-less
+            // object kind, or any diagnostic the delta compile itself raises. Every other mode
+            // (one-shot, --server) is untouched — normal-mode Emit() never tracks a baseline and
+            // never calls TryEmitIncremental, so its cost profile is unchanged.
+            BcEmitOutput? incrementalOutput = null;
+            if (watchMode)
+            {
+                incrementalOutput = emitter.TryEmitIncremental(allPaths, moduleName, appGroup.SuiteDir, out var incrementalFallbackReason);
+                if (incrementalOutput == null && AlRunner.Log.Verbose)
+                    Console.Error.WriteLine($"[watch] {moduleName}: full rebuild this cycle — {incrementalFallbackReason}");
+            }
+            var emitTask = incrementalOutput != null
+                ? Task.FromResult(incrementalOutput)
+                : Task.Run(() => emitter.Emit(allPaths, moduleName, appGroup.SuiteDir, trackIncrementalBaseline: watchMode));
             try
             {
                 if (!emitTask.Wait(TimeSpan.FromSeconds(emitTimeoutSec)))

--- a/AlRunner/SymbolJson.cs
+++ b/AlRunner/SymbolJson.cs
@@ -24,13 +24,35 @@ public static class SymbolJsonWriter
         if (comp is null) throw new ArgumentNullException(nameof(comp));
         if (output is null) throw new ArgumentNullException(nameof(output));
 
+        var module = GetModuleDefinition(comp);
+        SymbolReferenceJsonWriter.WriteModule(output, module);
+    }
+
+    /// <summary>
+    /// Converts a <see cref="Compilation"/> into the same in-memory <see cref="ModuleDefinition"/>
+    /// shape <see cref="WriteSymbolJson"/> serializes, without a disk round-trip. Used both by
+    /// the SymbolReference.json writer above and by <c>BcCompiler</c>'s incremental (RAD) compile
+    /// path (issue #1902), which needs a <see cref="ModuleDefinition"/> to hand
+    /// <c>Compilation.CreateForRad</c> as the packaged baseline for the NEXT cycle.
+    ///
+    /// IMPORTANT for callers building a multi-cycle baseline: this only reflects objects that
+    /// were actually SOURCE-DECLARED in <paramref name="comp"/>'s own syntax trees — objects
+    /// resolved from a <c>packagedModuleDefinition</c>/<c>ISymbolReferenceLoader</c> (i.e. a RAD
+    /// compilation's UNCHANGED baseline objects) do NOT come back here. Converting a RAD
+    /// <see cref="Compilation"/> therefore yields ONLY that cycle's delta, not the full merged
+    /// module — confirmed empirically (see BcCompiler.Incremental.cs's MergeModuleDefinition).
+    /// </summary>
+    public static ModuleDefinition GetModuleDefinition(Compilation comp)
+    {
+        if (comp is null) throw new ArgumentNullException(nameof(comp));
+
         // Force binding so the SerializableSymbolModelConverter sees fully-resolved
         // symbols. Without this the converter returns a skeleton ModuleDefinition with
         // empty Codeunits/Tables/Pages/etc. arrays.
         _ = comp.GetDeclarationDiagnostics();
         var declaredObjects = comp.GetDeclaredApplicationObjectSymbols();
         if (Environment.GetEnvironmentVariable("ALRUNNER_DUMP_SYMBOLS") == "1")
-            Console.Error.WriteLine($"  DEBUG WriteSymbolJson: comp has {declaredObjects.Length} declared application object symbol(s)");
+            Console.Error.WriteLine($"  DEBUG GetModuleDefinition: comp has {declaredObjects.Length} declared application object symbol(s)");
 
         var module = TryConvertCompilation(comp)
             ?? TryConvertCompilationByScan(comp)
@@ -44,10 +66,10 @@ public static class SymbolJsonWriter
                 var p = typeof(ModuleDefinition).GetProperty(prop);
                 if (p?.GetValue(module) is Array arr) count += arr.Length;
             }
-            Console.Error.WriteLine($"  DEBUG WriteSymbolJson: ModuleDefinition has {count} object(s) populated");
+            Console.Error.WriteLine($"  DEBUG GetModuleDefinition: ModuleDefinition has {count} object(s) populated");
         }
 
-        SymbolReferenceJsonWriter.WriteModule(output, module);
+        return module;
     }
 
     private static ModuleDefinition? TryConvertCompilation(Compilation comp)


### PR DESCRIPTION
Refs #1902

## What this delivers

`--watch` called the same whole-module `BcCompiler.Emit` a one-shot run uses on every cycle — full re-parse, re-bind, re-codegen of every object, every save. This wires in BC's own `Compilation.CreateForRad` (the same public factory BC's own RAD/F5 publish uses) for the highest-value, provably-safe case:

> A file that already declared exactly one id-bearing object had its **content edited** — same `(Kind, Id, Name)` as before.

Measured on a synthetic app (`BcCompiler.Emit`/`TryEmitIncremental` called directly, not through the file-watcher):

| Objects | Full rebuild (warm) | Incremental (1 object changed) | Speedup |
|---|---:|---:|---:|
| 500 | 459 ms | 35 ms | ~13x |
| 2,000 | 1,131 ms | 63 ms | ~18x |

The gap widens with app size because the incremental path's cost does not scale with object count — the proportionality claim from #1902 — while the full rebuild does. Method: `AL_RUNNER_RAD_PERF_PROBE`-style direct `BcCompiler` calls against a synthetic app of trivial codeunits (not included in the diff — throwaway harness), timed with `Stopwatch`, `dotnet run -c Release`.

## Why this is safe

Everything that isn't a pure content edit to an existing, id-bearing, single-object file falls back to the existing, already-correct whole-module `Emit()` — **never a stale or wrong result, just not accelerated for that cycle**:
- a file added/removed/renamed
- an id-less object kind (interface, controladdin, profile, pagecustomization, profileextension, entitlement)
- an app.json / dependency-set change
- a touched file that now declares zero or more than one object
- any diagnostic or exception from the delta compile itself

Reusing cached C# for every *untouched* object is safe because BC's own generated C# dispatches cross-object calls by `(object id, deterministic member-name hash)` at runtime (`NavCodeunitHandle`), not by a direct C# type reference — confirmed by inspecting real output via `--dump-csharp`. An unmodified caller is unaffected by a callee's edit and automatically sees the callee's new behaviour once the final union of cached + freshly-generated C# is compiled into the one assembly this cycle produces — completely unchanged from today's full-rebuild path (no multi-generation-assembly runtime merge anywhere in this design). A genuinely breaking edit (e.g. a renamed procedure an unmodified caller still calls by its old name) surfaces as a loud `NavNCLMissingMethodException` at the call site, not a silent wrong answer.

Two behaviours needed for `CreateForRad` to work were undocumented outside BC's own source and only findable empirically:
- it needs a **self-referencing `ISymbolReferenceLoader`** for the module's own baseline — `packagedModuleDefinition` alone leaves a changed object's references to unchanged siblings unresolved (`Unexpected value 'None' of type NavTypeKind`);
- the **next cycle's baseline must be a manual merge** of (old baseline minus the changed objects) with (the delta's converted definitions) — converting a RAD `Compilation` via BC's own `SerializableSymbolModelConverter` only returns that cycle's source-declared objects, so trusting it alone would silently lose objects from 2+ cycles back on a 3rd incremental cycle. Both are documented in `BcCompiler.Incremental.cs`'s header comment with the empirical evidence.

## Scope — this is a slice, not the whole issue

Per #1902's own acceptance criteria ("every object kind and every file operation — add, edit, rename, delete, touch-with-identical-bytes"), this PR only accelerates the **content-edit-to-an-existing-object** case. Add/remove/rename, id-less kinds, and a per-cycle multi-object touch set all still take the full-rebuild path (correct, just not sped up) — hence `Refs #1902`, not `Closes`. The dashboard "why a full rebuild happened" surfacing (#1905 item 4) is out of scope here too; a `[watch] <module>: full rebuild this cycle — <reason>` line is written under `--verbose` as a minimal stopgap.

## Tests

`AlRunner.Tests/BcCompilerIncrementalTests.cs` — RED/GREEN proof, run against the real BC compiler (`[Collection(BcEngineCollection.Name)]`, same pattern as `BcCompilerEmitRetryTests`):
- editing one codeunit leaves every other object's emitted C# **byte-identical** to the original full compile (proportional, not "still compiles"), and the incremental result matches an independent full rebuild of the same post-edit tree, object for object
- a touch-with-identical-bytes replays the last cycle's result at zero cost (`Assert.Same`)
- three sequential incremental cycles, each touching a *different* object, all survive into the final result — the regression proof for the "manual merge" fix above
- an unmodified caller automatically sees an edited callee's new behaviour without being touched
- no baseline yet / a file added / app.json changed / an id-less kind touched all correctly fall back, and the caller's full-rebuild-after-fallback contract still produces the correct, complete result

All 8 pass locally against the real in-process BC engine (Release build, warmed Ncl Cecil cache, `DOTNET_STARTUP_HOOKS` — the same recipe `test-matrix.yml` uses).

## Test plan
- [x] `AlRunner.Tests/BcCompilerIncrementalTests.cs` — 8/8 pass locally against the real BC compiler
- [ ] CI unit-test leg green (in progress)
- [x] Manual proportionality measurement on a synthetic 500/2,000-codeunit app