### PR TITLE
feat(provisioning): add --country to auto-provision the localized BC artifact set

### DIFF
--- a/AlRunner.Provisioning/ArtifactDownloader.cs
+++ b/AlRunner.Provisioning/ArtifactDownloader.cs
@@ -223,39 +223,99 @@ public static class ArtifactDownloader
 
     // -----------------------------------------------------------------------
     // Platform Apps: Microsoft Base/System/BusinessFoundation/Application .app files
-    // from the w1 artifact's Extensions/ folder.
+    // from the w1 (or, since #2236, a country-localized) artifact's Extensions/ folder.
     // -----------------------------------------------------------------------
-    public static int PlatformApps(string version, string outputDir, Action<string>? log = null)
+    /// <param name="country">
+    /// BC artifact country/localization channel — "w1" (worldwide, default) or a
+    /// country code such as "us"/"de"/"gb" (issue #2236). Not validated against an
+    /// allowlist here: an unresolvable code 404s against the CDN and
+    /// <see cref="TryHeadContentLength"/> reports the exact URL that failed, which is
+    /// the only "maintainable" validation for a set of codes Microsoft adds to on its
+    /// own schedule.
+    /// </param>
+    // w1 (the default): the curated 5-app core set, unchanged since #1653/#2210 — narrow
+    // on purpose so the default download stays ~135 MB for the overwhelming majority of
+    // projects, which need nothing country-specific.
+    internal static readonly string[] W1PlatformAppPrefixes =
+    {
+        "microsoft_base application_",
+        "microsoft_system application_",
+        "microsoft_business foundation_",
+        "microsoft_application_",
+        // Ships in w1/Extensions like the four above, NOT in the platform artifact the
+        // `test-apps` command streams — so `test-apps` cannot supply it however it is
+        // filtered. A test bundle depending on it (tests/runner-extras/microsoft-dependencies)
+        // was therefore unresolvable on any machine without a full BC sandbox artifact,
+        // which is every CI runner: the leg aborted with the provisioning-gap message
+        // before running a test, while passing locally off a multi-GB sandbox download.
+        "microsoft_application test library_",
+    };
+
+    /// <summary>
+    /// Normalizes a <c>--country</c> value the same way every entry point does: trim,
+    /// lowercase, empty/whitespace -> "w1". Pulled out as its own testable function so the
+    /// normalization rule is pinned once instead of copy-pasted at each call site.
+    /// </summary>
+    internal static string NormalizeCountry(string? country)
+        => string.IsNullOrWhiteSpace(country) ? "w1" : country.Trim().ToLowerInvariant();
+
+    /// <summary>The CDN URL PlatformApps/TestApps/ServiceTier download from for a given
+    /// version + channel ("w1", a country code, or "platform"). Pure string composition —
+    /// no I/O — so URL construction is directly testable without a network round trip.</summary>
+    internal static string BuildArtifactUrl(string version, string channel)
+        => $"{CdnBase}/{version}/{channel}";
+
+    /// <summary>
+    /// Whether a ZIP central-directory entry name is one PlatformApps should download for
+    /// the given country (issue #2236). Pure over the entry name alone — no I/O — so the
+    /// selection rule (including the Extensions/-vs-Applications.&lt;CC&gt;/ trap and the
+    /// w1-curated-list-vs-country-broad-match split) is directly unit-testable without
+    /// faking a ZIP central directory or an HTTP round trip.
+    /// </summary>
+    /// <param name="entryName">Raw ZIP entry name (any case, either slash style).</param>
+    /// <param name="isW1">True for the w1 (worldwide) channel; false for any country code.</param>
+    internal static bool IsWantedPlatformAppEntry(string entryName, bool isW1)
+    {
+        var lower = entryName.ToLowerInvariant();
+        // Anchor on Extensions/ specifically: a country artifact ALSO carries an
+        // Applications.<CC>/ folder holding a DIFFERENT, smaller file with the identical
+        // basename (e.g. Applications.US/Microsoft_Base Application_...app, 48.7 MB, vs
+        // the 110.6 MB localized one under Extensions/) — a basename-only match would
+        // silently pick the non-localized one from the wrong folder.
+        if (!lower.StartsWith("extensions/") || !lower.EndsWith(".app")) return false;
+        var bn = Path.GetFileName(lower);
+        // Any other country (#2236): a country artifact is not "w1 plus extras" — its
+        // Base/System Application etc. are DIFFERENT FILES from w1's (measured: the US
+        // Base Application is 110.6 MB vs w1's 98.6 MB for the same build), and a project
+        // depending on a country-specific Microsoft app (e.g. "IRS Forms") needs an app
+        // the curated w1 list above has never heard of and never will, by name, for every
+        // country Microsoft ships. Rather than hand-maintain a second curated list per
+        // country, fetch every Microsoft-published app the country artifact ships under
+        // Extensions/ — this naturally covers the localized core set AND whatever
+        // country-specific app(s) a project actually depends on, with nothing to guess.
+        return isW1
+            ? Array.Exists(W1PlatformAppPrefixes, p => bn.StartsWith(p))
+            : bn.StartsWith("microsoft_");
+    }
+
+    public static int PlatformApps(string version, string outputDir, string country = "w1", Action<string>? log = null)
     {
         var logf = L(log);
-        var artifactUrl = $"{CdnBase}/{version}/w1";
+        var countryLower = NormalizeCountry(country);
+        bool isW1 = countryLower == "w1";
+        var artifactUrl = BuildArtifactUrl(version, countryLower);
         Directory.CreateDirectory(outputDir);
 
         using var http = new HttpClient { Timeout = TimeSpan.FromMinutes(10) };
 
-        logf($"Resolving artifact size for BC {version} (w1)...");
-        if (!TryHeadContentLength(http, artifactUrl, version, "w1", logf, out long totalSize)) return 1;
+        logf($"Resolving artifact size for BC {version} ({countryLower})...");
+        if (!TryHeadContentLength(http, artifactUrl, version, countryLower, logf, out long totalSize)) return 1;
         if (totalSize == 0) { logf("Error: unknown size"); return 1; }
-        logf($"w1 artifact: {totalSize / 1048576} MB");
+        logf($"{countryLower} artifact: {totalSize / 1048576} MB");
 
         logf("Downloading ZIP directory...");
         if (!TryReadCentralDirectory(http, artifactUrl, totalSize, logf, out var cdData, out var cdStart, out var entryCount))
             return 1;
-
-        var wantedPrefixes = new[]
-        {
-            "microsoft_base application_",
-            "microsoft_system application_",
-            "microsoft_business foundation_",
-            "microsoft_application_",
-            // Ships in w1/Extensions like the four above, NOT in the platform artifact the
-            // `test-apps` command streams — so `test-apps` cannot supply it however it is
-            // filtered. A test bundle depending on it (tests/runner-extras/microsoft-dependencies)
-            // was therefore unresolvable on any machine without a full BC sandbox artifact,
-            // which is every CI runner: the leg aborted with the provisioning-gap message
-            // before running a test, while passing locally off a multi-GB sandbox download.
-            "microsoft_application test library_",
-        };
 
         var matching = new List<(string Name, int Method, long CompSize, long Offset)>();
         int pos = cdStart;
@@ -263,16 +323,13 @@ public static class ArtifactDownloader
         {
             if (!IsCentralHeader(cdData, pos)) break;
             var (cm, cs, nl, el, cl, lo, name) = ReadCentralEntry(cdData, pos);
-            var lower = name.ToLowerInvariant();
-            var bn = Path.GetFileName(lower);
-            if (lower.StartsWith("extensions/") && lower.EndsWith(".app") && cs > 0
-                && Array.Exists(wantedPrefixes, p => bn.StartsWith(p)))
+            if (cs > 0 && IsWantedPlatformAppEntry(name, isW1))
                 matching.Add((name, cm, cs, lo));
             pos += 46 + nl + el + cl;
         }
 
         if (matching.Count == 0) { logf("Error: no platform .app files found"); return 1; }
-        logf($"Found {matching.Count} platform app(s):");
+        logf($"Found {matching.Count} platform app(s) for country '{countryLower}':");
         foreach (var (name, _, compSize, _) in matching)
             logf($"  {Path.GetFileName(name)}  ({compSize / 1048576} MB compressed)");
 
@@ -460,7 +517,11 @@ public static class ArtifactDownloader
         catch (HttpRequestException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
         {
             var prefix = string.Join(".", version.Split('.').Take(2));
-            logf($"Error: no BC artifact published for {version} ({channel}).");
+            // Issue #2236: name the exact URL that 404'd, not just the version/channel —
+            // this is the only channel this method has (w1, platform, or a country code
+            // like "us"), so when the country is wrong the URL is what tells the reader
+            // which one to check.
+            logf($"Error: no BC artifact published for {version} ({channel}): {url}");
             logf("       Check the version, or resolve the latest for a prefix:");
             // Issue #2085: this fires both from the standalone tools/DownloadArtifacts CLI
             // (repo-checkout only) AND in-process from the shipped `al-runner` binary's own
@@ -468,6 +529,10 @@ public static class ArtifactDownloader
             // here would be a dead end for anyone using the latter, which is the common
             // case. `al-runner provision --resolve-version` works from both.
             logf($"         al-runner provision --resolve-version {prefix}");
+            if (!string.Equals(channel, "w1", StringComparison.OrdinalIgnoreCase)
+                && !string.Equals(channel, "platform", StringComparison.OrdinalIgnoreCase))
+                logf($"       If '{channel}' is a --country code, double-check the spelling — " +
+                     "the runner does not maintain its own list of valid codes.");
             size = 0;
             return false;
         }

--- a/AlRunner.Tests/ArtifactDownloader404Tests.cs
+++ b/AlRunner.Tests/ArtifactDownloader404Tests.cs
@@ -49,11 +49,36 @@ public sealed class ArtifactDownloader404Tests
 
         Assert.False(ok);
         Assert.Equal(0, size);
-        Assert.Contains(logs, l => l == "Error: no BC artifact published for 28.0.46665.47126 (w1).");
+        // Issue #2236: the message now names the exact URL that 404'd, not just the
+        // version/channel — that is what tells the reader which country/version to check.
+        Assert.Contains(logs, l => l == "Error: no BC artifact published for 28.0.46665.47126 (w1): " +
+            "https://bcartifacts.example/sandbox/28.0.46665.47126/w1");
         // Issue #2085: this hint must be tool-install-valid — `dotnet run --project` requires
         // a source checkout a `dotnet tool install -g` user never has.
         Assert.Contains(logs, l => l.Contains("al-runner provision --resolve-version 28.0"));
         Assert.DoesNotContain(logs, l => l.Contains("dotnet run --project"));
+        // w1 is not a country code — no --country spelling hint for it.
+        Assert.DoesNotContain(logs, l => l.Contains("--country code"));
+    }
+
+    [Fact]
+    public void TryHeadContentLength_404_WithCountryChannel_NamesUrlAndSuggestsCountrySpellingCheck()
+    {
+        using var http = new HttpClient(new StubHandler(HttpStatusCode.NotFound));
+        var logs = new List<string>();
+
+        // A country channel that does not exist on the CDN (typo'd or unsupported) — the
+        // message must point at the country, not repeat the generic "check the version" text
+        // as though the version itself were the problem.
+        var ok = ArtifactDownloader.TryHeadContentLength(
+            http, "https://bcartifacts.example/sandbox/28.4.53241.53989/xx",
+            "28.4.53241.53989", "xx", logs.Add, out long size);
+
+        Assert.False(ok);
+        Assert.Equal(0, size);
+        Assert.Contains(logs, l => l == "Error: no BC artifact published for 28.4.53241.53989 (xx): " +
+            "https://bcartifacts.example/sandbox/28.4.53241.53989/xx");
+        Assert.Contains(logs, l => l.Contains("--country code") && l.Contains("'xx'"));
     }
 
     [Fact]

--- a/AlRunner.Tests/ArtifactDownloaderCountryTests.cs
+++ b/AlRunner.Tests/ArtifactDownloaderCountryTests.cs
@@ -1,0 +1,94 @@
+// Issue #2236: al-runner only ever downloaded the w1 (worldwide) BC artifact, so any
+// codebase built against a country localization (e.g. a US customer extension depending on
+// "IRS Forms") could not be auto-provisioned at all. These tests pin the pure, no-network
+// pieces of the fix — URL construction, country normalization, and the ZIP-entry selection
+// rule (including the Extensions/-vs-Applications.<CC>/ duplicate-basename trap) — without
+// downloading a single byte, per .claude/rules/local-test-scope.md ("do not add a network
+// dependency to the default unit-test run"). The real end-to-end download is verified
+// manually against the live CDN (see the PR description), not here.
+using AlRunner.Provisioning;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class ArtifactDownloaderCountryTests
+{
+    [Theory]
+    [InlineData(null, "w1")]
+    [InlineData("", "w1")]
+    [InlineData("   ", "w1")]
+    [InlineData("W1", "w1")]
+    [InlineData("US", "us")]
+    [InlineData(" us ", "us")]
+    [InlineData("de", "de")]
+    public void NormalizeCountry_TrimsLowercasesAndDefaultsToW1(string? input, string expected)
+        => Assert.Equal(expected, ArtifactDownloader.NormalizeCountry(input));
+
+    [Fact]
+    public void BuildArtifactUrl_UsesCountryAsTheChannelSegment()
+    {
+        Assert.Equal(
+            "https://bcartifacts-exdbf9fwegejdqak.b02.azurefd.net/sandbox/28.4.53241.53989/w1",
+            ArtifactDownloader.BuildArtifactUrl("28.4.53241.53989", "w1"));
+        Assert.Equal(
+            "https://bcartifacts-exdbf9fwegejdqak.b02.azurefd.net/sandbox/28.4.53241.53989/us",
+            ArtifactDownloader.BuildArtifactUrl("28.4.53241.53989", "us"));
+    }
+
+    [Theory]
+    [InlineData("Extensions/Microsoft_Base Application_28.4.53241.53989.app", true)]
+    [InlineData("Extensions/Microsoft_System Application_28.4.53241.53989.app", true)]
+    [InlineData("Extensions/Microsoft_Business Foundation_28.4.53241.53989.app", true)]
+    [InlineData("Extensions/Microsoft_Application_28.4.53241.53989.app", true)]
+    [InlineData("Extensions/Microsoft_Application Test Library_28.4.53241.53989.app", true)]
+    public void IsWantedPlatformAppEntry_W1_MatchesTheFiveCuratedApps(string entryName, bool expected)
+        => Assert.Equal(expected, ArtifactDownloader.IsWantedPlatformAppEntry(entryName, isW1: true));
+
+    [Fact]
+    public void IsWantedPlatformAppEntry_W1_RejectsACountrySpecificMicrosoftApp()
+    {
+        // The exact real-world repro from #2236: "IRS Forms" is Microsoft-published but is
+        // NOT one of the curated w1 apps — the w1 selection must not pick it up (there would
+        // be nothing sane to do with it: w1 never ships it in the first place).
+        Assert.False(ArtifactDownloader.IsWantedPlatformAppEntry(
+            "Extensions/Microsoft_IRS Forms_27.5.53238.55217.app", isW1: true));
+    }
+
+    [Fact]
+    public void IsWantedPlatformAppEntry_NonW1Country_MatchesAnyMicrosoftAppUnderExtensions()
+    {
+        // A country channel is not "w1 plus extras": IRS Forms and its own transitive
+        // Microsoft dependencies (the "_Exclude_*" apps) must all be pulled in, with no
+        // hand-maintained per-country name list.
+        Assert.True(ArtifactDownloader.IsWantedPlatformAppEntry(
+            "Extensions/Microsoft_IRS Forms_27.5.53238.55217.app", isW1: false));
+        Assert.True(ArtifactDownloader.IsWantedPlatformAppEntry(
+            "Extensions/Microsoft__Exclude_APIV1__27.5.53238.55217.app", isW1: false));
+        // The localized core set is still covered (it also starts with "microsoft_").
+        Assert.True(ArtifactDownloader.IsWantedPlatformAppEntry(
+            "Extensions/Microsoft_Base Application_27.5.53238.55217.app", isW1: false));
+    }
+
+    [Fact]
+    public void IsWantedPlatformAppEntry_RejectsTheApplicationsCountryFolderDuplicate()
+    {
+        // The exact trap #2236 measured: a country artifact ALSO ships
+        // Applications.US/Microsoft_Base Application_....app — a DIFFERENT, smaller,
+        // non-localized file with the SAME basename as the correct one under Extensions/.
+        // Selecting by basename alone would silently ship the wrong file; anchoring on the
+        // Extensions/ folder must reject this entry regardless of country.
+        Assert.False(ArtifactDownloader.IsWantedPlatformAppEntry(
+            "Applications.US/Microsoft_Base Application_28.4.53241.53989.app", isW1: false));
+        Assert.False(ArtifactDownloader.IsWantedPlatformAppEntry(
+            "Applications.US/Microsoft_Base Application_28.4.53241.53989.app", isW1: true));
+    }
+
+    [Fact]
+    public void IsWantedPlatformAppEntry_RejectsNonAppFilesAndNonMicrosoftPublishers()
+    {
+        Assert.False(ArtifactDownloader.IsWantedPlatformAppEntry(
+            "Extensions/Microsoft_Base Application_28.4.53241.53989.dll", isW1: false));
+        Assert.False(ArtifactDownloader.IsWantedPlatformAppEntry(
+            "Extensions/Contoso_Custom Localization_1.0.0.0.app", isW1: false));
+    }
+}

--- a/AlRunner.Tests/CliDocumentationTests.cs
+++ b/AlRunner.Tests/CliDocumentationTests.cs
@@ -289,6 +289,10 @@ public sealed class CliDocumentationTests
     private static readonly string[] BehaviorChangingFlags =
     {
         "--tdd", "--watch", "--server", "--define", "--auto-provision", "--no-auto-provision", "--no-cache",
+        // Issue #2236: --country selects a DIFFERENT CDN artifact channel — a different
+        // Base/System Application file entirely, not just an extra flag on the same w1
+        // download — so it belongs here by this list's own "which code path" test.
+        "--country",
     };
 
     /// <summary>Negative: an unknown documentation flag must not be silently accepted.</summary>

--- a/AlRunner.Tests/CountryFlagTests.cs
+++ b/AlRunner.Tests/CountryFlagTests.cs
@@ -1,0 +1,110 @@
+// Issue #2236: al-runner only ever downloaded the w1 (worldwide) BC artifact, so a
+// country-localized codebase (a real US customer extension depending on "IRS Forms") could
+// not be auto-provisioned at all. This file proves the CLI-level half of the fix: --country
+// is a recognized flag (not rejected as "Unknown option"), it is visibly plumbed into the
+// process-wide selection (the "[bc] selected BC ..." startup line names it), and it does
+// not disturb an ordinary w1 run when omitted. The download/selection-logic half is proven
+// network-free in ArtifactDownloaderCountryTests and ProvisioningCheckTests; the real
+// end-to-end country download is verified manually against the live CDN (see the PR
+// description) rather than in the default test run — see
+// .claude/rules/local-test-scope.md ("do not add a network dependency to the default
+// unit-test run").
+using System.Diagnostics;
+using System.Text;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class CountryFlagTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+
+    // A dependency-free bundle: --country only changes WHICH artifact set would be
+    // downloaded for a MISSING Microsoft dependency, so a bundle with none must compile
+    // and run identically regardless of --country — proving --country does not disturb an
+    // ordinary run is as important as proving it is recognized at all.
+    private static readonly string MinimalBundle =
+        Path.Combine(RepoRoot, "tests", "runner-extras", "esm-xapp-table");
+
+    private static (int ExitCode, string StdOut, string StdErr) Run(params string[] args)
+    {
+        var sb = new StringBuilder(TestBuildConfig.RunArgs(Path.Combine(RepoRoot, "AlRunner")));
+        foreach (var a in args) sb.Append(' ').Append(a);
+
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            Arguments = sb.ToString(),
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            WorkingDirectory = RepoRoot,
+        };
+
+        var outSb = new StringBuilder();
+        var errSb = new StringBuilder();
+        using var proc = Process.Start(psi)!;
+        proc.OutputDataReceived += (_, e) => { if (e.Data != null) lock (outSb) outSb.AppendLine(e.Data); };
+        proc.ErrorDataReceived += (_, e) => { if (e.Data != null) lock (errSb) errSb.AppendLine(e.Data); };
+        proc.BeginOutputReadLine();
+        proc.BeginErrorReadLine();
+        if (!proc.WaitForExit(120_000))
+        {
+            try { proc.Kill(entireProcessTree: true); } catch { }
+            throw new TimeoutException("al-runner did not exit within 120s.");
+        }
+        return (proc.ExitCode, outSb.ToString(), errSb.ToString());
+    }
+
+    [Fact]
+    public void Country_IsARecognizedFlag_NotRejectedAsUnknownOption()
+    {
+        var (exit, _, stderr) = Run("--country", "us", "--no-auto-provision", $"\"{MinimalBundle}\"");
+
+        Assert.DoesNotContain("Unknown option '--country'", stderr, StringComparison.Ordinal);
+        Assert.True(exit == 0, $"expected a clean run (country only changes what a MISSING " +
+            $"Microsoft dep would be fetched from; this bundle has none). exit={exit}\n{stderr}");
+    }
+
+    [Fact]
+    public void Country_Us_IsNamedInTheSelectedBcVersionLine()
+    {
+        var (exit, _, stderr) = Run("--country", "us", "--no-auto-provision", $"\"{MinimalBundle}\"");
+        Assert.True(exit == 0, $"exit={exit}\n{stderr}");
+
+        var m = Regex.Match(stderr, @"\[bc\] selected BC \S+ \([^)]*\) \[country: (\S+)\]");
+        Assert.True(m.Success, $"expected the '[bc] selected BC ...' line to name the country. stderr:\n{stderr}");
+        Assert.Equal("us", m.Groups[1].Value);
+    }
+
+    [Fact]
+    public void Country_Omitted_DefaultsToW1_AndPrintsNoCountrySuffix()
+    {
+        var (exit, _, stderr) = Run("--no-auto-provision", $"\"{MinimalBundle}\"");
+        Assert.True(exit == 0, $"exit={exit}\n{stderr}");
+
+        // The pre-#2236 line shape, byte-for-byte: no [country: ...] suffix at all for the
+        // invisible w1 default — a w1 run must read exactly as it always has.
+        Assert.Matches(new Regex(@"\[bc\] selected BC \S+ \([^)]*\)\r?$", RegexOptions.Multiline), stderr);
+        Assert.DoesNotContain("[country:", stderr, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Country_IsCaseInsensitive_UppercaseUsAndLowercaseUsSelectTheSameChannel()
+    {
+        var (exitUpper, _, stderrUpper) = Run("--country", "US", "--no-auto-provision", $"\"{MinimalBundle}\"");
+        var (exitLower, _, stderrLower) = Run("--country", "us", "--no-auto-provision", $"\"{MinimalBundle}\"");
+
+        Assert.True(exitUpper == 0, stderrUpper);
+        Assert.True(exitLower == 0, stderrLower);
+
+        var mUpper = Regex.Match(stderrUpper, @"\[country: (\S+)\]");
+        var mLower = Regex.Match(stderrLower, @"\[country: (\S+)\]");
+        Assert.True(mUpper.Success && mLower.Success, $"upper:\n{stderrUpper}\nlower:\n{stderrLower}");
+        Assert.Equal("us", mUpper.Groups[1].Value);
+        Assert.Equal(mLower.Groups[1].Value, mUpper.Groups[1].Value);
+    }
+}

--- a/AlRunner.Tests/MissingDependencyCountryMessageTests.cs
+++ b/AlRunner.Tests/MissingDependencyCountryMessageTests.cs
@@ -1,0 +1,76 @@
+// Issue #2236: MissingDependencyException.ToDetailedMessage() used to recommend
+// `al-runner provision` / `--auto-provision` for EVERY Microsoft-publisher dependency,
+// even one that neither command can ever satisfy — a country-localization app (e.g. "IRS
+// Forms") is not in the w1 (worldwide) artifact set those commands download, no matter how
+// many times they are re-run. The repo owner ran exactly that advice, twice, against a real
+// US customer extension and got a byte-identical message both times.
+//
+// This file pins the fix separately from the download plumbing (#2236's own instruction:
+// "write this test first and make it pass before the download work — it is valuable on its
+// own"): a missing dependency that IS one of the apps `provision`/`--auto-provision` can
+// actually fetch keeps the existing advice; one that ISN'T gets a message naming the real
+// reason (country localization) and the flag that actually helps (--country), not a repeat
+// of advice already proven not to work.
+using AlRunner.Infrastructure;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class MissingDependencyCountryMessageTests
+{
+    private static MissingDependencyException Make(string publisher, string name)
+        => new(publisher, name, "27.5.0.0", Guid.NewGuid(), new[] { "/some/package-cache" });
+
+    [Fact]
+    public void ToDetailedMessage_KnownW1PlatformApp_StillRecommendsProvision()
+    {
+        var ex = Make("Microsoft", "Base Application");
+        var msg = ex.ToDetailedMessage("28.4.53241.53989");
+
+        Assert.Contains("al-runner provision", msg);
+        Assert.Contains("--auto-provision", msg);
+        Assert.DoesNotContain("--country", msg);
+        Assert.DoesNotContain("localization", msg, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ToDetailedMessage_KnownTestFrameworkApp_StillRecommendsProvision()
+    {
+        var ex = Make("Microsoft", "Library Assert");
+        var msg = ex.ToDetailedMessage("28.4.53241.53989");
+
+        Assert.Contains("al-runner provision", msg);
+        Assert.DoesNotContain("--country", msg);
+    }
+
+    [Fact]
+    public void ToDetailedMessage_UnknownMicrosoftApp_NamesCountryLocalizationInsteadOfDeadAdvice()
+    {
+        // "IRS Forms" is the exact real-world repro from #2236: Microsoft-published, but not
+        // part of the curated w1 platform-apps set and not part of the test-toolkit set —
+        // `al-runner provision --platform-apps` / `--test-apps` cannot fetch it, so the
+        // message must not tell the reader to run either.
+        var ex = Make("Microsoft", "IRS Forms");
+        var msg = ex.ToDetailedMessage("27.5.53238.55217");
+
+        Assert.Contains("--country", msg);
+        Assert.Contains("w1", msg);
+        Assert.Contains("localization", msg, StringComparison.OrdinalIgnoreCase);
+        // The dead advice must be GONE, not merely supplemented — repeating it is exactly
+        // what produced the byte-identical message the repo owner saw twice.
+        Assert.DoesNotContain("al-runner provision --platform-apps", msg);
+        Assert.DoesNotContain("al-runner provision --test-apps", msg);
+        Assert.DoesNotContain("        al-runner provision\n", msg);
+    }
+
+    [Fact]
+    public void ToDetailedMessage_NonMicrosoftDep_StillRecommendsPackageCacheNotCountry()
+    {
+        var ex = Make("Contoso", "Contoso Extension");
+        var msg = ex.ToDetailedMessage();
+
+        Assert.Contains("--package-cache", msg);
+        Assert.DoesNotContain("--country", msg);
+        Assert.DoesNotContain("al-runner provision", msg);
+    }
+}

--- a/AlRunner.Tests/ProvisioningCheckTests.cs
+++ b/AlRunner.Tests/ProvisioningCheckTests.cs
@@ -490,6 +490,75 @@ public sealed class ProvisioningCheckTests : IDisposable
         Assert.Equal(Path.GetDirectoryName(platform), Path.GetDirectoryName(testApps));
     }
 
+    // ── Issue #2236: country-keyed platform-apps directory ───────────────────
+    // A w1 set and a country-localized set for the SAME BC build must not collide — a
+    // country artifact's Base Application is a genuinely different file, not a superset of
+    // w1's. These pass the country explicitly (never mutate the global
+    // BcArtifacts.SelectedCountry) so they cannot race other tests under
+    // parallelizeTestCollections=true (see xunit.runner.json).
+
+    [Fact]
+    public void PlatformAppsDirFor_ExplicitW1_KeepsThePreExistingBareDirectoryName()
+    {
+        var artifactsRoot = Path.Combine(_dir, "artifacts");
+
+        var dir = ProvisioningCheck.PlatformAppsDirFor(artifactsRoot, "28.4.53241.53989", "w1");
+
+        // No migration needed for existing caches: identical to the no-country-arg overload.
+        Assert.Equal(Path.Combine(artifactsRoot, "28.4.53241.53989", "platform-apps"), dir);
+    }
+
+    [Fact]
+    public void PlatformAppsDirFor_ExplicitCountry_GetsItsOwnSiblingDirectory()
+    {
+        var artifactsRoot = Path.Combine(_dir, "artifacts");
+
+        var us = ProvisioningCheck.PlatformAppsDirFor(artifactsRoot, "28.4.53241.53989", "us");
+
+        Assert.Equal(Path.Combine(artifactsRoot, "28.4.53241.53989", "platform-apps-us"), us);
+    }
+
+    [Fact]
+    public void PlatformAppsDirFor_W1AndCountry_AreDistinctAndBothCoexist()
+    {
+        // The acceptance bar from #2236: a user who provisions BOTH w1 and us for the same
+        // build must end up with both usable — not one silently overwriting the other.
+        var artifactsRoot = Path.Combine(_dir, "artifacts");
+        const string version = "28.4.53241.53989";
+
+        var w1 = ProvisioningCheck.PlatformAppsDirFor(artifactsRoot, version, "w1");
+        var us = ProvisioningCheck.PlatformAppsDirFor(artifactsRoot, version, "us");
+        var de = ProvisioningCheck.PlatformAppsDirFor(artifactsRoot, version, "de");
+
+        Assert.NotEqual(w1, us);
+        Assert.NotEqual(w1, de);
+        Assert.NotEqual(us, de);
+
+        Directory.CreateDirectory(w1);
+        File.WriteAllText(Path.Combine(w1, "Microsoft_Base Application_28.4.53241.53989.app"), "w1-marker");
+        Directory.CreateDirectory(us);
+        File.WriteAllText(Path.Combine(us, "Microsoft_Base Application_28.4.53241.53989.app"), "us-marker");
+
+        // Each set kept its own distinct content — neither overwrote the other.
+        Assert.Equal("w1-marker",
+            File.ReadAllText(Path.Combine(w1, "Microsoft_Base Application_28.4.53241.53989.app")));
+        Assert.Equal("us-marker",
+            File.ReadAllText(Path.Combine(us, "Microsoft_Base Application_28.4.53241.53989.app")));
+    }
+
+    [Fact]
+    public void PlatformAppsDirFor_CountryIsCaseInsensitiveAndTrimmed()
+    {
+        var artifactsRoot = Path.Combine(_dir, "artifacts");
+
+        var upper = ProvisioningCheck.PlatformAppsDirFor(artifactsRoot, "28.4.53241.53989", "US");
+        var padded = ProvisioningCheck.PlatformAppsDirFor(artifactsRoot, "28.4.53241.53989", " us ");
+        var lower = ProvisioningCheck.PlatformAppsDirFor(artifactsRoot, "28.4.53241.53989", "us");
+
+        Assert.Equal(lower, upper);
+        Assert.Equal(lower, padded);
+    }
+
     // ── CollectBundleAlpackagesDirs (issue #1678) ─────────────────────────────
     // The startup gate that decides whether --auto-provision fires (or the run fails
     // loud without it) used to scan ONLY the home-rooted default package caches, never
@@ -688,6 +757,109 @@ public sealed class ProvisioningCheckTests : IDisposable
         var needs = ProvisioningCheck.DetermineManifestNeeds(roots);
         Assert.False(needs.NeedsPlatformApps);
         Assert.False(needs.NeedsTestApps);
+    }
+
+    // ── Issue #2236: country-widened platform need ────────────────────────────
+    // The real repro: a bundle depends on "IRS Forms" (Microsoft-published, a country-
+    // localization app), which is neither in the w1-curated set NOR reachable via any
+    // recorded edge (nothing has ever been downloaded, so ScanDependencyEdges knows
+    // nothing). Without extraPlatformNeedCandidates this reads exactly like
+    // "Power BI Reports" above — an unknown Microsoft extension, triggers nothing — and
+    // --auto-provision --country us would silently download NOTHING at all, leaving the
+    // exact same "Missing: Microsoft/IRS Forms" failure the country flag was supposed to
+    // fix. Widening the candidate set is what makes the download actually fire.
+
+    [Fact]
+    public void DetermineManifestNeeds_CountrySpecificApp_WithoutExtraCandidates_TriggersNeither()
+    {
+        // Baseline: identical shape to DetermineManifestNeeds_UnknownMicrosoftExtension_
+        // TriggersNeither, pinned explicitly for "IRS Forms" so the country-widening test
+        // right below it has an unwidened baseline to contrast against.
+        var roots = new[]
+        {
+            new DependencyRef(Guid.NewGuid(), "IRS Forms", "Microsoft", new Version(27, 5, 0, 0)),
+        };
+        var needs = ProvisioningCheck.DetermineManifestNeeds(roots);
+        Assert.False(needs.NeedsPlatformApps);
+    }
+
+    [Fact]
+    public void DetermineManifestNeeds_CountrySpecificApp_WithExtraCandidate_NeedsPlatformApps()
+    {
+        var roots = new[]
+        {
+            new DependencyRef(Guid.NewGuid(), "IRS Forms", "Microsoft", new Version(27, 5, 0, 0)),
+        };
+        var needs = ProvisioningCheck.DetermineManifestNeeds(
+            roots, dependencyEdges: null, extraPlatformNeedCandidates: new[] { "IRS Forms" });
+
+        Assert.True(needs.NeedsPlatformApps);
+        Assert.Contains("IRS Forms", needs.RequiredPlatformApps);
+    }
+
+    [Fact]
+    public void DecideManifestProvisioning_W1Country_DoesNotWidenBeyondTheCuratedSet()
+    {
+        // The safety rail: an ordinary (w1) run must NEVER widen — that would invent an
+        // unsatisfiable download demand for a country app the w1 set can never supply
+        // (exactly the bug the message-side #2236 fix addresses; doing it here too would
+        // instead waste a real w1 download attempt and still fail).
+        var roots = new[]
+        {
+            new DependencyRef(Guid.NewGuid(), "IRS Forms", "Microsoft", new Version(27, 5, 0, 0)),
+        };
+        var legacyReport = new ProvisioningCheck.PlatformAppsReport(
+            "27.5.53238.55217", Array.Empty<(string, string, string)>(), Array.Empty<string>());
+
+        var decision = ProvisioningCheck.DecideManifestProvisioning(
+            roots, legacyReport, Array.Empty<string>(), country: "w1");
+
+        Assert.False(decision.ShouldDownloadPlatform);
+    }
+
+    [Fact]
+    public void DecideManifestProvisioning_NonW1Country_WidensAndTriggersDownload()
+    {
+        var roots = new[]
+        {
+            new DependencyRef(Guid.NewGuid(), "IRS Forms", "Microsoft", new Version(27, 5, 0, 0)),
+        };
+        var legacyReport = new ProvisioningCheck.PlatformAppsReport(
+            "27.5.53238.55217", Array.Empty<(string, string, string)>(), Array.Empty<string>());
+
+        // No search dirs at all — nothing is on disk, matching the real repro's cold cache.
+        var decision = ProvisioningCheck.DecideManifestProvisioning(
+            roots, legacyReport, Array.Empty<string>(), country: "us");
+
+        Assert.True(decision.NeedsPlatformApps);
+        Assert.True(decision.ShouldDownloadPlatform);
+        Assert.Contains("IRS Forms", decision.RequiredPlatformApps);
+    }
+
+    [Fact]
+    public void DecideManifestProvisioning_NonW1Country_AlreadyPresent_DoesNotRedownload()
+    {
+        // Once the country-specific app IS present on disk (e.g. a prior --country us
+        // download already fetched it), the widened candidate must not force a spurious
+        // re-download every subsequent run.
+        var artifactsRoot = Path.Combine(_dir, "artifacts");
+        var usPlatformDir = ProvisioningCheck.PlatformAppsDirFor(artifactsRoot, "27.5.53238.55217", "us");
+        Directory.CreateDirectory(usPlatformDir);
+        WriteSymbolOnlyApp(usPlatformDir, "microsoft_irs forms_27.5.53238.55217.app",
+            "b696b4c9-637c-49d1-a806-763ff8f0a20e", "IRS Forms", "Microsoft", "27.5.53238.55217");
+
+        var roots = new[]
+        {
+            new DependencyRef(Guid.NewGuid(), "IRS Forms", "Microsoft", new Version(27, 5, 0, 0)),
+        };
+        var legacyReport = new ProvisioningCheck.PlatformAppsReport(
+            "27.5.53238.55217", Array.Empty<(string, string, string)>(), Array.Empty<string>());
+
+        var decision = ProvisioningCheck.DecideManifestProvisioning(
+            roots, legacyReport, new[] { usPlatformDir }, country: "us");
+
+        Assert.True(decision.NeedsPlatformApps);
+        Assert.False(decision.ShouldDownloadPlatform);
     }
 
     [Fact]

--- a/AlRunner/BcCompiler.cs
+++ b/AlRunner/BcCompiler.cs
@@ -2512,9 +2512,16 @@ public sealed partial class BcCompiler
             }
             else
             {
-                // bcartifacts.cache/sandbox/<ver>/{w1/Extensions, platform/Applications}
-                var w1Ext = Path.Combine(bestVer, "w1", "Extensions");
-                if (Directory.Exists(w1Ext)) yield return w1Ext;
+                // bcartifacts.cache/sandbox/<ver>/{<country>/Extensions, platform/Applications}
+                // Issue #2236: this is VS Code's AL-extension symbol cache (read-only to us),
+                // using the same sandbox/<ver>/<channel>/ layout as our own artifact CDN — one
+                // channel folder per country. Hardcoding "w1" here missed a machine that
+                // already has a country-localized project's symbols downloaded there. Scan the
+                // SELECTED country's own folder, not both w1 and the country's: mixing them
+                // would risk the same "which duplicate basename wins" ambiguity #2236's
+                // Extensions/-vs-Applications.<CC>/ fix exists to avoid for our own cache.
+                var localizedExt = Path.Combine(bestVer, AlRunner.Infrastructure.BcArtifacts.SelectedCountry, "Extensions");
+                if (Directory.Exists(localizedExt)) yield return localizedExt;
                 var platApps = Path.Combine(bestVer, "platform", "Applications");
                 if (Directory.Exists(platApps)) yield return platApps;
             }

--- a/AlRunner/Infrastructure/BcArtifacts.cs
+++ b/AlRunner/Infrastructure/BcArtifacts.cs
@@ -78,6 +78,28 @@ public static class BcArtifacts
     /// the process to latest-in-cache).</summary>
     public static bool IsSelected => _selectedVersion != null;
 
+    private static string _selectedCountry = "w1";
+
+    /// <summary>
+    /// The single BC artifact country/localization channel selected for this process
+    /// (issue #2236) — "w1" (worldwide, the default) or a two/three-letter BC country
+    /// code such as "us", "de", "gb". Set once at startup from <c>--country</c>
+    /// (Program.cs); every resolver that needs a country-keyed directory or CDN channel
+    /// reads this instead of taking the value as a parameter, so <c>--country</c> does
+    /// not have to be threaded through every call site individually — the same pattern
+    /// <see cref="SelectedVersion"/> already uses for the BC version. Deliberately a
+    /// plain mutable property, not lock-guarded like <see cref="SelectVersion"/>: unlike
+    /// version selection there is no directory to probe and no "already selected,
+    /// conflicting re-select" hazard — it is just a string the download/path helpers
+    /// read, validated lazily by whether the resulting CDN URL 404s (see
+    /// ArtifactDownloader.PlatformApps), not by an allowlist here.
+    /// </summary>
+    public static string SelectedCountry
+    {
+        get => _selectedCountry;
+        set => _selectedCountry = string.IsNullOrWhiteSpace(value) ? "w1" : value.Trim().ToLowerInvariant();
+    }
+
     private static readonly object _lock = new();
 
     // AlRunnerPaths.UserHome throws loudly (issue #2114) rather than silently handing back

--- a/AlRunner/Infrastructure/MissingDependencyException.cs
+++ b/AlRunner/Infrastructure/MissingDependencyException.cs
@@ -57,6 +57,15 @@ public sealed class MissingDependencyException : Exception, IDependencyProvision
     {
         var versionHint = bcVersion ?? "28.x";
         bool isMicrosoft = string.Equals(DepPublisher, "Microsoft", StringComparison.OrdinalIgnoreCase);
+        // Issue #2236: "Microsoft-published" alone does not mean `provision`/
+        // `--auto-provision` can ever fetch it — those two commands (and their narrower
+        // --platform-apps/--test-apps forms) only ever download the w1 (worldwide)
+        // artifact's curated app set. A Microsoft app outside that set (most commonly a
+        // country-localization app like "IRS Forms") is not something a repeated
+        // `al-runner provision` will ever produce, no matter how many times it is re-run
+        // — the repo owner hit exactly that: byte-identical advice, twice, no progress.
+        bool isKnownW1Downloadable = isMicrosoft
+            && AlRunner.Infrastructure.ProvisioningCheck.IsKnownW1DownloadableAppName(DepName);
 
         var lines = new List<string>
         {
@@ -74,7 +83,7 @@ public sealed class MissingDependencyException : Exception, IDependencyProvision
         lines.Add("");
         lines.Add("  Resolve it:");
         lines.Add("");
-        if (isMicrosoft)
+        if (isKnownW1Downloadable)
         {
             lines.Add("  (a) One command (recommended) — provisions all missing Microsoft artifacts:");
             lines.Add("        al-runner provision");
@@ -85,6 +94,25 @@ public sealed class MissingDependencyException : Exception, IDependencyProvision
             lines.Add("");
             lines.Add("  (c) Force-download Microsoft platform apps only:");
             lines.Add($"        al-runner provision --platform-apps --bc-version {versionHint}");
+        }
+        else if (isMicrosoft)
+        {
+            // Not one of the apps the w1 download path can ever produce. Re-running
+            // `provision`/`--auto-provision` cannot fix this — say so, and name the
+            // likely reason instead of repeating advice already proven not to work.
+            lines.Add($"  '{DepName}' is not part of the w1 (worldwide) artifact set that");
+            lines.Add("  `al-runner provision` / `--auto-provision` download — running either");
+            lines.Add("  again changes nothing here, no matter how many times you try.");
+            lines.Add("");
+            lines.Add("  This usually means it is a country/regional localization app (Microsoft");
+            lines.Add("  ships those in a separate, per-country artifact channel, not w1).");
+            lines.Add("");
+            lines.Add("  (a) If you know the target country, re-run with --country to fetch the");
+            lines.Add("      localized artifact set instead of w1, e.g.:");
+            lines.Add($"        al-runner --auto-provision --country us --bc-version {versionHint} <bundle>");
+            lines.Add("");
+            lines.Add("  (b) Otherwise, add the package to your --package-cache <dir> by hand");
+            lines.Add("      (usually your project's .alpackages).");
         }
         else
         {

--- a/AlRunner/Infrastructure/ProvisioningCheck.cs
+++ b/AlRunner/Infrastructure/ProvisioningCheck.cs
@@ -454,9 +454,28 @@ public static class ProvisioningCheck
     /// Runner-owned directory to download Microsoft platform R2R runtime apps (System
     /// Application, Base Application, Business Foundation) into. Sibling of
     /// <see cref="TestAppsDirFor"/> under the same per-version artifact root.
+    ///
+    /// Issue #2236: keyed by <paramref name="country"/> (default = <see
+    /// cref="BcArtifacts.SelectedCountry"/>, "w1" unless <c>--country</c> was passed) so a
+    /// w1 set and a country-localized set for the SAME BC build never collide — a country
+    /// artifact's Base Application is a genuinely different file, not a superset of w1's
+    /// (see ArtifactDownloader.PlatformApps). "w1" keeps the pre-#2236 bare directory name
+    /// (no migration needed for existing caches / test fixtures); any other country gets
+    /// its own "platform-apps-&lt;country&gt;" sibling, so provisioning both leaves both
+    /// usable side by side instead of one silently overwriting the other.
     /// </summary>
-    public static string PlatformAppsDirFor(string artifactsRootDir, string fullVersion)
-        => Path.Combine(artifactsRootDir, fullVersion, "platform-apps");
+    public static string PlatformAppsDirFor(string artifactsRootDir, string fullVersion, string? country = null)
+    {
+        var c = NormalizeCountry(country);
+        return c == "w1"
+            ? Path.Combine(artifactsRootDir, fullVersion, "platform-apps")
+            : Path.Combine(artifactsRootDir, fullVersion, $"platform-apps-{c}");
+    }
+
+    /// <summary>null → <see cref="BcArtifacts.SelectedCountry"/> (the process-wide default);
+    /// otherwise trim + lowercase the explicit value the same way SelectedCountry does.</summary>
+    private static string NormalizeCountry(string? country)
+        => string.IsNullOrWhiteSpace(country) ? BcArtifacts.SelectedCountry : country.Trim().ToLowerInvariant();
 
     /// <summary>
     /// Runner-owned directory to download the Microsoft test toolkit (Business Foundation
@@ -777,6 +796,31 @@ public static class ProvisioningCheck
     };
 
     /// <summary>
+    /// Every Microsoft app name the w1 (worldwide) artifact download commands
+    /// (`al-runner provision` / `--auto-provision`, and their `--platform-apps` /
+    /// `--test-apps` narrower forms) can ever actually fetch: <see
+    /// cref="KnownPlatformRuntimeApps"/> (System Application, Base Application, Business
+    /// Foundation) + the two curated w1/Extensions apps ArtifactDownloader.PlatformApps
+    /// also downloads by name ("Application", "Application Test Library") + the platform
+    /// symbol app "System" (ArtifactDownloader.SystemApp) + <see
+    /// cref="KnownTestFrameworkAppNames"/>.
+    ///
+    /// Issue #2236: MissingDependencyException.ToDetailedMessage uses this to decide
+    /// whether "re-run with --auto-provision" is actually true advice for a given
+    /// Microsoft-publisher dependency, or whether it is dead advice a user could follow
+    /// forever without result — a country-localization app such as "IRS Forms" is
+    /// Microsoft-published but is not in this list, because it ships only in a
+    /// country-specific artifact channel (see ArtifactDownloader.PlatformApps'
+    /// country-aware download), not the w1 one these two commands always fetch.
+    /// </summary>
+    public static bool IsKnownW1DownloadableAppName(string appName)
+        => IsKnownPlatformRuntimeApp(appName)
+           || string.Equals(appName, "Application", StringComparison.OrdinalIgnoreCase)
+           || string.Equals(appName, "Application Test Library", StringComparison.OrdinalIgnoreCase)
+           || string.Equals(appName, "System", StringComparison.OrdinalIgnoreCase)
+           || KnownTestFrameworkAppNames.Any(n => string.Equals(n, appName, StringComparison.OrdinalIgnoreCase));
+
+    /// <summary>
     /// Manifest-derived provisioning need, independent of what's currently on disk.
     /// <paramref name="RequiredPlatformApps"/> names the individual apps out of the curated
     /// platform-apps set that these manifests actually require, so callers can check
@@ -802,20 +846,41 @@ public static class ProvisioningCheck
     /// nothing has been downloaded yet. Tests also pass synthetic graphs here to prove the
     /// WALK itself (issue #2087).
     /// </param>
+    /// <param name="extraPlatformNeedCandidates">
+    /// Issue #2236: additional app names to ask "do these manifests require this" for,
+    /// beyond <see cref="PlatformNeedTargets"/> (the fixed w1-curated set). Pass null for
+    /// an ordinary w1 run — widening the candidate set there would invent an unsatisfiable
+    /// requirement for any Microsoft app outside the w1 download's actual contents (the
+    /// bug MissingDependencyException.ToDetailedMessage's #2236 fix addresses on the
+    /// message side; doing it here too would instead spend a real download attempt trying
+    /// and still failing). Only the caller's own <c>--country</c> selection knows whether
+    /// widening is safe: when a NON-w1 country is selected, ArtifactDownloader.PlatformApps
+    /// fetches every Microsoft app under Extensions/, not just the curated five, so a
+    /// direct Microsoft-publisher root the bundle declares (e.g. "IRS Forms") IS something
+    /// that download can satisfy and belongs in the candidate set too.
+    /// </param>
     public static ManifestNeeds DetermineManifestNeeds(
         IEnumerable<AlRunner.DependencyRef> roots,
-        IReadOnlyDictionary<string, IReadOnlyList<string>>? dependencyEdges = null)
+        IReadOnlyDictionary<string, IReadOnlyList<string>>? dependencyEdges = null,
+        IReadOnlyList<string>? extraPlatformNeedCandidates = null)
     {
         var edges = dependencyEdges ?? EmptyDependencyEdges;
         var rootList = roots as IReadOnlyCollection<AlRunner.DependencyRef> ?? roots.ToList();
         bool needsTest = false;
 
-        // Which apps out of the curated platform-apps set do these manifests require?
-        // Asked per-app, over whatever the manifests NAME (directly, or reach through
-        // recorded edges) — never a fixed exemption list. Iterating the set in its declared
-        // order keeps the result deterministic for messages and tests.
+        // Which apps out of the curated platform-apps set (plus, for a non-w1 country, any
+        // extra candidate the caller supplied) do these manifests require? Asked per-app,
+        // over whatever the manifests NAME (directly, or reach through recorded edges) —
+        // never a fixed exemption list. Iterating in declared order keeps the result
+        // deterministic for messages and tests; Distinct guards against a candidate
+        // appearing in both lists (harmless either way, but avoids a duplicate entry in
+        // RequiredPlatformApps/the eventual message).
+        var candidates = extraPlatformNeedCandidates == null
+            ? PlatformNeedTargets
+            : PlatformNeedTargets.Concat(extraPlatformNeedCandidates)
+                .Distinct(StringComparer.OrdinalIgnoreCase).ToList();
         var requiredPlatformApps = new List<string>();
-        foreach (var candidate in PlatformNeedTargets)
+        foreach (var candidate in candidates)
         {
             var single = new[] { candidate };
             foreach (var d in rootList)
@@ -1057,14 +1122,34 @@ public static class ProvisioningCheck
     /// --auto-provision download decision) just as much as it was in the warm-reuse scan
     /// this issue's repro pointed at.
     /// </summary>
+    /// <param name="country">
+    /// BC artifact country channel — null (the default) reads <see
+    /// cref="BcArtifacts.SelectedCountry"/>, same pattern as <see cref="PlatformAppsDirFor"/>.
+    /// Issue #2236: when this resolves to anything other than "w1", every direct
+    /// Microsoft-publisher root dependency the manifests declare becomes an extra platform-
+    /// need candidate (see DetermineManifestNeeds' extraPlatformNeedCandidates) — a
+    /// country-selected download can satisfy any Microsoft app under Extensions/, not just
+    /// the w1-curated five, so a bundle depending on e.g. "IRS Forms" now actually triggers
+    /// the download that can supply it, instead of needs-detection staying blind to an app
+    /// it has never heard of and never downloading anything.
+    /// </param>
     public static ManifestProvisionDecision DecideManifestProvisioning(
         IEnumerable<AlRunner.DependencyRef> manifestRoots,
         PlatformAppsReport legacySymbolOnlyReport,
-        IReadOnlyList<string> searchDirs)
+        IReadOnlyList<string> searchDirs,
+        string? country = null)
     {
         var rootsList = manifestRoots as ICollection<AlRunner.DependencyRef> ?? manifestRoots.ToList();
         var scan = ScanDependencyEdges(searchDirs);
-        var needs = DetermineManifestNeeds(rootsList, scan.Edges);
+        var countryNormalized = NormalizeCountry(country);
+        IReadOnlyList<string>? extraPlatformNeedCandidates = countryNormalized == "w1"
+            ? null
+            : rootsList
+                .Where(d => string.Equals(d.Publisher, "Microsoft", StringComparison.OrdinalIgnoreCase))
+                .Select(d => d.Name)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList();
+        var needs = DetermineManifestNeeds(rootsList, scan.Edges, extraPlatformNeedCandidates);
         // A floor the BC version under provision could never supply must not create a
         // demand no download can clear — see DropUnsatisfiableFloors. The report carries
         // the selected version, which is exactly the version a download would target.

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -366,6 +366,13 @@ bool provisionServiceTier = false;
 bool provisionForce = false;
 string? provisionResolveVersionPrefix = null;
 bool provisionHelp = false;
+// Issue #2236: BC artifact country/localization channel — "w1" (worldwide, default) or a
+// country code such as "us"/"de"/"gb". Not validated against a hardcoded allowlist here
+// (Microsoft adds codes on its own schedule); an unresolvable code fails loud, naming the
+// exact CDN URL that 404'd, the first time provisioning actually needs it (see
+// ArtifactDownloader.PlatformApps / TryHeadContentLength). Applies to BOTH a normal run's
+// --auto-provision AND the `provision` subcommand (including `provision --platform-apps`).
+string countryArg = "w1";
 for (int i = 0; i < args.Length; i++)
 {
     if (i == 0 && args[i] == "provision") { continue; } // consumed as subcommand
@@ -377,6 +384,7 @@ for (int i = 0; i < args.Length; i++)
     if (args[i] == "--resolve-version" && i + 1 < args.Length) { provisionResolveVersionPrefix = args[++i]; continue; }
     if (args[i] == "--auto-provision") { autoProvision = true; continue; }
     if (args[i] == "--no-auto-provision") { autoProvision = false; continue; }
+    if (args[i] == "--country" && i + 1 < args.Length) { countryArg = args[++i]; continue; }
     if (args[i] == "--bc-version" && i + 1 < args.Length) { bcVersionArg = args[++i]; continue; }
     if (args[i] == "--artifact-path" && i + 1 < args.Length) { artifactPathArg = args[++i]; continue; }
     if (args[i] == "--out" && i + 1 < args.Length) { outPath = args[++i]; printClassification = true; continue; }
@@ -475,6 +483,11 @@ for (int i = 0; i < args.Length; i++)
     }
     bundles.Add(args[i]);
 }
+// Issue #2236: set the process-wide selected country as early as possible — before
+// RunExplicitProvisionModes, PlatformCheckDirs, DefaultPackageCacheDirs, or any other
+// resolver that reads AlRunner.Infrastructure.BcArtifacts.SelectedCountry gets a chance
+// to run. The setter itself normalizes (trim + lowercase, empty/whitespace -> "w1").
+AlRunner.Infrastructure.BcArtifacts.SelectedCountry = countryArg;
 if (serverMode && watchMode)
 {
     Console.Error.WriteLine("--server and --watch are mutually exclusive (both stay warm in-process; pick one).");
@@ -1076,8 +1089,16 @@ try
     // BcArtifacts state happens to hold whenever the list is eventually flushed.
     var selectedVersionForPrint = AlRunner.Infrastructure.BcArtifacts.SelectedVersion;
     var serviceTierDirForPrint = AlRunner.Infrastructure.BcArtifacts.ServiceTierDir;
+    // Issue #2236: name the selected country whenever it is not the (invisible, so far
+    // unremarkable) w1 default — a --country run producing the byte-identical "[bc]
+    // selected BC ..." line as a w1 run would leave no visible trace that --country was
+    // even recognized, which is exactly the kind of silent-no-op this repo's
+    // loud-failures.md rule exists to prevent for a flag that changes what gets downloaded.
+    var selectedCountryForPrint = AlRunner.Infrastructure.BcArtifacts.SelectedCountry;
     deferredStartupLines.Add(() => Console.Error.WriteLine(
-        $"[bc] selected BC {selectedVersionForPrint} ({serviceTierDirForPrint})"));
+        selectedCountryForPrint == "w1"
+            ? $"[bc] selected BC {selectedVersionForPrint} ({serviceTierDirForPrint})"
+            : $"[bc] selected BC {selectedVersionForPrint} ({serviceTierDirForPrint}) [country: {selectedCountryForPrint}]"));
 }
 catch (InvalidOperationException ex)
 {
@@ -1500,7 +1521,8 @@ if (!provisionSubcommand)
             {
                 Console.Error.WriteLine("[provision] platform R2R apps missing — downloading...");
                 var rc = AlRunner.Provisioning.ArtifactDownloader.PlatformApps(
-                    full, platformAppsOut, m => Console.Error.WriteLine($"[provision] {m}"));
+                    full, platformAppsOut, AlRunner.Infrastructure.BcArtifacts.SelectedCountry,
+                    m => Console.Error.WriteLine($"[provision] {m}"));
                 if (rc != 0)
                 {
                     Console.Error.WriteLine("[provision] platform-apps download failed; cannot continue.");
@@ -5128,6 +5150,15 @@ static void PrintGuide(TextWriter w)
     w.WriteLine("    al-runner provision <bundle-dir>        # provision for that project's version, then exit");
     w.WriteLine("    al-runner --auto-provision <dirs>       # same as the default, explicit for scripts");
     w.WriteLine("    al-runner --no-auto-provision <dirs>    # fail loud instead of reaching the network");
+    w.WriteLine();
+    w.WriteLine("  Auto-provisioning only ever fetches the w1 (worldwide) artifact by default. A");
+    w.WriteLine("  project depending on a country-localization Microsoft app (e.g. \"IRS Forms\") can");
+    w.WriteLine("  NEVER be satisfied that way, no matter how many times `provision`/");
+    w.WriteLine("  --auto-provision is re-run — the \"Missing: Microsoft/...\" message says so and");
+    w.WriteLine("  names --country as the fix when that looks like the cause:");
+    w.WriteLine("    al-runner --auto-provision --country us <bundle-dir>");
+    w.WriteLine("  A country set is provisioned into its own \"platform-apps-<code>\" cache directory,");
+    w.WriteLine("  separate from w1's, so provisioning both leaves both usable.");
     w.WriteLine("  If a provisioning-gap message names a specific missing set, force just that one");
     w.WriteLine("  (bypasses need-detection entirely — useful when the default `provision` mis-detects,");
     w.WriteLine("  issue #2085):");
@@ -5364,6 +5395,18 @@ static void PrintHelp(TextWriter w)
     w.WriteLine("                          platform/ + w1/), bypassing the cache scan. Its version");
     w.WriteLine("                          is read from the dir name or the contained Ncl.dll.");
     w.WriteLine("                          Mutually exclusive with --bc-version.");
+    w.WriteLine("  --country CODE          BC artifact country/localization channel to provision from");
+    w.WriteLine("                          — \"w1\" (worldwide, default) or a country code such as");
+    w.WriteLine("                          \"us\"/\"de\"/\"gb\". A project depending on a country-");
+    w.WriteLine("                          localization Microsoft app (e.g. \"IRS Forms\") cannot be");
+    w.WriteLine("                          provisioned from w1 at all — the \"Missing: Microsoft/...\"");
+    w.WriteLine("                          message names this flag when that is the likely cause.");
+    w.WriteLine("                          Not validated against a hardcoded list of codes: an");
+    w.WriteLine("                          unresolvable one fails loud, naming the exact CDN URL that");
+    w.WriteLine("                          404'd. Provisioned country sets live in their own");
+    w.WriteLine("                          \"platform-apps-<code>\" cache directory, separate from the");
+    w.WriteLine("                          w1 \"platform-apps\" one, so provisioning both leaves both");
+    w.WriteLine("                          usable.");
     w.WriteLine("  --auto-provision        Download the BC artifacts for the project's version if");
     w.WriteLine("                          they are missing, then continue the run. ON BY DEFAULT");
     w.WriteLine("                          since issue #2024 — this flag is now redundant with a");
@@ -6759,8 +6802,18 @@ static IEnumerable<string> DefaultPackageCacheDirs()
     var bcLatest = SelectVersionDirOrNull(bcRoot, mmPrefix);
     if (bcLatest != null)
     {
-        var w1Ext = Path.Combine(bcLatest, "w1", "Extensions");
-        if (Directory.Exists(w1Ext)) yield return w1Ext;
+        // Issue #2236: this tree is VS Code's AL-extension symbol cache, not ours — we only
+        // read it, never download into it — but it uses the SAME sandbox/<ver>/<channel>/
+        // layout our own artifact CDN does, one channel folder per country. A machine that
+        // already has a country-localized project's symbols downloaded there (VS Code's own
+        // "AL: Download Symbols" honors app.json/the workspace's own settings, which can
+        // target a country other than w1) would never be found by a hardcoded "w1" lookup —
+        // the exact shape of gap this issue exists to close, one directory over. Scan the
+        // SELECTED country's own channel folder, not both: mixing w1 and a country's folder
+        // here would risk the identical "which duplicate basename wins" ambiguity #2236's
+        // own Extensions/-vs-Applications.<CC>/ fix exists to avoid for our own cache.
+        var localizedExt = Path.Combine(bcLatest, AlRunner.Infrastructure.BcArtifacts.SelectedCountry, "Extensions");
+        if (Directory.Exists(localizedExt)) yield return localizedExt;
         var platApps = Path.Combine(bcLatest, "platform", "Applications");
         if (Directory.Exists(platApps)) yield return platApps;
         // The `System` platform-symbols app (Microsoft/System) ships here, not in
@@ -7223,7 +7276,8 @@ static int RunExplicitProvisionModes(string? bcVersionArg, List<string> bundles,
         var dir = AlRunner.Infrastructure.ProvisioningCheck.PlatformAppsDirFor(
             AlRunner.Infrastructure.BcArtifacts.ArtifactsRootDir, full);
         anyFailed |= ForceProvisionMode("Microsoft platform apps", dir, full, force, "*.app",
-            (v, d, log) => AlRunner.Provisioning.ArtifactDownloader.PlatformApps(v, d, log)) != 0;
+            (v, d, log) => AlRunner.Provisioning.ArtifactDownloader.PlatformApps(
+                v, d, AlRunner.Infrastructure.BcArtifacts.SelectedCountry, log)) != 0;
     }
     if (testApps)
     {
@@ -7601,7 +7655,8 @@ static void EnsurePlatformAppsProvisioned(string engineVersion, List<string> bun
     try
     {
         var rc = AlRunner.Provisioning.ArtifactDownloader.PlatformApps(
-            platformFull, platformAppsOut, m => Console.Error.WriteLine($"[provision] {m}"));
+            platformFull, platformAppsOut, AlRunner.Infrastructure.BcArtifacts.SelectedCountry,
+            m => Console.Error.WriteLine($"[provision] {m}"));
         if (rc != 0)
             Console.Error.WriteLine(
                 $"[provision] warning: could not fetch platform apps for BC {platformFull}. " +

--- a/tools/DownloadArtifacts/Program.cs
+++ b/tools/DownloadArtifacts/Program.cs
@@ -6,11 +6,16 @@
 //   dotnet run --project tools/DownloadArtifacts -- <mode> <version> <output-dir>
 //
 // Modes:
-//   service-tier    <bc-version> <output-dir>   ~55 Nav DLLs (/service/ closure)
-//   platform-apps   <bc-version> <output-dir>   MS Base/System/BF/Application .app files
-//   test-apps       <bc-version> <output-dir>   test-toolkit .app files
-//   al-compiler     <tool-version> <output-dir> AL compiler DLLs (RID-aware NuGet pkg)
-//   resolve-version <bc-prefix>                 latest full version → stdout
+//   service-tier    <bc-version> <output-dir>              ~55 Nav DLLs (/service/ closure)
+//   platform-apps   <bc-version> <output-dir> [country]     MS Base/System/BF/Application .app
+//                                                            files. Optional 4th arg (issue
+//                                                            #2236): "w1" (default) or a country
+//                                                            code such as "us" — purely additive,
+//                                                            the stable 3-arg CI invocation is
+//                                                            unaffected.
+//   test-apps       <bc-version> <output-dir>              test-toolkit .app files
+//   al-compiler     <tool-version> <output-dir>             AL compiler DLLs (RID-aware NuGet pkg)
+//   resolve-version <bc-prefix>                             latest full version → stdout
 
 using AlRunner.Provisioning;
 
@@ -31,7 +36,11 @@ var outputDir = args.Length >= 3 ? args[2] : "";
 switch (mode)
 {
     case "service-tier": return ArtifactDownloader.ServiceTier(version, outputDir);
-    case "platform-apps": return ArtifactDownloader.PlatformApps(version, outputDir);
+    case "platform-apps":
+        // Optional 4th positional arg (issue #2236): country code, "w1" if omitted — additive
+        // only, so the stable 3-arg CI invocation (bc-tests.yml/AlRunner.csproj) is unaffected.
+        var country = args.Length >= 4 ? args[3] : "w1";
+        return ArtifactDownloader.PlatformApps(version, outputDir, country);
     case "test-apps": return ArtifactDownloader.TestApps(version, outputDir);
     case "al-compiler": return ArtifactDownloader.AlCompiler(version, outputDir);
     case "resolve-version":


### PR DESCRIPTION
Closes #2236

## Problem

`al-runner` only ever downloaded the **w1** (worldwide) BC artifact. Any project
depending on a country-localization Microsoft app (e.g. `IRS Forms`) could never be
auto-provisioned — `al-runner provision` / `--auto-provision` doesn't have that app,
no matter how many times you run it — and the "Missing:" error recommended exactly
those two commands anyway, so a user following the advice got the identical message
twice and reasonably concluded the tool was lying.

Measured on a real US customer extension (`Blumenthal_Extension`, one dependency:
`Microsoft/IRS Forms 27.5.0.0`).

## Fix

**1. `--country CODE` flag** (default `w1`), plumbed into `ArtifactDownloader.PlatformApps`'s
CDN URL (`{CdnBase}/{version}/{country}`). Not validated against a hardcoded allowlist —
an unresolvable code 404s, and the message now names the exact URL that failed (was
previously just version + channel name).

**2. Country downloads pull in more than the curated w1 set.** A country artifact is
not "w1 plus extras" — its Base/System Application etc. are *different files* from
w1's (measured: the US Base Application is 110.6 MB vs w1's 98.6 MB for the identical
build). For `w1` the download stays the existing curated 5-app set (unchanged, same
~135 MB). For any other country, it downloads every Microsoft-published `.app` under
the artifact's `Extensions/` folder — this naturally covers the localized core set
*and* whatever country-specific app a project depends on (IRS Forms and its own
transitive Microsoft deps), with no per-country name list to maintain. Anchored
specifically on `Extensions/` because the country artifact *also* ships an
`Applications.<CC>/` folder holding a different, smaller, non-localized file with the
identical basename — a basename-only match would silently pick the wrong one.

**3. Country-keyed cache directory.** `w1` keeps the existing `platform-apps` directory
name (no migration for existing caches). Any other country gets its own
`platform-apps-<code>` sibling, so a `w1` set and a `us` set for the same build coexist
instead of overwriting each other.

**4. Manifest-driven need-detection widened for non-w1.** Need-detection previously only
recognized the curated w1 app names (`System Application`, `Base Application`,
`Business Foundation`, `Application`, `Application Test Library`) as things worth
downloading for — an app like "IRS Forms" registered as an unrelated, unknown Microsoft
extension and triggered *nothing*, so `--auto-provision --country us` alone did not
actually fix the repro; it needed this too. When a non-w1 country is selected, every
direct Microsoft-publisher dependency a bundle declares becomes an extra candidate,
since the broadened country download (point 2) can actually satisfy it. This widening
is gated strictly on country != `w1` — an ordinary w1 run's behavior is byte-identical
to before.

**5. `MissingDependencyException`'s remediation message**, fixed and tested separately
first per the issue's instruction: it used to recommend `al-runner provision` /
`--auto-provision` for *any* Microsoft-publisher dependency. Now it checks whether the
missing app is actually one the w1 download can supply
(`ProvisioningCheck.IsKnownW1DownloadableAppName`) and, when it isn't, says so plainly,
names the likely reason (country localization), and points at `--country` instead of
repeating advice already proven not to work.

## Verification

**Real end-to-end run**, no `--package-cache`, ambient machine — before and after:

```
$ al-runner Blumenthal_Extension --no-auto-provision
...
  Missing: Microsoft/IRS Forms v27.5.0.0
  ...
  'IRS Forms' is not part of the w1 (worldwide) artifact set that
  `al-runner provision` / `--auto-provision` download — running either
  again changes nothing here, no matter how many times you try.
  ...
  (a) If you know the target country, re-run with --country ...

$ al-runner Blumenthal_Extension --auto-provision --country us
...
[provision] Downloaded 155 app(s) (374 MB total) to .../28.1.49838.54044/platform-apps-us
...
Tests:         0 total
  pass:        0
  fail:        0
  error:       0
compile-fail:0
```
Exit code 0, `compile-fail: 0` — matches the task's stated success signal (the
extension has no test codeunits). A repeat run against the now-warm cache completes in
0.2s.

Confirmed `~/.local/share/al-runner/artifacts/<ver>/platform-apps` (w1, pre-existing)
and `platform-apps-us` (new) coexist as separate directories.

## Same shape, other call sites

Grepped for other hardcoded `"w1"` assumptions in the runner (not just the reported
`ArtifactDownloader.PlatformApps` call site):

- **Found and fixed**: `BcCompiler.ResolveSymbolDirs` and `Program.DefaultPackageCacheDirs`
  both hardcoded `w1` when scanning `~/.bcartifacts.cache/sandbox/<ver>/w1/Extensions` —
  VS Code's AL-extension symbol cache (read-only to us, but the same
  `sandbox/<ver>/<channel>/` layout our own CDN uses). A machine that already has a
  country-localized project's symbols downloaded there via VS Code would never be found.
  Both now scan the selected country's own channel folder instead of always `w1` — one
  folder at a time, not both, for the same duplicate-basename reason as point 2 above.
- **Not touched**: `ArtifactDownloader.ResolveVersion`'s `indexes/w1.json` and
  `VersionExists`'s `/platform` HEAD probe — both are genuinely country-agnostic (BC
  version numbering is the same build across every country channel; only the app
  *contents* differ), so widening those would have been the wrong fix, not a missed one.

## Tests

All new tests are network-free except the real-project verification above (run
manually, not part of the test suite per `local-test-scope.md`'s "no network dependency
in the default unit-test run"):

- `ArtifactDownloaderCountryTests` — pure `NormalizeCountry`/`BuildArtifactUrl`/
  `IsWantedPlatformAppEntry` unit tests, including the `Applications.<CC>/`
  duplicate-basename trap.
- `ArtifactDownloader404Tests` — updated for the URL now appearing in the 404 message;
  added a country-specific-404 case.
- `ProvisioningCheckTests` — country-keyed `PlatformAppsDirFor` (w1 unchanged, country
  gets its own dir, both coexist, case-insensitive), and the manifest-need-widening
  behavior (w1 stays unwidened; non-w1 widens and triggers download; already-present
  does not re-trigger).
- `MissingDependencyCountryMessageTests` — the message-fix RED→GREEN, run first per the
  issue's instruction.
- `CountryFlagTests` — real subprocess CLI test proving `--country` is recognized, shows
  up in the `[bc] selected BC ...` line, is case-insensitive, and a w1 run's output is
  byte-identical to before when the flag is omitted.
- `CliDocumentationTests` — `--country` added to `--help` and the `--guide`
  behavior-changing-flags gate (both were failing before the doc updates).

156→186 tests passing in the directly-affected suites; a wider run across
dependency-resolution/cache-path test classes (56 tests) also green, since this PR
touches `BcCompiler.ResolveSymbolDirs`.
