### PR TITLE
docs(runner-extras): correct stale microsoft-dependencies Query 777 header

### DIFF
--- a/tests/runner-extras/microsoft-dependencies/MicrosoftDependencyTests.Codeunit.al
+++ b/tests/runner-extras/microsoft-dependencies/MicrosoftDependencyTests.Codeunit.al
@@ -278,21 +278,51 @@ codeunit 61001 "Microsoft Dependency Tests"
     // ("Unable to compare operands of type NavInteger with NavGuid") instead of ever being
     // evaluated as the filter it actually was.
     //
-    // Both tests below drive Query 777 directly (bypassing Codeunit 9170's business logic)
-    // so the assertion is squarely about the query engine itself: does the real InnerJoin
-    // between "User Plan" and "Plan" execute against the in-memory provider for real Guid
-    // filter values, or does it throw resolving the precompiled query's metadata.
+    // WHAT THIS FILE PROVES ABOUT QUERY 777, AND WHAT IT NO LONGER CLAIMS (issue #2153):
     //
-    // RED (before fix): the positive test (seeded matching row) throws
-    // NavNCLInvalidComparisonException the moment the aliased Guid-vs-Integer comparison runs.
-    // The negative test (no seeded rows at all) happens not to reproduce the bug on its own —
-    // an empty in-memory join never enumerates a row to compare against — so it is kept here
-    // as the literal "faithful expected behavior" acceptance criterion from the reported issue,
-    // not as independent proof of the fix.
-    // GREEN (after fix): both tests pass — filter-only columns get their own dedicated
-    // projection slot (see JoinExecutor.BuildJoinProjectionPlan /
-    // QueryProjection.ComputeJoinColumnSlotMap), so the Guid filter is evaluated against the
-    // real filtered value instead of an unrelated column.
+    // A prior version of this suite carried a "positive companion" test right here —
+    // Query777_RoleCenterFromPlans_MatchingPlan_ReturnsJoinedRoleCenterID — that declared
+    // `Plan: Record Plan;` / `UserPlan: Record "User Plan";` local variables to seed a real
+    // joined row, on the stated assumption that `Access = Internal` on System Application only
+    // blocks symbol-naming surfaces like `RecordRef.Open(Database::Plan)`, not a plain local
+    // variable declaration of that table type. #2150's fix — making the runner actually gate on
+    // AL error diagnostics instead of silently tolerating them whenever some objects still emit
+    // — surfaced that the assumption was wrong: BC's own compiler
+    // (Microsoft.Dynamics.Nav.CodeAnalysis.dll, the same one alc.exe uses) raises AL0161 on BOTH
+    // variable declarations, so that test could never actually compile against real BC. It was
+    // only ever "passing" here because of the exact bug #2150 fixes. It was removed rather than
+    // shipped as AL a real service tier would reject.
+    //
+    // #2153 investigated whether a legitimate way exists to seed Plan/User Plan data from
+    // third-party AL without tripping AL0161, by decompiling the shipped System Application
+    // Test Library app. It does: Codeunit 132916 "Azure AD Plan Test Library" (ships since BC
+    // 27.0) exposes `CreatePlan(Guid, Text, Integer, Guid)` and `AssignUserToPlan(Guid, Guid)`
+    // — both take only Guid/Text/Integer parameters, so a caller never declares a local
+    // `Record Plan` / `Record "User Plan"` and never trips AL0161. Seeding a joined row this
+    // way is possible, and the resulting assertion — "Query 777 correctly inner-joins Plan onto
+    // a seeded User Plan row and projects the joined Role Center ID" — is a plain statement
+    // about what BC's own precompiled query does, independent of AL Runner's existence, so that
+    // restored positive coverage belongs in the upstream al-language corpus (see
+    // bc-behavior-tests-go-upstream.md), not here. It does not live in this file.
+    //
+    // What DOES still live in this file, and what each test actually proves:
+    //
+    //   - Query777_RoleCenterFromPlans_NoMatchingPlan_ReturnsNoRows (below): with zero seeded
+    //     rows, reading the query must faithfully report "no rows", never NRE while resolving
+    //     the precompiled query's metadata. This is a runner-specific claim — it is squarely
+    //     about whether AL Runner's own query engine (AlRunner.QueryJoin.JoinExecutor /
+    //     RecordPatches.QueryProjection) resolves a precompiled System Application query's
+    //     metadata without throwing, not about what BC does (an empty result on an empty table
+    //     is not an interesting BC-behaviour claim on its own).
+    //   - BaseAppCodeunit_ConfPersonalizationMgt_GetCurrentProfileNoError_NoThrow (below): drives
+    //     the same query indirectly through Base App's Codeunit 9170, proving the runner's
+    //     dispatch into a precompiled dependency's query does not NRE.
+    //
+    // Neither remaining test seeds a real joined row, so neither proves the InnerJoin executes
+    // against non-empty data or that filter-only-column aliasing (NCLMetaQueryColumn.ColumnIndex
+    // defaulting to 0 for a column that is only ever a `filter(...)`, not a projected `column(...)`
+    // — see the original bug narrative above) stays fixed once real rows are involved. That
+    // regression coverage now depends on the upstream corpus test landing (issue #2153).
     [Test]
     procedure Query777_RoleCenterFromPlans_NoMatchingPlan_ReturnsNoRows()
     var
@@ -309,22 +339,6 @@ codeunit 61001 "Microsoft Dependency Tests"
             'Query 777 ("Role Center from Plans") must return zero rows when no AAD plan links this user to a Plan, not throw a NullReferenceException in NavQuery.FindDataImplAsync.');
         RoleCenterFromPlans.Close();
     end;
-
-    // REMOVED (issue #2153, found while fixing #2150): this suite used to carry a "positive
-    // companion" test here — Query777_RoleCenterFromPlans_MatchingPlan_ReturnsJoinedRoleCenterID
-    // — that declared `Plan: Record Plan;` / `UserPlan: Record "User Plan";` local variables to
-    // seed a real joined row, on the stated assumption that `Access = Internal` on System
-    // Application only blocks symbol-naming surfaces like `RecordRef.Open(Database::Plan)`, not
-    // a plain local variable declaration of that table type. #2150's fix — making the runner
-    // actually gate on AL error diagnostics instead of silently tolerating them whenever some
-    // objects still emit — surfaced that the assumption was wrong: BC's own compiler
-    // (Microsoft.Dynamics.Nav.CodeAnalysis.dll, the same one alc.exe uses) raises AL0161 on
-    // BOTH variable declarations, so this test could never actually compile against real BC. It
-    // was only ever "passing" here because of the exact bug #2150 fixes. Removed rather than
-    // shipped as AL that a real service tier would reject. The negative case immediately above
-    // and the NoThrow companion below still cover the query engine; #2153 tracks whether a
-    // legitimate way exists to seed Access=Internal table data from third-party AL so the "real
-    // joined data" claim can be restored.
 
     // Integration-level companion, matching the exact frame the reported stack trace names
     // (Codeunit9170.GetCurrentProfileNoError -> TryGetDefaultProfileForCurrentUser ->


### PR DESCRIPTION
Closes #2153

## What this settles

#2153 asked whether third-party AL has any legitimate way to seed `Plan`/`User Plan` (both `Access = Internal` on System Application) without tripping AL0161, so the removed `Query777_RoleCenterFromPlans_MatchingPlan_ReturnsJoinedRoleCenterID` positive test could be restored.

**Yes, it does.** Decompiling the shipped `Microsoft_System Application Test Library.app` (present since BC 27.0, confirmed at 27.0/28.0/28.1/28.3) shows Codeunit 132916 "Azure AD Plan Test Library" exposes:

- `CreatePlan(PlanGuid: Guid; PlanName: Text[50]; RoleCenterID: Integer; SystemId: Guid)`
- `AssignUserToPlan(UserID: Guid; PlanID: Guid)`

Both take only `Guid`/`Text`/`Integer` — the internal table types never appear in the caller's signature, so calling them never requires a local `Record Plan` / `Record "User Plan"` declaration and never trips AL0161.

I verified this against AL Runner's own compiler (the same `Microsoft.Dynamics.Nav.CodeAnalysis.dll` alc.exe uses) with a throwaway scratch project depending on System Application + System Application Test Library: a test that seeds a plan via the test library and reads Query 777 filtered by `UserSecurityId()` compiles with **zero diagnostics** and both the positive (matching plan → joined `Role_Center_ID`) and negative (no plan → zero rows) cases pass.

## Why this PR doesn't restore the test here

That restored assertion — "Query 777 correctly inner-joins `Plan` onto a seeded `User Plan` row and projects the joined Role Center ID" — is a plain statement about what BC's own precompiled query does, independent of AL Runner's existence. Per `bc-behavior-tests-go-upstream.md` it belongs in the upstream `al-language` corpus, not `runner-extras`. I'm not opening that corpus PR myself (`public-posting-approval.md`); the drafted corpus test (`query/TestQueryRoleCenterFromPlans.al`, codeunit id 60896, a free gap in the corpus's 60000-60999 range) plus the `app.json` dependency addition for "System Application Test Library" (id `9856ae4f-d1a7-46ef-89bb-6ef056398228`) were handed to the repo owner directly.

## What this PR does

Corrects the suite's stale header comment in `tests/runner-extras/microsoft-dependencies/MicrosoftDependencyTests.Codeunit.al`, which still described "both tests below" and a RED/GREEN narrative referencing the removed positive test. It now states plainly:
- what the two remaining tests (`Query777_RoleCenterFromPlans_NoMatchingPlan_ReturnsNoRows`, `BaseAppCodeunit_ConfPersonalizationMgt_GetCurrentProfileNoError_NoThrow`) actually prove (runner-specific: precompiled-query metadata resolution doesn't NRE) and don't prove (the InnerJoin against real non-empty joined data, or that the filter-only-column aliasing bug stays fixed with real rows involved)
- why the restored positive coverage lives upstream instead

No AL test methods were added or removed, so no `tests/expectations/count-baseline/` update is needed. Comment-only change to a `.al` file, so `no-tests-needed` applies for `require-tests` (nothing under `AlRunner/` touched).

## Verification

- `dotnet build AlRunner.slnx -c Release` — clean.
- `dotnet run --project AlRunner -c Release --framework net8.0 -- tests/runner-extras/microsoft-dependencies --package-cache ~/.al-runner/platform-apps --package-cache ~/.al-runner/test-apps` — 14/14 pass, before and after the edit (comment-only, no behavior change).
- `dotnet test AlRunner.Tests -c Release` — 1042 passed, 0 failed, 60 skipped.
- Scratch-project verification of the drafted upstream test against AL Runner's compiler — 2/2 pass, 0 diagnostics (evidence for the corpus PR, not part of this diff).