### PR TITLE
fix(cli): a bundle directory passed twice runs once, not twice

### DIFF
--- a/AlRunner.Tests/BundleRootDeduplicationTests.cs
+++ b/AlRunner.Tests/BundleRootDeduplicationTests.cs
@@ -1,0 +1,304 @@
+// BundleRootDeduplicationTests — RED->GREEN guard for issue #2136.
+//
+// The bug: the same bundle directory passed twice on one command line ran twice, so a
+// 1-test bundle reported 2 tests. Nothing crashed (that was #1692, fixed), but the test
+// count silently doubled — and the test count is what CI gates on and what
+// tests/expectations/count-baseline/ pins.
+//
+// The behaviour pinned here: two positional arguments that name the SAME DIRECTORY ON
+// DISK run once. "Same directory" is decided on the resolved real path — absolute,
+// with '.'/'..' collapsed, trailing separators trimmed, and symlinks followed — not on
+// the argument string, so `x`, `./x`, `/abs/x`, `x/` and a symlink to `x` all collapse
+// onto one another. The first spelling wins and argument order is preserved.
+//
+// Ghost-test trap avoided in both directions:
+//   * a no-op "fix" (or a raw-string Distinct(), which fixes only the identical-spelling
+//     case) fails RelativeAndAbsolute_*, TrailingSeparator_*, DotSegment_* and
+//     Symlink_*, because each asserts a concrete kept/dropped list, not merely
+//     "did not crash";
+//   * an over-eager fix that collapses distinct directories fails
+//     DistinctDirectories_AreBothKept and SameAppIdentityInTwoDirectories_AreBothKept —
+//     the latter pins that bundle IDENTITY is deliberately NOT the dedup key. Two
+//     different directories declaring the same app id already have their own loud,
+//     deliberate handling (the #1683 "AppId … already loaded earlier in this process"
+//     module reuse); collapsing them here would silently discard an argument the user
+//     really did type twice on purpose.
+using System.Diagnostics;
+using System.Text;
+using AlRunner.Infrastructure;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class BundleRootDeduplicationTests : IDisposable
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+    private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
+
+    private readonly string _root;
+
+    public BundleRootDeduplicationTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "al-runner-bundle-dedup", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { }
+    }
+
+    private string MakeDir(string name)
+    {
+        var p = Path.Combine(_root, name);
+        Directory.CreateDirectory(p);
+        return p;
+    }
+
+    // ── unit: the resolved-path dedup itself ─────────────────────────────────────
+
+    [Fact]
+    public void IdenticalSpelling_RunsOnce_AndNamesTheDroppedArgument()
+    {
+        var a = MakeDir("alpha");
+
+        var r = BundleRootDeduplication.Deduplicate(new[] { a, a });
+
+        Assert.Equal(new[] { a }, r.Roots);
+        var dropped = Assert.Single(r.Dropped);
+        Assert.Equal(a, dropped.Argument);
+        Assert.Equal(a, dropped.KeptArgument);
+        Assert.Equal(a, dropped.ResolvedPath);
+    }
+
+    [Fact]
+    public void RelativeAndAbsolute_CollapseToOne_KeepingTheFirstSpelling()
+    {
+        var a = MakeDir("alpha");
+        var relative = Path.GetRelativePath(Environment.CurrentDirectory, a);
+
+        var r = BundleRootDeduplication.Deduplicate(new[] { relative, a });
+
+        Assert.Equal(new[] { relative }, r.Roots);
+        var dropped = Assert.Single(r.Dropped);
+        Assert.Equal(a, dropped.Argument);
+        Assert.Equal(relative, dropped.KeptArgument);
+        Assert.Equal(a, dropped.ResolvedPath);
+    }
+
+    [Fact]
+    public void TrailingSeparator_CollapsesOntoTheSamePath()
+    {
+        var a = MakeDir("alpha");
+
+        var r = BundleRootDeduplication.Deduplicate(new[] { a, a + Path.DirectorySeparatorChar });
+
+        Assert.Equal(new[] { a }, r.Roots);
+        Assert.Single(r.Dropped);
+    }
+
+    [Fact]
+    public void DotSegment_CollapsesOntoTheSamePath()
+    {
+        var a = MakeDir("alpha");
+        var viaDots = Path.Combine(_root, "alpha", "..", "alpha");
+
+        var r = BundleRootDeduplication.Deduplicate(new[] { a, viaDots });
+
+        Assert.Equal(new[] { a }, r.Roots);
+        Assert.Equal(a, Assert.Single(r.Dropped).ResolvedPath);
+    }
+
+    [SkippableFact]
+    public void Symlink_AndItsTarget_CollapseToOne()
+    {
+        var a = MakeDir("alpha");
+        var link = Path.Combine(_root, "alpha-link");
+        Skip.IfNot(TryCreateSymlink(a, link), "the filesystem does not allow creating symlinks here");
+
+        var r = BundleRootDeduplication.Deduplicate(new[] { a, link });
+
+        Assert.Equal(new[] { a }, r.Roots);
+        Assert.Equal(link, Assert.Single(r.Dropped).Argument);
+    }
+
+    [SkippableFact]
+    public void Symlink_InAnIntermediateComponent_CollapsesToo()
+    {
+        var real = MakeDir(Path.Combine("real-parent", "alpha"));
+        var linkParent = Path.Combine(_root, "link-parent");
+        Skip.IfNot(TryCreateSymlink(Path.Combine(_root, "real-parent"), linkParent),
+            "the filesystem does not allow creating symlinks here");
+        var viaLink = Path.Combine(linkParent, "alpha");
+
+        var r = BundleRootDeduplication.Deduplicate(new[] { real, viaLink });
+
+        Assert.Equal(new[] { real }, r.Roots);
+        Assert.Equal(real, Assert.Single(r.Dropped).ResolvedPath);
+    }
+
+    [SkippableFact]
+    public void RelativeSymlink_ResolvesAgainstTheLinkDirectory_NotTheWorkingDirectory()
+    {
+        var a = MakeDir("alpha");
+        var link = Path.Combine(_root, "alpha-rel-link");
+        Skip.IfNot(TryCreateSymlink("alpha", link),   // stored relative to _root
+            "the filesystem does not allow creating symlinks here");
+
+        Assert.Equal(a, BundleRootDeduplication.Canonicalize(link));
+    }
+
+    // ── negative direction: genuinely different bundles must still both run ──────
+
+    [Fact]
+    public void DistinctDirectories_AreBothKept()
+    {
+        var a = MakeDir("alpha");
+        var b = MakeDir("beta");
+
+        var r = BundleRootDeduplication.Deduplicate(new[] { a, b });
+
+        Assert.Equal(new[] { a, b }, r.Roots);
+        Assert.Empty(r.Dropped);
+    }
+
+    [Fact]
+    public void SameAppIdentityInTwoDirectories_AreBothKept()
+    {
+        // Identity is deliberately NOT the dedup key — see the header comment.
+        const string manifest = """
+        { "id": "a1b2c3d4-2136-4a1b-9c3d-000000000001", "name": "Dup 2136",
+          "publisher": "Repro2136", "version": "1.0.0.0", "dependencies": [],
+          "platform": "1.0.0.0", "application": "1.0.0.0",
+          "idRanges": [ { "from": 62430, "to": 62439 } ], "runtime": "14.0" }
+        """;
+        var a = MakeDir("copy-a");
+        var b = MakeDir("copy-b");
+        File.WriteAllText(Path.Combine(a, "app.json"), manifest);
+        File.WriteAllText(Path.Combine(b, "app.json"), manifest);
+
+        var r = BundleRootDeduplication.Deduplicate(new[] { a, b });
+
+        Assert.Equal(new[] { a, b }, r.Roots);
+        Assert.Empty(r.Dropped);
+    }
+
+    [Fact]
+    public void ThreeWayDuplicate_KeepsOne_AndReportsBothDrops()
+    {
+        var a = MakeDir("alpha");
+        var b = MakeDir("beta");
+
+        var r = BundleRootDeduplication.Deduplicate(
+            new[] { a, b, a + Path.DirectorySeparatorChar, Path.Combine(_root, "alpha", ".") });
+
+        Assert.Equal(new[] { a, b }, r.Roots);
+        Assert.Equal(2, r.Dropped.Count);
+        Assert.All(r.Dropped, d => Assert.Equal(a, d.KeptArgument));
+    }
+
+    [Fact]
+    public void NoDuplicates_ProduceNoNotice()
+    {
+        var r = BundleRootDeduplication.Deduplicate(new[] { MakeDir("alpha"), MakeDir("beta") });
+        Assert.Null(BundleRootDeduplication.DescribeDropped(r.Dropped));
+    }
+
+    [Fact]
+    public void Notice_NamesBothSpellingsAndTheResolvedPath()
+    {
+        var a = MakeDir("alpha");
+        var relative = Path.GetRelativePath(Environment.CurrentDirectory, a);
+
+        var r = BundleRootDeduplication.Deduplicate(new[] { relative, a });
+        var notice = BundleRootDeduplication.DescribeDropped(r.Dropped);
+
+        Assert.NotNull(notice);
+        Assert.Contains("duplicate bundle argument", notice);
+        Assert.Contains(relative, notice);
+        Assert.Contains(a, notice);
+    }
+
+    [Fact]
+    public void Canonicalize_DoesNotThrow_OnAPathThatDoesNotExist()
+    {
+        var missing = Path.Combine(_root, "no", "such", "dir");
+        Assert.Equal(missing, BundleRootDeduplication.Canonicalize(missing));
+    }
+
+    [Fact]
+    public void EmptyAndWhitespaceArguments_AreLeftAlone()
+    {
+        var r = BundleRootDeduplication.Deduplicate(new[] { "", " " });
+        Assert.Equal(new[] { "", " " }, r.Roots);
+        Assert.Empty(r.Dropped);
+    }
+
+    // ── CLI: the reported test count is what the issue is actually about ─────────
+
+    [SkippableFact]
+    public void Cli_SameBundleTwice_RunsOnceAndReportsOneTest()
+    {
+        TestArtifacts.SkipIfMissing();
+        var fixture = Path.Combine(RepoRoot, "AlRunner.Tests", "Fixtures", "RecordTriggerXRec");
+
+        var single = RunRunner(fixture);
+        Assert.True(single.exit == 0, single.output);
+        Assert.True(single.output.Contains("Tests:         1 total"), single.output);
+
+        var doubled = RunRunner(fixture, fixture);
+
+        Assert.True(doubled.exit == 0, doubled.output);
+        // The count is the whole point of #2136: two arguments must not double it.
+        Assert.True(doubled.output.Contains("Tests:         1 total"), doubled.output);
+        Assert.True(doubled.output.Contains("Buckets:       1 total"), doubled.output);
+        Assert.True(doubled.output.Contains("duplicate bundle argument"), doubled.output);
+    }
+
+    [SkippableFact]
+    public void Cli_TwoDistinctBundles_StillRunTwice()
+    {
+        TestArtifacts.SkipIfMissing();
+        var fixture = Path.Combine(RepoRoot, "AlRunner.Tests", "Fixtures", "RecordTriggerXRec");
+        var copy = MakeDir("cli-copy");
+        foreach (var f in Directory.GetFiles(fixture))
+            File.Copy(f, Path.Combine(copy, Path.GetFileName(f)));
+
+        var r = RunRunner(fixture, copy);
+
+        Assert.True(r.exit == 0, r.output);
+        Assert.True(r.output.Contains("Tests:         2 total"), r.output);
+        Assert.True(!r.output.Contains("duplicate bundle argument"), r.output);
+    }
+
+    private static bool TryCreateSymlink(string target, string link)
+    {
+        try { Directory.CreateSymbolicLink(link, target); return Directory.Exists(link); }
+        catch (IOException) { return false; }
+        catch (UnauthorizedAccessException) { return false; }
+        catch (PlatformNotSupportedException) { return false; }
+    }
+
+    private static (string output, int exit) RunRunner(params string[] bundles)
+    {
+        var args = new StringBuilder(TestBuildConfig.RunArgs(ProjectPath));
+        args.Append(TestBuildConfig.BcVersionArg);
+        foreach (var b in bundles) args.Append(" \"").Append(b).Append('"');
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet", Arguments = args.ToString(),
+            RedirectStandardOutput = true, RedirectStandardError = true,
+            UseShellExecute = false, CreateNoWindow = true, WorkingDirectory = RepoRoot,
+        };
+        var sb = new StringBuilder();
+        var p = Process.Start(psi)!;
+        p.OutputDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.ErrorDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.BeginOutputReadLine();
+        p.BeginErrorReadLine();
+        if (!p.WaitForExit(300_000)) { try { p.Kill(true); } catch { } throw new TimeoutException("runner hung"); }
+        p.WaitForExit();
+        lock (sb) return (sb.ToString(), p.ExitCode);
+    }
+}

--- a/AlRunner.Tests/ServerDuplicateSourcePathTests.cs
+++ b/AlRunner.Tests/ServerDuplicateSourcePathTests.cs
@@ -1,0 +1,122 @@
+using System.Text.Json;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// Issue #2136 over <c>--server</c> instead of the CLI. The reported symptom was the
+/// CLI's (<c>al-runner ./x ./x</c> ran the bundle twice and reported twice the tests),
+/// but <c>RunAllBundlesForServer</c> made the same assumption one call site over: it
+/// iterated <c>sourcePaths</c> as given, so a request naming the same directory twice
+/// produced two <c>ServerRunResult</c>s, which <c>HandleRunTests</c> then
+/// <c>SelectMany</c>'d into a doubled test list and a doubled summary <c>total</c>.
+///
+/// RED (pre-fix): <c>total</c> is 2 for a 1-test bundle named twice.
+/// GREEN (post-fix): 1 — the duplicate is dropped by resolved real path, with a notice
+/// on stderr naming the argument that went.
+///
+/// The negative direction matters just as much and is pinned here too: two GENUINELY
+/// DIFFERENT directories must still both run. Identity is deliberately not the dedup
+/// key (see <see cref="AlRunner.Infrastructure.BundleRootDeduplication"/>).
+///
+/// Spawns the real runner in --server mode; needs the BC artifact cache. Skips when absent.
+/// </summary>
+public class ServerDuplicateSourcePathTests
+{
+    private static string MakeBundle(string dirName, string appId, int idFrom, int codeunitId)
+    {
+        var root = Path.Combine(Path.GetTempPath(), "al-runner-server-dup-2136", Guid.NewGuid().ToString("N"));
+        var dir = Path.Combine(root, dirName);
+        Directory.CreateDirectory(dir);
+
+        File.WriteAllText(Path.Combine(dir, "app.json"), $$"""
+        {
+          "id": "{{appId}}",
+          "name": "Dup2136 {{dirName}}",
+          "publisher": "Repro2136",
+          "version": "1.0.0.0",
+          "dependencies": [],
+          "platform": "1.0.0.0",
+          "application": "1.0.0.0",
+          "idRanges": [ { "from": {{idFrom}}, "to": {{idFrom + 4}} } ],
+          "runtime": "14.0"
+        }
+        """);
+        File.WriteAllText(Path.Combine(dir, "Dup2136Tests.al"), $$"""
+        codeunit {{codeunitId}} "Dup2136 Tests {{codeunitId}}"
+        {
+            Subtype = Test;
+
+            [Test]
+            procedure TheOnlyTest()
+            var
+                Total: Integer;
+            begin
+                Total := 20 + 22;
+                if Total <> 42 then
+                    Error('expected 42, got %1', Total);
+            end;
+        }
+        """);
+        return dir;
+    }
+
+    private static JsonElement Summary(List<string> lines)
+    {
+        var (_, d) = ProtocolV2Streaming.Split(lines);
+        return d;
+    }
+
+    [SkippableFact]
+    public async Task RunTests_SameSourcePathTwice_RunsOnceAndReportsOneTest()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var dir = MakeBundle("only", "d4e5f6a7-2136-4a1b-9c3d-000000000001", 62410, 62410);
+        var cacheDir = Path.Combine(Path.GetTempPath(), "al-runner-server-dup-2136-cache", Guid.NewGuid().ToString("N"));
+        await using var server = await CliServer.StartAsync(new[] { "--cache", cacheDir });
+
+        var req = JsonSerializer.Serialize(new
+        {
+            command = "runTests",
+            sourcePaths = new[] { dir, dir },
+            packagePaths = Array.Empty<string>(),
+        });
+        var lines = await server.SendRequestStreamingAsync(req, TimeSpan.FromSeconds(180));
+        var d = Summary(lines);
+
+        // The concrete numbers ARE the claim — a 1-test bundle named twice is 1 test,
+        // not 2. Asserting "it ran" would pass against the broken behaviour.
+        Assert.Equal(1, d.GetProperty("total").GetInt32());
+        Assert.Equal(1, d.GetProperty("passed").GetInt32());
+        Assert.Equal(0, d.GetProperty("failed").GetInt32());
+        Assert.Equal(0, d.GetProperty("errors").GetInt32());
+        Assert.Equal(0, d.GetProperty("exitCode").GetInt32());
+        Assert.True(server.StdErr.Contains("duplicate bundle argument"), server.StdErr);
+    }
+
+    [SkippableFact]
+    public async Task RunTests_TwoDistinctSourcePaths_StillRunBoth()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var a = MakeBundle("first", "d4e5f6a7-2136-4a1b-9c3d-000000000002", 62420, 62420);
+        var b = MakeBundle("second", "d4e5f6a7-2136-4a1b-9c3d-000000000003", 62425, 62425);
+        var cacheDir = Path.Combine(Path.GetTempPath(), "al-runner-server-dup-2136-cache", Guid.NewGuid().ToString("N"));
+        await using var server = await CliServer.StartAsync(new[] { "--cache", cacheDir });
+
+        var req = JsonSerializer.Serialize(new
+        {
+            command = "runTests",
+            sourcePaths = new[] { a, b },
+            packagePaths = Array.Empty<string>(),
+        });
+        var lines = await server.SendRequestStreamingAsync(req, TimeSpan.FromSeconds(180));
+        var d = Summary(lines);
+
+        Assert.Equal(2, d.GetProperty("total").GetInt32());
+        Assert.Equal(2, d.GetProperty("passed").GetInt32());
+        Assert.Equal(0, d.GetProperty("exitCode").GetInt32());
+        Assert.True(!server.StdErr.Contains("duplicate bundle argument"), server.StdErr);
+    }
+}

--- a/AlRunner/Infrastructure/BundleRootDeduplication.cs
+++ b/AlRunner/Infrastructure/BundleRootDeduplication.cs
@@ -1,0 +1,197 @@
+// BundleRootDeduplication — collapses positional bundle arguments that name the SAME
+// directory on disk, so each bundle runs once per invocation (#2136).
+//
+// The bug: `al-runner ./x ./x` ran the bundle twice, so a 1-test bundle reported 2
+// tests. Nothing crashed — that was #1692, where SerializeJsonOutput keyed a dictionary
+// on the bundle's last path segment and threw ArgumentException AFTER the tests had run;
+// it now keys on the full path. What was left behind is the quieter half of the same
+// mistake: the run itself never asked whether two arguments were the same directory, so
+// it silently doubled the test count. The count is what CI gates on and what
+// tests/expectations/count-baseline/ pins, which makes a silently doubled count worse
+// than a crash.
+//
+// WHY DEDUPLICATE AT ALL (rather than documenting "duplicates run twice"): a repeated
+// path on a command line is essentially always an accident — an overlapping shell glob,
+// a script appending a default plus an explicit argument. Running a suite twice on
+// purpose (to shake out order dependence) is a real thing to want, but nobody expresses
+// it by typing the same directory twice, and it deserves its own flag rather than being
+// inferred from a duplicate argument.
+//
+// WHAT COUNTS AS "THE SAME DIRECTORY" — the resolved real path, NOT the argument string:
+//   * absolute, with '.' / '..' collapsed  (Path.GetFullPath)
+//   * trailing separators trimmed          ('x' == 'x/')
+//   * symlinks followed, in EVERY path component, not just the last one
+// De-duplicating raw strings would fix only the identical-spelling case and leave `x`
+// vs `./x` vs `/abs/x` doubling exactly as before — the same "compared the convenient
+// string instead of the actual path" shape as #1692's basename key.
+//
+// WHAT IS DELIBERATELY *NOT* THE KEY: the bundle's app identity. Two DIFFERENT
+// directories that declare the same app id and version are not duplicates — the user
+// really did name two directories — and the runner already has loud, deliberate
+// handling for that case: the #1683 module reuse prints
+// "AppId … already loaded earlier in this process — reusing that module instead of
+// recompiling" and runs the second bundle against the first one's module. Collapsing
+// them here would silently discard an argument that was typed on purpose, which is the
+// failure mode .claude/rules/loud-failures.md exists to prevent.
+//
+// The dedup is NOT silent either: the caller prints DescribeDropped's notice naming both
+// spellings and the path they share.
+
+namespace AlRunner.Infrastructure;
+
+/// <summary>
+/// De-duplicates the positional bundle directories handed to the CLI (and the
+/// <c>sourcePaths</c> of a server request) by resolved real path. Runs AFTER
+/// <see cref="BundleRootValidation"/>, so by this point every root is known to exist —
+/// a mistyped path must still be reported as a mistyped path, never quietly folded into
+/// a similar-looking sibling.
+/// </summary>
+internal static class BundleRootDeduplication
+{
+    /// <summary>One argument that was dropped, and the earlier argument it duplicates.</summary>
+    public sealed record DroppedRoot(string Argument, string KeptArgument, string ResolvedPath);
+
+    /// <summary>
+    /// <paramref name="Roots"/> holds the surviving arguments in their ORIGINAL spelling
+    /// and original order (the first spelling of a directory wins); <paramref name="Dropped"/>
+    /// holds one entry per argument removed.
+    /// </summary>
+    public sealed record Result(IReadOnlyList<string> Roots, IReadOnlyList<DroppedRoot> Dropped);
+
+    /// <summary>
+    /// Path comparison matching the filesystem's own: ordinal on Linux (where two names
+    /// differing only in case are two different directories), case-insensitive elsewhere.
+    /// Folding case on Linux would collapse genuinely distinct bundles.
+    /// </summary>
+    private static readonly StringComparer PathComparer =
+        OperatingSystem.IsLinux() ? StringComparer.Ordinal : StringComparer.OrdinalIgnoreCase;
+
+    public static Result Deduplicate(IReadOnlyList<string> bundleRoots)
+    {
+        var kept = new List<string>(bundleRoots.Count);
+        var dropped = new List<DroppedRoot>();
+        var seen = new Dictionary<string, string>(PathComparer);   // canonical path -> kept argument
+
+        foreach (var root in bundleRoots)
+        {
+            // An empty/whitespace argument is not a path and has no "same directory"
+            // question to answer; BundleRootValidation ignores it too. Pass it through
+            // untouched rather than inventing a canonical form for it.
+            if (string.IsNullOrWhiteSpace(root)) { kept.Add(root); continue; }
+
+            var canonical = Canonicalize(root);
+            if (seen.TryGetValue(canonical, out var keptArgument))
+            {
+                dropped.Add(new DroppedRoot(root, keptArgument, canonical));
+                continue;
+            }
+
+            seen[canonical] = root;
+            kept.Add(root);
+        }
+
+        return new Result(kept, dropped);
+    }
+
+    /// <summary>
+    /// The resolved real path of <paramref name="root"/>: absolute, '.'/'..' collapsed,
+    /// trailing separators trimmed, and every symlinked component followed to its final
+    /// target. Returns the input unchanged when it cannot be resolved (an unparseable
+    /// path, an unreadable ancestor) — canonicalisation must never become the failure,
+    /// and two arguments that both fail to resolve simply compare as their own strings.
+    /// </summary>
+    public static string Canonicalize(string root)
+    {
+        if (string.IsNullOrWhiteSpace(root)) return root;
+
+        string abs;
+        try { abs = Path.GetFullPath(root); }
+        catch { return root; }
+
+        try { abs = ResolveSymlinkedComponents(abs); }
+        catch { /* keep the lexical form; see the doc comment */ }
+
+        return TrimTrailingSeparators(abs);
+    }
+
+    /// <summary>
+    /// The stderr notice for a set of dropped arguments, or <c>null</c> when nothing was
+    /// dropped. Names both spellings and the directory they share, so a caller who did
+    /// NOT mean to pass the path twice can see which of their two arguments produced it.
+    /// </summary>
+    public static string? DescribeDropped(IReadOnlyList<DroppedRoot> dropped)
+    {
+        if (dropped.Count == 0) return null;
+
+        var lines = new List<string>
+        {
+            $"al-runner: ignoring {dropped.Count} duplicate bundle argument"
+                + (dropped.Count == 1 ? "" : "s")
+                + " — each bundle directory runs once per invocation:",
+        };
+        foreach (var d in dropped)
+        {
+            lines.Add($"  '{d.Argument}' names the same directory as '{d.KeptArgument}'");
+            lines.Add($"    both resolve to: {d.ResolvedPath}");
+        }
+        return string.Join(Environment.NewLine, lines);
+    }
+
+    /// <summary>
+    /// Walks <paramref name="abs"/> component by component, replacing each symlinked
+    /// component with its target. Resolving only the LAST component (what
+    /// <c>Directory.ResolveLinkTarget</c> alone would give) misses the common shape where
+    /// a parent directory is the link — `link-to-repo/tests/x` and `repo/tests/x`.
+    /// </summary>
+    private static string ResolveSymlinkedComponents(string abs)
+    {
+        var root = Path.GetPathRoot(abs);
+        if (string.IsNullOrEmpty(root)) return abs;   // nothing to anchor a walk to
+
+        var current = root;
+        var rest = abs[root.Length..];
+        foreach (var part in rest.Split(
+                     new[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar },
+                     StringSplitOptions.RemoveEmptyEntries))
+        {
+            current = Path.Combine(current, part);
+            current = ResolveOneLink(current);
+        }
+        return current;
+    }
+
+    // Deliberately reads LinkTarget (the raw stored target) rather than trusting
+    // ResolveLinkTarget's returned FullName: a relative target such as `../sibling` must
+    // be resolved against the LINK's own directory, and re-deriving it here makes that
+    // explicit instead of depending on how the returned FileSystemInfo was rooted.
+    private const int MaxSymlinkHops = 40;   // matches the usual kernel ELOOP budget
+
+    private static string ResolveOneLink(string path)
+    {
+        var current = path;
+        for (var hop = 0; hop < MaxSymlinkHops; hop++)
+        {
+            FileSystemInfo info;
+            if (Directory.Exists(current)) info = new DirectoryInfo(current);
+            else if (File.Exists(current)) info = new FileInfo(current);
+            else return current;                       // does not exist — nothing to follow
+
+            var target = info.LinkTarget;
+            if (target == null) return current;        // not a link — done
+
+            var parent = Path.GetDirectoryName(current);
+            current = Path.GetFullPath(
+                Path.IsPathRooted(target) || parent == null ? target : Path.Combine(parent, target));
+        }
+        // A symlink cycle. Returning the last hop keeps this a comparison key rather than
+        // a failure: the run continues, and the two arguments are simply not merged.
+        return current;
+    }
+
+    private static string TrimTrailingSeparators(string path)
+    {
+        var trimmed = path.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        // Never trim away a filesystem root ("/" on Unix, "C:\" on Windows).
+        return trimmed.Length == 0 ? path : trimmed;
+    }
+}

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -594,6 +594,33 @@ if (tddMode && alCacheDir != null)
         return 2;
     }
 }
+// ── The same directory named twice runs ONCE (#2136) ──────────────────────────
+// Immediately after the existence check above, and deliberately not before it: a
+// mistyped path must still be reported as a mistyped path, never quietly folded into a
+// similar-looking sibling. Dedup is by RESOLVED REAL path (symlinks followed, '..'
+// collapsed, trailing separators trimmed), not by argument string — see
+// BundleRootDeduplication for why identity is not the key and why raw-string Distinct()
+// would fix only the least interesting case.
+//
+// Doing it here rather than inside the bundle loop fixes every downstream consumer at
+// once: PhaseLog.SetBundles, the expectations-directory probe, TryDeriveBcMajorFromProject,
+// CollectBundleAlpackagesDirs, the `bundles.Count > 1` layered pre-pass (which a
+// duplicated single bundle was needlessly triggering), the run banner's bundle count,
+// --watch's bundle name, and --dap's "exactly one bundle path" guard.
+//
+// Printed immediately rather than queued into startupNotices for the same reason the
+// --tdd cache notice above is: several unrelated failure returns still lie between here
+// and the flush, and any of them would discard a queued notice. It duplicates on a
+// stacked re-exec exactly as those lines do; losing it entirely is the worse trade.
+{
+    var deduped = AlRunner.Infrastructure.BundleRootDeduplication.Deduplicate(bundles);
+    var duplicateNotice = AlRunner.Infrastructure.BundleRootDeduplication.DescribeDropped(deduped.Dropped);
+    if (duplicateNotice != null)
+    {
+        Console.Error.WriteLine(duplicateNotice);
+        bundles = deduped.Roots.ToList();
+    }
+}
 // #2041/#2066/#2097: rather than PREDICTING whether this generation will need to
 // re-exec (the #2041 approach — a flag computed from NeedsShadow alone, before either
 // the per-BC-minor variant swap or the Cecil-rewrite cache state is knowable), the
@@ -3316,6 +3343,25 @@ return strictExitCode ? computedExitCode : 0;
         // parsed)" while the identical CLI invocation passed.
         BcRuntime.ResetForNewBundleReload();
 
+        // #2136, same defect as the CLI's positional arguments one call site over: a
+        // `sourcePaths` array naming the same directory twice ran it twice and returned
+        // two ServerRunResults, which HandleRunTests then SelectMany'd into a doubled
+        // test list — the JSON-RPC shape of the exact count inflation the CLI had. Same
+        // resolved-real-path rule, same notice, applied before the sourcePaths.Length > 1
+        // branch below so a duplicated single path no longer drags a request through the
+        // inter-bundle wiring pre-pass either. Server requests have no stderr contract of
+        // their own, so the notice goes to the same place every other server-side
+        // diagnostic does.
+        {
+            var deduped = AlRunner.Infrastructure.BundleRootDeduplication.Deduplicate(sourcePaths);
+            var notice = AlRunner.Infrastructure.BundleRootDeduplication.DescribeDropped(deduped.Dropped);
+            if (notice != null)
+            {
+                Console.Error.WriteLine(notice);
+                sourcePaths = deduped.Roots.ToArray();
+            }
+        }
+
         if (sourcePaths.Length > 1)
         {
             var bundleList = sourcePaths.ToList();
@@ -5191,6 +5237,10 @@ static void PrintHelp(TextWriter w)
     w.WriteLine();
     w.WriteLine("Multiple <bundle-dir> arguments run sequentially and aggregate into one");
     w.WriteLine("summary. Pass --out PATH to also emit a failure-classification JSON.");
+    w.WriteLine("Arguments that name the same directory run ONCE: they are de-duplicated by");
+    w.WriteLine("resolved real path, so `x`, `./x`, `x/` and a symlink to `x` collapse onto one");
+    w.WriteLine("another and the run says which argument it dropped. Two different directories");
+    w.WriteLine("are never merged, even when they declare the same app id.");
     w.WriteLine();
     w.WriteLine("SELECTION");
     w.WriteLine("  --test PATTERN, --filter PATTERN");


### PR DESCRIPTION
Closes #2136

## Reproducer

```
$ al-runner AlRunner.Tests/Fixtures/RecordTriggerXRec AlRunner.Tests/Fixtures/RecordTriggerXRec \
      --package-cache "$HOME/.al-runner/platform-apps"
...
Buckets:       2 total
Tests:         2 total
  pass:        2
```

One bundle, one `[Test]`, reported as 2. Exit 0, nothing crashed — the crash half of this
was #1692 and is already fixed.

## The reading I picked

**Two positional arguments that name the same directory on disk run once.** "Same
directory" is decided on the **resolved real path**:

* absolute, `.`/`..` collapsed (`Path.GetFullPath`)
* trailing separators trimmed (`x` == `x/`)
* symlinks followed, in **every** path component, not just the last one
* compared ordinally on Linux, case-insensitively elsewhere — folding case on Linux would
  merge two directories that genuinely differ

De-duplicating raw argument strings would have fixed only the identical-spelling case and
left `x` vs `./x` vs `/abs/x` doubling exactly as before. That is the same "compared the
convenient string instead of the actual path" mistake as #1692's basename dictionary key,
so it seemed worth not repeating one issue later.

Following symlinks in intermediate components (not just the final one) is the part that
is easy to under-build: `link-to-repo/tests/x` and `repo/tests/x` are the same directory,
and `Directory.ResolveLinkTarget` on the leaf alone does not say so.

### The third case — two different directories, same app id — is deliberately NOT merged

I measured what the runner does today with two distinct directories holding an identical
`app.json`:

```
[.../copyB] Runner Tests Fixture - Record Trigger xRec: AppId a1b2c3d4-… already loaded
earlier in this process — reusing that module instead of recompiling (see issue #1683).
```

So that case already has deliberate, loud handling: one module per AL app identity, a
printed line saying so, and both bundles still run. Collapsing them here would silently
discard an argument the user really did type on purpose — the failure mode
`loud-failures.md` exists to prevent — and would fight #1683's design. Identity is not the
dedup key, and `SameAppIdentityInTwoDirectories_AreBothKept` pins that so a later
"improvement" cannot quietly change it.

### Not silent

The drop is announced on stderr, naming both spellings and the path they share:

```
al-runner: ignoring 2 duplicate bundle arguments — each bundle directory runs once per invocation:
  './AlRunner.Tests/Fixtures/RecordTriggerXRec/' names the same directory as 'AlRunner.Tests/Fixtures/RecordTriggerXRec'
    both resolve to: /home/stefan/.../AlRunner.Tests/Fixtures/RecordTriggerXRec
  '/home/stefan/.../AlRunner.Tests/Fixtures/RecordTriggerXRec' names the same directory as 'AlRunner.Tests/Fixtures/RecordTriggerXRec'
    both resolve to: /home/stefan/.../AlRunner.Tests/Fixtures/RecordTriggerXRec
```

`--help` says so too, under the existing "Multiple `<bundle-dir>` arguments" paragraph.

## Fix the shape, not just the reported line

**1. Does the same wrong pattern appear at another call site?** Yes — `--server`.
`RunAllBundlesForServer` iterated `sourcePaths` as given, so a `runTests` request naming
one directory twice produced two `ServerRunResult`s, which `HandleRunTests` `SelectMany`'d
into a doubled test list and a doubled summary `total`. Identical defect, different
transport. Fixed with the same helper, and pinned by
`ServerDuplicateSourcePathTests`.

**2. Does a sibling function make the same assumption?** `RunLayeredPrePass` and
`BuildSiblingSourceDeps` both key off `bundles.Count > 1` / `sourcePaths.Length > 1`, so a
duplicated single bundle was dragging every run through the inter-bundle dependency wiring
pre-pass for no reason. De-duplicating upstream of both branches fixes them without either
learning about duplicates. Also checked and found clean:
`AlCoverageSourceMap.Build` (idempotent — `map[key] = path`), and `--package-cache`
duplicates (already `.Distinct()`ed at each consumer, and a search directory listed twice
is harmless — first match wins — so no count is affected). Not changed.

**3. If two code paths write the same state, do they maintain the same invariant?** They
did not: the CLI and the server each built their own "list of bundles to iterate" and
neither asked whether two entries were the same directory. They now go through one helper,
which is the reason the server side is in this PR rather than in a follow-up.

## RED → GREEN

`AlRunner/Infrastructure/BundleRootDeduplication.cs` was first committed as a no-op stub so
every test could prove RED against it rather than against a missing type.

| step | result |
|---|---|
| RED, `BundleRootDeduplicationTests` (stub helper) | `Failed: 10, Passed: 6, Total: 16` — the 6 that passed are the negative-direction ones, which must pass in both states |
| RED, CLI leg | `Tests:         2 total` where 1 was asserted |
| RED, `ServerDuplicateSourcePathTests` (server hunk reverted) | `Failed: 1, Passed: 1` — `Expected: 1 / Actual: 2` on the duplicate, the distinct-paths test green as it should be |
| GREEN, `BundleRootDeduplicationTests` | `Passed: 16, Failed: 0` |
| GREEN, `ServerDuplicateSourcePathTests` | `Passed: 2, Failed: 0` |

The negative direction is covered in three places: `DistinctDirectories_AreBothKept`,
`SameAppIdentityInTwoDirectories_AreBothKept`, `Cli_TwoDistinctBundles_StillRunTwice`
(asserts `Tests: 2 total` and no notice) and
`RunTests_TwoDistinctSourcePaths_StillRunBoth`.

## Count baseline

**No count moved, and none should.** Every `--count-baseline` invocation in
`bc-tests.yml` passes exactly one bundle root (`tests/al-language/tests/al-language`,
`tests/runner-extras`), and neither `server-mode-test.sh` nor `server-reload-test.sh`
sends a duplicate `sourcePaths` entry. `tests/expectations/count-baseline/test-count-baseline.json`
is untouched.

## Files

* `AlRunner/Infrastructure/BundleRootDeduplication.cs` — new
* `AlRunner/Program.cs` — dedup after `BundleRootValidation` (deliberately after: a
  mistyped path must still be reported as a mistyped path, never folded into a
  similar-looking sibling), dedup in `RunAllBundlesForServer`, `--help` wording
* `AlRunner.Tests/BundleRootDeduplicationTests.cs` — new
* `AlRunner.Tests/ServerDuplicateSourcePathTests.cs` — new

Object IDs used by the new inline fixtures: 62410, 62420, 62425 (62430–62439 for a
manifest that is never compiled). No collision with `AlRunner.Tests`' existing inline
ranges, and there were no other open PRs to collide with.
