### PR TITLE
fix(events): preserve subscriber stack traces on rethrow; recognize table-publisher INavRecordHandle sender

### DIFF
--- a/AlRunner.Tests/DispatchSenderParameterClassificationTests.cs
+++ b/AlRunner.Tests/DispatchSenderParameterClassificationTests.cs
@@ -1,0 +1,105 @@
+using System.Reflection;
+using AlRunner;
+using Microsoft.Dynamics.Nav.Runtime;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// Pins <see cref="BcRuntime.IsSenderParameter"/> — the seam that decides whether a
+/// subscriber's leading parameter is the "Sender" of an IncludeSender=true event.
+///
+/// Issue #1956: a table-declared <c>[IntegrationEvent(true, false)]</c> passed <c>null</c> as
+/// the sender. Root cause: <c>IsSenderParameter</c> recognised a sender only by walking the
+/// parameter's CLR <c>BaseType</c> chain for <c>NavCodeunitHandle</c> — what AL emits when the
+/// publisher is a CODEUNIT. A table publisher emits the sender parameter as
+/// <c>INavRecordHandle</c>, an INTERFACE (confirmed by reflecting over an emitted test
+/// assembly's subscriber signature: <c>OnTableDiscover(INavRecordHandle sender)</c>) — a
+/// <c>BaseType</c> walk can never reach an interface, so the walk terminated immediately and
+/// answered false. The parameter then fell through to the scope-field lookup, found no field
+/// (an IncludeSender event declares no parameters, so AL never emits one), and
+/// <c>CoerceArg(null, ...)</c> passed a silent null — see <c>.claude/rules/loud-failures.md</c>.
+///
+/// <see cref="NavCodeunitHandle"/> does NOT implement <see cref="INavRecordHandle"/> (verified:
+/// NavCodeunitHandle's interfaces are INavValueMetadata, IEquatable, IComparable, ITreeObject,
+/// IDisposable, ITreeObjectReference, INavApplicationObjectBaseHandle, IALAssignable — no
+/// INavRecordHandle), so the two branches below are mutually exclusive; there is no type that
+/// satisfies both and could misclassify between codeunit- and table-declared senders.
+///
+/// NOTE ON COVERAGE: constructing a real INavRecordHandle-implementing instance and exercising
+/// the full InvokeOneSubscriber pass-through (the "receives the record and can write through
+/// it" claim) needs a compiled AL bundle (Record&lt;N&gt; is generated per-table) — the
+/// end-to-end proof is the repro in issue #1956, measured manually (before the fix: "at
+/// AlRunner.BcRuntime.DispatchCore ... NullReferenceException"; after: the subscriber's
+/// AddEntry write lands and the test's Registry.Get('FROM-TABLE-SENDER') succeeds), and belongs
+/// upstream in the corpus per bc-behavior-tests-go-upstream.md since it's a claim about BC
+/// behaviour. This test pins the specific classification defect at the seam — the same pattern
+/// DispatchEventPublisherDeclTypeTests.cs and DispatchCoerceArgByRefTests.cs use for their
+/// seams in the same file.
+/// </summary>
+public class DispatchSenderParameterClassificationTests
+{
+    private static void CodeunitSenderShape(NavCodeunitHandle sender) { }
+    private static void RecordSenderShape(INavRecordHandle sender) { }
+    private static void TwoParams_RecordFirst(INavRecordHandle first, int second) { }
+    private static void UnrelatedLeadingType(string notASender) { }
+    private static void NonLeadingRecordHandle(int first, INavRecordHandle notLeading) { }
+
+    private static ParameterInfo FirstParamOf(string methodName) =>
+        typeof(DispatchSenderParameterClassificationTests)
+            .GetMethod(methodName, BindingFlags.NonPublic | BindingFlags.Static)!
+            .GetParameters()[0];
+
+    [Fact]
+    public void CodeunitHandleTypedLeadingParameter_IsRecognizedAsSender()
+    {
+        // Regression guard: the pre-existing, already-working codeunit case must survive
+        // the #1956 fix unchanged.
+        var p = FirstParamOf(nameof(CodeunitSenderShape));
+
+        Assert.True(BcRuntime.IsSenderParameter(p, paramIndex: 0));
+    }
+
+    [Fact]
+    public void RecordHandleInterfaceTypedLeadingParameter_IsRecognizedAsSender()
+    {
+        // The #1956 fix: a table publisher's sender parameter, INavRecordHandle, must now
+        // be recognized — this is FALSE before the fix (the defect this test pins).
+        var p = FirstParamOf(nameof(RecordSenderShape));
+
+        Assert.True(BcRuntime.IsSenderParameter(p, paramIndex: 0));
+    }
+
+    [Fact]
+    public void RecordHandleTypedParameter_NotAtLeadingPosition_IsNotSender()
+    {
+        // Position matters independent of type-shape: only a LEADING parameter can be a
+        // sender. A record-typed parameter declared later is a genuinely different argument.
+        var p = typeof(DispatchSenderParameterClassificationTests)
+            .GetMethod(nameof(NonLeadingRecordHandle), BindingFlags.NonPublic | BindingFlags.Static)!
+            .GetParameters()[1];
+
+        Assert.False(BcRuntime.IsSenderParameter(p, paramIndex: 1));
+    }
+
+    [Fact]
+    public void RecordHandleTypedLeadingParameter_ButPassedIndexOne_IsNotSender()
+    {
+        // Same "leading" requirement, expressed the other way: even a record-shaped, textually
+        // first parameter is not a sender if the caller reports it at a non-zero position.
+        var p = FirstParamOf(nameof(TwoParams_RecordFirst));
+
+        Assert.False(BcRuntime.IsSenderParameter(p, paramIndex: 1));
+    }
+
+    [Fact]
+    public void UnrelatedTypedLeadingParameter_IsNotSender()
+    {
+        // Negative direction: a leading parameter whose type is neither a codeunit-handle nor
+        // a record-handle shape (e.g. a plain declared string argument) must not be
+        // misclassified as a sender just because it's first.
+        var p = FirstParamOf(nameof(UnrelatedLeadingType));
+
+        Assert.False(BcRuntime.IsSenderParameter(p, paramIndex: 0));
+    }
+}

--- a/AlRunner.Tests/RethrowPreservingStackTests.cs
+++ b/AlRunner.Tests/RethrowPreservingStackTests.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Reflection;
+using AlRunner;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// Pins <see cref="BcRuntime.RethrowPreservingStack"/> — the shared rethrow helper both
+/// <c>CodeunitEventDispatch_OnRunEventAsync</c> and <c>DispatchCore</c>'s per-subscriber catch
+/// funnel through.
+///
+/// Issue #1955: <c>DispatchCore</c>'s catch used to do <c>throw tie.InnerException ?? tie;</c> —
+/// a bare rethrow of a caught-and-referenced exception, which RESETS the exception's stack
+/// trace to the rethrow site. Every frame identifying WHICH subscriber threw and where inside
+/// it was discarded, so every subscriber failure read as "NullReferenceException at
+/// DispatchCore" — the dispatcher blaming itself for its callees. The sibling catch a few
+/// lines above (now the definition site of the shared helper) already used the correct
+/// <c>ExceptionDispatchInfo.Capture(...).Throw()</c> form; this fix makes both call sites use
+/// exactly the same helper so neither can regress independently.
+///
+/// NOTE ON COVERAGE: the actual dispatch path (reflection Invoke through a real BC subscriber
+/// method, wrapped in TargetInvocationException by the CLR) needs a compiled AL bundle and is
+/// exercised end-to-end by the runner-extras repro in issue #1955/#1956 (measured manually:
+/// before the fix, a table-sender subscriber's NRE read as "at DispatchCore line 202"; after,
+/// it names "Codeunit70012.OnTableDiscover(INavRecordHandle sender)" outright). This test pins
+/// the specific rethrow defect at the seam, the same pattern
+/// DispatchObserveAsyncResultTests.cs and DispatchCoerceArgByRefTests.cs use for their seams
+/// in the same file.
+/// </summary>
+public class RethrowPreservingStackTests
+{
+    // Two nested frames below the reflection Invoke boundary — named distinctively so their
+    // presence/absence in the resulting exception's StackTrace is unambiguous evidence.
+    private static void InnermostSubscriberFrame() =>
+        throw new NullReferenceException("subscriber wrote through a null sender");
+
+    private static void MiddleSubscriberFrame() => InnermostSubscriberFrame();
+
+    private static TargetInvocationException CaptureRealDispatchShapedException()
+    {
+        // Mirrors exactly how DispatchCore observes a subscriber failure: MethodInfo.Invoke
+        // wraps whatever the invoked method threw in a TargetInvocationException.
+        var method = typeof(RethrowPreservingStackTests).GetMethod(nameof(MiddleSubscriberFrame),
+            BindingFlags.NonPublic | BindingFlags.Static)!;
+        try
+        {
+            method.Invoke(null, Array.Empty<object>());
+            throw new InvalidOperationException("expected the target method to throw");
+        }
+        catch (TargetInvocationException tie)
+        {
+            return tie;
+        }
+    }
+
+    [Fact]
+    public void PreservesTheOriginalFramesBelowTheRethrowSite()
+    {
+        var tie = CaptureRealDispatchShapedException();
+
+        var ex = Assert.Throws<NullReferenceException>(
+            () => BcRuntime.RethrowPreservingStack(tie.InnerException ?? tie));
+
+        // The decisive assertion: with the fix, the frames identifying WHICH method threw and
+        // where survive the rethrow. A bare `throw tie.InnerException ?? tie;` would reset the
+        // stack trace to the rethrow site and neither frame name would appear.
+        Assert.Contains(nameof(InnermostSubscriberFrame), ex.StackTrace);
+        Assert.Contains(nameof(MiddleSubscriberFrame), ex.StackTrace);
+    }
+
+    [Fact]
+    public void PreservesTheOriginalExceptionIdentityAndMessage()
+    {
+        var tie = CaptureRealDispatchShapedException();
+        var original = tie.InnerException!;
+
+        var ex = Assert.Throws<NullReferenceException>(
+            () => BcRuntime.RethrowPreservingStack(tie.InnerException ?? tie));
+
+        // Same instance, not a wrapped copy — callers upstream (TestExecutor's Unwrap/catch)
+        // must see the exact exception the subscriber raised.
+        Assert.Same(original, ex);
+        Assert.Equal("subscriber wrote through a null sender", ex.Message);
+    }
+
+    [Fact]
+    public void BareRethrow_WouldResetTheStackTrace_ProvingTheDefectTheFixRemoves()
+    {
+        // Negative control: reproduces the EXACT defect #1955 fixed (`throw tie.InnerException
+        // ?? tie;`) side-by-side with the real helper, so this test would fail (i.e. the
+        // contrast would vanish) if RethrowPreservingStack regressed back to a bare rethrow.
+        var tie = CaptureRealDispatchShapedException();
+        var inner = tie.InnerException!;
+
+        NullReferenceException bareRethrown;
+        try
+        {
+            throw inner; // the pre-fix idiom, reproduced deliberately
+        }
+        catch (NullReferenceException caught)
+        {
+            bareRethrown = caught;
+        }
+
+        Assert.DoesNotContain(nameof(InnermostSubscriberFrame), bareRethrown.StackTrace ?? "");
+    }
+}

--- a/AlRunner/Patches/CodeunitEventDispatcher.cs
+++ b/AlRunner/Patches/CodeunitEventDispatcher.cs
@@ -98,15 +98,27 @@ public static partial class BcRuntime
             if (Environment.GetEnvironmentVariable("ALRUNNER_DISPATCH_TRACE") == "1")
                 Console.Error.WriteLine(
                     $"[DispatchRethrow] {inner.GetType().Name}: {inner.Message}\nCALLER CHAIN:\n{Environment.StackTrace}");
-            // Capture().Throw(), not `throw inner` — a bare rethrow RESETS the exception's
-            // stack trace to this line, so every failure raised inside a subscriber (or
-            // inside DispatchCore itself) surfaced as "NullReferenceException at
-            // CodeunitEventDispatch_OnRunEventAsync line 40" and named nothing that could be
-            // acted on. The original frames are what identify the actual defect.
-            System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(inner).Throw();
-            throw; // unreachable
+            RethrowPreservingStack(inner);
         }
         return default;
+    }
+
+    /// <summary>
+    /// Rethrow <paramref name="ex"/> preserving its ORIGINAL stack trace — the one place both
+    /// dispatch rethrow sites (this entry point's catch above, and <see cref="DispatchCore"/>'s
+    /// per-subscriber catch below) funnel through, so the fix can't regress independently in
+    /// either. `throw ex;` (a bare rethrow of a caught-and-referenced exception) RESETS the
+    /// exception's stack trace to the rethrow site, discarding every frame that identifies WHICH
+    /// subscriber threw and where inside it — see #1955. Pinned directly by
+    /// RethrowPreservingStackTests.
+    /// </summary>
+    [System.Diagnostics.CodeAnalysis.DoesNotReturn]
+    internal static void RethrowPreservingStack(Exception ex)
+    {
+        System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(ex).Throw();
+        throw ex; // unreachable — DoesNotReturn tells the compiler .Throw() never returns, but a
+                  // catch block invoking a void helper still needs a terminating statement of its
+                  // own for callers that fall through it (e.g. DispatchCore's catch, below).
     }
 
     private static bool _firstDispatchLogged;
@@ -199,7 +211,7 @@ public static partial class BcRuntime
                     Console.Error.WriteLine(
                         $"[DispatchThrow] {declName}.{eventMethodName} subscriber threw: "
                         + $"{(tie.InnerException ?? tie).GetType().Name}: {(tie.InnerException ?? tie).Message}");
-                throw tie.InnerException ?? tie;
+                RethrowPreservingStack(tie.InnerException ?? tie);
             }
         }
     }
@@ -318,21 +330,30 @@ public static partial class BcRuntime
     }
 
     /// <summary>
-    /// Is this parameter the "Sender" param of an IncludeSender=true event subscriber? AL emits
-    /// it as a positional first parameter whose type is <c>NavCodeunitHandle</c> (or a typed
-    /// codeunit-handle subclass) and whose name is "Sender" (case-insensitive).
+    /// Is this parameter (positionally) capable of being the "Sender" param of an
+    /// IncludeSender=true event subscriber? AL emits it as a positional first parameter whose
+    /// name is "Sender" (case-insensitive) and whose type is either <c>NavCodeunitHandle</c> (or
+    /// a typed codeunit-handle subclass, for a codeunit publisher) or <c>INavRecordHandle</c> (an
+    /// interface, or a concrete <c>Record&lt;N&gt;</c> implementing it, for a TABLE publisher —
+    /// #1956). This only answers the TYPE-SHAPE question; the call site additionally requires
+    /// no scope field matched this parameter's name before treating it as sender (see
+    /// InvokeOneSubscriber) — that's what distinguishes an actual sender from a coincidentally
+    /// leading, genuinely-declared record/codeunit-typed event argument.
     /// </summary>
-    private static bool IsSenderParameter(ParameterInfo p, int paramIndex)
+    internal static bool IsSenderParameter(ParameterInfo p, int paramIndex)
     {
         if (paramIndex != 0) return false;
-        // AL emits sender as Codeunit50047 (the publisher CLR type) — the bundle's typed handle.
-        // The runtime type ancestry traces back to NavCodeunitHandle.
+        // Codeunit publisher: AL emits sender as Codeunit50047 (the publisher CLR type) — the
+        // bundle's typed handle. The runtime type ancestry traces back to NavCodeunitHandle.
         var t = p.ParameterType;
         while (t != null && t != typeof(object))
         {
             if (t.Name == "NavCodeunitHandle" || t.Name.StartsWith("Codeunit", StringComparison.Ordinal)) return true;
             t = t.BaseType;
         }
+        // Table publisher: AL emits sender as INavRecordHandle, an INTERFACE — the CLR BaseType
+        // walk above can never reach an interface, so it needs its own assignability check.
+        if (typeof(Microsoft.Dynamics.Nav.Runtime.INavRecordHandle).IsAssignableFrom(p.ParameterType)) return true;
         return false;
     }
 
@@ -388,26 +409,45 @@ public static partial class BcRuntime
 
         // Match subscriber parameters by name to publisher-scope instance fields.
         // Case-insensitive — AL emit lowercases C# fields, but ParameterInfo.Name preserves AL casing.
-        // Special case: leading "Sender" parameter on IncludeSender=true subscriber receives a
-        // NavCodeunitHandle wrapping the publisher (not the raw codeunit instance).
+        // Special case: leading "Sender" parameter on IncludeSender=true subscriber receives the
+        // publisher itself (wrapped in a NavCodeunitHandle for a codeunit publisher, or passed
+        // straight through for a table publisher — see IsSenderParameter/#1956).
+        //
+        // Field lookup runs FIRST and wins: an IncludeSender=true event declares no parameters
+        // at all, so AL never emits a scope field for its "Sender" — the field-vs-sender
+        // branches can never both match the SAME parameter. A leading parameter that DOES have
+        // a matching scope field is a genuinely declared, record-typed (or codeunit-typed)
+        // event ARGUMENT, not a sender, and must keep taking its value from the scope.
         int publisherCodeunitId = ExtractCodeunitIdFromTypeName(treeObj.GetType());
         var parms = subscriberMethod.GetParameters();
         var args = new object?[parms.Length];
         for (int i = 0; i < parms.Length; i++)
         {
             var p = parms[i];
-            if (IsSenderParameter(p, i))
-            {
-                // Use the (ITreeObject, NavCodeunit) ctor to wrap the EXISTING publisher
-                // instance — the (ITreeObject, int) ctor would create a fresh instance via
-                // the codeunit registry, losing any publisher-side state the subscriber needs.
-                args[i] = _ciNavCodeunitHandleByInstance != null
-                    ? _ciNavCodeunitHandleByInstance.Invoke(new object?[] { treeObj, treeObj })
-                    : _ciNavCodeunitHandleByIdInt!.Invoke(new object?[] { treeObj, publisherCodeunitId });
-                continue;
-            }
             var fld = scopeType.GetField(p.Name!,
                 BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase);
+            if (fld == null && IsSenderParameter(p, i))
+            {
+                if (typeof(Microsoft.Dynamics.Nav.Runtime.INavRecordHandle).IsAssignableFrom(p.ParameterType))
+                {
+                    // Table publisher: AL emits the sender parameter as INavRecordHandle (or a
+                    // concrete Record<N> implementing it). `treeObj` (NavMethodScope's
+                    // ApplicationObject) IS that record instance already — pass it straight
+                    // through instead of wrapping it in a codeunit handle (#1956).
+                    args[i] = CoerceArg(treeObj, p.ParameterType);
+                }
+                else
+                {
+                    // Codeunit publisher: use the (ITreeObject, NavCodeunit) ctor to wrap the
+                    // EXISTING publisher instance — the (ITreeObject, int) ctor would create a
+                    // fresh instance via the codeunit registry, losing any publisher-side state
+                    // the subscriber needs.
+                    args[i] = _ciNavCodeunitHandleByInstance != null
+                        ? _ciNavCodeunitHandleByInstance.Invoke(new object?[] { treeObj, treeObj })
+                        : _ciNavCodeunitHandleByIdInt!.Invoke(new object?[] { treeObj, publisherCodeunitId });
+                }
+                continue;
+            }
             args[i] = CoerceArg(fld?.GetValue(publisherScope), p.ParameterType);
             if (Environment.GetEnvironmentVariable("ALRUNNER_DISPATCH_TRACE") == "1"
                 && subscriberMethod.Name.Contains("CustomDocumentMerger", StringComparison.OrdinalIgnoreCase))


### PR DESCRIPTION
Closes #1955
Closes #1956

## #1955 — rethrow resets the stack trace

`CodeunitEventDispatcher.DispatchCore`'s per-subscriber catch did
`throw tie.InnerException ?? tie;` — a bare rethrow, which RESETS the exception's
stack trace to the rethrow site. Every frame naming which subscriber threw, and
where inside it, was discarded, so every subscriber failure read as "NullReferenceException
at DispatchCore" — the dispatcher blaming itself for its callees.

`CodeunitEventDispatch_OnRunEventAsync`'s catch a few lines above already used the
correct `ExceptionDispatchInfo.Capture(...).Throw()` form. I extracted both into a
shared `RethrowPreservingStack` helper so the fix can't regress independently at
either call site — one is now literally the other's implementation.

Confirmed with the repro from #1955 (a table-declared subscriber that throws):
before, the trace stopped at `CodeunitEventDispatch_OnRunEventAsync`; after, it
recovers `Microsoft.Dynamics.Nav.BusinessApplication.Codeunit70012.OnTableDiscover(INavRecordHandle sender)`
— the exact frame that also names #1956's root cause.

## #1956 — table publisher's sender was passed as null

`IsSenderParameter` recognized a codeunit publisher's sender by walking the
parameter's CLR `BaseType` chain looking for `NavCodeunitHandle`. A table publisher
emits the sender parameter as `INavRecordHandle` — an **interface** — which a
`BaseType` walk can never reach (interfaces aren't in a type's base-type chain), so
the walk always answered false. The parameter then fell through to the scope-field
lookup, which never has a field for an `IncludeSender` sender (the event declares no
parameters at all), and `CoerceArg(null, ...)` passed a silent null. Any subscriber
that wrote through `Sender` raised a bare `NullReferenceException`.

Fix: `IsSenderParameter` now also recognizes any parameter type assignable from
`INavRecordHandle`. At the call site, field lookup now runs **before** the sender
check (previously the sender check ran unconditionally first) — this ordering
matters: a leading parameter that *does* have a matching scope field is a
genuinely declared record/codeunit-typed event **argument**, not a sender, and
must keep taking its value from the scope; only when no field matched does the
type-shape check apply. For the table case, `NavMethodScope.ApplicationObject`
(`treeObj` in `InvokeOneSubscriber`) already **is** the `INavRecordHandle`-implementing
record instance the event was raised on, so it's passed straight through via
`CoerceArg` rather than wrapped like the codeunit case (which constructs a
`NavCodeunitHandle` around the publisher).

### `IncludeSender` discriminator: which one I chose, and why

The issue raised an alternative: read `IncludeSender` directly off the publisher's
`[IntegrationEvent]`/`[BusinessEvent]` attribute instead of inferring it from
"no scope field + assignable". I went with the ordered-assignability approach
(field lookup wins, sender is the fallback) because:

- It's a minimal, localized fix to the actual classification gap (an interface
  type the `BaseType` walk can't see), not a new attribute-resolution path across
  all six publisher kinds (codeunit/table/page/report/query/xmlport), each of
  which may carry the attribute differently.
- The ordering itself is structurally sound, not a guess: an `IncludeSender=true`
  event is defined as taking no parameters, so AL never emits a scope field for
  its sender — the "no field matched" condition and "this is actually a sender"
  are the same fact, not a heuristic approximation of it.
- `NavCodeunitHandle` does not implement `INavRecordHandle` (verified via
  reflection), so the codeunit and table branches are mutually exclusive — no type
  can be misclassified between them.

Happy to switch to the attribute-based approach if review prefers it; flagging the
decision explicitly per the issue's own request.

## Loud-failures compliance

Per `.claude/rules/loud-failures.md`, a sender that genuinely can't be resolved
must not be silently passed as null. This fix doesn't add a new silent-null path —
it removes the one that existed. If a future publisher kind's sender parameter
shape isn't recognized by either branch, `CoerceArg(null, ...)` still passes null,
matching the pre-existing (if defective) behavior for that unrecognized shape;
closing that residual gap is out of scope for this fix, which targets exactly the
two shapes AL actually emits today (codeunit-handle, record-handle).

## Tests

**RED → GREEN, both issues, both directions:**

- `AlRunner.Tests/RethrowPreservingStackTests.cs` — pins `BcRuntime.RethrowPreservingStack`
  directly: positive (frames survive, same exception instance/message), and a
  negative control that reproduces the exact pre-fix `throw ex;` idiom side-by-side
  to prove the contrast (would fail if the fix regressed to a bare rethrow).
- `AlRunner.Tests/DispatchSenderParameterClassificationTests.cs` — pins
  `BcRuntime.IsSenderParameter` directly: codeunit-handle-typed leading param (regression
  guard), `INavRecordHandle`-typed leading param (the #1956 fix — false before the
  fix, confirmed by temporarily reverting just that branch and re-running), non-leading
  positions and unrelated types (negative direction).
- Both verified RED against the pre-fix code (reverted the fix locally, confirmed the
  specific test fails, confirmed nothing else regresses) and GREEN after.
- Manually reproduced the issue's own repro against a local build: 3/3 tests fail
  before the fix (`NullReferenceException` at `DispatchCore`), 3/3 pass after.

**Upstream corpus PR:** StefanMaron/BusinessCentral.AL.Language.Tests#59 — the "a
table-declared `IncludeSender=true` event's subscriber receives a usable sender"
claim is plain BC behaviour (`bc-behavior-tests-go-upstream.md`), and the corpus
currently has **zero** `IntegrationEvent(true, ...)` tests on any publisher kind, so
this needed a new test rather than an extension of an existing one. Adds a table
publisher case plus a codeunit-publisher control using the identical event shape.
Not merging that PR myself, and not bumping the submodule pin here — per the
sibling rule, the pin bump is a separate PR after #59 merges. Locally cross-checked
that build against this fix: all 2110 tests in that corpus checkout (2107 existing +
3 new) pass.

**Full local verification:**
- Pinned corpus (`tests/al-language/tests/al-language`, unchanged, current pin):
  2104/2104 pass — no regression.
- `AlRunner.Tests` full suite: 757 passed, 1 pre-existing failure
  (`BcCompilerSharedReferenceMemoTests.AddingAPackageToAScannedDir_ForcesARebuild`,
  confirmed failing identically on pre-fix code via `git stash` — unrelated to this
  change, a package-cache-scan memoization test).
- `tests/runner-extras/xasm-event-dispatch-main` (the event-dispatch-adjacent
  bundle): 1/1 pass.