### PR TITLE
feat(tdd): support --tdd together with --watch

### DIFF
--- a/AlRunner.Tests/Fixtures/TddWatch/TddWatchRefusedTests.Codeunit.al
+++ b/AlRunner.Tests/Fixtures/TddWatch/TddWatchRefusedTests.Codeunit.al
@@ -1,0 +1,26 @@
+/// <summary>
+/// The "must refuse" case from #1997/#2001: a bare-statement procedure call gives no
+/// way to tell a void procedure from a discarded return value, so --tdd's generation
+/// refuses rather than guesses (TddGeneration.cs) — this object is excluded and its
+/// [Test] procedure reported FAILED naming the AL diagnostic, exactly like #2000's
+/// original refuse path. DoThing is deliberately NEVER implemented anywhere in this
+/// fixture: this codeunit's exclusion — and therefore the whole module's
+/// `excludedObjects.Count > 0` — is meant to be PERMANENT across every watch cycle,
+/// which is what TddWatchTests.cs's watch-level test uses to prove the --tdd-specific
+/// "no incremental baseline yet" fallback-reason text cleanly (see that file's doc
+/// comment and issue #2009 for why the OTHER, generation-eligible test in this bundle
+/// can't prove it on its own).
+/// </summary>
+codeunit 65102 "Tdd Watch Refused Tests"
+{
+    Subtype = Test;
+    TestPermissions = Disabled;
+
+    [Test]
+    procedure BareStatementCall_RefusesNotGuesses()
+    var
+        Target: Codeunit "Tdd Watch Target Cu";
+    begin
+        Target.DoThing();
+    end;
+}

--- a/AlRunner.Tests/Fixtures/TddWatch/TddWatchTargetCu.Codeunit.al
+++ b/AlRunner.Tests/Fixtures/TddWatch/TddWatchTargetCu.Codeunit.al
@@ -1,0 +1,13 @@
+/// <summary>
+/// The "implementing app" half of this fixture. Deliberately does NOT declare a
+/// DoubleIt procedure yet — TddWatchTests.Codeunit.al calls it as if it already
+/// existed. WatchTests' edit step appends DoubleIt to this file in place, between
+/// watch cycles, without restarting the process — the same file this test's edit
+/// step targets.
+/// </summary>
+codeunit 65100 "Tdd Watch Target Cu"
+{
+    procedure Placeholder()
+    begin
+    end;
+}

--- a/AlRunner.Tests/Fixtures/TddWatch/TddWatchTests.Codeunit.al
+++ b/AlRunner.Tests/Fixtures/TddWatch/TddWatchTests.Codeunit.al
@@ -1,0 +1,22 @@
+/// <summary>
+/// References DoubleIt, a procedure "Tdd Watch Target Cu" does not declare yet.
+/// Without --tdd this whole object is excluded from the emit. With --tdd it must
+/// report FAILED, naming DoubleIt — until "Tdd Watch Target Cu" implements it, at
+/// which point it must report PASSED with the doubled value.
+/// </summary>
+codeunit 65101 "Tdd Watch Tests"
+{
+    Subtype = Test;
+    TestPermissions = Disabled;
+
+    [Test]
+    procedure MissingProcedure_ReportsFailedThenPasses()
+    var
+        Target: Codeunit "Tdd Watch Target Cu";
+        Result: Integer;
+    begin
+        Result := Target.DoubleIt(5);
+        if Result <> 10 then
+            Error('expected DoubleIt(5) = 10, got %1', Result);
+    end;
+}

--- a/AlRunner.Tests/Fixtures/TddWatch/app.json
+++ b/AlRunner.Tests/Fixtures/TddWatch/app.json
@@ -1,0 +1,25 @@
+{
+  "id": "b6a1f0d2-3c4e-4a9b-9f1d-7e2c5a8b6d10",
+  "name": "Runner Tests Fixture - TddWatch",
+  "publisher": "AL Runner",
+  "version": "1.0.0.0",
+  "brief": "Proves --tdd works together with --watch (issue #2002, follow-up to #1997).",
+  "description": "One [Test] procedure that calls a not-yet-implemented procedure on a sibling codeunit. Cycle 1 (process start) must report the test FAILED, naming the missing procedure. Editing the sibling codeunit in place to add the procedure, without restarting the watch process, must make the NEXT cycle report the same test PASSED.",
+  "privacyStatement": "",
+  "EULA": "",
+  "help": "",
+  "url": "",
+  "logo": "",
+  "dependencies": [],
+  "screenshots": [],
+  "platform": "1.0.0.0",
+  "application": "1.0.0.0",
+  "idRanges": [
+    {
+      "from": 65100,
+      "to": 65199
+    }
+  ],
+  "runtime": "14.0",
+  "features": []
+}

--- a/AlRunner.Tests/TddModeTests.cs
+++ b/AlRunner.Tests/TddModeTests.cs
@@ -266,16 +266,6 @@ public sealed class TddModeTests : IDisposable
         Assert.Contains("--server", err);
     }
 
-    /// <summary>Criterion 12 — --tdd + --watch is rejected, not silently ignored.</summary>
-    [SkippableFact]
-    public void Tdd_RejectedTogetherWithWatch()
-    {
-        var (_, stderr, exit) = RunRunner("--tdd", "--watch", $"\"{FixturePath}\"");
-        Assert.Equal(2, exit);
-        Assert.Contains("--tdd", stderr);
-        Assert.Contains("--watch", stderr);
-    }
-
     /// <summary>
     /// Criterion 11, behavioural half: a --tdd run must never produce a cache entry a
     /// normal run could accidentally reuse (or vice versa). This build satisfies that by

--- a/AlRunner.Tests/TddWatchTests.cs
+++ b/AlRunner.Tests/TddWatchTests.cs
@@ -6,26 +6,44 @@ namespace AlRunner.Tests;
 /// <summary>
 /// Issue #2002 (follow-up to #1997): --tdd must work together with --watch, not be
 /// rejected outright. This is the proving test the issue's own acceptance criteria
-/// describe: cycle 1 (a test calls a not-yet-implemented procedure) reports the
-/// synthetic FAILED test #1997 already builds for a one-shot --tdd run; a LATER
-/// cycle, after the missing procedure is implemented and the file saved — WITHOUT
-/// restarting the watch process — reports the same test PASSED.
+/// describe: cycle 1 (a test calls a not-yet-implemented procedure) reports FAILED;
+/// a LATER cycle, after the missing procedure is implemented and the file saved —
+/// WITHOUT restarting the watch process — reports the same test PASSED.
 ///
-/// The mechanism that makes this correct is entirely pre-existing (see Program.cs's
-/// updated comment at the former "if (tddMode && watchMode)" rejection site, and
-/// BcCompiler.Incremental.cs's TryEmitIncremental doc comment): BcCompiler.Emit only
-/// records a RAD baseline on a CLEAN compile (nothing excluded). A --tdd cycle that
-/// excludes an object for a missing symbol therefore never records one, which forces
-/// every cycle up to and including the one that resolves the missing symbol through
-/// TryEmitIncremental's "no incremental baseline yet" fallback into the SAME full
-/// Emit() retry loop a one-shot --tdd run already uses. Nothing had to learn to carry
-/// TDD diagnostics through BC's CreateForRad — this test proves that mechanism holds
-/// end to end through a real --watch subprocess, not just by reading the code.
+/// Written and first verified against #2000's refuse-only --tdd (every missing
+/// symbol reported failed, nothing generated). #2005 landed member GENERATION while
+/// this PR was in flight (--tdd now infers and generates a stub for a resolvable
+/// missing symbol, per #2001) — rebasing onto it changed the fixture's behaviour, so
+/// this file was reworked. Two things are worth recording because they are not what
+/// the PR's own original design comment predicted:
 ///
-/// Also proves the corollary from the issue's requirement 3: the console must say
-/// WHY the cycle was slower under --tdd, not just that it was — the fallback reason
-/// on cycle 2 must be --tdd-specific, not the generic "previous cycle fell back" text
-/// a non-tdd watch session would show for the exact same "no baseline yet" shape.
+/// 1. DoubleIt (this fixture's originally-missing procedure) is now a RESOLVABLE case
+///    per #2001's inference rules: --tdd generates a stub for it rather than excluding
+///    it. Cycle 1 therefore reports FAILED via Program.cs's OverrideTddDependentResults
+///    ("this test depends on N generated member(s)..."), not TddSupport's refuse-path
+///    message — and, because the module then compiles CLEAN (nothing excluded),
+///    BcCompiler.Emit's RecordIncrementalBaseline (gated on `excludedObjects.Count ==
+///    0`) actually records a baseline after cycle 1. That's fine for the underlying
+///    safety argument (a baseline recorded from a generated compile is superseded
+///    object-by-object the moment the real file content differs — see
+///    BcCompiler.Incremental.cs's own "unmodified caller" guarantee), but it means a
+///    single-scenario version of this test can no longer reliably demonstrate the
+///    --tdd-specific "no incremental baseline yet" fallback-reason text this PR adds:
+///    with a baseline present, TryEmitIncremental actually ATTEMPTS BC's CreateForRad
+///    on cycle 2 — and that attempt independently fails for a reason unrelated to
+///    --tdd entirely (any bundle with real MS-app dependencies, tdd or not, currently
+///    falls back here — see issue #2009, filed from this investigation).
+/// 2. TddWatchRefusedTests.Codeunit.al (added alongside the original fixture) closes
+///    that gap cleanly: its bare-statement call to DoThing has no type anchor, so
+///    --tdd's generation REFUSES it (TddGeneration.cs) rather than guessing, and that
+///    object is excluded from EVERY compile — DoThing is deliberately never
+///    implemented anywhere in this fixture. A permanently-excluded object keeps the
+///    WHOLE MODULE's `excludedObjects.Count > 0` on every single cycle, so
+///    RecordIncrementalBaseline never runs at all, for this bundle, ever — meaning
+///    TryEmitIncremental short-circuits at its very first check ("no incremental
+///    baseline yet") on EVERY cycle, including cycle 2, without ever reaching
+///    CreateForRad and without the #2009 confound. That is what lets this test assert
+///    the --tdd-specific fallback-reason text this PR actually adds, cleanly.
 ///
 /// Spawns the real runner; needs the BC artifact cache. Skips (no-op) when absent.
 /// See DefineFlagIntegrationTests for why runner-subprocess tests used to be
@@ -96,19 +114,19 @@ public class TddWatchTests
 
         string Segment(int from, int to) { lock (lines) return WatchOutputSlicing.MergedJoin(lines, from, to); }
 
-        // Cross-stream diagnostics ("TDD-EXCLUDED", "FULL REBUILD") are written to
-        // STDERR by an INDEPENDENT pump task from the one that positions the stdout
-        // "waiting for source" markers — `lines`' overall order is pump-SCHEDULING
-        // order, not cross-stream WRITE order (see WatchOutputSlicing.cs's header,
-        // #1843). WatchTests.cs already hit this for its own stderr timing diagnostic
-        // and works around it by polling for an ABSOLUTE occurrence on the unbounded
+        // Cross-stream diagnostics ("FULL REBUILD") are written to STDERR by an
+        // INDEPENDENT pump task from the one that positions the stdout "waiting for
+        // source" markers — `lines`' overall order is pump-SCHEDULING order, not
+        // cross-stream WRITE order (see WatchOutputSlicing.cs's header, #1843).
+        // WatchTests.cs already hit this for its own stderr timing diagnostic and
+        // works around it by polling for an ABSOLUTE occurrence on the unbounded
         // stderr stream instead of reading a stdout-bounded window snapshot — do the
         // same here rather than trusting Segment(...) to contain a stderr line just
         // because it printed between the same two stdout markers in wall-clock time.
-        // This fixture is deliberately tiny (one codeunit + a placeholder) so BOTH
-        // cycles are fast, which — unlike the larger, slower fixture
-        // WatchFullRebuildReasonTests uses — leaves little natural separation between
-        // a cycle's own stderr diagnostic and its neighbouring stdout markers.
+        // This fixture's cycles are fast (small module), which — unlike the larger
+        // fixture WatchFullRebuildReasonTests uses — leaves little natural
+        // separation between a cycle's own stderr diagnostic and its neighbouring
+        // stdout markers.
         async Task WaitForStderrContains(string needle, TimeSpan timeout)
         {
             var deadline = DateTime.UtcNow + timeout;
@@ -134,31 +152,29 @@ public class TddWatchTests
 
         try
         {
-            // Cycle 1 (cold, process start): the test calls DoubleIt, which "Tdd Watch
-            // Target Cu" does not declare yet — this must report FAILED, naming DoubleIt,
-            // via the SAME TDD-EXCLUDED synthetic-test mechanism a one-shot --tdd run
-            // uses (#1997), not a generic EMIT-EXCLUDED compile failure. The FAIL line
-            // and the missing-symbol name both come from Reporter.PrintPerTest on
-            // STDOUT (the synthetic TestResult's own Message), so they are safe to
-            // assert on the stdout-bounded window; "TDD-EXCLUDED" itself is a stderr
-            // diagnostic, checked separately below via WaitForStderrContains.
+            // Cycle 1 (cold, process start): DoubleIt is resolvable, so --tdd
+            // generates a stub for it — the test compiles and RUNS against that
+            // stub, force-reported FAILED naming the generated member.
+            // BareStatementCall_RefusesNotGuesses (a SIBLING object, DoThing) is not
+            // resolvable at all — --tdd refuses to guess, that object is excluded,
+            // and its test is reported FAILED via TddSupport's original (#2000)
+            // refuse-path message. Both come from Reporter.PrintPerTest on stdout.
             int m1 = await WaitForMarkerAfter(0, TimeSpan.FromSeconds(150));
             var cycle1 = Segment(0, m1);
             Assert.Contains("FAIL ", cycle1);
             Assert.Contains("MissingProcedure_ReportsFailedThenPasses", cycle1);
             Assert.Contains("DoubleIt", cycle1);
-
-            await WaitForStderrContains("TDD-EXCLUDED", TimeSpan.FromSeconds(10));
-            // Cycle 0 always falls back to a full compile (no baseline exists yet for
-            // ANY reason, tdd or not), so "FULL REBUILD" must NOT appear for it — see
-            // WatchFullRebuildReasonTests for the same "cycle 0 is quiet" claim.
-            string stderrAfterCycle1; lock (lines) stderrAfterCycle1 = WatchOutputSlicing.StderrText(lines);
-            Assert.DoesNotContain("FULL REBUILD", stderrAfterCycle1);
+            Assert.Contains("depends on", cycle1); // OverrideTddDependentResults' message shape
+            Assert.Contains("BareStatementCall_RefusesNotGuesses", cycle1);
+            Assert.Contains("DoThing", cycle1);
+            Assert.Contains("did not compile", cycle1); // TddSupport.BuildFailedTests' message shape
 
             // Implement DoubleIt IN PLACE — the same file, same process, no restart.
             // Insert the new procedure just before the codeunit's final closing brace
             // (rather than a string-replace over the existing procedure body, which
-            // would be fragile against line-ending differences on disk).
+            // would be fragile against line-ending differences on disk). DoThing is
+            // deliberately left unimplemented — see this class's doc comment for why
+            // that permanent exclusion is exactly what this test needs.
             var original = await File.ReadAllTextAsync(targetCuPath);
             var lastBrace = original.LastIndexOf('}');
             Assert.True(lastBrace >= 0, $"fixture has no closing brace to insert before:\n{original}");
@@ -168,25 +184,29 @@ public class TddWatchTests
             Assert.NotEqual(original, edited);
             await File.WriteAllTextAsync(targetCuPath, edited);
 
-            // Cycle 2: the module now compiles clean (nothing excluded), so the test
-            // actually RUNS this time and must report PASSED — proving the synthetic
-            // failure from cycle 1 was not some permanently-cached verdict that a
-            // real fix can never overturn.
+            // Cycle 2: DoubleIt's test now compiles against the REAL implementation
+            // (no generated member involved at all) and must report PASSED — proving
+            // the FAILED verdict from cycle 1 was not some permanently-cached verdict
+            // a real fix can never overturn. DoThing's test is STILL excluded (never
+            // implemented) and must still report FAILED the same way.
             int m2 = await WaitForMarkerAfter(m1 + 1, TimeSpan.FromSeconds(240));
             var cycle2 = Segment(m1 + 1, m2);
             Assert.Contains("PASS", cycle2);
             Assert.Contains("MissingProcedure_ReportsFailedThenPasses", cycle2);
-            Assert.DoesNotContain("FAIL ", cycle2);
+            Assert.Contains("BareStatementCall_RefusesNotGuesses", cycle2);
+            Assert.Contains("DoThing", cycle2);
+            Assert.Contains("did not compile", cycle2);
 
-            // No baseline was ever recorded after cycle 1 (an excluded object skips
-            // RecordIncrementalBaseline entirely — see BcCompiler.cs), so this cycle
-            // MUST fall back to a full rebuild too, and — since watchCycleIndex > 0
+            // Requirement 3's "tell the user why" claim, proven end to end: this
+            // cycle falls back to a full rebuild, and — since watchCycleIndex > 0
             // here — that fallback IS reported, with the --tdd-specific reason text
-            // (not the generic one a non-tdd watch session would show for the exact
-            // same "no baseline yet" shape). This is requirement 3's "tell the user
-            // WHY" claim, proven end to end. Both are stderr diagnostics — checked via
-            // WaitForStderrContains, not the stdout-bounded cycle2 window, for the
-            // same cross-stream-ordering reason as cycle 1's TDD-EXCLUDED check above.
+            // this PR adds (not the generic one a non-tdd watch session would show
+            // for the exact same "no baseline yet" shape). Reachable cleanly here
+            // because DoThing's permanent exclusion keeps a baseline from EVER being
+            // recorded for this bundle — see this class's doc comment. Checked via
+            // the unbounded stderr poll above, not the stdout-bounded cycle2 window,
+            // for the same cross-stream-ordering reason as every stderr assertion in
+            // this file.
             await WaitForStderrContains("FULL REBUILD", TimeSpan.FromSeconds(10));
             await WaitForStderrContains("--tdd reported", TimeSpan.FromSeconds(10));
         }

--- a/AlRunner.Tests/TddWatchTests.cs
+++ b/AlRunner.Tests/TddWatchTests.cs
@@ -96,22 +96,64 @@ public class TddWatchTests
 
         string Segment(int from, int to) { lock (lines) return WatchOutputSlicing.MergedJoin(lines, from, to); }
 
+        // Cross-stream diagnostics ("TDD-EXCLUDED", "FULL REBUILD") are written to
+        // STDERR by an INDEPENDENT pump task from the one that positions the stdout
+        // "waiting for source" markers — `lines`' overall order is pump-SCHEDULING
+        // order, not cross-stream WRITE order (see WatchOutputSlicing.cs's header,
+        // #1843). WatchTests.cs already hit this for its own stderr timing diagnostic
+        // and works around it by polling for an ABSOLUTE occurrence on the unbounded
+        // stderr stream instead of reading a stdout-bounded window snapshot — do the
+        // same here rather than trusting Segment(...) to contain a stderr line just
+        // because it printed between the same two stdout markers in wall-clock time.
+        // This fixture is deliberately tiny (one codeunit + a placeholder) so BOTH
+        // cycles are fast, which — unlike the larger, slower fixture
+        // WatchFullRebuildReasonTests uses — leaves little natural separation between
+        // a cycle's own stderr diagnostic and its neighbouring stdout markers.
+        async Task WaitForStderrContains(string needle, TimeSpan timeout)
+        {
+            var deadline = DateTime.UtcNow + timeout;
+            while (DateTime.UtcNow < deadline)
+            {
+                string text; lock (lines) text = WatchOutputSlicing.StderrText(lines);
+                if (text.Contains(needle, StringComparison.Ordinal)) return;
+                if (p.HasExited)
+                {
+                    await Task.Delay(500);
+                    lock (lines) text = WatchOutputSlicing.StderrText(lines);
+                    throw new TimeoutException(
+                        $"stderr never contained \"{needle}\" — subprocess exited early " +
+                        $"({ProcessLiveness()}).\n--- stderr ---\n{text}");
+                }
+                await Task.Delay(200);
+            }
+            string dump; lock (lines) dump = WatchOutputSlicing.StderrText(lines);
+            throw new TimeoutException(
+                $"stderr never contained \"{needle}\" after {timeout.TotalSeconds}s. " +
+                $"{ProcessLiveness()}\n--- stderr ---\n{dump}");
+        }
+
         try
         {
             // Cycle 1 (cold, process start): the test calls DoubleIt, which "Tdd Watch
             // Target Cu" does not declare yet — this must report FAILED, naming DoubleIt,
             // via the SAME TDD-EXCLUDED synthetic-test mechanism a one-shot --tdd run
-            // uses (#1997), not a generic EMIT-EXCLUDED compile failure. Cycle 0 always
-            // falls back to a full compile (no baseline exists yet for ANY reason, tdd
-            // or not) so "FULL REBUILD" must NOT appear here — see
-            // WatchFullRebuildReasonTests for the same "cycle 0 is quiet" claim.
+            // uses (#1997), not a generic EMIT-EXCLUDED compile failure. The FAIL line
+            // and the missing-symbol name both come from Reporter.PrintPerTest on
+            // STDOUT (the synthetic TestResult's own Message), so they are safe to
+            // assert on the stdout-bounded window; "TDD-EXCLUDED" itself is a stderr
+            // diagnostic, checked separately below via WaitForStderrContains.
             int m1 = await WaitForMarkerAfter(0, TimeSpan.FromSeconds(150));
             var cycle1 = Segment(0, m1);
-            Assert.Contains("TDD-EXCLUDED", cycle1);
             Assert.Contains("FAIL ", cycle1);
             Assert.Contains("MissingProcedure_ReportsFailedThenPasses", cycle1);
             Assert.Contains("DoubleIt", cycle1);
-            Assert.DoesNotContain("FULL REBUILD", cycle1);
+
+            await WaitForStderrContains("TDD-EXCLUDED", TimeSpan.FromSeconds(10));
+            // Cycle 0 always falls back to a full compile (no baseline exists yet for
+            // ANY reason, tdd or not), so "FULL REBUILD" must NOT appear for it — see
+            // WatchFullRebuildReasonTests for the same "cycle 0 is quiet" claim.
+            string stderrAfterCycle1; lock (lines) stderrAfterCycle1 = WatchOutputSlicing.StderrText(lines);
+            Assert.DoesNotContain("FULL REBUILD", stderrAfterCycle1);
 
             // Implement DoubleIt IN PLACE — the same file, same process, no restart.
             // Insert the new procedure just before the codeunit's final closing brace
@@ -130,22 +172,23 @@ public class TddWatchTests
             // actually RUNS this time and must report PASSED — proving the synthetic
             // failure from cycle 1 was not some permanently-cached verdict that a
             // real fix can never overturn.
-            //
+            int m2 = await WaitForMarkerAfter(m1 + 1, TimeSpan.FromSeconds(240));
+            var cycle2 = Segment(m1 + 1, m2);
+            Assert.Contains("PASS", cycle2);
+            Assert.Contains("MissingProcedure_ReportsFailedThenPasses", cycle2);
+            Assert.DoesNotContain("FAIL ", cycle2);
+
             // No baseline was ever recorded after cycle 1 (an excluded object skips
             // RecordIncrementalBaseline entirely — see BcCompiler.cs), so this cycle
             // MUST fall back to a full rebuild too, and — since watchCycleIndex > 0
             // here — that fallback IS reported, with the --tdd-specific reason text
             // (not the generic one a non-tdd watch session would show for the exact
             // same "no baseline yet" shape). This is requirement 3's "tell the user
-            // WHY" claim, proven end to end.
-            int m2 = await WaitForMarkerAfter(m1 + 1, TimeSpan.FromSeconds(240));
-            var cycle2 = Segment(m1 + 1, m2);
-            Assert.Contains("PASS", cycle2);
-            Assert.Contains("MissingProcedure_ReportsFailedThenPasses", cycle2);
-            Assert.DoesNotContain("FAIL ", cycle2);
-            Assert.DoesNotContain("TDD-EXCLUDED", cycle2);
-            Assert.Contains("FULL REBUILD", cycle2);
-            Assert.Contains("--tdd reported", cycle2);
+            // WHY" claim, proven end to end. Both are stderr diagnostics — checked via
+            // WaitForStderrContains, not the stdout-bounded cycle2 window, for the
+            // same cross-stream-ordering reason as cycle 1's TDD-EXCLUDED check above.
+            await WaitForStderrContains("FULL REBUILD", TimeSpan.FromSeconds(10));
+            await WaitForStderrContains("--tdd reported", TimeSpan.FromSeconds(10));
         }
         finally
         {

--- a/AlRunner.Tests/TddWatchTests.cs
+++ b/AlRunner.Tests/TddWatchTests.cs
@@ -1,0 +1,155 @@
+using System.Diagnostics;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// Issue #2002 (follow-up to #1997): --tdd must work together with --watch, not be
+/// rejected outright. This is the proving test the issue's own acceptance criteria
+/// describe: cycle 1 (a test calls a not-yet-implemented procedure) reports the
+/// synthetic FAILED test #1997 already builds for a one-shot --tdd run; a LATER
+/// cycle, after the missing procedure is implemented and the file saved — WITHOUT
+/// restarting the watch process — reports the same test PASSED.
+///
+/// The mechanism that makes this correct is entirely pre-existing (see Program.cs's
+/// updated comment at the former "if (tddMode && watchMode)" rejection site, and
+/// BcCompiler.Incremental.cs's TryEmitIncremental doc comment): BcCompiler.Emit only
+/// records a RAD baseline on a CLEAN compile (nothing excluded). A --tdd cycle that
+/// excludes an object for a missing symbol therefore never records one, which forces
+/// every cycle up to and including the one that resolves the missing symbol through
+/// TryEmitIncremental's "no incremental baseline yet" fallback into the SAME full
+/// Emit() retry loop a one-shot --tdd run already uses. Nothing had to learn to carry
+/// TDD diagnostics through BC's CreateForRad — this test proves that mechanism holds
+/// end to end through a real --watch subprocess, not just by reading the code.
+///
+/// Also proves the corollary from the issue's requirement 3: the console must say
+/// WHY the cycle was slower under --tdd, not just that it was — the fallback reason
+/// on cycle 2 must be --tdd-specific, not the generic "previous cycle fell back" text
+/// a non-tdd watch session would show for the exact same "no baseline yet" shape.
+///
+/// Spawns the real runner; needs the BC artifact cache. Skips (no-op) when absent.
+/// See DefineFlagIntegrationTests for why runner-subprocess tests used to be
+/// [Collection("server-serial")] and no longer are — #1809.
+/// </summary>
+public class TddWatchTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+    private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
+    private static readonly string FixtureSrc = Path.GetFullPath(Path.Combine(
+        AppContext.BaseDirectory, "..", "..", "..", "Fixtures", "TddWatch"));
+
+    [SkippableFact]
+    public async Task TddWatch_MissingSymbol_ReportsFailedThenPasses_WithoutRestart()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var bundle = Path.Combine(Path.GetTempPath(), "al-runner-tdd-watch", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(bundle);
+        foreach (var f in Directory.GetFiles(FixtureSrc))
+            File.Copy(f, Path.Combine(bundle, Path.GetFileName(f)));
+        var targetCuPath = Path.Combine(bundle, "TddWatchTargetCu.Codeunit.al");
+        var cacheDir = Path.Combine(bundle, ".cache");
+
+        var lines = new List<CapturedLine>();
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            Arguments = TestBuildConfig.RunArgs(ProjectPath) + TestBuildConfig.BcVersionArg
+                + $" \"{bundle}\" --tdd --watch --cache \"{cacheDir}\"",
+            RedirectStandardOutput = true, RedirectStandardError = true,
+            UseShellExecute = false, CreateNoWindow = true, WorkingDirectory = RepoRoot,
+        };
+        using var p = Process.Start(psi)!;
+        void Pump(StreamReader r, OutputStream stream) => Task.Run(async () =>
+        {
+            string? l;
+            while ((l = await r.ReadLineAsync()) != null) lock (lines) lines.Add(new CapturedLine(stream, l));
+        });
+        Pump(p.StandardOutput, OutputStream.Stdout);
+        Pump(p.StandardError, OutputStream.Stderr);
+
+        string ProcessLiveness() =>
+            p.HasExited ? $"process alive=false exit={p.ExitCode}" : "process alive=true";
+        string DumpTail() { lock (lines) return string.Join("\n", lines.TakeLast(60).Select(l => $"[{l.Stream}] {l.Text}")); }
+
+        async Task<int> WaitForMarkerAfter(int fromIndex, TimeSpan timeout)
+        {
+            var deadline = DateTime.UtcNow + timeout;
+            while (DateTime.UtcNow < deadline)
+            {
+                List<int> found;
+                lock (lines)
+                    found = WatchOutputSlicing.FindStdoutMarkerIndices(lines, WatchOutputSlicing.WaitingForSourceMarker, fromIndex);
+                if (found.Count > 0) return found[0];
+                if (p.HasExited)
+                {
+                    await Task.Delay(500);
+                    throw new TimeoutException(
+                        $"watch marker not seen — subprocess exited early ({ProcessLiveness()}).\n--- last output ---\n{DumpTail()}");
+                }
+                await Task.Delay(200);
+            }
+            if (p.HasExited) await Task.Delay(500);
+            throw new TimeoutException($"watch marker not seen. {ProcessLiveness()}\n--- last output ---\n{DumpTail()}");
+        }
+
+        string Segment(int from, int to) { lock (lines) return WatchOutputSlicing.MergedJoin(lines, from, to); }
+
+        try
+        {
+            // Cycle 1 (cold, process start): the test calls DoubleIt, which "Tdd Watch
+            // Target Cu" does not declare yet — this must report FAILED, naming DoubleIt,
+            // via the SAME TDD-EXCLUDED synthetic-test mechanism a one-shot --tdd run
+            // uses (#1997), not a generic EMIT-EXCLUDED compile failure. Cycle 0 always
+            // falls back to a full compile (no baseline exists yet for ANY reason, tdd
+            // or not) so "FULL REBUILD" must NOT appear here — see
+            // WatchFullRebuildReasonTests for the same "cycle 0 is quiet" claim.
+            int m1 = await WaitForMarkerAfter(0, TimeSpan.FromSeconds(150));
+            var cycle1 = Segment(0, m1);
+            Assert.Contains("TDD-EXCLUDED", cycle1);
+            Assert.Contains("FAIL ", cycle1);
+            Assert.Contains("MissingProcedure_ReportsFailedThenPasses", cycle1);
+            Assert.Contains("DoubleIt", cycle1);
+            Assert.DoesNotContain("FULL REBUILD", cycle1);
+
+            // Implement DoubleIt IN PLACE — the same file, same process, no restart.
+            // Insert the new procedure just before the codeunit's final closing brace
+            // (rather than a string-replace over the existing procedure body, which
+            // would be fragile against line-ending differences on disk).
+            var original = await File.ReadAllTextAsync(targetCuPath);
+            var lastBrace = original.LastIndexOf('}');
+            Assert.True(lastBrace >= 0, $"fixture has no closing brace to insert before:\n{original}");
+            var edited = original[..lastBrace]
+                + "\n    procedure DoubleIt(X: Integer): Integer\n    begin\n        exit(X * 2);\n    end;\n"
+                + original[lastBrace..];
+            Assert.NotEqual(original, edited);
+            await File.WriteAllTextAsync(targetCuPath, edited);
+
+            // Cycle 2: the module now compiles clean (nothing excluded), so the test
+            // actually RUNS this time and must report PASSED — proving the synthetic
+            // failure from cycle 1 was not some permanently-cached verdict that a
+            // real fix can never overturn.
+            //
+            // No baseline was ever recorded after cycle 1 (an excluded object skips
+            // RecordIncrementalBaseline entirely — see BcCompiler.cs), so this cycle
+            // MUST fall back to a full rebuild too, and — since watchCycleIndex > 0
+            // here — that fallback IS reported, with the --tdd-specific reason text
+            // (not the generic one a non-tdd watch session would show for the exact
+            // same "no baseline yet" shape). This is requirement 3's "tell the user
+            // WHY" claim, proven end to end.
+            int m2 = await WaitForMarkerAfter(m1 + 1, TimeSpan.FromSeconds(240));
+            var cycle2 = Segment(m1 + 1, m2);
+            Assert.Contains("PASS", cycle2);
+            Assert.Contains("MissingProcedure_ReportsFailedThenPasses", cycle2);
+            Assert.DoesNotContain("FAIL ", cycle2);
+            Assert.DoesNotContain("TDD-EXCLUDED", cycle2);
+            Assert.Contains("FULL REBUILD", cycle2);
+            Assert.Contains("--tdd reported", cycle2);
+        }
+        finally
+        {
+            try { p.Kill(true); } catch { }
+        }
+    }
+}

--- a/AlRunner/BcCompiler.Incremental.cs
+++ b/AlRunner/BcCompiler.Incremental.cs
@@ -321,7 +321,20 @@ public sealed partial class BcCompiler
         fallbackReason = "";
         if (!_radBaselines.TryGetValue(moduleName, out var baseline))
         {
-            fallbackReason = "no incremental baseline yet for this bundle (first --watch cycle, or the previous cycle fell back)";
+            // #2002: under --tdd, RecordIncrementalBaseline (called from Emit, below) is
+            // deliberately skipped whenever the cycle excluded an object for referencing a
+            // missing symbol — a baseline built while an object is missing would let a LATER
+            // incremental cycle silently treat it as "still there". That means the cycle
+            // where a --tdd exclusion happens, AND every cycle after it up to and including
+            // the one that finally implements the missing symbol, all land here. Name that
+            // explicitly instead of the generic reason, so the console explains WHY (see
+            // #1994's precedent for surfacing full-rebuild causes at default verbosity).
+            fallbackReason = _tddMode
+                ? "no incremental baseline yet for this bundle (first --watch cycle, or --tdd reported " +
+                  "a synthetic FAILED test for a missing symbol on a previous cycle — a baseline is only " +
+                  "recorded on a clean compile with nothing excluded, so cycles stay a full rebuild until " +
+                  "the missing symbol is implemented and the module compiles clean again)"
+                : "no incremental baseline yet for this bundle (first --watch cycle, or the previous cycle fell back)";
             return null;
         }
 

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -377,21 +377,34 @@ if (serverMode && watchMode)
 }
 // --tdd (issue #1997) only changes the bundled-mode CLI run loop's EMIT-EXCLUDED
 // handling (Program.cs, below). --server has its own, separate EMIT-EXCLUDED guard
-// (a different Emit() call site) that this issue's reduced scope does not touch, and
-// --watch's incremental (RAD) recompile path does not carry per-excluded-object
-// diagnostics through to a synthetic TestResult either. Rejecting both explicitly beats
-// silently ignoring the flag — a --tdd run that quietly behaved like a normal run under
-// --server/--watch would be far more confusing than an upfront error naming the gap.
+// (a different Emit() call site) that this issue's reduced scope does not touch, so
+// --tdd + --server stays rejected. Rejecting explicitly beats silently ignoring the
+// flag — a --tdd run that quietly behaved like a normal run under --server would be
+// far more confusing than an upfront error naming the gap.
 if (tddMode && serverMode)
 {
     Console.Error.WriteLine("--tdd is not supported together with --server yet (local-development flag; --server's EMIT-EXCLUDED handling is a separate code path this hasn't reached). Run --tdd from the CLI directly.");
     return 2;
 }
-if (tddMode && watchMode)
-{
-    Console.Error.WriteLine("--tdd is not supported together with --watch yet (the incremental/RAD recompile path doesn't carry per-excluded-object diagnostics). Run --tdd without --watch.");
-    return 2;
-}
+// --tdd + --watch (issue #2002, follow-up to #1997): NOT rejected. --watch's
+// incremental (RAD) recompile path (BcCompiler.TryEmitIncremental) genuinely does not
+// carry per-excluded-object diagnostics through to a synthetic TestResult — but it
+// does not need to, because of how BcCompiler.Emit's own baseline bookkeeping already
+// behaves: RecordIncrementalBaseline (the thing that lets TryEmitIncremental take the
+// fast path AT ALL) is only ever called when a cycle's Emit was a CLEAN success —
+// caught == null && excludedObjects.Count == 0 — see BcCompiler.cs. Under --tdd, a
+// cycle that excludes an object for referencing a missing symbol therefore NEVER
+// records a baseline, which forces every cycle downstream of it (including the one
+// where the missing symbol finally gets implemented) through TryEmitIncremental's own
+// "no incremental baseline yet" fallback into the ordinary full Emit() — the SAME
+// full-emit-retry loop that already builds TddExcludedObjectDetail and reports
+// synthetic FAILED tests regardless of watchMode. So the option 2 the issue's own
+// text proposes ("fall back to a full re-emit whenever a symbol is still missing,
+// revert to incremental once resolved") falls out of the EXISTING guard for free —
+// nothing here had to learn to carry TDD diagnostics through CreateForRad. See
+// TryEmitIncremental's own tdd-specific fallback-reason text for what a developer
+// actually sees on the console when this happens (issue #1994 precedent).
+
 // --tdd forces the AL-output cache off (same effect as --no-cache), on top of the
 // tdd:<0|1> cache-key line added above. The line alone stops a --tdd run from ever
 // SERVING a normal-mode DLL or vice versa (criterion 11) — but it does not make a
@@ -3962,8 +3975,11 @@ static void PrintHelp(TextWriter w)
     w.WriteLine("                          every object that DID compile and reports each [Test]");
     w.WriteLine("                          procedure in an object that could NOT be recovered as a");
     w.WriteLine("                          FAILED test naming the missing symbol, so a red-green TDD");
-    w.WriteLine("                          cycle can start with an honestly red test (exit 1). Not");
-    w.WriteLine("                          yet supported together with --watch or --server.");
+    w.WriteLine("                          cycle can start with an honestly red test (exit 1). Works");
+    w.WriteLine("                          together with --watch (a cycle with a missing symbol falls");
+    w.WriteLine("                          back to a full rebuild instead of the fast incremental");
+    w.WriteLine("                          path — the console names the reason). Not yet supported");
+    w.WriteLine("                          together with --server.");
     w.WriteLine("  --per-suite             Legacy per-Compilation path. Default is bundled mode");
     w.WriteLine("                          (5-7x faster, parity-verified).");
     w.WriteLine("  --bundled               No-op alias for the default bundled mode (deprecated).");


### PR DESCRIPTION
Closes #2002

## What this does

Removes the CLI-level rejection of `--tdd` combined with `--watch`. `--tdd` now works under `--watch`.

## What I found in the RAD path

`BcCompiler.Emit`'s emit-retry loop (the thing that builds `TddExcludedObjectDetail` under `--tdd`) is completely independent of watch mode — it runs the same way whether `Emit` was called directly or as `TryEmitIncremental`'s fallback. The mechanism that makes combining `--tdd` with `--watch` safe already existed, unused for this purpose: `RecordIncrementalBaseline` (the thing that lets `TryEmitIncremental` take the fast path at all on a *later* cycle) is only ever called when a cycle's `Emit` was a **clean** success — `caught == null && excludedObjects.Count == 0`. So a `--tdd` cycle that excludes an object (a missing symbol `--tdd`'s generation can't confidently infer — see below) never records a RAD baseline, which forces every subsequent cycle through `TryEmitIncremental`'s own `"no incremental baseline yet"` fallback into the ordinary full `Emit()` — exactly where the `--tdd` synthetic-result machinery lives. Nothing had to change in `BcCompiler.Incremental.cs`'s classification/merge logic; I only removed the CLI rejection and improved the fallback-reason message.

**This PR was rebased mid-flight onto #2005** (`--tdd` member generation, merged while this PR was open), which changed the picture in a way worth being explicit about:

- A **resolvable** missing symbol (e.g. a missing procedure with an inferable signature) is no longer excluded at all under `--tdd` — #2005 generates a stub for it, and the module compiles clean. That means `RecordIncrementalBaseline` *does* fire after such a cycle. This is still safe (an unmodified caller's cached C# is unaffected by a callee's shape changing per `BcCompiler.Incremental.cs`'s own documented guarantee, and a file that gets a real edit is always re-parsed from disk, never from a stale generated tree) — but it means the "no baseline recorded while a symbol is missing" argument doesn't apply to this case on its own.
- An **unresolvable** missing symbol (no type anchor — `--tdd`'s generation refuses rather than guesses) still goes through the original exclude-and-retry path, so the "never records a baseline while excluded" argument holds exactly as designed.

## A pre-existing, unrelated gap I found along the way

While verifying the resolvable (generation) case end-to-end, cycle 2 fell back to a full rebuild for a reason that turned out to have nothing to do with `--tdd`: **any bundle with real MS-app dependencies (System Application, Base Application, etc. — the normal shape for a realistic AL app) currently fails inside `CreateForRad` itself** ("A package with publisher 'Microsoft', name '...', ... could not be loaded") and falls back to a full rebuild, every single cycle, **with or without `--tdd`** — I reproduced it identically on a plain `--watch` session with the same fixture shape. Filed as #2009, with a full repro and a plausible explanation for why `WatchTests.cs`/`WatchFullRebuildReasonTests.cs` haven't already caught it (their assertions don't actually distinguish "RAD's fast path succeeded" from "RAD fell back, but the fallback happens to be fast because `GetSharedReferences` is separately memoized"). Not this issue's to fix — out of scope for `--tdd`.

## Why it's slower, surfaced

Per issue #1994's precedent, a `--watch` cycle that falls back to a full rebuild must say why, at default verbosity. `TryEmitIncremental`'s "no baseline yet" fallback now gives a `--tdd`-specific reason when `_tddMode` is on, naming the actual mechanism (a prior cycle's synthetic failure meant no baseline was ever recorded) instead of the generic message a non-`--tdd` session would show for the same shape. This reason is reachable and asserted end-to-end by the proving test's "refused" scenario (see below); the "resolved via generation" scenario currently surfaces #2009's pre-existing, differently-worded reason instead — both are on the console at default verbosity either way, so the user is never left to wonder why, just not always via my new `--tdd`-specific string yet.

`--help` and `PrintHelp` are updated to reflect that `--tdd` now works with `--watch` (still rejected with `--server` — a different `Emit()` call site this issue's scope doesn't touch).

## Tests (RED → GREEN)

`AlRunner.Tests/TddWatchTests.cs` + fixture `AlRunner.Tests/Fixtures/TddWatch/` spawns a real `--tdd --watch` subprocess with two sibling test codeunits:
- `TddWatchTests.Codeunit.al` calls a **resolvable** missing procedure (`DoubleIt`) — cycle 1 reports it FAILED via `--tdd`'s generation path ("depends on N generated member(s)..."); after editing the implementing codeunit in place (no process restart) to add the real procedure, the next cycle reports the same test PASSED.
- `TddWatchTests/Fixtures/TddWatch/TddWatchRefusedTests.Codeunit.al` calls a bare-statement procedure with no type anchor (`DoThing`, deliberately never implemented) — `--tdd`'s generation refuses to guess, so this object is excluded from *every* compile, permanently. That permanent exclusion keeps a RAD baseline from ever being recorded for the whole bundle, so `TryEmitIncremental` short-circuits at its "no baseline" check on *every* cycle — cleanly reaching (and letting the test assert) the `--tdd`-specific fallback-reason text this PR actually adds, without #2009's confound.

Verified RED against the pre-fix code (temporarily swapped `Program.cs`/`BcCompiler.Incremental.cs` back to their pre-#2002 content): the subprocess exits 2 with the old rejection message. GREEN after restoring the fix, 4/4 repeat runs stable (~25s each) with no flake.

`AlRunner.Tests/TddModeTests.cs`: removed `Tdd_RejectedTogetherWithWatch` (the now-stale rejection test), per the issue's own acceptance criteria. `Tdd_RejectedTogetherWithServer` is unchanged — `--tdd` + `--server` is still rejected.

Ran locally (BC artifact cache present):
- `TddWatchTests`, `TddModeTests`, `WatchFullRebuildReasonTests`, `WatchTests`, `EmitExclusionLoudnessTests`, `BundleSuiteErrorLoudnessTests`, `CliDocumentationTests` — all pass.
- Full `dotnet test AlRunner.Tests` — 818 passed, 0 failed, 54 pre-existing skips unrelated to this change.

## Related

- #2009 — the pre-existing, `--tdd`-unrelated RAD/dependency-loading gap found during this investigation.