### PR TITLE
fix(provision): reject a warm app set below the manifest's version floor

### DIFF
--- a/AlRunner.Tests/ProvisioningCheckTests.cs
+++ b/AlRunner.Tests/ProvisioningCheckTests.cs
@@ -851,4 +851,210 @@ public sealed class ProvisioningCheckTests : IDisposable
         Assert.Single(result);
         Assert.Equal("Application Test Library", result[0].Name);
     }
+
+    // ── Issue #2003: manifest-driven version floors ───────────────────────────
+    // FindWarmProvisionedVersion used to decide "reuse this warm set" on presence alone,
+    // ignoring the version floor the bundle's app.json manifests declare. A warm set at the
+    // same major.minor but an OLDER patch than the manifest requires was reused
+    // unconditionally, and the run failed later on a compile diagnostic pointing at the test
+    // code rather than a message naming the stale provisioning. These tests drive the shared
+    // primitives (DetermineVersionFloors / FindVersionFloorViolations / the floor-aware
+    // NoFallbackPlatformAppsPresent+TestToolkitPresent overloads / DecideManifestProvisioning)
+    // that both the initial gate and FindWarmProvisionedVersion's warm-reuse scan consult.
+
+    [Fact]
+    public void DetermineVersionFloors_TwoRootsSameApp_KeepsHigherVersion()
+    {
+        // A looser dependency declared elsewhere must never relax the strictest floor.
+        var roots = new[]
+        {
+            new DependencyRef(Guid.NewGuid(), "Application Test Library", "Microsoft", new Version(28, 0, 0, 0)),
+            new DependencyRef(Guid.NewGuid(), "Application Test Library", "Microsoft", new Version(28, 1, 5, 0)),
+        };
+        var floors = ProvisioningCheck.DetermineVersionFloors(roots);
+        Assert.Equal(new Version(28, 1, 5, 0), floors["Application Test Library"]);
+    }
+
+    [Fact]
+    public void DetermineVersionFloors_NonMicrosoftPublisher_Ignored()
+    {
+        var roots = new[]
+        {
+            new DependencyRef(Guid.NewGuid(), "Application Test Library", "Contoso ISV", new Version(9, 9, 9, 9)),
+        };
+        var floors = ProvisioningCheck.DetermineVersionFloors(roots);
+        Assert.False(floors.ContainsKey("Application Test Library"));
+    }
+
+    [Fact]
+    public void DetermineVersionFloors_NoMicrosoftRoots_ReturnsEmptyMap()
+    {
+        // AC #4 basis: a bundle whose manifests declare no floor gets an empty map, which
+        // every floor-aware lookup below then treats identically to "no floor given".
+        var floors = ProvisioningCheck.DetermineVersionFloors(Array.Empty<DependencyRef>());
+        Assert.Empty(floors);
+    }
+
+    [Fact]
+    public void FindVersionFloorViolations_AppBelowFloor_ReportsNameFoundAndRequired()
+    {
+        var dir = Path.Combine(_dir, "warm-stale");
+        Directory.CreateDirectory(dir);
+        WriteR2RApp(dir, "atl.app", Guid.NewGuid().ToString(), "Application Test Library", "Microsoft", "28.0.0.0");
+
+        var floors = new Dictionary<string, Version> { ["Application Test Library"] = new Version(28, 1, 0, 0) };
+        var violations = ProvisioningCheck.FindVersionFloorViolations(new[] { dir }, floors);
+
+        var v = Assert.Single(violations);
+        Assert.Equal("Application Test Library", v.AppName);
+        Assert.Equal(new Version(28, 0, 0, 0), v.FoundVersion);
+        Assert.Equal(new Version(28, 1, 0, 0), v.RequiredVersion);
+    }
+
+    [Fact]
+    public void FindVersionFloorViolations_AppAtOrAboveFloor_ReportsNothing()
+    {
+        var dir = Path.Combine(_dir, "warm-fresh");
+        Directory.CreateDirectory(dir);
+        WriteR2RApp(dir, "atl.app", Guid.NewGuid().ToString(), "Application Test Library", "Microsoft", "28.1.0.0");
+
+        var floors = new Dictionary<string, Version> { ["Application Test Library"] = new Version(28, 1, 0, 0) };
+        var violations = ProvisioningCheck.FindVersionFloorViolations(new[] { dir }, floors);
+
+        Assert.Empty(violations);
+    }
+
+    [Fact]
+    public void FindVersionFloorViolations_AppAbsent_ReportsNothing()
+    {
+        // Plain absence is a presence gap, not a version-floor violation — the two are
+        // reported through different mechanisms (CheckPlatformApps/DecideManifestProvisioning
+        // for absence, this for "found but stale").
+        var floors = new Dictionary<string, Version> { ["Application Test Library"] = new Version(28, 1, 0, 0) };
+        var violations = ProvisioningCheck.FindVersionFloorViolations(new[] { _dir }, floors);
+
+        Assert.Empty(violations);
+    }
+
+    [Fact]
+    public void NoFallbackPlatformAppsPresent_BelowFloor_ReturnsFalse()
+    {
+        // AC #2: a warm-but-stale Application Test Library does not count as present when
+        // the manifest declares a higher floor.
+        var dir = Path.Combine(_dir, "atl-stale");
+        Directory.CreateDirectory(dir);
+        WriteR2RApp(dir, "atl.app", Guid.NewGuid().ToString(), "Application Test Library", "Microsoft", "28.0.0.0");
+
+        var floors = new Dictionary<string, Version> { ["Application Test Library"] = new Version(28, 1, 0, 0) };
+        Assert.False(ProvisioningCheck.NoFallbackPlatformAppsPresent(new[] { dir }, floors));
+    }
+
+    [Fact]
+    public void NoFallbackPlatformAppsPresent_AtOrAboveFloor_ReturnsTrue()
+    {
+        // AC #1: a warm set that DOES meet the floor is still reused — the common path.
+        var dir = Path.Combine(_dir, "atl-fresh");
+        Directory.CreateDirectory(dir);
+        WriteR2RApp(dir, "atl.app", Guid.NewGuid().ToString(), "Application Test Library", "Microsoft", "28.1.5.0");
+
+        var floors = new Dictionary<string, Version> { ["Application Test Library"] = new Version(28, 1, 0, 0) };
+        Assert.True(ProvisioningCheck.NoFallbackPlatformAppsPresent(new[] { dir }, floors));
+    }
+
+    [Fact]
+    public void NoFallbackPlatformAppsPresent_NoFloorsGiven_MatchesOldPresenceOnlyBehavior()
+    {
+        // AC #4: omitting versionFloors (or passing null, the default) must reproduce the
+        // pre-#2003 presence-only behavior exactly — an old app still counts as present.
+        var dir = Path.Combine(_dir, "atl-no-floor");
+        Directory.CreateDirectory(dir);
+        WriteR2RApp(dir, "atl.app", Guid.NewGuid().ToString(), "Application Test Library", "Microsoft", "1.0.0.0");
+
+        Assert.True(ProvisioningCheck.NoFallbackPlatformAppsPresent(new[] { dir }));
+    }
+
+    [Fact]
+    public void TestToolkitPresent_BelowFloor_ReturnsFalse()
+    {
+        var dir = Path.Combine(_dir, "toolkit-stale");
+        Directory.CreateDirectory(dir);
+        WriteR2RApp(dir, "bftl.app", Guid.NewGuid().ToString(),
+            ProvisioningCheck.TestToolkitSentinelApp, "Microsoft", "28.0.0.0");
+
+        var floors = new Dictionary<string, Version> { [ProvisioningCheck.TestToolkitSentinelApp] = new Version(28, 1, 0, 0) };
+        Assert.False(ProvisioningCheck.TestToolkitPresent(new[] { dir }, floors));
+    }
+
+    [Fact]
+    public void TestToolkitPresent_AtOrAboveFloor_ReturnsTrue()
+    {
+        var dir = Path.Combine(_dir, "toolkit-fresh");
+        Directory.CreateDirectory(dir);
+        WriteR2RApp(dir, "bftl.app", Guid.NewGuid().ToString(),
+            ProvisioningCheck.TestToolkitSentinelApp, "Microsoft", "28.1.0.0");
+
+        var floors = new Dictionary<string, Version> { [ProvisioningCheck.TestToolkitSentinelApp] = new Version(28, 1, 0, 0) };
+        Assert.True(ProvisioningCheck.TestToolkitPresent(new[] { dir }, floors));
+    }
+
+    [Fact]
+    public void DecideManifestProvisioning_WarmSetBelowDeclaredFloor_NotReused_DownloadsInstead()
+    {
+        // AC #2, wired through the SAME decision the initial gate (and the warm-reuse re-
+        // check after a download) both consult — not just a standalone helper.
+        var dir = Path.Combine(_dir, "decide-stale");
+        Directory.CreateDirectory(dir);
+        WriteR2RApp(dir, "atl.app", Guid.NewGuid().ToString(), "Application Test Library", "Microsoft", "28.0.0.0");
+
+        var roots = new[]
+        {
+            new DependencyRef(Guid.NewGuid(), "Application Test Library", "Microsoft", new Version(28, 1, 0, 0)),
+        };
+        var legacyReport = ProvisioningCheck.CheckPlatformApps("28.1.49838.50794", new[] { dir });
+        var decision = ProvisioningCheck.DecideManifestProvisioning(roots, legacyReport, new[] { dir });
+
+        Assert.False(decision.PlatformComplete);
+        Assert.True(decision.ShouldDownloadPlatform);
+    }
+
+    [Fact]
+    public void DecideManifestProvisioning_WarmSetMeetsDeclaredFloor_ReusedNoDownload()
+    {
+        // AC #1: the common case — a warm set that DOES meet the floor is still reused
+        // with no download. A regression here means every run starts downloading.
+        var dir = Path.Combine(_dir, "decide-fresh");
+        Directory.CreateDirectory(dir);
+        WriteR2RApp(dir, "atl.app", Guid.NewGuid().ToString(), "Application Test Library", "Microsoft", "28.1.5.0");
+
+        var roots = new[]
+        {
+            new DependencyRef(Guid.NewGuid(), "Application Test Library", "Microsoft", new Version(28, 1, 0, 0)),
+        };
+        var legacyReport = ProvisioningCheck.CheckPlatformApps("28.1.49838.50794", new[] { dir });
+        var decision = ProvisioningCheck.DecideManifestProvisioning(roots, legacyReport, new[] { dir });
+
+        Assert.True(decision.PlatformComplete);
+        Assert.False(decision.ShouldDownloadPlatform);
+    }
+
+    [Fact]
+    public void DecideManifestProvisioning_NoDeclaredFloor_KeepsPresenceOnlyBehavior()
+    {
+        // AC #4: a bundle whose manifests declare NO version for the dependency at all (the
+        // implicit `application`/`platform` synthesis passes Optional roots without pinning
+        // a real floor beyond whatever ships) must not newly reject a warm set it would have
+        // accepted before #2003. Simulate "no floor" the same way DetermineVersionFloors
+        // would see it for an app that's warm-present but was never named in any manifest
+        // root — DecideManifestProvisioning is called with roots that don't mention
+        // Application Test Library at all, only the legacy symbol-only signal drives it.
+        var dir = Path.Combine(_dir, "decide-no-floor");
+        Directory.CreateDirectory(dir);
+        WriteR2RApp(dir, "atl.app", Guid.NewGuid().ToString(), "Application Test Library", "Microsoft", "1.0.0.0");
+
+        var legacyReport = ProvisioningCheck.CheckPlatformApps("28.1.49838.50794", new[] { dir });
+        var decision = ProvisioningCheck.DecideManifestProvisioning(Array.Empty<DependencyRef>(), legacyReport, new[] { dir });
+
+        Assert.True(decision.PlatformComplete);
+        Assert.False(decision.ShouldDownloadPlatform);
+    }
 }

--- a/AlRunner/Infrastructure/ProvisioningCheck.cs
+++ b/AlRunner/Infrastructure/ProvisioningCheck.cs
@@ -269,9 +269,20 @@ public static class ProvisioningCheck
     /// True if the Microsoft test toolkit is provisioned in <paramref name="packageCacheDirs"/>,
     /// detected via <see cref="TestToolkitSentinelApp"/> (a Microsoft-published .app of that
     /// name). Missing/nonexistent dirs are skipped. Pure filesystem scan — no network.
+    ///
+    /// Issue #2003: <paramref name="versionFloors"/> is the manifest-declared minimum
+    /// version, if any, for <see cref="TestToolkitSentinelApp"/> (see
+    /// <see cref="DetermineVersionFloors"/>). A sentinel app found below its floor does NOT
+    /// count as present — presence alone used to be sufficient, which let a warm-but-stale
+    /// toolkit satisfy this check and get silently reused past the version the bundle's own
+    /// app.json actually requires. Null/empty (the default) preserves the old presence-only
+    /// behavior — a bundle whose manifests declare no floor is unaffected (AC #4).
     /// </summary>
-    public static bool TestToolkitPresent(IReadOnlyList<string> packageCacheDirs)
+    public static bool TestToolkitPresent(
+        IReadOnlyList<string> packageCacheDirs,
+        IReadOnlyDictionary<string, Version>? versionFloors = null)
     {
+        var floor = versionFloors != null && versionFloors.TryGetValue(TestToolkitSentinelApp, out var f) ? f : null;
         foreach (var dir in packageCacheDirs)
         {
             if (!Directory.Exists(dir)) continue;
@@ -280,8 +291,9 @@ public static class ProvisioningCheck
                 var m = AlRunner.AppLoader.ReadManifest(appFile);
                 if (m == null) continue;
                 if (!string.Equals(m.Publisher, "Microsoft", StringComparison.OrdinalIgnoreCase)) continue;
-                if (string.Equals(TestToolkitSentinelApp, m.Name, StringComparison.OrdinalIgnoreCase))
-                    return true;
+                if (!string.Equals(TestToolkitSentinelApp, m.Name, StringComparison.OrdinalIgnoreCase)) continue;
+                if (floor != null && m.Version < floor) continue;
+                return true;
             }
         }
         return false;
@@ -434,15 +446,98 @@ public static class ProvisioningCheck
         return new ManifestNeeds(needsPlatform, needsTest);
     }
 
+    // ── Issue #2003: manifest-driven version floors ──────────────────────────
+    // DetermineManifestNeeds above answers "is this app needed at all". It says nothing
+    // about WHICH version satisfies that need — a bundle's app.json can declare a
+    // dependency at a specific minimum version (e.g. Application Test Library 28.1.0.0),
+    // and a warm-provisioned set at the same major/minor but an OLDER patch used to satisfy
+    // every presence check unconditionally. The failure wasn't loud: the apps resolved,
+    // compilation proceeded, and the run failed later on whatever the missing symbol or
+    // changed signature produced — pointing at the test code instead of the stale
+    // provisioning. These helpers make the floor visible to the same presence checks that
+    // already decide "is this app already provisioned", so a stale warm set stops looking
+    // complete.
+
+    /// <summary>
+    /// The version floor (minimum acceptable version) each Microsoft dependency name
+    /// declares across <paramref name="roots"/> — the SAME roots
+    /// <see cref="DetermineManifestNeeds"/> reads. When multiple manifests (or bundles)
+    /// declare different floors for the same app name, the HIGHER one wins: a looser
+    /// dependency declared elsewhere can never relax what the strictest manifest requires.
+    /// Case-insensitive on name. Non-Microsoft roots are ignored (floors are only meaningful
+    /// for the curated platform-apps/test-apps sets, which are Microsoft-only). Pure — does
+    /// no I/O. Returns an empty (never null) map when no root declares a Microsoft
+    /// dependency, so callers can pass the result straight through without a null check —
+    /// which is also exactly AC #4: a bundle whose manifests declare no floor gets an empty
+    /// map, and every floor-aware lookup below then behaves identically to the old
+    /// presence-only check.
+    /// </summary>
+    public static IReadOnlyDictionary<string, Version> DetermineVersionFloors(IEnumerable<AlRunner.DependencyRef> roots)
+    {
+        var floors = new Dictionary<string, Version>(StringComparer.OrdinalIgnoreCase);
+        foreach (var d in roots)
+        {
+            if (!string.Equals(d.Publisher, "Microsoft", StringComparison.OrdinalIgnoreCase)) continue;
+            if (!floors.TryGetValue(d.Name, out var existing) || d.Version > existing)
+                floors[d.Name] = d.Version;
+        }
+        return floors;
+    }
+
+    /// <summary>One app found below the version floor its manifests declared for it.</summary>
+    public sealed record VersionFloorViolation(string AppName, Version FoundVersion, Version RequiredVersion);
+
+    /// <summary>
+    /// Scans <paramref name="packageCacheDirs"/> for every Microsoft app named in
+    /// <paramref name="versionFloors"/> and reports the ones whose highest found version is
+    /// BELOW its declared floor. An app entirely absent from <paramref name="packageCacheDirs"/>
+    /// is not a violation here (that's plain absence, already handled by the presence
+    /// checks) — this only flags "found, but too old", which is the specific silent gap
+    /// issue #2003 is about: a warm set that resolves as present yet doesn't meet what the
+    /// manifest actually requires. Pure filesystem scan — no network.
+    /// </summary>
+    public static IReadOnlyList<VersionFloorViolation> FindVersionFloorViolations(
+        IReadOnlyList<string> packageCacheDirs,
+        IReadOnlyDictionary<string, Version> versionFloors)
+    {
+        var violations = new List<VersionFloorViolation>();
+        foreach (var (appName, floor) in versionFloors)
+        {
+            Version? best = null;
+            foreach (var dir in packageCacheDirs)
+            {
+                if (!Directory.Exists(dir)) continue;
+                foreach (var appFile in Directory.EnumerateFiles(dir, "*.app", SearchOption.AllDirectories))
+                {
+                    var m = AlRunner.AppLoader.ReadManifest(appFile);
+                    if (m == null) continue;
+                    if (!string.Equals(m.Publisher, "Microsoft", StringComparison.OrdinalIgnoreCase)) continue;
+                    if (!string.Equals(m.Name, appName, StringComparison.OrdinalIgnoreCase)) continue;
+                    if (best == null || m.Version > best) best = m.Version;
+                }
+            }
+            if (best != null && best < floor)
+                violations.Add(new VersionFloorViolation(appName, best, floor));
+        }
+        return violations;
+    }
+
     /// <summary>
     /// True iff EVERY app in <see cref="KnownNoFallbackPlatformApps"/> is found (any
-    /// version, any R2R-ness — this only asks "is it there", not "is it runnable"; that's
-    /// CheckPlatformApps' job) somewhere across <paramref name="packageCacheDirs"/>.
+    /// R2R-ness — this only asks "is it there", not "is it runnable"; that's
+    /// CheckPlatformApps' job) somewhere across <paramref name="packageCacheDirs"/>, AT OR
+    /// ABOVE the version floor <paramref name="versionFloors"/> declares for it (issue
+    /// #2003). A found-but-below-floor app does NOT count as present. Null/empty
+    /// <paramref name="versionFloors"/> (the default) preserves the old any-version
+    /// presence-only behavior.
     /// </summary>
-    public static bool NoFallbackPlatformAppsPresent(IReadOnlyList<string> packageCacheDirs)
+    public static bool NoFallbackPlatformAppsPresent(
+        IReadOnlyList<string> packageCacheDirs,
+        IReadOnlyDictionary<string, Version>? versionFloors = null)
     {
         foreach (var required in KnownNoFallbackPlatformApps)
         {
+            var floor = versionFloors != null && versionFloors.TryGetValue(required, out var f) ? f : null;
             bool found = false;
             foreach (var dir in packageCacheDirs)
             {
@@ -453,6 +548,7 @@ public static class ProvisioningCheck
                     if (m == null) continue;
                     if (!string.Equals(m.Publisher, "Microsoft", StringComparison.OrdinalIgnoreCase)) continue;
                     if (!string.Equals(m.Name, required, StringComparison.OrdinalIgnoreCase)) continue;
+                    if (floor != null && m.Version < floor) continue;
                     found = true;
                     break;
                 }
@@ -487,15 +583,25 @@ public static class ProvisioningCheck
     /// compatible with issue #1678, even absent a manifest need — e.g. no app.json was
     /// readable). A manifest need with nothing found anywhere is issue #1996's gap:
     /// CheckPlatformApps alone reports that case vacuously "Ok".
+    ///
+    /// Issue #2003: "present" is no longer presence-alone. <paramref name="manifestRoots"/>
+    /// also carries each dependency's declared version, so PlatformComplete/TestComplete
+    /// (via NoFallbackPlatformAppsPresent/TestToolkitPresent) now require the found app to
+    /// meet that floor too — a warm-but-stale app in <paramref name="searchDirs"/> no longer
+    /// reads as complete, which was true here (the initial gate, before any
+    /// --auto-provision download decision) just as much as it was in the warm-reuse scan
+    /// this issue's repro pointed at.
     /// </summary>
     public static ManifestProvisionDecision DecideManifestProvisioning(
         IEnumerable<AlRunner.DependencyRef> manifestRoots,
         PlatformAppsReport legacySymbolOnlyReport,
         IReadOnlyList<string> searchDirs)
     {
-        var needs = DetermineManifestNeeds(manifestRoots);
-        var platformComplete = NoFallbackPlatformAppsPresent(searchDirs);
-        var testComplete = TestToolkitPresent(searchDirs);
+        var rootsList = manifestRoots as ICollection<AlRunner.DependencyRef> ?? manifestRoots.ToList();
+        var needs = DetermineManifestNeeds(rootsList);
+        var versionFloors = DetermineVersionFloors(rootsList);
+        var platformComplete = NoFallbackPlatformAppsPresent(searchDirs, versionFloors);
+        var testComplete = TestToolkitPresent(searchDirs, versionFloors);
         var shouldDownloadPlatform = !legacySymbolOnlyReport.Ok || (needs.NeedsPlatformApps && !platformComplete);
         var shouldDownloadTest = needs.NeedsTestApps && !testComplete;
         return new ManifestProvisionDecision(

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -809,10 +809,17 @@ if (!provisionSubcommand)
         // that case would never find a match and would incorrectly gate warm reuse on an
         // app the legacy issue has nothing to do with. Falling through to CDN resolution
         // here matches this path's pre-existing (issue #1678) behavior.
+        //
+        // Issue #2003: a warm candidate must also meet the version floor the bundle's own
+        // app.json manifests declare, not just be present — versionFloors carries that
+        // (derived from the SAME manifestDependencyRoots DetermineManifestNeeds already
+        // read above), so a stale warm set is skipped rather than silently reused.
+        var versionFloors = AlRunner.Infrastructure.ProvisioningCheck.DetermineVersionFloors(manifestDependencyRoots);
         var full = (platformReport.Ok
                 ? FindWarmProvisionedVersion(
                     AlRunner.Infrastructure.BcArtifacts.ArtifactsRootDir, mm,
-                    decision.NeedsPlatformApps, decision.ShouldDownloadTest)
+                    decision.NeedsPlatformApps, decision.ShouldDownloadTest,
+                    versionFloors, m => Console.Error.WriteLine(m))
                 : null)
             ?? AlRunner.Provisioning.ArtifactDownloader.ResolveVersion(
                 mm, m => Console.Error.WriteLine($"[provision] {m}"));
@@ -5054,9 +5061,24 @@ static string? SelectVersionDirOrNull(string root, string versionPrefix)
 /// whose major.minor matches <paramref name="majorMinorPrefix"/> and whose needed set(s) are
 /// already complete — highest patch first. Returns null when no such warm version exists
 /// (the caller then falls back to CDN resolution). Reuse-only: never downloads.
+///
+/// Issue #2003: "complete" used to mean presence alone — a warm set at the same
+/// major.minor but an OLDER patch than the bundle's app.json declares (<paramref
+/// name="versionFloors"/>) was reused unconditionally, and the run failed later on a
+/// compile diagnostic that pointed at the test code instead of the stale provisioning.
+/// NoFallbackPlatformAppsPresent/TestToolkitPresent now reject a candidate whose found app
+/// is below its floor, so this loop naturally skips it and falls through to the next
+/// (older) candidate, and eventually to CDN resolution if none qualify. When a candidate is
+/// rejected specifically because it was found-but-stale (not merely absent), <paramref
+/// name="onRejected"/> is told which app, the version found, and the version required —
+/// a silent re-download is better than reusing something too old, but a message is better
+/// than both. Null/empty <paramref name="versionFloors"/> (the default) reproduces the old
+/// presence-only behavior verbatim (AC #4).
 /// </summary>
 static string? FindWarmProvisionedVersion(
-    string artifactsRootDir, string majorMinorPrefix, bool needPlatform, bool needTest)
+    string artifactsRootDir, string majorMinorPrefix, bool needPlatform, bool needTest,
+    IReadOnlyDictionary<string, Version>? versionFloors = null,
+    Action<string>? onRejected = null)
 {
     if (!Directory.Exists(artifactsRootDir)) return null;
     var candidates = Directory.EnumerateDirectories(artifactsRootDir)
@@ -5070,11 +5092,23 @@ static string? FindWarmProvisionedVersion(
 
     foreach (var name in candidates)
     {
+        var platformDir = AlRunner.Infrastructure.ProvisioningCheck.PlatformAppsDirFor(artifactsRootDir, name);
+        var testDir = AlRunner.Infrastructure.ProvisioningCheck.TestAppsDirFor(artifactsRootDir, name);
         var platformOk = !needPlatform || AlRunner.Infrastructure.ProvisioningCheck.NoFallbackPlatformAppsPresent(
-            new[] { AlRunner.Infrastructure.ProvisioningCheck.PlatformAppsDirFor(artifactsRootDir, name) });
+            new[] { platformDir }, versionFloors);
         var testOk = !needTest || AlRunner.Infrastructure.ProvisioningCheck.TestToolkitPresent(
-            new[] { AlRunner.Infrastructure.ProvisioningCheck.TestAppsDirFor(artifactsRootDir, name) });
+            new[] { testDir }, versionFloors);
         if (platformOk && testOk) return name;
+
+        if (versionFloors is { Count: > 0 } && onRejected != null)
+        {
+            var violations = AlRunner.Infrastructure.ProvisioningCheck.FindVersionFloorViolations(
+                new[] { platformDir, testDir }, versionFloors);
+            foreach (var v in violations)
+                onRejected(
+                    $"[provision] warm set '{name}' rejected: '{v.AppName}' found at v{v.FoundVersion}, " +
+                    $"but this bundle's app.json requires >= v{v.RequiredVersion}.");
+        }
     }
     return null;
 }


### PR DESCRIPTION
Closes #2003

## Root cause

`FindWarmProvisionedVersion` decided "reuse this warm platform-apps/test-apps
set" on **presence alone** — it never compared the app actually found against
the version floor the bundle's `app.json` manifests declare. A warm set at the
same BC major.minor but an *older* patch than the manifest requires was reused
unconditionally. The failure wasn't loud: the apps resolved, compilation
proceeded, and the run failed later on whatever compile diagnostic the missing
symbol/changed signature produced — pointing at the test code, not the stale
provisioning.

The same presence-not-version assumption also existed in the **initial**
`DecideManifestProvisioning` gate (the check that decides whether to enter the
auto-provision branch at all, before `FindWarmProvisionedVersion` is ever
reached) — not just in the warm-reuse scan the issue names. Both consult the
same two presence primitives (`NoFallbackPlatformAppsPresent` /
`TestToolkitPresent`), so fixing those primitives fixes both call sites with
one change instead of two parallel special cases.

## Fix

- `ProvisioningCheck.DetermineVersionFloors` derives a per-app minimum version
  from the same manifest dependency roots `DetermineManifestNeeds` already
  reads (highest floor wins when multiple manifests declare different
  versions for the same app).
- `NoFallbackPlatformAppsPresent` / `TestToolkitPresent` gained an optional
  `versionFloors` parameter (default `null`, so every existing caller and test
  is unaffected): a found app below its floor no longer counts as present.
- `DecideManifestProvisioning` computes floors internally and threads them
  through automatically, so the initial gate, the post-download re-check, and
  `FindWarmProvisionedVersion`'s warm-reuse scan all become floor-aware from
  one fix.
- `ProvisioningCheck.FindVersionFloorViolations` reports which app was
  rejected, the version found, and the version required, for the specific
  "found but stale" case (plain absence is unaffected — that's still handled
  by the existing presence gap). `FindWarmProvisionedVersion` surfaces this on
  stderr before falling through to the next (older) candidate or to CDN
  resolution.

## Acceptance criteria

1. Warm set meeting the floor still reused, no download —
   `NoFallbackPlatformAppsPresent_AtOrAboveFloor_ReturnsTrue`,
   `DecideManifestProvisioning_WarmSetMeetsDeclaredFloor_ReusedNoDownload`.
2. Warm set below the floor not reused, correct version provisioned instead —
   `NoFallbackPlatformAppsPresent_BelowFloor_ReturnsFalse`,
   `DecideManifestProvisioning_WarmSetBelowDeclaredFloor_NotReused_DownloadsInstead`
   (falls through to `ArtifactDownloader.ResolveVersion`, unchanged).
3. Rejection names the app, version found, version required —
   `FindVersionFloorViolations_AppBelowFloor_ReportsNameFoundAndRequired`, and
   `FindWarmProvisionedVersion`'s `onRejected` callback in `Program.cs`.
4. No declared floor keeps presence-based behavior —
   `NoFallbackPlatformAppsPresent_NoFloorsGiven_MatchesOldPresenceOnlyBehavior`,
   `DecideManifestProvisioning_NoDeclaredFloor_KeepsPresenceOnlyBehavior`.
5. No new network request in any case the current code doesn't make one — all
   new/changed code is a pure filesystem scan; the only network call
   (`ArtifactDownloader.ResolveVersion`) is the pre-existing fallback path,
   unchanged.

## Testing

- RED confirmed: reverted the two implementation files (kept the new tests)
  and rebuilt — compile failure (`CS0117`/`CS1501`) on the new API surface,
  since it didn't exist yet.
- GREEN: `dotnet test AlRunner.Tests/AlRunner.Tests.csproj --filter
  FullyQualifiedName~ProvisioningCheckTests` → 66/66 passed.
- Full suite: `dotnet test AlRunner.Tests/AlRunner.Tests.csproj` → 841 passed,
  0 failed, 54 skipped (pre-existing skips, unrelated).

This is runner-specific behavior (auto-provision decision logic), not BC
behavior, so the proving tests live in `AlRunner.Tests/` per
`bc-behavior-tests-go-upstream.md`.