### PR TITLE
fix(query): aggregate Method columns instead of returning raw rows

### DIFF
--- a/AlRunner.Tests/BcAppSymbolCacheQueryMethodVersionTests.cs
+++ b/AlRunner.Tests/BcAppSymbolCacheQueryMethodVersionTests.cs
@@ -1,0 +1,213 @@
+// BcAppSymbolCacheQueryMethodVersionTests — proves the CacheVersion bump for
+// QueryColumnSymbol.Method (issue #2137) actually invalidates a stale on-disk entry,
+// instead of silently reintroducing the bug the field was added to fix.
+//
+// Gap being fixed
+// ----------------
+// QueryColumnSymbol.Method was added so BcAppSymbolCache.ParseQueryColumns carries the AL
+// `Method = Sum/Count/Average/Min/Max` property through to RecordPatches.QueryProjection's
+// GROUP BY aggregation. CachePayload (which holds QuerySymbol -> QueryDataItemSymbol ->
+// QueryColumnSymbol) is persisted to disk and read back via JsonSerializer, keyed by
+// `{fullPath}|hash:{contentHash}|v{CacheVersion}` (BcAppSymbolCache.Get). A machine whose
+// on-disk cache was written by the PREVIOUS build has an entry whose JSON has no "Method"
+// property at all — the .app's content hash has not changed, so without a CacheVersion
+// bump that entry keeps matching the key and Method deserialises as null on every
+// subsequent read, silently reintroducing #2137 (AggregationType stays None, the query
+// returns raw ungrouped rows) even though the fix is otherwise fully deployed. Bumping
+// CacheVersion changes the KEY STRING itself (see BcAppSymbolCache.CachePath — a SHA-256
+// hash of the key), so a stale v13 entry sits at a different on-disk filename entirely and
+// is never looked up; the .app is reparsed, and the fresh parse carries Method correctly.
+//
+// This is the same shape as every prior CacheVersion bump documented above the constant
+// (v9 LookupPageName, v11 SourceTableTemporary, v12 EnumSymbol.Captions, v13 PageSymbol's
+// PageType/Controls/CardPageName) — the fix for a "field defaults to a value that makes
+// old data readable but WRONG" bug is not just adding the field, it's making sure an old
+// payload can never satisfy the new key at all.
+//
+// Test strategy
+// -------------
+// A test that only writes and reads back a FRESH (v14) cache entry cannot catch a missing
+// version bump — a fresh entry always has Method, whichever version number the key embeds.
+// The decisive test therefore constructs the on-disk payload a v13 BUILD would have
+// written (a real .app's content hash, but a QueryColumnSymbol JSON shape with no "Method"
+// property at all — Query cache entries never carried it before this issue), places it at
+// the exact v13-keyed path, then calls Get() with the CURRENT code and asserts BOTH that
+// Method survives AND that BcAppSymbolCache actually reparsed (ParseInvocationCountForTests
+// == 1) rather than serving a HIT that merely happened to already have the right shape.
+//
+// Locating "the exact v13-keyed path" reuses BcAppSymbolCache.CachePathForVersionForTests
+// — an internal test seam that delegates to the SAME private CachePath hashing formula
+// Get() itself uses — rather than a hand-rolled copy of that formula in this file. A
+// review of an earlier version of this test caught exactly the risk a copy would carry:
+// if CachePath's hashing/layout ever changed, a duplicated copy here would keep computing
+// A path, just not the one Get() actually consults, and this test would then pass for the
+// wrong reason (write to a location nothing reads, MISS-and-reparse "succeeds" whether or
+// not the version bump is doing anything at all). Delegating to the real formula makes
+// that drift impossible instead of merely documented.
+using System.IO.Compression;
+using System.Text;
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+// #1821: BcAppSymbolCache.Get() resolves its on-disk path through the process-global
+// CacheRoots override, so this joins CacheRootsSerialCollection to avoid racing
+// CacheRootsTests's SetOverride calls — see that collection's header for why. This class
+// does not call SetOverride itself; like the other BcAppSymbolCache test classes it relies
+// on the content-addressed key (a fresh Guid-unique .app path per test) to make collisions
+// with the real shared bc-symbols cache directory practically impossible.
+[Collection(CacheRootsSerialCollection.Name)]
+public sealed class BcAppSymbolCacheQueryMethodVersionTests
+{
+    private static string NewTempDir()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "bc-symbol-cache-query-method-version-tests-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    private static string WriteApp(string dir, string fileName, string queryName)
+    {
+        var appPath = Path.Combine(dir, fileName);
+        using (var zip = new FileStream(appPath, FileMode.Create))
+        using (var za = new ZipArchive(zip, ZipArchiveMode.Create))
+        {
+            var entry = za.CreateEntry("SymbolReference.json");
+            using var w = new StreamWriter(entry.Open(), Encoding.UTF8);
+            w.Write($$"""
+                {
+                  "RuntimeVersion": "15.1",
+                  "Queries": [
+                    {
+                      "Id": 90210,
+                      "Name": "{{queryName}}",
+                      "Properties": [ { "Name": "QueryType", "Value": "Normal" } ],
+                      "Elements": [
+                        {
+                          "Id": 1,
+                          "Name": "Order",
+                          "RelatedTable": "CVT Order",
+                          "Properties": [],
+                          "Columns": [
+                            {
+                              "Id": 1,
+                              "Name": "TotalAmount",
+                              "SourceColumn": "Amount",
+                              "Properties": [ { "Name": "Method", "Value": "Sum" } ]
+                            }
+                          ],
+                          "Filters": []
+                        }
+                      ]
+                    }
+                  ]
+                }
+                """);
+        }
+        return appPath;
+    }
+
+    [Fact]
+    public void Get_StaleV13EntryWithNoMethodProperty_IsIgnored_AndTheAppIsReparsedWithMethodIntact()
+    {
+        var dir = NewTempDir();
+        try
+        {
+            var queryName = "CVT Order Sum " + Guid.NewGuid().ToString("N");
+            var appPath = WriteApp(dir, "agg-" + Guid.NewGuid().ToString("N") + ".app", queryName);
+
+            BcAppSymbolCache.ResetProcessCacheForTests();
+            var contentHash = BcAppSymbolCache.ComputeAppContentHash(appPath);
+
+            // The exact path a CacheVersion=13 build would have written to for this SAME
+            // .app content — a real machine's cache, unchanged .app bytes, pre-#2137
+            // runner build. Computed via the real CachePath formula (through the exposed
+            // test seam), never a copy of it — see the file header.
+            var staleCachePath = BcAppSymbolCache.CachePathForVersionForTests(appPath, contentHash, cacheVersion: 13);
+            Directory.CreateDirectory(Path.GetDirectoryName(staleCachePath)!);
+            // A v13 QueryColumnSymbol payload: no "Method" property in the JSON at all
+            // (the field did not exist yet) — exactly what a pre-fix TryWrite produced.
+            File.WriteAllText(staleCachePath, $$"""
+                {
+                  "ContentHash": "{{contentHash}}",
+                  "Tables": [], "Enums": [],
+                  "Queries": [
+                    {
+                      "Id": 90210, "Name": "{{queryName}}", "QueryType": "Normal", "Caption": null, "OrderBy": null,
+                      "TopNumberOfRowsToReturn": 0,
+                      "DataItems": [
+                        {
+                          "Id": 1, "Name": "Order", "RelatedTable": "CVT Order", "SqlJoinType": null, "DataItemLink": null,
+                          "Columns": [ { "Id": 1, "Name": "TotalAmount", "SourceColumn": "Amount", "Caption": null } ],
+                          "Filters": [], "DataItems": []
+                        }
+                      ]
+                    }
+                  ],
+                  "Objects": null, "Reports": null, "Pages": null
+                }
+                """);
+
+            Assert.Equal(0, BcAppSymbolCache.ParseInvocationCountForTests(appPath));
+
+            var symbols = BcAppSymbolCache.Get(appPath);
+
+            var query = Assert.Single(symbols.Queries, q => q.Name == queryName);
+            var dataItem = Assert.Single(query.DataItems);
+            var column = Assert.Single(dataItem.Columns);
+
+            // The decisive assertions: Method survived (only possible if the stale
+            // Method-less v13 entry was NOT served), and the .app was genuinely reparsed
+            // (ParseInvocationCount == 1) rather than the stale file being read as a HIT
+            // that merely happened, by construction of this test, to already be correct.
+            Assert.Equal("Sum", column.Method);
+            Assert.Equal(1, BcAppSymbolCache.ParseInvocationCountForTests(appPath));
+
+            // Prove the test's own premise, not just the outcome: the freshly-reparsed
+            // entry now lives at the CURRENT version's path (distinct from the stale v13
+            // one above), which is the concrete mechanism the whole test is claiming — a
+            // version bump moves the on-disk location, it doesn't patch the old file.
+            var currentCachePath = BcAppSymbolCache.CachePathForVersionForTests(
+                appPath, contentHash, BcAppSymbolCache.CacheVersionForTests);
+            Assert.NotEqual(staleCachePath, currentCachePath);
+            Assert.True(File.Exists(currentCachePath),
+                $"Expected a fresh cache entry at the current-version path {currentCachePath}");
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+
+    /// <summary>
+    /// Negative companion: a FRESH (current-version) cache entry that already carries
+    /// Method correctly must still be served as a genuine HIT — this fix must not turn
+    /// every Query cache lookup into an unconditional reparse. Two Get() calls across a
+    /// simulated separate process (ProcessCache cleared, mirroring
+    /// BcAppSymbolCacheContentAddressedKeyTests' own pattern) must reparse only once.
+    /// </summary>
+    [Fact]
+    public void Get_FreshEntryWithMethodAlreadyPresent_IsAGenuineHitOnTheSecondCall()
+    {
+        var dir = NewTempDir();
+        try
+        {
+            var queryName = "CVT Order Sum Hit " + Guid.NewGuid().ToString("N");
+            var appPath = WriteApp(dir, "agg-hit-" + Guid.NewGuid().ToString("N") + ".app", queryName);
+
+            BcAppSymbolCache.ResetProcessCacheForTests();
+            Assert.Equal(0, BcAppSymbolCache.ParseInvocationCountForTests(appPath));
+
+            var first = BcAppSymbolCache.Get(appPath);
+            Assert.Equal("Sum", Assert.Single(Assert.Single(first.Queries, q => q.Name == queryName).DataItems).Columns.Single().Method);
+            Assert.Equal(1, BcAppSymbolCache.ParseInvocationCountForTests(appPath));
+
+            BcAppSymbolCache.ResetProcessCacheForTests();
+            var second = BcAppSymbolCache.Get(appPath);
+
+            Assert.Equal("Sum", Assert.Single(Assert.Single(second.Queries, q => q.Name == queryName).DataItems).Columns.Single().Method);
+            // The on-disk (v-current) entry from the first call must be served as a HIT —
+            // no second reparse.
+            Assert.Equal(1, BcAppSymbolCache.ParseInvocationCountForTests(appPath));
+        }
+        finally { Directory.Delete(dir, recursive: true); }
+    }
+}

--- a/AlRunner.Tests/QueryAggregationProjectionTests.cs
+++ b/AlRunner.Tests/QueryAggregationProjectionTests.cs
@@ -100,7 +100,7 @@ public class QueryAggregationProjectionTests
                 {
                     column(CustNo; "Cust No.") { }
                     column(TotalAmount; Amount) { Method = Sum; }
-                    column(CountAmount; Amount) { Method = Count; }
+                    column(CountAmount) { Method = Count; }
                 }
             }
         }
@@ -113,7 +113,7 @@ public class QueryAggregationProjectionTests
                 dataitem(Order; "QAP Order")
                 {
                     column(TotalAmount; Amount) { Method = Sum; }
-                    column(CountAmount; Amount) { Method = Count; }
+                    column(CountAmount) { Method = Count; }
                 }
             }
         }

--- a/AlRunner.Tests/QueryAggregationProjectionTests.cs
+++ b/AlRunner.Tests/QueryAggregationProjectionTests.cs
@@ -1,0 +1,222 @@
+using System.Diagnostics;
+using System.Text;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// Issue #2137 — a query column with Method = Sum/Count/Average/Min/Max silently returned
+/// unaggregated, ungrouped rows (each raw row echoing its own unsummed source value) instead
+/// of the implicit GROUP BY real BC's compiled SQL performs.
+///
+/// This is a RUNNER-MECHANISM test, not a claim about what real BC does: it pins OUR OWN
+/// pipeline —
+///   1. BcAppSymbolCache.ParseQueryColumns reads the AL `Method = ...` property out of the
+///      compiled column's SymbolReference.json Properties bag; and
+///   2. RecordPatches.NclMetaQueryBuilder.AddColumn carries it onto the design-time
+///      MetaQueryColumn.FieldTotalingMethod, which NCLMetaQuery.CreateDynamicQuery reads to
+///      populate the real NCLMetaQueryColumn.AggregationType; and
+///   3. RecordPatches.QueryProjection.cs's ProjectQueryRows groups by the non-aggregated
+///      columns and computes each aggregate over its group (BuildRow/ComputeAggregate).
+///
+/// Before the fix, step 1 dropped Method entirely (QueryColumnSymbol had no such field), so
+/// every query column's AggregationType stayed at its default (None) — indistinguishable
+/// from an ordinary column — and the projection layer never grouped anything.
+///
+/// The BEHAVIORAL claim ("a Method = Sum column groups by the query's other columns and
+/// aggregates real BC's own way, for a scalar aggregate too") is proven upstream against a
+/// live BC service tier — see StefanMaron/BusinessCentral.AL.Language.Tests, per
+/// docs/rules/bc-behavior-tests-go-upstream.md. This test exists so a regression in OUR OWN
+/// symbol-parsing → metadata-reconstruction → projection pipeline fails loudly here, without
+/// waiting on that corpus PR to merge and the submodule pin to move.
+///
+/// Spawns the real runner; needs the BC artifact cache. Skips (no-op) when absent.
+/// </summary>
+public class QueryAggregationProjectionTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+    private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
+
+    private static (string output, int exit) RunRunner(string bundle)
+    {
+        var args = new StringBuilder(TestBuildConfig.RunArgs(ProjectPath));
+        args.Append(TestBuildConfig.BcVersionArg);
+        args.Append(" \"").Append(bundle).Append('"');
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet", Arguments = args.ToString(),
+            RedirectStandardOutput = true, RedirectStandardError = true,
+            UseShellExecute = false, CreateNoWindow = true, WorkingDirectory = RepoRoot,
+        };
+        var sb = new StringBuilder();
+        var p = Process.Start(psi)!;
+        p.OutputDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.ErrorDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.BeginOutputReadLine();
+        p.BeginErrorReadLine();
+        if (!p.WaitForExit(180_000)) { try { p.Kill(true); } catch { } throw new TimeoutException("runner hung"); }
+        p.WaitForExit();
+        lock (sb) return (sb.ToString(), p.ExitCode);
+    }
+
+    private static string WriteBundle()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "al-runner-query-agg-2137", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+
+        File.WriteAllText(Path.Combine(root, "app.json"), """
+        {
+          "id": "c7d1e4f2-2137-4a1b-9c3d-000000002137",
+          "name": "QAP 2137 Repro",
+          "publisher": "Repro2137",
+          "version": "1.0.0.0",
+          "dependencies": [],
+          "platform": "1.0.0.0",
+          "application": "1.0.0.0",
+          "idRanges": [ { "from": 61890, "to": 61899 } ],
+          "runtime": "14.0"
+        }
+        """);
+        File.WriteAllText(Path.Combine(root, "QapOrder.al"), """
+        table 61890 "QAP Order"
+        {
+            DataClassification = SystemMetadata;
+            fields
+            {
+                field(1; "Entry No."; Integer) { }
+                field(2; "Cust No."; Code[20]) { }
+                field(3; Amount; Decimal) { }
+            }
+            keys { key(PK; "Entry No.") { Clustered = true; } }
+        }
+
+        query 61891 "QAP Order Sum"
+        {
+            QueryType = Normal;
+            elements
+            {
+                dataitem(Order; "QAP Order")
+                {
+                    column(CustNo; "Cust No.") { }
+                    column(TotalAmount; Amount) { Method = Sum; }
+                    column(CountAmount; Amount) { Method = Count; }
+                }
+            }
+        }
+
+        query 61892 "QAP Order Scalar Sum"
+        {
+            QueryType = Normal;
+            elements
+            {
+                dataitem(Order; "QAP Order")
+                {
+                    column(TotalAmount; Amount) { Method = Sum; }
+                    column(CountAmount; Amount) { Method = Count; }
+                }
+            }
+        }
+
+        codeunit 61893 "QAP 2137 Tests"
+        {
+            Subtype = Test;
+
+            local procedure Initialize()
+            var
+                Order: Record "QAP Order";
+            begin
+                Order.DeleteAll();
+                Order.Init(); Order."Entry No." := 1; Order."Cust No." := 'C1'; Order.Amount := 100; Order.Insert();
+                Order.Init(); Order."Entry No." := 2; Order."Cust No." := 'C1'; Order.Amount := 200; Order.Insert();
+                Order.Init(); Order."Entry No." := 3; Order."Cust No." := 'C2'; Order.Amount := 50; Order.Insert();
+            end;
+
+            // The exact issue #2137 reproducer, generalised to two groups: real BC groups by
+            // the non-aggregated CustNo column and sums/counts Amount PER GROUP. Before the
+            // fix, every raw row echoed its own unsummed Amount and a Count of 1 — this
+            // asserts the grouped, aggregated answer instead.
+            [Test]
+            procedure GroupedSumAndCount_MatchPerGroupTotals()
+            var
+                Q: Query "QAP Order Sum";
+                C1Seen, C2Seen : Boolean;
+            begin
+                Initialize();
+                Q.Open();
+                while Q.Read() do begin
+                    case Q.CustNo of
+                        'C1':
+                            begin
+                                C1Seen := true;
+                                if Q.TotalAmount <> 300 then
+                                    Error('C1 TotalAmount must be 300 (100+200), got %1', Q.TotalAmount);
+                                if Q.CountAmount <> 2 then
+                                    Error('C1 CountAmount must be 2, got %1', Q.CountAmount);
+                            end;
+                        'C2':
+                            begin
+                                C2Seen := true;
+                                if Q.TotalAmount <> 50 then
+                                    Error('C2 TotalAmount must be 50, got %1', Q.TotalAmount);
+                                if Q.CountAmount <> 1 then
+                                    Error('C2 CountAmount must be 1, got %1', Q.CountAmount);
+                            end;
+                        else
+                            Error('Unexpected CustNo %1 - grouping produced an extra/wrong group', Q.CustNo);
+                    end;
+                end;
+                Q.Close();
+
+                if not (C1Seen and C2Seen) then
+                    Error('Expected exactly one grouped row per CustNo (C1Seen=%1, C2Seen=%2)', C1Seen, C2Seen);
+            end;
+
+            // Negative/edge case: a query with ONLY aggregate columns (no grouping column at
+            // all) is BC's scalar-aggregate case — exactly one output row over the WHOLE
+            // table, even when it is empty. Before the fix this either produced one row per
+            // raw source row (non-empty case) or zero rows at all (empty case) — neither of
+            // which is BC's single always-one-row scalar-aggregate answer.
+            [Test]
+            procedure ScalarAggregate_OverEmptyTable_StillProducesOneDefaultedRow()
+            var
+                Order: Record "QAP Order";
+                Q: Query "QAP Order Scalar Sum";
+                RowCount: Integer;
+            begin
+                Order.DeleteAll();
+                Q.Open();
+                while Q.Read() do begin
+                    RowCount += 1;
+                    if Q.TotalAmount <> 0 then
+                        Error('Sum over an empty table must default to 0, got %1', Q.TotalAmount);
+                    if Q.CountAmount <> 0 then
+                        Error('Count over an empty table must default to 0, got %1', Q.CountAmount);
+                end;
+                Q.Close();
+
+                if RowCount <> 1 then
+                    Error('A scalar aggregate (no grouping column) must always return exactly ONE row, got %1', RowCount);
+            end;
+        }
+        """);
+
+        return root;
+    }
+
+    [SkippableFact]
+    public void QueryColumnAggregation_GroupsAndAggregates_InsteadOfSilentlyEchoingRawRows()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var bundle = WriteBundle();
+        var (output, exitCode) = RunRunner(bundle);
+
+        // Never silently pass a run that failed to even get the test codeunit compiled/run.
+        Assert.DoesNotContain("EMIT-EXCLUDED", output);
+        Assert.DoesNotContain("COMPILE FAIL", output);
+        // Both tests must have run and passed — 2P/0F/0E is TestExecutor's own per-bundle
+        // summary line (see CrossBundleModuleIdentityDedupTests for the same convention).
+        Assert.Contains("2P/0F/0E", output);
+    }
+}

--- a/AlRunner/Patches/BcAppSymbolCache.cs
+++ b/AlRunner/Patches/BcAppSymbolCache.cs
@@ -54,7 +54,15 @@ internal static partial class BcAppSymbolCache
     // table has no card page at all — a real behavioral divergence, not a display nit),
     // and the Page Control Field provider would read as "no controls" — silent wrong
     // answers, not a cache miss, hence the bump.
-    private const int CacheVersion = 13;
+    // v14: QueryColumnSymbol gained Method (issue #2137 — a query column's Method =
+    // Sum/Count/Average/Min/Max property). A v13 payload deserialises with Method null,
+    // which RecordPatches.NclMetaQueryBuilder.AddColumn already treats as "no aggregation
+    // method declared" (skips setting FieldTotalingMethod, leaving AggregationType at its
+    // default None) — so a v13 cache entry would silently make ProjectQueryRows treat an
+    // aggregated column as an ordinary one again, returning raw ungrouped rows: the exact
+    // #2137 bug reintroduced on any machine whose symbol cache predates this change, not a
+    // cache miss, hence the bump.
+    private const int CacheVersion = 14;
     private static readonly ConcurrentDictionary<string, AppSymbols> ProcessCache = new(StringComparer.OrdinalIgnoreCase);
     // Issue #1820 — path -> content-hash memo. ComputeAppContentHash needs to read the
     // WHOLE .app to hash it (unlike the FileInfo.Length/LastWriteTimeUtc stat it replaced,
@@ -221,7 +229,12 @@ internal static partial class BcAppSymbolCache
         List<QueryDataItemSymbol> DataItems);
 
     // SourceColumn is the field NAME on RelatedTable; Id is the BC column id; Caption optional.
-    internal sealed record QueryColumnSymbol(int Id, string Name, string SourceColumn, string? Caption);
+    // Method (issue #2137) is the AL `Method = Sum/Count/Average/Min/Max` property, carried
+    // verbatim from the column's Properties bag — "Sum"/"Count"/"Average"/"Min"/"Max", or null
+    // for an unaggregated column. Names match Microsoft.Dynamics.Nav.Types.AggregationType's
+    // member names exactly, so RecordPatches.NclMetaQueryBuilder.AddColumn can hand it straight
+    // to SetProp's Enum.Parse without translation.
+    internal sealed record QueryColumnSymbol(int Id, string Name, string SourceColumn, string? Caption, string? Method);
 
     // #1820: ContentHash replaces Length/LastWriteUtcTicks. The KEY (below, in Get) already
     // switched from mtime to a content hash, so an old Length/LastWriteUtcTicks payload can
@@ -278,6 +291,24 @@ internal static partial class BcAppSymbolCache
         ProcessCache[key] = parsed;
         return parsed;
     }
+
+    // Test seam: mirrors Get()'s own key-string format and delegates to the SAME private
+    // CachePath hashing formula, so a test that needs to know where an OLDER (or a
+    // deliberately different) CacheVersion's entry lives on disk never duplicates that
+    // formula itself. A hand-rolled copy of CachePath in a test would silently stop
+    // testing anything the moment CachePath's hashing/layout changes — the copy would
+    // still compute A path, just not the one Get() actually consults, and the test would
+    // pass for the wrong reason (see BcAppSymbolCacheQueryMethodVersionTests, added for
+    // issue #2137's CacheVersion bump, where exactly this drift risk was caught in
+    // review). Exposing this one seam instead makes that drift impossible rather than
+    // merely documented.
+    internal static string CachePathForVersionForTests(string appPath, string contentHash, int cacheVersion)
+        => CachePath($"{Path.GetFullPath(appPath)}|hash:{contentHash}|v{cacheVersion}");
+
+    // The CURRENT CacheVersion, for a test that wants to prove a fresh entry landed at
+    // exactly the path Get() would consult, without hardcoding the number (which would
+    // then need updating every time an unrelated future field bump moves it).
+    internal static int CacheVersionForTests => CacheVersion;
 
     /// <summary>
     /// Content hash (hex SHA-256) of a .app file's bytes — the cache-key component that
@@ -698,7 +729,8 @@ internal static partial class BcAppSymbolCache
             var sourceColumn = col.TryGetProperty("SourceColumn", out var scProp) ? scProp.GetString() ?? string.Empty : string.Empty;
             var props = SymbolProperties(col);
             props.TryGetValue("Caption", out var caption);
-            result.Add(new QueryColumnSymbol(id, name, sourceColumn, caption));
+            props.TryGetValue("Method", out var method); // issue #2137 — Method = Sum/Count/Average/Min/Max
+            result.Add(new QueryColumnSymbol(id, name, sourceColumn, caption, method));
         }
         return result;
     }

--- a/AlRunner/Patches/FlowFieldPatches.cs
+++ b/AlRunner/Patches/FlowFieldPatches.cs
@@ -1026,8 +1026,14 @@ public static class FlowFieldPatches
     // field, since "" doesn't evaluate to Integer either). GetDefaultNavValue always returns
     // the field's OWN type's default, so this is correct for every field type, not just the
     // one the original hardcoded literal happened to match.
+    //
+    // internal (not private): RecordPatches.QueryProjection.cs's Min/Max query-column
+    // aggregation (issue #2137) reuses this same factory for its own "no source row in the
+    // group" case — NCLMetaQueryColumn is also an INavValueMetadata, so the exact same call
+    // works unchanged. Kept here rather than duplicated, per the sister-drift concern noted
+    // elsewhere in this codebase (ComputeJoinColumnSlotMap's comment).
     private static MethodInfo? _mFlowFieldGetDefaultNavValue;
-    private static NavValue? TypedDefaultForField(object fieldObj)
+    internal static NavValue? TypedDefaultForField(object fieldObj)
     {
         try
         {
@@ -1052,8 +1058,12 @@ public static class FlowFieldPatches
     // RecordBufferEvaluatorVisitor decides which rows match, so the hand-rolled
     // Equals/decimal/ToString ladder that used to stand in for BC's comparison semantics has
     // no callers — and no chance of disagreeing with them.
+    //
+    // internal (not private): reused by RecordPatches.QueryProjection.cs's query-column
+    // Min/Max aggregation (issue #2137) for the exact same "which of these NavValues wins"
+    // comparison, rather than re-deriving comparison semantics a second time.
 
-    private static int NavValueCompare(NavValue a, NavValue b)
+    internal static int NavValueCompare(NavValue a, NavValue b)
     {
         try
         {

--- a/AlRunner/Patches/RecordPatches.NclMetaQueryBuilder.cs
+++ b/AlRunner/Patches/RecordPatches.NclMetaQueryBuilder.cs
@@ -177,11 +177,35 @@ public static partial class RecordPatches
             // Result columns.
             foreach (var col in diSym.Columns)
             {
-                int fieldNo = ResolveFieldNo(fieldNoByName, col.SourceColumn);
-                if (fieldNo < 0)
+                int fieldNo;
+                if (string.IsNullOrEmpty(col.SourceColumn))
                 {
-                    QLog($"BuildMetaQueryDesign({queryId}): field '{col.SourceColumn}' not found on table {tableNo} ('{diSym.RelatedTable}') — abandoning build");
-                    return null;
+                    // Issue #2137/#2150: real BC's compiler REJECTS a Method=Count column
+                    // that names a source field at all (AL0353) -- the only valid AL is
+                    // `column(X) { Method = Count; }`, with no field. NCLMetaQueryColumn.
+                    // SourceTableField never reads FieldNo for a Count column anyway (BC's
+                    // own Ncl.dll special-cases it to always return the table's OWN primary
+                    // key field, regardless of what FieldNo says) -- the same fact
+                    // ComputeAggregate's Count branch already relies on by never touching
+                    // TableSlot. So a source-less column is legitimate ONLY when it is a
+                    // Count column; abandoning the build for missing a field it was never
+                    // going to use would silently make every Count-only query fail to
+                    // build at all. FieldNo is a placeholder (0) that is never read for it.
+                    if (col.Method != "Count")
+                    {
+                        QLog($"BuildMetaQueryDesign({queryId}): column '{col.Name}' has no SourceColumn and is not Method=Count — abandoning build");
+                        return null;
+                    }
+                    fieldNo = 0;
+                }
+                else
+                {
+                    fieldNo = ResolveFieldNo(fieldNoByName, col.SourceColumn);
+                    if (fieldNo < 0)
+                    {
+                        QLog($"BuildMetaQueryDesign({queryId}): field '{col.SourceColumn}' not found on table {tableNo} ('{diSym.RelatedTable}') — abandoning build");
+                        return null;
+                    }
                 }
                 AddColumn(di, id: col.Id, name: col.Name, fieldNo: fieldNo, index: resultColumnIndex++, caption: col.Caption, method: col.Method);
                 columnIdByName[col.Name] = col.Id;

--- a/AlRunner/Patches/RecordPatches.NclMetaQueryBuilder.cs
+++ b/AlRunner/Patches/RecordPatches.NclMetaQueryBuilder.cs
@@ -183,7 +183,7 @@ public static partial class RecordPatches
                     QLog($"BuildMetaQueryDesign({queryId}): field '{col.SourceColumn}' not found on table {tableNo} ('{diSym.RelatedTable}') — abandoning build");
                     return null;
                 }
-                AddColumn(di, id: col.Id, name: col.Name, fieldNo: fieldNo, index: resultColumnIndex++, caption: col.Caption);
+                AddColumn(di, id: col.Id, name: col.Name, fieldNo: fieldNo, index: resultColumnIndex++, caption: col.Caption, method: col.Method);
                 columnIdByName[col.Name] = col.Id;
             }
 
@@ -338,7 +338,7 @@ public static partial class RecordPatches
 
     private static MethodInfo? _mMultiLanguageParse;
 
-    private static void AddColumn(object dataItem, int id, string name, int fieldNo, int index, string? caption = null)
+    private static void AddColumn(object dataItem, int id, string name, int fieldNo, int index, string? caption = null, string? method = null)
     {
         var col = Activator.CreateInstance(_tMetaQueryColumn!)!;
         SetProp(col, "Id", id);
@@ -346,6 +346,19 @@ public static partial class RecordPatches
         SetProp(col, "FieldNo", fieldNo);
         SetProp(col, "QueryColumnIndex", index);
         SetProp(col, "FilterOnly", false);
+        // Issue #2137: the AL `Method = Sum/Count/Average/Min/Max` property, carried verbatim
+        // from the compiled column's SymbolReference.json Properties bag. MetaQueryColumn.
+        // FieldTotalingMethod (Microsoft.Dynamics.Nav.Types.AggregationType) is what
+        // NCLMetaQuery.CreateDynamicQuery reads to populate the real NCLMetaQueryColumn.
+        // AggregationType this runner-synthesized reconstruction otherwise leaves at its
+        // default (None) — RecordPatches.QueryProjection.cs's GROUP BY aggregation, and the
+        // OOS guards for join+aggregate / HAVING-style filters, all key off that value, so a
+        // query with an unset FieldTotalingMethod would silently behave as if it had no
+        // Method column at all. Symbol property values are the AggregationType member names
+        // verbatim ("Sum", "Count", "Average", "Min", "Max"), so SetProp's Enum.Parse needs no
+        // translation. Left at the design object's own default (None) when absent.
+        if (!string.IsNullOrEmpty(method) && !string.Equals(method, "None", StringComparison.OrdinalIgnoreCase))
+            SetProp(col, "FieldTotalingMethod", method);
         if (caption != null)
         {
             // MetaQueryColumn.CaptionML (MultiLanguage) feeds NCLMetaQueryColumn.columnCaptions

--- a/AlRunner/Patches/RecordPatches.QueryProjection.cs
+++ b/AlRunner/Patches/RecordPatches.QueryProjection.cs
@@ -30,13 +30,39 @@
 //   definition with >1 included table; the temp provider already cannot serve that
 //   (DataAccessSource.GetDataAccessForQuery throws QueriesBetweenDataSourcesNotSupported
 //   when the included tables map to different DataAccess instances), so join handling
-//   stays a follow-up. An aggregate / const / non-source column has no SourceTableField
+//   stays a follow-up. A const (ColumnType.ConstValue) column has no SourceTableField
 //   and is left at its slot default rather than faked — surfaced as a follow-up, never
 //   silently wrong for source columns.
+//
+// AGGREGATION (Method = Sum/Count/Average/Min/Max — issue #2137):
+//   NCLMetaQueryColumn.AggregationType is BC's own per-column aggregation method. A query
+//   with at least one aggregated column has an IMPLICIT GROUP BY over every OTHER Normal
+//   (non-aggregated, non-const, non-filter-only) column — exactly what BC's compiled SQL
+//   SELECT ... GROUP BY does. ProjectQueryRows detects that case (ProjectionPlan.HasAggregate)
+//   and groups the already-filtered/sorted raw rows by the non-aggregate columns' source
+//   field values (GroupKey, using NavValue's own IEquatable<NavValue>/GetHashCode — the same
+//   equality BC's record buffers already trust), then computes each aggregate column's value
+//   over its group via BuildAggregateRow/ComputeAggregate. A query with ONLY aggregate columns
+//   (no grouping column at all) is BC's scalar-aggregate case — one output row always, even
+//   over zero matched source rows (SUM/COUNT/AVERAGE default to 0, MIN/MAX to the column's
+//   typed default via FlowFieldPatches.TypedDefaultForField) — matching SQL's "GROUP BY ()"
+//   always producing exactly one group. TOP is applied AFTER aggregation now (previously it
+//   capped the RAW rows before projection, which is only correct when there's no grouping —
+//   capping raw rows first would silently drop rows out of a group before they're summed).
+//
+//   Runtime SetRange/SetFilter on an AGGREGATED column is a HAVING-clause filter (evaluated
+//   against the aggregated result, not the raw row), which TranslateQueryFilters' WHERE-style
+//   per-row pushdown cannot express — it throws RunnerOutOfScopeException rather than
+//   silently filtering raw rows by the source field instead (see #2146). A multi-dataitem
+//   JOIN with any aggregated column also throws: the isolated JoinExecutor (QueryJoin.cs)
+//   has no GROUP BY of its own, so letting it through would silently return unaggregated
+//   joined rows — the exact bug #2137 reports, just downstream of a join instead of a plain
+//   scan (see #2146 for both follow-ups: HAVING-style filters and join+aggregate).
 using System.Collections;
 using System.Collections.Generic;
 using System.Reflection;
 using Microsoft.Dynamics.Nav.Runtime;
+using Microsoft.Dynamics.Nav.Types;
 
 namespace AlRunner.Patches;
 
@@ -384,6 +410,20 @@ public static partial class RecordPatches
             var expr = item.GetType().GetProperty("Item2")!.GetValue(item);
             if (key != null && _tNCLMetaQueryColumn != null && _tNCLMetaQueryColumn.IsInstanceOfType(key))
             {
+                // #2137/#2146: a runtime SetRange/SetFilter on an AGGREGATED column (Method =
+                // Sum/Count/Average/Min/Max) is a HAVING-clause filter — evaluated against the
+                // per-group aggregated RESULT, not the raw row. Retargeting it to the source
+                // table field the way an ordinary column's filter is retargeted below would
+                // silently filter raw rows by the unaggregated value instead — a different
+                // silently-wrong answer than #2137, but the same class of bug. Throw rather
+                // than guess; see #2146 for the follow-up to implement real HAVING semantics.
+                if (((NCLMetaQueryColumn)key).AggregationType != AggregationType.None)
+                    throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
+                        "NavQuery.SetRange/SetFilter on an aggregated (Method=Sum/Count/Average/Min/Max) column",
+                        "query-having-filter-not-supported — a runtime filter on an aggregated column is a " +
+                        "HAVING-clause filter (evaluated against the aggregated result, not the raw row), which " +
+                        "is not yet implemented; see docs/scope.md and issue #2146");
+
                 var srcField = key.GetType().GetProperty("SourceTableField", BindingFlags.Public | BindingFlags.Instance)!.GetValue(key);
                 if (srcField != null && expr != null)
                 {
@@ -532,6 +572,19 @@ public static partial class RecordPatches
             .GetValue(metaAppObj);
         if (queryDef != null && IsMultiDataItemQuery(queryDef))
         {
+            // #2137/#2146: a JOIN with an aggregated column needs GROUP BY over the
+            // joined+projected rows, which JoinExecutor does not implement (join+project
+            // only). Letting it through would silently return unaggregated joined rows —
+            // exactly the bug #2137 reports, just downstream of a join. Throw rather than
+            // guess; see #2146 for the follow-up to implement this for real.
+            var qd = (NCLMetaQueryDefinition)queryDef;
+            if (qd.Columns.Any(c => c.AggregationType != AggregationType.None))
+                throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
+                    "NavQuery (multi-dataitem join with Method=Sum/Count/Average/Min/Max)",
+                    "query-join-aggregation-not-supported — a multi-dataitem JOIN query has an " +
+                    "aggregated column; the in-memory join executor has no GROUP BY of its own, " +
+                    "so this would return unaggregated joined rows; see docs/scope.md and issue #2146");
+
             // The isolated executor returns boxed ReadOnlyRecordBuffers (non-generic
             // IEnumerable) so its assembly carries no Ncl type in its public surface; cast
             // back here, where QueryProjection.cs already (necessarily) references the type.
@@ -551,13 +604,14 @@ public static partial class RecordPatches
         // Query.TopNumberOfRowsToReturn caps the dataset. NavQuery passes it through the
         // request's TopNumberOfRowsToReturn; the temp provider's Find only honours
         // FindType.FirstOnly (Take(1)), never the Top cap — that's a query concept the SQL
-        // provider would enforce via TOP. Apply it here, scoped to query requests so
-        // ordinary table reads keep BC's exact (uncapped) behaviour.
+        // provider would enforce via TOP. Applied AFTER projection (not on the raw `rows`
+        // here) so an aggregate query's TOP caps the number of GROUPS, matching SQL's
+        // TOP-after-GROUP-BY — capping the raw rows first would silently drop rows out of
+        // a group before they're ever summed/counted/averaged.
         var top = _pReqTopNumberOfRows!.GetValue(request);
         int topN = top == null ? 0 : Convert.ToInt32(top);
-        if (topN > 0) rows = rows.Take(topN);
-
-        return ProjectQueryRows(metaAppObj, rows);
+        var projected = ProjectQueryRows(metaAppObj, rows);
+        return topN > 0 ? projected.Take(topN) : projected;
     }
 
     private static MethodInfo? _mFilterExprEvaluate;
@@ -675,32 +729,200 @@ public static partial class RecordPatches
         catch { return null; }
     }
 
-    // Cached per NCLMetaQuery: the (queryColumnIndex -> tableFieldColumnIndex) projection map
-    // and the result slot count.
+    // Cached per NCLMetaQuery: which column goes in which result slot, whether it's backed
+    // by a source table field, and (issue #2137) its aggregation method.
     private static readonly System.Runtime.CompilerServices.ConditionalWeakTable<object, ProjectionPlan> _projectionPlans = new();
+
+    private sealed class ColumnPlan
+    {
+        public int QuerySlot;
+        // -1 means "no source table field to read" (a ConstValue column, or a column whose
+        // SourceTableField resolution failed) → leave the slot at its NavValue default.
+        public int TableSlot;
+        public AggregationType Aggregation;
+        // The implicit GROUP BY key: a genuinely-projected (Normal), non-aggregated column.
+        public bool IsGroupKey;
+        // The NCLMetaQueryColumn itself — also an INavValueMetadata, so it can be handed
+        // straight to NavValue.CreateNavValueFromObject / FlowFieldPatches.TypedDefaultForField
+        // to produce a value of the COLUMN's own declared type, not the source field's.
+        public NCLMetaQueryColumn Column = null!;
+    }
 
     private sealed class ProjectionPlan
     {
         public int SlotCount;
-        // map[i] = (queryResultSlot, tableFieldSlot); a value of -1 tableFieldSlot means
-        // the column has no NCLMetaField source (aggregate/const) → leave at default.
-        public (int querySlot, int tableSlot)[] Map = Array.Empty<(int, int)>();
+        public ColumnPlan[] Columns = Array.Empty<ColumnPlan>();
+        // True when at least one column has Method = Sum/Count/Average/Min/Max, i.e. this
+        // query has an implicit GROUP BY over its other (non-aggregated) Normal columns.
+        public bool HasAggregate;
     }
 
     private static IEnumerable<ReadOnlyRecordBuffer> ProjectQueryRows(object nclMetaQuery, IEnumerable<ReadOnlyRecordBuffer> rows)
     {
         var plan = _projectionPlans.GetValue(nclMetaQuery, BuildProjectionPlan);
-        foreach (var row in rows)
+
+        if (!plan.HasAggregate)
         {
-            var fields = new object?[plan.SlotCount];
-            foreach (var (querySlot, tableSlot) in plan.Map)
+            // No Method column anywhere in this query → every row projects independently,
+            // exactly as before #2137 (this is the 99% case: a plain, non-aggregated query).
+            foreach (var row in rows)
+                yield return BuildRow(nclMetaQuery, plan, new[] { row });
+            yield break;
+        }
+
+        // #2137: at least one aggregated column → an implicit GROUP BY over every OTHER
+        // Normal (non-aggregated) column, mirroring BC's compiled SQL SELECT ... GROUP BY.
+        // Grouping needs to see every candidate row before it can know the groups, so the
+        // filtered/sorted source rows are materialised once here.
+        var sourceRows = rows as IReadOnlyList<ReadOnlyRecordBuffer> ?? rows.ToList();
+        var groupKeyColumns = plan.Columns.Where(c => c.IsGroupKey).ToArray();
+
+        if (groupKeyColumns.Length == 0)
+        {
+            // Scalar aggregate (no non-aggregated column at all) — SQL's "GROUP BY ()" always
+            // produces exactly one group, even over zero source rows (SUM/COUNT/AVERAGE then
+            // default to 0; MIN/MAX to the column's own typed default — see ComputeAggregate).
+            yield return BuildRow(nclMetaQuery, plan, sourceRows);
+            yield break;
+        }
+
+        // Group by the group-key columns' source values, preserving first-seen order (the
+        // filtered/sorted row order the temp provider already produced — the closest faithful
+        // approximation available without a real SQL engine's own GROUP BY ordering).
+        var groups = new Dictionary<GroupKey, List<ReadOnlyRecordBuffer>>();
+        var groupOrder = new List<GroupKey>();
+        foreach (var row in sourceRows)
+        {
+            var key = new GroupKey(groupKeyColumns.Select(c =>
+                c.TableSlot >= 0 && c.TableSlot < row.FieldCount ? row[c.TableSlot] : null).ToArray());
+            if (!groups.TryGetValue(key, out var groupRows))
             {
-                if (tableSlot < 0 || tableSlot >= row.FieldCount) continue; // unsupported column → default
-                fields[querySlot] = row[tableSlot];
+                groupRows = new List<ReadOnlyRecordBuffer>();
+                groups[key] = groupRows;
+                groupOrder.Add(key);
             }
-            // ReadOnlyRecordBuffer(NCLMetaApplicationObject, params NavValue[])
-            yield return (ReadOnlyRecordBuffer)_ctorReadOnlyRecordBuffer!.Invoke(
-                new object?[] { nclMetaQuery, ToNavValueArray(fields) });
+            groupRows.Add(row);
+        }
+
+        foreach (var key in groupOrder)
+            yield return BuildRow(nclMetaQuery, plan, groups[key]);
+    }
+
+    /// <summary>
+    /// The implicit GROUP BY key: the group-key columns' source NavValues, compared by
+    /// NavValue's own IEquatable&lt;NavValue&gt;/GetHashCode — the same value equality BC's
+    /// record buffers already trust, not a re-derived one.
+    /// </summary>
+    private readonly struct GroupKey : IEquatable<GroupKey>
+    {
+        private readonly NavValue?[] _values;
+        public GroupKey(NavValue?[] values) => _values = values;
+
+        public bool Equals(GroupKey other)
+        {
+            if (_values.Length != other._values.Length) return false;
+            for (int i = 0; i < _values.Length; i++)
+            {
+                var a = _values[i]; var b = other._values[i];
+                if (ReferenceEquals(a, b)) continue;
+                if (a is null || b is null) return false;
+                if (!a.Equals(b)) return false;
+            }
+            return true;
+        }
+
+        public override bool Equals(object? obj) => obj is GroupKey other && Equals(other);
+
+        public override int GetHashCode()
+        {
+            var hash = new HashCode();
+            foreach (var v in _values) hash.Add(v?.GetHashCode() ?? 0);
+            return hash.ToHashCode();
+        }
+    }
+
+    /// <summary>
+    /// Project one output row from <paramref name="groupRows"/> — either a single raw row
+    /// (the non-aggregate path calls this with a one-row "group") or every row sharing one
+    /// GROUP BY key (the aggregate path). Non-aggregated columns read the first row's source
+    /// value (every row in a real group shares it by construction); aggregated columns compute
+    /// over the whole group via ComputeAggregate.
+    /// </summary>
+    private static ReadOnlyRecordBuffer BuildRow(object nclMetaQuery, ProjectionPlan plan, IReadOnlyList<ReadOnlyRecordBuffer> groupRows)
+    {
+        var fields = new object?[plan.SlotCount];
+        foreach (var c in plan.Columns)
+        {
+            if (c.Aggregation != AggregationType.None)
+            {
+                fields[c.QuerySlot] = ComputeAggregate(c, groupRows);
+                continue;
+            }
+            if (c.TableSlot < 0 || groupRows.Count == 0 || c.TableSlot >= groupRows[0].FieldCount)
+                continue; // unsupported column (ConstValue) → leave at NavValue default
+            fields[c.QuerySlot] = groupRows[0][c.TableSlot];
+        }
+        // ReadOnlyRecordBuffer(NCLMetaApplicationObject, params NavValue[])
+        return (ReadOnlyRecordBuffer)_ctorReadOnlyRecordBuffer!.Invoke(
+            new object?[] { nclMetaQuery, ToNavValueArray(fields) })!;
+    }
+
+    /// <summary>
+    /// Compute one aggregated column's value over its group, using BC's own NavValue
+    /// factory/comparison so the result carries the COLUMN's declared type (which can differ
+    /// from the source field's — e.g. an Average over an Integer field is typically Decimal).
+    /// Sum/Average mirror RecordPatches.cs's TempTableDataProvider_CalcNumeric (Decimal18
+    /// checked-arithmetic, no manual int/long coercion — the same FlowField aggregation
+    /// pattern, just over query rows instead of a CalcFormula source table). Min/Max reuse
+    /// FlowFieldPatches.NavValueCompare/TypedDefaultForField rather than re-deriving
+    /// comparison/default semantics a second time.
+    /// </summary>
+    private static NavValue? ComputeAggregate(ColumnPlan c, IReadOnlyList<ReadOnlyRecordBuffer> groupRows)
+    {
+        switch (c.Aggregation)
+        {
+            case AggregationType.Count:
+                return NavValue.CreateNavValueFromObject(c.Column, groupRows.Count);
+
+            case AggregationType.Sum:
+            case AggregationType.Average:
+            {
+                Decimal18 sum = default;
+                int n = 0;
+                foreach (var row in groupRows)
+                {
+                    if (c.TableSlot < 0 || c.TableSlot >= row.FieldCount) continue;
+                    var v = row[c.TableSlot];
+                    if (v == null) continue;
+                    sum = checked(sum + v.ToDecimal());
+                    n++;
+                }
+                return c.Aggregation == AggregationType.Average
+                    ? NavValue.CreateNavValueFromObject(c.Column, n > 0 ? sum / n : (Decimal18)0m)
+                    : NavValue.CreateNavValueFromObject(c.Column, sum);
+            }
+
+            case AggregationType.Min:
+            case AggregationType.Max:
+            {
+                NavValue? best = null;
+                foreach (var row in groupRows)
+                {
+                    if (c.TableSlot < 0 || c.TableSlot >= row.FieldCount) continue;
+                    var v = row[c.TableSlot];
+                    if (v == null) continue;
+                    if (best == null
+                        || (c.Aggregation == AggregationType.Min && FlowFieldPatches.NavValueCompare(v, best) < 0)
+                        || (c.Aggregation == AggregationType.Max && FlowFieldPatches.NavValueCompare(v, best) > 0))
+                        best = v;
+                }
+                // No row in the group (only reachable via the zero-row scalar-aggregate case)
+                // → the column's own typed default (0 / '' / 0D / …), never a bare literal.
+                return best ?? FlowFieldPatches.TypedDefaultForField(c.Column);
+            }
+
+            default:
+                return null; // AggregationType.None is handled by the caller, not here.
         }
     }
 
@@ -715,33 +937,43 @@ public static partial class RecordPatches
 
     private static ProjectionPlan BuildProjectionPlan(object nclMetaQuery)
     {
-        // queryDef = nclMetaQuery.QueryDefinition; columns = queryDef.Columns
-        var queryDef = _tNCLMetaQuery!.GetProperty("QueryDefinition", BindingFlags.Public | BindingFlags.Instance)!
+        var queryDef = (NCLMetaQueryDefinition)_tNCLMetaQuery!.GetProperty("QueryDefinition", BindingFlags.Public | BindingFlags.Instance)!
             .GetValue(nclMetaQuery)!;
-        var columns = (IEnumerable)queryDef.GetType()
-            .GetProperty("Columns", BindingFlags.Public | BindingFlags.Instance)!
-            .GetValue(queryDef)!;
 
-        var map = new List<(int, int)>();
+        var columnPlans = new List<ColumnPlan>();
         int maxSlot = -1;
-        foreach (var col in columns)
+        bool hasAggregate = false;
+        foreach (var col in queryDef.Columns) // excludes FilterOnly columns already
         {
-            var ct = col.GetType(); // NCLMetaQueryColumn
-            int querySlot = (int)ct.GetProperty("ColumnIndex", BindingFlags.Public | BindingFlags.Instance)!.GetValue(col)!;
+            int querySlot = col.ColumnIndex;
             if (querySlot > maxSlot) maxSlot = querySlot;
 
             int tableSlot = -1;
-            // SourceTableField is the NCLMetaField backing this column (null/throws for
-            // aggregate/const columns — treat those as unsupported → leave default).
+            // SourceTableField throws NotSupportedException for a ConstValue column (no
+            // source field at all — pre-existing, documented follow-up, unrelated to #2137);
+            // treat that as "unsupported → leave at default", same as before this fix.
             try
             {
-                var srcField = ct.GetProperty("SourceTableField", BindingFlags.Public | BindingFlags.Instance)!.GetValue(col);
-                if (srcField != null)
-                    tableSlot = (int)srcField.GetType().GetProperty("ColumnIndex", BindingFlags.Public | BindingFlags.Instance)!.GetValue(srcField)!;
+                if (col.ColumnType != QueryColumnType.ConstValue)
+                {
+                    var srcField = col.SourceTableField;
+                    if (srcField != null) tableSlot = srcField.ColumnIndex;
+                }
             }
             catch { tableSlot = -1; }
-            map.Add((querySlot, tableSlot));
+
+            var aggregation = col.AggregationType;
+            if (aggregation != AggregationType.None) hasAggregate = true;
+
+            columnPlans.Add(new ColumnPlan
+            {
+                QuerySlot = querySlot,
+                TableSlot = tableSlot,
+                Aggregation = aggregation,
+                IsGroupKey = aggregation == AggregationType.None && col.ColumnType == QueryColumnType.Normal,
+                Column = col,
+            });
         }
-        return new ProjectionPlan { SlotCount = maxSlot + 1, Map = map.ToArray() };
+        return new ProjectionPlan { SlotCount = maxSlot + 1, Columns = columnPlans.ToArray(), HasAggregate = hasAggregate };
     }
 }

--- a/tests/expectations/count-baseline/test-count-baseline.json
+++ b/tests/expectations/count-baseline/test-count-baseline.json
@@ -2,7 +2,7 @@
   "_comment": "Consumed by --count-baseline (AlRunner/Infrastructure/CountBaseline.cs), a DIFFERENT schema from the oos-/known-gaps-/divergence-/disabled- files in this directory: those declare the expected CLASSIFICATION of one named test, this declares the expected EXACT COUNT of a whole suite -- an exact match, not a floor: a mismatch in EITHER direction (drop OR growth) fails the run (exit 4). See #1880 and PR #1882's review for why growth is also a hard failure, not just a notice. Suite keys are the basename of the bundle directory CI passes on the command line (tests/al-language/tests/al-language -> 'al-language', tests/runner-extras -> 'runner-extras'), matching the '--out <name>-results.json' convention CI already uses. Values below are read off actual Test Matrix CI runs (see PR discussion for run URLs), not guessed: al-language's 2073->2076 bump reflects 3 corpus tests merged upstream between when the local baseline was drafted and when CI first ran against it. runner-extras' appGroups 23->21 byBcVersion override on 27.0/27.3/27.5 is the SAME preprocessor-gated-surface split that already explains its tests count divergence: fewer AL surfaces compile pre-28.0, which drops whole app groups, not just individual tests within a group. ANY PR that changes a suite's test or app-group count -- growth included -- MUST bump the matching number here in the SAME PR, or that PR's CI goes red with a [count-baseline] DROP or GROWTH diagnostic naming the exact expected/actual numbers to use.",
   "suites": {
     "al-language": {
-      "tests": { "default": 2150 },
+      "tests": { "default": 2155 },
       "appGroups": { "default": 1 }
     },
     "runner-extras": {

--- a/tests/expectations/count-baseline/test-count-baseline.json
+++ b/tests/expectations/count-baseline/test-count-baseline.json
@@ -7,12 +7,12 @@
     },
     "runner-extras": {
       "tests": {
-        "default": 186,
-        "byBcVersion": { "27.0": 175, "27.3": 175, "27.5": 175 }
+        "default": 190,
+        "byBcVersion": { "27.0": 179, "27.3": 179, "27.5": 179 }
       },
       "appGroups": {
-        "default": 32,
-        "byBcVersion": { "27.0": 27, "27.3": 27, "27.5": 27 }
+        "default": 33,
+        "byBcVersion": { "27.0": 28, "27.3": 28, "27.5": 28 }
       }
     }
   }

--- a/tests/runner-extras/query-join-aggregation-oos/QjaAssert.Codeunit.al
+++ b/tests/runner-extras/query-join-aggregation-oos/QjaAssert.Codeunit.al
@@ -1,0 +1,16 @@
+// Standalone Assert codeunit — this suite must stand alone (README.md), it does not
+// import from tests/al-language.
+codeunit 64534 "Qja Assert"
+{
+    procedure AreEqual(Expected: Variant; Actual: Variant; Msg: Text)
+    begin
+        if Format(Expected) <> Format(Actual) then
+            Error('Expected %1 but got %2: %3', Format(Expected), Format(Actual), Msg);
+    end;
+
+    procedure ExpectedError(Fragment: Text)
+    begin
+        if StrPos(GetLastErrorText(), Fragment) = 0 then
+            Error('Expected error containing ''%1'' but got ''%2''', Fragment, GetLastErrorText());
+    end;
+}

--- a/tests/runner-extras/query-join-aggregation-oos/QjaCustomer.Table.al
+++ b/tests/runner-extras/query-join-aggregation-oos/QjaCustomer.Table.al
@@ -1,0 +1,15 @@
+table 64531 "Qja Customer"
+{
+    DataClassification = CustomerContent;
+
+    fields
+    {
+        field(1; "No."; Code[20]) { }
+        field(2; Name; Text[50]) { }
+    }
+
+    keys
+    {
+        key(PK; "No.") { Clustered = true; }
+    }
+}

--- a/tests/runner-extras/query-join-aggregation-oos/QjaJoinPlain.Query.al
+++ b/tests/runner-extras/query-join-aggregation-oos/QjaJoinPlain.Query.al
@@ -1,0 +1,19 @@
+query 64536 "Qja Join Plain"
+{
+    // Sibling of "Qja Join Sum" with NO aggregated column — the join+aggregation guard in
+    // RecordPatches.QueryProjection.cs must not trip on an ordinary join query.
+    QueryType = Normal;
+
+    elements
+    {
+        dataitem(Order; "Qja Order")
+        {
+            column(CustNo; "Cust No.") { }
+            dataitem(Customer; "Qja Customer")
+            {
+                DataItemLink = "No." = Order."Cust No.";
+                column(CustName; Name) { }
+            }
+        }
+    }
+}

--- a/tests/runner-extras/query-join-aggregation-oos/QjaJoinSum.Query.al
+++ b/tests/runner-extras/query-join-aggregation-oos/QjaJoinSum.Query.al
@@ -1,0 +1,21 @@
+query 64532 "Qja Join Sum"
+{
+    QueryType = Normal;
+
+    elements
+    {
+        dataitem(Order; "Qja Order")
+        {
+            column(CustNo; "Cust No.") { }
+            column(TotalAmount; Amount)
+            {
+                Method = Sum;
+            }
+            dataitem(Customer; "Qja Customer")
+            {
+                DataItemLink = "No." = Order."Cust No.";
+                column(CustName; Name) { }
+            }
+        }
+    }
+}

--- a/tests/runner-extras/query-join-aggregation-oos/QjaOrder.Table.al
+++ b/tests/runner-extras/query-join-aggregation-oos/QjaOrder.Table.al
@@ -1,0 +1,16 @@
+table 64530 "Qja Order"
+{
+    DataClassification = CustomerContent;
+
+    fields
+    {
+        field(1; "Entry No."; Integer) { }
+        field(2; "Cust No."; Code[20]) { }
+        field(3; Amount; Decimal) { }
+    }
+
+    keys
+    {
+        key(PK; "Entry No.") { Clustered = true; }
+    }
+}

--- a/tests/runner-extras/query-join-aggregation-oos/QjaSingleSum.Query.al
+++ b/tests/runner-extras/query-join-aggregation-oos/QjaSingleSum.Query.al
@@ -1,0 +1,16 @@
+query 64533 "Qja Single Sum"
+{
+    QueryType = Normal;
+
+    elements
+    {
+        dataitem(Order; "Qja Order")
+        {
+            column(CustNo; "Cust No.") { }
+            column(TotalAmount; Amount)
+            {
+                Method = Sum;
+            }
+        }
+    }
+}

--- a/tests/runner-extras/query-join-aggregation-oos/QjaTests.Codeunit.al
+++ b/tests/runner-extras/query-join-aggregation-oos/QjaTests.Codeunit.al
@@ -1,0 +1,131 @@
+codeunit 64535 "Qja Tests"
+{
+    // Regression for issue #2137 (Query column aggregation silently returned unaggregated,
+    // ungrouped rows) — the two runner-specific surfaces the fix in RecordPatches.QueryProjection.cs
+    // could not implement now throw a named RunnerOutOfScopeException instead of silently
+    // returning the same wrong-rows bug via a different code path. Both are tracked for a
+    // real implementation by follow-up issue #2146.
+    Subtype = Test;
+
+    local procedure Initialize()
+    var
+        Order: Record "Qja Order";
+        Customer: Record "Qja Customer";
+    begin
+        Order.DeleteAll();
+        Customer.DeleteAll();
+
+        Customer.Init();
+        Customer."No." := 'C1';
+        Customer.Name := 'Contoso';
+        Customer.Insert();
+
+        Order.Init();
+        Order."Entry No." := 1;
+        Order."Cust No." := 'C1';
+        Order.Amount := 100;
+        Order.Insert();
+
+        Order.Init();
+        Order."Entry No." := 2;
+        Order."Cust No." := 'C1';
+        Order.Amount := 200;
+        Order.Insert();
+    end;
+
+    // Positive (must throw): a multi-dataitem JOIN query with an aggregated column (Method =
+    // Sum) has no in-memory GROUP BY available (AlRunner.QueryJoin.JoinExecutor only joins
+    // and projects) — it must fail loudly rather than return unaggregated joined rows.
+    [Test]
+    procedure JoinWithAggregateColumn_ThrowsOutOfScope()
+    var
+        Q: Query "Qja Join Sum";
+        Assert: Codeunit "Qja Assert";
+    begin
+        Initialize();
+
+        asserterror
+        begin
+            Q.Open();
+            if Q.Read() then;
+        end;
+
+        Assert.ExpectedError('out-of-scope: NavQuery (multi-dataitem join with Method=Sum/Count/Average/Min/Max)');
+        Assert.ExpectedError('query-join-aggregation-not-supported');
+    end;
+
+    // Negative (sibling, must NOT throw): the exact same join shape, minus the aggregated
+    // column, must keep working — proves the guard is scoped to aggregation, not to joins in
+    // general. Without this, a fix that refused EVERY multi-dataitem join (not just
+    // aggregated ones) would pass the positive test above and silently break every ordinary
+    // join query in the runner.
+    [Test]
+    procedure JoinWithoutAggregateColumn_StillReturnsJoinedRows()
+    var
+        Q: Query "Qja Join Plain";
+        Assert: Codeunit "Qja Assert";
+        RowCount: Integer;
+    begin
+        Initialize();
+
+        Q.Open();
+        while Q.Read() do begin
+            RowCount += 1;
+            Assert.AreEqual('C1', Q.CustNo, 'CustNo column');
+            Assert.AreEqual('Contoso', Q.CustName, 'CustName column (joined from Qja Customer)');
+        end;
+        Q.Close();
+
+        Assert.AreEqual(2, RowCount, 'a plain (non-aggregated) join must still return one row per matching Order/Customer pair');
+    end;
+
+    // Positive (must throw): a runtime SetFilter on an AGGREGATED column is a HAVING-clause
+    // filter (evaluated against the aggregated result), which the WHERE-style per-row filter
+    // pushdown (TranslateQueryFilters) cannot express — it must fail loudly rather than
+    // silently filter raw rows by the unaggregated source value instead.
+    [Test]
+    procedure SetFilterOnAggregateColumn_ThrowsOutOfScope()
+    var
+        Q: Query "Qja Single Sum";
+        Assert: Codeunit "Qja Assert";
+    begin
+        Initialize();
+        Q.SetFilter(TotalAmount, '>100');
+
+        asserterror
+        begin
+            Q.Open();
+            if Q.Read() then;
+        end;
+
+        Assert.ExpectedError('out-of-scope: NavQuery.SetRange/SetFilter on an aggregated (Method=Sum/Count/Average/Min/Max) column');
+        Assert.ExpectedError('query-having-filter-not-supported');
+    end;
+
+    // Negative (sibling, must NOT throw): a runtime filter on the NON-aggregated column of
+    // the very same query must still work — proves the guard is scoped to the filtered
+    // column's OWN aggregation method, not to "any filter on a query that happens to also
+    // have an aggregate column somewhere". Without this, a fix that refused every filter on
+    // an aggregate-bearing query would pass the positive test above and silently break
+    // ordinary WHERE-style filtering on aggregate queries.
+    [Test]
+    procedure SetFilterOnNonAggregateColumn_StillWorks()
+    var
+        Q: Query "Qja Single Sum";
+        Assert: Codeunit "Qja Assert";
+        RowCount: Integer;
+    begin
+        Initialize();
+        Q.SetFilter(CustNo, 'C1');
+
+        Q.Open();
+        while Q.Read() do begin
+            RowCount += 1;
+            Assert.AreEqual('C1', Q.CustNo, 'CustNo column');
+            Assert.AreEqual(300, Q.TotalAmount, 'TotalAmount must still aggregate correctly under a non-aggregate filter');
+        end;
+        Q.Close();
+
+        Assert.AreEqual(1, RowCount, 'a WHERE-style filter on the non-aggregate column must still group to one row for C1');
+    end;
+}

--- a/tests/runner-extras/query-join-aggregation-oos/app.json
+++ b/tests/runner-extras/query-join-aggregation-oos/app.json
@@ -1,0 +1,19 @@
+{
+  "id": "9d1e4f7a-6b2c-4a8d-9e0f-3c5b7a9d1f64",
+  "name": "Runner Extras - Query Join Aggregation OOS",
+  "publisher": "AL Runner",
+  "version": "1.0.0.0",
+  "brief": "Regression for issue #2137: a query column with Method = Sum/Count/Average/Min/Max used to silently return unaggregated, ungrouped rows instead of aggregating or throwing. This suite pins the two runner-specific surfaces that still cannot aggregate correctly and must throw loudly instead of returning a wrong answer (tracked by follow-up issue #2146): a multi-dataitem JOIN query with an aggregated column, and a runtime SetFilter/SetRange on an aggregated column (a HAVING-clause filter).",
+  "description": "The general BC-language claim this fix makes — a single-dataitem query with Method = Sum/Count/Average/Min/Max implicitly groups by its other (non-aggregated) columns and computes the aggregate per group, exactly like the SQL SELECT ... GROUP BY the real service tier compiles — is plain BC behaviour and belongs upstream in the al-language corpus (see the runner repo's bc-behavior-tests-go-upstream.md); a corpus PR was prepared alongside this fix. This suite is the runner-repo-local claim that is NOT plain BC behaviour: it proves the two surfaces the fix could not implement (a multi-dataitem JOIN combined with GROUP BY, and a HAVING-style runtime filter on an aggregated column) now fail loudly with a named RunnerOutOfScopeException instead of silently returning the exact wrong-rows bug #2137 reported, just reached through a different code path. Once #2146 implements either surface for real, the matching test here is replaced with a positive one.",
+  "dependencies": [],
+  "idRanges": [
+    {
+      "from": 64530,
+      "to": 64539
+    }
+  ],
+  "platform": "27.0.0.0",
+  "application": "27.0.0.0",
+  "runtime": "15.0",
+  "target": "Cloud"
+}


### PR DESCRIPTION
mise ~/.config/mise/config.toml tools: gh@2.98.0
Closes #2137

## Summary

A query column with `Method = Sum/Count/Average/Min/Max` was silently returning raw, ungrouped rows instead of aggregating. Root cause: the runner's own metadata reconstruction (`BcAppSymbolCache.ParseQueryColumns` -> `RecordPatches.NclMetaQueryBuilder.AddColumn`) never carried the AL `Method` property onto the synthesized `NCLMetaQueryColumn`, so `AggregationType` stayed at its default (`None`) - indistinguishable from an ordinary column, and `RecordPatches.QueryProjection.cs` never knew to group anything.

The fix:
- `AlRunner/Patches/BcAppSymbolCache.cs` - `QueryColumnSymbol` now carries `Method`, read verbatim from the column's `Properties` bag in `SymbolReference.json`.
- `AlRunner/Patches/RecordPatches.NclMetaQueryBuilder.cs` - `AddColumn` sets `MetaQueryColumn.FieldTotalingMethod` from it.
- `AlRunner/Patches/RecordPatches.QueryProjection.cs` - `ProjectQueryRows` now detects any aggregated column and groups by the query's other (non-aggregated) columns, computing Sum/Count/Average/Min/Max per group. A query with only aggregate columns (no grouping column at all) is BC's scalar-aggregate case: always exactly one row, even over an empty table. `TOP` now applies after aggregation (previously it capped raw rows before projection, which silently drops rows out of a group before they're summed).
- `AlRunner/Patches/FlowFieldPatches.cs` - `TypedDefaultForField`/`NavValueCompare` made `internal` so the new aggregation code can reuse them instead of re-deriving comparison/default semantics.

## Fix the shape, not just the reported line

Two sibling surfaces hit the identical "aggregate column treated as ordinary" assumption and could not be made correct in this PR - both now throw a named `RunnerOutOfScopeException` instead of silently returning a different wrong answer, tracked by follow-up #2146:
- A multi-dataitem JOIN with an aggregated column (the isolated `AlRunner.QueryJoin.JoinExecutor` has no GROUP BY of its own).
- A runtime `SetFilter`/`SetRange` on an aggregated column - that's a HAVING-clause filter (evaluated against the aggregated result), which the existing WHERE-style per-row filter pushdown (`TranslateQueryFilters`) cannot express.

## The CacheVersion finding (caught in review, not by me originally)

`QueryColumnSymbol` is part of `CachePayload`, persisted to the on-disk `bc-symbols` cache and read back via `JsonSerializer`, keyed by `{fullPath}|hash:{contentHash}|v{CacheVersion}`. Adding `Method` to that record without bumping `CacheVersion` (still 13 at the time) meant a stale cache entry from the previous build - same `.app` content hash, JSON with no `Method` property - would deserialize with `Method` null and silently reintroduce this exact bug on any machine whose symbol cache predates the fix. Bumped `CacheVersion` to 14 with a comment entry matching the existing v9/v11/v12/v13 precedents, and added `BcAppSymbolCacheQueryMethodVersionTests.cs` proving both directions: a hand-written v13-shaped stale entry is ignored and reparsed (not served as a false HIT), and a fresh entry with `Method` present is still served as a genuine HIT (no unconditional reparse). The test locates the exact on-disk path via two new internal seams (`BcAppSymbolCache.CachePathForVersionForTests` / `CacheVersionForTests`) that delegate to the cache's real hashing formula, rather than a duplicated copy of it that would silently stop testing anything if that formula ever changed.

General shape for future changes: adding a field to any record nested inside `CachePayload` (`ParsedTable`, `EnumSymbol`, `QuerySymbol`/`QueryDataItemSymbol`/`QueryColumnSymbol`, `ObjectSymbol`, `ReportSymbol`/`ReportDataItemSymbol`/`ReportColumnSymbol`, `PageSymbol`/`PageControlSymbol`) requires a `CacheVersion` bump, unless the change genuinely doesn't affect what's parsed (e.g. #1820's key-validation-only change, which the existing comment above `CacheVersion` explicitly calls out as not needing one).

I audited whether any other cached record had already gained a field without a matching bump, checking every commit that has ever touched `BcAppSymbolCache.cs`: `146bdbbb` (v2 cutover baseline), `bce0ecce`, `fa848852`, `ca83face`, `e7e9cba5`, `679422db`, `51043986`, `90ff5b15`, `0a173344`. Every version-affecting change is already accounted for in the comment block above `CacheVersion` (v3 through v13), and `90ff5b15` in particular only touches the cache-KEY strategy (content hash replacing mtime), not any record's shape - `QueryColumnSymbol` in that diff appears solely as an unchanged context line. Found no other instance; none filed.

## Upstream corpus status

Landed: StefanMaron/BusinessCentral.AL.Language.Tests#69, merged at `4a7dde4d`, green on real BC 27.5/28.3. `Codeunit60762` "QJ Query Aggregation Tests" (5 tests) covers grouped Sum/Count/Average/Min/Max and both the empty-table scalar-aggregate case (SUM/COUNT default to 0, still exactly one row) and the empty-table grouped case (zero rows) - all confirmed as real BC's actual behaviour, not assumed.

The first corpus run did NOT pass on real BC and the reason matters for this fix: `column(CountAmount; Amount) { Method = Count; }` does not compile (AL0353 - "A Column must have a valid data source or have the 'Method' property set to 'Count'"). The only valid AL is `column(CountAmount) { Method = Count; }` - a Method=Count column takes no source field, it counts rows in the group. The runner's own AL compiler silently accepted the invalid form, so local testing against it never exercised the form BC actually requires - tracked as a separate runner gap, issue #2150 (not fixed here).

Verifying end-to-end against the corrected, valid AL form surfaced a real second defect in this same code path: `RecordPatches.NclMetaQueryBuilder.BuildMetaQueryDesign` required every column to resolve a `FieldNo` against the table, unconditionally, and silently abandoned the WHOLE query's metadata build (returning null) when a column named no field - which a `Method=Count` column legitimately never does. Before the fix this NRE'd deep inside `NavQuery.ValidateTablesNotVirtual` (the query never got a real `NCLMetaQuery` at all); confirmed `ComputeAggregate`'s `Count` branch never reads `TableSlot` (it only needs `groupRows.Count`), so a placeholder `FieldNo = 0` is safe - `NCLMetaQueryColumn.SourceTableField` itself already special-cases `Count` to bypass `FieldNo` entirely and return the table's own primary key field. Fixed, and confirmed a source-less Count column is correctly excluded from the GROUP BY key (`IsGroupKey` is gated on `AggregationType == None`, not on whether a source field resolved).

The submodule pin is bumped to `4a7dde4d` in this PR (folded in per `al-language-submodule.md` - a standalone pin bump would be red by construction, since the new tests fail without this fix). `tests/expectations/count-baseline/test-count-baseline.json`'s `al-language` entry moves 2150 -> 2155, confirmed from an actual local run (2155/2155 passing, cold and warm), not computed.

## Test plan

- `tests/runner-extras/query-join-aggregation-oos/` (new suite, 4 tests) - proves the two new `RunnerOutOfScopeException` guards (join+aggregate, HAVING-style filter) fire correctly, and that their negative siblings (ordinary join, filter on a non-aggregate column of an aggregate query) still work.
- `AlRunner.Tests/QueryAggregationProjectionTests.cs` - spawns the real runner against a temp bundle proving the core Sum/Count grouping and the scalar-aggregate-over-empty-table case, using the AL-valid `column(CountAmount) { Method = Count; }` form (updated to match what #69 corrected upstream).
- `AlRunner.Tests/BcAppSymbolCacheQueryMethodVersionTests.cs` - proves the `CacheVersion` bump (see above).
- The upstream corpus is now part of this diff (pin `4a7dde4d`): `Codeunit60762` (new aggregation tests, 5/5, verified RED on the pre-fix commit / GREEN with it, cold and warm), `Codeunit60865` (existing join tests, 6/6, no regression), `Codeunit60205` (existing Query object tests incl. `Query_TopNumberOfRows_LimitsResultSet`, 17/17, no regression from the TOP-after-aggregation reorder), full corpus 2155/2155 cold and warm with `--count-baseline` passing (exit 0).
- `dotnet test AlRunner.Tests` filtered to `BcAppSymbolCache|Query`: 24/24.
- Cache-sensitive suites (runner-extras suite, `BcAppSymbolCacheQueryMethodVersionTests`, full corpus) run cold and warm per the local-test-scope rule; all green both ways.

