### PR TITLE
fix(ci): rerun pr-check.yml guards when a PR title/body is edited

### DIFF
--- a/.github/scripts/check_pr_check_triggers.sh
+++ b/.github/scripts/check_pr_check_triggers.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Fails when a workflow's `pull_request` trigger is missing a required event
+# type. Written for pr-check.yml, whose reject-ci-skip-directives and
+# reject-bad-closing-references jobs both read the PR title/body -- see
+# #2159.
+#
+# The gap this guards: `pull_request` only reruns a workflow on the event
+# types listed under `on.pull_request.types`. If `edited` is not one of
+# them, editing a PR's title or body after those two jobs already passed
+# retriggers nothing. The squash-merge commit then carries whatever title/
+# body existed at merge time, which may never have been checked at all.
+# Real incidents this exact mechanism produced: #2116 (a CI-skip directive
+# added after the check passed), #2128 (an unintended closing reference
+# added after the check passed).
+#
+# Extracted into its own script (out of pr-check.yml's inline `run:` block)
+# so this is unit-tested directly, the same pattern as
+# check_ci_skip_directives.sh and check_closing_reference.sh.
+#
+# This is a line-oriented extraction, not a real YAML parser -- deliberately
+# so, to avoid taking a yq/python-yaml dependency for a one-line sanity
+# check on a workflow file with a flat, single-line trigger declaration. It
+# reads the FIRST `types: [...]` line in the file, which is fine as long as
+# the workflow keeps that trigger on one line; a workflow that reformats it
+# across multiple lines needs a corresponding update here.
+#
+# Usage: check_pr_check_triggers.sh [path-to-workflow-yaml]
+# Defaults to .github/workflows/pr-check.yml relative to this script.
+# Exits 0 and prints a confirmation when all required types are present.
+# Exits 1 with an ::error:: line naming what's missing otherwise.
+# Exits 2 if the file or the types line can't be found at all (a distinct
+# code from "check failed" -- this means the check couldn't even run).
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKFLOW="${1:-$SCRIPT_DIR/../workflows/pr-check.yml}"
+
+if [ ! -f "$WORKFLOW" ]; then
+  echo "::error::workflow file not found: $WORKFLOW" >&2
+  exit 2
+fi
+
+TYPES_LINE=$(grep -E '^[[:space:]]*types:[[:space:]]*\[' "$WORKFLOW" | head -n1)
+
+if [ -z "$TYPES_LINE" ]; then
+  echo "::error::could not find a 'types: [...]' line under pull_request in $WORKFLOW" >&2
+  exit 2
+fi
+
+# 'edited' is required so a title/body edit after opened/synchronize/
+# reopened/labeled/unlabeled gets re-validated by the two jobs that read
+# PR_TITLE/PR_BODY (#2159). The rest are pre-existing and load-bearing for
+# reasons documented inline in pr-check.yml itself; this check also catches
+# one of them being dropped by accident while editing the trigger line for
+# something unrelated.
+REQUIRED_TYPES=(opened synchronize reopened labeled unlabeled edited)
+
+MISSING=()
+for t in "${REQUIRED_TYPES[@]}"; do
+  if ! echo "$TYPES_LINE" | grep -qE "(\[|,)[[:space:]]*${t}[[:space:]]*(,|\])"; then
+    MISSING+=("$t")
+  fi
+done
+
+if [ "${#MISSING[@]}" -ne 0 ]; then
+  echo "::error::pull_request trigger in $WORKFLOW is missing required type(s): ${MISSING[*]} (found line: ${TYPES_LINE# })" >&2
+  exit 1
+fi
+
+echo "pull_request trigger in $WORKFLOW includes all required types: ${REQUIRED_TYPES[*]}"

--- a/.github/scripts/test_check_pr_check_triggers.sh
+++ b/.github/scripts/test_check_pr_check_triggers.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# Tests for check_pr_check_triggers.sh -- #2159: pr-check.yml's
+# reject-ci-skip-directives and reject-bad-closing-references jobs both read
+# the PR title/body, but the workflow's `pull_request` trigger did not
+# include `edited`, so editing a PR's title or body after those checks
+# passed retriggered nothing.
+#
+# What this proves: the checker script correctly detects presence/absence
+# of each individually-required trigger type against synthetic fixture
+# workflow files, in both directions (a fixture missing 'edited' fails, one
+# missing an unrelated pre-existing type also fails, one with everything
+# present passes). It also runs the checker against the REAL
+# .github/workflows/pr-check.yml to prove that file currently satisfies it.
+#
+# What this does NOT prove: that GitHub Actions actually reruns the two
+# guard jobs when a PR is edited post-hoc -- that is a claim about GitHub's
+# own trigger semantics, documented at
+# https://docs.github.com/actions/using-workflows/events-that-trigger-workflows#pull_request,
+# not something a script run in this repo's own CI can exercise end to end.
+# This test only proves the workflow FILE declares the type; it cannot open
+# a real PR, edit its body, and observe a rerun.
+#
+# Run directly: bash .github/scripts/test_check_pr_check_triggers.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$SCRIPT_DIR/check_pr_check_triggers.sh"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+TMPDIR_FIXTURES="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_FIXTURES"' EXIT
+
+pass=0
+fail=0
+
+assert_exit() {
+  local desc="$1" expected_rc="$2" fixture_path="$3"
+  local rc
+  "$SCRIPT" "$fixture_path" >/dev/null 2>&1
+  rc=$?
+  if [ "$rc" = "$expected_rc" ]; then
+    echo "ok   - $desc"
+    pass=$((pass + 1))
+  else
+    echo "FAIL - $desc: expected exit $expected_rc, got $rc"
+    fail=$((fail + 1))
+  fi
+}
+
+write_fixture() {
+  local name="$1" types="$2"
+  local path="$TMPDIR_FIXTURES/$name"
+  cat > "$path" <<EOF
+name: PR Check
+
+on:
+  pull_request:
+    branches: [main]
+    types: [$types]
+
+jobs:
+  noop:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo noop
+EOF
+  echo "$path"
+}
+
+# --- The exact #2159 regression: 'edited' missing, everything else present --
+
+missing_edited=$(write_fixture "missing-edited.yml" "opened, synchronize, reopened, labeled, unlabeled")
+assert_exit "fixture missing 'edited' fails" 1 "$missing_edited"
+
+# --- Every required type present passes -------------------------------------
+
+all_present=$(write_fixture "all-present.yml" "opened, synchronize, reopened, labeled, unlabeled, edited")
+assert_exit "fixture with all required types passes" 0 "$all_present"
+
+# --- Order and spacing don't matter, just presence ---------------------------
+
+reordered=$(write_fixture "reordered.yml" "edited,opened,unlabeled,reopened,labeled,synchronize")
+assert_exit "fixture with reordered/no-space types still passes" 0 "$reordered"
+
+# --- A DIFFERENT pre-existing type going missing also fails (proves this  --
+# --- isn't just grepping for the literal string 'edited') -------------------
+
+missing_labeled=$(write_fixture "missing-labeled.yml" "opened, synchronize, reopened, unlabeled, edited")
+assert_exit "fixture missing pre-existing 'labeled' also fails" 1 "$missing_labeled"
+
+# --- A file with no recognizable types line at all is a hard error (exit 2, --
+# --- distinct from a failed check) -------------------------------------------
+
+cat > "$TMPDIR_FIXTURES/no-types-line.yml" <<'EOF'
+name: Something else entirely
+on:
+  push:
+    branches: [main]
+jobs:
+  noop:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo noop
+EOF
+assert_exit "file with no types line errors distinctly" 2 "$TMPDIR_FIXTURES/no-types-line.yml"
+
+# --- A nonexistent path is also a hard error ---------------------------------
+
+assert_exit "nonexistent file errors distinctly" 2 "$TMPDIR_FIXTURES/does-not-exist.yml"
+
+# --- Substring false positives: a type name that's a substring of another  --
+# --- (there are none among these six, but 'label' vs 'labeled' is exactly --
+# --- the shape of bug this guards against) -----------------------------------
+
+label_not_labeled=$(write_fixture "label-not-labeled.yml" "opened, synchronize, reopened, label, unlabeled, edited")
+assert_exit "'label' does not satisfy the requirement for 'labeled'" 1 "$label_not_labeled"
+
+# --- The real workflow file this script exists to guard ---------------------
+
+assert_exit "the actual .github/workflows/pr-check.yml satisfies the check" 0 \
+  "$REPO_ROOT/.github/workflows/pr-check.yml"
+
+echo ""
+echo "$pass passed, $fail failed"
+if [ "$fail" -ne 0 ]; then
+  exit 1
+fi

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -9,7 +9,17 @@ on:
     # pre-label payload. 'unlabeled' re-asserts the guard when the label is
     # removed, so the bypass cannot be applied and then silently withdrawn while
     # the check still reads green.
-    types: [opened, synchronize, reopened, labeled, unlabeled]
+    #
+    # 'edited' is also required (#2159), and for the same underlying reason:
+    # reject-ci-skip-directives and reject-bad-closing-references both read
+    # PR_TITLE/PR_BODY, and neither is re-evaluated on an event type that
+    # isn't in this list. Without 'edited', a title or body change made after
+    # those two jobs already passed retriggers nothing -- the merge commit
+    # then carries whatever title/body existed at merge time, which may
+    # never have actually been checked. Do not remove this as apparent
+    # noise: check_pr_check_triggers.sh (run by the verify-trigger-list job
+    # below) fails CI if it disappears.
+    types: [opened, synchronize, reopened, labeled, unlabeled, edited]
 
 jobs:
   require-tests:
@@ -197,6 +207,33 @@ jobs:
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_BODY: ${{ github.event.pull_request.body }}
         run: bash .github/scripts/check_closing_reference.sh
+
+  verify-trigger-list:
+    name: pr-check.yml's own pull_request trigger must include 'edited'
+    runs-on: ubuntu-latest
+    # #2159: reject-ci-skip-directives and reject-bad-closing-references
+    # above both read PR_TITLE/PR_BODY, but this workflow's `pull_request`
+    # trigger only reran them on opened/synchronize/reopened/labeled/
+    # unlabeled. Editing a PR's title or body after those two jobs already
+    # passed retriggered nothing, so the squash-merge commit could carry a
+    # title/body that was never actually checked. This job is a
+    # self-referential guard: it fails CI if this workflow's own trigger
+    # list ever drops 'edited' (or one of the pre-existing required types)
+    # again, whether that's a deliberate-looking edit or an accidental one
+    # made while touching the trigger line for something unrelated.
+    #
+    # The actual check logic lives in check_pr_check_triggers.sh, extracted
+    # specifically so it's unit-tested (test_check_pr_check_triggers.sh)
+    # against synthetic fixture workflow files, not provable only by
+    # opening a real PR and editing its body after the fact.
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Run check_pr_check_triggers.sh's own unit tests
+        run: bash .github/scripts/test_check_pr_check_triggers.sh
+
+      - name: Check this workflow's own pull_request trigger list
+        run: bash .github/scripts/check_pr_check_triggers.sh
 
   # validate-coverage (docs/coverage.yaml) removed at the v1->v2 cutover: v1 tracked
   # AL-language coverage in a hand-curated YAML the orchestrator validated on every PR.


### PR DESCRIPTION
Closes #2159

## The gap

`pr-check.yml`'s `pull_request` trigger only reran on `opened`, `synchronize`, `reopened`, `labeled`, and `unlabeled`. Two of its jobs — the CI-skip-directive rejector and the closing-reference checker — read the PR title and body, but neither event type covers editing the title or body after those jobs already passed. The title/body that gets folded into the eventual squash-merge commit could be different from the one that was actually checked. #2116 and #2128 are the two real incidents this exact mechanism produced.

## Fix

Adds `edited` to the trigger's `types` list, with an inline comment explaining why it's load-bearing (matching the existing comment style for `labeled`/`unlabeled`).

## Test

The gap lives in a workflow trigger declaration, not in script logic GitHub Actions can exercise locally, so there's no way to prove "GitHub reruns the job on an edit" from this repo's own CI. What I can prove, and did:

- `.github/scripts/check_pr_check_triggers.sh` — extracts the `pull_request.types` line from a given workflow file and asserts a required set of event types is present.
- `.github/scripts/test_check_pr_check_triggers.sh` — unit-tests that extraction against synthetic fixture workflow files, two-directionally: a fixture missing `edited` fails, a fixture missing an unrelated pre-existing type (`labeled`) also fails (so this isn't just grepping for the literal string `edited`), a fixture with everything present in a different order/spacing passes, and a near-miss (`label` vs `labeled`) correctly fails. It also runs the checker against the real `.github/workflows/pr-check.yml`.
- RED: ran the test suite against the unmodified workflow file before the trigger-list edit — the real-file assertion failed as expected (script exited 1, workflow was missing `edited`).
- GREEN: after adding `edited` to the trigger, the same suite passes in full (8/8).
- Wired the checker into `pr-check.yml` itself as a new `verify-trigger-list` job, so a future edit that drops `edited` (or one of the pre-existing required types) fails CI instead of silently reopening this gap.

What this test suite does **not** prove: that GitHub Actions actually reruns a job on a `pull_request: edited` event for a live PR — that's GitHub's own documented trigger semantics, not something this repo's CI can exercise end-to-end. It proves the workflow file declares the type, and that the declaration can't silently regress.

No `AlRunner/` changes, so `require-tests`'s file-presence gate doesn't trigger for this PR; the test above is the proof regardless.