### PR TITLE
fix(testpage): dispatch triggers of page members whose AL names contain spaces

### DIFF
--- a/AlRunner/Patches/RecordPatches.AlPageParser.cs
+++ b/AlRunner/Patches/RecordPatches.AlPageParser.cs
@@ -73,7 +73,8 @@ public static partial class RecordPatches
                 // none", which Page Metadata reports as CardPageID = 0 (a real, meaningful
                 // value: Base App "Page Management".GetDefaultCardPageID reads it to decide
                 // whether a table has a card page at all).
-                CardPageName: PageRefText(PropValue(props, "CardPageId")));
+                CardPageName: PageRefText(PropValue(props, "CardPageId")),
+                MemberIdToName: ParseMemberNames(id, p));
         }
 
         foreach (var obj in objects)
@@ -93,8 +94,58 @@ public static partial class RecordPatches
                 ControlIdToFieldName: extFieldMap,
                 InsertAllowed: !PropIs(pe.PropertyList, "InsertAllowed", "false"),
                 BaseName: Unquote(pe.BaseObject?.ToString()?.Trim() ?? ""),
-                Controls: extControls);
+                Controls: extControls,
+                MemberIdToName: ParseMemberNames(id, pe));
         }
+    }
+
+    /// <summary>
+    /// Member id → declared AL NAME for every named field control and action of one page or
+    /// pageextension, in the DECLARING object's own id space. This is the reverse index
+    /// trigger dispatch needs (issue #1968): the emitted C# trigger method carries the name
+    /// only in MANGLED form (<c>"Spaced Stamp"</c> → <c>Spaced_Stamp_a45_OnAction</c>), and
+    /// un-mangling is ambiguous — <c>Spaced_Stamp</c> reads back identically for the AL names
+    /// <c>"Spaced Stamp"</c> and <c>Spaced_Stamp</c>, which hash to DIFFERENT member ids. The
+    /// AL source is the one place the true name still exists, so the id is derived from it
+    /// here, forward, the same way BC's own IdSpace does.
+    /// <para>Unlike <see cref="ParsePageControls"/> this walk keeps every NAMED control —
+    /// non-Rec-bound and compound-expression fields included — because a trigger can hang off
+    /// any of them; the Rec.-bound scope limit over there is about field BINDING, not naming.
+    /// </para>
+    /// </summary>
+    private static Dictionary<int, string> ParseMemberNames(int declaringObjectId, SyntaxNode obj)
+    {
+        var map = new Dictionary<int, string>();
+        void Add(string name)
+        {
+            if (name.Length == 0) return;
+            // TryAdd, not indexer: a field and an action of the SAME name hash to the same
+            // member id and carry the same name — first writer wins, the value is identical.
+            map.TryAdd(IdSpace.GetMemberId(declaringObjectId, name), name);
+        }
+
+        foreach (var field in obj.DescendantNodes().OfType<NavSyntax.PageFieldSyntax>())
+            Add(IdentText(field.Name));
+        foreach (var action in obj.DescendantNodes().OfType<NavSyntax.PageActionSyntax>())
+            Add(IdentText(action.Name));
+        return map;
+    }
+
+    /// <summary>
+    /// The declared AL name of member <paramref name="memberId"/> on the page or
+    /// pageextension <paramref name="declaringObjectId"/>, or null when the object was never
+    /// AL-source-parsed here (a page that ships precompiled in a dependency .app) or does not
+    /// declare the member. <paramref name="isExtension"/> picks the id namespace — a page and
+    /// a pageextension may share an object number (#1710), and the caller always knows which
+    /// one it is dispatching against.
+    /// </summary>
+    internal static string? TryGetPageMemberName(int declaringObjectId, int memberId, bool isExtension)
+    {
+        var dict = isExtension ? _parsedPageExtensions : _parsedPages;
+        return dict.TryGetValue(declaringObjectId, out var parsed)
+               && parsed.MemberIdToName.TryGetValue(memberId, out var name)
+            ? name
+            : null;
     }
 
     /// <summary>
@@ -352,10 +403,15 @@ internal record ParsedPage(
     /// <summary>AL's <c>CardPageId</c> property, as the last name segment of the page
     /// reference (unresolved — see <see cref="RecordPatches"/>.PageMetadataVirtualTable.cs).
     /// Null when the page declares none.</summary>
-    string? CardPageName = null)
+    string? CardPageName = null,
+    /// <summary>Member id → declared AL name for every named field control and action of this
+    /// object, in its own id space — see <see cref="RecordPatches"/>.ParseMemberNames (#1968).</summary>
+    IReadOnlyDictionary<int, string>? MemberIdToName = null)
 {
     // Positional records can't give a collection parameter a literal default that isn't a
     // constant, so a null Controls (constructed via the shorter historical call sites/tests,
     // if any ever appear) is normalized to empty rather than NRE-ing every consumer.
     public IReadOnlyList<PageControlRow> Controls { get; init; } = Controls ?? Array.Empty<PageControlRow>();
+    public IReadOnlyDictionary<int, string> MemberIdToName { get; init; }
+        = MemberIdToName ?? new Dictionary<int, string>();
 }

--- a/AlRunner/Patches/RunnerPageInstance.cs
+++ b/AlRunner/Patches/RunnerPageInstance.cs
@@ -900,14 +900,16 @@ internal sealed class RunnerPageInstance
     /// </summary>
     private TriggerMatch? FindTrigger(int memberId, string suffix, string surface, int arity = 0)
     {
-        var own = FindTriggerOnTarget(_form, _pageId, memberId, suffix, surface, arity);
+        var own = FindTriggerOnTarget(_form, _pageId, memberId, suffix, surface, arity,
+            RecordPatches.TryGetPageMemberName(_pageId, memberId, isExtension: false));
         if (own != null) return own;
 
         foreach (var extensionId in RecordPatches.GetPageExtensionIdsForPage(_pageId))
         {
             var extInstance = GetOrCreateExtensionInstance(extensionId);
             if (extInstance == null) continue;
-            var extMatch = FindTriggerOnTarget(extInstance, extensionId, memberId, suffix, surface, arity);
+            var extMatch = FindTriggerOnTarget(extInstance, extensionId, memberId, suffix, surface, arity,
+                RecordPatches.TryGetPageMemberName(extensionId, memberId, isExtension: true));
             if (extMatch != null) return extMatch;
         }
         return null;
@@ -916,10 +918,23 @@ internal sealed class RunnerPageInstance
     /// <summary>
     /// FindTrigger's inner scan, over ONE declaring object (the base page or one
     /// pageextension instance) and its own id space (<paramref name="declaringObjectId"/>).
+    ///
+    /// Issue #1968: matching used to work backwards only — un-mangle each candidate method's
+    /// name and re-derive its member id. The emitted method name is LOSSY for any member whose
+    /// AL name needed mangling: <c>action("Spaced Stamp")</c> emits
+    /// <c>Spaced_Stamp_a45_OnAction</c>, which un-mangles to <c>Spaced_Stamp</c> and hashes to
+    /// a different id than <c>Spaced Stamp</c> — so every spaced-name trigger read as
+    /// "declares no trigger". When the AL source parser knows the member's TRUE declared name
+    /// (<paramref name="declaredName"/>, from RecordPatches.TryGetPageMemberName), the match
+    /// now runs FORWARD instead: mangle the true name exactly the way BC's C# emitter does and
+    /// compare against the method-name skeleton. The backward scan remains the fallback for
+    /// declaring objects the parser never saw (a precompiled dependency page's own members).
     /// </summary>
     private static TriggerMatch? FindTriggerOnTarget(
-        object target, int declaringObjectId, int memberId, string suffix, string surface, int arity)
+        object target, int declaringObjectId, int memberId, string suffix, string surface, int arity,
+        string? declaredName = null)
     {
+        var mangled = declaredName == null ? null : EmittedIdentifier(declaredName);
         MethodInfo? match = null;
         foreach (var m in target.GetType()
             .GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance))
@@ -929,7 +944,11 @@ internal sealed class RunnerPageInstance
 
             var memberName = MemberNameFromTriggerMethod(m.Name, suffix);
             if (memberName == null) continue;
-            if (MemberId(declaringObjectId, memberName) != memberId) continue;
+            if (mangled != null)
+            {
+                if (!string.Equals(memberName, mangled, StringComparison.Ordinal)) continue;
+            }
+            else if (MemberId(declaringObjectId, memberName) != memberId) continue;
 
             if (match != null)
                 throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
@@ -1059,7 +1078,8 @@ internal sealed class RunnerPageInstance
             // this path) — an OnAction trigger that only touches its own locals still runs
             // faithfully; one that reads Rec/CurrPage NREs, which surfaces as a genuine
             // runner-internal error rather than a silently wrong answer.
-            var match = FindTriggerOnTarget(instance, extensionId, actionId, "_OnAction", "OnAction", arity: 0);
+            var match = FindTriggerOnTarget(instance, extensionId, actionId, "_OnAction", "OnAction", arity: 0,
+                RecordPatches.TryGetPageMemberName(extensionId, actionId, isExtension: true));
             if (match == null) continue;
 
             try { match.Value.Method.Invoke(match.Value.Target, null); }
@@ -1081,6 +1101,31 @@ internal sealed class RunnerPageInstance
             // failure — rethrow it unwrapped so the AL stack survives.
             System.Runtime.ExceptionServices.ExceptionDispatchInfo.Capture(tie.InnerException).Throw();
         }
+    }
+
+    /// <summary>
+    /// The identifier BC's C# emitter gives an AL member name — the FORWARD half of the
+    /// trigger-method naming scheme, empirically pinned against BC's own emit (probe page with
+    /// one action per character class, decompiled): a space becomes <c>_</c>
+    /// (<c>"Spaced Stamp"</c> → <c>Spaced_Stamp</c>, each space separately: <c>"A  C"</c> →
+    /// <c>A__C</c>); letters (Unicode included: <c>"Ærø Løb"</c> → <c>Ærø_Løb</c>), digits and
+    /// <c>_</c> pass through; any other character becomes <c>a</c> + its decimal code point
+    /// (<c>-</c>→<c>a45</c>, <c>.</c>→<c>a46</c>, <c>&amp;</c>→<c>a38</c>, <c>%</c>→<c>a37</c>,
+    /// <c>/</c>→<c>a47</c>); a leading digit gets a <c>_</c> prefix (<c>"2Start"</c> →
+    /// <c>_2Start</c>). This is deliberately NOT invertible — that irreversibility is exactly
+    /// why FindTriggerOnTarget mangles forward instead of un-mangling (#1968).
+    /// </summary>
+    internal static string EmittedIdentifier(string name)
+    {
+        var sb = new System.Text.StringBuilder(name.Length);
+        foreach (var c in name)
+        {
+            if (char.IsLetterOrDigit(c) || c == '_') sb.Append(c);
+            else if (c == ' ') sb.Append('_');
+            else sb.Append('a').Append(((int)c).ToString(System.Globalization.CultureInfo.InvariantCulture));
+        }
+        if (sb.Length > 0 && char.IsDigit(sb[0])) sb.Insert(0, '_');
+        return sb.ToString();
     }
 
     /// <summary>

--- a/tests/expectations/count-baseline/test-count-baseline.json
+++ b/tests/expectations/count-baseline/test-count-baseline.json
@@ -2,7 +2,7 @@
   "_comment": "Consumed by --count-baseline (AlRunner/Infrastructure/CountBaseline.cs), a DIFFERENT schema from the oos-/known-gaps-/divergence-/disabled- files in this directory: those declare the expected CLASSIFICATION of one named test, this declares the expected EXACT COUNT of a whole suite -- an exact match, not a floor: a mismatch in EITHER direction (drop OR growth) fails the run (exit 4). See #1880 and PR #1882's review for why growth is also a hard failure, not just a notice. Suite keys are the basename of the bundle directory CI passes on the command line (tests/al-language/tests/al-language -> 'al-language', tests/runner-extras -> 'runner-extras'), matching the '--out <name>-results.json' convention CI already uses. Values below are read off actual Test Matrix CI runs (see PR discussion for run URLs), not guessed: al-language's 2073->2076 bump reflects 3 corpus tests merged upstream between when the local baseline was drafted and when CI first ran against it. runner-extras' appGroups 23->21 byBcVersion override on 27.0/27.3/27.5 is the SAME preprocessor-gated-surface split that already explains its tests count divergence: fewer AL surfaces compile pre-28.0, which drops whole app groups, not just individual tests within a group. ANY PR that changes a suite's test or app-group count -- growth included -- MUST bump the matching number here in the SAME PR, or that PR's CI goes red with a [count-baseline] DROP or GROWTH diagnostic naming the exact expected/actual numbers to use.",
   "suites": {
     "al-language": {
-      "tests": { "default": 2110 },
+      "tests": { "default": 2120 },
       "appGroups": { "default": 1 }
     },
     "runner-extras": {


### PR DESCRIPTION
Closes #1968
Closes #1981

## What

`RunnerPageInstance.FindTriggerOnTarget` matched trigger methods by **un-mangling** the emitted C# method name and re-deriving the member id. That is lossy for any member name that needed mangling: `action("Spaced Stamp")` emits `Spaced_Stamp_a45_OnAction`, which un-mangles to `Spaced_Stamp` and hashes to a *different* member id than `Spaced Stamp`. So every spaced-name action read as "declares no OnAction trigger" (#1968, loud OOS), and every spaced-name field control's page OnValidate was silently skipped (#1981 — a missing OnValidate is benign by design, so nothing threw).

Two changes, one mechanism:

- `RecordPatches.AlPageParser` now builds a member-id → **declared AL name** index (`ParseMemberNames`) for every named field control and action, on pages *and* pageextensions, each in its own id space — forward-hashed with the same `IdSpace.GetMemberId` the control map already uses.
- `FindTriggerOnTarget` takes that true name and matches **forward**: mangle it exactly the way BC's C# emitter does (`EmittedIdentifier`) and compare method-name skeletons. The mangling rule was pinned empirically against BC's own emit (probe page with one action per character class, decompiled): space→`_`, letters/digits/`_` pass through (Unicode letters included), any other char→`a`+decimal code point (`-`→`a45`, `.`→`a46`, `&`→`a38`, `%`→`a37`, `/`→`a47`), leading digit→`_` prefix. `Microsoft.Dynamics.Nav.CodeAnalysis` exposes no callable API for this rule (`GetSafeCSharpIdentifierName` is a no-op for these inputs; `GetValidClsIdentifierByUsingUnderscores` maps `-`→`_`, which is not what the emitter does).

Design notes a reviewer will ask about:

- **Fallback preserved:** when the declaring object was never AL-source-parsed here (a precompiled dependency page's own members), the legacy backward scan still runs unchanged — this PR only upgrades the path where the true name is knowable.
- **Two names, one prefix:** `"Spaced Stamp"` and `Spaced_Stamp` on the same object both mangle to `Spaced_Stamp`; that resolves to the pre-existing loud "both … resolve to member" collision throw, never a silent wrong dispatch.

## Proving tests (upstream, per bc-behavior-tests-go-upstream)

Both corpus specs are open with **CI green on real BC 27.5 and 28.3**:

- StefanMaron/BusinessCentral.AL.Language.Tests#60 — spaced action Invoke (direct + current-row context, error propagation, `SpacedStamp` vs `"Spaced Stamp"` collision negative, pageext on host page, pageext on precompiled Base App page). On `main` here: **1 PASS / 5 FAIL** with #1968's signature; with this fix: **6/6**.
- StefanMaron/BusinessCentral.AL.Language.Tests#61 — spaced field-control OnValidate (value-applied and trigger-ran asserted separately, sibling isolation over one table field, error propagation). On `main` here: **1 PASS / 3 FAIL**, all silent skips; with this fix: **4/4**.

After #60/#61 merge, the submodule pin bump will carry both regression guards here.

## Verification

- Pinned al-language corpus @ `0a30b00`: **2110 pass / 0 fail**, exit 0
- `tests/runner-extras`: **155 pass / 0 fail**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XRbg6WPfJmswYuxtz6793n