### PR TITLE
fix(compiler): gate module runs on AL error diagnostics, not zero sources

### DIFF
--- a/AlRunner.Tests/Al1081ToleranceScopingTests.cs
+++ b/AlRunner.Tests/Al1081ToleranceScopingTests.cs
@@ -1,0 +1,186 @@
+using System.Diagnostics;
+using System.Text;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// Issue #2150 review follow-up (PR #2154) — the AL-diagnostic compile-failure guard added
+/// for #2150 has to carve out AL1081 ("Unable to update report layout ... Could not find
+/// file") because turning the guard on surfaced a PRE-EXISTING, unrelated runner bug
+/// (#2151: the runner's Tier-3 source compile resolves a report's LayoutFile relative to
+/// the app root instead of the .al file's own directory) across 6 al-language corpus
+/// reports. A bare `d.Contains(": error AL1081:")` carve-out would tolerate EVERY AL1081,
+/// including one naming a layout file that genuinely does not exist anywhere in the app —
+/// exactly the silent-failure shape #2150 itself exists to remove, just moved to a
+/// different error code. `IsKnownLayoutPathResolutionBug` (AlRunner/Program.cs) scopes the
+/// carve-out to the SPECIFIC condition #2151 describes: the named file must actually exist
+/// somewhere else under the app's own directory tree. This suite proves both directions of
+/// that scoping directly against the CLI (not the C# helper in isolation), because the
+/// claim is about end-to-end runner behaviour: does a real bundle compile/fail the way the
+/// scoping intends.
+/// </summary>
+public class Al1081ToleranceScopingTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+    private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
+
+    private static (string output, int exit) RunRunner(string bundle)
+    {
+        var args = new StringBuilder(TestBuildConfig.RunArgs(ProjectPath));
+        args.Append(TestBuildConfig.BcVersionArg);
+        args.Append(" \"").Append(bundle).Append('"');
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet", Arguments = args.ToString(),
+            RedirectStandardOutput = true, RedirectStandardError = true,
+            UseShellExecute = false, CreateNoWindow = true, WorkingDirectory = RepoRoot,
+        };
+        var sb = new StringBuilder();
+        var p = Process.Start(psi)!;
+        p.OutputDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.ErrorDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.BeginOutputReadLine();
+        p.BeginErrorReadLine();
+        if (!p.WaitForExit(180_000)) { try { p.Kill(true); } catch { } throw new TimeoutException("runner hung"); }
+        p.WaitForExit();
+        lock (sb) return (sb.ToString(), p.ExitCode);
+    }
+
+    private static string WriteApp(string suffix, string appId, int baseId)
+    {
+        var root = Path.Combine(Path.GetTempPath(), "al-runner-al1081-scoping-" + suffix, Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        File.WriteAllText(Path.Combine(root, "app.json"), $$"""
+        {
+          "id": "{{appId}}",
+          "name": "AL1081 Scoping Test {{suffix}}",
+          "publisher": "Repro2154",
+          "version": "1.0.0.0",
+          "dependencies": [],
+          "platform": "1.0.0.0",
+          "application": "1.0.0.0",
+          "idRanges": [ { "from": {{baseId}}, "to": {{baseId + 9}} } ],
+          "runtime": "14.0"
+        }
+        """);
+        File.WriteAllText(Path.Combine(root, "Sample.Table.al"), $$"""
+        table {{baseId}} "AL1081 Sample {{suffix}}"
+        {
+            fields
+            {
+                field(1; "No."; Code[20]) { }
+            }
+            keys
+            {
+                key(PK; "No.") { Clustered = true; }
+            }
+        }
+        """);
+        return root;
+    }
+
+    /// <summary>
+    /// The exact shape of the al-language corpus bug #2151 tracks: the report .al file
+    /// lives in a SUBDIRECTORY, LayoutFile is a relative reference resolved against that
+    /// subdirectory in real BC, and the runner's app-root-relative resolution misses it —
+    /// but the file genuinely exists on disk, just not where the runner looked. Must
+    /// compile and run (exit 0), with the tolerance printed loudly and naming #2151 so a
+    /// developer hitting this can tell it's the runner's fault, not theirs.
+    /// </summary>
+    [SkippableFact]
+    public void LayoutFileResolvedAgainstWrongDirectory_FileExistsElsewhere_ToleratedLoudly()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var baseId = 62310;
+        var root = WriteApp("tolerated", "f4444444-4444-4444-4444-444444444444", baseId);
+        var handlersDir = Path.Combine(root, "handlers");
+        Directory.CreateDirectory(handlersDir);
+
+        // The layout genuinely exists — next to the report, exactly as AL's LayoutFile
+        // semantics require — NOT at the app root the runner's RelativeFileSystem checks.
+        File.WriteAllText(Path.Combine(handlersDir, "ScopingLayout.rdlc"), "<Report></Report>");
+        File.WriteAllText(Path.Combine(handlersDir, "ScopingReport.Report.al"), $$"""
+        report {{baseId + 1}} "AL1081 Report Tolerated"
+        {
+            UsageCategory = None;
+            ProcessingOnly = false;
+            DefaultRenderingLayout = ScopingLayout;
+
+            dataset
+            {
+                dataitem(Sample; "AL1081 Sample tolerated")
+                {
+                    column(No; "No.") { }
+                }
+            }
+
+            rendering
+            {
+                layout(ScopingLayout)
+                {
+                    Type = RDLC;
+                    LayoutFile = './ScopingLayout.rdlc';
+                }
+            }
+        }
+        """);
+
+        var (output, exitCode) = RunRunner(root);
+
+        Assert.Equal(0, exitCode);
+        Assert.Contains("AL1081-TOLERATED", output);
+        Assert.Contains("2151", output);
+        Assert.DoesNotContain("AL-DIAGNOSTIC-FAIL", output);
+    }
+
+    /// <summary>
+    /// Negative direction — the scoping's whole reason to exist. A report naming a layout
+    /// file that does not exist ANYWHERE under the app is a genuinely broken report, not
+    /// #2151's bug, and must still fail loudly. A carve-out keyed on the bare "AL1081"
+    /// error code alone (rather than "AND the file exists elsewhere") would wrongly pass
+    /// this case — this test is what would have caught that regression.
+    /// </summary>
+    [SkippableFact]
+    public void LayoutFileTrulyMissing_NotToleratedStillFailsCompile()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var baseId = 62320;
+        var root = WriteApp("missing", "f5555555-5555-5555-5555-555555555555", baseId);
+        File.WriteAllText(Path.Combine(root, "MissingReport.Report.al"), $$"""
+        report {{baseId + 1}} "AL1081 Report Missing"
+        {
+            UsageCategory = None;
+            ProcessingOnly = false;
+            DefaultRenderingLayout = MissingLayout;
+
+            dataset
+            {
+                dataitem(Sample; "AL1081 Sample missing")
+                {
+                    column(No; "No.") { }
+                }
+            }
+
+            rendering
+            {
+                layout(MissingLayout)
+                {
+                    Type = RDLC;
+                    LayoutFile = './ThisFileGenuinelyDoesNotExistAnywhereInTheApp.rdlc';
+                }
+            }
+        }
+        """);
+
+        var (output, exitCode) = RunRunner(root);
+
+        Assert.NotEqual(0, exitCode);
+        Assert.Contains("AL1081", output);
+        Assert.Contains("AL-DIAGNOSTIC-FAIL", output);
+        Assert.DoesNotContain("AL1081-TOLERATED", output);
+    }
+}

--- a/AlRunner.Tests/QueryColumnAlDiagnosticFailureTests.cs
+++ b/AlRunner.Tests/QueryColumnAlDiagnosticFailureTests.cs
@@ -1,0 +1,166 @@
+using System.Diagnostics;
+using System.Text;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// Issue #2150 — a query column that declares BOTH a data source AND
+/// <c>Method = Count</c> is rejected by real BC at compile time with AL0353
+/// ("A Column must have a valid data source or have the 'Method' property set
+/// to 'Count'"). The runner used to accept it and run the module anyway, so AL
+/// that can never build against a real service tier compiled and ran here —
+/// a test written and passing against the runner failed to compile the moment
+/// it reached a real BC upstream (see corpus commit 4a7dde4d,
+/// tests/al-language/tests/al-language/query/QjOrderSum.Query.al).
+///
+/// Root cause was NOT the diagnostic-collection mechanism BcCompiler.cs uses
+/// (compilation.GetDeclarationDiagnostics() / emitResult.Diagnostics already
+/// captures AL0353 correctly on every compile, unconditionally — verified by
+/// direct decompilation of Microsoft.Dynamics.Nav.CodeAnalysis.dll:
+/// SourceQueryColumnSymbol.CheckColumn() raises ERR_QueryColumnsMustDefine-
+/// SourceExpressionOrCountMethod via AddDeclarationDiagnostics(), a
+/// declaration-stage diagnostic, not a method-body one gated behind the more
+/// expensive full-semantic-binding GetDiagnostics() call). The bug was in
+/// Program.cs's consumption of that already-collected data: BC's own
+/// ContinueBuildOnError keeps compiling an object's SIBLINGS after a
+/// declaration-stage error on one of them, so `sources` can come back
+/// non-empty (the broken query's metadata still emits) at the same time
+/// `alDiagnostics` is also non-empty. Neither of Program.cs's two existing
+/// guards fired for that combination — PARTIAL-EMIT-DROP requires
+/// alDiagnostics.Count == 0, EMIT-ZERO requires sources.Count == 0 — so the
+/// module silently ran with a real BC compile error in it.
+///
+/// This test spawns the real runner CLI (not BcCompiler in-process) because
+/// the fix lives in Program.cs's post-emit gating, not in BcCompiler.Emit
+/// itself — an in-process BcCompiler-level test would prove the diagnostic
+/// exists but not that the CLI actually refuses to run the module.
+/// </summary>
+public class QueryColumnAlDiagnosticFailureTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+    private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
+
+    private static (string output, int exit) RunRunner(string bundle)
+    {
+        var args = new StringBuilder(TestBuildConfig.RunArgs(ProjectPath));
+        args.Append(TestBuildConfig.BcVersionArg);
+        args.Append(" \"").Append(bundle).Append('"');
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet", Arguments = args.ToString(),
+            RedirectStandardOutput = true, RedirectStandardError = true,
+            UseShellExecute = false, CreateNoWindow = true, WorkingDirectory = RepoRoot,
+        };
+        var sb = new StringBuilder();
+        var p = Process.Start(psi)!;
+        p.OutputDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.ErrorDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.BeginOutputReadLine();
+        p.BeginErrorReadLine();
+        if (!p.WaitForExit(180_000)) { try { p.Kill(true); } catch { } throw new TimeoutException("runner hung"); }
+        p.WaitForExit();
+        lock (sb) return (sb.ToString(), p.ExitCode);
+    }
+
+    private static string WriteBundle(string suffix, string queryBody)
+    {
+        var root = Path.Combine(Path.GetTempPath(), "al-runner-al0353-" + suffix, Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        File.WriteAllText(Path.Combine(root, "app.json"), """
+        {
+          "id": "c2222222-2222-2222-2222-222222222222",
+          "name": "AL0353 Diagnostic Test",
+          "publisher": "Repro2150",
+          "version": "1.0.0.0",
+          "dependencies": [],
+          "platform": "1.0.0.0",
+          "application": "1.0.0.0",
+          "idRanges": [ { "from": 62200, "to": 62209 } ],
+          "runtime": "14.0"
+        }
+        """);
+        File.WriteAllText(Path.Combine(root, "Order.Table.al"), """
+        table 62200 "AL0353 Order"
+        {
+            fields
+            {
+                field(1; "No."; Code[20]) { }
+                field(2; Amount; Decimal) { }
+            }
+            keys
+            {
+                key(PK; "No.") { Clustered = true; }
+            }
+        }
+        """);
+        File.WriteAllText(Path.Combine(root, "OrderSum.Query.al"), queryBody);
+        return root;
+    }
+
+    [SkippableFact]
+    public void Column_DeclaresDataSourceAndMethodCount_FailsCompileWithAl0353()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        // The invalid form real BC rejects: a column names BOTH a field AND
+        // Method = Count. AL0353 fires because Count columns must count rows
+        // in the group, not read a field.
+        var root = WriteBundle("bad", """
+        query 62201 "AL0353 Order Sum"
+        {
+            QueryType = Normal;
+
+            elements
+            {
+                dataitem(Order; "AL0353 Order")
+                {
+                    column(TheAmount; Amount) { }
+                    column(CountAmount; Amount) { Method = Count; }
+                }
+            }
+        }
+        """);
+
+        var (output, exitCode) = RunRunner(root);
+
+        // Would still pass if the runner always returned a default/no-op — assert
+        // the SPECIFIC BC diagnostic, not just "something failed".
+        Assert.NotEqual(0, exitCode);
+        Assert.Contains("AL0353", output);
+        Assert.Contains("A Column must have a valid data source or have the 'Method' property set to 'Count'", output);
+    }
+
+    [SkippableFact]
+    public void Column_MethodCountWithNoDataSource_CompilesCleanly()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        // The corrected form real BC accepts: a Count column names NO field —
+        // it counts rows in the group instead. Negative case above proves the
+        // runner rejects bad AL; this proves the fix did not also reject valid
+        // AL (a guard that always failed compilation would pass the test above
+        // too, so this positive case is required to prove anything).
+        var root = WriteBundle("good", """
+        query 62202 "AL0353 Order Sum"
+        {
+            QueryType = Normal;
+
+            elements
+            {
+                dataitem(Order; "AL0353 Order")
+                {
+                    column(TheAmount; Amount) { }
+                    column(CountAmount) { Method = Count; }
+                }
+            }
+        }
+        """);
+
+        var (output, exitCode) = RunRunner(root);
+
+        Assert.Equal(0, exitCode);
+        Assert.DoesNotContain("AL0353", output);
+    }
+}

--- a/AlRunner.Tests/TestIsolationCodeunitVariableSharingTests.cs
+++ b/AlRunner.Tests/TestIsolationCodeunitVariableSharingTests.cs
@@ -77,7 +77,7 @@ public sealed class TestIsolationCodeunitVariableSharingTests : IDisposable
         """);
 
         File.WriteAllText(Path.Combine(dir, "IsolationTest.Codeunit.al"), """
-        codeunit 62132 "Isolation Variable Sharing Tests"
+        codeunit 62132 "Isolation Var Sharing Tests"
         {
             Subtype = Test;
 

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -2590,12 +2590,33 @@ foreach (var bundle in bundles)
             // instead of the .al file's own directory, which is what real BC does and what
             // the corpus's own upstream CI (a real service tier) confirms works. That is a
             // genuine, separately-tracked runner gap (#2151), not new AL invalidity #2150
-            // needs to enforce, and BcCompiler.cs already documented tolerating it (see its
-            // "the al-language corpus emits all 355 of its objects and still reports
-            // Success=false purely because 7 reports fail AL1081" comment) before this guard
-            // existed. Excluding it here keeps that pre-existing behaviour unchanged while
-            // still catching genuinely new AL the runner has no business accepting.
-            var blockingAlDiagnostics = alDiagnostics.Where(d => !d.Contains(": error AL1081:")).ToList();
+            // needs to enforce.
+            //
+            // The carve-out is scoped to the SPECIFIC condition #2151 describes, not the bare
+            // error code: IsKnownLayoutPathResolutionBug only tolerates an AL1081 whose named
+            // file genuinely EXISTS somewhere else under this app's own directory tree — i.e.
+            // BC found the right file at the wrong (app-root-relative) path, which is exactly
+            // our bug. An AL1081 naming a file that does not exist ANYWHERE under the app — a
+            // real "your report names a layout that was never shipped" mistake — does NOT
+            // match and stays blocking. Silently swallowing every AL1081 regardless of cause
+            // would hide a genuinely broken report the same way #2150 itself needs fixing;
+            // loud-failures.md requires saying so, not going quiet for one error code.
+            var toleratedAl1081 = alDiagnostics
+                .Where(d => IsKnownLayoutPathResolutionBug(d, appGroup.SuiteDir)).ToList();
+            var blockingAlDiagnostics = alDiagnostics
+                .Where(d => !IsKnownLayoutPathResolutionBug(d, appGroup.SuiteDir)).ToList();
+            if (toleratedAl1081.Count > 0)
+            {
+                Console.Error.WriteLine(
+                    $"<bundled>: AL1081-TOLERATED — {moduleName}: {toleratedAl1081.Count} report-layout " +
+                    $"diagnostic(s) tolerated as a KNOWN RUNNER BUG, not invalid AL (see " +
+                    $"https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/2151 — the runner's " +
+                    $"Tier-3 source compile resolves a report's LayoutFile relative to the app root instead " +
+                    $"of the .al file's own directory). The named file genuinely exists elsewhere under this " +
+                    $"app, so this is OUR path-resolution defect, not yours:");
+                foreach (var d in toleratedAl1081)
+                    Console.Error.WriteLine($"  {d}");
+            }
             if (sources.Count > 0 && blockingAlDiagnostics.Count > 0)
             {
                 Console.Error.WriteLine(
@@ -4803,6 +4824,33 @@ static List<string> DiffServerFiles(Dictionary<string, string>? prev, Dictionary
 // WaitForSourceChange / ArmSourceWatch moved to AlRunner.WatchSource (see #1822):
 // local functions declared here cannot be unit-tested, and the arm-before-announce
 // ordering contract needed a deterministic test.
+
+// #2151 / #2150: an AL1081 ("Unable to update report layout ... Reason: Could not find
+// file '<path>'") gets tolerated by the AL-diagnostic compile-failure guard ONLY when the
+// named file genuinely exists somewhere else under this app's own directory tree — i.e.
+// BC found the right file at the wrong (app-root-relative, rather than .al-file-relative)
+// path, which is our Tier-3 LayoutFile resolution bug, not invalid AL. Any other AL1081 —
+// a different "Reason", or a file that truly does not exist anywhere under the app — does
+// NOT match and must stay blocking, or a genuinely broken report (a layout that was never
+// shipped) would go silently unreported exactly like #2150 itself.
+static bool IsKnownLayoutPathResolutionBug(string diagnostic, string? appRootDir)
+{
+    if (string.IsNullOrEmpty(appRootDir) || !Directory.Exists(appRootDir))
+        return false;
+    var match = System.Text.RegularExpressions.Regex.Match(
+        diagnostic, @": error AL1081: .*Could not find file '([^']+)'");
+    if (!match.Success)
+        return false;
+    var missingFileName = Path.GetFileName(match.Groups[1].Value);
+    if (string.IsNullOrEmpty(missingFileName))
+        return false;
+    try
+    {
+        return Directory.EnumerateFiles(appRootDir, missingFileName, SearchOption.AllDirectories).Any();
+    }
+    catch (IOException) { return false; }
+    catch (UnauthorizedAccessException) { return false; }
+}
 
 static void DumpCsharpSources(string dir, string moduleName, IReadOnlyList<EmittedSource> sources)
 {

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -2570,6 +2570,45 @@ foreach (var bundle in bundles)
                     Console.Error.WriteLine($"  {d}");
                 bundleErrors.Add($"<bundled>: EMIT-ZERO ({alDiagnostics.Count} AL error(s))");
             }
+            // AL-diagnostic compile-failure guard (#2150). BC's ContinueBuildOnError keeps
+            // compiling an object's SIBLINGS after a declaration-stage error on one object
+            // (e.g. a query column declaring both a data source AND `Method = Count`, AL0353)
+            // — the broken object's metadata can still emit alongside everything else, so
+            // `sources` comes back non-empty even though `alDiagnostics` (built from
+            // GetDeclarationDiagnostics()/emitResult.Diagnostics, always Error-severity only,
+            // see BcCompiler.Emit) is also non-empty. Neither guard above catches this: it
+            // isn't PARTIAL-EMIT-DROP (there ARE diagnostics explaining the gap) and it isn't
+            // EMIT-ZERO (sources isn't empty). Real BC never publishes an app with ANY error
+            // diagnostic regardless of how many other objects compiled clean, so this must
+            // fail the same way — a real service tier would reject this module outright.
+            // Skip when EMIT-EXCLUDED already handled it (that branch empties `sources`).
+            //
+            // AL1081 carve-out (#2151): turning this guard on for the first time surfaced 6
+            // PRE-EXISTING AL1081 diagnostics in the al-language corpus ("Unable to update
+            // report layout ... Could not find file"), all one root cause — the runner's
+            // Tier-3 source compile resolves a report's LayoutFile relative to the app root
+            // instead of the .al file's own directory, which is what real BC does and what
+            // the corpus's own upstream CI (a real service tier) confirms works. That is a
+            // genuine, separately-tracked runner gap (#2151), not new AL invalidity #2150
+            // needs to enforce, and BcCompiler.cs already documented tolerating it (see its
+            // "the al-language corpus emits all 355 of its objects and still reports
+            // Success=false purely because 7 reports fail AL1081" comment) before this guard
+            // existed. Excluding it here keeps that pre-existing behaviour unchanged while
+            // still catching genuinely new AL the runner has no business accepting.
+            var blockingAlDiagnostics = alDiagnostics.Where(d => !d.Contains(": error AL1081:")).ToList();
+            if (sources.Count > 0 && blockingAlDiagnostics.Count > 0)
+            {
+                Console.Error.WriteLine(
+                    $"<bundled>: AL-DIAGNOSTIC-FAIL — {moduleName}: {sources.Count} object(s) emitted but " +
+                    $"{blockingAlDiagnostics.Count} AL error(s) were reported by BC's own compiler; a real " +
+                    $"service tier would refuse to publish this module:");
+                foreach (var d in blockingAlDiagnostics)
+                    Console.Error.WriteLine($"  {d}");
+                bundleErrors.Add(
+                    $"<bundled>: AL-DIAGNOSTIC-FAIL for {moduleName}: {blockingAlDiagnostics.Count} AL error(s) " +
+                    $"reported even though {sources.Count} object(s) emitted.");
+                sources = Array.Empty<EmittedSource>(); // do not run a module BC would refuse to publish
+            }
             if (sources.Count > 0)
             {
                 var ct = System.Diagnostics.Stopwatch.StartNew();

--- a/tests/expectations/count-baseline/test-count-baseline.json
+++ b/tests/expectations/count-baseline/test-count-baseline.json
@@ -7,8 +7,8 @@
     },
     "runner-extras": {
       "tests": {
-        "default": 190,
-        "byBcVersion": { "27.0": 179, "27.3": 179, "27.5": 179 }
+        "default": 189,
+        "byBcVersion": { "27.0": 178, "27.3": 178, "27.5": 178 }
       },
       "appGroups": {
         "default": 33,

--- a/tests/runner-extras/microsoft-dependencies/MicrosoftDependencyTests.Codeunit.al
+++ b/tests/runner-extras/microsoft-dependencies/MicrosoftDependencyTests.Codeunit.al
@@ -310,53 +310,21 @@ codeunit 61001 "Microsoft Dependency Tests"
         RoleCenterFromPlans.Close();
     end;
 
-    // Positive companion, same fix (the filter-only-column projection-slot aliasing bug
-    // described above) — this is the case that actually reproduces it: a real Guid filter
-    // value compared against a real joined row. "Plan" and "User Plan" are `Access = Internal`
-    // on System Application, so this third-party test app cannot reference them via
-    // `RecordRef.Open(Database::Plan)` (AL0161 — the enum literal itself needs table access) —
-    // but a plain `Record Plan` / `Record "User Plan"` local variable declaration, and
-    // Init/field-assign/Insert on it, compiles and runs fine (AL only restricts the handful of
-    // surfaces that name the table by symbol at the point of use; a local variable of that
-    // type is not one of them). That is enough to seed real joined data and prove the fix past
-    // the empty-table case above.
-    [Test]
-    procedure Query777_RoleCenterFromPlans_MatchingPlan_ReturnsJoinedRoleCenterID()
-    var
-        Plan: Record Plan;
-        UserPlan: Record "User Plan";
-        RoleCenterFromPlans: Query "Role Center from Plans";
-        TestUserSecurityID: Guid;
-    begin
-        // [GIVEN] A Plan mapped to Role Center 9022, and this user linked to it via an AAD
-        // plan assignment — the exact join "User Plan" -> "Plan" Query 777 performs.
-        TestUserSecurityID := CreateGuid();
-
-        Plan.Init();
-        Plan."Plan ID" := CreateGuid();
-        Plan.Name := 'AL Runner Test Plan';
-        Plan."Role Center ID" := 9022;
-        Plan.Insert();
-
-        UserPlan.Init();
-        UserPlan."User Security ID" := TestUserSecurityID;
-        UserPlan."Plan ID" := Plan."Plan ID";
-        UserPlan."User Name" := 'alrunner';
-        UserPlan.Insert();
-
-        // [WHEN] Query 777 is opened filtered to this user and read.
-        RoleCenterFromPlans.SetRange(User_Security_ID, TestUserSecurityID);
-        RoleCenterFromPlans.Open();
-
-        // [THEN] The real InnerJoin executes against the in-memory tables and projects the
-        // linked Plan's Role Center ID — proving NavQuery.FindDataImplAsync runs the
-        // precompiled query's actual business logic end to end, not a stub.
-        Assert.IsTrue(RoleCenterFromPlans.Read(),
-            'Query 777 must return the joined row for a user with a matching AAD-plan-to-Plan link.');
-        Assert.AreEqual(9022, RoleCenterFromPlans.Role_Center_ID,
-            'Query 777''s Role_Center_ID column must reflect the joined Plan''s "Role Center ID" (9022), proving the InnerJoin ran for real.');
-        RoleCenterFromPlans.Close();
-    end;
+    // REMOVED (issue #2153, found while fixing #2150): this suite used to carry a "positive
+    // companion" test here — Query777_RoleCenterFromPlans_MatchingPlan_ReturnsJoinedRoleCenterID
+    // — that declared `Plan: Record Plan;` / `UserPlan: Record "User Plan";` local variables to
+    // seed a real joined row, on the stated assumption that `Access = Internal` on System
+    // Application only blocks symbol-naming surfaces like `RecordRef.Open(Database::Plan)`, not
+    // a plain local variable declaration of that table type. #2150's fix — making the runner
+    // actually gate on AL error diagnostics instead of silently tolerating them whenever some
+    // objects still emit — surfaced that the assumption was wrong: BC's own compiler
+    // (Microsoft.Dynamics.Nav.CodeAnalysis.dll, the same one alc.exe uses) raises AL0161 on
+    // BOTH variable declarations, so this test could never actually compile against real BC. It
+    // was only ever "passing" here because of the exact bug #2150 fixes. Removed rather than
+    // shipped as AL that a real service tier would reject. The negative case immediately above
+    // and the NoThrow companion below still cover the query engine; #2153 tracks whether a
+    // legitimate way exists to seed Access=Internal table data from third-party AL so the "real
+    // joined data" claim can be restored.
 
     // Integration-level companion, matching the exact frame the reported stack trace names
     // (Codeunit9170.GetCurrentProfileNoError -> TryGetDefaultProfileForCurrentUser ->

--- a/tests/runner-extras/standalone-suites/report-saveas-stream/FixtureReport.Report.al
+++ b/tests/runner-extras/standalone-suites/report-saveas-stream/FixtureReport.Report.al
@@ -6,6 +6,7 @@ report 60702 "RSS Fixture Report"
 {
     UsageCategory = None;
     ProcessingOnly = false;
+    DefaultRenderingLayout = RdlcFixture;
 
     dataset
     {


### PR DESCRIPTION
## Summary

The runner accepted a query column declaring both a data source and `Method = Count` — real BC rejects that with AL0353 ("A Column must have a valid data source or have the 'Method' property set to 'Count'"). The diagnostic was already being collected correctly (`compilation.GetDeclarationDiagnostics()` / `emitResult.Diagnostics` catch it as a declaration-stage error on every compile, unconditionally — confirmed by decompiling `Microsoft.Dynamics.Nav.CodeAnalysis.dll`: `SourceQueryColumnSymbol.CheckColumn()` raises it via `AddDeclarationDiagnostics()`, not a method-body diagnostic gated behind a more expensive semantic-binding pass). The actual bug was in `Program.cs`'s consumption of that data: it only checked non-empty AL diagnostics when a module produced zero sources. BC's own `ContinueBuildOnError` keeps compiling an object's siblings after a declaration-stage error on one of them, so the broken query's metadata still emitted alongside everything else — `sources.Count > 0` stayed true, `alDiagnostics.Count > 0` stayed true, and neither of the two existing guards (`PARTIAL-EMIT-DROP`, `EMIT-ZERO`) covers that combination.

Fix: add the missing `sources.Count > 0 && alDiagnostics.Count > 0` gate to the default "bundled" compile path (the one CI's corpus + runner-extras runs exercise). No new diagnostic collection is added — the data was already being computed on every run; this only changes how it's consumed, which is why the measured perf delta is noise-level (~44-46s wall either way on a cold corpus run).

## What turning the gate on found

Per the "expect a flood, report it honestly" guidance, here's every pre-existing AL error this surfaced, all traceable and all handled individually rather than blanket-suppressed:

- **6 report objects in the al-language corpus (AL1081, one root cause)** — the runner's Tier-3 source compile resolves a report's `LayoutFile` relative to the app root instead of the `.al` file's own directory (confirmed wrong against real BC's documented semantics — the layout files genuinely exist next to their reports, and the corpus's own upstream CI on a real service tier passes). This is a separate, pre-existing runner gap unrelated to #2150's query-diagnostic claim, already implicitly tolerated before this fix (see `BcCompiler.cs`'s own comment about "7 reports fail AL1081"). Tracked as #2151.
- **An AL0161 protection-level violation in `tests/runner-extras/microsoft-dependencies`** — a test declared local variables of `Record Plan` / `Record "User Plan"` (System Application tables with `Access = Internal`), on the documented assumption that a local variable declaration wasn't restricted the way `RecordRef.Open(Database::Plan)` is. That assumption was wrong; BC's own compiler rejects it too. This test could never actually compile against real BC. Removed (not carved out — it's our own test, not a corpus dependency), with the negative/no-throw companions in the same suite left intact. Tracked as #2153 (is there a legitimate way to seed this data at all?).
- **An AL0721 in `tests/runner-extras/standalone-suites/report-saveas-stream`** — a report using the `rendering { layout(...) }` syntax without the required `DefaultRenderingLayout` property. Fixed directly (one-line property addition).
- **An AL0305 in `AlRunner.Tests/TestIsolationCodeunitVariableSharingTests.cs`** — an inline test fixture's codeunit name (`"Isolation Variable Sharing Tests"`, 32 chars) exceeded BC's 30-character object-identifier limit. Renamed.

I swept both `AlRunner.Tests/**/*.cs` (inline AL fixtures) and `tests/runner-extras/**/*.al` for any other >30-char object names — no other instances.

Follow-up not done in this PR: the same "diagnostics collected but only checked when sources is empty" pattern exists in three other `Program.cs` code paths (`--per-suite`, `--server`, `--precompile`) that no current CI leg exercises against this exact shape. Tracked as #2152 rather than expanding this PR's test surface into paths I can't fully validate here.

## The AL1081 carve-out: scoped, not blanket, and loud

Review caught a real defect in the first version of this PR: the AL1081 carve-out was keyed on the bare error code (`!d.Contains(": error AL1081:")`), which silently dropped **every** AL1081 anywhere, forever, with nothing printed. That would have masked a genuinely broken report — one that names a layout file that was never shipped — the exact failure mode #2150 exists to remove, just moved to a different error code.

Fixed both problems:

- **Scoped to the exact condition #2151 describes**, not the bare error code. `IsKnownLayoutPathResolutionBug` (`AlRunner/Program.cs`) parses the "Could not find file '\<path\>'" reason out of the AL1081 message and tolerates it only when a file with that basename genuinely exists **somewhere else under the app's own directory tree** — i.e. BC found the right file at the wrong (app-root-relative) path, proving it's our bug, not the user's AL. An AL1081 naming a file that does not exist anywhere in the app no longer matches and still fails the compile.
- **Made loud.** When the carve-out fires, the runner now prints every tolerated diagnostic under an `AL1081-TOLERATED` banner naming #2151 and explaining why, instead of silence.
- **New test:** `AlRunner.Tests/Al1081ToleranceScopingTests.cs` proves both directions against the real CLI — a report whose layout genuinely exists in a subdirectory (the corpus's exact shape) compiles and prints the tolerance banner; a report naming a layout that truly doesn't exist anywhere still fails compile and never prints `AL1081-TOLERATED`. This is the test that would have caught the original bare-error-code version being too permissive.

I could not eliminate the carve-out entirely in this PR — actually fixing #2151 (making `LayoutFile` resolve against the `.al` file's own directory instead of a single app-wide root) is a real change to the Tier-3 file-system resolution strategy, out of scope here.

## Test plan

- [x] RED: `AlRunner.Tests/QueryColumnAlDiagnosticFailureTests.cs` — negative case (bad column) failed to fail (exit 0 instead of nonzero) before the fix; positive case (corrected form) already passed.
- [x] GREEN: both directions pass after the fix — exit 3 with `AL0353` and the exact BC message text on the bad form, exit 0 and no `AL0353` on the corrected form.
- [x] `AlRunner.Tests/Al1081ToleranceScopingTests.cs` — both directions of the scoped carve-out pass: tolerated-and-loud when the file exists elsewhere, still-blocking when it truly doesn't exist anywhere.
- [x] Full `tests/al-language` corpus: 2155/2155 pass, exit 0 (run three times across iterations of this PR; 43.3-45.6s wall throughout, no measurable regression), with the `AL1081-TOLERATED` banner now printed naming all 6 diagnostics and #2151.
- [x] Full `tests/runner-extras`: 189/189 pass, exit 0.
- [x] Full `AlRunner.Tests` suite: 1102 total, 1042 passed, 60 skipped, 0 failed — ran the full suite rather than a targeted subset because `Program.cs`'s compile-gating path is exercised by nearly every CLI-spawning test in the suite.

Closes #2150
