### PR TITLE
fix: print startup reporting once per invocation, not once per re-exec generation

### DIFF
--- a/AlRunner.Tests/StartupOutputReexecDedupTests.cs
+++ b/AlRunner.Tests/StartupOutputReexecDedupTests.cs
@@ -116,6 +116,76 @@ public sealed class StartupOutputReexecDedupTests
         Assert.DoesNotContain("[reexec]", output);
     }
 
+    /// <summary>
+    /// Regression: `reexecPending` must track the ACTUAL re-exec gate
+    /// (`NeedsShadow(...) && AL_RUNNER_NCL_SHADOW_DONE != "1"`), not `NeedsShadow` alone.
+    ///
+    /// Setup: Ncl.dll is genuinely absent from the original (non-shadow) bin/ — so
+    /// NeedsShadow is true — but AL_RUNNER_NCL_SHADOW_DONE=1 is forced by hand (a
+    /// plausible way to skip the shadow hop while debugging), and the ncl-cecil cache is
+    /// already warm for this exact build (primed by the earlier warm-up spawns in this
+    /// class). Under that combination: the shadow-re-exec block is skipped (env guard),
+    /// NclCecilRewrite.RewriteInPlace hits the warm cache and just copies the cached
+    /// bytes into the original bin/'s Ncl.dll (no further re-exec — it only re-execs on
+    /// a genuine cache MISS), so this single process runs the whole bundle itself. ZERO
+    /// re-execs happen at all.
+    ///
+    /// If `reexecPending` were computed from `NeedsShadow` alone (ignoring the env
+    /// guard), it would read true here even though no re-exec follows — suppressing the
+    /// provisioning line, `[bc] selected BC`, and the banner in the ONLY generation that
+    /// ever runs, with no later generation to reprint them. Confirmed by reverting the
+    /// env-guard clause locally: the trio does not appear ANYWHERE in the output in that
+    /// configuration, even though the run itself passes cleanly (same silent-output
+    /// class of bug #2034 was about, one file over).
+    /// </summary>
+    [SkippableFact]
+    public void ShadowDoneEnvVarForced_NoFurtherReexecFollows_StartupTrioStillPrintsOnce()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var originalDll = Path.Combine(
+            ProjectPath, "bin", TestBuildConfig.Configuration, TestBuildConfig.Framework, "al-runner.dll");
+        var originalNcl = Path.Combine(Path.GetDirectoryName(originalDll)!, "Microsoft.Dynamics.Nav.Ncl.dll");
+
+        // Warm the ncl-cecil cache for this exact build (normal spawn, via the shadow
+        // dir — never touches the original bin/) so the forced run below hits a cache
+        // HIT rather than a genuine MISS (a MISS would trigger the UNRELATED
+        // fresh-rewrite re-exec — see Program.cs — which would mask exactly the
+        // single-generation scenario this test is pinning).
+        Spawn();
+        Assert.False(File.Exists(originalNcl),
+            $"precondition violated: {originalNcl} already exists — NeedsShadow would be false " +
+            "for the original bin/ regardless of the env guard, and this test would not be " +
+            "exercising the scenario it claims to.");
+
+        try
+        {
+            var psi = BuildPsi(originalDll);
+            psi.Environment["AL_RUNNER_NCL_SHADOW_DONE"] = "1";
+            var (output, exit) = Run(psi);
+
+            Assert.Equal(0, exit);
+            Assert.Contains("pass:        1", output);
+            Assert.Contains("fail:        0", output);
+
+            // Zero re-execs of ANY kind fired — this really is the single-generation
+            // case, not the fresh-rewrite one masking it.
+            Assert.DoesNotContain("[reexec]", output);
+
+            Assert.Equal(1, CountOccurrences(output, "[provision] BC "));
+            Assert.Equal(1, CountOccurrences(output, "[bc] selected BC "));
+            Assert.Equal(1, CountOccurrences(output, "al-runner — running "));
+        }
+        finally
+        {
+            // RewriteInPlace writes Ncl.dll directly into the original bin/ as a side
+            // effect of this scenario (see the doc comment above) — clean it up so it
+            // cannot contaminate any other test in this assembly that inspects
+            // NclShadowRuntime.NeedsShadow against that same directory.
+            try { File.Delete(originalNcl); } catch { /* best effort */ }
+        }
+    }
+
     /// <summary>Extracts the path from Program's own `[Cecil] Building/Reusing Ncl
     /// shadow runtime dir at &lt;path&gt;` line.</summary>
     private static string ExtractShadowDir(string output)

--- a/AlRunner.Tests/StartupOutputReexecDedupTests.cs
+++ b/AlRunner.Tests/StartupOutputReexecDedupTests.cs
@@ -1,0 +1,181 @@
+// StartupOutputReexecDedupTests — issue #2041.
+//
+// Split out of #2037/#2038: this process's startup reporting (the `[provision] BC ...
+// already complete` line, `[bc] selected BC ...`, and the `al-runner — running N
+// bundle(s)` banner) is printed BEFORE the shadow-re-exec decision hands off to a child
+// process. The tool package no longer ships Microsoft.Dynamics.Nav.Ncl.dll (#2023/#2026),
+// so NclShadowRuntime.NeedsShadow is true on essentially every real invocation, and the
+// child re-runs the exact same startup sequence from scratch — reprinting all three
+// lines. Confirmed live against the published 2.5.0 package with `strace -f -e
+// trace=execve`: exactly two execve calls on a warm run, and all three lines appear
+// twice, once per process generation.
+//
+// The fix (see Program.cs) computes whether THIS generation will need to shadow-re-exec
+// — a cheap, deterministic filesystem check (does Ncl.dll already exist beside this
+// assembly?) that is known before any of the three lines would print — and suppresses
+// them in that generation only. The generation that actually goes on to run tests (no
+// re-exec pending) always prints them, exactly once. The `[reexec]` explanation itself
+// (#2034/#2038) is untouched: it still prints from the parent, at default verbosity.
+using System.Diagnostics;
+using System.Text;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class StartupOutputReexecDedupTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+    private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
+    private static readonly string Fixture =
+        Path.Combine(RepoRoot, "AlRunner.Tests", "Fixtures", "RecordTriggerXRec");
+
+    private static int CountOccurrences(string haystack, string needle)
+    {
+        var n = 0;
+        for (var i = haystack.IndexOf(needle, StringComparison.Ordinal); i >= 0;
+             i = haystack.IndexOf(needle, i + needle.Length, StringComparison.Ordinal))
+            n++;
+        return n;
+    }
+
+    /// <summary>
+    /// Acceptance #1 + #2: a WARM run (ncl-cecil cache already populated — the exact
+    /// shape of the issue's own repro, "two execve calls") against an explicit
+    /// --bc-version prints the provisioning line, the `[bc] selected BC` line and the
+    /// banner exactly once each, and the `[reexec]` explanation still fires from the
+    /// parent — all at DEFAULT verbosity (no AL_RUNNER_VERBOSE), since #2038 already
+    /// made `[provision]`/`[bc]`/`[reexec]` survive the default-verbosity filter and
+    /// this is what a real user actually sees.
+    /// </summary>
+    [SkippableFact]
+    public void WarmRun_PrintsStartupTrioExactlyOnce_ReexecExplanationStillFromParent()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        // Warm-up spawn: primes the ncl-cecil / ncl-shadow caches so the run asserted
+        // on below is genuinely warm (a cold cache adds a THIRD generation via the
+        // fresh-Cecil-rewrite re-exec, which this issue's acceptance criteria does not
+        // cover — see Program.cs's comment on the "fresh rewrite" re-exec).
+        Spawn();
+
+        var (output, exit) = Spawn();
+        Assert.Equal(0, exit);
+        Assert.Contains("pass:        1", output);
+        Assert.Contains("fail:        0", output);
+
+        Assert.Equal(1, CountOccurrences(output, "[provision] BC "));
+        Assert.Equal(1, CountOccurrences(output, "[bc] selected BC "));
+        Assert.Equal(1, CountOccurrences(output, "al-runner — running "));
+
+        // The re-exec explanation must not have been collapsed away along with the
+        // duplicated trio above — it is specifically about the parent and stays there.
+        Assert.Equal(1, CountOccurrences(output, "[reexec] Ncl.dll not shipped in this install"));
+    }
+
+    /// <summary>
+    /// Acceptance #3: a run that does NOT need to re-exec at all — spawned directly out
+    /// of the shadow runtime dir, which genuinely has Ncl.dll on disk, so
+    /// NclShadowRuntime.NeedsShadow is false for it — is unaffected by the fix: the trio
+    /// still prints, exactly once, same as it always did, and no `[reexec]` marker
+    /// appears since none fired.
+    /// </summary>
+    [SkippableFact]
+    public void NoReexecRun_StartupTrioUnchanged()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        // Discover the shadow dir path from a REAL subprocess's own [Cecil] "Building/
+        // Reusing Ncl shadow runtime dir at ..." line (verbose only for this discovery
+        // spawn) rather than calling NclShadowRuntime.EnsureShadowDir in-process: this
+        // test host process has almost certainly already loaded
+        // Microsoft.Dynamics.Nav.Ncl.dll for some OTHER test in the same run, and
+        // NclCecilRewrite.RewriteInPlace silently no-ops ("Ncl already loaded before
+        // in-place rewrite — no effect") whenever that is true for the CURRENT
+        // AppDomain — it would build a shadow dir with every dependency mirrored except
+        // the one file this test is actually about. A fresh child process never has
+        // that problem, and it is exactly the path Program.cs itself takes.
+        var (warmupOutput, warmupExit) = SpawnVerbose();
+        Assert.Equal(0, warmupExit);
+        var shadowDir = ExtractShadowDir(warmupOutput);
+        var shadowDll = Path.Combine(shadowDir, "al-runner.dll");
+        Assert.True(File.Exists(shadowDll), $"shadow al-runner.dll not found at {shadowDll}");
+        Assert.True(
+            File.Exists(Path.Combine(shadowDir, "Microsoft.Dynamics.Nav.Ncl.dll")),
+            "shadow dir is missing its own Ncl.dll copy — NeedsShadow would be true there too");
+
+        var (output, exit) = SpawnAssembly(shadowDll);
+        Assert.Equal(0, exit);
+        Assert.Contains("pass:        1", output);
+        Assert.Contains("fail:        0", output);
+
+        Assert.Equal(1, CountOccurrences(output, "[provision] BC "));
+        Assert.Equal(1, CountOccurrences(output, "[bc] selected BC "));
+        Assert.Equal(1, CountOccurrences(output, "al-runner — running "));
+        Assert.DoesNotContain("[reexec]", output);
+    }
+
+    /// <summary>Extracts the path from Program's own `[Cecil] Building/Reusing Ncl
+    /// shadow runtime dir at &lt;path&gt;` line.</summary>
+    private static string ExtractShadowDir(string output)
+    {
+        var m = Regex.Match(output, @"\[Cecil\] (?:Building|Reusing) Ncl shadow runtime dir at (.+)$",
+            RegexOptions.Multiline);
+        Assert.True(m.Success, $"could not find the shadow-dir marker line in runner output:\n{output}");
+        return m.Groups[1].Value.TrimEnd('\r');
+    }
+
+    private (string Output, int Exit) Spawn() =>
+        SpawnAssembly(Path.Combine(
+            ProjectPath, "bin", TestBuildConfig.Configuration, TestBuildConfig.Framework, "al-runner.dll"));
+
+    /// <summary>Same spawn as <see cref="Spawn"/>, but AL_RUNNER_VERBOSE=1 so the
+    /// `[Cecil]`-tagged shadow-dir marker line (suppressed by default — see Log.cs) is
+    /// observable, purely for path discovery. Not used for any of the count assertions,
+    /// which must stay at default verbosity to prove what a real user actually sees.
+    /// </summary>
+    private (string Output, int Exit) SpawnVerbose()
+    {
+        var psi = BuildPsi(Path.Combine(
+            ProjectPath, "bin", TestBuildConfig.Configuration, TestBuildConfig.Framework, "al-runner.dll"));
+        psi.Environment["AL_RUNNER_VERBOSE"] = "1";
+        return Run(psi);
+    }
+
+    private (string Output, int Exit) SpawnAssembly(string dllPath) => Run(BuildPsi(dllPath));
+
+    private ProcessStartInfo BuildPsi(string dllPath)
+    {
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            Arguments = $"\"{dllPath}\"{TestBuildConfig.BcVersionArg} \"{Fixture}\"",
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            WorkingDirectory = RepoRoot,
+        };
+        // Deliberately default verbosity — no AL_RUNNER_VERBOSE — this test is about
+        // what a real user sees by default, and #2038 already made every line asserted
+        // on here (`[provision]`, `[bc]`, `[reexec]`) survive that filter.
+        psi.Environment.Remove("AL_RUNNER_VERBOSE");
+        psi.Environment.Remove("AL_RUNNER_NCL_SHADOW_DONE");
+        psi.Environment.Remove("AL_RUNNER_REEXECED");
+        return psi;
+    }
+
+    private static (string Output, int Exit) Run(ProcessStartInfo psi)
+    {
+        var sb = new StringBuilder();
+        using var p = Process.Start(psi)!;
+        p.OutputDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.ErrorDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.BeginOutputReadLine();
+        p.BeginErrorReadLine();
+        Assert.True(p.WaitForExit(300_000), "runner did not exit within 300s");
+        p.WaitForExit();
+        return (sb.ToString(), p.ExitCode);
+    }
+}

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -706,6 +706,27 @@ if (bcVersionArg == null && artifactPathArg == null)
         }
     }
 }
+// #2041: whether THIS process generation will need to hand off to a shadow-re-exec
+// child before it can touch any BC type — a cheap, deterministic filesystem check (does
+// Ncl.dll already exist beside this assembly?) that does NOT depend on the selected BC
+// version or the variant-swap decision further down, so it is safe to compute this
+// early, before any startup-reporting line below would print. The tool package no
+// longer ships Ncl.dll (#2023/#2026), so this is true on essentially every real
+// invocation's first generation — and that generation's child re-runs this EXACT same
+// startup sequence from scratch, so printing the informational "[provision] ... already
+// complete" / "[bc] selected BC ..." / "al-runner — running N bundle(s)" lines here too
+// just duplicates them on stderr (confirmed via strace: two execve calls on a warm run,
+// each printing all three — see the issue). Gating those three success-path prints on
+// this flag means the generation that actually goes on to run tests — either the final
+// generation after a shadow hop, or an install that ships Ncl.dll and never needed
+// one — always prints them exactly once, and a generation about to be replaced does
+// not print the steady-state lines at all. LOUD FAILURES are untouched: every error
+// path below (provisioning failure, BC version selection failure, no matching engine
+// variant, an incomplete artifact closure) returns before this generation would ever
+// reach the shadow-re-exec check, so gating success-path noise here cannot hide one.
+// The `[reexec]` explanation itself (#2034/#2038) is a different print entirely and
+// stays unconditional — it is specifically about the parent and must keep firing there.
+var reexecPending = AlRunner.Infrastructure.NclShadowRuntime.NeedsShadow(AppContext.BaseDirectory);
 // ── Provisioning (on by default since issue #2024; opt out with --no-auto-provision):
 // `provision` subcommand or autoProvision (default true). Resolves the target version,
 // downloads the engine service-tier closure if it's missing/incomplete, then (subcommand)
@@ -722,8 +743,12 @@ if (provisionSubcommand || autoProvision)
     // handles the ENGINE service-tier closure in that case; only the `provision` subcommand
     // (which never reaches the post-selection gate — it returns immediately below) also
     // provisions manifest apps itself.
+    //
+    // #2041: `quiet` is never true for the `provision` subcommand itself — it returns
+    // immediately below and never re-execs, so its own success line would otherwise be
+    // silently lost with no later generation to reprint it.
     var prc = RunProvisioning(bcVersionArg, artifactPathArg, bundles, provisionManifestApps: provisionSubcommand,
-        out var provisionedVersion);
+        quiet: reexecPending && !provisionSubcommand, out var provisionedVersion);
     if (provisionSubcommand)
         return prc; // the subcommand always exits after provisioning, never runs tests
     if (prc == 0 && provisionedVersion != null)
@@ -756,8 +781,11 @@ try
     if (AlRunner.Infrastructure.BcArtifacts.ShouldWarnExplicitEngineMinorMismatch(
             bcVersionAutoSelected, shippedVariants.Count))
         AlRunner.Infrastructure.BcArtifacts.WarnIfExplicitEngineMinorMismatch();
-    Console.Error.WriteLine($"[bc] selected BC {AlRunner.Infrastructure.BcArtifacts.SelectedVersion} " +
-        $"({AlRunner.Infrastructure.BcArtifacts.ServiceTierDir})");
+    // #2041: suppressed when this generation is about to shadow-re-exec — see the
+    // `reexecPending` comment above. The child re-prints this exact line for real.
+    if (!reexecPending)
+        Console.Error.WriteLine($"[bc] selected BC {AlRunner.Infrastructure.BcArtifacts.SelectedVersion} " +
+            $"({AlRunner.Infrastructure.BcArtifacts.ServiceTierDir})");
 }
 catch (InvalidOperationException ex)
 {
@@ -837,11 +865,15 @@ if (alCacheDir != null) Directory.CreateDirectory(alCacheDir);
 // before any DependencyLoader/BcAppSymbolCache/workspace-deps call — all four read
 // CacheRoots.Resolve for their cache directory.
 AlRunner.Infrastructure.CacheRoots.SetOverride(cacheRootOverride);
-Console.WriteLine(serverMode
-    ? "al-runner — server mode (JSON-RPC over stdin/stdout)"
-    : watchMode
-        ? $"al-runner — watch mode, {bundles.Count} bundle(s) (Ctrl+C to quit)"
-        : $"al-runner — running {bundles.Count} bundle(s)");
+// #2041: suppressed when this generation is about to shadow-re-exec — see the
+// `reexecPending` comment above. The child re-prints this exact banner for real; this
+// generation touches no bundle work at all before handing off.
+if (!reexecPending)
+    Console.WriteLine(serverMode
+        ? "al-runner — server mode (JSON-RPC over stdin/stdout)"
+        : watchMode
+            ? $"al-runner — watch mode, {bundles.Count} bundle(s) (Ctrl+C to quit)"
+            : $"al-runner — running {bundles.Count} bundle(s)");
 
 // The packaged tool no longer ships Microsoft.Dynamics.Nav.Ncl.dll (see
 // check-nupkg-contents.sh) — it must be resolved from the user's own BC artifact
@@ -5692,13 +5724,17 @@ static string? TryDeriveBcMajorFromProject(IEnumerable<string> bundlePaths)
 // sole owner instead, so passing true there would attempt the SAME download twice in one
 // invocation (once here, pre-selection; once there, post-selection).
 static int RunProvisioning(string? bcVersionArg, string? artifactPathArg,
-    List<string> bundles, bool provisionManifestApps, out string? provisionedVersion)
+    List<string> bundles, bool provisionManifestApps, bool quiet, out string? provisionedVersion)
 {
     provisionedVersion = null;
 
     if (artifactPathArg != null)
     {
-        Console.Error.WriteLine("[provision] --artifact-path points at an explicit dir; nothing to provision.");
+        // #2041: `quiet` suppresses only this STEADY-STATE success line, never an error
+        // path — see the call site's comment for why (this generation is about to
+        // shadow-re-exec, and the child re-prints it once for real).
+        if (!quiet)
+            Console.Error.WriteLine("[provision] --artifact-path points at an explicit dir; nothing to provision.");
         return 0;
     }
 
@@ -5727,6 +5763,12 @@ static int RunProvisioning(string? bcVersionArg, string? artifactPathArg,
             var cachedDir = AlRunner.Infrastructure.BcArtifacts.SelectArtifactVersionDir(
                 AlRunner.Infrastructure.BcArtifacts.ArtifactsRootDir, prefix);
             full = Path.GetFileName(cachedDir);
+            // Not gated on `quiet`: unlike the two lines below, a re-exec'd child sees a
+            // DIFFERENT resolution outcome here than the parent did whenever the parent
+            // itself just downloaded (parent: "no cached ... resolving from the CDN",
+            // child: "found cached ... verifying completeness") — the two lines are not
+            // literal duplicates of each other, so suppressing either risks hiding a
+            // real state transition rather than a genuine repeat.
             Console.Error.WriteLine($"[provision] found cached BC {full} for prefix '{prefix}' — verifying completeness.");
         }
         catch (InvalidOperationException)
@@ -5744,7 +5786,16 @@ static int RunProvisioning(string? bcVersionArg, string? artifactPathArg,
     var serviceTierDir = AlRunner.Infrastructure.BcArtifacts.ArtifactDirFor(full);
     var report = AlRunner.Infrastructure.ProvisioningCheck.Check(full, serviceTierDir);
     if (report.Ok)
-        Console.Error.WriteLine($"[provision] BC {full} engine artifacts already complete at {serviceTierDir}.");
+    {
+        // #2041: the steady-state "nothing to do" line — suppressed under `quiet`, same
+        // reasoning as the --artifact-path branch above. AutoProvision's own download
+        // progress messages below are NOT gated: they only fire once regardless (by the
+        // time a shadow-re-exec child gets here the download already completed, so IT
+        // takes this same Ok branch instead), and a download in progress is exactly the
+        // kind of "real one-time work" .claude/rules/loud-failures.md means to stay loud.
+        if (!quiet)
+            Console.Error.WriteLine($"[provision] BC {full} engine artifacts already complete at {serviceTierDir}.");
+    }
     else if (!AlRunner.Infrastructure.ProvisioningCheck.AutoProvision(full, serviceTierDir))
         return 1;
 

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -726,7 +726,30 @@ if (bcVersionArg == null && artifactPathArg == null)
 // reach the shadow-re-exec check, so gating success-path noise here cannot hide one.
 // The `[reexec]` explanation itself (#2034/#2038) is a different print entirely and
 // stays unconditional — it is specifically about the parent and must keep firing there.
-var reexecPending = AlRunner.Infrastructure.NclShadowRuntime.NeedsShadow(AppContext.BaseDirectory);
+//
+// This MUST track the actual re-exec gate below (`NeedsShadow(...) || variantSwapDir !=
+// null) && AL_RUNNER_NCL_SHADOW_DONE != "1"`) as closely as it can be known this early:
+// - The `AL_RUNNER_NCL_SHADOW_DONE` clause is included below for exactly that reason.
+//   Without it, a process with Ncl.dll genuinely missing but that env var already set by
+//   hand (a plausible way to skip the shadow hop while debugging) would compute
+//   reexecPending=true, suppress all three lines, then NOT re-exec after all — silently
+//   dropping the very startup context (which BC version, which artifact dir) someone
+//   debugging an assembly-load failure in that exact scenario would need. Same failure
+//   class #2034 was about, one file over.
+// - `variantSwapDir` is deliberately NOT included: it is only known after SelectVersion
+//   resolves a version and the variant-selection block below matches it against the
+//   shipped variants, both well after this line. In the shipping shape that gap is not
+//   reachable — any install that ships per-BC-minor variants at all is one that also has
+//   Ncl.dll stripped from its top-level bin/ (variants are the packaged multi-version
+//   case; #2023/#2026 stripped Ncl.dll from every packaged install), so NeedsShadow is
+//   already true there regardless of variantSwapDir. If that coupling ever changes (e.g.
+//   a variants-shipping install that also ships its own default-variant Ncl.dll),
+//   NeedsShadow=false with variantSwapDir!=null would double-print again — restructuring
+//   to close that gap would mean computing SelectVersion + the variant match before any
+//   provisioning happens, which the provisioning step's own version resolution currently
+//   feeds into; that inversion is out of scope here.
+var reexecPending = AlRunner.Infrastructure.NclShadowRuntime.NeedsShadow(AppContext.BaseDirectory)
+    && Environment.GetEnvironmentVariable("AL_RUNNER_NCL_SHADOW_DONE") != "1";
 // ── Provisioning (on by default since issue #2024; opt out with --no-auto-provision):
 // `provision` subcommand or autoProvision (default true). Resolves the target version,
 // downloads the engine service-tier closure if it's missing/incomplete, then (subcommand)


### PR DESCRIPTION
Closes #2041

Split out of #2037. PR #2038 fixed the false KNOWN-DEGRADED warning + the `[reexec]` explanation visibility half; this is the other half.

## The bug

The runner's startup reporting — `[provision] BC ... already complete`, `[bc] selected BC ...`, and the `al-runner — running N bundle(s)` banner — is printed BEFORE the shadow-re-exec decision hands off to a child process. The tool package no longer ships `Microsoft.Dynamics.Nav.Ncl.dll` (#2023/#2026), so `NclShadowRuntime.NeedsShadow` is true on essentially every real invocation's first generation, and the child re-runs the exact same startup sequence from scratch — reprinting all three lines.

Confirmed live against the published 2.5.0 package with `strace -f -e trace=execve`: exactly two `execve` calls on a warm run, and all three lines appear twice.

## The fix

`NclShadowRuntime.NeedsShadow(AppContext.BaseDirectory)` is a cheap, deterministic filesystem check (does Ncl.dll already exist beside this assembly?) that does not depend on the selected BC version or the variant-swap decision further down — so it's computed once, early, before any of the three lines would print. The three success-path prints are gated on it: a generation about to shadow-re-exec no longer prints them; the generation that actually goes on to run tests (no re-exec pending) always prints them exactly once.

Error paths are untouched: provisioning failure, BC version selection failure, no matching engine variant, and an incomplete artifact closure all return *before* the shadow-re-exec check is ever reached, so gating success-path noise cannot hide a real failure (`.claude/rules/loud-failures.md`). The `[reexec]` explanation line itself (#2034/#2038) is a different print entirely and stays unconditional — it's specifically about the parent and keeps firing there, at default verbosity.

Also gated: the `provision`-subcommand-only `--artifact-path` message and the `RunProvisioning` "already complete" line (via a new `quiet` parameter, which is always `false` for the `provision` subcommand itself, since it never re-execs and has no later generation to reprint its own message).

## Verification

Manual repro against the built package, before/after:

```
# before (current main)
[provision] BC 28.1.49838.53910 engine artifacts already complete at ...
[bc] selected BC 28.1.49838.53910 (...)
al-runner — running 1 bundle(s)
[reexec] Ncl.dll not shipped in this install — re-execing into a shadow runtime dir that has it
[provision] BC 28.1.49838.53910 engine artifacts already complete at ...
[bc] selected BC 28.1.49838.53910 (...)
al-runner — running 1 bundle(s)
al-runner — test run summary

# after (this branch)
[reexec] Ncl.dll not shipped in this install — re-execing into a shadow runtime dir that has it
[provision] BC 28.1.49838.53910 engine artifacts already complete at ...
[bc] selected BC 28.1.49838.53910 (...)
al-runner — running 1 bundle(s)
al-runner — test run summary
```

New RED→GREEN test: `AlRunner.Tests/StartupOutputReexecDedupTests.cs` — spawns the real runner:
- `WarmRun_PrintsStartupTrioExactlyOnce_ReexecExplanationStillFromParent` — acceptance #1/#2: warm run against an explicit `--bc-version`, at default verbosity, asserts each of the three lines appears exactly once and the `[reexec]` marker still fires exactly once.
- `NoReexecRun_StartupTrioUnchanged` — acceptance #3: spawns the shadow runtime dir's own `al-runner.dll` directly (genuinely has Ncl.dll on disk, so `NeedsShadow` is false there) and asserts the trio is unaffected — still prints exactly once, no `[reexec]` marker at all.

## Tests run before push

- `StartupOutputReexecDedupTests` (new, both tests) — green
- `PhaseLogIntegrationTests`, `ExplicitEngineMinorWarningGatingTests`, `ReexecExplanationVisibilityTests`, `StartupJitModeTests`, `LogUserFacingTagsTests`, `NclShadowRuntimeTests` — the tests that share this code region — all green (34/34)
- Full `AlRunner.Tests` suite: 885 passed, 1 failed, 56 skipped. The one failure (`SourceDepSymbolsWithoutPackageCacheTests.SiblingSourceDep_CompilesWithZeroPackageCacheDirs`) reproduces identically on unmodified `main` (verified via `git stash`) — a pre-existing environment-dependent flake unrelated to this change (asserts an exact dep-assembly count that varies with this machine's stray global caches), not something this PR introduced.
- Manual sanity run against `tests/runner-extras/dep-tableext-invoke-main`, the `provision` subcommand, and `--no-auto-provision` — all print correctly.