### PR TITLE
fix(provisioning): derive transitive no-fallback platform-app need via a closure walk

### DIFF
--- a/AlRunner.Tests/ProvisioningCheckTests.cs
+++ b/AlRunner.Tests/ProvisioningCheckTests.cs
@@ -722,6 +722,117 @@ public sealed class ProvisioningCheckTests : IDisposable
         Assert.True(decision.ShouldDownloadPlatform);
     }
 
+    // ── Issue #2087: transitive need must be DERIVED (a closure walk over recorded
+    // dependency edges), not a hand-maintained list of "apps known to reach the no-fallback
+    // set today". Before this fix, DetermineManifestNeeds could only recognize the ONE
+    // literal name #2086 hardcoded (Tests-TestLibraries); a different Microsoft app with
+    // the identical shape (declares a dependency that itself, or transitively, reaches
+    // "Application Test Library") was invisible to it. These tests prove the WALK, not just
+    // the two apps that happen to already be known.
+
+    [Fact]
+    public void DetermineManifestNeeds_TransitiveClosure_CatchesAnyChainNotJustTheKnownOne()
+    {
+        // Synthetic dependency graph standing in for "the next Microsoft app with the same
+        // shape" (issue #2087's whole point): a two-hop chain nobody has hand-listed
+        // anywhere, ending at "Application Test Library" (a real KnownNoFallbackPlatformApps
+        // member). Neither name here is "Tests-TestLibraries" or in KnownTestFrameworkAppNames
+        // — a bespoke one-entry list keyed on THAT name could never catch this. The walk must.
+        var syntheticEdges = new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Contoso-Style Future App"] = new[] { "Some Intermediate Microsoft App" },
+            ["Some Intermediate Microsoft App"] = new[] { "Application Test Library" },
+        };
+        var roots = new[]
+        {
+            new DependencyRef(Guid.NewGuid(), "Contoso-Style Future App", "Microsoft", new Version(29, 0, 0, 0)),
+        };
+        var needs = ProvisioningCheck.DetermineManifestNeeds(roots, syntheticEdges);
+        Assert.True(needs.NeedsPlatformApps);
+        Assert.True(needs.NeedsTestApps);
+    }
+
+    [Fact]
+    public void DetermineManifestNeeds_ClosureWalk_DoesNotOverfireOnUnrelatedChain()
+    {
+        // Negative direction (issue #2087 acceptance): a synthetic app whose OWN declared
+        // dependency chain never reaches a KnownNoFallbackPlatformApps member must NOT be
+        // flagged. Proves the walk terminates on a real (non-trivial, multi-edge) graph
+        // without false-positiving — the mistake "widen to every known test-framework app"
+        // would have made.
+        var syntheticEdges = new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Contoso-Style Future App"] = new[] { "Some Intermediate Microsoft App" },
+            ["Some Intermediate Microsoft App"] = new[] { "Some Unrelated Microsoft App" },
+        };
+        var roots = new[]
+        {
+            new DependencyRef(Guid.NewGuid(), "Contoso-Style Future App", "Microsoft", new Version(29, 0, 0, 0)),
+        };
+        var needs = ProvisioningCheck.DetermineManifestNeeds(roots, syntheticEdges);
+        Assert.False(needs.NeedsPlatformApps);
+    }
+
+    [Fact]
+    public void DetermineManifestNeeds_SystemApplicationTestLibraryDependency_NeedsTestNotPlatform()
+    {
+        // Real Microsoft app (confirmed via its own NavxManifest.xml, BC 28.3.52162.53954):
+        // "System Application Test Library" depends on "System Application" and "Any" — real
+        // recorded edges in KnownMicrosoftAppDependencyEdges — but NEITHER reaches
+        // "Application Test Library". Proves the closure walk doesn't over-fire just because
+        // an app HAS recorded edges; it must actually reach the target.
+        var roots = new[]
+        {
+            new DependencyRef(Guid.NewGuid(), "System Application Test Library", "Microsoft", new Version(28, 1, 0, 0)),
+        };
+        var needs = ProvisioningCheck.DetermineManifestNeeds(roots);
+        Assert.True(needs.NeedsTestApps);
+        Assert.False(needs.NeedsPlatformApps);
+    }
+
+    [Fact]
+    public void ReachesAnyOf_DirectMember_ReturnsTrue()
+    {
+        var edges = new Dictionary<string, IReadOnlyList<string>>();
+        Assert.True(ProvisioningCheck.ReachesAnyOf("Application Test Library", edges, new[] { "Application Test Library" }));
+    }
+
+    [Fact]
+    public void ReachesAnyOf_MultiHopChain_ReturnsTrue()
+    {
+        var edges = new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["A"] = new[] { "B" },
+            ["B"] = new[] { "C" },
+            ["C"] = new[] { "Target" },
+        };
+        Assert.True(ProvisioningCheck.ReachesAnyOf("A", edges, new[] { "Target" }));
+    }
+
+    [Fact]
+    public void ReachesAnyOf_NoPathToTarget_ReturnsFalse()
+    {
+        var edges = new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["A"] = new[] { "B" },
+            ["B"] = new[] { "C" },
+        };
+        Assert.False(ProvisioningCheck.ReachesAnyOf("A", edges, new[] { "Target" }));
+    }
+
+    [Fact]
+    public void ReachesAnyOf_CyclicEdges_TerminatesWithoutHanging()
+    {
+        // A malformed/future edge table with a cycle must not hang the walk — cycle safety
+        // is the mechanism's own correctness property, independent of any specific app name.
+        var edges = new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["A"] = new[] { "B" },
+            ["B"] = new[] { "A" },
+        };
+        Assert.False(ProvisioningCheck.ReachesAnyOf("A", edges, new[] { "Target" }));
+    }
+
     // ── NoFallbackPlatformAppsPresent ──────────────────────────────────────────
     // Deliberately narrower than "all curated platform apps present": System/Base
     // Application and Business Foundation have a service-tier DLL dispatch fallback (the

--- a/AlRunner/Infrastructure/ProvisioningCheck.cs
+++ b/AlRunner/Infrastructure/ProvisioningCheck.cs
@@ -446,24 +446,79 @@ public static class ProvisioningCheck
     };
 
     /// <summary>
-    /// Microsoft app names whose OWN manifest transitively depends on a
-    /// <see cref="KnownNoFallbackPlatformApps"/> member, even though the DEPENDENT never
-    /// names that app directly (issue #2073). <see cref="DetermineManifestNeeds"/> only
-    /// sees the roots a bundle's own app.json declares — it can't read a not-yet-downloaded
-    /// dependency's manifest to discover ITS dependencies — so a bundle that names
-    /// "Tests-TestLibraries" but never "Application Test Library" read as not needing the
-    /// platform-apps set at all, and `provision` reported success while downloading
-    /// nothing. Confirmed via the real Microsoft NavxManifest.xml (Tests-TestLibraries
-    /// v28.1.49838.53910 declares `&lt;Dependency Id="d852d5d2-a39d-4179-baeb-f99a19e32510"
-    /// Name="Application Test Library" Publisher="Microsoft" .../&gt;` — the exact AppId the
-    /// issue's "Missing:" error names). Recorded here the same way
-    /// <see cref="KnownNoFallbackPlatformApps"/> records real app names, so the pre-scan can
-    /// see the edge without ever reading the dependency's own manifest.
+    /// Known DIRECT dependency edges among Microsoft apps that participate in the
+    /// platform-apps / test-apps provisioning sets, each one extracted from that app's own
+    /// real NavxManifest.xml &lt;Dependencies&gt; block (BC 28.3.52162.53954, verified against
+    /// the actual downloaded .app files — see the per-entry comment; not invented). This is
+    /// the smallest fact <see cref="DetermineManifestNeeds"/> cannot avoid recording ahead of
+    /// time: it only ever sees a BUNDLE's own declared roots, and it can't download a
+    /// not-yet-fetched dependency's manifest just to learn what THAT app depends on — the
+    /// same chicken-and-egg <see cref="KnownNoFallbackPlatformApps"/>' own doc comment
+    /// describes (issue #2073).
+    ///
+    /// Issue #2087: a PRIOR fix recorded this as a one-entry "known transitive dependents of
+    /// Application Test Library" list — correct for the one app it named
+    /// ("Tests-TestLibraries"), but shaped as a lookup table, not detection: the next
+    /// Microsoft app that reaches "Application Test Library" (directly or through another
+    /// app) would fail exactly the same silent way. Recording actual per-app EDGES here
+    /// instead, and walking them with <see cref="ReachesAnyOf"/>, generalizes: an app that
+    /// reaches a <see cref="KnownNoFallbackPlatformApps"/> member through ANY number of hops
+    /// is caught the moment its OWN direct edge is added here — no second per-shape list to
+    /// keep in sync, and a multi-hop chain composes automatically instead of needing its own
+    /// hand-written entry.
     /// </summary>
-    public static readonly IReadOnlyList<string> KnownTransitiveNoFallbackPlatformDependents = new[]
+    public static readonly IReadOnlyDictionary<string, IReadOnlyList<string>> KnownMicrosoftAppDependencyEdges =
+        new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase)
+        {
+            // Microsoft_Tests-TestLibraries.app NavxManifest.xml <Dependencies>: depends
+            // directly on "Application Test Library" (the exact edge issues #2073/#2086
+            // needed — AppId d852d5d2-a39d-4179-baeb-f99a19e32510, the one the "Missing:"
+            // error names), plus "System Application Test Library" and "Permissions Mock".
+            ["Tests-TestLibraries"] = new[]
+            {
+                "System Application Test Library", "Permissions Mock", "Application Test Library",
+            },
+            // Microsoft_System Application Test Library.app NavxManifest.xml: depends on
+            // "System Application" and "Any". Neither reaches a KnownNoFallbackPlatformApps
+            // member today, but recording the real edge means a FUTURE app naming only
+            // "System Application Test Library" still gets the right answer via the same
+            // walk, instead of needing its own bespoke check.
+            ["System Application Test Library"] = new[] { "System Application", "Any" },
+            // Microsoft_Business Foundation Test Libraries.app NavxManifest.xml: depends on
+            // "System Application" and "Business Foundation".
+            ["Business Foundation Test Libraries"] = new[] { "System Application", "Business Foundation" },
+        };
+
+    /// <summary>
+    /// True iff <paramref name="appName"/> itself is in <paramref name="targets"/>, or
+    /// reaches a member of it by following <paramref name="edges"/> through any number of
+    /// hops. Pure graph BFS — the general closure-walk mechanism issue #2087 asked for,
+    /// exposed separately from <see cref="DetermineManifestNeeds"/> so the WALK itself (not
+    /// just the specific apps <see cref="KnownMicrosoftAppDependencyEdges"/> happens to
+    /// record today) can be proven against synthetic data. Cycle-safe — a malformed or
+    /// future edge table with a loop terminates instead of hanging — and case-insensitive on
+    /// names, matching every other Microsoft-app-name comparison in this file.
+    /// </summary>
+    public static bool ReachesAnyOf(
+        string appName,
+        IReadOnlyDictionary<string, IReadOnlyList<string>> edges,
+        IReadOnlyList<string> targets)
     {
-        "Tests-TestLibraries",
-    };
+        var visited = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { appName };
+        var queue = new Queue<string>();
+        queue.Enqueue(appName);
+        while (queue.Count > 0)
+        {
+            var current = queue.Dequeue();
+            if (targets.Any(t => string.Equals(t, current, StringComparison.OrdinalIgnoreCase)))
+                return true;
+            if (!edges.TryGetValue(current, out var deps)) continue;
+            foreach (var dep in deps)
+                if (visited.Add(dep))
+                    queue.Enqueue(dep);
+        }
+        return false;
+    }
 
     /// <summary>
     /// Real Microsoft app names supplied by the curated `test-apps` download (platform
@@ -493,13 +548,30 @@ public static class ProvisioningCheck
     /// Classifies a bundle's unioned dependency roots (see Program.ReadBundleDependencyRoots)
     /// into which curated download set(s) — if any — the bundle needs. Pure — does no I/O.
     /// </summary>
-    public static ManifestNeeds DetermineManifestNeeds(IEnumerable<AlRunner.DependencyRef> roots)
+    /// <param name="roots">The bundle's own unioned dependency roots.</param>
+    /// <param name="dependencyEdges">
+    /// Known Microsoft app dependency edges to walk via <see cref="ReachesAnyOf"/> when
+    /// deciding whether a root transitively needs <see cref="KnownNoFallbackPlatformApps"/>.
+    /// Defaults to <see cref="KnownMicrosoftAppDependencyEdges"/>; overridable so tests can
+    /// prove the WALK against synthetic graphs (issue #2087) without needing a real
+    /// not-yet-discovered Microsoft app to exist first.
+    /// </param>
+    public static ManifestNeeds DetermineManifestNeeds(
+        IEnumerable<AlRunner.DependencyRef> roots,
+        IReadOnlyDictionary<string, IReadOnlyList<string>>? dependencyEdges = null)
     {
+        var edges = dependencyEdges ?? KnownMicrosoftAppDependencyEdges;
         bool needsPlatform = false, needsTest = false;
         foreach (var d in roots)
         {
             if (!string.Equals(d.Publisher, "Microsoft", StringComparison.OrdinalIgnoreCase)) continue;
-            if (KnownNoFallbackPlatformApps.Any(n => string.Equals(n, d.Name, StringComparison.OrdinalIgnoreCase)))
+            // Issue #2087: ONE closure walk replaces what used to be two separate checks —
+            // a direct KnownNoFallbackPlatformApps membership test, and a second hardcoded
+            // list of names known (by hand) to transitively reach one. ReachesAnyOf treats
+            // "d.Name IS a no-fallback app" and "d.Name REACHES one through recorded edges"
+            // as the same question, so a future multi-hop chain is caught the moment its own
+            // edge is recorded — no new list, no per-shape entry.
+            if (ReachesAnyOf(d.Name, edges, KnownNoFallbackPlatformApps))
             {
                 needsPlatform = true;
                 // Confirmed via a live BC 28.1 platform-apps download (issue #1996): App
@@ -512,18 +584,6 @@ public static class ProvisioningCheck
             }
             if (KnownTestFrameworkAppNames.Any(n => string.Equals(n, d.Name, StringComparison.OrdinalIgnoreCase)))
                 needsTest = true;
-            // Issue #2073: a root naming e.g. "Tests-TestLibraries" (already caught by
-            // KnownTestFrameworkAppNames above, for needsTest) ALSO transitively drags in
-            // "Application Test Library" — a KnownNoFallbackPlatformApps member — via that
-            // dependency's own manifest, which this pre-scan cannot read. Without this, a
-            // bundle shaped exactly like the issue's repro (names Tests-TestLibraries,
-            // never Application Test Library directly) read as needing no platform apps at
-            // all, and `provision` reported success while downloading nothing.
-            if (KnownTransitiveNoFallbackPlatformDependents.Any(n => string.Equals(n, d.Name, StringComparison.OrdinalIgnoreCase)))
-            {
-                needsPlatform = true;
-                needsTest = true;
-            }
         }
         return new ManifestNeeds(needsPlatform, needsTest);
     }


### PR DESCRIPTION
Closes #2087

## Problem

`KnownTransitiveNoFallbackPlatformDependents` (added by #2086 to fix #2073) was a one-entry lookup table naming exactly the app the reported repro hit (`Tests-TestLibraries`). It is a lookup table, not detection: the next Microsoft app with the same shape — a dependency that itself, or transitively through another app, reaches `Application Test Library` — would fail the identical silent way (`provision` reports success and downloads nothing), invisible until someone rediscovers it from scratch.

## Investigation

Read `DetermineManifestNeeds` and its surrounding pre-scan comments first. The pre-scan genuinely cannot read a not-yet-downloaded dependency's own manifest (chicken-and-egg, already documented on `KnownNoFallbackPlatformApps`), so full network-driven derivation isn't available at that point in the flow.

To ground the fix in real data rather than a guess, I extracted the actual `NavxManifest.xml` `<Dependencies>` blocks from real BC 28.3 `.app` files already on this machine (`Tests-TestLibraries`, `System Application Test Library`, `Business Foundation Test Libraries`, `Library Assert`, `Permissions Mock`, `Any`, `AI Test Toolkit`, `Business Foundation Tests`). Confirmed:
- Only `Tests-TestLibraries` has a real edge to `Application Test Library` today.
- `Library Assert`, `Permissions Mock`, and `Any` declare **no** dependencies at all.
- `System Application Test Library` depends on `System Application` + `Any` — real edges, but neither reaches `Application Test Library`.

This ruled out the "widen to every `KnownTestFrameworkAppNames` member" option from the issue: it would have caused spurious platform-apps downloads for `Library Assert`/`Permissions Mock`/`AI Test Toolkit` bundles, trading one silent miss for spurious downloads.

## Fix

Replaced the one-entry destination-name list with:
- `KnownMicrosoftAppDependencyEdges` — real, verified dependency edges among the known Microsoft test-framework apps (not invented; each entry cites which `.app`'s manifest it came from).
- `ReachesAnyOf` — a pure, cycle-safe BFS that walks those edges to decide whether an app reaches any `KnownNoFallbackPlatformApps` member, through any number of hops.

`DetermineManifestNeeds` now makes one call to `ReachesAnyOf` where it used to run two separate checks (direct membership + the old transitive list). A future Microsoft app that reaches `Application Test Library` through a chain nobody has manually enumerated is caught the moment its own direct edge is recorded — no second per-shape list to keep in sync, and multi-hop chains compose automatically.

## Tests (`AlRunner.Tests/ProvisioningCheckTests.cs`)

- `DetermineManifestNeeds_TransitiveClosure_CatchesAnyChainNotJustTheKnownOne` — proves the **general mechanism**, not just the two apps that already exist: a synthetic two-hop chain through an app named neither `Tests-TestLibraries` nor anything in `KnownTestFrameworkAppNames` is still caught. This fails before the fix (no such overload/walk existed).
- `DetermineManifestNeeds_ClosureWalk_DoesNotOverfireOnUnrelatedChain` — negative: a synthetic chain that never reaches a no-fallback app is not flagged.
- `DetermineManifestNeeds_SystemApplicationTestLibraryDependency_NeedsTestNotPlatform` — negative with real production data: an app with real recorded edges that don't lead to `Application Test Library` isn't flagged.
- `ReachesAnyOf_DirectMember_ReturnsTrue` / `_MultiHopChain_ReturnsTrue` / `_NoPathToTarget_ReturnsFalse` / `_CyclicEdges_TerminatesWithoutHanging` — direct unit coverage of the new walk, including cycle safety.
- Existing `DetermineManifestNeeds_TestsTestLibrariesDependency_AlsoNeedsPlatform` / `_ImpliesDownloadWhenAbsent` and `_LibraryAssertDependency_NeedsTestNotPlatform` continue to pass unchanged as regression coverage.

Ran `ProvisioningCheckTests` (80/80 pass), `TestArtifactsGateTests` + `CliDocumentationTests` (36/36 pass) locally via `dotnet build AlRunner.slnx -p:_BCVersion=28.1.49838.50794` + `dotnet test ... --filter`.