### PR TITLE
fix(provision): read Microsoft app dependency edges from the real manifests, not a hand table

### DIFF
--- a/AlRunner.Tests/ManifestDependencyEdgeScanTests.cs
+++ b/AlRunner.Tests/ManifestDependencyEdgeScanTests.cs
@@ -223,6 +223,29 @@ public sealed class ManifestDependencyEdgeScanTests : IDisposable
     }
 
     [Fact]
+    public void ScanDependencyEdges_NestedPackage_IsFoundJustLikeThePresenceChecksFindIt()
+    {
+        // NoFallbackPlatformAppsPresent and TestToolkitPresent both walk the search dirs
+        // with SearchOption.AllDirectories. If this scan looked only at the top level, an
+        // app nested one dir down would read as PRESENT to those two and as EDGE-UNKNOWN
+        // here — two answers about the same packages, from the same dirs, under different
+        // rules. Same rules, or the disagreement is a bug waiting to be reported.
+        var dir = NewDir("nested");
+        var inner = Path.Combine(dir, "Extensions");
+        Directory.CreateDirectory(inner);
+        WriteApp(inner, "Tests-TestLibraries", "Microsoft", "28.3.0.0",
+            ("Application Test Library", "Microsoft"));
+        WriteApp(inner, ProvisioningCheck.TestToolkitSentinelApp, "Microsoft", "28.3.0.0",
+            ("System Application", "Microsoft"), ("Business Foundation", "Microsoft"));
+
+        var scan = ProvisioningCheck.ScanDependencyEdges(new[] { dir });
+
+        Assert.Equal(new[] { "Application Test Library" }, scan.Edges["Tests-TestLibraries"].ToArray());
+        // The sibling presence check finds the same nested tree — same rules, same answer.
+        Assert.True(ProvisioningCheck.TestToolkitPresent(new[] { dir }));
+    }
+
+    [Fact]
     public void ScanDependencyEdges_NonMicrosoftPackage_IsNotRecordedAsAnEdgeSource()
     {
         var dir = NewDir("isv");

--- a/AlRunner.Tests/ManifestDependencyEdgeScanTests.cs
+++ b/AlRunner.Tests/ManifestDependencyEdgeScanTests.cs
@@ -1,0 +1,353 @@
+// ManifestDependencyEdgeScanTests — issue #2103.
+//
+// The Microsoft-app dependency edges the provisioning pre-scan walks used to be a
+// hand-written table (`ProvisioningCheck.KnownMicrosoftAppDependencyEdges`), transcribed
+// once from a BC 28.3 `NavxManifest.xml`. A hand table is version-blind by construction,
+// and Microsoft genuinely moves apps between packages across BC releases — measured while
+// fixing this issue:
+//
+//   BC 27.0 / 27.5   Tests-TestLibraries -> System Application Test Library,
+//                                           Library Variable Storage,
+//                                           Permissions Mock,
+//                                           Business Foundation Test Libraries
+//                    (NO "Application Test Library" — that app does not exist on 27.x at
+//                     all; it is absent from the w1 Extensions set for 27.0/27.3/27.5.)
+//
+//   BC 28.0/28.1/28.3  Tests-TestLibraries -> System Application Test Library,
+//                                             Permissions Mock,
+//                                             Application Test Library
+//
+// The hand table recorded only the 28.x shape, so on BC 27.x it claimed a dependency that
+// does not exist and drove provisioning to demand an app no 27.x artifact ships.
+//
+// These tests pin the replacement: real edges read out of the `.app` packages already on
+// disk. They assert CONCRETE named edges, both directions of the 27-vs-28 split, and that
+// an unreadable package is reported rather than silently collapsing the graph to empty
+// (.claude/rules/loud-failures.md).
+
+using System.IO.Compression;
+using System.Text;
+using Xunit;
+using AlRunner;
+using AlRunner.Infrastructure;
+
+namespace AlRunner.Tests;
+
+public sealed class ManifestDependencyEdgeScanTests : IDisposable
+{
+    private readonly string _root;
+
+    public ManifestDependencyEdgeScanTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "al-runner-edges", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { }
+    }
+
+    // ── fixtures ─────────────────────────────────────────────────────────────
+
+    private string NewDir(string name)
+    {
+        var d = Path.Combine(_root, name);
+        Directory.CreateDirectory(d);
+        return d;
+    }
+
+    /// <summary>Writes a NAVX `.app` whose NavxManifest.xml declares the given dependencies —
+    /// the same shape <see cref="AppLoader.ReadManifest"/> parses out of a real Microsoft
+    /// package.</summary>
+    private static void WriteApp(
+        string dir, string name, string publisher, string version,
+        params (string Name, string Publisher)[] dependencies)
+    {
+        var deps = string.Concat(dependencies.Select(d =>
+            $"""    <Dependency Id="{Guid.NewGuid()}" Name="{d.Name}" Publisher="{d.Publisher}" MinVersion="{version}" />{"\n"}"""));
+        var xml = $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <Package xmlns="http://schemas.microsoft.com/navx/2015/manifest">
+              <App Id="{Guid.NewGuid()}" Name="{name}" Publisher="{publisher}" Version="{version}"/>
+              <Dependencies>
+            {deps}  </Dependencies>
+            </Package>
+            """;
+        File.WriteAllBytes(Path.Combine(dir, $"{publisher}_{name}.app"), WrapNavx(xml));
+    }
+
+    private static byte[] WrapNavx(string manifestXml)
+    {
+        using var ms = new MemoryStream();
+        using (var zip = new ZipArchive(ms, ZipArchiveMode.Create, leaveOpen: true))
+        {
+            var entry = zip.CreateEntry("NavxManifest.xml");
+            using var es = entry.Open();
+            es.Write(Encoding.UTF8.GetBytes(manifestXml));
+        }
+        var zipBytes = ms.ToArray();
+        var result = new byte[8 + zipBytes.Length];
+        result[0] = (byte)'N'; result[1] = (byte)'A'; result[2] = (byte)'V'; result[3] = (byte)'X';
+        BitConverter.TryWriteBytes(result.AsSpan(4, 4), (uint)8);
+        zipBytes.CopyTo(result, 8);
+        return result;
+    }
+
+    /// <summary>The BC 28.x test-toolkit set, edges exactly as measured from the real
+    /// 28.0.46665.53258 / 28.1.49838.50794 / 28.3.52162.53954 packages.</summary>
+    private string WriteBc28TestToolkit()
+    {
+        var dir = NewDir("test-apps-28");
+        WriteApp(dir, "Tests-TestLibraries", "Microsoft", "28.3.0.0",
+            ("System Application Test Library", "Microsoft"),
+            ("Permissions Mock", "Microsoft"),
+            ("Application Test Library", "Microsoft"));
+        WriteApp(dir, "System Application Test Library", "Microsoft", "28.3.0.0",
+            ("System Application", "Microsoft"), ("Any", "Microsoft"));
+        WriteApp(dir, "Business Foundation Test Libraries", "Microsoft", "28.3.0.0",
+            ("System Application", "Microsoft"), ("Business Foundation", "Microsoft"));
+        WriteApp(dir, "Library Variable Storage", "Microsoft", "28.3.0.0",
+            ("Library Assert", "Microsoft"));
+        WriteApp(dir, "Library Assert", "Microsoft", "28.3.0.0");
+        WriteApp(dir, "Permissions Mock", "Microsoft", "28.3.0.0");
+        WriteApp(dir, "Any", "Microsoft", "28.3.0.0");
+        WriteApp(dir, "Test Runner", "Microsoft", "28.3.0.0");
+        return dir;
+    }
+
+    /// <summary>The BC 27.x test-toolkit set, edges exactly as measured from the real
+    /// 27.0.38460.53260 / 27.5.46862.48827 packages. Note the absence of any edge to
+    /// "Application Test Library" — no 27.x artifact ships that app.</summary>
+    private string WriteBc27TestToolkit()
+    {
+        var dir = NewDir("test-apps-27");
+        WriteApp(dir, "Tests-TestLibraries", "Microsoft", "27.5.0.0",
+            ("System Application Test Library", "Microsoft"),
+            ("Library Variable Storage", "Microsoft"),
+            ("Permissions Mock", "Microsoft"),
+            ("Business Foundation Test Libraries", "Microsoft"));
+        WriteApp(dir, "System Application Test Library", "Microsoft", "27.5.0.0",
+            ("System Application", "Microsoft"), ("Any", "Microsoft"));
+        WriteApp(dir, "Business Foundation Test Libraries", "Microsoft", "27.5.0.0",
+            ("System Application", "Microsoft"), ("Business Foundation", "Microsoft"));
+        WriteApp(dir, "Library Variable Storage", "Microsoft", "27.5.0.0",
+            ("Library Assert", "Microsoft"));
+        WriteApp(dir, "Library Assert", "Microsoft", "27.5.0.0");
+        WriteApp(dir, "Permissions Mock", "Microsoft", "27.5.0.0");
+        WriteApp(dir, "Any", "Microsoft", "27.5.0.0");
+        WriteApp(dir, "Test Runner", "Microsoft", "27.5.0.0");
+        return dir;
+    }
+
+    private static DependencyRef Root(string name, string publisher = "Microsoft", string version = "28.0.0.0")
+        => new(Guid.NewGuid(), name, publisher, Version.Parse(version));
+
+    // ── the scan itself ──────────────────────────────────────────────────────
+
+    [Fact]
+    public void ScanDependencyEdges_Bc28Packages_YieldsTheExactEdgesTheManifestsDeclare()
+    {
+        var scan = ProvisioningCheck.ScanDependencyEdges(new[] { WriteBc28TestToolkit() });
+
+        Assert.Empty(scan.UnreadablePackages);
+        Assert.Equal(
+            new[] { "Application Test Library", "Permissions Mock", "System Application Test Library" },
+            scan.Edges["Tests-TestLibraries"].OrderBy(x => x, StringComparer.Ordinal).ToArray());
+        Assert.Equal(
+            new[] { "Any", "System Application" },
+            scan.Edges["System Application Test Library"].OrderBy(x => x, StringComparer.Ordinal).ToArray());
+        Assert.Equal(
+            new[] { "Library Assert" },
+            scan.Edges["Library Variable Storage"].ToArray());
+    }
+
+    [Fact]
+    public void ScanDependencyEdges_Bc27Packages_RecordNoApplicationTestLibraryEdge()
+    {
+        // The measured 27.x shape. "Application Test Library" must appear NOWHERE in the
+        // graph — it is not a dependency of anything on 27.x because it does not exist there.
+        var scan = ProvisioningCheck.ScanDependencyEdges(new[] { WriteBc27TestToolkit() });
+
+        Assert.Equal(
+            new[] { "Business Foundation Test Libraries", "Library Variable Storage",
+                    "Permissions Mock", "System Application Test Library" },
+            scan.Edges["Tests-TestLibraries"].OrderBy(x => x, StringComparer.Ordinal).ToArray());
+        Assert.DoesNotContain(
+            scan.Edges.Values.SelectMany(v => v),
+            n => string.Equals(n, "Application Test Library", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void ScanDependencyEdges_AppWithNoDependencies_IsRecordedWithAnEmptyEdgeList()
+    {
+        // Negative direction that matters: "scanned, declares nothing" must be a RECORDED
+        // fact (key present, list empty), not indistinguishable from "never looked at".
+        var dir = NewDir("no-deps");
+        WriteApp(dir, "Library Assert", "Microsoft", "28.3.0.0");
+
+        var scan = ProvisioningCheck.ScanDependencyEdges(new[] { dir });
+
+        Assert.True(scan.Edges.ContainsKey("Library Assert"));
+        Assert.Empty(scan.Edges["Library Assert"]);
+        Assert.False(scan.Edges.ContainsKey("Test Runner"));
+    }
+
+    [Fact]
+    public void ScanDependencyEdges_CorruptPackage_IsReportedAndDoesNotCollapseTheGraph()
+    {
+        // .claude/rules/loud-failures.md: a package the scan cannot read must be NAMED.
+        // Silently yielding an empty graph would read as "this app needs nothing", which is
+        // exactly the quiet wrong answer that makes a provisioning miss surface later,
+        // somewhere unrelated.
+        var dir = NewDir("corrupt");
+        WriteApp(dir, "Tests-TestLibraries", "Microsoft", "28.3.0.0",
+            ("Application Test Library", "Microsoft"));
+        var bad = Path.Combine(dir, "Microsoft_Broken.app");
+        File.WriteAllBytes(bad, new byte[] { 0x4E, 0x41, 0x56, 0x58, 0x08, 0x00, 0x00, 0x00, 0x01, 0x02, 0x03 });
+
+        var scan = ProvisioningCheck.ScanDependencyEdges(new[] { dir });
+
+        Assert.Contains(bad, scan.UnreadablePackages);
+        // The readable sibling still contributes — one bad file is not a whole-scan wipe.
+        Assert.Equal(new[] { "Application Test Library" }, scan.Edges["Tests-TestLibraries"].ToArray());
+    }
+
+    [Fact]
+    public void ScanDependencyEdges_MissingDirectory_YieldsNothingAndReportsNoFalseFailure()
+    {
+        var scan = ProvisioningCheck.ScanDependencyEdges(new[] { Path.Combine(_root, "never-created") });
+
+        Assert.Empty(scan.Edges);
+        Assert.Empty(scan.UnreadablePackages);
+    }
+
+    [Fact]
+    public void ScanDependencyEdges_NonMicrosoftPackage_IsNotRecordedAsAnEdgeSource()
+    {
+        var dir = NewDir("isv");
+        WriteApp(dir, "Contoso Extension", "Contoso ISV", "1.0.0.0",
+            ("Application Test Library", "Microsoft"));
+
+        var scan = ProvisioningCheck.ScanDependencyEdges(new[] { dir });
+
+        Assert.False(scan.Edges.ContainsKey("Contoso Extension"));
+    }
+
+    [Fact]
+    public void ScanDependencyEdges_RepeatedCall_ReturnsTheSameEdgesOffTheWarmManifestCache()
+    {
+        // AppLoader.ReadManifest is backed by an in-process memo AND an on-disk index keyed
+        // by (path, length, mtime). A warm second scan must produce the identical graph —
+        // a cache-shaped defect here would be invisible to a single cold run.
+        var dir = WriteBc28TestToolkit();
+
+        var cold = ProvisioningCheck.ScanDependencyEdges(new[] { dir });
+        var warm = ProvisioningCheck.ScanDependencyEdges(new[] { dir });
+
+        Assert.Equal(
+            cold.Edges.OrderBy(kv => kv.Key, StringComparer.Ordinal)
+                .Select(kv => kv.Key + "=" + string.Join(",", kv.Value.OrderBy(v => v, StringComparer.Ordinal))),
+            warm.Edges.OrderBy(kv => kv.Key, StringComparer.Ordinal)
+                .Select(kv => kv.Key + "=" + string.Join(",", kv.Value.OrderBy(v => v, StringComparer.Ordinal))));
+        Assert.Equal(
+            new[] { "Application Test Library", "Permissions Mock", "System Application Test Library" },
+            warm.Edges["Tests-TestLibraries"].OrderBy(x => x, StringComparer.Ordinal).ToArray());
+    }
+
+    // ── the decision that consumes it ────────────────────────────────────────
+
+    [Fact]
+    public void DetermineManifestNeeds_Bc27Edges_TestsTestLibraries_DoesNotDemandPlatformApps()
+    {
+        // THE version-specific bug the hand table shipped: on BC 27.x this returned
+        // NeedsPlatformApps == true, sending provisioning after an "Application Test
+        // Library" no 27.x artifact contains.
+        var edges = ProvisioningCheck.ScanDependencyEdges(new[] { WriteBc27TestToolkit() }).Edges;
+
+        var needs = ProvisioningCheck.DetermineManifestNeeds(
+            new[] { Root("Tests-TestLibraries", version: "27.5.0.0") }, edges);
+
+        Assert.False(needs.NeedsPlatformApps);
+        Assert.True(needs.NeedsTestApps);
+    }
+
+    [Fact]
+    public void DetermineManifestNeeds_Bc28Edges_TestsTestLibraries_DoesDemandPlatformApps()
+    {
+        var edges = ProvisioningCheck.ScanDependencyEdges(new[] { WriteBc28TestToolkit() }).Edges;
+
+        var needs = ProvisioningCheck.DetermineManifestNeeds(
+            new[] { Root("Tests-TestLibraries", version: "28.3.0.0") }, edges);
+
+        Assert.True(needs.NeedsPlatformApps);
+        Assert.True(needs.NeedsTestApps);
+    }
+
+    [Fact]
+    public void DecideManifestProvisioning_Bc27ToolkitOnDisk_DoesNotAskForApplicationTestLibrary()
+    {
+        var dir = WriteBc27TestToolkit();
+        var legacy = ProvisioningCheck.CheckPlatformApps("27.5.46862.48827", new[] { dir });
+
+        var decision = ProvisioningCheck.DecideManifestProvisioning(
+            new[] { Root("Tests-TestLibraries", version: "27.5.0.0") }, legacy, new[] { dir });
+
+        Assert.False(decision.NeedsPlatformApps);
+        Assert.False(decision.ShouldDownloadPlatform);
+        Assert.True(decision.NeedsTestApps);
+    }
+
+    [Fact]
+    public void DecideManifestProvisioning_Bc28ToolkitOnDisk_AsksForApplicationTestLibrary()
+    {
+        var dir = WriteBc28TestToolkit();
+        var legacy = ProvisioningCheck.CheckPlatformApps("28.3.52162.53954", new[] { dir });
+
+        var decision = ProvisioningCheck.DecideManifestProvisioning(
+            new[] { Root("Tests-TestLibraries", version: "28.3.0.0") }, legacy, new[] { dir });
+
+        Assert.True(decision.NeedsPlatformApps);
+        Assert.True(decision.ShouldDownloadPlatform);
+    }
+
+    [Fact]
+    public void DecideManifestProvisioning_ColdCache_LearnsThePlatformNeedOnceTheTestSetLands()
+    {
+        // Issue #2103's chicken-and-egg, resolved by ordering rather than by a hand table:
+        // round 1 sees an empty cache and can only conclude "the test set is needed"; the
+        // test set is what carries Tests-TestLibraries' OWN manifest, so round 2 — run
+        // against the now-populated dir — derives the platform need from the real edges.
+        var testAppsDir = NewDir("cold-test-apps");
+        var roots = new[] { Root("Tests-TestLibraries", version: "28.3.0.0") };
+        var legacy = ProvisioningCheck.CheckPlatformApps("28.3.52162.53954", new[] { testAppsDir });
+
+        var round1 = ProvisioningCheck.DecideManifestProvisioning(roots, legacy, new[] { testAppsDir });
+        Assert.True(round1.ShouldDownloadTest);
+        Assert.False(round1.ShouldDownloadPlatform);
+
+        // "download" the BC 28.x test set into that dir.
+        foreach (var f in Directory.EnumerateFiles(WriteBc28TestToolkit(), "*.app"))
+            File.Copy(f, Path.Combine(testAppsDir, Path.GetFileName(f)));
+
+        var round2 = ProvisioningCheck.DecideManifestProvisioning(roots, legacy, new[] { testAppsDir });
+        Assert.True(round2.NeedsPlatformApps);
+        Assert.True(round2.ShouldDownloadPlatform);
+    }
+
+    [Fact]
+    public void DecideManifestProvisioning_UnreadablePackage_IsSurfacedOnTheDecision()
+    {
+        var dir = NewDir("decide-corrupt");
+        WriteApp(dir, "Tests-TestLibraries", "Microsoft", "28.3.0.0",
+            ("Application Test Library", "Microsoft"));
+        var bad = Path.Combine(dir, "Microsoft_Broken.app");
+        File.WriteAllBytes(bad, new byte[] { 0x4E, 0x41, 0x56, 0x58, 0x08, 0x00, 0x00, 0x00, 0xFF });
+
+        var legacy = ProvisioningCheck.CheckPlatformApps("28.3.52162.53954", new[] { dir });
+        var decision = ProvisioningCheck.DecideManifestProvisioning(
+            new[] { Root("Tests-TestLibraries") }, legacy, new[] { dir });
+
+        Assert.Contains(bad, decision.UnreadablePackages);
+    }
+}

--- a/AlRunner.Tests/ProvisioningCheckTests.cs
+++ b/AlRunner.Tests/ProvisioningCheckTests.cs
@@ -685,41 +685,67 @@ public sealed class ProvisioningCheckTests : IDisposable
     }
 
     [Fact]
-    public void DetermineManifestNeeds_TestsTestLibrariesDependency_AlsoNeedsPlatform()
+    public void DetermineManifestNeeds_TestsTestLibrariesDependency_NeedsPlatformOnceItsRealEdgeIsKnown()
     {
         // Issue #2073: a bundle depending on "Tests-TestLibraries" (already recognized as a
         // test-framework root, hence NeedsTestApps) never names "Application Test Library"
-        // directly — but Tests-TestLibraries' OWN manifest declares it as a dependency
-        // (confirmed via the real Microsoft NavxManifest.xml, v28.1.49838.53910:
-        // <Dependency Id="d852d5d2-a39d-4179-baeb-f99a19e32510" Name="Application Test
+        // directly — but on BC 28.x Tests-TestLibraries' OWN manifest declares it
+        // (<Dependency Id="d852d5d2-a39d-4179-baeb-f99a19e32510" Name="Application Test
         // Library" Publisher="Microsoft" .../> — the exact AppId the issue's "Missing:"
-        // error names). Before the fix this root produced NeedsPlatformApps == false, so
+        // error names). Before that fix this root produced NeedsPlatformApps == false, so
         // `provision` reported "already present" and downloaded nothing.
+        //
+        // Issue #2103: that edge is no longer transcribed by hand — it is read from the
+        // package on disk (ProvisioningCheck.ScanDependencyEdges), because the edge is
+        // VERSION-SPECIFIC: on BC 27.x the same app declares Library Variable Storage +
+        // Business Foundation Test Libraries and no Application Test Library at all. So this
+        // test states the walk in both directions: known edge → need; nothing known yet →
+        // no invented need, but still the test-apps download that reveals it. The real
+        // 27-vs-28 shapes are pinned in ManifestDependencyEdgeScanTests.
         var roots = new[]
         {
             new DependencyRef(Guid.NewGuid(), "Tests-TestLibraries", "Microsoft", new Version(28, 1, 0, 0)),
         };
-        var needs = ProvisioningCheck.DetermineManifestNeeds(roots);
-        Assert.True(needs.NeedsPlatformApps);
-        Assert.True(needs.NeedsTestApps);
+        var bc28Edges = new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Tests-TestLibraries"] = new[]
+            {
+                "System Application Test Library", "Permissions Mock", "Application Test Library",
+            },
+        };
+
+        var withEdge = ProvisioningCheck.DetermineManifestNeeds(roots, bc28Edges);
+        Assert.True(withEdge.NeedsPlatformApps);
+        Assert.True(withEdge.NeedsTestApps);
+
+        var nothingKnownYet = ProvisioningCheck.DetermineManifestNeeds(roots);
+        Assert.False(nothingKnownYet.NeedsPlatformApps);
+        Assert.True(nothingKnownYet.NeedsTestApps);
     }
 
     [Fact]
-    public void DetermineManifestNeeds_TestsTestLibrariesDependency_ImpliesDownloadWhenAbsent()
+    public void DetermineManifestNeeds_TestsTestLibrariesDependency_EmptyCacheStillDownloadsTheSetThatRevealsTheNeed()
     {
-        // The end-to-end shape of the issue's repro: a bundle naming only
-        // "Tests-TestLibraries", with an empty package cache (nothing provisioned yet).
-        // DecideManifestProvisioning must say a platform-apps download is needed — this is
-        // the pure decision `provision`'s "platform R2R apps already present" message was
-        // wrongly skipping.
+        // The end-to-end shape of #2073's repro: a bundle naming only "Tests-TestLibraries",
+        // with an empty package cache (nothing provisioned yet).
+        //
+        // Issue #2103 changed WHICH download that produces. With nothing on disk there is no
+        // manifest to read, and the runner no longer guesses from a version-blind table — it
+        // asks for the test-apps set, which is the set carrying Tests-TestLibraries' own
+        // manifest. The platform need is then derived from that real manifest on the next
+        // pass (DecideManifestProvisioning_ColdCache_LearnsThePlatformNeedOnceTheTestSetLands
+        // in ManifestDependencyEdgeScanTests proves the second round). One extra round, and
+        // a right answer on every BC version, instead of one round and a wrong answer on 27.x.
         var roots = new[]
         {
             new DependencyRef(Guid.NewGuid(), "Tests-TestLibraries", "Microsoft", new Version(28, 1, 0, 0)),
         };
         var legacyReport = ProvisioningCheck.CheckPlatformApps("28.1.49838.50794", Array.Empty<string>());
         var decision = ProvisioningCheck.DecideManifestProvisioning(roots, legacyReport, Array.Empty<string>());
-        Assert.True(decision.NeedsPlatformApps);
-        Assert.True(decision.ShouldDownloadPlatform);
+        Assert.True(decision.NeedsTestApps);
+        Assert.True(decision.ShouldDownloadTest);
+        Assert.False(decision.NeedsPlatformApps);
+        Assert.False(decision.ShouldDownloadPlatform);
     }
 
     // ── Issue #2087: transitive need must be DERIVED (a closure walk over recorded
@@ -776,11 +802,11 @@ public sealed class ProvisioningCheckTests : IDisposable
     [Fact]
     public void DetermineManifestNeeds_SystemApplicationTestLibraryDependency_NeedsTestNotPlatform()
     {
-        // Real Microsoft app (confirmed via its own NavxManifest.xml, BC 28.3.52162.53954):
-        // "System Application Test Library" depends on "System Application" and "Any" — real
-        // recorded edges in KnownMicrosoftAppDependencyEdges — but NEITHER reaches
-        // "Application Test Library". Proves the closure walk doesn't over-fire just because
-        // an app HAS recorded edges; it must actually reach the target.
+        // Real Microsoft app (confirmed via its own NavxManifest.xml on BC 27.0, 27.5, 28.0,
+        // 28.1 and 28.3 — the same two edges on every one): "System Application Test Library"
+        // depends on "System Application" and "Any", and NEITHER reaches "Application Test
+        // Library". Proves the closure walk doesn't over-fire just because an app HAS edges;
+        // it must actually reach the target.
         var roots = new[]
         {
             new DependencyRef(Guid.NewGuid(), "System Application Test Library", "Microsoft", new Version(28, 1, 0, 0)),

--- a/AlRunner/Infrastructure/ProvisioningCheck.cs
+++ b/AlRunner/Infrastructure/ProvisioningCheck.cs
@@ -509,6 +509,11 @@ public static class ProvisioningCheck
     /// (<see cref="KnownNoFallbackPlatformApps"/>) are Microsoft apps, so admitting
     /// third-party names could only introduce name collisions, never a real path.
     ///
+    /// Each directory is walked RECURSIVELY, matching
+    /// <see cref="NoFallbackPlatformAppsPresent"/> and <see cref="TestToolkitPresent"/> —
+    /// those answer "is this app present" over the same dirs, and the two views must not
+    /// disagree about which packages exist.
+    ///
     /// An app that declares NO dependencies is recorded with an EMPTY list rather than
     /// omitted — "scanned, declares nothing" is a fact, and must not be indistinguishable
     /// from "never looked at". When the same app name appears in more than one directory,
@@ -541,7 +546,14 @@ public static class ProvisioningCheck
             List<string> files;
             try
             {
-                files = Directory.EnumerateFiles(full, "*.app")
+                // SearchOption.AllDirectories, matching NoFallbackPlatformAppsPresent and
+                // TestToolkitPresent above: those two decide "is this app PRESENT" over the
+                // same search dirs, and a scan that saw a narrower set could report an app's
+                // edges as unknown while its sibling reported the app itself as present —
+                // two answers about the same state, from the same dirs, under different
+                // rules. ReadManifest is memo/disk-index cached and the siblings already
+                // walk these trees, so the extra walk is a cache hit, not a re-parse.
+                files = Directory.EnumerateFiles(full, "*.app", SearchOption.AllDirectories)
                     .OrderBy(f => f, StringComparer.Ordinal).ToList();
             }
             catch (Exception)

--- a/AlRunner/Infrastructure/ProvisioningCheck.cs
+++ b/AlRunner/Infrastructure/ProvisioningCheck.cs
@@ -446,58 +446,14 @@ public static class ProvisioningCheck
     };
 
     /// <summary>
-    /// Known DIRECT dependency edges among Microsoft apps that participate in the
-    /// platform-apps / test-apps provisioning sets, each one extracted from that app's own
-    /// real NavxManifest.xml &lt;Dependencies&gt; block (BC 28.3.52162.53954, verified against
-    /// the actual downloaded .app files — see the per-entry comment; not invented). This is
-    /// the smallest fact <see cref="DetermineManifestNeeds"/> cannot avoid recording ahead of
-    /// time: it only ever sees a BUNDLE's own declared roots, and it can't download a
-    /// not-yet-fetched dependency's manifest just to learn what THAT app depends on — the
-    /// same chicken-and-egg <see cref="KnownNoFallbackPlatformApps"/>' own doc comment
-    /// describes (issue #2073).
-    ///
-    /// Issue #2087: a PRIOR fix recorded this as a one-entry "known transitive dependents of
-    /// Application Test Library" list — correct for the one app it named
-    /// ("Tests-TestLibraries"), but shaped as a lookup table, not detection: the next
-    /// Microsoft app that reaches "Application Test Library" (directly or through another
-    /// app) would fail exactly the same silent way. Recording actual per-app EDGES here
-    /// instead, and walking them with <see cref="ReachesAnyOf"/>, generalizes: an app that
-    /// reaches a <see cref="KnownNoFallbackPlatformApps"/> member through ANY number of hops
-    /// is caught the moment its OWN direct edge is added here — no second per-shape list to
-    /// keep in sync, and a multi-hop chain composes automatically instead of needing its own
-    /// hand-written entry.
-    /// </summary>
-    public static readonly IReadOnlyDictionary<string, IReadOnlyList<string>> KnownMicrosoftAppDependencyEdges =
-        new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase)
-        {
-            // Microsoft_Tests-TestLibraries.app NavxManifest.xml <Dependencies>: depends
-            // directly on "Application Test Library" (the exact edge issues #2073/#2086
-            // needed — AppId d852d5d2-a39d-4179-baeb-f99a19e32510, the one the "Missing:"
-            // error names), plus "System Application Test Library" and "Permissions Mock".
-            ["Tests-TestLibraries"] = new[]
-            {
-                "System Application Test Library", "Permissions Mock", "Application Test Library",
-            },
-            // Microsoft_System Application Test Library.app NavxManifest.xml: depends on
-            // "System Application" and "Any". Neither reaches a KnownNoFallbackPlatformApps
-            // member today, but recording the real edge means a FUTURE app naming only
-            // "System Application Test Library" still gets the right answer via the same
-            // walk, instead of needing its own bespoke check.
-            ["System Application Test Library"] = new[] { "System Application", "Any" },
-            // Microsoft_Business Foundation Test Libraries.app NavxManifest.xml: depends on
-            // "System Application" and "Business Foundation".
-            ["Business Foundation Test Libraries"] = new[] { "System Application", "Business Foundation" },
-        };
-
-    /// <summary>
     /// True iff <paramref name="appName"/> itself is in <paramref name="targets"/>, or
     /// reaches a member of it by following <paramref name="edges"/> through any number of
     /// hops. Pure graph BFS — the general closure-walk mechanism issue #2087 asked for,
     /// exposed separately from <see cref="DetermineManifestNeeds"/> so the WALK itself (not
-    /// just the specific apps <see cref="KnownMicrosoftAppDependencyEdges"/> happens to
-    /// record today) can be proven against synthetic data. Cycle-safe — a malformed or
-    /// future edge table with a loop terminates instead of hanging — and case-insensitive on
-    /// names, matching every other Microsoft-app-name comparison in this file.
+    /// just the apps whose manifests <see cref="ScanDependencyEdges"/> happens to find on
+    /// this machine) can be proven against synthetic data. Cycle-safe — a real manifest
+    /// graph with a loop terminates instead of hanging — and case-insensitive on names,
+    /// matching every other Microsoft-app-name comparison in this file.
     /// </summary>
     public static bool ReachesAnyOf(
         string appName,
@@ -518,6 +474,109 @@ public static class ProvisioningCheck
                     queue.Enqueue(dep);
         }
         return false;
+    }
+
+    /// <summary>
+    /// The dependency edges read out of the Microsoft `.app` packages found on disk, plus
+    /// every package the scan could NOT read. Both halves matter: an unreadable package is
+    /// an app whose edges are unknown, and silently folding that into "declares nothing"
+    /// is precisely the quiet wrong answer .claude/rules/loud-failures.md exists to stop —
+    /// it reads downstream as "this app needs no provisioning".
+    /// </summary>
+    public sealed record DependencyEdgeScan(
+        IReadOnlyDictionary<string, IReadOnlyList<string>> Edges,
+        IReadOnlyList<string> UnreadablePackages);
+
+    /// <summary>
+    /// Reads the REAL direct dependency edges among Microsoft apps out of the `.app`
+    /// packages present in <paramref name="searchDirs"/> — each app's own
+    /// <c>NavxManifest.xml</c> &lt;Dependencies&gt; block, via
+    /// <see cref="AlRunner.AppLoader.ReadManifest"/> (which is memo- and disk-index-cached,
+    /// so a warm repeat scan is a dictionary lookup rather than a re-parse).
+    ///
+    /// Issue #2103: this replaces a hand-transcribed edge table. A hand table is
+    /// version-blind by construction, and Microsoft moves apps between packages across BC
+    /// releases — measured across the versions in <c>.github/bc-versions.txt</c>:
+    /// <c>Tests-TestLibraries</c> depends on <c>Application Test Library</c> on BC 28.x, and
+    /// does NOT on BC 27.x (where that app is absent from the w1 artifact entirely, and the
+    /// edge is <c>Library Variable Storage</c> + <c>Business Foundation Test Libraries</c>
+    /// instead). A table recording one of those shapes is silently wrong for the other, and
+    /// the resulting failure looks like a runner capability gap rather than a stale table.
+    ///
+    /// Only Microsoft-published packages become edge SOURCES, and only Microsoft-published
+    /// dependencies become edge TARGETS: the graph is keyed by app NAME (matching every
+    /// other Microsoft-app comparison in this file) and the walk's targets
+    /// (<see cref="KnownNoFallbackPlatformApps"/>) are Microsoft apps, so admitting
+    /// third-party names could only introduce name collisions, never a real path.
+    ///
+    /// An app that declares NO dependencies is recorded with an EMPTY list rather than
+    /// omitted — "scanned, declares nothing" is a fact, and must not be indistinguishable
+    /// from "never looked at". When the same app name appears in more than one directory,
+    /// the FIRST directory in <paramref name="searchDirs"/> wins, matching the search-order
+    /// precedence the rest of the package-cache lookups use.
+    /// </summary>
+    /// <summary>&quot;No edges known&quot; — the honest default when nothing has been
+    /// downloaded yet, in place of the version-blind hand-written table issue #2103
+    /// removed.</summary>
+    private static readonly IReadOnlyDictionary<string, IReadOnlyList<string>> EmptyDependencyEdges =
+        new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase);
+
+    public static DependencyEdgeScan ScanDependencyEdges(IEnumerable<string> searchDirs)
+    {
+        var edges = new Dictionary<string, IReadOnlyList<string>>(StringComparer.OrdinalIgnoreCase);
+        var unreadable = new List<string>();
+        var seenDirs = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var dir in searchDirs)
+        {
+            if (string.IsNullOrWhiteSpace(dir)) continue;
+            string full;
+            try { full = Path.GetFullPath(dir); } catch { continue; }
+            if (!seenDirs.Add(full)) continue;
+            // A directory that simply does not exist is NOT a failure: the search set
+            // routinely names dirs that only appear once something is provisioned. An
+            // unreadable FILE inside an existing dir is a different thing and is reported.
+            if (!Directory.Exists(full)) continue;
+
+            List<string> files;
+            try
+            {
+                files = Directory.EnumerateFiles(full, "*.app")
+                    .OrderBy(f => f, StringComparer.Ordinal).ToList();
+            }
+            catch (Exception)
+            {
+                continue;
+            }
+
+            foreach (var file in files)
+            {
+                AlRunner.AppManifest? manifest;
+                try { manifest = AlRunner.AppLoader.ReadManifest(file); }
+                catch (Exception) { manifest = null; }
+
+                if (manifest == null || string.IsNullOrWhiteSpace(manifest.Name))
+                {
+                    unreadable.Add(file);
+                    continue;
+                }
+                if (!string.Equals(manifest.Publisher, "Microsoft", StringComparison.OrdinalIgnoreCase))
+                    continue;
+                if (edges.ContainsKey(manifest.Name)) continue;
+
+                var deps = new List<string>();
+                foreach (var d in manifest.Dependencies)
+                {
+                    if (!string.Equals(d.Publisher, "Microsoft", StringComparison.OrdinalIgnoreCase)) continue;
+                    if (string.IsNullOrWhiteSpace(d.Name)) continue;
+                    if (!deps.Any(x => string.Equals(x, d.Name, StringComparison.OrdinalIgnoreCase)))
+                        deps.Add(d.Name);
+                }
+                edges[manifest.Name] = deps;
+            }
+        }
+
+        return new DependencyEdgeScan(edges, unreadable);
     }
 
     /// <summary>
@@ -550,17 +609,21 @@ public static class ProvisioningCheck
     /// </summary>
     /// <param name="roots">The bundle's own unioned dependency roots.</param>
     /// <param name="dependencyEdges">
-    /// Known Microsoft app dependency edges to walk via <see cref="ReachesAnyOf"/> when
-    /// deciding whether a root transitively needs <see cref="KnownNoFallbackPlatformApps"/>.
-    /// Defaults to <see cref="KnownMicrosoftAppDependencyEdges"/>; overridable so tests can
-    /// prove the WALK against synthetic graphs (issue #2087) without needing a real
-    /// not-yet-discovered Microsoft app to exist first.
+    /// Microsoft app dependency edges to walk via <see cref="ReachesAnyOf"/> when deciding
+    /// whether a root transitively needs <see cref="KnownNoFallbackPlatformApps"/>. Supply
+    /// them from <see cref="ScanDependencyEdges"/> — the real
+    /// <c>NavxManifest.xml</c> &lt;Dependencies&gt; of whatever Microsoft packages are on
+    /// disk (issue #2103); <see cref="DecideManifestProvisioning"/> does exactly that.
+    /// Null (the default) means "no edges known", which degrades this to a DIRECT
+    /// membership test rather than inventing a version-blind guess — the honest answer when
+    /// nothing has been downloaded yet. Tests also pass synthetic graphs here to prove the
+    /// WALK itself (issue #2087).
     /// </param>
     public static ManifestNeeds DetermineManifestNeeds(
         IEnumerable<AlRunner.DependencyRef> roots,
         IReadOnlyDictionary<string, IReadOnlyList<string>>? dependencyEdges = null)
     {
-        var edges = dependencyEdges ?? KnownMicrosoftAppDependencyEdges;
+        var edges = dependencyEdges ?? EmptyDependencyEdges;
         bool needsPlatform = false, needsTest = false;
         foreach (var d in roots)
         {
@@ -712,7 +775,8 @@ public static class ProvisioningCheck
         bool PlatformComplete,
         bool TestComplete,
         bool ShouldDownloadPlatform,
-        bool ShouldDownloadTest)
+        bool ShouldDownloadTest,
+        IReadOnlyList<string> UnreadablePackages)
     {
         public bool ShouldDownloadAny => ShouldDownloadPlatform || ShouldDownloadTest;
     }
@@ -740,7 +804,8 @@ public static class ProvisioningCheck
         IReadOnlyList<string> searchDirs)
     {
         var rootsList = manifestRoots as ICollection<AlRunner.DependencyRef> ?? manifestRoots.ToList();
-        var needs = DetermineManifestNeeds(rootsList);
+        var scan = ScanDependencyEdges(searchDirs);
+        var needs = DetermineManifestNeeds(rootsList, scan.Edges);
         var versionFloors = DetermineVersionFloors(rootsList);
         var platformComplete = NoFallbackPlatformAppsPresent(searchDirs, versionFloors);
         var testComplete = TestToolkitPresent(searchDirs, versionFloors);
@@ -748,7 +813,7 @@ public static class ProvisioningCheck
         var shouldDownloadTest = needs.NeedsTestApps && !testComplete;
         return new ManifestProvisionDecision(
             needs.NeedsPlatformApps, needs.NeedsTestApps, platformComplete, testComplete,
-            shouldDownloadPlatform, shouldDownloadTest);
+            shouldDownloadPlatform, shouldDownloadTest, scan.UnreadablePackages);
     }
 
     /// <summary>

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -1387,6 +1387,58 @@ if (!provisionSubcommand)
         var testAppsOut = AlRunner.Infrastructure.ProvisioningCheck.TestAppsDirFor(
             AlRunner.Infrastructure.BcArtifacts.ArtifactsRootDir, full);
 
+        if (decision.ShouldDownloadTest)
+        {
+            if (AlRunner.Infrastructure.ProvisioningCheck.TestToolkitPresent(new[] { testAppsOut }))
+            {
+                Console.Error.WriteLine($"[provision] test toolkit already complete at {testAppsOut}.");
+            }
+            else
+            {
+                Console.Error.WriteLine("[provision] test-toolkit apps missing — downloading...");
+                var rc = AlRunner.Provisioning.ArtifactDownloader.TestApps(
+                    full, testAppsOut, m => Console.Error.WriteLine($"[provision] {m}"));
+                if (rc != 0)
+                {
+                    Console.Error.WriteLine("[provision] test-toolkit download failed; cannot continue.");
+                    return 2;
+                }
+            }
+            // Make the downloaded apps visible to resolution: add the artifact-cache dir as
+            // an additional search root rather than copying its contents into the project.
+            if (!packageCacheDirs.Contains(testAppsOut))
+                packageCacheDirs.Add(testAppsOut);
+            // Re-check: never silently continue on a partial/failed provision.
+            toolkitPresent = AlRunner.Infrastructure.ProvisioningCheck.TestToolkitPresent(PlatformCheckDirs());
+            if (!toolkitPresent)
+            {
+                Console.Error.WriteLine("[provision] test-toolkit apps still missing after download.");
+                return 2;
+            }
+        }
+
+        // Issue #2103: re-derive the need from the manifests that are now READABLE.
+        //
+        // The pre-scan above only ever sees the BUNDLE's own app.json roots. Learning that
+        // (say) "Tests-TestLibraries" itself depends on "Application Test Library" means
+        // reading THAT app's NavxManifest.xml, which lives inside the test-apps set — the
+        // very thing that had not been fetched yet. That chicken-and-egg used to be broken
+        // by a hand-transcribed edge table, which was correct for the BC version whoever
+        // wrote it checked and silently wrong for the rest: on BC 27.x the same app declares
+        // no Application Test Library dependency at all (and no 27.x artifact ships that
+        // app), so the table sent provisioning after something unobtainable and the run died
+        // with "platform apps (Application Test Library) still missing after download".
+        //
+        // Downloading the test set FIRST removes the guess: its manifests are the real,
+        // per-version answer, and DecideManifestProvisioning reads them straight off disk.
+        // Hence the order here — test-apps, then re-decide, then platform-apps.
+        decision = AlRunner.Infrastructure.ProvisioningCheck.DecideManifestProvisioning(
+            manifestDependencyRoots, platformReport, PlatformCheckDirs());
+        foreach (var badPkg in decision.UnreadablePackages)
+            Console.Error.WriteLine(
+                $"[provision] warning: could not read the manifest of '{badPkg}' — its Microsoft " +
+                "dependency edges are unknown, so a provisioning need it implies may be missed.");
+
         if (decision.ShouldDownloadPlatform)
         {
             // Reuse-first (AC #4/#5): the resolved `full` version can be a warm same-
@@ -1436,36 +1488,6 @@ if (!provisionSubcommand)
                 && !AlRunner.Infrastructure.ProvisioningCheck.NoFallbackPlatformAppsPresent(PlatformCheckDirs()))
             {
                 Console.Error.WriteLine("[provision] platform apps (Application Test Library) still missing after download.");
-                return 2;
-            }
-        }
-
-        if (decision.ShouldDownloadTest)
-        {
-            if (AlRunner.Infrastructure.ProvisioningCheck.TestToolkitPresent(new[] { testAppsOut }))
-            {
-                Console.Error.WriteLine($"[provision] test toolkit already complete at {testAppsOut}.");
-            }
-            else
-            {
-                Console.Error.WriteLine("[provision] test-toolkit apps missing — downloading...");
-                var rc = AlRunner.Provisioning.ArtifactDownloader.TestApps(
-                    full, testAppsOut, m => Console.Error.WriteLine($"[provision] {m}"));
-                if (rc != 0)
-                {
-                    Console.Error.WriteLine("[provision] test-toolkit download failed; cannot continue.");
-                    return 2;
-                }
-            }
-            // Make the downloaded apps visible to resolution: add the artifact-cache dir as
-            // an additional search root rather than copying its contents into the project.
-            if (!packageCacheDirs.Contains(testAppsOut))
-                packageCacheDirs.Add(testAppsOut);
-            // Re-check: never silently continue on a partial/failed provision.
-            toolkitPresent = AlRunner.Infrastructure.ProvisioningCheck.TestToolkitPresent(PlatformCheckDirs());
-            if (!toolkitPresent)
-            {
-                Console.Error.WriteLine("[provision] test-toolkit apps still missing after download.");
                 return 2;
             }
         }
@@ -7277,8 +7299,14 @@ static int RunProvisioning(string? bcVersionArg, string? artifactPathArg,
 
     if (provisionManifestApps)
     {
-        EnsurePlatformAppsProvisioned(full, bundles);
+        // Issue #2103: test toolkit FIRST, platform apps second — the same ordering the
+        // --auto-provision path uses, for the same reason. Whether the bundle needs the
+        // platform set is decided by walking the real Microsoft dependency edges, and those
+        // edges live in the test-toolkit packages' own NavxManifest.xml. Fetch that set
+        // first and EnsurePlatformAppsProvisioned can read the answer instead of guessing it
+        // from a hand-written table that was only ever right for one BC version.
         EnsureTestToolkitProvisioned(full);
+        EnsurePlatformAppsProvisioned(full, bundles);
     }
     provisionedVersion = full;
     return 0;
@@ -7306,8 +7334,21 @@ static void EnsurePlatformAppsProvisioned(string engineVersion, List<string> bun
     var platformReport = AlRunner.Infrastructure.ProvisioningCheck.CheckPlatformApps(
         engineVersion, bundleAlpackagesDirs);
     var manifestDependencyRoots = ScanManifestDependencyRoots(bundles);
+    // Issue #2103: include the runner-owned test-apps dir in what the decision may READ.
+    // EnsureTestToolkitProvisioned has just populated it, and those packages' own manifests
+    // are where the real Microsoft dependency edges come from — the per-version fact that
+    // decides whether this bundle needs the platform set at all. Adding it cannot make the
+    // platform set look falsely complete: Application Test Library ships in the w1
+    // Extensions set, never in the test-apps set.
+    var edgeSearchDirs = bundleAlpackagesDirs
+        .Append(TestAppsDirFor(engineVersion))
+        .ToList();
     var decision = AlRunner.Infrastructure.ProvisioningCheck.DecideManifestProvisioning(
-        manifestDependencyRoots, platformReport, bundleAlpackagesDirs);
+        manifestDependencyRoots, platformReport, edgeSearchDirs);
+    foreach (var badPkg in decision.UnreadablePackages)
+        Console.Error.WriteLine(
+            $"[provision] warning: could not read the manifest of '{badPkg}' — its Microsoft " +
+            "dependency edges are unknown, so a provisioning need it implies may be missed.");
     if (!decision.ShouldDownloadPlatform)
     {
         // Issue #2073: "already present" is only true when something was actually VERIFIED


### PR DESCRIPTION
Closes #2103

`ProvisioningCheck.KnownMicrosoftAppDependencyEdges` held the Microsoft app dependency edges the provisioning pre-scan walks, transcribed once out of a BC 28.3 `NavxManifest.xml`. This replaces it with edges read from the manifests the runner already has on disk.

## The hand table and the manifests do NOT agree

I compared the table against every real artifact I could reach. They disagree, and the disagreement is a live bug on `main` today.

| BC build | `Application Test Library` in the w1 set | Real `Tests-TestLibraries` edges | Hand table said | Agree? |
|---|---|---|---|---|
| 27.0.38460.53260 | **absent** | SATL, Library Variable Storage, Permissions Mock, Business Foundation Test Libraries | SATL, Permissions Mock, **Application Test Library** | **no** |
| 27.3.44313.53267 | **absent** | not measurable offline | same | presumed no |
| 27.5.46862.48827 | **absent** | SATL, Library Variable Storage, Permissions Mock, Business Foundation Test Libraries | SATL, Permissions Mock, **Application Test Library** | **no** |
| 28.0.46665.53258 | present | SATL, Permissions Mock, Application Test Library | same | yes |
| 28.1.49838.50794 | present | SATL, Permissions Mock, Application Test Library | same | yes |
| 28.2 | not available locally | not measured | — | unknown |
| 28.3.52162.53954 | present | SATL, Permissions Mock, Application Test Library | same | yes |
| 28.4.53241.53955 | present | test-apps set not available locally | — | ATL present, presumed yes |

(SATL = System Application Test Library. Read straight out of each package's `NavxManifest.xml`; the CDN is unreachable from this machine, so 27.3, 28.2 and 28.4's test-apps sets could not be fetched. The 27-vs-28 split is consistent across all five builds I could measure, and matches the presence/absence of the app itself across all seven platform sets I have.)

The other two entries — `System Application Test Library` -> {System Application, Any} and `Business Foundation Test Libraries` -> {System Application, Business Foundation} — agree on every version measured. The table also simply lacked `Library Variable Storage` -> `Library Assert`, present on all five; harmless, since it reaches nothing in `KnownNoFallbackPlatformApps`.

### What the disagreement costs on BC 27.x

A project whose `app.json` depends on `Microsoft/Tests-TestLibraries` (a legitimate 27.x shape — the app ships as 27.0.x) running on BC 27.0/27.3/27.5:

1. `DetermineManifestNeeds` walks the table, reaches `Application Test Library`, sets `NeedsPlatformApps`.
2. `NoFallbackPlatformAppsPresent` can never be satisfied — no 27.x artifact contains that app.
3. With `--auto-provision`: the platform set downloads (four apps, no ATL), then `Program.cs` hits
   `[provision] platform apps (Application Test Library) still missing after download.` and returns 2.
4. With `--no-auto-provision`: the gap message tells the user to fetch a set that cannot supply it, on every run, forever.

This repo's own CI does not see it: the one suite depending on `Tests-TestLibraries` declares `"application": "28.0.0.0"`, so `BcFloorGate` drops it before the pre-scan on 27.x. The bug is reachable by any user project without that floor.

## The change

- **`ProvisioningCheck.ScanDependencyEdges(searchDirs)`** reads each Microsoft package's own `NavxManifest.xml` `<Dependencies>` via `AppLoader.ReadManifest` (already memo- and disk-index-cached, so a warm re-scan is a lookup). Returns `DependencyEdgeScan(Edges, UnreadablePackages)`.
- **`DecideManifestProvisioning`** walks those edges. `DetermineManifestNeeds`'s default is now "no edges known" — a direct-membership test — rather than a version-blind guess.
- **`KnownMicrosoftAppDependencyEdges` is deleted.**
- **Ordering**, in both provisioning paths (`--auto-provision` in `Program.cs`, and `RunProvisioning` -> `EnsureTestToolkitProvisioned` / `EnsurePlatformAppsProvisioned`): the test-apps set is fetched first, because it is the set carrying `Tests-TestLibraries`' own manifest, and the platform need is re-derived from the real edges afterwards. That is the issue's option 1, and it resolves the chicken-and-egg without any recorded fact. `EnsurePlatformAppsProvisioned` also folds the runner-owned test-apps dir into what its decision may read.
- **Loud on unknown edges**: a package whose manifest cannot be read is named on stderr and carried as `UnreadablePackages`, so "could not read it" never silently becomes "needs nothing" (`.claude/rules/loud-failures.md`).

Cold-cache behaviour changes in one visible way: a bundle naming only `Tests-TestLibraries` now takes two provisioning rounds instead of one (fetch test-apps, learn the real edge, fetch platform-apps if the edge exists). That is the tradeoff the issue named, and it buys a correct answer on all eight supported BC builds instead of one answer that is right on five.

## Fix the shape, not just the reported line

1. **Same wrong pattern at another call site?** Checked every hardcoded Microsoft-app list in `ProvisioningCheck`. `KnownTestFrameworkAppNames` is a deliberate closed allowlist of what the curated `test-apps` download supplies; `KnownNoFallbackPlatformApps` and `KnownPlatformRuntimeApps` record runner capability (which apps have a service-tier DLL fallback), not a manifest fact; `ArtifactDownloader.PlatformApps`' `wantedPrefixes` is a download filter. None of them is a transcribed manifest, so none has this defect.
2. **Sibling function with the same assumption?** Yes, and I filed it rather than widening this PR: `DetermineVersionFloors` reads floors only from the bundle's own roots, so a transitively required app (e.g. `Application Test Library` at the `MinVersion` `Tests-TestLibraries`' manifest declares) gets no floor at all — a warm cache one patch too old reads as complete. `ScanDependencyEdges` currently discards `MinVersion`, which is what would close it. Tracked in #2193, which stays open after this merges.
3. **Two paths writing the same state, same invariant?** Two found, both fixed here. (a) `--auto-provision` and the `provision` subcommand both decided the platform need — only one would have been reordered by a narrow fix; both are. (b) `NoFallbackPlatformAppsPresent` and `TestToolkitPresent` walk their search dirs with `SearchOption.AllDirectories` while my first cut of `ScanDependencyEdges` looked only at the top level, so a nested package would have read as *present* to those two and *edge-unknown* here. Second commit makes the walk match, with a test asserting both views agree on the same nested tree.

## Tests

New `AlRunner.Tests/ManifestDependencyEdgeScanTests.cs` (14 tests), runner-specific by nature — this is the runner's own provisioning decision, nothing about it is a claim about BC behaviour:

- both real shapes asserted as concrete named edges (28.x reaches Application Test Library, 27.x does not and the name appears nowhere in the graph);
- both decision directions (`ShouldDownloadPlatform` true on a 28.x toolkit, false on a 27.x one);
- the two-round cold-cache contract that replaces the table;
- negative: an app with no dependencies is recorded with an *empty* list, not omitted — "declares nothing" must not be indistinguishable from "never scanned";
- negative: a corrupt `.app` is named in `UnreadablePackages` and its readable siblings still contribute, so the graph never silently collapses to empty;
- a missing directory is not a failure; a non-Microsoft package is not an edge source;
- cache sensitivity: a warm second scan returns the identical graph off `AppLoader.ReadManifest`'s memo/disk index.

Two existing tests in `ProvisioningCheckTests.cs` encoded the hand table's answer and were rewritten to state the new contract (both directions of the walk, and the cold-cache round that still fetches the set which reveals the need). #2073's guarantee is preserved, by mechanism rather than by transcription.

**Run locally**, on `8ddb27b3`:
- `dotnet test AlRunner.Tests` — 1108 passed, 0 failed, 68 skipped (11m32s). An earlier run of the same tree under heavy concurrent load reported 4 failures; the harness truncated that log before the names, and the clean re-run is what I am reporting.
- `tests/runner-extras` on BC 28.1.49838.53910 with `--strict --count-baseline` — 189/189 pass.
- RED evidence: with `ScanDependencyEdges` landed but the decision still on the hand table, `DecideManifestProvisioning_Bc27ToolkitOnDisk_DoesNotAskForApplicationTestLibrary` and `DecideManifestProvisioning_ColdCache_LearnsThePlatformNeedOnceTheTestSetLands` both failed (`Assert.False() Failure — Expected: False, Actual: True`); both pass after wiring the scanned edges in.

I did not run the al-language corpus locally — no change here touches the compile or dispatch path.