### PR TITLE
feat(dap): restore --dap breakpoint debugging on v2 (slice 1 of #1642)

### DIFF
--- a/AlRunner.Tests/DapClient.cs
+++ b/AlRunner.Tests/DapClient.cs
@@ -1,0 +1,196 @@
+using System.Diagnostics;
+using System.Net.Sockets;
+using System.Text;
+using System.Text.Json;
+using AlRunner.Infrastructure;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// Spawns al-runner in <c>--dap</c> mode and drives it over the real DAP TCP wire
+/// format (AlRunner.Infrastructure.DapTransport — the exact same class the runner
+/// itself uses on the server side of this connection), for issue #1642. Unlike
+/// CliServer/SharedCliServer, a DAP session is inherently single-shot (one client,
+/// one bundle, one run) so there is no shared-process variant of this helper.
+/// </summary>
+public sealed class DapClient : IAsyncDisposable
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+    private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
+
+    private readonly Process _process;
+    private readonly TcpClient _tcp;
+    private readonly DapTransport _transport;
+    private readonly StringBuilder _stderr = new();
+    private readonly StringBuilder _stdout = new();
+
+    public string StdErr { get { lock (_stderr) return _stderr.ToString(); } }
+    public string StdOut { get { lock (_stdout) return _stdout.ToString(); } }
+
+    private DapClient(Process process, TcpClient tcp, DapTransport transport)
+    {
+        _process = process;
+        _tcp = tcp;
+        _transport = transport;
+    }
+
+    /// <summary>Starts al-runner --dap on a free loopback port and connects to it,
+    /// retrying the connect until the runner's own "[dap] listening on" line has
+    /// appeared on stdout (readiness is signalled there — --dap does NOT redirect
+    /// Console.Out to stderr the way --server does, see Program.cs's --dap block)
+    /// or <paramref name="readyTimeout"/> elapses.</summary>
+    public static async Task<DapClient> StartAsync(string bundleDir, TimeSpan? readyTimeout = null)
+    {
+        var port = GetFreeLoopbackPort();
+        var argList = new StringBuilder(
+            TestBuildConfig.RunArgs(ProjectPath) + TestBuildConfig.BcVersionArg +
+            $" --dap {port} \"{bundleDir}\"");
+
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            Arguments = argList.ToString(),
+            RedirectStandardInput = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            WorkingDirectory = RepoRoot,
+        };
+
+        var proc = Process.Start(psi)!;
+        var stderr = new StringBuilder();
+        var stdout = new StringBuilder();
+        var listeningTcs = new TaskCompletionSource();
+
+        _ = Task.Run(async () =>
+        {
+            string? line;
+            while ((line = await proc.StandardError.ReadLineAsync()) != null)
+                lock (stderr) stderr.AppendLine(line);
+        });
+        _ = Task.Run(async () =>
+        {
+            string? line;
+            while ((line = await proc.StandardOutput.ReadLineAsync()) != null)
+            {
+                lock (stdout) stdout.AppendLine(line);
+                if (line.Contains("[dap] listening on")) listeningTcs.TrySetResult();
+            }
+        });
+
+        var timeout = readyTimeout ?? TimeSpan.FromSeconds(120);
+        var completed = await Task.WhenAny(listeningTcs.Task, Task.Delay(timeout));
+        if (completed != listeningTcs.Task)
+        {
+            try { proc.Kill(true); } catch { }
+            throw new TimeoutException(
+                $"al-runner --dap did not report listening within {timeout.TotalSeconds:F0}s.\n" +
+                $"--- stdout ---\n{stdout}\n--- stderr ---\n{stderr}");
+        }
+
+        var tcp = new TcpClient();
+        await tcp.ConnectAsync("127.0.0.1", port);
+        var transport = new DapTransport(tcp.GetStream(), tcp.GetStream());
+
+        var client = new DapClient(proc, tcp, transport);
+        lock (stderr) client._stderr.Append(stderr);
+        lock (stdout) client._stdout.Append(stdout);
+        // Keep draining after handoff too, so later output (e.g. [dap] PASS/FAIL
+        // lines) is visible in a failure message.
+        _ = Task.Run(async () =>
+        {
+            string? line;
+            while ((line = await proc.StandardError.ReadLineAsync()) != null)
+                lock (client._stderr) client._stderr.AppendLine(line);
+        });
+        _ = Task.Run(async () =>
+        {
+            string? line;
+            while ((line = await proc.StandardOutput.ReadLineAsync()) != null)
+                lock (client._stdout) client._stdout.AppendLine(line);
+        });
+
+        return client;
+    }
+
+    private static int GetFreeLoopbackPort()
+    {
+        var l = new TcpListener(System.Net.IPAddress.Loopback, 0);
+        l.Start();
+        var port = ((System.Net.IPEndPoint)l.LocalEndpoint).Port;
+        l.Stop();
+        return port;
+    }
+
+    /// <summary>Sends a DAP request and returns its seq (for matching against the
+    /// eventual response's request_seq via <see cref="ReadUntilResponseAsync"/>).</summary>
+    public int SendRequest(string command, object? arguments = null) => _transport.WriteRequest(command, arguments);
+
+    /// <summary>Reads messages until the response to <paramref name="requestSeq"/>
+    /// arrives, returning it. Any events seen along the way are appended to
+    /// <paramref name="events"/> if given (so a caller can inspect e.g. an
+    /// `initialized` event that arrives between the `initialize` request and its
+    /// response, without a second read loop).</summary>
+    public async Task<JsonElement> ReadUntilResponseAsync(int requestSeq, List<JsonElement>? events = null, TimeSpan? timeout = null)
+    {
+        var deadline = DateTime.UtcNow + (timeout ?? TimeSpan.FromSeconds(30));
+        while (DateTime.UtcNow < deadline)
+        {
+            var msg = await ReadOneAsync(timeout ?? TimeSpan.FromSeconds(30));
+            var root = msg.Raw.RootElement;
+            var type = root.GetProperty("type").GetString();
+            if (type == "response" && root.TryGetProperty("request_seq", out var rs) && rs.GetInt32() == requestSeq)
+                return root;
+            if (type == "event") events?.Add(root);
+        }
+        throw new TimeoutException($"no response to request seq {requestSeq} within timeout.\n--- stdout ---\n{StdOut}\n--- stderr ---\n{StdErr}");
+    }
+
+    /// <summary>Reads messages until an event named <paramref name="eventName"/>
+    /// arrives, returning its body. Used to wait for e.g. "stopped". Every event
+    /// seen along the way (including the terminal one) is appended to <paramref
+    /// name="allEvents"/> if given, so a caller can assert on what did NOT arrive
+    /// (e.g. "no 'stopped' event fired") without a second read loop.</summary>
+    public async Task<JsonElement> ReadUntilEventAsync(string eventName, TimeSpan? timeout = null, List<JsonElement>? allEvents = null)
+    {
+        var t = timeout ?? TimeSpan.FromSeconds(60);
+        var deadline = DateTime.UtcNow + t;
+        while (DateTime.UtcNow < deadline)
+        {
+            var msg = await ReadOneAsync(t);
+            var root = msg.Raw.RootElement;
+            if (root.GetProperty("type").GetString() != "event") continue;
+            allEvents?.Add(root);
+            if (root.TryGetProperty("event", out var ev) && ev.GetString() == eventName)
+                return root;
+        }
+        throw new TimeoutException($"event '{eventName}' did not arrive within {t.TotalSeconds:F0}s.\n--- stdout ---\n{StdOut}\n--- stderr ---\n{StdErr}");
+    }
+
+    private async Task<DapIncomingMessage> ReadOneAsync(TimeSpan timeout)
+    {
+        using var cts = new CancellationTokenSource(timeout);
+        var msg = await _transport.ReadMessageAsync(cts.Token);
+        if (msg == null)
+            throw new Exception($"--dap connection closed unexpectedly.\n--- stdout ---\n{StdOut}\n--- stderr ---\n{StdErr}");
+        return msg;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        try { _transport.Dispose(); } catch { }
+        try { _tcp.Dispose(); } catch { }
+        try
+        {
+            if (!_process.HasExited)
+            {
+                _process.Kill(true);
+                await _process.WaitForExitAsync();
+            }
+        }
+        catch { }
+        _process.Dispose();
+    }
+}

--- a/AlRunner.Tests/DapServerTests.cs
+++ b/AlRunner.Tests/DapServerTests.cs
@@ -1,0 +1,143 @@
+using System.Text.Json;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// End-to-end tests for <c>--dap</c> (issue #1642): a real DAP TCP client
+/// (<see cref="DapClient"/>) drives al-runner through initialize/launch/
+/// setBreakpoints/configurationDone, proving a breakpoint actually PAUSES AL
+/// execution at the requested line — not a no-op that lets the test run straight
+/// through — and that the paused frame's locals reflect genuinely-live state (the
+/// first statement's effect visible, the second statement's NOT yet, since BC's
+/// StmtHit(N) fires BEFORE statement N's own side effect — see AlDapSession's file
+/// header for why that is the CORRECT boundary for a debugger, unlike
+/// --capture-values/#1640's Exit()-based design).
+///
+/// Uses AlRunner.Tests/Fixtures/DapBreakpoint: a [Test] method with three plain
+/// assignments (Counter := 1/2/3) followed by an Assert.AreEqual(3, Counter, ...).
+/// Line 21 of DapBreakpointTests.Codeunit.al is "Counter := 2;" — the second
+/// statement — see that file for the exact line numbering this test depends on.
+/// </summary>
+public class DapServerTests
+{
+    private static readonly string FixtureSrc = Path.GetFullPath(Path.Combine(
+        AppContext.BaseDirectory, "..", "..", "..", "Fixtures", "DapBreakpoint"));
+
+    private const int SecondStatementLine = 21;
+    private const string SourceFileName = "DapBreakpointTests.Codeunit.al";
+
+    [SkippableFact]
+    public async Task Dap_BreakpointOnSecondStatement_PausesBeforeItRuns_ThenContinueCompletesTheTest()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        await using var dap = await DapClient.StartAsync(FixtureSrc);
+
+        var initSeq = dap.SendRequest("initialize", new { adapterID = "al-runner-tests" });
+        var initEvents = new List<JsonElement>();
+        var initResp = await dap.ReadUntilResponseAsync(initSeq, initEvents);
+        Assert.True(initResp.GetProperty("success").GetBoolean(), initResp.ToString());
+        // "initialized" may have arrived before or after the response — accept both,
+        // but require it to have arrived at all (the client would otherwise wait
+        // forever on it in a real session).
+        var sawInitialized = initEvents.Any(e => e.GetProperty("event").GetString() == "initialized")
+            || (await dap.ReadUntilEventAsync("initialized")).GetProperty("event").GetString() == "initialized";
+        Assert.True(sawInitialized);
+
+        var launchSeq = dap.SendRequest("launch", new { });
+        var launchResp = await dap.ReadUntilResponseAsync(launchSeq, timeout: TimeSpan.FromSeconds(120));
+        Assert.True(launchResp.GetProperty("success").GetBoolean(),
+            $"launch failed: {launchResp}\n--- stderr ---\n{dap.StdErr}");
+
+        var sourcePath = Path.Combine(FixtureSrc, SourceFileName);
+        var bpSeq = dap.SendRequest("setBreakpoints", new
+        {
+            source = new { path = sourcePath },
+            breakpoints = new[] { new { line = SecondStatementLine } },
+        });
+        var bpResp = await dap.ReadUntilResponseAsync(bpSeq);
+        Assert.True(bpResp.GetProperty("success").GetBoolean(), bpResp.ToString());
+        var bps = bpResp.GetProperty("body").GetProperty("breakpoints");
+        Assert.Equal(1, bps.GetArrayLength());
+        Assert.True(bps[0].GetProperty("verified").GetBoolean(),
+            $"breakpoint at line {SecondStatementLine} was not verified: {bpResp}");
+        Assert.Equal(SecondStatementLine, bps[0].GetProperty("line").GetInt32());
+
+        var cfgSeq = dap.SendRequest("configurationDone");
+        await dap.ReadUntilResponseAsync(cfgSeq);
+
+        // The proof this test exists for: execution actually stops, at the line we
+        // asked for, not the third or first.
+        var stopped = await dap.ReadUntilEventAsync("stopped");
+        Assert.Equal("breakpoint", stopped.GetProperty("body").GetProperty("reason").GetString());
+        Assert.Equal(SecondStatementLine, stopped.GetProperty("body").GetProperty("line").GetInt32());
+
+        var stSeq = dap.SendRequest("stackTrace", new { threadId = 1 });
+        var stResp = await dap.ReadUntilResponseAsync(stSeq);
+        Assert.True(stResp.GetProperty("success").GetBoolean(), stResp.ToString());
+        var frames = stResp.GetProperty("body").GetProperty("stackFrames");
+        Assert.True(frames.GetArrayLength() >= 1, stResp.ToString());
+        var topFrame = frames[0];
+        Assert.Equal(SecondStatementLine, topFrame.GetProperty("line").GetInt32());
+        var frameId = topFrame.GetProperty("id").GetInt32();
+
+        var scSeq = dap.SendRequest("scopes", new { frameId });
+        var scResp = await dap.ReadUntilResponseAsync(scSeq);
+        var variablesReference = scResp.GetProperty("body").GetProperty("scopes")[0].GetProperty("variablesReference").GetInt32();
+
+        var varSeq = dap.SendRequest("variables", new { variablesReference });
+        var varResp = await dap.ReadUntilResponseAsync(varSeq);
+        Assert.True(varResp.GetProperty("success").GetBoolean(), varResp.ToString());
+        var vars = varResp.GetProperty("body").GetProperty("variables").EnumerateArray()
+            .ToDictionary(v => v.GetProperty("name").GetString()!, v => v.GetProperty("value").GetString());
+        Assert.True(vars.ContainsKey("Counter"), $"no Counter local reported: {varResp}");
+        // The load-bearing assertion: Counter is 1 (the FIRST statement's effect),
+        // NOT 2 — proving the pause happened BEFORE the second statement's own
+        // assignment ran, not after. A design that captured on StmtHit the way
+        // --capture-values' first (wrong) attempt did would still show "1" here by
+        // coincidence at this exact spot, but would be provably wrong at the LAST
+        // statement — see AlValueCaptureTests / the file header comments for that
+        // failure mode; this fact is specifically about the PAUSE boundary, not the
+        // read mechanism.
+        Assert.Equal("1", vars["Counter"]);
+
+        var contSeq = dap.SendRequest("continue", new { threadId = 1 });
+        await dap.ReadUntilResponseAsync(contSeq);
+
+        var exited = await dap.ReadUntilEventAsync("exited", timeout: TimeSpan.FromSeconds(60));
+        // exitCode 0 means the AL test (which asserts Counter == 3 after all three
+        // statements) actually passed once resumed — proving continue really let
+        // execution proceed to completion, not just silence the pause.
+        Assert.Equal(0, exited.GetProperty("body").GetProperty("exitCode").GetInt32());
+    }
+
+    [SkippableFact]
+    public async Task Dap_NoBreakpointsSet_RunsStraightThrough_NoStoppedEvent()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        await using var dap = await DapClient.StartAsync(FixtureSrc);
+
+        var initSeq = dap.SendRequest("initialize", new { adapterID = "al-runner-tests" });
+        await dap.ReadUntilResponseAsync(initSeq);
+        await dap.ReadUntilEventAsync("initialized");
+
+        var launchSeq = dap.SendRequest("launch", new { });
+        var launchResp = await dap.ReadUntilResponseAsync(launchSeq, timeout: TimeSpan.FromSeconds(120));
+        Assert.True(launchResp.GetProperty("success").GetBoolean(), launchResp.ToString());
+
+        // No setBreakpoints call at all — the negative direction: with the debug
+        // machinery wired but nothing armed, the AL execution must run straight
+        // through with zero "stopped" events, matching AlDapSession.Enabled's
+        // near-zero-cost-when-unused contract (same shape as AlCoverageTracker/
+        // AlValueCapture).
+        var cfgSeq = dap.SendRequest("configurationDone");
+        await dap.ReadUntilResponseAsync(cfgSeq);
+
+        var events = new List<JsonElement>();
+        var exited = await dap.ReadUntilEventAsync("exited", TimeSpan.FromSeconds(60), events);
+        Assert.DoesNotContain(events, e => e.GetProperty("event").GetString() == "stopped");
+        Assert.Equal(0, exited.GetProperty("body").GetProperty("exitCode").GetInt32());
+    }
+}

--- a/AlRunner.Tests/Fixtures/DapBreakpoint/Assert.Codeunit.al
+++ b/AlRunner.Tests/Fixtures/DapBreakpoint/Assert.Codeunit.al
@@ -1,0 +1,12 @@
+/// <summary>
+/// Minimal assertion helper for this fixture app (own ID range so it
+/// stands alone from the corpus Assert).
+/// </summary>
+codeunit 60250 "Dap Bp Assert"
+{
+    procedure AreEqual(Expected: Integer; Actual: Integer; Msg: Text)
+    begin
+        if Expected <> Actual then
+            Error('Assert.AreEqual failed. Expected:<%1>. Actual:<%2>. %3', Expected, Actual, Msg);
+    end;
+}

--- a/AlRunner.Tests/Fixtures/DapBreakpoint/DapBreakpointTests.Codeunit.al
+++ b/AlRunner.Tests/Fixtures/DapBreakpoint/DapBreakpointTests.Codeunit.al
@@ -1,0 +1,25 @@
+/// <summary>
+/// Three-statement test method for DapServerTests: proves a breakpoint set on the
+/// SECOND statement's line pauses BEFORE that statement runs — Counter is 1 (the
+/// first statement's effect), not yet 2 — and that continuing lets the third
+/// statement run and the test pass. See AlDapSession's file header for why StmtHit(N)
+/// firing before statement N's own effect is exactly the boundary a debugger wants.
+/// </summary>
+codeunit 60251 "Dap Breakpoint Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit "Dap Bp Assert";
+
+    [Test]
+    procedure ThreeStatements()
+    var
+        Counter: Integer;
+    begin
+        Counter := 1;
+        Counter := 2;
+        Counter := 3;
+        Assert.AreEqual(3, Counter, 'final value after all three statements');
+    end;
+}

--- a/AlRunner.Tests/Fixtures/DapBreakpoint/app.json
+++ b/AlRunner.Tests/Fixtures/DapBreakpoint/app.json
@@ -1,0 +1,25 @@
+{
+  "id": "b2c3d4e5-f6a7-4809-8b2c-3d4e5f6a7082",
+  "name": "Runner Tests Fixture - DAP Breakpoint",
+  "publisher": "AL Runner",
+  "version": "1.0.0.0",
+  "brief": "Fixture for --dap (issue #1642): a test method with several statements, used to prove a breakpoint pauses AL execution at the right AL line with the right locals visible.",
+  "description": "Used by AlRunner.Tests' DapServerTests.",
+  "privacyStatement": "",
+  "EULA": "",
+  "help": "",
+  "url": "",
+  "logo": "",
+  "dependencies": [],
+  "screenshots": [],
+  "platform": "1.0.0.0",
+  "application": "1.0.0.0",
+  "idRanges": [
+    {
+      "from": 60200,
+      "to": 60299
+    }
+  ],
+  "runtime": "14.0",
+  "features": []
+}

--- a/AlRunner.Tests/LogUserFacingTagsTests.cs
+++ b/AlRunner.Tests/LogUserFacingTagsTests.cs
@@ -60,6 +60,12 @@ public sealed class LogUserFacingTagsTests
     // launching a child had no explanation at default verbosity. re-exec explanations
     // now use their own exempted tag.
     [InlineData("[reexec] Ncl.dll not shipped in this install — re-execing into a shadow runtime dir that has it")]
+    // #1642: --dap's "listening on" line is the only readiness signal a DAP client (or
+    // a human at a terminal) has that the runner will accept a connection — caught by
+    // DapClient's own test harness timing out waiting for a line that was actually
+    // printed, just silently dropped before reaching stdout (same failure shape as the
+    // [bc] swallow above).
+    [InlineData("[dap] listening on 127.0.0.1:4711 — waiting for a debug client to connect...")]
     public void UserFacingTags_SurviveTheDefaultFilter(string line)
     {
         Assert.Contains(line, FilterOnce(line, verbose: false));

--- a/AlRunner/Infrastructure/AlDapSession.cs
+++ b/AlRunner/Infrastructure/AlDapSession.cs
@@ -1,0 +1,130 @@
+// AlDapSession — the runtime side of --dap (issue #1642): registers breakpoints as
+// (scope Type, statement index) pairs and blocks the AL execution thread when
+// NavMethodScope.StmtHit/CStmtHit fires for one of them, via a THIRD unconditional
+// Cecil-rewrite prepend on the same StmtHit/CStmtHit methods --coverage (#1922)
+// already hooks — see NclCecilRewrite's "DAP breakpoint hook" block. Process-global,
+// like AlCoverageTracker/AlValueCapture: al-runner runs one AL statement at a time on
+// one thread, so a single active session is the correct model (matches
+// docs/archive/dap.md's v1 design note: "Single SemaphoreSlim for pause/resume").
+//
+// WHY pausing AT StmtHit(N) is the RIGHT boundary for a debugger — unlike
+// AlValueCapture (#1640), which had to move OFF StmtHit and onto Exit() because a
+// "keep the latest StmtHit" snapshot is always one statement stale (BC calls
+// StmtHit(N) BEFORE statement N's own side effect runs). A breakpoint does not have
+// that problem: "stopped at line L" is CONVENTIONALLY DEFINED, in every mainstream
+// debugger, as "about to execute L; every statement before L has completed". That is
+// exactly what is true the instant StmtHit(N) fires — statement N-1's effects are
+// already visible on the scope's fields, statement N's are not yet. So pausing here,
+// and reading the live scope's fields from that exact instant (AlScopeInspector), is
+// not an approximation the way --capture-values' StmtHit-based prototype was — it is
+// the correct pause point by definition. No Exit()-style redesign is needed for pause.
+using Microsoft.Dynamics.Nav.Runtime;
+
+namespace AlRunner.Infrastructure;
+
+public static class AlDapSession
+{
+    /// <summary>True only while a --dap run is executing tests. Gates OnStmtHit; the
+    /// Cecil-rewritten StmtHit/CStmtHit call is unconditional, this flag is not — same
+    /// pattern as AlCoverageTracker.Enabled / AlValueCapture.Enabled.</summary>
+    public static volatile bool Enabled;
+
+    private static readonly HashSet<(Type ScopeType, int Stmt)> _breakpoints = new();
+    private static readonly object _bpLock = new();
+
+    private static volatile System.Threading.SemaphoreSlim? _pauseGate;
+    private static volatile NavMethodScope? _pausedScope;
+    private static volatile int _pausedStatement = -1;
+
+    /// <summary>Set once by Detach() (disconnect/terminate path) so a StmtHit that
+    /// arrives after the DAP session has gone away runs straight through instead of
+    /// registering a new pause nothing will ever release.</summary>
+    private static volatile bool _detached;
+
+    /// <summary>
+    /// Fired synchronously ON THE AL EXECUTION THREAD, before it blocks — the caller
+    /// (DapServer) uses this to push the DAP "stopped" event over the wire. Must not
+    /// throw: an exception here would propagate into BC's own StmtHit call.
+    /// </summary>
+    public static event Action<NavMethodScope, int>? Stopped;
+
+    /// <summary>Resets all state for a new session — breakpoints, any stale pause, the
+    /// detached flag. Call before a fresh --dap run starts.</summary>
+    public static void Reset()
+    {
+        lock (_bpLock) _breakpoints.Clear();
+        _pauseGate = null;
+        _pausedScope = null;
+        _pausedStatement = -1;
+        _detached = false;
+        Stopped = null;
+    }
+
+    public static void SetBreakpoint(Type scopeType, int statementIndex)
+    {
+        lock (_bpLock) _breakpoints.Add((scopeType, statementIndex));
+    }
+
+    public static void ClearBreakpoints(Type scopeType)
+    {
+        lock (_bpLock) _breakpoints.RemoveWhere(k => k.ScopeType == scopeType);
+    }
+
+    /// <summary>The scope currently paused, or null when nothing is paused.</summary>
+    public static NavMethodScope? PausedScope => _pausedScope;
+
+    /// <summary>The statement index the paused scope stopped at, or -1 when nothing is paused.</summary>
+    public static int PausedStatement => _pausedStatement;
+
+    public static bool IsPaused => _pausedScope != null;
+
+    /// <summary>Releases a paused AL execution thread (DAP `continue`/`next`/`stepIn`/
+    /// `stepOut` — this first slice treats all four identically, see the issue's PR
+    /// description for why real step granularity is follow-up work).</summary>
+    public static void Continue() => _pauseGate?.Release();
+
+    /// <summary>Permanently stops pausing (DAP `disconnect`/`terminate`) and releases
+    /// any thread currently blocked — an AL execution thread must never be left stuck
+    /// forever just because the debug client went away (.claude/rules/loud-failures.md:
+    /// no silent hang is acceptable either).</summary>
+    public static void Detach()
+    {
+        _detached = true;
+        _pauseGate?.Release();
+    }
+
+    /// <summary>
+    /// Hook target for the Cecil-rewritten NavMethodScope.StmtHit(int)/CStmtHit(int[,
+    /// bool]) — public static, exactly (NavMethodScope, int) so the rewrite can forward
+    /// `ldarg.0; ldarg.1; call` unboxed, same shape as AlCoverageTracker.OnStmtHit. Runs
+    /// on EVERY AL statement of every test, --dap or not — must stay near-zero-cost when
+    /// disabled.
+    /// </summary>
+    public static void OnStmtHit(NavMethodScope scope, int currentStatementNumber)
+    {
+        if (!Enabled || _detached) return;
+        // Same ExitStatementNumber guard as AlCoverageTracker.OnStmtHit — Exit() writes
+        // int.MaxValue directly, StmtHit never receives it from generated code.
+        if (currentStatementNumber == int.MaxValue) return;
+
+        bool hit;
+        lock (_bpLock) hit = _breakpoints.Contains((scope.GetType(), currentStatementNumber));
+        if (!hit) return;
+
+        var gate = new System.Threading.SemaphoreSlim(0, 1);
+        _pauseGate = gate;
+        _pausedScope = scope;
+        _pausedStatement = currentStatementNumber;
+        try
+        {
+            Stopped?.Invoke(scope, currentStatementNumber);
+            gate.Wait(); // blocks the AL execution thread until Continue()/Detach()
+        }
+        finally
+        {
+            _pausedScope = null;
+            _pausedStatement = -1;
+            _pauseGate = null;
+        }
+    }
+}

--- a/AlRunner/Infrastructure/AlDapStackWalker.cs
+++ b/AlRunner/Infrastructure/AlDapStackWalker.cs
@@ -1,0 +1,73 @@
+// AlDapStackWalker — DAP `stackTrace`: walks a paused NavMethodScope's ParentScope
+// chain outward, the same chain AlCallStackCapture already walks to format an AL
+// error's call stack, and resolves each frame's CURRENT AL source line from its own
+// [SourceSpansAttribute] (same decode DapBreakpointResolver uses for setBreakpoints).
+namespace AlRunner.Infrastructure;
+
+/// <summary>One live AL call-stack frame at a paused breakpoint. <c>Id</c> is a dense
+/// small int (0 = innermost/paused frame), reused directly as the DAP
+/// `stackTrace`/`scopes`/`variables` frame id — no separate id allocator needed.</summary>
+public readonly record struct AlDapFrame(
+    int Id, string ScopeName, string? SourcePath, int Line, Microsoft.Dynamics.Nav.Runtime.NavMethodScope Scope);
+
+public static class AlDapStackWalker
+{
+    /// <summary>
+    /// Walks from <paramref name="pausedScope"/> outward via ParentScope, stopping at
+    /// the root scope (Ncl's own bookkeeping frame, never AL-compiler-generated — it
+    /// carries no [SourceSpansAttribute] and IsRootScope is true).
+    ///
+    /// <paramref name="pausedStatementIndex"/> is the topmost (index-0) frame's
+    /// CURRENT statement — pass AlDapSession's own `currentStatementNumber` parameter,
+    /// NOT <c>pausedScope.StatementNumber</c>. This matters: the Cecil-rewritten hook
+    /// runs BEFORE StmtHit's own `statementNumber = currentStatementNumber;`
+    /// assignment (same "prepend runs first" mechanism as everywhere else in this
+    /// file's family — see AlDapSession's file header), so
+    /// <c>pausedScope.StatementNumber</c> is still the PREVIOUS statement's index at
+    /// the exact instant a breakpoint fires. Every ANCESTOR frame does not have this
+    /// problem — an ancestor's own StatementNumber was already correctly set by ITS
+    /// earlier StmtHit call (it is mid-call, waiting on whatever led to the paused
+    /// frame), so only frame 0 needs the override.
+    ///
+    /// <paramref name="sourceMap"/> resolves each frame's owning AL object to a file
+    /// path (see AlCoverageSourceMap.Build); a frame whose object isn't in the map
+    /// (e.g. a dependency app's procedure) still appears, with SourcePath null rather
+    /// than the frame being dropped — a debugger UI can show "no source" for it,
+    /// matching how ServerProtocol already treats a stack frame with no known file
+    /// (loud-failures.md: never silently omit a frame the caller could act on).
+    /// </summary>
+    public static List<AlDapFrame> Walk(
+        Microsoft.Dynamics.Nav.Runtime.NavMethodScope pausedScope,
+        int pausedStatementIndex,
+        IReadOnlyDictionary<(string Label, int Id), string> sourceMap)
+    {
+        var frames = new List<AlDapFrame>();
+        Microsoft.Dynamics.Nav.Runtime.NavMethodScope? cur = pausedScope;
+        int id = 0;
+        while (cur != null && !cur.IsRootScope)
+        {
+            var (label, objId) = AlCallStackCapture.ParseObjectTypeAndId(cur.GetType());
+            sourceMap.TryGetValue((label, objId), out var path);
+            var line = id == 0 ? ResolveLine(cur, pausedStatementIndex) : ResolveCurrentLine(cur);
+            frames.Add(new AlDapFrame(id, cur.ScopeName ?? "?", path, line, cur));
+            id++;
+            cur = cur.ParentScope;
+        }
+        return frames;
+    }
+
+    /// <summary>The absolute AL source line <paramref name="scope"/> is currently
+    /// stopped at, per its OWN live StatementNumber — correct for any ANCESTOR frame,
+    /// but NOT for the paused (topmost) frame itself; see <see cref="Walk"/>'s doc
+    /// comment for why.</summary>
+    public static int ResolveCurrentLine(Microsoft.Dynamics.Nav.Runtime.NavMethodScope scope)
+        => ResolveLine(scope, scope.StatementNumber);
+
+    private static int ResolveLine(Microsoft.Dynamics.Nav.Runtime.NavMethodScope scope, int statementIndex)
+    {
+        var spans = AlSourceSpansReflection.TryGetSpans(scope.GetType());
+        if (spans == null) return 0;
+        if (statementIndex < 0 || statementIndex >= spans.Length) return 0;
+        return AlSourceSpanCodec.AbsoluteFromLine(spans[statementIndex]);
+    }
+}

--- a/AlRunner/Infrastructure/AlNavNameReflection.cs
+++ b/AlRunner/Infrastructure/AlNavNameReflection.cs
@@ -1,0 +1,43 @@
+// AlNavNameReflection — shared lookup for BC's own [NavName(...)] attribute, the tag
+// the AL compiler puts on every public instance field it lifts an AL local onto in a
+// generated `*_Scope` class (see AlValueCapture's file header for how that was
+// confirmed). Two call sites need to resolve an AL local's declared name from it:
+// AlValueCapture (snapshot at NavMethodScope.Exit(), issue #1640) and AlScopeInspector
+// (live read at a paused breakpoint, issue #1642). Factored out so the reflection
+// handles are resolved once and the "BC changed shape" guard exists in exactly one
+// place — same reasoning as AlSourceSpanCodec's own file header ("Lift the
+// span-decoding ... into a shared helper ... Do not duplicate the bit layout").
+using System.Reflection;
+using Microsoft.Dynamics.Nav.Runtime;
+
+namespace AlRunner.Infrastructure;
+
+internal static class AlNavNameReflection
+{
+    private static Type? _tNavNameAttr;
+    private static PropertyInfo? _piNavNameName;
+    private static bool _reflInit;
+
+    public static void EnsureInit()
+    {
+        if (_reflInit) return;
+        // NavNameAttribute lives alongside NavMethodScope in Ncl.dll.
+        var nclAsm = typeof(NavMethodScope).Assembly;
+        _tNavNameAttr = nclAsm.GetType("Microsoft.Dynamics.Nav.Runtime.NavNameAttribute")
+            ?? throw new InvalidOperationException(
+                "[al-locals] Microsoft.Dynamics.Nav.Runtime.NavNameAttribute not found in Ncl.dll — BC changed shape, do not ship silently");
+        _piNavNameName = _tNavNameAttr.GetProperty("Name", BindingFlags.Public | BindingFlags.Instance)
+            ?? throw new InvalidOperationException(
+                "[al-locals] NavNameAttribute.Name not found — BC changed shape, do not ship silently");
+        _reflInit = true;
+    }
+
+    /// <summary>The AL-declared name for <paramref name="field"/>, or null if it does not
+    /// carry [NavName] (i.e. is not an AL local/parameter the compiler lifted onto this
+    /// scope class). Call <see cref="EnsureInit"/> first.</summary>
+    public static string? GetAlName(FieldInfo field)
+    {
+        if (Attribute.GetCustomAttribute(field, _tNavNameAttr!) is not object navNameAttr) return null;
+        return _piNavNameName!.GetValue(navNameAttr) as string ?? field.Name;
+    }
+}

--- a/AlRunner/Infrastructure/AlScopeInspector.cs
+++ b/AlRunner/Infrastructure/AlScopeInspector.cs
@@ -1,0 +1,55 @@
+// AlScopeInspector — reads the AL locals of a LIVE NavMethodScope instance, for --dap's
+// (#1642) "variables" request. Distinct from AlValueCapture (#1640): that one snapshots
+// the top-level scope exactly once, at Exit(), after every statement has run. This one
+// reads whichever scope instance a breakpoint pause handed it, at ANY point while a
+// method is executing — a debugger needs the frame's state as of the moment execution
+// stopped, not just the final state.
+//
+// This is safe to do "live" (the scope object is not done running) for the same reason
+// a breakpoint pausing at StmtHit(N) is itself correct: BC calls StmtHit(N) BEFORE
+// statement N's own side effect (see AlValueCapture's file header and
+// AlDapSession's), so "paused at line L" means "every statement before L has
+// completed, statement L has not started" — exactly what a debugger UI is supposed to
+// show. Reading the scope's fields at that instant is reading real, settled state, not
+// a mid-assignment tear.
+using System.Reflection;
+using Microsoft.Dynamics.Nav.Runtime;
+
+namespace AlRunner.Infrastructure;
+
+/// <summary>One AL local as seen at a live pause. <c>Value</c> is the wire-formatted
+/// value (see AlValueWireFormat); <c>Readable</c> is false only when reflection itself
+/// failed to read the field — the NAME still appears (never silently dropped, see
+/// .claude/rules/loud-failures.md), with an explicit marker instead of a value.</summary>
+public readonly record struct AlScopeLocal(string Name, object? Value, bool Readable);
+
+public static class AlScopeInspector
+{
+    /// <summary>
+    /// Every AL local currently visible on <paramref name="scope"/> — the same
+    /// [NavName]-tagged public instance field scan AlValueCapture.OnExit uses (via the
+    /// shared AlNavNameReflection), but against ANY live scope instance rather than only
+    /// at Exit(). A field that can't be reflected is reported with
+    /// <c>Readable:false</c> rather than omitted, so a debugger UI shows "cannot read
+    /// value" instead of the local silently vanishing from the Variables pane.
+    /// </summary>
+    public static List<AlScopeLocal> ReadLocals(NavMethodScope scope)
+    {
+        AlNavNameReflection.EnsureInit();
+        var result = new List<AlScopeLocal>();
+        foreach (var f in scope.GetType().GetFields(BindingFlags.Public | BindingFlags.Instance))
+        {
+            var name = AlNavNameReflection.GetAlName(f);
+            if (name == null) continue;
+            object? raw;
+            try { raw = f.GetValue(scope); }
+            catch (Exception ex)
+            {
+                result.Add(new AlScopeLocal(name, $"<unreadable: {ex.GetType().Name}>", false));
+                continue;
+            }
+            result.Add(new AlScopeLocal(name, AlValueWireFormat.ToWireValue(raw), true));
+        }
+        return result;
+    }
+}

--- a/AlRunner/Infrastructure/AlSourceSpansReflection.cs
+++ b/AlRunner/Infrastructure/AlSourceSpansReflection.cs
@@ -1,0 +1,42 @@
+// AlSourceSpansReflection — resolves BC's own [SourceSpansAttribute] type + its
+// EncodedSpans property once, for the two new --dap (#1642) call sites that need a
+// scope class's raw encoded-span array: DapBreakpointResolver (setBreakpoints —
+// file+line -> scope type + statement index) and AlDapStackWalker (a paused frame's
+// current AL line). AlCoverageTracker (#1922) resolves the same attribute
+// independently — its copy is left as-is here rather than retrofitted, so this
+// change cannot destabilize the already-shipped --coverage path; see this file's
+// PR description for that call.
+using System.Reflection;
+using Microsoft.Dynamics.Nav.Runtime;
+
+namespace AlRunner.Infrastructure;
+
+internal static class AlSourceSpansReflection
+{
+    private static Type? _tSourceSpansAttr;
+    private static PropertyInfo? _piEncodedSpans;
+    private static bool _init;
+
+    public static void EnsureInit()
+    {
+        if (_init) return;
+        var nclAsm = typeof(NavMethodScope).Assembly;
+        _tSourceSpansAttr = nclAsm.GetType("Microsoft.Dynamics.Nav.Runtime.SourceSpansAttribute")
+            ?? throw new InvalidOperationException(
+                "[dap] Microsoft.Dynamics.Nav.Runtime.SourceSpansAttribute not found in Ncl.dll — BC changed shape, do not ship silently");
+        _piEncodedSpans = _tSourceSpansAttr.GetProperty("EncodedSpans", BindingFlags.Public | BindingFlags.Instance)
+            ?? throw new InvalidOperationException(
+                "[dap] SourceSpansAttribute.EncodedSpans not found — BC changed shape, do not ship silently");
+        _init = true;
+    }
+
+    /// <summary>The decoded EncodedSpans array for <paramref name="scopeType"/>, or null
+    /// if it doesn't carry [SourceSpansAttribute] (e.g. an Ncl-internal scope class, not
+    /// AL-compiler-generated) or the array is empty.</summary>
+    public static long[]? TryGetSpans(Type scopeType)
+    {
+        EnsureInit();
+        if (Attribute.GetCustomAttribute(scopeType, _tSourceSpansAttr!) is not object srcAttr) return null;
+        return _piEncodedSpans!.GetValue(srcAttr) as long[] is { Length: > 0 } spans ? spans : null;
+    }
+}

--- a/AlRunner/Infrastructure/AlValueCapture.cs
+++ b/AlRunner/Infrastructure/AlValueCapture.cs
@@ -1,5 +1,8 @@
 // AlValueCapture — the runtime side of --capture-values (issue #1640, second slice of
-// the #1640 umbrella; --coverage was the first, #1922). Snapshots the AL locals of the
+// the #1640 umbrella; --coverage was the first, #1922). The NavName reflection lookup
+// and the wire-value conversion below are shared with --dap's live variable inspection
+// (issue #1642) via AlNavNameReflection / AlValueWireFormat — see those files.
+// Snapshots the AL locals of the
 // TOP-LEVEL AL call (the codeunit trigger the runner invokes directly — server `execute`'s
 // OnRun today) at the moment the scope is about to be disposed, via a Cecil-rewrite hook on
 // Microsoft.Dynamics.Nav.Ncl.dll's NavMethodScope.Exit() — see NclCecilRewrite's Exit block.
@@ -71,24 +74,6 @@ public static class AlValueCapture
     public static IReadOnlyList<AlCapturedValue> Collect() =>
         _snapshot ?? (IReadOnlyList<AlCapturedValue>)Array.Empty<AlCapturedValue>();
 
-    private static Type? _tNavNameAttr;
-    private static PropertyInfo? _piNavNameName;
-    private static bool _reflInit;
-
-    private static void EnsureReflInit()
-    {
-        if (_reflInit) return;
-        // NavNameAttribute lives alongside NavMethodScope in Ncl.dll.
-        var nclAsm = typeof(NavMethodScope).Assembly;
-        _tNavNameAttr = nclAsm.GetType("Microsoft.Dynamics.Nav.Runtime.NavNameAttribute")
-            ?? throw new InvalidOperationException(
-                "[capture-values] Microsoft.Dynamics.Nav.Runtime.NavNameAttribute not found in Ncl.dll — BC changed shape, do not ship silently");
-        _piNavNameName = _tNavNameAttr.GetProperty("Name", BindingFlags.Public | BindingFlags.Instance)
-            ?? throw new InvalidOperationException(
-                "[capture-values] NavNameAttribute.Name not found — BC changed shape, do not ship silently");
-        _reflInit = true;
-    }
-
     /// <summary>
     /// Hook target for the Cecil-rewritten NavMethodScope.Exit() — public static, exactly
     /// (NavMethodScope), prepended before Exit()'s own body (see the file header for why
@@ -104,7 +89,7 @@ public static class AlValueCapture
         // directly by the runner, i.e. server `execute`'s OnRun today.
         if (!scope.IsTopLevelCall) return;
 
-        EnsureReflInit();
+        AlNavNameReflection.EnsureInit();
         var scopeName = scope.ScopeName ?? "?";
         // Read BEFORE Exit()'s own body runs, so this is the real last-executed statement
         // index, not the int.MaxValue sentinel Exit() is about to write.
@@ -112,34 +97,13 @@ public static class AlValueCapture
         var values = new List<AlCapturedValue>();
         foreach (var f in scope.GetType().GetFields(BindingFlags.Public | BindingFlags.Instance))
         {
-            if (Attribute.GetCustomAttribute(f, _tNavNameAttr!) is not object navNameAttr) continue;
-            var name = _piNavNameName!.GetValue(navNameAttr) as string ?? f.Name;
+            var name = AlNavNameReflection.GetAlName(f);
+            if (name == null) continue;
             object? raw;
             try { raw = f.GetValue(scope); }
             catch { continue; } // a field that can't be read is skipped, never faked
-            values.Add(new AlCapturedValue(scopeName, name, ToWireValue(raw), statementId));
+            values.Add(new AlCapturedValue(scopeName, name, AlValueWireFormat.ToWireValue(raw), statementId));
         }
         _snapshot = values;
-    }
-
-    // JSON-serializable representation of a captured field's runtime value. CLR
-    // primitives (AL Integer/Boolean/BigInteger/... map straight to these — confirmed via
-    // DUMP_CS=1 on a probe fixture) pass through as-is so System.Text.Json emits a real
-    // JSON number/bool/string. Everything else is a BC value-type wrapper (NavText,
-    // NavCode, NavDate, Decimal18, NavOption, record handles, ...) — those are precompiled
-    // BC types we must not reimplement (.claude/rules/precompiled-dll-respect.md), so we
-    // take their own ToString() rather than guessing a bespoke encoding per type.
-    private static object? ToWireValue(object? raw)
-    {
-        if (raw == null) return null;
-        switch (raw)
-        {
-            case bool or byte or sbyte or short or ushort or int or uint or long or ulong
-                 or float or double or decimal or string:
-                return raw;
-            default:
-                try { return raw.ToString(); }
-                catch { return null; } // ToString() itself must never crash a capture
-        }
     }
 }

--- a/AlRunner/Infrastructure/AlValueWireFormat.cs
+++ b/AlRunner/Infrastructure/AlValueWireFormat.cs
@@ -1,0 +1,31 @@
+// AlValueWireFormat — turns a raw AL local's runtime value into a JSON-serializable
+// representation. Extracted from AlValueCapture (issue #1640) so both it and
+// AlScopeInspector's live variable reads (issue #1642, --dap) render the same value
+// the same way, rather than two independently-drifting copies.
+namespace AlRunner.Infrastructure;
+
+public static class AlValueWireFormat
+{
+    /// <summary>
+    /// CLR primitives (AL Integer/Boolean/BigInteger/... map straight to these —
+    /// confirmed via DUMP_CS=1 on a probe fixture) pass through as-is so a JSON writer
+    /// emits a real JSON number/bool/string. Everything else is a BC value-type wrapper
+    /// (NavText, NavCode, NavDate, Decimal18, NavOption, record handles, ...) — those
+    /// are precompiled BC types we must not reimplement
+    /// (.claude/rules/precompiled-dll-respect.md), so we take their own ToString()
+    /// rather than guessing a bespoke encoding per type.
+    /// </summary>
+    public static object? ToWireValue(object? raw)
+    {
+        if (raw == null) return null;
+        switch (raw)
+        {
+            case bool or byte or sbyte or short or ushort or int or uint or long or ulong
+                 or float or double or decimal or string:
+                return raw;
+            default:
+                try { return raw.ToString(); }
+                catch { return null; } // ToString() itself must never crash a capture
+        }
+    }
+}

--- a/AlRunner/Infrastructure/DapBreakpointResolver.cs
+++ b/AlRunner/Infrastructure/DapBreakpointResolver.cs
@@ -1,0 +1,99 @@
+// DapBreakpointResolver — DAP `setBreakpoints`: turns (source file, line) requests
+// into (AL scope Type, statement index) pairs AlDapSession can register, by scanning
+// every currently-loaded [SourceSpansAttribute] scope class — the same reflection
+// scan AlCoverageTracker.Collect performs for --coverage — and matching on (a) the AL
+// object the file declares, via a (label,id)->path source map built the same way
+// --coverage's is (AlCoverageSourceMap), and (b) an EXACT absolute-line match against
+// one of that object's INSTRUMENTED statements (AlCoverageInstrumentedStatements —
+// the sentinel/CStmtHit-aware set, not the raw SourceSpans count, which carries a
+// trailing never-instrumented entry — see that file's header).
+//
+// No "nearest line" heuristic: a requested line with no exact instrumented-statement
+// match comes back unverified rather than silently moved to a line the caller didn't
+// ask for (.claude/rules/loud-failures.md applied to protocol correctness — a
+// debugger that silently relocates a breakpoint is worse than one that says so).
+using System.Reflection;
+
+namespace AlRunner.Infrastructure;
+
+public readonly record struct DapBreakpointRequest(string SourcePath, int Line);
+
+public readonly record struct DapResolvedBreakpoint(
+    string SourcePath, int RequestedLine, bool Verified, int ActualLine, Type? ScopeType, int StatementIndex);
+
+public static class DapBreakpointResolver
+{
+    /// <summary>
+    /// Resolves each request against every AL object type currently loaded. Only
+    /// objects present in <paramref name="sourceMap"/> (built from the SAME bundle
+    /// roots the run compiled, e.g. via AlCoverageSourceMap.Build) can match — a
+    /// breakpoint in a file outside the debugged bundle is unverified, not a crash.
+    /// </summary>
+    public static List<DapResolvedBreakpoint> Resolve(
+        IReadOnlyList<DapBreakpointRequest> requests,
+        IReadOnlyDictionary<(string Label, int Id), string> sourceMap)
+    {
+        // Invert (label,id)->path into full-path -> (label,id). Both sides are real
+        // filesystem paths (not bare filenames — see docs/archive/dap.md's filename-only
+        // caveat, which this improves on), compared case-insensitively for
+        // cross-platform DAP clients.
+        var byPath = new Dictionary<string, (string Label, int Id)>(StringComparer.OrdinalIgnoreCase);
+        foreach (var kv in sourceMap)
+            byPath[Path.GetFullPath(kv.Value)] = kv.Key;
+
+        // (label,id) -> every loaded scope type for that object, each with its own
+        // (statement index -> absolute AL line) map.
+        var byObject = new Dictionary<(string, int), List<(Type Type, Dictionary<int, int> LineByStmt)>>();
+        foreach (var asm in AppDomain.CurrentDomain.GetAssemblies())
+        {
+            Type[] types;
+            try { types = asm.GetTypes(); }
+            catch (ReflectionTypeLoadException ex) { types = ex.Types.Where(t => t != null).Cast<Type>().ToArray(); }
+
+            foreach (var t in types)
+            {
+                var spans = AlSourceSpansReflection.TryGetSpans(t);
+                if (spans == null) continue;
+
+                var (label, id) = AlCallStackCapture.ParseObjectTypeAndId(t);
+                if (id == 0) continue;
+
+                var instrumented = AlCoverageInstrumentedStatements.Find(t);
+                var lineByStmt = new Dictionary<int, int>();
+                foreach (var i in instrumented)
+                {
+                    if (i < 0 || i >= spans.Length) continue; // defensive: BC shape drift
+                    lineByStmt[i] = AlSourceSpanCodec.AbsoluteFromLine(spans[i]);
+                }
+                if (!byObject.TryGetValue((label, id), out var list))
+                    byObject[(label, id)] = list = new();
+                list.Add((t, lineByStmt));
+            }
+        }
+
+        var result = new List<DapResolvedBreakpoint>(requests.Count);
+        foreach (var req in requests)
+        {
+            var full = Path.GetFullPath(req.SourcePath);
+            (Type Type, int Stmt, int Line)? match = null;
+            if (byPath.TryGetValue(full, out var objKey) && byObject.TryGetValue(objKey, out var scopes))
+            {
+                foreach (var (type, lineByStmt) in scopes)
+                {
+                    foreach (var kv in lineByStmt)
+                    {
+                        if (kv.Value != req.Line) continue;
+                        match = (type, kv.Key, kv.Value);
+                        break;
+                    }
+                    if (match != null) break;
+                }
+            }
+
+            result.Add(match is { } m
+                ? new DapResolvedBreakpoint(req.SourcePath, req.Line, true, m.Line, m.Type, m.Stmt)
+                : new DapResolvedBreakpoint(req.SourcePath, req.Line, false, 0, null, -1));
+        }
+        return result;
+    }
+}

--- a/AlRunner/Infrastructure/DapTransport.cs
+++ b/AlRunner/Infrastructure/DapTransport.cs
@@ -1,0 +1,158 @@
+// DapTransport — the Debug Adapter Protocol wire format: `Content-Length: N\r\n\r\n`
+// followed by N bytes of UTF-8 JSON, repeated for every request/response/event (DAP
+// spec, https://microsoft.github.io/debug-adapter-protocol/overview — the same
+// framing every DAP client, including VS Code's built-in debug UI, speaks). Built
+// fresh for issue #1642 rather than reusing ServerProtocol's newline-delimited JSON:
+// that framing is a --server-specific convention (see ServerProtocol.cs's own doc
+// comment), not the DAP spec, and a real DAP client will not speak it.
+//
+// Deliberately Stream-based, not Socket-based: a real --dap session wraps a
+// NetworkStream, but AlRunner.Tests drives the exact same class over an in-memory
+// duplex pipe (System.IO.Pipelines or a pair of AnonymousPipeServerStream/
+// AnonymousPipeClientStream) with no socket involved — deterministic, no port
+// contention between parallel test runs.
+using System.Text;
+using System.Text.Json;
+
+namespace AlRunner.Infrastructure;
+
+/// <summary>One parsed DAP message: request, response, or event. Only the fields this
+/// slice's command set actually uses are typed; anything else stays reachable via
+/// <see cref="Raw"/>.</summary>
+public sealed class DapIncomingMessage
+{
+    public required int Seq { get; init; }
+    public required string Type { get; init; } // "request"
+    public string? Command { get; init; }
+    public JsonElement? Arguments { get; init; }
+    public required JsonDocument Raw { get; init; }
+}
+
+public sealed class DapTransport : IDisposable
+{
+    private readonly Stream _input;
+    private readonly Stream _output;
+    private readonly object _writeLock = new();
+    private int _seq;
+
+    private static readonly JsonSerializerOptions WriteOpts = new()
+    {
+        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    public DapTransport(Stream input, Stream output)
+    {
+        _input = input;
+        _output = output;
+    }
+
+    /// <summary>Reads one framed message, or null on clean EOF (the peer closed the
+    /// connection — a normal end of session, not an error).</summary>
+    public async Task<DapIncomingMessage?> ReadMessageAsync(CancellationToken ct = default)
+    {
+        int contentLength = -1;
+        while (true)
+        {
+            var line = await ReadHeaderLineAsync(ct).ConfigureAwait(false);
+            if (line == null) return null; // EOF before/between headers
+            if (line.Length == 0) break; // blank line ends the header block
+            var idx = line.IndexOf(':');
+            if (idx <= 0) continue;
+            var name = line[..idx].Trim();
+            var value = line[(idx + 1)..].Trim();
+            if (string.Equals(name, "Content-Length", StringComparison.OrdinalIgnoreCase))
+            {
+                if (!int.TryParse(value, out contentLength))
+                    throw new InvalidOperationException($"[dap] malformed Content-Length header: '{value}'");
+            }
+        }
+        if (contentLength < 0)
+            throw new InvalidOperationException("[dap] message had no Content-Length header — not a DAP frame");
+
+        var buf = new byte[contentLength];
+        var read = 0;
+        while (read < contentLength)
+        {
+            var n = await _input.ReadAsync(buf.AsMemory(read, contentLength - read), ct).ConfigureAwait(false);
+            if (n == 0) return null; // EOF mid-body — peer closed while sending
+            read += n;
+        }
+
+        var doc = JsonDocument.Parse(buf);
+        var root = doc.RootElement;
+        return new DapIncomingMessage
+        {
+            Seq = root.TryGetProperty("seq", out var seqEl) ? seqEl.GetInt32() : 0,
+            Type = root.TryGetProperty("type", out var typeEl) ? typeEl.GetString() ?? "" : "",
+            Command = root.TryGetProperty("command", out var cmdEl) ? cmdEl.GetString() : null,
+            Arguments = root.TryGetProperty("arguments", out var argsEl) ? argsEl : null,
+            Raw = doc,
+        };
+    }
+
+    private async Task<string?> ReadHeaderLineAsync(CancellationToken ct)
+    {
+        var sb = new StringBuilder();
+        var b = new byte[1];
+        while (true)
+        {
+            var n = await _input.ReadAsync(b.AsMemory(0, 1), ct).ConfigureAwait(false);
+            if (n == 0) return sb.Length == 0 ? null : sb.ToString();
+            if (b[0] == (byte)'\r') continue;
+            if (b[0] == (byte)'\n') return sb.ToString();
+            sb.Append((char)b[0]);
+        }
+    }
+
+    /// <summary>Writes a DAP response for <paramref name="requestSeq"/>. <paramref
+    /// name="body"/> is omitted entirely (not emitted as null) when the command has
+    /// nothing to report, matching every other optional-field convention in this
+    /// codebase (ServerProtocol.cs).</summary>
+    public void WriteResponse(int requestSeq, string command, bool success, object? body = null, string? message = null)
+        => Write(new
+        {
+            seq = NextSeq(),
+            type = "response",
+            request_seq = requestSeq,
+            success,
+            command,
+            body,
+            message,
+        });
+
+    public void WriteEvent(string eventName, object? body = null)
+        => Write(new { seq = NextSeq(), type = "event", @event = eventName, body });
+
+    /// <summary>Writes a DAP request — the CLIENT side of this same class. Only used
+    /// by AlRunner.Tests' DAP client harness (a real DAP client, e.g. VS Code, drives
+    /// this side too, but al-runner itself only ever plays the adapter/server role).
+    /// Returns the seq this request was sent with, so the caller can match it against
+    /// the response's request_seq.</summary>
+    public int WriteRequest(string command, object? arguments = null)
+    {
+        var seq = NextSeq();
+        Write(new { seq, type = "request", command, arguments });
+        return seq;
+    }
+
+    private int NextSeq() => System.Threading.Interlocked.Increment(ref _seq);
+
+    private void Write(object payload)
+    {
+        var json = JsonSerializer.Serialize(payload, WriteOpts);
+        var bytes = Encoding.UTF8.GetBytes(json);
+        var header = Encoding.ASCII.GetBytes($"Content-Length: {bytes.Length}\r\n\r\n");
+        lock (_writeLock)
+        {
+            _output.Write(header, 0, header.Length);
+            _output.Write(bytes, 0, bytes.Length);
+            _output.Flush();
+        }
+    }
+
+    public void Dispose()
+    {
+        try { _input.Dispose(); } catch { /* peer may already have closed */ }
+        try { _output.Dispose(); } catch { /* peer may already have closed */ }
+    }
+}

--- a/AlRunner/Infrastructure/NclCecilRewrite.cs
+++ b/AlRunner/Infrastructure/NclCecilRewrite.cs
@@ -6659,6 +6659,52 @@ public static class NclCecilRewrite
         }
 
         // ─────────────────────────────────────────────────────────────────────
+        // NavMethodScope.StmtHit(int) / CStmtHit(int[, bool]) — --dap breakpoint hook
+        // (issue #1642). A THIRD unconditional prepend on the exact same methods the
+        // --coverage block above already hooks — same shape (`ldarg.0; ldarg.1; call`,
+        // int unboxed), same reasoning for why it's safe to add a second prepend to an
+        // already-once-rewritten method: each rewrite only ever prepends before the
+        // CURRENT first instruction, so this call runs AFTER AlCoverageTracker.OnStmtHit
+        // (inserted first, above) but still strictly BEFORE StmtHit's own body — the
+        // `statementNumber = currentStatementNumber` assignment AlCallStackCapture
+        // depends on is untouched either way.
+        //
+        // AlDapSession.OnStmtHit may BLOCK the calling thread (a breakpoint pause) —
+        // unlike AlCoverageTracker.OnStmtHit and AlValueCapture.OnExit, which are both
+        // side-effect-free beyond recording. That is intentional and safe: a normal
+        // (non-paused) StmtHit still returns immediately (Enabled gate, or the
+        // breakpoint-set lookup misses), so the added cost on every AL statement of
+        // every test — --dap or not — is one more near-zero-cost volatile read plus a
+        // dictionary lookup, not a block.
+        {
+            var nclMod = asm.MainModule;
+            const string MsType = "Microsoft.Dynamics.Nav.Runtime.NavMethodScope";
+            var hookMi = typeof(AlRunner.Infrastructure.AlDapSession).GetMethod(
+                nameof(AlRunner.Infrastructure.AlDapSession.OnStmtHit), BindingFlags.Public | BindingFlags.Static)
+                ?? throw new InvalidOperationException(
+                    "[Cecil] AlDapSession.OnStmtHit not found — runner-side rename?");
+            var hookRef = nclMod.ImportReference(hookMi);
+
+            foreach (var (name, paramCount) in new[] { ("StmtHit", 1), ("CStmtHit", 1), ("CStmtHit", 2) })
+            {
+                var target = FindNclMethod(nclMod, MsType, name, paramCount);
+                if (target.Parameters[0].ParameterType.FullName != "System.Int32")
+                    throw new InvalidOperationException(
+                        $"[Cecil] NavMethodScope.{name}/{paramCount}'s first parameter is "
+                        + $"{target.Parameters[0].ParameterType.FullName}, expected System.Int32 — Ncl shape changed; do not commit");
+
+                var body = target.Body;
+                var il = body.GetILProcessor();
+                var first = body.Instructions[0];
+                il.InsertBefore(first, il.Create(OpCodes.Ldarg_0));
+                il.InsertBefore(first, il.Create(OpCodes.Ldarg_1));
+                il.InsertBefore(first, il.Create(OpCodes.Call, hookRef));
+                if (body.MaxStackSize < 2) body.MaxStackSize = 2;
+                Console.Error.WriteLine($"[Cecil] Prepended AlDapSession.OnStmtHit to NavMethodScope.{name}/{paramCount}");
+            }
+        }
+
+        // ─────────────────────────────────────────────────────────────────────
         // ALFunctionTimingExecutionListener cluster — JmpHook→Cecil (Batch 2).
         //
         // Telemetry/diagnostic-only listener reached during AL method execution via

--- a/AlRunner/Log.cs
+++ b/AlRunner/Log.cs
@@ -40,8 +40,15 @@ public static class Log
     // same way BC-version selection is; the ~280 other `[Cecil]`-tagged per-method
     // rewrite diagnostics in NclCecilRewrite.cs are NOT retagged and stay suppressed —
     // that volume of internal detail is exactly what this filter exists to hide.
+    //
+    // `[dap]` was added for #1642: --dap's "listening on 127.0.0.1:<port>" line is the
+    // ONLY signal a DAP client (or a human at a terminal) has that the runner is ready
+    // to accept a connection — the exact same "readiness, not diagnostic" class as
+    // `[bc]`/`[reexec]` above. Caught by DapClient's own test harness timing out waiting
+    // for a line that was actually printed, just silently dropped before reaching
+    // stdout — the same failure shape the `[bc]` comment above describes.
     private static readonly Regex ComponentTag =
-        new(@"^\[(?!(?:layered|watch|provision|bc|dep|expectations|reexec)\])[A-Za-z][A-Za-z0-9._+]*\]",
+        new(@"^\[(?!(?:layered|watch|provision|bc|dep|expectations|reexec|dap)\])[A-Za-z][A-Za-z0-9._+]*\]",
             RegexOptions.Compiled);
 
     public static void Install()

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -4484,6 +4484,7 @@ static void PrintGuide(TextWriter w)
     w.WriteLine("  docs/limitations.md          the real architectural limits");
     w.WriteLine("  docs/scope.md                in-scope vs out-of-scope-by-design surfaces");
     w.WriteLine("  docs/server-mode.md          the --server JSON-RPC protocol");
+    w.WriteLine("  docs/dap-mode.md             the --dap Debug Adapter Protocol server");
     w.WriteLine("  docs/subsystems.md           subsystem map");
 }
 
@@ -4575,6 +4576,14 @@ static void PrintHelp(TextWriter w)
     w.WriteLine("                          protocol; all logs go to stderr. Used by the VS Code");
     w.WriteLine("                          extension. Commands: runTests, shutdown (execute: TODO).");
     w.WriteLine("                          See docs/server-mode.md. Mutually exclusive with --watch.");
+    w.WriteLine("  --dap [PORT]            Debug Adapter Protocol server (default port 4711):");
+    w.WriteLine("                          set AL breakpoints, pause execution, inspect locals over a");
+    w.WriteLine("                          real DAP TCP connection. Requires exactly one bundle path.");
+    w.WriteLine("                          Compiles on `launch`, pauses AL execution at StmtHit for");
+    w.WriteLine("                          any breakpointed statement once `configurationDone` starts");
+    w.WriteLine("                          the run. next/stepIn/stepOut currently behave like");
+    w.WriteLine("                          continue (real step granularity is follow-up work).");
+    w.WriteLine("                          See docs/dap-mode.md. Mutually exclusive with --server.");
     w.WriteLine("  --tdd                   Local-development flag (not for CI). A test referencing a");
     w.WriteLine("                          table field / procedure / enum value the implementing app");
     w.WriteLine("                          doesn't have yet normally drops the whole app group with a");

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -109,6 +109,27 @@ if (serverMode)
     Console.SetOut(Console.Error);
 }
 
+// ── --dap [port]: Debug Adapter Protocol server (issue #1642) — restores v1's AL
+// breakpoint debugging. Unlike --server, this speaks the DAP wire format (Content-
+// Length-framed JSON, see AlRunner/Infrastructure/DapTransport.cs) over a real TCP
+// socket, not stdin/stdout — that IS the DAP transport every DAP client (including
+// VS Code's built-in debug UI) expects, so there is no protocol reason to redirect
+// Console here the way --server does. Port defaults to 4711 (v1's default,
+// docs/archive/dap.md), overridable via a numeric argument right after --dap.
+bool dapMode = args.Contains("--dap");
+int dapPort = 4711;
+if (dapMode)
+{
+    var dapFlagIndex = Array.IndexOf(args, "--dap");
+    if (dapFlagIndex >= 0 && dapFlagIndex + 1 < args.Length && int.TryParse(args[dapFlagIndex + 1], out var parsedDapPort))
+        dapPort = parsedDapPort;
+}
+if (serverMode && dapMode)
+{
+    Console.Error.WriteLine("--server and --dap are mutually exclusive (both are long-running session modes; pick one).");
+    return 2;
+}
+
 // Output filters must be installed BEFORE any other code prints to Console.
 // Reads AL_RUNNER_VERBOSE env var by default; --verbose flag overrides below.
 AlRunner.Log.Install();
@@ -319,6 +340,11 @@ for (int i = 0; i < args.Length; i++)
     if (args[i] == "--watch") { watchMode = true; continue; }
     if (args[i] == "--tdd") { tddMode = true; continue; }
     if (args[i] == "--server") { continue; }  // handled above (serverMode); consume so it isn't "unknown"
+    if (args[i] == "--dap")  // handled above (dapMode/dapPort); consume the flag and an optional numeric port
+    {
+        if (i + 1 < args.Length && int.TryParse(args[i + 1], out _)) i++;
+        continue;
+    }
     if (args[i] == "--verbose") { AlRunner.Log.Verbose = true; continue; }
     if (args[i] == "--show-pass") { showPass = true; continue; }   // no-op (default in v2); kept for v1 back-compat
     if (args[i] == "--failures-only" || args[i] == "--quiet") { showPass = false; continue; }
@@ -1292,6 +1318,22 @@ var compilerPackageDirs = packageCacheDirs
 // same-identity bundle is picked up. Never returns to the bundle loop below.
 if (serverMode)
     return RunServerLoop(serverStdin!, serverStdout!);
+
+// ── --dap: start a Debug Adapter Protocol session and stay resident until the
+// client disconnects or the debuggee run finishes (issue #1642). Never returns to
+// the bundle loop below — same "stay resident" shape as --server above, minus the
+// warm-reload contract (a debug session runs the bundle exactly once).
+if (dapMode)
+{
+    if (bundles.Count != 1)
+    {
+        Console.Error.WriteLine(
+            $"--dap currently supports exactly one bundle path (got {bundles.Count}) — " +
+            "multi-bundle debugging is tracked as follow-up work, see issue #1642's PR.");
+        return 2;
+    }
+    return RunDapLoop(dapPort, bundles[0]);
+}
 
 // Watch loop: normal mode runs exactly one pass then breaks to the summary below.
 // Watch mode loops forever — each pass re-emits (warm) and re-runs in-process.
@@ -2844,6 +2886,731 @@ if (coverageEnabled)
 // Exit non-zero if anything failed — the default since the v2 cut, matching main/v1.
 // --no-strict-exit restores the old always-0 behaviour for JSON-only consumers.
 return strictExitCode ? computedExitCode : 0;
+    // Runs every bundle in sourcePaths in order and returns one ServerRunResult per
+    // bundle. Restores v1's "honour every sourcePaths entry" behaviour (v1 fed them
+    // all into a single compile; v2 keeps one bundle = one compile, so it runs each
+    // sequentially instead — the same shape the CLI already uses for multiple
+    // <bundle-dir> arguments). See #1658: honouring only sourcePaths[0] silently
+    // dropped the rest, returning a green empty result for an app + separate
+    // test-app request.
+    //
+    // When more than one path is given, first wire any inter-bundle dependency (the
+    // app + test-app shape --guide recommends) the same way the CLI does before its
+    // per-bundle loop: compile whichever bundle a sibling bundle depends on into a
+    // package cache the sibling can resolve against.
+    //
+    // `cancellationToken` (default: none, for the `execute` caller which has no
+    // active-run CTS) is checked BETWEEN bundles: a `cancel` landing while bundle 1
+    // of a multi-bundle runTests request is still running must stop bundle 2 from
+    // ever starting, not just stop mid-bundle-1 (that half is TestExecutor.Run's job).
+    List<ServerRunResult> RunAllBundlesForServer(string[] sourcePaths, string[]? requestPackagePaths,
+        Func<Assembly, IReadOnlyList<TestResult>> runStep,
+        System.Threading.CancellationToken cancellationToken = default)
+    {
+        // Drop the previous REQUEST's bundle-derived caches so a reloaded same-named
+        // bundle resolves the freshly-emitted Record/Codeunit types and starts with
+        // empty in-memory tables. Once per request, NOT per bundle: the CLI bucket
+        // loop never resets between bundles, so AddSourceDir accumulates across an
+        // app + test-app pair — resetting per bundle wiped the app bundle's parsed
+        // table schemas before the test bundle ran, and every Record op on an
+        // app-defined table died with "no NCLMetaTable for table N (AL source not
+        // parsed)" while the identical CLI invocation passed.
+        BcRuntime.ResetForNewBundleReload();
+
+        if (sourcePaths.Length > 1)
+        {
+            var bundleList = sourcePaths.ToList();
+            var workspaceScratch = new List<string>();
+            try
+            {
+                packageCacheDirs = RunLayeredPrePass(bundleList, packageCacheDirs, workspaceScratch);
+                packageCacheDirs = BuildSiblingSourceDeps(bundleList, packageCacheDirs, workspaceScratch);
+            }
+            catch (Exception ex)
+            {
+                // Loud per-bundle failure below (dep resolution during the per-bundle
+                // compile) already covers the "can't resolve" case; a failure in the
+                // wiring pre-pass itself must not silently fall back to unwired compiles.
+                return new List<ServerRunResult>
+                {
+                    ServerRunResult.Failure(3, "<inter-bundle-deps>", $"LAYERED-PREPASS-FAIL: {ex.Message}", new())
+                };
+            }
+        }
+
+        var results = new List<ServerRunResult>(sourcePaths.Length);
+        // #1888: open/close a phase-log bundle+app row per request bundle, mirroring
+        // the CLI loop's BeginBundle/EndBundle. Before this the server path never
+        // called into PhaseLog at all, so a --server process produced ZERO bundle/app
+        // rows regardless of whether it exited cleanly — the Stage()/AppStage() marks
+        // sprinkled through DependencyLoader/TestExecutor were silently no-ops the
+        // whole time (AddStageTo/AddApp bail out when _bundle/_app is null). Unlike
+        // the once-per-process row (written only from PhaseLog's ProcessExit hook,
+        // see WriteProcessRecord), EndBundle appends its row IMMEDIATELY on return —
+        // so as long as a request's bundle finishes before the process is later
+        // killed (true for every server test: CliServer.DisposeAsync always Kill()s
+        // AFTER the runTests round trip completes), this row survives the kill even
+        // though the process-level row still does not. bundle_index restarts at 1 per
+        // REQUEST (not per process lifetime) — server sessions have no single
+        // "argument order" the way a CLI invocation does, and nothing downstream reads
+        // it across requests.
+        var bundleIndex = 0;
+        foreach (var bundleDir in sourcePaths)
+        {
+            if (cancellationToken.IsCancellationRequested) break;
+            bundleIndex++;
+            var relBundle = Path.GetRelativePath(
+                Environment.CurrentDirectory, Path.GetFullPath(bundleDir));
+            AlRunner.Infrastructure.PhaseLog.BeginBundle(relBundle, bundleIndex);
+            var result = RunBundleForServer(bundleDir, requestPackagePaths, runStep,
+                out var emitElapsed, out var compileElapsed, out var runElapsed);
+            AlRunner.Infrastructure.PhaseLog.EndBundle(emitElapsed, compileElapsed, runElapsed);
+            results.Add(result);
+        }
+        return results;
+    }
+
+    // Compile + run one bundle, resetting bundle-derived caches first so an edited
+    // same-identity bundle is picked up (server reload contract). Mirrors the
+    // bundled-mode path of the normal run loop for a single bundle. The run step
+    // (executor.Run for runTests, OnRun dispatch for execute) is supplied by the caller.
+    ServerRunResult RunBundleForServer(string bundleDir, string[]? requestPackagePaths,
+        Func<Assembly, IReadOnlyList<TestResult>> runStep,
+        out TimeSpan emitElapsed, out TimeSpan compileElapsed, out TimeSpan runElapsed)
+    {
+        // #1888: defaulted here so every early-return path below (dep-resolve
+        // failure, empty bundle, …) satisfies definite assignment without needing
+        // its own assignment — those paths never opened an app row, so zero is the
+        // honest answer for them, not a stand-in for a real measurement.
+        emitElapsed = TimeSpan.Zero;
+        compileElapsed = TimeSpan.Zero;
+        runElapsed = TimeSpan.Zero;
+
+        // Cache reset happens once per request in RunAllBundlesForServer, not here —
+        // see the comment there for why per-bundle resetting breaks sibling bundles.
+
+        var bundleAbs = Path.GetFullPath(bundleDir);
+        var bucketRoot = FindBucketRoot(bundleAbs) ?? bundleAbs;
+
+        // Request package paths augment the server's default caches.
+        var effectivePkgDirs = (requestPackagePaths ?? Array.Empty<string>())
+            .Where(Directory.Exists)
+            .Concat(packageCacheDirs)
+            .Distinct()
+            .ToList();
+
+        IReadOnlyList<(AlRunner.AppManifest Manifest, string AppPath)> ordered =
+            Array.Empty<(AlRunner.AppManifest, string)>();
+        var appJsonPath = Path.Combine(bucketRoot, "app.json");
+        // Hoisted out of the `if (File.Exists(appJsonPath))` block below so the
+        // cross-bundle module identity dedup (#1892) can read it after this block:
+        // this bundle's OWN identity, used both to check whether an earlier bundle
+        // in this request/session already loaded the same AppId, and to register
+        // THIS bundle's freshly-compiled module under its AppId once loaded.
+        AlRunner.Infrastructure.BundleIdentity? bundleId = null;
+        if (File.Exists(appJsonPath))
+        {
+            try
+            {
+                var roots = ReadDependencies(appJsonPath);
+                var bundlePkgDirs = Directory
+                    .EnumerateDirectories(bucketRoot, ".alpackages", SearchOption.AllDirectories)
+                    .ToList();
+                var resolverDirs = bundlePkgDirs.Concat(effectivePkgDirs).Distinct().ToList();
+                var resolver = new DependencyResolver(resolverDirs);
+                ordered = resolver.Resolve(roots);
+                AlRunner.Infrastructure.PhaseLog.NoteDepsResolved(ordered.Count);
+                BcCompiler.SetResolvedDeps(ordered, resolverDirs);
+                var loaded = depLoader.LoadAll(ordered, bucketRoot);
+                AlRunner.Infrastructure.PhaseLog.NoteDepAssembliesLoaded(loaded.Count);
+                // New bundle in the server session: replace (not inherit) the
+                // install-trigger registrations, then register this bundle's deps.
+                AlRunner.InstallTriggerRunner.ResetForNewBundle();
+                AlRunner.InstallTriggerRunner.SetDependencyAssemblies(loaded);
+                BcCompiler.SetResolvedDeps(ordered, resolverDirs);
+                foreach (var (_, appPath) in ordered)
+                    AlRunner.Patches.RecordPatches.AddBcAppPath(appPath);
+                AlRunner.Patches.RecordPatches.RegisterBundleSymbolApps(bucketRoot);
+                SetBundleInfoFromAppJson(appJsonPath);
+                bundleId = AlRunner.Infrastructure.InProcessAppPackager.ReadIdentity(appJsonPath);
+                if (bundleId != null)
+                    BcCompiler.SetCurrentAppIdentity(bundleId.AppId, bundleId.Publisher, bundleId.Version);
+                else
+                    BcCompiler.SetCurrentAppIdentity(null, null, null);
+            }
+            catch (AlRunner.Infrastructure.DependencyLoadException ex)
+            {
+                return ServerRunResult.Failure(3, "<deps>", ex.Message, new());
+            }
+            catch (Exception ex)
+            {
+                return ServerRunResult.Failure(3, "<deps>", $"DEP-RESOLVE-FAIL: {ex.Message}", new());
+            }
+        }
+
+        var suites = EnumerateSuites(bundleAbs).ToList();
+        var allPaths = new List<string>();
+        // Batched via AddSourceDirs (#1833) — see the register-source-dirs comment in the
+        // non-server run loop above for why per-suite AddSourceDir calls were quadratic.
+        var dirsToRegister = new List<string>();
+        foreach (var suite in suites)
+        {
+            var s = Path.Combine(suite, "src");
+            if (Directory.Exists(s)) dirsToRegister.Add(s);
+            else if (!Directory.Exists(Path.Combine(suite, "test")))
+                dirsToRegister.Add(suite);
+            allPaths.AddRange(CollectSuitePaths(suite, bucketRoot));
+        }
+        AlRunner.Patches.RecordPatches.AddSourceDirs(dirsToRegister);
+        allPaths = allPaths.Distinct().ToList();
+        var fileHashes = ComputeServerFileHashes(allPaths);
+
+        if (allPaths.Count == 0)
+            return new ServerRunResult(Array.Empty<TestResult>(), 1, false, null, fileHashes);
+
+        var moduleName = $"V2_{Path.GetFileName(bundleAbs)}";
+
+        // ── cross-bundle module identity dedup (#1892, mirrors the CLI bundle
+        // loop's own #1683 fix) ──────────────────────────────────────────────
+        // RunAllBundlesForServer runs every sourcePaths entry through THIS method
+        // in order, in the SAME process, sharing the SAME DependencyLoader. If an
+        // earlier bundle in this request already compiled+loaded this bundle's
+        // AppId — either as ITS OWN bundle (this same method, an earlier
+        // iteration) or as a resolved dependency (DependencyLoader.LoadAll) —
+        // reuse that exact Assembly instead of emitting+compiling a second,
+        // distinct module for the same AL app identity. Without this, a sibling
+        // bundle that declares a dependency on THIS bundle's app resolves it via
+        // DependencyLoader's Tier-3 source-compile (a "Dep_..." module) BEFORE
+        // this bundle's own iteration ever runs, or vice versa — either order
+        // ends with two live modules for one AL identity, which is exactly the
+        // TargetException at NavEventSubscription's ValidateInvokeTarget #1683
+        // fixed for the CLI loop: a subscriber MethodInfo discovered from one
+        // module's Type paired with a subscriberInstance BC's dispatcher
+        // materialized from the OTHER module's Type.
+        Assembly? reusedAsm = null;
+        if (bundleId != null)
+        {
+            try
+            {
+                reusedAsm = DependencyLoader.TryGetByAppId(
+                    bundleId.AppId, bundleId.Name, bundleId.Publisher,
+                    bundleId.Version.ToString(), bundleAbs);
+            }
+            catch (AlRunner.Infrastructure.AppIdCollisionException ex)
+            {
+                // Two different apps declare the same app.json id (#1850) — never
+                // silently reuse one app's module for the other's tests.
+                return ServerRunResult.Failure(3, moduleName, $"FATAL: {ex.Message}", fileHashes);
+            }
+            if (reusedAsm != null)
+                Console.Error.WriteLine(
+                    $"  [server] {moduleName}: AppId {bundleId.AppId} already loaded earlier in " +
+                    "this request/session — reusing that module instead of recompiling " +
+                    "(see issue #1683/#1892).");
+        }
+
+        // #1888: one app row per server-mode module (this mode never groups several
+        // AL apps into one bundled compile the way the CLI's bundled mode does, so
+        // "1 of 1" is always correct here). EndApp in the finally below closes it on
+        // EVERY exit path, including the many early `return`s below — matching
+        // TestExecutor.EndApp's own idempotent-close contract.
+        AlRunner.Infrastructure.PhaseLog.BeginApp(moduleName, 1, 1);
+        try
+        {
+            // AL-output cache: HIT short-circuits Emit+Compile, like the normal loop.
+            // Skipped entirely when reusedAsm is already set (see the cross-bundle
+            // dedup check above) — nothing to cache-check, emit, or compile.
+            byte[]? assemblyBytes = null;
+            // A cross-bundle reuse (reusedAsm != null) is "cached" in the sense the
+            // caller cares about — nothing changed for THIS bundle's contribution to
+            // the request, exactly like an AL-output cache hit.
+            bool cached = reusedAsm != null;
+            string? cacheKey = null, cachePath = null, sidecarPath = null, querySidecarPath = null;
+            // See AlCacheSidecars: a query bundle without its query-symbols sidecar must MISS.
+            bool bundleDeclaresQuery = BcCompiler.BundleDeclaresQuery(allPaths);
+            if (reusedAsm == null && alCacheDir != null)
+            {
+                cacheKey = ComputeAlCacheKey(allPaths, moduleName,
+                    ordered: GetOrderedDepIds(bucketRoot, effectivePkgDirs), appRootDir: bucketRoot);
+                cachePath = Path.Combine(alCacheDir, cacheKey + ".dll");
+                sidecarPath = Path.Combine(alCacheDir, cacheKey + AlRunner.Infrastructure.AlCacheSidecars.EnumRegistrySuffix);
+                querySidecarPath = Path.Combine(alCacheDir, cacheKey + AlRunner.Infrastructure.AlCacheSidecars.QuerySymbolsSuffix);
+                if (AlRunner.Infrastructure.AlCacheSidecars.IsCompleteEntry(
+                        File.Exists(cachePath), File.Exists(sidecarPath),
+                        bundleDeclaresQuery, File.Exists(querySidecarPath)))
+                {
+                    try
+                    {
+                        var bytes = File.ReadAllBytes(cachePath);
+                        // Same short-read defence as the CLI path above (issue #1810): a torn
+                        // DLL is not a read error, so validate the PE image explicitly before
+                        // trusting it.
+                        AlRunner.Infrastructure.AlCacheSidecars.ValidateCachedAssemblyBytes(bytes, cachePath);
+                        LoadEnumRegistrySidecar(sidecarPath);
+                        if (bundleDeclaresQuery)
+                            AlRunner.Patches.RecordPatches.RegisterBundleQuerySymbolsJson(querySidecarPath);
+                        assemblyBytes = bytes;
+                        cached = true;
+                        AlRunner.Infrastructure.PhaseLog.NoteCacheHit();
+                    }
+                    catch (Exception ex)
+                    {
+                        Console.Error.WriteLine($"  [cache] hit replay failed: {ex.Message} — rebuilding");
+                        assemblyBytes = null;
+                        cached = false;
+                    }
+                }
+            }
+
+            var compileErrors = new List<string>();
+            if (reusedAsm == null && assemblyBytes == null)
+            {
+                if (alCacheDir != null)
+                    AlRunner.Infrastructure.PhaseLog.NoteCacheMiss();
+                IReadOnlyList<EmittedSource> sources;
+                IReadOnlyList<string> alDiagnostics;
+                IReadOnlyList<string> excludedObjects;
+                var et = System.Diagnostics.Stopwatch.StartNew();
+                try
+                {
+                    var emitOutput = emitter.Emit(allPaths, moduleName, bucketRoot);
+                    sources = emitOutput.Sources;
+                    alDiagnostics = emitOutput.Diagnostics;
+                    excludedObjects = emitOutput.ExcludedObjects;
+                }
+                catch (Exception ex)
+                {
+                    return ServerRunResult.Failure(3, moduleName, $"EMIT-FAIL: {ex.Message.Split('\n')[0]}", fileHashes);
+                }
+                finally
+                {
+                    et.Stop();
+                    emitElapsed = et.Elapsed;
+                    AlRunner.Infrastructure.PhaseLog.AddAppEmit(et.Elapsed);
+                }
+                // An emit-retry exclusion means one or more AL objects are NOT in the
+                // compiled module, so any tests they declare silently vanish and the
+                // request looks green. Fail loudly with the same classification the CLI's
+                // bundled-mode EMIT-EXCLUDED guard uses (.claude/rules/loud-failures.md);
+                // without this the server path ran the surviving objects and reported
+                // exitCode 0 while e.g. a whole test codeunit was missing from the run.
+                if (excludedObjects.Count > 0)
+                {
+                    var names = string.Join(", ", excludedObjects);
+                    compileErrors.Add(
+                        $"EMIT-EXCLUDED: {excludedObjects.Count} object(s) dropped from the module — " +
+                        $"tests they declare are missing: [{names}]." +
+                        (alDiagnostics.Count > 0
+                            ? " The AL diagnostics that identified them follow."
+                            : " Re-run with --verbose for the AL diagnostics that identified them."));
+                    foreach (var d in alDiagnostics) compileErrors.Add(d);
+                    return new ServerRunResult(Array.Empty<TestResult>(), 3, false,
+                        new List<CompilationErrorGroup> { new(moduleName, compileErrors) }, fileHashes);
+                }
+                if (sources.Count == 0)
+                {
+                    foreach (var d in alDiagnostics) compileErrors.Add(d);
+                    if (compileErrors.Count == 0) compileErrors.Add("EMIT-ZERO: 0 sources emitted");
+                    return new ServerRunResult(Array.Empty<TestResult>(), 3, false,
+                        new List<CompilationErrorGroup> { new(moduleName, compileErrors) }, fileHashes);
+                }
+                var ct = System.Diagnostics.Stopwatch.StartNew();
+                var compile = assembler.Compile(moduleName, sources);
+                ct.Stop();
+                compileElapsed = ct.Elapsed;
+                AlRunner.Infrastructure.PhaseLog.AddAppCompile(ct.Elapsed);
+                if (!compile.Success)
+                {
+                    compileErrors.AddRange(compile.Errors);
+                    compileErrors.AddRange(alDiagnostics);
+                    return new ServerRunResult(Array.Empty<TestResult>(), 3, false,
+                        new List<CompilationErrorGroup> { new(moduleName, compileErrors) }, fileHashes);
+                }
+                assemblyBytes = compile.AssemblyBytes;
+                if (cachePath != null && assemblyBytes != null)
+                {
+                    try
+                    {
+                        // Same atomic, sidecars-first-DLL-last publish as the CLI path above
+                        // (issue #1810) — see the comment there for why the ordering matters.
+                        AlRunner.Infrastructure.AlCacheWriter.AtomicPublish(
+                            sidecarPath!, tmp => SaveEnumRegistrySidecar(tmp));
+                        var qsrc = BcCompiler.LastBundleQuerySymbolsPath;
+                        if (qsrc != null && File.Exists(qsrc))
+                            AlRunner.Infrastructure.AlCacheWriter.AtomicPublish(
+                                querySidecarPath!, tmp => File.Copy(qsrc, tmp, overwrite: true));
+                        AlRunner.Infrastructure.AlCacheWriter.AtomicPublish(
+                            cachePath, tmp => File.WriteAllBytes(tmp, assemblyBytes));
+                    }
+                    catch (Exception ex) { Console.Error.WriteLine($"  [cache] write failed: {ex.Message}"); }
+                }
+            }
+
+            Assembly asm;
+            if (reusedAsm != null)
+            {
+                // See the cross-bundle module identity dedup comment above: this
+                // bundle's AppId was already loaded earlier in this request/session,
+                // so run with that exact Assembly instead of Assembly.Load-ing a
+                // second, distinct module for the same AL identity.
+                asm = reusedAsm;
+            }
+            else
+            {
+                if (assemblyBytes == null)
+                    return ServerRunResult.Failure(2, moduleName, "no assembly produced", fileHashes);
+                asm = Assembly.Load(assemblyBytes);
+                // Register this freshly-loaded module under its AppId so a LATER
+                // bundle in this request/session that resolves the same AppId —
+                // either as its own bundle (this same method, a later iteration) or
+                // as a dependency (DependencyLoader.LoadAll) — reuses this exact
+                // Assembly instead of re-emitting/re-compiling a second module for
+                // the same AL identity (#1892, mirrors the CLI loop's #1683 fix).
+                if (bundleId != null)
+                {
+                    try
+                    {
+                        DependencyLoader.RegisterLoaded(
+                            bundleId.AppId, asm, bundleId.Name, bundleId.Publisher,
+                            bundleId.Version.ToString(), bundleAbs);
+                    }
+                    catch (AlRunner.Infrastructure.AppIdCollisionException ex)
+                    {
+                        // Same defence as the TryGetByAppId check above, for the (in
+                        // this process, one request at a time) race window between
+                        // that check and this registration — see loud-failures.md.
+                        return ServerRunResult.Failure(3, moduleName, $"FATAL: {ex.Message}", fileHashes);
+                    }
+                }
+            }
+
+            IReadOnlyList<TestResult> tests;
+            var rt = System.Diagnostics.Stopwatch.StartNew();
+            try
+            {
+                BcRuntime.SetTestAssembly(asm);
+                BcRuntime.RegisterTestAssemblyInfo(asm);
+                BcRuntime.OosHooksActive = true;
+                tests = runStep(asm);
+            }
+            catch (Exception ex)
+            {
+                return ServerRunResult.Failure(2, moduleName, $"EXEC-FAIL: {ex.Message.Split('\n')[0]}", fileHashes);
+            }
+            finally
+            {
+                BcRuntime.OosHooksActive = false;
+                rt.Stop();
+                runElapsed = rt.Elapsed;
+                AlRunner.Infrastructure.PhaseLog.AddAppRun(rt.Elapsed);
+            }
+
+            int exit = 0;
+            if (tests.Any(t => t.Outcome == TestOutcome.Fail || t.Outcome == TestOutcome.Error)) exit = 1;
+            return new ServerRunResult(tests, exit, cached, null, fileHashes);
+        }
+        finally
+        {
+            AlRunner.Infrastructure.PhaseLog.EndApp();
+        }
+    }
+
+
+// ── --dap loop (issue #1642) ─────────────────────────────────────────────────────
+// Non-static so it captures the warm pipeline objects (executor et al.) and
+// RunAllBundlesForServer, same reasons as RunServerLoop below. Unlike --server this
+// is not a warm-reload daemon: one TCP client, one bundle, one run, then exit — a
+// debug session is inherently single-shot (VS Code starts al-runner, debugs,
+// disconnects, the process goes away).
+//
+// Session shape (see docs/archive/dap.md for the mechanism this restores, and
+// AlDapSession's file header for why pausing at StmtHit(N) — unlike
+// --capture-values, #1640 — needs no Exit()-style redesign):
+//   initialize     -> capabilities, then an `initialized` event
+//   launch/attach  -> compiles the bundle SYNCHRONOUSLY (blocks the response until
+//                     compiledTcs resolves or the whole run finishes without ever
+//                     reaching runStep, i.e. a compile failure) so setBreakpoints
+//                     right after has real statement indices to resolve against
+//   setBreakpoints -> DapBreakpointResolver against the now-loaded scope types;
+//                     REPLACES this source's previous set (DAP contract)
+//   configurationDone -> releases the run-start gate; AL execution begins
+//   (AlDapSession.Stopped fires on the AL thread when a breakpoint hits; this loop
+//    pushes the "stopped" event the moment it fires — see the subscription below)
+//   threads/stackTrace/scopes/variables -> read AlDapSession.PausedScope while paused
+//   continue/next/stepIn/stepOut -> AlDapSession.Continue() (all four alike — see the
+//    PR description for why real step granularity is explicit follow-up scope)
+//   disconnect/terminate -> AlDapSession.Detach() (never leaves the AL thread stuck)
+int RunDapLoop(int port, string bundleDir)
+{
+    var listener = new System.Net.Sockets.TcpListener(System.Net.IPAddress.Loopback, port);
+    listener.Start();
+    Console.WriteLine($"[dap] listening on 127.0.0.1:{port} — waiting for a debug client to connect...");
+    using var tcpClient = listener.AcceptTcpClient();
+    listener.Stop();
+    Console.WriteLine("[dap] client connected.");
+
+    using var transport = new AlRunner.Infrastructure.DapTransport(tcpClient.GetStream(), tcpClient.GetStream());
+    AlRunner.Infrastructure.AlDapSession.Reset();
+
+    Dictionary<(string Label, int Id), string> sourceMap = new();
+    var lastFrames = new List<AlRunner.Infrastructure.AlDapFrame>();
+
+    var compiledTcs = new System.Threading.Tasks.TaskCompletionSource<Assembly>(
+        System.Threading.Tasks.TaskCreationOptions.RunContinuationsAsynchronously);
+    var configurationDoneGate = new System.Threading.SemaphoreSlim(0, 1);
+    var cts = new System.Threading.CancellationTokenSource();
+
+    Func<Assembly, IReadOnlyList<TestResult>> dapRunStep = asm =>
+    {
+        compiledTcs.TrySetResult(asm);
+        configurationDoneGate.Wait(cts.Token);
+        return executor.Run(asm, t => Console.WriteLine($"[dap] {t.Codeunit}.{t.Method}: {t.Outcome}"), cts.Token);
+    };
+
+    var bundleRunTask = System.Threading.Tasks.Task.Run(
+        () => RunAllBundlesForServer(new[] { bundleDir }, null, dapRunStep, cts.Token));
+
+    int exitCode = 0;
+    bool terminatedSent = false;
+    void SendTerminatedOnce()
+    {
+        if (terminatedSent) return;
+        terminatedSent = true;
+        transport.WriteEvent("terminated");
+        transport.WriteEvent("exited", new { exitCode });
+    }
+    // Reports the run's outcome the moment it finishes, on WHATEVER thread that is —
+    // Stopped's handler below writes to `transport` from the AL execution thread
+    // too, and DapTransport's write lock is what keeps those from interleaving.
+    _ = bundleRunTask.ContinueWith(t =>
+    {
+        if (t.IsFaulted)
+        {
+            exitCode = 2;
+        }
+        else
+        {
+            var runs = t.Result;
+            exitCode = runs.Count > 0 ? runs.Max(r => r.ExitCode) : 0;
+        }
+        SendTerminatedOnce();
+    }, System.Threading.Tasks.TaskScheduler.Default);
+
+    // Pushed synchronously on the AL EXECUTION thread by AlDapSession.OnStmtHit,
+    // right before it blocks — see that method's doc comment. Must not throw.
+    AlRunner.Infrastructure.AlDapSession.Stopped += (scope, stmt) =>
+    {
+        try
+        {
+            lastFrames = AlRunner.Infrastructure.AlDapStackWalker.Walk(scope, stmt, sourceMap);
+            var line = lastFrames.Count > 0 ? lastFrames[0].Line : 0;
+            transport.WriteEvent("stopped", new
+            {
+                reason = "breakpoint",
+                threadId = 1,
+                allThreadsStopped = true,
+                line,
+            });
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"[dap] failed to report a breakpoint stop: {ex.Message}");
+        }
+    };
+
+    try
+    {
+        while (true)
+        {
+            AlRunner.Infrastructure.DapIncomingMessage? msg;
+            try { msg = transport.ReadMessageAsync().GetAwaiter().GetResult(); }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"[dap] transport error: {ex.Message}");
+                break;
+            }
+            if (msg == null) break; // client closed the connection
+
+            var command = msg.Command ?? "";
+            var args = msg.Arguments;
+            try
+            {
+                switch (command)
+                {
+                    case "initialize":
+                        transport.WriteResponse(msg.Seq, command, true, new
+                        {
+                            supportsConfigurationDoneRequest = true,
+                        });
+                        transport.WriteEvent("initialized");
+                        break;
+
+                    case "launch":
+                    case "attach":
+                    {
+                        var winner = System.Threading.Tasks.Task.WhenAny(compiledTcs.Task, bundleRunTask)
+                            .GetAwaiter().GetResult();
+                        if (!ReferenceEquals(winner, compiledTcs.Task))
+                        {
+                            // The run finished (or failed) before ever reaching dapRunStep —
+                            // a compile failure. Report it on the launch response rather than
+                            // silently proceeding into a session that will never run anything.
+                            var runs = bundleRunTask.Result;
+                            var errMsg = runs
+                                .SelectMany(r => r.CompileErrors ?? Array.Empty<CompilationErrorGroup>())
+                                .SelectMany(g => g.Errors)
+                                .FirstOrDefault() ?? "compile failed (no diagnostic captured)";
+                            transport.WriteResponse(msg.Seq, command, false, message: errMsg);
+                            break;
+                        }
+                        sourceMap = AlRunner.Infrastructure.AlCoverageSourceMap.Build(
+                            new[] { bundleDir }, relativeTo: null);
+                        transport.WriteResponse(msg.Seq, command, true);
+                        break;
+                    }
+
+                    case "setBreakpoints":
+                    {
+                        if (args == null || !args.Value.TryGetProperty("source", out var srcEl) ||
+                            !srcEl.TryGetProperty("path", out var pathEl) || pathEl.GetString() is not string srcPath)
+                        {
+                            transport.WriteResponse(msg.Seq, command, false, message: "setBreakpoints: missing source.path");
+                            break;
+                        }
+                        var lines = new List<int>();
+                        if (args.Value.TryGetProperty("breakpoints", out var bpsEl) && bpsEl.ValueKind == System.Text.Json.JsonValueKind.Array)
+                            foreach (var bp in bpsEl.EnumerateArray())
+                                if (bp.TryGetProperty("line", out var lineEl)) lines.Add(lineEl.GetInt32());
+                        else if (args.Value.TryGetProperty("lines", out var legacyLinesEl) && legacyLinesEl.ValueKind == System.Text.Json.JsonValueKind.Array)
+                            foreach (var l in legacyLinesEl.EnumerateArray()) lines.Add(l.GetInt32());
+
+                        var requests = lines.Select(l => new AlRunner.Infrastructure.DapBreakpointRequest(srcPath, l)).ToList();
+                        var resolved = AlRunner.Infrastructure.DapBreakpointResolver.Resolve(requests, sourceMap);
+
+                        var fullSrcPath = Path.GetFullPath(srcPath);
+                        // Replace (not accumulate) — DAP's setBreakpoints contract: this
+                        // request is the COMPLETE set for `source` from now on.
+                        foreach (var rb in resolved)
+                            if (rb.ScopeType != null) AlRunner.Infrastructure.AlDapSession.ClearBreakpoints(rb.ScopeType);
+                        foreach (var rb in resolved)
+                            if (rb.Verified && rb.ScopeType != null)
+                                AlRunner.Infrastructure.AlDapSession.SetBreakpoint(rb.ScopeType, rb.StatementIndex);
+
+                        transport.WriteResponse(msg.Seq, command, true, new
+                        {
+                            breakpoints = resolved.Select((rb, idx) => new
+                            {
+                                id = idx,
+                                verified = rb.Verified,
+                                line = rb.Verified ? rb.ActualLine : rb.RequestedLine,
+                            }),
+                        });
+                        break;
+                    }
+
+                    case "configurationDone":
+                        transport.WriteResponse(msg.Seq, command, true);
+                        AlRunner.Infrastructure.AlDapSession.Enabled = true;
+                        configurationDoneGate.Release();
+                        break;
+
+                    case "threads":
+                        transport.WriteResponse(msg.Seq, command, true, new
+                        {
+                            threads = new[] { new { id = 1, name = "AL Test Thread" } },
+                        });
+                        break;
+
+                    case "stackTrace":
+                        if (!AlRunner.Infrastructure.AlDapSession.IsPaused)
+                        {
+                            transport.WriteResponse(msg.Seq, command, false, message: "not stopped");
+                            break;
+                        }
+                        transport.WriteResponse(msg.Seq, command, true, new
+                        {
+                            stackFrames = lastFrames.Select(f => new
+                            {
+                                id = f.Id,
+                                name = f.ScopeName,
+                                source = f.SourcePath != null ? new { path = f.SourcePath, name = Path.GetFileName(f.SourcePath) } : null,
+                                line = f.Line,
+                                column = 1,
+                            }),
+                            totalFrames = lastFrames.Count,
+                        });
+                        break;
+
+                    case "scopes":
+                    {
+                        var frameId = args?.GetProperty("frameId").GetInt32() ?? -1;
+                        transport.WriteResponse(msg.Seq, command, true, new
+                        {
+                            scopes = new[] { new { name = "Locals", variablesReference = frameId, expensive = false } },
+                        });
+                        break;
+                    }
+
+                    case "variables":
+                    {
+                        var varsRef = args?.GetProperty("variablesReference").GetInt32() ?? -1;
+                        var frame = lastFrames.FirstOrDefault(f => f.Id == varsRef);
+                        if (frame.Scope == null)
+                        {
+                            transport.WriteResponse(msg.Seq, command, false, message: $"unknown variablesReference {varsRef}");
+                            break;
+                        }
+                        var locals = AlRunner.Infrastructure.AlScopeInspector.ReadLocals(frame.Scope);
+                        transport.WriteResponse(msg.Seq, command, true, new
+                        {
+                            variables = locals.Select(v => new
+                            {
+                                name = v.Name,
+                                value = v.Readable ? System.Text.Json.JsonSerializer.Serialize(v.Value) : (string)v.Value!,
+                                variablesReference = 0,
+                            }),
+                        });
+                        break;
+                    }
+
+                    case "continue":
+                    case "next":
+                    case "stepIn":
+                    case "stepOut":
+                    case "pause":
+                        AlRunner.Infrastructure.AlDapSession.Continue();
+                        transport.WriteResponse(msg.Seq, command, true,
+                            command == "continue" ? new { allThreadsContinued = true } : null);
+                        break;
+
+                    case "disconnect":
+                    case "terminate":
+                        AlRunner.Infrastructure.AlDapSession.Enabled = false;
+                        AlRunner.Infrastructure.AlDapSession.Detach();
+                        cts.Cancel();
+                        transport.WriteResponse(msg.Seq, command, true);
+                        SendTerminatedOnce();
+                        return exitCode;
+
+                    default:
+                        transport.WriteResponse(msg.Seq, command, false, message: $"unsupported command: {command}");
+                        break;
+                }
+            }
+            catch (Exception ex)
+            {
+                transport.WriteResponse(msg.Seq, command, false, message: ex.Message);
+            }
+        }
+    }
+    finally
+    {
+        AlRunner.Infrastructure.AlDapSession.Enabled = false;
+        AlRunner.Infrastructure.AlDapSession.Detach();
+        cts.Cancel();
+    }
+    return exitCode;
+}
 
 // ── --server loop ──────────────────────────────────────────────────────────────
 // Non-static so it captures the warm pipeline objects (emitter/assembler/executor/
@@ -3333,434 +4100,6 @@ int RunServerLoop(System.IO.TextReader input, System.IO.TextWriter output)
         }
     }
 
-    // Runs every bundle in sourcePaths in order and returns one ServerRunResult per
-    // bundle. Restores v1's "honour every sourcePaths entry" behaviour (v1 fed them
-    // all into a single compile; v2 keeps one bundle = one compile, so it runs each
-    // sequentially instead — the same shape the CLI already uses for multiple
-    // <bundle-dir> arguments). See #1658: honouring only sourcePaths[0] silently
-    // dropped the rest, returning a green empty result for an app + separate
-    // test-app request.
-    //
-    // When more than one path is given, first wire any inter-bundle dependency (the
-    // app + test-app shape --guide recommends) the same way the CLI does before its
-    // per-bundle loop: compile whichever bundle a sibling bundle depends on into a
-    // package cache the sibling can resolve against.
-    //
-    // `cancellationToken` (default: none, for the `execute` caller which has no
-    // active-run CTS) is checked BETWEEN bundles: a `cancel` landing while bundle 1
-    // of a multi-bundle runTests request is still running must stop bundle 2 from
-    // ever starting, not just stop mid-bundle-1 (that half is TestExecutor.Run's job).
-    List<ServerRunResult> RunAllBundlesForServer(string[] sourcePaths, string[]? requestPackagePaths,
-        Func<Assembly, IReadOnlyList<TestResult>> runStep,
-        System.Threading.CancellationToken cancellationToken = default)
-    {
-        // Drop the previous REQUEST's bundle-derived caches so a reloaded same-named
-        // bundle resolves the freshly-emitted Record/Codeunit types and starts with
-        // empty in-memory tables. Once per request, NOT per bundle: the CLI bucket
-        // loop never resets between bundles, so AddSourceDir accumulates across an
-        // app + test-app pair — resetting per bundle wiped the app bundle's parsed
-        // table schemas before the test bundle ran, and every Record op on an
-        // app-defined table died with "no NCLMetaTable for table N (AL source not
-        // parsed)" while the identical CLI invocation passed.
-        BcRuntime.ResetForNewBundleReload();
-
-        if (sourcePaths.Length > 1)
-        {
-            var bundleList = sourcePaths.ToList();
-            var workspaceScratch = new List<string>();
-            try
-            {
-                packageCacheDirs = RunLayeredPrePass(bundleList, packageCacheDirs, workspaceScratch);
-                packageCacheDirs = BuildSiblingSourceDeps(bundleList, packageCacheDirs, workspaceScratch);
-            }
-            catch (Exception ex)
-            {
-                // Loud per-bundle failure below (dep resolution during the per-bundle
-                // compile) already covers the "can't resolve" case; a failure in the
-                // wiring pre-pass itself must not silently fall back to unwired compiles.
-                return new List<ServerRunResult>
-                {
-                    ServerRunResult.Failure(3, "<inter-bundle-deps>", $"LAYERED-PREPASS-FAIL: {ex.Message}", new())
-                };
-            }
-        }
-
-        var results = new List<ServerRunResult>(sourcePaths.Length);
-        // #1888: open/close a phase-log bundle+app row per request bundle, mirroring
-        // the CLI loop's BeginBundle/EndBundle. Before this the server path never
-        // called into PhaseLog at all, so a --server process produced ZERO bundle/app
-        // rows regardless of whether it exited cleanly — the Stage()/AppStage() marks
-        // sprinkled through DependencyLoader/TestExecutor were silently no-ops the
-        // whole time (AddStageTo/AddApp bail out when _bundle/_app is null). Unlike
-        // the once-per-process row (written only from PhaseLog's ProcessExit hook,
-        // see WriteProcessRecord), EndBundle appends its row IMMEDIATELY on return —
-        // so as long as a request's bundle finishes before the process is later
-        // killed (true for every server test: CliServer.DisposeAsync always Kill()s
-        // AFTER the runTests round trip completes), this row survives the kill even
-        // though the process-level row still does not. bundle_index restarts at 1 per
-        // REQUEST (not per process lifetime) — server sessions have no single
-        // "argument order" the way a CLI invocation does, and nothing downstream reads
-        // it across requests.
-        var bundleIndex = 0;
-        foreach (var bundleDir in sourcePaths)
-        {
-            if (cancellationToken.IsCancellationRequested) break;
-            bundleIndex++;
-            var relBundle = Path.GetRelativePath(
-                Environment.CurrentDirectory, Path.GetFullPath(bundleDir));
-            AlRunner.Infrastructure.PhaseLog.BeginBundle(relBundle, bundleIndex);
-            var result = RunBundleForServer(bundleDir, requestPackagePaths, runStep,
-                out var emitElapsed, out var compileElapsed, out var runElapsed);
-            AlRunner.Infrastructure.PhaseLog.EndBundle(emitElapsed, compileElapsed, runElapsed);
-            results.Add(result);
-        }
-        return results;
-    }
-
-    // Compile + run one bundle, resetting bundle-derived caches first so an edited
-    // same-identity bundle is picked up (server reload contract). Mirrors the
-    // bundled-mode path of the normal run loop for a single bundle. The run step
-    // (executor.Run for runTests, OnRun dispatch for execute) is supplied by the caller.
-    ServerRunResult RunBundleForServer(string bundleDir, string[]? requestPackagePaths,
-        Func<Assembly, IReadOnlyList<TestResult>> runStep,
-        out TimeSpan emitElapsed, out TimeSpan compileElapsed, out TimeSpan runElapsed)
-    {
-        // #1888: defaulted here so every early-return path below (dep-resolve
-        // failure, empty bundle, …) satisfies definite assignment without needing
-        // its own assignment — those paths never opened an app row, so zero is the
-        // honest answer for them, not a stand-in for a real measurement.
-        emitElapsed = TimeSpan.Zero;
-        compileElapsed = TimeSpan.Zero;
-        runElapsed = TimeSpan.Zero;
-
-        // Cache reset happens once per request in RunAllBundlesForServer, not here —
-        // see the comment there for why per-bundle resetting breaks sibling bundles.
-
-        var bundleAbs = Path.GetFullPath(bundleDir);
-        var bucketRoot = FindBucketRoot(bundleAbs) ?? bundleAbs;
-
-        // Request package paths augment the server's default caches.
-        var effectivePkgDirs = (requestPackagePaths ?? Array.Empty<string>())
-            .Where(Directory.Exists)
-            .Concat(packageCacheDirs)
-            .Distinct()
-            .ToList();
-
-        IReadOnlyList<(AlRunner.AppManifest Manifest, string AppPath)> ordered =
-            Array.Empty<(AlRunner.AppManifest, string)>();
-        var appJsonPath = Path.Combine(bucketRoot, "app.json");
-        // Hoisted out of the `if (File.Exists(appJsonPath))` block below so the
-        // cross-bundle module identity dedup (#1892) can read it after this block:
-        // this bundle's OWN identity, used both to check whether an earlier bundle
-        // in this request/session already loaded the same AppId, and to register
-        // THIS bundle's freshly-compiled module under its AppId once loaded.
-        AlRunner.Infrastructure.BundleIdentity? bundleId = null;
-        if (File.Exists(appJsonPath))
-        {
-            try
-            {
-                var roots = ReadDependencies(appJsonPath);
-                var bundlePkgDirs = Directory
-                    .EnumerateDirectories(bucketRoot, ".alpackages", SearchOption.AllDirectories)
-                    .ToList();
-                var resolverDirs = bundlePkgDirs.Concat(effectivePkgDirs).Distinct().ToList();
-                var resolver = new DependencyResolver(resolverDirs);
-                ordered = resolver.Resolve(roots);
-                AlRunner.Infrastructure.PhaseLog.NoteDepsResolved(ordered.Count);
-                BcCompiler.SetResolvedDeps(ordered, resolverDirs);
-                var loaded = depLoader.LoadAll(ordered, bucketRoot);
-                AlRunner.Infrastructure.PhaseLog.NoteDepAssembliesLoaded(loaded.Count);
-                // New bundle in the server session: replace (not inherit) the
-                // install-trigger registrations, then register this bundle's deps.
-                AlRunner.InstallTriggerRunner.ResetForNewBundle();
-                AlRunner.InstallTriggerRunner.SetDependencyAssemblies(loaded);
-                BcCompiler.SetResolvedDeps(ordered, resolverDirs);
-                foreach (var (_, appPath) in ordered)
-                    AlRunner.Patches.RecordPatches.AddBcAppPath(appPath);
-                AlRunner.Patches.RecordPatches.RegisterBundleSymbolApps(bucketRoot);
-                SetBundleInfoFromAppJson(appJsonPath);
-                bundleId = AlRunner.Infrastructure.InProcessAppPackager.ReadIdentity(appJsonPath);
-                if (bundleId != null)
-                    BcCompiler.SetCurrentAppIdentity(bundleId.AppId, bundleId.Publisher, bundleId.Version);
-                else
-                    BcCompiler.SetCurrentAppIdentity(null, null, null);
-            }
-            catch (AlRunner.Infrastructure.DependencyLoadException ex)
-            {
-                return ServerRunResult.Failure(3, "<deps>", ex.Message, new());
-            }
-            catch (Exception ex)
-            {
-                return ServerRunResult.Failure(3, "<deps>", $"DEP-RESOLVE-FAIL: {ex.Message}", new());
-            }
-        }
-
-        var suites = EnumerateSuites(bundleAbs).ToList();
-        var allPaths = new List<string>();
-        // Batched via AddSourceDirs (#1833) — see the register-source-dirs comment in the
-        // non-server run loop above for why per-suite AddSourceDir calls were quadratic.
-        var dirsToRegister = new List<string>();
-        foreach (var suite in suites)
-        {
-            var s = Path.Combine(suite, "src");
-            if (Directory.Exists(s)) dirsToRegister.Add(s);
-            else if (!Directory.Exists(Path.Combine(suite, "test")))
-                dirsToRegister.Add(suite);
-            allPaths.AddRange(CollectSuitePaths(suite, bucketRoot));
-        }
-        AlRunner.Patches.RecordPatches.AddSourceDirs(dirsToRegister);
-        allPaths = allPaths.Distinct().ToList();
-        var fileHashes = ComputeServerFileHashes(allPaths);
-
-        if (allPaths.Count == 0)
-            return new ServerRunResult(Array.Empty<TestResult>(), 1, false, null, fileHashes);
-
-        var moduleName = $"V2_{Path.GetFileName(bundleAbs)}";
-
-        // ── cross-bundle module identity dedup (#1892, mirrors the CLI bundle
-        // loop's own #1683 fix) ──────────────────────────────────────────────
-        // RunAllBundlesForServer runs every sourcePaths entry through THIS method
-        // in order, in the SAME process, sharing the SAME DependencyLoader. If an
-        // earlier bundle in this request already compiled+loaded this bundle's
-        // AppId — either as ITS OWN bundle (this same method, an earlier
-        // iteration) or as a resolved dependency (DependencyLoader.LoadAll) —
-        // reuse that exact Assembly instead of emitting+compiling a second,
-        // distinct module for the same AL app identity. Without this, a sibling
-        // bundle that declares a dependency on THIS bundle's app resolves it via
-        // DependencyLoader's Tier-3 source-compile (a "Dep_..." module) BEFORE
-        // this bundle's own iteration ever runs, or vice versa — either order
-        // ends with two live modules for one AL identity, which is exactly the
-        // TargetException at NavEventSubscription's ValidateInvokeTarget #1683
-        // fixed for the CLI loop: a subscriber MethodInfo discovered from one
-        // module's Type paired with a subscriberInstance BC's dispatcher
-        // materialized from the OTHER module's Type.
-        Assembly? reusedAsm = null;
-        if (bundleId != null)
-        {
-            try
-            {
-                reusedAsm = DependencyLoader.TryGetByAppId(
-                    bundleId.AppId, bundleId.Name, bundleId.Publisher,
-                    bundleId.Version.ToString(), bundleAbs);
-            }
-            catch (AlRunner.Infrastructure.AppIdCollisionException ex)
-            {
-                // Two different apps declare the same app.json id (#1850) — never
-                // silently reuse one app's module for the other's tests.
-                return ServerRunResult.Failure(3, moduleName, $"FATAL: {ex.Message}", fileHashes);
-            }
-            if (reusedAsm != null)
-                Console.Error.WriteLine(
-                    $"  [server] {moduleName}: AppId {bundleId.AppId} already loaded earlier in " +
-                    "this request/session — reusing that module instead of recompiling " +
-                    "(see issue #1683/#1892).");
-        }
-
-        // #1888: one app row per server-mode module (this mode never groups several
-        // AL apps into one bundled compile the way the CLI's bundled mode does, so
-        // "1 of 1" is always correct here). EndApp in the finally below closes it on
-        // EVERY exit path, including the many early `return`s below — matching
-        // TestExecutor.EndApp's own idempotent-close contract.
-        AlRunner.Infrastructure.PhaseLog.BeginApp(moduleName, 1, 1);
-        try
-        {
-            // AL-output cache: HIT short-circuits Emit+Compile, like the normal loop.
-            // Skipped entirely when reusedAsm is already set (see the cross-bundle
-            // dedup check above) — nothing to cache-check, emit, or compile.
-            byte[]? assemblyBytes = null;
-            // A cross-bundle reuse (reusedAsm != null) is "cached" in the sense the
-            // caller cares about — nothing changed for THIS bundle's contribution to
-            // the request, exactly like an AL-output cache hit.
-            bool cached = reusedAsm != null;
-            string? cacheKey = null, cachePath = null, sidecarPath = null, querySidecarPath = null;
-            // See AlCacheSidecars: a query bundle without its query-symbols sidecar must MISS.
-            bool bundleDeclaresQuery = BcCompiler.BundleDeclaresQuery(allPaths);
-            if (reusedAsm == null && alCacheDir != null)
-            {
-                cacheKey = ComputeAlCacheKey(allPaths, moduleName,
-                    ordered: GetOrderedDepIds(bucketRoot, effectivePkgDirs), appRootDir: bucketRoot);
-                cachePath = Path.Combine(alCacheDir, cacheKey + ".dll");
-                sidecarPath = Path.Combine(alCacheDir, cacheKey + AlRunner.Infrastructure.AlCacheSidecars.EnumRegistrySuffix);
-                querySidecarPath = Path.Combine(alCacheDir, cacheKey + AlRunner.Infrastructure.AlCacheSidecars.QuerySymbolsSuffix);
-                if (AlRunner.Infrastructure.AlCacheSidecars.IsCompleteEntry(
-                        File.Exists(cachePath), File.Exists(sidecarPath),
-                        bundleDeclaresQuery, File.Exists(querySidecarPath)))
-                {
-                    try
-                    {
-                        var bytes = File.ReadAllBytes(cachePath);
-                        // Same short-read defence as the CLI path above (issue #1810): a torn
-                        // DLL is not a read error, so validate the PE image explicitly before
-                        // trusting it.
-                        AlRunner.Infrastructure.AlCacheSidecars.ValidateCachedAssemblyBytes(bytes, cachePath);
-                        LoadEnumRegistrySidecar(sidecarPath);
-                        if (bundleDeclaresQuery)
-                            AlRunner.Patches.RecordPatches.RegisterBundleQuerySymbolsJson(querySidecarPath);
-                        assemblyBytes = bytes;
-                        cached = true;
-                        AlRunner.Infrastructure.PhaseLog.NoteCacheHit();
-                    }
-                    catch (Exception ex)
-                    {
-                        Console.Error.WriteLine($"  [cache] hit replay failed: {ex.Message} — rebuilding");
-                        assemblyBytes = null;
-                        cached = false;
-                    }
-                }
-            }
-
-            var compileErrors = new List<string>();
-            if (reusedAsm == null && assemblyBytes == null)
-            {
-                if (alCacheDir != null)
-                    AlRunner.Infrastructure.PhaseLog.NoteCacheMiss();
-                IReadOnlyList<EmittedSource> sources;
-                IReadOnlyList<string> alDiagnostics;
-                IReadOnlyList<string> excludedObjects;
-                var et = System.Diagnostics.Stopwatch.StartNew();
-                try
-                {
-                    var emitOutput = emitter.Emit(allPaths, moduleName, bucketRoot);
-                    sources = emitOutput.Sources;
-                    alDiagnostics = emitOutput.Diagnostics;
-                    excludedObjects = emitOutput.ExcludedObjects;
-                }
-                catch (Exception ex)
-                {
-                    return ServerRunResult.Failure(3, moduleName, $"EMIT-FAIL: {ex.Message.Split('\n')[0]}", fileHashes);
-                }
-                finally
-                {
-                    et.Stop();
-                    emitElapsed = et.Elapsed;
-                    AlRunner.Infrastructure.PhaseLog.AddAppEmit(et.Elapsed);
-                }
-                // An emit-retry exclusion means one or more AL objects are NOT in the
-                // compiled module, so any tests they declare silently vanish and the
-                // request looks green. Fail loudly with the same classification the CLI's
-                // bundled-mode EMIT-EXCLUDED guard uses (.claude/rules/loud-failures.md);
-                // without this the server path ran the surviving objects and reported
-                // exitCode 0 while e.g. a whole test codeunit was missing from the run.
-                if (excludedObjects.Count > 0)
-                {
-                    var names = string.Join(", ", excludedObjects);
-                    compileErrors.Add(
-                        $"EMIT-EXCLUDED: {excludedObjects.Count} object(s) dropped from the module — " +
-                        $"tests they declare are missing: [{names}]." +
-                        (alDiagnostics.Count > 0
-                            ? " The AL diagnostics that identified them follow."
-                            : " Re-run with --verbose for the AL diagnostics that identified them."));
-                    foreach (var d in alDiagnostics) compileErrors.Add(d);
-                    return new ServerRunResult(Array.Empty<TestResult>(), 3, false,
-                        new List<CompilationErrorGroup> { new(moduleName, compileErrors) }, fileHashes);
-                }
-                if (sources.Count == 0)
-                {
-                    foreach (var d in alDiagnostics) compileErrors.Add(d);
-                    if (compileErrors.Count == 0) compileErrors.Add("EMIT-ZERO: 0 sources emitted");
-                    return new ServerRunResult(Array.Empty<TestResult>(), 3, false,
-                        new List<CompilationErrorGroup> { new(moduleName, compileErrors) }, fileHashes);
-                }
-                var ct = System.Diagnostics.Stopwatch.StartNew();
-                var compile = assembler.Compile(moduleName, sources);
-                ct.Stop();
-                compileElapsed = ct.Elapsed;
-                AlRunner.Infrastructure.PhaseLog.AddAppCompile(ct.Elapsed);
-                if (!compile.Success)
-                {
-                    compileErrors.AddRange(compile.Errors);
-                    compileErrors.AddRange(alDiagnostics);
-                    return new ServerRunResult(Array.Empty<TestResult>(), 3, false,
-                        new List<CompilationErrorGroup> { new(moduleName, compileErrors) }, fileHashes);
-                }
-                assemblyBytes = compile.AssemblyBytes;
-                if (cachePath != null && assemblyBytes != null)
-                {
-                    try
-                    {
-                        // Same atomic, sidecars-first-DLL-last publish as the CLI path above
-                        // (issue #1810) — see the comment there for why the ordering matters.
-                        AlRunner.Infrastructure.AlCacheWriter.AtomicPublish(
-                            sidecarPath!, tmp => SaveEnumRegistrySidecar(tmp));
-                        var qsrc = BcCompiler.LastBundleQuerySymbolsPath;
-                        if (qsrc != null && File.Exists(qsrc))
-                            AlRunner.Infrastructure.AlCacheWriter.AtomicPublish(
-                                querySidecarPath!, tmp => File.Copy(qsrc, tmp, overwrite: true));
-                        AlRunner.Infrastructure.AlCacheWriter.AtomicPublish(
-                            cachePath, tmp => File.WriteAllBytes(tmp, assemblyBytes));
-                    }
-                    catch (Exception ex) { Console.Error.WriteLine($"  [cache] write failed: {ex.Message}"); }
-                }
-            }
-
-            Assembly asm;
-            if (reusedAsm != null)
-            {
-                // See the cross-bundle module identity dedup comment above: this
-                // bundle's AppId was already loaded earlier in this request/session,
-                // so run with that exact Assembly instead of Assembly.Load-ing a
-                // second, distinct module for the same AL identity.
-                asm = reusedAsm;
-            }
-            else
-            {
-                if (assemblyBytes == null)
-                    return ServerRunResult.Failure(2, moduleName, "no assembly produced", fileHashes);
-                asm = Assembly.Load(assemblyBytes);
-                // Register this freshly-loaded module under its AppId so a LATER
-                // bundle in this request/session that resolves the same AppId —
-                // either as its own bundle (this same method, a later iteration) or
-                // as a dependency (DependencyLoader.LoadAll) — reuses this exact
-                // Assembly instead of re-emitting/re-compiling a second module for
-                // the same AL identity (#1892, mirrors the CLI loop's #1683 fix).
-                if (bundleId != null)
-                {
-                    try
-                    {
-                        DependencyLoader.RegisterLoaded(
-                            bundleId.AppId, asm, bundleId.Name, bundleId.Publisher,
-                            bundleId.Version.ToString(), bundleAbs);
-                    }
-                    catch (AlRunner.Infrastructure.AppIdCollisionException ex)
-                    {
-                        // Same defence as the TryGetByAppId check above, for the (in
-                        // this process, one request at a time) race window between
-                        // that check and this registration — see loud-failures.md.
-                        return ServerRunResult.Failure(3, moduleName, $"FATAL: {ex.Message}", fileHashes);
-                    }
-                }
-            }
-
-            IReadOnlyList<TestResult> tests;
-            var rt = System.Diagnostics.Stopwatch.StartNew();
-            try
-            {
-                BcRuntime.SetTestAssembly(asm);
-                BcRuntime.RegisterTestAssemblyInfo(asm);
-                BcRuntime.OosHooksActive = true;
-                tests = runStep(asm);
-            }
-            catch (Exception ex)
-            {
-                return ServerRunResult.Failure(2, moduleName, $"EXEC-FAIL: {ex.Message.Split('\n')[0]}", fileHashes);
-            }
-            finally
-            {
-                BcRuntime.OosHooksActive = false;
-                rt.Stop();
-                runElapsed = rt.Elapsed;
-                AlRunner.Infrastructure.PhaseLog.AddAppRun(rt.Elapsed);
-            }
-
-            int exit = 0;
-            if (tests.Any(t => t.Outcome == TestOutcome.Fail || t.Outcome == TestOutcome.Error)) exit = 1;
-            return new ServerRunResult(tests, exit, cached, null, fileHashes);
-        }
-        finally
-        {
-            AlRunner.Infrastructure.PhaseLog.EndApp();
-        }
-    }
 
     // Run the bundle's OnRun-bearing codeunit (run-mode), mirroring CodeunitPatches'
     // OnRun dispatch. Prefers a non-[Test] codeunit; returns one TestResult named

--- a/README.md
+++ b/README.md
@@ -143,6 +143,14 @@ al-runner --server [--package-cache PATH ...] [--cache DIR]
 
 A long-running JSON-RPC daemon over stdin/stdout. Dependencies and BC patches load once; each `runTests` request re-emits the bundle warm and runs it in-process (~19s→~4s). stdout carries only the newline-delimited JSON protocol; logs go to stderr. The VS Code extension uses this. Full protocol + the same-bundle reload contract: [docs/server-mode.md](docs/server-mode.md).
 
+### Debug adapter mode (breakpoints)
+
+```bash
+al-runner --dap [PORT] <bundle-dir>
+```
+
+A real Debug Adapter Protocol server (default port 4711) over a TCP socket: set AL breakpoints, pause execution, inspect locals. No new AL→source mapping — it reuses BC's own `StmtHit`/`[SourceSpans]` instrumentation, the same mechanism `--coverage` and `--capture-values` already consume. Full protocol + current limitations (no real step granularity yet, no VS Code launch configuration in this repo): [docs/dap-mode.md](docs/dap-mode.md).
+
 ### Precompile a single `.app` to a DLL
 
 ```bash
@@ -174,6 +182,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md#dev-loop) for provisioning them as a separ
 | `--isolation codeunit\|test\|disabled` | Test isolation mode. Default `codeunit`. |
 | `--watch` | Stay resident with warm dependencies; on every `.al` change reset + re-emit + run **in-process** (~seconds/save). Debounces on quiescence (default 250ms of no further `.al` event, capped at 10s) so a bulk multi-file rewrite — a branch switch, a rebase, a formatter run — settles before a cycle starts, instead of firing mid-checkout. Tune with `AL_RUNNER_WATCH_QUIET_MS` / `AL_RUNNER_WATCH_MAX_WAIT_MS`. |
 | `--server` | Long-running JSON-RPC daemon over stdin/stdout (warm deps → ~19s→~4s/run). See [docs/server-mode.md](docs/server-mode.md). |
+| `--dap [PORT]` | Debug Adapter Protocol server (default port 4711): set AL breakpoints, pause execution, inspect locals. Requires exactly one bundle path. See [docs/dap-mode.md](docs/dap-mode.md). |
 | `--per-suite` | Legacy per-suite compile mode (diagnostic). Default is bundled-per-bucket. |
 | `--bundled` | No-op alias for backwards compatibility. |
 | `--verbose` | Show internal `[Component]` diagnostic logs. Equivalent to `AL_RUNNER_VERBOSE=1`. |

--- a/docs/dap-mode.md
+++ b/docs/dap-mode.md
@@ -1,0 +1,99 @@
+# `--dap` — Debug Adapter Protocol server
+
+`al-runner --dap [PORT] <bundle-dir>` starts a real [Debug Adapter
+Protocol](https://microsoft.github.io/debug-adapter-protocol/overview) server
+over a TCP socket (default port `4711`, matching v1). It compiles the given
+bundle, waits for a DAP client to connect, and lets that client set
+breakpoints on AL source lines, pause execution at them, and inspect the AL
+locals in scope at the pause — with no BC service tier, no PDB, and no
+IL-offset mapping.
+
+This is the first slice of issue #1642. See "What's not in this slice" below
+before assuming a capability exists.
+
+## Mechanism
+
+No new AL→source mapping was needed. BC's own AL compiler already instruments
+every AL statement with `NavMethodScope.StmtHit(N)` (or `CStmtHit(N)` for an
+`if`/`while`/`repeat` condition), and every generated scope class carries a
+`[SourceSpans(...)]` attribute mapping each index `N` to an AL (file, line,
+column) span — the same instrumentation `--coverage` (#1922) and
+`--capture-values` (#1640) already consume. `--dap` adds a third,
+unconditional Cecil prepend on those same methods
+(`AlDapSession.OnStmtHit`, see `NclCecilRewrite.cs`) that blocks the AL
+execution thread when the fired `(scope type, statement index)` pair matches
+a registered breakpoint.
+
+**Why pausing at `StmtHit(N)` is the correct boundary, not an approximation**:
+BC calls `StmtHit(N)` *before* statement `N`'s own side effect runs. A
+mainstream debugger's "stopped at line L" already means exactly that —
+statement `L-1`'s effects are visible, statement `L`'s are not yet — so no
+`Exit()`-style redesign (the fix `--capture-values` needed for its *final*
+value snapshot) is required for pausing. See
+`AlRunner/Infrastructure/AlDapSession.cs`'s file header for the full argument,
+and `AlRunner/Infrastructure/AlDapStackWalker.cs` for a related, genuine gotcha
+this issue's implementation hit and fixed: the paused frame's own
+`StatementNumber` field is still the *previous* statement's index at the
+instant the hook fires (the Cecil prepend runs before `StmtHit`'s own
+assignment), so the stack walker uses the hook's `currentStatementNumber`
+parameter for the topmost frame instead of the (stale) live property.
+
+## Usage
+
+```
+al-runner --dap 4711 ./tests/some-bundle
+```
+
+The process prints `[dap] listening on 127.0.0.1:4711 — waiting for a debug
+client to connect...` on stdout, then blocks until a client connects. Session
+lifecycle:
+
+1. `initialize` → capabilities, then an `initialized` event.
+2. `launch`/`attach` → compiles the bundle. The response does not return until
+   compilation finishes (success or failure), so a `setBreakpoints` request
+   right after has real statement indices to resolve against.
+3. `setBreakpoints` (per source file) → resolves each requested line to an
+   AL-compiler-instrumented statement via an exact absolute-line match — no
+   "nearest line" heuristic. A line with no exact instrumented statement comes
+   back `verified: false` rather than silently relocated.
+4. `configurationDone` → AL execution begins.
+5. When a breakpointed statement's `StmtHit` fires, the AL execution thread
+   blocks and a `stopped` event (`reason: "breakpoint"`) is sent.
+6. `threads` / `stackTrace` / `scopes` / `variables` — read the paused call
+   stack and each frame's `[NavName]`-tagged AL locals, live, via
+   `AlScopeInspector`.
+7. `continue` / `next` / `stepIn` / `stepOut` — resumes execution (all four
+   behave identically in this slice; see below).
+8. `disconnect` / `terminate` — releases any paused thread (never leaves it
+   stuck) and ends the session.
+
+## Trying it without a DAP client
+
+Any TCP client that speaks Content-Length-framed JSON can drive a session —
+see `AlRunner.Tests/DapClient.cs` for a minimal one, or connect a raw socket
+and write `Content-Length: <n>\r\n\r\n<json>` frames by hand.
+
+## What's not in this slice
+
+- **Real step granularity.** `next`/`stepIn`/`stepOut` all behave like
+  `continue` — none of them pause at the very next statement the way a real
+  single-step would. Tracked as follow-up.
+- **A VS Code launch configuration.** There is no `type` contribution a
+  `launch.json` can point at without an installed extension; wiring this up
+  belongs in the (separate-repo) AL Runner VS Code extension. Tracked as
+  follow-up. Until then, `{"type": "al", "request": "attach", "debugServer":
+  4711}` (borrowing the AL extension's own dev-mode DAP attach point) is a
+  workaround for manual trying-out, not a supported story.
+- **Multiple bundles in one session.** `--dap` currently refuses more than one
+  bundle path.
+- **`setVariable` / expression evaluation / conditional breakpoints.**
+  `setVariable` is explicitly tracked separately (#2017); the others are not
+  yet planned.
+
+## See also
+
+- `docs/archive/dap.md` — v1's design notes for the same mechanism (some
+  naming has since changed — `SourceLineMapper`/`ValueCapture` there map onto
+  `AlSourceSpanCodec`/`AlScopeInspector` here — but the architecture holds).
+- `AlRunner/Infrastructure/AlDapSession.cs`, `DapBreakpointResolver.cs`,
+  `AlDapStackWalker.cs`, `AlScopeInspector.cs`, `DapTransport.cs`.


### PR DESCRIPTION
Part of #1642 — not closing it, see "What's left" below.

## What this does

Restores AL breakpoint debugging on v2: a real Debug Adapter Protocol server
(`--dap [PORT] <bundle-dir>`, TCP, default port 4711) implementing
`initialize`/`launch`/`setBreakpoints`/`configurationDone`/`threads`/
`stackTrace`/`scopes`/`variables`/`continue`/`next`/`stepIn`/`stepOut`/
`disconnect`, driving the existing test executor.

No new AL→source mapping was needed — the premise in #1642's original text
was already established wrong before this PR (see the issue's own history):
BC's compiler already instruments every AL statement with `StmtHit(N)`/
`CStmtHit(N)` and carries `[SourceSpans(...)]` per generated scope class, the
same mechanism `--coverage` (#1922) and `--capture-values` (#1640) already
consume. `--dap` adds a third, unconditional Cecil prepend on those same
methods (`AlDapSession.OnStmtHit`) that blocks the AL execution thread when
the fired statement matches a registered breakpoint.

**Why pausing at `StmtHit(N)` is correct, not an approximation** (the thing
the task asked me to think through explicitly): BC calls `StmtHit(N)` before
statement `N`'s own side effect runs. A debugger's "stopped at line L"
already means exactly that — statement `L-1`'s effects are visible,
statement `L`'s are not yet — so, unlike `--capture-values` (which needed an
`Exit()`-based redesign to avoid being one statement stale for its *final*
value snapshot), no redesign is needed here. Full argument in
`AlRunner/Infrastructure/AlDapSession.cs`'s file header.

**A genuine bug found and fixed via the RED→GREEN loop**: the paused frame's
own `NavMethodScope.StatementNumber` field is still the *previous*
statement's index at the instant the hook fires, because the Cecil prepend
runs before `StmtHit`'s own `statementNumber = currentStatementNumber;`
assignment (same "prepend runs first" shape as every other hook in this
family). The stack trace/`stopped` line now uses the hook's
`currentStatementNumber` parameter for the topmost frame instead of the
(stale) live property — see `AlDapStackWalker`'s doc comment for the detail.
This was caught by the proving test's assertion that `Counter == 1` (not
`2`) at the pause, not by inspection.

Also fixed along the way: `[dap]`-tagged readiness output was being silently
swallowed by `Log`'s component-tag filter (the same class of bug the `[bc]`/
`[reexec]` exemptions already document) — a DAP client had no way to know
the server was listening. `[dap]` is now exempted, with a regression test in
`LogUserFacingTagsTests.cs`.

## Tests

- `AlRunner.Tests/DapServerTests.cs` — end-to-end: spawns the real runner
  with `--dap`, drives it over a real DAP TCP client
  (`AlRunner.Tests/DapClient.cs`, using the runner's own `DapTransport`
  class), sets a breakpoint on a fixture's second of three statements,
  asserts the pause is reported at the right line, asserts the paused
  frame's `Counter` local is `1` (the first statement's effect) not `2`
  (proving the pause boundary is genuinely pre-side-effect, not a coincidence),
  continues, and asserts the test completes (`exitCode: 0`). A second fact
  proves the negative direction: no breakpoints set → no `stopped` event ever
  fires, straight-through execution.
- `LogUserFacingTagsTests.cs` — `[dap]` survives the default log filter.
- `AlRunner.Tests/Fixtures/DapBreakpoint/` — the AL fixture (own app id/id
  range, self-contained assert helper, matching existing fixture conventions).

## What's left (filed before opening this PR, not closing #1642)

- #2045 — real `next`/`stepIn`/`stepOut` step granularity (currently all
  three alias `continue`, matching v1's own documented limitation).
- #2046 — a VS Code launch configuration / extension contribution (this repo
  has no way to point a `launch.json` at an arbitrary adapter without one;
  the runner side is done, the editor side needs a decision + likely a
  second repo).
- #2047 — multi-bundle debug sessions (`--dap` currently refuses more than
  one bundle path).

See `docs/dap-mode.md` for the full protocol subset, mechanism, and current
limitations.

## Test plan

- [x] `AlRunner.Tests/DapServerTests.cs` (both facts) green
- [x] `LogUserFacingTagsTests`, `CliDocumentationTests`, `ServerTests` (incl.
      `--capture-values`, unaffected by the `AlValueCapture` refactor) green
- [x] Manually verified the RED state (off-by-one line, silently-swallowed
      readiness line) before each fix, and GREEN after
- [ ] CI (pushing now)

Claude-Session: https://claude.ai/code/session_01Ex8SjUeKZd71bUMN5k6hMR