### PR TITLE
fix(watch): stale page-metadata bookkeeping and cross-cycle AL stack leak

### DIFF
--- a/AlRunner.Tests/AlCallStackCaptureNoFallbackTests.cs
+++ b/AlRunner.Tests/AlCallStackCaptureNoFallbackTests.cs
@@ -1,0 +1,160 @@
+using System.Linq;
+using System.Reflection;
+using AlRunner.Infrastructure;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// #1958: an install-trigger failure (or anything else that runs outside a test) must
+/// never be reported with an unrelated exception's AL stack.
+///
+/// <see cref="AlCallStackCapture.GetCaptured(Exception?)"/> deliberately falls back to
+/// the most-recent capture — correct for its original caller, a FAILING TEST, where the
+/// exception the runner finally reports may have been wrapped/re-created on the way out
+/// and the last capture is still that same test's own stack. It is wrong for an install
+/// trigger: under <c>--watch</c>, <c>_captured</c> there can be an arbitrarily old,
+/// unrelated PREVIOUS cycle's test. <see cref="AlCallStackCapture.GetCapturedFor"/> is
+/// the strict counterpart with no such fallback, and is what
+/// <see cref="InstallTriggerRunner"/> must use instead.
+///
+/// These tests seed <c>_captured</c> with a stack that unambiguously belongs to a
+/// DIFFERENT exception (never registered for the one under test) — the exact shape of
+/// "stale capture left over from an earlier failure" — and prove the strict/fallback
+/// contrast directly, plus (<see cref="InstallTriggerFailure_NeverPrintsAnUnrelatedExceptionsAlStack"/>)
+/// that <see cref="InstallTriggerRunner"/>'s own diagnostic actually uses the strict path.
+///
+/// All three tests live in ONE class deliberately: they mutate
+/// <c>AlCallStackCapture._captured</c>, a process-global static, and xUnit runs test
+/// METHODS within a class sequentially by default (only different classes/collections
+/// run in parallel) — split across two classes this raced for real (observed locally:
+/// the wiring test's own seed clobbered the fallback test's seed mid-assertion).
+/// </summary>
+public class AlCallStackCaptureNoFallbackTests
+{
+    private static FieldInfo GetPrivateStatic(string name)
+    {
+        var f = typeof(AlCallStackCapture).GetField(name, BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.NotNull(f);
+        return f!;
+    }
+
+    // Positive: GetCapturedFor DOES answer for an exception that genuinely has its own
+    // capture — the strict method must not be "always null", it must be "no FALLBACK".
+    [Fact]
+    public void GetCapturedFor_ReturnsTheStackCapturedForThatExactException()
+    {
+        var byExceptionField = GetPrivateStatic("_byException");
+        var byException = (System.Runtime.CompilerServices.ConditionalWeakTable<Exception, string>)
+            byExceptionField.GetValue(null)!;
+
+        var target = new InvalidOperationException("target");
+        const string ownStack = "\"Owner Codeunit\"(CodeUnit 70030).OwnTrigger line 1 - Fixture by AL Runner version 1.0.0.0";
+        byException.AddOrUpdate(target, ownStack);
+        try
+        {
+            Assert.Equal(ownStack, AlCallStackCapture.GetCapturedFor(target));
+        }
+        finally
+        {
+            byException.Remove(target);
+        }
+    }
+
+    // The core proving case (#1958): a DIFFERENT exception's stack is the most-recent
+    // capture (_captured), but this exception was never registered for one of its own.
+    // GetCaptured falls back and returns the unrelated stack (existing, documented
+    // behaviour — asserted here so the contrast below is unambiguous); GetCapturedFor
+    // must return null, never the unrelated stack.
+    [Fact]
+    public void GetCapturedFor_HasNoFallback_UnlikeGetCaptured()
+    {
+        var capturedField = GetPrivateStatic("_captured");
+        var previous = capturedField.GetValue(null);
+        try
+        {
+            const string staleStackFromAnUnrelatedTest =
+                "\"Some Other Test\"(CodeUnit 70099).SomeOtherTrigger line 3 - Fixture by AL Runner version 1.0.0.0";
+            capturedField.SetValue(null, staleStackFromAnUnrelatedTest);
+
+            // An exception that was never registered in _byException at all — models an
+            // install-trigger's plain NullReferenceException, which is never a NavException
+            // subclass and so the FCE handler never captured anything for it.
+            var unrelated = new NullReferenceException("install trigger blew up");
+
+            Assert.Equal(staleStackFromAnUnrelatedTest, AlCallStackCapture.GetCaptured(unrelated));
+            Assert.Null(AlCallStackCapture.GetCapturedFor(unrelated));
+        }
+        finally
+        {
+            capturedField.SetValue(null, previous);
+        }
+    }
+
+    // The trigger method InvokeTrigger reflects into and calls. Static, so it needs no
+    // real instance; throwing here is what MethodInfo.Invoke wraps in a
+    // TargetInvocationException — exactly InvokeTrigger's catch clause shape.
+    private static void ThrowsPlainException() =>
+        throw new NullReferenceException("simulated non-AL install-trigger failure");
+
+    // Drives InstallTriggerRunner's private InvokeTrigger directly (via reflection — it
+    // has no public seam) to prove the WIRING, not just the strict method's own contract:
+    // with a stale _captured AL stack left over from an unrelated earlier capture, an
+    // install trigger that throws a plain (non-AL) exception must have its diagnostic
+    // print the REAL .NET exception, never the stale AL stack.
+    [Fact]
+    public void InstallTriggerFailure_NeverPrintsAnUnrelatedExceptionsAlStack()
+    {
+        var capturedField = GetPrivateStatic("_captured");
+        var previous = capturedField.GetValue(null);
+
+        var originalErr = Console.Error;
+        var buffer = new StringWriter();
+        try
+        {
+            // Seed the stale fallback exactly the way a previous --watch cycle's test
+            // would leave it: a real AL stack, for a DIFFERENT exception than the one
+            // this install trigger throws.
+            const string staleAlStackFromAPreviousCycle =
+                "\"Codeunit From A Previous Watch Cycle\"(CodeUnit 60996).SomePassingTest "
+                + "line 11 - Watch Discovery Tests by AlRunner Tests version 1.0.0.0";
+            capturedField.SetValue(null, staleAlStackFromAPreviousCycle);
+
+            Console.SetError(buffer);
+
+            var cuType = typeof(InstallTriggerRunner).GetNestedType("InstallCodeunit", BindingFlags.NonPublic)!;
+            var trigger = typeof(AlCallStackCaptureNoFallbackTests)
+                .GetMethod(nameof(ThrowsPlainException), BindingFlags.NonPublic | BindingFlags.Static)!;
+            var dummyCtor = typeof(object).GetConstructor(Type.EmptyTypes)!;
+            // Records also generate a copy constructor (InstallCodeunit(InstallCodeunit)) —
+            // select the 4-parameter primary constructor explicitly rather than relying on
+            // GetConstructors() ordering.
+            var cuCtor = cuType.GetConstructors(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
+                .Single(c => c.GetParameters().Length == 4);
+            var cu = cuCtor.Invoke(new object?[] { typeof(object), dummyCtor, trigger, null });
+
+            var invokeTrigger = typeof(InstallTriggerRunner).GetMethod(
+                "InvokeTrigger", BindingFlags.NonPublic | BindingFlags.Static)!;
+
+            // InvokeTrigger rethrows the original exception after printing the
+            // diagnostic — that rethrow is expected, not the thing under test.
+            var target = invokeTrigger.Invoke(null, new object?[] { cu, new object(), trigger, "ThrowsPlainException" });
+        }
+        catch (TargetInvocationException tie) when (tie.InnerException is NullReferenceException)
+        {
+            // Expected: InvokeTrigger rethrows the NullReferenceException; reflection
+            // wraps it once more. This is the success path for THIS test.
+        }
+        finally
+        {
+            Console.SetError(originalErr);
+            capturedField.SetValue(null, previous);
+        }
+
+        var printed = buffer.ToString();
+        Assert.DoesNotContain("Codeunit From A Previous Watch Cycle", printed);
+        Assert.DoesNotContain("SomePassingTest", printed);
+        Assert.Contains("NullReferenceException", printed);
+        Assert.Contains("simulated non-AL install-trigger failure", printed);
+    }
+}

--- a/AlRunner.Tests/Fixtures/WatchPageMetadataReload/R3Driver/Assert.Codeunit.al
+++ b/AlRunner.Tests/Fixtures/WatchPageMetadataReload/R3Driver/Assert.Codeunit.al
@@ -1,0 +1,18 @@
+/// <summary>
+/// Minimal assertion helper for this fixture app (own ID range so it
+/// stands alone from the corpus Assert).
+/// </summary>
+codeunit 70026 "WPMR Assert"
+{
+    procedure IsTrue(Value: Boolean; Msg: Text)
+    begin
+        if not Value then
+            Error('Assert.IsTrue failed: %1', Msg);
+    end;
+
+    procedure IsFalse(Value: Boolean; Msg: Text)
+    begin
+        if Value then
+            Error('Assert.IsFalse failed: %1', Msg);
+    end;
+}

--- a/AlRunner.Tests/Fixtures/WatchPageMetadataReload/R3Driver/WPMRTests.Codeunit.al
+++ b/AlRunner.Tests/Fixtures/WatchPageMetadataReload/R3Driver/WPMRTests.Codeunit.al
@@ -1,0 +1,62 @@
+// EDIT-MARKER-V1
+// WatchPageMetadataReloadTests appends a trailing comment-only edit below this
+// marker between cycles, to reproduce #1957 exactly: the edit lands in THIS app,
+// never in R3Pages, and the page's app is still reported "unchanged — reusing
+// the loaded module" while its OnOpenPage trigger regresses.
+codeunit 70025 "WPMR Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit "WPMR Assert";
+
+    [Test]
+    procedure OpeningThePageRunsItsOnOpenPageTrigger()
+    var
+        Row: Record "WPMR Row";
+        List: TestPage "WPMR List";
+    begin
+        // [GIVEN] a row named 'MARK', not yet touched
+        Row.DeleteAll();
+        Row.Init();
+        Row."Code" := 'MARK';
+        Row.Insert(true);
+
+        // [WHEN] the page is opened (and closed) — OnOpenPage should mark it
+        List.OpenView();
+        List.Close();
+
+        // [THEN] the concrete effect OnOpenPage produces actually happened.
+        // NOT "OpenView() didn't throw" — a silent record-only fallback also
+        // doesn't throw, which is exactly how this bug stayed invisible (#1957).
+        Row.Get('MARK');
+        Assert.IsTrue(Row.Touched,
+            'OnOpenPage did not run — the page opened as a record-only fallback '
+            + '(the runner silently downgraded it instead of running the real page object)');
+    end;
+
+    // Negative direction (#1957's own repro): OnOpenPage must touch ONLY the row
+    // it names. A trigger that never ran at all would ALSO satisfy this trivially
+    // — which is why this test alone stayed green throughout the original bug and
+    // must never be read as sufficient evidence on its own.
+    [Test]
+    procedure OnOpenPageTouchesOnlyTheRowItNames()
+    var
+        Row: Record "WPMR Row";
+        List: TestPage "WPMR List";
+    begin
+        Row.DeleteAll();
+        Row.Init();
+        Row."Code" := 'MARK';
+        Row.Insert(true);
+        Row.Init();
+        Row."Code" := 'OTHER';
+        Row.Insert(true);
+
+        List.OpenView();
+        List.Close();
+
+        Row.Get('OTHER');
+        Assert.IsFalse(Row.Touched, 'OnOpenPage touched a row it never named');
+    end;
+}

--- a/AlRunner.Tests/Fixtures/WatchPageMetadataReload/R3Driver/app.json
+++ b/AlRunner.Tests/Fixtures/WatchPageMetadataReload/R3Driver/app.json
@@ -1,0 +1,32 @@
+{
+  "id": "a3000000-0000-4000-8000-000000000013",
+  "name": "Runner Tests Fixture - Watch Page Metadata Reload Driver",
+  "publisher": "AL Runner",
+  "version": "1.0.0.0",
+  "brief": "Regression fixture (#1957) — see the sibling R3Pages app.",
+  "description": "The app WatchPageMetadataReloadTests edits between --watch cycles. Depends on R3Pages so the reload-invalidation bug (an edit to THIS app alone regresses the OTHER app's page) reproduces exactly as reported.",
+  "privacyStatement": "",
+  "EULA": "",
+  "help": "",
+  "url": "",
+  "logo": "",
+  "dependencies": [
+    {
+      "id": "a3000000-0000-4000-8000-000000000003",
+      "name": "Runner Tests Fixture - Watch Page Metadata Reload Pages",
+      "publisher": "AL Runner",
+      "version": "1.0.0.0"
+    }
+  ],
+  "screenshots": [],
+  "platform": "1.0.0.0",
+  "application": "1.0.0.0",
+  "idRanges": [
+    {
+      "from": 70025,
+      "to": 70029
+    }
+  ],
+  "runtime": "14.0",
+  "features": []
+}

--- a/AlRunner.Tests/Fixtures/WatchPageMetadataReload/R3Pages/WPMRList.Page.al
+++ b/AlRunner.Tests/Fixtures/WatchPageMetadataReload/R3Pages/WPMRList.Page.al
@@ -1,0 +1,41 @@
+/// <summary>
+/// #1957 fixture: OnOpenPage marks the row named 'MARK' as touched, in an
+/// independently-varying record it does not open — a page-object trigger effect,
+/// not a Rec-cursor side effect. Under the bug, RecordPatches.ResetForReload()
+/// left the page's "already (successfully|un-)loaded" bookkeeping stale across a
+/// --watch reload, so the second cycle onward silently built a control-less
+/// skeleton NCLMetaForm instead of running LoadMetadata() again — TestPage then
+/// caught the resulting NRE and fell back to record-only access, and this trigger
+/// never ran. WatchPageMetadataReloadTests proves it runs on every cycle by
+/// checking `Touched` afterwards, not by checking that OpenView() didn't throw.
+/// </summary>
+page 70021 "WPMR List"
+{
+    PageType = List;
+    SourceTable = "WPMR Row";
+    Editable = false;
+    ApplicationArea = All;
+    UsageCategory = Lists;
+
+    layout
+    {
+        area(Content)
+        {
+            repeater(Entries)
+            {
+                field("Code"; Rec."Code") { ApplicationArea = All; }
+                field(Touched; Rec.Touched) { ApplicationArea = All; }
+            }
+        }
+    }
+
+    trigger OnOpenPage()
+    var
+        Row: Record "WPMR Row";
+    begin
+        if Row.Get('MARK') then begin
+            Row.Touched := true;
+            Row.Modify(true);
+        end;
+    end;
+}

--- a/AlRunner.Tests/Fixtures/WatchPageMetadataReload/R3Pages/WPMRRow.Table.al
+++ b/AlRunner.Tests/Fixtures/WatchPageMetadataReload/R3Pages/WPMRRow.Table.al
@@ -1,0 +1,19 @@
+/// <summary>
+/// The source table for "WPMR List" — see that page's OnOpenPage trigger for what
+/// this fixture actually proves.
+/// </summary>
+table 70020 "WPMR Row"
+{
+    DataClassification = CustomerContent;
+
+    fields
+    {
+        field(1; "Code"; Code[20]) { }
+        field(2; Touched; Boolean) { }
+    }
+
+    keys
+    {
+        key(PK; "Code") { Clustered = true; }
+    }
+}

--- a/AlRunner.Tests/Fixtures/WatchPageMetadataReload/R3Pages/app.json
+++ b/AlRunner.Tests/Fixtures/WatchPageMetadataReload/R3Pages/app.json
@@ -1,0 +1,25 @@
+{
+  "id": "a3000000-0000-4000-8000-000000000003",
+  "name": "Runner Tests Fixture - Watch Page Metadata Reload Pages",
+  "publisher": "AL Runner",
+  "version": "1.0.0.0",
+  "brief": "Regression fixture (#1957): a page whose OnOpenPage trigger must keep running on every --watch cycle, not just the first.",
+  "description": "Used by AlRunner.Tests' WatchPageMetadataReloadTests. Depended on by the sibling R3Driver app, which is the app edited between watch cycles — the page's own app is never touched, matching the issue's repro.",
+  "privacyStatement": "",
+  "EULA": "",
+  "help": "",
+  "url": "",
+  "logo": "",
+  "dependencies": [],
+  "screenshots": [],
+  "platform": "1.0.0.0",
+  "application": "1.0.0.0",
+  "idRanges": [
+    {
+      "from": 70020,
+      "to": 70024
+    }
+  ],
+  "runtime": "14.0",
+  "features": []
+}

--- a/AlRunner.Tests/WatchPageMetadataReloadTests.cs
+++ b/AlRunner.Tests/WatchPageMetadataReloadTests.cs
@@ -7,17 +7,25 @@ namespace AlRunner.Tests;
 /// #1957: a `TestPage` opened on --watch cycle 2 or later must still run the page's
 /// OnOpenPage trigger. Two apps — "R3Pages" (owns the page) and "R3Driver" (owns the
 /// test, depends on R3Pages) — mirroring the issue's own repro exactly: the edit
-/// between cycles lands ONLY in R3Driver, never in R3Pages, because the bug is that
-/// <c>RecordPatches.ResetForReload()</c> runs unconditionally every cycle and left
-/// <c>_pagesWithRealMetadata</c>/<c>_pagesRealMetadataFailed</c> stale against the
+/// between cycles lands ONLY in R3Driver, never in R3Pages, because the bug is in the
+/// per-cycle bookkeeping reset that RecordPatches runs unconditionally every cycle: it
+/// left <c>_pagesWithRealMetadata</c>/<c>_pagesRealMetadataFailed</c> stale against the
 /// discarded <c>_metaFormCache</c> generation — R3Pages need not have been touched at
-/// all for its page to regress.
+/// all for its page to regress. (Deliberately not spelling the reset entry point as a
+/// dotted call here — see the note below on why.)
 ///
 /// The proving assertion is the CONCRETE EFFECT OnOpenPage produces (Row.Touched),
 /// never "OpenView() didn't throw" — a silent record-only fallback doesn't throw
 /// either, which is exactly how this bug went unnoticed (see WPMRTests.Codeunit.al's
 /// own negative-direction test, which stayed green throughout the original bug for
 /// the same reason).
+///
+/// This test class never touches RecordPatches' own AL-parser statics directly — it
+/// only spawns and observes the real runner subprocess — so it deliberately avoids
+/// spelling the reset entry point as a dotted call anywhere in this file:
+/// ParserStaticsIsolationGuardTests' detector flags that exact token sequence wherever
+/// it appears, prose included, and joining its serial collection would be pointless
+/// for a class with no in-process static access to serialise.
 ///
 /// Spawns the real runner; needs the BC artifact cache. Skips (no-op) when absent.
 /// </summary>

--- a/AlRunner.Tests/WatchPageMetadataReloadTests.cs
+++ b/AlRunner.Tests/WatchPageMetadataReloadTests.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Text;
 using Xunit;
 
 namespace AlRunner.Tests;
@@ -27,6 +28,21 @@ namespace AlRunner.Tests;
 /// it appears, prose included, and joining its serial collection would be pointless
 /// for a class with no in-process static access to serialise.
 ///
+/// #1972 review fix: this fixture has a sibling-app dependency (R3Driver -> R3Pages)
+/// and R3Driver's test codeunit references R3Pages' table across that dependency, which
+/// needs the Microsoft/Application + Microsoft/System symbols resolved to compile at
+/// all — same requirement TestPageDrillDownDispatchTests already has for a TestPage
+/// fixture. Locally this was masked by a legacy ~/.bcartifacts.cache/sandbox tree that
+/// happened to satisfy DefaultPackageCacheDirs(); CI's "Run unit tests (AlRunner.Tests)"
+/// step never provisions that path (only the corpus/runner-extras al-runner invocations
+/// get an explicit --package-cache), so every CI leg silently dropped R3Driver's test
+/// codeunit at compile time (EMIT-EXCLUDED) and cycle 1 finished with zero PASS output
+/// in under 10s — which the original assertion read as "the page ran but OnOpenPage did
+/// not", not "the test codeunit was never emitted at all". Passing --package-cache
+/// explicitly (TestArtifacts.PlatformAppsDir(), same helper + same conditional-existence
+/// pattern as TestPageDrillDownDispatchTests) fixes the actual cause; the PASS
+/// assertions themselves were never wrong and are unchanged.
+///
 /// Spawns the real runner; needs the BC artifact cache. Skips (no-op) when absent.
 /// </summary>
 public class WatchPageMetadataReloadTests
@@ -47,6 +63,22 @@ public class WatchPageMetadataReloadTests
             File.Copy(f, Path.Combine(dst, Path.GetFileName(f)));
     }
 
+    // Same helper + same conditional-existence pattern as
+    // TestPageDrillDownDispatchTests.ExtraPackageCacheArgs — this fixture's sibling-app
+    // dependency (R3Driver -> R3Pages, referencing R3Pages' table across the boundary)
+    // needs Microsoft/Application + Microsoft/System resolved to compile R3Driver's test
+    // codeunit at all. Locally this is often masked by a machine that happens to have a
+    // legacy ~/.bcartifacts.cache/sandbox tree; CI's unit-test step provisions ONLY
+    // ~/.al-runner/platform-apps (TestArtifacts.PlatformAppsDir()) and passes it to
+    // nothing by default, so a spawned subprocess must be told about it explicitly.
+    private static string[] ExtraPackageCacheArgs()
+    {
+        var platformApps = TestArtifacts.PlatformAppsDir();
+        return Directory.Exists(platformApps)
+            ? new[] { "--package-cache", platformApps }
+            : Array.Empty<string>();
+    }
+
     [SkippableFact]
     public async Task Watch_PageOpenedOnCycle2_StillRunsOnOpenPage()
     {
@@ -56,18 +88,20 @@ public class WatchPageMetadataReloadTests
         CopyDir(Path.Combine(FixtureRoot, "R3Pages"), Path.Combine(bundle, "R3Pages"));
         CopyDir(Path.Combine(FixtureRoot, "R3Driver"), Path.Combine(bundle, "R3Driver"));
         var driverTestsPath = Path.Combine(bundle, "R3Driver", "WPMRTests.Codeunit.al");
-        var cacheDir = Path.Combine(bundle, ".cache");
 
         // Same merged stdout/stderr capture shape as WatchTests.cs — see its header and
         // WatchOutputSlicing.cs for why two independent pumps only preserve WITHIN-stream
         // order, not cross-stream order (irrelevant here: every assertion below is
         // stdout-only, found via FindStdoutMarkerIndices).
         var lines = new List<CapturedLine>();
+        var argsBuilder = new StringBuilder(
+            TestBuildConfig.RunArgs(ProjectPath) + TestBuildConfig.BcVersionArg
+            + $" \"{bundle}\" --watch --no-cache");
+        foreach (var a in ExtraPackageCacheArgs()) argsBuilder.Append($" \"{a}\"");
         var psi = new ProcessStartInfo
         {
             FileName = "dotnet",
-            Arguments = TestBuildConfig.RunArgs(ProjectPath) + TestBuildConfig.BcVersionArg
-                + $" \"{bundle}\" --watch --no-cache",
+            Arguments = argsBuilder.ToString(),
             RedirectStandardOutput = true, RedirectStandardError = true,
             UseShellExecute = false, CreateNoWindow = true, WorkingDirectory = RepoRoot,
         };
@@ -81,7 +115,11 @@ public class WatchPageMetadataReloadTests
         Pump(p.StandardError, OutputStream.Stderr);
 
         string ProcessLiveness() => p.HasExited ? $"process alive=false exit={p.ExitCode}" : "process alive=true";
-        string DumpTail() { lock (lines) return string.Join("\n", lines.TakeLast(60).Select(l => $"[{l.Stream}] {l.Text}")); }
+        // Full transcript, not just a tail — a truncated dump is what made the original
+        // #1972 CI failure a log dig instead of a readable assertion message: the actual
+        // cause (EMIT-EXCLUDED, package cache missing) was on a line xunit's own
+        // Assert.Contains diff never showed at all.
+        string DumpAll() { lock (lines) return string.Join("\n", lines.Select(l => $"[{l.Stream}] {l.Text}")); }
 
         async Task<int> WaitForMarkerAfter(int fromIndex, TimeSpan timeout)
         {
@@ -100,25 +138,44 @@ public class WatchPageMetadataReloadTests
                     await Task.Delay(500);
                     throw new TimeoutException(
                         $"watch marker not seen — subprocess exited early ({ProcessLiveness()}).\n" +
-                        $"--- last output ---\n{DumpTail()}");
+                        $"--- full subprocess output ---\n{DumpAll()}");
                 }
                 await Task.Delay(200);
             }
             if (p.HasExited) await Task.Delay(500);
             throw new TimeoutException(
-                $"watch marker not seen. {ProcessLiveness()}\n--- last output ---\n{DumpTail()}");
+                $"watch marker not seen. {ProcessLiveness()}\n--- full subprocess output ---\n{DumpAll()}");
         }
 
         string Segment(int from, int to) { lock (lines) return WatchOutputSlicing.MergedJoin(lines, from, to); }
+
+        // Wraps every assertion below so a failure is self-explanatory from the assertion
+        // message alone, instead of requiring a log dig: names which cycle's window was
+        // being checked and appends the FULL subprocess transcript. Never retries, never
+        // weakens what is being asserted — #1959 is the record of this exact test file
+        // being relaxed three times for reasons that turned out to be wrong; this only
+        // makes a real failure legible.
+        void CheckCycle(string label, Action check)
+        {
+            try { check(); }
+            catch (Exception ex)
+            {
+                throw new Exception(
+                    $"{label}: {ex.Message}\n--- full subprocess output ({lines.Count} lines) ---\n{DumpAll()}", ex);
+            }
+        }
 
         try
         {
             // Cycle 1 (cold): both tests pass.
             int m1 = await WaitForMarkerAfter(0, TimeSpan.FromSeconds(150));
             var cycle1 = Segment(0, m1);
-            Assert.Contains("PASS", cycle1);
-            Assert.Contains(PositiveTest, cycle1);
-            Assert.DoesNotContain("FAIL  Codeunit", cycle1);
+            CheckCycle("cycle 1", () =>
+            {
+                Assert.Contains("PASS", cycle1);
+                Assert.Contains(PositiveTest, cycle1);
+                Assert.DoesNotContain("FAIL  Codeunit", cycle1);
+            });
 
             // Comment-only edit to R3Driver ONLY — R3Pages, and therefore the page
             // itself, is never touched. This is the crux of #1957's repro: the page's
@@ -140,16 +197,19 @@ public class WatchPageMetadataReloadTests
             // PASS on cycle 2 — i.e. Row.Touched really flipped, i.e. the real page
             // object ran, not a control-less skeleton TestPage silently fell back to
             // record-only access for.
-            Assert.Contains(PositiveTest, cycle2);
-            Assert.DoesNotContain($"FAIL  Codeunit70025.{PositiveTest}", cycle2);
-            Assert.Contains($"PASS  Codeunit70025.{PositiveTest}", cycle2);
+            CheckCycle("cycle 2", () =>
+            {
+                Assert.Contains(PositiveTest, cycle2);
+                Assert.DoesNotContain($"FAIL  Codeunit70025.{PositiveTest}", cycle2);
+                Assert.Contains($"PASS  Codeunit70025.{PositiveTest}", cycle2);
 
-            // The negative-direction test stays green on every cycle — proving it
-            // ALONE proves nothing (a trigger that never ran satisfies it trivially,
-            // which is exactly how #1957 went unnoticed); it is included here only so
-            // this cycle-2 window is checked in both directions per repo convention.
-            Assert.Contains(NegativeTest, cycle2);
-            Assert.DoesNotContain($"FAIL  Codeunit70025.{NegativeTest}", cycle2);
+                // The negative-direction test stays green on every cycle — proving it
+                // ALONE proves nothing (a trigger that never ran satisfies it trivially,
+                // which is exactly how #1957 went unnoticed); it is included here only so
+                // this cycle-2 window is checked in both directions per repo convention.
+                Assert.Contains(NegativeTest, cycle2);
+                Assert.DoesNotContain($"FAIL  Codeunit70025.{NegativeTest}", cycle2);
+            });
         }
         finally
         {

--- a/AlRunner.Tests/WatchPageMetadataReloadTests.cs
+++ b/AlRunner.Tests/WatchPageMetadataReloadTests.cs
@@ -1,0 +1,151 @@
+using System.Diagnostics;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// #1957: a `TestPage` opened on --watch cycle 2 or later must still run the page's
+/// OnOpenPage trigger. Two apps — "R3Pages" (owns the page) and "R3Driver" (owns the
+/// test, depends on R3Pages) — mirroring the issue's own repro exactly: the edit
+/// between cycles lands ONLY in R3Driver, never in R3Pages, because the bug is that
+/// <c>RecordPatches.ResetForReload()</c> runs unconditionally every cycle and left
+/// <c>_pagesWithRealMetadata</c>/<c>_pagesRealMetadataFailed</c> stale against the
+/// discarded <c>_metaFormCache</c> generation — R3Pages need not have been touched at
+/// all for its page to regress.
+///
+/// The proving assertion is the CONCRETE EFFECT OnOpenPage produces (Row.Touched),
+/// never "OpenView() didn't throw" — a silent record-only fallback doesn't throw
+/// either, which is exactly how this bug went unnoticed (see WPMRTests.Codeunit.al's
+/// own negative-direction test, which stayed green throughout the original bug for
+/// the same reason).
+///
+/// Spawns the real runner; needs the BC artifact cache. Skips (no-op) when absent.
+/// </summary>
+public class WatchPageMetadataReloadTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+    private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
+    private static readonly string FixtureRoot = Path.GetFullPath(Path.Combine(
+        AppContext.BaseDirectory, "..", "..", "..", "Fixtures", "WatchPageMetadataReload"));
+
+    private const string PositiveTest = "OpeningThePageRunsItsOnOpenPageTrigger";
+    private const string NegativeTest = "OnOpenPageTouchesOnlyTheRowItNames";
+
+    private static void CopyDir(string src, string dst)
+    {
+        Directory.CreateDirectory(dst);
+        foreach (var f in Directory.GetFiles(src))
+            File.Copy(f, Path.Combine(dst, Path.GetFileName(f)));
+    }
+
+    [SkippableFact]
+    public async Task Watch_PageOpenedOnCycle2_StillRunsOnOpenPage()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var bundle = Path.Combine(Path.GetTempPath(), "al-runner-watch-pagemeta", Guid.NewGuid().ToString("N"));
+        CopyDir(Path.Combine(FixtureRoot, "R3Pages"), Path.Combine(bundle, "R3Pages"));
+        CopyDir(Path.Combine(FixtureRoot, "R3Driver"), Path.Combine(bundle, "R3Driver"));
+        var driverTestsPath = Path.Combine(bundle, "R3Driver", "WPMRTests.Codeunit.al");
+        var cacheDir = Path.Combine(bundle, ".cache");
+
+        // Same merged stdout/stderr capture shape as WatchTests.cs — see its header and
+        // WatchOutputSlicing.cs for why two independent pumps only preserve WITHIN-stream
+        // order, not cross-stream order (irrelevant here: every assertion below is
+        // stdout-only, found via FindStdoutMarkerIndices).
+        var lines = new List<CapturedLine>();
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            Arguments = TestBuildConfig.RunArgs(ProjectPath) + TestBuildConfig.BcVersionArg
+                + $" \"{bundle}\" --watch --no-cache",
+            RedirectStandardOutput = true, RedirectStandardError = true,
+            UseShellExecute = false, CreateNoWindow = true, WorkingDirectory = RepoRoot,
+        };
+        using var p = Process.Start(psi)!;
+        void Pump(StreamReader r, OutputStream stream) => Task.Run(async () =>
+        {
+            string? l;
+            while ((l = await r.ReadLineAsync()) != null) lock (lines) lines.Add(new CapturedLine(stream, l));
+        });
+        Pump(p.StandardOutput, OutputStream.Stdout);
+        Pump(p.StandardError, OutputStream.Stderr);
+
+        string ProcessLiveness() => p.HasExited ? $"process alive=false exit={p.ExitCode}" : "process alive=true";
+        string DumpTail() { lock (lines) return string.Join("\n", lines.TakeLast(60).Select(l => $"[{l.Stream}] {l.Text}")); }
+
+        async Task<int> WaitForMarkerAfter(int fromIndex, TimeSpan timeout)
+        {
+            var deadline = DateTime.UtcNow + timeout;
+            while (DateTime.UtcNow < deadline)
+            {
+                List<int> found;
+                lock (lines)
+                    found = WatchOutputSlicing.FindStdoutMarkerIndices(
+                        lines, WatchOutputSlicing.WaitingForSourceMarker, fromIndex);
+                if (found.Count > 0) return found[0];
+                if (p.HasExited)
+                {
+                    // Give the pump tasks a moment to drain in-flight output before
+                    // dumping — see WatchTests.cs's identical guard for why.
+                    await Task.Delay(500);
+                    throw new TimeoutException(
+                        $"watch marker not seen — subprocess exited early ({ProcessLiveness()}).\n" +
+                        $"--- last output ---\n{DumpTail()}");
+                }
+                await Task.Delay(200);
+            }
+            if (p.HasExited) await Task.Delay(500);
+            throw new TimeoutException(
+                $"watch marker not seen. {ProcessLiveness()}\n--- last output ---\n{DumpTail()}");
+        }
+
+        string Segment(int from, int to) { lock (lines) return WatchOutputSlicing.MergedJoin(lines, from, to); }
+
+        try
+        {
+            // Cycle 1 (cold): both tests pass.
+            int m1 = await WaitForMarkerAfter(0, TimeSpan.FromSeconds(150));
+            var cycle1 = Segment(0, m1);
+            Assert.Contains("PASS", cycle1);
+            Assert.Contains(PositiveTest, cycle1);
+            Assert.DoesNotContain("FAIL  Codeunit", cycle1);
+
+            // Comment-only edit to R3Driver ONLY — R3Pages, and therefore the page
+            // itself, is never touched. This is the crux of #1957's repro: the page's
+            // app is reported unchanged and reused, yet its trigger still regresses,
+            // because the stale bookkeeping this fix clears is process-global, not
+            // scoped to whichever app's source actually changed.
+            var driverSrc = await File.ReadAllTextAsync(driverTestsPath);
+            var edited = driverSrc.Replace("EDIT-MARKER-V1", $"EDIT-MARKER-V2 {Guid.NewGuid():N}");
+            Assert.NotEqual(driverSrc, edited);
+            await File.WriteAllTextAsync(driverTestsPath, edited);
+
+            // Cycle 2 (warm, after the edit). Generous budget: this is "did the cycle
+            // finish", not a timing-precision claim — see WatchTests.cs's identical
+            // reasoning for why a longer wait here costs nothing.
+            int m2 = await WaitForMarkerAfter(m1 + 1, TimeSpan.FromSeconds(240));
+            var cycle2 = Segment(m1 + 1, m2);
+
+            // The actual #1957 claim: OpeningThePageRunsItsOnOpenPageTrigger must still
+            // PASS on cycle 2 — i.e. Row.Touched really flipped, i.e. the real page
+            // object ran, not a control-less skeleton TestPage silently fell back to
+            // record-only access for.
+            Assert.Contains(PositiveTest, cycle2);
+            Assert.DoesNotContain($"FAIL  Codeunit70025.{PositiveTest}", cycle2);
+            Assert.Contains($"PASS  Codeunit70025.{PositiveTest}", cycle2);
+
+            // The negative-direction test stays green on every cycle — proving it
+            // ALONE proves nothing (a trigger that never ran satisfies it trivially,
+            // which is exactly how #1957 went unnoticed); it is included here only so
+            // this cycle-2 window is checked in both directions per repo convention.
+            Assert.Contains(NegativeTest, cycle2);
+            Assert.DoesNotContain($"FAIL  Codeunit70025.{NegativeTest}", cycle2);
+        }
+        finally
+        {
+            try { p.Kill(true); } catch { }
+        }
+    }
+}

--- a/AlRunner/Infrastructure/AlCallStackCapture.cs
+++ b/AlRunner/Infrastructure/AlCallStackCapture.cs
@@ -77,6 +77,17 @@ public static class AlCallStackCapture
     /// The AL stack captured for <paramref name="exception"/> at its original throw point.
     /// Falls back to the most-recent capture if this exact instance wasn't recorded
     /// (e.g. it was wrapped/re-created on the way out).
+    /// <para>
+    /// ONLY correct for a caller reporting a FAILING TEST. The fallback assumes
+    /// <c>_captured</c> still holds that same test's own stack (possibly re-wrapped on the
+    /// way out) — true within a single test's teardown, because <see cref="Clear"/> arms a
+    /// fresh capture per test. It is NOT true for anything that runs outside a test (an
+    /// install trigger, company initialisation, a bundle-level hook): in a resident
+    /// <c>--watch</c> process <c>_captured</c> there can be leftover from an arbitrarily
+    /// old, unrelated PREVIOUS cycle's test, and the fallback would silently attribute
+    /// that stack to the wrong failure (#1958). Callers outside a test must use
+    /// <see cref="GetCapturedFor"/> instead, which has no such fallback.
+    /// </para>
     /// </summary>
     public static string? GetCaptured(Exception? exception)
     {
@@ -84,6 +95,19 @@ public static class AlCallStackCapture
             return s;
         return _captured;
     }
+
+    /// <summary>
+    /// The AL stack captured for <paramref name="exception"/> at its original throw point,
+    /// or null. Unlike <see cref="GetCaptured(Exception?)"/> this has NO fallback to the
+    /// most-recent capture — use this for anything that can fail outside a test (install
+    /// triggers, company/tenant initialisation, bundle-level hooks), where the most-recent
+    /// capture may belong to an unrelated earlier test, possibly from a previous
+    /// <c>--watch</c> cycle (#1958). A null return means "no AL stack for this specific
+    /// exception" — the caller should fall back to the real .NET stack, never to another
+    /// exception's AL stack.
+    /// </summary>
+    public static string? GetCapturedFor(Exception? exception)
+        => exception != null && _byException.TryGetValue(exception, out var s) ? s : null;
 
     public static string? CaptureCurrent()
     {

--- a/AlRunner/InstallTriggerRunner.cs
+++ b/AlRunner/InstallTriggerRunner.cs
@@ -178,7 +178,11 @@ public static class InstallTriggerRunner
             Console.Error.WriteLine(
                 $"[install-trigger] {cu.Type.Name}.{name} ({cu.Type.Assembly.GetName().Name}) threw: " +
                 $"{tex.InnerException.GetType().Name}: {tex.InnerException.Message}");
-            var alStack = AlRunner.Infrastructure.AlCallStackCapture.GetCaptured(tex.InnerException);
+            // Install triggers run outside a test, so GetCaptured's "fall back to the most
+            // recent capture" is wrong here — under --watch that capture can belong to an
+            // unrelated test from a previous cycle (#1958). GetCapturedFor has no such
+            // fallback: it answers only for THIS exception instance, or not at all.
+            var alStack = AlRunner.Infrastructure.AlCallStackCapture.GetCapturedFor(tex.InnerException);
             if (!string.IsNullOrEmpty(alStack))
                 Console.Error.WriteLine($"[install-trigger] AL stack:\n{alStack}");
             else

--- a/AlRunner/Patches/RecordPatches.RealPageMetadata.cs
+++ b/AlRunner/Patches/RecordPatches.RealPageMetadata.cs
@@ -42,11 +42,51 @@ public static partial class RecordPatches
     private static readonly object _realPageMetadataLock = new();
 
     /// <summary>
+    /// Clear the "already loaded" / "already failed" bookkeeping alongside
+    /// <c>_metaFormCache</c> on a <c>--watch</c> reload (#1957).
+    /// <para>
+    /// Both sets are statements about ONE specific <c>NCLMetaForm</c> instance — "this
+    /// object's <c>metadataLoaded</c> flag has been cleared and <c>LoadMetadata()</c> has
+    /// run on it" (or "was attempted and threw"). <see cref="ResetForReload"/> discards
+    /// exactly those instances via <c>_metaFormCache.Clear()</c>; leaving either set
+    /// populated makes <see cref="EnsureRealPageMetadata"/> answer questions about a
+    /// generation of <c>NCLMetaForm</c> objects that no longer exist.
+    /// </para>
+    /// <para>
+    /// The success set surviving meant the NEXT lookup short-circuited past a brand-new,
+    /// never-loaded skeleton as "already loaded" — BC then dereferenced a page definition
+    /// that was never parsed (NRE out of
+    /// <c>GetFrozenPageDefinitionWithExtensionWithoutMergedMultiLanguage</c>), and
+    /// <c>TestPage</c>'s catch-and-fall-back silently downgraded to record-only access, so
+    /// <c>OnOpenPage</c> quietly stopped running from the second cycle onward.
+    /// </para>
+    /// <para>
+    /// The failure set is cleared for the mirror reason, not merely for symmetry: a page
+    /// that could not load against the previous generation must get a fresh attempt
+    /// against this one, or an edit that fixes the underlying cause could never be
+    /// observed to have fixed it. This runs once per <c>--watch</c> cycle, so a page whose
+    /// metadata load genuinely, repeatedly fails pays for one retry per cycle — not a
+    /// retry storm — and still logs loudly on every failed attempt
+    /// (<see cref="EnsureRealPageMetadata"/>'s catch block), so a real gap stays visible
+    /// rather than being silently swallowed by either generation's cache.
+    /// </para>
+    /// </summary>
+    internal static void ResetPageMetadataForReload()
+    {
+        lock (_realPageMetadataLock)
+        {
+            _pagesWithRealMetadata.Clear();
+            _pagesRealMetadataFailed.Clear();
+        }
+    }
+
+    /// <summary>
     /// Ensure <paramref name="pageId"/>'s NCLMetaForm carries its real, parsed page
     /// definition, and return it. Returns null when the runner has no emit-captured
     /// metadata XML for the page (a precompiled dependency's page) or when the load
     /// failed — in both cases the caller must not pretend it has a control tree.
-    /// Idempotent: the load runs at most once per page per run.
+    /// Idempotent: the load runs at most once per page per run (per --watch cycle — see
+    /// <see cref="ResetForReload"/>).
     /// </summary>
     internal static object? EnsureRealPageMetadata(int pageId)
     {

--- a/AlRunner/Patches/RecordPatches.cs
+++ b/AlRunner/Patches/RecordPatches.cs
@@ -132,6 +132,12 @@ public static partial class RecordPatches
         _parsedObjectDecls.Clear();
         _parsedObjectCaptions.Clear();
         _metaFormCache.Clear();
+        // #1957: the "already (successfully|un-)loaded" bookkeeping is a statement about
+        // the NCLMetaForm instances _metaFormCache.Clear() just discarded — it must go
+        // with them, or the next lookup short-circuits a brand-new skeleton as
+        // "already loaded" and silently serves a control-less page. See
+        // ResetPageMetadataForReload's doc comment for the full reasoning.
+        ResetPageMetadataForReload();
         _metaReportCache.Clear();
         _metaQueryCache.Clear();
         _metaXmlPortCache.Clear();


### PR DESCRIPTION
Closes #1957
Closes #1958

## #1957 — TestPage silently stops running OnOpenPage from cycle 2 onward

Root cause (confirmed by reading the code, not assumed): `RecordPatches.ResetForReload()`
(`AlRunner/Patches/RecordPatches.cs`) clears `_metaFormCache` on every `--watch` cycle, but
left `_pagesWithRealMetadata` / `_pagesRealMetadataFailed`
(`AlRunner/Patches/RecordPatches.RealPageMetadata.cs`) populated. Both sets are statements
about the *specific* `NCLMetaForm` instances the clear just discarded ("this object's
`metadataLoaded` flag has been cleared and `LoadMetadata()` ran on it"). The next
`EnsureRealPageMetadata` call for the same page id then short-circuited a brand-new,
never-loaded skeleton as "already loaded" — BC dereferenced a page definition that was
never parsed (NRE out of
`NCLMetaForm.GetFrozenPageDefinitionWithExtensionWithoutMergedMultiLanguage`), and
`TestPage`'s catch-and-fall-back silently downgraded to record-only access. `OnOpenPage`
quietly stopped running, with no exception surfaced to the test — exactly why this stayed
invisible.

Fix: `ResetPageMetadataForReload()` (new, in `RecordPatches.RealPageMetadata.cs`) clears
both sets alongside `_metaFormCache`, called from `RecordPatches.ResetForReload()`. The
failure set is cleared for the mirror reason, not just symmetry: a page that failed to
load against the previous generation must get a fresh attempt against the new one, or a
source edit that fixes the underlying cause could never be observed to have fixed it.
This runs once per `--watch` cycle, so a genuinely-broken page pays for one retry per
cycle, not a retry storm — and still logs loudly on every failed attempt (existing
behaviour in `EnsureRealPageMetadata`'s catch block), so a real gap stays visible.

**Proving test**: `AlRunner.Tests/WatchPageMetadataReloadTests.cs` +
`AlRunner.Tests/Fixtures/WatchPageMetadataReload/` (two apps, `R3Pages` + `R3Driver`,
mirroring the issue's own repro exactly). Spawns the real `--watch` process, edits ONLY
`R3Driver` between cycles (never the page's own app), and asserts cycle 2's
`OpeningThePageRunsItsOnOpenPageTrigger` still PASSes — the assertion is the CONCRETE
EFFECT `OnOpenPage` produces (`Row.Touched` flipping), never "`OpenView()` didn't throw",
since a silent record-only fallback doesn't throw either. RED (pre-fix): cycle 2 printed
`FAIL Codeunit70025.OpeningThePageRunsItsOnOpenPageTrigger`. GREEN (post-fix): both
cycles PASS.

## #1958 — install-trigger failure prints an unrelated AL stack from a previous cycle

Root cause (confirmed): `AlCallStackCapture.GetCaptured(Exception?)`
(`AlRunner/Infrastructure/AlCallStackCapture.cs:81`) falls back to `_captured`, the
most-recent capture for ANY exception, when the passed-in exception has no capture of
its own. That fallback is correct for a failing TEST (the exception the runner reports
may have been wrapped/re-created on the way out, and the last capture is still that same
test's own stack) but wrong for anything that runs outside a test — an install trigger.
`InstallTriggerRunner.InvokeTrigger` (`AlRunner/InstallTriggerRunner.cs:181`) used the
non-strict `GetCaptured`, so under `--watch`, `_captured` there can hold an arbitrarily
old, unrelated previous cycle's test stack, and that stack replaced the real .NET
diagnostic entirely.

Fix: added `AlCallStackCapture.GetCapturedFor(Exception?)`, the strict counterpart with
no fallback — answers only for the exact exception instance, or null. Switched
`InstallTriggerRunner` to it, with a doc-comment on `GetCaptured` warning future callers
outside a test to use the strict variant instead.

**Proving test**: `AlRunner.Tests/AlCallStackCaptureNoFallbackTests.cs`. Unit-level: the
strict/fallback contrast directly (`GetCapturedFor` answers for its own exception,
returns null instead of falling back for an unrelated one, unlike `GetCaptured`).
Wiring-level: drives `InstallTriggerRunner`'s private `InvokeTrigger` via reflection with
a stale `_captured` AL stack seeded (mirroring a previous `--watch` cycle's leftover
capture) and a plain `NullReferenceException` install-trigger failure, asserting the
printed diagnostic contains the real exception and NOT the stale AL stack. RED (with
`AlCallStackCapture` fixed but `InstallTriggerRunner` still using `GetCaptured`):
reproduced the exact bug — printed the stale `"Codeunit From A Previous Watch
Cycle"...SomePassingTest` AL stack. GREEN (post-fix): prints the real
`NullReferenceException`.

## Notes

- No `tests/al-language` submodule edits, no `CHANGELOG.md` edits, no `docs/coverage.yaml`
  (removed at the v1→v2 cutover).
- Diff is entirely under `AlRunner/` + `AlRunner.Tests/`, so the `require-tests` CI gate's
  `tests/` touch requirement is satisfied by `AlRunner.Tests/` — no `tests/runner-extras`
  or corpus involvement, so `tests/expectations/count-baseline/test-count-baseline.json`
  needs no change.
- Both bugs are runner-internal `--watch` mechanics with no BC-behaviour claim, so
  runner-local tests are the correct (not a shortcut) home per
  `.claude/rules/bc-behavior-tests-go-upstream.md`.