### PR TITLE
fix(shadow-runtime): copy Win32Stubs/ into the ncl-shadow dir, don't symlink it

### DIFF
--- a/.github/workflows/bc-tests.yml
+++ b/.github/workflows/bc-tests.yml
@@ -592,6 +592,11 @@ jobs:
                      AlRunner.QueryJoin.dll AlRunner.Provisioning.dll AlRunner.Provisioning.pdb; do
               cp "./variant-build-$full/$f" "./variants-staging/$full/$f"
             done
+            # #2168: Win32Stubs/ is the directory-shaped equivalent of the same gap —
+            # Win32Stubs.LocatePrebuiltSo resolves the prebuilt Linux Win32 P/Invoke shim
+            # from AppContext.BaseDirectory/Win32Stubs/ at runtime, so it must ship in
+            # every variant dir too (see NclShadowRuntime.MustCopyDirectoryNames).
+            cp -r "./variant-build-$full/Win32Stubs" "./variants-staging/$full/Win32Stubs"
             rm -rf "./variant-build-$full"
           done
           echo "Staged variants:"
@@ -668,6 +673,24 @@ jobs:
             echo "Packed variant copies of $f: $vcount, expected: $expected"
             if [ "$vcount" -ne "$expected" ]; then
               echo "::error::nupkg contains $vcount variant copy/copies of $f, expected $expected (one per .github/bc-versions.txt entry) — #2166"
+              exit 1
+            fi
+          done
+
+          # #2168: Win32Stubs/ has the identical unpackaged-per-variant fragility, just
+          # as a directory rather than a single file — Win32Stubs.LocatePrebuiltSo
+          # resolves the prebuilt Linux Win32 P/Invoke shim from
+          # AppContext.BaseDirectory/Win32Stubs/<rid-named .so> at runtime (lazily, the
+          # first time AL test code reaches a Windows-only Win32 API through BC's
+          # runtime), and the shadow-dir mirror's fallback-to-origDir directory symlink
+          # masks a missing per-variant copy the same way it masked #2166 — so this is a
+          # deterministic nupkg inspection, not an install-and-run check, same reasoning
+          # as the loop above.
+          for f in win32_stubs.c libwin32_stubs.linux-x64.so libwin32_stubs.linux-arm64.so; do
+            vcount=$(unzip -l ./nupkg/*.nupkg | grep -c "tools/net8.0/any/variants/.*/Win32Stubs/$f\$")
+            echo "Packed variant copies of Win32Stubs/$f: $vcount, expected: $expected"
+            if [ "$vcount" -ne "$expected" ]; then
+              echo "::error::nupkg contains $vcount variant copy/copies of Win32Stubs/$f, expected $expected (one per .github/bc-versions.txt entry) — #2168"
               exit 1
             fi
           done

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -207,6 +207,11 @@ jobs:
                      AlRunner.QueryJoin.dll AlRunner.Provisioning.dll AlRunner.Provisioning.pdb; do
               cp "./variant-build-$full/$f" "./variants-staging/$full/$f"
             done
+            # #2168: Win32Stubs/ is the directory-shaped equivalent of the same gap —
+            # Win32Stubs.LocatePrebuiltSo resolves the prebuilt Linux Win32 P/Invoke shim
+            # from AppContext.BaseDirectory/Win32Stubs/ at runtime, so it must ship in
+            # every variant dir too (see NclShadowRuntime.MustCopyDirectoryNames).
+            cp -r "./variant-build-$full/Win32Stubs" "./variants-staging/$full/Win32Stubs"
             rm -rf "./variant-build-$full"
           done
           echo "Staged variants:"

--- a/AlRunner.Tests/NclShadowRuntimeTests.cs
+++ b/AlRunner.Tests/NclShadowRuntimeTests.cs
@@ -223,6 +223,100 @@ public sealed class NclShadowRuntimeTests
         }
     }
 
+    // ─────────────────────────────────────────────────────────────────────────
+    // #2168: Win32Stubs/ — a load-by-path DIRECTORY, not a single file
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// <summary>Positive + the #2168 regression pin: <c>Win32Stubs/</c> (the prebuilt
+    /// Linux P/Invoke shim <c>Win32Stubs.LocatePrebuiltSo</c> resolves via
+    /// <c>Path.Combine(AppContext.BaseDirectory, "Win32Stubs", ...)</c>, lazily, the first
+    /// time AL test code reaches a Windows-only Win32 API through BC's runtime — see
+    /// Win32Stubs.cs) must land in the shadow dir as a REAL, independent copy, not a
+    /// directory symlink back to the original install.
+    ///
+    /// Identical shape to <see cref="MirrorInstallDirectory_LoadByPathAssemblies_AreRealCopiesNotSymlinks"/>
+    /// (#2166), except the load-by-path entry here is a DIRECTORY: before this fix it fell
+    /// into the generic "every other entry" bucket (see
+    /// <see cref="MirrorInstallDirectory_OtherDependencyDll_IsSymlinkedNotCopied"/>) and
+    /// <see cref="LinkOrCopy"/> symlinked the whole directory. That only kept working
+    /// because <see cref="EnsureShadowDir"/>'s caller always passes the top-level "any"
+    /// install directory as origDir, which does ship <c>Win32Stubs/</c> — so the symlink
+    /// target resolved. Per-BC-minor engine variant directories do NOT ship their own
+    /// <c>Win32Stubs/</c> (confirmed from the published nupkg), and nothing re-validates
+    /// the symlink once the shadow dir is cached "reusable" — if the original install's
+    /// <c>Win32Stubs/</c> is later removed (tool reinstall/upgrade in place, pruning an
+    /// old version), the dangling symlink only surfaces the first time AL test code
+    /// actually reaches a Win32 API, deep inside <c>Win32Stubs.GetOrBuild</c>.</summary>
+    [Fact]
+    public void MirrorInstallDirectory_Win32StubsDirectory_IsRealCopyNotSymlink()
+    {
+        var origDir = NewTempDir("mirror-win32stubs-orig");
+        var shadowDir = NewTempDir("mirror-win32stubs-shadow");
+        try
+        {
+            var win32Dir = Path.Combine(origDir, "Win32Stubs");
+            Directory.CreateDirectory(win32Dir);
+            var soBytes = new byte[] { 0x7f, 0x45, 0x4c, 0x46, 1, 2, 3 };
+            File.WriteAllBytes(Path.Combine(win32Dir, "libwin32_stubs.linux-x64.so"), soBytes);
+            File.WriteAllText(Path.Combine(win32Dir, "win32_stubs.c"), "int main(void) { return 0; }");
+
+            NclShadowRuntime.MirrorInstallDirectory(origDir, shadowDir);
+
+            var shadowWin32Dir = Path.Combine(shadowDir, "Win32Stubs");
+            var shadowSo = Path.Combine(shadowWin32Dir, "libwin32_stubs.linux-x64.so");
+            var shadowC = Path.Combine(shadowWin32Dir, "win32_stubs.c");
+
+            Assert.False(IsSymlink(shadowWin32Dir), "Win32Stubs must be a real copy of the directory, not a directory symlink");
+            Assert.True(File.Exists(shadowSo));
+            Assert.Equal(soBytes, File.ReadAllBytes(shadowSo));
+            Assert.Equal("int main(void) { return 0; }", File.ReadAllText(shadowC));
+
+            // Independent inode, not just independent path: removing the ENTIRE original
+            // directory after mirroring must not take the shadow copy down with it — the
+            // exact failure mode #2168 reports (a dangling directory symlink surfacing as
+            // a Win32Stubs.GetOrBuild failure deep inside the first AL test that reaches a
+            // Windows-only Win32 API).
+            Directory.Delete(win32Dir, recursive: true);
+
+            Assert.True(File.Exists(shadowSo), "shadow copy of Win32Stubs must survive the original install's directory being removed");
+            Assert.Equal(soBytes, File.ReadAllBytes(shadowSo));
+        }
+        finally
+        {
+            if (Directory.Exists(origDir)) Directory.Delete(origDir, recursive: true);
+            Directory.Delete(shadowDir, recursive: true);
+        }
+    }
+
+    /// <summary>Negative (the cost-control half, mirroring
+    /// <see cref="MirrorInstallDirectory_OtherDependencyDll_IsSymlinkedNotCopied"/> but for
+    /// a directory): a directory that is NOT <c>Win32Stubs/</c> must still be linked, not
+    /// copied, so the general "other directories stay symlinked" contract from
+    /// <see cref="MirrorInstallDirectory_Subdirectory_IsMirroredAndReachable"/> doesn't
+    /// regress into "every directory is now a real copy".</summary>
+    [Fact]
+    public void MirrorInstallDirectory_NonWin32StubsDirectory_StillSymlinked()
+    {
+        var origDir = NewTempDir("mirror-other-dir-orig");
+        var shadowDir = NewTempDir("mirror-other-dir-shadow");
+        try
+        {
+            var subDir = Path.Combine(origDir, "cs");
+            Directory.CreateDirectory(subDir);
+            File.WriteAllText(Path.Combine(subDir, "al-runner.resources.dll"), "fake satellite resource");
+
+            NclShadowRuntime.MirrorInstallDirectory(origDir, shadowDir);
+
+            var shadowSubDir = Path.Combine(shadowDir, "cs");
+            Assert.True(IsSymlink(shadowSubDir), "non-Win32Stubs directories should still be symlinked for near-zero cost");
+        }
+        finally
+        {
+            Directory.Delete(origDir, recursive: true);
+            Directory.Delete(shadowDir, recursive: true);
+        }
+    }
+
     /// <summary>Positive: a subdirectory (e.g. a satellite-resource culture folder, or
     /// runtimes/) is mirrored too, as a directory symlink, and its content is reachable
     /// through it.</summary>

--- a/AlRunner/AlRunner.csproj
+++ b/AlRunner/AlRunner.csproj
@@ -106,9 +106,12 @@
        -p:_BCVersion=<full-build>` per .github/bc-versions.txt entry (including the one
        this csproj itself was built with — see the pack job for why that duplication is
        deliberate, not wasted), each copied to
-       $(EngineVariantsStagingDir)/<full-build>/{al-runner.dll,.pdb,.deps.json,.runtimeconfig.json}.
-       %(RecursiveDir) reproduces that per-version subfolder under variants/ in the
-       packed nupkg. -->
+       $(EngineVariantsStagingDir)/<full-build>/{al-runner.dll,.pdb,.deps.json,.runtimeconfig.json,
+       AlRunner.QueryJoin.dll,AlRunner.Provisioning.dll,AlRunner.Provisioning.pdb,Win32Stubs/}
+       (see NclShadowRuntime.MustCopyNames / MustCopyDirectoryNames — #2166/#2168 — for
+       why these load-by-path items need to ship per-variant, not just at the top level).
+       %(RecursiveDir) reproduces that per-version subfolder (including the nested
+       Win32Stubs/ one) under variants/ in the packed nupkg. -->
   <PropertyGroup>
     <EngineVariantsStagingDir Condition="'$(EngineVariantsStagingDir)' == ''"></EngineVariantsStagingDir>
   </PropertyGroup>

--- a/AlRunner/Infrastructure/NclShadowRuntime.cs
+++ b/AlRunner/Infrastructure/NclShadowRuntime.cs
@@ -87,8 +87,27 @@ public static class NclShadowRuntime
         "AlRunner.QueryJoin.dll", "AlRunner.Provisioning.dll", "AlRunner.Provisioning.pdb",
     };
 
+    // #2168: same "load-by-path from AppContext.BaseDirectory, must survive the original
+    // install changing later" reasoning as MustCopyNames above, but for a DIRECTORY rather
+    // than a single file. Win32Stubs.LocatePrebuiltSo resolves the prebuilt Linux Win32
+    // P/Invoke shim via Path.Combine(AppContext.BaseDirectory, "Win32Stubs", <rid-named .so>)
+    // — lazily, the first time AL test code reaches a Windows-only Win32 API through BC's
+    // runtime (see the comment on Win32Stubs.BuildNoCompilerMessage). Per-BC-minor engine
+    // variant directories don't ship their own Win32Stubs/ (confirmed from the published
+    // nupkg), so before this fix Win32Stubs/ fell into the generic "every other directory"
+    // bucket and was symlinked back to origFull by LinkOrCopy. That only kept working
+    // because EnsureShadowDir's caller always passes the top-level "any" install directory
+    // as origDir, which does ship Win32Stubs/ — same masking #2166 found for
+    // AlRunner.QueryJoin.dll/AlRunner.Provisioning.dll, just one level up (a directory
+    // symlink instead of a file symlink). A real, independent copy at shadow-build time
+    // removes the dependency on origFull's Win32Stubs/ surviving.
+    private static readonly string[] MustCopyDirectoryNames = { "Win32Stubs" };
+
     private static bool MustBeRealCopy(string fileName) =>
         MustCopyNames.Contains(fileName, StringComparer.OrdinalIgnoreCase);
+
+    private static bool MustBeRealCopyDirectory(string directoryName) =>
+        MustCopyDirectoryNames.Contains(directoryName, StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
     /// True when this install does not ship Ncl.dll beside the running assembly — i.e.
@@ -251,11 +270,13 @@ public static class NclShadowRuntime
     /// </summary>
     /// <summary>
     /// Mirrors every entry of <paramref name="origFull"/> into <paramref name="shadowDir"/>:
-    /// the entry assembly and its deps/runtimeconfig manifests (<see cref="MustCopyNames"/>)
-    /// as real, independent copies; everything else as a symlink (near-zero cost — these
-    /// are typically dozens of large, numerous dependency DLLs). Internal and side-effect-
-    /// isolated from the Ncl-specific/caching logic above so it's directly testable without
-    /// needing real BC artifact bytes to Cecil-rewrite — see NclShadowRuntimeTests.
+    /// the entry assembly and its deps/runtimeconfig manifests (<see cref="MustCopyNames"/>),
+    /// plus any directory named in <see cref="MustCopyDirectoryNames"/> (currently just
+    /// <c>Win32Stubs/</c> — see #2168), as real, independent copies; everything else as a
+    /// symlink (near-zero cost — these are typically dozens of large, numerous dependency
+    /// DLLs). Internal and side-effect-isolated from the Ncl-specific/caching logic above
+    /// so it's directly testable without needing real BC artifact bytes to Cecil-rewrite —
+    /// see NclShadowRuntimeTests.
     /// </summary>
     /// <param name="origFull">The install directory to mirror (dependency closure,
     /// satellite resource dirs, Win32Stubs, …).</param>
@@ -291,6 +312,14 @@ public static class NclShadowRuntime
                     ? Path.Combine(entrySource, name)
                     : entry;
                 File.Copy(source, target, overwrite: true);
+            }
+            else if (Directory.Exists(entry) && MustBeRealCopyDirectory(name))
+            {
+                // #2168: directory-aware equivalent of the file case above. Win32Stubs/
+                // is shared across every BC-minor engine variant (it's RID-keyed, not
+                // BC-version-keyed), so — unlike the entry assembly — it's always sourced
+                // from origFull, never from entrySource, even during a variant swap.
+                CopyDirectoryRecursive(entry, target);
             }
             else
             {


### PR DESCRIPTION
Closes #2168

## What was wrong

`Win32Stubs.LocatePrebuiltSo` resolves the prebuilt Linux Win32 P/Invoke shim via `Path.Combine(AppContext.BaseDirectory, "Win32Stubs", <rid-named .so>)` — the same load-by-path-from-the-running-process's-own-directory shape #2166 fixed for `AlRunner.QueryJoin.dll`/`AlRunner.Provisioning.dll`, except `Win32Stubs` is a **directory**, not a single file. `NclShadowRuntime.MirrorInstallDirectory` put it in the generic "every other directory" bucket, which symlinks back to the original install directory (`origDir`) instead of copying.

Per-BC-minor engine variant directories (`tools/net8.0/any/variants/<build>/`) don't ship their own `Win32Stubs/` — only the top-level `any` folder does. On a plain install this is masked: `EnsureShadowDir`'s caller always passes that top-level directory as `origDir`, so the symlink target resolves. But `EnsureShadowDir`'s "reusable" cache check never re-validates that symlink once built — if the original install's `Win32Stubs/` is later removed (a reinstall/upgrade in place, `mise`/`dotnet tool` pruning an old version), the dangling symlink only surfaces the first time AL test code reaches a Windows-only Win32 API, deep inside `Win32Stubs.GetOrBuild`.

## Confirming the defect (before fixing it)

Wrote a unit test that mirrors a `Win32Stubs/` directory (containing a fake `.so` + `.c`) into a shadow dir via `MirrorInstallDirectory`, then asserted it landed as a real copy rather than a directory symlink. It was RED before the fix: the directory landed as a symlink, and deleting the original directory afterward took the shadow copy's file down with it — the same class of `FileNotFoundException` #2166 reported, one level up.

## Fix

1. **Runtime**: `NclShadowRuntime` gains a directory-aware equivalent of `MustCopyNames` — `MustCopyDirectoryNames` (currently just `Win32Stubs`). `MirrorInstallDirectory` real-copies (`CopyDirectoryRecursive`) any directory named there instead of symlinking it, while every other directory keeps the existing symlink behavior (asserted by a new negative test, `MirrorInstallDirectory_NonWin32StubsDirectory_StillSymlinked`, so this doesn't regress the "everything else stays cheap" contract `MirrorInstallDirectory_Subdirectory_IsMirroredAndReachable` already pins).
2. **Packaging**: both `.github/workflows/bc-tests.yml` and `publish.yml`'s "Build each BC-minor engine variant" steps now stage `Win32Stubs/` into every variant directory (mirroring the existing `AlRunner.QueryJoin.dll`/`AlRunner.Provisioning.dll` staging from #2166).
3. **CI check**: the pack job's "Assert every BC-minor engine variant made it into the package" step now also asserts a matching count of `Win32Stubs/{win32_stubs.c,libwin32_stubs.linux-x64.so,libwin32_stubs.linux-arm64.so}` across variant directories — a deterministic `unzip -l` inspection of the packed nupkg, same style as #2166's assertion and deliberately not an install-and-run check (that's exactly what the symlink fallback masks).

## Verification against a real `dotnet pack`

Built one variant locally against a cached BC artifact, staged it the way the updated workflow now does (including `Win32Stubs/`), and packed it with `EngineVariantsStagingDir` pointed at that staging dir:

```
$ unzip -l *.nupkg | grep -i win32stubs
tools/net8.0/any/Win32Stubs/libwin32_stubs.linux-x64.so
tools/net8.0/any/Win32Stubs/win32_stubs.c
tools/net8.0/any/variants/28.1.49838.53910/Win32Stubs/libwin32_stubs.linux-x64.so
tools/net8.0/any/variants/28.1.49838.53910/Win32Stubs/win32_stubs.c
```

Then repeated the pack with a staging dir built the *pre-fix* way (omitting `Win32Stubs/`, matching what CI produced before this change) — the variant directory carried zero `Win32Stubs` entries, confirming the packaging gap the issue reports.

## Tests

- `AlRunner.Tests/NclShadowRuntimeTests.cs`:
  - `MirrorInstallDirectory_Win32StubsDirectory_IsRealCopyNotSymlink` — RED before the fix (directory symlinked, shadow copy didn't survive the original being deleted), GREEN after.
  - `MirrorInstallDirectory_NonWin32StubsDirectory_StillSymlinked` — negative/regression guard: every other directory keeps the cheap symlink path.
  - `dotnet test AlRunner.Tests -c Release --filter "FullyQualifiedName~NclShadowRuntimeTests|FullyQualifiedName~Win32Stubs"`: 26 passed, 0 failed.

## Fix-the-shape check

1. **Same wrong pattern elsewhere?** Checked every `AppContext.BaseDirectory` use in `AlRunner/`. `Win32Stubs.cs` has two references (`LocatePrebuiltSo` and `LocateStubSource`'s walk-up fallback) — both terminate at the same `Win32Stubs/` directory, already covered by this one fix. The other `AppContext.BaseDirectory` reads (`EngineVariants.Discover`, the Ncl.dll presence checks, `BcArtifacts.EngineMajor`/`EngineVersion`) all execute in the *parent* process before the shadow-hop decision (confirmed by line position relative to `Program.cs`'s re-exec block), so they read the real install directory, not the shadow dir — no equivalent gap there. `Microsoft.Dynamics.Nav.Ncl.dll` itself is deliberately excluded from the package and written by `NclCecilRewrite.RewriteInPlace` as a genuine file, not routed through `MirrorInstallDirectory`'s symlink/copy split at all.
2. **Sibling function, same assumption?** N/A beyond the above — `Win32Stubs.cs`'s two resolution paths are the only load-by-path directory consumers.
3. **Two paths, same invariant?** `MirrorInstallDirectory` is the single path building the shadow dir; the packaging side (`bc-tests.yml` vs `publish.yml`) is two independent copies of the same staging loop (pre-existing duplication from #2166, not introduced here) and both were updated identically.
