### PR TITLE
docs(agents): say how to wait for CI, not just how to read it

### DIFF
--- a/.claude/agents/impl-agent.md
+++ b/.claude/agents/impl-agent.md
@@ -152,6 +152,30 @@ conflicts, not a CI outage); rebase + force-push with `--force-with-lease` if
 `DIRTY`/`CONFLICTING`. Fix CI failures, address review comments. Once merged,
 return to Step 1. One issue at a time — do not claim another while a PR is open.
 
+### Waiting for a run that has not finished
+
+Wait in the **foreground**:
+
+```
+gh run watch <run-id> --repo StefanMaron/BusinessCentral.AL.Runner
+```
+
+**Do not end your turn while CI you are responsible for is still running.** A
+background process you start inside your own turn dies when that turn ends, so
+no notification will ever arrive — you will be waiting on something already
+dead. There is no flag or wrapper that earns you a wake-up
+(`.claude/rules/no-backgrounding-long-commands.md`). Three agents lost their
+work this way in a single day, each having reported "CI is running, I'll
+confirm."
+
+Both of these must hold before you report completion:
+
+1. The run status is `completed` — not `in_progress`, and not "the last
+   completed run was green."
+2. The green check's commit SHA matches your own current `HEAD`.
+
+State the head SHA in your completion report so the claim is checkable.
+
 ---
 
 ## Hard rules

--- a/.claude/rules/ci-verdicts.md
+++ b/.claude/rules/ci-verdicts.md
@@ -37,6 +37,11 @@ The one required check on `main` is **`All BC versions passed`**
 (`.github/workflows/test-matrix.yml`); matrix legs report as
 `bc-tests / BC <ver> (required)`.
 
+Wait for a running check in the **foreground** — `gh run watch <run-id>`. Do not
+end a turn while CI you are responsible for is still running: a background
+process started inside your own turn dies with it, so the notification you are
+waiting for never comes (`no-backgrounding-long-commands.md`).
+
 ## 3. Never re-run a failed job
 
 `gh run rerun` and the web "Re-run" button overwrite the failed run's logs


### PR DESCRIPTION
Three implementation agents today ended their turn with a version of "CI is running, I will confirm when the monitor notifies me." The notification never arrives — a background process started inside a turn dies when that turn ends. Each time the PR sat unmerged and the work read as done; I had to read the verdict myself, and two of the three runs were red.

`.claude/rules/no-backgrounding-long-commands.md` already covers this and is auto-loaded. It was being followed for long test runs and ignored for CI waits, which says the rule was not reaching agents at the moment they needed it: the end of Step 5, right after pushing. Step 5 gave the two commands for reading status and said nothing about waiting for a run still in progress, so agents invented a background monitor.

**`.claude/agents/impl-agent.md`** — Step 5 now names the foreground command (`gh run watch`), states the prohibition directly, and lists the two conditions that must both hold before reporting completion: the run status is `completed`, and the green checks commit SHA matches the agents own `HEAD`. Agents are asked to state that SHA in their report so the claim is checkable rather than taken on trust.

**`.claude/rules/ci-verdicts.md`** — the same point added next to "a verdict is about one commit", which is where the verdict-reading rules live after #2094.

No code change.

Closes #2098