### PR TITLE
fix(shadow-runtime): stop symlinking load-by-path assemblies into the ncl-shadow dir

### DIFF
--- a/.github/workflows/bc-tests.yml
+++ b/.github/workflows/bc-tests.yml
@@ -582,7 +582,14 @@ jobs:
               -p:_BCVersion="$full" -p:AllowBcArtifactDownload=true \
               -o "./variant-build-$full"
             mkdir -p "./variants-staging/$full"
-            for f in al-runner.dll al-runner.pdb al-runner.deps.json al-runner.runtimeconfig.json; do
+            # #2166: AlRunner.QueryJoin.dll and AlRunner.Provisioning.dll are load-by-path
+            # assemblies (see NclShadowRuntime.MustCopyNames) that al-runner.dll resolves
+            # from its own directory at runtime — they must ship in every variant dir the
+            # same as the top-level "any" folder already ships them, not be left for the
+            # shadow-dir mirror to symlink in from origDir (see NclShadowRuntime.cs's
+            # #2166 comment for why relying on that symlink surviving is fragile).
+            for f in al-runner.dll al-runner.pdb al-runner.deps.json al-runner.runtimeconfig.json \
+                     AlRunner.QueryJoin.dll AlRunner.Provisioning.dll AlRunner.Provisioning.pdb; do
               cp "./variant-build-$full/$f" "./variants-staging/$full/$f"
             done
             rm -rf "./variant-build-$full"
@@ -648,3 +655,19 @@ jobs:
             echo "::error::nupkg contains $count engine variant(s), expected $expected (one per .github/bc-versions.txt entry)"
             exit 1
           fi
+
+          # #2166: variant directories are ALSO the runtime shadow-dir mirror's origDir
+          # substitute for the entry-assembly manifest set (see NclShadowRuntime), so
+          # every load-by-path assembly al-runner.dll resolves from its own directory at
+          # runtime must ship here too — not just the top-level "any" folder. This nupkg
+          # inspection is deterministic (unlike an install-and-run check, which the
+          # shadow-dir's fallback-to-origDir symlinking can mask — see the PR for #2166)
+          # and is the check that would have caught the regression in CI before release.
+          for f in AlRunner.QueryJoin.dll AlRunner.Provisioning.dll AlRunner.Provisioning.pdb; do
+            vcount=$(unzip -l ./nupkg/*.nupkg | grep -c "tools/net8.0/any/variants/.*/$f\$")
+            echo "Packed variant copies of $f: $vcount, expected: $expected"
+            if [ "$vcount" -ne "$expected" ]; then
+              echo "::error::nupkg contains $vcount variant copy/copies of $f, expected $expected (one per .github/bc-versions.txt entry) — #2166"
+              exit 1
+            fi
+          done

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -197,7 +197,14 @@ jobs:
               -p:_BCVersion="$full" -p:AllowBcArtifactDownload=true \
               -o "./variant-build-$full"
             mkdir -p "./variants-staging/$full"
-            for f in al-runner.dll al-runner.pdb al-runner.deps.json al-runner.runtimeconfig.json; do
+            # #2166: AlRunner.QueryJoin.dll and AlRunner.Provisioning.dll are load-by-path
+            # assemblies (see NclShadowRuntime.MustCopyNames) that al-runner.dll resolves
+            # from its own directory at runtime — they must ship in every variant dir the
+            # same as the top-level "any" folder already ships them, not be left for the
+            # shadow-dir mirror to symlink in from origDir (see NclShadowRuntime.cs's
+            # #2166 comment for why relying on that symlink surviving is fragile).
+            for f in al-runner.dll al-runner.pdb al-runner.deps.json al-runner.runtimeconfig.json \
+                     AlRunner.QueryJoin.dll AlRunner.Provisioning.dll AlRunner.Provisioning.pdb; do
               cp "./variant-build-$full/$f" "./variants-staging/$full/$f"
             done
             rm -rf "./variant-build-$full"

--- a/AlRunner.Tests/NclShadowRuntimeTests.cs
+++ b/AlRunner.Tests/NclShadowRuntimeTests.cs
@@ -119,6 +119,80 @@ public sealed class NclShadowRuntimeTests
         }
     }
 
+    // ─────────────────────────────────────────────────────────────────────────
+    // #2166: load-by-path assemblies (AlRunner.QueryJoin.dll, AlRunner.Provisioning.dll)
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// <summary>Positive + the #2166 regression pin: AlRunner.QueryJoin.dll and
+    /// AlRunner.Provisioning.dll must land in the shadow dir as REAL, independent copies,
+    /// not symlinks back to the original install directory.
+    ///
+    /// Before this fix they fell into the generic "every other dependency DLL" bucket
+    /// (see <see cref="MirrorInstallDirectory_OtherDependencyDll_IsSymlinkedNotCopied"/>)
+    /// and were symlinked. That happened to keep working ONLY because
+    /// <see cref="EnsureShadowDir"/>'s caller always passes the top-level "any" install
+    /// directory as origDir — which does ship both files — so the symlink target
+    /// resolved. But nothing re-validates that symlink once the shadow dir is cached:
+    /// EnsureShadowDir's "reusable" check only looks at the marker file plus the entry
+    /// assembly and Ncl.dll, never at every other file it once linked. If the file the
+    /// symlink points to is later removed from the original install (a tool
+    /// reinstall/upgrade in place, `mise`/`dotnet tool` pruning an old version, disk
+    /// cleanup) the shadow dir is still reported "reusable", and the dangling symlink
+    /// only surfaces when <c>RecordPatches.EnsureJoinExecutorLoaded</c> lazily
+    /// <c>Assembly.LoadFrom</c>s it on the FIRST multi-dataitem query JOIN test that
+    /// actually runs — reproduced empirically against the published 2.8.0 package: a
+    /// shadow dir built while the install was intact keeps working right up until the
+    /// original install's AlRunner.QueryJoin.dll is deleted, at which point every JOIN
+    /// test in that process starts failing with exactly the FileNotFoundException #2166
+    /// reports, even though nothing about the shadow dir itself changed.
+    ///
+    /// AlRunner.Provisioning.dll is resolved differently (implicit CLR probing off a
+    /// compiled-in reference, not an explicit LoadFrom — see ProvisioningCheck.cs) but
+    /// off the exact same AppContext.BaseDirectory, post-shadow-hop, so it inherits the
+    /// identical fragility and gets the identical fix.</summary>
+    [Fact]
+    public void MirrorInstallDirectory_LoadByPathAssemblies_AreRealCopiesNotSymlinks()
+    {
+        var origDir = NewTempDir("mirror-loadbypath-orig");
+        var shadowDir = NewTempDir("mirror-loadbypath-shadow");
+        try
+        {
+            var queryJoinBytes = new byte[] { 0x4D, 0x5A, 1, 2, 3 };
+            var provisioningDllBytes = new byte[] { 0x4D, 0x5A, 4, 5, 6 };
+            var provisioningPdbBytes = new byte[] { 7, 8, 9 };
+            File.WriteAllBytes(Path.Combine(origDir, "AlRunner.QueryJoin.dll"), queryJoinBytes);
+            File.WriteAllBytes(Path.Combine(origDir, "AlRunner.Provisioning.dll"), provisioningDllBytes);
+            File.WriteAllBytes(Path.Combine(origDir, "AlRunner.Provisioning.pdb"), provisioningPdbBytes);
+
+            NclShadowRuntime.MirrorInstallDirectory(origDir, shadowDir);
+
+            var shadowQueryJoin = Path.Combine(shadowDir, "AlRunner.QueryJoin.dll");
+            var shadowProvisioningDll = Path.Combine(shadowDir, "AlRunner.Provisioning.dll");
+            var shadowProvisioningPdb = Path.Combine(shadowDir, "AlRunner.Provisioning.pdb");
+
+            Assert.False(IsSymlink(shadowQueryJoin), "AlRunner.QueryJoin.dll must be a real copy, not a symlink");
+            Assert.False(IsSymlink(shadowProvisioningDll), "AlRunner.Provisioning.dll must be a real copy, not a symlink");
+            Assert.False(IsSymlink(shadowProvisioningPdb), "AlRunner.Provisioning.pdb must be a real copy, not a symlink");
+
+            // Independent inode, not just independent path: deleting the source AFTER
+            // mirroring must not take the shadow copy down with it — that is the exact
+            // failure mode #2166 reports (a dangling symlink surfacing as
+            // FileNotFoundException deep inside a lazily-loaded join test).
+            File.Delete(Path.Combine(origDir, "AlRunner.QueryJoin.dll"));
+            File.Delete(Path.Combine(origDir, "AlRunner.Provisioning.dll"));
+
+            Assert.True(File.Exists(shadowQueryJoin), "shadow copy must survive the original install's file being removed");
+            Assert.Equal(queryJoinBytes, File.ReadAllBytes(shadowQueryJoin));
+            Assert.True(File.Exists(shadowProvisioningDll), "shadow copy must survive the original install's file being removed");
+            Assert.Equal(provisioningDllBytes, File.ReadAllBytes(shadowProvisioningDll));
+        }
+        finally
+        {
+            Directory.Delete(origDir, recursive: true);
+            Directory.Delete(shadowDir, recursive: true);
+        }
+    }
+
     /// <summary>Negative (the cost-control half of the same design): every OTHER file —
     /// the large, numerous dependency DLLs that are NOT the entry assembly or its
     /// manifests — must be linked, not copied, so building/rebuilding the shadow dir

--- a/AlRunner/Infrastructure/NclShadowRuntime.cs
+++ b/AlRunner/Infrastructure/NclShadowRuntime.cs
@@ -52,10 +52,39 @@ public static class NclShadowRuntime
     // The entry assembly and the small manifests hostfxr reads to launch it — these
     // must be real, independent files in the shadow dir, not symlinks. See the comment
     // at the call site in EnsureShadowDir for why.
+    //
+    // #2166: AlRunner.QueryJoin.dll and AlRunner.Provisioning.dll join this list for a
+    // DIFFERENT reason — they are load-by-path assemblies, not entry-assembly manifests.
+    // AlRunner.QueryJoin.dll is loaded explicitly via Assembly.LoadFrom(AppContext.
+    // BaseDirectory + name) — see RecordPatches.QueryJoin.cs — lazily, on the first
+    // multi-dataitem query JOIN a test actually runs. AlRunner.Provisioning.dll is
+    // resolved implicitly by the CLR (a normal compiled-in reference, probed relative to
+    // the entry assembly's own directory) from --auto-provision / ProvisioningCheck code
+    // that runs AFTER the shadow-hop — confirmed by reading Program.cs: those call sites
+    // sit past both re-exec decision points, so they execute in whatever directory this
+    // method built.
+    //
+    // Before this fix both fell into the generic "every other dependency DLL" bucket
+    // below and were symlinked back to origDir. That happened to keep working ONLY
+    // because EnsureShadowDir's caller always passes the top-level "tools/.../any"
+    // install directory as origDir, which does ship both files — so the symlink target
+    // resolved. But nothing re-validates that symlink once the shadow dir is cached:
+    // EnsureShadowDir's "reusable" check only looks at the marker file plus the entry
+    // assembly and Ncl.dll, never at the rest of what it once linked. If the file a
+    // symlink points to is later removed from the original install — a tool reinstall/
+    // upgrade in place, `mise`/`dotnet tool` pruning an old version, disk cleanup — the
+    // shadow dir is still reported "reusable", and the dangling symlink only surfaces
+    // the next time something tries to load it. For AlRunner.QueryJoin.dll that is
+    // deep inside the FIRST join test that happens to run, long after the shadow dir was
+    // validated — reproduced empirically: deleting the original install's copy of
+    // AlRunner.QueryJoin.dll out from under an already-built, already-"reusable" shadow
+    // dir reliably reproduces the exact FileNotFoundException #2166 reports. A real,
+    // independent copy at shadow-build time removes the dependency on origDir surviving.
     private static readonly string[] MustCopyNames =
     {
         "al-runner.dll", "al-runner.pdb", "al-runner.deps.json",
         "al-runner.runtimeconfig.json", "al-runner.runtimeconfig.dev.json",
+        "AlRunner.QueryJoin.dll", "AlRunner.Provisioning.dll", "AlRunner.Provisioning.pdb",
     };
 
     private static bool MustBeRealCopy(string fileName) =>


### PR DESCRIPTION
Closes #2166

## What was wrong

`AlRunner.QueryJoin.dll` (loaded via `Assembly.LoadFrom` — `RecordPatches.QueryJoin.cs`) and `AlRunner.Provisioning.dll` (resolved implicitly by the CLR off a compiled-in reference, from `--auto-provision`/`ProvisioningCheck` code that runs *after* the shadow-hop) are both load-by-path assemblies resolved from the running process's own directory. `NclShadowRuntime.MirrorInstallDirectory` put them in the generic "every other dependency DLL" bucket, which symlinks back to the original install directory (`origDir`) instead of copying.

Per-BC-minor engine variant directories (`tools/net8.0/any/variants/<build>/`) don't ship these two files at all — confirmed directly from the published 2.8.0 nupkg (only `al-runner.dll`/`.pdb`/`.deps.json`/`.runtimeconfig.json` per variant). That packaging gap is real, but on a plain `dotnet tool install` + direct invocation it's fully masked: `EnsureShadowDir`'s caller always passes the top-level "any" directory as `origDir`, and that directory *does* ship both files, so the symlink resolves.

## Root cause (the part the masking hides)

`EnsureShadowDir`'s "reusable" cache check only verifies the marker file, the entry assembly, and `Ncl.dll` — it never re-validates the other symlinks a shadow dir once built. If the file a symlink points to is later removed from the original install (a tool reinstall/upgrade in place, `mise`/`dotnet tool` pruning an old version, disk cleanup), the shadow dir is still reported "reusable", and the dangling symlink only surfaces the next time something tries to load it. For `AlRunner.QueryJoin.dll` that's deep inside the *first* multi-dataitem query JOIN test that actually runs — long after the shadow dir was already validated.

I reproduced this exactly against the published 2.8.0 package: built a shadow dir with an intact install (join tests pass), then deleted the original install's `AlRunner.QueryJoin.dll` and reran the same filtered test — every JOIN test failed with the identical `FileNotFoundException` and classification (`runtime/Runtime.DataAccessSource.GetDataAccessForQuery`) the issue reports. A plain `dotnet tool install --tool-path ./tools` + immediate run (no reinstall, no deletion) did **not** reproduce it on this machine — the masking held. I could not pin down the exact real-world trigger that strips the file from an intact install without deleting anything myself, but the defect (an un-revalidated symlink to a file that can legitimately disappear over a tool's lifetime) is real and independent of how it gets triggered.

## Fix

1. **Runtime**: `AlRunner.QueryJoin.dll`, `AlRunner.Provisioning.dll`, `AlRunner.Provisioning.pdb` join `NclShadowRuntime.MustCopyNames` — real, independent copies at shadow-build time, immune to the original install changing afterward.
2. **Packaging**: both `.github/workflows/bc-tests.yml` and `publish.yml`'s "Build each BC-minor engine variant" steps now stage these files into every variant directory (verified against a real `dotnet pack` locally — all three now land in `tools/net8.0/any/variants/<build>/`).
3. **CI check**: the pack job's "Assert every BC-minor engine variant made it into the package" step now also asserts a matching count of `AlRunner.QueryJoin.dll`/`AlRunner.Provisioning.dll`/`.pdb` across variant directories — deterministic, independent of the shadow-dir masking that hid the runtime symptom.

## Tests

- `AlRunner.Tests/NclShadowRuntimeTests.cs`: new `MirrorInstallDirectory_LoadByPathAssemblies_AreRealCopiesNotSymlinks` — RED before the fix (symlinked, asserted with `Assert.False(IsSymlink(...))`), GREEN after. Also proves the shadow copy survives the original being deleted, which is the actual failure mode.
- Verified against a real `dotnet pack` (not just the unit test): built one variant locally with `EngineVariantsStagingDir`, packed it, confirmed `unzip -l` shows all three files under the variant path.
- Installed the freshly-packed nupkg and re-ran the exact dangling-symlink repro above against it — the join tests kept passing after deleting the original install's copies, because the shadow dir's own copies are now independent.
- `dotnet test AlRunner.Tests -c Release`: 1050 passed, 0 failed, 60 skipped (pre-existing, engine-collection tests that need the startup-hook harness this invocation doesn't set up).

## Fix-the-shape check

1. **Same wrong pattern elsewhere?** Yes — `AlRunner/Win32Stubs.cs` resolves its prebuilt `.so`/`.c` shim from `AppContext.BaseDirectory` just as lazily (only when AL test code reaches a Windows-only Win32 API), and the `Win32Stubs/` directory has the identical gap: shipped at the top level, absent from variant directories, currently masked by `MirrorInstallDirectory`'s generic directory-symlink path. Filed as a separate follow-up, #2168, rather than folding in here — fixing it needs the must-copy path to become directory-aware (`CopyDirectoryRecursive` vs `File.Copy`), which is a distinct, slightly larger change with its own regression risk against the existing "other directories stay symlinked" test.
2. **Sibling function, same assumption?** Checked `BcAssembler.cs` and `RunnerFingerprint.cs`, which also read `typeof(...).Assembly.Location` — both refer to `al-runner.dll` itself, already in `MustCopyNames`, so no gap there.
3. **Two paths, same invariant?** N/A here — there's one path (`MirrorInstallDirectory`) building the shadow dir; the packaging side (bc-tests.yml vs publish.yml) is two independent copies of the same staging loop (pre-existing duplication, not introduced by this PR) and I updated both identically.
