### PR TITLE
fix(provisioning): need detection searches every patch dir the run path does

### DIFF
--- a/AlRunner.Tests/ProvisioningCheckTests.cs
+++ b/AlRunner.Tests/ProvisioningCheckTests.cs
@@ -1657,4 +1657,94 @@ public sealed class ProvisioningCheckTests : IDisposable
 
         Assert.Empty(missing);
     }
+
+    // ── Issue #2234: need detection must consult the run path's FULL search set ──
+    // #2226 (separate, still open) can leave `provision`'s platform-app and test-app
+    // sub-steps under DIFFERENT patch directories of the same major.minor — the engine's
+    // own exact build for one sub-step, the CDN's "latest" for the major.minor for the
+    // other. Need detection used to build its search set from the SELECTED engine
+    // version's own exact patch directory alone, so an app provisioned under a sibling
+    // patch directory read as absent even though it was present and usable — the run
+    // path found it only as an incidental side effect of the auto-provision reuse scan
+    // (FindWarmProvisionedVersion), so `--no-auto-provision` reported the identical
+    // "missing" diagnostic on every subsequent run, even immediately after `provision`
+    // had just completed successfully (an unbreakable loop: the tool's own advice was to
+    // run the command that had just run).
+
+    [Fact]
+    public void CollectRunnerOwnedProvisionDirs_FindsDirsAcrossDifferentPatchVersions()
+    {
+        var root = Path.Combine(_dir, "artifacts-root-2234-collect");
+        var enginePatchTestApps = Path.Combine(root, "28.1.49838.53910", "test-apps");
+        var laterPatchPlatformApps = Path.Combine(root, "28.1.49838.54044", "platform-apps");
+        Directory.CreateDirectory(enginePatchTestApps);
+        Directory.CreateDirectory(laterPatchPlatformApps);
+        // A DIFFERENT major.minor must never be picked up, even though "28.2" sorts
+        // higher than "28.1" — only patches sharing the requested major.minor qualify.
+        Directory.CreateDirectory(Path.Combine(root, "28.2.50931.53737", "platform-apps"));
+
+        var dirs = ProvisioningCheck.CollectRunnerOwnedProvisionDirs(root, "28.1");
+
+        Assert.Contains(enginePatchTestApps, dirs);
+        Assert.Contains(laterPatchPlatformApps, dirs);
+        Assert.DoesNotContain(dirs, d => d.Contains("28.2.50931.53737"));
+    }
+
+    [Fact]
+    public void CollectRunnerOwnedProvisionDirs_MissingRoot_ReturnsEmpty()
+    {
+        var dirs = ProvisioningCheck.CollectRunnerOwnedProvisionDirs(
+            Path.Combine(_dir, "does-not-exist-2234"), "28.1");
+
+        Assert.Empty(dirs);
+    }
+
+    [Fact]
+    public void NeedDetection_PlatformAppsUnderADifferentPatchThanSelectedEngine_AreNotReportedMissing()
+    {
+        // The exact #2234 repro shape: the platform apps live under a DIFFERENT patch
+        // directory than the engine's own selected build, and NOTHING at all exists under
+        // the engine's own patch directory except the (unrelated) test toolkit. This test
+        // would still pass if #2226 were fixed by making both directories always land on
+        // the SAME version — the point is it must ALSO pass when they genuinely differ,
+        // which is exactly the case a fix to #2226 would stop exercising, leaving this
+        // disagreement live and undetected the next time the two steps diverge for any
+        // other reason.
+        var root = Path.Combine(_dir, "artifacts-root-2234-present-elsewhere");
+        const string selectedEngineVersion = "28.1.49838.53910";
+        const string differentPatchVersion = "28.1.49838.54044";
+        var platformAppsDir = Path.Combine(root, differentPatchVersion, "platform-apps");
+        Directory.CreateDirectory(platformAppsDir);
+        WriteR2RApp(platformAppsDir, "application.app", Guid.NewGuid().ToString(), "Application", "Microsoft", "28.1.0.0");
+        WriteR2RApp(platformAppsDir, "system.app", Guid.NewGuid().ToString(), "System", "Microsoft", "28.1.0.0");
+        // Nothing under the engine's OWN patch directory but the unrelated test toolkit —
+        // matches the repro's "provision downloaded the test toolkit to the engine's own
+        // version, the platform apps to a different one" split exactly.
+        Directory.CreateDirectory(Path.Combine(root, selectedEngineVersion, "test-apps"));
+
+        var searchDirs = ProvisioningCheck.CollectRunnerOwnedProvisionDirs(
+            root, ProvisioningCheck.ResolveProvisionMajorMinor(selectedEngineVersion));
+        var missing = ProvisioningCheck.FindMissingPlatformApps(
+            new[] { "Application", "System" }, searchDirs);
+
+        Assert.Empty(missing);
+    }
+
+    [Fact]
+    public void NeedDetection_PlatformAppsGenuinelyAbsentEverywhere_AreStillReportedMissing()
+    {
+        // The negative direction: the widened search must not turn "genuinely absent"
+        // into a false "present" — regression guard for #2205/#2220's good diagnostic.
+        var root = Path.Combine(_dir, "artifacts-root-2234-genuinely-absent");
+        Directory.CreateDirectory(Path.Combine(root, "28.1.49838.53910", "test-apps"));
+        Directory.CreateDirectory(Path.Combine(root, "28.1.49838.54044")); // no platform-apps subdir at all
+
+        var searchDirs = ProvisioningCheck.CollectRunnerOwnedProvisionDirs(root, "28.1");
+        var missing = ProvisioningCheck.FindMissingPlatformApps(
+            new[] { "Application", "System" }, searchDirs);
+
+        Assert.Equal(
+            new[] { "Application", "System" },
+            missing.OrderBy(n => n, StringComparer.Ordinal).ToArray());
+    }
 }

--- a/AlRunner/Infrastructure/ProvisioningCheck.cs
+++ b/AlRunner/Infrastructure/ProvisioningCheck.cs
@@ -465,6 +465,66 @@ public static class ProvisioningCheck
     public static string TestAppsDirFor(string artifactsRootDir, string fullVersion)
         => Path.Combine(artifactsRootDir, fullVersion, "test-apps");
 
+    /// <summary>
+    /// Every version directory directly under <paramref name="artifactsRootDir"/> whose
+    /// name is exactly <paramref name="majorMinorPrefix"/> or starts with
+    /// <c>"&lt;majorMinorPrefix&gt;."</c> — i.e. every provisioned patch of the same
+    /// major.minor line — ordered by descending <see cref="Version"/> (newest first,
+    /// matching the order the warm-reuse scan in Program.cs's FindWarmProvisionedVersion
+    /// already uses). Pure directory-name scan; a missing root yields no candidates
+    /// rather than throwing.
+    /// </summary>
+    public static IReadOnlyList<string> EnumerateVersionDirNames(
+        string artifactsRootDir, string majorMinorPrefix)
+    {
+        if (!Directory.Exists(artifactsRootDir)) return Array.Empty<string>();
+        return Directory.EnumerateDirectories(artifactsRootDir)
+            .Select(Path.GetFileName)
+            .Where(n => !string.IsNullOrEmpty(n)
+                && (n == majorMinorPrefix || n!.StartsWith(majorMinorPrefix + ".", StringComparison.Ordinal)))
+            .Select(n => (Name: n!, Ver: Version.TryParse(n, out var v) ? v : null))
+            .Where(t => t.Ver != null)
+            .OrderByDescending(t => t.Ver)
+            .Select(t => t.Name)
+            .ToList();
+    }
+
+    /// <summary>
+    /// Every runner-owned platform-apps/test-apps directory that ACTUALLY EXISTS ON DISK
+    /// for any patch version sharing <paramref name="majorMinorPrefix"/> with the selected
+    /// engine version — not just the engine's own exact patch (issue #2234).
+    ///
+    /// Issue #2226 (a separate, still-open defect) can make `provision`'s platform-app and
+    /// test-app sub-steps land under DIFFERENT patch directories of the same major.minor —
+    /// one resolved from the engine's own exact build, the other from the CDN's "latest"
+    /// for the major.minor. Need detection used to build its search set from the SELECTED
+    /// engine version alone (<see cref="PlatformAppsDirFor"/>/<see cref="TestAppsDirFor"/>
+    /// called with just that one version), so an app provisioned under a sibling patch
+    /// directory read as absent even though it was present and usable — the run path found
+    /// it only as an incidental side effect of the reuse scan (FindWarmProvisionedVersion)
+    /// that runs solely inside the auto-provision download branch, so `--no-auto-provision`
+    /// never benefited from it and reported the identical "missing" diagnostic forever,
+    /// even immediately after `provision` had just completed successfully.
+    ///
+    /// This is the single source of truth both the run path and need detection now share,
+    /// so they can no longer independently drift onto different search sets. Pure
+    /// filesystem existence scan — no network — and it can only ADD directories that exist
+    /// on disk, never remove or fabricate one.
+    /// </summary>
+    public static IReadOnlyList<string> CollectRunnerOwnedProvisionDirs(
+        string artifactsRootDir, string majorMinorPrefix)
+    {
+        var dirs = new List<string>();
+        foreach (var name in EnumerateVersionDirNames(artifactsRootDir, majorMinorPrefix))
+        {
+            var platformDir = PlatformAppsDirFor(artifactsRootDir, name);
+            if (Directory.Exists(platformDir)) dirs.Add(platformDir);
+            var testDir = TestAppsDirFor(artifactsRootDir, name);
+            if (Directory.Exists(testDir)) dirs.Add(testDir);
+        }
+        return dirs;
+    }
+
     // ── Issue #1996: manifest-driven need detection ──────────────────────────
     // CheckPlatformApps / TestToolkitPresent above are REACTIVE: they can only report a
     // gap for an app that is already PRESENT (as symbol-only) in the cache. An empty

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -1290,21 +1290,25 @@ if (inaccessibleScanWarning != null) Console.WriteLine(inaccessibleScanWarning);
 // empty/nonexistent --package-cache, as issue #1996's own repro does) never re-hits the
 // CDN. Populated once the selected BC version is known (already true at this point).
 var selectedVersionForProvisioning = AlRunner.Infrastructure.BcArtifacts.SelectedVersion.ToString();
-var runnerOwnedPlatformAppsDir = AlRunner.Infrastructure.ProvisioningCheck.PlatformAppsDirFor(
-    AlRunner.Infrastructure.BcArtifacts.ArtifactsRootDir, selectedVersionForProvisioning);
-var runnerOwnedTestAppsDir = AlRunner.Infrastructure.ProvisioningCheck.TestAppsDirFor(
-    AlRunner.Infrastructure.BcArtifacts.ArtifactsRootDir, selectedVersionForProvisioning);
-var extraProvisionSearchDirs = new List<string>();
-if (Directory.Exists(runnerOwnedPlatformAppsDir)) extraProvisionSearchDirs.Add(runnerOwnedPlatformAppsDir);
-if (Directory.Exists(runnerOwnedTestAppsDir)) extraProvisionSearchDirs.Add(runnerOwnedTestAppsDir);
+// Issue #2234: scan every patch directory sharing the selected engine's major.minor, not
+// just its own exact patch — #2226 (separate, still open) can leave `provision`'s
+// platform-app and test-app sub-steps under DIFFERENT patch directories of the same
+// major.minor, and need detection used to look only at the engine's own patch, missing a
+// sibling directory the run path found (as an incidental side effect of the auto-provision
+// reuse scan) and reporting "missing" forever even right after `provision` succeeded.
+var extraProvisionSearchDirsMajorMinor = AlRunner.Infrastructure.ProvisioningCheck.ResolveProvisionMajorMinor(
+    selectedVersionForProvisioning);
+var extraProvisionSearchDirs = AlRunner.Infrastructure.ProvisioningCheck.CollectRunnerOwnedProvisionDirs(
+    AlRunner.Infrastructure.BcArtifacts.ArtifactsRootDir, extraProvisionSearchDirsMajorMinor).ToList();
 List<string> PlatformCheckDirs() =>
     packageCacheDirs.Concat(bundleAlpackagesDirs).Concat(extraProvisionSearchDirs).Distinct().ToList();
-// These are read-only, already-on-disk runner-owned dirs for the SELECTED version — fold
-// them into the set dependency resolution actually uses too (mirrors what
-// DefaultPackageCacheDirs already does automatically when no explicit --package-cache is
-// given; this closes the same gap for an EXPLICIT --package-cache, e.g. this exact
-// invocation's own CLI flags). Without this, a prior run's warm test-apps/platform-apps
-// stay invisible to compilation even though the provisioning DECISION already sees them.
+// These are read-only, already-on-disk runner-owned dirs for the SELECTED version's
+// major.minor line — fold them into the set dependency resolution actually uses too
+// (mirrors what DefaultPackageCacheDirs already does automatically when no explicit
+// --package-cache is given; this closes the same gap for an EXPLICIT --package-cache,
+// e.g. this exact invocation's own CLI flags). Without this, a prior run's warm
+// test-apps/platform-apps stay invisible to compilation even though the provisioning
+// DECISION already sees them.
 foreach (var d in extraProvisionSearchDirs)
     if (!packageCacheDirs.Contains(d))
         packageCacheDirs.Add(d);
@@ -6770,19 +6774,22 @@ static IEnumerable<string> DefaultPackageCacheDirs()
     var symLatest = SelectVersionDirOrNull(symRoot, mmPrefix);
     if (symLatest != null) yield return symLatest;
 
-    // The provisioned MS test toolkit for the SELECTED version (see
-    // EnsureTestToolkitProvisioned). Scanned by default so a test bundle whose app.json
-    // depends on Library Assert / Test Runner / Any resolves them without --package-cache.
-    var testApps = AlRunner.Infrastructure.ProvisioningCheck.TestAppsDirFor(
-        AlRunner.Infrastructure.BcArtifacts.ArtifactsRootDir, sel.ToString());
-    if (Directory.Exists(testApps)) yield return testApps;
-
-    // The provisioned Microsoft platform R2R runtime apps for the SELECTED version (see
-    // --auto-provision, issue #1653). Scanned by default so a --auto-provision run on one
-    // invocation is visible on a later run that omits --auto-provision.
-    var platformApps = AlRunner.Infrastructure.ProvisioningCheck.PlatformAppsDirFor(
-        AlRunner.Infrastructure.BcArtifacts.ArtifactsRootDir, sel.ToString());
-    if (Directory.Exists(platformApps)) yield return platformApps;
+    // The provisioned MS test toolkit / platform R2R runtime apps (see
+    // EnsureTestToolkitProvisioned / --auto-provision, issue #1653). Scanned by default so
+    // a test bundle whose app.json depends on Library Assert / Test Runner / Any / System
+    // Application resolves them without --package-cache, and so a --auto-provision run on
+    // one invocation is visible on a later run that omits --auto-provision.
+    //
+    // Issue #2234: scan every patch directory sharing this major.minor, not just `sel`'s
+    // own exact patch — #2226 (separate, still open) can leave `provision`'s platform-app
+    // and test-app sub-steps under DIFFERENT patch directories of the same major.minor,
+    // and this used to look only at `sel`'s own patch, missing a sibling directory the
+    // auto-provision reuse scan (FindWarmProvisionedVersion) found and reporting
+    // "missing" on every subsequent --no-auto-provision run even right after `provision`
+    // had just completed successfully.
+    foreach (var dir in AlRunner.Infrastructure.ProvisioningCheck.CollectRunnerOwnedProvisionDirs(
+        AlRunner.Infrastructure.BcArtifacts.ArtifactsRootDir, mmPrefix))
+        yield return dir;
 }
 
 // Highest version-named child of <root> matching <versionPrefix> (System.Version sort),


### PR DESCRIPTION
Closes #2234

## The disagreement

Need detection built its search set from the SELECTED engine version's own exact
patch directory alone (`extraProvisionSearchDirs` in the main run flow, and
`DefaultPackageCacheDirs()`'s test-apps/platform-apps yield). The run path's
auto-provision reuse scan (`FindWarmProvisionedVersion`) searches every patch
directory sharing the same major.minor, and only *incidentally* folds the right
one into `packageCacheDirs` when a download decision runs.

Issue #2226 (separate, still open — not touched here) can leave `provision`'s
platform-app and test-app sub-steps under DIFFERENT patch directories of the same
major.minor (the engine's own exact build for one sub-step, the CDN's "latest" for
the major.minor for the other). When that happens, an app provisioned under a
sibling patch directory read as absent even though it was present and usable, so
`--no-auto-provision` reported the identical "missing" diagnostic forever, even
immediately after `provision` had just completed successfully — the loop #2234
describes.

## The fix

Added `ProvisioningCheck.CollectRunnerOwnedProvisionDirs` (backed by a new
`EnumerateVersionDirNames` helper) as the single source of truth for "every
runner-owned platform-apps/test-apps dir that exists on disk for any patch
sharing this major.minor" — the same shape `FindWarmProvisionedVersion` already
used for reuse, generalized into a reusable, pure, no-network helper. Both
`extraProvisionSearchDirs` (main run flow) and `DefaultPackageCacheDirs()` now
call it instead of checking only the selected version's own exact patch, so need
detection and the run path can no longer independently drift onto different
search sets.

## Proof

**Reproduced first** against a cold, isolated `$HOME` pinned at the real engine's
service-tier dir (`--artifact-path`), with real platform apps symlinked under a
different patch directory than the engine's own selected build (mirroring the
exact #2226-caused split) — confirmed the reported message and directory
verbatim (`Searched: .../28.1.49838.53910/test-apps`, `missing: Application,
System`) before touching any code.

- **RED**: reverted the fix locally, ran the new unit tests — build fails with
  `CS0117: 'ProvisioningCheck' does not contain a definition for
  'CollectRunnerOwnedProvisionDirs'` (the fix doesn't exist yet).
- **GREEN**: restored the fix, same tests pass. Also re-ran the real end-to-end
  CLI repro against the fixed binary:
  - Platform apps present under a *different* patch directory than the selected
    engine build → `--no-auto-provision` no longer reports them missing; the
    bundle resolves 5 dependencies, compiles, and **executes real System
    Application code** (`Codeunit "Environment Information".IsSaaS()`) — exit 0,
    `1P/0F/0E`.
  - Platform apps genuinely absent everywhere → still correctly exits 2 with
    #2220's good diagnostic (regression guard).

New tests in `AlRunner.Tests/ProvisioningCheckTests.cs`:
- `CollectRunnerOwnedProvisionDirs_FindsDirsAcrossDifferentPatchVersions` — finds
  dirs across two different patches of the same major.minor, and confirms a
  *different* major.minor is excluded even though it sorts higher.
- `CollectRunnerOwnedProvisionDirs_MissingRoot_ReturnsEmpty`
- `NeedDetection_PlatformAppsUnderADifferentPatchThanSelectedEngine_AreNotReportedMissing`
  — the issue's exact repro shape (platform apps under a version different from
  the selected engine's, nothing under the engine's own patch but the unrelated
  test toolkit). This test would still pass if #2226 made both directories always
  land on the same version — the point is it must *also* pass when they
  genuinely differ, which is exactly the case a fix to #2226 would otherwise stop
  exercising.
- `NeedDetection_PlatformAppsGenuinelyAbsentEverywhere_AreStillReportedMissing` —
  negative direction, regression guard for #2205/#2220.

Targeted local runs (not the full suite, per `local-test-scope.md`): the new
`ProvisioningCheckTests`, plus every existing subprocess-level test that
exercises the same search-set machinery on this (warm, heavily-provisioned) dev
machine — `PackageCacheFinalSearchSetTests`, `PrecompileSupportTests`,
`ProvisionExplicitModesTests`, `DefaultProvisionTargetMessagingTests`,
`SourceDepSymbolsWithoutPackageCacheTests`, `SourceDepCacheEnumMetadataTests`,
`ReportLayoutFileResolutionTests`, `WatchPageMetadataReloadTests` — all pass
(21/21 + 106/106 including the new ones).

## Same shape elsewhere (fix-the-shape-not-just-the-line)

- **`AlRunner/PrecompileSupport.cs`'s `WidenPackageCacheDirs`** has the identical
  "selected version's own exact patch only" narrowness, used by `--precompile`.
  Deliberately **not** widened here: its tests
  (`PrecompileSupportTests`) pin an exact-version, exact-count contract, and
  `--precompile` isn't part of this issue's repro path. Filing this as a
  follow-up gap rather than silently expanding this PR's scope — will file after
  this merges.
- **`Program.cs`'s `EnsurePlatformAppsProvisioned`** (the `provision` subcommand's
  own decision of whether to download at all) uses `TestAppsDirFor(engineVersion)`
  for edge-scanning — checked, and left alone: that's discovering *new* manifest
  edges from a test-toolkit `EnsureTestToolkitProvisioned` just wrote to the
  engine's own version, which is a different purpose than presence search, so
  widening it isn't the same fix and risks unrelated behavior change.
