### PR TITLE
chore: gitignore graphify-out/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,14 @@ AlRunner/Win32Stubs/*.so
 # that produced it — and CI would silently overwrite it anyway. Same rationale as #1881
 # above: keep a stray copy from showing up as untracked or being swept into `git add -A`.
 /engine.runsettings
+
+# graphify builds a knowledge graph of the codebase into graphify-out/ (graph.json,
+# graph.html, GRAPH_REPORT.md, a manifest and an extraction cache). It is entirely
+# DERIVED from the tree it was run against and is several MB, so committing it would
+# add a large binary-ish blob that goes stale on the next commit — AlRunner/ took 9
+# commits in a single day, and a stale graph is worse than no graph because it reads
+# as authoritative. Anyone who wants one regenerates it locally in seconds (the
+# AlRunner/ corpus is code-only, so extraction is deterministic AST work with no LLM
+# cost). Ignore it so a local build never shows up as untracked or gets swept into a
+# `git add -A`, the same rationale as /engine.runsettings above.
+/graphify-out/


### PR DESCRIPTION
`graphify-out/` holds a locally generated knowledge graph of the codebase — `graph.json`, `graph.html`, `GRAPH_REPORT.md`, a manifest, and an extraction cache. On this repo that is about 5.4 MB.

It should never be committed:

- It is entirely derived from the tree it was run against.
- It goes stale fast. `AlRunner/` took 9 commits in a single day, and a stale graph is worse than no graph, because it still reads as authoritative.
- Regenerating it is cheap. The `AlRunner/` corpus is code-only, so extraction is deterministic AST work with no LLM cost.

Without this entry the whole directory shows up as untracked, which is exactly how it gets swept into a `git add -A`. Same rationale as the `/engine.runsettings` entry above it.

No behavior change, docs and config only.
