### PR TITLE
chore(corpus): bump al-language pin to ab43ec0 (#66/#67), count-baseline to 2140

### DIFF
--- a/tests/expectations/count-baseline/test-count-baseline.json
+++ b/tests/expectations/count-baseline/test-count-baseline.json
@@ -2,7 +2,7 @@
   "_comment": "Consumed by --count-baseline (AlRunner/Infrastructure/CountBaseline.cs), a DIFFERENT schema from the oos-/known-gaps-/divergence-/disabled- files in this directory: those declare the expected CLASSIFICATION of one named test, this declares the expected EXACT COUNT of a whole suite -- an exact match, not a floor: a mismatch in EITHER direction (drop OR growth) fails the run (exit 4). See #1880 and PR #1882's review for why growth is also a hard failure, not just a notice. Suite keys are the basename of the bundle directory CI passes on the command line (tests/al-language/tests/al-language -> 'al-language', tests/runner-extras -> 'runner-extras'), matching the '--out <name>-results.json' convention CI already uses. Values below are read off actual Test Matrix CI runs (see PR discussion for run URLs), not guessed: al-language's 2073->2076 bump reflects 3 corpus tests merged upstream between when the local baseline was drafted and when CI first ran against it. runner-extras' appGroups 23->21 byBcVersion override on 27.0/27.3/27.5 is the SAME preprocessor-gated-surface split that already explains its tests count divergence: fewer AL surfaces compile pre-28.0, which drops whole app groups, not just individual tests within a group. ANY PR that changes a suite's test or app-group count -- growth included -- MUST bump the matching number here in the SAME PR, or that PR's CI goes red with a [count-baseline] DROP or GROWTH diagnostic naming the exact expected/actual numbers to use.",
   "suites": {
     "al-language": {
-      "tests": { "default": 2138 },
+      "tests": { "default": 2140 },
       "appGroups": { "default": 1 }
     },
     "runner-extras": {


### PR DESCRIPTION
Bumps `tests/al-language` from `8337b918` to `ab43ec0bc7` (corpus `master`) and `tests/expectations/count-baseline/test-count-baseline.json`'s `al-language.tests.default` from 2138 to 2140, in the same commit.

## Why these two ride together

The pin bump is the direct follow-up to #2078 (issue #2053) and #2079 (issue #2057), which merged into `main` ahead of their upstream proving tests. Corpus PRs [`StefanMaron/BusinessCentral.AL.Language.Tests#66`](https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/66) and [`#67`](https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/67) are those proving tests, now merged upstream. `main`'s pin (`8337b918`) already sat on #66's merge commit; this bump pulls in #67's two files only:

```
$ git -C tests/al-language diff 8337b918..ab43ec0bc7
 tests/al-language/handlers/TestPageGoToRecordPrecompiled_Ext.al   | 42 ++++++++
 tests/al-language/handlers/TestPageGoToRecordPrecompiled_Tests.al | 100 +++++++++++++
```

Nothing else — confirmed by inspecting the diff before committing.

The count-baseline bump is not a separate concern: `--count-baseline` hard-fails on growth as well as shrinkage (exit 4), so pulling in 2 new tests without moving the baseline number in the same commit would leave this PR permanently red on its own CI, for a reason unrelated to any actual regression.

## Reading the number off the tool, not computing it

Ran the corpus with the *old* baseline (2138) still in place after bumping only the pin:

```
[count-baseline] GROWTH: suite 'al-language' tests count: expected 2138, actual 2140 (BC 28.1) — grew past the baseline; --count-baseline requires an exact match. Bump tests/expectations/count-baseline/test-count-baseline.json in this PR.
```

2140 matches the prediction from the RED→GREEN verification that led to merging #2078/#2079 in this order, but it was read off this diagnostic, not entered from that earlier measurement.

Then bumped the baseline to 2140 and reran twice, per this repo's cache-sensitivity history:

- **Warm** (existing `--cache` dir, reused): `AL emit: 0.0s`, `C# compile: 0.0s` (cache HIT) — 2140/2140 pass, exit 0, no count-baseline diagnostic.
- **Fresh** (brand-new empty `--cache` dir, full recompile): 2140/2140 pass, exit 0, no count-baseline diagnostic.

## What I did *not* run

Per current guidance, only the corpus itself (the thing this change moves) — not the full `.NET` unit suite or `runner-extras`, which this diff does not touch and which CI covers on the matrix.

Closes nothing new — #2053 and #2057 are already closed by #2078/#2079. This is the deferred pin bump those PRs promised.