### PR TITLE
feat(server): per-statement hit counts + position table (coverage:true)

### DIFF
--- a/AlRunner.Tests/AlStatementTableTests.cs
+++ b/AlRunner.Tests/AlStatementTableTests.cs
@@ -1,0 +1,283 @@
+using System.Text.Json;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// #2042 — the statement-position table: per-statement hit counts PLUS the id↔position
+/// mapping <c>--capture-values</c> (#2040) needed but never had. Per SShadowS/ALchemist#1
+/// (the consumer's own spec, quoted in the issue): ALchemist maps a captured value's
+/// <c>statementId</c> to an editor line today by treating it as an index into a
+/// covered-lines list SORTED BY LINE NUMBER — a heuristic that breaks on multi-statement
+/// lines and skipped statements. This class proves the fix: `coverage:true` on
+/// `runTests`/`execute` reports one entry per BC-instrumented statement — id, owning AL
+/// member name (`scope`), 1-based start/end line+column, and this run's hit count — and
+/// that `id` is PROVABLY the same id-space `capturedValues[].statementId` already uses
+/// for the same `scope`, not merely documented to be.
+///
+/// Ghost-test guard: every assertion below names a SPECIFIC id, line, column, or hit
+/// count — never just "coverage present". A no-op implementation (empty array) fails
+/// every positive fact; an implementation that sums hits by line instead of keeping
+/// statements separate fails <see cref="TwoStatementsOnSameLine_ReportSeparately_NotSummed"/>
+/// specifically because it would collapse two entries into one.
+///
+/// Spawns the real runner in --server mode; needs the BC artifact cache — reports
+/// Skipped (not Passed) when absent, via TestArtifacts.
+/// </summary>
+public class AlStatementTableTests : IClassFixture<SharedCliServer>
+{
+    private readonly SharedCliServer _fixture;
+
+    public AlStatementTableTests(SharedCliServer fixture) => _fixture = fixture;
+
+    private static string Req(string command, string code, bool coverage, bool captureValues = false)
+        => JsonSerializer.Serialize(new
+        {
+            command,
+            coverage,
+            captureValues,
+            code,
+        });
+
+    // Mirrors ServerTests.MakeExecuteBundle's disk-bundle shape (own AppId/idRange so
+    // this class never collides with another suite's compiled-module cache).
+    private static string MakeRunTestsBundle(string sourceFile)
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "al-runner-stmt-table-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "app.json"), """
+        {
+          "id": "d4e5f607-1829-4a0b-bc2d-3e4f60718293",
+          "name": "Statement Table RunTests Probe",
+          "publisher": "AL Runner",
+          "version": "1.0.0.0",
+          "dependencies": [],
+          "platform": "1.0.0.0",
+          "application": "1.0.0.0",
+          "idRanges": [ { "from": 60190, "to": 60199 } ],
+          "runtime": "14.0"
+        }
+        """);
+        File.WriteAllText(Path.Combine(dir, "Probe.Codeunit.al"), sourceFile);
+        return dir;
+    }
+
+    // #2042 acceptance criterion 2, the whole point of the issue: capturedValues'
+    // statementId and the statement table's id are the SAME id-space for the SAME
+    // scope, proven from ONE `execute` call (not asserted separately and assumed to
+    // line up). The codeunit is the SAME 4-statement shape ServerTests'
+    // Execute_CaptureValues_True_ReportsFinalLocalsOfTopLevelScope already proves
+    // reports statementId 3 for its last statement — this fact additionally locates
+    // that exact id in the statement table and asserts its POSITION is the literal
+    // AL source line "Msg := 'after';" sits on (line 11 below), not just "some line".
+    [SkippableFact]
+    public async Task CapturedValueStatementId_MatchesStatementTableScopeAndId()
+    {
+        TestArtifacts.SkipIfMissing();
+        var server = await _fixture.GetAsync();
+        var code =
+            "codeunit 60190 \"Stmt Table Corr SX\"\n" +
+            "{\n" +
+            "    trigger OnRun()\n" +
+            "    var\n" +
+            "        Counter: Integer;\n" +
+            "        Msg: Text;\n" +
+            "    begin\n" +
+            "        Counter := 41;\n" +
+            "        Msg := 'before';\n" +
+            "        Counter := 42;\n" +
+            "        Msg := 'after';\n" +
+            "    end;\n" +
+            "}\n";
+        var r = await server.SendAsync(Req("execute", code, coverage: true, captureValues: true));
+        var d = JsonSerializer.Deserialize<JsonElement>(r);
+        Assert.False(d.TryGetProperty("error", out _), $"unexpected error response: {r}");
+        Assert.Equal(0, d.GetProperty("exitCode").GetInt32());
+
+        var tests = d.GetProperty("tests");
+        Assert.Equal(1, tests.GetArrayLength());
+        var captured = tests[0].GetProperty("capturedValues");
+        var counterEntry = captured.EnumerateArray()
+            .Single(e => e.GetProperty("variableName").GetString() == "Counter");
+        Assert.Equal("OnRun", counterEntry.GetProperty("scopeName").GetString());
+        var capturedStatementId = counterEntry.GetProperty("statementId").GetInt32();
+        Assert.Equal(3, capturedStatementId); // 4 statements, 0-based, last one
+
+        Assert.True(d.TryGetProperty("coverage", out var coverage), $"expected coverage on the response: {r}");
+        var fileEntry = coverage.EnumerateArray().Single();
+        var statements = fileEntry.GetProperty("statements").EnumerateArray().ToList();
+        Assert.Equal(4, statements.Count);
+
+        // The core claim: find the statement-table row whose (scope, id) matches
+        // capturedValues' (scopeName, statementId) EXACTLY, then assert its position
+        // is the real AL source line the captured value came from — not a guess from
+        // a sorted covered-lines index (the heuristic ALchemist's own issue reply
+        // names as broken).
+        var matched = statements.Single(s =>
+            s.GetProperty("scope").GetString() == "OnRun" &&
+            s.GetProperty("id").GetInt32() == capturedStatementId);
+        Assert.Equal(11, matched.GetProperty("line").GetInt32()); // "Msg := 'after';"
+        Assert.Equal(1, matched.GetProperty("hits").GetInt32());
+        Assert.True(matched.GetProperty("column").GetInt32() > 0);
+        Assert.True(matched.GetProperty("endColumn").GetInt32() >= matched.GetProperty("column").GetInt32());
+    }
+
+    // #2042 acceptance criterion 3, first half: a statement hit N times reports N —
+    // not 1 (vacuous "it ran"), not 0. The loop body ("Counter := Counter + 1;")
+    // executes exactly 4 times; the loop-entry statement itself executes exactly once
+    // (entering the FOR construct, not its body).
+    [SkippableFact]
+    public async Task LoopBodyStatement_HitFourTimes_ReportsHitCountFour()
+    {
+        TestArtifacts.SkipIfMissing();
+        var server = await _fixture.GetAsync();
+        var code =
+            "codeunit 60191 \"Stmt Table Loop SX\"\n" +
+            "{\n" +
+            "    trigger OnRun()\n" +
+            "    var\n" +
+            "        i: Integer;\n" +
+            "        Counter: Integer;\n" +
+            "    begin\n" +
+            "        for i := 1 to 4 do\n" +
+            "            Counter := Counter + 1;\n" +
+            "    end;\n" +
+            "}\n";
+        var r = await server.SendAsync(Req("execute", code, coverage: true));
+        var d = JsonSerializer.Deserialize<JsonElement>(r);
+        Assert.False(d.TryGetProperty("error", out _), $"unexpected error response: {r}");
+        Assert.True(d.TryGetProperty("coverage", out var coverage), $"expected coverage on the response: {r}");
+        var statements = coverage.EnumerateArray().Single()
+            .GetProperty("statements").EnumerateArray().ToList();
+
+        var loopEntry = statements.Single(s => s.GetProperty("line").GetInt32() == 8);
+        Assert.Equal(1, loopEntry.GetProperty("hits").GetInt32());
+
+        var loopBody = statements.Single(s => s.GetProperty("line").GetInt32() == 9);
+        Assert.Equal(4, loopBody.GetProperty("hits").GetInt32());
+    }
+
+    // #2042 acceptance criterion 3, second half: two statements sharing a source
+    // line are reported as TWO SEPARATE entries with their OWN hit counts, not one
+    // entry with a summed count. "Counter := 100;" and "Counter := 200;" sit on the
+    // SAME line (10) but are different statements with different ids/columns — a
+    // rollup implementation would report ONE entry for line 10 with hits:2; this
+    // fact fails against that shape and only passes against genuinely per-statement
+    // tracking.
+    [SkippableFact]
+    public async Task TwoStatementsOnSameLine_ReportSeparately_NotSummed()
+    {
+        TestArtifacts.SkipIfMissing();
+        var server = await _fixture.GetAsync();
+        var code =
+            "codeunit 60192 \"Stmt Table SameLine SX\"\n" +
+            "{\n" +
+            "    trigger OnRun()\n" +
+            "    var\n" +
+            "        Counter: Integer;\n" +
+            "    begin\n" +
+            "        Counter := 100; Counter := 200;\n" +
+            "    end;\n" +
+            "}\n";
+        var r = await server.SendAsync(Req("execute", code, coverage: true));
+        var d = JsonSerializer.Deserialize<JsonElement>(r);
+        Assert.False(d.TryGetProperty("error", out _), $"unexpected error response: {r}");
+        Assert.True(d.TryGetProperty("coverage", out var coverage), $"expected coverage on the response: {r}");
+        var statements = coverage.EnumerateArray().Single()
+            .GetProperty("statements").EnumerateArray().ToList();
+
+        var sameLine = statements.Where(s => s.GetProperty("line").GetInt32() == 7).ToList();
+        // TWO entries, not one — the ghost-test check a summed-by-line
+        // implementation cannot pass: it would produce Count == 1.
+        Assert.Equal(2, sameLine.Count);
+        Assert.All(sameLine, s => Assert.Equal(1, s.GetProperty("hits").GetInt32()));
+        // Distinct ids and distinct (non-overlapping) columns — proves these are
+        // really two different statements, not the same one reported twice.
+        var ids = sameLine.Select(s => s.GetProperty("id").GetInt32()).Distinct().ToList();
+        Assert.Equal(2, ids.Count);
+        var columns = sameLine.Select(s => s.GetProperty("column").GetInt32()).OrderBy(c => c).ToList();
+        Assert.True(columns[1] > columns[0]);
+    }
+
+    // Negative direction: coverage omitted (false by default) must leave `coverage`
+    // ABSENT — not an empty array, not present with stale data — proving the flag
+    // actually gates the feature (same convention captureValues already uses).
+    [SkippableFact]
+    public async Task Coverage_Omitted_NoCoverageField()
+    {
+        TestArtifacts.SkipIfMissing();
+        var server = await _fixture.GetAsync();
+        var r = await server.SendAsync(JsonSerializer.Serialize(new
+        {
+            command = "execute",
+            code = "codeunit 60193 \"Stmt Table NoCov SX\" { trigger OnRun() var Counter: Integer; " +
+                   "begin Counter := 1; end; }",
+        }));
+        var d = JsonSerializer.Deserialize<JsonElement>(r);
+        Assert.False(d.TryGetProperty("error", out _), $"unexpected error response: {r}");
+        Assert.False(d.TryGetProperty("coverage", out _),
+            $"coverage must be absent when coverage:true wasn't requested: {r}");
+    }
+
+    // Regression guard for the ghost-generation bug this issue's own investigation
+    // surfaced: RunBundleForServer calls Assembly.Load(assemblyBytes) again on EVERY
+    // request that isn't a cross-bundle-dedup reuse — including a pure AL-output
+    // cache HIT — so a warm server accumulates one Assembly generation PER REQUEST
+    // for the SAME bundle (assemblies never unload). A statement-table scan that
+    // walked every loaded assembly (rather than the current run's own hit-tracked
+    // types) reported the SAME statement once per generation ever loaded: the live
+    // one with a real count, plus one phantom-zero ghost per stale generation.
+    // Reproduced empirically (2nd+ identical runTests request against one warm
+    // server) before AlCoverageTracker.GetHitTrackedTypes() restricted the scan.
+    // This sends the SAME runTests request three times on one shared server and
+    // asserts every response has EXACTLY the statements the bundle declares — no
+    // duplicates, no drift in hit counts across repeats.
+    [SkippableFact]
+    public async Task Coverage_RepeatedIdenticalRequests_NeverGhostDuplicates()
+    {
+        TestArtifacts.SkipIfMissing();
+        var bundle = MakeRunTestsBundle("""
+        codeunit 60194 "Stmt Table Repeat SX"
+        {
+            Subtype = Test;
+
+            [Test]
+            procedure LoopHitsThrice()
+            var
+                i: Integer;
+                Counter: Integer;
+            begin
+                for i := 1 to 3 do
+                    Counter := Counter + 1;
+            end;
+        }
+        """);
+        var server = await _fixture.GetAsync();
+        var req = JsonSerializer.Serialize(new
+        {
+            command = "runTests",
+            coverage = true,
+            sourcePaths = new[] { bundle },
+            packagePaths = Array.Empty<string>(),
+        });
+
+        for (var attempt = 1; attempt <= 3; attempt++)
+        {
+            var lines = await server.SendRequestStreamingAsync(req);
+            var (_, summary) = ProtocolV2Streaming.Split(lines);
+            Assert.True(summary.TryGetProperty("coverage", out var coverage),
+                $"attempt {attempt}: expected coverage on the summary: {string.Join(" | ", lines)}");
+            var statements = coverage.EnumerateArray().Single()
+                .GetProperty("statements").EnumerateArray().ToList();
+
+            // Exactly 2 statements (loop entry + loop body) — never 4/6/... from an
+            // accumulating ghost generation.
+            Assert.Equal(2, statements.Count);
+            var ids = statements.Select(s => s.GetProperty("id").GetInt32()).OrderBy(x => x).ToList();
+            Assert.Equal(new[] { 0, 1 }, ids);
+
+            var loopBody = statements.Single(s => s.GetProperty("id").GetInt32() == 1);
+            Assert.Equal(3, loopBody.GetProperty("hits").GetInt32());
+        }
+    }
+}

--- a/AlRunner/Infrastructure/AlCoverageTracker.cs
+++ b/AlRunner/Infrastructure/AlCoverageTracker.cs
@@ -129,4 +129,98 @@ public static class AlCoverageTracker
 
         return result;
     }
+
+    /// <summary>
+    /// One AL statement's full identity + hit count for the statement-position table
+    /// (issue #2042): the SAME id-space <see cref="AlValueCapture"/>'s
+    /// <c>AlCapturedValue.StatementId</c> uses (both read straight off
+    /// NavMethodScope.StatementNumber / the StmtHit(N) argument for THIS scope type —
+    /// verified in AlStatementTableTests, not assumed), the AL member name that owns
+    /// the scope (<c>ScopeName</c>, matching <c>AlCapturedValue.ScopeName</c>), and the
+    /// FULL decoded [SourceSpans] position (start AND end line/column) rather than just
+    /// the start line <see cref="AlCoverageStatement"/> carries — the id↔position
+    /// mapping a consumer like ALchemist needs to place a captured value in an editor
+    /// instead of guessing from a covered-lines index (see the issue's linked
+    /// SShadowS/ALchemist#1 reply).
+    /// </summary>
+    public readonly record struct AlStatementRecord(
+        string FilePath, string ScopeName, int StatementId,
+        int Line, int Column, int EndLine, int EndColumn, int HitCount);
+
+    /// <summary>
+    /// Distinct scope Types that have recorded at least one hit since the last
+    /// <see cref="Reset"/> — i.e. scopes genuinely invoked in the CURRENT run.
+    ///
+    /// #2042's <see cref="CollectStatementTable"/> scans exactly this set instead of
+    /// every SourceSpans-carrying type currently loaded in the process (which is what
+    /// <see cref="Collect"/> does), because a warm <c>--server</c> process is not the
+    /// single-generation world <c>Collect</c> was built for: <c>RunBundleForServer</c>
+    /// calls <c>Assembly.Load(assemblyBytes)</c> again on EVERY request that isn't a
+    /// cross-bundle-dedup reuse — including a pure AL-output cache HIT with
+    /// byte-identical content — so re-running the SAME bundle N times against one warm
+    /// server leaves N distinct Assembly generations resident (assemblies are never
+    /// unloaded). Scanning "every loaded assembly" after <see cref="Reset"/> then
+    /// reports the SAME AL statement once per generation: the CURRENT generation with
+    /// its real hit count, plus one ghost entry per STALE generation showing 0 (its
+    /// Type is still reflectable; Reset() only cleared the dictionary, not the type
+    /// itself) — reproduced empirically by sending an identical `coverage:true`
+    /// `runTests` request twice to one warm server and observing duplicate
+    /// {id, line} entries, one live and one phantom-zero, per statement. Restricting
+    /// to _hits' own keys sidesteps this entirely: a stale generation's Type recorded
+    /// zero hits THIS run (Reset() cleared it and nothing in this run touched it), so
+    /// it is simply absent from the key set — no "which generation is live" logic
+    /// needed. <see cref="Collect"/> (--coverage, CLI-only) does not need this fix: a
+    /// CLI invocation is one short-lived process, so exactly one generation ever
+    /// exists there.
+    /// </summary>
+    private static IReadOnlyCollection<Type> GetHitTrackedTypes() =>
+        _hits.Keys.Select(k => k.ScopeType).Distinct().ToArray();
+
+    /// <summary>
+    /// Same idea as <see cref="Collect"/> (cross-reference SourceSpans-carrying scope
+    /// types against OnStmtHit's hit counts), but scoped to <see
+    /// cref="GetHitTrackedTypes"/> instead of every loaded assembly (see that method's
+    /// doc comment for why), and keeping each statement separate — never summed by
+    /// line — while carrying the scope name plus the full decoded span instead of
+    /// collapsing to (object, line, hits). Two statements sharing a line get two
+    /// entries here with the SAME line but different id/column, which is exactly the
+    /// distinction <see cref="AlCoverageReport"/>'s line-rollup necessarily discards.
+    /// </summary>
+    public static List<AlStatementRecord> CollectStatementTable(IReadOnlyDictionary<(string Label, int Id), string> sourceMap)
+    {
+        EnsureReflInit();
+        AlNavNameReflection.EnsureInit();
+        var result = new List<AlStatementRecord>();
+
+        foreach (var t in GetHitTrackedTypes())
+        {
+            if (Attribute.GetCustomAttribute(t, _tSourceSpansAttr!) is not object srcAttr) continue;
+            if (_piEncodedSpans!.GetValue(srcAttr) is not long[] spans || spans.Length == 0) continue;
+
+            var (label, id) = AlCallStackCapture.ParseObjectTypeAndId(t);
+            if (id == 0) continue;
+            if (!sourceMap.TryGetValue((label, id), out var filePath)) continue;
+
+            // [NavName] on the scope class itself is the AL procedure/trigger/test
+            // method name — the SAME attribute AlValueCapture reads off scope
+            // FIELDS for local names, here read off the TYPE instead (both are
+            // MemberInfo — see AlNavNameReflection). Confirmed via
+            // BCCOMPILER_DUMP_CS=1: `[NavName("Run")] private sealed class
+            // Run_Scope__... : NavMethodScope<...>`.
+            var scopeName = AlNavNameReflection.GetAlName(t) ?? "?";
+
+            var instrumented = AlCoverageInstrumentedStatements.Find(t);
+            foreach (var i in instrumented)
+            {
+                if (i < 0 || i >= spans.Length) continue; // defensive: BC shape drift
+                var (fromLine, fromColumn, toLine, toColumn) = AlSourceSpanCodec.Decode(spans[i]);
+                result.Add(new AlStatementRecord(
+                    filePath, scopeName, i,
+                    fromLine + 1, fromColumn + 1, toLine + 1, toColumn + 1,
+                    GetHitCount(t, i)));
+            }
+        }
+
+        return result;
+    }
 }

--- a/AlRunner/Infrastructure/AlNavNameReflection.cs
+++ b/AlRunner/Infrastructure/AlNavNameReflection.cs
@@ -7,6 +7,15 @@
 // handles are resolved once and the "BC changed shape" guard exists in exactly one
 // place — same reasoning as AlSourceSpanCodec's own file header ("Lift the
 // span-decoding ... into a shared helper ... Do not duplicate the bit layout").
+//
+// #2042: the SAME [NavName(...)] attribute is also present on the `*_Scope` class
+// itself (not just its fields), carrying the AL member name the scope belongs to —
+// confirmed via BCCOMPILER_DUMP_CS=1 on AlRunner.Tests/Fixtures/CoverageBranch:
+// `[NavName("Run")] private sealed class Run_Scope__1684062386 : ...`. That is the
+// SAME string NavMethodScope.ScopeName returns at runtime (AlValueCapture's
+// `scopeName`/AlCapturedValue.ScopeName), so AlStatementTable reuses this one lookup
+// — taking Type instead of FieldInfo, both being MemberInfo — instead of duplicating
+// the attribute-resolution logic for a class instead of a field.
 using System.Reflection;
 using Microsoft.Dynamics.Nav.Runtime;
 
@@ -32,12 +41,14 @@ internal static class AlNavNameReflection
         _reflInit = true;
     }
 
-    /// <summary>The AL-declared name for <paramref name="field"/>, or null if it does not
-    /// carry [NavName] (i.e. is not an AL local/parameter the compiler lifted onto this
-    /// scope class). Call <see cref="EnsureInit"/> first.</summary>
-    public static string? GetAlName(FieldInfo field)
+    /// <summary>The AL-declared name for <paramref name="member"/>, or null if it does
+    /// not carry [NavName]. <paramref name="member"/> is either a <see cref="FieldInfo"/>
+    /// (an AL local/parameter lifted onto a scope class) or a <see cref="Type"/> (the
+    /// scope class itself, carrying the AL member — procedure/trigger/test method —
+    /// name; #2042). Call <see cref="EnsureInit"/> first.</summary>
+    public static string? GetAlName(MemberInfo member)
     {
-        if (Attribute.GetCustomAttribute(field, _tNavNameAttr!) is not object navNameAttr) return null;
-        return _piNavNameName!.GetValue(navNameAttr) as string ?? field.Name;
+        if (Attribute.GetCustomAttribute(member, _tNavNameAttr!) is not object navNameAttr) return null;
+        return _piNavNameName!.GetValue(navNameAttr) as string ?? member.Name;
     }
 }

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -3930,6 +3930,15 @@ int RunServerLoop(System.IO.TextReader input, System.IO.TextWriter output)
             return;
         }
 
+        // #2042: 'coverage:true' opts into per-statement hit counts + a position table
+        // on the terminal summary line — reuses AlCoverageTracker's existing StmtHit
+        // hook (#1922), same process-global-flag pattern as AlValueCapture.Enabled in
+        // HandleServerExecute below. Reset() (not just Enabled=true) so a warm
+        // server's hit counts from a PRIOR request never leak into this one — the
+        // dictionary is process-global and this process outlives many requests.
+        AlRunner.Infrastructure.AlCoverageTracker.Enabled = req.Coverage == true;
+        if (req.Coverage == true) AlRunner.Infrastructure.AlCoverageTracker.Reset();
+
         var cts = new System.Threading.CancellationTokenSource();
         System.Threading.Interlocked.Exchange(ref activeRunCts, cts);
         try
@@ -3992,17 +4001,37 @@ int RunServerLoop(System.IO.TextReader input, System.IO.TextWriter output)
             // theoretical TOCTOU. See ServerCancelTests.Cancel_AfterRunTestsCompletes_IsNoop.
             System.Threading.Interlocked.CompareExchange(ref activeRunCts, null, cts);
 
+            // #2042: built from sourcePaths (the SAME roots the run just compiled),
+            // matching the CLI --coverage path's AlCoverageSourceMap.Build call —
+            // scopes whose owning object isn't found here (framework/dependency
+            // assemblies outside the bundle under test) are silently excluded, same
+            // as --coverage. Only built when requested: reflection-scanning every
+            // loaded assembly's types on every plain runTests call would be wasted
+            // work for callers who never asked for it.
+            IReadOnlyList<AlRunner.Infrastructure.AlCoverageTracker.AlStatementRecord>? statementTable = null;
+            if (req.Coverage == true)
+            {
+                var covSourceMap = AlRunner.Infrastructure.AlCoverageSourceMap.Build(
+                    req.SourcePaths, relativeTo: null);
+                statementTable = AlRunner.Infrastructure.AlCoverageTracker.CollectStatementTable(covSourceMap);
+            }
+
             lock (outputLock)
             {
                 output.WriteLine(AlRunner.ServerProtocol.Summary(
                     allTests, exitCode, cached, changed,
                     allCompileErrors.Count > 0 ? allCompileErrors : null,
-                    cancelled: cancelled, wallSeconds: reqSw.Elapsed.TotalSeconds));
+                    cancelled: cancelled, wallSeconds: reqSw.Elapsed.TotalSeconds,
+                    statementTable: statementTable));
                 output.Flush();
             }
         }
         finally
         {
+            // Scoped to THIS request only, same reasoning as HandleServerExecute's
+            // AlValueCapture.Enabled reset below — a coverage:true request must never
+            // leave hit-count tracking on for a later request that didn't ask for it.
+            AlRunner.Infrastructure.AlCoverageTracker.Enabled = false;
             // Belt-and-braces: reaches the same state as the explicit clear above on
             // every path, INCLUDING an exception thrown before that point (e.g. from
             // RunAllBundlesForServer) — a pathological caller must never be left with a
@@ -4051,6 +4080,13 @@ int RunServerLoop(System.IO.TextReader input, System.IO.TextWriter output)
         // so a captureValues:true request never leaves the flag on for a later request
         // that didn't ask for it (the flag is process-global, same as AlCoverageTracker.Enabled).
         AlRunner.Infrastructure.AlValueCapture.Enabled = req.CaptureValues == true;
+        // #2042: 'coverage:true' on `execute` — same request/response correlation the
+        // issue's acceptance criteria need: THIS single `execute` call can enable BOTH
+        // captureValues AND coverage together, so a caller can prove statementId lines
+        // up between capturedValues and the statement table from ONE run (see
+        // AlStatementTableTests.CapturedValueStatementId_MatchesStatementTableScopeAndId).
+        AlRunner.Infrastructure.AlCoverageTracker.Enabled = req.Coverage == true;
+        if (req.Coverage == true) AlRunner.Infrastructure.AlCoverageTracker.Reset();
         try
         {
             var runs = RunAllBundlesForServer(sourcePaths, req.PackagePaths, RunFirstCodeunitOnRun);
@@ -4065,12 +4101,25 @@ int RunServerLoop(System.IO.TextReader input, System.IO.TextWriter output)
                     combinedHashes[kv.Key] = kv.Value;
             lastFileHashes = combinedHashes;
 
+            // Built BEFORE returning (i.e. before `finally` deletes an inline-code
+            // scratchDir below) — sourcePaths here is either the caller's real
+            // sourcePaths or that same scratchDir, and AlCoverageSourceMap.Build
+            // needs the .al files on disk to still exist when it scans them.
+            IReadOnlyList<AlRunner.Infrastructure.AlCoverageTracker.AlStatementRecord>? statementTable = null;
+            if (req.Coverage == true)
+            {
+                var covSourceMap = AlRunner.Infrastructure.AlCoverageSourceMap.Build(sourcePaths, relativeTo: null);
+                statementTable = AlRunner.Infrastructure.AlCoverageTracker.CollectStatementTable(covSourceMap);
+            }
+
             return AlRunner.ServerProtocol.Execute(allTests, exitCode, null,
-                allCompileErrors.Count > 0 ? allCompileErrors : null);
+                allCompileErrors.Count > 0 ? allCompileErrors : null,
+                statementTable: statementTable);
         }
         finally
         {
             AlRunner.Infrastructure.AlValueCapture.Enabled = false;
+            AlRunner.Infrastructure.AlCoverageTracker.Enabled = false;
             // Best-effort cleanup: the scratch dir's contents are fully consumed
             // once RunBundleForServer has emitted+compiled them into an in-memory
             // assembly (or failed trying) — nothing downstream needs the files on

--- a/AlRunner/ServerProtocol.cs
+++ b/AlRunner/ServerProtocol.cs
@@ -8,14 +8,14 @@ namespace AlRunner;
 /// newline-delimited JSON protocol the VS Code extension depends on.
 ///
 /// One JSON object per line. stdin = requests, stdout = responses.
-///   request : {command, sourcePaths[], packagePaths[], stubPaths[], code, captureValues, testIsolation}
+///   request : {command, sourcePaths[], packagePaths[], stubPaths[], code, captureValues, coverage, testIsolation}
 ///   runTests: STREAMING (protocol-v2.schema.json — see #1641) — zero or more
 ///             {"type":"test", name, status, durationMs, message, errorKind,
 ///             stackFrames, stackTrace} lines, one per completed test as it
 ///             finishes, followed by exactly one terminal
 ///             {"type":"summary", exitCode, passed, failed, errors,
 ///             total, cached, cancelled|omitted, changedFiles|omitted,
-///             compilationErrors|omitted, wallSeconds|omitted,
+///             compilationErrors|omitted, coverage|omitted, wallSeconds|omitted,
 ///             protocolVersion:2} line.
 ///             `cancelled` (true) is present only when a concurrent `cancel`
 ///             command actually stopped the run before every test ran; omitted
@@ -31,7 +31,8 @@ namespace AlRunner;
 ///             already finished) at the moment the cancel was processed — the v1
 ///             shape (#1613/#1614), reused verbatim rather than inventing a new one.
 ///   execute : {exitCode, tests:[{name,status,durationMs,message,stackTrace,
-///              capturedValues|omitted}], messages|null, compilationErrors|null} —
+///              capturedValues|omitted}], messages|null, compilationErrors|null,
+///              coverage|omitted} —
 ///              single response, not streamed (matches v1: only runTests streams).
 ///              `capturedValues` (#1640) is present per test only when the request
 ///              set `captureValues:true`; each entry is {scopeName, variableName,
@@ -40,6 +41,15 @@ namespace AlRunner;
 ///              read or its ToString() threw; `value` is null in that case too but
 ///              MUST NOT be read as "genuinely null" — a genuinely null AL variable
 ///              has `captureError` absent.
+///   `coverage` (#2042, on BOTH `runTests`' summary and `execute`'s response) is
+///   present only when the request set `coverage:true`: one entry per AL source file,
+///   {file, statements:[{id, scope, line, column, endLine, endColumn, hits}]}. `id` is
+///   the SAME id-space as `capturedValues[].statementId` for the same `scope` — see
+///   AlStatementTableTests. Supersedes the schema-only v1 `FileCoverage{file, lines[],
+///   totalStatements, hitStatements}` shape (protocol-v2.schema.json never had a
+///   working implementation of it, so there is no compatibility break): per-statement
+///   detail with positions strictly subsumes a line-hit rollup, which a caller can
+///   still derive client-side by grouping `statements` on `line`.
 ///   error   : {error}
 ///   shutdown: {status}
 /// </summary>
@@ -60,6 +70,21 @@ public sealed class ServerRequest
     /// field omitted from the response.
     /// </summary>
     [JsonPropertyName("captureValues")] public bool? CaptureValues { get; set; }
+    /// <summary>
+    /// Opt-in to per-statement hit counts + a position table on `runTests`/`execute`
+    /// (issue #2042 — the id/position half `captureValues`' `statementId` needed to be
+    /// placeable in an editor, per SShadowS/ALchemist#1). When true, the response's
+    /// `coverage[]` carries one entry per AL source file; each entry's `statements[]`
+    /// gives every BC-instrumented statement's `id` (the SAME id-space as
+    /// `capturedValues[].statementId` for the SAME `scope` — see
+    /// AlStatementTableTests.CapturedValueStatementId_MatchesStatementTableScopeAndId), the
+    /// owning AL member name (`scope`), the 1-based start/end line+column, and this
+    /// run's hit count. Per statement, never per line: two statements sharing a line
+    /// are two separate entries, not one summed count. Reuses AlCoverageTracker's
+    /// existing StmtHit hook (#1922) — no new instrumentation. Null/false = unchanged
+    /// behaviour, `coverage` omitted from the response.
+    /// </summary>
+    [JsonPropertyName("coverage")] public bool? Coverage { get; set; }
     /// <summary>
     /// "codeunit" (default) | "test"/"method" | "disabled" — see <see cref="TestIsolationParser"/>.
     /// Null = the server's existing default (TestIsolation.Codeunit), matching the
@@ -175,6 +200,12 @@ public static class ServerProtocol
     /// first one). Omitted (never 0) when the caller does not supply it, same
     /// null-omission convention as every other optional field here.
     /// </summary>
+    /// <paramref name="statementTable"/> (#2042) is the run's aggregated per-statement
+    /// hit-count + position table (see AlCoverageTracker.CollectStatementTable), passed
+    /// only when the request set `coverage:true`. Null omits `coverage` entirely
+    /// (WhenWritingNull); a non-null EMPTY list still serializes as `coverage:[]` —
+    /// "asked, nothing instrumented" is a real, distinct answer from "didn't ask",
+    /// same convention `capturedValues` already uses for `captureValues`.
     public static string Summary(
         IReadOnlyList<TestResult> tests,
         int exitCode,
@@ -182,7 +213,8 @@ public static class ServerProtocol
         IReadOnlyList<string>? changedFiles = null,
         IReadOnlyList<CompilationErrorGroup>? compilationErrors = null,
         bool cancelled = false,
-        double? wallSeconds = null)
+        double? wallSeconds = null,
+        IReadOnlyList<Infrastructure.AlCoverageTracker.AlStatementRecord>? statementTable = null)
     {
         var payload = new
         {
@@ -198,18 +230,22 @@ public static class ServerProtocol
             compilationErrors = compilationErrors is { Count: > 0 }
                 ? compilationErrors.Select(g => new { file = g.File, errors = g.Errors })
                 : null,
+            coverage = ToStatementTableWire(statementTable),
             wallSeconds,
             protocolVersion = 2,
         };
         return JsonSerializer.Serialize(payload, Opts);
     }
 
-    /// <summary>Serialize an execute response (run-mode / inline code).</summary>
+    /// <summary>Serialize an execute response (run-mode / inline code). <paramref
+    /// name="statementTable"/> — see Summary's doc comment; identical `coverage`
+    /// shape and null-vs-empty convention.</summary>
     public static string Execute(
         IReadOnlyList<TestResult> tests,
         int exitCode,
         IReadOnlyList<string>? messages = null,
-        IReadOnlyList<CompilationErrorGroup>? compilationErrors = null)
+        IReadOnlyList<CompilationErrorGroup>? compilationErrors = null,
+        IReadOnlyList<Infrastructure.AlCoverageTracker.AlStatementRecord>? statementTable = null)
     {
         var payload = new
         {
@@ -219,8 +255,41 @@ public static class ServerProtocol
             compilationErrors = compilationErrors is { Count: > 0 }
                 ? compilationErrors.Select(g => new { file = g.File, errors = g.Errors })
                 : null,
+            coverage = ToStatementTableWire(statementTable),
         };
         return JsonSerializer.Serialize(payload, Opts);
+    }
+
+    // Groups a flat statement list into the wire's per-file shape (issue #2042):
+    // {file, statements:[{id, scope, line, column, endLine, endColumn, hits}]}.
+    // Null in -> null out (coverage omitted); a non-null empty list in -> an empty
+    // (but present) enumerable out, so Summary/Execute's WhenWritingNull only ever
+    // strips the field for "not requested", never for "requested, found nothing".
+    // Ordered (file, then line, then column) so repeated calls against the same run
+    // are byte-identical — reflection's assembly/type enumeration order is not a
+    // contract callers should have to tolerate drifting.
+    private static IEnumerable<object>? ToStatementTableWire(
+        IReadOnlyList<Infrastructure.AlCoverageTracker.AlStatementRecord>? statements)
+    {
+        if (statements == null) return null;
+        return statements
+            .GroupBy(s => s.FilePath)
+            .OrderBy(g => g.Key, StringComparer.Ordinal)
+            .Select(g => (object)new
+            {
+                file = g.Key,
+                statements = g.OrderBy(s => s.Line).ThenBy(s => s.Column).ThenBy(s => s.StatementId)
+                    .Select(s => new
+                    {
+                        id = s.StatementId,
+                        scope = s.ScopeName,
+                        line = s.Line,
+                        column = s.Column,
+                        endLine = s.EndLine,
+                        endColumn = s.EndColumn,
+                        hits = s.HitCount,
+                    }),
+            });
     }
 
     // A single test result on the wire. stackTrace prefers the AL call stack

--- a/docs/server-mode.md
+++ b/docs/server-mode.md
@@ -41,6 +41,7 @@ al-runner --server [--package-cache PATH ...] [--cache DIR]
   "stubPaths": [],              // v1 field, ignored in v2 (no stubs layer)
   "code": "...",                // execute only (inline AL); mutually exclusive with sourcePaths
   "captureValues": false,       // execute only — see #1640
+  "coverage": false,            // runTests + execute — per-statement hit counts + position table, see #2042
   "testIsolation": "codeunit"   // optional: "codeunit" (default) | "test"/"method" | "disabled"
                                  // — see #1616. Applies to this request only; a later
                                  // request that omits the field falls back to the
@@ -100,8 +101,9 @@ streams `test` lines across all of them before the one final `summary`.
   bundle (there was nothing to run).
 - `cancelled: true` is present on the summary only when a concurrent `cancel`
   command actually stopped the run before every test ran (see `cancel` below);
-  omitted otherwise (never emitted as `false`). `capturedValues` and `coverage`
-  still need the Cecil instrumentation pass tracked on #1640.
+  omitted otherwise (never emitted as `false`).
+- `coverage` (#2042) is present on the summary only when the request set
+  `coverage: true` — see "Per-statement hit counts (`coverage`)" below.
 
 A request-level problem (e.g. a missing `sourcePaths`) returns the usual single
 `{"error":"..."}` line instead of a `test`/`summary` sequence — see Errors below.
@@ -194,6 +196,60 @@ variable: a genuinely null variable is reported with `value:null` and
 `captureError` **absent**. A variable whose read failed is never simply
 omitted from the array — that would be indistinguishable from "this variable
 does not exist" (`.claude/rules/loud-failures.md`).
+
+### Per-statement hit counts (`coverage`)
+
+`coverage: true` (#2042) opts into a per-statement hit-count + position table on
+**both** `runTests`' terminal `summary` line and `execute`'s response — reusing
+`--coverage`'s existing `StmtHit`/`CStmtHit` hook (#1922), no new instrumentation.
+`coverage` is an array with one entry per AL source file; each file's
+`statements` array has one entry per BC-instrumented statement:
+
+```json
+{"command":"execute","captureValues":true,"coverage":true,
+ "code":"codeunit 50100 X { trigger OnRun() var Msg: Text; begin Msg := 'hi'; Msg := 'bye'; end; }"}
+```
+
+```json
+{"exitCode":0,"tests":[{"name":"X.OnRun","status":"pass","durationMs":7,
+ "capturedValues":[{"scopeName":"OnRun","variableName":"Msg","value":"bye","statementId":1}]}],
+ "coverage":[{"file":"/tmp/.../Scratch.al","statements":[
+   {"id":0,"scope":"OnRun","line":1,"column":57,"endLine":1,"endColumn":69,"hits":1},
+   {"id":1,"scope":"OnRun","line":1,"column":70,"endLine":1,"endColumn":83,"hits":1}]}]}
+```
+
+- **`id` is the SAME id-space as `capturedValues[].statementId` for the SAME
+  `scope`.** This is the feature's actual point: `--capture-values` (#2040)
+  emits a `statementId` with no reliable way to place it in an editor short of
+  treating it as an index into a sorted covered-lines list — a heuristic that
+  breaks on multi-statement lines and skipped statements (see the upstream
+  request, SShadowS/ALchemist#1). `coverage[].statements[].id` resolves it
+  exactly: look up the entry whose `scope` matches `capturedValues[].scopeName`
+  and whose `id` matches `capturedValues[].statementId`, and its `line`/`column`
+  is the real AL source position that value was captured at.
+- **Per statement, never per line.** Two statements sharing a source line are
+  two separate entries with their own `hits`, not one summed count — the
+  distinction a plain line-coverage rollup necessarily discards. A line rollup
+  is still trivial to derive client-side (group `statements` by `line`, sum
+  `hits`); the reverse is not.
+- `line`/`column`/`endLine`/`endColumn` are 1-based, decoded from BC's own
+  `[SourceSpans]` attribute (`AlSourceSpanCodec`) — the same source
+  `--coverage`'s Cobertura output and `--capture-values`' `statementId` both
+  already read.
+- `hits` is the number of times that exact statement executed in **this**
+  request — not accumulated across the server process's lifetime. A statement
+  hit 0 times (an untaken branch) is still listed, not omitted — "did not
+  execute" is a real, distinct answer from "not part of this scope".
+- Supersedes protocol-v2.schema.json's older, never-implemented
+  `FileCoverage{file, lines[], totalStatements, hitStatements}` shape — that
+  shape was schema-only (this repo never shipped a working `coverage` producer
+  for it), so there is no compatibility break. Per-statement detail with
+  positions strictly subsumes a line-hit rollup.
+- `coverage` is omitted entirely (not an empty array) when the request didn't
+  set `coverage: true`; a non-null but empty `coverage: []` means "asked,
+  nothing was instrumented" (e.g. a compile failure before any AL code ran) —
+  the same "requested vs found nothing" distinction `capturedValues` already
+  makes.
 
 ### `shutdown`
 

--- a/protocol-v2.schema.json
+++ b/protocol-v2.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/StefanMaron/BusinessCentral.AL.Runner/schemas/protocol-v2.json",
   "title": "AL.Runner Server Protocol v2",
-  "description": "Newline-delimited JSON. A `runtests` request emits zero or more `test` lines, optional `progress` lines, then exactly one `summary` line. Each line is a separate JSON document. STATUS on v2 (#1641): --server streams this shape for `runTests`, and each `test` line carries `errorKind` and `stackFrames`. The `cancel` command and its `ack` response are live, and a run it actually stopped carries `cancelled:true` on the summary — see docs/server-mode.md. `progress` is defined but has no producer yet (same as v1: reserved for a future finer-grained progress signal; `test` lines already give per-test progress). Still schema-only: `capturedValues`/`coverage`/`alSourceFile`/`alSourceLine`, which need the Cecil instrumentation pass tracked on #1640. Absent optional fields mean 'not known', never 'empty'.",
+  "description": "Newline-delimited JSON. A `runtests` request emits zero or more `test` lines, optional `progress` lines, then exactly one `summary` line. Each line is a separate JSON document. STATUS on v2 (#1641): --server streams this shape for `runTests`, and each `test` line carries `errorKind` and `stackFrames`. The `cancel` command and its `ack` response are live, and a run it actually stopped carries `cancelled:true` on the summary — see docs/server-mode.md. `progress` is defined but has no producer yet (same as v1: reserved for a future finer-grained progress signal; `test` lines already give per-test progress). `Summary.coverage` (#2042) is live when the request set `coverage:true` — per-statement hit counts + position table, the SAME id-space as `execute`'s `capturedValues[].statementId` per scope; see docs/server-mode.md's \"Per-statement hit counts\" section. Still schema-only on TestEvent: `capturedValues`/`alSourceFile`/`alSourceLine`, which need the Cecil instrumentation pass tracked on #1640 wired into the STREAMING path specifically (execute's own, non-streamed response already carries capturedValues+coverage today). Absent optional fields mean 'not known', never 'empty'.",
   "definitions": {
     "AlStackFrame": {
       "type": "object",
@@ -65,24 +65,39 @@
         }
       }
     },
-    "FileCoverage": {
+    "StatementRecord": {
       "type": "object",
-      "required": ["file", "lines", "totalStatements", "hitStatements"],
+      "required": ["id", "scope", "line", "column", "hits"],
+      "properties": {
+        "id": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "BC's own StmtHit(N)/CStmtHit(N) index for this statement, scoped to `scope`. The SAME id-space as `capturedValues[].statementId` for a scope of the same name (#2042) — both are read straight off NavMethodScope.StatementNumber for the identical compiled scope class, never independently derived. Not globally unique across scopes: id 0 in one `scope` is a different statement from id 0 in another."
+        },
+        "scope": {
+          "type": "string",
+          "description": "The AL member (procedure/trigger/test method) name owning this statement — BC's own [NavName(...)] on the generated scope class, matching `capturedValues[].scopeName`."
+        },
+        "line": { "type": "integer", "minimum": 1 },
+        "column": { "type": "integer", "minimum": 1 },
+        "endLine": { "type": "integer", "minimum": 1 },
+        "endColumn": { "type": "integer", "minimum": 1 },
+        "hits": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Times this exact statement executed in THIS run — never summed with any other statement, even one sharing the same line."
+        }
+      }
+    },
+    "FileStatements": {
+      "type": "object",
+      "required": ["file", "statements"],
       "properties": {
         "file": { "type": "string" },
-        "lines": {
+        "statements": {
           "type": "array",
-          "items": {
-            "type": "object",
-            "required": ["line", "hits"],
-            "properties": {
-              "line": { "type": "integer", "minimum": 1 },
-              "hits": { "type": "integer", "minimum": 0 }
-            }
-          }
-        },
-        "totalStatements": { "type": "integer", "minimum": 0 },
-        "hitStatements": { "type": "integer", "minimum": 0 }
+          "items": { "$ref": "#/definitions/StatementRecord" }
+        }
       }
     },
     "Summary": {
@@ -116,7 +131,8 @@
         },
         "coverage": {
           "type": "array",
-          "items": { "$ref": "#/definitions/FileCoverage" }
+          "items": { "$ref": "#/definitions/FileStatements" },
+          "description": "Present only when the request set `coverage:true` (#2042). One entry per AL source file with per-statement hit counts and positions — see StatementRecord/FileStatements. Supersedes the older, never-implemented FileCoverage{lines[], totalStatements, hitStatements} shape (this repo shipped no working `coverage` producer for it, so there is no compatibility break): per-statement detail with positions strictly subsumes a line-hit rollup, which a caller can still derive client-side by grouping `statements` on `line`."
         },
         "wallSeconds": { "type": "number", "minimum": 0 },
         "protocolVersion": { "const": 2 }


### PR DESCRIPTION
Closes #2042

## What

`coverage:true` on `runTests`/`execute` reports one entry per AL source file, each with a `statements[]` array giving every BC-instrumented statement's `id`, owning AL member name (`scope`), 1-based start/end line+column, and this run's hit count. Reuses `--coverage`'s existing `StmtHit`/`CStmtHit` hook (#1922) via a new `AlCoverageTracker.CollectStatementTable` — no new instrumentation.

## The id-space claim, verified not assumed

Per the issue's own instruction, I verified before building that `capturedValues[].statementId` (from `--capture-values`, #2040) and the new statement table's `id` are genuinely the same id-space, per scope:

- Both are read straight off `NavMethodScope.StatementNumber` / the `StmtHit(N)` argument, for the identical compiled `*_Scope` class — confirmed by decompiling emitted C# (`BCCOMPILER_DUMP_CS=1`) and by keying both `AlCoverageTracker`'s hit dictionary and `AlValueCapture`'s captured statement id off the exact same integer source.
- Proven end-to-end by `AlStatementTableTests.CapturedValueStatementId_MatchesStatementTableScopeAndId`: one `execute` call with both `captureValues:true` and `coverage:true`, asserting the statement-table row whose `(scope, id)` matches `capturedValues[].(scopeName, statementId)` sits at the exact AL source line the captured value came from.

They lined up correctly the first time — no fix was needed there. What *did* need fixing (see below) was a duplication bug the correlation testing surfaced in a warm, repeated-request server.

## Design decision: supersede `coverage[]`, not extend it

Per the issue: "the consumer has said superseding the existing coverage[] shape entirely is acceptable rather than carrying two shapes. Decide deliberately, and state which you chose and why."

**Chose: supersede.** `protocol-v2.schema.json`'s old `FileCoverage{file, lines[], totalStatements, hitStatements}` was schema-only — grep-verified there was never a working `ServerProtocol.Summary()`/`Execute()` producer for it before this PR — so there is no compatibility break. Per-statement detail with positions strictly subsumes a line-hit rollup: a caller who still wants line-level totals can trivially derive them client-side (group `statements` by `line`, sum `hits`); the reverse (recovering per-statement detail from a line rollup) is not possible, which is exactly the gap ALchemist's own issue reply named.

## A ghost-duplication bug the feature's own testing found

While writing a regression test for "hit counts don't leak across requests on a warm server," I found that a naive "scan every loaded assembly for SourceSpans-carrying types" (the same pattern `AlCoverageTracker.Collect()`, used by the CLI's `--coverage`, already used) reports **duplicate** entries on a warm `--server` process: `RunBundleForServer` calls `Assembly.Load(assemblyBytes)` again on every request that isn't a cross-bundle-dedup reuse — including a pure AL-output cache HIT with byte-identical content — so repeating the same request N times leaves N Assembly generations resident (.NET never unloads them). Each generation's `Type` still carries `[SourceSpans]` and is still reflectable, so a scan after `Reset()` finds the live generation (real hit count) *and* every stale generation (hit count 0, since `Reset()` cleared the dictionary but not the type) — one phantom-zero ghost entry per prior request.

Fixed by scoping `CollectStatementTable`'s scan to `AlCoverageTracker.GetHitTrackedTypes()` — the distinct `Type`s that recorded at least one hit since the last `Reset()` — instead of every loaded assembly. This only affects the new method; `Collect()` (CLI `--coverage`, a single-generation short-lived process) is untouched. Covered by `AlStatementTableTests.Coverage_RepeatedIdenticalRequests_NeverGhostDuplicates`, which sends the identical `runTests` request three times on one shared server and asserts no duplicate/drifting entries.

## Tests (`AlRunner.Tests/AlStatementTableTests.cs`)

- `CapturedValueStatementId_MatchesStatementTableScopeAndId` — the id-space correlation proof (acceptance criterion 2).
- `LoopBodyStatement_HitFourTimes_ReportsHitCountFour` — a statement hit N times reports N (acceptance criterion 3, first half).
- `TwoStatementsOnSameLine_ReportSeparately_NotSummed` — two statements on one line report as two entries, not a summed count (acceptance criterion 3, second half).
- `Coverage_Omitted_NoCoverageField` — negative direction: the flag actually gates the feature.
- `Coverage_RepeatedIdenticalRequests_NeverGhostDuplicates` — regression guard for the ghost-duplication bug above.

RED confirmed before the implementation (4 of 5 failed; the negative-direction fact legitimately already passed), GREEN after. Full `AlRunner.Tests` suite (975 tests) still green.

## Explicitly out of scope (per the issue)

- Per-test statement hits (`statementHits` on `TestEvent`) — not built; the aggregate-in-Summary/execute-response shape is the agreed default. The mechanism doesn't make per-test hits "nearly free" (hit counts are already aggregated process-wide via `AlCoverageTracker`, not scoped per test invocation), so no follow-up issue filed for it.
- Loop-iteration/value pairing — already split out to #2056 per a previous comment on this issue.

## Docs

- `docs/server-mode.md` — new "Per-statement hit counts (`coverage`)" section.
- `protocol-v2.schema.json` — `FileCoverage` replaced with `StatementRecord`/`FileStatements`; `Summary.coverage` now points at the new shape with a description of the id-space guarantee and the supersession rationale.