### PR TITLE
docs(cli): archive the v1 subsystems essay --help and --guide advertised as a map

### DIFF
--- a/.claude/skills/al-runner-architecture/SKILL.md
+++ b/.claude/skills/al-runner-architecture/SKILL.md
@@ -126,7 +126,6 @@ As of 2026-05-20, new runtime patches go through Cecil IL rewriting (`NclCecilRe
 
 ## Sister docs
 
-- `docs/subsystems.md` — BC subsystem boundary analysis
 - `docs/scope.md` — per-API in/out-of-scope decisions
 - `docs/limitations.md` — hard architectural limits
 - `docs/expectations.md` — expectation-manifest schema

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -49,8 +49,8 @@ tests/al-language/             — git submodule, canonical corpus (READ-ONLY)
 tests/expectations/            — JSON manifest declaring expected outcomes for corpus tests
 tests/runner-extras/           — runner-specific positive tests
 tests/archive/                 — v1 buckets and fixtures (frozen, scheduled for deletion)
-docs/                          — expectations.md, scope.md, limitations.md, cecil-migration.md, subsystems.md
-docs/archive/                  — v1-only documents (dap.md, extract-deps.md, coverage.{md,yaml}, etc.)
+docs/                          — expectations.md, scope.md, limitations.md, cecil-migration.md
+docs/archive/                  — v1-only documents (dap.md, extract-deps.md, coverage.{md,yaml}, subsystems.md, etc.)
 tools/                         — DownloadArtifacts (used by AlRunner.csproj), RuntimeApiEnumerator, telemetry-triage
 scripts/                       — al-inventory.py, coverage-gen.js
 ```

--- a/AlRunner.Tests/CliDocumentationTests.cs
+++ b/AlRunner.Tests/CliDocumentationTests.cs
@@ -417,4 +417,138 @@ public sealed class CliDocumentationTests
             + "checkout a `dotnet tool install` user never has:\n  "
             + string.Join("\n  ", offenders));
     }
+
+    /// <summary>
+    /// Issue #2080: --help and --guide listed `docs/subsystems.md` as the "subsystem
+    /// map". It is a v1-era spike artifact that says so in its own second line
+    /// ("preserved as historical analysis"), recommends the JmpHook strategy the
+    /// runner has since abandoned, and cross-references files that no longer exist.
+    /// An agent told by CLAUDE.md to read --guide first was routed straight into it.
+    ///
+    /// The pre-existing drift tests only assert that referenced strings are PRESENT,
+    /// so a pointer can be present and false at the same time. These two tests close
+    /// the mechanically-checkable half of that gap:
+    ///
+    ///   1. every docs/*.md path the CLI prints resolves on disk, and
+    ///   2. none of them is a self-declared historical/archived artifact.
+    ///
+    /// Deliberately NOT asserted: that the printed label matches the document's H1.
+    /// That check would not have caught this bug — the label was "subsystem map" and
+    /// the H1 is "BC service-tier subsystem boundary analysis", which share the word
+    /// "subsystem" — and any looser prose comparison is a false-failure generator.
+    /// The staleness marker is the property that actually distinguishes the case.
+    /// </summary>
+    [Fact]
+    public void HelpAndGuide_ReferenceOnlyDocsThatExistOnDisk()
+    {
+        var missing = new List<string>();
+        foreach (var (surface, path) in ReferencedDocPaths())
+            if (!File.Exists(Path.Combine(RepoRoot, path)))
+                missing.Add($"{surface} prints '{path}', which does not exist");
+
+        Assert.True(missing.Count == 0,
+            "The CLI's own documentation lists paths that are not in the repository. "
+            + "A caller with nothing but the binary follows these:\n  "
+            + string.Join("\n  ", missing));
+    }
+
+    [Fact]
+    public void HelpAndGuide_DoNotAdvertiseHistoricalArtifacts()
+    {
+        var offenders = new List<string>();
+        foreach (var (surface, path) in ReferencedDocPaths())
+        {
+            var full = Path.Combine(RepoRoot, path);
+            if (!File.Exists(full)) continue; // reported by the sibling test
+
+            if (path.StartsWith("docs/archive/", StringComparison.Ordinal))
+            {
+                offenders.Add($"{surface} prints '{path}', which lives under docs/archive/");
+                continue;
+            }
+
+            var marker = HistoricalMarkerIn(File.ReadAllText(full));
+            if (marker != null)
+                offenders.Add($"{surface} prints '{path}', whose header declares itself historical (\"{marker}\")");
+        }
+
+        Assert.True(offenders.Count == 0,
+            "--help / --guide are read by agents as the current operating manual, so every "
+            + "document they name must be current. Move the document out of the list (or out "
+            + "of docs/archive/) rather than leaving the pointer:\n  "
+            + string.Join("\n  ", offenders));
+    }
+
+    /// <summary>
+    /// The negative direction for the two tests above: prove the audit actually
+    /// rejects a bad reference instead of passing because it found nothing to check.
+    /// Without this, both tests would still be green if the extraction regex silently
+    /// matched zero paths.
+    /// </summary>
+    [Fact]
+    public void DocReferenceAudit_RejectsArchivedAndHistoricalReferences()
+    {
+        // Extraction finds every docs/*.md path in CLI-shaped output, and nothing else.
+        var extracted = ExtractDocPaths(
+            "FURTHER READING\n"
+            + "  --help                       full flag reference\n"
+            + "  docs/limitations.md          the real architectural limits\n"
+            + "  docs/archive/subsystems.md   subsystem map\n"
+            + "  README.md                    not a docs/ path\n");
+        Assert.Equal(new[] { "docs/archive/subsystems.md", "docs/limitations.md" }, extracted.OrderBy(p => p).ToArray());
+
+        // A docs/archive/ path is rejected on its path alone.
+        Assert.StartsWith("docs/archive/", extracted.Single(p => p.Contains("archive")), StringComparison.Ordinal);
+
+        // The historical-marker scan fires on the exact header shape that caused #2080 ...
+        Assert.Equal("preserved as historical analysis", HistoricalMarkerIn(
+            "# BC service-tier subsystem boundary analysis\n\n"
+            + "> **STATUS UPDATE — 2026-05-07.** This document is preserved as historical analysis.\n"));
+        Assert.Equal("spike artifact", HistoricalMarkerIn("# Something\n\n**Status:** spike artifact, architectural analysis only.\n"));
+
+        // ... and not on a current document's header, nor on a late mention in the body.
+        Assert.Null(HistoricalMarkerIn("# Cecil migration — architecture decision\n\n**Status:** approved 2026-05-20.\n"));
+        Assert.Null(HistoricalMarkerIn("# Current doc\n" + string.Join("\n", Enumerable.Repeat("body", 200))
+            + "\nthis spike artifact is only discussed here, far below the header\n"));
+    }
+
+    /// <summary>Phrases a document uses to declare itself superseded.</summary>
+    private static readonly string[] HistoricalMarkers =
+    {
+        "preserved as historical analysis",
+        "historical analysis only",
+        "spike artifact",
+        "superseded by",
+        "no longer accurate",
+    };
+
+    /// <summary>
+    /// Scans only the document header (first 60 lines). A current document may
+    /// legitimately discuss a superseded spike in its body; what disqualifies it from
+    /// the CLI's reading list is declaring ITSELF historical up front.
+    /// </summary>
+    private static string? HistoricalMarkerIn(string docText)
+    {
+        var header = string.Join("\n", docText.Split('\n').Take(60));
+        return HistoricalMarkers.FirstOrDefault(m => header.Contains(m, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static string[] ExtractDocPaths(string cliOutput) =>
+        Regex.Matches(cliOutput, @"\bdocs/[A-Za-z0-9_./-]*\.md\b")
+             .Select(m => m.Value)
+             .Distinct(StringComparer.Ordinal)
+             .ToArray();
+
+    /// <summary>(surface, path) for every docs/*.md printed by --help or --guide.</summary>
+    private static IEnumerable<(string Surface, string Path)> ReferencedDocPaths()
+    {
+        foreach (var flag in new[] { "--help", "--guide" })
+        {
+            var (exit, stdout, _) = RunCli(flag);
+            Assert.Equal(0, exit);
+            var paths = ExtractDocPaths(stdout);
+            Assert.NotEmpty(paths); // the surfaces DO cite docs; an empty scrape is a broken test
+            foreach (var p in paths) yield return (flag, p);
+        }
+    }
 }

--- a/AlRunner.Tests/CliDocumentationTests.cs
+++ b/AlRunner.Tests/CliDocumentationTests.cs
@@ -438,12 +438,20 @@ public sealed class CliDocumentationTests
     /// "subsystem" — and any looser prose comparison is a false-failure generator.
     /// The staleness marker is the property that actually distinguishes the case.
     /// </summary>
+    /// <summary>
+    /// Widened past the reported line: the same defect — a repository path printed by
+    /// the CLI that is not in the repository — was also sitting in --help's EXAMPLES,
+    /// which offered `tests/runner-extras/oos-reports`. That bundle has never existed;
+    /// it was invented in the same v2-cutover commit that left docs/subsystems.md
+    /// advertised as a map. So this checks every docs/, tests/, tools/ and scripts/
+    /// path either surface prints, not just the .md ones.
+    /// </summary>
     [Fact]
-    public void HelpAndGuide_ReferenceOnlyDocsThatExistOnDisk()
+    public void HelpAndGuide_ReferenceOnlyPathsThatExistOnDisk()
     {
         var missing = new List<string>();
-        foreach (var (surface, path) in ReferencedDocPaths())
-            if (!File.Exists(Path.Combine(RepoRoot, path)))
+        foreach (var (surface, path) in ReferencedRepoPaths())
+            if (!File.Exists(Path.Combine(RepoRoot, path)) && !Directory.Exists(Path.Combine(RepoRoot, path)))
                 missing.Add($"{surface} prints '{path}', which does not exist");
 
         Assert.True(missing.Count == 0,
@@ -456,7 +464,7 @@ public sealed class CliDocumentationTests
     public void HelpAndGuide_DoNotAdvertiseHistoricalArtifacts()
     {
         var offenders = new List<string>();
-        foreach (var (surface, path) in ReferencedDocPaths())
+        foreach (var (surface, path) in ReferencedRepoPaths().Where(p => p.Path.EndsWith(".md", StringComparison.Ordinal)))
         {
             var full = Path.Combine(RepoRoot, path);
             if (!File.Exists(full)) continue; // reported by the sibling test
@@ -494,8 +502,12 @@ public sealed class CliDocumentationTests
             + "  --help                       full flag reference\n"
             + "  docs/limitations.md          the real architectural limits\n"
             + "  docs/archive/subsystems.md   subsystem map\n"
-            + "  README.md                    not a docs/ path\n");
-        Assert.Equal(new[] { "docs/archive/subsystems.md", "docs/limitations.md" }, extracted.OrderBy(p => p).ToArray());
+            + "  al-runner tests/runner-extras/oos-reports\n"
+            + "  al-runner tests/al-language/tests/al-language   (submodule, not asserted)\n"
+            + "  README.md                    not a repo-relative path this audit covers\n");
+        Assert.Equal(
+            new[] { "docs/archive/subsystems.md", "docs/limitations.md", "tests/runner-extras/oos-reports" },
+            extracted.OrderBy(p => p, StringComparer.Ordinal).ToArray());
 
         // A docs/archive/ path is rejected on its path alone.
         Assert.StartsWith("docs/archive/", extracted.Single(p => p.Contains("archive")), StringComparison.Ordinal);
@@ -533,21 +545,28 @@ public sealed class CliDocumentationTests
         return HistoricalMarkers.FirstOrDefault(m => header.Contains(m, StringComparison.OrdinalIgnoreCase));
     }
 
+    /// <summary>
+    /// Repository-relative paths in CLI output. Trailing sentence punctuation is
+    /// trimmed; `tests/al-language/...` is dropped because that submodule is legitimately
+    /// absent in a checkout without `git submodule update`, so asserting on it would
+    /// fail for a reason that has nothing to do with the CLI's honesty.
+    /// </summary>
     private static string[] ExtractDocPaths(string cliOutput) =>
-        Regex.Matches(cliOutput, @"\bdocs/[A-Za-z0-9_./-]*\.md\b")
+        Regex.Matches(cliOutput, @"\b(?:docs|tests|tools|scripts)/[A-Za-z0-9_./-]*[A-Za-z0-9_/-]")
              .Select(m => m.Value)
+             .Where(p => !p.StartsWith("tests/al-language/", StringComparison.Ordinal))
              .Distinct(StringComparer.Ordinal)
              .ToArray();
 
-    /// <summary>(surface, path) for every docs/*.md printed by --help or --guide.</summary>
-    private static IEnumerable<(string Surface, string Path)> ReferencedDocPaths()
+    /// <summary>(surface, path) for every repository path printed by --help or --guide.</summary>
+    private static IEnumerable<(string Surface, string Path)> ReferencedRepoPaths()
     {
         foreach (var flag in new[] { "--help", "--guide" })
         {
             var (exit, stdout, _) = RunCli(flag);
             Assert.Equal(0, exit);
             var paths = ExtractDocPaths(stdout);
-            Assert.NotEmpty(paths); // the surfaces DO cite docs; an empty scrape is a broken test
+            Assert.NotEmpty(paths); // the surfaces DO cite paths; an empty scrape is a broken test
             foreach (var p in paths) yield return (flag, p);
         }
     }

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -5199,7 +5199,6 @@ static void PrintGuide(TextWriter w)
     w.WriteLine("  docs/scope.md                in-scope vs out-of-scope-by-design surfaces");
     w.WriteLine("  docs/server-mode.md          the --server JSON-RPC protocol");
     w.WriteLine("  docs/dap-mode.md             the --dap Debug Adapter Protocol server");
-    w.WriteLine("  docs/subsystems.md           subsystem map");
 }
 
 static void PrintHelp(TextWriter w)
@@ -5272,7 +5271,7 @@ static void PrintHelp(TextWriter w)
     w.WriteLine("  --auto-provision        Download the BC artifacts for the project's version if");
     w.WriteLine("                          they are missing, then continue the run. ON BY DEFAULT");
     w.WriteLine("                          since issue #2024 — this flag is now redundant with a");
-    w.WriteLine("                          plain run, kept for explicit scripts/back-compat. See");
+    w.WriteLine("                          plain run, kept for explicit scripts and back-compat. See");
     w.WriteLine("                          --no-auto-provision to turn it off (or the `provision`");
     w.WriteLine("                          subcommand to provision without running tests).");
     w.WriteLine("  --no-auto-provision     Disable automatic provisioning: a missing/incomplete BC");
@@ -5468,7 +5467,7 @@ static void PrintHelp(TextWriter w)
     w.WriteLine("  al-runner --output-json tests/al-language/tests/al-language");
     w.WriteLine();
     w.WriteLine("  # Dump the C# for a debugging session");
-    w.WriteLine("  al-runner --dump-csharp /tmp/al-csharp tests/runner-extras/oos-reports");
+    w.WriteLine("  al-runner --dump-csharp /tmp/al-csharp tests/runner-extras/query-join-aggregation-oos");
     w.WriteLine();
     w.WriteLine("  # Pre-compile an .app to a managed DLL");
     w.WriteLine("  al-runner --precompile MyExtension_1.0.0.0.app --out MyExtension.dll");
@@ -5490,7 +5489,6 @@ static void PrintHelp(TextWriter w)
     w.WriteLine("  docs/scope.md                runtime scope (in-scope vs OOS-by-design)");
     w.WriteLine("  docs/limitations.md          architectural limits");
     w.WriteLine("  docs/cecil-migration.md      Cecil rewrite strategy");
-    w.WriteLine("  docs/subsystems.md           subsystem map");
 }
 
 // Issue #2085: `provision --help` used to fall through to the generic arg-parser's

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Thanks for your interest in contributing. This guide covers what every pull requ
 
 ## Before you start
 
-Read `README.md` (architecture overview), [`docs/limitations.md`](docs/limitations.md) (hard architectural limits), [`docs/scope.md`](docs/scope.md) (per-API in/out-of-scope list), [`docs/subsystems.md`](docs/subsystems.md) (subsystem boundary map), and [`docs/expectations.md`](docs/expectations.md) (test-expectation schema). `CLAUDE.md` is the entry point for AI agents working in the repo; it points at the rules in `.claude/rules/` and the on-demand reference in `.claude/skills/`.
+Read `README.md` (architecture overview), [`docs/limitations.md`](docs/limitations.md) (hard architectural limits), [`docs/scope.md`](docs/scope.md) (per-API in/out-of-scope list), and [`docs/expectations.md`](docs/expectations.md) (test-expectation schema). `CLAUDE.md` is the entry point for AI agents working in the repo; it points at the rules in `.claude/rules/` and the on-demand reference in `.claude/skills/`.
 
 The goal is broad AL-language compatibility — any AL code that can run without the BC service tier should compile and execute here. A small number of hard architectural limits exist (parallel sessions, transaction isolation, service-tier rendering, real HTTP), documented in `docs/limitations.md` and `docs/scope.md`. Everything else is a gap to close. Silent workarounds are forbidden: a gap goes to a GitHub issue and (if necessary) a `tests/expectations/` entry, never a quiet patch (`.claude/rules/file-issues-for-gaps.md`, `.claude/rules/loud-failures.md`).
 
@@ -22,7 +22,7 @@ tests/expectations/      — JSON manifest: OOS-by-design, known gaps, disabled 
 tests/runner-extras/     — runner-specific positive tests (e.g. asserts that a
                            given surface throws RunnerOutOfScopeException)
 docs/                    — expectations.md, scope.md, limitations.md,
-                           cecil-migration.md, subsystems.md (+ docs/archive/ for v1)
+                           cecil-migration.md (+ docs/archive/ for v1)
 tools/                   — DownloadArtifacts (auto-used by AlRunner.csproj),
                            RuntimeApiEnumerator, telemetry-triage
 scripts/                 — al-inventory.py, coverage-gen.js (auxiliary)

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ AL Runner is a standalone test executor for Business Central AL code. It loads t
 
 There is no service tier, no SQL Server, no NST, and no rendered UI. There is also no "mock layer" — types and method bodies inside the precompiled MS / ISV DLLs run exactly as MS / the ISV compiled them. Where the runner stands in for the service tier (database persistence, session state, table provider, event dispatch) it does so by patching the **runtime engine** (`Microsoft.Dynamics.Nav.Ncl.dll`) at load time, not by editing business-logic DLLs.
 
-See [`docs/subsystems.md`](docs/subsystems.md) for the subsystem map, [`docs/cecil-migration.md`](docs/cecil-migration.md) for the Cecil-rewrite contract, [`docs/scope.md`](docs/scope.md) for what is in / out of scope, and [`docs/limitations.md`](docs/limitations.md) for the hard architectural limits.
+See [`docs/cecil-migration.md`](docs/cecil-migration.md) for the Cecil-rewrite contract, [`docs/scope.md`](docs/scope.md) for what is in / out of scope, and [`docs/limitations.md`](docs/limitations.md) for the hard architectural limits.
 
 ## Architecture
 

--- a/docs/archive/subsystems.md
+++ b/docs/archive/subsystems.md
@@ -1,5 +1,26 @@
 # BC service-tier subsystem boundary analysis
 
+> **ARCHIVED — 2026-08-30 (#2080).** Moved here from `docs/subsystems.md`, where
+> `--help`, `--guide`, `README.md` and `CONTRIBUTING.md` all advertised it as "the
+> subsystem map". It is not a map of the runner; it is a v1-era spike artifact
+> arguing one architectural decision, and that decision has since gone the other
+> way. Its headline recommendation — "stay with reactive JMP-hooks" — is the
+> opposite of what the runner does now: `JmpHook` is disabled by default and a new
+> `JmpHook` call site is a silent no-op (`docs/cecil-migration.md`,
+> `.claude/rules/precompiled-dll-respect.md`). Its companion spike documents were
+> archived at the v1→v2 cutover; this one was missed.
+>
+> **What is still true:** the decompiled shapes of BC's own types — `NavGlobal` as a
+> pure forwarder, `NavSession` as a god object with no interface boundary, the
+> `NCLMetadata` five-collaborator constructor, the `TreeHandler` parent-non-null
+> check. Those are facts about BC 27.5 and do not rot with our code. Read it for
+> that, not for what the runner does today.
+>
+> For current material: `README.md` (architecture), `docs/cecil-migration.md` (how
+> patches are applied), `docs/limitations.md` and `docs/scope.md` (the limits), and
+> the `al-runner-architecture` skill. There is deliberately no replacement map —
+> `AlRunner/` is ~180 files and ripgrep is exhaustive, instant, and never stale.
+
 > **STATUS UPDATE — 2026-05-07.** This document is preserved as historical analysis.
 > Several specifics are stale:
 >


### PR DESCRIPTION
Closes #2080

`--help` and `--guide` both printed `docs/subsystems.md   subsystem map`. `CLAUDE.md` and the `al-runner-workflow` skill tell an automated caller to read `--guide` first, so an agent looking for a map was routed straight into a v1-era spike artifact.

## What I judged the document to be

Stale, and worse than stale in one specific way: its headline recommendation is now inverted relative to what the runner does.

- Its own second line says "This document is preserved as historical analysis."
- Its conclusion is **"Recommendation: stay with reactive JMP-hooks"** and "~16-20 patches". `JmpHook` is now disabled by default (`JmpHook.cs:107`), a new `JmpHook` call site is a silent no-op, and `.claude/rules/precompiled-dll-respect.md` plus the architecture skill both tell you not to add one. So the one thing the document argues for is the thing the repo now forbids.
- Its recommended next step ("add a replacement for `NavMethodScope..ctor`, closes 155/158 failures, 2-3 hours") shipped long ago.
- It cross-references `CLASSIFICATION.md`, `spike/v2/results-after-w1.json` and `v2-classification.json` — none of which exist in the repository.
- It last changed at the v2 cutover (`146bdbbb`, 2026-08-05).

The decisive detail: its own Appendix B points at `docs/archive/spike-classification.md` and `docs/archive/spike-bc-abi-identity-findings.md`. Its companion spike documents were archived at the v1→v2 cutover and this one was missed. It is the last member of that set still sitting in `docs/` and still advertised as current.

It is not worthless — the decompiled shapes of BC's own types (`NavGlobal` as a pure forwarder, `NavSession` as a god object with no interface boundary, `NCLMetadata`'s five-collaborator constructor, the `TreeHandler` parent-non-null check) are facts about BC 27.5 that do not rot with our code. That is archaeology worth keeping, not a subsystem map.

## What I did

Moved it to `docs/archive/subsystems.md`, where its siblings already are, with a header note saying why it moved, what in it is still true, and where the current material is. No replacement map — per the issue, and because `AlRunner/` is ~180 files where ripgrep is exhaustive, instant, and never stale.

All six pointers, not just the two in the issue:

| Reference | Action |
|---|---|
| `AlRunner/Program.cs` `PrintGuide` FURTHER READING | line removed |
| `AlRunner/Program.cs` `PrintHelp` DOCUMENTATION | line removed |
| `README.md:14` | dropped the "subsystem map" clause |
| `CONTRIBUTING.md:9` "Before you start" read-list | removed |
| `CONTRIBUTING.md:25` repo-layout `docs/` listing | removed |
| `.claude/skills/al-runner-architecture/SKILL.md:129` "Sister docs" | removed |
| `.github/copilot-instructions.md:52` `docs/` listing | removed; added to the `docs/archive/` listing on the next line |

Nothing under `.claude/rules/` referenced it, so `RuleCrossReferenceTests` is unaffected (it scans `.claude/rules/` only) and stays green.

## Fixing the shape, not the reported line

**Does the same wrong pattern appear at another call site?** Yes, and it was worth looking. `--help`'s EXAMPLES section offered:

```
al-runner --dump-csharp /tmp/al-csharp tests/runner-extras/oos-reports
```

`tests/runner-extras/oos-reports` has never existed in this repository — `git log --diff-filter=A --all` finds no commit that ever added it. It was invented in `146bdbbb`, the same v2-cutover commit that left `docs/subsystems.md` advertised as a map. A caller copying that example gets a bundle-not-found error from the runner's own documented example. Repointed at `tests/runner-extras/query-join-aggregation-oos`, a real bundle.

**Does a sibling function make the same assumption?** I scraped every `docs/`, `tests/`, `tools/`, `scripts/` path printed by `--help`, `--guide` and `provision --help` and checked each against disk. Everything else resolves. One prose line read ambiguously as a path (`kept for explicit scripts/back-compat`) and is now `explicit scripts and back-compat`.

**If two code paths write the same state, do they maintain the same invariant?** `PrintHelp` and `PrintGuide` keep independently-maintained documentation lists, which is exactly how one of them drifted. The new tests audit both surfaces together, so the two lists can no longer disagree with the filesystem separately.

## Tests

I did add tests, because the checkable half of this is genuinely mechanical. Three in `AlRunner.Tests/CliDocumentationTests.cs`, the existing drift gate:

1. `HelpAndGuide_ReferenceOnlyPathsThatExistOnDisk` — every repository path either surface prints resolves on disk. Skips `tests/al-language/...` (submodule legitimately absent without `git submodule update`, which would be a failure about the checkout rather than about the CLI's honesty).
2. `HelpAndGuide_DoNotAdvertiseHistoricalArtifacts` — no referenced `.md` lives under `docs/archive/`, and none declares itself historical in its header (first 60 lines; a current doc may legitimately discuss a superseded spike in its body).
3. `DocReferenceAudit_RejectsArchivedAndHistoricalReferences` — the negative direction on the helpers, so the two audits above cannot pass by finding nothing to check.

RED → GREEN, both proven by running them:

- Before the move, (2) failed with `--help prints 'docs/subsystems.md', whose header declares itself historical ("preserved as historical analysis")` and the same line for `--guide`.
- Temporarily restoring the bad example made (1) fail with `--help prints 'tests/runner-extras/oos-reports', which does not exist`.

**What I deliberately did not implement**, and why it differs from the issue's suggestion: the issue proposed asserting that a printed label agrees with the document's H1. That check would not have caught this bug. The label was "subsystem map" and the H1 is "BC service-tier subsystem boundary analysis" — they share the word "subsystem", so any word-overlap rule passes on the exact case that motivated it, and anything looser is a false-failure generator on prose. The self-declared-historical marker is the property that actually separates this document from the seven other docs the CLI cites, and it is checkable without judging prose.

## Verification

- `dotnet test AlRunner.Tests` — 1124 passed, 0 failed, 68 skipped (14m11s), run on this branch at this state.
- No AL corpus run: this diff changes only help/guide string output and documentation paths. Nothing on the compile, dispatch or execution path is touched.
