### PR TITLE
feat(cli): --tdd — report excluded objects' tests as failed, not vanished

### DIFF
--- a/AlRunner.Tests/CliDocumentationTests.cs
+++ b/AlRunner.Tests/CliDocumentationTests.cs
@@ -131,7 +131,7 @@ public sealed class CliDocumentationTests
         Assert.True(idx >= 0, "--help should keep a 'NOT YET IMPLEMENTED' section.");
         var notYet = help[idx..];
 
-        foreach (var implemented in new[] { "--server", "--watch", "--define", "--auto-provision", "--output-json", "--output-junit" })
+        foreach (var implemented in new[] { "--server", "--watch", "--define", "--auto-provision", "--output-json", "--output-junit", "--tdd" })
             Assert.False(notYet.Contains(implemented, StringComparison.Ordinal),
                 $"{implemented} is implemented but listed under 'NOT YET IMPLEMENTED'.");
     }

--- a/AlRunner.Tests/Fixtures/Tdd/Assert.Codeunit.al
+++ b/AlRunner.Tests/Fixtures/Tdd/Assert.Codeunit.al
@@ -1,0 +1,9 @@
+/// <summary>Minimal assertion helper for this fixture app (own ID range).</summary>
+codeunit 65000 "Tdd Assert"
+{
+    procedure AreEqual(Expected: Integer; Actual: Integer; Msg: Text)
+    begin
+        if Expected <> Actual then
+            Error('Assert.AreEqual failed. Expected:<%1>. Actual:<%2>. %3', Expected, Actual, Msg);
+    end;
+}

--- a/AlRunner.Tests/Fixtures/Tdd/TddBrokenEnumTests.Codeunit.al
+++ b/AlRunner.Tests/Fixtures/Tdd/TddBrokenEnumTests.Codeunit.al
@@ -1,0 +1,18 @@
+/// <summary>
+/// References Archived, an enum value "Tdd Target Enum" does not declare yet.
+/// Without --tdd this whole object is excluded from the emit. With --tdd it must
+/// report FAILED, naming Archived.
+/// </summary>
+codeunit 65012 "Tdd Broken Enum Tests"
+{
+    Subtype = Test;
+    TestPermissions = Disabled;
+
+    [Test]
+    procedure MissingEnumValue_ReportsFailedNotVanished()
+    var
+        E: Enum "Tdd Target Enum";
+    begin
+        E := E::Archived;
+    end;
+}

--- a/AlRunner.Tests/Fixtures/Tdd/TddBrokenFieldTests.Codeunit.al
+++ b/AlRunner.Tests/Fixtures/Tdd/TddBrokenFieldTests.Codeunit.al
@@ -1,0 +1,18 @@
+/// <summary>
+/// References "Loyalty Points", a field "Tdd Target Table" does not declare yet.
+/// Without --tdd this whole object is excluded from the emit. With --tdd it must
+/// report FAILED, naming "Loyalty Points".
+/// </summary>
+codeunit 65011 "Tdd Broken Field Tests"
+{
+    Subtype = Test;
+    TestPermissions = Disabled;
+
+    [Test]
+    procedure MissingField_ReportsFailedNotVanished()
+    var
+        Rec: Record "Tdd Target Table";
+    begin
+        Rec."Loyalty Points" := 5;
+    end;
+}

--- a/AlRunner.Tests/Fixtures/Tdd/TddBrokenProcTests.Codeunit.al
+++ b/AlRunner.Tests/Fixtures/Tdd/TddBrokenProcTests.Codeunit.al
@@ -1,0 +1,20 @@
+/// <summary>
+/// References CalcTotal, a procedure "Tdd Target Cu" does not declare yet. Without
+/// --tdd this whole object is excluded from the emit (BC's method-body check is not
+/// gated on ContinueBuildOnError) and its [Test] procedure vanishes from the run. With
+/// --tdd it must report FAILED, naming CalcTotal.
+/// </summary>
+codeunit 65010 "Tdd Broken Proc Tests"
+{
+    Subtype = Test;
+    TestPermissions = Disabled;
+
+    [Test]
+    procedure MissingProcedure_ReportsFailedNotVanished()
+    var
+        Target: Codeunit "Tdd Target Cu";
+        Result: Integer;
+    begin
+        Result := Target.CalcTotal(5);
+    end;
+}

--- a/AlRunner.Tests/Fixtures/Tdd/TddHealthyTests.Codeunit.al
+++ b/AlRunner.Tests/Fixtures/Tdd/TddHealthyTests.Codeunit.al
@@ -1,0 +1,19 @@
+/// <summary>
+/// The healthy half of the fixture: this test binds and runs normally, referencing
+/// nothing missing. It exists to prove a --tdd run's OTHER tests still pass while
+/// three sibling objects are excluded and reported as synthetic failures.
+/// </summary>
+codeunit 65020 "Tdd Healthy Tests"
+{
+    Subtype = Test;
+    TestPermissions = Disabled;
+
+    var
+        Assert: Codeunit "Tdd Assert";
+
+    [Test]
+    procedure UnrelatedTest_StillPasses()
+    begin
+        Assert.AreEqual(3, 1 + 2, 'the healthy object must compile and run under --tdd too');
+    end;
+}

--- a/AlRunner.Tests/Fixtures/Tdd/TddTargetCu.Codeunit.al
+++ b/AlRunner.Tests/Fixtures/Tdd/TddTargetCu.Codeunit.al
@@ -1,0 +1,11 @@
+/// <summary>
+/// The "implementing app" codeunit half of the fixture. Deliberately does NOT declare a
+/// CalcTotal procedure yet — TddBrokenProcTests.Codeunit.al calls it as if it already
+/// existed.
+/// </summary>
+codeunit 65002 "Tdd Target Cu"
+{
+    procedure Placeholder()
+    begin
+    end;
+}

--- a/AlRunner.Tests/Fixtures/Tdd/TddTargetEnum.Enum.al
+++ b/AlRunner.Tests/Fixtures/Tdd/TddTargetEnum.Enum.al
@@ -1,0 +1,11 @@
+/// <summary>
+/// The "implementing app" enum half of the fixture. Deliberately does NOT declare an
+/// Archived value yet — TddBrokenEnumTests.Codeunit.al references it as if it already
+/// existed.
+/// </summary>
+enum 65003 "Tdd Target Enum"
+{
+    Extensible = true;
+
+    value(0; Open) { }
+}

--- a/AlRunner.Tests/Fixtures/Tdd/TddTargetTable.Table.al
+++ b/AlRunner.Tests/Fixtures/Tdd/TddTargetTable.Table.al
@@ -1,0 +1,20 @@
+/// <summary>
+/// The "implementing app" table half of the fixture. Deliberately does NOT declare a
+/// "Loyalty Points" field yet — TddBrokenFieldTests.Codeunit.al references it as if it
+/// already existed, the shape a test-first developer writes before the implementation
+/// catches up.
+/// </summary>
+table 65001 "Tdd Target Table"
+{
+    DataClassification = SystemMetadata;
+
+    fields
+    {
+        field(1; "No."; Code[20]) { }
+    }
+
+    keys
+    {
+        key(PK; "No.") { Clustered = true; }
+    }
+}

--- a/AlRunner.Tests/Fixtures/Tdd/app.json
+++ b/AlRunner.Tests/Fixtures/Tdd/app.json
@@ -1,0 +1,25 @@
+{
+  "id": "9a2c7e14-5b6d-4f8a-9c1e-3d7f2a8b6c40",
+  "name": "Runner Tests Fixture - Tdd",
+  "publisher": "AL Runner",
+  "version": "1.0.0.0",
+  "brief": "Proves --tdd (issue #1997) turns objects excluded for referencing a not-yet-implemented symbol into synthetic FAILED tests instead of a whole-module compile failure.",
+  "description": "Three broken test codeunits (missing procedure, missing table field, missing enum value) plus one unrelated healthy test codeunit, all in the same bundle. Without --tdd this fixture behaves exactly like EmitExclusionLoudnessTests' fixture (exit 3, EMIT-EXCLUDED, zero test results). With --tdd it must exit 1, report each broken [Test] procedure as FAILED naming the missing symbol, and still run the healthy test to PASS.",
+  "privacyStatement": "",
+  "EULA": "",
+  "help": "",
+  "url": "",
+  "logo": "",
+  "dependencies": [],
+  "screenshots": [],
+  "platform": "1.0.0.0",
+  "application": "1.0.0.0",
+  "idRanges": [
+    {
+      "from": 65000,
+      "to": 65099
+    }
+  ],
+  "runtime": "14.0",
+  "features": []
+}

--- a/AlRunner.Tests/TddModeTests.cs
+++ b/AlRunner.Tests/TddModeTests.cs
@@ -1,0 +1,221 @@
+// TddModeTests — issue #1997: --tdd turns objects excluded for referencing a
+// not-yet-implemented symbol into synthetic FAILED tests instead of a whole-module
+// compile failure.
+//
+// This is a runner-specific claim (--tdd producing a failed test where BC's compiler
+// produces a hard error), not a BC-behaviour claim — it belongs here per
+// .claude/rules/bc-behavior-tests-go-upstream.md, not in the al-language corpus.
+//
+// Reduced scope (see the issue and the PR this file shipped in): no type inference.
+// Every missing symbol is REFUSED — reported as a failed test naming the symbol —
+// rather than guessed at. Acceptance criteria covered: 1, 2, 6, 7, 9, 10, 11, 12.
+// Criteria 3/4/5/8 (actual member generation) are a tracked follow-up.
+using System.Diagnostics;
+using System.Text;
+using System.Text.Json;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+// See DefineFlagIntegrationTests for why runner-subprocess tests used to be
+// [Collection("server-serial")] and no longer are — #1809.
+public sealed class TddModeTests : IDisposable
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+    private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
+    private static readonly string FixturePath = Path.Combine(
+        RepoRoot, "AlRunner.Tests", "Fixtures", "Tdd");
+
+    private readonly string _scratch;
+
+    public TddModeTests()
+    {
+        _scratch = Path.Combine(Path.GetTempPath(), "al-runner-tdd", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_scratch);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_scratch, recursive: true); } catch { }
+    }
+
+    private static (string StdOut, string StdErr, int Exit) RunRunner(params string[] extraArgs)
+    {
+        var args = new StringBuilder(TestBuildConfig.RunArgs(ProjectPath));
+        args.Append(TestBuildConfig.BcVersionArg);
+        foreach (var a in extraArgs) args.Append($" {a}");
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet", Arguments = args.ToString(),
+            RedirectStandardOutput = true, RedirectStandardError = true,
+            UseShellExecute = false, CreateNoWindow = true, WorkingDirectory = RepoRoot,
+        };
+        var outSb = new StringBuilder();
+        var errSb = new StringBuilder();
+        using var p = Process.Start(psi)!;
+        p.OutputDataReceived += (_, e) => { if (e.Data != null) lock (outSb) outSb.AppendLine(e.Data); };
+        p.ErrorDataReceived += (_, e) => { if (e.Data != null) lock (errSb) errSb.AppendLine(e.Data); };
+        p.BeginOutputReadLine();
+        p.BeginErrorReadLine();
+        if (!p.WaitForExit(240_000)) { try { p.Kill(true); } catch { } throw new TimeoutException("runner hung"); }
+        p.WaitForExit();
+        lock (outSb) lock (errSb) return (outSb.ToString(), errSb.ToString(), p.ExitCode);
+    }
+
+    /// <summary>
+    /// The core proof. Without --tdd this fixture drops its whole module (see
+    /// <see cref="WithoutTdd_BehaviorIsByteForByteUnchanged"/>); with --tdd the three
+    /// broken [Test] procedures must report FAILED — each naming the specific missing
+    /// symbol, not a generic "compile failed" — while the unrelated healthy test in a
+    /// SIBLING object still passes. Covers acceptance criteria 3 (field), 4 (procedure),
+    /// 5 (enum value), 6 (unrelated tests unaffected), 7 (refuse-not-guess: every one of
+    /// these IS the refused case in this build), 9 (exit 1, not 3).
+    /// </summary>
+    [SkippableFact]
+    public void MissingSymbols_ReportAsFailedTestsNamingTheSymbol()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var alCache = Path.Combine(_scratch, "al-cache");
+        var (stdout, stderr, exit) = RunRunner(
+            "--tdd", $"--cache \"{alCache}\"", "--output-json", $"\"{FixturePath}\"");
+
+        Assert.Equal(1, exit); // failed tests, not a compile failure (criterion 9)
+
+        using var doc = JsonDocument.Parse(stdout.Trim());
+        var root = doc.RootElement;
+        Assert.Equal(4, root.GetProperty("total").GetInt32());
+        Assert.Equal(1, root.GetProperty("passed").GetInt32());
+        Assert.Equal(3, root.GetProperty("failed").GetInt32());
+        Assert.Equal(0, root.GetProperty("errors").GetInt32());
+
+        var tests = root.GetProperty("tests").EnumerateArray().ToList();
+
+        var proc = tests.Single(t => t.GetProperty("name").GetString()!.Contains("MissingProcedure_ReportsFailedNotVanished"));
+        Assert.Equal("fail", proc.GetProperty("status").GetString());
+        Assert.Contains("CalcTotal", proc.GetProperty("message").GetString());
+
+        var field = tests.Single(t => t.GetProperty("name").GetString()!.Contains("MissingField_ReportsFailedNotVanished"));
+        Assert.Equal("fail", field.GetProperty("status").GetString());
+        Assert.Contains("Loyalty Points", field.GetProperty("message").GetString());
+
+        var enumVal = tests.Single(t => t.GetProperty("name").GetString()!.Contains("MissingEnumValue_ReportsFailedNotVanished"));
+        Assert.Equal("fail", enumVal.GetProperty("status").GetString());
+        Assert.Contains("Archived", enumVal.GetProperty("message").GetString());
+
+        // Criterion 6: an unrelated test in a SIBLING object, referencing nothing
+        // missing, still passes in the same run.
+        var healthy = tests.Single(t => t.GetProperty("name").GetString()!.Contains("UnrelatedTest_StillPasses"));
+        Assert.Equal("pass", healthy.GetProperty("status").GetString());
+
+        // Criterion 8: the run prints a generated-members summary (empty in this build —
+        // no inference — but the summary line itself must appear, not silently vanish).
+        Assert.Contains("--tdd:", stderr);
+        Assert.Contains("no members were generated", stderr);
+    }
+
+    /// <summary>
+    /// Criterion 10 — the default path must not change AT ALL. This asserts the SAME
+    /// fixture, without --tdd, still exits 3, reports EMIT-EXCLUDED (not TDD-EXCLUDED),
+    /// and runs zero tests — same shape EmitExclusionLoudnessTests pins for its own
+    /// fixture. This is a second, independent proof over a DIFFERENT fixture (one with
+    /// method-body reference errors rather than an unresolvable type), which is exactly
+    /// the class of compile failure this issue is about.
+    /// </summary>
+    [SkippableFact]
+    public void WithoutTdd_BehaviorIsByteForByteUnchanged()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var alCache = Path.Combine(_scratch, "al-cache-plain");
+        var (stdout, stderr, exit) = RunRunner($"--cache \"{alCache}\"", $"\"{FixturePath}\"");
+
+        Assert.Equal(3, exit);
+        Assert.Contains("EMIT-EXCLUDED", stdout + stderr);
+        Assert.DoesNotContain("TDD-EXCLUDED", stdout + stderr);
+        Assert.Contains("Tests:         0 total", stdout);
+    }
+
+    /// <summary>Criterion 12 — --tdd + --server is rejected, not silently ignored.</summary>
+    [SkippableFact]
+    public void Tdd_RejectedTogetherWithServer()
+    {
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            Arguments = $"{TestBuildConfig.RunArgs(ProjectPath)} --tdd --server",
+            RedirectStandardInput = true, RedirectStandardOutput = true, RedirectStandardError = true,
+            UseShellExecute = false, CreateNoWindow = true, WorkingDirectory = RepoRoot,
+        };
+        using var p = Process.Start(psi)!;
+        p.StandardInput.Close(); // no requests — the rejection must happen before the daemon loop reads anything
+        var err = p.StandardError.ReadToEnd();
+        if (!p.WaitForExit(30_000)) { try { p.Kill(true); } catch { } throw new TimeoutException("runner hung"); }
+
+        Assert.Equal(2, p.ExitCode);
+        Assert.Contains("--tdd", err);
+        Assert.Contains("--server", err);
+    }
+
+    /// <summary>Criterion 12 — --tdd + --watch is rejected, not silently ignored.</summary>
+    [SkippableFact]
+    public void Tdd_RejectedTogetherWithWatch()
+    {
+        var (_, stderr, exit) = RunRunner("--tdd", "--watch", $"\"{FixturePath}\"");
+        Assert.Equal(2, exit);
+        Assert.Contains("--tdd", stderr);
+        Assert.Contains("--watch", stderr);
+    }
+
+    /// <summary>
+    /// Criterion 11, behavioural half: a --tdd run must never produce a cache entry a
+    /// normal run could accidentally reuse (or vice versa). This build satisfies that by
+    /// disabling the AL-output cache outright under --tdd (see Program.cs) — its
+    /// synthetic FAILED tests are derived fresh from source every Emit() call and are
+    /// not part of a cached DLL, so a HIT would silently drop them. Proven here by
+    /// asserting a --tdd run leaves the cache directory empty.
+    /// </summary>
+    [SkippableFact]
+    public void Tdd_NeverWritesTheAlOutputCache()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var alCache = Path.Combine(_scratch, "al-cache-empty-check");
+        var (_, stderr, _) = RunRunner("--tdd", $"--cache \"{alCache}\"", $"\"{FixturePath}\"");
+
+        Assert.Contains("--tdd disables the AL-output cache", stderr);
+        // TOP-LEVEL only, not recursive: --cache <dir> is also the isolation root for
+        // three OTHER, unrelated caches (compiled-deps/, bc-symbols/, ncl-cecil/ — see
+        // AlRunner.Infrastructure.CacheRoots), which legitimately write .dll files under
+        // subdirectories of `alCache` regardless of --tdd. Only the AL-OUTPUT cache
+        // writes directly at `<dir>/<key>.dll`, with no subdirectory — that is the one
+        // --tdd must leave untouched.
+        if (Directory.Exists(alCache))
+            Assert.Empty(Directory.EnumerateFiles(alCache, "*.dll", SearchOption.TopDirectoryOnly));
+    }
+
+    /// <summary>
+    /// Criterion 11, code-shape half: Program.cs:5334's ComputeAlCacheKey must hash the
+    /// --tdd flag itself, not only rely on the cache being disabled at runtime — the
+    /// issue calls this out as required in the FIRST commit, and a future PR that
+    /// re-enables caching under --tdd (e.g. once excluded-object detail has its own
+    /// sidecar) must not be able to silently drop this line and still compile. A scrape
+    /// test (same technique as CliDocumentationTests' flag scrape) rather than a runtime
+    /// probe, because --tdd runs never reach ComputeAlCacheKey while the cache is
+    /// disabled (see the test above) — there is no live --print-cache-key path to probe.
+    /// </summary>
+    [Fact]
+    public void ComputeAlCacheKey_HashesTheTddFlag()
+    {
+        var programSource = File.ReadAllText(Path.Combine(RepoRoot, "AlRunner", "Program.cs"));
+        var start = programSource.IndexOf("static string ComputeAlCacheKey(", StringComparison.Ordinal);
+        Assert.True(start >= 0, "ComputeAlCacheKey not found in Program.cs");
+        var end = programSource.IndexOf("static string? CommonDirectory(", start, StringComparison.Ordinal);
+        Assert.True(end > start, "could not bound ComputeAlCacheKey's body (CommonDirectory marker not found after it)");
+        var body = programSource[start..end];
+
+        Assert.Contains("IsTddMode()", body);
+        Assert.Contains("tdd:", body);
+    }
+}

--- a/AlRunner.Tests/TddModeTests.cs
+++ b/AlRunner.Tests/TddModeTests.cs
@@ -68,9 +68,20 @@ public sealed class TddModeTests : IDisposable
     /// <see cref="WithoutTdd_BehaviorIsByteForByteUnchanged"/>); with --tdd the three
     /// broken [Test] procedures must report FAILED — each naming the specific missing
     /// symbol, not a generic "compile failed" — while the unrelated healthy test in a
-    /// SIBLING object still passes. Covers acceptance criteria 3 (field), 4 (procedure),
-    /// 5 (enum value), 6 (unrelated tests unaffected), 7 (refuse-not-guess: every one of
-    /// these IS the refused case in this build), 9 (exit 1, not 3).
+    /// SIBLING object still passes.
+    ///
+    /// Covers acceptance criteria 6 (unrelated tests unaffected), 7 (refuse-not-guess:
+    /// every one of these IS the refused case in this build — see below), 9 (exit 1,
+    /// not 3). Covers ONLY PART of 3/4/5: a missing field / procedure / enum value each
+    /// produce a failed test naming that specific symbol, which is as far as this build
+    /// goes. It does NOT cover the rest of 3 ("the test... runs and reports failed" —
+    /// under this build the [Test] procedure never executes; the FAILED result is
+    /// synthesized from the compile diagnostic, not from running the method body), nor
+    /// any of 4's "with parameter and return types inferred from the call" (there is no
+    /// type inference anywhere in this build — see TddSupport's doc comment). Criterion
+    /// 8 (the generated-members list) is exercised by this test's own stderr assertion
+    /// below, but the list is always empty here, for the same reason. See issue #2001
+    /// (member generation/inference — the follow-up to #1997) for what closes the gap.
     /// </summary>
     [SkippableFact]
     public void MissingSymbols_ReportAsFailedTestsNamingTheSymbol()

--- a/AlRunner/BcCompiler.cs
+++ b/AlRunner/BcCompiler.cs
@@ -50,10 +50,34 @@ public sealed record EmittedSource(string Name, string Code);
 /// silently cost 7 tests (1904 -> 1897) with no output at any verbosity below --verbose.
 /// The caller MUST treat this as a hard failure (.claude/rules/loud-failures.md).
 /// </param>
+/// <summary>
+/// Per-excluded-object detail captured DURING the emit-retry loop (issue #1997 —
+/// <c>--tdd</c>), before the retry loop's compilation/emitResult variables get
+/// reassigned to the next round's smaller retry compile and the diagnostics that
+/// identified this object become unreachable. Only populated when
+/// <see cref="BcCompiler.SetTddMode"/> is on — see that method's doc comment for why.
+/// </summary>
+/// <param name="FilePath">
+/// The excluded object's own source file — NOT a temp copy (precompiled-dll-respect.md
+/// / this issue's "do not compile from a temp-directory copy" note applies equally to
+/// this path: it is what makes a --tdd synthetic failure's message point at a real,
+/// clickable file).
+/// </param>
+/// <param name="ObjectDisplayName">Matches the corresponding entry in <c>ExcludedObjects</c>.</param>
+/// <param name="Diagnostics">
+/// The AL diagnostics (alc-style: <c>path(line,col): error ALXXXX: message</c>) that
+/// caused THIS object specifically to be excluded — not the whole module's diagnostics.
+/// </param>
+public sealed record TddExcludedObjectDetail(
+    string FilePath,
+    string ObjectDisplayName,
+    IReadOnlyList<string> Diagnostics);
+
 public sealed record BcEmitOutput(
     IReadOnlyList<EmittedSource> Sources,
     IReadOnlyList<string> Diagnostics,
-    IReadOnlyList<string> ExcludedObjects);
+    IReadOnlyList<string> ExcludedObjects,
+    IReadOnlyList<TddExcludedObjectDetail>? TddExcludedDetails = null);
 
 public sealed partial class BcCompiler
 {
@@ -227,6 +251,34 @@ public sealed partial class BcCompiler
             lock (_refSync) { _resolvedDeps = _saved; _refSpecs = null; }
         }
     }
+    // --tdd (issue #1997): off by default. When on, the emit-retry loop in Emit()
+    // additionally captures per-excluded-object TddExcludedObjectDetail (file path +
+    // the diagnostics that identified it) into the returned BcEmitOutput, so the
+    // caller (Program.cs) can turn each excluded object's [Test] procedures into
+    // synthetic FAILED TestResults instead of discarding the whole module — see
+    // Program.cs's EMIT-EXCLUDED handling. Gated behind this flag (rather than always
+    // capturing) so the default (non-tdd) path is PROVABLY unchanged: no extra
+    // allocation, no extra diagnostic formatting work, on every ordinary run.
+    private static bool _tddMode;
+
+    /// <summary>
+    /// Sets whether the emit-retry loop should capture <see cref="TddExcludedObjectDetail"/>
+    /// for excluded objects. Follows the same static-setter pattern as
+    /// <see cref="SetExtraPreprocessorSymbols"/> — compile-affecting CLI options are pushed
+    /// into BcCompiler this way because there are four Emit call sites in Program.cs and no
+    /// single place to thread a parameter through all of them.
+    /// </summary>
+    public static void SetTddMode(bool enabled)
+    {
+        lock (_refSync) { _tddMode = enabled; }
+    }
+
+    /// <summary>True when a --tdd run is in progress. Read-only mirror of <see cref="SetTddMode"/>.</summary>
+    public static bool IsTddMode()
+    {
+        lock (_refSync) { return _tddMode; }
+    }
+
     // Extra preprocessor symbols supplied by the caller via --define / --preprocessor-symbols.
     // Merged with the built-in CLEANSCHEMA1..25 set at both ParseOptions sites.
     private static IReadOnlyList<string>? _extraPreprocessorSymbols;
@@ -1519,6 +1571,15 @@ public sealed partial class BcCompiler
         // a stderr line alone does not do that (Log's [Component] filter eats it, and
         // nothing counts it).
         var excludedObjects = new List<string>();
+        // --tdd only (issue #1997): file path + the diagnostics that identified each
+        // excluded object, captured HERE — inside the round that identifies it — because
+        // `emitResult`/`caught` get reassigned to the next (smaller) retry compile's
+        // result at the bottom of this loop, at which point the diagnostics that named
+        // an EARLIER round's excluded object are no longer reachable from any variable
+        // in scope. Left null (not merely empty) when not in --tdd mode, so the emitted
+        // BcEmitOutput.TddExcludedDetails is null on the default path exactly as before
+        // this issue — no behavioural difference for a non-tdd caller.
+        var tddDetails = _tddMode ? new List<TddExcludedObjectDetail>() : null;
         {
             const int maxRounds = 10;
             // Indices are always relative to the ORIGINAL alFiles/trees arrays (captured once,
@@ -1557,7 +1618,17 @@ public sealed partial class BcCompiler
                         catch { nextKeepIdx.Add(i); continue; }
                         var hit = failing.FirstOrDefault(f => DeclaresObject(src, f.Type, f.Namespace, f.Name));
                         if (hit.Name != null)
-                            roundExcluded.Add($"{hit.Type} {hit.Namespace}.\"{hit.Name}\"");
+                        {
+                            var label = $"{hit.Type} {hit.Namespace}.\"{hit.Name}\"";
+                            roundExcluded.Add(label);
+                            // No structured Location for an emitter-crash exclusion — only the
+                            // exception's own message names it. Still useful for a --tdd
+                            // synthetic failure: it says WHICH object and WHY, even without a
+                            // path@line:col anchor.
+                            tddDetails?.Add(new TddExcludedObjectDetail(
+                                alFiles[i], label,
+                                new[] { $"emit-crash: {label} — {caught.Message.Split('\n', 2)[0]}" }));
+                        }
                         else
                             nextKeepIdx.Add(i);
                     }
@@ -1581,7 +1652,20 @@ public sealed partial class BcCompiler
                     foreach (var i in keepIdx)
                     {
                         if (badTrees.Contains(originalTrees[i]))
-                            roundExcluded.Add(Path.GetFileNameWithoutExtension(alFiles[i]));
+                        {
+                            var label = Path.GetFileNameWithoutExtension(alFiles[i]);
+                            roundExcluded.Add(label);
+                            if (tddDetails != null)
+                            {
+                                var objDiags = emitResult.Diagnostics
+                                    .Where(d => d.Severity == NavDiag.DiagnosticSeverity.Error
+                                        && d.Location.IsInSource
+                                        && d.Location.SourceTree == originalTrees[i])
+                                    .Select(d => $"{d.Location}: error {d.Id}: {d.GetMessage().Split('\n', 2)[0]}")
+                                    .ToList();
+                                tddDetails.Add(new TddExcludedObjectDetail(alFiles[i], label, objDiags));
+                            }
+                        }
                         else
                             nextKeepIdx.Add(i);
                     }
@@ -1792,7 +1876,7 @@ public sealed partial class BcCompiler
             }
         }
 
-        var emitOutput = new BcEmitOutput(outputter.Captured, alDiags, excludedObjects);
+        var emitOutput = new BcEmitOutput(outputter.Captured, alDiags, excludedObjects, tddDetails);
 
         // #1902: only a CLEAN success (nothing excluded, every source captured) is trustworthy
         // as a RAD baseline — a module that only compiled after dropping broken objects must

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -230,6 +230,17 @@ int? testTimeoutSeconds = null;
 // same-bundle in-process reload is now safe because the type finders prefer the current
 // test assembly. Net: ~seconds per save instead of a cold re-run.
 bool watchMode = false;
+// --tdd (issue #1997): local-development-only flag, off by default. Normally a test
+// referencing a not-yet-implemented table field / procedure / enum value is a
+// method-body compile ERROR, which drops the WHOLE app group (BC's ContinueBuildOnError
+// does not cover method bodies — see BcCompiler.Emit's emit-retry-loop comment) and the
+// run reports a compile failure with zero test results, not a failing test. --tdd keeps
+// the recovered sources for the objects that DID compile and turns every [Test]
+// procedure inside an object that could NOT be recovered into a synthetic FAILED
+// TestResult naming the AL diagnostic that broke it — see TddSupport.BuildFailedTests
+// and Program.cs's EMIT-EXCLUDED handling below. Not recommended for CI: it exists so a
+// red-green TDD cycle can start with an honestly red test, not a compile failure.
+bool tddMode = false;
 // --dump-csharp DIR: write the emitted C# (BC Compilation.Emit output, post-BcAssembler
 // polyfill injection) to disk for every bundle compile. Useful for debugging codegen.
 string? dumpCsharpDir = null;
@@ -293,6 +304,7 @@ for (int i = 0; i < args.Length; i++)
     if (args[i] == "--no-cache") { alCacheDir = null; continue; }
     if (args[i] == "--print-cache-key") { printCacheKeyOnly = true; continue; }
     if (args[i] == "--watch") { watchMode = true; continue; }
+    if (args[i] == "--tdd") { tddMode = true; continue; }
     if (args[i] == "--server") { continue; }  // handled above (serverMode); consume so it isn't "unknown"
     if (args[i] == "--verbose") { AlRunner.Log.Verbose = true; continue; }
     if (args[i] == "--show-pass") { showPass = true; continue; }   // no-op (default in v2); kept for v1 back-compat
@@ -362,6 +374,42 @@ if (serverMode && watchMode)
 {
     Console.Error.WriteLine("--server and --watch are mutually exclusive (both stay warm in-process; pick one).");
     return 2;
+}
+// --tdd (issue #1997) only changes the bundled-mode CLI run loop's EMIT-EXCLUDED
+// handling (Program.cs, below). --server has its own, separate EMIT-EXCLUDED guard
+// (a different Emit() call site) that this issue's reduced scope does not touch, and
+// --watch's incremental (RAD) recompile path does not carry per-excluded-object
+// diagnostics through to a synthetic TestResult either. Rejecting both explicitly beats
+// silently ignoring the flag — a --tdd run that quietly behaved like a normal run under
+// --server/--watch would be far more confusing than an upfront error naming the gap.
+if (tddMode && serverMode)
+{
+    Console.Error.WriteLine("--tdd is not supported together with --server yet (local-development flag; --server's EMIT-EXCLUDED handling is a separate code path this hasn't reached). Run --tdd from the CLI directly.");
+    return 2;
+}
+if (tddMode && watchMode)
+{
+    Console.Error.WriteLine("--tdd is not supported together with --watch yet (the incremental/RAD recompile path doesn't carry per-excluded-object diagnostics). Run --tdd without --watch.");
+    return 2;
+}
+// --tdd forces the AL-output cache off (same effect as --no-cache), on top of the
+// tdd:<0|1> cache-key line added above. The line alone stops a --tdd run from ever
+// SERVING a normal-mode DLL or vice versa (criterion 11) — but it does not make a
+// --tdd HIT correct on its own: the synthetic FAILED TestResults for excluded
+// objects are derived fresh from source every Emit() call (TddSupport.BuildFailedTests
+// re-parses the excluded .al files), and nothing about them is baked into the cached
+// DLL. A --tdd cache HIT would skip Emit() entirely and silently drop back to
+// reporting only the objects that DID compile — the exact "tests vanished, run looks
+// green" failure mode this whole issue exists to fix, just moved one level down. Until
+// the excluded-object detail has its own cache sidecar (a --tdd cache HIT is a
+// reasonable follow-up), disabling the cache is what keeps every --tdd run correct.
+if (tddMode && alCacheDir != null)
+{
+    Console.Error.WriteLine(
+        "--tdd disables the AL-output cache for this run — its synthetic FAILED tests " +
+        "for excluded objects are derived fresh from source on every Emit() call and " +
+        "are not part of the cached DLL, so a cache HIT would silently drop them.");
+    alCacheDir = null;
 }
 // ── Positional bundle roots must exist (#1713) ────────────────────────────────
 // Checked HERE — at argument-parse time, before the BC artifact selection, the Cecil
@@ -862,6 +910,7 @@ if (!provisionSubcommand)
 DependencyLoader.EnsureResolverInstalled_Public();
 if (extraPreprocessorSymbols.Count > 0)
     BcCompiler.SetExtraPreprocessorSymbols(extraPreprocessorSymbols.Distinct().ToList());
+BcCompiler.SetTddMode(tddMode);
 if (Environment.GetEnvironmentVariable("AL_RUNNER_DIAG_FCE") is "1" or "2")
 {
     var fceFull = Environment.GetEnvironmentVariable("AL_RUNNER_DIAG_FCE") == "2";
@@ -1601,6 +1650,13 @@ foreach (var bundle in bundles)
             var et = System.Diagnostics.Stopwatch.StartNew();
             IReadOnlyList<EmittedSource> sources = Array.Empty<EmittedSource>();
             IReadOnlyList<string> alDiagnostics = Array.Empty<string>();
+            // --tdd only (issue #1997): count of objects the TDD-EXCLUDED branch below
+            // deliberately kept `sources` short by. The PARTIAL-EMIT-DROP guard further
+            // down flags any declared-vs-emitted gap as a SILENT drop — under --tdd that
+            // gap is not silent (it is exactly the TDD-EXCLUDED objects, already reported
+            // above with a synthetic FAILED test each), so the guard must subtract this
+            // count before deciding there is an unexplained gap left.
+            int tddExcludedCount = 0;
             // Emit-phase timeout: default 120 s, override via AL_RUNNER_EMIT_TIMEOUT_SEC.
             // Note: Task.Run thread continues in background after timeout — acceptable for a CLI tool.
             int emitTimeoutSec = int.TryParse(
@@ -1696,17 +1752,44 @@ foreach (var bundle in bundles)
                     if (emitOutput.ExcludedObjects.Count > 0)
                     {
                         var names = string.Join(", ", emitOutput.ExcludedObjects);
-                        // Untagged on purpose: a `[Component]` prefix would be swallowed by
-                        // Log's filter at default verbosity, which is the original defect.
-                        Console.Error.WriteLine(
-                            $"<bundled>: EMIT-EXCLUDED — {moduleName}: {emitOutput.ExcludedObjects.Count} object(s) " +
-                            $"could not be compiled and were dropped from the module, so any tests they declare " +
-                            $"are MISSING from this run: [{names}]. Re-run with --verbose for the AL diagnostics " +
-                            $"that identified them.");
-                        bundleErrors.Add(
-                            $"<bundled>: EMIT-EXCLUDED for {moduleName}: {emitOutput.ExcludedObjects.Count} " +
-                            $"object(s) dropped from the module — tests they declare are missing: [{names}].");
-                        sources = Array.Empty<EmittedSource>(); // do not run a module that is missing objects
+                        if (tddMode)
+                        {
+                            // --tdd (issue #1997): the default path above (else branch) is
+                            // UNCHANGED — this branch only runs when --tdd was passed. Keep the
+                            // recovered `sources` (BcCompiler's emit-retry loop already dropped
+                            // ONLY the broken objects and recompiled the survivors) instead of
+                            // discarding the whole module, and turn every [Test] procedure the
+                            // excluded objects declared into a synthetic FAILED TestResult naming
+                            // the AL diagnostic that broke it. bundleErrors MUST stay untouched
+                            // here: any entry there forces exit code 3 at the exit-code ladder
+                            // below, and the whole point of --tdd is to report a RED TEST (exit
+                            // 1), not a compile failure.
+                            var synthetic = TddSupport.BuildFailedTests(
+                                emitOutput.TddExcludedDetails ?? Array.Empty<TddExcludedObjectDetail>());
+                            Console.Error.WriteLine(
+                                $"<bundled>: TDD-EXCLUDED — {moduleName}: {emitOutput.ExcludedObjects.Count} " +
+                                $"object(s) could not be compiled: [{names}]. {synthetic.Count} [Test] " +
+                                $"procedure(s) they declare report as FAILED instead of vanishing from the run. " +
+                                $"Re-run with --verbose for the AL diagnostics that identified them.");
+                            bundleTests.AddRange(synthetic);
+                            tddExcludedCount = emitOutput.ExcludedObjects.Count;
+                            // sources stays as BcCompiler returned it (the recovered set) — do
+                            // NOT clear it, unlike the non-tdd branch below.
+                        }
+                        else
+                        {
+                            // Untagged on purpose: a `[Component]` prefix would be swallowed by
+                            // Log's filter at default verbosity, which is the original defect.
+                            Console.Error.WriteLine(
+                                $"<bundled>: EMIT-EXCLUDED — {moduleName}: {emitOutput.ExcludedObjects.Count} object(s) " +
+                                $"could not be compiled and were dropped from the module, so any tests they declare " +
+                                $"are MISSING from this run: [{names}]. Re-run with --verbose for the AL diagnostics " +
+                                $"that identified them.");
+                            bundleErrors.Add(
+                                $"<bundled>: EMIT-EXCLUDED for {moduleName}: {emitOutput.ExcludedObjects.Count} " +
+                                $"object(s) dropped from the module — tests they declare are missing: [{names}].");
+                            sources = Array.Empty<EmittedSource>(); // do not run a module that is missing objects
+                        }
                     }
 
                     // --dump-csharp DIR: write the emitted intermediate C# (BC's
@@ -1764,7 +1847,11 @@ foreach (var bundle in bundles)
                         System.Text.RegularExpressions.RegexOptions.Multiline))
                     .Select(m => m.Groups[2].Value.Trim())
                     .ToList();
-                if (declaredObjects.Count > sources.Count)
+                // #1997: the gap is not silent when it exactly matches tddExcludedCount — the
+                // TDD-EXCLUDED branch above already reported those objects loudly, with a
+                // synthetic FAILED test each. Only a gap BEYOND that is the unexplained,
+                // genuinely silent drop this guard exists to catch.
+                if (declaredObjects.Count > sources.Count + tddExcludedCount)
                 {
                     var emittedNames = sources.Select(s => s.Name).ToList();
                     bundleErrors.Add(
@@ -2387,6 +2474,23 @@ else
     if (printClassification)
         Reporter.PrintFailureClassification(results, Console.Out);
     Reporter.PrintSummary(results, Console.Out);
+}
+if (tddMode)
+{
+    // issue #1997 acceptance criterion 8: print the members --tdd generated this run —
+    // the API the implementing app still has to provide, derived from the tests rather
+    // than written by hand. This build's --tdd deliberately REFUSES to infer a missing
+    // member's type (see TddSupport's doc comment / .claude/rules/loud-failures.md — a
+    // wrong guess compiles and produces a test that is red for the wrong reason), so the
+    // list is always empty for now; the excluded [Test] results above already name every
+    // missing symbol individually. Printed either way so the summary's shape doesn't
+    // silently change once generation ships.
+    var tddOut = outputJson ? Console.Error : Console.Out;
+    tddOut.WriteLine();
+    tddOut.WriteLine(
+        "--tdd: no members were generated this run — every missing symbol was reported " +
+        "as a failed test instead (type inference is not implemented yet; see the FAILED " +
+        "test messages above for each missing symbol).");
 }
 if (outPath != null)
 {
@@ -3742,6 +3846,15 @@ static void PrintHelp(TextWriter w)
     w.WriteLine("                          protocol; all logs go to stderr. Used by the VS Code");
     w.WriteLine("                          extension. Commands: runTests, shutdown (execute: TODO).");
     w.WriteLine("                          See docs/server-mode.md. Mutually exclusive with --watch.");
+    w.WriteLine("  --tdd                   Local-development flag (not for CI). A test referencing a");
+    w.WriteLine("                          table field / procedure / enum value the implementing app");
+    w.WriteLine("                          doesn't have yet normally drops the whole app group with a");
+    w.WriteLine("                          compile failure (exit 3, zero test results). --tdd keeps");
+    w.WriteLine("                          every object that DID compile and reports each [Test]");
+    w.WriteLine("                          procedure in an object that could NOT be recovered as a");
+    w.WriteLine("                          FAILED test naming the missing symbol, so a red-green TDD");
+    w.WriteLine("                          cycle can start with an honestly red test (exit 1). Not");
+    w.WriteLine("                          yet supported together with --watch or --server.");
     w.WriteLine("  --per-suite             Legacy per-Compilation path. Default is bundled mode");
     w.WriteLine("                          (5-7x faster, parity-verified).");
     w.WriteLine("  --bundled               No-op alias for the default bundled mode (deprecated).");
@@ -5572,7 +5685,17 @@ static string ComputeAlCacheKey(
     //        branch, missing NoImplicitWith, stale contextSensitiveHelpUrl) forever, until
     //        something else in the key happened to change. v10 entries never hashed the
     //        manifest at all and must not be served under the new key shape.
-    WriteLine("schema:v11");
+    //    v12 (issue #1997): added a tdd:<0|1> line. --tdd keeps recovered sources for
+    //        objects a normal run drops entirely and can (in a follow-up) inject
+    //        generated members into the in-memory compile — a --tdd assembly and a
+    //        normal-mode assembly for the SAME source bytes are not the same output.
+    //        Without this line a bare run and a --tdd run over identical sources hash
+    //        identically, and whichever compiled first would silently serve the other:
+    //        a normal run reusing a --tdd-generated DLL, or (just as bad) a later --tdd
+    //        run reusing a normal-mode DLL and reporting the excluded tests' vanished
+    //        instead of failed. v11 entries never hashed this and must not be served.
+    WriteLine("schema:v12");
+    WriteLine($"tdd:{(AlRunner.BcCompiler.IsTddMode() ? "1" : "0")}");
 
     // 1. Runner assembly fingerprint (content hash, not mtime — see v10 note above) +
     //    the selected BC version, so any rewriter/polyfill/patch change in the runner,

--- a/AlRunner/TddSupport.cs
+++ b/AlRunner/TddSupport.cs
@@ -1,0 +1,108 @@
+// TddSupport — issue #1997: turns objects excluded from a --tdd emit (because they
+// reference a symbol the implementing app doesn't have yet) into synthetic FAILED
+// TestResult entries, one per [Test] procedure the excluded object declares.
+//
+// Scope of this file matches the issue's reduced-scope acceptance criteria (1, 2, 6,
+// 7, 9, 10, 11, 12): it REFUSES to infer a missing member's type and generate it —
+// every excluded [Test] procedure reports failed, naming the object and carrying the
+// AL diagnostics that identified the break. Type inference / member generation
+// (criteria 3, 4, 5, 8's "list of GENERATED members") is tracked as a follow-up; see
+// the PR this file shipped in for the issue number.
+//
+// Why re-parse rather than reuse a compiled type: an EXCLUDED object never reached
+// Compilation.Emit successfully, so there is no IL, no MethodInfo, nothing reflection
+// can see. The only surviving artifact is its own source file, so [Test] procedures
+// are found the same way RecordPatches.AlSourceParser finds table/field declarations —
+// by walking BC's own AL syntax tree (NavSyntax.SyntaxTree.ParseObjectText), never by
+// copying the file elsewhere (see BcCompiler.Emit's interposition-point comment: a
+// temp-directory copy would make the reported path unclickable in the editor and
+// would desync --watch's watched tree from the tree actually compiled).
+using NavCA = Microsoft.Dynamics.Nav.CodeAnalysis;
+using NavSyntax = Microsoft.Dynamics.Nav.CodeAnalysis.Syntax;
+
+namespace AlRunner;
+
+public static class TddSupport
+{
+    // Mirrors BcCompiler's own ParseOptions (CLEANSCHEMA1..25 + whatever --define /
+    // --preprocessor-symbols supplied) so this re-parse sees exactly the same source
+    // the original (failed) emit attempt saw — same rule RecordPatches.AlSourceParser
+    // follows for the same reason (see its AlParseOptions doc comment). Recomputed per
+    // call rather than cached: BcCompiler.SetExtraPreprocessorSymbols can run after
+    // this type is first touched, and a frozen `static readonly` would miss that.
+    private static NavCA.ParseOptions ParseOptions => new(
+        runtimeVersion: null!,
+        preprocessorSymbols: Enumerable.Range(1, 25).Select(n => $"CLEANSCHEMA{n}")
+            .Concat(BcCompiler.GetExtraPreprocessorSymbols()),
+        documentationMode: NavCA.DocumentationMode.None);
+
+    private static string Unquote(string s)
+        => s.Length >= 2 && s[0] == '"' && s[^1] == '"' ? s[1..^1] : s;
+
+    private static string IdentText(NavSyntax.IdentifierNameSyntax? id)
+        => id == null ? "" : Unquote(id.Identifier.ValueText ?? id.Identifier.Text ?? "");
+
+    /// <summary>
+    /// Builds one synthetic <see cref="TestResult"/> per <c>[Test]</c> procedure declared by
+    /// each excluded object, all with <see cref="TestOutcome.Fail"/>. Objects with no
+    /// <c>[Test]</c> procedure (a table, a non-test codeunit, …) contribute nothing here —
+    /// they were never a "test [that] vanished", so there is no test-shaped result to
+    /// report for them; the caller's own EMIT-EXCLUDED log line still names the object.
+    /// </summary>
+    public static IReadOnlyList<TestResult> BuildFailedTests(
+        IReadOnlyList<TddExcludedObjectDetail> details)
+    {
+        var results = new List<TestResult>();
+        var parseOpts = ParseOptions;
+        foreach (var detail in details)
+        {
+            string src;
+            try { src = File.ReadAllText(detail.FilePath); }
+            catch (Exception ex)
+            {
+                // The file itself is unreadable (deleted between emit and this call, race
+                // with an editor save, …) — still report SOMETHING for this object rather
+                // than silently dropping it, per loud-failures.md. There is no method name
+                // to attach it to, so it becomes a single synthetic "object" result.
+                results.Add(new TestResult(
+                    detail.ObjectDisplayName, "<tdd-excluded>", TestOutcome.Fail,
+                    $"--tdd: could not re-read {detail.FilePath} to find its [Test] procedures: {ex.Message}",
+                    string.Join("\n", detail.Diagnostics), TimeSpan.Zero,
+                    AlCallStack: null, CodeunitDisplayName: detail.ObjectDisplayName,
+                    Exception: null, Expectation: null, InsideTestProc: false));
+                continue;
+            }
+
+            var tree = NavSyntax.SyntaxTree.ParseObjectText(
+                src, path: detail.FilePath, encoding: null!, parseOpts, default);
+            if (tree.GetRoot() is not NavSyntax.CompilationUnitSyntax root) continue;
+
+            var diagText = string.Join("\n", detail.Diagnostics);
+            var firstDiag = detail.Diagnostics.Count > 0 ? detail.Diagnostics[0] : "(no diagnostic captured)";
+
+            foreach (var obj in root.ChildNodes().OfType<NavSyntax.ObjectSyntax>())
+            {
+                var objName = IdentText(obj.Name);
+                if (objName.Length == 0) objName = detail.ObjectDisplayName;
+                foreach (var member in obj.Members)
+                {
+                    if (member is not NavSyntax.MethodDeclarationSyntax method) continue;
+                    var isTest = method.Attributes.Any(a =>
+                        string.Equals(IdentText(a.Name), "Test", StringComparison.OrdinalIgnoreCase));
+                    if (!isTest) continue;
+
+                    var methodName = IdentText(method.Name);
+                    if (methodName.Length == 0) methodName = "<unnamed>";
+
+                    results.Add(new TestResult(
+                        objName, methodName, TestOutcome.Fail,
+                        $"--tdd: {objName} did not compile — {firstDiag}",
+                        diagText, TimeSpan.Zero,
+                        AlCallStack: null, CodeunitDisplayName: objName,
+                        Exception: null, Expectation: null, InsideTestProc: false));
+                }
+            }
+        }
+        return results;
+    }
+}


### PR DESCRIPTION
Closes #1997

## What this does

`--tdd` (off by default, local-development only) changes what happens when a
test references a table field / procedure / enum value the implementing app
doesn't have yet. Today that's a method-body compile error, which BC's
`ContinueBuildOnError` does not cover — the whole app group is dropped,
`Program.cs`'s bundled-mode EMIT-EXCLUDED handling records a compile error,
and the run reports exit 3 with **zero test results**, not a red test. That
breaks the first half of red-green TDD: you can't confirm a new test fails
for the reason you intended without changing the implementation first.

With `--tdd`, the objects `BcCompiler`'s existing emit-retry loop *does*
recover still run normally. Every `[Test]` procedure inside an object that
could **not** be recovered gets a synthetic `TestResult` with
`Outcome = Fail`, naming the AL diagnostic that broke it (source path,
line/col, and the missing symbol). Exit code becomes 1 (tests failed), not 3.

## Scope (per the issue's own sizing note)

This ships the **no-inference** slice: every missing symbol is refused —
reported as a failed test — rather than guessed at and generated. Per
`.claude/rules/loud-failures.md`, a wrong type guess would compile and
produce a test that's red for the wrong reason, which is worse than not
running it.

**Covered:** acceptance criteria 1, 2, 6, 7, 9, 10, 11, 12.
**Not covered (follow-up):** criteria 3/4/5/8 — actual type inference and
member generation into the in-memory compile, and the resulting non-empty
"generated members" list. The run does print the criterion-8 summary line,
but it's always empty in this build and says so explicitly.

## Where the change lives

- `BcCompiler.cs`: the emit-retry loop now optionally captures
  `TddExcludedObjectDetail` (file path + the diagnostics that identified
  *that specific* object) while it still has them — they're not reachable
  once the loop reassigns to the next retry round's smaller compile. Gated
  behind a new `BcCompiler.SetTddMode(bool)` static setter (same pattern as
  `SetExtraPreprocessorSymbols`), so the default path allocates nothing extra.
- `TddSupport.cs` (new): re-parses each excluded object's own source file
  with BC's AL syntax API (`SyntaxTree.ParseObjectText`, no temp-directory
  copy — diagnostics stay clickable and `--watch` isn't desynced from what
  it compiles) and turns every `[Test]`-attributed method into a failed
  `TestResult`.
- `Program.cs`:
  - `--tdd` flag, `--help` entry, rejected together with `--server`/`--watch`
    (both have separate code paths this reduced scope doesn't reach).
  - The bundled-mode EMIT-EXCLUDED block gets a `tddMode` branch that keeps
    the recovered `sources` and appends the synthetic failures to
    `bundleTests` instead of zeroing `sources` and adding to `bundleErrors`
    — `bundleErrors` staying empty is what keeps exit code at 1 instead of 3.
    The non-tdd branch is byte-for-byte what was there before.
  - The pre-existing PARTIAL-EMIT-DROP guard had to learn to subtract the
    count of objects the TDD-EXCLUDED branch already reported loudly — it
    was flagging that legitimate, already-explained gap as a fresh silent
    drop (caught by my own fixture during RED→GREEN, not by inspection).
  - `ComputeAlCacheKey` (Program.cs:5334): `tdd:<0|1>` line + schema bump to
    v12, in this same commit as required by the issue.
  - `--tdd` also disables the AL-output cache outright (same effect as
    `--no-cache`). The synthetic failures are derived fresh from source on
    every `Emit()` call and aren't part of the cached DLL — a cache HIT
    would skip `Emit()` entirely and silently drop back to reporting only
    the objects that compiled, which is the exact bug this issue exists to
    fix, one level down. Confirmed empirically: without this, a warm-cache
    second run of the fixture lost the three synthetic failures. The
    `tdd:` cache-key line is defense-in-depth for whenever a follow-up adds
    a proper excluded-object-detail sidecar and re-enables caching.

## Tests

- `AlRunner.Tests/Fixtures/Tdd/` — one app: three broken test codeunits
  (missing procedure / missing table field / missing enum value, one bad
  reference per object) plus one healthy, unrelated test codeunit.
- `AlRunner.Tests/TddModeTests.cs`:
  - `MissingSymbols_ReportAsFailedTestsNamingTheSymbol` — the core proof:
    `--tdd --output-json` against the fixture, asserts exit 1, 4 total tests,
    each of the three broken tests failed with its specific missing symbol
    (`CalcTotal` / `Loyalty Points` / `Archived`) in the message, and the
    healthy test in the sibling object still passes.
  - `WithoutTdd_BehaviorIsByteForByteUnchanged` — same fixture, no `--tdd`:
    exit 3, `EMIT-EXCLUDED` (not `TDD-EXCLUDED`), zero tests.
  - `Tdd_RejectedTogetherWithServer` / `Tdd_RejectedTogetherWithWatch` —
    exit 2 with a clear message.
  - `Tdd_NeverWritesTheAlOutputCache` — a `--tdd` run leaves no `.dll`
    directly under the AL-output cache root (scoped to top-level only —
    `--cache <dir>` is also the isolation root for three unrelated caches
    that legitimately write under subdirectories regardless of `--tdd`).
  - `ComputeAlCacheKey_HashesTheTddFlag` — scrape test (same technique as
    `CliDocumentationTests`) pinning that the cache-key function actually
    hashes the flag, since a live `--tdd --print-cache-key` probe can't work
    once the cache is disabled.
- `AlRunner.Tests/CliDocumentationTests.cs`: added `--tdd` to the existing
  "not listed as unimplemented" check.
- `AlRunner.Tests/EmitExclusionLoudnessTests.cs` and
  `BundleSuiteErrorLoudnessTests.cs` are **untouched** and still pass —
  confirmed by running them explicitly.

Full `AlRunner.Tests` suite: 801 passed, 54 skipped, 0 failed (no regressions).

This is a runner-specific claim (`--tdd` producing a failed test where BC's
compiler produces a hard error), not a BC-behaviour claim, so the proving
tests live in this repo per `.claude/rules/bc-behavior-tests-go-upstream.md`
— nothing belongs in the `tests/al-language/` corpus for this change.

## Test plan

- [x] RED → GREEN on the new fixture (verified manually before writing the
      test assertions, then via the test suite)
- [x] `dotnet test AlRunner.Tests` — 801 passed, 0 failed
- [x] Manual smoke: `--tdd`, `--tdd --server`, `--tdd --watch`,
      `--tdd --print-cache-key`, warm-cache second run (regression that led
      to the cache-disable decision)