### PR TITLE
fix: declare _BCVersion default once in Directory.Build.props

### DIFF
--- a/AlRunner.Tests/AlRunner.Tests.csproj
+++ b/AlRunner.Tests/AlRunner.Tests.csproj
@@ -78,15 +78,19 @@
        Same resolution as AlRunner.csproj — plain <Reference> items do not flow
        transitively through the project reference. -->
   <PropertyGroup>
-    <!-- Condition="'$(_BCVersion)' == ''" so a matrix build's -p:_BCVersion (AlRunner.slnx ->
-         AlRunner.csproj's own _BCVersion) reaches this project's direct BC references too.
-         Before this Condition, the plain assignment below always won regardless of the
-         command line, so these two <Reference> items (below) stayed pinned to 28.1 on every
-         CI leg while AlRunner.csproj's ProjectReference output correctly followed the matrix
-         version — the two disagreed, and in-process tests that read the BC DLL actually
-         copied into this project's own bin (not the subprocess-spawned runner) silently
-         exercised 28.1 no matter which leg was running. -->
-    <_BCVersion Condition="'$(_BCVersion)' == ''">28.1.49838.50794</_BCVersion>
+    <!-- _BCVersion itself is declared once in the repo-root Directory.Build.props (#2102),
+         under the same Condition="'$(_BCVersion)' == ''" this project used to carry its own
+         copy of — that Condition is what lets a matrix build's -p:_BCVersion reach this
+         project's direct BC <Reference> items below, not just AlRunner.csproj's
+         ProjectReference output. Before the Condition existed here at all, a plain
+         assignment always won regardless of the command line, so these two <Reference>
+         items stayed pinned to 28.1 on every CI leg while AlRunner.csproj's referenced
+         output correctly followed the matrix version — the two disagreed, and in-process
+         tests that read the BC DLL actually copied into this project's own bin (not the
+         subprocess-spawned runner) silently exercised 28.1 no matter which leg was running.
+         Carrying its OWN default value on top of that Condition is what caused #2102: it
+         disagreed with AlRunner.csproj's separate default on a bare local build with no
+         override at all. -->
     <_CacheBase Condition="$([MSBuild]::IsOSPlatform('Windows'))">$(USERPROFILE)/.local/share/al-runner</_CacheBase>
     <_CacheBase Condition="!$([MSBuild]::IsOSPlatform('Windows'))">$(HOME)/.local/share/al-runner</_CacheBase>
     <ServiceTierPath Condition="'$(ServiceTierPath)' == ''">$(_CacheBase)/artifacts/$(_BCVersion)</ServiceTierPath>

--- a/AlRunner.Tests/BCVersionDefaultTests.cs
+++ b/AlRunner.Tests/BCVersionDefaultTests.cs
@@ -1,0 +1,72 @@
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// Issue #2102: a bare `dotnet build`/`dotnet test` with no `-p:_BCVersion` failed with
+/// CS1705 because AlRunner.csproj and AlRunner.Tests.csproj each declared their OWN
+/// default BC build (28.1.49838.53910 vs 28.1.49838.50794) and a project-level MSBuild
+/// property never flows to a sibling project. A command-line `-p:_BCVersion` is a global
+/// property that overrides both, so every CI leg (which always passes it) never saw the
+/// mismatch — only a bare local build did.
+///
+/// The fix is structural, not a value bump: `_BCVersion` is declared exactly ONCE, in the
+/// repo-root Directory.Build.props that every project already implicitly imports, kept
+/// under the same `Condition="'$(_BCVersion)' == ''"` form so an explicit `-p:_BCVersion`
+/// still wins everywhere it does today. These tests are the drift gate that keeps that
+/// true — they fail the moment a second per-project default reappears (the actual defect
+/// this issue reported), or the shared declaration loses its override guard.
+/// </summary>
+public class BCVersionDefaultTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+
+    [Fact]
+    public void NoProjectFile_DeclaresItsOwnBCVersionDefault()
+    {
+        var offenders = new List<string>();
+        foreach (var file in Directory.EnumerateFiles(RepoRoot, "*.csproj", SearchOption.AllDirectories))
+        {
+            // tests/al-language is a read-only upstream submodule; not ours to police,
+            // and it declares no BC-version defaults of its own anyway.
+            var rel = Path.GetRelativePath(RepoRoot, file).Replace('\\', '/');
+            if (rel.StartsWith("tests/al-language/", StringComparison.Ordinal)) continue;
+
+            foreach (var line in File.ReadAllLines(file))
+            {
+                var trimmed = line.TrimStart();
+                if (trimmed.StartsWith("<!--", StringComparison.Ordinal)) continue; // comment, not a live declaration
+                if (Regex.IsMatch(trimmed, @"^<_BCVersion\b"))
+                    offenders.Add($"{rel}: {line.Trim()}");
+            }
+        }
+
+        Assert.True(offenders.Count == 0,
+            "Only Directory.Build.props may declare a _BCVersion default. A per-project "
+            + "default drifts from the shared one exactly like AlRunner.csproj and "
+            + "AlRunner.Tests.csproj did (#2102): a bare local build silently picks up "
+            + "whichever project MSBuild happens to evaluate first, and mismatched "
+            + "defaults across projects break with CS1705. Offending declarations:\n  "
+            + string.Join("\n  ", offenders));
+    }
+
+    [Fact]
+    public void DirectoryBuildProps_DeclaresExactlyOneConditionalBCVersionDefault()
+    {
+        var path = Path.Combine(RepoRoot, "Directory.Build.props");
+        var text = File.ReadAllText(path);
+
+        var matches = Regex.Matches(text, @"<_BCVersion\b[^>]*>[^<]*</_BCVersion>");
+        Assert.True(matches.Count == 1,
+            $"Directory.Build.props must declare the shared _BCVersion default exactly "
+            + $"once so it cannot drift from itself; found {matches.Count} declaration(s).");
+
+        var declaration = matches[0].Value;
+        Assert.Contains("Condition=\"'$(_BCVersion)' == ''\"", declaration);
+        // Must actually be pinned to a full 4-part BC build, not left blank — an unpinned
+        // default is a different bug (every dev resolves a different "latest").
+        Assert.Matches(@">\d+\.\d+\.\d+\.\d+<", declaration);
+    }
+}

--- a/AlRunner/AlRunner.csproj
+++ b/AlRunner/AlRunner.csproj
@@ -195,29 +195,11 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <!-- #2010: this default is a DEV-MACHINE FALLBACK ONLY, not the release version. It used
-         to be both — publish.yml's release job built with whatever this said, and that is
-         exactly what broke the v2.4.0 release: Microsoft withdrew 28.1.49838.50794 (the value
-         that WAS here) between when this was last bumped and when the release ran, the release
-         job's build failed on "no BC artifact published", and by then the release commit and
-         tag had already been pushed to main — because nothing had exercised this value except
-         a release itself.
+    <!-- _BCVersion's dev-machine-fallback default is declared once in the repo-root
+         Directory.Build.props (#2102) — see the comment there — not per-project, so it
+         cannot drift from AlRunner.Tests.csproj's copy the way it did before.
 
-         Every CI/release caller now passes -p:_BCVersion explicitly, live-resolved via
-         tools/DownloadArtifacts' `resolve-version` command (the same call bc-tests.yml's
-         resolve-versions job makes): the BC-test matrix (per matrix
-         leg), the smoke job, the pack job (bc-tests.yml, added by #2010 specifically to run
-         publish.yml's build-and-pack commands on ordinary CI instead of only during a release),
-         and publish.yml's release job, which reads bc-tests.yml's `required-version` output —
-         the exact build the matrix it just depended on tested — rather than resolving again or
-         reading this property. So this value only fires for a bare `dotnet build`/`dotnet pack`
-         with no override, i.e. an interactive dev machine. It WILL still go stale the next time
-         Microsoft withdraws this exact build; that is expected and low-stakes now — it costs a
-         local rebuild against a fresh -p:_BCVersion, not a broken release. Bump opportunistically
-         when noticed; nothing gates on it. -->
-    <_BCVersion>28.1.49838.53910</_BCVersion>
-
-    <!-- No compile-time BC feature constants. BC-version differences are handled by
+         No compile-time BC feature constants. BC-version differences are handled by
          reflection at runtime — one binary, no build matrix in the source.
 
          A set of BC 26 constants lived here briefly (BC_TESTPAGE_GETPAGE,

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -48,4 +48,33 @@
     <SuppressImplicitGitSourceLink>true</SuppressImplicitGitSourceLink>
   </PropertyGroup>
 
+  <!--
+    #2102: declared here, ONCE, so AlRunner.csproj and AlRunner.Tests.csproj cannot drift
+    apart again. They used to each carry their own default (28.1.49838.53910 vs
+    28.1.49838.50794) — a project-level MSBuild property never flows to a sibling project,
+    so a bare `dotnet build`/`dotnet test` with no override compiled the two against
+    different BC builds and failed with CS1705. A command-line `-p:_BCVersion` is a global
+    property that overrides both regardless, which is why every CI leg (all of which pass
+    it explicitly) never saw the mismatch.
+
+    This is a DEV-MACHINE FALLBACK ONLY, not the release version — every CI/release caller
+    still passes -p:_BCVersion explicitly, live-resolved via tools/DownloadArtifacts'
+    `resolve-version` command, and only a bare local build ever reads this. It WILL go
+    stale the next time Microsoft withdraws this exact build (#2010: that is what broke the
+    v2.4.0 release, back when this value doubled as the release default) — that is expected
+    and low-stakes now, costing a local rebuild against a fresh -p:_BCVersion, never a
+    broken release. Bump opportunistically when noticed; nothing gates on it.
+
+    Condition="'$(_BCVersion)' == ''" so a caller's -p:_BCVersion (a global property) still
+    wins here exactly as it did in each project before consolidation, AND reaches every
+    project's own direct BC references, not just AlRunner.csproj's ProjectReference output
+    — without the Condition, AlRunner.Tests's direct <Reference> items to the BC DLLs
+    stayed pinned to whatever this said regardless of the command line, while
+    AlRunner.csproj's referenced output correctly followed it, and in-process tests that
+    read those DLLs directly silently exercised the wrong BC version on every CI leg.
+  -->
+  <PropertyGroup>
+    <_BCVersion Condition="'$(_BCVersion)' == ''">28.1.49838.53910</_BCVersion>
+  </PropertyGroup>
+
 </Project>


### PR DESCRIPTION
Closes #2102

## Problem
`AlRunner/AlRunner.csproj` (`28.1.49838.53910`) and `AlRunner.Tests/AlRunner.Tests.csproj` (`28.1.49838.50794`) each declared their own default `_BCVersion`. A project-level MSBuild property never flows to a sibling project, so a bare `dotnet build`/`dotnet test` with no `-p:_BCVersion` compiled the two projects against different BC builds and failed with CS1705. Every CI job passes `-p:_BCVersion` explicitly (a global property, which overrides both), so CI never saw the mismatch — only an interactive dev machine did.

## Fix
Declares `_BCVersion` exactly once, in the repo-root `Directory.Build.props` (which every project in the solution already implicitly imports), under the same `Condition="'$(_BCVersion)' == ''"` guard both prior declarations used, so an explicit `-p:_BCVersion` still wins everywhere it does today.

**Value chosen:** `28.1.49838.53910`. Checked both candidates against the BC artifact CDN before picking:
- `28.1.49838.50794` (AlRunner.Tests.csproj's old value) → HTTP 404. This is the exact build `#2010`'s comment already documents Microsoft withdrew.
- `28.1.49838.53910` (AlRunner.csproj's old value) → HTTP 200, still published.

**Other projects:** `AlRunner.slnx` lists three projects (`AlRunner`, `AlRunner.Provisioning`, `AlRunner.Tests`). `AlRunner.Provisioning.csproj` declares no `_BCVersion` default of its own — nothing to fold in there.

Both original comments carried real history (`#2010`'s rationale for why the default may go stale; the `Condition` rationale for why it must exist at all so a matrix build reaches `AlRunner.Tests`'s own direct BC `<Reference>` items, not just `AlRunner.csproj`'s `ProjectReference` output). Both points are preserved in the consolidated `Directory.Build.props` comment, and each `.csproj` keeps a short pointer back to it.

## Test
Added `AlRunner.Tests/BCVersionDefaultTests.cs` as a drift gate (option 1 from the issue): scrapes every `.csproj` under the repo (excluding the read-only `tests/al-language` submodule) for a `_BCVersion` declaration — asserts there are none outside `Directory.Build.props` — and asserts `Directory.Build.props` declares exactly one, `Condition`-guarded, pinned to a full 4-part build.

- RED: confirmed against the pre-fix tree — the test found both per-project declarations verbatim and failed with 2/2 failing.
- GREEN: after the fix, 2/2 passing.
- Hand-verified: `rm -rf **/bin **/obj && dotnet build AlRunner.slnx` with no `-p:_BCVersion` override → `0 Error(s)` (artifacts for `28.1.49838.53910` already present locally under `~/.local/share/al-runner/artifacts/`).
- Also ran the two named gates: `TestArtifactsGateTests` and `CliDocumentationTests.NoRemediationText_NamesTheCheckoutOnlyDownloadArtifactsInvocation` — both green, unaffected by this change.

Local scope only — did not run the full `dotnet test`/AL corpus locally per `.claude/rules/local-test-scope.md`; CI covers that.