### PR TITLE
fix(watch): RadSelfBaselineLoader must agree on the composite "not mine" convention

### DIFF
--- a/AlRunner.Tests/WatchRadRealDependencyTests.cs
+++ b/AlRunner.Tests/WatchRadRealDependencyTests.cs
@@ -1,0 +1,132 @@
+using System.Diagnostics;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// Issue #2009: `--watch`'s incremental (RAD) recompile path always fell back to a full
+/// rebuild, from cycle 2 onward, for any bundle whose dependency set includes real
+/// (package-scanner-resolved) app references — which is the normal shape for almost any
+/// realistic AL app (RecordTriggerXRec's `app.json` has empty `dependencies` but
+/// `"runtime": "14.0"`, which pulls in the 5 implicit MS-app deps: System, Application, Base
+/// Application, Business Foundation, System Application).
+///
+/// Root cause (confirmed by adding temporary diagnostics to `RadSelfBaselineLoader` and
+/// observing which method actually returned the wrong value before `CreateForRad`'s
+/// "could not be loaded" diagnostics fired): `RadSelfBaselineLoader.LoadModuleInfo` and
+/// `.GetDependencies` (`AlRunner/BcCompiler.Incremental.cs`) signalled "not mine" by
+/// returning `null!` / `Enumerable.Empty&lt;&gt;()`, instead of throwing
+/// `FileNotFoundException` — the convention `CompositeSymbolReferenceLoader`
+/// (`AlRunner/SymbolJson.cs`) actually falls through on for those two methods (only
+/// `LoadModule` has an explicit non-null check). Sitting FIRST in the composite chain, its
+/// null/empty "miss" WAS the composite's final answer for every MS package spec, so
+/// `refLoader` (the real package scanner, second in the chain) was never consulted —
+/// verbatim the failure mode `JsonSymbolReferenceLoader.GetDependencies`'s own comment
+/// warns about ("would WIN the composite race and erase the real dependency list").
+///
+/// This test proves the FAST PATH is actually taken, not merely that the build succeeds
+/// (it always succeeded before too, just via the slow full-rebuild fallback): it asserts
+/// cycle 2's console output — after a trivial single-literal edit that does not touch any
+/// of the documented disqualifying conditions — does NOT contain "FULL REBUILD".
+///
+/// Spawns the real runner against the real BC artifact/package cache; skips (no-op) when
+/// that cache is absent.
+/// </summary>
+public class WatchRadRealDependencyTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+    private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
+    private static readonly string FixtureSrc = Path.GetFullPath(Path.Combine(
+        AppContext.BaseDirectory, "..", "..", "..", "Fixtures", "RecordTriggerXRec"));
+
+    [SkippableFact]
+    public async Task Watch_TrivialEditOnBundleWithRealMsAppDeps_TakesRadFastPath_NotFullRebuild()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var bundle = Path.Combine(Path.GetTempPath(), "al-runner-watch-rad-msdep", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(bundle);
+        foreach (var f in Directory.GetFiles(FixtureSrc))
+            File.Copy(f, Path.Combine(bundle, Path.GetFileName(f)));
+        var testsCodeunitPath = Path.Combine(bundle, "XRecProbeTests.Codeunit.al");
+        var cacheDir = Path.Combine(bundle, ".cache");
+
+        var lines = new List<CapturedLine>();
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            Arguments = TestBuildConfig.RunArgs(ProjectPath) + TestBuildConfig.BcVersionArg
+                + $" \"{bundle}\" --watch --cache \"{cacheDir}\"",
+            RedirectStandardOutput = true, RedirectStandardError = true,
+            UseShellExecute = false, CreateNoWindow = true, WorkingDirectory = RepoRoot,
+        };
+        using var p = Process.Start(psi)!;
+        void Pump(StreamReader r, OutputStream stream) => Task.Run(async () =>
+        {
+            string? l;
+            while ((l = await r.ReadLineAsync()) != null) lock (lines) lines.Add(new CapturedLine(stream, l));
+        });
+        Pump(p.StandardOutput, OutputStream.Stdout);
+        Pump(p.StandardError, OutputStream.Stderr);
+
+        string ProcessLiveness() =>
+            p.HasExited ? $"process alive=false exit={p.ExitCode}" : "process alive=true";
+        string DumpTail() { lock (lines) return string.Join("\n", lines.TakeLast(40).Select(l => $"[{l.Stream}] {l.Text}")); }
+
+        async Task<int> WaitForMarkerAfter(int fromIndex, TimeSpan timeout)
+        {
+            var deadline = DateTime.UtcNow + timeout;
+            while (DateTime.UtcNow < deadline)
+            {
+                List<int> found;
+                lock (lines)
+                    found = WatchOutputSlicing.FindStdoutMarkerIndices(lines, WatchOutputSlicing.WaitingForSourceMarker, fromIndex);
+                if (found.Count > 0) return found[0];
+                if (p.HasExited)
+                {
+                    await Task.Delay(500);
+                    throw new TimeoutException(
+                        $"watch marker not seen — subprocess exited early ({ProcessLiveness()}).\n--- last output ---\n{DumpTail()}");
+                }
+                await Task.Delay(200);
+            }
+            if (p.HasExited) await Task.Delay(500);
+            throw new TimeoutException($"watch marker not seen. {ProcessLiveness()}\n--- last output ---\n{DumpTail()}");
+        }
+
+        string Segment(int from, int to) { lock (lines) return WatchOutputSlicing.MergedJoin(lines, from, to); }
+
+        try
+        {
+            // Cycle 0 (cold): always falls back ("no incremental baseline yet") — not the
+            // claim under test, just getting a baseline recorded.
+            int m1 = await WaitForMarkerAfter(0, TimeSpan.FromSeconds(150));
+            var cycle1 = Segment(0, m1);
+            Assert.DoesNotContain("FULL REBUILD", cycle1);
+
+            // Trivial content edit: change ONE string literal inside a procedure body.
+            // Still exactly one object in the file, no rename, no app.json change, no
+            // duplicate declaration — none of BcCompiler.Incremental.cs's documented
+            // disqualifying conditions apply, so this must take the RAD fast path.
+            var original = await File.ReadAllTextAsync(testsCodeunitPath);
+            Assert.Contains("'A1'", original);
+            var edited = original.Replace("'A1'", "'A2'");
+            await File.WriteAllTextAsync(testsCodeunitPath, edited);
+
+            int m2 = await WaitForMarkerAfter(m1 + 1, TimeSpan.FromSeconds(240));
+            var cycle2 = Segment(m1 + 1, m2);
+
+            // The actual claim: RAD's fast path was taken, not the full-rebuild fallback.
+            // Before the fix, this cycle prints "FULL REBUILD ... RAD Emit failed: A
+            // package with publisher 'Microsoft', name '...', ... could not be loaded."
+            // for all 5 implicit MS-app deps, every single cycle.
+            Assert.DoesNotContain("FULL REBUILD", cycle2);
+            Assert.DoesNotContain("could not be loaded", cycle2);
+        }
+        finally
+        {
+            try { p.Kill(true); } catch { }
+        }
+    }
+}

--- a/AlRunner/BcCompiler.Incremental.cs
+++ b/AlRunner/BcCompiler.Incremental.cs
@@ -876,6 +876,50 @@ public sealed partial class BcCompiler
     /// Resolves CreateForRad's mandatory <c>symbolReferenceLoader</c>/<c>symbolReferences</c> for
     /// THIS module's own baseline objects — see this file's header comment for why
     /// packagedModuleDefinition alone does not resolve them.
+    ///
+    /// Placed FIRST in the <see cref="CompositeSymbolReferenceLoader"/> chain built by
+    /// <see cref="TryEmitIncremental"/> (self loader, then <c>refLoader</c> — the real
+    /// package/JSON-symbols loader for every OTHER dependency, e.g. System Application, Base
+    /// Application). "Not mine" (a spec for any AppId other than this module's own) MUST
+    /// throw <see cref="FileNotFoundException"/> — the ONE "not mine" convention every
+    /// <see cref="NavCA.ISymbolReferenceLoader"/> composed via
+    /// <see cref="CompositeSymbolReferenceLoader"/> in this file uses (see
+    /// <see cref="JsonSymbolReferenceLoader"/>'s <c>LoadModule</c>/<c>LoadModuleInfo</c>/
+    /// <c>GetDependencies</c> in SymbolJson.cs, which already throw for exactly this reason,
+    /// on all three methods).
+    ///
+    /// Issue #2009: this loader used to signal "not mine" by returning <c>null</c> /
+    /// <c>Enumerable.Empty&lt;&gt;()</c> instead — a DIFFERENT convention from the rest of the
+    /// chain. Sitting first, that null/empty answer WAS the composite's final result for
+    /// every non-self spec on two of the three methods:
+    ///   - <c>CompositeSymbolReferenceLoader.LoadModuleInfo</c> has no null-check (`return
+    ///     child.LoadModuleInfo(...)` inside a `catch (FileNotFoundException)` only) — a
+    ///     `null` answer from THIS (first) child was returned as the composite's own final
+    ///     answer, without ever asking `refLoader`. Confirmed the live cause by instrumenting
+    ///     this method and reproducing #2009's exact "could not be loaded" diagnostics: BC's
+    ///     `CreateForRad` calls `LoadModuleInfo` (never bare `LoadModule`) to resolve each
+    ///     dependency spec, got `null` for every MS-app package, and reported it unresolved.
+    ///   - <c>CompositeSymbolReferenceLoader.GetDependencies</c> only falls through on
+    ///     `null`, and `Enumerable.Empty&lt;&gt;()` is not null — the same failure
+    ///     <see cref="JsonSymbolReferenceLoader.GetDependencies"/>'s own comment warns about
+    ///     ("would WIN the composite race and erase the real dependency list").
+    /// `LoadModule` happened to keep working only because
+    /// <c>CompositeSymbolReferenceLoader.LoadModule</c> is the one method with an explicit
+    /// `if (module != null) return module;` check — a second, independent "not mine" signal
+    /// that the other two methods do not share. Converging THIS loader onto the throwing
+    /// convention (rather than adding matching null-checks to the other two composite
+    /// methods) removes the split itself, so the next loader added to this chain cannot
+    /// reintroduce the same bug by picking the "wrong" one of two coexisting conventions.
+    ///
+    /// Throwing here is safe even when this loader is used bare (no `refLoader` — a bundle
+    /// with zero resolved dependencies, so `TryEmitIncremental` skips the
+    /// <see cref="CompositeSymbolReferenceLoader"/> wrapper entirely and hands
+    /// <c>Compilation.CreateForRad</c> this loader directly): <see cref="JsonSymbolReferenceLoader"/>
+    /// already throws unconditionally on every miss and is *also* sometimes handed to BC bare
+    /// (<c>BcCompiler.GetSharedReferences</c>' `chain.Count == 1` case) — proven safe by every
+    /// green corpus run that exercises that path, since BC's own reference resolution treats
+    /// the exception exactly like the null/empty answer it tolerates from a `Compilation`
+    /// built without any dependencies at all: a graceful "not found" diagnostic, not a crash.
     /// </summary>
     private sealed class RadSelfBaselineLoader : NavCA.ISymbolReferenceLoader
     {
@@ -884,12 +928,30 @@ public sealed partial class BcCompiler
         public RadSelfBaselineLoader(Guid appId, NavSymRef.ModuleDefinition module) { _appId = appId; _module = module; }
 
         public NavSymRef.ModuleDefinition? LoadModule(NavCA.SymbolReferenceSpecification reference, IList<NavCA.Diagnostics.Diagnostic> diagnostics)
-            => reference.AppId == _appId ? _module : null;
+        {
+            if (reference.AppId != _appId)
+                throw new FileNotFoundException(
+                    $"Symbol reference not found: {reference.Publisher}/{reference.Name} {reference.Version}");
+            return _module;
+        }
 
         public NavCA.ModuleInfo LoadModuleInfo(NavCA.SymbolReferenceSpecification reference, IList<NavCA.Diagnostics.Diagnostic> diagnostics, NavCA.LoadModuleInfoFlags flags)
-            => reference.AppId == _appId ? new NavCA.ModuleInfo(_module, documentationProvider: null) : null!;
+        {
+            if (reference.AppId != _appId)
+                throw new FileNotFoundException(
+                    $"Symbol reference not found: {reference.Publisher}/{reference.Name} {reference.Version}");
+            return new NavCA.ModuleInfo(_module, documentationProvider: null);
+        }
 
         public IEnumerable<NavCA.SymbolReferenceSpecification> GetDependencies(NavCA.SymbolReferenceSpecification reference, IList<NavCA.Diagnostics.Diagnostic> diagnostics)
-            => Enumerable.Empty<NavCA.SymbolReferenceSpecification>();
+        {
+            if (reference.AppId != _appId)
+                throw new FileNotFoundException(
+                    $"Symbol reference dependencies not found: {reference.Publisher}/{reference.Name} {reference.Version}");
+            // Self has no further transitive deps THIS loader needs to report — the
+            // module's own dependency closure is already the (separately supplied)
+            // `combinedSpecs` list, not something discovered on demand here.
+            return Enumerable.Empty<NavCA.SymbolReferenceSpecification>();
+        }
     }
 }


### PR DESCRIPTION
Closes #2009

## Root cause (confirmed before patching, per no-assumption-fixes.md)

`--watch`'s incremental (RAD) recompile path fell back to a full rebuild on
every cycle for any bundle with real MS-app dependencies (System Application,
Base Application, Business Foundation, Application, System) — the normal
shape for almost any realistic AL app.

Confirmed the exact mechanism by temporarily instrumenting
`RadSelfBaselineLoader` (`AlRunner/BcCompiler.Incremental.cs`) and reproducing
the issue's exact "could not be loaded" diagnostics against the
`RecordTriggerXRec` fixture (empty `dependencies`, `runtime: 14.0` → 5
implicit MS-app deps, `--bc-version 28.1.49838.53910`):

- BC's `CreateForRad` calls `LoadModuleInfo` (never bare `LoadModule`) to
  resolve each dependency spec — confirmed by trace, `LoadModule` is never
  invoked for the MS packages at all.
- `RadSelfBaselineLoader` sits **first** in
  `CompositeSymbolReferenceLoader`'s chain (self loader, then `refLoader` —
  the real package scanner). It signalled "not mine" for `LoadModuleInfo`
  and `GetDependencies` by returning `null!` / `Enumerable.Empty<>()`,
  instead of throwing `FileNotFoundException` — the convention
  `JsonSymbolReferenceLoader` already uses (`AlRunner/SymbolJson.cs`), and
  the *only* one `CompositeSymbolReferenceLoader.LoadModuleInfo` /
  `.GetDependencies` actually fall through on (only `LoadModule` has an
  explicit `if (module != null)` check).
- Sitting first, that null/empty answer **was** the composite's final
  answer for every MS package spec — `refLoader` (the real scanner, second
  in the chain) was never consulted. Verbatim the failure
  `JsonSymbolReferenceLoader.GetDependencies`'s own comment warns about.

Trace evidence (temporary debug instrumentation, removed before commit):

```
DEBUG RadSelf.LoadModuleInfo(Microsoft/System Application) hit=False
DEBUG RadSelf.LoadModuleInfo(Microsoft/Business Foundation) hit=False
DEBUG RadSelf.LoadModuleInfo(Microsoft/Base Application) hit=False
DEBUG RadSelf.LoadModuleInfo(Microsoft/Application) hit=False
DEBUG RadSelf.LoadModuleInfo(Microsoft/System) hit=False
DEBUG RadSelf.LoadModuleInfo(AL Runner/...) hit=True
[watch] ...: FULL REBUILD ... RAD Emit failed: A package with publisher
'Microsoft', name 'System Application', ... could not be loaded. | ...
```

## Fix

Converge `RadSelfBaselineLoader` onto the throwing convention on **all
three** methods, rather than adding a matching null-check to
`CompositeSymbolReferenceLoader`. The split convention between loaders is
what let this bug happen once already; a null-check only patches this one
symptom and leaves the same trap for the next loader someone adds to the
chain. One documented invariant ("not mine" → `FileNotFoundException`,
always) is easier to keep correct going forward than two coexisting
conventions plus a per-method null-check to paper over the mismatch.

This is safe even for the "no `refLoader`" standalone case (a bundle with
zero resolved dependencies, where `TryEmitIncremental` hands
`RadSelfBaselineLoader` to `Compilation.CreateForRad` bare, with no
`CompositeSymbolReferenceLoader` wrapper): `JsonSymbolReferenceLoader` is
*also* sometimes handed to BC bare (`BcCompiler.GetSharedReferences`'
`chain.Count == 1` case) and already throws unconditionally on every miss —
proven safe by every green corpus run that exercises that path.

Checked whether the same convention mismatch affects anything else in the
chain (issue requirement 4): `SelfExcludingSymbolReferenceLoader`
(`AlRunner/SymbolJson.cs`) uses the same null/`Enumerable.Empty<>()` "not
mine" signal, but it is always placed **last** in its own internal chain
(`AlRunner/BcCompiler.cs`'s `GetSharedReferences`, explicit comment: "stays
at the END of the chain"), where a null/empty answer at the end of the loop
is indistinguishable from falling off the end — no live bug there today.
Left as-is; noted in the fix's own doc comment for the next person who
touches this file.

## Proof

Real `--watch` subprocess against `RecordTriggerXRec`
(`AlRunner.Tests/Fixtures/RecordTriggerXRec`), a trivial single-literal edit
on cycle 2 (`'A1'` → `'A2'`, still exactly one object per file, no rename, no
`app.json` change):

| | Before | After |
|---|---|---|
| Cycle 2 console | `FULL REBUILD ... could not be loaded` (all 5 MS packages) | `[watch] re-emitted ... running…` (RAD fast path) |
| AL emit time | 15.2s | 0.1s |

New test `AlRunner.Tests/WatchRadRealDependencyTests.cs`
(`Watch_TrivialEditOnBundleWithRealMsAppDeps_TakesRadFastPath_NotFullRebuild`)
proves the fast path is actually taken — asserts cycle 2's console output
does NOT contain `"FULL REBUILD"` / `"could not be loaded"`, not merely that
the build succeeds (it always succeeded before too, just via the slow
fallback). RED against the pre-fix code (confirmed), GREEN after.

## Test plan

- [x] RED: new test fails against pre-fix code with the exact reported
      "FULL REBUILD ... could not be loaded" diagnostics.
- [x] GREEN: new test passes after the fix.
- [x] Manual before/after `--watch` repro (see table above) — the actual
      performance claim, not just a pass/fail assertion.
- [x] `BcCompilerSharedReferenceMemoTests` (composite/self-exclusion
      machinery) still green — no regression to the loader chain the fix
      touches.
- [ ] CI (8-version corpus + runner-extras matrix)