### PR TITLE
fix(startup): defer the remaining per-generation startup lines past re-exec

### DIFF
--- a/AlRunner.Tests/StartupOutputReexecDedupTests.cs
+++ b/AlRunner.Tests/StartupOutputReexecDedupTests.cs
@@ -258,6 +258,71 @@ public sealed class StartupOutputReexecDedupTests
     }
 
     /// <summary>
+    /// Issue #2097 — #2066 deferred the startup trio, but two more steady-state
+    /// informational lines on the exact same startup path were left unconditional and
+    /// duplicated once per process generation the same way: the "[bc] no --bc-version
+    /// given — selecting BC ..." auto-selection line, and the "[expectations] loaded N
+    /// entries from ..." manifest line. Both are printed BEFORE the shadow-re-exec
+    /// decision (unlike the trio, before `deferredStartupLines` even existed prior to
+    /// this fix), so the same stacked-three-generation shape
+    /// (ColdCecilCache_StackedShadowAndFreshRewriteReexec_... above) reprints them twice
+    /// too many.
+    ///
+    /// Unlike that sibling test, this one must NOT pass an explicit --bc-version — the
+    /// auto-selection line only prints when none is given (`bcVersionArg == null &&
+    /// artifactPathArg == null`), which is also the realistic case #2097's own
+    /// measurement used. This dev/CI environment always has the exact engine build
+    /// cached (TestArtifacts.SkipIfMissing's own precondition), so BcArtifacts.
+    /// DefaultVersionPrefix resolves the "cached-exact" tier deterministically —
+    /// the same branch #2097 measured against.
+    ///
+    /// Asserts both `[reexec]` lines first, exactly once each — proof this genuinely ran
+    /// three generations, not that nothing re-exec'd at all (a test that skipped that
+    /// check could pass by accident on a single-generation run where nothing had a
+    /// chance to duplicate).
+    /// </summary>
+    [SkippableFact]
+    public void ColdCecilCache_StackedShadowAndFreshRewriteReexec_BcAutoSelectAndExpectationsPrintExactlyOnce()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        // See the file header (#2061) for why this runs against a private mirror rather
+        // than the shared AlRunner/bin/.../ directory.
+        var privateDir = MirrorOriginalBinDir();
+        try
+        {
+            var privateDll = Path.Combine(privateDir, "al-runner.dll");
+
+            var psi = BuildPsiWithoutBcVersion(privateDll);
+            // Same forced-cold-cecil-cache technique as the sibling test above — see its
+            // own doc comment for why this reliably reproduces the stacked
+            // shadow-hop-then-fresh-rewrite, three-generation shape.
+            psi.Environment["AL_RUNNER_NCL_CACHE"] = "0";
+            var (output, exit) = Run(psi);
+
+            Assert.Equal(0, exit);
+            Assert.Contains("pass:        1", output);
+            Assert.Contains("fail:        0", output);
+
+            // Confirm three generations genuinely happened before trusting any of the
+            // exactly-once counts below — the same guard the sibling test above uses.
+            Assert.Equal(1, CountOccurrences(output, "[reexec] Ncl.dll not shipped in this install"));
+            Assert.Equal(1, CountOccurrences(output, "[reexec] Fresh rewrite done — re-execing for a clean Ncl load"));
+
+            // The two lines #2097 reported as still duplicating per generation.
+            Assert.Equal(1, CountOccurrences(output, "[bc] no --bc-version given — selecting BC "));
+            Assert.Equal(1, CountOccurrences(output, "[expectations] loaded "));
+        }
+        finally
+        {
+            // RewriteInPlace writes Ncl.dll directly into the private mirror (top-level
+            // dir) as a side effect of the top-level generation's own rewrite, same as
+            // the sibling tests above — clean up the whole mirror.
+            DeleteDirectoryOrFail(privateDir);
+        }
+    }
+
+    /// <summary>
     /// Regression: `reexecPending` must track the ACTUAL re-exec gate
     /// (`NeedsShadow(...) && AL_RUNNER_NCL_SHADOW_DONE != "1"`), not `NeedsShadow` alone.
     ///
@@ -501,12 +566,24 @@ public sealed class StartupOutputReexecDedupTests
 
     private (string Output, int Exit) SpawnAssembly(string dllPath) => Run(BuildPsi(dllPath));
 
-    private ProcessStartInfo BuildPsi(string dllPath)
+    private ProcessStartInfo BuildPsi(string dllPath) =>
+        BuildPsiCore($"\"{dllPath}\"{TestBuildConfig.BcVersionArg} \"{Fixture}\"");
+
+    /// <summary>
+    /// Same as <see cref="BuildPsi"/>, but WITHOUT the pinned `--bc-version` argument —
+    /// needed by issue #2097's test, which is specifically about the auto-selection
+    /// "[bc] no --bc-version given — selecting BC ..." line that only prints when no
+    /// version is given on the command line at all.
+    /// </summary>
+    private ProcessStartInfo BuildPsiWithoutBcVersion(string dllPath) =>
+        BuildPsiCore($"\"{dllPath}\" \"{Fixture}\"");
+
+    private ProcessStartInfo BuildPsiCore(string arguments)
     {
         var psi = new ProcessStartInfo
         {
             FileName = "dotnet",
-            Arguments = $"\"{dllPath}\"{TestBuildConfig.BcVersionArg} \"{Fixture}\"",
+            Arguments = arguments,
             RedirectStandardOutput = true,
             RedirectStandardError = true,
             UseShellExecute = false,

--- a/AlRunner.Tests/StartupOutputReexecDedupTests.cs
+++ b/AlRunner.Tests/StartupOutputReexecDedupTests.cs
@@ -280,6 +280,15 @@ public sealed class StartupOutputReexecDedupTests
     /// three generations, not that nothing re-exec'd at all (a test that skipped that
     /// check could pass by accident on a single-generation run where nothing had a
     /// chance to duplicate).
+    ///
+    /// Only the "cached-exact"/"cached-minor" branches of Program.cs's BC-selection
+    /// switch and the "loaded" (not "not found") expectations line are actually
+    /// deferred by the fix — see Program.cs's own comments at each site for why the
+    /// "cdn-exact"/"cdn-minor"/KNOWN-DEGRADED branches and the --tdd cache-disable
+    /// notice deliberately stay immediate instead (deferring them broke
+    /// DefaultProvisionTargetMessagingTests, which pins their immediate-print
+    /// contract). This test only exercises the "cached-exact" branch, matching #2097's
+    /// own measured repro.
     /// </summary>
     [SkippableFact]
     public void ColdCecilCache_StackedShadowAndFreshRewriteReexec_BcAutoSelectAndExpectationsPrintExactlyOnce()

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -536,6 +536,42 @@ if (tddMode && serverMode)
 // TryEmitIncremental's own tdd-specific fallback-reason text for what a developer
 // actually sees on the console when this happens (issue #1994 precedent).
 
+// #2041/#2066/#2097: rather than PREDICTING whether this generation will need to
+// re-exec (the #2041 approach — a flag computed from NeedsShadow alone, before either
+// the per-BC-minor variant swap or the Cecil-rewrite cache state is knowable), the
+// success-path startup lines below are DEFERRED into this list and only flushed once
+// this generation has cleared every re-exec decision point in the function — the
+// shadow-hop check AND the Cecil-fresh-rewrite check, in that order, however many of
+// them fire.
+//
+// #2041's predict-then-suppress design covered exactly one re-exec (the shadow hop) and
+// silently broke the moment a SECOND one stacked on top: a per-BC-minor engine-variant
+// swap forces its own shadow-hop generation to also perform its first-ever Cecil rewrite
+// of that variant's Ncl.dll (a cache MISS, since the shadow-dir builder skips the
+// pre-rewrite for a variant swap — see EnsureShadowDir's doc comment), which is a SECOND
+// re-exec `reexecPending` had no way to see coming. That intermediate generation printed
+// the trio believing itself final, then re-exec'd anyway, and the real final generation
+// printed it again — three generations, two prints. See #2066.
+//
+// #2097: #2066 only fixed the trio. Two more steady-state informational lines on this
+// same startup path — the --tdd cache-disable notice, the expectations-manifest
+// found/not-found lines, and every branch of the BC auto-selection logic below (both the
+// per-BC-minor-variants-shipped branch and the no-variants-shipped switch) — had the
+// identical shape and duplicated the identical way, because they all print BEFORE
+// either re-exec decision point below and this list did not exist yet at the point they
+// ran. Declared here, ahead of all of them, instead of just ahead of the trio, so no
+// print between here and the flush point below can still slip past deferral.
+//
+// A generation that re-execs further always `return`s from inside one of the two
+// decision blocks below, before ever reaching the flush point — so its accumulated
+// entries are silently discarded, exactly as #2041 intended for the single-re-exec case,
+// but now correctly for however many stack. LOUD FAILURES are untouched: every error path
+// in this function (provisioning failure, BC version selection failure, no matching
+// engine variant, an incomplete artifact closure) returns its own specific message
+// immediately and never reaches — nor needs — this list. The `[reexec]` explanation
+// lines (#2034/#2038) are a different print entirely and stay unconditional, printed
+// from whichever generation actually decides to hand off.
+var deferredStartupLines = new List<Action>();
 // --tdd forces the AL-output cache off (same effect as --no-cache), on top of the
 // tdd:<0|1> cache-key line added above. The line alone stops a --tdd run from ever
 // SERVING a normal-mode DLL or vice versa (criterion 11) — but it does not make a
@@ -549,10 +585,13 @@ if (tddMode && serverMode)
 // reasonable follow-up), disabling the cache is what keeps every --tdd run correct.
 if (tddMode && alCacheDir != null)
 {
-    Console.Error.WriteLine(
+    // #2097: deferred — see `deferredStartupLines`'s declaration above. A no-string-
+    // interpolation constant message, so nothing needs capturing into a local before
+    // queueing.
+    deferredStartupLines.Add(() => Console.Error.WriteLine(
         "--tdd disables the AL-output cache for this run — its synthetic FAILED tests " +
         "for excluded objects are derived fresh from source on every Emit() call and " +
-        "are not part of the cached DLL, so a cache HIT would silently drop them.");
+        "are not part of the cached DLL, so a cache HIT would silently drop them."));
     alCacheDir = null;
 }
 // ── Positional bundle roots must exist (#1713) ────────────────────────────────
@@ -597,11 +636,17 @@ AlRunner.Infrastructure.ExpectationManifest? expectations = null;
             // every expect-oos/expect-divergence test in the run flipped to a plain
             // FAIL with nothing in the output to say why. Diagnosable, not inferred.
             var cwdCandidate = Path.Combine(Path.GetFullPath(Environment.CurrentDirectory), "tests", "expectations");
-            Console.Error.WriteLine(
+            // #2097: deferred — see `deferredStartupLines`'s declaration above. Captured
+            // into a local now: `bundles` itself is never mutated again after arg
+            // parsing, but capturing its count here (rather than reading `bundles.Count`
+            // fresh inside the closure) keeps this consistent with every other deferred
+            // line's rule of freezing values at queue time, not at flush time.
+            var bundleCountForPrint = bundles.Count;
+            deferredStartupLines.Add(() => Console.Error.WriteLine(
                 $"[expectations] no tests/expectations manifest found (probed {cwdCandidate}" +
-                (bundles.Count > 0 ? $" and the ancestor tree of {bundles.Count} bundle path(s)" : "") +
+                (bundleCountForPrint > 0 ? $" and the ancestor tree of {bundleCountForPrint} bundle path(s)" : "") +
                 ") — expect-oos / expect-fail-known-gap / expect-divergence classification is OFF " +
-                "this run. Pass --expectations DIR to set it explicitly.");
+                "this run. Pass --expectations DIR to set it explicitly."));
         }
     }
     if (expectationsDir != null)
@@ -609,9 +654,17 @@ AlRunner.Infrastructure.ExpectationManifest? expectations = null;
         try
         {
             expectations = AlRunner.Infrastructure.ExpectationManifest.LoadFromDirectory(expectationsDir);
-            Console.Error.WriteLine(
-                $"[expectations] loaded {expectations.Entries.Count} " +
-                (expectations.Entries.Count == 1 ? "entry" : "entries") + $" from {expectationsDir}");
+            // #2097: deferred — see `deferredStartupLines`'s declaration above. Captured
+            // into locals now (LoadFromDirectory has already returned, so these values
+            // are fixed) so the closure below reads exactly what THIS generation loaded,
+            // not `expectations`/`expectationsDir` as they stand whenever the list is
+            // eventually flushed.
+            var expectationsEntryCountForPrint = expectations.Entries.Count;
+            var expectationsDirForPrint = expectationsDir;
+            deferredStartupLines.Add(() => Console.Error.WriteLine(
+                $"[expectations] loaded {expectationsEntryCountForPrint} " +
+                (expectationsEntryCountForPrint == 1 ? "entry" : "entries") +
+                $" from {expectationsDirForPrint}"));
         }
         catch (InvalidOperationException ex)
         {
@@ -719,9 +772,17 @@ if (bcVersionArg == null && artifactPathArg == null)
             var latestDir = AlRunner.Infrastructure.BcArtifacts.SelectArtifactVersionDir(
                 AlRunner.Infrastructure.BcArtifacts.ArtifactsRootDir, null);
             bcVersionArg = Path.GetFileName(latestDir);
-            Console.Error.WriteLine($"[bc] no --bc-version given — selecting BC {bcVersionArg}, the latest " +
-                $"cached artifact ({shippedVariantsForDefault.Count} engine variant(s) shipped; the matching " +
-                $"one is selected automatically below). Override with --bc-version.");
+            // #2097: deferred — see `deferredStartupLines`'s declaration above. Captured
+            // into locals now: `bcVersionArg` is reassigned further down (after
+            // provisioning resolves the actual version to run against), so a closure
+            // reading `bcVersionArg` directly would print whatever THAT later
+            // reassignment left behind, not what THIS generation auto-selected here.
+            var autoSelectedVersionForPrint = bcVersionArg;
+            var shippedVariantCountForPrint = shippedVariantsForDefault.Count;
+            deferredStartupLines.Add(() => Console.Error.WriteLine(
+                $"[bc] no --bc-version given — selecting BC {autoSelectedVersionForPrint}, the latest " +
+                $"cached artifact ({shippedVariantCountForPrint} engine variant(s) shipped; the matching " +
+                $"one is selected automatically below). Override with --bc-version."));
         }
         catch (InvalidOperationException)
         {
@@ -732,8 +793,16 @@ if (bcVersionArg == null && artifactPathArg == null)
         var projMajorV = TryDeriveBcMajorFromProject(bundles);
         if (projMajorV != null && bcVersionArg != null
             && Version.TryParse(bcVersionArg, out var selV) && selV.Major.ToString() != projMajorV)
-            Console.Error.WriteLine($"[bc] warning: project app.json targets BC major {projMajorV} but the " +
-                $"latest cached artifact is {bcVersionArg} (major {selV.Major}).");
+        {
+            // #2097: deferred — see `deferredStartupLines`'s declaration above. Same
+            // `bcVersionArg`-reassignment hazard as the block above — capture now.
+            var projMajorForPrint = projMajorV;
+            var autoSelectedVersionForMismatchPrint = bcVersionArg;
+            var selMajorForPrint = selV.Major;
+            deferredStartupLines.Add(() => Console.Error.WriteLine(
+                $"[bc] warning: project app.json targets BC major {projMajorForPrint} but the " +
+                $"latest cached artifact is {autoSelectedVersionForMismatchPrint} (major {selMajorForPrint})."));
+        }
     }
     else
     {
@@ -773,83 +842,75 @@ if (bcVersionArg == null && artifactPathArg == null)
             }
 
             var engineMajorMinor = $"{engineVersion.Major}.{engineVersion.Minor}";
+            // #2097: every branch of this switch is deferred — see
+            // `deferredStartupLines`'s declaration above. `engineVersion`, `engineMajorMinor`
+            // and `engineMajor` are all `var`-declared once above and never reassigned
+            // afterward (unlike `bcVersionArg` elsewhere in this function), so the
+            // closures below can read them directly with no separate capture step; their
+            // values are already fixed for this generation.
             switch (tier)
             {
                 case "cached-exact":
-                    Console.Error.WriteLine($"[bc] no --bc-version given — selecting BC {engineVersion}, the exact " +
-                        $"build this binary was compiled against. Override with --bc-version.");
+                    deferredStartupLines.Add(() => Console.Error.WriteLine(
+                        $"[bc] no --bc-version given — selecting BC {engineVersion}, the exact " +
+                        $"build this binary was compiled against. Override with --bc-version."));
                     break;
                 case "cdn-exact":
-                    Console.Error.WriteLine($"[bc] no --bc-version given — provisioning BC {engineVersion}, the exact " +
-                        $"build this binary was compiled against. Override with --bc-version.");
+                    deferredStartupLines.Add(() => Console.Error.WriteLine(
+                        $"[bc] no --bc-version given — provisioning BC {engineVersion}, the exact " +
+                        $"build this binary was compiled against. Override with --bc-version."));
                     break;
                 case "cached-minor":
                     // Degraded but usually survivable: right minor, different build. The CodeAnalysis
                     // assembly version can still differ between builds of one minor, which fails loud
                     // at startup rather than silently — see BcArtifacts.DefaultVersionPrefix.
-                    Console.Error.WriteLine($"[bc] warning: no cached BC {engineVersion} — selecting the latest " +
+                    deferredStartupLines.Add(() => Console.Error.WriteLine(
+                        $"[bc] warning: no cached BC {engineVersion} — selecting the latest " +
                         $"{engineMajorMinor}.x instead. Build-level skew within a minor can still fail to load " +
-                        $"Microsoft.Dynamics.Nav.CodeAnalysis. Fix with: al-runner provision --bc-version {engineVersion}");
+                        $"Microsoft.Dynamics.Nav.CodeAnalysis. Fix with: al-runner provision --bc-version {engineVersion}"));
                     break;
                 case "cdn-minor":
-                    Console.Error.WriteLine($"[bc] no --bc-version given and BC {engineVersion} is not published on " +
+                    deferredStartupLines.Add(() => Console.Error.WriteLine(
+                        $"[bc] no --bc-version given and BC {engineVersion} is not published on " +
                         $"the CDN — provisioning the latest {engineMajorMinor}.x instead (still this binary's own " +
                         $"engine minor). Build-level skew within a minor can still fail to load " +
-                        $"Microsoft.Dynamics.Nav.CodeAnalysis. Fix with: al-runner provision --bc-version {engineVersion}");
+                        $"Microsoft.Dynamics.Nav.CodeAnalysis. Fix with: al-runner provision --bc-version {engineVersion}"));
                     break;
                 case "major-fallback-offline":
                     // No network step is coming (--no-auto-provision, or the rare case where
                     // engineVersion resolved but auto-provisioning is off) — this can only speak
                     // to what's CACHED, never to CDN availability. Original pre-#2033 wording.
-                    Console.Error.WriteLine($"[bc] warning: no cached BC {engineMajorMinor}.x — this binary's engine " +
+                    deferredStartupLines.Add(() => Console.Error.WriteLine(
+                        $"[bc] warning: no cached BC {engineMajorMinor}.x — this binary's engine " +
                         $"was built for {engineVersion}, so a different minor is a KNOWN-DEGRADED configuration " +
                         $"(measured: dozens of extra failures from engine/artifact minor skew). Falling back to the " +
-                        $"latest cached {engineMajor}.x. Fix with: al-runner provision --bc-version {engineMajorMinor}");
+                        $"latest cached {engineMajor}.x. Fix with: al-runner provision --bc-version {engineMajorMinor}"));
                     break;
                 default: // major-fallback: neither the exact build nor the engine's own minor is
                          // available from cache or the CDN — a genuine degradation (e.g. #2010,
                          // Microsoft withdrew the build), not the default-path norm.
-                    Console.Error.WriteLine($"[bc] warning: BC {engineMajorMinor}.x is not cached and not available " +
+                    deferredStartupLines.Add(() => Console.Error.WriteLine(
+                        $"[bc] warning: BC {engineMajorMinor}.x is not cached and not available " +
                         $"from the CDN — this binary's engine was built for {engineVersion}, so a different minor is " +
                         $"a KNOWN-DEGRADED configuration (measured: dozens of extra failures from engine/artifact " +
                         $"minor skew). Falling back to the latest {engineMajor}.x. Fix with: al-runner provision " +
-                        $"--bc-version {engineMajorMinor}");
+                        $"--bc-version {engineMajorMinor}"));
                     break;
             }
 
             var projMajor = TryDeriveBcMajorFromProject(bundles);
             if (projMajor != null && projMajor != engineMajor.Value.ToString())
-                Console.Error.WriteLine($"[bc] warning: project app.json targets BC major {projMajor} but this " +
-                    $"runner build supports major {engineMajor} (cross-major needs a matching runner build).");
+            {
+                // #2097: deferred — see `deferredStartupLines`'s declaration above.
+                // `projMajor` and `engineMajor` are stable for the same reason as the
+                // switch above.
+                deferredStartupLines.Add(() => Console.Error.WriteLine(
+                    $"[bc] warning: project app.json targets BC major {projMajor} but this " +
+                    $"runner build supports major {engineMajor} (cross-major needs a matching runner build)."));
+            }
         }
     }
 }
-// #2041/#2066: rather than PREDICTING whether this generation will need to re-exec (the
-// #2041 approach — a flag computed from NeedsShadow alone, before either the per-BC-minor
-// variant swap or the Cecil-rewrite cache state is knowable), the success-path startup
-// lines below are DEFERRED into this list and only flushed once this generation has
-// cleared every re-exec decision point in the function — the shadow-hop check AND the
-// Cecil-fresh-rewrite check, in that order, however many of them fire.
-//
-// #2041's predict-then-suppress design covered exactly one re-exec (the shadow hop) and
-// silently broke the moment a SECOND one stacked on top: a per-BC-minor engine-variant
-// swap forces its own shadow-hop generation to also perform its first-ever Cecil rewrite
-// of that variant's Ncl.dll (a cache MISS, since the shadow-dir builder skips the
-// pre-rewrite for a variant swap — see EnsureShadowDir's doc comment), which is a SECOND
-// re-exec `reexecPending` had no way to see coming. That intermediate generation printed
-// the trio believing itself final, then re-exec'd anyway, and the real final generation
-// printed it again — three generations, two prints. See #2066.
-//
-// A generation that re-execs further always `return`s from inside one of the two
-// decision blocks below, before ever reaching the flush point — so its accumulated
-// entries are silently discarded, exactly as #2041 intended for the single-re-exec case,
-// but now correctly for however many stack. LOUD FAILURES are untouched: every error path
-// in this function (provisioning failure, BC version selection failure, no matching
-// engine variant, an incomplete artifact closure) returns its own specific message
-// immediately and never reaches — nor needs — this list. The `[reexec]` explanation
-// lines (#2034/#2038) are a different print entirely and stay unconditional, printed
-// from whichever generation actually decides to hand off.
-var deferredStartupLines = new List<Action>();
 // ── Provisioning (on by default since issue #2024; opt out with --no-auto-provision):
 // `provision` subcommand or autoProvision (default true). Resolves the target version,
 // downloads the engine service-tier closure if it's missing/incomplete, then (subcommand)

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -536,42 +536,6 @@ if (tddMode && serverMode)
 // TryEmitIncremental's own tdd-specific fallback-reason text for what a developer
 // actually sees on the console when this happens (issue #1994 precedent).
 
-// #2041/#2066/#2097: rather than PREDICTING whether this generation will need to
-// re-exec (the #2041 approach — a flag computed from NeedsShadow alone, before either
-// the per-BC-minor variant swap or the Cecil-rewrite cache state is knowable), the
-// success-path startup lines below are DEFERRED into this list and only flushed once
-// this generation has cleared every re-exec decision point in the function — the
-// shadow-hop check AND the Cecil-fresh-rewrite check, in that order, however many of
-// them fire.
-//
-// #2041's predict-then-suppress design covered exactly one re-exec (the shadow hop) and
-// silently broke the moment a SECOND one stacked on top: a per-BC-minor engine-variant
-// swap forces its own shadow-hop generation to also perform its first-ever Cecil rewrite
-// of that variant's Ncl.dll (a cache MISS, since the shadow-dir builder skips the
-// pre-rewrite for a variant swap — see EnsureShadowDir's doc comment), which is a SECOND
-// re-exec `reexecPending` had no way to see coming. That intermediate generation printed
-// the trio believing itself final, then re-exec'd anyway, and the real final generation
-// printed it again — three generations, two prints. See #2066.
-//
-// #2097: #2066 only fixed the trio. Two more steady-state informational lines on this
-// same startup path — the --tdd cache-disable notice, the expectations-manifest
-// found/not-found lines, and every branch of the BC auto-selection logic below (both the
-// per-BC-minor-variants-shipped branch and the no-variants-shipped switch) — had the
-// identical shape and duplicated the identical way, because they all print BEFORE
-// either re-exec decision point below and this list did not exist yet at the point they
-// ran. Declared here, ahead of all of them, instead of just ahead of the trio, so no
-// print between here and the flush point below can still slip past deferral.
-//
-// A generation that re-execs further always `return`s from inside one of the two
-// decision blocks below, before ever reaching the flush point — so its accumulated
-// entries are silently discarded, exactly as #2041 intended for the single-re-exec case,
-// but now correctly for however many stack. LOUD FAILURES are untouched: every error path
-// in this function (provisioning failure, BC version selection failure, no matching
-// engine variant, an incomplete artifact closure) returns its own specific message
-// immediately and never reaches — nor needs — this list. The `[reexec]` explanation
-// lines (#2034/#2038) are a different print entirely and stay unconditional, printed
-// from whichever generation actually decides to hand off.
-var deferredStartupLines = new List<Action>();
 // --tdd forces the AL-output cache off (same effect as --no-cache), on top of the
 // tdd:<0|1> cache-key line added above. The line alone stops a --tdd run from ever
 // SERVING a normal-mode DLL or vice versa (criterion 11) — but it does not make a
@@ -583,15 +547,21 @@ var deferredStartupLines = new List<Action>();
 // green" failure mode this whole issue exists to fix, just moved one level down. Until
 // the excluded-object detail has its own cache sidecar (a --tdd cache HIT is a
 // reasonable follow-up), disabling the cache is what keeps every --tdd run correct.
+//
+// #2097 considered — but rejected — deferring this notice: unlike the trio (#2066) and
+// the "already cached, proceeds normally" BC-selection lines below, this print sits
+// upstream of several unrelated failure returns still to come in THIS SAME generation
+// (bad bundle root, malformed --expectations/--count-baseline manifest, BC version
+// selection failure, no matching engine variant, an incomplete artifact closure) — any
+// of which would silently discard this notice along with it if it were queued instead
+// of printed immediately. It duplicates on a stacked re-exec exactly like the lines
+// below do, but staying immediate here is the smaller cost versus losing it on error.
 if (tddMode && alCacheDir != null)
 {
-    // #2097: deferred — see `deferredStartupLines`'s declaration above. A no-string-
-    // interpolation constant message, so nothing needs capturing into a local before
-    // queueing.
-    deferredStartupLines.Add(() => Console.Error.WriteLine(
+    Console.Error.WriteLine(
         "--tdd disables the AL-output cache for this run — its synthetic FAILED tests " +
         "for excluded objects are derived fresh from source on every Emit() call and " +
-        "are not part of the cached DLL, so a cache HIT would silently drop them."));
+        "are not part of the cached DLL, so a cache HIT would silently drop them.");
     alCacheDir = null;
 }
 // ── Positional bundle roots must exist (#1713) ────────────────────────────────
@@ -610,6 +580,52 @@ if (tddMode && alCacheDir != null)
         return 2;
     }
 }
+// #2041/#2066/#2097: rather than PREDICTING whether this generation will need to
+// re-exec (the #2041 approach — a flag computed from NeedsShadow alone, before either
+// the per-BC-minor variant swap or the Cecil-rewrite cache state is knowable), the
+// success-path startup lines below are DEFERRED into this list and only flushed once
+// this generation has cleared every re-exec decision point in the function — the
+// shadow-hop check AND the Cecil-fresh-rewrite check, in that order, however many of
+// them fire.
+//
+// #2041's predict-then-suppress design covered exactly one re-exec (the shadow hop) and
+// silently broke the moment a SECOND one stacked on top: a per-BC-minor engine-variant
+// swap forces its own shadow-hop generation to also perform its first-ever Cecil rewrite
+// of that variant's Ncl.dll (a cache MISS, since the shadow-dir builder skips the
+// pre-rewrite for a variant swap — see EnsureShadowDir's doc comment), which is a SECOND
+// re-exec `reexecPending` had no way to see coming. That intermediate generation printed
+// the trio believing itself final, then re-exec'd anyway, and the real final generation
+// printed it again — three generations, two prints. See #2066.
+//
+// #2097: #2066 only fixed the trio. The "[expectations] loaded/not found" lines just
+// below, and the "cached-exact"/"cached-minor" branches of the BC auto-selection switch
+// further down, had the identical shape and duplicated the identical way, because they
+// all print BEFORE either re-exec decision point below and this list did not exist yet
+// at the point they ran. Declared here — ahead of all of them, instead of just ahead of
+// the trio — so none of those prints can slip past deferral.
+//
+// NOT every candidate found by #2097's own audit of this startup path got moved into
+// this list, even though every one of them duplicates the same way on a stacked re-exec.
+// The --tdd cache-disable notice, the "cdn-exact"/"cdn-minor"/KNOWN-DEGRADED branches of
+// the switch below, and the per-BC-minor-variants-shipped branch's own auto-select line
+// all sit upstream of a LOUD FAILURE that can return from THIS SAME generation before
+// ever reaching the flush point — deferring them risks silently discarding the one
+// piece of output that explains why that failure happened, or (for "cdn-exact"/"cdn-
+// minor" specifically) delays the caller's only signal that a real, possibly
+// multi-minute download is about to start until AFTER that download finishes. See each
+// site's own comment for why it was left immediate instead. Confirmed necessary by
+// DefaultProvisionTargetMessagingTests, which failed against an earlier draft of this
+// fix that deferred all of them uniformly.
+//
+// A generation that re-execs further always `return`s from inside one of the two
+// decision blocks below, before ever reaching the flush point — so its accumulated
+// entries are silently discarded, exactly as #2041 intended for the single-re-exec case,
+// but now correctly for however many stack. LOUD FAILURES on the lines that ARE deferred
+// here are still fine to lose this way: every error path in this function returns its
+// own specific message immediately regardless, and the `[reexec]` explanation lines
+// (#2034/#2038) are a different print entirely and stay unconditional, printed from
+// whichever generation actually decides to hand off.
+var deferredStartupLines = new List<Action>();
 // ── Test-expectations manifest (issue #1734; docs/expectations.md) ────────────────
 // Loaded HERE — at parse time, before BC init — so a malformed manifest aborts the
 // invocation (exit 2, the "bad invocation" ladder entry) without running a single
@@ -772,17 +788,19 @@ if (bcVersionArg == null && artifactPathArg == null)
             var latestDir = AlRunner.Infrastructure.BcArtifacts.SelectArtifactVersionDir(
                 AlRunner.Infrastructure.BcArtifacts.ArtifactsRootDir, null);
             bcVersionArg = Path.GetFileName(latestDir);
-            // #2097: deferred — see `deferredStartupLines`'s declaration above. Captured
-            // into locals now: `bcVersionArg` is reassigned further down (after
-            // provisioning resolves the actual version to run against), so a closure
-            // reading `bcVersionArg` directly would print whatever THAT later
-            // reassignment left behind, not what THIS generation auto-selected here.
-            var autoSelectedVersionForPrint = bcVersionArg;
-            var shippedVariantCountForPrint = shippedVariantsForDefault.Count;
-            deferredStartupLines.Add(() => Console.Error.WriteLine(
-                $"[bc] no --bc-version given — selecting BC {autoSelectedVersionForPrint}, the latest " +
-                $"cached artifact ({shippedVariantCountForPrint} engine variant(s) shipped; the matching " +
-                $"one is selected automatically below). Override with --bc-version."));
+            // #2097 considered — but rejected — deferring this line and the mismatch
+            // warning just below: unlike the "cached-exact"/"cached-minor" branches of
+            // the OTHER (no-variants-shipped) half of this if/else, this branch's own
+            // "latest cached artifact" can still fail to have a matching engine variant
+            // a few dozen lines further down (EngineVariants.SelectBestMatch returning
+            // null is a loud, immediate `return 2`) — the exact silent-discard-on-error
+            // shape proven real by DefaultProvisionTargetMessagingTests below, one
+            // if/else branch over. Staying immediate accepts the same "duplicates 3x on
+            // a stacked re-exec" cost the no-variants-shipped switch's KNOWN-DEGRADED
+            // branches also still pay, for the same reason.
+            Console.Error.WriteLine($"[bc] no --bc-version given — selecting BC {bcVersionArg}, the latest " +
+                $"cached artifact ({shippedVariantsForDefault.Count} engine variant(s) shipped; the matching " +
+                $"one is selected automatically below). Override with --bc-version.");
         }
         catch (InvalidOperationException)
         {
@@ -793,16 +811,8 @@ if (bcVersionArg == null && artifactPathArg == null)
         var projMajorV = TryDeriveBcMajorFromProject(bundles);
         if (projMajorV != null && bcVersionArg != null
             && Version.TryParse(bcVersionArg, out var selV) && selV.Major.ToString() != projMajorV)
-        {
-            // #2097: deferred — see `deferredStartupLines`'s declaration above. Same
-            // `bcVersionArg`-reassignment hazard as the block above — capture now.
-            var projMajorForPrint = projMajorV;
-            var autoSelectedVersionForMismatchPrint = bcVersionArg;
-            var selMajorForPrint = selV.Major;
-            deferredStartupLines.Add(() => Console.Error.WriteLine(
-                $"[bc] warning: project app.json targets BC major {projMajorForPrint} but the " +
-                $"latest cached artifact is {autoSelectedVersionForMismatchPrint} (major {selMajorForPrint})."));
-        }
+            Console.Error.WriteLine($"[bc] warning: project app.json targets BC major {projMajorV} but the " +
+                $"latest cached artifact is {bcVersionArg} (major {selV.Major}).");
     }
     else
     {
@@ -842,12 +852,40 @@ if (bcVersionArg == null && artifactPathArg == null)
             }
 
             var engineMajorMinor = $"{engineVersion.Major}.{engineVersion.Minor}";
-            // #2097: every branch of this switch is deferred — see
-            // `deferredStartupLines`'s declaration above. `engineVersion`, `engineMajorMinor`
-            // and `engineMajor` are all `var`-declared once above and never reassigned
-            // afterward (unlike `bcVersionArg` elsewhere in this function), so the
-            // closures below can read them directly with no separate capture step; their
-            // values are already fixed for this generation.
+            // #2097: only "cached-exact" and "cached-minor" below are deferred — see
+            // `deferredStartupLines`'s declaration above. Both describe an artifact
+            // that is ALREADY on disk, so SelectVersion just below reliably succeeds
+            // against it and this generation proceeds normally to the flush point,
+            // same shape as the reported "cached-exact" duplication. The other three
+            // branches are deliberately left printing immediately, for two DIFFERENT
+            // reasons:
+            //   - "cdn-exact"/"cdn-minor": ResolveProvisionTargetCore checks the cache
+            //     BEFORE the CDN at every tier (see its own doc comment), so once
+            //     RunProvisioning below successfully downloads what these branches
+            //     describe, EVERY later generation's tier recomputation finds it
+            //     already cached and takes the "cached-exact"/"cached-minor" branch
+            //     instead — a "cdn-*" branch can only ever fire in the one generation
+            //     that is about to perform the download, so it cannot itself
+            //     duplicate across re-execs the way the cached branches do. Deferring
+            //     it anyway would be a straight regression: the download that follows
+            //     can take minutes, and this line is the ONLY signal a caller gets
+            //     that a download is about to start at all — see
+            //     DefaultProvisionTargetMessagingTests.
+            //     AutoProvisionDefault_EmptyCache_TargetsEngineExactBuild_NeverDegradedWarning,
+            //     which kills the process the instant this line appears specifically
+            //     so it never has to wait out the real download, and failed hard
+            //     (30s timeout) the one time this was deferred here.
+            //   - "major-fallback-offline"/default ("major-fallback"): both are a
+            //     KNOWN-DEGRADED warning that commonly precedes an immediate failure
+            //     in THIS SAME generation (SelectVersion below has nothing durable to
+            //     select if nothing at all could be resolved) — deferring would risk
+            //     silently discarding the one piece of output that explains WHY the
+            //     following generic "BC version selection failed" error happened.
+            //     Confirmed by DefaultProvisionTargetMessagingTests.
+            //     NoAutoProvision_EmptyCache_MajorFallbackWarning_NeverClaimsCdnWasChecked,
+            //     which asserts on this exact text and failed the one time it was
+            //     deferred here (the process exits 2 before ever reaching the flush
+            //     point, so the deferred entry was silently dropped).
             switch (tier)
             {
                 case "cached-exact":
@@ -856,9 +894,8 @@ if (bcVersionArg == null && artifactPathArg == null)
                         $"build this binary was compiled against. Override with --bc-version."));
                     break;
                 case "cdn-exact":
-                    deferredStartupLines.Add(() => Console.Error.WriteLine(
-                        $"[bc] no --bc-version given — provisioning BC {engineVersion}, the exact " +
-                        $"build this binary was compiled against. Override with --bc-version."));
+                    Console.Error.WriteLine($"[bc] no --bc-version given — provisioning BC {engineVersion}, the exact " +
+                        $"build this binary was compiled against. Override with --bc-version.");
                     break;
                 case "cached-minor":
                     // Degraded but usually survivable: right minor, different build. The CodeAnalysis
@@ -870,44 +907,40 @@ if (bcVersionArg == null && artifactPathArg == null)
                         $"Microsoft.Dynamics.Nav.CodeAnalysis. Fix with: al-runner provision --bc-version {engineVersion}"));
                     break;
                 case "cdn-minor":
-                    deferredStartupLines.Add(() => Console.Error.WriteLine(
-                        $"[bc] no --bc-version given and BC {engineVersion} is not published on " +
+                    Console.Error.WriteLine($"[bc] no --bc-version given and BC {engineVersion} is not published on " +
                         $"the CDN — provisioning the latest {engineMajorMinor}.x instead (still this binary's own " +
                         $"engine minor). Build-level skew within a minor can still fail to load " +
-                        $"Microsoft.Dynamics.Nav.CodeAnalysis. Fix with: al-runner provision --bc-version {engineVersion}"));
+                        $"Microsoft.Dynamics.Nav.CodeAnalysis. Fix with: al-runner provision --bc-version {engineVersion}");
                     break;
                 case "major-fallback-offline":
                     // No network step is coming (--no-auto-provision, or the rare case where
                     // engineVersion resolved but auto-provisioning is off) — this can only speak
                     // to what's CACHED, never to CDN availability. Original pre-#2033 wording.
-                    deferredStartupLines.Add(() => Console.Error.WriteLine(
-                        $"[bc] warning: no cached BC {engineMajorMinor}.x — this binary's engine " +
+                    Console.Error.WriteLine($"[bc] warning: no cached BC {engineMajorMinor}.x — this binary's engine " +
                         $"was built for {engineVersion}, so a different minor is a KNOWN-DEGRADED configuration " +
                         $"(measured: dozens of extra failures from engine/artifact minor skew). Falling back to the " +
-                        $"latest cached {engineMajor}.x. Fix with: al-runner provision --bc-version {engineMajorMinor}"));
+                        $"latest cached {engineMajor}.x. Fix with: al-runner provision --bc-version {engineMajorMinor}");
                     break;
                 default: // major-fallback: neither the exact build nor the engine's own minor is
                          // available from cache or the CDN — a genuine degradation (e.g. #2010,
                          // Microsoft withdrew the build), not the default-path norm.
-                    deferredStartupLines.Add(() => Console.Error.WriteLine(
-                        $"[bc] warning: BC {engineMajorMinor}.x is not cached and not available " +
+                    Console.Error.WriteLine($"[bc] warning: BC {engineMajorMinor}.x is not cached and not available " +
                         $"from the CDN — this binary's engine was built for {engineVersion}, so a different minor is " +
                         $"a KNOWN-DEGRADED configuration (measured: dozens of extra failures from engine/artifact " +
                         $"minor skew). Falling back to the latest {engineMajor}.x. Fix with: al-runner provision " +
-                        $"--bc-version {engineMajorMinor}"));
+                        $"--bc-version {engineMajorMinor}");
                     break;
             }
 
+            // #2097: NOT deferred — deliberately kept immediate, unlike the cached-tier
+            // branches above. This fires regardless of which tier won, including the two
+            // KNOWN-DEGRADED branches that can precede an immediate failure return in
+            // this same generation — deferring it would risk the same silent-discard-on-
+            // error trap documented on the switch above.
             var projMajor = TryDeriveBcMajorFromProject(bundles);
             if (projMajor != null && projMajor != engineMajor.Value.ToString())
-            {
-                // #2097: deferred — see `deferredStartupLines`'s declaration above.
-                // `projMajor` and `engineMajor` are stable for the same reason as the
-                // switch above.
-                deferredStartupLines.Add(() => Console.Error.WriteLine(
-                    $"[bc] warning: project app.json targets BC major {projMajor} but this " +
-                    $"runner build supports major {engineMajor} (cross-major needs a matching runner build)."));
-            }
+                Console.Error.WriteLine($"[bc] warning: project app.json targets BC major {projMajor} but this " +
+                    $"runner build supports major {engineMajor} (cross-major needs a matching runner build).");
         }
     }
 }


### PR DESCRIPTION
Closes #2097

#2066 deferred the startup trio (`[provision] BC ... already complete`, `[bc] selected BC ...`, `al-runner — running N bundle(s)`) into `deferredStartupLines`, flushed once a generation clears every re-exec decision point. That list, however, was declared partway through Program.cs's startup path — after several other steady-state informational prints already ran — so those kept printing once per process generation on a stacked re-exec, the same bug in different lines.

## Fix

Moved `deferredStartupLines`'s declaration ahead of the earliest print that needs it, and deferred:

- `[expectations] loaded N entries from ...` / `[expectations] no tests/expectations manifest found ...` (both explicitly named/measured by the issue's own repro shape for the first one).
- The `"cached-exact"`/`"cached-minor"` branches of the BC auto-selection switch (`[bc] no --bc-version given — selecting BC ...` / `[bc] warning: no cached BC ... selecting the latest ...`) — this is the exact line the issue measured duplicating 3x.

Where the interpolated value is read from a variable reassigned later in the same generation before the flush point (`bcVersionArg` is reassigned after provisioning resolves the actual version to run against), the value is captured into a fresh local at queue time — following the same pattern #2096 already used for `[bc] selected BC`.

### Audit for other candidates (requirement 3) — and why most of them stay immediate

I checked the whole startup path for other unconditional informational prints with the same shape, and found more than the two named lines: the `--tdd` cache-disable notice, the `"cdn-exact"`/`"cdn-minor"`/`"major-fallback-offline"`/`"major-fallback"` branches of the same switch, the trailing project-major-mismatch warning, and the per-BC-minor-variants-shipped branch's own auto-select line all have the identical "prints once per generation, unconditionally" shape.

My first draft deferred all of them uniformly. CI's `DefaultProvisionTargetMessagingTests` caught two real regressions that draft introduced:

1. **`NoAutoProvision_EmptyCache_MajorFallbackWarning_NeverClaimsCdnWasChecked`** — the `"major-fallback-offline"` KNOWN-DEGRADED warning explains *why* the version-selection failure that follows it (in the same generation, before the flush point) happened. Deferring it meant the process returns 2 before ever reaching the flush, silently discarding the one line that explains the failure.
2. **`AutoProvisionDefault_EmptyCache_TargetsEngineExactBuild_NeverDegradedWarning`** — the `"cdn-exact"` line is the only signal a caller gets that a real, possibly multi-minute provisioning download is about to start. This test kills the process the instant that line appears specifically to avoid waiting out the real download. Deferring it delays the print until after that download completes (or fails), which is both a UX regression and what made this test time out.

Neither of these two failure modes applies to `"cached-exact"`/`"cached-minor"`: the artifact they describe is already on disk, so `SelectVersion` reliably succeeds and this generation reaches the flush point normally — same shape as the already-shipped `[bc] selected BC` line. `ResolveProvisionTargetCore` also checks the cache before the CDN at every tier, so a `"cdn-*"` branch can only ever fire once (in the generation that performs the download); every later generation's tier recomputation finds it cached and takes the `"cached-*"` branch instead — it can't actually duplicate across re-execs the way the cached branches do, so leaving it immediate costs nothing.

Given that, I kept the `--tdd` notice, the `"cdn-exact"`/`"cdn-minor"`/`"major-fallback-offline"`/`"major-fallback"` branches, the trailing project-major-mismatch warning, and the per-BC-minor-variants-shipped branch's auto-select line (whose own later `EngineVariants.SelectBestMatch` call can also `return 2`) printing immediately, each with a comment at the call site explaining why. Every one of `.claude/rules/loud-failures.md`'s "don't silently discard diagnostic information" concerns pointed the same direction here.

## Testing

Extended `AlRunner.Tests/StartupOutputReexecDedupTests.cs` with `ColdCecilCache_StackedShadowAndFreshRewriteReexec_BcAutoSelectAndExpectationsPrintExactlyOnce`, following the same pattern as the existing `ColdCecilCache_StackedShadowAndFreshRewriteReexec_StartupTrioPrintsExactlyOnce` (private mirror + `AL_RUNNER_NCL_CACHE=0` to force the stacked three-generation case), but spawned WITHOUT `--bc-version` so the auto-selection line actually fires (this dev/CI environment always has the exact engine build cached, so this deterministically hits the `"cached-exact"` branch). Asserts both `[reexec]` lines exactly once first (proof of three genuine generations), then both target lines exactly once each.

- RED confirmed against `HEAD` (pre-fix `Program.cs`): `Assert.Equal(1, ...)` failed with actual `3` for both target lines.
- GREEN confirmed after the fix: all 7 tests in `StartupOutputReexecDedupTests` pass.
- `DefaultProvisionTargetMessagingTests` (both cases described above): now pass — this is the regression-proof for the narrowed scope.
- `BcArtifactSelectionTests`, `BcVersionFloorSkipTests`, `ExpectationManifestWiringTests`, `ExplicitEngineMinorWarningGatingTests`, `EngineMinorMismatchWarningTests`, `DefaultProvisionTargetTests`, `TestArtifactsGateTests`, `CliDocumentationTests`: 79 passed.
- `scripts/check-collection-weights.py` against a fresh TRX for `StartupOutputReexecDedupTests`: OK (no collection above 60s missing from the table).

Ran with `-p:_BCVersion=28.1.49838.53910` per #2102 (bare `dotnet test` currently fails with CS1705 on a clean checkout — filed separately, not fixed here).