### PR TITLE
fix(testpage): build a linkless subpage part without demanding the host's record

### DIFF
--- a/AlRunner/Patches/MockTestPage.cs
+++ b/AlRunner/Patches/MockTestPage.cs
@@ -212,10 +212,16 @@ internal class LiveNavTestPage : MockITestPage
                 "testpage-part — the part's own page could not be driven live "
                 + "(no source table, or no runtime record type for it). See docs/scope.md");
 
+        // The parent record is only needed to evaluate SubPageLink pairs (issue #2053). A
+        // part with no links never reads it — and a FIELD link can only be declared against
+        // a parent SourceTable field, so a SourceTable-less host (the Worksheet-dialog shape,
+        // legal AL) always lands in the linkless case. Demanding the record up front turned
+        // every part access on such a host into a refusal the operation never required.
+        var links = SubPageLinks(definition, partPageId);
         var part = new LiveNavTestPart(
             built.Record, RecordPatches.GetPageControlFieldMap(partPageId),
             RecordPatches.GetInsertAllowedForPage(partPageId), built.Page, _owner!, partPageId,
-            parentRecord: RequireRecord($"subpage part {controlId}"), links: SubPageLinks(definition, partPageId));
+            parentRecord: links.Length == 0 ? null : RequireRecord($"subpage part {controlId}"), links: links);
         _parts[controlId] = part;
         return part;
     }
@@ -1783,12 +1789,15 @@ internal sealed class MockITestPart : MockITestPage, ITestPart
 /// </summary>
 internal sealed class LiveNavTestPart : LiveNavTestPage, ITestPart
 {
-    private readonly NavRecord _parentRecord;
+    // Null only when _links is empty (issue #2053: a linkless part on a SourceTable-less
+    // host has no parent record and needs none) — every read below sits inside a _links
+    // loop, so a null parent is never dereferenced.
+    private readonly NavRecord? _parentRecord;
     private readonly (int PartFieldNo, int ParentFieldNo)[] _links;
 
     public LiveNavTestPart(NavRecord record, IReadOnlyDictionary<int, int> controlIdToFieldNo, bool creatable,
         RunnerPageInstance? page, object owner, int pageId,
-        NavRecord parentRecord, (int PartFieldNo, int ParentFieldNo)[] links)
+        NavRecord? parentRecord, (int PartFieldNo, int ParentFieldNo)[] links)
         : base(record, controlIdToFieldNo, creatable, page, owner, pageId)
     {
         _parentRecord = parentRecord;
@@ -1807,7 +1816,7 @@ internal sealed class LiveNavTestPart : LiveNavTestPage, ITestPart
         var record = RequireRecord("subpage link");
         foreach (var (partFieldNo, parentFieldNo) in _links)
         {
-            var parentValue = _parentRecord.GetFieldValue(parentFieldNo);
+            var parentValue = _parentRecord!.GetFieldValue(parentFieldNo);
             record.ALSetRange(partFieldNo, parentValue);
         }
     }
@@ -1834,6 +1843,6 @@ internal sealed class LiveNavTestPart : LiveNavTestPage, ITestPart
         base.InsertEmptyRow(beforeCurrent);
         var record = RequireRecord("subpage link");
         foreach (var (partFieldNo, parentFieldNo) in _links)
-            record.SetFieldValue(partFieldNo, _parentRecord.GetFieldValue(parentFieldNo));
+            record.SetFieldValue(partFieldNo, _parentRecord!.GetFieldValue(parentFieldNo));
     }
 }

--- a/tests/expectations/count-baseline/test-count-baseline.json
+++ b/tests/expectations/count-baseline/test-count-baseline.json
@@ -2,7 +2,7 @@
   "_comment": "Consumed by --count-baseline (AlRunner/Infrastructure/CountBaseline.cs), a DIFFERENT schema from the oos-/known-gaps-/divergence-/disabled- files in this directory: those declare the expected CLASSIFICATION of one named test, this declares the expected EXACT COUNT of a whole suite -- an exact match, not a floor: a mismatch in EITHER direction (drop OR growth) fails the run (exit 4). See #1880 and PR #1882's review for why growth is also a hard failure, not just a notice. Suite keys are the basename of the bundle directory CI passes on the command line (tests/al-language/tests/al-language -> 'al-language', tests/runner-extras -> 'runner-extras'), matching the '--out <name>-results.json' convention CI already uses. Values below are read off actual Test Matrix CI runs (see PR discussion for run URLs), not guessed: al-language's 2073->2076 bump reflects 3 corpus tests merged upstream between when the local baseline was drafted and when CI first ran against it. runner-extras' appGroups 23->21 byBcVersion override on 27.0/27.3/27.5 is the SAME preprocessor-gated-surface split that already explains its tests count divergence: fewer AL surfaces compile pre-28.0, which drops whole app groups, not just individual tests within a group. ANY PR that changes a suite's test or app-group count -- growth included -- MUST bump the matching number here in the SAME PR, or that PR's CI goes red with a [count-baseline] DROP or GROWTH diagnostic naming the exact expected/actual numbers to use.",
   "suites": {
     "al-language": {
-      "tests": { "default": 2135 },
+      "tests": { "default": 2138 },
       "appGroups": { "default": 1 }
     },
     "runner-extras": {


### PR DESCRIPTION
Closes #2053

`LiveNavTestPage.GetPart` built every part with `parentRecord: RequireRecord(...)`, refusing before it knew whether the part needs a parent record at all. `LiveNavTestPart` only reads the parent record while evaluating SubPageLink pairs, and a FIELD link can only be declared against a parent SourceTable field — so a part with no links (the ordinary Worksheet-dialog shape: header fields bound to page globals, rows in a ListPart over its own table) never needs one.

The fix defers the `RequireRecord` refusal to the linked case: `GetPart` computes the links first and only demands the host's record when there is a link to evaluate. `LiveNavTestPart._parentRecord` becomes nullable with the invariant documented — null only when the link list is empty, and every read sits inside a `_links` loop.

**Spec:** StefanMaron/BusinessCentral.AL.Language.Tests#66 (three arms: part read on the no-SourceTable host, header OnValidate pushing into the part page, identical part read on a bound host as control).

- RED on main: 1F/2P — the no-SourceTable part read fails with the exact `subpage part … testpage-modal-no-source-table` signature from #2053; both control arms pass.
- GREEN with this fix: 3/3.
- Full pinned corpus + runner-extras: exit 0 under `--strict` with `--count-baseline` — no regressions.

After #66 merges, the submodule pin bump (plus the count-baseline bump for the 3 new tests) will be pushed onto this branch so CI machine-checks the RED→GREEN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)