### PR TITLE
feat(dap): real step granularity for next/stepIn/stepOut

### DIFF
--- a/AlRunner.Tests/DapServerTests.cs
+++ b/AlRunner.Tests/DapServerTests.cs
@@ -27,6 +27,19 @@ public class DapServerTests
     private const int SecondStatementLine = 21;
     private const string SourceFileName = "DapBreakpointTests.Codeunit.al";
 
+    // AlRunner.Tests/Fixtures/DapStepping/DapSteppingTests.Codeunit.al — a nested-call
+    // fixture (issue #2045) so step-over/step-in/step-out are actually distinguishable:
+    // NestedCall's outer body calls a local procedure (Double) that has two statements
+    // of its own. See that file's line-numbered listing; these constants are asserted
+    // against exactly, so keep them in sync with the fixture.
+    private static readonly string SteppingFixtureSrc = Path.GetFullPath(Path.Combine(
+        AppContext.BaseDirectory, "..", "..", "..", "Fixtures", "DapStepping"));
+    private const string SteppingSourceFileName = "DapSteppingTests.Codeunit.al";
+    private const int OuterCallLine = 22;             // Result := Double(Result);
+    private const int OuterThirdStatementLine = 23;   // Result := Result + 10;
+    private const int DoubleFirstStatementLine = 31;  // Y := X * 2;
+    private const int DoubleSecondStatementLine = 32; // exit(Y);
+
     [SkippableFact]
     public async Task Dap_BreakpointOnSecondStatement_PausesBeforeItRuns_ThenContinueCompletesTheTest()
     {
@@ -138,6 +151,164 @@ public class DapServerTests
         var events = new List<JsonElement>();
         var exited = await dap.ReadUntilEventAsync("exited", TimeSpan.FromSeconds(60), events);
         Assert.DoesNotContain(events, e => e.GetProperty("event").GetString() == "stopped");
+        Assert.Equal(0, exited.GetProperty("body").GetProperty("exitCode").GetInt32());
+    }
+
+    /// <summary>Starts a DapClient against the DapStepping fixture, sets one breakpoint,
+    /// and pauses there — the common setup shared by the three step-granularity tests
+    /// below. Returns the client positioned right after the first "stopped" event.</summary>
+    private static async Task<DapClient> StartAndPauseAtAsync(int line)
+    {
+        var dap = await DapClient.StartAsync(SteppingFixtureSrc);
+
+        var initSeq = dap.SendRequest("initialize", new { adapterID = "al-runner-tests" });
+        await dap.ReadUntilResponseAsync(initSeq);
+        await dap.ReadUntilEventAsync("initialized");
+
+        var launchSeq = dap.SendRequest("launch", new { });
+        var launchResp = await dap.ReadUntilResponseAsync(launchSeq, timeout: TimeSpan.FromSeconds(120));
+        Assert.True(launchResp.GetProperty("success").GetBoolean(), launchResp.ToString());
+
+        var sourcePath = Path.Combine(SteppingFixtureSrc, SteppingSourceFileName);
+        var bpSeq = dap.SendRequest("setBreakpoints", new
+        {
+            source = new { path = sourcePath },
+            breakpoints = new[] { new { line } },
+        });
+        var bpResp = await dap.ReadUntilResponseAsync(bpSeq);
+        Assert.True(bpResp.GetProperty("body").GetProperty("breakpoints")[0].GetProperty("verified").GetBoolean(),
+            $"breakpoint at line {line} was not verified: {bpResp}");
+
+        var cfgSeq = dap.SendRequest("configurationDone");
+        await dap.ReadUntilResponseAsync(cfgSeq);
+
+        var stopped = await dap.ReadUntilEventAsync("stopped");
+        Assert.Equal("breakpoint", stopped.GetProperty("body").GetProperty("reason").GetString());
+        Assert.Equal(line, stopped.GetProperty("body").GetProperty("line").GetInt32());
+
+        return dap;
+    }
+
+    /// <summary>Reads the locals of the currently-paused top frame via
+    /// stackTrace/scopes/variables, the same three-call sequence a real DAP client
+    /// makes.</summary>
+    private static async Task<Dictionary<string, string?>> ReadTopFrameLocalsAsync(DapClient dap)
+    {
+        var stSeq = dap.SendRequest("stackTrace", new { threadId = 1 });
+        var stResp = await dap.ReadUntilResponseAsync(stSeq);
+        var frameId = stResp.GetProperty("body").GetProperty("stackFrames")[0].GetProperty("id").GetInt32();
+
+        var scSeq = dap.SendRequest("scopes", new { frameId });
+        var scResp = await dap.ReadUntilResponseAsync(scSeq);
+        var variablesReference = scResp.GetProperty("body").GetProperty("scopes")[0].GetProperty("variablesReference").GetInt32();
+
+        var varSeq = dap.SendRequest("variables", new { variablesReference });
+        var varResp = await dap.ReadUntilResponseAsync(varSeq);
+        return varResp.GetProperty("body").GetProperty("variables").EnumerateArray()
+            .ToDictionary(v => v.GetProperty("name").GetString()!, v => v.GetProperty("value").GetString());
+    }
+
+    /// <summary>
+    /// The core proof for issue #2045: "next" (step over) must run the ENTIRE nested
+    /// call (Double) to completion without pausing inside it, and land on the outer
+    /// scope's next statement. A "next" that behaved like "continue" (pre-#2045) would
+    /// produce no second "stopped" event at all — ReadUntilEventAsync would time out.
+    /// A "next" that behaved like "stepIn" would land on line 31 (inside Double)
+    /// instead of line 23 — the exact-line assertion below catches that too.
+    /// </summary>
+    [SkippableFact]
+    public async Task Dap_Next_StepsOverNestedCall_LandsOnOuterNextStatement()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        await using var dap = await StartAndPauseAtAsync(OuterCallLine);
+
+        var nextSeq = dap.SendRequest("next", new { threadId = 1 });
+        await dap.ReadUntilResponseAsync(nextSeq);
+
+        var stopped = await dap.ReadUntilEventAsync("stopped");
+        Assert.Equal("step", stopped.GetProperty("body").GetProperty("reason").GetString());
+        Assert.Equal(OuterThirdStatementLine, stopped.GetProperty("body").GetProperty("line").GetInt32());
+
+        // Result already holds Double's return (2) — proving the whole nested call
+        // (including its own two statements) genuinely ran to completion, it was not
+        // skipped or faked, and we are paused BEFORE "Result := Result + 10" runs.
+        var vars = await ReadTopFrameLocalsAsync(dap);
+        Assert.Equal("2", vars["Result"]);
+
+        var contSeq = dap.SendRequest("continue", new { threadId = 1 });
+        await dap.ReadUntilResponseAsync(contSeq);
+        var exited = await dap.ReadUntilEventAsync("exited", TimeSpan.FromSeconds(60));
+        Assert.Equal(0, exited.GetProperty("body").GetProperty("exitCode").GetInt32());
+    }
+
+    /// <summary>
+    /// "stepIn" must land on the FIRST statement inside the nested call (Double), not
+    /// the outer scope's next statement — the opposite of the "next" test above, using
+    /// the identical starting pause point, so the two tests only differ in which
+    /// command was sent.
+    /// </summary>
+    [SkippableFact]
+    public async Task Dap_StepIn_EntersNestedCall_LandsOnFirstStatementInside()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        await using var dap = await StartAndPauseAtAsync(OuterCallLine);
+
+        var stepInSeq = dap.SendRequest("stepIn", new { threadId = 1 });
+        await dap.ReadUntilResponseAsync(stepInSeq);
+
+        var stopped = await dap.ReadUntilEventAsync("stopped");
+        Assert.Equal("step", stopped.GetProperty("body").GetProperty("reason").GetString());
+        Assert.Equal(DoubleFirstStatementLine, stopped.GetProperty("body").GetProperty("line").GetInt32());
+
+        // X is Double's parameter (bound to Result==1 at the call site); Y is Double's
+        // own local, not yet assigned ("Y := X * 2" is the statement we are paused
+        // BEFORE, not after) — both readable only because we are genuinely inside
+        // Double's live scope, not the outer one.
+        var vars = await ReadTopFrameLocalsAsync(dap);
+        Assert.Equal("1", vars["X"]);
+        Assert.Equal("0", vars["Y"]);
+
+        var contSeq = dap.SendRequest("continue", new { threadId = 1 });
+        await dap.ReadUntilResponseAsync(contSeq);
+        var exited = await dap.ReadUntilEventAsync("exited", TimeSpan.FromSeconds(60));
+        Assert.Equal(0, exited.GetProperty("body").GetProperty("exitCode").GetInt32());
+    }
+
+    /// <summary>
+    /// "stepOut", issued from INSIDE Double (paused on its second statement), must run
+    /// the rest of Double to completion, return to the outer scope, and land on the
+    /// very next outer statement — the same landing line "next" reaches from the call
+    /// site, but reached from the opposite direction (from inside the callee rather
+    /// than from before the call).
+    /// </summary>
+    [SkippableFact]
+    public async Task Dap_StepOut_ReturnsToCaller_LandsOnStatementAfterTheCall()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        await using var dap = await StartAndPauseAtAsync(DoubleSecondStatementLine);
+
+        // Sanity check on the starting pause itself: Y already holds X*2 (2), the first
+        // statement inside Double already ran, proving we are paused on line 32 for the
+        // reason we think, not by coincidence.
+        var innerVars = await ReadTopFrameLocalsAsync(dap);
+        Assert.Equal("2", innerVars["Y"]);
+
+        var stepOutSeq = dap.SendRequest("stepOut", new { threadId = 1 });
+        await dap.ReadUntilResponseAsync(stepOutSeq);
+
+        var stopped = await dap.ReadUntilEventAsync("stopped");
+        Assert.Equal("step", stopped.GetProperty("body").GetProperty("reason").GetString());
+        Assert.Equal(OuterThirdStatementLine, stopped.GetProperty("body").GetProperty("line").GetInt32());
+
+        var vars = await ReadTopFrameLocalsAsync(dap);
+        Assert.Equal("2", vars["Result"]);
+
+        var contSeq = dap.SendRequest("continue", new { threadId = 1 });
+        await dap.ReadUntilResponseAsync(contSeq);
+        var exited = await dap.ReadUntilEventAsync("exited", TimeSpan.FromSeconds(60));
         Assert.Equal(0, exited.GetProperty("body").GetProperty("exitCode").GetInt32());
     }
 }

--- a/AlRunner.Tests/Fixtures/DapStepping/Assert.Codeunit.al
+++ b/AlRunner.Tests/Fixtures/DapStepping/Assert.Codeunit.al
@@ -1,0 +1,12 @@
+/// <summary>
+/// Minimal assertion helper for this fixture app (own ID range so it
+/// stands alone from the corpus Assert).
+/// </summary>
+codeunit 60900 "Dap Step Assert"
+{
+    procedure AreEqual(Expected: Integer; Actual: Integer; Msg: Text)
+    begin
+        if Expected <> Actual then
+            Error('Assert.AreEqual failed. Expected:<%1>. Actual:<%2>. %3', Expected, Actual, Msg);
+    end;
+}

--- a/AlRunner.Tests/Fixtures/DapStepping/DapSteppingTests.Codeunit.al
+++ b/AlRunner.Tests/Fixtures/DapStepping/DapSteppingTests.Codeunit.al
@@ -1,0 +1,34 @@
+/// <summary>
+/// Nested-call test method for DapServerTests (issue #2045): the outer test procedure
+/// has a statement that calls a local procedure (Double) with two statements of its
+/// own, so step-over ("next"), step-in, and step-out land on three DIFFERENT
+/// statements — proving real step granularity, not all three behaving like "continue".
+/// See individual line-number constants in DapServerTests.cs; they are asserted
+/// against exactly, so do not reformat this file without updating them there too.
+/// </summary>
+codeunit 60901 "Dap Stepping Tests"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit "Dap Step Assert";
+
+    [Test]
+    procedure NestedCall()
+    var
+        Result: Integer;
+    begin
+        Result := 1;
+        Result := Double(Result);
+        Result := Result + 10;
+        Assert.AreEqual(12, Result, 'final value after the nested call and the outer addition');
+    end;
+
+    local procedure Double(X: Integer): Integer
+    var
+        Y: Integer;
+    begin
+        Y := X * 2;
+        exit(Y);
+    end;
+}

--- a/AlRunner.Tests/Fixtures/DapStepping/app.json
+++ b/AlRunner.Tests/Fixtures/DapStepping/app.json
@@ -1,0 +1,25 @@
+{
+  "id": "c3d4e5f6-a7b8-4910-9c3d-4e5f6a7b8093",
+  "name": "Runner Tests Fixture - DAP Stepping",
+  "publisher": "AL Runner",
+  "version": "1.0.0.0",
+  "brief": "Fixture for --dap (issue #2045): a test method with a nested procedure call, used to prove next/stepIn/stepOut land on different statements.",
+  "description": "Used by AlRunner.Tests' DapServerTests.",
+  "privacyStatement": "",
+  "EULA": "",
+  "help": "",
+  "url": "",
+  "logo": "",
+  "dependencies": [],
+  "screenshots": [],
+  "platform": "1.0.0.0",
+  "application": "1.0.0.0",
+  "idRanges": [
+    {
+      "from": 60900,
+      "to": 60949
+    }
+  ],
+  "runtime": "14.0",
+  "features": []
+}

--- a/AlRunner/Infrastructure/AlDapSession.cs
+++ b/AlRunner/Infrastructure/AlDapSession.cs
@@ -18,9 +18,72 @@
 // and reading the live scope's fields from that exact instant (AlScopeInspector), is
 // not an approximation the way --capture-values' StmtHit-based prototype was — it is
 // the correct pause point by definition. No Exit()-style redesign is needed for pause.
+//
+// STEP GRANULARITY (issue #2045) — next/stepIn/stepOut arm a SECOND, orthogonal gate:
+// "pause at the next qualifying StmtHit regardless of the registered breakpoint set".
+//
+// "Qualifying" is defined in terms of NESTING DEPTH — but NOT NavMethodScope's own
+// internal StackDepth property, which the issue originally proposed. Measured
+// (instrumented, running the DapStepping fixture's nested call directly): a LOCAL
+// procedure call within the SAME codeunit gets its own NavMethodScope instance — a
+// genuinely different Type, own fields, own statement numbering restarting at 0,
+// exactly the frame AlDapStackWalker already treats as a distinct stack frame — but
+// StackDepth on that instance comes back IDENTICAL to its caller's, not caller+1.
+// (StackDepth increments crossing an application-object boundary — Codeunit.Run,
+// eventing, TryFunction — not for a same-object local-procedure call lowered to a
+// plain call at compile time.) A depth check built on StackDepth alone therefore could
+// not tell "the call this statement just made" apart from "the next statement in the
+// same procedure" for exactly the nested-call case this feature has to get right, and
+// measurably didn't: it under-stepped (see the PR description for the concrete
+// pre-fix "next landed inside the callee instead of after it" failure).
+//
+// The nesting signal that DOES distinguish them, still needing no reflection, is the
+// same one AlDapStackWalker.Walk already uses to build stack frames: walk
+// NavMethodScope.ParentScope (public) until IsRootScope (public), counting hops.
+// ComputeChainDepth below does exactly that. Confirmed on the same fixture: the outer
+// scope's chain depth is 1, the nested call's is 2, its ParentScope is literally the
+// outer scope instance — the caller/callee relationship AlDapStackWalker's frame list
+// already relies on. Chain depth increases by exactly 1 per NavMethodScope frame
+// regardless of whether the call crosses an application-object boundary, so it is
+// correct through recursion too (a recursive call is still one MORE frame, whatever
+// StackDepth says about it).
+//
+// Given D = the chain depth of the scope the step command was issued from:
+//   - stepIn:  ANY next StmtHit qualifies, at any depth — "stop at the very next
+//              statement, wherever it runs".
+//   - next (step over): chain depth <= D. A nested call the current statement makes
+//              runs to completion unobserved (its own StmtHits are all > D); the first
+//              StmtHit back at D itself, OR at any shallower depth if the current
+//              scope returns without another statement of its own (matches every
+//              mainstream debugger: stepping over the LAST statement of a function
+//              lands you in the caller, not nowhere), satisfies it.
+//   - stepOut: chain depth < D strictly — must have returned past the scope stepOut
+//              was issued from. This is deliberately NOT "shallower than D's
+//              immediate parent" (that would overshoot by one frame): the first
+//              statement that runs at any depth shallower than D is, by construction,
+//              the caller's next statement, because nothing between D and that depth
+//              can run without itself producing a StmtHit that would have satisfied
+//              this condition already.
+// A step that never finds a qualifying StmtHit before its OWN test method finishes
+// simply never pauses again — the test runs to completion normally, same as it would
+// after a plain "continue" that outruns every breakpoint. Nothing hangs: the gate is
+// only ever waited on from inside OnStmtHit, and if OnStmtHit never fires again there
+// is no thread blocked on it. What DOES need explicit handling is that an unconsumed
+// step must not silently apply to the NEXT test in the same --dap run — OnTestBoundary
+// disarms it between tests (see that method's doc comment).
 using Microsoft.Dynamics.Nav.Runtime;
 
 namespace AlRunner.Infrastructure;
+
+/// <summary>Which DAP step command is currently armed. <c>None</c> means only
+/// registered breakpoints can pause execution (or nothing is armed at all).</summary>
+internal enum AlDapStepKind
+{
+    None,
+    In,
+    Over,
+    Out,
+}
 
 public static class AlDapSession
 {
@@ -41,15 +104,31 @@ public static class AlDapSession
     /// registering a new pause nothing will ever release.</summary>
     private static volatile bool _detached;
 
+    /// <summary>The currently-armed step command, or None. Written by StepOver/StepIn/
+    /// StepOut (the DAP-loop thread, while the AL thread is blocked in OnStmtHit) and by
+    /// Continue()/OnTestBoundary() to disarm; read by OnStmtHit (the AL thread). Safe
+    /// without a lock: writers only ever run while the AL thread is either blocked on
+    /// the semaphore or not running at all (between tests), and SemaphoreSlim.Release/
+    /// Wait supply the happens-before edge that makes the write visible before the
+    /// woken thread's next read.</summary>
+    private static volatile AlDapStepKind _stepKind = AlDapStepKind.None;
+
+    /// <summary>ParentScope-chain depth (see ComputeChainDepth) of the scope a step
+    /// command was issued from — the D in the qualifying-depth comparisons documented
+    /// in this file's header.</summary>
+    private static volatile int _stepFromDepth = int.MinValue;
+
     /// <summary>
     /// Fired synchronously ON THE AL EXECUTION THREAD, before it blocks — the caller
     /// (DapServer) uses this to push the DAP "stopped" event over the wire. Must not
-    /// throw: an exception here would propagate into BC's own StmtHit call.
+    /// throw: an exception here would propagate into BC's own StmtHit call. The reason
+    /// is "breakpoint" or "step" (DAP's StoppedEvent.reason values), matching whichever
+    /// condition actually caused this particular pause — see OnStmtHit.
     /// </summary>
-    public static event Action<NavMethodScope, int>? Stopped;
+    public static event Action<NavMethodScope, int, string>? Stopped;
 
     /// <summary>Resets all state for a new session — breakpoints, any stale pause, the
-    /// detached flag. Call before a fresh --dap run starts.</summary>
+    /// detached flag, any armed step. Call before a fresh --dap run starts.</summary>
     public static void Reset()
     {
         lock (_bpLock) _breakpoints.Clear();
@@ -57,6 +136,8 @@ public static class AlDapSession
         _pausedScope = null;
         _pausedStatement = -1;
         _detached = false;
+        _stepKind = AlDapStepKind.None;
+        _stepFromDepth = int.MinValue;
         Stopped = null;
     }
 
@@ -78,10 +159,49 @@ public static class AlDapSession
 
     public static bool IsPaused => _pausedScope != null;
 
-    /// <summary>Releases a paused AL execution thread (DAP `continue`/`next`/`stepIn`/
-    /// `stepOut` — this first slice treats all four identically, see the issue's PR
-    /// description for why real step granularity is follow-up work).</summary>
-    public static void Continue() => _pauseGate?.Release();
+    /// <summary>Releases a paused AL execution thread (DAP `continue`) without arming
+    /// any step — only a registered breakpoint can pause it again.</summary>
+    public static void Continue()
+    {
+        _stepKind = AlDapStepKind.None;
+        _pauseGate?.Release();
+    }
+
+    /// <summary>DAP `stepIn`: arms "pause at the very next StmtHit, at any depth" and
+    /// releases the paused thread.</summary>
+    public static void StepIn() => ArmStep(AlDapStepKind.In);
+
+    /// <summary>DAP `next` (step over): arms "pause at the next StmtHit at the same or
+    /// a shallower chain depth than the paused frame" and releases the paused thread.</summary>
+    public static void StepOver() => ArmStep(AlDapStepKind.Over);
+
+    /// <summary>DAP `stepOut`: arms "pause at the next StmtHit strictly shallower
+    /// (chain depth) than the paused frame" and releases the paused thread.</summary>
+    public static void StepOut() => ArmStep(AlDapStepKind.Out);
+
+    private static void ArmStep(AlDapStepKind kind)
+    {
+        var scope = _pausedScope;
+        // If nothing is paused (defensive; the DAP loop only calls this while
+        // IsPaused), there is no depth to compare against and no thread to release
+        // either — arm nothing rather than compare against a meaningless depth.
+        _stepFromDepth = scope != null ? ComputeChainDepth(scope) : int.MinValue;
+        _stepKind = kind;
+        _pauseGate?.Release();
+    }
+
+    /// <summary>Call once per completed test, between tests, in a --dap run (see
+    /// RunDapLoop's dapRunStep onTestComplete callback). A step command that never
+    /// found a qualifying StmtHit within the test it was issued for must not silently
+    /// carry over and pause some LATER, unrelated test purely because that test's
+    /// early statements happen to run at a chain depth the old comparison still
+    /// accepts — a fresh top-level call always starts back at chain depth 1, so a
+    /// stale armed step is a live hazard, not just clutter.</summary>
+    public static void OnTestBoundary()
+    {
+        _stepKind = AlDapStepKind.None;
+        _stepFromDepth = int.MinValue;
+    }
 
     /// <summary>Permanently stops pausing (DAP `disconnect`/`terminate`) and releases
     /// any thread currently blocked — an AL execution thread must never be left stuck
@@ -98,7 +218,8 @@ public static class AlDapSession
     /// bool]) — public static, exactly (NavMethodScope, int) so the rewrite can forward
     /// `ldarg.0; ldarg.1; call` unboxed, same shape as AlCoverageTracker.OnStmtHit. Runs
     /// on EVERY AL statement of every test, --dap or not — must stay near-zero-cost when
-    /// disabled.
+    /// disabled. The `!Enabled` check MUST stay first: everything after it, including
+    /// the step-depth walk, only runs for an active --dap session.
     /// </summary>
     public static void OnStmtHit(NavMethodScope scope, int currentStatementNumber)
     {
@@ -107,9 +228,21 @@ public static class AlDapSession
         // int.MaxValue directly, StmtHit never receives it from generated code.
         if (currentStatementNumber == int.MaxValue) return;
 
-        bool hit;
-        lock (_bpLock) hit = _breakpoints.Contains((scope.GetType(), currentStatementNumber));
-        if (!hit) return;
+        bool breakpointHit;
+        lock (_bpLock) breakpointHit = _breakpoints.Contains((scope.GetType(), currentStatementNumber));
+
+        var stepKind = _stepKind;
+        bool stepHit = stepKind != AlDapStepKind.None && StepQualifies(stepKind, scope);
+
+        if (!breakpointHit && !stepHit) return;
+
+        // Breakpoints and steps are independent gates; if a step happens to land on a
+        // registered breakpoint's statement too, report it as the more specific/
+        // intentional "breakpoint" — matches mainstream debugger UX (an explicit
+        // breakpoint always "wins" the displayed reason). Either way, disarm the step:
+        // it has either been consumed or superseded by an explicit breakpoint.
+        var reason = breakpointHit ? "breakpoint" : "step";
+        _stepKind = AlDapStepKind.None;
 
         var gate = new System.Threading.SemaphoreSlim(0, 1);
         _pauseGate = gate;
@@ -117,8 +250,8 @@ public static class AlDapSession
         _pausedStatement = currentStatementNumber;
         try
         {
-            Stopped?.Invoke(scope, currentStatementNumber);
-            gate.Wait(); // blocks the AL execution thread until Continue()/Detach()
+            Stopped?.Invoke(scope, currentStatementNumber, reason);
+            gate.Wait(); // blocks the AL execution thread until Continue()/Step*()/Detach()
         }
         finally
         {
@@ -126,5 +259,30 @@ public static class AlDapSession
             _pausedStatement = -1;
             _pauseGate = null;
         }
+    }
+
+    private static bool StepQualifies(AlDapStepKind kind, NavMethodScope scope)
+    {
+        if (kind == AlDapStepKind.In) return true;
+        var depth = ComputeChainDepth(scope);
+        return kind == AlDapStepKind.Over ? depth <= _stepFromDepth : depth < _stepFromDepth;
+    }
+
+    /// <summary>Counts NavMethodScope frames from <paramref name="scope"/> outward via
+    /// ParentScope (public) until IsRootScope (public) — the SAME walk
+    /// AlDapStackWalker.Walk already performs to build stack frames, reused here purely
+    /// for its length rather than its content. See this file's header for why this,
+    /// not NavMethodScope's own (internal) StackDepth, is the correct nesting signal
+    /// for step granularity.</summary>
+    private static int ComputeChainDepth(NavMethodScope scope)
+    {
+        var depth = 0;
+        var cur = scope;
+        while (cur != null && !cur.IsRootScope)
+        {
+            depth++;
+            cur = cur.ParentScope;
+        }
+        return depth;
     }
 }

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -3392,8 +3392,10 @@ return strictExitCode ? computedExitCode : 0;
 //   (AlDapSession.Stopped fires on the AL thread when a breakpoint hits; this loop
 //    pushes the "stopped" event the moment it fires — see the subscription below)
 //   threads/stackTrace/scopes/variables -> read AlDapSession.PausedScope while paused
-//   continue/next/stepIn/stepOut -> AlDapSession.Continue() (all four alike — see the
-//    PR description for why real step granularity is explicit follow-up scope)
+//   continue -> AlDapSession.Continue(); next/stepIn/stepOut -> AlDapSession.StepOver()/
+//    StepIn()/StepOut() (issue #2045 — real step granularity, arms a depth-based
+//    qualifying condition instead of releasing unconditionally; see AlDapSession's file
+//    header for exactly what "qualifies" means for each)
 //   disconnect/terminate -> AlDapSession.Detach() (never leaves the AL thread stuck)
 int RunDapLoop(int port, string bundleDir)
 {
@@ -3419,7 +3421,14 @@ int RunDapLoop(int port, string bundleDir)
     {
         compiledTcs.TrySetResult(asm);
         configurationDoneGate.Wait(cts.Token);
-        return executor.Run(asm, t => Console.WriteLine($"[dap] {t.Codeunit}.{t.Method}: {t.Outcome}"), cts.Token);
+        return executor.Run(asm, t =>
+        {
+            Console.WriteLine($"[dap] {t.Codeunit}.{t.Method}: {t.Outcome}");
+            // issue #2045: a step armed for THIS test but never consumed (it ran to
+            // completion without another qualifying StmtHit) must not leak into the
+            // NEXT test — see AlDapSession.OnTestBoundary's doc comment.
+            AlRunner.Infrastructure.AlDapSession.OnTestBoundary();
+        }, cts.Token);
     };
 
     var bundleRunTask = System.Threading.Tasks.Task.Run(
@@ -3452,8 +3461,10 @@ int RunDapLoop(int port, string bundleDir)
     }, System.Threading.Tasks.TaskScheduler.Default);
 
     // Pushed synchronously on the AL EXECUTION thread by AlDapSession.OnStmtHit,
-    // right before it blocks — see that method's doc comment. Must not throw.
-    AlRunner.Infrastructure.AlDapSession.Stopped += (scope, stmt) =>
+    // right before it blocks — see that method's doc comment. Must not throw. `reason`
+    // is "breakpoint" or "step" (issue #2045), whichever condition actually caused
+    // this particular pause.
+    AlRunner.Infrastructure.AlDapSession.Stopped += (scope, stmt, reason) =>
     {
         try
         {
@@ -3461,7 +3472,7 @@ int RunDapLoop(int port, string bundleDir)
             var line = lastFrames.Count > 0 ? lastFrames[0].Line : 0;
             transport.WriteEvent("stopped", new
             {
-                reason = "breakpoint",
+                reason,
                 threadId = 1,
                 allThreadsStopped = true,
                 line,
@@ -3629,13 +3640,28 @@ int RunDapLoop(int port, string bundleDir)
                     }
 
                     case "continue":
-                    case "next":
-                    case "stepIn":
-                    case "stepOut":
                     case "pause":
                         AlRunner.Infrastructure.AlDapSession.Continue();
                         transport.WriteResponse(msg.Seq, command, true,
                             command == "continue" ? new { allThreadsContinued = true } : null);
+                        break;
+
+                    // issue #2045: real step granularity — each arms a depth-based
+                    // qualifying condition (see AlDapSession's file header) instead of
+                    // releasing unconditionally like "continue" above.
+                    case "next":
+                        AlRunner.Infrastructure.AlDapSession.StepOver();
+                        transport.WriteResponse(msg.Seq, command, true);
+                        break;
+
+                    case "stepIn":
+                        AlRunner.Infrastructure.AlDapSession.StepIn();
+                        transport.WriteResponse(msg.Seq, command, true);
+                        break;
+
+                    case "stepOut":
+                        AlRunner.Infrastructure.AlDapSession.StepOut();
+                        transport.WriteResponse(msg.Seq, command, true);
                         break;
 
                     case "disconnect":
@@ -4636,9 +4662,10 @@ static void PrintHelp(TextWriter w)
     w.WriteLine("                          real DAP TCP connection. Requires exactly one bundle path.");
     w.WriteLine("                          Compiles on `launch`, pauses AL execution at StmtHit for");
     w.WriteLine("                          any breakpointed statement once `configurationDone` starts");
-    w.WriteLine("                          the run. next/stepIn/stepOut currently behave like");
-    w.WriteLine("                          continue (real step granularity is follow-up work).");
-    w.WriteLine("                          See docs/dap-mode.md. Mutually exclusive with --server.");
+    w.WriteLine("                          the run. next/stepIn/stepOut pause at a real qualifying");
+    w.WriteLine("                          statement (step-over/into/out of the current call), not");
+    w.WriteLine("                          just at the next breakpoint. See docs/dap-mode.md.");
+    w.WriteLine("                          Mutually exclusive with --server.");
     w.WriteLine("  --tdd                   Local-development flag (not for CI). A test referencing a");
     w.WriteLine("                          table field / procedure / enum value the implementing app");
     w.WriteLine("                          doesn't have yet normally drops the whole app group with a");

--- a/README.md
+++ b/README.md
@@ -143,13 +143,13 @@ al-runner --server [--package-cache PATH ...] [--cache DIR]
 
 A long-running JSON-RPC daemon over stdin/stdout. Dependencies and BC patches load once; each `runTests` request re-emits the bundle warm and runs it in-process (~19s→~4s). stdout carries only the newline-delimited JSON protocol; logs go to stderr. The VS Code extension uses this. Full protocol + the same-bundle reload contract: [docs/server-mode.md](docs/server-mode.md).
 
-### Debug adapter mode (breakpoints)
+### Debug adapter mode (breakpoints + stepping)
 
 ```bash
 al-runner --dap [PORT] <bundle-dir>
 ```
 
-A real Debug Adapter Protocol server (default port 4711) over a TCP socket: set AL breakpoints, pause execution, inspect locals. No new AL→source mapping — it reuses BC's own `StmtHit`/`[SourceSpans]` instrumentation, the same mechanism `--coverage` and `--capture-values` already consume. Full protocol + current limitations (no real step granularity yet, no VS Code launch configuration in this repo): [docs/dap-mode.md](docs/dap-mode.md).
+A real Debug Adapter Protocol server (default port 4711) over a TCP socket: set AL breakpoints, pause execution, step through the paused code (`next`/`stepIn`/`stepOut`), inspect locals. No new AL→source mapping — it reuses BC's own `StmtHit`/`[SourceSpans]` instrumentation, the same mechanism `--coverage` and `--capture-values` already consume. Full protocol + current limitations (no VS Code launch configuration in this repo): [docs/dap-mode.md](docs/dap-mode.md).
 
 ### Precompile a single `.app` to a DLL
 

--- a/docs/dap-mode.md
+++ b/docs/dap-mode.md
@@ -4,12 +4,13 @@
 Protocol](https://microsoft.github.io/debug-adapter-protocol/overview) server
 over a TCP socket (default port `4711`, matching v1). It compiles the given
 bundle, waits for a DAP client to connect, and lets that client set
-breakpoints on AL source lines, pause execution at them, and inspect the AL
-locals in scope at the pause — with no BC service tier, no PDB, and no
-IL-offset mapping.
+breakpoints on AL source lines, pause execution at them, step through the
+paused code (`next`/`stepIn`/`stepOut`), and inspect the AL locals in scope
+at each pause — with no BC service tier, no PDB, and no IL-offset mapping.
 
-This is the first slice of issue #1642. See "What's not in this slice" below
-before assuming a capability exists.
+This started as the first slice of issue #1642 (breakpoints only); issue
+#2045 added real step granularity. See "What's not in this slice" below
+before assuming some other capability exists.
 
 ## Mechanism
 
@@ -62,8 +63,15 @@ lifecycle:
 6. `threads` / `stackTrace` / `scopes` / `variables` — read the paused call
    stack and each frame's `[NavName]`-tagged AL locals, live, via
    `AlScopeInspector`.
-7. `continue` / `next` / `stepIn` / `stepOut` — resumes execution (all four
-   behave identically in this slice; see below).
+7. `continue` — resumes execution; only a registered breakpoint pauses it
+   again. `next` (step over) / `stepIn` / `stepOut` (issue #2045) each arm a
+   depth-based condition instead — the AL execution thread stops at the first
+   subsequent `StmtHit` that "qualifies" for the command sent, and the
+   `stopped` event's `reason` is `"step"` rather than `"breakpoint"`. See
+   `AlRunner/Infrastructure/AlDapSession.cs`'s file header for exactly what
+   "qualifies" means for each (it is defined purely in terms of
+   `NavMethodScope.StackDepth`, so it is correct through recursion too, not
+   just simple nested calls).
 8. `disconnect` / `terminate` — releases any paused thread (never leaves it
    stuck) and ends the session.
 
@@ -75,9 +83,6 @@ and write `Content-Length: <n>\r\n\r\n<json>` frames by hand.
 
 ## What's not in this slice
 
-- **Real step granularity.** `next`/`stepIn`/`stepOut` all behave like
-  `continue` — none of them pause at the very next statement the way a real
-  single-step would. Tracked as follow-up.
 - **A VS Code launch configuration.** There is no `type` contribution a
   `launch.json` can point at without an installed extension; wiring this up
   belongs in the (separate-repo) AL Runner VS Code extension. Tracked as

--- a/docs/dap-mode.md
+++ b/docs/dap-mode.md
@@ -69,9 +69,15 @@ lifecycle:
    subsequent `StmtHit` that "qualifies" for the command sent, and the
    `stopped` event's `reason` is `"step"` rather than `"breakpoint"`. See
    `AlRunner/Infrastructure/AlDapSession.cs`'s file header for exactly what
-   "qualifies" means for each (it is defined purely in terms of
-   `NavMethodScope.StackDepth`, so it is correct through recursion too, not
-   just simple nested calls).
+   "qualifies" means for each. The depth signal is a manual walk of
+   `NavMethodScope.ParentScope` (the same chain `AlDapStackWalker` already
+   walks to build stack frames), NOT the scope's own (internal) `StackDepth`
+   property — measured directly: a local procedure call within the same
+   codeunit gets its own `NavMethodScope` (a genuinely nested frame) but
+   `StackDepth` on it comes back identical to its caller's, so a StackDepth-
+   based check could not tell "entered a nested call" apart from "next
+   statement, same scope" for exactly the case this feature needs to get
+   right. The `ParentScope` walk is correct through recursion too.
 8. `disconnect` / `terminate` — releases any paused thread (never leaves it
    stuck) and ends the session.
 


### PR DESCRIPTION
Closes #2045

## Summary

`next`/`stepIn`/`stepOut` previously all behaved exactly like `continue` (see #2048's slice-1 note). This adds a second, orthogonal pause gate to `AlDapSession`: an armed step condition that pauses at the next qualifying `StmtHit` regardless of the registered breakpoint set.

## The depth signal, and why it isn't `NavMethodScope.StackDepth`

The issue proposed comparing `NavMethodScope.StackDepth` (internal, reflectable) between the paused frame and each subsequent `StmtHit`. Measured directly against a nested-call fixture: a **local procedure call within the same codeunit gets its own `NavMethodScope` instance** (own type, own fields, own statement numbering, exactly the frame `AlDapStackWalker` already treats as a distinct stack frame) — but its `StackDepth` comes back **identical** to its caller's, not caller+1. `StackDepth` evidently only increments crossing an application-object boundary (`Codeunit.Run`, eventing, `TryFunction`), not for a same-object local-procedure call lowered to a plain call at compile time. A `StackDepth`-based "next" therefore could not tell "entered the nested call" apart from "next statement, same scope" — and didn't: it stepped straight into the callee instead of over it.

The signal that does distinguish them needs no reflection at all: walking `NavMethodScope.ParentScope` (public) until `IsRootScope` (public) — the exact same walk `AlDapStackWalker.Walk` already performs to build stack frames. Confirmed on the same fixture: the outer scope's chain depth is 1, the nested call's is 2, and the nested call's `ParentScope` is literally the outer scope instance.

Given `D` = the chain depth of the paused scope:
- `stepIn` — any next `StmtHit` qualifies, at any depth.
- `next` (step over) — chain depth `<= D`. A nested call runs to completion unobserved; the first `StmtHit` back at `D` (or shallower, if the current scope returns without another statement of its own — matches mainstream debugger behaviour on a function's last statement) satisfies it.
- `stepOut` — chain depth `< D` strictly.

A step that never finds a qualifying `StmtHit` before its own test finishes simply never pauses again (same as a `continue` that outruns every breakpoint) — nothing hangs. An armed-but-unconsumed step is explicitly disarmed between tests (`AlDapSession.OnTestBoundary`, wired into the DAP loop's per-test callback) so it can never leak into an unrelated later test whose early statements happen to sit at a chain depth the old comparison would still accept.

The `!Enabled` early return in `OnStmtHit` is untouched and still gates everything after it — no work added ahead of it.

## Interim-signal follow-up (maintainer comment on #2045)

Resolved by this PR rather than needing a separate interim fix: a step command now genuinely pauses and reports `reason: "step"` in the `stopped` event, so there's no more silent-resume gap for an editor to show.

## Tests

`AlRunner.Tests/Fixtures/DapStepping` — a new fixture with a nested procedure call (`NestedCall` calls local `Double`), so step-over vs step-into vs step-out land on three different, asserted statements:
- `Dap_Next_StepsOverNestedCall_LandsOnOuterNextStatement` — "next" from the call site skips the entire nested call and lands on the outer scope's next statement; asserts the specific line and that `Result` already reflects the callee's return value.
- `Dap_StepIn_EntersNestedCall_LandsOnFirstStatementInside` — "stepIn" from the same starting point lands on the callee's first statement; asserts the specific line and the callee's own live locals (`X`/`Y`).
- `Dap_StepOut_ReturnsToCaller_LandsOnStatementAfterTheCall` — "stepOut" issued from inside the callee runs it to completion and lands on the outer scope's next statement.

RED confirmed against the pre-fix code (all three timed out waiting for a second `stopped` event that never arrived, since `next`/`stepIn`/`stepOut` were all `Continue()`). GREEN confirmed after the fix, including the two pre-existing `DapServerTests` (breakpoint pause + no-breakpoints-set) — no regression.

Note on a pre-existing, unrelated local test failure: `SourceDepSymbolsWithoutPackageCacheTests.SiblingSourceDep_CompilesWithZeroPackageCacheDirs` fails identically on a clean `origin/main` checkout with none of this PR's changes (verified in a separate worktree) — it is not caused by or related to this change.

`docs/dap-mode.md`'s "What's not in this slice" section is updated (the real-step-granularity bullet removed; the mechanism section explains the `ParentScope`-vs-`StackDepth` finding), and README's `--dap` blurb updated.