### PR TITLE
fix(startup): report the true final package-cache search set

### DIFF
--- a/AlRunner.Tests/PackageCacheFinalSearchSetTests.cs
+++ b/AlRunner.Tests/PackageCacheFinalSearchSetTests.cs
@@ -1,0 +1,227 @@
+// Issue #2107 — "package caches: N dir(s)" is printed in Program.cs BEFORE three later
+// additions fold into packageCacheDirs (extraProvisionSearchDirs, platformAppsOut,
+// testAppsOut), so the number it reports is not the set dependency resolution actually
+// searches a moment later. This surfaced diagnosing #2067: the line read "package caches:
+// 0 dir(s)" on a machine where resolution went on to search several directories, because a
+// prior --auto-provision/`provision` run for the exact same BC build had left runner-owned
+// `<artifacts>/<version>/{platform-apps,test-apps}` on disk, and Program.cs folds those in
+// right after printing the count.
+//
+// This test forces that fold deterministically and asserts the run also reports a SECOND,
+// later line naming the TRUE final count — not just that some number gets printed (the
+// pre-fix code already does that; it is simply the wrong number at the wrong time).
+//
+// Uses --artifact-path (not --bc-version) so the engine/service-tier directory stays
+// pinned at the REAL, already-provisioned machine path — BcArtifacts.ServiceTierDir takes
+// the literal explicit-root branch there, independent of $HOME — while
+// BcArtifacts.ArtifactsRootDir (used ONLY to compute the runnerOwnedPlatformAppsDir /
+// runnerOwnedTestAppsDir fold-in candidates in Program.cs) resolves under the isolated
+// $HOME this test controls. That lets the fold be forced or withheld on demand without
+// ever touching this machine's real ~/.local/share/al-runner/artifacts.
+using System.Diagnostics;
+using System.Text;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class PackageCacheFinalSearchSetTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+    private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
+
+    /// <summary>
+    /// A dep/tests pair that declares nothing Microsoft (mirrors
+    /// SourceDepSymbolsWithoutPackageCacheTests's fixture) — so whatever the fold adds to
+    /// packageCacheDirs is visible only in the SEARCH SET this test asserts on, never in a
+    /// provisioning decision (which would otherwise try to download real platform/test
+    /// apps and make the test depend on network access).
+    /// </summary>
+    private static string WriteFixture(string scratchRoot)
+    {
+        var depDir = Path.Combine(scratchRoot, "dep-app");
+        var testsDir = Path.Combine(scratchRoot, "tests-app");
+        Directory.CreateDirectory(depDir);
+        Directory.CreateDirectory(testsDir);
+        var depId = Guid.NewGuid();
+        var testsId = Guid.NewGuid();
+        File.WriteAllText(Path.Combine(depDir, "app.json"), $$"""
+        {
+          "id": "{{depId}}",
+          "name": "Repro2107 Dep App",
+          "publisher": "Repro2107",
+          "version": "1.0.0.0",
+          "dependencies": [],
+          "platform": "1.0.0.0",
+          "application": "1.0.0.0",
+          "idRanges": [ { "from": 61950, "to": 61959 } ],
+          "runtime": "14.0"
+        }
+        """);
+        File.WriteAllText(Path.Combine(depDir, "Repro2107Dep.al"), """
+        codeunit 61950 "Repro2107 Service"
+        {
+            procedure Echo(): Text
+            begin
+                exit('ok');
+            end;
+        }
+        """);
+        File.WriteAllText(Path.Combine(testsDir, "app.json"), $$"""
+        {
+          "id": "{{testsId}}",
+          "name": "Repro2107 Tests",
+          "publisher": "Repro2107",
+          "version": "1.0.0.0",
+          "dependencies": [
+            { "id": "{{depId}}", "name": "Repro2107 Dep App", "publisher": "Repro2107", "version": "1.0.0.0" }
+          ],
+          "platform": "1.0.0.0",
+          "application": "1.0.0.0",
+          "idRanges": [ { "from": 61960, "to": 61969 } ],
+          "runtime": "14.0"
+        }
+        """);
+        File.WriteAllText(Path.Combine(testsDir, "Repro2107Tests.al"), """
+        codeunit 61960 "Repro2107 Tests"
+        {
+            Subtype = Test;
+
+            [Test]
+            procedure DepResolves()
+            var
+                Svc: Codeunit "Repro2107 Service";
+            begin
+                if Svc.Echo() <> 'ok' then
+                    Error('dep did not resolve');
+            end;
+        }
+        """);
+        return testsDir;
+    }
+
+    private static string RealServiceTierDir()
+    {
+        var version = AlRunner.Infrastructure.BcArtifacts.EngineBuiltVersion()
+            ?? throw new InvalidOperationException(
+                "EngineBuiltVersion() unavailable — cannot locate a real artifact dir to pin --artifact-path at.");
+        var home = Environment.GetEnvironmentVariable("HOME")
+            ?? throw new InvalidOperationException("HOME not set on this machine.");
+        return Path.Combine(TestArtifacts.StandardCacheDir(home), version.ToString());
+    }
+
+    private static string RunAgainstIsolatedHome(
+        string testsDir, string alCacheDir, string isolatedHome, bool foldRunnerOwnedDirs)
+    {
+        var realServiceTierDir = RealServiceTierDir();
+        TestArtifacts.SkipIf(!Directory.Exists(realServiceTierDir),
+            $"real BC service-tier dir not provisioned at '{realServiceTierDir}' " +
+            "(needed so --artifact-path can pin the engine while $HOME is isolated).");
+
+        if (foldRunnerOwnedDirs)
+        {
+            var version = AlRunner.Infrastructure.BcArtifacts.EngineBuiltVersion()!.ToString();
+            var artifactsRoot = Path.Combine(TestArtifacts.StandardCacheDir(isolatedHome), version);
+            Directory.CreateDirectory(Path.Combine(artifactsRoot, "platform-apps"));
+            Directory.CreateDirectory(Path.Combine(artifactsRoot, "test-apps"));
+        }
+
+        var absentPackageCache = Path.Combine(isolatedHome, "no-such-package-cache");
+        var args = new StringBuilder(TestBuildConfig.RunArgs(ProjectPath));
+        args.Append($" --artifact-path \"{realServiceTierDir}\"");
+        args.Append($" \"{testsDir}\"");
+        args.Append($" --cache \"{alCacheDir}\"");
+        // Deliberately NEVER created: ExpandPackageCacheDirs drops non-existent dirs, so
+        // this takes the explicit-arg branch and resolves to the EMPTY set — the same
+        // "package caches: 0 dir(s)" precondition SourceDepSymbolsWithoutPackageCacheTests
+        // relies on.
+        args.Append($" --package-cache \"{absentPackageCache}\"");
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            Arguments = args.ToString(),
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            WorkingDirectory = RepoRoot,
+        };
+        // Isolates BcArtifacts.ArtifactsRootDir (and therefore the fold-in candidates
+        // Program.cs computes from it) from this machine's real provisioning history,
+        // WITHOUT touching BcArtifacts.ServiceTierDir — that stays pinned at the literal
+        // --artifact-path above regardless of $HOME.
+        psi.Environment["HOME"] = isolatedHome;
+
+        var sb = new StringBuilder();
+        using var p = Process.Start(psi)!;
+        p.OutputDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.ErrorDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.BeginOutputReadLine();
+        p.BeginErrorReadLine();
+        if (!p.WaitForExit(180_000)) { try { p.Kill(true); } catch { } throw new TimeoutException("runner hung"); }
+        p.WaitForExit();
+        string output;
+        lock (sb) output = sb.ToString();
+
+        Assert.True(p.ExitCode == 0 && output.Contains("1P/0F/0E"),
+            $"fixture (nothing Microsoft, one dep, one passing test) must compile and run:\n{output}");
+        return output;
+    }
+
+    /// <summary>
+    /// RED (pre-fix): the ONLY "package caches" line prints the pre-fold count (0), taken
+    /// before Program.cs adds the two runner-owned dirs this test pre-creates — the exact
+    /// #2067 shape. GREEN: a second, later line reports the true final count (2).
+    /// </summary>
+    [SkippableFact]
+    public void FinalSearchSet_ReflectsRunnerOwnedFoldIn()
+    {
+        TestArtifacts.SkipIfMissing();
+        var scratchRoot = Path.Combine(
+            Path.GetTempPath(), "al-runner-pkgcache-final", Guid.NewGuid().ToString("N"));
+        var testsDir = WriteFixture(scratchRoot);
+        var isolatedHome = Path.Combine(scratchRoot, "home");
+        Directory.CreateDirectory(isolatedHome);
+        var alCacheDir = Path.Combine(scratchRoot, "al-out");
+        try
+        {
+            var output = RunAgainstIsolatedHome(testsDir, alCacheDir, isolatedHome, foldRunnerOwnedDirs: true);
+
+            Assert.Contains("package caches: 0 dir(s)", output);
+            Assert.Matches(new Regex(@"package caches \(final search set\): 2 dir\(s\)"), output);
+        }
+        finally
+        {
+            try { Directory.Delete(scratchRoot, recursive: true); } catch { }
+        }
+    }
+
+    /// <summary>
+    /// The plain-path guard: when nothing runner-owned exists to fold in, the final line
+    /// must report the SAME count as the first — the fix must not distort the common case
+    /// (no --auto-provision history for this BC build) by inventing a phantom addition.
+    /// </summary>
+    [SkippableFact]
+    public void FinalSearchSet_UnchangedWhenNothingFolds()
+    {
+        TestArtifacts.SkipIfMissing();
+        var scratchRoot = Path.Combine(
+            Path.GetTempPath(), "al-runner-pkgcache-final-plain", Guid.NewGuid().ToString("N"));
+        var testsDir = WriteFixture(scratchRoot);
+        var isolatedHome = Path.Combine(scratchRoot, "home");
+        Directory.CreateDirectory(isolatedHome);
+        var alCacheDir = Path.Combine(scratchRoot, "al-out");
+        try
+        {
+            var output = RunAgainstIsolatedHome(testsDir, alCacheDir, isolatedHome, foldRunnerOwnedDirs: false);
+
+            Assert.Contains("package caches: 0 dir(s)", output);
+            Assert.Contains("package caches (final search set): 0 dir(s)", output);
+        }
+        finally
+        {
+            try { Directory.Delete(scratchRoot, recursive: true); } catch { }
+        }
+    }
+}

--- a/AlRunner.Tests/PackageCacheFinalSearchSetTests.cs
+++ b/AlRunner.Tests/PackageCacheFinalSearchSetTests.cs
@@ -1,15 +1,18 @@
-// Issue #2107 — "package caches: N dir(s)" is printed in Program.cs BEFORE three later
-// additions fold into packageCacheDirs (extraProvisionSearchDirs, platformAppsOut,
-// testAppsOut), so the number it reports is not the set dependency resolution actually
-// searches a moment later. This surfaced diagnosing #2067: the line read "package caches:
-// 0 dir(s)" on a machine where resolution went on to search several directories, because a
-// prior --auto-provision/`provision` run for the exact same BC build had left runner-owned
-// `<artifacts>/<version>/{platform-apps,test-apps}` on disk, and Program.cs folds those in
-// right after printing the count.
+// Issue #2107 — Program.cs prints "package caches (requested): N dir(s)" for the
+// explicit/default set BEFORE three later additions fold into packageCacheDirs
+// (extraProvisionSearchDirs, platformAppsOut, testAppsOut), so that count is never the
+// set dependency resolution actually searches a moment later. Before the fix the line
+// carried no "(requested)" qualifier at all, so it read as the whole story: it printed
+// "package caches: 0 dir(s)" on a machine where resolution went on to search several
+// directories, because a prior --auto-provision/`provision` run for the exact same BC
+// build had left runner-owned `<artifacts>/<version>/{platform-apps,test-apps}` on disk,
+// and Program.cs folds those in right after printing the count. That is what made #2067
+// slow to diagnose.
 //
 // This test forces that fold deterministically and asserts the run also reports a SECOND,
-// later line naming the TRUE final count — not just that some number gets printed (the
-// pre-fix code already does that; it is simply the wrong number at the wrong time).
+// later line naming the TRUE final count under its own "(final search set)" label — not
+// just that some number gets printed (the pre-fix code already did that; it was simply
+// the wrong number, unlabeled, at the wrong time).
 //
 // Uses --artifact-path (not --bc-version) so the engine/service-tier directory stays
 // pinned at the REAL, already-provisioned machine path — BcArtifacts.ServiceTierDir takes
@@ -134,8 +137,8 @@ public sealed class PackageCacheFinalSearchSetTests
         args.Append($" --cache \"{alCacheDir}\"");
         // Deliberately NEVER created: ExpandPackageCacheDirs drops non-existent dirs, so
         // this takes the explicit-arg branch and resolves to the EMPTY set — the same
-        // "package caches: 0 dir(s)" precondition SourceDepSymbolsWithoutPackageCacheTests
-        // relies on.
+        // "package caches (requested): 0 dir(s)" precondition
+        // SourceDepSymbolsWithoutPackageCacheTests relies on.
         args.Append($" --package-cache \"{absentPackageCache}\"");
         var psi = new ProcessStartInfo
         {
@@ -170,9 +173,11 @@ public sealed class PackageCacheFinalSearchSetTests
     }
 
     /// <summary>
-    /// RED (pre-fix): the ONLY "package caches" line prints the pre-fold count (0), taken
-    /// before Program.cs adds the two runner-owned dirs this test pre-creates — the exact
-    /// #2067 shape. GREEN: a second, later line reports the true final count (2).
+    /// RED (pre-fix): the ONLY "package caches" line prints the pre-fold count (0, and
+    /// unlabeled — no "(requested)" qualifier existed yet), taken before Program.cs adds
+    /// the two runner-owned dirs this test pre-creates — the exact #2067 shape. GREEN: the
+    /// "(requested)" line still reads 0, and a second, later "(final search set)" line
+    /// reports the true final count (2).
     /// </summary>
     [SkippableFact]
     public void FinalSearchSet_ReflectsRunnerOwnedFoldIn()
@@ -188,7 +193,7 @@ public sealed class PackageCacheFinalSearchSetTests
         {
             var output = RunAgainstIsolatedHome(testsDir, alCacheDir, isolatedHome, foldRunnerOwnedDirs: true);
 
-            Assert.Contains("package caches: 0 dir(s)", output);
+            Assert.Contains("package caches (requested): 0 dir(s)", output);
             Assert.Matches(new Regex(@"package caches \(final search set\): 2 dir\(s\)"), output);
         }
         finally
@@ -198,9 +203,10 @@ public sealed class PackageCacheFinalSearchSetTests
     }
 
     /// <summary>
-    /// The plain-path guard: when nothing runner-owned exists to fold in, the final line
-    /// must report the SAME count as the first — the fix must not distort the common case
-    /// (no --auto-provision history for this BC build) by inventing a phantom addition.
+    /// The plain-path guard: when nothing runner-owned exists to fold in, the "(final
+    /// search set)" line must report the SAME count as the "(requested)" line — the fix
+    /// must not distort the common case (no --auto-provision history for this BC build)
+    /// by inventing a phantom addition.
     /// </summary>
     [SkippableFact]
     public void FinalSearchSet_UnchangedWhenNothingFolds()
@@ -216,7 +222,7 @@ public sealed class PackageCacheFinalSearchSetTests
         {
             var output = RunAgainstIsolatedHome(testsDir, alCacheDir, isolatedHome, foldRunnerOwnedDirs: false);
 
-            Assert.Contains("package caches: 0 dir(s)", output);
+            Assert.Contains("package caches (requested): 0 dir(s)", output);
             Assert.Contains("package caches (final search set): 0 dir(s)", output);
         }
         finally

--- a/AlRunner.Tests/SourceDepCacheEnumMetadataTests.cs
+++ b/AlRunner.Tests/SourceDepCacheEnumMetadataTests.cs
@@ -57,7 +57,7 @@ public class SourceDepCacheEnumMetadataTests
         args.Append(TestBuildConfig.BcVersionArg);
         args.Append($" \"{bundleDir}\"");
         args.Append($" --cache \"{alCacheDir}\"");
-        // Pin `package caches: 0 dir(s)` — the fixture depends on NOTHING Microsoft
+        // Pin `package caches (requested): 0 dir(s)` — the fixture depends on NOTHING Microsoft
         // (platform/application 1.0.0.0, no declared deps), so no package cache is
         // needed, and passing an --package-cache path that does not exist makes the
         // runner take the explicit-arg branch and resolve it to the empty set
@@ -202,7 +202,7 @@ public class SourceDepCacheEnumMetadataTests
         // --package-cache that does not exist and silently falls back to the default
         // dirs, this test would quietly stop covering the zero-package-cache path
         // (the one CI actually runs) and go green for the wrong reason.
-        Assert.Contains("package caches: 0 dir(s)", output1);
+        Assert.Contains("package caches (requested): 0 dir(s)", output1);
         // Name the specific regression this direction guards: with no package cache
         // dir the compiler used to skip building the source-dep *.symbols.json loader
         // chain entirely, so the sibling source dep was runtime-loadable but
@@ -218,7 +218,7 @@ public class SourceDepCacheEnumMetadataTests
 
         // Run 2: dep HIT + bundle MISS — the exact condition from the issue.
         var (output2, exit2) = RunRunner(testsDir, alCacheDir, absentPackageCache);
-        Assert.Contains("package caches: 0 dir(s)", output2);
+        Assert.Contains("package caches (requested): 0 dir(s)", output2);
 
         // The exact reported defect. Never let a run that hits this pass silently —
         // the assertion below is the whole point of the RED -> GREEN cycle.

--- a/AlRunner.Tests/SourceDepSymbolsWithoutPackageCacheTests.cs
+++ b/AlRunner.Tests/SourceDepSymbolsWithoutPackageCacheTests.cs
@@ -43,9 +43,10 @@ namespace AlRunner.Tests;
 /// version's runner-owned <c>&lt;ArtifactsRootDir&gt;/&lt;version&gt;/{platform-apps,test-apps}</c>
 /// into <c>packageCacheDirs</c> whenever that exact directory already exists on disk — by
 /// design (#1996), so a warm re-run of <c>--auto-provision</c>/<c>al-runner provision</c>
-/// never re-hits the CDN — and it does so AFTER the "package caches: N dir(s)" line below is
-/// printed, so that line's "0" is true of the explicit/default set only, not of what
-/// dependency resolution actually searches a moment later. CI's own provisioning writes to a
+/// never re-hits the CDN — and it does so AFTER the "package caches (requested): N dir(s)"
+/// line below is printed, so that line's "0" is true of the explicit/default set only
+/// (#2107 relabeled it "(requested)" for exactly this reason), not of what dependency
+/// resolution actually searches a moment later. CI's own provisioning writes to a
 /// DIFFERENT path (<c>$HOME/.al-runner/platform-apps</c> — see .github/workflows/bc-tests.yml),
 /// which the runner's fold-in logic never references, so CI's actual search set really is
 /// empty; a machine that has ever run <c>--auto-provision</c>/<c>provision</c> FOR THIS EXACT
@@ -79,7 +80,7 @@ public class SourceDepSymbolsWithoutPackageCacheTests
         // Deliberately NEVER created: ExpandPackageCacheDirs drops non-existent dirs, so
         // passing it takes the explicit-arg branch and resolves to the EMPTY set rather
         // than falling back to DefaultPackageCacheDirs. That reproduces CI's
-        // "package caches: 0 dir(s)" on any machine, provisioned or not.
+        // "package caches (requested): 0 dir(s)" on any machine, provisioned or not.
         var absentPackageCache = Path.Combine(scratchRoot, "no-such-package-cache");
         Directory.CreateDirectory(depDir);
         Directory.CreateDirectory(testsDir);
@@ -202,7 +203,7 @@ public class SourceDepSymbolsWithoutPackageCacheTests
         // "0" even when the machine's own provisioning history later adds more candidates —
         // see the class doc comment. If this ever goes non-zero, the explicit-arg branch
         // itself broke, which is what this precondition actually guards.
-        Assert.Contains("package caches: 0 dir(s)", output);
+        Assert.Contains("package caches (requested): 0 dir(s)", output);
         // The dep must be BOTH runtime-loadable and compile-visible. Do NOT pin the total
         // dep count: a machine that has ever run --auto-provision/`provision` for this exact
         // BC build resolves additional (legitimately available) Microsoft platform/test-

--- a/AlRunner/BcCompiler.cs
+++ b/AlRunner/BcCompiler.cs
@@ -1060,8 +1060,8 @@ public sealed partial class BcCompiler
                 // This block is built BEFORE the .app scanner and independently of it: with
                 // no package-cache dir at all (a bundle whose only dependency is a SIBLING
                 // SOURCE app — no .alpackages, no ~/.bcartifacts.cache, no provisioned
-                // test-apps/platform-apps dir; exactly CI's `package caches: 0 dir(s)`), the
-                // old `loaderScanDirs.Count == 0` early-return bailed out here and the
+                // test-apps/platform-apps dir; exactly CI's `package caches (requested): 0
+                // dir(s)`), the old `loaderScanDirs.Count == 0` early-return bailed out here and the
                 // source dep's freshly written *.symbols.json was never consulted. The dep
                 // loaded fine at RUNTIME and was invisible at COMPILE time — AL0185
                 // "Codeunit 'X' is missing", after which BC's emitter crashes on the

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -1210,8 +1210,18 @@ foreach (var deferredLine in deferredStartupLines) deferredLine();
 var packageCacheDirs = packageCacheArgs.Count > 0
     ? ExpandPackageCacheDirs(packageCacheArgs).ToList()
     : DefaultPackageCacheDirs().ToList();
+// #2107: this count is the explicit/default set ONLY. packageCacheDirs still gains
+// entries below (extraProvisionSearchDirs, then platformAppsOut/testAppsOut inside the
+// provisioning block) before dependency resolution ever runs, so this line is true of
+// what the caller asked for / what the default scan found, never of what actually gets
+// searched a moment later. Kept — and its wording UNCHANGED — because
+// SourceDepSymbolsWithoutPackageCacheTests/SourceDepCacheEnumMetadataTests pin it as a
+// precondition on the explicit-arg branch specifically (it must read 0 when
+// --package-cache points at a directory that doesn't exist, independent of anything a
+// prior --auto-provision/`provision` run for this exact BC build later folds in — see
+// those tests' doc comments). The honest, final count is the second line printed once
+// the list is complete, below.
 Console.WriteLine($"  package caches: {packageCacheDirs.Count} dir(s)");
-AlRunner.Infrastructure.PhaseLog.SetPackageCacheDirs(packageCacheDirs.Count);
 AlRunner.Infrastructure.PhaseLog.SetBundles(bundles);
 
 // Issue #1678: the platform-app R2R gate below used to scan ONLY packageCacheDirs
@@ -1439,6 +1449,27 @@ if (!provisionSubcommand)
         }
     }
 }
+
+// #2107: packageCacheDirs is now complete — every fold-in above (extraProvisionSearchDirs,
+// then platformAppsOut/testAppsOut inside the provisioning block just closed) has already
+// run, whichever branch of `if (!provisionSubcommand)` was taken. This is the FIRST point
+// where a count of packageCacheDirs is the number dependency resolution (PlatformCheckDirs,
+// DependencyResolver's resolverDirs) actually searches, rather than what the caller passed
+// or the default scan found before any of those folds. Reported separately from the earlier
+// "package caches: N dir(s)" line rather than replacing it, so neither claim is lost: that
+// line is a precondition several tests pin on the explicit/default set specifically (see the
+// comment above it), and this one is the true search set a person debugging a resolution
+// gap like #2067 actually needs.
+AlRunner.Infrastructure.PhaseLog.SetPackageCacheDirs(packageCacheDirs.Count);
+Console.WriteLine($"  package caches (final search set): {packageCacheDirs.Count} dir(s)");
+// --verbose: name the directories themselves, not just the count. The count alone was
+// exactly what made #2067 hard to read — "0" on a machine that went on to search several
+// dirs — so the natural companion to the --verbose "[dep] Publisher/Name" line below (which
+// names which package WON each dependency slot) is naming what got SEARCHED to produce that
+// winner in the first place.
+if (AlRunner.Log.Verbose)
+    foreach (var d in packageCacheDirs)
+        Console.WriteLine($"    [pkg-cache] {d}");
 
 // One-time runtime setup. Must happen BEFORE any BC type is touched.
 // Install the assembly Resolving handler FIRST so patch reflection or generic
@@ -4776,6 +4807,14 @@ static void PrintGuide(TextWriter w)
     w.WriteLine("      [dep] <Publisher>/<Name> <Version>  <- /path/to/the/winning.app");
     w.WriteLine("    That is the resolved set. Check the path and version of each dependency that");
     w.WriteLine("    is actually on the failing call's path, not just the one that threw.");
+    w.WriteLine();
+    w.WriteLine("    The [dep] winner comes FROM somewhere: --verbose also lists every directory");
+    w.WriteLine("    that was actually searched to produce it, as [pkg-cache] lines, right after");
+    w.WriteLine("    the \"package caches (final search set): N dir(s)\" count — the honest total,");
+    w.WriteLine("    folded in AFTER the earlier \"package caches: N dir(s)\" line (which reports");
+    w.WriteLine("    only the explicit/default set, before a prior --auto-provision/`provision`");
+    w.WriteLine("    run's own artifacts get added). If a package you expect to win is missing,");
+    w.WriteLine("    check whether its directory is even in that final list.");
     w.WriteLine();
     w.WriteLine("  VERSION SKEW ACROSS A FAMILY. When a workspace's .alpackages reference two");
     w.WriteLine("  different minors of the same platform family, stage BOTH minors in the");

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -1210,18 +1210,15 @@ foreach (var deferredLine in deferredStartupLines) deferredLine();
 var packageCacheDirs = packageCacheArgs.Count > 0
     ? ExpandPackageCacheDirs(packageCacheArgs).ToList()
     : DefaultPackageCacheDirs().ToList();
-// #2107: this count is the explicit/default set ONLY. packageCacheDirs still gains
-// entries below (extraProvisionSearchDirs, then platformAppsOut/testAppsOut inside the
-// provisioning block) before dependency resolution ever runs, so this line is true of
-// what the caller asked for / what the default scan found, never of what actually gets
-// searched a moment later. Kept — and its wording UNCHANGED — because
-// SourceDepSymbolsWithoutPackageCacheTests/SourceDepCacheEnumMetadataTests pin it as a
-// precondition on the explicit-arg branch specifically (it must read 0 when
-// --package-cache points at a directory that doesn't exist, independent of anything a
-// prior --auto-provision/`provision` run for this exact BC build later folds in — see
-// those tests' doc comments). The honest, final count is the second line printed once
-// the list is complete, below.
-Console.WriteLine($"  package caches: {packageCacheDirs.Count} dir(s)");
+// #2107: labeled "(requested)" — this is the explicit/default set ONLY, before
+// packageCacheDirs gains the fold-ins below (extraProvisionSearchDirs, then
+// platformAppsOut/testAppsOut inside the provisioning block). A generic "package
+// caches: N dir(s)" label read as the whole story here, so a reader who only saw this
+// line (the provisioning block between it and the final count can print a multi-minute
+// download) could reasonably conclude nothing was searched — exactly backwards from
+// what #2067 needed. SourceDepSymbolsWithoutPackageCacheTests/SourceDepCacheEnumMetadataTests
+// pin this exact label + count as a precondition on the explicit-arg branch.
+Console.WriteLine($"  package caches (requested): {packageCacheDirs.Count} dir(s)");
 AlRunner.Infrastructure.PhaseLog.SetBundles(bundles);
 
 // Issue #1678: the platform-app R2R gate below used to scan ONLY packageCacheDirs
@@ -1452,14 +1449,9 @@ if (!provisionSubcommand)
 
 // #2107: packageCacheDirs is now complete — every fold-in above (extraProvisionSearchDirs,
 // then platformAppsOut/testAppsOut inside the provisioning block just closed) has already
-// run, whichever branch of `if (!provisionSubcommand)` was taken. This is the FIRST point
-// where a count of packageCacheDirs is the number dependency resolution (PlatformCheckDirs,
-// DependencyResolver's resolverDirs) actually searches, rather than what the caller passed
-// or the default scan found before any of those folds. Reported separately from the earlier
-// "package caches: N dir(s)" line rather than replacing it, so neither claim is lost: that
-// line is a precondition several tests pin on the explicit/default set specifically (see the
-// comment above it), and this one is the true search set a person debugging a resolution
-// gap like #2067 actually needs.
+// run, whichever branch of `if (!provisionSubcommand)` was taken. This is the number
+// dependency resolution (PlatformCheckDirs, DependencyResolver's resolverDirs) actually
+// searches — the "(requested)" line above is scoped to before these folds by its label.
 AlRunner.Infrastructure.PhaseLog.SetPackageCacheDirs(packageCacheDirs.Count);
 Console.WriteLine($"  package caches (final search set): {packageCacheDirs.Count} dir(s)");
 // --verbose: name the directories themselves, not just the count. The count alone was
@@ -4809,12 +4801,10 @@ static void PrintGuide(TextWriter w)
     w.WriteLine("    is actually on the failing call's path, not just the one that threw.");
     w.WriteLine();
     w.WriteLine("    The [dep] winner comes FROM somewhere: --verbose also lists every directory");
-    w.WriteLine("    that was actually searched to produce it, as [pkg-cache] lines, right after");
-    w.WriteLine("    the \"package caches (final search set): N dir(s)\" count — the honest total,");
-    w.WriteLine("    folded in AFTER the earlier \"package caches: N dir(s)\" line (which reports");
-    w.WriteLine("    only the explicit/default set, before a prior --auto-provision/`provision`");
-    w.WriteLine("    run's own artifacts get added). If a package you expect to win is missing,");
-    w.WriteLine("    check whether its directory is even in that final list.");
+    w.WriteLine("    actually searched to produce it, as [pkg-cache] lines under the \"package");
+    w.WriteLine("    caches (final search set): N dir(s)\" count — not the earlier \"(requested)\"");
+    w.WriteLine("    count, which is the explicit/default set only. If a package you expect to");
+    w.WriteLine("    win is missing, check whether its directory is even in the final list.");
     w.WriteLine();
     w.WriteLine("  VERSION SKEW ACROSS A FAMILY. When a workspace's .alpackages reference two");
     w.WriteLine("  different minors of the same platform family, stage BOTH minors in the");


### PR DESCRIPTION
Closes #2107

## Problem

`"  package caches: N dir(s)"` was printed at `Program.cs:1213` right after `packageCacheDirs` was first built, but the same list gains three more additions further down in the same function (`extraProvisionSearchDirs`, then `platformAppsOut`/`testAppsOut` inside the provisioning block). Each addition is deliberate and already commented; the defect was only that the count was captured and printed before any of them ran. That made the line read `0` on a machine that had ever run `--auto-provision`/`al-runner provision` for the exact same BC build, even though dependency resolution went on to search several extra directories a moment later — this is what made #2067 slow to diagnose.

## Fix

- Kept the original line's wording and timing unchanged (two existing tests — `SourceDepSymbolsWithoutPackageCacheTests` and `SourceDepCacheEnumMetadataTests` — pin it as a precondition confirming the explicit/default package-cache resolution branch specifically, independent of anything this machine's own provisioning history later folds in).
- Added a second line, `"  package caches (final search set): N dir(s)"`, printed once every fold-in above has run (right after the `if (!provisionSubcommand) { ... }` block closes), regardless of which branch inside it was taken.
- Moved `PhaseLog.SetPackageCacheDirs` to record that same final count instead of the pre-fold one — it sits right beside the print and had the identical problem.
- Under `--verbose`, added `[pkg-cache] <dir>` lines naming every directory in the final search set — the natural companion to the existing `[dep] Publisher/Name` lines that name which package won each dependency slot, and the piece of the output that would have made #2067 immediately obvious. Also added a short mention of it to `--guide`'s object-ID-0 troubleshooting section, next to the existing `[dep]` line guidance.

## Tests

`AlRunner.Tests/PackageCacheFinalSearchSetTests.cs` (new) — two cases, both spawning the real runner:
- `FinalSearchSet_ReflectsRunnerOwnedFoldIn`: forces the `extraProvisionSearchDirs` fold deterministically (an isolated `$HOME` with the selected version's `platform-apps`/`test-apps` dirs pre-created, `--artifact-path` pinning the engine at this machine's real, already-provisioned service-tier dir so the isolation only affects the fold-in candidates) and asserts the final line reports `2`, while the first line still reads `0`. This is RED against the pre-fix code (only the pre-fold `0` line exists).
- `FinalSearchSet_UnchangedWhenNothingFolds`: same setup without pre-creating those dirs, asserting both lines report the same count — proving the fix doesn't distort the common path where nothing folds in.

Confirmed both existing tests that pin the original line's wording (`SourceDepSymbolsWithoutPackageCacheTests`, `SourceDepCacheEnumMetadataTests`) still pass unmodified, plus `PhaseLogTests`, `TestArtifactsGateTests`, and `CliDocumentationTests` locally.