### PR TITLE
feat(server): implement --capture-values on execute via NavMethodScope.Exit()

### DIFF
--- a/AlRunner.Tests/ServerTests.cs
+++ b/AlRunner.Tests/ServerTests.cs
@@ -184,18 +184,71 @@ public class ServerTests : IClassFixture<SharedCliServer>
         Assert.Contains("executed-onrun-boom", tests[0].GetProperty("message").GetString());
     }
 
-    // #1917: 'captureValues' still needs the Cecil instrumentation pass tracked
-    // on #1640 — that half of v1 parity stays a loud, structured error.
+    // #1640 (second slice; --coverage was the first, #1922): 'captureValues:true' on
+    // `execute` reflects the AL locals of the top-level OnRun scope, as of the LAST
+    // statement that ran, via BC's own StmtHit instrumentation (AlValueCapture) — no
+    // Cecil pass over AL output, no dependency on #1642. Asserts EXACT values (42,
+    // "after") so this fails if the implementation were gutted to always report empty
+    // or default values.
     [SkippableFact]
-    public async Task Execute_CaptureValues_NotSupported_ReturnsError()
+    public async Task Execute_CaptureValues_True_ReportsFinalLocalsOfTopLevelScope()
     {
         TestArtifacts.SkipIfMissing();
         var server = await _fixture.GetAsync();
-        var r = await server.SendAsync(
-            "{\"command\":\"execute\",\"code\":\"Message('hi');\",\"captureValues\":true}");
+        var r = await server.SendAsync(JsonSerializer.Serialize(new
+        {
+            command = "execute",
+            captureValues = true,
+            code = "codeunit 60171 \"CV Capture SX\" { trigger OnRun() var Counter: Integer; " +
+                   "Msg: Text; begin Counter := 41; Msg := 'before'; Counter := 42; " +
+                   "Msg := 'after'; end; }"
+        }));
         var d = JsonSerializer.Deserialize<JsonElement>(r);
-        Assert.True(d.TryGetProperty("error", out var err));
-        Assert.Contains("captureValues", err.GetString());
+        Assert.False(d.TryGetProperty("error", out _), $"unexpected error response: {r}");
+        Assert.Equal(0, d.GetProperty("exitCode").GetInt32());
+        var tests = d.GetProperty("tests");
+        Assert.Equal(1, tests.GetArrayLength());
+        Assert.Equal("pass", tests[0].GetProperty("status").GetString());
+
+        Assert.True(tests[0].TryGetProperty("capturedValues", out var captured),
+            $"expected capturedValues on the response: {r}");
+        var byName = captured.EnumerateArray()
+            .ToDictionary(e => e.GetProperty("variableName").GetString()!, e => e);
+        Assert.True(byName.ContainsKey("Counter"), $"no Counter entry: {r}");
+        Assert.True(byName.ContainsKey("Msg"), $"no Msg entry: {r}");
+        // Final values, not the intermediate 41/"before" — proves the snapshot is
+        // taken continuously (overwritten every statement) rather than once at the
+        // first hit or some other stale point.
+        Assert.Equal(42, byName["Counter"].GetProperty("value").GetInt32());
+        Assert.Equal("after", byName["Msg"].GetProperty("value").GetString());
+        Assert.Equal("OnRun", byName["Counter"].GetProperty("scopeName").GetString());
+        // statementId indexes the LAST statement of the OnRun trigger (4 statements,
+        // 0-based) — the exact index [SourceSpans] backs, not just "some int".
+        Assert.Equal(3, byName["Counter"].GetProperty("statementId").GetInt32());
+    }
+
+    // Negative direction: the SAME codeunit shape, but captureValues omitted (false by
+    // default). capturedValues must be ABSENT — not an empty array, not present with
+    // stale/default data — proving the flag actually gates the feature rather than it
+    // being always-on (which the positive test alone could not distinguish).
+    [SkippableFact]
+    public async Task Execute_CaptureValues_Omitted_NoCapturedValuesField()
+    {
+        TestArtifacts.SkipIfMissing();
+        var server = await _fixture.GetAsync();
+        var r = await server.SendAsync(JsonSerializer.Serialize(new
+        {
+            command = "execute",
+            code = "codeunit 60172 \"CV NoCapture SX\" { trigger OnRun() var Counter: Integer; " +
+                   "begin Counter := 42; end; }"
+        }));
+        var d = JsonSerializer.Deserialize<JsonElement>(r);
+        Assert.False(d.TryGetProperty("error", out _), $"unexpected error response: {r}");
+        var tests = d.GetProperty("tests");
+        Assert.Equal(1, tests.GetArrayLength());
+        Assert.Equal("pass", tests[0].GetProperty("status").GetString());
+        Assert.False(tests[0].TryGetProperty("capturedValues", out _),
+            $"capturedValues must be absent when captureValues wasn't requested: {r}");
     }
 
     // #1917: inline `code` that is a bare statement list (no leading `codeunit`/

--- a/AlRunner/Infrastructure/AlValueCapture.cs
+++ b/AlRunner/Infrastructure/AlValueCapture.cs
@@ -1,0 +1,145 @@
+// AlValueCapture — the runtime side of --capture-values (issue #1640, second slice of
+// the #1640 umbrella; --coverage was the first, #1922). Snapshots the AL locals of the
+// TOP-LEVEL AL call (the codeunit trigger the runner invokes directly — server `execute`'s
+// OnRun today) at the moment the scope is about to be disposed, via a Cecil-rewrite hook on
+// Microsoft.Dynamics.Nav.Ncl.dll's NavMethodScope.Exit() — see NclCecilRewrite's Exit block.
+//
+// The prior "blocked on a mechanism for reading AL locals" framing (see #1640's original
+// text) does not hold: BC's own AL compiler lifts every AL local to a PUBLIC instance
+// field on the generated `*_Scope` class, tagged `[NavName("<AL name>")]` — confirmed by
+// decompiling an emitted test DLL (DUMP_CS=1) and cross-checked against a live probe
+// fixture during this issue's investigation. Reading those fields via reflection needs no
+// new instrumentation and no pass over AL output.
+//
+// WHY Exit(), NOT StmtHit(int) — the design actually shipped here, after a wrong first
+// attempt:
+//
+// BC's generated code calls StmtHit(N) BEFORE statement N's own side effect runs (decompile
+// evidence: `StmtHit(3); this.msg = new NavText("after");`). A "snapshot on every StmtHit,
+// keep the latest" design (the coverage hook's shape) is therefore always ONE STATEMENT
+// STALE: at the LAST hit, the previous statement's effect is visible but the CURRENT
+// statement's is not — a probe fixture caught this directly (asserted "after", the
+// StmtHit-based prototype reported "before"). There is no StmtHit call after the final
+// statement to correct for it.
+//
+// NavMethodScope.Run() (decompiled) is:
+//   try { OnRun(); } catch (...) { ... } finally { Exit(); }
+// and Exit() is:
+//   internal void Exit() { statementNumber = int.MaxValue; ...; Dispose(); }
+// So Exit() fires EXACTLY ONCE per scope, unconditionally (success or AL error — see
+// Run()'s finally), strictly AFTER every statement in OnRun() — including its side
+// effects — has completed, and STRICTLY BEFORE Dispose() (confirmed by decompile: Dispose()
+// does not touch AL-declared fields, only Tree/session bookkeeping, so nothing is torn down
+// before our hook runs). Prepending the capture call before Exit()'s own
+// `statementNumber = int.MaxValue` line means AlCapturedValue.StatementId is the real last-
+// executed statement index, not the ExitStatementNumber sentinel.
+//
+// "The scope is disposed when the AL method returns" (per the issue's own #1640 comment) is
+// exactly why the capture must happen INSIDE Exit(), before Dispose() — by the time our C#
+// caller's Invoke() returns, the scope object has already run through Dispose().
+using System.Reflection;
+using Microsoft.Dynamics.Nav.Runtime;
+
+namespace AlRunner.Infrastructure;
+
+/// <summary>One AL local's value, captured the instant its top-level scope's method body
+/// finished (NavMethodScope.Exit(), before Dispose()). <c>StatementId</c> indexes the SAME
+/// [SourceSpans] array AlCoverageTracker/AlCallStackCapture already decode, so a caller
+/// that also wants the AL source line can resolve it via AlSourceSpanCodec.</summary>
+public readonly record struct AlCapturedValue(string ScopeName, string VariableName, object? Value, int StatementId);
+
+public static class AlValueCapture
+{
+    /// <summary>True only while a --capture-values run is executing. Gates OnExit; the
+    /// Cecil-rewritten Exit() call is unconditional, this flag is not — same pattern as
+    /// AlCoverageTracker.Enabled.</summary>
+    public static volatile bool Enabled;
+
+    // Single process-global slot, NOT per-scope: only the OUTERMOST AL call (IsTopLevelCall)
+    // is captured (see the file header), and the runner invokes exactly one such call at a
+    // time — RunFirstCodeunitOnRun's OnRun invocations run strictly sequentially, matching
+    // the same single-slot assumption AlCallStackCapture already makes for the AL call stack.
+    private static volatile List<AlCapturedValue>? _snapshot;
+
+    /// <summary>Reset before each top-level AL invocation whose locals should be captured.</summary>
+    public static void Reset() => _snapshot = null;
+
+    /// <summary>The most recent snapshot, or an empty list if nothing was captured yet
+    /// (--capture-values on but the top-level scope has no AL locals, or Exit() never
+    /// fired — e.g. a compile/setup failure before any AL code ran). Never null so callers
+    /// don't need a null-check.</summary>
+    public static IReadOnlyList<AlCapturedValue> Collect() =>
+        _snapshot ?? (IReadOnlyList<AlCapturedValue>)Array.Empty<AlCapturedValue>();
+
+    private static Type? _tNavNameAttr;
+    private static PropertyInfo? _piNavNameName;
+    private static bool _reflInit;
+
+    private static void EnsureReflInit()
+    {
+        if (_reflInit) return;
+        // NavNameAttribute lives alongside NavMethodScope in Ncl.dll.
+        var nclAsm = typeof(NavMethodScope).Assembly;
+        _tNavNameAttr = nclAsm.GetType("Microsoft.Dynamics.Nav.Runtime.NavNameAttribute")
+            ?? throw new InvalidOperationException(
+                "[capture-values] Microsoft.Dynamics.Nav.Runtime.NavNameAttribute not found in Ncl.dll — BC changed shape, do not ship silently");
+        _piNavNameName = _tNavNameAttr.GetProperty("Name", BindingFlags.Public | BindingFlags.Instance)
+            ?? throw new InvalidOperationException(
+                "[capture-values] NavNameAttribute.Name not found — BC changed shape, do not ship silently");
+        _reflInit = true;
+    }
+
+    /// <summary>
+    /// Hook target for the Cecil-rewritten NavMethodScope.Exit() — public static, exactly
+    /// (NavMethodScope), prepended before Exit()'s own body (see the file header for why
+    /// that ordering matters). Must stay side-effect-free beyond the snapshot: it runs once
+    /// per AL method invocation, capture-values or not.
+    /// </summary>
+    public static void OnExit(NavMethodScope scope)
+    {
+        if (!Enabled) return;
+        // Only the test's own locals — not those of any procedure it calls, which get
+        // their own (deeper) scope instances and their own Exit() traffic. IsTopLevelCall
+        // (StackDepth == 2, decompiled and confirmed) is true exactly for the scope invoked
+        // directly by the runner, i.e. server `execute`'s OnRun today.
+        if (!scope.IsTopLevelCall) return;
+
+        EnsureReflInit();
+        var scopeName = scope.ScopeName ?? "?";
+        // Read BEFORE Exit()'s own body runs, so this is the real last-executed statement
+        // index, not the int.MaxValue sentinel Exit() is about to write.
+        var statementId = scope.StatementNumber;
+        var values = new List<AlCapturedValue>();
+        foreach (var f in scope.GetType().GetFields(BindingFlags.Public | BindingFlags.Instance))
+        {
+            if (Attribute.GetCustomAttribute(f, _tNavNameAttr!) is not object navNameAttr) continue;
+            var name = _piNavNameName!.GetValue(navNameAttr) as string ?? f.Name;
+            object? raw;
+            try { raw = f.GetValue(scope); }
+            catch { continue; } // a field that can't be read is skipped, never faked
+            values.Add(new AlCapturedValue(scopeName, name, ToWireValue(raw), statementId));
+        }
+        _snapshot = values;
+    }
+
+    // JSON-serializable representation of a captured field's runtime value. CLR
+    // primitives (AL Integer/Boolean/BigInteger/... map straight to these — confirmed via
+    // DUMP_CS=1 on a probe fixture) pass through as-is so System.Text.Json emits a real
+    // JSON number/bool/string. Everything else is a BC value-type wrapper (NavText,
+    // NavCode, NavDate, Decimal18, NavOption, record handles, ...) — those are precompiled
+    // BC types we must not reimplement (.claude/rules/precompiled-dll-respect.md), so we
+    // take their own ToString() rather than guessing a bespoke encoding per type.
+    private static object? ToWireValue(object? raw)
+    {
+        if (raw == null) return null;
+        switch (raw)
+        {
+            case bool or byte or sbyte or short or ushort or int or uint or long or ulong
+                 or float or double or decimal or string:
+                return raw;
+            default:
+                try { return raw.ToString(); }
+                catch { return null; } // ToString() itself must never crash a capture
+        }
+    }
+}

--- a/AlRunner/Infrastructure/NclCecilRewrite.cs
+++ b/AlRunner/Infrastructure/NclCecilRewrite.cs
@@ -6618,6 +6618,47 @@ public static class NclCecilRewrite
         }
 
         // ─────────────────────────────────────────────────────────────────────
+        // NavMethodScope.Exit() — --capture-values hook (issue #1640, second slice;
+        // --coverage above was the first, #1922).
+        //
+        // NOT a StmtHit hook, despite the coverage block right above being the obvious
+        // template — see AlValueCapture.cs's file header for why a StmtHit-based "keep
+        // overwriting the latest hit" design is provably one statement stale (BC calls
+        // StmtHit(N) BEFORE statement N's own side effect, so the LAST hit never sees the
+        // LAST statement's result). Exit() is decompiled as:
+        //   internal void Exit() { statementNumber = int.MaxValue; ...; Dispose(); }
+        // called from Run()'s `finally` — i.e. exactly once per scope, unconditionally
+        // (success or AL error), strictly AFTER every OnRun() statement has completed and
+        // strictly BEFORE Dispose() (confirmed by decompile: Dispose() only touches
+        // Tree/session bookkeeping, never AL-declared fields). Prepending BEFORE Exit()'s
+        // own first instruction means AlValueCapture.OnExit sees both the true final field
+        // values AND the real last-executed statementNumber (not yet stomped to
+        // int.MaxValue).
+        {
+            var nclMod = asm.MainModule;
+            const string MsType = "Microsoft.Dynamics.Nav.Runtime.NavMethodScope";
+            var hookMi = typeof(AlRunner.Infrastructure.AlValueCapture).GetMethod(
+                nameof(AlRunner.Infrastructure.AlValueCapture.OnExit), BindingFlags.Public | BindingFlags.Static)
+                ?? throw new InvalidOperationException(
+                    "[Cecil] AlValueCapture.OnExit not found — runner-side rename?");
+            var hookRef = nclMod.ImportReference(hookMi);
+
+            var target = FindNclMethod(nclMod, MsType, "Exit", 0);
+            if (target.ReturnType.FullName != "System.Void")
+                throw new InvalidOperationException(
+                    $"[Cecil] NavMethodScope.Exit()'s return type is {target.ReturnType.FullName}, "
+                    + "expected void — Ncl shape changed; do not commit");
+
+            var body = target.Body;
+            var il = body.GetILProcessor();
+            var first = body.Instructions[0];
+            il.InsertBefore(first, il.Create(OpCodes.Ldarg_0));
+            il.InsertBefore(first, il.Create(OpCodes.Call, hookRef));
+            if (body.MaxStackSize < 1) body.MaxStackSize = 1;
+            Console.Error.WriteLine("[Cecil] Prepended AlValueCapture.OnExit to NavMethodScope.Exit()");
+        }
+
+        // ─────────────────────────────────────────────────────────────────────
         // ALFunctionTimingExecutionListener cluster — JmpHook→Cecil (Batch 2).
         //
         // Telemetry/diagnostic-only listener reached during AL method execution via

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -3151,15 +3151,11 @@ int RunServerLoop(System.IO.TextReader input, System.IO.TextWriter output)
     // SynthesizeInlineCodeBundle) and run through the SAME compile pipeline a
     // sourcePaths-based execute already uses (RunAllBundlesForServer →
     // RunBundleForServer → RunFirstCodeunitOnRun), rather than inventing a
-    // second execution path. `captureValues` stays out of scope — it needs the
-    // Cecil instrumentation pass tracked on #1640 — so that case still fails
-    // LOUD (never a silent fake) per .claude/rules/loud-failures.md.
+    // second execution path. `captureValues` (#1640, second slice — --coverage
+    // was the first, #1922) gates AlValueCapture.Enabled for the duration of
+    // this call; RunFirstCodeunitOnRun resets+collects it per bundle.
     string HandleServerExecute(AlRunner.ServerRequest req)
     {
-        if (req.CaptureValues == true)
-            return AlRunner.ServerProtocol.Error(
-                "execute: 'captureValues' is not yet supported in v2. See docs/server-mode.md.");
-
         string? scratchDir = null;
         string[] sourcePaths;
         if (!string.IsNullOrWhiteSpace(req.Code))
@@ -3183,6 +3179,10 @@ int RunServerLoop(System.IO.TextReader input, System.IO.TextWriter output)
         var isolationError = ApplyRequestIsolation(req);
         if (isolationError != null) return isolationError;
 
+        // Scoped to THIS request only — reset in `finally` below regardless of outcome,
+        // so a captureValues:true request never leaves the flag on for a later request
+        // that didn't ask for it (the flag is process-global, same as AlCoverageTracker.Enabled).
+        AlRunner.Infrastructure.AlValueCapture.Enabled = req.CaptureValues == true;
         try
         {
             var runs = RunAllBundlesForServer(sourcePaths, req.PackagePaths, RunFirstCodeunitOnRun);
@@ -3202,6 +3202,7 @@ int RunServerLoop(System.IO.TextReader input, System.IO.TextWriter output)
         }
         finally
         {
+            AlRunner.Infrastructure.AlValueCapture.Enabled = false;
             // Best-effort cleanup: the scratch dir's contents are fully consumed
             // once RunBundleForServer has emitted+compiled them into an in-memory
             // assembly (or failed trying) — nothing downstream needs the files on
@@ -3772,6 +3773,15 @@ int RunServerLoop(System.IO.TextReader input, System.IO.TextWriter output)
 
         var sw = System.Diagnostics.Stopwatch.StartNew();
         AlRunner.Infrastructure.AlCallStackCapture.Clear();
+        // #1640: only meaningfully non-null when the caller enabled
+        // AlValueCapture (HandleServerExecute, gated by req.CaptureValues). Reset
+        // BEFORE invoking, mirroring AlCallStackCapture.Clear() above — same
+        // process-global, sequential-invocation assumption.
+        AlRunner.Infrastructure.AlValueCapture.Reset();
+        IReadOnlyList<AlRunner.Infrastructure.AlCapturedValue>? Captured() =>
+            AlRunner.Infrastructure.AlValueCapture.Enabled
+                ? AlRunner.Infrastructure.AlValueCapture.Collect()
+                : null;
         try
         {
             var ctor = target.GetConstructors().FirstOrDefault(c =>
@@ -3787,19 +3797,21 @@ int RunServerLoop(System.IO.TextReader input, System.IO.TextWriter output)
             else target.GetMethod("OnRun",
                 System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance, null,
                 Type.EmptyTypes, null)!.Invoke(instance, null);
-            return new[] { new TestResult(target.Name, "OnRun", TestOutcome.Pass, null, null, sw.Elapsed) };
+            return new[] { new TestResult(target.Name, "OnRun", TestOutcome.Pass, null, null, sw.Elapsed,
+                CapturedValues: Captured()) };
         }
         catch (System.Reflection.TargetInvocationException tex)
         {
             var inner = tex.InnerException ?? tex;
             var alStack = AlRunner.Infrastructure.AlCallStackCapture.GetCaptured(inner);
             return new[] { new TestResult(target.Name, "OnRun", TestOutcome.Fail,
-                $"{inner.GetType().Name}: {inner.Message}", inner.ToString(), sw.Elapsed, alStack) };
+                $"{inner.GetType().Name}: {inner.Message}", inner.ToString(), sw.Elapsed, alStack,
+                CapturedValues: Captured()) };
         }
         catch (Exception ex)
         {
             return new[] { new TestResult(target.Name, "OnRun", TestOutcome.Error,
-                ex.Message, ex.ToString(), sw.Elapsed) };
+                ex.Message, ex.ToString(), sw.Elapsed, CapturedValues: Captured()) };
         }
     }
 }

--- a/AlRunner/ServerProtocol.cs
+++ b/AlRunner/ServerProtocol.cs
@@ -30,9 +30,12 @@ namespace AlRunner;
 ///             "noop":bool}. `noop:true` when there was no active run (or it had
 ///             already finished) at the moment the cancel was processed — the v1
 ///             shape (#1613/#1614), reused verbatim rather than inventing a new one.
-///   execute : {exitCode, tests:[{name,status,durationMs,message,stackTrace}],
-///              messages|null, compilationErrors|null} — single response, not
-///              streamed (matches v1: only runTests streams).
+///   execute : {exitCode, tests:[{name,status,durationMs,message,stackTrace,
+///              capturedValues|omitted}], messages|null, compilationErrors|null} —
+///              single response, not streamed (matches v1: only runTests streams).
+///              `capturedValues` (#1640) is present per test only when the request
+///              set `captureValues:true`; each entry is {scopeName, variableName,
+///              value, statementId} — see AlValueCapture.
 ///   error   : {error}
 ///   shutdown: {status}
 /// </summary>
@@ -45,7 +48,13 @@ public sealed class ServerRequest
     [JsonPropertyName("stubPaths")] public string[]? StubPaths { get; set; }
     /// <summary>Inline AL source (used by the <c>execute</c> command).</summary>
     [JsonPropertyName("code")] public string? Code { get; set; }
-    /// <summary>Opt-in to variable capture on <c>execute</c> (v1 field; not yet supported in v2).</summary>
+    /// <summary>
+    /// Opt-in to variable capture on <c>execute</c> (v1 field; #1640 second slice —
+    /// --coverage was the first, #1922). When true, each response test entry's
+    /// <c>capturedValues</c> carries the top-level AL scope's locals as of the last
+    /// statement that ran (see AlValueCapture). Null/false = unchanged behaviour,
+    /// field omitted from the response.
+    /// </summary>
     [JsonPropertyName("captureValues")] public bool? CaptureValues { get; set; }
     /// <summary>
     /// "codeunit" (default) | "test"/"method" | "disabled" — see <see cref="TestIsolationParser"/>.
@@ -214,6 +223,11 @@ public static class ServerProtocol
     // (meaningful for AL-originated errors) and falls back to the raw C#
     // exception for runner-internal failures — see
     // .claude rule al_stack_vs_csharp_stack.
+    // capturedValues (#1640) is null-omitted (WhenWritingNull) when the request
+    // didn't set captureValues:true — t.CapturedValues is null in that case
+    // (RunFirstCodeunitOnRun only populates it when AlValueCapture.Enabled).
+    // When captureValues WAS requested it is present even as an empty array
+    // ("captured, zero AL locals" — a real, distinct answer from "not asked").
     private static object ToWire(TestResult t) => new
     {
         name = $"{t.Codeunit}.{t.Method}",
@@ -221,5 +235,17 @@ public static class ServerProtocol
         durationMs = (long)t.Duration.TotalMilliseconds,
         message = t.Message,
         stackTrace = (t.AlCallStack ?? t.FullException)?.TrimEnd(),
+        capturedValues = t.CapturedValues?.Select(ToWire),
+    };
+
+    // One captured AL local on the wire — the shape protocol-v2.schema.json already
+    // reserves for TestEvent.capturedValues (see the schema's top-level description),
+    // reused here for execute's own (schema-independent) response.
+    private static object ToWire(Infrastructure.AlCapturedValue v) => new
+    {
+        scopeName = v.ScopeName,
+        variableName = v.VariableName,
+        value = v.Value,
+        statementId = v.StatementId,
     };
 }

--- a/AlRunner/TestExecutor.cs
+++ b/AlRunner/TestExecutor.cs
@@ -71,7 +71,15 @@ public sealed record TestResult(string Codeunit, string Method, TestOutcome Outc
                                 Exception? Exception = null,
                                 Infrastructure.ExpectationResult? Expectation = null,
                                 bool InsideTestProc = true,
-                                bool TimedOut = false);
+                                bool TimedOut = false,
+                                // #1640: only ever non-null when the caller asked for
+                                // --capture-values (server `execute`'s captureValues flag
+                                // today — see Program.cs's RunFirstCodeunitOnRun/HandleServerExecute
+                                // and AlValueCapture). Null means "not requested", never
+                                // "requested but empty" — an empty list IS how "requested,
+                                // zero AL locals" is represented (AlValueCapture.Collect()
+                                // never returns null).
+                                IReadOnlyList<Infrastructure.AlCapturedValue>? CapturedValues = null);
 
 public sealed class TestExecutor
 {

--- a/docs/server-mode.md
+++ b/docs/server-mode.md
@@ -40,7 +40,7 @@ al-runner --server [--package-cache PATH ...] [--cache DIR]
   "packagePaths": ["/extra"],   // optional: extra .app caches, augment server defaults
   "stubPaths": [],              // v1 field, ignored in v2 (no stubs layer)
   "code": "...",                // execute only (inline AL); mutually exclusive with sourcePaths
-  "captureValues": false,       // execute only — not yet supported
+  "captureValues": false,       // execute only — see #1640
   "testIsolation": "codeunit"   // optional: "codeunit" (default) | "test"/"method" | "disabled"
                                  // — see #1616. Applies to this request only; a later
                                  // request that omits the field falls back to the
@@ -166,12 +166,23 @@ covers every object type BC supports, not just `codeunit`/`table` (#1931):
 ```
 
 `code` and `sourcePaths` are mutually exclusive — sending both is a
-request-level error. Value capture (`captureValues`) still needs the Cecil
-instrumentation pass on #1640, so that flag alone still fails loudly with a
-structured error rather than a silent fake, per `.claude/rules/loud-failures.md`:
+request-level error.
+
+`captureValues: true` (#1640) reports each test entry's AL locals as of the
+last statement that ran — captured via a Cecil hook on
+`NavMethodScope.Exit()`, not a pass over emitted AL output (see
+`AlRunner/Infrastructure/AlValueCapture.cs`). `capturedValues` is present per
+test only when the request set the flag; each entry is `{scopeName,
+variableName, value, statementId}`:
 
 ```json
-{"error":"execute: 'captureValues' is not yet supported in v2. See docs/server-mode.md."}
+{"command":"execute","captureValues":true,
+ "code":"codeunit 50100 X { trigger OnRun() var Msg: Text; begin Msg := 'hi'; end; }"}
+```
+
+```json
+{"exitCode":0,"tests":[{"name":"X.OnRun","status":"pass","durationMs":5,
+ "capturedValues":[{"scopeName":"OnRun","variableName":"Msg","value":"hi","statementId":0}]}]}
 ```
 
 ### `shutdown`


### PR DESCRIPTION
Closes #1640

## What

Server `execute`'s `captureValues:true` now works, instead of the loud
"not yet supported" error placeholder. The response's per-test
`capturedValues` array reports the top-level AL scope's locals — `[NavName]`
fields on the generated `*_Scope` class — as of the last statement that ran,
each entry shaped `{scopeName, variableName, value, statementId}` (the shape
`protocol-v2.schema.json`'s `TestEvent.capturedValues` already reserves).

Per #1640's re-scoped issue body/comments, this PR covers `--capture-values`
only. `--iteration-tracking` is explicitly deferred — the issue's own
2026-08-25 comment says it "should be split into its own issue rather than
holding this one" because it still carries an open design question (whether
per-statement hit counts are the whole feature, or whether it needs loop
structure the `[SourceSpans]` table doesn't describe).

## Why no Cecil pass over AL output

BC's own AL compiler already lifts every AL local to a **public** instance
field on the generated scope class, tagged `[NavName("<AL name>")]` —
confirmed by decompiling an emitted test DLL (`DUMP_CS=1`):

```csharp
private sealed class OnRun_Scope : NavTriggerMethodScope<Codeunit60100>
{
    [NavName("Counter")] public int counter = default(int);
    [NavName("Msg")]     public NavText msg = NavText.Default(0);
    ...
}
```

So capturing values is reflection over a live scope instance's public
fields, not a new instrumentation pass — matching the mechanism `--coverage`
(#1922) already proved for statement-level tracking.

## Design correction during implementation: Exit(), not StmtHit

The obvious first design — reuse the `--coverage` shape, i.e. a Cecil hook on
`NavMethodScope.StmtHit(int)` that overwrites a snapshot on every hit —
turns out to be **provably wrong**, and a probe fixture caught it directly:

```csharp
protected override void OnRun()
{
    StmtHit(0); this.counter = 1;
    StmtHit(1); this.msg = new NavText("a");
    StmtHit(2); this.counter = 2;
    StmtHit(3); this.msg = new NavText("b");
}
```

`StmtHit(N)` fires **before** statement `N`'s own side effect, so the LAST
hit call never sees the LAST statement's result — the prototype reported
`Msg = "before"` when the correct final value is `"after"`. There's no
StmtHit call after the final statement to correct for this.

The fix hooks `NavMethodScope.Exit()` instead (decompiled):

```csharp
// NavMethodScope.Run():
try { OnRun(); } finally { Exit(); }

// NavMethodScope.Exit():
internal void Exit() { statementNumber = int.MaxValue; ...; Dispose(); }
```

`Exit()` fires exactly once per scope, unconditionally (success or AL
error), strictly *after* every statement (and its side effects) has run, and
strictly *before* `Dispose()` (confirmed by decompile: `Dispose()` only
touches `Tree`/session bookkeeping, never AL-declared fields). The hook is
prepended before `Exit()`'s own body, so `AlValueCapture.OnExit` sees both
the true final field values and the real last-executed statement index (not
yet stomped to the `int.MaxValue` sentinel).

Only the **top-level** scope is captured — `NavMethodScope.IsTopLevelCall`
(`StackDepth == 2`, decompiled and confirmed) — matching the re-scoped
issue's "final-state snapshot per test" framing, not procedures the test
calls into.

## Tests (RED → GREEN)

`AlRunner.Tests/ServerTests.cs`:
- `Execute_CaptureValues_True_ReportsFinalLocalsOfTopLevelScope` — asserts
  the exact final values (`Counter=42`, not the intermediate `41`;
  `Msg="after"`, not `"before"`) and the exact last-statement index. Would
  fail against a gutted/default implementation, and did fail against the
  StmtHit-based prototype for the reason above.
- `Execute_CaptureValues_Omitted_NoCapturedValuesField` — negative
  direction: `capturedValues` is absent (not an empty array) when the flag
  isn't set, proving the feature is actually gated rather than always-on.

This is runner-specific wire-protocol behaviour (server-mode JSON shape,
Cecil-hook mechanism), not a claim about plain BC semantics, so it lives in
`AlRunner.Tests` per `.claude/rules/bc-behavior-tests-go-upstream.md` rather
than the corpus.

## Verification

- New/targeted tests green (`Execute_CaptureValues_*`, full `ServerTests`
  class — 19/19).
- Full `AlRunner.Tests` suite: 874 passed, 56 skipped, 1 failed — the failure
  (`SourceDepSymbolsWithoutPackageCacheTests.SiblingSourceDep_CompilesWithZeroPackageCacheDirs`)
  reproduces identically on a clean `main` checkout with none of this PR's
  changes applied, so it's pre-existing and unrelated.
- Full `tests/al-language` corpus run against the built runner (with the new
  `Exit()` Cecil hook active, `--capture-values` off): 2130/2130 pass — the
  hook is a no-op on the default path, since `AlValueCapture.Enabled` gates
  everything past the unconditional (cheap) prepended call.

## Scope note (`docs/coverage.yaml`)

No coverage file touched — that mechanism was retired at the v1→v2 cutover;
the corpus + `tests/runner-extras/`/`AlRunner.Tests/` *are* the coverage
record.