### PR TITLE
fix(pack): stop shipping Microsoft.Dynamics.Nav.Ncl.dll in the tool nupkg

### DIFF
--- a/.github/scripts/check-nupkg-contents.sh
+++ b/.github/scripts/check-nupkg-contents.sh
@@ -31,20 +31,20 @@ deny_patterns=(
   'Aspose\.[^/]*\.dll$'
   'Microsoft\.Graph[^/]*\.dll$'
 )
-# The one documented exception: Microsoft.Dynamics.Nav.Ncl.dll must ship. Program.cs
-# Cecil-rewrites it in place at the exact bin path CoreCLR's TPA probe — computed once
-# at native-host startup — must already know; stripping it makes the process fall
-# through to the RAW, un-rewritten copy in the artifact dir instead, which crashes at
-# startup (NavEnvironment..cctor calls the real WindowsIdentity.GetCurrent(), which
-# throws PlatformNotSupportedException on Linux). See Directory.Build.targets.
-allow_exact='Microsoft.Dynamics.Nav.Ncl.dll'
+# No allow-list exception. Microsoft.Dynamics.Nav.Ncl.dll used to be exempted here
+# because Program.cs Cecil-rewrote it in place at the exact bin path CoreCLR's TPA probe
+# needed to already know about, and TPA is computed once at native-host startup — so
+# stripping the file made the process fall through to the RAW, un-rewritten copy in the
+# artifact dir and crash at startup. NclShadowRuntime.cs now resolves that without
+# shipping the file: it builds a runner-owned shadow directory (symlinks to this
+# install, plus the Cecil-rewritten Ncl.dll copied from the user's own BC artifact
+# cache) and re-execs into it, so a fresh process's TPA legitimately includes it. See
+# Directory.Build.targets and NclShadowRuntime.cs's class doc for the full mechanism.
 
 violations=()
 for pat in "${deny_patterns[@]}"; do
   while IFS= read -r line; do
     [[ -z "$line" ]] && continue
-    fname=$(basename "$line")
-    [[ "$fname" == "$allow_exact" ]] && continue
     violations+=("$line")
   done < <(echo "$listing" | grep -E "$pat" || true)
 done

--- a/.github/workflows/bc-tests.yml
+++ b/.github/workflows/bc-tests.yml
@@ -180,25 +180,31 @@ jobs:
           ls -la ~/.cache/al-runner/ncl-cecil/ || echo "WARNING: Cecil cache still cold"
 
           # AlRunner.Tests ships its OWN bin-deployed copy of Microsoft.Dynamics.Nav.Ncl.dll (it
-          # references Nav.Ncl directly — see AlRunner.Tests.csproj), and that copy starts out
-          # PRISTINE (un-rewritten) after every build. Left alone, BcEngineBootstrap (see
-          # AlRunner.Tests/BcEngineCollection.cs) would rewrite it in-process on the very first
-          # `dotnet test` invocation below, then skip rather than load a file it just replaced
-          # (BadImageFormatException 0x80131124 hazard) — on every fresh CI runner, every time,
-          # covering nothing. Pre-copy the ALREADY-rewritten copy from AlRunner's own bin dir
-          # above so the bootstrap below sees a no-op instead of a cold rewrite. This is NOT
-          # about the Cecil disk cache under ~/.cache/al-runner/ncl-cecil (that cache is keyed
-          # off the SERVICE-TIER Ncl's own bytes + the runner assembly's own CONTENT hash
-          # (#1871 — previously its mtime, see NclCecilRewrite.ComputeCacheKey) — the bin
-          # copy's own path/mtime never enters that key, so a plain `cp` cannot affect it
-          # either way).
-          # What actually makes this pre-copy work is BcEngineBootstrap's own
-          # before/after SHA-256 CONTENT hash of the bin copy (see the `FileHash` calls around
-          # `RewriteInPlace` in BcEngineCollection.cs): once the bin copy is already
-          # byte-identical to what the rewrite would produce, that comparison reports
-          # `changed == false` regardless of either file's timestamp, so the bootstrap treats
-          # it as already-rewritten and does not skip.
-          cp AlRunner/bin/Release/net8.0/Microsoft.Dynamics.Nav.Ncl.dll AlRunner.Tests/bin/Release/net8.0/Microsoft.Dynamics.Nav.Ncl.dll
+          # references Nav.Ncl directly — see AlRunner.Tests.csproj — and, unlike AlRunner
+          # itself, is NOT stripped of it: see Directory.Build.targets' project-scoped Ncl
+          # exclusion), and that copy starts out PRISTINE (un-rewritten) after every build.
+          # Left alone, BcEngineBootstrap (see AlRunner.Tests/BcEngineCollection.cs) would
+          # rewrite it in-process on the very first `dotnet test` invocation below, then skip
+          # rather than load a file it just replaced (BadImageFormatException 0x80131124
+          # hazard) — on every fresh CI runner, every time, covering nothing. Pre-copy an
+          # ALREADY-rewritten copy so the bootstrap below sees a no-op instead of a cold
+          # rewrite.
+          #
+          # Source: ~/.cache/al-runner/ncl-cecil, NOT AlRunner's own bin dir — AlRunner no
+          # longer ships (or even builds with) a bin-deployed Ncl.dll at all (see
+          # NclShadowRuntime.cs; the throwaway run above wrote its rewritten copy into a
+          # runner-owned SHADOW dir instead, keeping ncl-cecil warm same as before). The
+          # rewritten BYTES are identical regardless of which project triggered the rewrite
+          # (RewriteNcl is a deterministic transform of the same service-tier Ncl.dll; the
+          # cache key folds in the runner assembly's content hash only for INVALIDATION, not
+          # because the output differs per caller) — that's what makes this pre-copy work at
+          # all: BcEngineBootstrap's own before/after SHA-256 CONTENT hash comparison of the
+          # bin copy (see the `FileHash` calls around `RewriteInPlace` in
+          # BcEngineCollection.cs) reports `changed == false` once the bin copy is already
+          # byte-identical to what an in-process rewrite would produce, regardless of either
+          # file's timestamp or origin, so the bootstrap treats it as already-rewritten and
+          # does not skip.
+          cp "$(ls -t ~/.cache/al-runner/ncl-cecil/*.dll | head -1)" AlRunner.Tests/bin/Release/net8.0/Microsoft.Dynamics.Nav.Ncl.dll
 
       - name: Generate .runsettings for in-process BC engine tests
         run: |
@@ -454,7 +460,11 @@ jobs:
           dotnet-version: '8.0.x'
 
       - name: Clear cold-cache Cecil rewrite cache
-        run: rm -rf ~/.cache/al-runner/ncl-cecil/
+        # ncl-shadow alongside ncl-cecil: on a fresh ubuntu-latest runner neither has any
+        # prior content anyway, but clearing both keeps this step's intent (simulate a
+        # genuinely first-ever Cecil rewrite, not a cache HIT) unambiguous now that Ncl.dll
+        # is resolved via NclShadowRuntime's shadow dir rather than an in-place bin rewrite.
+        run: rm -rf ~/.cache/al-runner/ncl-cecil/ ~/.cache/al-runner/ncl-shadow/
 
       - name: Build Release
         # Pin to the resolved REQUIRED version rather than AlRunner.csproj's baked-in
@@ -553,11 +563,12 @@ jobs:
           echo "Packed: ${pkgs[*]}"
 
       - name: Assert the package doesn't ship BC/Aspose/Graph binaries
-        # Guards against a regression of the mechanism fixed by issue #2022: MSBuild's
-        # default assembly-reference resolution follows Ncl.dll's transitive closure
-        # (Aspose.PDF/Words/Cells, Microsoft.Graph, the whole Microsoft.BusinessCentral.*
-        # family, …) into the tool package unless Directory.Build.targets'
-        # StripBcAppClosureFromCopyLocal target strips it back out. See that target's
-        # comment for the full mechanism and why Microsoft.Dynamics.Nav.Ncl.dll itself is
-        # the one documented exception.
+        # Guards against a regression of the mechanism fixed by issues #2022/#2025:
+        # MSBuild's default assembly-reference resolution follows Ncl.dll's transitive
+        # closure (Aspose.PDF/Words/Cells, Microsoft.Graph, the whole
+        # Microsoft.BusinessCentral.* family, Ncl.dll itself, …) into the tool package
+        # unless Directory.Build.targets' StripBcAppClosureFromCopyLocal target strips it
+        # back out. No exceptions any more — see that target's comment and
+        # NclShadowRuntime.cs's class doc for how Ncl.dll itself is now resolved from the
+        # user's own BC artifact cache at runtime instead of being shipped.
         run: .github/scripts/check-nupkg-contents.sh ./nupkg/*.nupkg

--- a/AlRunner.Tests/NclShadowRuntimeTests.cs
+++ b/AlRunner.Tests/NclShadowRuntimeTests.cs
@@ -1,0 +1,178 @@
+// NclShadowRuntimeTests — pins the mechanism the tool package now relies on to avoid
+// shipping Microsoft.Dynamics.Nav.Ncl.dll (see check-nupkg-contents.sh, which asserts
+// its absence from the packed nupkg with no allow-list exception).
+//
+// CoreCLR's trusted-platform-assemblies (TPA) list is computed once, by the native host,
+// before any of our own code runs — so a THIS-process fix once Ncl.dll is already known
+// to be missing is impossible. NclShadowRuntime instead builds a "shadow" directory that
+// mirrors the real install (so a fresh child process's TPA legitimately includes a real,
+// on-disk Ncl.dll) and Program.cs re-execs into it via the dotnet muxer.
+//
+// The one entry this file exists to prove: MirrorInstallDirectory MUST copy the entry
+// assembly (al-runner.dll) and its deps/runtimeconfig manifests as REAL, independent
+// files rather than symlinks. This is not a style preference — it is a regression pin.
+// Confirmed empirically while building this class: when the entry assembly in the
+// shadow dir was a symlink back to the real install, CoreCLR reported
+// AppContext.BaseDirectory as the symlink's TARGET directory (the real install), not the
+// directory the symlink itself lived in (the shadow dir) — silently defeating the whole
+// mechanism. Concretely, that made Program.cs's later "Cecil-rewrite Ncl.dll IN-PLACE"
+// step write Ncl.dll back into the real install directory — the very directory
+// check-nupkg-contents.sh's regression this whole class exists to prevent staying clean.
+using AlRunner.Infrastructure;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class NclShadowRuntimeTests
+{
+    private static string NewTempDir(string label)
+    {
+        var dir = Path.Combine(Path.GetTempPath(), $"ncl-shadow-tests-{label}-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    private static bool IsSymlink(string path) =>
+        File.GetAttributes(path).HasFlag(FileAttributes.ReparsePoint);
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // NeedsShadow
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// <summary>Positive: Ncl.dll present beside the running assembly (a package that
+    /// still ships it, or a shadow child that already has its own real copy) means no
+    /// shadow/re-exec dance is needed.</summary>
+    [Fact]
+    public void NeedsShadow_NclPresent_ReturnsFalse()
+    {
+        var dir = NewTempDir("needs-present");
+        try
+        {
+            File.WriteAllBytes(Path.Combine(dir, "Microsoft.Dynamics.Nav.Ncl.dll"), new byte[] { 1, 2, 3 });
+            Assert.False(NclShadowRuntime.NeedsShadow(dir));
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    /// <summary>Negative: an install directory without Ncl.dll (the packaging fix's whole
+    /// point — see check-nupkg-contents.sh) must be flagged as needing the shadow dance,
+    /// specifically so Program.cs doesn't fall through to loading the raw, un-rewritten
+    /// copy via the ALC.Resolving fallback (which crashes at startup on Linux — see the
+    /// class doc on NclShadowRuntime).</summary>
+    [Fact]
+    public void NeedsShadow_NclAbsent_ReturnsTrue()
+    {
+        var dir = NewTempDir("needs-absent");
+        try
+        {
+            File.WriteAllText(Path.Combine(dir, "al-runner.dll"), "not actually a dll, just needs to exist");
+            Assert.True(NclShadowRuntime.NeedsShadow(dir));
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // MirrorInstallDirectory — the entry-assembly-must-be-a-real-copy regression pin
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// <summary>Positive + the actual regression pin: the entry assembly and its
+    /// manifests land in the shadow dir as REAL files (not symlinks) with byte-identical
+    /// content to the source. A symlink here would make CoreCLR report
+    /// AppContext.BaseDirectory as the ORIGINAL install directory instead of the shadow
+    /// dir — see this file's header comment for the empirical confirmation.</summary>
+    [Fact]
+    public void MirrorInstallDirectory_EntryAssemblyAndManifests_AreRealCopiesNotSymlinks()
+    {
+        var origDir = NewTempDir("mirror-orig");
+        var shadowDir = NewTempDir("mirror-shadow");
+        try
+        {
+            var dllBytes = new byte[] { 0x4D, 0x5A, 9, 9, 9 };
+            File.WriteAllBytes(Path.Combine(origDir, "al-runner.dll"), dllBytes);
+            File.WriteAllText(Path.Combine(origDir, "al-runner.deps.json"), "{\"deps\":true}");
+            File.WriteAllText(Path.Combine(origDir, "al-runner.runtimeconfig.json"), "{\"rc\":true}");
+
+            NclShadowRuntime.MirrorInstallDirectory(origDir, shadowDir);
+
+            var shadowDll = Path.Combine(shadowDir, "al-runner.dll");
+            var shadowDeps = Path.Combine(shadowDir, "al-runner.deps.json");
+            var shadowRc = Path.Combine(shadowDir, "al-runner.runtimeconfig.json");
+
+            Assert.False(IsSymlink(shadowDll), "al-runner.dll must be a real copy, not a symlink");
+            Assert.False(IsSymlink(shadowDeps), "al-runner.deps.json must be a real copy, not a symlink");
+            Assert.False(IsSymlink(shadowRc), "al-runner.runtimeconfig.json must be a real copy, not a symlink");
+
+            Assert.Equal(dllBytes, File.ReadAllBytes(shadowDll));
+            Assert.Equal("{\"deps\":true}", File.ReadAllText(shadowDeps));
+            Assert.Equal("{\"rc\":true}", File.ReadAllText(shadowRc));
+
+            // Independent inode, not just independent path: mutating the source after
+            // mirroring must NOT change the shadow copy (a hardlink or symlink would
+            // both fail this — only a genuine File.Copy passes).
+            File.WriteAllBytes(Path.Combine(origDir, "al-runner.dll"), new byte[] { 0xFF, 0xFF });
+            Assert.Equal(dllBytes, File.ReadAllBytes(shadowDll));
+        }
+        finally
+        {
+            Directory.Delete(origDir, recursive: true);
+            Directory.Delete(shadowDir, recursive: true);
+        }
+    }
+
+    /// <summary>Negative (the cost-control half of the same design): every OTHER file —
+    /// the large, numerous dependency DLLs that are NOT the entry assembly or its
+    /// manifests — must be linked, not copied, so building/rebuilding the shadow dir
+    /// stays near-zero-cost. Asserts a symlink specifically (not just "resolves to the
+    /// right content", which a copy would also satisfy) so a regression that silently
+    /// switches everything to File.Copy — correct but expensive — still fails this test.</summary>
+    [Fact]
+    public void MirrorInstallDirectory_OtherDependencyDll_IsSymlinkedNotCopied()
+    {
+        var origDir = NewTempDir("mirror-orig2");
+        var shadowDir = NewTempDir("mirror-shadow2");
+        try
+        {
+            var depBytes = new byte[] { 0x4D, 0x5A, 7, 7, 7 };
+            var depPath = Path.Combine(origDir, "Some.Dependency.dll");
+            File.WriteAllBytes(depPath, depBytes);
+
+            NclShadowRuntime.MirrorInstallDirectory(origDir, shadowDir);
+
+            var shadowDep = Path.Combine(shadowDir, "Some.Dependency.dll");
+            Assert.True(IsSymlink(shadowDep), "non-entry dependency DLLs should be symlinked for near-zero cost");
+            Assert.Equal(depBytes, File.ReadAllBytes(shadowDep));
+        }
+        finally
+        {
+            Directory.Delete(origDir, recursive: true);
+            Directory.Delete(shadowDir, recursive: true);
+        }
+    }
+
+    /// <summary>Positive: a subdirectory (e.g. a satellite-resource culture folder, or
+    /// runtimes/) is mirrored too, as a directory symlink, and its content is reachable
+    /// through it.</summary>
+    [Fact]
+    public void MirrorInstallDirectory_Subdirectory_IsMirroredAndReachable()
+    {
+        var origDir = NewTempDir("mirror-orig3");
+        var shadowDir = NewTempDir("mirror-shadow3");
+        try
+        {
+            var subDir = Path.Combine(origDir, "cs");
+            Directory.CreateDirectory(subDir);
+            File.WriteAllText(Path.Combine(subDir, "al-runner.resources.dll"), "fake satellite resource");
+
+            NclShadowRuntime.MirrorInstallDirectory(origDir, shadowDir);
+
+            var shadowSubFile = Path.Combine(shadowDir, "cs", "al-runner.resources.dll");
+            Assert.True(File.Exists(shadowSubFile));
+            Assert.Equal("fake satellite resource", File.ReadAllText(shadowSubFile));
+        }
+        finally
+        {
+            Directory.Delete(origDir, recursive: true);
+            Directory.Delete(shadowDir, recursive: true);
+        }
+    }
+}

--- a/AlRunner.Tests/PhaseLogIntegrationTests.cs
+++ b/AlRunner.Tests/PhaseLogIntegrationTests.cs
@@ -307,7 +307,12 @@ public sealed class PhaseLogIntegrationTests : IDisposable
         // there rather than passing quietly here.
         var expectedParents =
             CountOccurrences(output, "[r2r] re-execing")
-            + CountOccurrences(output, "[Cecil] Fresh rewrite done");
+            + CountOccurrences(output, "[Cecil] Fresh rewrite done")
+            // The tool package no longer ships Microsoft.Dynamics.Nav.Ncl.dll (see
+            // check-nupkg-contents.sh) — NclShadowRuntime re-execs into a shadow runtime
+            // dir that legitimately has it, UNCONDITIONALLY (every cold AND warm spawn,
+            // not just a fresh-rewrite cache MISS), so this fires on every test run here.
+            + CountOccurrences(output, "[Cecil] Ncl.dll not shipped in this install");
         var parents = ReadRecords(_logPath, "process-reexec-parent");
         Assert.Equal(expectedParents, parents.Count);
         Assert.All(parents, parent =>

--- a/AlRunner/Infrastructure/NclShadowRuntime.cs
+++ b/AlRunner/Infrastructure/NclShadowRuntime.cs
@@ -1,0 +1,306 @@
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace AlRunner.Infrastructure;
+
+/// <summary>
+/// Bootstraps a fresh process whose <c>AppContext.BaseDirectory</c> legitimately
+/// contains <c>Microsoft.Dynamics.Nav.Ncl.dll</c>, for installs that no longer ship it
+/// in the tool package (see <c>.github/scripts/check-nupkg-contents.sh</c> — the
+/// package must not redistribute Microsoft's BC assembly; the user's own artifact
+/// cache supplies it at runtime instead, same as every other BC/Aspose/Graph DLL that
+/// was already stripped).
+///
+/// <para><b>Why this can't be fixed in-process.</b> CoreCLR's trusted-platform-assemblies
+/// (TPA) list is computed once, by the native host, before any of our managed code
+/// runs — from the app's <c>deps.json</c> plus the literal on-disk contents of
+/// <c>AppContext.BaseDirectory</c> AT THAT MOMENT. Writing Ncl.dll into that directory
+/// a few statements into <c>Main</c> (as <see cref="NclCecilRewrite.RewriteInPlace"/>
+/// already does, for the case where the file already exists there) is too late: TPA
+/// was already fixed without it. A later <c>Assembly.Load("Microsoft.Dynamics.Nav.Ncl")</c>
+/// then falls through to the <c>AssemblyLoadContext.Default.Resolving</c> fallback
+/// (<see cref="AlRunner.DependencyLoader"/>), which serves the RAW, un-Cecil-rewritten
+/// copy straight from the BC artifact cache — and <c>NavEnvironment</c>'s static
+/// constructor then calls the real <c>WindowsIdentity.GetCurrent()</c>, which throws
+/// <c>PlatformNotSupportedException</c> on Linux. Confirmed empirically before this
+/// class existed (see the PR that introduced it).
+/// </para>
+///
+/// <para><b>The fix.</b> Build (or reuse) a runner-owned "shadow" directory that
+/// mirrors this install: most of the large, numerous dependency DLLs are symlinked
+/// (near-zero cost — so they resolve exactly as they would from the real install
+/// directory), but the entry assembly (<c>al-runner.dll</c>) plus its deps/runtimeconfig
+/// manifests are real, independent COPIES, not symlinks — confirmed empirically that a
+/// symlinked entry assembly makes CoreCLR report <c>AppContext.BaseDirectory</c> as the
+/// symlink's TARGET directory (the real install), silently defeating the whole point.
+/// The Cecil-rewritten Ncl.dll (produced via the existing <c>ncl-cecil</c> cache) is
+/// likewise a real file. Then re-exec via the <c>dotnet</c> muxer pointed at the shadow
+/// copy of <c>al-runner.dll</c>. The CHILD process's TPA is computed fresh, from a
+/// directory where Ncl.dll genuinely exists on disk before that process starts, so it
+/// resolves faithfully with no further trickery — the child takes the exact same
+/// <see cref="NclCecilRewrite.RewriteInPlace"/> path any normal (Ncl.dll-shipping)
+/// install already takes.</para>
+/// </summary>
+public static class NclShadowRuntime
+{
+    private const string NclFileName = "Microsoft.Dynamics.Nav.Ncl.dll";
+    private const string MarkerFileName = ".al-runner-shadow-source";
+    private const string EntryDllName = "al-runner.dll";
+
+    // The entry assembly and the small manifests hostfxr reads to launch it — these
+    // must be real, independent files in the shadow dir, not symlinks. See the comment
+    // at the call site in EnsureShadowDir for why.
+    private static readonly string[] MustCopyNames =
+    {
+        "al-runner.dll", "al-runner.pdb", "al-runner.deps.json",
+        "al-runner.runtimeconfig.json", "al-runner.runtimeconfig.dev.json",
+    };
+
+    private static bool MustBeRealCopy(string fileName) =>
+        MustCopyNames.Contains(fileName, StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// True when this install does not ship Ncl.dll beside the running assembly — i.e.
+    /// <see cref="EnsureShadowDir"/> + a re-exec is required before any BC type can be
+    /// touched. (A shadow child's own base directory always has the real file, so this
+    /// is naturally false there — no separate "am I the child" flag needed.)
+    /// </summary>
+    public static bool NeedsShadow(string baseDirectory) =>
+        !File.Exists(Path.Combine(baseDirectory, NclFileName));
+
+    /// <summary>
+    /// Builds (or reuses) the shadow directory mirroring <paramref name="origDir"/> and
+    /// returns the absolute path to its <c>al-runner.dll</c> — the argument the caller
+    /// should re-exec via <c>dotnet exec &lt;path&gt;</c>.
+    /// </summary>
+    public static string EnsureShadowDir(string origDir, string bcServiceTierDir)
+    {
+        var origFull = Path.GetFullPath(origDir);
+
+        // Keys off the SAME hash NclCecilRewrite's own ncl-cecil cache uses (source Ncl
+        // bytes + this runner build's content hash + its CACHE_VERSION) so the two
+        // caches invalidate together, plus a hash of origFull itself: what's cached
+        // HERE is a set of symlinks to a specific PATH, not just content, so two
+        // installs that happen to be byte-identical must not share a shadow dir — if
+        // one install is later removed, the other would be left with dangling links.
+        var nclSrc = Path.Combine(bcServiceTierDir, NclFileName);
+        var nclBytes = File.ReadAllBytes(nclSrc);
+        var contentKey = NclCecilRewrite.ComputeCacheKeyCore(nclBytes, RunnerFingerprint.ContentHash);
+        var pathHash = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(origFull)))
+            .ToLowerInvariant()[..16];
+        var key = $"{contentKey}-{pathHash}";
+
+        var shadowRoot = CacheRoots.Resolve("ncl-shadow");
+        var shadowDir = Path.Combine(shadowRoot, key);
+        var markerPath = Path.Combine(shadowDir, MarkerFileName);
+        var shadowDll = Path.Combine(shadowDir, EntryDllName);
+        var shadowNcl = Path.Combine(shadowDir, NclFileName);
+
+        // AL_RUNNER_NCL_CACHE=0 (NclCecilRewrite's own escape hatch) means "always do a
+        // fresh Cecil rewrite" — honour that here too rather than silently reusing a
+        // stale shadow dir built before the flag was set.
+        var forceFresh = Environment.GetEnvironmentVariable("AL_RUNNER_NCL_CACHE") == "0";
+
+        var reusable = !forceFresh
+            && File.Exists(markerPath)
+            && File.ReadAllText(markerPath) == origFull
+            && File.Exists(shadowDll)
+            && File.Exists(shadowNcl);
+
+        if (reusable)
+        {
+            Console.Error.WriteLine($"[Cecil] Reusing Ncl shadow runtime dir at {shadowDir}");
+            return shadowDll;
+        }
+
+        Console.Error.WriteLine($"[Cecil] Building Ncl shadow runtime dir at {shadowDir}");
+
+        // Build into a private temp dir, then Directory.Move (rename(2) — atomic on the
+        // same filesystem) into place. AlRunner.Tests's own parallel test collections
+        // proved this matters: several test classes spawn the real runner concurrently,
+        // and since the shadow-dir key depends only on (runner content hash, Ncl bytes,
+        // origFull) — not on anything per-process — two concurrent invocations against
+        // the same install legitimately compute the SAME key and would otherwise both
+        // delete-and-rebuild the SAME final directory at once, so one process's
+        // File.Copy could read a file the other had just deleted mid-rebuild
+        // (IOException: "being used by another process"). Building off to the side and
+        // rename-ing into place means every reader only ever sees either nothing or a
+        // fully-built directory, never a half-built one — same invariant AtomicReplace
+        // already gives the single-file ncl-cecil cache.
+        Directory.CreateDirectory(shadowRoot);
+        var tempDir = Path.Combine(shadowRoot, $"{key}.building.{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            MirrorInstallDirectory(origFull, tempDir);
+
+            // The one real file: Cecil-rewritten Ncl.dll, via the existing ncl-cecil
+            // cache (populates it on MISS, reuses it on HIT — the same cache the child
+            // process's own RewriteInPlace call reads once it starts from this dir).
+            NclCecilRewrite.RewriteInPlace(bcServiceTierDir, Path.Combine(tempDir, NclFileName));
+
+            // Marker goes in LAST, inside the temp dir, so the invariant "marker present
+            // => fully built" survives the rename: nobody can observe a marker-bearing
+            // shadowDir that isn't complete.
+            File.WriteAllText(Path.Combine(tempDir, MarkerFileName), origFull);
+
+            Directory.Move(tempDir, shadowDir);
+        }
+        catch (IOException) when (Directory.Exists(shadowDir))
+        {
+            // Lost the race: another process's Directory.Move landed first. Its
+            // directory is complete by construction (only ever created via this same
+            // rename-into-place path), and — same key — content-equivalent to what we
+            // would have built. Discard our temp build rather than leave it orphaned.
+            try { Directory.Delete(tempDir, recursive: true); } catch { /* best effort */ }
+        }
+        finally
+        {
+            // Belt-and-braces cleanup if something above threw for an unrelated reason
+            // (e.g. RewriteInPlace failing) — don't leave a half-built temp dir behind.
+            try { if (Directory.Exists(tempDir)) Directory.Delete(tempDir, recursive: true); } catch { /* best effort */ }
+        }
+
+        PruneStaleShadowDirs(shadowRoot, shadowDir, keepNewest: 4);
+
+        return shadowDll;
+    }
+
+    /// <summary>
+    /// Symlinks <paramref name="target"/> to <paramref name="source"/> (near-zero cost —
+    /// no data copied). Windows requires admin rights or Developer Mode to create
+    /// symlinks; falls back to a real copy there (and on any other platform where link
+    /// creation is refused) so the shadow dir still comes up correctly, just slower to
+    /// build the first time.
+    /// </summary>
+    /// <summary>
+    /// Mirrors every entry of <paramref name="origFull"/> into <paramref name="shadowDir"/>:
+    /// the entry assembly and its deps/runtimeconfig manifests (<see cref="MustCopyNames"/>)
+    /// as real, independent copies; everything else as a symlink (near-zero cost — these
+    /// are typically dozens of large, numerous dependency DLLs). Internal and side-effect-
+    /// isolated from the Ncl-specific/caching logic above so it's directly testable without
+    /// needing real BC artifact bytes to Cecil-rewrite — see NclShadowRuntimeTests.
+    /// </summary>
+    internal static void MirrorInstallDirectory(string origFull, string shadowDir)
+    {
+        foreach (var entry in Directory.EnumerateFileSystemEntries(origFull))
+        {
+            var name = Path.GetFileName(entry);
+            var target = Path.Combine(shadowDir, name);
+            if (MustBeRealCopy(name))
+            {
+                // Confirmed empirically: a SYMLINKED entry assembly makes CoreCLR report
+                // AppContext.BaseDirectory as the symlink's TARGET directory (origFull),
+                // not the directory the symlink itself lives in (shadowDir) — silently
+                // defeating the entire point of this class (the "in-place" Cecil rewrite
+                // further down Program.cs would then write Ncl.dll back into origFull,
+                // the very directory check-nupkg-contents.sh asserts stays clean). The
+                // entry assembly plus its deps/runtimeconfig manifests must be real,
+                // independent files; every other (large, numerous) dependency DLL is
+                // still fine as a symlink since nothing resolves BaseDirectory from them.
+                File.Copy(entry, target, overwrite: true);
+            }
+            else
+            {
+                LinkOrCopy(entry, target, isDirectory: Directory.Exists(entry));
+            }
+        }
+    }
+
+    private static void LinkOrCopy(string source, string target, bool isDirectory)
+    {
+        try
+        {
+            if (isDirectory) Directory.CreateSymbolicLink(target, source);
+            else File.CreateSymbolicLink(target, source);
+            return;
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or PlatformNotSupportedException)
+        {
+            Console.Error.WriteLine($"[Cecil] Symlink for '{Path.GetFileName(source)}' refused ({ex.GetType().Name}) — falling back to a real copy");
+        }
+
+        if (isDirectory) CopyDirectoryRecursive(source, target);
+        else File.Copy(source, target, overwrite: true);
+    }
+
+    private static void CopyDirectoryRecursive(string sourceDir, string destDir)
+    {
+        Directory.CreateDirectory(destDir);
+        foreach (var file in Directory.EnumerateFiles(sourceDir))
+            File.Copy(file, Path.Combine(destDir, Path.GetFileName(file)), overwrite: true);
+        foreach (var dir in Directory.EnumerateDirectories(sourceDir))
+            CopyDirectoryRecursive(dir, Path.Combine(destDir, Path.GetFileName(dir)));
+    }
+
+    /// <summary>Mirrors NclCecilRewrite's own cache pruning — bounds how many stale
+    /// shadow dirs (one per distinct runner-build + Ncl-version + install-path
+    /// combination) accumulate under ncl-shadow/ across upgrades.</summary>
+    private static void PruneStaleShadowDirs(string shadowRoot, string protectedDir, int keepNewest)
+    {
+        var protectedFull = Path.GetFullPath(protectedDir);
+        List<string> stale;
+        try
+        {
+            stale = Directory.EnumerateDirectories(shadowRoot)
+                .Select(d => new DirectoryInfo(d))
+                .OrderByDescending(d => d.LastWriteTimeUtc)
+                .Skip(keepNewest)
+                .Select(d => d.FullName)
+                .Where(d => !string.Equals(d, protectedFull, StringComparison.OrdinalIgnoreCase))
+                .ToList();
+        }
+        catch (IOException) { return; }
+        catch (UnauthorizedAccessException) { return; }
+
+        foreach (var dir in stale)
+        {
+            try { Directory.Delete(dir, recursive: true); }
+            catch (IOException ex) { Console.Error.WriteLine($"[Cecil] WARN: failed to prune stale shadow dir {dir}: {ex.Message}"); }
+            catch (UnauthorizedAccessException ex) { Console.Error.WriteLine($"[Cecil] WARN: failed to prune stale shadow dir {dir}: {ex.Message}"); }
+        }
+    }
+
+    /// <summary>
+    /// Locates the <c>dotnet</c> muxer this process is running under, without depending
+    /// on PATH: <c>RuntimeEnvironment.GetRuntimeDirectory()</c> resolves to
+    /// <c>&lt;dotnet-root&gt;/shared/Microsoft.NETCore.App/&lt;ver&gt;/</c> for a
+    /// framework-dependent app (which is what this tool always is — see AlRunner.csproj,
+    /// no RuntimeIdentifier); three directories up is the muxer's own install root.
+    /// Falls back to DOTNET_ROOT / PATH for the rare host shape where that layout
+    /// assumption doesn't hold.
+    /// </summary>
+    public static string FindDotnetMuxer()
+    {
+        var exeName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "dotnet.exe" : "dotnet";
+
+        var runtimeDir = RuntimeEnvironment.GetRuntimeDirectory();
+        var candidate = Path.GetFullPath(Path.Combine(runtimeDir, "..", "..", "..", exeName));
+        if (File.Exists(candidate)) return candidate;
+
+        foreach (var envVar in new[] { "DOTNET_ROOT", "DOTNET_ROOT(x86)" })
+        {
+            var root = Environment.GetEnvironmentVariable(envVar);
+            if (string.IsNullOrEmpty(root)) continue;
+            var fromEnv = Path.Combine(root, exeName);
+            if (File.Exists(fromEnv)) return fromEnv;
+        }
+
+        var pathVar = Environment.GetEnvironmentVariable("PATH") ?? "";
+        var sep = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? ';' : ':';
+        foreach (var dir in pathVar.Split(sep, StringSplitOptions.RemoveEmptyEntries))
+        {
+            var fromPath = Path.Combine(dir, exeName);
+            if (File.Exists(fromPath)) return fromPath;
+        }
+
+        throw new InvalidOperationException(
+            "Could not locate the 'dotnet' muxer needed to re-exec into the Ncl runtime " +
+            "shadow directory (Microsoft.Dynamics.Nav.Ncl.dll is deliberately not shipped " +
+            "in this package — see check-nupkg-contents.sh). Tried: this runtime's own " +
+            "install layout, DOTNET_ROOT/DOTNET_ROOT(x86), and PATH. Set DOTNET_ROOT to " +
+            "your .NET install directory and retry.");
+    }
+}

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -672,6 +672,38 @@ Console.WriteLine(serverMode
         ? $"al-runner — watch mode, {bundles.Count} bundle(s) (Ctrl+C to quit)"
         : $"al-runner — running {bundles.Count} bundle(s)");
 
+// The packaged tool no longer ships Microsoft.Dynamics.Nav.Ncl.dll (see
+// check-nupkg-contents.sh) — it must be resolved from the user's own BC artifact
+// cache at runtime, like every other BC/Aspose/Graph DLL already stripped from the
+// package. CoreCLR's TPA list is computed once, by the native host, before any of
+// our code runs, so a THIS-process fix is impossible once we're past that point:
+// re-exec into a shadow runtime dir (see NclShadowRuntime) that legitimately has the
+// file on disk before ITS TPA is computed. A shadow child's own base directory
+// always has the real file, so this naturally does not re-fire there.
+if (AlRunner.Infrastructure.NclShadowRuntime.NeedsShadow(AppContext.BaseDirectory)
+    && Environment.GetEnvironmentVariable("AL_RUNNER_NCL_SHADOW_DONE") != "1")
+{
+    var srcDirForShadow = AlRunner.Infrastructure.BcArtifacts.ServiceTierDir;
+    var shadowDll = AlRunner.Infrastructure.NclShadowRuntime.EnsureShadowDir(AppContext.BaseDirectory, srcDirForShadow);
+    var dotnetMuxer = AlRunner.Infrastructure.NclShadowRuntime.FindDotnetMuxer();
+
+    var psi = new System.Diagnostics.ProcessStartInfo(dotnetMuxer) { UseShellExecute = false };
+    psi.ArgumentList.Add("exec");
+    psi.ArgumentList.Add(shadowDll);
+    // argv[0] is THIS process's own entry path (apphost exe, or the dll path the
+    // dotnet muxer forwarded) — never a user arg, and irrelevant here since we've
+    // already picked the child's entry point explicitly above.
+    var argv = RewriteArtifactPathArg(Environment.GetCommandLineArgs());
+    foreach (var a in argv.Skip(1)) psi.ArgumentList.Add(a);
+    psi.Environment["AL_RUNNER_NCL_SHADOW_DONE"] = "1";
+
+    Console.Error.WriteLine("[Cecil] Ncl.dll not shipped in this install — re-execing into a shadow runtime dir that has it");
+    AlRunner.Infrastructure.PhaseLog.MarkReexecParent();
+    using var shadowChild = System.Diagnostics.Process.Start(psi)!;
+    shadowChild.WaitForExit();
+    return shadowChild.ExitCode;
+}
+
 // Cecil-rewrite Ncl.dll IN-PLACE on the bin path BEFORE CoreCLR's TPA probe
 // resolves it. Must run BEFORE any reference to BcRuntime (whose field metadata
 // triggers Ncl load on class init). Allowed surface per

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -41,18 +41,23 @@
     ANY one of the 6 stays Private=true (copy-local), its own transitive dependencies (the
     entire Aspose/Graph/BusinessCentral closure) stay copy-local too, regardless of the other 5.
 
-    Ncl.dll ITSELF must stay Private=true (and therefore ship, both to bin and to the nupkg):
-    Program.cs Cecil-rewrites Ncl.dll IN PLACE at the exact `AppContext.BaseDirectory +
-    "Microsoft.Dynamics.Nav.Ncl.dll"` path, before Main resolves any BC type, and relies on
-    CoreCLR's TPA (trusted platform assemblies) probe — computed ONCE at native-host startup —
-    already knowing that path. Verified empirically: stripping Ncl.dll from bin (so TPA never
-    learns the path, even though Program.cs still successfully re-writes bytes there moments
-    later) makes the process fall through to DependencyLoader's Resolving handler instead,
-    which loads the RAW, un-Cecil-rewritten copy straight from the artifact dir — the
-    NavEnvironment cctor then calls the real WindowsIdentity.GetCurrent(), which throws
-    PlatformNotSupportedException on Linux, and the process crashes at startup. So Ncl.dll's
-    PATH must exist in bin/the package even though its bytes get overwritten every run; the
-    other 23 DLLs in its closure do not need to.
+    Ncl.dll ITSELF is also now stripped — it must NOT ship in bin or the nupkg either, even
+    though it's a Microsoft BC assembly like the rest of the closure. Historically it stayed
+    (see git blame on this comment for the older text) because Program.cs Cecil-rewrites it IN
+    PLACE at the exact `AppContext.BaseDirectory + "Microsoft.Dynamics.Nav.Ncl.dll"` path, and
+    relies on CoreCLR's TPA (trusted platform assemblies) probe — computed ONCE at native-host
+    startup — already knowing that path; stripping it (so TPA never learns the path, even
+    though Program.cs still successfully re-writes bytes there moments later) made the process
+    fall through to DependencyLoader's Resolving handler instead, which loads the RAW,
+    un-Cecil-rewritten copy straight from the artifact dir and crashes at startup
+    (NavEnvironment's cctor calls the real WindowsIdentity.GetCurrent(), PlatformNotSupported
+    on Linux). That's still true for THIS process — but NclShadowRuntime.cs (Program.cs's very
+    first BC-touching step) now works around it instead of requiring the file to ship: it
+    builds a runner-owned "shadow" directory that mirrors this install via symlinks plus one
+    real file (the Cecil-rewritten Ncl.dll, sourced from the user's own BC artifact cache) and
+    re-execs into it via the dotnet muxer, so the CHILD process's TPA is computed against a
+    directory where Ncl.dll genuinely, legitimately exists on disk. See NclShadowRuntime.cs's
+    class doc for the full mechanism and why an in-process fix is impossible.
 
     The other 5 direct references (Types/Common/Language/Apps/CodeAnalysis) do NOT need to
     ship at all: BcRuntime.ForceLoadBcDlls already loads Common/Types/Language explicitly via
@@ -61,9 +66,9 @@
     Resolving handler below already serves from ServiceTierDir. Confirmed by running a real
     bundle end to end with all 5 stripped from bin.
 
-    Verified end to end (dotnet pack + a clean tool install + a real bundle run) in the PR
-    that added this comment. Guarded in CI by the `pack` job's "Assert the package
-    doesn't ship BC/Aspose/Graph binaries" step (bc-tests.yml), which runs
+    Verified end to end (dotnet pack + a clean tool install + a real bundle run) in the PRs
+    that added and later completed this comment. Guarded in CI by the `pack` job's "Assert the
+    package doesn't ship BC/Aspose/Graph binaries" step (bc-tests.yml), which runs
     .github/scripts/check-nupkg-contents.sh against the real packed nupkg on every
     push/PR — a deny-list of today's known offenders plus a total-size ceiling so a
     future unwanted dependency that doesn't match any name here still fails the build.
@@ -77,8 +82,7 @@
                    OR $([System.String]::Copy('%(Filename)').StartsWith('Aspose.'))
                    OR $([System.String]::Copy('%(Filename)').StartsWith('Microsoft.Graph'))
                    OR $([System.String]::Copy('%(Filename)').StartsWith('Microsoft.BusinessCentral.'))
-                   OR ($([System.String]::Copy('%(Filename)').StartsWith('Microsoft.Dynamics.'))
-                       AND '%(Filename)' != 'Microsoft.Dynamics.Nav.Ncl')
+                   OR $([System.String]::Copy('%(Filename)').StartsWith('Microsoft.Dynamics.'))
                    OR $([System.String]::Copy('%(Filename)').StartsWith('CoreWCF.'))
                    OR $([System.String]::Copy('%(Filename)').StartsWith('Grpc.'))
                    OR '%(Filename)' == 'System.Private.ServiceModel'

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -75,6 +75,10 @@
   -->
   <Target Name="StripBcAppClosureFromCopyLocal" AfterTargets="ResolveAssemblyReferences">
     <ItemGroup>
+      <!-- Universal (every project): the closure minus Ncl.dll itself. Unchanged by the
+           Ncl packaging fix below — AlRunner.Tests never needed Types/Common/Language/
+           Apps/CodeAnalysis in its own bin either (same reasoning as AlRunner: loaded
+           via ServiceTierDir at runtime, not TPA), only Ncl.dll is special. -->
       <ReferenceCopyLocalPaths Remove="@(ReferenceCopyLocalPaths)"
         Condition="$([System.String]::Copy('%(Filename)').StartsWith('Microsoft.Identity'))
                    OR $([System.String]::Copy('%(Filename)').StartsWith('System.IdentityModel'))
@@ -82,7 +86,8 @@
                    OR $([System.String]::Copy('%(Filename)').StartsWith('Aspose.'))
                    OR $([System.String]::Copy('%(Filename)').StartsWith('Microsoft.Graph'))
                    OR $([System.String]::Copy('%(Filename)').StartsWith('Microsoft.BusinessCentral.'))
-                   OR $([System.String]::Copy('%(Filename)').StartsWith('Microsoft.Dynamics.'))
+                   OR ($([System.String]::Copy('%(Filename)').StartsWith('Microsoft.Dynamics.'))
+                       AND '%(Filename)' != 'Microsoft.Dynamics.Nav.Ncl')
                    OR $([System.String]::Copy('%(Filename)').StartsWith('CoreWCF.'))
                    OR $([System.String]::Copy('%(Filename)').StartsWith('Grpc.'))
                    OR '%(Filename)' == 'System.Private.ServiceModel'
@@ -91,6 +96,17 @@
                    OR '%(Filename)' == 'Microsoft.Data.SqlClient'
                    OR '%(Filename)' == 'Microsoft.Exchange.WebServices.NETStandard'
                    OR '%(Filename)' == 'System.Drawing.Common'" />
+
+      <!-- Ncl.dll itself: stripped ONLY from AlRunner's own copy-local — that's the
+           project PackAsTool packs, and NclShadowRuntime.cs handles resolving Ncl.dll
+           from the user's BC artifact cache at runtime instead (see the class doc there,
+           and check-nupkg-contents.sh). AlRunner.Tests is NOT packed and keeps its own
+           pristine bin-deployed copy: BcEngineCollection's in-process engine tests load
+           Ncl.dll directly (they can't re-exec the way a real `al-runner` invocation
+           does — see bc-tests.yml's "Warm the Ncl Cecil rewrite cache" step, which
+           pre-seeds that copy from a throwaway `al-runner` run's shadow-dir output). -->
+      <ReferenceCopyLocalPaths Remove="@(ReferenceCopyLocalPaths)"
+        Condition="'$(MSBuildProjectName)' == 'AlRunner' AND '%(Filename)' == 'Microsoft.Dynamics.Nav.Ncl'" />
     </ItemGroup>
   </Target>
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ What the runner does **not** do:
 
 What the runner **does** modify:
 
-- `Microsoft.Dynamics.Nav.Ncl.dll` — rewritten once via Cecil at startup and cached at `~/.cache/al-runner/ncl-cecil/<key>.dll`. This is the runtime-engine layer. See `AlRunner/Infrastructure/NclCecilRewrite.cs`.
+- `Microsoft.Dynamics.Nav.Ncl.dll` — rewritten once via Cecil at startup and cached at `~/.cache/al-runner/ncl-cecil/<key>.dll`. This is the runtime-engine layer. See `AlRunner/Infrastructure/NclCecilRewrite.cs`. The tool package does **not** ship this DLL (it's Microsoft's, resolved from your own BC artifact cache at runtime, same as the rest of the BC service-tier closure) — on first run for a given install + BC version, `AlRunner/Infrastructure/NclShadowRuntime.cs` builds a small shadow runtime directory containing the rewritten copy and re-execs into it once; that shadow dir is then reused on every later run.
 - Remaining R2R-reachable entry points — patched via JMP-hooks installed by `BcRuntime.EnsureApplied()` (`AlRunner/BcRuntime.cs`, `AlRunner/Patches/*.cs`).
 
 This is the **precompiled-DLL contract** described in `.claude/rules/precompiled-dll-respect.md`. AL output the runner emits is governed by the same contract once finalised — it is meant to be cacheable on disk and reusable like any MS or ISV DLL.


### PR DESCRIPTION
Closes #2025

## Problem

PR #2023 stripped Aspose/Graph/every-other-`Microsoft.Dynamics.*` DLL from the packed tool nupkg, but kept one exception: `Microsoft.Dynamics.Nav.Ncl.dll` (11.3 MB), Microsoft's own BC runtime-engine assembly. It stayed because `Program.cs` Cecil-rewrites it in place at the exact bin path CoreCLR's trusted-platform-assemblies (TPA) probe needs to already know about — TPA is computed once, by the native host, before any of the runner's own code runs. A prior attempt to just strip it (confirmed empirically) made the process fall through to the raw, un-rewritten copy served from the BC artifact cache, and crash at startup on Linux (`NavEnvironment`'s cctor calls the real `WindowsIdentity.GetCurrent()`, `PlatformNotSupportedException`).

Like the rest of the BC service-tier closure, `Ncl.dll` belongs in the user's own BC artifact cache, resolved at runtime — not redistributed in the package.

## Fix

Adds `NclShadowRuntime`: on first run for a given install + BC version, builds a runner-owned shadow runtime directory that mirrors the real install — most files symlinked (near-zero cost), but the entry assembly (`al-runner.dll`) and its deps/runtimeconfig manifests as real, independent copies. That last part matters: confirmed empirically that symlinking the entry assembly itself makes CoreCLR report `AppContext.BaseDirectory` as the symlink's *target* directory (the real install), not the shadow dir the symlink lives in — silently defeating the whole mechanism and, worse, writing the rewritten `Ncl.dll` right back into the real install directory. The Cecil-rewritten `Ncl.dll` itself is likewise a real file, sourced via the existing `ncl-cecil` cache. Program.cs then re-execs via the `dotnet` muxer into that shadow directory, so a fresh process's TPA legitimately includes the real, on-disk file.

Shadow-dir builds are atomic (build into a private temp dir, then `Directory.Move` into place) — `AlRunner.Tests`' own parallel runner spawns raced to rebuild the same shared directory concurrently during testing, which the atomic-rename fixes the same way the existing `ncl-cecil` single-file cache already avoids the same race.

Removes the allow-list exception from `check-nupkg-contents.sh` so it now enforces `Ncl.dll`'s absence exactly like every other stripped DLL.

## Verification

**Clean install, full corpus, from `dotnet pack` → `dotnet tool install --tool-path` into an isolated dir:**
- Zero `Microsoft.Dynamics.*` files anywhere in the installed tool, before *and* after a full corpus run (confirms nothing leaks a copy back into the install directory).
- Full `tests/al-language` corpus: **2130/2130 pass**, both with the machine's normal BC artifact cache present and after a complete artifact-cache wipe + `--auto-provision` re-download (this also happened to answer a parallel concern raised mid-review about first-run-with-empty-cache behavior — see below).
- Package size: **14.9 MB → 10.96 MB** compressed.

**Startup cost** (the actual ask — an 11 MB assembly copy/rewrite isn't free):
- Fully cold (empty `~/.cache/al-runner`, BC artifacts already present): 65.9s wall for the full 2130-test corpus — dominated by AL emit (4s) + C# compile (14s) + test execution (36s) + BC engine bootstrap, not by the shadow mechanism.
- Fully warm (repeat run): ~14.3s wall.
- Isolating JUST the shadow-dir rebuild (delete `ncl-shadow`, keep the `ncl-cecil` Cecil-rewrite cache and AL-output cache warm): ~14.4s — a ~100ms difference, within run-to-run noise. Rebuilding the shadow dir is cheap because it's mostly symlinks plus one cache-hit copy of an already-rewritten 11 MB file.
- The now-unconditional extra re-exec (previously only fired on an `ncl-cecil` cache miss; now fires on every single invocation, warm or cold, since `Ncl.dll` is never shipped): measured directly by comparing three repeated warm full-corpus runs with `Ncl.dll` artificially present (single-process, old behavior) vs absent (two-process shadow path) against the *same* warm cache — 14.26s average vs 14.27s average. The extra process spawn is unmeasurable against a ~14s run.

**Empty-artifact-cache first-run path** (raised mid-review, tested as its own thing): with `~/.local/share/al-runner/artifacts`, `~/.bcartifacts.cache`, and `~/.cache/al-runner` all moved aside to simulate a genuinely fresh machine:
- Without `--auto-provision`: fails loud and clear — `BC artifact root not found: ... No artifacts are downloaded — download one explicitly, e.g.: dotnet run --project tools/DownloadArtifacts -- service-tier 28.1 ...`, exit code 2. (The suggested fix command assumes a repo checkout rather than a tool-only install — a pre-existing, unrelated rough edge, not introduced by this PR.)
- With `--auto-provision`: fully recovers from nothing — downloads the BC engine closure and the platform R2R apps the corpus needs, then runs the full corpus green (2130/2130), all in one command.

All caches were restored to their original state afterward.

## Tests

- `AlRunner.Tests/NclShadowRuntimeTests.cs` (new): pins `NeedsShadow`'s presence/absence detection, and the actual regression this class exists to prevent — `MirrorInstallDirectory` must copy the entry assembly + manifests as real, independent files (not symlinks), while every other dependency DLL is symlinked for cost. 5 tests, all passing.
- `AlRunner.Tests/PhaseLogIntegrationTests.cs` updated: the always-on shadow re-exec adds a new, distinctly-labelled re-exec path this test's marker-counting invariant needed to know about — exactly the "every re-exec path must be labelled" check the test's own comment describes.
- Full `AlRunner.Tests` suite: 907/908 passing. The one remaining failure (`SourceDepSymbolsWithoutPackageCacheTests.SiblingSourceDep_CompilesWithZeroPackageCacheDirs`) reproduces identically on unmodified `main` (verified directly) — a pre-existing, environment-dependent flake unrelated to this change.

## Test plan
- [x] `AlRunner.Tests/NclShadowRuntimeTests.cs` — RED → GREEN
- [x] Full `AlRunner.Tests` suite (907/908, 1 pre-existing unrelated flake reproduced on `main`)
- [x] `check-nupkg-contents.sh` RED (old nupkg, exemption removed) → GREEN (new nupkg)
- [x] Clean `dotnet tool install` + full corpus (2130/2130), before/after a run
- [x] Cold/warm/shadow-only-rebuild startup cost measured
- [x] Empty-artifact-cache + `--auto-provision` end-to-end recovery verified