### PR TITLE
chore: bump corpus pin to ab43ec0b (#67 GoToRecord-precompiled spec)

### DIFF
--- a/tests/expectations/count-baseline/test-count-baseline.json
+++ b/tests/expectations/count-baseline/test-count-baseline.json
@@ -2,7 +2,7 @@
   "_comment": "Consumed by --count-baseline (AlRunner/Infrastructure/CountBaseline.cs), a DIFFERENT schema from the oos-/known-gaps-/divergence-/disabled- files in this directory: those declare the expected CLASSIFICATION of one named test, this declares the expected EXACT COUNT of a whole suite -- an exact match, not a floor: a mismatch in EITHER direction (drop OR growth) fails the run (exit 4). See #1880 and PR #1882's review for why growth is also a hard failure, not just a notice. Suite keys are the basename of the bundle directory CI passes on the command line (tests/al-language/tests/al-language -> 'al-language', tests/runner-extras -> 'runner-extras'), matching the '--out <name>-results.json' convention CI already uses. Values below are read off actual Test Matrix CI runs (see PR discussion for run URLs), not guessed: al-language's 2073->2076 bump reflects 3 corpus tests merged upstream between when the local baseline was drafted and when CI first ran against it. runner-extras' appGroups 23->21 byBcVersion override on 27.0/27.3/27.5 is the SAME preprocessor-gated-surface split that already explains its tests count divergence: fewer AL surfaces compile pre-28.0, which drops whole app groups, not just individual tests within a group. ANY PR that changes a suite's test or app-group count -- growth included -- MUST bump the matching number here in the SAME PR, or that PR's CI goes red with a [count-baseline] DROP or GROWTH diagnostic naming the exact expected/actual numbers to use.",
   "suites": {
     "al-language": {
-      "tests": { "default": 2138 },
+      "tests": { "default": 2140 },
       "appGroups": { "default": 1 }
     },
     "runner-extras": {


### PR DESCRIPTION
Corpus pin `8337b918` → `ab43ec0b`, picking up exactly one commit: the #2057 spec (StefanMaron/BusinessCentral.AL.Language.Tests#67, TestPage.GoToRecord on a precompiled page — merged after #2079 landed, so main currently carries that fix without its regression guard). Count-baseline 2138 → 2140 for the two new tests.

Full pinned corpus on current main at the new pin: **2140/2140, exit 0 under `--strict`**.

Pin diff: `git -C tests/al-language log --oneline 8337b918..ab43ec0b` → `ab43ec0 test(handlers): TestPage.GoToRecord positions the cursor on a precompiled page (#67)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)