### PR TITLE
fix: gate degraded-minor warning on shipped variants; surface re-exec explanations

### DIFF
--- a/AlRunner.Tests/ExplicitEngineMinorWarningGatingTests.cs
+++ b/AlRunner.Tests/ExplicitEngineMinorWarningGatingTests.cs
@@ -1,0 +1,103 @@
+// ExplicitEngineMinorWarningGatingTests — issue #2037.
+//
+// #2008's DescribeExplicitEngineMinorMismatch/WarnIfExplicitEngineMinorMismatch (see
+// EngineMinorMismatchWarningTests.cs) fire whenever this binary's OWN compiled-in engine
+// minor differs from the explicitly-selected BC version. That was correct for the
+// single-build install it was written for — there was only ever one engine, so a
+// mismatched minor really was degraded.
+//
+// #2027 shipped per-BC-minor engine variants (variants/<build>/, see EngineVariants):
+// a packaged install now carries several engines and swaps to whichever one matches the
+// SELECTED version at startup. Program.cs called WarnIfExplicitEngineMinorMismatch
+// BEFORE that variant swap ran (line 748, swap at 771-801), comparing THIS PROCESS's
+// own compiled-in minor — which is irrelevant once a matching variant is about to be
+// swapped in. Reported live against the published 2.5.0 package: `--bc-version
+// 27.5.46862.53931` printed the KNOWN-DEGRADED warning and then immediately selected
+// the correct 27.5 variant and ran clean.
+//
+// This file pins the decision of WHETHER to call the warning at all, gated on how many
+// engine variants this install ships (EngineVariants.Discover(...).Count) — the same
+// input Program.cs's variant-selection block already inspects. Once ANY variant is
+// shipped, either one matches the selection (the warning's claim becomes false — this
+// process is about to swap into the right engine) or none does (the variant-selection
+// block itself exits with a sharper, version-naming error before a warning would even
+// help) — so the old generic warning has nothing correct left to say. It is only still
+// true for a single-build install with no variants/ directory at all, which is the case
+// #2008 was filed against and MUST stay reachable.
+using AlRunner.Infrastructure;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class ExplicitEngineMinorWarningGatingTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+
+    /// <summary>
+    /// Structural guard on Program.cs's own source: the call site that decides whether
+    /// to print WarnIfExplicitEngineMinorMismatch must route through
+    /// ShouldWarnExplicitEngineMinorMismatch (which also inspects the shipped-variant
+    /// count), not merely `!bcVersionAutoSelected`. A behavioural test on the pure
+    /// function alone (the four cases above) would pass equally well whether Program.cs
+    /// actually calls it or still gates on the old, narrower condition — reading the
+    /// source is the only way to prove the call site itself was fixed, not just that a
+    /// correct function exists unused beside it.
+    /// </summary>
+    [Fact]
+    public void ProgramCs_GatesTheWarnCall_OnShouldWarnExplicitEngineMinorMismatch()
+    {
+        var programSource = File.ReadAllText(Path.Combine(RepoRoot, "AlRunner", "Program.cs"));
+        var callIdx = programSource.IndexOf("WarnIfExplicitEngineMinorMismatch();", StringComparison.Ordinal);
+        Assert.True(callIdx >= 0, "WarnIfExplicitEngineMinorMismatch() call not found in Program.cs");
+
+        // The `if` guarding the call must be within a short lookbehind window and must
+        // name ShouldWarnExplicitEngineMinorMismatch, not just bcVersionAutoSelected alone.
+        var windowStart = Math.Max(0, callIdx - 400);
+        var window = programSource[windowStart..callIdx];
+        Assert.Contains("ShouldWarnExplicitEngineMinorMismatch", window);
+    }
+
+    /// <summary>Negative — the exact #2037 reproduction: an explicit --bc-version
+    /// (bcVersionAutoSelected=false) with at least one shipped engine variant. The
+    /// warning must NOT fire; the variant-selection block downstream is the sole
+    /// authority once any variant is shipped.</summary>
+    [Fact]
+    public void ShippedVariantsPresent_ExplicitSelection_DoesNotWarn()
+    {
+        Assert.False(BcArtifacts.ShouldWarnExplicitEngineMinorMismatch(
+            bcVersionAutoSelected: false, shippedVariantCount: 1));
+    }
+
+    /// <summary>Same negative, several variants shipped (the real packaged-install
+    /// shape — one per bc-versions.txt entry) — count above 1 must not change the
+    /// answer.</summary>
+    [Fact]
+    public void MultipleShippedVariants_ExplicitSelection_DoesNotWarn()
+    {
+        Assert.False(BcArtifacts.ShouldWarnExplicitEngineMinorMismatch(
+            bcVersionAutoSelected: false, shippedVariantCount: 3));
+    }
+
+    /// <summary>Positive — the case the warning was written for (#2008): a single-build
+    /// install with NO variants/ directory at all (EngineVariants.Discover returns
+    /// empty), explicit --bc-version/--artifact-path. Must stay loud.</summary>
+    [Fact]
+    public void NoShippedVariants_ExplicitSelection_StillWarns()
+    {
+        Assert.True(BcArtifacts.ShouldWarnExplicitEngineMinorMismatch(
+            bcVersionAutoSelected: false, shippedVariantCount: 0));
+    }
+
+    /// <summary>Negative control: the auto-select default path already prints its own,
+    /// richer equivalent warning in Program.cs — this must never double-warn regardless
+    /// of variant count.</summary>
+    [Fact]
+    public void AutoSelected_NeverWarns_RegardlessOfVariantCount()
+    {
+        Assert.False(BcArtifacts.ShouldWarnExplicitEngineMinorMismatch(
+            bcVersionAutoSelected: true, shippedVariantCount: 0));
+        Assert.False(BcArtifacts.ShouldWarnExplicitEngineMinorMismatch(
+            bcVersionAutoSelected: true, shippedVariantCount: 2));
+    }
+}

--- a/AlRunner.Tests/LogUserFacingTagsTests.cs
+++ b/AlRunner.Tests/LogUserFacingTagsTests.cs
@@ -55,6 +55,11 @@ public sealed class LogUserFacingTagsTests
     [InlineData("[layered] building")]   // already exempt; pinned so it stays that way
     [InlineData("[provision] downloading")]
     [InlineData("[watch] waiting")]
+    // #2034: NclShadowRuntime's re-exec explanation was tagged [Cecil] (suppressed by
+    // default, same class of bug as the [bc] swallow above) so a process silently
+    // launching a child had no explanation at default verbosity. re-exec explanations
+    // now use their own exempted tag.
+    [InlineData("[reexec] Ncl.dll not shipped in this install — re-execing into a shadow runtime dir that has it")]
     public void UserFacingTags_SurviveTheDefaultFilter(string line)
     {
         Assert.Contains(line, FilterOnce(line, verbose: false));

--- a/AlRunner.Tests/PhaseLogIntegrationTests.cs
+++ b/AlRunner.Tests/PhaseLogIntegrationTests.cs
@@ -149,10 +149,11 @@ public sealed class PhaseLogIntegrationTests : IDisposable
 
         // Verbose so the re-exec markers are observable. AlRunner/Log.cs installs a
         // FilteredWriter that drops `[Component]`-tagged lines at default verbosity;
-        // `[r2r] re-execing` is printed BEFORE Log.Install() and survives, but
-        // `[Cecil] Fresh rewrite done` is printed after it and does not. Without this,
-        // the marker-derived expected-parent count silently under-counts on a cold
-        // Cecil cache and the test is a coin flip on cache state.
+        // `[r2r] re-execing` is printed BEFORE Log.Install() and survives, and the
+        // re-exec explanations below (#2034: retagged `[reexec]`, exempted like `[bc]`)
+        // now also survive at default verbosity on their own — but this stays verbose
+        // regardless so the marker-derived expected-parent count never depends on which
+        // tags happen to be exempted today.
         psi.Environment["AL_RUNNER_VERBOSE"] = "1";
 
         var sb = new StringBuilder();
@@ -307,12 +308,12 @@ public sealed class PhaseLogIntegrationTests : IDisposable
         // there rather than passing quietly here.
         var expectedParents =
             CountOccurrences(output, "[r2r] re-execing")
-            + CountOccurrences(output, "[Cecil] Fresh rewrite done")
+            + CountOccurrences(output, "[reexec] Fresh rewrite done")
             // The tool package no longer ships Microsoft.Dynamics.Nav.Ncl.dll (see
             // check-nupkg-contents.sh) — NclShadowRuntime re-execs into a shadow runtime
             // dir that legitimately has it, UNCONDITIONALLY (every cold AND warm spawn,
             // not just a fresh-rewrite cache MISS), so this fires on every test run here.
-            + CountOccurrences(output, "[Cecil] Ncl.dll not shipped in this install");
+            + CountOccurrences(output, "[reexec] Ncl.dll not shipped in this install");
         var parents = ReadRecords(_logPath, "process-reexec-parent");
         Assert.Equal(expectedParents, parents.Count);
         Assert.All(parents, parent =>

--- a/AlRunner.Tests/ReexecExplanationVisibilityTests.cs
+++ b/AlRunner.Tests/ReexecExplanationVisibilityTests.cs
@@ -1,0 +1,86 @@
+// ReexecExplanationVisibilityTests — issue #2034.
+//
+// PR #2026 added NclShadowRuntime: when Ncl.dll is not shipped in the install (the
+// packaged-tool default since #2023/#2026), the runner builds a shadow runtime
+// directory that has it and re-execs into it. The explanatory line for that ("[Cecil]
+// Ncl.dll not shipped in this install — re-execing into a shadow runtime dir that has
+// it") was tagged `[Cecil]`, which Log's component filter suppresses by default (see
+// LogUserFacingTagsTests' negative control pinning `[Cecil] rewriting NavDialog` as
+// suppressed) — the exact same class of bug the `[bc]` swallow was (see Log.cs's own
+// comment on that history). Confirmed on a real clean install: the shadow dir was
+// built, the re-exec fired, and the explanatory line never reached stderr.
+//
+// The fix retags the process-relaunch explanations with `[reexec]`, an exempted tag
+// (see LogUserFacingTagsTests), leaving the ~280 other `[Cecil]`-tagged lines in
+// NclCecilRewrite.cs (per-method IL-rewrite diagnostics) suppressed exactly as Log.cs's
+// own docstring says they should be — `[Cecil]` is its canonical example of an internal
+// diagnostic tag.
+//
+// This file is the structural half: LogUserFacingTagsTests proves the FILTER exempts
+// `[reexec]`; this file proves the actual re-exec call sites in Program.cs and
+// NclShadowRuntime.cs were retagged to use it, not merely that a correctly-exempted tag
+// exists unused. A test that only spawned the runner and grepped stdout/stderr for a
+// hardcoded fixed BC version would be far slower (real artifact provisioning) and no
+// more conclusive than reading the source directly — see FindBucketRootDedupeTests.cs
+// and TddModeTests.ComputeAlCacheKey_HashesTheTddFlag for the same technique already
+// established in this suite.
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class ReexecExplanationVisibilityTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+
+    /// <summary>Acceptance #1 (source half): the Ncl-shadow / variant-swap re-exec
+    /// explanation in Program.cs — the exact line named in the issue — must be tagged
+    /// `[reexec]`, not `[Cecil]`.</summary>
+    [Fact]
+    public void ProgramCs_NclShadowReexecExplanation_UsesReexecTag()
+    {
+        var src = File.ReadAllText(Path.Combine(RepoRoot, "AlRunner", "Program.cs"));
+        Assert.Contains(
+            "[reexec] Ncl.dll not shipped in this install — re-execing into a shadow runtime dir that has it",
+            src);
+        Assert.Contains(
+            "[reexec] Re-execing into a shadow runtime dir with the matching BC-minor engine variant",
+            src);
+        Assert.DoesNotContain(
+            "[Cecil] Ncl.dll not shipped in this install", src);
+    }
+
+    /// <summary>Acceptance #3 (audit): the OTHER re-exec explanation in Program.cs — the
+    /// "fresh Cecil rewrite done, re-execing for a clean Ncl load" line — is the same
+    /// class of silently-swallowed line and must also surface.</summary>
+    [Fact]
+    public void ProgramCs_FreshRewriteReexecExplanation_UsesReexecTag()
+    {
+        var src = File.ReadAllText(Path.Combine(RepoRoot, "AlRunner", "Program.cs"));
+        Assert.Contains("[reexec] Fresh rewrite done — re-execing for a clean Ncl load", src);
+    }
+
+    /// <summary>Acceptance #3 (audit): NclShadowRuntime's own WARN lines (symlink
+    /// fallback, stale-shadow-dir prune failure) report genuinely unexpected conditions
+    /// during the shadow-dir build, not routine per-method rewrite noise — they were
+    /// swallowed by the same `[Cecil]` filter and must also surface.</summary>
+    [Fact]
+    public void NclShadowRuntime_WarnLines_UseReexecTag()
+    {
+        var src = File.ReadAllText(Path.Combine(RepoRoot, "AlRunner", "Infrastructure", "NclShadowRuntime.cs"));
+        Assert.Contains("[reexec] Symlink for", src);
+        Assert.Contains("[reexec] WARN: failed to prune stale shadow dir", src);
+    }
+
+    /// <summary>Negative control: the routine, high-volume per-method IL-rewrite
+    /// diagnostics in NclCecilRewrite.cs must stay on `[Cecil]` (suppressed by default)
+    /// — this issue is about the re-exec explanation specifically, not a licence to
+    /// surface every internal Cecil diagnostic.</summary>
+    [Fact]
+    public void NclCecilRewrite_RoutineDiagnostics_StillUseCecilTag()
+    {
+        var src = File.ReadAllText(Path.Combine(RepoRoot, "AlRunner", "Infrastructure", "NclCecilRewrite.cs"));
+        Assert.Contains("[Cecil] Rewriting", src);
+        Assert.DoesNotContain("[reexec]", src);
+    }
+}

--- a/AlRunner/Infrastructure/BcArtifacts.cs
+++ b/AlRunner/Infrastructure/BcArtifacts.cs
@@ -496,4 +496,26 @@ public static class BcArtifacts
         var msg = DescribeExplicitEngineMinorMismatch(EngineBuiltVersion(), SelectedVersion);
         if (msg != null) Console.Error.WriteLine(msg);
     }
+
+    /// <summary>
+    /// Issue #2037: whether Program.cs should even CALL <see cref="WarnIfExplicitEngineMinorMismatch"/>
+    /// at all, given how many per-BC-minor engine variants this install ships (see
+    /// <see cref="EngineVariants.Discover"/>, called just before the variant-swap block in
+    /// Program.cs — the same input, so no rediscovery is needed at the call site).
+    ///
+    /// The warning compares THIS PROCESS's own compiled-in engine minor against the
+    /// selected version — a comparison that stopped being meaningful the moment a packaged
+    /// install started shipping more than one engine (#2027 / #2035): once <em>any</em>
+    /// variant is shipped, the variant-selection block downstream is the sole authority —
+    /// either a matching variant is found (this process is about to swap into the right
+    /// engine, making the warning's claim false, as reported live against the published
+    /// 2.5.0 package with `--bc-version 27.5.46862.53931`) or none matches (that block itself
+    /// exits with a sharper, version-naming error before a generic warning would even help).
+    /// So the warning has nothing correct left to say once <paramref name="shippedVariantCount"/>
+    /// is nonzero. It is only still true for a single-build install with no variants/
+    /// directory at all (shippedVariantCount == 0) — the case #2008 was filed against, which
+    /// must stay reachable.
+    /// </summary>
+    public static bool ShouldWarnExplicitEngineMinorMismatch(bool bcVersionAutoSelected, int shippedVariantCount)
+        => !bcVersionAutoSelected && shippedVariantCount == 0;
 }

--- a/AlRunner/Infrastructure/NclShadowRuntime.cs
+++ b/AlRunner/Infrastructure/NclShadowRuntime.cs
@@ -294,7 +294,10 @@ public static class NclShadowRuntime
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or PlatformNotSupportedException)
         {
-            Console.Error.WriteLine($"[Cecil] Symlink for '{Path.GetFileName(source)}' refused ({ex.GetType().Name}) — falling back to a real copy");
+            // #2034 audit: a genuine unexpected condition during the shadow-dir build
+            // (not routine per-method Cecil-rewrite noise), so it uses the `[reexec]`
+            // tag — same reasoning as Program.cs's re-exec explanation lines.
+            Console.Error.WriteLine($"[reexec] Symlink for '{Path.GetFileName(source)}' refused ({ex.GetType().Name}) — falling back to a real copy");
         }
 
         if (isDirectory) CopyDirectoryRecursive(source, target);
@@ -332,9 +335,11 @@ public static class NclShadowRuntime
 
         foreach (var dir in stale)
         {
+            // #2034 audit: same reasoning as the symlink-fallback WARN above — a real
+            // failure during shadow-dir upkeep, not routine Cecil-rewrite diagnostics.
             try { Directory.Delete(dir, recursive: true); }
-            catch (IOException ex) { Console.Error.WriteLine($"[Cecil] WARN: failed to prune stale shadow dir {dir}: {ex.Message}"); }
-            catch (UnauthorizedAccessException ex) { Console.Error.WriteLine($"[Cecil] WARN: failed to prune stale shadow dir {dir}: {ex.Message}"); }
+            catch (IOException ex) { Console.Error.WriteLine($"[reexec] WARN: failed to prune stale shadow dir {dir}: {ex.Message}"); }
+            catch (UnauthorizedAccessException ex) { Console.Error.WriteLine($"[reexec] WARN: failed to prune stale shadow dir {dir}: {ex.Message}"); }
         }
     }
 

--- a/AlRunner/Log.cs
+++ b/AlRunner/Log.cs
@@ -31,8 +31,17 @@ public static class Log
     // eaten by this exact filter — the very issue those notices exist to fix. Whether
     // out-of-scope/known-gap/divergence classification applied to a run is a RESULT
     // (it changes pass/fail counts), not a diagnostic.
+    //
+    // `[reexec]` was added for #2034: NclShadowRuntime's re-exec explanation lines were
+    // tagged `[Cecil]` — the SAME class of bug as the `[bc]` swallow above — so a process
+    // silently relaunching a child had no explanation on stderr at default verbosity.
+    // These lines (why a second process is about to run, plus the genuinely unexpected
+    // conditions hit while building the shadow dir) are operationally significant in the
+    // same way BC-version selection is; the ~280 other `[Cecil]`-tagged per-method
+    // rewrite diagnostics in NclCecilRewrite.cs are NOT retagged and stay suppressed —
+    // that volume of internal detail is exactly what this filter exists to hide.
     private static readonly Regex ComponentTag =
-        new(@"^\[(?!(?:layered|watch|provision|bc|dep|expectations)\])[A-Za-z][A-Za-z0-9._+]*\]",
+        new(@"^\[(?!(?:layered|watch|provision|bc|dep|expectations|reexec)\])[A-Za-z][A-Za-z0-9._+]*\]",
             RegexOptions.Compiled);
 
     public static void Install()

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -731,6 +731,10 @@ if (provisionSubcommand || autoProvision)
     // On failure with --auto-provision we fall through; SelectVersion below emits the
     // loud, path-naming error (and the detailed ProvisioningCheck report if partial).
 }
+// #2037: discovered here, OUTSIDE and BEFORE the try block below, so both the warn-gate
+// (inside the try) and the variant-swap block (after it) share one discovery — see the
+// comments at each use site.
+var shippedVariants = AlRunner.Infrastructure.EngineVariants.Discover(AppContext.BaseDirectory);
 try
 {
     AlRunner.Infrastructure.BcArtifacts.SelectVersion(bcVersionArg, artifactPathArg);
@@ -744,7 +748,13 @@ try
     // different-minor selection). The auto-select default path above already warns about
     // minor skew; an EXPLICIT --bc-version/--artifact-path bypassed that warning entirely
     // and ran a mismatched engine silently. Only warn here for the explicit path.
-    if (!bcVersionAutoSelected)
+    //
+    // #2037: also only warn when this install ships NO per-BC-minor engine variants at
+    // all (see ShouldWarnExplicitEngineMinorMismatch) — once any variant is shipped, the
+    // variant-swap block below is the sole authority on whether the selection is
+    // degraded, not this generic same-process-engine comparison.
+    if (AlRunner.Infrastructure.BcArtifacts.ShouldWarnExplicitEngineMinorMismatch(
+            bcVersionAutoSelected, shippedVariants.Count))
         AlRunner.Infrastructure.BcArtifacts.WarnIfExplicitEngineMinorMismatch();
     Console.Error.WriteLine($"[bc] selected BC {AlRunner.Infrastructure.BcArtifacts.SelectedVersion} " +
         $"({AlRunner.Infrastructure.BcArtifacts.ServiceTierDir})");
@@ -766,9 +776,11 @@ catch (InvalidOperationException ex)
 // No match found among the shipped variants is a LOUD failure, never a silent fallback
 // to a nearby minor — that silent fallback is the root cause #2020 traced this whole
 // mechanism back to (see .claude/rules/loud-failures.md).
+//
+// `shippedVariants` was already discovered above (see #2037 comment on the warn gate) —
+// reused here rather than re-walking the variants/ directory a second time.
 string? variantSwapDir = null;
 {
-    var shippedVariants = AlRunner.Infrastructure.EngineVariants.Discover(AppContext.BaseDirectory);
     if (shippedVariants.Count > 0)
     {
         var selected = AlRunner.Infrastructure.BcArtifacts.SelectedVersion;
@@ -863,8 +875,13 @@ if ((AlRunner.Infrastructure.NclShadowRuntime.NeedsShadow(AppContext.BaseDirecto
     psi.Environment["AL_RUNNER_NCL_SHADOW_DONE"] = "1";
 
     Console.Error.WriteLine(variantSwapDir != null
-        ? "[Cecil] Re-execing into a shadow runtime dir with the matching BC-minor engine variant"
-        : "[Cecil] Ncl.dll not shipped in this install — re-execing into a shadow runtime dir that has it");
+        // #2034: this line explains why a second process is about to launch — a
+        // genuinely operational fact, not an internal Cecil-rewrite diagnostic — so it
+        // uses the exempted `[reexec]` tag rather than `[Cecil]`. Under `[Cecil]`, Log's
+        // filter suppressed a real, live re-exec silently: the shadow dir was built, the
+        // child launched, and nothing on stderr said why.
+        ? "[reexec] Re-execing into a shadow runtime dir with the matching BC-minor engine variant"
+        : "[reexec] Ncl.dll not shipped in this install — re-execing into a shadow runtime dir that has it");
     AlRunner.Infrastructure.PhaseLog.MarkReexecParent();
     using var shadowChild = System.Diagnostics.Process.Start(psi)!;
     shadowChild.WaitForExit();
@@ -903,7 +920,10 @@ if ((AlRunner.Infrastructure.NclShadowRuntime.NeedsShadow(AppContext.BaseDirecto
         foreach (var a in userArgs)
             psi.ArgumentList.Add(a);
         psi.Environment["AL_RUNNER_REEXECED"] = "1";
-        Console.Error.WriteLine("[Cecil] Fresh rewrite done — re-execing for a clean Ncl load");
+        // #2034 audit: this is the SAME class of silently-swallowed re-exec explanation
+        // (a fresh Cecil IL rewrite forces one more relaunch so the child loads the
+        // now-cached bytes cleanly) — also retagged so it survives the default filter.
+        Console.Error.WriteLine("[reexec] Fresh rewrite done — re-execing for a clean Ncl load");
         // This process waits for the child below, so its wall clock CONTAINS the
         // child's entire run. Re-label the row so aggregates that sum `kind=="process"`
         // do not double-count it.


### PR DESCRIPTION
Closes #2037
Closes #2034

## #2037 — false degraded-minor warning

`WarnIfExplicitEngineMinorMismatch` (Program.cs:748, old) compared THIS PROCESS's own
compiled-in engine minor against an explicitly-selected `--bc-version`, and fired
**before** the per-BC-minor engine variant swap (#2027/#2035) got a chance to decide
whether a matching variant would actually be used. On a packaged install that ships
variants, that meant the warning printed a false KNOWN-DEGRADED message — citing #2008
and suggesting fixes that don't apply ("drop --bc-version", "rebuild from source") —
right before the process cleanly swapped into the correct engine and ran the suite
without issue. Reproduced live against the published 2.5.0 package with
`--bc-version 27.5.46862.53931`.

Fix: discover `EngineVariants.Discover(...)` once, before the warn call, and gate the
call on `BcArtifacts.ShouldWarnExplicitEngineMinorMismatch(bcVersionAutoSelected,
shippedVariants.Count)`. Once any variant is shipped, the variant-swap block downstream
is the sole authority — either a match is found (the warning's claim becomes false) or
none is (that block exits with a sharper, version-naming error of its own). The warning
stays reachable for the single-build install it was written for (#2008): no `variants/`
directory at all, `shippedVariants.Count == 0`.

`EngineMinorMismatchWarningTests.cs` (the pure `DescribeExplicitEngineMinorMismatch`
tests) is untouched and stays green, per the issue's own requirement — this fix only
changes whether the call site invokes it, not the message itself.

## #2034 — NclShadowRuntime re-execs silently

Confirmed the suspected cause before touching anything: `AlRunner/Log.cs`'s component
filter suppresses any `[Tag]`-prefixed line by default unless `--verbose`/
`AL_RUNNER_VERBOSE=1`, and `[Cecil]` was never added to the exempt list (`layered`,
`watch`, `provision`, `bc`, `dep`, `expectations`) — the exact same class of bug as the
historical `[bc]` swallow the file's own comment documents (42-test silent swing,
2026-07-29). `NclShadowRuntime`'s re-exec explanation and Program.cs's
"fresh-rewrite-done" re-exec explanation were both tagged `[Cecil]`, so a process
silently relaunching a child printed nothing explaining why.

Fix: a new exempted tag, `[reexec]`, applied only to the lines that explain *why a
process is about to relaunch* — the two Program.cs re-exec messages, plus the genuinely
unexpected-condition WARN lines in `NclShadowRuntime.cs` (symlink-fallback, stale-dir
prune failure). The ~280 other `[Cecil]`-tagged lines in `NclCecilRewrite.cs` (per-method
IL-rewrite diagnostics) are untouched and stay suppressed by default — `Log.cs`'s own
docstring uses `[Cecil]` as the canonical example of what this filter exists to hide, and
that volume of internal detail should stay hidden.

## Tests (RED → GREEN)

- `AlRunner.Tests/ExplicitEngineMinorWarningGatingTests.cs` (new) — pins
  `ShouldWarnExplicitEngineMinorMismatch`'s four cases (explicit selection + shipped
  variants → no warn; explicit selection + no variants → still warns; auto-selected →
  never warns regardless of variant count) plus a structural guard proving Program.cs's
  actual call site routes through it, not just `!bcVersionAutoSelected`.
- `AlRunner.Tests/ReexecExplanationVisibilityTests.cs` (new) — structural guard proving
  the actual re-exec lines in `Program.cs`/`NclShadowRuntime.cs` use `[reexec]`, and a
  negative control pinning that `NclCecilRewrite.cs`'s routine diagnostics still use
  `[Cecil]`.
- `AlRunner.Tests/LogUserFacingTagsTests.cs` — added a `[reexec]` case to the existing
  "survives the default filter" theory.
- `AlRunner.Tests/PhaseLogIntegrationTests.cs` — updated its re-exec marker-counting
  strings from `[Cecil] ...` to `[reexec] ...` to match the retag (this test always runs
  its subprocess with `AL_RUNNER_VERBOSE=1`, so it was never blocked by the filter
  itself — only the literal marker text it searches for needed to follow the rename).

All four RED before the fix (compile error for the new function; the marker-count test
failing 0-vs-1 after the retag until updated). All GREEN after.

## Manual end-to-end verification

Built a synthetic `variants/27.5.46862.53931/` next to a source build and ran
`--bc-version 27.5.46862.53931` against a real cached BC artifact:

```
[bc] selected BC 27.5.46862.53931 (...)
[bc] selecting engine variant 27.5.46862.53931 for BC 27.5.46862.53931 (...) — re-execing.
al-runner — running 1 bundle(s)
[reexec] Re-execing into a shadow runtime dir with the matching BC-minor engine variant
...
[reexec] Fresh rewrite done — re-execing for a clean Ncl load
```

No `KNOWN-DEGRADED` warning at any point (confirms #2037), and both `[reexec]` lines are
visible at default verbosity with no `--verbose` flag (confirms #2034).

## Test run

`dotnet test AlRunner.Tests` (targeted: all tests in the touched files, 41/41 pass) and a
full `AlRunner.Tests` run (938 relevant tests: 940 total minus the 2 caught below).
One pre-existing, unrelated failure —
`SourceDepSymbolsWithoutPackageCacheTests.SiblingSourceDep_CompilesWithZeroPackageCacheDirs`
— reproduces identically on the unmodified `origin/main` baseline (verified by stashing
this diff and re-running just that test), so it is not introduced by this change and is
left untouched per `no-assumption-fixes.md`.