### PR TITLE
fix(tests): make SiblingSourceDep_CompilesWithZeroPackageCacheDirs hermetic

### DIFF
--- a/AlRunner.Tests/SourceDepSymbolsWithoutPackageCacheTests.cs
+++ b/AlRunner.Tests/SourceDepSymbolsWithoutPackageCacheTests.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using Xunit;
 
 namespace AlRunner.Tests;
@@ -35,6 +36,25 @@ namespace AlRunner.Tests;
 /// them (it downloads to <c>~/.al-runner/…</c> and passes <c>--package-cache</c> explicitly
 /// on the steps that need it), while a dev box that once ran <c>--auto-provision</c> has
 /// them and silently took the working path.
+///
+/// #2067: that last sentence is not hypothetical — it is exactly what makes this test
+/// non-hermetic on a warm dev box, and it happens even with the explicit
+/// <c>--package-cache &lt;nonexistent dir&gt;</c> below. Program.cs folds the SELECTED BC
+/// version's runner-owned <c>&lt;ArtifactsRootDir&gt;/&lt;version&gt;/{platform-apps,test-apps}</c>
+/// into <c>packageCacheDirs</c> whenever that exact directory already exists on disk — by
+/// design (#1996), so a warm re-run of <c>--auto-provision</c>/<c>al-runner provision</c>
+/// never re-hits the CDN — and it does so AFTER the "package caches: N dir(s)" line below is
+/// printed, so that line's "0" is true of the explicit/default set only, not of what
+/// dependency resolution actually searches a moment later. CI's own provisioning writes to a
+/// DIFFERENT path (<c>$HOME/.al-runner/platform-apps</c> — see .github/workflows/bc-tests.yml),
+/// which the runner's fold-in logic never references, so CI's actual search set really is
+/// empty; a machine that has ever run <c>--auto-provision</c>/<c>provision</c> FOR THIS EXACT
+/// BC BUILD gets extra (correctly resolvable, Optional) Microsoft platform/test-toolkit
+/// candidates folded in and so resolves/loads more than the one sibling dep. That is
+/// legitimate warm-reuse behaviour, not a regression — so the assertions below only pin
+/// down what the #1748 fix actually claims (the sibling dep specifically is BOTH
+/// runtime-loadable and compile-visible), not the total dependency count, which is allowed
+/// to vary with this machine's own provisioning history.
 ///
 /// Spawns the real runner; needs the BC artifact cache. Skips (no-op) when absent.
 /// See DefineFlagIntegrationTests for why this used to be
@@ -153,6 +173,11 @@ public class SourceDepSymbolsWithoutPackageCacheTests
         args.Append($" \"{testsDir}\"");
         args.Append($" --cache \"{alCacheDir}\"");
         args.Append($" --package-cache \"{absentPackageCache}\"");
+        // --verbose: names which package WON each dependency slot (the "[dep] Publisher/Name
+        // Version <- path" line below), which is what lets the assertions confirm the
+        // SIBLING dep specifically resolved, independent of whatever else this machine's own
+        // provisioning history additionally folds in (see the class doc comment, #2067).
+        args.Append(" --verbose");
         var psi = new ProcessStartInfo
         {
             FileName = "dotnet", Arguments = args.ToString(),
@@ -170,12 +195,24 @@ public class SourceDepSymbolsWithoutPackageCacheTests
         string output;
         lock (sb) output = sb.ToString();
 
-        // Precondition: the configuration under test really is the zero-package-cache
-        // one. If the runner ever falls back to the default dirs here, this test would
-        // stop covering the CI path and go green for the wrong reason.
+        // Precondition: the EXPLICIT/DEFAULT package-cache set really is the zero-dir one
+        // (i.e. --package-cache pointing at a directory that doesn't exist really does take
+        // the explicit-arg branch, not a DefaultPackageCacheDirs fallback). This line is
+        // printed BEFORE Program.cs's runner-owned-provisioning fold (#1996), so it can be
+        // "0" even when the machine's own provisioning history later adds more candidates —
+        // see the class doc comment. If this ever goes non-zero, the explicit-arg branch
+        // itself broke, which is what this precondition actually guards.
         Assert.Contains("package caches: 0 dir(s)", output);
-        // The dep must be BOTH runtime-loadable and compile-visible.
-        Assert.Contains("loaded 1 dep assembl(ies)", output);
+        // The dep must be BOTH runtime-loadable and compile-visible. Do NOT pin the total
+        // dep count: a machine that has ever run --auto-provision/`provision` for this exact
+        // BC build resolves additional (legitimately available) Microsoft platform/test-
+        // toolkit apps too (#1996, #2067) — CI never does, because its own provisioning
+        // writes to a path the runner's fold-in logic doesn't reference. What the #1748 fix
+        // actually claims is that the SIBLING dep specifically resolved and loaded, which the
+        // --verbose "[dep] Publisher/Name" line below names directly, independent of whatever
+        // else got folded in alongside it.
+        Assert.Matches(new Regex(@"loaded [1-9]\d* dep assembl\(ies\)"), output);
+        Assert.Contains("[dep] Repro1731B/Repro1731B Dep App", output);
         Assert.DoesNotContain("AL0185", output);
         Assert.DoesNotContain("EMIT-ZERO", output);
         Assert.True(p.ExitCode == 0 && output.Contains("2P/0F/0E"),


### PR DESCRIPTION
Closes #2067

## Root cause (confirmed by reproduction, not guessed)

Deterministic on this box, matching the issue's four independent
reproductions. Traced it to a specific mechanism, not resource contention:

`Program.cs` unconditionally folds this machine's runner-owned
`<ArtifactsRootDir>/<version>/{platform-apps,test-apps}` (i.e.
`~/.local/share/al-runner/artifacts/<exact-BC-build>/{platform-apps,test-apps}`)
into `packageCacheDirs` whenever that exact directory already exists on disk
— by design, from issue #1996, so a warm re-run of `--auto-provision`/
`al-runner provision` never re-hits the CDN. It does this **after** the
`package caches: N dir(s)` diagnostic line prints, so that line can (correctly)
read `0 dir(s)` even though the dependency-resolution search set used a moment
later is not actually empty.

CI's own provisioning writes to a **different** path
(`$HOME/.al-runner/platform-apps` / `$HOME/.al-runner/test-apps` — see
`.github/workflows/bc-tests.yml`), which the runner's fold-in logic never
references. So on CI the search set really is empty and the sibling dep is the
only thing resolved (`resolved 1 dep(s)`, `loaded 1 dep assembl(ies)`). On a
dev box that has ever run `--auto-provision`/`provision` for the exact BC
build under test, the fold-in adds extra (legitimately available, `Optional`)
Microsoft platform/test-toolkit apps alongside the sibling dep, so the actual
counts come out higher (verified: `resolved 6 dep(s)`, `loaded 4 dep
assembl(ies)` here) — while the run itself still compiles and passes
correctly (`2P/0F/0E`, exit 0).

This is legitimate warm-reuse behavior (#1996), not a regression, and not the
resource-contention theory from the issue's original body — reproduced with
zero concurrent agents/builds, and with `--verbose` instrumentation showing
exactly which dirs and `.app` files fed dependency resolution.

## Fix

The test's own assertions were over-specified: they pinned the *total*
dependency count (`loaded 1 dep assembl(ies)`) instead of the actual claim
under test (the #1748 fix — the sibling dep is *specifically* both
runtime-loadable and compile-visible). That count is allowed to vary with a
machine's own provisioning history without the underlying claim being false.

- Added `--verbose` to the spawned runner invocation, which names the winning
  package per dependency slot (`[dep] Publisher/Name Version <- path`).
- Replaced the hardcoded `loaded 1 dep assembl(ies)` assertion with a
  `loaded [1-9]\d* dep assembl\(ies\)` pattern (at least one dep loaded) plus
  an explicit `[dep] Repro1731B/Repro1731B Dep App` assertion, so the test
  proves the *sibling dep by name* resolved and loaded, independent of
  whatever else this machine's warm cache also resolves alongside it.
- `DoesNotContain("AL0185"/"EMIT-ZERO")` and the `2P/0F/0E` + exit-0 check are
  unchanged — those already carry the real proof that the dep is
  compile-visible and its procedures execute correctly, and are unaffected by
  ambient provisioning state.
- Expanded the class doc comment to record the mechanism for future readers.

No `AlRunner/` production code was touched — this is a test-only fix. The
`#1996` fold-in behavior itself is correct and deliberate.

## Test plan

- [x] Reproduced the failure on a clean `origin/main` checkout with zero
      concurrent agents (RED), and traced it with temporary instrumentation
      (reverted before commit) to the exact fold-in mechanism.
- [x] `dotnet test AlRunner.Tests --filter
      FullyQualifiedName~SiblingSourceDep_CompilesWithZeroPackageCacheDirs`
      passes after the fix — run twice (cold + warm build) since this test
      spawns a real child process, per the cache-sensitivity rule.
- [x] `dotnet test AlRunner.Tests --filter FullyQualifiedName~SourceDep` (9
      tests) — all green.
- [x] `dotnet test AlRunner.Tests --filter
      "FullyQualifiedName~TestArtifactsGateTests|FullyQualifiedName~NoRemediationText_NamesTheCheckoutOnlyDownloadArtifactsInvocation"`
      (25 tests) — all green.
- [x] `dotnet build AlRunner.Tests -c Debug` — clean, no new warnings.