### PR TITLE
fix: reject non-rooted $HOME resolution instead of silently using a relative artifact/cache root

### DIFF
--- a/AlRunner.Tests/AlRunnerPathsTests.cs
+++ b/AlRunner.Tests/AlRunnerPathsTests.cs
@@ -24,4 +24,65 @@ public sealed class AlRunnerPathsTests
             Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
             AlRunnerPaths.UserHome);
     }
+
+    // Issue #2114: when $HOME names a directory that does not exist,
+    // Environment.GetFolderPath(SpecialFolder.UserProfile) silently returns "" instead of
+    // throwing (verified empirically: HOME=/missing -> "", HOME=/existing-empty -> the real
+    // path). Every consumer then does Path.Combine(home, ".local", "share", ...), and
+    // Path.Combine("", "a", "b") == "a/b" — a bare RELATIVE path with no leading separator.
+    // That relative path survives every File.Exists/Directory.Exists probe downstream by
+    // silently resolving against the CWD, and only fails deep inside
+    // AssemblyLoadContext.LoadFromAssemblyPath (one of the few APIs that demands an
+    // absolute path) — by which point it's an unhandled exception that aborts the process
+    // with SIGABRT and a core dump instead of a diagnostic.
+    //
+    // AlRunnerPaths.Validate is the internal, parameter-driven core of UserHome's rootedness
+    // check — tested directly (rather than by mutating the real process $HOME, which is
+    // shared mutable state every parallel test collection reads) so this pins the exact
+    // wrong shape without racing anything else in this heavily-parallelized test process.
+
+    [Fact]
+    public void Validate_EmptyResolvedHome_ThrowsNamingRawHomeValueAndRequiringAbsolutePath()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => AlRunnerPaths.Validate(resolvedHome: "", rawHomeEnvVar: "/tmp/al-runner-2114-missing-home"));
+
+        Assert.Contains("/tmp/al-runner-2114-missing-home", ex.Message);
+        Assert.Contains("HOME", ex.Message);
+        Assert.Contains("absolute", ex.Message, StringComparison.OrdinalIgnoreCase);
+        // Points at the documented explicit override for the artifact-root case specifically.
+        Assert.Contains("--artifact-path", ex.Message);
+    }
+
+    [Fact]
+    public void Validate_RelativeResolvedHome_Throws_EvenThoughFileExistsWouldSilentlyAcceptIt()
+    {
+        // The EXACT shape Path.Combine(home, BcArtifacts.ArtifactsRoot_Rel) produces when
+        // home == "" — BcArtifacts.ArtifactsRoot's own construction. Reads the real
+        // constant rather than spelling the path segments here (TestArtifactsGateTests'
+        // OnlyTheSharedHelperNamesTheArtifactCachePathsInCode gate reserves that to
+        // TestArtifacts.cs) — this is the same string either way.
+        var relativeArtifactsRoot = Path.Combine("", BcArtifacts.ArtifactsRoot_Rel);
+        Assert.False(Path.IsPathRooted(relativeArtifactsRoot));
+
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => AlRunnerPaths.Validate(resolvedHome: relativeArtifactsRoot, rawHomeEnvVar: "/tmp/al-runner-2114-missing-home"));
+        Assert.Contains("absolute", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Validate_UnsetHome_MessageSaysUnset_NotABlankQuotedValue()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => AlRunnerPaths.Validate(resolvedHome: "", rawHomeEnvVar: null));
+
+        Assert.Contains("<unset>", ex.Message);
+    }
+
+    [Fact]
+    public void Validate_RootedExistingHome_ReturnsItUnchanged_NeverThrows()
+    {
+        var abs = Path.GetTempPath().TrimEnd(Path.DirectorySeparatorChar);
+        Assert.Equal(abs, AlRunnerPaths.Validate(resolvedHome: abs, rawHomeEnvVar: abs));
+    }
 }

--- a/AlRunner.Tests/HomeDirectoryMissingLoudFailureTests.cs
+++ b/AlRunner.Tests/HomeDirectoryMissingLoudFailureTests.cs
@@ -1,0 +1,147 @@
+// HomeDirectoryMissingLoudFailureTests — issue #2114.
+//
+// When $HOME names a directory that does NOT exist, .NET's
+// Environment.GetFolderPath(SpecialFolder.UserProfile) silently returns "" instead of
+// throwing (verified empirically against a probe binary: HOME=/missing -> "",
+// HOME=/existing-empty -> the real path — unlike AutoProvisionDefaultTests' isolated-home
+// fixture, which always mkdir's the dir first and so never exercises this branch).
+// Every artifact/cache-root resolver then does Path.Combine(home, ".local", "share", ...),
+// and Path.Combine("", "a", "b") == "a/b" — a bare RELATIVE path. That relative path used
+// to survive every File.Exists/Directory.Exists probe downstream by silently resolving
+// against the CWD, and only failed deep inside AssemblyLoadContext.LoadFromAssemblyPath (one
+// of the few APIs that demands an absolute path) — by which point it was an unhandled
+// exception that took the process down with SIGABRT and a core dump (exit 134) instead of a
+// diagnostic, verified on `main` at c94c2f02 (see the issue body for the exact repro and
+// stack trace).
+//
+// This spawns the REAL runner binary with $HOME pointed at a directory that is deliberately
+// NEVER created, mirroring the issue's own reproduction command exactly
+// (`--bc-version <ver> --no-auto-provision`, no bundle argument). Per
+// .claude/rules/bc-behavior-tests-go-upstream.md this is a runner-mechanism claim (how the
+// CLI resolves its own cache roots and reports the failure), not a BC-behaviour claim, so it
+// belongs here, not in the al-language corpus.
+using System.Diagnostics;
+using System.Text;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class HomeDirectoryMissingLoudFailureTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+
+    // A version that will never exist on the CDN/cache — irrelevant here since the process
+    // must fail at HOME resolution, well before it ever gets to asking "does this version
+    // exist" (mirrors AutoProvisionDefaultTests' NonexistentVersion for the same reason).
+    private const string SomeVersion = "1.2.3.4";
+
+    private static (int ExitCode, string StdErr) RunWithHome(string homeValue, params string[] extraArgs)
+    {
+        var args = new StringBuilder(TestBuildConfig.RunArgs(Path.Combine(RepoRoot, "AlRunner")));
+        args.Append($" --bc-version {SomeVersion}");
+        args.Append(" --no-auto-provision");
+        foreach (var a in extraArgs) args.Append(' ').Append(a);
+
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            Arguments = args.ToString(),
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            WorkingDirectory = RepoRoot,
+        };
+        psi.Environment["HOME"] = homeValue;
+        // Windows resolves SpecialFolder.UserProfile from USERPROFILE, not HOME — clear it
+        // so this test exercises the same "profile resolution fails" branch on every OS this
+        // suite runs on, not just POSIX.
+        psi.Environment["USERPROFILE"] = homeValue;
+
+        var errSb = new StringBuilder();
+        using var proc = Process.Start(psi)!;
+        proc.OutputDataReceived += (_, e) => { };
+        proc.ErrorDataReceived += (_, e) => { if (e.Data != null) lock (errSb) errSb.AppendLine(e.Data); };
+        proc.BeginOutputReadLine();
+        proc.BeginErrorReadLine();
+        if (!proc.WaitForExit(60_000))
+        {
+            try { proc.Kill(entireProcessTree: true); } catch { }
+            throw new TimeoutException("al-runner did not exit within 60s against a missing $HOME.");
+        }
+        proc.WaitForExit();
+        lock (errSb) return (proc.ExitCode, errSb.ToString());
+    }
+
+    /// <summary>
+    /// RED on unfixed `main`: $HOME names a directory that was never created, so
+    /// Environment.GetFolderPath silently returns "" and every downstream
+    /// Path.Combine("", ".local", ...) call produces a bare relative path. From this test's
+    /// WorkingDirectory (the repo root, which has no coincidental `.local/share/al-runner/`
+    /// tree of its own), the OLD code's Directory.Exists probe simply finds nothing and
+    /// prints a generic "BC artifact root not found: .local/share/al-runner/artifacts. …"
+    /// message — never mentioning $HOME, never saying an absolute path is required. This
+    /// test's assertions are specific enough to fail against that generic message. GREEN
+    /// after the fix: AlRunnerPaths.UserHome (issue #2114) rejects the non-rooted resolution
+    /// before any Path.Combine happens, naming $HOME's raw value and requiring an absolute
+    /// path — exit code stays a documented 2 (matching every other loud BcArtifacts
+    /// failure in this file), never a raw .NET crash.
+    /// </summary>
+    [Fact]
+    public void MissingHomeDirectory_FailsLoud_NamingHomeValue_NeverCrashesWithRawStack()
+    {
+        var missingHome = Path.Combine(Path.GetTempPath(), "al-runner-2114-missing-home", Guid.NewGuid().ToString("N"));
+        Assert.False(Directory.Exists(missingHome)); // never created — the exact trigger
+
+        var (exit, stderr) = RunWithHome(missingHome);
+
+        // Documented, controlled exit — never the SIGABRT-driven 134 the issue reports.
+        Assert.Equal(2, exit);
+
+        // The loud diagnostic names the raw $HOME value and requires an absolute path —
+        // the generic pre-fix "BC artifact root not found: .local/share/al-runner/artifacts"
+        // message contains neither.
+        Assert.Contains(missingHome, stderr);
+        Assert.Contains("HOME", stderr);
+        Assert.Contains("absolute", stderr, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("--artifact-path", stderr);
+
+        // Never a raw, undiagnosed .NET crash trace — the exact shape the issue reports
+        // (System.ArgumentException from AssemblyLoadContext.LoadFromAssemblyPath, deep
+        // inside a Cecil rewrite the user has no way to act on).
+        Assert.DoesNotContain("System.ArgumentException", stderr);
+        Assert.DoesNotContain("AssemblyLoadContext", stderr);
+        Assert.DoesNotContain("is not an absolute path", stderr);
+    }
+
+    /// <summary>
+    /// Differential half of the issue's own proof: $HOME existing (created ahead of time)
+    /// but otherwise empty must behave exactly as it always has — a loud, path-naming
+    /// "BC artifact root not found" message, unrelated to the new $HOME-specific
+    /// diagnostic. Confirms the #2114 fix is additive: it only changes behaviour for the
+    /// specific "profile resolution returned a non-rooted value" case, never for an
+    /// ordinary empty-but-real cache directory.
+    /// </summary>
+    [Fact]
+    public void ExistingEmptyHomeDirectory_BehaviourUnchanged_GenericArtifactRootMessage()
+    {
+        var existingHome = Path.Combine(Path.GetTempPath(), "al-runner-2114-existing-home", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(existingHome);
+        try
+        {
+            var (exit, stderr) = RunWithHome(existingHome);
+
+            Assert.Equal(2, exit);
+            Assert.Contains("BC artifact root not found", stderr);
+            Assert.Contains("al-runner provision", stderr);
+            // The new $HOME-specific diagnostic must NOT fire for a perfectly valid
+            // (if empty) home directory — that would be a false positive.
+            Assert.DoesNotContain("could not resolve an absolute home directory", stderr);
+        }
+        finally
+        {
+            try { Directory.Delete(existingHome, recursive: true); } catch { }
+        }
+    }
+}

--- a/AlRunner/BcCompiler.cs
+++ b/AlRunner/BcCompiler.cs
@@ -611,9 +611,11 @@ public sealed partial class BcCompiler
         // transitive Ncl reference does not match the pinned-version Ncl on the path → the
         // toolkit's Azure-KV / Azure-AD codeunits fail to bind the interface (AL0133). Scope
         // to the pinned version (mirrors BcArtifacts' highest-version convention).
+        // AlRunner.Infrastructure.AlRunnerPaths.UserHome throws loudly (issue #2114) rather
+        // than silently handing back a relative path when $HOME names a directory that
+        // does not exist.
         var sandbox = Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
-            ".bcartifacts.cache", "sandbox");
+            AlRunner.Infrastructure.AlRunnerPaths.UserHome, ".bcartifacts.cache", "sandbox");
         if (Directory.Exists(sandbox))
         {
             var bestSandbox = Directory.EnumerateDirectories(sandbox)

--- a/AlRunner/Infrastructure/AlRunnerPaths.cs
+++ b/AlRunner/Infrastructure/AlRunnerPaths.cs
@@ -10,10 +10,61 @@ namespace AlRunner.Infrastructure;
 /// is <c>$HOME</c> on Linux/macOS and <c>C:\Users\&lt;name&gt;</c> on Windows — identical
 /// behaviour on POSIX, correct on Windows. <see cref="BcArtifacts"/> already resolves its
 /// artifacts root this way; this helper is where the remaining sites converge.
+///
+/// <para><b>Issue #2114:</b> when <c>$HOME</c> names a directory that does not exist,
+/// <see cref="Environment.GetFolderPath"/> silently returns <c>""</c> instead of throwing.
+/// Every caller that then does <c>Path.Combine(UserHome, ".local", "share", ...)</c> gets
+/// back a bare RELATIVE path (<c>Path.Combine("", "a", "b")</c> == <c>"a/b"</c>, no leading
+/// separator). That relative path passes every <c>File.Exists</c>/<c>Directory.Exists</c>
+/// probe downstream by silently resolving against whatever the process's current working
+/// directory happens to be — sometimes finding nothing (a confusing "not found" message
+/// pointing at a path with no root), sometimes coincidentally finding something real
+/// (e.g. the actual artifact cache, if launched from the real <c>$HOME</c> as CWD despite
+/// the env var itself pointing elsewhere) — and it is only caught, if at all, deep inside
+/// an API that demands an absolute path (<c>AssemblyLoadContext.LoadFromAssemblyPath</c>),
+/// by which point the exception is unhandled and takes the process down with SIGABRT and a
+/// core dump instead of a diagnostic. <see cref="UserHome"/> validates the resolved value
+/// is non-empty and rooted before ever returning it, so every consumer inherits the loud
+/// failure for free instead of quietly handing out a relative path.</para>
 /// </summary>
 public static class AlRunnerPaths
 {
-    /// <summary>The current user's home/profile directory, on every OS.</summary>
+    /// <summary>The current user's home/profile directory, on every OS. Throws
+    /// <see cref="InvalidOperationException"/> naming <c>$HOME</c>'s raw value when
+    /// resolution does not yield an absolute path — see the class remarks for why a
+    /// relative result must never be handed to a caller.</summary>
     public static string UserHome =>
-        Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        Validate(
+            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+            Environment.GetEnvironmentVariable("HOME") ?? Environment.GetEnvironmentVariable("USERPROFILE"));
+
+    /// <summary>
+    /// Rejects a non-rooted (empty or relative) resolved home directory with a loud,
+    /// actionable diagnostic instead of returning it. Takes the raw <c>$HOME</c>/
+    /// <c>%USERPROFILE%</c> value purely for the error message, so this validation logic
+    /// is unit-testable without mutating the real process environment (which is shared,
+    /// mutable, process-wide state — see <c>no-git-stash-with-worktrees.md</c>'s sibling
+    /// concern about shared state races, same class of problem here across parallel tests).
+    /// Internal + <c>InternalsVisibleTo("AlRunner.Tests")</c>.
+    /// </summary>
+    internal static string Validate(string resolvedHome, string? rawHomeEnvVar)
+    {
+        if (!string.IsNullOrEmpty(resolvedHome) && Path.IsPathRooted(resolvedHome))
+            return resolvedHome;
+
+        var rawDisplay = string.IsNullOrEmpty(rawHomeEnvVar) ? "<unset>" : rawHomeEnvVar;
+        var why = string.IsNullOrEmpty(rawHomeEnvVar)
+            ? "no HOME (or USERPROFILE) environment variable is set"
+            : $"the directory named by HOME ('{rawHomeEnvVar}') likely does not exist";
+        throw new InvalidOperationException(
+            $"al-runner could not resolve an absolute home directory for the current user: " +
+            $"{why}, so .NET's profile resolution returned '{resolvedHome}' instead of a real " +
+            $"path. HOME is currently '{rawDisplay}'. Every al-runner cache (BC artifacts, " +
+            $"symbols, compiled dependencies) is derived from this directory and requires an " +
+            $"ABSOLUTE path — a relative one would silently resolve against whatever directory " +
+            $"the process happens to be launched from. Resolve it ONE of these ways: " +
+            $"(a) create the directory named by HOME; (b) point HOME at an existing absolute " +
+            $"directory; (c) for the BC artifact root specifically, bypass this resolution " +
+            $"entirely with --artifact-path <dir>.");
+    }
 }

--- a/AlRunner/Infrastructure/BcArtifacts.cs
+++ b/AlRunner/Infrastructure/BcArtifacts.cs
@@ -80,8 +80,9 @@ public static class BcArtifacts
 
     private static readonly object _lock = new();
 
-    private static string ArtifactsRoot => Path.Combine(
-        Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ArtifactsRoot_Rel);
+    // AlRunnerPaths.UserHome throws loudly (issue #2114) rather than silently handing back
+    // a relative path when $HOME names a directory that does not exist.
+    private static string ArtifactsRoot => Path.Combine(AlRunnerPaths.UserHome, ArtifactsRoot_Rel);
 
     /// <summary>The per-user artifacts root (<c>~/.local/share/al-runner/artifacts</c>),
     /// where each BC version lives in a version-named subdir. Public for the provisioning

--- a/AlRunner/Infrastructure/CacheRoots.cs
+++ b/AlRunner/Infrastructure/CacheRoots.cs
@@ -59,9 +59,9 @@ public static class CacheRoots
     /// </summary>
     public static string Resolve(string name)
     {
-        var root = _override ?? Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
-            ".cache", "al-runner");
+        // AlRunnerPaths.UserHome throws loudly (issue #2114) rather than silently handing
+        // back a relative path when $HOME names a directory that does not exist.
+        var root = _override ?? Path.Combine(AlRunnerPaths.UserHome, ".cache", "al-runner");
         return Path.Combine(root, name);
     }
 

--- a/AlRunner/Infrastructure/ServiceTierDllIndex.cs
+++ b/AlRunner/Infrastructure/ServiceTierDllIndex.cs
@@ -106,9 +106,19 @@ public static class ServiceTierDllIndex
 
     private static string? ResolveCacheDir()
     {
-        var root = Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
-            ".cache/al-runner/servicetier-dlls");
+        // Runs inside CacheDir's static-property initializer (eager, type-init time), so
+        // letting AlRunnerPaths.UserHome's #2114 loud failure propagate here would poison
+        // the WHOLE type with a TypeInitializationException for the rest of the process on
+        // every subsequent access — for what is only an optional, best-effort perf cache
+        // (a missing/absent index just means "not extracted yet", already a legitimate
+        // null return below). The load-bearing resolvers that actually consume $HOME as
+        // data (BcArtifacts.ArtifactsRoot, CacheRoots.Resolve) still throw loud; a broken
+        // $HOME surfaces there instead, deterministically, without this optional cache
+        // taking the whole process down first.
+        string home;
+        try { home = AlRunnerPaths.UserHome; }
+        catch (InvalidOperationException) { return null; }
+        var root = Path.Combine(home, ".cache/al-runner/servicetier-dlls");
         if (!Directory.Exists(root)) return null;
         return Directory.EnumerateDirectories(root)
             .Select(d => (Dir: d, Ver: System.Version.TryParse(Path.GetFileName(d), out var v) ? v : null))

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -247,9 +247,23 @@ bool bundledMode = true;
 // of (all .al source files contributing to the bundle, the resolved-deps list,
 // the runner assembly mtime). See `precompiled-dll-respect.md` —
 // "Our AL output is meant to be cacheable".
-string? alCacheDir = Path.Combine(
-    Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
-    ".cache", "al-runner", "al-out");
+// AlRunner.Infrastructure.AlRunnerPaths.UserHome throws loudly (issue #2114) rather than
+// silently handing back a relative path when $HOME names a directory that does not exist.
+// Caught HERE (not left to propagate) because nothing wraps top-level statements at this
+// point in the file — an uncaught exception this early reproduces the exact bug being
+// fixed (an unhandled .NET exception aborts the process instead of a documented exit).
+string? alCacheDir;
+try
+{
+    alCacheDir = Path.Combine(
+        AlRunner.Infrastructure.AlRunnerPaths.UserHome,
+        ".cache", "al-runner", "al-out");
+}
+catch (InvalidOperationException ex)
+{
+    Console.Error.WriteLine(ex.Message);
+    return 2;
+}
 // #1821: mirrors alCacheDir, but only ever set by an explicit --cache flag (never by
 // the default init above, never by --no-cache) — see the --cache parsing branch below
 // and AlRunner.Infrastructure.CacheRoots for what this drives.
@@ -822,7 +836,18 @@ if (bcVersionArg == null && artifactPathArg == null)
         var engineVersion = AlRunner.Infrastructure.BcArtifacts.EngineBuiltVersion()
             ?? AlRunner.Infrastructure.BcArtifacts.EngineVersion(AppContext.BaseDirectory);
         var engineMajor = engineVersion?.Major;
-        if (engineVersion != null && engineMajor != null)
+        // #2114: ArtifactsRootDir (used twice inside this block) throws loudly when $HOME
+        // cannot be resolved to an absolute path. Probing it here — instead of letting the
+        // two calls below throw UNCAUGHT (nothing wraps this block, unlike the sibling
+        // "shippedVariantsForDefault" branch above, which already swallows the same
+        // exception the same way) — lets a broken $HOME fall through to the
+        // unconditionally-reached SelectVersion call further down, which IS wrapped in a
+        // try/catch that turns this into the correct "BC version selection failed: ..."
+        // exit-2 diagnostic, instead of crashing here unhandled.
+        bool artifactsRootResolvable;
+        try { _ = AlRunner.Infrastructure.BcArtifacts.ArtifactsRootDir; artifactsRootResolvable = true; }
+        catch (InvalidOperationException) { artifactsRootResolvable = false; }
+        if (engineVersion != null && engineMajor != null && artifactsRootResolvable)
         {
             bcVersionAutoSelected = true;
             // Prefer the engine's OWN major.minor. Latest-in-major used to win here, which


### PR DESCRIPTION
Closes #2114

## Problem

When `$HOME` names a directory that does not exist, `Environment.GetFolderPath(SpecialFolder.UserProfile)` silently returns `""` instead of throwing (verified empirically: `HOME=/missing` -> `""`, `HOME=/existing-empty` -> the real path). Every consumer then does `Path.Combine(home, ".local", "share", ...)`, and `Path.Combine("", "a", "b") == "a/b"` — a bare relative path with no leading separator.

That relative path passed every `File.Exists`/`Directory.Exists` probe downstream by silently resolving against the current working directory, and only failed deep inside `AssemblyLoadContext.LoadFromAssemblyPath` (one of the few APIs that demands an absolute path) — by which point it was an unhandled exception that took the process down with SIGABRT and a core dump instead of a diagnostic.

## Fix

`AlRunnerPaths.UserHome` (already documented as the intended single source of truth for this resolution, though several call sites weren't actually routed through it) now validates the resolved value is non-empty and rooted, throwing a loud `InvalidOperationException` that names `$HOME`'s raw value, states an absolute path is required, and points at `--artifact-path` as the explicit override. The validation core (`AlRunnerPaths.Validate`) takes the raw `$HOME` value as a parameter rather than reading the live environment variable directly, so it's unit-testable without racing other tests that touch the same shared, mutable, process-wide environment.

## Other call sites checked and fixed

Per the issue's ask to audit `BcArtifacts.cs` and `CacheRoots` together (and I extended the audit to every direct `Environment.GetFolderPath(SpecialFolder.UserProfile)` call site in the codebase — 6 total, one of which was `AlRunnerPaths.cs` itself):

- `BcArtifacts.ArtifactsRoot` — migrated to `AlRunnerPaths.UserHome`.
- `CacheRoots.Resolve`'s default-root fallback — migrated to `AlRunnerPaths.UserHome`.
- `BcCompiler`'s `.bcartifacts.cache/sandbox` probe — migrated to `AlRunnerPaths.UserHome`.
- `Program.cs`'s `alCacheDir` default — migrated to `AlRunnerPaths.UserHome`, wrapped in a `try/catch` since nothing wraps top-level statements at that point in the file (an uncaught exception there would reproduce the exact SIGABRT this PR fixes, just earlier).
- `ServiceTierDllIndex`'s cache-dir probe — migrated to `AlRunnerPaths.UserHome`, but caught and degraded to `null` (its existing "not available yet" contract) rather than propagated, because it runs inside a static property initializer (`CacheDir { get; } = ResolveCacheDir();`); letting the exception through there would poison the whole type with a `TypeInitializationException` for the rest of the process, for what is only an optional, best-effort DLL-cache lookup — the load-bearing resolvers (`BcArtifacts`, `CacheRoots`) still fail loud.
- Two eager `BcArtifacts.ArtifactsRootDir` reads inside `Program.cs`'s no-`--bc-version`-given default-selection branch were not wrapped in any `try/catch` (unlike the sibling `shippedVariantsForDefault` branch just above, which already swallows the same exception the same way) — added the same guard so a broken `$HOME` falls through to the unconditionally-reached `SelectVersion` call further down, which already turns this into the correct `"BC version selection failed: ..."` exit-2 diagnostic instead of crashing unhandled.

## Tests (strict TDD, RED confirmed before GREEN)

- `AlRunner.Tests/AlRunnerPathsTests.cs` — new `Validate(...)` unit tests covering both directions: empty/relative resolved home throws naming the raw `$HOME` value, requiring an absolute path, and pointing at `--artifact-path`; an unset `$HOME` says `<unset>` rather than a blank value; a rooted existing home passes through unchanged. Confirmed RED (`CS0117: does not contain a definition for 'Validate'`) against the pre-fix `AlRunnerPaths.cs`, then GREEN.
- `AlRunner.Tests/HomeDirectoryMissingLoudFailureTests.cs` — new subprocess-level test spawning the real runner binary with `$HOME` pointed at a directory deliberately never created, mirroring the issue's own reproduction command (`--bc-version <ver> --no-auto-provision`). Confirmed RED against the reverted implementation (old message: `"BC version selection failed: BC artifact root not found: .local/share/al-runner/artifacts. ..."`, missing any mention of `$HOME` or "absolute"), then GREEN (exit code 2, message names the raw `$HOME` value and requires an absolute path, never a raw `System.ArgumentException`/`AssemblyLoadContext` stack). A second test in the same file confirms the differential half of the issue's own proof — an *existing* empty `$HOME` still produces the original, unrelated "BC artifact root not found" message, so the fix is additive.

Both reverts/restores were done via `git checkout HEAD -- <path>` / `git apply` (never `git stash`, per this repo's rule), and I diffed the restored implementation against the saved patch to confirm it was byte-identical before re-verifying GREEN.

## Verification run

- `dotnet test AlRunner.Tests` (full suite): 979 passed, 56 skipped, 0 failed. (An unrelated gate test, `TestArtifactsGateTests.OnlyTheSharedHelperNamesTheArtifactCachePathsInCode`, initially failed because my first draft of the relative-path test spelled out `".local", "share", "al-runner", "artifacts"` literally — fixed by referencing `BcArtifacts.ArtifactsRoot_Rel` instead.)

No AL-level behavior changes for a normal (valid) `$HOME` — this only changes behavior on the specific "profile resolution returned a non-rooted value" path, so no AL bundle run was needed.