### PR TITLE
fix(help): describe execute for what it does, add --dap to USAGE, drop stale debug-adapter TODO

### DIFF
--- a/AlRunner.Tests/CliDocumentationTests.cs
+++ b/AlRunner.Tests/CliDocumentationTests.cs
@@ -138,6 +138,71 @@ public sealed class CliDocumentationTests
     }
 
     /// <summary>
+    /// --help is user-facing documentation, not a source-comment scratchpad. A flag
+    /// whose behavior --help calls "TODO" is either not shipped (and must not claim
+    /// otherwise) or is shipped and the text just never got updated — issue #2118:
+    /// `--server`'s `execute` command shipped and returns real results (tests,
+    /// `capturedValues`, `coverage`, and — as of #2117/#2120 — `messages`), but
+    /// --help still read "Commands: runTests, shutdown (execute: TODO)" for multiple
+    /// releases of the thing it describes. Neither the flag-name scrape
+    /// (<see cref="Help_DocumentsEveryRecognizedFlag"/>) nor the "not listed as
+    /// unimplemented" check (<see cref="Help_DoesNotListImplementedFlagsAsUnimplemented"/>)
+    /// would have caught this: `execute` is not a `--flag`, and the stale text lived
+    /// under EXECUTION, not under "NOT YET IMPLEMENTED". A blanket "no literal TODO"
+    /// guard catches this whole class without needing to know which command it names.
+    /// </summary>
+    [Fact]
+    public void Help_NeverMarksAShippedCommandAsTodo()
+    {
+        var (_, help, _) = RunCli("--help");
+        Assert.DoesNotContain("TODO", help, StringComparison.Ordinal);
+
+        var (_, guide, _) = RunCli("--guide");
+        Assert.DoesNotContain("TODO", guide, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// --dap is documented in full later in the flag list (its own EXECUTION entries,
+    /// with docs/dap-mode.md), but the USAGE synopsis at the very top of --help never
+    /// mentioned it (issue #2118) even though every other mode flag with its own
+    /// invocation shape (--server, --precompile, --emit-app) got a synopsis line. An
+    /// agent that only skims USAGE before scrolling to the flag it already knows the
+    /// name of would not learn --dap exists at all.
+    /// </summary>
+    [Fact]
+    public void Usage_SynopsisListsDap()
+    {
+        var (_, help, _) = RunCli("--help");
+        var usageIdx = help.IndexOf("USAGE", StringComparison.Ordinal);
+        var selectionIdx = help.IndexOf("SELECTION", StringComparison.Ordinal);
+        Assert.True(usageIdx >= 0 && selectionIdx > usageIdx, "--help should keep USAGE/SELECTION sections.");
+        var usage = help[usageIdx..selectionIdx];
+        Assert.Contains("--dap", usage, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// --dap (issue #1642, stdio transport in #2058) is fully implemented and already
+    /// documented as such earlier in --help, but "NOT YET IMPLEMENTED" carried a stale
+    /// "(debug adapter)" bullet dating from before --dap existed (issue #2118), naming
+    /// a DapServer.cs that has since been deleted from the repository entirely. The
+    /// curated-flag-name check in <see cref="Help_DoesNotListImplementedFlagsAsUnimplemented"/>
+    /// does not catch this shape of staleness: the stale bullet never spells out the
+    /// literal flag ("--dap") it is actually describing, so a flag-name-based
+    /// allowlist has nothing to match against.
+    /// </summary>
+    [Fact]
+    public void Help_DoesNotDescribeDapAsUnimplemented()
+    {
+        var (_, help, _) = RunCli("--help");
+        var idx = help.IndexOf("NOT YET IMPLEMENTED", StringComparison.Ordinal);
+        Assert.True(idx >= 0, "--help should keep a 'NOT YET IMPLEMENTED' section.");
+        var notYet = help[idx..];
+
+        Assert.DoesNotContain("debug adapter", notYet, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("DapServer", notYet, StringComparison.Ordinal);
+    }
+
+    /// <summary>
     /// --guide is advertised in CLAUDE.md and the al-runner-workflow skill. It must
     /// actually exist, and it must answer the questions an agent gets wrong when it
     /// only has the binary: how to invoke against a real app + test app, where deps

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -5047,6 +5047,7 @@ static void PrintHelp(TextWriter w)
     w.WriteLine("  al-runner [OPTIONS] <bundle-dir>...");
     w.WriteLine("  al-runner provision [<bundle-dir>]");
     w.WriteLine("  al-runner --server [--package-cache PATH ...] [--cache DIR]");
+    w.WriteLine("  al-runner --dap [PORT|stdio] <bundle-dir>");
     w.WriteLine("  al-runner --precompile <input.app> --out <output.dll> [--package-cache PATH ...]");
     w.WriteLine("  al-runner --emit-app <bundleDir> <outPath> [--package-cache PATH ...]");
     w.WriteLine("  al-runner --guide      (operating manual for automated callers)");
@@ -5125,8 +5126,11 @@ static void PrintHelp(TextWriter w)
     w.WriteLine("                          deps + BC patches loaded once; ~19s->~4s per run). One");
     w.WriteLine("                          JSON request/response per line. stdout carries ONLY the");
     w.WriteLine("                          protocol; all logs go to stderr. Used by the VS Code");
-    w.WriteLine("                          extension. Commands: runTests, shutdown (execute: TODO).");
-    w.WriteLine("                          See docs/server-mode.md. Mutually exclusive with --watch.");
+    w.WriteLine("                          extension. Commands: runTests (streaming per-test results),");
+    w.WriteLine("                          execute (compile+run inline AL source; one response with");
+    w.WriteLine("                          tests, Message() output, coverage and captured values),");
+    w.WriteLine("                          shutdown. Full wire schema: docs/server-mode.md. Mutually");
+    w.WriteLine("                          exclusive with --watch.");
     w.WriteLine("  --dap [PORT]            Debug Adapter Protocol server (default port 4711):");
     w.WriteLine("                          set AL breakpoints, pause execution, inspect locals over a");
     w.WriteLine("                          real DAP TCP connection. Requires exactly one bundle path.");
@@ -5298,10 +5302,6 @@ static void PrintHelp(TextWriter w)
     w.WriteLine("NOT YET IMPLEMENTED (see docs/v1-to-v2-migration.md)");
     w.WriteLine("  Nothing in this section is accepted as a flag. Everything documented above IS");
     w.WriteLine("  implemented.");
-    w.WriteLine("  (debug adapter)         v1's DAP debug server (DapServer.cs). Needs an AL→C#");
-    w.WriteLine("                          source map the compile pipeline does not currently");
-    w.WriteLine("                          expose; tracked as a separate workstream. Distinct from");
-    w.WriteLine("                          the JSON-RPC daemon in EXECUTION above, which IS supported.");
     w.WriteLine("  --stubs DIR             v1's stub-merge path. Real MS DLLs load in-process so the");
     w.WriteLine("                          original use case mostly evaporated; still possible to");
     w.WriteLine("                          add as an extra source-root merge if needed.");


### PR DESCRIPTION
Closes #2118

## What was stale

- `--help`'s `--server` entry called the shipped `execute` command a TODO
  (`Commands: runTests, shutdown (execute: TODO).`) — `execute` has been
  implemented for a while and, as of #2117/#2120, also returns Message()
  output. Replaced with a one-liner naming what `execute` actually returns
  (tests, Message() output, coverage, captured values) and pointing at
  `docs/server-mode.md` for the full wire schema, at the same level of
  detail the surrounding EXECUTION entries already use.
- The USAGE synopsis never mentioned `--dap` even though `--server`,
  `--precompile`, and `--emit-app` — every other mode flag with its own
  invocation shape — each got a synopsis line, and `--dap` is fully
  documented further down. Added `al-runner --dap [PORT|stdio] <bundle-dir>`
  to USAGE.
- Auditing the rest of `--help`/`--guide` per the issue's ask turned up a
  second staleness bug of the same class: the "NOT YET IMPLEMENTED" section
  still carried a `(debug adapter)` bullet dating from before `--dap`
  existed, describing a `DapServer.cs` that has since been deleted from the
  repository entirely, while `--dap` is already documented as implemented
  earlier in the very same `--help` output. Removed the stale bullet.
- `--guide` was checked for the same class of drift and did not have any —
  it already documents `--dap stdio`/`--dap [PORT]` correctly and has no
  TODO markers.

## Proving test (the drift-test gate, requirement 4)

`AlRunner.Tests/CliDocumentationTests.cs` already gates `--help`/`--guide`
against drift, but none of its existing checks would have caught either bug:
- `Help_DocumentsEveryRecognizedFlag` only scrapes `--flag` literals from the
  parser; `execute` is a server *command*, not a CLI flag, so it's invisible
  to that scrape.
- `Help_DoesNotListImplementedFlagsAsUnimplemented` checks a curated flag-name
  allowlist against the "NOT YET IMPLEMENTED" section, but the stale
  `(debug adapter)` bullet never spells out the literal flag (`--dap`) it
  describes, so a flag-name allowlist has nothing to match.

Added three new tests, verified RED against the pre-fix text (via a
temporary revert) and GREEN against the fix:

- `Help_NeverMarksAShippedCommandAsTodo` — asserts neither `--help` nor
  `--guide` contains a literal `TODO` marker. General enough to catch this
  whole class without knowing which command/flag is stale.
- `Usage_SynopsisListsDap` — asserts the USAGE block (between `USAGE` and
  `SELECTION`) mentions `--dap`.
- `Help_DoesNotDescribeDapAsUnimplemented` — asserts the "NOT YET
  IMPLEMENTED" section contains neither "debug adapter" nor "DapServer".

All three failed against the pre-fix text with the exact substrings named
above, and pass now.

## Testing

- `dotnet test AlRunner.Tests --filter "FullyQualifiedName~CliDocumentationTests"`
  — 15/15 passed (RED confirmed via temporary revert of `Program.cs` before
  restoring the fix; see commit).
- `dotnet test AlRunner.Tests` (full suite) — 988 passed, 56 skipped, 0
  failed.

## Scope

Only `--help`/`--guide` text and the CLI-documentation test file changed, per
the issue's explicit "do not expand scope beyond help/guide text."