### PR TITLE
fix(pages): Rec resolves inside a pageextension-contributed OnAction

### DIFF
--- a/AlRunner/Patches/RunnerPageInstance.cs
+++ b/AlRunner/Patches/RunnerPageInstance.cs
@@ -50,6 +50,20 @@ internal sealed class RunnerPageInstance
     // reused after that. See FindTrigger/GetOrCreateExtensionInstance.
     private readonly Dictionary<int, object?> _extensionInstances = new();
 
+    // NavFormExtension.ParentObject ("protected internal NavForm ParentObject { get;
+    // private set; }") — resolved from its DECLARING type, never from a derived
+    // PageExtension{id} instance's own Type. Issue #1966: PropertyInfo.SetValue against a
+    // PropertyInfo obtained via instance.GetType().GetProperty(...) throws "Property set
+    // method not found." for an inherited property whose SETTER is `private` — .NET
+    // reflection only exposes a private accessor through the type that actually declares
+    // it, even though the property's GETTER is `protected internal` and freely visible on
+    // the derived type. GetCallerRecordPatches.cs's _pFormExtensionParentObject already
+    // resolves this same property the correct way (via typeof(NavFormExtension)); this
+    // mirrors that, so both call sites use one working pattern instead of two, one broken.
+    private static readonly PropertyInfo? _pFormExtensionParentObject =
+        typeof(Microsoft.Dynamics.Nav.Runtime.Extensions.NavFormExtension).GetProperty(
+            "ParentObject", BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Public);
+
     private RunnerPageInstance(object form, object owner, NavRecord? record, int pageId, System.Collections.IDictionary sourceExpressions)
     {
         _form = form;
@@ -964,9 +978,7 @@ internal sealed class RunnerPageInstance
                 try
                 {
                     instance = ctor.Invoke(new object?[] { _owner, _record });
-                    var parentObjectProp = instance.GetType().GetProperty("ParentObject",
-                        BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
-                    parentObjectProp?.SetValue(instance, _form);
+                    _pFormExtensionParentObject?.SetValue(instance, _form);
                 }
                 catch (Exception ex)
                 {

--- a/tests/expectations/count-baseline/test-count-baseline.json
+++ b/tests/expectations/count-baseline/test-count-baseline.json
@@ -7,8 +7,8 @@
     },
     "runner-extras": {
       "tests": {
-        "default": 142,
-        "byBcVersion": { "27.0": 136, "27.3": 136, "27.5": 136 }
+        "default": 144,
+        "byBcVersion": { "27.0": 138, "27.3": 138, "27.5": 138 }
       },
       "appGroups": {
         "default": 28,

--- a/tests/runner-extras/pageext-action-dispatch/PadAssert.Codeunit.al
+++ b/tests/runner-extras/pageext-action-dispatch/PadAssert.Codeunit.al
@@ -13,4 +13,10 @@ codeunit 64525 "Pad Assert"
         if Value then
             Error('Assert.IsFalse failed: %1', Msg);
     end;
+
+    procedure AreEqual(Expected: Text; Actual: Text; Msg: Text)
+    begin
+        if Expected <> Actual then
+            Error('Assert.AreEqual failed: %1 (expected ''%2'', got ''%3'')', Msg, Expected, Actual);
+    end;
 }

--- a/tests/runner-extras/pageext-action-dispatch/PadHostPageExt.PageExt.al
+++ b/tests/runner-extras/pageext-action-dispatch/PadHostPageExt.PageExt.al
@@ -19,6 +19,34 @@ pageextension 64522 "Pad Host Page Ext" extends "Pad Host Page"
                     Row.Log('EXT-OWN-PAGE');
                 end;
             }
+
+            // Issue #1966: dispatch alone is not enough — the trigger body must be able to
+            // READ Rec and see the page's actual current row. #1954's four original tests in
+            // this suite all logged a fixed tag and never touched Rec, so they stayed green
+            // while get_Rec() NREd on every corpus leg (PageExtension60723.get_Rec, see
+            // tests/al-language's TestPageExtensionActionInvoke_Tests.al,
+            // ExtActionInvokeRunsAgainstThePagesCurrentRow — already upstream and already the
+            // real service-tier proof; this is the fast local regression pin for it).
+            action(ExtActionReadsRec)
+            {
+                ApplicationArea = All;
+                Caption = 'Ext Action Reads Rec';
+
+                trigger OnAction()
+                var
+                    Stamp: Record "Pad Row";
+                begin
+                    if not Stamp.Get('REC-STAMP') then begin
+                        Stamp.Init();
+                        Stamp."No." := 'REC-STAMP';
+                        Stamp.Descr := Rec."No.";
+                        Stamp.Insert();
+                    end else begin
+                        Stamp.Descr := Rec."No.";
+                        Stamp.Modify();
+                    end;
+                end;
+            }
         }
     }
 }

--- a/tests/runner-extras/pageext-action-dispatch/PadTests.Codeunit.al
+++ b/tests/runner-extras/pageext-action-dispatch/PadTests.Codeunit.al
@@ -28,6 +28,23 @@ codeunit 64524 "Pad Tests"
         Row.DeleteAll();
     end;
 
+    // Two distinct rows so a test can tell "the trigger read A CURRENT ROW" apart from
+    // "the trigger read THE row the page is actually positioned on" — a stub that always
+    // resolved to the first row, or to a blank record, could not pass both
+    // ExtActionReadsRecAgainstFirstRow and ExtActionReadsRecAgainstThePagesCurrentRow below.
+    local procedure SeedRows()
+    var
+        Row: Record "Pad Row";
+    begin
+        Row.Init();
+        Row."No." := 'A';
+        Row.Insert();
+
+        Row.Init();
+        Row."No." := 'B';
+        Row.Insert();
+    end;
+
     // Control: an action declared directly on the page dispatches. If this fails, the
     // other two tests' failures would be meaningless (broken plumbing, not #1923).
     [Test]
@@ -107,5 +124,55 @@ codeunit 64524 "Pad Tests"
 
         Assert.IsTrue(Row.Get('EXT-OWN-PAGE'), 'the invoked action must have run');
         Assert.IsFalse(Row.Get('DIRECT'), 'invoking the extension action must not run the page''s own action');
+    end;
+
+    // Issue #1966: RED before the fix — get_Rec() NREs inside the extension's own trigger
+    // body ("Object reference not set to an instance of an object", at
+    // PageExtension{extId}.get_Rec()) the instant it reads Rec, so Invoke() never returns.
+    // A stub implementation that swallowed the NRE and left Stamp.Descr blank would also
+    // fail this: the assert is against a SPECIFIC row value ('A'), not merely "no exception".
+    [Test]
+    procedure ExtActionReadsRecAgainstFirstRow()
+    var
+        Stamp: Record "Pad Row";
+        HostPage: TestPage "Pad Host Page";
+    begin
+        Initialize();
+        SeedRows();
+
+        HostPage.OpenEdit();
+        HostPage.First();
+        HostPage.ExtActionReadsRec.Invoke();
+        HostPage.Close();
+
+        Assert.IsTrue(Stamp.Get('REC-STAMP'),
+            'Invoke() must have run the pageextension''s OnAction trigger that reads Rec');
+        Assert.AreEqual('A', Stamp.Descr,
+            'the extension action''s OnAction must have read Rec as the page''s current (first) row');
+    end;
+
+    // Positive, the actual claim in #1966: moving the page's cursor changes what Rec reads
+    // inside the SAME extension trigger — proves Rec is wired to the page's LIVE cursor, not
+    // a snapshot frozen at extension-construction time. If the fix instead hard-wired Rec to
+    // whatever row was current when the runner lazily built the extension instance, this
+    // would still read 'A' here and the test would catch it.
+    [Test]
+    procedure ExtActionReadsRecAgainstThePagesCurrentRow()
+    var
+        Stamp: Record "Pad Row";
+        HostPage: TestPage "Pad Host Page";
+    begin
+        Initialize();
+        SeedRows();
+
+        HostPage.OpenEdit();
+        HostPage.First();
+        HostPage.Next();
+        HostPage.ExtActionReadsRec.Invoke();
+        HostPage.Close();
+
+        Assert.IsTrue(Stamp.Get('REC-STAMP'), 'the extension action must have run');
+        Assert.AreEqual('B', Stamp.Descr,
+            'the extension action''s OnAction must have seen the row the page is positioned on, via Rec');
     end;
 }


### PR DESCRIPTION
Closes #1966

## Root cause

#1954 lazily constructs a pageextension's `NavFormExtension`-derived instance and then wires its `ParentObject` so `Rec`/`CurrPage` route to the base page's current row, via:

```csharp
var parentObjectProp = instance.GetType().GetProperty("ParentObject",
    BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
parentObjectProp?.SetValue(instance, _form);
```

`ParentObject` is declared on the *base* `NavFormExtension` class as `protected internal NavForm ParentObject { get; private set; }` (confirmed via ilspycmd decompile of `Microsoft.Dynamics.Nav.Ncl.dll`). .NET reflection only exposes a `private` accessor through the type that actually *declares* it — a `PropertyInfo` obtained via `instance.GetType()` (the derived `PageExtension{extId}` type) finds the property (its getter is visible), but its `SetValue` throws `ArgumentException: Property set method not found.` because the setter itself is private to `NavFormExtension`. That exception was caught by the surrounding try/catch and logged (visible only under `--verbose`, since `Log.cs`'s `[Component]`-tag filter swallows it by default), leaving `ParentObject` null.

The compiled `PageExtension{extId}.get_Rec()` (verified via ilspycmd on our own AL output) is:
```csharp
private NavRecord Rec => ((NavFormExtension)this).ParentObject.SourceTable;
```
so a null `ParentObject` NREs the instant the trigger body reads `Rec` — exactly the corpus failure signature (`NullReferenceException at PageExtension60723.get_Rec()`).

`AlRunner/Patches/GetCallerRecordPatches.cs` already resolves this same property correctly, via `typeof(NavFormExtension).GetProperty(...)` (the *declaring* type) rather than the instance's own type. This PR applies the same working pattern to `RunnerPageInstance.GetOrCreateExtensionInstance`.

## RED → GREEN

- Corpus (`tests/al-language` pinned at `2f892b1`, the commit #1963 bumps to): `Codeunit60724.ExtActionInvokeRunsTheOnActionTrigger`, `ExtActionInvokeRunsAgainstThePagesCurrentRow`, `ExtActionInvokeRunsOnlyItsOwnTrigger` — all NRE before the fix with the exact stack trace in #1966, all pass after (verified locally by pointing `--package-cache`/the bundle path at a checkout of the corpus branch; the submodule pin itself is untouched here per `al-language-submodule.md`).
- `tests/runner-extras/pageext-action-dispatch/`: added `ExtActionReadsRec` (a new pageextension action that reads `Rec."No."`) plus two proving tests — `ExtActionReadsRecAgainstFirstRow` and `ExtActionReadsRecAgainstThePagesCurrentRow` — that NRE before the fix (same signature, on the runner-local `PageExtension64522`) and assert a *specific* row value (`'A'` / `'B'`) after, matching whichever row the TestPage cursor is actually positioned on. This closes the exact gap #1966 describes: the four pre-existing tests in this suite never read `Rec`, so they stayed green while this was broken.
- `dotnet test AlRunner.Tests`: 754 passed, 1 pre-existing unrelated failure (`BcCompilerSharedReferenceMemoTests.AddingAPackageToAScannedDir_ForcesARebuild`, reproduces identically on `origin/main` HEAD with this branch's changes stashed out — confirmed not caused by this change).
- `tests/runner-extras` full bundle with `--count-baseline`: 144/144 pass, exits 0, no DROP/GROWTH diagnostic (baseline bumped 142→144 / 136→138 in the same PR for the 2 new tests).

## Pin bump sequencing

This PR does **not** touch `tests/al-language` or bump its submodule pin — that stays in #1963, which can now be rebased/merged after this lands (or in either order, since this fix doesn't depend on the pin being bumped; the corpus test already exists upstream at `2f892b1`/#56 and was used here only to reproduce and verify locally).