### PR TITLE
fix(capture-values): surface field-read/ToString() failures instead of dropping them

### DIFF
--- a/AlRunner.Tests/AlValueCaptureErrorVisibilityTests.cs
+++ b/AlRunner.Tests/AlValueCaptureErrorVisibilityTests.cs
@@ -1,0 +1,145 @@
+// Issue #2043: --capture-values (#1640) had two catch blocks in AlValueCapture.cs /
+// AlValueWireFormat.cs that DROPPED information instead of reporting it —
+//   1. a field whose FieldInfo.GetValue(scope) threw was silently `continue`d, so the
+//      variable was simply absent from the captured list;
+//   2. a raw value whose ToString() threw was flattened to `null`, indistinguishable
+//      from an AL variable that is genuinely null.
+// Both are the right instinct (a capture must never crash the run), but the consumer
+// (the VS Code extension, reading `capturedValues` off `execute`'s wire response — see
+// ServerProtocol.ToWire(AlCapturedValue)) could not tell "this variable does not exist",
+// "this variable is null", and "reading this variable failed" apart. .claude/rules/
+// loud-failures.md is the governing rule: a missing/faked value must never be silently
+// indistinguishable from a real one.
+//
+// These are pure C# unit tests against AlValueCapture.CaptureField (the field-level
+// helper extracted so this is testable without a real NavMethodScope — the reflective
+// read is abstracted behind a `Func<object?>` so a throw can be injected directly) and
+// AlValueWireFormat.ToWireValue's error-surfacing overload. No BC artifact needed.
+using AlRunner.Infrastructure;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class AlValueCaptureErrorVisibilityTests
+{
+    // --- AlValueWireFormat.ToWireValue(object?, out string?) ---------------------------
+
+    [Fact]
+    public void ToWireValue_GenuinelyNull_ReturnsNullValueAndNullCaptureError()
+    {
+        var value = AlValueWireFormat.ToWireValue(null, out var captureError);
+        Assert.Null(value);
+        Assert.Null(captureError);
+    }
+
+    [Fact]
+    public void ToWireValue_ClrPrimitive_PassesThroughWithNoCaptureError()
+    {
+        var value = AlValueWireFormat.ToWireValue(42, out var captureError);
+        Assert.Equal(42, value);
+        Assert.Null(captureError);
+    }
+
+    [Fact]
+    public void ToWireValue_ToStringThrows_ReturnsNullValueWithCaptureErrorNamingExceptionType()
+    {
+        var value = AlValueWireFormat.ToWireValue(new ThrowingToString(), out var captureError);
+        Assert.Null(value);
+        Assert.NotNull(captureError);
+        // The exact exception type must be nameable from the marker — an unusual throw
+        // on ToString() is worth being able to see (issue's "Include the exception type").
+        Assert.Contains(nameof(InvalidOperationException), captureError);
+    }
+
+    [Fact]
+    public void ToWireValue_NormalObject_UsesToStringWithNoCaptureError()
+    {
+        var value = AlValueWireFormat.ToWireValue(new NormalObject(), out var captureError);
+        Assert.Equal("normal-value", value);
+        Assert.Null(captureError);
+    }
+
+    // --- AlValueCapture.CaptureField (field-level helper behind OnExit) ----------------
+
+    [Fact]
+    public void CaptureField_ReadThrows_ReportsCaptureErrorAndNullValue_NotOmitted()
+    {
+        var captured = AlValueCapture.CaptureField("OnRun", "Broken", statementId: 3,
+            readField: () => throw new NotSupportedException("field cannot be read"));
+
+        Assert.Equal("OnRun", captured.ScopeName);
+        Assert.Equal("Broken", captured.VariableName);
+        Assert.Equal(3, captured.StatementId);
+        Assert.Null(captured.Value);
+        Assert.NotNull(captured.CaptureError);
+        Assert.Contains(nameof(NotSupportedException), captured.CaptureError);
+    }
+
+    [Fact]
+    public void CaptureField_ToStringThrows_ReportsCaptureError_DistinctFromGenuineNull()
+    {
+        var captured = AlValueCapture.CaptureField("OnRun", "Bad", statementId: 1,
+            readField: () => new ThrowingToString());
+
+        Assert.Null(captured.Value);
+        Assert.NotNull(captured.CaptureError);
+        Assert.Contains(nameof(InvalidOperationException), captured.CaptureError);
+    }
+
+    [Fact]
+    public void CaptureField_GenuinelyNullValue_ReportsNullWithNoCaptureError()
+    {
+        var captured = AlValueCapture.CaptureField("OnRun", "Rec", statementId: 2,
+            readField: () => null);
+
+        Assert.Null(captured.Value);
+        Assert.Null(captured.CaptureError);
+    }
+
+    [Fact]
+    public void CaptureField_SuccessfulRead_ReportsValueWithNoCaptureError()
+    {
+        var captured = AlValueCapture.CaptureField("OnRun", "Counter", statementId: 0,
+            readField: () => 42);
+
+        Assert.Equal(42, captured.Value);
+        Assert.Null(captured.CaptureError);
+    }
+
+    // Acceptance criterion #4 ("Neither path can throw out of OnExit"): CaptureField is
+    // the piece OnExit calls per field, with no try/catch of its own around the call —
+    // so if either internal catch (read-throws, ToString-throws) ever let an exception
+    // escape, it would propagate straight out of OnExit and crash the AL run mid-scope-
+    // teardown. Assert.Null(Record.Exception(...)) makes that an explicit, named claim
+    // rather than an implicit one (the four tests above only reached their assertions
+    // because nothing threw first — this test is the one that says so on purpose).
+    [Theory]
+    [InlineData(typeof(NotSupportedException))]
+    [InlineData(typeof(InvalidOperationException))]
+    [InlineData(typeof(ArgumentException))]
+    [InlineData(typeof(FieldAccessException))]
+    public void CaptureField_ReadThrows_NeverPropagates_ForAnyExceptionType(Type exceptionType)
+    {
+        var ex = Record.Exception(() => AlValueCapture.CaptureField("OnRun", "X", 0,
+            readField: () => throw (Exception)Activator.CreateInstance(exceptionType)!));
+        Assert.Null(ex);
+    }
+
+    [Fact]
+    public void CaptureField_ToStringThrows_NeverPropagates()
+    {
+        var ex = Record.Exception(() => AlValueCapture.CaptureField("OnRun", "X", 0,
+            readField: () => new ThrowingToString()));
+        Assert.Null(ex);
+    }
+
+    private sealed class ThrowingToString
+    {
+        public override string ToString() => throw new InvalidOperationException("boom");
+    }
+
+    private sealed class NormalObject
+    {
+        public override string ToString() => "normal-value";
+    }
+}

--- a/AlRunner/Infrastructure/AlValueCapture.cs
+++ b/AlRunner/Infrastructure/AlValueCapture.cs
@@ -48,8 +48,18 @@ namespace AlRunner.Infrastructure;
 /// <summary>One AL local's value, captured the instant its top-level scope's method body
 /// finished (NavMethodScope.Exit(), before Dispose()). <c>StatementId</c> indexes the SAME
 /// [SourceSpans] array AlCoverageTracker/AlCallStackCapture already decode, so a caller
-/// that also wants the AL source line can resolve it via AlSourceSpanCodec.</summary>
-public readonly record struct AlCapturedValue(string ScopeName, string VariableName, object? Value, int StatementId);
+/// that also wants the AL source line can resolve it via AlSourceSpanCodec.
+///
+/// <c>CaptureError</c> (issue #2043) is non-null exactly when this value could not be
+/// faithfully read or rendered — either the field read itself threw (reflection failure
+/// on the generated `*_Scope` class), or the raw value's own ToString() threw (see
+/// AlValueWireFormat). In both cases <c>Value</c> is null, but that null must never be
+/// confused with a genuinely null AL variable — a genuinely null variable has
+/// <c>CaptureError == null</c>. Naming the exception type in the message is deliberate:
+/// either failure mode is unusual and worth being able to see (.claude/rules/
+/// loud-failures.md — never drop or fake a value silently).</summary>
+public readonly record struct AlCapturedValue(
+    string ScopeName, string VariableName, object? Value, int StatementId, string? CaptureError = null);
 
 public static class AlValueCapture
 {
@@ -99,11 +109,36 @@ public static class AlValueCapture
         {
             var name = AlNavNameReflection.GetAlName(f);
             if (name == null) continue;
-            object? raw;
-            try { raw = f.GetValue(scope); }
-            catch { continue; } // a field that can't be read is skipped, never faked
-            values.Add(new AlCapturedValue(scopeName, name, AlValueWireFormat.ToWireValue(raw), statementId));
+            values.Add(CaptureField(scopeName, name, statementId, () => f.GetValue(scope)));
         }
         _snapshot = values;
+    }
+
+    /// <summary>
+    /// Captures one AL local given a way to read its raw CLR value. Extracted from
+    /// <see cref="OnExit"/> so the two failure modes issue #2043 names — a read that
+    /// throws, and a ToString() that throws — are unit-testable without a real
+    /// NavMethodScope: <paramref name="readField"/> is exactly <c>() =&gt;
+    /// f.GetValue(scope)</c> in production, but a test can inject a throwing delegate
+    /// directly. Neither failure mode is allowed to propagate out of this method (this is
+    /// what OnExit calls, and OnExit itself may never throw — see the file header and
+    /// AlValueCaptureErrorVisibilityTests).
+    /// </summary>
+    internal static AlCapturedValue CaptureField(
+        string scopeName, string name, int statementId, Func<object?> readField)
+    {
+        object? raw;
+        try { raw = readField(); }
+        catch (Exception ex)
+        {
+            // A field that can't be read is reported, not skipped — a variable silently
+            // absent from the list is indistinguishable from one that doesn't exist
+            // (.claude/rules/loud-failures.md). Value stays null: nothing was ever read,
+            // so nothing is faked.
+            return new AlCapturedValue(scopeName, name, null, statementId,
+                $"field read threw {ex.GetType().Name}");
+        }
+        var wireValue = AlValueWireFormat.ToWireValue(raw, out var captureError);
+        return new AlCapturedValue(scopeName, name, wireValue, statementId, captureError);
     }
 }

--- a/AlRunner/Infrastructure/AlValueWireFormat.cs
+++ b/AlRunner/Infrastructure/AlValueWireFormat.cs
@@ -15,8 +15,21 @@ public static class AlValueWireFormat
     /// (.claude/rules/precompiled-dll-respect.md), so we take their own ToString()
     /// rather than guessing a bespoke encoding per type.
     /// </summary>
-    public static object? ToWireValue(object? raw)
+    public static object? ToWireValue(object? raw) => ToWireValue(raw, out _);
+
+    /// <summary>
+    /// Same conversion as <see cref="ToWireValue(object?)"/>, but surfaces a ToString()
+    /// failure via <paramref name="captureError"/> instead of silently flattening it to
+    /// <c>null</c> (issue #2043 — a genuinely-null AL variable and one whose ToString()
+    /// threw were both reported as the same <c>null</c>, indistinguishable to the
+    /// consumer). <paramref name="captureError"/> is null whenever the conversion
+    /// succeeded (including the "raw is genuinely null" case), so callers can tell the
+    /// two apart. The value returned on a ToString() failure is still <c>null</c> — no
+    /// value was ever faked — but now the caller can see WHY.
+    /// </summary>
+    public static object? ToWireValue(object? raw, out string? captureError)
     {
+        captureError = null;
         if (raw == null) return null;
         switch (raw)
         {
@@ -25,7 +38,13 @@ public static class AlValueWireFormat
                 return raw;
             default:
                 try { return raw.ToString(); }
-                catch { return null; } // ToString() itself must never crash a capture
+                catch (Exception ex)
+                {
+                    // ToString() itself must never crash a capture — but the failure
+                    // must be visible, not silently flattened to null (loud-failures.md).
+                    captureError = $"ToString() threw {ex.GetType().Name}";
+                    return null;
+                }
         }
     }
 }

--- a/AlRunner/ServerProtocol.cs
+++ b/AlRunner/ServerProtocol.cs
@@ -35,7 +35,11 @@ namespace AlRunner;
 ///              single response, not streamed (matches v1: only runTests streams).
 ///              `capturedValues` (#1640) is present per test only when the request
 ///              set `captureValues:true`; each entry is {scopeName, variableName,
-///              value, statementId} — see AlValueCapture.
+///              value, statementId, captureError|omitted} — see AlValueCapture.
+///              `captureError` (#2043) is present, non-null, only when the field
+///              read or its ToString() threw; `value` is null in that case too but
+///              MUST NOT be read as "genuinely null" — a genuinely null AL variable
+///              has `captureError` absent.
 ///   error   : {error}
 ///   shutdown: {status}
 /// </summary>
@@ -241,11 +245,15 @@ public static class ServerProtocol
     // One captured AL local on the wire — the shape protocol-v2.schema.json already
     // reserves for TestEvent.capturedValues (see the schema's top-level description),
     // reused here for execute's own (schema-independent) response.
+    // captureError (#2043) is null-omitted (WhenWritingNull) on the common path — only
+    // present when the field read or its ToString() threw, so it never gets confused
+    // with a genuinely null AL variable (which has value:null and no captureError key).
     private static object ToWire(Infrastructure.AlCapturedValue v) => new
     {
         scopeName = v.ScopeName,
         variableName = v.VariableName,
         value = v.Value,
         statementId = v.StatementId,
+        captureError = v.CaptureError,
     };
 }

--- a/docs/server-mode.md
+++ b/docs/server-mode.md
@@ -173,7 +173,7 @@ last statement that ran — captured via a Cecil hook on
 `NavMethodScope.Exit()`, not a pass over emitted AL output (see
 `AlRunner/Infrastructure/AlValueCapture.cs`). `capturedValues` is present per
 test only when the request set the flag; each entry is `{scopeName,
-variableName, value, statementId}`:
+variableName, value, statementId, captureError|omitted}`:
 
 ```json
 {"command":"execute","captureValues":true,
@@ -184,6 +184,16 @@ variableName, value, statementId}`:
 {"exitCode":0,"tests":[{"name":"X.OnRun","status":"pass","durationMs":5,
  "capturedValues":[{"scopeName":"OnRun","variableName":"Msg","value":"hi","statementId":0}]}]}
 ```
+
+`captureError` (issue #2043) is present, non-null, only when the runtime could
+not faithfully read or render this variable — either the reflective field
+read itself threw, or the raw value's own `ToString()` threw. It names the
+exception type (e.g. `"field read threw NotSupportedException"`). `value` is
+`null` in that case, but this must not be confused with a genuinely null AL
+variable: a genuinely null variable is reported with `value:null` and
+`captureError` **absent**. A variable whose read failed is never simply
+omitted from the array — that would be indistinguishable from "this variable
+does not exist" (`.claude/rules/loud-failures.md`).
 
 ### `shutdown`
 

--- a/protocol-v2.schema.json
+++ b/protocol-v2.schema.json
@@ -58,7 +58,8 @@
               "scopeName": { "type": "string" },
               "variableName": { "type": "string" },
               "value": {},
-              "statementId": { "type": "integer" }
+              "statementId": { "type": "integer" },
+              "captureError": { "type": "string" }
             }
           }
         }


### PR DESCRIPTION
Closes #2043

## Problem

`AlValueCapture.OnExit` (the `--capture-values` snapshot hook) had two catch blocks
that discarded information rather than reporting it:

```csharp
try { raw = f.GetValue(scope); }
catch { continue; }              // a field that can't be read is skipped
```

```csharp
try { return raw.ToString(); }
catch { return null; }           // ToString() itself must never crash a capture
```

Both are the right instinct — a capture must never crash the run — but the consumer
(the VS Code extension, reading `capturedValues` off `execute`'s response) could not
tell three states apart: "this variable does not exist", "this variable is null", and
"reading this variable failed". `.claude/rules/loud-failures.md` is the governing rule:
a missing/faked value must never be silently indistinguishable from a real one.

## Fix

- `AlCapturedValue` gains a `CaptureError` field (wire: `captureError`), non-null only
  when a read or `ToString()` genuinely failed, naming the exception type
  (e.g. `"field read threw NotSupportedException"`).
- The field-read try/catch is extracted into `AlValueCapture.CaptureField`
  (internal, testable without a real `NavMethodScope`) so both failure modes are unit
  tested directly, including the "neither path can throw out of `OnExit`" guarantee.
- `AlValueWireFormat.ToWireValue` gains an `out string? captureError` overload; the
  existing 1-arg overload delegates to it (unchanged behaviour for other callers, e.g.
  `AlScopeInspector`'s `--dap` live-variable read — see follow-up below).
- `docs/server-mode.md` and `protocol-v2.schema.json` updated for the new
  `captureError` field on `capturedValues` entries.

## Tests

`AlRunner.Tests/AlValueCaptureErrorVisibilityTests.cs` — pure C# unit tests, no BC
artifact needed:
- a field read that throws → reported, not omitted, `CaptureError` names the exception
  type, `Value` is `null`.
- a value whose `ToString()` throws → reported with `CaptureError`, `Value` is `null`,
  and is asserted **distinct** from the genuinely-null case (different assertions on
  the same shape, not just "not omitted").
- a genuinely null read → `Value` is `null`, `CaptureError` is `null` (no marker) —
  proves the fix doesn't fabricate a marker on the legitimate null case.
- a successful read → unaffected.
- `Theory`-driven "never propagates" tests for both catch paths across multiple
  exception types, satisfying the issue's "neither path can throw out of `OnExit`"
  acceptance criterion explicitly (`Record.Exception(...)` is asserted `Null`, not just
  implied by the other tests reaching their assertions).

Ran `dotnet test AlRunner.Tests` in full (`-p:_BCVersion=28.1.49838.53910`, matching
`AlRunner.csproj`'s own hardcoded default to avoid an unrelated `_BCVersion`
mismatch between the two `.csproj` files' independent defaults): 903 passed, 56
skipped (require BC artifacts/fixtures not fully present in this environment), 1
failed — `SourceDepSymbolsWithoutPackageCacheTests.SiblingSourceDep_CompilesWithZeroPackageCacheDirs`,
confirmed pre-existing and unrelated by reproducing it identically against unmodified
`origin/main` at the same BC version (`git stash` + rerun). The two existing
`ServerTests` integration tests covering `capturedValues` (`Execute_CaptureValues_True_*`,
`Execute_CaptureValues_Omitted_*`) both still pass, confirming the new field is
additive and doesn't break the existing wire shape.

## Follow-up filed, not in this PR's scope

#2051 — `AlScopeInspector` (the `--dap` live-variable-read sibling of this file) still
has the ToString()-throws-flattens-to-null ambiguity for its own wire shape
(`AlScopeLocal`); it already handles the field-read-throws case distinctly. Out of
scope here because #2043's acceptance criteria are specifically about
`AlValueCapture.cs` / `execute`'s `capturedValues`, and DAP's `variables` request is a
separate wire path with its own tests.