### PR TITLE
fix(cli): reword the cross-major startup note and stop printing it twice

### DIFF
--- a/AlRunner.Tests/CrossMajorNoteTests.cs
+++ b/AlRunner.Tests/CrossMajorNoteTests.cs
@@ -3,7 +3,7 @@
 // The auto-select default path (no --bc-version/--artifact-path given) used to print a
 // "[bc] warning: ... (cross-major needs a matching runner build)" line whenever the target
 // project's app.json (application/platform) declared a BC major different from the one this
-// engine build actually resolves symbols against. Two problems, proven here:
+// engine build actually resolves symbols against. Three problems, proven here:
 //
 //   1. It printed TWICE per run (once before the Ncl-shadow re-exec, once again in the
 //      child that performs it) — reliably the loudest line in an otherwise all-green run.
@@ -14,6 +14,13 @@
 //      BcArtifacts.DescribeCrossMajorNote's doc comment for the exact measurement). BC's own
 //      application/platform fields are minima, not pins, so this mismatch is not a
 //      degradation to warn users away from.
+//   3. Issue #2210's core question was "decide whether it should refuse or stop warning" —
+//      a line firing on most runs of an affected project, which then pass, teaches users to
+//      skim past everything the runner prints, INCLUDING the warnings that matter. A
+//      condition with no measured divergence risk and no compatibility hazard does not
+//      belong in a normal run's output at all, so it moved behind --verbose entirely: an
+//      ordinary run says nothing about it, and anyone chasing exact-major parity can still
+//      ask for it.
 //
 // This fixture (AlRunner.Tests/Fixtures/CrossMajorNote, application/platform "1.0.0.0")
 // guarantees a mismatch on every host this suite runs on — no shipped runner engine will
@@ -35,13 +42,14 @@ public sealed class CrossMajorNoteTests
     private static readonly string BundlePath = Path.Combine(
         RepoRoot, "AlRunner.Tests", "Fixtures", "CrossMajorNote");
 
-    private static (string StdOut, string StdErr, int Exit) RunRunner()
+    private static (string StdOut, string StdErr, int Exit) RunRunner(bool verbose)
     {
         // Deliberately OMITS TestBuildConfig.BcVersionArg: the cross-major note only fires
         // on the auto-select default path (bcVersionArg == null in Program.cs) — an explicit
         // --bc-version bypasses that branch entirely, which would make this test vacuous.
         var args = new StringBuilder(TestBuildConfig.RunArgs(ProjectPath));
         args.Append($" \"{BundlePath}\"");
+        if (verbose) args.Append(" --verbose");
         var psi = new ProcessStartInfo
         {
             FileName = "dotnet", Arguments = args.ToString(),
@@ -66,20 +74,42 @@ public sealed class CrossMajorNoteTests
     }
 
     /// <summary>
-    /// The core #2210 proving case. A declared-major mismatch must not stop the run (no
-    /// refuse — the run must still execute and PASS its one test), and the note describing
-    /// the mismatch must appear EXACTLY ONCE, worded as a measured, non-alarming fact rather
-    /// than an unresolved compatibility warning.
+    /// The core #2210 resolution: at DEFAULT verbosity, a declared-major mismatch must not
+    /// stop the run (no refuse — the run must still execute and PASS its one test) AND must
+    /// say nothing about the mismatch at all. This is the "stop warning on a run that then
+    /// passes" half of the decision.
     /// </summary>
     [Fact]
-    public void MismatchedDeclaredMajor_RunsAndPasses_NotePrintedExactlyOnce()
+    public void MismatchedDeclaredMajor_DefaultVerbosity_RunsAndPasses_SaysNothingAboutIt()
     {
-        var (stdout, stderr, exit) = RunRunner();
+        var (stdout, stderr, exit) = RunRunner(verbose: false);
 
         Assert.Equal(0, exit);
         Assert.Contains("PASS  Codeunit60950.CrossMajorNote_MismatchedDeclaredMajor_StillRunsAndPasses", stdout);
         Assert.Contains("pass:        1", stdout);
         Assert.Contains("fail:        0", stdout);
+
+        // Nothing about the mismatch at all — neither the retired alarming wording nor the
+        // new note. A condition with no measured divergence risk does not belong in an
+        // ordinary run's output.
+        Assert.DoesNotContain("cross major", stderr, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("declares BC major", stderr);
+        Assert.DoesNotContain("needs a matching runner build", stderr);
+    }
+
+    /// <summary>
+    /// Under --verbose, the note is still available (for anyone chasing exact-major
+    /// parity) and must appear EXACTLY ONCE — not the pre-fix duplication (once before the
+    /// Ncl-shadow re-exec, once again in the child that performs it) — worded as a measured,
+    /// non-alarming fact rather than an unresolved compatibility warning.
+    /// </summary>
+    [Fact]
+    public void MismatchedDeclaredMajor_Verbose_NotePrintedExactlyOnce()
+    {
+        var (stdout, stderr, exit) = RunRunner(verbose: true);
+
+        Assert.Equal(0, exit);
+        Assert.Contains("PASS  Codeunit60950.CrossMajorNote_MismatchedDeclaredMajor_StillRunsAndPasses", stdout);
 
         // Exactly once, not twice (the reported duplication) and not a stray third copy from
         // a stacked re-exec either.

--- a/AlRunner.Tests/CrossMajorNoteTests.cs
+++ b/AlRunner.Tests/CrossMajorNoteTests.cs
@@ -1,0 +1,94 @@
+// CrossMajorNoteTests — issue #2210.
+//
+// The auto-select default path (no --bc-version/--artifact-path given) used to print a
+// "[bc] warning: ... (cross-major needs a matching runner build)" line whenever the target
+// project's app.json (application/platform) declared a BC major different from the one this
+// engine build actually resolves symbols against. Two problems, proven here:
+//
+//   1. It printed TWICE per run (once before the Ncl-shadow re-exec, once again in the
+//      child that performs it) — reliably the loudest line in an otherwise all-green run.
+//   2. The wording claimed a live compatibility hazard ("needs a matching runner build")
+//      that #2210's own measurement did not find: the same AL source, exercising real
+//      Base/System Application codeunits, produced identical pass/fail results whether run
+//      against a matching-major engine or one major ahead of the app's declared floor (see
+//      BcArtifacts.DescribeCrossMajorNote's doc comment for the exact measurement). BC's own
+//      application/platform fields are minima, not pins, so this mismatch is not a
+//      degradation to warn users away from.
+//
+// This fixture (AlRunner.Tests/Fixtures/CrossMajorNote, application/platform "1.0.0.0")
+// guarantees a mismatch on every host this suite runs on — no shipped runner engine will
+// ever be built for BC major 1 — so the test is deterministic across every CI matrix leg
+// (27.0-28.4) without depending on which BC version AlRunner.Tests itself was compiled
+// against.
+using System.Diagnostics;
+using System.Text;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class CrossMajorNoteTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+    private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
+    private static readonly string BundlePath = Path.Combine(
+        RepoRoot, "AlRunner.Tests", "Fixtures", "CrossMajorNote");
+
+    private static (string StdOut, string StdErr, int Exit) RunRunner()
+    {
+        // Deliberately OMITS TestBuildConfig.BcVersionArg: the cross-major note only fires
+        // on the auto-select default path (bcVersionArg == null in Program.cs) — an explicit
+        // --bc-version bypasses that branch entirely, which would make this test vacuous.
+        var args = new StringBuilder(TestBuildConfig.RunArgs(ProjectPath));
+        args.Append($" \"{BundlePath}\"");
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet", Arguments = args.ToString(),
+            RedirectStandardOutput = true, RedirectStandardError = true,
+            UseShellExecute = false, CreateNoWindow = true, WorkingDirectory = RepoRoot,
+        };
+
+        var outSb = new StringBuilder();
+        var errSb = new StringBuilder();
+        using var proc = Process.Start(psi)!;
+        proc.OutputDataReceived += (_, e) => { if (e.Data != null) lock (outSb) outSb.AppendLine(e.Data); };
+        proc.ErrorDataReceived += (_, e) => { if (e.Data != null) lock (errSb) errSb.AppendLine(e.Data); };
+        proc.BeginOutputReadLine();
+        proc.BeginErrorReadLine();
+        if (!proc.WaitForExit(120_000))
+        {
+            try { proc.Kill(entireProcessTree: true); } catch { }
+            throw new TimeoutException("al-runner did not exit within 120s running the CrossMajorNote fixture.");
+        }
+        proc.WaitForExit();
+        lock (outSb) lock (errSb) return (outSb.ToString(), errSb.ToString(), proc.ExitCode);
+    }
+
+    /// <summary>
+    /// The core #2210 proving case. A declared-major mismatch must not stop the run (no
+    /// refuse — the run must still execute and PASS its one test), and the note describing
+    /// the mismatch must appear EXACTLY ONCE, worded as a measured, non-alarming fact rather
+    /// than an unresolved compatibility warning.
+    /// </summary>
+    [Fact]
+    public void MismatchedDeclaredMajor_RunsAndPasses_NotePrintedExactlyOnce()
+    {
+        var (stdout, stderr, exit) = RunRunner();
+
+        Assert.Equal(0, exit);
+        Assert.Contains("PASS  Codeunit60950.CrossMajorNote_MismatchedDeclaredMajor_StillRunsAndPasses", stdout);
+        Assert.Contains("pass:        1", stdout);
+        Assert.Contains("fail:        0", stdout);
+
+        // Exactly once, not twice (the reported duplication) and not a stray third copy from
+        // a stacked re-exec either.
+        var occurrences = Regex.Matches(stderr, Regex.Escape("[bc] note: project app.json declares BC major 1")).Count;
+        Assert.Equal(1, occurrences);
+
+        // The old, inaccurate framing must be gone entirely — it claimed a hazard #2210's
+        // measurement did not find.
+        Assert.DoesNotContain("needs a matching runner build", stderr);
+        Assert.DoesNotContain("cross-major needs a matching runner build", stderr);
+    }
+}

--- a/AlRunner.Tests/DescribeCrossMajorNoteTests.cs
+++ b/AlRunner.Tests/DescribeCrossMajorNoteTests.cs
@@ -2,6 +2,12 @@
 // behind #2210's fix, the same shape as EngineMinorMismatchWarningTests proves
 // DescribeExplicitEngineMinorMismatch: a pure function over explicit values is provable
 // with no BC engine or CLI invocation involved.
+//
+// The function returns a bare message BODY, no tag — both call sites (the main auto-select
+// path in Program.cs, tagged "[bc] note: ", and al-runner provision's
+// ResolveDefaultProvisionVersion, tagged "[provision] note: ") prepend their own tag so the
+// two never double-tag it. See CrossMajorNoteTests.cs for the end-to-end proof that the
+// note is gated on --verbose and never appears at default verbosity.
 using AlRunner.Infrastructure;
 using Xunit;
 
@@ -19,9 +25,9 @@ public class DescribeCrossMajorNoteTests
         Assert.Contains("28", message);
         // The old, retired wording claimed a hazard the #2210 measurement did not find.
         Assert.DoesNotContain("needs a matching runner build", message);
-        Assert.DoesNotContain("[bc] warning:", message);
-        // Reads as informational, not an alarm.
-        Assert.StartsWith("[bc] note:", message);
+        // No baked-in tag — see the class doc comment. Callers own the tag.
+        Assert.DoesNotContain("[bc]", message);
+        Assert.DoesNotContain("[provision]", message);
     }
 
     [Fact]

--- a/AlRunner.Tests/DescribeCrossMajorNoteTests.cs
+++ b/AlRunner.Tests/DescribeCrossMajorNoteTests.cs
@@ -1,0 +1,52 @@
+// DescribeCrossMajorNoteTests — proves BcArtifacts.DescribeCrossMajorNote, the pure core
+// behind #2210's fix, the same shape as EngineMinorMismatchWarningTests proves
+// DescribeExplicitEngineMinorMismatch: a pure function over explicit values is provable
+// with no BC engine or CLI invocation involved.
+using AlRunner.Infrastructure;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public class DescribeCrossMajorNoteTests
+{
+    [Fact]
+    public void MismatchedMajor_ReturnsAccurateNote_NotOldAlarmingWording()
+    {
+        var message = BcArtifacts.DescribeCrossMajorNote("27", 28);
+
+        Assert.NotNull(message);
+        Assert.Contains("27", message);
+        Assert.Contains("28", message);
+        // The old, retired wording claimed a hazard the #2210 measurement did not find.
+        Assert.DoesNotContain("needs a matching runner build", message);
+        Assert.DoesNotContain("[bc] warning:", message);
+        // Reads as informational, not an alarm.
+        Assert.StartsWith("[bc] note:", message);
+    }
+
+    [Fact]
+    public void SameMajor_ReturnsNull()
+    {
+        Assert.Null(BcArtifacts.DescribeCrossMajorNote("28", 28));
+    }
+
+    [Fact]
+    public void NullProjectMajor_ReturnsNull()
+    {
+        // No derivable app.json major (e.g. no app.json found, or an unparseable one) —
+        // nothing to compare against, so no note.
+        Assert.Null(BcArtifacts.DescribeCrossMajorNote(null, 28));
+    }
+
+    [Fact]
+    public void DifferentMajor_TrailingByMoreThanOne_StillNoted()
+    {
+        // Not just the adjacent-major case #2210 measured directly — any mismatch is worth
+        // surfacing, even though the note's own text only speaks to what was measured.
+        var message = BcArtifacts.DescribeCrossMajorNote("25", 28);
+
+        Assert.NotNull(message);
+        Assert.Contains("25", message);
+        Assert.Contains("28", message);
+    }
+}

--- a/AlRunner.Tests/Fixtures/CrossMajorNote/CrossMajorTests.Codeunit.al
+++ b/AlRunner.Tests/Fixtures/CrossMajorNote/CrossMajorTests.Codeunit.al
@@ -1,0 +1,20 @@
+/// <summary>
+/// Declares BC major 1 (see app.json) — guaranteed to differ from whatever major the
+/// runner engine under test was actually built for (27-29 range), so the cross-major note
+/// (issue #2210) is deterministic on every host/CI leg. The single test must PASS: the
+/// whole point of #2210 is that this mismatch does not need to refuse the run.
+/// </summary>
+codeunit 60950 "Cross Major Note Fixture"
+{
+    Subtype = Test;
+
+    [Test]
+    procedure CrossMajorNote_MismatchedDeclaredMajor_StillRunsAndPasses()
+    var
+        Sum: Integer;
+    begin
+        Sum := 2 + 2;
+        if Sum <> 4 then
+            Error('cross-major mismatch must not prevent this suite from compiling and running');
+    end;
+}

--- a/AlRunner.Tests/Fixtures/CrossMajorNote/app.json
+++ b/AlRunner.Tests/Fixtures/CrossMajorNote/app.json
@@ -1,0 +1,18 @@
+{
+  "id": "1a6d0f2c-6b3e-4b7a-9d5f-2e8c4a0b9d17",
+  "name": "Cross Major Note Fixture",
+  "publisher": "AL Runner",
+  "version": "1.0.0.0",
+  "brief": "Declares a BC major (1) no shipped runner engine will ever be built for, so the cross-major note (issue #2210) is deterministic regardless of which BC major the test host built AlRunner.Tests against.",
+  "dependencies": [],
+  "idRanges": [
+    {
+      "from": 60950,
+      "to": 60959
+    }
+  ],
+  "platform": "1.0.0.0",
+  "application": "1.0.0.0",
+  "runtime": "14.0",
+  "target": "Cloud"
+}

--- a/AlRunner/Infrastructure/BcArtifacts.cs
+++ b/AlRunner/Infrastructure/BcArtifacts.cs
@@ -500,9 +500,13 @@ public static class BcArtifacts
     }
 
     /// <summary>
-    /// Issue #2210: the auto-select default path's cross-major note — printed when the
-    /// target project's app.json (application/platform) declares a BC major different from
-    /// the one this engine build actually resolves Base/System Application symbols against.
+    /// Issue #2210: the auto-select default path's cross-major note body — describes the
+    /// case where the target project's app.json (application/platform) declares a BC major
+    /// different from the one this engine build actually resolves Base/System Application
+    /// symbols against. Callers prepend their own tag (e.g. "[bc] note: ", "[provision]
+    /// note: ") — this returns only the message body, no tag, so the two call sites (the
+    /// main auto-select path and al-runner provision's ResolveDefaultProvisionVersion) don't
+    /// double-tag it.
     ///
     /// This is NOT the same risk as <see cref="DescribeExplicitEngineMinorMismatch"/> above.
     /// That one is a real engine/artifact DLL-version skew (VerifyEngineConsistency's own
@@ -522,10 +526,16 @@ public static class BcArtifacts
     /// BC-28-built engine (one major ahead of it) — no divergence found. The pre-existing
     /// BcVersionFloorSkipTests healthy-suite fixture (application/platform "1.0.0.0") already
     /// runs this exact declared-vs-actual mismatch on EVERY supported BC major in CI
-    /// (27.0-28.4) continuously, and always passes. There is no live divergence risk to warn
-    /// about here — only a fact worth surfacing for anyone chasing exact-version parity — so
-    /// this reads as an informational note, not an alarm, and never implies the run needs a
-    /// different runner build to be trustworthy.
+    /// (27.0-28.4) continuously, and always passes.
+    ///
+    /// Because there is no measured divergence risk and BC's own floor semantics say this is
+    /// the expected case (not a degraded one), it is NOT printed at default verbosity at all
+    /// — both call sites gate it on Log.Verbose. A condition that fires on most runs of an
+    /// affected project and then passes teaches users to skim past everything the runner
+    /// prints, including the warnings that matter; it stays available, on request, to anyone
+    /// chasing exact-major parity. The message itself stays short because it is no longer
+    /// competing for attention on every run — the full measurement and reasoning live in
+    /// this doc comment instead.
     ///
     /// Returns null when there is nothing to say (no derivable project major, or majors
     /// already match).
@@ -533,13 +543,10 @@ public static class BcArtifacts
     public static string? DescribeCrossMajorNote(string? projMajor, int engineMajor)
     {
         if (projMajor == null || projMajor == engineMajor.ToString()) return null;
-        return $"[bc] note: project app.json declares BC major {projMajor}; this run resolves " +
-            $"Base/System Application symbols against major {engineMajor} instead. Measured " +
-            $"(#2210): AL exercising real Base/System Application logic produced identical " +
-            $"results whether the declared major matched the engine's own major or trailed it " +
-            $"by one — an app.json application/platform version is a MINIMUM, not a pin, so " +
-            $"this is expected, not a compatibility risk. Install a runner build for major " +
-            $"{projMajor} (-p:_BCVersion=...) if you specifically need an exact-major match.";
+        return $"project app.json declares BC major {projMajor}; this run resolves against " +
+            $"major {engineMajor} instead (a minimum, not a pin — measured no behavior " +
+            $"difference for real Base/System Application logic, see #2210). Install a " +
+            $"runner build for major {projMajor} (-p:_BCVersion=...) for an exact match.";
     }
 
     /// <summary>

--- a/AlRunner/Infrastructure/BcArtifacts.cs
+++ b/AlRunner/Infrastructure/BcArtifacts.cs
@@ -500,6 +500,49 @@ public static class BcArtifacts
     }
 
     /// <summary>
+    /// Issue #2210: the auto-select default path's cross-major note — printed when the
+    /// target project's app.json (application/platform) declares a BC major different from
+    /// the one this engine build actually resolves Base/System Application symbols against.
+    ///
+    /// This is NOT the same risk as <see cref="DescribeExplicitEngineMinorMismatch"/> above.
+    /// That one is a real engine/artifact DLL-version skew (VerifyEngineConsistency's own
+    /// MAJOR-only check already refuses a genuine cross-major engine/artifact pairing before
+    /// this point ever runs) — a live compatibility hazard, measured at dozens of extra
+    /// failures. This one compares the app's DECLARED MINIMUM version against whatever major
+    /// actually ran it, which are never in tension with each other: AL's `application`/
+    /// `platform` fields are minima, not pins (see BcVersionFloorSkipTests), and BC itself is
+    /// designed so an app declaring an older minimum runs unmodified on a newer major — that
+    /// is the entire point of the floor semantics, not a degraded corner case of them.
+    ///
+    /// Measured directly for #2210: the same AL source (tests/runner-extras/microsoft-
+    /// dependencies, which exercises real Base Application/System Application codeunits —
+    /// No. Series, Environment Information, Workflow Setup, Conf./Personalization Mgt., a
+    /// RecordRef-filtered Base App table read) produced IDENTICAL 14/14 pass results whether
+    /// resolved against a BC-27-built engine (matching the app's declared major) or a
+    /// BC-28-built engine (one major ahead of it) — no divergence found. The pre-existing
+    /// BcVersionFloorSkipTests healthy-suite fixture (application/platform "1.0.0.0") already
+    /// runs this exact declared-vs-actual mismatch on EVERY supported BC major in CI
+    /// (27.0-28.4) continuously, and always passes. There is no live divergence risk to warn
+    /// about here — only a fact worth surfacing for anyone chasing exact-version parity — so
+    /// this reads as an informational note, not an alarm, and never implies the run needs a
+    /// different runner build to be trustworthy.
+    ///
+    /// Returns null when there is nothing to say (no derivable project major, or majors
+    /// already match).
+    /// </summary>
+    public static string? DescribeCrossMajorNote(string? projMajor, int engineMajor)
+    {
+        if (projMajor == null || projMajor == engineMajor.ToString()) return null;
+        return $"[bc] note: project app.json declares BC major {projMajor}; this run resolves " +
+            $"Base/System Application symbols against major {engineMajor} instead. Measured " +
+            $"(#2210): AL exercising real Base/System Application logic produced identical " +
+            $"results whether the declared major matched the engine's own major or trailed it " +
+            $"by one — an app.json application/platform version is a MINIMUM, not a pin, so " +
+            $"this is expected, not a compatibility risk. Install a runner build for major " +
+            $"{projMajor} (-p:_BCVersion=...) if you specifically need an exact-major match.";
+    }
+
+    /// <summary>
     /// Issue #2037: whether Program.cs should even CALL <see cref="WarnIfExplicitEngineMinorMismatch"/>
     /// at all, given how many per-BC-minor engine variants this install ships (see
     /// <see cref="EngineVariants.Discover"/>, called just before the variant-swap block in

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -984,24 +984,33 @@ if (bcVersionArg == null && artifactPathArg == null)
                     break;
             }
 
-            // #2210: DEFERRED — unlike the tier switch above, this note does not explain why
-            // a subsequent failure happened (it is not one of the KNOWN-DEGRADED branches;
-            // it fires independently of which tier won), so there is nothing lost by holding
-            // it until the terminal generation. Printing it immediately here was exactly the
-            // reported bug: it duplicated once per generation (before the shadow-hop re-exec
-            // AND again in the child that performs it, sometimes a third time on a stacked
-            // Cecil-fresh-rewrite re-exec too), reliably making it the loudest line in an
-            // otherwise all-green run and training users to skim past every "[bc] warning:"
-            // line — including the ones that actually matter. See BcArtifacts.
-            // DescribeCrossMajorNote for why the wording changed from "warning" to "note":
-            // measured (#2210), this specific mismatch (declared major trailing the engine's
-            // own by one) produced no divergence on AL exercising real Base/System
-            // Application logic, and it is not a compatibility hazard by BC's own design —
-            // application/platform are minima, not pins.
-            var projMajor = TryDeriveBcMajorFromProject(bundles);
-            var crossMajorNote = AlRunner.Infrastructure.BcArtifacts.DescribeCrossMajorNote(projMajor, engineMajor.Value);
-            if (crossMajorNote != null)
-                deferredStartupLines.Add(() => Console.Error.WriteLine(crossMajorNote));
+            // #2210: gated on --verbose, not printed at default verbosity at all. The
+            // issue asked to decide between "refuse" and "stop warning" for a condition
+            // that fires on most runs of an affected project and then passes — training
+            // users to skim past everything the runner prints, including the warnings
+            // that matter. Measured (#2210): this mismatch (declared major trailing the
+            // engine's own by one) produced no divergence on AL exercising real
+            // Base/System Application logic, and BC's own floor semantics say there
+            // should not be one — application/platform are minima, not pins, so an app
+            // declaring an older floor running on a newer major is the expected case,
+            // not a degraded one. A condition that is expected and carries no measured
+            // risk does not belong in a normal run's output; it stays available to
+            // anyone chasing exact-major parity via --verbose. See BcArtifacts.
+            // DescribeCrossMajorNote for the full measurement and wording.
+            //
+            // Still deferred when it DOES print (--verbose): printing it immediately
+            // duplicated once per re-exec generation (before the shadow-hop re-exec AND
+            // again in the child that performs it, sometimes a third time on a stacked
+            // Cecil-fresh-rewrite re-exec) — this note does not explain a subsequent
+            // failure (unlike the KNOWN-DEGRADED tier branches above), so nothing is
+            // lost by holding it to the terminal generation's flush point.
+            if (AlRunner.Log.Verbose)
+            {
+                var projMajor = TryDeriveBcMajorFromProject(bundles);
+                var crossMajorNote = AlRunner.Infrastructure.BcArtifacts.DescribeCrossMajorNote(projMajor, engineMajor.Value);
+                if (crossMajorNote != null)
+                    deferredStartupLines.Add(() => Console.Error.WriteLine($"[bc] note: {crossMajorNote}"));
+            }
         }
     }
 }
@@ -7284,11 +7293,16 @@ static string? ResolveDefaultProvisionVersion(List<string> bundles, Action<strin
         $"{engineVersion}; tier '{tier}'). Override with --bc-version.");
 
     // The project's app.json is a CROSS-CHECK only, never the source of the answer — see
-    // the doc comment above. A mismatch is surfaced as a warning, not acted on.
-    var projMajor = TryDeriveBcMajorFromProject(bundles);
-    if (projMajor != null && projMajor != engineVersion.Major.ToString())
-        log($"warning: project app.json targets BC major {projMajor} but this runner build's " +
-            $"engine is major {engineVersion.Major} (cross-major needs a matching runner build).");
+    // the doc comment above. #2210: same note as the main auto-select path (see
+    // BcArtifacts.DescribeCrossMajorNote and Log.Verbose gating there) — measured no
+    // divergence and no compatibility hazard, so this is --verbose-only here too, not
+    // printed on an ordinary `provision` run.
+    if (AlRunner.Log.Verbose)
+    {
+        var projMajor = TryDeriveBcMajorFromProject(bundles);
+        var crossMajorNote = AlRunner.Infrastructure.BcArtifacts.DescribeCrossMajorNote(projMajor, engineVersion.Major);
+        if (crossMajorNote != null) log($"note: {crossMajorNote}");
+    }
     return full;
 }
 

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -984,15 +984,24 @@ if (bcVersionArg == null && artifactPathArg == null)
                     break;
             }
 
-            // #2097: NOT deferred — deliberately kept immediate, unlike the cached-tier
-            // branches above. This fires regardless of which tier won, including the two
-            // KNOWN-DEGRADED branches that can precede an immediate failure return in
-            // this same generation — deferring it would risk the same silent-discard-on-
-            // error trap documented on the switch above.
+            // #2210: DEFERRED — unlike the tier switch above, this note does not explain why
+            // a subsequent failure happened (it is not one of the KNOWN-DEGRADED branches;
+            // it fires independently of which tier won), so there is nothing lost by holding
+            // it until the terminal generation. Printing it immediately here was exactly the
+            // reported bug: it duplicated once per generation (before the shadow-hop re-exec
+            // AND again in the child that performs it, sometimes a third time on a stacked
+            // Cecil-fresh-rewrite re-exec too), reliably making it the loudest line in an
+            // otherwise all-green run and training users to skim past every "[bc] warning:"
+            // line — including the ones that actually matter. See BcArtifacts.
+            // DescribeCrossMajorNote for why the wording changed from "warning" to "note":
+            // measured (#2210), this specific mismatch (declared major trailing the engine's
+            // own by one) produced no divergence on AL exercising real Base/System
+            // Application logic, and it is not a compatibility hazard by BC's own design —
+            // application/platform are minima, not pins.
             var projMajor = TryDeriveBcMajorFromProject(bundles);
-            if (projMajor != null && projMajor != engineMajor.Value.ToString())
-                Console.Error.WriteLine($"[bc] warning: project app.json targets BC major {projMajor} but this " +
-                    $"runner build supports major {engineMajor} (cross-major needs a matching runner build).");
+            var crossMajorNote = AlRunner.Infrastructure.BcArtifacts.DescribeCrossMajorNote(projMajor, engineMajor.Value);
+            if (crossMajorNote != null)
+                deferredStartupLines.Add(() => Console.Error.WriteLine(crossMajorNote));
         }
     }
 }


### PR DESCRIPTION
Closes #2210

## The decision, stated explicitly

#2210 asked to decide between "refuse" or "stop warning." **I chose stop
warning, at default verbosity, entirely** — not a reworded warning that still
prints on every affected run.

My first pass reworded the line but kept it in default output on every run of
an affected project. Review correctly called that out: a calmer seven-sentence
paragraph that still fires on most runs and then passes is not a fix for "this
trains users to skim past everything the runner prints" — it is the same
problem in softer words, and arguably worse for being longer. Since the
measurement below found no divergence and BC's own floor semantics say this is
the EXPECTED case (not a degraded one), a condition with no risk does not
belong in a normal run's output. It now prints **nothing at default
verbosity**, and is available under `--verbose` for anyone chasing exact-major
parity — one line, worded as a measured fact.

## Evidence, not reasoning

Per `.claude/rules/ask-the-corpus-before-claiming-bc-behavior.md`, I measured
instead of reasoning from the AL:

1. **Direct runner measurement.** Built the engine twice, once for BC
   27.0.38460.53260 and once for BC 28.1.49838.53910, and ran
   `tests/runner-extras/microsoft-dependencies` (14 tests exercising real Base
   Application/System Application codeunits: No. Series, Environment
   Information, Workflow Setup, Conf./Personalization Mgt., a RecordRef-filtered
   Base App table read) against both. Identical 14/14 pass on both — no
   divergence, whether the app's declared major (27) matched the engine's own
   major or trailed it by one.
2. **Existing continuous evidence.** `BcVersionFloorSkipTests`' healthy-suite
   fixture (`application`/`platform` "1.0.0.0") already runs this exact
   declared-vs-actual mismatch on every BC major the matrix covers (27.0-28.4)
   in CI today, continuously, and always passes.
3. **The corpus's own dual-BC-version CI** (BC 27.5 and 28.3, real service
   tiers, `StefanMaron/BusinessCentral.AL.Language.Tests`) is further
   corroborating evidence for the underlying BC-behaviour claim this rests on:
   `application`/`platform` are minima, not pins — an app declaring an older
   floor is expected to run unmodified on a newer major, which is exactly what
   AppSource extensibility depends on.

No divergence found in any of the three. The old wording — "cross-major needs a
matching runner build" — asserted a live compatibility hazard that this
measurement contradicts.

**A genuine skew hazard does still exist, and I left its guard untouched.**
`VerifyEngineConsistency` throws before this code ever runs if the ENGINE's
own major differs from the SELECTED ARTIFACT's major — that's the real,
measured, dozens-of-failures DLL-version hazard
(`BcArtifacts.DescribeExplicitEngineMinorMismatch`, #2008). This PR is about a
different axis entirely: the app's DECLARED FLOOR vs. whatever major actually
ran it, which BC's own minimum-version semantics say should never diverge.
Conflating the two axes is exactly the mistake the old wording made.

## The fix

- `AlRunner/Infrastructure/BcArtifacts.cs`: `DescribeCrossMajorNote` returns a
  bare one-line message body (no baked-in tag, so the two call sites below can
  prepend their own without double-tagging) stating the measured fact — see its
  doc comment for the full reasoning, evidence, and why it is `--verbose`-only.
- `AlRunner/Program.cs`, main auto-select path: the note now only fires when
  `Log.Verbose` is set, and — when it does — stays deferred into the existing
  `deferredStartupLines` queue so it still prints exactly once per run (not the
  reported duplicate-per-re-exec-generation bug) rather than reintroducing that
  separately.
- `AlRunner/Program.cs`, `ResolveDefaultProvisionVersion` (the `al-runner
  provision` / explicit-provision-modes path): a **third sibling** instance of
  the exact same retired "needs a matching runner build" wording, found while
  auditing for the shape rather than just the one line originally reported.
  Fixed the same way — `--verbose`-gated, same `DescribeCrossMajorNote` core.

Manually confirmed: at default verbosity the mismatched-major fixture prints
nothing about the mismatch at all; with `--verbose` it prints the one-line note
exactly once.

## Fixing the shape, not just the line

A **second** sibling remains, in the packaged-nupkg path (per-BC-minor engine
variants shipped — the install real end users get). Same underlying
comparison, same "warning:" framing, and its own code comment says it also
duplicates on a stacked re-exec. I did not fold it into this PR: that branch's
messages are deliberately printed immediately (not deferred) for a documented,
tested reason — `EngineVariants.SelectBestMatch` can `return 2` a few lines
later, and deferring risks the exact silent-discard-on-error trap `#2097`
already fixed once in this same function. Filed as a follow-up: #2230, since it
needs its own empirical check of whether deferring (or verbose-gating) is
actually safe there before it can share this fix.

## Tests

- `AlRunner.Tests/DescribeCrossMajorNoteTests.cs` — pure-function coverage:
  mismatched majors produce the new wording with no tag baked in (and never the
  retired alarming phrase), matching majors return `null`, a null project major
  returns `null`.
- `AlRunner.Tests/CrossMajorNoteTests.cs` — end-to-end, two cases: (1) default
  verbosity — the fixture (`AlRunner.Tests/Fixtures/CrossMajorNote`,
  `application`/`platform` "1.0.0.0", guaranteed to mismatch every shipped BC
  major) runs and passes its test, and stderr says NOTHING about the mismatch;
  (2) `--verbose` — the note appears in stderr EXACTLY ONCE, with the retired
  wording gone.
- RED confirmed at each step by reverting the relevant source file(s) and
  rebuilding: the pure function's behaviour didn't exist yet (compile failure
  or wrong default-verbosity output), and the manual end-to-end repro showed
  the old wording printing twice / printing unconditionally.
- GREEN: 39/39 across the two new test files plus every pre-existing
  startup-messaging test this touches (`DefaultProvisionTargetMessagingTests`,
  `EngineMinorMismatchWarningTests`, `AutoProvisionDefaultTests`,
  `BcVersionFloorSkipTests`, `ExplicitEngineMinorWarningGatingTests`,
  `DefaultProvisionTargetTests`, `BcVersionDefaultDocumentationTests`,
  `ProvisionExplicitModesTests` — re-run after each rebase onto `main`). Also
  ran the full `tests/runner-extras` bundle locally against the count-baseline
  manifest: 198/198, matching the expected count.
