### PR TITLE
fix(diagnostics): stop the Field virtual-table ctor-failure message from asserting an unverified cause

### DIFF
--- a/AlRunner.Tests/EngineMinorMismatchWarningTests.cs
+++ b/AlRunner.Tests/EngineMinorMismatchWarningTests.cs
@@ -1,0 +1,91 @@
+// EngineMinorMismatchWarningTests — proves BcArtifacts.DescribeExplicitEngineMinorMismatch,
+// the pure core behind #2008's fix.
+//
+// #2008's root cause: every shipped al-runner binary's engine (Ncl.dll etc.) is compiled
+// against BC 28.1 (bc-tests.yml's resolve-versions job hardcodes 28.1 as `required-version`
+// for release/pack jobs). Ncl.dll's own AssemblyVersion is always MAJOR.0.0.0 (28.0.0.0 for
+// every 28.x build), so VerifyEngineConsistency — which only compares Major — cannot see a
+// same-major, different-MINOR selection. The reporter ran the v2.3.1 binary (engine built
+// for 28.1.49838.50794) with `--bc-version 28.3` explicitly. That silently ran a BC-28.1
+// engine against BC-28.3 artifacts and threw NullReferenceException deep inside BC's own
+// FieldDataProvider ctor (NavGlobal.get_SystemTenant -> get_NCLMetadata) — confirmed by
+// reproducing it against both the actual published v2.3.1 tool and a from-source rebuild
+// pinned to the exact same engine version, and confirming a matched-minor rebuild (engine
+// built for 28.3, run against 28.3) is clean.
+//
+// The runner ALREADY had an equivalent warning for the auto-select default path (no
+// --bc-version/--artifact-path given) in Program.cs — this test proves the NEW check that
+// makes it reachable from an EXPLICIT --bc-version/--artifact-path selection too, which is
+// exactly the case that reproduced #2008 and went unwarned.
+using AlRunner.Infrastructure;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public class EngineMinorMismatchWarningTests
+{
+    [Fact]
+    public void DescribeExplicitEngineMinorMismatch_DifferentMinor_WarnsWithBothVersions()
+    {
+        var built = new Version("28.1.49838.50794");
+        var selected = new Version("28.3.52162.53954");
+
+        var message = BcArtifacts.DescribeExplicitEngineMinorMismatch(built, selected);
+
+        Assert.NotNull(message);
+        Assert.Contains("28.1.49838.50794", message);
+        Assert.Contains("28.3.52162.53954", message);
+        Assert.Contains("explicitly selected", message);
+        Assert.Contains("KNOWN-DEGRADED", message);
+        Assert.Contains("#2008", message);
+        // Names the fix, not just the symptom, so the message is actionable.
+        Assert.Contains("-p:_BCVersion=28.3.52162.53954", message);
+    }
+
+    [Fact]
+    public void DescribeExplicitEngineMinorMismatch_SameMajorMinor_ExactBuildMatch_ReturnsNull()
+    {
+        var built = new Version("28.1.49838.50794");
+        var selected = new Version("28.1.49838.50794");
+
+        Assert.Null(BcArtifacts.DescribeExplicitEngineMinorMismatch(built, selected));
+    }
+
+    [Fact]
+    public void DescribeExplicitEngineMinorMismatch_SameMinor_DifferentPatchBuild_TreatedAsTolerated()
+    {
+        // Patch-level skew within one minor (28.1.49838.53910 vs 28.1.49838.50794) is the
+        // SAME tolerance VerifyEngineConsistency already applies for Major-only comparison —
+        // this extends it one level deeper (Major.Minor) without narrowing what was already
+        // accepted.
+        var built = new Version("28.1.49838.50794");
+        var selected = new Version("28.1.49838.53910");
+
+        Assert.Null(BcArtifacts.DescribeExplicitEngineMinorMismatch(built, selected));
+    }
+
+    [Fact]
+    public void DescribeExplicitEngineMinorMismatch_DifferentMajor_StillWarns()
+    {
+        // VerifyEngineConsistency throws before this ever runs for a real Major mismatch in
+        // production, but the pure function itself must not silently approve one either —
+        // Major is also part of "Major.Minor", so this is a genuine proving case, not
+        // reachable-in-practice noise.
+        var built = new Version("27.5.46862.53931");
+        var selected = new Version("28.1.49838.53910");
+
+        var message = BcArtifacts.DescribeExplicitEngineMinorMismatch(built, selected);
+
+        Assert.NotNull(message);
+        Assert.Contains("27.5.46862.53931", message);
+        Assert.Contains("28.1.49838.53910", message);
+    }
+
+    [Fact]
+    public void DescribeExplicitEngineMinorMismatch_UnstampedOlderBinary_ReturnsNull()
+    {
+        // BcEngineVersion is missing on a binary built before this attribute existed —
+        // nothing to compare against, so this must not fabricate a warning.
+        Assert.Null(BcArtifacts.DescribeExplicitEngineMinorMismatch(builtVersion: null, new Version("28.3.52162.53954")));
+    }
+}

--- a/AlRunner.Tests/MetadataProviderSeedDiagnosisTests.cs
+++ b/AlRunner.Tests/MetadataProviderSeedDiagnosisTests.cs
@@ -1,0 +1,106 @@
+// MetadataProviderSeedDiagnosisTests — proves BcRuntime.IsMetadataProviderSeeded() reports
+// the REAL, live state of NavSystemTenant.metadataProvider instead of assuming it.
+//
+// Why this exists (#2008)
+// ------------------------
+// AlRunner.Patches.RecordPatches.FieldVirtualTable.cs's BuildManagedFieldDataProvider wraps
+// any failure of BC's own FieldDataProvider(NavSession) ctor in a RunnerOutOfScopeException
+// whose message used to assert, UNCONDITIONALLY, "the skeleton NavGlobal.MetadataProvider/
+// NCLMetadata is not seeded" — even though EnsureMetadataProviderSeeded() (one frame up, in
+// PopulateFieldVirtualTable) had already run by the time that catch block could ever fire.
+// That was a guess dressed up as a diagnosis: issue #2008's own triage comment confirmed
+// nothing in the code path actually verified it. A wrong diagnosis is worse than none — it
+// sends the next investigator down the exact dead end #2008's reporter nearly went down.
+//
+// The fix replaces the assumption with a live field read: BcRuntime.IsMetadataProviderSeeded()
+// (see MetadataPatches.cs) inspects NavSystemTenant.metadataProvider directly and the catch
+// block now reports whichever is actually true. This test proves that helper is accurate in
+// both directions — unseeded (null field) reports false, seeded (non-null field) reports
+// true — by manipulating the live field directly (deterministic, independent of whichever
+// other test in this process may or may not have called EnsureMetadataProviderSeeded()
+// first) and restoring the original value afterwards.
+using System.Reflection;
+using AlRunner;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+// Loads Ncl/skeleton state in-process, so it must share the serial bc-engine collection —
+// see BcEngineCollection.cs.
+[Collection(BcEngineCollection.Name)]
+public class MetadataProviderSeedDiagnosisTests
+{
+    private readonly BcEngineFixture _engine;
+
+    public MetadataProviderSeedDiagnosisTests(BcEngineFixture engine) => _engine = engine;
+
+    private static (Type systemTenantType, object skeletonSystemTenant, FieldInfo metadataProviderField) ResolveSeam()
+    {
+        var skeletonSystemTenant = typeof(BcRuntime)
+            .GetProperty("SkeletonSystemTenant", BindingFlags.Public | BindingFlags.Static)!
+            .GetValue(null);
+        Assert.NotNull(skeletonSystemTenant);
+
+        var systemTenantType = skeletonSystemTenant!.GetType();
+        var metadataProviderField = systemTenantType.GetField(
+            "metadataProvider", BindingFlags.NonPublic | BindingFlags.Instance);
+        Assert.NotNull(metadataProviderField);
+
+        return (systemTenantType, skeletonSystemTenant, metadataProviderField!);
+    }
+
+    [SkippableFact]
+    public void IsMetadataProviderSeeded_FieldIsNull_ReportsFalse()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready,
+            _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        var (_, skeletonSystemTenant, metadataProviderField) = ResolveSeam();
+        var original = metadataProviderField.GetValue(skeletonSystemTenant);
+        try
+        {
+            metadataProviderField.SetValue(skeletonSystemTenant, null);
+
+            Assert.False(BcRuntime.IsMetadataProviderSeeded(),
+                "IsMetadataProviderSeeded() must report false when NavSystemTenant.metadataProvider is genuinely null " +
+                "— this is the one case where the OLD unconditional 'not seeded' wording was actually true.");
+        }
+        finally
+        {
+            metadataProviderField.SetValue(skeletonSystemTenant, original);
+        }
+    }
+
+    [SkippableFact]
+    public void IsMetadataProviderSeeded_FieldIsNonNull_ReportsTrue()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready,
+            _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        var (_, skeletonSystemTenant, metadataProviderField) = ResolveSeam();
+        var original = metadataProviderField.GetValue(skeletonSystemTenant);
+        try
+        {
+            // A real MetadataProvider instance (built the same way EnsureMetadataProviderSeeded
+            // builds one) proves the check reads the field, not merely "did anyone call the
+            // seed method" — the bug #2008 exposed is exactly that distinction: the OLD message
+            // could not tell "never attempted" from "attempted and succeeded".
+            var metaProvType = metadataProviderField.FieldType;
+            var ctor = metaProvType.GetConstructor(
+                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance, null, Type.EmptyTypes, null);
+            var seeded = ctor != null
+                ? ctor.Invoke(null)
+                : System.Runtime.CompilerServices.RuntimeHelpers.GetUninitializedObject(metaProvType);
+            metadataProviderField.SetValue(skeletonSystemTenant, seeded);
+
+            Assert.True(BcRuntime.IsMetadataProviderSeeded(),
+                "IsMetadataProviderSeeded() must report true once NavSystemTenant.metadataProvider genuinely holds " +
+                "a non-null value — proving #2008's fix: the exception message this feeds no longer blames " +
+                "'not seeded' when seeding actually succeeded.");
+        }
+        finally
+        {
+            metadataProviderField.SetValue(skeletonSystemTenant, original);
+        }
+    }
+}

--- a/AlRunner/Infrastructure/BcArtifacts.cs
+++ b/AlRunner/Infrastructure/BcArtifacts.cs
@@ -352,4 +352,49 @@ public static class BcArtifacts
                 $"(--bc-version {engineVer.Major}).");
         }
     }
+
+    /// <summary>
+    /// Pure core of <see cref="WarnIfExplicitEngineMinorMismatch"/>, split out for direct unit
+    /// testing (see AlRunner.Tests.EngineMinorMismatchWarningTests) — mirrors the
+    /// BcEngineReadinessGuard.AssertReadyOnCi(bool,string?,bool) shape: a pure function over
+    /// explicit values is provable with no BC engine or CLI invocation involved.
+    ///
+    /// #2008's actual root cause: a shipped al-runner binary's engine (Ncl.dll etc.) is built
+    /// for one BC MINOR (the release pipeline pins BC 28.1 as `required-version` — see
+    /// bc-tests.yml), but Ncl.dll's own AssemblyVersion is always MAJOR.0.0.0, so
+    /// VerifyEngineConsistency (which only compares Major) cannot see a same-major
+    /// different-minor selection at all. Running that binary with `--bc-version 28.3`
+    /// silently ran BC 28.1's engine against BC 28.3 artifacts and threw a
+    /// NullReferenceException deep inside BC's own FieldDataProvider ctor
+    /// (NavGlobal.get_SystemTenant → get_NCLMetadata) with nothing pointing at the real
+    /// cause. The runner ALREADY had this exact warning — Program.cs's auto-select default
+    /// path prints it when the user passes neither --bc-version nor --artifact-path — but it
+    /// was unreachable in precisely the case that needed it: an EXPLICIT --bc-version/
+    /// --artifact-path skips the auto-select branch entirely. This is the same warning,
+    /// reachable from the explicit-selection path too.
+    /// </summary>
+    internal static string? DescribeExplicitEngineMinorMismatch(System.Version? builtVersion, System.Version selectedVersion)
+    {
+        if (builtVersion == null) return null; // older/unstamped binary — nothing to compare
+        if (builtVersion.Major == selectedVersion.Major && builtVersion.Minor == selectedVersion.Minor)
+            return null; // matched minor, or patch-level skew within it — tolerated, same as VerifyEngineConsistency
+
+        return $"[bc] warning: this binary's engine was built for BC {builtVersion} but BC {selectedVersion} was " +
+            $"explicitly selected (--bc-version/--artifact-path) — different minor is a KNOWN-DEGRADED " +
+            $"configuration (measured: dozens of extra failures from engine/artifact minor skew, see #2008). " +
+            $"Fix with one of: drop --bc-version so the runner auto-selects its own engine's minor " +
+            $"({builtVersion.Major}.{builtVersion.Minor}), or rebuild with -p:_BCVersion={selectedVersion}.";
+    }
+
+    /// <summary>
+    /// Called ONLY when the user explicitly chose the BC version (--bc-version or
+    /// --artifact-path) — never from the auto-select default path, which already prints its
+    /// own equivalent warning inside Program.cs and must not be double-warned. See
+    /// DescribeExplicitEngineMinorMismatch for the full rationale.
+    /// </summary>
+    public static void WarnIfExplicitEngineMinorMismatch()
+    {
+        var msg = DescribeExplicitEngineMinorMismatch(EngineBuiltVersion(), SelectedVersion);
+        if (msg != null) Console.Error.WriteLine(msg);
+    }
 }

--- a/AlRunner/Patches/MetadataPatches.cs
+++ b/AlRunner/Patches/MetadataPatches.cs
@@ -225,6 +225,24 @@ public static partial class BcRuntime
         }
     }
 
+    /// <summary>
+    /// True iff <c>NavSystemTenant.metadataProvider</c> — the field
+    /// <see cref="EnsureMetadataProviderSeeded"/> populates — currently holds a non-null
+    /// value. Reflects live field state rather than the "did we attempt to seed it"
+    /// <c>_metadataProviderSeeded</c> flag, so a caller diagnosing a downstream failure
+    /// (e.g. <c>FieldDataProvider</c>'s ctor throwing) can report a VERIFIED claim about
+    /// whether seeding actually took, instead of assuming it (see #2008: the runner's own
+    /// prior wording asserted "not seeded" unconditionally on any ctor failure, which is a
+    /// guess, not something the code had checked).
+    /// </summary>
+    public static bool IsMetadataProviderSeeded()
+    {
+        var systemTenantType = _systemTenantTypeForSeed;
+        if (systemTenantType == null || _skeletonSystemTenant == null) return false;
+        var stMetaProvField = systemTenantType.GetField("metadataProvider", BindingFlags.NonPublic | BindingFlags.Instance);
+        return stMetaProvField != null && stMetaProvField.GetValue(_skeletonSystemTenant) != null;
+    }
+
     /// <summary>Exposes the manufactured skeleton NCLMetadata so other patch files can
     /// FieldPoke into its caches (e.g. populate per-table NCLMetaTable entries).</summary>
     public static object? SkeletonNCLMetadata => _skeletonNCLMetadata;

--- a/AlRunner/Patches/RecordPatches.FieldVirtualTable.cs
+++ b/AlRunner/Patches/RecordPatches.FieldVirtualTable.cs
@@ -356,10 +356,21 @@ public static partial class RecordPatches
         catch (TargetInvocationException tie)
         {
             var inner = tie.InnerException ?? tie;
+            // #2008: do NOT assert "NavGlobal.MetadataProvider/NCLMetadata is not seeded" —
+            // that was a guess at the cause, stated unconditionally, even in runs where
+            // EnsureMetadataProviderSeeded() (one frame up, in PopulateFieldVirtualTable)
+            // had already completed successfully and the field genuinely was seeded. A wrong
+            // diagnosis sends the next investigator down a dead end (it did here — see #2008's
+            // triage comment). Report the VERIFIED seed state plus the real inner exception's
+            // type, message AND stack trace instead, so whoever hits this next can actually
+            // find the true failing member without re-deriving it from a decompile.
+            var seedState = AlRunner.BcRuntime.IsMetadataProviderSeeded()
+                ? "NavGlobal.MetadataProvider IS seeded (so that is not the cause)"
+                : "NavGlobal.MetadataProvider is NOT seeded";
             throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
                 "Field (virtual table 2000000041)",
                 $"field-virtual-table — FieldDataProvider ctor failed ({inner.GetType().Name}: {inner.Message}); " +
-                "the skeleton NavGlobal.MetadataProvider/NCLMetadata is not seeded; see docs/scope.md");
+                $"{seedState}; see docs/scope.md. Inner stack trace:\n{inner.StackTrace}");
         }
 
         // Bind base.metaTable to OUR 2000000041 instance so emitted rows align with the

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -552,6 +552,11 @@ if (artifactPathArg != null)
 // The target project's app.json (application/platform) is read purely as a cross-check —
 // a mismatch means the project targets a BC major this runner build can't run, surfaced
 // as a clear message instead of a deep failure. All of this stays overridable.
+// Tracks whether bcVersionArg/artifactPathArg came from the auto-select default
+// below, so the explicit-selection engine-minor-mismatch warning further down (see
+// BcArtifacts.WarnIfExplicitEngineMinorMismatch) does not double-warn a case the
+// auto-select branch already covers with its own, richer message.
+bool bcVersionAutoSelected = false;
 if (bcVersionArg == null && artifactPathArg == null)
 {
     // The BUILT version (4-part, baked in at compile time) — not Ncl.dll's assembly
@@ -562,6 +567,7 @@ if (bcVersionArg == null && artifactPathArg == null)
     var engineMajor = engineVersion?.Major;
     if (engineVersion != null && engineMajor != null)
     {
+        bcVersionAutoSelected = true;
         // Prefer the engine's OWN major.minor. Latest-in-major used to win here, which
         // silently selected a minor the engine was not built for — measured at -45 passing
         // / +42 failing / +3 errors on Pageworks. See BcArtifacts.DefaultVersionPrefix.
@@ -623,6 +629,13 @@ try
     // and the engine can disagree — fail loud rather than crash deep in BC. Patch-level
     // skew (28.1.x build vs 28.1.y cache) is tolerated.
     AlRunner.Infrastructure.BcArtifacts.VerifyEngineConsistency(AppContext.BaseDirectory);
+    // #2008's root cause: VerifyEngineConsistency only catches a MAJOR mismatch (Ncl.dll's
+    // own AssemblyVersion is always major.0.0.0, so it cannot see a same-major
+    // different-minor selection). The auto-select default path above already warns about
+    // minor skew; an EXPLICIT --bc-version/--artifact-path bypassed that warning entirely
+    // and ran a mismatched engine silently. Only warn here for the explicit path.
+    if (!bcVersionAutoSelected)
+        AlRunner.Infrastructure.BcArtifacts.WarnIfExplicitEngineMinorMismatch();
     Console.Error.WriteLine($"[bc] selected BC {AlRunner.Infrastructure.BcArtifacts.SelectedVersion} " +
         $"({AlRunner.Infrastructure.BcArtifacts.ServiceTierDir})");
 }

--- a/tests/expectations/count-baseline/test-count-baseline.json
+++ b/tests/expectations/count-baseline/test-count-baseline.json
@@ -7,11 +7,11 @@
     },
     "runner-extras": {
       "tests": {
-        "default": 179,
+        "default": 184,
         "byBcVersion": { "27.0": 173, "27.3": 173, "27.5": 173 }
       },
       "appGroups": {
-        "default": 28,
+        "default": 31,
         "byBcVersion": { "27.0": 26, "27.3": 26, "27.5": 26 }
       }
     }

--- a/tests/runner-extras/field-virtual-table-item-tracking-ext/WhseItemTrackingSubscriber.Codeunit.al
+++ b/tests/runner-extras/field-virtual-table-item-tracking-ext/WhseItemTrackingSubscriber.Codeunit.al
@@ -1,0 +1,36 @@
+// Non-test half of the two-bundle #2008 reproducer. Mirrors the issue's exact
+// description: "The extension subscribes to the standard event
+// Whse.-Create Source Document.OnAfterSetQtysOnRcptLine and calls the standard
+// tracking API [ItemTrackingManagement.ItemTrackingExistsOnDocumentLine]." This
+// lives in a REGULAR (non-test) codeunit with automatic event binding — not a
+// manually-bound test-codeunit subscriber — because that is what "an extension
+// subscribes" means for an installed app.
+codeunit 61200 "FVTIT Ext Whse Subscriber"
+{
+    SingleInstance = true;
+
+    var
+        LookupRan: Boolean;
+        LookupFound: Boolean;
+
+    [EventSubscriber(ObjectType::Codeunit, Codeunit::"Whse.-Create Source Document", 'OnAfterSetQtysOnRcptLine', '', false, false)]
+    local procedure OnAfterSetQtysOnRcptLine(var WarehouseReceiptLine: Record "Warehouse Receipt Line"; Qty: Decimal; QtyBase: Decimal)
+    var
+        ItemTrackingManagement: Codeunit "Item Tracking Management";
+    begin
+        LookupFound := ItemTrackingManagement.ItemTrackingExistsOnDocumentLine(
+            WarehouseReceiptLine."Source Type", WarehouseReceiptLine."Source Subtype",
+            WarehouseReceiptLine."Source No.", WarehouseReceiptLine."Source Line No.");
+        LookupRan := true;
+    end;
+
+    procedure GetLookupRan(): Boolean
+    begin
+        exit(LookupRan);
+    end;
+
+    procedure GetLookupFound(): Boolean
+    begin
+        exit(LookupFound);
+    end;
+}

--- a/tests/runner-extras/field-virtual-table-item-tracking-ext/app.json
+++ b/tests/runner-extras/field-virtual-table-item-tracking-ext/app.json
@@ -1,0 +1,19 @@
+{
+  "id": "3f2e1d0c-9b8a-4756-a5f3-1e2d3c4b5a69",
+  "name": "Runner Extras - Field Virtual Table Item Tracking Ext",
+  "publisher": "AL Runner",
+  "version": "1.0.0.0",
+  "brief": "Two-bundle #2008 reproducer, dependency half: a non-test, automatically-bound event subscriber that mirrors the reporter's 'the extension subscribes to the standard event' setup.",
+  "description": "Paired with field-virtual-table-item-tracking-test — reproduces #2008's exact two-path invocation shape (extension app + separate test app) rather than a single self-contained test bundle.",
+  "dependencies": [],
+  "idRanges": [
+    {
+      "from": 61200,
+      "to": 61249
+    }
+  ],
+  "platform": "28.0.0.0",
+  "application": "28.0.0.0",
+  "runtime": "17.0",
+  "target": "Cloud"
+}

--- a/tests/runner-extras/field-virtual-table-item-tracking-test/FVTITAssert.Codeunit.al
+++ b/tests/runner-extras/field-virtual-table-item-tracking-test/FVTITAssert.Codeunit.al
@@ -1,0 +1,14 @@
+codeunit 61250 "FVTITX Assert"
+{
+    procedure IsTrue(Condition: Boolean; Msg: Text)
+    begin
+        if not Condition then
+            Error('Assert.IsTrue failed. %1', Msg);
+    end;
+
+    procedure IsFalse(Condition: Boolean; Msg: Text)
+    begin
+        if Condition then
+            Error('Assert.IsFalse failed. %1', Msg);
+    end;
+}

--- a/tests/runner-extras/field-virtual-table-item-tracking-test/WarehouseReceiptTwoBundleTests.Codeunit.al
+++ b/tests/runner-extras/field-virtual-table-item-tracking-test/WarehouseReceiptTwoBundleTests.Codeunit.al
@@ -1,0 +1,77 @@
+// Two-bundle #2008 reproducer, test half. The reporter's exact command line
+// passed TWO bundle paths — an extension app and a separate test app that
+// depends on it — not one self-contained bundle. field-virtual-table-item-
+// tracking (a single-bundle reproducer with the subscriber inlined into the
+// test codeunit) already proved the surface works standalone; this bundle
+// exists to prove (or disprove) that going through a SEPARATE, non-test,
+// automatically-bound extension codeunit changes anything.
+codeunit 61251 "FVTITX Whse Flow Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit "FVTITX Assert";
+        LibraryPurchase: Codeunit "Library - Purchase";
+        LibraryInventory: Codeunit "Library - Inventory";
+        LibraryItemTracking: Codeunit "Library - Item Tracking";
+        LibraryWarehouse: Codeunit "Library - Warehouse";
+        LibraryUtility: Codeunit "Library - Utility";
+
+    [Test]
+    procedure PurchLine2ReceiptLine_LotTrackedWithReservation_ExtensionSubscriberLookupWorks()
+    var
+        WarehouseSetup: Record "Warehouse Setup";
+        PurchasesPayablesSetup: Record "Purchases & Payables Setup";
+        SourceCodeSetup: Record "Source Code Setup";
+        ItemTrackingCode: Record "Item Tracking Code";
+        Item: Record Item;
+        WarehouseReceiptHeader: Record "Warehouse Receipt Header";
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        ReservEntry: Record "Reservation Entry";
+        PurchasesWarehouseManagement: Codeunit "Purchases Warehouse Mgt.";
+        Subscriber: Codeunit "FVTIT Ext Whse Subscriber";
+    begin
+        LibraryWarehouse.NoSeriesSetup(WarehouseSetup);
+
+        PurchasesPayablesSetup.Get();
+        PurchasesPayablesSetup.Validate("Order Nos.", LibraryUtility.GetGlobalNoSeriesCode());
+        PurchasesPayablesSetup.Modify(true);
+
+        // See field-virtual-table-item-tracking/WarehouseReceiptFlowTests.Codeunit.al for why
+        // this is needed (unrelated, already-documented Company-Initialize gap).
+        if not SourceCodeSetup.Get() then begin
+            SourceCodeSetup.Init();
+            SourceCodeSetup.Insert();
+        end;
+
+        LibraryItemTracking.CreateLotItem(Item);
+        ItemTrackingCode.Get(Item."Item Tracking Code");
+
+        LibraryPurchase.CreatePurchaseDocumentWithItem(
+            PurchaseHeader, PurchaseLine, PurchaseHeader."Document Type"::Order,
+            '', Item."No.", 4, '', 0D);
+
+        ReservEntry.Init();
+        ReservEntry."Entry No." := 1;
+        ReservEntry."Item No." := Item."No.";
+        ReservEntry."Source Type" := Database::"Purchase Line";
+        ReservEntry."Source Subtype" := PurchaseLine."Document Type".AsInteger();
+        ReservEntry."Source ID" := PurchaseLine."Document No.";
+        ReservEntry."Source Ref. No." := PurchaseLine."Line No.";
+        ReservEntry."Qty. to Handle (Base)" := 2;
+        ReservEntry."Item Tracking" := ReservEntry."Item Tracking"::"Lot No.";
+        ReservEntry."Lot No." := 'ALR-LOT-1';
+        ReservEntry.Insert();
+
+        LibraryWarehouse.CreateWarehouseReceiptHeader(WarehouseReceiptHeader);
+
+        // Codeunit 61200 in the DEPENDENCY app is a regular, non-test, automatically-bound
+        // subscriber (not manually bound like the single-bundle reproducer) — the closest
+        // match to "the extension subscribes to the standard event" from #2008.
+        PurchasesWarehouseManagement.PurchLine2ReceiptLine(WarehouseReceiptHeader, PurchaseLine);
+
+        Assert.IsTrue(Subscriber.GetLookupRan(), 'The extension subscriber must have run and reached the item-tracking lookup');
+        Assert.IsTrue(Subscriber.GetLookupFound(), 'The seeded lot-tracked Reservation Entry must be found by ItemTrackingExistsOnDocumentLine');
+    end;
+}

--- a/tests/runner-extras/field-virtual-table-item-tracking-test/app.json
+++ b/tests/runner-extras/field-virtual-table-item-tracking-test/app.json
@@ -1,0 +1,32 @@
+{
+  "id": "6a5b4c3d-2e1f-4890-b7c6-5d4e3f2a1b08",
+  "name": "Runner Extras - Field Virtual Table Item Tracking Test",
+  "publisher": "AL Runner",
+  "version": "1.0.0.0",
+  "brief": "Two-bundle #2008 reproducer, test half. Depends on field-virtual-table-item-tracking-ext, matching the reporter's two-path invocation: an extension app plus a separate test app.",
+  "description": "See field-virtual-table-item-tracking-ext for the subscriber half.",
+  "dependencies": [
+    {
+      "id": "3f2e1d0c-9b8a-4756-a5f3-1e2d3c4b5a69",
+      "name": "Runner Extras - Field Virtual Table Item Tracking Ext",
+      "publisher": "AL Runner",
+      "version": "1.0.0.0"
+    },
+    {
+      "id": "d852d5d2-a39d-4179-baeb-f99a19e32510",
+      "name": "Application Test Library",
+      "publisher": "Microsoft",
+      "version": "28.0.0.0"
+    }
+  ],
+  "idRanges": [
+    {
+      "from": 61250,
+      "to": 61299
+    }
+  ],
+  "platform": "28.0.0.0",
+  "application": "28.0.0.0",
+  "runtime": "17.0",
+  "target": "Cloud"
+}

--- a/tests/runner-extras/field-virtual-table-item-tracking/FVTITAssert.Codeunit.al
+++ b/tests/runner-extras/field-virtual-table-item-tracking/FVTITAssert.Codeunit.al
@@ -1,0 +1,20 @@
+codeunit 61100 "FVTIT Assert"
+{
+    procedure IsTrue(Condition: Boolean; Msg: Text)
+    begin
+        if not Condition then
+            Error('Assert.IsTrue failed. %1', Msg);
+    end;
+
+    procedure IsFalse(Condition: Boolean; Msg: Text)
+    begin
+        if Condition then
+            Error('Assert.IsFalse failed. %1', Msg);
+    end;
+
+    procedure AreEqual(Expected: Integer; Actual: Integer; Msg: Text)
+    begin
+        if Expected <> Actual then
+            Error('Assert.AreEqual failed. Expected:<%1>. Actual:<%2>. %3', Expected, Actual, Msg);
+    end;
+}

--- a/tests/runner-extras/field-virtual-table-item-tracking/FieldVirtualTableItemTrackingTests.Codeunit.al
+++ b/tests/runner-extras/field-virtual-table-item-tracking/FieldVirtualTableItemTrackingTests.Codeunit.al
@@ -1,0 +1,73 @@
+// Reproduces #2008: the virtual Field system table (2000000041) provider must
+// initialize successfully during a standard item-tracking / reservation lookup
+// against Base App's "Reservation Entry" table (337), not only for a bundle's
+// own private table (which tests/runner-extras/standalone-suites/field-virtual-table
+// already proves works).
+//
+// RED (before the fix): Reservation Entry.SetSourceFilter(...) -> IsEmpty() threw
+// RunnerOutOfScopeException("Field (virtual table 2000000041)") from
+// AlRunner.Patches.RecordPatches.BuildManagedFieldDataProvider, even though
+// AlRunner.BcRuntime.EnsureMetadataProviderSeeded() had already run one frame up.
+//
+// GREEN (after the fix): the lookup completes and returns a truthful, empty
+// result set (no reservation entries seeded), proving the Field virtual-table
+// provider initializes on this Base-App-backed path.
+codeunit 61101 "FVTIT Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit "FVTIT Assert";
+
+    // Minimal isolation reproducer from #2008: a direct Reservation Entry.SetSourceFilter
+    // call (the same pattern ItemTrackingManagement.ItemTrackingExistsOnDocumentLine uses
+    // internally) must not throw while initializing the Field virtual table.
+    [Test]
+    procedure ReservationEntrySetSourceFilter_NoTrackingSeeded_IsEmpty()
+    var
+        ReservEntry: Record "Reservation Entry";
+    begin
+        ReservEntry.SetSourceFilter(Database::"Purchase Line", 1, '', -1, true);
+        ReservEntry.SetSourceFilter('', 0);
+
+        Assert.IsTrue(ReservEntry.IsEmpty(), 'No Reservation Entry rows were seeded for this source filter; IsEmpty must report true');
+    end;
+
+    // Positive companion: once a matching Reservation Entry row exists, the same
+    // lookup path must find it — proves the Field virtual table initialization
+    // this fix restores does not just avoid throwing, it lets the real lookup work.
+    [Test]
+    procedure ReservationEntrySetSourceFilter_MatchingEntrySeeded_IsFound()
+    var
+        ReservEntry: Record "Reservation Entry";
+    begin
+        ReservEntry.Init();
+        ReservEntry."Entry No." := 1;
+        ReservEntry."Source Type" := Database::"Purchase Line";
+        ReservEntry."Source Subtype" := 1;
+        ReservEntry."Source ID" := '';
+        ReservEntry."Source Ref. No." := 10000;
+        ReservEntry.Insert();
+
+        ReservEntry.Reset();
+        ReservEntry.SetSourceFilter(Database::"Purchase Line", 1, '', 10000, true);
+        ReservEntry.SetSourceFilter('', 0);
+
+        Assert.IsFalse(ReservEntry.IsEmpty(), 'The seeded Reservation Entry must be found by SetSourceFilter');
+        Assert.IsTrue(ReservEntry.FindFirst(), 'FindFirst must locate the seeded Reservation Entry');
+        Assert.AreEqual(1, ReservEntry."Entry No.", 'Entry No. of the found row must match the seeded row');
+    end;
+
+    // Item-tracking-lookup surface: the exact standard procedure the original report
+    // failed inside. Proves the fix at the level the issue was actually reported.
+    [Test]
+    procedure ItemTrackingExistsOnDocumentLine_NoTrackingSeeded_ReturnsFalse()
+    var
+        ItemTrackingManagement: Codeunit "Item Tracking Management";
+        Exists: Boolean;
+    begin
+        Exists := ItemTrackingManagement.ItemTrackingExistsOnDocumentLine(Database::"Purchase Line", 1, '', -1);
+
+        Assert.IsFalse(Exists, 'No item tracking was seeded for this document line; ItemTrackingExistsOnDocumentLine must return false');
+    end;
+}

--- a/tests/runner-extras/field-virtual-table-item-tracking/WarehouseReceiptFlowTests.Codeunit.al
+++ b/tests/runner-extras/field-virtual-table-item-tracking/WarehouseReceiptFlowTests.Codeunit.al
@@ -1,0 +1,108 @@
+// Full-flow reproducer for #2008: the exact call chain the reporter used —
+// PurchasesWarehouseManagement.PurchLine2ReceiptLine -> Whse.-Create Source
+// Document.SetQtysOnRcptLine -> OnAfterSetQtysOnRcptLine subscriber -> a
+// Reservation Entry item-tracking lookup. The direct SetSourceFilter probe in
+// FieldVirtualTableItemTrackingTests.Codeunit.al already proves the Field
+// virtual table works when called directly; this bundle exists to prove (or
+// disprove) that going through the real subscriber-dispatch path changes
+// anything.
+codeunit 61102 "FVTIT Whse Flow Tests"
+{
+    Subtype = Test;
+    EventSubscriberInstance = Manual;
+
+    var
+        Assert: Codeunit "FVTIT Assert";
+        LibraryPurchase: Codeunit "Library - Purchase";
+        LibraryInventory: Codeunit "Library - Inventory";
+        LibraryItemTracking: Codeunit "Library - Item Tracking";
+        LibraryWarehouse: Codeunit "Library - Warehouse";
+        LibraryUtility: Codeunit "Library - Utility";
+
+    [Test]
+    procedure PurchLine2ReceiptLine_LotTrackedWithReservation_TriggersFieldVirtualTableLookupInSubscriber()
+    var
+        WarehouseSetup: Record "Warehouse Setup";
+        PurchasesPayablesSetup: Record "Purchases & Payables Setup";
+        SourceCodeSetup: Record "Source Code Setup";
+        ItemTrackingCode: Record "Item Tracking Code";
+        Item: Record Item;
+        WarehouseReceiptHeader: Record "Warehouse Receipt Header";
+        PurchaseHeader: Record "Purchase Header";
+        PurchaseLine: Record "Purchase Line";
+        ReservEntry: Record "Reservation Entry";
+        PurchasesWarehouseManagement: Codeunit "Purchases Warehouse Mgt.";
+    begin
+        BindSubscription(this);
+
+        LibraryWarehouse.NoSeriesSetup(WarehouseSetup);
+
+        PurchasesPayablesSetup.Get();
+        PurchasesPayablesSetup.Validate("Order Nos.", LibraryUtility.GetGlobalNoSeriesCode());
+        PurchasesPayablesSetup.Modify(true);
+
+        // Company-Initialize (codeunit 2) does not run to completion in this runner today
+        // (a Manufacturing subscriber NREs partway through InitSourceCodeSetup — see
+        // AlRunner/CompanyInitializer.cs "KNOWN INCOMPLETE"). That is a separate, already
+        // documented gap unrelated to #2008: it blocks Purchase Header's dimension-default
+        // lookup (CreateDim -> SourceCodeSetup.Get()) before this test ever reaches the
+        // Field-virtual-table surface under test. Insert the blank singleton row directly so
+        // this test proves #2008, not the unrelated company-init gap.
+        if not SourceCodeSetup.Get() then begin
+            SourceCodeSetup.Init();
+            SourceCodeSetup.Insert();
+        end;
+
+        // Lot-tracked item, matching #2008's exact setup.
+        LibraryItemTracking.CreateLotItem(Item);
+        ItemTrackingCode.Get(Item."Item Tracking Code");
+
+        LibraryPurchase.CreatePurchaseDocumentWithItem(
+            PurchaseHeader, PurchaseLine, PurchaseHeader."Document Type"::Order,
+            '', Item."No.", 4, '', 0D);
+
+        // A lot-tracked Reservation Entry with Qty. to Handle (Base) = 2, sourced to this
+        // purchase line — the exact seed #2008 describes.
+        ReservEntry.Init();
+        ReservEntry."Entry No." := 1;
+        ReservEntry."Item No." := Item."No.";
+        ReservEntry."Source Type" := Database::"Purchase Line";
+        ReservEntry."Source Subtype" := PurchaseLine."Document Type".AsInteger();
+        ReservEntry."Source ID" := PurchaseLine."Document No.";
+        ReservEntry."Source Ref. No." := PurchaseLine."Line No.";
+        ReservEntry."Qty. to Handle (Base)" := 2;
+        ReservEntry."Item Tracking" := ReservEntry."Item Tracking"::"Lot No.";
+        ReservEntry."Lot No." := 'ALR-LOT-1';
+        ReservEntry.Insert();
+
+        LibraryWarehouse.CreateWarehouseReceiptHeader(WarehouseReceiptHeader);
+
+        // This is the exact standard procedure from #2008. It fires the
+        // Whse.-Create Source Document.OnAfterSetQtysOnRcptLine event, which our
+        // subscriber below uses to run the exact standard tracking API from the issue —
+        // the surface the issue reported as throwing RunnerOutOfScopeException for the
+        // Field virtual table (2000000041).
+        PurchasesWarehouseManagement.PurchLine2ReceiptLine(WarehouseReceiptHeader, PurchaseLine);
+
+        UnbindSubscription(this);
+
+        Assert.IsTrue(FieldVirtualTableLookupRan, 'The OnAfterSetQtysOnRcptLine subscriber must have run and reached the item-tracking lookup');
+        Assert.IsTrue(FieldVirtualTableLookupFound, 'The seeded lot-tracked Reservation Entry must be found by ItemTrackingExistsOnDocumentLine');
+    end;
+
+    var
+        FieldVirtualTableLookupRan: Boolean;
+        FieldVirtualTableLookupFound: Boolean;
+
+    [EventSubscriber(ObjectType::Codeunit, Codeunit::"Whse.-Create Source Document", 'OnAfterSetQtysOnRcptLine', '', false, false)]
+    local procedure OnAfterSetQtysOnRcptLine(var WarehouseReceiptLine: Record "Warehouse Receipt Line"; Qty: Decimal; QtyBase: Decimal)
+    var
+        ItemTrackingManagement: Codeunit "Item Tracking Management";
+    begin
+        // The exact standard API from #2008.
+        FieldVirtualTableLookupFound := ItemTrackingManagement.ItemTrackingExistsOnDocumentLine(
+            WarehouseReceiptLine."Source Type", WarehouseReceiptLine."Source Subtype",
+            WarehouseReceiptLine."Source No.", WarehouseReceiptLine."Source Line No.");
+        FieldVirtualTableLookupRan := true;
+    end;
+}

--- a/tests/runner-extras/field-virtual-table-item-tracking/WarehouseReceiptFlowTests.Codeunit.al
+++ b/tests/runner-extras/field-virtual-table-item-tracking/WarehouseReceiptFlowTests.Codeunit.al
@@ -6,6 +6,17 @@
 // virtual table works when called directly; this bundle exists to prove (or
 // disprove) that going through the real subscriber-dispatch path changes
 // anything.
+//
+// PurchaseLine/WarehouseReceiptHeader are built with raw field assignment +
+// Insert(false) rather than Library-Purchase's Validate-heavy helpers — those
+// helpers chain through Vendor/Dimension/User-Profile lookups that need a much
+// larger default-company setup (General Ledger Setup, Marketing Setup, a
+// resolvable user profile, ...) which is orthogonal to what #2008 is actually
+// about and, on some runner builds, hits its own unrelated gaps before ever
+// reaching PurchLine2ReceiptLine. PurchLine2ReceiptLine itself only reads
+// fields off the PurchaseLine parameter — it never re-fetches Purchase Header
+// or validates the line — so a raw, unvalidated PurchaseLine record is
+// faithful to what the procedure actually consumes.
 codeunit 61102 "FVTIT Whse Flow Tests"
 {
     Subtype = Test;
@@ -13,59 +24,56 @@ codeunit 61102 "FVTIT Whse Flow Tests"
 
     var
         Assert: Codeunit "FVTIT Assert";
-        LibraryPurchase: Codeunit "Library - Purchase";
-        LibraryInventory: Codeunit "Library - Inventory";
-        LibraryItemTracking: Codeunit "Library - Item Tracking";
         LibraryWarehouse: Codeunit "Library - Warehouse";
-        LibraryUtility: Codeunit "Library - Utility";
 
     [Test]
     procedure PurchLine2ReceiptLine_LotTrackedWithReservation_TriggersFieldVirtualTableLookupInSubscriber()
     var
         WarehouseSetup: Record "Warehouse Setup";
-        PurchasesPayablesSetup: Record "Purchases & Payables Setup";
-        SourceCodeSetup: Record "Source Code Setup";
-        ItemTrackingCode: Record "Item Tracking Code";
-        Item: Record Item;
+        InventorySetup: Record "Inventory Setup";
         WarehouseReceiptHeader: Record "Warehouse Receipt Header";
-        PurchaseHeader: Record "Purchase Header";
         PurchaseLine: Record "Purchase Line";
         ReservEntry: Record "Reservation Entry";
         PurchasesWarehouseManagement: Codeunit "Purchases Warehouse Mgt.";
     begin
         BindSubscription(this);
 
+        // Older runner builds (v2.3.1, the version #2008 was reported against) did not
+        // seed the Warehouse Setup singleton row via install triggers; current main does.
+        // Seed it explicitly so this test is portable across both, instead of silently
+        // depending on install-trigger completeness (a separate, unrelated area).
+        if not WarehouseSetup.Get() then begin
+            WarehouseSetup.Init();
+            WarehouseSetup.Insert();
+        end;
         LibraryWarehouse.NoSeriesSetup(WarehouseSetup);
 
-        PurchasesPayablesSetup.Get();
-        PurchasesPayablesSetup.Validate("Order Nos.", LibraryUtility.GetGlobalNoSeriesCode());
-        PurchasesPayablesSetup.Modify(true);
-
-        // Company-Initialize (codeunit 2) does not run to completion in this runner today
-        // (a Manufacturing subscriber NREs partway through InitSourceCodeSetup — see
-        // AlRunner/CompanyInitializer.cs "KNOWN INCOMPLETE"). That is a separate, already
-        // documented gap unrelated to #2008: it blocks Purchase Header's dimension-default
-        // lookup (CreateDim -> SourceCodeSetup.Get()) before this test ever reaches the
-        // Field-virtual-table surface under test. Insert the blank singleton row directly so
-        // this test proves #2008, not the unrelated company-init gap.
-        if not SourceCodeSetup.Get() then begin
-            SourceCodeSetup.Init();
-            SourceCodeSetup.Insert();
+        if not InventorySetup.Get() then begin
+            InventorySetup.Init();
+            InventorySetup.Insert();
         end;
 
-        // Lot-tracked item, matching #2008's exact setup.
-        LibraryItemTracking.CreateLotItem(Item);
-        ItemTrackingCode.Get(Item."Item Tracking Code");
-
-        LibraryPurchase.CreatePurchaseDocumentWithItem(
-            PurchaseHeader, PurchaseLine, PurchaseHeader."Document Type"::Order,
-            '', Item."No.", 4, '', 0D);
+        // Raw Purchase Line, no Item/Vendor/Dimension machinery — see file header.
+        PurchaseLine.Init();
+        PurchaseLine."Document Type" := PurchaseLine."Document Type"::Order;
+        PurchaseLine."Document No." := 'PO0001';
+        PurchaseLine."Line No." := 10000;
+        PurchaseLine.Type := PurchaseLine.Type::Item;
+        PurchaseLine."No." := 'FVTIT-ITEM';
+        PurchaseLine.Description := 'FVTIT lot-tracked item';
+        PurchaseLine."Unit of Measure Code" := 'PCS';
+        PurchaseLine."Qty. per Unit of Measure" := 1;
+        PurchaseLine.Quantity := 4;
+        PurchaseLine."Quantity (Base)" := 4;
+        PurchaseLine."Quantity Received" := 0;
+        PurchaseLine."Expected Receipt Date" := WorkDate();
+        PurchaseLine.Insert(false);
 
         // A lot-tracked Reservation Entry with Qty. to Handle (Base) = 2, sourced to this
         // purchase line — the exact seed #2008 describes.
         ReservEntry.Init();
         ReservEntry."Entry No." := 1;
-        ReservEntry."Item No." := Item."No.";
+        ReservEntry."Item No." := PurchaseLine."No.";
         ReservEntry."Source Type" := Database::"Purchase Line";
         ReservEntry."Source Subtype" := PurchaseLine."Document Type".AsInteger();
         ReservEntry."Source ID" := PurchaseLine."Document No.";

--- a/tests/runner-extras/field-virtual-table-item-tracking/app.json
+++ b/tests/runner-extras/field-virtual-table-item-tracking/app.json
@@ -1,0 +1,26 @@
+{
+  "id": "8b7c6d5e-4f3a-4b2c-9d1e-0f8a7c6b5d4e",
+  "name": "Runner Extras - Field Virtual Table Item Tracking",
+  "publisher": "AL Runner",
+  "version": "1.0.0.0",
+  "brief": "Reproduces #2008: the virtual Field table (2000000041) must initialize during a Base App item-tracking/reservation lookup, not just for a bundle's own tables.",
+  "description": "Regression for #2008: FieldDataProvider ctor failing on a Base-App-dependent path even though the standalone field-virtual-table suite passes.",
+  "dependencies": [
+    {
+      "id": "d852d5d2-a39d-4179-baeb-f99a19e32510",
+      "name": "Application Test Library",
+      "publisher": "Microsoft",
+      "version": "28.0.0.0"
+    }
+  ],
+  "idRanges": [
+    {
+      "from": 61100,
+      "to": 61199
+    }
+  ],
+  "platform": "28.0.0.0",
+  "application": "28.0.0.0",
+  "runtime": "17.0",
+  "target": "Cloud"
+}


### PR DESCRIPTION
Relates to #2008 — does NOT close it, since #2008 stays open for the reporter to confirm the fix against their actual environment. #2008's root cause is now confirmed and root-caused (see below and #2020); this PR fixes the diagnostic message AND closes the warning gap that let the root cause run silently.

## Root cause of #2008 (confirmed)

Every released `al-runner` binary is compiled against a single, fixed BC engine minor (`bc-tests.yml`'s `resolve-versions` job hardcodes BC 28.1 as `required-version` — see #2020 for a real, independent improvement to that, and #2021 for the PR). The reporter ran the published v2.3.1 tool (engine built for BC 28.1.49838.50794) with `--bc-version 28.3` explicitly. That silently ran a BC-28.1-built engine against BC-28.3 artifacts, which threw a `NullReferenceException` deep inside BC's own `FieldDataProvider` ctor (`NavGlobal.get_SystemTenant()` → `get_NCLMetadata()`).

Confirmed by:
- Installing the actual published v2.3.1 tool and reproducing the exact reported error, deterministically, against real BC 28.3 artifacts (3 runs, including one with the Cecil-rewrite disk cache forced cold).
- Rebuilding the `v2.3.1` git tag from source, forcing `-p:_BCVersion=28.1.49838.50794` to match the published binary's engine exactly — also reproduced it, ruling out a build-pipeline artifact and confirming the mechanism is the engine/minor skew itself.
- Rebuilding the same source with `-p:_BCVersion=28.3.52162.53954` (engine matches the target) — clean, 0 occurrences, confirming a matched engine/target minor is NOT itself broken.
- Reproducing the identical failure on current `main`, built the same mismatched way — the mismatch is not something main's source has fixed; only this PR's diagnostic/warning has changed.

Full writeup on #2008 and #2020.

## What this PR does

1. **Fixes a message that could be false.** `BuildManagedFieldDataProvider`'s catch block asserted "the skeleton NavGlobal.MetadataProvider/NCLMetadata is not seeded" unconditionally, even when seeding had already succeeded one frame up. `.claude/rules/loud-failures.md` requires throwing with a **true** reason, not merely throwing loudly — this was a genuine rule violation. `BcRuntime.IsMetadataProviderSeeded()` now reads the live field instead of assuming, and the message includes the real inner exception's type/message/**stack trace** — which is what actually surfaced the root cause above.
2. **Closes the silent half of the root cause.** The runner already had a warning for an engine/BC-minor mismatch, but only on the auto-select default path (neither `--bc-version` nor `--artifact-path` given). The reporter's exact invocation passed `--bc-version 28.3` explicitly, which skipped that whole branch — `BcArtifacts.WarnIfExplicitEngineMinorMismatch` (called only for the explicit-selection path, so the existing auto-select warning is untouched and not double-printed) closes that gap.
3. **Adds regression coverage** (`tests/runner-extras/field-virtual-table-item-tracking{,-ext,-test}`) pinning that the exact reported call chain does not throw when run with a matched engine, across two BC versions.

## Test plan

- `dotnet test AlRunner.Tests` — full run 902/903 pass; the 1 failure (`SiblingSourceDep_CompilesWithZeroPackageCacheDirs`) reproduces identically with these changes stashed out, confirmed pre-existing/unrelated.
- New `MetadataProviderSeedDiagnosisTests` (2 tests, both directions of the verified-seed-state check) and `EngineMinorMismatchWarningTests` (5 tests, asserting the warning text AND the specific mismatched versions, not just that some warning appeared) — pass.
- New `tests/runner-extras/field-virtual-table-item-tracking{,-ext,-test}` bundles (5 tests total) — pass on BC 28.1 and BC 28.3, with a matched engine.
- Existing `tests/runner-extras/standalone-suites/field-virtual-table` (4 tests) — still pass, unaffected.
- Manually verified end-to-end: an explicit `--bc-version` mismatch now prints the new warning; the auto-select default path is unchanged (no double-warning).
