### PR TITLE
docs(rules): a backgrounded foreground command promises nothing either

### DIFF
--- a/.claude/agents/impl-agent.md
+++ b/.claude/agents/impl-agent.md
@@ -168,6 +168,14 @@ dead. There is no flag or wrapper that earns you a wake-up
 work this way in a single day, each having reported "CI is running, I'll
 confirm."
 
+This includes the case where the harness moves your foreground `gh run watch`
+to the background on its own and says it will notify you. It will not, for
+anything you started. Re-check directly instead, and keep checking:
+
+```
+gh run view <run-id> --json status,conclusion
+```
+
 Both of these must hold before you report completion:
 
 1. The run status is `completed` — not `in_progress`, and not "the last

--- a/.claude/rules/ci-verdicts.md
+++ b/.claude/rules/ci-verdicts.md
@@ -42,6 +42,11 @@ end a turn while CI you are responsible for is still running: a background
 process started inside your own turn dies with it, so the notification you are
 waiting for never comes (`no-backgrounding-long-commands.md`).
 
+That holds even when the harness backgrounds the watch itself and tells you it
+will notify you — it will not, for anything you started. Re-check with
+`gh run view <id> --json status,conclusion` and treat anything other than
+`completed` as "not yet reported".
+
 ## 3. Never re-run a failed job
 
 `gh run rerun` and the web "Re-run" button overwrite the failed run's logs

--- a/.claude/rules/no-backgrounding-long-commands.md
+++ b/.claude/rules/no-backgrounding-long-commands.md
@@ -32,6 +32,23 @@ anything. The notifying kind of background work is the `Agent` tool, which
 you may not have. There is no flag, wrapper, or phrasing of a `Bash` call that
 earns you a wake-up.
 
+**Nor does the harness backgrounding it FOR you.** A long foreground command
+can be moved to the background out from under you, together with a message
+saying you will be notified when it completes. That promise does not hold for
+a process started inside your own turn — whatever produced it. This has already
+cost a stall: an agent correctly ran `gh run watch` in the foreground, the
+harness backgrounded it and promised a notification, and the agent ended its
+turn waiting for one that could never arrive.
+
+When that happens, do not end your turn on the strength of the promise. Re-check
+the thing directly and keep checking in the foreground:
+
+```bash
+gh run view <run-id> --json status,conclusion
+```
+
+Anything other than `completed` means "not yet reported", never "green".
+
 The correct shapes, in order of preference: run it in the foreground; or push
 first so the loss is survivable and let CI be the verdict; or genuinely
 abandon it and say so. "End the turn and wait" is not on the list. Of every


### PR DESCRIPTION
PR #2099 told agents to wait for CI in the foreground with `gh run watch <run-id>`, because a background process started inside a turn dies with the turn and its notification never arrives. An agent followed that instruction today and still stalled. It reported:

> The system moved my `gh run watch` call to background with an explicit promise to notify me on completion, so I will wait for that notification rather than polling with sleep loops.

The harness backgrounded the command on its own and said a notification would follow. The agent reasonably believed it, ended its turn, and the notification could never arrive — the exact dead end the rule exists to prevent, reached by following the rule.

The rule was incomplete. It covered what an agent chooses to background, and said no flag or wrapper earns a wake-up. That reads as being about the agents own choices. It did not cover a correctly-foregrounded command being moved to the background out from under you, along with a promise that sounds authoritative.

All three surfaces now say the same thing:

- **`.claude/rules/no-backgrounding-long-commands.md`** — a new paragraph directly after the `run_in_background` one, since that is where a reader is already thinking about this.
- **`.claude/rules/ci-verdicts.md`** — the CI-waiting point from #2099, extended.
- **`.claude/agents/impl-agent.md`** — Step 5, where an agent actually is when it happens.

The recovery in each: re-check the run directly with `gh run view <id> --json status,conclusion` and treat anything other than `completed` as "not yet reported", rather than ending the turn on the strength of a promise.

No code change.

Closes #2111