### PR TITLE
Make --verbose actually print the AL diagnostics behind an EMIT-EXCLUDED

### DIFF
--- a/AlRunner.Tests/EmitExclusionLoudnessTests.cs
+++ b/AlRunner.Tests/EmitExclusionLoudnessTests.cs
@@ -36,10 +36,11 @@ public sealed class EmitExclusionLoudnessTests
     private static readonly string FixturePath = Path.Combine(
         RepoRoot, "AlRunner.Tests", "Fixtures", "EmitExclusion");
 
-    private static (string Output, int Exit) RunRunner()
+    private static (string Output, int Exit) RunRunner(bool verbose = false)
     {
         var args = new StringBuilder(TestBuildConfig.RunArgs(ProjectPath));
         args.Append(TestBuildConfig.BcVersionArg);
+        if (verbose) args.Append(" --verbose");
         args.Append($" \"{FixturePath}\"");
         var psi = new ProcessStartInfo
         {
@@ -86,6 +87,52 @@ public sealed class EmitExclusionLoudnessTests
         // And the report must say that tests went missing, since that is the consequence
         // a reader has to understand.
         Assert.Contains("MISSING", output, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Issue #2207: the EMIT-EXCLUDED message tells the user to "Re-run with --verbose for
+    /// the AL diagnostics that identified them." Passing --verbose must actually produce the
+    /// AL compiler diagnostic (AL0185, "Codeunit '...' is missing") that explains WHY
+    /// "Emit Excl Broken" could not bind — not just the same summary line again. Before the
+    /// fix, BcCompiler's emit-retry loop discarded the identifying diagnostics once the
+    /// retry against the surviving objects succeeded, so re-running with --verbose printed
+    /// nothing new — the exact defect this test proves fixed.
+    /// </summary>
+    [SkippableFact]
+    public void ExcludedObject_Verbose_PrintsTheIdentifyingAlDiagnostic()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var (output, exit) = RunRunner(verbose: true);
+
+        Assert.True(exit != 0, $"exclusion must still fail the run under --verbose. exit={exit}\n{output}");
+        Assert.Contains("EMIT-EXCLUDED", output, StringComparison.Ordinal);
+
+        // The specific AL diagnostic that caused the exclusion — not just the object's name
+        // (already asserted by the non-verbose test above) and not just the crash's internal
+        // BC-emitter text ("Unexpected value 'None' of type 'NavTypeKind'"), which names an
+        // implementation detail, not the AL-level cause a developer can act on.
+        Assert.Contains("AL0185", output, StringComparison.Ordinal);
+        Assert.Contains("This Codeunit Does Not Exist At All", output, StringComparison.Ordinal);
+        Assert.Contains("BrokenObject.Codeunit.al", output, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Negative direction for the test above: at DEFAULT verbosity the diagnostic must stay
+    /// out of the output (the summary line alone is the promise; printing it unconditionally
+    /// would defeat the point of gating it behind --verbose at all), while the object name
+    /// and "MISSING" framing from the non-verbose test still show up.
+    /// </summary>
+    [SkippableFact]
+    public void ExcludedObject_DefaultVerbosity_OmitsTheAlDiagnostic()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var (output, exit) = RunRunner(verbose: false);
+
+        Assert.True(exit != 0, $"exit={exit}\n{output}");
+        Assert.Contains("EMIT-EXCLUDED", output, StringComparison.Ordinal);
+        Assert.DoesNotContain("AL0185", output, StringComparison.Ordinal);
     }
 
     /// <summary>

--- a/AlRunner.Tests/ServerEmitExclusionDiagnosticTests.cs
+++ b/AlRunner.Tests/ServerEmitExclusionDiagnosticTests.cs
@@ -1,0 +1,108 @@
+// Issue #2207 — server-mode sibling of EmitExclusionLoudnessTests.
+//
+// --server's EMIT-EXCLUDED compileErrors path already branched on "do we have the AL
+// diagnostics that identified the excluded object(s)?" (Program.cs, RunBundleForServer),
+// but the branch was dead code: it read `alDiagnostics`, which BcCompiler's emit-retry
+// loop only ever populated from the FINAL (successfully recovered) compile round — by
+// construction empty once the retry against the surviving objects succeeds. So every
+// server-mode exclusion fell into the "Re-run with --verbose" fallback message, over a
+// wire protocol that has no --verbose to re-run with at all.
+//
+// The fix threads BcEmitOutput's new ExcludedObjectDiagnostics field (populated
+// unconditionally, not gated on --tdd) through instead — this proves the wire response
+// actually carries the identifying AL diagnostic (AL0185), not just the generic count.
+using System.Text.Json;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class ServerEmitExclusionDiagnosticTests
+{
+    private static string WriteBundle()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "al-runner-server-emitexcl-2207", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        File.WriteAllText(Path.Combine(root, "app.json"), """
+        {
+          "id": "f5555555-5555-5555-5555-555555555555",
+          "name": "Server Emit Exclusion Diagnostic Test",
+          "publisher": "Repro2207",
+          "version": "1.0.0.0",
+          "dependencies": [],
+          "platform": "1.0.0.0",
+          "application": "1.0.0.0",
+          "idRanges": [ { "from": 62230, "to": 62239 } ],
+          "runtime": "14.0"
+        }
+        """);
+        // Mirrors AlRunner.Tests/Fixtures/EmitExclusion/BrokenObject.Codeunit.al: a
+        // reference to a codeunit that exists nowhere, so BC's Compilation.Emit crashes
+        // on this object specifically and BcCompiler's retry loop excludes it.
+        File.WriteAllText(Path.Combine(root, "Broken.Codeunit.al"), """
+        codeunit 62230 "Srv Emit Excl Broken"
+        {
+            Subtype = Test;
+
+            [Test]
+            procedure Broken_NeverRuns()
+            var
+                Missing: Codeunit "This Server Codeunit Does Not Exist Either";
+            begin
+                Missing.DoSomething();
+            end;
+        }
+        """);
+        File.WriteAllText(Path.Combine(root, "Healthy.Codeunit.al"), """
+        codeunit 62231 "Srv Emit Excl Healthy"
+        {
+            Subtype = Test;
+
+            [Test]
+            procedure Healthy_StillRuns()
+            begin
+            end;
+        }
+        """);
+        return root;
+    }
+
+    private static string Req(string bundle) => JsonSerializer.Serialize(new
+    {
+        command = "runTests",
+        sourcePaths = new[] { bundle },
+        packagePaths = Array.Empty<string>(),
+    });
+
+    [SkippableFact]
+    public async Task RunTests_ExcludedObject_CompilationErrorsCarryTheIdentifyingAlDiagnostic()
+    {
+        TestArtifacts.SkipIfMissing();
+        var bundle = WriteBundle();
+        try
+        {
+            await using var server = await CliServer.StartAsync();
+            var lines = await server.SendRequestStreamingAsync(Req(bundle), TimeSpan.FromSeconds(180));
+            var (_, d) = ProtocolV2Streaming.Split(lines);
+
+            Assert.NotEqual(0, d.GetProperty("exitCode").GetInt32());
+            Assert.True(d.TryGetProperty("compilationErrors", out var compileErrors),
+                $"expected compilationErrors on an EMIT-EXCLUDED failure: {string.Join(" | ", lines)}");
+            var allErrorText = string.Join(" | ", compileErrors.EnumerateArray()
+                .SelectMany(g => g.GetProperty("errors").EnumerateArray().Select(e => e.GetString())));
+
+            Assert.Contains("EMIT-EXCLUDED", allErrorText);
+            // Would still pass if the fix were a no-op that just always claimed success —
+            // assert the SPECIFIC diagnostic that identifies WHY the object was excluded,
+            // not merely that some compile error text is present.
+            Assert.Contains("AL0185", allErrorText);
+            Assert.Contains("This Server Codeunit Does Not Exist Either", allErrorText);
+            // The dead "re-run with --verbose" fallback must not appear once the real
+            // diagnostics are actually available — a server client has no CLI to re-run.
+            Assert.DoesNotContain("Re-run with --verbose", allErrorText);
+        }
+        finally
+        {
+            try { Directory.Delete(bundle, recursive: true); } catch { }
+        }
+    }
+}

--- a/AlRunner/BcCompiler.cs
+++ b/AlRunner/BcCompiler.cs
@@ -83,7 +83,17 @@ public sealed record BcEmitOutput(
     // excluded (a wrong guess still shows up here — see TddGeneration.cs's header for why
     // that's fine: the object's own exclusion is what catches a bad guess, not this list).
     // Null (not merely empty) when not in --tdd mode — same discipline as TddExcludedDetails.
-    IReadOnlyList<TddGeneratedMember>? TddGeneratedMembers = null);
+    IReadOnlyList<TddGeneratedMember>? TddGeneratedMembers = null,
+    // Issue #2207: the AL diagnostics that identified EACH object ExcludedObjects names —
+    // e.g. AL0185 "Codeunit 'X' is missing" — always populated (unlike TddExcludedDetails,
+    // this is NOT gated on --tdd mode). Deliberately separate from `Diagnostics` above,
+    // which reflects only the FINAL (possibly-recovered) compile round and backs the
+    // EMIT-ZERO / AL-DIAGNOSTIC-FAIL guards in Program.cs — folding these into `Diagnostics`
+    // instead made those guards misfire for a successful --tdd exclusion recovery (sources
+    // non-empty by design there, Diagnostics now non-empty too) and wipe the recovered
+    // sources it depends on. This is what the EMIT-EXCLUDED / TDD-EXCLUDED messages'
+    // "re-run with --verbose" promise actually surfaces.
+    IReadOnlyList<string>? ExcludedObjectDiagnostics = null);
 
 public sealed partial class BcCompiler
 {
@@ -1706,6 +1716,17 @@ public sealed partial class BcCompiler
         // BcEmitOutput.TddExcludedDetails is null on the default path exactly as before
         // this issue — no behavioural difference for a non-tdd caller.
         var tddDetails = _tddMode ? new List<TddExcludedObjectDetail>() : null;
+        // Issue #2207: the SAME per-object diagnostics tddDetails captures above, but
+        // ALWAYS collected (not gated on --tdd) and folded into the returned `alDiags`
+        // below. Before this, the non-tdd path's EMIT-EXCLUDED message told the user to
+        // "re-run with --verbose for the AL diagnostics that identified them" — but
+        // nothing ever captured those diagnostics outside --tdd mode: by the time the
+        // retry against the surviving objects succeeds, `compilation`/`emitResult` have
+        // been reassigned to the smaller retry's (clean) result, so the diagnostics that
+        // explained the ORIGINAL failure are gone with no `??` fallback that could
+        // recover them. Re-running with --verbose printed the same summary line again —
+        // this list, and `originalDeclErrors` below, are what make the promise true.
+        var excludedObjectDiagnosticsList = new List<string>();
         {
             const int maxRounds = 10;
             // Indices are always relative to the ORIGINAL alFiles/trees arrays (captured once,
@@ -1713,6 +1734,16 @@ public sealed partial class BcCompiler
             // indexing with original-file indices would silently misalign the two and blow up
             // with an IndexOutOfRangeException on the second round onward.
             var originalTrees = trees;
+            // The declaration diagnostics of the FULL, pre-exclusion compilation — e.g. AL0185
+            // "Codeunit 'X' is missing" for a reference that cannot bind. This is the actual
+            // AL-level cause a developer can act on; the crash-branch fallback below (BC's raw
+            // AggregateException text, e.g. "Unexpected value 'None' of type 'NavTypeKind'")
+            // names an internal emitter detail, not the AL problem. Computed once, up front,
+            // because later rounds reassign `compilation` to the smaller retry compilation,
+            // which no longer contains the excluded file's tree at all.
+            var originalDeclErrors = compilation.GetDeclarationDiagnostics()
+                .Where(d => d.Severity == NavDiag.DiagnosticSeverity.Error && d.Location.IsInSource)
+                .ToList();
             var keepIdx = Enumerable.Range(0, alFiles.Count).ToList();
             var allExcluded = excludedObjects;
             int round = 0;
@@ -1747,13 +1778,21 @@ public sealed partial class BcCompiler
                         {
                             var label = $"{hit.Type} {hit.Namespace}.\"{hit.Name}\"";
                             roundExcluded.Add(label);
-                            // No structured Location for an emitter-crash exclusion — only the
-                            // exception's own message names it. Still useful for a --tdd
-                            // synthetic failure: it says WHICH object and WHY, even without a
-                            // path@line:col anchor.
-                            tddDetails?.Add(new TddExcludedObjectDetail(
-                                alFiles[i], label,
-                                new[] { $"emit-crash: {label} — {caught.Message.Split('\n', 2)[0]}" }));
+                            // Prefer the original compilation's OWN declaration diagnostics for
+                            // this file (e.g. AL0185 "Codeunit 'X' is missing") — a real,
+                            // path@line:col-anchored AL error a developer can act on. Only fall
+                            // back to the emitter-crash exception text (an internal detail, e.g.
+                            // "Unexpected value 'None' of type 'NavTypeKind'") when the crash
+                            // left no corresponding declaration diagnostic behind at all.
+                            var declDiagsForFile = originalDeclErrors
+                                .Where(d => d.Location.SourceTree == originalTrees[i])
+                                .Select(d => $"{d.Location}: error {d.Id}: {d.GetMessage().Split('\n', 2)[0]}")
+                                .ToList();
+                            var diagsForThisObject = declDiagsForFile.Count > 0
+                                ? declDiagsForFile
+                                : new List<string> { $"emit-crash: {label} — {caught.Message.Split('\n', 2)[0]}" };
+                            excludedObjectDiagnosticsList.AddRange(diagsForThisObject);
+                            tddDetails?.Add(new TddExcludedObjectDetail(alFiles[i], label, diagsForThisObject));
                         }
                         else
                             nextKeepIdx.Add(i);
@@ -1781,16 +1820,14 @@ public sealed partial class BcCompiler
                         {
                             var label = Path.GetFileNameWithoutExtension(alFiles[i]);
                             roundExcluded.Add(label);
-                            if (tddDetails != null)
-                            {
-                                var objDiags = emitResult.Diagnostics
-                                    .Where(d => d.Severity == NavDiag.DiagnosticSeverity.Error
-                                        && d.Location.IsInSource
-                                        && d.Location.SourceTree == originalTrees[i])
-                                    .Select(d => $"{d.Location}: error {d.Id}: {d.GetMessage().Split('\n', 2)[0]}")
-                                    .ToList();
-                                tddDetails.Add(new TddExcludedObjectDetail(alFiles[i], label, objDiags));
-                            }
+                            var objDiags = emitResult.Diagnostics
+                                .Where(d => d.Severity == NavDiag.DiagnosticSeverity.Error
+                                    && d.Location.IsInSource
+                                    && d.Location.SourceTree == originalTrees[i])
+                                .Select(d => $"{d.Location}: error {d.Id}: {d.GetMessage().Split('\n', 2)[0]}")
+                                .ToList();
+                            excludedObjectDiagnosticsList.AddRange(objDiags);
+                            tddDetails?.Add(new TddExcludedObjectDetail(alFiles[i], label, objDiags));
                         }
                         else
                             nextKeepIdx.Add(i);
@@ -1961,6 +1998,19 @@ public sealed partial class BcCompiler
                 // No per-object breakdown in the message — surface the raw emit failure.
                 alDiags.Add($"emit-crash: {caught.GetType().Name}: {caught.Message.Split('\n', 2)[0]}");
         }
+        // Issue #2207: deliberately NOT folded into `alDiags` above. `alDiags` feeds the
+        // pre-existing EMIT-ZERO / AL-DIAGNOSTIC-FAIL guards in Program.cs, both gated on
+        // "sources.Count == 0" / "sources.Count > 0" combined with "alDiags.Count > 0" —
+        // guards that must keep meaning exactly what they meant before this issue: whether
+        // the FINAL (possibly-recovered) compile round itself still carries an unexplained
+        // or a ContinueBuildOnError-surviving diagnostic. Mixing the exclusion diagnostics
+        // in unconditionally made AL-DIAGNOSTIC-FAIL fire for every successfully-recovered
+        // --tdd exclusion (sources non-empty by design there, and now alDiags non-empty too)
+        // and wipe the recovered sources it depends on — a real regression caught by
+        // TddModeTests turning exit 1 (red test) into exit 3 (compile failure). Returned as
+        // its own field instead, so a caller that wants "what explained the exclusion" reads
+        // this, and the pre-existing guards keep reading `Diagnostics` exactly as before.
+        var excludedObjectDiagnostics = excludedObjectDiagnosticsList.Distinct().ToList();
 
         // ── Bundle query-symbol registration ────────────────────────────────────
         // Source-compiled queries (no prebuilt .app in the bundle root) have no
@@ -2004,7 +2054,7 @@ public sealed partial class BcCompiler
 
         var emitOutput = new BcEmitOutput(
             outputter.Captured, alDiags, excludedObjects, tddDetails,
-            _tddMode ? tddGeneratedMembers : null);
+            _tddMode ? tddGeneratedMembers : null, excludedObjectDiagnostics);
 
         // #1902: only a CLEAN success (nothing excluded, every source captured) is trustworthy
         // as a RAD baseline — a module that only compiled after dropping broken objects must

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -2506,6 +2506,19 @@ foreach (var bundle in bundles)
                                 $"object(s) could not be compiled: [{names}]. {synthetic.Count} [Test] " +
                                 $"procedure(s) they declare report as FAILED instead of vanishing from the run. " +
                                 $"Re-run with --verbose for the AL diagnostics that identified them.");
+                            // #2207: same fix as the non-tdd branch below — actually print
+                            // them under --verbose. Each synthetic FAILED test already carries
+                            // its own object's diagnostic in its failure message, but that
+                            // requires reading the per-test result; this gives the same
+                            // information right at the summary line the message above points at.
+                            var tddExclDiags = emitOutput.ExcludedObjectDiagnostics ?? Array.Empty<string>();
+                            if (AlRunner.Log.Verbose && tddExclDiags.Count > 0)
+                            {
+                                Console.Error.WriteLine(
+                                    $"<bundled>: AL diagnostics that identified the excluded object(s):");
+                                foreach (var d in tddExclDiags)
+                                    Console.Error.WriteLine($"  {d}");
+                            }
                             bundleTests.AddRange(synthetic);
                             tddExcludedCount = emitOutput.ExcludedObjects.Count;
                             // sources stays as BcCompiler returned it (the recovered set) — do
@@ -2520,6 +2533,24 @@ foreach (var bundle in bundles)
                                 $"could not be compiled and were dropped from the module, so any tests they declare " +
                                 $"are MISSING from this run: [{names}]. Re-run with --verbose for the AL diagnostics " +
                                 $"that identified them.");
+                            // #2207: the message above promises the AL diagnostics under
+                            // --verbose — actually print them, gated on Log.Verbose directly
+                            // (not Console.Error.WriteLine's usual [Component] path) so a
+                            // developer following the instruction gets something, not another
+                            // copy of the same summary line. Deliberately reads
+                            // emitOutput.ExcludedObjectDiagnostics, NOT `alDiagnostics` — the
+                            // latter reflects only the final (recovered) compile round and
+                            // backs the EMIT-ZERO / AL-DIAGNOSTIC-FAIL guards below; it is
+                            // formatted alc-style with no leading `[Tag]`, so it is never eaten
+                            // by Log's filter either way.
+                            var exclDiags = emitOutput.ExcludedObjectDiagnostics ?? Array.Empty<string>();
+                            if (AlRunner.Log.Verbose && exclDiags.Count > 0)
+                            {
+                                Console.Error.WriteLine(
+                                    $"<bundled>: AL diagnostics that identified the excluded object(s):");
+                                foreach (var d in exclDiags)
+                                    Console.Error.WriteLine($"  {d}");
+                            }
                             bundleErrors.Add(
                                 $"<bundled>: EMIT-EXCLUDED for {moduleName}: {emitOutput.ExcludedObjects.Count} " +
                                 $"object(s) dropped from the module — tests they declare are missing: [{names}].");
@@ -3626,6 +3657,7 @@ return strictExitCode ? computedExitCode : 0;
                 IReadOnlyList<EmittedSource> sources;
                 IReadOnlyList<string> alDiagnostics;
                 IReadOnlyList<string> excludedObjects;
+                IReadOnlyList<string> excludedObjectDiagnostics;
                 var et = System.Diagnostics.Stopwatch.StartNew();
                 try
                 {
@@ -3633,6 +3665,7 @@ return strictExitCode ? computedExitCode : 0;
                     sources = emitOutput.Sources;
                     alDiagnostics = emitOutput.Diagnostics;
                     excludedObjects = emitOutput.ExcludedObjects;
+                    excludedObjectDiagnostics = emitOutput.ExcludedObjectDiagnostics ?? Array.Empty<string>();
                 }
                 catch (Exception ex)
                 {
@@ -3653,13 +3686,17 @@ return strictExitCode ? computedExitCode : 0;
                 if (excludedObjects.Count > 0)
                 {
                     var names = string.Join(", ", excludedObjects);
+                    // #2207: read the dedicated ExcludedObjectDiagnostics field, not
+                    // `alDiagnostics` — the latter reflects only the final (recovered)
+                    // compile round, which by construction has none of its own left once
+                    // BcCompiler's retry against the surviving objects has succeeded.
                     compileErrors.Add(
                         $"EMIT-EXCLUDED: {excludedObjects.Count} object(s) dropped from the module — " +
                         $"tests they declare are missing: [{names}]." +
-                        (alDiagnostics.Count > 0
+                        (excludedObjectDiagnostics.Count > 0
                             ? " The AL diagnostics that identified them follow."
                             : " Re-run with --verbose for the AL diagnostics that identified them."));
-                    foreach (var d in alDiagnostics) compileErrors.Add(d);
+                    foreach (var d in excludedObjectDiagnostics) compileErrors.Add(d);
                     return new ServerRunResult(Array.Empty<TestResult>(), 3, false,
                         new List<CompilationErrorGroup> { new(moduleName, compileErrors) }, fileHashes);
                 }


### PR DESCRIPTION
mise ~/.config/mise/config.toml tools: gh@2.98.0
Closes #2207

## The bug

EMIT-EXCLUDED tells the user to re-run with `--verbose` to see the AL diagnostics that identified the excluded object. Nothing printed one, because nothing ever captured them outside `--tdd` mode: `BcCompiler`'s emit-retry loop reassigns its `compilation`/`emitResult` variables to the successful retry round once recovery succeeds, so the diagnostics that explained the original failure were gone by the time `Program.cs` looked for them under `--verbose`.

## The fix

- `BcCompiler.cs` now captures the identifying diagnostic for each excluded object unconditionally (not gated on `--tdd`), preferring the original compilation's own declaration diagnostic (e.g. `AL0185 "Codeunit 'X' is missing"`) over the emitter-crash exception text, which names an internal BC detail rather than the AL-level cause.
- It's returned as a new `BcEmitOutput.ExcludedObjectDiagnostics` field, kept **separate** from the existing `Diagnostics` field. Folding it into `Diagnostics` looked like the natural fix, but that field also backs the pre-existing EMIT-ZERO / AL-DIAGNOSTIC-FAIL guards in `Program.cs` — doing so made those guards misfire for a successful `--tdd` exclusion recovery (sources non-empty by design there, `Diagnostics` now non-empty too) and wipe the recovered sources, turning a red test (exit 1) into a compile failure (exit 3). The existing `TddModeTests` suite caught this regression before push.
- `Program.cs`'s bundled-mode CLI now prints these diagnostics under `--verbose` right after the `EMIT-EXCLUDED`/`TDD-EXCLUDED` summary line.
- `--server`'s `EMIT-EXCLUDED` `compileErrors` payload already branched on "do we have the identifying diagnostics" but read the always-empty `alDiagnostics` field, so it always fell into the dead "re-run with --verbose" fallback over a wire protocol with no `--verbose` to re-run with. It now reads the same new field, so a server client actually gets the diagnostics too.

## Fix the shape, not just the reported line

- **Same wrong pattern elsewhere?** Yes — `--server`'s parallel EMIT-EXCLUDED handling (`RunBundleForServer`) had the identical dead branch, fixed alongside the CLI path with its own test (`ServerEmitExclusionDiagnosticTests.cs`).
- **Sibling function, same assumption?** The `--tdd` TDD-EXCLUDED branch made the identical "re-run with --verbose" promise. It's less broken in practice (each synthetic FAILED test already carries its own object's diagnostic inline), but I added the same verbose-gated print there too so the promise is uniformly true regardless of mode.
- **Two paths, one invariant?** `TddExcludedDetails` (tdd-only) and the new `ExcludedObjectDiagnostics` (always-on) now share the same underlying per-object diagnostic computation (preferring the real declaration diagnostic over the crash-text fallback) — previously only the `emitResult`-failure branch used the accurate diagnostic; the emitter-crash branch used only the internal crash text even in `--tdd` mode. Both branches now compute the same way.

## Re: #2221 (Log's `[Component]` filter)

Checked whether this was another instance of #2221's shape. It is not: the EMIT-EXCLUDED/TDD-EXCLUDED summary lines are already deliberately untagged (see the existing comment at their call sites, added specifically to dodge that filter), and the diagnostics this PR adds are formatted alc-style (`path(line,col): error ALXXXX: message`) with no leading `[Tag]`, so `Log`'s filter never touches them either way. The defect here was that the diagnostics were never *captured* for the non-tdd path in the first place — not that they were captured and then filtered.

## Testing

- `AlRunner.Tests/EmitExclusionLoudnessTests.cs`: two new tests — `ExcludedObject_Verbose_PrintsTheIdentifyingAlDiagnostic` (RED before the fix) and `ExcludedObject_DefaultVerbosity_OmitsTheAlDiagnostic` (negative direction — the diagnostic must stay out of default-verbosity output).
- `AlRunner.Tests/ServerEmitExclusionDiagnosticTests.cs` (new file): proves the `--server` wire response carries `AL0185`, not the dead fallback message.
- Manually verified against the real binary (not just the unit tests) with `--package-cache` pointed at a real platform-apps cache, both with and without `--verbose`, confirming no duplicate `EMIT-ZERO` block and no diagnostic leak at default verbosity.
- `dotnet test AlRunner.Tests` (full suite): 1148 passed, 0 failed, 68 skipped.

## Rebased onto main — checked interaction with #2220

#2220 (merged after this PR's original CI run) made an ordinary app.json's `application`/`platform` fields count as a real Microsoft dependency for platform-app need detection. `AlRunner.Tests/Fixtures/EmitExclusion/app.json` (used by this PR's tests) has exactly that shape — `"application": "1.0.0.0"`, `"platform": "1.0.0.0"`, empty `dependencies` — and `EmitExclusionLoudnessTests`/`ServerEmitExclusionDiagnosticTests` spawn the real binary against it without `--package-cache`, so it's worth checking directly rather than trusting a green rebase.

Rebased onto current `main` and re-verified by hand, not just re-running CI:

1. **Same EMIT-EXCLUDED output / exit code?** Yes. `"This Codeunit Does Not Exist At All"` cannot bind regardless of which symbols are present, so AL0185 is unaffected. Ran the fixture with the runner-owned platform-apps caches present (matching CI, which now hardlinks them into the default location) — output gains a couple of extra `[provision] platform apps already complete at ...` lines, but `EMIT-EXCLUDED`, the excluded object's name, `MISSING`, and exit code 3 are all unchanged; under `--verbose` the `AL0185` diagnostic still appears exactly as before.
2. **Do the tests still pass with those apps genuinely absent?** I moved aside every platform-app cache on this machine I could find (the runner-owned per-version `platform-apps` dirs for two different 28.1 patches, the `~/.bcartifacts.cache/sandbox` `platform/Applications` + `platform/ModernDev` trees, and the `~/.local/share/al-runner/symbols` copy) and re-ran the exact no-`--package-cache` invocation the tests use. With default `--auto-provision` (on by default, not disabled by these tests), the runner detected the need, resolved a fresh BC patch, downloaded a real 116 MB platform-apps set from the CDN, and *then* reached `EMIT-EXCLUDED` with exit 3 — same shape my tests assert on, just slower (real network I/O in the run). So the tests are not silently broken on a genuinely cold machine that has network access.

   The gap is real once auto-provision can't run: with `--no-auto-provision` and no cache, the run now refuses with **exit 2** before ever reaching the emit path — none of `EMIT-EXCLUDED`/`AL0185`/`MISSING` appear. My tests don't pass `--no-auto-provision`, so they don't hit this directly, but any machine or environment that runs the AlRunner.Tests subprocess suite offline, or with `AL_RUNNER`-style provisioning disabled, now gets a **new required network dependency** on a test suite that previously needed none for this fixture — that's #2220's consequence on this shared fixture shape, not something introduced or fixable by this PR, and not something I've tried to paper over here. Flagging it as-is; happy to file it separately if wanted.

Restored every cache directory I moved aside to its original state afterward and re-verified `dotnet test` locally still green with them back.

New head after rebase: `643c4f0e150e423b92a3f4f04aceaafe78c71d5d`. Post-rebase CI: all 8 required BC legs + `All BC versions passed` green, `mergeStateStatus: CLEAN`.
