### PR TITLE
capture-values: record one value per statement execution, in order

### DIFF
--- a/AlRunner.Tests/AlStatementTableTests.cs
+++ b/AlRunner.Tests/AlStatementTableTests.cs
@@ -66,10 +66,18 @@ public class AlStatementTableTests : IClassFixture<SharedCliServer>
     // statementId and the statement table's id are the SAME id-space for the SAME
     // scope, proven from ONE `execute` call (not asserted separately and assumed to
     // line up). The codeunit is the SAME 4-statement shape ServerTests'
-    // Execute_CaptureValues_True_ReportsFinalLocalsOfTopLevelScope already proves
-    // reports statementId 3 for its last statement — this fact additionally locates
-    // that exact id in the statement table and asserts its POSITION is the literal
-    // AL source line "Msg := 'after';" sits on (line 11 below), not just "some line".
+    // Execute_CaptureValues_True_ReportsOneEntryPerStatementExecutionInOrder proves in
+    // full — this fact additionally locates Msg's LAST entry's id in the statement table
+    // and asserts its POSITION is the literal AL source line "Msg := 'after';" sits on
+    // (line 11 below), not just "some line".
+    //
+    // #2074 UPDATE: capturedValues now carries ONE entry per statement execution, so
+    // Counter appears TWICE (41 at statement 0, 42 at statement 2) — its statementId is
+    // no longer uniformly the scope's LAST statement, the way the pre-#2074 snapshot
+    // reported it. This test now cross-references Msg's LAST entry instead (still
+    // statement 3, the scope's true last statement, since "Msg := 'after';" IS the last
+    // statement) so the line-11 assertion below is unchanged; Counter's own corrected
+    // attribution (statement 2, not 3) is covered directly by ServerTests.
     [SkippableFact]
     public async Task CapturedValueStatementId_MatchesStatementTableScopeAndId()
     {
@@ -97,10 +105,14 @@ public class AlStatementTableTests : IClassFixture<SharedCliServer>
         var tests = d.GetProperty("tests");
         Assert.Equal(1, tests.GetArrayLength());
         var captured = tests[0].GetProperty("capturedValues");
-        var counterEntry = captured.EnumerateArray()
-            .Single(e => e.GetProperty("variableName").GetString() == "Counter");
-        Assert.Equal("OnRun", counterEntry.GetProperty("scopeName").GetString());
-        var capturedStatementId = counterEntry.GetProperty("statementId").GetInt32();
+        // Msg is assigned TWICE (statement 1, then statement 3) — take its LAST entry,
+        // the "final value" a caller reading only the tail of the series would see.
+        var msgEntry = captured.EnumerateArray()
+            .Where(e => e.GetProperty("variableName").GetString() == "Msg")
+            .Last();
+        Assert.Equal("OnRun", msgEntry.GetProperty("scopeName").GetString());
+        Assert.Equal("after", msgEntry.GetProperty("value").GetString());
+        var capturedStatementId = msgEntry.GetProperty("statementId").GetInt32();
         Assert.Equal(3, capturedStatementId); // 4 statements, 0-based, last one
 
         Assert.True(d.TryGetProperty("coverage", out var coverage), $"expected coverage on the response: {r}");

--- a/AlRunner.Tests/AlValueCaptureSeriesTests.cs
+++ b/AlRunner.Tests/AlValueCaptureSeriesTests.cs
@@ -1,0 +1,150 @@
+// Issue #2074: --capture-values used to record ONE end-of-test snapshot per AL local
+// (AlValueCapture.OnExit walked every [NavName] field once, unconditionally). A local
+// reassigned inside a loop that runs N times therefore collapsed to its FINAL value —
+// ALchemist's inline loop rendering needs the full per-iteration series (e.g. `myInt = 2
+// .. 56 (x10)`), which a single snapshot cannot supply.
+//
+// These are pure C# unit tests against AlValueCapture.DiffAndUpdate — the diff engine
+// behind the new per-execution series, extracted (same reasoning as CaptureField's own
+// extraction for #2043) so it is testable with injected read delegates instead of a real
+// NavMethodScope. No BC artifact needed; this is the runner's own mechanism, not AL/BC
+// behaviour, so it belongs here rather than upstream (.claude/rules/
+// bc-behavior-tests-go-upstream.md) — the end-to-end wire proof against a real compiled
+// AL loop lives in ServerExecuteCapturedValuesSeriesTests (needs the BC artifact cache).
+using AlRunner.Infrastructure;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class AlValueCaptureSeriesTests
+{
+    private static (string Name, Func<object?> ReadField) Field(string name, object? value) =>
+        (name, () => value);
+
+    // --- The core claim: repeated executions of the SAME statement each emit a record ---
+
+    [Fact]
+    public void DiffAndUpdate_ValueChangesAcrossThreeObservations_EmitsThreeRecordsInOrder()
+    {
+        var lastKnown = new Dictionary<string, (object?, string?)>();
+
+        // Observation 1 (baseline: the scope's very first StmtHit, nothing has run yet).
+        var r0 = AlValueCapture.DiffAndUpdate("OnRun", -1,
+            new[] { Field("Sum", 0) }, lastKnown, isBaseline: true);
+        Assert.Empty(r0); // baseline never emits — nothing produced this value
+
+        // Iteration 1: Sum := Sum + 1 (statement 5 just ran).
+        var r1 = AlValueCapture.DiffAndUpdate("OnRun", 5,
+            new[] { Field("Sum", 1) }, lastKnown, isBaseline: false);
+        // Iteration 2: same statement runs again, Sum := Sum + 2.
+        var r2 = AlValueCapture.DiffAndUpdate("OnRun", 5,
+            new[] { Field("Sum", 3) }, lastKnown, isBaseline: false);
+        // Iteration 3: same statement a third time, Sum := Sum + 3.
+        var r3 = AlValueCapture.DiffAndUpdate("OnRun", 5,
+            new[] { Field("Sum", 6) }, lastKnown, isBaseline: false);
+
+        var series = r1.Concat(r2).Concat(r3).ToList();
+        Assert.Equal(3, series.Count);
+        Assert.Equal(new object?[] { 1, 3, 6 }, series.Select(v => v.Value).ToArray());
+        // All three executions are the SAME source statement — same statementId for all.
+        Assert.All(series, v => Assert.Equal(5, v.StatementId));
+        Assert.All(series, v => Assert.Equal("OnRun", v.ScopeName));
+        Assert.All(series, v => Assert.Equal("Sum", v.VariableName));
+    }
+
+    [Fact]
+    public void DiffAndUpdate_ValueUnchangedBetweenObservations_EmitsNothing()
+    {
+        var lastKnown = new Dictionary<string, (object?, string?)>();
+        AlValueCapture.DiffAndUpdate("OnRun", -1, new[] { Field("X", 42) }, lastKnown, isBaseline: true);
+
+        // Same value observed again — nothing was "produced" between these two points.
+        var changed = AlValueCapture.DiffAndUpdate("OnRun", 2, new[] { Field("X", 42) }, lastKnown, isBaseline: false);
+        Assert.Empty(changed);
+    }
+
+    // --- Attribution: the producing statement is the one BEFORE the current observation ---
+
+    [Fact]
+    public void DiffAndUpdate_AttributesChangeToThePreviousStatementId_NotTheCurrentOne()
+    {
+        var lastKnown = new Dictionary<string, (object?, string?)>();
+        AlValueCapture.DiffAndUpdate("OnRun", -1, new[] { Field("Counter", 0) }, lastKnown, isBaseline: true);
+
+        // attributionStatementId=2 is passed in as "the statement that just finished" —
+        // the caller (OnStmtHit) is responsible for passing the PREVIOUS statement's id,
+        // never the one currently about to run. This test pins that the diff engine
+        // records whatever id it's given, not scope.StatementNumber or the current one.
+        var changed = AlValueCapture.DiffAndUpdate("OnRun", 2, new[] { Field("Counter", 42) }, lastKnown, isBaseline: false);
+        var entry = Assert.Single(changed);
+        Assert.Equal(2, entry.StatementId);
+        Assert.Equal(42, entry.Value);
+    }
+
+    // --- Untouched fields: no execution ever produced a value, so no record ---
+
+    [Fact]
+    public void DiffAndUpdate_FieldNeverChangesFromBaseline_NeverEmitted()
+    {
+        var lastKnown = new Dictionary<string, (object?, string?)>();
+        AlValueCapture.DiffAndUpdate("OnRun", -1,
+            new[] { Field("Touched", 0), Field("Untouched", 0) }, lastKnown, isBaseline: true);
+
+        var changed = AlValueCapture.DiffAndUpdate("OnRun", 0,
+            new[] { Field("Touched", 99), Field("Untouched", 0) }, lastKnown, isBaseline: false);
+
+        var entry = Assert.Single(changed);
+        Assert.Equal("Touched", entry.VariableName);
+    }
+
+    // --- Degenerate case: Exit() is the ONLY observation (no StmtHit fired at all) ---
+
+    [Fact]
+    public void DiffAndUpdate_NoPriorObservation_NonBaselineCall_EmitsEveryField()
+    {
+        // Mirrors OnExit's own fallback for a scope whose body never called StmtHit:
+        // an empty lastKnown makes every field look "changed from nothing observed",
+        // which is the pre-#2074 "walk everything unconditionally" behaviour for this
+        // one degenerate shape.
+        var lastKnown = new Dictionary<string, (object?, string?)>();
+        var changed = AlValueCapture.DiffAndUpdate("OnRun", 0,
+            new[] { Field("A", 1), Field("B", "x") }, lastKnown, isBaseline: false);
+
+        Assert.Equal(2, changed.Count);
+        Assert.Contains(changed, v => v.VariableName == "A" && Equals(v.Value, 1));
+        Assert.Contains(changed, v => v.VariableName == "B" && Equals(v.Value, "x"));
+    }
+
+    // --- Read/ToString failures still surface through CaptureField, not swallowed ---
+
+    [Fact]
+    public void DiffAndUpdate_FieldReadThrows_StillEmittedWithCaptureError()
+    {
+        var lastKnown = new Dictionary<string, (object?, string?)>();
+        var fields = new (string, Func<object?>)[]
+        {
+            ("Broken", () => throw new InvalidOperationException("boom")),
+        };
+
+        var changed = AlValueCapture.DiffAndUpdate("OnRun", 0, fields, lastKnown, isBaseline: false);
+        var entry = Assert.Single(changed);
+        Assert.Null(entry.Value);
+        Assert.NotNull(entry.CaptureError);
+        Assert.Contains(nameof(InvalidOperationException), entry.CaptureError);
+    }
+
+    [Fact]
+    public void DiffAndUpdate_TransitionFromErrorToRealValue_CountsAsAChange()
+    {
+        var lastKnown = new Dictionary<string, (object?, string?)>();
+        var throwing = new (string, Func<object?>)[] { ("Flaky", () => throw new InvalidOperationException()) };
+        AlValueCapture.DiffAndUpdate("OnRun", -1, throwing, lastKnown, isBaseline: true);
+
+        var recovered = new (string, Func<object?>)[] { ("Flaky", () => 7) };
+        var changed = AlValueCapture.DiffAndUpdate("OnRun", 1, recovered, lastKnown, isBaseline: false);
+
+        var entry = Assert.Single(changed);
+        Assert.Equal(7, entry.Value);
+        Assert.Null(entry.CaptureError);
+    }
+}

--- a/AlRunner.Tests/ServerExecuteCapturedValuesSeriesTests.cs
+++ b/AlRunner.Tests/ServerExecuteCapturedValuesSeriesTests.cs
@@ -1,0 +1,176 @@
+using System.Text.Json;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// Issue #2074 — `--capture-values` used to record ONE end-of-test snapshot of a top-
+/// level OnRun scope's AL locals (AlValueCapture.OnExit walked every [NavName] field
+/// once, unconditionally, when the scope's method body finished). A local reassigned
+/// inside a loop that runs N times collapsed to its FINAL value only — ALchemist's
+/// inline loop rendering (SShadowS/ALchemist#1, this issue's own reporter) needs the
+/// full per-iteration series, e.g. `myInt = 2 .. 56 (x10)`.
+///
+/// This class proves the fix end-to-end against a real compiled+executed AL loop (needs
+/// the BC artifact cache — see TestArtifacts). The pure diff-engine mechanism tests live
+/// in AlValueCaptureSeriesTests (no BC needed).
+///
+/// Ghost-test guard: every positive assertion names SPECIFIC values in a SPECIFIC order.
+/// A no-op fix (still one entry per variable) fails
+/// <see cref="Execute_CaptureValues_LoopReassignsVariable_ReportsOneEntryPerIteration"/>
+/// outright (it asserts 3 entries with DIFFERENT values sharing ONE statementId); an
+/// implementation that always emits every field on every statement (no diffing) fails
+/// the same test differently (way more than 3 entries) and would also fail the negative
+/// direction below (an untouched local must never surface).
+/// </summary>
+public class ServerExecuteCapturedValuesSeriesTests : IClassFixture<SharedCliServer>
+{
+    private readonly SharedCliServer _fixture;
+
+    public ServerExecuteCapturedValuesSeriesTests(SharedCliServer fixture) => _fixture = fixture;
+
+    // Same loop shape as ServerExecuteMessagesTests' LoopAndFinalMessageCode (#2117) —
+    // a `for` loop running 3 times, reassigning `total` to a DIFFERENT cumulative value
+    // each iteration (1, 3, 6 — never the same value twice, so DiffAndUpdate's own
+    // "unchanged value = no record" behaviour can never be mistaken for the real feature
+    // working), followed by one more assignment on a separate, later statement.
+    private const string LoopReassignsThenFinalAssignCode =
+        "codeunit 60210 \"CV Loop Series SX\"\n" +
+        "{\n" +
+        "    trigger OnRun()\n" +
+        "    var\n" +
+        "        i: Integer;\n" +
+        "        total: Integer;\n" +
+        "        tag: Text;\n" +
+        "    begin\n" +
+        "        total := 0;\n" +
+        "        for i := 1 to 3 do begin\n" +
+        "            total := total + i;\n" +
+        "        end;\n" +
+        "        tag := 'done';\n" +
+        "    end;\n" +
+        "}\n";
+
+    [SkippableFact]
+    public async Task Execute_CaptureValues_LoopReassignsVariable_ReportsOneEntryPerIteration()
+    {
+        TestArtifacts.SkipIfMissing();
+        var server = await _fixture.GetAsync();
+        var r = await server.SendAsync(JsonSerializer.Serialize(new
+        {
+            command = "execute",
+            captureValues = true,
+            coverage = true,
+            code = LoopReassignsThenFinalAssignCode,
+        }));
+        var d = JsonSerializer.Deserialize<JsonElement>(r);
+        Assert.False(d.TryGetProperty("error", out _), $"unexpected error response: {r}");
+        Assert.Equal(0, d.GetProperty("exitCode").GetInt32());
+
+        var tests = d.GetProperty("tests");
+        Assert.Equal(1, tests.GetArrayLength());
+        Assert.True(tests[0].TryGetProperty("capturedValues", out var captured),
+            $"expected capturedValues on the response: {r}");
+
+        var totalEntries = captured.EnumerateArray()
+            .Where(e => e.GetProperty("variableName").GetString() == "total")
+            .Select(e => (Value: e.GetProperty("value").GetInt32(), StatementId: e.GetProperty("statementId").GetInt32()))
+            .ToList();
+
+        // total := 0 (the initializer, statement 0) is a DIFFERENT statement from the
+        // loop body — the loop body itself runs 3 times, each producing a genuinely
+        // different cumulative value (1, 3, 6), which is exactly the series ALchemist's
+        // inline loop rendering needs.
+        var loopEntries = totalEntries.Where(e => e.Value is 1 or 3 or 6).ToList();
+        Assert.Equal(3, loopEntries.Count);
+        Assert.Equal(new[] { 1, 3, 6 }, loopEntries.Select(e => e.Value).ToArray());
+
+        // All three loop-body executions are the SAME source statement — one id, hit
+        // three times — the "same statement, three executions" claim the whole issue
+        // hinges on. Cross-referenced against coverage's own hit count, same technique
+        // ServerExecuteMessagesTests / AlStatementTableTests already use.
+        var loopStatementIds = loopEntries.Select(e => e.StatementId).Distinct().ToList();
+        Assert.Single(loopStatementIds);
+        var loopStatementId = loopStatementIds[0];
+
+        Assert.True(d.TryGetProperty("coverage", out var coverage), $"expected coverage on the response: {r}");
+        var statementsById = coverage.EnumerateArray().Single()
+            .GetProperty("statements").EnumerateArray()
+            .ToDictionary(s => s.GetProperty("id").GetInt32(), s => s);
+        Assert.True(statementsById.ContainsKey(loopStatementId),
+            $"loop statementId {loopStatementId} not in statement table: {r}");
+        Assert.Equal(3, statementsById[loopStatementId].GetProperty("hits").GetInt32());
+
+        // tag := 'done' runs on a LATER, separate statement, exactly once — proves the
+        // series correctly stops repeating once the loop exits and moves on.
+        var tagEntries = captured.EnumerateArray()
+            .Where(e => e.GetProperty("variableName").GetString() == "tag")
+            .ToList();
+        var tagEntry = Assert.Single(tagEntries);
+        Assert.Equal("done", tagEntry.GetProperty("value").GetString());
+        Assert.NotEqual(loopStatementId, tagEntry.GetProperty("statementId").GetInt32());
+    }
+
+    // Negative direction (`.claude/rules/tdd.md`'s "both directions"): a local that is
+    // declared but NEVER assigned anywhere in the scope must NOT appear in
+    // capturedValues at all — under "one record per execution", an untouched local was
+    // never executed into existing, so it has no execution to report (see
+    // AlValueCapture's file header for why this is a deliberate change from the
+    // pre-#2074 snapshot, which reported every declared local unconditionally).
+    [SkippableFact]
+    public async Task Execute_CaptureValues_UnassignedLocal_NeverAppearsInSeries()
+    {
+        TestArtifacts.SkipIfMissing();
+        var server = await _fixture.GetAsync();
+        var r = await server.SendAsync(JsonSerializer.Serialize(new
+        {
+            command = "execute",
+            captureValues = true,
+            code = "codeunit 60211 \"CV Untouched Local SX\" { trigger OnRun() " +
+                   "var Touched: Integer; Untouched: Integer; begin Touched := 7; end; }",
+        }));
+        var d = JsonSerializer.Deserialize<JsonElement>(r);
+        Assert.False(d.TryGetProperty("error", out _), $"unexpected error response: {r}");
+        Assert.Equal(0, d.GetProperty("exitCode").GetInt32());
+
+        var tests = d.GetProperty("tests");
+        Assert.True(tests[0].TryGetProperty("capturedValues", out var captured),
+            $"expected capturedValues on the response: {r}");
+        var names = captured.EnumerateArray()
+            .Select(e => e.GetProperty("variableName").GetString())
+            .ToList();
+
+        Assert.Contains("Touched", names);
+        Assert.DoesNotContain("Untouched", names);
+        // The touched local's own series is exactly what it should be: one execution,
+        // one record.
+        var touchedEntries = captured.EnumerateArray()
+            .Where(e => e.GetProperty("variableName").GetString() == "Touched").ToList();
+        var touchedEntry = Assert.Single(touchedEntries);
+        Assert.Equal(7, touchedEntry.GetProperty("value").GetInt32());
+    }
+
+    // Negative direction, second half: captureValues omitted entirely — the field must
+    // be ABSENT (not an empty array, not a stale series) even for a codeunit whose OnRun
+    // contains a loop that WOULD have produced a rich series if the flag were set. Proves
+    // the opt-in gate still works after the redesign — a regression here would mean
+    // AlValueCapture.Enabled stopped gating OnStmtHit (the new hook this issue adds).
+    [SkippableFact]
+    public async Task Execute_CaptureValues_Omitted_LoopCodeunit_NoCapturedValuesField()
+    {
+        TestArtifacts.SkipIfMissing();
+        var server = await _fixture.GetAsync();
+        var r = await server.SendAsync(JsonSerializer.Serialize(new
+        {
+            command = "execute",
+            code = LoopReassignsThenFinalAssignCode,
+        }));
+        var d = JsonSerializer.Deserialize<JsonElement>(r);
+        Assert.False(d.TryGetProperty("error", out _), $"unexpected error response: {r}");
+        var tests = d.GetProperty("tests");
+        Assert.Equal(1, tests.GetArrayLength());
+        Assert.Equal("pass", tests[0].GetProperty("status").GetString());
+        Assert.False(tests[0].TryGetProperty("capturedValues", out _),
+            $"capturedValues must be absent when captureValues wasn't requested: {r}");
+    }
+}

--- a/AlRunner.Tests/ServerTests.cs
+++ b/AlRunner.Tests/ServerTests.cs
@@ -184,14 +184,18 @@ public class ServerTests : IClassFixture<SharedCliServer>
         Assert.Contains("executed-onrun-boom", tests[0].GetProperty("message").GetString());
     }
 
-    // #1640 (second slice; --coverage was the first, #1922): 'captureValues:true' on
-    // `execute` reflects the AL locals of the top-level OnRun scope, as of the LAST
-    // statement that ran, via BC's own StmtHit instrumentation (AlValueCapture) — no
-    // Cecil pass over AL output, no dependency on #1642. Asserts EXACT values (42,
-    // "after") so this fails if the implementation were gutted to always report empty
-    // or default values.
+    // #1640/#2074 (second slice; --coverage was the first, #1922): 'captureValues:true'
+    // on `execute` reports ONE entry per statement EXECUTION that changed a top-level
+    // OnRun local's value, in execution order — not a single end-of-test snapshot (see
+    // AlValueCapture's file header for the #2074 redesign). Four assignment statements,
+    // two variables, no loop: Counter is assigned twice (41, then 42) and Msg is assigned
+    // twice ('before', then 'after'), interleaved. Asserting the FULL ordered series
+    // (not just each variable's final value) is what proves this is a per-execution
+    // series and not a snapshot — a snapshot-based implementation would collapse this to
+    // two entries, both attributed to statement 3 (see AlStatementTableTests's corollary
+    // fix for the OLD, coarser attribution this replaces).
     [SkippableFact]
-    public async Task Execute_CaptureValues_True_ReportsFinalLocalsOfTopLevelScope()
+    public async Task Execute_CaptureValues_True_ReportsOneEntryPerStatementExecutionInOrder()
     {
         TestArtifacts.SkipIfMissing();
         var server = await _fixture.GetAsync();
@@ -212,19 +216,33 @@ public class ServerTests : IClassFixture<SharedCliServer>
 
         Assert.True(tests[0].TryGetProperty("capturedValues", out var captured),
             $"expected capturedValues on the response: {r}");
-        var byName = captured.EnumerateArray()
-            .ToDictionary(e => e.GetProperty("variableName").GetString()!, e => e);
-        Assert.True(byName.ContainsKey("Counter"), $"no Counter entry: {r}");
-        Assert.True(byName.ContainsKey("Msg"), $"no Msg entry: {r}");
-        // Final values, not the intermediate 41/"before" — proves the snapshot is
-        // taken continuously (overwritten every statement) rather than once at the
-        // first hit or some other stale point.
-        Assert.Equal(42, byName["Counter"].GetProperty("value").GetInt32());
-        Assert.Equal("after", byName["Msg"].GetProperty("value").GetString());
-        Assert.Equal("OnRun", byName["Counter"].GetProperty("scopeName").GetString());
-        // statementId indexes the LAST statement of the OnRun trigger (4 statements,
-        // 0-based) — the exact index [SourceSpans] backs, not just "some int".
-        Assert.Equal(3, byName["Counter"].GetProperty("statementId").GetInt32());
+        var entries = captured.EnumerateArray()
+            .Select(e => (
+                Name: e.GetProperty("variableName").GetString(),
+                Value: e.GetProperty("value"),
+                StatementId: e.GetProperty("statementId").GetInt32(),
+                ScopeName: e.GetProperty("scopeName").GetString()))
+            .ToList();
+
+        // The whole point of #2074: FOUR executions, not two collapsed final values —
+        // Counter's FIRST assignment (41) is now visible, which the old single-snapshot
+        // shape could never report.
+        Assert.Equal(4, entries.Count);
+        Assert.Equal(new[] { "Counter", "Msg", "Counter", "Msg" }, entries.Select(e => e.Name).ToArray());
+        Assert.Equal(41, entries[0].Value.GetInt32());
+        Assert.Equal("before", entries[1].Value.GetString());
+        Assert.Equal(42, entries[2].Value.GetInt32());
+        Assert.Equal("after", entries[3].Value.GetString());
+        Assert.All(entries, e => Assert.Equal("OnRun", e.ScopeName));
+
+        // statementId is attributed to the ACTUAL producing statement (0-based, 4
+        // statements total) — Counter's SECOND assignment is statement 2, NOT the
+        // scope's last statement (3), which is what the pre-#2074 design always
+        // reported regardless of which variable or which assignment produced it.
+        Assert.Equal(0, entries[0].StatementId);
+        Assert.Equal(1, entries[1].StatementId);
+        Assert.Equal(2, entries[2].StatementId);
+        Assert.Equal(3, entries[3].StatementId);
     }
 
     // Negative direction: the SAME codeunit shape, but captureValues omitted (false by

--- a/AlRunner/Infrastructure/AlCoverageTracker.cs
+++ b/AlRunner/Infrastructure/AlCoverageTracker.cs
@@ -46,10 +46,17 @@ public static class AlCoverageTracker
     /// coverage/capturedValues) has no request-side opt-in — see AlCurrentStatement's
     /// and AlMessageCapture's doc comments for why session.CurrentMethodScope could not
     /// answer that question and this hook's own scope argument can.
+    ///
+    /// Also feeds AlValueCapture.OnStmtHit (#2074) — the per-execution half of
+    /// --capture-values, SELF-gated by AlValueCapture.Enabled (a separate flag from this
+    /// class's own Enabled), so a coverage:false/captureValues:true request still gets
+    /// per-statement value diffing, and a plain corpus run (neither flag set) pays only
+    /// the volatile-bool check inside that method.
     /// </summary>
     public static void OnStmtHit(NavMethodScope scope, int currentStatementNumber)
     {
         AlCurrentStatement.Update(scope, currentStatementNumber);
+        AlValueCapture.OnStmtHit(scope, currentStatementNumber);
         if (!Enabled) return;
         // NavMethodScope.ExitStatementNumber (int.MaxValue) is written directly by
         // Exit(), never passed to StmtHit by generated code — guarded defensively so a

--- a/AlRunner/Infrastructure/AlDapSession.cs
+++ b/AlRunner/Infrastructure/AlDapSession.cs
@@ -8,16 +8,21 @@
 // docs/archive/dap.md's v1 design note: "Single SemaphoreSlim for pause/resume").
 //
 // WHY pausing AT StmtHit(N) is the RIGHT boundary for a debugger — unlike
-// AlValueCapture (#1640), which had to move OFF StmtHit and onto Exit() because a
-// "keep the latest StmtHit" snapshot is always one statement stale (BC calls
-// StmtHit(N) BEFORE statement N's own side effect runs). A breakpoint does not have
-// that problem: "stopped at line L" is CONVENTIONALLY DEFINED, in every mainstream
-// debugger, as "about to execute L; every statement before L has completed". That is
-// exactly what is true the instant StmtHit(N) fires — statement N-1's effects are
-// already visible on the scope's fields, statement N's are not yet. So pausing here,
-// and reading the live scope's fields from that exact instant (AlScopeInspector), is
-// not an approximation the way --capture-values' StmtHit-based prototype was — it is
-// the correct pause point by definition. No Exit()-style redesign is needed for pause.
+// AlValueCapture (#1640)'s ORIGINAL design, which had to move OFF a "keep the latest
+// StmtHit" snapshot and onto Exit() because that shape is always one statement stale
+// (BC calls StmtHit(N) BEFORE statement N's own side effect runs). A breakpoint does
+// not have that problem: "stopped at line L" is CONVENTIONALLY DEFINED, in every
+// mainstream debugger, as "about to execute L; every statement before L has
+// completed". That is exactly what is true the instant StmtHit(N) fires — statement
+// N-1's effects are already visible on the scope's fields, statement N's are not yet.
+// So pausing here, and reading the live scope's fields from that exact instant
+// (AlScopeInspector), is not an approximation the way the ORIGINAL --capture-values
+// StmtHit-based prototype was — it is the correct pause point by definition. No
+// Exit()-style redesign is needed for pause. (#2074 later brought AlValueCapture back
+// onto StmtHit too, but attributing each observation to the PREVIOUS statement id
+// rather than overwriting a single "latest" slot — see AlValueCapture's own file
+// header; that redesign does not change anything about THIS session's live-read
+// timing, which was always correct.)
 //
 // STEP GRANULARITY (issue #2045) — next/stepIn/stepOut arm a SECOND, orthogonal gate:
 // "pause at the next qualifying StmtHit regardless of the registered breakpoint set".

--- a/AlRunner/Infrastructure/AlValueCapture.cs
+++ b/AlRunner/Infrastructure/AlValueCapture.cs
@@ -2,53 +2,72 @@
 // the #1640 umbrella; --coverage was the first, #1922). The NavName reflection lookup
 // and the wire-value conversion below are shared with --dap's live variable inspection
 // (issue #1642) via AlNavNameReflection / AlValueWireFormat — see those files.
-// Snapshots the AL locals of the
-// TOP-LEVEL AL call (the codeunit trigger the runner invokes directly — server `execute`'s
-// OnRun today) at the moment the scope is about to be disposed, via a Cecil-rewrite hook on
-// Microsoft.Dynamics.Nav.Ncl.dll's NavMethodScope.Exit() — see NclCecilRewrite's Exit block.
 //
-// The prior "blocked on a mechanism for reading AL locals" framing (see #1640's original
-// text) does not hold: BC's own AL compiler lifts every AL local to a PUBLIC instance
-// field on the generated `*_Scope` class, tagged `[NavName("<AL name>")]` — confirmed by
-// decompiling an emitted test DLL (DUMP_CS=1) and cross-checked against a live probe
-// fixture during this issue's investigation. Reading those fields via reflection needs no
-// new instrumentation and no pass over AL output.
+// #2074 REDESIGN: one record per statement EXECUTION, in order, not one end-of-test
+// snapshot. A local reassigned inside a loop that runs N times must produce N records —
+// its whole series, not just the final value — because ALchemist's inline loop
+// rendering needs the series to show e.g. `myInt = 2 .. 56 (x10)` (SShadowS/ALchemist#1).
+// The WIRE SHAPE is unchanged ({scopeName, variableName, value, statementId,
+// captureError}, still under `capturedValues`) — only how many entries a variable gets,
+// and what each one's statementId means, changes: "just repeated rather than collapsed"
+// per the issue text. See ServerProtocol.cs's class doc comment for the wire contract.
 //
-// WHY Exit(), NOT StmtHit(int) — the design actually shipped here, after a wrong first
-// attempt:
+// MECHANISM — StmtHit for every intermediate execution, Exit() for the last one:
 //
-// BC's generated code calls StmtHit(N) BEFORE statement N's own side effect runs (decompile
-// evidence: `StmtHit(3); this.msg = new NavText("after");`). A "snapshot on every StmtHit,
-// keep the latest" design (the coverage hook's shape) is therefore always ONE STATEMENT
-// STALE: at the LAST hit, the previous statement's effect is visible but the CURRENT
-// statement's is not — a probe fixture caught this directly (asserted "after", the
-// StmtHit-based prototype reported "before"). There is no StmtHit call after the final
-// statement to correct for it.
+// BC's generated code calls StmtHit(N) BEFORE statement N's own side effect runs
+// (decompile evidence: `StmtHit(3); this.msg = new NavText("after");` — see this file's
+// pre-#2074 header for the full investigation). So the values visible AT StmtHit(N)
+// are the result of everything up through statement N-1, not statement N. That is
+// exactly the "producing statement" a value should be attributed to: read at
+// StmtHit(N), attribute to N-1 (the LAST statement id observed before this call, tracked
+// in `_lastStatementId`, not literally N-1 as an integer — control flow means the
+// previous StmtHit's own argument is the only true "what ran last" answer). There is no
+// StmtHit call after the true final statement, so — same reason the original #1640
+// design needed Exit() at all — Exit() takes one more, final snapshot attributed to
+// NavMethodScope.StatementNumber (read BEFORE Exit()'s own `statementNumber =
+// int.MaxValue` sentinel write).
 //
-// NavMethodScope.Run() (decompiled) is:
-//   try { OnRun(); } catch (...) { ... } finally { Exit(); }
-// and Exit() is:
-//   internal void Exit() { statementNumber = int.MaxValue; ...; Dispose(); }
-// So Exit() fires EXACTLY ONCE per scope, unconditionally (success or AL error — see
-// Run()'s finally), strictly AFTER every statement in OnRun() — including its side
-// effects — has completed, and STRICTLY BEFORE Dispose() (confirmed by decompile: Dispose()
-// does not touch AL-declared fields, only Tree/session bookkeeping, so nothing is torn down
-// before our hook runs). Prepending the capture call before Exit()'s own
-// `statementNumber = int.MaxValue` line means AlCapturedValue.StatementId is the real last-
-// executed statement index, not the ExitStatementNumber sentinel.
+// DIFF, NOT A FULL WALK, ON EVERY OBSERVATION — the actual "one record per execution":
 //
-// "The scope is disposed when the AL method returns" (per the issue's own #1640 comment) is
-// exactly why the capture must happen INSIDE Exit(), before Dispose() — by the time our C#
-// caller's Invoke() returns, the scope object has already run through Dispose().
+// Capturing every [NavName] field on every StmtHit and emitting all of them
+// unconditionally would produce (fields x statements) records for a test that touches
+// none of them repeatedly — noise, and a different order of runtime cost per statement
+// than the old "walk once at Exit" design (the issue's own "measure before shipping"
+// warning). Emitting a record only when a field's value (or capture error) actually
+// CHANGED since the last observation gives exactly "one record per execution that
+// produced a new value" — a loop reassigning the SAME field N times still yields N
+// records (each iteration's diff against the previous iteration's value), because each
+// iteration's StmtHit is a SEPARATE observation even when consecutive values coincide...
+// with one accepted, documented gap: two back-to-back iterations that happen to write
+// the IDENTICAL value are indistinguishable from one iteration (see DiffAndUpdate's own
+// doc comment) — the issue itself flags this tradeoff ("cannot answer what x was at
+// iteration 7 if unchanged") and accepts it as "probably enough for the inline series".
+//
+// THE FIRST OBSERVATION IS A BASELINE, NEVER EMITTED:
+//
+// The very first StmtHit call in a scope fires before ANY statement has run, so every
+// field is still at its declared-default value — nothing produced that state, so no
+// statement earns credit for it (see OnStmtHit's `isBaseline` handling). This is also
+// why an AL local that is declared but NEVER assigned anywhere in the scope now gets NO
+// record at all — a real, deliberate behaviour change from the pre-#2074 snapshot, which
+// walked every [NavName] field unconditionally at Exit() regardless of whether it was
+// ever touched. Under "one record per execution", an untouched local was never executed
+// into existing, so it has no execution to report. Existing callers that read only the
+// LAST entry per variable name for straight-line (single-assignment-per-variable) code
+// see the identical values as before; see ServerTests for the updated assertions and
+// AlStatementTableTests for the corollary statementId-precision fix (a variable's own
+// LAST entry is now attributed to the statement that actually produced it, not
+// uniformly to the scope's last statement the way the pre-#2074 design did).
 using System.Reflection;
 using Microsoft.Dynamics.Nav.Runtime;
 
 namespace AlRunner.Infrastructure;
 
-/// <summary>One AL local's value, captured the instant its top-level scope's method body
-/// finished (NavMethodScope.Exit(), before Dispose()). <c>StatementId</c> indexes the SAME
-/// [SourceSpans] array AlCoverageTracker/AlCallStackCapture already decode, so a caller
-/// that also wants the AL source line can resolve it via AlSourceSpanCodec.
+/// <summary>One AL local's value, captured at the moment the statement that produced it
+/// finished running (issue #2074 — see this file's header for the StmtHit/Exit
+/// attribution). <c>StatementId</c> indexes the SAME [SourceSpans] array
+/// AlCoverageTracker/AlCallStackCapture already decode, so a caller that also wants the
+/// AL source line can resolve it via AlSourceSpanCodec.
 ///
 /// <c>CaptureError</c> (issue #2043) is non-null exactly when this value could not be
 /// faithfully read or rendered — either the field read itself threw (reflection failure
@@ -63,32 +82,93 @@ public readonly record struct AlCapturedValue(
 
 public static class AlValueCapture
 {
-    /// <summary>True only while a --capture-values run is executing. Gates OnExit; the
-    /// Cecil-rewritten Exit() call is unconditional, this flag is not — same pattern as
-    /// AlCoverageTracker.Enabled.</summary>
+    /// <summary>True only while a --capture-values run is executing. Gates both OnStmtHit
+    /// and OnExit; the Cecil-rewritten StmtHit/Exit calls are unconditional, this flag is
+    /// not — same pattern as AlCoverageTracker.Enabled.</summary>
     public static volatile bool Enabled;
 
-    // Single process-global slot, NOT per-scope: only the OUTERMOST AL call (IsTopLevelCall)
-    // is captured (see the file header), and the runner invokes exactly one such call at a
-    // time — RunFirstCodeunitOnRun's OnRun invocations run strictly sequentially, matching
-    // the same single-slot assumption AlCallStackCapture already makes for the AL call stack.
-    private static volatile List<AlCapturedValue>? _snapshot;
+    // Single process-global slots, NOT per-scope: only the OUTERMOST AL call
+    // (IsTopLevelCall) is captured (see the file header), and the runner invokes exactly
+    // one such call at a time — RunFirstCodeunitOnRun's OnRun invocations run strictly
+    // sequentially, matching the same single-slot assumption AlCallStackCapture already
+    // makes for the AL call stack.
+    private static volatile List<AlCapturedValue>? _series;
+    // Last observed (value, captureError) per AL local name, used to detect a genuine
+    // change between one observation and the next (see DiffAndUpdate). Reset alongside
+    // _series so a new top-level invocation starts with a clean baseline.
+    private static volatile Dictionary<string, (object? Value, string? Error)>? _lastKnown;
+    // The most recent StmtHit's OWN statement id — i.e. "what just finished running", the
+    // producing statement the NEXT observation's diff should be attributed to. -1 means
+    // "no StmtHit observed yet this invocation" (the pending-baseline state).
+    private static volatile int _lastStatementId = -1;
 
     /// <summary>Reset before each top-level AL invocation whose locals should be captured.</summary>
-    public static void Reset() => _snapshot = null;
+    public static void Reset()
+    {
+        _series = new List<AlCapturedValue>();
+        _lastKnown = new Dictionary<string, (object?, string?)>();
+        _lastStatementId = -1;
+    }
 
-    /// <summary>The most recent snapshot, or an empty list if nothing was captured yet
-    /// (--capture-values on but the top-level scope has no AL locals, or Exit() never
-    /// fired — e.g. a compile/setup failure before any AL code ran). Never null so callers
-    /// don't need a null-check.</summary>
+    /// <summary>Every value change observed since the last Reset(), in execution order —
+    /// or an empty list if nothing was captured yet (--capture-values on but the
+    /// top-level scope has no AL locals ever assigned, or neither StmtHit nor Exit()
+    /// fired — e.g. a compile/setup failure before any AL code ran). Never null so
+    /// callers don't need a null-check.</summary>
     public static IReadOnlyList<AlCapturedValue> Collect() =>
-        _snapshot ?? (IReadOnlyList<AlCapturedValue>)Array.Empty<AlCapturedValue>();
+        _series ?? (IReadOnlyList<AlCapturedValue>)Array.Empty<AlCapturedValue>();
+
+    /// <summary>
+    /// Feeds the per-execution series from BC's own StmtHit(N) — called from
+    /// AlCoverageTracker.OnStmtHit (the same Cecil-prepended hook site --coverage
+    /// already uses; see NclCecilRewrite's StmtHit block), NOT itself a Cecil target.
+    /// Self-gated by <see cref="Enabled"/> so the cost of walking every [NavName] field
+    /// on every AL statement is paid ONLY on a --capture-values run — a plain corpus run
+    /// (captureValues never requested) pays one extra volatile-bool read per statement,
+    /// same as AlCoverageTracker.Enabled's own gate.
+    ///
+    /// The FIRST call for a top-level invocation (<c>_lastStatementId == -1</c>) is a
+    /// baseline: it fires before any statement ran, so every field is still at its
+    /// declared-default value and nothing produced that state — recorded into
+    /// `_lastKnown` so later diffs have something to compare against, but never emitted
+    /// (see the file header). Every subsequent call diffs the CURRENT field values
+    /// against `_lastKnown` and emits one record per field that actually changed,
+    /// attributed to `_lastStatementId` — the statement that just finished running, i.e.
+    /// the one whose side effect this observation reflects (see the file header for why
+    /// that is N's PREVIOUS statement, not N itself).
+    /// </summary>
+    public static void OnStmtHit(NavMethodScope scope, int currentStatementNumber)
+    {
+        if (!Enabled) return;
+        if (!scope.IsTopLevelCall) return;
+        // NavMethodScope.ExitStatementNumber (int.MaxValue) is written directly by
+        // Exit(), never passed to StmtHit by generated code — guarded defensively, same
+        // reasoning as AlCoverageTracker.OnStmtHit's own guard.
+        if (currentStatementNumber == int.MaxValue) return;
+
+        AlNavNameReflection.EnsureInit();
+        var scopeName = scope.ScopeName ?? "?";
+        var lastKnown = _lastKnown ??= new Dictionary<string, (object?, string?)>();
+        bool isBaseline = _lastStatementId < 0;
+
+        var changed = DiffAndUpdate(scopeName, _lastStatementId, NamedFields(scope), lastKnown, isBaseline);
+        if (changed.Count > 0) (_series ??= new List<AlCapturedValue>()).AddRange(changed);
+        _lastStatementId = currentStatementNumber;
+    }
 
     /// <summary>
     /// Hook target for the Cecil-rewritten NavMethodScope.Exit() — public static, exactly
-    /// (NavMethodScope), prepended before Exit()'s own body (see the file header for why
-    /// that ordering matters). Must stay side-effect-free beyond the snapshot: it runs once
-    /// per AL method invocation, capture-values or not.
+    /// (NavMethodScope), prepended before Exit()'s own body. Takes the FINAL diffed
+    /// observation, attributed to the real last-executed statement index (read BEFORE
+    /// Exit()'s own `statementNumber = int.MaxValue` sentinel write) — this is the only
+    /// observation point for whatever the truly last statement changed, since there is
+    /// no StmtHit call after it. Never a baseline (`isBaseline: false`): even a scope
+    /// whose body never called StmtHit at all (a degenerate empty trigger) still reports
+    /// every field once here, because an empty `_lastKnown` makes DiffAndUpdate treat
+    /// every field as "changed from nothing observed" — the same backstop the pre-#2074
+    /// design got for free by walking every field unconditionally. Must stay
+    /// side-effect-free beyond the snapshot: it runs once per AL method invocation,
+    /// capture-values or not.
     /// </summary>
     public static void OnExit(NavMethodScope scope)
     {
@@ -104,25 +184,78 @@ public static class AlValueCapture
         // Read BEFORE Exit()'s own body runs, so this is the real last-executed statement
         // index, not the int.MaxValue sentinel Exit() is about to write.
         var statementId = scope.StatementNumber;
-        var values = new List<AlCapturedValue>();
+        var lastKnown = _lastKnown ??= new Dictionary<string, (object?, string?)>();
+
+        var changed = DiffAndUpdate(scopeName, statementId, NamedFields(scope), lastKnown, isBaseline: false);
+        if (changed.Count > 0) (_series ??= new List<AlCapturedValue>()).AddRange(changed);
+    }
+
+    // Every [NavName]-tagged public instance field on the scope, paired with a delegate
+    // that reads its current CLR value — the SAME injectable-delegate shape CaptureField
+    // already uses (below), so DiffAndUpdate is testable without a real NavMethodScope.
+    private static List<(string Name, Func<object?> ReadField)> NamedFields(NavMethodScope scope)
+    {
+        var result = new List<(string, Func<object?>)>();
         foreach (var f in scope.GetType().GetFields(BindingFlags.Public | BindingFlags.Instance))
         {
             var name = AlNavNameReflection.GetAlName(f);
             if (name == null) continue;
-            values.Add(CaptureField(scopeName, name, statementId, () => f.GetValue(scope)));
+            result.Add((name, () => f.GetValue(scope)));
         }
-        _snapshot = values;
+        return result;
     }
 
     /// <summary>
-    /// Captures one AL local given a way to read its raw CLR value. Extracted from
-    /// <see cref="OnExit"/> so the two failure modes issue #2043 names — a read that
-    /// throws, and a ToString() that throws — are unit-testable without a real
-    /// NavMethodScope: <paramref name="readField"/> is exactly <c>() =&gt;
-    /// f.GetValue(scope)</c> in production, but a test can inject a throwing delegate
-    /// directly. Neither failure mode is allowed to propagate out of this method (this is
-    /// what OnExit calls, and OnExit itself may never throw — see the file header and
-    /// AlValueCaptureErrorVisibilityTests).
+    /// Core diff engine behind the per-execution series (issue #2074): reads each named
+    /// field's CURRENT value via <paramref name="fields"/>'s read delegates (through
+    /// <see cref="CaptureField"/>, so a read/ToString() failure is reported exactly like
+    /// today rather than silently dropped or masking a real change), compares it against
+    /// <paramref name="lastKnown"/>, updates <paramref name="lastKnown"/> in place for
+    /// every field regardless of outcome, and returns ONLY the fields whose value or
+    /// capture error actually changed since the last observation.
+    ///
+    /// When <paramref name="isBaseline"/> is true, every field is still recorded into
+    /// <paramref name="lastKnown"/> but NOTHING is returned — see OnStmtHit's doc comment
+    /// for why the very first observation of a scope has no producing statement to credit.
+    ///
+    /// KNOWN LIMITATION (named in the issue, accepted as a tradeoff, not a bug): two
+    /// consecutive executions of the SAME statement that happen to write the IDENTICAL
+    /// value are indistinguishable from a single execution — this diff can only tell
+    /// "the value is different from last time", not "a statement ran again". A caller
+    /// that needs "what was x at iteration 7" for an iteration where x did not change
+    /// cannot get that from this series; full per-iteration sampling regardless of value
+    /// was considered and rejected as (fields x statements) noise for the common case —
+    /// see the file header.
+    /// </summary>
+    internal static List<AlCapturedValue> DiffAndUpdate(
+        string scopeName, int attributionStatementId,
+        IEnumerable<(string Name, Func<object?> ReadField)> fields,
+        Dictionary<string, (object? Value, string? Error)> lastKnown,
+        bool isBaseline)
+    {
+        var changed = new List<AlCapturedValue>();
+        foreach (var (name, readField) in fields)
+        {
+            var captured = CaptureField(scopeName, name, attributionStatementId, readField);
+            if (lastKnown.TryGetValue(name, out var prev)
+                && Equals(prev.Value, captured.Value) && prev.Error == captured.CaptureError)
+            {
+                continue; // no change since the last observation — no execution to report
+            }
+            lastKnown[name] = (captured.Value, captured.CaptureError);
+            if (!isBaseline) changed.Add(captured);
+        }
+        return changed;
+    }
+
+    /// <summary>
+    /// Captures one AL local given a way to read its raw CLR value. Extracted so the two
+    /// failure modes issue #2043 names — a read that throws, and a ToString() that throws
+    /// — are unit-testable without a real NavMethodScope: <paramref name="readField"/> is
+    /// exactly <c>() =&gt; f.GetValue(scope)</c> in production, but a test can inject a
+    /// throwing delegate directly. Neither failure mode is allowed to propagate out of
+    /// this method (this is what OnStmtHit/OnExit call via DiffAndUpdate, and neither may
+    /// ever throw — see the file header and AlValueCaptureErrorVisibilityTests).
     /// </summary>
     internal static AlCapturedValue CaptureField(
         string scopeName, string name, int statementId, Func<object?> readField)

--- a/AlRunner/Infrastructure/NclCecilRewrite.cs
+++ b/AlRunner/Infrastructure/NclCecilRewrite.cs
@@ -6634,6 +6634,14 @@ public static class NclCecilRewrite
         // own first instruction means AlValueCapture.OnExit sees both the true final field
         // values AND the real last-executed statementNumber (not yet stomped to
         // int.MaxValue).
+        //
+        // #2074 later ALSO fed AlValueCapture from the StmtHit hook above (via
+        // AlCoverageTracker.OnStmtHit -> AlValueCapture.OnStmtHit — no new Cecil rewrite,
+        // it reuses the same call site), for every INTERMEDIATE execution. This Exit()
+        // hook stays exactly as it was: it is still the only observation point for
+        // whatever the TRUE FINAL statement changed, since there is no StmtHit call after
+        // it — the "one statement stale" problem this comment describes for a naive
+        // overwrite-on-every-hit design still applies to that one, unavoidable case.
         {
             var nclMod = asm.MainModule;
             const string MsType = "Microsoft.Dynamics.Nav.Runtime.NavMethodScope";

--- a/AlRunner/ServerProtocol.cs
+++ b/AlRunner/ServerProtocol.cs
@@ -37,6 +37,18 @@ namespace AlRunner;
 ///              `capturedValues` (#1640) is present per test only when the request
 ///              set `captureValues:true`; each entry is {scopeName, variableName,
 ///              value, statementId, captureError|omitted} — see AlValueCapture.
+///              `capturedValues` carries ONE ENTRY PER STATEMENT EXECUTION THAT
+///              CHANGED A LOCAL'S VALUE, in execution order (#2074) — NOT one
+///              end-of-test snapshot per variable. A local reassigned N times (e.g.
+///              inside a loop) produces N entries sharing that assignment
+///              statement's `statementId`, each with the value that execution
+///              actually produced — a caller that only wants "the final value"
+///              reads the LAST entry for a given `variableName`. A local that is
+///              declared but never assigned produces NO entry at all (nothing
+///              executed into existing it). `statementId` is the id-space
+///              `coverage[].statements[].id` cross-references (see below) —
+///              genuinely the statement that PRODUCED this value, never the
+///              following one.
 ///              `captureError` (#2043) is present, non-null, only when the field
 ///              read or its ToString() threw; `value` is null in that case too but
 ///              MUST NOT be read as "genuinely null" — a genuinely null AL variable
@@ -80,9 +92,10 @@ public sealed class ServerRequest
     /// <summary>
     /// Opt-in to variable capture on <c>execute</c> (v1 field; #1640 second slice —
     /// --coverage was the first, #1922). When true, each response test entry's
-    /// <c>capturedValues</c> carries the top-level AL scope's locals as of the last
-    /// statement that ran (see AlValueCapture). Null/false = unchanged behaviour,
-    /// field omitted from the response.
+    /// <c>capturedValues</c> carries ONE ENTRY PER STATEMENT EXECUTION that changed a
+    /// top-level AL scope local's value, in execution order — not a single end-of-test
+    /// snapshot (issue #2074; see AlValueCapture's file header). Null/false = unchanged
+    /// behaviour, field omitted from the response.
     /// </summary>
     [JsonPropertyName("captureValues")] public bool? CaptureValues { get; set; }
     /// <summary>

--- a/docs/server-mode.md
+++ b/docs/server-mode.md
@@ -170,11 +170,13 @@ covers every object type BC supports, not just `codeunit`/`table` (#1931):
 `code` and `sourcePaths` are mutually exclusive — sending both is a
 request-level error.
 
-`captureValues: true` (#1640) reports each test entry's AL locals as of the
-last statement that ran — captured via a Cecil hook on
-`NavMethodScope.Exit()`, not a pass over emitted AL output (see
-`AlRunner/Infrastructure/AlValueCapture.cs`). `capturedValues` is present per
-test only when the request set the flag; each entry is `{scopeName,
+`captureValues: true` (#1640) reports ONE ENTRY PER STATEMENT EXECUTION that
+changed a top-level AL local's value, in execution order — not a single
+end-of-test snapshot (#2074) — captured via Cecil hooks on
+`NavMethodScope.StmtHit(int)` (every intermediate execution) and
+`NavMethodScope.Exit()` (the final one), not a pass over emitted AL output
+(see `AlRunner/Infrastructure/AlValueCapture.cs`). `capturedValues` is present
+per test only when the request set the flag; each entry is `{scopeName,
 variableName, value, statementId, captureError|omitted}`:
 
 ```json
@@ -185,6 +187,27 @@ variableName, value, statementId, captureError|omitted}`:
 ```json
 {"exitCode":0,"tests":[{"name":"X.OnRun","status":"pass","durationMs":5,
  "capturedValues":[{"scopeName":"OnRun","variableName":"Msg","value":"hi","statementId":0}]}]}
+```
+
+A local reassigned N times (e.g. inside a loop) produces N entries sharing
+that assignment statement's `statementId`, each carrying the value that
+execution actually produced — never collapsed to just the final one. A caller
+that only wants "the final value" reads the LAST entry for a given
+`variableName`. A local that is declared but never assigned produces NO entry
+at all — nothing executed a value into it, so there is no execution to
+report. The next example shows the SAME variable assigned twice on two
+different statements — TWO entries, not one:
+
+```json
+{"command":"execute","captureValues":true,
+ "code":"codeunit 50101 X2 { trigger OnRun() var Msg: Text; begin Msg := 'hi'; Msg := 'bye'; end; }"}
+```
+
+```json
+{"exitCode":0,"tests":[{"name":"X2.OnRun","status":"pass","durationMs":1,
+ "capturedValues":[
+   {"scopeName":"OnRun","variableName":"Msg","value":"hi","statementId":0},
+   {"scopeName":"OnRun","variableName":"Msg","value":"bye","statementId":1}]}]}
 ```
 
 `captureError` (issue #2043) is present, non-null, only when the runtime could
@@ -212,7 +235,9 @@ does not exist" (`.claude/rules/loud-failures.md`).
 
 ```json
 {"exitCode":0,"tests":[{"name":"X.OnRun","status":"pass","durationMs":7,
- "capturedValues":[{"scopeName":"OnRun","variableName":"Msg","value":"bye","statementId":1}]}],
+ "capturedValues":[
+   {"scopeName":"OnRun","variableName":"Msg","value":"hi","statementId":0},
+   {"scopeName":"OnRun","variableName":"Msg","value":"bye","statementId":1}]}],
  "coverage":[{"file":"/tmp/.../Scratch.al","statements":[
    {"id":0,"scope":"OnRun","line":1,"column":57,"endLine":1,"endColumn":69,"hits":1},
    {"id":1,"scope":"OnRun","line":1,"column":70,"endLine":1,"endColumn":83,"hits":1}]}]}


### PR DESCRIPTION
Closes #2074

## Problem

`--capture-values` (server `execute`) recorded ONE end-of-test snapshot of the top-level AL scope's locals — `AlValueCapture.OnExit` walked every `[NavName]` field once, unconditionally, when the scope's method body finished (`NavMethodScope.Exit()`). A local reassigned inside a loop that ran N times collapsed to its final value only. ALchemist's inline loop rendering (its own reporter's linked issue, SShadowS/ALchemist#1) needs the full per-iteration series, e.g. `myInt = 2 .. 56 (x10)`.

## Design

Builds directly on #2117/#2120's `AlCurrentStatement`/statement-id groundwork, without adding a second mechanism.

- **Mechanism**: `AlValueCapture.OnStmtHit` is fed from the SAME Cecil-prepended `NavMethodScope.StmtHit`/`CStmtHit` call site `AlCoverageTracker.OnStmtHit` already owns — no new Cecil rewrite. It's self-gated by `AlValueCapture.Enabled` (a separate flag from `AlCoverageTracker.Enabled`), so `coverage:false, captureValues:true` still gets per-statement diffing. `Exit()` still covers the true final statement, since there's no `StmtHit` call after it (same reasoning the original #1640 design needed `Exit()` for at all).
- **Attribution**: BC calls `StmtHit(N)` *before* statement N's own side effect runs, so the values visible at `StmtHit(N)` are the result of everything up through the PREVIOUS statement, not N. Each observation is attributed to the previous StmtHit's own statement id, not the current one — this is also the corollary fix: the old design attributed every captured value uniformly to the scope's LAST statement, regardless of which statement actually produced it. `AlStatementTableTests.CapturedValueStatementId_MatchesStatementTableScopeAndId` encoded that old coarse attribution directly (asserted `Counter`'s statementId as 3, the scope's last statement, when `Counter`'s real producing statement was 2) — updated to cross-reference `Msg`'s own last entry instead, with a comment explaining why.
- **Diff, not a full walk, on every observation**: capturing every field on every `StmtHit` unconditionally would be `(fields x statements)` noise and a different cost order than the old design. A record is emitted only when a field's value (or capture error) actually changed since the last observation — this is what turns "one full snapshot on every StmtHit" into "one record per execution that produced a new value." Documented tradeoff (named in the issue, accepted): two back-to-back executions of the same statement that happen to write the identical value are indistinguishable from one execution.
- **First observation is a baseline, never emitted**: the first `StmtHit` in a scope fires before any statement ran, so every field is still at its declared default — nothing produced that state. Consequence, called out explicitly: a local that is declared but never assigned now produces NO entry at all (previously it appeared once, at its default value). Under "one record per execution," an untouched local was never executed into existing, so there is no execution to report.
- **Backward compatibility**: the wire shape is unchanged (`{scopeName, variableName, value, statementId, captureError|omitted}`, still under `capturedValues`) — this is "just repeated rather than collapsed," per the issue text, not a new field. Straight-line code with each variable assigned exactly once still reports the identical count and values; only the untouched-local case above changes, and only the statementId attribution becomes more precise (per-variable, not uniformly the scope's last statement).
- **Opt-in unchanged**: still gated by the request's `captureValues:true`, same as today — no change to when the machinery runs at all.

## Measured cost

Ran a `for` loop reassigning 2 locals every iteration through `--server execute`, comparing `captureValues:false` vs `true`:

| iterations | durationMs (off) | durationMs (on) | entries |
|---|---|---|---|
| 10 | 4 | 4 | 19 |
| 100 | 0 | 1 | 199 |
| 1000 | 0 | 7 | 1999 |
| 5000 | 0 | 38 | 9999 |

Roughly linear, ~7-8µs per emitted entry when values change on every execution (the worst case — every field changes every statement). The `!Enabled` fast path (captureValues not requested) shows no measurable difference from before.

## Tests

- `AlValueCaptureSeriesTests` (new, pure C#, no BC needed): unit tests against the extracted `DiffAndUpdate` diff engine — repeated executions emit N records in order sharing one statementId, unchanged values emit nothing, attribution uses the previous statement id, untouched fields never emit, the degenerate no-StmtHit-fired case still backstops at Exit(), and read/ToString failures still surface (not swallowed).
- `ServerExecuteCapturedValuesSeriesTests` (new, needs BC artifacts): end-to-end proof against a real compiled+executed AL `for` loop — 3 iterations produce 3 entries with DIFFERENT values (1, 3, 6) sharing ONE statementId (cross-referenced against `coverage`'s own hit count of 3), a later statement's assignment is a separate entry with a different id, and the negative directions (untouched local never appears; `captureValues` omitted leaves the field absent even for loop-bearing code).
- `ServerTests.Execute_CaptureValues_True_ReportsOneEntryPerStatementExecutionInOrder` (renamed/rewritten from the old snapshot-era test): asserts the full 4-entry ordered series for the existing 4-statement, 2-variable fixture, replacing the old single-snapshot assertion.
- `AlStatementTableTests.CapturedValueStatementId_MatchesStatementTableScopeAndId`: updated to cross-reference `Msg`'s last entry (still statement 3, the scope's real last statement) instead of `Counter`'s old coarse attribution.

All of the above pass locally (`dotnet test AlRunner.Tests`, full suite: 1000 passed, 0 failed, 57 skipped — skips are the usual artifact-gated ones unrelated to this change).

## Audit

Checked whether the same "collapse a series to one snapshot" or "uniform final-statement attribution" assumption exists elsewhere:
- `AlMessageCapture` (#2117) already appends per-call, in order — no defect there.
- `AlScopeInspector` (`--dap` live variable inspection) reads live at pause time; not a snapshot-collapse concern.
- `AlCoverageTracker`'s hit counts are deliberately aggregated counts, not a value series — not applicable.
- `AlDapSession`'s own file header referenced the old "AlValueCapture had to move OFF StmtHit onto Exit()" framing — updated so it doesn't read as contradicting the new design (pausing timing itself is unaffected).

## Docs

Updated `ServerProtocol.cs`'s class doc comment, `ServerRequest.CaptureValues`'s doc comment, and `docs/server-mode.md`'s two `capturedValues` examples (one now shows the untouched-local/multi-entry distinction directly, the other — previously showing a two-assignment codeunit collapsed to one entry — now shows both entries).