### PR TITLE
docs(graphify): note the optional local knowledge graph, and which build to install

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,3 +31,15 @@ Operating rules live in `.claude/rules/` and are auto-loaded. Task-specific refe
 - Triage new untriaged issues → sub-agent `triager` (Opus, runs once at the start of a cycle)
 - Act as orchestrator or implementation agent → sub-agents `orchestrator` / `impl-agent` in `.claude/agents/`
 - Drive a full work cycle (triage → parallel impls in worktrees → orchestrator merge pass, until the queue is empty) → slash command `/work-cycle`
+
+### Local knowledge graph (optional)
+
+If `graphify-out/graph.json` exists, this checkout has a locally built knowledge graph of
+`AlRunner/`. It is generated, gitignored, and never committed. Query it from the repo root with
+`graphify query "<question>"`, and rebuild it with `graphify AlRunner --update` — `AlRunner/`
+changes often and a stale graph still reads as authoritative.
+
+It maps **static** structure only: which types and files reference which. It cannot tell you
+whether a `Hook(...)` registration or a Cecil rewrite actually fires at runtime — an orphaned
+hook and a live one look identical in the graph. Use `AL_RUNNER_HOOK_AUDIT=1` for that question,
+and see the README's Knowledge graph section for which graphify build to install.

--- a/README.md
+++ b/README.md
@@ -207,21 +207,27 @@ Out of scope by design: SMTP, HTTP egress to external services, file I/O against
 
 ## Knowledge graph (optional)
 
-`AlRunner/` can be indexed into a queryable knowledge graph — communities, most-connected
-types, import cycles — with [graphify](https://github.com/safishamsi/graphify).
+This repo — the C# runner and AL sources alike — can be indexed into a queryable knowledge
+graph: communities, most-connected types, import cycles. Built with
+[graphify](https://github.com/safishamsi/graphify).
 
-Install the AL-aware fork rather than the upstream package. It adds `.al` to the file detector
-and an AL extractor, so it can index the AL corpus and AL bundles; upstream handles the C# under
-`AlRunner/` but skips every `.al` file:
+**Install the AL-aware fork**, not the upstream package:
 
 ```bash
 uv tool install --upgrade "git+https://github.com/ChristianHovenbitzer/graphify-al.git@al-support"
 ```
 
+The fork adds `.al` to the file detector and an AL extractor. Upstream graphify has no AL
+support, and it does not fail on `.al` files — it skips them silently, so a graph built with it
+looks complete while containing none of the AL in this repo. Upstream is enough if you only ever
+index the C# under `AlRunner/`, but anyone working on this project reaches AL sooner or later.
+Install the fork once and the question does not come up.
+
 Then, from the repo root:
 
 ```bash
-graphify AlRunner              # build the graph
+graphify AlRunner              # index the C# runner
+graphify tests/runner-extras   # or an AL tree (needs the fork)
 graphify query "<question>"    # ask it something
 graphify AlRunner --update     # refresh after changes
 ```

--- a/README.md
+++ b/README.md
@@ -205,6 +205,36 @@ Out of scope by design: SMTP, HTTP egress to external services, file I/O against
 | `2` | Runner limitations only |
 | `3` | AL compilation error |
 
+## Knowledge graph (optional)
+
+`AlRunner/` can be indexed into a queryable knowledge graph — communities, most-connected
+types, import cycles — with [graphify](https://github.com/safishamsi/graphify).
+
+Install the AL-aware fork rather than the upstream package. It adds `.al` to the file detector
+and an AL extractor, so it can index the AL corpus and AL bundles; upstream handles the C# under
+`AlRunner/` but skips every `.al` file:
+
+```bash
+uv tool install --upgrade "git+https://github.com/ChristianHovenbitzer/graphify-al.git@al-support"
+```
+
+Then, from the repo root:
+
+```bash
+graphify AlRunner              # build the graph
+graphify query "<question>"    # ask it something
+graphify AlRunner --update     # refresh after changes
+```
+
+Output lands in `graphify-out/` (`graph.html`, `graph.json`, `GRAPH_REPORT.md`). It is gitignored
+— it is derived, several MB, and goes stale quickly.
+
+`AlRunner/` is code-only, so extraction is deterministic AST work and costs no LLM tokens.
+
+One limit worth knowing before trusting it: the graph is static. A `Hook(...)` registration that
+never fires and one that does look the same in it. For that question use `AL_RUNNER_HOOK_AUDIT=1`,
+which measures at runtime.
+
 ## Reporting Gaps
 
 If AL code fails to run and the reason is not in [`docs/limitations.md`](docs/limitations.md) or [`docs/scope.md`](docs/scope.md), that is a **runner gap**. Open an issue with `.github/ISSUE_TEMPLATE/runner-gap.md`. Silent workarounds are forbidden (`.claude/rules/file-issues-for-gaps.md`).


### PR DESCRIPTION
Two additions, docs only.

## README

A "Knowledge graph (optional)" section with install and usage, pointing at [`ChristianHovenbitzer/graphify-al@al-support`](https://github.com/ChristianHovenbitzer/graphify-al) rather than the upstream `graphifyy` package.

It recommends the fork outright instead of presenting a choice, because upstream graphify has no AL support and **does not fail on `.al` files — it skips them**. A graph built with upstream therefore looks complete while containing none of the AL in this repo. Upstream would be enough for the C# under `AlRunner/` alone, but everyone using this project reaches AL eventually, so installing the fork once removes the trap.

Verified: the fork's `al-support` branch head is `216874c`, the exact commit installed on the machine that built our graph, so following the README reproduces our setup.

## CLAUDE.md

A conditional pointer under "Operating rules and skills". It applies only if `graphify-out/graph.json` exists, so it reads as a no-op for anyone who has not built a graph.

It says what the graph is for, how to refresh it, and what it cannot answer. That last part is why I wrote it: the graph is static, so a `Hook(...)` registration that never fires and one that does look identical in it. Three issues this week — #1883, #1948, #1961 — were exactly that, a mechanism that reads as correctly wired and does nothing at runtime. The note sends the reader to `AL_RUNNER_HOOK_AUDIT=1`, which measures at runtime.

## Companion

#1965 gitignores `graphify-out/`.

No behavior change, no code touched.
