### PR TITLE
fix(layered): feed each source app the workspace output of the apps built before it

### DIFF
--- a/AlRunner.Tests/CollectionCostOrderer.cs
+++ b/AlRunner.Tests/CollectionCostOrderer.cs
@@ -138,6 +138,15 @@ public sealed class CollectionCostOrderer : ITestCollectionOrderer
             // while leaving dispatch order exactly as it was, which is the tail the gate
             // exists to prevent. Carry the observed maximum instead.
             ["StartupOutputReexecDedupTests"] = 61,
+            // #2178: 3 tests, each spawning a real runner subprocess over a three-app source
+            // chain (two of them compile all three apps cold). Measured 53.3s (28.3) to
+            // 90.5s (27.5) across the eight legs of its first CI run, where it was absent
+            // from this table, fell back to UnmeasuredWeightSeconds and was dispatched at
+            // t=354s of a 441s run — the #1887 tail again. Carries the observed maximum,
+            // for the same reason StartupOutputReexecDedupTests above does: its low end is
+            // already near enough to the 60s freshness threshold that a rounded-down low
+            // value would satisfy the gate while leaving the tail in place.
+            ["LayeredSourceChainTests"] = 90,
             ["TestFilterFlagTests"] = 99,
             ["PhaseLogIntegrationTests"] = 85,
             // #1922: 6 tests, each spawning a real runner subprocess against an AL fixture

--- a/AlRunner.Tests/LayeredSourceChainTests.cs
+++ b/AlRunner.Tests/LayeredSourceChainTests.cs
@@ -1,0 +1,348 @@
+using System.Diagnostics;
+using System.Text;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// #2178 — a source-compiled dependency that itself depends on another source-compiled
+/// app must be able to see it.
+///
+/// Both source pre-passes in <c>Program.cs</c> write each app they build into its own
+/// deterministic workspace dir (a synthetic source-only <c>.app</c> plus the
+/// <c>*.symbols.json</c> sidecar that carries the compile half), and both topologically
+/// sort so a dependency is built before its dependent. Neither one used to feed those
+/// freshly written dirs back into the NEXT app's compile: every iteration resolved
+/// against the same list that was computed once, before the loop. So the moment a chain
+/// was three apps deep — <c>test -&gt; middle -&gt; base</c>, with both <c>middle</c> and
+/// <c>base</c> compiled from AL source in the same invocation — the middle app could not
+/// see the base app at all:
+/// <code>
+///   [layered] WROTE LSC Chain Base 1.0.0.0 -> AL_Runner_LSC_Chain_Base_1_0_0_0.app
+///   &lt;layered-deps&gt;: COMPILE-FAIL — [layered] Failed to emit symbols for impl
+///     'LSC Chain Middle' ...: Dependency not found: AL Runner/LSC Chain Base v1.0.0.0
+///     ... Searched: &lt;platform-apps&gt;, &lt;test-apps&gt;
+/// </code>
+/// naming an app the runner had written itself one line earlier.
+///
+/// Two apps was the deepest shape with coverage, and two apps never exercises it: the one
+/// impl in a two-app bundle has no impl dependency of its own. The existing
+/// <c>dep-tableext-platform-base-{dep,main}</c> fixture passes for exactly that reason.
+///
+/// The fixtures below use no Microsoft objects at all (platform/application 1.0.0.0, no
+/// declared Microsoft deps), so the chain is legitimately resolvable with whatever package
+/// caches this machine happens to have — the claim under test is about propagation between
+/// the runner's OWN workspace dirs, not about artifact provisioning.
+///
+/// Spawns the real runner; needs the BC artifact cache. Skips (visibly) when absent.
+/// </summary>
+public class LayeredSourceChainTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+    private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
+
+    // ── Fixture writers ────────────────────────────────────────────────────────
+    // One chain, written three times into different layouts so each pre-pass sees the
+    // shape it is responsible for. Object IDs are per-app (each app.json declares its
+    // own idRanges) and the app ids are fresh GUIDs per run, so no workspace-deps /
+    // compiled-deps / al-out cache from a previous run can answer for any of them.
+
+    private static void WriteBaseApp(string dir, Guid baseId)
+    {
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "app.json"), $$"""
+        {
+          "id": "{{baseId}}",
+          "name": "LSC Chain Base",
+          "publisher": "AL Runner",
+          "version": "1.0.0.0",
+          "dependencies": [],
+          "platform": "1.0.0.0",
+          "application": "1.0.0.0",
+          "idRanges": [ { "from": 60050, "to": 60059 } ],
+          "runtime": "14.0"
+        }
+        """);
+        // A table AND a codeunit: the table is what the middle app needs at COMPILE time
+        // (it declares `Record "LSC Chain Row"`), the codeunit is what it needs at RUNTIME.
+        // A fix that restored only one of the two halves would fail the other.
+        File.WriteAllText(Path.Combine(dir, "ChainRow.Table.al"), """
+        table 60050 "LSC Chain Row"
+        {
+            DataClassification = CustomerContent;
+            fields
+            {
+                field(1; "Row Code"; Code[20]) { DataClassification = CustomerContent; }
+                field(2; "Row Value"; Integer) { DataClassification = CustomerContent; }
+                field(3; "Row Label"; Text[50]) { DataClassification = CustomerContent; }
+            }
+            keys { key(PK; "Row Code") { Clustered = true; } }
+        }
+        """);
+        File.WriteAllText(Path.Combine(dir, "ChainBaseApi.Codeunit.al"), """
+        codeunit 60051 "LSC Chain Base Api"
+        {
+            procedure BaseTag(): Text[50]
+            begin
+                exit('chain-base-60051');
+            end;
+
+            procedure Amplify(Value: Integer): Integer
+            begin
+                exit((Value * 2) + 3);
+            end;
+        }
+        """);
+    }
+
+    private static void WriteMiddleApp(string dir, Guid middleId, Guid baseId)
+    {
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "app.json"), $$"""
+        {
+          "id": "{{middleId}}",
+          "name": "LSC Chain Middle",
+          "publisher": "AL Runner",
+          "version": "1.0.0.0",
+          "dependencies": [
+            { "id": "{{baseId}}", "name": "LSC Chain Base", "publisher": "AL Runner", "version": "1.0.0.0" }
+          ],
+          "platform": "1.0.0.0",
+          "application": "1.0.0.0",
+          "idRanges": [ { "from": 60060, "to": 60069 } ],
+          "runtime": "14.0"
+        }
+        """);
+        // Public surface is primitives-only on purpose: the test app depends on THIS app
+        // and on nothing else, so a green run cannot be explained by the test app seeing
+        // the base app directly.
+        File.WriteAllText(Path.Combine(dir, "ChainMiddleApi.Codeunit.al"), """
+        codeunit 60060 "LSC Chain Middle Api"
+        {
+            procedure StoreAmplified(RowCode: Code[20]; Value: Integer)
+            var
+                ChainRow: Record "LSC Chain Row";
+                BaseApi: Codeunit "LSC Chain Base Api";
+            begin
+                ChainRow.Init();
+                ChainRow."Row Code" := RowCode;
+                ChainRow."Row Value" := BaseApi.Amplify(Value);
+                ChainRow."Row Label" := BaseApi.BaseTag();
+                ChainRow.Insert();
+            end;
+
+            procedure ReadValue(RowCode: Code[20]): Integer
+            var
+                ChainRow: Record "LSC Chain Row";
+            begin
+                ChainRow.Get(RowCode);
+                exit(ChainRow."Row Value");
+            end;
+
+            procedure ReadLabel(RowCode: Code[20]): Text[50]
+            var
+                ChainRow: Record "LSC Chain Row";
+            begin
+                ChainRow.Get(RowCode);
+                exit(ChainRow."Row Label");
+            end;
+        }
+        """);
+    }
+
+    private static void WriteTestApp(string dir, Guid testsId, Guid middleId)
+    {
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "app.json"), $$"""
+        {
+          "id": "{{testsId}}",
+          "name": "LSC Chain Test",
+          "publisher": "AL Runner",
+          "version": "1.0.0.0",
+          "dependencies": [
+            { "id": "{{middleId}}", "name": "LSC Chain Middle", "publisher": "AL Runner", "version": "1.0.0.0" }
+          ],
+          "platform": "1.0.0.0",
+          "application": "1.0.0.0",
+          "idRanges": [ { "from": 60070, "to": 60079 } ],
+          "runtime": "14.0"
+        }
+        """);
+        // Three tests, each pinning a different half of the handoff:
+        //  - Amplified: the base app's CODE ran ((11*2)+3 = 25, not 11 and not 0).
+        //  - Marker:    a text only the base app's codeunit can produce round-tripped
+        //               through the base app's TABLE.
+        //  - Negative:  a missing row still raises BC's real record-not-found error
+        //               rather than degrading to a default 0.
+        File.WriteAllText(Path.Combine(dir, "ChainTests.al"), """
+        codeunit 60070 "LSC Chain Tests"
+        {
+            Subtype = Test;
+
+            [Test]
+            procedure ChainStore_AmplifiesThroughBaseCodeunit()
+            var
+                MiddleApi: Codeunit "LSC Chain Middle Api";
+                Actual: Integer;
+            begin
+                MiddleApi.StoreAmplified('LSC-A', 11);
+                Actual := MiddleApi.ReadValue('LSC-A');
+                if Actual <> 25 then
+                    Error('Expected 25 ((11*2)+3 through the base app''s codeunit), got %1', Actual);
+            end;
+
+            [Test]
+            procedure ChainStore_BaseTagMarkerRoundTrips()
+            var
+                MiddleApi: Codeunit "LSC Chain Middle Api";
+                Actual: Text;
+            begin
+                MiddleApi.StoreAmplified('LSC-B', 4);
+                Actual := MiddleApi.ReadLabel('LSC-B');
+                if Actual <> 'chain-base-60051' then
+                    Error('Expected ''chain-base-60051'' from the base app''s codeunit, got ''%1''', Actual);
+            end;
+
+            [Test]
+            procedure ChainRead_UnknownRowCodeRaises()
+            var
+                MiddleApi: Codeunit "LSC Chain Middle Api";
+                Actual: Text;
+            begin
+                asserterror MiddleApi.ReadValue('LSC-NOPE');
+                Actual := GetLastErrorText();
+                if not Actual.Contains('does not exist') then
+                    Error('Expected a record-not-found error from the base app''s table, got ''%1''', Actual);
+            end;
+        }
+        """);
+    }
+
+    private static (string Output, int Exit) RunRunner(string scratchRoot, params string[] bundles)
+    {
+        var args = new StringBuilder(TestBuildConfig.RunArgs(ProjectPath));
+        args.Append(TestBuildConfig.BcVersionArg);
+        foreach (var b in bundles) args.Append($" \"{b}\"");
+        args.Append($" --cache \"{Path.Combine(scratchRoot, "al-out")}\"");
+        var platformApps = TestArtifacts.PlatformAppsDir();
+        if (Directory.Exists(platformApps)) args.Append($" --package-cache \"{platformApps}\"");
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet", Arguments = args.ToString(),
+            RedirectStandardOutput = true, RedirectStandardError = true,
+            UseShellExecute = false, CreateNoWindow = true, WorkingDirectory = RepoRoot,
+        };
+        var sb = new StringBuilder();
+        using var p = Process.Start(psi)!;
+        p.OutputDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.ErrorDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.BeginOutputReadLine();
+        p.BeginErrorReadLine();
+        if (!p.WaitForExit(300_000)) { try { p.Kill(true); } catch { } throw new TimeoutException("runner hung"); }
+        p.WaitForExit();
+        lock (sb) return (sb.ToString(), p.ExitCode);
+    }
+
+    private static string NewScratch(string tag) =>
+        Path.Combine(Path.GetTempPath(), "al-runner-layered-chain", tag, Guid.NewGuid().ToString("N"));
+
+    // ── Positive: RunLayeredPrePass (three bundle arguments) ───────────────────
+
+    /// <summary>
+    /// Three source bundles on one command line, chained test -&gt; middle -&gt; base.
+    /// Both middle and base are "impls" in <c>RunLayeredPrePass</c> terms, and middle is
+    /// the first impl whose own dependency is also an impl — the shape that had no
+    /// coverage. Before the fix this never reached a test: exit 3 with
+    /// "Dependency not found: AL Runner/LSC Chain Base".
+    /// </summary>
+    [SkippableFact]
+    public void LayeredPrePass_ThreeSourceBundles_MiddleImplResolvesTheBaseImpl()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var scratch = NewScratch("layered");
+        Guid baseId = Guid.NewGuid(), middleId = Guid.NewGuid(), testsId = Guid.NewGuid();
+        var baseDir = Path.Combine(scratch, "base-app");
+        var middleDir = Path.Combine(scratch, "middle-app");
+        var testsDir = Path.Combine(scratch, "tests-app");
+        WriteBaseApp(baseDir, baseId);
+        WriteMiddleApp(middleDir, middleId, baseId);
+        WriteTestApp(testsDir, testsId, middleId);
+
+        var (output, exit) = RunRunner(scratch, baseDir, middleDir, testsDir);
+
+        Assert.DoesNotContain("Dependency not found", output);
+        Assert.DoesNotContain("AL1022", output);
+        Assert.DoesNotContain("COMPILE-FAIL", output);
+        Assert.True(exit == 0 && output.Contains("3P/0F/0E"),
+            $"a three-deep source chain must compile and run (exit {exit}):\n{output}");
+    }
+
+    // ── Positive: BuildSiblingSourceDeps (one bundle argument, sibling sources) ─
+
+    /// <summary>
+    /// The same chain through the OTHER pre-pass: only the test app is passed as a
+    /// bundle, and middle + base are discovered as sibling source apps next to it.
+    /// <c>BuildSiblingSourceDeps</c> topo-sorts for the same reason
+    /// <c>RunLayeredPrePass</c> does, and had the same gap — its <c>resolveDirs</c> was
+    /// computed once, before the loop, and never gained the workspace dirs it was
+    /// writing. Without this case a fix applied to only one of the two pre-passes would
+    /// still ship the bug.
+    /// </summary>
+    [SkippableFact]
+    public void SiblingSourceDeps_ChainedSourceApps_MiddleSiblingResolvesTheBaseSibling()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var scratch = NewScratch("sibling");
+        Guid baseId = Guid.NewGuid(), middleId = Guid.NewGuid(), testsId = Guid.NewGuid();
+        var baseDir = Path.Combine(scratch, "base-app");
+        var middleDir = Path.Combine(scratch, "middle-app");
+        var testsDir = Path.Combine(scratch, "tests-app");
+        WriteBaseApp(baseDir, baseId);
+        WriteMiddleApp(middleDir, middleId, baseId);
+        WriteTestApp(testsDir, testsId, middleId);
+
+        // Only the TEST app is a bundle; the other two are siblings under the same parent.
+        var (output, exit) = RunRunner(scratch, testsDir);
+
+        Assert.DoesNotContain("Dependency not found", output);
+        Assert.DoesNotContain("AL1022", output);
+        Assert.DoesNotContain("COMPILE-FAIL", output);
+        Assert.True(exit == 0 && output.Contains("3P/0F/0E"),
+            $"a three-deep sibling source chain must compile and run (exit {exit}):\n{output}");
+    }
+
+    // ── Negative: an absent dependency still fails, and says which one ─────────
+
+    /// <summary>
+    /// The mirror of the two cases above: with the base app genuinely absent — not
+    /// passed as a bundle, not a sibling, not in any package cache — the middle app must
+    /// still fail, and the failure must name the app it could not find. Widening the
+    /// search set is only correct if it stops widening at "what actually exists"; a fix
+    /// that made resolution succeed unconditionally would turn this into a green run
+    /// with a silently missing dependency.
+    /// </summary>
+    [SkippableFact]
+    public void LayeredPrePass_BaseAppAbsent_FailsNamingTheMissingDependency()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var scratch = NewScratch("absent");
+        Guid baseId = Guid.NewGuid(), middleId = Guid.NewGuid(), testsId = Guid.NewGuid();
+        // The base app is written OUTSIDE the scratch tree so it is neither a bundle
+        // argument nor a sibling of the two apps that are.
+        var chainRoot = Path.Combine(scratch, "chain");
+        var middleDir = Path.Combine(chainRoot, "middle-app");
+        var testsDir = Path.Combine(chainRoot, "tests-app");
+        WriteMiddleApp(middleDir, middleId, baseId);
+        WriteTestApp(testsDir, testsId, middleId);
+
+        var (output, exit) = RunRunner(scratch, middleDir, testsDir);
+
+        Assert.NotEqual(0, exit);
+        Assert.Contains("LSC Chain Base", output);
+        Assert.Contains("Dependency not found", output);
+    }
+}

--- a/AlRunner.Tests/PkgDedupSearchSetProvenanceTests.cs
+++ b/AlRunner.Tests/PkgDedupSearchSetProvenanceTests.cs
@@ -1,0 +1,166 @@
+// PkgDedupSearchSetProvenanceTests — #2178, the honesty half.
+//
+// When BcCompiler.DeduplicateAppPackageDirs collapses the scan set, every dir the caller
+// gave it is replaced by ONE content-addressed staging directory under
+// <temp>/al-runner-pkgdedup/<hash>. BC's own AL1022 text then reads:
+//
+//   AL1022 A package with publisher 'X', name 'Y', and a version compatible with '1.0.0.0'
+//   could not be found in the package cache folders: /tmp/al-runner-pkgdedup/1c98b3f208e9c69a
+//
+// which is accurate and useless: the reader cannot tell whether their --package-cache
+// directory reached the compile at all, and cannot see that a package matching exactly
+// that identity WAS in one of their directories and was deliberately left out of the
+// staging copy for carrying no SymbolReference.json.
+//
+// #2108 is the precedent for why this matters: a search-set message that does not describe
+// the set actually searched sends people to look in the wrong place.
+
+using System.IO.Compression;
+using System.Reflection;
+using System.Text;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class PkgDedupSearchSetProvenanceTests : IDisposable
+{
+    private readonly string _root;
+
+    public PkgDedupSearchSetProvenanceTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "al-runner-pkgdedup-provenance", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { /* best-effort */ }
+    }
+
+    /// <summary>
+    /// Positive: a staging directory's description names every original package dir it was
+    /// built from, and names the package that was dropped for carrying no
+    /// SymbolReference.json — with its publisher, name, version and path, so the reader can
+    /// go and look at the file.
+    ///
+    /// Negative, in the same run: the symbol-BEARING package must NOT be reported as
+    /// excluded (a description that listed everything would be no more informative than the
+    /// bare staging path it replaces), and a diagnostic that names no staging directory at
+    /// all must produce no description rather than an invented one.
+    /// </summary>
+    [Fact]
+    public void StagedSearchSet_IsDescribedByItsOriginDirsAndDroppedPackages()
+    {
+        var withSymbols = Path.Combine(_root, "with-symbols");
+        var handedIn = Path.Combine(_root, "handed-in");
+        Directory.CreateDirectory(withSymbols);
+        Directory.CreateDirectory(handedIn);
+
+        // A real, compiler-usable package …
+        WriteApp(withSymbols, "Alpha.app",
+            "11111111-0000-0000-0000-0000000000a1", "Prov Alpha", "Contoso", "1.0.0.0",
+            withSymbolReference: true);
+        // … and the shape from the issue: a source-only package the user copied into a dir
+        // they passed on --package-cache. It cannot serve symbols, so dedup drops it — and
+        // dropping ANY package is what forces the staging branch to engage at all.
+        WriteApp(handedIn, "Beta.app",
+            "22222222-0000-0000-0000-0000000000b2", "Prov Beta", "Contoso", "2.3.4.5",
+            withSymbolReference: false);
+
+        var packageDirs = new List<string> { withSymbols, handedIn };
+        var staged = InvokeDeduplicateAppPackageDirs(packageDirs, excludeAppId: null);
+
+        // Precondition: the staging branch really engaged, else the rest is vacuous.
+        Assert.Single(staged);
+        Assert.NotEqual(packageDirs, staged);
+
+        var diagnostic =
+            "AL1022 A package with publisher 'Contoso', name 'Prov Beta', and a version " +
+            $"compatible with '2.3.4.5' could not be found in the package cache folders: {staged[0]}";
+
+        var description = BcCompiler.DescribeStagedSearchSet(diagnostic);
+
+        Assert.NotNull(description);
+        // Every dir the caller handed in is named, including the one whose only package was
+        // dropped — that dir being invisible is exactly what made #2178 read as "my
+        // --package-cache never reached the compile".
+        Assert.Contains(withSymbols, description);
+        Assert.Contains(handedIn, description);
+        // The dropped package is named in full, with the reason.
+        Assert.Contains("Contoso/Prov Beta 2.3.4.5", description);
+        Assert.Contains(Path.Combine(handedIn, "Beta.app"), description);
+        Assert.Contains("no SymbolReference.json", description);
+        // …and the package that WAS staged is not reported as excluded.
+        Assert.DoesNotContain("Prov Alpha", description);
+    }
+
+    /// <summary>
+    /// Negative: a diagnostic naming no staging directory gets no description. The helper
+    /// must stay silent rather than attach the provenance of some unrelated staging dir
+    /// that happens to be in the process-wide table.
+    /// </summary>
+    [Fact]
+    public void DiagnosticWithoutAStagingDir_GetsNoDescription()
+    {
+        var withSymbols = Path.Combine(_root, "with-symbols");
+        var handedIn = Path.Combine(_root, "handed-in");
+        Directory.CreateDirectory(withSymbols);
+        Directory.CreateDirectory(handedIn);
+        WriteApp(withSymbols, "Alpha.app",
+            "33333333-0000-0000-0000-0000000000c3", "Prov Gamma", "Contoso", "1.0.0.0",
+            withSymbolReference: true);
+        WriteApp(handedIn, "Beta.app",
+            "44444444-0000-0000-0000-0000000000d4", "Prov Delta", "Contoso", "2.0.0.0",
+            withSymbolReference: false);
+
+        // Populate the provenance table, so "returns null" cannot be explained by it
+        // being empty.
+        var staged = InvokeDeduplicateAppPackageDirs(
+            new List<string> { withSymbols, handedIn }, excludeAppId: null);
+        Assert.Single(staged);
+
+        Assert.Null(BcCompiler.DescribeStagedSearchSet(
+            "AL0185 Codeunit 'Something' is missing"));
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────────────────
+
+    private static List<string> InvokeDeduplicateAppPackageDirs(List<string> packageDirs, Guid? excludeAppId)
+    {
+        var method = typeof(BcCompiler)
+            .GetMethods(BindingFlags.NonPublic | BindingFlags.Static)
+            .SingleOrDefault(m => m.Name == "DeduplicateAppPackageDirs" && m.GetParameters().Length == 2)
+            ?? throw new InvalidOperationException(
+                "BcCompiler.DeduplicateAppPackageDirs(dirs, excludeAppId) not found by reflection — signature may have changed.");
+        return (List<string>)method.Invoke(null, new object?[] { packageDirs, excludeAppId })!;
+    }
+
+    private static void WriteApp(string dir, string fileName, string appId, string name,
+        string publisher, string version, bool withSymbolReference)
+    {
+        var xml = $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <Package xmlns="http://schemas.microsoft.com/navx/2015/manifest">
+              <App Id="{appId}" Name="{name}" Publisher="{publisher}" Version="{version}"/>
+            </Package>
+            """;
+        using var ms = new MemoryStream();
+        using (var zip = new ZipArchive(ms, ZipArchiveMode.Create, leaveOpen: true))
+        {
+            var entry = zip.CreateEntry("NavxManifest.xml");
+            using (var es = entry.Open()) es.Write(Encoding.UTF8.GetBytes(xml));
+            if (withSymbolReference)
+            {
+                var symEntry = zip.CreateEntry("SymbolReference.json");
+                using var symStream = symEntry.Open();
+                symStream.Write(Encoding.UTF8.GetBytes("{}"));
+            }
+        }
+        var zipBytes = ms.ToArray();
+        var result = new byte[8 + zipBytes.Length];
+        result[0] = (byte)'N'; result[1] = (byte)'A'; result[2] = (byte)'V'; result[3] = (byte)'X';
+        BitConverter.TryWriteBytes(result.AsSpan(4, 4), (uint)8);
+        zipBytes.CopyTo(result, 8);
+        File.WriteAllBytes(Path.Combine(dir, fileName), result);
+    }
+}

--- a/AlRunner/BcCompiler.cs
+++ b/AlRunner/BcCompiler.cs
@@ -697,6 +697,57 @@ public sealed partial class BcCompiler
     internal readonly record struct PackageScanEntry(
         string Path, Guid AppId, string Publisher, string Name, Version Version);
 
+    /// <summary>
+    /// One .app that <see cref="DeduplicateAppPackageDirs"/> left OUT of the staging dir
+    /// because it carries no <c>SymbolReference.json</c>, so it cannot supply compile-time
+    /// symbols to anything. See the drop site for why keeping it would fail every compile
+    /// that scans its directory.
+    /// </summary>
+    internal readonly record struct UnstagedPackage(string Path, string Publisher, string Name, Version Version);
+
+    /// <summary>
+    /// What a deduplicated staging directory stands for: the original package dirs it was
+    /// built from, and the packages that were dropped on the way in.
+    ///
+    /// #2178 (and #2108 before it): BC's own AL1022 text names the folders it searched, and
+    /// once the scan set has been collapsed that is one content-addressed path under
+    /// <c>al-runner-pkgdedup/</c>. The path is honest — it really is what BC searched — but
+    /// on its own it tells the reader nothing about which of their <c>--package-cache</c>
+    /// directories it represents, and nothing about a package that WAS in one of them and
+    /// was excluded here. <see cref="DescribeStagedSearchSet"/> turns it back into both.
+    /// </summary>
+    private static readonly System.Collections.Concurrent.ConcurrentDictionary<
+        string, (IReadOnlyList<string> Origin, IReadOnlyList<UnstagedPackage> Unstaged)> _stageProvenance =
+        new(StringComparer.Ordinal);
+
+    /// <summary>
+    /// An explanatory suffix for a compiler diagnostic that names a pkgdedup staging
+    /// directory, or null when it names none. Never speculates: it reports the dirs the
+    /// staging copy was actually built from and the packages actually dropped from it.
+    /// </summary>
+    internal static string? DescribeStagedSearchSet(string diagnosticText)
+    {
+        foreach (var kv in _stageProvenance)
+        {
+            if (!diagnosticText.Contains(kv.Key, StringComparison.Ordinal)) continue;
+            var sb = new System.Text.StringBuilder();
+            sb.Append(" [al-runner] That folder is a deduplicated staging copy of: ")
+              .Append(string.Join(", ", kv.Value.Origin))
+              .Append('.');
+            if (kv.Value.Unstaged.Count > 0)
+            {
+                sb.Append(" Excluded from it, because they carry no SymbolReference.json and so cannot supply compile-time symbols: ")
+                  .Append(string.Join(", ", kv.Value.Unstaged.Take(10)
+                      .Select(u => $"{u.Publisher}/{u.Name} {u.Version} ({u.Path})")));
+                if (kv.Value.Unstaged.Count > 10)
+                    sb.Append($", and {kv.Value.Unstaged.Count - 10} more");
+                sb.Append('.');
+            }
+            return sb.ToString();
+        }
+        return null;
+    }
+
     // Per-file cache of the two zip reads DeduplicateAppPackageDirs performs on every .app
     // it scans (ReadManifest + HasSymbolReference). Both re-read the WHOLE package from
     // disk and unzip it — for a 113-package, 138 MB platform-apps dir that is ~1–2.5 s per
@@ -829,6 +880,11 @@ public sealed partial class BcCompiler
         var seen = new HashSet<(Guid, string)>();
         var picked = new List<string>();
         inventory = new List<PackageScanEntry>();
+        // #2178: remembered, not just counted. When the staging dir is what BC ends up
+        // naming in an AL1022 "could not be found in the package cache folders" message,
+        // a package that was IN one of the caller's dirs and dropped here is precisely the
+        // thing the reader needs told. See DescribeStagedSearchSet.
+        var unstaged = new List<UnstagedPackage>();
         var changed = false;
         foreach (var dir in packageDirs)
         {
@@ -860,7 +916,13 @@ public sealed partial class BcCompiler
                 // paths reach the compiler independently, and BC 27 is far stricter than BC 28
                 // about a malformed package, so a gap here shows up as a version-specific
                 // failure that looks like a runner capability gap and is not one.
-                if (!hasSymbolReference) { changed = true; continue; }
+                if (!hasSymbolReference)
+                {
+                    changed = true;
+                    unstaged.Add(new UnstagedPackage(
+                        Path.GetFullPath(app), m.Publisher, m.Name, m.Version));
+                    continue;
+                }
                 // Normalise to an absolute path BEFORE it is ever used as a symlink target.
                 // `dir` (and therefore `app`) may be a caller-supplied RELATIVE path (e.g. a
                 // relative --package-cache argument, exactly as in issue #1652's repro:
@@ -914,9 +976,11 @@ public sealed partial class BcCompiler
                 // at emit time (#1691). Publish retries, then falls back to the scratch dir —
                 // same staged files, so the compile is unaffected; only the cross-compile
                 // reuse of this key is lost.
-                return new List<string> {
-                    AlRunner.Infrastructure.PkgDedupStaging.Publish(tmp, stage, Console.Error) };
+                var published = AlRunner.Infrastructure.PkgDedupStaging.Publish(tmp, stage, Console.Error);
+                _stageProvenance[published] = (packageDirs.ToList(), unstaged);
+                return new List<string> { published };
             }
+            _stageProvenance[stage] = (packageDirs.ToList(), unstaged);
             return new List<string> { stage };
         }
     }
@@ -2203,9 +2267,16 @@ public sealed partial class BcCompiler
             .Where(d => d.Id != "AL0327" && d.Id != "AL1023")
             .ToList();
         if (errors.Count > 0)
+        {
+            var detail = string.Join("; ", errors.Take(10).Select(d => $"{d.Id} {d.GetMessage()}"));
+            // #2178: an AL1022 here names the dirs BC searched, which after deduplication is
+            // one opaque content-addressed staging path. Say what it stands for, and which
+            // packages were left out of it, rather than leaving the reader to guess whether
+            // their --package-cache reached the compile at all.
+            detail += DescribeStagedSearchSet(detail) ?? string.Empty;
             throw new InvalidOperationException(
-                $"source dependency '{moduleName}' does not compile ({errors.Count} error(s)): " +
-                string.Join("; ", errors.Take(10).Select(d => $"{d.Id} {d.GetMessage()}")));
+                $"source dependency '{moduleName}' does not compile ({errors.Count} error(s)): {detail}");
+        }
 
         Directory.CreateDirectory(Path.GetDirectoryName(Path.GetFullPath(symbolsJsonPath))!);
         using var fs = new FileStream(symbolsJsonPath, FileMode.Create, FileAccess.Write, FileShare.None);

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -5906,6 +5906,18 @@ static List<string> RunLayeredPrePass(List<string> bundles, List<string> package
             if (!implAlpackagesDirs.Contains(d, StringComparer.OrdinalIgnoreCase))
                 implAlpackagesDirs.Add(d);
 
+        // The workspace dirs of the impls ALREADY built by this loop, snapshotted before
+        // this impl's own dir joins the list. sortedImpls is topologically ordered, so an
+        // impl that this one depends on has necessarily been written by now — and #2178 was
+        // that this snapshot was never taken, so every impl resolved against the same list
+        // computed before the loop and could not see any of its siblings' output. A chain
+        // three apps deep (test -> middle -> base, middle and base BOTH compiled from
+        // source) therefore failed on the middle app with "Dependency not found:
+        // <publisher>/<base app>" — naming a package the runner had written itself one
+        // line earlier. Two apps never reproduced it: the single impl in a two-app bundle
+        // has no impl dependency of its own.
+        var priorImplDirs = implDirs.ToList();
+
         var implKey = ComputeSourceWorkspaceKey(new[] { implPath }, idByKey);
         var wsDir = Path.Combine(workspaceRoot, implKey[..12]);
         Directory.CreateDirectory(wsDir);
@@ -5972,9 +5984,34 @@ static List<string> RunLayeredPrePass(List<string> bundles, List<string> package
                 // ORIGINAL package cache dirs + the impl's .alpackages (NOT extendedCaches,
                 // which includes wsDir — wsDir has no valid .app yet at this point anyway).
                 var implSymbolDirs = thisImplAlpackages.Concat(packageCacheDirs).Distinct().ToList();
-                var implResolver = new DependencyResolver(implSymbolDirs);
+                // RESOLUTION set (#2178): the compile set above, PLUS the workspace dirs of
+                // the impls already built by this loop and their .alpackages. This is what
+                // lets an impl declare a dependency on ANOTHER impl in the same invocation —
+                // the synthetic .app the earlier iteration wrote lives only in its workspace
+                // dir, which is otherwise not visible until this whole function returns
+                // extendedCaches to the per-bundle compiles below.
+                //
+                // Deliberately kept SEPARATE from implSymbolDirs, which is what
+                // SetResolvedDeps hands to BC's own .app scanner: a synthetic workspace .app
+                // carries no SymbolReference.json and makes that scanner report AL1023
+                // "package not valid" for the whole compilation. The compile-time half of an
+                // earlier impl travels through its *.symbols.json sidecar instead, via
+                // SetExtraSymbolDirs below — exactly the split the per-bundle compile in Main
+                // already uses (see the SetExtraSymbolDirs(layeredWorkspaceDirs) call sites).
+                var implResolveDirs = implSymbolDirs
+                    .Concat(priorImplDirs)
+                    .Concat(implAlpackagesDirs)
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .ToList();
+                var implResolver = new DependencyResolver(implResolveDirs);
                 var implDeps = implResolver.Resolve(implId.Dependencies);
                 BcCompiler.SetResolvedDeps(implDeps, implSymbolDirs);
+                // AFTER SetResolvedDeps, which resets _extraSymbolDirs. Passing an empty
+                // list is not the same as not calling it at all — the previous impl's call
+                // has already been cleared by SetResolvedDeps, so this is a no-op either way
+                // and the guard is only here to avoid churning the loader signature.
+                if (priorImplDirs.Count > 0)
+                    BcCompiler.SetExtraSymbolDirs(priorImplDirs);
                 using (BcCompiler.ScopeCurrentAppIdentity(implId.AppId, implId.Publisher, implId.Version))
                     new BcCompiler().EmitDepSymbols(new[] { implPath }, implId.Name, implId.AppId, implId.Publisher, implId.Version, symbolsPath, implPath);
                 // Declare the FULL compile closure — the resolved deps (real AppIds/versions)
@@ -6120,9 +6157,21 @@ static List<string> BuildSiblingSourceDeps(List<string> bundles, List<string> pa
     // keep a packaged copy under .alpackages; that package has authoritative symbols
     // (including tableextension field merging) while the sibling source is only needed
     // as a fallback when no package exists.
+    // #2178: worklist, not a single pass over the bundles' own declared deps. A sibling
+    // source app that gets BUILT here brings its own declared dependencies into scope, and
+    // those may themselves only exist as sibling source apps. Matching one level deep left
+    // the second level undiscovered entirely, so the chain failed inside this function's
+    // own per-dep resolve below with "Dependency not found" / a provisioning-gap report for
+    // an app sitting right next to the one being built. Only deps of apps we are actually
+    // going to build are enqueued: a dep already satisfied by a real .app package resolves
+    // through that package's own closure, exactly as before.
     var toBuild = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-    foreach (var dep in neededDeps)
+    var depQueue = new Queue<DependencyRef>(neededDeps);
+    var seenDeps = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+    while (depQueue.Count > 0)
     {
+        var dep = depQueue.Dequeue();
+        if (!seenDeps.Add($"{dep.AppId:N}|{dep.Publisher}/{dep.Name}")) continue;
         var packageAvailable = IsDependencyPackageAvailable(dep, existingPackageDirs);
         foreach (var (dir, sid) in sourceApps)
         {
@@ -6136,7 +6185,11 @@ static List<string> BuildSiblingSourceDeps(List<string> bundles, List<string> pa
             // workspace-deps .app (which carries no /resources/ part).
             AlRunner.Patches.NavAppResourcePatches.RegisterSourceDirForApp(sid.AppId, dir);
             if (!packageAvailable)
+            {
                 toBuild.Add(dir);
+                foreach (var transitive in sid.Dependencies.Where(d => !d.Optional))
+                    depQueue.Enqueue(transitive);
+            }
         }
     }
     if (toBuild.Count == 0) return packageCacheDirs;
@@ -6178,6 +6231,11 @@ static List<string> BuildSiblingSourceDeps(List<string> bundles, List<string> pa
     foreach (var dir in sorted)
     {
         if (!sourceApps.TryGetValue(dir, out var sid)) continue;
+        // The workspace dirs of the source deps already built by this loop, snapshotted
+        // before this dep's own dir joins the list. `sorted` is topological, so a dep this
+        // one depends on has necessarily been written by now — see the identical snapshot
+        // in RunLayeredPrePass and #2178.
+        var priorDepDirs = depDirs.ToList();
         // Per-dep cache dir keyed on THIS dep's own sources + dep identities.
         var depKey = ComputeSourceWorkspaceKey(new[] { dir }, sourceApps);
         var wsDir = Path.Combine(workspaceRoot, depKey[..12]);
@@ -6227,9 +6285,22 @@ static List<string> BuildSiblingSourceDeps(List<string> bundles, List<string> pa
         // Resolve pulls only this dep's declared closure (BaseApp / System App / …).
         // ScopeCurrentAppIdentity sets _currentAppId so GetSharedReferences excludes the dep
         // from its own specs (self-ref guard). Reset by the per-bundle SetResolvedDeps below.
-        var depResolver = new DependencyResolver(resolveDirs);
+        // #2178: resolve against the workspace dirs written for the source deps BUILT
+        // BEFORE this one as well, so a source dep may itself depend on another source dep.
+        // As in RunLayeredPrePass, those dirs are kept out of the set handed to
+        // SetResolvedDeps — BC's .app scanner reports AL1023 on a synthetic .app with no
+        // SymbolReference.json — and reach the compiler as *.symbols.json through
+        // SetExtraSymbolDirs instead.
+        var depResolveDirs = resolveDirs
+            .Concat(priorDepDirs)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+        var depResolver = new DependencyResolver(depResolveDirs);
         var resolvedDepDeps = depResolver.Resolve(sid.Dependencies);
         BcCompiler.SetResolvedDeps(resolvedDepDeps, resolveDirs);
+        // AFTER SetResolvedDeps, which resets _extraSymbolDirs.
+        if (priorDepDirs.Count > 0)
+            BcCompiler.SetExtraSymbolDirs(priorDepDirs);
         var symBase = Path.Combine(wsDir, $"{Sanitize(sid.Publisher)}_{Sanitize(sid.Name)}_{sid.Version.ToString().Replace('.', '_')}");
         var symbolsPath = symBase + ".symbols.json";
         var depsPath = symBase + ".symbols.deps.json";


### PR DESCRIPTION
Closes #2178

## What was actually wrong

Not package-cache propagation. Both source pre-passes in `Program.cs`
(`RunLayeredPrePass`, `BuildSiblingSourceDeps`) already pass the user's
`--package-cache` dirs into a source dependency's compile. What neither of them
passed was **their own output**.

Both build the apps they own in topological order, deps first, and write each one
into its own workspace dir under `workspace-deps/` — a synthetic source-only
`.app` carrying the runtime half, plus a `*.symbols.json` sidecar carrying the
compile half. Neither fed those freshly written dirs back into the *next* app's
compile: every iteration resolved against a list computed once, before the loop.

So the moment a chain was three apps deep — `test -> middle -> base`, with both
`middle` and `base` compiled from AL source in the same invocation — the middle
app could not see the base app at all:

```
[layered] WROTE R25 Vendor Ext 1.0.0.0 -> AL_Runner_R25_Vendor_Ext_1_0_0_0.app
<layered-deps>: COMPILE-FAIL - Dependency not found: AL Runner/R25 Vendor Ext v1.0.0.0
  Searched: .../platform-apps, .../test-apps
```

naming a package the runner had written itself one line earlier. Two apps never
reproduced it: the single impl in a two-app bundle has no impl dependency of its
own, which is exactly why the `dep-tableext-platform-base-{dep,main}` control in
the issue passes. So the answer to "source-compiled dependency, or chain deeper
than two layers?" is the second one — the depth is what matters, and the
`--package-cache` dirs were a red herring.

`BuildSiblingSourceDeps` had the same gap **plus one more**: it matched sibling
source apps only against the *bundles'* declared deps, so a sibling that a built
sibling depends on was never discovered at all. It failed one step earlier, as a
provisioning-gap report for an app sitting in the directory right next to it.

## The second failure shape in the issue

The `--package-cache ./precompiled` variant is a different bug and is not fixed by
propagation — it is fixed by making the message honest.

`./precompiled` held the runner's own synthetic source-only `.app`, which has no
`SymbolReference.json`. `DeduplicateAppPackageDirs` deliberately drops those (a
symbol-less package makes BC's scanner report AL1023 for the whole compilation),
and once it has collapsed the scan set the AL1022 text names one content-addressed
staging path. That path is accurate — it really is what BC searched — and useless:
the reader cannot tell that their directory reached the compile, and cannot see
that the one package that mattered was dropped on the way in. Hence "none of the
directories I passed."

The dedup pass now records, per staging dir, the origin dirs and the packages it
excluded, and the source-dependency compile failure appends that:

```
AL1022 A package with publisher 'AL Runner', name 'R25 Vendor Ext' ... could not be
found in the package cache folders: /tmp/al-runner-pkgdedup/9e924d1b8b658727
[al-runner] That folder is a deduplicated staging copy of: ~/.al-runner/platform-apps,
.../repro2125/precompiled, .../platform-apps, .../test-apps. Excluded from it, because
they carry no SymbolReference.json and so cannot supply compile-time symbols:
AL Runner/R25 Vendor Ext 1.0.0.0 (.../precompiled/AL_Runner_R25_Vendor_Ext_1_0_0_0.app).
```

Same class of defect as #2108: a search-set message that does not describe the set
actually searched sends people to look in the wrong place.

## RED evidence

The issue's own reproducer, unchanged, before the fix:

```
[layered] WROTE R25 Vendor Ext 1.0.0.0 -> AL_Runner_R25_Vendor_Ext_1_0_0_0.app (647 bytes)
<layered-deps>: COMPILE-FAIL - [layered] Failed to emit symbols for impl 'R25 Middle':
  Dependency not found: AL Runner/R25 Vendor Ext v1.0.0.0   [exit 3]
```

New tests, before the fix (`dotnet test --filter LayeredSourceChainTests`):

- `LayeredPrePass_ThreeSourceBundles_MiddleImplResolvesTheBaseImpl` — FAIL,
  `Dependency not found`, exit 3.
- `SiblingSourceDeps_ChainedSourceApps_MiddleSiblingResolvesTheBaseSibling` — FAIL,
  provisioning-gap report for `AL Runner/LSC Chain Base`, exit 2.
- `LayeredPrePass_BaseAppAbsent_FailsNamingTheMissingDependency` — passed before and
  after; it is the guard that the widened search set still stops at what exists.

`PkgDedupSearchSetProvenanceTests` was re-run with the drop-recording line deleted to
confirm it is not passing for free: `Assert.Contains() Failure: Sub-string not found`.

After the fix all five pass, and the issue's reproducer runs `1P/0F/0E`, exit 0.

## Fixing the shape, not the reported line

1. **Same wrong pattern at another call site?** Yes — `BuildSiblingSourceDeps`, fixed
   here too, with the extra transitive-discovery gap described above.
2. **Sibling function making the same assumption?** `EmitSiblingSymbols` is the third
   `EmitDepSymbols` caller and already maintains the invariant correctly: it calls
   `BcCompiler.RefreshSiblingSymbols()` inside its own loop so each app sees the
   symbols written for the apps before it. Left alone.
3. **Two paths writing the same state, same invariant?** Both pre-passes append to
   `workspaceDirsOut` and both are consumed by `SetExtraSymbolDirs` in `Main`. They now
   maintain the same in-loop invariant as well: each app's compile sees the workspace
   dirs already written by its own pass.

## Tests

- `AlRunner.Tests/LayeredSourceChainTests.cs` — three subprocess tests driving the real
  binary over a `test -> middle -> base` chain, once through each pre-pass, plus the
  absent-dependency negative. The fixtures assert concrete values through the chain
  (`(11*2)+3 = 25`, a marker string only the base app's codeunit produces) so a stub that
  returned a default cannot pass, and a `does not exist` negative so the lookup miss is
  not swallowed.
- `AlRunner.Tests/PkgDedupSearchSetProvenanceTests.cs` — the staging dir's description
  names every origin dir and the dropped package in full, does **not** list the package
  that was staged, and returns null for a diagnostic naming no staging dir.

These are runner-behavior claims (CLI multi-bundle wiring, a runner-emitted diagnostic),
not BC-behavior claims, so they belong in this repo rather than upstream.

## Suites run locally (this commit)

| Suite | Result |
|---|---|
| `dotnet test AlRunner.Tests` | 1063 passed, 0 failed, 60 skipped |
| `tests/runner-extras` cold / warm | 189P/0F/0E both, exit 0 |
| `tests/al-language` corpus cold / warm | 2161P/0F/0E both, exit 0 |
| issue reproducer, cold then warm | `1P/0F/0E` exit 0 both; warm run full cache HIT |

Run twice throughout per `local-test-scope.md` — this touches the workspace-deps and
shared-reference-loader caching paths.

## Note on the other issue in the reproducer

The reproducer's own AL test, which reads a transitive dependency's tableextension field
on `Vendor` at runtime, now passes as well. That is the shape issue #2125 describes; I am
not claiming this addresses it, and it is not linked as fixed here.

https://claude.ai/code/session_014JcikpL1FaA977QUkCSMYY
