### PR TITLE
fix: precompiled tableextension merge now evicts a stale base NCLMetaTable

### DIFF
--- a/AlRunner.Tests/RecordPatchesPrecompiledTableExtEvictionTests.cs
+++ b/AlRunner.Tests/RecordPatchesPrecompiledTableExtEvictionTests.cs
@@ -1,0 +1,182 @@
+// RecordPatchesPrecompiledTableExtEvictionTests — proves #2126: the precompiled-.app
+// tableextension merge path must evict an already-built NCLMetaTable for the base table,
+// exactly like the AL-source tableextension parser already does.
+//
+// The asymmetry
+// -------------
+// Two writers merge tableextension fields into the shared _parsedExtensionFields
+// dictionary:
+//   - TryParseTableExtensionFile (RecordPatches.AlSourceParser.cs) — the AL-source path.
+//   - EnsureBcSymbolExtensionIndex (RecordPatches.BcAppFallback.cs) — the precompiled-.app
+//     symbol path.
+// BuildNCLMetaTable only ever consults _parsedExtensionFields at BUILD time. If a base
+// table's NCLMetaTable was already built and cached before one of these writers ran, that
+// cached instance is frozen without the extension's fields forever, unless something evicts
+// it from _metaTableCache so the next lookup rebuilds. The AL-source path always did this
+// (EvictCachedMetaTableForBaseTable); the precompiled path never did.
+//
+// Why a direct unit test, not an AL fixture
+// ------------------------------------------
+// #2125's investigation built 2-hop and 3-hop dependency-chain AL fixtures and could not
+// force the ordering that exposes the gap: in every fixture, nothing referenced the base
+// table before EnsureBcSymbolExtensionIndex ran, so eviction had nothing stale to evict.
+// This test drives RecordPatches' own public entry points directly, in the exact order the
+// issue names, so the ordering is forced rather than hoped for:
+//   1. Parse the base table from AL source and materialize its NCLMetaTable FIRST (before
+//      any tableextension is known) via NCLMetadata_GetMetaTableById.
+//   2. Register a precompiled .app whose SymbolReference.json carries a tableextension for
+//      that SAME base table, plus an unrelated table only known via symbols.
+//   3. Look up the unrelated table — its miss against _parsedTables walks the .app symbol
+//      fallback (TryPopulateParsedTableFromBcApps -> EnsureBcSymbolTableIndex), which
+//      co-builds EnsureBcSymbolExtensionIndex as a side effect. This is the real trigger a
+//      large dependency graph exercises the moment ANY OTHER precompiled table is touched
+//      after the base table was already referenced — see #2126's "why it is likely
+//      reachable in a real workspace".
+//   4. Read the extension field back off the base table's NCLMetaTable.
+//
+// Without the fix: step 4 throws "extension field 50 ... not found" — the NCLMetaTable
+// cached in step 1 is untouched. With the fix: the merge in step 3 evicts it, so step 4's
+// lookup rebuilds and finds the field.
+using System.IO.Compression;
+using System.Text;
+using AlRunner.Patches;
+using Microsoft.Dynamics.Nav.Runtime;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+[Collection(BcEngineCollection.Name)]
+public sealed class RecordPatchesPrecompiledTableExtEvictionTests : IDisposable
+{
+    private readonly BcEngineFixture _engine;
+    private readonly string _root;
+
+    public RecordPatchesPrecompiledTableExtEvictionTests(BcEngineFixture engine)
+    {
+        _engine = engine;
+        _root = Path.Combine(Path.GetTempPath(), "al-runner-2126-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { /* best-effort cleanup */ }
+    }
+
+    private static void WriteApp(string path, string symbolReferenceJson)
+    {
+        using var zip = new FileStream(path, FileMode.Create);
+        using var za = new ZipArchive(zip, ZipArchiveMode.Create);
+        var entry = za.CreateEntry("SymbolReference.json");
+        using var w = new StreamWriter(entry.Open(), Encoding.UTF8);
+        w.Write(symbolReferenceJson);
+    }
+
+    [SkippableFact]
+    public void PrecompiledTableExtensionMerge_EvictsAlreadyBuiltBaseMetaTable()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready,
+            _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        // Object ids picked to be process-wide unique among AlRunner.Tests statics (these
+        // land in the same static _parsedTables / _metaTableCache the whole test assembly
+        // shares) and outside every other file's declared ranges.
+        const int baseTableId = 93900;
+        const string baseTableName = "Bug2126 Base";
+        const int triggerTableId = 93901;
+        const int extId = 93902;
+        const int extFieldId = 50;
+        const string extFieldName = "ExtField2126";
+
+        // ── ARRANGE: base table via AL source ───────────────────────────────────────────
+        var baseDir = Path.Combine(_root, "base");
+        Directory.CreateDirectory(baseDir);
+        File.WriteAllText(Path.Combine(baseDir, "Base.al"), $$"""
+            table {{baseTableId}} "{{baseTableName}}"
+            {
+                fields
+                {
+                    field(1; "No."; Code[20]) { }
+                }
+                keys
+                {
+                    key(PK; "No.") { Clustered = true; }
+                }
+            }
+            """);
+        RecordPatches.AddSourceDir(baseDir);
+
+        var skeleton = AlRunner.BcRuntime.SkeletonNCLMetadata;
+        Assert.NotNull(skeleton);
+
+        // ── STEP 1: materialize the base table's NCLMetaTable FIRST ─────────────────────
+        // Nothing about tableextension 93902 is known to the runner yet.
+        var before = RecordPatches.NCLMetadata_GetMetaTableById(skeleton!, baseTableId, false, 0);
+        Assert.NotNull(before);
+        Assert.Equal(baseTableId, before.TableId);
+        Assert.False(before.TryGetFieldByNo(extFieldId, out _),
+            "sanity check: the extension field must not exist on the pre-merge NCLMetaTable");
+
+        // ── STEP 2: register a precompiled .app with a tableextension for the SAME base
+        //    table, plus an unrelated table only known via symbols ──────────────────────
+        var sr = $$"""
+            {
+              "RuntimeVersion": "15.1",
+              "Namespaces": [],
+              "Tables": [
+                {
+                  "Id": {{triggerTableId}},
+                  "Name": "Bug2126 Trigger",
+                  "Fields": [
+                    { "TypeDefinition": { "Name": "Code[20]" }, "Properties": [], "Id": 1, "Name": "No." }
+                  ],
+                  "Keys": [
+                    { "Name": "PK", "FieldNames": [ "No." ] }
+                  ]
+                }
+              ],
+              "TableExtensions": [
+                {
+                  "TargetObject": "{{baseTableName}}",
+                  "Fields": [
+                    { "TypeDefinition": { "Name": "Code[10]" }, "Properties": [], "Id": {{extFieldId}}, "Name": "{{extFieldName}}" }
+                  ],
+                  "Id": {{extId}},
+                  "Name": "Bug2126Ext"
+                }
+              ]
+            }
+            """;
+        var appPath = Path.Combine(_root, "dep.app");
+        WriteApp(appPath, sr);
+        RecordPatches.AddBcAppPath(appPath);
+
+        // ── STEP 3: reference the UNRELATED trigger table ───────────────────────────────
+        // Its miss against _parsedTables walks the .app symbol fallback
+        // (TryPopulateParsedTableFromBcApps -> EnsureBcSymbolTableIndex), which co-builds
+        // EnsureBcSymbolExtensionIndex — merging the base table's tableextension fields into
+        // _parsedExtensionFields as a side effect, exactly as it would in a real dependency
+        // graph the moment any OTHER precompiled table gets referenced.
+        var triggerMeta = RecordPatches.NCLMetadata_GetMetaTableById(skeleton!, triggerTableId, false, 0);
+        Assert.NotNull(triggerMeta);
+        Assert.Equal(triggerTableId, triggerMeta.TableId);
+
+        // ── STEP 4 / ASSERT (positive): the extension field now resolves ────────────────
+        // Re-resolve through the same cache-or-build entry point BuildNCLMetaTable's callers
+        // use. Without the fix this returns the STALE instance from step 1 (still missing
+        // the field); with the fix the merge in step 3 evicted it, so this rebuilds.
+        var after = RecordPatches.EnsureTableInMetadataCache(baseTableId);
+        Assert.NotNull(after);
+        var field = RecordPatches.NCLMetaTable_GetFieldByNoExt(after!, extId, extFieldId);
+        Assert.Equal(extFieldId, field.FieldNo);
+        Assert.Equal(extFieldName, field.FieldName);
+
+        // ── ASSERT (negative): a genuinely nonexistent field still raises loudly ────────
+        // The fix must not weaken this path into silently returning null/default.
+        const int nonExistentFieldId = 999999;
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            RecordPatches.NCLMetaTable_GetFieldByNoExt(after!, extId, nonExistentFieldId));
+        Assert.Contains($"extension field {nonExistentFieldId}", ex.Message);
+        Assert.Contains("not found", ex.Message);
+    }
+}

--- a/AlRunner/Patches/RecordPatches.AlSourceParser.cs
+++ b/AlRunner/Patches/RecordPatches.AlSourceParser.cs
@@ -541,47 +541,15 @@ public static partial class RecordPatches
 
             Console.Error.WriteLine($"[TableExt] parsed extension {extId} '{extName}' extends '{baseName}' with {fields.Count} fields");
 
-            var key = baseName.ToLowerInvariant();
-            // De-dup by field id (mirrors the symbol-index merge in
-            // RecordPatches.BcAppFallback.cs's EnsureBcSymbolExtensionIndex): the same
-            // extension source file can legitimately be scanned more than once (e.g. a
-            // dependency app's source dir registered both by its own suite AND by
-            // BuildSiblingSourceDeps' sibling-source discovery — see #1686), and without
-            // this guard the same field id lands twice in the merged list. A duplicated
-            // NCLMetaField with the same FieldNo corrupts NCLMetaTable.AssignFromMetaTable's
-            // positional field-count arithmetic, which crashes deep inside
-            // NCLMetaTable.SetSystemFields() with a bare NullReferenceException — surfaced
-            // to the caller as the misleading "no NCLMetaTable ... (AL source not parsed)".
-            if (!_parsedExtensionFields.TryGetValue(key, out var existing))
-                _parsedExtensionFields[key] = fields;
-            else
-            {
-                var existingIds = new HashSet<int>(existing.Select(f => f.FieldId));
-                foreach (var f in fields)
-                    if (existingIds.Add(f.FieldId))
-                        existing.Add(f);
-            }
-
-            // The base table's NCLMetaTable may ALREADY be built and cached at this point:
-            // a table pulled in from a precompiled dependency .app is materialised lazily
-            // the moment something references it, which happens during source parsing —
-            // i.e. BEFORE this tableextension is parsed. BuildNCLMetaTable merges
-            // _parsedExtensionFields at build time only, so that cached metatable is frozen
-            // without the extension's fields, and every AL access to one of them dies in
-            // NCLMetaTable_GetFieldByNoExt ("extension field N ... not found").
-            // Evict it so the next access rebuilds WITH the merge. Safe here: source
-            // parsing runs before any AL test code, so nothing holds the stale instance.
-            EvictCachedMetaTableForBaseTable(baseName);
-
-            // Record the extension object id so its emitted TableExtension{extId} CLR type
-            // can be instantiated and registered on each record of the base table — this is
-            // what makes the extension's record-level triggers (OnInsert/OnModify/OnDelete/
-            // OnRename) and field-validate triggers fire. Preserve declaration order and
-            // de-dup (the same extension file is scanned from multiple source dirs).
-            if (!_extensionIdsByBaseTable.TryGetValue(key, out var extIds))
-                _extensionIdsByBaseTable[key] = extIds = new List<int>();
-            if (!extIds.Contains(extId))
-                extIds.Add(extId);
+            // Merge into _parsedExtensionFields, record the extension id (so its emitted
+            // TableExtension{extId} CLR type can be instantiated and registered on each
+            // record of the base table — record-level triggers + field-validate dispatch),
+            // and evict any already-built NCLMetaTable for the base table so a rebuild picks
+            // up these fields. All three steps — including the eviction, whose necessity is
+            // explained on MergeExtensionFields itself (#2126) — happen atomically in the
+            // shared helper so a second writer (RecordPatches.BcAppFallback.cs's
+            // EnsureBcSymbolExtensionIndex) can't repeat this file's own former omission of it.
+            MergeExtensionFields(baseName, extId, fields);
         }
     }
 

--- a/AlRunner/Patches/RecordPatches.BcAppFallback.cs
+++ b/AlRunner/Patches/RecordPatches.BcAppFallback.cs
@@ -465,7 +465,11 @@ public static partial class RecordPatches
     /// Only runs once per registration epoch; reset by <see cref="AddBcAppPath"/> and by
     /// <see cref="ResetForReload"/> (since _parsedExtensionFields is cleared on reload).
     ///
-    /// Mirrors AlSourceParser.cs:246-260 for populating those dictionaries.
+    /// Mirrors AlSourceParser.cs's TryParseTableExtensionFile for populating those
+    /// dictionaries; both funnel through the shared <see cref="MergeExtensionFields"/>
+    /// helper, which also evicts any already-built NCLMetaTable for the base table — see
+    /// #2126. Registration is guarded in RegisterParsedTableExtensions: malformed instances
+    /// (ObjectId.ObjectNumber ≠ extId) and duplicates are skipped without crashing.
     ///
     /// De-duplicates by field id: precompiled BaseApp SymbolReference.json lists fields both
     /// in the base table's Tables[] entry AND in TableExtensions[].Fields. The merge skips
@@ -485,32 +489,8 @@ public static partial class RecordPatches
                 foreach (var ext in BcAppSymbolCache.GetTableExtensions(appPath))
                 {
                     if (string.IsNullOrEmpty(ext.TargetTableName)) continue;
-                    var key = ext.TargetTableName.ToLowerInvariant();
 
-                    // Append fields to _parsedExtensionFields — keep existing list from AL source.
-                    // Also add the extension id to _extensionIdsByBaseTable so RegisterParsedTableExtensions
-                    // can instantiate the precompiled TableExtension{id} CLR type (from dep .app DLLs)
-                    // and wire its triggers. This mirrors the AL-source path (AlSourceParser.cs:257-260).
-                    // Registration is guarded in RegisterParsedTableExtensions: malformed instances
-                    // (ObjectId.ObjectNumber ≠ extId) and duplicates are skipped without crashing.
-                    if (ext.ExtensionId > 0)
-                    {
-                        if (!_extensionIdsByBaseTable.TryGetValue(key, out var extIdList))
-                            _extensionIdsByBaseTable[key] = extIdList = new List<int>();
-                        if (!extIdList.Contains(ext.ExtensionId))
-                            extIdList.Add(ext.ExtensionId);
-                    }
-
-                    if (!_parsedExtensionFields.TryGetValue(key, out var existing))
-                        _parsedExtensionFields[key] = new List<ParsedField>(ext.Fields);
-                    else
-                    {
-                        var existingIds = new HashSet<int>(existing.Select(f => f.FieldId));
-                        foreach (var f in ext.Fields)
-                            if (existingIds.Add(f.FieldId))
-                                existing.Add(f);
-                    }
-
+                    MergeExtensionFields(ext.TargetTableName, ext.ExtensionId, ext.Fields);
                     merged++;
                 }
             }

--- a/AlRunner/Patches/RecordPatches.cs
+++ b/AlRunner/Patches/RecordPatches.cs
@@ -102,6 +102,55 @@ public static partial class RecordPatches
     // dispatch). See RecordPatches.CreateObjectInstance.cs / WireFieldTriggerHandlers.
     internal static readonly Dictionary<string, List<int>> _extensionIdsByBaseTable = new();
 
+    /// <summary>
+    /// Merge <paramref name="fields"/> into <c>_parsedExtensionFields[baseTableName]</c>,
+    /// record <paramref name="extensionId"/> in <c>_extensionIdsByBaseTable</c>, and evict
+    /// any already-built NCLMetaTable for the base table so the next lookup rebuilds it with
+    /// these fields merged in.
+    ///
+    /// This is the single writer both tableextension-field sources funnel through — the
+    /// AL-source parser (<c>TryParseTableExtensionFile</c> in
+    /// RecordPatches.AlSourceParser.cs) and the precompiled-.app symbol merge
+    /// (<c>EnsureBcSymbolExtensionIndex</c> in RecordPatches.BcAppFallback.cs) — so the
+    /// eviction happens exactly once, in one place, and any future third writer inherits it
+    /// automatically instead of needing to remember to call it. See #2126: before this,
+    /// only the AL-source path evicted, so a base table whose NCLMetaTable had already been
+    /// materialized (e.g. referenced by AL source parsed earlier in the dependency graph)
+    /// before EnsureBcSymbolExtensionIndex ran stayed frozen forever without the precompiled
+    /// extension's fields.
+    /// </summary>
+    private static void MergeExtensionFields(string baseTableName, int extensionId, IEnumerable<ParsedField> fields)
+    {
+        if (string.IsNullOrEmpty(baseTableName)) return;
+        var key = baseTableName.ToLowerInvariant();
+
+        // De-dup by field id: the same extension can legitimately be scanned/merged more than
+        // once (a dependency app's source dir registered both by its own suite AND by
+        // sibling-source discovery, or a precompiled SymbolReference.json listing the same
+        // field in both the base table's Tables[] entry and TableExtensions[].Fields — see
+        // #1686 / #1711). A duplicated field id corrupts NCLMetaTable's positional field-count
+        // arithmetic.
+        if (!_parsedExtensionFields.TryGetValue(key, out var existing))
+            _parsedExtensionFields[key] = new List<ParsedField>(fields);
+        else
+        {
+            var existingIds = new HashSet<int>(existing.Select(f => f.FieldId));
+            foreach (var f in fields)
+                if (existingIds.Add(f.FieldId))
+                    existing.Add(f);
+        }
+
+        if (extensionId > 0)
+        {
+            if (!_extensionIdsByBaseTable.TryGetValue(key, out var extIds))
+                _extensionIdsByBaseTable[key] = extIds = new List<int>();
+            if (!extIds.Contains(extensionId))
+                extIds.Add(extensionId);
+        }
+
+        EvictCachedMetaTableForBaseTable(baseTableName);
+    }
+
     // Set to true once Register() has been called.
     private static bool _registered;
 


### PR DESCRIPTION
Closes #2126

## The asymmetry

Two writers merge tableextension fields into the shared `_parsedExtensionFields` dictionary:

- `TryParseTableExtensionFile` (`AlRunner/Patches/RecordPatches.AlSourceParser.cs`) — the AL-source path. It already called `EvictCachedMetaTableForBaseTable` afterward, with a comment explaining why.
- `EnsureBcSymbolExtensionIndex` (`AlRunner/Patches/RecordPatches.BcAppFallback.cs`) — the precompiled-`.app` symbol path. It wrote the same dictionary but never evicted.

`BuildNCLMetaTable` only ever merges `_parsedExtensionFields` at build time, so a base table whose `NCLMetaTable` was already materialized before the precompiled merge ran stayed frozen without the extension's fields — permanently, since nothing rebuilt it.

## Fix

Both writers now funnel through one shared `MergeExtensionFields` helper (in `RecordPatches.cs`) that merges the fields, records the extension id in `_extensionIdsByBaseTable`, and evicts the cached metatable — all three steps together. The eviction now lives in exactly one place, so a third writer added later inherits it automatically instead of needing to remember to call it (the issue explicitly asked me to evaluate this — this is the conclusion).

## Proving test

#2125's investigation found that small AL fixtures couldn't force the ordering that exposes this: in every fixture built there, nothing referenced the base table before the precompiled merge ran, so eviction had nothing stale to evict.

Rather than guess at a bigger fixture, I added a runner-side unit test (`AlRunner.Tests/RecordPatchesPrecompiledTableExtEvictionTests.cs`) that drives `RecordPatches`' own public entry points directly, in the exact order needed to force the hazard:

1. Parse a base table from AL source and materialize its `NCLMetaTable` first via `NCLMetadata_GetMetaTableById` — before any tableextension is known.
2. Register a precompiled `.app` (a hand-built `SymbolReference.json` in a zip) declaring a tableextension for that same base table, plus an unrelated table only known via symbols.
3. Look up the unrelated table. Its miss against `_parsedTables` walks the `.app` symbol fallback, which co-builds `EnsureBcSymbolExtensionIndex` as a side effect — exactly what happens in a real dependency graph the moment any other precompiled table gets referenced after the base table was already touched.
4. Read the extension field back off the base table.

This is a runner-side mechanism test, not a BC-behavior claim, so it lives in `AlRunner.Tests/` per `bc-behavior-tests-go-upstream.md` rather than upstream or in `tests/runner-extras/`.

Confirmed RED against the pre-fix code (temporarily reverted the eviction call and reran): the test fails with `extension field 50 from extension 93902 not found in NCLMetaTable Bug2126 Base` — the same failure shape #2126 describes. GREEN with the fix restored, run twice.

Negative case: a genuinely nonexistent field number still raises the same `InvalidOperationException` with "not found" — the fix doesn't weaken that path.

## Regression check

`tests/runner-extras` (full suite, `--package-cache` for both platform-apps and test-apps): 184/184 pass, including the tableextension-nearest suites `dep-tableext-platform-base-*` (`Codeunit63411.ItemRoundtrip_*`) and `dep-tableext-invoke-*` (`Codeunit60751.DepExt*`).

## Scope note

This does not close #2125 — that report stays open pending its own reproduction, per the issue's own instruction.