### PR TITLE
fix(testpage): GoToRecord on a precompiled page derives the key from the record's metadata

### DIFF
--- a/AlRunner/Patches/CodeunitPatches.cs
+++ b/AlRunner/Patches/CodeunitPatches.cs
@@ -422,6 +422,20 @@ public static partial class BcRuntime
         var pageId = GetPageIdFromTestPage(self);
         var tableId = RecordPatches.GetSourceTableIdForPage(pageId);
         var pkFields = RecordPatches.GetPrimaryKeyFieldIdsForTable(tableId);
+        if (pkFields.Length == 0)
+        {
+            // A page that ships PRECOMPILED (and its table) never went through the AL
+            // parser, so both lookups above answer empty — and returning false here left
+            // GoToRecord a silent no-op: the cursor never moved and every later Rec read
+            // on the page saw an unpositioned record (issue #2057). BC's own ALGoToRecord
+            // derives the key from the passed RECORD's compiled metadata
+            // (NCLMetadata.GetMetaTableById(record.TableID).PrimaryKey), not from parsed
+            // page source — mirror that.
+            var metaTable = Microsoft.Dynamics.Nav.Runtime.NavGlobal.NCLMetadata
+                .GetMetaTableById(record.TableID, requireCompiled: false);
+            pkFields = metaTable?.PrimaryKey?.KeyFieldsList?
+                .Select(f => f.FieldNo).ToArray() ?? Array.Empty<int>();
+        }
         if (pkFields.Length == 0) return false;
 
         var testPageField = FindInstanceField(self.GetType(), "testPage");


### PR DESCRIPTION
Closes #2057

**Root cause is upstream of both paths named in the issue thread.** `TryRaiseExtensionOnlyAction` never runs for this shape — the precompiled card gets a live `RunnerPageInstance` (the `Page{id}` type exists in the precompiled Base App assembly) and the pageextension's `ParentObject.SourceTable` correctly shares the TestPage's record. The actual break: **`GoToRecord` was a silent no-op on any precompiled page.** The Cecil replacement for `NavTestPageBase.ALGoToRecord` (`CodeunitPatches.cs`) resolved the page's SourceTable and primary key through the runner's AL-source parser; a precompiled page and its table never went through the parser, so both lookups answered empty and the method returned `false` without moving the cursor. Every later `Rec` read then saw an unpositioned record — default field values and a null `SystemId` — while `Rec.Count()` was right, because `OpenEdit` had applied filters but nothing had positioned the row.

**Fix:** fall back to the passed record's compiled metadata (`NCLMetadata.GetMetaTableById(record.TableID).PrimaryKey`) when the parser cannot answer — which is exactly how BC's own `ALGoToRecord` derives the key (it never consults page source for this).

**Behavior change worth noting:** `GoToRecord` against a page with no SourceTable moves from silently returning `false` to the loud `RequireRecord` refusal, since the fallback now resolves a key and proceeds to the row search. Real BC throws there too (`NavTestSourceTableMismatchException`), so louder is the more faithful direction; the strict full-corpus run below shows nothing depended on the silent `false`.

**Spec:** StefanMaron/BusinessCentral.AL.Language.Tests#67 (`GoToRecord` returns true + a pageextension action sees the positioned row including `SystemId` + two-row movement).

- RED on main: 0/2 — both tests fail directly at `Assert.IsTrue(GoToRecord(...))`.
- GREEN with this fix: 2/2.
- Full pinned corpus + runner-extras: exit 0 under `--strict` with `--count-baseline` — no regressions.

After #67 merges, the submodule pin bump (plus count-baseline bump for the 2 new tests) will be pushed onto this branch so CI machine-checks the RED→GREEN. Note for sequencing with #2078: each branch will pin the corpus commit whose spec it passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)