### PR TITLE
fix(provision): resolve default BC version from the engine build, not the bundle major

### DIFF
--- a/AlRunner.Tests/ProvisionExplicitModesTests.cs
+++ b/AlRunner.Tests/ProvisionExplicitModesTests.cs
@@ -316,27 +316,33 @@ public sealed class ProvisionExplicitModesTests
     [Fact]
     public void TestApps_BundleDeclaresOlderMajor_StillTargetsEngineMajor()
     {
+        // The bundle's declared major must genuinely differ from THIS build's engine
+        // major — a CI matrix leg builds against 27.x as often as 28.x (bc-tests.yml), so
+        // a hardcoded "27" collided with the engine's own major on a 27.x leg and made
+        // the negative assertion below fail on real, CORRECT output (#2208 follow-up).
+        var engineMajor = Version.Parse(ThisBuildsEngineVersion).Major;
+        var bundleMajor = engineMajor - 1;
         var home = NewIsolatedHome();
         var bundleDir = Path.Combine(Path.GetTempPath(), "al-runner-provision-explicit-bundle", Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(bundleDir);
         File.WriteAllText(Path.Combine(bundleDir, "app.json"),
             "{ \"id\": \"11111111-1111-1111-1111-111111111111\", \"name\": \"Fixture\", " +
-            "\"publisher\": \"Fixture\", \"version\": \"1.0.0.0\", \"application\": \"27.0.0.0\" }");
+            "\"publisher\": \"Fixture\", \"version\": \"1.0.0.0\", \"application\": \"" + bundleMajor + ".0.0.0\" }");
         try
         {
-            var testAppsDir = TestAppsDirFor(home, ThisBuildsEngineVersion); // the ENGINE's own build, not the bundle's major 27
+            var testAppsDir = TestAppsDirFor(home, ThisBuildsEngineVersion); // the ENGINE's own build, not the bundle's major
             Assert.False(Directory.Exists(testAppsDir), "precondition: fresh cache must not already have this dir");
 
             var (exit, stderr) = Run(home, "provision", "--test-apps", "--force", bundleDir);
 
             Assert.True(exit == 0, $"provision --test-apps must exit 0. stderr:\n{stderr}");
             Assert.True(Directory.Exists(testAppsDir),
-                $"expected {testAppsDir} (the engine's own build {ThisBuildsEngineVersion}, not the bundle's major 27) to exist. stderr:\n{stderr}");
+                $"expected {testAppsDir} (the engine's own build {ThisBuildsEngineVersion}, not the bundle's major {bundleMajor}) to exist. stderr:\n{stderr}");
             var cacheRoot = TestArtifacts.StandardCacheDir(home);
             var versionDirs = Directory.Exists(cacheRoot)
                 ? Directory.GetDirectories(cacheRoot).Select(Path.GetFileName).ToArray()
                 : Array.Empty<string?>();
-            Assert.DoesNotContain(versionDirs, d => d != null && d.StartsWith("27.", StringComparison.Ordinal));
+            Assert.DoesNotContain(versionDirs, d => d != null && d.StartsWith(bundleMajor + ".", StringComparison.Ordinal));
         }
         finally
         {

--- a/AlRunner.Tests/ProvisionExplicitModesTests.cs
+++ b/AlRunner.Tests/ProvisionExplicitModesTests.cs
@@ -33,9 +33,22 @@ public sealed class ProvisionExplicitModesTests
     // A real, already-published BC version — this test needs the CDN to actually have it
     // (unlike AutoProvisionDefaultTests's deliberately-nonexistent 1.2.3.4, which exists
     // purely to prove "an attempt was made" via a fast 404). Also the version this repo's
-    // own AlRunner.csproj/AlRunner.Tests.csproj build against by default, so it is already
-    // in wide use and unlikely to be withdrawn from the CDN out from under this test.
+    // own AlRunner.csproj/AlRunner.Tests.csproj build against by DEFAULT (a bare `dotnet
+    // build`/`dotnet test`, no `-p:_BCVersion`) — see Directory.Build.props — so it is
+    // already in wide use and unlikely to be withdrawn from the CDN out from under this
+    // test. Only usable where the version is passed EXPLICITLY (`--bc-version RealVersion`)
+    // — a matrix CI leg builds against a DIFFERENT `-p:_BCVersion`, so any test that
+    // resolves the version IMPLICITLY (no `--bc-version` on the command line) must use
+    // <see cref="ThisBuildsEngineVersion"/> instead, which reads the actual value baked
+    // into THIS test binary rather than assuming the dev-machine default (#2208: a matrix
+    // leg built for 28.1.49838.54044 failed here when this constant was used for that).
     private const string RealVersion = "28.1.49838.53910";
+
+    // The exact BC version THIS test assembly (and the AlRunner binary it spawns, built in
+    // the same `dotnet build AlRunner.slnx -p:_BCVersion=...` invocation) was built
+    // against — see the comment on RealVersion above for why this must NOT be a constant.
+    private static readonly string ThisBuildsEngineVersion =
+        AlRunner.Infrastructure.BcArtifacts.EngineBuiltVersion()?.ToString() ?? RealVersion;
 
     private static (int ExitCode, string StdErr) Run(string isolatedHome, params string[] args)
     {
@@ -84,8 +97,8 @@ public sealed class ProvisionExplicitModesTests
     // bc-tests.yml actually provisions), not spelled out here — TestArtifactsGateTests'
     // OnlyTheSharedHelperNamesTheArtifactCachePathsInCode enforces that only TestArtifacts
     // itself may name the raw ".local/share/al-runner/artifacts" path segments in code.
-    private static string TestAppsDirFor(string home) =>
-        Path.Combine(TestArtifacts.StandardCacheDir(home), RealVersion, "test-apps");
+    private static string TestAppsDirFor(string home, string version = RealVersion) =>
+        Path.Combine(TestArtifacts.StandardCacheDir(home), version, "test-apps");
 
     /// <summary>
     /// Positive direction: `provision --test-apps --bc-version &lt;ver&gt;` downloads the
@@ -270,7 +283,7 @@ public sealed class ProvisionExplicitModesTests
         var home = NewIsolatedHome();
         try
         {
-            var testAppsDir = TestAppsDirFor(home); // RealVersion == this build's _BCVersion
+            var testAppsDir = TestAppsDirFor(home, ThisBuildsEngineVersion);
             Assert.False(Directory.Exists(testAppsDir), "precondition: fresh cache must not already have this dir");
 
             var (exit, stderr) = Run(home, "provision", "--test-apps");
@@ -279,7 +292,7 @@ public sealed class ProvisionExplicitModesTests
                 $"provision --test-apps with no --bc-version must resolve the engine's own build. stderr:\n{stderr}");
             Assert.DoesNotContain("cannot determine which BC version to provision", stderr, StringComparison.Ordinal);
             Assert.True(Directory.Exists(testAppsDir),
-                $"expected {testAppsDir} (this binary's own engine build, {RealVersion}) to exist. stderr:\n{stderr}");
+                $"expected {testAppsDir} (this binary's own engine build, {ThisBuildsEngineVersion}) to exist. stderr:\n{stderr}");
             var apps = Directory.GetFiles(testAppsDir, "*.app");
             Assert.True(apps.Length > 10,
                 $"expected more than 10 .app files, got {apps.Length}: {string.Join(", ", apps.Select(Path.GetFileName))}");
@@ -311,14 +324,14 @@ public sealed class ProvisionExplicitModesTests
             "\"publisher\": \"Fixture\", \"version\": \"1.0.0.0\", \"application\": \"27.0.0.0\" }");
         try
         {
-            var testAppsDir = TestAppsDirFor(home); // RealVersion is major 28 — the ENGINE's major
+            var testAppsDir = TestAppsDirFor(home, ThisBuildsEngineVersion); // the ENGINE's own build, not the bundle's major 27
             Assert.False(Directory.Exists(testAppsDir), "precondition: fresh cache must not already have this dir");
 
             var (exit, stderr) = Run(home, "provision", "--test-apps", "--force", bundleDir);
 
             Assert.True(exit == 0, $"provision --test-apps must exit 0. stderr:\n{stderr}");
             Assert.True(Directory.Exists(testAppsDir),
-                $"expected {testAppsDir} (the engine's own major 28, not the bundle's major 27) to exist. stderr:\n{stderr}");
+                $"expected {testAppsDir} (the engine's own build {ThisBuildsEngineVersion}, not the bundle's major 27) to exist. stderr:\n{stderr}");
             var cacheRoot = TestArtifacts.StandardCacheDir(home);
             var versionDirs = Directory.Exists(cacheRoot)
                 ? Directory.GetDirectories(cacheRoot).Select(Path.GetFileName).ToArray()

--- a/AlRunner.Tests/ProvisionExplicitModesTests.cs
+++ b/AlRunner.Tests/ProvisionExplicitModesTests.cs
@@ -221,6 +221,118 @@ public sealed class ProvisionExplicitModesTests
     }
 
     /// <summary>
+    /// Issue #2208 secondary defect: a provisioning failure exited 1, the code the
+    /// documented exit ladder (`docs/server-mode.md`'s "Exit codes" section) reserves for
+    /// "at least one test failed" — but `provision` never runs a test, so that code lies
+    /// about what happened. A resolution failure here is an execution error (exit 2), the
+    /// same code every other "provisioning went wrong before a run could start" path uses
+    /// (see `BC version selection failed: ...` returning 2 elsewhere in Program.cs).
+    /// Exercises a real failure (a version prefix the public BC CDN index does not carry),
+    /// not a mocked one.
+    /// </summary>
+    [Fact]
+    public void ResolveVersion_NonexistentPrefix_ExitsExecutionErrorNotTestFailureCode()
+    {
+        var argLine = TestBuildConfig.RunArgs(Path.Combine(RepoRoot, "AlRunner"))
+            + " provision --resolve-version 999.9";
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            Arguments = argLine,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            WorkingDirectory = RepoRoot,
+        };
+        psi.Environment["HOME"] = NewIsolatedHome();
+        using var proc = Process.Start(psi)!;
+        var stderr = proc.StandardError.ReadToEnd();
+        Assert.True(proc.WaitForExit(30_000), "a nonexistent-prefix lookup must fail fast (one 404 index miss).");
+        Assert.Equal(2, proc.ExitCode);
+        Assert.Contains("could not resolve a full BC version for prefix '999.9'", stderr, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Issue #2208 defect 1: with no `--bc-version`, no engine DLL shipped in `bin/` (the
+    /// ordinary shadow-copy/re-exec layout — `EngineMajor(AppContext.BaseDirectory)` returns
+    /// null there), and no bundle argument, the resolver used to give up and print "cannot
+    /// determine which BC version to provision" even though the binary's own build version
+    /// (`BcArtifacts.EngineBuiltVersion()`, baked in at compile time — no file needed) answers
+    /// the question on every other code path ("selecting BC 28.1.49838.53910, the exact build
+    /// this binary was compiled against"). This test proves the fix resolves and downloads
+    /// into the canonical directory for THAT exact version — not merely that the process
+    /// doesn't crash.
+    /// </summary>
+    [Fact]
+    public void TestApps_NoBcVersionNoBundle_ResolvesEngineBuiltVersion()
+    {
+        var home = NewIsolatedHome();
+        try
+        {
+            var testAppsDir = TestAppsDirFor(home); // RealVersion == this build's _BCVersion
+            Assert.False(Directory.Exists(testAppsDir), "precondition: fresh cache must not already have this dir");
+
+            var (exit, stderr) = Run(home, "provision", "--test-apps");
+
+            Assert.True(exit == 0,
+                $"provision --test-apps with no --bc-version must resolve the engine's own build. stderr:\n{stderr}");
+            Assert.DoesNotContain("cannot determine which BC version to provision", stderr, StringComparison.Ordinal);
+            Assert.True(Directory.Exists(testAppsDir),
+                $"expected {testAppsDir} (this binary's own engine build, {RealVersion}) to exist. stderr:\n{stderr}");
+            var apps = Directory.GetFiles(testAppsDir, "*.app");
+            Assert.True(apps.Length > 10,
+                $"expected more than 10 .app files, got {apps.Length}: {string.Join(", ", apps.Select(Path.GetFileName))}");
+        }
+        finally
+        {
+            try { Directory.Delete(home, recursive: true); } catch { }
+        }
+    }
+
+    /// <summary>
+    /// Issue #2208 defect 2: given a bundle whose app.json declares a lower `application`
+    /// major than this binary's engine (a project's manifest floor, not the version to
+    /// provision against), the resolver used to derive the provisioning target FROM that
+    /// manifest field and silently fetch the wrong major's platform-apps set into a
+    /// directory the actual engine never scans. This proves the fix ignores the manifest
+    /// major for version SELECTION (a mismatch is a warning only) and still targets this
+    /// binary's own engine build — asserting on the concrete resulting directory name, not
+    /// just "some directory got created".
+    /// </summary>
+    [Fact]
+    public void TestApps_BundleDeclaresOlderMajor_StillTargetsEngineMajor()
+    {
+        var home = NewIsolatedHome();
+        var bundleDir = Path.Combine(Path.GetTempPath(), "al-runner-provision-explicit-bundle", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(bundleDir);
+        File.WriteAllText(Path.Combine(bundleDir, "app.json"),
+            "{ \"id\": \"11111111-1111-1111-1111-111111111111\", \"name\": \"Fixture\", " +
+            "\"publisher\": \"Fixture\", \"version\": \"1.0.0.0\", \"application\": \"27.0.0.0\" }");
+        try
+        {
+            var testAppsDir = TestAppsDirFor(home); // RealVersion is major 28 — the ENGINE's major
+            Assert.False(Directory.Exists(testAppsDir), "precondition: fresh cache must not already have this dir");
+
+            var (exit, stderr) = Run(home, "provision", "--test-apps", "--force", bundleDir);
+
+            Assert.True(exit == 0, $"provision --test-apps must exit 0. stderr:\n{stderr}");
+            Assert.True(Directory.Exists(testAppsDir),
+                $"expected {testAppsDir} (the engine's own major 28, not the bundle's major 27) to exist. stderr:\n{stderr}");
+            var cacheRoot = TestArtifacts.StandardCacheDir(home);
+            var versionDirs = Directory.Exists(cacheRoot)
+                ? Directory.GetDirectories(cacheRoot).Select(Path.GetFileName).ToArray()
+                : Array.Empty<string?>();
+            Assert.DoesNotContain(versionDirs, d => d != null && d.StartsWith("27.", StringComparison.Ordinal));
+        }
+        finally
+        {
+            try { Directory.Delete(home, recursive: true); } catch { }
+            try { Directory.Delete(bundleDir, recursive: true); } catch { }
+        }
+    }
+
+    /// <summary>
     /// Negative: `--platform-apps` (and its siblings) only make sense under the `provision`
     /// subcommand — a plain test run has no use for them. Rejected up front rather than
     /// silently accepted-and-ignored, which would look like support that isn't there.

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -7092,6 +7092,11 @@ static string? TryDeriveBcMajorFromProject(IEnumerable<string> bundlePaths)
 static int RunExplicitProvisionModes(string? bcVersionArg, List<string> bundles,
     bool platformApps, bool testApps, bool serviceTier, bool force, string? resolveVersionPrefix)
 {
+    // #2208: every failure return below is 2 ("execution error"), never 1. `provision`
+    // does not run a single test, so 1 — the documented exit ladder's "at least one test
+    // failed or errored" — would be a lie about what happened here; 2 is what every other
+    // "couldn't get to a run at all" path in this file already uses (e.g. "BC version
+    // selection failed: ..." further up).
     if (resolveVersionPrefix != null)
     {
         var resolved = AlRunner.Provisioning.ArtifactDownloader.ResolveVersion(
@@ -7099,7 +7104,7 @@ static int RunExplicitProvisionModes(string? bcVersionArg, List<string> bundles,
         if (resolved == null)
         {
             Console.Error.WriteLine($"[provision] could not resolve a full BC version for prefix '{resolveVersionPrefix}'.");
-            return 1;
+            return 2;
         }
         Console.WriteLine(resolved); // stdout for script/agent consumption, mirrors tools/DownloadArtifacts
         return 0;
@@ -7107,7 +7112,7 @@ static int RunExplicitProvisionModes(string? bcVersionArg, List<string> bundles,
 
     var full = ResolveFullVersionForExplicitProvision(bcVersionArg, bundles);
     if (full == null)
-        return 1; // the resolver already printed a loud, named reason
+        return 2; // the resolver already printed a loud, named reason
 
     bool anyFailed = false;
     if (serviceTier)
@@ -7129,7 +7134,7 @@ static int RunExplicitProvisionModes(string? bcVersionArg, List<string> bundles,
         anyFailed |= ForceProvisionMode("Microsoft test-toolkit apps", dir, full, force, "*.app",
             (v, d, log) => AlRunner.Provisioning.ArtifactDownloader.TestApps(v, d, log)) != 0;
     }
-    return anyFailed ? 1 : 0;
+    return anyFailed ? 2 : 0;
 }
 
 // Shared by every explicit provision mode: skip the download when the canonical directory
@@ -7160,27 +7165,83 @@ static int ForceProvisionMode(string label, string outputDir, string fullVersion
     }
 }
 
+// Issue #2208: shared by ResolveFullVersionForExplicitProvision and RunProvisioning's own
+// no-`--bc-version` branch. Resolves the version to target from the ENGINE's own build —
+// matching the run path's default selection (#2077) — rather than the project's app.json,
+// which states a floor ("application": "27.0.0.0") and not the version to provision
+// against. `BcArtifacts.EngineMajor(AppContext.BaseDirectory)` (the OLD source both call
+// sites used) requires `Microsoft.Dynamics.Nav.Ncl.dll` to be physically present in bin/,
+// which is FALSE in the ordinary shadow-copy/re-exec install layout — so it silently
+// returned null and both callers fell through past the engine entirely, either giving up
+// ("cannot determine which BC version to provision" despite the binary printing the exact
+// build on every other code path) or deriving the major from whichever bundle happened to
+// be on the command line, downloading a completely different major's artifact set.
+// `BcArtifacts.EngineBuiltVersion()` is baked in at compile time (an AssemblyMetadata
+// attribute) and needs nothing on disk, so it answers the question unconditionally.
+// Returns null only when the engine's build version is genuinely unknown (a stripped/older
+// binary with neither the attribute nor a shipped Ncl.dll) or the artifacts root itself
+// can't be resolved — the caller falls back to prefix-based resolution in that case.
+static string? ResolveDefaultProvisionVersion(List<string> bundles, Action<string> log)
+{
+    var engineVersion = AlRunner.Infrastructure.BcArtifacts.EngineBuiltVersion()
+        ?? AlRunner.Infrastructure.BcArtifacts.EngineVersion(AppContext.BaseDirectory);
+    if (engineVersion == null)
+        return null;
+
+    string full;
+    string tier;
+    try
+    {
+        full = AlRunner.Infrastructure.BcArtifacts.DefaultProvisionTarget(
+            engineVersion, AlRunner.Infrastructure.BcArtifacts.ArtifactsRootDir, out tier, log);
+    }
+    catch (InvalidOperationException)
+    {
+        return null; // ArtifactsRootDir unresolvable — caller falls back to prefix-based resolution
+    }
+    log($"no --bc-version given — targeting BC {full} (this binary's own engine build is " +
+        $"{engineVersion}; tier '{tier}'). Override with --bc-version.");
+
+    // The project's app.json is a CROSS-CHECK only, never the source of the answer — see
+    // the doc comment above. A mismatch is surfaced as a warning, not acted on.
+    var projMajor = TryDeriveBcMajorFromProject(bundles);
+    if (projMajor != null && projMajor != engineVersion.Major.ToString())
+        log($"warning: project app.json targets BC major {projMajor} but this runner build's " +
+            $"engine is major {engineVersion.Major} (cross-major needs a matching runner build).");
+    return full;
+}
+
 // Resolves the full 4-part BC version to target for an EXPLICIT provision mode
 // (--platform-apps/--test-apps/--service-tier). Deliberately mirrors RunProvisioning's own
-// resolution (explicit --bc-version, else the engine's own major, else the target bundle's
-// app.json major; prefer an already-cached matching version, else resolve the latest full
-// version from the CDN) — kept as a separate small function rather than sharing
-// RunProvisioning's inline block because that block's own success message ("verifying
-// completeness") describes what RunProvisioning does NEXT (an engine-closure completeness
-// check), which does not apply here.
+// resolution (explicit --bc-version, else the engine's own build via
+// ResolveDefaultProvisionVersion, else the target bundle's app.json major as a last
+// resort; prefer an already-cached matching version, else resolve the latest full version
+// from the CDN) — kept as a separate small function rather than sharing RunProvisioning's
+// inline block because that block's own success message ("verifying completeness")
+// describes what RunProvisioning does NEXT (an engine-closure completeness check), which
+// does not apply here.
 static string? ResolveFullVersionForExplicitProvision(string? bcVersionArg, List<string> bundles)
 {
     if (bcVersionArg != null && System.Version.TryParse(bcVersionArg, out var maybeFull) && maybeFull.Revision >= 0
         && bcVersionArg.Split('.').Length == 4)
         return bcVersionArg; // an explicit 4-part version — target exactly that
 
-    var prefix = bcVersionArg
-        ?? AlRunner.Infrastructure.BcArtifacts.EngineMajor(AppContext.BaseDirectory)?.ToString()
-        ?? TryDeriveBcMajorFromProject(bundles);
+    void Log(string m) => Console.Error.WriteLine($"[provision] {m}");
+
+    if (bcVersionArg == null)
+    {
+        var fromEngine = ResolveDefaultProvisionVersion(bundles, Log);
+        if (fromEngine != null)
+            return fromEngine;
+    }
+
+    // Last resort: the engine's build version is genuinely unknown — fall back to the
+    // project's app.json major (or an explicit bare-major --bc-version).
+    var prefix = bcVersionArg ?? TryDeriveBcMajorFromProject(bundles);
     if (prefix == null)
     {
-        Console.Error.WriteLine("[provision] cannot determine which BC version to provision — pass " +
-            "--bc-version <ver> (no --bc-version, no engine in bin, and no readable project app.json).");
+        Log("cannot determine which BC version to provision — pass --bc-version <ver> " +
+            "(no --bc-version, no engine build info, and no readable project app.json).");
         return null;
     }
     try
@@ -7188,15 +7249,15 @@ static string? ResolveFullVersionForExplicitProvision(string? bcVersionArg, List
         var cachedDir = AlRunner.Infrastructure.BcArtifacts.SelectArtifactVersionDir(
             AlRunner.Infrastructure.BcArtifacts.ArtifactsRootDir, prefix);
         var full = Path.GetFileName(cachedDir);
-        Console.Error.WriteLine($"[provision] found cached BC {full} for prefix '{prefix}'.");
+        Log($"found cached BC {full} for prefix '{prefix}'.");
         return full;
     }
     catch (InvalidOperationException)
     {
-        Console.Error.WriteLine($"[provision] no cached BC {prefix}.x — resolving latest full version from the CDN...");
+        Log($"no cached BC {prefix}.x — resolving latest full version from the CDN...");
         var full = AlRunner.Provisioning.ArtifactDownloader.ResolveVersion(prefix);
         if (full == null)
-            Console.Error.WriteLine($"[provision] could not resolve a full BC version for prefix '{prefix}'.");
+            Log($"could not resolve a full BC version for prefix '{prefix}'.");
         return full;
     }
 }
@@ -7245,14 +7306,21 @@ static int RunProvisioning(string? bcVersionArg, string? artifactPathArg,
     }
     else
     {
+        // #2208: EngineMajor(AppContext.BaseDirectory) requires Ncl.dll to be physically
+        // present in bin/, which is false in the ordinary shadow-copy/re-exec layout — use
+        // the compile-time-baked EngineBuiltVersion() (falling back to EngineVersion, same
+        // as the run path's own default selection, #2077) so this branch answers the same
+        // question the same way instead of falling straight through to the project's
+        // app.json, which states a floor, not the version to provision against.
         var prefix = bcVersionArg
-            ?? AlRunner.Infrastructure.BcArtifacts.EngineMajor(AppContext.BaseDirectory)?.ToString()
+            ?? (AlRunner.Infrastructure.BcArtifacts.EngineBuiltVersion()
+                ?? AlRunner.Infrastructure.BcArtifacts.EngineVersion(AppContext.BaseDirectory))?.Major.ToString()
             ?? TryDeriveBcMajorFromProject(bundles);
         if (prefix == null)
         {
             Console.Error.WriteLine("[provision] cannot determine which BC version to provision — pass " +
-                "--bc-version <ver> (no --bc-version, no engine in bin, and no readable project app.json).");
-            return 1;
+                "--bc-version <ver> (no --bc-version, no engine build info, and no readable project app.json).");
+            return 2; // execution error, not "test failure" — no tests ran (#2208)
         }
         // Prefer an already-cached version matching the prefix (completes a partial one);
         // otherwise resolve the latest full version from the public CDN index.
@@ -7276,7 +7344,7 @@ static int RunProvisioning(string? bcVersionArg, string? artifactPathArg,
             if (full == null)
             {
                 Console.Error.WriteLine($"[provision] could not resolve a full BC version for prefix '{prefix}'.");
-                return 1;
+                return 2; // execution error, not "test failure" — no tests ran (#2208)
             }
         }
     }


### PR DESCRIPTION
Closes #2208

## What was wrong

`provision --platform-apps`/`--test-apps`/`--service-tier` resolved the target
BC version differently — and worse — than every other code path in the
runner:

1. With no `--bc-version`, the resolver called
   `BcArtifacts.EngineMajor(AppContext.BaseDirectory)`, which needs
   `Microsoft.Dynamics.Nav.Ncl.dll` physically present in `bin/`. That is false
   in the ordinary shadow-copy/re-exec install layout, so it returned null and
   the resolver gave up with `"cannot determine which BC version to
   provision"` — even though the binary's own build version is printed on
   every other code path (`"selecting BC 28.1.49838.53910, the exact build
   this binary was compiled against"`).
2. Given a bundle argument instead, the resolver fell through to
   `TryDeriveBcMajorFromProject`, deriving the target from the app.json
   `application` field — a floor the project declares, not the version to
   provision against. A 28.1-engine binary run against a bundle declaring
   `"application": "27.0.0.0"` silently downloaded BC 27.5's ~116MB
   platform-apps set into a directory the 28.1 engine never scans.

## Fix

Both call sites (`ResolveFullVersionForExplicitProvision` for the explicit
`--platform-apps`/`--test-apps`/`--service-tier` modes, and `RunProvisioning`'s
own no-`--bc-version` branch) now resolve from
`BcArtifacts.EngineBuiltVersion()` first — baked in at compile time, needs
nothing on disk — via the same `DefaultProvisionTarget` cache-then-CDN tiered
resolver the run path already uses (#2077). The project's app.json is
consulted only as a mismatch *warning* afterward, never as the source of the
answer.

Also fixed the exit code: a provisioning failure under the `provision`
subcommand returned `1`, the code the documented ladder
(`docs/server-mode.md`) reserves for "at least one test failed" — but
`provision` never runs a test. Failures there now return `2` (execution
error), matching every other "couldn't get to a run at all" path in
`Program.cs`.

## Fix the shape, not just the reported line

- **Same wrong pattern elsewhere?** Yes — `RunProvisioning`'s own no-`--bc-version`
  branch (used by the bare `provision` subcommand and reachable when the
  artifacts root is unresolvable before this point in the flow) had the exact
  same `EngineMajor(bin)` mistake and the same `return 1` exit code. Fixed
  both, and extracted the engine-version-first resolution into a shared
  `ResolveDefaultProvisionVersion` helper so the two call sites can't diverge
  again.
- **Sibling function, same assumption?** `RunExplicitProvisionModes`'s
  `--resolve-version` branch had the same `return 1` on failure; fixed to `2`
  for consistency (own test added).
- **Two paths, one invariant?** The run path's own default-selection block
  (`#2077`) already got this right (engine-first, project-as-cross-check-only);
  this PR makes the explicit-provision path agree with it instead of
  re-deriving the answer independently and worse.

## Tests

Added to `AlRunner.Tests/ProvisionExplicitModesTests.cs` (spawns the real
binary against a hermetically empty, isolated `$HOME`, real CDN calls — same
pattern the file already uses):

- `TestApps_NoBcVersionNoBundle_ResolvesEngineBuiltVersion` — RED before the
  fix (`"cannot determine..."`, exit 1); GREEN after, asserting the real
  content landed in the exact `28.1.49838.53910/test-apps` directory (this
  build's own `_BCVersion`).
- `TestApps_BundleDeclaresOlderMajor_StillTargetsEngineMajor` — RED before the
  fix (measured: it actually downloaded 103 apps into a `27.5.46862.53931`
  directory); GREEN after, asserting no `27.*` version directory was created
  at all.
- `ResolveVersion_NonexistentPrefix_ExitsExecutionErrorNotTestFailureCode` —
  proves the exit-code fix against a real CDN 404 for a nonexistent version
  prefix.

All 3 confirmed RED against pre-fix code (including the wrong-major download
actually happening), then GREEN after the fix. Full
`ProvisionExplicitModesTests` suite (8 tests) and the broader
provisioning/BcArtifact/AutoProvision suites (123 tests total) pass locally.