### PR TITLE
chore(corpus): bump al-language pin to 41013f6

### DIFF
--- a/tests/expectations/count-baseline/test-count-baseline.json
+++ b/tests/expectations/count-baseline/test-count-baseline.json
@@ -2,7 +2,7 @@
   "_comment": "Consumed by --count-baseline (AlRunner/Infrastructure/CountBaseline.cs), a DIFFERENT schema from the oos-/known-gaps-/divergence-/disabled- files in this directory: those declare the expected CLASSIFICATION of one named test, this declares the expected EXACT COUNT of a whole suite -- an exact match, not a floor: a mismatch in EITHER direction (drop OR growth) fails the run (exit 4). See #1880 and PR #1882's review for why growth is also a hard failure, not just a notice. Suite keys are the basename of the bundle directory CI passes on the command line (tests/al-language/tests/al-language -> 'al-language', tests/runner-extras -> 'runner-extras'), matching the '--out <name>-results.json' convention CI already uses. Values below are read off actual Test Matrix CI runs (see PR discussion for run URLs), not guessed: al-language's 2073->2076 bump reflects 3 corpus tests merged upstream between when the local baseline was drafted and when CI first ran against it. runner-extras' appGroups 23->21 byBcVersion override on 27.0/27.3/27.5 is the SAME preprocessor-gated-surface split that already explains its tests count divergence: fewer AL surfaces compile pre-28.0, which drops whole app groups, not just individual tests within a group. ANY PR that changes a suite's test or app-group count -- growth included -- MUST bump the matching number here in the SAME PR, or that PR's CI goes red with a [count-baseline] DROP or GROWTH diagnostic naming the exact expected/actual numbers to use.",
   "suites": {
     "al-language": {
-      "tests": { "default": 2104 },
+      "tests": { "default": 2107 },
       "appGroups": { "default": 1 }
     },
     "runner-extras": {


### PR DESCRIPTION
Bumps the `tests/al-language` submodule from `2f892b1` to `41013f6`, and the al-language count baseline from 2104 to 2107.

Picks up [upstream #58](https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/58), the proof for the one genuine bug found while clearing the single-site orphaned-hook cluster in #1970 (tracking issue #1883):

`NavHttpRequestMessage.get_Target` threw `ArgumentNullException("parent")` on a bare `var Req: HttpRequestMessage;` declaration. BC's real body constructs `SharedNavHttpRequestMessage(base.Tree.Session.Company.SharedObjects)`, and `Company.SharedObjects` is null on the headless skeleton. The declaration alone was enough to hit it, because the constructor eagerly touches `Target`.

The runner fix (a Cecil rewrite mirroring the sibling pattern) is already on main via #1970, so these three tests exercise the fixed behavior rather than failing by design. Upstream CI passed them against real BC 27.5 and 28.3.

Baseline 2104 to 2107 accounts for 3 new test procedures.
