### PR TITLE
fix(watch): surface WHY a --watch cycle fell back to a full rebuild

### DIFF
--- a/AlRunner.Tests/WatchDashboardTests.cs
+++ b/AlRunner.Tests/WatchDashboardTests.cs
@@ -14,12 +14,13 @@ namespace AlRunner.Tests;
 public class WatchDashboardTests
 {
     private static string Render(IReadOnlyList<BucketResult> results, WatchStatus status,
-        DateTime ts, TimeSpan dur)
+        DateTime ts, TimeSpan dur, IReadOnlyList<(string Module, string Reason)>? fullRebuildReasons = null,
+        int width = 120)
     {
         var console = new TestConsole();
         // Wide enough that the table columns aren't truncated away in the test.
-        console.Profile.Width = 120;
-        console.Write(WatchDashboard.Build(results, "my-bundle", status, ts, dur));
+        console.Profile.Width = width;
+        console.Write(WatchDashboard.Build(results, "my-bundle", status, ts, dur, fullRebuildReasons));
         return console.Output;
     }
 
@@ -142,6 +143,61 @@ public class WatchDashboardTests
         Assert.Contains("running", output);
         // The cold first run must not look frozen — busy state is explicit.
         Assert.DoesNotContain("watching", output);
+    }
+
+    /// <summary>
+    /// #1905 (defect 4): when a cycle fell back to a full rebuild, the interactive
+    /// dashboard must show WHY as a distinct frame element — not just a log line,
+    /// because Program.cs's watch loop deliberately redirects Console.Out/Error to
+    /// TextWriter.Null for the duration of the cycle body while the dashboard is
+    /// active (see its "Clean loading (#5)" comment), so a log-line-only fix is
+    /// invisible in exactly the mode it exists for. Assert the module name AND the
+    /// specific cause both reach the rendered frame, not just a generic "rebuilt"
+    /// marker — a generic marker would pass even if the actual reason never made it
+    /// through.
+    /// </summary>
+    [Fact]
+    public void Render_FullRebuildReason_ShowsBannerNamingModuleAndCause()
+    {
+        var results = new List<BucketResult> { Bucket() };
+        var reasons = new List<(string Module, string Reason)>
+        {
+            ("MyTestApp", "app.json (identity/version/preprocessor symbols/features/help url) changed since the last cycle"),
+        };
+
+        // Wide enough that the reason line doesn't word-wrap mid-sentence — this test
+        // asserts on the reason text as a contiguous substring, and the real dashboard
+        // wraps at whatever the actual terminal width is, which this is standing in for.
+        var output = Render(results, WatchStatus.Idle, DateTime.Now, TimeSpan.FromSeconds(842.5), reasons, width: 400);
+
+        Assert.Contains("MyTestApp", output);
+        Assert.Contains("app.json", output);
+        Assert.Contains("changed since the last cycle", output);
+        // Distinct from an ordinary compile/test failure row — a developer scanning the
+        // frame must be able to tell "this cost minutes for a structural reason" apart
+        // from "a test failed".
+        Assert.Contains("FULL REBUILD", output);
+    }
+
+    /// <summary>
+    /// The converse of the above: a proportional (incremental) cycle must show NO
+    /// full-rebuild banner at all — not an empty one, not a "no reason" placeholder.
+    /// "Present on a full-rebuild cycle, absent entirely on a proportional one" is the
+    /// #1905 acceptance wording verbatim; a banner that's merely empty-but-rendered
+    /// would still occupy dashboard real estate every single cycle and get trained
+    /// into background noise exactly like the defect this fixes.
+    /// </summary>
+    [Fact]
+    public void Render_NoFullRebuildReason_OmitsBannerEntirely()
+    {
+        var results = new List<BucketResult> { Bucket() };
+
+        var withNull = Render(results, WatchStatus.Idle, DateTime.Now, TimeSpan.FromSeconds(2.1), fullRebuildReasons: null);
+        var withEmpty = Render(results, WatchStatus.Idle, DateTime.Now, TimeSpan.FromSeconds(2.1),
+            fullRebuildReasons: new List<(string Module, string Reason)>());
+
+        Assert.DoesNotContain("FULL REBUILD", withNull);
+        Assert.DoesNotContain("FULL REBUILD", withEmpty);
     }
 
     [Fact]

--- a/AlRunner.Tests/WatchFullRebuildReasonTests.cs
+++ b/AlRunner.Tests/WatchFullRebuildReasonTests.cs
@@ -1,0 +1,130 @@
+using System.Diagnostics;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// #1905 (defect 4): when a `--watch` cycle falls back to a full rebuild (instead of
+/// the proportional-cost incremental path), the reason must reach the console at
+/// DEFAULT verbosity — not only under `--verbose`. A full rebuild costs whole minutes
+/// on a large app (761-862s measured on NP Retail, #1905's own numbers), so which
+/// reason forced it is a RESULT the developer needs, exactly like which BC version was
+/// selected (Log.cs's `[bc]` history) and whether the expectations manifest was found
+/// (`[expectations]`, #1984) — both were previously swallowed by the same
+/// --verbose-only gate and both cost real, measured damage before being exempted.
+///
+/// Also proves the inverse the "judgment" half of #1905's ask cares about: the very
+/// first --watch cycle for a bundle ALWAYS falls back (there is no baseline yet), and
+/// that is not a fallback in any meaningful sense — printing an alarming "full
+/// rebuild" line on every single startup would train the reader to ignore it, so cycle
+/// 0 must stay quiet and only cycle 1+ is asserted here.
+///
+/// Runs the real CLI in non-interactive (piped) watch mode, so it exercises
+/// Program.cs's plain-line fallback branch (WatchDashboard's own interactive-frame
+/// surfacing is covered separately, and purely, in WatchDashboardTests — this test
+/// proves the wiring that actually reaches Program.cs's console output end-to-end).
+///
+/// Spawns the real runner; needs the BC artifact cache. Skips (no-op) when absent.
+/// </summary>
+public class WatchFullRebuildReasonTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+    private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
+    private static readonly string FixtureSrc = Path.GetFullPath(Path.Combine(
+        AppContext.BaseDirectory, "..", "..", "..", "Fixtures", "RecordTriggerXRec"));
+
+    [SkippableFact]
+    public async Task Watch_FullRebuildFallback_ReasonReachesDefaultVerbosityOutput_ButNotOnFirstCycle()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var bundle = Path.Combine(Path.GetTempPath(), "al-runner-watch-fullrebuild", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(bundle);
+        foreach (var f in Directory.GetFiles(FixtureSrc))
+            File.Copy(f, Path.Combine(bundle, Path.GetFileName(f)));
+        var testsCodeunitPath = Path.Combine(bundle, "XRecProbeTests.Codeunit.al");
+        var cacheDir = Path.Combine(bundle, ".cache");
+
+        var lines = new List<CapturedLine>();
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            // Deliberately NO --verbose: this is the whole claim under test — the
+            // reason must reach default-verbosity output.
+            Arguments = TestBuildConfig.RunArgs(ProjectPath) + TestBuildConfig.BcVersionArg
+                + $" \"{bundle}\" --watch --cache \"{cacheDir}\"",
+            RedirectStandardOutput = true, RedirectStandardError = true,
+            UseShellExecute = false, CreateNoWindow = true, WorkingDirectory = RepoRoot,
+        };
+        using var p = Process.Start(psi)!;
+        void Pump(StreamReader r, OutputStream stream) => Task.Run(async () =>
+        {
+            string? l;
+            while ((l = await r.ReadLineAsync()) != null) lock (lines) lines.Add(new CapturedLine(stream, l));
+        });
+        Pump(p.StandardOutput, OutputStream.Stdout);
+        Pump(p.StandardError, OutputStream.Stderr);
+
+        string ProcessLiveness() =>
+            p.HasExited ? $"process alive=false exit={p.ExitCode}" : "process alive=true";
+        string DumpTail() { lock (lines) return string.Join("\n", lines.TakeLast(40).Select(l => $"[{l.Stream}] {l.Text}")); }
+
+        async Task<int> WaitForMarkerAfter(int fromIndex, TimeSpan timeout)
+        {
+            var deadline = DateTime.UtcNow + timeout;
+            while (DateTime.UtcNow < deadline)
+            {
+                List<int> found;
+                lock (lines)
+                    found = WatchOutputSlicing.FindStdoutMarkerIndices(lines, WatchOutputSlicing.WaitingForSourceMarker, fromIndex);
+                if (found.Count > 0) return found[0];
+                if (p.HasExited)
+                {
+                    await Task.Delay(500);
+                    throw new TimeoutException(
+                        $"watch marker not seen — subprocess exited early ({ProcessLiveness()}).\n--- last output ---\n{DumpTail()}");
+                }
+                await Task.Delay(200);
+            }
+            if (p.HasExited) await Task.Delay(500);
+            throw new TimeoutException($"watch marker not seen. {ProcessLiveness()}\n--- last output ---\n{DumpTail()}");
+        }
+
+        string Segment(int from, int to) { lock (lines) return WatchOutputSlicing.MergedJoin(lines, from, to); }
+
+        try
+        {
+            // Cycle 0 (cold): the fixture always falls back here too ("no incremental
+            // baseline yet") — but that fallback must NOT be reported as a "full
+            // rebuild" alarm, since every single --watch invocation hits it.
+            int m1 = await WaitForMarkerAfter(0, TimeSpan.FromSeconds(150));
+            var cycle1 = Segment(0, m1);
+            Assert.DoesNotContain("FULL REBUILD", cycle1);
+
+            // Force a genuine fallback on cycle 1 via an ACTUAL .al edit (app.json isn't
+            // watched at all — WatchSource.cs filters strictly to "*.al", so an app.json-only
+            // edit would never even trigger a cycle): append a second object declaration to
+            // an already-tracked .al file. Per BcCompiler.Incremental.cs's
+            // ClassifyDeclaredObject, the fast path requires exactly one object per file, so
+            // this is a reliable, deterministic fallback with a specific, recognisable cause.
+            var original = await File.ReadAllTextAsync(testsCodeunitPath);
+            var edited = original + "\ncodeunit 60199 \"xRec Probe Extra RXT\"\n{\n}\n";
+            await File.WriteAllTextAsync(testsCodeunitPath, edited);
+
+            int m2 = await WaitForMarkerAfter(m1 + 1, TimeSpan.FromSeconds(240));
+            var cycle2 = Segment(m1 + 1, m2);
+
+            // The reason reached the console WITHOUT --verbose (the defect) and names
+            // the specific cause, not a generic "something changed" — a reader must be
+            // able to tell WHY the cycle cost minutes instead of milliseconds.
+            Assert.Contains("FULL REBUILD", cycle2);
+            Assert.Contains("XRecProbeTests.Codeunit.al", cycle2);
+            Assert.Contains("declares 2 object(s)", cycle2);
+        }
+        finally
+        {
+            try { p.Kill(true); } catch { }
+        }
+    }
+}

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -800,6 +800,21 @@ var executor = new TestExecutor { Isolation = isolation, TestFilter = testFilter
 var depLoader = new DependencyLoader(emitter, assembler);
 var results = new List<BucketResult>();
 
+// #1905 (defect 4): the reason a --watch cycle fell back to a full rebuild (instead
+// of the proportional-cost incremental path), one entry per module that fell back
+// THIS cycle. Declared once, outside the loop, and cleared+repopulated at the top
+// of each cycle — same pattern as `results` above — so the local functions below
+// (closures declared once, before the loop) always see the current cycle's data
+// when they render. Left empty on a proportional cycle, so its emptiness alone is
+// "nothing to explain" for both the dashboard banner and the plain-line fallback.
+var watchFullRebuildReasons = new List<(string Module, string Reason)>();
+// The very first --watch cycle for a bundle ALWAYS falls back (there is no baseline
+// yet to diff against) — that is not a fallback in any meaningful sense, just the
+// starting state, so it is excluded from watchFullRebuildReasons below rather than
+// trained into looking like every other startup's alarm. See the incremental-path
+// call site for the full reasoning.
+int watchCycleIndex = 0;
+
 // ── Layered source build pre-pass ─────────────────────────────────────────
 // When multiple bundles are passed and one depends on another (by AppId or
 // Name+Publisher), emit each "impl" bundle (one that another depends on) as
@@ -907,7 +922,13 @@ List<string> RenderDashboardLines(WatchStatus status, DateTime ts, TimeSpan dur)
         Out = new Spectre.Console.AnsiConsoleOutput(sw),
     });
     rec.Profile.Width = width;
-    rec.Write(WatchDashboard.Build(results, watchBundleName, status, ts, dur));
+    // #1905 (defect 4): watchFullRebuildReasons reflects the cycle that JUST finished
+    // (populated during this iteration's bundle loop, cleared at the top of the NEXT
+    // one) — exactly what an idle/post-cycle repaint should explain. PaintWatchRunning
+    // below deliberately does NOT pass it: while "⟳ running…" is showing, the reason
+    // in this list (if any) is stale — it belongs to the PREVIOUS cycle, and the cycle
+    // in flight hasn't decided whether it needs a full rebuild yet.
+    rec.Write(WatchDashboard.Build(results, watchBundleName, status, ts, dur, watchFullRebuildReasons));
     return sw.ToString().Replace("\r\n", "\n").TrimEnd('\n').Split('\n').ToList();
 }
 
@@ -960,6 +981,7 @@ if (watchUi) PaintWatchRunning();
 while (true)
 {
 results.Clear();
+watchFullRebuildReasons.Clear();
 // Clean loading (#5): the interactive dashboard owns the whole screen, but the
 // run-cycle body emits diagnostic Console.WriteLine noise ("[bundle] resolved N
 // dep(s)", "loaded N assembl(ies)", "[i/N] … suites", …) that would scroll over
@@ -1511,8 +1533,33 @@ foreach (var bundle in bundles)
             if (watchMode)
             {
                 incrementalOutput = emitter.TryEmitIncremental(allPaths, moduleName, appGroup.SuiteDir, out var incrementalFallbackReason);
-                if (incrementalOutput == null && AlRunner.Log.Verbose)
-                    Console.Error.WriteLine($"[watch] {moduleName}: full rebuild this cycle — {incrementalFallbackReason}");
+                // #1905 (defect 4): a full rebuild costs whole MINUTES on a large app
+                // (761-862s measured on NP Retail, #1905's own numbers) against an
+                // incremental cycle's seconds, so which reason forced it is a RESULT
+                // the developer needs to see, not an internal diagnostic — it must NOT
+                // be gated behind --verbose. That gate was exactly the [bc]/[expectations]
+                // mistake Log.cs's header comment warns about: both were silently eaten
+                // by the component filter until their cost was measured after the fact.
+                // [watch] is already exempt from that filter (see Log.cs), so this reaches
+                // the console unconditionally at default verbosity.
+                //
+                // Cycle 0 is excluded: the very first --watch cycle for a bundle ALWAYS
+                // falls back ("no incremental baseline yet") because there is nothing to
+                // diff against yet — that is not a fallback in any meaningful sense, it is
+                // the starting state every single invocation hits. Printing a scary-sounding
+                // "full rebuild" line on every startup would train the reader to ignore it,
+                // which is the exact failure this line exists to prevent (see this file's
+                // header comment for the identical trap already hit twice with [bc] and
+                // [expectations]). From cycle 1 onward the same reason text (e.g. two
+                // fallbacks in a row because CreateForRad keeps throwing) IS interesting and
+                // is reported.
+                if (incrementalOutput == null && watchCycleIndex > 0)
+                {
+                    watchFullRebuildReasons.Add((moduleName, incrementalFallbackReason));
+                    Console.Error.WriteLine(
+                        $"[watch] {moduleName}: FULL REBUILD this cycle (whole module — expect the " +
+                        $"cold-cycle order of magnitude, not a proportional edit) — {incrementalFallbackReason}");
+                }
             }
             var emitTask = incrementalOutput != null
                 ? Task.FromResult(incrementalOutput)
@@ -2106,6 +2153,7 @@ else
     Console.WriteLine("[watch] change detected — re-running…");
     Console.Out.Flush();
 }
+watchCycleIndex++; // the cycle that just finished is no longer "the first cycle"
 } // end while(true) watch loop
 
 // ── Count-baseline check (issue #1880) ──────────────────────────────────────────────

--- a/AlRunner/WatchDashboard.cs
+++ b/AlRunner/WatchDashboard.cs
@@ -31,25 +31,60 @@ public static class WatchDashboard
 {
     /// <summary>
     /// Builds the full dashboard renderable: header (bundle · status · last-run
-    /// timestamp+duration), a per-codeunit tree of test procedures, and a footer with
-    /// P/F/E counts. Pure — no console side effects — so it is repaintable and testable.
+    /// timestamp+duration), an optional full-rebuild-reason banner, a per-codeunit tree
+    /// of test procedures, and a footer with P/F/E counts. Pure — no console side
+    /// effects — so it is repaintable and testable.
     /// </summary>
+    /// <param name="fullRebuildReasons">
+    /// #1905 (defect 4): why the just-finished cycle recompiled the WHOLE module
+    /// instead of the proportional-cost incremental path, one entry per module that
+    /// fell back — e.g. ("MyApp", "app.json (identity/version/...) changed since the
+    /// last cycle"). A full rebuild costs whole minutes on a large app, so a developer
+    /// staring at "⟳ running…" for far longer than usual needs to know why, and the
+    /// interactive dashboard is exactly the surface that deliberately swallows
+    /// Console.Out/Error during the cycle body (see Program.cs's stdoutSilenced) — so
+    /// logging the reason there is not enough, it has to be a frame element. Null or
+    /// empty renders NOTHING (no row at all): present only on a full-rebuild cycle,
+    /// absent entirely on a proportional one, so it can't be trained into background
+    /// noise the way an always-present line would be.
+    /// </param>
     public static IRenderable Build(
         IReadOnlyList<BucketResult> results,
         string bundleName,
         WatchStatus status,
         DateTime lastRun,
-        TimeSpan lastDuration)
+        TimeSpan lastDuration,
+        IReadOnlyList<(string Module, string Reason)>? fullRebuildReasons = null)
     {
         var rows = new List<IRenderable>
         {
             Header(bundleName, status, lastRun, lastDuration),
             new Text(string.Empty),
-            BuildTree(results),
-            new Text(string.Empty),
-            Footer(results),
         };
+        var banner = FullRebuildBanner(fullRebuildReasons);
+        if (banner != null)
+        {
+            rows.Add(banner);
+            rows.Add(new Text(string.Empty));
+        }
+        rows.Add(BuildTree(results));
+        rows.Add(new Text(string.Empty));
+        rows.Add(Footer(results));
         return new Rows(rows);
+    }
+
+    /// <summary>
+    /// One line per module that fell back to a full rebuild this cycle, naming the
+    /// cause verbatim from BcCompiler.Incremental.cs — e.g. "app.json (identity/
+    /// version/...) changed since the last cycle". Null when nothing fell back, so
+    /// <see cref="Build"/> can omit the row entirely rather than render an empty panel.
+    /// </summary>
+    private static IRenderable? FullRebuildBanner(IReadOnlyList<(string Module, string Reason)>? reasons)
+    {
+        if (reasons == null || reasons.Count == 0) return null;
+        var lines = reasons.Select(r =>
+            $"[yellow]⚠ FULL REBUILD[/] [blue]{Markup.Escape(r.Module)}[/]: {Markup.Escape(r.Reason)}");
+        return new Markup(string.Join("\n", lines));
     }
 
     private static IRenderable Header(string bundleName, WatchStatus status,


### PR DESCRIPTION
Closes #1905

## What this is

#1905 is an umbrella tracking four `--watch` performance defects. #1903 (parse
count) and #1904 (debounce) are closed on their own issues; #1902 (delta
recompile) was just closed by #1991. **Defect 4** — described in #1905's own
body, not a separate issue — is the last one: when a full rebuild *is*
triggered, nothing on the dashboard explains why.

#1991 already built `BcCompiler.TryEmitIncremental`'s `fallbackReason` output
and wired it as far as a `Console.Error.WriteLine` in `Program.cs`. The gap was
that this line was gated behind `AlRunner.Log.Verbose`, so at default verbosity
a 13-14 minute full rebuild looked identical to a proportional-cost incremental
cycle.

## The fix

**`AlRunner/Program.cs`** — the fallback reason now reaches the console
unconditionally from cycle 1 onward (`[watch]` is already exempt from
`Log.cs`'s component filter — the same trap that swallowed the `[bc]`/
`[expectations]` lines before, per that file's own header comment). **Cycle 0
is deliberately excluded**: every bundle's mandatory first `--watch` cycle
always falls back ("no incremental baseline yet") because there's nothing to
diff against yet. That's not a fallback in any meaningful sense — printing an
alarming "full rebuild" line on every single startup would train the reader to
ignore it, which is the exact failure this fix exists to prevent. From cycle 1
onward, the same reason text (e.g. two fallbacks in a row) genuinely is
interesting and is reported.

**`AlRunner/WatchDashboard.cs`** — the interactive dashboard redirects both
console streams to `TextWriter.Null` for the duration of the cycle body (so the
painted frame isn't scrolled away), which means a log-line-only fix is
invisible in exactly the mode #1905 calls out. `Build()` now accepts the
cycle's full-rebuild reasons and renders them as a distinct frame element —
present only on a full-rebuild cycle, absent entirely on a proportional one —
naming the module and the specific cause (e.g. "app.json (identity/version/...)
changed since the last cycle").

## Tests (RED → GREEN)

- `AlRunner.Tests/WatchDashboardTests.cs` — two new pure render-model tests:
  the banner shows the module name and specific cause when a reason is passed,
  and is omitted entirely (not rendered empty) when none is. Confirmed RED
  against the pre-fix `WatchDashboard.Build` (no overload for the reasons
  param / banner suppressed), GREEN after.
- `AlRunner.Tests/WatchFullRebuildReasonTests.cs` (new) — spawns the real CLI
  in non-interactive `--watch` mode with no `--verbose` flag, forces a genuine
  incremental-fallback via an actual `.al` edit (declares a second object in an
  already-tracked file — `app.json` isn't watched at all, `WatchSource.cs`
  filters strictly to `*.al`), and asserts the reason reaches default-verbosity
  output on cycle 1+ while staying absent on cycle 0. Confirmed RED against
  unmodified `main` (`Assert.Contains("FULL REBUILD", cycle2)` fails — the line
  is gated behind `--verbose`), GREEN after the fix.

Both confirmed locally against real BC artifacts (not just compiled — actually
run end-to-end).

## Scope check

Verified via `gh issue view` before starting: #1902, #1903, #1904 are all
closed. This PR is the only remaining piece, so `Closes #1905` closes the
umbrella too.

https://claude.ai/code/session_019fzJRHYdYdcX6R7HQSd7QC