### PR TITLE
fix(publish): stop hardcoding main in the release-commit push, fail fast on an unpushable ref

### DIFF
--- a/.github/scripts/resolve_release_ref.sh
+++ b/.github/scripts/resolve_release_ref.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Decide which commit a publish.yml dispatch tests and ships, and validate that
+# the release commit can actually be pushed back somewhere real. See #2060.
+#
+# Extracted into its own script (out of publish.yml's inline `run:` block) so
+# this logic -- previously provable only by dispatching the real workflow --
+# can be unit-tested directly. publish.yml's plan job calls this exact script;
+# there is no separate copy for tests to drift against.
+#
+# Before #2060, the release job unconditionally ran `git push origin HEAD:main`
+# no matter what was dispatched. A release branch is by definition not a
+# fast-forward of main -- that's the entire point of cutting one -- so that
+# push could never succeed, and the failure only surfaced after the full
+# ~40-minute test matrix had already run. This script fixes both problems:
+#
+#   1. The commit is pushed back to whatever ref was actually dispatched
+#      (REF_NAME) instead of a hardcoded "main". Ordinary main releases are
+#      unaffected -- REF_NAME is "main" for those, same push target as before.
+#   2. It's called from the "Resolve the commit to test and ship" job, which
+#      runs first and takes seconds, so a dispatch that CANNOT be released
+#      (see below) fails immediately instead of after the matrix.
+#
+# A dispatch cannot be released when the ref dispatched against isn't a
+# branch. Only a branch can receive the release-commit push; a tag is
+# immutable by convention, and workflow_dispatch doesn't offer dispatching
+# against a bare commit SHA in the first place.
+#
+# Inputs (environment variables, all required):
+#   VERSION              - package version being released, e.g. "1.0.23"
+#   REF_TYPE             - github.ref_type ("branch" or "tag")
+#   REF_NAME             - github.ref_name (the dispatched branch/tag's short name)
+#   SHA                  - github.sha (the dispatched ref's head commit)
+#   TAG_EXISTS_REMOTELY  - "true"/"false". Precomputed by the caller via
+#                          `git ls-remote --exit-code --tags origin refs/tags/vVERSION`
+#                          rather than run here, so this script has no network
+#                          dependency and is trivially testable offline.
+#
+# Output: GITHUB_OUTPUT-format `key=value` lines on stdout (ref=..., tag-exists=...,
+# and, only when a fresh release is being planned, branch=...). Diagnostic
+# messages go to stderr. Exits non-zero (no output on stdout) when the dispatch
+# cannot be released.
+
+set -euo pipefail
+
+: "${VERSION:?VERSION is required}"
+: "${REF_TYPE:?REF_TYPE is required}"
+: "${REF_NAME:?REF_NAME is required}"
+: "${SHA:?SHA is required}"
+: "${TAG_EXISTS_REMOTELY:?TAG_EXISTS_REMOTELY is required}"
+
+TAG="v${VERSION}"
+
+if [ "$TAG_EXISTS_REMOTELY" = "true" ]; then
+  # A retry of an attempt that already tagged -- which now means the release
+  # job itself failed after tagging (NuGet rejected the push, the Release API
+  # call failed), NOT that tests failed, because tests run first. Test and
+  # ship the tag as it stands and let the release job skip re-committing, so
+  # no push target is needed here either.
+  echo "Tag $TAG already exists on origin — testing and shipping that tag." >&2
+  echo "ref=$TAG"
+  echo "tag-exists=true"
+  exit 0
+fi
+
+if [ "$REF_TYPE" != "branch" ]; then
+  echo "::error::This workflow was dispatched against a $REF_TYPE ($REF_NAME), not a branch. The release commit is pushed back to the ref that was dispatched, which only makes sense for a branch. Re-dispatch against the branch you want to release (usually 'main', or a release branch for a patch release)." >&2
+  exit 1
+fi
+
+# SHA is the dispatched branch's head at dispatch time. Pinning it HERE, rather
+# than letting the release job read origin/<branch> once the matrix finishes,
+# is what makes the tag point at the commit that was actually tested: the
+# branch can move during a 40-minute run, and whatever gets pushed meanwhile
+# has not been through this matrix at this version.
+echo "Releasing $SHA ($REF_NAME at dispatch)." >&2
+echo "ref=$SHA"
+echo "tag-exists=false"
+echo "branch=$REF_NAME"

--- a/.github/scripts/test_resolve_release_ref.sh
+++ b/.github/scripts/test_resolve_release_ref.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# Tests for resolve_release_ref.sh -- the #2060 fix: publish.yml must push the
+# release commit back to whatever ref was dispatched (not a hardcoded "main"),
+# and must reject an undispatchable ref (anything but a branch) in the plan
+# job, before the ~40-minute test matrix runs.
+#
+# Run directly: bash .github/scripts/test_resolve_release_ref.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$SCRIPT_DIR/resolve_release_ref.sh"
+
+pass=0
+fail=0
+
+assert_contains() {
+  local haystack="$1" needle="$2" desc="$3"
+  if [[ "$haystack" == *"$needle"* ]]; then
+    echo "ok - $desc"
+    pass=$((pass + 1))
+  else
+    echo "NOT ok - $desc"
+    echo "    expected to find: $needle"
+    echo "    in: $haystack"
+    fail=$((fail + 1))
+  fi
+}
+
+assert_not_contains() {
+  local haystack="$1" needle="$2" desc="$3"
+  if [[ "$haystack" != *"$needle"* ]]; then
+    echo "ok - $desc"
+    pass=$((pass + 1))
+  else
+    echo "NOT ok - $desc"
+    echo "    expected NOT to find: $needle"
+    echo "    in: $haystack"
+    fail=$((fail + 1))
+  fi
+}
+
+assert_eq() {
+  local actual="$1" expected="$2" desc="$3"
+  if [ "$actual" = "$expected" ]; then
+    echo "ok - $desc"
+    pass=$((pass + 1))
+  else
+    echo "NOT ok - $desc"
+    echo "    expected: $expected"
+    echo "    actual:   $actual"
+    fail=$((fail + 1))
+  fi
+}
+
+# --- Ordinary path: dispatched against main, no existing tag -----------------
+out=$(VERSION="1.0.23" REF_TYPE="branch" REF_NAME="main" SHA="abc123" \
+      TAG_EXISTS_REMOTELY="false" "$SCRIPT" 2>/dev/null)
+rc=$?
+assert_eq "$rc" "0" "main dispatch: exits 0"
+assert_contains "$out" "ref=abc123" "main dispatch: ref is the dispatched SHA"
+assert_contains "$out" "branch=main" "main dispatch: push target is 'main'"
+assert_contains "$out" "tag-exists=false" "main dispatch: tag-exists is false"
+
+# --- The #2060 case: dispatched against a release branch ---------------------
+out=$(VERSION="2.5.1" REF_TYPE="branch" REF_NAME="release/2.5.1" SHA="def456" \
+      TAG_EXISTS_REMOTELY="false" "$SCRIPT" 2>/dev/null)
+rc=$?
+assert_eq "$rc" "0" "release-branch dispatch: exits 0"
+assert_contains "$out" "ref=def456" "release-branch dispatch: ref is the dispatched SHA"
+# The core #2060 assertion: the push target is the DISPATCHED branch, not the
+# hardcoded literal "main".
+assert_contains "$out" "branch=release/2.5.1" "release-branch dispatch: push target is the dispatched branch"
+assert_not_contains "$out" "branch=main" "release-branch dispatch: push target is NOT the literal 'main'"
+
+# --- Fail fast: dispatched against a tag, not a branch ------------------------
+out=$(VERSION="1.0.23" REF_TYPE="tag" REF_NAME="v1.0.0" SHA="ghi789" \
+      TAG_EXISTS_REMOTELY="false" "$SCRIPT" 2>&1 >/dev/null)
+rc=$?
+assert_eq "$rc" "1" "tag dispatch: exits non-zero (fails before the matrix runs)"
+assert_contains "$out" "not a branch" "tag dispatch: error explains why"
+
+out=$(VERSION="1.0.23" REF_TYPE="tag" REF_NAME="v1.0.0" SHA="ghi789" \
+      TAG_EXISTS_REMOTELY="false" "$SCRIPT" 2>/dev/null)
+assert_eq "$out" "" "tag dispatch: no GITHUB_OUTPUT lines are emitted on failure"
+
+# --- Retry path: the tag already exists on origin -----------------------------
+out=$(VERSION="1.0.23" REF_TYPE="branch" REF_NAME="main" SHA="abc123" \
+      TAG_EXISTS_REMOTELY="true" "$SCRIPT" 2>/dev/null)
+rc=$?
+assert_eq "$rc" "0" "retry: exits 0"
+assert_contains "$out" "ref=v1.0.23" "retry: ref is the existing tag"
+assert_contains "$out" "tag-exists=true" "retry: tag-exists is true"
+assert_not_contains "$out" "branch=" "retry: no push target is emitted (nothing gets pushed)"
+
+# --- Required env vars are actually enforced ----------------------------------
+out=$(REF_TYPE="branch" REF_NAME="main" SHA="abc123" TAG_EXISTS_REMOTELY="false" \
+      "$SCRIPT" 2>&1 >/dev/null)
+rc=$?
+assert_eq "$rc" "1" "missing VERSION: exits non-zero"
+
+echo ""
+echo "$pass passed, $fail failed"
+if [ "$fail" -ne 0 ]; then
+  exit 1
+fi

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -64,6 +64,44 @@ jobs:
           echo ""
           echo "Test presence check passed. Copilot review will assess test quality."
 
+  release-workflow-script-tests:
+    name: Release workflow script tests
+    runs-on: ubuntu-latest
+    # The actual test run is gated inside the job (see the "Check whether..."
+    # step below) on whether publish.yml's extracted scripts or their tests
+    # changed -- they're plain bash unrelated to the rest of a typical PR.
+    # #2060: resolve_release_ref.sh is a new extraction of publish.yml's
+    # resolve/validate logic (which ref gets pushed to, and whether the
+    # dispatch can be released at all), specifically so it's provable
+    # without dispatching the real release workflow.
+    #
+    # generate_changelog.py also has a local test file (test_generate_changelog.py)
+    # from earlier #2060 work on backfilling CHANGELOG sections from published
+    # tags -- deliberately NOT wired in here. Whether this workflow should
+    # support releasing from a branch other than main (and, if so, what that
+    # means for CHANGELOG.md) is still an open question on #2060; that script
+    # change stays on the branch, unused, until it's resolved.
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Check whether the scripts or their tests changed
+        id: changed
+        run: |
+          BASE=${{ github.event.pull_request.base.sha }}
+          HEAD=${{ github.event.pull_request.head.sha }}
+          CHANGED=$(git diff --name-only "$BASE"..."$HEAD")
+          if echo "$CHANGED" | grep -qE '^\.github/scripts/(resolve_release_ref\.sh|test_resolve_release_ref\.sh)$'; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run resolve_release_ref.sh tests
+        if: steps.changed.outputs.run == 'true'
+        run: bash .github/scripts/test_resolve_release_ref.sh
+
   # validate-coverage (docs/coverage.yaml) removed at the v1->v2 cutover: v1 tracked
   # AL-language coverage in a hand-curated YAML the orchestrator validated on every PR.
   # v2's spec is the tests/al-language/ corpus itself -- every AL surface that needs

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,8 @@ name: Publish to NuGet
 
 # Triggered manually only — supply the version and the workflow does everything:
 # runs the full BC test matrix, then BUILDS AND PACKS, then generates the CHANGELOG
-# section, commits it to main, pushes the tag, pushes to NuGet, and creates the
+# section, commits it to the dispatched branch (normally main; see #2060 below for
+# releasing from anything else), pushes the tag, pushes to NuGet, and creates the
 # GitHub Release.
 #
 # ORDER MATTERS, and it has been backwards twice.
@@ -40,8 +41,31 @@ name: Publish to NuGet
 # the NEXT release: [2.3.1] lists two entries while the 21 real ones sit under
 # [2.3.0], a heading with no release behind it.
 #
+# #2060: this workflow used to hardcode its release-commit push as `git push origin
+# HEAD:main`, from a detached HEAD, regardless of what was actually dispatched. That
+# is a latent bug even for the ordinary path — it names a destination the workflow
+# already knows from context instead of asking for it — and it is fatal the moment
+# anything other than main is dispatched: a non-`main` ref is not, in general, a
+# fast-forward of `main`, so the push cannot succeed, and the failure only surfaced
+# after the full ~40-minute test matrix had already run. Fixed two ways:
+#
+#   1. The release commit is pushed back to whatever ref was actually dispatched
+#      (needs.plan.outputs.branch, read from github.ref_name) instead of the
+#      hardcoded literal "main". For the ordinary path github.ref_name IS "main",
+#      so this is a no-op there.
+#   2. The plan job — which runs first and takes seconds — rejects a dispatch that
+#      isn't against a branch (e.g. a tag, which can't receive this push at all)
+#      before the matrix runs, instead of discovering the push was impossible
+#      40 minutes later. See .github/scripts/resolve_release_ref.sh, which is
+#      unit-tested directly rather than provable only by dispatching a real release.
+#
+# Whether this workflow should support releasing from a branch OTHER than main at
+# all — and, if so, what that means for CHANGELOG.md on main — is a separate,
+# undecided question tracked on #2060. Nothing here assumes an answer either way.
+#
 # The release job's checkout uses RELEASE_DEPLOY_KEY (a write-access deploy key) so
-# the git push to main bypasses the branch ruleset ("Deploy keys" -> Always allow).
+# the git push to the released branch bypasses the branch ruleset ("Deploy keys" ->
+# Always allow).
 on:
   workflow_dispatch:
     inputs:
@@ -71,32 +95,32 @@ jobs:
     outputs:
       ref: ${{ steps.plan.outputs.ref }}
       tag-exists: ${{ steps.plan.outputs.tag-exists }}
+      branch: ${{ steps.plan.outputs.branch }}
     steps:
       - uses: actions/checkout@v6
 
       - name: Decide which commit this release tests and ships
         id: plan
+        # The actual decision logic (including the #2060 branch-or-fail check) lives
+        # in resolve_release_ref.sh, extracted specifically so it can be unit-tested
+        # without dispatching this workflow for real -- see
+        # .github/scripts/test_resolve_release_ref.sh. This step is just the git
+        # lookup (TAG_EXISTS_REMOTELY) the script can't do itself without a network
+        # dependency, plus wiring GitHub's context values into its env vars.
         run: |
           TAG="v${{ inputs.version }}"
-
           if git ls-remote --exit-code --tags origin "refs/tags/$TAG" >/dev/null 2>&1; then
-            # A retry of an attempt that already tagged — which now means the release
-            # job itself failed after tagging (NuGet rejected the push, the Release API
-            # call failed), NOT that tests failed, because tests run first. Test and
-            # ship the tag as it stands and let the release job skip re-committing.
-            echo "Tag $TAG already exists on origin — testing and shipping that tag."
-            echo "ref=$TAG" >> "$GITHUB_OUTPUT"
-            echo "tag-exists=true" >> "$GITHUB_OUTPUT"
+            TAG_EXISTS_REMOTELY=true
           else
-            # github.sha is main's head at dispatch. Pinning it HERE, rather than letting
-            # the release job read origin/main once the matrix finishes, is what makes the
-            # tag point at the commit that was actually tested: main can move during a
-            # 40-minute run, and whatever gets merged meanwhile has not been through this
-            # matrix at this version.
-            echo "Releasing ${{ github.sha }} (main at dispatch)."
-            echo "ref=${{ github.sha }}" >> "$GITHUB_OUTPUT"
-            echo "tag-exists=false" >> "$GITHUB_OUTPUT"
+            TAG_EXISTS_REMOTELY=false
           fi
+
+          VERSION="${{ inputs.version }}" \
+          REF_TYPE="${{ github.ref_type }}" \
+          REF_NAME="${{ github.ref_name }}" \
+          SHA="${{ github.sha }}" \
+          TAG_EXISTS_REMOTELY="$TAG_EXISTS_REMOTELY" \
+          .github/scripts/resolve_release_ref.sh >> "$GITHUB_OUTPUT"
 
   test:
     needs: plan
@@ -266,16 +290,19 @@ jobs:
               # #2010: dry_run proves the CHANGELOG generation + commit machinery works
               # (the commit above ran for real, locally, in this checkout) without
               # writing anything to origin — a dry run that pushed a real tag/commit to
-              # main would recreate the exact dead-tag problem this workflow exists to
-              # prevent, just self-inflicted during a test.
+              # the branch would recreate the exact dead-tag problem this workflow exists
+              # to prevent, just self-inflicted during a test.
               echo "dry_run: skipping push of the release commit and tag to origin."
             else
               # Push the release commit BEFORE creating the tag, and deliberately without
-              # --force. HEAD is the commit build-and-pack just built plus a CHANGELOG-only
-              # diff, so this is a fast-forward exactly when main is still where the matrix
-              # found it. If someone merged during the run it fails here — and NO tag is
-              # created, which is the whole point of #1978. Re-dispatch against the new main.
-              git push origin HEAD:main
+              # --force, to the branch that was actually dispatched (needs.plan.outputs.branch
+              # — "main" for the ordinary path, a release branch for a patch release; #2060).
+              # HEAD is the commit build-and-pack just built plus a CHANGELOG-only diff, so
+              # this is a fast-forward exactly when that branch is still where the matrix
+              # found it. If someone pushed to it during the run this fails here — and NO
+              # tag is created, which is the whole point of #1978. Re-dispatch against the
+              # branch's new head.
+              git push origin HEAD:${{ needs.plan.outputs.branch }}
               git tag "$TAG"
               git push origin "$TAG"
             fi

--- a/AlRunner.Tests/ReleaseTestParityTests.cs
+++ b/AlRunner.Tests/ReleaseTestParityTests.cs
@@ -340,7 +340,11 @@ public sealed class ReleaseTestParityTests
         var writes = new (string Marker, string What)[]
         {
             ("git push origin \"$TAG\"", "the release tag"),
-            ("git push origin HEAD:main", "the CHANGELOG commit on main"),
+            // #2060: the push target used to be the literal "main" -- pushing to whatever
+            // ref was actually dispatched instead is the fix, so the marker here has to be
+            // the templated form or this assertion would start failing for the right reason
+            // (the write moved) reported as the wrong one (no owner found at all).
+            ("git push origin HEAD:${{ needs.plan.outputs.branch }}", "the CHANGELOG commit on the released branch"),
             ("dotnet nuget push", "the NuGet package"),
             ("softprops/action-gh-release", "the GitHub Release"),
         };


### PR DESCRIPTION
Closes #2060

## Rescoped

#2060 as filed asked for three things: push to the dispatched ref instead of
hardcoded `main`, fail fast in the resolve job before the 40-minute matrix
runs, and a deliberate CHANGELOG policy for a release shipped from a branch
that never merges to `main`.

Releasing from a branch other than `main` was considered and declined. The
evidence: 14 releases in 23 days, median gap 1 day. The one time a release
branch was tried (`release/2.5.1`, the reproduction in #2060), it was
abandoned and the fix it carried reached users the same day anyway, by
releasing `main` as v2.6.0. There's no standing need for the capability this
repo has actually hit. What would change that answer is a user pinned to an
older version who genuinely cannot upgrade — that hasn't happened yet.

So this PR is rescoped to the two items that stand on their own regardless of
that decision:

1. **Push to the ref being released, not a hardcoded `main`.** The release
   job used to run `git push origin HEAD:main` unconditionally, from a
   detached HEAD, regardless of what was actually dispatched. That's a latent
   bug even on the ordinary path — it names a destination the workflow
   already has in `github.ref_name` instead of asking for it.
2. **Fail fast.** A ref that can't receive the push now fails in the
   `Resolve the commit to test and ship` job, which runs first and takes
   seconds, instead of after the full ~40-minute test matrix.

The fail-fast check is `github.ref_type == 'branch'` — permissive, not
narrowed to `main`-only. Nothing in this PR enables releasing from a
non-`main` branch; it just stops a workflow that already accepts any
dispatched ref from wasting 40 minutes on a push that was never going to
succeed, and stops assuming the destination is always `main` when GitHub
already told the workflow what it is.

The CHANGELOG question from #2060 doesn't apply under this scope — there's no
branch-release path left to generate a section for that never reaches `main`.

## What changed

- `.github/scripts/resolve_release_ref.sh` (new): the plan job's
  resolve/validate logic, extracted out of the inline `run:` block so it's
  provable without dispatching the real release workflow. Given
  `REF_TYPE`/`REF_NAME`/`SHA`/`VERSION`/`TAG_EXISTS_REMOTELY`, it emits
  `ref`/`tag-exists`/`branch` in `GITHUB_OUTPUT` format, or exits non-zero
  with an `::error::` when the dispatched ref isn't a branch.
- `.github/workflows/publish.yml`: the plan job now calls that script instead
  of inlining the logic; the release job pushes to
  `needs.plan.outputs.branch` instead of the literal `main`. Header comment
  updated to document both.
- `.github/scripts/test_resolve_release_ref.sh` (new): 16 assertions
  covering the ordinary `main` path, a release-branch dispatch, a
  tag-dispatch rejection, the tag-already-exists retry path, and required-env
  enforcement.
- `.github/workflows/pr-check.yml`: new `release-workflow-script-tests` job,
  path-gated on the two new script files, runs the shell test in CI.

## Testing

RED confirmed: swapped in the original hardcoded-`main`/no-validation logic
and reran `test_resolve_release_ref.sh` — 5 of 16 assertions failed,
reproducing the exact reported bug (push target stayed `main` for a
release-branch dispatch; a tag dispatch didn't fail). Restored the fix, all
16 pass.

```
$ bash .github/scripts/test_resolve_release_ref.sh
...
16 passed, 0 failed
```

Not runnable locally: dispatching the real workflow (explicitly out of
scope per the task — "a release workflow is not something to trial-run").
Manual verification instead: `python3 -c "import yaml; yaml.safe_load(...)"`
against both changed workflow files confirms valid YAML syntax; no
`actionlint` available locally.

Local scope: the new/changed scripts and their tests only — no AL corpus or
.NET suite run (change is entirely inside `.github/`, doesn't touch
`AlRunner/` or `tests/`).