### PR TITLE
docs(rules): give the RED-baseline recipe a commit-first precondition and cover its index side effect

### DIFF
--- a/.claude/rules/no-git-stash-with-worktrees.md
+++ b/.claude/rules/no-git-stash-with-worktrees.md
@@ -21,13 +21,50 @@ in this repository. Not in a worktree, not in the top-level checkout.
 
 | Goal | Use |
 |---|---|
-| Temporarily revert one file to compare RED vs GREEN | `git checkout <rev> -- <path>`, then `git checkout HEAD -- <path>` to restore |
-| Set aside changes you will bring back | `git diff > /tmp/mine.patch`, then `git apply /tmp/mine.patch` |
+| Temporarily revert one file to compare RED vs GREEN | **Commit your work first.** Then `git checkout <rev> -- <path>`, and `git checkout HEAD -- <path>` to restore. On uncommitted work the restore step **deletes** the change instead of restoring it — if you do not want to commit yet, use the patch row below instead. Read the two failure modes below before you run either half. |
+| Set aside changes you will bring back | `git diff HEAD > /tmp/mine.patch`, then `git apply /tmp/mine.patch`. Use `git diff HEAD`, not `git diff` — plain `git diff` captures **nothing** once the change is staged. Neither form captures untracked files; copy those by hand. |
 | Keep work safe across a crash or reboot | Commit it on your own branch. A commit on an agent branch is free and cannot be popped by anyone else. |
 | Move to another branch with changes in hand | You should not need to — each agent owns one worktree on one branch. |
 
 Committing early is the preferred answer to all of these. An agent's branch is
 its own, a reboot cannot take a commit, and no other agent can touch it.
+
+## The RED-baseline recipe has two ways to destroy work
+
+Both were hit by real agents within a single day, following the first table row
+literally. The behaviour below is measured on git 2.55.0, not inferred.
+
+**1. The restore step is not a restore.** `git checkout HEAD -- <path>` sets the
+file to whatever `HEAD` says. If your fix is still uncommitted, `HEAD` is the
+state *without* the fix — so the command does not give you your work back, it
+throws it away. There is no stash entry and no reflog entry to recover from.
+Commit first, or use the `git diff HEAD` / `git apply` row instead.
+
+**2. `git checkout <rev> -- <paths>` writes the index, not just the working
+tree.** After the revert those paths are **staged** as the pre-fix content.
+Restore the working tree from a copy and `git status` reads `MM`; restore only
+some of the paths and the rest read `M `. Commit from that state and:
+
+- `git commit` commits the **index** — the reverted, pre-fix content, for every
+  path you reverted.
+- `git commit -a` commits the **working tree** — right for the paths you
+  restored, still pre-fix for any you did not.
+
+Both are silent. Mode 1 announces itself, because the tests stop passing and you
+notice. Mode 2 does not: it produces a PR carrying a green CI verdict for code
+that is not what CI measured.
+
+So, around any `git checkout <rev> -- <paths>`:
+
+1. **Copy the affected files outside the repository before you revert** —
+   `mkdir -p /tmp/red-baseline && cp <paths> /tmp/red-baseline/`. This is what
+   makes the restore verifiable instead of hopeful; you can diff against it
+   afterwards.
+2. Restore, then `git add` those paths again — the revert staged them and the
+   restore does not necessarily unstage them.
+3. Read `git diff --cached` and confirm it is your fix, not the revert, before
+   you commit.
+4. Never `git commit -a` straight after a RED baseline.
 
 ## Why the obvious workarounds do not help
 
@@ -40,9 +77,19 @@ another agent pushes. There is no per-worktree stash.
 
 `pgrep -f <pattern>` matches the polling shell's own command line, so
 `while pgrep -f "dotnet run"; do ...; done` never terminates. This has hung an agent
-turn. Use `$!` on a job you started, `wait`, or `pgrep -f <pat> | grep -v $$`.
-Better: don't poll — run it in the foreground.
+turn. Use `$!` on a job you started, or `wait`.
+
+Filtering the shell's own PID back out does **not** rescue the loop, and this rule
+used to recommend it. Measured: `pgrep -f <pat>` also matches every *ancestor*
+whose command line contains the pattern — including the outer tool shell that ran
+your command — so `pgrep -f <pat> | grep -v $$` still returns a match and the loop
+still spins. `grep -v $$` is a substring filter besides, so with `$$` of `123` it
+also drops PIDs `1234` and `4123`; `grep -vx` fixes that half and not the ancestor
+half. Better: don't poll — run it in the foreground.
 
 ## Sister rules
 
 - `branch-and-pr.md` — one branch per agent, one open PR per agent
+- `tdd.md` — the RED → GREEN cycle the revert recipe above exists to serve
+- `no-backgrounding-long-commands.md` — why the answer to "is it done yet" is a
+  foreground wait, not a polling loop


### PR DESCRIPTION
Closes #2196

`.claude/rules/no-git-stash-with-worktrees.md` exists because `git stash` silently
destroyed an agent's work through a shared `refs/stash`. Its replacement recipe had
two silent-destruction modes of its own, both hit by real agents in a single day. I
treated this as a correctness fix rather than a wording fix, because agents execute
the table row literally.

## What I changed

**The table row now carries its own precondition.** An agent copies the row, not the
prose three paragraphs down, so the row says "Commit your work first" and states
outright that on uncommitted work `git checkout HEAD -- <path>` deletes the change
rather than restoring it. It points at the patch row as the route to take when you do
not want to commit yet.

**New section: "The RED-baseline recipe has two ways to destroy work."** Covers both
failure modes, including the index one from the follow-up comment: `git checkout
<rev> -- <paths>` stages what it writes, so after a RED baseline the staged content
can be the pre-fix content even when the working tree looks right. The procedure is
spelled out — copy the affected files outside the repo before reverting so the
restore can be diffed against something rather than assumed, `git add` the paths
again after restoring, read `git diff --cached` before committing, and never `git
commit -a` straight after a RED baseline.

## Everything in the file is now measured, not asserted

I ran each claim against git 2.55.0 in throwaway repos rather than reasoning about
it. That turned up two more wrong claims in the same copy-the-row-lose-the-caveat
shape, both fixed here.

**The "safe" patch row was not safe.** It said `git diff > /tmp/mine.patch`. Plain
`git diff` captures **nothing** once the change is staged — measured: 0 lines of
output with a staged edit, 7 lines from `git diff HEAD` for the same edit. An agent
told to prefer this row for uncommitted work would have written an empty patch and
believed it had a backup. Now `git diff HEAD`, with a note that neither form captures
untracked files.

**Which commit form bites, precisely.** With two reverted paths and only one restored
from an outside copy, `git status` reproduces the reported `MM` exactly. Plain `git
commit` then commits pre-fix content for **both** paths (it commits the index); `git
commit -a` commits the fix for the restored path and pre-fix content for the one that
was not restored. So both forms can ship a reverted file, by different routes, and the
rule now says which does which.

**The polling-loop remedy did not work.** The rule offered `pgrep -f <pat> | grep -v
$$` as a way to stop a loop matching itself. Measured, it fails twice over: `pgrep -f`
also matches every *ancestor* whose command line contains the pattern — in my
measurement the outer tool shell, PID 397902, alongside `$$` at 397904 — so the loop
still sees a match and still spins. And `grep -v $$` is a substring filter, so with
`$$` of `123` it also drops PIDs `1234` and `4123`. `grep -vx` fixes the substring
half and not the ancestor half. The rule now says the remedy does not work and points
at `$!` / `wait`.

**The claims that do hold**, re-verified rather than inherited: `refs/stash` really is
shared across worktrees on git 2.55.0 — I created two worktrees, stashed in one, and
listed it from the other. The 2026-08-27 incident narrative and the `pgrep` self-match
premise are both accurate as written.

## Checking for the same shape elsewhere

1. *Same wrong pattern at another call site?* `grep` for `git checkout .*HEAD --`,
   `git diff >` and `git stash` across all markdown outside the corpus: the recipe
   appears only in this file. `.claude/agents/impl-agent.md` names the rule but does
   not restate the commands, so it inherits the fix.
2. *Sibling guidance making the same assumption?* The other three table rows: "commit
   on your own branch" and "you should not need to" carry no hidden precondition. The
   patch row did, and is fixed above.
3. *Two paths maintaining the same invariant?* The invariant is "your uncommitted work
   survives the experiment." The revert path and the patch path both claimed it and
   neither delivered it. Both now do.

## On adding a test

I did not add one, deliberately.

A test asserting the file contains a phrase would pass against a stub of itself —
exactly what `tdd.md` bars, and the kind of decorative check that makes the next
person distrust the suite.

The other candidate was an xunit test executing the prescribed git commands in a temp
repo and asserting the outcomes above. It would not be a string match, but it would
test *git*, not this repo: nothing here implements the behavior, so it can only go red
if a future git changes semantics, and it would not catch the thing that actually went
wrong — someone editing the guidance back. There is no precedent for git-invoking
tests in `AlRunner.Tests` (`grep -l '"git"'` returns nothing). The measurements belong
in this PR as evidence and in the rule as prose, not as permanent CI weight.

`AlRunner.Tests/RuleCrossReferenceTests.cs` is the mechanical check that does apply
here, and it covers the two sister references I added (`tdd.md`,
`no-backgrounding-long-commands.md`). Both resolve; 3/3 green locally.

## Verification

- `dotnet test AlRunner.Tests --filter RuleCrossReferenceTests` — 3 passed, 0 failed.
- Diff touches `.claude/rules/` only, so `pr-check.yml`'s `require-tests` job does not
  trigger.
