### PR TITLE
test(corpus): bump the pin for the Query 777 join tests

### DIFF
--- a/.github/workflows/bc-tests.yml
+++ b/.github/workflows/bc-tests.yml
@@ -349,6 +349,7 @@ jobs:
           dotnet run --no-build --project AlRunner -c Release --framework net8.0 -- \
               tests/al-language/tests/al-language \
               --package-cache "$HOME/.al-runner/platform-apps" \
+              --package-cache "$HOME/.al-runner/test-apps" \
               --strict \
               --count-baseline tests/expectations/count-baseline/test-count-baseline.json \
               --out al-language-results.json || rc=$?

--- a/tests/expectations/count-baseline/test-count-baseline.json
+++ b/tests/expectations/count-baseline/test-count-baseline.json
@@ -2,7 +2,7 @@
   "_comment": "Consumed by --count-baseline (AlRunner/Infrastructure/CountBaseline.cs), a DIFFERENT schema from the oos-/known-gaps-/divergence-/disabled- files in this directory: those declare the expected CLASSIFICATION of one named test, this declares the expected EXACT COUNT of a whole suite -- an exact match, not a floor: a mismatch in EITHER direction (drop OR growth) fails the run (exit 4). See #1880 and PR #1882's review for why growth is also a hard failure, not just a notice. Suite keys are the basename of the bundle directory CI passes on the command line (tests/al-language/tests/al-language -> 'al-language', tests/runner-extras -> 'runner-extras'), matching the '--out <name>-results.json' convention CI already uses. Values below are read off actual Test Matrix CI runs (see PR discussion for run URLs), not guessed: al-language's 2073->2076 bump reflects 3 corpus tests merged upstream between when the local baseline was drafted and when CI first ran against it. runner-extras' appGroups 23->21 byBcVersion override on 27.0/27.3/27.5 is the SAME preprocessor-gated-surface split that already explains its tests count divergence: fewer AL surfaces compile pre-28.0, which drops whole app groups, not just individual tests within a group. ANY PR that changes a suite's test or app-group count -- growth included -- MUST bump the matching number here in the SAME PR, or that PR's CI goes red with a [count-baseline] DROP or GROWTH diagnostic naming the exact expected/actual numbers to use.",
   "suites": {
     "al-language": {
-      "tests": { "default": 2155 },
+      "tests": { "default": 2157 },
       "appGroups": { "default": 1 }
     },
     "runner-extras": {


### PR DESCRIPTION
No linked issue: this moves the submodule pointer for tests merged upstream as BusinessCentral.AL.Language.Tests#70, which restores coverage tracked by #2153 (already closed).

## What this does

Moves `tests/al-language` from `4a7dde4` to `aaefdde`, adding two tests that cover Query 777 "Role Center from Plans" inner-joining `Plan` onto a seeded `User Plan` row and projecting the joined Role Center ID.

These restore the coverage lost in #2153. The removed test declared local variables of `Plan` and `User Plan`, which are `Access = Internal`, so it could never compile against real BC — it only ever passed here because of the bug #2150 fixed. The replacement seeds the same data through Microsoft's own `Codeunit 132916 "Azure AD Plan Test Library"`, whose parameters are all Guid, Text and Integer, so the internal types never appear in a caller's signature.

## The workflow change, and why it is here

These are the first tests in the corpus to depend on the System Application Test Library. That app ships in the test-apps cache, not platform-apps, and the corpus step only passed platform-apps.

It resolves anyway today: the runner folds its default test-apps directory into the search set during provisioning, so the corpus run finds the library without being told about it. I verified that locally — the run reports 1 requested cache and 3 in the final search set, and the tests pass.

I added the explicit `--package-cache` regardless. Relying on the implicit fold-in couples the corpus build to a side effect of provisioning, in a step whose own command line does not mention the dependency at all. When that breaks it will not look like a missing package cache. One line makes the requirement visible.

## Verification

Upstream #70 ran against real BC on 27.5 and 28.3 before merging, including the `app.json` dependency addition, so the library is genuinely published in the test container.

Locally on BC 28.4 at this pin: 2157 total, 2157 pass, 0 fail. Run twice, cold and warm — the second run exercises the compile-cache path, which has hidden query defects here before.

Count baseline for `al-language` goes 2155 to 2157.
