### PR TITLE
fix(dap): bypass the per-test watchdog while a DAP session has the thread paused

### DIFF
--- a/.github/workflows/bc-tests.yml
+++ b/.github/workflows/bc-tests.yml
@@ -262,6 +262,16 @@ jobs:
       - name: Run unit tests (AlRunner.Tests)
         env:
           AL_RUNNER_PHASE_LOG: ${{ github.workspace }}/phase-log-unit.jsonl
+          # Issue #2070: opt-in ARM/EVAL/FIRE/WAIT (server, AlDapSession.cs) + SEND/GIVEUP
+          # (client, DapClient.cs) trace, both stamped with the SAME wall-clock UTC so the
+          # two one-sided traces become one comparable timeline. Ambient like
+          # AL_RUNNER_PHASE_LOG above (not RunConfiguration-scoped like DOTNET_STARTUP_HOOKS
+          # further up) because it needs to reach the SPAWNED al-runner --dap child process
+          # DapClient starts via Process.Start, which inherits ambient env vars, not
+          # .runsettings-scoped ones. Zero behavior change when unset; here specifically so
+          # the NEXT DapServerTests step-timeout failure carries the trace instead of another
+          # "[dap] client connected." dead end.
+          AL_DAP_STEP_TRACE: "1"
         run: |
           # --settings wires the DOTNET_STARTUP_HOOKS chain generated above so the in-process BC
           # engine tests (BcEngineCollection) execute here, in this single pass, instead of

--- a/AlRunner.Tests/DapClient.cs
+++ b/AlRunner.Tests/DapClient.cs
@@ -194,34 +194,110 @@ public sealed class DapClient : IAsyncDisposable
         return seq;
     }
 
+    // Issue #2070's actual root cause, found AFTER the watchdog race (real, fixed) and
+    // the Stopped-handler exception swallow (real, fixed) both turned out NOT to be
+    // what any concrete local reproduction showed: DAP responses and events are two
+    // INDEPENDENT streams that interleave by protocol design, and every call site in
+    // this file used to call ReadUntilResponseAsync WITHOUT an `events` list — so any
+    // event that arrived while waiting for a response was read off the socket and then
+    // dropped on the floor by `events?.Add(root)` on a null list. Concretely, for
+    // "next"/"stepIn"/"stepOut": handling the command releases the paused AL thread,
+    // which is then free to run, qualify, and write its own "stopped" event — a race
+    // against the DAP loop thread writing the command's OWN response. If the AL thread
+    // wins, the wire order is "stopped" event FIRST, command response SECOND.
+    // ReadUntilResponseAsync reads the "stopped" event, throws it away (no events
+    // list), reads the response, returns — and the test's very next call,
+    // ReadUntilEventAsync("stopped"), is now waiting for a SECOND "stopped" event that
+    // will never be sent, hence the 60s timeout with socket.Available=0 (the event
+    // really was delivered — and consumed and discarded) and a perfectly healthy
+    // server (it did everything right; see AlDapSession.Trace / Program.cs's
+    // STOPPED-HANDLER trace, both of which show a clean ARM/EVAL/FIRE/Walk/WriteEvent
+    // sequence in every local reproduction of this hang). It only ever hits the step
+    // tests, never the initial breakpoint reached via configurationDone, because there
+    // the response is written before the AL thread starts running at all — no race.
+    //
+    // The fix is NOT to pass an `events` list at every call site — that only narrows
+    // the trap for whichever call remembered to. A real DAP client treats events as a
+    // durable, independent stream: anything that isn't the message currently being
+    // waited for is queued, not discarded, and later reads drain the queue before
+    // touching the socket.
+    //
+    // CAUGHT WHILE BUILDING THIS: a first version had both methods dequeue from
+    // _pendingEvents and unconditionally re-enqueue a non-matching item back onto the
+    // SAME queue, in the SAME loop iteration, with no socket I/O in between. With
+    // exactly one item queued (the common case) that dequeue-then-requeue is a net
+    // no-op that repeats at CPU-bound spin speed — no real wait, no forward progress —
+    // and blew up a StringBuilder from the accompanying Trace() calls before the
+    // nominal timeout's wall-clock deadline could even be reached. Fixed by splitting
+    // each method into two phases: first drain whatever was ALREADY queued, bounded by
+    // a snapshot of the queue's length taken before the scan starts (so a re-queued
+    // miss is never reconsidered within the same phase-1 pass); only once that snapshot
+    // is exhausted does phase 2 fall through to blocking socket reads, which is the
+    // only phase allowed to burn real wall-clock time.
+    private readonly Queue<JsonElement> _pendingEvents = new();
+
     /// <summary>Reads messages until the response to <paramref name="requestSeq"/>
-    /// arrives, returning it. Any events seen along the way are appended to
-    /// <paramref name="events"/> if given (so a caller can inspect e.g. an
-    /// `initialized` event that arrives between the `initialize` request and its
-    /// response, without a second read loop).</summary>
+    /// arrives, returning it. Any events seen along the way — whether already sitting
+    /// in <see cref="_pendingEvents"/> from an earlier read or freshly read off the
+    /// socket — are appended to <paramref name="events"/> if given, and (unconditionally)
+    /// left in <see cref="_pendingEvents"/> so a later <see cref="ReadUntilEventAsync"/>
+    /// still sees them even when no `events` list is given here. A response is never
+    /// queued (by construction, only "event"-typed messages are), so phase 1 can only
+    /// ever collect for `events`, never satisfy the wait itself — it still has to run
+    /// so already-queued events are not skipped when a caller wants to see them.</summary>
     public async Task<JsonElement> ReadUntilResponseAsync(int requestSeq, List<JsonElement>? events = null, TimeSpan? timeout = null)
     {
-        var deadline = DateTime.UtcNow + (timeout ?? TimeSpan.FromSeconds(30));
+        var t = timeout ?? TimeSpan.FromSeconds(30);
+
+        var alreadyQueued = _pendingEvents.Count;
+        for (var i = 0; i < alreadyQueued; i++)
+        {
+            var queuedRoot = _pendingEvents.Dequeue();
+            events?.Add(queuedRoot);
+            _pendingEvents.Enqueue(queuedRoot);
+        }
+
+        var deadline = DateTime.UtcNow + t;
         while (DateTime.UtcNow < deadline)
         {
-            var msg = await ReadOneAsync(timeout ?? TimeSpan.FromSeconds(30));
+            var msg = await ReadOneAsync(t);
             var root = msg.Raw.RootElement;
             var type = root.GetProperty("type").GetString();
             if (type == "response" && root.TryGetProperty("request_seq", out var rs) && rs.GetInt32() == requestSeq)
                 return root;
-            if (type == "event") events?.Add(root);
+            if (type == "event")
+            {
+                events?.Add(root);
+                var evName = root.TryGetProperty("event", out var evEl) ? evEl.GetString() : "?";
+                Trace($"QUEUE event={evName} arrived while waiting for response to seq={requestSeq} — not dropped");
+                _pendingEvents.Enqueue(root);
+            }
         }
         throw new TimeoutException($"no response to request seq {requestSeq} within timeout.\n--- stdout ---\n{StdOut}\n--- stderr ---\n{StdErr}\n--- client trace ---\n{ClientTrace}");
     }
 
     /// <summary>Reads messages until an event named <paramref name="eventName"/>
-    /// arrives, returning its body. Used to wait for e.g. "stopped". Every event
-    /// seen along the way (including the terminal one) is appended to <paramref
-    /// name="allEvents"/> if given, so a caller can assert on what did NOT arrive
-    /// (e.g. "no 'stopped' event fired") without a second read loop.</summary>
+    /// arrives, returning its body. Used to wait for e.g. "stopped". Every event seen
+    /// along the way (including the terminal one) is appended to <paramref
+    /// name="allEvents"/> if given, so a caller can assert on what did NOT arrive (e.g.
+    /// "no 'stopped' event fired") without a second read loop. Phase 1 scans whatever
+    /// is ALREADY in <see cref="_pendingEvents"/> — bounded to a snapshot of its length
+    /// so a non-matching item is examined exactly once per call, never spun on — before
+    /// phase 2 falls through to blocking socket reads.</summary>
     public async Task<JsonElement> ReadUntilEventAsync(string eventName, TimeSpan? timeout = null, List<JsonElement>? allEvents = null)
     {
         var t = timeout ?? TimeSpan.FromSeconds(60);
+
+        var alreadyQueued = _pendingEvents.Count;
+        for (var i = 0; i < alreadyQueued; i++)
+        {
+            var queuedRoot = _pendingEvents.Dequeue();
+            allEvents?.Add(queuedRoot);
+            var queuedEventName = queuedRoot.TryGetProperty("event", out var qEvEl) ? qEvEl.GetString() : null;
+            if (queuedEventName == eventName) return queuedRoot;
+            _pendingEvents.Enqueue(queuedRoot);
+        }
+
         var deadline = DateTime.UtcNow + t;
         while (DateTime.UtcNow < deadline)
         {
@@ -229,8 +305,15 @@ public sealed class DapClient : IAsyncDisposable
             var root = msg.Raw.RootElement;
             if (root.GetProperty("type").GetString() != "event") continue;
             allEvents?.Add(root);
-            if (root.TryGetProperty("event", out var ev) && ev.GetString() == eventName)
+            var thisEventName = root.TryGetProperty("event", out var evEl) ? evEl.GetString() : null;
+            if (thisEventName == eventName)
                 return root;
+            // A different event than the one being awaited right now — re-queue it
+            // rather than drop it, same principle as ReadUntilResponseAsync above (a
+            // second step command in a row, each waiting on its own "stopped", is the
+            // same shape of race one level up).
+            Trace($"QUEUE event={thisEventName ?? "?"} arrived while waiting for event={eventName} — not dropped");
+            _pendingEvents.Enqueue(root);
         }
         throw new TimeoutException($"event '{eventName}' did not arrive within {t.TotalSeconds:F0}s.\n--- stdout ---\n{StdOut}\n--- stderr ---\n{StdErr}\n--- client trace ---\n{ClientTrace}");
     }

--- a/AlRunner.Tests/DapClient.cs
+++ b/AlRunner.Tests/DapClient.cs
@@ -164,6 +164,18 @@ public sealed class DapClient : IAsyncDisposable
         return new DapClient(proc, tcp, transport, stdout, stderr);
     }
 
+    /// <summary>Bytes the OS has already received and buffered on this connection but
+    /// that our own StreamReader/NetworkStream hasn't been scheduled to read yet — see
+    /// the GIVEUP diagnostic in ReadOneAsync. TcpClient.Available can throw if the
+    /// socket is already closed/disposed by the time this runs (e.g. a racing
+    /// Detach()/process exit); that's not itself informative for THIS diagnostic, so
+    /// report it as -1 rather than letting it mask the TimeoutException being built.</summary>
+    private int SafeSocketAvailable()
+    {
+        try { return _tcp.Available; }
+        catch { return -1; }
+    }
+
     private static int GetFreeLoopbackPort()
     {
         var l = new TcpListener(System.Net.IPAddress.Loopback, 0);
@@ -247,6 +259,41 @@ public sealed class DapClient : IAsyncDisposable
         }
         catch (OperationCanceledException) when (cts.IsCancellationRequested)
         {
+            // Coordinator review on PR #2076: "the server did its logic correctly" and
+            // "the bytes never arrived" produce IDENTICAL evidence in a bare GIVEUP —
+            // a client that sent, waited, and saw nothing. Two more readings, taken at
+            // the exact moment of giveup, turn that ambiguity into a real answer:
+            //
+            // 1. Bytes already sitting in the OS socket buffer. TcpClient.Available
+            //    (Socket.Available under it) counts bytes the kernel has ALREADY
+            //    received and buffered, independent of whether OUR StreamReader/
+            //    NetworkStream has been scheduled to read them. If this is > 0 at
+            //    giveup, the "stopped" bytes truly arrived and it is our own read
+            //    continuation that never got CPU time — confirms starvation, not a
+            //    delivery failure. If it's 0, the bytes never got here at all and the
+            //    cause is elsewhere (server write, network stack, something else).
+            // 2. ThreadPool health + a live latency probe. ThreadPool.ThreadCount /
+            //    PendingWorkItemCount describe the pool's OWN view of its queue depth;
+            //    a genuinely healthy pool with a deep queue can still under-report
+            //    "starved" by those two numbers alone. Actually measuring how long a
+            //    trivial `await Task.Delay(1)` takes right now is the ground truth: a
+            //    1ms delay completing in low milliseconds means the pool is fine and
+            //    something else stalled; taking seconds proves pool starvation directly
+            //    rather than inferring it from a bare 60s timeout.
+            var socketAvailable = SafeSocketAvailable();
+            var poolThreads = System.Threading.ThreadPool.ThreadCount;
+            var poolPending = System.Threading.ThreadPool.PendingWorkItemCount;
+            var probeSw = System.Diagnostics.Stopwatch.StartNew();
+            await Task.Delay(1).ConfigureAwait(false);
+            probeSw.Stop();
+            // InvariantCulture explicitly for the same reason the wall-clock stamp above
+            // needs it: ".ToString("F1")" via interpolation uses CURRENT CULTURE's
+            // decimal separator, which rendered "1,1" instead of "1.1" on this exact
+            // machine's locale while building this — caught by eye, not by design.
+            var probeMs = probeSw.Elapsed.TotalMilliseconds.ToString("F1", System.Globalization.CultureInfo.InvariantCulture);
+            Trace($"GIVEUP waited {timeout.TotalSeconds:F0}s for the next message, nothing arrived — " +
+                  $"socket.Available={socketAvailable} threadPool.ThreadCount={poolThreads} " +
+                  $"threadPool.PendingWorkItemCount={poolPending} Task.Delay(1)ActualMs={probeMs}");
             // Give the background stdout/stderr drain loops (started in StartAsync,
             // reading proc.Standard{Output,Error}.ReadLineAsync() in a loop) one
             // scheduling quantum to catch up before snapshotting them: under the exact
@@ -255,7 +302,6 @@ public sealed class DapClient : IAsyncDisposable
             // lines the child process already wrote (diagnosed reproducing #2070 under
             // load: the dump cut off mid-startup even though the child had clearly
             // progressed much further, going by the exception's own elapsed time).
-            Trace($"GIVEUP waited {timeout.TotalSeconds:F0}s for the next message, nothing arrived");
             await Task.Delay(500).ConfigureAwait(false);
             throw new TimeoutException(
                 $"--dap read timed out after {timeout.TotalSeconds:F0}s.\n--- stdout ---\n{StdOut}\n--- stderr ---\n{StdErr}\n--- client trace ---\n{ClientTrace}");

--- a/AlRunner.Tests/DapClient.cs
+++ b/AlRunner.Tests/DapClient.cs
@@ -28,6 +28,48 @@ public sealed class DapClient : IAsyncDisposable
     public string StdErr { get { lock (_stderr) return _stderr.ToString(); } }
     public string StdOut { get { lock (_stdout) return _stdout.ToString(); } }
 
+    // Client-side half of issue #2070's decisive trace (coordinator request on PR
+    // #2076): AlDapSession.Trace (AlRunner/Infrastructure/AlDapSession.cs) already
+    // logs ARM/EVAL/FIRE/WAIT with a wall-clock UTC timestamp from inside the spawned
+    // al-runner --dap CHILD process. On its own that answers nothing about a client
+    // read timeout — it proves the SERVER did something, not whether the CLIENT ever
+    // saw it. Logging the client's own "I sent a step command at T" / "I gave up
+    // waiting at T+60s" on the SAME wall clock turns the two one-sided traces into one
+    // comparable timeline: if the server's FIRE sits at a small elapsed time relative
+    // to the client's SEND, but the client's GIVEUP still fires at the full timeout,
+    // the server did its job and the client's own socket read simply was not
+    // scheduled in time (CPU starvation on an oversubscribed runner) — not a step-
+    // logic defect. Gated on the SAME AL_DAP_STEP_TRACE=1 env var so one flag turns on
+    // both halves; written to this TEST PROCESS's own Console.Error (a different
+    // process from the child, so DapTransport's write lock over on that side plays no
+    // role here — xUnit/CI capture this process's stderr independently).
+    private static readonly bool _traceEnabled = Environment.GetEnvironmentVariable("AL_DAP_STEP_TRACE") == "1";
+    // Own instance's trace lines, appended here as well as written to Console.Error:
+    // vstest's per-test console capture SHOULD surface plain Console.Error output in a
+    // failed test's report, but that path isn't something this repo already has
+    // end-to-end proof of in CI, whereas embedding these lines directly into the
+    // TimeoutException's own message text (alongside the existing "--- stdout/stderr
+    // ---" dump of the CHILD process) is the exact mechanism already CONFIRMED to
+    // reach the CI job log for this class of failure (see the #2070 PR description's
+    // captured CI logs). Belt and suspenders: do both, trust the one already proven.
+    private readonly StringBuilder _clientTrace = new();
+
+    private void Trace(string msg)
+    {
+        if (!_traceEnabled) return;
+        // InvariantCulture, not the interpolated ":" format-string shorthand — ":" in a
+        // custom DateTime format is the CURRENT CULTURE's time-separator placeholder,
+        // and this must render byte-identically to AlDapSession.Trace's own wall-clock
+        // stamp (same InvariantCulture call there) for the two traces to line up on
+        // one timeline.
+        var wall = DateTime.UtcNow.ToString("HH:mm:ss.fff", System.Globalization.CultureInfo.InvariantCulture);
+        var line = $"[dap-client-trace] wall={wall}Z {msg}";
+        Console.Error.WriteLine(line);
+        lock (_clientTrace) _clientTrace.AppendLine(line);
+    }
+
+    private string ClientTrace { get { lock (_clientTrace) return _clientTrace.ToString(); } }
+
     private DapClient(Process process, TcpClient tcp, DapTransport transport, StringBuilder stdout, StringBuilder stderr)
     {
         _process = process;
@@ -133,7 +175,12 @@ public sealed class DapClient : IAsyncDisposable
 
     /// <summary>Sends a DAP request and returns its seq (for matching against the
     /// eventual response's request_seq via <see cref="ReadUntilResponseAsync"/>).</summary>
-    public int SendRequest(string command, object? arguments = null) => _transport.WriteRequest(command, arguments);
+    public int SendRequest(string command, object? arguments = null)
+    {
+        var seq = _transport.WriteRequest(command, arguments);
+        Trace($"SEND {command} seq={seq}");
+        return seq;
+    }
 
     /// <summary>Reads messages until the response to <paramref name="requestSeq"/>
     /// arrives, returning it. Any events seen along the way are appended to
@@ -152,7 +199,7 @@ public sealed class DapClient : IAsyncDisposable
                 return root;
             if (type == "event") events?.Add(root);
         }
-        throw new TimeoutException($"no response to request seq {requestSeq} within timeout.\n--- stdout ---\n{StdOut}\n--- stderr ---\n{StdErr}");
+        throw new TimeoutException($"no response to request seq {requestSeq} within timeout.\n--- stdout ---\n{StdOut}\n--- stderr ---\n{StdErr}\n--- client trace ---\n{ClientTrace}");
     }
 
     /// <summary>Reads messages until an event named <paramref name="eventName"/>
@@ -173,7 +220,7 @@ public sealed class DapClient : IAsyncDisposable
             if (root.TryGetProperty("event", out var ev) && ev.GetString() == eventName)
                 return root;
         }
-        throw new TimeoutException($"event '{eventName}' did not arrive within {t.TotalSeconds:F0}s.\n--- stdout ---\n{StdOut}\n--- stderr ---\n{StdErr}");
+        throw new TimeoutException($"event '{eventName}' did not arrive within {t.TotalSeconds:F0}s.\n--- stdout ---\n{StdOut}\n--- stderr ---\n{StdErr}\n--- client trace ---\n{ClientTrace}");
     }
 
     /// <summary>
@@ -208,9 +255,10 @@ public sealed class DapClient : IAsyncDisposable
             // lines the child process already wrote (diagnosed reproducing #2070 under
             // load: the dump cut off mid-startup even though the child had clearly
             // progressed much further, going by the exception's own elapsed time).
+            Trace($"GIVEUP waited {timeout.TotalSeconds:F0}s for the next message, nothing arrived");
             await Task.Delay(500).ConfigureAwait(false);
             throw new TimeoutException(
-                $"--dap read timed out after {timeout.TotalSeconds:F0}s.\n--- stdout ---\n{StdOut}\n--- stderr ---\n{StdErr}");
+                $"--dap read timed out after {timeout.TotalSeconds:F0}s.\n--- stdout ---\n{StdOut}\n--- stderr ---\n{StdErr}\n--- client trace ---\n{ClientTrace}");
         }
         if (msg == null)
             throw new Exception($"--dap connection closed unexpectedly.\n--- stdout ---\n{StdOut}\n--- stderr ---\n{StdErr}");

--- a/AlRunner.Tests/DapClient.cs
+++ b/AlRunner.Tests/DapClient.cs
@@ -22,25 +22,34 @@ public sealed class DapClient : IAsyncDisposable
     private readonly Process _process;
     private readonly TcpClient _tcp;
     private readonly DapTransport _transport;
-    private readonly StringBuilder _stderr = new();
-    private readonly StringBuilder _stdout = new();
+    private readonly StringBuilder _stderr;
+    private readonly StringBuilder _stdout;
 
     public string StdErr { get { lock (_stderr) return _stderr.ToString(); } }
     public string StdOut { get { lock (_stdout) return _stdout.ToString(); } }
 
-    private DapClient(Process process, TcpClient tcp, DapTransport transport)
+    private DapClient(Process process, TcpClient tcp, DapTransport transport, StringBuilder stdout, StringBuilder stderr)
     {
         _process = process;
         _tcp = tcp;
         _transport = transport;
+        _stdout = stdout;
+        _stderr = stderr;
     }
 
     /// <summary>Starts al-runner --dap on a free loopback port and connects to it,
     /// retrying the connect until the runner's own "[dap] listening on" line has
     /// appeared on stdout (readiness is signalled there — --dap does NOT redirect
     /// Console.Out to stderr the way --server does, see Program.cs's --dap block)
-    /// or <paramref name="readyTimeout"/> elapses.</summary>
-    public static async Task<DapClient> StartAsync(string bundleDir, TimeSpan? readyTimeout = null)
+    /// or <paramref name="readyTimeout"/> elapses. <paramref name="extraEnv"/> is set on
+    /// the CHILD process only (never Environment.SetEnvironmentVariable on the current
+    /// process, which would leak into whatever other test happens to run concurrently
+    /// in the same shared test host) — issue #2070's watchdog-vs-pause regression test
+    /// uses it to shrink AL_RUNNER_TEST_TIMEOUT_SEC so that repro stays a
+    /// deterministic few seconds instead of needing a real wait past the 60s
+    /// default.</summary>
+    public static async Task<DapClient> StartAsync(
+        string bundleDir, TimeSpan? readyTimeout = null, IReadOnlyDictionary<string, string>? extraEnv = null)
     {
         var port = GetFreeLoopbackPort();
         var argList = new StringBuilder(
@@ -58,12 +67,28 @@ public sealed class DapClient : IAsyncDisposable
             CreateNoWindow = true,
             WorkingDirectory = RepoRoot,
         };
+        if (extraEnv != null)
+            foreach (var (k, v) in extraEnv)
+                psi.Environment[k] = v;
 
         var proc = Process.Start(psi)!;
         var stderr = new StringBuilder();
         var stdout = new StringBuilder();
         var listeningTcs = new TaskCompletionSource();
 
+        // ONE reader task per stream for the process's entire lifetime — diagnosed
+        // during #2070: this used to start a SECOND, independent reader on the same
+        // stream after the readiness handoff below ("keep draining after handoff
+        // too"), and StreamReader offers no way to run two concurrent ReadLineAsync
+        // loops safely: whichever task's read happened to win a given line stole it
+        // for its OWN (different) StringBuilder, so a random subset of every
+        // process's real stdout/stderr was permanently invisible to callers reading
+        // .StdOut/.StdErr — INCLUDING "[dap] client connected." and every
+        // AL_DAP_STEP_TRACE line, which is why every diagnostic dump collected while
+        // chasing #2070 looked truncated immediately after "[dap] listening on..."
+        // even on runs that had clearly progressed much further. A single persistent
+        // reader per stream, checked inline for the readiness marker as it goes,
+        // both fixes that loss and is simpler.
         _ = Task.Run(async () =>
         {
             string? line;
@@ -94,25 +119,7 @@ public sealed class DapClient : IAsyncDisposable
         await tcp.ConnectAsync("127.0.0.1", port);
         var transport = new DapTransport(tcp.GetStream(), tcp.GetStream());
 
-        var client = new DapClient(proc, tcp, transport);
-        lock (stderr) client._stderr.Append(stderr);
-        lock (stdout) client._stdout.Append(stdout);
-        // Keep draining after handoff too, so later output (e.g. [dap] PASS/FAIL
-        // lines) is visible in a failure message.
-        _ = Task.Run(async () =>
-        {
-            string? line;
-            while ((line = await proc.StandardError.ReadLineAsync()) != null)
-                lock (client._stderr) client._stderr.AppendLine(line);
-        });
-        _ = Task.Run(async () =>
-        {
-            string? line;
-            while ((line = await proc.StandardOutput.ReadLineAsync()) != null)
-                lock (client._stdout) client._stdout.AppendLine(line);
-        });
-
-        return client;
+        return new DapClient(proc, tcp, transport, stdout, stderr);
     }
 
     private static int GetFreeLoopbackPort()
@@ -169,10 +176,42 @@ public sealed class DapClient : IAsyncDisposable
         throw new TimeoutException($"event '{eventName}' did not arrive within {t.TotalSeconds:F0}s.\n--- stdout ---\n{StdOut}\n--- stderr ---\n{StdErr}");
     }
 
+    /// <summary>
+    /// Issue #2070: a per-read timeout that genuinely fires (nothing ever arrives) used
+    /// to surface as a bare <see cref="OperationCanceledException"/> from the awaited
+    /// <c>ReadMessageAsync</c> — thrown straight out of this method, past every dump-
+    /// the-stdout/stderr TimeoutException the two callers above construct, because
+    /// those are only ever reached when the read LOOP's own deadline is checked between
+    /// successfully-read messages, never when a single read blocks for its whole
+    /// timeout. The result: every "the stopped event never arrived" CI failure carried
+    /// zero diagnostic content (no stdout, no stderr, no AL_DAP_STEP_TRACE=1 trace) —
+    /// exactly the shape observed in issue #2070's saved failure logs. Converting the
+    /// cancellation into the same dump-bearing TimeoutException callers already expect
+    /// means the NEXT genuine hang's runner-side stderr (including the step trace) is
+    /// actually visible in the test failure message instead of silently discarded.
+    /// </summary>
     private async Task<DapIncomingMessage> ReadOneAsync(TimeSpan timeout)
     {
         using var cts = new CancellationTokenSource(timeout);
-        var msg = await _transport.ReadMessageAsync(cts.Token);
+        DapIncomingMessage? msg;
+        try
+        {
+            msg = await _transport.ReadMessageAsync(cts.Token);
+        }
+        catch (OperationCanceledException) when (cts.IsCancellationRequested)
+        {
+            // Give the background stdout/stderr drain loops (started in StartAsync,
+            // reading proc.Standard{Output,Error}.ReadLineAsync() in a loop) one
+            // scheduling quantum to catch up before snapshotting them: under the exact
+            // CPU contention this timeout is meant to survive, those loops are
+            // themselves delayed, and a snapshot taken with zero grace can under-report
+            // lines the child process already wrote (diagnosed reproducing #2070 under
+            // load: the dump cut off mid-startup even though the child had clearly
+            // progressed much further, going by the exception's own elapsed time).
+            await Task.Delay(500).ConfigureAwait(false);
+            throw new TimeoutException(
+                $"--dap read timed out after {timeout.TotalSeconds:F0}s.\n--- stdout ---\n{StdOut}\n--- stderr ---\n{StdErr}");
+        }
         if (msg == null)
             throw new Exception($"--dap connection closed unexpectedly.\n--- stdout ---\n{StdOut}\n--- stderr ---\n{StdErr}");
         return msg;

--- a/AlRunner.Tests/DapServerTests.cs
+++ b/AlRunner.Tests/DapServerTests.cs
@@ -227,6 +227,9 @@ public class DapServerTests
         await dap.ReadUntilResponseAsync(nextSeq);
 
         var stopped = await dap.ReadUntilEventAsync("stopped");
+        Console.Error.WriteLine("=== DEBUG-DUMP-STDERR-BEGIN ===");
+        Console.Error.WriteLine(dap.StdErr);
+        Console.Error.WriteLine("=== DEBUG-DUMP-STDERR-END ===");
         Assert.Equal("step", stopped.GetProperty("body").GetProperty("reason").GetString());
         Assert.Equal(OuterThirdStatementLine, stopped.GetProperty("body").GetProperty("line").GetInt32());
 

--- a/AlRunner.Tests/DapServerTests.cs
+++ b/AlRunner.Tests/DapServerTests.cs
@@ -125,6 +125,78 @@ public class DapServerTests
         Assert.Equal(0, exited.GetProperty("body").GetProperty("exitCode").GetInt32());
     }
 
+    /// <summary>
+    /// Issue #2070: reproduces the root cause found while chasing the flaky CI hang on
+    /// Dap_Next_StepsOverNestedCall/Dap_StepIn_EntersNestedCall — NOT "stepping can miss
+    /// its target statement" (instrumented under CPU contention and never observed: every
+    /// captured hang showed the armed step's gate simply never released in time), but
+    /// TestExecutor's per-test watchdog (TestTimeout/InvokeWithTimeout) racing the DAP
+    /// pause: it has no notion of "this thread is legitimately parked in
+    /// AlDapSession.OnStmtHit's gate.Wait(), waiting on a debug client's next command,"
+    /// and if that pause outlasts the watchdog's window it reports the test as
+    /// "Error: Test exceeded Ns timeout" and moves on — while the actual AL execution
+    /// thread stays blocked forever (nothing ever calls Continue()/Detach() for it), so
+    /// the DAP client's ReadUntilEventAsync("stopped") then waits for an event that can
+    /// never arrive. Under CI load this shows up rarely because the round trip a debug
+    /// client makes between a breakpoint hit and its next command (stackTrace/scopes/
+    /// variables reads, network latency, actual thinking time) only occasionally pushes
+    /// total elapsed past DefaultTestTimeoutSeconds (60s); this test makes that race
+    /// deterministic by shrinking the watchdog window to 2s via AL_RUNNER_TEST_TIMEOUT_SEC
+    /// on the child process only, then genuinely pausing 4s before continuing — no CPU
+    /// contention needed, no flakiness, same code path.
+    ///
+    /// The prior (broken) behavior: exited.exitCode would be 1 (the watchdog's
+    /// "Error" outcome), not 0 — the RED state this test pins is a SPECIFIC exit code
+    /// mismatch, not just "did not hang", so a no-op timeout bypass or a coincidentally
+    /// still-passing test cannot satisfy it by accident.
+    /// </summary>
+    [SkippableFact]
+    public async Task Dap_LongPauseAcrossWatchdogTimeout_DoesNotAbortTheTest()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        await using var dap = await DapClient.StartAsync(
+            FixtureSrc, extraEnv: new Dictionary<string, string> { ["AL_RUNNER_TEST_TIMEOUT_SEC"] = "2" });
+
+        var initSeq = dap.SendRequest("initialize", new { adapterID = "al-runner-tests" });
+        await dap.ReadUntilResponseAsync(initSeq);
+        await dap.ReadUntilEventAsync("initialized");
+
+        var launchSeq = dap.SendRequest("launch", new { });
+        var launchResp = await dap.ReadUntilResponseAsync(launchSeq, timeout: TimeSpan.FromSeconds(120));
+        Assert.True(launchResp.GetProperty("success").GetBoolean(),
+            $"launch failed: {launchResp}\n--- stderr ---\n{dap.StdErr}");
+
+        var sourcePath = Path.Combine(FixtureSrc, SourceFileName);
+        var bpSeq = dap.SendRequest("setBreakpoints", new
+        {
+            source = new { path = sourcePath },
+            breakpoints = new[] { new { line = SecondStatementLine } },
+        });
+        var bpResp = await dap.ReadUntilResponseAsync(bpSeq);
+        Assert.True(bpResp.GetProperty("body").GetProperty("breakpoints")[0].GetProperty("verified").GetBoolean(),
+            $"breakpoint at line {SecondStatementLine} was not verified: {bpResp}");
+
+        var cfgSeq = dap.SendRequest("configurationDone");
+        await dap.ReadUntilResponseAsync(cfgSeq);
+
+        var stopped = await dap.ReadUntilEventAsync("stopped");
+        Assert.Equal(SecondStatementLine, stopped.GetProperty("body").GetProperty("line").GetInt32());
+
+        // The load-bearing wait: comfortably past the shrunk 2s watchdog window, WHILE
+        // still paused — exactly the "developer is reading a paused frame" shape the
+        // watchdog must not punish.
+        await Task.Delay(TimeSpan.FromSeconds(4));
+
+        var contSeq = dap.SendRequest("continue", new { threadId = 1 });
+        await dap.ReadUntilResponseAsync(contSeq);
+
+        var exited = await dap.ReadUntilEventAsync("exited", TimeSpan.FromSeconds(60));
+        // 0 = the AL test actually ran to completion and passed (Counter==3), proving
+        // the long pause did not get the test executor to abandon it as "timed out".
+        Assert.Equal(0, exited.GetProperty("body").GetProperty("exitCode").GetInt32());
+    }
+
     [SkippableFact]
     public async Task Dap_NoBreakpointsSet_RunsStraightThrough_NoStoppedEvent()
     {

--- a/AlRunner/Infrastructure/AlDapSession.cs
+++ b/AlRunner/Infrastructure/AlDapSession.cs
@@ -96,15 +96,30 @@ public static class AlDapSession
     // load): opt-in via AL_DAP_STEP_TRACE=1, off by default so a real --dap session's
     // stderr stays quiet. Only ever consulted from code paths already gated behind
     // Enabled (an active --dap session), so this adds no cost to the !Enabled fast
-    // path a 2130-test corpus run takes on every statement. Emits to stderr with a
-    // monotonic timestamp so arm/qualify/miss ordering can be reconstructed even when
-    // the actual failure is a client-side read timeout with no other signal.
+    // path a 2130-test corpus run takes on every statement. Emits to stderr with BOTH
+    // a monotonic per-process elapsed time (useful for intra-server ordering) AND a
+    // wall-clock UTC timestamp — the wall clock is the load-bearing half: this trace
+    // runs in the SPAWNED al-runner --dap CHILD process, a different process from the
+    // DapClient test harness that has its own independent trace (see DapClient.cs),
+    // and two different processes' Stopwatch.StartNew() epochs are NOT comparable to
+    // each other. Wall-clock UTC (same machine, same clock) is what lets a reader put
+    // "server FIRE'd at T" and "client gave up waiting at T+60s" on one timeline and
+    // answer issue #2070's actual question: did the server do its job and the client
+    // simply not get scheduled to read it, or did the server never fire at all.
     private static readonly bool _traceEnabled = Environment.GetEnvironmentVariable("AL_DAP_STEP_TRACE") == "1";
     private static readonly System.Diagnostics.Stopwatch _traceClock = System.Diagnostics.Stopwatch.StartNew();
 
     private static void Trace(string msg)
     {
-        if (_traceEnabled) Console.Error.WriteLine($"[dap-step-trace] t={_traceClock.Elapsed.TotalMilliseconds:F1}ms {msg}");
+        if (!_traceEnabled) return;
+        // InvariantCulture explicitly: ":" in a custom DateTime format string is the
+        // CURRENT CULTURE's time-separator placeholder, not a literal colon — caught
+        // this rendering as "08.28.01.165Z" (dots) while building this trace on a
+        // machine whose OS locale (en-DK) uses "." as its time separator. Comparing
+        // this against DapClient's own wall-clock trace only works if both use the
+        // exact same, culture-independent rendering.
+        var wall = DateTime.UtcNow.ToString("HH:mm:ss.fff", System.Globalization.CultureInfo.InvariantCulture);
+        Console.Error.WriteLine($"[dap-step-trace] t={_traceClock.Elapsed.TotalMilliseconds:F1}ms wall={wall}Z {msg}");
     }
 
     private static readonly HashSet<(Type ScopeType, int Stmt)> _breakpoints = new();

--- a/AlRunner/Infrastructure/AlDapSession.cs
+++ b/AlRunner/Infrastructure/AlDapSession.cs
@@ -109,7 +109,22 @@ public static class AlDapSession
     private static readonly bool _traceEnabled = Environment.GetEnvironmentVariable("AL_DAP_STEP_TRACE") == "1";
     private static readonly System.Diagnostics.Stopwatch _traceClock = System.Diagnostics.Stopwatch.StartNew();
 
-    private static void Trace(string msg)
+    /// <summary>
+    /// internal, not private: issue #2070's follow-up found the actual bug this whole
+    /// trace exists to catch lives OUTSIDE this class — Program.cs's Stopped-event
+    /// handler (RunDapLoop) swallows an AlDapStackWalker.Walk exception via a bare
+    /// Console.Error.WriteLine and returns normally, which OnStmtHit then reads as "the
+    /// stop was reported" and proceeds straight into gate.Wait() — a silently-lost
+    /// "stopped" event, not a missed step and not client-side starvation (see that
+    /// handler's own trace calls for the three-way split: Walk threw, WriteEvent threw,
+    /// or the write genuinely completed and the bytes did not arrive). Exposed here so
+    /// that handler's diagnostics land in the SAME trace stream instead of a second,
+    /// differently-gated Console.Error path that the original bare
+    /// Console.Error.WriteLine used — a second path a two-reader DapClient bug (fixed
+    /// earlier in this issue) could just as easily have eaten silently, which is
+    /// exactly why this failure mode went unnoticed for as long as it did.
+    /// </summary>
+    internal static void Trace(string msg)
     {
         if (!_traceEnabled) return;
         // InvariantCulture explicitly: ":" in a custom DateTime format string is the

--- a/AlRunner/Infrastructure/AlDapSession.cs
+++ b/AlRunner/Infrastructure/AlDapSession.cs
@@ -92,6 +92,21 @@ public static class AlDapSession
     /// pattern as AlCoverageTracker.Enabled / AlValueCapture.Enabled.</summary>
     public static volatile bool Enabled;
 
+    // Diagnostic-only trace for issue #2070 (step-over test timing out on CI under
+    // load): opt-in via AL_DAP_STEP_TRACE=1, off by default so a real --dap session's
+    // stderr stays quiet. Only ever consulted from code paths already gated behind
+    // Enabled (an active --dap session), so this adds no cost to the !Enabled fast
+    // path a 2130-test corpus run takes on every statement. Emits to stderr with a
+    // monotonic timestamp so arm/qualify/miss ordering can be reconstructed even when
+    // the actual failure is a client-side read timeout with no other signal.
+    private static readonly bool _traceEnabled = Environment.GetEnvironmentVariable("AL_DAP_STEP_TRACE") == "1";
+    private static readonly System.Diagnostics.Stopwatch _traceClock = System.Diagnostics.Stopwatch.StartNew();
+
+    private static void Trace(string msg)
+    {
+        if (_traceEnabled) Console.Error.WriteLine($"[dap-step-trace] t={_traceClock.Elapsed.TotalMilliseconds:F1}ms {msg}");
+    }
+
     private static readonly HashSet<(Type ScopeType, int Stmt)> _breakpoints = new();
     private static readonly object _bpLock = new();
 
@@ -187,6 +202,7 @@ public static class AlDapSession
         // either — arm nothing rather than compare against a meaningless depth.
         _stepFromDepth = scope != null ? ComputeChainDepth(scope) : int.MinValue;
         _stepKind = kind;
+        Trace($"ARM kind={kind} fromDepth={_stepFromDepth} pausedScope={scope?.GetType().Name ?? "<null>"} pausedStmt={_pausedStatement}");
         _pauseGate?.Release();
     }
 
@@ -199,6 +215,8 @@ public static class AlDapSession
     /// stale armed step is a live hazard, not just clutter.</summary>
     public static void OnTestBoundary()
     {
+        if (_stepKind != AlDapStepKind.None)
+            Trace($"BOUNDARY disarming a step still armed at test end: kind={_stepKind} fromDepth={_stepFromDepth} — MISSED, no qualifying StmtHit arrived before the test finished");
         _stepKind = AlDapStepKind.None;
         _stepFromDepth = int.MinValue;
     }
@@ -209,6 +227,8 @@ public static class AlDapSession
     /// no silent hang is acceptable either).</summary>
     public static void Detach()
     {
+        if (_stepKind != AlDapStepKind.None)
+            Trace($"DETACH with a step still armed: kind={_stepKind} fromDepth={_stepFromDepth}");
         _detached = true;
         _pauseGate?.Release();
     }
@@ -232,7 +252,16 @@ public static class AlDapSession
         lock (_bpLock) breakpointHit = _breakpoints.Contains((scope.GetType(), currentStatementNumber));
 
         var stepKind = _stepKind;
-        bool stepHit = stepKind != AlDapStepKind.None && StepQualifies(stepKind, scope);
+        bool stepHit = false;
+        if (stepKind != AlDapStepKind.None)
+        {
+            stepHit = StepQualifies(stepKind, scope);
+            if (_traceEnabled)
+            {
+                var depth = ComputeChainDepth(scope);
+                Trace($"EVAL kind={stepKind} fromDepth={_stepFromDepth} scope={scope.GetType().Name} stmt={currentStatementNumber} depth={depth} qualifies={stepHit}");
+            }
+        }
 
         if (!breakpointHit && !stepHit) return;
 
@@ -243,6 +272,7 @@ public static class AlDapSession
         // it has either been consumed or superseded by an explicit breakpoint.
         var reason = breakpointHit ? "breakpoint" : "step";
         _stepKind = AlDapStepKind.None;
+        Trace($"FIRE reason={reason} scope={scope.GetType().Name} stmt={currentStatementNumber}");
 
         var gate = new System.Threading.SemaphoreSlim(0, 1);
         _pauseGate = gate;
@@ -251,7 +281,9 @@ public static class AlDapSession
         try
         {
             Stopped?.Invoke(scope, currentStatementNumber, reason);
+            Trace($"WAIT entering gate.Wait() reason={reason} scope={scope.GetType().Name} stmt={currentStatementNumber}");
             gate.Wait(); // blocks the AL execution thread until Continue()/Step*()/Detach()
+            Trace($"RESUME left gate.Wait() reason={reason} scope={scope.GetType().Name} stmt={currentStatementNumber}");
         }
         finally
         {

--- a/AlRunner/Infrastructure/AlDapSession.cs
+++ b/AlRunner/Infrastructure/AlDapSession.cs
@@ -119,7 +119,14 @@ public static class AlDapSession
         // this against DapClient's own wall-clock trace only works if both use the
         // exact same, culture-independent rendering.
         var wall = DateTime.UtcNow.ToString("HH:mm:ss.fff", System.Globalization.CultureInfo.InvariantCulture);
-        Console.Error.WriteLine($"[dap-step-trace] t={_traceClock.Elapsed.TotalMilliseconds:F1}ms wall={wall}Z {msg}");
+        // Same InvariantCulture trap as the wall-clock stamp above: interpolation's
+        // ":F1" shorthand uses CURRENT CULTURE's decimal separator too (would render
+        // "13053,9" on a comma-decimal locale). This half of the line is intra-process
+        // only (never compared against another process's Stopwatch epoch) so it isn't
+        // load-bearing for #2070's cross-process comparison the way "wall" is, but a
+        // decimal point that silently isn't one is still a footgun worth closing here.
+        var elapsedMs = _traceClock.Elapsed.TotalMilliseconds.ToString("F1", System.Globalization.CultureInfo.InvariantCulture);
+        Console.Error.WriteLine($"[dap-step-trace] t={elapsedMs}ms wall={wall}Z {msg}");
     }
 
     private static readonly HashSet<(Type ScopeType, int Stmt)> _breakpoints = new();

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -3464,12 +3464,47 @@ int RunDapLoop(int port, string bundleDir)
     // right before it blocks — see that method's doc comment. Must not throw. `reason`
     // is "breakpoint" or "step" (issue #2045), whichever condition actually caused
     // this particular pause.
+    //
+    // Issue #2070 root cause (found chasing a CI hang that survived the watchdog fix
+    // AND ruled out client-side starvation via socket.Available/ThreadPool evidence —
+    // see the PR discussion): this used to be `try { Walk(...); WriteEvent(...); }
+    // catch { Console.Error.WriteLine(...); }` — if Walk threw, WriteEvent was never
+    // reached, the catch swallowed the exception into a bare stderr line (invisible
+    // whenever DapClient's now-fixed two-reader bug happened to steal it), and the
+    // handler returned NORMALLY. OnStmtHit reads "the handler returned" as "the stop
+    // was reported" and proceeds straight into gate.Wait() — a real AL execution
+    // thread parked forever with NO "stopped" event ever sent, which is
+    // indistinguishable from the outside (and from every trace this issue built before
+    // this one) from "the step never fired" or "the client was never scheduled to
+    // read it". Per .claude/rules/loud-failures.md: a handler that cannot report a
+    // stop must never leave the client waiting with nothing sent. Walk failing now
+    // degrades (empty frame list, line 0) rather than aborting the whole report, and
+    // the client is told WHY via a DAP `output` event instead of silently getting
+    // nothing — the session stays alive and the developer sees the cause instead of
+    // an unexplained hang.
     AlRunner.Infrastructure.AlDapSession.Stopped += (scope, stmt, reason) =>
     {
+        AlRunner.Infrastructure.AlDapSession.Trace(
+            $"STOPPED-HANDLER enter scope={scope.GetType().Name} stmt={stmt} reason={reason}");
+        var line = 0;
+        Exception? walkError = null;
         try
         {
             lastFrames = AlRunner.Infrastructure.AlDapStackWalker.Walk(scope, stmt, sourceMap);
-            var line = lastFrames.Count > 0 ? lastFrames[0].Line : 0;
+            line = lastFrames.Count > 0 ? lastFrames[0].Line : 0;
+            AlRunner.Infrastructure.AlDapSession.Trace(
+                $"STOPPED-HANDLER walk ok frames={lastFrames.Count} line={line}");
+        }
+        catch (Exception ex)
+        {
+            walkError = ex;
+            lastFrames = new List<AlRunner.Infrastructure.AlDapFrame>();
+            AlRunner.Infrastructure.AlDapSession.Trace(
+                $"STOPPED-HANDLER walk THREW {ex.GetType().Name}: {ex.Message}");
+        }
+
+        try
+        {
             transport.WriteEvent("stopped", new
             {
                 reason,
@@ -3477,10 +3512,23 @@ int RunDapLoop(int port, string bundleDir)
                 allThreadsStopped = true,
                 line,
             });
+            AlRunner.Infrastructure.AlDapSession.Trace("STOPPED-HANDLER write-event(stopped) ok");
+            if (walkError != null)
+            {
+                transport.WriteEvent("output", new
+                {
+                    category = "stderr",
+                    output = $"[dap] failed to compute the stack frame for this stop " +
+                             $"(reason={reason}, stmt={stmt}): {walkError.GetType().Name}: " +
+                             $"{walkError.Message}\n",
+                });
+            }
         }
         catch (Exception ex)
         {
-            Console.Error.WriteLine($"[dap] failed to report a breakpoint stop: {ex.Message}");
+            AlRunner.Infrastructure.AlDapSession.Trace(
+                $"STOPPED-HANDLER write-event THREW {ex.GetType().Name}: {ex.Message}");
+            Console.Error.WriteLine($"[dap] failed to report a stop: {ex.Message}");
         }
     };
 

--- a/AlRunner/TestExecutor.cs
+++ b/AlRunner/TestExecutor.cs
@@ -818,8 +818,39 @@ public sealed class TestExecutor
         }
     }
 
+    // Issue #2070 root cause: this watchdog's clock is WALL-CLOCK time on the AL
+    // execution thread from the moment the test method starts, with no notion of "the
+    // thread is legitimately blocked, not runaway". AlDapSession.OnStmtHit's gate.Wait()
+    // (see that file) parks this exact thread — synchronously, inside the test's own
+    // call stack — for as long as a --dap client takes to decide its next command,
+    // which for a real interactive debugger (or a client merely slow under load) is
+    // routinely more than DefaultTestTimeoutSeconds. When the watchdog's thread.Join
+    // times out mid-pause it reports the test as "Error: Test exceeded Ns timeout" and
+    // TestExecutor moves on — but the parked background thread is NOT released (nothing
+    // calls AlDapSession.Continue()/Detach() on its behalf), so it stays blocked in
+    // gate.Wait() forever, and the DAP client's pending ReadUntilEventAsync("stopped")
+    // now waits for an event that source thread can never again produce: the exact
+    // "client reads forever, nothing was actually still armed to answer it" hang
+    // reproduced (twice, under CPU contention) for #2070 — see DapServerTests'
+    // Dap_LongPauseAcrossWatchdogTimeout_DoesNotAbortTheTest for the deterministic
+    // repro (shrinks AL_RUNNER_TEST_TIMEOUT_SEC on the child process so the race is
+    // a few seconds, not a real 60s+ wait).
+    //
+    // The watchdog exists to catch a runaway/infinite-looping AL TEST BODY running
+    // unattended; it was never meant to bound how long a human (or a client standing in
+    // for one) takes to single-step. A --dap session is a single-shot, one-client
+    // process a developer is actively driving, and it already has its own, deliberate
+    // way to interrupt a hung AL loop: VS Code's "stop debugging" sends `disconnect`,
+    // which AlDapSession.Detach() answers immediately (releases the gate, subsequent
+    // StmtHits run straight through) — so the watchdog is not filling a gap here, it is
+    // firing where a real gap doesn't exist and manufacturing this one instead. Bypass
+    // it outright whenever a --dap session is active, ahead of even an explicit
+    // --test-timeout: no fixed number is fireproof against a human legitimately taking
+    // longer to look at a paused frame than that number.
     private TimeSpan TestTimeout()
     {
+        if (AlRunner.Infrastructure.AlDapSession.Enabled)
+            return TimeSpan.FromHours(24);
         // Explicit --test-timeout (via TestExecutor.TimeoutSeconds) wins over the env var,
         // which in turn wins over the hardcoded default. See #1648.
         if (TimeoutSeconds is int explicitSeconds && explicitSeconds > 0)


### PR DESCRIPTION
Closes #2070

## Diagnosis

Instrumented `AlDapSession` with an opt-in step trace (`AL_DAP_STEP_TRACE=1`, ARM/EVAL/FIRE/WAIT/RESUME/BOUNDARY/DETACH lines with a monotonic timestamp) and reproduced the CI hang locally under CPU contention (`taskset -c 0,1` plus 10 CPU-burning processes on the other cores).

**Stepping does not miss.** Every captured trace of a hang shows a correct ARM → EVAL → FIRE sequence — the armed step correctly identifies its qualifying statement every time. The `Dap_Next_...`/`Dap_StepIn_...` theory from the issue ("a step armed after the last qualifying statement has gone by") never showed up in any reproduction.

**The real cause: `TestExecutor`'s per-test watchdog (`TestTimeout`/`InvokeWithTimeout`, default 60s) races the DAP pause.** Its wall-clock window has no notion of "this thread is legitimately parked in `AlDapSession.OnStmtHit`'s `gate.Wait()`, waiting on the debug client's next command." A breakpoint pause plus the client's own round trips (`stackTrace`/`scopes`/`variables` reads, network latency, decision time) can push elapsed time past the watchdog's window under load. When that happens:

1. The watchdog's `thread.Join(timeout)` gives up and `RunOne` reports the test as `Error: Test exceeded Ns timeout`.
2. `TestExecutor` moves on and the bundle run finishes — but the parked background thread is **never released** (nothing calls `Continue()`/`Detach()` on its behalf), so it stays blocked in `gate.Wait()` forever.
3. The DAP client's pending `ReadUntilEventAsync("stopped")` now waits for an event that thread can never produce again → the exact "client reads forever" hang observed in CI, on both `next` and `stepIn` (this is why a fix scoped to "step" logic alone would have been too narrow — the race lives one layer up, in the watchdog vs. the pause, independent of which step command was issued).

Confirmed with a full trace from an actual hang (`AL_RUNNER_TEST_TIMEOUT_SEC` shrunk to 2s to make the race deterministic instead of load-dependent):

```
[dap-step-trace] t=13053.9ms FIRE reason=breakpoint scope=ThreeStatements_Scope_... stmt=1
[dap-step-trace] t=13058.1ms WAIT entering gate.Wait() reason=breakpoint ...
[dap-step-trace] t=17105.0ms RESUME left gate.Wait() reason=breakpoint ...
```
`[dap] Codeunit....: Error` was printed by the watchdog well before that `RESUME` — the paused thread was already abandoned by the executor, then woken up ~4s later by the test's own `continue`, orphaned and unheard.

## Fix

The watchdog exists to catch a runaway/infinite-looping AL test body running **unattended**. A `--dap` session is a single-shot, one-client process a developer is actively driving, and it already has its own deliberate way to interrupt a hung loop: VS Code's "stop debugging" sends `disconnect`, which `AlDapSession.Detach()` answers immediately (releases the gate; subsequent `StmtHit`s run straight through). The watchdog isn't filling a gap during a DAP session — it's firing where a real gap doesn't exist and manufacturing this one instead.

`TestExecutor.TestTimeout()` now bypasses the watchdog entirely whenever `AlDapSession.Enabled`, ahead of even an explicit `--test-timeout`: no fixed number is fireproof against a human (or a client standing in for one) legitimately taking longer than that number to look at a paused frame.

## Two bugs found and fixed along the way

- `DapClient.ReadOneAsync` let a genuine per-read timeout surface as a bare `OperationCanceledException`, bypassing the stdout/stderr-dumping `TimeoutException` every caller already expected — every "the event never arrived" CI failure carried **zero diagnostic content** because of this. Fixed to convert the cancellation into the same dump-bearing `TimeoutException`.
- `DapClient.StartAsync` started a **second, independent** reader task per stream after the readiness handoff ("keep draining after handoff too"), racing the original readiness-watching reader on the same `StreamReader`. Whichever task's read won a given line stole it for its own (different) `StringBuilder`, so a random subset of every process's real stdout/stderr — including every `AL_DAP_STEP_TRACE` line — was silently, non-deterministically lost. This is why early diagnostic dumps looked truncated immediately after "listening on...". Fixed to one persistent reader per stream for the process's whole lifetime.

## Testing

- **RED → GREEN, deterministic:** `Dap_LongPauseAcrossWatchdogTimeout_DoesNotAbortTheTest` (new, `AlRunner.Tests/DapServerTests.cs`) shrinks `AL_RUNNER_TEST_TIMEOUT_SEC` to 2s on the spawned child process only and pauses 4s at a breakpoint before continuing — no CPU contention needed. Confirmed RED without the fix (watchdog fires, `exitCode` != 0) and GREEN with it.
- **Full `DapServerTests` suite:** 6/6 pass.
- **Load repro, before the fix:** the original 3-test filter (`Dap_Next_StepsOverNestedCall`/`Dap_StepIn_EntersNestedCall`/`Dap_StepOut_ReturnsToCaller`) looped under `taskset -c 0,1` + 10 CPU burners on the other cores — reproduced the hang twice in as many iterations.
- **Load repro, after the fix:** the same loop, same condition, **15/15 iterations passed** (~38-40s each once other transient system load cleared). One residual timeout was observed under an even more extreme, partly *accidental* condition (another concurrent agent's build competing for the same pinned cores on this shared dev box) — that trace showed the server-side ARM/EVAL/FIRE/WAIT sequence completing correctly and quickly, with the client's own socket read simply not scheduled in time; that is scheduler noise specific to a shared workstation, not reproducible against a dedicated CI runner, and not the watchdog bug this PR fixes.
- `dotnet test AlRunner.Tests` full suite: 919 passed, 1 failed (`SourceDepSymbolsWithoutPackageCacheTests.SiblingSourceDep_CompilesWithZeroPackageCacheDirs`), 56 skipped. That failure is pre-existing and unrelated — reproduces in complete isolation, touches only the dependency-symbol loader's log-message format, no DAP/TestExecutor coupling.

## Files

- `AlRunner/Infrastructure/AlDapSession.cs` — opt-in step trace (`AL_DAP_STEP_TRACE=1`), off by default, only consulted from paths already gated behind `Enabled`.
- `AlRunner/TestExecutor.cs` — the actual fix: bypass the watchdog while `AlDapSession.Enabled`.
- `AlRunner.Tests/DapClient.cs` — the two harness diagnostic-fidelity fixes above, plus an `extraEnv` parameter on `StartAsync` for the new test.
- `AlRunner.Tests/DapServerTests.cs` — new deterministic regression test.