### PR TITLE
fix(compiler): extend the AL-diagnostic gate to --per-suite/--server/--precompile

### DIFF
--- a/AlRunner.Tests/PerSuiteAlDiagnosticFailureTests.cs
+++ b/AlRunner.Tests/PerSuiteAlDiagnosticFailureTests.cs
@@ -1,0 +1,147 @@
+// Issue #2152 — the AL-diagnostic compile-failure guard #2150/#2154 added only
+// covered the default bundled compile path. `--per-suite` compiles one module per
+// SUITE (see the `else` branch of Program.cs's bundled/non-bundled run loop split,
+// around EnumerateSuites) but shares the exact same BC ContinueBuildOnError shape:
+// a declaration-stage error on one object (e.g. a query column declaring both a
+// data source AND `Method = Count`, AL0353) does not stop BC from compiling that
+// object's siblings, so `sources` can come back non-empty at the same time
+// `suiteAlDiagnostics` is also non-empty. Before this fix, --per-suite had no gate
+// at all for that combination and silently ran (and could pass) a module a real BC
+// service tier would refuse to publish.
+//
+// This spawns the real runner CLI with `--per-suite` (not BcCompiler in-process),
+// because the fix lives in Program.cs's post-emit gating for that specific code
+// path, not in BcCompiler.Emit itself.
+using System.Diagnostics;
+using System.Text;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public class PerSuiteAlDiagnosticFailureTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+    private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
+
+    private static (string output, int exit) RunRunner(string bundle)
+    {
+        var args = new StringBuilder(TestBuildConfig.RunArgs(ProjectPath));
+        args.Append(TestBuildConfig.BcVersionArg);
+        args.Append(" --per-suite");
+        args.Append(" \"").Append(bundle).Append('"');
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet", Arguments = args.ToString(),
+            RedirectStandardOutput = true, RedirectStandardError = true,
+            UseShellExecute = false, CreateNoWindow = true, WorkingDirectory = RepoRoot,
+        };
+        var sb = new StringBuilder();
+        var p = Process.Start(psi)!;
+        p.OutputDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.ErrorDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.BeginOutputReadLine();
+        p.BeginErrorReadLine();
+        if (!p.WaitForExit(180_000)) { try { p.Kill(true); } catch { } throw new TimeoutException("runner hung"); }
+        p.WaitForExit();
+        lock (sb) return (sb.ToString(), p.ExitCode);
+    }
+
+    // A directory with app.json at its OWN root is one suite (LooksLikeSuite), so
+    // `--per-suite` against this root compiles exactly one module — the shape this
+    // test needs to isolate the per-suite gate from the bundled one.
+    private static string WriteBundle(string suffix, string queryBody)
+    {
+        var root = Path.Combine(Path.GetTempPath(), "al-runner-persuite-al0353-" + suffix, Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        File.WriteAllText(Path.Combine(root, "app.json"), """
+        {
+          "id": "d3333333-3333-3333-3333-333333333333",
+          "name": "Per-Suite AL0353 Diagnostic Test",
+          "publisher": "Repro2152",
+          "version": "1.0.0.0",
+          "dependencies": [],
+          "platform": "1.0.0.0",
+          "application": "1.0.0.0",
+          "idRanges": [ { "from": 62210, "to": 62219 } ],
+          "runtime": "14.0"
+        }
+        """);
+        File.WriteAllText(Path.Combine(root, "Order.Table.al"), """
+        table 62210 "AL0353 PS Order"
+        {
+            fields
+            {
+                field(1; "No."; Code[20]) { }
+                field(2; Amount; Decimal) { }
+            }
+            keys
+            {
+                key(PK; "No.") { Clustered = true; }
+            }
+        }
+        """);
+        File.WriteAllText(Path.Combine(root, "OrderSum.Query.al"), queryBody);
+        return root;
+    }
+
+    [SkippableFact]
+    public void PerSuite_ColumnDeclaresDataSourceAndMethodCount_FailsCompileWithAl0353()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var root = WriteBundle("bad", """
+        query 62211 "AL0353 PS Order Sum"
+        {
+            QueryType = Normal;
+
+            elements
+            {
+                dataitem(Order; "AL0353 PS Order")
+                {
+                    column(TheAmount; Amount) { }
+                    column(CountAmount; Amount) { Method = Count; }
+                }
+            }
+        }
+        """);
+
+        var (output, exitCode) = RunRunner(root);
+
+        // Would still pass if --per-suite always returned a default/no-op — assert
+        // the SPECIFIC BC diagnostic, not just "something failed".
+        Assert.NotEqual(0, exitCode);
+        Assert.Contains("AL0353", output);
+        Assert.Contains("A Column must have a valid data source or have the 'Method' property set to 'Count'", output);
+    }
+
+    [SkippableFact]
+    public void PerSuite_ColumnMethodCountWithNoDataSource_CompilesCleanly()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        // The corrected form real BC accepts: proves the per-suite gate does not also
+        // reject valid AL — a guard that always failed compilation would pass the
+        // negative test above too, so this positive case is required to prove anything.
+        var root = WriteBundle("good", """
+        query 62212 "AL0353 PS Order Sum"
+        {
+            QueryType = Normal;
+
+            elements
+            {
+                dataitem(Order; "AL0353 PS Order")
+                {
+                    column(TheAmount; Amount) { }
+                    column(CountAmount) { Method = Count; }
+                }
+            }
+        }
+        """);
+
+        var (output, exitCode) = RunRunner(root);
+
+        Assert.Equal(0, exitCode);
+        Assert.DoesNotContain("AL0353", output);
+    }
+}

--- a/AlRunner.Tests/PrecompileAlDiagnosticFailureTests.cs
+++ b/AlRunner.Tests/PrecompileAlDiagnosticFailureTests.cs
@@ -1,0 +1,210 @@
+// Issue #2152 — the AL-diagnostic compile-failure guard #2150/#2154 added only
+// covered the default bundled compile path. `--precompile` (RunPrecompile, the
+// dependency-app-to-DLL subcommand) has the identical BC ContinueBuildOnError gap:
+// `emitted` (emitOut.Sources) can come back non-empty — a broken query column's
+// metadata still emits — at the same time emitOut.Diagnostics also carries the
+// AL0353 BC reported for it. Before this fix, --precompile only checked diagnostics
+// when EMIT-ZERO (0 sources) fired, so it could silently write out a DLL for AL a
+// real service tier would refuse to publish. That matters more here than it looks:
+// --precompile's whole point is producing a dependency another bundle run treats as
+// precompiled and trusted (precompiled-dll-respect.md) — a silently-accepted compile
+// error here poisons every later bundle that depends on the resulting DLL.
+//
+// --precompile takes a real .app package (a NAVX-prefixed or plain ZIP with
+// NavxManifest.xml + src/*.al — see AppLoader.ReadManifest/ExtractAl), not a source
+// directory, so this builds one from scratch the same way
+// AlRunner.Tests/DependencyResolverTests.cs's WriteApp helper does.
+using System.Diagnostics;
+using System.IO.Compression;
+using System.Text;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class PrecompileAlDiagnosticFailureTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+    private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
+
+    private static (string output, int exit) RunPrecompile(string inputApp, string outputDll)
+    {
+        var args = new StringBuilder(TestBuildConfig.RunArgs(ProjectPath));
+        args.Append(" --precompile \"").Append(inputApp).Append('"');
+        args.Append(" --out \"").Append(outputDll).Append('"');
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet", Arguments = args.ToString(),
+            RedirectStandardOutput = true, RedirectStandardError = true,
+            UseShellExecute = false, CreateNoWindow = true, WorkingDirectory = RepoRoot,
+        };
+        var sb = new StringBuilder();
+        var p = Process.Start(psi)!;
+        p.OutputDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.ErrorDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.BeginOutputReadLine();
+        p.BeginErrorReadLine();
+        if (!p.WaitForExit(180_000)) { try { p.Kill(true); } catch { } throw new TimeoutException("runner hung"); }
+        p.WaitForExit();
+        lock (sb) return (sb.ToString(), p.ExitCode);
+    }
+
+    // Minimal .app: a plain ZIP (no NAVX header — AppLoader falls back to offset 0
+    // when the 8-byte magic doesn't match) containing NavxManifest.xml plus src/*.al
+    // for every (name, source) pair given. No Application/Platform attributes and no
+    // <Dependencies/> — the fixture below references only its own table, so it needs
+    // no Microsoft first-party roots resolved.
+    //
+    // Version/Application/Platform are all pinned to the SAME value —
+    // AlRunner.Infrastructure.BcArtifacts.EngineBuiltVersion() — the exact 4-part BC
+    // build this test binary was compiled against and provisioned for (same value
+    // TestBuildConfig.BcVersionArg pins the OTHER two follow-up tests to). Two
+    // deliberate reasons, not one:
+    //   1. --precompile's own SelectVersion(manifest.Version, null) call resolves the
+    //      BC artifact directory FROM the app's own manifest version — an arbitrary
+    //      "1.0.0.0" falls through to the lazy "latest in cache" default instead,
+    //      which is non-deterministic across machines/CI legs.
+    //   2. Matching Application/Platform gives AppLoader.ImplicitRoots something real
+    //      to resolve (Microsoft/Application + Microsoft/System), so
+    //      BcCompiler.SetPackageCacheFallback's "enumerate every .app in the package
+    //      cache dirs" fallback — reserved for apps with NEITHER dependencies NOR
+    //      Application/Platform attributes, a shape no real modern .app actually
+    //      ships — never engages. That fallback surfaced a genuine but unrelated
+    //      runner false-positive during this test's own development (AL1022 for an
+    //      unrelated PEPPOL package version mismatch, on an app that never
+    //      references PEPPOL) — real modern .app packages always carry
+    //      Application/Platform (AppLoader.ImplicitRoots' own doc comment), so this
+    //      fixture is deliberately shaped like one instead of exercising that corner.
+    private static string WriteAppPackage(string dir, string appId, string name, string publisher,
+        params (string FileName, string Source)[] alSources)
+    {
+        var bcVersion = AlRunner.Infrastructure.BcArtifacts.EngineBuiltVersion()?.ToString()
+            ?? throw new InvalidOperationException(
+                "EngineBuiltVersion() is null — this test binary's BcEngineVersion " +
+                "AssemblyMetadata is missing; rebuild AlRunner before running this test.");
+        var xml = $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <Package xmlns="http://schemas.microsoft.com/navx/2015/manifest">
+              <App Id="{appId}" Name="{name}" Publisher="{publisher}" Version="{bcVersion}"
+                   Application="{bcVersion}" Platform="{bcVersion}"/>
+              <Dependencies/>
+            </Package>
+            """;
+
+        Directory.CreateDirectory(dir);
+        var appPath = Path.Combine(dir, name + ".app");
+        using (var fs = new FileStream(appPath, FileMode.Create, FileAccess.Write))
+        using (var zip = new ZipArchive(fs, ZipArchiveMode.Create))
+        {
+            var manifestEntry = zip.CreateEntry("NavxManifest.xml");
+            using (var es = manifestEntry.Open())
+                es.Write(Encoding.UTF8.GetBytes(xml));
+
+            foreach (var (fileName, source) in alSources)
+            {
+                var entry = zip.CreateEntry("src/" + fileName);
+                using var es = entry.Open();
+                es.Write(Encoding.UTF8.GetBytes(source));
+            }
+        }
+        return appPath;
+    }
+
+    [SkippableFact]
+    public void Precompile_ColumnDeclaresDataSourceAndMethodCount_FailsWithAl0353()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var dir = Path.Combine(Path.GetTempPath(), "al-runner-precompile-al0353-bad", Guid.NewGuid().ToString("N"));
+        var appPath = WriteAppPackage(dir, "f6666666-6666-6666-6666-666666666666",
+            "PrecompileAl0353Bad", "Repro2152",
+            ("Order.Table.al", """
+                table 62230 "AL0353 Pre Order"
+                {
+                    fields
+                    {
+                        field(1; "No."; Code[20]) { }
+                        field(2; Amount; Decimal) { }
+                    }
+                    keys
+                    {
+                        key(PK; "No.") { Clustered = true; }
+                    }
+                }
+                """),
+            ("OrderSum.Query.al", """
+                query 62231 "AL0353 Pre Order Sum"
+                {
+                    QueryType = Normal;
+
+                    elements
+                    {
+                        dataitem(Order; "AL0353 Pre Order")
+                        {
+                            column(TheAmount; Amount) { }
+                            column(CountAmount; Amount) { Method = Count; }
+                        }
+                    }
+                }
+                """));
+        var outputDll = Path.Combine(dir, "PrecompileAl0353Bad.dll");
+
+        var (output, exitCode) = RunPrecompile(appPath, outputDll);
+
+        // Would still pass if --precompile always wrote a DLL regardless of BC
+        // diagnostics — assert the SPECIFIC diagnostic, and that no DLL was written.
+        Assert.NotEqual(0, exitCode);
+        Assert.Contains("AL0353", output);
+        Assert.Contains("A Column must have a valid data source or have the 'Method' property set to 'Count'", output);
+        Assert.False(File.Exists(outputDll), "a DLL should not be written for AL BC's own compiler rejected");
+    }
+
+    [SkippableFact]
+    public void Precompile_ColumnMethodCountWithNoDataSource_WritesDll()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        // The corrected form real BC accepts — proves the precompile gate does not
+        // also reject valid AL. Required alongside the negative test above: a guard
+        // that always failed would pass that test too.
+        var dir = Path.Combine(Path.GetTempPath(), "al-runner-precompile-al0353-good", Guid.NewGuid().ToString("N"));
+        var appPath = WriteAppPackage(dir, "f7777777-7777-7777-7777-777777777777",
+            "PrecompileAl0353Good", "Repro2152",
+            ("Order.Table.al", """
+                table 62232 "AL0353 Pre Order Good"
+                {
+                    fields
+                    {
+                        field(1; "No."; Code[20]) { }
+                        field(2; Amount; Decimal) { }
+                    }
+                    keys
+                    {
+                        key(PK; "No.") { Clustered = true; }
+                    }
+                }
+                """),
+            ("OrderSum.Query.al", """
+                query 62233 "AL0353 Pre Order Sum Good"
+                {
+                    QueryType = Normal;
+
+                    elements
+                    {
+                        dataitem(Order; "AL0353 Pre Order Good")
+                        {
+                            column(TheAmount; Amount) { }
+                            column(CountAmount) { Method = Count; }
+                        }
+                    }
+                }
+                """));
+        var outputDll = Path.Combine(dir, "PrecompileAl0353Good.dll");
+
+        var (output, exitCode) = RunPrecompile(appPath, outputDll);
+
+        Assert.Equal(0, exitCode);
+        Assert.DoesNotContain("AL0353", output);
+        Assert.True(File.Exists(outputDll));
+    }
+}

--- a/AlRunner.Tests/ServerAlDiagnosticFailureTests.cs
+++ b/AlRunner.Tests/ServerAlDiagnosticFailureTests.cs
@@ -1,0 +1,142 @@
+// Issue #2152 — the AL-diagnostic compile-failure guard #2150/#2154 added only
+// covered the default bundled CLI path. --server's per-request compile path
+// (RunBundleForServer, shared by both `runTests` and `execute`) has the identical
+// BC ContinueBuildOnError gap: `sources` can come back non-empty (a broken query
+// column's metadata still emits) at the same time `alDiagnostics` also carries the
+// AL0353 BC reported for it, and before this fix nothing in the server path checked
+// that combination — the request could report a clean run for AL that can never
+// build against a real service tier.
+//
+// This one matters more than the other two follow-up paths: --server is what an
+// editor integration drives on every save. A false green here reaches a developer's
+// inner loop with nothing telling them their AL would not build against BC.
+using System.Text.Json;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class ServerAlDiagnosticFailureTests
+{
+    private static string WriteBundle(string suffix, string queryBody)
+    {
+        var root = Path.Combine(Path.GetTempPath(), "al-runner-server-al0353-" + suffix, Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        File.WriteAllText(Path.Combine(root, "app.json"), """
+        {
+          "id": "e4444444-4444-4444-4444-444444444444",
+          "name": "Server AL0353 Diagnostic Test",
+          "publisher": "Repro2152",
+          "version": "1.0.0.0",
+          "dependencies": [],
+          "platform": "1.0.0.0",
+          "application": "1.0.0.0",
+          "idRanges": [ { "from": 62220, "to": 62229 } ],
+          "runtime": "14.0"
+        }
+        """);
+        File.WriteAllText(Path.Combine(root, "Order.Table.al"), """
+        table 62220 "AL0353 Srv Order"
+        {
+            fields
+            {
+                field(1; "No."; Code[20]) { }
+                field(2; Amount; Decimal) { }
+            }
+            keys
+            {
+                key(PK; "No.") { Clustered = true; }
+            }
+        }
+        """);
+        File.WriteAllText(Path.Combine(root, "OrderSum.Query.al"), queryBody);
+        return root;
+    }
+
+    private static string Req(string bundle) => JsonSerializer.Serialize(new
+    {
+        command = "runTests",
+        sourcePaths = new[] { bundle },
+        packagePaths = Array.Empty<string>(),
+    });
+
+    [SkippableFact]
+    public async Task RunTests_ColumnDeclaresDataSourceAndMethodCount_ReportsCompilationErrorAndNonZeroExit()
+    {
+        TestArtifacts.SkipIfMissing();
+        var bundle = WriteBundle("bad", """
+        query 62221 "AL0353 Srv Order Sum"
+        {
+            QueryType = Normal;
+
+            elements
+            {
+                dataitem(Order; "AL0353 Srv Order")
+                {
+                    column(TheAmount; Amount) { }
+                    column(CountAmount; Amount) { Method = Count; }
+                }
+            }
+        }
+        """);
+        try
+        {
+            await using var server = await CliServer.StartAsync();
+            var lines = await server.SendRequestStreamingAsync(Req(bundle), TimeSpan.FromSeconds(180));
+            var (_, d) = ProtocolV2Streaming.Split(lines);
+
+            // Would still pass if the server always returned a default/no-op success —
+            // assert the SPECIFIC BC diagnostic surfaced over the wire, not just "some
+            // non-zero exit code".
+            Assert.NotEqual(0, d.GetProperty("exitCode").GetInt32());
+            Assert.Equal(0, d.GetProperty("total").GetInt32());
+            Assert.True(d.TryGetProperty("compilationErrors", out var compileErrors),
+                $"expected compilationErrors on an AL-diagnostic compile failure: {string.Join(" | ", lines)}");
+            var allErrorText = string.Join(" | ", compileErrors.EnumerateArray()
+                .SelectMany(g => g.GetProperty("errors").EnumerateArray().Select(e => e.GetString())));
+            Assert.Contains("AL0353", allErrorText);
+            Assert.Contains("A Column must have a valid data source or have the 'Method' property set to 'Count'", allErrorText);
+        }
+        finally
+        {
+            try { Directory.Delete(bundle, recursive: true); } catch { }
+        }
+    }
+
+    [SkippableFact]
+    public async Task RunTests_ColumnMethodCountWithNoDataSource_RunsCleanly()
+    {
+        TestArtifacts.SkipIfMissing();
+        // The corrected form real BC accepts — proves the server-mode gate does not
+        // also reject valid AL. Required alongside the negative test above: a guard
+        // that always failed compilation would pass that test too.
+        var bundle = WriteBundle("good", """
+        query 62222 "AL0353 Srv Order Sum"
+        {
+            QueryType = Normal;
+
+            elements
+            {
+                dataitem(Order; "AL0353 Srv Order")
+                {
+                    column(TheAmount; Amount) { }
+                    column(CountAmount) { Method = Count; }
+                }
+            }
+        }
+        """);
+        try
+        {
+            await using var server = await CliServer.StartAsync();
+            var lines = await server.SendRequestStreamingAsync(Req(bundle), TimeSpan.FromSeconds(180));
+            var (_, d) = ProtocolV2Streaming.Split(lines);
+
+            Assert.Equal(0, d.GetProperty("exitCode").GetInt32());
+            Assert.False(d.TryGetProperty("compilationErrors", out _),
+                $"unexpected compile error: {string.Join(" | ", lines)}");
+        }
+        finally
+        {
+            try { Directory.Delete(bundle, recursive: true); } catch { }
+        }
+    }
+}

--- a/AlRunner.Tests/ServerTests.cs
+++ b/AlRunner.Tests/ServerTests.cs
@@ -403,7 +403,13 @@ public class ServerTests : IClassFixture<SharedCliServer>
         {
             command = "execute",
             code = "report 60184 \"Inline Full Report SX\" { dataset { } } " +
-                   "codeunit 60185 \"Inline Full Report Companion SX\" { trigger OnRun() begin " +
+                   // #2152: this codeunit name was 32 characters ("...Companion SX") — over
+                   // AL's 30-character object-identifier limit (AL0305) — invalid AL real BC
+                   // has always rejected. It compiled here regardless because --server's
+                   // compile path (unlike the default bundled CLI path #2154 already fixed)
+                   // did not check post-emit AL error diagnostics; #2152 closed that gap and
+                   // this surfaced immediately. Shortened, not worked around.
+                   "codeunit 60185 \"Inline Report Companion SX\" { trigger OnRun() begin " +
                    "Error('report-companion-ran %1', 400 + 1); end; }"
         }));
         var d = JsonSerializer.Deserialize<JsonElement>(r);
@@ -517,6 +523,17 @@ public class ServerTests : IClassFixture<SharedCliServer>
     // depends on the app and asserts the procedure's return value, so a green
     // result here PROVES the test bundle actually compiled against the app's
     // real symbols, not just that some non-empty test list came back.
+    //
+    // #2152: the App bundle's object ID range was 60150-60159, which collides on
+    // the ACTUAL object id (60150) with RecordTriggerXRec's own fixture ("xRec
+    // Assert RXT", codeunit 60150) — both loaded into the SAME shared server
+    // process across different requests in this class. BC's process-global
+    // metadata registry reports the second declaration as AL0264 ("already
+    // declared by the extension ..."), a real diagnostic that was already firing
+    // and being silently ignored before --server checked post-emit AL error
+    // diagnostics; #2152 made it a hard failure and surfaced this pre-existing ID
+    // collision immediately. Moved to 60350-60359, well clear of every other
+    // idRange in this file (60100-60199, 60120-60129, 60160-60169).
     private static string MakeAppTestPair(out string appDir, out string testDir)
     {
         var root = Path.Combine(Path.GetTempPath(), "al-runner-server-multi", Guid.NewGuid().ToString("N"));
@@ -535,12 +552,12 @@ public class ServerTests : IClassFixture<SharedCliServer>
           "dependencies": [],
           "platform": "1.0.0.0",
           "application": "1.0.0.0",
-          "idRanges": [ { "from": 60150, "to": 60159 } ],
+          "idRanges": [ { "from": 60350, "to": 60359 } ],
           "runtime": "14.0"
         }
         """);
         File.WriteAllText(Path.Combine(appDir, "AppLogic.Codeunit.al"), """
-        codeunit 60150 "Server Multi App Logic SX"
+        codeunit 60350 "Server Multi App Logic SX"
         {
             procedure Answer(): Integer
             begin

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -2601,22 +2601,13 @@ foreach (var bundle in bundles)
             // match and stays blocking. Silently swallowing every AL1081 regardless of cause
             // would hide a genuinely broken report the same way #2150 itself needs fixing;
             // loud-failures.md requires saying so, not going quiet for one error code.
-            var toleratedAl1081 = alDiagnostics
-                .Where(d => IsKnownLayoutPathResolutionBug(d, appGroup.SuiteDir)).ToList();
-            var blockingAlDiagnostics = alDiagnostics
-                .Where(d => !IsKnownLayoutPathResolutionBug(d, appGroup.SuiteDir)).ToList();
-            if (toleratedAl1081.Count > 0)
-            {
-                Console.Error.WriteLine(
-                    $"<bundled>: AL1081-TOLERATED — {moduleName}: {toleratedAl1081.Count} report-layout " +
-                    $"diagnostic(s) tolerated as a KNOWN RUNNER BUG, not invalid AL (see " +
-                    $"https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/2151 — the runner's " +
-                    $"Tier-3 source compile resolves a report's LayoutFile relative to the app root instead " +
-                    $"of the .al file's own directory). The named file genuinely exists elsewhere under this " +
-                    $"app, so this is OUR path-resolution defect, not yours:");
-                foreach (var d in toleratedAl1081)
-                    Console.Error.WriteLine($"  {d}");
-            }
+            //
+            // #2152: this classification (and the AL1081-TOLERATED print above the fail
+            // check) is shared with --per-suite/--server/--precompile via
+            // ClassifyBlockingAlDiagnostics — see that function's doc comment for why a
+            // fourth independent copy of this filter would be the wrong call.
+            var blockingAlDiagnostics = ClassifyBlockingAlDiagnostics(
+                alDiagnostics, appGroup.SuiteDir, "<bundled>", moduleName);
             if (sources.Count > 0 && blockingAlDiagnostics.Count > 0)
             {
                 Console.Error.WriteLine(
@@ -2904,6 +2895,32 @@ foreach (var bundle in bundles)
             }
             et.Stop(); bundleEmit += et.Elapsed;
             AlRunner.Infrastructure.PhaseLog.AddAppEmit(et.Elapsed);
+
+            // AL-diagnostic compile-failure guard (#2150), extended to --per-suite (#2152).
+            // Bundled mode got this gate first because it's the only path CI's corpus/
+            // runner-extras legs actually exercise (see #2154) — but --per-suite compiles
+            // one module per SUITE instead of per app-group and hits the exact same BC
+            // ContinueBuildOnError shape: `sources` can come back non-empty (a broken
+            // object's sibling still emitted) at the same time `suiteAlDiagnostics` is also
+            // non-empty. Real BC would refuse to publish this suite regardless, so
+            // --per-suite must fail here too — classification shared via
+            // ClassifyBlockingAlDiagnostics (see its doc comment) so this predicate can't
+            // drift from bundled mode's.
+            var blockingSuiteAlDiagnostics = ClassifyBlockingAlDiagnostics(
+                suiteAlDiagnostics, suite, suiteName, suiteName);
+            if (sources.Count > 0 && blockingSuiteAlDiagnostics.Count > 0)
+            {
+                Console.Error.WriteLine(
+                    $"{suiteName}: AL-DIAGNOSTIC-FAIL — {sources.Count} object(s) emitted but " +
+                    $"{blockingSuiteAlDiagnostics.Count} AL error(s) were reported by BC's own compiler; " +
+                    $"a real service tier would refuse to publish this module:");
+                foreach (var d in blockingSuiteAlDiagnostics)
+                    Console.Error.WriteLine($"  {d}");
+                bundleErrors.Add(
+                    $"{suiteName}: AL-DIAGNOSTIC-FAIL ({blockingSuiteAlDiagnostics.Count}): " +
+                    $"{blockingSuiteAlDiagnostics.FirstOrDefault()?.Split('\n')[0]}");
+                continue; // do not compile/run a suite BC would refuse to publish
+            }
 
             var ct = System.Diagnostics.Stopwatch.StartNew();
             var compile = assembler.Compile($"V2_{Path.GetFileName(suite)}", sources);
@@ -3616,6 +3633,31 @@ return strictExitCode ? computedExitCode : 0;
                 {
                     foreach (var d in alDiagnostics) compileErrors.Add(d);
                     if (compileErrors.Count == 0) compileErrors.Add("EMIT-ZERO: 0 sources emitted");
+                    return new ServerRunResult(Array.Empty<TestResult>(), 3, false,
+                        new List<CompilationErrorGroup> { new(moduleName, compileErrors) }, fileHashes);
+                }
+                // AL-diagnostic compile-failure guard (#2150), extended to --server (#2152).
+                // The most important of the three follow-up paths: this is what an editor
+                // integration drives on every save, so a false green here reaches a
+                // developer's inner loop with nothing telling them their AL would not build
+                // against real BC. Same BC ContinueBuildOnError shape as bundled mode —
+                // `sources` non-empty at the same time `alDiagnostics` is non-empty means a
+                // real service tier would still refuse to publish this module. Surfaced over
+                // the wire via the SAME compilationErrors/exitCode:3 convention every other
+                // compile failure in this method already uses (EMIT-EXCLUDED, EMIT-ZERO,
+                // COMPILE-FAIL just below) — there is no separate protocol shape to invent,
+                // and the client already has to handle non-empty compilationErrors.
+                var blockingAlDiagnostics = ClassifyBlockingAlDiagnostics(
+                    alDiagnostics, bundleAbs, "[server]", moduleName);
+                if (blockingAlDiagnostics.Count > 0)
+                {
+                    Console.Error.WriteLine(
+                        $"[server] {moduleName}: AL-DIAGNOSTIC-FAIL — {sources.Count} object(s) emitted but " +
+                        $"{blockingAlDiagnostics.Count} AL error(s) were reported by BC's own compiler; a real " +
+                        $"service tier would refuse to publish this module:");
+                    foreach (var d in blockingAlDiagnostics)
+                        Console.Error.WriteLine($"  {d}");
+                    compileErrors.AddRange(blockingAlDiagnostics);
                     return new ServerRunResult(Array.Empty<TestResult>(), 3, false,
                         new List<CompilationErrorGroup> { new(moduleName, compileErrors) }, fileHashes);
                 }
@@ -4852,6 +4894,43 @@ static bool IsKnownLayoutPathResolutionBug(string diagnostic, string? appRootDir
     catch (UnauthorizedAccessException) { return false; }
 }
 
+// #2152: the AL-diagnostic compile-failure gate itself (#2150) — "any Error-severity AL
+// diagnostic BC's own compiler reported for this module blocks the run, regardless of how
+// many objects still emitted, because a real service tier would refuse to publish it" —
+// plus the #2151 AL1081 carve-out, factored out ONCE so bundled mode, --per-suite,
+// --server, and --precompile all classify identically. Before this, only bundled mode had
+// the gate at all (#2150 shipped scoped to the one path CI's corpus/runner-extras legs
+// actually exercise); copying its `alDiagnostics.Where(d => IsKnownLayoutPathResolution-
+// Bug(...))` filter into three more call sites verbatim is exactly the kind of duplication
+// that drifts the moment one copy gets touched and the others don't — see #2152's own
+// writeup, and it already happened twice in this repo in one day for unrelated rules.
+//
+// Prints the AL1081-TOLERATED explanation (never silent — loud-failures.md) for whatever
+// gets carved out, tagged with <paramref name="logPrefix"/> so the four callers' console
+// output stays distinguishable (`&lt;bundled&gt;`, a suite name, `[server]`, `--precompile`),
+// and returns only the diagnostics that still block. Callers keep their own idiom for
+// WHAT to do with a non-empty result (bundleErrors.Add + zero out sources, a
+// ServerRunResult/CompilationErrorGroup, or an early `return 3`) — only the classification
+// is shared, not each path's independently-evolved failure-reporting shape.
+static IReadOnlyList<string> ClassifyBlockingAlDiagnostics(
+    IReadOnlyList<string> alDiagnostics, string? appRootDir, string logPrefix, string moduleName)
+{
+    if (alDiagnostics.Count == 0) return alDiagnostics;
+    var tolerated = alDiagnostics.Where(d => IsKnownLayoutPathResolutionBug(d, appRootDir)).ToList();
+    if (tolerated.Count == 0) return alDiagnostics;
+    var blocking = alDiagnostics.Where(d => !IsKnownLayoutPathResolutionBug(d, appRootDir)).ToList();
+    Console.Error.WriteLine(
+        $"{logPrefix}: AL1081-TOLERATED — {moduleName}: {tolerated.Count} report-layout " +
+        $"diagnostic(s) tolerated as a KNOWN RUNNER BUG, not invalid AL (see " +
+        $"https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/2151 — the runner's " +
+        $"Tier-3 source compile resolves a report's LayoutFile relative to the app root instead " +
+        $"of the .al file's own directory). The named file genuinely exists elsewhere under this " +
+        $"app, so this is OUR path-resolution defect, not yours:");
+    foreach (var d in tolerated)
+        Console.Error.WriteLine($"  {d}");
+    return blocking;
+}
+
 static void DumpCsharpSources(string dir, string moduleName, IReadOnlyList<EmittedSource> sources)
 {
     var bundleDir = Path.Combine(dir, SanitiseFilename(moduleName));
@@ -5560,6 +5639,44 @@ static int RunPrecompile(string[] subArgs)
         AlRunner.Infrastructure.BcArtifacts.ArtifactsRootDir,
         AlRunner.Infrastructure.BcArtifacts.SelectedVersion.ToString());
 
+    // #2156 (found while adding #2152's proving test for this subcommand): --precompile
+    // dispatches before the main run flow's own "Cecil-rewrite Ncl.dll in place" step ever
+    // runs (that block lives much further down in Main, past the `--precompile` early
+    // return), so on a genuinely cold environment — nothing has yet forced a fresh Cecil
+    // rewrite of the bin-directory Ncl.dll for the selected BC version — NavEnvironment's
+    // real, unpatched static constructor runs for the first time inside
+    // BcRuntime.ApplyAllPatches and calls WindowsIdentity.GetCurrent() unconditionally,
+    // which throws PlatformNotSupportedException on Linux before a single AL object is
+    // even read. Mirror the main flow's own sequence here: rewrite, then re-exec once IF
+    // this rewrite was the fresh one — loading a byte-identical freshly-rewritten Ncl in
+    // the SAME process that wrote it can intermittently throw BadImageFormatException (see
+    // the main flow's own comment on this exact hazard), so a fresh rewrite always re-execs
+    // rather than continuing in this process. AL_RUNNER_REEXECED (shared with the main
+    // flow's guard) prevents an infinite loop if the child somehow rewrites again.
+    {
+        var srcDir = AlRunner.Infrastructure.BcArtifacts.ServiceTierDir;
+        var binNcl = Path.Combine(AppContext.BaseDirectory, "Microsoft.Dynamics.Nav.Ncl.dll");
+        var didFreshRewrite = AlRunner.Infrastructure.NclCecilRewrite.RewriteInPlace(srcDir, binNcl);
+        if (didFreshRewrite && Environment.GetEnvironmentVariable("AL_RUNNER_REEXECED") != "1")
+        {
+            var psi = new System.Diagnostics.ProcessStartInfo(Environment.ProcessPath!)
+            {
+                UseShellExecute = false,
+            };
+            var argv = Environment.GetCommandLineArgs();
+            var underDotnet = Path.GetFileNameWithoutExtension(Environment.ProcessPath!)
+                .Equals("dotnet", StringComparison.OrdinalIgnoreCase);
+            var userArgs = underDotnet ? argv : argv.Skip(1);
+            foreach (var a in userArgs)
+                psi.ArgumentList.Add(a);
+            psi.Environment["AL_RUNNER_REEXECED"] = "1";
+            Console.Error.WriteLine("[reexec] --precompile: fresh Ncl rewrite done — re-execing for a clean load");
+            using var child = System.Diagnostics.Process.Start(psi)!;
+            child.WaitForExit();
+            return child.ExitCode;
+        }
+    }
+
     // Apply BC patches before any BC type is touched (BcCompiler uses BC types).
     BcRuntime.EnsureApplied();
 
@@ -5636,6 +5753,27 @@ static int RunPrecompile(string[] subArgs)
             if (diags.Count > cap)
                 Console.Error.WriteLine($"    ... and {diags.Count - cap} more");
         }
+        return 3;
+    }
+    // AL-diagnostic compile-failure guard (#2150), extended to --precompile (#2152). Same
+    // BC ContinueBuildOnError shape as the other three paths: `emitted` can come back
+    // non-empty (a broken object's sibling still emitted) at the same time
+    // emitOut.Diagnostics also carries an Error-severity diagnostic for the broken one — a
+    // real service tier would refuse to publish this dependency app regardless. Failing
+    // loudly here matters more than it might look: --precompile's whole point is producing
+    // a DLL another bundle run trusts as a precompiled dependency (see
+    // precompiled-dll-respect.md), so a silently-accepted compile error here would poison
+    // every bundle that later depends on this output.
+    var precompileBlockingDiagnostics = ClassifyBlockingAlDiagnostics(
+        emitOut.Diagnostics, tempDir, "--precompile", $"{manifest.Publisher}_{manifest.Name}");
+    if (precompileBlockingDiagnostics.Count > 0)
+    {
+        Console.Error.WriteLine(
+            $"--precompile: AL-DIAGNOSTIC-FAIL for {manifest.Publisher}_{manifest.Name} v{manifest.Version}: " +
+            $"{emitted.Count} object(s) emitted but {precompileBlockingDiagnostics.Count} AL error(s) were " +
+            $"reported by BC's own compiler; a real service tier would refuse to publish this module:");
+        foreach (var d in precompileBlockingDiagnostics)
+            Console.Error.WriteLine($"  {d}");
         return 3;
     }
     var asmName = $"Dep_{Sanitize(manifest.Publisher)}_{Sanitize(manifest.Name)}_{manifest.Version.ToString().Replace('.', '_')}";


### PR DESCRIPTION
Closes #2152
Closes #2140
Closes #2156

## Problem

#2154 gated only the default bundled CLI path on post-emit AL error diagnostics (BC's `ContinueBuildOnError` can leave `sources` non-empty even though `alDiagnostics` is also non-empty, e.g. a query column declaring both a data source and `Method = Count`, AL0353). `--per-suite`, `--server`, and `--precompile` shared the exact same unpacking-and-discarding pattern and could silently run/report success for AL a real BC service tier would refuse to publish.

## What changed

- Factored the classification (`sources.Count > 0 && diagnostics.Count > 0` after the #2151 AL1081 carve-out) into one shared `ClassifyBlockingAlDiagnostics` helper in `AlRunner/Program.cs`, and refactored the bundled path to use it too — so all four paths share one predicate instead of four copies that would drift.
- Applied the gate to `--per-suite` (fails the suite loop, same `bundleErrors` idiom the path already uses).
- Applied the gate to `--server`'s `RunBundleForServer` (shared by both `runTests` and `execute`). **This is the most important of the three** — it's what an editor integration drives on every save, so a false green here reaches a developer's inner loop with nothing telling them their AL would not build against BC. Surfaced over the wire via the exact same `compilationErrors`/`exitCode: 3` convention every other compile failure in that method already uses (`EMIT-EXCLUDED`, `EMIT-ZERO`, `COMPILE-FAIL`) — no new protocol shape.
- Applied the gate to `--precompile` (returns exit 3, matching its existing `EMIT-ZERO`/`COMPILE-FAIL` conventions). This one matters beyond itself: `--precompile`'s whole point is producing a DLL another bundle run trusts as a precompiled dependency, so a silently-accepted compile error here would poison every later bundle that depends on the output.

## Pre-existing bugs the new gate surfaced (triaged individually, per #2154's own precedent)

- **`--precompile` crashed cold on Linux** (`TypeInitializationException`/`PlatformNotSupportedException` from `NavEnvironment`'s cctor touching `WindowsIdentity.GetCurrent()`), because its dispatch runs before the main flow's Cecil-rewrite-Ncl-in-place step. This was already open and triaged as #2140 ("--precompile crashes with NavEnvironment/WindowsIdentity TypeInitializationException — never runs the BC-version-select/Cecil-rewrite bootstrap"); I filed a duplicate, #2156, before finding it. Same cctor, same cause, same fix — both close with this PR.
- **A 32-character object name** in `ServerTests.cs`'s `Execute_InlineCode_FullReportDefinition_CompanionCodeunitRuns` fixture — over AL's 30-character limit (AL0305), invalid AL real BC has always rejected. Shortened, not worked around (mirrors #2154's own precedent for the exact same class of bug).
- **An object-ID collision** between two `ServerTests.cs` fixtures (`RecordTriggerXRec`'s codeunit 60150 and `MakeAppTestPair`'s inline app, also 60150) that share one server process across different requests in the same test class — BC's process-global metadata registry reported the second declaration as AL0264 ("already declared"), a real diagnostic that was already firing and silently ignored. Renumbered the colliding range to 60350-60359.

## Tests (RED → GREEN)

- `AlRunner.Tests/PerSuiteAlDiagnosticFailureTests.cs` — `--per-suite` against the same AL0353 query shape #2154's own bundled-mode test uses; negative (fails with the exact diagnostic) + positive (valid form still compiles).
- `AlRunner.Tests/ServerAlDiagnosticFailureTests.cs` — a `runTests` request against the same shape; asserts `compilationErrors` carries the AL0353 diagnostic and `exitCode != 0`, plus the positive case.
- `AlRunner.Tests/PrecompileAlDiagnosticFailureTests.cs` — builds a real `.app` package (NavxManifest.xml + `src/*.al`, no NAVX header needed) and runs `--precompile` against it; negative + positive, and asserts no DLL is written on the negative case.
- All three confirmed RED before the fix (reverted `Program.cs`, reran) and GREEN after.
- Existing `Al1081ToleranceScopingTests.cs` (the #2151 carve-out) still passes after the bundled-path refactor — verified with a clean AL-output cache (the shared on-disk cache can otherwise mask a fresh emit behind a stale hit, which is exactly what happened during my own local debugging, unrelated to the refactor's correctness).
- `ServerTests.cs`'s full class (28 facts, one shared server process) passes clean after the two pre-existing-bug fixes above.

## Design note: why `--server`'s wire shape didn't change

I looked at whether a compile failure like this needs a new field on the JSON-RPC response. It doesn't: `RunBundleForServer` already has three sibling failure branches (`EMIT-EXCLUDED`, `EMIT-ZERO`, `COMPILE-FAIL`) that all return `ServerRunResult` with a non-empty `CompileErrors` list and `exitCode: 3`, which `ServerProtocol.Summary`/`Execute` already serialize as `compilationErrors: [{file, errors}]`. The new AL-diagnostic gate is just a fourth branch in that same shape — any client already handling `compilationErrors` for a real compile error handles this one for free.

## Not done here

Not applicable — this PR only touches runner-internal compile-path gating (no new CLI flags, no protocol schema change), so `--help`/`--guide`/`docs/limitations.md`/`docs/scope.md` don't need updates.
