### PR TITLE
chore(corpus): bump al-language pin to e300a304, raise count baseline to 2124

### DIFF
--- a/tests/expectations/count-baseline/test-count-baseline.json
+++ b/tests/expectations/count-baseline/test-count-baseline.json
@@ -2,7 +2,7 @@
   "_comment": "Consumed by --count-baseline (AlRunner/Infrastructure/CountBaseline.cs), a DIFFERENT schema from the oos-/known-gaps-/divergence-/disabled- files in this directory: those declare the expected CLASSIFICATION of one named test, this declares the expected EXACT COUNT of a whole suite -- an exact match, not a floor: a mismatch in EITHER direction (drop OR growth) fails the run (exit 4). See #1880 and PR #1882's review for why growth is also a hard failure, not just a notice. Suite keys are the basename of the bundle directory CI passes on the command line (tests/al-language/tests/al-language -> 'al-language', tests/runner-extras -> 'runner-extras'), matching the '--out <name>-results.json' convention CI already uses. Values below are read off actual Test Matrix CI runs (see PR discussion for run URLs), not guessed: al-language's 2073->2076 bump reflects 3 corpus tests merged upstream between when the local baseline was drafted and when CI first ran against it. runner-extras' appGroups 23->21 byBcVersion override on 27.0/27.3/27.5 is the SAME preprocessor-gated-surface split that already explains its tests count divergence: fewer AL surfaces compile pre-28.0, which drops whole app groups, not just individual tests within a group. ANY PR that changes a suite's test or app-group count -- growth included -- MUST bump the matching number here in the SAME PR, or that PR's CI goes red with a [count-baseline] DROP or GROWTH diagnostic naming the exact expected/actual numbers to use.",
   "suites": {
     "al-language": {
-      "tests": { "default": 2120 },
+      "tests": { "default": 2124 },
       "appGroups": { "default": 1 }
     },
     "runner-extras": {


### PR DESCRIPTION
## Summary

Bumps the `tests/al-language` submodule pin from `b536579e` to `e300a304`, pulling in upstream corpus PR [StefanMaron/BusinessCentral.AL.Language.Tests#62](https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/62), which adds the `TestPageSaveRecordInOnValidate` suite (table 60250, page 60251, codeunit 60252, 4 new `[Test]` procedures) proving `CurrPage.SaveRecord()` / `CurrPage.Update(true)` called from a field's `OnValidate` modify the existing row rather than inserting a duplicate.

The runner fix that makes this suite pass — #1983 (stamping rowversions on database-backed writes so `HasBeenInserted` answers truthfully) — already merged to `main`. So this pin bump is **green by construction**: it's the regression guard landing, not a RED→GREEN demonstration. #1980 already closed via #1983.

Raises `tests/expectations/count-baseline/test-count-baseline.json`'s `al-language.tests.default` from 2120 to 2124 in the same commit, since `--count-baseline` fails on test-count growth as well as shrinkage.

## Verification

- Inspected the submodule diff directly (`git -C tests/al-language diff b536579e..e300a304`): exactly the 3 new AL files from PR #62, nothing else came along.
- Confirmed `08cce02b` (#1983) is an ancestor of this branch's HEAD.
- No local BC run performed — letting CI adjudicate per the task instructions.

## Test plan
- [ ] CI Test Matrix green across all BC version legs
- [ ] `--count-baseline` check passes with the new 2124 figure