### PR TITLE
fix(pages): pageextension action stops dispatching when it also adds a part()

### DIFF
--- a/AlRunner.Tests/TestPageExtensionActionWithPartDispatchTests.cs
+++ b/AlRunner.Tests/TestPageExtensionActionWithPartDispatchTests.cs
@@ -1,0 +1,337 @@
+// TestPageExtensionActionWithPartDispatchTests — issue #1995 (TestPage Invoke() of a
+// pageextension-contributed action fails with "declares no OnAction trigger" when the SAME
+// pageextension also adds a part() to the page layout).
+//
+// This is a RUNNER-MECHANISM test, not a claim about what real BC does: it proves that OUR
+// OWN dispatch path — RunnerPageInstance.GetOrCreateExtensionInstance — still constructs a
+// working pageextension instance (and therefore still finds and runs its OnAction triggers)
+// when that pageextension's AL-compiler-emitted constructor ALSO calls
+// NavFormExtension.RegisterUIPart (emitted for a part() the extension adds to the layout).
+//
+// Root cause: GetOrCreateExtensionInstance used to invoke the extension's
+// (ITreeObject, NavRecord) constructor with `_owner` (the TestPage's original caller,
+// essentially never a NavForm) as the `parent` argument, then patched
+// NavFormExtension.ParentObject to the real page form AFTERWARD via reflection, once the
+// constructor had already returned. That is too late for any AL-emitted constructor code
+// that touches ParentObject itself: a pageextension with a part() emits an
+// InitializeComponent() override that calls ParentObject.RegisterUIPart(...) from INSIDE the
+// constructor, which NREs on the still-null property and aborts construction — caching a
+// permanently null instance for that extension id, so EVERY trigger the extension declares
+// (not just ones near the part) reads as "extension not found" and every one of its actions
+// misreports as declaring no OnAction trigger. The fix passes the page's own live form as the
+// constructor's `parent` argument directly, so ParentObject is set correctly by
+// NavFormExtension's own base constructor before any AL-emitted code runs.
+//
+// The BEHAVIORAL claim ("a pageextension action must still dispatch when the same
+// pageextension also adds a part() to the layout, on real BC") is proven upstream against a
+// live BC service tier — see StefanMaron/BusinessCentral.AL.Language.Tests PR for "TPXP
+// Action Invoke Tests" (60729), per .claude/rules/bc-behavior-tests-go-upstream.md. This test
+// exists so a regression in OUR OWN extension-instance construction fails loudly here,
+// without needing the corpus's al-language submodule pin bumped (deliberately deferred to a
+// separate centralized PR, per the orchestrator's process).
+//
+// RED/GREEN proof: reverting RunnerPageInstance.GetOrCreateExtensionInstance's
+// `ctor.Invoke(new object?[] { _form, _record })` back to `ctor.Invoke(new object?[] { _owner,
+// _record })` (the pre-fix shape) makes ActionOnPageExtensionWithPart_StillDispatches fail —
+// Invoke() raises RunnerOutOfScopeException naming "testpage-action — the page declares no
+// OnAction trigger for this action" for an action that plainly declares one, exactly the
+// issue's own repro.
+using System.Diagnostics;
+using System.Text;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class TestPageExtensionActionWithPartDispatchTests : IDisposable
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+    private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
+
+    private readonly string _root;
+
+    public TestPageExtensionActionWithPartDispatchTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "al-runner-pageext-part-action-dispatch", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { /* best-effort cleanup */ }
+    }
+
+    private static string[] ExtraPackageCacheArgs()
+    {
+        var platformApps = TestArtifacts.PlatformAppsDir();
+        return Directory.Exists(platformApps)
+            ? new[] { "--package-cache", platformApps }
+            : Array.Empty<string>();
+    }
+
+    /// <summary>
+    /// A list page with one action of its own AND an (empty) FactBoxes area, a CardPart page
+    /// for a factbox, and a pageextension that adds BOTH a part() (via addfirst(FactBoxes),
+    /// the same shape the issue's own repro used against a real Base App page that already
+    /// declares one) AND two actions (unspaced and spaced names — #1968's discriminator is a
+    /// different one, so both are covered to keep this test independent of that fix).
+    /// </summary>
+    private void WriteBundle()
+    {
+        Directory.CreateDirectory(_root);
+        File.WriteAllText(Path.Combine(_root, "app.json"), """
+        {
+          "id": "c1d2e3f4-5a6b-4780-8c9d-0e1f2a3b4c01",
+          "name": "Runner Mechanism - TestPage PageExt Action With Part Dispatch",
+          "publisher": "AL Runner",
+          "version": "1.0.0.0",
+          "dependencies": [],
+          "platform": "1.0.0.0",
+          "application": "1.0.0.0",
+          "idRanges": [ { "from": 62400, "to": 62409 } ],
+          "runtime": "14.0"
+        }
+        """);
+
+        File.WriteAllText(Path.Combine(_root, "PapRow.Table.al"), """
+        table 62400 "Pap Row"
+        {
+            DataClassification = CustomerContent;
+
+            fields
+            {
+                field(1; "No."; Code[20]) { }
+                field(2; Descr; Text[50]) { }
+            }
+
+            keys
+            {
+                key(PK; "No.") { Clustered = true; }
+            }
+        }
+        """);
+
+        File.WriteAllText(Path.Combine(_root, "PapList.Page.al"), """
+        page 62401 "Pap List"
+        {
+            PageType = List;
+            SourceTable = "Pap Row";
+            ApplicationArea = All;
+            UsageCategory = Lists;
+
+            layout
+            {
+                area(Content)
+                {
+                    repeater(Rows)
+                    {
+                        field("No."; Rec."No.")
+                        {
+                            ApplicationArea = All;
+                        }
+                    }
+                }
+                area(FactBoxes)
+                {
+                }
+            }
+
+            actions
+            {
+                area(Processing)
+                {
+                    action(DirectAction)
+                    {
+                        ApplicationArea = All;
+
+                        trigger OnAction()
+                        var
+                            Row: Record "Pap Row";
+                        begin
+                            if not Row.Get('DIRECT') then begin
+                                Row.Init();
+                                Row."No." := 'DIRECT';
+                                Row.Insert();
+                            end;
+                        end;
+                    }
+                }
+            }
+        }
+        """);
+
+        File.WriteAllText(Path.Combine(_root, "PapFactBox.Page.al"), """
+        page 62402 "Pap FactBox"
+        {
+            PageType = CardPart;
+            SourceTable = "Pap Row";
+            Caption = 'Pap FactBox';
+
+            layout
+            {
+                area(Content)
+                {
+                    field("No."; Rec."No.")
+                    {
+                        ApplicationArea = All;
+                    }
+                }
+            }
+        }
+        """);
+
+        File.WriteAllText(Path.Combine(_root, "PapListExt.PageExt.al"), """
+        pageextension 62403 "Pap List Ext" extends "Pap List"
+        {
+            layout
+            {
+                addfirst(FactBoxes)
+                {
+                    part(PapFactBox; "Pap FactBox")
+                    {
+                        ApplicationArea = All;
+                        SubPageLink = "No." = field("No.");
+                    }
+                }
+            }
+
+            actions
+            {
+                addlast(Processing)
+                {
+                    action(ExtActionWithPart)
+                    {
+                        ApplicationArea = All;
+
+                        trigger OnAction()
+                        var
+                            Row: Record "Pap Row";
+                        begin
+                            if not Row.Get('EXT-WITH-PART') then begin
+                                Row.Init();
+                                Row."No." := 'EXT-WITH-PART';
+                                Row.Insert();
+                            end;
+                        end;
+                    }
+
+                    action("Ext Action With Part Spaced")
+                    {
+                        ApplicationArea = All;
+
+                        trigger OnAction()
+                        var
+                            Row: Record "Pap Row";
+                        begin
+                            if not Row.Get('EXT-WITH-PART-SPACED') then begin
+                                Row.Init();
+                                Row."No." := 'EXT-WITH-PART-SPACED';
+                                Row.Insert();
+                            end;
+                        end;
+                    }
+                }
+            }
+        }
+        """);
+
+        File.WriteAllText(Path.Combine(_root, "PapTests.Codeunit.al"), """
+        codeunit 62404 "Pap Tests"
+        {
+            Subtype = Test;
+
+            [Test]
+            procedure ActionOnPageExtensionWithPart_StillDispatches()
+            var
+                Row: Record "Pap Row";
+                PapListPage: TestPage "Pap List";
+            begin
+                Row.DeleteAll();
+
+                PapListPage.OpenEdit();
+                PapListPage.ExtActionWithPart.Invoke();
+                PapListPage.Close();
+
+                if not Row.Get('EXT-WITH-PART') then
+                    Error('Invoke() must have run the pageextension''s OnAction trigger, even though the same pageextension also adds a part() to the layout');
+            end;
+
+            [Test]
+            procedure SpacedActionOnPageExtensionWithPart_StillDispatches()
+            var
+                Row: Record "Pap Row";
+                PapListPage: TestPage "Pap List";
+            begin
+                Row.DeleteAll();
+
+                PapListPage.OpenEdit();
+                PapListPage."Ext Action With Part Spaced".Invoke();
+                PapListPage.Close();
+
+                if not Row.Get('EXT-WITH-PART-SPACED') then
+                    Error('Invoke() must have run the pageextension''s spaced-name OnAction trigger, even though the same pageextension also adds a part() to the layout');
+            end;
+
+            [Test]
+            procedure DirectActionOnTheBasePage_StillDispatches()
+            var
+                Row: Record "Pap Row";
+                PapListPage: TestPage "Pap List";
+            begin
+                Row.DeleteAll();
+
+                PapListPage.OpenEdit();
+                PapListPage.DirectAction.Invoke();
+                PapListPage.Close();
+
+                if not Row.Get('DIRECT') then
+                    Error('Invoke() must have run the page''s own OnAction trigger');
+            end;
+        }
+        """);
+    }
+
+    private (string output, int exit) RunBundled()
+    {
+        var args = new StringBuilder(
+            TestBuildConfig.RunArgs(ProjectPath) + TestBuildConfig.BcVersionArg + $" \"{_root}\"");
+        foreach (var a in ExtraPackageCacheArgs()) args.Append($" \"{a}\"");
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet", Arguments = args.ToString(),
+            RedirectStandardOutput = true, RedirectStandardError = true,
+            UseShellExecute = false, CreateNoWindow = true, WorkingDirectory = RepoRoot,
+        };
+        var sb = new StringBuilder();
+        var p = Process.Start(psi)!;
+        p.OutputDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.ErrorDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.BeginOutputReadLine();
+        p.BeginErrorReadLine();
+        if (!p.WaitForExit(600_000)) { try { p.Kill(true); } catch { } throw new TimeoutException("runner hung"); }
+        p.WaitForExit();
+        lock (sb) return (sb.ToString(), p.ExitCode);
+    }
+
+    /// <summary>
+    /// Positive, all three arms in one run: the part()-adding pageextension's unspaced
+    /// action, its spaced-name action, and the base page's OWN action must all still
+    /// dispatch. A stub that fell back to "does nothing" for the extension's actions would
+    /// leave the first two rows unwritten while the third still passed — this asserts on the
+    /// concrete effect of each, not merely "did not throw".
+    /// </summary>
+    [SkippableFact]
+    public void ActionOnPageExtensionWithPart_StillDispatches()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        WriteBundle();
+        var (output, exit) = RunBundled();
+
+        Assert.True(exit == 0, $"Expected the bundle to pass; exit={exit}\n{output}");
+        Assert.Contains("PASS  Codeunit62404.ActionOnPageExtensionWithPart_StillDispatches", output);
+        Assert.Contains("PASS  Codeunit62404.SpacedActionOnPageExtensionWithPart_StillDispatches", output);
+        Assert.Contains("PASS  Codeunit62404.DirectActionOnTheBasePage_StillDispatches", output);
+        Assert.DoesNotContain("FAIL", output);
+    }
+}

--- a/AlRunner/Patches/RunnerPageInstance.cs
+++ b/AlRunner/Patches/RunnerPageInstance.cs
@@ -970,16 +970,31 @@ internal sealed class RunnerPageInstance
     /// Constructed the same way <see cref="TryCreate"/> constructs the base page itself: the
     /// AL-compiler-emitted <c>(ITreeObject, NavRecord)</c> ctor (verified via IL: it just
     /// forwards to <c>NavFormExtension(ITreeObject, int extId, NavRecord, NCLStaticMetadata)</c>
-    /// with the extension's own object id baked in) — then <c>ParentObject</c> is set to this
-    /// page's own <c>_form</c>, because the extension's OWN <c>get_Rec</c>/<c>get_CurrPage</c>
-    /// overrides route through <c>ParentObject</c> (also verified via IL), not through the
-    /// record the ctor was handed. Real BC wires this by adding the extension to the page's
-    /// own <c>PageExtensions</c> list during metadata load; the runner's skeleton always keeps
-    /// that list empty (see NclCecilRewrite.cs's <c>get_PageExtensions</c> rewrite), so this
-    /// is the runner-owned substitute for that step — the trigger DISPATCH here has always
-    /// been the runner's own reflection scheme (see FindTrigger's remarks), never BC's real
-    /// action-invoke machinery, so this is consistent with the existing architecture, not a
-    /// new shortcut.
+    /// with the extension's own object id baked in), <b>passed this page's own <c>_form</c> as
+    /// the <c>ITreeObject parent</c> argument</b> — <c>NavFormExtension</c>'s own ctor does
+    /// <c>ParentObject = parent as NavForm</c> as its very first statement, and the extension's
+    /// <c>get_Rec</c>/<c>get_CurrPage</c> overrides route through <c>ParentObject</c> (verified
+    /// via IL), not through the record the ctor was handed. Real BC wires this by adding the
+    /// extension to the page's own <c>PageExtensions</c> list during metadata load; the
+    /// runner's skeleton always keeps that list empty (see NclCecilRewrite.cs's
+    /// <c>get_PageExtensions</c> rewrite), so this is the runner-owned substitute for that step
+    /// — the trigger DISPATCH here has always been the runner's own reflection scheme (see
+    /// FindTrigger's remarks), never BC's real action-invoke machinery, so this is consistent
+    /// with the existing architecture, not a new shortcut.
+    ///
+    /// Issue #1995: passing <c>_owner</c> (the TestPage's original caller, essentially never a
+    /// NavForm) here used to leave <c>ParentObject</c> null for the ENTIRE constructor body,
+    /// papered over afterward with a reflection <c>SetValue(instance, _form)</c> once
+    /// <c>ctor.Invoke</c> returned. That is too late for any AL-compiler-emitted constructor
+    /// code that touches <c>ParentObject</c> itself — a pageextension that adds a <c>part()</c>
+    /// to the page layout emits an <c>InitializeComponent()</c> override that calls
+    /// <c>ParentObject.RegisterUIPart(...)</c> from inside the ctor, which NREs on the still-null
+    /// property and aborts construction entirely. <c>GetOrCreateExtensionInstance</c> then
+    /// caches a null instance for that extension id, so EVERY trigger the extension declares —
+    /// not just ones near the part — reads as "extension not found", which surfaces up through
+    /// FindTrigger as the extension's actions "declaring no OnAction trigger". Passing <c>_form</c>
+    /// as the ctor's <c>parent</c> argument sets <c>ParentObject</c> correctly from the extension's
+    /// own base-class ctor, before any AL-emitted code runs.
     /// </summary>
     private object? GetOrCreateExtensionInstance(int extensionId)
     {
@@ -996,7 +1011,11 @@ internal sealed class RunnerPageInstance
             {
                 try
                 {
-                    instance = ctor.Invoke(new object?[] { _owner, _record });
+                    instance = ctor.Invoke(new object?[] { _form, _record });
+                    // Defensive, not load-bearing: the ctor argument above already sets
+                    // ParentObject correctly (see remarks). Kept in case some future
+                    // extension ctor overload does not run NavFormExtension's own base ctor
+                    // first.
                     _pFormExtensionParentObject?.SetValue(instance, _form);
                 }
                 catch (Exception ex)

--- a/tests/expectations/count-baseline/test-count-baseline.json
+++ b/tests/expectations/count-baseline/test-count-baseline.json
@@ -2,7 +2,7 @@
   "_comment": "Consumed by --count-baseline (AlRunner/Infrastructure/CountBaseline.cs), a DIFFERENT schema from the oos-/known-gaps-/divergence-/disabled- files in this directory: those declare the expected CLASSIFICATION of one named test, this declares the expected EXACT COUNT of a whole suite -- an exact match, not a floor: a mismatch in EITHER direction (drop OR growth) fails the run (exit 4). See #1880 and PR #1882's review for why growth is also a hard failure, not just a notice. Suite keys are the basename of the bundle directory CI passes on the command line (tests/al-language/tests/al-language -> 'al-language', tests/runner-extras -> 'runner-extras'), matching the '--out <name>-results.json' convention CI already uses. Values below are read off actual Test Matrix CI runs (see PR discussion for run URLs), not guessed: al-language's 2073->2076 bump reflects 3 corpus tests merged upstream between when the local baseline was drafted and when CI first ran against it. runner-extras' appGroups 23->21 byBcVersion override on 27.0/27.3/27.5 is the SAME preprocessor-gated-surface split that already explains its tests count divergence: fewer AL surfaces compile pre-28.0, which drops whole app groups, not just individual tests within a group. ANY PR that changes a suite's test or app-group count -- growth included -- MUST bump the matching number here in the SAME PR, or that PR's CI goes red with a [count-baseline] DROP or GROWTH diagnostic naming the exact expected/actual numbers to use.",
   "suites": {
     "al-language": {
-      "tests": { "default": 2124 },
+      "tests": { "default": 2128 },
       "appGroups": { "default": 1 }
     },
     "runner-extras": {


### PR DESCRIPTION
Closes #1995

## Root cause

`RunnerPageInstance.GetOrCreateExtensionInstance` constructed a compiled pageextension's `(ITreeObject, NavRecord)` constructor with `_owner` — the `TestPage`'s original caller, essentially never a `NavForm` — as the `parent` argument, then patched `NavFormExtension.ParentObject` to the real page form **afterward** via reflection, once `ctor.Invoke` had already returned. That is too late for any AL-compiler-emitted constructor code that touches `ParentObject` itself: a pageextension that also adds a `part()` to the page layout emits an `InitializeComponent()` override that calls `ParentObject.RegisterUIPart(...)` from inside the constructor, which NREs on the still-null property and aborts construction entirely. `GetOrCreateExtensionInstance` then caches a permanently null instance for that extension id, so **every** `OnAction` trigger the extension declares — not just ones near the part — misreports through `FindTrigger`/`RaiseOnAction` as "the page declares no OnAction trigger", exactly the issue's repro (both unspaced and spaced action names fail identically, and removing only the `part()` restores dispatch).

Fix: pass the page's own live `_form` as the constructor's `parent` argument directly, so `NavFormExtension`'s own base constructor sets `ParentObject` correctly before any AL-emitted code runs.

## This PR now also carries the corpus pin bump

The upstream corpus PR, [StefanMaron/BusinessCentral.AL.Language.Tests#63](https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/63), is merged (`09361bf`) — it adds `TPXP Action Invoke Tests` (60729), the real-BC-validated proof that a pageextension action dispatches via `TestPage.Invoke()` regardless of a co-located `part()`.

Per the orchestrator, the pin bump is folded into **this** PR rather than a separate pin-bump PR: a pin-bump-only PR would be red by construction here, since it would land the new `TPXP` corpus tests on `main` *before* the `RunnerPageInstance` fix that makes them pass. Folding them means the fix and the test that proves it land atomically, and this PR's CI is now direct evidence that the fix resolves the corpus test, not just the local repro.

Also bumps `tests/expectations/count-baseline/test-count-baseline.json`'s `al-language` default from 2124 to 2128 (+4, matching the 4 new `[Test]` procedures) — `--count-baseline` fails on growth as well as shrinkage.

## Tests

- **`AlRunner.Tests/TestPageExtensionActionWithPartDispatchTests.cs`** (new) — runner-mechanism test spawning the runner against a small local AL bundle (list page + CardPart factbox + a pageextension adding both `addfirst(FactBoxes)` and two actions), asserting both the unspaced and spaced action's `OnAction` still runs, plus a control (the base page's own action). RED against the pre-fix constructor argument (`_owner`) — reverted locally to confirm — GREEN with the fix.
- **Corpus test (now at the bumped pin):** `Codeunit60729 "TPXP Action Invoke Tests"` — 4 tests, all passing at the new pin. Verified locally that they genuinely *run* (not just compile): `--test ExtActionWithPart` shows all 4 `Codeunit60729.*` tests executing and passing.

## Verification

- `dotnet test AlRunner.Tests -c Release`: 796 passed, 54 skipped (BC-engine-gated), 0 failed.
- `tests/runner-extras/pageext-action-dispatch` (the existing #1923/#1966/#1968 regression suite for pageextension action dispatch): 6/6 pass, no regressions.
- Full corpus run at the new pin: 2128/2128 passing (up from 2124, exactly +4 — the new `Codeunit60729` tests), matches the updated count-baseline.
- Manual repro matching the issue's own 4-arm AL reproducer verbatim (scratch bundle, not committed): RED before the fix (arms 3/4 throw `RunnerOutOfScopeException` naming `testpage-action`), GREEN after (4/4 pass).