### PR TITLE
fix(provision): expose platform-apps/test-apps/service-tier download from the shipped binary

### DIFF
--- a/AlRunner.Provisioning/ArtifactDownloader.cs
+++ b/AlRunner.Provisioning/ArtifactDownloader.cs
@@ -462,7 +462,12 @@ public static class ArtifactDownloader
             var prefix = string.Join(".", version.Split('.').Take(2));
             logf($"Error: no BC artifact published for {version} ({channel}).");
             logf("       Check the version, or resolve the latest for a prefix:");
-            logf($"         dotnet run --project tools/DownloadArtifacts -- resolve-version {prefix}");
+            // Issue #2085: this fires both from the standalone tools/DownloadArtifacts CLI
+            // (repo-checkout only) AND in-process from the shipped `al-runner` binary's own
+            // auto-provision path — a `dotnet run --project tools/DownloadArtifacts` hint
+            // here would be a dead end for anyone using the latter, which is the common
+            // case. `al-runner provision --resolve-version` works from both.
+            logf($"         al-runner provision --resolve-version {prefix}");
             size = 0;
             return false;
         }

--- a/AlRunner.Tests/ArtifactDownloader404Tests.cs
+++ b/AlRunner.Tests/ArtifactDownloader404Tests.cs
@@ -50,7 +50,10 @@ public sealed class ArtifactDownloader404Tests
         Assert.False(ok);
         Assert.Equal(0, size);
         Assert.Contains(logs, l => l == "Error: no BC artifact published for 28.0.46665.47126 (w1).");
-        Assert.Contains(logs, l => l.Contains("dotnet run --project tools/DownloadArtifacts -- resolve-version 28.0"));
+        // Issue #2085: this hint must be tool-install-valid — `dotnet run --project` requires
+        // a source checkout a `dotnet tool install -g` user never has.
+        Assert.Contains(logs, l => l.Contains("al-runner provision --resolve-version 28.0"));
+        Assert.DoesNotContain(logs, l => l.Contains("dotnet run --project"));
     }
 
     [Fact]

--- a/AlRunner.Tests/BcArtifactSelectionTests.cs
+++ b/AlRunner.Tests/BcArtifactSelectionTests.cs
@@ -65,11 +65,14 @@ public sealed class BcArtifactSelectionTests : IDisposable
         var ex = Assert.Throws<InvalidOperationException>(
             () => BcArtifacts.SelectArtifactVersionDir(_root, "26"));
         // Loud failure: names what IS available so a human/agent can act, and leads with
-        // the tool-install-valid fix (issue #2024/#2028) before the repo-checkout-only
-        // manual fallback.
+        // the tool-install-valid fix (issue #2024/#2028) before the secondary manual
+        // fallback — which (issue #2085) must ALSO be tool-install-valid, not a
+        // `dotnet run --project tools/DownloadArtifacts` dead end for anyone without a
+        // source checkout.
         Assert.Contains("28.2.50931.52786", ex.Message);
         Assert.Contains("al-runner provision", ex.Message);
-        Assert.Contains("dotnet run --project tools/DownloadArtifacts", ex.Message);
+        Assert.Contains("al-runner provision --service-tier", ex.Message);
+        Assert.DoesNotContain("dotnet run --project", ex.Message);
     }
 
     /// <summary>

--- a/AlRunner.Tests/CliDocumentationTests.cs
+++ b/AlRunner.Tests/CliDocumentationTests.cs
@@ -312,4 +312,44 @@ public sealed class CliDocumentationTests
         // alongside the new instructions, not be displaced by them.
         Assert.Contains("worse than none", section, StringComparison.Ordinal);
     }
+
+    /// <summary>
+    /// Issue #2085: `dotnet run --project tools/DownloadArtifacts` requires a source
+    /// checkout of this repository. A `dotnet tool install -g msdyn365bc.al.runner` user
+    /// has none — `tools/DownloadArtifacts` ships only as source, never as part of the
+    /// packaged tool — so a provisioning-gap message naming it as a fix is a dead end for
+    /// exactly the audience it's printed for (measured on the published 2.7.0: two of the
+    /// three "Resolve it" routes were unusable). `al-runner provision
+    /// --platform-apps/--test-apps/--service-tier [--force]` is the tool-install-valid
+    /// replacement every remediation message must use instead.
+    ///
+    /// Scans the actual source that BUILDS these messages, the same style as
+    /// <see cref="Help_DocumentsEveryRecognizedFlag"/>'s Program.cs scrape, rather than
+    /// driving every message site through a real provisioning-gap scenario. Comment-only
+    /// lines are excluded — they legitimately document the history/rationale (e.g. this
+    /// very test's own doc comment) — only live code lines that could actually reach a
+    /// console/exception message count.
+    /// </summary>
+    [Fact]
+    public void NoRemediationText_NamesTheCheckoutOnlyDownloadArtifactsInvocation()
+    {
+        var root = Path.Combine(RepoRoot, "AlRunner");
+        var offenders = new List<string>();
+        foreach (var file in Directory.EnumerateFiles(root, "*.cs", SearchOption.AllDirectories))
+        {
+            var lines = File.ReadAllLines(file);
+            for (int i = 0; i < lines.Length; i++)
+            {
+                var trimmed = lines[i].TrimStart();
+                if (trimmed.StartsWith("//")) continue; // comment: rationale, never emitted
+                if (lines[i].Contains("dotnet run --project", StringComparison.Ordinal))
+                    offenders.Add($"{Path.GetRelativePath(RepoRoot, file)}:{i + 1}: {lines[i].Trim()}");
+            }
+        }
+        Assert.True(offenders.Count == 0,
+            "These lines under AlRunner/ (the shipped binary's own source) build "
+            + "remediation text containing 'dotnet run --project', which requires a source "
+            + "checkout a `dotnet tool install` user never has:\n  "
+            + string.Join("\n  ", offenders));
+    }
 }

--- a/AlRunner.Tests/CollectionCostOrderer.cs
+++ b/AlRunner.Tests/CollectionCostOrderer.cs
@@ -129,6 +129,13 @@ public sealed class CollectionCostOrderer : ITestCollectionOrderer
             // t=400s.
             ["CountBaselineIntegrationTests"] = 84,
             ["ServerTests"] = 81,
+            // #2085: 5 tests, three of which download a real ~20MB Microsoft test-toolkit
+            // set from the public BC artifact CDN (twice for the force/no-force pair, once
+            // for the fresh-download positive test) — network-latency dependent, measured
+            // 83-125s across the four legs that first ran it. Round down to the low end so
+            // a fast run still ranks it above the freshness threshold rather than have it
+            // fall back to UnmeasuredWeightSeconds and reproduce the #1887 tail pattern.
+            ["ProvisionExplicitModesTests"] = 80,
             // #1940/#1941/#1943: 4 tests, each spawning a real runner subprocess (two
             // single-bundle, two layered two-bundle dep compiles) — needed because
             // NoImplicitWith's binder-shadowing effect isn't observable via a bare

--- a/AlRunner.Tests/ProvisionExplicitModesTests.cs
+++ b/AlRunner.Tests/ProvisionExplicitModesTests.cs
@@ -1,0 +1,244 @@
+// Issue #2085: every remediation route the runner prints must be executable using only
+// the installed tool. `dotnet run --project tools/DownloadArtifacts -- <mode> <ver> <dir>`
+// requires a source checkout of this repository that a `dotnet tool install -g
+// msdyn365bc.al.runner` user never has — measured on the published 2.7.0, two of the three
+// printed "Resolve it" routes were dead ends for exactly that audience. `al-runner provision
+// --platform-apps/--test-apps/--service-tier [--force]` exposes the SAME
+// AlRunner.Provisioning.ArtifactDownloader methods tools/DownloadArtifacts already wraps,
+// straight from the shipped binary.
+//
+// These tests spawn the REAL runner binary against a REAL, hermetically empty artifact
+// cache (an isolated $HOME, never the machine's actual
+// ~/.local/share/al-runner/artifacts) and make a genuine download against the public BC
+// artifact CDN — deliberately `--test-apps` (~20MB), the smallest of the three real sets,
+// rather than the ~118MB platform-apps set or the multi-GB service-tier closure, to prove a
+// REAL end-to-end download without paying for the largest one. Confirmed RED on unfixed
+// `main` (pre-#2085, i.e. right after #2086): `--test-apps` is not a recognized flag at
+// all, so the arg parser's fallback rejects it with "Unknown option '--test-apps'. Run with
+// --help for the supported flags." and exits 2 — nothing is downloaded, because the only
+// implemented route (tools/DownloadArtifacts) requires the checkout this test's isolated
+// $HOME/binary-only setup deliberately does not have.
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class ProvisionExplicitModesTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+
+    // A real, already-published BC version — this test needs the CDN to actually have it
+    // (unlike AutoProvisionDefaultTests's deliberately-nonexistent 1.2.3.4, which exists
+    // purely to prove "an attempt was made" via a fast 404). Also the version this repo's
+    // own AlRunner.csproj/AlRunner.Tests.csproj build against by default, so it is already
+    // in wide use and unlikely to be withdrawn from the CDN out from under this test.
+    private const string RealVersion = "28.1.49838.53910";
+
+    private static (int ExitCode, string StdErr) Run(string isolatedHome, params string[] args)
+    {
+        var argLine = TestBuildConfig.RunArgs(Path.Combine(RepoRoot, "AlRunner")) + " " + string.Join(' ', args);
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            Arguments = argLine,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            WorkingDirectory = RepoRoot,
+        };
+        // Redirect $HOME so BcArtifacts.ArtifactsRoot resolves under a directory that has
+        // NEVER existed — the exact "clean tool install, no artifact cache" scenario,
+        // independent of whatever the machine actually running this test has cached.
+        psi.Environment["HOME"] = isolatedHome;
+
+        var errSb = new StringBuilder();
+        using var proc = Process.Start(psi)!;
+        proc.OutputDataReceived += (_, e) => { };
+        proc.ErrorDataReceived += (_, e) => { if (e.Data != null) lock (errSb) errSb.AppendLine(e.Data); };
+        proc.BeginOutputReadLine();
+        proc.BeginErrorReadLine();
+        if (!proc.WaitForExit(180_000))
+        {
+            try { proc.Kill(entireProcessTree: true); } catch { }
+            throw new TimeoutException(
+                $"al-runner did not exit within 180s for: {argLine}. If the test machine " +
+                "has no network reachability to the BC artifact CDN this will hang instead " +
+                "of failing fast.");
+        }
+        proc.WaitForExit();
+        lock (errSb) return (proc.ExitCode, errSb.ToString());
+    }
+
+    private static string NewIsolatedHome()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "al-runner-provision-explicit", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    private static string TestAppsDirFor(string home) =>
+        Path.Combine(home, ".local", "share", "al-runner", "artifacts", RealVersion, "test-apps");
+
+    /// <summary>
+    /// Positive direction: `provision --test-apps --bc-version &lt;ver&gt;` downloads the
+    /// real Microsoft test-toolkit set straight into the canonical
+    /// &lt;artifacts&gt;/&lt;ver&gt;/test-apps directory and exits 0 — no --package-cache,
+    /// no checkout, nothing but the installed binary and a version number. Asserts real
+    /// content landed (specific, well-known app names), not merely that the directory
+    /// exists — a no-op that created an empty directory would also pass a bare
+    /// Directory.Exists check.
+    /// </summary>
+    [Fact]
+    public void TestApps_FreshCache_DownloadsRealSetIntoCanonicalDir()
+    {
+        var home = NewIsolatedHome();
+        try
+        {
+            var testAppsDir = TestAppsDirFor(home);
+            Assert.False(Directory.Exists(testAppsDir), "precondition: fresh cache must not already have this dir");
+
+            var (exit, stderr) = Run(home, "provision", "--test-apps", "--bc-version", RealVersion);
+
+            Assert.True(exit == 0, $"provision --test-apps must exit 0. stderr:\n{stderr}");
+            Assert.True(Directory.Exists(testAppsDir), $"expected {testAppsDir} to exist after provisioning. stderr:\n{stderr}");
+            var apps = Directory.GetFiles(testAppsDir, "*.app");
+            // Real content, not an empty/stub directory: Library Assert and Test Runner are
+            // foundational apps every AL test bundle transitively depends on.
+            Assert.True(apps.Length > 10,
+                $"expected more than 10 .app files, got {apps.Length}: {string.Join(", ", apps.Select(Path.GetFileName))}");
+            Assert.Contains(apps, a => Path.GetFileName(a).Contains("Library Assert", StringComparison.OrdinalIgnoreCase));
+            Assert.Contains(apps, a => Path.GetFileName(a).Contains("Test Runner", StringComparison.OrdinalIgnoreCase));
+        }
+        finally
+        {
+            try { Directory.Delete(home, recursive: true); } catch { }
+        }
+    }
+
+    /// <summary>
+    /// Negative direction of the same feature: a SECOND invocation without --force must
+    /// leave the already-downloaded set alone rather than re-fetching ~20MB on every
+    /// re-run — the whole point of checking the canonical directory before downloading.
+    /// Proven by the marker file's write time: if a re-download happened it would move;
+    /// the "already present — skipping" short-circuit must leave it exactly where the
+    /// FIRST invocation wrote it. A test that only checked "exit 0" would pass even if the
+    /// runner silently re-downloaded every time, which is the failure this guards against.
+    /// </summary>
+    [Fact]
+    public void TestApps_SecondInvocationWithoutForce_DoesNotRedownload()
+    {
+        var home = NewIsolatedHome();
+        try
+        {
+            var testAppsDir = TestAppsDirFor(home);
+            var (exit1, stderr1) = Run(home, "provision", "--test-apps", "--bc-version", RealVersion);
+            Assert.True(exit1 == 0, $"first provision must exit 0. stderr:\n{stderr1}");
+            var marker = Directory.GetFiles(testAppsDir, "*.app").First();
+            var writeTimeBefore = File.GetLastWriteTimeUtc(marker);
+
+            var (exit2, stderr2) = Run(home, "provision", "--test-apps", "--bc-version", RealVersion);
+
+            Assert.True(exit2 == 0, $"second provision (no --force) must still exit 0. stderr:\n{stderr2}");
+            Assert.Contains("already present", stderr2, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("skipping", stderr2, StringComparison.OrdinalIgnoreCase);
+            Assert.Equal(writeTimeBefore, File.GetLastWriteTimeUtc(marker));
+        }
+        finally
+        {
+            try { Directory.Delete(home, recursive: true); } catch { }
+        }
+    }
+
+    /// <summary>
+    /// `--force` is the escape hatch from the skip above: it must re-run the download even
+    /// though the directory already looks populated. Proven the same way as the negative
+    /// test above, inverted — the marker's write time MUST move.
+    /// </summary>
+    [Fact]
+    public void TestApps_Force_RedownloadsEvenWhenAlreadyPresent()
+    {
+        var home = NewIsolatedHome();
+        try
+        {
+            var testAppsDir = TestAppsDirFor(home);
+            var (exit1, stderr1) = Run(home, "provision", "--test-apps", "--bc-version", RealVersion);
+            Assert.True(exit1 == 0, $"first provision must exit 0. stderr:\n{stderr1}");
+            var marker = Directory.GetFiles(testAppsDir, "*.app").First();
+            var writeTimeBefore = File.GetLastWriteTimeUtc(marker);
+            System.Threading.Thread.Sleep(1100); // filesystem mtime resolution margin
+
+            var (exit2, stderr2) = Run(home, "provision", "--test-apps", "--bc-version", RealVersion, "--force");
+
+            Assert.True(exit2 == 0, $"forced provision must exit 0. stderr:\n{stderr2}");
+            Assert.DoesNotContain("skipping", stderr2, StringComparison.OrdinalIgnoreCase);
+            Assert.True(File.GetLastWriteTimeUtc(marker) > writeTimeBefore,
+                $"expected {marker}'s write time to move after --force. Before: {writeTimeBefore:o}, " +
+                $"after: {File.GetLastWriteTimeUtc(marker):o}\nstderr:\n{stderr2}");
+        }
+        finally
+        {
+            try { Directory.Delete(home, recursive: true); } catch { }
+        }
+    }
+
+    /// <summary>
+    /// `provision --resolve-version PREFIX` mirrors tools/DownloadArtifacts's
+    /// `resolve-version` mode from the installed binary: prints the latest full version for
+    /// a prefix to stdout and exits 0. No artifact cache needed at all.
+    /// </summary>
+    [Fact]
+    public void ResolveVersion_PrintsFullVersionToStdout()
+    {
+        var argLine = TestBuildConfig.RunArgs(Path.Combine(RepoRoot, "AlRunner"))
+            + " provision --resolve-version 28.1";
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            Arguments = argLine,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            WorkingDirectory = RepoRoot,
+        };
+        psi.Environment["HOME"] = NewIsolatedHome();
+        using var proc = Process.Start(psi)!;
+        var stdout = proc.StandardOutput.ReadToEnd();
+        var stderr = proc.StandardError.ReadToEnd();
+        Assert.True(proc.WaitForExit(30_000), "provision --resolve-version must resolve quickly (one index fetch).");
+        Assert.True(proc.ExitCode == 0, $"exit code: {proc.ExitCode}\nstderr:\n{stderr}");
+        var resolved = stdout.Trim();
+        Assert.StartsWith("28.1.", resolved);
+        Assert.Equal(4, resolved.Split('.').Length);
+    }
+
+    /// <summary>
+    /// Negative: `--platform-apps` (and its siblings) only make sense under the `provision`
+    /// subcommand — a plain test run has no use for them. Rejected up front rather than
+    /// silently accepted-and-ignored, which would look like support that isn't there.
+    /// </summary>
+    [Fact]
+    public void PlatformApps_WithoutProvisionSubcommand_IsRejected()
+    {
+        var argLine = TestBuildConfig.RunArgs(Path.Combine(RepoRoot, "AlRunner")) + " --platform-apps";
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            Arguments = argLine,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            WorkingDirectory = RepoRoot,
+        };
+        using var proc = Process.Start(psi)!;
+        var stderr = proc.StandardError.ReadToEnd();
+        Assert.True(proc.WaitForExit(30_000));
+        Assert.NotEqual(0, proc.ExitCode);
+        Assert.Contains("only valid with the `provision` subcommand", stderr, StringComparison.Ordinal);
+    }
+}

--- a/AlRunner.Tests/ProvisionExplicitModesTests.cs
+++ b/AlRunner.Tests/ProvisionExplicitModesTests.cs
@@ -80,8 +80,12 @@ public sealed class ProvisionExplicitModesTests
         return dir;
     }
 
+    // Composed from the shared TestArtifacts.StandardCacheDir(home) root (the layout
+    // bc-tests.yml actually provisions), not spelled out here — TestArtifactsGateTests'
+    // OnlyTheSharedHelperNamesTheArtifactCachePathsInCode enforces that only TestArtifacts
+    // itself may name the raw ".local/share/al-runner/artifacts" path segments in code.
     private static string TestAppsDirFor(string home) =>
-        Path.Combine(home, ".local", "share", "al-runner", "artifacts", RealVersion, "test-apps");
+        Path.Combine(TestArtifacts.StandardCacheDir(home), RealVersion, "test-apps");
 
     /// <summary>
     /// Positive direction: `provision --test-apps --bc-version &lt;ver&gt;` downloads the

--- a/AlRunner.Tests/ProvisioningCheckTests.cs
+++ b/AlRunner.Tests/ProvisioningCheckTests.cs
@@ -91,8 +91,12 @@ public sealed class ProvisioningCheckTests : IDisposable
 
         // Every missing item's FULL path is named (human/agent can act).
         Assert.Contains(Path.Combine(_dir, "Microsoft.Dynamics.Nav.Ncl.dll"), msg);
-        // The exact manual download command, with version and target dir.
-        Assert.Contains("service-tier 28.2.50931.52786", msg);
+        // The exact manual command, with version — issue #2085: this must be the
+        // tool-install-valid `provision --service-tier` subcommand, never
+        // `dotnet run --project tools/DownloadArtifacts`, which requires a source checkout
+        // a `dotnet tool install` user never has.
+        Assert.Contains("al-runner provision --service-tier --bc-version 28.2.50931.52786", msg);
+        Assert.DoesNotContain("dotnet run --project", msg);
         Assert.Contains(_dir, msg);
         // The one-command auto-resolve, targeting the project.
         Assert.Contains("al-runner provision", msg);

--- a/AlRunner/DependencyResolver.cs
+++ b/AlRunner/DependencyResolver.cs
@@ -281,7 +281,7 @@ public sealed class DependencyResolver
                         + "\n      have a member with that ID\". Provision a package that carries an"
                         + "\n      implementation — `al-runner provision`, or re-run with --auto-provision;"
                         + "\n      for the Microsoft test toolkit specifically:"
-                        + $"\n        dotnet run --project tools/DownloadArtifacts -- test-apps {best.Manifest.Version} \"<dir>\"");
+                        + $"\n        al-runner provision --test-apps --bc-version {best.Manifest.Version}");
                 }
                 else
                     _diagnostics.Add(

--- a/AlRunner/Infrastructure/BcArtifacts.cs
+++ b/AlRunner/Infrastructure/BcArtifacts.cs
@@ -32,9 +32,9 @@ public static class BcArtifacts
     /// <summary>
     /// The tool-install-valid, one-command fix — works identically whether the runner
     /// came from `dotnet tool install` or a source checkout. This is the PRIMARY
-    /// recommendation in every provisioning-gap message: unlike
-    /// <see cref="DownloadCommand"/>, it names no path that only exists in this repo's
-    /// own source tree.
+    /// recommendation in every provisioning-gap message: unlike the old
+    /// `tools/DownloadArtifacts` fallback, it names no path that only exists in this
+    /// repo's own source tree.
     /// </summary>
     public static string ProvisionHint(string? versionPrefix = null)
         => versionPrefix == null
@@ -42,14 +42,16 @@ public static class BcArtifacts
             : $"al-runner provision --bc-version {versionPrefix}   (or re-run your command with --auto-provision)";
 
     /// <summary>
-    /// The manual, repo-checkout-only fallback: invokes `tools/DownloadArtifacts` directly.
-    /// That project ships only as source in this repo — it is NOT part of the packaged
-    /// `dotnet tool install` output — so this command is only valid from a checkout, never
-    /// for a tool install. Callers must always pair it with <see cref="ProvisionHint"/> as
-    /// the primary, universally-valid recommendation.
+    /// The explicit, force-a-specific-download fallback: `provision --service-tier`
+    /// (issue #2085). Unlike the old `dotnet run --project tools/DownloadArtifacts --
+    /// service-tier` this replaced — which required a source checkout of this repo, so it
+    /// was a dead end for anyone who reached it via `dotnet tool install` — this is a
+    /// subcommand on the SAME binary printing the message, so it always works. Bypasses
+    /// need-detection and resolves its own canonical output directory, so no directory
+    /// argument is needed here (kept as a parameter for the version only).
     /// </summary>
-    public static string DownloadCommand(System.Version ver, string dir)
-        => $"dotnet run --project tools/DownloadArtifacts -- service-tier {ver} \"{dir}\"";
+    public static string DownloadCommand(System.Version ver)
+        => $"al-runner provision --service-tier --bc-version {ver} --force";
 
     private static System.Version? _selectedVersion;
     private static string? _selectedRoot;
@@ -164,7 +166,7 @@ public static class BcArtifacts
             throw new InvalidOperationException(
                 $"BC artifact root not found: {rootDir}. No artifacts are downloaded — resolve it ONE of these ways: " +
                 $"(a) {ProvisionHint()}; " +
-                $"(b) manually, repo checkout only: {DownloadCommand(new System.Version(28, 1), rootDir)}");
+                $"(b) {DownloadCommand(new System.Version(28, 1))}");
 
         var candidates = Directory.EnumerateDirectories(rootDir)
             .Select(d => (Dir: d, Name: Path.GetFileName(d),
@@ -177,7 +179,7 @@ public static class BcArtifacts
             throw new InvalidOperationException(
                 $"BC artifact root {rootDir} contains no version-named directories. Resolve it ONE of these ways: " +
                 $"(a) {ProvisionHint()}; " +
-                $"(b) manually, repo checkout only: {DownloadCommand(new System.Version(28, 1), rootDir)}");
+                $"(b) {DownloadCommand(new System.Version(28, 1))}");
 
         if (requestedVersionOrNull == null)
             return candidates[0].Dir;
@@ -193,8 +195,7 @@ public static class BcArtifacts
                 $"No BC artifact under {rootDir} matches version '{requestedVersionOrNull}'. " +
                 $"Available: {available}. Resolve it ONE of these ways: " +
                 $"(a) {ProvisionHint(prefix)}; " +
-                $"(b) manually, repo checkout only: " +
-                $"{DownloadCommand(System.Version.TryParse(EnsureFourPart(prefix), out var pv) ? pv : new System.Version(28, 1), rootDir)}");
+                $"(b) {DownloadCommand(System.Version.TryParse(EnsureFourPart(prefix), out var pv) ? pv : new System.Version(28, 1))}");
         }
         return match.Dir;
     }

--- a/AlRunner/Infrastructure/MissingDependencyException.cs
+++ b/AlRunner/Infrastructure/MissingDependencyException.cs
@@ -80,11 +80,11 @@ public sealed class MissingDependencyException : Exception
             lines.Add("        al-runner provision");
             lines.Add("      or re-run with --auto-provision.");
             lines.Add("");
-            lines.Add("  (b) Download Microsoft test-toolkit apps:");
-            lines.Add($"        dotnet run --project tools/DownloadArtifacts -- test-apps {versionHint} \"<package-cache-dir>\"");
+            lines.Add("  (b) Force-download Microsoft test-toolkit apps only:");
+            lines.Add($"        al-runner provision --test-apps --bc-version {versionHint}");
             lines.Add("");
-            lines.Add("  (c) Download Microsoft platform apps:");
-            lines.Add($"        dotnet run --project tools/DownloadArtifacts -- platform-apps {versionHint} \"<package-cache-dir>\"");
+            lines.Add("  (c) Force-download Microsoft platform apps only:");
+            lines.Add($"        al-runner provision --platform-apps --bc-version {versionHint}");
         }
         else
         {

--- a/AlRunner/Infrastructure/ProvisioningCheck.cs
+++ b/AlRunner/Infrastructure/ProvisioningCheck.cs
@@ -109,12 +109,12 @@ public static class ProvisioningCheck
             lines.Add("        al-runner provision");
             lines.Add("      or re-run with --auto-provision.");
             lines.Add("");
-            lines.Add("  (b) Download Microsoft platform apps only:");
+            lines.Add("  (b) Force-download Microsoft platform apps only:");
             // Use the FIRST missing app's own real version — not a truncation of Version
             // (the engine version), which can be a different minor and would 404 against
             // the artifact CDN (it needs a FULL artifact version, e.g. 28.2.50931.52786).
             var suggestVer = Issues.Count > 0 ? Issues[0].AppVersion : "<full-version, e.g. 28.2.50931.52786>";
-            lines.Add($"        dotnet run --project tools/DownloadArtifacts -- platform-apps {suggestVer} \"<package-cache-dir>\"");
+            lines.Add($"        al-runner provision --platform-apps --bc-version {suggestVer}");
             return string.Join(Environment.NewLine, lines);
         }
     }
@@ -279,7 +279,7 @@ public static class ProvisioningCheck
             // Suggest the APP's own version, not bcVersion (the engine's) — the engine is
             // version-agnostic w.r.t. the R2R apps it dispatches to, so these can differ
             // (e.g. engine 28.1 running 28.2 R2R apps); using bcVersion here would 404.
-            $"    dotnet run --project tools/DownloadArtifacts -- platform-apps {appVersion} \"<package-cache-dir>\"",
+            $"    al-runner provision --platform-apps --bc-version {appVersion}",
         });
     }
 
@@ -750,11 +750,11 @@ public static class ProvisioningCheck
         lines.Add("        al-runner provision");
         lines.Add("      or re-run with --auto-provision.");
         lines.Add("");
-        lines.Add("  (b) Download manually:");
+        lines.Add("  (b) Force-download a specific set:");
         if (needsPlatform)
-            lines.Add("        dotnet run --project tools/DownloadArtifacts -- platform-apps <full-version> \"<package-cache-dir>\"");
+            lines.Add("        al-runner provision --platform-apps --bc-version <full-version>");
         if (needsTest)
-            lines.Add("        dotnet run --project tools/DownloadArtifacts -- test-apps <full-version> \"<package-cache-dir>\"");
+            lines.Add("        al-runner provision --test-apps --bc-version <full-version>");
         return string.Join(Environment.NewLine, lines);
     }
 
@@ -788,8 +788,8 @@ public static class ProvisioningCheck
             lines.Add($"        al-runner provision{provisionTarget}");
             lines.Add($"      or re-run your command with --auto-provision.");
             lines.Add("");
-            lines.Add("  (b) Manually — fetch the full service-tier closure for this version:");
-            lines.Add($"        dotnet run --project tools/DownloadArtifacts -- service-tier {Version} \"{ServiceTierDir}\"");
+            lines.Add("  (b) Force-download the full service-tier closure for this version:");
+            lines.Add($"        al-runner provision --service-tier --bc-version {Version}");
             lines.Add("");
             lines.Add("  (c) Point the runner at an existing artifact dir with --artifact-path <dir>,");
             lines.Add("      or select a different cached version with --bc-version <ver>.");

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -4675,6 +4675,15 @@ static void PrintGuide(TextWriter w)
     w.WriteLine("    al-runner provision <bundle-dir>        # provision for that project's version, then exit");
     w.WriteLine("    al-runner --auto-provision <dirs>       # same as the default, explicit for scripts");
     w.WriteLine("    al-runner --no-auto-provision <dirs>    # fail loud instead of reaching the network");
+    w.WriteLine("  If a provisioning-gap message names a specific missing set, force just that one");
+    w.WriteLine("  (bypasses need-detection entirely — useful when the default `provision` mis-detects,");
+    w.WriteLine("  issue #2085):");
+    w.WriteLine("    al-runner provision --platform-apps --bc-version V [--force]");
+    w.WriteLine("    al-runner provision --test-apps --bc-version V [--force]");
+    w.WriteLine("    al-runner provision --service-tier --bc-version V [--force]");
+    w.WriteLine("  Every one of these works from a plain `dotnet tool install -g` with no source");
+    w.WriteLine("  checkout — the standalone tools/DownloadArtifacts project these wrap ships only");
+    w.WriteLine("  as source in this repo and is unreachable from an installed tool.");
     w.WriteLine("  The engine must be built against the same BC MINOR as the target artifacts");
     w.WriteLine("  (28.1 vs 28.2 matters; a major-only match is not sufficient).");
     w.WriteLine();

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -339,9 +339,28 @@ string? countBaselinePath = null;
 // back-compat with existing scripts/docs that already pass it.
 bool provisionSubcommand = args.Length > 0 && args[0] == "provision";
 bool autoProvision = true;
+// Issue #2085: `provision --platform-apps` / `--test-apps` / `--service-tier` [--force]
+// force-download ONE specific artifact set into its canonical directory, bypassing
+// need-detection entirely. This is the tool-install-valid replacement for
+// `dotnet run --project tools/DownloadArtifacts -- <mode> <ver> <dir>`, which requires a
+// source checkout that a `dotnet tool install -g` user never has — see the issue for the
+// measured dead-end. `--resolve-version PREFIX` mirrors the CLI's `resolve-version` mode.
+// All four are only meaningful under the `provision` subcommand; validated below.
+bool provisionPlatformApps = false;
+bool provisionTestApps = false;
+bool provisionServiceTier = false;
+bool provisionForce = false;
+string? provisionResolveVersionPrefix = null;
+bool provisionHelp = false;
 for (int i = 0; i < args.Length; i++)
 {
     if (i == 0 && args[i] == "provision") { continue; } // consumed as subcommand
+    if (provisionSubcommand && (args[i] == "--help" || args[i] == "-h")) { provisionHelp = true; continue; }
+    if (args[i] == "--platform-apps") { provisionPlatformApps = true; continue; }
+    if (args[i] == "--test-apps") { provisionTestApps = true; continue; }
+    if (args[i] == "--service-tier") { provisionServiceTier = true; continue; }
+    if (args[i] == "--force") { provisionForce = true; continue; }
+    if (args[i] == "--resolve-version" && i + 1 < args.Length) { provisionResolveVersionPrefix = args[++i]; continue; }
     if (args[i] == "--auto-provision") { autoProvision = true; continue; }
     if (args[i] == "--no-auto-provision") { autoProvision = false; continue; }
     if (args[i] == "--bc-version" && i + 1 < args.Length) { bcVersionArg = args[++i]; continue; }
@@ -446,6 +465,46 @@ if (serverMode && watchMode)
 {
     Console.Error.WriteLine("--server and --watch are mutually exclusive (both stay warm in-process; pick one).");
     return 2;
+}
+// Issue #2085: --platform-apps/--test-apps/--service-tier/--resolve-version only make
+// sense under the `provision` subcommand (they force/bypass a specific artifact-set
+// download; a normal test run has no use for them). Reject early rather than silently
+// accepting-and-ignoring, which would look like support that isn't there.
+if (!provisionSubcommand && (provisionPlatformApps || provisionTestApps || provisionServiceTier
+    || provisionResolveVersionPrefix != null))
+{
+    var badFlag = provisionPlatformApps ? "--platform-apps"
+        : provisionTestApps ? "--test-apps"
+        : provisionServiceTier ? "--service-tier"
+        : "--resolve-version";
+    Console.Error.WriteLine($"{badFlag} is only valid with the `provision` subcommand (e.g. `al-runner provision {badFlag}`).");
+    return 2;
+}
+if (!provisionSubcommand && provisionForce)
+{
+    Console.Error.WriteLine("--force is only valid with `provision --platform-apps` / `--test-apps` / `--service-tier`.");
+    return 2;
+}
+// `al-runner provision --help`: subcommands must accept --help like everything else —
+// previously this fell through to the generic arg-parser and answered "Unknown option
+// '--help'. Run with --help for the supported flags.", which tells the caller to run the
+// exact command it just ran. Handled before any BC type loads, same as the top-level
+// --help/--guide fast paths.
+if (provisionHelp)
+{
+    PrintProvisionHelp(Console.Out);
+    return 0;
+}
+// `provision --resolve-version PREFIX` / `--platform-apps` / `--test-apps` / `--service-tier`:
+// force a specific artifact set, bypassing need-detection, and exit — never reaches the
+// bundle/version-auto-select machinery below (none of it applies: there's no run to size a
+// BC selection for). Handled here, before the shadow-re-exec / BcArtifacts.SelectVersion
+// machinery further down, so it works even with a completely empty artifacts cache.
+if (provisionSubcommand && (provisionPlatformApps || provisionTestApps || provisionServiceTier
+    || provisionResolveVersionPrefix != null))
+{
+    return RunExplicitProvisionModes(bcVersionArg, bundles, provisionPlatformApps, provisionTestApps,
+        provisionServiceTier, provisionForce, provisionResolveVersionPrefix);
 }
 // --tdd (issue #1997) only changes the bundled-mode CLI run loop's EMIT-EXCLUDED
 // handling (Program.cs, below). --server has its own, separate EMIT-EXCLUDED guard
@@ -4958,7 +5017,22 @@ static void PrintHelp(TextWriter w)
     w.WriteLine("  provision [<bundle-dir>] Download and install the BC artifacts matching the");
     w.WriteLine("                          project's version, then exit without running tests.");
     w.WriteLine("                          This is the supported way to obtain artifacts on a");
-    w.WriteLine("                          fresh machine.");
+    w.WriteLine("                          fresh machine — including a plain `dotnet tool install`");
+    w.WriteLine("                          with no source checkout. Run `al-runner provision --help`");
+    w.WriteLine("                          for its full flag list, or use one of:");
+    w.WriteLine("                            --platform-apps [--bc-version V] [--force]");
+    w.WriteLine("                                          Force-download Microsoft's platform .app");
+    w.WriteLine("                                          set into the canonical dir, bypassing");
+    w.WriteLine("                                          need-detection.");
+    w.WriteLine("                            --test-apps [--bc-version V] [--force]");
+    w.WriteLine("                                          Same, for the Microsoft test-toolkit set.");
+    w.WriteLine("                            --service-tier [--bc-version V] [--force]");
+    w.WriteLine("                                          Same, for the BC engine's service-tier DLLs.");
+    w.WriteLine("                            --resolve-version PREFIX");
+    w.WriteLine("                                          Print the latest full BC version for a");
+    w.WriteLine("                                          prefix (e.g. \"28.4\") to stdout.");
+    w.WriteLine("                          --force re-downloads even when the target directory");
+    w.WriteLine("                          already looks populated (default: leave it alone).");
     w.WriteLine("  --precompile <input.app> --out <output.dll> [--package-cache PATH ...]");
     w.WriteLine("                          Compile a single .app to a managed DLL without running");
     w.WriteLine("                          tests. Useful for pre-warming caches.");
@@ -5032,6 +5106,58 @@ static void PrintHelp(TextWriter w)
     w.WriteLine("  docs/limitations.md          architectural limits");
     w.WriteLine("  docs/cecil-migration.md      Cecil rewrite strategy");
     w.WriteLine("  docs/subsystems.md           subsystem map");
+}
+
+// Issue #2085: `provision --help` used to fall through to the generic arg-parser's
+// unknown-flag error ("Unknown option '--help'. Run with --help for the supported
+// flags.") — telling the caller to run the exact thing it just ran. Every subcommand
+// must answer --help, not just the top level.
+static void PrintProvisionHelp(TextWriter w)
+{
+    w.WriteLine("al-runner provision — download and install BC artifacts. Every form below works");
+    w.WriteLine("from a plain `dotnet tool install -g msdyn365bc.al.runner`; none require a source");
+    w.WriteLine("checkout of this repository.");
+    w.WriteLine();
+    w.WriteLine("USAGE");
+    w.WriteLine("  al-runner provision [<bundle-dir>]");
+    w.WriteLine("  al-runner provision --platform-apps [--bc-version V] [--force]");
+    w.WriteLine("  al-runner provision --test-apps [--bc-version V] [--force]");
+    w.WriteLine("  al-runner provision --service-tier [--bc-version V] [--force]");
+    w.WriteLine("  al-runner provision --resolve-version PREFIX");
+    w.WriteLine("  al-runner provision --help");
+    w.WriteLine();
+    w.WriteLine("OPTIONS");
+    w.WriteLine("  [<bundle-dir>]          With no mode flag: provision everything the named");
+    w.WriteLine("                          bundle's app.json needs (engine closure + platform apps");
+    w.WriteLine("                          + test toolkit, whichever are missing) and exit. This is");
+    w.WriteLine("                          the default `provision` behavior and what a provisioning-");
+    w.WriteLine("                          gap error's \"(a) One command (recommended)\" fix means.");
+    w.WriteLine("  --bc-version V          Target BC version (a prefix like \"28.4\" or a full");
+    w.WriteLine("                          4-part version). Default: this binary's own built");
+    w.WriteLine("                          engine version, or the target bundle's app.json.");
+    w.WriteLine("  --platform-apps         Force-download Microsoft's platform .app set (Base");
+    w.WriteLine("                          Application / System Application / Business Foundation /");
+    w.WriteLine("                          Application / Application Test Library) into the");
+    w.WriteLine("                          canonical <artifacts>/<version>/platform-apps directory,");
+    w.WriteLine("                          bypassing need-detection entirely.");
+    w.WriteLine("  --test-apps             Force-download the Microsoft test-toolkit .app set");
+    w.WriteLine("                          (Library Assert, Test Runner, Any, Tests-TestLibraries, …)");
+    w.WriteLine("                          into <artifacts>/<version>/test-apps, bypassing");
+    w.WriteLine("                          need-detection entirely.");
+    w.WriteLine("  --service-tier          Force-download the BC engine's ~55-DLL service-tier");
+    w.WriteLine("                          closure into <artifacts>/<version>, bypassing");
+    w.WriteLine("                          need-detection entirely.");
+    w.WriteLine("  --force                 With --platform-apps/--test-apps/--service-tier: re-run");
+    w.WriteLine("                          the download even if the canonical directory already");
+    w.WriteLine("                          contains files. Without it, a populated directory is");
+    w.WriteLine("                          left alone and nothing is re-downloaded.");
+    w.WriteLine("  --resolve-version PREFIX");
+    w.WriteLine("                          Resolve a BC version prefix (e.g. \"28.4\") to the latest");
+    w.WriteLine("                          full version published on the CDN and print it to stdout.");
+    w.WriteLine("  --help, -h              Print this text and exit 0.");
+    w.WriteLine();
+    w.WriteLine("--platform-apps/--test-apps/--service-tier/--resolve-version may be combined in");
+    w.WriteLine("one invocation (each named set is fetched); --force applies to all of them.");
 }
 
 static int RunPrecompile(string[] subArgs)
@@ -6309,6 +6435,129 @@ static string? TryDeriveBcMajorFromProject(IEnumerable<string> bundlePaths)
         catch { /* unparseable manifest — fall through to next bundle / latest-in-cache */ }
     }
     return null;
+}
+
+// Issue #2085: `al-runner provision --platform-apps|--test-apps|--service-tier [--force]`
+// — a tool-install-valid replacement for `dotnet run --project tools/DownloadArtifacts --
+// <mode> <ver> <dir>`, whose whole body is a switch over the same
+// AlRunner.Provisioning.ArtifactDownloader methods this calls. That project ships only as
+// source (never part of a packaged `dotnet tool install`), so a user without a checkout had
+// no way to reach it. Downloads straight into the canonical directory each mode already
+// resolves to at runtime (BcArtifacts.ArtifactDirFor / ProvisioningCheck.PlatformAppsDirFor /
+// TestAppsDirFor) — no need-detection, no bundle scan, just "fetch this set for this
+// version." `--force` re-downloads even when the directory already looks populated;
+// without it, a populated directory is left alone (mirrors EnsureTestToolkitProvisioned's
+// existing "already present" short-circuit).
+static int RunExplicitProvisionModes(string? bcVersionArg, List<string> bundles,
+    bool platformApps, bool testApps, bool serviceTier, bool force, string? resolveVersionPrefix)
+{
+    if (resolveVersionPrefix != null)
+    {
+        var resolved = AlRunner.Provisioning.ArtifactDownloader.ResolveVersion(
+            resolveVersionPrefix, m => Console.Error.WriteLine($"[provision] {m}"));
+        if (resolved == null)
+        {
+            Console.Error.WriteLine($"[provision] could not resolve a full BC version for prefix '{resolveVersionPrefix}'.");
+            return 1;
+        }
+        Console.WriteLine(resolved); // stdout for script/agent consumption, mirrors tools/DownloadArtifacts
+        return 0;
+    }
+
+    var full = ResolveFullVersionForExplicitProvision(bcVersionArg, bundles);
+    if (full == null)
+        return 1; // the resolver already printed a loud, named reason
+
+    bool anyFailed = false;
+    if (serviceTier)
+    {
+        var dir = AlRunner.Infrastructure.BcArtifacts.ArtifactDirFor(full);
+        anyFailed |= ForceProvisionMode("BC service-tier engine DLLs", dir, full, force, "*.dll",
+            (v, d, log) => AlRunner.Provisioning.ArtifactDownloader.ServiceTier(v, d, log)) != 0;
+    }
+    if (platformApps)
+    {
+        var dir = AlRunner.Infrastructure.ProvisioningCheck.PlatformAppsDirFor(
+            AlRunner.Infrastructure.BcArtifacts.ArtifactsRootDir, full);
+        anyFailed |= ForceProvisionMode("Microsoft platform apps", dir, full, force, "*.app",
+            (v, d, log) => AlRunner.Provisioning.ArtifactDownloader.PlatformApps(v, d, log)) != 0;
+    }
+    if (testApps)
+    {
+        var dir = TestAppsDirFor(full);
+        anyFailed |= ForceProvisionMode("Microsoft test-toolkit apps", dir, full, force, "*.app",
+            (v, d, log) => AlRunner.Provisioning.ArtifactDownloader.TestApps(v, d, log)) != 0;
+    }
+    return anyFailed ? 1 : 0;
+}
+
+// Shared by every explicit provision mode: skip the download when the canonical directory
+// already contains at least one file matching <paramref name="expectedGlob"/> (unless
+// --force), otherwise run <paramref name="download"/> and report success/failure. Named
+// per-mode so the log lines read like the rest of `[provision]` output, not a generic
+// "done"/"failed".
+static int ForceProvisionMode(string label, string outputDir, string fullVersion, bool force,
+    string expectedGlob, Func<string, string, Action<string>, int> download)
+{
+    if (!force && Directory.Exists(outputDir) && Directory.EnumerateFiles(outputDir, expectedGlob).Any())
+    {
+        Console.Error.WriteLine($"[provision] {label} already present at {outputDir} for BC {fullVersion} — skipping (pass --force to re-download).");
+        return 0;
+    }
+    Console.Error.WriteLine($"[provision] fetching {label} for BC {fullVersion} → {outputDir}");
+    try
+    {
+        var rc = download(fullVersion, outputDir, m => Console.Error.WriteLine($"[provision] {m}"));
+        if (rc != 0)
+            Console.Error.WriteLine($"[provision] warning: {label} download failed for BC {fullVersion}.");
+        return rc;
+    }
+    catch (Exception ex)
+    {
+        Console.Error.WriteLine($"[provision] warning: {label} download failed for BC {fullVersion}: {ex.Message}");
+        return 1;
+    }
+}
+
+// Resolves the full 4-part BC version to target for an EXPLICIT provision mode
+// (--platform-apps/--test-apps/--service-tier). Deliberately mirrors RunProvisioning's own
+// resolution (explicit --bc-version, else the engine's own major, else the target bundle's
+// app.json major; prefer an already-cached matching version, else resolve the latest full
+// version from the CDN) — kept as a separate small function rather than sharing
+// RunProvisioning's inline block because that block's own success message ("verifying
+// completeness") describes what RunProvisioning does NEXT (an engine-closure completeness
+// check), which does not apply here.
+static string? ResolveFullVersionForExplicitProvision(string? bcVersionArg, List<string> bundles)
+{
+    if (bcVersionArg != null && System.Version.TryParse(bcVersionArg, out var maybeFull) && maybeFull.Revision >= 0
+        && bcVersionArg.Split('.').Length == 4)
+        return bcVersionArg; // an explicit 4-part version — target exactly that
+
+    var prefix = bcVersionArg
+        ?? AlRunner.Infrastructure.BcArtifacts.EngineMajor(AppContext.BaseDirectory)?.ToString()
+        ?? TryDeriveBcMajorFromProject(bundles);
+    if (prefix == null)
+    {
+        Console.Error.WriteLine("[provision] cannot determine which BC version to provision — pass " +
+            "--bc-version <ver> (no --bc-version, no engine in bin, and no readable project app.json).");
+        return null;
+    }
+    try
+    {
+        var cachedDir = AlRunner.Infrastructure.BcArtifacts.SelectArtifactVersionDir(
+            AlRunner.Infrastructure.BcArtifacts.ArtifactsRootDir, prefix);
+        var full = Path.GetFileName(cachedDir);
+        Console.Error.WriteLine($"[provision] found cached BC {full} for prefix '{prefix}'.");
+        return full;
+    }
+    catch (InvalidOperationException)
+    {
+        Console.Error.WriteLine($"[provision] no cached BC {prefix}.x — resolving latest full version from the CDN...");
+        var full = AlRunner.Provisioning.ArtifactDownloader.ResolveVersion(prefix);
+        if (full == null)
+            Console.Error.WriteLine($"[provision] could not resolve a full BC version for prefix '{prefix}'.");
+        return full;
+    }
 }
 
 // Provisioning driver for the `provision` subcommand / --auto-provision. Resolves the


### PR DESCRIPTION
Closes #2085

## Problem

Every remediation route the CLI printed on a provisioning gap assumed a source checkout:

```
(b) Download Microsoft test-toolkit apps:
      dotnet run --project tools/DownloadArtifacts -- test-apps 28.4.53241.53989 "<package-cache-dir>"
```

A `dotnet tool install -g msdyn365bc.al.runner` user has no checkout — `tools/DownloadArtifacts`
ships only as source, never as part of the packaged tool. Two of the three printed fixes were
dead ends for exactly the audience they were printed for. #2086 fixed the recommended
`al-runner provision` / `--auto-provision` route for one specific detection gap, but the
manual escape hatches were still unreachable, so the *next* detection gap (#2087) strands
the next agent the same way.

## Fix

`AlRunner.Provisioning.ArtifactDownloader` already ships inside the main binary —
`tools/DownloadArtifacts` is a 45-line wrapper over it. This exposes the same capability
directly on the shipped CLI:

```
al-runner provision --platform-apps [--bc-version V] [--force]
al-runner provision --test-apps     [--bc-version V] [--force]
al-runner provision --service-tier  [--bc-version V] [--force]
al-runner provision --resolve-version PREFIX
```

Each downloads straight into the same canonical directory the runner already resolves
at runtime (`ProvisioningCheck.PlatformAppsDirFor` / `TestAppsDirFor` /
`BcArtifacts.ArtifactDirFor`) — no `--package-cache` needed afterward. `--force`
re-downloads even when the directory already looks populated; without it, a populated
directory is left alone (verified, not silently claimed — the #2086 "already present"
honesty distinction is preserved and extended to these new paths).

Every "Resolve it" message that used to name `dotnet run --project tools/DownloadArtifacts`
(`MissingDependencyException`, `ProvisioningCheck`'s three report types, `BcArtifacts`'
`SelectArtifactVersionDir` failure, `DependencyResolver`'s "no implementation" diagnostic,
and `ArtifactDownloader.TryHeadContentLength`'s 404 hint, which fires in-process from the
shipped binary too) now names the new subcommand instead.

Also: `al-runner provision --help` used to answer `Unknown option '--help'. Run with --help
for the supported flags.` — telling the caller to run the exact thing it just ran. Subcommands
now accept `--help`/`-h` and print their own flag reference.

## Regression guard

`AlRunner.Tests/CliDocumentationTests.cs` gained
`NoRemediationText_NamesTheCheckoutOnlyDownloadArtifactsInvocation`, which scans every `.cs`
file under `AlRunner/` (the shipped assembly) for a live (non-comment) line containing
`dotnet run --project` — the same scrape style `Help_DocumentsEveryRecognizedFlag` already
uses against `Program.cs`. A future remediation string that regresses to the checkout-only
form fails this test immediately.

## Testing

New `AlRunner.Tests/ProvisionExplicitModesTests.cs` spawns the real runner binary against
an isolated, hermetically empty `$HOME` and makes a genuine download against the public BC
artifact CDN (`--test-apps`, ~20MB — the smallest of the three real sets, to keep the test
fast while still proving a real end-to-end download, not a stub):

- `TestApps_FreshCache_DownloadsRealSetIntoCanonicalDir` — positive: asserts the canonical
  directory contains real, named `.app` files (Library Assert, Test Runner) afterward, not
  just that the directory exists.
- `TestApps_SecondInvocationWithoutForce_DoesNotRedownload` — negative: a second invocation
  without `--force` leaves the already-downloaded marker file's mtime untouched.
- `TestApps_Force_RedownloadsEvenWhenAlreadyPresent` — `--force` does move the mtime.
- `ResolveVersion_PrintsFullVersionToStdout` — `--resolve-version` mirrors
  `tools/DownloadArtifacts`'s `resolve-version` mode.
- `PlatformApps_WithoutProvisionSubcommand_IsRejected` — the new flags are rejected outside
  `provision` rather than silently accepted-and-ignored.

RED confirmed against unfixed `main` (post-#2086, commit `93ff442f`): `al-runner provision
--test-apps --bc-version 28.1.49838.53910` answers `Unknown option '--test-apps'. Run with
--help for the supported flags.` and exits 2 — nothing is downloaded. GREEN on this branch:
all 5 new tests pass, plus the updated `ArtifactDownloader404Tests`,
`BcArtifactSelectionTests`, `ProvisioningCheckTests`, `AutoProvisionDefaultTests`,
`DependencyResolverTests`, and `CliDocumentationTests` (targeted run, 143 tests total, all
green).

## Verified end-to-end

On this branch, from only the built `al-runner` binary and an isolated `$HOME`:
```
al-runner provision --test-apps --bc-version 28.1.49838.53910
```
downloaded the real Microsoft test-toolkit set (Library Assert, Test Runner, Any,
Tests-TestLibraries, …) into `~/.local/share/al-runner/artifacts/28.1.49838.53910/test-apps`,
and a second invocation without `--force` left it untouched, reporting
`[provision] Microsoft test-toolkit apps already present at ... — skipping (pass --force to re-download)`.
This is the same mechanism `--platform-apps`/`--service-tier` use, per the issue's confirmed
`platform-apps` repro (116 MB, 6 apps, 1012 tests passing on BC 28.4).