### PR TITLE
fix(record): stamp rowversions on database-backed writes so HasBeenInserted answers truthfully

### DIFF
--- a/AlRunner/Infrastructure/NclCecilRewrite.cs
+++ b/AlRunner/Infrastructure/NclCecilRewrite.cs
@@ -19,7 +19,7 @@ namespace AlRunner.Infrastructure;
 
 public static class NclCecilRewrite
 {
-    private const int CACHE_VERSION = 127;
+    private const int CACHE_VERSION = 128;
 
     // ─────────────────────────────────────────────────────────────────────────
     // Cecil-owned skip registry (JmpHook→Cecil migration enabler).
@@ -6889,6 +6889,28 @@ public static class NclCecilRewrite
                     ByParams(Rt + "TempTableRecordBuffer", "CloneBlobs", "MutableRecordBuffer"),
                     H(blobIsolation, "DetachStoredBlobs"),
                     argSlots: 1); // `this` — the freshly stored row
+
+                // ── Rowversion stamping (issue #1980) ────────────────────────────────
+                // SQL assigns a rowversion on every insert/update; the SQL stand-in never
+                // did, so NavRecord.HasBeenInserted (== "timestamp field is non-zero") was
+                // false for every stored row and NavForm.SaveRecordAsync always chose
+                // Insert — CurrPage.SaveRecord() in a field OnValidate dup-keyed on rows
+                // reached via GoToRecord. Stamp the record buffer before Insert/Modify run;
+                // the guard inside the helper keeps `temporary` records at timestamp 0,
+                // exactly like real BC. See Patches/RowVersionPatches.cs for the audit.
+                var rowVersion = typeof(AlRunner.Patches.RowVersionPatches);
+
+                PrependStaticCall(nclMod,
+                    ByParams(Rt + "TempTableDataProvider", "Insert",
+                        "Int32", "MutableRecordBuffer", "InsertOptions", "ReadOnlyRecordBuffer&"),
+                    H(rowVersion, "OnBeforeInsert"),
+                    argSlots: 3); // this, companyToken, recordBuffer
+
+                PrependStaticCall(nclMod,
+                    ByParams(Rt + "TempTableDataProvider", "Modify",
+                        "Int32", "MutableRecordBuffer", "Boolean", "ReadOnlyRecordBuffer&"),
+                    H(rowVersion, "OnBeforeModify"),
+                    argSlots: 3); // this, companyToken, recordBuffer
 
                 // ── Rename store-aliasing boundary for `temporary` records (issue #1765) ──
                 // A temporary record's BLOB committed with Modify() is LOST across a

--- a/AlRunner/Patches/BlobStoreIsolationPatches.cs
+++ b/AlRunner/Patches/BlobStoreIsolationPatches.cs
@@ -124,6 +124,15 @@ public static class BlobStoreIsolationPatches
     }
 
     /// <summary>
+    /// Whether <paramref name="provider"/> was handed out for a NON-temporary table, i.e.
+    /// stands in for SQL. Shared with RowVersionPatches, which must stamp rowversions on
+    /// exactly the providers whose rows SQL would stamp — a `temporary` record's timestamp
+    /// stays zero on real BC, and its HasBeenInserted takes the ExistsAsync branch instead.
+    /// </summary>
+    internal static bool IsDatabaseBacked(object? provider)
+        => provider != null && _databaseBackedProviders.TryGetValue(provider, out _);
+
+    /// <summary>
     /// Cecil prepend on TempTableRecordBuffer.CloneBlobs. For a database-backed
     /// table, replaces every NavBLOB in the freshly stored row with a deep copy, so
     /// the row shares no BLOB object with the record variable that inserted it.

--- a/AlRunner/Patches/RowVersionPatches.cs
+++ b/AlRunner/Patches/RowVersionPatches.cs
@@ -1,0 +1,122 @@
+// RowVersionPatches — assign a rowversion ("timestamp", field 0) to every row written
+// through a DATABASE-BACKED TempTableDataProvider, the way SQL Server does on every
+// insert and update.
+//
+// ── The gap this closes (issue #1980) ────────────────────────────────────────
+//
+// NavRecord.HasBeenInserted for a non-temporary record is, verbatim from Ncl:
+//
+//     return !GetFieldValue(MetaTable.TimestampField).IsZeroOrEmpty;
+//
+// i.e. "does the row carry a rowversion" — which only SQL ever assigns. The runner's
+// SQL stand-in (TempTableDataProvider, see RecordPatches.NavDataAccessSource_
+// GetDataAccessForTable) never wrote the slot, so every stored row answered
+// HasBeenInserted = false forever. NavForm.SaveRecordAsync branches on exactly that
+// flag to pick Insert vs Modify, so CurrPage.SaveRecord() / CurrPage.Update(true)
+// from a field's OnValidate issued an INSERT for a row the page had reached via
+// GoToRecord — NavCSideDuplicateKeyException on the primary key. The rename path in
+// SaveRecordAsync reads OldRecord.HasBeenInserted the same way, so a spot fix at the
+// form would have repaired one consumer of a wrong answer instead of the answer.
+//
+// ── Why this is observably equivalent to real BC (loud-failures.md audit) ────
+//
+// SQL Server assigns a fresh, strictly-increasing rowversion to a row on every
+// INSERT and UPDATE; AL can observe it only as "zero or not" (HasBeenInserted) and
+// as an opaque monotonic BigInteger (Rec."timestamp"). A process-wide
+// Interlocked.Increment counter starting above zero reproduces both observable
+// properties. Temporary records are deliberately NOT stamped: on real BC a
+// `temporary` record's timestamp stays zero (NCLMetaTable.SqlHasTimestamp is false
+// for TableType.Temporary without a user-defined timestamp field), and its
+// HasBeenInserted takes the ExistsAsync branch — the database-backed-only guard
+// (BlobStoreIsolationPatches.IsDatabaseBacked) preserves that split.
+//
+// ── Mechanics ────────────────────────────────────────────────────────────────
+//
+// Two Cecil prepends (NclCecilRewrite), same pattern as BlobStoreIsolationPatches:
+// TempTableDataProvider.Insert and .Modify each get the stamp before their body
+// runs. The stamp writes the MutableRecordBuffer's own timestamp slot — the same
+// `this[MetaTable.<SystemField>.FieldIndex] = value` idiom the buffer itself uses
+// for SystemCreatedAt/SystemModifiedAt — so BOTH copies see it: Insert stores
+// recordBuffer.ToArray() (stamp travels into the store) and the inserting record
+// keeps its buffer (stamp answers the record's own HasBeenInserted immediately,
+// mirroring SQL returning the new rowversion to the writer). Reads serve the stored
+// buffer, so a record that Get()s the row afterwards carries the rowversion too.
+// There is no timestamp-based optimistic-concurrency compare anywhere on the
+// runner's modify path (checked: TempTableDataProvider.Modify compares nothing, and
+// Ncl contains no record-changed check for this provider), so a record holding an
+// older stamp than the store never trips anything.
+using System.Reflection;
+
+namespace AlRunner.Patches;
+
+public static class RowVersionPatches
+{
+    // Strictly increasing, process-wide, never 0 — rowversion semantics. Starts at 1
+    // so the very first stamped row already answers HasBeenInserted = true.
+    private static long _rowVersion;
+
+    private static PropertyInfo? _pMetaTable;      // MutableRecordBuffer.MetaTable
+    private static PropertyInfo? _pTimestampField; // NCLMetaTable.TimestampField (internal)
+    private static PropertyInfo? _pFieldIndex;     // NCLMetaField.FieldIndex
+    private static PropertyInfo? _pItem;           // MutableRecordBuffer.this[int]
+    private static MethodInfo? _mCreate;           // NavBigInteger.Create(long)
+    private static bool _reflectionFailed;
+
+    /// <summary>Cecil prepend on TempTableDataProvider.Insert — (this, companyToken, recordBuffer).</summary>
+    public static void OnBeforeInsert(object? provider, int companyToken, object? recordBuffer)
+        => Stamp(provider, recordBuffer);
+
+    /// <summary>Cecil prepend on TempTableDataProvider.Modify — same first three arg slots.</summary>
+    public static void OnBeforeModify(object? provider, int companyToken, object? recordBuffer)
+        => Stamp(provider, recordBuffer);
+
+    private static void Stamp(object? provider, object? recordBuffer)
+    {
+        if (recordBuffer == null || !BlobStoreIsolationPatches.IsDatabaseBacked(provider)) return;
+        if (_reflectionFailed) return;
+
+        try
+        {
+            var bufferType = recordBuffer.GetType();
+            _pMetaTable ??= bufferType.GetProperty("MetaTable",
+                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
+                ?? throw new MissingMemberException(bufferType.Name, "MetaTable");
+            var metaTable = _pMetaTable.GetValue(recordBuffer)
+                ?? throw new InvalidOperationException("record buffer has no MetaTable");
+
+            _pTimestampField ??= metaTable.GetType().GetProperty("TimestampField",
+                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
+                ?? throw new MissingMemberException(metaTable.GetType().Name, "TimestampField");
+            var tsField = _pTimestampField.GetValue(metaTable);
+            // A table without a timestamp field (companion-table shapes) simply has
+            // nothing to stamp — same as SQL never returning a rowversion for it.
+            if (tsField == null) return;
+
+            _pFieldIndex ??= tsField.GetType().GetProperty("FieldIndex",
+                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
+                ?? throw new MissingMemberException(tsField.GetType().Name, "FieldIndex");
+            var index = (int)_pFieldIndex.GetValue(tsField)!;
+
+            _mCreate ??= typeof(Microsoft.Dynamics.Nav.Runtime.NavBigInteger).GetMethod(
+                "Create", BindingFlags.Public | BindingFlags.Static, binder: null,
+                new[] { typeof(long) }, modifiers: null)
+                ?? throw new MissingMemberException("NavBigInteger", "Create(long)");
+            _pItem ??= bufferType.GetProperty("Item",
+                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
+                ?? throw new MissingMemberException(bufferType.Name, "Item");
+
+            _pItem.SetValue(recordBuffer,
+                _mCreate.Invoke(null, new object[] { System.Threading.Interlocked.Increment(ref _rowVersion) }),
+                new object[] { index });
+        }
+        catch (Exception ex)
+        {
+            // Loud once, then permanently off for this process — a half-working stamp
+            // that throws on every write would take the whole store down, while a
+            // missing stamp only reverts to the pre-#1980 behaviour it replaces.
+            _reflectionFailed = true;
+            Console.Out.WriteLine(
+                $"[RowVersionPatches] rowversion stamping disabled — {ex.GetType().Name}: {ex.Message}");
+        }
+    }
+}


### PR DESCRIPTION
Closes #1980

## What

`NavRecord.HasBeenInserted` for a non-temporary record is, verbatim from Ncl, "does the row carry a rowversion": `!GetFieldValue(MetaTable.TimestampField).IsZeroOrEmpty` — a value only SQL ever assigns. The runner's SQL stand-in (`TempTableDataProvider`) never wrote that slot, so every stored row answered `HasBeenInserted = false` forever. `NavForm.SaveRecordAsync` branches on exactly that flag to pick Insert vs Modify, so `CurrPage.SaveRecord()` / `CurrPage.Update(true)` from a field's OnValidate issued an **Insert** for a row the page had reached via `GoToRecord` — `NavCSideDuplicateKeyException` on the primary key. The rename path in `SaveRecordAsync` reads `OldRecord.HasBeenInserted` the same way, so the fix lands at the answer, not the caller.

Two Cecil prepends (same pattern as the blob-isolation patch) stamp a process-wide strictly-increasing rowversion into the record buffer's timestamp slot on `TempTableDataProvider.Insert` and `.Modify` — **database-backed providers only** (the `BlobStoreIsolationPatches` registry): a `temporary` record's timestamp stays zero exactly as on real BC (`SqlHasTimestamp` is false for `TableType.Temporary`), and its `HasBeenInserted` keeps taking the `ExistsAsync` branch.

Design points a reviewer will ask about:

- **Both copies see the stamp:** `Insert` stores `recordBuffer.ToArray()`, so stamping the `MutableRecordBuffer` before the body runs reaches the store *and* the inserting record — mirroring SQL returning the new rowversion to the writer. Reads serve the stored buffer, so `Get()` carries it too.
- **No concurrency-check regression:** there is no timestamp-based "modified by another user" compare anywhere on the runner's modify path (`TempTableDataProvider.Modify` compares nothing; Ncl holds no such check for this provider) — a record variable holding an older stamp than the store trips nothing.
- **Observable equivalence** (loud-failures audit, in-code): AL can observe a rowversion only as "zero or not" and as an opaque monotonic BigInteger; an `Interlocked.Increment` counter starting above zero reproduces both.
- `CACHE_VERSION` 127→128 (rewritten-Ncl disk cache).

## Proving tests (upstream, per bc-behavior-tests-go-upstream)

Corpus spec StefanMaron/BusinessCentral.AL.Language.Tests#62 is open with **CI green on real BC 27.5 and 28.3**: SaveRecord / Update(true) in a field OnValidate must Modify (count-asserted so an insert-then-shadow scheme cannot pass), an implicit-save-on-Close control arm, and a persists-before-Close positive. On `main` here: **1 PASS / 3 FAIL**, all `NavCSideDuplicateKeyException`; with this fix: **4/4**. After #62 merges, the submodule pin bump will carry the regression guard here.

## Verification

- Pinned al-language corpus @ `b536579`: **2120 pass / 0 fail**, exit 0
- `tests/runner-extras`: **155 pass / 0 fail**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XRbg6WPfJmswYuxtz6793n