### PR TITLE
feat(pack): select and shadow-swap a per-BC-minor engine variant at startup

### DIFF
--- a/.github/workflows/bc-tests.yml
+++ b/.github/workflows/bc-tests.yml
@@ -42,6 +42,17 @@ on:
           means the release can never build against a version different from — or
           staler than — the one that just passed the matrix.
         value: ${{ jobs.resolve-versions.outputs.required-version }}
+      versions-json:
+        description: >-
+          JSON array of every live-resolved full BC build this run tested — one per
+          .github/bc-versions.txt entry (the same list `matrix` carries, flattened to
+          just the version strings). Used to build the per-BC-minor engine variants
+          (#2024 item 3 / #2027) WITHOUT either caller re-resolving versions itself —
+          re-resolving in a caller is exactly the re-inlining ReleaseTestParityTests
+          guards against (#1976), and would risk building a variant against a DIFFERENT
+          build than the one the matrix above just gated on if Microsoft published a new
+          build in between.
+        value: ${{ jobs.resolve-versions.outputs.versions-json }}
 
 env:
   DOTNET_NOLOGO: true
@@ -56,6 +67,7 @@ jobs:
       # jobs that build once rather than across the matrix (currently `smoke`). Every
       # version in the matrix now gates; this output just picks the representative one.
       required-version: ${{ steps.resolve.outputs.required-version }}
+      versions-json: ${{ steps.resolve.outputs.versions-json }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -98,6 +110,10 @@ jobs:
           done
           echo "matrix={\"target\":$ENTRIES}" >> "$GITHUB_OUTPUT"
           echo "Matrix: $ENTRIES"
+
+          VERSIONS_JSON=$(echo "$ENTRIES" | python3 -c "import json,sys; v=json.load(sys.stdin); print(json.dumps([e['bc-version'] for e in v]))")
+          echo "versions-json=$VERSIONS_JSON" >> "$GITHUB_OUTPUT"
+          echo "Versions: $VERSIONS_JSON"
 
   test:
     needs: resolve-versions
@@ -528,6 +544,41 @@ jobs:
       - name: Install the aarch64 cross-compiler (#1672)
         run: sudo apt-get update && sudo apt-get install -y gcc-aarch64-linux-gnu
 
+      - name: Build each BC-minor engine variant (#2024 item 3 / #2027)
+        # One thin al-runner.dll build per version in resolve-versions' versions-json
+        # output (already the live-resolved, already-tested build for every
+        # .github/bc-versions.txt entry — NOT re-resolved here: re-resolving would be
+        # exactly the re-inlining ReleaseTestParityTests/#1976 exists to catch, since
+        # publish.yml's release job runs this identical step and must not carry its own
+        # copy of `tools/DownloadArtifacts` version resolution). Staged for the pack step
+        # below to fold into variants/<full-build-version>/ in the nupkg (see
+        # AlRunner.csproj's EngineVariantsStagingDir property). EngineVariants.cs picks
+        # the matching one at startup instead of running a single fixed-minor engine
+        # against whatever BC artifact happens to be selected — the root cause of #2020.
+        # Deliberately rebuilds the SAME version the "Build and pack" step below also
+        # builds for the top-level entry point (whichever prefix resolve-versions marks
+        # `required-version`) — that duplication is intentional, not wasted: the
+        # top-level slot and its own variants/<version>/ copy are independent package
+        # locations by design (see AlRunner.csproj), and this loop is the single source
+        # of truth for every variant regardless of which one also happens to be primary.
+        env:
+          VERSIONS_JSON: ${{ needs.resolve-versions.outputs.versions-json }}
+        run: |
+          mkdir -p ./variants-staging
+          for full in $(echo "$VERSIONS_JSON" | python3 -c "import json,sys; [print(v) for v in json.load(sys.stdin)]"); do
+            echo "Building engine variant for BC $full..."
+            dotnet build AlRunner/ \
+              -p:_BCVersion="$full" -p:AllowBcArtifactDownload=true \
+              -o "./variant-build-$full"
+            mkdir -p "./variants-staging/$full"
+            for f in al-runner.dll al-runner.pdb al-runner.deps.json al-runner.runtimeconfig.json; do
+              cp "./variant-build-$full/$f" "./variants-staging/$full/$f"
+            done
+            rm -rf "./variant-build-$full"
+          done
+          echo "Staged variants:"
+          ls -la ./variants-staging
+
       - name: Build and pack (mirrors publish.yml's release job, minus the push)
         # #2010: publish.yml's "Build and pack" step is the one step in the whole
         # release path that ONLY ever ran during an actual release — the release of
@@ -550,6 +601,7 @@ jobs:
             -p:_BCVersion=${{ needs.resolve-versions.outputs.required-version }} \
             -p:AllowBcArtifactDownload=true -p:Version=0.0.0-ci \
             -p:SuppressImplicitGitSourceLink=false -p:IncludeSourceRevisionInInformationalVersion=true \
+            -p:EngineVariantsStagingDir="$(pwd)/variants-staging" \
             -o ./nupkg
 
       - name: Assert a package was actually produced
@@ -572,3 +624,16 @@ jobs:
         # NclShadowRuntime.cs's class doc for how Ncl.dll itself is now resolved from the
         # user's own BC artifact cache at runtime instead of being shipped.
         run: .github/scripts/check-nupkg-contents.sh ./nupkg/*.nupkg
+
+      - name: Assert every BC-minor engine variant made it into the package
+        # A staging-step failure that got silently skipped (e.g. a bad glob) would
+        # otherwise still produce a valid-looking package with zero variants — the exact
+        # "looks fine, quietly regressed" shape #1825/#2010's own history warns about.
+        run: |
+          count=$(unzip -l ./nupkg/*.nupkg | grep -c 'tools/net8.0/any/variants/.*/al-runner\.dll$')
+          expected=$(grep -v '^#' .github/bc-versions.txt | tr ' ' '\n' | grep -c .)
+          echo "Packed variants: $count, expected: $expected"
+          if [ "$count" -ne "$expected" ]; then
+            echo "::error::nupkg contains $count engine variant(s), expected $expected (one per .github/bc-versions.txt entry)"
+            exit 1
+          fi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -154,6 +154,33 @@ jobs:
           # stubs for both RIDs without needing an arm64 runner.
           sudo apt-get update && sudo apt-get install -y gcc-aarch64-linux-gnu
 
+      - name: Build each BC-minor engine variant (#2024 item 3 / #2027)
+        # Consumes needs.test.outputs.versions-json — the SAME live-resolved, ALREADY
+        # tested build list bc-tests.yml's own `pack` job uses (see that job's identical
+        # step for the full rationale) — rather than re-resolving versions here. Calling
+        # tools/DownloadArtifacts directly in this file is exactly the re-inlining
+        # ReleaseTestParityTests/#1976 fails a normal unit-test run over: two copies of
+        # version-resolution logic drifted before and broke two releases. Delegating the
+        # resolution to the shared bc-tests.yml workflow (via its versions-json output)
+        # keeps this file down to consuming an already-tested list, not restating it.
+        env:
+          VERSIONS_JSON: ${{ needs.test.outputs.versions-json }}
+        run: |
+          mkdir -p ./variants-staging
+          for full in $(echo "$VERSIONS_JSON" | python3 -c "import json,sys; [print(v) for v in json.load(sys.stdin)]"); do
+            echo "Building engine variant for BC $full..."
+            dotnet build AlRunner/ \
+              -p:_BCVersion="$full" -p:AllowBcArtifactDownload=true \
+              -o "./variant-build-$full"
+            mkdir -p "./variants-staging/$full"
+            for f in al-runner.dll al-runner.pdb al-runner.deps.json al-runner.runtimeconfig.json; do
+              cp "./variant-build-$full/$f" "./variants-staging/$full/$f"
+            done
+            rm -rf "./variant-build-$full"
+          done
+          echo "Staged variants:"
+          ls -la ./variants-staging
+
       - name: Build and pack
         id: build-and-pack
         run: |
@@ -202,6 +229,7 @@ jobs:
             -p:_BCVersion=${{ needs.test.outputs.required-version }} \
             -p:AllowBcArtifactDownload=true -p:Version=${{ inputs.version }} \
             -p:SuppressImplicitGitSourceLink=false -p:IncludeSourceRevisionInInformationalVersion=true \
+            -p:EngineVariantsStagingDir="$(pwd)/variants-staging" \
             -o ./nupkg
 
       - name: Generate CHANGELOG and push the release commit + tag

--- a/AlRunner.Tests/EngineVariantsTests.cs
+++ b/AlRunner.Tests/EngineVariantsTests.cs
@@ -1,0 +1,178 @@
+// EngineVariantsTests — pins the per-BC-minor engine variant discovery/selection
+// mechanism for #2024 item 3 / #2027: a packed tool now ships one thin engine binary
+// per .github/bc-versions.txt entry under variants/<full-build-version>/, and the runner
+// picks the right one at startup instead of running a single, fixed-minor engine against
+// whatever BC artifact happens to be selected (the root cause of #2020).
+//
+// Every assertion here is a concrete value, not a bare non-throw — a stub implementation
+// that always returned the first variant, or null, or an empty list, would fail every
+// negative case and most of the positives (see .claude/rules/tdd.md).
+using AlRunner.Infrastructure;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class EngineVariantsTests
+{
+    private static string NewTempDir(string label)
+    {
+        var dir = Path.Combine(Path.GetTempPath(), $"engine-variants-tests-{label}-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    private static void MakeVariant(string baseDir, string version)
+    {
+        var dir = Path.Combine(baseDir, EngineVariants.VariantsDirName, version);
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, EngineVariants.EntryAssemblyFileName), "fake");
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Discover
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// <summary>Negative: no variants/ directory at all (a plain dev/test `dotnet build`
+    /// checkout) — discovery must come back empty, not throw, so every downstream caller
+    /// degrades to today's single-build behaviour.</summary>
+    [Fact]
+    public void Discover_NoVariantsDirectory_ReturnsEmpty()
+    {
+        var baseDir = NewTempDir("no-dir");
+        try
+        {
+            Assert.Empty(EngineVariants.Discover(baseDir));
+        }
+        finally { Directory.Delete(baseDir, recursive: true); }
+    }
+
+    /// <summary>Positive: well-formed variant directories are all discovered, with their
+    /// build version parsed from the directory name and their own directory path.</summary>
+    [Fact]
+    public void Discover_WellFormedVariants_ReturnsAllWithParsedVersionsAndPaths()
+    {
+        var baseDir = NewTempDir("well-formed");
+        try
+        {
+            MakeVariant(baseDir, "28.1.49838.53910");
+            MakeVariant(baseDir, "28.3.52162.53954");
+
+            var found = EngineVariants.Discover(baseDir);
+
+            Assert.Equal(2, found.Count);
+            Assert.Contains(found, v => v.BuildVersion == new Version(28, 1, 49838, 53910)
+                && v.Dir == Path.Combine(baseDir, "variants", "28.1.49838.53910"));
+            Assert.Contains(found, v => v.BuildVersion == new Version(28, 3, 52162, 53954));
+        }
+        finally { Directory.Delete(baseDir, recursive: true); }
+    }
+
+    /// <summary>Negative: a directory whose name isn't a parseable version, and a
+    /// version-named directory missing its own al-runner.dll, are both skipped rather
+    /// than corrupting discovery for the well-formed siblings.</summary>
+    [Fact]
+    public void Discover_MalformedEntries_AreSkippedNotThrown()
+    {
+        var baseDir = NewTempDir("malformed");
+        try
+        {
+            MakeVariant(baseDir, "28.1.49838.53910"); // well-formed
+            Directory.CreateDirectory(Path.Combine(baseDir, "variants", "not-a-version"));
+            Directory.CreateDirectory(Path.Combine(baseDir, "variants", "28.9.0.0")); // no al-runner.dll inside
+
+            var found = EngineVariants.Discover(baseDir);
+
+            Assert.Single(found);
+            Assert.Equal(new Version(28, 1, 49838, 53910), found[0].BuildVersion);
+        }
+        finally { Directory.Delete(baseDir, recursive: true); }
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // SelectBestMatch
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// <summary>Positive: an EXACT 4-part build match wins over a same-minor,
+    /// different-build variant that's also present — proves the tiering order, not just
+    /// "a match was found".</summary>
+    [Fact]
+    public void SelectBestMatch_ExactBuildPresent_PrefersExactOverSameMinorDifferentBuild()
+    {
+        var variants = new[]
+        {
+            new EngineVariants.Variant(new Version(28, 1, 11111, 1), "/v/28.1.11111.1"),
+            new EngineVariants.Variant(new Version(28, 1, 22222, 2), "/v/28.1.22222.2"),
+        };
+
+        var match = EngineVariants.SelectBestMatch(variants, new Version(28, 1, 22222, 2));
+
+        Assert.NotNull(match);
+        Assert.Equal(new Version(28, 1, 22222, 2), match!.Value.Variant.BuildVersion);
+        Assert.False(match.Value.Degraded);
+    }
+
+    /// <summary>Positive: no exact build, but a same-major.minor variant exists — matched,
+    /// flagged Degraded (the known CodeAnalysis per-build strong-name skew risk).</summary>
+    [Fact]
+    public void SelectBestMatch_NoExactBuild_FallsBackToSameMinorAsDegraded()
+    {
+        var variants = new[]
+        {
+            new EngineVariants.Variant(new Version(28, 1, 11111, 1), "/v/28.1.11111.1"),
+        };
+
+        var match = EngineVariants.SelectBestMatch(variants, new Version(28, 1, 99999, 9));
+
+        Assert.NotNull(match);
+        Assert.Equal(new Version(28, 1, 11111, 1), match!.Value.Variant.BuildVersion);
+        Assert.True(match.Value.Degraded);
+    }
+
+    /// <summary>Negative: no variant shares even the MAJOR — must return null, not a
+    /// nearby-major variant. #2020's root cause was exactly this silent fallback; the
+    /// caller (Program.cs) turns a null here into a loud, version-naming failure.</summary>
+    [Fact]
+    public void SelectBestMatch_NoMajorMatch_ReturnsNull()
+    {
+        var variants = new[]
+        {
+            new EngineVariants.Variant(new Version(28, 1, 11111, 1), "/v/28.1.11111.1"),
+        };
+
+        var match = EngineVariants.SelectBestMatch(variants, new Version(27, 5, 1, 1));
+
+        Assert.Null(match);
+    }
+
+    /// <summary>Negative: an empty variant list never matches anything.</summary>
+    [Fact]
+    public void SelectBestMatch_NoVariants_ReturnsNull()
+    {
+        var match = EngineVariants.SelectBestMatch(Array.Empty<EngineVariants.Variant>(), new Version(28, 1, 1, 1));
+        Assert.Null(match);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // DescribeAvailable
+    // ─────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void DescribeAvailable_ListsEachVariantVersion()
+    {
+        var variants = new[]
+        {
+            new EngineVariants.Variant(new Version(27, 5, 1, 1), "/v/27.5"),
+            new EngineVariants.Variant(new Version(28, 1, 1, 1), "/v/28.1"),
+        };
+
+        var desc = EngineVariants.DescribeAvailable(variants);
+
+        Assert.Equal("27.5.1.1, 28.1.1.1", desc);
+    }
+
+    [Fact]
+    public void DescribeAvailable_NoVariants_SaysNone()
+    {
+        Assert.Equal("(none)", EngineVariants.DescribeAvailable(Array.Empty<EngineVariants.Variant>()));
+    }
+}

--- a/AlRunner.Tests/NclShadowRuntimeTests.cs
+++ b/AlRunner.Tests/NclShadowRuntimeTests.cs
@@ -175,4 +175,81 @@ public sealed class NclShadowRuntimeTests
             Directory.Delete(shadowDir, recursive: true);
         }
     }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // entrySource — per-BC-minor engine variant swap (#2024 item 3 / #2027)
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// <summary>Positive: when entrySource is given, the entry assembly (and its
+    /// manifests) come from THAT directory instead of origDir — proves the actual
+    /// variant-swap mechanism, not just "some file got copied". Every OTHER file still
+    /// comes from origDir (the shared dependency closure), asserted via the untouched
+    /// dependency DLL.</summary>
+    [Fact]
+    public void MirrorInstallDirectory_WithEntrySource_EntryAssemblyComesFromEntrySource()
+    {
+        var origDir = NewTempDir("mirror-swap-orig");
+        var entryDir = NewTempDir("mirror-swap-entry");
+        var shadowDir = NewTempDir("mirror-swap-shadow");
+        try
+        {
+            var origBytes = new byte[] { 0x4D, 0x5A, 1, 1, 1 };
+            var variantBytes = new byte[] { 0x4D, 0x5A, 2, 2, 2 };
+            File.WriteAllBytes(Path.Combine(origDir, "al-runner.dll"), origBytes);
+            File.WriteAllText(Path.Combine(origDir, "al-runner.deps.json"), "{\"from\":\"orig\"}");
+            File.WriteAllBytes(Path.Combine(origDir, "Some.Dependency.dll"), new byte[] { 9, 9 });
+
+            File.WriteAllBytes(Path.Combine(entryDir, "al-runner.dll"), variantBytes);
+            File.WriteAllText(Path.Combine(entryDir, "al-runner.deps.json"), "{\"from\":\"variant\"}");
+
+            NclShadowRuntime.MirrorInstallDirectory(origDir, shadowDir, entryDir);
+
+            // The entry assembly and its present manifest came from entryDir, not origDir.
+            Assert.Equal(variantBytes, File.ReadAllBytes(Path.Combine(shadowDir, "al-runner.dll")));
+            Assert.Equal("{\"from\":\"variant\"}", File.ReadAllText(Path.Combine(shadowDir, "al-runner.deps.json")));
+            Assert.False(IsSymlink(Path.Combine(shadowDir, "al-runner.dll")));
+
+            // The shared dependency closure still comes from origDir, untouched.
+            var shadowDep = Path.Combine(shadowDir, "Some.Dependency.dll");
+            Assert.True(IsSymlink(shadowDep));
+            Assert.Equal(new byte[] { 9, 9 }, File.ReadAllBytes(shadowDep));
+        }
+        finally
+        {
+            Directory.Delete(origDir, recursive: true);
+            Directory.Delete(entryDir, recursive: true);
+            Directory.Delete(shadowDir, recursive: true);
+        }
+    }
+
+    /// <summary>Negative: a MustCopyNames file entrySource does NOT have (e.g. a variant
+    /// built without al-runner.runtimeconfig.dev.json, which only a plain `dotnet build`
+    /// produces) falls back to origDir's copy instead of leaving the shadow dir missing
+    /// that file.</summary>
+    [Fact]
+    public void MirrorInstallDirectory_WithEntrySource_MissingManifestFallsBackToOrigDir()
+    {
+        var origDir = NewTempDir("mirror-swap-fallback-orig");
+        var entryDir = NewTempDir("mirror-swap-fallback-entry");
+        var shadowDir = NewTempDir("mirror-swap-fallback-shadow");
+        try
+        {
+            File.WriteAllBytes(Path.Combine(origDir, "al-runner.dll"), new byte[] { 1 });
+            File.WriteAllText(Path.Combine(origDir, "al-runner.runtimeconfig.dev.json"), "{\"dev\":true}");
+            // entryDir has NO al-runner.runtimeconfig.dev.json at all.
+            File.WriteAllBytes(Path.Combine(entryDir, "al-runner.dll"), new byte[] { 2 });
+
+            NclShadowRuntime.MirrorInstallDirectory(origDir, shadowDir, entryDir);
+
+            Assert.Equal(new byte[] { 2 }, File.ReadAllBytes(Path.Combine(shadowDir, "al-runner.dll")));
+            Assert.Equal("{\"dev\":true}",
+                File.ReadAllText(Path.Combine(shadowDir, "al-runner.runtimeconfig.dev.json")));
+        }
+        finally
+        {
+            Directory.Delete(origDir, recursive: true);
+            Directory.Delete(entryDir, recursive: true);
+            Directory.Delete(shadowDir, recursive: true);
+        }
+    }
 }

--- a/AlRunner/AlRunner.csproj
+++ b/AlRunner/AlRunner.csproj
@@ -91,6 +91,39 @@
     <None Include="../CHANGELOG.md" Pack="true" PackagePath="/" />
   </ItemGroup>
 
+  <!-- Per-BC-minor engine variants (#2024 item 3 / #2027). This binary is only ONE
+       engine build (whichever _BCVersion it was compiled with); EngineVariants.cs +
+       NclShadowRuntime pick and swap to the matching one at startup among whatever
+       ships under tools/$(TargetFramework)/any/variants/<full-build-version>/.
+
+       Packing them in is opt-in and additive: EngineVariantsStagingDir is empty by
+       default, so a plain `dotnet pack` (a dev machine, or any CI job that doesn't set
+       it) produces exactly today's single-engine package — EngineVariants.Discover then
+       finds no variants/ directory at all and every selection path falls back to the
+       existing single-build behaviour unchanged.
+
+       CI populates the staging dir before packing: one `dotnet build
+       -p:_BCVersion=<full-build>` per .github/bc-versions.txt entry (including the one
+       this csproj itself was built with — see the pack job for why that duplication is
+       deliberate, not wasted), each copied to
+       $(EngineVariantsStagingDir)/<full-build>/{al-runner.dll,.pdb,.deps.json,.runtimeconfig.json}.
+       %(RecursiveDir) reproduces that per-version subfolder under variants/ in the
+       packed nupkg. -->
+  <PropertyGroup>
+    <EngineVariantsStagingDir Condition="'$(EngineVariantsStagingDir)' == ''"></EngineVariantsStagingDir>
+  </PropertyGroup>
+  <ItemGroup Condition="'$(EngineVariantsStagingDir)' != '' AND Exists('$(EngineVariantsStagingDir)')">
+    <_EngineVariantFiles Include="$(EngineVariantsStagingDir)/**/*" />
+    <!-- Explicit %(Filename)%(Extension) rather than letting PackagePath end in
+         %(RecursiveDir) alone — NuGet's pack task was observed appending the file's own
+         relative-include path AGAIN under a trailing-%(RecursiveDir) PackagePath,
+         doubling the version-folder segment (variants/<v>/<v>/al-runner.dll). Spelling
+         the full destination path out explicitly avoids relying on that inference. -->
+    <None Include="@(_EngineVariantFiles)"
+          Pack="true"
+          PackagePath="tools/$(TargetFramework)/any/variants/%(RecursiveDir)%(Filename)%(Extension)" />
+  </ItemGroup>
+
   <!-- Win32 P/Invoke stubs (kernel32 / user32 / advapi32 / …) for Linux. The .c
        source is compiled on first use by Win32Stubs.cs. Ship it beside the
        binary so the installed dotnet tool can find it. -->

--- a/AlRunner/Infrastructure/EngineVariants.cs
+++ b/AlRunner/Infrastructure/EngineVariants.cs
@@ -1,0 +1,89 @@
+namespace AlRunner.Infrastructure;
+
+/// <summary>
+/// Discovers and selects per-BC-minor engine variants shipped in the packed tool
+/// (issue #2024 item 3 / #2027). BC-free by construction — this runs before
+/// <see cref="BcArtifacts.SelectVersion"/> even completes, let alone before any BC type
+/// is touched, so it may only use <c>System.*</c>.
+///
+/// <para><b>Layout.</b> A packed install carries <c>&lt;packageRoot&gt;/variants/&lt;full-build-version&gt;/</c>
+/// — one directory per <c>.github/bc-versions.txt</c> entry, each holding that build's
+/// own <c>al-runner.dll</c>/<c>.pdb</c>/<c>.deps.json</c>/<c>.runtimeconfig.json</c> (no
+/// native apphost — variants are only ever entered via <c>dotnet exec</c> through
+/// <see cref="NclShadowRuntime"/>'s re-exec, never launched directly). A plain
+/// <c>dotnet build</c>/<c>dotnet run</c> dev checkout has no <c>variants/</c> directory at
+/// all — <see cref="Discover"/> returns empty, and every caller must treat that as "no
+/// variants shipped, behave exactly as the single-build runner always has," not as an
+/// error.</para>
+/// </summary>
+public static class EngineVariants
+{
+    public const string VariantsDirName = "variants";
+    public const string EntryAssemblyFileName = "al-runner.dll";
+
+    public sealed record Variant(Version BuildVersion, string Dir)
+    {
+        public string EntryAssemblyPath => Path.Combine(Dir, EntryAssemblyFileName);
+    }
+
+    /// <summary>
+    /// Every variant shipped alongside <paramref name="baseDirectory"/> (normally
+    /// <c>AppContext.BaseDirectory</c>). Empty — never throws — when there is no
+    /// <c>variants/</c> directory, or it's empty, or malformed entries are found (a
+    /// non-version directory name, or a version directory missing its own
+    /// <c>al-runner.dll</c>, is silently skipped rather than failing discovery for the
+    /// variants that ARE well-formed).
+    /// </summary>
+    public static IReadOnlyList<Variant> Discover(string baseDirectory)
+    {
+        var root = Path.Combine(baseDirectory, VariantsDirName);
+        if (!Directory.Exists(root)) return Array.Empty<Variant>();
+
+        var list = new List<Variant>();
+        foreach (var dir in Directory.EnumerateDirectories(root))
+        {
+            var name = Path.GetFileName(dir.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+            if (!Version.TryParse(name, out var v)) continue;
+            if (!File.Exists(Path.Combine(dir, EntryAssemblyFileName))) continue;
+            list.Add(new Variant(v, dir));
+        }
+        return list;
+    }
+
+    /// <summary>
+    /// Best-matching shipped variant for <paramref name="targetVersion"/> (the SELECTED
+    /// BC artifact version — see <see cref="BcArtifacts.SelectedVersion"/>), in
+    /// descending order of tightness:
+    /// <list type="number">
+    ///   <item>exact 4-part build match — the only tier immune to the
+    ///     <c>Microsoft.Dynamics.Nav.CodeAnalysis</c> per-BUILD strong-name skew (see
+    ///     <see cref="BcArtifacts.DefaultVersionPrefix"/> for the same lesson one level
+    ///     down); returned with <c>Degraded: false</c>.</item>
+    ///   <item>same major.minor, different build — a KNOWN-DEGRADED but usually-survivable
+    ///     configuration (the shipped variant's compiled-against
+    ///     <c>Microsoft.Dynamics.Nav.CodeAnalysis</c> may not strong-name-match the
+    ///     selected artifact's own copy); returned with <c>Degraded: true</c>.</item>
+    /// </list>
+    /// Never falls back across MAJOR or MINOR — <c>.claude/rules/loud-failures.md</c> /
+    /// #2020 is explicit that silently landing on a nearby minor is the bug this whole
+    /// mechanism exists to retire. A caller seeing <c>null</c> must fail loud, naming
+    /// <paramref name="targetVersion"/> and <paramref name="variants"/>, never guess.
+    /// </summary>
+    public static (Variant Variant, bool Degraded)? SelectBestMatch(
+        IReadOnlyList<Variant> variants, Version targetVersion)
+    {
+        foreach (var v in variants)
+            if (v.BuildVersion == targetVersion)
+                return (v, false);
+
+        foreach (var v in variants)
+            if (v.BuildVersion.Major == targetVersion.Major && v.BuildVersion.Minor == targetVersion.Minor)
+                return (v, true);
+
+        return null;
+    }
+
+    /// <summary>Human-readable list of available variant versions, for the loud-fail message.</summary>
+    public static string DescribeAvailable(IReadOnlyList<Variant> variants) =>
+        variants.Count == 0 ? "(none)" : string.Join(", ", variants.Select(v => v.BuildVersion.ToString()));
+}

--- a/AlRunner/Infrastructure/NclShadowRuntime.cs
+++ b/AlRunner/Infrastructure/NclShadowRuntime.cs
@@ -74,10 +74,34 @@ public static class NclShadowRuntime
     /// Builds (or reuses) the shadow directory mirroring <paramref name="origDir"/> and
     /// returns the absolute path to its <c>al-runner.dll</c> — the argument the caller
     /// should re-exec via <c>dotnet exec &lt;path&gt;</c>.
+    ///
+    /// <para><b><paramref name="entrySourceDir"/> — per-BC-minor engine variants
+    /// (#2024 item 3 / #2027).</b> Null (the default) mirrors <paramref name="origDir"/>
+    /// entirely, including its own entry assembly — today's behaviour, unchanged. When
+    /// non-null (the caller selected a DIFFERENT shipped variant than the one currently
+    /// running — see <see cref="EngineVariants"/>), the entry-assembly manifest set
+    /// (<see cref="MustCopyNames"/>) is copied from THAT directory instead, while every
+    /// other dependency DLL is still symlinked from <paramref name="origDir"/> — variants
+    /// share the exact same dependency closure (same commit, same NuGet package
+    /// versions; only the BC <c>&lt;Reference&gt;</c> set differs, and that's resolved
+    /// per-request from the artifact cache, not CopyLocal'd — see
+    /// <c>AlRunner.csproj</c>'s "Version-agnosticism" comment), so nothing needs
+    /// duplicating beyond the entry assembly itself. The Ncl.dll pre-rewrite below is
+    /// SKIPPED in this case: it would be keyed off THIS process's own
+    /// <see cref="RunnerFingerprint.ContentHash"/>, not the swapped-in variant's — the
+    /// child process (running as that variant) does its own first-start rewrite via the
+    /// existing, unchanged <see cref="NclCecilRewrite.RewriteInPlace"/> call in
+    /// Program.cs, correctly keyed to ITSELF. Skipping it here just avoids wasted work
+    /// (and a wrongly-keyed cache write) rather than risking incorrect bytes either way —
+    /// the rewrite transform of a given BC version's Ncl.dll is deterministic and
+    /// identical across variants of the same commit, so at worst an unswapped pre-write
+    /// would have been immediately overwritten by the child's own correctly-keyed one.
+    /// </para>
     /// </summary>
-    public static string EnsureShadowDir(string origDir, string bcServiceTierDir)
+    public static string EnsureShadowDir(string origDir, string bcServiceTierDir, string? entrySourceDir = null)
     {
         var origFull = Path.GetFullPath(origDir);
+        var entrySource = entrySourceDir != null ? Path.GetFullPath(entrySourceDir) : null;
 
         // Keys off the SAME hash NclCecilRewrite's own ncl-cecil cache uses (source Ncl
         // bytes + this runner build's content hash + its CACHE_VERSION) so the two
@@ -85,12 +109,30 @@ public static class NclShadowRuntime
         // HERE is a set of symlinks to a specific PATH, not just content, so two
         // installs that happen to be byte-identical must not share a shadow dir — if
         // one install is later removed, the other would be left with dangling links.
-        var nclSrc = Path.Combine(bcServiceTierDir, NclFileName);
-        var nclBytes = File.ReadAllBytes(nclSrc);
-        var contentKey = NclCecilRewrite.ComputeCacheKeyCore(nclBytes, RunnerFingerprint.ContentHash);
-        var pathHash = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(origFull)))
-            .ToLowerInvariant()[..16];
-        var key = $"{contentKey}-{pathHash}";
+        //
+        // When swapping in a different variant (entrySource != null), the identity
+        // component is the variant's OWN directory name (a stable per-build version
+        // string — see EngineVariants) rather than RunnerFingerprint.ContentHash (which
+        // would describe the CURRENTLY RUNNING process, not the variant being shadowed
+        // in) — otherwise two different variant swaps requested by the same running
+        // process would collide on one shadow dir. No nclBytes/contentKey needed in this
+        // branch since the Ncl pre-rewrite is skipped (see the doc comment above).
+        string key;
+        if (entrySource != null)
+        {
+            var pathHash0 = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(origFull)))
+                .ToLowerInvariant()[..16];
+            key = $"variant-{Path.GetFileName(entrySource)}-{pathHash0}";
+        }
+        else
+        {
+            var nclSrc = Path.Combine(bcServiceTierDir, NclFileName);
+            var nclBytes = File.ReadAllBytes(nclSrc);
+            var contentKey = NclCecilRewrite.ComputeCacheKeyCore(nclBytes, RunnerFingerprint.ContentHash);
+            var pathHash = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(origFull)))
+                .ToLowerInvariant()[..16];
+            key = $"{contentKey}-{pathHash}";
+        }
 
         var shadowRoot = CacheRoots.Resolve("ncl-shadow");
         var shadowDir = Path.Combine(shadowRoot, key);
@@ -134,12 +176,15 @@ public static class NclShadowRuntime
         Directory.CreateDirectory(tempDir);
         try
         {
-            MirrorInstallDirectory(origFull, tempDir);
+            MirrorInstallDirectory(origFull, tempDir, entrySource);
 
             // The one real file: Cecil-rewritten Ncl.dll, via the existing ncl-cecil
             // cache (populates it on MISS, reuses it on HIT — the same cache the child
             // process's own RewriteInPlace call reads once it starts from this dir).
-            NclCecilRewrite.RewriteInPlace(bcServiceTierDir, Path.Combine(tempDir, NclFileName));
+            // Skipped when swapping in a different variant — see the entrySourceDir doc
+            // comment on EnsureShadowDir above for why the child does this itself instead.
+            if (entrySource == null)
+                NclCecilRewrite.RewriteInPlace(bcServiceTierDir, Path.Combine(tempDir, NclFileName));
 
             // Marker goes in LAST, inside the temp dir, so the invariant "marker present
             // => fully built" survives the rename: nobody can observe a marker-bearing
@@ -183,7 +228,20 @@ public static class NclShadowRuntime
     /// isolated from the Ncl-specific/caching logic above so it's directly testable without
     /// needing real BC artifact bytes to Cecil-rewrite — see NclShadowRuntimeTests.
     /// </summary>
-    internal static void MirrorInstallDirectory(string origFull, string shadowDir)
+    /// <param name="origFull">The install directory to mirror (dependency closure,
+    /// satellite resource dirs, Win32Stubs, …).</param>
+    /// <param name="shadowDir">Destination.</param>
+    /// <param name="entrySource">When non-null, the entry-assembly manifest set
+    /// (<see cref="MustCopyNames"/>) is copied from HERE instead of
+    /// <paramref name="origFull"/> — the per-BC-minor engine-variant swap (see the doc
+    /// comment on <see cref="EnsureShadowDir"/>). A name missing from
+    /// <paramref name="entrySource"/> (e.g. a variant built without a
+    /// <c>.runtimeconfig.dev.json</c>, which only plain <c>dotnet build</c> produces)
+    /// falls back to <paramref name="origFull"/>'s copy — harmless, since only
+    /// <c>al-runner.dll</c> itself needs to be the swapped-in variant; the manifests
+    /// alongside it (deps/runtimeconfig) are only consulted for correctness when
+    /// they exist.</param>
+    internal static void MirrorInstallDirectory(string origFull, string shadowDir, string? entrySource = null)
     {
         foreach (var entry in Directory.EnumerateFileSystemEntries(origFull))
         {
@@ -200,11 +258,28 @@ public static class NclShadowRuntime
                 // entry assembly plus its deps/runtimeconfig manifests must be real,
                 // independent files; every other (large, numerous) dependency DLL is
                 // still fine as a symlink since nothing resolves BaseDirectory from them.
-                File.Copy(entry, target, overwrite: true);
+                var source = entrySource != null && File.Exists(Path.Combine(entrySource, name))
+                    ? Path.Combine(entrySource, name)
+                    : entry;
+                File.Copy(source, target, overwrite: true);
             }
             else
             {
                 LinkOrCopy(entry, target, isDirectory: Directory.Exists(entry));
+            }
+        }
+
+        // A variant swap's entry assembly might carry a MustCopyNames file that
+        // origFull's own enumeration never produced a `target` for (e.g. origFull is a
+        // dev build lacking al-runner.pdb, but the variant has one) — cheap top-up pass.
+        if (entrySource != null)
+        {
+            foreach (var name in MustCopyNames)
+            {
+                var source = Path.Combine(entrySource, name);
+                var target = Path.Combine(shadowDir, name);
+                if (File.Exists(source) && !File.Exists(target))
+                    File.Copy(source, target, overwrite: true);
             }
         }
     }

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -572,90 +572,138 @@ if (artifactPathArg != null)
 bool bcVersionAutoSelected = false;
 if (bcVersionArg == null && artifactPathArg == null)
 {
-    // The BUILT version (4-part, baked in at compile time) — not Ncl.dll's assembly
-    // version, whose minor is always 0. Falls back to the Ncl major if the attribute is
-    // missing (e.g. an older build), which restores the previous major-only behaviour.
-    var engineVersion = AlRunner.Infrastructure.BcArtifacts.EngineBuiltVersion()
-        ?? AlRunner.Infrastructure.BcArtifacts.EngineVersion(AppContext.BaseDirectory);
-    var engineMajor = engineVersion?.Major;
-    if (engineVersion != null && engineMajor != null)
+    // #2027 BEHAVIOUR CHANGE: when this install ships per-BC-minor engine variants
+    // (variants/ present — see EngineVariants), the no-flags default INVERTS from
+    // engine-first to artifact-first. Below, ENGINE-first means "prefer whichever
+    // minor THIS compiled binary happens to be" — that bias existed because there was
+    // only ever one engine that could run at all, so a mismatched artifact was a real
+    // problem to steer away from (see the -45/+42/+3 Pageworks regression in the
+    // comment inside the else branch). With N correctly-matched variants shipped and
+    // auto-swapped-to below, that bias no longer protects anything — ANY of the N
+    // shipped minors is equally "this install's own engine" now, so picking the
+    // LATEST CACHED artifact (this was the runner's ORIGINAL default, before the
+    // engine-first change) is the more useful behaviour: a user who has since
+    // downloaded a newer BC artifact gets it by default, rather than being pinned to
+    // whichever minor happened to be copied into the package's top-level slot at pack
+    // time. TryDeriveBcMajorFromProject(bundles) is still the cross-check either way.
+    var shippedVariantsForDefault = AlRunner.Infrastructure.EngineVariants.Discover(AppContext.BaseDirectory);
+    if (shippedVariantsForDefault.Count > 0)
     {
         bcVersionAutoSelected = true;
         // Prefer the engine's OWN major.minor. Latest-in-major used to win here, which
         // silently selected a minor the engine was not built for — measured at -45 passing
         // / +42 failing / +3 errors on Pageworks. See BcArtifacts.DefaultVersionPrefix.
         //
-        // Issue #2033: when auto-provisioning is about to run anyway (the default since
-        // #2024/#2028), ask what it can FETCH — cache, then the CDN, at each tier — not
-        // just what's already cached. Otherwise a genuinely empty cache collapses this
-        // straight to "major only" before a single byte is downloaded, and provisioning
-        // then fetches "latest in major" (e.g. 28.4) while the engine was built for 28.1,
-        // landing a first run in the exact KNOWN-DEGRADED skew #2020 describes. Without
-        // --auto-provision there is no network step coming, so stay cache-only exactly as
-        // before — that path has nothing to gain from probing a CDN it will never use.
-        string tier;
-        if (provisionSubcommand || autoProvision)
-            bcVersionArg = AlRunner.Infrastructure.BcArtifacts.DefaultProvisionTarget(
-                engineVersion, AlRunner.Infrastructure.BcArtifacts.ArtifactsRootDir, out tier);
-        else
+        // #2027: with per-BC-minor engine variants shipped, this branch (variants present)
+        // goes artifact-first instead of engine-first — see the outer if/else below for why.
+        try
         {
-            bcVersionArg = AlRunner.Infrastructure.BcArtifacts.DefaultVersionPrefix(
-                engineVersion, AlRunner.Infrastructure.BcArtifacts.ArtifactsRootDir);
-            var engineMinorPfx = $"{engineVersion.Major}.{engineVersion.Minor}";
-            tier = bcVersionArg == engineVersion.ToString() ? "cached-exact"
-                : bcVersionArg == engineMinorPfx ? "cached-minor"
-                : "major-fallback-offline"; // distinct from "major-fallback": no CDN was consulted
+            var latestDir = AlRunner.Infrastructure.BcArtifacts.SelectArtifactVersionDir(
+                AlRunner.Infrastructure.BcArtifacts.ArtifactsRootDir, null);
+            bcVersionArg = Path.GetFileName(latestDir);
+            Console.Error.WriteLine($"[bc] no --bc-version given — selecting BC {bcVersionArg}, the latest " +
+                $"cached artifact ({shippedVariantsForDefault.Count} engine variant(s) shipped; the matching " +
+                $"one is selected automatically below). Override with --bc-version.");
+        }
+        catch (InvalidOperationException)
+        {
+            // No artifacts cached at all — leave bcVersionArg null. SelectVersion below
+            // throws the loud, path-naming "no artifacts" error users already see today.
         }
 
-        var engineMajorMinor = $"{engineVersion.Major}.{engineVersion.Minor}";
-        switch (tier)
+        var projMajorV = TryDeriveBcMajorFromProject(bundles);
+        if (projMajorV != null && bcVersionArg != null
+            && Version.TryParse(bcVersionArg, out var selV) && selV.Major.ToString() != projMajorV)
+            Console.Error.WriteLine($"[bc] warning: project app.json targets BC major {projMajorV} but the " +
+                $"latest cached artifact is {bcVersionArg} (major {selV.Major}).");
+    }
+    else
+    {
+        // The BUILT version (4-part, baked in at compile time) — not Ncl.dll's assembly
+        // version, whose minor is always 0. Falls back to the Ncl major if the attribute is
+        // missing (e.g. an older build), which restores the previous major-only behaviour.
+        var engineVersion = AlRunner.Infrastructure.BcArtifacts.EngineBuiltVersion()
+            ?? AlRunner.Infrastructure.BcArtifacts.EngineVersion(AppContext.BaseDirectory);
+        var engineMajor = engineVersion?.Major;
+        if (engineVersion != null && engineMajor != null)
         {
-            case "cached-exact":
-                Console.Error.WriteLine($"[bc] no --bc-version given — selecting BC {engineVersion}, the exact " +
-                    $"build this binary was compiled against. Override with --bc-version.");
-                break;
-            case "cdn-exact":
-                Console.Error.WriteLine($"[bc] no --bc-version given — provisioning BC {engineVersion}, the exact " +
-                    $"build this binary was compiled against. Override with --bc-version.");
-                break;
-            case "cached-minor":
-                // Degraded but usually survivable: right minor, different build. The CodeAnalysis
-                // assembly version can still differ between builds of one minor, which fails loud
-                // at startup rather than silently — see BcArtifacts.DefaultVersionPrefix.
-                Console.Error.WriteLine($"[bc] warning: no cached BC {engineVersion} — selecting the latest " +
-                    $"{engineMajorMinor}.x instead. Build-level skew within a minor can still fail to load " +
-                    $"Microsoft.Dynamics.Nav.CodeAnalysis. Fix with: al-runner provision --bc-version {engineVersion}");
-                break;
-            case "cdn-minor":
-                Console.Error.WriteLine($"[bc] no --bc-version given and BC {engineVersion} is not published on " +
-                    $"the CDN — provisioning the latest {engineMajorMinor}.x instead (still this binary's own " +
-                    $"engine minor). Build-level skew within a minor can still fail to load " +
-                    $"Microsoft.Dynamics.Nav.CodeAnalysis. Fix with: al-runner provision --bc-version {engineVersion}");
-                break;
-            case "major-fallback-offline":
-                // No network step is coming (--no-auto-provision, or the rare case where
-                // engineVersion resolved but auto-provisioning is off) — this can only speak
-                // to what's CACHED, never to CDN availability. Original pre-#2033 wording.
-                Console.Error.WriteLine($"[bc] warning: no cached BC {engineMajorMinor}.x — this binary's engine " +
-                    $"was built for {engineVersion}, so a different minor is a KNOWN-DEGRADED configuration " +
-                    $"(measured: dozens of extra failures from engine/artifact minor skew). Falling back to the " +
-                    $"latest cached {engineMajor}.x. Fix with: al-runner provision --bc-version {engineMajorMinor}");
-                break;
-            default: // major-fallback: neither the exact build nor the engine's own minor is
-                     // available from cache or the CDN — a genuine degradation (e.g. #2010,
-                     // Microsoft withdrew the build), not the default-path norm.
-                Console.Error.WriteLine($"[bc] warning: BC {engineMajorMinor}.x is not cached and not available " +
-                    $"from the CDN — this binary's engine was built for {engineVersion}, so a different minor is " +
-                    $"a KNOWN-DEGRADED configuration (measured: dozens of extra failures from engine/artifact " +
-                    $"minor skew). Falling back to the latest {engineMajor}.x. Fix with: al-runner provision " +
-                    $"--bc-version {engineMajorMinor}");
-                break;
-        }
+            bcVersionAutoSelected = true;
+            // Prefer the engine's OWN major.minor. Latest-in-major used to win here, which
+            // silently selected a minor the engine was not built for — measured at -45 passing
+            // / +42 failing / +3 errors on Pageworks. See BcArtifacts.DefaultVersionPrefix.
+            //
+            // Issue #2033: when auto-provisioning is about to run anyway (the default since
+            // #2024/#2028), ask what it can FETCH — cache, then the CDN, at each tier — not
+            // just what's already cached. Otherwise a genuinely empty cache collapses this
+            // straight to "major only" before a single byte is downloaded, and provisioning
+            // then fetches "latest in major" (e.g. 28.4) while the engine was built for 28.1,
+            // landing a first run in the exact KNOWN-DEGRADED skew #2020 describes. Without
+            // --auto-provision there is no network step coming, so stay cache-only exactly as
+            // before — that path has nothing to gain from probing a CDN it will never use.
+            string tier;
+            if (provisionSubcommand || autoProvision)
+                bcVersionArg = AlRunner.Infrastructure.BcArtifacts.DefaultProvisionTarget(
+                    engineVersion, AlRunner.Infrastructure.BcArtifacts.ArtifactsRootDir, out tier);
+            else
+            {
+                bcVersionArg = AlRunner.Infrastructure.BcArtifacts.DefaultVersionPrefix(
+                    engineVersion, AlRunner.Infrastructure.BcArtifacts.ArtifactsRootDir);
+                var engineMinorPfx = $"{engineVersion.Major}.{engineVersion.Minor}";
+                tier = bcVersionArg == engineVersion.ToString() ? "cached-exact"
+                    : bcVersionArg == engineMinorPfx ? "cached-minor"
+                    : "major-fallback-offline"; // distinct from "major-fallback": no CDN was consulted
+            }
 
-        var projMajor = TryDeriveBcMajorFromProject(bundles);
-        if (projMajor != null && projMajor != engineMajor.Value.ToString())
-            Console.Error.WriteLine($"[bc] warning: project app.json targets BC major {projMajor} but this " +
-                $"runner build supports major {engineMajor} (cross-major needs a matching runner build).");
+            var engineMajorMinor = $"{engineVersion.Major}.{engineVersion.Minor}";
+            switch (tier)
+            {
+                case "cached-exact":
+                    Console.Error.WriteLine($"[bc] no --bc-version given — selecting BC {engineVersion}, the exact " +
+                        $"build this binary was compiled against. Override with --bc-version.");
+                    break;
+                case "cdn-exact":
+                    Console.Error.WriteLine($"[bc] no --bc-version given — provisioning BC {engineVersion}, the exact " +
+                        $"build this binary was compiled against. Override with --bc-version.");
+                    break;
+                case "cached-minor":
+                    // Degraded but usually survivable: right minor, different build. The CodeAnalysis
+                    // assembly version can still differ between builds of one minor, which fails loud
+                    // at startup rather than silently — see BcArtifacts.DefaultVersionPrefix.
+                    Console.Error.WriteLine($"[bc] warning: no cached BC {engineVersion} — selecting the latest " +
+                        $"{engineMajorMinor}.x instead. Build-level skew within a minor can still fail to load " +
+                        $"Microsoft.Dynamics.Nav.CodeAnalysis. Fix with: al-runner provision --bc-version {engineVersion}");
+                    break;
+                case "cdn-minor":
+                    Console.Error.WriteLine($"[bc] no --bc-version given and BC {engineVersion} is not published on " +
+                        $"the CDN — provisioning the latest {engineMajorMinor}.x instead (still this binary's own " +
+                        $"engine minor). Build-level skew within a minor can still fail to load " +
+                        $"Microsoft.Dynamics.Nav.CodeAnalysis. Fix with: al-runner provision --bc-version {engineVersion}");
+                    break;
+                case "major-fallback-offline":
+                    // No network step is coming (--no-auto-provision, or the rare case where
+                    // engineVersion resolved but auto-provisioning is off) — this can only speak
+                    // to what's CACHED, never to CDN availability. Original pre-#2033 wording.
+                    Console.Error.WriteLine($"[bc] warning: no cached BC {engineMajorMinor}.x — this binary's engine " +
+                        $"was built for {engineVersion}, so a different minor is a KNOWN-DEGRADED configuration " +
+                        $"(measured: dozens of extra failures from engine/artifact minor skew). Falling back to the " +
+                        $"latest cached {engineMajor}.x. Fix with: al-runner provision --bc-version {engineMajorMinor}");
+                    break;
+                default: // major-fallback: neither the exact build nor the engine's own minor is
+                         // available from cache or the CDN — a genuine degradation (e.g. #2010,
+                         // Microsoft withdrew the build), not the default-path norm.
+                    Console.Error.WriteLine($"[bc] warning: BC {engineMajorMinor}.x is not cached and not available " +
+                        $"from the CDN — this binary's engine was built for {engineVersion}, so a different minor is " +
+                        $"a KNOWN-DEGRADED configuration (measured: dozens of extra failures from engine/artifact " +
+                        $"minor skew). Falling back to the latest {engineMajor}.x. Fix with: al-runner provision " +
+                        $"--bc-version {engineMajorMinor}");
+                    break;
+            }
+
+            var projMajor = TryDeriveBcMajorFromProject(bundles);
+            if (projMajor != null && projMajor != engineMajor.Value.ToString())
+                Console.Error.WriteLine($"[bc] warning: project app.json targets BC major {projMajor} but this " +
+                    $"runner build supports major {engineMajor} (cross-major needs a matching runner build).");
+        }
     }
 }
 // ── Provisioning (on by default since issue #2024; opt out with --no-auto-provision):
@@ -707,6 +755,55 @@ catch (InvalidOperationException ex)
     return 2;
 }
 
+// ── Per-BC-minor engine variant selection (#2024 item 3 / #2027). A packaged install
+// ships one thin engine variant per .github/bc-versions.txt entry under
+// variants/<full-build-version>/ (see EngineVariants) — this process's own compiled-in
+// engine is just ONE of them. A plain dev/test build (`dotnet build`/`dotnet run`) has no
+// variants/ directory at all, and this whole block is then a complete no-op: `variants`
+// comes back empty, `variantSwapDir` stays null, and every existing single-build code
+// path below behaves exactly as it always has.
+//
+// No match found among the shipped variants is a LOUD failure, never a silent fallback
+// to a nearby minor — that silent fallback is the root cause #2020 traced this whole
+// mechanism back to (see .claude/rules/loud-failures.md).
+string? variantSwapDir = null;
+{
+    var shippedVariants = AlRunner.Infrastructure.EngineVariants.Discover(AppContext.BaseDirectory);
+    if (shippedVariants.Count > 0)
+    {
+        var selected = AlRunner.Infrastructure.BcArtifacts.SelectedVersion;
+        var match = AlRunner.Infrastructure.EngineVariants.SelectBestMatch(shippedVariants, selected);
+        if (match == null)
+        {
+            Console.Error.WriteLine(
+                $"BC version selection failed: no shipped engine variant supports BC {selected} " +
+                $"(major {selected.Major}). Available variants: " +
+                $"{AlRunner.Infrastructure.EngineVariants.DescribeAvailable(shippedVariants)}. Select a " +
+                $"cached BC version this install ships an engine for (--bc-version), or update al-runner.");
+            return 2;
+        }
+
+        var (variant, degraded) = match.Value;
+        if (degraded)
+            Console.Error.WriteLine(
+                $"[bc] warning: the shipped {variant.BuildVersion.Major}.{variant.BuildVersion.Minor} engine " +
+                $"variant was built against {variant.BuildVersion}, not the selected {selected} — different " +
+                $"BUILDS of the same minor can still fail to load Microsoft.Dynamics.Nav.CodeAnalysis (it's " +
+                $"strong-named per build, not per minor). Expected: variants pin the newest build of a minor " +
+                $"AT PACK TIME, so any user on a different build of that same minor hits this. See " +
+                $"docs/limitations.md.");
+
+        var runningBuild = AlRunner.Infrastructure.BcArtifacts.EngineBuiltVersion();
+        if (runningBuild != variant.BuildVersion)
+        {
+            variantSwapDir = variant.Dir;
+            Console.Error.WriteLine(
+                $"[bc] selecting engine variant {variant.BuildVersion} for BC {selected} (this process is " +
+                $"currently running the {(runningBuild?.ToString() ?? "unknown")} variant) — re-execing.");
+        }
+    }
+}
+
 // Completeness gate: the selected version's dir exists, but is its engine closure whole?
 // A partial /service/ closure would otherwise fail deep in a FileLoadException at runtime
 // (the version-agnostic engine serves the BC-app closure from this dir). On a normal run
@@ -742,11 +839,17 @@ Console.WriteLine(serverMode
 // re-exec into a shadow runtime dir (see NclShadowRuntime) that legitimately has the
 // file on disk before ITS TPA is computed. A shadow child's own base directory
 // always has the real file, so this naturally does not re-fire there.
-if (AlRunner.Infrastructure.NclShadowRuntime.NeedsShadow(AppContext.BaseDirectory)
+// variantSwapDir != null (set above) ALSO routes through this same shadow-dir
+// mechanism: NclShadowRuntime.EnsureShadowDir's entrySourceDir parameter copies the
+// entry-assembly manifest set from the SELECTED VARIANT's own directory instead of this
+// process's, so one re-exec covers both "Ncl.dll isn't shipped" and "a different BC-minor
+// engine variant is needed" — see the doc comment on EnsureShadowDir.
+if ((AlRunner.Infrastructure.NclShadowRuntime.NeedsShadow(AppContext.BaseDirectory) || variantSwapDir != null)
     && Environment.GetEnvironmentVariable("AL_RUNNER_NCL_SHADOW_DONE") != "1")
 {
     var srcDirForShadow = AlRunner.Infrastructure.BcArtifacts.ServiceTierDir;
-    var shadowDll = AlRunner.Infrastructure.NclShadowRuntime.EnsureShadowDir(AppContext.BaseDirectory, srcDirForShadow);
+    var shadowDll = AlRunner.Infrastructure.NclShadowRuntime.EnsureShadowDir(
+        AppContext.BaseDirectory, srcDirForShadow, variantSwapDir);
     var dotnetMuxer = AlRunner.Infrastructure.NclShadowRuntime.FindDotnetMuxer();
 
     var psi = new System.Diagnostics.ProcessStartInfo(dotnetMuxer) { UseShellExecute = false };
@@ -759,7 +862,9 @@ if (AlRunner.Infrastructure.NclShadowRuntime.NeedsShadow(AppContext.BaseDirector
     foreach (var a in argv.Skip(1)) psi.ArgumentList.Add(a);
     psi.Environment["AL_RUNNER_NCL_SHADOW_DONE"] = "1";
 
-    Console.Error.WriteLine("[Cecil] Ncl.dll not shipped in this install — re-execing into a shadow runtime dir that has it");
+    Console.Error.WriteLine(variantSwapDir != null
+        ? "[Cecil] Re-execing into a shadow runtime dir with the matching BC-minor engine variant"
+        : "[Cecil] Ncl.dll not shipped in this install — re-execing into a shadow runtime dir that has it");
     AlRunner.Infrastructure.PhaseLog.MarkReexecParent();
     using var shadowChild = System.Diagnostics.Process.Start(psi)!;
     shadowChild.WaitForExit();

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -260,6 +260,37 @@ the exact value will see different results.
 
 ---
 
+## Per-BC-minor engine variants: granularity is per MINOR, not per exact build
+
+Every released `al-runner` binary used to be compiled against exactly one BC minor's
+reference assemblies (`Microsoft.Dynamics.Nav.CodeAnalysis` etc.), regardless of which
+`--bc-version` a user actually ran it against — running a mismatched minor could NRE
+deep inside BC's own code (#2020). The package now ships one thin engine variant per
+[`.github/bc-versions.txt`](../.github/bc-versions.txt) entry and swaps to the matching
+one automatically at startup (#2024 item 3, #2027) — a large improvement, but **not
+"any BC version works."**
+
+**`Microsoft.Dynamics.Nav.CodeAnalysis` is strong-named per BUILD, not per minor.**
+Two separate builds of the same BC minor ship different `CodeAnalysis` assembly
+versions (e.g. 28.1.49838.50794 → 17.0.36.40629 vs. 28.1.49838.53220 → 17.0.39.53543),
+and the runner's variant was compiled against whichever build was newest at PACK TIME.
+The strong-named reference does not tolerate that skew — a mismatched build fails loud
+at startup with `FileLoadException` before any test runs, not silently.
+
+So concretely: if the shipped `28.3` variant was built against build `28.3.52162.53954`
+and you have a *different* `28.3.x` build cached locally (a real scenario — Microsoft
+regularly ships more than one build per minor, and can withdraw one after the fact —
+see #2012), the runner prints a loud, explicit warning naming both versions and still
+attempts the run; it may or may not actually load, depending on how far that specific
+skew reaches. This is the one case per-minor variants don't close — only shipping a
+variant per exact 4-part build would, and that's a materially larger package for a
+combination that's uncommon in practice.
+
+Eight correctly-matched minors instead of one is the real, measured improvement here.
+Treat "shipped variant" and "exact user build" as related but distinct guarantees.
+
+---
+
 ## BC 26
 
 Not supported. The runner is tested against **BC 27.0 and up** — see


### PR DESCRIPTION
Closes #2027

Item 3 of #2024, root-caused by #2020: every released `al-runner` binary was compiled against one BC minor's reference assemblies, regardless of `--bc-version`. Running a mismatched minor could NRE deep inside BC's own code (`NavGlobal.get_SystemTenant()`). CI already builds a correctly-matched binary for every `.github/bc-versions.txt` entry, one per matrix leg, and discarded all of them — this ships that instead of a single fixed-minor build.

## Mechanism — reused, not invented

The original plan (see the #2027 comment trail) was a launcher/engine split loading the selected variant via an isolated `AssemblyLoadContext`. A canary of that shape found real, structural "I am `AssemblyLoadContext.Default`" assumptions cascading through the codebase — dependency resolution, `Ncl.dll` bootstrap, compiled-test-assembly loading, and an unresolved AL-compiler-integration issue. Per instruction, I stopped and reported rather than working around it further.

The shipped mechanism instead **reuses #2026's `NclShadowRuntime` re-exec** (already-merged, already-proven): build a shadow directory mirroring the install — entry assembly + manifests as real copies, everything else symlinked — and re-exec via the `dotnet` muxer so a fresh process gets a correct TPA. The extension: when a different variant is needed, the entry-assembly copy comes from that variant's own directory instead of the currently-running process's. The selected variant becomes the process's REAL entry assembly, loaded normally into `Default` — no second load context, so none of the ALC canary's problems apply. Canaried the same way before building the feature (see #2027):

1. **Real select-then-shadow-then-re-exec, driven by the actual running process** (not hand-assembled) — confirmed via `strace` (two real `execve` calls) and a byte-for-byte SHA-256 match between the shadow directory's `al-runner.dll` and the target variant's own build output.
2. **Reverse direction** (28.3-built process swapping DOWN to 28.1) — symmetric, same mechanism, same result.
3. **Genuinely cold BC artifact** — BC 28.4, resolved and downloaded fresh mid-session (never previously cached on this machine), full service-tier + platform-app provisioning, then a real cross-app dependency bundle (`tests/runner-extras/dep-tableext-platform-base-main`, cold compile, 4P/0F/0E).

## What's in this PR

- `AlRunner/Infrastructure/EngineVariants.cs` (new, BC-free): discovers `variants/<full-build-version>/` directories and picks the best match — exact build > same major.minor (degraded, warned — build-level `CodeAnalysis` skew) > **no match at all, a loud failure** naming the requested version and every available variant. Never a silent fallback to a nearby minor — that's #2020's root cause.
- `AlRunner/Infrastructure/NclShadowRuntime.cs`: `EnsureShadowDir` gained an optional `entrySourceDir` — when set, the entry-assembly manifest set comes from the selected variant's directory; the dependency closure is still symlinked from the current install (variants share the same commit/NuGet closure — only the BC `<Reference>` set differs, already resolved per-request from the artifact cache).
- `AlRunner/Program.cs`: **behavior change, called out explicitly in the code and here** — when this install ships variants and neither `--bc-version` nor `--artifact-path` is given, the default selection inverts from engine-first (prefer whichever minor this binary happens to be) to artifact-first (prefer the latest cached artifact, then swap to the matching variant). `TryDeriveBcMajorFromProject(bundles)` is still the cross-check either way. Installs with no `variants/` directory (any plain `dotnet build`/`dotnet run` dev checkout) are completely unaffected — every new code path degrades to today's unchanged behavior, verified via a direct before/after baseline run.
- `AlRunner/AlRunner.csproj`: packs `variants/<version>/` opt-in via `EngineVariantsStagingDir` (empty by default — a plain pack is unchanged).
- `.github/workflows/bc-tests.yml` + `publish.yml`: build one variant per `bc-versions.txt` entry and stage them before packing. Both consume a new `resolve-versions` output (`versions-json`) rather than each re-resolving live — the first attempt at this called `tools/DownloadArtifacts` directly in `publish.yml` and immediately failed `ReleaseTestParityTests`/#1976's "don't re-inline BC-matrix steps in a caller" guard; the fix routes through the shared workflow's already-tested version list instead.
- `docs/limitations.md`: documents the one gap this doesn't close plainly — `Microsoft.Dynamics.Nav.CodeAnalysis` is strong-named per BUILD, not per minor. A shipped "28.3" variant is the newest 28.3 build at pack time; a user on a *different* 28.3 build still hits the degraded-match warning and can still fail to load `CodeAnalysis`. **Eight minors instead of one, not "any BC version works."**

## #2020's scenario, now working

```
$ ./al-runner --bc-version 28.3 ...
[bc] selected BC 28.3.52162.53954 (…/artifacts/28.3.52162.53954)
[bc] selecting engine variant 28.3.52162.53954 for BC 28.3.52162.53954 (this process is currently running the 28.1.49838.53910 variant) — re-execing.
[Cecil] Re-execing into a shadow runtime dir with the matching BC-minor engine variant
… 1P/0F/0E …
```
No `NullReferenceException`, no engine/artifact minor mismatch — the correct variant loads and runs.

## No-match loud failure (requirement, not optional)

```
$ ./al-runner --bc-version 27.0 ...
BC version selection failed: no shipped engine variant supports BC 27.0.38460.53338 (major 27). Available variants: 28.1.49838.53910, 28.3.52162.53954, 28.4.53241.53955. Select a cached BC version this install ships an engine for (--bc-version), or update al-runner.
```
Exit code 2.

## Package size

All 8 `bc-versions.txt` variants built against real BC artifacts (one, BC 28.4, freshly downloaded mid-session — never previously cached): **17,343,573 bytes (~16.5 MiB)** against the 30 MiB `check-nupkg-contents.sh` ceiling — comfortably under, ~53% of budget.

## Split out per orchestrator direction

- `EngineLoadContext` (centralizing 8 hardcoded `AssemblyLoadContext.Default` call sites, found during the ALC canary) → its own PR, #2032 — unrelated to how variants actually load here, worth reviewing independently.
- `Assembly.Load(byte[])` always binding into `Default` regardless of caller (6 call sites, latent bug) → tracked separately, #2030 — not fixed here since it doesn't affect this shipped mechanism (everything stays in one ALC).

## Known overlap

Rebased onto `main` after #2029 (auto-provision-by-default, impl-16) merged — clean rebase, no conflicts, `Program.cs`'s startup-selection block sits adjacent to but doesn't overlap #2029's provisioning block.

One pre-existing, unrelated test failure noted during verification: `SourceDepSymbolsWithoutPackageCacheTests.SiblingSourceDep_CompilesWithZeroPackageCacheDirs` fails locally on a control branch containing only #2029 + a no-op commit (i.e. reproduces on `main` itself, not introduced by this PR) — flagged for visibility, not fixed here as out of scope.

## Test plan
- [x] `EngineVariantsTests.cs` (new): RED→GREEN verified (gutting `SelectBestMatch` fails the positive-match tests)
- [x] `NclShadowRuntimeTests.cs`: new `entrySource` coverage (positive: entry assembly + present manifest come from the swap target; negative: a manifest missing from the swap target falls back to the original install)
- [x] Manual end-to-end proof for all three canary gaps (above) against real BC artifacts, including one genuinely-fresh download
- [x] `AlRunner.Tests` full run: 863 passed / 2 failed / 56 skipped (921 total) — both failures diagnosed above (one fixed in this PR, one pre-existing/unrelated)
- [ ] CI (full matrix + pack job's new variant-count assertion)