### PR TITLE
fix(release): build before write, and stop pinning a BC build MS can withdraw

### DIFF
--- a/.github/workflows/bc-tests.yml
+++ b/.github/workflows/bc-tests.yml
@@ -30,6 +30,18 @@ on:
         type: string
         required: false
         default: ''
+    outputs:
+      required-version:
+        description: >-
+          The live-resolved 28.1.* build this run actually tested (resolve-versions'
+          `required-version`, see below). publish.yml's release job reads this instead
+          of carrying its own static _BCVersion pin — see #2010: a hardcoded pin in the
+          one path nobody exercises except during a release rotted the moment Microsoft
+          withdrew the build it named, and the release failed AFTER the tag was already
+          pushed. Handing the caller the exact version THIS run resolved and gated on
+          means the release can never build against a version different from — or
+          staler than — the one that just passed the matrix.
+        value: ${{ jobs.resolve-versions.outputs.required-version }}
 
 env:
   DOTNET_NOLOGO: true
@@ -489,3 +501,53 @@ jobs:
             exit 1
           fi
 
+  pack:
+    name: Release pack (dry, no publish)
+    needs: resolve-versions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref }}
+          submodules: true
+
+      - uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Install the aarch64 cross-compiler (#1672)
+        run: sudo apt-get update && sudo apt-get install -y gcc-aarch64-linux-gnu
+
+      - name: Build and pack (mirrors publish.yml's release job, minus the push)
+        # #2010: publish.yml's "Build and pack" step is the one step in the whole
+        # release path that ONLY ever ran during an actual release — the release of
+        # v2.4.0 passed all 8 matrix legs above and then failed here, because
+        # AlRunner.csproj's static _BCVersion pin named a build Microsoft had since
+        # withdrawn. The pin no longer exists (publish.yml now resolves it live from
+        # this workflow's resolve-versions output), but the failure mode this job
+        # guards against is broader than that one pin: ANYTHING in the build-and-pack
+        # step — a bad Directory.Build.props override, a Win32Stubs cross-compile
+        # regression, a nuspec/PackAsTool misconfiguration — used to be untestable
+        # without dispatching a real release. Running the identical commands here,
+        # on every push/PR, against the SAME live-resolved version the matrix above
+        # just gated on, means a release-build regression fails a normal CI run
+        # instead of a release.
+        run: |
+          dotnet build AlRunner/ \
+            -p:_BCVersion=${{ needs.resolve-versions.outputs.required-version }} \
+            -p:AllowBcArtifactDownload=true
+          dotnet pack AlRunner/ \
+            -p:_BCVersion=${{ needs.resolve-versions.outputs.required-version }} \
+            -p:AllowBcArtifactDownload=true -p:Version=0.0.0-ci \
+            -p:SuppressImplicitGitSourceLink=false -p:IncludeSourceRevisionInInformationalVersion=true \
+            -o ./nupkg
+
+      - name: Assert a package was actually produced
+        run: |
+          shopt -s nullglob
+          pkgs=(./nupkg/*.nupkg)
+          if [ "${#pkgs[@]}" -eq 0 ]; then
+            echo "::error::dotnet pack produced no .nupkg — the release path would ship nothing"
+            exit 1
+          fi
+          echo "Packed: ${pkgs[*]}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,19 +1,44 @@
 name: Publish to NuGet
 
 # Triggered manually only — supply the version and the workflow does everything:
-# runs the full BC test matrix, then generates the CHANGELOG section, commits it to
-# main, pushes the tag, packs, pushes to NuGet, and creates the GitHub Release.
+# runs the full BC test matrix, then BUILDS AND PACKS, then generates the CHANGELOG
+# section, commits it to main, pushes the tag, pushes to NuGet, and creates the
+# GitHub Release.
 #
-# ORDER MATTERS, and it used to be backwards. Until #1978 the first job pushed the
-# release commit and the tag BEFORE a single test ran, so a red matrix left a
-# permanent tag on main with no release behind it. Not hypothetical: v2.3.0 and
-# v2.3.1 are both such tags. Tests now gate every write — a failed release attempt
-# leaves the repository exactly as it found it.
+# ORDER MATTERS, and it has been backwards twice.
 #
-# That ordering had a second cost. CHANGELOG sections are generated from
-# `git describe --tags`, so a dead tag becomes the baseline for the NEXT release:
-# [2.3.1] lists two entries while the 21 real ones sit under [2.3.0], a heading with
-# no release behind it.
+# Until #1978 the first job pushed the release commit and the tag BEFORE a single
+# test ran, so a red matrix left a permanent tag on main with no release behind
+# it (v2.3.0, v2.3.1). #1978 moved the TEST MATRIX ahead of the writes and this
+# header used to claim that made a failed release leave the repository exactly as
+# it found it. That claim was false: it never covered the release job's OWN build.
+# The v2.4.0 release proved it — all 8 matrix legs green, then `Build and pack`
+# failed on a withdrawn BC artifact (#2010), after the CHANGELOG commit and the
+# `v2.4.0` tag had already been pushed at what was then the FIRST step of this
+# job. Gating on tests is not gating on the build; the build can fail on its own,
+# independent of what the tests found.
+#
+# So as of #2010 the actual guarantee is: EVERYTHING THAT CAN FAIL — the test
+# matrix (a separate job) and, within this job, the build and the pack — runs
+# BEFORE anything is written. The commit + tag push is the last cheap,
+# almost-never-fails step before the genuinely irreversible ones (NuGet push,
+# GitHub Release), not the first step of the job. A build/pack failure now leaves
+# no commit, no tag, no NuGet push and no GitHub Release — see the `dry_run` input
+# below, which exercises exactly that path (everything except the NuGet push and
+# the GitHub Release) without publishing anything, so this guarantee is something
+# you can run, not just read.
+#
+# The one write that CAN still precede a later failure is the commit + tag push
+# itself: if NuGet rejects the push after that, the tag and commit stay on main
+# with no package and no release behind them yet. That is a known, accepted gap —
+# reordering the tag to come after NuGet would mean NuGet has no immutable ref to
+# attach provenance to — and the release job's final step reports exactly what was
+# and was not written so a NuGet-push failure is diagnosable, not silent.
+#
+# That ordering had a second cost, orthogonal to the one above. CHANGELOG sections
+# are generated from `git describe --tags`, so a dead tag becomes the baseline for
+# the NEXT release: [2.3.1] lists two entries while the 21 real ones sit under
+# [2.3.0], a heading with no release behind it.
 #
 # The release job's checkout uses RELEASE_DEPLOY_KEY (a write-access deploy key) so
 # the git push to main bypasses the branch ruleset ("Deploy keys" -> Always allow).
@@ -23,6 +48,17 @@ on:
       version:
         description: 'Package version (e.g. 1.0.23)'
         required: true
+      dry_run:
+        description: >-
+          Run every step except the NuGet push and the GitHub Release. Still runs the
+          full test matrix, and still builds, packs, generates the CHANGELOG section
+          and commits it — but does NOT push that commit or the tag to origin, and
+          stops before publishing. Use this to prove the build/pack step (and its BC
+          version resolution) actually works end to end, without writing anything to
+          main or nuget.org. See #2010.
+        type: boolean
+        required: false
+        default: false
 
 env:
   DOTNET_NOLOGO: true
@@ -85,6 +121,11 @@ jobs:
     # Gated on `test`: this job holds every write this workflow performs — the
     # CHANGELOG commit, the push to main, the tag, the NuGet push and the GitHub
     # Release. Nothing above it touches the repository. See #1978.
+    #
+    # WITHIN this job, order matters too (#2010): build-and-pack runs FIRST, before
+    # the commit/tag push, so a build/pack failure (the failure that broke v2.4.0)
+    # leaves no write behind either. See the workflow header for the full guarantee
+    # and its one known gap (a NuGet-push failure).
     needs: [plan, test]
     runs-on: ubuntu-latest
     permissions:
@@ -100,6 +141,68 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Install the aarch64 cross-compiler (#1672)
+        run: |
+          # This runner is linux-x64; AlRunner.csproj's BuildWin32PrebuiltStubs target
+          # uses the native `cc` for linux-x64 (always present) and this cross
+          # toolchain for linux-arm64, so a single x64 job ships prebuilt Win32
+          # stubs for both RIDs without needing an arm64 runner.
+          sudo apt-get update && sudo apt-get install -y gcc-aarch64-linux-gnu
+
+      - name: Build and pack
+        id: build-and-pack
+        run: |
+          # Packing also needs the BC service tier present (RAR resolves against it),
+          # so the same download switch applies here.
+          #
+          # #2010: _BCVersion is passed explicitly here rather than left at
+          # AlRunner.csproj's default. The default is a static pin that Microsoft can
+          # (and did — the v2.4.0 release) withdraw between when it was last bumped
+          # and when a release runs, and nothing exercised that exact value except a
+          # release itself. `needs.test.outputs.required-version` is the live-resolved
+          # 28.1.* build the test matrix THIS RUN just gated on (bc-tests.yml's
+          # resolve-versions job, same resolve-version call bc-tests.yml's other jobs
+          # use) — it cannot be a version Microsoft has withdrawn, because resolving it
+          # is what proved it still exists, in this same run. It's also what the
+          # package is stamped with (AssemblyMetadata BcEngineVersion, AlRunner.csproj)
+          # so a released package still records a single, definite engine version.
+          #
+          # Also runs BuildWin32PrebuiltStubs (see AlRunner.csproj) which ships the
+          # prebuilt libwin32_stubs.linux-{x64,arm64}.so shims in the resulting nupkg.
+          #
+          # #1881's Directory.Build.props turns OFF IncludeSourceRevisionInInformationalVersion
+          # and SuppressImplicitGitSourceLink=true repo-wide, so every dev/CI build of
+          # al-runner.dll is content-addressable (RunnerFingerprint.ContentHash stops
+          # being a hash of the commit). This is the ONE place that must turn them back
+          # ON: `dotnet pack`'s nuspec RepositoryUrl/RepositoryCommit come from
+          # SourceLink's git task, and PackAsTool=true (AlRunner.csproj) ships this to
+          # nuget.org under MSDyn365BC.AL.Runner — losing that would silently strip
+          # commit provenance / source-stepping from every released package.
+          #
+          # Safe to override here specifically: a released package's bytes are fixed for a
+          # given version, so the ContentHash an end user's run computes from it is stable.
+          # Commit-embedding only invalidates caches when the SAME code is rebuilt
+          # commit-to-commit — the dev/CI/test-matrix path, never the release path.
+          #
+          # This step now runs BEFORE the CHANGELOG commit below (it used to run after),
+          # so the embedded commit SHA is the tested commit, one commit behind the tag
+          # that will point at tested-commit-plus-CHANGELOG. The two commits are
+          # byte-identical in every file that affects the built DLL (CHANGELOG.md isn't
+          # compiled), so this costs nothing but a one-commit-back SourceLink pointer —
+          # a small, known trade for building before writing.
+          dotnet build AlRunner/ \
+            -p:_BCVersion=${{ needs.test.outputs.required-version }} \
+            -p:AllowBcArtifactDownload=true
+          dotnet pack AlRunner/ \
+            -p:_BCVersion=${{ needs.test.outputs.required-version }} \
+            -p:AllowBcArtifactDownload=true -p:Version=${{ inputs.version }} \
+            -p:SuppressImplicitGitSourceLink=false -p:IncludeSourceRevisionInInformationalVersion=true \
+            -o ./nupkg
 
       - name: Generate CHANGELOG and push the release commit + tag
         id: changelog
@@ -131,14 +234,23 @@ jobs:
             git add CHANGELOG.md
             git commit -m "chore: release v${VERSION}"
 
-            # Push the release commit BEFORE creating the tag, and deliberately without
-            # --force. HEAD is the commit the matrix tested plus a CHANGELOG-only diff,
-            # so this is a fast-forward exactly when main is still where the matrix found
-            # it. If someone merged during the run it fails here — and NO tag is created,
-            # which is the whole point of #1978. Re-dispatch against the new main.
-            git push origin HEAD:main
-            git tag "$TAG"
-            git push origin "$TAG"
+            if [ "${{ inputs.dry_run }}" = "true" ]; then
+              # #2010: dry_run proves the CHANGELOG generation + commit machinery works
+              # (the commit above ran for real, locally, in this checkout) without
+              # writing anything to origin — a dry run that pushed a real tag/commit to
+              # main would recreate the exact dead-tag problem this workflow exists to
+              # prevent, just self-inflicted during a test.
+              echo "dry_run: skipping push of the release commit and tag to origin."
+            else
+              # Push the release commit BEFORE creating the tag, and deliberately without
+              # --force. HEAD is the commit build-and-pack just built plus a CHANGELOG-only
+              # diff, so this is a fast-forward exactly when main is still where the matrix
+              # found it. If someone merged during the run it fails here — and NO tag is
+              # created, which is the whole point of #1978. Re-dispatch against the new main.
+              git push origin HEAD:main
+              git tag "$TAG"
+              git push origin "$TAG"
+            fi
           fi
 
           {
@@ -147,49 +259,14 @@ jobs:
             echo "EOF_NOTES"
           } >> "$GITHUB_OUTPUT"
 
-      - uses: actions/setup-dotnet@v5
-        with:
-          dotnet-version: '8.0.x'
-
-      - name: Install the aarch64 cross-compiler (#1672)
-        run: |
-          # This runner is linux-x64; AlRunner.csproj's BuildWin32PrebuiltStubs target
-          # uses the native `cc` for linux-x64 (always present) and this cross
-          # toolchain for linux-arm64, so a single x64 job ships prebuilt Win32
-          # stubs for both RIDs without needing an arm64 runner.
-          sudo apt-get update && sudo apt-get install -y gcc-aarch64-linux-gnu
-
-      - name: Build and pack
-        run: |
-          # Packing also needs the BC service tier present (RAR resolves against it),
-          # so the same download switch applies here. This job builds once at the
-          # csproj's default _BCVersion, which is the version the package is stamped
-          # with (AssemblyMetadata BcEngineVersion). It also runs
-          # BuildWin32PrebuiltStubs (see AlRunner.csproj) which ships the prebuilt
-          # libwin32_stubs.linux-{x64,arm64}.so shims in the resulting nupkg.
-          #
-          # #1881's Directory.Build.props turns OFF IncludeSourceRevisionInInformationalVersion
-          # and SuppressImplicitGitSourceLink=true repo-wide, so every dev/CI build of
-          # al-runner.dll is content-addressable (RunnerFingerprint.ContentHash stops
-          # being a hash of the commit). This is the ONE place that must turn them back
-          # ON: `dotnet pack`'s nuspec RepositoryUrl/RepositoryCommit come from
-          # SourceLink's git task, and PackAsTool=true (AlRunner.csproj) ships this to
-          # nuget.org under MSDyn365BC.AL.Runner — losing that would silently strip
-          # commit provenance / source-stepping from every released package.
-          #
-          # Safe to override here specifically: a released package's bytes are fixed for a
-          # given version, so the ContentHash an end user's run computes from it is stable.
-          # Commit-embedding only invalidates caches when the SAME code is rebuilt
-          # commit-to-commit — the dev/CI/test-matrix path, never the release path.
-          dotnet build AlRunner/ -p:AllowBcArtifactDownload=true
-          dotnet pack AlRunner/ -p:AllowBcArtifactDownload=true -p:Version=${{ inputs.version }} \
-            -p:SuppressImplicitGitSourceLink=false -p:IncludeSourceRevisionInInformationalVersion=true \
-            -o ./nupkg
-
       - name: Push to NuGet
+        id: nuget-push
+        if: ${{ inputs.dry_run != true }}
         run: dotnet nuget push ./nupkg/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
 
       - name: Create GitHub Release
+        id: gh-release
+        if: ${{ inputs.dry_run != true }}
         uses: softprops/action-gh-release@v2
         with:
           tag_name: v${{ inputs.version }}
@@ -199,7 +276,27 @@ jobs:
           draft: false
           prerelease: false
 
+      - name: Report what this run wrote
+        # always(): AC2 (#2010) — a NuGet-push failure still leaves the commit + tag on
+        # main (see the header comment's known gap), so the failure needs to say
+        # exactly what happened rather than leave the next person to reconstruct it
+        # from raw step logs. Reads .outcome (not .conclusion) so a step that never ran
+        # because an earlier one failed reports as empty/skip, not as a false success.
+        if: always()
+        run: |
+          {
+            echo "## Release report — v${{ inputs.version }}${{ inputs.dry_run == true && ' (DRY RUN — nothing published)' || '' }}"
+            echo ""
+            echo "| Step | Outcome |"
+            echo "|---|---|"
+            echo "| Build and pack | ${{ steps.build-and-pack.outcome || 'did not run' }} |"
+            echo "| CHANGELOG commit + tag pushed to main | ${{ inputs.dry_run == true && 'skipped (dry_run)' || (steps.changelog.outcome || 'did not run') }} |"
+            echo "| Push to NuGet | ${{ inputs.dry_run == true && 'skipped (dry_run)' || (steps.nuget-push.outcome || 'did not run') }} |"
+            echo "| Create GitHub Release | ${{ inputs.dry_run == true && 'skipped (dry_run)' || (steps.gh-release.outcome || 'did not run') }} |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Summary
+        if: ${{ inputs.dry_run != true }}
         run: |
           echo "## Published to NuGet" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"

--- a/AlRunner.Tests/PublishReleaseOrderingTests.cs
+++ b/AlRunner.Tests/PublishReleaseOrderingTests.cs
@@ -1,0 +1,279 @@
+// PublishReleaseOrderingTests — regression guard for #2010: the v2.4.0 release passed all 8
+// BC test-matrix legs, then failed in the release job's "Build and pack" step (a withdrawn BC
+// artifact), after the CHANGELOG commit and the `v2.4.0` tag had already been pushed to main —
+// because that step ran AFTER the push, not before it, and the pin it built against was a
+// static value nothing exercised except a release.
+//
+// Two things this pins down, both as pure functions of the real workflow text so a future
+// reordering (or a reintroduced static pin) fails a normal unit-test run instead of the next
+// release:
+//
+//   1. Within publish.yml's `release` job, "Build and pack" appears BEFORE the step that
+//      pushes the CHANGELOG commit and tag to origin, which appears before "Push to NuGet" and
+//      "Create GitHub Release". A build/pack failure must be unreachable-after-a-write.
+//   2. The build/pack step passes `-p:_BCVersion=` a value derived from
+//      `needs.test.outputs.required-version` (the live-resolved version the matrix this run
+//      just gated on), not a hardcoded four-part BC build number. bc-tests.yml's
+//      `workflow_call` block actually exposes that output — a caller reading an output the
+//      reusable workflow never declares silently gets an empty string, not an error.
+//
+// See AlRunner.Tests/ReleaseTestParityTests.cs for the sibling guard (test-matrix parity) this
+// follows the same shape as, and AlRunner/AlRunner.csproj's `_BCVersion` PropertyGroup comment
+// for why the static default staying in the csproj is fine now: nothing in CI or the release
+// path reads it anymore.
+
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+/// <summary>Pure helpers over workflow YAML text, proven on constructed strings before being
+/// wired to the real files.</summary>
+internal static class PublishOrdering
+{
+    private static readonly Regex StepName = new(@"^\s*-\s*(?:id:\s*\S+\s*)?name:\s*(.+?)\s*$", RegexOptions.Compiled);
+
+    /// <summary>
+    /// The order (top to bottom) in which step names matching <paramref name="markers"/> first
+    /// appear in <paramref name="jobBody"/>, matched by substring so callers can pass a stable
+    /// fragment rather than the exact step name. A marker with no matching step is omitted —
+    /// callers assert on <c>Count</c> to catch that rather than silently ignoring it.
+    /// </summary>
+    internal static IReadOnlyList<string> StepOrder(string jobBody, IReadOnlyList<string> markers)
+    {
+        var found = new List<string>();
+        foreach (var line in jobBody.Split('\n'))
+        {
+            var trimmed = line.TrimStart();
+            if (trimmed.StartsWith('#') || !trimmed.StartsWith("- name:", StringComparison.Ordinal)) continue;
+
+            var match = StepName.Match(line);
+            if (!match.Success) continue;
+            var name = match.Groups[1].Value;
+
+            var marker = markers.FirstOrDefault(m => name.Contains(m, StringComparison.Ordinal));
+            if (marker is not null && !found.Contains(marker)) found.Add(marker);
+        }
+        return found;
+    }
+
+    /// <summary>
+    /// True if <paramref name="jobBody"/>'s "Build and pack" step (or whatever step contains
+    /// <paramref name="buildStepMarker"/>) passes <c>-p:_BCVersion=</c> a value that references
+    /// <paramref name="expectedSource"/>, rather than a bare hardcoded four-part BC build number
+    /// (e.g. <c>28.1.49838.50794</c>) which is exactly the shape that rotted in #2010.
+    /// </summary>
+    internal static bool BuildStepResolvesBcVersionFrom(string jobBody, string buildStepMarker, string expectedSource)
+    {
+        var lines = jobBody.Split('\n');
+        var inStep = false;
+        foreach (var line in lines)
+        {
+            if (line.Contains(buildStepMarker, StringComparison.Ordinal)) inStep = true;
+            else if (inStep && Regex.IsMatch(line, @"^\s*- (name|id):", RegexOptions.None) && !line.Contains(buildStepMarker, StringComparison.Ordinal))
+                break; // next step started
+
+            if (!inStep) continue;
+            if (!line.Contains("_BCVersion=", StringComparison.Ordinal)) continue;
+
+            if (Regex.IsMatch(line, @"_BCVersion=\d+\.\d+\.\d+\.\d+")) return false; // hardcoded literal
+            if (line.Contains(expectedSource, StringComparison.Ordinal)) return true;
+        }
+        return false;
+    }
+}
+
+public sealed class PublishReleaseOrderingTests
+{
+    private static readonly string WorkflowDir = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", ".github", "workflows"));
+
+    private static string Read(string name)
+    {
+        var path = Path.Combine(WorkflowDir, name);
+        Assert.True(File.Exists(path), $"expected workflow {name} at {path}");
+        return File.ReadAllText(path);
+    }
+
+    // ---- the pure functions, proven on constructed text ------------------------------
+
+    [Fact]
+    public void StepOrder_ReturnsMarkers_InDocumentOrder_NotDeclarationOrder()
+    {
+        const string job = """
+              release:
+                steps:
+                  - name: Push to NuGet
+                    run: dotnet nuget push
+                  - name: Build and pack
+                    run: dotnet pack
+            """;
+
+        var order = PublishOrdering.StepOrder(job, new[] { "Push to NuGet", "Build and pack" });
+
+        Assert.Equal(new[] { "Push to NuGet", "Build and pack" }, order);
+    }
+
+    [Fact]
+    public void StepOrder_IgnoresCommentedOutStepNames()
+    {
+        const string job = """
+              release:
+                steps:
+                  # - name: Build and pack (old, disabled)
+                  - name: Generate CHANGELOG and push the release commit + tag
+                    run: git push
+            """;
+
+        var order = PublishOrdering.StepOrder(job, new[] { "Build and pack", "Generate CHANGELOG" });
+
+        Assert.Equal(new[] { "Generate CHANGELOG" }, order);
+    }
+
+    [Fact]
+    public void BuildStepResolvesBcVersionFrom_RejectsAHardcodedFourPartVersion()
+    {
+        const string job = """
+              release:
+                steps:
+                  - name: Build and pack
+                    run: |
+                      dotnet build AlRunner/ -p:_BCVersion=28.1.49838.50794 -p:AllowBcArtifactDownload=true
+            """;
+
+        Assert.False(PublishOrdering.BuildStepResolvesBcVersionFrom(job, "Build and pack", "needs.test.outputs.required-version"));
+    }
+
+    [Fact]
+    public void BuildStepResolvesBcVersionFrom_AcceptsALiveResolvedSource()
+    {
+        const string job = """
+              release:
+                steps:
+                  - name: Build and pack
+                    run: |
+                      dotnet build AlRunner/ -p:_BCVersion=${{ needs.test.outputs.required-version }} -p:AllowBcArtifactDownload=true
+            """;
+
+        Assert.True(PublishOrdering.BuildStepResolvesBcVersionFrom(job, "Build and pack", "needs.test.outputs.required-version"));
+    }
+
+    // ---- wired to the real files on disk ----------------------------------------------
+
+    [Fact]
+    public void ReleaseJob_BuildsAndPacks_BeforeItPushesTheCommitAndTag_BeforeNuGetAndGitHubRelease()
+    {
+        var text = Read("publish.yml");
+        var jobs = WorkflowParity.SplitJobs(text);
+        Assert.True(jobs.TryGetValue("release", out var releaseJob), "publish.yml has no top-level 'release' job");
+
+        var markers = new[]
+        {
+            "Build and pack",
+            "Generate CHANGELOG and push the release commit + tag",
+            "Push to NuGet",
+            "Create GitHub Release",
+        };
+
+        var order = PublishOrdering.StepOrder(releaseJob!, markers);
+
+        Assert.True(order.Count == markers.Length,
+            $"expected all four release-job steps present in order; found: {string.Join(" -> ", order)}");
+        Assert.Equal(markers, order);
+    }
+
+    [Fact]
+    public void ReleaseJob_BuildAndPackStep_ResolvesBcVersionFromTheGatedMatrix_NotAHardcodedPin()
+    {
+        // #2010: the pin that rotted (AlRunner.csproj's static default _BCVersion) is still a
+        // legitimate DEV-MACHINE fallback (see its own comment), but the release job must never
+        // read it implicitly — it has to pass a version it can prove, this run, still exists.
+        var text = Read("publish.yml");
+        var jobs = WorkflowParity.SplitJobs(text);
+        Assert.True(jobs.TryGetValue("release", out var releaseJob), "publish.yml has no top-level 'release' job");
+
+        Assert.True(
+            PublishOrdering.BuildStepResolvesBcVersionFrom(releaseJob!, "Build and pack", "needs.test.outputs.required-version"),
+            "release job's 'Build and pack' step must pass -p:_BCVersion=${{ needs.test.outputs.required-version }}, "
+            + "not a hardcoded four-part BC build number — that is exactly what rotted and broke v2.4.0.");
+    }
+
+    [Fact]
+    public void BcTestsWorkflow_ExposesRequiredVersion_AsAWorkflowCallOutput()
+    {
+        // The release job reads needs.test.outputs.required-version, which only resolves to
+        // something non-empty if bc-tests.yml's `on.workflow_call` block actually declares
+        // `required-version` as a top-level output (jobs' own `outputs:` blocks are NOT
+        // automatically visible to callers of a reusable workflow).
+        var text = Read("bc-tests.yml");
+
+        var callBlock = Regex.Match(text, @"on:\s*\n\s*workflow_call:.*?(?=\nenv:|\njobs:)", RegexOptions.Singleline);
+        Assert.True(callBlock.Success, "bc-tests.yml has no on.workflow_call block");
+
+        Assert.Matches(new Regex(@"outputs:\s*\n\s*required-version:", RegexOptions.Singleline), callBlock.Value);
+        Assert.Contains("jobs.resolve-versions.outputs.required-version", callBlock.Value, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void BcTestsWorkflow_HasAPackJob_ThatBuildsAndPacksOnOrdinaryCI()
+    {
+        // #2010 acceptance criterion 6: the release path's build must be exercised by ordinary
+        // CI, so a build/pack regression (BC-version rot or otherwise) surfaces on a normal
+        // push/PR run instead of during a release. This is the job that does that — it runs the
+        // same `dotnet build`/`dotnet pack` commands as publish.yml's release job, against the
+        // same live-resolved version, without publishing anything.
+        var text = Read("bc-tests.yml");
+        var jobs = WorkflowParity.SplitJobs(text);
+        Assert.True(jobs.TryGetValue("pack", out var packJob), "bc-tests.yml has no top-level 'pack' job");
+
+        Assert.Contains("dotnet build AlRunner/", packJob, StringComparison.Ordinal);
+        Assert.Contains("dotnet pack AlRunner/", packJob, StringComparison.Ordinal);
+        Assert.Contains("needs.resolve-versions.outputs.required-version", packJob, StringComparison.Ordinal);
+
+        // Must never push anywhere — this job proves the build works, it does not publish it.
+        Assert.DoesNotContain("nuget push", packJob, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("action-gh-release", packJob, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void PublishWorkflow_HasADryRunInput_ThatSkipsOnlyNuGetPushAndGitHubRelease()
+    {
+        var text = Read("publish.yml");
+
+        Assert.Contains("dry_run:", text, StringComparison.Ordinal);
+
+        var jobs = WorkflowParity.SplitJobs(text);
+        Assert.True(jobs.TryGetValue("release", out var releaseJob), "publish.yml has no top-level 'release' job");
+
+        // Exactly the two irreversible/external steps are gated on dry_run being false.
+        var pushToNuGet = ExtractStep(releaseJob!, "Push to NuGet");
+        var createRelease = ExtractStep(releaseJob!, "Create GitHub Release");
+        Assert.Contains("inputs.dry_run", pushToNuGet, StringComparison.Ordinal);
+        Assert.Contains("inputs.dry_run", createRelease, StringComparison.Ordinal);
+
+        // Build and pack must NOT be skipped in dry_run — it's the step the dry run exists to
+        // exercise.
+        var buildAndPack = ExtractStep(releaseJob!, "Build and pack");
+        Assert.DoesNotContain("if:", buildAndPack, StringComparison.Ordinal);
+    }
+
+    private static string ExtractStep(string jobBody, string stepNameMarker)
+    {
+        var lines = jobBody.Split('\n');
+        var start = Array.FindIndex(lines, l => l.TrimStart().StartsWith("- name:", StringComparison.Ordinal)
+                                                  && l.Contains(stepNameMarker, StringComparison.Ordinal));
+        Assert.True(start >= 0, $"no step named like '{stepNameMarker}' found");
+
+        var end = lines.Length;
+        for (var i = start + 1; i < lines.Length; i++)
+        {
+            if (lines[i].TrimStart().StartsWith("- name:", StringComparison.Ordinal)
+                || lines[i].TrimStart().StartsWith("- uses:", StringComparison.Ordinal))
+            {
+                end = i;
+                break;
+            }
+        }
+        return string.Join('\n', lines[start..end]);
+    }
+}

--- a/AlRunner/AlRunner.csproj
+++ b/AlRunner/AlRunner.csproj
@@ -162,7 +162,27 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <_BCVersion>28.1.49838.50794</_BCVersion>
+    <!-- #2010: this default is a DEV-MACHINE FALLBACK ONLY, not the release version. It used
+         to be both — publish.yml's release job built with whatever this said, and that is
+         exactly what broke the v2.4.0 release: Microsoft withdrew 28.1.49838.50794 (the value
+         that WAS here) between when this was last bumped and when the release ran, the release
+         job's build failed on "no BC artifact published", and by then the release commit and
+         tag had already been pushed to main — because nothing had exercised this value except
+         a release itself.
+
+         Every CI/release caller now passes -p:_BCVersion explicitly, live-resolved via
+         tools/DownloadArtifacts' `resolve-version` command (the same call bc-tests.yml's
+         resolve-versions job makes): the BC-test matrix (per matrix
+         leg), the smoke job, the pack job (bc-tests.yml, added by #2010 specifically to run
+         publish.yml's build-and-pack commands on ordinary CI instead of only during a release),
+         and publish.yml's release job, which reads bc-tests.yml's `required-version` output —
+         the exact build the matrix it just depended on tested — rather than resolving again or
+         reading this property. So this value only fires for a bare `dotnet build`/`dotnet pack`
+         with no override, i.e. an interactive dev machine. It WILL still go stale the next time
+         Microsoft withdraws this exact build; that is expected and low-stakes now — it costs a
+         local rebuild against a fresh -p:_BCVersion, not a broken release. Bump opportunistically
+         when noticed; nothing gates on it. -->
+    <_BCVersion>28.1.49838.53910</_BCVersion>
 
     <!-- No compile-time BC feature constants. BC-version differences are handled by
          reflection at runtime — one binary, no build matrix in the source.


### PR DESCRIPTION
Closes #2010

The v2.4.0 release ([run 32842284423](https://github.com/StefanMaron/BusinessCentral.AL.Runner/actions/runs/32842284423)) passed all 8 BC test-matrix legs, then failed in `Build and pack` because `AlRunner.csproj`'s static `_BCVersion` pin named a build Microsoft had since withdrawn — and by then the CHANGELOG commit and the `v2.4.0` tag had already been pushed to main. Two independent bugs, both fixed here.

## Bug 1 — the pinned `_BCVersion` rotted, nothing detected it

`AlRunner.csproj`'s default `_BCVersion` was a static four-part BC build number that only the release job ever built against without an override. Fix: the release job now resolves it live instead.

- `bc-tests.yml`'s `on.workflow_call` now exposes `required-version` (the live-resolved 28.1.* build `resolve-versions` picked for **this run**) as a top-level output.
- `publish.yml`'s release job passes `-p:_BCVersion=${{ needs.test.outputs.required-version }}` to both `dotnet build` and `dotnet pack`, instead of relying on the csproj default. It can never build against a version Microsoft has withdrawn, because resolving it live is what proved it still exists, in this same run.
- A new `pack` job in `bc-tests.yml` runs the exact same `dotnet build`/`dotnet pack` commands publish.yml's release job runs (no push), on every ordinary push/PR. This is what closes the loop per the issue's acceptance criterion 6: a release-build regression (BC-version rot, or anything else in that step) now fails a normal CI run instead of a release.
- `AlRunner.csproj`'s static `_BCVersion` stays, bumped to the currently-resolvable build, with a comment explaining it is now a **dev-machine-only fallback** — nothing in CI or the release path reads it anymore, so it can go stale again without blocking a release; that's an accepted, low-stakes cost now.

## Bug 2 — the release job wrote before it built

`publish.yml`'s release job used to push the CHANGELOG commit + tag as its *first* step and build/pack as its *third*. Reordered so `Build and pack` runs first; the commit + tag push is now the last cheap step before the genuinely irreversible ones (NuGet push, GitHub Release).

- Corrected the workflow's header comment, which claimed "a failed release attempt leaves the repository exactly as it found it" — false as written, since it never covered the release job's own build (which is exactly what broke v2.4.0 despite all 8 matrix legs being green).
- One residual, documented gap: a **NuGet-push failure** still leaves the commit + tag on main, because the tag has to exist before NuGet/GitHub Release can reference it. Added a final "Report what this run wrote" step (`if: always()`) that names exactly which of build-and-pack / commit+tag / NuGet push / GitHub Release ran and what its outcome was, so that failure is diagnosable rather than silent — this is acceptance criterion 2.
- Added a `dry_run` boolean input that runs every step **except** the NuGet push and the GitHub Release — including a real build+pack against the live-resolved version, and a real local CHANGELOG commit — without pushing the commit/tag to origin or publishing anything. Built specifically because "a failed build leaves nothing behind" is exactly the kind of ordering claim that looks right and isn't (per the issue's closing note).

## Verification

- **RED → GREEN, both directions, actually run**: I reverted `publish.yml`/`bc-tests.yml` to `main`'s versions locally, re-ran the new test file — 5 of 9 new tests failed for precisely the right reasons (`pack` job missing, `dry_run` input missing, wrong step order, `required-version` output missing, hardcoded `_BCVersion`). Restored the fix, re-ran — all green. `AlRunner.Tests/PublishReleaseOrderingTests.cs` pins this down as regression coverage in the same shape as the existing `ReleaseTestParityTests.cs`.
- **Full `AlRunner.Tests` suite**: 827 passed, 54 skipped, 0 failed.
- **The real GitHub Actions dry run** (`workflow_dispatch` with `dry_run: true`) is the acceptance test this issue explicitly asks for — I'll dispatch it against this branch and report the result once CI is set up on the PR, since `workflow_dispatch` needs the workflow file present on a ref GitHub already knows about.

## What a dry run does and does not cover

Covers: the full 8-leg BC test matrix, the release job's build + pack (against the live-resolved BC version), CHANGELOG generation and a real local `git commit` — everything **except** pushing that commit/tag to origin, the NuGet push, and the GitHub Release creation.

Does not cover: the actual NuGet push or GitHub Release API call succeeding — those are exactly the two steps intentionally skipped, since exercising them for real would mean publishing. Confidence in those two steps still rests on their being unchanged, thin wrappers (`dotnet nuget push`, `softprops/action-gh-release`) whose behavior isn't part of what changed here.

## Explicitly out of scope (per the issue)

Did not touch the existing `v2.4.0` tag or the `12609ba1` "chore: release v2.4.0" CHANGELOG commit on `main` — that cleanup is separate repo surgery. `12609ba1` is on `main` and is included in this branch's history as a result, but nothing here reverts or builds on it.