### PR TITLE
docs(agents): make the audit-the-surrounding-shape step standing instruction

### DIFF
--- a/.claude/agents/impl-agent.md
+++ b/.claude/agents/impl-agent.md
@@ -71,6 +71,35 @@ Tests must PROVE the feature: assert specific values, cover positive + negative 
 - **`--package-cache "$HOME/.al-runner/platform-apps"` is required on every corpus run in this repo's CI** (see `.github/workflows/bc-tests.yml`) — the runner build's default BC major and the corpus's platform apps don't line up without it, and the run aborts on a provisioning-gap message before executing a single test. If that cache directory doesn't exist yet on your machine, run `al-runner provision` (or pass `--auto-provision`) first, or fetch it with `tools/DownloadArtifacts` (see the skill and `bc-tests.yml` for the exact invocation).
 - **Never background a long-running command and end your turn.** See `.claude/rules/no-backgrounding-long-commands.md` — a cold full-corpus run is not a few-seconds operation, budget several minutes in the foreground, and commit/push before starting anything long.
 
+### Fix the shape, not just the reported line
+
+Before you call the fix done, look for the same defect elsewhere. A reported bug is one
+observation of a shape, and the shape usually repeats — the reporter found the instance
+that bit them, not every instance.
+
+Ask three questions and answer them in the PR body, **even when the answer is "nothing
+found"**:
+
+1. **Does the same wrong pattern appear at another call site?** Grep for the shape you
+   just fixed, not the symptom you were handed.
+2. **Does a sibling function make the same assumption?** Methods called alongside the
+   broken one, or reading the same state, usually share its blind spot.
+3. **If two code paths write the same state, do they maintain the same invariant?** One
+   path having a guard the other lacks is a defect whether or not anyone has hit it.
+
+This is not scope creep. Fixing one of N instances closes the issue while leaving the bug
+in, and the next report reads as a regression. If the wider fix is genuinely too large,
+say so and file the rest per `.claude/rules/file-issues-for-gaps.md` — never silently fix
+only what was reported.
+
+Recorded because it keeps paying: in one day this step found a sibling `_parsedPages`
+gap in `GetInsertAllowedForPage` called at every TestPage construction site (#2088), five
+more call sites doing the same unrooted `Path.Combine` on a home directory (#2114), a
+`--help` section listing a shipped feature as unimplemented (#2118), a wrong
+statement-attribution bug that an existing test had encoded as correct (#2074), and a
+`WorkDate` regression that would have broken nearly every `execute` call (#2117). CI was
+green in all five cases and would have stayed green.
+
 ### What to run before you push — targeted, not everything
 
 See `.claude/rules/local-test-scope.md` for the general rule. Concretely for


### PR DESCRIPTION
Impl agents fix exactly the line they were pointed at unless the dispatching prompt tells them to look wider. I have been hand-writing that instruction into every prompt; this makes it standing.

Adds a **Fix the shape, not just the reported line** step to Step 3, between RED → GREEN and the pre-push run guidance. It asks three questions — same wrong pattern at another call site, sibling function with the same assumption, two writers of one piece of state maintaining different invariants — and requires the answer in the PR body **even when nothing is found**. That last part is the load-bearing half: without it, "I checked and there was nothing" is indistinguishable from not checking.

## Why now

Five instances in one day, all in changes whose CI was green and would have stayed green:

- **#2088** — a sibling `_parsedPages` gap in `GetInsertAllowedForPage`, called at every TestPage construction site alongside the reported method. Fixing only the reported one would have left half the bug.
- **#2114** — five more call sites doing the same unrooted `Path.Combine` against a home directory.
- **#2118** — a `--help` section listing a shipped feature as unimplemented, found while fixing a different stale line in the same output.
- **#2074** — a wrong statement-attribution bug that an existing test had encoded as correct.
- **#2117** — a `WorkDate` regression that would have broken nearly every `execute` call, found by asking what else read the property being changed.

The corpus could not have caught the last one: it runs `runTests`, and the defect was on the `execute` path.

## Scope

One file, documentation only. No behavior change, no code.

No linked issue: process change to an agent definition, raised and approved in session rather than tracked as a bug.
