### PR TITLE
fix(precompile): take the shadow hop before rewriting Ncl.dll, so --precompile stops leaving it in AlRunner/bin

### DIFF
--- a/.github/workflows/bc-tests.yml
+++ b/.github/workflows/bc-tests.yml
@@ -192,8 +192,32 @@ jobs:
           # than silently skipping on every fresh CI runner.
           # Must be a REAL run: --version/--help return long before the Cecil bootstrap.
           # The RecordTriggerXRec fixture is the smallest bundle in the repo.
-          ./AlRunner/bin/Release/net8.0/al-runner --quiet AlRunner.Tests/Fixtures/RecordTriggerXRec || true
-          ls -la ~/.cache/al-runner/ncl-cecil/ || echo "WARNING: Cecil cache still cold"
+          #
+          # #2065: this used to end in `|| true`. A warm step that cannot fail is the exact
+          # failure mode this job's own header records twice (#1976: 47 engine tests silently
+          # skipped, two releases in a row) — a run that behaved differently from what the
+          # comments below assert left no signal at all. It is not a lenient guard either: the
+          # `cp` at the end of this step already fails hard when the cache is still cold, just
+          # with a confusing "cp: missing destination file operand" instead of the runner's own
+          # error. Let the runner's exit code speak.
+          ./AlRunner/bin/Release/net8.0/al-runner --quiet AlRunner.Tests/Fixtures/RecordTriggerXRec
+          ls -la ~/.cache/al-runner/ncl-cecil/
+
+          # #2065, the invariant the comment block below depends on, now checked instead of
+          # assumed. The run above must have written its rewritten Ncl.dll into a runner-owned
+          # SHADOW dir (see NclShadowRuntime.cs), never back into AlRunner's own build output —
+          # AlRunner is stripped of Ncl.dll by Directory.Build.targets and
+          # NclShadowRuntime.NeedsShadow reads that directory to decide whether a re-exec is
+          # required, so a stray copy here silently changes the runner's behaviour for every
+          # later invocation in this job. It appeared for real on the BC 27.3 leg of PR #2063,
+          # where it broke five StartupOutputReexecDedupTests, and nothing reported it.
+          stray_ncl=AlRunner/bin/Release/net8.0/Microsoft.Dynamics.Nav.Ncl.dll
+          if [ -e "$stray_ncl" ]; then
+            echo "ERROR: $stray_ncl exists after the warm run." >&2
+            echo "Something rewrote Ncl.dll into AlRunner's build output instead of a shadow dir." >&2
+            echo "See issue #2065 and AlRunner.Tests/PrecompileNclShadowHopTests.cs." >&2
+            exit 1
+          fi
 
           # AlRunner.Tests ships its OWN bin-deployed copy of Microsoft.Dynamics.Nav.Ncl.dll (it
           # references Nav.Ncl directly — see AlRunner.Tests.csproj — and, unlike AlRunner

--- a/AlRunner.Tests/PrecompileNclShadowHopTests.cs
+++ b/AlRunner.Tests/PrecompileNclShadowHopTests.cs
@@ -1,0 +1,280 @@
+// PrecompileNclShadowHopTests — issue #2065.
+//
+// The question #2065 asks is "why did Microsoft.Dynamics.Nav.Ncl.dll appear in
+// AlRunner/bin/Release/net8.0/ at all?", and the answer measured while closing it is:
+// the `--precompile` subcommand wrote it there.
+//
+// Program.cs dispatches `--precompile` (RunPrecompile) near the very top of Main, long
+// before the shadow-re-exec decision point that the normal bundle-run flow passes
+// through. RunPrecompile then calls
+//
+//     NclCecilRewrite.RewriteInPlace(srcDir, Path.Combine(AppContext.BaseDirectory,
+//                                                         "Microsoft.Dynamics.Nav.Ncl.dll"))
+//
+// unconditionally. On an install that does NOT ship Ncl.dll beside al-runner.dll — which
+// is every install since #2023/#2026, including AlRunner's own build output, where
+// Directory.Build.targets strips it — RewriteInPlace CREATES the file rather than
+// replacing one. That single write is the whole defect:
+//
+//   * It permanently changes what NclShadowRuntime.NeedsShadow() answers for that
+//     directory, so every LATER invocation from the same directory silently stops taking
+//     the shadow hop. The runner's observable behaviour then differs between a clean
+//     checkout and a used one — measured: with the stray file present the
+//     `[reexec] Ncl.dll not shipped in this install ...` line disappears entirely.
+//   * It contaminates a directory `--precompile` does not own. Two implementation agents
+//     independently lost time to exactly this on 2026-08-29 (five
+//     StartupOutputReexecDedupTests failing their own precondition because a stray
+//     Ncl.dll had been left in the shared AlRunner/bin/Release/net8.0), and both worked
+//     around it by deleting the file by hand.
+//   * It does not even help THIS process. CoreCLR computes the trusted-platform-assemblies
+//     list in the native host, before any managed code runs, from the literal on-disk
+//     contents of AppContext.BaseDirectory AT THAT MOMENT — see NclShadowRuntime's class
+//     doc. Writing the file a few statements into RunPrecompile is too late for the
+//     process doing the writing; it only ever benefits the NEXT one.
+//
+// The main bundle-run flow already has the right answer for all of this: hop into a
+// runner-owned shadow directory that legitimately holds Ncl.dll before its TPA is
+// computed, and rewrite in place THERE. This suite pins that `--precompile` takes the
+// same hop, in both directions.
+using System.Diagnostics;
+using System.IO.Compression;
+using System.Text;
+using AlRunner.Infrastructure;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class PrecompileNclShadowHopTests
+{
+    private const string NclFileName = "Microsoft.Dynamics.Nav.Ncl.dll";
+
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+    private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
+
+    private const string ShadowReexecLine = "[reexec] Ncl.dll not shipped in this install";
+
+    /// <summary>
+    /// A private, uniquely-named mirror of AlRunner's real build output — the same
+    /// mechanism (and for the same reason) as StartupOutputReexecDedupTests.MirrorOriginalBinDir:
+    /// these tests need to observe, and in one case deliberately change, whether Ncl.dll sits
+    /// beside al-runner.dll, and the shared build output directory is spawned against
+    /// concurrently by roughly two dozen other classes in this assembly.
+    /// </summary>
+    private static string MirrorOriginalBinDir()
+    {
+        var originalBinDir = Path.Combine(
+            ProjectPath, "bin", TestBuildConfig.Configuration, TestBuildConfig.Framework);
+        var originalNcl = Path.Combine(originalBinDir, NclFileName);
+        Assert.False(File.Exists(originalNcl),
+            $"precondition violated: {originalNcl} already exists in the runner's shared build " +
+            "output directory. It is stripped from AlRunner's copy-local set by " +
+            "Directory.Build.targets, so a fresh build never produces it — if it is there, " +
+            "something wrote it (the defect issue #2065 is about), and mirroring would copy " +
+            "that contamination forward and make these tests assert nothing.");
+
+        var privateDir = Directory.CreateTempSubdirectory("al-runner-precompile-mirror-").FullName;
+        NclShadowRuntime.MirrorInstallDirectory(originalBinDir, privateDir);
+        return privateDir;
+    }
+
+    /// <summary>
+    /// Minimal but real .app package: a plain ZIP (AppLoader falls back to offset 0 when the
+    /// 8-byte NAVX magic does not match) holding NavxManifest.xml plus one src/*.al table.
+    /// Version/Application/Platform are all pinned to the exact 4-part BC build this binary
+    /// was compiled against, so RunPrecompile's own SelectVersion(manifest.Version, null)
+    /// resolves a real artifact directory instead of falling through to a non-deterministic
+    /// "latest in cache" default — same reasoning as PrecompileAlDiagnosticFailureTests.
+    /// </summary>
+    private static string WriteAppPackage(string dir, int tableId)
+    {
+        var bcVersion = BcArtifacts.EngineBuiltVersion()?.ToString()
+            ?? throw new InvalidOperationException(
+                "EngineBuiltVersion() is null — this test binary's BcEngineVersion " +
+                "AssemblyMetadata is missing; rebuild AlRunner before running this test.");
+        var name = $"Precompile2065_{tableId}";
+        var xml = $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <Package xmlns="http://schemas.microsoft.com/navx/2015/manifest">
+              <App Id="{Guid.NewGuid()}" Name="{name}" Publisher="Repro2065" Version="{bcVersion}"
+                   Application="{bcVersion}" Platform="{bcVersion}"/>
+              <Dependencies/>
+            </Package>
+            """;
+
+        Directory.CreateDirectory(dir);
+        var appPath = Path.Combine(dir, name + ".app");
+        using (var fs = new FileStream(appPath, FileMode.Create, FileAccess.Write))
+        using (var zip = new ZipArchive(fs, ZipArchiveMode.Create))
+        {
+            using (var es = zip.CreateEntry("NavxManifest.xml").Open())
+                es.Write(Encoding.UTF8.GetBytes(xml));
+            using (var es = zip.CreateEntry("src/Repro.Table.al").Open())
+                es.Write(Encoding.UTF8.GetBytes($$"""
+                    table {{tableId}} "Repro 2065 Tab {{tableId}}"
+                    {
+                        fields
+                        {
+                            field(1; "No."; Code[20]) { }
+                            field(2; Amount; Decimal) { }
+                        }
+                        keys { key(PK; "No.") { Clustered = true; } }
+                    }
+                    """));
+        }
+        return appPath;
+    }
+
+    private static (string Output, int Exit) RunPrecompile(string dllPath, string appPath, string outputDll)
+    {
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            Arguments = $"\"{dllPath}\" --precompile \"{appPath}\" --out \"{outputDll}\"",
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            WorkingDirectory = RepoRoot,
+        };
+        // Default verbosity: `[reexec]` survives Log's default filter (#2038), and what a
+        // real user sees is exactly what this asserts on.
+        psi.Environment.Remove("AL_RUNNER_VERBOSE");
+        psi.Environment.Remove("AL_RUNNER_NCL_SHADOW_DONE");
+        psi.Environment.Remove("AL_RUNNER_REEXECED");
+
+        var sb = new StringBuilder();
+        using var p = Process.Start(psi)!;
+        p.OutputDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.ErrorDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.BeginOutputReadLine();
+        p.BeginErrorReadLine();
+        Assert.True(p.WaitForExit(300_000), "--precompile did not exit within 300s");
+        p.WaitForExit();
+        lock (sb) return (sb.ToString(), p.ExitCode);
+    }
+
+    private static int CountOccurrences(string haystack, string needle)
+    {
+        var n = 0;
+        for (var i = haystack.IndexOf(needle, StringComparison.Ordinal); i >= 0;
+             i = haystack.IndexOf(needle, i + needle.Length, StringComparison.Ordinal))
+            n++;
+        return n;
+    }
+
+    /// <summary>
+    /// #2065, the defect itself: `--precompile` run from an install that does not ship
+    /// Ncl.dll must take the shadow hop (like the bundle-run flow already does) and leave the
+    /// directory it was launched from exactly as it found it.
+    ///
+    /// Asserts all three things that matter together, because any one alone is satisfiable by
+    /// a wrong implementation: the subcommand still WORKS (a DLL is written), it announced the
+    /// hop exactly once, and no Ncl.dll was left behind — so NeedsShadow answers the same
+    /// before and after, and a second invocation from the same directory behaves identically
+    /// to the first.
+    /// </summary>
+    [SkippableFact]
+    public void Precompile_InstallWithoutNcl_HopsToShadowDirAndLeavesInstallDirClean()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var privateDir = MirrorOriginalBinDir();
+        try
+        {
+            var privateDll = Path.Combine(privateDir, "al-runner.dll");
+            var privateNcl = Path.Combine(privateDir, NclFileName);
+            Assert.True(NclShadowRuntime.NeedsShadow(privateDir),
+                $"precondition violated: {privateNcl} exists in the freshly built mirror");
+
+            var workDir = Path.Combine(privateDir, "..", "al-runner-2065-work-" + Guid.NewGuid().ToString("N"));
+            var appPath = WriteAppPackage(workDir, 62290);
+            var outputDll = Path.Combine(workDir, "Repro2065.dll");
+
+            var (output, exit) = RunPrecompile(privateDll, appPath, outputDll);
+
+            // --precompile still does its job. Without this, "never write Ncl.dll" would be
+            // satisfied by a subcommand that simply stopped working.
+            Assert.Equal(0, exit);
+            Assert.True(File.Exists(outputDll),
+                $"--precompile exited 0 but wrote no DLL at {outputDll}.\n{output}");
+
+            // The defect: nothing was written into the directory --precompile was launched from.
+            Assert.False(File.Exists(privateNcl),
+                $"--precompile left {NclFileName} in the install directory it was launched from " +
+                $"({privateDir}) — that permanently flips NclShadowRuntime.NeedsShadow for every " +
+                $"later invocation from there. Output:\n{output}");
+            Assert.True(NclShadowRuntime.NeedsShadow(privateDir));
+
+            // It got there via the shadow hop, announced once — not by skipping the rewrite.
+            Assert.Equal(1, CountOccurrences(output, ShadowReexecLine));
+
+            // Idempotent: a second run from the same directory behaves exactly like the first,
+            // which is the property the stray file destroyed.
+            var appPath2 = WriteAppPackage(workDir, 62291);
+            var outputDll2 = Path.Combine(workDir, "Repro2065b.dll");
+            var (output2, exit2) = RunPrecompile(privateDll, appPath2, outputDll2);
+            Assert.Equal(0, exit2);
+            Assert.True(File.Exists(outputDll2));
+            Assert.False(File.Exists(privateNcl));
+            Assert.Equal(1, CountOccurrences(output2, ShadowReexecLine));
+        }
+        finally
+        {
+            Directory.Delete(privateDir, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// The negative direction, and the reason the fix cannot simply be "never rewrite from
+    /// --precompile": an install that LEGITIMATELY ships Ncl.dll beside al-runner.dll (a
+    /// shadow child's own directory is exactly this shape, and so is AlRunner.Tests' own bin
+    /// dir) must be recognised as not needing the hop. It must run in-process — no `[reexec]`
+    /// line, one process — and it must still hold its Ncl.dll afterwards, rewritten in place
+    /// the way every Ncl-shipping install already expects.
+    /// </summary>
+    [SkippableFact]
+    public void Precompile_InstallShippingNcl_RunsInProcessWithNoShadowHop()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var privateDir = MirrorOriginalBinDir();
+        try
+        {
+            var privateDll = Path.Combine(privateDir, "al-runner.dll");
+            var privateNcl = Path.Combine(privateDir, NclFileName);
+
+            // Make this mirror a legitimately Ncl-shipping install, the way every install
+            // was before #2023/#2026 stripped the file from the package. Source: the BC
+            // artifact cache's own service-tier copy — the same file NclShadowRuntime reads
+            // when it builds a shadow dir.
+            File.Copy(Path.Combine(BcArtifacts.ServiceTierDir, NclFileName), privateNcl);
+            Assert.False(NclShadowRuntime.NeedsShadow(privateDir),
+                "precondition violated: NeedsShadow is still true after placing Ncl.dll beside " +
+                "the entry assembly");
+
+            var workDir = Path.Combine(privateDir, "..", "al-runner-2065-work-" + Guid.NewGuid().ToString("N"));
+            var appPath = WriteAppPackage(workDir, 62292);
+            var outputDll = Path.Combine(workDir, "Repro2065Shipping.dll");
+
+            var (output, exit) = RunPrecompile(privateDll, appPath, outputDll);
+
+            Assert.Equal(0, exit);
+            Assert.True(File.Exists(outputDll),
+                $"--precompile exited 0 but wrote no DLL at {outputDll}.\n{output}");
+
+            // No hop: this install already satisfies the precondition the hop exists to create.
+            Assert.Equal(0, CountOccurrences(output, ShadowReexecLine));
+
+            // And the file it legitimately ships is still there — rewritten in place, not
+            // removed, not left pristine.
+            Assert.True(File.Exists(privateNcl),
+                $"{privateNcl} disappeared — an Ncl-shipping install must keep its own copy");
+            Assert.False(NclShadowRuntime.NeedsShadow(privateDir));
+        }
+        finally
+        {
+            Directory.Delete(privateDir, recursive: true);
+        }
+    }
+}

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -1171,36 +1171,9 @@ deferredStartupLines.Add(() => Console.WriteLine(serverMode
 // entry-assembly manifest set from the SELECTED VARIANT's own directory instead of this
 // process's, so one re-exec covers both "Ncl.dll isn't shipped" and "a different BC-minor
 // engine variant is needed" — see the doc comment on EnsureShadowDir.
-if ((AlRunner.Infrastructure.NclShadowRuntime.NeedsShadow(AppContext.BaseDirectory) || variantSwapDir != null)
-    && Environment.GetEnvironmentVariable("AL_RUNNER_NCL_SHADOW_DONE") != "1")
 {
-    var srcDirForShadow = AlRunner.Infrastructure.BcArtifacts.ServiceTierDir;
-    var shadowDll = AlRunner.Infrastructure.NclShadowRuntime.EnsureShadowDir(
-        AppContext.BaseDirectory, srcDirForShadow, variantSwapDir);
-    var dotnetMuxer = AlRunner.Infrastructure.NclShadowRuntime.FindDotnetMuxer();
-
-    var psi = new System.Diagnostics.ProcessStartInfo(dotnetMuxer) { UseShellExecute = false };
-    psi.ArgumentList.Add("exec");
-    psi.ArgumentList.Add(shadowDll);
-    // argv[0] is THIS process's own entry path (apphost exe, or the dll path the
-    // dotnet muxer forwarded) — never a user arg, and irrelevant here since we've
-    // already picked the child's entry point explicitly above.
-    var argv = RewriteArtifactPathArg(Environment.GetCommandLineArgs());
-    foreach (var a in argv.Skip(1)) psi.ArgumentList.Add(a);
-    psi.Environment["AL_RUNNER_NCL_SHADOW_DONE"] = "1";
-
-    Console.Error.WriteLine(variantSwapDir != null
-        // #2034: this line explains why a second process is about to launch — a
-        // genuinely operational fact, not an internal Cecil-rewrite diagnostic — so it
-        // uses the exempted `[reexec]` tag rather than `[Cecil]`. Under `[Cecil]`, Log's
-        // filter suppressed a real, live re-exec silently: the shadow dir was built, the
-        // child launched, and nothing on stderr said why.
-        ? "[reexec] Re-execing into a shadow runtime dir with the matching BC-minor engine variant"
-        : "[reexec] Ncl.dll not shipped in this install — re-execing into a shadow runtime dir that has it");
-    AlRunner.Infrastructure.PhaseLog.MarkReexecParent();
-    using var shadowChild = System.Diagnostics.Process.Start(psi)!;
-    shadowChild.WaitForExit();
-    return shadowChild.ExitCode;
+    var shadowChildExit = TryShadowReexec(variantSwapDir);
+    if (shadowChildExit.HasValue) return shadowChildExit.Value;
 }
 
 // Cecil-rewrite Ncl.dll IN-PLACE on the bin path BEFORE CoreCLR's TPA probe
@@ -5622,6 +5595,29 @@ static int RunPrecompile(string[] subArgs)
     // the main flow's own comment on this exact hazard), so a fresh rewrite always re-execs
     // rather than continuing in this process. AL_RUNNER_REEXECED (shared with the main
     // flow's guard) prevents an infinite loop if the child somehow rewrites again.
+    //
+    // #2065: "mirror the main flow's own sequence" was only half done — the main flow's
+    // rewrite is unreachable until the SHADOW HOP below has already run, and this one had
+    // no hop in front of it, so on an install that does not ship Ncl.dll the rewrite
+    // CREATED the file in the caller's own directory (measured: a 10.7 MB
+    // Microsoft.Dynamics.Nav.Ncl.dll appearing in AlRunner/bin/Release/net8.0 after one
+    // `--precompile`, which then suppressed the shadow hop for every subsequent invocation
+    // from that directory). Take the same hop first; the child runs from a directory that
+    // legitimately holds Ncl.dll before ITS trusted-platform-assemblies list is computed,
+    // and the rewrite below then replaces a file rather than creating one. See
+    // TryShadowReexec's own comment for the full reasoning, and
+    // AlRunner.Tests/PrecompileNclShadowHopTests.cs for the proof in both directions.
+    //
+    // Deliberately variantSwapDir: null — `--precompile` does not do per-BC-minor engine
+    // variant selection today (the main bundle-run flow computes variantSwapDir from
+    // EngineVariants long after this early dispatch), so passing null keeps this call to
+    // exactly the "Ncl.dll isn't shipped" half of the decision and changes nothing else
+    // about the subcommand's behaviour.
+    {
+        var shadowChildExit = TryShadowReexec(variantSwapDir: null);
+        if (shadowChildExit.HasValue) return shadowChildExit.Value;
+    }
+
     {
         var srcDir = AlRunner.Infrastructure.BcArtifacts.ServiceTierDir;
         var binNcl = Path.Combine(AppContext.BaseDirectory, "Microsoft.Dynamics.Nav.Ncl.dll");
@@ -6538,6 +6534,69 @@ static IEnumerable<string> BcArtifactTestDirs(string cacheDir)
         if (parent == null || parent == dir) yield break;
         dir = parent;
     }
+}
+
+// ── The one shadow-re-exec decision ────────────────────────────────────────────────
+// Returns null when this process may proceed in place, or the child's exit code when it
+// handed off to a shadow-runtime process (in which case the caller must return that code
+// immediately and touch no BC type).
+//
+// #2065: this used to be written out inline at the single call site in the main bundle-run
+// flow, and `--precompile` — which dispatches near the top of Main, LONG before that call
+// site — had no equivalent. It went straight to NclCecilRewrite.RewriteInPlace against
+// `AppContext.BaseDirectory`, which on any install that does not ship Ncl.dll (i.e. every
+// install since #2023/#2026, including AlRunner's own build output, where
+// Directory.Build.targets strips it) CREATES the file instead of replacing one. Two
+// separate costs, and neither is theoretical — both were measured while closing #2065:
+//
+//   * It does not help the process doing the writing. CoreCLR fixes the
+//     trusted-platform-assemblies list in the native host from the literal on-disk contents
+//     of AppContext.BaseDirectory BEFORE any managed code runs (see NclShadowRuntime's class
+//     doc), so a file written a few statements into RunPrecompile is already too late. The
+//     `--precompile` run only worked at all because DependencyLoader's Resolving fallback
+//     then happened to serve the freshly written copy — and on a genuine cache HIT there is
+//     no re-exec to recover, so the whole thing rested on a side effect.
+//   * It permanently changes what NclShadowRuntime.NeedsShadow answers for that directory,
+//     so every LATER invocation from it silently stops taking the hop. The runner then
+//     behaves differently in a used checkout than in a clean one — the exact class of
+//     problem a stale shadow cache caused when it faked a packaging bug here.
+//
+// Two code paths writing the same state where only one held the invariant is the defect, so
+// there is now exactly one place that decides. Any future pre-dispatch subcommand that needs
+// BC types calls this first.
+static int? TryShadowReexec(string? variantSwapDir)
+{
+    if (!(AlRunner.Infrastructure.NclShadowRuntime.NeedsShadow(AppContext.BaseDirectory) || variantSwapDir != null)
+        || Environment.GetEnvironmentVariable("AL_RUNNER_NCL_SHADOW_DONE") == "1")
+        return null;
+
+    var srcDirForShadow = AlRunner.Infrastructure.BcArtifacts.ServiceTierDir;
+    var shadowDll = AlRunner.Infrastructure.NclShadowRuntime.EnsureShadowDir(
+        AppContext.BaseDirectory, srcDirForShadow, variantSwapDir);
+    var dotnetMuxer = AlRunner.Infrastructure.NclShadowRuntime.FindDotnetMuxer();
+
+    var psi = new System.Diagnostics.ProcessStartInfo(dotnetMuxer) { UseShellExecute = false };
+    psi.ArgumentList.Add("exec");
+    psi.ArgumentList.Add(shadowDll);
+    // argv[0] is THIS process's own entry path (apphost exe, or the dll path the
+    // dotnet muxer forwarded) — never a user arg, and irrelevant here since we've
+    // already picked the child's entry point explicitly above.
+    var argv = RewriteArtifactPathArg(Environment.GetCommandLineArgs());
+    foreach (var a in argv.Skip(1)) psi.ArgumentList.Add(a);
+    psi.Environment["AL_RUNNER_NCL_SHADOW_DONE"] = "1";
+
+    Console.Error.WriteLine(variantSwapDir != null
+        // #2034: this line explains why a second process is about to launch — a
+        // genuinely operational fact, not an internal Cecil-rewrite diagnostic — so it
+        // uses the exempted `[reexec]` tag rather than `[Cecil]`. Under `[Cecil]`, Log's
+        // filter suppressed a real, live re-exec silently: the shadow dir was built, the
+        // child launched, and nothing on stderr said why.
+        ? "[reexec] Re-execing into a shadow runtime dir with the matching BC-minor engine variant"
+        : "[reexec] Ncl.dll not shipped in this install — re-execing into a shadow runtime dir that has it");
+    AlRunner.Infrastructure.PhaseLog.MarkReexecParent();
+    using var shadowChild = System.Diagnostics.Process.Start(psi)!;
+    shadowChild.WaitForExit();
+    return shadowChild.ExitCode;
 }
 
 // Rewrite a forwarded argv so that `--artifact-path <dir>` becomes `--bc-version <ver>`


### PR DESCRIPTION
Closes #2065

## Answer: it was `--precompile`, not the Cecil warm step

The issue title is a hypothesis. I measured both, and the warm step is innocent.

**The warm step does take the shadow path.** On a clean build output, running the exact CI
command leaves the directory untouched:

```
$ ls AlRunner/bin/Release/net8.0/Microsoft.Dynamics.Nav.Ncl.dll
ls: cannot access ...: No such file or directory
$ ./AlRunner/bin/Release/net8.0/al-runner --quiet AlRunner.Tests/Fixtures/RecordTriggerXRec
[reexec] Ncl.dll not shipped in this install — re-execing into a shadow runtime dir that has it
  pass:        1
$ ls AlRunner/bin/Release/net8.0/Microsoft.Dynamics.Nav.Ncl.dll
ls: cannot access ...: No such file or directory
```

So `bc-tests.yml`'s comment ("the throwaway run above wrote its rewritten copy into a
runner-owned SHADOW dir instead") is accurate. I left it alone and added a check that
keeps it accurate.

**The writer is `RunPrecompile`.** `AlRunner/Program.cs:210` dispatches `--precompile`
near the top of `Main`, and the shadow-re-exec decision lives at `AlRunner/Program.cs:1174`
— roughly a thousand lines later, past the early return. `RunPrecompile` then called

```csharp
var binNcl = Path.Combine(AppContext.BaseDirectory, "Microsoft.Dynamics.Nav.Ncl.dll");
var didFreshRewrite = NclCecilRewrite.RewriteInPlace(srcDir, binNcl);   // Program.cs:5627
```

with nothing in front of it. `RewriteInPlace` ends in `AtomicReplaceFrom(cachePath, binNclPath)`
(`AlRunner/Infrastructure/NclCecilRewrite.cs:8642`), which **creates** the file when it isn't
already there — and AlRunner's build output never has it, because `Directory.Build.targets`
strips Ncl.dll from that one project's copy-local set.

Reproduced deterministically:

```
$ ls AlRunner/bin/Release/net8.0/Microsoft.Dynamics.Nav.Ncl.dll
ls: cannot access ...: No such file or directory
$ dotnet AlRunner/bin/Release/net8.0/al-runner.dll --precompile <minimal.app> --out out.dll
precompiled Impl61Repro v28.1.49838.53910 → out.dll (11776 bytes, 15948ms)
$ ls -la AlRunner/bin/Release/net8.0/Microsoft.Dynamics.Nav.Ncl.dll
644  AlRunner/bin/Release/net8.0/Microsoft.Dynamics.Nav.Ncl.dll  10.7M
```

And the behavior change it causes, which is the part that actually matters — same binary,
same fixture, only the stray file differs:

```
=== with the leaked Ncl.dll present ===
  pass:        1                      <- no [reexec] line at all
=== after deleting it ===
[reexec] Ncl.dll not shipped in this install — re-execing into a shadow runtime dir that has it
  pass:        1
```

`NclShadowRuntime.NeedsShadow` reads that directory to decide whether a re-exec is needed,
so one `--precompile` permanently flips the answer for every later invocation from there.
That is the divergence between a clean checkout and a used one that both agents ran into.

Worth noting: the write does not even help the process doing it. CoreCLR fixes the
trusted-platform-assemblies list in the native host from the on-disk contents of
`AppContext.BaseDirectory` before any managed code runs (`NclShadowRuntime`'s class doc says
so). `--precompile` worked only because `DependencyLoader`'s `Resolving` fallback then served
the copy it had just written — the whole thing rested on a side effect in a directory the
subcommand does not own.

## Was the BC 27.3 detail real?

Incidental. Nothing in this path is version-dependent — no BC version appears in the
decision, and I reproduced it on 28.1.

The 27.3 leg is also not the same instance. `--precompile`'s `RewriteInPlace` call arrived
in 44889338 (#2158) on 2026-08-29; #2065 was filed 2026-08-26. At that commit,
`RunPrecompile` did not rewrite at all. The 8/26 writer was almost certainly
`StartupOutputReexecDedupTests.ShadowDoneEnvVarForced_...`, which forces
`AL_RUNNER_NCL_SHADOW_DONE=1` and, before #2061's private-mirror fix, ran against the
**shared** `AlRunner/bin/...` — that env var skips the shadow hop and drops straight into
the same in-place rewrite. That instance is already closed structurally by #2061; this PR
closes the one that is still live.

So: one shape, two call sites, two dates. The regression-prone half is fixed here, and the
shape now has one owner.

## The fix

There is now exactly one place that decides whether to hop:
`TryShadowReexec(string? variantSwapDir)` in `AlRunner/Program.cs`. The main bundle-run flow's
inline block became a call to it (byte-identical logic, including the variant-swap branch and
the `[reexec]` wording), and `RunPrecompile` calls it immediately before its own rewrite.

`--precompile` passes `variantSwapDir: null` on purpose — it does not do per-BC-minor engine
variant selection today, so this call is scoped to the "Ncl.dll isn't shipped" half of the
decision and changes nothing else.

## Fixing the shape, not just the reported line

1. **Same wrong pattern at another call site?** Two writers of
   `AppContext.BaseDirectory/Microsoft.Dynamics.Nav.Ncl.dll` exist in the whole tree —
   `Program.cs:1212` (guarded) and `Program.cs:5627` (not). The other two `RewriteInPlace`
   callers target directories that legitimately hold the file:
   `NclShadowRuntime.cs:235` writes into the shadow dir it is building, and
   `BcEngineCollection.cs:130` deliberately uses `Assembly.Location` rather than
   `AppContext.BaseDirectory` (a fix for this same family — it once rewrote Ncl.dll into the
   .NET SDK's own folder).
2. **Sibling subcommand making the same assumption?** `--emit-app` also dispatches before the
   shadow hop. I ran it: it never calls `RewriteInPlace` and leaves nothing behind. `provision`
   likewise. Checked, not assumed.
3. **Two paths writing the same state, same invariant?** No — that was the defect exactly:
   the bundle-run path held "hop before you rewrite" and the `--precompile` path did not.
   Unifying them into `TryShadowReexec` is the fix, not a refactor alongside it.

I considered a defense-in-depth `allowCreate: false` on `RewriteInPlace` and rejected it:
`ShadowDoneEnvVarForced_NoFurtherReexecFollows_StartupTrioStillPrintsOnce` pins
`AL_RUNNER_NCL_SHADOW_DONE=1` as a documented, deliberate way to skip the hop while debugging,
and that scenario legitimately creates the file. A blanket refusal would break a supported
escape hatch to guard a case the single decision point already covers.

## Should `StartupOutputReexecDedupTests` be made robust to a dirty output directory?

No, and I did not change it. Its `MirrorOriginalBinDir` already asserts the shared build
output is clean before mirroring, with a message explaining why. Now that #2065's writer is
gone, a stray Ncl.dll there means a **new** writer — which is precisely what you want reported
loudly, not tolerated. The tests are already isolated from the contamination (#2061's private
mirror); the assert exists to name it, and it should keep doing that.

## Tests

`AlRunner.Tests/PrecompileNclShadowHopTests.cs`, both directions, each against a private
mirror of the build output (`NclShadowRuntime.MirrorInstallDirectory`, the same mechanism
`StartupOutputReexecDedupTests` uses):

- `Precompile_InstallWithoutNcl_HopsToShadowDirAndLeavesInstallDirClean` — the defect. Asserts
  together that a DLL is still produced (so "stop writing Ncl.dll" cannot be satisfied by a
  subcommand that quietly stopped working), that `[reexec] Ncl.dll not shipped in this install`
  appears exactly once, that no Ncl.dll is left in the launch directory, that
  `NeedsShadow` still answers true — and then runs a **second** `--precompile` from the same
  directory and asserts identical results, since idempotence is the property the stray file
  destroyed.
- `Precompile_InstallShippingNcl_RunsInProcessWithNoShadowHop` — the negative. Copies a real
  Ncl.dll from the BC artifact cache into the mirror, so it is a legitimately Ncl-shipping
  install (the shape a shadow child and AlRunner.Tests' own bin dir both have). Asserts zero
  `[reexec]` lines, exit 0, a DLL written, and that the install keeps its own Ncl.dll.

RED, before the fix (assertion order puts the leak first):

```
[FAIL] Precompile_InstallWithoutNcl_HopsToShadowDirAndLeavesInstallDirClean
  --precompile left Microsoft.Dynamics.Nav.Ncl.dll in the install directory it was
  launched from (/tmp/al-runner-precompile-mirror-bDd87i) — that permanently flips
  NclShadowRuntime.NeedsShadow for every later invocation from there.
Failed: 1, Passed: 1
```

(The negative test passed already, as it must — it is what stops the fix from being "never
rewrite".)

GREEN, after: `Failed: 0, Passed: 2, Total: 2`.

## CI warm step

Both remaining asks in the issue, now that the invariant is measured rather than assumed:

- Dropped the `|| true`. A warm step that cannot fail is the failure mode this job's own
  header records twice (#1976 — 47 engine tests silently skipped, two releases running). It is
  not a lenient guard in practice either: the `cp` at the end of the step already fails hard
  when the cache is cold, just with `cp: missing destination file operand` instead of the
  runner's own error.
- Added an explicit check that `AlRunner/bin/Release/net8.0/Microsoft.Dynamics.Nav.Ncl.dll`
  does not exist after the warm run, naming #2065 and the proving test in the failure message.
  This is the check that would have reported the 27.3 leg instead of leaving it to be
  rediscovered by two agents three days later.

## What I ran locally

- `PrecompileNclShadowHopTests` — RED then GREEN, quoted above.
- `PrecompileAlDiagnosticFailureTests`, `NclShadowRuntimeTests`,
  `ReexecExplanationVisibilityTests`, `CliDocumentationTests` — 31 passed.
- `StartupOutputReexecDedupTests`, `PhaseLogIntegrationTests` — 10 passed.
- Manual before/after against the real `AlRunner/bin/Release/net8.0`, quoted above.

Left the full corpus and the matrix to CI.
