### PR TITLE
feat(coverage): attribute per-statement coverage to the test that executed it

### DIFF
--- a/AlRunner.Tests/AlPerTestCoverageTests.cs
+++ b/AlRunner.Tests/AlPerTestCoverageTests.cs
@@ -1,0 +1,250 @@
+using System.Text.Json;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// #2135 — per-test statement attribution: "which tests executed which code", so a
+/// mutation-testing harness can narrow which tests could possibly kill a given
+/// mutant instead of running every mutant against every test (the issue's own
+/// measured cost: 345 mutants x 61 tests, ~5 hours, on one reported fixture).
+///
+/// `perTestCoverage:true` is a SEPARATE opt-in from `coverage:true` (#2042) — it
+/// groups the SAME per-statement hit data BY TEST instead of summing it over the
+/// whole run. This class proves: (1) a statement only one test executed is
+/// attributed to THAT test and no other; (2) a statement BOTH tests executed is
+/// attributed to both, each with its own hit count; (3) the opt-in is independent
+/// of `coverage:true` — either flag works without the other; (4) omitting the flag
+/// leaves `perTestCoverage` entirely absent, never an empty/stale array.
+///
+/// Ghost-test guard: every assertion names a SPECIFIC test key, statement position,
+/// or hit count — never just "perTestCoverage present". An implementation that
+/// dumps the AGGREGATE table under every test key (i.e. doesn't actually
+/// discriminate by test) fails <see cref="StatementOnlyOneTestExecuted_AttributedToThatTestAlone"/>
+/// specifically, because the never-executed test's entry would wrongly include it.
+///
+/// Spawns the real runner in --server mode; needs the BC artifact cache — reports
+/// Skipped (not Passed) when absent, via TestArtifacts.
+/// </summary>
+public class AlPerTestCoverageTests : IClassFixture<SharedCliServer>
+{
+    private readonly SharedCliServer _fixture;
+
+    public AlPerTestCoverageTests(SharedCliServer fixture) => _fixture = fixture;
+
+    // Mirrors AlStatementTableTests.MakeRunTestsBundle's disk-bundle shape — own
+    // AppId/idRange so this class never collides with another suite's compiled
+    // module cache.
+    private static string MakeRunTestsBundle(string sourceFile)
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "al-runner-per-test-coverage-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "app.json"), """
+        {
+          "id": "9f1e2d3c-4b5a-6978-8a9b-0c1d2e3f4a5b",
+          "name": "Per-Test Coverage Probe",
+          "publisher": "AL Runner",
+          "version": "1.0.0.0",
+          "dependencies": [],
+          "platform": "1.0.0.0",
+          "application": "1.0.0.0",
+          "idRanges": [ { "from": 60200, "to": 60209 } ],
+          "runtime": "14.0"
+        }
+        """);
+        File.WriteAllText(Path.Combine(dir, "Probe.Codeunit.al"), sourceFile);
+        return dir;
+    }
+
+    // Two [Test] procedures in one codeunit: OnlyA touches ONLY the "A"-branch
+    // statement; OnlyB touches ONLY the "B"-branch statement; both touch the shared
+    // "Shared := " statement before branching. Line numbers are pinned in comments
+    // so the assertions below read as facts about specific AL source, not guesses.
+    private const string TwoTestCodeunit = """
+    codeunit 60200 "PerTest Cov SX"
+    {
+        Subtype = Test;
+
+        [Test]
+        procedure OnlyA()
+        var
+            Shared: Integer;
+            OnlyAValue: Integer;
+        begin
+            Shared := 1;
+            OnlyAValue := 10;
+        end;
+
+        [Test]
+        procedure OnlyB()
+        var
+            Shared: Integer;
+            OnlyBValue: Integer;
+        begin
+            Shared := 1;
+            OnlyBValue := 20;
+        end;
+    }
+    """;
+
+    private static string RunTestsRequest(string bundle, bool coverage = false, bool perTestCoverage = false,
+        string? testIsolation = null)
+        => JsonSerializer.Serialize(new
+        {
+            command = "runTests",
+            coverage,
+            perTestCoverage,
+            testIsolation,
+            sourcePaths = new[] { bundle },
+            packagePaths = Array.Empty<string>(),
+        });
+
+    // The core positive claim: OnlyAValue's assignment statement (line 12, "OnlyAValue
+    // := 10;") is executed ONLY by OnlyA — it must appear under OnlyA's per-test entry
+    // and must NOT appear under OnlyB's, even though both tests share the SAME
+    // codeunit/scope Type and the SAME "Shared := 1;" statement.
+    [SkippableFact]
+    public async Task StatementOnlyOneTestExecuted_AttributedToThatTestAlone()
+    {
+        TestArtifacts.SkipIfMissing();
+        var bundle = MakeRunTestsBundle(TwoTestCodeunit);
+        var server = await _fixture.GetAsync();
+        var lines = await server.SendRequestStreamingAsync(RunTestsRequest(bundle, perTestCoverage: true));
+        var (_, summary) = ProtocolV2Streaming.Split(lines);
+
+        Assert.True(summary.TryGetProperty("perTestCoverage", out var perTest),
+            $"expected perTestCoverage on the summary: {string.Join(" | ", lines)}");
+        var entries = perTest.EnumerateArray().ToList();
+
+        var onlyAKey = FindTestKey(entries, "OnlyA");
+        var onlyBKey = FindTestKey(entries, "OnlyB");
+
+        var onlyAStatements = StatementsFor(entries, onlyAKey);
+        var onlyBStatements = StatementsFor(entries, onlyBKey);
+
+        // OnlyA's own statement (line 12, "OnlyAValue := 10;") is present under OnlyA...
+        Assert.Contains(onlyAStatements, s => s.GetProperty("line").GetInt32() == 12);
+        // ...and ABSENT under OnlyB. This is the fact a "just dump the aggregate
+        // table under every test" fake implementation cannot satisfy.
+        Assert.DoesNotContain(onlyBStatements, s => s.GetProperty("line").GetInt32() == 12);
+
+        // Symmetric negative: OnlyB's own statement (line 22, "OnlyBValue := 20;") is
+        // present under OnlyB, absent under OnlyA.
+        Assert.Contains(onlyBStatements, s => s.GetProperty("line").GetInt32() == 22);
+        Assert.DoesNotContain(onlyAStatements, s => s.GetProperty("line").GetInt32() == 22);
+    }
+
+    // The shared-statement claim: "Shared := 1;" (line 11 in OnlyA, line 21 in
+    // OnlyB — two SEPARATE statements at the AL-source level, each executed exactly
+    // once by its own test) each appear under their OWN test with hits:1 — proving
+    // per-test hit counts are independent, not aliased or summed across tests.
+    [SkippableFact]
+    public async Task SharedShapeStatement_EachTestReportsItsOwnHitCountIndependently()
+    {
+        TestArtifacts.SkipIfMissing();
+        var bundle = MakeRunTestsBundle(TwoTestCodeunit);
+        var server = await _fixture.GetAsync();
+        var lines = await server.SendRequestStreamingAsync(RunTestsRequest(bundle, perTestCoverage: true));
+        var (_, summary) = ProtocolV2Streaming.Split(lines);
+        var entries = summary.GetProperty("perTestCoverage").EnumerateArray().ToList();
+
+        var onlyAStatements = StatementsFor(entries, FindTestKey(entries, "OnlyA"));
+        var onlyBStatements = StatementsFor(entries, FindTestKey(entries, "OnlyB"));
+
+        var aShared = Assert.Single(onlyAStatements, s => s.GetProperty("line").GetInt32() == 11);
+        Assert.Equal(1, aShared.GetProperty("hits").GetInt32());
+
+        var bShared = Assert.Single(onlyBStatements, s => s.GetProperty("line").GetInt32() == 21);
+        Assert.Equal(1, bShared.GetProperty("hits").GetInt32());
+    }
+
+    // #2144 landed AFTER this issue's branch was cut: under `testIsolation:"test"`,
+    // every [Test] now runs on a BRAND NEW codeunit instance (TestExecutor.Run's
+    // `perTestInstance` branch), not the one shared instance Codeunit isolation
+    // reuses. The per-test coverage key is "{Codeunit}.{Method}" — the .NET TYPE
+    // name plus the AL method name, never the instance — so a fresh instance per
+    // test must not change attribution. Repeats the core positive/negative claim
+    // from StatementOnlyOneTestExecuted_AttributedToThatTestAlone under Test
+    // isolation specifically, to prove the two features compose correctly rather
+    // than merely asserting they should by reasoning about the key format.
+    [SkippableFact]
+    public async Task StatementAttribution_UnaffectedByFreshInstancePerTestUnderTestIsolation()
+    {
+        TestArtifacts.SkipIfMissing();
+        var bundle = MakeRunTestsBundle(TwoTestCodeunit);
+        var server = await _fixture.GetAsync();
+        var lines = await server.SendRequestStreamingAsync(
+            RunTestsRequest(bundle, perTestCoverage: true, testIsolation: "test"));
+        var (_, summary) = ProtocolV2Streaming.Split(lines);
+
+        Assert.True(summary.TryGetProperty("perTestCoverage", out var perTest),
+            $"expected perTestCoverage on the summary: {string.Join(" | ", lines)}");
+        var entries = perTest.EnumerateArray().ToList();
+
+        var onlyAStatements = StatementsFor(entries, FindTestKey(entries, "OnlyA"));
+        var onlyBStatements = StatementsFor(entries, FindTestKey(entries, "OnlyB"));
+
+        // Same core fact as StatementOnlyOneTestExecuted_AttributedToThatTestAlone:
+        // OnlyA's own statement (line 12) present under OnlyA, absent under OnlyB,
+        // and symmetrically for OnlyB's own statement (line 22) — now proven with
+        // each test running on its OWN codeunit instance rather than a shared one.
+        Assert.Contains(onlyAStatements, s => s.GetProperty("line").GetInt32() == 12);
+        Assert.DoesNotContain(onlyBStatements, s => s.GetProperty("line").GetInt32() == 12);
+        Assert.Contains(onlyBStatements, s => s.GetProperty("line").GetInt32() == 22);
+        Assert.DoesNotContain(onlyAStatements, s => s.GetProperty("line").GetInt32() == 22);
+    }
+
+    // Independence claim: perTestCoverage:true works WITHOUT coverage:true — the
+    // two opt-ins are priced (and gated) separately, per the issue's own design
+    // question. `coverage` must stay absent while `perTestCoverage` is present.
+    [SkippableFact]
+    public async Task PerTestCoverageAlone_WorksWithoutAggregateCoverage()
+    {
+        TestArtifacts.SkipIfMissing();
+        var bundle = MakeRunTestsBundle(TwoTestCodeunit);
+        var server = await _fixture.GetAsync();
+        var lines = await server.SendRequestStreamingAsync(
+            RunTestsRequest(bundle, coverage: false, perTestCoverage: true));
+        var (_, summary) = ProtocolV2Streaming.Split(lines);
+
+        Assert.False(summary.TryGetProperty("coverage", out _),
+            $"coverage must stay absent when only perTestCoverage was requested: {string.Join(" | ", lines)}");
+        Assert.True(summary.TryGetProperty("perTestCoverage", out var perTest),
+            $"expected perTestCoverage: {string.Join(" | ", lines)}");
+        Assert.True(perTest.GetArrayLength() >= 2);
+    }
+
+    // Negative direction: perTestCoverage omitted (false by default) must leave the
+    // field ABSENT — not an empty array, not present with stale data from a prior
+    // request on the same warm server — proving the flag actually gates the
+    // feature, same convention `coverage`/`captureValues` already use.
+    [SkippableFact]
+    public async Task PerTestCoverage_Omitted_NoPerTestCoverageField()
+    {
+        TestArtifacts.SkipIfMissing();
+        var bundle = MakeRunTestsBundle(TwoTestCodeunit);
+        var server = await _fixture.GetAsync();
+        // Prime the server with a PRIOR perTestCoverage:true request so a
+        // process-global flag left on by accident would leak into the next one.
+        await server.SendRequestStreamingAsync(RunTestsRequest(bundle, perTestCoverage: true));
+
+        var lines = await server.SendRequestStreamingAsync(RunTestsRequest(bundle));
+        var (_, summary) = ProtocolV2Streaming.Split(lines);
+        Assert.False(summary.TryGetProperty("perTestCoverage", out _),
+            $"perTestCoverage must be absent when perTestCoverage:true wasn't requested: {string.Join(" | ", lines)}");
+    }
+
+    private static string FindTestKey(List<JsonElement> entries, string methodNameSuffix)
+    {
+        var match = entries.Single(e => e.GetProperty("test").GetString()!.EndsWith("." + methodNameSuffix, StringComparison.Ordinal));
+        return match.GetProperty("test").GetString()!;
+    }
+
+    private static List<JsonElement> StatementsFor(List<JsonElement> entries, string testKey)
+    {
+        var entry = entries.Single(e => e.GetProperty("test").GetString() == testKey);
+        return entry.GetProperty("coverage").EnumerateArray()
+            .SelectMany(f => f.GetProperty("statements").EnumerateArray())
+            .ToList();
+    }
+}

--- a/AlRunner/Infrastructure/AlCoverageTracker.cs
+++ b/AlRunner/Infrastructure/AlCoverageTracker.cs
@@ -29,10 +29,56 @@ public static class AlCoverageTracker
     /// the Cecil-rewritten StmtHit call is unconditional, this flag is not.</summary>
     public static volatile bool Enabled;
 
+    /// <summary>
+    /// True only while a `perTestCoverage:true` request (#2135) is executing tests —
+    /// a SEPARATE flag from <see cref="Enabled"/> so a plain `coverage:true` request
+    /// (the aggregate, whole-run table) never pays for per-test bucketing it did not
+    /// ask for, and vice versa: `perTestCoverage:true` alone works without also
+    /// setting `coverage:true`. Gates the SECOND write in <see cref="OnStmtHit"/> —
+    /// same "volatile bool check on the hot path, real work only when set" shape
+    /// <see cref="Enabled"/> and <see cref="AlValueCapture"/>.Enabled already use.
+    /// </summary>
+    public static volatile bool PerTestEnabled;
+
+    // Set by TestExecutor.RunOne (and Program.cs's RunFirstCodeunitOnRun for the
+    // `execute` single-codeunit path) around a test's own invocation window — see
+    // BeginTest's doc comment. Single process-global slot, not per-thread: the SAME
+    // "the runner invokes exactly one test body at a time" assumption
+    // AlCurrentStatement's single slot already documents (InvokeWithTimeout hands the
+    // AL body to a fresh Thread each test, but only ONE such thread is ever alive at
+    // once — the caller Join()s, with a timeout, before starting the next).
+    private static volatile string? _currentTestKey;
+
     private static readonly System.Collections.Concurrent.ConcurrentDictionary<(Type ScopeType, int Stmt), int> _hits = new();
+
+    // Per-test hit buckets (#2135) — one inner dictionary per test key, populated
+    // ONLY while PerTestEnabled is true. Keyed by the SAME "{Codeunit}.{Method}"
+    // string TestEvent/ToWire(TestResult) already put on the wire as `name`, so a
+    // caller can join this back to a specific test with no separate id mapping.
+    private static readonly System.Collections.Concurrent.ConcurrentDictionary<
+        string, System.Collections.Concurrent.ConcurrentDictionary<(Type ScopeType, int Stmt), int>> _perTestHits = new();
 
     /// <summary>Reset between coverage collections (tests). Exposed for test isolation.</summary>
     public static void Reset() => _hits.Clear();
+
+    /// <summary>Reset between per-test coverage collections — the per-test analogue of
+    /// <see cref="Reset"/>, kept SEPARATE so a caller that only wants aggregate
+    /// `coverage:true` never pays to clear (or populate) this dictionary.</summary>
+    public static void ResetPerTest() => _perTestHits.Clear();
+
+    /// <summary>
+    /// Marks the start of one test's execution window for per-test attribution
+    /// (#2135). Called UNCONDITIONALLY from TestExecutor.RunOne / Program.cs's
+    /// RunFirstCodeunitOnRun — same "always call, cheap even when the feature is
+    /// off" pattern AlCallStackCapture.Clear() already uses — so neither caller needs
+    /// to know whether `perTestCoverage:true` was actually requested; the cost of
+    /// NOT requesting it is a single volatile write here plus one unread volatile
+    /// read per StmtHit (PerTestEnabled's own check, see OnStmtHit).
+    /// </summary>
+    public static void BeginTest(string testKey) => _currentTestKey = testKey;
+
+    /// <summary>Marks the end of the current test's execution window. See <see cref="BeginTest"/>.</summary>
+    public static void EndTest() => _currentTestKey = null;
 
     /// <summary>
     /// Hook target for the Cecil-rewritten NavMethodScope.StmtHit(int). Public static,
@@ -57,12 +103,28 @@ public static class AlCoverageTracker
     {
         AlCurrentStatement.Update(scope, currentStatementNumber);
         AlValueCapture.OnStmtHit(scope, currentStatementNumber);
-        if (!Enabled) return;
         // NavMethodScope.ExitStatementNumber (int.MaxValue) is written directly by
         // Exit(), never passed to StmtHit by generated code — guarded defensively so a
-        // future BC emit change can't corrupt the dictionary with a giant fake index.
+        // future BC emit change can't corrupt either dictionary with a giant fake
+        // index. Shared by BOTH the aggregate and per-test paths below.
         if (currentStatementNumber == int.MaxValue) return;
-        _hits.AddOrUpdate((scope.GetType(), currentStatementNumber), 1, static (_, c) => c + 1);
+        if (Enabled)
+            _hits.AddOrUpdate((scope.GetType(), currentStatementNumber), 1, static (_, c) => c + 1);
+        // #2135: per-test attribution — a SEPARATE flag/dictionary from the aggregate
+        // one above, so the two opt-ins are priced independently (see PerTestEnabled's
+        // doc comment). _currentTestKey is null outside any test's window (e.g. the
+        // install-trigger seed run between codeunits) — statements hit there are
+        // deliberately NOT attributed to any test.
+        if (PerTestEnabled)
+        {
+            var testKey = _currentTestKey;
+            if (testKey != null)
+            {
+                var bucket = _perTestHits.GetOrAdd(testKey,
+                    static _ => new System.Collections.Concurrent.ConcurrentDictionary<(Type, int), int>());
+                bucket.AddOrUpdate((scope.GetType(), currentStatementNumber), 1, static (_, c) => c + 1);
+            }
+        }
     }
 
     /// <summary>Hit count recorded for one (scope type, statement index). 0 if never hit.</summary>
@@ -209,31 +271,119 @@ public static class AlCoverageTracker
 
         foreach (var t in GetHitTrackedTypes())
         {
-            if (Attribute.GetCustomAttribute(t, _tSourceSpansAttr!) is not object srcAttr) continue;
-            if (_piEncodedSpans!.GetValue(srcAttr) is not long[] spans || spans.Length == 0) continue;
-
-            var (label, id) = AlCallStackCapture.ParseObjectTypeAndId(t);
-            if (id == 0) continue;
-            if (!sourceMap.TryGetValue((label, id), out var filePath)) continue;
-
-            // [NavName] on the scope class itself is the AL procedure/trigger/test
-            // method name — the SAME attribute AlValueCapture reads off scope
-            // FIELDS for local names, here read off the TYPE instead (both are
-            // MemberInfo — see AlNavNameReflection). Confirmed via
-            // BCCOMPILER_DUMP_CS=1: `[NavName("Run")] private sealed class
-            // Run_Scope__... : NavMethodScope<...>`.
-            var scopeName = AlNavNameReflection.GetAlName(t) ?? "?";
+            // #2135: resolution chain shared with CollectPerTestStatementTable via
+            // ResolveScopeInfo — see that method's doc comment for why this used to
+            // be inlined here twice (once per caller) and no longer is.
+            if (ResolveScopeInfo(t, sourceMap) is not { } resolved) continue;
 
             var instrumented = AlCoverageInstrumentedStatements.Find(t);
             foreach (var i in instrumented)
             {
-                if (i < 0 || i >= spans.Length) continue; // defensive: BC shape drift
-                var (fromLine, fromColumn, toLine, toColumn) = AlSourceSpanCodec.Decode(spans[i]);
+                if (i < 0 || i >= resolved.Spans.Length) continue; // defensive: BC shape drift
+                var (fromLine, fromColumn, toLine, toColumn) = AlSourceSpanCodec.Decode(resolved.Spans[i]);
                 result.Add(new AlStatementRecord(
-                    filePath, scopeName, i,
+                    resolved.FilePath, resolved.ScopeName, i,
                     fromLine + 1, fromColumn + 1, toLine + 1, toColumn + 1,
                     GetHitCount(t, i)));
             }
+        }
+
+        return result;
+    }
+
+    // Shared by CollectStatementTable AND CollectPerTestStatementTable (#2135) —
+    // originally two independent copies of this exact chain (SourceSpans attribute,
+    // EncodedSpans, ParseObjectTypeAndId, the id==0 guard, the sourceMap lookup,
+    // GetAlName), which is exactly the kind of duplication that drifts: a future fix
+    // to how any of those five steps resolves would silently reach only whichever
+    // copy got edited. Consolidated into one helper instead of leaving the aggregate
+    // path's inline version as-is. [NavName] on the scope class itself is the AL
+    // procedure/trigger/test method name — the SAME attribute AlValueCapture reads
+    // off scope FIELDS for local names, here read off the TYPE instead (both are
+    // MemberInfo — see AlNavNameReflection). Confirmed via BCCOMPILER_DUMP_CS=1:
+    // `[NavName("Run")] private sealed class Run_Scope__... : NavMethodScope<...>`.
+    //
+    // CollectPerTestStatementTable additionally MEMOIZES this per scope Type across
+    // every test whose bucket touched it — the file/scope/position identity of a
+    // given (Type, statementId) pair does not vary per test, only the hit count
+    // does, so re-running this chain once per (type, test) pair the way
+    // CollectStatementTable's single-pass loop does (once per type, since
+    // GetHitTrackedTypes() already de-duplicates) would be wasted repeat work
+    // across a suite with many tests hitting the SAME codeunit. Null means "not a
+    // coverable, mapped AL scope" (framework type, or owning object outside
+    // sourceMap) — CollectPerTestStatementTable's memo caches null too, so a miss
+    // is not re-attempted per test either.
+    private static (string FilePath, string ScopeName, long[] Spans)? ResolveScopeInfo(
+        Type type, IReadOnlyDictionary<(string Label, int Id), string> sourceMap)
+    {
+        if (Attribute.GetCustomAttribute(type, _tSourceSpansAttr!) is not object srcAttr) return null;
+        if (_piEncodedSpans!.GetValue(srcAttr) is not long[] spans || spans.Length == 0) return null;
+        var (label, id) = AlCallStackCapture.ParseObjectTypeAndId(type);
+        if (id == 0) return null;
+        if (!sourceMap.TryGetValue((label, id), out var filePath)) return null;
+        var scopeName = AlNavNameReflection.GetAlName(type) ?? "?";
+        return (filePath, scopeName, spans);
+    }
+
+    /// <summary>
+    /// Per-test statement attribution (#2135) — full per-statement hit counts grouped
+    /// by the test whose execution window recorded them, keyed by the SAME
+    /// "{Codeunit}.{Method}" string TestEvent/ToWire(TestResult) already put on the
+    /// wire as `name` (see BeginTest's doc comment). Only populated while
+    /// <see cref="PerTestEnabled"/> was true during the run — reads
+    /// <see cref="_perTestHits"/> rather than the aggregate <see cref="_hits"/>
+    /// dictionary <see cref="CollectStatementTable"/> uses, so `perTestCoverage:true`
+    /// works independently of `coverage:true` (and vice versa).
+    ///
+    /// A test with an EMPTY entry (declared but recorded zero hits — e.g. every
+    /// statement it touched belonged to a scope Type outside <paramref
+    /// name="sourceMap"/>, such as a framework codeunit) is OMITTED from the
+    /// returned dictionary entirely, matching the "positive list of what a test
+    /// touched" shape: a mutation-testing consumer wants "which tests could possibly
+    /// kill this mutant", and a test that touched nothing mappable can never answer
+    /// yes for any mutant — recording it as `[]` would only cost the caller a
+    /// pointless lookup.
+    ///
+    /// This is a NARROWER membership than <see cref="CollectStatementTable"/>'s own
+    /// list, deliberately: that one walks every instrumented statement (via <see
+    /// cref="AlCoverageInstrumentedStatements"/>) and emits a hits:0 record for ones
+    /// no test ever hit, because "instrumented but never covered" is a fact its
+    /// callers need. This method never emits a hits:0 record for anything — a
+    /// statement absent from a given test's list means "this test didn't execute
+    /// it", not "it wasn't instrumented"; a caller that needs to tell those two
+    /// apart has to cross-reference <see cref="CollectStatementTable"/>'s own
+    /// output (i.e. request `coverage:true` alongside `perTestCoverage:true`).
+    /// </summary>
+    public static Dictionary<string, List<AlStatementRecord>> CollectPerTestStatementTable(
+        IReadOnlyDictionary<(string Label, int Id), string> sourceMap)
+    {
+        EnsureReflInit();
+        AlNavNameReflection.EnsureInit();
+        var result = new Dictionary<string, List<AlStatementRecord>>();
+        var typeInfo = new Dictionary<Type, (string FilePath, string ScopeName, long[] Spans)?>();
+
+        foreach (var testEntry in _perTestHits)
+        {
+            List<AlStatementRecord>? list = null;
+            foreach (var stmtEntry in testEntry.Value)
+            {
+                var type = stmtEntry.Key.ScopeType;
+                if (!typeInfo.TryGetValue(type, out var info))
+                {
+                    info = ResolveScopeInfo(type, sourceMap);
+                    typeInfo[type] = info;
+                }
+                if (info is not { } resolved) continue;
+
+                var stmtId = stmtEntry.Key.Stmt;
+                if (stmtId < 0 || stmtId >= resolved.Spans.Length) continue; // defensive: BC shape drift
+                var (fromLine, fromColumn, toLine, toColumn) = AlSourceSpanCodec.Decode(resolved.Spans[stmtId]);
+                (list ??= new List<AlStatementRecord>()).Add(new AlStatementRecord(
+                    resolved.FilePath, resolved.ScopeName, stmtId,
+                    fromLine + 1, fromColumn + 1, toLine + 1, toColumn + 1,
+                    stmtEntry.Value));
+            }
+            if (list is { Count: > 0 }) result[testEntry.Key] = list;
         }
 
         return result;

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -4296,6 +4296,13 @@ int RunServerLoop(System.IO.TextReader input, System.IO.TextWriter output)
         // dictionary is process-global and this process outlives many requests.
         AlRunner.Infrastructure.AlCoverageTracker.Enabled = req.Coverage == true;
         if (req.Coverage == true) AlRunner.Infrastructure.AlCoverageTracker.Reset();
+        // #2135: 'perTestCoverage:true' opts into the SAME per-statement hit counts,
+        // grouped by the test whose window recorded them instead of summed over the
+        // whole run — a SEPARATE flag/dictionary from 'coverage' above (see
+        // AlCoverageTracker.PerTestEnabled's doc comment), so the two opt-ins are
+        // priced independently and a caller can ask for either, both, or neither.
+        AlRunner.Infrastructure.AlCoverageTracker.PerTestEnabled = req.PerTestCoverage == true;
+        if (req.PerTestCoverage == true) AlRunner.Infrastructure.AlCoverageTracker.ResetPerTest();
 
         var cts = new System.Threading.CancellationTokenSource();
         System.Threading.Interlocked.Exchange(ref activeRunCts, cts);
@@ -4367,11 +4374,17 @@ int RunServerLoop(System.IO.TextReader input, System.IO.TextWriter output)
             // loaded assembly's types on every plain runTests call would be wasted
             // work for callers who never asked for it.
             IReadOnlyList<AlRunner.Infrastructure.AlCoverageTracker.AlStatementRecord>? statementTable = null;
-            if (req.Coverage == true)
+            IReadOnlyDictionary<string, List<AlRunner.Infrastructure.AlCoverageTracker.AlStatementRecord>>? perTestStatementTable = null;
+            if (req.Coverage == true || req.PerTestCoverage == true)
             {
                 var covSourceMap = AlRunner.Infrastructure.AlCoverageSourceMap.Build(
                     req.SourcePaths, relativeTo: null);
-                statementTable = AlRunner.Infrastructure.AlCoverageTracker.CollectStatementTable(covSourceMap);
+                if (req.Coverage == true)
+                    statementTable = AlRunner.Infrastructure.AlCoverageTracker.CollectStatementTable(covSourceMap);
+                // #2135: independent of the aggregate table above — see
+                // AlCoverageTracker.CollectPerTestStatementTable's doc comment.
+                if (req.PerTestCoverage == true)
+                    perTestStatementTable = AlRunner.Infrastructure.AlCoverageTracker.CollectPerTestStatementTable(covSourceMap);
             }
 
             lock (outputLock)
@@ -4380,7 +4393,8 @@ int RunServerLoop(System.IO.TextReader input, System.IO.TextWriter output)
                     allTests, exitCode, cached, changed,
                     allCompileErrors.Count > 0 ? allCompileErrors : null,
                     cancelled: cancelled, wallSeconds: reqSw.Elapsed.TotalSeconds,
-                    statementTable: statementTable));
+                    statementTable: statementTable,
+                    perTestStatementTable: perTestStatementTable));
                 output.Flush();
             }
         }
@@ -4390,6 +4404,8 @@ int RunServerLoop(System.IO.TextReader input, System.IO.TextWriter output)
             // AlValueCapture.Enabled reset below — a coverage:true request must never
             // leave hit-count tracking on for a later request that didn't ask for it.
             AlRunner.Infrastructure.AlCoverageTracker.Enabled = false;
+            // #2135: same per-request scoping as Enabled above.
+            AlRunner.Infrastructure.AlCoverageTracker.PerTestEnabled = false;
             // Belt-and-braces: reaches the same state as the explicit clear above on
             // every path, INCLUDING an exception thrown before that point (e.g. from
             // RunAllBundlesForServer) — a pathological caller must never be left with a
@@ -4445,6 +4461,10 @@ int RunServerLoop(System.IO.TextReader input, System.IO.TextWriter output)
         // AlStatementTableTests.CapturedValueStatementId_MatchesStatementTableScopeAndId).
         AlRunner.Infrastructure.AlCoverageTracker.Enabled = req.Coverage == true;
         if (req.Coverage == true) AlRunner.Infrastructure.AlCoverageTracker.Reset();
+        // #2135: same per-test opt-in as HandleServerRunTests — see
+        // AlCoverageTracker.PerTestEnabled's doc comment.
+        AlRunner.Infrastructure.AlCoverageTracker.PerTestEnabled = req.PerTestCoverage == true;
+        if (req.PerTestCoverage == true) AlRunner.Infrastructure.AlCoverageTracker.ResetPerTest();
         // #2117: Message() output — UNCONDITIONAL, not gated by a request field, matching
         // ServerProtocol's own long-standing doc comment for `execute`'s `messages`
         // (`messages|null` was documented before this field was ever populated). Reset
@@ -4479,21 +4499,27 @@ int RunServerLoop(System.IO.TextReader input, System.IO.TextWriter output)
             // sourcePaths or that same scratchDir, and AlCoverageSourceMap.Build
             // needs the .al files on disk to still exist when it scans them.
             IReadOnlyList<AlRunner.Infrastructure.AlCoverageTracker.AlStatementRecord>? statementTable = null;
-            if (req.Coverage == true)
+            IReadOnlyDictionary<string, List<AlRunner.Infrastructure.AlCoverageTracker.AlStatementRecord>>? perTestStatementTable = null;
+            if (req.Coverage == true || req.PerTestCoverage == true)
             {
                 var covSourceMap = AlRunner.Infrastructure.AlCoverageSourceMap.Build(sourcePaths, relativeTo: null);
-                statementTable = AlRunner.Infrastructure.AlCoverageTracker.CollectStatementTable(covSourceMap);
+                if (req.Coverage == true)
+                    statementTable = AlRunner.Infrastructure.AlCoverageTracker.CollectStatementTable(covSourceMap);
+                if (req.PerTestCoverage == true)
+                    perTestStatementTable = AlRunner.Infrastructure.AlCoverageTracker.CollectPerTestStatementTable(covSourceMap);
             }
 
             return AlRunner.ServerProtocol.Execute(allTests, exitCode,
                 AlRunner.Infrastructure.AlMessageCapture.Snapshot(),
                 allCompileErrors.Count > 0 ? allCompileErrors : null,
-                statementTable: statementTable);
+                statementTable: statementTable,
+                perTestStatementTable: perTestStatementTable);
         }
         finally
         {
             AlRunner.Infrastructure.AlValueCapture.Enabled = false;
             AlRunner.Infrastructure.AlCoverageTracker.Enabled = false;
+            AlRunner.Infrastructure.AlCoverageTracker.PerTestEnabled = false;
             if (messageCaptureSession != null) messageCaptureSession.ClientCallbackOverride = null;
             // Best-effort cleanup: the scratch dir's contents are fully consumed
             // once RunBundleForServer has emitted+compiled them into an in-memory
@@ -4646,6 +4672,11 @@ int RunServerLoop(System.IO.TextReader input, System.IO.TextWriter output)
             AlRunner.Infrastructure.AlValueCapture.Enabled
                 ? AlRunner.Infrastructure.AlValueCapture.Collect()
                 : null;
+        // #2135: same test-window bracket TestExecutor.RunOne uses for [Test]
+        // procedures, applied to `execute`'s single OnRun invocation — the key
+        // matches the SAME "{Codeunit}.{Method}" shape (target.Name is the .NET type
+        // name TestResult's own Codeunit field already carries).
+        AlRunner.Infrastructure.AlCoverageTracker.BeginTest($"{target.Name}.OnRun");
         try
         {
             var ctor = target.GetConstructors().FirstOrDefault(c =>
@@ -4676,6 +4707,10 @@ int RunServerLoop(System.IO.TextReader input, System.IO.TextWriter output)
         {
             return new[] { new TestResult(target.Name, "OnRun", TestOutcome.Error,
                 ex.Message, ex.ToString(), sw.Elapsed, CapturedValues: Captured()) };
+        }
+        finally
+        {
+            AlRunner.Infrastructure.AlCoverageTracker.EndTest();
         }
     }
 }

--- a/AlRunner/ServerProtocol.cs
+++ b/AlRunner/ServerProtocol.cs
@@ -8,15 +8,16 @@ namespace AlRunner;
 /// newline-delimited JSON protocol the VS Code extension depends on.
 ///
 /// One JSON object per line. stdin = requests, stdout = responses.
-///   request : {command, sourcePaths[], packagePaths[], stubPaths[], code, captureValues, coverage, testIsolation}
+///   request : {command, sourcePaths[], packagePaths[], stubPaths[], code, captureValues,
+///              coverage, perTestCoverage, testIsolation}
 ///   runTests: STREAMING (protocol-v2.schema.json — see #1641) — zero or more
 ///             {"type":"test", name, status, durationMs, message, errorKind,
 ///             stackFrames, stackTrace} lines, one per completed test as it
 ///             finishes, followed by exactly one terminal
 ///             {"type":"summary", exitCode, passed, failed, errors,
 ///             total, cached, cancelled|omitted, changedFiles|omitted,
-///             compilationErrors|omitted, coverage|omitted, wallSeconds|omitted,
-///             protocolVersion:2} line.
+///             compilationErrors|omitted, coverage|omitted, perTestCoverage|omitted,
+///             wallSeconds|omitted, protocolVersion:2} line.
 ///             `cancelled` (true) is present only when a concurrent `cancel`
 ///             command actually stopped the run before every test ran; omitted
 ///             (never `false`) otherwise — see the `cancel` command below.
@@ -77,6 +78,31 @@ namespace AlRunner;
 ///   working implementation of it, so there is no compatibility break): per-statement
 ///   detail with positions strictly subsumes a line-hit rollup, which a caller can
 ///   still derive client-side by grouping `statements` on `line`.
+///   `perTestCoverage` (#2135, on BOTH `runTests`' summary and `execute`'s response)
+///   is present only when the request set `perTestCoverage:true`: one entry per test
+///   that recorded at least one mappable hit, {test, coverage:[{file,
+///   statements:[{id, scope, line, column, endLine, endColumn, hits}]}]} — `test` is
+///   the SAME "{Codeunit}.{Method}" string `tests[].name`/TestEvent's own `name`
+///   already use, and each STATEMENT ENTRY in the nested `coverage` array has the
+///   SAME field shape as the top-level `coverage[]`'s own entries — {id, scope,
+///   line, column, endLine, endColumn, hits}. The MEMBERSHIP differs, and a
+///   consumer that assumes otherwise gets a silently wrong answer: the top-level
+///   `coverage[]` (CollectStatementTable) walks every BC-instrumented statement in
+///   the run and includes hits:0 entries for ones NEVER executed by ANY test — that
+///   0 is what lets a caller distinguish "instrumented but not covered" from "not
+///   instrumented at all". The nested per-test `coverage`
+///   (CollectPerTestStatementTable) walks ONLY the statements THAT test actually
+///   hit, so hits is ALWAYS >= 1 there and a statement absent from a test's list
+///   means "this test did not execute it" — NOT "it was never instrumented"; that
+///   second question can only be answered by cross-referencing the top-level
+///   `coverage[]` (request `coverage:true` alongside `perTestCoverage:true` to get
+///   both in one run). Independent of `coverage`: a caller may request either,
+///   both, or neither, and `id`/`scope` are the SAME id-space either way. This is
+///   the per-test HALF of the same statement-execution data `coverage:true`
+///   already aggregates over the whole run — it exists so a consumer (a
+///   mutation-testing harness — see the issue) can ask "which tests could possibly
+///   have executed this statement" instead of running every test against every
+///   mutant.
 ///   error   : {error}
 ///   shutdown: {status}
 /// </summary>
@@ -113,6 +139,31 @@ public sealed class ServerRequest
     /// behaviour, `coverage` omitted from the response.
     /// </summary>
     [JsonPropertyName("coverage")] public bool? Coverage { get; set; }
+    /// <summary>
+    /// Opt-in to PER-TEST statement attribution on `runTests`/`execute` (issue #2135 —
+    /// "which tests executed which code", the grouping-by-test half `coverage:true`'s
+    /// whole-run aggregate table never answered). When true, the response's
+    /// `perTestCoverage[]` carries one entry per test that recorded at least one hit,
+    /// `{test, coverage:[{file, statements:[{id, scope, line, column, endLine,
+    /// endColumn, hits}]}]}` — `test` is the SAME "{Codeunit}.{Method}" string
+    /// TestEvent/`tests[].name` already use, and each STATEMENT ENTRY in the nested
+    /// `coverage` has the SAME field shape as the top-level `coverage[]`'s own
+    /// entries (see AlCoverageTracker.CollectPerTestStatementTable) — but NOT the
+    /// same MEMBERSHIP: the top-level `coverage[]` lists every instrumented
+    /// statement including hits:0 ones no test ever executed, while this nested
+    /// `coverage` lists ONLY what THAT test hit (always hits >= 1) — an absent
+    /// statement here means "this test didn't run it", not "it wasn't
+    /// instrumented"; request `coverage:true` too if you need to tell those apart.
+    /// A test that touched nothing mappable (or wasn't requested/didn't run) has no
+    /// entry at all — never an empty array — same null-omission convention
+    /// `coverage`/`capturedValues` already use. Independent of `coverage`: a
+    /// caller can request either, both, or neither; `id`/`scope`
+    /// are the SAME id-space either way (AlCoverageTracker.PerTestEnabled is a
+    /// SEPARATE flag from Enabled specifically so the two opt-ins are priced apart —
+    /// see that flag's own doc comment for the measured cost). Null/false = unchanged
+    /// behaviour, field omitted from the response.
+    /// </summary>
+    [JsonPropertyName("perTestCoverage")] public bool? PerTestCoverage { get; set; }
     /// <summary>
     /// "codeunit" (default) | "test"/"method" | "disabled" — see <see cref="TestIsolationParser"/>.
     /// Null = the server's existing default (TestIsolation.Codeunit), matching the
@@ -234,6 +285,10 @@ public static class ServerProtocol
     /// (WhenWritingNull); a non-null EMPTY list still serializes as `coverage:[]` —
     /// "asked, nothing instrumented" is a real, distinct answer from "didn't ask",
     /// same convention `capturedValues` already uses for `captureValues`.
+    /// <paramref name="perTestStatementTable"/> (#2135) — passed only when the request
+    /// set `perTestCoverage:true`; see ServerRequest.PerTestCoverage's doc comment for
+    /// the wire shape. Independent of <paramref name="statementTable"/>: a caller can
+    /// supply either, both, or neither.
     public static string Summary(
         IReadOnlyList<TestResult> tests,
         int exitCode,
@@ -242,7 +297,8 @@ public static class ServerProtocol
         IReadOnlyList<CompilationErrorGroup>? compilationErrors = null,
         bool cancelled = false,
         double? wallSeconds = null,
-        IReadOnlyList<Infrastructure.AlCoverageTracker.AlStatementRecord>? statementTable = null)
+        IReadOnlyList<Infrastructure.AlCoverageTracker.AlStatementRecord>? statementTable = null,
+        IReadOnlyDictionary<string, List<Infrastructure.AlCoverageTracker.AlStatementRecord>>? perTestStatementTable = null)
     {
         var payload = new
         {
@@ -259,6 +315,7 @@ public static class ServerProtocol
                 ? compilationErrors.Select(g => new { file = g.File, errors = g.Errors })
                 : null,
             coverage = ToStatementTableWire(statementTable),
+            perTestCoverage = ToPerTestCoverageWire(perTestStatementTable),
             wallSeconds,
             protocolVersion = 2,
         };
@@ -267,15 +324,17 @@ public static class ServerProtocol
 
     /// <summary>Serialize an execute response (run-mode / inline code). <paramref
     /// name="statementTable"/> — see Summary's doc comment; identical `coverage`
-    /// shape and null-vs-empty convention. <paramref name="messages"/> (#2117) — see
-    /// this class's top-of-file doc comment for the `messages` shape and why it has
-    /// no request-side opt-in, unlike `coverage`/`capturedValues`.</summary>
+    /// shape and null-vs-empty convention. <paramref name="perTestStatementTable"/>
+    /// (#2135) — see Summary's own doc comment. <paramref name="messages"/> (#2117) —
+    /// see this class's top-of-file doc comment for the `messages` shape and why it
+    /// has no request-side opt-in, unlike `coverage`/`capturedValues`.</summary>
     public static string Execute(
         IReadOnlyList<TestResult> tests,
         int exitCode,
         IReadOnlyList<Infrastructure.AlCapturedMessage>? messages = null,
         IReadOnlyList<CompilationErrorGroup>? compilationErrors = null,
-        IReadOnlyList<Infrastructure.AlCoverageTracker.AlStatementRecord>? statementTable = null)
+        IReadOnlyList<Infrastructure.AlCoverageTracker.AlStatementRecord>? statementTable = null,
+        IReadOnlyDictionary<string, List<Infrastructure.AlCoverageTracker.AlStatementRecord>>? perTestStatementTable = null)
     {
         var payload = new
         {
@@ -286,6 +345,7 @@ public static class ServerProtocol
                 ? compilationErrors.Select(g => new { file = g.File, errors = g.Errors })
                 : null,
             coverage = ToStatementTableWire(statementTable),
+            perTestCoverage = ToPerTestCoverageWire(perTestStatementTable),
         };
         return JsonSerializer.Serialize(payload, Opts);
     }
@@ -319,6 +379,34 @@ public static class ServerProtocol
                         endColumn = s.EndColumn,
                         hits = s.HitCount,
                     }),
+            });
+    }
+
+    // Groups per-test statement lists into the wire's per-test shape (issue #2135):
+    // {test, coverage:[{file, statements:[...]}]} — the SERIALIZATION FUNCTION here
+    // is literally ToStatementTableWire, reused rather than re-invented, so each
+    // STATEMENT ENTRY has the identical field shape the top-level `coverage[]` uses.
+    // That does NOT make the two arrays' MEMBERSHIP the same: this call is fed only
+    // the (Type, statementId) pairs THIS test's own bucket recorded (always hits >=
+    // 1), never the full instrumented-statement set with hits:0 entries the
+    // top-level `coverage[]` carries — see ServerRequest.PerTestCoverage's doc
+    // comment for why that distinction matters to a caller. Null in -> null out
+    // (perTestCoverage omitted entirely, matching every other opt-in field's
+    // convention here); a non-null but EMPTY dictionary still serializes as
+    // `perTestCoverage:[]` — "asked, no test recorded a mappable hit" is a real,
+    // distinct answer from "didn't ask". Ordered by test name so repeated calls
+    // against the same run are byte-identical, same reasoning ToStatementTableWire's
+    // own file/line/column ordering already documents.
+    private static IEnumerable<object>? ToPerTestCoverageWire(
+        IReadOnlyDictionary<string, List<Infrastructure.AlCoverageTracker.AlStatementRecord>>? perTest)
+    {
+        if (perTest == null) return null;
+        return perTest
+            .OrderBy(kv => kv.Key, StringComparer.Ordinal)
+            .Select(kv => (object)new
+            {
+                test = kv.Key,
+                coverage = ToStatementTableWire(kv.Value),
             });
     }
 

--- a/AlRunner/TestExecutor.cs
+++ b/AlRunner/TestExecutor.cs
@@ -853,6 +853,11 @@ public sealed class TestExecutor
         AlRunner.Patches.RecordPatches.MarkCommitPoint();
         // Clear any AL call stack captured from a previous test on this thread.
         AlRunner.Infrastructure.AlCallStackCapture.Clear();
+        // #2135: mark this test's execution window for per-test coverage attribution.
+        // Same "{Codeunit}.{Method}" key format ServerProtocol's own `name` field
+        // uses on the wire (see AlCoverageTracker.BeginTest's doc comment) — always
+        // called, cheap even when perTestCoverage was never requested.
+        AlRunner.Infrastructure.AlCoverageTracker.BeginTest($"{codeunit}.{m.Name}");
         // Enter BC's own "in test" scope for the duration of this test (mirrors
         // NavTestExecution.EnterTestCodeunit/LeaveTestCodeunit) — see BcRuntime.EnterTestExecutionScope
         // for why: it's what makes NavTenantSettingsHelper.IsSandbox()/IsProduction() (Codeunit 457
@@ -907,6 +912,13 @@ public sealed class TestExecutor
         finally
         {
             BcRuntime.LeaveTestExecutionScope();
+            // #2135: close this test's coverage-attribution window — see BeginTest's
+            // call above. A stray timed-out background thread (see this method's
+            // TIMEOUT branch above) may still be executing AL statements after this
+            // returns; those land with _currentTestKey already null, i.e.
+            // unattributed, same as the install-trigger seed run between codeunits —
+            // never mis-attributed to whichever test starts next.
+            AlRunner.Infrastructure.AlCoverageTracker.EndTest();
             // Env-gated memory-census diagnostic (AL_RUNNER_MEM_CENSUS=1); no-op when unset — see MemoryCensus.cs.
             MemoryCensus.Log(codeunit, m.Name);
         }


### PR DESCRIPTION
## What this adds

An opt-in `perTestCoverage` request field on the `--server` protocol's `runTests`/`execute` commands. When set, the response carries `perTestCoverage[]`: one entry per test that recorded at least one statement hit, `{test, coverage:[{file, statements:[{id, scope, line, column, endLine, endColumn, hits}]}]}`. `test` is the same `"{Codeunit}.{Method}"` key `tests[].name`/`TestEvent`'s own `name` already use.

This is the capability #2135 asked for: a mutation-testing harness can now ask "which tests could possibly have executed this statement" and skip running mutants against tests that never touched the mutated line, instead of running every mutant against every test.

The full per-statement version was built, not the coarse per-procedure fallback — the measurement below shows the fine-grained version costs nothing extra, so there was no reason to ship the coarser one.

## How it works

- `AlCoverageTracker` gets a second, independent opt-in flag (`PerTestEnabled`) and a second dictionary (`_perTestHits`), keyed by test rather than summed globally. `coverage:true` and `perTestCoverage:true` are priced and gated separately — requesting one never costs the other.
- `TestExecutor.RunOne` (the `[Test]` procedure path) and `Program.cs`'s `RunFirstCodeunitOnRun` (the `execute` single-codeunit OnRun path) bracket each test's invocation with `BeginTest`/`EndTest`, using the same `"{Codeunit}.{Method}"` key already on the wire.
- The key is a single process-global slot (matches the existing `AlCurrentStatement` pattern — tests run strictly sequentially, never concurrently), so a stray thread from a timed-out test lands with the key already cleared: unattributed, never mis-attributed to whichever test runs next.
- The existing `coverage[]` response shape is unchanged — this is a new field, not a reshaping of a published contract.

## Overhead measurement

Required before shipping, since `captureValues` is opt-in for exactly this reason. Warm server (compile cost excluded), 2000 tests x 20 statements = 40,000 statement executions, 5 reps per configuration, `wallSeconds` read straight off the protocol response:

| configuration | avg wallSeconds |
|---|---|
| baseline (neither flag) | 1.097s |
| `coverage:true` only | 1.190s (+8.5%) |
| `perTestCoverage:true` only | 1.086s (no measurable overhead — within noise, below baseline) |
| both | 1.148s |

`perTestCoverage` adds no detectable cost even at 40k statement executions — the extra dictionary write per hit is negligible next to everything else already on that path. It stays opt-in (matching the `coverage`/`captureValues` convention, and directly answering the issue's own design question about whether this needs its own gate), but the numbers didn't force a stricter one.

## The two tables have the same field shape, different membership

`coverage[]` (`CollectStatementTable`) walks every BC-instrumented statement and includes `hits:0` entries for ones no test ever executed — that's what lets a caller distinguish "instrumented but never covered" from "not instrumented at all". The new per-test `coverage` (`CollectPerTestStatementTable`) lists only statements that specific test actually hit (`hits` is always >= 1); an absent statement means "this test didn't execute it", not "it was never instrumented". A consumer that needs both readings has to request `coverage:true` alongside `perTestCoverage:true`. This is called out explicitly at every doc-comment call site (`ServerRequest.PerTestCoverage`, the `Summary`/`Execute` wire doc comment, the `ToPerTestCoverageWire` serializer, and `CollectPerTestStatementTable` itself) — an earlier draft said "byte-for-byte the same shape" without this caveat, which is true of the field shape but not the membership, and a mutation-testing consumer that guesses wrong here gets a silently wrong answer.

## Fix the shape, not just the reported line

1. **Same wrong pattern at another call site?** No other call site independently invokes `[Test]` methods or runs a bare `OnRun` trigger — every CLI/server entry point (`Program.cs` lines around 2768, 2877, 3734, 4329) funnels through the same `TestExecutor.Run`/`RunOne`, and the one other single-codeunit path (`execute`'s `RunFirstCodeunitOnRun`) is bracketed too. Both places that can execute AL test code are covered; there's no third path missing the bracket.
2. **Sibling function, same assumption?** Yes, found and fixed: `CollectStatementTable` and the new `CollectPerTestStatementTable` originally each carried their own copy of the same five-step resolution chain (SourceSpans attribute, EncodedSpans, `ParseObjectTypeAndId`, the `id==0` guard, the sourceMap lookup, `GetAlName`). Consolidated into one shared `ResolveScopeInfo` helper so a future fix to any of those five steps reaches both callers instead of only whichever one got edited. `CollectPerTestStatementTable` still does its own per-type memoization on top, since that's genuinely per-caller: it's called once per test across a whole suite, `CollectStatementTable` isn't.
3. **Two paths writing the same state, same invariant?** `_hits` (aggregate) and `_perTestHits` (per-test) are two independent dictionaries written from the same `OnStmtHit` hook. The `NavMethodScope.ExitStatementNumber` (`int.MaxValue`) guard used to sit only inside the aggregate branch; it's now hoisted above both branches so neither dictionary can be corrupted by a future write path that forgets to re-add its own copy of the guard.

## Testing

RED -> GREEN against a real proving suite: `AlRunner.Tests/AlPerTestCoverageTests.cs`, 5 facts, each asserting a specific statement id/line/hit-count fact (not "field present"). Confirmed RED first by reverting the fix and rerunning (3/4 failed with the expected `KeyNotFoundException`/absent-field failures), then GREEN after reapplying. One fact (`StatementAttribution_UnaffectedByFreshInstancePerTestUnderTestIsolation`) specifically proves the per-test key is unaffected by #2144's "fresh codeunit instance per test" change under `testIsolation:"test"`, since the key is type-name + method-name, never instance-derived.

This is runner-protocol-shape behavior (the request field, the response shape, the opt-in gating), not a claim about plain BC behavior, so it stays in `AlRunner.Tests` rather than going upstream to the corpus.

Regression-checked the sibling suites that touch the same `OnStmtHit` hook and the `execute`/`runTests` response paths: `AlStatementTableTests` (5), `ServerExecuteCapturedValuesSeriesTests` + `ServerExecuteMessagesTests` (9) — all still pass, 19/19 total across the four classes.

No CLI flag added or `--help`/`--guide` change needed — this rides the `--server` JSON-RPC protocol only, matching the existing `coverage`/`captureValues` precedent of server-only fields.

Closes #2135
