### PR TITLE
fix(deps): report missing/too-old third-party deps as provisioning gaps, not COMPILE-FAIL

### DIFF
--- a/AlRunner.Tests/DependencyResolverTests.cs
+++ b/AlRunner.Tests/DependencyResolverTests.cs
@@ -117,8 +117,8 @@ public sealed class DependencyResolverTests : IDisposable
 
     /// <summary>
     /// Dep requires minimum v29.0; only v17 and v28.1 are available.
-    /// Must throw InvalidOperationException whose message names the available versions.
-    /// (This is a version-mismatch problem, not a provisioning gap.)
+    /// Must throw DependencyVersionMismatchException whose message names the available
+    /// versions. (This is a version-mismatch problem, not a provisioning gap — #2095.)
     /// </summary>
     [Fact]
     public void MinimumNotSatisfied_ThrowsWithVersionDetail()
@@ -134,7 +134,8 @@ public sealed class DependencyResolverTests : IDisposable
         var dep = new DependencyRef(Guid.Parse(appId), "TestLib", "Microsoft",
             new Version(29, 0, 0, 0));
 
-        var ex = Assert.Throws<InvalidOperationException>(() => resolver.Resolve(new[] { dep }));
+        var ex = Assert.Throws<AlRunner.Infrastructure.DependencyVersionMismatchException>(
+            () => resolver.Resolve(new[] { dep }));
         // Error must mention the too-low versions so the problem is obviously a version issue.
         Assert.Contains("29.0", ex.Message);
         Assert.Contains("17.0", ex.Message);
@@ -236,11 +237,110 @@ public sealed class DependencyResolverTests : IDisposable
     }
 
     /// <summary>
-    /// Version near-miss (dep found but below minimum) still throws InvalidOperationException,
-    /// not MissingDependencyException — backward compatibility for existing callers.
+    /// #2095: the non-Microsoft branch names the flag CONCRETELY (with an example dir)
+    /// and says where that dir usually lives, for an agent that has never used this tool.
     /// </summary>
     [Fact]
-    public void VersionNearMiss_StillThrowsInvalidOperationException_NotMissingDependencyException()
+    public void DepCompletelyAbsent_ToDetailedMessage_ThirdPartyDep_NamesPackageCacheFlagConcretely()
+    {
+        var dir = MakeDir("MDE_msg_3p_concrete");
+        var ex = new AlRunner.Infrastructure.MissingDependencyException(
+            "Contoso", "Contoso Core Library", "5.0.0.0",
+            Guid.NewGuid(), new[] { dir });
+
+        var msg = ex.ToDetailedMessage("28.2.50931.52786");
+
+        Assert.Contains("--package-cache <dir>", msg);
+        Assert.Contains(".alpackages", msg);
+    }
+
+    /// <summary>
+    /// #2095: MissingDependencyException is recognized by the shared
+    /// IDependencyProvisioningDiagnostic marker Program.cs uses to special-case both
+    /// dependency-resolution exceptions ahead of the generic COMPILE-FAIL path.
+    /// </summary>
+    [Fact]
+    public void MissingDependencyException_ImplementsSharedProvisioningDiagnosticInterface()
+    {
+        var ex = new AlRunner.Infrastructure.MissingDependencyException(
+            "Contoso", "Contoso Core Library", "5.0.0.0", Guid.NewGuid(), Array.Empty<string>());
+
+        Assert.IsAssignableFrom<AlRunner.Infrastructure.IDependencyProvisioningDiagnostic>(ex);
+    }
+
+    // ── Part 2c: dep found but every version too old → DependencyVersionMismatchException ──
+
+    /// <summary>
+    /// #2095: DependencyVersionMismatchException.ToDetailedMessage names the "VERSION gap"
+    /// (not "PROVISIONING gap" — the dep IS in the cache, just too old), tells the reader
+    /// to obtain a newer build, and does NOT repeat the searched directories (already
+    /// implied by "Available (all too old)").
+    /// </summary>
+    [Fact]
+    public void DependencyVersionMismatch_ToDetailedMessage_NamesVersionGapAndNewerBuildAdvice()
+    {
+        var ex = new AlRunner.Infrastructure.DependencyVersionMismatchException(
+            "Acme Corp", "Acme Add-On", "2.0.0.0", Guid.NewGuid(),
+            new[] { "/some/cache/dir" }, "1.0.0.0");
+
+        var msg = ex.ToDetailedMessage();
+
+        Assert.Contains("VERSION gap", msg);
+        Assert.Contains("your code is NOT the problem", msg);
+        Assert.Contains("Acme Add-On", msg);
+        Assert.Contains("2.0.0.0", msg);
+        Assert.Contains("1.0.0.0", msg);
+        Assert.Contains("--package-cache", msg);
+        // Not a compile failure, not the missing-dep wording.
+        Assert.DoesNotContain("COMPILE-FAIL", msg);
+        Assert.DoesNotContain("PROVISIONING gap", msg);
+    }
+
+    /// <summary>
+    /// #2095 root cause: the short .Message unconditionally appended "Stack: " even when
+    /// the too-old dependency was a ROOT of the resolve call (empty chain), leaving a
+    /// dangling "Stack: " with nothing after it. Must be omitted entirely, not printed empty.
+    /// </summary>
+    [Fact]
+    public void DependencyVersionMismatch_RootLevelDependency_NoDanglingStackSegment()
+    {
+        var appId = "eeeeeeee-0000-0000-0000-000000000001";
+        var dir = MakeDir("VM_root");
+        WriteApp(dir, "App_v1.app", appId, "RootDep", "SomePub", "1.0.0.0");
+
+        var resolver = new DependencyResolver(new[] { dir });
+        // Root-level dep (empty stack) requiring a version that isn't available.
+        var dep = new DependencyRef(Guid.Parse(appId), "RootDep", "SomePub", new Version(2, 0, 0, 0));
+
+        var ex = Assert.Throws<AlRunner.Infrastructure.DependencyVersionMismatchException>(
+            () => resolver.Resolve(new[] { dep }));
+
+        Assert.Null(ex.DependencyStack);
+        Assert.DoesNotContain("Stack:", ex.Message);
+        Assert.DoesNotContain("Dependency chain:", ex.ToDetailedMessage());
+    }
+
+    /// <summary>
+    /// DependencyVersionMismatchException implements the same shared marker interface as
+    /// MissingDependencyException, so Program.cs recognizes both without a type check per
+    /// exception name.
+    /// </summary>
+    [Fact]
+    public void DependencyVersionMismatchException_ImplementsSharedProvisioningDiagnosticInterface()
+    {
+        var ex = new AlRunner.Infrastructure.DependencyVersionMismatchException(
+            "Acme Corp", "Acme Add-On", "2.0.0.0", Guid.NewGuid(),
+            Array.Empty<string>(), "1.0.0.0");
+
+        Assert.IsAssignableFrom<AlRunner.Infrastructure.IDependencyProvisioningDiagnostic>(ex);
+    }
+
+    /// <summary>
+    /// Version near-miss (dep found but below minimum) throws DependencyVersionMismatchException,
+    /// not MissingDependencyException — the two need different advice (#2095).
+    /// </summary>
+    [Fact]
+    public void VersionNearMiss_ThrowsDependencyVersionMismatchException_NotMissingDependencyException()
     {
         var appId = "dddddddd-0000-0000-0000-000000000001";
         var dir = MakeDir("MDE_nearmiss");
@@ -250,9 +350,10 @@ public sealed class DependencyResolverTests : IDisposable
         var dep = new DependencyRef(Guid.Parse(appId), "SomeLib", "SomePub",
             new Version(10, 0, 0, 0)); // requires v10 but only v5 exists
 
-        // Must be InvalidOperationException (version near-miss), NOT MissingDependencyException
-        // (completely absent).
-        var ex = Assert.Throws<InvalidOperationException>(() => resolver.Resolve(new[] { dep }));
+        // Must be DependencyVersionMismatchException (version near-miss), NOT
+        // MissingDependencyException (completely absent).
+        var ex = Assert.Throws<AlRunner.Infrastructure.DependencyVersionMismatchException>(
+            () => resolver.Resolve(new[] { dep }));
         Assert.IsNotType<AlRunner.Infrastructure.MissingDependencyException>(ex);
         Assert.Contains("5.0", ex.Message);
     }
@@ -309,7 +410,8 @@ public sealed class DependencyResolverTests : IDisposable
         var dep = new DependencyRef(Guid.Parse(appIdX), "Shared", "Vendor",
             new Version(10, 0, 0, 0));
 
-        var ex = Assert.Throws<InvalidOperationException>(() => resolver.Resolve(new[] { dep }));
+        var ex = Assert.Throws<AlRunner.Infrastructure.DependencyVersionMismatchException>(
+            () => resolver.Resolve(new[] { dep }));
         // Should report that v5 was found (near-miss) — not silently succeed.
         Assert.Contains("5.0", ex.Message);
     }

--- a/AlRunner.Tests/SiblingSourceDepProvisioningReportingTests.cs
+++ b/AlRunner.Tests/SiblingSourceDepProvisioningReportingTests.cs
@@ -1,0 +1,298 @@
+using System.Diagnostics;
+using System.IO.Compression;
+using System.Text;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// #2095: a missing/too-old THIRD-PARTY dependency reached through
+/// <c>Program.BuildSiblingSourceDeps</c>'s own dependency resolution (resolving the
+/// sibling source app's OWN <c>dependencies</c>, not the main bundle's) was folded into
+/// the generic <c>catch (Exception ex)</c> at that call site and printed as
+/// <c>"&lt;sibling-source-deps&gt;: COMPILE-FAIL — {ex.Message}"</c> — the SHORT one-line
+/// form of the exception, under a label that reads as "your AL code did not compile"
+/// when it is actually a provisioning or version gap the reader cannot fix by touching
+/// their AL.
+///
+/// Three tests, all through the real spawned runner (same shape as
+/// LayeredDepManifestTests, which covers the sibling RunLayeredPrePass call site for the
+/// same #1898 unhandled-exception fix):
+///   - Positive (missing): the sibling source app's own declared dependency is absent
+///     from every cache dir → provisioning-gap wording, --package-cache guidance, no
+///     COMPILE-FAIL.
+///   - Positive (version too old): the dependency IS present but every candidate is
+///     below the declared minimum → version-gap wording, no COMPILE-FAIL.
+///   - Negative (regression guard for #1898): a genuine failure on the SAME call site
+///     that is NOT one of the two dependency-resolution exceptions must still report
+///     exactly as it does today — "COMPILE-FAIL" + exit 3 — proving the special case
+///     did not swallow the general one.
+///
+/// Spawns the real runner; needs the BC artifact cache. Skips (no-op) when absent.
+/// </summary>
+public class SiblingSourceDepProvisioningReportingTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+    private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
+
+    private static (string output, int exit) RunRunner(string mainBundle, string? packageCacheDir)
+    {
+        var args = new StringBuilder(TestBuildConfig.RunArgs(ProjectPath));
+        args.Append(TestBuildConfig.BcVersionArg);
+        if (packageCacheDir != null)
+            args.Append(" --package-cache \"").Append(packageCacheDir).Append('"');
+        args.Append(" \"").Append(mainBundle).Append('"');
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet", Arguments = args.ToString(),
+            RedirectStandardOutput = true, RedirectStandardError = true,
+            UseShellExecute = false, CreateNoWindow = true, WorkingDirectory = RepoRoot,
+        };
+        var sb = new StringBuilder();
+        var p = Process.Start(psi)!;
+        p.OutputDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.ErrorDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.BeginOutputReadLine();
+        p.BeginErrorReadLine();
+        if (!p.WaitForExit(180_000)) { try { p.Kill(true); } catch { } throw new TimeoutException("runner hung"); }
+        p.WaitForExit();
+        lock (sb) return (sb.ToString(), p.ExitCode);
+    }
+
+    private static void WriteMain(string dir, string id, int idFrom, string sidekickId, int testCodeunitId)
+    {
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "app.json"), $$"""
+        {
+          "id": "{{id}}",
+          "name": "SSD Main",
+          "publisher": "AL Runner",
+          "version": "1.0.0.0",
+          "dependencies": [
+            { "id": "{{sidekickId}}", "name": "SSD Sidekick", "publisher": "AL Runner", "version": "1.0.0.0" }
+          ],
+          "platform": "1.0.0.0",
+          "application": "1.0.0.0",
+          "idRanges": [ { "from": {{idFrom}}, "to": {{idFrom + 19}} } ],
+          "runtime": "14.0"
+        }
+        """);
+        File.WriteAllText(Path.Combine(dir, "Tests.Codeunit.al"), $$"""
+        codeunit {{testCodeunitId}} "SSD Tests"
+        {
+            Subtype = Test;
+
+            [Test]
+            procedure NeverReached()
+            begin
+                Error('should never compile far enough to run this');
+            end;
+        }
+        """);
+    }
+
+    /// <summary>
+    /// Sidekick's OWN app.json declares a dependency on a third-party app that is
+    /// completely absent from every searched cache dir. Optionally omits
+    /// contextSensitiveHelpUrl to also produce a genuine AL0543 further down the
+    /// pipeline — irrelevant here, we never get that far.
+    /// </summary>
+    private static void WriteSidekick(string dir, string id, int idFrom,
+        string thirdPartyId, string thirdPartyMinVersion, int codeunitId)
+    {
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "app.json"), $$"""
+        {
+          "id": "{{id}}",
+          "name": "SSD Sidekick",
+          "publisher": "AL Runner",
+          "version": "1.0.0.0",
+          "dependencies": [
+            { "id": "{{thirdPartyId}}", "name": "Acme Add-On", "publisher": "Acme Corp", "version": "{{thirdPartyMinVersion}}" }
+          ],
+          "platform": "1.0.0.0",
+          "application": "1.0.0.0",
+          "idRanges": [ { "from": {{idFrom}}, "to": {{idFrom + 19}} } ],
+          "runtime": "14.0"
+        }
+        """);
+        File.WriteAllText(Path.Combine(dir, "Answer.Codeunit.al"), $$"""
+        codeunit {{codeunitId}} "SSD Sidekick Answer"
+        {
+            procedure Answer(): Integer
+            begin
+                exit(42);
+            end;
+        }
+        """);
+    }
+
+    /// <summary>
+    /// Sidekick whose own manifest genuinely omits contextSensitiveHelpUrl for a page
+    /// that requires it — a real AL0543, unrelated to dependency resolution (no
+    /// declared dependencies at all). Used as the regression guard: the SAME
+    /// try/catch this issue touches must still report a non-dependency failure the way
+    /// it always has.
+    /// </summary>
+    private static void WriteBadManifestSidekick(string dir, string id, int idFrom,
+        int pageId, int codeunitId)
+    {
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "app.json"), $$"""
+        {
+          "id": "{{id}}",
+          "name": "SSD Sidekick",
+          "publisher": "AL Runner",
+          "version": "1.0.0.0",
+          "dependencies": [],
+          "platform": "1.0.0.0",
+          "application": "1.0.0.0",
+          "idRanges": [ { "from": {{idFrom}}, "to": {{idFrom + 19}} } ],
+          "runtime": "14.0"
+        }
+        """);
+        File.WriteAllText(Path.Combine(dir, "HelpAware.Page.al"), $$"""
+        page {{pageId}} "SSD Help Aware Page"
+        {
+            PageType = Card;
+            ContextSensitiveHelpPage = 'sales-invoice';
+
+            layout
+            {
+                area(Content)
+                {
+                    field(Dummy; DummyValue) { ApplicationArea = All; Caption = 'Dummy'; }
+                }
+            }
+
+            var
+                DummyValue: Text[30];
+        }
+        """);
+        File.WriteAllText(Path.Combine(dir, "Answer.Codeunit.al"), $$"""
+        codeunit {{codeunitId}} "SSD Sidekick Answer"
+        {
+            procedure Answer(): Integer
+            begin
+                exit(42);
+            end;
+        }
+        """);
+    }
+
+    /// <summary>Writes a minimal NAVX .app file (header + ZIP with NavxManifest.xml) — a
+    /// synthetic third-party dependency package for the resolver to index, without
+    /// needing a real BC compile.</summary>
+    private static void WriteMinimalApp(string dir, string fileName, string appId, string name,
+        string publisher, string version)
+    {
+        Directory.CreateDirectory(dir);
+        var xml = $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <Package xmlns="http://schemas.microsoft.com/navx/2015/manifest">
+              <App Id="{appId}" Name="{name}" Publisher="{publisher}" Version="{version}"/>
+            </Package>
+            """;
+        using var ms = new MemoryStream();
+        using (var zip = new ZipArchive(ms, ZipArchiveMode.Create, leaveOpen: true))
+        {
+            var entry = zip.CreateEntry("NavxManifest.xml");
+            using var es = entry.Open();
+            es.Write(Encoding.UTF8.GetBytes(xml));
+        }
+        var zipBytes = ms.ToArray();
+        // NAVX wrapper AppLoader.NavxZipOffset actually recognizes: magic "NAVX" + LE
+        // uint32 zip offset (8) + zip bytes immediately after. A file that does not start
+        // with "NAVX" reads as zip-offset-0, i.e. THIS byte stream must itself be a valid
+        // zip — which a zero-filled placeholder header is not, so the .app silently fails
+        // to parse (AppLoader.ReadManifest returns null) and never gets indexed at all.
+        var result = new byte[8 + zipBytes.Length];
+        result[0] = (byte)'N'; result[1] = (byte)'A'; result[2] = (byte)'V'; result[3] = (byte)'X';
+        BitConverter.TryWriteBytes(result.AsSpan(4, 4), (uint)8);
+        zipBytes.CopyTo(result, 8);
+        File.WriteAllBytes(Path.Combine(dir, fileName), result);
+    }
+
+    [SkippableFact]
+    public void SiblingDep_ThirdPartyDependencyMissingEverywhere_ReportsProvisioningGap_NotCompileFail()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var root = Path.Combine(Path.GetTempPath(), "al-runner-ssd-missing", Guid.NewGuid().ToString("N"));
+        var mainDir = Path.Combine(root, "main");
+        var sidekickDir = Path.Combine(root, "sidekick");
+        var emptyCacheDir = Path.Combine(root, "empty-cache");
+        Directory.CreateDirectory(emptyCacheDir);
+        var mainId = "5cd10000-0000-4000-8000-0000000000c1";
+        var sidekickId = "5cd10000-0000-4000-8000-0000000000c2";
+        var thirdPartyId = "5cd10000-0000-4000-8000-0000000000c3";
+
+        WriteMain(mainDir, mainId, 60950, sidekickId, 60950);
+        WriteSidekick(sidekickDir, sidekickId, 60960, thirdPartyId, "2.0.0.0", 60961);
+
+        var (output, exit) = RunRunner(mainDir, emptyCacheDir);
+
+        // Must NOT be mislabeled as a compile failure.
+        Assert.DoesNotContain("COMPILE-FAIL", output);
+        Assert.DoesNotContain("Unhandled exception", output);
+        // Must reach the detailed, actionable message: names the gap kind and the fix.
+        Assert.Contains("PROVISIONING gap", output);
+        Assert.Contains("Acme Add-On", output);
+        Assert.Contains("--package-cache", output);
+        Assert.Equal(2, exit);
+    }
+
+    [SkippableFact]
+    public void SiblingDep_ThirdPartyDependencyPresentButTooOld_ReportsVersionGap_NotCompileFail()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var root = Path.Combine(Path.GetTempPath(), "al-runner-ssd-oldver", Guid.NewGuid().ToString("N"));
+        var mainDir = Path.Combine(root, "main");
+        var sidekickDir = Path.Combine(root, "sidekick");
+        var cacheDir = Path.Combine(root, "cache");
+        var mainId = "5cd20000-0000-4000-8000-0000000000d1";
+        var sidekickId = "5cd20000-0000-4000-8000-0000000000d2";
+        var thirdPartyId = "5cd20000-0000-4000-8000-0000000000d3";
+
+        WriteMain(mainDir, mainId, 60970, sidekickId, 60970);
+        WriteSidekick(sidekickDir, sidekickId, 60980, thirdPartyId, "2.0.0.0", 60981);
+        // Third-party dep IS in the cache, but only at v1.0.0.0 — below the declared v2.0.0.0.
+        WriteMinimalApp(cacheDir, "AcmeAddOn_v1.app", thirdPartyId, "Acme Add-On", "Acme Corp", "1.0.0.0");
+
+        var (output, exit) = RunRunner(mainDir, cacheDir);
+
+        Assert.DoesNotContain("COMPILE-FAIL", output);
+        Assert.DoesNotContain("Unhandled exception", output);
+        Assert.Contains("VERSION gap", output);
+        Assert.Contains("Acme Add-On", output);
+        // Names the fix: get a build at/above the declared minimum.
+        Assert.Contains("2.0.0.0", output);
+        Assert.Equal(2, exit);
+    }
+
+    [SkippableFact]
+    public void SiblingDep_GenuineManifestFailure_StillReportsCompileFail_Exit3()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var root = Path.Combine(Path.GetTempPath(), "al-runner-ssd-badmanifest", Guid.NewGuid().ToString("N"));
+        var mainDir = Path.Combine(root, "main");
+        var sidekickDir = Path.Combine(root, "sidekick");
+        var mainId = "5cd30000-0000-4000-8000-0000000000e1";
+        var sidekickId = "5cd30000-0000-4000-8000-0000000000e2";
+
+        WriteMain(mainDir, mainId, 60990, sidekickId, 60990);
+        WriteBadManifestSidekick(sidekickDir, sidekickId, 60995, 60995, 60996);
+
+        var (output, exit) = RunRunner(mainDir, packageCacheDir: null);
+
+        // A genuine non-dependency-resolution failure on the SAME call site must still
+        // report exactly as it always has — the #2095 special case must not swallow it.
+        Assert.Contains("AL0543", output);
+        Assert.DoesNotContain("Unhandled exception", output);
+        Assert.Contains("<sibling-source-deps>: COMPILE-FAIL", output);
+        Assert.Equal(3, exit);
+    }
+}

--- a/AlRunner/DependencyResolver.cs
+++ b/AlRunner/DependencyResolver.cs
@@ -108,12 +108,13 @@ public sealed class DependencyResolver
             if (nearMissVersions != null)
             {
                 // Dep IS in the cache, but every candidate is below the declared minimum version.
-                // This is a version-mismatch problem, not a provisioning gap.
-                throw new InvalidOperationException(
-                    $"Dependency not found: {dep.Publisher}/{dep.Name} v{dep.Version} " +
-                    $"(found same-named package at {nearMissVersions} — all below minimum v{dep.Version}). " +
-                    $"Searched: {string.Join(", ", _cacheDirs)}. " +
-                    $"Stack: {string.Join(" -> ", stack.Reverse())}");
+                // This is a version-mismatch problem, not a provisioning gap — throw a distinct
+                // exception (not MissingDependencyException) so Program.cs can give the right
+                // advice ("get a newer build") instead of "add the missing package" (#2095).
+                throw new AlRunner.Infrastructure.DependencyVersionMismatchException(
+                    dep.Publisher, dep.Name, dep.Version.ToString(), dep.AppId,
+                    _cacheDirs.ToList(), nearMissVersions,
+                    stack.Count > 0 ? string.Join(" → ", stack.Reverse()) : null);
             }
             // Dep is completely absent from every searched directory — this is a provisioning gap.
             // Throw MissingDependencyException (not InvalidOperationException) so Program.cs can

--- a/AlRunner/Infrastructure/DependencyVersionMismatchException.cs
+++ b/AlRunner/Infrastructure/DependencyVersionMismatchException.cs
@@ -1,0 +1,109 @@
+// DependencyVersionMismatchException — thrown by DependencyResolver when a declared
+// dependency IS present in one or more package-cache directories, but every available
+// build is below the minimum version app.json declares.
+//
+// Distinct from MissingDependencyException (dep is absent everywhere) — the two need
+// different advice: "add the package" vs. "get a newer build of the package you already
+// have". Neither is a compile failure, so callers must not fold it into a generic
+// "COMPILE-FAIL" line (see #2095).
+//
+// See: .claude/rules/loud-failures.md
+
+namespace AlRunner.Infrastructure;
+
+/// <summary>
+/// Common shape for the two dependency-resolution exceptions that are provisioning
+/// problems, not compile failures: <see cref="MissingDependencyException"/> (absent
+/// everywhere) and <see cref="DependencyVersionMismatchException"/> (present, too old).
+/// Lets a single catch clause in Program.cs recognize either without special-casing each
+/// type by name.
+/// </summary>
+public interface IDependencyProvisioningDiagnostic
+{
+    /// <summary>
+    /// One loud, self-contained message naming the problem and the exact fix. Detailed
+    /// enough for an end user or an agent to act on without any additional context.
+    /// </summary>
+    string ToDetailedMessage(string? bcVersion = null);
+}
+
+/// <summary>
+/// Thrown by DependencyResolver when a declared dependency app IS found in the package
+/// cache, but every candidate version is below the minimum app.json declares. Carries the
+/// dep identity + the too-old versions that were found so callers can emit ONE loud,
+/// actionable "version gap" message (not a misleading "your code is wrong" message, and
+/// not the "add the missing package" advice that fits MissingDependencyException instead).
+/// </summary>
+public sealed class DependencyVersionMismatchException : Exception, IDependencyProvisioningDiagnostic
+{
+    public string DepPublisher { get; }
+    public string DepName { get; }
+    public string DepMinVersion { get; }
+    public Guid DepAppId { get; }
+    public IReadOnlyList<string> SearchedDirs { get; }
+    public string AvailableVersions { get; }
+    /// <summary>
+    /// Human-readable "A → B → C" chain leading to this dependency, or null when this
+    /// dependency was a root of the resolve call (no chain to show — omit the whole
+    /// segment rather than print an empty one).
+    /// </summary>
+    public string? DependencyStack { get; }
+
+    public DependencyVersionMismatchException(
+        string depPublisher,
+        string depName,
+        string depMinVersion,
+        Guid depAppId,
+        IReadOnlyList<string> searchedDirs,
+        string availableVersions,
+        string? dependencyStack = null)
+        : base(BuildShortMessage(depPublisher, depName, depMinVersion, searchedDirs, availableVersions, dependencyStack))
+    {
+        DepPublisher = depPublisher;
+        DepName = depName;
+        DepMinVersion = depMinVersion;
+        DepAppId = depAppId;
+        SearchedDirs = searchedDirs;
+        AvailableVersions = availableVersions;
+        DependencyStack = dependencyStack;
+    }
+
+    private static string BuildShortMessage(
+        string pub, string name, string minVersion, IReadOnlyList<string> dirs,
+        string availableVersions, string? stack)
+    {
+        var msg = $"Dependency version too old: {pub}/{name} requires >= v{minVersion} " +
+                  $"(found {availableVersions} — all below minimum v{minVersion}). " +
+                  $"Searched: {string.Join(", ", dirs)}";
+        // Omit the "Stack:" segment entirely for a root-level dependency (empty chain) —
+        // printing it unconditionally left a dangling "Stack: " with nothing after it.
+        if (!string.IsNullOrEmpty(stack))
+            msg += $". Stack: {stack}";
+        return msg;
+    }
+
+    /// <inheritdoc/>
+    public string ToDetailedMessage(string? bcVersion = null)
+    {
+        var lines = new List<string>
+        {
+            "A dependency package is present in your package cache, but every available",
+            "build is older than the version required by app.json.",
+            "  This is a VERSION gap — your code is NOT the problem.",
+            "",
+            $"  Required: {DepPublisher}/{DepName} v{DepMinVersion} or newer",
+        };
+        if (DepAppId != Guid.Empty)
+            lines.Add($"  App ID:  {DepAppId}");
+        lines.Add($"  Available (all too old): {AvailableVersions}");
+        if (DependencyStack is { Length: > 0 })
+            lines.Add($"  Dependency chain: {DependencyStack}");
+        lines.Add("");
+        lines.Add("  Resolve it:");
+        lines.Add("");
+        lines.Add($"  Obtain a build of {DepPublisher}/{DepName} at or above v{DepMinVersion} and");
+        lines.Add("  add it to your --package-cache <dir> (usually your project's .alpackages).");
+
+        return string.Join(Environment.NewLine, lines);
+    }
+}

--- a/AlRunner/Infrastructure/MissingDependencyException.cs
+++ b/AlRunner/Infrastructure/MissingDependencyException.cs
@@ -17,7 +17,7 @@ namespace AlRunner.Infrastructure;
 /// emit ONE loud, actionable "provisioning gap" message (not a misleading "your code is wrong"
 /// message).
 /// </summary>
-public sealed class MissingDependencyException : Exception
+public sealed class MissingDependencyException : Exception, IDependencyProvisioningDiagnostic
 {
     public string DepPublisher { get; }
     public string DepName { get; }
@@ -88,8 +88,13 @@ public sealed class MissingDependencyException : Exception
         }
         else
         {
-            lines.Add("  Add the missing package to your --package-cache directory.");
-            lines.Add("  Verify the package version satisfies the minimum declared in app.json.");
+            // Third-party (non-Microsoft) dep: the runner cannot download this from
+            // anywhere, so the fix is entirely on the reader — name the flag concretely
+            // (with an example dir) so an agent that has never used this tool can act
+            // without guessing what "--package-cache" means or where that dir usually is.
+            lines.Add("  Add the missing package to your --package-cache <dir> (usually your");
+            lines.Add("  project's .alpackages). Verify the package version satisfies the");
+            lines.Add("  minimum declared in app.json.");
         }
 
         return string.Join(Environment.NewLine, lines);

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -1444,11 +1444,33 @@ var layeredWorkspaceDirs = new List<string>();
 // compile-time failure in this file does: a "<layered-deps>: COMPILE-FAIL" line on
 // stderr and the documented exit code 3 (docs/server-mode.md's "3 compilation error"
 // ladder — same code EMIT-ZERO/COMPILE-FAIL already return elsewhere in Main).
+//
+// #2095: a MissingDependencyException / DependencyVersionMismatchException reaching
+// either catch below is NOT a compile failure — it is a provisioning/version gap
+// discovered while resolving THIS pre-pass's OWN dependency closure (e.g. a sibling
+// source app's declared dep that no cache dir has, or has only too-old builds of).
+// Folding it into the generic "COMPILE-FAIL — {ex.Message}" line prints the short
+// one-liner (ex.Message) instead of the detailed, actionable ToDetailedMessage() the
+// exception already carries, and mislabels a missing/too-old package as "your AL code
+// did not compile". Special-case both (via the shared IDependencyProvisioningDiagnostic
+// marker) ahead of the generic path; every other exception keeps today's COMPILE-FAIL /
+// exit 3 behavior unchanged. Exit code 2 ("execution error" in docs/server-mode.md's
+// ladder) matches the ProvisioningCheck gap report a few hundred lines up (Program.cs,
+// the "Completeness gate" block) — same shape (bare ToDetailedMessage, no compile even
+// attempted yet) and the same exit code.
 if (bundles.Count > 1)
 {
     try
     {
         packageCacheDirs = RunLayeredPrePass(bundles, packageCacheDirs, layeredWorkspaceDirs);
+    }
+    catch (Exception ex) when (ex is AlRunner.Infrastructure.IDependencyProvisioningDiagnostic diag)
+    {
+        var bcVer = AlRunner.Infrastructure.BcArtifacts.SelectedVersion.ToString();
+        Console.Error.WriteLine();
+        Console.Error.WriteLine(diag.ToDetailedMessage(bcVer));
+        Console.Error.WriteLine();
+        return 2;
     }
     catch (Exception ex)
     {
@@ -1461,9 +1483,18 @@ if (bundles.Count > 1)
 // .app in any cache) — e.g. the corpus internalsVisibleTo fixture next to the
 // main test app. Inert when no declared dep matches a sibling source app.
 // Same unhandled-exception exposure as RunLayeredPrePass above (#1898) — same fix.
+// Same #2095 provisioning/version-gap special-case as RunLayeredPrePass above.
 try
 {
     packageCacheDirs = BuildSiblingSourceDeps(bundles, packageCacheDirs, layeredWorkspaceDirs);
+}
+catch (Exception ex) when (ex is AlRunner.Infrastructure.IDependencyProvisioningDiagnostic diag)
+{
+    var bcVer = AlRunner.Infrastructure.BcArtifacts.SelectedVersion.ToString();
+    Console.Error.WriteLine();
+    Console.Error.WriteLine(diag.ToDetailedMessage(bcVer));
+    Console.Error.WriteLine();
+    return 2;
 }
 catch (Exception ex)
 {


### PR DESCRIPTION
Closes #2095

## What was wrong

`RunLayeredPrePass`/`BuildSiblingSourceDeps`'s catch blocks in `Program.cs` caught `Exception` broadly and printed `"<layered-deps>: COMPILE-FAIL — {ex.Message}"` / `"<sibling-source-deps>: COMPILE-FAIL — {ex.Message}"`. When the cause was a missing or version-mismatched third-party dependency, this:

1. Mislabeled a provisioning/version problem as a compile failure.
2. Printed only the short one-line `.Message`, never the detailed, actionable `ToDetailedMessage()` the exception already carries.

Widened during review: a **present-but-too-old** third-party dependency threw a plain `InvalidOperationException` from `DependencyResolver.cs` with the same problems, plus a "Stack: " segment that printed with nothing after it when the dependency was a root of the resolve call.

## Fix

- Added `DependencyVersionMismatchException` (`AlRunner/Infrastructure/DependencyVersionMismatchException.cs`) alongside the existing `MissingDependencyException`, both implementing a new shared `IDependencyProvisioningDiagnostic` marker interface with `ToDetailedMessage(bcVersion)`.
- `DependencyResolver.cs` now throws `DependencyVersionMismatchException` (not `InvalidOperationException`) for the "found but too old" case, and omits the "Stack:" segment entirely when the dependency chain is empty instead of printing a dangling one.
- Both `Program.cs` catch blocks now special-case `IDependencyProvisioningDiagnostic` ahead of the generic `Exception` path: they print `ToDetailedMessage(bcVersion)` and return exit code **2**, instead of `COMPILE-FAIL`/exit 3. Every other exception on that path is untouched (still `COMPILE-FAIL`/exit 3), verified by a regression test that reproduces the original #1898 AL0543 scenario through the sibling-source path.
- `MissingDependencyException`'s non-Microsoft advice now names the flag concretely (`--package-cache <dir>`) and says the directory is usually the project's `.alpackages`.

## Exit code

Per the issue, exit 3 stays unless a documented code fits better. I found two existing precedents that both disagree with 3 for this case:
- `Program.cs`'s per-bundle-loop `MissingDependencyException` handler (unrelated call site, deeper in the pipeline) returns **1**.
- The artifact-completeness `ProvisioningCheck` gap report — same shape (bare `ToDetailedMessage()`, no compile ever attempted) — returns **2**.

I went with **2** ("execution error" in `docs/server-mode.md`'s ladder) because it matches the `ProvisioningCheck` precedent both in timing (this also runs before any bundle compiles) and in message shape (no label prefix, blank lines around the detailed message). Flagging the `1` precedent here in case the exit-code convention should instead unify around that one.

## Tests

- `AlRunner.Tests/DependencyResolverTests.cs`: updated 3 existing tests that asserted `InvalidOperationException` for the version-mismatch case to assert `DependencyVersionMismatchException` instead (a deliberate behavior change), plus new tests for `ToDetailedMessage()` wording, the shared interface, and the no-dangling-"Stack:" fix.
- `AlRunner.Tests/SiblingSourceDepProvisioningReportingTests.cs` (new): three CLI-level tests spawning the real runner through `BuildSiblingSourceDeps` — missing dep → provisioning-gap wording/exit 2, too-old dep → version-gap wording/exit 2, and a genuine AL0543 manifest failure on the same call site → still `COMPILE-FAIL`/exit 3 (regression guard for #1898).

Ran locally: `DependencyResolverTests`, `SiblingSourceDepProvisioningReportingTests`, `LayeredDepManifestTests` (unaffected #1898 coverage on the sibling layered path), `TestArtifactsGateTests`, `CliDocumentationTests` — 67/67 pass on BC 28.1.49838.53910.