### PR TITLE
fix(deps): stop misreporting a dependency-load failure, widen precompile's compile search path

### DIFF
--- a/AlRunner.Tests/DependencyLoaderServiceTierFallbackTests.cs
+++ b/AlRunner.Tests/DependencyLoaderServiceTierFallbackTests.cs
@@ -1,0 +1,83 @@
+// DependencyLoaderServiceTierFallbackTests — pins DependencyLoader.HasFaithfulServiceTierFallback
+// (issue #2131).
+//
+// DependencyLoader.LoadAll USED TO swallow ANY Tier-3 compile failure for a Microsoft
+// "source-only" dependency (bare `when (microsoftSourceOnly)`) and silently defer to
+// "service-tier DLL dispatch" — even when no such dispatch existed for that app at all.
+// That is exactly how Microsoft's real "Library Assert" test-library app (ships full AL
+// source, zero service-tier DLL coverage) turned an EMIT-ZERO compile failure into a
+// swallowed no-op: the dependency silently failed to load, and the FIRST test that called
+// one of its members died with a cryptic `NavNCLMissingMethodException` ("object with ID 0
+// does not have a member with that ID") instead of ever seeing the real cause.
+//
+// This pins the DECISION the fix narrows that catch guard to, in isolation from the full
+// BC engine / Emit / Assembly pipeline: swallowing is faithful ONLY when the extracted
+// service-tier DLL index genuinely covers at least one of the failing app's own codeunits.
+using AlRunner;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class DependencyLoaderServiceTierFallbackTests
+{
+    [Fact]
+    public void HasFaithfulServiceTierFallback_FalseWhenIndexUnavailable_EvenIfNamesWouldMatch()
+    {
+        // The exact "Library Assert" shape on a machine/CI leg with no extracted
+        // service-tier DLL cache at all (ServiceTierDllIndex.Available == false, which is
+        // the CI default — no extraction step runs there): even a codeunit name the index
+        // WOULD serve if it were available must not count as a fallback here — there is
+        // no real DLL to dispatch to.
+        var result = DependencyLoader.HasFaithfulServiceTierFallback(
+            serviceTierIndexAvailable: false,
+            codeunitTypeNames: new[] { "Codeunit130002" },
+            indexContains: _ => true);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void HasFaithfulServiceTierFallback_FalseWhenAppHasNoCodeunits()
+    {
+        // A source-only app that declares zero codeunits (e.g. only tables/pages) has
+        // nothing for the index to cover — vacuously no fallback, not vacuously "safe to
+        // swallow".
+        var result = DependencyLoader.HasFaithfulServiceTierFallback(
+            serviceTierIndexAvailable: true,
+            codeunitTypeNames: Array.Empty<string>(),
+            indexContains: _ => true);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void HasFaithfulServiceTierFallback_FalseForLibraryAssertShapedApp_ZeroCoverage()
+    {
+        // The actual reported case (#2131): Microsoft "Library Assert" ships ONE codeunit
+        // (130002) whose body exists only as AL source — it was never precompiled into any
+        // service-tier DLL. Even with the index available, THIS specific codeunit is not
+        // in it. This must return false so DependencyLoader.LoadAll's catch guard does NOT
+        // swallow the failure — the caller needs to see the real DependencyLoadException.
+        var result = DependencyLoader.HasFaithfulServiceTierFallback(
+            serviceTierIndexAvailable: true,
+            codeunitTypeNames: new[] { "Codeunit130002" },
+            indexContains: name => name is "Codeunit1" or "Codeunit9015"); // unrelated platform codeunits
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void HasFaithfulServiceTierFallback_TrueWhenAtLeastOneCodeunitIsCovered()
+    {
+        // Case (a) from the tier comment: a platform-runtime-shaped app not yet in
+        // KnownPlatformRuntimeApps, where the index DOES cover (at least some of) its
+        // codeunits — a genuine "index gap", not a total absence. Swallowing here is
+        // faithful: the real MS-compiled body still runs via lazy dispatch.
+        var result = DependencyLoader.HasFaithfulServiceTierFallback(
+            serviceTierIndexAvailable: true,
+            codeunitTypeNames: new[] { "Codeunit1", "Codeunit2", "Codeunit3" },
+            indexContains: name => name == "Codeunit2");
+
+        Assert.True(result);
+    }
+}

--- a/AlRunner.Tests/PrecompileSupportTests.cs
+++ b/AlRunner.Tests/PrecompileSupportTests.cs
@@ -1,0 +1,91 @@
+// PrecompileSupportTests — pins PrecompileSupport.WidenPackageCacheDirs (issue #2131).
+//
+// Proves the "search path is too narrow" fix directly: an EXPLICIT --package-cache dir
+// list that omits the selected version's own runner-owned platform-apps/test-apps dirs
+// must still see them widened in, when they exist on disk — and must NOT gain a phantom
+// entry for a directory that does not exist. No BC engine, no BcArtifacts process-global
+// state touched; this is pure filesystem + list logic.
+using AlRunner;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class PrecompileSupportTests
+{
+    private static string NewTempArtifactsRoot()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "precompile-support-tests-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    [Fact]
+    public void WidenPackageCacheDirs_AddsExistingPlatformAndTestAppsDirsNotAlreadyPresent()
+    {
+        var artifactsRoot = NewTempArtifactsRoot();
+        try
+        {
+            const string version = "28.1.49838.53910";
+            var platformAppsDir = Path.Combine(artifactsRoot, version, "platform-apps");
+            var testAppsDir = Path.Combine(artifactsRoot, version, "test-apps");
+            Directory.CreateDirectory(platformAppsDir);
+            Directory.CreateDirectory(testAppsDir);
+
+            var explicitlyRequested = new List<string> { "/some/caller-supplied/package-cache" };
+
+            var widened = PrecompileSupport.WidenPackageCacheDirs(explicitlyRequested, artifactsRoot, version);
+
+            // The caller's own dir is preserved (never dropped)...
+            Assert.Contains("/some/caller-supplied/package-cache", widened);
+            // ...and BOTH canonical dirs the caller never mentioned are added — this is
+            // exactly the AL1022 "System Application is missing" gap #2131 reports: the
+            // caller passed only test-apps and System Application (in platform-apps) was
+            // never in the search set at all.
+            Assert.Contains(platformAppsDir, widened);
+            Assert.Contains(testAppsDir, widened);
+            Assert.Equal(3, widened.Count);
+        }
+        finally
+        {
+            Directory.Delete(artifactsRoot, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void WidenPackageCacheDirs_NeverAddsADirectoryThatDoesNotExistOnDisk()
+    {
+        // No artifacts root created at all — the negative direction: a version that was
+        // never provisioned must not conjure a phantom search-path entry the caller can
+        // silently rely on (Directory.EnumerateFiles over a missing dir already throws
+        // elsewhere in this codebase's .app scanners if this ever regressed).
+        var artifactsRoot = Path.Combine(Path.GetTempPath(), "precompile-support-tests-missing-" + Guid.NewGuid().ToString("N"));
+        const string version = "28.1.49838.50794";
+
+        var widened = PrecompileSupport.WidenPackageCacheDirs(Array.Empty<string>(), artifactsRoot, version);
+
+        Assert.Empty(widened);
+        Assert.False(Directory.Exists(Path.Combine(artifactsRoot, version, "platform-apps")));
+    }
+
+    [Fact]
+    public void WidenPackageCacheDirs_DoesNotDuplicateADirTheCallerAlreadyIncluded()
+    {
+        var artifactsRoot = NewTempArtifactsRoot();
+        try
+        {
+            const string version = "28.1.49838.53910";
+            var platformAppsDir = Path.Combine(artifactsRoot, version, "platform-apps");
+            Directory.CreateDirectory(platformAppsDir);
+
+            var alreadyIncluded = new List<string> { platformAppsDir };
+
+            var widened = PrecompileSupport.WidenPackageCacheDirs(alreadyIncluded, artifactsRoot, version);
+
+            Assert.Single(widened, d => d == platformAppsDir);
+        }
+        finally
+        {
+            Directory.Delete(artifactsRoot, recursive: true);
+        }
+    }
+}

--- a/AlRunner/DependencyLoader.cs
+++ b/AlRunner/DependencyLoader.cs
@@ -154,14 +154,26 @@ public sealed class DependencyLoader
             {
                 asm = LoadOne(m, path, bucketRoot);
             }
-            catch (AlRunner.Infrastructure.DependencyLoadException) when (microsoftSourceOnly)
+            // #2131: this guard USED to be bare `when (microsoftSourceOnly)` — it caught
+            // and silently swallowed EVERY Microsoft-source-only Tier-3 failure, including
+            // genuine test-library apps (Library Assert, …) that have no service-tier DLL
+            // fallback at all. That swallow-and-continue left the dependency unloaded with
+            // no abort, so the FIRST time the consuming test called one of its members it
+            // died with a cryptic NavNCLMissingMethodException ("object with ID 0") instead
+            // of ever seeing the real EMIT-ZERO/EMIT-FAIL/COMPILE-FAIL cause. The narrowed
+            // guard below only swallows when HasServiceTierDllFallback proves this specific
+            // app's own codeunits ARE served by the extracted service-tier DLL index — a
+            // FAITHFUL fallback (real MS-compiled code), matching case (a) in the tier
+            // comment above (platform-runtime app not yet in KnownPlatformRuntimeApps).
+            // Everything else propagates uncaught to Program.cs's existing
+            // `catch (DependencyLoadException ex)` handler, which aborts the WHOLE run with
+            // one loud "FATAL: dependency compile failed — cannot continue. {ex.Message}"
+            // line naming the dependency + stage — see .claude/rules/loud-failures.md.
+            catch (AlRunner.Infrastructure.DependencyLoadException) when (microsoftSourceOnly && HasServiceTierDllFallback(path))
             {
-                // Platform symbol-stub app whose runtime is the service-tier DLLs: skip the
-                // source-compile and let runtime codeunit resolution serve real bodies from the
-                // DLL index (or NoOp for the documented system/test-toolkit ranges).
                 Console.Error.WriteLine(
                     $"[deps] Microsoft source-only {m.Publisher}_{m.Name} v{m.Version}: Tier-3 compile " +
-                    $"unavailable — deferring to service-tier DLL dispatch at runtime");
+                    $"unavailable — deferring to service-tier DLL dispatch at runtime (partial index coverage)");
                 continue;
             }
             if (asm != null)
@@ -585,6 +597,42 @@ public sealed class DependencyLoader
             foreach (System.Text.RegularExpressions.Match mm in _codeunitDecl.Matches(src))
                 set.Add("Codeunit" + mm.Groups[1].Value);
         return set;
+    }
+
+    // #2131: pure decision extracted so AlRunner.Tests can pin it directly (no BC engine
+    // boot needed) — see DependencyLoaderServiceTierFallbackTests. True only when the
+    // extracted service-tier DLL index genuinely covers at least one of THIS app's own
+    // codeunits, i.e. LoadAll's catch below may faithfully defer to real MS-compiled code
+    // instead of aborting. A Microsoft test-library app (Library Assert, …) whose bodies
+    // exist ONLY as AL source has ZERO coverage here — this returns false for it, so the
+    // caller must NOT swallow the failure. Before this existed, LoadAll's catch swallowed
+    // EVERY Microsoft-source-only Tier-3 failure unconditionally, which is how a broken
+    // Library Assert compile turned into a cryptic NavNCLMissingMethodException deep inside
+    // the CONSUMING test instead of a named "Library Assert failed to build" abort.
+    internal static bool HasFaithfulServiceTierFallback(
+        bool serviceTierIndexAvailable,
+        IReadOnlyCollection<string> codeunitTypeNames,
+        Func<string, bool> indexContains)
+    {
+        if (!serviceTierIndexAvailable || codeunitTypeNames.Count == 0) return false;
+        foreach (var name in codeunitTypeNames)
+            if (indexContains(name)) return true;
+        return false;
+    }
+
+    /// <summary>Real-state wrapper around <see cref="HasFaithfulServiceTierFallback"/> —
+    /// extracts this app's own codeunit names and asks the actual ServiceTierDllIndex.
+    /// Never throws: an unreadable .app just means "no fallback", not a crash here.</summary>
+    private static bool HasServiceTierDllFallback(string appPath)
+    {
+        IReadOnlyList<(string Name, string Src)> alSources;
+        try { alSources = AppLoader.ExtractAl(appPath); }
+        catch { return false; }
+        var codeunitIds = ExtractCodeunitTypeNames(alSources);
+        return HasFaithfulServiceTierFallback(
+            AlRunner.Infrastructure.ServiceTierDllIndex.Available,
+            codeunitIds,
+            AlRunner.Infrastructure.ServiceTierDllIndex.Contains);
     }
 
     private static string SanitizeFileName(string s)

--- a/AlRunner/PrecompileSupport.cs
+++ b/AlRunner/PrecompileSupport.cs
@@ -1,0 +1,49 @@
+// PrecompileSupport — small, pure helpers for the `--precompile` subcommand (issue #2131).
+//
+// Moved out of Program.cs's top-level-statement local functions for the same reason
+// WatchSource.cs was (#1822): a local function declared inside top-level statements is
+// nested inside the synthesized <Main>$ method and cannot be referenced from another
+// file/class at all, so it has no way to be unit-tested directly. AlRunner.csproj already
+// grants AlRunner.Tests InternalsVisibleTo, so an `internal` class here is directly
+// testable — no new plumbing required.
+namespace AlRunner;
+
+internal static class PrecompileSupport
+{
+    /// <summary>
+    /// Always folds the SELECTED version's own runner-owned platform-apps/test-apps dirs
+    /// (the exact <c>&lt;artifacts-root&gt;/&lt;version&gt;/{platform-apps,test-apps}</c> this
+    /// runner itself downloads into via <c>provision</c>/--auto-provision) into a
+    /// caller-supplied package-cache dir list, when present on disk — mirrors the main
+    /// bundle-run flow's runnerOwnedPlatformAppsDir/runnerOwnedTestAppsDir fold-in (issue
+    /// #1996), which closes this same gap for an EXPLICIT --package-cache there.
+    /// --precompile's own packageCacheDirs computation never had that fold-in, which is
+    /// how a Tier-3 compile of a Microsoft test-toolkit app (Library Assert, whose own
+    /// NavxManifest.xml &lt;Dependencies&gt; is empty — its need for System Application is
+    /// via the implicit <c>Platform=</c> root, not an explicit dependency edge) could miss
+    /// System Application/Application Test Library/PEPPOL even though they were sitting
+    /// right next to test-apps the whole time (issue #2131: AL1022 for all three, cascading
+    /// into AL0791 "namespace 'Reflection' is unknown" and two AL0185 "Table 'Field' is
+    /// missing", all from the SAME missing-symbols cause).
+    ///
+    /// Pure — does no mutation of <paramref name="baseDirs"/>, and only ever ADDS a dir
+    /// that genuinely exists on disk, so it can never turn a working search set into a
+    /// broken one. Plain string list in/out so tests can prove it without touching
+    /// BcArtifacts' process-global state at all.
+    /// </summary>
+    internal static List<string> WidenPackageCacheDirs(
+        IReadOnlyList<string> baseDirs, string artifactsRootDir, string selectedVersion)
+    {
+        var result = baseDirs.ToList();
+        foreach (var d in new[]
+        {
+            AlRunner.Infrastructure.ProvisioningCheck.PlatformAppsDirFor(artifactsRootDir, selectedVersion),
+            AlRunner.Infrastructure.ProvisioningCheck.TestAppsDirFor(artifactsRootDir, selectedVersion),
+        })
+        {
+            if (Directory.Exists(d) && !result.Contains(d))
+                result.Add(d);
+        }
+        return result;
+    }
+}

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -5390,7 +5390,44 @@ static int RunPrecompile(string[] subArgs)
     var manifest = AppLoader.ReadManifest(input);
     if (manifest == null) { Console.Error.WriteLine($"Failed to read manifest from {input}"); return 2; }
 
+    // #2131: select the BC version that matches the app being precompiled (its own
+    // manifest Version — Microsoft test-apps/platform-apps are versioned identically to
+    // the BC build they ship with, e.g. "Library Assert" v28.1.49838.50794 lives under
+    // artifacts/28.1.49838.50794/) BEFORE computing the package-cache search dirs below.
+    // Without this, DefaultPackageCacheDirs() falls back to ITS OWN lazy "latest version
+    // in the artifacts cache" default (BcArtifacts.EnsureSelected), which is almost never
+    // the version whose test-apps/platform-apps directories actually hold this app's
+    // dependencies — exactly the "search path is too narrow" symptom #2131 reports
+    // (AL1022 for System Application / Application Test Library / PEPPOL, none of which
+    // exist under whatever version happened to be "latest"). Best-effort: an app whose
+    // version does not correspond to any provisioned BC artifact directory (e.g. a
+    // non-Microsoft or hand-versioned .app) falls through to the pre-existing lazy-default
+    // behavior unchanged. A caller who already selected a version explicitly (a normal
+    // bundle run reaching this helper, or a future --bc-version on --precompile) is left
+    // alone — SelectVersion is call-once, so this never overrides that choice.
+    if (!AlRunner.Infrastructure.BcArtifacts.IsSelected)
+    {
+        try { AlRunner.Infrastructure.BcArtifacts.SelectVersion(manifest.Version.ToString(), null); }
+        catch
+        {
+            // No artifacts dir named exactly after this app's version — fall through to
+            // the pre-existing lazy "latest in cache" default (triggered the first time
+            // DefaultPackageCacheDirs() below reads BcArtifacts.SelectedVersion).
+        }
+    }
+
     var packageCacheDirs = caches.Count > 0 ? ExpandPackageCacheDirs(caches).ToList() : DefaultPackageCacheDirs().ToList();
+    // Mirror the main bundle-run flow's runnerOwnedPlatformAppsDir/runnerOwnedTestAppsDir
+    // fold-in (issue #1996) — always include the SELECTED version's own runner-owned
+    // platform-apps/test-apps dirs when present on disk, even when the caller passed an
+    // EXPLICIT --package-cache that doesn't happen to include them. System Application
+    // (needed to compile Microsoft test-toolkit apps like Library Assert, whose own
+    // NavxManifest.xml <Dependencies> is empty — the need is via the implicit `Platform=`
+    // root, not an explicit dependency edge) lives in platform-apps, not test-apps.
+    packageCacheDirs = AlRunner.PrecompileSupport.WidenPackageCacheDirs(
+        packageCacheDirs,
+        AlRunner.Infrastructure.BcArtifacts.ArtifactsRootDir,
+        AlRunner.Infrastructure.BcArtifacts.SelectedVersion.ToString());
 
     // Apply BC patches before any BC type is touched (BcCompiler uses BC types).
     BcRuntime.EnsureApplied();


### PR DESCRIPTION
mise ~/.config/mise/config.toml tools: gh@2.98.0
Addresses priorities 1 and 2 of #2131 (the dependency-load-failure misreport, and the too-narrow `--precompile` search path). Priorities 3 (the emitter crash) and 4 (the AL0264 self-collision) named in that issue still need their own investigation, and are left open for follow-up work.

## Priority 1 — misreported failure

`DependencyLoader.LoadAll` caught and silently swallowed **every** Tier-3 compile failure for a Microsoft-published, source-only dependency, on the theory that it was a platform-runtime app (System Application, Base Application, …) with a service-tier DLL dispatch fallback. That theory only holds when the extracted service-tier DLL index genuinely covers the failing app's own codeunits. A real test-library app — Microsoft's "Library Assert" — ships one codeunit (130002) that exists only as AL source and was never precompiled into any service-tier DLL, so it has zero such coverage. The old catch swallowed its EMIT-ZERO anyway, left the dependency silently unloaded, and the first test that called `LibraryAssert.AreEqual(...)` died with `NavNCLMissingMethodException: Function ID -1626256597 was called. The object with ID 0 does not have a member with that ID.` instead of ever seeing the real cause.

**Decision: fail fast, not annotate.** I investigated both shapes. Library Assert has no valid fallback at all — every test using it is guaranteed to fail with a nonsensical error, so "run some tests, annotate the rest" doesn't apply; the whole dependency set is broken. The fix narrows the catch guard to a new pure decision, `DependencyLoader.HasFaithfulServiceTierFallback`, which only returns true when the service-tier DLL index actually covers at least one of the app's own codeunits. When it doesn't, the `DependencyLoadException` now propagates uncaught to Program.cs's existing handler, which already aborts the whole run with one loud line naming the dependency, version, and stage:

```
FATAL: dependency compile failed — cannot continue. [dep-load-fail] Microsoft_Library Assert v28.1.49838.50794: EMIT-ZERO — BC Compilation.Emit() returned 0 sources from app AL source ...
```

Verified RED → GREEN against a live bundle depending on the real Microsoft "Library Assert" app (BC 28.1, narrow package-cache so it genuinely fails to compile): before the fix, the test PASSED with the dependency silently unloaded and would have failed elsewhere with the missing-member error the moment it actually called a member; after the fix, the run aborts immediately with the message above. Both directions are pinned in `AlRunner.Tests/DependencyLoaderServiceTierFallbackTests.cs` (index unavailable → false, zero-coverage app → false, partial-coverage app → true — a dependency that loads fine is unaffected, since this guard only fires on an actual `DependencyLoadException`).

## Priority 2 — precompile's search path

Verified the issue's own framing directly: the reported `AL0791 namespace 'Reflection' is unknown` and two `AL0185 Table 'Field' is missing` diagnostics, plus the `EMIT-ZERO`, are all the SAME cause (missing System Application symbols) — widening the compile-time search path to include System Application's `platform-apps` directory makes all three disappear in one shot, exactly as the issue predicted.

Root cause: `--precompile`'s `RunPrecompile` computes its own package-cache search dirs, but (a) never selects a BC version matching the app being precompiled (it lazily defaults to "latest in the artifacts cache", which is essentially never the version whose `test-apps`/`platform-apps` hold this app's own dependencies), and (b) never folds in the runner's own canonical per-selected-version `platform-apps`/`test-apps` directories the way the main bundle-run flow already does (issue #1996's fix for the same class of gap). Microsoft's "Library Assert" app declares an *empty* `<Dependencies>` in its own manifest — its need for System Application is via the implicit `Platform=` attribute, not an explicit dependency edge — so it's exactly the shape #1996's fold-in was never extended to cover for `--precompile`.

Fix: `RunPrecompile` now (1) selects the BC version from the app's own manifest version before computing search dirs (best-effort — falls through to the existing lazy default if no matching artifact dir exists), and (2) always folds in the selected version's own `platform-apps`/`test-apps` dirs when present on disk, mirroring the main flow. The widening logic is extracted into `PrecompileSupport.WidenPackageCacheDirs`, a pure function unit-tested in `AlRunner.Tests/PrecompileSupportTests.cs` (adds an existing-on-disk dir the caller omitted; never adds a dir that doesn't exist; never duplicates a dir the caller already included).

## What I could not verify end-to-end, and why

While investigating, I found that `--precompile` currently crashes unconditionally on **any** input, on Linux, with a `NavEnvironment`/`WindowsIdentity` `TypeInitializationException` — it never runs the BC-version-select/Cecil-rewrite bootstrap every other invocation path performs before touching a BC type. This is a separate, pre-existing bug, not one of the four named in #2131, and fixing it is out of scope here. I filed it separately: #2140. Because of it, I verified both fixes above through the **normal bundle-run path** instead (which already runs that bootstrap correctly) — for priority 2 specifically, I proved `PrecompileSupport.WidenPackageCacheDirs` correct in isolation via unit tests, since `--precompile` itself can't currently reach the code that calls it.

## Tests run locally

- `dotnet build AlRunner/AlRunner.csproj -c Debug` — clean.
- `dotnet test AlRunner.Tests` — 1007 passed, 57 skipped, 0 failed (a first run under heavy concurrent load from my own manual reproduction showed 4 unrelated flaky failures that did not reproduce on a clean rerun).
- `tests/runner-extras/depapp-dictionary-main`, `dep-tableext-invoke-main`, `dep-tableext-platform-base-main` — all pass, confirming a healthy dependency still loads with no spurious `[dep-load-fail]`/FATAL message.
- Manual RED → GREEN against the real Microsoft "Library Assert" app on BC 28.1, both with a deliberately narrow `--package-cache` and with the version genuinely missing a `platform-apps` directory on disk.

Only priorities 1 and 2 from that report landed in this PR. Problems 3 and 4 (the emitter crash and the AL0264 self-collision) remain open, tracked in that same report, and need their own follow-up work.

No linked issue: this PR deliberately leaves #2131 open — it lands only priorities 1 and 2 of that report; priorities 3 and 4 stay open there for follow-up work.
