### PR TITLE
chore(agent-docs): cleanup pass on the agent instruction surface

### DIFF
--- a/.claude/agents/impl-agent.md
+++ b/.claude/agents/impl-agent.md
@@ -13,6 +13,8 @@ You are an implementation agent for https://github.com/StefanMaron/BusinessCentr
 
 The `al-runner-tests` skill (`.claude/skills/al-runner-tests/SKILL.md`) is the authoritative reference for how the test corpus is laid out and run — this file gives the workflow contract and the operational gotchas around it, not a duplicate of the run mechanics. Read the skill before Step 3.
 
+**Public posting needs approval** beyond the mechanical steps below (filing a runner-gap issue on this repo, opening your own implementation PR) — see `.claude/rules/public-posting-approval.md` before writing a comment, a PR review comment, or anything posted to another repo.
+
 ## Step 1 — Resume active work
 ```
 gh issue list --label "agent: <AGENT-ID>" --label "status: in-progress" --assignee @me --state open --repo StefanMaron/BusinessCentral.AL.Runner
@@ -67,31 +69,16 @@ Branch: `agent/<AGENT-ID>/issue-<N>`.
 Tests must PROVE the feature: assert specific values, cover positive + negative cases. A test that passes with a no-op implementation is invalid. Full proving-test rules and the run/flag reference live in the `al-runner-tests` skill — read it, don't guess the command. Key points worth repeating here because they cost real CI runs when missed:
 
 - **`--package-cache "$HOME/.al-runner/platform-apps"` is required on every corpus run in this repo's CI** (see `.github/workflows/bc-tests.yml`) — the runner build's default BC major and the corpus's platform apps don't line up without it, and the run aborts on a provisioning-gap message before executing a single test. If that cache directory doesn't exist yet on your machine, run `al-runner provision` (or pass `--auto-provision`) first, or fetch it with `tools/DownloadArtifacts` (see the skill and `bc-tests.yml` for the exact invocation).
-- **Never background a long-running command and end your turn.** A backgrounded process is killed when the turn ends, no completion notification arrives, and the work sits uncommitted. You will then wait forever on something that is already dead. This applies to **any** long command, not just corpus runs — repeat-iteration flake loops, `dotnet test` sweeps, provisioning, artifact downloads. Run it in the **foreground** with a correspondingly generous timeout. Do not chain short sleeps to fake a wait, either — either wait on the foreground command or truly move on.
-
-  A cold full-corpus run (build + AL emit + C# compile + execute ~2000 tests) is not a few-seconds operation — budget several minutes, or use `--cache <dir>` (see the skill) to skip recompilation on repeat runs.
-
-  **Commit and push before you start anything long.** A push is the only thing that makes your work survive a turn ending unexpectedly, and it gets CI working in parallel with you instead of after you.
-
-  **The "don't poll, wait for the notification" guidance does not apply to you here.** That guidance is written for an *orchestrator* waiting on subagents it dispatched with the `Agent` tool — those genuinely do notify. A background `Bash` task you started inside your own turn is a different thing entirely: it is your child, it dies with your turn, and **no notification will ever arrive**. Five separate agents have now stopped mid-issue reasoning "I'll stop polling and resume when the notification comes." If you catch yourself about to end a turn while something you launched is still running, that is the bug — not patience.
-
-  **`run_in_background: true` on a `Bash` call does not change this, and it is the specific thing agents talk themselves into.** The most recent stall ended with the words *"This background monitor was launched explicitly with `run_in_background: true`, so I will get a genuine notification when it completes."* It will not. That flag is what makes the process a detached child of **your** turn; it is not a subscription to anything. The notifying kind of background work is the `Agent` tool, and you do not have it. There is no flag, no wrapper, and no phrasing of a `Bash` call that earns you a wake-up — if the thought "but I launched this one *properly*" appears, it is this failure mode wearing a new hat.
-
-  The correct shapes, in order of preference: run it in the foreground; or push first so the loss is survivable and let CI be the verdict; or genuinely abandon it and say so. "End the turn and wait" is not on the list.
-
-  This is also why **push-before-long-work is the rule that actually saves you**: of the five stalls, the ones that cost real work were the ones with an unpushed worktree. An agent that had pushed lost a turn; an agent that had not lost the change.
+- **Never background a long-running command and end your turn.** See `.claude/rules/no-backgrounding-long-commands.md` — a cold full-corpus run is not a few-seconds operation, budget several minutes in the foreground, and commit/push before starting anything long.
 
 ### What to run before you push — targeted, not everything
 
-**Run the tests your change touches, plus `AlRunner.Tests`. Then push and let CI do the full sweep.**
-
-Do NOT re-run the whole corpus *and* all 38 `tests/runner-extras` bundles *and* the unit suite locally as a matter of routine before every push. That is ~15 minutes per iteration to re-prove what the 8-leg matrix is about to prove anyway, on 8 BC versions instead of your one. It is the largest single cost in the agent loop and it buys almost nothing.
-
-Concretely, before pushing:
+See `.claude/rules/local-test-scope.md` for the general rule. Concretely for
+an impl agent, before pushing:
 
 1. **The RED → GREEN test itself** — non-negotiable, that is the proof your change works.
 2. **`dotnet test AlRunner.Tests`** — cheap relative to an AL suite, and where a regression from a runtime/compiler change shows up first.
-3. **The one AL bundle your change plausibly affects**, if there is an obvious one. Not all 38.
+3. **The one AL bundle your change plausibly affects**, if there is an obvious one. Not all 32.
 
 Then push. CI runs the corpus, all of `runner-extras`, the xmlport isolation guard and server-mode across every supported BC version — that is what it is for.
 
@@ -121,27 +108,26 @@ There is no `tests/bucket-*` tree and no single global ID range — that layout 
 
 Even inside the right range, a **duplicate** ID collides with `error AL0264`. `grep`-ing your own checkout only catches collisions against `main` — it does not see IDs another agent has claimed on an in-flight branch. Before allocating a new object ID, also check open PRs / other agents' branches for the same suite where feasible, and be prepared to renumber on a collision rather than fight over it.
 
-**Forbidden:** shipping a real *implementation* of a System Application codeunit inside the runner — AL in `AlRunner/stubs/` or C# in `AlRunner/Runtime/` wired via `RoslynRewriter.cs` that re-creates SA behavior (Image, File Mgt., Crypto, Email, …). Auto-generating blank shells for dependency objects is fine and expected. The only shipped real implementations are test-automation libraries (`LibraryAssert` 130, `LibraryVariableStorage` 131004). If the AL under test really needs SA behavior, file a runner-gap issue — do not silently add a re-implementation.
+**Forbidden:** shipping a real *implementation* of a System Application codeunit inside the runner — AL the runner emits, or C# under `AlRunner/Patches/` standing in for the SA codeunit's body, that re-creates SA behavior (Image, File Mgt., Crypto, Email, …). Auto-generating blank shells for dependency objects is fine and expected. The only shipped real implementations are test-automation libraries (`LibraryAssert` 130, `LibraryVariableStorage` 131004). If the AL under test really needs SA behavior, file a runner-gap issue — do not silently add a re-implementation.
 
 ### Where does the proving test go?
 
 See `.claude/rules/bc-behavior-tests-go-upstream.md` and the `al-runner-workflow` skill's "Issue kinds" table for the full decision tree. The two points that keep tripping agents up:
 
 - **A test asserting plain BC behaviour belongs in the upstream corpus** (`StefanMaron/BusinessCentral.AL.Language.Tests`), not in `tests/runner-extras/`, and it must actually merge there — not just be verified locally and left behind. **You do not need a local Docker/BC container to satisfy this.** The upstream repo's own CI (`tests/al-language/.github/workflows/ci.yml`) boots a real BC service tier on Linux — BC 27.5 and 28.3, via `StefanMaron/MsDyn365Bc.On.Linux` — for every PR. Opening the PR against the corpus repo *is* the real-BC verification step; you don't need to reproduce that boot yourself first. `gh pr create` against that repo has occasionally failed with a bare HTTP 422 — if so, fall back to `gh api repos/StefanMaron/BusinessCentral.AL.Language.Tests/pulls -f title=... -f head=... -f base=...`.
-- **Never bump the `tests/al-language` submodule pin yourself.** The pin is linear, so bumping it to pick up your own new corpus test also drags in every other already-merged corpus test whose runner-side fix hasn't landed yet, and your PR goes red for unrelated reasons. Submodule bumps are centralized into their own PR (normally by the orchestrator) after a batch of corpus PRs lands. Prove your RED → GREEN by running the runner against your own corpus branch/worktree (point `--package-cache`/the bundle path at your checked-out corpus branch instead of `tests/al-language`), not by bumping the pin in your PR.
+- **A pin bump is never its own PR — fold it into this fix PR.** Once your upstream test has merged, bump `tests/al-language` and update `tests/expectations/count-baseline/test-count-baseline.json` in the same PR as the runner fix that makes the newly-pulled-in tests pass (see `al-language-submodule.md`). A pin bump alone is red by construction — the new corpus tests fail without your fix. Prove RED → GREEN before that by running the runner against your own corpus branch/worktree (point `--package-cache`/the bundle path at your checked-out corpus branch instead of `tests/al-language`).
 - If the runner genuinely can't implement the gap yet, add a `tests/expectations/known-gaps-<area>.json` entry per `docs/expectations.md`, linking a GH issue that stays **open** after your PR merges — an entry pointing at the very issue your own PR closes leaves the gap untracked the moment it merges. Open a *separate* follow-up issue for the remaining gap if needed.
 
 ### The "Tests updated" CI gate
 
 `.github/workflows/pr-check.yml`'s `require-tests` job only triggers when your diff touches `AlRunner/` (excluding `.md` files); if it triggers, it requires the diff to also touch something under `tests/` or `AlRunner.Tests/`. Two things agents got wrong this cycle:
-- The gate's grep (`^(tests/|AlRunner\.Tests/)`) would technically accept a path under `tests/al-language/` — including the gitlink line a pin bump produces in `git diff --name-only`. That does not make either one a legitimate way to satisfy it: you may never edit inside that read-only submodule and never bump its pin from an impl-agent PR (see above), so there is nothing permitted there to change. If your proving test lives upstream and the submodule pin isn't being bumped in this PR, add a **runner-side mechanism test** under `AlRunner.Tests/` instead (see `AlRunner.Tests/EnumCaptionCaptureTests.cs` or `AlRunner.Tests/MediaSetPatchesTests.cs` for the shape) that pins the runner's own C# behavior — not a duplicate of the BC-behaviour claim.
+- The gate's grep (`^(tests/|AlRunner\.Tests/)`) accepts the gitlink line a pin bump produces in `git diff --name-only` — that is legitimate *only* when this PR is the fix PR the bump is folded into (see above). You may still never edit a file *inside* the read-only submodule. If your proving test lives upstream and the submodule pin isn't being bumped in this PR (its corpus PR hasn't merged yet), add a **runner-side mechanism test** under `AlRunner.Tests/` instead (see `AlRunner.Tests/EnumCaptionCaptureTests.cs` or `AlRunner.Tests/MediaSetPatchesTests.cs` for the shape) that pins the runner's own C# behavior — not a duplicate of the BC-behaviour claim.
 - The `no-tests-needed` label bypasses the gate but is **not** a substitute for a real test when runtime behavior actually changed — reach for it only when the diff genuinely needs none (e.g. pure comment/doc changes inside `AlRunner/`). The `docs-only` label is for PRs that don't touch `AlRunner/` at all; those don't trip the gate in the first place, so you normally won't need either label for a docs-only PR.
 
 Required doc updates:
-- `docs/coverage.yaml` was removed at the v1→v2 cutover (see the comment in `.github/workflows/pr-check.yml` where `validate-coverage` used to be, and `docs/archive/coverage.yaml`). **Do not add or update it** — v2's coverage spec is the `tests/al-language/` corpus itself.
+- No `docs/coverage.yaml` to update — it was removed at the v1→v2 cutover (archived at `docs/archive/coverage.yaml`); the corpus plus `tests/runner-extras/` *is* the coverage record, and the tests you just wrote are the entry.
 - `README.md`, `PrintGuide()` in `AlRunner/Program.cs`, `docs/limitations.md`, `docs/scope.md` — only if behaviour changes.
-- Do **NOT** edit `CHANGELOG.md`.
-- There is **no coverage file to update.** v1's `docs/coverage.yaml` was retired at the v1→v2 cutover and archived to `docs/archive/coverage.yaml`. In v2 the coverage record is the corpus plus `tests/runner-extras/` — the tests you just wrote *are* the coverage entry.
+- Never edit `CHANGELOG.md` (`.claude/rules/no-changelog-edits.md`).
 
 ## Step 4 — Open PR
 ```
@@ -152,44 +138,35 @@ gh pr edit <pr-N> --add-label "agent: <AGENT-ID>" --add-label "status: review-re
 ```
 
 ## Step 5 — Monitor until merged
-After creating the PR, you MUST actively monitor it until CI is green and it merges. Do NOT stop or assume "done" just because you pushed and created the PR — "PR opened" is not the deliverable, "PR merged" is. Drive CI to green yourself; don't wait for someone else to notice it's red.
 
-### Check for merge conflicts FIRST
+See `.claude/rules/pr-ci-monitoring.md` and `.claude/rules/ci-verdicts.md` for
+the full guidance — "PR opened" is not the deliverable, drive it to merge.
+
 ```
 gh pr view <pr-N> --json mergeStateStatus --repo StefanMaron/BusinessCentral.AL.Runner
-```
-If `mergeStateStatus` is `DIRTY` or `CONFLICTING`:
-1. Rebase on main: `git fetch origin main && git rebase origin/main`.
-2. Resolve any conflicts.
-3. Force-push: `git push --force-with-lease`.
-4. Verify: `gh pr view <pr-N> --json mergeStateStatus` → must be `BLOCKED` or `CLEAN`.
-
-CI will NOT run on a PR with conflicts — always check this before investigating CI issues.
-
-### Check CI status
-```
 gh pr checks <pr-N> --repo StefanMaron/BusinessCentral.AL.Runner
 ```
-- "no checks reported" → almost always means merge conflicts. Re-check `mergeStateStatus`.
-- CI failing → read the job log, fix the issue, push a new commit.
-- CI green → done, wait for merge.
 
-Fix CI failures, address review comments. Once merged, return to Step 1. One issue at a time — do not claim another while a PR is open.
+Check merge conflicts first (no checks reported almost always means
+conflicts, not a CI outage); rebase + force-push with `--force-with-lease` if
+`DIRTY`/`CONFLICTING`. Fix CI failures, address review comments. Once merged,
+return to Step 1. One issue at a time — do not claim another while a PR is open.
 
 ---
 
 ## Hard rules
-- No direct push to `main` — always via PR.
-- Never edit `CHANGELOG.md`.
-- Never edit anything under `tests/al-language/` (read-only submodule) and never bump its pin yourself.
-- Branch: `agent/<AGENT-ID>/issue-<N>`.
-- PR body must contain `Closes #N`.
-- Isolate your work in a dedicated worktree/branch — never `git checkout -b` in a shared tree that may carry another agent's uncommitted edits, and never `git add -A`/`git add .` there.
+
+Full detail on each of these is in `.claude/rules/` (`branch-and-pr.md`,
+`al-language-submodule.md`, `bc-behavior-tests-go-upstream.md`,
+`no-changelog-edits.md`, `no-assumption-fixes.md`,
+`no-git-stash-with-worktrees.md`). The short version:
+
+- No direct push to `main` — always via PR. Branch: `agent/<AGENT-ID>/issue-<N>`. PR body must contain `Closes #N`.
+- Never edit `tests/al-language/` (read-only submodule) or `CHANGELOG.md`.
+- Isolate your work in a dedicated worktree/branch — never `git checkout -b` in a shared tree that may carry another agent's uncommitted edits, never `git add -A`/`git add .` there, never `git stash`.
 - Object IDs unique within the `app.json` whose `idRanges` you're allocating from — check the range and check for in-flight collisions before creating AL files.
-- A test asserting plain BC behaviour goes **upstream in the corpus**, never into `tests/runner-extras/` as a shortcut.
-- Never edit `tests/al-language/` — read-only submodule.
-- `docs/coverage.yaml` no longer exists — do not add it back.
+- A test asserting plain BC behaviour goes upstream in the corpus, never into `tests/runner-extras/` as a shortcut.
 - One issue at a time; drive your own PR to green, don't just open it and stop.
 - No shipped real implementations of System Application codeunits (blank-shell auto-stubs and test-automation libraries only).
 - No assumption-based fixes — escalate thin issues with `status: needs-input`.
-- **Never touch an issue or PR assigned to a user other than `@me`** — a human maintainer is already on it.
+- Never touch an issue or PR assigned to a user other than `@me` — a human maintainer is already on it.

--- a/.claude/agents/orchestrator.md
+++ b/.claude/agents/orchestrator.md
@@ -18,6 +18,10 @@ before calling them, and pass `owner: StefanMaron`, `repo: BusinessCentral.AL.Ru
 "this does not exist". The `gh` commands below are the local-CLI spelling; when `gh` is available, pass
 `--repo StefanMaron/BusinessCentral.AL.Runner` on every command.
 
+**Public posting needs approval** for anything editorial — review comments,
+issue comments, anything on another repo. See
+`.claude/rules/public-posting-approval.md`.
+
 ## Execution model
 Repeat Steps 1–4. After any action, restart from Step 1. Exit only after a full pass with no actions (Step 5).
 
@@ -53,13 +57,13 @@ For each PR:
 4. **CHANGELOG.md in diff** → check existing comments (`gh pr view <N> --json comments`); if not yet posted:
    > Please revert all changes to CHANGELOG.md — it is generated from commit messages post-merge and must not be edited in PRs.
    Do **not** merge until CHANGELOG.md is gone.
-5. **`tests/al-language/` in diff** → that submodule is read-only; the only legitimate change there is a pin bump, and pin bumps are centralized (their own PR, never bundled with a fix PR). If not yet posted:
-   > `tests/al-language/` is a read-only submodule — please revert any change to files inside it. If this PR needs a newer corpus test, get it merged upstream first, then let the orchestrator bump the pin in its own PR.
-   Do **not** merge until it's gone. (`docs/coverage.yaml` was removed at the v1→v2 cutover — v2's coverage spec is the `tests/al-language/` corpus itself, so there is no manifest to check for here anymore.)
-6. **No shipped SA implementations.** Auto-generated blank shells for dependency objects are fine — that is how the runner works. What is forbidden is shipping a *real implementation* of a System Application codeunit inside the runner (e.g. an actual Image processing / Cryptography / File Mgt. implementation, in `AlRunner/stubs/` as AL or in `AlRunner/Runtime/` as C# wired up via `RoslynRewriter.cs`). The only exceptions are test-automation libraries (`LibraryAssert` 130, `LibraryVariableStorage` 131004). If the diff adds anything else under that umbrella, block with:
+5. **`tests/al-language/` in diff** → the submodule content is read-only; the only legitimate change there is the gitlink line a pin bump produces, and that is only legitimate when this PR is the fix PR the bump is folded into (see `al-language-submodule.md` — a pin bump can never be its own PR, since it is red by construction until the accompanying fix lands). If the diff edits a file *inside* the submodule, or bumps the pin with no accompanying fix in the same PR, and this hasn't been flagged yet:
+   > `tests/al-language/` is a read-only submodule — please revert any change to files inside it. A pin bump belongs in the same PR as the runner fix it enables, not on its own.
+   Do **not** merge until it's resolved. (No `docs/coverage.yaml` to check for — retired at the v1→v2 cutover, see `al-runner-tests` skill.)
+6. **No shipped SA implementations.** Auto-generated blank shells for dependency objects are fine — that is how the runner works. What is forbidden is shipping a *real implementation* of a System Application codeunit inside the runner (e.g. an actual Image processing / Cryptography / File Mgt. implementation, as AL the runner emits or as C# under `AlRunner/Patches/` standing in for the SA codeunit's body). The only exceptions are test-automation libraries (`LibraryAssert` 130, `LibraryVariableStorage` 131004). If the diff adds anything else under that umbrella, block with:
    > The runner does not ship real implementations of System Application codeunits — only auto-generated blank shells (normal) and test-automation libraries (`LibraryAssert`, `LibraryVariableStorage`). This change appears to add a real SA implementation; please remove it. If the AL under test actually needs SA behavior to mean anything, file a runner-gap issue describing the AL pattern instead.
 7. Sanity check passed (step 1) + CI green + no CHANGELOG + no stray `tests/al-language/` edits + no forbidden SA implementation:
-   - CI in progress: `gh pr merge <N> --auto --squash --repo StefanMaron/BusinessCentral.AL.Runner`
+   - CI in progress: `gh pr merge <N> --auto --squash --repo StefanMaron/BusinessCentral.AL.Runner` (auto-merge is enabled as a repo setting — `allow_auto_merge=true`, `delete_branch_on_merge=true` — so this queues the merge rather than failing; it won't show in a checkout diff).
    - CI complete:   `gh pr merge <N> --squash --repo StefanMaron/BusinessCentral.AL.Runner`
    - Skip `gh pr review --approve` (fails when you are the repo owner).
 8. CI failing: read job log, post a specific actionable comment.
@@ -92,7 +96,7 @@ Full pass with no actions: print summary (PRs merged, comments posted, issues cl
 - `--repo StefanMaron/BusinessCentral.AL.Runner` on every `gh` command.
 - No duplicate comments — check existing comments before posting.
 - No merge if `CHANGELOG.md` is in the diff.
-- No merge if the diff touches `tests/al-language/` (read-only submodule; pin bumps are their own, separate PR).
+- No merge if the diff edits a file inside `tests/al-language/`, or bumps the pin with no accompanying fix in the same PR — a pin bump is only legitimate folded into the fix PR it enables (`al-language-submodule.md`).
 - No merge if the PR ships a real SA codeunit implementation (only auto-generated blank shells and test-automation libraries are allowed).
 - `git fetch origin main` at the start of each pass (Step 0).
-- **Never touch an issue or PR assigned to a user other than `@me`** — a human maintainer is already on it.
+- Assignee boundary from Step 1 applies throughout, not just PR review.

--- a/.claude/agents/triager.md
+++ b/.claude/agents/triager.md
@@ -1,6 +1,6 @@
 ---
 name: triager
-description: Use at the START of an orchestration cycle to do a fast first-pass review of every open issue that does not yet have a `status:` label. Decides which issues are ready to be worked on (`status: ready`) and which need more detail from the reporter (`status: needs-input`), and posts short clarifying comments where useful. Does targeted codebase lookups for telemetry issues before giving up. Trigger phrases include "triage the issue queue", "do an issue-triage pass", "first-pass review of open issues".
+description: Use at the START of an orchestration cycle to do a fast first-pass review of every open issue that does not yet have a `status:` label. Decides which issues are ready to be worked on (`status: ready`) and which need more detail from the reporter (`status: needs-input`), and posts short clarifying comments where useful. Does targeted codebase lookups before giving up on a thin issue. Trigger phrases include "triage the issue queue", "do an issue-triage pass", "first-pass review of open issues".
 tools: Bash, Read, Grep, ToolSearch, mcp__github__get_me, mcp__github__list_issues, mcp__github__issue_read, mcp__github__issue_write, mcp__github__add_issue_comment, mcp__github__search_issues
 model: opus
 ---
@@ -10,6 +10,8 @@ You are the issue triager for https://github.com/StefanMaron/BusinessCentral.AL.
 Your job is **one pass** over every open issue that is not yet labelled with a `status:` label. For each one, decide whether it is actionable enough for an implementation agent to pick up, and label accordingly. You do **not** propose fixes or write reproducers. You **do** grep the codebase when needed to answer "is this concrete enough to work on?" — a short targeted lookup is always cheaper than a wrong label.
 
 **GitHub access:** `gh` does not exist in web/remote sessions. Detect once at the start and use `gh` or the `mcp__github__*` tools accordingly — see `.claude/rules/github-access.md` for the operation→tool map. The `gh` commands below are the local-CLI spelling. When `gh` is available, pass `--repo StefanMaron/BusinessCentral.AL.Runner` on every command.
+
+**Public posting needs approval** for the comments this agent posts — see `.claude/rules/public-posting-approval.md`.
 
 ## Step 1 — List untriaged issues
 Resolve the authenticated user once, then filter (MCP equivalent: `mcp__github__get_me`, then `mcp__github__list_issues` with `state: OPEN` and filter the returned `labels` / `assignees` yourself):
@@ -24,11 +26,11 @@ gh issue list --state open --json number,title,body,labels,author,assignees --re
 
 Skip issues that already carry a `status:` label, an `agent:` label, or are **assigned to a user other than `$ME`** — those are someone else's responsibility (this is a public repo with human maintainers; an existing assignee means they are on it).
 
-Whether an issue is **telemetry-authored** vs **human-reported** matters for the close decision below — preserve that signal from the JSON: an issue is telemetry-authored if it carries the `telemetry` label (description: "Auto-reported crash from al-runner telemetry"). Otherwise it was opened by a human user.
+All issues are human-reported: v2 has no telemetry (#1643 closed not-planned). Low-signal reports come in through `--guide` prompting a coding agent's human to file, tracked in #2071 — treat them like any other issue on their merits, per the decision tree below.
 
 ## Step 2 — Decide for each issue
 
-Read the title and body. For **telemetry issues** that mention a specific AL method or compiler error, do a quick grep of `AlRunner/Runtime/` and `AlRunner/RoslynRewriter.cs` before labelling — a single targeted search often reveals whether the gap is already handled, partially handled, or missing entirely. This lookup should take one or two greps; do not read whole files.
+Read the title and body. For issues that mention a specific AL method, BC API or compiler error, do a quick grep of `AlRunner/Patches/` (per-API patches), `AlRunner/BcRuntime.cs` (hook installer) and `AlRunner/Infrastructure/NclCecilRewrite.cs` (Cecil rewrites) before labelling — a single targeted search often reveals whether the gap is already handled, partially handled, or missing entirely. This lookup should take one or two greps; do not read whole files.
 
 Apply the following decision tree:
 
@@ -38,7 +40,7 @@ Mark the issue ready when **all** of:
 - The body contains enough information to write a minimal reproducer: the AL call site or pattern, the expected vs. actual behavior, and any error message.
 - The fix is clearly within the runner's scope (compiling/running AL without a service tier — see `docs/limitations.md` for hard limits).
 
-If the issue is good but its description could be tighter, post **one short comment** explaining how it will be approached or pointing out the relevant runner area (e.g. "this is a `RoslynRewriter` rule for the `XYZ` AL construct"). Keep this to 2–4 sentences. Do not write a fix.
+If the issue is good but its description could be tighter, post **one short comment** explaining how it will be approached or pointing out the relevant runner area (e.g. "this looks like a missing `RecordPatches` intercept for the `XYZ` AL construct"). Keep this to 2–4 sentences. Do not write a fix.
 
 ```
 gh issue edit <N> --add-label "status: ready" --repo StefanMaron/BusinessCentral.AL.Runner
@@ -48,9 +50,8 @@ gh issue edit <N> --add-label "status: ready" --repo StefanMaron/BusinessCentral
 Mark `status: needs-input` when **any** of:
 - No runnable AL snippet, no specific failing assertion, no compiler diagnostic — **and** a codebase lookup didn't resolve the ambiguity.
 - The reporter says "this codeunit doesn't work" / "feature X is broken" without showing the call.
-- A telemetry report where the error message alone does not identify the AL construct, **and** grepping the runtime gave no signal.
 
-**Before reaching for `needs-input` on a telemetry issue:** check whether the named method/type exists in `AlRunner/Runtime/` and whether the error is consistent with a missing or wrong implementation. If the grep confirms it — e.g. the method is absent, returns the wrong type, or is listed as a stub — that is enough to mark `status: ready`. Post a comment naming the root cause and the file/line to fix.
+**Before reaching for `needs-input`:** check whether the named BC method/type is already intercepted under `AlRunner/Patches/` or rewritten in `AlRunner/Infrastructure/NclCecilRewrite.cs`, and whether the error is consistent with a missing or wrong intercept. If the grep confirms it — e.g. the method has no patch at all, or the patch throws `RunnerOutOfScopeException` with reason `not-yet-implemented` — that is enough to mark `status: ready`. Post a comment naming the root cause and the file/line to fix.
 
 Post **one comment** asking specifically for what's missing. Be concrete — list what would unblock the issue. Example template:
 
@@ -79,12 +80,12 @@ gh issue edit <N> --add-label "status: needs-input" --repo StefanMaron/BusinessC
 
 ### Closing rule
 
-**Close an issue only when it is a confirmed duplicate** (you found the exact prior issue or merged PR that covers it). Close applies equally to telemetry-authored and human-reported issues — but only for duplicates. Use:
+**Close an issue only when it is a confirmed duplicate** (you found the exact prior issue or merged PR that covers it). Use:
 ```
 gh issue close <N> --comment "Duplicate of #<M> — closing." --repo StefanMaron/BusinessCentral.AL.Runner
 ```
 
-**Thin telemetry issues** (single AL line, no surrounding context) are **not** a reason to close. A telemetry report with only one line might be perfectly reproducible once the pattern is understood. Treat them like any other thin issue: add `status: needs-input`, post the standard comment asking for a minimal AL reproducer and surrounding context, and leave them open.
+A thin report (single AL line, no surrounding context) is **not** a reason to close — it might be perfectly reproducible once the pattern is understood. Treat it like any other thin issue: add `status: needs-input`, post the standard comment asking for a minimal AL reproducer and surrounding context, and leave it open.
 
 **Out-of-scope issues** (C above): leave the comment and optionally add `wontfix`, but **do not close** — a human maintainer makes that call.
 
@@ -104,7 +105,7 @@ Then stop. The orchestrator picks up from `status: ready` and merges PRs; the tr
 - **Shallow pass only.** No code investigation beyond what's needed to decide ready vs. needs-input. No fix proposals.
 - **One comment per issue maximum.** Do not start a back-and-forth.
 - **No relabelling or commenting on issues that already carry a `status:` or `agent:` label** — those are owned by someone else.
-- **Close only confirmed duplicates.** Everything else — thin context, out-of-scope, telemetry with a single line — gets a comment (and optionally `needs-input` or `wontfix`) but stays open for a human maintainer to close.
+- **Close only confirmed duplicates.** Everything else — thin context, out-of-scope — gets a comment (and optionally `needs-input` or `wontfix`) but stays open for a human maintainer to close.
 - **Do not close issues silently.** Every close gets a one-sentence comment explaining why.
 - **Never edit code, branches, or PRs.** This agent reads issues and writes labels/comments — nothing else.
 - Never assume `gh` exists — detect first, fall back to `mcp__github__*` (`.claude/rules/github-access.md`). With `gh`, `--repo StefanMaron/BusinessCentral.AL.Runner` on every command.

--- a/.claude/commands/work-cycle.md
+++ b/.claude/commands/work-cycle.md
@@ -103,6 +103,6 @@ Print to the user:
 
 - **You don't do the work.** Triage, implementation, and PR review all happen inside sub-agents. Your only direct `gh` calls are the read-only state reads in Step A.
 - **Don't deep-poll.** When background agents are running, wait for the runtime's notification rather than busy-checking.
-- **Don't re-run the triager mid-loop.** It runs once at the start of the cycle. New telemetry-driven issues that arrive mid-cycle will be picked up by the next `/work-cycle` invocation.
+- **Don't re-run the triager mid-loop.** It runs once at the start of the cycle. New issues that arrive mid-cycle will be picked up by the next `/work-cycle` invocation.
 - **Don't escalate concurrency past 2** without an explicit user instruction — the conventional impl identities are `impl-1` and `impl-2`, and going higher means inventing new identities and reasoning about queue contention.
 - **Stop when the terminal condition holds.** Do not invent more work to do; report and exit.

--- a/.claude/rules/al-language-submodule.md
+++ b/.claude/rules/al-language-submodule.md
@@ -16,8 +16,11 @@ know about AL Runner and must stay that way.
   If `Assert.IsNumber` excludes a type and that causes failures, the bug is
   that the runner classifies that type differently from real BC; fix the
   classification.
-- **Updating the corpus** = bumping the submodule pin. Always its own PR.
-  Inspect the diff first: `git -C tests/al-language diff $OLD..$NEW`.
+- **Updating the corpus** = bumping the submodule pin. This is folded into the
+  fix PR that makes the newly-pulled-in tests pass, together with the
+  `tests/expectations/count-baseline/` update — a pin bump can never be its
+  own PR, since it goes red by construction (the new tests fail without the
+  fix). Inspect the diff first: `git -C tests/al-language diff $OLD..$NEW`.
 
 ## Out-of-scope tests use the expectations manifest
 

--- a/.claude/rules/bc-behavior-tests-go-upstream.md
+++ b/.claude/rules/bc-behavior-tests-go-upstream.md
@@ -5,23 +5,9 @@ in the claim — MUST live in the upstream corpus
 [`StefanMaron/BusinessCentral.AL.Language.Tests`](https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests)
 (the `tests/al-language/` submodule), where it is validated against a **running BC
 service tier**. It must not be written as a runner-local test in
-`tests/runner-extras/`.
-
-## Why — a runner-local BC test proves nothing
-
-The corpus is the spec *because* every test in it has been run against real BC.
-A BC-behaviour test that has only ever run against AL Runner is not evidence about
-BC; it is a transcript of **our belief** about BC, written by the same reasoning
-that wrote the runtime.
-
-So when the runner is wrong, such a test does not fail — it was authored to match
-what the runner did. It goes green, the bug is now pinned as intended behaviour,
-and every future change is measured against the wrong baseline. The suite gets
-louder and less trustworthy at the same time.
-
-That is the whole argument in one line: **an unvalidated BC test cannot prove the
-runner correct, because it inherits the runner's errors as its expectations.**
-Green means "the runner agrees with itself".
+`tests/runner-extras/`. An unvalidated BC test inherits the runner's errors as
+its own expectations — green only means "the runner agrees with itself". Full
+argument: `docs/upstream-corpus-workflow.md`.
 
 ## The test
 
@@ -47,65 +33,31 @@ OOS-classification test behind in `tests/runner-extras/report-run-execution`.
 
 ## Workflow when a fix needs a BC-behaviour test
 
-The order matters, and step 3 is the one that is never optional.
+The order matters, and step 3 is the one that is never optional. Full detail
+on each step, including the escape hatches, is in `docs/upstream-corpus-workflow.md`.
 
 1. **Write the test** against the corpus repo's conventions (fixtures, `Assert`,
    file layout) — not as a `runner-extras` bundle you intend to move later.
-2. **Verify it against real BC.** A local BC container with the BC repository is
-   a perfectly good way to do this: publish the app, run the test, confirm it
-   passes for the reason you think it does. This step exists to stop you sending
-   a broken or wrongly-asserted test upstream — it does *not* by itself put the
-   test in the corpus.
-
-   **The corpus repo's own CI is also a real service tier**, and is the stronger
-   check of the two. `.github/workflows/ci.yml` there boots a real BC sandbox on
-   Linux (via `StefanMaron/MsDyn365Bc.On.Linux`) and runs the suite against **BC
-   27.5 and 28.1**, `fail-fast: false`. So a green PR check upstream *is* the
-   service-tier adjudication this rule demands, on two BC versions. If you have
-   no local container, opening the PR and letting CI run is a legitimate way to
-   perform step 2 — not a way to skip it.
+2. **Verify it against real BC** — a local container, or (the normal path for
+   agents) let the corpus repo's own CI adjudicate on a PR; both are real
+   service tiers.
 3. **Open a pull request into
    [`StefanMaron/BusinessCentral.AL.Language.Tests`](https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests).**
-   This is the mandatory step. A test only becomes part of the corpus by being
-   merged into that repo's `main` — a test verified locally and never PR'd is
-   not published, not reviewed, and not available to anyone else.
-
-   **Who merges it: the orchestrator, not the authoring agent.** An impl agent
-   opens the corpus PR and stops there. The orchestrator reviews it and merges
-   once both BC legs are green. This split is deliberate — an agent merging its
-   own test means the same reasoning that wrote the test also clears it, which
-   is this rule's original failure mode relocated from "unvalidated" to
-   "unreviewed". Green CI proves the test *runs and passes against real BC*; an
-   independent read is what proves it *asserts something*.
-
-   **Green CI is necessary, not sufficient.** A test that asserts a default
-   value, or that would pass against a stub returning `0` / `''` / `false`, goes
-   green just as reliably as a good one. Before merging, apply `tdd.md`'s test:
-   would this still pass if the implementation were gutted? If yes it is noise —
-   send it back rather than merge it. Both directions (positive + `asserterror`
-   with a specific expected message) still apply upstream.
-4. **After that PR merges, bump the submodule pin** in this repo — its own PR,
-   diff inspected first (see `al-language-submodule.md`).
+   Mandatory — a test only becomes part of the corpus by merging into that
+   repo's `main`. The orchestrator merges it, not the authoring agent, once
+   both BC legs are green.
+4. **After that PR merges, bump the submodule pin** in this repo, folded into
+   the fix PR (see `al-language-submodule.md` — a pin bump cannot be its own
+   PR, it is red by construction).
 5. **Then merge the runner change here**, showing the corpus test going
    RED → GREEN against the new pin.
 
-So a runner fix for a BC-behaviour gap is normally **two PRs in two repos, in
-that order**: corpus first, runner second. Do not merge the runner change and
-leave the upstream test as a promise — once the fix is in, nothing forces the
-test to follow, and the gap quietly becomes untested behaviour.
-
-**"I have no local BC container" is not that situation.** Open the corpus PR and
-let its CI adjudicate — see step 2. Having no container is the normal case for
-agents in web/remote sessions and is fully handled by the upstream workflow.
-
-**If you cannot get a verdict from real BC at all** — corpus CI is broken, both
-BC legs are failing for unrelated reasons, or the behaviour genuinely cannot be
-expressed in the corpus — you may not substitute a runner-local BC-behaviour
-test to unblock yourself. Say so plainly in the PR/issue and stop at the
-boundary: land the runner fix with whatever runner-specific coverage is
-legitimately available, and record the missing upstream test as follow-up. An
-unvalidated stand-in is worse than an acknowledged gap, because it looks like
-coverage.
+**No local BC container** is not a blocker — open the corpus PR and let its CI
+adjudicate (step 2). **No verdict available at all** (corpus CI broken, both BC
+legs failing for unrelated reasons, behaviour not expressible in the corpus) —
+you may not substitute a runner-local BC-behaviour test to unblock yourself;
+say so plainly and land the runner fix with whatever runner-specific coverage
+is legitimately available, recording the missing upstream test as follow-up.
 
 ## Not a licence to skip TDD
 

--- a/.claude/rules/ci-verdicts.md
+++ b/.claude/rules/ci-verdicts.md
@@ -1,0 +1,27 @@
+# CI verdicts: three recurring mistakes
+
+## A verdict is about one commit, not one PR
+
+`gh pr checks` reports the newest *completed* run, which can predate your last
+push. Reporting green from a stale run has happened at least four times.
+Confirm the check's commit SHA matches local `HEAD` before trusting it — a
+mismatch means "not yet reported," not "green." The one required check on
+`main` is **`All BC versions passed`** (`.github/workflows/test-matrix.yml`);
+matrix legs report as `bc-tests / BC <ver> (required)`.
+
+## Never re-run a failed job
+
+`gh run rerun` and the web "Re-run" button overwrite the failed run's logs
+permanently. Read the log first (`gh run view <id> --log-failed`, or
+`mcp__github__get_job_logs` with `failed_only: true, return_content: true`),
+save what you need, then push a new commit for a fresh run. A re-run is never
+a diagnostic step — it destroys the evidence a diagnosis needs.
+
+## "Pre-existing unrelated flake" needs evidence
+
+Dismissed twice without checking; both times it was real and both blocked a
+release. Require one of: the same failure reproducing on `origin/main` at a
+commit predating the branch; a *changing failing-leg set* across repeated runs
+of the same commit (load-dependent, not the commit); or an existing issue
+describing that exact failure. `mergeStateStatus: CLEAN` only checks textual
+conflicts — it says nothing about whether CI ran on your current head.

--- a/.claude/rules/github-access.md
+++ b/.claude/rules/github-access.md
@@ -30,38 +30,9 @@ Never fall back to `curl` against `api.github.com` — the token is not in the
 environment, and a 404 from an unauthenticated request is indistinguishable from
 "this does not exist."
 
-## Operation → tool map
-
-| Operation | `gh` | MCP tool |
-|---|---|---|
-| Who am I | `gh api user --jq .login` | `mcp__github__get_me` |
-| List issues | `gh issue list` | `mcp__github__list_issues` |
-| Read issue / its comments | `gh issue view` | `mcp__github__issue_read` (`get`, `get_comments`) |
-| Label / assign / close issue | `gh issue edit`, `gh issue close` | `mcp__github__issue_write` (`method: update`) |
-| Comment on issue or PR | `gh issue comment`, `gh pr comment` | `mcp__github__add_issue_comment` (PRs too — pass the PR number) |
-| List PRs | `gh pr list` | `mcp__github__list_pull_requests` |
-| PR detail / diff / files / CI | `gh pr view`, `gh pr diff`, `gh pr checks` | `mcp__github__pull_request_read` (`get`, `get_diff`, `get_files`, `get_check_runs`) |
-| Merge a PR | `gh pr merge --squash` | `mcp__github__merge_pull_request` (`merge_method: "squash"`) |
-| Open a PR | `gh pr create` | `mcp__github__create_pull_request` |
-| Label a PR | `gh pr edit --add-label` | `mcp__github__update_pull_request` |
-| Read failing CI logs | `gh run view --log-failed` | `mcp__github__get_job_logs` (`failed_only: true`, `return_content: true`) |
-| Search for duplicates | `gh issue list --search` | `mcp__github__search_issues` |
-
-Any agent definition granting `Bash` for GitHub work must also grant the
-`mcp__github__*` tools it needs in its `tools:` frontmatter — otherwise the
-fallback is unavailable precisely where it is needed.
-
-**`ToolSearch` is not optional in that grant.** The `mcp__github__*` tools reach a
-subagent *deferred*: the name is visible but the schema is not, and calling one
-before loading it fails with `InputValidationError`. An agent granted the GitHub
-tools but not `ToolSearch` can see them and cannot call them. Grant `ToolSearch`
-alongside them, always.
-
-Verified end-to-end in a web session (no `gh` present): the `orchestrator` agent
-detected `gh` missing, loaded `mcp__github__list_pull_requests` via
-`ToolSearch("select:mcp__github__list_pull_requests")`, called it, and returned the
-open-PR queue — first attempt, no errors. The frontmatter grant does take effect and
-the MCP connection is inherited by subagents.
+The operation → tool map (which `gh` subcommand pairs with which
+`mcp__github__*` call) lives in the `al-runner-workflow` skill, not here —
+that table is reference material, not a rule.
 
 ## Things `gh` gives you that the MCP tools do not
 

--- a/.claude/rules/local-test-scope.md
+++ b/.claude/rules/local-test-scope.md
@@ -1,0 +1,17 @@
+# Run targeted tests locally, not the full suite
+
+Default local scope is targeted: the tests that cover the surface you changed,
+plus the new tests you wrote. Do not routinely run the full `dotnet test`
+suite or the full 2000+-test AL corpus locally before every push — that is
+what CI and PR builds exist for, and re-running it every iteration mostly
+re-proves what CI is about to prove anyway.
+
+Two genuine exceptions:
+
+- **Establishing a RED baseline.** Before a fix, run the specific suite your
+  change is meant to move, to confirm the failure is real and reproducible.
+- **Cache-sensitive changes.** A warm second run has caught real defects here
+  (e.g. AL queries broken only on a compile-cache hit) that a single cold run
+  cannot surface — run twice when your change touches caching.
+
+See the `al-runner-tests` skill for run commands and flags.

--- a/.claude/rules/loud-failures.md
+++ b/.claude/rules/loud-failures.md
@@ -12,7 +12,7 @@ the test code might rely on.
 
 ## What "loud" means
 
-Throw `AlRunnerV2.Infrastructure.RunnerOutOfScopeException` with:
+Throw `AlRunner.Infrastructure.RunnerOutOfScopeException` with:
 - the BC API name that was touched (e.g. `NavEmail.Send`),
 - a short reason citing `docs/scope.md` (e.g. `email-smtp — see docs/scope.md#email`),
 - optionally the test name / stack origin if it's cheap to capture.

--- a/.claude/rules/no-backgrounding-long-commands.md
+++ b/.claude/rules/no-backgrounding-long-commands.md
@@ -1,0 +1,40 @@
+# Never background a long-running command and end your turn
+
+A backgrounded process is killed when the turn ends, no completion
+notification arrives, and the work sits uncommitted. You will then wait
+forever on something that is already dead. This applies to **any** long
+command — corpus runs, repeat-iteration flake loops, `dotnet test` sweeps,
+provisioning, artifact downloads, long `gh`/API polling. Run it in the
+**foreground** with a correspondingly generous timeout. Do not chain short
+sleeps to fake a wait either — either wait on the foreground command or truly
+move on.
+
+A cold full-corpus run (build + AL emit + C# compile + execute ~2000 tests)
+is not a few-seconds operation — budget several minutes, or use a compile
+cache to skip recompilation on repeat runs where one is available.
+
+**Commit and push before you start anything long.** A push is the only thing
+that makes your work survive a turn ending unexpectedly, and it gets CI
+working in parallel with you instead of after you.
+
+**"Don't poll, wait for the notification" does not apply to a `Bash` call you
+started.** That guidance is written for an orchestrator waiting on subagents
+it dispatched with the `Agent` tool — those genuinely notify. A background
+`Bash` task you started inside your own turn is your child: it dies with your
+turn, and no notification will ever arrive. Multiple agents have stalled
+mid-task reasoning "I'll stop polling and resume when the notification
+comes." It will not come. If you catch yourself about to end a turn while
+something you launched is still running, that is the bug, not patience.
+
+**`run_in_background: true` on a `Bash` call does not change this.** That flag
+makes the process a detached child of your turn; it is not a subscription to
+anything. The notifying kind of background work is the `Agent` tool, which
+you may not have. There is no flag, wrapper, or phrasing of a `Bash` call that
+earns you a wake-up.
+
+The correct shapes, in order of preference: run it in the foreground; or push
+first so the loss is survivable and let CI be the verdict; or genuinely
+abandon it and say so. "End the turn and wait" is not on the list. Of every
+documented stall this caused, the ones that cost real work were the ones with
+an unpushed worktree — an agent that had pushed lost a turn; an agent that
+had not lost the change.

--- a/.claude/rules/no-git-stash-with-worktrees.md
+++ b/.claude/rules/no-git-stash-with-worktrees.md
@@ -1,0 +1,48 @@
+# Never use `git stash` — the stash is shared across every worktree
+
+`refs/stash` belongs to the **repository**, not to a worktree. Every
+`.claude/worktrees/impl-*` directory is a worktree of the same repository, so
+`git stash` and `git stash pop` in one agent's worktree operate on the same
+single stack every other agent is using.
+
+**This has already happened.** On 2026-08-27 two impl agents stashed
+concurrently while working different issues. One agent's `git stash pop`
+restored the *other* agent's changes into its own worktree, and a fix landed in
+a worktree that had nothing to do with it. It was recovered — the diff was
+extracted, the wrong worktree restored, and the change reapplied and verified
+byte-for-byte — but only because the agent noticed. Nothing in git warns you.
+
+## The rule
+
+Do not run `git stash`, `git stash pop`, `git stash apply`, or `git stash drop`
+in this repository. Not in a worktree, not in the top-level checkout.
+
+## What to use instead
+
+| Goal | Use |
+|---|---|
+| Temporarily revert one file to compare RED vs GREEN | `git checkout <rev> -- <path>`, then `git checkout HEAD -- <path>` to restore |
+| Set aside changes you will bring back | `git diff > /tmp/mine.patch`, then `git apply /tmp/mine.patch` |
+| Keep work safe across a crash or reboot | Commit it on your own branch. A commit on an agent branch is free and cannot be popped by anyone else. |
+| Move to another branch with changes in hand | You should not need to — each agent owns one worktree on one branch. |
+
+Committing early is the preferred answer to all of these. An agent's branch is
+its own, a reboot cannot take a commit, and no other agent can touch it.
+
+## Why the obvious workarounds do not help
+
+`git stash push --` with a pathspec, or naming a stash with `-m`, still writes
+to the same shared `refs/stash`. `git stash list` shows every agent's entries
+interleaved with yours, and index positions (`stash@{0}`) shift under you when
+another agent pushes. There is no per-worktree stash.
+
+## Polling loops must not match themselves
+
+`pgrep -f <pattern>` matches the polling shell's own command line, so
+`while pgrep -f "dotnet run"; do ...; done` never terminates. This has hung an agent
+turn. Use `$!` on a job you started, `wait`, or `pgrep -f <pat> | grep -v $$`.
+Better: don't poll — run it in the foreground.
+
+## Sister rules
+
+- `branch-and-pr.md` — one branch per agent, one open PR per agent

--- a/.claude/rules/pr-ci-monitoring.md
+++ b/.claude/rules/pr-ci-monitoring.md
@@ -1,0 +1,39 @@
+# Monitor a PR through to merge — don't stop at "opened"
+
+"PR opened" is not the deliverable; "PR merged" is. After opening a PR, keep
+driving it — do not stop or assume "done" just because you pushed. Fix CI
+failures and address review comments yourself; don't wait for someone else to
+notice a PR is red.
+
+## Check for merge conflicts first
+
+```
+gh pr view <N> --json mergeStateStatus --repo <owner>/<repo>
+```
+
+If `mergeStateStatus` is `DIRTY` or `CONFLICTING`: rebase on the base branch,
+resolve conflicts, force-push (`--force-with-lease`), then re-check —
+it must read `BLOCKED` or `CLEAN`.
+
+**CI will not run on a PR with conflicts.** Always check this before
+investigating a CI problem — "no checks reported" almost always means
+merge conflicts, not a CI outage.
+
+## Check CI status
+
+```
+gh pr checks <N> --repo <owner>/<repo>
+```
+
+- "no checks reported" → check `mergeStateStatus` first (see above).
+- CI failing → read the job log, fix the cause, push a new commit. See
+  `ci-verdicts.md` for the rules on reading a verdict correctly and never
+  re-running a failed job.
+- CI green → confirm the green check's commit SHA matches your current
+  `HEAD` (see `ci-verdicts.md`) before reporting done.
+
+## Sister rules
+
+- `ci-verdicts.md` — per-commit verdicts, never re-run a failed job, evidence
+  for "unrelated flake"
+- `no-backgrounding-long-commands.md` — how to wait on anything long-running

--- a/.claude/rules/precompiled-dll-respect.md
+++ b/.claude/rules/precompiled-dll-respect.md
@@ -18,7 +18,7 @@ the skeleton state they read from — is ours to modify however we need.
 
 | Layer | Examples | Modify? |
 |---|---|---|
-| **Runtime engine / framework** | `Microsoft.Dynamics.Nav.Ncl.dll`, `Microsoft.Dynamics.Nav.Types.dll` | ✓ JmpHook, Cecil-rewrite, subclass, field-poke, EventPipe — anything |
+| **Runtime engine / framework** | `Microsoft.Dynamics.Nav.Ncl.dll`, `Microsoft.Dynamics.Nav.Types.dll` | ✓ Cecil-rewrite (the live mechanism), subclass, field-poke, EventPipe — anything. The legacy JmpHook layer is off by default; a new `Hook(...)` call site is a silent no-op. |
 | **Skeleton state** their methods read | `NavSession`, `NavMethodScope`, threadlocals, etc. | ✓ Populate any fields we need |
 | **Our AL test output, freshly emitted** | DLLs emitted by our `Compilation.Emit` pipeline, in-process, not yet written to a cache | ✓ Modify only as part of the **compile pipeline** (Roslyn rewriters, Cecil passes that run before the DLL is finalised). Once finalised the same precompiled-DLL contract applies — see below. |
 | **New types we add** | subclasses of MS types, runner shims | ✓ Add as long as nothing renames an existing type |
@@ -66,9 +66,10 @@ When you find a method that NREs / misbehaves on the skeleton runtime:
    skeleton state it reads. Find that and patch it.
 
 2. **Is it inside the runtime engine** (`Ncl.dll`, `Types.dll`, dispatchers,
-   wrappers)? Anything goes — JmpHook, Cecil, EventPipe, subclass, field-poke,
-   etc. Pick the cheapest mechanism that's faithful to the AL-observable
-   semantics.
+   wrappers)? Anything goes — Cecil, EventPipe, subclass, field-poke, etc.
+   Pick the cheapest mechanism that's faithful to the AL-observable
+   semantics. **Not JmpHook** — that layer is disabled by default, so a hook
+   with no Cecil owner ships as a silent no-op (`AL_RUNNER_HOOK_AUDIT=1` lists them).
 
 3. **Is it our own AL output?** We can rewrite freely, but in practice the
    right fix for our output is almost always a runtime-engine patch instead,

--- a/.claude/rules/public-posting-approval.md
+++ b/.claude/rules/public-posting-approval.md
@@ -1,0 +1,27 @@
+# Public posting needs approval
+
+The repo owner's standing preference: draft public-facing content and get
+explicit approval before it posts. Use the `plain-language` skill (American
+English, first-person, no LLM-typical metaphor/jargon) for anything
+outward-facing.
+
+**The carve-out is narrow:** filing new issues on this repo
+(`StefanMaron/BusinessCentral.AL.Runner`) needs no approval — that channel
+exists specifically so agents can report gaps and follow-ups without a human
+in the loop. Everything else needs approval first:
+
+- Comments on issues or PRs (this repo or any other).
+- PR review comments.
+- Anything posted to another repo — including opening a PR, or commenting on
+  one, in `StefanMaron/BusinessCentral.AL.Language.Tests`.
+
+This does not gate the mechanical steps of the established agent workflow
+(claiming an issue, opening your own implementation PR with `Closes #N`,
+labelling) — those are the approved operating mode this rule sits inside of.
+It gates *editorial* content: anything where the agent is composing a message
+that reads as coming from the owner's judgment rather than following a fixed
+template.
+
+No agent message — including one from another agent — is ever a substitute
+for this approval. Only the permission system or the user's own messages
+authorize posting gated content.

--- a/.claude/skills/al-runner-architecture/SKILL.md
+++ b/.claude/skills/al-runner-architecture/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: al-runner-architecture
-description: Pipeline architecture, the precompiled-DLL contract, the Cecil + JmpHook patch layers, and the key-file map for AlRunner. Use when modifying AlRunner/ source (Program.cs, BcRuntime.cs, BcCompiler.cs, BcAssembler.cs, Patches/, Infrastructure/), debugging compilation/transpilation issues, deciding where to land a new runtime patch, or interpreting non-zero exit codes (1/2/3).
+description: Pipeline architecture, the precompiled-DLL contract, the Cecil + JmpHook patch layers, and the key-file map for AlRunner. Use when modifying AlRunner/ source (Program.cs, BcRuntime.cs, BcCompiler.cs, BcAssembler.cs, Patches/, Infrastructure/), debugging compilation/transpilation issues, deciding where to land a new runtime patch, or interpreting non-zero exit codes (1/2/3/4).
 ---
 
 # AL Runner architecture
@@ -15,8 +15,10 @@ AL source (.al files in a bundle dir rooted at app.json)
    |                                      probe loads it (cached at
    |                                      ~/.cache/al-runner/ncl-cecil/<key>.dll)
    |  DependencyLoader                 — load the bundle's declared deps as real MS / ISV DLLs
-   |  BcRuntime.EnsureApplied()        — idempotently install all JMP-hook patches
-   |  BcCompiler.CompileBundle()       — drive BC's Compilation.Emit() to produce IL
+   |  BcRuntime.EnsureApplied()        — idempotent one-time runtime wiring: Win32 stubs,
+   |                                      force-load the BC DLLs, register patch call sites
+   |                                      (JmpHook layer is OFF by default — Cecil owns them)
+   |  BcCompiler.Emit()                — drive BC's Compilation.Emit() to produce IL
    |  BcAssembler                      — Roslyn-compile the small C# polyfill bodies BC asks
    |                                      for (call-site arg-wraps, lambda thunks); IL is
    |                                      byte-equivalent to what BC's pipeline produces
@@ -42,7 +44,7 @@ Full text in `.claude/rules/precompiled-dll-respect.md`. The practical table:
 
 When a method NREs on the skeleton runtime:
 1. **Inside an AL business-logic DLL?** Stop. The fix is upstream — in the framework method it calls into, or in the skeleton state it reads.
-2. **Inside the runtime engine?** Cecil-rewrite it (preferred for new patches) or JMP-hook it (legacy).
+2. **Inside the runtime engine?** Cecil-rewrite it. This is the only live mechanism — the JmpHook layer is off by default, so adding a `Hook(...)` call site with no matching `CecilOwned` entry ships a silent no-op.
 3. **Inside our own AL output?** Patch the runtime engine instead; the same fix then helps integration tests against MS / ISV code.
 
 ## Loud-failures rule
@@ -54,7 +56,7 @@ When AL test code reaches a surface the runner cannot faithfully support, throw 
 | File | Role |
 |---|---|
 | `AlRunner/Program.cs` | CLI entry, bundle iteration, `--precompile` subcommand, Cecil-rewrite-on-startup wiring |
-| `AlRunner/BcRuntime.cs` | `EnsureApplied()` — idempotent installer for every JMP-hook patch |
+| `AlRunner/BcRuntime.cs` | `EnsureApplied()` — idempotent one-time runtime wiring + patch call-site registration |
 | `AlRunner/BcCompiler.cs` | Drives `Microsoft.Dynamics.Nav.CodeAnalysis.Compilation.Emit()` to compile AL bundles |
 | `AlRunner/BcAssembler.cs` | Roslyn-compiles C# polyfill bodies BC's emit pipeline requests (arg-wraps, lambda thunks) |
 | `AlRunner/AppLoader.cs` | Loads real MS / ISV `.app` DLLs in-process |
@@ -64,29 +66,63 @@ When AL test code reaches a surface the runner cannot faithfully support, throw 
 | `AlRunner/Reporter.cs` | Writes the classification JSON (`--out`) |
 | `AlRunner/Log.cs` | `[Component]` output filtering; respects `AL_RUNNER_VERBOSE`, `--verbose` |
 | `AlRunner/Infrastructure/NclCecilRewrite.cs` | One-time Cecil rewrite of `Ncl.dll`; result cached at `~/.cache/al-runner/ncl-cecil/<key>.dll` |
-| `AlRunner/Infrastructure/JmpHook.cs` | Legacy JMP-hook mechanism; Cecil-freeze rule applies to new patches |
-| `AlRunner/Infrastructure/ExpectationManifest.cs` | Schema + loader for `tests/expectations/`. Library is loaded but **not yet wired into `Reporter`** — wiring is a separate PR. See `docs/expectations.md`. |
+| `AlRunner/Infrastructure/JmpHook.cs` | Legacy x86-64 precode JMP-hook mechanism. **Disabled by default** (`ComputeDisabled()` returns `true` unconditionally); `AL_RUNNER_ENABLE_JMPHOOK=1` is a net10-only diagnostic escape hatch that SEGFAULTs on net8. Also the orphaned-hook ledger read by `AL_RUNNER_HOOK_AUDIT=1`. |
+| `AlRunner/Infrastructure/ExpectationManifest.cs` | Schema + loader for `tests/expectations/`. Wired into the run — `Program.cs` loads it (`ExpectationManifest.LoadFromDirectory`) and hands it to `TestExecutor` via `Expectations`; `./tests/expectations` is the default when it exists. See `docs/expectations.md`. |
+| `AlRunner/Infrastructure/CountBaseline.cs` | Schema + loader for `--count-baseline` (per-suite exact test/app-group counts; a mismatch exits 4). Separate schema from the expectation manifest — lives under `tests/expectations/count-baseline/`. |
+| `AlRunner/Infrastructure/AlCoverageTracker.cs`, `AlCoverageReport.cs`, `AlCoverageSourceMap.cs` | `--coverage` / `--coverage-out` — per-statement hit counts + Cobertura output, built on BC's own `StmtHit(N)` + `SourceSpans` line table |
+| `AlRunner/Infrastructure/AlDapSession.cs`, `DapTransport.cs`, `DapBreakpointResolver.cs`, `AlDapStackWalker.cs` | `--dap` debug-adapter mode. See `docs/dap-mode.md`. |
+| `AlRunner/ServerProtocol.cs`, `WatchSource.cs`, `WatchDashboard.cs` | `--server` (JSON-RPC daemon) and `--watch`. See `docs/server-mode.md`. |
 | `AlRunner/Infrastructure/RunnerOutOfScopeException.cs` | Typed OOS exception (named API + reason) |
-| `AlRunner/Patches/*.cs` | Per-API JMP-hook patches (CodeunitPatches, RecordPatches, MetadataPatches, NavRecordIdPatches, etc.) |
+| `AlRunner/Patches/*.cs` | Per-API patch bodies (CodeunitPatches, RecordPatches, MetadataPatches, NavRecordIdPatches, …). A body only runs if `NclCecilRewrite` routes to it — a `Hook(...)` call site with no Cecil owner is a **silent no-op**. Triage with `AL_RUNNER_HOOK_AUDIT=1`. |
 
 ## Exit codes
 
+Authoritative source: the `--strict` block in `PrintGuide()` (`AlRunner/Program.cs`).
+
 | Code | Meaning |
 |---|---|
-| 0 | All tests pass |
-| 1 | Test assertion failures, runner errors, or argument error |
-| 2 | Runner limitations only |
-| 3 | AL compilation error |
+| 0 | All tests passed |
+| 1 | At least one test FAILED or ERRORED |
+| 2 | A bundle could not execute (process-level error) — also a bad invocation: unknown flag, or a bundle path that does not exist |
+| 3 | A bundle could not compile |
+| 4 | `--count-baseline`: a suite's test or app-group count did not exactly match its declared baseline |
+
+`--no-strict-exit` forces exit 0 regardless, so a caller can parse the JSON output without failing the step.
 
 ## CLI flags
 
-Defined in `AlRunner/Program.cs`. Current set: `--out`, `--package-cache` (repeatable), `--cache`, `--isolation {codeunit|test|disabled}`, `--per-suite`, `--bundled` (no-op alias), `--verbose`, `--show-pass`, `--precompile <input.app>` (subcommand). Environment: `AL_RUNNER_VERBOSE`, `AL_RUNNER_SHOW_PASS`, `AL_RUNNER_TRACE_NRE`.
+**Do not take this list as authoritative — `AlRunner/Program.cs` is.** Run `al-runner --guide`
+(the operating manual written for automated callers) or `--help`, or grep Program.cs for
+`args[i] == "--`. The set as of 2026-08-27:
 
-No `--guide`, `--stubs`, `--coverage`, `--dap`, `extract-deps` — those were v1.
+`--artifact-path`, `--auto-provision`, `--bc-version`, `--bundled` (no-op alias for the default
+bundled mode), `--cache`, `--classify`, `--count-baseline`, `--coverage`, `--coverage-out`,
+`--dap [PORT]`, `--define`, `--dump-csharp`, `--emit-app`, `--expectations`, `--failures-only`,
+`--filter`, `--guide`, `--help`, `--isolation {codeunit|test|disabled}` (alias `--test-isolation`),
+`--no-auto-provision`, `--no-cache`, `--no-strict-exit`, `--out`, `--output-json`,
+`--output-junit`, `--package-cache` (repeatable), `--per-suite`, `--preprocessor-symbols`,
+`--print-cache-key`, `--quiet`, `--server`, `--show-pass` (v1 back-compat; PASS lines are on by
+default in v2), `--strict` (back-compat; the default since the v2 cut), `--tdd`, `--test`,
+`--test-timeout`, `--verbose`, `--version`, `--watch`. Subcommands: `provision`,
+`--precompile <input.app>`.
+
+Auto-provisioning is **on by default** (#2024) — `--no-auto-provision` is the opt-out for
+offline/air-gapped runs.
+
+Environment: ~39 `AL_RUNNER_*` variables; the ones worth knowing are `AL_RUNNER_VERBOSE`,
+`AL_RUNNER_TRACE_NRE`, `AL_RUNNER_HOOK_AUDIT` (live-vs-orphaned hook triage),
+`AL_RUNNER_HOOK_TRACE`, `AL_RUNNER_PHASE_LOG`, `AL_RUNNER_PERF`, `AL_RUNNER_NCL_CACHE`,
+`AL_RUNNER_TEST_TIMEOUT_SEC`. Full list: `grep -ohE 'AL_RUNNER_[A-Z0-9_]+' AlRunner -r --include=*.cs | sort -u`.
+
+`--stubs` and `extract-deps` were v1 and are gone (`docs/archive/extract-deps.md`).
+`--guide`, `--coverage` and `--dap` are **not** v1 leftovers — they are live v2 surfaces
+(`docs/dap-mode.md`, `.github/workflows/coverage-demo.yml`).
 
 ## Cecil migration freeze
 
-As of 2026-05-20, new runtime patches go through Cecil IL rewriting (`NclCecilRewrite`). Do not add new `JmpHook` patches. Existing JmpHook code migrates to Cecil opportunistically in hotspot order. See `docs/cecil-migration.md`.
+As of 2026-05-20, new runtime patches go through Cecil IL rewriting (`NclCecilRewrite`). Do not add new `JmpHook` patches — since the Cecil-only cutover a JmpHook call site does nothing at all. Existing JmpHook code migrates to Cecil opportunistically in hotspot order. See `docs/cecil-migration.md`.
+
+**Measured twice, both negative: re-enabling orphaned JmpHooks is a net loss** (−7 Pageworks passes; −42 corpus passes on 2026-08-21). The remedy for an orphaned hook is to migrate it to Cecil or delete it — never `AL_RUNNER_ENABLE_JMPHOOK=1`. Roughly half the remainder are silent-fake stubs that `.claude/rules/loud-failures.md` forbids reviving at all.
 
 ## Sister docs
 

--- a/.claude/skills/al-runner-tests/SKILL.md
+++ b/.claude/skills/al-runner-tests/SKILL.md
@@ -11,12 +11,16 @@ description: How AL tests are organised and run — the read-only al-language su
 tests/
   al-language/         ← git submodule, READ-ONLY (StefanMaron/BusinessCentral.AL.Language.Tests).
                          The canonical AL-language test corpus validated against a real BC service tier.
-                         Never edit. Bump the pin in its own PR.
+                         Never edit. Pin bump folds into the fix PR it enables — see below.
   expectations/        ← runner-owned JSON manifest declaring expected outcomes for corpus tests
                          the runner cannot or does not yet run.
                          - oos-<area>.json         out-of-scope-by-design
                          - known-gaps-<area>.json  in-scope but not yet implemented (links GH issue)
+                         - divergence-<area>.json  runner intentionally answers differently from BC
                          - disabled-<area>.json    won't compile or won't run; pure skip
+                         - count-baseline/         SEPARATE schema for --count-baseline; a
+                                                   subdirectory so the (non-recursive) --expectations
+                                                   scan never parses it as a classification array
   runner-extras/       ← runner-specific positive tests (e.g. "surface X throws OOS with reason Y")
   archive/             ← v1 buckets and fixtures, frozen, scheduled for deletion
 ```
@@ -30,14 +34,33 @@ dotnet build AlRunner.slnx -c Release
 dotnet run --project AlRunner -c Release -- tests/al-language/tests/al-language
 ```
 
-Useful flags (see `AlRunner/Program.cs` for the full list):
+**Match CI when you are proving something.** `.github/workflows/bc-tests.yml` runs the corpus as:
 
 ```bash
-# Show passes in addition to failures
-dotnet run --project AlRunner -c Release -- --show-pass tests/al-language/tests/al-language
+dotnet run --no-build --project AlRunner -c Release --framework net8.0 -- \
+    tests/al-language/tests/al-language \
+    --package-cache "$HOME/.al-runner/platform-apps" \
+    --strict \
+    --count-baseline tests/expectations/count-baseline/test-count-baseline.json \
+    --out al-language-results.json
+```
+
+and `tests/runner-extras` with a second `--package-cache "$HOME/.al-runner/test-apps"`. The
+`$HOME/.al-runner/platform-apps` cache is what `provision` / `--auto-provision` (on by default
+since #2024) and `tools/DownloadArtifacts` populate. A run without it falls back to whatever
+artifacts are cached, which is not necessarily the version the corpus declares.
+
+Useful flags (`--guide` and `AlRunner/Program.cs` are the full list):
+
+```bash
+# Only FAIL/ERROR lines (PASS lines are on by default in v2; --show-pass is a v1 no-op alias)
+dotnet run --project AlRunner -c Release -- --failures-only tests/al-language/tests/al-language
 
 # Verbose internal logs
 dotnet run --project AlRunner -c Release -- --verbose tests/al-language/tests/al-language
+
+# One test by name
+dotnet run --project AlRunner -c Release -- --test Record_Insert tests/al-language/tests/al-language
 
 # Test isolation modes
 dotnet run --project AlRunner -c Release -- --isolation codeunit  tests/al-language/tests/al-language
@@ -48,7 +71,7 @@ dotnet run --project AlRunner -c Release -- --isolation disabled  tests/al-langu
 dotnet run --project AlRunner -c Release -- --cache ~/.cache/al-runner/al-out tests/al-language/tests/al-language
 
 # Extra package caches for dep resolution (repeatable)
-dotnet run --project AlRunner -c Release -- --package-cache ~/.local/share/al-runner/packages tests/al-language/tests/al-language
+dotnet run --project AlRunner -c Release -- --package-cache "$HOME/.al-runner/platform-apps" tests/al-language/tests/al-language
 
 # JSON classification output
 dotnet run --project AlRunner -c Release -- --out results.json tests/al-language/tests/al-language
@@ -56,7 +79,7 @@ dotnet run --project AlRunner -c Release -- --out results.json tests/al-language
 
 ## Interpreting output
 
-Today the reporter prints raw PASS / FAIL / ERROR per test plus aggregate counts. Exit codes: `0` all pass, `1` real failures, `2` runner-limitations only, `3` AL compile error.
+Today the reporter prints raw PASS / FAIL / ERROR per test plus aggregate counts. Exit codes: `0` all passed, `1` at least one test FAILED or ERRORED, `2` a bundle could not execute (process-level error — also a bad invocation: unknown flag or a missing bundle path), `3` a bundle could not compile, `4` a `--count-baseline` count mismatch. `--no-strict-exit` forces `0`.
 
 `AlRunner/Infrastructure/ExpectationManifest.cs` loads the schema described in `docs/expectations.md` and is wired into the run, so results are additionally classified as:
 
@@ -121,10 +144,17 @@ git -C tests/al-language log --oneline HEAD..origin/master
 git -C tests/al-language diff HEAD..origin/master   # review
 git -C tests/al-language checkout origin/master
 git add tests/al-language
-git commit -m "Bump tests/al-language to <sha>"
 ```
 
-Tests that newly fail after the bump are runner gaps. Patch the runner (or add an expectation entry); never patch the corpus.
+**A pin bump cannot be its own PR — it is red by construction.** The new
+upstream tests it pulls in exist because they exercise a gap the runner does
+not yet handle; bumping the pin alone fails CI for that reason before anyone
+reviews it. Fold the pin bump into the **fix PR** that makes those new tests
+pass, together with the `tests/expectations/count-baseline/test-count-baseline.json`
+update (`--count-baseline` is an exact match — it fails on growth as well as
+shrinkage). Any other tests that newly fail after the bump are separate runner
+gaps: patch the runner or add an expectation entry for them; never patch the
+corpus.
 
 ## Sister docs
 

--- a/.claude/skills/al-runner-workflow/SKILL.md
+++ b/.claude/skills/al-runner-workflow/SKILL.md
@@ -22,7 +22,7 @@ If you are `impl-1` or `impl-2`:
 5. Implement red → green (`.claude/rules/tdd.md`). The right test depends on what kind of issue this is — see "Issue kinds" below.
 6. Open PR with `Closes #N` in the body. Label PR `agent: <your-id>` + `status: review-ready`. Assign to `@me`.
 7. Fix CI failures or review comments.
-8. Auto-merge fires when approved + green. Return to step 1.
+8. Auto-merge fires when approved + green (`allow_auto_merge=true` is a repo setting, not visible in the checkout). Return to step 1.
 
 **One issue at a time per impl agent.** No second claim while a PR is open.
 
@@ -48,6 +48,31 @@ If you are `orchestrator`:
 
 Workers self-select from the `status: ready` queue. The orchestrator does not assign issues to specific workers.
 
+## GitHub access: operation → tool map
+
+`.claude/rules/github-access.md` covers detecting whether `gh` is available.
+Once detected, here is which tool covers which operation:
+
+| Operation | `gh` | MCP tool |
+|---|---|---|
+| Who am I | `gh api user --jq .login` | `mcp__github__get_me` |
+| List issues | `gh issue list` | `mcp__github__list_issues` |
+| Read issue / its comments | `gh issue view` | `mcp__github__issue_read` (`get`, `get_comments`) |
+| Label / assign / close issue | `gh issue edit`, `gh issue close` | `mcp__github__issue_write` (`method: update`) |
+| Comment on issue or PR | `gh issue comment`, `gh pr comment` | `mcp__github__add_issue_comment` (PRs too — pass the PR number) |
+| List PRs | `gh pr list` | `mcp__github__list_pull_requests` |
+| PR detail / diff / files / CI | `gh pr view`, `gh pr diff`, `gh pr checks` | `mcp__github__pull_request_read` (`get`, `get_diff`, `get_files`, `get_check_runs`) |
+| Merge a PR | `gh pr merge --squash` | `mcp__github__merge_pull_request` (`merge_method: "squash"`) |
+| Open a PR | `gh pr create` | `mcp__github__create_pull_request` |
+| Label a PR | `gh pr edit --add-label` | `mcp__github__update_pull_request` |
+| Read failing CI logs | `gh run view --log-failed` | `mcp__github__get_job_logs` (`failed_only: true`, `return_content: true`) |
+| Search for duplicates | `gh issue list --search` | `mcp__github__search_issues` |
+
+Any agent definition granting `Bash` for GitHub work must also grant the
+`mcp__github__*` tools it needs (plus `ToolSearch`, since those tools are
+deferred) in its `tools:` frontmatter — otherwise the fallback is unavailable
+precisely where it is needed.
+
 ## Concurrency with human maintainers
 
 The **GitHub assignee field** is the boundary between agent-owned and human-owned work:
@@ -66,7 +91,7 @@ The **GitHub assignee field** is the boundary between agent-owned and human-owne
 - Set `status: review-ready` on the PR once CI is green.
 - One PR at a time per impl agent.
 - Never edit `CHANGELOG.md`.
-- Never edit `tests/al-language/`. Corpus bumps are their own PR.
+- Never edit a file inside `tests/al-language/`. A pin bump is folded into the fix PR it enables, never its own PR (`al-language-submodule.md`).
 - Honour the precompiled-DLL contract (`.claude/rules/precompiled-dll-respect.md`) and loud-failures rule (`.claude/rules/loud-failures.md`).
 - `--repo StefanMaron/BusinessCentral.AL.Runner` on every `gh` command when running outside the repo's default.
 

--- a/.claudeignore
+++ b/.claudeignore
@@ -2,6 +2,6 @@ cobertura.xml
 **/bin/
 **/obj/
 .claude/worktrees/
-tests/excluded/
+tests/archive/
 CHANGELOG.md
 *.app

--- a/.github/ISSUE_TEMPLATE/runner-gap.md
+++ b/.github/ISSUE_TEMPLATE/runner-gap.md
@@ -48,26 +48,33 @@ codeunit 50101 MyCodeunitTest
 
 ## Root cause
 
-<!-- What BC runtime type or method is missing / crashing? -->
-<!-- e.g. "MockRecordRef does not have ALName" or "NavSession is null when ALIsInWriteTransaction() is called" -->
+<!-- Which BC runtime type or method is missing / crashing? -->
+<!-- e.g. "NavRecordRef.ALName has no Cecil rewrite" or "NavSession is null when ALIsInWriteTransaction() is called" -->
+<!-- Tip: AL_RUNNER_HOOK_AUDIT=1 names patch call sites that are silent no-ops. -->
 
 ## Expected behavior
 
-<!-- What should happen in standalone mode? -->
-<!-- e.g. "Return false (no write transaction in runner)", "Return empty string stub", "No-op" -->
+<!-- What does REAL BC do here? That is the target — the runner matches BC or throws loudly. -->
+<!-- A silent stub / no-op / default return is never the answer: see .claude/rules/loud-failures.md. -->
+<!-- If the surface is permanently out of scope, the expected behavior is
+     RunnerOutOfScopeException with a named API + a reason from docs/scope.md. -->
 
 ## Likely fix
 
 <!-- Where is the fix? Pick one: -->
-- [ ] Add stub/method to `Runtime/MockXxx.cs`
-- [ ] Add rewriter rule in `RoslynRewriter.cs`
-- [ ] New mock class needed
-- [ ] New built-in AL stub in `stubs/`
+- [ ] Cecil rewrite in `AlRunner/Infrastructure/NclCecilRewrite.cs` routing to a new/existing patch body
+- [ ] New or extended patch under `AlRunner/Patches/`
+- [ ] Compile-pipeline fix in `AlRunner/BcCompiler.cs` / `AlRunner/BcAssembler.cs`
+- [ ] Skeleton state the BC method reads (`NavSession`, `NavMethodScope`, …) is missing/unpopulated
+- [ ] Out of scope by design → `tests/expectations/oos-<area>.json` entry + a loud throw
 - [ ] Other: <!-- describe -->
 
 ## Acceptance criteria
 
-- [ ] Test case `tests/NN-name/` added with positive + negative cases
+- [ ] Proving test with positive + negative (`asserterror` + `Assert.ExpectedError`) cases.
+      A test of plain BC behavior goes UPSTREAM in `StefanMaron/BusinessCentral.AL.Language.Tests`;
+      only runner-specific claims go in `tests/runner-extras/`.
+      See `.claude/rules/bc-behavior-tests-go-upstream.md`.
 - [ ] RED confirmed before fix, GREEN after
-- [ ] Full regression passes
-- [ ] CHANGELOG updated under `[Unreleased]`
+- [ ] CI matrix green on the PR's own head commit
+- [ ] Do NOT edit `CHANGELOG.md` — it is generated post-merge (`.claude/rules/no-changelog-edits.md`)

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -15,12 +15,12 @@ When you receive a **PR review request**, you are a **code reviewer**. Apply the
 3. Implement following the TDD rules below — failing test first, then fix.
 4. Open PR with `Closes #N` in the body. Add labels `agent: <your-id>` and `status: review-ready`.
 5. Fix any CI failures or review comments that come back.
-6. Auto-merge fires once approved and CI is green.
+6. Auto-merge fires once approved and CI is green (`allow_auto_merge=true` is a repo setting, not visible in the checkout).
 
 **Hard rules:**
 - Never push directly to `main`.
 - Never edit `CHANGELOG.md` (auto-generated from squash-commit messages post-merge).
-- Never edit anything under `tests/al-language/` — that submodule is read-only. Corpus bumps are their own PR (`.claude/rules/al-language-submodule.md`).
+- Never edit a file under `tests/al-language/` — that submodule is read-only. A pin bump is folded into the fix PR it enables, never its own PR (`.claude/rules/al-language-submodule.md`).
 - Honour the precompiled-DLL contract: do not rewrite method bodies or rename types in MS / ISV business-logic DLLs (`.claude/rules/precompiled-dll-respect.md`).
 - Every unsupported surface must throw `RunnerOutOfScopeException` with a named API and reason from `docs/scope.md`. Never silently return a default (`.claude/rules/loud-failures.md`).
 
@@ -38,12 +38,13 @@ AlRunner/                      — runner source
   AppLoader.cs                 — load real MS / ISV .app DLLs in-process
   DependencyLoader.cs          — 3-tier dep resolution (precompiled / loose / compiled-from-source)
   Reporter.cs                  — JSON classification output
-  Patches/*.cs                 — per-API JMP-hook patches
+  Patches/*.cs                 — per-API patch bodies, only live if NclCecilRewrite routes to them
   Infrastructure/
-    NclCecilRewrite.cs         — one-time Cecil rewrite of Ncl.dll, cached
-    JmpHook.cs                 — legacy JMP-hook mechanism (Cecil-freeze rule applies to new patches)
-    ExpectationManifest.cs     — schema + loader for tests/expectations (not yet wired into Reporter)
+    NclCecilRewrite.cs         — one-time Cecil rewrite of Ncl.dll, cached; the only live patch mechanism
+    JmpHook.cs                 — legacy JMP-hook mechanism, disabled by default; a new call site is a silent no-op
+    ExpectationManifest.cs     — schema + loader for tests/expectations, wired into the run via Program.cs/TestExecutor
     RunnerOutOfScopeException.cs — typed OOS exception
+AlRunner.Tests/                — C# unit-test project (dotnet test AlRunner.Tests); mechanism-level tests, not AL
 tests/al-language/             — git submodule, canonical corpus (READ-ONLY)
 tests/expectations/            — JSON manifest declaring expected outcomes for corpus tests
 tests/runner-extras/           — runner-specific positive tests
@@ -54,7 +55,7 @@ tools/                         — DownloadArtifacts (used by AlRunner.csproj), 
 scripts/                       — al-inventory.py, coverage-gen.js
 ```
 
-The v1 layout (`tests/bucket-1/`, `tests/bucket-2/`, AlRunner.Tests/, stubs/, Runtime/MockX.cs, RoslynRewriter, DepCompiler, DAP server, `extract-deps`) has been removed. Do not reference it. There is no C# unit-test project.
+The v1 layout (`tests/bucket-1/`, `tests/bucket-2/`, stubs/, Runtime/MockX.cs, RoslynRewriter, DepCompiler, `extract-deps`) has been removed. Do not reference it. `AlRunner.Tests/` is current, not v1 — it is the C# unit-test project both `bc-tests.yml` and `pr-check.yml` depend on.
 
 ---
 
@@ -76,7 +77,7 @@ dotnet run --project AlRunner -c Release -- --isolation test tests/al-language/t
 dotnet run --project AlRunner -c Release -- --cache ~/.cache/al-runner/al-out tests/al-language/tests/al-language
 ```
 
-Exit codes: `0` all pass, `1` real failures or arg error, `2` runner limitations, `3` AL compile error.
+Exit codes: `0` all tests passed, `1` a test failed/errored, `2` a bundle could not execute (process-level error, or a bad invocation), `3` a bundle could not compile, `4` a `--count-baseline` mismatch.
 
 ---
 
@@ -134,7 +135,7 @@ Flag any patch that silently returns a default value for an unsupported surface.
 
 `tests/al-language/` is read-only. Flag any PR that:
 - Edits files under `tests/al-language/` directly.
-- Bundles a submodule pin bump with unrelated runner changes (corpus bumps are their own PR).
+- Bumps the submodule pin with no accompanying fix in the same PR — a pin bump alone is red by construction and belongs folded into the fix PR it enables.
 
 ## Code quality
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -162,7 +162,7 @@ Pull requests run against a matrix of BC versions. A PR cannot merge unless ever
 dotnet run --project AlRunner -c Release -- tests/al-language/tests/al-language
 ```
 
-Exit code 2 is "runner limitations only" — not a fail in itself, but treat it as work-to-do. Exit codes 1 and 3 always fail CI.
+Exit codes: `0` all tests passed, `1` a test failed/errored, `2` a bundle could not execute (process-level error, or a bad invocation), `3` a bundle could not compile, `4` a `--count-baseline` mismatch. All non-zero codes fail CI.
 
 ---
 
@@ -178,3 +178,11 @@ All loaded automatically by `.claude/` in agent sessions. Read them once:
 - `.claude/rules/no-changelog-edits.md` — never touch `CHANGELOG.md`.
 - `.claude/rules/al-language-submodule.md` — the corpus is read-only.
 - `.claude/rules/file-issues-for-gaps.md` — gaps go to issues + expectation entries, never silent workarounds.
+- `.claude/rules/github-access.md` — `gh` is absent in web/remote sessions; detect and fall back to `mcp__github__*`.
+- `.claude/rules/bc-behavior-tests-go-upstream.md` — a test of plain BC behaviour goes upstream in the corpus, never `tests/runner-extras/`.
+- `.claude/rules/no-git-stash-with-worktrees.md` — the stash is shared across every worktree; never use it here.
+- `.claude/rules/ci-verdicts.md` — a CI verdict is per-commit-SHA; never re-run a failed job; "unrelated flake" needs evidence.
+- `.claude/rules/local-test-scope.md` — run the tests your change touches locally; the full suite/corpus is CI's job.
+- `.claude/rules/no-backgrounding-long-commands.md` — a backgrounded process dies with your turn; run long commands in the foreground.
+- `.claude/rules/pr-ci-monitoring.md` — check merge conflicts before CI status; drive a PR to merge, don't stop at "opened".
+- `.claude/rules/public-posting-approval.md` — filing issues on this repo needs no approval; comments, PR review comments, and anything on another repo do.

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ al-runner tests/al-language/tests/al-language
 al-runner ./app1 ./app2
 
 # Specify package caches for dependency resolution (repeatable)
-al-runner --package-cache ~/.local/share/al-runner/packages tests/al-language/tests/al-language
+al-runner --package-cache "$HOME/.al-runner/platform-apps" tests/al-language/tests/al-language
 
 # Choose test isolation (matches BC's "Test Runner - Isol. Codeunit" by default)
 al-runner --isolation codeunit ./my-bundle

--- a/docs/upstream-corpus-workflow.md
+++ b/docs/upstream-corpus-workflow.md
@@ -1,0 +1,62 @@
+# Why BC-behaviour tests go upstream, and the full workflow rationale
+
+This is the supporting argument and detail for
+`.claude/rules/bc-behavior-tests-go-upstream.md`. The rule states the
+requirement; this doc carries the justification so the rule stays short
+enough to load into every session.
+
+## Why — a runner-local BC test proves nothing
+
+The corpus is the spec *because* every test in it has been run against real
+BC. A BC-behaviour test that has only ever run against AL Runner is not
+evidence about BC; it is a transcript of **our belief** about BC, written by
+the same reasoning that wrote the runtime.
+
+So when the runner is wrong, such a test does not fail — it was authored to
+match what the runner did. It goes green, the bug is now pinned as intended
+behaviour, and every future change is measured against the wrong baseline.
+The suite gets louder and less trustworthy at the same time.
+
+That is the whole argument in one line: an unvalidated BC test cannot prove
+the runner correct, because it inherits the runner's errors as its
+expectations. Green means "the runner agrees with itself".
+
+## Step 2 in full — verifying against real BC
+
+A local BC container with the BC repository is a perfectly good way to check
+a new upstream test: publish the app, run the test, confirm it passes for the
+reason you think it does. This step exists to stop you sending a broken or
+wrongly-asserted test upstream — it does not by itself put the test in the
+corpus.
+
+The corpus repo's own CI is also a real service tier, and is the stronger
+check of the two. `.github/workflows/ci.yml` there boots a real BC sandbox on
+Linux (via `StefanMaron/MsDyn365Bc.On.Linux`) and runs the suite against **BC
+27.5 and 28.3**, `fail-fast: false`. So a green PR check upstream *is* the
+service-tier adjudication this rule demands, on two BC versions. If you have
+no local container, opening the PR and letting CI run is a legitimate way to
+perform step 2 — not a way to skip it. Having no container is the normal case
+for agents in web/remote sessions and is fully handled by this workflow.
+
+## Step 3 in full — why the orchestrator merges, not the authoring agent
+
+An impl agent opens the corpus PR and stops there. The orchestrator reviews
+it and merges once both BC legs are green. This split is deliberate — an
+agent merging its own test means the same reasoning that wrote the test also
+clears it, which is this rule's original failure mode relocated from
+"unvalidated" to "unreviewed". Green CI proves the test *runs and passes
+against real BC*; an independent read is what proves it *asserts something*.
+
+Green CI is necessary, not sufficient. A test that asserts a default value,
+or that would pass against a stub returning `0` / `''` / `false`, goes green
+just as reliably as a good one. Before merging, apply `tdd.md`'s test: would
+this still pass if the implementation were gutted? If yes it is noise — send
+it back rather than merge it. Both directions (positive + `asserterror` with
+a specific expected message) still apply upstream.
+
+## Why two PRs in that order, never one
+
+A runner fix for a BC-behaviour gap is normally two PRs in two repos, corpus
+first, runner second. Do not merge the runner change and leave the upstream
+test as a promise — once the fix is in, nothing forces the test to follow,
+and the gap quietly becomes untested behaviour.


### PR DESCRIPTION
Closes #2081

Lands the repo-owner-approved cleanup pass on the agent instruction surface (`.claude/rules/`, `.claude/skills/`, `.claude/agents/`, `.claude/commands/work-cycle.md`, `.github/ISSUE_TEMPLATE/runner-gap.md`, `.github/copilot-instructions.md`, `.claudeignore`, `CONTRIBUTING.md`, `README.md`).

## What changed

1. **Committed `.claude/rules/no-git-stash-with-worktrees.md`** — it was untracked, so it never applied to a fresh worktree or web session. Added a "polling loops must not match themselves" (`pgrep -f` self-matching) section.
2. **New `.claude/rules/ci-verdicts.md`** — a CI verdict is about one commit (check the check's SHA against `HEAD`, don't trust a stale `gh pr checks` read); never re-run a failed job (destroys the log); "pre-existing unrelated flake" needs evidence, not a claim.
3. **New `.claude/rules/local-test-scope.md`** — targeted local runs (what you touched + your new tests); the full `dotnet test` suite and the 2000+-test AL corpus are CI's job, with two exceptions (RED baseline, cache-sensitive changes).
4. **Deleted `tests/.claude/`** — gitignored, untracked, never part of this repo; it was 12 KB of unrelated customer AL-consulting instructions plus a plugin-enabling `settings.json` that loaded for any session with cwd under `tests/`. No tracked diff results from this (it was never in git), noted here for the record.
5. **Trimmed the two heaviest always-loaded rules** — `bc-behavior-tests-go-upstream.md` (7,033 B → 4,194 B) and `github-access.md` (4,234 B → 2,257 B) — moving justification/reference material to `docs/upstream-corpus-workflow.md` and the `al-runner-workflow` skill while keeping every requirement in place.
6. **Fixed the three-way corpus-pin contradiction.** The correct rule: a pin bump can never be its own PR — it's red by construction (the new corpus tests fail without the accompanying runner fix) — so it folds into the fix PR together with the `tests/expectations/count-baseline/test-count-baseline.json` update. This was stated wrong (or inconsistently) in six places; all six now agree: `al-runner-tests` skill (the ASCII-tree comment *and* the "Bumping the corpus pin" section), `al-language-submodule.md`, `al-runner-workflow` skill, `impl-agent.md`, `orchestrator.md`, `copilot-instructions.md`.
7. **Removed the dead telemetry-issue branches.** #1643 (telemetry) closed not-planned on 2026-08-27; v2 has no telemetry. Removed the telemetry-authored/human-reported distinction and the "thin telemetry issue" carve-out from `triager.md`, and the telemetry reference in `work-cycle.md`. Pointed at `--guide` + #2071 (the human-in-the-loop filing channel) instead.
8. **New `.claude/rules/public-posting-approval.md`.** Owner's standing preference: draft and get approval before posting public-facing content, use the `plain-language` skill for outward-facing writing. Narrow carve-out stated exactly: filing issues on this repo needs no approval; comments, PR review comments, and anything posted to another repo do. Referenced from all three agent definitions.
9. **Smaller confirmed fixes:**
   - Noted auto-merge (`allow_auto_merge=true`) is a repo setting, not visible in the checkout, everywhere it's claimed (`al-runner-workflow` skill, `orchestrator.md`, `copilot-instructions.md`).
   - Fixed `copilot-instructions.md`'s stale "there is no C# unit-test project" / "`AlRunner.Tests/` was removed" claims (it exists, has dozens of files, and both `bc-tests.yml` and `pr-check.yml` depend on it) and its repeated "`ExpectationManifest` not yet wired" error (it is wired, via `Program.cs`/`TestExecutor`).
   - Fixed `.claudeignore`'s dead `tests/excluded/` entry (moved to `tests/archive/excluded/` at the v1→v2 cutover) — now ignores `tests/archive/` (9 subtrees).
   - Updated `CONTRIBUTING.md`'s rule inventory (8 listed, 16 now exist) and its stale exit-code claim.
   - Fixed `README.md`'s invented `--package-cache ~/.local/share/al-runner/packages` example to match what CI actually uses (`"$HOME/.al-runner/platform-apps"`).
   - Removed two verbatim-duplicated paragraphs in `impl-agent.md`.
10. **Moved rule-shaped content out of `impl-agent.md`** into `.claude/rules/no-backgrounding-long-commands.md` and `.claude/rules/pr-ci-monitoring.md` so the orchestrator and triager see this guidance too (previously only impl agents did). Collapsed restated boilerplate (assignee-`@me` boundary, `tests/al-language` read-only, `coverage.yaml` note) into one-line pointers across the three agent definitions.

## Byte accounting for `.claude/rules/` (auto-loaded every session)

- Before (origin/main, 10 tracked files): 26,887 B
- After (16 files): 32,351 B — net **+5,464 B**

This is a net increase, not a decrease, and that's expected: items 2/3/8/10 explicitly call for new rule files that make content previously visible only to impl agents (buried in `impl-agent.md`) available to every agent via `.claude/rules/`. Isolating just the item-5 trim (the two files targeted for that specific cut): `bc-behavior-tests-go-upstream.md` + `github-access.md` dropped from 11,267 B to 6,451 B combined — a **-4,816 B** saving on those two files, matching the "-5 KB" target for that item specifically.

## Testing

This PR only touches Markdown/instruction files — no `AlRunner/` source changed. Per `.claude/rules/local-test-scope.md`, ran the test explicitly called out as able to break from these edits:

- `dotnet test AlRunner.Tests --filter "FullyQualifiedName~CliDocumentationTests"` — hit a pre-existing local build-environment issue (`CS1705`, a `Microsoft.Dynamics.Nav.CodeAnalysis` version mismatch between cached BC artifacts) unrelated to this diff — confirmed via `git diff --stat -- '*.cs' '*.csproj' '*.slnx'` showing zero code changes in this PR. CI runs in a clean environment and will be the actual verdict; will monitor.

No `no-tests-needed` / `docs-only` label needed — this diff doesn't touch `AlRunner/`, so `pr-check.yml`'s `require-tests` gate doesn't trigger.
