### PR TITLE
fix(provision): detect transitive Application Test Library need, target the selected BC version

### DIFF
--- a/AlRunner.Tests/ProvisioningCheckTests.cs
+++ b/AlRunner.Tests/ProvisioningCheckTests.cs
@@ -680,6 +680,44 @@ public sealed class ProvisioningCheckTests : IDisposable
         Assert.False(needs.NeedsTestApps);
     }
 
+    [Fact]
+    public void DetermineManifestNeeds_TestsTestLibrariesDependency_AlsoNeedsPlatform()
+    {
+        // Issue #2073: a bundle depending on "Tests-TestLibraries" (already recognized as a
+        // test-framework root, hence NeedsTestApps) never names "Application Test Library"
+        // directly — but Tests-TestLibraries' OWN manifest declares it as a dependency
+        // (confirmed via the real Microsoft NavxManifest.xml, v28.1.49838.53910:
+        // <Dependency Id="d852d5d2-a39d-4179-baeb-f99a19e32510" Name="Application Test
+        // Library" Publisher="Microsoft" .../> — the exact AppId the issue's "Missing:"
+        // error names). Before the fix this root produced NeedsPlatformApps == false, so
+        // `provision` reported "already present" and downloaded nothing.
+        var roots = new[]
+        {
+            new DependencyRef(Guid.NewGuid(), "Tests-TestLibraries", "Microsoft", new Version(28, 1, 0, 0)),
+        };
+        var needs = ProvisioningCheck.DetermineManifestNeeds(roots);
+        Assert.True(needs.NeedsPlatformApps);
+        Assert.True(needs.NeedsTestApps);
+    }
+
+    [Fact]
+    public void DetermineManifestNeeds_TestsTestLibrariesDependency_ImpliesDownloadWhenAbsent()
+    {
+        // The end-to-end shape of the issue's repro: a bundle naming only
+        // "Tests-TestLibraries", with an empty package cache (nothing provisioned yet).
+        // DecideManifestProvisioning must say a platform-apps download is needed — this is
+        // the pure decision `provision`'s "platform R2R apps already present" message was
+        // wrongly skipping.
+        var roots = new[]
+        {
+            new DependencyRef(Guid.NewGuid(), "Tests-TestLibraries", "Microsoft", new Version(28, 1, 0, 0)),
+        };
+        var legacyReport = ProvisioningCheck.CheckPlatformApps("28.1.49838.50794", Array.Empty<string>());
+        var decision = ProvisioningCheck.DecideManifestProvisioning(roots, legacyReport, Array.Empty<string>());
+        Assert.True(decision.NeedsPlatformApps);
+        Assert.True(decision.ShouldDownloadPlatform);
+    }
+
     // ── NoFallbackPlatformAppsPresent ──────────────────────────────────────────
     // Deliberately narrower than "all curated platform apps present": System/Base
     // Application and Business Foundation have a service-tier DLL dispatch fallback (the
@@ -1056,5 +1094,56 @@ public sealed class ProvisioningCheckTests : IDisposable
 
         Assert.True(decision.PlatformComplete);
         Assert.False(decision.ShouldDownloadPlatform);
+    }
+
+    // ── ResolveProvisionMajorMinor / BuildProvisionVersionSkewNote (issue #2077) ──────────
+    // `--bc-version 28.4` was observed provisioning 28.1 platform apps because the
+    // provisioning minor used to be DERIVED from whatever was already in the package cache
+    // (a project's committed `.alpackages`, or a stale symbol-only app) instead of the BC
+    // version the run had already selected. These prove the decision in isolation, and the
+    // loud note the fix emits when the cache disagrees with the selection.
+
+    [Fact]
+    public void ResolveProvisionMajorMinor_AlwaysUsesSelectedVersion_IgnoresCache()
+    {
+        // The exact repro shape: engine/selection is 28.4, regardless of anything found on
+        // disk elsewhere — this function takes no cache input at all, by design.
+        var mm = ProvisioningCheck.ResolveProvisionMajorMinor("28.4.53241.53989");
+        Assert.Equal("28.4", mm);
+    }
+
+    [Fact]
+    public void ResolveProvisionMajorMinor_ShortVersion_ReturnedAsIs()
+    {
+        var mm = ProvisioningCheck.ResolveProvisionMajorMinor("28");
+        Assert.Equal("28", mm);
+    }
+
+    [Fact]
+    public void BuildProvisionVersionSkewNote_CacheAgrees_ReturnsNull()
+    {
+        var note = ProvisioningCheck.BuildProvisionVersionSkewNote("28.4", "28.4", "platform apps in cache");
+        Assert.Null(note);
+    }
+
+    [Fact]
+    public void BuildProvisionVersionSkewNote_CacheDisagrees_NamesBothVersionsLoudly()
+    {
+        // The Pageworks.Bench repro: selected 28.4, but the bundle's committed
+        // `.alpackages` vendors a 28.1 symbol closure. The note must name BOTH versions —
+        // a vague "version mismatch" would not tell a reader which one actually got used.
+        var note = ProvisioningCheck.BuildProvisionVersionSkewNote(
+            "28.4", "28.1", "platform apps already in the package cache");
+        Assert.NotNull(note);
+        Assert.Contains("28.1", note);
+        Assert.Contains("28.4", note);
+        Assert.Contains("SELECTED", note);
+    }
+
+    [Fact]
+    public void BuildProvisionVersionSkewNote_CaseInsensitiveAgreement_ReturnsNull()
+    {
+        var note = ProvisioningCheck.BuildProvisionVersionSkewNote("28.4", "28.4", "x");
+        Assert.Null(note);
     }
 }

--- a/AlRunner/Infrastructure/ProvisioningCheck.cs
+++ b/AlRunner/Infrastructure/ProvisioningCheck.cs
@@ -197,20 +197,63 @@ public static class ProvisioningCheck
     }
 
     /// <summary>
-    /// Derives the BC major.minor to auto-provision platform apps for. The engine is
-    /// version-agnostic w.r.t. the R2R apps it dispatches to at runtime, so the minor to
-    /// download is the one the MISSING apps actually need (carried in
-    /// <paramref name="report"/>.Issues[0].AppVersion) — NOT the engine's own
-    /// <paramref name="fallbackVersion"/> (SelectedVersion), which can be a different minor
-    /// (e.g. engine 28.1 running 28.2 R2R business logic). Falls back to
-    /// <paramref name="fallbackVersion"/>'s major.minor when there are no issues. Pure —
-    /// does no I/O.
+    /// Derives the BC major.minor a symbol-only platform app already in the cache would
+    /// suggest for auto-provisioning. Carried in <paramref name="report"/>.Issues[0]
+    /// .AppVersion when one exists; falls back to <paramref name="fallbackVersion"/>'s
+    /// major.minor otherwise. Pure — does no I/O.
+    ///
+    /// Issue #2077: this used to be the value callers actually downloaded — "the engine is
+    /// version-agnostic w.r.t. the R2R apps it dispatches to, so download whatever the
+    /// on-disk symbol-only app needs" sounds reasonable until the app already in the cache
+    /// is simply a STALE artifact (a project's committed `.alpackages`, an old warm run) at
+    /// a DIFFERENT minor than the BC version the caller explicitly selected — then this
+    /// silently redirected the whole provisioning pass to that stale minor instead. Once a
+    /// BC version has been selected, provisioning MUST target that version — see
+    /// <see cref="ResolveProvisionMajorMinor"/>, the function callers now use for the
+    /// actual decision. This one is kept only as a pure cache-inspection signal, e.g. to
+    /// build the loud mismatch note <see cref="BuildProvisionVersionSkewNote"/> emits when
+    /// the cache disagrees with the selection.
     /// </summary>
     public static string DeriveProvisionMajorMinor(PlatformAppsReport report, string fallbackVersion)
     {
         var source = report.Issues.Count > 0 ? report.Issues[0].AppVersion : fallbackVersion;
-        var parts = source.Split('.');
-        return parts.Length >= 2 ? string.Join(".", parts.Take(2)) : source;
+        return MajorMinorOf(source);
+    }
+
+    /// <summary>
+    /// The BC major.minor to actually auto-provision platform apps/the test toolkit for:
+    /// always <paramref name="selectedVersion"/>'s own major.minor (issue #2077 — once a BC
+    /// version is selected, provisioning targets THAT version, never one derived from cache
+    /// contents, a symbol-only closure, or a project's vendored `.alpackages`). Pure — does
+    /// no I/O.
+    /// </summary>
+    public static string ResolveProvisionMajorMinor(string selectedVersion) => MajorMinorOf(selectedVersion);
+
+    /// <summary>Shared major.minor extraction used by the Derive*/Resolve* helpers above.</summary>
+    private static string MajorMinorOf(string version)
+    {
+        var parts = version.Split('.');
+        return parts.Length >= 2 ? string.Join(".", parts.Take(2)) : version;
+    }
+
+    /// <summary>
+    /// Issue #2077 acceptance criterion: "if the runner ever compiles against platform apps
+    /// whose build differs from the selected engine build, it says so explicitly." Returns
+    /// a loud one-line note when <paramref name="cacheDerivedMajorMinor"/> — what the
+    /// package cache alone would have suggested (<see cref="DeriveProvisionMajorMinor"/> /
+    /// <see cref="DerivePresentPlatformMajorMinor"/>) — disagrees with
+    /// <paramref name="selectedMajorMinor"/> (what <see cref="ResolveProvisionMajorMinor"/>
+    /// actually provisions). Null when they agree, so callers can
+    /// `if (note != null) Console.Error.WriteLine(note);` unconditionally. Pure.
+    /// </summary>
+    public static string? BuildProvisionVersionSkewNote(
+        string selectedMajorMinor, string cacheDerivedMajorMinor, string cacheSource)
+    {
+        if (string.Equals(selectedMajorMinor, cacheDerivedMajorMinor, StringComparison.OrdinalIgnoreCase))
+            return null;
+        return $"[provision] note: {cacheSource} suggest(s) BC {cacheDerivedMajorMinor}.x, which differs from " +
+               $"the selected BC {selectedMajorMinor}.x — provisioning platform R2R apps for the SELECTED " +
+               $"version, not the cache's.";
     }
 
     /// <summary>
@@ -300,14 +343,24 @@ public static class ProvisioningCheck
     }
 
     /// <summary>
-    /// Derives the BC major.minor to auto-provision FROM WHAT'S ALREADY IN THE CACHE: scans
-    /// <paramref name="packageCacheDirs"/> for a Microsoft "Base Application" or "System
-    /// Application" .app and returns its major.minor. Used when there's no
-    /// <see cref="PlatformAppsReport"/> issue to derive from (e.g. platform apps are already
-    /// R2R-complete but the test toolkit is still missing) — we still need SOME minor to
-    /// resolve a full artifact version for the test-toolkit download, and the platform apps
-    /// already in the cache are the most reliable signal of which minor this project targets.
-    /// Falls back to <paramref name="fallbackVersion"/>'s major.minor when no such app is found.
+    /// The BC major.minor a Microsoft "Base Application"/"System Application" .app already
+    /// present in <paramref name="packageCacheDirs"/> would suggest for auto-provisioning.
+    /// Falls back to <paramref name="fallbackVersion"/>'s major.minor when no such app is
+    /// found. Pure filesystem scan — no network.
+    ///
+    /// Issue #2077: this used to be the value callers actually downloaded whenever no
+    /// symbol-only-R2R issue existed — "the platform apps already in the cache are the most
+    /// reliable signal of which minor this project targets" sounds reasonable until the
+    /// apps already in the cache are simply a committed `.alpackages` symbol closure at a
+    /// DIFFERENT minor than the BC version the caller explicitly selected (e.g. `--bc-
+    /// version 28.4` with a project-vendored 28.1 closure) — then this silently redirected
+    /// the whole provisioning pass to that unrelated minor instead, and the run went on to
+    /// compile against it while reporting `[bc] selected BC 28.4...`. Once a BC version has
+    /// been selected, provisioning MUST target that version — see
+    /// <see cref="ResolveProvisionMajorMinor"/>, the function callers now use for the
+    /// actual decision. This one is kept only as a pure cache-inspection signal, e.g. to
+    /// build the loud mismatch note <see cref="BuildProvisionVersionSkewNote"/> emits when
+    /// the cache disagrees with the selection.
     /// </summary>
     public static string DerivePresentPlatformMajorMinor(
         IReadOnlyList<string> packageCacheDirs, string fallbackVersion)
@@ -323,13 +376,10 @@ public static class ProvisioningCheck
                 if (!string.Equals(m.Name, "Base Application", StringComparison.OrdinalIgnoreCase)
                     && !string.Equals(m.Name, "System Application", StringComparison.OrdinalIgnoreCase))
                     continue;
-                var v = m.Version.ToString();
-                var vparts = v.Split('.');
-                return vparts.Length >= 2 ? string.Join(".", vparts.Take(2)) : v;
+                return MajorMinorOf(m.Version.ToString());
             }
         }
-        var parts = fallbackVersion.Split('.');
-        return parts.Length >= 2 ? string.Join(".", parts.Take(2)) : fallbackVersion;
+        return MajorMinorOf(fallbackVersion);
     }
 
     // ── Auto-provision download destination (issue #1653) ────────────────────
@@ -396,6 +446,26 @@ public static class ProvisioningCheck
     };
 
     /// <summary>
+    /// Microsoft app names whose OWN manifest transitively depends on a
+    /// <see cref="KnownNoFallbackPlatformApps"/> member, even though the DEPENDENT never
+    /// names that app directly (issue #2073). <see cref="DetermineManifestNeeds"/> only
+    /// sees the roots a bundle's own app.json declares — it can't read a not-yet-downloaded
+    /// dependency's manifest to discover ITS dependencies — so a bundle that names
+    /// "Tests-TestLibraries" but never "Application Test Library" read as not needing the
+    /// platform-apps set at all, and `provision` reported success while downloading
+    /// nothing. Confirmed via the real Microsoft NavxManifest.xml (Tests-TestLibraries
+    /// v28.1.49838.53910 declares `&lt;Dependency Id="d852d5d2-a39d-4179-baeb-f99a19e32510"
+    /// Name="Application Test Library" Publisher="Microsoft" .../&gt;` — the exact AppId the
+    /// issue's "Missing:" error names). Recorded here the same way
+    /// <see cref="KnownNoFallbackPlatformApps"/> records real app names, so the pre-scan can
+    /// see the edge without ever reading the dependency's own manifest.
+    /// </summary>
+    public static readonly IReadOnlyList<string> KnownTransitiveNoFallbackPlatformDependents = new[]
+    {
+        "Tests-TestLibraries",
+    };
+
+    /// <summary>
     /// Real Microsoft app names supplied by the curated `test-apps` download (platform
     /// artifact's Applications/&lt;area&gt;/Test + TestFramework trees — see
     /// ArtifactDownloader.TestApps). Deliberately a closed allowlist, NOT "any Microsoft
@@ -442,6 +512,18 @@ public static class ProvisioningCheck
             }
             if (KnownTestFrameworkAppNames.Any(n => string.Equals(n, d.Name, StringComparison.OrdinalIgnoreCase)))
                 needsTest = true;
+            // Issue #2073: a root naming e.g. "Tests-TestLibraries" (already caught by
+            // KnownTestFrameworkAppNames above, for needsTest) ALSO transitively drags in
+            // "Application Test Library" — a KnownNoFallbackPlatformApps member — via that
+            // dependency's own manifest, which this pre-scan cannot read. Without this, a
+            // bundle shaped exactly like the issue's repro (names Tests-TestLibraries,
+            // never Application Test Library directly) read as needing no platform apps at
+            // all, and `provision` reported success while downloading nothing.
+            if (KnownTransitiveNoFallbackPlatformDependents.Any(n => string.Equals(n, d.Name, StringComparison.OrdinalIgnoreCase)))
+            {
+                needsPlatform = true;
+                needsTest = true;
+            }
         }
         return new ManifestNeeds(needsPlatform, needsTest);
     }

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -1132,17 +1132,29 @@ if (!provisionSubcommand)
 
     if (autoProvision && decision.ShouldDownloadAny)
     {
-        // Resolve ONE target full version and reuse it for both artifact sets — avoids
-        // resolving two different minors for what should be the same provisioning pass.
-        // Priority: (a) the missing/symbol-only platform apps carry their OWN version
-        // (the engine is version-agnostic w.r.t. the R2R apps it dispatches to at
-        // runtime, so this can be a different minor than the engine's SelectedVersion);
-        // (b) else derive from whatever platform app IS already present in the cache
-        // (only the toolkit — or a manifest-only need — is missing); (c) else fall back
-        // to the engine's own version.
-        var mm = !platformReport.Ok
-            ? AlRunner.Infrastructure.ProvisioningCheck.DeriveProvisionMajorMinor(platformReport, version)
-            : AlRunner.Infrastructure.ProvisioningCheck.DerivePresentPlatformMajorMinor(PlatformCheckDirs(), version);
+        // Issue #2077: always target the SELECTED BC version's own major.minor — never one
+        // derived from cache contents (a symbol-only app, or a project-vendored
+        // `.alpackages` closure) as this used to. That derivation silently redirected the
+        // whole provisioning pass to whatever minor happened to already be on disk (e.g.
+        // `--bc-version 28.4` provisioning 28.1 platform apps because the bundle's own
+        // committed `.alpackages` vendors 28.1 symbols) — the engine ended up running R2R
+        // apps from a build nobody asked for, with the mismatch never stated.
+        var mm = AlRunner.Infrastructure.ProvisioningCheck.ResolveProvisionMajorMinor(version);
+        {
+            // Loud mismatch note (acceptance criterion): tell the user when the cache would
+            // have suggested a DIFFERENT minor than the one actually being provisioned, even
+            // though we no longer act on that suggestion.
+            var cacheMm = !platformReport.Ok
+                ? AlRunner.Infrastructure.ProvisioningCheck.DeriveProvisionMajorMinor(platformReport, version)
+                : AlRunner.Infrastructure.ProvisioningCheck.DerivePresentPlatformMajorMinor(PlatformCheckDirs(), version);
+            var skewNote = AlRunner.Infrastructure.ProvisioningCheck.BuildProvisionVersionSkewNote(
+                mm, cacheMm,
+                !platformReport.Ok
+                    ? "a symbol-only platform app already in the package cache"
+                    : "platform apps already in the package cache");
+            if (skewNote != null)
+                Console.Error.WriteLine(skewNote);
+        }
         // AC #4/#5: prefer a version ALREADY cached (any patch of this major.minor) whose
         // needed set(s) are complete, before ever asking the CDN for "latest" — otherwise a
         // warm machine re-resolves and re-downloads a NEWER patch on every single run.
@@ -6393,13 +6405,32 @@ static void EnsurePlatformAppsProvisioned(string engineVersion, List<string> bun
         manifestDependencyRoots, platformReport, bundleAlpackagesDirs);
     if (!decision.ShouldDownloadPlatform)
     {
-        Console.Error.WriteLine("[provision] platform R2R apps already present for the target bundle(s).");
+        // Issue #2073: "already present" is only true when something was actually VERIFIED
+        // present — a bundle that was simply determined not to need the set at all (the
+        // manifest names nothing platform-only) never checked presence, so claiming
+        // presence for it is a silent wrong answer under .claude/rules/loud-failures.md.
+        Console.Error.WriteLine(decision.NeedsPlatformApps
+            ? "[provision] platform R2R apps already present for the target bundle(s)."
+            : "[provision] target bundle(s) do not need the platform R2R apps set — nothing to provision.");
         return;
     }
 
-    var mm = !platformReport.Ok
-        ? AlRunner.Infrastructure.ProvisioningCheck.DeriveProvisionMajorMinor(platformReport, engineVersion)
-        : AlRunner.Infrastructure.ProvisioningCheck.DerivePresentPlatformMajorMinor(bundleAlpackagesDirs, engineVersion);
+    // Issue #2077: always target the SELECTED engine version's own major.minor — never one
+    // derived from cache contents, which used to silently redirect the download to whatever
+    // minor happened to already be vendored in the bundle's own `.alpackages`.
+    var mm = AlRunner.Infrastructure.ProvisioningCheck.ResolveProvisionMajorMinor(engineVersion);
+    {
+        var cacheMm = !platformReport.Ok
+            ? AlRunner.Infrastructure.ProvisioningCheck.DeriveProvisionMajorMinor(platformReport, engineVersion)
+            : AlRunner.Infrastructure.ProvisioningCheck.DerivePresentPlatformMajorMinor(bundleAlpackagesDirs, engineVersion);
+        var skewNote = AlRunner.Infrastructure.ProvisioningCheck.BuildProvisionVersionSkewNote(
+            mm, cacheMm,
+            !platformReport.Ok
+                ? "a symbol-only platform app already in the bundle's package cache"
+                : "platform apps already in the bundle's package cache");
+        if (skewNote != null)
+            Console.Error.WriteLine(skewNote);
+    }
     var platformFull = AlRunner.Provisioning.ArtifactDownloader.ResolveVersion(
         mm, m => Console.Error.WriteLine($"[provision] {m}"));
     if (platformFull == null)


### PR DESCRIPTION
Closes #2073
Closes #2077

## #2073 — provision reports success and downloads nothing

`ProvisioningCheck.DetermineManifestNeeds` only reads a bundle's own dependency
roots. A bundle depending on `Tests-TestLibraries` never names `Application Test
Library` directly, so the need was invisible even though `Tests-TestLibraries`'
own manifest declares that dependency (confirmed via the real Microsoft
NavxManifest.xml for `Tests-TestLibraries` v28.1.49838.53910 — it declares
`<Dependency Id="d852d5d2-a39d-4179-baeb-f99a19e32510" Name="Application Test
Library" .../>`, the exact AppId the issue's "Missing:" error names).

Fix: `KnownTransitiveNoFallbackPlatformDependents` records that known edge the
same way `KnownNoFallbackPlatformApps` records real app names, so
`DetermineManifestNeeds` sees the transitive need without reading a
not-yet-downloaded manifest. Also fixed the message: "platform R2R apps already
present" is only printed when something was actually needed and verified
present; a bundle genuinely needing nothing now says so instead of claiming
presence it never checked (`.claude/rules/loud-failures.md`).

Confirmed `application`/`platform` app.json properties are **not** a second
path to this same gap — they synthesize implicit `Application`/`System` roots
(the platform-runtime-apps set, which has a service-tier DLL fallback and its
own detection path), not `Application Test Library`.

I did not observe `AL0791` at any point during investigation — the actual
downstream failure is the `Missing: Microsoft/Application Test Library`
message described in the issue.

## #2077 — provision downloads platform apps for the wrong BC version

The provisioning major.minor was derived from whatever was already in the
package cache (`DeriveProvisionMajorMinor` / `DerivePresentPlatformMajorMinor`)
instead of the BC version the run had already selected. A `--bc-version 28.4`
run could silently provision and compile against 28.1 platform apps because
the bundle's own committed `.alpackages` vendored a 28.1 symbol-only closure.

Fix: `ResolveProvisionMajorMinor` always returns the selected version's own
major.minor — the two cache-derived helpers are kept only as inputs to a new
`BuildProvisionVersionSkewNote`, which prints a loud note when the cache would
have suggested a different minor than the one actually being provisioned.

## Verification

- Unit tests (`AlRunner.Tests/ProvisioningCheckTests.cs`, RED confirmed against
  reverted implementation, GREEN against the fix — 73/73 passing):
  - `DetermineManifestNeeds_TestsTestLibrariesDependency_AlsoNeedsPlatform` /
    `..._ImpliesDownloadWhenAbsent`
  - `ResolveProvisionMajorMinor_AlwaysUsesSelectedVersion_IgnoresCache` /
    `..._ShortVersion_ReturnedAsIs`
  - `BuildProvisionVersionSkewNote_CacheAgrees_ReturnsNull` /
    `..._CacheDisagrees_NamesBothVersionsLoudly` / `..._CaseInsensitiveAgreement_ReturnsNull`
- End-to-end against the real `SMC/Pageworks` repro (scratch `$HOME`, seeded
  engine artifacts only, network download for platform-apps/test-apps):
  - `Pageworks.Test` (#2073 shape — depends on `Tests-TestLibraries`, never
    `Application Test Library`): `provision --bc-version 28.4` now actually
    detects the need and downloads platform-apps + the test toolkit, instead
    of "already present" + nothing on disk.
  - `Pageworks.Bench` (#2077 shape — `.alpackages` vendors a real 28.1
    symbol-only Base/System Application/Business Foundation closure):
    `--bc-version 28.4` now compiles against platform apps at
    `28.4.53241.54007` (same build the engine selected), not the bundle's
    committed 28.1 closure.
- `dotnet test AlRunner.Tests` (998 tests): 997 passed, 1 pre-existing failure
  (`SourceDepSymbolsWithoutPackageCacheTests.SiblingSourceDep_CompilesWithZeroPackageCacheDirs`)
  — reproduces identically with these changes fully reverted (confirmed via
  `git checkout HEAD -- <changed files>` + rerun), so it's unrelated to this
  PR.