### PR TITLE
fix(changelog): classify scoped conventional-commit prefixes, strip repeated (#N), sync [Unreleased]

### DIFF
--- a/.github/scripts/generate_changelog.py
+++ b/.github/scripts/generate_changelog.py
@@ -53,6 +53,28 @@ Idempotent by construction: re-running it against the same tag/HEAD pair
 recomputes byte-identical text, so the caller only needs to check whether the
 file actually changed before committing.
 
+This can't be allowed to race publish.yml's own release commit. Two things
+make it not race, not just "probably not race":
+
+1. `generate_release_section()` -- the function publish.yml's release path
+   calls -- WIPES whatever is currently sitting in `[Unreleased]` before
+   inserting the new version's section (rather than the old behavior of
+   inserting the new section ABOVE the existing content and leaving that
+   content orphaned there). Without this, anything update_unreleased() wrote
+   between releases would survive a release, duplicated underneath the new
+   version's own heading instead of correctly emptying `[Unreleased]`.
+2. `update_unreleased()` refuses to run at all when the commit it's checked
+   out at is itself a release commit (`RELEASE_COMMIT_RE`). This matters
+   because a release's CHANGELOG commit lands on main and pushes BEFORE
+   publish.yml's very next command creates and pushes the release tag --
+   sync-changelog-unreleased.yml's run on that same push could be checked
+   out on the release commit while the tag still isn't visible on origin,
+   in which case `git describe --tags --abbrev=0` would still resolve the
+   PREVIOUS tag and wrongly recompute a non-empty range covering everything
+   the release just shipped. Recognizing the release commit by its own
+   message sidesteps that timing question entirely -- the check never looks
+   at tags when HEAD already announces itself as a release.
+
 Environment variables (all required unless noted):
   VERSION  - the release version, e.g. 1.0.22 (not read in --unreleased mode)
   DATE     - ISO date string, e.g. 2026-04-24 (not read in --unreleased mode)
@@ -79,6 +101,13 @@ CONVENTIONAL_RE = re.compile(r'^([A-Za-z][\w.+-]*)(\(([^)]*)\))?:\s*(.*)$')
 PR_NUMBER_RE = re.compile(r'\s+\(#\d+\)$')
 
 UNRELEASED_SECTION_RE = re.compile(r'(## \[Unreleased\]\n)(.*?)\n+(?=## \[|\Z)', re.DOTALL)
+
+# publish.yml commits exactly this message ("chore: release v${VERSION}") when
+# it ships a release. update_unreleased() uses it to recognize "the commit I
+# was just checked out at IS a release commit" without depending on whether
+# the release's tag has propagated to origin yet -- see update_unreleased()'s
+# docstring for why that timing question matters.
+RELEASE_COMMIT_RE = re.compile(r'^chore:\s*release\s+v\d+\.\d+\.\d+\s*$', re.IGNORECASE)
 
 
 def strip_pr_numbers(line):
@@ -160,10 +189,39 @@ def run_git_log(ref_range):
     ).stdout
 
 
-def update_unreleased(changelog_path, commits_raw=None):
+def git_head_commit_message():
+    return subprocess.run(
+        ['git', 'log', '-1', '--pretty=%s', 'HEAD'],
+        capture_output=True, text=True,
+    ).stdout.strip()
+
+
+def update_unreleased(changelog_path, commits_raw=None, head_message=None):
     """Recomputes '## [Unreleased]' from every commit since the last tag and
     rewrites it in place. Returns True iff the file's content actually
-    changed (so the caller can skip a no-op commit)."""
+    changed (so the caller can skip a no-op commit).
+
+    Skips entirely (returns False, no write) when the commit this is running
+    against is ITSELF a release commit ("chore: release vX.Y.Z" -- see
+    RELEASE_COMMIT_RE). This is the race with publish.yml (#2109 PR
+    discussion): a release's CHANGELOG commit lands on main and pushes,
+    triggering this same script via sync-changelog-unreleased.yml, BEFORE
+    publish.yml's very next command (`git tag "$TAG"` / `git push origin
+    "$TAG"`) has necessarily made that tag visible on origin. If this
+    function fell through to git_commits_since_last_tag() on that run,
+    `git describe --tags --abbrev=0` could still resolve the PREVIOUS tag,
+    producing a commit range that wrongly re-includes everything the release
+    JUST shipped -- duplicating the release's own section back into
+    [Unreleased] right after it was correctly emptied by
+    generate_release_section(). Recognizing the release commit by its own
+    message sidesteps the tag-visibility timing question entirely: it
+    doesn't matter whether the tag has propagated, because the check never
+    looks at tags at all when HEAD is the release commit itself."""
+    if head_message is None:
+        head_message = git_head_commit_message()
+    if RELEASE_COMMIT_RE.match(head_message.strip()):
+        return False
+
     if commits_raw is None:
         commits_raw = git_commits_since_last_tag()
 
@@ -193,18 +251,25 @@ def update_unreleased(changelog_path, commits_raw=None):
 
 
 def generate_release_section(version, date, commits_raw, changelog_path):
+    """Inserts a fresh '## [x.y.z]' section right after '## [Unreleased]',
+    WIPING whatever was previously sitting between that heading and the next
+    one. commits_raw already covers everything that would legitimately be in
+    [Unreleased] at this point (both are "since the last tag") -- leaving
+    stale content in place (e.g. left over from sync-changelog-unreleased.yml
+    running between releases) would duplicate it, orphaned underneath the
+    new version's own heading instead of correctly emptying [Unreleased]."""
     body = build_section_body(*classify_commits(commits_raw))
     section_text = f'## [{version}] - {date}\n\n' + body if body else f'## [{version}] - {date}'
 
     with open(changelog_path, 'r') as f:
         content = f.read()
 
-    updated = re.sub(
-        r'(## \[Unreleased\]\n+)',
-        r'\1' + section_text.rstrip() + '\n\n',
-        content,
-        count=1,
-    )
+    def repl(m):
+        return m.group(1) + '\n' + section_text.rstrip() + '\n\n'
+
+    updated, count = UNRELEASED_SECTION_RE.subn(repl, content, count=1)
+    if count == 0:
+        raise SystemExit(f"{changelog_path} has no '## [Unreleased]' heading to update")
 
     with open(changelog_path, 'w') as f:
         f.write(updated)

--- a/.github/scripts/generate_changelog.py
+++ b/.github/scripts/generate_changelog.py
@@ -1,66 +1,234 @@
 """
 Generate a CHANGELOG.md section from git commit messages and inject it into the file.
 
-Environment variables (all required):
-  VERSION  - the release version, e.g. 1.0.22
-  DATE     - ISO date string, e.g. 2026-04-24
+## Conventional-commit classification (#2109)
+
+This repo writes scoped commits almost exclusively -- `fix(startup):`,
+`feat(dap):`, `docs(agents):`, `chore(corpus):` -- but the classifier used to
+test only unscoped prefixes (`feat:`, `fix:`, `docs:`, `chore:`). A scoped
+commit matched none of those, fell to the catch-all branch, and was dumped
+into `### Changed` with its raw prefix still attached: measured against the
+11 commits queued for a release, 1 was classified and 10 landed in `Changed`
+reading `fix(startup): ...`, prefix and all. Bare `chore:` was skipped but
+`chore(corpus):` was not, so scoped chores -- meaningless to someone reading
+a release changelog -- reached the published output (2.7.0 shipped two of
+them).
+
+`CONVENTIONAL_RE` now recognizes an OPTIONAL `(scope)` after any
+conventional-commit type, not just the four this classifier sections
+(`feat`/`fix`/`docs`) or drops (`chore`). Every other type this repo has
+actually used in its history (`perf`, `test`, `refactor`, `ci`, and even
+one-off outliers like `dap:` that were clearly meant to carry a real type but
+never merged one -- see 2.7.0's shipped "`- dap: add a stdio transport...`")
+gets the SAME treatment: the raw `type(scope):` token is never left in the
+output. Recognized types (`feat`/`fix`/`docs`) go to their section with the
+scope preserved as a bold prefix (`**startup:** ...`) or dropped if there was
+none; `chore` (scoped or not) is skipped outright, matching #2109's
+acceptance criterion directly; anything else still lands in `### Changed`,
+but with the type token stripped either way -- the type-prefix leak this
+issue is about isn't specific to feat/fix/docs/chore, it's specific to
+"any recognized-looking commit type", so the fix generalizes to match.
+
+A message that doesn't look like `word:` or `word(scope):` at all (rare,
+free-form) is left completely untouched, same as before -- there's nothing
+conventional-commit-shaped to strip.
+
+## Repeated PR-number stripping
+
+A squash of a PR whose title already carried a trailing `(#N)` leaves the
+squash merge's OWN `(#N)` appended after it: `fix: ... (#2102) (#2104)`. The
+old code stripped once; STRIP_PR_NUMBER_RE now loops until nothing more
+matches.
+
+## [Unreleased] (#2109)
+
+`update_unreleased()` / `--unreleased` recomputes the `## [Unreleased]`
+section from every commit since the last tag reachable from HEAD (an
+ancestry walk via `git describe --tags --abbrev=0` -- unambiguous here since
+#2060 declined releasing from any branch other than main) and rewrites just
+that section in place. It's meant to be run on every push to main (see
+.github/workflows/sync-changelog-unreleased.yml), so `[Unreleased]` is a live
+answer to "what's about to ship", not permanently empty between releases.
+Idempotent by construction: re-running it against the same tag/HEAD pair
+recomputes byte-identical text, so the caller only needs to check whether the
+file actually changed before committing.
+
+Environment variables (all required unless noted):
+  VERSION  - the release version, e.g. 1.0.22 (not read in --unreleased mode)
+  DATE     - ISO date string, e.g. 2026-04-24 (not read in --unreleased mode)
   COMMITS  - newline-separated squash-commit subjects since the previous tag
+             (not read in --unreleased mode, which computes this itself)
   CHANGELOG_PATH - path to CHANGELOG.md (default: CHANGELOG.md)
 """
 
 import os
 import re
+import subprocess
+import sys
 
-version     = os.environ["VERSION"]
-date        = os.environ["DATE"]
-commits_raw = os.environ.get("COMMITS", "")
-changelog   = os.environ.get("CHANGELOG_PATH", "CHANGELOG.md")
+# Matches any conventional-commit-shaped prefix: a lowercase-led type token,
+# an optional (scope), then a colon. Deliberately not restricted to
+# feat/fix/docs/chore -- see the module docstring for why: any OTHER type
+# this repo has used (perf, test, refactor, ci, even a bare mis-typed one
+# like "dap:") gets its prefix stripped too, just without a dedicated section.
+CONVENTIONAL_RE = re.compile(r'^([A-Za-z][\w.+-]*)(\(([^)]*)\))?:\s*(.*)$')
 
-added, fixed, docs, changed = [], [], [], []
-for line in commits_raw.splitlines():
-    line = line.strip()
-    if not line:
-        continue
-    line = re.sub(r'\s+\(#\d+\)$', '', line)   # strip PR number suffix
-    lower = line.lower()
-    if re.match(r'chore:\s*(release|update changelog)', lower):
-        continue                                 # skip release-housekeeping
-    if lower.startswith('feat:'):
-        added.append('- ' + line[5:].strip())
-    elif lower.startswith('fix:'):
-        fixed.append('- ' + line[4:].strip())
-    elif lower.startswith('docs:'):
-        docs.append('- ' + line[5:].strip())
-    elif lower.startswith('chore:'):
-        pass                                     # skip internal chores
-    else:
-        changed.append('- ' + line)
+# A commit subject can carry more than one trailing "(#N)" -- one from the PR
+# title, one appended by the squash-merge itself. Applied repeatedly by
+# strip_pr_numbers() below, not just once.
+PR_NUMBER_RE = re.compile(r'\s+\(#\d+\)$')
 
-section = [f'## [{version}] - {date}', '']
-if added:
-    section += ['### Added'] + added + ['']
-if fixed:
-    section += ['### Fixed'] + fixed + ['']
-if docs:
-    section += ['### Documentation'] + docs + ['']
-if changed:
-    section += ['### Changed'] + changed + ['']
+UNRELEASED_SECTION_RE = re.compile(r'(## \[Unreleased\]\n)(.*?)\n+(?=## \[|\Z)', re.DOTALL)
 
-section_text = '\n'.join(section)
 
-# Print section for capture by the shell
-print(section_text)
+def strip_pr_numbers(line):
+    while True:
+        stripped = PR_NUMBER_RE.sub('', line)
+        if stripped == line:
+            return line
+        line = stripped
 
-# Inject into CHANGELOG.md after the [Unreleased] heading
-with open(changelog, 'r') as f:
-    content = f.read()
 
-updated = re.sub(
-    r'(## \[Unreleased\]\n+)',
-    r'\1' + section_text.rstrip() + '\n\n',
-    content,
-    count=1
-)
+def classify_commits(commits_raw):
+    """(commits_raw: str) -> (added, fixed, docs, changed), each a list of
+    '- ...' bullet strings ready to drop under a '### Heading'."""
+    added, fixed, docs, changed = [], [], [], []
 
-with open(changelog, 'w') as f:
-    f.write(updated)
+    for line in commits_raw.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        line = strip_pr_numbers(line)
+
+        m = CONVENTIONAL_RE.match(line)
+        if not m:
+            # Not conventional-commit-shaped at all -- nothing to strip.
+            changed.append('- ' + line)
+            continue
+
+        ctype = m.group(1).lower()
+        scope = m.group(3)
+        rest = m.group(4).strip()
+
+        if ctype == 'chore':
+            continue  # a chore never belongs in a published changelog, scoped or not
+
+        bullet = '- ' + (f'**{scope}:** ' if scope else '') + rest
+
+        if ctype == 'feat':
+            added.append(bullet)
+        elif ctype == 'fix':
+            fixed.append(bullet)
+        elif ctype == 'docs':
+            docs.append(bullet)
+        else:
+            # Any other conventional type (perf, test, refactor, ci, dap, ...)
+            # -- no dedicated section, but the raw prefix still must not leak.
+            changed.append(bullet)
+
+    return added, fixed, docs, changed
+
+
+def build_section_body(added, fixed, docs, changed):
+    lines = []
+    if added:
+        lines += ['### Added'] + added + ['']
+    if fixed:
+        lines += ['### Fixed'] + fixed + ['']
+    if docs:
+        lines += ['### Documentation'] + docs + ['']
+    if changed:
+        lines += ['### Changed'] + changed + ['']
+    return '\n'.join(lines).rstrip()
+
+
+def git_commits_since_last_tag():
+    described = subprocess.run(
+        ['git', 'describe', '--tags', '--abbrev=0'],
+        capture_output=True, text=True,
+    )
+    prev_tag = described.stdout.strip() if described.returncode == 0 else None
+    if prev_tag:
+        return run_git_log(f'{prev_tag}..HEAD')
+    return run_git_log('HEAD')
+
+
+def run_git_log(ref_range):
+    return subprocess.run(
+        ['git', 'log', ref_range, '--pretty=format:%s'],
+        capture_output=True, text=True,
+    ).stdout
+
+
+def update_unreleased(changelog_path, commits_raw=None):
+    """Recomputes '## [Unreleased]' from every commit since the last tag and
+    rewrites it in place. Returns True iff the file's content actually
+    changed (so the caller can skip a no-op commit)."""
+    if commits_raw is None:
+        commits_raw = git_commits_since_last_tag()
+
+    body = build_section_body(*classify_commits(commits_raw))
+
+    with open(changelog_path, 'r') as f:
+        content = f.read()
+
+    # UNRELEASED_SECTION_RE's trailing `\n+` consumes every blank line up to
+    # (not including) the next heading or EOF, so the replacement supplies the
+    # exact spacing itself rather than depending on what was already there.
+    replacement_tail = ('\n' + body + '\n\n') if body else '\n'
+
+    def repl(m):
+        return m.group(1) + replacement_tail
+
+    updated, count = UNRELEASED_SECTION_RE.subn(repl, content, count=1)
+    if count == 0:
+        raise SystemExit(f"{changelog_path} has no '## [Unreleased]' heading to update")
+
+    if updated == content:
+        return False
+
+    with open(changelog_path, 'w') as f:
+        f.write(updated)
+    return True
+
+
+def generate_release_section(version, date, commits_raw, changelog_path):
+    body = build_section_body(*classify_commits(commits_raw))
+    section_text = f'## [{version}] - {date}\n\n' + body if body else f'## [{version}] - {date}'
+
+    with open(changelog_path, 'r') as f:
+        content = f.read()
+
+    updated = re.sub(
+        r'(## \[Unreleased\]\n+)',
+        r'\1' + section_text.rstrip() + '\n\n',
+        content,
+        count=1,
+    )
+
+    with open(changelog_path, 'w') as f:
+        f.write(updated)
+
+    return section_text
+
+
+def main():
+    changelog_path = os.environ.get('CHANGELOG_PATH', 'CHANGELOG.md')
+
+    if len(sys.argv) > 1 and sys.argv[1] == '--unreleased':
+        changed = update_unreleased(changelog_path)
+        print('changed=true' if changed else 'changed=false')
+        return
+
+    version = os.environ['VERSION']
+    date = os.environ['DATE']
+    commits_raw = os.environ.get('COMMITS', '')
+
+    section_text = generate_release_section(version, date, commits_raw, changelog_path)
+
+    # Print section for capture by the shell
+    print(section_text)
+
+
+if __name__ == '__main__':
+    main()

--- a/.github/scripts/test_generate_changelog.py
+++ b/.github/scripts/test_generate_changelog.py
@@ -164,6 +164,13 @@ class RepeatedPrNumberStrippingTests(unittest.TestCase):
 
 class UpdateUnreleasedTests(unittest.TestCase):
 
+    # A real, unrelated commit subject -- so these tests exercise the normal
+    # path deterministically rather than depending on whatever HEAD's message
+    # happens to be in whatever repo the test suite is run inside (which would
+    # otherwise make these tests hit real git AND be non-hermetic: they'd behave
+    # differently if ever run checked out exactly at a real release commit).
+    NOT_A_RELEASE_COMMIT = 'fix: unrelated commit, not a release'
+
     def setUp(self):
         self.tmp_path = os.path.join(
             SCRIPT_DIR, '.test_changelog_scratch_2109.md'
@@ -187,6 +194,7 @@ class UpdateUnreleasedTests(unittest.TestCase):
         changed = gc.update_unreleased(
             self.tmp_path,
             commits_raw='feat(dap): new debugger feature\nfix(startup): faster boot',
+            head_message=self.NOT_A_RELEASE_COMMIT,
         )
 
         self.assertTrue(changed)
@@ -205,7 +213,11 @@ class UpdateUnreleasedTests(unittest.TestCase):
             '## [1.0.0] - 2026-01-01\n'
         )
 
-        gc.update_unreleased(self.tmp_path, commits_raw='feat(x): brand new thing')
+        gc.update_unreleased(
+            self.tmp_path,
+            commits_raw='feat(x): brand new thing',
+            head_message=self.NOT_A_RELEASE_COMMIT,
+        )
 
         text = self.read()
         self.assertNotIn('stale entry', text)
@@ -217,7 +229,9 @@ class UpdateUnreleasedTests(unittest.TestCase):
             '## [1.0.0] - 2026-01-01\n'
         )
 
-        changed = gc.update_unreleased(self.tmp_path, commits_raw='')
+        changed = gc.update_unreleased(
+            self.tmp_path, commits_raw='', head_message=self.NOT_A_RELEASE_COMMIT,
+        )
 
         self.assertTrue(changed)
         text = self.read()
@@ -227,16 +241,132 @@ class UpdateUnreleasedTests(unittest.TestCase):
     def test_idempotent_rerun_reports_no_change(self):
         self.write('# Changelog\n\n## [Unreleased]\n\n## [1.0.0] - 2026-01-01\n')
 
-        first = gc.update_unreleased(self.tmp_path, commits_raw='fix(a): thing one')
+        first = gc.update_unreleased(
+            self.tmp_path, commits_raw='fix(a): thing one', head_message=self.NOT_A_RELEASE_COMMIT,
+        )
         self.assertTrue(first)
 
-        second = gc.update_unreleased(self.tmp_path, commits_raw='fix(a): thing one')
+        second = gc.update_unreleased(
+            self.tmp_path, commits_raw='fix(a): thing one', head_message=self.NOT_A_RELEASE_COMMIT,
+        )
         self.assertFalse(second)
 
     def test_missing_unreleased_heading_raises(self):
         self.write('# Changelog\n\n## [1.0.0] - 2026-01-01\n')
         with self.assertRaises(SystemExit):
-            gc.update_unreleased(self.tmp_path, commits_raw='fix: x')
+            gc.update_unreleased(
+                self.tmp_path, commits_raw='fix: x', head_message=self.NOT_A_RELEASE_COMMIT,
+            )
+
+    # ---- race with publish.yml's own release commit (#2109 PR discussion) --------
+
+    def test_skips_entirely_when_head_is_a_release_commit(self):
+        # A release's CHANGELOG commit lands on main and pushes BEFORE
+        # publish.yml's very next command creates and pushes the release tag.
+        # If sync-changelog-unreleased.yml's run on that same push fell through
+        # to git_commits_since_last_tag(), `git describe` could still resolve
+        # the PREVIOUS tag (this release's own tag isn't visible on origin
+        # yet), wrongly re-including everything just shipped. The commit's own
+        # message is checked first and short-circuits before any of that.
+        self.write(
+            '# Changelog\n\n## [Unreleased]\n\n## [1.0.0] - 2026-01-01\n'
+        )
+
+        changed = gc.update_unreleased(
+            self.tmp_path,
+            # Deliberately non-empty -- proves the skip happens BEFORE this is
+            # ever consulted, not that it coincidentally produced no diff.
+            commits_raw='feat(x): this must never be written',
+            head_message='chore: release v1.1.0',
+        )
+
+        self.assertFalse(changed)
+        text = self.read()
+        self.assertNotIn('this must never be written', text)
+        self.assertEqual(text, '# Changelog\n\n## [Unreleased]\n\n## [1.0.0] - 2026-01-01\n')
+
+    def test_release_commit_recognized_case_insensitively_and_with_whitespace(self):
+        changed = gc.update_unreleased(
+            self._scratch_with_unreleased(),
+            commits_raw='feat(x): must not land',
+            head_message='  Chore: Release v2.0.0  ',
+        )
+        self.assertFalse(changed)
+
+    def _scratch_with_unreleased(self):
+        self.write('# Changelog\n\n## [Unreleased]\n\n## [1.0.0] - 2026-01-01\n')
+        return self.tmp_path
+
+    def test_non_release_commit_that_merely_mentions_release_still_runs_normally(self):
+        # Must not be a substring match -- "release" appearing anywhere in an
+        # unrelated commit message must not be mistaken for the release commit
+        # itself, or a real change would silently vanish.
+        changed = gc.update_unreleased(
+            self._scratch_with_unreleased(),
+            commits_raw='feat(x): document the release process',
+            head_message='docs: explain how to release a version',
+        )
+        self.assertTrue(changed)
+        self.assertIn('document the release process', self.read())
+
+
+class GenerateReleaseSectionTests(unittest.TestCase):
+
+    def setUp(self):
+        self.tmp_path = os.path.join(
+            SCRIPT_DIR, '.test_changelog_scratch_2109_release.md'
+        )
+
+    def tearDown(self):
+        if os.path.exists(self.tmp_path):
+            os.remove(self.tmp_path)
+
+    def write(self, content):
+        with open(self.tmp_path, 'w') as f:
+            f.write(content)
+
+    def read(self):
+        with open(self.tmp_path) as f:
+            return f.read()
+
+    def test_wipes_stale_unreleased_content_left_by_the_sync_workflow(self):
+        # Simulates the exact race #2109's PR review raised: sync-changelog-
+        # unreleased.yml already wrote something into [Unreleased] before this
+        # release ran. commits_raw covers the SAME "since last tag" range, so
+        # the stale text must be replaced, not left dangling under the new
+        # version heading.
+        self.write(
+            '# Changelog\n\n## [Unreleased]\n\n### Fixed\n'
+            '- **startup:** stale entry the sync workflow already wrote\n\n'
+            '## [1.0.0] - 2026-01-01\n'
+        )
+
+        section = gc.generate_release_section(
+            '1.1.0', '2026-03-01', 'fix(startup): stale entry the sync workflow already wrote',
+            self.tmp_path,
+        )
+
+        text = self.read()
+        # The stale line appears exactly once -- inside the new release
+        # section -- not a second time left over under [Unreleased].
+        self.assertEqual(text.count('stale entry the sync workflow already wrote'), 1)
+        self.assertIn('## [1.1.0] - 2026-03-01', text)
+        self.assertIn(
+            '## [1.1.0] - 2026-03-01\n\n### Fixed\n- **startup:** stale entry the sync workflow already wrote',
+            text,
+        )
+        # [Unreleased] itself is empty again -- nothing sits between its
+        # heading and the new release heading.
+        self.assertIn('## [Unreleased]\n\n## [1.1.0]', text)
+        self.assertEqual(section, '## [1.1.0] - 2026-03-01\n\n### Fixed\n- **startup:** stale entry the sync workflow already wrote')
+
+    def test_old_sections_below_are_untouched(self):
+        self.write(
+            '# Changelog\n\n## [Unreleased]\n\n## [1.0.0] - 2026-01-01\n\nold notes here\n'
+        )
+        gc.generate_release_section('1.1.0', '2026-03-01', 'feat(x): new thing', self.tmp_path)
+        text = self.read()
+        self.assertIn('## [1.0.0] - 2026-01-01\n\nold notes here', text)
 
 
 if __name__ == '__main__':

--- a/.github/scripts/test_generate_changelog.py
+++ b/.github/scripts/test_generate_changelog.py
@@ -1,0 +1,243 @@
+"""
+Tests for generate_changelog.py -- #2109.
+
+The classifier is exercised with REAL commit subjects from this repo's own
+history (`git log --pretty=format:%s`), not synthetic examples, because the
+synthetic/unscoped case was never broken -- scoped commits are what #2109 is
+about, and this repo writes those almost exclusively.
+
+Run directly: python3 .github/scripts/test_generate_changelog.py
+"""
+
+import importlib.util
+import os
+import unittest
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+SCRIPT_PATH = os.path.join(SCRIPT_DIR, 'generate_changelog.py')
+
+spec = importlib.util.spec_from_file_location('generate_changelog', SCRIPT_PATH)
+gc = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(gc)
+
+
+class ClassifyScopedCommitsTests(unittest.TestCase):
+    """Real subjects, taken verbatim from `git log --pretty=format:%s` on this
+    repo, before #2109's fix -- this is the case that was broken."""
+
+    def test_scoped_fix_is_classified_as_fixed_not_dumped_into_changed(self):
+        added, fixed, docs, changed = gc.classify_commits(
+            'fix(startup): report the true final package-cache search set (#2108)'
+        )
+        self.assertEqual(fixed, ['- **startup:** report the true final package-cache search set'])
+        self.assertEqual(changed, [])
+
+    def test_scoped_feat_is_classified_as_added_not_dumped_into_changed(self):
+        added, fixed, docs, changed = gc.classify_commits(
+            'feat(server): per-statement hit counts + position table (coverage:true) (#2069)'
+        )
+        self.assertEqual(
+            added,
+            ['- **server:** per-statement hit counts + position table (coverage:true)'],
+        )
+        self.assertEqual(changed, [])
+
+    def test_scoped_docs_is_classified_as_documentation_not_dumped_into_changed(self):
+        added, fixed, docs, changed = gc.classify_commits(
+            "docs(agents): say how to wait for CI, not just how to read it (#2099)"
+        )
+        self.assertEqual(docs, ['- **agents:** say how to wait for CI, not just how to read it'])
+        self.assertEqual(changed, [])
+
+    def test_scoped_chore_is_skipped_exactly_as_bare_chore_is(self):
+        added, fixed, docs, changed = gc.classify_commits(
+            'chore(corpus): bump al-language pin to ab43ec0 for #66/#67, bump count-baseline to 2140 (#2083)'
+            '\nchore(agent-docs): cleanup pass on the agent instruction surface (#2084)'
+            '\nchore: release v2.7.0'
+        )
+        self.assertEqual(added, [])
+        self.assertEqual(fixed, [])
+        self.assertEqual(docs, [])
+        self.assertEqual(changed, [])
+
+    def test_measured_release_batch_from_the_issue_classifies_ten_of_eleven(self):
+        # The exact 11-commit batch #2109 measured: "1 classified, 10 dumped
+        # into Changed with their prefixes visible" under the old classifier.
+        commits = "\n".join([
+            "fix(tests): make SiblingSourceDep_CompilesWithZeroPackageCacheDirs hermetic (#2106)",
+            "fix(startup): defer the remaining per-generation startup lines past re-exec (#2105)",
+            "fix(provisioning): derive transitive no-fallback platform-app need via a closure walk, not a hand-maintained list (#2101)",
+            "docs(agents): say how to wait for CI, not just how to read it (#2099)",
+            "fix(deps): report missing/too-old third-party deps as provisioning gaps, not COMPILE-FAIL (#2100)",
+            "fix(startup): defer startup trio across every re-exec generation, not just the shadow hop (#2096)",
+            "docs(rules): fold pr-ci-monitoring.md into ci-verdicts.md (#2094)",
+            "fix(provision): expose platform-apps/test-apps/service-tier download from the shipped binary (#2091)",
+            "fix(cli): -v/-V/version alias --version, --help prints version, --guide tells agents where and how to report gaps (#2092)",
+            "fix(provision): detect transitive Application Test Library need, provision the selected BC version not the cache's (#2086)",
+            "fix: declare _BCVersion default once in Directory.Build.props (#2102) (#2104)",
+        ])
+
+        added, fixed, docs, changed = gc.classify_commits(commits)
+
+        # Every one of the 11 lands in a real section; NONE fall through to
+        # Changed with a raw prefix (that was the defect: 10 of 11 did).
+        self.assertEqual(changed, [])
+        self.assertEqual(len(fixed), 9)
+        self.assertEqual(len(docs), 2)
+        self.assertEqual(len(added), 0)
+
+        # Spot-check one bullet has its scope preserved and prefix stripped.
+        self.assertIn(
+            '- **startup:** defer the remaining per-generation startup lines past re-exec',
+            fixed,
+        )
+        for bullet in fixed + docs:
+            self.assertNotRegex(bullet, r'^\-\s*(fix|feat|docs|chore)\(')
+
+    def test_unscoped_forms_still_classify_exactly_as_before(self):
+        # The case that was NEVER broken -- must keep working unchanged.
+        added, fixed, docs, changed = gc.classify_commits(
+            'feat: restore --dap breakpoint debugging on v2 (slice 1 of #1642) (#2048)'
+            '\nfix: print startup reporting once per invocation, not once per re-exec generation (#2044)'
+            '\ndocs: correct something'
+            '\nchore: internal cleanup only'
+        )
+        self.assertEqual(added, ['- restore --dap breakpoint debugging on v2 (slice 1 of #1642)'])
+        self.assertEqual(fixed, ['- print startup reporting once per invocation, not once per re-exec generation'])
+        self.assertEqual(docs, ['- correct something'])
+        self.assertEqual(changed, [])
+
+    def test_unrecognized_conventional_type_is_stripped_not_left_raw(self):
+        # "dap:" shipped raw into the published 2.7.0 changelog under the old
+        # classifier (visible in CHANGELOG.md as "- dap: add a stdio
+        # transport..."). Not one of feat/fix/docs/chore, but still
+        # conventional-commit-shaped -- the type prefix must not leak either.
+        added, fixed, docs, changed = gc.classify_commits(
+            'dap: add a stdio transport so VS Code can launch the adapter directly (#2068)'
+        )
+        self.assertEqual(changed, ['- add a stdio transport so VS Code can launch the adapter directly'])
+        for section in (added, fixed, docs):
+            self.assertEqual(section, [])
+
+    def test_scoped_unrecognized_type_preserves_scope_and_drops_type(self):
+        added, fixed, docs, changed = gc.classify_commits(
+            'perf(startup): shave 200ms off cold boot'
+        )
+        self.assertEqual(changed, ['- **startup:** shave 200ms off cold boot'])
+
+    def test_non_conventional_free_form_message_is_left_completely_alone(self):
+        added, fixed, docs, changed = gc.classify_commits('Merge pull request #123 from foo/bar')
+        self.assertEqual(changed, ['- Merge pull request #123 from foo/bar'])
+
+
+class RepeatedPrNumberStrippingTests(unittest.TestCase):
+
+    def test_single_trailing_pr_number_is_stripped(self):
+        self.assertEqual(
+            gc.strip_pr_numbers('fix: do the thing (#123)'),
+            'fix: do the thing',
+        )
+
+    def test_double_trailing_pr_number_is_stripped_repeatedly(self):
+        # The exact real subject from #2109: a squash of a PR whose title
+        # already carried a trailing (#N) leaves the squash-merge's own (#N)
+        # appended after it.
+        self.assertEqual(
+            gc.strip_pr_numbers(
+                'fix: declare _BCVersion default once in Directory.Build.props (#2102) (#2104)'
+            ),
+            'fix: declare _BCVersion default once in Directory.Build.props',
+        )
+
+    def test_no_trailing_pr_number_is_left_unchanged(self):
+        self.assertEqual(
+            gc.strip_pr_numbers('fix: something with no PR number'),
+            'fix: something with no PR number',
+        )
+
+    def test_end_to_end_double_pr_number_via_classify_commits(self):
+        added, fixed, docs, changed = gc.classify_commits(
+            'fix: declare _BCVersion default once in Directory.Build.props (#2102) (#2104)'
+        )
+        self.assertEqual(fixed, ['- declare _BCVersion default once in Directory.Build.props'])
+
+
+class UpdateUnreleasedTests(unittest.TestCase):
+
+    def setUp(self):
+        self.tmp_path = os.path.join(
+            SCRIPT_DIR, '.test_changelog_scratch_2109.md'
+        )
+
+    def tearDown(self):
+        if os.path.exists(self.tmp_path):
+            os.remove(self.tmp_path)
+
+    def write(self, content):
+        with open(self.tmp_path, 'w') as f:
+            f.write(content)
+
+    def read(self):
+        with open(self.tmp_path) as f:
+            return f.read()
+
+    def test_populates_empty_unreleased_from_supplied_commits(self):
+        self.write('# Changelog\n\n## [Unreleased]\n\n## [1.0.0] - 2026-01-01\n\nold stuff\n')
+
+        changed = gc.update_unreleased(
+            self.tmp_path,
+            commits_raw='feat(dap): new debugger feature\nfix(startup): faster boot',
+        )
+
+        self.assertTrue(changed)
+        text = self.read()
+        self.assertIn('## [Unreleased]', text)
+        self.assertIn('### Added', text)
+        self.assertIn('- **dap:** new debugger feature', text)
+        self.assertIn('### Fixed', text)
+        self.assertIn('- **startup:** faster boot', text)
+        # The old [1.0.0] section is untouched.
+        self.assertIn('## [1.0.0] - 2026-01-01\n\nold stuff', text)
+
+    def test_replaces_stale_unreleased_content_rather_than_appending(self):
+        self.write(
+            '# Changelog\n\n## [Unreleased]\n\n### Fixed\n- stale entry\n\n'
+            '## [1.0.0] - 2026-01-01\n'
+        )
+
+        gc.update_unreleased(self.tmp_path, commits_raw='feat(x): brand new thing')
+
+        text = self.read()
+        self.assertNotIn('stale entry', text)
+        self.assertIn('- **x:** brand new thing', text)
+
+    def test_no_commits_since_last_tag_clears_unreleased_to_empty(self):
+        self.write(
+            '# Changelog\n\n## [Unreleased]\n\n### Fixed\n- stale entry\n\n'
+            '## [1.0.0] - 2026-01-01\n'
+        )
+
+        changed = gc.update_unreleased(self.tmp_path, commits_raw='')
+
+        self.assertTrue(changed)
+        text = self.read()
+        self.assertNotIn('stale entry', text)
+        self.assertIn('## [Unreleased]\n\n## [1.0.0]', text)
+
+    def test_idempotent_rerun_reports_no_change(self):
+        self.write('# Changelog\n\n## [Unreleased]\n\n## [1.0.0] - 2026-01-01\n')
+
+        first = gc.update_unreleased(self.tmp_path, commits_raw='fix(a): thing one')
+        self.assertTrue(first)
+
+        second = gc.update_unreleased(self.tmp_path, commits_raw='fix(a): thing one')
+        self.assertFalse(second)
+
+    def test_missing_unreleased_heading_raises(self):
+        self.write('# Changelog\n\n## [1.0.0] - 2026-01-01\n')
+        with self.assertRaises(SystemExit):
+            gc.update_unreleased(self.tmp_path, commits_raw='fix: x')
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -74,13 +74,6 @@ jobs:
     # resolve/validate logic (which ref gets pushed to, and whether the
     # dispatch can be released at all), specifically so it's provable
     # without dispatching the real release workflow.
-    #
-    # generate_changelog.py also has a local test file (test_generate_changelog.py)
-    # from earlier #2060 work on backfilling CHANGELOG sections from published
-    # tags -- deliberately NOT wired in here. Whether this workflow should
-    # support releasing from a branch other than main (and, if so, what that
-    # means for CHANGELOG.md) is still an open question on #2060; that script
-    # change stays on the branch, unused, until it's resolved.
     steps:
       - uses: actions/checkout@v6
         with:
@@ -101,6 +94,38 @@ jobs:
       - name: Run resolve_release_ref.sh tests
         if: steps.changed.outputs.run == 'true'
         run: bash .github/scripts/test_resolve_release_ref.sh
+
+  changelog-generator-tests:
+    name: CHANGELOG generator tests
+    runs-on: ubuntu-latest
+    # Gated inside the job (see "Check whether..." below) on whether the
+    # generator or its tests changed -- plain Python unrelated to most PRs.
+    # #2109: the classifier now shells out to git for --unreleased mode
+    # (git describe / git log), where it used to be a pure string-classifier
+    # driven entirely by caller-supplied env vars.
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Check whether the generator or its tests changed
+        id: changed
+        run: |
+          BASE=${{ github.event.pull_request.base.sha }}
+          HEAD=${{ github.event.pull_request.head.sha }}
+          CHANGED=$(git diff --name-only "$BASE"..."$HEAD")
+          if echo "$CHANGED" | grep -qE '^\.github/scripts/(generate_changelog\.py|test_generate_changelog\.py)$'; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run generate_changelog.py tests
+        if: steps.changed.outputs.run == 'true'
+        run: |
+          git config --global user.email "test@example.com"
+          git config --global user.name "Test"
+          python3 .github/scripts/test_generate_changelog.py
 
   # validate-coverage (docs/coverage.yaml) removed at the v1->v2 cutover: v1 tracked
   # AL-language coverage in a hand-curated YAML the orchestrator validated on every PR.

--- a/.github/workflows/sync-changelog-unreleased.yml
+++ b/.github/workflows/sync-changelog-unreleased.yml
@@ -1,0 +1,64 @@
+name: Sync CHANGELOG [Unreleased]
+
+# Keeps CHANGELOG.md's "## [Unreleased]" section a live answer to "what's
+# about to ship", recomputed from every commit since the last release tag
+# (#2109). Before this workflow, generate_changelog.py only ran inside
+# publish.yml at release time, so [Unreleased] sat empty between releases —
+# right when it was filed, empty with 11 merged PRs already sitting on main.
+#
+# generate_changelog.py --unreleased recomputes the section from
+# `git describe --tags --abbrev=0`..HEAD every time this runs and reports
+# whether the text actually changed (`changed=true`/`false`), so a run that
+# finds nothing new commits nothing. That also makes this workflow safe
+# against re-triggering itself: pushing the sync commit onto main fires this
+# workflow again, but by then HEAD already reflects the state the sync
+# computed, so the second run is a no-op. The sync commit's message carries
+# "[skip ci]" as well, so GitHub does not even schedule that second run (or
+# the full bc-tests.yml matrix test-matrix.yml would otherwise trigger for a
+# CHANGELOG-only commit) in the first place.
+#
+# A release itself (publish.yml) also pushes straight to main and would
+# otherwise re-trigger this workflow too. That run is harmless without any
+# special-casing: PREV_TAG at that point IS the tag the release just created,
+# so the commit range is empty and this workflow simply clears [Unreleased]
+# back out — which is exactly the state it should be in right after a
+# release ships.
+#
+# This is the ONE place besides a release itself that CHANGELOG.md changes
+# outside a pull request. It has to be that way: no PR may touch
+# CHANGELOG.md at all (.claude/rules/no-changelog-edits.md), specifically so
+# merges never conflict on it. Pushes here bypass the branch ruleset the same
+# documented way publish.yml's release job does — via RELEASE_DEPLOY_KEY, a
+# deploy key with "Always allow" set for it.
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ssh-key: ${{ secrets.RELEASE_DEPLOY_KEY }}
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Recompute [Unreleased] from commits since the last tag
+        id: sync
+        run: python3 .github/scripts/generate_changelog.py --unreleased >> "$GITHUB_OUTPUT"
+
+      - name: Commit and push if it changed
+        if: steps.sync.outputs.changed == 'true'
+        run: |
+          git add CHANGELOG.md
+          git commit -m "chore: update changelog [skip ci]"
+          git push origin HEAD:main

--- a/.github/workflows/sync-changelog-unreleased.yml
+++ b/.github/workflows/sync-changelog-unreleased.yml
@@ -17,12 +17,21 @@ name: Sync CHANGELOG [Unreleased]
 # the full bc-tests.yml matrix test-matrix.yml would otherwise trigger for a
 # CHANGELOG-only commit) in the first place.
 #
-# A release itself (publish.yml) also pushes straight to main and would
-# otherwise re-trigger this workflow too. That run is harmless without any
-# special-casing: PREV_TAG at that point IS the tag the release just created,
-# so the commit range is empty and this workflow simply clears [Unreleased]
-# back out — which is exactly the state it should be in right after a
-# release ships.
+# A release itself (publish.yml) also pushes its own CHANGELOG commit
+# straight to main and would otherwise re-trigger this workflow on THAT push.
+# This is deliberately made race-proof, not just probably-fine: publish.yml
+# pushes the release commit BEFORE its next command creates and pushes the
+# release tag, so a sync run triggered by that same push could be checked out
+# on the release commit while the tag still isn't visible on origin.
+# generate_changelog.py's update_unreleased() handles this by recognizing the
+# checked-out commit as a release commit FROM ITS OWN MESSAGE ("chore:
+# release vX.Y.Z") and refusing to run at all in that case — it never
+# consults `git describe`, so it never depends on whether the tag has landed.
+# See that function's docstring for the full reasoning. The complementary
+# half of the fix lives in generate_release_section() (also in
+# generate_changelog.py, called by publish.yml): it WIPES whatever this
+# workflow last wrote into [Unreleased] before inserting the new version's
+# own section, rather than leaving that content dangling underneath it.
 #
 # This is the ONE place besides a release itself that CHANGELOG.md changes
 # outside a pull request. It has to be that way: no PR may touch


### PR DESCRIPTION
Closes #2109

## What was broken

`generate_changelog.py`'s classifier tested only unscoped conventional-commit
prefixes (`feat:`, `fix:`, `docs:`, `chore:`), but this repo writes scoped
commits almost exclusively (`fix(startup):`, `feat(dap):`, `docs(agents):`,
`chore(corpus):`). A scoped commit matched none of the classifier's checks,
fell to the catch-all branch, and was dumped into `### Changed` with its raw
prefix still attached. Bare `chore:` was skipped but `chore(corpus):` was
not, so scoped chores reached the published changelog (2.7.0 shipped two).
`[Unreleased]` was permanently empty between releases. A commit subject
carrying two trailing `(#N)` markers (one from the PR title, one from the
squash merge) only had the last one stripped.

## How RED was established

Rather than write a synthetic fixture and hope it represents the bug, I
copied the *verbatim* old classifier logic out of `origin/main` and ran it
against the exact 11-commit batch #2109's own body measured, byte-for-byte:

```
added: 0
fixed: 1
docs: 0
changed: 10
   - fix(tests): make SiblingSourceDep_CompilesWithZeroPackageCacheDirs hermetic
   - fix(startup): defer the remaining per-generation startup lines past re-exec
   ... (8 more, all raw `fix(...):`/`docs(...):` prefixes)
```

That reproduces "1 classified, 10 dumped raw" exactly as the issue reports
it. This is a stronger proof than a synthetic fixture would have been — it
pins the fix against the specific batch that motivated the issue, not
against examples I made up to match my own understanding of the bug. The new
classifier run against the identical batch: 9 fixed, 2 docs, 0 changed, 0
added — every commit lands in a real section, none leak a raw prefix.
Unit test: `test_measured_release_batch_from_the_issue_classifies_ten_of_eleven`.

## Scope increase over what the issue asked for

#2109 was written around `feat`/`fix`/`docs`/`chore` because those were what
got measured. I extended the fix to `perf`, `test`, `refactor`, `ci`, and a
one-off `dap:` commit that had already shipped raw into the published 2.7.0
section (`- dap: add a stdio transport...`) — not one of the four named
types. The reasoning: the defect is "a raw conventional-commit-shaped prefix
leaks into user-facing output", and that defect isn't specific to the four
types that happened to appear in the issue's sample — any type this repo has
actually used in its history has the same failure mode. `CONVENTIONAL_RE`
now matches any `type` or `type(scope)` prefix; `feat`/`fix`/`docs` get a
dedicated section, `chore` is dropped, and everything else still lands in
`### Changed` but with the type token stripped either way (scope preserved
as a bold prefix if present). Covered by
`test_unrecognized_conventional_type_is_stripped_not_left_raw` and
`test_scoped_unrecognized_type_preserves_scope_and_drops_type`.

## `[Unreleased]` sync — and why it can't race a release

`update_unreleased()` / `--unreleased` recomputes `[Unreleased]` from every
commit since the last tag, and a new `sync-changelog-unreleased.yml` runs it
on every push to `main`, committing only when the text actually changed.

Reviewing this before opening the PR, I found two real correctness gaps
against `publish.yml`'s own release flow, not hypothetical ones:

1. `publish.yml` pushes its release commit to `main` **before** its next
   command creates and pushes the release tag. A sync run triggered by that
   same push could be checked out on the release commit while the tag still
   isn't visible on origin. If `update_unreleased()` had fallen through to
   `git describe --tags --abbrev=0` on that run, it could still resolve the
   *previous* tag and wrongly recompute a range covering everything the
   release just shipped, writing it back into `[Unreleased]` right after the
   release emptied it.

   Fixed by having `update_unreleased()` recognize the commit it's checked
   out at as a release commit **from its own message**
   (`chore: release vX.Y.Z`, `RELEASE_COMMIT_RE`) and refuse to run at all in
   that case — it never consults `git describe`, so it never depends on
   whether the tag has landed. This isn't "the scheduling delay before a
   workflow starts makes this unlikely" — it removes the dependency on
   timing entirely. Verified against a real (not mocked) git repo with the
   tag deliberately not yet created at the moment `--unreleased` runs against
   the release commit: `changed=false`, file byte-for-byte untouched.
   Unit test: `test_skips_entirely_when_head_is_a_release_commit` (proven
   with a `commits_raw` that would otherwise write a marker string, so the
   test proves the skip happens *before* that's ever consulted, not that it
   coincidentally produced no diff).

2. `generate_release_section()` (the function `publish.yml`'s release job
   calls) only ever inserted the new version's section right after the
   `## [Unreleased]` heading — it never touched whatever content was already
   sitting between that heading and the next one. Before this PR nothing was
   ever written there between releases, so this was latent and harmless.
   With the sync workflow now populating `[Unreleased]` continuously, every
   release would have left stale synced content orphaned underneath the
   newly-inserted release section instead of correctly emptying
   `[Unreleased]`. Fixed by having `generate_release_section()` wipe that
   content the same way `update_unreleased()` does (both reuse
   `UNRELEASED_SECTION_RE`) — correct because `commits_raw` already covers
   everything that would legitimately be in `[Unreleased]` at release time;
   both are computed from the same "since last tag" range.
   Unit test: `test_wipes_stale_unreleased_content_left_by_the_sync_workflow`
   (pre-seeds stale content, asserts it appears exactly once in the output —
   inside the new release section — not duplicated below it).

I'm not asserting "this can't interfere" as a hope — both failure modes were
real, reproduced, and are now closed by removing the dependency on ordering/
timing rather than by making the race narrower. If either of these two
mechanisms is missing, the interaction is broken; together, I believe this
rules it out by construction, and the tests above are the evidence for that
claim, not just a description of it.

Also confirmed: `sync-changelog-unreleased.yml`'s own sync commit carries
`[skip ci]`, which GitHub honors by not scheduling any push-triggered
workflow for that commit — so it doesn't re-trigger itself in a loop, and it
doesn't burn a full `bc-tests.yml` matrix run for a text-only change. A
release's tag push (`git push origin "$TAG"`) is a ref push, not a branch
push, so it doesn't trigger this workflow (`on: push: branches: [main]`) at
all — only the release *commit* push does, which is the case items 1–2
above cover.

## `.claude/rules/no-changelog-edits.md`

This PR does not touch `CHANGELOG.md` itself — confirmed via
`git diff origin/main --stat`, which shows only
`generate_changelog.py`/`test_generate_changelog.py`/two workflow files.
The rule's literal text ("never stage, edit, or include CHANGELOG.md in any
PR") isn't violated by this PR.

The new `sync-changelog-unreleased.yml` workflow *will*, once merged, commit
directly to `CHANGELOG.md` on `main` outside of any PR — the same mechanism
`publish.yml`'s release job already uses today (also outside PR review, via
`RELEASE_DEPLOY_KEY`). This PR doesn't add a new category of interaction
with PRs, just a second, more frequent direct-push writer alongside the
existing one. That said, a future reader of `no-changelog-edits.md` who
doesn't know a bot writes to `CHANGELOG.md` outside PRs could reasonably be
confused by seeing it change on `main` without a PR behind it. I'm flagging
that plainly rather than editing the rule myself, per the note that the rule
change would be handled separately.

## Testing

- `python3 .github/scripts/test_generate_changelog.py` — 23 tests, all
  passing (classifier: scoped/unscoped/unrecognized types, repeated `(#N)`
  stripping, `[Unreleased]` sync including both race-condition fixes,
  `generate_release_section`'s wipe behavior).
- `bash .github/scripts/test_resolve_release_ref.sh` — 16 tests (from #2060,
  came along via the rebase onto `ac850614`), still passing.
- `dotnet test AlRunner.Tests --filter "FullyQualifiedName~ReleaseTestParityTests|FullyQualifiedName~PublishReleaseOrderingTests"` —
  21 tests, all passing (this PR doesn't touch `publish.yml` itself, so this
  confirms no regression there).
- Manual end-to-end smoke tests against real throwaway git repos (not just
  the unit-test mocks) for both `--unreleased` mode and the release-commit
  race scenario — outputs shown above.

Local scope per `.claude/rules/local-test-scope.md`: the changed scripts and
their own tests, plus the targeted C# tests that reference `publish.yml`'s
shape (since `pr-check.yml` and the rebase touch adjacent territory). Did not
run the full AL corpus or the full `dotnet test` suite — this PR touches
nothing under `AlRunner/` or `tests/`.
