### PR TITLE
test(perf): record StartupOutputReexecDedupTests' measured weight

### DIFF
--- a/AlRunner.Tests/CollectionCostOrderer.cs
+++ b/AlRunner.Tests/CollectionCostOrderer.cs
@@ -61,6 +61,16 @@
 // dispatched at t=383 s and t=400 s of a 581 s run — a tail on every leg, silently, until
 // someone read a TRX occupancy report by hand.
 //
+// #2175: which number to record when a collection measures differently on every leg.
+// ProvisionExplicitModesTests says round DOWN to the low end, and that is right when the
+// low end still sits well above UnmeasuredWeightSeconds (its low end was 80). It is wrong
+// when the low end is at or near the fallback: StartupOutputReexecDedupTests measured
+// 31.8 s to 61.2 s across eight legs, so recording 31 would have silenced
+// check-collection-weights.py while leaving dispatch order identical to being absent —
+// satisfying the gate without addressing the tail it exists to catch. Record the observed
+// MAXIMUM in that case. The rule is: whichever end you pick, the recorded value must
+// change dispatch order relative to the fallback, or the entry is decoration.
+//
 // scripts/check-collection-weights.py is the loud guard that replaces "someone reads it by
 // hand": run against the same trx/unit-tests.trx the occupancy report already parses, it
 // fails CI when a collection above 2x UnmeasuredWeightSeconds is absent from this table —
@@ -119,6 +129,15 @@ public sealed class CollectionCostOrderer : ITestCollectionOrderer
             // producing a 73s single-threaded tail (it is 3rd-heaviest at ~196s of serial
             // work; see the file header and issue #1887 for the measured timeline).
             ["InstallSeedDepCompanyCacheTests"] = 196,
+            // #2175: measured 31.8s (28.2) to 61.2s (27.5) across the eight legs of one
+            // run — it crosses the 60s freshness threshold only under load, so it failed
+            // whichever leg happened to be slow while being absent here. The low-end rule
+            // ProvisionExplicitModesTests documents does NOT apply: its low end was 80,
+            // comfortably above the fallback, whereas 31 is one second above
+            // UnmeasuredWeightSeconds — rounding down would satisfy check-collection-weights.py
+            // while leaving dispatch order exactly as it was, which is the tail the gate
+            // exists to prevent. Carry the observed maximum instead.
+            ["StartupOutputReexecDedupTests"] = 61,
             ["TestFilterFlagTests"] = 99,
             ["PhaseLogIntegrationTests"] = 85,
             // #1922: 6 tests, each spawning a real runner subprocess against an AL fixture


### PR DESCRIPTION
Closes #2175

`check-collection-weights.py` failed the BC 27.5 leg of #2174 — a two-file markdown change that cannot affect test runtime. The collection cost 61.2s on that leg and is absent from `MeasuredWeightSeconds`.

Across the eight legs of that single run:

| Leg | Seconds |
|---|---|
| 28.2 | 31.8 |
| 28.0 | 40.2 |
| 27.0 | 47.7 |
| 27.3 | 52.7 |
| 28.4 | 53.4 |
| 28.3 | 53.9 |
| 28.1 | 54.5 |
| 27.5 | **61.2** |

It sits under the 60s freshness threshold most of the time and crosses it under load, so it can fail any PR on whichever leg happens to be slow. And absent from the table it falls back to `UnmeasuredWeightSeconds` (30s) and gets dispatched as though it were cheap — the #1887 tail pattern, on exactly the runs where it is not cheap.

## Why 61 and not the low end

`ProvisionExplicitModesTests` documents rounding down to the low end of a varying measurement. That is right when the low end still sits well above the fallback — its low end was 80. Here the low end is 31, one second above `UnmeasuredWeightSeconds`, so rounding down would satisfy `check-collection-weights.py` while leaving dispatch order exactly as it was when the entry was missing. That silences the gate without addressing the tail the gate exists to catch.

The file header now records the general rule rather than leaving the next person to re-derive it: whichever end you pick, the recorded value has to change dispatch order relative to the fallback, or the entry is decoration.