### PR TITLE
fix(singleinstance): make a reset invalidate handles that already resolved the instance

### DIFF
--- a/AlRunner.Tests/SingleInstanceResetHandleInvalidationTests.cs
+++ b/AlRunner.Tests/SingleInstanceResetHandleInvalidationTests.cs
@@ -1,0 +1,181 @@
+// SingleInstanceResetHandleInvalidationTests — pins the invariant that makes a
+// SingleInstance codeunit have exactly ONE live instance at any moment, across BOTH of
+// the places the runner records which instance that is.
+//
+// The two places (this is the bug)
+// --------------------------------
+// 1. BcRuntime._singleInstanceCache — codeunit id -> instance, consulted by
+//    BcRuntime.NavCodeunitHandle_CreateTarget (our replacement for
+//    NavCodeunitHandle.CreateTarget).
+// 2. Every AL variable's own handle. NavApplicationObjectBaseHandle<T>.get_Target is
+//    unmodified BC code and reads:
+//
+//        target = Tree.GetReferenceTarget();
+//        if (target == null && !Tree.IsDisposed) {
+//            target = CreateTarget();              // <- our patch
+//            Tree.SetReferenceTarget(target);      // <- second copy of the answer
+//        }
+//        return target;
+//
+//    So a handle calls CreateTarget exactly ONCE and remembers what it got, for as long
+//    as the AL variable holding it lives.
+//
+// ResetSingleInstanceCache() used to maintain only (1). Any handle that had already
+// resolved kept answering with the dropped instance, so AL writing through a handle bound
+// before the reset and AL reading through a handle bound after it silently addressed two
+// different objects — the writer's state was invisible to the reader, and neither side
+// had any way to notice.
+//
+// Why this is a runner-side test and not an AL corpus test
+// -------------------------------------------------------
+// The AL-level claim ("a SingleInstance codeunit keeps its state across a callback in the
+// same test") is plain BC behaviour and is already covered upstream — corpus codeunits
+// 60237 "Test Event ByRef Mut" and 60922 "ASK Tests" both write a SingleInstance codeunit
+// from a test method and read it back from a callback. What THIS file pins is the runner's
+// own cache/handle bookkeeping, which no AL test can address directly: the divergence is
+// only reachable when a reset fires while an AL object holding a bound handle is still
+// alive, and which moments those are is a property of TestExecutor's isolation wiring, not
+// of AL. It was reachable in #2144 (a per-test reset under Codeunit isolation, where the
+// test codeunit instance is shared by every test in the codeunit) and cost 15 corpus
+// tests; #2161 changed the reset placement, which hid it again without fixing it. This
+// test asserts the invariant directly so the next isolation change cannot re-expose it.
+
+using AlRunner;
+using Microsoft.Dynamics.Nav.Runtime;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// A minimal SingleInstance codeunit for the tests below. Named <c>Codeunit69001</c>
+/// because BcRuntime.FindCodeunitType resolves a codeunit id to the type literally named
+/// <c>Codeunit{id}</c>; 69001 is outside every AL idRange this repo declares, so it can
+/// never collide with a compiled AL object. IsSingleInstance is BC's own public virtual
+/// property — overriding it here is exactly what BC's AL emitter does for a codeunit
+/// declaring <c>SingleInstance = true</c>, so CreateTarget's real, unmodified
+/// <c>instance.IsSingleInstance</c> read sees faithful metadata.
+/// </summary>
+internal sealed class Codeunit69001 : NavCodeunit
+{
+    public Codeunit69001(ITreeObject parent) : base(parent, 69001) { }
+
+    public override bool IsSingleInstance => true;
+
+    /// <summary>Stands in for an AL instance variable — the state whose visibility is
+    /// the whole point of SingleInstance.</summary>
+    public string Token { get; set; } = string.Empty;
+}
+
+// Loads Ncl types in-process, so it shares the serial bc-engine collection with the class
+// that Cecil-rewrites Ncl.dll on disk. See BcEngineCollection.cs.
+[Collection(BcEngineCollection.Name)]
+public class SingleInstanceResetHandleInvalidationTests
+{
+    private const int ProbeId = 69001;
+
+    private readonly BcEngineFixture _engine;
+
+    public SingleInstanceResetHandleInvalidationTests(BcEngineFixture engine) => _engine = engine;
+
+    private ITreeObject Root()
+    {
+        var root = BcRuntime.RootTreeStub;
+        Assert.True(root != null,
+            "BcRuntime.RootTreeStub is null after the engine bootstrap — the skeleton tree these " +
+            "handles must be parented on does not exist, so this test cannot run at all.");
+        return root!;
+    }
+
+    /// <summary>
+    /// Positive: within one reset window every handle — however many AL variables name the
+    /// codeunit — resolves to the SAME instance, so state written through one is visible
+    /// through the other. This is the property SingleInstance exists to provide, and it is
+    /// also the guard against "fix" the invalidation by simply never caching.
+    /// </summary>
+    [SkippableFact]
+    public void WithinOneResetWindow_EveryHandleResolvesTheSameInstance()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready,
+            _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        BcRuntime.ResetSingleInstanceCache();
+        var root = Root();
+
+        var writer = new NavCodeunitHandle(root, ProbeId);
+        var written = Assert.IsType<Codeunit69001>(writer.Target);
+        written.Token = "WINDOW-1";
+
+        var reader = new NavCodeunitHandle(root, ProbeId);
+        var read = Assert.IsType<Codeunit69001>(reader.Target);
+
+        Assert.Same(written, read);
+        Assert.Equal("WINDOW-1", read.Token);
+    }
+
+    /// <summary>
+    /// The bug. A handle that resolved BEFORE ResetSingleInstanceCache() must not keep
+    /// handing back the instance the reset dropped — it must re-resolve and agree with a
+    /// handle bound after the reset.
+    ///
+    /// Asserts both directions of the same identity, because either alone is satisfiable
+    /// by a broken implementation: NotSame(before, after) alone passes today (the reset
+    /// does drop the cache entry), and Same(stale.Target, after) alone would pass if the
+    /// reset simply stopped dropping anything.
+    /// </summary>
+    [SkippableFact]
+    public void AfterReset_AHandleBoundBeforeIt_ReResolvesToTheNewInstance()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready,
+            _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        BcRuntime.ResetSingleInstanceCache();
+        var root = Root();
+
+        // An AL variable that resolved in the previous test window and is still alive.
+        var boundBefore = new NavCodeunitHandle(root, ProbeId);
+        var before = Assert.IsType<Codeunit69001>(boundBefore.Target);
+        before.Token = "BEFORE-RESET";
+
+        BcRuntime.ResetSingleInstanceCache();
+
+        // A callback's own local variable, resolving for the first time after the reset.
+        var boundAfter = new NavCodeunitHandle(root, ProbeId);
+        var after = Assert.IsType<Codeunit69001>(boundAfter.Target);
+
+        Assert.NotSame(before, after);
+        Assert.Equal(string.Empty, after.Token);
+
+        // The invariant: the surviving handle must now see what everyone else sees.
+        Assert.Same(after, boundBefore.Target);
+
+        // And state written through the surviving handle after the reset must be visible
+        // through the freshly bound one — the exact read/write pairing #2143 reported as
+        // broken (test method writes, callback reads, same test).
+        ((Codeunit69001)boundBefore.Target).Token = "AFTER-RESET";
+        Assert.Equal("AFTER-RESET", ((Codeunit69001)boundAfter.Target).Token);
+    }
+
+    /// <summary>
+    /// Negative: the reset must still be a real boundary. A fix that kept every handle
+    /// pointing at one immortal instance would satisfy the test above and silently leak
+    /// SingleInstance state from one test into the next, which is what
+    /// ResetSingleInstanceCache exists to prevent.
+    /// </summary>
+    [SkippableFact]
+    public void AfterReset_StateWrittenBeforeIt_IsNotVisible()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready,
+            _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        BcRuntime.ResetSingleInstanceCache();
+        var root = Root();
+
+        var first = new NavCodeunitHandle(root, ProbeId);
+        ((Codeunit69001)first.Target).Token = "LEAKED";
+
+        BcRuntime.ResetSingleInstanceCache();
+
+        var second = new NavCodeunitHandle(root, ProbeId);
+        Assert.Equal(string.Empty, ((Codeunit69001)second.Target).Token);
+    }
+}

--- a/AlRunner/Patches/CodeunitPatches.cs
+++ b/AlRunner/Patches/CodeunitPatches.cs
@@ -43,6 +43,48 @@ public static partial class BcRuntime
     // long as the cache entry does.
     private static readonly ConcurrentDictionary<int, Microsoft.Dynamics.Nav.Runtime.NavCodeunitHandle> _singleInstanceKeepAlive = new();
 
+    // Every AL variable handle that has already resolved a SingleInstance codeunit through
+    // NavCodeunitHandle_CreateTarget, held WEAKLY so a handle whose AL scope has gone can
+    // still be collected.
+    //
+    // _singleInstanceCache above is NOT the only place recording "which object is the
+    // instance of codeunit N". NavApplicationObjectBaseHandle<T>.get_Target is unmodified
+    // BC code and reads, in IL:
+    //
+    //     target = Tree.GetReferenceTarget();
+    //     if (target == null && !Tree.IsDisposed) {
+    //         target = CreateTarget();            // our replacement, consults the cache
+    //         Tree.SetReferenceTarget(target);    // the SECOND copy of the answer
+    //     }
+    //     return target;
+    //
+    // so a handle calls CreateTarget exactly ONCE and then answers from its own tree for as
+    // long as the AL variable holding it lives. Clearing only the cache left those handles
+    // returning the instance the reset had dropped, while any handle resolving afterwards
+    // got a new one — two live "single" instances, and AL writing through one could not be
+    // read through the other. That is issue #2143: it cost 15 corpus tests under #2144's
+    // per-test reset (where the test codeunit instance, and therefore its global Codeunit
+    // variables' handles, is shared by every test in the codeunit), and #2161 moved the
+    // reset rather than fixing it. Registering here and invalidating below keeps the two
+    // records in step whenever the reset fires, not only where it happens to fire today.
+    private static readonly List<WeakReference<Microsoft.Dynamics.Nav.Runtime.NavCodeunitHandle>>
+        _singleInstanceBoundHandles = new();
+    private static readonly object _singleInstanceBoundHandlesLock = new();
+
+    /// <summary>
+    /// Remember that <paramref name="handle"/> is about to cache a SingleInstance codeunit
+    /// instance of its own, so <see cref="ResetSingleInstanceCache"/> can make it re-resolve.
+    /// Called from NavCodeunitHandle_CreateTarget on every path that hands a SingleInstance
+    /// instance back — including the cache-hit path, because the handle receiving the hit is
+    /// a DIFFERENT handle each time and each one caches the answer independently.
+    /// </summary>
+    private static void TrackSingleInstanceBinding(Microsoft.Dynamics.Nav.Runtime.NavCodeunitHandle handle)
+    {
+        lock (_singleInstanceBoundHandlesLock)
+            _singleInstanceBoundHandles.Add(
+                new WeakReference<Microsoft.Dynamics.Nav.Runtime.NavCodeunitHandle>(handle));
+    }
+
     /// <summary>
     /// Drop every cached SingleInstance codeunit instance. Must run at the per-test-isolation
     /// boundary (see RecordPatches.ResetPerTestState) so SingleInstance field state does not
@@ -50,10 +92,45 @@ public static partial class BcRuntime
     /// </summary>
     public static void ResetSingleInstanceCache()
     {
+        // Invalidate the per-handle copies FIRST — see _singleInstanceBoundHandles. Doing it
+        // before the dictionaries are cleared matters only for readability; what matters for
+        // correctness is that no handle is left holding an instance the cache no longer has.
+        InvalidateBoundSingleInstanceHandles();
         // Release the keep-alive references first: dropping them is what lets BC's refcount
         // fall to zero and dispose the instances, which is the per-test cleanup real BC does.
         _singleInstanceKeepAlive.Clear();
         _singleInstanceCache.Clear();
+    }
+
+    /// <summary>
+    /// Clear the cached target of every handle that resolved a SingleInstance codeunit, so
+    /// its next <c>Target</c> read goes back through CreateTarget and picks up the instance
+    /// everyone else is using.
+    ///
+    /// NavCodeunitHandle.ClearReference() is BC's own public API for exactly this — it is
+    /// <c>set_Target(null)</c>, i.e. <c>Tree.SetReferenceTarget(null)</c>, which is the only
+    /// state get_Target consults before rebuilding. It also drops the handle's reference on
+    /// the instance, but that cannot dispose the instance here: the session-rooted keep-alive
+    /// handle (see _singleInstanceKeepAlive) is still holding one at this point, so the
+    /// refcount cannot reach zero while this loop runs.
+    /// </summary>
+    private static void InvalidateBoundSingleInstanceHandles()
+    {
+        lock (_singleInstanceBoundHandlesLock)
+        {
+            foreach (var weak in _singleInstanceBoundHandles)
+            {
+                if (!weak.TryGetTarget(out var handle))
+                    continue;   // the AL scope holding it is gone; nothing can read it again
+                // A disposed handle's tree already refuses to rebuild (get_Target returns
+                // whatever GetReferenceTarget gives and skips CreateTarget when IsDisposed),
+                // and touching it would only risk an ObjectDisposedException for no gain.
+                if (handle.IsDisposed || !handle.HasTarget)
+                    continue;
+                handle.ClearReference();
+            }
+            _singleInstanceBoundHandles.Clear();
+        }
     }
 
     // Fallback cache: report ID → skeleton NCLMetaReport built via CreateEmptyNCLMetaReport
@@ -267,7 +344,11 @@ public static partial class BcRuntime
         // its instance fields keep whatever state prior calls left in them. See the handle/
         // parent note below for why reusing the first caller's tree-parent is correct here.
         if (_singleInstanceCache.TryGetValue(id, out var cachedInstance))
+        {
+            // `self` is about to store this in its own tree (see TrackSingleInstanceBinding).
+            TrackSingleInstanceBinding(self);
             return cachedInstance;
+        }
 
         var codeunitType = _codeunitTypeCache.GetOrAdd(id, FindCodeunitType);
         if (codeunitType == null)
@@ -321,6 +402,7 @@ public static partial class BcRuntime
 
             _singleInstanceCache[id] = instance;
             KeepSingleInstanceAlive(id, instance);
+            TrackSingleInstanceBinding(self);
         }
 
         return instance;


### PR DESCRIPTION
Closes #2143

## What was actually wrong

`BcRuntime._singleInstanceCache` is not the only place the runner records "which object is *the* instance of SingleInstance codeunit N". `NavApplicationObjectBaseHandle<T>.get_Target` is unmodified BC code, and in IL it reads:

```
target = Tree.GetReferenceTarget();
if (target == null && !Tree.IsDisposed) {
    target = CreateTarget();            // our replacement, consults the cache
    Tree.SetReferenceTarget(target);    // the SECOND copy of the answer
}
return target;
```

So a handle calls `CreateTarget` **exactly once** and answers from its own tree forever after — for as long as the AL variable holding it lives. `ResetSingleInstanceCache()` maintained only the dictionary. Every handle that had already resolved kept returning the instance the reset dropped, while anything resolving after the reset got a new one. Two live "single" instances, and AL writing through one could not be read through the other.

The fix registers (weakly) every handle `CreateTarget` hands a SingleInstance instance to — including on the cache-hit path, since that is a *different* handle each time and each one caches independently — and the reset clears their cached targets with BC's own `NavCodeunitHandle.ClearReference()` so they re-resolve. The session-rooted keep-alive handle still holds a reference while that loop runs, so no instance is disposed early and disposal semantics are unchanged.

## The AL pattern that triggers it

A test method writes a `SingleInstance` codeunit through one variable and a callback reads it back through another:

```al
codeunit 69001 "SI Probe State" { SingleInstance = true;
    var Token: Code[50];
    procedure SetToken(t: Code[50]) begin Token := t; end;
    procedure GetToken(): Code[50] begin exit(Token); end; }

codeunit 69010 "SI Probe Tests" { Subtype = Test;
    var State: Codeunit "SI Probe State";       // <- handle lives as long as the test codeunit
    [Test] procedure T2() begin
        State.SetToken('TOKEN-02');             // writes through the handle bound in T1
        Row.Insert(true);                       // subscriber's own local Codeunit variable
        ...                                     // reads '' — a different instance
    end; }
```

It fires whenever a reset lands between two uses of a *shared* handle, i.e. when the test codeunit instance is shared across tests and a reset happens between them.

## RED evidence

Three separate measurements, all on BC 28.1.49838.53910.

**1. Runner-side mechanism test** (`AlRunner.Tests/SingleInstanceResetHandleInvalidationTests.cs`), RED on `main` before the fix:

```
AfterReset_AHandleBoundBeforeIt_ReResolvesToTheNewInstance [FAIL]
  Assert.Same() Failure: Values are not the same instance
  Expected: 69001
  Actual:   69001
  at ...SingleInstanceResetHandleInvalidationTests.cs:line 149
Failed! - Failed: 1, Passed: 2, Skipped: 0, Total: 3
```

The other two tests in the file passed while the bug was present, deliberately: `WithinOneResetWindow_EveryHandleResolvesTheSameInstance` (a "fix" that never caches would break it) and `AfterReset_StateWrittenBeforeIt_IsNotVisible` (a "fix" that never resets would break it). Neither alone catches the defect; the three together pin it from both sides. After the fix: `Passed! - Failed: 0, Passed: 3`.

**2. AL-level reproduction.** A purpose-built probe suite (SingleInstance state written by a `[Test]`, read back from an `[EventSubscriber]`, a table `OnInsert` trigger, and a page action's `OnAction`) run against `2622f364` — the commit where the reset lands between tests that share the codeunit instance:

| | before fix | after fix |
|---|---|---|
| `--isolation codeunit` | **1 pass / 5 fail** | **6 pass / 0 fail** |
| `--isolation test` | 6 pass / 0 fail | 6 pass / 0 fail |

Only the first test in the codeunit passed — the signature of a handle binding in test 1 and going stale for every test after it.

**3. Instrumented trace** confirming the mechanism rather than inferring it. Logging every `CreateTarget` resolution with instance identity, under codeunit isolation at that commit:

```
RESET clearing []
NEW  69001 -> #24686589 handle#21819209     <- test 1: test codeunit's global binds
HIT  69001 -> #24686589 handle#2357503      <- test 1: subscriber's local
HIT  69001 -> #24686589 handle#47310067     <- test 1: page action's local     => PASS
RESET clearing [69001]
NEW  69001 -> #29158541 handle#13031584     <- test 2: subscriber's local
HIT  69001 -> #29158541 handle#3535220                                          => FAIL
```

Test 1 shows three resolutions, test 2 only two. The missing one is the test codeunit's own global — it never called `CreateTarget` again, because its tree still held `#24686589`. That is the bug, seen directly.

## A correction to the issue as written

#2143's body attributes 15 corpus failures (13 in `Codeunit60237`, 2 in `Codeunit60922`) to this defect. Measured, they are **not** this defect:

* On current `main` (ae1e1d6b) all 15 pass, under both `--isolation codeunit` (2164/2164) and `--isolation test`.
* At `2622f364`, where they do fail, tracing shows the SingleInstance instance was **identical** for the writer and every reader in each failing test (`NEW #19420176` followed by six `HIT #19420176`), so instance identity was never the cause there.
* Applying this fix at that commit leaves all 15 still failing, while curing the AL probe above. They belong to the record-mutation family #2170 fixed, plus a separate AutoSplitKey-vs-action-save ordering problem.

So the defect named in the issue **title** is real and is what this PR fixes; the failures quoted in the issue **body** were a different bug that has since been fixed independently. The window that made this one AL-reachable was closed by #2161 moving the reset, not by fixing it — which is why the proving test is runner-side, and why it is worth pinning: the next isolation change re-opens it otherwise.

## Fix the shape, not just the reported line

**1. Same wrong pattern at another call site?** No. The other four `*Handle_CreateTarget` replacements (`NavTestPageHandle`, `NavFormHandle`, `NavReportHandle`, `NavQueryHandle`) cache only the *Type* and construct a fresh instance on every resolution, so no handle can be left holding a dropped one. `_singleInstanceCache` is the runner's only instance-identity cache.

**2. Sibling function making the same assumption?** `BcRuntime.ResetForNewBundleReload()` clears every bundle-derived *type* cache but not `_singleInstanceCache`, which holds instances of those very types — by that method's own stated contract ("without serving stale record/codeunit CLR types") it belongs in the list. Checked both callers (`Program.cs:1814` watch mode, `Program.cs:3317` server mode): each is followed by `TestExecutor.Run`, whose bundle-start `RecordPatches.ResetPerTestState()` clears the SingleInstance cache before any test body runs. No reachable window, so left alone rather than guessing at server-mode ordering.

**3. Two code paths writing the same state, same invariant?** Yes — and it is this bug. A **third** record turned up in the same function and is filed as #2181 rather than fixed here: `_singleInstanceKeepAlive.Clear()` drops the runner's dictionary reference, but those handles were constructed parented on the skeleton session, so the session tree still owns them and they still hold a reference on the instance. Measured on `main`: 20 reset cycles grow the session tree's child chain from 3 to 43 children, exactly 2 per cycle, never shrinking. Fixing it means changing disposal, which re-opens the "disposed tree returns NULL instead of rebuilding" NRE hazard `KeepSingleInstanceAlive`'s own comment documents — that needs its own RED/GREEN, so it is a follow-up, not silence.

## Where the proving test lives

Runner-side (`AlRunner.Tests/`), not upstream, on purpose. The AL-level claim is plain BC behaviour and is **already** covered upstream — corpus codeunits 60237 "Test Event ByRef Mut" and 60922 "ASK Tests" both write a SingleInstance codeunit from a test method and read it back from a callback, and both are green on real BC 27.5 and 28.3. What no AL test can address is the runner's own cache/handle bookkeeping: whether the divergence is reachable depends on when `TestExecutor` fires the reset, which is a property of the runner, not of AL. No corpus PR and no submodule pin bump are needed for this change.

## Test evidence, all actually run at this commit on BC 28.1.49838.53910

| Suite | Result |
|---|---|
| `SingleInstanceResetHandleInvalidationTests` | RED 1F/2P before, GREEN 3P after |
| al-language corpus, default isolation, `--strict --count-baseline` | 2164P / 0F / 0E |
| al-language corpus, `--isolation test` | 2162P / 2F — the same two (`Codeunit60897`/`Codeunit60898` `Test02`) that fail on unmodified `main` under this mode by design, since they assert codeunit-scope survival |
| `tests/runner-extras`, `--strict` | 189P / 0F / 0E |
| AL probe suite at `2622f364`, `--isolation codeunit` | 1P/5F before → 6P/0F after |
