### PR TITLE
dap: add a stdio transport so VS Code can launch the adapter directly

### DIFF
--- a/AlRunner.Tests/DapClient.cs
+++ b/AlRunner.Tests/DapClient.cs
@@ -12,8 +12,14 @@ namespace AlRunner.Tests;
 /// itself uses on the server side of this connection), for issue #1642. Unlike
 /// CliServer/SharedCliServer, a DAP session is inherently single-shot (one client,
 /// one bundle, one run) so there is no shared-process variant of this helper.
+///
+/// The response/event demultiplexing (queueing, phased drain, the #2070 race this
+/// exists to prevent) lives in the shared <see cref="DapClientBase"/> — see its
+/// header comment. This class supplies only what's specific to the TCP transport:
+/// spawning + connecting, and the socket-available/ThreadPool diagnostics attached
+/// to a genuine read timeout.
 /// </summary>
-public sealed class DapClient : IAsyncDisposable
+public sealed class DapClient : DapClientBase
 {
     private static readonly string RepoRoot = Path.GetFullPath(
         Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
@@ -21,7 +27,6 @@ public sealed class DapClient : IAsyncDisposable
 
     private readonly Process _process;
     private readonly TcpClient _tcp;
-    private readonly DapTransport _transport;
     private readonly StringBuilder _stderr;
     private readonly StringBuilder _stdout;
 
@@ -54,7 +59,7 @@ public sealed class DapClient : IAsyncDisposable
     // captured CI logs). Belt and suspenders: do both, trust the one already proven.
     private readonly StringBuilder _clientTrace = new();
 
-    private void Trace(string msg)
+    protected override void Trace(string msg)
     {
         if (!_traceEnabled) return;
         // InvariantCulture, not the interpolated ":" format-string shorthand — ":" in a
@@ -70,11 +75,14 @@ public sealed class DapClient : IAsyncDisposable
 
     private string ClientTrace { get { lock (_clientTrace) return _clientTrace.ToString(); } }
 
+    protected override string DiagnosticDump() =>
+        $"--- stdout ---\n{StdOut}\n--- stderr ---\n{StdErr}\n--- client trace ---\n{ClientTrace}";
+
     private DapClient(Process process, TcpClient tcp, DapTransport transport, StringBuilder stdout, StringBuilder stderr)
+        : base(transport)
     {
         _process = process;
         _tcp = tcp;
-        _transport = transport;
         _stdout = stdout;
         _stderr = stderr;
     }
@@ -185,139 +193,6 @@ public sealed class DapClient : IAsyncDisposable
         return port;
     }
 
-    /// <summary>Sends a DAP request and returns its seq (for matching against the
-    /// eventual response's request_seq via <see cref="ReadUntilResponseAsync"/>).</summary>
-    public int SendRequest(string command, object? arguments = null)
-    {
-        var seq = _transport.WriteRequest(command, arguments);
-        Trace($"SEND {command} seq={seq}");
-        return seq;
-    }
-
-    // Issue #2070's actual root cause, found AFTER the watchdog race (real, fixed) and
-    // the Stopped-handler exception swallow (real, fixed) both turned out NOT to be
-    // what any concrete local reproduction showed: DAP responses and events are two
-    // INDEPENDENT streams that interleave by protocol design, and every call site in
-    // this file used to call ReadUntilResponseAsync WITHOUT an `events` list — so any
-    // event that arrived while waiting for a response was read off the socket and then
-    // dropped on the floor by `events?.Add(root)` on a null list. Concretely, for
-    // "next"/"stepIn"/"stepOut": handling the command releases the paused AL thread,
-    // which is then free to run, qualify, and write its own "stopped" event — a race
-    // against the DAP loop thread writing the command's OWN response. If the AL thread
-    // wins, the wire order is "stopped" event FIRST, command response SECOND.
-    // ReadUntilResponseAsync reads the "stopped" event, throws it away (no events
-    // list), reads the response, returns — and the test's very next call,
-    // ReadUntilEventAsync("stopped"), is now waiting for a SECOND "stopped" event that
-    // will never be sent, hence the 60s timeout with socket.Available=0 (the event
-    // really was delivered — and consumed and discarded) and a perfectly healthy
-    // server (it did everything right; see AlDapSession.Trace / Program.cs's
-    // STOPPED-HANDLER trace, both of which show a clean ARM/EVAL/FIRE/Walk/WriteEvent
-    // sequence in every local reproduction of this hang). It only ever hits the step
-    // tests, never the initial breakpoint reached via configurationDone, because there
-    // the response is written before the AL thread starts running at all — no race.
-    //
-    // The fix is NOT to pass an `events` list at every call site — that only narrows
-    // the trap for whichever call remembered to. A real DAP client treats events as a
-    // durable, independent stream: anything that isn't the message currently being
-    // waited for is queued, not discarded, and later reads drain the queue before
-    // touching the socket.
-    //
-    // CAUGHT WHILE BUILDING THIS: a first version had both methods dequeue from
-    // _pendingEvents and unconditionally re-enqueue a non-matching item back onto the
-    // SAME queue, in the SAME loop iteration, with no socket I/O in between. With
-    // exactly one item queued (the common case) that dequeue-then-requeue is a net
-    // no-op that repeats at CPU-bound spin speed — no real wait, no forward progress —
-    // and blew up a StringBuilder from the accompanying Trace() calls before the
-    // nominal timeout's wall-clock deadline could even be reached. Fixed by splitting
-    // each method into two phases: first drain whatever was ALREADY queued, bounded by
-    // a snapshot of the queue's length taken before the scan starts (so a re-queued
-    // miss is never reconsidered within the same phase-1 pass); only once that snapshot
-    // is exhausted does phase 2 fall through to blocking socket reads, which is the
-    // only phase allowed to burn real wall-clock time.
-    private readonly Queue<JsonElement> _pendingEvents = new();
-
-    /// <summary>Reads messages until the response to <paramref name="requestSeq"/>
-    /// arrives, returning it. Any events seen along the way — whether already sitting
-    /// in <see cref="_pendingEvents"/> from an earlier read or freshly read off the
-    /// socket — are appended to <paramref name="events"/> if given, and (unconditionally)
-    /// left in <see cref="_pendingEvents"/> so a later <see cref="ReadUntilEventAsync"/>
-    /// still sees them even when no `events` list is given here. A response is never
-    /// queued (by construction, only "event"-typed messages are), so phase 1 can only
-    /// ever collect for `events`, never satisfy the wait itself — it still has to run
-    /// so already-queued events are not skipped when a caller wants to see them.</summary>
-    public async Task<JsonElement> ReadUntilResponseAsync(int requestSeq, List<JsonElement>? events = null, TimeSpan? timeout = null)
-    {
-        var t = timeout ?? TimeSpan.FromSeconds(30);
-
-        var alreadyQueued = _pendingEvents.Count;
-        for (var i = 0; i < alreadyQueued; i++)
-        {
-            var queuedRoot = _pendingEvents.Dequeue();
-            events?.Add(queuedRoot);
-            _pendingEvents.Enqueue(queuedRoot);
-        }
-
-        var deadline = DateTime.UtcNow + t;
-        while (DateTime.UtcNow < deadline)
-        {
-            var msg = await ReadOneAsync(t);
-            var root = msg.Raw.RootElement;
-            var type = root.GetProperty("type").GetString();
-            if (type == "response" && root.TryGetProperty("request_seq", out var rs) && rs.GetInt32() == requestSeq)
-                return root;
-            if (type == "event")
-            {
-                events?.Add(root);
-                var evName = root.TryGetProperty("event", out var evEl) ? evEl.GetString() : "?";
-                Trace($"QUEUE event={evName} arrived while waiting for response to seq={requestSeq} — not dropped");
-                _pendingEvents.Enqueue(root);
-            }
-        }
-        throw new TimeoutException($"no response to request seq {requestSeq} within timeout.\n--- stdout ---\n{StdOut}\n--- stderr ---\n{StdErr}\n--- client trace ---\n{ClientTrace}");
-    }
-
-    /// <summary>Reads messages until an event named <paramref name="eventName"/>
-    /// arrives, returning its body. Used to wait for e.g. "stopped". Every event seen
-    /// along the way (including the terminal one) is appended to <paramref
-    /// name="allEvents"/> if given, so a caller can assert on what did NOT arrive (e.g.
-    /// "no 'stopped' event fired") without a second read loop. Phase 1 scans whatever
-    /// is ALREADY in <see cref="_pendingEvents"/> — bounded to a snapshot of its length
-    /// so a non-matching item is examined exactly once per call, never spun on — before
-    /// phase 2 falls through to blocking socket reads.</summary>
-    public async Task<JsonElement> ReadUntilEventAsync(string eventName, TimeSpan? timeout = null, List<JsonElement>? allEvents = null)
-    {
-        var t = timeout ?? TimeSpan.FromSeconds(60);
-
-        var alreadyQueued = _pendingEvents.Count;
-        for (var i = 0; i < alreadyQueued; i++)
-        {
-            var queuedRoot = _pendingEvents.Dequeue();
-            allEvents?.Add(queuedRoot);
-            var queuedEventName = queuedRoot.TryGetProperty("event", out var qEvEl) ? qEvEl.GetString() : null;
-            if (queuedEventName == eventName) return queuedRoot;
-            _pendingEvents.Enqueue(queuedRoot);
-        }
-
-        var deadline = DateTime.UtcNow + t;
-        while (DateTime.UtcNow < deadline)
-        {
-            var msg = await ReadOneAsync(t);
-            var root = msg.Raw.RootElement;
-            if (root.GetProperty("type").GetString() != "event") continue;
-            allEvents?.Add(root);
-            var thisEventName = root.TryGetProperty("event", out var evEl) ? evEl.GetString() : null;
-            if (thisEventName == eventName)
-                return root;
-            // A different event than the one being awaited right now — re-queue it
-            // rather than drop it, same principle as ReadUntilResponseAsync above (a
-            // second step command in a row, each waiting on its own "stopped", is the
-            // same shape of race one level up).
-            Trace($"QUEUE event={thisEventName ?? "?"} arrived while waiting for event={eventName} — not dropped");
-            _pendingEvents.Enqueue(root);
-        }
-        throw new TimeoutException($"event '{eventName}' did not arrive within {t.TotalSeconds:F0}s.\n--- stdout ---\n{StdOut}\n--- stderr ---\n{StdErr}\n--- client trace ---\n{ClientTrace}");
-    }
-
     /// <summary>
     /// Issue #2070: a per-read timeout that genuinely fires (nothing ever arrives) used
     /// to surface as a bare <see cref="OperationCanceledException"/> from the awaited
@@ -332,13 +207,13 @@ public sealed class DapClient : IAsyncDisposable
     /// means the NEXT genuine hang's runner-side stderr (including the step trace) is
     /// actually visible in the test failure message instead of silently discarded.
     /// </summary>
-    private async Task<DapIncomingMessage> ReadOneAsync(TimeSpan timeout)
+    protected override async Task<DapIncomingMessage> ReadOneAsync(TimeSpan timeout)
     {
         using var cts = new CancellationTokenSource(timeout);
         DapIncomingMessage? msg;
         try
         {
-            msg = await _transport.ReadMessageAsync(cts.Token);
+            msg = await Transport.ReadMessageAsync(cts.Token);
         }
         catch (OperationCanceledException) when (cts.IsCancellationRequested)
         {
@@ -394,9 +269,9 @@ public sealed class DapClient : IAsyncDisposable
         return msg;
     }
 
-    public async ValueTask DisposeAsync()
+    public override async ValueTask DisposeAsync()
     {
-        try { _transport.Dispose(); } catch { }
+        try { Transport.Dispose(); } catch { }
         try { _tcp.Dispose(); } catch { }
         try
         {

--- a/AlRunner.Tests/DapClientBase.cs
+++ b/AlRunner.Tests/DapClientBase.cs
@@ -1,0 +1,165 @@
+using System.Text.Json;
+using AlRunner.Infrastructure;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// Shared response/event demultiplexing core for the DAP end-to-end test clients —
+/// <see cref="DapClient"/> (TCP) and <see cref="DapStdioClient"/> (the child
+/// process's own stdin/stdout). Both drive the identical DAP session over
+/// AlRunner.Infrastructure.DapTransport; the only difference between them is which
+/// pair of Streams the transport is constructed over, and which transport-specific
+/// diagnostics are worth attaching to a timeout (DapClient's TCP-socket-available/
+/// ThreadPool probe has no stdio equivalent). Everything about turning "a stream of
+/// DAP messages" into "the response to seq N" / "the next 'stopped' event" belongs
+/// HERE, once — not duplicated per transport.
+///
+/// That duplication is exactly how issue #2070 recurred: DAP responses and events
+/// are two INDEPENDENT streams that interleave by protocol design. Handling
+/// "next"/"stepIn"/"stepOut" releases the paused AL thread, which is then free to
+/// run, qualify, and write its own "stopped" event — a race against the DAP loop
+/// thread writing the command's OWN response. If the AL thread wins, the wire order
+/// is "stopped" event FIRST, command response SECOND. A ReadUntilResponseAsync that
+/// discards events seen while waiting for a response reads that "stopped" event,
+/// throws it away, reads the response, returns — and the caller's very next
+/// ReadUntilEventAsync("stopped") then waits the full timeout for a second "stopped"
+/// that will never be sent. #2070 fixed this for DapClient (the TCP client); the
+/// original PR for #2058 (this stdio client) shipped its OWN, unfixed copy of the
+/// same read loop, reproducing the identical hang one transport over. A shared base
+/// class is the fix for the CLASS of bug, not just the one instance of it: anything
+/// that isn't the message currently being waited for is queued, not discarded, and
+/// later reads drain the queue before touching the underlying stream again.
+///
+/// CAUGHT WHILE BUILDING THE ORIGINAL FIX: a first version had both methods dequeue
+/// from <see cref="_pendingEvents"/> and unconditionally re-enqueue a non-matching
+/// item back onto the SAME queue, in the SAME loop iteration, with no stream I/O in
+/// between. With exactly one item queued (the common case) that dequeue-then-requeue
+/// is a net no-op that repeats at CPU-bound spin speed — no real wait, no forward
+/// progress. Fixed by splitting each method into two phases: phase 1 drains whatever
+/// was ALREADY queued, bounded by a snapshot of the queue's length taken before the
+/// scan starts (so a re-queued miss is never reconsidered within the same phase-1
+/// pass); only once that snapshot is exhausted does phase 2 fall through to blocking
+/// reads via <see cref="ReadOneAsync"/>, the only phase allowed to burn real
+/// wall-clock time.
+/// </summary>
+public abstract class DapClientBase : IAsyncDisposable
+{
+    protected readonly DapTransport Transport;
+
+    protected DapClientBase(DapTransport transport)
+    {
+        Transport = transport;
+    }
+
+    private readonly Queue<JsonElement> _pendingEvents = new();
+
+    /// <summary>Sends a DAP request and returns its seq (for matching against the
+    /// eventual response's request_seq via <see cref="ReadUntilResponseAsync"/>).</summary>
+    public int SendRequest(string command, object? arguments = null)
+    {
+        var seq = Transport.WriteRequest(command, arguments);
+        Trace($"SEND {command} seq={seq}");
+        return seq;
+    }
+
+    /// <summary>Reads messages until the response to <paramref name="requestSeq"/>
+    /// arrives, returning it. Any events seen along the way — whether already sitting
+    /// in <see cref="_pendingEvents"/> from an earlier read or freshly read off the
+    /// stream — are appended to <paramref name="events"/> if given, and (unconditionally)
+    /// left in <see cref="_pendingEvents"/> so a later <see cref="ReadUntilEventAsync"/>
+    /// still sees them even when no `events` list is given here. A response is never
+    /// queued (by construction, only "event"-typed messages are), so phase 1 can only
+    /// ever collect for `events`, never satisfy the wait itself — it still has to run
+    /// so already-queued events are not skipped when a caller wants to see them.</summary>
+    public async Task<JsonElement> ReadUntilResponseAsync(int requestSeq, List<JsonElement>? events = null, TimeSpan? timeout = null)
+    {
+        var t = timeout ?? TimeSpan.FromSeconds(30);
+
+        var alreadyQueued = _pendingEvents.Count;
+        for (var i = 0; i < alreadyQueued; i++)
+        {
+            var queuedRoot = _pendingEvents.Dequeue();
+            events?.Add(queuedRoot);
+            _pendingEvents.Enqueue(queuedRoot);
+        }
+
+        var deadline = DateTime.UtcNow + t;
+        while (DateTime.UtcNow < deadline)
+        {
+            var msg = await ReadOneAsync(t);
+            var root = msg.Raw.RootElement;
+            var type = root.GetProperty("type").GetString();
+            if (type == "response" && root.TryGetProperty("request_seq", out var rs) && rs.GetInt32() == requestSeq)
+                return root;
+            if (type == "event")
+            {
+                events?.Add(root);
+                var evName = root.TryGetProperty("event", out var evEl) ? evEl.GetString() : "?";
+                Trace($"QUEUE event={evName} arrived while waiting for response to seq={requestSeq} — not dropped");
+                _pendingEvents.Enqueue(root);
+            }
+        }
+        throw new TimeoutException($"no response to request seq {requestSeq} within timeout.\n{DiagnosticDump()}");
+    }
+
+    /// <summary>Reads messages until an event named <paramref name="eventName"/>
+    /// arrives, returning its body. Used to wait for e.g. "stopped". Every event seen
+    /// along the way (including the terminal one) is appended to <paramref
+    /// name="allEvents"/> if given, so a caller can assert on what did NOT arrive (e.g.
+    /// "no 'stopped' event fired") without a second read loop. Phase 1 scans whatever
+    /// is ALREADY in <see cref="_pendingEvents"/> — bounded to a snapshot of its length
+    /// so a non-matching item is examined exactly once per call, never spun on — before
+    /// phase 2 falls through to blocking reads.</summary>
+    public async Task<JsonElement> ReadUntilEventAsync(string eventName, TimeSpan? timeout = null, List<JsonElement>? allEvents = null)
+    {
+        var t = timeout ?? TimeSpan.FromSeconds(60);
+
+        var alreadyQueued = _pendingEvents.Count;
+        for (var i = 0; i < alreadyQueued; i++)
+        {
+            var queuedRoot = _pendingEvents.Dequeue();
+            allEvents?.Add(queuedRoot);
+            var queuedEventName = queuedRoot.TryGetProperty("event", out var qEvEl) ? qEvEl.GetString() : null;
+            if (queuedEventName == eventName) return queuedRoot;
+            _pendingEvents.Enqueue(queuedRoot);
+        }
+
+        var deadline = DateTime.UtcNow + t;
+        while (DateTime.UtcNow < deadline)
+        {
+            var msg = await ReadOneAsync(t);
+            var root = msg.Raw.RootElement;
+            if (root.GetProperty("type").GetString() != "event") continue;
+            allEvents?.Add(root);
+            var thisEventName = root.TryGetProperty("event", out var evEl) ? evEl.GetString() : null;
+            if (thisEventName == eventName)
+                return root;
+            // A different event than the one being awaited right now — re-queue it
+            // rather than drop it, same principle as ReadUntilResponseAsync above (a
+            // second step command in a row, each waiting on its own "stopped", is the
+            // same shape of race one level up).
+            Trace($"QUEUE event={thisEventName ?? "?"} arrived while waiting for event={eventName} — not dropped");
+            _pendingEvents.Enqueue(root);
+        }
+        throw new TimeoutException($"event '{eventName}' did not arrive within {t.TotalSeconds:F0}s.\n{DiagnosticDump()}");
+    }
+
+    /// <summary>Reads the next DAP message off the transport, subject to
+    /// <paramref name="timeout"/>. Implemented per-subclass because what's worth
+    /// capturing at a genuine giveup differs by transport (DapClient's TCP
+    /// socket-available/ThreadPool-health probe has no stdio equivalent) — but both
+    /// subclasses funnel every read through this one seam, which is what lets the
+    /// demux logic above live here exactly once.</summary>
+    protected abstract Task<DapIncomingMessage> ReadOneAsync(TimeSpan timeout);
+
+    /// <summary>Optional per-line wall-clock tracing (see DapClient's AL_DAP_STEP_TRACE
+    /// support). A no-op by default so a subclass isn't forced to implement it.</summary>
+    protected virtual void Trace(string msg) { }
+
+    /// <summary>Extra context appended to every TimeoutException this class throws.
+    /// DapClient dumps stdout/stderr/its own trace buffer; DapStdioClient dumps
+    /// stderr only — stdout IS the DAP channel there, not diagnostic text.</summary>
+    protected abstract string DiagnosticDump();
+
+    public abstract ValueTask DisposeAsync();
+}

--- a/AlRunner.Tests/DapRawFrameValidator.cs
+++ b/AlRunner.Tests/DapRawFrameValidator.cs
@@ -1,0 +1,69 @@
+using System.Text;
+using System.Text.Json;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// Strict, no-tolerance re-parser for the DAP wire format
+/// (<c>Content-Length: N\r\n\r\n</c> + N bytes of JSON, repeated), independent of
+/// <see cref="AlRunner.Infrastructure.DapTransport"/>'s own reader — for issue #2058's
+/// acceptance criterion "no non-DAP byte reaches stdout in stdio mode", which
+/// DapTransport itself cannot prove: its header loop silently SKIPS any header line
+/// without a colon (see DapTransport.ReadMessageAsync's `if (idx &lt;= 0) continue;`)
+/// rather than rejecting it, so a stray banner line ahead of "Content-Length:" would
+/// pass DapTransport's own parse without complaint. This validator requires every
+/// single byte of the input to belong to exactly one well-formed frame — nothing
+/// before the first frame, nothing between frames, nothing after the last one — and
+/// throws naming the offset the moment that is not true.
+/// </summary>
+public static class DapRawFrameValidator
+{
+    private static readonly byte[] Prefix = Encoding.ASCII.GetBytes("Content-Length: ");
+
+    /// <summary>Parses <paramref name="raw"/> as zero or more back-to-back DAP
+    /// frames consuming every byte, and returns how many frames were found. Throws
+    /// <see cref="InvalidDataException"/> naming the byte offset and a short dump of
+    /// the surrounding bytes the moment anything does not match a well-formed frame
+    /// exactly.</summary>
+    public static int CountFramesOrThrow(byte[] raw)
+    {
+        var pos = 0;
+        var count = 0;
+        while (pos < raw.Length)
+        {
+            if (pos + Prefix.Length > raw.Length || !raw.AsSpan(pos, Prefix.Length).SequenceEqual(Prefix))
+                throw new InvalidDataException(
+                    $"stray bytes at offset {pos} (frame #{count + 1}): expected 'Content-Length: ', got {Dump(raw, pos)}");
+            pos += Prefix.Length;
+
+            var digitsStart = pos;
+            while (pos < raw.Length && raw[pos] is >= (byte)'0' and <= (byte)'9') pos++;
+            if (pos == digitsStart)
+                throw new InvalidDataException($"no Content-Length digits at offset {digitsStart}: {Dump(raw, digitsStart)}");
+            var contentLength = int.Parse(Encoding.ASCII.GetString(raw, digitsStart, pos - digitsStart));
+
+            if (pos + 4 > raw.Length || raw[pos] != '\r' || raw[pos + 1] != '\n' || raw[pos + 2] != '\r' || raw[pos + 3] != '\n')
+                throw new InvalidDataException($"expected CRLFCRLF right after Content-Length at offset {pos}: {Dump(raw, pos)}");
+            pos += 4;
+
+            if (pos + contentLength > raw.Length)
+                throw new InvalidDataException(
+                    $"frame #{count + 1} body truncated at offset {pos}: need {contentLength} bytes, only {raw.Length - pos} remain");
+
+            // Must be valid, complete JSON occupying EXACTLY contentLength bytes — this
+            // is what catches trailing garbage appended to a body without its own
+            // Content-Length header (a corrupted length would show up here too).
+            JsonDocument.Parse(raw.AsSpan(pos, contentLength).ToArray());
+            pos += contentLength;
+            count++;
+        }
+        return count;
+    }
+
+    private static string Dump(byte[] raw, int pos)
+    {
+        var len = Math.Min(40, raw.Length - pos);
+        var slice = raw.AsSpan(pos, Math.Max(len, 0)).ToArray();
+        return $"\"{Encoding.Latin1.GetString(slice)}\" ({len} bytes shown)";
+    }
+}

--- a/AlRunner.Tests/DapRawFrameValidatorTests.cs
+++ b/AlRunner.Tests/DapRawFrameValidatorTests.cs
@@ -1,0 +1,81 @@
+using System.Text;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// Proves DapRawFrameValidator actually detects corruption — not just that it
+/// accepts well-formed input, which a no-op "always return N" implementation would
+/// also do. Each negative case reproduces a concrete way a stray byte could reach
+/// stdout (the exact failure mode issue #2058 exists to rule out) and asserts the
+/// validator throws naming an offset, not that it silently under- or over-counts.
+/// </summary>
+public class DapRawFrameValidatorTests
+{
+    private static byte[] Frame(string json)
+    {
+        var body = Encoding.UTF8.GetBytes(json);
+        var header = Encoding.ASCII.GetBytes($"Content-Length: {body.Length}\r\n\r\n");
+        return header.Concat(body).ToArray();
+    }
+
+    [Fact]
+    public void CountFramesOrThrow_TwoWellFormedFrames_ReturnsTwo()
+    {
+        var raw = Frame("""{"a":1}""").Concat(Frame("""{"b":2}""")).ToArray();
+        Assert.Equal(2, DapRawFrameValidator.CountFramesOrThrow(raw));
+    }
+
+    [Fact]
+    public void CountFramesOrThrow_EmptyInput_ReturnsZero()
+    {
+        Assert.Equal(0, DapRawFrameValidator.CountFramesOrThrow(Array.Empty<byte>()));
+    }
+
+    [Fact]
+    public void CountFramesOrThrow_StrayBannerBeforeFirstFrame_Throws()
+    {
+        // Reproduces exactly the bug #2058 exists to prevent: a startup banner
+        // ("[dap] listening on ...", the kind of line RunDapLoop used to print via
+        // plain Console.WriteLine) landing on stdout ahead of the first real frame.
+        var raw = Encoding.ASCII.GetBytes("[dap] listening on 127.0.0.1:4711\n")
+            .Concat(Frame("""{"a":1}""")).ToArray();
+        var ex = Assert.Throws<InvalidDataException>(() => DapRawFrameValidator.CountFramesOrThrow(raw));
+        Assert.Contains("offset 0", ex.Message);
+    }
+
+    [Fact]
+    public void CountFramesOrThrow_StrayBytesBetweenFrames_Throws()
+    {
+        var frame1 = Frame("""{"a":1}""");
+        var raw = frame1.Concat(Encoding.ASCII.GetBytes("oops\n")).Concat(Frame("""{"b":2}""")).ToArray();
+        var ex = Assert.Throws<InvalidDataException>(() => DapRawFrameValidator.CountFramesOrThrow(raw));
+        Assert.Contains($"offset {frame1.Length}", ex.Message);
+    }
+
+    [Fact]
+    public void CountFramesOrThrow_TrailingGarbageAfterLastFrame_Throws()
+    {
+        var frame1 = Frame("""{"a":1}""");
+        var raw = frame1.Concat(Encoding.ASCII.GetBytes("[dap] client connected.\n")).ToArray();
+        var ex = Assert.Throws<InvalidDataException>(() => DapRawFrameValidator.CountFramesOrThrow(raw));
+        Assert.Contains($"offset {frame1.Length}", ex.Message);
+    }
+
+    [Fact]
+    public void CountFramesOrThrow_TruncatedBody_Throws()
+    {
+        var full = Frame("""{"hello":"world"}""");
+        var truncated = full.AsSpan(0, full.Length - 3).ToArray(); // chop off the last 3 body bytes
+        Assert.Throws<InvalidDataException>(() => DapRawFrameValidator.CountFramesOrThrow(truncated));
+    }
+
+    [Fact]
+    public void CountFramesOrThrow_WrongContentLengthClaimsMoreThanActualBody_Throws()
+    {
+        var body = Encoding.UTF8.GetBytes("""{"a":1}""");
+        var header = Encoding.ASCII.GetBytes($"Content-Length: {body.Length + 100}\r\n\r\n");
+        var raw = header.Concat(body).ToArray();
+        Assert.Throws<InvalidDataException>(() => DapRawFrameValidator.CountFramesOrThrow(raw));
+    }
+}

--- a/AlRunner.Tests/DapStdioClient.cs
+++ b/AlRunner.Tests/DapStdioClient.cs
@@ -1,6 +1,5 @@
 using System.Diagnostics;
 using System.Text;
-using System.Text.Json;
 using AlRunner.Infrastructure;
 
 namespace AlRunner.Tests;
@@ -11,8 +10,11 @@ namespace AlRunner.Tests;
 /// <see cref="DapTransport"/> class <see cref="DapClient"/> uses for the TCP path,
 /// just handed the process's piped stdio streams instead of a socket.
 ///
-/// The whole point of this harness (vs. reusing DapClient) is <see
-/// cref="RawStdoutBytes"/>: every byte the child ever wrote to its OWN stdout,
+/// The response/event demultiplexing (queueing, phased drain, the #2070 race this
+/// exists to prevent) lives in the shared <see cref="DapClientBase"/> — see its
+/// header comment. This class supplies only what's specific to stdio: spawning +
+/// readiness detection over stderr (stdout can't be used for that — see below), and
+/// <see cref="RawStdoutBytes"/>: every byte the child ever wrote to its OWN stdout,
 /// captured independently of DapTransport's own (lenient) header parser — see
 /// DapTransport.ReadMessageAsync, which silently skips any header line without a
 /// colon rather than failing on it. A test asserting only "the handshake succeeded"
@@ -20,14 +22,13 @@ namespace AlRunner.Tests;
 /// lets a test re-parse the exact bytes with a strict, no-tolerance framer instead
 /// (see DapRawFrameValidator).
 /// </summary>
-public sealed class DapStdioClient : IAsyncDisposable
+public sealed class DapStdioClient : DapClientBase
 {
     private static readonly string RepoRoot = Path.GetFullPath(
         Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
     private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
 
     private readonly Process _process;
-    private readonly DapTransport _transport;
     private readonly TeeReadStream _rawStdout;
     private readonly StringBuilder _stderr = new();
     private int _messagesReceived;
@@ -43,10 +44,12 @@ public sealed class DapStdioClient : IAsyncDisposable
     /// re-parse of <see cref="RawStdoutBytes"/> — see DapRawFrameValidator.</summary>
     public int MessagesReceived => _messagesReceived;
 
+    protected override string DiagnosticDump() => $"--- stderr ---\n{StdErr}";
+
     private DapStdioClient(Process process, DapTransport transport, TeeReadStream rawStdout)
+        : base(transport)
     {
         _process = process;
-        _transport = transport;
         _rawStdout = rawStdout;
     }
 
@@ -111,45 +114,21 @@ public sealed class DapStdioClient : IAsyncDisposable
         return client;
     }
 
-    public int SendRequest(string command, object? arguments = null) => _transport.WriteRequest(command, arguments);
-
-    public async Task<JsonElement> ReadUntilResponseAsync(int requestSeq, List<JsonElement>? events = null, TimeSpan? timeout = null)
-    {
-        var deadline = DateTime.UtcNow + (timeout ?? TimeSpan.FromSeconds(30));
-        while (DateTime.UtcNow < deadline)
-        {
-            var msg = await ReadOneAsync(timeout ?? TimeSpan.FromSeconds(30));
-            var root = msg.Raw.RootElement;
-            var type = root.GetProperty("type").GetString();
-            if (type == "response" && root.TryGetProperty("request_seq", out var rs) && rs.GetInt32() == requestSeq)
-                return root;
-            if (type == "event") events?.Add(root);
-        }
-        throw new TimeoutException($"no response to request seq {requestSeq} within timeout.\n--- stderr ---\n{StdErr}");
-    }
-
-    public async Task<JsonElement> ReadUntilEventAsync(string eventName, TimeSpan? timeout = null, List<JsonElement>? allEvents = null)
-    {
-        var t = timeout ?? TimeSpan.FromSeconds(60);
-        var deadline = DateTime.UtcNow + t;
-        while (DateTime.UtcNow < deadline)
-        {
-            var msg = await ReadOneAsync(t);
-            var root = msg.Raw.RootElement;
-            if (root.GetProperty("type").GetString() != "event") continue;
-            allEvents?.Add(root);
-            if (root.TryGetProperty("event", out var ev) && ev.GetString() == eventName)
-                return root;
-        }
-        throw new TimeoutException($"event '{eventName}' did not arrive within {t.TotalSeconds:F0}s.\n--- stderr ---\n{StdErr}");
-    }
-
-    private async Task<DapIncomingMessage> ReadOneAsync(TimeSpan timeout)
+    protected override async Task<DapIncomingMessage> ReadOneAsync(TimeSpan timeout)
     {
         using var cts = new CancellationTokenSource(timeout);
-        var msg = await _transport.ReadMessageAsync(cts.Token);
+        DapIncomingMessage? msg;
+        try
+        {
+            msg = await Transport.ReadMessageAsync(cts.Token);
+        }
+        catch (OperationCanceledException) when (cts.IsCancellationRequested)
+        {
+            throw new TimeoutException(
+                $"--dap stdio read timed out after {timeout.TotalSeconds:F0}s.\n{DiagnosticDump()}");
+        }
         if (msg == null)
-            throw new Exception($"--dap stdio connection closed unexpectedly.\n--- stderr ---\n{StdErr}");
+            throw new Exception($"--dap stdio connection closed unexpectedly.\n{DiagnosticDump()}");
         Interlocked.Increment(ref _messagesReceived);
         return msg;
     }
@@ -180,9 +159,9 @@ public sealed class DapStdioClient : IAsyncDisposable
         try { await _process.WaitForExitAsync(new CancellationTokenSource(t).Token); } catch { }
     }
 
-    public async ValueTask DisposeAsync()
+    public override async ValueTask DisposeAsync()
     {
-        try { _transport.Dispose(); } catch { }
+        try { Transport.Dispose(); } catch { }
         try
         {
             if (!_process.HasExited)

--- a/AlRunner.Tests/DapStdioClient.cs
+++ b/AlRunner.Tests/DapStdioClient.cs
@@ -1,0 +1,240 @@
+using System.Diagnostics;
+using System.Text;
+using System.Text.Json;
+using AlRunner.Infrastructure;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// Spawns al-runner in <c>--dap stdio</c> mode (issue #2058) and drives it over the
+/// real DAP wire format on the child process's own stdin/stdout — the same
+/// <see cref="DapTransport"/> class <see cref="DapClient"/> uses for the TCP path,
+/// just handed the process's piped stdio streams instead of a socket.
+///
+/// The whole point of this harness (vs. reusing DapClient) is <see
+/// cref="RawStdoutBytes"/>: every byte the child ever wrote to its OWN stdout,
+/// captured independently of DapTransport's own (lenient) header parser — see
+/// DapTransport.ReadMessageAsync, which silently skips any header line without a
+/// colon rather than failing on it. A test asserting only "the handshake succeeded"
+/// would still pass with a stray banner line mixed into the stream; this harness
+/// lets a test re-parse the exact bytes with a strict, no-tolerance framer instead
+/// (see DapRawFrameValidator).
+/// </summary>
+public sealed class DapStdioClient : IAsyncDisposable
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+    private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
+
+    private readonly Process _process;
+    private readonly DapTransport _transport;
+    private readonly TeeReadStream _rawStdout;
+    private readonly StringBuilder _stderr = new();
+    private int _messagesReceived;
+
+    public string StdErr { get { lock (_stderr) return _stderr.ToString(); } }
+
+    /// <summary>Every byte read so far from the child's real OS stdout handle, in
+    /// the exact order the child wrote it — see the class header.</summary>
+    public byte[] RawStdoutBytes => _rawStdout.CapturedBytes;
+
+    /// <summary>Count of DAP messages (responses + events) successfully decoded off
+    /// the stdout stream so far, for cross-checking against an independent strict
+    /// re-parse of <see cref="RawStdoutBytes"/> — see DapRawFrameValidator.</summary>
+    public int MessagesReceived => _messagesReceived;
+
+    private DapStdioClient(Process process, DapTransport transport, TeeReadStream rawStdout)
+    {
+        _process = process;
+        _transport = transport;
+        _rawStdout = rawStdout;
+    }
+
+    /// <summary>Starts al-runner in stdio DAP mode and waits for its readiness line
+    /// on STDERR ("[dap] stdio transport ready ..." — see Program.cs's RunDapLoop).
+    /// Unlike DapClient.StartAsync, this never reads stdout for readiness: in stdio
+    /// mode stdout IS the DAP channel, so reading it for anything other than framed
+    /// DAP messages would itself be the bug this class exists to catch.</summary>
+    public static async Task<DapStdioClient> StartAsync(string bundleDir, TimeSpan? readyTimeout = null)
+    {
+        var argList = TestBuildConfig.RunArgs(ProjectPath) + TestBuildConfig.BcVersionArg +
+            $" --dap stdio \"{bundleDir}\"";
+
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            Arguments = argList,
+            RedirectStandardInput = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            WorkingDirectory = RepoRoot,
+        };
+
+        var proc = Process.Start(psi)!;
+        var stderr = new StringBuilder();
+        var readyTcs = new TaskCompletionSource();
+
+        _ = Task.Run(async () =>
+        {
+            string? line;
+            while ((line = await proc.StandardError.ReadLineAsync()) != null)
+            {
+                lock (stderr) stderr.AppendLine(line);
+                if (line.Contains("[dap] stdio transport ready")) readyTcs.TrySetResult();
+            }
+        });
+
+        var timeout = readyTimeout ?? TimeSpan.FromSeconds(120);
+        var completed = await Task.WhenAny(readyTcs.Task, Task.Delay(timeout));
+        if (completed != readyTcs.Task)
+        {
+            try { proc.Kill(true); } catch { }
+            throw new TimeoutException(
+                $"al-runner --dap stdio did not report ready within {timeout.TotalSeconds:F0}s.\n" +
+                $"--- stderr ---\n{stderr}");
+        }
+
+        var rawStdout = new TeeReadStream(proc.StandardOutput.BaseStream);
+        var transport = new DapTransport(rawStdout, proc.StandardInput.BaseStream);
+
+        var client = new DapStdioClient(proc, transport, rawStdout);
+        lock (stderr) client._stderr.Append(stderr);
+        _ = Task.Run(async () =>
+        {
+            string? line;
+            while ((line = await proc.StandardError.ReadLineAsync()) != null)
+                lock (client._stderr) client._stderr.AppendLine(line);
+        });
+
+        return client;
+    }
+
+    public int SendRequest(string command, object? arguments = null) => _transport.WriteRequest(command, arguments);
+
+    public async Task<JsonElement> ReadUntilResponseAsync(int requestSeq, List<JsonElement>? events = null, TimeSpan? timeout = null)
+    {
+        var deadline = DateTime.UtcNow + (timeout ?? TimeSpan.FromSeconds(30));
+        while (DateTime.UtcNow < deadline)
+        {
+            var msg = await ReadOneAsync(timeout ?? TimeSpan.FromSeconds(30));
+            var root = msg.Raw.RootElement;
+            var type = root.GetProperty("type").GetString();
+            if (type == "response" && root.TryGetProperty("request_seq", out var rs) && rs.GetInt32() == requestSeq)
+                return root;
+            if (type == "event") events?.Add(root);
+        }
+        throw new TimeoutException($"no response to request seq {requestSeq} within timeout.\n--- stderr ---\n{StdErr}");
+    }
+
+    public async Task<JsonElement> ReadUntilEventAsync(string eventName, TimeSpan? timeout = null, List<JsonElement>? allEvents = null)
+    {
+        var t = timeout ?? TimeSpan.FromSeconds(60);
+        var deadline = DateTime.UtcNow + t;
+        while (DateTime.UtcNow < deadline)
+        {
+            var msg = await ReadOneAsync(t);
+            var root = msg.Raw.RootElement;
+            if (root.GetProperty("type").GetString() != "event") continue;
+            allEvents?.Add(root);
+            if (root.TryGetProperty("event", out var ev) && ev.GetString() == eventName)
+                return root;
+        }
+        throw new TimeoutException($"event '{eventName}' did not arrive within {t.TotalSeconds:F0}s.\n--- stderr ---\n{StdErr}");
+    }
+
+    private async Task<DapIncomingMessage> ReadOneAsync(TimeSpan timeout)
+    {
+        using var cts = new CancellationTokenSource(timeout);
+        var msg = await _transport.ReadMessageAsync(cts.Token);
+        if (msg == null)
+            throw new Exception($"--dap stdio connection closed unexpectedly.\n--- stderr ---\n{StdErr}");
+        Interlocked.Increment(ref _messagesReceived);
+        return msg;
+    }
+
+    /// <summary>Closes the child's stdin (its DAP input) so RunDapLoop's read loop
+    /// observes clean EOF and returns on its own — the graceful-shutdown path,
+    /// deliberately NOT a Kill(): a killed process can be torn down mid-write,
+    /// which would make a "no extra bytes after the last frame" assertion
+    /// meaningless (the kill, not the implementation, decided where the stream
+    /// stopped). Then drains every remaining byte the child writes until ITS stdout
+    /// reaches true EOF, so <see cref="RawStdoutBytes"/> reflects the process's
+    /// entire lifetime, not just what this test happened to read before deciding it
+    /// was done.</summary>
+    public async Task ShutdownAndDrainAsync(TimeSpan? timeout = null)
+    {
+        var t = timeout ?? TimeSpan.FromSeconds(30);
+        try { _process.StandardInput.Close(); } catch { }
+        var deadline = DateTime.UtcNow + t;
+        var buf = new byte[4096];
+        while (DateTime.UtcNow < deadline)
+        {
+            using var cts = new CancellationTokenSource(t);
+            int n;
+            try { n = await _rawStdout.ReadAsync(buf.AsMemory(0, buf.Length), cts.Token); }
+            catch (OperationCanceledException) { break; }
+            if (n == 0) break; // clean EOF: the child closed stdout on exit
+        }
+        try { await _process.WaitForExitAsync(new CancellationTokenSource(t).Token); } catch { }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        try { _transport.Dispose(); } catch { }
+        try
+        {
+            if (!_process.HasExited)
+            {
+                _process.Kill(true);
+                await _process.WaitForExitAsync();
+            }
+        }
+        catch { }
+        _process.Dispose();
+    }
+}
+
+/// <summary>Wraps a Stream's read side, appending every byte actually read to an
+/// internal buffer — used to capture al-runner's raw child-process stdout
+/// independently of whatever parses it, so a strict re-parse can be run against the
+/// exact bytes later. Read-only; write/seek are not needed and not supported.</summary>
+public sealed class TeeReadStream : Stream
+{
+    private readonly Stream _inner;
+    private readonly object _lock = new();
+    private readonly List<byte> _captured = new();
+
+    public TeeReadStream(Stream inner) { _inner = inner; }
+
+    public byte[] CapturedBytes { get { lock (_lock) return _captured.ToArray(); } }
+
+    public override bool CanRead => true;
+    public override bool CanSeek => false;
+    public override bool CanWrite => false;
+    public override long Length => throw new NotSupportedException();
+    public override long Position { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
+    public override void Flush() { }
+
+    public override int Read(byte[] buffer, int offset, int count)
+    {
+        var n = _inner.Read(buffer, offset, count);
+        if (n > 0) lock (_lock) for (var i = 0; i < n; i++) _captured.Add(buffer[offset + i]);
+        return n;
+    }
+
+    public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+    {
+        var n = await _inner.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
+        if (n > 0) lock (_lock) for (var i = 0; i < n; i++) _captured.Add(buffer.Span[i]);
+        return n;
+    }
+
+    public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        => ReadAsync(buffer.AsMemory(offset, count), cancellationToken).AsTask();
+
+    public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+    public override void SetLength(long value) => throw new NotSupportedException();
+    public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+}

--- a/AlRunner.Tests/DapStdioServerTests.cs
+++ b/AlRunner.Tests/DapStdioServerTests.cs
@@ -21,6 +21,16 @@ public class DapStdioServerTests
     private const int SecondStatementLine = 21;
     private const string SourceFileName = "DapBreakpointTests.Codeunit.al";
 
+    // Same nested-call fixture DapServerTests uses for its step-granularity tests
+    // (issue #2045) — reused here rather than duplicated, see AlRunner.Tests/
+    // Fixtures/DapStepping/DapSteppingTests.Codeunit.al for the line numbering these
+    // constants are asserted against.
+    private static readonly string SteppingFixtureSrc = Path.GetFullPath(Path.Combine(
+        AppContext.BaseDirectory, "..", "..", "..", "Fixtures", "DapStepping"));
+    private const string SteppingSourceFileName = "DapSteppingTests.Codeunit.al";
+    private const int OuterCallLine = 22;             // Result := Double(Result);
+    private const int OuterThirdStatementLine = 23;   // Result := Result + 10;
+
     [SkippableFact]
     public async Task DapStdio_BreakpointOnSecondStatement_PausesBeforeItRuns_ThenContinueCompletesTheTest()
     {
@@ -135,5 +145,64 @@ public class DapStdioServerTests
         var exited = await dap.ReadUntilEventAsync("exited", timeout: TimeSpan.FromSeconds(60), allEvents: allEvents);
         Assert.Equal(0, exited.GetProperty("body").GetProperty("exitCode").GetInt32());
         Assert.DoesNotContain(allEvents, e => e.GetProperty("event").GetString() == "stopped");
+    }
+
+    /// <summary>
+    /// Issue #2070's actual root cause, one transport over: "next" releases the
+    /// paused AL thread, which is then free to run, qualify, and write its own
+    /// "stopped" event — racing the DAP loop thread writing the "next" response. When
+    /// the AL thread wins, the wire order is "stopped" event FIRST, response SECOND.
+    /// A ReadUntilResponseAsync that discards events seen while waiting for a response
+    /// (DapClient's own pre-#2070-fix shape — see DapClient.cs's header comment above
+    /// _pendingEvents) reads that "stopped" event, throws it away, reads the response,
+    /// returns — and this test's very next ReadUntilEventAsync("stopped") then waits
+    /// the full timeout for a second "stopped" that will never come. This is the exact
+    /// same race #2070 fixed for the TCP client (DapClient), reproduced here over
+    /// stdio because DapStdioClient shipped with its own, unfixed copy of the same
+    /// read loop.
+    /// </summary>
+    [SkippableFact]
+    public async Task DapStdio_Next_StepsOverNestedCall_LandsOnOuterNextStatement()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        await using var dap = await DapStdioClient.StartAsync(SteppingFixtureSrc);
+
+        var initSeq = dap.SendRequest("initialize", new { adapterID = "al-runner-tests" });
+        await dap.ReadUntilResponseAsync(initSeq);
+        await dap.ReadUntilEventAsync("initialized");
+
+        var launchSeq = dap.SendRequest("launch", new { });
+        var launchResp = await dap.ReadUntilResponseAsync(launchSeq, timeout: TimeSpan.FromSeconds(120));
+        Assert.True(launchResp.GetProperty("success").GetBoolean(), launchResp.ToString());
+
+        var sourcePath = Path.Combine(SteppingFixtureSrc, SteppingSourceFileName);
+        var bpSeq = dap.SendRequest("setBreakpoints", new
+        {
+            source = new { path = sourcePath },
+            breakpoints = new[] { new { line = OuterCallLine } },
+        });
+        var bpResp = await dap.ReadUntilResponseAsync(bpSeq);
+        Assert.True(bpResp.GetProperty("body").GetProperty("breakpoints")[0].GetProperty("verified").GetBoolean(),
+            $"breakpoint at line {OuterCallLine} was not verified: {bpResp}");
+
+        var cfgSeq = dap.SendRequest("configurationDone");
+        await dap.ReadUntilResponseAsync(cfgSeq);
+
+        var stopped = await dap.ReadUntilEventAsync("stopped");
+        Assert.Equal("breakpoint", stopped.GetProperty("body").GetProperty("reason").GetString());
+        Assert.Equal(OuterCallLine, stopped.GetProperty("body").GetProperty("line").GetInt32());
+
+        var nextSeq = dap.SendRequest("next", new { threadId = 1 });
+        await dap.ReadUntilResponseAsync(nextSeq);
+
+        var nextStopped = await dap.ReadUntilEventAsync("stopped");
+        Assert.Equal("step", nextStopped.GetProperty("body").GetProperty("reason").GetString());
+        Assert.Equal(OuterThirdStatementLine, nextStopped.GetProperty("body").GetProperty("line").GetInt32());
+
+        var contSeq = dap.SendRequest("continue", new { threadId = 1 });
+        await dap.ReadUntilResponseAsync(contSeq);
+        var exited2 = await dap.ReadUntilEventAsync("exited", TimeSpan.FromSeconds(60));
+        Assert.Equal(0, exited2.GetProperty("body").GetProperty("exitCode").GetInt32());
     }
 }

--- a/AlRunner.Tests/DapStdioServerTests.cs
+++ b/AlRunner.Tests/DapStdioServerTests.cs
@@ -1,0 +1,139 @@
+using System.Text.Json;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// End-to-end tests for <c>--dap stdio</c> (issue #2058): the same DAP session
+/// <see cref="DapServerTests"/> proves over TCP, driven instead over the child
+/// process's own stdin/stdout via <see cref="DapStdioClient"/> — proving parity
+/// (acceptance #1: "completes the same handshake DapServerTests already covers for
+/// the socket path") — plus the requirement specific to this transport (acceptance
+/// #2): stdout must carry ONLY well-formed DAP frames, never a stray byte.
+///
+/// Reuses AlRunner.Tests/Fixtures/DapBreakpoint, same as DapServerTests.
+/// </summary>
+public class DapStdioServerTests
+{
+    private static readonly string FixtureSrc = Path.GetFullPath(Path.Combine(
+        AppContext.BaseDirectory, "..", "..", "..", "Fixtures", "DapBreakpoint"));
+
+    private const int SecondStatementLine = 21;
+    private const string SourceFileName = "DapBreakpointTests.Codeunit.al";
+
+    [SkippableFact]
+    public async Task DapStdio_BreakpointOnSecondStatement_PausesBeforeItRuns_ThenContinueCompletesTheTest()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        await using var dap = await DapStdioClient.StartAsync(FixtureSrc);
+
+        var initSeq = dap.SendRequest("initialize", new { adapterID = "al-runner-tests" });
+        var initEvents = new List<JsonElement>();
+        var initResp = await dap.ReadUntilResponseAsync(initSeq, initEvents);
+        Assert.True(initResp.GetProperty("success").GetBoolean(), initResp.ToString());
+        var sawInitialized = initEvents.Any(e => e.GetProperty("event").GetString() == "initialized")
+            || (await dap.ReadUntilEventAsync("initialized")).GetProperty("event").GetString() == "initialized";
+        Assert.True(sawInitialized);
+
+        var launchSeq = dap.SendRequest("launch", new { });
+        var launchResp = await dap.ReadUntilResponseAsync(launchSeq, timeout: TimeSpan.FromSeconds(120));
+        Assert.True(launchResp.GetProperty("success").GetBoolean(),
+            $"launch failed: {launchResp}\n--- stderr ---\n{dap.StdErr}");
+
+        var sourcePath = Path.Combine(FixtureSrc, SourceFileName);
+        var bpSeq = dap.SendRequest("setBreakpoints", new
+        {
+            source = new { path = sourcePath },
+            breakpoints = new[] { new { line = SecondStatementLine } },
+        });
+        var bpResp = await dap.ReadUntilResponseAsync(bpSeq);
+        Assert.True(bpResp.GetProperty("success").GetBoolean(), bpResp.ToString());
+        var bps = bpResp.GetProperty("body").GetProperty("breakpoints");
+        Assert.Equal(1, bps.GetArrayLength());
+        Assert.True(bps[0].GetProperty("verified").GetBoolean(),
+            $"breakpoint at line {SecondStatementLine} was not verified: {bpResp}");
+        Assert.Equal(SecondStatementLine, bps[0].GetProperty("line").GetInt32());
+
+        var cfgSeq = dap.SendRequest("configurationDone");
+        await dap.ReadUntilResponseAsync(cfgSeq);
+
+        var stopped = await dap.ReadUntilEventAsync("stopped");
+        Assert.Equal("breakpoint", stopped.GetProperty("body").GetProperty("reason").GetString());
+        Assert.Equal(SecondStatementLine, stopped.GetProperty("body").GetProperty("line").GetInt32());
+
+        var stSeq = dap.SendRequest("stackTrace", new { threadId = 1 });
+        var stResp = await dap.ReadUntilResponseAsync(stSeq);
+        Assert.True(stResp.GetProperty("success").GetBoolean(), stResp.ToString());
+        var frames = stResp.GetProperty("body").GetProperty("stackFrames");
+        Assert.True(frames.GetArrayLength() >= 1, stResp.ToString());
+        var topFrame = frames[0];
+        Assert.Equal(SecondStatementLine, topFrame.GetProperty("line").GetInt32());
+        var frameId = topFrame.GetProperty("id").GetInt32();
+
+        var scSeq = dap.SendRequest("scopes", new { frameId });
+        var scResp = await dap.ReadUntilResponseAsync(scSeq);
+        var variablesReference = scResp.GetProperty("body").GetProperty("scopes")[0].GetProperty("variablesReference").GetInt32();
+
+        var varSeq = dap.SendRequest("variables", new { variablesReference });
+        var varResp = await dap.ReadUntilResponseAsync(varSeq);
+        Assert.True(varResp.GetProperty("success").GetBoolean(), varResp.ToString());
+        var vars = varResp.GetProperty("body").GetProperty("variables").EnumerateArray()
+            .ToDictionary(v => v.GetProperty("name").GetString()!, v => v.GetProperty("value").GetString());
+        Assert.True(vars.ContainsKey("Counter"), $"no Counter local reported: {varResp}");
+        // Same load-bearing assertion as DapServerTests' TCP version: paused BEFORE
+        // the second statement's own assignment, not after.
+        Assert.Equal("1", vars["Counter"]);
+
+        var contSeq = dap.SendRequest("continue", new { threadId = 1 });
+        await dap.ReadUntilResponseAsync(contSeq);
+
+        var exited = await dap.ReadUntilEventAsync("exited", timeout: TimeSpan.FromSeconds(60));
+        Assert.Equal(0, exited.GetProperty("body").GetProperty("exitCode").GetInt32());
+
+        // Acceptance #2: no non-DAP byte reaches stdout in stdio mode. Asserting the
+        // handshake above succeeded is NOT sufficient by itself — DapTransport's own
+        // header parser silently skips any line without a colon (see
+        // DapTransport.ReadMessageAsync), so a stray banner mixed into the stream
+        // would still let this same handshake pass. Drain the child to true EOF (its
+        // process exit, not just "we stopped asking"), then re-parse the ENTIRE raw
+        // byte stream it wrote with an independent, zero-tolerance framer
+        // (DapRawFrameValidator, proven against synthetic corruption by
+        // DapRawFrameValidatorTests) and require it to decompose into EXACTLY the
+        // messages this test itself decoded — nothing more, nothing less, nothing
+        // extra anywhere in the stream.
+        await dap.ShutdownAndDrainAsync();
+        var raw = dap.RawStdoutBytes;
+        Assert.True(raw.Length > 0, "expected at least one DAP frame on stdout");
+        var strictFrameCount = DapRawFrameValidator.CountFramesOrThrow(raw);
+        Assert.Equal(dap.MessagesReceived, strictFrameCount);
+    }
+
+    [SkippableFact]
+    public async Task DapStdio_NoBreakpointsSet_RunsStraightThrough_NoStoppedEvent()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        await using var dap = await DapStdioClient.StartAsync(FixtureSrc);
+
+        var initSeq = dap.SendRequest("initialize", new { adapterID = "al-runner-tests" });
+        await dap.ReadUntilResponseAsync(initSeq);
+        await dap.ReadUntilEventAsync("initialized");
+
+        var launchSeq = dap.SendRequest("launch", new { });
+        var launchResp = await dap.ReadUntilResponseAsync(launchSeq, timeout: TimeSpan.FromSeconds(120));
+        Assert.True(launchResp.GetProperty("success").GetBoolean(), launchResp.ToString());
+
+        // No setBreakpoints call at all — the negative direction: with the debug
+        // client never arming a breakpoint, the AL test runs straight through and
+        // reports the SAME pass it would running headless (exit 0), never a
+        // "stopped" event.
+        var cfgSeq = dap.SendRequest("configurationDone");
+        await dap.ReadUntilResponseAsync(cfgSeq);
+
+        var allEvents = new List<JsonElement>();
+        var exited = await dap.ReadUntilEventAsync("exited", timeout: TimeSpan.FromSeconds(60), allEvents: allEvents);
+        Assert.Equal(0, exited.GetProperty("body").GetProperty("exitCode").GetInt32());
+        Assert.DoesNotContain(allEvents, e => e.GetProperty("event").GetString() == "stopped");
+    }
+}

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -109,20 +109,50 @@ if (serverMode)
     Console.SetOut(Console.Error);
 }
 
-// ── --dap [port]: Debug Adapter Protocol server (issue #1642) — restores v1's AL
-// breakpoint debugging. Unlike --server, this speaks the DAP wire format (Content-
-// Length-framed JSON, see AlRunner/Infrastructure/DapTransport.cs) over a real TCP
-// socket, not stdin/stdout — that IS the DAP transport every DAP client (including
-// VS Code's built-in debug UI) expects, so there is no protocol reason to redirect
-// Console here the way --server does. Port defaults to 4711 (v1's default,
-// docs/archive/dap.md), overridable via a numeric argument right after --dap.
+// ── --dap [port|stdio]: Debug Adapter Protocol server (issue #1642; stdio transport
+// added for #2058) — restores v1's AL breakpoint debugging. Two transports:
+//   --dap [PORT]  TCP on 127.0.0.1:PORT (default 4711, v1's default, see
+//                 docs/archive/dap.md). That IS the DAP transport every socket-based
+//                 DAP client expects, so there is no protocol reason to redirect
+//                 Console here — this branch is unchanged from before #2058.
+//   --dap stdio   speaks DAP over the process's own stdin/stdout (issue #2058, for
+//                 VS Code's DebugAdapterExecutable — no port to pick, no readiness
+//                 race polling for a free port or a "listening" line). Stdout
+//                 becomes the DAP channel the instant this is selected, so —
+//                 exactly like --server above — the raw OS stdin/stdout handles
+//                 must be captured via Console.OpenStandardInput()/OpenStandardOutput()
+//                 RIGHT NOW, before Log.Install or any Console.Write runs, and
+//                 Console.Out redirected to Console.Error so every startup banner
+//                 (including RunDapLoop's own readiness line) lands on stderr
+//                 instead. Capturing the raw Stream directly — not Console.Out —
+//                 means the transport's byte channel can never be intercepted by
+//                 anything that already cached a Console.Out reference; it also
+//                 gives DapTransport exactly the Stream-based input its constructor
+//                 already wants (see DapTransport.cs's own header), rather than the
+//                 TextReader/TextWriter pair --server hands to RunServerLoop.
 bool dapMode = args.Contains("--dap");
 int dapPort = 4711;
+bool dapStdioMode = false;
+System.IO.Stream? dapStdioInput = null;
+System.IO.Stream? dapStdioOutput = null;
 if (dapMode)
 {
     var dapFlagIndex = Array.IndexOf(args, "--dap");
-    if (dapFlagIndex >= 0 && dapFlagIndex + 1 < args.Length && int.TryParse(args[dapFlagIndex + 1], out var parsedDapPort))
-        dapPort = parsedDapPort;
+    if (dapFlagIndex >= 0 && dapFlagIndex + 1 < args.Length)
+    {
+        var dapArg = args[dapFlagIndex + 1];
+        if (string.Equals(dapArg, "stdio", StringComparison.OrdinalIgnoreCase))
+        {
+            dapStdioMode = true;
+            dapStdioInput = Console.OpenStandardInput();
+            dapStdioOutput = Console.OpenStandardOutput();
+            Console.SetOut(Console.Error);
+        }
+        else if (int.TryParse(dapArg, out var parsedDapPort))
+        {
+            dapPort = parsedDapPort;
+        }
+    }
 }
 if (serverMode && dapMode)
 {
@@ -340,9 +370,9 @@ for (int i = 0; i < args.Length; i++)
     if (args[i] == "--watch") { watchMode = true; continue; }
     if (args[i] == "--tdd") { tddMode = true; continue; }
     if (args[i] == "--server") { continue; }  // handled above (serverMode); consume so it isn't "unknown"
-    if (args[i] == "--dap")  // handled above (dapMode/dapPort); consume the flag and an optional numeric port
+    if (args[i] == "--dap")  // handled above (dapMode/dapPort/dapStdioMode); consume the flag and its optional value (numeric port, or "stdio")
     {
-        if (i + 1 < args.Length && int.TryParse(args[i + 1], out _)) i++;
+        if (i + 1 < args.Length && (int.TryParse(args[i + 1], out _) || string.Equals(args[i + 1], "stdio", StringComparison.OrdinalIgnoreCase))) i++;
         continue;
     }
     if (args[i] == "--verbose") { AlRunner.Log.Verbose = true; continue; }
@@ -1387,7 +1417,7 @@ if (dapMode)
             "multi-bundle debugging is tracked as follow-up work, see issue #1642's PR.");
         return 2;
     }
-    return RunDapLoop(dapPort, bundles[0]);
+    return RunDapLoop(bundles[0], dapPort, dapStdioMode, dapStdioInput, dapStdioOutput);
 }
 
 // Watch loop: normal mode runs exactly one pass then breaks to the summary below.
@@ -3371,12 +3401,19 @@ return strictExitCode ? computedExitCode : 0;
     }
 
 
-// ── --dap loop (issue #1642) ─────────────────────────────────────────────────────
+// ── --dap loop (issue #1642; stdio transport added for #2058) ────────────────────
 // Non-static so it captures the warm pipeline objects (executor et al.) and
 // RunAllBundlesForServer, same reasons as RunServerLoop below. Unlike --server this
-// is not a warm-reload daemon: one TCP client, one bundle, one run, then exit — a
+// is not a warm-reload daemon: one client, one bundle, one run, then exit — a
 // debug session is inherently single-shot (VS Code starts al-runner, debugs,
 // disconnects, the process goes away).
+//
+// `stdioMode` selects the transport: stdio (stdioInput/stdioOutput, captured as raw
+// OS handles before Log.Install — see the argument-parsing block above) or the
+// original TCP accept loop. Everything from AlDapSession.Reset() onward is
+// transport-agnostic and identical either way, matching DapTransport's own
+// Stream-based design (its header comment: proven against a non-socket stream by
+// AlRunner.Tests' in-memory-pipe harness well before this issue existed).
 //
 // Session shape (see docs/archive/dap.md for the mechanism this restores, and
 // AlDapSession's file header for why pausing at StmtHit(N) — unlike
@@ -3397,16 +3434,36 @@ return strictExitCode ? computedExitCode : 0;
 //    qualifying condition instead of releasing unconditionally; see AlDapSession's file
 //    header for exactly what "qualifies" means for each)
 //   disconnect/terminate -> AlDapSession.Detach() (never leaves the AL thread stuck)
-int RunDapLoop(int port, string bundleDir)
+int RunDapLoop(string bundleDir, int port, bool stdioMode, System.IO.Stream? stdioInput, System.IO.Stream? stdioOutput)
 {
-    var listener = new System.Net.Sockets.TcpListener(System.Net.IPAddress.Loopback, port);
-    listener.Start();
-    Console.WriteLine($"[dap] listening on 127.0.0.1:{port} — waiting for a debug client to connect...");
-    using var tcpClient = listener.AcceptTcpClient();
-    listener.Stop();
-    Console.WriteLine("[dap] client connected.");
-
-    using var transport = new AlRunner.Infrastructure.DapTransport(tcpClient.GetStream(), tcpClient.GetStream());
+    System.Net.Sockets.TcpListener? listener = null;
+    System.Net.Sockets.TcpClient? tcpClient = null;
+    AlRunner.Infrastructure.DapTransport transport;
+    if (stdioMode)
+    {
+        // Readiness signal for a stdio client: unlike the TCP branch below, there is
+        // no "listening" state to report (stdin/stdout are already connected the
+        // moment this process exists) — this just tells a human/log watcher the
+        // session loop is about to start reading. Console.Error directly, not
+        // Console.WriteLine: Console.Out is redirected to Console.Error already (see
+        // the argument-parsing block above) so it would land in the same place
+        // either way, but writing to Console.Error here documents the intent at the
+        // call site rather than relying on the earlier redirect being remembered.
+        Console.Error.WriteLine("[dap] stdio transport ready — waiting for a debug client to send 'initialize'...");
+        transport = new AlRunner.Infrastructure.DapTransport(stdioInput!, stdioOutput!);
+    }
+    else
+    {
+        listener = new System.Net.Sockets.TcpListener(System.Net.IPAddress.Loopback, port);
+        listener.Start();
+        Console.WriteLine($"[dap] listening on 127.0.0.1:{port} — waiting for a debug client to connect...");
+        tcpClient = listener.AcceptTcpClient();
+        listener.Stop();
+        Console.WriteLine("[dap] client connected.");
+        transport = new AlRunner.Infrastructure.DapTransport(tcpClient.GetStream(), tcpClient.GetStream());
+    }
+    using var transportDisposable = transport;
+    using var tcpClientDisposable = tcpClient;
     AlRunner.Infrastructure.AlDapSession.Reset();
 
     Dictionary<(string Label, int Id), string> sourceMap = new();
@@ -4597,6 +4654,8 @@ static void PrintGuide(TextWriter w)
     w.WriteLine("  echoed live — a probe that writes to stdout will appear to produce nothing.");
     w.WriteLine("  Write diagnostics to a FILE instead.");
     w.WriteLine("  In --server mode stdout carries ONLY the JSON protocol; all logs go to stderr.");
+    w.WriteLine("  Same for --dap stdio: stdout carries ONLY the DAP wire format, all logs go to");
+    w.WriteLine("  stderr. --dap [PORT] (TCP) is unaffected — stdout is normal there.");
     w.WriteLine();
 
     w.WriteLine("TDD MODE (--tdd) — starting a red-green cycle before the app has the symbol yet");
@@ -4763,6 +4822,11 @@ static void PrintHelp(TextWriter w)
     w.WriteLine("                          statement (step-over/into/out of the current call), not");
     w.WriteLine("                          just at the next breakpoint. See docs/dap-mode.md.");
     w.WriteLine("                          Mutually exclusive with --server.");
+    w.WriteLine("  --dap stdio             Same DAP session, over this process's own stdin/stdout");
+    w.WriteLine("                          instead of a TCP socket — for a client that launches");
+    w.WriteLine("                          al-runner directly (e.g. VS Code's DebugAdapterExecutable),");
+    w.WriteLine("                          no port to pick, no readiness race. stdout carries ONLY the");
+    w.WriteLine("                          DAP protocol; all logs go to stderr. See docs/dap-mode.md.");
     w.WriteLine("  --tdd                   Local-development flag (not for CI). A test referencing a");
     w.WriteLine("                          table field / procedure / enum value the implementing app");
     w.WriteLine("                          doesn't have yet normally drops the whole app group with a");

--- a/docs/dap-mode.md
+++ b/docs/dap-mode.md
@@ -2,15 +2,19 @@
 
 `al-runner --dap [PORT] <bundle-dir>` starts a real [Debug Adapter
 Protocol](https://microsoft.github.io/debug-adapter-protocol/overview) server
-over a TCP socket (default port `4711`, matching v1). It compiles the given
-bundle, waits for a DAP client to connect, and lets that client set
-breakpoints on AL source lines, pause execution at them, step through the
-paused code (`next`/`stepIn`/`stepOut`), and inspect the AL locals in scope
-at each pause — with no BC service tier, no PDB, and no IL-offset mapping.
+over a TCP socket (default port `4711`, matching v1). `al-runner --dap stdio
+<bundle-dir>` starts the identical session over the process's own
+stdin/stdout instead — for a client that launches al-runner itself rather
+than connecting to a port (issue #2058). Either way, it compiles the given
+bundle, waits for a DAP client, and lets that client set breakpoints on AL
+source lines, pause execution at them, step through the paused code
+(`next`/`stepIn`/`stepOut`), and inspect the AL locals in scope at each pause
+— with no BC service tier, no PDB, and no IL-offset mapping.
 
 This started as the first slice of issue #1642 (breakpoints only); issue
-#2045 added real step granularity. See "What's not in this slice" below
-before assuming some other capability exists.
+#2045 added real step granularity; issue #2058 added the stdio transport.
+See "What's not in this slice" below before assuming some other capability
+exists.
 
 ## Mechanism
 
@@ -46,8 +50,32 @@ al-runner --dap 4711 ./tests/some-bundle
 ```
 
 The process prints `[dap] listening on 127.0.0.1:4711 — waiting for a debug
-client to connect...` on stdout, then blocks until a client connects. Session
-lifecycle:
+client to connect...` on stdout, then blocks until a client connects.
+
+### stdio transport (`--dap stdio`)
+
+```
+al-runner --dap stdio ./tests/some-bundle
+```
+
+Speaks the identical DAP session over stdin/stdout instead of a socket — the
+shape `vscode.DebugAdapterExecutable(command, args)` expects, so a client can
+launch al-runner directly instead of spawning it, polling for a free port,
+and connecting a `DebugAdapterServer(port)`. Chosen over a second flag
+(`--dap-stdio`) because both forms are the same session over a different
+transport, and `--dap [PORT|stdio]` says that at the call site: one flag,
+one argument that's either "which port" or "no port, use my stdio".
+
+**In this mode stdout carries ONLY the DAP wire format — Content-Length-framed
+JSON, nothing else.** Every line of startup/diagnostic output that the TCP
+path prints to stdout (including this loop's own readiness line) goes to
+stderr instead, the same redirection `--server` already does for its own
+protocol (`docs/server-mode.md`). A DAP client reading stdout as a strict
+byte stream must never see anything but well-formed frames — see
+`AlRunner.Tests/DapStdioClient.cs` for the harness that checks this
+byte-for-byte, not just "the handshake succeeded".
+
+Session lifecycle is identical to the TCP transport from here on:
 
 1. `initialize` → capabilities, then an `initialized` event.
 2. `launch`/`attach` → compiles the bundle. The response does not return until
@@ -161,10 +189,15 @@ since it does not hold up:
    `launch.json` entry instead of raw sockets.
 2. **Making the extension launch `al-runner --dap` itself** (instead of
    requiring the manual terminal step) needs a small amount of TypeScript: a
-   `vscode.DebugAdapterDescriptorFactory` for that new type, returning a
-   `vscode.DebugAdapterServer(port)` after spawning the process — the same
-   shape the extension already needs for `--server` (`docs/server-mode.md`),
-   since it already knows where the al-runner binary is.
+   `vscode.DebugAdapterDescriptorFactory` for that new type. As of #2058, the
+   simplest shape is `return new vscode.DebugAdapterExecutable(alRunnerPath,
+   ['--dap', 'stdio', bundleDir])` — VS Code launches the process and speaks
+   DAP over its stdio directly, no port to pick and no readiness race to poll
+   for. (The TCP form — spawning the process, waiting for it to report
+   listening, then returning `vscode.DebugAdapterServer(port)` — still works
+   and is what the extension already needs for `--server`
+   (`docs/server-mode.md`), but stdio removes that extra step for `--dap`
+   specifically.)
 3. Whether the existing (separate-repo, not-in-this-repo) AL Runner VS Code
    extension can take either contribution cheaply is **not verified here** —
    this repo has no access to that extension's source. That remains the open


### PR DESCRIPTION
Closes #2058

## Summary

- `--dap stdio <bundle-dir>` speaks the identical DAP session `--dap [PORT]` already does, but over the process's own stdin/stdout instead of a TCP socket — for `vscode.DebugAdapterExecutable(command, args)`, which launches the process directly rather than connecting to a port. This is what unblocks SShadowS/ALchemist#1.
- Mechanism: `Console.OpenStandardInput()`/`OpenStandardOutput()` are captured as raw `Stream`s at the very top of `Program.cs` (before `Log.Install` or any `Console.Write`), `Console.Out` is redirected to `Console.Error` — exactly the pattern `--server` already uses for the same "stdout is the protocol channel" constraint — and those raw streams are handed straight to `DapTransport`, which was already Stream-based by design (see its own header comment).
- `RunDapLoop` now branches on `stdioMode`: the TCP branch (listener, accept, `[dap] listening on ...`/`[dap] client connected.` banners) is untouched; the stdio branch skips straight to constructing the transport and prints its own readiness line to `Console.Error` directly.
- Flag shape: `--dap stdio` (a value on the existing `--dap` flag), not a second `--dap-stdio` flag — both forms are the same session over a different transport, and `--dap [PORT|stdio]` says that at the parse site instead of needing two mutually-exclusive flags with separate mutual-exclusion checks against `--server`.

## Testing

- **RED**: confirmed on a clean pre-fix build that `al-runner --dap stdio <bundle>` treats `stdio` as a bundle-directory positional argument and fails immediately (`no such directory: stdio`) — the gap the issue describes.
- **GREEN**: `AlRunner.Tests/DapStdioServerTests.cs` — the same breakpoint-pause/continue and no-breakpoints-set scenarios `DapServerTests.cs` proves over TCP, driven instead over a real spawned child process's stdio via a new `DapStdioClient` harness.
- **Acceptance #2 (no non-DAP byte reaches stdout)** is proven, not asserted: `DapStdioClient` captures every byte the child ever writes to its own OS stdout handle independently of `DapTransport`'s own (lenient — it silently skips any header line without a colon) parser, then a new zero-tolerance re-parser (`DapRawFrameValidator`) requires the entire byte stream to decompose into exactly the messages the test itself read, with nothing before/between/after. `DapRawFrameValidatorTests.cs` proves the validator itself actually detects corruption (stray banner before/between/after frames, truncated body, wrong Content-Length) rather than being a vacuous pass-through.
- Manually verified on a **cold Cecil cache** (triggers the shadow-runtime re-exec, `[reexec] Ncl.dll not shipped in this install...`) that stdout stays byte-for-byte empty across the re-exec and only the expected DAP frames appear once the session starts — the re-exec inherits the OS stdio handles directly (no .NET pipe redirection), so the child's own top-of-`Program.cs` redirection is all that's needed; #2066 (double-printed startup banners on a cold cache) is a separate, pre-existing issue not touched here.
- Existing TCP-path tests (`DapServerTests.cs`, all 5) pass unchanged.
- `dotnet test AlRunner.Tests` (full suite, 979 tests): 922 passed, 56 skipped (BC-engine-bootstrap flakes under this machine's concurrent-agent load — pre-existing, unrelated to this change), 1 failed — `SourceDepSymbolsWithoutPackageCacheTests.SiblingSourceDep_CompilesWithZeroPackageCacheDirs`, reproduced identically on a clean `origin/main` checkout with no changes applied, so it predates this PR. Filed as #2067 rather than silently ignored.
- `--help`/`--guide`/`docs/dap-mode.md` updated.

## Follow-ups filed

- #2067 — pre-existing, unrelated `SourceDepSymbolsWithoutPackageCacheTests` failure hit while running the full local suite.