### PR TITLE
test(corpus): bump the al-language pin to pick up the NumberSequence tests

### DIFF
--- a/tests/expectations/count-baseline/test-count-baseline.json
+++ b/tests/expectations/count-baseline/test-count-baseline.json
@@ -2,7 +2,7 @@
   "_comment": "Consumed by --count-baseline (AlRunner/Infrastructure/CountBaseline.cs), a DIFFERENT schema from the oos-/known-gaps-/divergence-/disabled- files in this directory: those declare the expected CLASSIFICATION of one named test, this declares the expected EXACT COUNT of a whole suite -- an exact match, not a floor: a mismatch in EITHER direction (drop OR growth) fails the run (exit 4). See #1880 and PR #1882's review for why growth is also a hard failure, not just a notice. Suite keys are the basename of the bundle directory CI passes on the command line (tests/al-language/tests/al-language -> 'al-language', tests/runner-extras -> 'runner-extras'), matching the '--out <name>-results.json' convention CI already uses. Values below are read off actual Test Matrix CI runs (see PR discussion for run URLs), not guessed: al-language's 2073->2076 bump reflects 3 corpus tests merged upstream between when the local baseline was drafted and when CI first ran against it. runner-extras' appGroups 23->21 byBcVersion override on 27.0/27.3/27.5 is the SAME preprocessor-gated-surface split that already explains its tests count divergence: fewer AL surfaces compile pre-28.0, which drops whole app groups, not just individual tests within a group. ANY PR that changes a suite's test or app-group count -- growth included -- MUST bump the matching number here in the SAME PR, or that PR's CI goes red with a [count-baseline] DROP or GROWTH diagnostic naming the exact expected/actual numbers to use.",
   "suites": {
     "al-language": {
-      "tests": { "default": 2140 },
+      "tests": { "default": 2150 },
       "appGroups": { "default": 1 }
     },
     "runner-extras": {


### PR DESCRIPTION
No linked issue: the work this pin brings in is already tracked and closed by #2145; this PR only moves the submodule pointer and the count baseline.

## What this does

Moves the `tests/al-language` submodule from `ab43ec0` to `bb20c87`, picking up `session/TestNumberSequence.al` from BusinessCentral.AL.Language.Tests#68.

That file adds ten tests: seed and increment behavior for `Next`, `Current` immediately after `Insert`, `Restart` replacing the next value while keeping the increment, `Delete`, both `Range` overloads including the ByRef one that reports the increment, company-specific and global sequences of the same name staying independent, and the two error cases (inserting a duplicate, and asking for the next value of a sequence that does not exist).

## Why it is a standalone PR

The rule is that a pin bump folds into the fix PR, because new corpus tests fail without the fix and a pin-bump-only PR would be red by construction. That does not apply here. The runner support these tests exercise merged in #2145, so the tests pass on current `main` and this PR is green on its own.

## Verification

The upstream tests ran against a real BC service tier on 27.5 and 28.3 before #68 merged, so the values they assert are BC's, not the runner's.

Locally on BC 28.4, at this pin: 2150 total, 2150 pass, 0 fail. I ran it twice — the second run exercises the compile-cache path, which has hidden query defects here before.

The count baseline for `al-language` goes 2140 to 2150, matching the ten added tests.
