### PR TITLE
chore(corpus): bump al-language pin to 2f892b1

### DIFF
--- a/tests/expectations/count-baseline/test-count-baseline.json
+++ b/tests/expectations/count-baseline/test-count-baseline.json
@@ -2,7 +2,7 @@
   "_comment": "Consumed by --count-baseline (AlRunner/Infrastructure/CountBaseline.cs), a DIFFERENT schema from the oos-/known-gaps-/divergence-/disabled- files in this directory: those declare the expected CLASSIFICATION of one named test, this declares the expected EXACT COUNT of a whole suite -- an exact match, not a floor: a mismatch in EITHER direction (drop OR growth) fails the run (exit 4). See #1880 and PR #1882's review for why growth is also a hard failure, not just a notice. Suite keys are the basename of the bundle directory CI passes on the command line (tests/al-language/tests/al-language -> 'al-language', tests/runner-extras -> 'runner-extras'), matching the '--out <name>-results.json' convention CI already uses. Values below are read off actual Test Matrix CI runs (see PR discussion for run URLs), not guessed: al-language's 2073->2076 bump reflects 3 corpus tests merged upstream between when the local baseline was drafted and when CI first ran against it. runner-extras' appGroups 23->21 byBcVersion override on 27.0/27.3/27.5 is the SAME preprocessor-gated-surface split that already explains its tests count divergence: fewer AL surfaces compile pre-28.0, which drops whole app groups, not just individual tests within a group. ANY PR that changes a suite's test or app-group count -- growth included -- MUST bump the matching number here in the SAME PR, or that PR's CI goes red with a [count-baseline] DROP or GROWTH diagnostic naming the exact expected/actual numbers to use.",
   "suites": {
     "al-language": {
-      "tests": { "default": 2096 },
+      "tests": { "default": 2104 },
       "appGroups": { "default": 1 }
     },
     "runner-extras": {


### PR DESCRIPTION
Bumps the `tests/al-language` submodule from `46d6ec66` to `2f892b1`, and the al-language count baseline from 2096 to 2104.

Three tests merged upstream since the current pin, all written as the upstream proofs for fixes that landed on main today. Each only adds new files or new test procedures; no existing corpus test changed.

- **#55** — ModalPageHandler dispatch for a precompiled Base Application page. Upstream proof for #1939, fixed by #1953.
- **#56** — a pageextension-contributed action's `Invoke()` runs its own `OnAction` trigger. Upstream proof for #1923, fixed by #1954.
- **#57** — static `XmlPort.Import(id, InStream, Record)` is usable without an explicit `Get()`. This one records what real BC actually does: the given record variable is never populated by the call, it only seeds `SetTableView`'s row filter. That finding is what led to #1946's real cause, fixed by #1960.

All three runner fixes are already on main, so these tests exercise the fixed behavior here rather than failing by design. Upstream CI passed all three against real BC 27.5 and 28.3.

Baseline 2096 to 2104 accounts for 8 new test procedures.
