### PR TITLE
fix(ci): publish.yml must run the BC engine tests, not skip them

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -146,9 +146,34 @@ jobs:
           dotnet run --project tools/DownloadArtifacts -- \
             test-apps ${{ matrix.bc-version }} "$HOME/.al-runner/test-apps"
 
+      - name: Generate .runsettings for the in-process BC engine tests
+        run: |
+          # Mirrors test-matrix.yml's identical step. Without the DOTNET_STARTUP_HOOKS
+          # chain the in-process BC engine tests (BcEngineCollection) SKIP instead of
+          # running, and a release would ship a version whose engine tests never
+          # executed. BcEngineReadinessGuardTests exists to fail loudly when that
+          # happens; it caught this on the v2.3.0 attempt (47 skipped, guard red).
+          # Set inside <EnvironmentVariables> and deliberately NOT as an ambient env
+          # var on the step: an ambient var also runs the bootstrap inside the outer
+          # `dotnet test` CLI driver process, where AppContext.BaseDirectory resolves
+          # to the SDK's install directory and the Ncl rewrite lands there.
+          cp AlRunner/bin/Release/net8.0/Microsoft.Dynamics.Nav.Ncl.dll \
+             AlRunner.Tests/bin/Release/net8.0/Microsoft.Dynamics.Nav.Ncl.dll
+          cat > engine.runsettings <<EOF
+          <?xml version="1.0" encoding="utf-8"?>
+          <RunSettings>
+            <RunConfiguration>
+              <EnvironmentVariables>
+                <DOTNET_STARTUP_HOOKS>$(pwd)/AlRunner.Tests/bin/Release/net8.0/al-runner.dll:$(pwd)/AlRunner.Tests/bin/Release/net8.0/AlRunner.Tests.dll</DOTNET_STARTUP_HOOKS>
+              </EnvironmentVariables>
+            </RunConfiguration>
+          </RunSettings>
+          EOF
+
       - name: Run unit tests (AlRunner.Tests)
         run: |
-          dotnet test AlRunner.Tests/AlRunner.Tests.csproj -c Release --no-build
+          dotnet test AlRunner.Tests/AlRunner.Tests.csproj -c Release --no-build \
+              --settings engine.runsettings
 
       - name: Run al-language corpus
         run: |


### PR DESCRIPTION
The v2.3.0 release stopped at the test stage. Nothing was published to NuGet and no GitHub Release was created, but the tag and the `chore: release v2.3.0` commit are on main, because `publish.yml` pushes those before it runs tests.

## Cause

`publish.yml`'s test job ran:

```
dotnet test AlRunner.Tests/AlRunner.Tests.csproj -c Release --no-build
```

with no engine runsettings. `test-matrix.yml` generates an `engine.runsettings` carrying the `DOTNET_STARTUP_HOOKS` chain and passes `--settings engine.runsettings`; that is what makes the in-process BC engine tests actually execute. Without it they skip.

On the v2.3.0 attempt the BC 28.1 leg reported 767 passed, **47 skipped**, and `BcEngineReadinessGuardTests.Ready_IsTrue_WhenArtifactsAreProvisioned` failed. That guard exists precisely to fail loudly when the engine tests silently skip, so it worked as intended — the release was about to ship a version whose engine tests had never run.

## Fix

Adds the same "Generate .runsettings" step `test-matrix.yml` already has, and passes `--settings engine.runsettings`. Also copies the freshly built `Ncl.dll` into the test bin directory first, matching test-matrix.yml.

## Note

This is the second time this job has drifted from `test-matrix.yml`. The first is recorded in a comment in this very file: the missing platform-apps download, which failed 17 corpus tests on BC 27.3 during the 2026-08-05 release attempts "despite the identical commit passing clean in test-matrix.yml". The two jobs are maintained by hand and diverge. Worth considering whether the shared steps should be factored into a composite action so a third divergence is not possible.
