### PR TITLE
fix(cli): resolve tests/expectations relative to bundle path, not just cwd

### DIFF
--- a/AlRunner.Tests/ExpectationManifestWiringTests.cs
+++ b/AlRunner.Tests/ExpectationManifestWiringTests.cs
@@ -19,6 +19,17 @@
 // `out-of-scope: <api> — <reason>` message convention, and #1741 added
 // expect-divergence. Both are covered here end-to-end; the negatives that keep the
 // widened matcher honest live in ManifestDrift_EveryDirection_FailsTheRunLoudly.
+//
+// #1984 added AutoProbe_ResolvesRelativeToBundlePath_EvenWhenCwdHasNoManifest and
+// AutoProbe_NoManifestAnywhere_EmitsLoudDiagnostic below: the auto-probe used to
+// check ONLY Environment.CurrentDirectory, so the SAME bundle silently lost its
+// out-of-scope/known-gap/divergence classification depending on which directory the
+// shell happened to be sitting in when al-runner was invoked. That also forced
+// NoManifest_UnchangedBehaviour_OosIsAPlainFail to move its fixture bundle OUTSIDE
+// this repo's working tree: this repo's own tests/expectations/ is a genuine
+// ancestor of AlRunner.Tests/Fixtures/ExpectationsBundle/suite, so once the
+// auto-probe walks up from the bundle path, that fixture is no longer a valid
+// "no manifest reachable at all" scenario in-place.
 
 using System.Diagnostics;
 using System.Text;
@@ -29,7 +40,7 @@ namespace AlRunner.Tests;
 
 // See DefineFlagIntegrationTests for why runner-subprocess tests used to be
 // [Collection("server-serial")] and no longer are — #1809.
-public sealed class ExpectationManifestWiringTests
+public sealed class ExpectationManifestWiringTests : IDisposable
 {
     private static readonly string RepoRoot = Path.GetFullPath(
         Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
@@ -40,6 +51,26 @@ public sealed class ExpectationManifestWiringTests
         RepoRoot, "AlRunner.Tests", "Fixtures", "ExpectationsManifest");
     private static readonly string MalformedManifestDir = Path.Combine(
         RepoRoot, "AlRunner.Tests", "Fixtures", "ExpectationsManifestMalformed");
+
+    // #1984: scratch root for tests that need fixture copies living OUTSIDE this
+    // repo's working tree, so no ancestor of the copy accidentally carries this
+    // repo's own tests/expectations/. Torn down in Dispose.
+    private readonly string _scratchRoot = Path.Combine(
+        Path.GetTempPath(), "al-runner-expectations-wiring", Guid.NewGuid().ToString("N"));
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_scratchRoot, recursive: true); } catch { }
+    }
+
+    private static void CopyDirectory(string sourceDir, string destDir)
+    {
+        Directory.CreateDirectory(destDir);
+        foreach (var file in Directory.EnumerateFiles(sourceDir))
+            File.Copy(file, Path.Combine(destDir, Path.GetFileName(file)), overwrite: true);
+        foreach (var subDir in Directory.EnumerateDirectories(sourceDir))
+            CopyDirectory(subDir, Path.Combine(destDir, Path.GetFileName(subDir)));
+    }
 
     private static (string Output, int Exit) RunRunner(string runnerArgs, string? workingDir = null)
     {
@@ -175,23 +206,89 @@ public sealed class ExpectationManifestWiringTests
     }
 
     /// <summary>
-    /// Negative direction: with NO manifest (cwd without tests/expectations and no
-    /// --expectations flag), behaviour is unchanged — an uncaught OOS throw is a plain
-    /// FAIL without any drift diagnostic. Without this, the assertions above would
-    /// still hold if classification ran unconditionally and rewrote every user-facing
-    /// OOS failure into manifest advice.
+    /// Negative direction: with NO manifest reachable AT ALL (neither cwd nor any
+    /// ancestor of the bundle path has a tests/expectations directory, and no
+    /// --expectations flag), behaviour is unchanged — an uncaught OOS throw is a
+    /// plain FAIL without any drift diagnostic. Without this, the assertions above
+    /// would still hold if classification ran unconditionally and rewrote every
+    /// user-facing OOS failure into manifest advice.
+    ///
+    /// #1984: the fixture bundle is copied OUTSIDE this repo's working tree for this
+    /// test specifically — see the class-level #1984 comment for why the in-repo
+    /// SuitePath no longer proves "no manifest reachable" once the auto-probe walks
+    /// up from the bundle path (this repo's own tests/expectations/ IS an ancestor
+    /// of SuitePath).
     /// </summary>
     [SkippableFact]
     public void NoManifest_UnchangedBehaviour_OosIsAPlainFail()
     {
         TestArtifacts.SkipIfMissing();
 
+        var isolatedBundle = Path.Combine(_scratchRoot, "no-manifest", "suite");
+        CopyDirectory(SuitePath, isolatedBundle);
+        var isolatedCwd = Path.Combine(_scratchRoot, "no-manifest", "cwd");
+        Directory.CreateDirectory(isolatedCwd);
+
         var (output, exit) = RunRunner(
-            $"--test Drift_OosThrownButNoEntry \"{SuitePath}\"",
-            workingDir: Path.Combine(RepoRoot, "AlRunner.Tests", "Fixtures"));
+            $"--test Drift_OosThrownButNoEntry \"{isolatedBundle}\"",
+            workingDir: isolatedCwd);
 
         Assert.DoesNotContain("Add an expect-oos entry", output, StringComparison.Ordinal);
         AssertCount(output, "  fail:", 1);
         Assert.True(exit == 1, $"an uncaught OOS throw stays a failing test. exit={exit}\n{output}");
+    }
+
+    /// <summary>
+    /// The reported bug (#1984): a bundle whose enclosing checkout HAS a
+    /// tests/expectations manifest must have it applied regardless of cwd. Before
+    /// the fix, the auto-probe checked only Environment.CurrentDirectory, so this
+    /// SAME invocation — manifest and bundle both copied under one "fake-repo" tree,
+    /// cwd pointed at a totally unrelated directory — silently lost classification:
+    /// the declared expect-oos entry never reclassified the throw, and the run
+    /// reported a plain FAIL where it should report pass-oos.
+    /// </summary>
+    [SkippableFact]
+    public void AutoProbe_ResolvesRelativeToBundlePath_EvenWhenCwdHasNoManifest()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var fakeRepo = Path.Combine(_scratchRoot, "fake-repo");
+        CopyDirectory(ManifestDir, Path.Combine(fakeRepo, "tests", "expectations"));
+        var bundleDir = Path.Combine(fakeRepo, "nested", "path", "to", "suite");
+        CopyDirectory(SuitePath, bundleDir);
+        var unrelatedCwd = Path.Combine(_scratchRoot, "unrelated-cwd");
+        Directory.CreateDirectory(unrelatedCwd);
+
+        var (output, exit) = RunRunner(
+            $"--test GreenPath_OosDeclared \"{bundleDir}\"",
+            workingDir: unrelatedCwd);
+
+        AssertCount(output, "pass-oos:", 1);
+        AssertCount(output, "  fail:", 0);
+        Assert.True(exit == 0,
+            $"the bundle-path-relative manifest must reclassify the OOS throw regardless of cwd. exit={exit}\n{output}");
+    }
+
+    /// <summary>
+    /// The loud-failures half of #1984: when NO manifest is reachable via either the
+    /// bundle path's ancestors or cwd, the run must say so on stderr — before the
+    /// fix there was no notice at any verbosity, so a corpus run from the wrong cwd
+    /// silently lost classification with nothing in the output pointing at why.
+    /// </summary>
+    [SkippableFact]
+    public void AutoProbe_NoManifestAnywhere_EmitsLoudDiagnostic()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var isolatedBundle = Path.Combine(_scratchRoot, "loud-miss", "suite");
+        CopyDirectory(SuitePath, isolatedBundle);
+        var isolatedCwd = Path.Combine(_scratchRoot, "loud-miss", "cwd");
+        Directory.CreateDirectory(isolatedCwd);
+
+        var (output, _) = RunRunner(
+            $"--test GreenPath_OosDeclared \"{isolatedBundle}\"",
+            workingDir: isolatedCwd);
+
+        Assert.Contains("[expectations] no tests/expectations manifest found", output, StringComparison.Ordinal);
     }
 }

--- a/AlRunner.Tests/ExpectationsDirectoryResolutionTests.cs
+++ b/AlRunner.Tests/ExpectationsDirectoryResolutionTests.cs
@@ -1,0 +1,118 @@
+// ExpectationsDirectoryResolutionTests — pins the resolver at #1984's core: the
+// auto-probed tests/expectations manifest must be found relative to the BUNDLE
+// path, not only relative to cwd.
+//
+// Before the fix, Program.cs's auto-probe was a single
+// `Directory.Exists(Path.Combine(Environment.CurrentDirectory, "tests", "expectations"))`
+// check — so `al-runner ... tests/al-language/tests/al-language` found the manifest
+// only when cwd happened to be the repo root, and missed it (silently) from every
+// other cwd, even though the SAME bundle sits inside a checkout whose tests/expectations
+// is perfectly discoverable by walking up from the bundle argument.
+//
+// These tests exercise ExpectationsDirectoryResolution.Resolve directly — no
+// subprocess, no BC engine — so they are fast and give an unambiguous RED→GREEN
+// signal for the resolution algorithm itself. ExpectationManifestWiringTests carries
+// the slower end-to-end proof that Program.cs actually calls this.
+using AlRunner.Infrastructure;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class ExpectationsDirectoryResolutionTests : IDisposable
+{
+    private readonly string _root;
+
+    public ExpectationsDirectoryResolutionTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "al-runner-expectations-resolve", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { }
+    }
+
+    /// <summary>
+    /// The reported bug (#1984), reproduced without a subprocess: a manifest that
+    /// lives several levels above the bundle path must be found by walking up from
+    /// the bundle argument, even though cwd is a completely unrelated directory that
+    /// has no tests/expectations anywhere above it.
+    /// </summary>
+    [Fact]
+    public void Resolve_WalksUpFromBundlePath_EvenWhenCwdHasNoManifest()
+    {
+        var repoLike = Path.Combine(_root, "fake-repo");
+        var manifestDir = Path.Combine(repoLike, "tests", "expectations");
+        Directory.CreateDirectory(manifestDir);
+        var bundleDir = Path.Combine(repoLike, "tests", "al-language", "tests", "al-language");
+        Directory.CreateDirectory(bundleDir);
+
+        var unrelatedCwd = Path.Combine(_root, "unrelated-cwd");
+        Directory.CreateDirectory(unrelatedCwd);
+
+        var resolved = ExpectationsDirectoryResolution.Resolve(new[] { bundleDir }, unrelatedCwd);
+
+        Assert.Equal(manifestDir, resolved);
+    }
+
+    /// <summary>
+    /// Negative: when NEITHER the bundle path's ancestors NOR cwd have a
+    /// tests/expectations directory, resolution must return null (not throw, not
+    /// guess) — the caller is responsible for making that loud.
+    /// </summary>
+    [Fact]
+    public void Resolve_NoManifestAnywhere_ReturnsNull()
+    {
+        var bundleDir = Path.Combine(_root, "isolated", "bundle");
+        Directory.CreateDirectory(bundleDir);
+        var unrelatedCwd = Path.Combine(_root, "isolated", "cwd");
+        Directory.CreateDirectory(unrelatedCwd);
+
+        var resolved = ExpectationsDirectoryResolution.Resolve(new[] { bundleDir }, unrelatedCwd);
+
+        Assert.Null(resolved);
+    }
+
+    /// <summary>
+    /// Back-compat: the original cwd-only behaviour still works when the bundle path
+    /// itself has no reachable manifest but cwd does — a relative bundle path
+    /// invoked from the repo root (the pre-#1984 working case) must keep working.
+    /// </summary>
+    [Fact]
+    public void Resolve_FallsBackToCwd_WhenBundlePathHasNoManifest()
+    {
+        var manifestDir = Path.Combine(_root, "tests", "expectations");
+        Directory.CreateDirectory(manifestDir);
+        var bundleOutsideRoot = Path.Combine(Path.GetTempPath(), "al-runner-expectations-resolve-elsewhere", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(bundleOutsideRoot);
+        try
+        {
+            var resolved = ExpectationsDirectoryResolution.Resolve(new[] { bundleOutsideRoot }, _root);
+            Assert.Equal(manifestDir, resolved);
+        }
+        finally
+        {
+            try { Directory.Delete(bundleOutsideRoot, recursive: true); } catch { }
+        }
+    }
+
+    /// <summary>
+    /// A nonexistent bundle path (e.g. mistyped, or diagnosed elsewhere by
+    /// BundleRootValidation) must not throw — it degrades to walking up from its
+    /// would-be parent directory rather than crashing the auto-probe.
+    /// </summary>
+    [Fact]
+    public void Resolve_NonexistentBundlePath_DoesNotThrow_WalksUpFromParent()
+    {
+        var manifestDir = Path.Combine(_root, "tests", "expectations");
+        Directory.CreateDirectory(manifestDir);
+        var nonexistentBundle = Path.Combine(_root, "does-not-exist");
+        var unrelatedCwd = Path.Combine(_root, "unrelated-cwd2");
+        Directory.CreateDirectory(unrelatedCwd);
+
+        var resolved = ExpectationsDirectoryResolution.Resolve(new[] { nonexistentBundle }, unrelatedCwd);
+
+        Assert.Equal(manifestDir, resolved);
+    }
+}

--- a/AlRunner/Infrastructure/ExpectationsDirectoryResolution.cs
+++ b/AlRunner/Infrastructure/ExpectationsDirectoryResolution.cs
@@ -1,0 +1,78 @@
+// ExpectationsDirectoryResolution — locates the tests/expectations/ manifest
+// directory for a run when the caller has NOT passed --expectations explicitly.
+//
+// Issue #1984: the original auto-probe checked ONLY Environment.CurrentDirectory
+// (see the comment that used to sit at Program.cs's expectations block). That meant
+//
+//   cwd = repo root                          → tests/expectations FOUND
+//   cwd = AlRunner/bin/Release/net8.0         → tests/expectations MISSED
+//
+// for the byte-identical `al-runner ... tests/al-language/tests/al-language`
+// invocation — the manifest's relevance depends on which bundle is being run, not on
+// where the shell happens to be sitting. Worse, the miss was completely silent: an
+// explicit --expectations pointing at a missing directory exits 2 loudly, but the
+// auto-probed default just left `expectations` null and every expect-oos /
+// expect-divergence test in the run silently flipped from its classified outcome to
+// a plain FAIL.
+//
+// Fix: resolve relative to the BUNDLE path too. A bundle argument names where the
+// suite lives; walking UP from it to find a `tests/expectations` sibling is the same
+// thing you'd do by eye if asked "which repo's manifest applies to this bundle?".
+// cwd stays a secondary probe (kept for back-compat: a relative bundle path invoked
+// from the repo root already worked before this fix, and should keep working).
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace AlRunner.Infrastructure;
+
+/// <summary>
+/// Pure, testable resolution logic for the auto-probed <c>tests/expectations</c>
+/// manifest directory. See file header for the bug this exists to fix (#1984).
+/// </summary>
+public static class ExpectationsDirectoryResolution
+{
+    /// <summary>
+    /// Probes for <c>&lt;ancestor&gt;/tests/expectations</c>, walking UP from each
+    /// bundle root's absolute path first (in the order given), then from
+    /// <paramref name="currentDirectory"/>. Returns the first existing directory
+    /// found, or null if none of the probed locations exist.
+    /// </summary>
+    public static string? Resolve(IReadOnlyList<string> bundleRoots, string currentDirectory)
+    {
+        foreach (var root in bundleRoots)
+        {
+            if (string.IsNullOrWhiteSpace(root)) continue;
+            string start;
+            try { start = Path.GetFullPath(root); }
+            catch { continue; }   // an unusable bundle path is diagnosed elsewhere (BundleRootValidation)
+            var found = TryWalkUp(start);
+            if (found != null) return found;
+        }
+
+        string cwdStart;
+        try { cwdStart = Path.GetFullPath(currentDirectory); }
+        catch { return null; }
+        return TryWalkUp(cwdStart);
+    }
+
+    /// <summary>
+    /// Walks from <paramref name="start"/> (a directory, or a file/nonexistent path
+    /// whose containing directory is used instead) up through every ancestor,
+    /// looking for a <c>tests/expectations</c> subdirectory at each level. Stops at
+    /// the filesystem root.
+    /// </summary>
+    private static string? TryWalkUp(string start)
+    {
+        var dir = Directory.Exists(start) ? start : Path.GetDirectoryName(start);
+        while (dir != null)
+        {
+            var candidate = Path.Combine(dir, "tests", "expectations");
+            if (Directory.Exists(candidate)) return candidate;
+            var parent = Path.GetDirectoryName(dir);
+            if (parent == dir) break;   // reached the filesystem root
+            dir = parent;
+        }
+        return null;
+    }
+}

--- a/AlRunner/Log.cs
+++ b/AlRunner/Log.cs
@@ -15,17 +15,24 @@ public static class Log
 
     // Matches `[Component]` or `[ComponentName]` at the start of a line — alphanumeric
     // tag in square brackets, NOT a numeric progress tag like `[1/3]`.
-    // `[layered]`, `[watch]`, `[provision]`, `[bc]` and `[dep]` are explicitly exempted —
-    // they are user-facing output (layered source-build progress; watch-mode status;
-    // artifact provisioning/download progress; which BC version was selected; dependency
-    // resolution warnings), not internal diagnostics.
+    // `[layered]`, `[watch]`, `[provision]`, `[bc]`, `[dep]` and `[expectations]` are
+    // explicitly exempted — they are user-facing output (layered source-build progress;
+    // watch-mode status; artifact provisioning/download progress; which BC version was
+    // selected; dependency resolution warnings; whether the tests/expectations manifest
+    // was found), not internal diagnostics.
     //
     // `[bc]` was NOT exempted until 2026-07-29, so the two lines naming the selected BC
     // version vanished at default verbosity. Measured: the same suite scores 1041P/35F/0E
     // on `--bc-version 28.1` and 996P/77F/3E on the default selection — a 42-test swing
     // decided silently. Which version ran is a RESULT, not a diagnostic.
+    //
+    // `[expectations]` was NOT exempted until #1984, so the notices Program.cs prints
+    // when the tests/expectations manifest is (or is not) found were themselves silently
+    // eaten by this exact filter — the very issue those notices exist to fix. Whether
+    // out-of-scope/known-gap/divergence classification applied to a run is a RESULT
+    // (it changes pass/fail counts), not a diagnostic.
     private static readonly Regex ComponentTag =
-        new(@"^\[(?!(?:layered|watch|provision|bc|dep)\])[A-Za-z][A-Za-z0-9._+]*\]",
+        new(@"^\[(?!(?:layered|watch|provision|bc|dep|expectations)\])[A-Za-z][A-Za-z0-9._+]*\]",
             RegexOptions.Compiled);
 
     public static void Install()

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -244,8 +244,9 @@ string? artifactPathArg = null;
 // Validated as AL identifiers and merged with CLEANSCHEMA1..25 in BcCompiler.
 var extraPreprocessorSymbols = new List<string>();
 // --expectations DIR: test-expectations manifest directory (issue #1734; schema in
-// docs/expectations.md). Null = probe the default ./tests/expectations below; only an
-// existing directory activates classification, so ordinary runs outside this repo are
+// docs/expectations.md). Null = auto-probe below (walk up from each bundle path,
+// then cwd, looking for a tests/expectations sibling — #1984); only an existing
+// directory activates classification, so ordinary runs outside this repo are
 // untouched.
 string? expectationsDirArg = null;
 // --count-baseline PATH: opt-in test/app-group expected-count manifest (issue #1880;
@@ -381,9 +382,11 @@ if (serverMode && watchMode)
 // ── Test-expectations manifest (issue #1734; docs/expectations.md) ────────────────
 // Loaded HERE — at parse time, before BC init — so a malformed manifest aborts the
 // invocation (exit 2, the "bad invocation" ladder entry) without running a single
-// test. An explicit --expectations dir must exist; without the flag, the documented
-// default ./tests/expectations activates only when present (this repo's corpus CI),
-// leaving every other invocation exactly as before.
+// test. An explicit --expectations dir must exist; without the flag, the auto-probe
+// walks up from each bundle path (and, secondarily, cwd) looking for a
+// `tests/expectations` sibling — see ExpectationsDirectoryResolution for why cwd
+// alone silently missed it (#1984) — activating classification only when found,
+// leaving every invocation with no reachable manifest exactly as before.
 AlRunner.Infrastructure.ExpectationManifest? expectations = null;
 {
     var expectationsDir = expectationsDirArg;
@@ -392,14 +395,31 @@ AlRunner.Infrastructure.ExpectationManifest? expectations = null;
         Console.Error.WriteLine($"--expectations: directory not found: {expectationsDir}");
         return 2;
     }
-    expectationsDir ??= Directory.Exists(Path.Combine(Environment.CurrentDirectory, "tests", "expectations"))
-        ? Path.Combine(Environment.CurrentDirectory, "tests", "expectations")
-        : null;
+    if (expectationsDir == null)
+    {
+        expectationsDir = AlRunner.Infrastructure.ExpectationsDirectoryResolution.Resolve(bundles, Environment.CurrentDirectory);
+        if (expectationsDir == null)
+        {
+            // #1984: this used to be silent — an explicit --expectations miss exits 2
+            // loudly, but the auto-probed default just left `expectations` null and
+            // every expect-oos/expect-divergence test in the run flipped to a plain
+            // FAIL with nothing in the output to say why. Diagnosable, not inferred.
+            var cwdCandidate = Path.Combine(Path.GetFullPath(Environment.CurrentDirectory), "tests", "expectations");
+            Console.Error.WriteLine(
+                $"[expectations] no tests/expectations manifest found (probed {cwdCandidate}" +
+                (bundles.Count > 0 ? $" and the ancestor tree of {bundles.Count} bundle path(s)" : "") +
+                ") — expect-oos / expect-fail-known-gap / expect-divergence classification is OFF " +
+                "this run. Pass --expectations DIR to set it explicitly.");
+        }
+    }
     if (expectationsDir != null)
     {
         try
         {
             expectations = AlRunner.Infrastructure.ExpectationManifest.LoadFromDirectory(expectationsDir);
+            Console.Error.WriteLine(
+                $"[expectations] loaded {expectations.Entries.Count} " +
+                (expectations.Entries.Count == 1 ? "entry" : "entries") + $" from {expectationsDir}");
         }
         catch (InvalidOperationException ex)
         {


### PR DESCRIPTION
Closes #1984

## Root cause

`Program.cs`'s expectations-manifest auto-probe checked only
`Environment.CurrentDirectory`. The exact same invocation —
`al-runner ... tests/al-language/tests/al-language` — found the manifest
when cwd was the repo root and silently missed it from any other cwd (e.g.
`AlRunner/bin/Release/net8.0`), even though the bundle sits inside a
checkout whose `tests/expectations` is perfectly discoverable by walking up
from the bundle argument. An explicit `--expectations` pointing at a missing
directory already exited 2 loudly; the auto-probed default just left
`expectations` null with nothing in the output to say why, so every
`expect-oos`/`expect-divergence` corpus test silently flipped to a plain
FAIL.

## Fix

- `AlRunner/Infrastructure/ExpectationsDirectoryResolution.cs` (new):
  probes `<ancestor>/tests/expectations` by walking up from each bundle
  root first, then falling back to cwd (kept for back-compat with the
  pre-#1984 working case: a relative bundle path invoked from the repo
  root).
- `Program.cs` now calls this resolver for the auto-probe and, either way,
  reports the outcome on stderr: which directory the manifest loaded from
  (with entry count), or that none was found (naming the probed cwd
  location and how many bundle paths were also walked), plus a pointer to
  `--expectations DIR` to override.
- That new stderr notice was itself being silently eaten by `Log.cs`'s
  `[Component]` bracket filter — the exact same class of bug that the
  `[bc]` exemption fixed in July (see the comment there: "which version ran
  is a RESULT, not a diagnostic", a 42-test swing that used to vanish
  silently). `[expectations]` is now exempted alongside `[bc]`/`[dep]`/etc.
  for the same reason: whether classification applied to a run changes
  pass/fail counts, so it isn't an internal diagnostic to suppress by
  default.

I went with resolving relative to the bundle path (the issue's first
suggested fix) as the primary fix, since it makes the reported scenario
just work without requiring the corpus's own CI invocation style to change,
plus a permanent loud notice (issue's second suggestion) as defense in
depth for the case where truly no manifest is reachable at all.

## Tests

This is runner CLI plumbing — not BC behaviour — so per
`.claude/rules/bc-behavior-tests-go-upstream.md` the proving tests stay in
this repo, not the corpus. Given the claim is about process/cwd/bundle-path
resolution (nothing an AL test method can observe from inside AL), I put
them alongside `AlRunner.Tests/ExpectationManifestWiringTests.cs`, the
existing CLI-subprocess mechanism-test suite for this exact manifest (the
`AlRunner.Tests/` shape the pr-check gate's own guidance points to for
"runner-side mechanism tests"), rather than `tests/runner-extras/`.

- `AlRunner.Tests/ExpectationsDirectoryResolutionTests.cs` (new): fast,
  no-subprocess unit tests pinning the resolver algorithm directly —
  walks up from bundle path even when cwd has no manifest; returns null
  when nothing is reachable anywhere; falls back to cwd when the bundle
  path has no manifest; degrades gracefully (no throw) on a nonexistent
  bundle path.
- `AlRunner.Tests/ExpectationManifestWiringTests.cs`: two new end-to-end
  subprocess tests —
  `AutoProbe_ResolvesRelativeToBundlePath_EvenWhenCwdHasNoManifest` (the
  reported bug, reproduced: manifest + bundle copied under one temp
  "fake-repo" tree, cwd pointed at an unrelated directory, asserts
  `pass-oos: 1` and exit 0) and
  `AutoProbe_NoManifestAnywhere_EmitsLoudDiagnostic` (asserts the stderr
  notice appears at default verbosity). Also relocated the existing
  `NoManifest_UnchangedBehaviour_OosIsAPlainFail` fixture copy outside this
  repo's working tree, since this repo's own `tests/expectations/` is a
  genuine ancestor of its old in-repo fixture path and would otherwise
  falsely satisfy the new resolver.

RED→GREEN verified locally: stashed the production fix (keeping the new
tests) and confirmed both new subprocess tests failed for the documented
reason (`pass-oos: 0`/`fail: 1` for the resolution test; substring not
found for the diagnostic test), then restored the fix and reran — all 10
tests across both files green. Also ran the full `AlRunner.Tests` suite
(833 tests): 1 pre-existing, unrelated failure
(`BcCompilerSharedReferenceMemoTests.AddingAPackageToAScannedDir_ForcesARebuild`,
confirmed present on `main` before this branch's changes, nothing to do
with expectations/Log/Program.cs) — everything else green.