### PR TITLE
fix(number-sequence): restore in-memory runtime support

### DIFF
--- a/AlRunner.Tests/NumberSequenceCecilBindingTests.cs
+++ b/AlRunner.Tests/NumberSequenceCecilBindingTests.cs
@@ -1,0 +1,172 @@
+using System.Reflection;
+using AlRunner.Infrastructure;
+using AlRunner.Patches;
+using Microsoft.Dynamics.Nav.Runtime;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+[Collection(BcEngineCollection.Name)]
+public sealed class NumberSequenceCecilBindingTests
+{
+    private readonly BcEngineFixture _engine;
+
+    public NumberSequenceCecilBindingTests(BcEngineFixture engine) => _engine = engine;
+
+    private static Type NumberSequenceType => typeof(ITreeObject).Assembly.GetType(
+        "Microsoft.Dynamics.Nav.Runtime.ALNumberSequence")!;
+
+    private static readonly (string Name, Type ReturnType, Type[] Parameters)[] SynchronousEntryPoints =
+    {
+        ("ALInsert", typeof(void), new[] { typeof(string), typeof(long), typeof(long), typeof(bool) }),
+        ("ALRestart", typeof(void), new[] { typeof(string), typeof(long), typeof(bool) }),
+        ("ALExists", typeof(bool), new[] { typeof(string), typeof(bool) }),
+        ("ALDelete", typeof(void), new[] { typeof(string), typeof(bool) }),
+        ("ALNext", typeof(long), new[] { typeof(string), typeof(bool) }),
+        ("ALCurrent", typeof(long), new[] { typeof(string), typeof(bool) }),
+        ("ALRange", typeof(long), new[] { typeof(string), typeof(int), typeof(bool) }),
+        ("ALRange", typeof(long), new[] { typeof(string), typeof(int), typeof(ByRef<long>), typeof(bool) }),
+    };
+
+    private static readonly (string Name, Type ReturnType, Type[] Parameters)[] AsynchronousEntryPoints =
+    {
+        ("ALInsertAsync", typeof(ValueTask), new[] { typeof(NavSession), typeof(string), typeof(long), typeof(long), typeof(bool) }),
+        ("ALRestartAsync", typeof(ValueTask), new[] { typeof(NavSession), typeof(string), typeof(long), typeof(bool) }),
+        ("ALExistsAsync", typeof(ValueTask<bool>), new[] { typeof(NavSession), typeof(string), typeof(bool) }),
+        ("ALDeleteAsync", typeof(ValueTask), new[] { typeof(NavSession), typeof(string), typeof(bool) }),
+        ("ALNextAsync", typeof(ValueTask<long>), new[] { typeof(NavSession), typeof(string), typeof(bool) }),
+        ("ALCurrentAsync", typeof(ValueTask<long>), new[] { typeof(NavSession), typeof(string), typeof(bool) }),
+        ("ALRangeAsync", typeof(ValueTask<long>), new[] { typeof(NavSession), typeof(string), typeof(int), typeof(bool) }),
+        ("ALRangeAsync", typeof(ValueTask<long>), new[] { typeof(NavSession), typeof(string), typeof(int), typeof(ByRef<long>), typeof(bool) }),
+    };
+
+    private static IEnumerable<(string Name, Type ReturnType, Type[] Parameters)> EntryPoints =>
+        SynchronousEntryPoints.Concat(AsynchronousEntryPoints);
+
+    [Fact]
+    public void AllAlEntryPointKeys_AreCecilOwned()
+    {
+        var expectedKeys = EntryPoints.Select(entry =>
+            $"Microsoft.Dynamics.Nav.Runtime.ALNumberSequence::{entry.Name}/{entry.Parameters.Length}");
+
+        Assert.All(expectedKeys, key => Assert.Contains(key, NclCecilRewrite.CecilOwned));
+    }
+
+    [SkippableFact]
+    public void AllAlEntryPoints_AreCecilOwnedWithExactShapes()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready,
+            _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        foreach (var expected in EntryPoints)
+        {
+            var method = NumberSequenceType.GetMethod(expected.Name,
+                BindingFlags.Public | BindingFlags.Static, null, expected.Parameters, null);
+
+            Assert.NotNull(method);
+            Assert.Equal(expected.ReturnType, method!.ReturnType);
+            Assert.Contains(NclCecilRewrite.Key(method), NclCecilRewrite.CecilOwned);
+        }
+    }
+
+    [SkippableFact]
+    public void SynchronousAlEntryPoints_InvokeTheInMemoryStore()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready,
+            _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        NumberSequencePatches.ResetForNewExecution();
+        try
+        {
+            Invoke("ALInsert",
+                new[] { typeof(string), typeof(long), typeof(long), typeof(bool) },
+                "Cecil", 10L, 3L, false);
+            Assert.True((bool)Invoke("ALExists",
+                new[] { typeof(string), typeof(bool) }, "cecil", false)!);
+            Assert.Equal(10L, Invoke("ALNext",
+                new[] { typeof(string), typeof(bool) }, "Cecil", false));
+
+            long reportedIncrement = 0;
+#pragma warning disable CA1416 // The standalone runner executes BC's platform-annotated ByRef wrapper cross-platform.
+            var increment = new ByRef<long>(() => reportedIncrement, value => reportedIncrement = value);
+#pragma warning restore CA1416
+            Assert.Equal(13L, Invoke("ALRange",
+                new[] { typeof(string), typeof(int), typeof(ByRef<long>), typeof(bool) },
+                "Cecil", 2, increment, false));
+            Assert.Equal(3L, reportedIncrement);
+            Assert.Equal(16L, Invoke("ALCurrent",
+                new[] { typeof(string), typeof(bool) }, "Cecil", false));
+
+            Invoke("ALRestart",
+                new[] { typeof(string), typeof(long), typeof(bool) }, "Cecil", 50L, false);
+            Assert.Equal(50L, Invoke("ALRange",
+                new[] { typeof(string), typeof(int), typeof(bool) }, "Cecil", 1, false));
+            Invoke("ALDelete", new[] { typeof(string), typeof(bool) }, "Cecil", false);
+            Assert.False((bool)Invoke("ALExists",
+                new[] { typeof(string), typeof(bool) }, "Cecil", false)!);
+        }
+        finally
+        {
+            NumberSequencePatches.ResetForNewExecution();
+        }
+    }
+
+    [SkippableFact]
+    public async Task AsynchronousAlEntryPoints_InvokeTheSameInMemoryStore()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready,
+            _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        NumberSequencePatches.ResetForNewExecution();
+        try
+        {
+            await (ValueTask)Invoke("ALInsertAsync",
+                new[] { typeof(NavSession), typeof(string), typeof(long), typeof(long), typeof(bool) },
+                null, "AsyncCecil", 10L, 3L, false)!;
+            Assert.True((bool)Invoke("ALExists",
+                new[] { typeof(string), typeof(bool) }, "ASYNCCECIL", false)!);
+            Assert.True(await (ValueTask<bool>)Invoke("ALExistsAsync",
+                new[] { typeof(NavSession), typeof(string), typeof(bool) },
+                null, "AsyncCecil", false)!);
+            Assert.Equal(10L, await (ValueTask<long>)Invoke("ALNextAsync",
+                new[] { typeof(NavSession), typeof(string), typeof(bool) },
+                null, "AsyncCecil", false)!);
+
+            long reportedIncrement = 0;
+#pragma warning disable CA1416 // The standalone runner executes BC's platform-annotated ByRef wrapper cross-platform.
+            var increment = new ByRef<long>(() => reportedIncrement, value => reportedIncrement = value);
+#pragma warning restore CA1416
+            Assert.Equal(13L, await (ValueTask<long>)Invoke("ALRangeAsync",
+                new[] { typeof(NavSession), typeof(string), typeof(int), typeof(ByRef<long>), typeof(bool) },
+                null, "AsyncCecil", 2, increment, false)!);
+            Assert.Equal(3L, reportedIncrement);
+            Assert.Equal(16L, await (ValueTask<long>)Invoke("ALCurrentAsync",
+                new[] { typeof(NavSession), typeof(string), typeof(bool) },
+                null, "AsyncCecil", false)!);
+
+            await (ValueTask)Invoke("ALRestartAsync",
+                new[] { typeof(NavSession), typeof(string), typeof(long), typeof(bool) },
+                null, "AsyncCecil", 50L, false)!;
+            Assert.Equal(50L, await (ValueTask<long>)Invoke("ALRangeAsync",
+                new[] { typeof(NavSession), typeof(string), typeof(int), typeof(bool) },
+                null, "AsyncCecil", 1, false)!);
+            await (ValueTask)Invoke("ALDeleteAsync",
+                new[] { typeof(NavSession), typeof(string), typeof(bool) },
+                null, "AsyncCecil", false)!;
+            Assert.False((bool)Invoke("ALExists",
+                new[] { typeof(string), typeof(bool) }, "AsyncCecil", false)!);
+        }
+        finally
+        {
+            NumberSequencePatches.ResetForNewExecution();
+        }
+    }
+
+    private static object? Invoke(string name, Type[] parameterTypes, params object?[] arguments)
+    {
+        var method = NumberSequenceType.GetMethod(name,
+            BindingFlags.Public | BindingFlags.Static, null, parameterTypes, null);
+        Assert.NotNull(method);
+        return method!.Invoke(null, arguments);
+    }
+}

--- a/AlRunner.Tests/NumberSequenceEntryPointResolutionTests.cs
+++ b/AlRunner.Tests/NumberSequenceEntryPointResolutionTests.cs
@@ -1,0 +1,125 @@
+using AlRunner.Infrastructure;
+using Microsoft.Dynamics.Nav.Runtime;
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class NumberSequenceEntryPointResolutionTests
+{
+    private static TypeDefinition AddNumberSequenceType(ModuleDefinition module)
+    {
+        var type = new TypeDefinition(
+            "Microsoft.Dynamics.Nav.Runtime",
+            "ALNumberSequence",
+            TypeAttributes.Public | TypeAttributes.Class,
+            module.TypeSystem.Object);
+        module.Types.Add(type);
+        return type;
+    }
+
+    private static MethodDefinition AddMethod(
+        ModuleDefinition module,
+        TypeDefinition type,
+        string name,
+        MethodAttributes attributes,
+        TypeReference returnType,
+        params TypeReference[] parameterTypes)
+    {
+        var method = new MethodDefinition(name, attributes, returnType);
+        foreach (var parameterType in parameterTypes)
+            method.Parameters.Add(new ParameterDefinition(parameterType));
+        type.Methods.Add(method);
+        method.Body.GetILProcessor().Append(Instruction.Create(OpCodes.Ret));
+        return method;
+    }
+
+    [Fact]
+    public void ExactPublicStaticShape_IsSelectedAmongSameNameSiblings()
+    {
+        using var module = ModuleDefinition.CreateModule("SyntheticNumberSequence", ModuleKind.Dll);
+        var type = AddNumberSequenceType(module);
+        var expected = AddMethod(module, type, "ALRange",
+            MethodAttributes.Public | MethodAttributes.Static,
+            module.TypeSystem.Int64,
+            module.TypeSystem.String, module.TypeSystem.Int32, module.TypeSystem.Boolean);
+        AddMethod(module, type, "ALRange",
+            MethodAttributes.Private | MethodAttributes.Static,
+            module.TypeSystem.Int64,
+            module.TypeSystem.String, module.TypeSystem.Int32, module.TypeSystem.Boolean);
+        AddMethod(module, type, "ALRange",
+            MethodAttributes.Public,
+            module.TypeSystem.Int64,
+            module.TypeSystem.String, module.TypeSystem.Int32, module.TypeSystem.Boolean);
+        AddMethod(module, type, "ALRange",
+            MethodAttributes.Public | MethodAttributes.Static,
+            module.TypeSystem.Int64,
+            module.TypeSystem.String, module.TypeSystem.Int64, module.TypeSystem.Boolean);
+
+        var resolved = NclCecilRewrite.ResolveNumberSequenceEntryPoint(
+            type, "ALRange", "System.Int64",
+            "System.String", "System.Int32", "System.Boolean");
+
+        Assert.Same(expected, resolved);
+    }
+
+    [Fact]
+    public void ByRefShape_IsMatchedExactly()
+    {
+        using var module = ModuleDefinition.CreateModule("SyntheticNumberSequenceByRef", ModuleKind.Dll);
+        var type = AddNumberSequenceType(module);
+        var byRefLong = module.ImportReference(typeof(ByRef<long>));
+        var expected = AddMethod(module, type, "ALRange",
+            MethodAttributes.Public | MethodAttributes.Static,
+            module.TypeSystem.Int64,
+            module.TypeSystem.String, module.TypeSystem.Int32, byRefLong, module.TypeSystem.Boolean);
+
+        var resolved = NclCecilRewrite.ResolveNumberSequenceEntryPoint(
+            type, "ALRange", "System.Int64",
+            "System.String", "System.Int32",
+            "Microsoft.Dynamics.Nav.Runtime.ByRef`1<System.Int64>", "System.Boolean");
+
+        Assert.Same(expected, resolved);
+    }
+
+    [Fact]
+    public void MissingExactShape_HardErrorsAndListsAvailableOverloads()
+    {
+        using var module = ModuleDefinition.CreateModule("SyntheticNumberSequenceMissing", ModuleKind.Dll);
+        var type = AddNumberSequenceType(module);
+        AddMethod(module, type, "ALRange",
+            MethodAttributes.Public | MethodAttributes.Static,
+            module.TypeSystem.Int64,
+            module.TypeSystem.String, module.TypeSystem.Int64, module.TypeSystem.Boolean);
+
+        var error = Assert.Throws<InvalidOperationException>(() =>
+            NclCecilRewrite.ResolveNumberSequenceEntryPoint(
+                type, "ALRange", "System.Int64",
+                "System.String", "System.Int32", "System.Boolean"));
+
+        Assert.Contains("found 0", error.Message);
+        Assert.Contains("System.Int32", error.Message);
+        Assert.Contains("System.Int64", error.Message);
+        Assert.Contains("#2049", error.Message);
+    }
+
+    [Fact]
+    public void DuplicateExactShape_HardErrors()
+    {
+        using var module = ModuleDefinition.CreateModule("SyntheticNumberSequenceDuplicate", ModuleKind.Dll);
+        var type = AddNumberSequenceType(module);
+        for (var index = 0; index < 2; index++)
+            AddMethod(module, type, "ALNext",
+                MethodAttributes.Public | MethodAttributes.Static,
+                module.TypeSystem.Int64,
+                module.TypeSystem.String, module.TypeSystem.Boolean);
+
+        var error = Assert.Throws<InvalidOperationException>(() =>
+            NclCecilRewrite.ResolveNumberSequenceEntryPoint(
+                type, "ALNext", "System.Int64", "System.String", "System.Boolean"));
+
+        Assert.Contains("found 2", error.Message);
+        Assert.Contains("#2049", error.Message);
+    }
+}

--- a/AlRunner.Tests/NumberSequencePatchesTests.cs
+++ b/AlRunner.Tests/NumberSequencePatchesTests.cs
@@ -1,0 +1,196 @@
+using System.Collections.Concurrent;
+using AlRunner.Patches;
+using Microsoft.Dynamics.Nav.Runtime;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+[Collection(BcEngineCollection.Name)]
+public sealed class NumberSequencePatchesTests : IDisposable
+{
+    public NumberSequencePatchesTests() => NumberSequencePatches.ResetForNewExecution();
+
+    public void Dispose() => NumberSequencePatches.ResetForNewExecution();
+
+    [Fact]
+    public void Insert_CurrentAndNext_StartAtSeed_ThenHonorIncrement()
+    {
+        NumberSequencePatches.ALInsert("Orders", 10, 3, true);
+
+        Assert.Equal(10, NumberSequencePatches.ALCurrent("Orders", true));
+        Assert.Equal(10, NumberSequencePatches.ALNext("Orders", true));
+        Assert.Equal(13, NumberSequencePatches.ALNext("Orders", true));
+        Assert.Equal(13, NumberSequencePatches.ALCurrent("Orders", true));
+    }
+
+    [Fact]
+    public void NamesAreCaseInsensitive_ButCompanyScopesAreIndependent()
+    {
+        NumberSequencePatches.ALInsert("Orders", 1, 1, true);
+        NumberSequencePatches.ALInsert("orders", 100, 10, false);
+
+        Assert.True(NumberSequencePatches.ALExists("ORDERS", true));
+        Assert.True(NumberSequencePatches.ALExists("ORDERS", false));
+        Assert.Equal(1, NumberSequencePatches.ALNext("orders", true));
+        Assert.Equal(100, NumberSequencePatches.ALNext("Orders", false));
+
+        var duplicate = Assert.Throws<InvalidOperationException>(
+            () => NumberSequencePatches.ALInsert("ORDERS", 999, 1, true));
+        Assert.Contains("already exists", duplicate.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(2, NumberSequencePatches.ALNext("Orders", true));
+    }
+
+    [Fact]
+    public void Restart_SetsTheNextValue_AndPreservesIncrement()
+    {
+        NumberSequencePatches.ALInsert("Orders", 10, 3, true);
+        Assert.Equal(10, NumberSequencePatches.ALNext("Orders", true));
+
+        NumberSequencePatches.ALRestart("Orders", 50, true);
+
+        Assert.Equal(50, NumberSequencePatches.ALCurrent("Orders", true));
+        Assert.Equal(50, NumberSequencePatches.ALNext("Orders", true));
+        Assert.Equal(53, NumberSequencePatches.ALNext("Orders", true));
+    }
+
+    [Fact]
+    public void Range_ReturnsStart_ReportsIncrement_AndAdvancesCurrent()
+    {
+        NumberSequencePatches.ALInsert("Orders", 10, 3, true);
+        long reportedIncrement = 0;
+#pragma warning disable CA1416 // The standalone runner executes BC's platform-annotated ByRef wrapper cross-platform.
+        var increment = new ByRef<long>(() => reportedIncrement, value => reportedIncrement = value);
+#pragma warning restore CA1416
+
+        var rangeStart = NumberSequencePatches.ALRange("Orders", 4, increment, true);
+
+        Assert.Equal(10, rangeStart);
+        Assert.Equal(3, reportedIncrement);
+        Assert.Equal(19, NumberSequencePatches.ALCurrent("Orders", true));
+        Assert.Equal(22, NumberSequencePatches.ALNext("Orders", true));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void Range_InvalidCount_DoesNotAdvance(int count)
+    {
+        NumberSequencePatches.ALInsert("Orders", 10, 3, true);
+
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => NumberSequencePatches.ALRange("Orders", count, true));
+
+        Assert.Equal(10, NumberSequencePatches.ALNext("Orders", true));
+    }
+
+    [Fact]
+    public void MissingOperations_FailWithoutCreatingTheSequence()
+    {
+        Assert.False(NumberSequencePatches.ALExists("Missing", true));
+
+        Assert.Throws<InvalidOperationException>(() => NumberSequencePatches.ALCurrent("Missing", true));
+        Assert.Throws<InvalidOperationException>(() => NumberSequencePatches.ALNext("Missing", true));
+        Assert.Throws<InvalidOperationException>(() => NumberSequencePatches.ALRestart("Missing", 1, true));
+        Assert.Throws<InvalidOperationException>(() => NumberSequencePatches.ALDelete("Missing", true));
+        Assert.Throws<InvalidOperationException>(() => NumberSequencePatches.ALRange("Missing", 1, true));
+
+        Assert.False(NumberSequencePatches.ALExists("Missing", true));
+    }
+
+    [Fact]
+    public void Delete_RemovesOnlyTheSelectedScope()
+    {
+        NumberSequencePatches.ALInsert("Orders", 1, 1, true);
+        NumberSequencePatches.ALInsert("Orders", 100, 10, false);
+
+        NumberSequencePatches.ALDelete("orders", true);
+
+        Assert.False(NumberSequencePatches.ALExists("Orders", true));
+        Assert.Equal(100, NumberSequencePatches.ALNext("Orders", false));
+    }
+
+    [Fact]
+    public void Insert_RejectsZeroIncrement_WithoutCreatingTheSequence()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => NumberSequencePatches.ALInsert("Orders", 1, 0, true));
+
+        Assert.False(NumberSequencePatches.ALExists("Orders", true));
+    }
+
+    [Fact]
+    public void Overflow_FailsWithoutAdvancing()
+    {
+        NumberSequencePatches.ALInsert("Orders", long.MaxValue - 1, 2, true);
+        Assert.Equal(long.MaxValue - 1, NumberSequencePatches.ALNext("Orders", true));
+
+        var error = Assert.Throws<InvalidOperationException>(
+            () => NumberSequencePatches.ALNext("Orders", true));
+
+        Assert.Contains("range", error.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(long.MaxValue - 1, NumberSequencePatches.ALCurrent("Orders", true));
+    }
+
+    [Fact]
+    public void ByRefSetterFailure_DoesNotAdvanceRange()
+    {
+        NumberSequencePatches.ALInsert("Orders", 10, 3, true);
+#pragma warning disable CA1416 // The standalone runner executes BC's platform-annotated ByRef wrapper cross-platform.
+        var increment = new ByRef<long>(() => 0, _ => throw new InvalidOperationException("setter failed"));
+#pragma warning restore CA1416
+
+        Assert.Throws<InvalidOperationException>(
+            () => NumberSequencePatches.ALRange("Orders", 2, increment, true));
+
+        Assert.Equal(10, NumberSequencePatches.ALNext("Orders", true));
+    }
+
+    [Fact]
+    public void ConcurrentNext_AllocatesEachValueOnce()
+    {
+        NumberSequencePatches.ALInsert("Orders", 1, 1, true);
+        var values = new ConcurrentBag<long>();
+
+        Parallel.For(0, 100, _ => values.Add(NumberSequencePatches.ALNext("Orders", true)));
+
+        Assert.Equal(Enumerable.Range(1, 100).Select(value => (long)value), values.Order());
+    }
+
+    [Fact]
+    public void ConcurrentRange_AllocatesNonOverlappingBlocks()
+    {
+        NumberSequencePatches.ALInsert("Orders", 1, 2, true);
+        var starts = new ConcurrentBag<long>();
+
+        Parallel.For(0, 50, _ => starts.Add(NumberSequencePatches.ALRange("Orders", 3, true)));
+
+        Assert.Equal(
+            Enumerable.Range(0, 50).Select(index => 1L + (index * 6L)),
+            starts.Order());
+        Assert.Equal(299, NumberSequencePatches.ALCurrent("Orders", true));
+    }
+
+    [Fact]
+    public void PerTestRollbackReset_DoesNotReturnAllocatedValues()
+    {
+        NumberSequencePatches.ALInsert("Orders", 1, 1, true);
+        Assert.Equal(1, NumberSequencePatches.ALNext("Orders", true));
+
+        RecordPatches.ResetPerTestState();
+
+        Assert.True(NumberSequencePatches.ALExists("Orders", true));
+        Assert.Equal(2, NumberSequencePatches.ALNext("Orders", true));
+    }
+
+    [Fact]
+    public void ResetForNewExecution_ClearsAllScopes()
+    {
+        NumberSequencePatches.ALInsert("Orders", 1, 1, true);
+        NumberSequencePatches.ALInsert("Orders", 1, 1, false);
+
+        NumberSequencePatches.ResetForNewExecution();
+
+        Assert.False(NumberSequencePatches.ALExists("Orders", true));
+        Assert.False(NumberSequencePatches.ALExists("Orders", false));
+    }
+}

--- a/AlRunner.Tests/NumberSequenceServerResetTests.cs
+++ b/AlRunner.Tests/NumberSequenceServerResetTests.cs
@@ -1,0 +1,136 @@
+using System.Text.Json;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class NumberSequenceServerResetTests
+{
+    [SkippableFact]
+    public async Task ConsecutiveServerRequests_StartWithIndependentSequenceState()
+    {
+        TestArtifacts.SkipIfMissing();
+        var bundle = CreateProbeBundle();
+        try
+        {
+            var request = JsonSerializer.Serialize(new
+            {
+                command = "runTests",
+                sourcePaths = new[] { bundle },
+                packagePaths = Array.Empty<string>(),
+            });
+
+            await using var server = await CliServer.StartAsync();
+
+            AssertSuccessful(await server.SendRequestStreamingAsync(request));
+            AssertSuccessful(await server.SendRequestStreamingAsync(request));
+        }
+        finally
+        {
+            try { Directory.Delete(bundle, recursive: true); } catch { }
+        }
+    }
+
+    private static string CreateProbeBundle()
+    {
+        var directory = Path.Combine(
+            Path.GetTempPath(), "al-runner-number-sequence-server", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        File.WriteAllText(Path.Combine(directory, "app.json"), """
+        {
+          "id": "419709b5-6033-4f36-b3da-4491742d5485",
+          "name": "Runner Tests - Number Sequence Server Reset",
+          "publisher": "AL Runner",
+          "version": "1.0.0.0",
+          "dependencies": [],
+          "platform": "1.0.0.0",
+          "application": "1.0.0.0",
+          "idRanges": [ { "from": 64590, "to": 64590 } ],
+          "runtime": "14.0"
+        }
+        """);
+        File.WriteAllText(Path.Combine(directory, "Probe.Codeunit.al"), """
+        codeunit 64590 "Number Sequence Reset Tests"
+        {
+            Subtype = Test;
+
+            [Test]
+            procedure DefaultAndGlobalScopesAllocateConfiguredValues()
+            begin
+                NumberSequence.Insert('ALRunnerDefaultScope', 5, 2);
+                if NumberSequence.Next('ALRunnerDefaultScope') <> 5 then
+                    Error('Default-scope NumberSequence did not allocate its seed.');
+
+                NumberSequence.Insert('ALRunnerGlobalScope', 10, 3, false);
+                if NumberSequence.Next('ALRunnerGlobalScope', false) <> 10 then
+                    Error('Global NumberSequence did not allocate its seed.');
+                if NumberSequence.Next('ALRunnerGlobalScope', false) <> 13 then
+                    Error('Global NumberSequence did not apply its increment.');
+            end;
+
+            [Test]
+            procedure CurrentRestartAndDeleteWork()
+            begin
+                NumberSequence.Insert('ALRunnerLifecycle', 10, 3, false);
+                if NumberSequence.Current('ALRunnerLifecycle', false) <> 10 then
+                    Error('Current did not expose the configured seed.');
+
+                NumberSequence.Restart('ALRunnerLifecycle', 50, false);
+                if NumberSequence.Next('ALRunnerLifecycle', false) <> 50 then
+                    Error('Restart did not supply the next value.');
+
+                NumberSequence.Delete('ALRunnerLifecycle', false);
+                if NumberSequence.Exists('ALRunnerLifecycle', false) then
+                    Error('Delete did not remove the sequence.');
+            end;
+
+            [Test]
+            procedure RangeReportsIncrementAndReservesValues()
+            var
+                First: BigInteger;
+                Increment: BigInteger;
+            begin
+                NumberSequence.Insert('ALRunnerRange', 10, 3, false);
+                First := NumberSequence.Range('ALRunnerRange', 4, Increment, false);
+                if First <> 10 then
+                    Error('Range did not return the configured seed.');
+                if Increment <> 3 then
+                    Error('Range did not report the configured increment.');
+                if NumberSequence.Current('ALRunnerRange', false) <> 19 then
+                    Error('Range did not reserve the requested values.');
+            end;
+
+            [Test]
+            procedure DuplicateInsertRaisesCatchableError()
+            begin
+                NumberSequence.Insert('ALRunnerDuplicate', 1, 1, false);
+
+                asserterror NumberSequence.Insert('ALRunnerDuplicate', 1, 1, false);
+                if StrPos(GetLastErrorText(), 'already exists') = 0 then
+                    Error('Duplicate Insert returned the wrong error: %1', GetLastErrorText());
+            end;
+
+            [Test]
+            procedure MissingNextRaisesCatchableError()
+            var
+                Value: BigInteger;
+            begin
+                asserterror Value := NumberSequence.Next('ALRunnerMissing', false);
+                if StrPos(GetLastErrorText(), 'does not exist') = 0 then
+                    Error('Missing Next returned the wrong error: %1', GetLastErrorText());
+            end;
+        }
+        """);
+        return directory;
+    }
+
+    private static void AssertSuccessful(IReadOnlyList<string> response)
+    {
+        var (events, summary) = ProtocolV2Streaming.Split(response);
+        Assert.Equal(5, summary.GetProperty("passed").GetInt32());
+        Assert.Equal(0, summary.GetProperty("failed").GetInt32());
+        Assert.Equal(0, summary.GetProperty("errors").GetInt32());
+        Assert.Equal(0, summary.GetProperty("exitCode").GetInt32());
+        Assert.Equal(5, events.Count);
+        Assert.All(events, test => Assert.Equal("pass", test.GetProperty("status").GetString()));
+    }
+}

--- a/AlRunner.Tests/NumberSequenceServerResetTests.cs
+++ b/AlRunner.Tests/NumberSequenceServerResetTests.cs
@@ -9,26 +9,27 @@ public sealed class NumberSequenceServerResetTests
     public async Task ConsecutiveServerRequests_StartWithIndependentSequenceState()
     {
         TestArtifacts.SkipIfMissing();
-        var bundle = CreateProbeBundle();
+        var bundles = new[] { CreateProbeBundle(), CreateProbeBundle() };
         try
         {
-            var request = JsonSerializer.Serialize(new
-            {
-                command = "runTests",
-                sourcePaths = new[] { bundle },
-                packagePaths = Array.Empty<string>(),
-            });
-
             await using var server = await CliServer.StartAsync();
 
-            AssertSuccessful(await server.SendRequestStreamingAsync(request));
-            AssertSuccessful(await server.SendRequestStreamingAsync(request));
+            foreach (var bundle in bundles)
+                AssertSuccessful(await server.SendRequestStreamingAsync(CreateRequest(bundle)));
         }
         finally
         {
-            try { Directory.Delete(bundle, recursive: true); } catch { }
+            foreach (var bundle in bundles)
+                try { Directory.Delete(bundle, recursive: true); } catch { }
         }
     }
+
+    private static string CreateRequest(string bundle) => JsonSerializer.Serialize(new
+    {
+        command = "runTests",
+        sourcePaths = new[] { bundle },
+        packagePaths = Array.Empty<string>(),
+    });
 
     private static string CreateProbeBundle()
     {
@@ -54,69 +55,14 @@ public sealed class NumberSequenceServerResetTests
             Subtype = Test;
 
             [Test]
-            procedure DefaultAndGlobalScopesAllocateConfiguredValues()
+            procedure RequestStartsWithFreshSequenceState()
             begin
-                NumberSequence.Insert('ALRunnerDefaultScope', 5, 2);
-                if NumberSequence.Next('ALRunnerDefaultScope') <> 5 then
-                    Error('Default-scope NumberSequence did not allocate its seed.');
+                if NumberSequence.Exists('ALRunnerRequestState', false) then
+                    Error('NumberSequence state leaked from an earlier server request.');
 
-                NumberSequence.Insert('ALRunnerGlobalScope', 10, 3, false);
-                if NumberSequence.Next('ALRunnerGlobalScope', false) <> 10 then
-                    Error('Global NumberSequence did not allocate its seed.');
-                if NumberSequence.Next('ALRunnerGlobalScope', false) <> 13 then
-                    Error('Global NumberSequence did not apply its increment.');
-            end;
-
-            [Test]
-            procedure CurrentRestartAndDeleteWork()
-            begin
-                NumberSequence.Insert('ALRunnerLifecycle', 10, 3, false);
-                if NumberSequence.Current('ALRunnerLifecycle', false) <> 10 then
-                    Error('Current did not expose the configured seed.');
-
-                NumberSequence.Restart('ALRunnerLifecycle', 50, false);
-                if NumberSequence.Next('ALRunnerLifecycle', false) <> 50 then
-                    Error('Restart did not supply the next value.');
-
-                NumberSequence.Delete('ALRunnerLifecycle', false);
-                if NumberSequence.Exists('ALRunnerLifecycle', false) then
-                    Error('Delete did not remove the sequence.');
-            end;
-
-            [Test]
-            procedure RangeReportsIncrementAndReservesValues()
-            var
-                First: BigInteger;
-                Increment: BigInteger;
-            begin
-                NumberSequence.Insert('ALRunnerRange', 10, 3, false);
-                First := NumberSequence.Range('ALRunnerRange', 4, Increment, false);
-                if First <> 10 then
-                    Error('Range did not return the configured seed.');
-                if Increment <> 3 then
-                    Error('Range did not report the configured increment.');
-                if NumberSequence.Current('ALRunnerRange', false) <> 19 then
-                    Error('Range did not reserve the requested values.');
-            end;
-
-            [Test]
-            procedure DuplicateInsertRaisesCatchableError()
-            begin
-                NumberSequence.Insert('ALRunnerDuplicate', 1, 1, false);
-
-                asserterror NumberSequence.Insert('ALRunnerDuplicate', 1, 1, false);
-                if StrPos(GetLastErrorText(), 'already exists') = 0 then
-                    Error('Duplicate Insert returned the wrong error: %1', GetLastErrorText());
-            end;
-
-            [Test]
-            procedure MissingNextRaisesCatchableError()
-            var
-                Value: BigInteger;
-            begin
-                asserterror Value := NumberSequence.Next('ALRunnerMissing', false);
-                if StrPos(GetLastErrorText(), 'does not exist') = 0 then
-                    Error('Missing Next returned the wrong error: %1', GetLastErrorText());
+                NumberSequence.Insert('ALRunnerRequestState', 1, 1, false);
+                if not NumberSequence.Exists('ALRunnerRequestState', false) then
+                    Error('NumberSequence.Insert did not create request-local state.');
             end;
         }
         """);
@@ -126,11 +72,11 @@ public sealed class NumberSequenceServerResetTests
     private static void AssertSuccessful(IReadOnlyList<string> response)
     {
         var (events, summary) = ProtocolV2Streaming.Split(response);
-        Assert.Equal(5, summary.GetProperty("passed").GetInt32());
+        Assert.Equal(1, summary.GetProperty("passed").GetInt32());
         Assert.Equal(0, summary.GetProperty("failed").GetInt32());
         Assert.Equal(0, summary.GetProperty("errors").GetInt32());
         Assert.Equal(0, summary.GetProperty("exitCode").GetInt32());
-        Assert.Equal(5, events.Count);
+        Assert.Single(events);
         Assert.All(events, test => Assert.Equal("pass", test.GetProperty("status").GetString()));
     }
 }

--- a/AlRunner/Infrastructure/NclCecilRewrite.cs
+++ b/AlRunner/Infrastructure/NclCecilRewrite.cs
@@ -19,7 +19,7 @@ namespace AlRunner.Infrastructure;
 
 public static class NclCecilRewrite
 {
-    private const int CACHE_VERSION = 128;
+    private const int CACHE_VERSION = 130;
 
     // ─────────────────────────────────────────────────────────────────────────
     // Cecil-owned skip registry (JmpHook→Cecil migration enabler).
@@ -54,6 +54,26 @@ public static class NclCecilRewrite
         // once the JmpHook layer went off by default — so BC's SQL body ran and NRE'd.
         "Microsoft.Dynamics.Nav.Runtime.ALDatabase::ALLastUsedRowVersion/0",
         "Microsoft.Dynamics.Nav.Runtime.ALDatabase::ALMinimumActiveRowVersion/0",
+        // AL NumberSequence's public synchronous entry points. Their real bodies
+        // delegate to SQL-backed async methods and NRE on the standalone skeleton.
+        "Microsoft.Dynamics.Nav.Runtime.ALNumberSequence::ALInsert/4",
+        "Microsoft.Dynamics.Nav.Runtime.ALNumberSequence::ALRestart/3",
+        "Microsoft.Dynamics.Nav.Runtime.ALNumberSequence::ALExists/2",
+        "Microsoft.Dynamics.Nav.Runtime.ALNumberSequence::ALDelete/2",
+        "Microsoft.Dynamics.Nav.Runtime.ALNumberSequence::ALNext/2",
+        "Microsoft.Dynamics.Nav.Runtime.ALNumberSequence::ALCurrent/2",
+        "Microsoft.Dynamics.Nav.Runtime.ALNumberSequence::ALRange/3",
+        "Microsoft.Dynamics.Nav.Runtime.ALNumberSequence::ALRange/4",
+        // Precompiled Microsoft apps call these async entry points directly instead of
+        // passing through the synchronous AL wrappers, so both surfaces must share state.
+        "Microsoft.Dynamics.Nav.Runtime.ALNumberSequence::ALInsertAsync/5",
+        "Microsoft.Dynamics.Nav.Runtime.ALNumberSequence::ALRestartAsync/4",
+        "Microsoft.Dynamics.Nav.Runtime.ALNumberSequence::ALExistsAsync/3",
+        "Microsoft.Dynamics.Nav.Runtime.ALNumberSequence::ALDeleteAsync/3",
+        "Microsoft.Dynamics.Nav.Runtime.ALNumberSequence::ALNextAsync/3",
+        "Microsoft.Dynamics.Nav.Runtime.ALNumberSequence::ALCurrentAsync/3",
+        "Microsoft.Dynamics.Nav.Runtime.ALNumberSequence::ALRangeAsync/4",
+        "Microsoft.Dynamics.Nav.Runtime.ALNumberSequence::ALRangeAsync/5",
         // ALDatabase.get_ALSerialNumber (#1883 follow-up) — genuinely NREs standalone
         // (NavSession.get_License() chain), confirmed empirically. Cecil-migrated onto the
         // ReturnStandalone_0Args sentinel; legacy JmpHook registration deleted from BcRuntime.cs.
@@ -409,6 +429,35 @@ public static class NclCecilRewrite
     /// </summary>
     public static string Key(MethodBase m)
         => NormalizeTypeName(m.DeclaringType?.FullName ?? "") + "::" + m.Name + "/" + m.GetParameters().Length;
+
+    internal static MethodDefinition ResolveNumberSequenceEntryPoint(
+        TypeDefinition type,
+        string methodName,
+        string returnType,
+        params string[] parameterTypes)
+    {
+        var matches = type.Methods.Where(method =>
+                method.Name == methodName &&
+                method.IsPublic &&
+                method.IsStatic &&
+                method.HasBody &&
+                method.ReturnType.FullName == returnType &&
+                method.Parameters.Select(parameter => parameter.ParameterType.FullName)
+                    .SequenceEqual(parameterTypes, StringComparer.Ordinal))
+            .ToArray();
+
+        if (matches.Length == 1)
+            return matches[0];
+
+        var expected = $"{returnType} {type.FullName}.{methodName}({string.Join(", ", parameterTypes)})";
+        var available = string.Join("; ", type.Methods
+            .Where(method => method.Name == methodName)
+            .Select(method => method.FullName));
+        throw new InvalidOperationException(
+            $"[Cecil] expected exactly one {expected}, found {matches.Length}. " +
+            $"Available overloads: {(available.Length == 0 ? "<none>" : available)}. " +
+            "Ncl shape changed; do not commit (#2049).");
+    }
 
     // Cecil uses '/' between an outer type and a nested type; reflection uses '+'.
     // Our targets are all top-level so neither separator appears, but normalize
@@ -2732,6 +2781,102 @@ public static class NclCecilRewrite
 
                 Console.Error.WriteLine("[Cecil] Patched NavDotNet.CreateDotNet catch-all → RethrowIfRunnerOOS guard");
             }
+        }
+
+        // ALNumberSequence — runner-emitted AL calls the synchronous entry points, while
+        // precompiled Microsoft apps call the async entry points directly. Rewrite both
+        // public surfaces so neither can reach SQL and both observe the same store.
+        {
+            const string sequenceTypeName = "Microsoft.Dynamics.Nav.Runtime.ALNumberSequence";
+            var sequenceType = asm.MainModule.GetType(sequenceTypeName)
+                ?? throw new InvalidOperationException(
+                    $"[Cecil] type {sequenceTypeName} not found — Ncl shape changed; do not commit (#2049)");
+            var patchType = typeof(AlRunner.Patches.NumberSequencePatches);
+
+            void RewriteSequence(
+                string methodName,
+                string returnType,
+                Type[] helperParameterTypes,
+                params string[] nclParameterTypes)
+            {
+                var target = ResolveNumberSequenceEntryPoint(
+                    sequenceType, methodName, returnType, nclParameterTypes);
+                var helper = patchType.GetMethod(
+                    methodName,
+                    BindingFlags.Public | BindingFlags.Static,
+                    binder: null,
+                    types: helperParameterTypes,
+                    modifiers: null)
+                    ?? throw new InvalidOperationException(
+                        $"[Cecil] helper {patchType.Name}.{methodName}({string.Join(", ", helperParameterTypes.Select(type => type.Name))}) not found");
+                var helperReturnType = asm.MainModule.ImportReference(helper.ReturnType).FullName;
+                var helperParameters = helper.GetParameters()
+                    .Select(parameter => asm.MainModule.ImportReference(parameter.ParameterType).FullName)
+                    .ToArray();
+                if (helperReturnType != returnType ||
+                    !helperParameters.SequenceEqual(nclParameterTypes, StringComparer.Ordinal))
+                    throw new InvalidOperationException(
+                        $"[Cecil] helper {helper} does not exactly match {target.FullName}");
+                var asyncAttribute = target.CustomAttributes.FirstOrDefault(attribute =>
+                    attribute.AttributeType.Name == "AsyncStateMachineAttribute");
+                if (asyncAttribute != null)
+                    target.CustomAttributes.Remove(asyncAttribute);
+                ReplaceBodyWithHelper(asm.MainModule, target, helper);
+            }
+
+            RewriteSequence("ALInsert", "System.Void",
+                new[] { typeof(string), typeof(long), typeof(long), typeof(bool) },
+                "System.String", "System.Int64", "System.Int64", "System.Boolean");
+            RewriteSequence("ALRestart", "System.Void",
+                new[] { typeof(string), typeof(long), typeof(bool) },
+                "System.String", "System.Int64", "System.Boolean");
+            RewriteSequence("ALExists", "System.Boolean",
+                new[] { typeof(string), typeof(bool) },
+                "System.String", "System.Boolean");
+            RewriteSequence("ALDelete", "System.Void",
+                new[] { typeof(string), typeof(bool) },
+                "System.String", "System.Boolean");
+            RewriteSequence("ALNext", "System.Int64",
+                new[] { typeof(string), typeof(bool) },
+                "System.String", "System.Boolean");
+            RewriteSequence("ALCurrent", "System.Int64",
+                new[] { typeof(string), typeof(bool) },
+                "System.String", "System.Boolean");
+            RewriteSequence("ALRange", "System.Int64",
+                new[] { typeof(string), typeof(int), typeof(bool) },
+                "System.String", "System.Int32", "System.Boolean");
+            RewriteSequence("ALRange", "System.Int64",
+                new[] { typeof(string), typeof(int), typeof(Microsoft.Dynamics.Nav.Runtime.ByRef<long>), typeof(bool) },
+                "System.String", "System.Int32",
+                "Microsoft.Dynamics.Nav.Runtime.ByRef`1<System.Int64>", "System.Boolean");
+
+            RewriteSequence("ALInsertAsync", "System.Threading.Tasks.ValueTask",
+                new[] { typeof(Microsoft.Dynamics.Nav.Runtime.NavSession), typeof(string), typeof(long), typeof(long), typeof(bool) },
+                "Microsoft.Dynamics.Nav.Runtime.NavSession", "System.String", "System.Int64", "System.Int64", "System.Boolean");
+            RewriteSequence("ALRestartAsync", "System.Threading.Tasks.ValueTask",
+                new[] { typeof(Microsoft.Dynamics.Nav.Runtime.NavSession), typeof(string), typeof(long), typeof(bool) },
+                "Microsoft.Dynamics.Nav.Runtime.NavSession", "System.String", "System.Int64", "System.Boolean");
+            RewriteSequence("ALExistsAsync", "System.Threading.Tasks.ValueTask`1<System.Boolean>",
+                new[] { typeof(Microsoft.Dynamics.Nav.Runtime.NavSession), typeof(string), typeof(bool) },
+                "Microsoft.Dynamics.Nav.Runtime.NavSession", "System.String", "System.Boolean");
+            RewriteSequence("ALDeleteAsync", "System.Threading.Tasks.ValueTask",
+                new[] { typeof(Microsoft.Dynamics.Nav.Runtime.NavSession), typeof(string), typeof(bool) },
+                "Microsoft.Dynamics.Nav.Runtime.NavSession", "System.String", "System.Boolean");
+            RewriteSequence("ALNextAsync", "System.Threading.Tasks.ValueTask`1<System.Int64>",
+                new[] { typeof(Microsoft.Dynamics.Nav.Runtime.NavSession), typeof(string), typeof(bool) },
+                "Microsoft.Dynamics.Nav.Runtime.NavSession", "System.String", "System.Boolean");
+            RewriteSequence("ALCurrentAsync", "System.Threading.Tasks.ValueTask`1<System.Int64>",
+                new[] { typeof(Microsoft.Dynamics.Nav.Runtime.NavSession), typeof(string), typeof(bool) },
+                "Microsoft.Dynamics.Nav.Runtime.NavSession", "System.String", "System.Boolean");
+            RewriteSequence("ALRangeAsync", "System.Threading.Tasks.ValueTask`1<System.Int64>",
+                new[] { typeof(Microsoft.Dynamics.Nav.Runtime.NavSession), typeof(string), typeof(int), typeof(bool) },
+                "Microsoft.Dynamics.Nav.Runtime.NavSession", "System.String", "System.Int32", "System.Boolean");
+            RewriteSequence("ALRangeAsync", "System.Threading.Tasks.ValueTask`1<System.Int64>",
+                new[] { typeof(Microsoft.Dynamics.Nav.Runtime.NavSession), typeof(string), typeof(int), typeof(Microsoft.Dynamics.Nav.Runtime.ByRef<long>), typeof(bool) },
+                "Microsoft.Dynamics.Nav.Runtime.NavSession", "System.String", "System.Int32",
+                "Microsoft.Dynamics.Nav.Runtime.ByRef`1<System.Int64>", "System.Boolean");
+            Console.Error.WriteLine(
+                "[Cecil] Rewrote ALNumberSequence sync+async {Insert,Restart,Exists,Delete,Next,Current,Range×2} → in-memory store");
         }
 
         // IsolatedStorageRepository — Cecil migration of the TenantStoragePatches

--- a/AlRunner/Patches/NumberSequencePatches.cs
+++ b/AlRunner/Patches/NumberSequencePatches.cs
@@ -1,0 +1,248 @@
+using System.Runtime.CompilerServices;
+using Microsoft.Dynamics.Nav.Runtime;
+
+namespace AlRunner.Patches;
+
+/// <summary>
+/// Process-local backing store for AL's NumberSequence data type. Values are shared for
+/// one runner execution and cleared explicitly at the CLI/watch/server execution boundary.
+/// Like BC's SQL sequence, Current initially exposes the configured start value, Next first
+/// returns that start and then applies the increment, Restart supplies the next value, Range
+/// atomically reserves values, and allocations survive AL transaction rollback. Every invalid
+/// operation still fails, although issue #2049 explicitly permits runner-specific error text.
+/// The (name, CompanySpecific) key intentionally models only the runner's single-company scope;
+/// database persistence and company switching remain outside that issue's initial contract.
+/// </summary>
+public static class NumberSequencePatches
+{
+    private sealed class SequenceState
+    {
+        public SequenceState(long seed, long increment)
+        {
+            Current = seed;
+            Increment = increment;
+        }
+
+        public long Current { get; set; }
+        public long Increment { get; }
+        public bool HasAllocated { get; set; }
+    }
+
+    private sealed class SequenceKeyComparer : IEqualityComparer<(string Name, bool CompanySpecific)>
+    {
+        public bool Equals(
+            (string Name, bool CompanySpecific) left,
+            (string Name, bool CompanySpecific) right) =>
+            left.CompanySpecific == right.CompanySpecific &&
+            StringComparer.OrdinalIgnoreCase.Equals(left.Name, right.Name);
+
+        public int GetHashCode((string Name, bool CompanySpecific) key) =>
+            HashCode.Combine(StringComparer.OrdinalIgnoreCase.GetHashCode(key.Name), key.CompanySpecific);
+    }
+
+    private static readonly object _sync = new();
+    private static readonly Dictionary<(string Name, bool CompanySpecific), SequenceState> _sequences =
+        new(new SequenceKeyComparer());
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void ALInsert(string name, long seed, long increment, bool companySpecific)
+    {
+        ArgumentNullException.ThrowIfNull(name);
+        if (increment == 0)
+            throw new ArgumentOutOfRangeException(nameof(increment), "Number sequence increment cannot be zero.");
+
+        lock (_sync)
+        {
+            var key = (name, companySpecific);
+            if (!_sequences.TryAdd(key, new SequenceState(seed, increment)))
+                throw new InvalidOperationException($"Number sequence '{name}' already exists.");
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static bool ALExists(string name, bool companySpecific)
+    {
+        ArgumentNullException.ThrowIfNull(name);
+        lock (_sync)
+            return _sequences.ContainsKey((name, companySpecific));
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static long ALCurrent(string name, bool companySpecific)
+    {
+        ArgumentNullException.ThrowIfNull(name);
+        lock (_sync)
+            return GetExisting(name, companySpecific).Current;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static long ALNext(string name, bool companySpecific)
+    {
+        ArgumentNullException.ThrowIfNull(name);
+        lock (_sync)
+        {
+            var state = GetExisting(name, companySpecific);
+            var next = state.HasAllocated
+                ? AddChecked(name, state.Current, state.Increment)
+                : state.Current;
+            state.Current = next;
+            state.HasAllocated = true;
+            return next;
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void ALRestart(string name, long seed, bool companySpecific)
+    {
+        ArgumentNullException.ThrowIfNull(name);
+        lock (_sync)
+        {
+            var state = GetExisting(name, companySpecific);
+            state.Current = seed;
+            state.HasAllocated = false;
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void ALDelete(string name, bool companySpecific)
+    {
+        ArgumentNullException.ThrowIfNull(name);
+        lock (_sync)
+        {
+            if (!_sequences.Remove((name, companySpecific)))
+                throw MissingSequence(name);
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static long ALRange(string name, int count, bool companySpecific) =>
+        ReserveRange(name, count, incrementOutput: null, companySpecific);
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static long ALRange(
+        string name,
+        int count,
+        ByRef<long> increment,
+        bool companySpecific)
+    {
+        ArgumentNullException.ThrowIfNull(increment);
+        return ReserveRange(name, count, increment, companySpecific);
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static ValueTask ALInsertAsync(
+        NavSession _, string name, long seed, long increment, bool companySpecific)
+    {
+        ALInsert(name, seed, increment, companySpecific);
+        return ValueTask.CompletedTask;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static ValueTask ALRestartAsync(
+        NavSession _, string name, long seed, bool companySpecific)
+    {
+        ALRestart(name, seed, companySpecific);
+        return ValueTask.CompletedTask;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static ValueTask<bool> ALExistsAsync(NavSession _, string name, bool companySpecific) =>
+        ValueTask.FromResult(ALExists(name, companySpecific));
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static ValueTask ALDeleteAsync(NavSession _, string name, bool companySpecific)
+    {
+        ALDelete(name, companySpecific);
+        return ValueTask.CompletedTask;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static ValueTask<long> ALNextAsync(NavSession _, string name, bool companySpecific) =>
+        ValueTask.FromResult(ALNext(name, companySpecific));
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static ValueTask<long> ALCurrentAsync(NavSession _, string name, bool companySpecific) =>
+        ValueTask.FromResult(ALCurrent(name, companySpecific));
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static ValueTask<long> ALRangeAsync(
+        NavSession _, string name, int count, bool companySpecific) =>
+        ValueTask.FromResult(ALRange(name, count, companySpecific));
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static ValueTask<long> ALRangeAsync(
+        NavSession _, string name, int count, ByRef<long> increment, bool companySpecific) =>
+        ValueTask.FromResult(ALRange(name, count, increment, companySpecific));
+
+    public static void ResetForNewExecution()
+    {
+        lock (_sync)
+            _sequences.Clear();
+    }
+
+    private static long ReserveRange(
+        string name,
+        int count,
+        ByRef<long>? incrementOutput,
+        bool companySpecific)
+    {
+        ArgumentNullException.ThrowIfNull(name);
+        if (count <= 0)
+            throw new ArgumentOutOfRangeException(nameof(count), "Number sequence range count must be greater than zero.");
+
+        lock (_sync)
+        {
+            var state = GetExisting(name, companySpecific);
+            var first = state.HasAllocated
+                ? AddChecked(name, state.Current, state.Increment)
+                : state.Current;
+            var last = AddChecked(name, first, MultiplyChecked(name, state.Increment, count - 1L));
+
+            // Ncl's ByRef setter is a runtime-generated write to the caller's variable.
+            // Keep it inside the reservation lock so failed writeback leaves the sequence
+            // untouched and no concurrent allocation can interleave before state commits.
+            if (incrementOutput != null)
+                incrementOutput.Value = state.Increment;
+            state.Current = last;
+            state.HasAllocated = true;
+            return first;
+        }
+    }
+
+    private static SequenceState GetExisting(string name, bool companySpecific)
+    {
+        if (_sequences.TryGetValue((name, companySpecific), out var state))
+            return state;
+        throw MissingSequence(name);
+    }
+
+    private static InvalidOperationException MissingSequence(string name) =>
+        new($"Number sequence '{name}' does not exist.");
+
+    private static long AddChecked(string name, long left, long right)
+    {
+        try
+        {
+            return checked(left + right);
+        }
+        catch (OverflowException exception)
+        {
+            throw OutOfRange(name, exception);
+        }
+    }
+
+    private static long MultiplyChecked(string name, long left, long right)
+    {
+        try
+        {
+            return checked(left * right);
+        }
+        catch (OverflowException exception)
+        {
+            throw OutOfRange(name, exception);
+        }
+    }
+
+    private static InvalidOperationException OutOfRange(string name, OverflowException inner) =>
+        new($"Number sequence '{name}' moved outside the supported BigInteger range.", inner);
+}

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -1768,6 +1768,9 @@ if (watchUi) PaintWatchRunning();
 
 while (true)
 {
+// A watch rerun is a new execution even though it reuses the process. NumberSequence
+// values deliberately survive bundle and test boundaries within this cycle.
+AlRunner.Patches.NumberSequencePatches.ResetForNewExecution();
 results.Clear();
 watchFullRebuildReasons.Clear();
 // Clean loading (#5): the interactive dashboard owns the whole screen, but the
@@ -3245,6 +3248,10 @@ return strictExitCode ? computedExitCode : 0;
         Func<Assembly, IReadOnlyList<TestResult>> runStep,
         System.Threading.CancellationToken cancellationToken = default)
     {
+        // Server requests share a process, so give each request the same fresh
+        // NumberSequence lifetime as a standalone CLI/watch execution.
+        AlRunner.Patches.NumberSequencePatches.ResetForNewExecution();
+
         // Drop the previous REQUEST's bundle-derived caches so a reloaded same-named
         // bundle resolves the freshly-emitted Record/Codeunit types and starts with
         // empty in-memory tables. Once per request, NOT per bundle: the CLI bucket


### PR DESCRIPTION
Closes #2049

## Summary

Redirects the synchronous and asynchronous `ALNumberSequence` entry points in `Microsoft.Dynamics.Nav.Ncl.dll` from the SQL-backed implementation to a thread-safe, process-local store.

The store supports `Exists`, `Insert`, `Next`, `Current`, `Restart`, `Delete`, and both `Range` overloads, including `ByRef`. It preserves seed and increment behavior, separates company-specific and global sequences, treats names case-insensitively, and throws for invalid operations instead of returning defaults.

Sequence state lasts for one CLI or watch execution and resets between independent server requests. Allocations survive AL transaction rollback.

The corresponding Business Central behavior is captured in [BusinessCentral.AL.Language.Tests #68](https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests/pull/68). This PR keeps only runner-specific coverage in this repository.

## Proof

- [`Test Number Sequence`](https://github.com/vhn/BusinessCentral.AL.Language.Tests/blob/fbb4a500d19213b2772bc744bec8cb0c91ffc02a/tests/al-language/session/TestNumberSequence.al) is the AL-language regression suite for scope, allocation, lifecycle, `Range`, and error behavior.
- [`NumberSequenceServerResetTests.ConsecutiveServerRequests_StartWithIndependentSequenceState`](https://github.com/StefanMaron/BusinessCentral.AL.Runner/blob/13250f2618ef189f39823951811b85c439fde830/AlRunner.Tests/NumberSequenceServerResetTests.cs#L9) runs two independent requests with the same app ID and proves that sequence state does not leak between them.
- [`NumberSequenceCecilBindingTests`](https://github.com/StefanMaron/BusinessCentral.AL.Runner/blob/13250f2618ef189f39823951811b85c439fde830/AlRunner.Tests/NumberSequenceCecilBindingTests.cs) proves that the synchronous and asynchronous Ncl entry points use the in-memory store.
- [`NumberSequencePatchesTests`](https://github.com/StefanMaron/BusinessCentral.AL.Runner/blob/13250f2618ef189f39823951811b85c439fde830/AlRunner.Tests/NumberSequencePatchesTests.cs) covers store semantics, invalid operations, concurrency, rollback lifetime, and execution reset.
- [`NumberSequenceEntryPointResolutionTests`](https://github.com/StefanMaron/BusinessCentral.AL.Runner/blob/13250f2618ef189f39823951811b85c439fde830/AlRunner.Tests/NumberSequenceEntryPointResolutionTests.cs) proves that Cecil selects exact method shapes and fails loudly if the Ncl API changes.

## Contract notes

The Cecil rewrite changes `Microsoft.Dynamics.Nav.Ncl.dll`, which is runtime-engine code permitted by the precompiled-DLL contract. It does not modify Microsoft or ISV business-logic DLLs.

`NumberSequence` has an in-process implementation, so it is in scope and does not require `RunnerOutOfScopeException`. Invalid operations still fail explicitly.

This PR does not modify `CHANGELOG.md` or files under `tests/al-language/`; the corpus addition is isolated in BusinessCentral.AL.Language.Tests #68.