### PR TITLE
docs(rules): settle a claim about BC by asking the corpus CI, not by reading

### DIFF
--- a/.claude/rules/al-language-submodule.md
+++ b/.claude/rules/al-language-submodule.md
@@ -56,6 +56,9 @@ so a real service tier can adjudicate it. See
 
 ## Sister rules
 
+- `ask-the-corpus-before-claiming-bc-behavior.md` — a corpus test green on real BC is
+  evidence; never declare an `expect-fail-known-gap` for one, and never propose
+  inverting one upstream
 - `bc-behavior-tests-go-upstream.md` — which repo a new test belongs in, and why
 - `precompiled-dll-respect.md` — what we may not rewrite in BC DLLs
 - `loud-failures.md` — when to throw `RunnerOutOfScopeException`

--- a/.claude/rules/ask-the-corpus-before-claiming-bc-behavior.md
+++ b/.claude/rules/ask-the-corpus-before-claiming-bc-behavior.md
@@ -1,0 +1,77 @@
+# Settle a claim about BC by asking the corpus CI, not by reading the corpus
+
+`bc-behavior-tests-go-upstream.md` says where a **test** about BC's behavior must
+live. This rule is about a **claim**: before you change runner behavior because you
+believe BC does X, find out whether a real service tier has already answered it.
+
+It usually has. The al-language corpus runs on real BC on every push, and its CI log
+prints a PASS/FAIL line per test per BC version. That log is a measurement. Reading
+the AL and deciding what BC "must" do is not.
+
+## The check
+
+```bash
+# newest corpus runs
+gh run list --repo StefanMaron/BusinessCentral.AL.Language.Tests --limit 5 \
+  --json databaseId,conclusion,createdAt --jq '.[]|"\(.databaseId) \(.conclusion) \(.createdAt)"'
+
+# what real BC did with the tests you care about
+gh run view <run-id> --repo StefanMaron/BusinessCentral.AL.Language.Tests --log \
+  | grep -E "<TestName1>|<TestName2>"
+```
+
+If no corpus test covers the shape, write one and let the corpus CI adjudicate — that
+is step 2 of the workflow in `bc-behavior-tests-go-upstream.md`, and it takes minutes,
+not a local container.
+
+## What outranks what
+
+A corpus test green on a real service tier beats, in this order, every one of:
+
+- reading the AL and reasoning about what the platform must do,
+- a differential measured through a harness against a BC container,
+- Microsoft's documentation,
+- the name of a BC codeunit, or a comment naming one.
+
+That order is not theoretical. In #2144 a container differential said
+`TestIsolation = Codeunit` rolls the database back per test; Microsoft's
+documentation said per codeunit; the corpus test agreed with the documentation and
+the container measurement was an artifact of a harness that invoked tests one at a
+time and could not tell a platform rollback from a new transaction. The same change
+cited a codeunit 130452 "Test Runner - Isol. Test" that does not exist — 130452 is
+"Test Runner - Get Methods". A name is not evidence.
+
+## Two green corpus tests never contradict each other
+
+If two corpus tests look like they assert opposite things about the same AL shape and
+both pass upstream, the shape is not the same and you have not found the distinction
+yet. That is a fact about your reading, not about the corpus.
+
+In #2170 three tests looked identical — uncommitted `Insert`, unrelated `asserterror`,
+then a read — and were read as contradictory. All three pass on BC 27.5 and 28.3.
+
+So:
+
+- **Never write an `expect-fail-known-gap` entry for a test that is green upstream.**
+  That records a runner defect as though it were a corpus defect, and
+  `docs/expectations.md` gives the mode a meaning it does not have here.
+- **Never propose inverting an upstream assertion that is green on a service tier.**
+  A PR into the corpus that flips a passing test is asking a service tier to disagree
+  with itself.
+- Name the mechanism you found, not the symptom you could not explain.
+
+## When no verdict is available
+
+Say so plainly, name what would settle it, and land the runner change with whatever
+coverage is legitimately available — the escape hatch in
+`bc-behavior-tests-go-upstream.md` applies here too. What is not acceptable is
+substituting confident reasoning for the measurement and writing it into a comment,
+a doc table, or an issue as though it were established.
+
+## Sister rules
+
+- `bc-behavior-tests-go-upstream.md` — where a BC-behavior test must live, and how to
+  get a verdict out of the corpus CI
+- `no-assumption-fixes.md` — understand the AL pattern before patching
+- `al-language-submodule.md` — the corpus is read-only here; how to bump the pin
+- `file-issues-for-gaps.md` — gaps get tracked, never silently worked around

--- a/.claude/rules/bc-behavior-tests-go-upstream.md
+++ b/.claude/rules/bc-behavior-tests-go-upstream.md
@@ -68,6 +68,9 @@ may not be provable yet, which is information the reviewer needs.
 
 ## Sister rules
 
+- `ask-the-corpus-before-claiming-bc-behavior.md` — before you act on a belief
+  about what BC does, read the corpus CI's verdict; a green corpus test outranks
+  reading, a container differential, the docs, and a codeunit's name
 - `al-language-submodule.md` — the corpus is read-only here; how to bump the pin
 - `tdd.md` — every fix needs a RED → GREEN, and tests must prove, not just pass
 - `no-assumption-fixes.md` — understand the AL pattern before patching

--- a/.claude/rules/no-assumption-fixes.md
+++ b/.claude/rules/no-assumption-fixes.md
@@ -12,3 +12,8 @@ If the issue body or telemetry payload is too thin to identify the root cause �
 **Why:** assumption-based "fixes" produce ghost tests that pass against a wrong mental model. The patch ships green, the real bug stays, and the test suite gains noise. This has happened before — apply the rule strictly.
 
 **Triggers:** any time an impl agent picks up an issue from telemetry, `coverage-gap`, or auto-generated reports and the body lacks a concrete reproducer.
+
+## Sister rules
+
+- `ask-the-corpus-before-claiming-bc-behavior.md` — the same discipline for a claim
+  about BC's behavior: the corpus CI has probably already measured it

--- a/AlRunner.Tests/RuleCrossReferenceTests.cs
+++ b/AlRunner.Tests/RuleCrossReferenceTests.cs
@@ -1,0 +1,119 @@
+using System.Linq;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// The rules in .claude/rules/ are auto-loaded and cross-reference each other by
+/// filename, mostly under a "Sister rules" heading. Nothing validated those
+/// references, so a rule renamed or deleted left dangling pointers in every file
+/// that named it — and an agent following a pointer to a file that does not exist
+/// gets nothing, silently, exactly when it was trying to find the constraint that
+/// applies to what it is about to do.
+///
+/// #2171 added a rule with four such references, which is what surfaced the gap.
+/// This pins every reference in the whole directory, not just that file's.
+/// </summary>
+public sealed class RuleCrossReferenceTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+
+    private static string RulesDir => Path.Combine(RepoRoot, ".claude", "rules");
+
+    // Matches a bare rule filename in backticks, e.g. `no-assumption-fixes.md`, and
+    // the markdown-link form used in a few files, e.g. [`tdd.md`](tdd.md). Both are
+    // pointers an agent is expected to be able to follow.
+    private static readonly Regex RuleRefRx = new(
+        @"`(?<name>[a-z0-9][a-z0-9._-]*\.md)`", RegexOptions.Compiled);
+
+    [Fact]
+    public void EveryRuleFileCrossReferenceNamesAFileThatExists()
+    {
+        Assert.True(Directory.Exists(RulesDir), $"rules directory not found: {RulesDir}");
+
+        var ruleFiles = Directory.GetFiles(RulesDir, "*.md").OrderBy(f => f).ToList();
+        Assert.NotEmpty(ruleFiles);
+
+        // Names that live outside .claude/rules/ but are legitimately referenced from
+        // inside it. Anything not in this set must resolve to a real rule file.
+        var knownOutsideRules = new HashSet<string>(StringComparer.Ordinal)
+        {
+            "README.md",
+            "CHANGELOG.md",
+            "CLAUDE.md",
+            "app.json",
+        };
+
+        var present = new HashSet<string>(
+            ruleFiles.Select(Path.GetFileName)!, StringComparer.Ordinal);
+
+        var dangling = new List<string>();
+        foreach (var file in ruleFiles)
+        {
+            var text = File.ReadAllText(file);
+            foreach (Match m in RuleRefRx.Matches(text))
+            {
+                var name = m.Groups["name"].Value;
+                if (knownOutsideRules.Contains(name)) continue;
+                // A path-qualified reference (docs/expectations.md, ../../tests/...)
+                // points outside this directory on purpose; only bare names are
+                // claims about a sibling rule.
+                if (name.Contains('/')) continue;
+                if (!present.Contains(name))
+                    dangling.Add($"{Path.GetFileName(file)} -> {name}");
+            }
+        }
+
+        Assert.True(
+            dangling.Count == 0,
+            "rule files reference sibling rules that do not exist:\n  " +
+            string.Join("\n  ", dangling.Distinct().OrderBy(s => s)));
+    }
+
+    /// <summary>
+    /// Negative direction: the check above must actually fail on a dangling
+    /// reference. Without this, a regex that silently matches nothing would make
+    /// the test vacuously green forever.
+    /// </summary>
+    [Fact]
+    public void TheCrossReferenceCheckRejectsANameThatDoesNotResolve()
+    {
+        var present = new HashSet<string>(
+            Directory.GetFiles(RulesDir, "*.md").Select(Path.GetFileName)!,
+            StringComparer.Ordinal);
+
+        const string sample = "See `no-assumption-fixes.md` and `this-rule-does-not-exist.md`.";
+        var names = RuleRefRx.Matches(sample).Select(m => m.Groups["name"].Value).ToList();
+
+        Assert.Equal(
+            new[] { "no-assumption-fixes.md", "this-rule-does-not-exist.md" }, names);
+        Assert.Contains("no-assumption-fixes.md", present);
+        Assert.DoesNotContain("this-rule-does-not-exist.md", present);
+    }
+
+    /// <summary>
+    /// The rule #2171 adds is only useful if it is discoverable from the rules an
+    /// agent is already reading when the question comes up. Pin those three
+    /// entry points so a future edit cannot quietly orphan it.
+    /// </summary>
+    [Fact]
+    public void TheAskTheCorpusRuleIsReachableFromItsSisterRules()
+    {
+        const string target = "ask-the-corpus-before-claiming-bc-behavior.md";
+        Assert.True(File.Exists(Path.Combine(RulesDir, target)), $"{target} is missing");
+
+        foreach (var sister in new[]
+                 {
+                     "bc-behavior-tests-go-upstream.md",
+                     "no-assumption-fixes.md",
+                     "al-language-submodule.md",
+                 })
+        {
+            var path = Path.Combine(RulesDir, sister);
+            Assert.True(File.Exists(path), $"{sister} is missing");
+            Assert.Contains(target, File.ReadAllText(path));
+        }
+    }
+}


### PR DESCRIPTION
Closes #2171

Two incidents in one day had the same shape: read the AL, decide what BC must do, act on it — while a real service tier was already running those exact tests and disagreed.

- **#2144** changed the default isolation mode believing BC's 130450 rolls the database back per test. The evidence was a container differential plus reasoning about codeunit names, and it cited a codeunit 130452 "Test Runner - Isol. Test" that does not exist. It shipped, and 20 corpus tests were declared known gaps to accommodate it. #2160 reverted it after one corpus test measured the answer.
- **#2170** concluded the corpus contradicts itself and added `expect-fail-known-gap` entries for two tests it judged stale, plus a public issue proposing to invert them upstream. All three tests in question pass on real BC 27.5 and 28.3.

Both were answerable from the corpus CI log, which prints a PASS/FAIL line per test per BC version on every run. The new rule gives that command and states:

- a corpus test green on a real service tier outranks reading the AL, a container differential, Microsoft's documentation, and a codeunit's name — in #2144 the documentation was right and the measurement was the artifact;
- two green corpus tests never contradict each other, so a distinction you have not found is not a corpus bug;
- never write an `expect-fail-known-gap` for a test green upstream, and never propose inverting an upstream assertion that passes on a service tier;
- when no verdict is available, say so and name what would settle it.

## The validator

While cross-linking the new rule from its three sister rules I found nothing validated those pointers. A renamed or deleted rule leaves dangling references that fail silently — at exactly the moment an agent is following one to find the constraint that applies to what it is about to do.

`AlRunner.Tests/RuleCrossReferenceTests.cs` checks every backticked `*.md` reference in `.claude/rules/` resolves to a real sibling, with a negative test so the regex cannot go vacuously green, and a third test pinning the new rule's three entry points so a future edit cannot orphan it.

RED → GREEN: appending a reference to a nonexistent rule makes the check fail and name it (`Failed: 1, Passed: 2`); with it removed, `Passed: 3`.

## What this does not prove

That agents will follow the rule. It records the two incidents so the next person to reach for "BC must do X" has the command that settles it, and it makes one specific failure — a known-gap entry for an upstream-green test — a thing the rule names explicitly rather than something to re-derive.