### PR TITLE
fix(provisioning): detect the Microsoft platform-app need on a cold cache, and stop `provision` reporting success without fixing it

### DIFF
--- a/.github/workflows/bc-tests.yml
+++ b/.github/workflows/bc-tests.yml
@@ -164,6 +164,23 @@ jobs:
           dotnet run --project tools/DownloadArtifacts -- \
             platform-apps ${{ matrix.target.bc-version }} "$HOME/.al-runner/platform-apps"
 
+          # Issue #2205: the same apps, also at the location the runner scans BY DEFAULT
+          # (ProvisioningCheck.PlatformAppsDirFor — <artifacts-root>/<version>/platform-apps),
+          # which is where `provision`/--auto-provision put them on a real machine.
+          #
+          # Every AlRunner.Tests case that spawns the runner as a subprocess runs without
+          # --package-cache, so it only ever sees the default caches. Now that an ordinary
+          # app.json's `application`/`platform` fields are recognised as a real Microsoft
+          # dependency, each of those subprocesses would otherwise decide it needs the
+          # platform set and fetch 116 MB from the CDN — dozens of times, four in parallel,
+          # into the same directory. Hardlinking the already-downloaded set is instant and
+          # makes CI match a developer machine that has provisioned once.
+          DEFAULT_PLATFORM_APPS="$HOME/.local/share/al-runner/artifacts/${{ matrix.target.bc-version }}/platform-apps"
+          mkdir -p "$DEFAULT_PLATFORM_APPS"
+          cp -al "$HOME/.al-runner/platform-apps/." "$DEFAULT_PLATFORM_APPS/" \
+            || cp -a "$HOME/.al-runner/platform-apps/." "$DEFAULT_PLATFORM_APPS/"
+          ls -la "$DEFAULT_PLATFORM_APPS"
+
       - name: Download the Microsoft test toolkit (Any, Library Assert, Test Runner, …)
         run: |
           # tests/runner-extras/microsoft-dependencies depends on Application Test Library

--- a/AlRunner.Tests/CacheKeyDependencyClosureTests.cs
+++ b/AlRunner.Tests/CacheKeyDependencyClosureTests.cs
@@ -64,10 +64,13 @@ public sealed class CacheKeyDependencyClosureTests : IDisposable
 
     /// <summary>Spawns the runner with the given extra args against the fixture and returns its combined output.</summary>
     private static string RunRunner(string packageCacheDir, string alCacheDir, string extraArgs)
+        => RunRunner(FixturePath, packageCacheDir, alCacheDir, extraArgs);
+
+    private static string RunRunner(string bundlePath, string packageCacheDir, string alCacheDir, string extraArgs)
     {
         var args = new StringBuilder(TestBuildConfig.RunArgs(ProjectPath));
         args.Append(TestBuildConfig.BcVersionArg);
-        args.Append($" \"{FixturePath}\"");
+        args.Append($" \"{bundlePath}\"");
         args.Append($" --package-cache \"{packageCacheDir}\"");
         args.Append($" --cache \"{alCacheDir}\"");
         args.Append(extraArgs);
@@ -95,8 +98,11 @@ public sealed class CacheKeyDependencyClosureTests : IDisposable
     /// the key string, so there is nothing lost by not paying for the compile.
     /// </summary>
     private static string RunAndReadCacheKeyOnly(string packageCacheDir, string alCacheDir)
+        => RunAndReadCacheKeyOnly(FixturePath, packageCacheDir, alCacheDir);
+
+    private static string RunAndReadCacheKeyOnly(string bundlePath, string packageCacheDir, string alCacheDir)
     {
-        var output = RunRunner(packageCacheDir, alCacheDir, " --print-cache-key");
+        var output = RunRunner(bundlePath, packageCacheDir, alCacheDir, " --print-cache-key");
         var m = Regex.Match(output, @"\[cache\]\s+KEY\s+key=([0-9a-f]{64})");
         Assert.True(m.Success, $"could not read a cache key from --print-cache-key output:\n{output}");
         return m.Groups[1].Value;
@@ -119,47 +125,130 @@ public sealed class CacheKeyDependencyClosureTests : IDisposable
     /// Two different dependency closures over byte-identical AL sources must produce two
     /// different keys. Reverting GetOrderedDepIds to resolve without the bundle's
     /// .alpackages makes both keys collapse to the same value and fails this.
+    ///
+    /// The closure is varied with a SYNTHETIC third-party dependency at two different
+    /// versions, and the bundle declares no `application`/`platform` at all, so nothing the
+    /// runner can provision is part of the answer.
+    ///
+    /// It used to vary the closure by copying the real Microsoft platform apps and dropping
+    /// System.app from one side. That has now failed twice for reasons unrelated to the
+    /// cache key, and both times the fix was to pick a different app to drop:
+    /// <list type="number">
+    /// <item>provisioning started fetching Application Test Library, so "the ordinally-first
+    /// .app" became one this fixture never resolves;</item>
+    /// <item>issue #2205 made the platform set a real, detected need, so the runner-owned
+    /// `&lt;artifacts&gt;/&lt;version&gt;/platform-apps` directory folds into the search set
+    /// (and, on a cold machine, gets downloaded) — which supplies System.app right back to
+    /// the "reduced" side.</item>
+    /// </list>
+    /// Both runs then keyed on the same closure and the test failed while the cache key was
+    /// working correctly. Worse, it PASSED on a developer machine for an accidental reason:
+    /// the key stamps each winning `.app`'s mtime+size, and the freshly-copied file and the
+    /// warm provisioned one merely had different timestamps. A test whose verdict depends on
+    /// the machine's provisioning history is not measuring the cache key. This variant
+    /// cannot be restored by any provisioning path, because no artifact Microsoft ships is
+    /// published by "Contoso ISV".
     /// </summary>
     [SkippableFact]
     public void DifferentDependencyClosure_ProducesDifferentCacheKey()
     {
         TestArtifacts.SkipIfMissing();
-        var platformApps = TestArtifacts.PlatformAppsDir();
-        TestArtifacts.SkipIfDirectoryMissing(platformApps, "R2R platform apps");
 
-        var full = Path.Combine(_scratch, "full");
-        var reduced = Path.Combine(_scratch, "reduced");
-        Directory.CreateDirectory(full);
-        Directory.CreateDirectory(reduced);
+        var bundle = WriteIsvDependentFixture(Path.Combine(_scratch, "isv-bundle"));
+        var v1 = Path.Combine(_scratch, "isv-v1");
+        var v2 = Path.Combine(_scratch, "isv-v2");
+        Directory.CreateDirectory(v1);
+        Directory.CreateDirectory(v2);
+        WriteSyntheticApp(v1, IsvDepId, "Contoso Dep", "Contoso ISV", "1.0.0.0");
+        WriteSyntheticApp(v2, IsvDepId, "Contoso Dep", "Contoso ISV", "1.4.0.0");
 
-        var apps = Directory.GetFiles(platformApps, "*.app");
-        TestArtifacts.SkipIf(apps.Length < 2,
-            $"varying the dependency closure needs >= 2 platform apps; '{platformApps}' holds {apps.Length}.");
+        var keyV1 = RunAndReadCacheKeyOnly(bundle, v1, Path.Combine(_scratch, "cache-isv-v1"));
+        var keyV2 = RunAndReadCacheKeyOnly(bundle, v2, Path.Combine(_scratch, "cache-isv-v2"));
 
-        foreach (var a in apps) File.Copy(a, Path.Combine(full, Path.GetFileName(a)));
+        Assert.NotEqual(keyV1, keyV2);
+    }
 
-        // Same closure minus exactly one package — and it has to be a package the bundle
-        // actually RESOLVES, or the two closures come out identical and this asserts nothing.
-        //
-        // Dropping the ordinally-first .app used to satisfy that by accident: the directory
-        // held only the platform apps, so "first" was Microsoft_Application_*. Once
-        // provisioning also fetched Application Test Library, "first" became a package this
-        // fixture never references — both keys matched and the test failed while the cache
-        // key was working correctly. Pick the platform root explicitly instead: every AL app
-        // resolves `System` (the manifest's `platform` root), so removing it is guaranteed to
-        // be a different compile input regardless of what else provisioning drops in here.
-        var platformRoot = apps.FirstOrDefault(
-            a => Path.GetFileName(a).Equals("System.app", StringComparison.OrdinalIgnoreCase));
-        Assert.True(platformRoot != null,
-            $"platform-apps must contain System.app to vary the closure; found: " +
-            string.Join(", ", apps.Select(Path.GetFileName)));
-        foreach (var a in apps.Where(a => a != platformRoot))
-            File.Copy(a, Path.Combine(reduced, Path.GetFileName(a)));
+    /// <summary>
+    /// The companion to the above at the same isolation: the SAME synthetic closure must key
+    /// identically across runs. Without this, "the key changed" above would be satisfied by a
+    /// key that simply varies, which would destroy the cache rather than track the closure.
+    /// </summary>
+    [SkippableFact]
+    public void SameIsvDependencyClosure_ProducesStableCacheKey()
+    {
+        TestArtifacts.SkipIfMissing();
 
-        var keyFull = RunAndReadCacheKeyOnly(full, Path.Combine(_scratch, "cache-full"));
-        var keyReduced = RunAndReadCacheKeyOnly(reduced, Path.Combine(_scratch, "cache-reduced"));
+        var bundle = WriteIsvDependentFixture(Path.Combine(_scratch, "isv-bundle-stable"));
+        var dir = Path.Combine(_scratch, "isv-stable");
+        Directory.CreateDirectory(dir);
+        WriteSyntheticApp(dir, IsvDepId, "Contoso Dep", "Contoso ISV", "1.0.0.0");
 
-        Assert.NotEqual(keyFull, keyReduced);
+        var alCache = Path.Combine(_scratch, "cache-isv-stable");
+        var first = RunAndReadCacheKeyOnly(bundle, dir, alCache);
+        var second = RunAndReadCacheKeyOnly(bundle, dir, alCache);
+
+        Assert.Equal(first, second);
+    }
+
+    private const string IsvDepId = "b7e1c0de-1111-4222-8333-444455556666";
+
+    /// <summary>A one-codeunit bundle declaring exactly one third-party dependency and NO
+    /// `application`/`platform` — so its resolved closure is entirely under this test's
+    /// control and no provisioning decision touches it.</summary>
+    private static string WriteIsvDependentFixture(string dir)
+    {
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "app.json"), $$"""
+        {
+          "id": "3f9a1c22-5b7d-4e10-9c33-8a0e1d2b4c56",
+          "name": "CacheKey ISV Dep Fixture",
+          "publisher": "AL Runner",
+          "version": "1.0.0.0",
+          "dependencies": [
+            { "id": "{{IsvDepId}}", "name": "Contoso Dep", "publisher": "Contoso ISV", "version": "1.0.0.0" }
+          ],
+          "idRanges": [ { "from": 60700, "to": 60709 } ],
+          "runtime": "14.0"
+        }
+        """);
+        File.WriteAllText(Path.Combine(dir, "CacheKeyIsv.Codeunit.al"), """
+        codeunit 60700 "CacheKey Isv Probe"
+        {
+            procedure Probe(): Integer
+            begin
+                exit(1);
+            end;
+        }
+        """);
+        return dir;
+    }
+
+    /// <summary>Writes a minimal NAVX `.app` — enough for AppLoader.ReadManifest and
+    /// DependencyResolver to see the package and its version.</summary>
+    private static void WriteSyntheticApp(
+        string dir, string appId, string name, string publisher, string version)
+    {
+        var xml = $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <Package xmlns="http://schemas.microsoft.com/navx/2015/manifest">
+              <App Id="{appId}" Name="{name}" Publisher="{publisher}" Version="{version}"/>
+              <Dependencies />
+            </Package>
+            """;
+        using var ms = new MemoryStream();
+        using (var zip = new System.IO.Compression.ZipArchive(
+                   ms, System.IO.Compression.ZipArchiveMode.Create, leaveOpen: true))
+        {
+            var entry = zip.CreateEntry("NavxManifest.xml");
+            using var es = entry.Open();
+            es.Write(Encoding.UTF8.GetBytes(xml));
+        }
+        var zipBytes = ms.ToArray();
+        var result = new byte[8 + zipBytes.Length];
+        result[0] = (byte)'N'; result[1] = (byte)'A'; result[2] = (byte)'V'; result[3] = (byte)'X';
+        BitConverter.TryWriteBytes(result.AsSpan(4, 4), (uint)8);
+        zipBytes.CopyTo(result, 8);
+        File.WriteAllBytes(Path.Combine(dir, $"{publisher}_{name}_{version}.app"), result);
     }
 
     /// <summary>

--- a/AlRunner.Tests/CollectionCostOrderer.cs
+++ b/AlRunner.Tests/CollectionCostOrderer.cs
@@ -163,6 +163,30 @@ public sealed class CollectionCostOrderer : ITestCollectionOrderer
             // 83-125s across the four legs that first ran it. Round down to the low end so
             // a fast run still ranks it above the freshness threshold rather than have it
             // fall back to UnmeasuredWeightSeconds and reproduce the #1887 tail pattern.
+            // #2205: these six became visible to this gate together, and all six are
+            // subprocess-heavy collections. The cause is not the tests: once CI provisions
+            // the Microsoft platform apps into the runner-owned
+            // `<artifacts>/<version>/platform-apps` — the location DefaultPackageCacheDirs
+            // and the #2067 fold-in both read — every spawned runner resolves and LOADS the
+            // real Base Application / System Application closure that its app.json's
+            // `application` field always declared, where before it silently resolved
+            // nothing. Measured locally on the same two collections: 21s with no
+            // platform-apps on disk, 79s with them (pre-#2205 need detection, so the load
+            // is the whole difference), 98s with #2205's detection on top. Any developer
+            // machine that has ever run `al-runner provision` was already paying it; CI was
+            // not, because it only ever put the apps where --package-cache pointed.
+            // Follow-up on the load cost itself, which is pre-existing and stays open: #2223.
+            //
+            // Values are the observed MAXIMUM across all eight BC legs of one run (the
+            // spread is ~1.5x, e.g. DapServerTests 112.2s on 28.2 to 170.1s on 28.3), for
+            // the reason StartupOutputReexecDedupTests documents: rounding to the low end
+            // of a wide spread satisfies the gate while leaving the tail in place.
+            ["DapServerTests"] = 170,
+            ["TddModeTests"] = 141,
+            ["ServerCrossAppStaleGenerationTests"] = 130,
+            ["DapStdioServerTests"] = 101,
+            ["CacheRootsIsolationTests"] = 83,
+            ["ServerDuplicateSourcePathTests"] = 73,
             ["ProvisionExplicitModesTests"] = 80,
             // #1940/#1941/#1943: 4 tests, each spawning a real runner subprocess (two
             // single-bundle, two layered two-bundle dep compiles) — needed because

--- a/AlRunner.Tests/ManifestDependencyEdgeScanTests.cs
+++ b/AlRunner.Tests/ManifestDependencyEdgeScanTests.cs
@@ -77,14 +77,41 @@ public sealed class ManifestDependencyEdgeScanTests : IDisposable
         File.WriteAllBytes(Path.Combine(dir, $"{publisher}_{name}.app"), WrapNavx(xml));
     }
 
-    private static byte[] WrapNavx(string manifestXml)
+    /// <summary>As <see cref="WriteApp"/>, but the package carries a
+    /// <c>publishedartifacts/</c> entry — i.e. an R2R runtime package rather than a
+    /// symbol-only one, which is what a real provisioned platform-apps dir holds.</summary>
+    private static void WriteR2RApp(
+        string dir, string name, string publisher, string version,
+        params (string Name, string Publisher)[] dependencies)
+    {
+        var deps = string.Concat(dependencies.Select(d =>
+            $"""    <Dependency Id="{Guid.NewGuid()}" Name="{d.Name}" Publisher="{d.Publisher}" MinVersion="{version}" />{"\n"}"""));
+        var xml = $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <Package xmlns="http://schemas.microsoft.com/navx/2015/manifest">
+              <App Id="{Guid.NewGuid()}" Name="{name}" Publisher="{publisher}" Version="{version}"/>
+              <Dependencies>
+            {deps}  </Dependencies>
+            </Package>
+            """;
+        File.WriteAllBytes(Path.Combine(dir, $"{publisher}_{name}.app"),
+            WrapNavx(xml, includePublishedArtifact: true));
+    }
+
+    private static byte[] WrapNavx(string manifestXml, bool includePublishedArtifact = false)
     {
         using var ms = new MemoryStream();
         using (var zip = new ZipArchive(ms, ZipArchiveMode.Create, leaveOpen: true))
         {
             var entry = zip.CreateEntry("NavxManifest.xml");
-            using var es = entry.Open();
-            es.Write(Encoding.UTF8.GetBytes(manifestXml));
+            using (var es = entry.Open())
+                es.Write(Encoding.UTF8.GetBytes(manifestXml));
+            if (includePublishedArtifact)
+            {
+                var dll = zip.CreateEntry("publishedartifacts/app.dll");
+                using var ds = dll.Open();
+                ds.Write(new byte[] { 0x4D, 0x5A });
+            }
         }
         var zipBytes = ms.ToArray();
         var result = new byte[8 + zipBytes.Length];
@@ -281,17 +308,27 @@ public sealed class ManifestDependencyEdgeScanTests : IDisposable
     // ── the decision that consumes it ────────────────────────────────────────
 
     [Fact]
-    public void DetermineManifestNeeds_Bc27Edges_TestsTestLibraries_DoesNotDemandPlatformApps()
+    public void DetermineManifestNeeds_Bc27Edges_TestsTestLibraries_DoesNotDemandApplicationTestLibrary()
     {
-        // THE version-specific bug the hand table shipped: on BC 27.x this returned
-        // NeedsPlatformApps == true, sending provisioning after an "Application Test
-        // Library" no 27.x artifact contains.
+        // THE version-specific bug the hand table shipped: on BC 27.x this demanded an
+        // "Application Test Library" no 27.x artifact contains, and provisioning then died
+        // with "still missing after download".
+        //
+        // Issue #2205 broadened the need targets from that one app to the whole curated
+        // platform-apps set, so the claim worth pinning is now the precise one, not
+        // NeedsPlatformApps as a blanket. On 27.x the recorded edges reach System
+        // Application (via System Application Test Library) and Business Foundation (via
+        // Business Foundation Test Libraries) — both of which the 27.x w1 artifact really
+        // does ship — and they must NOT reach Application Test Library.
         var edges = ProvisioningCheck.ScanDependencyEdges(new[] { WriteBc27TestToolkit() }).Edges;
 
         var needs = ProvisioningCheck.DetermineManifestNeeds(
             new[] { Root("Tests-TestLibraries", version: "27.5.0.0") }, edges);
 
-        Assert.False(needs.NeedsPlatformApps);
+        Assert.DoesNotContain("Application Test Library", needs.RequiredPlatformApps);
+        Assert.Equal(
+            new[] { "Business Foundation", "System Application" },
+            needs.RequiredPlatformApps.OrderBy(n => n, StringComparer.Ordinal).ToArray());
         Assert.True(needs.NeedsTestApps);
     }
 
@@ -304,21 +341,50 @@ public sealed class ManifestDependencyEdgeScanTests : IDisposable
             new[] { Root("Tests-TestLibraries", version: "28.3.0.0") }, edges);
 
         Assert.True(needs.NeedsPlatformApps);
+        Assert.Contains("Application Test Library", needs.RequiredPlatformApps);
         Assert.True(needs.NeedsTestApps);
     }
 
     [Fact]
     public void DecideManifestProvisioning_Bc27ToolkitOnDisk_DoesNotAskForApplicationTestLibrary()
     {
+        // Only the test-apps set is on disk here, so the platform apps the 27.x edges DO
+        // reach are genuinely absent and a platform fetch is the right answer (issue
+        // #2205). What must never come back is Application Test Library: no 27.x artifact
+        // ships it, so demanding it makes the download unsatisfiable.
         var dir = WriteBc27TestToolkit();
         var legacy = ProvisioningCheck.CheckPlatformApps("27.5.46862.48827", new[] { dir });
 
         var decision = ProvisioningCheck.DecideManifestProvisioning(
             new[] { Root("Tests-TestLibraries", version: "27.5.0.0") }, legacy, new[] { dir });
 
-        Assert.False(decision.NeedsPlatformApps);
-        Assert.False(decision.ShouldDownloadPlatform);
+        Assert.DoesNotContain("Application Test Library", decision.RequiredPlatformApps);
+        Assert.DoesNotContain("Application Test Library", decision.MissingPlatformApps);
         Assert.True(decision.NeedsTestApps);
+    }
+
+    [Fact]
+    public void DecideManifestProvisioning_Bc27ToolkitAndPlatformAppsOnDisk_NoPlatformDownload()
+    {
+        // The warm 27.x machine (what CI's --package-cache gives every leg): the same
+        // roots, with the platform apps the edges reach also present, must still decide
+        // "no download". This is the no-spurious-download arm for the edge-derived half of
+        // the requirement, the counterpart of the manifest-declared half in
+        // ProvisioningCheckTests.DecideManifestProvisioning_WarmCache_OrdinaryAlApp_NoDownload.
+        var toolkit = WriteBc27TestToolkit();
+        var platform = NewDir("platform-apps-27");
+        WriteR2RApp(platform, "System Application", "Microsoft", "27.5.0.0");
+        WriteR2RApp(platform, "Business Foundation", "Microsoft", "27.5.0.0");
+
+        var dirs = new[] { toolkit, platform };
+        var legacy = ProvisioningCheck.CheckPlatformApps("27.5.46862.48827", dirs);
+
+        var decision = ProvisioningCheck.DecideManifestProvisioning(
+            new[] { Root("Tests-TestLibraries", version: "27.5.0.0") }, legacy, dirs);
+
+        Assert.Empty(decision.MissingPlatformApps);
+        Assert.True(decision.PlatformComplete);
+        Assert.False(decision.ShouldDownloadPlatform);
     }
 
     [Fact]

--- a/AlRunner.Tests/PackageCacheFinalSearchSetTests.cs
+++ b/AlRunner.Tests/PackageCacheFinalSearchSetTests.cs
@@ -40,6 +40,15 @@ public sealed class PackageCacheFinalSearchSetTests
     /// packageCacheDirs is visible only in the SEARCH SET this test asserts on, never in a
     /// provisioning decision (which would otherwise try to download real platform/test
     /// apps and make the test depend on network access).
+    ///
+    /// Issue #2205: "nothing Microsoft" now has to mean it literally. These manifests used
+    /// to carry `"application"`/`"platform"`, from which ReadDependencies synthesises
+    /// implicit Microsoft/Application + Microsoft/System roots — a real Microsoft
+    /// dependency the need detection had simply never looked at. Once it does, this fixture
+    /// triggers a genuine 116 MB platform-apps download mid-test, which folds another dir
+    /// into packageCacheDirs and makes the final count neither 0 nor 2. Dropping the two
+    /// fields is what the comment above always claimed; the AL here uses no Microsoft type,
+    /// so nothing else changes.
     /// </summary>
     private static string WriteFixture(string scratchRoot)
     {
@@ -56,8 +65,6 @@ public sealed class PackageCacheFinalSearchSetTests
           "publisher": "Repro2107",
           "version": "1.0.0.0",
           "dependencies": [],
-          "platform": "1.0.0.0",
-          "application": "1.0.0.0",
           "idRanges": [ { "from": 61950, "to": 61959 } ],
           "runtime": "14.0"
         }
@@ -80,8 +87,6 @@ public sealed class PackageCacheFinalSearchSetTests
           "dependencies": [
             { "id": "{{depId}}", "name": "Repro2107 Dep App", "publisher": "Repro2107", "version": "1.0.0.0" }
           ],
-          "platform": "1.0.0.0",
-          "application": "1.0.0.0",
           "idRanges": [ { "from": 61960, "to": 61969 } ],
           "runtime": "14.0"
         }

--- a/AlRunner.Tests/ProvisioningCheckTests.cs
+++ b/AlRunner.Tests/ProvisioningCheckTests.cs
@@ -1287,4 +1287,271 @@ public sealed class ProvisioningCheckTests : IDisposable
         var note = ProvisioningCheck.BuildProvisionVersionSkewNote("28.4", "28.4", "x");
         Assert.Null(note);
     }
+
+    // ── Issue #2205: cold cache + an ordinary AL app ──────────────────────────
+    // Every real AL extension declares its Microsoft roots through app.json's
+    // `application`/`platform` fields, not the `dependencies` array — ReadDependencies
+    // synthesises them as Optional Microsoft/Application + Microsoft/System roots. The
+    // need-detection above used to ignore those roots entirely, on the premise that
+    // System/Base Application and Business Foundation have a service-tier DLL dispatch
+    // fallback so their ABSENCE is never a gap (only PRESENT-but-symbol-only is).
+    //
+    // That premise is false on a cold cache: the DLL fallback serves RUNTIME DISPATCH, it
+    // does not supply COMPILE-TIME SYMBOLS. With engine-only artifacts on disk the app
+    // never compiles, so there is no runtime for the fallback to serve — the run died with
+    // EMIT-EXCLUDED and two unframed `[deps] dependency not found in cache, skipping`
+    // lines, and `provision` reported "nothing to provision" and exited 0.
+    //
+    // The distinction these pin is ABSENT vs PRESENT-BUT-SYMBOL-ONLY, asked of whatever
+    // the manifest actually names — not membership of a hardcoded exemption list. The
+    // warm arms are the constraint that matters most: a warm cache must keep deciding
+    // "no download", or every bundle in the corpus starts claiming it needs one.
+
+    /// <summary>The implicit roots ReadDependencies synthesises for an ordinary AL app
+    /// whose app.json carries `"application"` + `"platform"` and `"dependencies": []`.</summary>
+    private static DependencyRef[] ImplicitMicrosoftRoots(string version = "27.0.0.0") => new[]
+    {
+        new DependencyRef(Guid.Empty, "Application", "Microsoft", Version.Parse(version), Optional: true),
+        new DependencyRef(Guid.Empty, "System", "Microsoft", Version.Parse(version), Optional: true),
+    };
+
+    [Fact]
+    public void DetermineManifestNeeds_ImplicitMicrosoftRoots_RequireTheAppsTheyName()
+    {
+        var needs = ProvisioningCheck.DetermineManifestNeeds(ImplicitMicrosoftRoots());
+
+        Assert.True(needs.NeedsPlatformApps);
+        // Exactly the two apps the manifest named — NOT the whole downloadable set. A
+        // bundle that never mentions Business Foundation must not be told it needs it.
+        Assert.Equal(new[] { "Application", "System" }, needs.RequiredPlatformApps.OrderBy(n => n).ToArray());
+        // The test-apps set is a SEPARATE 20 MB download and these roots say nothing about
+        // it. Broadening the platform need must not drag the toolkit along.
+        Assert.False(needs.NeedsTestApps);
+    }
+
+    [Fact]
+    public void DecideManifestProvisioning_ColdCache_OrdinaryAlApp_NeedsPlatformApps()
+    {
+        // Issue #2205's exact repro shape: engine artifacts on disk, nothing else. The
+        // legacy symbol-only check reports Ok vacuously (nothing found = nothing broken),
+        // so the decision must come from the manifest.
+        var legacyReport = ProvisioningCheck.CheckPlatformApps("28.1.49838.53910", Array.Empty<string>());
+        Assert.True(legacyReport.Ok);
+
+        var decision = ProvisioningCheck.DecideManifestProvisioning(
+            ImplicitMicrosoftRoots(), legacyReport, Array.Empty<string>());
+
+        Assert.True(decision.NeedsPlatformApps);
+        Assert.False(decision.PlatformComplete);
+        Assert.True(decision.ShouldDownloadPlatform);
+        Assert.Equal(new[] { "Application", "System" }, decision.MissingPlatformApps.OrderBy(n => n).ToArray());
+        Assert.False(decision.ShouldDownloadTest);
+    }
+
+    [Fact]
+    public void DecideManifestProvisioning_WarmCache_OrdinaryAlApp_NoDownload()
+    {
+        // THE no-spurious-download constraint. Same bundle, same roots, platform apps
+        // already on disk: the decision must be identical to what it was before #2205 —
+        // nothing to download. A regression here makes every warm corpus bundle start
+        // claiming it needs a 120 MB fetch on every single run.
+        var dir = Path.Combine(_dir, "warm-ordinary");
+        Directory.CreateDirectory(dir);
+        WriteR2RApp(dir, "application.app", Guid.NewGuid().ToString(), "Application", "Microsoft", "28.1.49838.53910");
+        WriteR2RApp(dir, "system.app", Guid.NewGuid().ToString(), "System", "Microsoft", "28.0.53872.0");
+
+        var legacyReport = ProvisioningCheck.CheckPlatformApps("28.1.49838.53910", new[] { dir });
+        var decision = ProvisioningCheck.DecideManifestProvisioning(
+            ImplicitMicrosoftRoots(), legacyReport, new[] { dir });
+
+        Assert.True(decision.NeedsPlatformApps);
+        Assert.True(decision.PlatformComplete);
+        Assert.Empty(decision.MissingPlatformApps);
+        Assert.False(decision.ShouldDownloadPlatform);
+        Assert.False(decision.ShouldDownloadTest);
+    }
+
+    [Fact]
+    public void DecideManifestProvisioning_OrdinaryAlApp_PresentButSymbolOnly_StillADownload()
+    {
+        // The other side of the absent/symbol-only distinction, unchanged by #2205: an app
+        // that IS on disk but only as a symbol package cannot execute, so it stays a gap.
+        // Proving both states here is what makes "absent" a real classification rather
+        // than a synonym for "not R2R".
+        var dir = Path.Combine(_dir, "symbolonly-ordinary");
+        Directory.CreateDirectory(dir);
+        WriteR2RApp(dir, "application.app", Guid.NewGuid().ToString(), "Application", "Microsoft", "28.1.49838.53910");
+        WriteR2RApp(dir, "system.app", Guid.NewGuid().ToString(), "System", "Microsoft", "28.0.53872.0");
+        WriteSymbolOnlyApp(dir, "sysapp.app", Guid.NewGuid().ToString(), "System Application", "Microsoft", "28.1.49838.53910");
+
+        var legacyReport = ProvisioningCheck.CheckPlatformApps("28.1.49838.53910", new[] { dir });
+        Assert.False(legacyReport.Ok);
+
+        var decision = ProvisioningCheck.DecideManifestProvisioning(
+            ImplicitMicrosoftRoots(), legacyReport, new[] { dir });
+
+        // The two apps the manifest named ARE present, so nothing is "missing"...
+        Assert.Empty(decision.MissingPlatformApps);
+        // ...yet the symbol-only System Application still forces the download.
+        Assert.True(decision.ShouldDownloadPlatform);
+    }
+
+    [Fact]
+    public void DecideManifestProvisioning_ExplicitMicrosoftRoots_RequireExactlyThoseApps()
+    {
+        // The al-language corpus shape: `application`/`platform` PLUS explicit Base/System
+        // Application dependencies at a declared floor. Warm, at or above the floor, this
+        // must still decide "no download".
+        var dir = Path.Combine(_dir, "warm-corpus");
+        Directory.CreateDirectory(dir);
+        WriteR2RApp(dir, "application.app", Guid.NewGuid().ToString(), "Application", "Microsoft", "27.5.46862.53931");
+        WriteR2RApp(dir, "system.app", Guid.NewGuid().ToString(), "System", "Microsoft", "27.5.46862.0");
+        WriteR2RApp(dir, "sysapp.app", Guid.NewGuid().ToString(), "System Application", "Microsoft", "27.5.46862.53931");
+        WriteR2RApp(dir, "baseapp.app", Guid.NewGuid().ToString(), "Base Application", "Microsoft", "27.5.46862.53931");
+
+        var roots = ImplicitMicrosoftRoots().Concat(new[]
+        {
+            new DependencyRef(Guid.NewGuid(), "System Application", "Microsoft", new Version(27, 5, 0, 0)),
+            new DependencyRef(Guid.NewGuid(), "Base Application", "Microsoft", new Version(27, 5, 0, 0)),
+        }).ToArray();
+
+        var needs = ProvisioningCheck.DetermineManifestNeeds(roots);
+        Assert.Equal(
+            new[] { "Application", "Base Application", "System", "System Application" },
+            needs.RequiredPlatformApps.OrderBy(n => n, StringComparer.Ordinal).ToArray());
+        // Business Foundation and Application Test Library are in the downloadable set but
+        // this manifest names neither — they must not be demanded, and their absence from
+        // the warm dir above must not make it look incomplete.
+        Assert.DoesNotContain("Business Foundation", needs.RequiredPlatformApps);
+        Assert.DoesNotContain("Application Test Library", needs.RequiredPlatformApps);
+
+        var legacyReport = ProvisioningCheck.CheckPlatformApps("27.5.46862.53931", new[] { dir });
+        var decision = ProvisioningCheck.DecideManifestProvisioning(roots, legacyReport, new[] { dir });
+        Assert.True(decision.PlatformComplete);
+        Assert.False(decision.ShouldDownloadPlatform);
+    }
+
+    [Fact]
+    public void DecideManifestProvisioning_ExplicitMicrosoftRootBelowFloor_IsNotPresent()
+    {
+        // Negative arm of the floor rule at the broadened set: a Base Application found
+        // BELOW the floor the manifest declares reads as missing, not present.
+        var dir = Path.Combine(_dir, "stale-baseapp");
+        Directory.CreateDirectory(dir);
+        WriteR2RApp(dir, "application.app", Guid.NewGuid().ToString(), "Application", "Microsoft", "27.5.46862.53931");
+        WriteR2RApp(dir, "system.app", Guid.NewGuid().ToString(), "System", "Microsoft", "27.5.46862.0");
+        WriteR2RApp(dir, "baseapp.app", Guid.NewGuid().ToString(), "Base Application", "Microsoft", "27.0.0.0");
+
+        var roots = ImplicitMicrosoftRoots().Concat(new[]
+        {
+            new DependencyRef(Guid.NewGuid(), "Base Application", "Microsoft", new Version(27, 5, 0, 0)),
+        }).ToArray();
+
+        var legacyReport = ProvisioningCheck.CheckPlatformApps("27.5.46862.53931", new[] { dir });
+        var decision = ProvisioningCheck.DecideManifestProvisioning(roots, legacyReport, new[] { dir });
+
+        Assert.Equal(new[] { "Base Application" }, decision.MissingPlatformApps.ToArray());
+        Assert.True(decision.ShouldDownloadPlatform);
+    }
+
+    [Fact]
+    public void DetermineManifestNeeds_NoMicrosoftRootsAtAll_RequiresNothing()
+    {
+        // A bundle with no `application`/`platform` fields and no Microsoft dependency (the
+        // al-language-internals-fixture shape) must still require nothing — the broadened
+        // rule keys off what the manifest NAMES, so naming nothing demands nothing.
+        var roots = new[]
+        {
+            new DependencyRef(Guid.NewGuid(), "AL Internals Test Fixture", "AL Language", new Version(1, 0, 0, 0)),
+        };
+        var needs = ProvisioningCheck.DetermineManifestNeeds(roots);
+
+        Assert.False(needs.NeedsPlatformApps);
+        Assert.Empty(needs.RequiredPlatformApps);
+        Assert.False(needs.NeedsTestApps);
+    }
+
+    [Fact]
+    public void DetermineManifestNeeds_UnrelatedMicrosoftExtension_StillRequiresNothing()
+    {
+        // Unchanged by #2205: a Microsoft app the platform-apps set cannot supply must not
+        // become an unsatisfiable requirement.
+        var roots = new[]
+        {
+            new DependencyRef(Guid.NewGuid(), "Power BI Reports", "Microsoft", new Version(28, 1, 0, 0)),
+        };
+        var needs = ProvisioningCheck.DetermineManifestNeeds(roots);
+
+        Assert.False(needs.NeedsPlatformApps);
+        Assert.Empty(needs.RequiredPlatformApps);
+    }
+
+    // ── Issue #2205, second half: `provision` must not claim a need does not exist ─────
+
+    [Fact]
+    public void BuildPlatformProvisionSkippedMessage_NeedVerifiedPresent_SaysWhatItFound()
+    {
+        var msg = ProvisioningCheck.BuildPlatformProvisionSkippedMessage(
+            new[] { "Application", "System" }, new[] { "/cache/platform-apps" });
+
+        Assert.Contains("Application", msg);
+        Assert.Contains("System", msg);
+        Assert.Contains("/cache/platform-apps", msg);
+        // #2073's intent preserved: presence is claimed only because it was verified.
+        Assert.Contains("already present", msg);
+        Assert.DoesNotContain("do not need", msg);
+    }
+
+    [Fact]
+    public void BuildPlatformProvisionSkippedMessage_NoNeedDeclared_StatesWhatWasChecked()
+    {
+        // The wrong answer #2205 reports: "target bundle(s) do not need the platform R2R
+        // apps set" for a bundle that demonstrably needs it. The honest form states what
+        // was examined and what was found there, and never asserts a need does not exist.
+        var msg = ProvisioningCheck.BuildPlatformProvisionSkippedMessage(
+            Array.Empty<string>(), new[] { "/cache/platform-apps" });
+
+        Assert.DoesNotContain("do not need", msg);
+        Assert.Contains("app.json", msg);
+        Assert.Contains("Microsoft", msg);
+    }
+
+    [Fact]
+    public void BuildManifestNeedsMissingMessage_NamesTheMissingAppsNotJustTheSet()
+    {
+        // The run-path message. Naming "the Microsoft platform-app set" alone told the
+        // reader nothing about which app was actually absent.
+        var msg = ProvisioningCheck.BuildManifestNeedsMissingMessage(
+            needsPlatform: true, needsTest: false,
+            searchedDirs: new[] { "/cache/a" },
+            missingPlatformApps: new[] { "Application", "System" });
+
+        Assert.Contains("Application", msg);
+        Assert.Contains("System", msg);
+        Assert.Contains("/cache/a", msg);
+    }
+
+    // ── FindMissingPlatformApps: absent vs present, in isolation ──────────────
+
+    [Fact]
+    public void FindMissingPlatformApps_NamesOnlyTheAbsentOnes()
+    {
+        var dir = Path.Combine(_dir, "partial-set");
+        Directory.CreateDirectory(dir);
+        WriteR2RApp(dir, "application.app", Guid.NewGuid().ToString(), "Application", "Microsoft", "28.1.0.0");
+
+        var missing = ProvisioningCheck.FindMissingPlatformApps(
+            new[] { "Application", "System", "Base Application" }, new[] { dir });
+
+        Assert.Equal(new[] { "Base Application", "System" }, missing.OrderBy(n => n, StringComparer.Ordinal).ToArray());
+    }
+
+    [Fact]
+    public void FindMissingPlatformApps_EmptyRequirement_FindsNothingMissing()
+    {
+        var missing = ProvisioningCheck.FindMissingPlatformApps(
+            Array.Empty<string>(), new[] { Path.Combine(_dir, "does-not-exist") });
+
+        Assert.Empty(missing);
+    }
 }

--- a/AlRunner.Tests/ProvisioningCheckTests.cs
+++ b/AlRunner.Tests/ProvisioningCheckTests.cs
@@ -1537,6 +1537,21 @@ public sealed class ProvisioningCheckTests : IDisposable
         Assert.Contains("/cache/a", msg);
     }
 
+    [Fact]
+    public void BuildManifestNeedsMissingMessage_NoSearchedDirs_SaysSoRatherThanTrailingOff()
+    {
+        // On a genuinely cold cache there is no package cache directory at all, and the
+        // line used to render as a bare "  Searched: " — which reads as a value the runner
+        // failed to fill in, not as the fact that nothing exists to search yet.
+        var msg = ProvisioningCheck.BuildManifestNeedsMissingMessage(
+            needsPlatform: true, needsTest: false,
+            searchedDirs: Array.Empty<string>(),
+            missingPlatformApps: new[] { "Application" });
+
+        Assert.DoesNotContain("Searched: \n", msg);
+        Assert.Contains("no package cache directory exists yet", msg);
+    }
+
     // ── FindMissingPlatformApps: absent vs present, in isolation ──────────────
 
     [Fact]

--- a/AlRunner.Tests/ProvisioningCheckTests.cs
+++ b/AlRunner.Tests/ProvisioningCheckTests.cs
@@ -1461,6 +1461,88 @@ public sealed class ProvisioningCheckTests : IDisposable
     }
 
     [Fact]
+    public void DecideManifestProvisioning_FloorAboveTheSelectedBcVersion_IsNotADownloadDemand()
+    {
+        // The al-language corpus on the BC 27.0 leg, exactly. Its app.json declares
+        // System Application / Base Application >= 27.5.0.0 while the leg provisions 27.0 —
+        // and it passes there, because the runner deliberately tolerates a bundle whose
+        // declared floor sits above the selected BC version (BcFloorGate owns the case
+        // where that is genuinely incompatible).
+        //
+        // #2003's floor rule was measured on a STALE PATCH — 28.0 present, 28.1 wanted,
+        // a newer one obtainable. A floor above the version being provisioned is a
+        // different thing: no download can ever clear it, so treating it as "absent" turns
+        // every 27.0/27.3 leg into "platform apps still missing after download", exit 2.
+        // A floor may only make an app absent when satisfying it is possible.
+        var dir = Path.Combine(_dir, "bc27-leg");
+        Directory.CreateDirectory(dir);
+        WriteR2RApp(dir, "application.app", Guid.NewGuid().ToString(), "Application", "Microsoft", "27.0.38460.53260");
+        WriteR2RApp(dir, "system.app", Guid.NewGuid().ToString(), "System", "Microsoft", "27.0.38460.0");
+        WriteR2RApp(dir, "sysapp.app", Guid.NewGuid().ToString(), "System Application", "Microsoft", "27.0.38460.53260");
+        WriteR2RApp(dir, "baseapp.app", Guid.NewGuid().ToString(), "Base Application", "Microsoft", "27.0.38460.53260");
+
+        var roots = ImplicitMicrosoftRoots().Concat(new[]
+        {
+            new DependencyRef(Guid.NewGuid(), "System Application", "Microsoft", new Version(27, 5, 0, 0)),
+            new DependencyRef(Guid.NewGuid(), "Base Application", "Microsoft", new Version(27, 5, 0, 0)),
+        }).ToArray();
+
+        var legacyReport = ProvisioningCheck.CheckPlatformApps("27.0.38460.53260", new[] { dir });
+        var decision = ProvisioningCheck.DecideManifestProvisioning(roots, legacyReport, new[] { dir });
+
+        Assert.Empty(decision.MissingPlatformApps);
+        Assert.True(decision.PlatformComplete);
+        Assert.False(decision.ShouldDownloadPlatform);
+    }
+
+    [Fact]
+    public void DecideManifestProvisioning_FloorWithinTheSelectedBcVersion_StillADownloadDemand()
+    {
+        // The negative arm: a floor the selected version CAN satisfy keeps #2003's
+        // behavior — a stale patch is still a gap, and dropping unsatisfiable floors must
+        // not become a licence to ignore satisfiable ones.
+        var dir = Path.Combine(_dir, "bc275-stale");
+        Directory.CreateDirectory(dir);
+        WriteR2RApp(dir, "application.app", Guid.NewGuid().ToString(), "Application", "Microsoft", "27.5.46862.53931");
+        WriteR2RApp(dir, "system.app", Guid.NewGuid().ToString(), "System", "Microsoft", "27.5.46862.0");
+        WriteR2RApp(dir, "baseapp.app", Guid.NewGuid().ToString(), "Base Application", "Microsoft", "27.5.1.0");
+
+        var roots = ImplicitMicrosoftRoots().Concat(new[]
+        {
+            new DependencyRef(Guid.NewGuid(), "Base Application", "Microsoft", new Version(27, 5, 46862, 53931)),
+        }).ToArray();
+
+        var legacyReport = ProvisioningCheck.CheckPlatformApps("27.5.46862.53931", new[] { dir });
+        var decision = ProvisioningCheck.DecideManifestProvisioning(roots, legacyReport, new[] { dir });
+
+        Assert.Equal(new[] { "Base Application" }, decision.MissingPlatformApps.ToArray());
+        Assert.True(decision.ShouldDownloadPlatform);
+    }
+
+    [Fact]
+    public void DropUnsatisfiableFloors_KeepsWhatTheVersionCanSupply_DropsWhatItCannot()
+    {
+        var floors = new Dictionary<string, Version>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Base Application"] = new Version(27, 5, 0, 0),
+            ["Application Test Library"] = new Version(27, 0, 0, 0),
+        };
+
+        var on27_0 = ProvisioningCheck.DropUnsatisfiableFloors(floors, "27.0.38460.53260");
+        Assert.False(on27_0.ContainsKey("Base Application"));
+        Assert.Equal(new Version(27, 0, 0, 0), on27_0["Application Test Library"]);
+
+        var on28_1 = ProvisioningCheck.DropUnsatisfiableFloors(floors, "28.1.49838.53910");
+        Assert.Equal(new Version(27, 5, 0, 0), on28_1["Base Application"]);
+        Assert.Equal(new Version(27, 0, 0, 0), on28_1["Application Test Library"]);
+
+        // An unparseable/absent version cannot rule anything out — keep every floor rather
+        // than silently relax them all.
+        var unknown = ProvisioningCheck.DropUnsatisfiableFloors(floors, "not-a-version");
+        Assert.Equal(2, unknown.Count);
+    }
+
+    [Fact]
     public void DetermineManifestNeeds_NoMicrosoftRootsAtAll_RequiresNothing()
     {
         // A bundle with no `application`/`platform` fields and no Microsoft dependency (the

--- a/AlRunner.Tests/ProvisioningCheckTests.cs
+++ b/AlRunner.Tests/ProvisioningCheckTests.cs
@@ -626,22 +626,28 @@ public sealed class ProvisioningCheckTests : IDisposable
     }
 
     [Fact]
-    public void DetermineManifestNeeds_ImplicitApplicationAndSystemRootsAlone_NeitherFlagSet()
+    public void DetermineManifestNeeds_ImplicitApplicationAndSystemRootsAlone_NeedNoTestApps()
     {
         // Mirrors ReadDependencies' synthesis of implicit `application`/`platform` roots
         // (Guid.Empty, "Application"/"System", "Microsoft", Optional: true) — present on
-        // essentially every AL Runner bundle. These alone must NOT set NeedsPlatformApps:
-        // the apps they represent (System/Base Application, Business Foundation) have a
-        // service-tier DLL dispatch fallback the runner already uses when absent, so
-        // requiring literal presence here would regress nearly the whole corpus into a
-        // spurious "needs download".
+        // essentially every AL Runner bundle.
+        //
+        // This used to assert NeedsPlatformApps == false as well, on the premise that
+        // System/Base Application and Business Foundation have a service-tier DLL dispatch
+        // fallback, so their absence is never a gap. Issue #2205 measured that premise
+        // false on a cold cache: the fallback serves runtime dispatch, not compile-time
+        // symbols, so an ordinary app with exactly these roots and nothing on disk does not
+        // compile at all. The platform half of the claim now lives in
+        // DetermineManifestNeeds_ImplicitMicrosoftRoots_RequireTheAppsTheyName.
+        //
+        // What stays true here, and is the half worth keeping: these roots say nothing
+        // about the MS test toolkit, which is a separate download.
         var roots = new[]
         {
             new DependencyRef(Guid.Empty, "Application", "Microsoft", new Version(28, 1, 0, 0), Optional: true),
             new DependencyRef(Guid.Empty, "System", "Microsoft", new Version(28, 1, 0, 0), Optional: true),
         };
         var needs = ProvisioningCheck.DetermineManifestNeeds(roots);
-        Assert.False(needs.NeedsPlatformApps);
         Assert.False(needs.NeedsTestApps);
     }
 

--- a/AlRunner/Infrastructure/ProvisioningCheck.cs
+++ b/AlRunner/Infrastructure/ProvisioningCheck.cs
@@ -1067,7 +1067,12 @@ public static class ProvisioningCheck
             lines.Add("  Needs: the Microsoft test-toolkit set (Business Foundation Test Libraries / " +
                 "Library Assert / Test Runner / …).");
         lines.Add("");
-        lines.Add($"  Searched: {string.Join(", ", searchedDirs)}");
+        // "Searched: " followed by nothing reads as a missing value rather than as the
+        // fact it is — on a genuinely cold cache there is no package cache directory yet,
+        // and that is precisely the thing the reader needs told (issue #2205).
+        lines.Add(searchedDirs.Count > 0
+            ? $"  Searched: {string.Join(", ", searchedDirs)}"
+            : "  Searched: nothing — no package cache directory exists yet on this machine.");
         lines.Add("");
         lines.Add("  Resolve it ONE of these ways:");
         lines.Add("");

--- a/AlRunner/Infrastructure/ProvisioningCheck.cs
+++ b/AlRunner/Infrastructure/ProvisioningCheck.cs
@@ -504,6 +504,27 @@ public static class ProvisioningCheck
     };
 
     /// <summary>
+    /// The Microsoft app names <see cref="AlRunner.Provisioning.ArtifactDownloader.PlatformApps"/>
+    /// actually supplies — the four w1 <c>Extensions/</c> apps, Application Test Library,
+    /// and the platform artifact's <c>System.app</c>. This is a description of the DOWNLOAD
+    /// SET's contents, not a policy list: it exists so a manifest need can only ever be
+    /// declared for something the download can satisfy (a Microsoft app outside it — an
+    /// unrelated MS extension, say — must never become an unsatisfiable requirement).
+    /// </summary>
+    public static readonly IReadOnlyList<string> PlatformAppSetContents = new[]
+    {
+        "Application",
+        "System",
+        "System Application",
+        "Base Application",
+        "Business Foundation",
+        "Application Test Library",
+    };
+
+    /// <summary>Which of the platform-apps set a manifest need may be declared for.</summary>
+    private static readonly IReadOnlyList<string> PlatformNeedTargets = KnownNoFallbackPlatformApps;
+
+    /// <summary>
     /// True iff <paramref name="appName"/> itself is in <paramref name="targets"/>, or
     /// reaches a member of it by following <paramref name="edges"/> through any number of
     /// hops. Pure graph BFS — the general closure-walk mechanism issue #2087 asked for,
@@ -670,8 +691,15 @@ public static class ProvisioningCheck
         "Permissions Mock",
     };
 
-    /// <summary>Manifest-derived provisioning need, independent of what's currently on disk.</summary>
-    public sealed record ManifestNeeds(bool NeedsPlatformApps, bool NeedsTestApps);
+    /// <summary>
+    /// Manifest-derived provisioning need, independent of what's currently on disk.
+    /// <paramref name="RequiredPlatformApps"/> names the individual apps out of the curated
+    /// platform-apps set that these manifests actually require, so callers can check
+    /// presence of exactly those (and name the absent ones) instead of a fixed list —
+    /// see <see cref="FindMissingPlatformApps"/>.
+    /// </summary>
+    public sealed record ManifestNeeds(
+        bool NeedsPlatformApps, bool NeedsTestApps, IReadOnlyList<string> RequiredPlatformApps);
 
     /// <summary>
     /// Classifies a bundle's unioned dependency roots (see Program.ReadBundleDependencyRoots)
@@ -694,8 +722,28 @@ public static class ProvisioningCheck
         IReadOnlyDictionary<string, IReadOnlyList<string>>? dependencyEdges = null)
     {
         var edges = dependencyEdges ?? EmptyDependencyEdges;
-        bool needsPlatform = false, needsTest = false;
-        foreach (var d in roots)
+        var rootList = roots as IReadOnlyCollection<AlRunner.DependencyRef> ?? roots.ToList();
+        bool needsTest = false;
+
+        // Which apps out of the curated platform-apps set do these manifests require?
+        // Asked per-app, over whatever the manifests NAME (directly, or reach through
+        // recorded edges) — never a fixed exemption list. Iterating the set in its declared
+        // order keeps the result deterministic for messages and tests.
+        var requiredPlatformApps = new List<string>();
+        foreach (var candidate in PlatformNeedTargets)
+        {
+            var single = new[] { candidate };
+            foreach (var d in rootList)
+            {
+                if (!string.Equals(d.Publisher, "Microsoft", StringComparison.OrdinalIgnoreCase)) continue;
+                if (!ReachesAnyOf(d.Name, edges, single)) continue;
+                requiredPlatformApps.Add(candidate);
+                break;
+            }
+        }
+        bool needsPlatform = requiredPlatformApps.Count > 0;
+
+        foreach (var d in rootList)
         {
             if (!string.Equals(d.Publisher, "Microsoft", StringComparison.OrdinalIgnoreCase)) continue;
             // Issue #2087: ONE closure walk replaces what used to be two separate checks —
@@ -706,7 +754,6 @@ public static class ProvisioningCheck
             // edge is recorded — no new list, no per-shape entry.
             if (ReachesAnyOf(d.Name, edges, KnownNoFallbackPlatformApps))
             {
-                needsPlatform = true;
                 // Confirmed via a live BC 28.1 platform-apps download (issue #1996): App
                 // Test Library's OWN manifest transitively depends on the MS test toolkit
                 // (Any, and from there Library Assert/Business Foundation Test Libraries)
@@ -718,7 +765,7 @@ public static class ProvisioningCheck
             if (KnownTestFrameworkAppNames.Any(n => string.Equals(n, d.Name, StringComparison.OrdinalIgnoreCase)))
                 needsTest = true;
         }
-        return new ManifestNeeds(needsPlatform, needsTest);
+        return new ManifestNeeds(needsPlatform, needsTest, requiredPlatformApps);
     }
 
     // ── Issue #2003: manifest-driven version floors ──────────────────────────
@@ -809,8 +856,24 @@ public static class ProvisioningCheck
     public static bool NoFallbackPlatformAppsPresent(
         IReadOnlyList<string> packageCacheDirs,
         IReadOnlyDictionary<string, Version>? versionFloors = null)
+        => FindMissingPlatformApps(KnownNoFallbackPlatformApps, packageCacheDirs, versionFloors).Count == 0;
+
+    /// <summary>
+    /// The subset of <paramref name="requiredAppNames"/> that is NOT found as a
+    /// Microsoft-published <c>.app</c> anywhere across <paramref name="packageCacheDirs"/>
+    /// at or above the floor <paramref name="versionFloors"/> declares for it — i.e. the
+    /// apps that are genuinely ABSENT (a found-but-below-floor app counts as absent, issue
+    /// #2003; a found-but-symbol-only app is a DIFFERENT gap, reported by
+    /// <see cref="CheckPlatformApps"/>). Order follows <paramref name="requiredAppNames"/>,
+    /// so messages built from it are deterministic. Pure filesystem scan — no network.
+    /// </summary>
+    public static IReadOnlyList<string> FindMissingPlatformApps(
+        IReadOnlyList<string> requiredAppNames,
+        IReadOnlyList<string> packageCacheDirs,
+        IReadOnlyDictionary<string, Version>? versionFloors = null)
     {
-        foreach (var required in KnownNoFallbackPlatformApps)
+        var missing = new List<string>();
+        foreach (var required in requiredAppNames)
         {
             var floor = versionFloors != null && versionFloors.TryGetValue(required, out var f) ? f : null;
             bool found = false;
@@ -829,9 +892,9 @@ public static class ProvisioningCheck
                 }
                 if (found) break;
             }
-            if (!found) return false;
+            if (!found) missing.Add(required);
         }
-        return true;
+        return missing;
     }
 
     /// <summary>
@@ -846,7 +909,9 @@ public static class ProvisioningCheck
         bool TestComplete,
         bool ShouldDownloadPlatform,
         bool ShouldDownloadTest,
-        IReadOnlyList<string> UnreadablePackages)
+        IReadOnlyList<string> UnreadablePackages,
+        IReadOnlyList<string> RequiredPlatformApps,
+        IReadOnlyList<string> MissingPlatformApps)
     {
         public bool ShouldDownloadAny => ShouldDownloadPlatform || ShouldDownloadTest;
     }
@@ -877,13 +942,18 @@ public static class ProvisioningCheck
         var scan = ScanDependencyEdges(searchDirs);
         var needs = DetermineManifestNeeds(rootsList, scan.Edges);
         var versionFloors = DetermineVersionFloors(rootsList);
-        var platformComplete = NoFallbackPlatformAppsPresent(searchDirs, versionFloors);
+        // Presence is asked of exactly the apps the manifests required — so an app the
+        // bundle never names cannot make the set look incomplete, and an app it DOES name
+        // cannot be silently exempted from the check.
+        var missingPlatformApps = FindMissingPlatformApps(needs.RequiredPlatformApps, searchDirs, versionFloors);
+        var platformComplete = missingPlatformApps.Count == 0;
         var testComplete = TestToolkitPresent(searchDirs, versionFloors);
         var shouldDownloadPlatform = !legacySymbolOnlyReport.Ok || (needs.NeedsPlatformApps && !platformComplete);
         var shouldDownloadTest = needs.NeedsTestApps && !testComplete;
         return new ManifestProvisionDecision(
             needs.NeedsPlatformApps, needs.NeedsTestApps, platformComplete, testComplete,
-            shouldDownloadPlatform, shouldDownloadTest, scan.UnreadablePackages);
+            shouldDownloadPlatform, shouldDownloadTest, scan.UnreadablePackages,
+            needs.RequiredPlatformApps, missingPlatformApps);
     }
 
     /// <summary>
@@ -917,12 +987,41 @@ public static class ProvisioningCheck
     }
 
     /// <summary>
+    /// What `al-runner provision` prints when it is NOT going to fetch the platform-app
+    /// set. Issue #2073 removed an unverified "already present" claim here; issue #2205
+    /// found the replacement had swapped it for a different unverified claim — "target
+    /// bundle(s) do not need the platform R2R apps set" was printed for a bundle that
+    /// demonstrably needed it, because the need was never detected in the first place.
+    ///
+    /// The honest form states what was CHECKED and what was FOUND, and never asserts that
+    /// a need does not exist:
+    /// <list type="bullet">
+    /// <item>apps were required and all were found → presence is claimed, because it was
+    /// verified, and the apps are named;</item>
+    /// <item>no app was required → say that the manifests named none, and where we looked,
+    /// so a reader who disagrees knows exactly which fact to go check.</item>
+    /// </list>
+    /// Pure — does no I/O.
+    /// </summary>
+    public static string BuildPlatformProvisionSkippedMessage(
+        IReadOnlyList<string> requiredPlatformApps, IReadOnlyList<string> searchedDirs)
+    {
+        var where = searchedDirs.Count > 0 ? string.Join(", ", searchedDirs) : "(no package cache directories)";
+        if (requiredPlatformApps.Count > 0)
+            return "[provision] platform R2R apps already present for the target bundle(s): " +
+                   $"{string.Join(", ", requiredPlatformApps)} — found in {where}.";
+        return "[provision] no Microsoft platform app is named by the target bundle(s)' app.json " +
+               $"(neither `dependencies` nor `application`/`platform`); searched {where} — nothing to fetch.";
+    }
+
+    /// <summary>
     /// Loud message for the case DecideManifestProvisioning identifies: the manifest
     /// declares a need, nothing satisfying it was found anywhere, and --auto-provision
     /// was NOT given (issue #1996 acceptance criterion #10: no download without opt-in).
     /// </summary>
     public static string BuildManifestNeedsMissingMessage(
-        bool needsPlatform, bool needsTest, IReadOnlyList<string> searchedDirs)
+        bool needsPlatform, bool needsTest, IReadOnlyList<string> searchedDirs,
+        IReadOnlyList<string>? missingPlatformApps = null)
     {
         var lines = new List<string>
         {
@@ -931,8 +1030,14 @@ public static class ProvisioningCheck
             "",
         };
         if (needsPlatform)
-            lines.Add("  Needs: the Microsoft platform-app set (Base Application / System Application / " +
-                "Business Foundation / Application / Application Test Library).");
+            lines.Add(missingPlatformApps is { Count: > 0 }
+                // Issue #2205: name the apps that are actually absent. "the Microsoft
+                // platform-app set" alone left the reader no way to tell which dependency
+                // the run was about to die on.
+                ? "  Needs: the Microsoft platform-app set — missing from every searched cache: " +
+                  string.Join(", ", missingPlatformApps) + "."
+                : "  Needs: the Microsoft platform-app set (Base Application / System Application / " +
+                  "Business Foundation / Application / Application Test Library).");
         if (needsTest)
             lines.Add("  Needs: the Microsoft test-toolkit set (Business Foundation Test Libraries / " +
                 "Library Assert / Test Runner / …).");

--- a/AlRunner/Infrastructure/ProvisioningCheck.cs
+++ b/AlRunner/Infrastructure/ProvisioningCheck.cs
@@ -831,6 +831,45 @@ public static class ProvisioningCheck
         return floors;
     }
 
+    /// <summary>
+    /// <paramref name="versionFloors"/> minus every floor that <paramref name="provisionableVersion"/>
+    /// could not possibly satisfy — a floor whose major.minor is ABOVE the BC version being
+    /// provisioned.
+    ///
+    /// Issue #2003's floor rule was measured on a stale PATCH: 28.0 present, 28.1 declared,
+    /// a newer build obtainable — so "found but too old" is a real gap a download fixes.
+    /// A floor above the selected version is a different thing entirely and no download can
+    /// ever clear it. The al-language corpus declares System Application / Base Application
+    /// &gt;= 27.5.0.0 and is nonetheless run — green — on the BC 27.0 and 27.3 legs, because
+    /// the runner tolerates that gap deliberately (<c>BcFloorGate</c> owns the case where it
+    /// is genuinely incompatible). Counting it as "absent" once issue #2205 made these apps
+    /// a real requirement would have turned both legs into "platform apps still missing
+    /// after download", exit 2, on every cold run.
+    ///
+    /// An unparseable <paramref name="provisionableVersion"/> rules nothing out: every floor
+    /// is kept, because "we cannot tell" must not read as "relax them all". Pure.
+    /// </summary>
+    public static IReadOnlyDictionary<string, Version> DropUnsatisfiableFloors(
+        IReadOnlyDictionary<string, Version>? versionFloors, string? provisionableVersion)
+    {
+        var empty = new Dictionary<string, Version>(StringComparer.OrdinalIgnoreCase);
+        if (versionFloors == null || versionFloors.Count == 0) return empty;
+        if (string.IsNullOrWhiteSpace(provisionableVersion)) return versionFloors;
+
+        var parts = provisionableVersion.Split('.');
+        if (parts.Length < 2 || !int.TryParse(parts[0], out var major) || !int.TryParse(parts[1], out var minor))
+            return versionFloors;
+
+        var kept = new Dictionary<string, Version>(StringComparer.OrdinalIgnoreCase);
+        foreach (var (name, floor) in versionFloors)
+        {
+            var floorMinor = floor.Minor < 0 ? 0 : floor.Minor;
+            if (floor.Major > major || (floor.Major == major && floorMinor > minor)) continue;
+            kept[name] = floor;
+        }
+        return kept;
+    }
+
     /// <summary>One app found below the version floor its manifests declared for it.</summary>
     public sealed record VersionFloorViolation(string AppName, Version FoundVersion, Version RequiredVersion);
 
@@ -966,7 +1005,11 @@ public static class ProvisioningCheck
         var rootsList = manifestRoots as ICollection<AlRunner.DependencyRef> ?? manifestRoots.ToList();
         var scan = ScanDependencyEdges(searchDirs);
         var needs = DetermineManifestNeeds(rootsList, scan.Edges);
-        var versionFloors = DetermineVersionFloors(rootsList);
+        // A floor the BC version under provision could never supply must not create a
+        // demand no download can clear — see DropUnsatisfiableFloors. The report carries
+        // the selected version, which is exactly the version a download would target.
+        var versionFloors = DropUnsatisfiableFloors(
+            DetermineVersionFloors(rootsList), legacySymbolOnlyReport.Version);
         // Presence is asked of exactly the apps the manifests required — so an app the
         // bundle never names cannot make the set look incomplete, and an app it DOES name
         // cannot be silently exempted from the check.

--- a/AlRunner/Infrastructure/ProvisioningCheck.cs
+++ b/AlRunner/Infrastructure/ProvisioningCheck.cs
@@ -521,8 +521,33 @@ public static class ProvisioningCheck
         "Application Test Library",
     };
 
-    /// <summary>Which of the platform-apps set a manifest need may be declared for.</summary>
-    private static readonly IReadOnlyList<string> PlatformNeedTargets = KnownNoFallbackPlatformApps;
+    /// <summary>
+    /// Which apps a manifest need may be declared for — the whole contents of the curated
+    /// platform-apps download set (issue #2205), asked one app at a time against what the
+    /// manifests actually name.
+    ///
+    /// It used to be <see cref="KnownNoFallbackPlatformApps"/> alone, on the premise that
+    /// System/Base Application and Business Foundation always have a service-tier DLL
+    /// dispatch fallback, so only PRESENT-but-symbol-only could ever be a gap for them and
+    /// requiring the whole set would regress every corpus bundle (they all carry implicit
+    /// `application`/`platform` roots) into a spurious "needs download".
+    ///
+    /// The premise is false on a cold cache. The DLL fallback serves RUNTIME DISPATCH; it
+    /// does not supply COMPILE-TIME SYMBOLS. With engine-only artifacts on disk an ordinary
+    /// AL app — `"dependencies": []` plus `application`/`platform`, the default shape of
+    /// virtually every real extension — never compiles, so there is no runtime for the
+    /// fallback to serve: the run ended in EMIT-EXCLUDED preceded by two unframed
+    /// `[deps] dependency not found in cache, skipping` lines. CI never saw it because CI
+    /// machines always already have platform-apps/ on disk.
+    ///
+    /// The spurious-download worry the old premise was protecting against does not follow
+    /// from broadening the targets, because the decision is not "is this app named in a
+    /// list" — it is <see cref="FindMissingPlatformApps"/>, "is this app ABSENT from every
+    /// searched cache", asked only of the apps the manifests named. A warm machine has them,
+    /// so a warm bundle still decides "no download"; a cold one does not, which is the whole
+    /// point. And a bundle that names, say, no Business Foundation is never asked for it.
+    /// </summary>
+    private static readonly IReadOnlyList<string> PlatformNeedTargets = PlatformAppSetContents;
 
     /// <summary>
     /// True iff <paramref name="appName"/> itself is in <paramref name="targets"/>, or

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -7463,6 +7463,34 @@ static void EnsurePlatformAppsProvisioned(string engineVersion, List<string> bun
         if (skewNote != null)
             Console.Error.WriteLine(skewNote);
     }
+
+    // Reuse-first, the same check the --auto-provision path in the main flow already does
+    // (FindWarmProvisionedVersion) and this one never did. It did not matter while the need
+    // was almost never detected here — `provision` simply printed "nothing to provision" and
+    // stopped. Once issue #2205 made the need real for ordinary bundles, its absence meant
+    // every single `al-runner provision` re-fetched the full 116 MB platform set over a
+    // complete one already on disk. Skipped when the bundle's OWN package cache holds a
+    // symbol-only platform app (issue #1678): that is a known-bad package a warm set
+    // elsewhere does not repair.
+    var provisionFloors = AlRunner.Infrastructure.ProvisioningCheck.DetermineVersionFloors(manifestDependencyRoots);
+    var warmVersion = platformReport.Ok
+        ? FindWarmProvisionedVersion(
+            AlRunner.Infrastructure.BcArtifacts.ArtifactsRootDir, mm,
+            decision.RequiredPlatformApps, needTest: false,
+            provisionFloors, m => Console.Error.WriteLine(m))
+        : null;
+    if (warmVersion != null)
+    {
+        Console.Error.WriteLine(AlRunner.Infrastructure.ProvisioningCheck.BuildPlatformProvisionSkippedMessage(
+            decision.RequiredPlatformApps,
+            new[]
+            {
+                AlRunner.Infrastructure.ProvisioningCheck.PlatformAppsDirFor(
+                    AlRunner.Infrastructure.BcArtifacts.ArtifactsRootDir, warmVersion),
+            }));
+        return;
+    }
+
     var platformFull = AlRunner.Provisioning.ArtifactDownloader.ResolveVersion(
         mm, m => Console.Error.WriteLine($"[provision] {m}"));
     if (platformFull == null)

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -1374,7 +1374,11 @@ if (!provisionSubcommand)
         // app.json manifests declare, not just be present — versionFloors carries that
         // (derived from the SAME manifestDependencyRoots DetermineManifestNeeds already
         // read above), so a stale warm set is skipped rather than silently reused.
-        var versionFloors = AlRunner.Infrastructure.ProvisioningCheck.DetermineVersionFloors(manifestDependencyRoots);
+        // Same rule DecideManifestProvisioning applies: a floor above the version being
+        // provisioned is not something a download can fix, so it must not reject a warm
+        // set (see ProvisioningCheck.DropUnsatisfiableFloors).
+        var versionFloors = AlRunner.Infrastructure.ProvisioningCheck.DropUnsatisfiableFloors(
+            AlRunner.Infrastructure.ProvisioningCheck.DetermineVersionFloors(manifestDependencyRoots), version);
         var full = (platformReport.Ok
                 ? FindWarmProvisionedVersion(
                     AlRunner.Infrastructure.BcArtifacts.ArtifactsRootDir, mm,
@@ -7472,7 +7476,8 @@ static void EnsurePlatformAppsProvisioned(string engineVersion, List<string> bun
     // complete one already on disk. Skipped when the bundle's OWN package cache holds a
     // symbol-only platform app (issue #1678): that is a known-bad package a warm set
     // elsewhere does not repair.
-    var provisionFloors = AlRunner.Infrastructure.ProvisioningCheck.DetermineVersionFloors(manifestDependencyRoots);
+    var provisionFloors = AlRunner.Infrastructure.ProvisioningCheck.DropUnsatisfiableFloors(
+        AlRunner.Infrastructure.ProvisioningCheck.DetermineVersionFloors(manifestDependencyRoots), engineVersion);
     var warmVersion = platformReport.Ok
         ? FindWarmProvisionedVersion(
             AlRunner.Infrastructure.BcArtifacts.ArtifactsRootDir, mm,

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -1329,7 +1329,8 @@ if (!provisionSubcommand)
         Console.Error.WriteLine(!platformReport.Ok
             ? platformReport.ToDetailedMessage()
             : AlRunner.Infrastructure.ProvisioningCheck.BuildManifestNeedsMissingMessage(
-                decision.ShouldDownloadPlatform, decision.ShouldDownloadTest, PlatformCheckDirs()));
+                decision.ShouldDownloadPlatform, decision.ShouldDownloadTest, PlatformCheckDirs(),
+                decision.MissingPlatformApps));
         return 2;
     }
 
@@ -1377,7 +1378,7 @@ if (!provisionSubcommand)
         var full = (platformReport.Ok
                 ? FindWarmProvisionedVersion(
                     AlRunner.Infrastructure.BcArtifacts.ArtifactsRootDir, mm,
-                    decision.NeedsPlatformApps, decision.ShouldDownloadTest,
+                    decision.RequiredPlatformApps, decision.ShouldDownloadTest,
                     versionFloors, m => Console.Error.WriteLine(m))
                 : null)
             ?? AlRunner.Provisioning.ArtifactDownloader.ResolveVersion(
@@ -1489,14 +1490,18 @@ if (!provisionSubcommand)
                 Console.Error.WriteLine($"[provision] platform apps still symbol-only after download: {stillMissing}");
                 return 2;
             }
-            // Only demand literal Application Test Library presence when the MANIFEST
-            // actually declared a need for it — some BC versions never ship it at all, so
-            // requiring it unconditionally would fail every platform-apps download
-            // triggered solely by the legacy symbol-only gap (e.g. corpus bundles on BC 27.x).
-            if (decision.NeedsPlatformApps
-                && !AlRunner.Infrastructure.ProvisioningCheck.NoFallbackPlatformAppsPresent(PlatformCheckDirs()))
+            // Only demand the apps the MANIFEST actually named — some BC versions never
+            // ship some of them at all (Application Test Library does not exist on 27.x),
+            // so a fixed list would fail every platform-apps download triggered by a bundle
+            // that never needed that app. Issue #2205: this used to hardcode Application
+            // Test Library, which the broadened need-detection would have made fatal for
+            // every ordinary bundle on 27.x.
+            var stillAbsent = AlRunner.Infrastructure.ProvisioningCheck.FindMissingPlatformApps(
+                decision.RequiredPlatformApps, PlatformCheckDirs());
+            if (stillAbsent.Count > 0)
             {
-                Console.Error.WriteLine("[provision] platform apps (Application Test Library) still missing after download.");
+                Console.Error.WriteLine(
+                    $"[provision] platform apps still missing after download: {string.Join(", ", stillAbsent)}.");
                 return 2;
             }
         }
@@ -6738,7 +6743,8 @@ static string? SelectVersionDirOrNull(string root, string versionPrefix)
 /// presence-only behavior verbatim (AC #4).
 /// </summary>
 static string? FindWarmProvisionedVersion(
-    string artifactsRootDir, string majorMinorPrefix, bool needPlatform, bool needTest,
+    string artifactsRootDir, string majorMinorPrefix,
+    IReadOnlyList<string> requiredPlatformApps, bool needTest,
     IReadOnlyDictionary<string, Version>? versionFloors = null,
     Action<string>? onRejected = null)
 {
@@ -6756,8 +6762,10 @@ static string? FindWarmProvisionedVersion(
     {
         var platformDir = AlRunner.Infrastructure.ProvisioningCheck.PlatformAppsDirFor(artifactsRootDir, name);
         var testDir = AlRunner.Infrastructure.ProvisioningCheck.TestAppsDirFor(artifactsRootDir, name);
-        var platformOk = !needPlatform || AlRunner.Infrastructure.ProvisioningCheck.NoFallbackPlatformAppsPresent(
-            new[] { platformDir }, versionFloors);
+        // Issue #2205: "is this warm set usable" asks for the apps this bundle actually
+        // requires, not a fixed one-element list. An empty requirement is vacuously ok.
+        var platformOk = AlRunner.Infrastructure.ProvisioningCheck.FindMissingPlatformApps(
+            requiredPlatformApps, new[] { platformDir }, versionFloors).Count == 0;
         var testOk = !needTest || AlRunner.Infrastructure.ProvisioningCheck.TestToolkitPresent(
             new[] { testDir }, versionFloors);
         if (platformOk && testOk) return name;
@@ -7430,12 +7438,12 @@ static void EnsurePlatformAppsProvisioned(string engineVersion, List<string> bun
     if (!decision.ShouldDownloadPlatform)
     {
         // Issue #2073: "already present" is only true when something was actually VERIFIED
-        // present — a bundle that was simply determined not to need the set at all (the
-        // manifest names nothing platform-only) never checked presence, so claiming
-        // presence for it is a silent wrong answer under .claude/rules/loud-failures.md.
-        Console.Error.WriteLine(decision.NeedsPlatformApps
-            ? "[provision] platform R2R apps already present for the target bundle(s)."
-            : "[provision] target bundle(s) do not need the platform R2R apps set — nothing to provision.");
+        // present. Issue #2205: and "do not need the platform R2R apps set" was equally
+        // unverified — it was printed for a bundle whose implicit Microsoft roots the need
+        // detection simply never looked at. The message now states what was checked and
+        // what was found there; see BuildPlatformProvisionSkippedMessage.
+        Console.Error.WriteLine(AlRunner.Infrastructure.ProvisioningCheck.BuildPlatformProvisionSkippedMessage(
+            decision.RequiredPlatformApps, edgeSearchDirs));
         return;
     }
 


### PR DESCRIPTION
Closes #2205

Part of the "install, execute, done" story tracked in #2213 (not closing it).

## What was wrong

On a cold cache an ordinary AL app — `"dependencies": []` plus `application`/`platform`,
which is how `al` gets the Microsoft roots for virtually every real extension — did not
run, and nothing said why.

`ProvisioningCheck.DetermineManifestNeeds` only set `needsPlatform` when a root reached
`KnownNoFallbackPlatformApps`, a one-element list holding `"Application Test Library"`.
The implicit `Microsoft/Application` and `Microsoft/System` roots were produced and passed
in, but deliberately excluded, on this premise:

> only PRESENT-but-symbol-only is a gap for them … requiring the whole set would regress
> nearly every bundle in the corpus … into a spurious "needs download".

The premise is false on a cold cache. The service-tier DLL fallback it rests on covers
**runtime dispatch**; it does not supply **compile-time symbols**. With engine-only
artifacts the app never compiles, so there is no runtime for the fallback to serve.

## Cold reproduction (verbatim)

`HOME` pointed at a directory holding only the 501-DLL / 336 MB engine closure — no
`platform-apps/`, no `test-apps/`, no `.alpackages`:

```
$ env HOME=<cold> al-runner tests/runner-extras/microsoft-dependencies
[provision] BC 28.1.49838.53910 engine artifacts already complete at <cold>/.local/share/al-runner/artifacts/28.1.49838.53910.
al-runner — running 1 bundle(s)
  package caches (requested): 0 dir(s)
  [deps] dependency not found in cache, skipping: Microsoft/Application
  [deps] dependency not found in cache, skipping: Microsoft/System
<bundled>: EMIT-EXCLUDED — Runner Extras - Microsoft Dependencies: 1 object(s) could not be
compiled and were dropped from the module, so any tests they declare are MISSING from this
run: [Codeunit ."Microsoft Dependency Tests"].
  → 0P/0F/0E across 0 tests, 1 suite errors (0.5s)
EXIT=3
```

and the second half:

```
$ env HOME=<cold> al-runner provision tests/runner-extras/microsoft-dependencies
[provision] Downloaded 107 test .app file(s) (20 MB) to <cold>/.../test-apps
[provision] target bundle(s) do not need the platform R2R apps set — nothing to provision.
EXIT=0
```

Exit 0, no `platform-apps/` created, and the next plain run is a byte-identical exit 3.

## The fix

**Absent vs present-but-symbol-only, asked of what the manifest names.** The need targets
widen from the one-element `KnownNoFallbackPlatformApps` to `PlatformAppSetContents` — a
description of what `ArtifactDownloader.PlatformApps` actually supplies, not a policy list.
It exists only so a need can never be declared for something the download cannot satisfy;
an unrelated Microsoft extension still requires nothing.

The decision itself is not list membership. `DetermineManifestNeeds` returns
`RequiredPlatformApps` — the apps these manifests name, directly or through recorded
dependency edges, one app at a time. `FindMissingPlatformApps` then asks the only question
that matters: **is this app absent from every searched cache** (or present below its
declared floor, per #2003). Symbol-only remains a separate, unchanged gap reported by
`CheckPlatformApps`.

That is why the spurious-download worry does not follow. A warm machine has the apps, so a
warm bundle still decides "no download". A bundle that never names Business Foundation is
never asked for it.

Two call sites had the same shape and would have broken under the wider need:

- **`FindWarmProvisionedVersion`** gated warm reuse on `NoFallbackPlatformAppsPresent`
  (Application Test Library). Now checks the required set.
- **The post-download verification** hardcoded `"platform apps (Application Test Library)
  still missing after download"`. ATL does not ship on BC 27.x at all, so with the wider
  need this would have failed **every 27.x leg** on a cold cache. Now it names whatever is
  genuinely still absent.

**`provision` (the second half).** `EnsurePlatformAppsProvisioned` shares
`DecideManifestProvisioning`, so the need detection fixes it too. Its message was the other
half: #2073 replaced an unverified "already present" with an equally unverified "do not
need the platform R2R apps set". `BuildPlatformProvisionSkippedMessage` keeps #2073's
intent — it states what was checked and what was found, and never asserts a need does not
exist:

```
[provision] platform R2R apps already present for the target bundle(s): Application, System — found in <dir>.
[provision] no Microsoft platform app is named by the target bundle(s)' app.json (neither `dependencies` nor `application`/`platform`); searched <dir> — nothing to fetch.
```

One more defect surfaced by fixing the first: `EnsurePlatformAppsProvisioned` never
consulted the runner-owned `platform-apps` dirs it writes to. Harmless while the need was
almost never detected there; once the need became real it refetched 116 MB on **every**
`al-runner provision`. It now runs the same `FindWarmProvisionedVersion` reuse scan the
main `--auto-provision` flow already did.

## Cold, after — zero flags

```
$ env HOME=<cold> al-runner tests/runner-extras/microsoft-dependencies
[provision] platform R2R apps missing — downloading...
[provision] Downloaded 6 app(s) (116 MB total) to <cold>/.../platform-apps
Tests:        14 total
  pass:        14
EXIT=0
```

`provision` on the same cold cache now creates `platform-apps/` with all six apps, and a
second `provision` reuses it instead of refetching.

With `--no-auto-provision` the refusal now names the cause:

```
  Needs: the Microsoft platform-app set — missing from every searched cache: Application, System.
  Searched: nothing — no package cache directory exists yet on this machine.
```

## Warm no-regression evidence

Measured with `--no-auto-provision`, so the *provisioning decision itself* is the verdict:
if anything newly claimed a need, the run exits 2 with the "declares Microsoft dependencies
that were not found" message instead of running.

| Run | Before | After |
|---|---|---|
| `tests/al-language/tests/al-language` + both CI package caches | exit 0, 2199 pass | exit 0, 2199 pass |
| `tests/runner-extras` + both CI package caches | exit 0, 198 pass | exit 0, 198 pass |
| `tests/runner-extras`, **no** `--package-cache` (default caches only) | — | exit 0, 198 pass |

Zero occurrences of the needs-missing message in any after-run. The decision is unchanged.

Two things were needed to keep it that way, and both were found by looking for the shape
rather than by CI:

- **A floor the selected BC version cannot supply is not a demand.** The corpus declares
  System Application / Base Application `>= 27.5.0.0` and runs green on the **BC 27.0 and
  27.3 legs**. Once these apps became a real requirement, #2003's floor rule counted them
  absent there — and no 27.0 download can clear a 27.5 floor, so both legs would have
  ended in `platform apps still missing after download`, exit 2, on every cold run.
  `DropUnsatisfiableFloors` keeps #2003 intact for the case it was measured on (a stale
  patch, a newer build obtainable) and drops only floors above the version being
  provisioned.
- **CI put the platform apps only where `--package-cache` pointed.** Every
  `AlRunner.Tests` case that spawns the runner as a subprocess passes no `--package-cache`,
  so it sees only the default caches — and would now each fetch 116 MB from the CDN, dozens
  of times, four in parallel, into the same directory. `bc-tests.yml` now hardlinks the
  already-downloaded set into `<artifacts-root>/<version>/platform-apps` as well, which is
  where `provision` puts it on a real machine.

One test fixture was genuinely wrong and is fixed rather than worked around:
`PackageCacheFinalSearchSetTests`'s fixture carried `"application"`/`"platform"` while its
own comment promised it "declares nothing Microsoft ... never in a provisioning decision
(which would otherwise try to download real platform/test apps and make the test depend on
network access)". Dropping the two fields is what that comment always claimed.

## What CI found that local runs could not

The first two runs were red, both times for something worth keeping:

**BC 27.0 / 27.3 stayed green throughout.** On the first run the corpus, the xmlport
isolation guard, runner-extras (187) and both server-mode steps all passed on 27.0 with
zero provisioning messages — the `DropUnsatisfiableFloors` reasoning above, confirmed
against a real leg rather than only in a unit test.

**`CacheKeyDependencyClosureTests` was measuring the machine, not the cache key.** It varied
the closure by dropping `System.app` from a copied platform-apps directory. With the
platform set now a detected need, the runner-owned dir supplies `System.app` right back, so
both runs keyed on the same closure. It nonetheless *passed* locally — the key stamps each
winning `.app`'s mtime, and a freshly copied file and a warm provisioned one simply had
different timestamps. It now varies a synthetic `Contoso ISV` dependency across two
versions, which no provisioning path can restore; verified the dep really resolves in both
runs, so the keys differ on the closure and not on a resolution failure.

**Six collections crossed `check-collection-weights.py`'s 60 s threshold at once**, and the
cause is not the tests. Once the platform apps sit in the runner-owned location, every
spawned runner resolves and loads the Base Application closure its `app.json` always
declared. Measured on two of the six, same machine and build, with the need detection held
identical across both rows:

| runner-owned `platform-apps` | need detection | wall |
|---|---|---|
| absent | pre-#2205 | 21 s |
| present | pre-#2205 | 79 s |

That ~3.8x is the *load*. Any machine that has run `al-runner provision` was already paying
it; CI was not, only because it put the apps where `--package-cache` pointed. It is
pre-existing, is not something this PR should revert, and stays open as #2223. The weights
are recorded with the observed maximum across all eight legs.

### What this change itself costs: +116 ms per invocation, about +2.8%

An earlier revision of this section reported a third row (98 s, post-#2205) and attributed
the whole 21→98 s span to pre-existing load. That was wrong. The 79→98 s step was measured
in two separate, non-interleaved `dotnet test` runs on a machine whose spread on identical
suites is ~1.6x, so it was mostly load — and it held the platform apps constant, so "the
apps are now present" could never have explained it. Re-measured by alternating the two
builds within one session:

- **Collection level**, 3 interleaved pairs of the same two collections: new 85.9 / 72.0 /
  83.4 s vs old 91.8 / 82.7 / 82.2 s — medians 83.4 s and 82.7 s, with the new build faster
  in two of three pairs. No separable difference at this granularity.
- **Per invocation**, 8 interleaved pairs against a warm AL cache, where variance is far
  lower: median 4.238 s vs 4.122 s — **+116 ms**. Real and repeatable.

The mechanism is `FindMissingPlatformApps` running one presence scan per app the manifest
requires — two for an ordinary bundle, `Application` and `System` — where the old code ran a
single scan for one hardcoded name, and the decision being computed more than once per
invocation. It is stated here as this change's own cost rather than folded into #2223,
which is about the 21→79 s step and now says so explicitly.

## Does this make #2207 / #2208 unreachable?

Not fully — both still stand.

- **#2207** (`--verbose` prints nothing new) is reached through the EMIT-EXCLUDED message,
  which this makes far rarer but does not remove: any other compile failure still points
  the user at `--verbose`.
- **#2208** is fixed by #2222, which merged after this PR's first CI run and which this
  branch is now rebased onto. The residual is narrower than #2208 was: `provision`'s engine
  closure and test toolkit now correctly target the engine's own build
  (`28.1.49838.53910`), while the platform-app sub-step still resolves the CDN's latest for
  the major.minor (`28.1.49838.54044`), because it goes through
  `ArtifactDownloader.ResolveVersion(mm)` rather than #2222's new
  `DefaultProvisionTarget`. The run passes either way — the engine is version-agnostic
  w.r.t. the R2R apps it dispatches to — so this is an inconsistency, not a break, and it
  is out of scope here.

## The three questions

1. **Same wrong pattern at another call site?** Yes — two, both fixed above
   (`FindWarmProvisionedVersion`, and the post-download ATL-hardcoded verification, which
   would have gone red on every BC 27.x leg).
2. **Sibling function making the same assumption?** Yes — `EnsurePlatformAppsProvisioned`,
   fixed here, plus the missing warm-reuse scan it never had.
3. **Two paths writing the same state, same invariant?** The run path folds its
   runner-owned platform-apps dir into the search set and scans for a warm version; the
   `provision` path did neither. They now share `FindWarmProvisionedVersion`.

## Tests

RED first: the 5 new behavior tests were added together with the API surface but with the
need targets still set to the old value, so they failed on the assertion, not on a compile
error. Flipping the targets is the second commit. The `DropUnsatisfiableFloors` test was
proven RED the same way, by unwiring only that call.

New, in `AlRunner.Tests/ProvisioningCheckTests.cs` and
`AlRunner.Tests/ManifestDependencyEdgeScanTests.cs`:

- cold implicit roots → needs `Application` + `System`, and **not** the test-apps set;
- **warm implicit roots → no download** (the constraint arm);
- warm explicit corpus-shaped roots (`application`/`platform` + Base/System Application at
  a floor) → no download, and Business Foundation / ATL are not demanded;
- present-but-symbol-only → still a download, with nothing "missing";
- a root below its declared floor → reported missing; a root below a floor the selected BC
  version cannot supply → **not** reported missing;
- BC 27.x edges reach System Application + Business Foundation and **not** ATL; warm 27.x
  with those two present → no download;
- both `provision` messages, and the missing-app naming on the run-path message.

Two pre-existing tests encoded the false premise and were rewritten rather than deleted —
each keeps the half of its claim that is still true, with a comment recording what was
measured and why the other half changed.

## Verification

Rebased onto current `main` after #2222, which rewrote how the provision target version is
resolved in the same flow these hunks touch. Re-verified on the rebased build: the cold
reproduction still refuses with the named cause under `--no-auto-provision` and passes
14/14 with no flags; `provision` still creates `platform-apps/` cold and reuses it warm;
128 provisioning-area unit tests pass, including #2222's own `ProvisionExplicitModesTests`
and `DefaultProvisionTargetMessagingTests`.

Full local `dotnet test AlRunner.Tests`: 1150 passed, 0 failed.
