### PR TITLE
docs(dap): correct VS Code launch-config guidance for --dap

### DIFF
--- a/docs/dap-mode.md
+++ b/docs/dap-mode.md
@@ -81,14 +81,84 @@ and write `Content-Length: <n>\r\n\r\n<json>` frames by hand.
 - **A VS Code launch configuration.** There is no `type` contribution a
   `launch.json` can point at without an installed extension; wiring this up
   belongs in the (separate-repo) AL Runner VS Code extension. Tracked as
-  follow-up. Until then, `{"type": "al", "request": "attach", "debugServer":
-  4711}` (borrowing the AL extension's own dev-mode DAP attach point) is a
-  workaround for manual trying-out, not a supported story.
+  follow-up in #2046. See "VS Code integration status" below — the
+  `debugServer` workaround this section used to suggest does not actually
+  work with the currently shipped AL extension.
 - **Multiple bundles in one session.** `--dap` currently refuses more than one
   bundle path.
 - **`setVariable` / expression evaluation / conditional breakpoints.**
   `setVariable` is explicitly tracked separately (#2017); the others are not
   yet planned.
+
+## VS Code integration status (#2046)
+
+**Stock VS Code cannot attach to `--dap` from a plain `launch.json`.** A
+`launch.json` entry's `type` must be contributed by an installed extension's
+`contributes.debuggers` — VS Code has no generic "point me at a TCP DAP
+server" debug type. This was already known going into #2046; it is confirmed
+here rather than re-derived, since VS Code's extension model has not changed
+in a way that would affect it.
+
+**The previously-suggested `debugServer` workaround does not work.** This
+document used to suggest borrowing the AL extension's own `type: "al"` with
+`debugServer: 4711` to bypass its adapter and connect directly to al-runner's
+DAP port, as a way to try the adapter without installing anything new. That
+does not function with the currently shipped `ms-dynamics-smb.al` extension.
+Verified by decompiling the installed extension bundles (17.0.2273547 and the
+newer 18.0.2498801, both checked — same result in each) and VS Code's own
+`extensionHostProcess.js`, rather than by trying it and guessing why it
+failed:
+
+- VS Code core's debug-adapter resolution (`getAdapterDescriptor` in
+  `extensionHostProcess.js`) does exactly what the workaround assumes: if
+  `session.configuration.debugServer` is a number, it connects a raw TCP
+  socket to that port and never asks the extension for a debug adapter
+  executable at all.
+- But `session.configuration` there is the **resolved** configuration — the
+  output of every registered `DebugConfigurationProvider.resolveDebugConfiguration`
+  for that `type`, chained in sequence — not the literal object written in
+  `launch.json`. `ms-dynamics-smb.al` registers exactly such a provider for
+  `type: "al"` (`AlDebugConfigurationProvider`), and for both `launch` and
+  `attach` requests it rebuilds the configuration object field-by-field from
+  an explicit whitelist (`name`, `type`, `request`, `authentication`, `port`,
+  `server`, `serverInstance`, `tenant`, ... — dozens of named fields). Neither
+  build's whitelist includes `debugServer`, and the extension's bundled JS
+  contains zero occurrences of the string `"debugServer"` anywhere — it has no
+  special-case handling for it, so nothing preserves the field. By the time
+  VS Code core checks `session.configuration.debugServer`, the field is gone,
+  and it falls through to asking the AL extension for its own real debug
+  adapter instead of al-runner's.
+- This is a property of the currently-installed AL extension, not of VS Code:
+  a debug `type` with **no** competing `resolveDebugConfiguration` (i.e. a
+  type the AL extension does not own) would not have this problem, because
+  there would be nothing rebuilding the configuration out from under
+  `debugServer`.
+
+**What this means for the follow-up in the (separate) AL Runner VS Code
+extension**, restated from #1642/#2046 with the workaround option removed
+since it does not hold up:
+
+1. **A minimal extension contributing a new `debuggers` type needs no
+   TypeScript**, and would not hit the problem above, because a fresh `type`
+   name has no other extension's `resolveDebugConfiguration` in the way.
+   `package.json` alone can declare `contributes.debuggers: [{ "type":
+   "al-runner", "label": "AL Runner", "languages": ["al"],
+   "configurationAttributes": {...} }]` plus a `configurationSnippets` entry
+   whose body bakes in a fixed `debugServer` port — the user runs `al-runner
+   --dap` themselves in a terminal first, same manual two-step this document
+   already describes under "Trying it without a DAP client", just with a
+   `launch.json` entry instead of raw sockets.
+2. **Making the extension launch `al-runner --dap` itself** (instead of
+   requiring the manual terminal step) needs a small amount of TypeScript: a
+   `vscode.DebugAdapterDescriptorFactory` for that new type, returning a
+   `vscode.DebugAdapterServer(port)` after spawning the process — the same
+   shape the extension already needs for `--server` (`docs/server-mode.md`),
+   since it already knows where the al-runner binary is.
+3. Whether the existing (separate-repo, not-in-this-repo) AL Runner VS Code
+   extension can take either contribution cheaply is **not verified here** —
+   this repo has no access to that extension's source. That remains the open
+   question #2046's issue body raised, and is unchanged by this finding: it
+   is a decision, and a change, for whoever owns that extension's repository.
 
 ## See also
 


### PR DESCRIPTION
Addresses #2046 (does not close it — see "What's left open" below).

## What was asked

Issue #2046 asks the specific question first: does attaching to `--dap` require a VS Code extension, or can stock VS Code attach to a plain TCP DAP server? And if an extension is genuinely required, don't build one — record the finding plus whatever documentation is still useful.

## Answer: an extension is required, and the previously-documented workaround does not work

Stock VS Code has no built-in "attach to an arbitrary DAP server" debug type — a `launch.json` entry's `type` must be contributed by an installed extension's `contributes.debuggers`. That much was already known (it's restated in #2046's own body, carried over from #1642's investigation).

What was *not* known, and is the actual finding of this issue: `docs/dap-mode.md` suggested a zero-install workaround — borrow the AL extension's `type: "al"` with `debugServer: 4711` to bypass its adapter and connect straight to al-runner's DAP port. **That workaround does not function with the currently shipped `ms-dynamics-smb.al` extension.** I verified this by decompiling the installed extension bundles rather than trying it and guessing:

- Checked both `ms-dynamics-smb.al` 17.0.2273547 (currently installed) and 18.0.2498801 (latest cached VSIX) — same result in both, and the string `"debugServer"` appears zero times in either bundle's JS.
- VS Code core's own adapter resolution (`getAdapterDescriptor` in `extensionHostProcess.js`) does exactly what the workaround assumes — a numeric `session.configuration.debugServer` short-circuits straight to a TCP socket connection, bypassing the extension's adapter factory entirely.
- But `session.configuration` there is the *resolved* configuration, i.e. whatever `AlDebugConfigurationProvider.resolveDebugConfiguration` returns. For both `launch` and `attach`, that provider rebuilds the configuration object from an explicit field whitelist (`name`, `type`, `request`, `authentication`, `port`, `server`, `serverInstance`, `tenant`, ... dozens of fields) that does not include `debugServer`. The field never survives resolution, so VS Code's core fast-path never sees it, and instead asks the AL extension for its own real debug adapter.

This is a property of the AL extension (no competing `resolveDebugConfiguration` = no problem), not of VS Code, so it doesn't affect the actual recommended path: a purpose-built extension contributing a *new* debug type is unaffected, since there's nothing else rebuilding its config.

## What this PR changes

`docs/dap-mode.md`:
- Removes the disproven `debugServer` workaround claim.
- Adds a "VS Code integration status (#2046)" section with the decompiled evidence above, and restates what a minimal extension contribution needs (a `contributes.debuggers` entry needs zero TypeScript; making the extension launch `al-runner --dap` itself needs a small `DebugAdapterDescriptorFactory`, the same shape `--server` already needs).

## What's left open

Whether the existing (separate-repo, not in this repository) AL Runner VS Code extension can take either contribution cheaply is **not verified here** — this repo has no access to that extension's source, so that half of #2046's question is unanswered. That's a decision, and a change, for whoever owns that extension's repository, not something to build unasked from this repo. #2046 stays open for that.

## Verification

This is a documentation-only change — no code under `AlRunner/` was touched, so no test is added or required (the `require-tests` CI gate only triggers on `AlRunner/` changes, and this diff doesn't touch it).

What was actually verified, and how:
- **Verified**: the `debugServer`-drop finding, by decompiling the real installed/cached AL extension bundles (both versions) and VS Code's own `extensionHostProcess.js` in this environment — not by assumption.
- **Not verified**: an actual interactive VS Code debug session against a running `--dap` server. This machine has a real VS Code install and a real display, but no GUI automation tooling (no `xdotool`/`Xvfb`) and the display is the user's own live desktop session, so driving an interactive VS Code window here would be disruptive without being able to observe the result any better than the static analysis already gives. The runner side of the same DAP handshake VS Code would perform is already covered end-to-end by the existing `AlRunner.Tests/DapServerTests.cs` (a raw TCP DAP client drives initialize/launch/setBreakpoints/configurationDone and asserts a real pause) — that part was not touched or re-verified here since it's unrelated to this issue's VS Code-side question.