### PR TITLE
ci(release): tests gate every write — no more dead tags on main

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,11 +1,22 @@
 name: Publish to NuGet
 
 # Triggered manually only — supply the version and the workflow does everything:
-# generates the CHANGELOG section, commits it to main, pushes the tag, runs
-# tests, packs, pushes to NuGet, and creates the GitHub Release.
+# runs the full BC test matrix, then generates the CHANGELOG section, commits it to
+# main, pushes the tag, packs, pushes to NuGet, and creates the GitHub Release.
 #
-# The checkout step uses RELEASE_DEPLOY_KEY (a write-access deploy key) so the
-# git push to main bypasses the branch ruleset ("Deploy keys" -> Always allow).
+# ORDER MATTERS, and it used to be backwards. Until #1978 the first job pushed the
+# release commit and the tag BEFORE a single test ran, so a red matrix left a
+# permanent tag on main with no release behind it. Not hypothetical: v2.3.0 and
+# v2.3.1 are both such tags. Tests now gate every write — a failed release attempt
+# leaves the repository exactly as it found it.
+#
+# That ordering had a second cost. CHANGELOG sections are generated from
+# `git describe --tags`, so a dead tag becomes the baseline for the NEXT release:
+# [2.3.1] lists two entries while the 21 real ones sit under [2.3.0], a heading with
+# no release behind it.
+#
+# The release job's checkout uses RELEASE_DEPLOY_KEY (a write-access deploy key) so
+# the git push to main bypasses the branch ruleset ("Deploy keys" -> Always allow).
 on:
   workflow_dispatch:
     inputs:
@@ -18,16 +29,71 @@ env:
   DOTNET_CLI_TELEMETRY_OPTOUT: true
 
 jobs:
-  prepare:
+  plan:
+    name: Resolve the commit to test and ship
     runs-on: ubuntu-latest
     outputs:
-      notes: ${{ steps.changelog.outputs.notes }}
+      ref: ${{ steps.plan.outputs.ref }}
+      tag-exists: ${{ steps.plan.outputs.tag-exists }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Decide which commit this release tests and ships
+        id: plan
+        run: |
+          TAG="v${{ inputs.version }}"
+
+          if git ls-remote --exit-code --tags origin "refs/tags/$TAG" >/dev/null 2>&1; then
+            # A retry of an attempt that already tagged — which now means the release
+            # job itself failed after tagging (NuGet rejected the push, the Release API
+            # call failed), NOT that tests failed, because tests run first. Test and
+            # ship the tag as it stands and let the release job skip re-committing.
+            echo "Tag $TAG already exists on origin — testing and shipping that tag."
+            echo "ref=$TAG" >> "$GITHUB_OUTPUT"
+            echo "tag-exists=true" >> "$GITHUB_OUTPUT"
+          else
+            # github.sha is main's head at dispatch. Pinning it HERE, rather than letting
+            # the release job read origin/main once the matrix finishes, is what makes the
+            # tag point at the commit that was actually tested: main can move during a
+            # 40-minute run, and whatever gets merged meanwhile has not been through this
+            # matrix at this version.
+            echo "Releasing ${{ github.sha }} (main at dispatch)."
+            echo "ref=${{ github.sha }}" >> "$GITHUB_OUTPUT"
+            echo "tag-exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  test:
+    needs: plan
+    # The SAME matrix the push / pull-request path runs — resolve-versions, every
+    # BC version, and the cold-cache smoke job.
+    #
+    # This used to be a hand-maintained copy of those steps living in this file.
+    # It drifted from the original four times, and the last two divergences failed
+    # a release each (v2.3.0 and v2.3.1, both on BcEngineReadinessGuardTests with
+    # 47 engine tests skipped). Calling the definition instead of restating it is
+    # the fix — issue #1976.
+    #
+    # It also closes a gap that was never a "drift" so much as a permanent
+    # shortfall: the old copy ran neither --count-baseline, nor the xmlport
+    # order-independence guard, nor the server-mode integration tests, nor the
+    # smoke job. A release was gated on strictly less than a pull request.
+    uses: ./.github/workflows/bc-tests.yml
+    with:
+      ref: ${{ needs.plan.outputs.ref }}
+
+  release:
+    # Gated on `test`: this job holds every write this workflow performs — the
+    # CHANGELOG commit, the push to main, the tag, the NuGet push and the GitHub
+    # Release. Nothing above it touches the repository. See #1978.
+    needs: [plan, test]
+    runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          ref: ${{ needs.plan.outputs.ref }}
           ssh-key: ${{ secrets.RELEASE_DEPLOY_KEY }}
 
       - name: Configure git
@@ -35,21 +101,17 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-      - name: Generate CHANGELOG and push release commit + tag
+      - name: Generate CHANGELOG and push the release commit + tag
         id: changelog
         run: |
           VERSION="${{ inputs.version }}"
           TAG="v${VERSION}"
 
-          # Idempotent retry: if a prior run for this version already got as far as
-          # pushing the release commit + tag (then failed later, e.g. in `test`), a
-          # naive re-run would generate and commit a SECOND [x.y.z] section — exactly
-          # what happened on 2026-08-05 (two duplicate v2.0.0 sections, cleaned up by
-          # hand). Detect the existing tag and reuse its CHANGELOG section instead of
-          # regenerating.
-          if git ls-remote --exit-code --tags origin "refs/tags/$TAG" >/dev/null 2>&1; then
-            echo "Tag $TAG already exists on origin — reusing its release commit, not re-committing."
-            git fetch origin "refs/tags/$TAG:refs/tags/$TAG"
+          if [ "${{ needs.plan.outputs.tag-exists }}" = "true" ]; then
+            # The tag is already on origin and this checkout IS that tag. Reuse its
+            # CHANGELOG section rather than generating a second [x.y.z] heading — that
+            # happened on 2026-08-05 (two duplicate v2.0.0 sections, cleaned up by hand).
+            echo "Reusing the CHANGELOG section already committed at $TAG."
             SECTION=$(git show "$TAG:CHANGELOG.md" | awk -v ver="## [$VERSION]" '
               $0 == ver { found=1 }
               found && /^## \[/ && $0 != ver { exit }
@@ -68,7 +130,13 @@ jobs:
 
             git add CHANGELOG.md
             git commit -m "chore: release v${VERSION}"
-            git push origin main
+
+            # Push the release commit BEFORE creating the tag, and deliberately without
+            # --force. HEAD is the commit the matrix tested plus a CHANGELOG-only diff,
+            # so this is a fast-forward exactly when main is still where the matrix found
+            # it. If someone merged during the run it fails here — and NO tag is created,
+            # which is the whole point of #1978. Re-dispatch against the new main.
+            git push origin HEAD:main
             git tag "$TAG"
             git push origin "$TAG"
           fi
@@ -78,35 +146,6 @@ jobs:
             echo "$SECTION"
             echo "EOF_NOTES"
           } >> "$GITHUB_OUTPUT"
-
-  test:
-    needs: prepare
-    # The SAME matrix the push / pull-request path runs — resolve-versions, every
-    # BC version, and the cold-cache smoke job — checked out at the release tag.
-    #
-    # This used to be a hand-maintained copy of those steps living in this file.
-    # It drifted from the original four times, and the last two divergences failed
-    # a release each (v2.3.0 and v2.3.1, both on BcEngineReadinessGuardTests with
-    # 47 engine tests skipped). Calling the definition instead of restating it is
-    # the fix — issue #1976.
-    #
-    # It also closes a gap that was never a "drift" so much as a permanent
-    # shortfall: the old copy ran neither --count-baseline, nor the xmlport
-    # order-independence guard, nor the server-mode integration tests, nor the
-    # smoke job. A release was gated on strictly less than a pull request.
-    uses: ./.github/workflows/bc-tests.yml
-    with:
-      ref: v${{ inputs.version }}
-
-  publish:
-    needs: [prepare, test]
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          ref: v${{ inputs.version }}
 
       - uses: actions/setup-dotnet@v5
         with:
@@ -155,7 +194,7 @@ jobs:
         with:
           tag_name: v${{ inputs.version }}
           name: v${{ inputs.version }}
-          body: ${{ needs.prepare.outputs.notes }}
+          body: ${{ steps.changelog.outputs.notes }}
           files: ./nupkg/*.nupkg
           draft: false
           prerelease: false

--- a/AlRunner.Tests/ReleaseTestParityTests.cs
+++ b/AlRunner.Tests/ReleaseTestParityTests.cs
@@ -30,6 +30,8 @@
 //      below against constructed strings — it does not need the real files to be provable.
 //   2. The remaining tests wire that pure function to the REAL workflow files on disk.
 
+using System.Text;
+using System.Text.RegularExpressions;
 using Xunit;
 
 namespace AlRunner.Tests;
@@ -82,6 +84,63 @@ internal static class WorkflowParity
             .Select(s => s.Marker)
             .ToList();
     }
+
+    private static readonly Regex JobHeader = new(@"^  ([A-Za-z0-9_-]+):\s*$", RegexOptions.Compiled);
+
+    /// <summary>
+    /// Splits a workflow into its top-level jobs, keyed by job id. Only the region after the
+    /// `jobs:` key is considered — `on:` and `env:` also have two-space keys, and
+    /// `workflow_dispatch:` would otherwise read as a job.
+    /// </summary>
+    internal static IReadOnlyDictionary<string, string> SplitJobs(string workflowText)
+    {
+        var lines = workflowText.Replace("\r\n", "\n").Split('\n');
+        var jobs = new Dictionary<string, string>(StringComparer.Ordinal);
+
+        var i = Array.FindIndex(lines, l => l.StartsWith("jobs:", StringComparison.Ordinal));
+        if (i < 0) return jobs;
+
+        string? current = null;
+        var body = new StringBuilder();
+        for (i++; i < lines.Length; i++)
+        {
+            var header = JobHeader.Match(lines[i]);
+            if (header.Success)
+            {
+                if (current is not null) jobs[current] = body.ToString();
+                current = header.Groups[1].Value;
+                body.Clear();
+                continue;
+            }
+            body.Append(lines[i]).Append('\n');
+        }
+        if (current is not null) jobs[current] = body.ToString();
+        return jobs;
+    }
+
+    /// <summary>The job ids a job declares in <c>needs:</c>, in either the inline or list form.</summary>
+    internal static IReadOnlyList<string> NeedsOf(string jobBody)
+    {
+        foreach (var line in jobBody.Split('\n'))
+        {
+            var trimmed = line.Trim();
+            if (trimmed.StartsWith('#') || !trimmed.StartsWith("needs:", StringComparison.Ordinal)) continue;
+
+            return trimmed["needs:".Length..].Trim().Trim('[', ']')
+                .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .Select(s => s.Trim('"', '\''))
+                .ToList();
+        }
+        return Array.Empty<string>();
+    }
+
+    /// <summary>The ids of jobs whose body contains <paramref name="marker"/>, comments excluded.</summary>
+    internal static IReadOnlyList<string> JobsContaining(string workflowText, string marker) =>
+        SplitJobs(workflowText)
+            .Where(j => string.Join('\n', j.Value.Split('\n').Where(l => !l.TrimStart().StartsWith('#')))
+                              .Contains(marker, StringComparison.Ordinal))
+            .Select(j => j.Key)
+            .ToList();
 }
 
 public sealed class ReleaseTestParityTests
@@ -205,5 +264,115 @@ public sealed class ReleaseTestParityTests
 
         Assert.Contains("name: All BC versions passed", text, StringComparison.Ordinal);
         Assert.DoesNotContain("All BC versions passed", Read(WorkflowParity.SharedWorkflow), StringComparison.Ordinal);
+    }
+
+    // ---- release ordering: tests gate every write (#1978) ---------------------------
+
+    [Fact]
+    public void SplitJobs_DoesNotMistakeWorkflowDispatchForAJob()
+    {
+        // `on:` and `env:` carry two-space keys too. Splitting from the top of the file
+        // instead of from `jobs:` would report "workflow_dispatch" as a job and quietly
+        // break every ordering assertion below.
+        const string wf = """
+            on:
+              workflow_dispatch:
+                inputs:
+                  version:
+                    required: true
+            env:
+              DOTNET_NOLOGO: true
+            jobs:
+              plan:
+                runs-on: ubuntu-latest
+              release:
+                needs: [plan, test]
+            """;
+
+        Assert.Equal(new[] { "plan", "release" }, WorkflowParity.SplitJobs(wf).Keys.OrderBy(k => k, StringComparer.Ordinal));
+    }
+
+    [Fact]
+    public void NeedsOf_ReadsBothTheInlineAndTheSingleForm()
+    {
+        Assert.Equal(new[] { "plan", "test" }, WorkflowParity.NeedsOf("    needs: [plan, test]\n"));
+        Assert.Equal(new[] { "plan" }, WorkflowParity.NeedsOf("    needs: plan\n"));
+        Assert.Empty(WorkflowParity.NeedsOf("    runs-on: ubuntu-latest\n"));
+    }
+
+    [Fact]
+    public void JobsContaining_FindsThePreOrderingShapeThatLeftDeadTags()
+    {
+        // publish.yml as it stood before #1978: the tag was pushed by a job that needed
+        // nothing, so a red matrix still left the tag behind. v2.3.0 and v2.3.1 both.
+        const string oldShape = """
+            jobs:
+              prepare:
+                runs-on: ubuntu-latest
+                steps:
+                  - name: Generate CHANGELOG and push release commit + tag
+                    run: |
+                      git push origin main
+                      git tag "$TAG"
+                      git push origin "$TAG"
+              test:
+                needs: prepare
+                uses: ./.github/workflows/bc-tests.yml
+            """;
+
+        var tagging = WorkflowParity.JobsContaining(oldShape, "git push origin \"$TAG\"");
+
+        Assert.Equal(new[] { "prepare" }, tagging);
+        Assert.Empty(WorkflowParity.NeedsOf(WorkflowParity.SplitJobs(oldShape)["prepare"]));
+    }
+
+    [Fact]
+    public void EveryWriteInPublishYml_IsGatedOnTheTestMatrix()
+    {
+        // The property that matters: a red matrix must leave the repository untouched.
+        // Before #1978 the tag went up first, and v2.3.0 and v2.3.1 are both tags on main
+        // with no release behind them because of it.
+        var text = Read("publish.yml");
+        var jobs = WorkflowParity.SplitJobs(text);
+
+        var testJob = jobs.Keys.Single(j => jobs[j].Contains(WorkflowParity.DelegationMarker, StringComparison.Ordinal));
+
+        var writes = new (string Marker, string What)[]
+        {
+            ("git push origin \"$TAG\"", "the release tag"),
+            ("git push origin HEAD:main", "the CHANGELOG commit on main"),
+            ("dotnet nuget push", "the NuGet package"),
+            ("softprops/action-gh-release", "the GitHub Release"),
+        };
+
+        foreach (var (marker, what) in writes)
+        {
+            var owners = WorkflowParity.JobsContaining(text, marker);
+            Assert.True(owners.Count == 1,
+                $"expected exactly one job to write {what}; found {owners.Count} ({string.Join(", ", owners)})");
+
+            var needs = WorkflowParity.NeedsOf(jobs[owners[0]]);
+            Assert.True(needs.Contains(testJob),
+                $"publish.yml job '{owners[0]}' writes {what} without needing '{testJob}'. "
+                + "A failed matrix would leave it behind — that is how v2.3.0 and v2.3.1 became "
+                + "dead tags on main (#1978).");
+        }
+    }
+
+    [Fact]
+    public void PublishYml_TestsTheCommitItShips_NotWhateverMainBecomes()
+    {
+        // main can move during a 40-minute matrix run. The ref is pinned once, by the plan
+        // job, and both the matrix and the release checkout read that same pinned value —
+        // otherwise the tag could land on code this run never tested.
+        var text = Read("publish.yml");
+        var jobs = WorkflowParity.SplitJobs(text);
+
+        var testJob = jobs.Keys.Single(j => jobs[j].Contains(WorkflowParity.DelegationMarker, StringComparison.Ordinal));
+        var releaseJob = WorkflowParity.JobsContaining(text, "git push origin \"$TAG\"").Single();
+
+        const string pinnedRef = "ref: ${{ needs.plan.outputs.ref }}";
+        Assert.Contains(pinnedRef, jobs[testJob], StringComparison.Ordinal);
+        Assert.Contains(pinnedRef, jobs[releaseJob], StringComparison.Ordinal);
     }
 }


### PR DESCRIPTION
Closes #1978

## The problem

`publish.yml` wrote to the repository before running a single test. `prepare` generated the CHANGELOG section, committed it to `main`, pushed it, created the tag and pushed that — and only then did the matrix start.

So a red matrix left a permanent tag with no release behind it. Both `v2.3.0` and `v2.3.1` are such tags, each with a `chore: release` commit on `main` and a CHANGELOG section for a version that does not exist on NuGet.

The idempotent retry path made it recoverable. It should not need recovering.

**There is a second cost that is easy to miss.** CHANGELOG sections are generated from `git describe --tags`, so a dead tag becomes the baseline for the *next* release. That is why `[2.3.1]` lists two entries while the 21 real ones sit under `[2.3.0]`, a heading no release points at. Someone reading the v2.3.1 notes would never find the transaction fixes, the `--watch` incremental recompile, or the boot-overhead work.

## The change

| Job | Does | Writes |
|---|---|---|
| `plan` | resolves which commit to test and ship | nothing |
| `test` | the shared BC matrix at that ref | nothing |
| `release` | CHANGELOG commit, push to main, tag, pack, NuGet, Release | everything |

`plan` normally resolves `github.sha` — `main`'s head at dispatch. If the tag already exists it resolves the tag; that path now means only "the release job failed *after* tagging" (NuGet rejected the push, the Release API call failed), because tests can no longer be the thing that failed after a tag exists.

Two details that carry weight:

- **Pinning the ref in `plan`** — `main` can move during a 40-minute matrix run, and the tag has to point at the commit that was tested, not at whatever `main` has become. Both the matrix and the release checkout read the same pinned value.
- **Pushing the release commit before creating the tag**, without `--force`. `HEAD` is the tested commit plus a CHANGELOG-only diff, so the push fast-forwards exactly when `main` is still where the matrix found it. If someone merged meanwhile it fails there and **no tag is created** — re-dispatch against the new `main`.

The Release body now reads `steps.changelog.outputs.notes`, since generation and publication are one job.

## Test

Four assertions added to `ReleaseTestParityTests` (from #1976). Every write in `publish.yml` — the tag, the `main` push, the NuGet push, the GitHub Release — must live in a job that `needs:` the matrix job; and the matrix and release checkout must read the same pinned ref.

Verified red against the pre-change `publish.yml`, same binary:

```
EveryWriteInPublishYml_IsGatedOnTheTestMatrix                [FAIL]
  publish.yml job 'prepare' writes the release tag without needing 'test'.
PublishYml_TestsTheCommitItShips_NotWhateverMainBecomes      [FAIL]
Failed!  - Failed: 2, Passed: 10

# after:
Passed!  - Failed: 0, Passed: 12
```

The YAML helpers are proven separately on constructed input, including that `on:`/`env:` two-space keys are not mistaken for jobs — splitting from the top of the file rather than from `jobs:` would report `workflow_dispatch` as a job and silently void every ordering assertion.

## Interaction with the running release

None. The in-flight v2.3.1 run resolved its workflow at dispatch, and it is green through BC 27.0 and 27.5 — the leg that failed both previous attempts. This change applies from the next release onward.

## What this does not do

It does not clean up the existing `v2.3.0` / `v2.3.1` tags or their CHANGELOG sections. `v2.3.1` is about to become a real release; `v2.3.0` stays a dead tag, and I'll say so in the release notes rather than rewriting published history.