### PR TITLE
fix(server): stop execute from silently discarding Message() output

### DIFF
--- a/AlRunner.Tests/ServerExecuteMessagesTests.cs
+++ b/AlRunner.Tests/ServerExecuteMessagesTests.cs
@@ -1,0 +1,235 @@
+using System.Text.Json;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// #2117 — `--server` `execute` silently discarded Message() output. Reported by
+/// SShadowS/ALchemist against the published 2.7.0: an OnRun-driven codeunit calling
+/// Message() four times returned exitCode:0 and test results with NO trace of any of
+/// the four strings — no dispatch, no exception, nothing.
+///
+/// ROOT CAUSE (confirmed by decompiling Microsoft.Dynamics.Nav.Ncl.dll): NavDialog.
+/// ALMessage's real body is
+///     if (!session.TestExecution.TestHandleMessage(message2))
+///         session.ClientCallbackOrNull?.DialogMessage(message2, automationId);
+/// TestHandleMessage only ever finds a [MessageHandler] (or throws BC's own "Unhandled
+/// UI") while a [Test] procedure is executing; on `execute`'s OnRun path
+/// (executingTestMethod == null) it quietly returns false without throwing, and
+/// ClientCallbackOrNull is null (the runner has no client) — the `?.` swallows the
+/// call. Confirm()/StrMenu() read the NON-null-conditional `session.ClientCallback`,
+/// which throws NavNCLCallbackNotAllowedException when there is no client instead —
+/// already loud, not part of this hole (see NoHoleForConfirmOrStrMenu_ExecutePath below,
+/// which pins that finding rather than assuming it).
+///
+/// Ghost-test guard: every positive assertion below names a SPECIFIC string, order, or
+/// statement id — never just "messages present". A no-op fix (an always-empty array)
+/// fails every positive fact here. An implementation that hands out the SAME
+/// statementId regardless of which AL statement actually called Message() fails
+/// <see cref="Execute_MessageInLoop_StatementIdDistinguishesLoopFromFinalCall"/>
+/// specifically, which cross-references the id against the statement table's own
+/// decoded source line (the same technique AlStatementTableTests uses) rather than just
+/// checking the ids differ from each other by accident.
+///
+/// Spawns the real runner in --server mode; needs the BC artifact cache — reports
+/// Skipped (not Passed) when absent, via TestArtifacts.
+/// </summary>
+public class ServerExecuteMessagesTests : IClassFixture<SharedCliServer>
+{
+    private readonly SharedCliServer _fixture;
+
+    public ServerExecuteMessagesTests(SharedCliServer fixture) => _fixture = fixture;
+
+    // The issue's own reproducer, verbatim shape: a loop calling Message() three times
+    // (SAME source statement, three executions) followed by one more Message() call on
+    // a DIFFERENT statement.
+    private const string LoopAndFinalMessageCode =
+        "codeunit 60200 \"Msg Loop SX\"\n" +
+        "{\n" +
+        "    trigger OnRun()\n" +
+        "    var\n" +
+        "        i: Integer;\n" +
+        "        total: Integer;\n" +
+        "    begin\n" +
+        "        total := 0;\n" +
+        "        for i := 1 to 3 do begin\n" +
+        "            total := total + i;\n" +
+        "            Message('LOOP_MSG_' + Format(i));\n" +
+        "        end;\n" +
+        "        Message('FINAL_MSG');\n" +
+        "    end;\n" +
+        "}\n";
+
+    [SkippableFact]
+    public async Task Execute_MessageInLoop_ReturnsMessagesInCallOrder()
+    {
+        TestArtifacts.SkipIfMissing();
+        var server = await _fixture.GetAsync();
+        var r = await server.SendAsync(JsonSerializer.Serialize(new
+        {
+            command = "execute",
+            code = LoopAndFinalMessageCode,
+        }));
+        var d = JsonSerializer.Deserialize<JsonElement>(r);
+        Assert.False(d.TryGetProperty("error", out _), $"unexpected error response: {r}");
+        Assert.Equal(0, d.GetProperty("exitCode").GetInt32());
+
+        Assert.True(d.TryGetProperty("messages", out var messages), $"expected messages on the response: {r}");
+        var texts = messages.EnumerateArray().Select(m => m.GetProperty("text").GetString()).ToList();
+        Assert.Equal(new[] { "LOOP_MSG_1", "LOOP_MSG_2", "LOOP_MSG_3", "FINAL_MSG" }, texts);
+    }
+
+    // The statementId claim, proven the strong way: cross-referenced against the
+    // statement table's own decoded source line (coverage:true on the SAME call, same
+    // technique AlStatementTableTests.CapturedValueStatementId_MatchesStatementTableScopeAndId
+    // uses) rather than merely asserting "the ids differ". The three loop messages come
+    // from the SAME AL statement executed three times, so they must share ONE id; the
+    // final message comes from a later statement, so its id must differ AND its
+    // resolved line must be strictly after the loop message's resolved line.
+    [SkippableFact]
+    public async Task Execute_MessageInLoop_StatementIdDistinguishesLoopFromFinalCall()
+    {
+        TestArtifacts.SkipIfMissing();
+        var server = await _fixture.GetAsync();
+        var r = await server.SendAsync(JsonSerializer.Serialize(new
+        {
+            command = "execute",
+            coverage = true,
+            code = LoopAndFinalMessageCode,
+        }));
+        var d = JsonSerializer.Deserialize<JsonElement>(r);
+        Assert.False(d.TryGetProperty("error", out _), $"unexpected error response: {r}");
+
+        Assert.True(d.TryGetProperty("messages", out var messages), $"expected messages on the response: {r}");
+        var entries = messages.EnumerateArray().ToList();
+        Assert.Equal(4, entries.Count);
+
+        var loopIds = entries.Take(3).Select(e => e.GetProperty("statementId").GetInt32()).Distinct().ToList();
+        Assert.Single(loopIds); // all three loop calls are the SAME AL statement
+        var loopId = loopIds[0];
+        var finalId = entries[3].GetProperty("statementId").GetInt32();
+        Assert.NotEqual(loopId, finalId); // the trailing call is a DIFFERENT statement
+        Assert.Equal("OnRun", entries[0].GetProperty("scopeName").GetString());
+
+        // Cross-reference: the statement table's own decoded position for each id —
+        // proves statementId is a REAL position lookup, not two arbitrary distinct ints.
+        Assert.True(d.TryGetProperty("coverage", out var coverage), $"expected coverage on the response: {r}");
+        var statements = coverage.EnumerateArray().Single()
+            .GetProperty("statements").EnumerateArray()
+            .ToDictionary(s => s.GetProperty("id").GetInt32(), s => s);
+        Assert.True(statements.ContainsKey(loopId), $"loop statementId {loopId} not in statement table: {r}");
+        Assert.True(statements.ContainsKey(finalId), $"final statementId {finalId} not in statement table: {r}");
+        var loopLine = statements[loopId].GetProperty("line").GetInt32();
+        var finalLine = statements[finalId].GetProperty("line").GetInt32();
+        Assert.True(finalLine > loopLine,
+            $"FINAL_MSG's statement (line {finalLine}) should resolve strictly after the loop's (line {loopLine}): {r}");
+        // The loop statement was hit 3 times (once per iteration) — proves the hit count
+        // and the message count for that id genuinely agree, not coincidentally equal.
+        Assert.Equal(3, statements[loopId].GetProperty("hits").GetInt32());
+    }
+
+    // Negative direction: an OnRun that never calls Message() must NOT get a `messages`
+    // field at all — omitted, not an empty array. `execute` always collects (there is no
+    // request-side opt-in for this field, unlike coverage/captureValues), so "absent"
+    // must mean "zero messages produced", proven here rather than merely documented.
+    [SkippableFact]
+    public async Task Execute_NoMessageCalls_MessagesFieldAbsent()
+    {
+        TestArtifacts.SkipIfMissing();
+        var server = await _fixture.GetAsync();
+        var r = await server.SendAsync(JsonSerializer.Serialize(new
+        {
+            command = "execute",
+            code = "codeunit 60201 \"No Msg SX\" { trigger OnRun() var X: Integer; begin X := 1; end; }",
+        }));
+        var d = JsonSerializer.Deserialize<JsonElement>(r);
+        Assert.False(d.TryGetProperty("error", out _), $"unexpected error response: {r}");
+        Assert.Equal(0, d.GetProperty("exitCode").GetInt32());
+        Assert.False(d.TryGetProperty("messages", out _),
+            $"messages must be absent when Message() was never called: {r}");
+    }
+
+    // THE regression guard the issue calls out by name: a [Test] procedure's Message()
+    // call must still raise BC's real "Unhandled UI" when no [MessageHandler] is
+    // declared — completely unaffected by RunnerClientCallback/AlMessageCapture, because
+    // NavTestExecution.TestHandleMessage resolves (or throws) BEFORE NavDialog.ALMessage
+    // ever consults ClientCallbackOrNull. Run via `runTests`, NOT `execute` — this is
+    // the code path this fix must leave alone.
+    [SkippableFact]
+    public async Task RunTests_MessageWithoutHandler_StillRaisesUnhandledUI()
+    {
+        TestArtifacts.SkipIfMissing();
+        var dir = Path.Combine(Path.GetTempPath(), "al-runner-msg-unhandled-ui-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "app.json"), """
+        {
+          "id": "f1a2b3c4-d5e6-4f70-8192-a3b4c5d6e7f8",
+          "name": "Msg Unhandled UI Probe",
+          "publisher": "AL Runner",
+          "version": "1.0.0.0",
+          "dependencies": [],
+          "platform": "1.0.0.0",
+          "application": "1.0.0.0",
+          "idRanges": [ { "from": 60202, "to": 60202 } ],
+          "runtime": "14.0"
+        }
+        """);
+        File.WriteAllText(Path.Combine(dir, "Probe.Codeunit.al"), """
+        codeunit 60202 "Msg Unhandled UI SX"
+        {
+            Subtype = Test;
+
+            [Test]
+            procedure MessageWithoutHandler()
+            begin
+                Message('should not be swallowed nor silently succeed');
+            end;
+        }
+        """);
+
+        var server = await _fixture.GetAsync();
+        var req = JsonSerializer.Serialize(new
+        {
+            command = "runTests",
+            sourcePaths = new[] { dir },
+            packagePaths = Array.Empty<string>(),
+        });
+        var lines = await server.SendRequestStreamingAsync(req);
+        var (events, summary) = ProtocolV2Streaming.Split(lines);
+
+        Assert.Single(events);
+        var status = events[0].GetProperty("status").GetString();
+        Assert.True(status is "fail" or "error", $"expected the unhandled Message() to fail the test, got {status}: {events[0]}");
+        var message = events[0].GetProperty("message").GetString() ?? "";
+        Assert.Contains("Unhandled UI", message);
+        Assert.NotEqual(0, summary.GetProperty("exitCode").GetInt32());
+    }
+
+    // Documents the OTHER finding the issue asked for: Confirm()/StrMenu() on the SAME
+    // `execute` path do NOT have this hole today — they already raise a real BC
+    // exception (NavNCLCallbackNotAllowedException, "Callback functions are not
+    // allowed") because their AL bodies read the non-null-conditional
+    // `session.ClientCallback`. RunnerClientCallback reproduces that SAME exception for
+    // every member except DialogMessage specifically so this stays true after the fix —
+    // pinned here rather than left as an unverified claim in the PR description.
+    [SkippableFact]
+    public async Task Execute_ConfirmWithoutHandler_StillThrowsCallbackNotAllowed_NotSwallowed()
+    {
+        TestArtifacts.SkipIfMissing();
+        var server = await _fixture.GetAsync();
+        var r = await server.SendAsync(JsonSerializer.Serialize(new
+        {
+            command = "execute",
+            code = "codeunit 60203 \"Confirm NoHandler SX\" { trigger OnRun() var Ans: Boolean; " +
+                   "begin Ans := Confirm('proceed?'); end; }",
+        }));
+        var d = JsonSerializer.Deserialize<JsonElement>(r);
+        Assert.False(d.TryGetProperty("error", out _), $"unexpected error response: {r}");
+        Assert.Equal(1, d.GetProperty("exitCode").GetInt32());
+        var tests = d.GetProperty("tests");
+        Assert.Equal(1, tests.GetArrayLength());
+        Assert.Equal("fail", tests[0].GetProperty("status").GetString());
+        var message = tests[0].GetProperty("message").GetString() ?? "";
+        Assert.Contains("Callback", message);
+    }
+}

--- a/AlRunner.Tests/ServerExecuteMessagesTests.cs
+++ b/AlRunner.Tests/ServerExecuteMessagesTests.cs
@@ -232,4 +232,39 @@ public class ServerExecuteMessagesTests : IClassFixture<SharedCliServer>
         var message = tests[0].GetProperty("message").GetString() ?? "";
         Assert.Contains("Callback", message);
     }
+
+    // Decompile-verified regression guard: installing RunnerClientCallback makes
+    // NavSession.ClientCallbackOrNull non-null for the WHOLE session, not only inside
+    // ALMessage — NavSession.set_WorkDate's real body ALSO reads it (null-checked, not
+    // via the throwing property) to fire IClientCallback.WorkDateChanged, a
+    // client-UI-refresh notification. `WorkDate := ...` is near-universal in BC test
+    // setup, so an earlier revision of this fix that made every non-DialogMessage
+    // member throw would have made this ONE line fail every such `execute` call. Proven
+    // two ways in one request: the run must still pass (not throw), and Format(WorkDate)
+    // fed back through the now-fixed Message() capture must show the REAL assigned
+    // date, not a default/unset one.
+    [SkippableFact]
+    public async Task Execute_SetsWorkDate_DoesNotThrow_AndNewValueIsObservable()
+    {
+        TestArtifacts.SkipIfMissing();
+        var server = await _fixture.GetAsync();
+        var r = await server.SendAsync(JsonSerializer.Serialize(new
+        {
+            command = "execute",
+            code = "codeunit 60204 \"WorkDate NoClient SX\" { trigger OnRun() " +
+                   "begin WorkDate := DMY2Date(17, 3, 2031); " +
+                   "Message(Format(WorkDate, 0, '<Day,2>/<Month,2>/<Year4>')); end; }",
+        }));
+        var d = JsonSerializer.Deserialize<JsonElement>(r);
+        Assert.False(d.TryGetProperty("error", out _), $"unexpected error response: {r}");
+        Assert.Equal(0, d.GetProperty("exitCode").GetInt32());
+        var tests = d.GetProperty("tests");
+        Assert.Equal(1, tests.GetArrayLength());
+        Assert.Equal("pass", tests[0].GetProperty("status").GetString());
+
+        Assert.True(d.TryGetProperty("messages", out var messages), $"expected messages on the response: {r}");
+        var entries = messages.EnumerateArray().ToList();
+        Assert.Single(entries);
+        Assert.Equal("17/03/2031", entries[0].GetProperty("text").GetString());
+    }
 }

--- a/AlRunner/Infrastructure/AlCoverageTracker.cs
+++ b/AlRunner/Infrastructure/AlCoverageTracker.cs
@@ -39,9 +39,17 @@ public static class AlCoverageTracker
     /// exactly (NavMethodScope, int) so the rewrite can forward `ldarg.0; ldarg.1; call`
     /// without boxing the int. Must stay side-effect-free beyond counting: it runs on
     /// every AL statement of every test, coverage or not.
+    ///
+    /// Also feeds AlCurrentStatement (#2117) UNCONDITIONALLY — i.e. before the Enabled
+    /// check below, not gated by it. That tracker answers "which AL statement is
+    /// executing right now" for RunnerClientCallback's Message() capture, which (unlike
+    /// coverage/capturedValues) has no request-side opt-in — see AlCurrentStatement's
+    /// and AlMessageCapture's doc comments for why session.CurrentMethodScope could not
+    /// answer that question and this hook's own scope argument can.
     /// </summary>
     public static void OnStmtHit(NavMethodScope scope, int currentStatementNumber)
     {
+        AlCurrentStatement.Update(scope, currentStatementNumber);
         if (!Enabled) return;
         // NavMethodScope.ExitStatementNumber (int.MaxValue) is written directly by
         // Exit(), never passed to StmtHit by generated code — guarded defensively so a

--- a/AlRunner/Infrastructure/AlCurrentStatement.cs
+++ b/AlRunner/Infrastructure/AlCurrentStatement.cs
@@ -1,0 +1,53 @@
+// AlCurrentStatement — "which AL statement is executing right now", tracked off the
+// SAME Cecil-rewritten NavMethodScope.StmtHit(int) hook AlCoverageTracker.OnStmtHit
+// already receives on every AL statement of every run (issue #2117).
+//
+// WHY NOT NavSession.CurrentMethodScope — the obvious-looking alternative
+//   NavMethodScope's own constructor does `session.CurrentMethodScope = this;`, so
+//   reading `NavCurrentThread.Session.CurrentMethodScope` looks like it should give
+//   "the scope currently running". Empirically (a probe with Console.Error debug output
+//   under AL_RUNNER_VERBOSE=1) it does NOT: for a codeunit's OnRun trigger, invoked via
+//   NavTriggerMethodScope<T>, `session.CurrentMethodScope` stayed the process's
+//   RootMethodScope throughout — trigger scopes evidently do not become
+//   `CurrentMethodScope` the way an ordinary procedure call's scope would. Chasing
+//   the exact reason further wasn't worth it: StmtHit's own hook ALREADY hands us the
+//   right scope directly as its first argument, with no session-tracking involved at
+//   all — the same "receive the scope as a call argument, don't go hunting for it via
+//   session" approach AlValueCapture's Exit() hook and AlCoverageTracker's own
+//   OnStmtHit already use for the SAME reason.
+//
+// UNCONDITIONAL, NOT GATED BY AlCoverageTracker.Enabled
+//   The StmtHit hook call itself is unconditional in the rewritten IL (see
+//   AlCoverageTracker's doc comment); this class updates on EVERY call regardless of
+//   Enabled, so a caller (RunnerClientCallback) can resolve "the statement that just
+//   called Message()" even when `coverage:true` was never requested — matching
+//   `messages`' own no-opt-in design (see AlMessageCapture's header).
+using Microsoft.Dynamics.Nav.Runtime;
+
+namespace AlRunner.Infrastructure;
+
+public static class AlCurrentStatement
+{
+    // Single process-global slot, NOT per-scope/per-thread — same "the runner invokes
+    // exactly one such call at a time" assumption AlValueCapture's snapshot slot and
+    // AlCallStackCapture's single-slot AL stack already make.
+    private static volatile NavMethodScope? _scope;
+    private static volatile int _statementId = -1;
+
+    /// <summary>Called unconditionally from AlCoverageTracker.OnStmtHit — see that
+    /// method's own doc comment for why the underlying hook call is unconditional.
+    /// <paramref name="statementId"/> of <c>int.MaxValue</c> (NavMethodScope.
+    /// ExitStatementNumber, written by Exit()) is ignored, same guard
+    /// AlCoverageTracker.OnStmtHit already applies, for the same reason: it is never a
+    /// real statement a caller should be told about.</summary>
+    public static void Update(NavMethodScope scope, int statementId)
+    {
+        if (statementId == int.MaxValue) return;
+        _scope = scope;
+        _statementId = statementId;
+    }
+
+    /// <summary>The scope + statement id as of the last StmtHit call, or (null, -1) if
+    /// none has fired yet in this process.</summary>
+    public static (NavMethodScope? Scope, int StatementId) Current => (_scope, _statementId);
+}

--- a/AlRunner/Infrastructure/AlMessageCapture.cs
+++ b/AlRunner/Infrastructure/AlMessageCapture.cs
@@ -1,0 +1,68 @@
+// AlMessageCapture — the runtime side of `--server` `execute`'s `messages` response
+// field (issue #2117). Collects every Message() call an OnRun-driven codeunit makes
+// during a `server execute` (run-mode) invocation, in call order, each tagged with the
+// AL statement that produced it.
+//
+// WHY THIS EXISTS
+//   BC's own NavDialog.ALMessage body (decompiled from Microsoft.Dynamics.Nav.Ncl.dll)
+//   is:
+//       string message2 = ALSystemString.ALStrSubstNo(ReplaceBackSlashWithCRLF(message), values);
+//       if (!session.TestExecution.TestHandleMessage(message2))
+//           session.ClientCallbackOrNull?.DialogMessage(message2, automationId);
+//   TestHandleMessage only ever finds a [MessageHandler] (or throws BC's own "Unhandled
+//   UI") while a [Test] procedure is executing — NavTestExecution.FindHandler's inner
+//   lookup is unconditionally `if (executingTestMethod == null) return null;`, and
+//   `executingTestMethod` is only set by EnterTestMethod, which runs exactly once per
+//   [Test] invocation. `execute`'s OnRun path never calls EnterTestMethod, so
+//   TestHandleMessage quietly returns false WITHOUT throwing, and `ClientCallbackOrNull`
+//   is null on the runner (no client) — the `?.` swallows the call outright: no
+//   dispatch, no exception, nothing. Confirm()/StrMenu() do NOT have this hole: their AL
+//   bodies read the non-null-conditional `session.ClientCallback`, which throws
+//   NavNCLCallbackNotAllowedException when there is no client — loud, not silent. See
+//   AlRunner/Patches/RunnerClientCallback.cs for the fix and the fuller comparison.
+//
+// STATEMENT ID
+//   NavMethodScope.StatementNumber (public, unmodified BC state — StmtHit/Exit already
+//   maintain it; see AlCoverageTracker's and AlValueCapture's own doc comments) is read
+//   off NavSession.CurrentMethodScope at the moment DialogMessage fires — i.e. the
+//   statement whose side effect is "call Message()" is still the CURRENT statement of
+//   the innermost executing AL method scope. This is the SAME id-space
+//   AlCoverageTracker.AlStatementRecord.StatementId and
+//   AlValueCapture.AlCapturedValue.StatementId already use for the SAME scope (see
+//   AlStatementTableTests.CapturedValueStatementId_MatchesStatementTableScopeAndId) — no
+//   new numbering, reusing exactly the id/position table #2042 built.
+namespace AlRunner.Infrastructure;
+
+/// <summary>One Message() call captured during a <c>server execute</c> run, in call
+/// order. <c>ScopeName</c> is the AL member (trigger/procedure) whose currently
+/// executing statement called Message() — matching <c>AlCapturedValue.ScopeName</c> /
+/// <c>AlStatementRecord.ScopeName</c>'s scope-name space. <c>StatementId</c> is -1 only
+/// when no AL method scope was active at capture time (should not happen for a real
+/// Message() call reached through AL code; recorded rather than thrown so an
+/// unanticipated shape does not crash the whole run — loud in the log, not fatal).</summary>
+public readonly record struct AlCapturedMessage(string Text, string ScopeName, int StatementId);
+
+public static class AlMessageCapture
+{
+    private static volatile List<AlCapturedMessage>? _messages;
+
+    /// <summary>Reset once per `execute` call (HandleServerExecute), BEFORE the (possibly
+    /// multi-bundle) run — mirrors AlCoverageTracker.Reset's placement: messages must
+    /// accumulate across every bundle in ONE execute call, in the order Message() was
+    /// actually called, not be scoped per-bundle the way AlValueCapture's per-OnRun
+    /// snapshot is.</summary>
+    public static void Reset() => _messages = new List<AlCapturedMessage>();
+
+    /// <summary>Called from RunnerClientCallback.DialogMessage. Appends, never replaces —
+    /// a loop calling Message() three times must produce three entries, in order.</summary>
+    public static void Record(string text, string scopeName, int statementId) =>
+        (_messages ??= new List<AlCapturedMessage>()).Add(new AlCapturedMessage(text, scopeName, statementId));
+
+    /// <summary>Everything captured since the last Reset(), in call order. Empty (never
+    /// null) whether Reset() was never called or nothing was captured — the caller
+    /// (HandleServerExecute / ServerProtocol.Execute) decides whether zero entries means
+    /// "omit messages from the wire" (it does — see ServerProtocol.Execute's doc
+    /// comment).</summary>
+    public static IReadOnlyList<AlCapturedMessage> Snapshot() =>
+        (IReadOnlyList<AlCapturedMessage>?)_messages ?? Array.Empty<AlCapturedMessage>();
+}

--- a/AlRunner/Patches/RunnerClientCallback.cs
+++ b/AlRunner/Patches/RunnerClientCallback.cs
@@ -1,0 +1,114 @@
+// RunnerClientCallback — stands in for NavSession.ClientCallbackOverride so
+// NavDialog.ALMessage's `session.ClientCallbackOrNull?.DialogMessage(...)` has somewhere
+// real to land during `server execute` (issue #2117).
+//
+// NavSession.ClientCallbackOverride is a plain, public, settable property BC itself
+// ships on NavSession — decompiled:
+//     public IClientCallback ClientCallbackOverride { get; set; }
+//     public IClientCallback ClientCallbackOrNull =>
+//         ClientCallbackOverride ?? serviceConnection?.ClientCallback;
+//     public IClientCallback ClientCallback =>
+//         ClientCallbackOrNull ?? throw new NavNCLCallbackNotAllowedException();
+// Installing an instance here is exactly the extension point BC provides for a
+// process with no real client connection — no Cecil rewrite of NavDialog or any other
+// Ncl.dll business logic is needed.
+//
+// SCOPE OF THE CHANGE
+//   DialogMessage is the ONLY member whose answer differs from what real BC would do
+//   with no client connected. Every other member reproduces
+//   NavNCLCallbackNotAllowedException exactly — the SAME exception
+//   `NavSession.ClientCallback`'s throwing getter raises when ClientCallbackOrNull is
+//   null. That matters because installing this override makes ClientCallbackOrNull
+//   non-null for the WHOLE session, so BC's own ALConfirm/ALStrMenu bodies (which read
+//   the throwing `session.ClientCallback`, not `ClientCallbackOrNull`) stop throwing at
+//   the property access and instead call DialogConfirm/DialogSelectionMenu on US.
+//   Reproducing the exact same exception type+message there means Confirm()/StrMenu()
+//   on the `execute` path keep their EXISTING, already-correct, already-loud behaviour
+//   byte-for-byte — this override changes NOTHING observable except Message().
+//
+// [Test]-PROCEDURE BEHAVIOUR IS UNCHANGED
+//   Message() called from within a [Test] procedure never reaches this class at all:
+//   NavTestExecution.TestHandleMessage resolves (or raises "Unhandled UI") via
+//   FindHandler while `executingTestMethod` is set, strictly BEFORE ALMessage ever
+//   consults ClientCallbackOrNull. See AlMessageCapture.cs's header for the full call
+//   chain and ServerExecuteMessagesTests for the regression guard.
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.Dynamics.Nav.Runtime;
+using Microsoft.Dynamics.Nav.Types;
+using Microsoft.Dynamics.Nav.Types.Exceptions;
+
+namespace AlRunner.Patches;
+
+public sealed class RunnerClientCallback : IClientCallback
+{
+    // The runner IS a UI-capable session for the same reason
+    // ALSystemOperatingSystem.get_ALGuiAllowed is rewritten to true (see
+    // NclCecilRewrite.cs ~line 1537) — it dispatches UI callbacks itself rather than
+    // delegating to a client window. Nothing on the Message()/Confirm()/StrMenu() path
+    // consults this getter today; it is answered truthfully rather than defaulted to
+    // false in case something else ever does.
+    public bool IsCallbackAllowed => true;
+
+    /// <summary>The fix: capture the message and the AL statement that produced it
+    /// instead of the real BC "no client" answer (silently doing nothing). Reads
+    /// AlCurrentStatement, NOT NavSession.CurrentMethodScope — see that class's doc
+    /// comment for why the latter does not track a trigger scope like OnRun.</summary>
+    public void DialogMessage(string message, Guid automationId)
+    {
+        var (scope, statementId) = Infrastructure.AlCurrentStatement.Current;
+        string scopeName;
+        if (scope != null)
+        {
+            Infrastructure.AlNavNameReflection.EnsureInit();
+            scopeName = Infrastructure.AlNavNameReflection.GetAlName(scope.GetType()) ?? scope.GetType().Name;
+        }
+        else
+        {
+            scopeName = "?";
+        }
+        Infrastructure.AlMessageCapture.Record(message, scopeName, statementId);
+    }
+
+    // ── Everything else: reproduce BC's own "no client connected" answer exactly ──
+    // (see the file header — this is NOT a silent fake: it is the identical exception
+    // NavSession.ClientCallback's throwing getter raises today, for callers this
+    // override's mere existence would otherwise divert around that getter.)
+    public void DialogHyperlink(string hyperlink, Guid automationId) => throw NotAllowed();
+    public bool DialogConfirm(string message, bool defaultValue, Guid automationId) => throw NotAllowed();
+    public void ProcessServerRequests() => throw NotAllowed();
+    public void DialogOpen(Guid handle, Guid automationId, DialogCancellationBehavior cancellationBehavior, string format, object[] parameters) => throw NotAllowed();
+    public void DialogUpdate(Guid dialogHandle, DialogCancellationBehavior cancellationBehavior, object[] parameters) => throw NotAllowed();
+    public void DialogClose(Guid dialogHandle) => throw NotAllowed();
+    public void ThrowIfDialogCanceled() => throw NotAllowed();
+    public int DialogSelectionMenu(string[] options, int defaultSelection, string instruction, Guid automationId) => throw NotAllowed();
+    public bool DownloadFileAction(Stream stream, bool displayDialog, string title, string initialFolder, string typeFilter, ref string fileName, Guid automationId) => throw NotAllowed();
+    public FileBufferedStream UploadFileAction(bool displayDialog, string title, string initialFolder, string typeFilter, ref string fileName, Guid automationId) => throw NotAllowed();
+    public bool ViewFileAction(Stream stream, string fileName, bool allowDownloadAndPrint) => throw NotAllowed();
+    public bool ExportDataAction(Stream stream, ref string fileName, string dialogTitle, bool showDialog) => throw NotAllowed();
+    public bool ImportDataAction(ref string fileName, string dialogTitle, bool showDialog) => throw NotAllowed();
+    public FormResult FormRunModal(NavForm form, NavFormRuntimeParameters parameters) => throw NotAllowed();
+    public void FormRun(NavForm form, NavFormRuntimeParameters parameters) => throw NotAllowed();
+    public void FormClose(NavForm form) => throw NotAllowed();
+    public void FormActivate(NavForm form, bool refresh) => throw NotAllowed();
+    public bool DataSetPageReady(DataSetRequest request) => throw NotAllowed();
+    public NavAutomationHandle CreateDotNetHandle(string assemblyFullName, string typeName, Guid formHandle, string varName, bool createInstance, params object[] arguments) => throw NotAllowed();
+    public NavAutomationHandle GetDotNetObject(Guid formHandle, int controlId) => throw NotAllowed();
+    public UserNamePasswordCredentials RequestCredentials(UserNamePasswordRequestOptions requestOptions) => throw NotAllowed();
+    public void DisposeAutomationObject(int handle, bool suppressDispose) => throw NotAllowed();
+    public object InvokeAutomationMethod(InvokeAutomationMethodRequest<object> request) => throw NotAllowed();
+    public void ClearClientMetadataCache() => throw NotAllowed();
+    public void SendNotification(NotificationInfo notification) => throw NotAllowed();
+    public void SendGlobalNotification(NotificationInfo notification) => throw NotAllowed();
+    public void SendSessionUpdateRequest(SessionSettingsInfo sessionSettingsInfo) => throw NotAllowed();
+    public void CompanyInformationChanged(CompanyInformationChanges companyInformationChanges) => throw NotAllowed();
+    public void WorkDateChanged(DateTime workDate) => throw NotAllowed();
+    public void VerifyCallbackAllowed(NavApplicationObjectBase applicationObject) => throw NotAllowed();
+    public Task SendPageBackgroundTaskCompletedNotificationAsync(Guid formHandle, int taskId, string clientActivityId) => throw NotAllowed();
+    public Task FeedbackRequested(FeedbackRequest feedbackRequest) => throw NotAllowed();
+    public void TokenChangedNotification() => throw NotAllowed();
+    public Task InvokeTaskPaneAction(InvokeTaskPaneActionArguments arguments) => throw NotAllowed();
+
+    private static NavNCLCallbackNotAllowedException NotAllowed() => new();
+}

--- a/AlRunner/Patches/RunnerClientCallback.cs
+++ b/AlRunner/Patches/RunnerClientCallback.cs
@@ -13,18 +13,65 @@
 // process with no real client connection — no Cecil rewrite of NavDialog or any other
 // Ncl.dll business logic is needed.
 //
-// SCOPE OF THE CHANGE
-//   DialogMessage is the ONLY member whose answer differs from what real BC would do
-//   with no client connected. Every other member reproduces
-//   NavNCLCallbackNotAllowedException exactly — the SAME exception
-//   `NavSession.ClientCallback`'s throwing getter raises when ClientCallbackOrNull is
-//   null. That matters because installing this override makes ClientCallbackOrNull
-//   non-null for the WHOLE session, so BC's own ALConfirm/ALStrMenu bodies (which read
-//   the throwing `session.ClientCallback`, not `ClientCallbackOrNull`) stop throwing at
-//   the property access and instead call DialogConfirm/DialogSelectionMenu on US.
-//   Reproducing the exact same exception type+message there means Confirm()/StrMenu()
-//   on the `execute` path keep their EXISTING, already-correct, already-loud behaviour
-//   byte-for-byte — this override changes NOTHING observable except Message().
+// WHY THIS IS SAFE TO INSTALL SESSION-WIDE, NOT JUST FOR ALMessage
+//   Installing ClientCallbackOverride makes ClientCallbackOrNull non-null for the WHOLE
+//   session, not only inside ALMessage — so every OTHER Ncl.dll call site that reads
+//   ClientCallbackOrNull/ClientCallback is affected too. Verified by decompiling
+//   Microsoft.Dynamics.Nav.Ncl.dll 28.1 in full (ilspycmd -il on the whole assembly,
+//   every `callvirt ... IClientCallback::<Member>` site traced back to its nearest
+//   preceding getter) rather than assumed. Two shapes exist, and they need DIFFERENT
+//   answers here:
+//
+//   (A) Reached via the THROWING `session.ClientCallback` property (or a decorator
+//       whose own ctor already went through it, e.g. DataItemIteratorClientCallback /
+//       QueryClientCallback) — DialogConfirm, DialogSelectionMenu, DialogOpen/Update/
+//       Close, ProcessServerRequests, ImportDataAction/ExportDataAction,
+//       DownloadFileAction/UploadFileAction/ViewFileAction, FormRun/FormRunModal/
+//       FormClose/FormActivate, CreateDotNetHandle/GetDotNetObject/
+//       InvokeAutomationMethod/DisposeAutomationObject, RequestCredentials,
+//       ClearClientMetadataCache, DialogHyperlink, InvokeTaskPaneAction,
+//       DataSetPageReady, VerifyCallbackAllowed. On the runner (no client, no
+//       override) that property THROWS before any of these are ever reached — with
+//       this override installed it returns US instead, so these members must
+//       reproduce that EXACT exception rather than silently answering something.
+//       They throw NavNCLCallbackNotAllowedException — the identical type+message
+//       `ClientCallback`'s own getter raises — so this class changes NOTHING
+//       observable for any of them.
+//
+//   (B) Reached via a NULL-CHECK on `ClientCallbackOrNull` (never the throwing
+//       property) — WorkDateChanged (NavSession.set_WorkDate — AL `WorkDate := ...`,
+//       extremely common), FeedbackRequested (Base App's in-app-feedback codeunit
+//       2000000021), SendSessionUpdateRequest (NavSessionSettings.SaveSessionSettings),
+//       CompanyInformationChanged (SystemTableTriggers reacting to a Company
+//       display-name write), TokenChangedNotification (Agents.
+//       AgentTaskTableChangeMonitor's background poll). BC's own real behaviour for
+//       ALL of these, with no client, is "do nothing" — a pure best-effort
+//       client-UI-refresh signal with nobody to receive it, same shape as the
+//       existing Batch-5 no-op headless progress dialog
+//       (ALSystemOperatingSystem's neighbouring NavDialog.ALOpenAsync/ALUpdateAsync/
+//       ALClose — see NclCecilRewrite.cs). THROWING here instead — which an earlier
+//       revision of this file did — would be a REAL regression on the `execute` path:
+//       any AL codeunit that sets `WorkDate` (near-universal in BC test setup) would
+//       flip from "ran fine" to "throws", discovered only by a reviewer decompiling
+//       Ncl.dll, not stated here. So these five reproduce the EXACT pre-existing
+//       silent-no-client answer: do nothing, return a default where one is needed.
+//       This is not the silent-fake loud-failures.md forbids — it is the literal,
+//       unconditional real-BC answer for "no client is connected" on a
+//       notification nobody exists to receive; DialogMessage (case (D) below) is
+//       the ONE such site this issue changes on purpose, and it changes it because
+//       the caller of `execute` explicitly wants that text, unlike these five.
+//       NavNotification.ALSend/ALRecall (SendNotification/SendGlobalNotification's
+//       PUBLIC AL-facing entry points) are separately Cecil-owned (NclCecilRewrite.cs,
+//       Batch 8) — their REAL bodies with this same null-check shape are already dead
+//       code on the runner regardless of what this class does, so those two members
+//       are implemented here only to complete the interface, never actually reached.
+//
+//   (C) The `CallbackAllowed` getter (`ClientCallbackOrNull?.IsCallbackAllowed ??
+//       false`) — deliberately answers `true`: the runner IS a UI-capable session
+//       (same reasoning as ALSystemOperatingSystem.get_ALGuiAllowed's own Cecil
+//       rewrite), not a silent default.
+//
+//   (D) DialogMessage — the fix. See below.
 //
 // [Test]-PROCEDURE BEHAVIOUR IS UNCHANGED
 //   Message() called from within a [Test] procedure never reaches this class at all:
@@ -43,16 +90,13 @@ namespace AlRunner.Patches;
 
 public sealed class RunnerClientCallback : IClientCallback
 {
-    // The runner IS a UI-capable session for the same reason
-    // ALSystemOperatingSystem.get_ALGuiAllowed is rewritten to true (see
-    // NclCecilRewrite.cs ~line 1537) — it dispatches UI callbacks itself rather than
-    // delegating to a client window. Nothing on the Message()/Confirm()/StrMenu() path
+    // (C) — see file header. Nothing on the Message()/Confirm()/StrMenu() path
     // consults this getter today; it is answered truthfully rather than defaulted to
     // false in case something else ever does.
     public bool IsCallbackAllowed => true;
 
-    /// <summary>The fix: capture the message and the AL statement that produced it
-    /// instead of the real BC "no client" answer (silently doing nothing). Reads
+    /// <summary>(D) — the fix: capture the message and the AL statement that produced
+    /// it instead of the real BC "no client" answer (silently doing nothing). Reads
     /// AlCurrentStatement, NOT NavSession.CurrentMethodScope — see that class's doc
     /// comment for why the latter does not track a trigger scope like OnRun.</summary>
     public void DialogMessage(string message, Guid automationId)
@@ -71,10 +115,23 @@ public sealed class RunnerClientCallback : IClientCallback
         Infrastructure.AlMessageCapture.Record(message, scopeName, statementId);
     }
 
-    // ── Everything else: reproduce BC's own "no client connected" answer exactly ──
-    // (see the file header — this is NOT a silent fake: it is the identical exception
-    // NavSession.ClientCallback's throwing getter raises today, for callers this
-    // override's mere existence would otherwise divert around that getter.)
+    // ── (B) — reached only via a null-check today; a no-op here is the EXACT real-BC
+    // "no client connected" answer, not a silent fake (see file header, case (B)).
+    public void WorkDateChanged(DateTime workDate) { }
+    public Task FeedbackRequested(FeedbackRequest feedbackRequest) => Task.CompletedTask;
+    public void SendSessionUpdateRequest(SessionSettingsInfo sessionSettingsInfo) { }
+    public void CompanyInformationChanged(CompanyInformationChanges companyInformationChanges) { }
+    public void TokenChangedNotification() { }
+    // NavNotification.ALSend/ALRecall (the only AL-facing entry points to these two)
+    // are Cecil-owned (NclCecilRewrite.cs, Batch 8) — dead code regardless of this
+    // implementation. No-op for the same reason as the rest of case (B), not reached.
+    public void SendNotification(NotificationInfo notification) { }
+    public void SendGlobalNotification(NotificationInfo notification) { }
+
+    // ── (A) — reproduce BC's own "no client connected" answer exactly (see file
+    // header): the identical exception NavSession.ClientCallback's throwing getter
+    // raises today, for callers this override's mere existence would otherwise divert
+    // around that getter.
     public void DialogHyperlink(string hyperlink, Guid automationId) => throw NotAllowed();
     public bool DialogConfirm(string message, bool defaultValue, Guid automationId) => throw NotAllowed();
     public void ProcessServerRequests() => throw NotAllowed();
@@ -99,15 +156,8 @@ public sealed class RunnerClientCallback : IClientCallback
     public void DisposeAutomationObject(int handle, bool suppressDispose) => throw NotAllowed();
     public object InvokeAutomationMethod(InvokeAutomationMethodRequest<object> request) => throw NotAllowed();
     public void ClearClientMetadataCache() => throw NotAllowed();
-    public void SendNotification(NotificationInfo notification) => throw NotAllowed();
-    public void SendGlobalNotification(NotificationInfo notification) => throw NotAllowed();
-    public void SendSessionUpdateRequest(SessionSettingsInfo sessionSettingsInfo) => throw NotAllowed();
-    public void CompanyInformationChanged(CompanyInformationChanges companyInformationChanges) => throw NotAllowed();
-    public void WorkDateChanged(DateTime workDate) => throw NotAllowed();
     public void VerifyCallbackAllowed(NavApplicationObjectBase applicationObject) => throw NotAllowed();
     public Task SendPageBackgroundTaskCompletedNotificationAsync(Guid formHandle, int taskId, string clientActivityId) => throw NotAllowed();
-    public Task FeedbackRequested(FeedbackRequest feedbackRequest) => throw NotAllowed();
-    public void TokenChangedNotification() => throw NotAllowed();
     public Task InvokeTaskPaneAction(InvokeTaskPaneActionArguments arguments) => throw NotAllowed();
 
     private static NavNCLCallbackNotAllowedException NotAllowed() => new();

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -4420,6 +4420,21 @@ int RunServerLoop(System.IO.TextReader input, System.IO.TextWriter output)
         // AlStatementTableTests.CapturedValueStatementId_MatchesStatementTableScopeAndId).
         AlRunner.Infrastructure.AlCoverageTracker.Enabled = req.Coverage == true;
         if (req.Coverage == true) AlRunner.Infrastructure.AlCoverageTracker.Reset();
+        // #2117: Message() output — UNCONDITIONAL, not gated by a request field, matching
+        // ServerProtocol's own long-standing doc comment for `execute`'s `messages`
+        // (`messages|null` was documented before this field was ever populated). Reset
+        // ONCE before the whole (possibly multi-bundle) run so messages from every bundle
+        // land in ONE ordered list — see AlMessageCapture.Reset's doc comment for why
+        // that differs from AlValueCapture's per-bundle scoping. ClientCallbackOverride
+        // is installed on the skeleton session for the SAME reason AlValueCapture.Enabled
+        // /AlCoverageTracker.Enabled are process-global flags reset in `finally` below: a
+        // later request that isn't `execute` (e.g. `runTests`) must never see it — though
+        // in practice nothing on the [Test]-procedure path would ever consult it (see
+        // RunnerClientCallback.cs's header).
+        AlRunner.Infrastructure.AlMessageCapture.Reset();
+        var messageCaptureSession = AlRunner.BcRuntime.SkeletonSession as Microsoft.Dynamics.Nav.Runtime.NavSession;
+        if (messageCaptureSession != null)
+            messageCaptureSession.ClientCallbackOverride = new AlRunner.Patches.RunnerClientCallback();
         try
         {
             var runs = RunAllBundlesForServer(sourcePaths, req.PackagePaths, RunFirstCodeunitOnRun);
@@ -4445,7 +4460,8 @@ int RunServerLoop(System.IO.TextReader input, System.IO.TextWriter output)
                 statementTable = AlRunner.Infrastructure.AlCoverageTracker.CollectStatementTable(covSourceMap);
             }
 
-            return AlRunner.ServerProtocol.Execute(allTests, exitCode, null,
+            return AlRunner.ServerProtocol.Execute(allTests, exitCode,
+                AlRunner.Infrastructure.AlMessageCapture.Snapshot(),
                 allCompileErrors.Count > 0 ? allCompileErrors : null,
                 statementTable: statementTable);
         }
@@ -4453,6 +4469,7 @@ int RunServerLoop(System.IO.TextReader input, System.IO.TextWriter output)
         {
             AlRunner.Infrastructure.AlValueCapture.Enabled = false;
             AlRunner.Infrastructure.AlCoverageTracker.Enabled = false;
+            if (messageCaptureSession != null) messageCaptureSession.ClientCallbackOverride = null;
             // Best-effort cleanup: the scratch dir's contents are fully consumed
             // once RunBundleForServer has emitted+compiled them into an in-memory
             // assembly (or failed trying) — nothing downstream needs the files on

--- a/AlRunner/ServerProtocol.cs
+++ b/AlRunner/ServerProtocol.cs
@@ -31,7 +31,7 @@ namespace AlRunner;
 ///             already finished) at the moment the cancel was processed — the v1
 ///             shape (#1613/#1614), reused verbatim rather than inventing a new one.
 ///   execute : {exitCode, tests:[{name,status,durationMs,message,stackTrace,
-///              capturedValues|omitted}], messages|null, compilationErrors|null,
+///              capturedValues|omitted}], messages|omitted, compilationErrors|null,
 ///              coverage|omitted} —
 ///              single response, not streamed (matches v1: only runTests streams).
 ///              `capturedValues` (#1640) is present per test only when the request
@@ -41,6 +41,21 @@ namespace AlRunner;
 ///              read or its ToString() threw; `value` is null in that case too but
 ///              MUST NOT be read as "genuinely null" — a genuinely null AL variable
 ///              has `captureError` absent.
+///   `messages` (#2117) is the OnRun-driven codeunit's Message() calls, in the order
+///   they were made — UNLIKE `capturedValues`/`coverage` there is no request field
+///   that opts into this: an `execute` call always collects Message() output, so
+///   "omitted" always means "zero messages produced", never "did not collect" (see
+///   AlMessageCapture.Snapshot's doc comment — there is no not-collected state to
+///   distinguish it from). Each entry is {text, scopeName, statementId}; `statementId`
+///   is the SAME id-space `coverage[].statements[].id` / `capturedValues[].statementId`
+///   use for the SAME scope, so a caller (SShadowS/ALchemist#1) can place a message at
+///   the exact AL statement that produced it instead of guessing from a line count —
+///   this matters for a loop, where the same source line calls Message() N times with
+///   N different statement executions but only ONE statement id. A `[Test]` procedure's
+///   Message() calls are UNCHANGED by this: they still raise BC's own "Unhandled UI"
+///   when no [MessageHandler] is declared, exactly as before — see
+///   AlRunner.Patches.RunnerClientCallback's header for why the two paths never
+///   collide, and ServerExecuteMessagesTests for the regression guard.
 ///   `coverage` (#2042, on BOTH `runTests`' summary and `execute`'s response) is
 ///   present only when the request set `coverage:true`: one entry per AL source file,
 ///   {file, statements:[{id, scope, line, column, endLine, endColumn, hits}]}. `id` is
@@ -239,11 +254,13 @@ public static class ServerProtocol
 
     /// <summary>Serialize an execute response (run-mode / inline code). <paramref
     /// name="statementTable"/> — see Summary's doc comment; identical `coverage`
-    /// shape and null-vs-empty convention.</summary>
+    /// shape and null-vs-empty convention. <paramref name="messages"/> (#2117) — see
+    /// this class's top-of-file doc comment for the `messages` shape and why it has
+    /// no request-side opt-in, unlike `coverage`/`capturedValues`.</summary>
     public static string Execute(
         IReadOnlyList<TestResult> tests,
         int exitCode,
-        IReadOnlyList<string>? messages = null,
+        IReadOnlyList<Infrastructure.AlCapturedMessage>? messages = null,
         IReadOnlyList<CompilationErrorGroup>? compilationErrors = null,
         IReadOnlyList<Infrastructure.AlCoverageTracker.AlStatementRecord>? statementTable = null)
     {
@@ -251,7 +268,7 @@ public static class ServerProtocol
         {
             exitCode,
             tests = tests.Select(ToWire),
-            messages = messages is { Count: > 0 } ? messages : null,
+            messages = messages is { Count: > 0 } ? messages.Select(ToWire) : null,
             compilationErrors = compilationErrors is { Count: > 0 }
                 ? compilationErrors.Select(g => new { file = g.File, errors = g.Errors })
                 : null,
@@ -324,5 +341,14 @@ public static class ServerProtocol
         value = v.Value,
         statementId = v.StatementId,
         captureError = v.CaptureError,
+    };
+
+    // One Message() call on the wire (#2117) — see the class doc comment for `execute`'s
+    // `messages` shape and the id-space `statementId` shares with `capturedValues`/`coverage`.
+    private static object ToWire(Infrastructure.AlCapturedMessage m) => new
+    {
+        text = m.Text,
+        scopeName = m.ScopeName,
+        statementId = m.StatementId,
     };
 }


### PR DESCRIPTION
Closes #2117

## What was broken

`--server` `execute` (run-mode `OnRun` invocation) called into BC's real
`NavDialog.ALMessage`, whose body is:

```
if (!session.TestExecution.TestHandleMessage(message2))
    session.ClientCallbackOrNull?.DialogMessage(message2, automationId);
```

`TestHandleMessage` only resolves a `[MessageHandler]` (or raises BC's own
"Unhandled UI") while a `[Test]` procedure is executing — `executingTestMethod`
is null on the `execute`/`OnRun` path, so it quietly returns `false` without
throwing. `ClientCallbackOrNull` is also null (the runner has no client), so
the `?.` swallows the call outright: no dispatch, no exception, nothing on the
wire.

Confirmed by decompiling `Microsoft.Dynamics.Nav.Ncl.dll` (28.1) — `ALConfirm`
and `ALStrMenu` do **not** have this hole: their bodies read the
non-null-conditional `session.ClientCallback`, which throws
`NavNCLCallbackNotAllowedException` when there's no client. Already loud, not
part of this fix. `Error()` isn't part of this dispatch machinery at all — it
throws directly regardless of handler state.

## Fix

- `AlRunner/Patches/RunnerClientCallback.cs` — a new `IClientCallback`
  implementation installed on `NavSession.ClientCallbackOverride` (a plain,
  public, BC-provided extension point) for the duration of an `execute` call.
  `DialogMessage` captures the message; every other member reproduces BC's own
  real "no client connected" answer for that specific call shape (see the
  "Session-wide side effects" section below) — this override changes nothing
  observable except `Message()`.
- `AlRunner/Infrastructure/AlMessageCapture.cs` — collects captured messages in
  call order across a (possibly multi-bundle) `execute` request.
- `AlRunner/Infrastructure/AlCurrentStatement.cs` — tracks "which AL statement
  is executing right now", fed off the existing `StmtHit` hook
  (`AlCoverageTracker.OnStmtHit`, now unconditional rather than gated by
  `coverage:true`). `NavSession.CurrentMethodScope` turned out **not** to track
  a trigger scope like `OnRun` — confirmed empirically via a debug probe, not
  assumed — so `statementId` reuses the same id-space the `#2042` statement
  table already established instead of inventing a second one.
- `AlRunner/ServerProtocol.cs` — `execute`'s `messages` field (previously
  documented in a comment but never populated) now carries
  `[{text, scopeName, statementId}]`. No request-side opt-in, unlike
  `coverage`/`capturedValues`: an `execute` call always collects, so "omitted"
  always means "zero messages produced," never "did not collect."

`[Test]`-procedure `Message()` behavior is untouched: `TestHandleMessage`
resolves (or raises "Unhandled UI") strictly before `ALMessage` ever consults
`ClientCallbackOrNull`, so this override is never reached from that path.

## Session-wide side effects of installing `ClientCallbackOverride` (reviewed, not assumed)

Installing the override makes `NavSession.ClientCallbackOrNull` non-null for
the **whole session**, not only inside `ALMessage` — every other Ncl.dll call
site that reads it is affected too. Verified by decompiling the whole of
`Microsoft.Dynamics.Nav.Ncl.dll` 28.1 (`ilspycmd -il` on the full assembly) and
tracing every `callvirt ... IClientCallback::<Member>` site back to its nearest
preceding getter, rather than reasoning about it. Two shapes exist:

- **Reached via the throwing `session.ClientCallback` property** (or a
  decorator whose own constructor already went through it) —
  `DialogConfirm`, `DialogSelectionMenu`, `DialogOpen/Update/Close`,
  `ProcessServerRequests`, `ImportDataAction`/`ExportDataAction`,
  `DownloadFileAction`/`UploadFileAction`/`ViewFileAction`,
  `FormRun`/`FormRunModal`/`FormClose`/`FormActivate`,
  `CreateDotNetHandle`/`GetDotNetObject`/`InvokeAutomationMethod`/`DisposeAutomationObject`,
  `RequestCredentials`, `ClearClientMetadataCache`, `DialogHyperlink`,
  `InvokeTaskPaneAction`, `DataSetPageReady`, `VerifyCallbackAllowed`. These
  throw `NavNCLCallbackNotAllowedException` — the exact exception the throwing
  property itself raises today — so nothing changes for any of them.
- **Reached only via a null-check on `ClientCallbackOrNull`, never the
  throwing property** — `WorkDateChanged` (`NavSession.set_WorkDate`, i.e.
  AL's `WorkDate := ...`, near-universal in BC test setup),
  `FeedbackRequested` (Base App's in-app-feedback codeunit 2000000021),
  `SendSessionUpdateRequest` (`NavSessionSettings.SaveSessionSettings`),
  `CompanyInformationChanged` (a `Company Information` display-name write
  trigger), `TokenChangedNotification` (Agents background poll). BC's real
  behavior for **all** of these with no client is "do nothing" — a pure
  best-effort client-UI-refresh signal with nobody to receive it, the same
  shape as the existing headless progress-dialog no-op
  (`NavDialog.ALOpenAsync`/`ALUpdateAsync`/`ALClose`). **An earlier revision of
  this PR made these throw too, which would have broken every `execute` call
  whose AL sets `WorkDate`** — caught locally via the decompile enumeration
  above and fixed before this became someone else's bug report; pinned by
  `Execute_SetsWorkDate_DoesNotThrow_AndNewValueIsObservable`, which fails
  (RED) against the throw-everything revision and passes against the current
  one.
- `CallbackAllowed`'s own getter deliberately answers `true` (the runner IS a
  UI-capable session, same reasoning as `ALGuiAllowed`'s existing rewrite).

## Tests (`AlRunner.Tests/ServerExecuteMessagesTests.cs`)

- `Execute_MessageInLoop_ReturnsMessagesInCallOrder` — the issue's own
  reproducer (loop calling `Message()` 3x + one more call); asserts the exact
  4 strings in order.
- `Execute_MessageInLoop_StatementIdDistinguishesLoopFromFinalCall` — asserts
  the 3 loop calls share one `statementId` (same AL statement, 3 executions)
  while the trailing call has a different one, cross-referenced against
  `coverage`'s own decoded line/hit-count for both ids — not just "the ids
  differ."
- `Execute_NoMessageCalls_MessagesFieldAbsent` — negative: `messages` must be
  absent, not an empty array, when nothing was called.
- `RunTests_MessageWithoutHandler_StillRaisesUnhandledUI` — the regression
  guard: a `[Test]` procedure's unhandled `Message()` still fails with
  "Unhandled UI", run via `runTests` (not `execute`).
- `Execute_ConfirmWithoutHandler_StillThrowsCallbackNotAllowed_NotSwallowed` —
  pins the Confirm()/StrMenu() finding rather than leaving it as an unverified
  claim.
- `Execute_SetsWorkDate_DoesNotThrow_AndNewValueIsObservable` — pins the
  session-wide-side-effect finding above: `WorkDate := ...` must not throw,
  and the assigned value must round-trip through the now-fixed `Message()`
  capture.

RED confirmed for the whole suite by temporarily reverting the fix files and
re-running: only the `messages`-presence tests failed pre-fix; the
already-correct-behavior tests (Confirm, `[Test]` Unhandled UI) passed even
pre-fix. RED/GREEN confirmed separately for the `WorkDate` finding against the
intermediate throw-everything revision.

## Local verification

- `dotnet build AlRunner.slnx -c Release` — 0 errors.
- `dotnet test AlRunner.Tests -c Release --filter "FullyQualifiedName~ServerExecuteMessagesTests"` — 6/6 pass.
- `dotnet test AlRunner.Tests -c Release --filter "FullyQualifiedName~AlStatementTableTests|FullyQualifiedName~ServerTests"` — 33/33 pass (covers the shared `AlCoverageTracker.OnStmtHit` hook, including the DAP breakpoint suites that also depend on it).
- `dotnet test AlRunner.Tests -c Release --filter "FullyQualifiedName~TestArtifactsGateTests|FullyQualifiedName~CliDocumentationTests"` — 36/36 pass.