### PR TITLE
fix(testpage): type-aware conversion for page-global Code/Date/Enum controls

### DIFF
--- a/AlRunner.Tests/TestPageDateValueTests.cs
+++ b/AlRunner.Tests/TestPageDateValueTests.cs
@@ -1,0 +1,67 @@
+// TestPageDateValueTests — contract tests for AlRunner.TestPageDateValue (issue #2054, the
+// page-variable-Date half — see MockTestPage.cs's TestPageDateValue doc comment for the full
+// root-cause story).
+//
+// This is deliberately NOT a claim about what Business Central does (that claim belongs
+// upstream, in StefanMaron/BusinessCentral.AL.Language.Tests, where a real BC service tier can
+// adjudicate it). It is a claim about OUR OWN conversion helper: that it accepts exactly the
+// spelling PageVariableTestField.ValueToString produces for a Date ClientObject (.NET's
+// InvariantCulture general date/time pattern) and throws loudly — not silently defaulting —
+// for anything else, so a SetValue(Date) round trip cannot silently start accepting arbitrary
+// text or silently coerce an unparseable string into a wrong date.
+//
+// RED/GREEN: before this fix, PageVariableTestField.ToBoundValue had no case for NavDate at
+// all and fell through to ALCompiler.ToNavValue(value) — a NavText — which the page's own
+// generated setter for a Date global then rejected with
+// "Unable to cast object of type 'NavText' to type 'NavDate'". Reverting
+// TestPageDateValue.Resolve to that same always-NavText fallback makes the positive assertion
+// here fail (no NavDate is ever produced), which is exactly the regression this file exists to
+// catch in milliseconds, without needing the BC engine loaded.
+using System;
+using AlRunner;
+using AlRunner.Infrastructure;
+using Microsoft.Dynamics.Nav.Runtime;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class TestPageDateValueTests
+{
+    // Positive: the exact spelling .NET's Convert.ToString(DateTime, InvariantCulture) produces
+    // — the general date/time pattern "MM/dd/yyyy HH:mm:ss" — round-trips to the same date.
+    [Fact]
+    public void Resolve_InvariantCultureGeneralFormat_ReturnsMatchingNavDate()
+    {
+        var result = TestPageDateValue.Resolve("12/31/2026 00:00:00", "unit test");
+
+        var date = Assert.IsType<NavDate>(result);
+        Assert.Equal(new DateTime(2026, 12, 31), date.Value.Date);
+    }
+
+    [Fact]
+    public void Resolve_DifferentDate_ReturnsThatExactDate()
+    {
+        var result = TestPageDateValue.Resolve("01/15/2020 00:00:00", "unit test");
+
+        var date = Assert.IsType<NavDate>(result);
+        Assert.Equal(new DateTime(2020, 1, 15), date.Value.Date);
+    }
+
+    // Negative: NOT the round-trip spelling this mock itself produces. "31/12/2026" is a
+    // day-first spelling InvariantCulture's month-first parser rejects (month 31 is invalid) —
+    // whether real BC's own TestPage.SetValue accepts other date spellings is a separate,
+    // upstream-unvalidated question; this must throw loudly rather than silently guessing, per
+    // .claude/rules/loud-failures.md.
+    [Theory]
+    [InlineData("31/12/2026")]
+    [InlineData("not a date")]
+    [InlineData("")]
+    public void Resolve_AnythingElse_ThrowsOutOfScope_NamingTheReason(string input)
+    {
+        var ex = Assert.Throws<RunnerOutOfScopeException>(
+            () => TestPageDateValue.Resolve(input, "unit test context"));
+
+        Assert.Contains("testpage-date-value", ex.Reason);
+        Assert.Contains("unit test context", ex.Message);
+    }
+}

--- a/AlRunner/Patches/MockTestPage.cs
+++ b/AlRunner/Patches/MockTestPage.cs
@@ -1287,6 +1287,40 @@ internal static class TestPageBooleanValue
     }
 }
 
+/// <summary>
+/// Date values as a page-variable TestPage control sees them (issue #2054).
+///
+/// A <c>Date</c> global is not a <c>NavStringValue</c>, so <c>NavTestField.ALSetValue</c> (the
+/// real, precompiled BC method the AL compiler emits for every <c>SetValue(&lt;Date&gt;)</c>
+/// call) round-trips it through OUR OWN <see cref="PageVariableTestField.FieldType"/> (now
+/// correctly answering <c>NavType.Date</c> — see that property's doc comment) and OUR OWN
+/// <c>ValueToString</c> before it ever reaches <see cref="ITestField.Value"/>'s setter. Both
+/// ends of that round trip are code this runner owns: <c>ValueToString</c> for this class is
+/// the generic <c>Convert.ToString(value, CultureInfo.InvariantCulture)</c>, which — once
+/// FieldType stops lying about the type — is handed a plain <c>DateTime</c>
+/// (<c>NavDate.ClientObject</c>) and renders it via .NET's InvariantCulture general date/time
+/// pattern (e.g. "12/31/2026 00:00:00"). <see cref="Resolve"/> only needs to invert THAT exact
+/// spelling, the same way <see cref="TestPageBooleanValue"/> only needs to invert "True"/"False".
+/// </summary>
+internal static class TestPageDateValue
+{
+    internal static NavValue Resolve(string value, string context)
+    {
+        if (!DateTime.TryParse(value, CultureInfo.InvariantCulture,
+                System.Globalization.DateTimeStyles.None, out var parsed))
+            throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
+                context,
+                $"testpage-date-value — '{value}' is not the round-trip spelling TestPage "
+                + "SetValue(Date) itself produces (InvariantCulture general date/time format). "
+                + "See docs/scope.md");
+
+        // NavDate.Create requires DateTimeKind.Local (its private ctor throws
+        // NavNCLDateInvalidException otherwise) — DateTime.Parse without an explicit style
+        // always returns Unspecified, so it must be stamped before handing it back.
+        return NavDate.Create(DateTime.SpecifyKind(parsed, DateTimeKind.Local));
+    }
+}
+
 internal sealed class LiveNavTestField : ITestField
 {
     private readonly NavRecord _record;
@@ -1498,7 +1532,16 @@ internal sealed class PageVariableTestField : ITestField
 
     public string Value
     {
-        get => Convert.ToString(ObjectValue, CultureInfo.InvariantCulture) ?? string.Empty;
+        // An Option/Enum-bound control answers with its CAPTION, not the ordinal it stores —
+        // the read-side complement of #1928 (issue #2055). LiveNavTestField.Value already does
+        // this for a Rec-bound control; this class never got it, so `Format(Field.Value())` on
+        // a page-variable enum control returned "1" instead of "OR" while the write direction
+        // (SetValue, below) already resolved captions correctly.
+        get => (CurrentOption() is { } option
+                   ? TestPageOptionValue.Display(option, _page.TryGetOptionCaptions(_controlId, option))
+                   : null)
+               ?? Convert.ToString(ObjectValue, CultureInfo.InvariantCulture)
+               ?? string.Empty;
         set
         {
             RunnerPageInstance.SetValue(_expression, ToBoundValue(value));
@@ -1507,6 +1550,11 @@ internal sealed class PageVariableTestField : ITestField
     }
 
     public object? ObjectValue => LiveNavTestPage.Unwrap(RunnerPageInstance.GetValue(_expression));
+
+    // The stored NavValue, not the unwrapped ClientObject — see LiveNavTestField.CurrentOption
+    // for why: the option metadata (and, for an Enum, whether it IS one — see
+    // TestPageOptionValue.EnumCaptions) rides on the NavOption itself.
+    private NavOption? CurrentOption() => RunnerPageInstance.GetValue(_expression) as NavOption;
 
     /// <summary>
     /// Convert the string a test wrote into the NavValue the binding actually holds.
@@ -1518,6 +1566,14 @@ internal sealed class PageVariableTestField : ITestField
     /// (#1837): a NavText written into it throws "The input string '...' was not in a
     /// correct format" instead of setting the field, so Boolean gets the same NavOption-style
     /// special case — see <see cref="TestPageBooleanValue"/>.
+    ///
+    /// Code and Date bindings (#2054) are the same shape of bug again. A `Code[20]` global's
+    /// generated setter throws "Unable to cast object of type 'NavText' to type 'NavCode'",
+    /// and a `Date` global's throws the same against 'NavDate' — Integer and Text globals
+    /// round-trip fine only because their generated setters happen to accept a NavText and
+    /// coerce it themselves, which Code's and Date's do not. NavCode carries the field's own
+    /// declared length (`Code[20]`), so the replacement is built against the CURRENT bound
+    /// value's own MaxLength rather than a guessed constant.
     /// </summary>
     private NavValue ToBoundValue(string value)
         => RunnerPageInstance.GetValue(_expression) switch
@@ -1525,6 +1581,8 @@ internal sealed class PageVariableTestField : ITestField
             NavOption option => TestPageOptionValue.Resolve(option, value, _page.TryGetOptionCaptions(_controlId, option),
                 $"TestPage SetValue (control {_controlId})"),
             NavBoolean => TestPageBooleanValue.Resolve(value, $"TestPage SetValue (control {_controlId})"),
+            NavCode current => new NavCode(current.MaxLength, value),
+            NavDate => TestPageDateValue.Resolve(value, $"TestPage SetValue (control {_controlId})"),
             _ => ALCompiler.ToNavValue(value),
         };
 
@@ -1542,11 +1600,20 @@ internal sealed class PageVariableTestField : ITestField
     // (NOT the "True"/"False" ValueToString itself would have produced) before ever reaching our
     // Value setter — which is why the var-bound and Rec-bound halves of #1837 threw two DIFFERENT
     // exceptions for the same SetValue(true) call: they disagreed about what string this control
-    // even claimed to receive.
+    // even claimed to receive. A Date global (#2054) failed the SAME way for the SAME reason:
+    // FieldType answering Text sent NavTestField.ALSetValue's DMY2Date(...) argument through
+    // Text metadata instead of Date, and the text it came out as could not be cast back into
+    // the Date binding. Code does not need an entry here — NavCode IS a NavStringValue, so
+    // ALSetValue's own fast path (`value is NavStringValue`) skips FieldType/ValueToString
+    // entirely for it and hands SetValue's literal straight to ToBoundValue above — but it is
+    // listed anyway so a reader checking "does this table cover every case ToBoundValue does"
+    // is not left wondering whether it was missed.
     public NavType FieldType => RunnerPageInstance.GetValue(_expression) switch
     {
         NavOption => NavType.Option,
         NavBoolean => NavType.Boolean,
+        NavCode => NavType.Code,
+        NavDate => NavType.Date,
         _ => NavType.Text,
     };
     public int ValidationErrorCount => 0;

--- a/tests/expectations/count-baseline/test-count-baseline.json
+++ b/tests/expectations/count-baseline/test-count-baseline.json
@@ -2,7 +2,7 @@
   "_comment": "Consumed by --count-baseline (AlRunner/Infrastructure/CountBaseline.cs), a DIFFERENT schema from the oos-/known-gaps-/divergence-/disabled- files in this directory: those declare the expected CLASSIFICATION of one named test, this declares the expected EXACT COUNT of a whole suite -- an exact match, not a floor: a mismatch in EITHER direction (drop OR growth) fails the run (exit 4). See #1880 and PR #1882's review for why growth is also a hard failure, not just a notice. Suite keys are the basename of the bundle directory CI passes on the command line (tests/al-language/tests/al-language -> 'al-language', tests/runner-extras -> 'runner-extras'), matching the '--out <name>-results.json' convention CI already uses. Values below are read off actual Test Matrix CI runs (see PR discussion for run URLs), not guessed: al-language's 2073->2076 bump reflects 3 corpus tests merged upstream between when the local baseline was drafted and when CI first ran against it. runner-extras' appGroups 23->21 byBcVersion override on 27.0/27.3/27.5 is the SAME preprocessor-gated-surface split that already explains its tests count divergence: fewer AL surfaces compile pre-28.0, which drops whole app groups, not just individual tests within a group. ANY PR that changes a suite's test or app-group count -- growth included -- MUST bump the matching number here in the SAME PR, or that PR's CI goes red with a [count-baseline] DROP or GROWTH diagnostic naming the exact expected/actual numbers to use.",
   "suites": {
     "al-language": {
-      "tests": { "default": 2130 },
+      "tests": { "default": 2135 },
       "appGroups": { "default": 1 }
     },
     "runner-extras": {


### PR DESCRIPTION
Closes #2054
Closes #2055

## Summary

`PageVariableTestField` never received the type-aware `SetValue`/`Value` conversion its Rec-bound sibling `LiveNavTestField` already has.

- **#2054**: `ToBoundValue` only handled `NavOption` and `NavBoolean` bindings; everything else fell through to `ALCompiler.ToNavValue(value)`, which produces a `NavText`. A `Code[20]` or `Date` page-global control's generated setter then threw `InvalidCastException` (`NavText` → `NavCode`/`NavDate`) — Integer and Text globals round-tripped fine only because their generated setters happen to accept a `NavText` and coerce it themselves.
- **#2055**: the `Value` getter was a bare `Convert.ToString(ObjectValue, ...)`, so an enum-typed page-global control's `.Value()` returned the raw ordinal instead of its caption — the read-side complement of the closed #1928, which fixed caption resolution on the `SetValue` side only.

Adds `NavCode`/`NavDate` cases to `ToBoundValue` and `FieldType` (backed by a new `TestPageDateValue` round-trip helper mirroring `TestPageBooleanValue`), and adds the same `CurrentOption()`/`Display()` caption resolution `LiveNavTestField.Value` already does to `PageVariableTestField.Value`'s getter.

## Tests

Both claims are plain BC behaviour, so the proving tests went upstream per `bc-behavior-tests-go-upstream.md`: StefanMaron/BusinessCentral.AL.Language.Tests#65 (not yet merged — awaiting review/CI there). Verified locally against this branch's build:

- RED (pre-fix): 4 failures in the corpus's `TestPageVariableControl` suite (`InvalidCastException`), 1 failure in `TestPageEnumVariableControl` (`Expected:<Blocks> Actual:<1>`).
- GREEN (this branch): all 17 tests across both suites pass.

This PR also adds a runner-side mechanism test, `AlRunner.Tests/TestPageDateValueTests.cs`, pinning the new `TestPageDateValue` round-trip helper's own contract (positive: canonical spelling round-trips; negative: anything else throws `RunnerOutOfScopeException` naming `testpage-date-value`).

`dotnet test AlRunner.Tests` run locally: 918 passed, 1 failed (`SourceDepSymbolsWithoutPackageCacheTests.SiblingSourceDep_CompilesWithZeroPackageCacheDirs`) — confirmed pre-existing and unrelated by reproducing the same failure against plain `main` with this change reverted.

## Note on the submodule pin

`tests/al-language` is not bumped in this PR (per policy) — the corpus PR above needs to merge first. The RED→GREEN evidence above was gathered by running this branch's runner build directly against the corpus branch checked out locally, not by bumping the pin.

https://claude.ai/code/session_014JcikpL1FaA977QUkCSMYY