### PR TITLE
docs(rules): correct what an expect-fail-known-gap entry may rest on

### DIFF
--- a/.claude/rules/al-language-submodule.md
+++ b/.claude/rules/al-language-submodule.md
@@ -57,8 +57,8 @@ so a real service tier can adjudicate it. See
 ## Sister rules
 
 - `ask-the-corpus-before-claiming-bc-behavior.md` — a corpus test green on real BC is
-  evidence; never declare an `expect-fail-known-gap` for one, and never propose
-  inverting one upstream
+  evidence; what a known-gap entry may rest on, and never propose inverting a green
+  upstream assertion
 - `bc-behavior-tests-go-upstream.md` — which repo a new test belongs in, and why
 - `precompiled-dll-respect.md` — what we may not rewrite in BC DLLs
 - `loud-failures.md` — when to throw `RunnerOutOfScopeException`

--- a/.claude/rules/ask-the-corpus-before-claiming-bc-behavior.md
+++ b/.claude/rules/ask-the-corpus-before-claiming-bc-behavior.md
@@ -52,13 +52,33 @@ then a read — and were read as contradictory. All three pass on BC 27.5 and 28
 
 So:
 
-- **Never write an `expect-fail-known-gap` entry for a test that is green upstream.**
-  That records a runner defect as though it were a corpus defect, and
-  `docs/expectations.md` gives the mode a meaning it does not have here.
 - **Never propose inverting an upstream assertion that is green on a service tier.**
   A PR into the corpus that flips a passing test is asking a service tier to disagree
   with itself.
 - Name the mechanism you found, not the symptom you could not explain.
+
+## What an `expect-fail-known-gap` entry may and may not rest on
+
+An earlier version of this rule said never to declare a known gap for a test that is
+green upstream. That was wrong, and it contradicted `docs/expectations.md`: every test
+in the corpus passes on real BC by construction, so *every* known-gap entry is for a
+test green upstream. The mode means exactly "the surface is in scope, real BC does it,
+the runner does not do it yet, and `Issue` tracks the work."
+
+What the two incidents actually got wrong was the **justification**, not the mode:
+
+- **Do not declare a known gap for a failure your own change just introduced.** In
+  #2144 the 20 entries existed only because the same PR had changed the default
+  isolation mode in a way real BC does not; reverting the change made all 20 pass. The
+  fix for a self-inflicted failure is to revert it, not to classify it.
+- **Do not declare a known gap on the strength of an unmeasured claim about BC.** In
+  #2170 the entries were justified by "the corpus contradicts itself," which the corpus
+  CI falsified. An entry whose `Note` asserts something about BC that no service tier
+  has confirmed is a guess wearing a schema.
+
+A known-gap entry is honest when it says: real BC passes this, the runner does not yet,
+here is the issue. It is dishonest when it converts a live question, or a
+self-inflicted regression, into settled classification.
 
 ## When no verdict is available
 


### PR DESCRIPTION
Closes #2173

#2172 added the corpus-verdict rule an hour ago and one of its bullets is wrong:

> Never write an `expect-fail-known-gap` entry for a test that is green upstream.

`docs/expectations.md` defines that mode as "surface is in scope but not yet implemented; `Issue` tracks the work". Every test in the corpus passes on real BC by construction, so every known-gap entry is necessarily for a test green upstream. The bullet forbade the mode's only legitimate use, in a file that auto-loads and reads as settled.

## What the incidents actually got wrong

The justification, not the mode — a narrower and more useful claim:

- **#2144** — the 20 entries existed only because the same PR had changed the default isolation mode in a way real BC does not. Reverting made all 20 pass. The fix for a self-inflicted failure is to revert it, not classify it.
- **#2170** — the entries rested on "the corpus contradicts itself", which the corpus CI falsified. An entry whose `Note` asserts something about BC that no service tier has confirmed is a guess wearing a schema.

The new section states both, and keeps the bullet that was right: never propose inverting an assertion that is green on a service tier.

## Note on how this happened

I wrote a rule about not acting on unverified claims, and did not verify it against `docs/expectations.md` — the authoritative reference for the schema it was describing, one command away. The rule's own subject matter is the thing it got wrong.