### PR TITLE
fix(provision): default auto-provisioning to the engine's own build, not latest

### DIFF
--- a/AlRunner.Provisioning/ArtifactDownloader.cs
+++ b/AlRunner.Provisioning/ArtifactDownloader.cs
@@ -361,6 +361,31 @@ public static class ArtifactDownloader
     }
 
     // -----------------------------------------------------------------------
+    // Cheap existence probe for an EXACT 4-part version (issue #2033): a single HEAD
+    // request against the platform artifact, no download and no ZIP central-directory
+    // read. Used by BcArtifacts.DefaultProvisionTarget to check whether the engine's own
+    // exact build is fetchable before deciding to fall back to a looser tier (minor, then
+    // major). ResolveVersion below answers a different question (latest build matching a
+    // PREFIX); this answers "does this exact version exist at all".
+    // -----------------------------------------------------------------------
+    public static bool VersionExists(string version, Action<string>? log = null)
+    {
+        var logf = L(log);
+        var url = $"{CdnBase}/{version}/platform";
+        try
+        {
+            using var http = new HttpClient();
+            using var resp = http.Send(new HttpRequestMessage(HttpMethod.Head, url));
+            return resp.IsSuccessStatusCode;
+        }
+        catch (HttpRequestException ex)
+        {
+            logf($"[provision] could not probe BC {version} on the CDN: {ex.Message}");
+            return false;
+        }
+    }
+
+    // -----------------------------------------------------------------------
     // Resolve a BC version prefix (e.g. "28.2") to the latest full version via
     // Microsoft's public index. Returns null when nothing matches.
     // -----------------------------------------------------------------------

--- a/AlRunner.Tests/DefaultProvisionTargetMessagingTests.cs
+++ b/AlRunner.Tests/DefaultProvisionTargetMessagingTests.cs
@@ -1,0 +1,163 @@
+// DefaultProvisionTargetMessagingTests — proves Program.cs's version-selection message
+// text agrees with what actually happened, for issue #2033.
+//
+// #2033's core fix is BcArtifacts.ResolveProvisionTargetCore (see
+// DefaultProvisionTargetTests.cs) — auto-provisioning targets the engine's own build/minor
+// instead of collapsing to "latest in major" on an empty cache. But Program.cs's message
+// selection is a SEPARATE piece of logic (it picks which of five hand-written strings to
+// print based on which tier won), and it is not exercised by that pure-function test at
+// all — it lives inline in Main. The first draft of this fix had a real bug there, caught
+// only by spawning the actual binary end-to-end: the "major fallback" case originally
+// always said "... is not cached and not available from the CDN", but with
+// --no-auto-provision the CDN is never even asked — no network step exists on that path at
+// all. The message claimed a check that never happened.
+//
+// This test pins the two message variants against a real, hermetically empty artifact
+// cache: --no-auto-provision (offline; never consults the CDN, so the message must say
+// only "no cached", never "CDN") and the auto-provisioning default (does consult the CDN,
+// so a genuine double-miss message legitimately can).
+using System.Diagnostics;
+using System.Text;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class DefaultProvisionTargetMessagingTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+
+    private static (int ExitCode, string StdErr) RunIsolated(string isolatedHome, params string[] extraArgs)
+    {
+        var args = new StringBuilder(TestBuildConfig.RunArgs(Path.Combine(RepoRoot, "AlRunner")));
+        foreach (var a in extraArgs) args.Append(' ').Append(a);
+        args.Append($" \"{Path.Combine(RepoRoot, "tests", "runner-extras", "esm-xapp")}\"");
+
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            Arguments = args.ToString(),
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            WorkingDirectory = RepoRoot,
+        };
+        psi.Environment["HOME"] = isolatedHome;
+
+        var errSb = new StringBuilder();
+        using var proc = Process.Start(psi)!;
+        proc.OutputDataReceived += (_, e) => { };
+        proc.ErrorDataReceived += (_, e) => { if (e.Data != null) lock (errSb) errSb.AppendLine(e.Data); };
+        proc.BeginOutputReadLine();
+        proc.BeginErrorReadLine();
+        if (!proc.WaitForExit(60_000))
+        {
+            try { proc.Kill(entireProcessTree: true); } catch { }
+            throw new TimeoutException("al-runner did not exit within 60s against an isolated empty artifact cache.");
+        }
+        proc.WaitForExit();
+        lock (errSb) return (proc.ExitCode, errSb.ToString());
+    }
+
+    private static string NewIsolatedHome()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "al-runner-provision-target-msg", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    /// <summary>
+    /// The bug caught by the manual end-to-end verification: --no-auto-provision never
+    /// touches the network, so the major-fallback warning must describe only what's
+    /// CACHED, never claim the CDN was consulted (it wasn't).
+    /// </summary>
+    [SkippableFact]
+    public void NoAutoProvision_EmptyCache_MajorFallbackWarning_NeverClaimsCdnWasChecked()
+    {
+        TestArtifacts.SkipIf(AlRunner.Infrastructure.BcArtifacts.EngineBuiltVersion() == null,
+            "no baked-in BcEngineVersion on this build — nothing to assert a message about.");
+
+        var home = NewIsolatedHome();
+        try
+        {
+            var (exit, stderr) = RunIsolated(home, "--no-auto-provision");
+
+            Assert.Equal(2, exit);
+            // Must describe the LOCAL CACHE state truthfully...
+            Assert.Contains("[bc] warning: no cached BC", stderr);
+            Assert.Contains("KNOWN-DEGRADED", stderr);
+            // ...and must NEVER claim network was consulted when --no-auto-provision
+            // guarantees it wasn't.
+            Assert.DoesNotContain("CDN", stderr);
+        }
+        finally
+        {
+            try { Directory.Delete(home, recursive: true); } catch { }
+        }
+    }
+
+    /// <summary>
+    /// THE #2033 proving case, end-to-end against the real CDN: with auto-provisioning ON
+    /// (the default) and a genuinely empty cache, the runner must target the engine's OWN
+    /// exact build — the "[bc] ... provisioning BC &lt;exact build&gt;" message, never the
+    /// KNOWN-DEGRADED warning that the pre-fix "collapse to major, then let provisioning
+    /// fetch latest-in-major" behaviour produced on a first run (issue #2020's exact
+    /// symptom). Makes a genuine small network call — a version-index lookup plus a HEAD
+    /// probe — but is killed the instant the target message appears in stderr, BEFORE the
+    /// multi-hundred-MB service-tier download that follows it gets underway, so this stays
+    /// a fast, CI-safe test rather than a real provisioning run (that full run is proven
+    /// separately, manually, and recorded in the PR description).
+    /// </summary>
+    [SkippableFact]
+    public void AutoProvisionDefault_EmptyCache_TargetsEngineExactBuild_NeverDegradedWarning()
+    {
+        var engineVersion = AlRunner.Infrastructure.BcArtifacts.EngineBuiltVersion();
+        TestArtifacts.SkipIf(engineVersion == null,
+            "no baked-in BcEngineVersion on this build — nothing to assert a message about.");
+
+        var home = NewIsolatedHome();
+        var expected = $"[bc] no --bc-version given — provisioning BC {engineVersion}, the exact build " +
+            "this binary was compiled against.";
+        try
+        {
+            var args = new StringBuilder(TestBuildConfig.RunArgs(Path.Combine(RepoRoot, "AlRunner")));
+            args.Append($" \"{Path.Combine(RepoRoot, "tests", "runner-extras", "esm-xapp")}\"");
+            var psi = new ProcessStartInfo
+            {
+                FileName = "dotnet", Arguments = args.ToString(),
+                RedirectStandardOutput = true, RedirectStandardError = true,
+                UseShellExecute = false, CreateNoWindow = true, WorkingDirectory = RepoRoot,
+            };
+            psi.Environment["HOME"] = home;
+
+            var errSb = new StringBuilder();
+            var found = new ManualResetEventSlim(false);
+            using var proc = Process.Start(psi)!;
+            proc.OutputDataReceived += (_, e) => { };
+            proc.ErrorDataReceived += (_, e) =>
+            {
+                if (e.Data == null) return;
+                lock (errSb) errSb.AppendLine(e.Data);
+                if (e.Data.Contains(expected, StringComparison.Ordinal)) found.Set();
+            };
+            proc.BeginOutputReadLine();
+            proc.BeginErrorReadLine();
+
+            var signalled = found.Wait(30_000);
+            try { proc.Kill(entireProcessTree: true); } catch { }
+            proc.WaitForExit(5_000);
+
+            string captured;
+            lock (errSb) captured = errSb.ToString();
+
+            Assert.True(signalled,
+                $"expected line never appeared within 30s (CDN unreachable from this environment?):\n{captured}");
+            Assert.DoesNotContain("KNOWN-DEGRADED", captured);
+        }
+        finally
+        {
+            try { Directory.Delete(home, recursive: true); } catch { }
+        }
+    }
+}

--- a/AlRunner.Tests/DefaultProvisionTargetTests.cs
+++ b/AlRunner.Tests/DefaultProvisionTargetTests.cs
@@ -1,0 +1,152 @@
+// DefaultProvisionTargetTests — proves BcArtifacts.ResolveProvisionTargetCore, the fix for
+// issue #2033.
+//
+// Root cause: on the auto-provision default path (no --bc-version / --artifact-path),
+// Program.cs used to call BcArtifacts.DefaultVersionPrefix — which answers "what does the
+// LOCAL CACHE already have" — and handed that pre-collapsed value to provisioning. On a
+// genuinely empty cache DefaultVersionPrefix has nothing to look at for either the engine's
+// exact build or its minor, so it falls straight through to "major only" (e.g. "28") BEFORE
+// a single byte has been downloaded. Provisioning then resolved "latest full version for
+// major 28" from the CDN — landing on 28.4 while the shipped engine was built for 28.1,
+// putting a fresh install straight into the KNOWN-DEGRADED engine/artifact skew #2020
+// describes, silently, on the very first run.
+//
+// The fix: when auto-provisioning is going to run anyway, ask the SAME three tiers (exact
+// build, then minor, then major) whether they're available from EITHER the cache or the
+// CDN before giving up and falling looser — so provisioning fetches the version selection
+// actually wants. These tests exercise the pure core with fake cache/CDN state — no
+// network, no BC engine — proving each tier decision and, most importantly, that a cache
+// miss with a CDN hit does NOT collapse to the major (the exact defect from #2033).
+using AlRunner.Infrastructure;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class DefaultProvisionTargetTests : IDisposable
+{
+    private readonly string _root;
+
+    public DefaultProvisionTargetTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "al-runner-provision-target", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { }
+    }
+
+    private void MakeVersionDirs(params string[] versions)
+    {
+        foreach (var v in versions) Directory.CreateDirectory(Path.Combine(_root, v));
+    }
+
+    /// <summary>
+    /// THE #2033 proving case: a genuinely empty cache (nothing cached at all — the real
+    /// first-run shape) with the engine's own exact build actually published on the CDN
+    /// must select THAT build, not collapse to "major only" the way DefaultVersionPrefix
+    /// alone would. This is the exact scenario that landed a first run on BC 28.4 while
+    /// the engine was built for 28.1.
+    /// </summary>
+    [Fact]
+    public void EmptyCache_CdnHasEngineExactBuild_SelectsExactBuild_NotMajorFallback()
+    {
+        var engineVersion = new Version("28.1.49838.50794");
+
+        var result = BcArtifacts.ResolveProvisionTargetCore(
+            engineVersion, _root,
+            cdnHasExactVersion: v => v == "28.1.49838.50794",
+            cdnResolvePrefix: p => throw new InvalidOperationException(
+                $"must not fall through to prefix resolution when the exact build is on the CDN (asked for '{p}')"),
+            out var tier);
+
+        Assert.Equal("28.1.49838.50794", result);
+        Assert.Equal("cdn-exact", tier);
+
+        // Contrast with the cache-only function this replaces on the auto-provision path:
+        // it has nothing cached to look at, so it degrades to "28" — the defect #2033 fixes.
+        Assert.Equal("28", BcArtifacts.DefaultVersionPrefix(engineVersion, _root));
+    }
+
+    /// <summary>
+    /// The exact build was withdrawn / never published (issue #2010's scenario) but the
+    /// engine's own MINOR still has a build on the CDN — must fall back one tier, to that
+    /// resolved build, not all the way to the major.
+    /// </summary>
+    [Fact]
+    public void EmptyCache_CdnLacksExactBuild_ButHasEngineMinor_ResolvesToLatestOfThatMinor()
+    {
+        var engineVersion = new Version("28.1.49838.50794");
+
+        var result = BcArtifacts.ResolveProvisionTargetCore(
+            engineVersion, _root,
+            cdnHasExactVersion: v => false, // withdrawn build, e.g. #2010
+            cdnResolvePrefix: p => p == "28.1" ? "28.1.55555.66666" : null,
+            out var tier);
+
+        Assert.Equal("28.1.55555.66666", result);
+        Assert.Equal("cdn-minor", tier);
+    }
+
+    /// <summary>
+    /// Genuinely degraded: neither the exact build nor the engine's own minor exists
+    /// anywhere (cache or CDN). Only NOW may this fall back to the bare major — and the
+    /// caller (Program.cs) must print the KNOWN-DEGRADED warning for this tier specifically.
+    /// </summary>
+    [Fact]
+    public void EmptyCache_CdnHasNeitherExactNorMinor_FallsBackToMajor()
+    {
+        var engineVersion = new Version("28.1.49838.50794");
+
+        var result = BcArtifacts.ResolveProvisionTargetCore(
+            engineVersion, _root,
+            cdnHasExactVersion: v => false,
+            cdnResolvePrefix: p => null,
+            out var tier);
+
+        Assert.Equal("28", result);
+        Assert.Equal("major-fallback", tier);
+    }
+
+    /// <summary>
+    /// A cached exact build wins outright — no CDN probe needed or performed. Proves the
+    /// fast path stays fast and offline-safe when nothing needs fetching.
+    /// </summary>
+    [Fact]
+    public void CachedExactBuild_WinsWithoutConsultingTheCdnAtAll()
+    {
+        var engineVersion = new Version("28.1.49838.50794");
+        MakeVersionDirs("28.1.49838.50794", "28.2.50931.52786");
+
+        var result = BcArtifacts.ResolveProvisionTargetCore(
+            engineVersion, _root,
+            cdnHasExactVersion: v => throw new InvalidOperationException("must not probe the CDN when already cached"),
+            cdnResolvePrefix: p => throw new InvalidOperationException("must not probe the CDN when already cached"),
+            out var tier);
+
+        Assert.Equal("28.1.49838.50794", result);
+        Assert.Equal("cached-exact", tier);
+    }
+
+    /// <summary>
+    /// The engine's minor is cached (but not its exact build) — must win over a CDN probe
+    /// for the exact build being unavailable, without ever falling to major.
+    /// </summary>
+    [Fact]
+    public void CachedMinor_WinsOverMajorFallback_WhenExactBuildNotCachedOrOnCdn()
+    {
+        var engineVersion = new Version("28.1.49838.50794");
+        MakeVersionDirs("28.1.60000.60000"); // same minor, different (higher) build
+
+        var result = BcArtifacts.ResolveProvisionTargetCore(
+            engineVersion, _root,
+            cdnHasExactVersion: v => false,
+            cdnResolvePrefix: p => throw new InvalidOperationException(
+                "must not resolve via CDN when the engine's own minor is already cached"),
+            out var tier);
+
+        Assert.Equal("28.1", result);
+        Assert.Equal("cached-minor", tier);
+    }
+}

--- a/AlRunner/Infrastructure/BcArtifacts.cs
+++ b/AlRunner/Infrastructure/BcArtifacts.cs
@@ -356,6 +356,83 @@ public static class BcArtifacts
         }
     }
 
+    /// <summary>
+    /// Pure core of <see cref="DefaultProvisionTarget"/>, network-injectable for testing
+    /// (see AlRunner.Tests.DefaultProvisionTargetTests) — same shape as
+    /// <see cref="DescribeExplicitEngineMinorMismatch"/>/<see cref="WarnIfExplicitEngineMinorMismatch"/>:
+    /// a provable pure function plus a thin real-network wrapper.
+    ///
+    /// Issue #2033: <see cref="DefaultVersionPrefix"/> answers "what does the LOCAL CACHE
+    /// already have" — the right question when there is no provisioning step coming (offline
+    /// / --no-auto-provision), but the wrong one when auto-provisioning is about to run
+    /// anyway. On a genuinely empty cache it collapses straight to "major only" before a
+    /// single byte has been fetched, and the caller then asked provisioning for "the newest
+    /// build of major 28" instead of "BC 28.1, the engine's own minor" — landing on 28.4 while
+    /// the engine was built for 28.1. This variant tries the SAME three tiers (exact build,
+    /// then minor, then major) but at each tier also asks whether the CDN can fetch it before
+    /// giving up and falling looser, so auto-provisioning downloads what version selection
+    /// actually wants instead of "whatever happens to already be cached."
+    /// </summary>
+    /// <param name="tier">
+    /// Which tier won: "cached-exact"/"cached-minor" (already local, nothing to fetch,
+    /// identical to <see cref="DefaultVersionPrefix"/>'s outcome), "cdn-exact"/"cdn-minor"
+    /// (not cached but the CDN has it — provisioning will fetch exactly this), or
+    /// "major-fallback" (neither the engine's exact build nor its minor is available from
+    /// either source — genuinely degraded; the caller must warn, per issue #2020).
+    /// </param>
+    public static string ResolveProvisionTargetCore(Version engineVersion, string artifactsRoot,
+        Func<string, bool> cdnHasExactVersion, Func<string, string?> cdnResolvePrefix, out string tier)
+    {
+        // Tier 1: the exact 4-part build — cached, or fetchable from the CDN.
+        var exact = engineVersion.ToString();
+        try
+        {
+            SelectArtifactVersionDir(artifactsRoot, exact);
+            tier = "cached-exact";
+            return exact;
+        }
+        catch (InvalidOperationException) { /* not cached — try the CDN, then fall through */ }
+        if (cdnHasExactVersion(exact))
+        {
+            tier = "cdn-exact";
+            return exact;
+        }
+
+        // Tier 2: the engine's own minor — cached, or resolvable to a full build via the CDN.
+        var majorMinor = $"{engineVersion.Major}.{engineVersion.Minor}";
+        try
+        {
+            SelectArtifactVersionDir(artifactsRoot, majorMinor);
+            tier = "cached-minor";
+            return majorMinor;
+        }
+        catch (InvalidOperationException) { /* not cached — try the CDN, then fall through */ }
+        var minorResolved = cdnResolvePrefix(majorMinor);
+        if (minorResolved != null)
+        {
+            tier = "cdn-minor";
+            return minorResolved;
+        }
+
+        // Tier 3: neither the exact build nor the engine's own minor is available from
+        // either source (e.g. Microsoft withdrew the build — #2010). Fall back to the bare
+        // major; the caller resolves+downloads the latest build of it and must warn loud —
+        // this is the one genuinely degraded outcome, not the default-path norm.
+        tier = "major-fallback";
+        return engineVersion.Major.ToString();
+    }
+
+    /// <summary>
+    /// Real-network wrapper around <see cref="ResolveProvisionTargetCore"/> — the one
+    /// Program.cs calls on the auto-provision default path (issue #2033).
+    /// </summary>
+    public static string DefaultProvisionTarget(Version engineVersion, string artifactsRoot, out string tier,
+        Action<string>? log = null)
+        => ResolveProvisionTargetCore(engineVersion, artifactsRoot,
+            v => AlRunner.Provisioning.ArtifactDownloader.VersionExists(v, log),
+            p => AlRunner.Provisioning.ArtifactDownloader.ResolveVersion(p, log),
+            out tier);
+
     public static void VerifyEngineConsistency(string binDir)
     {
         var ncl = Path.Combine(binDir, "Microsoft.Dynamics.Nav.Ncl.dll");

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -584,25 +584,73 @@ if (bcVersionArg == null && artifactPathArg == null)
         // Prefer the engine's OWN major.minor. Latest-in-major used to win here, which
         // silently selected a minor the engine was not built for — measured at -45 passing
         // / +42 failing / +3 errors on Pageworks. See BcArtifacts.DefaultVersionPrefix.
-        bcVersionArg = AlRunner.Infrastructure.BcArtifacts.DefaultVersionPrefix(
-            engineVersion, AlRunner.Infrastructure.BcArtifacts.ArtifactsRootDir);
+        //
+        // Issue #2033: when auto-provisioning is about to run anyway (the default since
+        // #2024/#2028), ask what it can FETCH — cache, then the CDN, at each tier — not
+        // just what's already cached. Otherwise a genuinely empty cache collapses this
+        // straight to "major only" before a single byte is downloaded, and provisioning
+        // then fetches "latest in major" (e.g. 28.4) while the engine was built for 28.1,
+        // landing a first run in the exact KNOWN-DEGRADED skew #2020 describes. Without
+        // --auto-provision there is no network step coming, so stay cache-only exactly as
+        // before — that path has nothing to gain from probing a CDN it will never use.
+        string tier;
+        if (provisionSubcommand || autoProvision)
+            bcVersionArg = AlRunner.Infrastructure.BcArtifacts.DefaultProvisionTarget(
+                engineVersion, AlRunner.Infrastructure.BcArtifacts.ArtifactsRootDir, out tier);
+        else
+        {
+            bcVersionArg = AlRunner.Infrastructure.BcArtifacts.DefaultVersionPrefix(
+                engineVersion, AlRunner.Infrastructure.BcArtifacts.ArtifactsRootDir);
+            var engineMinorPfx = $"{engineVersion.Major}.{engineVersion.Minor}";
+            tier = bcVersionArg == engineVersion.ToString() ? "cached-exact"
+                : bcVersionArg == engineMinorPfx ? "cached-minor"
+                : "major-fallback-offline"; // distinct from "major-fallback": no CDN was consulted
+        }
 
         var engineMajorMinor = $"{engineVersion.Major}.{engineVersion.Minor}";
-        if (bcVersionArg == engineVersion.ToString())
-            Console.Error.WriteLine($"[bc] no --bc-version given — selecting BC {engineVersion}, the exact " +
-                $"build this binary was compiled against. Override with --bc-version.");
-        else if (bcVersionArg == engineMajorMinor)
-            // Degraded but usually survivable: right minor, different build. The CodeAnalysis
-            // assembly version can still differ between builds of one minor, which fails loud
-            // at startup rather than silently — see BcArtifacts.DefaultVersionPrefix.
-            Console.Error.WriteLine($"[bc] warning: no cached BC {engineVersion} — selecting the latest " +
-                $"{engineMajorMinor}.x instead. Build-level skew within a minor can still fail to load " +
-                $"Microsoft.Dynamics.Nav.CodeAnalysis. Fix with: al-runner provision --bc-version {engineVersion}");
-        else
-            Console.Error.WriteLine($"[bc] warning: no cached BC {engineMajorMinor}.x — this binary's engine was " +
-                $"built for {engineVersion}, so a different minor is a KNOWN-DEGRADED configuration " +
-                $"(measured: dozens of extra failures from engine/artifact minor skew). Falling back to the " +
-                $"latest cached {engineMajor}.x. Fix with: al-runner provision --bc-version {engineMajorMinor}");
+        switch (tier)
+        {
+            case "cached-exact":
+                Console.Error.WriteLine($"[bc] no --bc-version given — selecting BC {engineVersion}, the exact " +
+                    $"build this binary was compiled against. Override with --bc-version.");
+                break;
+            case "cdn-exact":
+                Console.Error.WriteLine($"[bc] no --bc-version given — provisioning BC {engineVersion}, the exact " +
+                    $"build this binary was compiled against. Override with --bc-version.");
+                break;
+            case "cached-minor":
+                // Degraded but usually survivable: right minor, different build. The CodeAnalysis
+                // assembly version can still differ between builds of one minor, which fails loud
+                // at startup rather than silently — see BcArtifacts.DefaultVersionPrefix.
+                Console.Error.WriteLine($"[bc] warning: no cached BC {engineVersion} — selecting the latest " +
+                    $"{engineMajorMinor}.x instead. Build-level skew within a minor can still fail to load " +
+                    $"Microsoft.Dynamics.Nav.CodeAnalysis. Fix with: al-runner provision --bc-version {engineVersion}");
+                break;
+            case "cdn-minor":
+                Console.Error.WriteLine($"[bc] no --bc-version given and BC {engineVersion} is not published on " +
+                    $"the CDN — provisioning the latest {engineMajorMinor}.x instead (still this binary's own " +
+                    $"engine minor). Build-level skew within a minor can still fail to load " +
+                    $"Microsoft.Dynamics.Nav.CodeAnalysis. Fix with: al-runner provision --bc-version {engineVersion}");
+                break;
+            case "major-fallback-offline":
+                // No network step is coming (--no-auto-provision, or the rare case where
+                // engineVersion resolved but auto-provisioning is off) — this can only speak
+                // to what's CACHED, never to CDN availability. Original pre-#2033 wording.
+                Console.Error.WriteLine($"[bc] warning: no cached BC {engineMajorMinor}.x — this binary's engine " +
+                    $"was built for {engineVersion}, so a different minor is a KNOWN-DEGRADED configuration " +
+                    $"(measured: dozens of extra failures from engine/artifact minor skew). Falling back to the " +
+                    $"latest cached {engineMajor}.x. Fix with: al-runner provision --bc-version {engineMajorMinor}");
+                break;
+            default: // major-fallback: neither the exact build nor the engine's own minor is
+                     // available from cache or the CDN — a genuine degradation (e.g. #2010,
+                     // Microsoft withdrew the build), not the default-path norm.
+                Console.Error.WriteLine($"[bc] warning: BC {engineMajorMinor}.x is not cached and not available " +
+                    $"from the CDN — this binary's engine was built for {engineVersion}, so a different minor is " +
+                    $"a KNOWN-DEGRADED configuration (measured: dozens of extra failures from engine/artifact " +
+                    $"minor skew). Falling back to the latest {engineMajor}.x. Fix with: al-runner provision " +
+                    $"--bc-version {engineMajorMinor}");
+                break;
+        }
 
         var projMajor = TryDeriveBcMajorFromProject(bundles);
         if (projMajor != null && projMajor != engineMajor.Value.ToString())


### PR DESCRIPTION
Closes #2033

References #2024, #2020, #2010.

## The bug

Version *selection* is engine-first (`Program.cs`'s `DefaultVersionPrefix(EngineBuiltVersion(), ...)`), but auto-provisioning (on by default since #2024/#2028) wasn't consistent with it. On a genuinely empty cache, `Program.cs` pre-collapsed the auto-select default to a bare BC major (`DefaultVersionPrefix` checks only the LOCAL CACHE, and an empty cache has nothing at any tier) *before* handing that value to provisioning. Provisioning then resolved "latest full version for that major" from the CDN — landing a first run on BC 28.4 while the shipped engine was built for 28.1: the exact KNOWN-DEGRADED engine/artifact minor skew #2020 describes, silently, by default.

## The fix

`BcArtifacts.ResolveProvisionTargetCore` / `DefaultProvisionTarget` tries the same three tiers `DefaultVersionPrefix` always used — exact build, then minor, then major — but at each tier also asks the CDN (not just the local cache) before falling looser. `Program.cs` only takes this path when auto-provisioning is actually about to run (`provision` subcommand / `--auto-provision` default); `--no-auto-provision` keeps the original cache-only tiering unchanged, since there's no network step coming on that path — nothing to gain from a CDN probe it will never use.

`--bc-version <X>` is untouched: still provisions and selects exactly `X`, and the existing engine/artifact minor-mismatch warning (#2008/#2018) still fires for it unchanged.

A message-wording bug caught only by the manual end-to-end verification (not by the unit tests) is also fixed here: the major-fallback warning must never claim the CDN was consulted on the offline (`--no-auto-provision`) path, since it wasn't — see `DefaultProvisionTargetMessagingTests.NoAutoProvision_EmptyCache_MajorFallbackWarning_NeverClaimsCdnWasChecked`.

## `TryDeriveBcMajorFromProject` — investigated, not changed

Currently used in exactly two places, neither of which drives what gets auto-provisioned in the normal case:
1. A cross-check-only warning printed *after* version selection (`project app.json targets BC major X but this runner build supports major Y`).
2. A last-resort fallback inside `RunProvisioning`, reachable only when the engine version itself can't be determined at all (no `Ncl.dll` present) — essentially dead in practice, since a built binary always ships it.

I did not change this. Recommendation (not applied): letting a project's own declared BC major influence the default target has the trade-off the issue names — a user targeting a newer BC would get it without `--bc-version`, but a user on an older/default project would get whatever that project targets rather than the engine's own tested build, which is a bigger behavior change than this issue asks for. I'd treat it as a separate, deliberate decision rather than folding it into this fix.

## Verification (end-to-end, not just unit tests)

1. Packed current branch (`dotnet pack AlRunner/ -p:_BCVersion=28.1.49838.53953 ...`, mirroring `pack`/`publish.yml`), installed into an isolated `--tool-path`.
2. Verified a genuinely empty isolated `$HOME`: no `~/.local/share/al-runner/artifacts`, no `~/.cache/al-runner`, no `~/.bcartifacts.cache`.
3. Ran a real bundle (`tests/runner-extras/esm-xapp`) with **no flags**: provisioned and selected BC `28.1.49838.53953` — this build's exact engine version — no `KNOWN-DEGRADED` warning anywhere in the output, test passed (1P/0F/0E).
4. Repeated with `--bc-version 28.3`: provisioned and selected `28.3.52162.53954`, the existing `KNOWN-DEGRADED` mismatch warning fired exactly as before, test still passed.
5. Spot-checked `provision` subcommand (same engine-first target, `28.1.49838.53953`) and `--no-auto-provision` on an empty cache (fails loud, exit 2, no network attempted, correct "no cached" wording with no CDN mention).

## Overlap with #2027 (impl-17, PR #2035) — flagging, not resolving

PR #2035 restructures this exact same `Program.cs` auto-select block, wrapping it in an `if (shippedVariantsForDefault.Count > 0) { <new latest-cached-artifact default> } else { <original engine-first logic, byte-identical to what's on main today> }`. My change lives entirely inside what becomes the `else` branch there. Today `main` is unmodified (`deeb7f05`) so there's no git conflict for me to resolve, but whichever of these two PRs merges second will need to fold this fix into the restructured `else` branch rather than the top-level block. Not resolving this myself per instructions — flagging for the orchestrator to sequence.