### PR TITLE
docs(agents): state that impl identities are a reusable pool, not a counter

### DIFF
--- a/.claude/agents/impl-agent.md
+++ b/.claude/agents/impl-agent.md
@@ -7,7 +7,11 @@ model: sonnet
 
 You are an implementation agent for https://github.com/StefanMaron/BusinessCentral.AL.Runner.
 
-**Take your identity from the invoking prompt** — it will say `impl-1`, `impl-2`, etc. That string is your `<AGENT-ID>`. Your GitHub label is `agent: <AGENT-ID>`. If no identity was provided, stop and ask before doing anything else.
+**Take your identity from the invoking prompt** — it will say `impl-1` or `impl-2`. That string is your `<AGENT-ID>`. Your GitHub label is `agent: <AGENT-ID>`. If no identity was provided, stop and ask before doing anything else.
+
+**The identities are a fixed, reusable pool: `impl-1` and `impl-2`.** They are not task numbers and they do not count up. Their only job is to stop two agents that run at the same time from colliding, so the pool only ever needs as many names as the concurrency limit. Reuse them; a finished agent's identity is immediately free.
+
+If you are handed an identity outside the pool, use it for this task but say so in your report — whoever spawned you is drifting, and the drift has a real cost: each new identity leaves behind its own `.claude/worktrees/<AGENT-ID>` checkout forever.
 
 **GitHub access:** `gh` does not exist in web/remote sessions. Detect once at the start and use `gh` or the `mcp__github__*` tools accordingly — see `.claude/rules/github-access.md` for the operation→tool map. The `gh` commands below are the local-CLI spelling. When `gh` is available, pass `--repo StefanMaron/BusinessCentral.AL.Runner` on every command.
 
@@ -53,11 +57,21 @@ Read it: `gh issue view <N> --repo StefanMaron/BusinessCentral.AL.Runner`.
 
 ### Isolate your working tree first
 If you were not already handed an isolated checkout (a dedicated worktree, e.g. under `.claude/worktrees/<AGENT-ID>/`), check before touching git: `git status --short` on the tree you were given. If it shows uncommitted changes you did not make, another agent is mid-edit in that shared tree — do **not** `git checkout -b` there, you will either drag their work onto your branch or yank the tree out from under them. Give yourself an isolated worktree instead:
+Because identities are reused, `.claude/worktrees/<AGENT-ID>` may already exist from an earlier task under the same name. That is expected. **Do not pick a fresh identity just to get a clean directory** — reset the one you have:
+
 ```
 git fetch origin main
+
+# Only if the worktree already exists from a previous task:
+git -C .claude/worktrees/<AGENT-ID> status --porcelain              # must be empty
+git -C .claude/worktrees/<AGENT-ID> log --oneline origin/main..HEAD # must be empty
+git worktree remove .claude/worktrees/<AGENT-ID>
+
 git worktree add .claude/worktrees/<AGENT-ID> -b agent/<AGENT-ID>/issue-<N> origin/main
 cd .claude/worktrees/<AGENT-ID>
 ```
+
+**Never `git worktree remove --force` without running both checks above first.** An agent that crashed or was interrupted mid-task leaves its only copy of that work there — nowhere else. If either check prints anything, stop and report it rather than discarding it.
 Verify with `git rev-parse --show-toplevel` before your first commit. Never `git add -A` / `git add .` in a tree that might carry another agent's edits — stage only the specific files you changed, by name.
 
 ### RED → GREEN

--- a/.claude/commands/work-cycle.md
+++ b/.claude/commands/work-cycle.md
@@ -28,6 +28,7 @@ Report the triager's summary numbers (ready / needs-input / closed / left-alone)
 
 Settings:
 - **Concurrency**: up to 2 implementation agents in parallel (identities `impl-1`, `impl-2`).
+- **Identities are a reusable pool, not a counter.** `impl-1` and `impl-2` are the only two, for every cycle. A finished agent frees its name immediately; the next task reuses it and resets that worktree. Never allocate `impl-3` or higher to "keep them separate" — separation is what the two names already provide, and every extra identity leaves a permanent multi-hundred-megabyte checkout under `.claude/worktrees/`.
 - **Isolation**: each impl agent runs with `isolation: "worktree"` so it has its own checkout and branch.
 - **Background**: impl agents run with `run_in_background: true` so the orchestrator pass can run alongside them.
 
@@ -104,5 +105,5 @@ Print to the user:
 - **You don't do the work.** Triage, implementation, and PR review all happen inside sub-agents. Your only direct `gh` calls are the read-only state reads in Step A.
 - **Don't deep-poll.** When background agents are running, wait for the runtime's notification rather than busy-checking.
 - **Don't re-run the triager mid-loop.** It runs once at the start of the cycle. New issues that arrive mid-cycle will be picked up by the next `/work-cycle` invocation.
-- **Don't escalate concurrency past 2** without an explicit user instruction — the conventional impl identities are `impl-1` and `impl-2`, and going higher means inventing new identities and reasoning about queue contention.
+- **Don't escalate concurrency past 2** without an explicit user instruction, and don't invent identities past the pool even then. The identities are `impl-1` and `impl-2`, reused every cycle. Raising concurrency means reasoning about queue contention; inventing names means accumulating worktrees. If the user does raise the limit, extend the pool to exactly the new limit (`impl-3` only if three run at once) — never one name per task.
 - **Stop when the terminal condition holds.** Do not invent more work to do; report and exit.

--- a/.claude/rules/branch-and-pr.md
+++ b/.claude/rules/branch-and-pr.md
@@ -1,7 +1,7 @@
 # Branch and PR rules
 
 - **Never push directly to `main`.** Always via PR. Branch protection enforces this; agents must respect it even if a task says "push to main".
-- **Branch name:** `agent/<agent-id>/issue-<N>` — no exceptions.
+- **Branch name:** `agent/<agent-id>/issue-<N>` — no exceptions. `<agent-id>` comes from a fixed, reusable pool (`impl-1`, `impl-2`) sized to the concurrency limit — it is not a task counter and does not increase. The issue number is what makes the branch unique, so reusing an identity never collides. See `.claude/agents/impl-agent.md` for how to reset a reused worktree safely.
 - **PR body must contain `Closes #N`** so the linked issue auto-closes on merge, and it must not contain a closing keyword (`Closes`/`Fixes`/`Resolves`, any tense, case-insensitive) next to any OTHER issue number unless you actually mean to close that issue too -- `pr-check.yml`'s `reject-bad-closing-references` job enforces both directions (see below).
 - **This repo squash-merges, and the PR title + body become the squash commit message. The general rule: anything GitHub parses out of a commit message fires when written in a PR body, regardless of the author's intent or the surrounding prose, so refer to issues and directives without their trigger keywords/forms unless the effect is intended.** Three real bugs share this one root cause:
   - A trailing `(#N)` already in the title survives into the merge commit and gets a second one appended by the squash itself (`generate_changelog.py` strips both, see #2109).


### PR DESCRIPTION
The instructions already named `impl-1` and `impl-2`, but left room to invent more: `impl-agent.md` said "`impl-1`, `impl-2`, etc.", and `work-cycle.md` only warned against raising *concurrency*, not against allocating a new identity per task.

That gap got used. Identities ran up past `impl-60`, one per task, and each one left a worktree behind. There are now **42 worktrees under `.claude/worktrees/`, totalling 5.3 GB**, nearly all for work that merged long ago.

## What changed

- **`.claude/agents/impl-agent.md`** — states the identities are a fixed, reusable pool sized to the concurrency limit, that a finished agent's name is immediately free, and what to do if handed an identity outside the pool (use it, but report it, because the spawner is drifting).
- **`.claude/agents/impl-agent.md`**, worktree section — adds the reset procedure for a reused worktree, since the obvious shortcut when `.claude/worktrees/impl-1` already exists is to pick a fresh name instead of cleaning it up.
- **`.claude/commands/work-cycle.md`** — same statement at both places that discuss identities, including the existing "don't escalate past 2" note, which now also says that raising the limit means extending the pool to exactly the new limit rather than one name per task.
- **`.claude/rules/branch-and-pr.md`** — records why reuse is safe: the issue number in `agent/<agent-id>/issue-<N>` is what makes a branch unique, so an identity can be reused without collision.

## The one thing worth reviewing carefully

The reset procedure requires **two** checks before removing a reused worktree — no uncommitted changes, and no commits ahead of `origin/main` — and forbids `--force` without them.

That is not defensive boilerplate. A crashed or interrupted agent's work exists **only** in its worktree: nothing is pushed, and there is no stash to recover from. This session had a machine crash today that killed two agents mid-task; both happened to be clean, but a `--force` removal to "reuse the name" would have silently discarded their work if they had not been. Discarding it is exactly the kind of quiet loss this repo's git rules already exist to prevent (see `no-git-stash-with-worktrees.md`).

## Not included

The 5.3 GB of existing worktrees are untouched. Cleaning them up is a separate job that needs auditing each one for unpushed commits first, and two are in active use right now.

## Testing

No new test. The claim is a convention, and an assertion that a markdown file contains a phrase would pass against a stub of itself, which `.claude/rules/tdd.md` bars. `RuleCrossReferenceTests` and `CliDocumentationTests` both stay green (21 passed) — the new `.claude/agents/impl-agent.md` reference is path-qualified, matching the existing `.claude/rules/github-access.md` reference in the same file.

Closes #2215
