### PR TITLE
docs(isolation): record the measured verdict on codeunit-instance sharing

### DIFF
--- a/AlRunner.Tests/TestIsolationCodeunitVariableSharingTests.cs
+++ b/AlRunner.Tests/TestIsolationCodeunitVariableSharingTests.cs
@@ -13,13 +13,16 @@
 // passes. That asymmetry is the whole proof, and it is built on a plain Integer that
 // never touches a Record, so the database reset cannot be what makes it pass or fail.
 //
-// #2160, on what this file may and may not claim: it asserts what the RUNNER's two
-// modes do, which is a runner-specific claim and belongs here. It deliberately does not
-// assert that real BC shares one instance across a codeunit's tests. #2144 did make that
-// claim, citing a BC codeunit 130452 that does not exist, and the sibling claim it made
-// about the database was measured against a real service tier and found backwards. The
-// instance question is being measured the same way, in al-language corpus PR #73; until
-// that returns a verdict, no comment here should state BC's answer to it.
+// On what this file claims: it asserts what the RUNNER's two modes do, which is a
+// runner-specific claim and belongs here. The matching claim about BC is proved where
+// it has to be, against a real service tier — corpus codeunit 60898
+// "Test Isolation Global Var" raises a global in one [Test] and reads it in the next,
+// and is green on BC 27.5 and 28.3. So sharing the instance under `codeunit` is
+// faithful to BC, and this file's asymmetry is the runner-side proof of it.
+//
+// #2144 asserted the same thing from a BC codeunit 130452 that does not exist, and its
+// sibling claim about the database turned out backwards when a service tier was finally
+// asked (#2160). The conclusion happened to survive; the way it was reached did not.
 using System.Diagnostics;
 using System.Text;
 using Xunit;

--- a/AlRunner/TestExecutor.cs
+++ b/AlRunner/TestExecutor.cs
@@ -421,12 +421,13 @@ public sealed class TestExecutor
         // Codeunit/Disabled keep ONE instance for every test in the codeunit, so AL
         // global variables persist across a codeunit's tests.
         //
-        // #2160: whether real BC shares one instance across a codeunit's tests is being
-        // measured upstream (al-language corpus PR #73). The runner has always shared it,
-        // and this line does not change that; if the service tier says BC constructs a
-        // fresh instance per test, Codeunit isolation follows the measurement then. What
-        // #2160 corrected is the DATABASE half, which is settled: BC rolls back per
-        // codeunit, so that reset is back at the codeunit boundary above.
+        // Both halves are now measured against a real service tier, not inferred.
+        // BC runs every [Test] in a codeunit on the SAME codeunit instance, so its AL
+        // global variables persist across them — corpus test 60898
+        // "Test Isolation Global Var", green on BC 27.5 and 28.3. The database half is
+        // in 60897 and resets per codeunit (see the boundary above). Sharing the
+        // instance under Codeunit isolation is therefore faithful, and Test isolation's
+        // fresh instance per test is AL's TestIsolation = Function.
         var perTestInstance = Isolation == TestIsolation.Test;
         foreach (var t in types)
         {

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -86,10 +86,13 @@ They are AL's own `TestIsolation` values: reading the strings out of
 | `test` (alias `method`) | `Function` | none — no shipped BC runner declares `Function` | Rolls back before every `[Test]` procedure | **Not** shared — every `[Test]` runs on a brand-new codeunit instance |
 | `disabled` | `Disabled` | 130451 "Test Runner - Isol. Disabled" | Never rolls back — suite-long sharing | Shared for the whole suite |
 
-The database column is measured, not inferred. `TestIsolationRollbackScope` (60897) in
-the [al-language corpus](https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests)
-writes an uncommitted row in one `[Test]` and reads it back in the next `[Test]` of the
-same codeunit; it is green on real BC 27.5 and 28.3.
+Both of the last two columns are measured against a real service tier, not inferred.
+In the [al-language corpus](https://github.com/StefanMaron/BusinessCentral.AL.Language.Tests),
+`TestIsolationRollbackScope` (60897) writes an uncommitted row in one `[Test]` and reads
+it back in the next `[Test]` of the same codeunit, and `Test Isolation Global Var`
+(60898) does the same with a global Integer and a global Text. Both are green on BC 27.5
+and 28.3: the row survives and so do the globals, which is what "rolls back after each
+test codeunit" and "one codeunit instance runs them all" mean in practice.
 
 #### A correction worth recording (#2160)
 

--- a/tests/expectations/count-baseline/test-count-baseline.json
+++ b/tests/expectations/count-baseline/test-count-baseline.json
@@ -2,7 +2,7 @@
   "_comment": "Consumed by --count-baseline (AlRunner/Infrastructure/CountBaseline.cs), a DIFFERENT schema from the oos-/known-gaps-/divergence-/disabled- files in this directory: those declare the expected CLASSIFICATION of one named test, this declares the expected EXACT COUNT of a whole suite -- an exact match, not a floor: a mismatch in EITHER direction (drop OR growth) fails the run (exit 4). See #1880 and PR #1882's review for why growth is also a hard failure, not just a notice. Suite keys are the basename of the bundle directory CI passes on the command line (tests/al-language/tests/al-language -> 'al-language', tests/runner-extras -> 'runner-extras'), matching the '--out <name>-results.json' convention CI already uses. Values below are read off actual Test Matrix CI runs (see PR discussion for run URLs), not guessed: al-language's 2073->2076 bump reflects 3 corpus tests merged upstream between when the local baseline was drafted and when CI first ran against it. runner-extras' appGroups 23->21 byBcVersion override on 27.0/27.3/27.5 is the SAME preprocessor-gated-surface split that already explains its tests count divergence: fewer AL surfaces compile pre-28.0, which drops whole app groups, not just individual tests within a group. ANY PR that changes a suite's test or app-group count -- growth included -- MUST bump the matching number here in the SAME PR, or that PR's CI goes red with a [count-baseline] DROP or GROWTH diagnostic naming the exact expected/actual numbers to use.",
   "suites": {
     "al-language": {
-      "tests": { "default": 2159 },
+      "tests": { "default": 2161 },
       "appGroups": { "default": 1 }
     },
     "runner-extras": {


### PR DESCRIPTION
Closes #2162

#2160 corrected the database half of `--isolation codeunit` and deliberately left the instance half alone, saying its premise was unverified and being measured upstream.

The measurement is in, and the premise holds. Corpus codeunit 60898 `Test Isolation Global Var` raises a global Integer and a global Text in one `[Test]` and reads them in the next `[Test]` of the same codeunit. Green on real BC 27.5 and 28.3 — both survive. BC runs every `[Test]` in a codeunit on the same codeunit instance, so AL global variables persist across them.

**No behavior changes.** The runner already shares the instance. What changes is the text that said the question was open:

- `AlRunner/TestExecutor.cs` — the `perTestInstance` comment.
- `AlRunner.Tests/TestIsolationCodeunitVariableSharingTests.cs` — the header, which said no comment there may state BC's answer.
- `docs/limitations.md` — the AL-global-variables column is now measured, like the database column next to it.

#2144 asserted this same conclusion from a BC codeunit 130452 that does not exist. The conclusion happened to survive; the way it was reached did not, and the comments now point at the corpus test instead.

Pin bump for 60898, `al-language` baseline 2159 → 2161. Unlike #2160's pin bump this one is green by construction — the corpus test asserts what the runner already does.