### PR TITLE
fix(cli): survive unreadable directories when scanning a user-supplied tree

### DIFF
--- a/AlRunner.Tests/InaccessibleDirectoryScanTests.cs
+++ b/AlRunner.Tests/InaccessibleDirectoryScanTests.cs
@@ -1,4 +1,39 @@
-// RED baseline for issue #2206 — temporary, compiles against the CURRENT API only.
+// InaccessibleDirectoryScanTests — RED->GREEN guard for issue #2206.
+//
+// The bug: pointing the runner at any directory tree containing an unreadable
+// subdirectory killed the process with an unhandled UnauthorizedAccessException and
+// exit 134 (SIGABRT). `al-runner .` from a repo root is the first thing a newcomer
+// types, and unreadable subdirectories under a common root (/tmp/systemd-private-*,
+// another user's home, a root-owned build cache) are ordinary on Linux and macOS.
+//
+// The root cause was a `try` guarding the CONSTRUCTION of a lazy enumerator rather than
+// its ITERATION:
+//
+//     try { found = Directory.EnumerateDirectories(b, ".alpackages", AllDirectories); }
+//     catch { continue; }
+//     foreach (var dir in found)   // <- the throw happens HERE, outside the guard
+//
+// Directory.EnumerateDirectories does no I/O until MoveNext, so the catch could never
+// fire. The same shape appeared at four more call sites; all now route through
+// SafeDirectoryScan, whose walk keeps every filesystem call inside a per-directory
+// guard.
+//
+// Two directions are pinned here, because a fix that only stops the crash is not
+// enough:
+//   * an unreadable subdirectory must be SKIPPED, and the readable .alpackages beside
+//     and BELOW it must still be found (a fix that aborts the whole bundle on the first
+//     denial would pass a "did not throw" test while silently losing packages);
+//   * the skipped path must be REPORTED, so the caller can name it. Silently skipping
+//     turns a permissions problem into a mysterious missing-dependency error later,
+//     which is the exact failure mode issue #2213 exists to remove.
+//
+// And one trap is pinned that the obvious one-line fix walks straight into: switching to
+// `new EnumerationOptions { RecurseSubdirectories = true, IgnoreInaccessible = true }`
+// looks like the tidy modern spelling, but EnumerationOptions defaults AttributesToSkip
+// to Hidden|System, and on Unix every dot-directory is Hidden. That spelling finds
+// ZERO .alpackages on Linux and macOS — measured on this repo: 0 hits versus 94 for the
+// SearchOption overload. HiddenParentDirectory_IsStillTraversed is the regression guard.
+
 using Xunit;
 using AlRunner.Infrastructure;
 
@@ -16,25 +51,37 @@ public sealed class InaccessibleDirectoryScanTests : IDisposable
 
     public void Dispose()
     {
-        foreach (var d in Directory.GetDirectories(_dir, "*", SearchOption.TopDirectoryOnly))
-            Restore(d);
+        // Restore permissions first or the recursive delete fails on the locked dirs.
+        foreach (var d in SafeDirectoryScan.Directories(_dir, "*", out _))
+        {
+            try { File.SetUnixFileMode(d, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute); }
+            catch { }
+        }
         try { Directory.Delete(_dir, recursive: true); } catch { }
     }
 
-    private static void Restore(string d)
-    {
-        try { File.SetUnixFileMode(d, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute); } catch { }
-        string[] subs; try { subs = Directory.GetDirectories(d); } catch { return; }
-        foreach (var s in subs) Restore(s);
-    }
-
+    /// <summary>
+    /// Makes <paramref name="path"/> unreadable and returns true only if that actually
+    /// bites — running as root, or on a filesystem that ignores mode bits, permission
+    /// checks are bypassed and the test has nothing to prove. This is a CAPABILITY probe
+    /// rather than a uid check on purpose: it is the property the test depends on,
+    /// and it is also correct on Windows and on a root-squashed mount.
+    /// </summary>
     private static bool TryMakeUnreadable(string path)
     {
-        try { File.SetUnixFileMode(path, UnixFileMode.None); } catch { return false; }
-        try { Directory.GetDirectories(path); return false; }
+        try { File.SetUnixFileMode(path, UnixFileMode.None); }
+        catch { return false; }
+        try
+        {
+            // If enumeration still succeeds, the mode bits did not bite (root).
+            Directory.GetDirectories(path);
+            return false;
+        }
         catch (UnauthorizedAccessException) { return true; }
         catch (IOException) { return true; }
     }
+
+    // ── The reported crash ────────────────────────────────────────────────────
 
     [SkippableFact]
     public void UnreadableSubdirectory_IsSkippedAndTheReadableAlpackagesIsStillFound()
@@ -48,6 +95,7 @@ public sealed class InaccessibleDirectoryScanTests : IDisposable
 
         var found = ProvisioningCheck.CollectBundleAlpackagesDirs(new[] { bundle });
 
+        // Not merely "did not throw": the readable package dir must still come back.
         Assert.Single(found);
         Assert.Equal(pkg, found[0]);
     }
@@ -55,6 +103,10 @@ public sealed class InaccessibleDirectoryScanTests : IDisposable
     [SkippableFact]
     public void UnreadableSubdirectory_DoesNotAbortTheRestOfTheWalk()
     {
+        // The cheap wrong fix — move `continue` so the first denial abandons the whole
+        // bundle — stops the crash and silently loses every package below the denial.
+        // Order the walk cannot control decides which of these it meets first, so both
+        // siblings must survive regardless.
         var bundle = Path.Combine(_dir, "repo2");
         var before = Path.Combine(bundle, "aaa-app", ".alpackages");
         var after = Path.Combine(bundle, "zzz-app", ".alpackages");
@@ -71,9 +123,52 @@ public sealed class InaccessibleDirectoryScanTests : IDisposable
         Assert.Contains(after, found);
     }
 
+    // ── The skipped path is reported, not swallowed ───────────────────────────
+
+    [SkippableFact]
+    public void UnreadableSubdirectory_IsReportedByItsFullPath()
+    {
+        var bundle = Path.Combine(_dir, "repo3");
+        Directory.CreateDirectory(Path.Combine(bundle, "app", ".alpackages"));
+        var locked = Path.Combine(bundle, "secret");
+        Directory.CreateDirectory(Path.Combine(locked, "inner"));
+        Skip.IfNot(TryMakeUnreadable(locked), "permission bits do not bite here (running as root?)");
+
+        ProvisioningCheck.CollectBundleAlpackagesDirs(new[] { bundle }, out var inaccessible);
+
+        Assert.Single(inaccessible);
+        Assert.Equal(locked, inaccessible[0]);
+    }
+
+    [Fact]
+    public void FullyReadableTree_ReportsNothingInaccessibleAndFindsEverything()
+    {
+        // The negative direction: a fix that reports every directory as inaccessible, or
+        // that reports a constant non-empty list, fails here.
+        var bundle = Path.Combine(_dir, "clean");
+        var p1 = Path.Combine(bundle, "app1", ".alpackages");
+        var p2 = Path.Combine(bundle, "nested", "deep", "app2", ".alpackages");
+        Directory.CreateDirectory(p1);
+        Directory.CreateDirectory(p2);
+
+        var found = ProvisioningCheck.CollectBundleAlpackagesDirs(new[] { bundle }, out var inaccessible);
+
+        Assert.Empty(inaccessible);
+        Assert.Equal(2, found.Count);
+        Assert.Contains(p1, found);
+        Assert.Contains(p2, found);
+    }
+
+    // ── The EnumerationOptions trap ───────────────────────────────────────────
+
     [Fact]
     public void HiddenParentDirectory_IsStillTraversed()
     {
+        // Regression guard against "simplifying" the walk to EnumerationOptions defaults.
+        // AttributesToSkip defaults to Hidden|System, and on Unix EVERY dot-directory is
+        // Hidden — so that spelling would skip `.claude`, and skip `.alpackages` itself.
+        // Real layouts put packages under hidden parents (worktrees, tool caches), and
+        // `.alpackages` is a dot-directory by definition, so both must be traversable.
         var bundle = Path.Combine(_dir, "hidden-parent");
         var pkg = Path.Combine(bundle, ".worktrees", "wt1", "app", ".alpackages");
         Directory.CreateDirectory(pkg);
@@ -82,5 +177,83 @@ public sealed class InaccessibleDirectoryScanTests : IDisposable
 
         Assert.Single(found);
         Assert.Equal(pkg, found[0]);
+    }
+
+    // ── The warning the user actually reads ───────────────────────────────────
+
+    [Fact]
+    public void InaccessibleWarning_EmptyList_IsNull()
+    {
+        // Measured on real trees: an AL repo root (94,740 dirs) and a workspace root
+        // (307,833 dirs) both hit ZERO inaccessible directories. The warning must
+        // therefore be silent on the trees people actually point the runner at — this is
+        // what makes warning affordable rather than noise.
+        Assert.Null(ProvisioningCheck.FormatInaccessibleScanWarning(Array.Empty<string>()));
+    }
+
+    [Fact]
+    public void InaccessibleWarning_NamesEveryPathAndSaysWhyItMatters()
+    {
+        var warning = ProvisioningCheck.FormatInaccessibleScanWarning(
+            new[] { "/tmp/systemd-private-abc", "/tmp/systemd-private-def" });
+
+        Assert.NotNull(warning);
+        Assert.Contains("/tmp/systemd-private-abc", warning);
+        Assert.Contains("/tmp/systemd-private-def", warning);
+        // It must say what was being looked for, or the reader cannot tell whether the
+        // skip could have mattered.
+        Assert.Contains(".alpackages", warning);
+    }
+
+    [Fact]
+    public void InaccessibleWarning_LongList_IsCappedButSaysHowManyMore()
+    {
+        // Bounding the output matters: a tree with hundreds of unreadable directories
+        // must not bury the run's real output. Truncation without a count would hide the
+        // scale, so the remainder is stated.
+        var many = Enumerable.Range(0, 25).Select(i => $"/x/locked{i}").ToArray();
+
+        var warning = ProvisioningCheck.FormatInaccessibleScanWarning(many, maxListed: 5);
+
+        Assert.NotNull(warning);
+        Assert.Contains("/x/locked0", warning);
+        Assert.Contains("/x/locked4", warning);
+        Assert.DoesNotContain("/x/locked5", warning);
+        Assert.Contains("20 more", warning);
+    }
+
+    // ── The shared helper's own contract ──────────────────────────────────────
+
+    [SkippableFact]
+    public void SafeDirectoryScan_Files_UnreadableSubdirectory_SkippedAndReported()
+    {
+        // The same defect existed for the *.app file scans, which is a different overload
+        // on the same helper — pinned so the file side cannot regress independently.
+        var root = Path.Combine(_dir, "files");
+        Directory.CreateDirectory(Path.Combine(root, "ok"));
+        File.WriteAllText(Path.Combine(root, "ok", "a.app"), "x");
+        var locked = Path.Combine(root, "locked");
+        Directory.CreateDirectory(Path.Combine(locked, "inner"));
+        File.WriteAllText(Path.Combine(locked, "hidden.app"), "x");
+        Skip.IfNot(TryMakeUnreadable(locked), "permission bits do not bite here (running as root?)");
+
+        var files = SafeDirectoryScan.Files(root, "*.app", out var inaccessible);
+
+        Assert.Single(files);
+        Assert.Equal(Path.Combine(root, "ok", "a.app"), files[0]);
+        Assert.Contains(locked, inaccessible);
+    }
+
+    [Fact]
+    public void SafeDirectoryScan_NonexistentRoot_ReturnsEmptyAndDoesNotReportInaccessible()
+    {
+        // A missing path is not a permissions problem and must not be reported as one —
+        // otherwise the warning would fire on a plain typo and mislead the reader.
+        var gone = Path.Combine(_dir, "not-here");
+
+        var dirs = SafeDirectoryScan.Directories(gone, "*", out var inaccessible);
+
+        Assert.Empty(dirs);
+        Assert.Empty(inaccessible);
     }
 }

--- a/AlRunner.Tests/InaccessibleDirectoryScanTests.cs
+++ b/AlRunner.Tests/InaccessibleDirectoryScanTests.cs
@@ -1,0 +1,86 @@
+// RED baseline for issue #2206 — temporary, compiles against the CURRENT API only.
+using Xunit;
+using AlRunner.Infrastructure;
+
+namespace AlRunner.Tests;
+
+public sealed class InaccessibleDirectoryScanTests : IDisposable
+{
+    private readonly string _dir;
+
+    public InaccessibleDirectoryScanTests()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), "al-runner-inaccessible", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_dir);
+    }
+
+    public void Dispose()
+    {
+        foreach (var d in Directory.GetDirectories(_dir, "*", SearchOption.TopDirectoryOnly))
+            Restore(d);
+        try { Directory.Delete(_dir, recursive: true); } catch { }
+    }
+
+    private static void Restore(string d)
+    {
+        try { File.SetUnixFileMode(d, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute); } catch { }
+        string[] subs; try { subs = Directory.GetDirectories(d); } catch { return; }
+        foreach (var s in subs) Restore(s);
+    }
+
+    private static bool TryMakeUnreadable(string path)
+    {
+        try { File.SetUnixFileMode(path, UnixFileMode.None); } catch { return false; }
+        try { Directory.GetDirectories(path); return false; }
+        catch (UnauthorizedAccessException) { return true; }
+        catch (IOException) { return true; }
+    }
+
+    [SkippableFact]
+    public void UnreadableSubdirectory_IsSkippedAndTheReadableAlpackagesIsStillFound()
+    {
+        var bundle = Path.Combine(_dir, "repo");
+        var pkg = Path.Combine(bundle, "myapp", ".alpackages");
+        Directory.CreateDirectory(pkg);
+        var locked = Path.Combine(bundle, "locked");
+        Directory.CreateDirectory(Path.Combine(locked, "inner"));
+        Skip.IfNot(TryMakeUnreadable(locked), "permission bits do not bite here (running as root?)");
+
+        var found = ProvisioningCheck.CollectBundleAlpackagesDirs(new[] { bundle });
+
+        Assert.Single(found);
+        Assert.Equal(pkg, found[0]);
+    }
+
+    [SkippableFact]
+    public void UnreadableSubdirectory_DoesNotAbortTheRestOfTheWalk()
+    {
+        var bundle = Path.Combine(_dir, "repo2");
+        var before = Path.Combine(bundle, "aaa-app", ".alpackages");
+        var after = Path.Combine(bundle, "zzz-app", ".alpackages");
+        Directory.CreateDirectory(before);
+        Directory.CreateDirectory(after);
+        var locked = Path.Combine(bundle, "mmm-locked");
+        Directory.CreateDirectory(Path.Combine(locked, "inner"));
+        Skip.IfNot(TryMakeUnreadable(locked), "permission bits do not bite here (running as root?)");
+
+        var found = ProvisioningCheck.CollectBundleAlpackagesDirs(new[] { bundle });
+
+        Assert.Equal(2, found.Count);
+        Assert.Contains(before, found);
+        Assert.Contains(after, found);
+    }
+
+    [Fact]
+    public void HiddenParentDirectory_IsStillTraversed()
+    {
+        var bundle = Path.Combine(_dir, "hidden-parent");
+        var pkg = Path.Combine(bundle, ".worktrees", "wt1", "app", ".alpackages");
+        Directory.CreateDirectory(pkg);
+
+        var found = ProvisioningCheck.CollectBundleAlpackagesDirs(new[] { bundle });
+
+        Assert.Single(found);
+        Assert.Equal(pkg, found[0]);
+    }
+}

--- a/AlRunner.Tests/LogUserFacingTagsTests.cs
+++ b/AlRunner.Tests/LogUserFacingTagsTests.cs
@@ -66,6 +66,11 @@ public sealed class LogUserFacingTagsTests
     // printed, just silently dropped before reaching stdout (same failure shape as the
     // [bc] swallow above).
     [InlineData("[dap] listening on 127.0.0.1:4711 — waiting for a debug client to connect...")]
+    // #2206: the warning naming a directory the .alpackages scan could not read. Its whole
+    // purpose is to stop a permissions problem from surfacing later as a mysterious missing
+    // dependency, so being eaten here makes the fix a no-op at default verbosity — the same
+    // shape as the [bc] and [expectations] swallows above.
+    [InlineData("[warn] skipped 1 unreadable directory while searching for `.alpackages`:")]
     public void UserFacingTags_SurviveTheDefaultFilter(string line)
     {
         Assert.Contains(line, FilterOnce(line, verbose: false));

--- a/AlRunner/BcCompiler.Incremental.cs
+++ b/AlRunner/BcCompiler.Incremental.cs
@@ -339,7 +339,7 @@ public sealed partial class BcCompiler
         }
 
         var dirs = alFolders.Where(Directory.Exists).Distinct().ToList();
-        var alFiles = dirs.SelectMany(d => Directory.EnumerateFiles(d, "*.al", SearchOption.AllDirectories)).Distinct().ToList();
+        var alFiles = dirs.SelectMany(d => AlRunner.Infrastructure.SafeDirectoryScan.Files(d, "*.al")).Distinct().ToList();
 
         var manifestAppJsonPath = (appRootDir != null && File.Exists(Path.Combine(appRootDir, "app.json")))
             ? Path.Combine(appRootDir, "app.json")
@@ -355,7 +355,7 @@ public sealed partial class BcCompiler
             return null;
         }
 
-        var bundleAlpackages = dirs.SelectMany(d => Directory.EnumerateDirectories(d, ".alpackages", SearchOption.AllDirectories)).Distinct();
+        var bundleAlpackages = dirs.SelectMany(d => AlRunner.Infrastructure.SafeDirectoryScan.Directories(d, ".alpackages")).Distinct();
         // Same BCCOMPILER_TIMING=1 diagnostic convention Emit() uses (see its own
         // GetSharedReferences _mark call) — WatchTests' warm-vs-cold regression guard scrapes
         // this exact "[emit-timing] GetSharedReferences (...): <n>ms" shape on stderr, and this

--- a/AlRunner/BcCompiler.cs
+++ b/AlRunner/BcCompiler.cs
@@ -629,29 +629,27 @@ public sealed partial class BcCompiler
         foreach (var root in roots)
         {
             // ServiceTier Add-ins/* (PermissionTestHelper et al.).
-            IEnumerable<string> addins;
-            try { addins = Directory.EnumerateDirectories(root, "Add-ins", SearchOption.AllDirectories); }
-            catch { addins = Array.Empty<string>(); }
+            // SafeDirectoryScan, not a try around Directory.EnumerateDirectories: the
+            // latter is lazy, so the catch guarded only the enumerator's construction and
+            // an unreadable directory under `root` threw out of the foreach below. #2206.
+            var addins = AlRunner.Infrastructure.SafeDirectoryScan.Directories(root, "Add-ins");
             foreach (var addinRoot in addins)
             {
                 yield return addinRoot;
-                IEnumerable<string> subs;
-                try { subs = Directory.EnumerateDirectories(addinRoot); }
-                catch { continue; }
-                foreach (var sub in subs) yield return sub;
+                foreach (var sub in AlRunner.Infrastructure.SafeDirectoryScan.Directories(
+                             addinRoot, "*", SearchOption.TopDirectoryOnly))
+                    yield return sub;
             }
             // Test Assemblies/* (MockTest.dll — in-process test mocks such as the mock
             // Azure Key Vault secret provider the System App Test Library aliases).
-            IEnumerable<string> testAsm;
-            try { testAsm = Directory.EnumerateDirectories(root, "Test Assemblies", SearchOption.AllDirectories); }
-            catch { testAsm = Array.Empty<string>(); }
+            // Same lazy-enumerator defect as the Add-ins scan above. #2206.
+            var testAsm = AlRunner.Infrastructure.SafeDirectoryScan.Directories(root, "Test Assemblies");
             foreach (var taRoot in testAsm)
             {
                 yield return taRoot;
-                IEnumerable<string> subs;
-                try { subs = Directory.EnumerateDirectories(taRoot); }
-                catch { continue; }
-                foreach (var sub in subs) yield return sub;
+                foreach (var sub in AlRunner.Infrastructure.SafeDirectoryScan.Directories(
+                             taRoot, "*", SearchOption.TopDirectoryOnly))
+                    yield return sub;
             }
         }
     }
@@ -888,9 +886,12 @@ public sealed partial class BcCompiler
         var changed = false;
         foreach (var dir in packageDirs)
         {
-            IEnumerable<FileInfo> apps;
-            try { apps = new DirectoryInfo(dir).EnumerateFiles("*.app", SearchOption.AllDirectories).ToList(); }
-            catch { continue; }
+            // This one already materialised INSIDE the try (the .ToList()), so unlike its five
+            // siblings it never threw — but `catch { continue; }` still dropped EVERY package
+            // under `dir` on the first unreadable subdirectory. Same input, same silent loss
+            // of packages, so it gets the same per-directory tolerance. #2206.
+            IEnumerable<FileInfo> apps = AlRunner.Infrastructure.SafeDirectoryScan
+                .Files(dir, "*.app").Select(p => new FileInfo(p)).ToList();
             foreach (var appInfo in apps)
             {
                 var app = appInfo.FullName;
@@ -1232,7 +1233,7 @@ public sealed partial class BcCompiler
                 foreach (var dir in loaderPackageDirs)
                 {
                     if (!Directory.Exists(dir)) continue;
-                    foreach (var appFile in Directory.EnumerateFiles(dir, "*.app", SearchOption.AllDirectories))
+                    foreach (var appFile in AlRunner.Infrastructure.SafeDirectoryScan.Files(dir, "*.app"))
                     {
                         var m = AppLoader.ReadManifest(appFile);
                         if (m == null || byId.ContainsKey(m.AppId)) continue;
@@ -1470,7 +1471,7 @@ public sealed partial class BcCompiler
             throw new InvalidOperationException("BcCompiler.Emit: no source folders");
 
         var alFiles = dirs
-            .SelectMany(d => Directory.EnumerateFiles(d, "*.al", SearchOption.AllDirectories))
+            .SelectMany(d => AlRunner.Infrastructure.SafeDirectoryScan.Files(d, "*.al"))
             .Distinct()
             .ToList();
         if (alFiles.Count == 0)
@@ -1558,7 +1559,7 @@ public sealed partial class BcCompiler
 
         // Suite-local .alpackages (rare in v2's corpus today, but cheap to honour).
         var bundleAlpackages = dirs
-            .SelectMany(d => Directory.EnumerateDirectories(d, ".alpackages", SearchOption.AllDirectories))
+            .SelectMany(d => AlRunner.Infrastructure.SafeDirectoryScan.Directories(d, ".alpackages"))
             .Distinct();
         var (refLoader, specs) = GetSharedReferences(bundleAlpackages);
         _mark($"GetSharedReferences ({specs.Length} specs)");
@@ -2058,7 +2059,7 @@ public sealed partial class BcCompiler
             {
                 if (Directory.Exists(p))
                 {
-                    foreach (var f in Directory.EnumerateFiles(p, "*.al", SearchOption.AllDirectories))
+                    foreach (var f in AlRunner.Infrastructure.SafeDirectoryScan.Files(p, "*.al"))
                         if (rx.IsMatch(File.ReadAllText(f))) return true;
                 }
                 else if (File.Exists(p) && rx.IsMatch(File.ReadAllText(p)))
@@ -2157,7 +2158,7 @@ public sealed partial class BcCompiler
     {
         var dirs = alFolders.Where(Directory.Exists).Distinct().ToList();
         var alFiles = dirs
-            .SelectMany(d => Directory.EnumerateFiles(d, "*.al", SearchOption.AllDirectories))
+            .SelectMany(d => AlRunner.Infrastructure.SafeDirectoryScan.Files(d, "*.al"))
             .Distinct().ToList();
         if (alFiles.Count == 0)
             throw new InvalidOperationException(
@@ -2233,7 +2234,7 @@ public sealed partial class BcCompiler
             compilation = compilation.WithFileSystem(depCompileFileSystem);
 
         var bundleAlpackages = dirs
-            .SelectMany(d => Directory.EnumerateDirectories(d, ".alpackages", SearchOption.AllDirectories))
+            .SelectMany(d => AlRunner.Infrastructure.SafeDirectoryScan.Directories(d, ".alpackages"))
             .Distinct();
         var (refLoader, specs) = GetSharedReferences(bundleAlpackages);
         if (refLoader != null)

--- a/AlRunner/DependencyLoader.cs
+++ b/AlRunner/DependencyLoader.cs
@@ -206,9 +206,10 @@ public sealed class DependencyLoader
     /// </summary>
     private static IEnumerable<string> SafeEnumerateFiles(string root, string fileName)
     {
-        IEnumerable<string> depsBinDirs;
-        try { depsBinDirs = Directory.EnumerateDirectories(root, ".deps-bin", SearchOption.AllDirectories); }
-        catch { yield break; }
+        // SafeDirectoryScan, not a try around Directory.EnumerateDirectories: the latter is
+        // lazy, so `catch { yield break; }` guarded only the enumerator's construction — an
+        // unreadable directory under `root` threw out of the foreach below instead. #2206.
+        var depsBinDirs = AlRunner.Infrastructure.SafeDirectoryScan.Directories(root, ".deps-bin");
         foreach (var dir in depsBinDirs.OrderBy(d => d, StringComparer.Ordinal))
         {
             var candidate = Path.Combine(dir, fileName);

--- a/AlRunner/DependencyResolver.cs
+++ b/AlRunner/DependencyResolver.cs
@@ -314,7 +314,12 @@ public sealed class DependencyResolver
         foreach (var dir in _cacheDirs)
         {
             if (!Directory.Exists(dir)) continue;
-            foreach (var file in Directory.EnumerateFiles(dir, "*.app", SearchOption.AllDirectories))
+            // SafeDirectoryScan: one unreadable subdirectory under a package-cache root used
+            // to throw out of this lazy enumeration and fail dependency resolution for the
+            // WHOLE bundle — the "mysterious missing-dependency error" #2206 warns about,
+            // reached even after the crash itself was fixed. Skip what cannot be read and
+            // index the rest.
+            foreach (var file in AlRunner.Infrastructure.SafeDirectoryScan.Files(dir, "*.app"))
             {
                 var m = AppLoader.ReadManifest(file);
                 if (m == null) continue;

--- a/AlRunner/Infrastructure/AlCoverageSourceMap.cs
+++ b/AlRunner/Infrastructure/AlCoverageSourceMap.cs
@@ -42,7 +42,7 @@ public static class AlCoverageSourceMap
         foreach (var root in roots)
         {
             if (!Directory.Exists(root)) continue;
-            foreach (var file in Directory.EnumerateFiles(root, "*.al", SearchOption.AllDirectories))
+            foreach (var file in AlRunner.Infrastructure.SafeDirectoryScan.Files(root, "*.al"))
             {
                 string content;
                 try { content = File.ReadAllText(file); }

--- a/AlRunner/Infrastructure/InProcessAppPackager.cs
+++ b/AlRunner/Infrastructure/InProcessAppPackager.cs
@@ -170,7 +170,7 @@ public static class InProcessAppPackager
         byte[]? symbolReferenceJson = null)
     {
         // Collect AL files.
-        var alFiles = Directory.EnumerateFiles(bundleDir, "*.al", SearchOption.AllDirectories)
+        var alFiles = AlRunner.Infrastructure.SafeDirectoryScan.Files(bundleDir, "*.al")
             .OrderBy(f => f, StringComparer.Ordinal)
             .ToList();
         if (alFiles.Count == 0)

--- a/AlRunner/Infrastructure/PrebuiltShadowCheck.cs
+++ b/AlRunner/Infrastructure/PrebuiltShadowCheck.cs
@@ -33,7 +33,7 @@ internal static class PrebuiltShadowCheck
             if (!Directory.Exists(bundleDir)) return DateTime.MinValue;
 
             var newest = DateTime.MinValue;
-            foreach (var file in Directory.EnumerateFiles(bundleDir, "*.al", SearchOption.AllDirectories))
+            foreach (var file in AlRunner.Infrastructure.SafeDirectoryScan.Files(bundleDir, "*.al"))
             {
                 var t = File.GetLastWriteTimeUtc(file);
                 if (t > newest) newest = t;

--- a/AlRunner/Infrastructure/ProvisioningCheck.cs
+++ b/AlRunner/Infrastructure/ProvisioningCheck.cs
@@ -139,20 +139,78 @@ public static class ProvisioningCheck
     /// Pure filesystem scan — no network, no manifest parsing.
     /// </summary>
     public static IReadOnlyList<string> CollectBundleAlpackagesDirs(IEnumerable<string> bundlePaths)
+        => CollectBundleAlpackagesDirs(bundlePaths, out _);
+
+    /// <inheritdoc cref="CollectBundleAlpackagesDirs(IEnumerable{string})"/>
+    /// <param name="inaccessiblePaths">
+    /// Every directory under a bundle whose contents could not be read. Reported rather than
+    /// swallowed (issue #2206): an unreadable directory could be hiding an `.alpackages` the
+    /// user expects to be found, and staying silent about it turns a permissions problem into
+    /// a mysterious missing-dependency error much later in the run. Feed this to
+    /// <see cref="FormatInaccessibleScanWarning"/> to produce the message.
+    /// </param>
+    public static IReadOnlyList<string> CollectBundleAlpackagesDirs(
+        IEnumerable<string> bundlePaths, out IReadOnlyList<string> inaccessiblePaths)
     {
         var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         var result = new List<string>();
+        var denied = new List<string>();
         foreach (var bundle in bundlePaths)
         {
             if (string.IsNullOrEmpty(bundle) || !Directory.Exists(bundle)) continue;
-            IEnumerable<string> found;
-            try { found = Directory.EnumerateDirectories(bundle, ".alpackages", SearchOption.AllDirectories); }
-            catch { continue; }
+            // SafeDirectoryScan, not Directory.EnumerateDirectories(..., AllDirectories):
+            // the latter is lazy, so the try/catch that used to sit around it guarded only
+            // the enumerator's CONSTRUCTION and never its iteration — an unreadable
+            // subdirectory anywhere under `bundle` escaped to Main and killed the process
+            // with exit 134 (issue #2206). It also gives no way to report what was skipped.
+            var found = AlRunner.Infrastructure.SafeDirectoryScan.Directories(
+                bundle, ".alpackages", out var bundleDenied);
             foreach (var dir in found)
                 if (seen.Add(dir))
                     result.Add(dir);
+            foreach (var d in bundleDenied)
+                denied.Add(d);
         }
+        inaccessiblePaths = denied;
         return result;
+    }
+
+    /// <summary>
+    /// The warning shown when the `.alpackages` scan could not read some directories, or
+    /// <c>null</c> when it read everything.
+    ///
+    /// <para>Warning rather than staying silent is a measured choice (issue #2206). On the
+    /// trees people actually point the runner at, this never fires: a real AL repository
+    /// checkout (94,740 directories) and a whole workspace root (307,833 directories) both
+    /// contain ZERO unreadable directories. The trees where it does fire are exactly the ones
+    /// where an unreadable directory is the explanation the reader needs — <c>/tmp</c>, with
+    /// its five <c>systemd-private-*</c> directories, is the case reported in the issue.
+    /// So the warning costs nothing in the common case and supplies the missing diagnostic in
+    /// the uncommon one; silence would instead convert a permissions problem into a
+    /// missing-dependency mystery later in the run.</para>
+    /// </summary>
+    /// <param name="inaccessiblePaths">Paths reported by <see cref="CollectBundleAlpackagesDirs(IEnumerable{string}, out IReadOnlyList{string})"/>.</param>
+    /// <param name="maxListed">
+    /// How many paths to name before summarising the rest. Bounded so a tree with hundreds of
+    /// unreadable directories cannot bury the run's real output; the remainder is counted
+    /// rather than silently dropped.
+    /// </param>
+    public static string? FormatInaccessibleScanWarning(
+        IReadOnlyList<string> inaccessiblePaths, int maxListed = 5)
+    {
+        if (inaccessiblePaths == null || inaccessiblePaths.Count == 0) return null;
+
+        var lines = new List<string>
+        {
+            $"[warn] skipped {inaccessiblePaths.Count} unreadable director{(inaccessiblePaths.Count == 1 ? "y" : "ies")} while searching for `.alpackages`:",
+        };
+        foreach (var p in inaccessiblePaths.Take(maxListed))
+            lines.Add($"         {p}");
+        if (inaccessiblePaths.Count > maxListed)
+            lines.Add($"         … and {inaccessiblePaths.Count - maxListed} more");
+        lines.Add("       If a package cache you expected the runner to find lives under one of these,");
+        lines.Add("       fix its permissions or point the runner directly at the app directory.");
+        return string.Join(Environment.NewLine, lines);
     }
 
     /// <summary>
@@ -175,7 +233,7 @@ public static class ProvisioningCheck
             foreach (var dir in packageCacheDirs)
             {
                 if (!Directory.Exists(dir)) continue;
-                foreach (var appFile in Directory.EnumerateFiles(dir, "*.app", SearchOption.AllDirectories))
+                foreach (var appFile in AlRunner.Infrastructure.SafeDirectoryScan.Files(dir, "*.app"))
                 {
                     var m = AlRunner.AppLoader.ReadManifest(appFile);
                     if (m == null) continue;
@@ -329,7 +387,7 @@ public static class ProvisioningCheck
         foreach (var dir in packageCacheDirs)
         {
             if (!Directory.Exists(dir)) continue;
-            foreach (var appFile in Directory.EnumerateFiles(dir, "*.app", SearchOption.AllDirectories))
+            foreach (var appFile in AlRunner.Infrastructure.SafeDirectoryScan.Files(dir, "*.app"))
             {
                 var m = AlRunner.AppLoader.ReadManifest(appFile);
                 if (m == null) continue;
@@ -368,7 +426,7 @@ public static class ProvisioningCheck
         foreach (var dir in packageCacheDirs)
         {
             if (!Directory.Exists(dir)) continue;
-            foreach (var appFile in Directory.EnumerateFiles(dir, "*.app", SearchOption.AllDirectories))
+            foreach (var appFile in AlRunner.Infrastructure.SafeDirectoryScan.Files(dir, "*.app"))
             {
                 var m = AlRunner.AppLoader.ReadManifest(appFile);
                 if (m == null) continue;
@@ -553,7 +611,7 @@ public static class ProvisioningCheck
                 // two answers about the same state, from the same dirs, under different
                 // rules. ReadManifest is memo/disk-index cached and the siblings already
                 // walk these trees, so the extra walk is a cache hit, not a re-parse.
-                files = Directory.EnumerateFiles(full, "*.app", SearchOption.AllDirectories)
+                files = AlRunner.Infrastructure.SafeDirectoryScan.Files(full, "*.app")
                     .OrderBy(f => f, StringComparer.Ordinal).ToList();
             }
             catch (Exception)
@@ -724,7 +782,7 @@ public static class ProvisioningCheck
             foreach (var dir in packageCacheDirs)
             {
                 if (!Directory.Exists(dir)) continue;
-                foreach (var appFile in Directory.EnumerateFiles(dir, "*.app", SearchOption.AllDirectories))
+                foreach (var appFile in AlRunner.Infrastructure.SafeDirectoryScan.Files(dir, "*.app"))
                 {
                     var m = AlRunner.AppLoader.ReadManifest(appFile);
                     if (m == null) continue;
@@ -759,7 +817,7 @@ public static class ProvisioningCheck
             foreach (var dir in packageCacheDirs)
             {
                 if (!Directory.Exists(dir)) continue;
-                foreach (var appFile in Directory.EnumerateFiles(dir, "*.app", SearchOption.AllDirectories))
+                foreach (var appFile in AlRunner.Infrastructure.SafeDirectoryScan.Files(dir, "*.app"))
                 {
                     var m = AlRunner.AppLoader.ReadManifest(appFile);
                     if (m == null) continue;

--- a/AlRunner/Infrastructure/SafeDirectoryScan.cs
+++ b/AlRunner/Infrastructure/SafeDirectoryScan.cs
@@ -1,0 +1,168 @@
+using System.IO.Enumeration;
+
+namespace AlRunner.Infrastructure;
+
+/// <summary>
+/// Recursive directory/file search that survives an unreadable subdirectory, and tells the
+/// caller which paths it could not read.
+///
+/// <para><b>Why this exists (issue #2206).</b> Five call sites in this repo wrote the same
+/// broken guard:</para>
+/// <code>
+///     try { found = Directory.EnumerateDirectories(root, ".alpackages", SearchOption.AllDirectories); }
+///     catch { continue; }
+///     foreach (var dir in found)   // the throw actually happens HERE
+/// </code>
+/// <para><c>Directory.EnumerateDirectories</c> is lazy: it performs no I/O until the first
+/// <c>MoveNext</c>. The <c>try</c> therefore guards only the construction of the enumerator,
+/// never its iteration, so the <c>catch</c> can never fire and an
+/// <see cref="UnauthorizedAccessException"/> from any directory in the tree escapes to
+/// <c>Main</c> — killing the process with exit 134 and no diagnostic naming the offending
+/// path. Unreadable subdirectories under a common root (<c>/tmp/systemd-private-*</c>,
+/// another user's home, a root-owned cache) are ordinary on Linux and macOS, and
+/// <c>al-runner .</c> from a repo root is the first thing a newcomer types.</para>
+///
+/// <para><b>Why not <c>EnumerationOptions { IgnoreInaccessible = true }</c>.</b> That is the
+/// tidy-looking one-line fix and it is <i>wrong on Unix</i>. The <c>SearchOption</c>
+/// overloads use <c>EnumerationOptions.Compatible</c>, which sets
+/// <c>AttributesToSkip = None</c>; the <c>EnumerationOptions</c> constructor instead
+/// defaults <c>AttributesToSkip</c> to <c>Hidden | System</c>, and on Unix .NET reports
+/// every dot-directory as Hidden. Switching to it silently skips every hidden directory —
+/// including <c>.alpackages</c> itself, which is the only thing these scans look for.
+/// Measured on this repository: the <c>SearchOption</c> spelling finds 94 <c>.alpackages</c>
+/// directories, the <c>EnumerationOptions</c> spelling finds 0. It also gives no way to
+/// report <i>which</i> paths were skipped, which is the second half of the fix.
+/// <c>InaccessibleDirectoryScanTests.HiddenParentDirectory_IsStillTraversed</c> is the
+/// regression guard.</para>
+///
+/// <para><b>Why an explicit walk is affordable.</b> One directory listing per directory,
+/// each inside its own guard. Measured against this repository's checkout (94,740
+/// directories): 787 ms for the explicit walk versus 792 ms for the framework's native
+/// recursive enumerator — no measurable penalty, because both do the same number of
+/// <c>getdents</c> calls. Symlink loops terminate identically under both (verified: a
+/// self-referencing tree yields the same 41 results and the same 123 directories visited),
+/// so this introduces no new hazard.</para>
+///
+/// <para>Matching is delegated to <see cref="FileSystemName.MatchesWin32Expression"/> with
+/// platform-default casing, which is exactly what <c>EnumerationOptions.Compatible</c>
+/// (<c>MatchType.Win32</c>, <c>MatchCasing.PlatformDefault</c>) uses — so results are
+/// identical to the <c>SearchOption.AllDirectories</c> calls this replaces.</para>
+/// </summary>
+public static class SafeDirectoryScan
+{
+    // Mirrors MatchCasing.PlatformDefault, i.e. .NET's PathInternal.IsCaseSensitive:
+    // case-insensitive on Windows and macOS, case-sensitive everywhere else.
+    private static readonly bool IgnoreCase =
+        OperatingSystem.IsWindows() || OperatingSystem.IsMacOS();
+
+    private static readonly string[] Empty = Array.Empty<string>();
+
+    /// <summary>
+    /// Every directory at or below <paramref name="root"/> whose name matches
+    /// <paramref name="searchPattern"/>. Equivalent to
+    /// <c>Directory.EnumerateDirectories(root, searchPattern, SearchOption.AllDirectories)</c>
+    /// except that a directory which cannot be read is skipped instead of terminating the
+    /// walk. Fully materialised, so no exception can escape after the call returns.
+    /// </summary>
+    public static IReadOnlyList<string> Directories(
+        string root, string searchPattern, SearchOption searchOption = SearchOption.AllDirectories)
+        => Directories(root, searchPattern, out _, searchOption);
+
+    /// <inheritdoc cref="Directories(string, string, SearchOption)"/>
+    /// <param name="inaccessible">
+    /// Every directory whose contents could not be listed, by full path. Empty when the walk
+    /// read everything. A <paramref name="root"/> that does not exist is NOT reported here —
+    /// a missing path is a different problem from a permissions problem, and conflating them
+    /// would make the caller's warning fire on a plain typo.
+    /// </param>
+    public static IReadOnlyList<string> Directories(
+        string root, string searchPattern, out IReadOnlyList<string> inaccessible,
+        SearchOption searchOption = SearchOption.AllDirectories)
+    {
+        var hits = new List<string>();
+        var denied = new List<string>();
+        Walk(root, searchPattern, hits, denied, matchFiles: false,
+             recurse: searchOption == SearchOption.AllDirectories);
+        inaccessible = denied;
+        return hits;
+    }
+
+    /// <summary>
+    /// Every file at or below <paramref name="root"/> matching <paramref name="searchPattern"/>,
+    /// with the same unreadable-directory tolerance as <see cref="Directories(string, string)"/>.
+    /// </summary>
+    public static IReadOnlyList<string> Files(
+        string root, string searchPattern, SearchOption searchOption = SearchOption.AllDirectories)
+        => Files(root, searchPattern, out _, searchOption);
+
+    /// <inheritdoc cref="Files(string, string, SearchOption)"/>
+    /// <param name="inaccessible">Every directory whose contents could not be listed, by full path.</param>
+    public static IReadOnlyList<string> Files(
+        string root, string searchPattern, out IReadOnlyList<string> inaccessible,
+        SearchOption searchOption = SearchOption.AllDirectories)
+    {
+        var hits = new List<string>();
+        var denied = new List<string>();
+        Walk(root, searchPattern, hits, denied, matchFiles: true,
+             recurse: searchOption == SearchOption.AllDirectories);
+        inaccessible = denied;
+        return hits;
+    }
+
+    private static void Walk(
+        string root, string searchPattern, List<string> hits, List<string> denied,
+        bool matchFiles, bool recurse)
+    {
+        if (string.IsNullOrEmpty(root)) return;
+
+        // A nonexistent root is not a permissions failure and must not be reported as one.
+        try { if (!Directory.Exists(root)) return; }
+        catch (UnauthorizedAccessException) { denied.Add(root); return; }
+        catch (IOException) { denied.Add(root); return; }
+
+        // Iterative rather than recursive: a deep tree (or a symlink chain) must not be able
+        // to overflow the stack in a code path whose entire job is to survive hostile input.
+        var pending = new Stack<string>();
+        pending.Push(root);
+
+        while (pending.Count > 0)
+        {
+            var dir = pending.Pop();
+
+            // The whole point of this class: the listing is materialised INSIDE the guard,
+            // so a denial on this directory is caught here and the walk continues with the
+            // rest of the tree instead of unwinding out of the caller's foreach.
+            string[] subdirs;
+            try { subdirs = Directory.GetDirectories(dir); }
+            catch (UnauthorizedAccessException) { denied.Add(dir); continue; }
+            catch (DirectoryNotFoundException) { continue; }   // raced away mid-walk
+            catch (IOException) { denied.Add(dir); continue; }
+
+            if (matchFiles)
+            {
+                string[] files;
+                try { files = Directory.GetFiles(dir); }
+                catch (UnauthorizedAccessException) { denied.Add(dir); files = Empty; }
+                catch (DirectoryNotFoundException) { files = Empty; }
+                catch (IOException) { denied.Add(dir); files = Empty; }
+
+                foreach (var f in files)
+                    if (Matches(searchPattern, Path.GetFileName(f)))
+                        hits.Add(f);
+            }
+
+            foreach (var sub in subdirs)
+            {
+                if (!matchFiles && Matches(searchPattern, Path.GetFileName(sub)))
+                    hits.Add(sub);
+                // Recurse into it regardless of whether it matched: SearchOption.AllDirectories
+                // descends into matching directories too (a `.alpackages` nested inside another
+                // `.alpackages` is still reported by the call this replaces).
+                if (recurse) pending.Push(sub);
+            }
+        }
+    }
+
+    private static bool Matches(string pattern, string name)
+        => FileSystemName.MatchesWin32Expression(pattern, name, IgnoreCase);
+}

--- a/AlRunner/Log.cs
+++ b/AlRunner/Log.cs
@@ -47,8 +47,17 @@ public static class Log
     // `[bc]`/`[reexec]` above. Caught by DapClient's own test harness timing out waiting
     // for a line that was actually printed, just silently dropped before reaching
     // stdout — the same failure shape the `[bc]` comment above describes.
+    // `[warn]` was added for #2206. The fix for that issue prints a warning naming any
+    // directory it could not read while searching for `.alpackages` — the diagnostic whose
+    // ABSENCE is the whole complaint, since silently skipping an unreadable directory turns
+    // a permissions problem into a missing-dependency mystery later. Tagged `[warn]` it
+    // matched this pattern and was dropped before reaching the terminal, making the fix a
+    // no-op at default verbosity: the fourth instance of exactly the bug the `[bc]`,
+    // `[expectations]`, `[reexec]` and `[dap]` notes above each describe. A severity tag is
+    // never an internal diagnostic — if something is worth calling a warning, it is worth
+    // the user seeing it.
     private static readonly Regex ComponentTag =
-        new(@"^\[(?!(?:layered|watch|provision|bc|dep|expectations|reexec|dap)\])[A-Za-z][A-Za-z0-9._+]*\]",
+        new(@"^\[(?!(?:layered|watch|provision|bc|dep|expectations|reexec|dap|warn)\])[A-Za-z][A-Za-z0-9._+]*\]",
             RegexOptions.Compiled);
 
     public static void Install()

--- a/AlRunner/Patches/RecordPatches.cs
+++ b/AlRunner/Patches/RecordPatches.cs
@@ -247,7 +247,7 @@ public static partial class RecordPatches
     private static void ParseAllRegisteredSourceFiles()
     {
         foreach (var dir in _sourceDirs)
-            foreach (var file in Directory.GetFiles(dir, "*.al", SearchOption.AllDirectories))
+            foreach (var file in AlRunner.Infrastructure.SafeDirectoryScan.Files(dir, "*.al"))
                 ParseSourceFileIntoAllExtractors(File.ReadAllText(file));
     }
 
@@ -300,7 +300,7 @@ public static partial class RecordPatches
             // (#1903) — see ParseSourceFileIntoAllExtractors.
             if (_registered)
             {
-                foreach (var file in Directory.GetFiles(dir, "*.al", SearchOption.AllDirectories))
+                foreach (var file in AlRunner.Infrastructure.SafeDirectoryScan.Files(dir, "*.al"))
                     ParseSourceFileIntoAllExtractors(File.ReadAllText(file));
                 parsedAny = true;
             }

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -1255,7 +1255,16 @@ AlRunner.Infrastructure.PhaseLog.SetBundles(bundles);
 // instead of hitting either remediation the "[provision-gap]" message promises. Fold the
 // bundles' own .alpackages into the dirs the gate scans (recomputed via PlatformCheckDirs
 // below so it picks up anything --auto-provision adds to packageCacheDirs afterward).
-var bundleAlpackagesDirs = AlRunner.Infrastructure.ProvisioningCheck.CollectBundleAlpackagesDirs(bundles);
+var bundleAlpackagesDirs = AlRunner.Infrastructure.ProvisioningCheck.CollectBundleAlpackagesDirs(
+    bundles, out var inaccessibleBundleDirs);
+// Issue #2206: an unreadable subdirectory used to abort this scan with an unhandled
+// UnauthorizedAccessException (exit 134). It is now skipped — but skipping SILENTLY would
+// hide the case where the `.alpackages` the user expected lives under one of these, turning
+// a permissions problem into a missing-dependency mystery later. Measured: real repo and
+// workspace roots hit zero of these, so this stays quiet on the trees people actually use.
+var inaccessibleScanWarning =
+    AlRunner.Infrastructure.ProvisioningCheck.FormatInaccessibleScanWarning(inaccessibleBundleDirs);
+if (inaccessibleScanWarning != null) Console.WriteLine(inaccessibleScanWarning);
 
 // Issue #1996 (AC #3/#4): the runner-owned versioned destination(s) from a PRIOR
 // --auto-provision / `provision` run — checked BEFORE any network attempt, and BEFORE any
@@ -1878,8 +1887,7 @@ foreach (var bundle in bundles)
                 // runtime still comes from the service-tier DLLs, not a .app source-compile.
                 List<string> bundlePkgDirs;
                 using (AlRunner.Infrastructure.PhaseLog.Stage("alpackages-scan"))
-                    bundlePkgDirs = Directory
-                        .EnumerateDirectories(depRootDir, ".alpackages", SearchOption.AllDirectories)
+                    bundlePkgDirs = AlRunner.Infrastructure.SafeDirectoryScan.Directories(depRootDir, ".alpackages")
                         .ToList();
                 var resolverDirs = bundlePkgDirs.Concat(packageCacheDirs).Distinct().ToList();
                 var resolver = new DependencyResolver(resolverDirs);
@@ -2557,7 +2565,7 @@ foreach (var bundle in bundles)
                 var declaredObjects = allPaths
                     .Where(File.Exists)
                     .Concat(allPaths.Where(Directory.Exists)
-                        .SelectMany(d => Directory.EnumerateFiles(d, "*.al", SearchOption.AllDirectories)))
+                        .SelectMany(d => AlRunner.Infrastructure.SafeDirectoryScan.Files(d, "*.al")))
                     .Distinct()
                     .SelectMany(f => System.Text.RegularExpressions.Regex.Matches(
                         File.ReadAllText(f),
@@ -3453,8 +3461,7 @@ return strictExitCode ? computedExitCode : 0;
             try
             {
                 var roots = ReadDependencies(appJsonPath);
-                var bundlePkgDirs = Directory
-                    .EnumerateDirectories(bucketRoot, ".alpackages", SearchOption.AllDirectories)
+                var bundlePkgDirs = AlRunner.Infrastructure.SafeDirectoryScan.Directories(bucketRoot, ".alpackages")
                     .ToList();
                 var resolverDirs = bundlePkgDirs.Concat(effectivePkgDirs).Distinct().ToList();
                 var resolver = new DependencyResolver(resolverDirs);
@@ -4850,7 +4857,7 @@ static Dictionary<string, string> ComputeServerFileHashes(IReadOnlyList<string> 
     using var sha = System.Security.Cryptography.SHA256.Create();
     foreach (var f in folders
         .Where(Directory.Exists)
-        .SelectMany(d => Directory.EnumerateFiles(Path.GetFullPath(d), "*.al", SearchOption.AllDirectories))
+        .SelectMany(d => AlRunner.Infrastructure.SafeDirectoryScan.Files(Path.GetFullPath(d), "*.al"))
         .Distinct())
     {
         try
@@ -5895,7 +5902,7 @@ static List<string> RunLayeredPrePass(List<string> bundles, List<string> package
         if (!idByKey.TryGetValue(implPath, out var implId)) continue;
         var prebuilt = packageCacheDirs
             .Where(Directory.Exists)
-            .SelectMany(d => Directory.EnumerateFiles(d, "*.app", SearchOption.AllDirectories))
+            .SelectMany(d => AlRunner.Infrastructure.SafeDirectoryScan.Files(d, "*.app"))
             .FirstOrDefault(f =>
             {
                 var m = AppLoader.ReadManifest(f);
@@ -5965,8 +5972,7 @@ static List<string> RunLayeredPrePass(List<string> bundles, List<string> package
         // The impl bundle's own .alpackages (same dirs the main per-bundle compile scans),
         // reused for both this impl's symbol-emit and the dependent-visible caches below.
         var implBucketRootForPkgs = FindBucketRoot(implPath) ?? implPath;
-        var thisImplAlpackages = Directory
-            .EnumerateDirectories(implBucketRootForPkgs, ".alpackages", SearchOption.AllDirectories)
+        var thisImplAlpackages = AlRunner.Infrastructure.SafeDirectoryScan.Directories(implBucketRootForPkgs, ".alpackages")
             .ToList();
         foreach (var d in thisImplAlpackages)
             if (!implAlpackagesDirs.Contains(d, StringComparer.OrdinalIgnoreCase))
@@ -6213,7 +6219,7 @@ static List<string> BuildSiblingSourceDeps(List<string> bundles, List<string> pa
     if (sourceApps.Count == 0) return packageCacheDirs;
 
     var existingPackageDirs = bundleRoots
-        .SelectMany(root => Directory.EnumerateDirectories(root, ".alpackages", SearchOption.AllDirectories))
+        .SelectMany(root => AlRunner.Infrastructure.SafeDirectoryScan.Directories(root, ".alpackages"))
         .Concat(packageCacheDirs)
         .Distinct(StringComparer.OrdinalIgnoreCase)
         .ToList();
@@ -6289,7 +6295,7 @@ static List<string> BuildSiblingSourceDeps(List<string> bundles, List<string> pa
     // these for the source-dep dependency resolution + symbol loader below.
     var bundleAlpackagesDirs = bundles
         .Where(Directory.Exists)
-        .SelectMany(b => Directory.EnumerateDirectories(b, ".alpackages", SearchOption.AllDirectories))
+        .SelectMany(b => AlRunner.Infrastructure.SafeDirectoryScan.Directories(b, ".alpackages"))
         .Distinct()
         .ToList();
     var resolveDirs = bundleAlpackagesDirs.Concat(packageCacheDirs).Distinct().ToList();
@@ -6381,8 +6387,8 @@ static List<string> BuildSiblingSourceDeps(List<string> bundles, List<string> pa
                 // impl-bundle site above and #1546. Filtering to non-Optional declared deps
                 // would drop the implicit platform roots whose types appear in this dep's
                 // public surface, yielding __MissingTypeSymbol__ in the dependent compile.
-                var depOwnAlpackages = Directory.EnumerateDirectories(
-                    FindBucketRoot(dir) ?? dir, ".alpackages", SearchOption.AllDirectories);
+                var depOwnAlpackages = AlRunner.Infrastructure.SafeDirectoryScan.Directories(
+                    FindBucketRoot(dir) ?? dir, ".alpackages");
                 DepsSidecarWriter.Write(
                     depsPath, sid.Publisher, sid.Name, sid.Version, sid.AppId,
                     DepsSidecarWriter.BuildClosure(
@@ -6414,7 +6420,7 @@ static bool IsDependencyPackageAvailable(DependencyRef dep, IReadOnlyList<string
     foreach (var dir in packageDirs)
     {
         if (!Directory.Exists(dir)) continue;
-        foreach (var file in Directory.EnumerateFiles(dir, "*.app", SearchOption.AllDirectories))
+        foreach (var file in AlRunner.Infrastructure.SafeDirectoryScan.Files(dir, "*.app"))
         {
             var manifest = AlRunner.AppLoader.ReadManifest(file);
             if (manifest == null || manifest.Version < dep.Version)
@@ -6456,7 +6462,7 @@ static string ComputeSourceWorkspaceKey(
         WriteLine($"app:{id.AppId}:{id.Publisher}:{id.Name}:{id.Version}");
         foreach (var dep in id.Dependencies.OrderBy(d => $"{d.Publisher}/{d.Name}/{d.Version}/{d.AppId}", StringComparer.OrdinalIgnoreCase))
             WriteLine($"dep:{dep.AppId}:{dep.Publisher}:{dep.Name}:{dep.Version}");
-        var files = Directory.EnumerateFiles(dir, "*.al", SearchOption.AllDirectories)
+        var files = AlRunner.Infrastructure.SafeDirectoryScan.Files(dir, "*.al")
             .Append(Path.Combine(dir, "app.json"))
             .Where(File.Exists)
             .OrderBy(f => f, StringComparer.OrdinalIgnoreCase);
@@ -6866,7 +6872,7 @@ static void EmitSiblingSymbols(
                     bundleResolvedDeps.Select(d => new DepsSidecarWriter.DepEntry(
                         d.Manifest.Publisher, d.Manifest.Name, d.Manifest.Version, d.Manifest.AppId)),
                     ScanVendoredPlatformApps(
-                        Directory.EnumerateDirectories(bundleAbs, ".alpackages", SearchOption.AllDirectories)),
+                        AlRunner.Infrastructure.SafeDirectoryScan.Directories(bundleAbs, ".alpackages")),
                     group.AppId.Value));
             // Re-index in place so the NEXT app in this loop — and every app group compiled
             // below — sees it, without rebuilding the expensive shared reference loader.
@@ -7022,9 +7028,10 @@ static IEnumerable<DepsSidecarWriter.DepEntry> ScanVendoredPlatformApps(IEnumera
     foreach (var dir in dirs)
     {
         if (!Directory.Exists(dir)) continue;
-        IEnumerable<string> apps;
-        try { apps = Directory.EnumerateFiles(dir, "*.app", SearchOption.AllDirectories); }
-        catch { continue; }
+        // SafeDirectoryScan, not a try around Directory.EnumerateFiles: the latter is lazy,
+        // so the catch guarded only the enumerator's construction and an unreadable
+        // subdirectory threw out of the foreach below. #2206.
+        var apps = AlRunner.Infrastructure.SafeDirectoryScan.Files(dir, "*.app");
         foreach (var app in apps)
         {
             var m = AppLoader.ReadManifest(app);
@@ -7328,7 +7335,12 @@ static void EnsurePlatformAppsProvisioned(string engineVersion, List<string> bun
     // alone can never see a manifest need for an app (Application Test Library) that has no
     // service-tier DLL fallback and is therefore simply absent, not symbol-only. Consult the
     // manifest directly — same decision engine the main --auto-provision gate uses.
-    var bundleAlpackagesDirs = AlRunner.Infrastructure.ProvisioningCheck.CollectBundleAlpackagesDirs(bundles);
+    var bundleAlpackagesDirs = AlRunner.Infrastructure.ProvisioningCheck.CollectBundleAlpackagesDirs(
+        bundles, out var inaccessibleBundleDirs);
+    // Issue #2206 — same reasoning as the main gate: skipped, but named.
+    var inaccessibleWarning =
+        AlRunner.Infrastructure.ProvisioningCheck.FormatInaccessibleScanWarning(inaccessibleBundleDirs);
+    if (inaccessibleWarning != null) Console.WriteLine(inaccessibleWarning);
     var platformReport = AlRunner.Infrastructure.ProvisioningCheck.CheckPlatformApps(
         engineVersion, bundleAlpackagesDirs);
     var manifestDependencyRoots = ScanManifestDependencyRoots(bundles);
@@ -7618,7 +7630,7 @@ static List<string> CollectSuitePaths(string suite, string? bucketRoot = null)
     if (Directory.Exists(t)) all.Add(t);
     // Flat bundle: if neither src/ nor test/ exist, include the suite root so
     // the emitter can recurse into it and find all .al files.
-    if (all.Count == 0 && Directory.EnumerateFiles(suite, "*.al", SearchOption.AllDirectories).Any())
+    if (all.Count == 0 && AlRunner.Infrastructure.SafeDirectoryScan.Files(suite, "*.al").Any())
         all.Add(suite);
     if (bucketRoot != null)
     {
@@ -7732,7 +7744,7 @@ static string ComputeAlCacheKey(
     // same bundle from a different current directory does not force a rebuild.
     var alFiles = alFolders
         .Where(Directory.Exists)
-        .SelectMany(d => Directory.EnumerateFiles(Path.GetFullPath(d), "*.al", SearchOption.AllDirectories))
+        .SelectMany(d => AlRunner.Infrastructure.SafeDirectoryScan.Files(Path.GetFullPath(d), "*.al"))
         .Distinct()
         .OrderBy(p => p, StringComparer.Ordinal)
         .ToList();
@@ -7959,8 +7971,7 @@ static IReadOnlyList<string> GetOrderedDepIds(
     try
     {
         var roots = ReadBundleDependencyRoots(manifests);
-        var bundlePkgDirs = Directory
-            .EnumerateDirectories(depRootDir, ".alpackages", SearchOption.AllDirectories)
+        var bundlePkgDirs = AlRunner.Infrastructure.SafeDirectoryScan.Directories(depRootDir, ".alpackages")
             .ToList();
         var resolver = new AlRunner.DependencyResolver(
             bundlePkgDirs.Concat(packageCacheDirs).Distinct().ToList());
@@ -8031,7 +8042,9 @@ static IEnumerable<string> EnumerateSuites(string root)
 
     // Flat bundle: no app.json and no src//test/ anywhere, but .al files exist.
     // Treat the whole root as one compilation + test unit.
-    if (!found && Directory.EnumerateFiles(root, "*.al", SearchOption.AllDirectories).Any())
+    // SafeDirectoryScan: an unreadable subdirectory anywhere below `root` used to throw
+    // out of this lazy .Any() and take the process down with exit 134 (#2206).
+    if (!found && AlRunner.Infrastructure.SafeDirectoryScan.Files(root, "*.al").Count > 0)
         yield return Path.GetFullPath(root);
 }
 
@@ -8041,7 +8054,13 @@ static IEnumerable<string> EnumerateSuitesBelow(string dir)
     // and it also recurses into directories that may disappear mid-walk.
     if (!Directory.Exists(dir)) yield break;
 
-    foreach (var child in Directory.EnumerateDirectories(dir))
+    // #1713 guarded the directory that VANISHES; #2206 is the directory that is merely
+    // UNREADABLE, which reached exactly the same `foreach` and produced exactly the same
+    // exit 134 out of Main. Directory.EnumerateDirectories is lazy, so no try around the
+    // call could have caught it either — the listing has to be materialised under the
+    // guard, which is what SafeDirectoryScan does.
+    foreach (var child in AlRunner.Infrastructure.SafeDirectoryScan.Directories(
+                 dir, "*", SearchOption.TopDirectoryOnly))
     {
         if (LooksLikeSuite(child))
             yield return Path.GetFullPath(child);

--- a/AlRunner/SymbolJson.cs
+++ b/AlRunner/SymbolJson.cs
@@ -497,7 +497,7 @@ public sealed class JsonSymbolReferenceLoader : ISymbolReferenceLoader
     private void IndexModules()
     {
         if (!Directory.Exists(_rootDirectory)) return;
-        foreach (var file in Directory.EnumerateFiles(_rootDirectory, "*.symbols.json", SearchOption.AllDirectories))
+        foreach (var file in AlRunner.Infrastructure.SafeDirectoryScan.Files(_rootDirectory, "*.symbols.json"))
         {
             try
             {
@@ -526,7 +526,7 @@ public sealed class JsonSymbolReferenceLoader : ISymbolReferenceLoader
     private void IndexDependencySidecars()
     {
         if (!Directory.Exists(_rootDirectory)) return;
-        foreach (var file in Directory.EnumerateFiles(_rootDirectory, "*.symbols.deps.json", SearchOption.AllDirectories))
+        foreach (var file in AlRunner.Infrastructure.SafeDirectoryScan.Files(_rootDirectory, "*.symbols.deps.json"))
         {
             try
             {


### PR DESCRIPTION
Closes #2206

Part of the "install, execute, done" story, see #2213.

## The defect

`Directory.EnumerateDirectories` is lazy, so this guard never fired:

```csharp
try { found = Directory.EnumerateDirectories(bundle, ".alpackages", SearchOption.AllDirectories); }
catch { continue; }
foreach (var dir in found)      // the throw happens HERE, outside the try
```

The `try` guarded constructing the enumerator, not iterating it. Any unreadable
directory anywhere under the target took the process down.

Reproduced before the fix, exactly as reported — exit 134, `ProvisioningCheck.cs:151`,
`Program.cs:1258`. After the fix, `al-runner /tmp` exits 0 and prints:

```
[warn] skipped 5 unreadable directories while searching for `.alpackages`:
         /tmp/systemd-private-…-NetworkManager.service-VTiHgv
         /tmp/systemd-private-…-systemd-logind.service-wXd1US
         /tmp/systemd-private-…-power-profiles-daemon.service-0AqG8d
         /tmp/systemd-private-…-polkit.service-MmkPFK
         /tmp/systemd-private-…-upower.service-s3Cq8T
       If a package cache you expected the runner to find lives under one of these,
       fix its permissions or point the runner directly at the app directory.
```

## 1. Warn, don't skip silently

Warn, naming every path. I decided this on measurement rather than taste, because the
obvious objection is noise:

| Tree | Directories walked | Unreadable |
|---|---|---|
| An AL repository checkout | 94,740 | **0** |
| A whole workspace root (`~/Documents/Repos`) | 307,833 | **0** |
| `/tmp` | 1,608 | **5** |

On the trees people actually point the runner at, the warning never fires. The only trees
where it fires are the ones where an unreadable directory is the explanation the reader
needs. So warning costs nothing in the common case and supplies the missing diagnostic in
the uncommon one, while silence would turn a permissions problem into a
missing-dependency mystery later — the failure mode #2213 exists to remove. The list is
capped at five paths with a count of the remainder, so a pathological tree cannot bury the
run's output.

## 2. The unbounded walk stays unbounded

I expected to bound this and the measurement said not to. Real `.alpackages` directories
in a working AL developer's tree sit at depths 2 through 10:

| Depth cap | Time | Hits found (of 436 real ones) |
|---|---|---|
| 3 | 5 ms | 77 |
| 5 | 112 ms | 245 |
| 8 | 831 ms | 345 |
| 12 | 2,608 ms | 436 |
| none | 2,876 ms | 436 |

Any cap cheap enough to be worth having silently loses packages, and a cap that finds
everything costs the same as no cap. Pruning by directory name does not help either: after
skipping `.git`, `node_modules`, `bin`, `obj` and friends, the walk still visited 90,158 of
94,584 directories, because the bulk of a real tree is real content.

The walk is correct as it stands. The cost is real, though — 0.8 s on a repository root,
2.9 s on a workspace root, repeated at several call sites per invocation — so I filed that
separately rather than folding a performance change into a crash fix.

## 3. The same shape elsewhere

The `try`-around-a-lazy-enumerator pattern appeared at **five** more sites, all reachable
from a user-supplied path: two in `BcCompiler` (`Add-ins`, `Test Assemblies`), the
`.deps-bin` probe in `DependencyLoader`, and the vendored-app scan in `Program.cs`. Each is
fixed.

Fixing only the reported line does not fix the reported invocation. I ran the binary after
each change and the crash simply moved: first to `EnumerateSuitesBelow`, then dependency
resolution failed wholesale on the same input. Both are the same defect on the same input,
so all 36 recursive filesystem walks that can be rooted at a user-supplied path now go
through one guarded helper, `SafeDirectoryScan`.

Two things worth calling out, because both would have shipped green:

**The tidy one-line fix is wrong on Unix.** `new EnumerationOptions { RecurseSubdirectories
= true, IgnoreInaccessible = true }` is the modern spelling and it defaults
`AttributesToSkip` to `Hidden | System`. On Unix every dot-directory is Hidden — including
`.alpackages` itself. Measured on this repository: the `SearchOption` spelling finds 94
`.alpackages`, that spelling finds **0**. It would have silently disabled the entire
feature. `HiddenParentDirectory_IsStillTraversed` is the guard.

**The warning was being eaten.** `Log`'s component filter drops any `[tag]`-prefixed line
that is not explicitly exempted, so `[warn]` never reached the terminal and the fix was a
no-op at default verbosity. That is the fourth instance of the bug the `[bc]`,
`[expectations]`, `[reexec]` and `[dap]` notes in `Log.cs` each describe. `warn` is now
exempt, with a case added to `LogUserFacingTagsTests`.

I verified the helper is result-identical to what it replaces before trusting it: same
results for `.alpackages`, `*`, `*.app` and `*.al` across four trees, 829 ms versus 798 ms
on a 94,740-directory tree, and identical termination on a symlink loop.

## Tests

`AlRunner.Tests/InaccessibleDirectoryScanTests.cs`, 10 tests. RED first: two failed with
the reported `UnauthorizedAccessException` from `ProvisioningCheck.cs:151`.

Both directions are covered. An unreadable directory must be skipped *and* the readable
package directory below and beside it must still be found, so the cheap wrong fix — abandon
the bundle on first denial — fails `DoesNotAbortTheRestOfTheWalk`. A fully readable tree
must report nothing inaccessible, so a fix that reports everything fails too.

The four permission-dependent tests use a capability probe rather than a uid check: they
try to make a directory unreadable and confirm it actually bites. As root, or on a
filesystem that ignores mode bits, they report **Skipped**, not passed — verified by
forcing the probe to fail (`Skipped: 4, Passed: 6`).

## Verification

- Unit suite: 1142 passed, 0 failed, 68 skipped.
- `tests/runner-extras`: 198/198, exit 0.
- al-language corpus: 2164/2164, 0 failed, 0 errors, exit 0.
- `al-runner /tmp` and a synthetic tree with an unreadable sibling: exit 0, warning shown.

## Follow-ups filed

Not folded in, because they are different bugs: the repeated cost of the unbounded walk,
and duplicate results when a symlink loop makes one physical `.alpackages` appear under 41
distinct paths.
