### PR TITLE
fix(pack): stop shipping BC service-tier/Aspose/Graph binaries in the tool nupkg

### DIFF
--- a/.github/scripts/check-nupkg-contents.sh
+++ b/.github/scripts/check-nupkg-contents.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Fails if the packed tool nupkg ships BC service-tier / Aspose / Graph binaries that
+# are supposed to come from the user's own artifact cache at runtime, never from the
+# package itself (see Directory.Build.targets' StripBcAppClosureFromCopyLocal target
+# for the full mechanism, and AlRunner.csproj's "BC Service Tier DLL provisioning"
+# comment — the runner never auto-downloads these; the user's artifact cache supplies
+# them). v2.4.0 shipped 167 such files, 92.8 MB compressed / 196 MB uncompressed,
+# including Aspose.PDF.dll (60.2 MB) and Aspose.Words.dll (28.0 MB) — this script is
+# what would have caught that before release.
+#
+# Two checks, deliberately independent:
+#   1. A deny-list of today's known offenders, by filename pattern.
+#   2. A total package-size ceiling, so a FUTURE unwanted dependency that doesn't match
+#      any name below still fails the build instead of silently regrowing the package.
+set -euo pipefail
+
+pkg="${1:?usage: check-nupkg-contents.sh <path-to-nupkg> [size-ceiling-bytes]}"
+# Bytes. The fixed package is ~15 MB compressed; the ceiling leaves headroom for
+# legitimate growth (new PackageReferences, more Win32-stub RIDs, …) while still
+# catching a many-MB regression like Aspose/Graph/BusinessCentral being re-added.
+size_ceiling_bytes="${2:-31457280}" # 30 MiB
+
+actual_size=$(stat -c%s "$pkg")
+echo "nupkg size: $actual_size bytes ($((actual_size / 1024 / 1024)) MiB), ceiling: $size_ceiling_bytes bytes"
+
+listing=$(unzip -l "$pkg")
+
+deny_patterns=(
+  'Microsoft\.Dynamics\.[^/]*\.dll$'
+  'Microsoft\.BusinessCentral\.[^/]*\.dll$'
+  'Aspose\.[^/]*\.dll$'
+  'Microsoft\.Graph[^/]*\.dll$'
+)
+# The one documented exception: Microsoft.Dynamics.Nav.Ncl.dll must ship. Program.cs
+# Cecil-rewrites it in place at the exact bin path CoreCLR's TPA probe — computed once
+# at native-host startup — must already know; stripping it makes the process fall
+# through to the RAW, un-rewritten copy in the artifact dir instead, which crashes at
+# startup (NavEnvironment..cctor calls the real WindowsIdentity.GetCurrent(), which
+# throws PlatformNotSupportedException on Linux). See Directory.Build.targets.
+allow_exact='Microsoft.Dynamics.Nav.Ncl.dll'
+
+violations=()
+for pat in "${deny_patterns[@]}"; do
+  while IFS= read -r line; do
+    [[ -z "$line" ]] && continue
+    fname=$(basename "$line")
+    [[ "$fname" == "$allow_exact" ]] && continue
+    violations+=("$line")
+  done < <(echo "$listing" | grep -E "$pat" || true)
+done
+
+status=0
+if [[ ${#violations[@]} -gt 0 ]]; then
+  echo "::error::nupkg contains BC/Aspose/Graph binaries that must be resolved from the user's artifact cache at runtime, not shipped:"
+  printf '  %s\n' "${violations[@]}"
+  status=1
+fi
+
+if [[ "$actual_size" -gt "$size_ceiling_bytes" ]]; then
+  echo "::error::nupkg size $actual_size bytes exceeds ceiling $size_ceiling_bytes bytes"
+  status=1
+fi
+
+if [[ "$status" -eq 0 ]]; then
+  echo "OK: nupkg contents and size are within bounds."
+fi
+exit "$status"

--- a/.github/workflows/bc-tests.yml
+++ b/.github/workflows/bc-tests.yml
@@ -552,8 +552,8 @@ jobs:
           fi
           echo "Packed: ${pkgs[*]}"
 
-      - name: Assert the package doesn't ship BC/Aspose/Graph binaries (issue: nupkg contents)
-        # Guards against a regression of the mechanism fixed by that issue: MSBuild's
+      - name: Assert the package doesn't ship BC/Aspose/Graph binaries
+        # Guards against a regression of the mechanism fixed by issue #2022: MSBuild's
         # default assembly-reference resolution follows Ncl.dll's transitive closure
         # (Aspose.PDF/Words/Cells, Microsoft.Graph, the whole Microsoft.BusinessCentral.*
         # family, …) into the tool package unless Directory.Build.targets'

--- a/.github/workflows/bc-tests.yml
+++ b/.github/workflows/bc-tests.yml
@@ -551,3 +551,13 @@ jobs:
             exit 1
           fi
           echo "Packed: ${pkgs[*]}"
+
+      - name: Assert the package doesn't ship BC/Aspose/Graph binaries (issue: nupkg contents)
+        # Guards against a regression of the mechanism fixed by that issue: MSBuild's
+        # default assembly-reference resolution follows Ncl.dll's transitive closure
+        # (Aspose.PDF/Words/Cells, Microsoft.Graph, the whole Microsoft.BusinessCentral.*
+        # family, …) into the tool package unless Directory.Build.targets'
+        # StripBcAppClosureFromCopyLocal target strips it back out. See that target's
+        # comment for the full mechanism and why Microsoft.Dynamics.Nav.Ncl.dll itself is
+        # the one documented exception.
+        run: .github/scripts/check-nupkg-contents.sh ./nupkg/*.nupkg

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -23,6 +23,50 @@
     re-copy the closure into its own bin, re-pinning the in-process engine there.
 
     Guarded by VersionAgnosticClosureTests.
+
+    === Packaging: the SAME closure was shipping inside the tool NuGet package ===
+
+    AlRunner.csproj's <Reference Include="Microsoft.Dynamics.Nav.Ncl"> (and its 5 siblings —
+    Types/Common/Language/CodeAnalysis/Apps) have no <Private>false</Private>, so RAR resolves
+    Ncl.dll's ENTIRE transitive dependency graph — ~24 BC service-tier DLLs, including
+    Aspose.PDF/Words/Cells (report rendering), Microsoft.Graph (email/OAuth), and the whole
+    Microsoft.BusinessCentral.* telemetry/licensing/reporting-client family — and copies all of
+    it into bin. `dotnet pack`'s PackAsTool step then embeds the whole bin directory into the
+    .nupkg: ~92 MB compressed / ~196 MB uncompressed in v2.4.0, none of which the runner
+    actually needs shipped (see docs/scope.md — the runner never auto-downloads BC artifacts;
+    the user's own artifact cache supplies them at runtime).
+
+    Setting Private=false on the 6 <Reference> items directly does NOT work: RAR computes a
+    dependency's CopyLocal from the closure of ALL primary references combined, so as long as
+    ANY one of the 6 stays Private=true (copy-local), its own transitive dependencies (the
+    entire Aspose/Graph/BusinessCentral closure) stay copy-local too, regardless of the other 5.
+
+    Ncl.dll ITSELF must stay Private=true (and therefore ship, both to bin and to the nupkg):
+    Program.cs Cecil-rewrites Ncl.dll IN PLACE at the exact `AppContext.BaseDirectory +
+    "Microsoft.Dynamics.Nav.Ncl.dll"` path, before Main resolves any BC type, and relies on
+    CoreCLR's TPA (trusted platform assemblies) probe — computed ONCE at native-host startup —
+    already knowing that path. Verified empirically: stripping Ncl.dll from bin (so TPA never
+    learns the path, even though Program.cs still successfully re-writes bytes there moments
+    later) makes the process fall through to DependencyLoader's Resolving handler instead,
+    which loads the RAW, un-Cecil-rewritten copy straight from the artifact dir — the
+    NavEnvironment cctor then calls the real WindowsIdentity.GetCurrent(), which throws
+    PlatformNotSupportedException on Linux, and the process crashes at startup. So Ncl.dll's
+    PATH must exist in bin/the package even though its bytes get overwritten every run; the
+    other 23 DLLs in its closure do not need to.
+
+    The other 5 direct references (Types/Common/Language/Apps/CodeAnalysis) do NOT need to
+    ship at all: BcRuntime.ForceLoadBcDlls already loads Common/Types/Language explicitly via
+    `Assembly.LoadFrom(ServiceTierDir/…)` (not via TPA/default resolve), and Apps/CodeAnalysis
+    are only ever touched through reflection/generics inside Ncl's R2R code, which the
+    Resolving handler below already serves from ServiceTierDir. Confirmed by running a real
+    bundle end to end with all 5 stripped from bin.
+
+    Verified end to end (dotnet pack + a clean tool install + a real bundle run) in the PR
+    that added this comment. Guarded in CI by the `pack` job's "Assert the package
+    doesn't ship BC/Aspose/Graph binaries" step (bc-tests.yml), which runs
+    .github/scripts/check-nupkg-contents.sh against the real packed nupkg on every
+    push/PR — a deny-list of today's known offenders plus a total-size ceiling so a
+    future unwanted dependency that doesn't match any name here still fails the build.
   -->
   <Target Name="StripBcAppClosureFromCopyLocal" AfterTargets="ResolveAssemblyReferences">
     <ItemGroup>
@@ -30,7 +74,19 @@
         Condition="$([System.String]::Copy('%(Filename)').StartsWith('Microsoft.Identity'))
                    OR $([System.String]::Copy('%(Filename)').StartsWith('System.IdentityModel'))
                    OR $([System.String]::Copy('%(Filename)').StartsWith('Azure.'))
-                   OR '%(Filename)' == 'Microsoft.Dynamics.Nav.CodeAnalysis'" />
+                   OR $([System.String]::Copy('%(Filename)').StartsWith('Aspose.'))
+                   OR $([System.String]::Copy('%(Filename)').StartsWith('Microsoft.Graph'))
+                   OR $([System.String]::Copy('%(Filename)').StartsWith('Microsoft.BusinessCentral.'))
+                   OR ($([System.String]::Copy('%(Filename)').StartsWith('Microsoft.Dynamics.'))
+                       AND '%(Filename)' != 'Microsoft.Dynamics.Nav.Ncl')
+                   OR $([System.String]::Copy('%(Filename)').StartsWith('CoreWCF.'))
+                   OR $([System.String]::Copy('%(Filename)').StartsWith('Grpc.'))
+                   OR '%(Filename)' == 'System.Private.ServiceModel'
+                   OR '%(Filename)' == 'SkiaSharp'
+                   OR '%(Filename)' == 'DocumentFormat.OpenXml'
+                   OR '%(Filename)' == 'Microsoft.Data.SqlClient'
+                   OR '%(Filename)' == 'Microsoft.Exchange.WebServices.NETStandard'
+                   OR '%(Filename)' == 'System.Drawing.Common'" />
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
Closes #2022

## Problem

The published `MSDyn365BC.AL.Runner` nupkg shipped Microsoft's BC service-tier assemblies and Aspose's commercial components — 92.8 MB compressed / 196 MB uncompressed in v2.4.0, including `Aspose.PDF.dll` (60.2 MB), `Aspose.Words.dll` (28.0 MB), `Aspose.Cells.dll` (19.1 MB), `Microsoft.Dynamics.Nav.Ncl.dll` (11.3 MB), `Microsoft.BusinessCentral.SystemApp.dll` (6.3 MB), `Microsoft.Graph.dll`, and ~30 more `Microsoft.BusinessCentral.*` files. None of this is supposed to ship — the runner resolves BC service-tier DLLs from the user's own artifact cache at runtime and never auto-downloads them (`AlRunner.csproj`'s "BC Service Tier DLL provisioning" comment already says so).

## Confirmed mechanism

MSBuild's default reference resolution follows `Microsoft.Dynamics.Nav.Ncl.dll`'s full transitive dependency closure (~24 assemblies) into the build output directory because none of the six `<Reference Include="Microsoft.Dynamics.Nav.*">` entries in `AlRunner.csproj` set `<Private>false</Private>`, and `PackAsTool` packs the whole output directory.

Setting `Private=false` on the six references directly does **not** work — verified by testing it. RAR computes a dependency's copy-local status from the union of all primary references, so as long as *any* of the six stays copy-local (Ncl.dll must, see below), its own transitive dependencies stay copy-local too, regardless of the other five.

`Microsoft.Dynamics.Nav.Ncl.dll` itself must remain in the output directory: `Program.cs` Cecil-rewrites it **in place** at the exact bin-relative path CoreCLR's TPA probe — computed once at native-host startup — already knows about. Stripping it makes the process fall through to the assembly resolver instead, which loads the *raw, un-rewritten* copy from the artifact directory — `NavEnvironment`'s static constructor then calls the real `WindowsIdentity.GetCurrent()`, which throws `PlatformNotSupportedException` on Linux and crashes the process at startup. Reproduced this crash directly while investigating.

The other five direct references (`Types`/`Common`/`Language`/`Apps`/`CodeAnalysis`) don't need to ship at all: `BcRuntime.ForceLoadBcDlls` already loads `Common`/`Types`/`Language` explicitly via `Assembly.LoadFrom` against the artifact directory (not TPA), and `Apps`/`CodeAnalysis` are only ever touched through reflection/generics inside `Ncl`'s R2R code, already served on demand by `DependencyLoader`'s `AssemblyLoadContext.Default.Resolving` handler from the same artifact directory.

## Fix

Extended the existing `StripBcAppClosureFromCopyLocal` MSBuild target (`Directory.Build.targets`) — which already stripped the Azure/Identity/IdentityModel/CodeAnalysis closure for a pre-existing, unrelated cross-BC-minor-compatibility reason — to also strip `Aspose.*`, `Microsoft.Graph*`, `Microsoft.BusinessCentral.*`, every other `Microsoft.Dynamics.*` assembly except `Ncl.dll`, and the rest of `Ncl.dll`'s non-BC-branded closure (`CoreWCF.*`, `Grpc.*`, `System.Private.ServiceModel`, `SkiaSharp`, `DocumentFormat.OpenXml`, `Microsoft.Data.SqlClient`, `Microsoft.Exchange.WebServices.NETStandard`, `System.Drawing.Common`) that the runner never references directly.

## Where the BC assemblies resolve from at runtime, with them absent from the tool directory

Two mechanisms, both pre-existing:

- `Types.dll`/`Common.dll`/`Language.dll`: `BcRuntime.ForceLoadBcDlls` calls `Assembly.LoadFrom(Path.Combine(BcArtifacts.ServiceTierDir, "<name>.dll"))` explicitly — never touches TPA/default resolve for these.
- Everything else (`Apps`/`CodeAnalysis`/Aspose/Graph/BusinessCentral/the rest of Ncl's closure): `DependencyLoader.EnsureResolverInstalled`'s `AssemblyLoadContext.Default.Resolving` handler, which only fires after default resolution has already failed, then probes `Path.Combine(BcArtifacts.ServiceTierDir, name.Name + ".dll")`.

`BcArtifacts.ServiceTierDir` resolves to `~/.local/share/al-runner/artifacts/<selected-version>/` — the user's own artifact cache, populated by `al-runner provision` / `--auto-provision`, never anything shipped in the package.

## Proof

- **RED against `main`:** built and packed unmodified `main` locally — 92,859,830 bytes (matches the reported v2.4.0 size almost exactly), fails the new `check-nupkg-contents.sh` on both the deny-list and the size ceiling.
- **GREEN with the fix:** 14,940,584 bytes compressed, passes both checks. Only `Microsoft.Dynamics.Nav.Ncl.dll` remains from the deny-listed families (the documented exception).
- **Clean-install proof (the part that actually matters):** `dotnet tool install --tool-path` into an isolated directory from the packed nupkg, then ran:
  - `tests/runner-extras/depapp-dictionary-main` — 4/4 pass.
  - The full `tests/al-language` corpus — **2130/2130 pass**, `pass-oos: 2`, `pass-divergence: 1`, 0 fail/error.
  - Confirmed via `find` that none of `Aspose.*`, `Microsoft.Graph*`, `Microsoft.BusinessCentral.*`, or any `Microsoft.Dynamics.*` other than `Ncl.dll` exist anywhere under the installed tool's `.store` directory.
- **No regression:** `AlRunner.Tests` — one pre-existing failure (`SourceDepSymbolsWithoutPackageCacheTests.SiblingSourceDep_CompilesWithZeroPackageCacheDirs`), reproduced identically against an unmodified `Directory.Build.targets`, so unrelated to this change.

## CI

Wired a new step into `bc-tests.yml`'s existing `pack` job (added by #2010) — `.github/scripts/check-nupkg-contents.sh` — asserting the same deny-list plus a 30 MiB total-size ceiling on every push/PR, so this can't regress silently. The deny-list only names today's known offenders; the size ceiling is what catches the *next* one.

## Coordination note

impl-12 is separately changing `resolve-versions` in `bc-tests.yml`. This PR's diff to that file is a single small appended step at the end of the `pack` job — should not conflict, but flagging per the task's coordination note. Will rebase before going `review-ready` if needed.
