### PR TITLE
fix(dap): surface --dap variable ToString() failures instead of flattening to null

### DIFF
--- a/AlRunner.Tests/AlScopeInspectorErrorVisibilityTests.cs
+++ b/AlRunner.Tests/AlScopeInspectorErrorVisibilityTests.cs
@@ -1,0 +1,78 @@
+// Issue #2051 — follow-on to #2043 (AlValueCaptureErrorVisibilityTests.cs). #2043 fixed
+// the --capture-values path (AlValueCapture.CaptureField / execute's `capturedValues`):
+// a field read that throws and a value whose ToString() throws are both reported with a
+// distinct CaptureError instead of being flattened to the same `null` a genuinely-null AL
+// variable produces. AlScopeInspector.ReadLocals (--dap's live "variables" request, #1642)
+// already handled the read-throws case distinctly (Readable:false, "<unreadable: ...>"),
+// but still called AlValueWireFormat.ToWireValue(object?) — the ONE-ARGUMENT overload — so
+// a ToString() throw on an otherwise-successfully-read field was silently flattened back
+// down to Readable:true, Value:null: indistinguishable from a genuinely null AL local in
+// the DAP Variables pane.
+//
+// These are pure C# unit tests against AlScopeInspector.ReadField, the field-level helper
+// extracted (mirroring AlValueCapture.CaptureField) so both failure modes are testable via
+// an injected Func<object?> without a real NavMethodScope.
+using AlRunner.Infrastructure;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class AlScopeInspectorErrorVisibilityTests
+{
+    [Fact]
+    public void ReadField_ReadThrows_ReportsUnreadableMarker_NotReadable()
+    {
+        var local = AlScopeInspector.ReadField("Broken",
+            () => throw new NotSupportedException("field cannot be read"));
+
+        Assert.Equal("Broken", local.Name);
+        Assert.False(local.Readable);
+        Assert.Equal("<unreadable: NotSupportedException>", local.Value);
+    }
+
+    // The load-bearing negative-direction test for this issue: a field that reads fine
+    // but whose ToString() throws must NOT collapse to the same (Readable:true, Value:null)
+    // shape a genuinely-null AL local produces (the next test down). Before the fix this
+    // test fails: ReadField (via the 1-arg ToWireValue overload) reports Readable:true,
+    // Value:null here too.
+    [Fact]
+    public void ReadField_ToStringThrows_ReportsUnreadableMarker_DistinctFromGenuineNull()
+    {
+        var local = AlScopeInspector.ReadField("Bad", () => new ThrowingToString());
+
+        Assert.False(local.Readable);
+        Assert.NotNull(local.Value);
+        Assert.Contains(nameof(InvalidOperationException), (string)local.Value!);
+        Assert.Contains("ToString", (string)local.Value!);
+    }
+
+    [Fact]
+    public void ReadField_GenuinelyNullValue_ReportsReadableWithNullValue()
+    {
+        var local = AlScopeInspector.ReadField("Rec", () => null);
+
+        Assert.True(local.Readable);
+        Assert.Null(local.Value);
+    }
+
+    [Fact]
+    public void ReadField_SuccessfulRead_ReportsReadableWithValue()
+    {
+        var local = AlScopeInspector.ReadField("Counter", () => 42);
+
+        Assert.True(local.Readable);
+        Assert.Equal(42, local.Value);
+    }
+
+    [Fact]
+    public void ReadField_ToStringThrows_NeverPropagates()
+    {
+        var ex = Record.Exception(() => AlScopeInspector.ReadField("X", () => new ThrowingToString()));
+        Assert.Null(ex);
+    }
+
+    private sealed class ThrowingToString
+    {
+        public override string ToString() => throw new InvalidOperationException("boom");
+    }
+}

--- a/AlRunner/Infrastructure/AlScopeInspector.cs
+++ b/AlRunner/Infrastructure/AlScopeInspector.cs
@@ -18,8 +18,11 @@ using Microsoft.Dynamics.Nav.Runtime;
 namespace AlRunner.Infrastructure;
 
 /// <summary>One AL local as seen at a live pause. <c>Value</c> is the wire-formatted
-/// value (see AlValueWireFormat); <c>Readable</c> is false only when reflection itself
-/// failed to read the field — the NAME still appears (never silently dropped, see
+/// value (see AlValueWireFormat); <c>Readable</c> is false when EITHER reflection itself
+/// failed to read the field OR the field read fine but the raw value's own ToString()
+/// threw (issue #2051 — before this fix, a ToString() failure was silently flattened to
+/// the same (Readable:true, Value:null) shape a genuinely-null AL local produces). The
+/// NAME still appears in both failure modes (never silently dropped, see
 /// .claude/rules/loud-failures.md), with an explicit marker instead of a value.</summary>
 public readonly record struct AlScopeLocal(string Name, object? Value, bool Readable);
 
@@ -41,15 +44,38 @@ public static class AlScopeInspector
         {
             var name = AlNavNameReflection.GetAlName(f);
             if (name == null) continue;
-            object? raw;
-            try { raw = f.GetValue(scope); }
-            catch (Exception ex)
-            {
-                result.Add(new AlScopeLocal(name, $"<unreadable: {ex.GetType().Name}>", false));
-                continue;
-            }
-            result.Add(new AlScopeLocal(name, AlValueWireFormat.ToWireValue(raw), true));
+            result.Add(ReadField(name, () => f.GetValue(scope)));
         }
         return result;
+    }
+
+    /// <summary>
+    /// Reads one AL local given a way to fetch its raw CLR value. Extracted from
+    /// <see cref="ReadLocals"/> (mirroring AlValueCapture.CaptureField's extraction for
+    /// #2043) so both failure modes issue #2051 names — a read that throws, and a
+    /// ToString() that throws — are unit-testable without a real NavMethodScope:
+    /// <paramref name="readField"/> is exactly <c>() =&gt; f.GetValue(scope)</c> in
+    /// production, but a test can inject a throwing delegate directly. Neither failure
+    /// mode is allowed to propagate — this feeds a live DAP "variables" response and must
+    /// never crash a paused debug session.
+    /// </summary>
+    internal static AlScopeLocal ReadField(string name, Func<object?> readField)
+    {
+        object? raw;
+        try { raw = readField(); }
+        catch (Exception ex)
+        {
+            return new AlScopeLocal(name, $"<unreadable: {ex.GetType().Name}>", false);
+        }
+        var wireValue = AlValueWireFormat.ToWireValue(raw, out var captureError);
+        if (captureError != null)
+        {
+            // Same marker-string / Readable:false convention as the read-throws case
+            // above, so both failure modes render identically in the DAP Variables pane
+            // instead of the ToString()-throws case silently collapsing to a genuinely-
+            // null AL local's (Readable:true, Value:null) shape.
+            return new AlScopeLocal(name, $"<unreadable: {captureError}>", false);
+        }
+        return new AlScopeLocal(name, wireValue, true);
     }
 }


### PR DESCRIPTION
Closes #2051

## Problem

`AlScopeInspector.ReadLocals` (--dap's live "variables" read, #1642) already reported a field-*read* failure distinctly (`Readable:false`, `<unreadable: {ExceptionType}>`), but for a field that read successfully it still called `AlValueWireFormat.ToWireValue(raw)` — the **1-argument** overload. That overload swallows a `ToString()` failure back down to a plain `null`, so a variable whose `ToString()` throws and a variable that is genuinely `null` both rendered as `Readable:true, Value:null` in the DAP Variables pane — exactly the ambiguity #2043 (PR #2052) fixed for the `--capture-values` path.

## Fix

`AlValueWireFormat.ToWireValue(object?, out string? captureError)` already exists (added by #2043) and already distinguishes "genuinely null" from "ToString() threw". `AlScopeInspector.ReadLocals` now uses that overload and folds a non-null `captureError` into the *same* `Readable:false` / marker-string convention it already used for read failures — `<unreadable: ToString() threw {ExceptionType}>` — so both failure modes render identically in the debugger instead of one being silently faked.

I chose to keep DAP's existing `(Name, Value, Readable)` shape rather than introduce a third state, because that's the shape the `variables` request handler in `Program.cs` already understands (`value = v.Readable ? JsonSerializer.Serialize(v.Value) : (string)v.Value!`) — a `Variable` in the DAP protocol only has a `value: string`, so there's no wire-shape reason to carry a separate error field the way `AlCapturedValue.CaptureError` does for the JSON-typed `execute` response. Folding both failure modes into the marker-string convention that already existed keeps the two failure kinds visually distinct in the UI (the marker text names which one happened and, for the ToString() case, the exception type) without adding a new response field.

The read path is also refactored to extract `AlScopeInspector.ReadField(string name, Func<object?> readField)`, mirroring the extraction #2043 did for `AlValueCapture.CaptureField` — same shape, same reason: unit-testable against an injected throwing delegate without needing a real `NavMethodScope`.

## Testing

- **RED**: `AlRunner.Tests/AlScopeInspectorErrorVisibilityTests.cs` added first; failed to compile (`ReadField` didn't exist yet).
- **GREEN**: after the fix, all 5 new tests pass, including the load-bearing negative-direction case `ReadField_ToStringThrows_ReportsUnreadableMarker_DistinctFromGenuineNull`, which is asserted against the separate positive case `ReadField_GenuinelyNullValue_ReportsReadableWithNullValue` to prove the two are no longer conflated.
- `dotnet test AlRunner.Tests` (full suite, `_BCVersion=28.1.49838.50794`, matching `AlRunner.Tests.csproj`'s own default so the solution-wide `Microsoft.Dynamics.Nav.CodeAnalysis` version stays consistent across projects): 908 passed, 1 pre-existing environment/network flake unrelated to this change (a `DefaultProvisionTargetMessagingTests` CDN-download test and `StartupOutputReexecDedupTests` reexec-dedup timing tests — neither touches DAP/AlScopeInspector/AlValueCapture).
- Targeted re-run of `DapServerTests`, `AlValueCaptureErrorVisibilityTests`, and the new `AlScopeInspectorErrorVisibilityTests` together: 20/20 passed — `DapServerTests` (the e2e --dap breakpoint suite) is not regressed.