### PR TITLE
fix(provision): auto-provision the BC artifact cache by default

### DIFF
--- a/AlRunner.Tests/AutoProvisionDefaultTests.cs
+++ b/AlRunner.Tests/AutoProvisionDefaultTests.cs
@@ -1,0 +1,153 @@
+// Issue #2028 (item 2 of #2024): a clean `dotnet tool install` on a machine with NO
+// artifact cache must work without the user knowing anything about provisioning. Since
+// PR #2023/#2026 stripped the BC engine assemblies out of the packed tool nupkg, the
+// ONLY place they can come from is ~/.local/share/al-runner/artifacts/<version>/,
+// populated exclusively by provisioning — and Program.cs used to default
+// `autoProvision = false`, so a first run against an empty cache failed instead of
+// self-healing.
+//
+// These tests spawn the REAL runner binary against a REAL, hermetically empty artifact
+// cache (an isolated $HOME, never the machine's actual
+// ~/.local/share/al-runner/artifacts) and make a genuine small network call against the
+// public BC artifact CDN — deliberately NOT a download of the multi-gigabyte service-tier
+// closure. Passing --bc-version 1.2.3.4 (a version that can never exist) means:
+//   - the "explicit 4-part version" branch of RunProvisioning skips CDN index resolution
+//     entirely and goes straight to a single HEAD request for that (nonexistent) version,
+//   - which 404s immediately, so the assertion is "a network attempt was made and named",
+//     never "the download succeeded" — no bytes beyond a 404 response are ever fetched.
+// This is the cheapest test that can distinguish "the runner tried to provision
+// automatically" from "the runner didn't". Per .claude/rules/bc-behavior-tests-go-upstream.md
+// this is a runner-mechanism claim (default flag value + the CLI's own provisioning-gap
+// message), not a BC-behaviour claim, so it belongs here, not in the al-language corpus.
+using System.Diagnostics;
+using System.Text;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class AutoProvisionDefaultTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+
+    // A version that will never exist on the CDN — guarantees a fast 404 (or a fast
+    // "no such prefix" from the index) instead of ever touching the multi-GB service-tier
+    // ZIP. Four segments so RunProvisioning's "explicit full version" branch is taken,
+    // skipping index resolution and going straight to one HEAD request.
+    private const string NonexistentVersion = "1.2.3.4";
+
+    private static (int ExitCode, string StdErr) RunIsolated(string isolatedHome, params string[] extraArgs)
+    {
+        var args = new StringBuilder(TestBuildConfig.RunArgs(Path.Combine(RepoRoot, "AlRunner")));
+        args.Append($" --bc-version {NonexistentVersion}");
+        foreach (var a in extraArgs) args.Append(' ').Append(a);
+
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            Arguments = args.ToString(),
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            WorkingDirectory = RepoRoot,
+        };
+        // Redirect $HOME so BcArtifacts.ArtifactsRoot (~/.local/share/al-runner/artifacts)
+        // resolves under a directory that has NEVER existed — the exact "clean tool
+        // install, no artifact cache" scenario issue #2028 requires, independent of
+        // whatever the machine actually running this test has cached for real.
+        psi.Environment["HOME"] = isolatedHome;
+
+        var errSb = new StringBuilder();
+        using var proc = Process.Start(psi)!;
+        proc.OutputDataReceived += (_, e) => { };
+        proc.ErrorDataReceived += (_, e) => { if (e.Data != null) lock (errSb) errSb.AppendLine(e.Data); };
+        proc.BeginOutputReadLine();
+        proc.BeginErrorReadLine();
+        if (!proc.WaitForExit(60_000))
+        {
+            try { proc.Kill(entireProcessTree: true); } catch { }
+            throw new TimeoutException(
+                "al-runner did not exit within 60s against an isolated empty artifact cache. " +
+                "If the test machine has no network reachability to the BC artifact CDN, a " +
+                "provisioning attempt can block on HttpClient's multi-minute timeout instead " +
+                "of failing fast — see ArtifactDownloader.ServiceTier/TryHeadContentLength.");
+        }
+        proc.WaitForExit();
+        lock (errSb) return (proc.ExitCode, errSb.ToString());
+    }
+
+    private static string NewIsolatedHome()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "al-runner-auto-provision-default", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    /// <summary>
+    /// RED on unfixed `main`: with autoProvision defaulting to false, a plain invocation
+    /// against an empty cache never attempts a download at all — it goes straight to the
+    /// "BC artifact root not found" throw with no "[provision]" line anywhere in stderr.
+    /// GREEN: auto-provisioning is now on by default (issue #2024/#2028), so the SAME
+    /// invocation, with NO --auto-provision flag, must attempt to fetch the requested
+    /// version automatically.
+    /// </summary>
+    [Fact]
+    public void NoFlags_EmptyArtifactCache_AttemptsAutomaticProvisioning()
+    {
+        var home = NewIsolatedHome();
+        try
+        {
+            var (exit, stderr) = RunIsolated(home); // no --auto-provision, no --no-auto-provision
+
+            Assert.Contains(
+                $"[provision] downloading BC {NonexistentVersion} engine service-tier closure",
+                stderr);
+            // The version can never exist, so this must still fail — the claim under test
+            // is "provisioning was ATTEMPTED automatically", not "it succeeded".
+            Assert.Equal(2, exit);
+        }
+        finally
+        {
+            try { Directory.Delete(home, recursive: true); } catch { }
+        }
+    }
+
+    /// <summary>
+    /// The opt-out (issue #2028 requirement #2, for offline/air-gapped machines): with
+    /// --no-auto-provision, the exact same empty-cache invocation must NOT touch the
+    /// network at all, and must fail loud with the tool-install-valid fix command
+    /// (`al-runner provision` / `--auto-provision`) named as the PRIMARY recommendation —
+    /// not only the repo-checkout-only `dotnet run --project tools/DownloadArtifacts`
+    /// command, which is useless to a `dotnet tool install` user (the exact gap impl-15
+    /// found testing PR #2026 with an empty cache).
+    /// </summary>
+    [Fact]
+    public void NoAutoProvision_EmptyArtifactCache_FailsLoudWithToolInstallValidCommand_NoNetworkAttempt()
+    {
+        var home = NewIsolatedHome();
+        try
+        {
+            var (exit, stderr) = RunIsolated(home, "--no-auto-provision");
+
+            Assert.DoesNotContain("[provision] downloading", stderr);
+            Assert.Equal(2, exit);
+            Assert.Contains("BC artifact root not found", stderr);
+            // The universally-valid fix, whether the runner came from a tool install or a
+            // checkout — must be present, not just the checkout-only fallback.
+            Assert.Contains("al-runner provision", stderr);
+            // The checkout-only command may still be offered as a secondary option, but
+            // must not be the ONLY thing on offer — assert the primary recommendation
+            // appears BEFORE it in the message.
+            var toolInstallIdx = stderr.IndexOf("al-runner provision", StringComparison.Ordinal);
+            var checkoutOnlyIdx = stderr.IndexOf("dotnet run --project tools/DownloadArtifacts", StringComparison.Ordinal);
+            Assert.True(checkoutOnlyIdx < 0 || toolInstallIdx < checkoutOnlyIdx,
+                $"The tool-install-valid fix ('al-runner provision') must be named before " +
+                $"the repo-checkout-only fallback, not after it:\n{stderr}");
+        }
+        finally
+        {
+            try { Directory.Delete(home, recursive: true); } catch { }
+        }
+    }
+}

--- a/AlRunner.Tests/BcArtifactSelectionTests.cs
+++ b/AlRunner.Tests/BcArtifactSelectionTests.cs
@@ -64,9 +64,12 @@ public sealed class BcArtifactSelectionTests : IDisposable
 
         var ex = Assert.Throws<InvalidOperationException>(
             () => BcArtifacts.SelectArtifactVersionDir(_root, "26"));
-        // Loud failure: names what IS available so a human/agent can act.
+        // Loud failure: names what IS available so a human/agent can act, and leads with
+        // the tool-install-valid fix (issue #2024/#2028) before the repo-checkout-only
+        // manual fallback.
         Assert.Contains("28.2.50931.52786", ex.Message);
-        Assert.Contains("Download it explicitly", ex.Message);
+        Assert.Contains("al-runner provision", ex.Message);
+        Assert.Contains("dotnet run --project tools/DownloadArtifacts", ex.Message);
     }
 
     /// <summary>

--- a/AlRunner.Tests/CliDocumentationTests.cs
+++ b/AlRunner.Tests/CliDocumentationTests.cs
@@ -223,7 +223,7 @@ public sealed class CliDocumentationTests
     /// </summary>
     private static readonly string[] BehaviorChangingFlags =
     {
-        "--tdd", "--watch", "--server", "--define", "--auto-provision", "--no-cache",
+        "--tdd", "--watch", "--server", "--define", "--auto-provision", "--no-auto-provision", "--no-cache",
     };
 
     /// <summary>Negative: an unknown documentation flag must not be silently accepted.</summary>

--- a/AlRunner/Infrastructure/BcArtifacts.cs
+++ b/AlRunner/Infrastructure/BcArtifacts.cs
@@ -29,7 +29,25 @@ public static class BcArtifacts
 {
     public const string ArtifactsRoot_Rel = ".local/share/al-runner/artifacts";
 
-    /// <summary>The explicit download command users must run (no auto-download).</summary>
+    /// <summary>
+    /// The tool-install-valid, one-command fix — works identically whether the runner
+    /// came from `dotnet tool install` or a source checkout. This is the PRIMARY
+    /// recommendation in every provisioning-gap message: unlike
+    /// <see cref="DownloadCommand"/>, it names no path that only exists in this repo's
+    /// own source tree.
+    /// </summary>
+    public static string ProvisionHint(string? versionPrefix = null)
+        => versionPrefix == null
+            ? "al-runner provision   (or re-run your command with --auto-provision)"
+            : $"al-runner provision --bc-version {versionPrefix}   (or re-run your command with --auto-provision)";
+
+    /// <summary>
+    /// The manual, repo-checkout-only fallback: invokes `tools/DownloadArtifacts` directly.
+    /// That project ships only as source in this repo — it is NOT part of the packaged
+    /// `dotnet tool install` output — so this command is only valid from a checkout, never
+    /// for a tool install. Callers must always pair it with <see cref="ProvisionHint"/> as
+    /// the primary, universally-valid recommendation.
+    /// </summary>
     public static string DownloadCommand(System.Version ver, string dir)
         => $"dotnet run --project tools/DownloadArtifacts -- service-tier {ver} \"{dir}\"";
 
@@ -144,8 +162,9 @@ public static class BcArtifacts
     {
         if (!Directory.Exists(rootDir))
             throw new InvalidOperationException(
-                $"BC artifact root not found: {rootDir}. No artifacts are downloaded — " +
-                $"download one explicitly, e.g.: {DownloadCommand(new System.Version(28, 1), rootDir)}");
+                $"BC artifact root not found: {rootDir}. No artifacts are downloaded — resolve it ONE of these ways: " +
+                $"(a) {ProvisionHint()}; " +
+                $"(b) manually, repo checkout only: {DownloadCommand(new System.Version(28, 1), rootDir)}");
 
         var candidates = Directory.EnumerateDirectories(rootDir)
             .Select(d => (Dir: d, Name: Path.GetFileName(d),
@@ -156,8 +175,9 @@ public static class BcArtifacts
 
         if (candidates.Count == 0)
             throw new InvalidOperationException(
-                $"BC artifact root {rootDir} contains no version-named directories. " +
-                $"Download one explicitly, e.g.: {DownloadCommand(new System.Version(28, 1), rootDir)}");
+                $"BC artifact root {rootDir} contains no version-named directories. Resolve it ONE of these ways: " +
+                $"(a) {ProvisionHint()}; " +
+                $"(b) manually, repo checkout only: {DownloadCommand(new System.Version(28, 1), rootDir)}");
 
         if (requestedVersionOrNull == null)
             return candidates[0].Dir;
@@ -171,7 +191,9 @@ public static class BcArtifacts
             var available = string.Join(", ", candidates.Select(t => t.Name));
             throw new InvalidOperationException(
                 $"No BC artifact under {rootDir} matches version '{requestedVersionOrNull}'. " +
-                $"Available: {available}. Download it explicitly, e.g.: " +
+                $"Available: {available}. Resolve it ONE of these ways: " +
+                $"(a) {ProvisionHint(prefix)}; " +
+                $"(b) manually, repo checkout only: " +
                 $"{DownloadCommand(System.Version.TryParse(EnsureFourPart(prefix), out var pv) ? pv : new System.Version(28, 1), rootDir)}");
         }
         return match.Dir;

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -269,14 +269,27 @@ string? expectationsDirArg = null;
 string? countBaselinePath = null;
 // `provision` subcommand: `al-runner provision [<project>]` provisions the BC artifacts
 // for the project's version and exits (no test run). `--auto-provision` provisions on the
-// fly when artifacts are missing, then continues the normal run. Both are the opt-in that
-// gates the runner's otherwise-forbidden downloads (no silent auto-download).
+// fly when artifacts are missing, then continues the normal run.
+//
+// Issue #2024 (item 2): auto-provisioning is ON BY DEFAULT. Since PR #2023/#2026 the
+// packaged tool ships none of the BC engine assemblies — they resolve ONLY from
+// ~/.local/share/al-runner/artifacts/<version>/, populated by nothing but provisioning
+// itself. A first-time `dotnet tool install` user with an empty cache has no copy
+// anywhere, so opt-in provisioning (the pre-#2024 default) meant a clean install could
+// never run a single test without the user first discovering `--auto-provision` exists.
+// `--no-auto-provision` is the explicit opt-out for offline/air-gapped environments,
+// where reaching the network unasked for gigabyte-scale artifacts is a real problem —
+// see docs/scope.md and .claude/rules/loud-failures.md (a refused/failed provision must
+// still fail loud with an actionable, tool-install-valid fix command, never silently).
+// `--auto-provision` itself is kept as an explicit, redundant-with-the-default alias for
+// back-compat with existing scripts/docs that already pass it.
 bool provisionSubcommand = args.Length > 0 && args[0] == "provision";
-bool autoProvision = false;
+bool autoProvision = true;
 for (int i = 0; i < args.Length; i++)
 {
     if (i == 0 && args[i] == "provision") { continue; } // consumed as subcommand
     if (args[i] == "--auto-provision") { autoProvision = true; continue; }
+    if (args[i] == "--no-auto-provision") { autoProvision = false; continue; }
     if (args[i] == "--bc-version" && i + 1 < args.Length) { bcVersionArg = args[++i]; continue; }
     if (args[i] == "--artifact-path" && i + 1 < args.Length) { artifactPathArg = args[++i]; continue; }
     if (args[i] == "--out" && i + 1 < args.Length) { outPath = args[++i]; printClassification = true; continue; }
@@ -597,10 +610,11 @@ if (bcVersionArg == null && artifactPathArg == null)
                 $"runner build supports major {engineMajor} (cross-major needs a matching runner build).");
     }
 }
-// ── Provisioning (opt-in): `provision` subcommand or --auto-provision. Resolves the
-// target version, downloads the engine service-tier closure if it's missing/incomplete,
-// then (subcommand) exits or (flag) continues the run against what was provisioned. This
-// is the ONLY path that downloads — a normal run never does.
+// ── Provisioning (on by default since issue #2024; opt out with --no-auto-provision):
+// `provision` subcommand or autoProvision (default true). Resolves the target version,
+// downloads the engine service-tier closure if it's missing/incomplete, then (subcommand)
+// exits or (flag/default) continues the run against what was provisioned. This is the
+// ONLY path that downloads — a run with --no-auto-provision never does.
 if (provisionSubcommand || autoProvision)
 {
     // Issue #1996 (AC #6): manifest-app (platform-apps/test-apps) provisioning must have
@@ -823,7 +837,8 @@ if (!provisionSubcommand)
 
     if (decision.ShouldDownloadAny && !autoProvision)
     {
-        // Issue #1996 acceptance criterion #10: no download without opt-in, on EITHER path.
+        // Issue #1996 acceptance criterion #10 / issue #2024: no download when the caller
+        // has explicitly refused it with --no-auto-provision, on EITHER path.
         Console.Error.WriteLine(!platformReport.Ok
             ? platformReport.ToDetailedMessage()
             : AlRunner.Infrastructure.ProvisioningCheck.BuildManifestNeedsMissingMessage(
@@ -3809,9 +3824,16 @@ static void PrintGuide(TextWriter w)
     w.WriteLine("  not currently print its selection, so pass --bc-version explicitly rather than");
     w.WriteLine("  relying on the default — leaving it off can silently change test outcomes.");
     w.WriteLine();
-    w.WriteLine("  BC artifacts are never downloaded silently. Obtain them explicitly:");
-    w.WriteLine("    al-runner provision <bundle-dir>     # provision for that project's version, then exit");
-    w.WriteLine("    al-runner --auto-provision <dirs>    # provision on demand, then continue the run");
+    w.WriteLine("  BC artifacts are provisioned AUTOMATICALLY by default (issue #2024): a first run");
+    w.WriteLine("  against an empty ~/.local/share/al-runner/artifacts downloads the engine +");
+    w.WriteLine("  platform/test apps it needs and continues, no flag required. Pass");
+    w.WriteLine("  --no-auto-provision to refuse network access (offline/air-gapped machines) —");
+    w.WriteLine("  a refused or failed provision still fails loud, naming exactly what is");
+    w.WriteLine("  missing and a fix command that is valid for a `dotnet tool install`, never a");
+    w.WriteLine("  silent stub. Other provisioning entry points:");
+    w.WriteLine("    al-runner provision <bundle-dir>        # provision for that project's version, then exit");
+    w.WriteLine("    al-runner --auto-provision <dirs>       # same as the default, explicit for scripts");
+    w.WriteLine("    al-runner --no-auto-provision <dirs>    # fail loud instead of reaching the network");
     w.WriteLine("  The engine must be built against the same BC MINOR as the target artifacts");
     w.WriteLine("  (28.1 vs 28.2 matters; a major-only match is not sufficient).");
     w.WriteLine();
@@ -3858,8 +3880,10 @@ static void PrintGuide(TextWriter w)
     w.WriteLine("      Action: add the missing .app's directory via --package-cache.");
     w.WriteLine();
     w.WriteLine("  Artifact version not found");
-    w.WriteLine("      Action: the runner never auto-downloads. Run `al-runner provision`, or pass");
-    w.WriteLine("      --auto-provision, or point --artifact-path at an existing artifact root.");
+    w.WriteLine("      Action: auto-provisioning is on by default and should have fetched it —");
+    w.WriteLine("      if you passed --no-auto-provision, drop it (or run `al-runner provision`");
+    w.WriteLine("      explicitly). If provisioning itself failed (no network), point");
+    w.WriteLine("      --artifact-path at an existing artifact root instead.");
     w.WriteLine();
     w.WriteLine("  Compile succeeds, tests still do not run");
     w.WriteLine("      Action: read the DEPENDENCIES trap above. Compilation validates symbols");
@@ -3986,17 +4010,24 @@ static void PrintHelp(TextWriter w)
     w.WriteLine("  --bc-version X          Select the BC artifact version (e.g. \"28.1\" or a full");
     w.WriteLine("                          version). Default: the latest version present in");
     w.WriteLine("                          ~/.local/share/al-runner/artifacts. A prefix matches the");
-    w.WriteLine("                          highest version with that prefix. The runner never");
-    w.WriteLine("                          auto-downloads; an unavailable version fails loud.");
+    w.WriteLine("                          highest version with that prefix. Missing artifacts are");
+    w.WriteLine("                          auto-provisioned by default (see --no-auto-provision);");
+    w.WriteLine("                          an unavailable/refused version still fails loud.");
     w.WriteLine("                          Mutually exclusive with --artifact-path.");
     w.WriteLine("  --artifact-path DIR     Use an explicit BC artifact root (the dir containing");
     w.WriteLine("                          platform/ + w1/), bypassing the cache scan. Its version");
     w.WriteLine("                          is read from the dir name or the contained Ncl.dll.");
     w.WriteLine("                          Mutually exclusive with --bc-version.");
     w.WriteLine("  --auto-provision        Download the BC artifacts for the project's version if");
-    w.WriteLine("                          they are missing, then continue the run. The runner never");
-    w.WriteLine("                          downloads without this flag (or the `provision`");
-    w.WriteLine("                          subcommand) — a missing artifact otherwise fails loud.");
+    w.WriteLine("                          they are missing, then continue the run. ON BY DEFAULT");
+    w.WriteLine("                          since issue #2024 — this flag is now redundant with a");
+    w.WriteLine("                          plain run, kept for explicit scripts/back-compat. See");
+    w.WriteLine("                          --no-auto-provision to turn it off (or the `provision`");
+    w.WriteLine("                          subcommand to provision without running tests).");
+    w.WriteLine("  --no-auto-provision     Disable automatic provisioning: a missing/incomplete BC");
+    w.WriteLine("                          artifact fails loud instead of downloading it. Use this");
+    w.WriteLine("                          on offline/air-gapped machines, or anywhere reaching the");
+    w.WriteLine("                          network unasked for gigabyte-scale artifacts is unwanted.");
     w.WriteLine("  --package-cache PATH    Extra directory to scan for .app dependencies");
     w.WriteLine("                          (repeatable). Default scan: ~/.bcartifacts.cache,");
     w.WriteLine("                          ~/.local/share/al-runner/artifacts, and bundle .alpackages/.");
@@ -5465,8 +5496,9 @@ static string? TryDeriveBcMajorFromProject(IEnumerable<string> bundlePaths)
 // prefers an already-cached matching version (completing a partial one) and otherwise
 // resolves the latest full version from the CDN, then downloads the engine service-tier
 // closure if it is missing/incomplete. Returns 0 on success (already-complete counts) and
-// sets provisionedVersion to the full version to run against; 1 on failure. This is opt-in
-// — the only path in the runner that downloads.
+// sets provisionedVersion to the full version to run against; 1 on failure. This is the
+// only path in the runner that downloads — on by default since issue #2024, refusable
+// with --no-auto-provision.
 //
 // <paramref name="provisionManifestApps"/> (issue #1996, AC #6): whether THIS call should
 // also provision platform-apps/test-apps. Pass true only for the `provision` subcommand,


### PR DESCRIPTION
Closes #2028 (item 2 of #2024 — **a release is blocked on this**).

## Problem

PR #2023 and #2026 (both merged) removed all Microsoft/ISV binaries from the packed tool nupkg — 92.8 MB down to 10.96 MB. Until then the BC engine assemblies shipped inside the package, so they were present whether or not the user's own artifact cache (`~/.local/share/al-runner/artifacts/<version>/`) was. Now they come from that cache only, and nothing populates it on its own — `Program.cs` defaulted `autoProvision = false`, so a clean `dotnet tool install` on a machine with no cache never runs a single test unless the user already knows `--auto-provision` exists.

Confirmed (impl-15, testing PR #2026 with the artifact cache moved aside):
- **With `--auto-provision`:** recovers from a completely empty cache and runs the full corpus green. The provisioning machinery works.
- **Without it:** fails loud, but the suggested fix command (`dotnet run --project tools/DownloadArtifacts -- service-tier ...`) assumes a source checkout — useless to the one user who actually hits this: someone who obtained the runner via `dotnet tool install` and has no checkout.

## Fix

1. **`autoProvision` now defaults to `true`.** `--auto-provision` is kept as an explicit, back-compat alias (now redundant with a plain run). Added `--no-auto-provision` as the explicit opt-out for offline/air-gapped environments — reaching the network unasked for gigabyte-scale artifacts is a real concern there, and this repo had no prior offline convention to honor.
2. **Fixed the one provisioning-gap message that was invalid for a tool install.** `BcArtifacts.SelectArtifactVersionDir` — the exact site impl-15 hit — only offered `dotnet run --project tools/DownloadArtifacts`. Every *other* provisioning-gap message in the runner (`ProvisioningCheck.Report.ToDetailedMessage`, `MissingDependencyException`, `DependencyResolver`, `BuildPlatformAppMissingR2RMessage`, `BuildManifestNeedsMissingMessage`) already led with `al-runner provision` / `--auto-provision` as the primary recommendation — I checked every site that emits a provisioning-command hint, and this was the only one that didn't. Added `BcArtifacts.ProvisionHint(...)` and lead all three of `SelectArtifactVersionDir`'s throw messages with it, keeping the manual `dotnet run` command as an explicitly-labeled repo-checkout-only fallback.
3. **Progress output** already flows through `Action<string> logf` defaulting to `Console.Error.WriteLine` in `ArtifactDownloader`/`ProvisioningCheck.AutoProvision` — nothing was swallowing it on the auto path; no change needed there.
4. **No regression to `--auto-provision` / `provision` or issue #1996's "exactly one owner per invocation."** Only the `autoProvision` default value changed; `RunProvisioning`'s call sites, the post-`SelectVersion` manifest-provisioning gate, and the single-owner comments are untouched (updated in place to describe the new default, not the mechanics).
5. **`--help`/`--guide` updated** to document `--no-auto-provision` and the new default (`CliDocumentationTests`'s drift guards enforce both).

## Proof

`AlRunner.Tests/AutoProvisionDefaultTests.cs` spawns the real runner binary against a hermetically empty artifact cache (isolated `$HOME`, never the machine's real `~/.local/share/al-runner/artifacts`) with `--bc-version 1.2.3.4` — a version that can never exist, so the assertion is "a network attempt was made and named," never "the download succeeded." This deliberately avoids ever touching the multi-gigabyte service-tier ZIP: the explicit 4-part version skips CDN index resolution and goes straight to one HEAD request, which 404s immediately.

- **RED on unfixed `main`** (verified directly): `HOME=<empty> dotnet al-runner.dll --bc-version 1.2.3.4` → no `[provision]` line anywhere in stderr, and the failure message only offers `dotnet run --project tools/DownloadArtifacts -- service-tier 28.1 "<dir>"`.
- **GREEN with the fix:** the same invocation, no flags, attempts `[provision] downloading BC 1.2.3.4 engine service-tier closure`. `--no-auto-provision` makes zero network attempts and fails with `al-runner provision` named before the checkout-only fallback.

Also ran:
- `dotnet test AlRunner.Tests` (full suite, 910 tests): 853 passed, 56 skipped (need a live artifact cache/corpus, unaffected), 1 pre-existing failure (`SourceDepSymbolsWithoutPackageCacheTests.SiblingSourceDep_CompilesWithZeroPackageCacheDirs`) — reproduced identically on unmodified `main`, unrelated to this change.
- `CliDocumentationTests`, `ProvisioningCheckTests`, `BcArtifactSelectionTests`, `ArtifactDownloader404Tests` individually — all green (one existing `BcArtifactSelectionTests` assertion updated for the new message wording).

## Note for the release

Manual verification of the full "clean `dotnet tool install`, zero-flag, full corpus" scenario from a genuinely empty cache (as impl-15 did for PR #2026) is still worth doing before the release ships, since it exercises the multi-gigabyte download path this PR's tests deliberately avoid — the mechanism itself (`--auto-provision` recovering from nothing) was already proven working by impl-15's PR #2026 testing; this PR only changes when it fires, not how it works.

## Overlap check (per instructions — impl-17 is concurrently working #2024 item 3)

Checked `origin/agent/impl-17/engine-variants` against this branch: its `Program.cs` edits are 3 isolated one-line swaps (`Assembly.Load` → `EngineLoadContext.LoadFromBytes`) at lines ~2086/2297/3517, nowhere near this PR's edits (arg parsing ~L275-282, provisioning flow ~L604-810, `--help`/`--guide` text, and `RunProvisioning`'s doc comments ~L5460+). No line-level or functional overlap found.