### PR TITLE
fix(cli): -v/-V/version alias --version; --help prints version; --guide tells agents where to report gaps

### DIFF
--- a/AlRunner.Tests/CliDocumentationTests.cs
+++ b/AlRunner.Tests/CliDocumentationTests.cs
@@ -234,4 +234,82 @@ public sealed class CliDocumentationTests
         Assert.True(exit != 0, "A misspelled flag must not exit 0.");
         Assert.Contains("--guied", stderr, StringComparison.Ordinal);
     }
+
+    /// <summary>
+    /// --help accepts three spellings (--help, -h, help). --version accepted only
+    /// one, so `al-runner -v` fell through to the bundle-path parser and produced
+    /// an unrelated "directory not found" error instead of pointing at --version
+    /// (issue #2072). -v, -V and bare "version" must all print the identical
+    /// version string and exit 0, same as --version itself.
+    /// </summary>
+    [Fact]
+    public void Version_AcceptsAllDocumentedSpellings()
+    {
+        var (baseExit, baseOut, baseErr) = RunCli("--version");
+        Assert.True(baseExit == 0, $"--version must exit 0. exit={baseExit}\n{baseErr}");
+        Assert.Matches(new Regex(@"^al-runner v\S+"), baseOut.Trim());
+
+        foreach (var spelling in new[] { "-v", "-V", "version" })
+        {
+            var (exit, stdout, stderr) = RunCli(spelling);
+            Assert.True(exit == 0, $"'{spelling}' must exit 0 like --version. exit={exit}\n{stderr}");
+            Assert.Equal(baseOut.Trim(), stdout.Trim());
+        }
+    }
+
+    /// <summary>
+    /// Negative: accepting -v/-V/version must not turn into accepting arbitrary
+    /// short flags. An unrecognized single-dash flag still falls through to the
+    /// existing bundle-path handling and fails loud, not silently as version 0.
+    /// </summary>
+    [Fact]
+    public void Version_UnrecognizedShortFlag_StillFailsAsBefore()
+    {
+        var (exit, stdout, _) = RunCli("-q");
+        Assert.True(exit != 0, "An unrecognized short flag must not exit 0.");
+        Assert.DoesNotContain("al-runner v", stdout, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// --help never printed which build is running (issue #2072). Someone pasting
+    /// --help output into a gap report should carry their runner version with it
+    /// without being asked separately for --version's output too.
+    /// </summary>
+    [Fact]
+    public void Help_PrintsVersionAsFirstLine()
+    {
+        var (_, version, _) = RunCli("--version");
+        var (exit, help, stderr) = RunCli("--help");
+        Assert.True(exit == 0, $"--help must exit 0. exit={exit}\n{stderr}");
+
+        var firstLine = help.Split('\n', 2)[0].Trim();
+        Assert.Equal(version.Trim(), firstLine);
+    }
+
+    /// <summary>
+    /// The REPORTING A RUNNER GAP section is the replacement for telemetry (#1643,
+    /// closed as not-planned). It must actually be able to produce a report: a
+    /// caller with only the binary needs the repository URL, and the section must
+    /// tell the agent to ask its human for permission before posting anything —
+    /// without that instruction the only two behaviors left are "post without
+    /// asking" and "say nothing and work around it silently", both wrong per
+    /// .claude/rules/file-issues-for-gaps.md.
+    /// </summary>
+    [Fact]
+    public void Guide_ReportingSectionCoversWhereAndPermission()
+    {
+        var (exit, guide, stderr) = RunCli("--guide");
+        Assert.True(exit == 0, $"--guide must exit 0. exit={exit}\n{stderr}");
+
+        var idx = guide.IndexOf("REPORTING A RUNNER GAP", StringComparison.Ordinal);
+        Assert.True(idx >= 0, "--guide should keep a 'REPORTING A RUNNER GAP' section.");
+        var section = guide[idx..];
+
+        Assert.Contains("github.com/StefanMaron/BusinessCentral.AL.Runner", section, StringComparison.Ordinal);
+        Assert.Contains("ask", section, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("permission", section, StringComparison.OrdinalIgnoreCase);
+        // The existing constraint against naming an unsupported cause must survive
+        // alongside the new instructions, not be displaced by them.
+        Assert.Contains("worse than none", section, StringComparison.Ordinal);
+    }
 }

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -55,10 +55,13 @@ if (args[0] == "--guide")
     return 0;
 }
 
-if (args[0] == "--version")
+// -v/-V accepted alongside --version and bare "version" (#2072), matching the
+// three-spelling treatment --help already gets at the top of this file. -v is
+// free: --verbose (line ~348) is matched only as its long form and has no
+// short alias, so there is no ambiguity to resolve here.
+if (args[0] == "--version" || args[0] == "-v" || args[0] == "-V" || args[0] == "version")
 {
-    var asmVer = typeof(Program).Assembly.GetName().Version?.ToString() ?? "unknown";
-    Console.WriteLine($"al-runner v{asmVer}");
+    Console.WriteLine(VersionString());
     return 0;
 }
 
@@ -4495,6 +4498,14 @@ static string SanitiseFilename(string name)
 // common failure signatures mean. Keep it self-contained — the moment an agent
 // has to go read docs/ or a HANDOFF file to form a correct invocation, this
 // guide has failed at its job.
+// Shared by --version/-v/-V/version and --help's first line, so a build's
+// self-reported version can never drift between the two surfaces (#2072).
+static string VersionString()
+{
+    var asmVer = typeof(Program).Assembly.GetName().Version?.ToString() ?? "unknown";
+    return $"al-runner v{asmVer}";
+}
+
 static void PrintGuide(TextWriter w)
 {
     w.WriteLine("al-runner — AGENT GUIDE");
@@ -4727,6 +4738,23 @@ static void PrintGuide(TextWriter w)
     w.WriteLine("  A report that names a cause the evidence does not support is worse than none:");
     w.WriteLine("  it sends someone to fix a subsystem that was never involved.");
     w.WriteLine();
+    w.WriteLine("  Where to file: https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues");
+    w.WriteLine("  Gap reports are welcome — this is the replacement for the telemetry channel");
+    w.WriteLine("  that used to exist (#1643, closed not-planned); nothing is sent anywhere");
+    w.WriteLine("  automatically, and no report happens without a human reading it first.");
+    w.WriteLine();
+    w.WriteLine("  Before posting anything: ask the person you are working with for permission,");
+    w.WriteLine("  and show them the report text first. Do not open the issue on your own, and");
+    w.WriteLine("  do not silently work around the gap instead — both are wrong. Filing without");
+    w.WriteLine("  asking treats someone else's repository as yours to post to; working around it");
+    w.WriteLine("  silently is exactly what runner-gap tracking exists to prevent.");
+    w.WriteLine();
+    w.WriteLine("  An uncertain report is still worth offering, as long as the uncertainty is");
+    w.WriteLine("  stated plainly. \"I do not know what caused this, here is the reproducer\" is a");
+    w.WriteLine("  good report. \"This is a metadata cache bug\", offered with no evidence for");
+    w.WriteLine("  that specific mechanism, is not — that is the cause-without-support problem");
+    w.WriteLine("  above, just stated with more confidence than the evidence supports.");
+    w.WriteLine();
 
     w.WriteLine("FURTHER READING");
     w.WriteLine("  --help                       full flag reference");
@@ -4739,6 +4767,10 @@ static void PrintGuide(TextWriter w)
 
 static void PrintHelp(TextWriter w)
 {
+    // First line so a build carries its own version wherever --help output gets
+    // pasted (e.g. into a gap report) without asking separately for --version's
+    // output too (#2072).
+    w.WriteLine(VersionString());
     w.WriteLine("al-runner — run Business Central AL unit tests in-process.");
     w.WriteLine();
     w.WriteLine("USAGE");
@@ -4748,7 +4780,7 @@ static void PrintHelp(TextWriter w)
     w.WriteLine("  al-runner --precompile <input.app> --out <output.dll> [--package-cache PATH ...]");
     w.WriteLine("  al-runner --emit-app <bundleDir> <outPath> [--package-cache PATH ...]");
     w.WriteLine("  al-runner --guide      (operating manual for automated callers)");
-    w.WriteLine("  al-runner --version");
+    w.WriteLine("  al-runner --version   (also: -v, -V, version)");
     w.WriteLine("  al-runner --help");
     w.WriteLine();
     w.WriteLine("Agents and scripted callers should start with --guide: it covers correct");


### PR DESCRIPTION
Closes #2071
Closes #2072

## #2072 — version reporting
- `--version` accepted only one spelling while `--help` accepted three (`--help`, `-h`, `help`). `al-runner -v` fell through to the bundle-path parser and produced an unrelated "directory not found" error. Now `-v`, `-V` and bare `version` all print the identical version string and exit 0, same as `--version`.
- `--help` now prints `al-runner v<version>` as its first line, sourced from the same `VersionString()` helper `--version` uses, so the two can never drift apart.

## #2071 — `--guide` closes the reporting loop
`--guide`'s `REPORTING A RUNNER GAP` section never said where to file a gap, and never told the agent to ask its human before posting. Added, after the existing evidence checklist:
- The repository issue URL, and that gap reports are welcome (this is the replacement for the telemetry channel closed in #1643).
- An explicit instruction to ask the person the agent is working with for permission before posting anything, and to show them the report text first.
- Confirmation that an uncertain report is still worth offering as long as the uncertainty is stated plainly — the existing "worse than none" warning against naming an unsupported cause stays untouched.

## Tests
`AlRunner.Tests/CliDocumentationTests.cs` gained:
- `Version_AcceptsAllDocumentedSpellings` — `-v`, `-V`, `version` all print the same string as `--version` and exit 0.
- `Version_UnrecognizedShortFlag_StillFailsAsBefore` — an arbitrary unrecognized short flag (`-q`) still fails loud, proving the fix didn't widen into accepting arbitrary short flags.
- `Help_PrintsVersionAsFirstLine` — `--help`'s first line equals `--version`'s output.
- `Guide_ReportingSectionCoversWhereAndPermission` — asserts the repo URL, the ask/permission instructions, and that the existing "worse than none" constraint survived.

Ran `dotnet test AlRunner.Tests` in full locally (`-p:_BCVersion=28.1.49838.53910` to match the artifact cache): 1001/1002 passed, 56 skipped (engine-bootstrap-gated tests, expected on this box). The one failure, `SourceDepSymbolsWithoutPackageCacheTests.SiblingSourceDep_CompilesWithZeroPackageCacheDirs`, reproduces identically against unmodified `origin/main` — confirmed pre-existing and unrelated to this change, not touched by this diff.