### PR TITLE
fix(tests): isolate BcCompilerSharedReferenceMemoTests from the machine's real symbol caches

### DIFF
--- a/AlRunner.Tests/BcCompilerSharedReferenceMemoTests.cs
+++ b/AlRunner.Tests/BcCompilerSharedReferenceMemoTests.cs
@@ -391,6 +391,15 @@ public sealed class BcCompilerSharedReferenceMemoTests : IDisposable
     private static (ISymbolReferenceLoader? Loader, SymbolReferenceSpecification[] Specs)
         InvokeGetSharedReferences(IEnumerable<string> bundleAlpackagesDirs)
     {
+        // Issue #1992: pin _packageCacheDirs to empty BEFORE every call so GetSharedReferences
+        // never falls through to ResolveSymbolDirs() and scans the CALLING MACHINE's real
+        // ~/.local/share/al-runner/symbols / ~/.bcartifacts.cache/sandbox caches. Those tests
+        // that never call SetResolvedDeps (this class's rebuild-count assertions) got that
+        // fallback by accident of the dev box, which could already fold real, unrelated .app
+        // duplicates into DeduplicateAppPackageDirs' "changed" decision before this test's own
+        // fixture ever touched it — deterministically wrong on a machine with a populated
+        // bcartifacts sandbox, silently right everywhere else. See SetPackageCacheDirsForTests.
+        BcCompiler.SetPackageCacheDirsForTests(Array.Empty<string>());
         var method = typeof(BcCompiler).GetMethod(
             "GetSharedReferences", BindingFlags.NonPublic | BindingFlags.Static)
             ?? throw new InvalidOperationException("BcCompiler.GetSharedReferences not found by reflection.");

--- a/AlRunner/BcCompiler.cs
+++ b/AlRunner/BcCompiler.cs
@@ -695,6 +695,35 @@ public sealed partial class BcCompiler
         _appMetaCache.Clear();
     }
 
+    /// <summary>
+    /// Test seam: pin <c>_packageCacheDirs</c> to an explicit (possibly empty) list so
+    /// <see cref="GetSharedReferences"/> never falls through to <see cref="ResolveSymbolDirs"/>
+    /// (issue #1992). That fallback reads the CALLING MACHINE's real, process-wide symbol
+    /// caches — <c>~/.local/share/al-runner/symbols/&lt;ver&gt;</c> and
+    /// <c>~/.bcartifacts.cache/sandbox/&lt;ver&gt;/{w1/Extensions,platform/Applications}</c> —
+    /// which is exactly the behaviour <see cref="SetResolvedDeps"/> gives the real compile
+    /// pipeline, but tests that exercise the memo directly (bypassing SetResolvedDeps) got it
+    /// only by accident of whichever dirs happen to exist on whoever's machine runs them.
+    ///
+    /// A test asserting an EXACT rebuild count is reading BcCompiler's memo signature, which
+    /// folds in every scanned package dir (see ComputeLoaderSignature/DeduplicateAppPackageDirs).
+    /// On a dev box with a populated `.bcartifacts.cache/sandbox` (hundreds of real .app
+    /// files, some already deduped against each other), DeduplicateAppPackageDirs' "changed"
+    /// flag can already be true before the test's own fixture contributes anything — so the
+    /// FIRST call already takes the content-addressed staging path instead of the
+    /// unchanged-dirs fast path the test's math assumes as its baseline. A later call whose
+    /// only real-world change is a test-fixture duplicate (deduped away to the SAME surviving
+    /// file set) then hashes to the SAME staging key as the first call — the loader legitimately
+    /// serves the same modules, so this isn't wrong on the merits, but it defeats the test's
+    /// contract of forcing a rebuild through a specific narrow mechanism. Scoping
+    /// `_packageCacheDirs` here removes that machine-state coupling entirely: these tests then
+    /// see ONLY the dirs they construct, on every machine, deterministically.
+    /// </summary>
+    internal static void SetPackageCacheDirsForTests(IReadOnlyList<string> dirs)
+    {
+        lock (_refSync) { _packageCacheDirs = dirs; }
+    }
+
     private static List<string> DeduplicateAppPackageDirs(List<string> packageDirs, Guid? excludeAppId = null)
         => DeduplicateAppPackageDirs(packageDirs, excludeAppId, out _);
 


### PR DESCRIPTION
Closes #1992

## What I found (the parallelization hypothesis is refuted)

The issue's hypothesis was that `BcCompilerSharedReferenceMemoTests` and
`BcCompilerWarmLoaderReuseTests` race on `BcCompiler`'s static loader-memo
counter because `AlRunner.Tests` has no `CollectionBehavior`/parallelization
guard between them.

That's not the case on this codebase as it stands: both classes already carry
`[Collection(BcCompilerSharedReferenceCollection.Name)]`, and that collection
is declared `[CollectionDefinition(Name, DisableParallelization = true)]`
(added in #1836/#1841). xUnit therefore already serializes every test in both
classes against each other.

I reproduced the failure by running **only**
`AddingAPackageToAScannedDir_ForcesARebuild`, alone, with nothing else in the
test host process at all:

```
dotnet test AlRunner.Tests/AlRunner.Tests.csproj --no-build \
  --filter "FullyQualifiedName=AlRunner.Tests.BcCompilerSharedReferenceMemoTests.AddingAPackageToAScannedDir_ForcesARebuild"
```

It failed **every single time — 3/3** with `Expected: 2, Actual: 1`, with zero
other tests running. That's impossible to explain by cross-class interleaving,
so I kept digging instead of taking the issue's hypothesis at face value (per
`no-assumption-fixes.md`).

## The real cause

`InvokeGetSharedReferences` (the test helper both fixture classes share)
calls `BcCompiler.GetSharedReferences` via reflection without ever setting
`_packageCacheDirs`. That static falls through to `ResolveSymbolDirs()`,
which scans **this machine's real, process-wide symbol caches** —
`~/.local/share/al-runner/symbols/<ver>` and
`~/.bcartifacts.cache/sandbox/<ver>/{w1/Extensions,platform/Applications}` —
alongside the test's own tiny fixture dir.

I instrumented `DeduplicateAppPackageDirs`/`GetSharedReferences` temporarily
(not part of this diff) and confirmed directly: on this machine those real
caches already contain enough packages that `DeduplicateAppPackageDirs`'
`changed` flag is `true` on the test's **first** call — before the test's own
fixture data contributes anything. That routes the *first* call through the
content-addressed staging path instead of the "dirs unchanged" fast path the
test's assertion assumes as a baseline. The *second* call adds a `dup` dir
containing a duplicate copy of an already-scanned app; that duplicate gets
deduped away either way, so the **surviving file set is byte-identical**
between call 1 and call 2 — same hash key, same staged dir, same loader
signature. No rebuild. `ReferenceLoaderBuildCount` stays `1`.

CI stays green because its runners don't have `~/.bcartifacts.cache/sandbox`
populated with a matching-version symbol tree, so `ResolveSymbolDirs()`
contributes nothing there — the test only "works" by accident of what's on
disk on whoever runs it, which is exactly why 3 separate agents independently
hit this and one confirmed it reproduces on unmodified `origin/main`.

`BcCompilerWarmLoaderReuseTests.cs` never has this problem: every one of its
`InvokeGetSharedReferences` calls is preceded by
`SetDeps(...) -> BcCompiler.SetResolvedDeps(deps, packageCacheDirs)`, which
already pins `_packageCacheDirs` explicitly.

## The fix

Removes the coupling instead of scheduling around it (the issue's own
preferred option, though the actual coupling turned out to be real-filesystem
state, not a race): a new test seam,
`BcCompiler.SetPackageCacheDirsForTests(IReadOnlyList<string> dirs)`, pins
`_packageCacheDirs` to an explicit list so `GetSharedReferences` never
consults `ResolveSymbolDirs()`. `BcCompilerSharedReferenceMemoTests`'
`InvokeGetSharedReferences` now calls it with an empty list before every
invocation, so these tests see **only** the dirs they construct, on every
machine, deterministically. `BcCompilerWarmLoaderReuseTests.cs` is
intentionally left untouched — touching `_packageCacheDirs` there would
clobber the explicit dirs its own tests already set via `SetResolvedDeps`.

I did not put the two classes in one `DisableParallelization` collection
(the issue's other suggested option) — they already are, and that guard was
never the problem, so adding more serialization on top would only cost
suite wall-clock for zero benefit.

## Proof

**Before the fix**, on this machine (which reproduces the bug):
- 1/1 failure in the full-class run (`--filter
  FullyQualifiedName~BcCompilerSharedReferenceMemoTests`, 13 tests).
- 3/3 failures running the single test in isolation with nothing else in the
  process.

**After the fix**, on the same machine:
- 30/30 clean passes running the single test alone, back-to-back
  (`for i in 1..30: dotnet test --filter
  FullyQualifiedName=...AddingAPackageToAScannedDir_ForcesARebuild`).
- Both fixture classes together: 22/22 passed.
- Full `AlRunner.Tests` suite: 792 passed, 0 failed, 54 skipped (6m46s).

A single green run on this machine would be weak evidence for something
that was originally reported as environment/timing-sensitive — 30 is the
number I actually ran, not a token pass.

**CI cannot validate this fix directly** — the failure never occurred there,
so CI green here is necessary but not sufficient. The reproduction evidence
above, on a machine that reliably showed the bug, is the real proof.

## Constraints checked
- No changes under `tests/al-language/` or to `CHANGELOG.md`.
- Diff touches both `AlRunner/` and `AlRunner.Tests/`, satisfying the
  `require-tests` CI gate without needing a label.