### PR TITLE
fix(record): fail loudly instead of silently disabling rowversion stamping

### DIFF
--- a/AlRunner.Tests/RowVersionPatchesTests.cs
+++ b/AlRunner.Tests/RowVersionPatchesTests.cs
@@ -1,0 +1,199 @@
+// RowVersionPatchesTests — contract tests for issue #1986.
+//
+// RowVersionPatches.Stamp (added by #1983) resolves five members by reflection
+// (MutableRecordBuffer.MetaTable, NCLMetaTable.TimestampField, NCLMetaField.
+// FieldIndex, the buffer indexer, NavBigInteger.Create(long)). Before this fix, any
+// failed lookup was caught, latched into a process-wide "give up forever" flag, and
+// reported with one line to Console.Out — which the test host captures — so the
+// #1980 bug it exists to fix (HasBeenInserted permanently false) would silently
+// resurface with no visible cause.
+//
+// These pin the C# CONTRACT directly, the same way BlobStoreIsolationPatchesTests
+// pins its sibling patch in the same Cecil-prepend group: reflected-shape fake POCOs
+// exercise the exact reflection path Stamp walks, without needing a loaded BC
+// runtime. This is runner-internal behaviour (a reflection-resolution failure mode),
+// not a claim about what BC does, so it belongs here rather than in the upstream
+// corpus — see bc-behavior-tests-go-upstream.md.
+//
+// RowVersionPatches' PropertyInfo/MethodInfo fields are a process-wide cache keyed
+// by nothing but "first successful resolution wins" (mirrors production: every real
+// record buffer is the same concrete MutableRecordBuffer type). A fake POCO missing
+// a member only exercises the "not found" branch if the cache has not already been
+// warmed by a real buffer elsewhere in this process — so every test here resets the
+// cache via reflection first, the same boundary-crossing pattern
+// BlobStoreIsolationPatchesTests uses for NavBLOB.IsDirty. All tests live in one
+// class (xunit runs collections in parallel but a class's own tests serially by
+// default), so there is nothing else in-process racing this shared static state.
+using System;
+using System.Reflection;
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class RowVersionPatchesTests
+{
+    private const int CompanyToken = 0;
+
+    private static void ResetReflectionCache()
+    {
+        var t = typeof(RowVersionPatches);
+        foreach (var name in new[] { "_pMetaTable", "_pTimestampField", "_pFieldIndex", "_pItem", "_mCreate" })
+        {
+            var f = t.GetField(name, BindingFlags.NonPublic | BindingFlags.Static)
+                ?? throw new InvalidOperationException($"test setup: RowVersionPatches.{name} not found");
+            f.SetValue(null, null);
+        }
+    }
+
+    private static object MarkDatabaseBackedProvider()
+    {
+        var provider = new object();
+        BlobStoreIsolationPatches.MarkDatabaseBacked(new FakeDataAccess(provider));
+        return provider;
+    }
+
+    private sealed class FakeDataAccess
+    {
+        public object DataProvider { get; }
+        public FakeDataAccess(object provider) => DataProvider = provider;
+    }
+
+    // A record buffer with no "MetaTable" member at all — simulates a future BC
+    // build renaming/removing the very first member Stamp resolves.
+    private sealed class BufferMissingMetaTable
+    {
+    }
+
+    private sealed class FakeMetaField
+    {
+        public int FieldIndex { get; }
+        public FakeMetaField(int fieldIndex) => FieldIndex = fieldIndex;
+    }
+
+    private sealed class FakeMetaTable
+    {
+        public FakeMetaField? TimestampField { get; }
+        public FakeMetaTable(FakeMetaField? timestampField) => TimestampField = timestampField;
+    }
+
+    private sealed class FakeBuffer
+    {
+        public FakeMetaTable MetaTable { get; }
+        private readonly object?[] _slots;
+        public FakeBuffer(FakeMetaTable metaTable, int slotCount)
+        {
+            MetaTable = metaTable;
+            _slots = new object?[slotCount];
+        }
+        public object? this[int index]
+        {
+            get => _slots[index];
+            set => _slots[index] = value;
+        }
+    }
+
+    // ── RED case: a failed lookup must throw loudly, not disappear ────────────────
+
+    [Fact]
+    public void OnBeforeInsert_BufferMissingMetaTableMember_ThrowsNamingTheMember()
+    {
+        ResetReflectionCache();
+        var provider = MarkDatabaseBackedProvider();
+        var buffer = new BufferMissingMetaTable();
+
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => RowVersionPatches.OnBeforeInsert(provider, CompanyToken, buffer));
+
+        Assert.Contains("MetaTable", ex.Message);
+        Assert.Contains(nameof(BufferMissingMetaTable), ex.Message);
+    }
+
+    [Fact]
+    public void OnBeforeModify_BufferMissingMetaTableMember_ThrowsNamingTheMember()
+    {
+        ResetReflectionCache();
+        var provider = MarkDatabaseBackedProvider();
+        var buffer = new BufferMissingMetaTable();
+
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => RowVersionPatches.OnBeforeModify(provider, CompanyToken, buffer));
+
+        Assert.Contains("MetaTable", ex.Message);
+    }
+
+    // A repeat call must keep throwing — no "loud once, then permanently silent
+    // fallback" latch. That latch was the exact mechanism #1986 forbids: it meant
+    // the SECOND and every later insert reverted to the pre-#1980 bug with nothing
+    // printed anywhere the test host could see.
+    [Fact]
+    public void OnBeforeInsert_RepeatedFailedLookup_KeepsThrowing_NeverLatchesSilentFallback()
+    {
+        ResetReflectionCache();
+        var provider = MarkDatabaseBackedProvider();
+        var buffer = new BufferMissingMetaTable();
+
+        Assert.Throws<InvalidOperationException>(
+            () => RowVersionPatches.OnBeforeInsert(provider, CompanyToken, buffer));
+        // Second call, same process, no reset in between: must throw again.
+        Assert.Throws<InvalidOperationException>(
+            () => RowVersionPatches.OnBeforeInsert(provider, CompanyToken, buffer));
+    }
+
+    // ── Not a reflection failure: no timestamp field is a legitimate quiet no-op ──
+
+    [Fact]
+    public void OnBeforeInsert_TableWithNoTimestampField_DoesNotThrow_StaysQuiet()
+    {
+        ResetReflectionCache();
+        var provider = MarkDatabaseBackedProvider();
+        var metaTable = new FakeMetaTable(timestampField: null); // property resolves fine, answers "none"
+        var buffer = new FakeBuffer(metaTable, slotCount: 1);
+
+        var record = Record.Exception(() => RowVersionPatches.OnBeforeInsert(provider, CompanyToken, buffer));
+
+        Assert.Null(record);
+    }
+
+    // ── Positive path still stamps once every member resolves ─────────────────────
+
+    [Fact]
+    public void OnBeforeInsert_AllMembersResolve_StampsRowVersionIntoTimestampSlot()
+    {
+        ResetReflectionCache();
+        var provider = MarkDatabaseBackedProvider();
+        const int timestampSlot = 0;
+        var metaTable = new FakeMetaTable(new FakeMetaField(timestampSlot));
+        var buffer = new FakeBuffer(metaTable, slotCount: 1);
+
+        RowVersionPatches.OnBeforeInsert(provider, CompanyToken, buffer);
+
+        var stamped = Assert.IsType<Microsoft.Dynamics.Nav.Runtime.NavBigInteger>(buffer[timestampSlot]);
+        Assert.False(stamped.IsZeroOrEmpty);
+    }
+
+    // ── Guard clauses stay quiet: nothing to stamp, no reflection even attempted ──
+
+    [Fact]
+    public void OnBeforeInsert_NullBuffer_DoesNotThrow()
+    {
+        ResetReflectionCache();
+        var provider = MarkDatabaseBackedProvider();
+
+        var record = Record.Exception(() => RowVersionPatches.OnBeforeInsert(provider, CompanyToken, null));
+
+        Assert.Null(record);
+    }
+
+    [Fact]
+    public void OnBeforeInsert_ProviderNotDatabaseBacked_DoesNotThrow_EvenWithBrokenBuffer()
+    {
+        ResetReflectionCache();
+        var provider = new object(); // never marked database-backed => temporary
+        var buffer = new BufferMissingMetaTable();
+
+        var record = Record.Exception(() => RowVersionPatches.OnBeforeInsert(provider, CompanyToken, buffer));
+
+        Assert.Null(record);
+    }
+}

--- a/AlRunner/Patches/RowVersionPatches.cs
+++ b/AlRunner/Patches/RowVersionPatches.cs
@@ -45,6 +45,27 @@
 // runner's modify path (checked: TempTableDataProvider.Modify compares nothing, and
 // Ncl contains no record-changed check for this provider), so a record holding an
 // older stamp than the store never trips anything.
+//
+// ── Loud-failures audit (issue #1986) ─────────────────────────────────────────
+//
+// The five reflection lookups below (MetaTable, TimestampField, FieldIndex, the
+// buffer indexer, NavBigInteger.Create) are NOT allowed to fail quietly. Reverting
+// to "no stamp" on a resolution failure is exactly the pre-#1980 bug this patch
+// exists to close — HasBeenInserted going back to permanently false — so any lookup
+// that cannot resolve throws InvalidOperationException naming the missing member,
+// the same convention the rest of AlRunner/Patches uses for an internal invariant
+// breaking (see e.g. NavRecordRefPatches, RecordPatches.AllObjVirtualTable).
+// RunnerOutOfScopeException does not apply here: that type means "this AL surface
+// is intentionally unsupported" (SMTP, HTTP egress, printing — see docs/scope.md),
+// which a developer cannot fix by upgrading the runner. A BC build moving one of
+// these members is a genuine runner defect with a fix available, not a permanent
+// scope boundary, so a plain thrown exception carrying the member name is the
+// right signal — it stops the run instead of quietly reintroducing #1980.
+//
+// The ONE legitimate quiet path stays quiet: `tsField == null` after the
+// TimestampField property itself resolved and answered fine. That is a real BC
+// answer — "this table has no timestamp field" — not a reflection failure, and
+// must not be conflated with one (see the comment at that line).
 using System.Reflection;
 
 namespace AlRunner.Patches;
@@ -60,7 +81,6 @@ public static class RowVersionPatches
     private static PropertyInfo? _pFieldIndex;     // NCLMetaField.FieldIndex
     private static PropertyInfo? _pItem;           // MutableRecordBuffer.this[int]
     private static MethodInfo? _mCreate;           // NavBigInteger.Create(long)
-    private static bool _reflectionFailed;
 
     /// <summary>Cecil prepend on TempTableDataProvider.Insert — (this, companyToken, recordBuffer).</summary>
     public static void OnBeforeInsert(object? provider, int companyToken, object? recordBuffer)
@@ -73,50 +93,56 @@ public static class RowVersionPatches
     private static void Stamp(object? provider, object? recordBuffer)
     {
         if (recordBuffer == null || !BlobStoreIsolationPatches.IsDatabaseBacked(provider)) return;
-        if (_reflectionFailed) return;
 
-        try
-        {
-            var bufferType = recordBuffer.GetType();
-            _pMetaTable ??= bufferType.GetProperty("MetaTable",
-                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
-                ?? throw new MissingMemberException(bufferType.Name, "MetaTable");
-            var metaTable = _pMetaTable.GetValue(recordBuffer)
-                ?? throw new InvalidOperationException("record buffer has no MetaTable");
+        // No try/catch here — a failed lookup throws straight out of this method and
+        // out of the Cecil-prepended TempTableDataProvider.Insert/Modify call it runs
+        // ahead of, so the run stops with the failing member named instead of quietly
+        // reverting to the pre-#1980 behaviour. See the file header for why this is
+        // InvalidOperationException rather than RunnerOutOfScopeException.
+        var bufferType = recordBuffer.GetType();
+        _pMetaTable ??= bufferType.GetProperty("MetaTable",
+            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException(
+                $"[RowVersionPatches] {bufferType.Name}.MetaTable property not found — " +
+                "rowversion stamping cannot resolve its reflection target");
+        var metaTable = _pMetaTable.GetValue(recordBuffer)
+            ?? throw new InvalidOperationException(
+                "[RowVersionPatches] record buffer has no MetaTable");
 
-            _pTimestampField ??= metaTable.GetType().GetProperty("TimestampField",
-                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
-                ?? throw new MissingMemberException(metaTable.GetType().Name, "TimestampField");
-            var tsField = _pTimestampField.GetValue(metaTable);
-            // A table without a timestamp field (companion-table shapes) simply has
-            // nothing to stamp — same as SQL never returning a rowversion for it.
-            if (tsField == null) return;
+        _pTimestampField ??= metaTable.GetType().GetProperty("TimestampField",
+            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException(
+                $"[RowVersionPatches] {metaTable.GetType().Name}.TimestampField property not found — " +
+                "rowversion stamping cannot resolve its reflection target");
+        var tsField = _pTimestampField.GetValue(metaTable);
+        // A table without a timestamp field (companion-table shapes) simply has
+        // nothing to stamp — same as SQL never returning a rowversion for it. This
+        // is the ONE legitimate quiet return: the property above resolved and ran
+        // fine, and truthfully answered "no timestamp field" — it is a real BC
+        // answer, not a reflection failure, and must stay a quiet no-op.
+        if (tsField == null) return;
 
-            _pFieldIndex ??= tsField.GetType().GetProperty("FieldIndex",
-                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
-                ?? throw new MissingMemberException(tsField.GetType().Name, "FieldIndex");
-            var index = (int)_pFieldIndex.GetValue(tsField)!;
+        _pFieldIndex ??= tsField.GetType().GetProperty("FieldIndex",
+            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException(
+                $"[RowVersionPatches] {tsField.GetType().Name}.FieldIndex property not found — " +
+                "rowversion stamping cannot resolve its reflection target");
+        var index = (int)_pFieldIndex.GetValue(tsField)!;
 
-            _mCreate ??= typeof(Microsoft.Dynamics.Nav.Runtime.NavBigInteger).GetMethod(
-                "Create", BindingFlags.Public | BindingFlags.Static, binder: null,
-                new[] { typeof(long) }, modifiers: null)
-                ?? throw new MissingMemberException("NavBigInteger", "Create(long)");
-            _pItem ??= bufferType.GetProperty("Item",
-                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
-                ?? throw new MissingMemberException(bufferType.Name, "Item");
+        _mCreate ??= typeof(Microsoft.Dynamics.Nav.Runtime.NavBigInteger).GetMethod(
+            "Create", BindingFlags.Public | BindingFlags.Static, binder: null,
+            new[] { typeof(long) }, modifiers: null)
+            ?? throw new InvalidOperationException(
+                "[RowVersionPatches] NavBigInteger.Create(long) method not found — " +
+                "rowversion stamping cannot resolve its reflection target");
+        _pItem ??= bufferType.GetProperty("Item",
+            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException(
+                $"[RowVersionPatches] {bufferType.Name}.Item indexer not found — " +
+                "rowversion stamping cannot resolve its reflection target");
 
-            _pItem.SetValue(recordBuffer,
-                _mCreate.Invoke(null, new object[] { System.Threading.Interlocked.Increment(ref _rowVersion) }),
-                new object[] { index });
-        }
-        catch (Exception ex)
-        {
-            // Loud once, then permanently off for this process — a half-working stamp
-            // that throws on every write would take the whole store down, while a
-            // missing stamp only reverts to the pre-#1980 behaviour it replaces.
-            _reflectionFailed = true;
-            Console.Out.WriteLine(
-                $"[RowVersionPatches] rowversion stamping disabled — {ex.GetType().Name}: {ex.Message}");
-        }
+        _pItem.SetValue(recordBuffer,
+            _mCreate.Invoke(null, new object[] { System.Threading.Interlocked.Increment(ref _rowVersion) }),
+            new object[] { index });
     }
 }


### PR DESCRIPTION
Closes #1986

## What changed

`RowVersionPatches.Stamp` (#1983) resolves five members by reflection — `MutableRecordBuffer.MetaTable`, `NCLMetaTable.TimestampField`, `NCLMetaField.FieldIndex`, the buffer indexer, `NavBigInteger.Create(long)`. Before this fix, any failed lookup was caught, latched a process-wide `_reflectionFailed = true` flag, and reported with one `Console.Out.WriteLine` — captured by the test host. That fallback reintroduces the exact #1980 bug this patch exists to close: `HasBeenInserted` permanently answering `false`, surfacing later as an unexplained `NavCSideDuplicateKeyException`.

The fix removes the catch-and-latch entirely. Each reflection lookup now throws `InvalidOperationException` naming the specific missing member, so a run stops with a visible, named cause instead of quietly reverting to the pre-#1980 behaviour.

The one legitimate quiet path — `tsField == null` after `TimestampField` itself resolved and answered "this table has no timestamp field" — is preserved and explicitly called out in comments as NOT a reflection failure (it's a real BC answer), so it doesn't get collapsed into the loud case.

## Exception type: `InvalidOperationException`, not `RunnerOutOfScopeException`

I looked at how the rest of `AlRunner/Patches/` handles this class of failure before choosing. `RunnerOutOfScopeException` is reserved for AL surfaces the runner intentionally does not support (SMTP, HTTP egress, printing, etc. — see `docs/scope.md`) — a developer cannot fix those by upgrading the runner, only by not exercising that surface. A future BC build moving a reflected member is a different kind of failure: a genuine runner defect with an available fix (update the reflection target), not a permanent scope boundary. `InvalidOperationException` naming the missing member is also the existing convention throughout `AlRunner/Patches/` for exactly this situation — see `NavRecordRefPatches.cs`, `RecordPatches.AllObjVirtualTable.cs`, `EnumMetadataPatches.cs`, `FormStaticRunModalPatches.cs`, all of which throw `InvalidOperationException` on a failed reflection lookup with the same shape. I matched that rather than introducing a new type or repurposing `RunnerOutOfScopeException` for something it doesn't mean.

## `CACHE_VERSION` (currently 128, bumped 127→128 by #1983)

No bump needed. The disk cache holds the *rewritten Ncl.dll bytes* — i.e. the IL the Cecil prepends inject at the `TempTableDataProvider.Insert`/`.Modify` call sites in `NclCecilRewrite.cs`. Those prepends call `RowVersionPatches.OnBeforeInsert`/`OnBeforeModify` by name, signature (`object?, int, object?`), and arg-slot count — none of which changed. The actual behaviour change (throw vs. silently latch) lives entirely inside `RowVersionPatches.Stamp`, in `AlRunner.dll`, not in the cached rewritten `Ncl.dll`. Confirmed by inspecting `NclCecilRewrite.cs`'s `TempTableDataProvider` prepend block — the `H(rowVersion, "OnBeforeInsert"/"OnBeforeModify")` call shape is unchanged.

## RED → GREEN

Added `AlRunner.Tests/RowVersionPatchesTests.cs`, following the same reflected-shape-fake pattern `BlobStoreIsolationPatchesTests.cs` uses for its sibling patch in the same Cecil-prepend group (issue #1751/#1765). This is runner-internal behaviour — a reflection-resolution failure mode with no BC-behaviour claim in it — so per `bc-behavior-tests-go-upstream.md` it correctly lives in `AlRunner.Tests/`, not the upstream corpus.

- **RED**: with the fix stashed (i.e. against the current `main` implementation), 4 of 7 tests fail:
  - `OnBeforeInsert_BufferMissingMetaTableMember_ThrowsNamingTheMember` — no exception thrown
  - `OnBeforeModify_BufferMissingMetaTableMember_ThrowsNamingTheMember` — no exception thrown
  - `OnBeforeInsert_RepeatedFailedLookup_KeepsThrowing_NeverLatchesSilentFallback` — no exception on the second call either (the latch)
  - `OnBeforeInsert_AllMembersResolve_StampsRowVersionIntoTimestampSlot` — fails for an unrelated reason: the static reflection cache had already been poisoned to "always no-op" by the earlier failing tests in the same process, which is itself evidence of the bug (a single failed lookup anywhere kills stamping for the rest of the run)
- **GREEN**: all 7 pass with the fix.

Also covers: the guard clauses (`recordBuffer == null`, provider not database-backed) stay quiet without ever touching reflection, and the "no timestamp field" branch stays a quiet no-op rather than throwing.

Full `AlRunner.Tests` run: 785 passed, 1 pre-existing unrelated failure (`BcCompilerSharedReferenceMemoTests.AddingAPackageToAScannedDir_ForcesARebuild`), 48 skipped. Confirmed the failure reproduces identically on `main` with my changes stashed — unrelated to this change (symbol-reference-loader memoization, nothing to do with `RowVersionPatches`).

## Secondary item (cached compiled delegates)

Left out, per the issue's own "lower priority" framing and the task instruction to keep it separable. `PropertyInfo.SetValue`/`MethodInfo.Invoke` per insert/modify is a performance concern, not a correctness one, and folding it into this PR would add surface area to a fix that's specifically about a silent-failure bug. Happy to pick it up as a follow-up issue if wanted.