### PR TITLE
Spike: read BC table rows from the demo .bak without SQL Server

### DIFF
--- a/tools/BakTableReader.Tests/BakTableReader.Tests.csproj
+++ b/tools/BakTableReader.Tests/BakTableReader.Tests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsTestProject>true</IsTestProject>
+    <IsPackable>false</IsPackable>
+    <RootNamespace>BakTableReader.Tests</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="Xunit.SkippableFact" Version="1.5.61" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../BakTableReader/BakTableReader.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tools/BakTableReader.Tests/BakTableReaderIntegrationTests.cs
+++ b/tools/BakTableReader.Tests/BakTableReaderIntegrationTests.cs
@@ -1,0 +1,64 @@
+// Opt-in end-to-end proof for AL Runner issue #2241: reads the REAL demo .bak
+// from a sandbox artifact and decodes "Source Code Setup" for the CRONUS
+// International Ltd. company, using nothing but this project.
+//
+// Gated on AL_RUNNER_SPIKE_BAK_PATH because the .bak (~900MB) does not exist
+// in CI -- every fact here calls Skip.If first and is a real Skipped result,
+// not a silently-passing early return, when the file is absent.
+using System.Linq;
+using System.Text;
+using BakTableReader.RecordDecoding;
+using Xunit;
+
+namespace BakTableReader.Tests;
+
+public class BakTableReaderIntegrationTests
+{
+    private static string? BakPath => Environment.GetEnvironmentVariable("AL_RUNNER_SPIKE_BAK_PATH");
+
+    [SkippableFact]
+    public void ReadsSourceCodeSetupForCronusFromTheRealDemoBak()
+    {
+        Skip.If(string.IsNullOrEmpty(BakPath) || !File.Exists(BakPath),
+            "set AL_RUNNER_SPIKE_BAK_PATH to a BC sandbox artifact's " +
+            "w1/BusinessCentral-W1.bak to run this against real data (see issue #2241)");
+
+        using var file = BakTableReader.BakFile.Open(BakPath!);
+        var catalog = new SqlCatalog(file);
+
+        var baseObject = catalog.SysSchObjs.Single(o =>
+            o.Type == "U " && o.Name.StartsWith("CRONUS International Ltd_$Source Code Setup$") &&
+            !o.Name.EndsWith("$ext"));
+        var extObject = catalog.SysSchObjs.Single(o =>
+            o.Type == "U " && o.Name.StartsWith("CRONUS International Ltd_$Source Code Setup$") &&
+            o.Name.EndsWith("$ext"));
+
+        var (baseRowset, baseAu) = catalog.GetTableStorage(baseObject.Id);
+        Assert.Equal(1, baseRowset.RowCount); // Source Code Setup is a singleton
+        Assert.True(baseRowset.CompressionLevel >= 1, "expected the real demo data to be compressed");
+
+        var baseRow = catalog.WalkCompressedRows(baseAu.PgFirst).Single();
+        Assert.Equal(7, baseRow.NumberOfColumns); // timestamp + PK + 5 system columns
+
+        var (extRowset, extAu) = catalog.GetTableStorage(extObject.Id);
+        var extRow = catalog.WalkCompressedRows(extAu.PgFirst).Single();
+        Assert.Equal(84, extRow.NumberOfColumns);
+
+        // Ground truth is the table's AL schema (field numbers/names), not
+        // eyeballed strings -- see the PR description for how it was pulled
+        // from the shipped Base Application .app's SymbolReference.json
+        // (table id 242, field 2 "Sales" is business-field position 0, and
+        // the ext table's physical column order matches AL field declaration
+        // order starting at physical column 2).
+        Assert.Equal("SALES", Ascii(extRow, 2));
+        Assert.Equal("PURCHASES", Ascii(extRow, 3));
+        Assert.Equal("INVTPCOST", Ascii(extRow, 4));
+    }
+
+    private static string Ascii(CompressedRecord record, int columnIndex)
+    {
+        var bytes = record.GetColumnBytes(columnIndex);
+        Assert.NotNull(bytes);
+        return Encoding.ASCII.GetString(bytes!).TrimEnd('\x10', '\0');
+    }
+}

--- a/tools/BakTableReader.Tests/CompressedRecordTests.cs
+++ b/tools/BakTableReader.Tests/CompressedRecordTests.cs
@@ -1,0 +1,154 @@
+using System.Text;
+using BakTableReader.RecordDecoding;
+using Xunit;
+
+namespace BakTableReader.Tests;
+
+public class CompressedRecordTests
+{
+    // Captured verbatim from the real BC 28.1 W1 sandbox demo .bak (AL Runner
+    // #2241). This is the base "CRONUS International Ltd_ Code
+    // Setup$<guid>" row -- 7 native SQL columns (a versioning/partition
+    // column, the primary key, and 5 platform system columns: SystemId,
+    // SystemCreatedAt/By, SystemModifiedAt/By). PAGE-compressed
+    // (sysrowsets.cmprlevel == 2).
+    private const string BaseRowHex =
+        "2107418a8a1a03fb8380b44f0181b6a880b44f0181b6a8010300100020003000dbd1420053d911f18e267ced8d9e40940000000000000000000000000000000100000000000000000000000000000001";
+
+    // The companion "..." table for the same row -- 84 columns, one per
+    // AL business field (Sales, Purchases, Inventory Post Cost, ...). This is
+    // the row that reproduces the cluster-pointer bug described in the file
+    // header of CompressedRecord.cs: 84 columns need 3 short-data clusters.
+    private const string ExtRowHex =
+        "215441a6aa11aaa8aa8a88aa88aa1aaaaaaa8a8a8aaaaaaaaaa8aa8486aaaaaaaa6a88a8aaaaaaaaa8aaa88a323203fb8453414c455347454e4a4e4c104954454d4a4e4c5245534a4e4c1050524f4a4a4e4c56415453544d54434f4d5052474c46494e4348524744454c4554451042414e4b5245434346574b534810474c1043414a4f555210414c4c4f435452414255441046414a4e4c4641474c4a4e4c494e534a4e4c10434f4d5052464157484954454d1057485049434b1053455256494345013900090012001d0026002f00380041004c0057006000690072007b0084008d009600a100ac00b500c000cb00d400df00e800f100fc0007011001190124012f01380141014a0153015c01650170017b0184018f019801a301ae01b701c001c901d201db01e401ed01f80103020e02170222022b021216505552434841534553494e565450434f53544558434852415441444a10434c53494e434f4d45434f4e534f4c49441053414c45534a4e4c1050555243484a4e4c10434153485245434a4e4c105041594d454e544a4e4c1053414c45534150504c50555243484150504c434f4d505256415410434f4d505243555354434f4d505256454e44434f4d505252455310434f4d505250524f4a5245434c4153534a4e4c1050485953494e564a4e4c10434f4d505242414e4b434f4d5052434845434b1046494e564f494443484b1052454d494e4445521041444a4144444355525210494e544552434f4d50554e415050454d504c554e41505053414c455310554e415050505552434810524556455253414c10454d504c4150504c105041594d545245434f4e10474c435552524556414c10415353454d424c591050524f4a474c4a4e4c50524f4a474c57495047454e2d444546455253414c2d44454645525055522d4445464552434f4e53554d504a4e4c10504f494e4f55544a4e4c10464c555348494e4710434150414349544a4e4c1050524f444f5244455250524f44554354494f4e10434f4d50524d41494e5410434f4d5052494e53105452414e5346455210524556414c4a4e4c10494e565441444a4d54494e56545243505410494e56545348505410494e56544f52444552434f4d5052494255444710574850485953494e565410574852434c53534a4e4c1057485055544157415957484d4f56454d454e5410434f4d505257485345";
+
+    private static CompressedRecord ParseHex(string hex)
+    {
+        var page = new byte[PageHeader.PageLength];
+        Convert.FromHexString(hex).CopyTo(page, 0);
+        return CompressedRecord.Parse(page, 0);
+    }
+
+    private static string DecodeAscii(byte[]? bytes) =>
+        bytes is null ? "<NULL>" : Encoding.ASCII.GetString(bytes).TrimEnd('\x10', '\0');
+
+    [Fact]
+    public void Parse_BaseRow_HasSevenSystemColumnsAndConsumesExactlyItsFreeDataBoundary()
+    {
+        var record = ParseHex(BaseRowHex);
+
+        Assert.True(record.IsCdFormat);
+        Assert.Equal(7, record.NumberOfColumns);
+        Assert.True(record.HasLongDataRegion);
+        // The captured hex already ends exactly at the page's own FreeData
+        // boundary (176 absolute - 96 header = 80) -- if Length undershoots or
+        // overshoots, a real page walk would either re-read part of this row
+        // as if it were a second row, or skip real bytes.
+        Assert.Equal(80, record.Length);
+    }
+
+    [Fact]
+    public void Parse_BaseRow_SystemIdColumnIsA16ByteGuid()
+    {
+        var record = ParseHex(BaseRowHex);
+
+        // Column 2 is LongData, 16 bytes -- the row's SystemId.
+        Assert.Equal(ColumnIndicator.LongData, record.Indicators[2]);
+        var systemId = record.GetColumnBytes(2);
+        Assert.NotNull(systemId);
+        Assert.Equal(16, systemId!.Length);
+    }
+
+    [Fact]
+    public void Parse_BaseRow_CreatedAtAndModifiedAtAreEqualByteForByte()
+    {
+        // A freshly-seeded demo row was never updated after creation, so its
+        // SystemCreatedAt and SystemModifiedAt columns (indices 3 and 5,
+        // 7-byte datetime2 values) should be byte-identical -- this is an
+        // independent semantic check that the short-data-region offsets are
+        // right, not just that parsing didn't throw.
+        var record = ParseHex(BaseRowHex);
+
+        var createdAt = record.GetColumnBytes(3);
+        var modifiedAt = record.GetColumnBytes(5);
+
+        Assert.Equal(ColumnIndicator.SevenByte, record.Indicators[3]);
+        Assert.Equal(ColumnIndicator.SevenByte, record.Indicators[5]);
+        Assert.Equal(createdAt, modifiedAt);
+    }
+
+    [Fact]
+    public void Parse_ExtRow_Has84ColumnsSpanningThreeShortDataClusters()
+    {
+        var record = ParseHex(ExtRowHex);
+
+        // 84 columns needs ceil(84/30) = 3 short-data clusters. This is
+        // exactly the shape OrcaMDF's own cluster-pointer sizing gets wrong
+        // (see CompressedRecord.cs file header) -- decoding a column in the
+        // 3rd cluster (index >= 60) without the fix throws
+        // IndexOutOfRangeException instead of returning "REVALJNL".
+        Assert.Equal(84, record.NumberOfColumns);
+        Assert.Equal(867, record.Length);
+
+        var thirdClusterColumn = record.GetColumnBytes(70); // "REVALJNL"
+        Assert.NotNull(thirdClusterColumn);
+    }
+
+    [Theory]
+    [InlineData(2, "SALES")]           // AL field 2 "Sales"
+    [InlineData(3, "PURCHASES")]       // AL field 3 "Purchases"
+    [InlineData(4, "INVTPCOST")]       // AL field 4 "Inventory Post Cost"
+    [InlineData(5, "EXCHRATADJ")]      // AL field 5 "Exchange Rate Adjmt."
+    [InlineData(10, "GENJNL")]         // AL field 10 "General Journal"
+    [InlineData(61, "PRODORDER")]      // AL field 5502 "Production Order"
+    [InlineData(82, "COMPRWHSE")]      // AL field 7307 "Compress Whse. Entries" (the LAST declared field --
+                                       // physical columns run one further, to index 83 "SERVICE", which is
+                                       // not any of the 80 currently-declared business fields: BC never
+                                       // reclaims a dropped/obsoleted field's physical column)
+    public void Parse_ExtRow_DecodesRecognisableSourceCodeValues(int columnIndex, string expected)
+    {
+        // Cross-checked against the table's AL schema pulled from the shipped
+        // Base Application .app's SymbolReference.json (table id 242,
+        // "Source Code Setup") -- these are real default demo values for the
+        // CRONUS International Ltd. company, not just "bytes came out".
+        var record = ParseHex(ExtRowHex);
+
+        var bytes = record.GetColumnBytes(columnIndex);
+        Assert.NotNull(bytes);
+        Assert.Equal(expected, DecodeAscii(bytes!));
+    }
+
+    [Fact]
+    public void Parse_ExtRow_UnsetBusinessFieldsDecodeAsEmptyNotNull()
+    {
+        // AL fields 6 "Post Recognition" and 7 "Post Value" (columns 6, 7)
+        // are not configured on this demo company -- Code[10]'s AL default is
+        // blank, which SQL stores as a real zero-length value, not NULL.
+        var record = ParseHex(ExtRowHex);
+
+        Assert.Equal(ColumnIndicator.ZeroByte, record.Indicators[6]);
+        Assert.Equal(ColumnIndicator.ZeroByte, record.Indicators[7]);
+        Assert.Equal(Array.Empty<byte>(), record.GetColumnBytes(6));
+        Assert.Equal(Array.Empty<byte>(), record.GetColumnBytes(7));
+    }
+
+    [Fact]
+    public void GetColumnBytes_ThrowsForDictionarySubstitutedColumns()
+    {
+        // No column in either captured row actually uses indicator 0xC
+        // (DictionarySymbol) -- construct a minimal synthetic record that
+        // does, to prove the "not implemented" path throws loudly instead of
+        // returning wrong bytes silently.
+        var page = new byte[PageHeader.PageLength];
+        page[0] = 0x01;       // CD format, Primary, no long data
+        page[1] = 0x01;       // numCols = 1
+        // Indicator packing reads column 0 from the LOW nibble of the byte
+        // right after the column count -- 0xC is DictionarySymbol.
+        page[2] = 0x0C;
+
+        var record = CompressedRecord.Parse(page, 0);
+
+        Assert.Equal(ColumnIndicator.DictionarySymbol, record.Indicators[0]);
+        Assert.Throws<NotSupportedException>(() => record.GetColumnBytes(0));
+    }
+}

--- a/tools/BakTableReader.Tests/FixedVarRecordTests.cs
+++ b/tools/BakTableReader.Tests/FixedVarRecordTests.cs
@@ -1,0 +1,79 @@
+using System.Text;
+using BakTableReader.RecordDecoding;
+using Xunit;
+
+namespace BakTableReader.Tests;
+
+public class FixedVarRecordTests
+{
+    // Captured verbatim from the real BC 28.1 W1 sandbox demo .bak (AL Runner
+    // #2241) -- a sysallocunits row for the fixed sysrowsets allocation unit
+    // (auid 327680). No null values, no variable-length columns.
+    private const string SysAllocUnitRowHex =
+        "100045000000050000000000010000050000000000000000000100110000000100a000000001008300000001006800000000000000660000000000000075000000000000000b0000f8";
+
+    // A sysschobjs row for object id 34 ("sysschobjs" itself, a SYSTEM_TABLE) --
+    // has a null bitmap and one variable-length column (the sysname `name`).
+    private const string SysSchObjRowHex =
+        "3000300022000000040000000001000e00532000000000010c0000008702d600ea9b000004c36a0028af0000000000000c0000f001004c007300790073007300630068006f0062006a007300";
+
+    private static FixedVarRecord ParseHex(string hex)
+    {
+        var page = new byte[PageHeader.PageLength];
+        Convert.FromHexString(hex).CopyTo(page, 0);
+        return FixedVarRecord.Parse(page, 0);
+    }
+
+    [Fact]
+    public void Parse_SysAllocUnitRow_HasNoVarLenColumns()
+    {
+        var record = ParseHex(SysAllocUnitRowHex);
+
+        Assert.Equal(RecordType.Primary, record.Type);
+        Assert.True(record.HasNullBitmap);
+        Assert.False(record.HasVariableLengthColumns);
+        Assert.Equal(11, record.NumberOfColumns);
+        Assert.Equal(65, record.FixedLengthData.Length);
+
+        long auid = BitConverter.ToInt64(record.FixedLengthData, 0);
+        byte type = record.FixedLengthData[8];
+        Assert.Equal(327680, auid);
+        Assert.Equal(1, type); // IN_ROW_DATA
+    }
+
+    [Fact]
+    public void Parse_SysSchObjRow_DecodesIdNameAndType()
+    {
+        var record = ParseHex(SysSchObjRowHex);
+
+        Assert.True(record.HasNullBitmap);
+        Assert.True(record.HasVariableLengthColumns);
+        Assert.Equal(12, record.NumberOfColumns);
+        Assert.Single(record.VariableLengthColumns);
+
+        int id = BitConverter.ToInt32(record.FixedLengthData, 0);
+        string type = Encoding.ASCII.GetString(record.FixedLengthData, 13, 2);
+        string name = Encoding.Unicode.GetString(record.VariableLengthColumns[0].Data);
+
+        Assert.Equal(34, id);
+        Assert.Equal("S ", type); // SYSTEM_TABLE
+        Assert.Equal("sysschobjs", name);
+        Assert.False(record.VariableLengthColumns[0].Complex);
+    }
+
+    [Fact]
+    public void IsNull_ReturnsFalseWhenNoNullBitmapPresent()
+    {
+        // Fabricate a minimal record with the null-bitmap bit clear.
+        var page = new byte[PageHeader.PageLength];
+        page[0] = 0x00; // Primary, no null bitmap, no varlen
+        page[1] = 0x00;
+        BitConverter.GetBytes((short)4).CopyTo(page, 2); // fixedLength = 0
+        BitConverter.GetBytes((short)0).CopyTo(page, 4); // numberOfColumns = 0
+
+        var record = FixedVarRecord.Parse(page, 0);
+
+        Assert.False(record.HasNullBitmap);
+        Assert.False(record.IsNull(0));
+    }
+}

--- a/tools/BakTableReader.Tests/PageHeaderTests.cs
+++ b/tools/BakTableReader.Tests/PageHeaderTests.cs
@@ -1,0 +1,70 @@
+using BakTableReader;
+using Xunit;
+
+namespace BakTableReader.Tests;
+
+public class PageHeaderTests
+{
+    private static byte[] BuildPage(byte headerVersion, byte type, short slotCount, int selfPageId,
+        short selfFileId, int nextPageId, short nextFileId, short freeData)
+    {
+        var page = new byte[PageHeader.PageLength];
+        page[0] = headerVersion;
+        page[1] = type;
+        BitConverter.GetBytes(nextPageId).CopyTo(page, 16);
+        BitConverter.GetBytes(nextFileId).CopyTo(page, 20);
+        BitConverter.GetBytes(slotCount).CopyTo(page, 22);
+        BitConverter.GetBytes(freeData).CopyTo(page, 30);
+        BitConverter.GetBytes(selfPageId).CopyTo(page, 32);
+        BitConverter.GetBytes(selfFileId).CopyTo(page, 36);
+        return page;
+    }
+
+    [Fact]
+    public void TryParse_DecodesKnownFieldOffsets()
+    {
+        var page = BuildPage(headerVersion: 1, type: 1, slotCount: 3,
+            selfPageId: 143, selfFileId: 1, nextPageId: 189, nextFileId: 1, freeData: 500);
+
+        Assert.True(PageHeader.TryParse(page, out var header));
+        Assert.Equal(PageType.Data, header.Type);
+        Assert.Equal(3, header.SlotCount);
+        Assert.Equal(new PagePointer(1, 143), header.Self);
+        Assert.Equal(new PagePointer(1, 189), header.Next);
+        Assert.Equal(500, header.FreeData);
+    }
+
+    [Fact]
+    public void TryParse_RejectsWrongHeaderVersion()
+    {
+        var page = BuildPage(headerVersion: 2, type: 1, slotCount: 1,
+            selfPageId: 1, selfFileId: 1, nextPageId: 0, nextFileId: 0, freeData: 0);
+
+        Assert.False(PageHeader.TryParse(page, out _));
+    }
+
+    [Fact]
+    public void TryParse_RejectsUndefinedPageType()
+    {
+        // 6 and 12 are not defined PageType values -- a real BC .bak has never
+        // been observed to produce them, and a random byte in a LOB page body
+        // must not be mistaken for a page header.
+        var page = BuildPage(headerVersion: 1, type: 6, slotCount: 1,
+            selfPageId: 1, selfFileId: 1, nextPageId: 0, nextFileId: 0, freeData: 0);
+
+        Assert.False(PageHeader.TryParse(page, out _));
+    }
+
+    [Fact]
+    public void ReadSlotArray_ReadsBackToFrontFromPageTail()
+    {
+        var page = new byte[PageHeader.PageLength];
+        short[] expected = { 96, 250, 4038 };
+        for (int i = 0; i < expected.Length; i++)
+            BitConverter.GetBytes(expected[i]).CopyTo(page, page.Length - i * 2 - 2);
+
+        var slots = PageHeader.ReadSlotArray(page, (short)expected.Length);
+
+        Assert.Equal(expected, slots);
+    }
+}

--- a/tools/BakTableReader.Tests/PageIndexTests.cs
+++ b/tools/BakTableReader.Tests/PageIndexTests.cs
@@ -1,0 +1,83 @@
+using BakTableReader;
+using Xunit;
+
+namespace BakTableReader.Tests;
+
+public class PageIndexTests
+{
+    private static byte[] MakePageBytes(byte headerVersion, byte type, int selfPageId, short selfFileId)
+    {
+        var page = new byte[PageHeader.PageLength];
+        page[0] = headerVersion;
+        page[1] = type;
+        BitConverter.GetBytes(selfPageId).CopyTo(page, 32);
+        BitConverter.GetBytes(selfFileId).CopyTo(page, 36);
+        return page;
+    }
+
+    [Fact]
+    public void Build_ResolvesAddressByStoredHeaderNotByBlockPosition()
+    {
+        // Reproduces the discontinuity AL Runner #2241 found in a real BC demo
+        // .bak: after some point in the file, "absolute block == logical
+        // PageId + constant" stops holding (an MTF structure is spliced into
+        // the otherwise page-aligned stream). Block 0 claims to be logical
+        // page 9 (matching a "+9" offset); block 1 claims to be logical page
+        // 776 (NOT "+9" -- if PageIndex fell back to position arithmetic
+        // instead of trusting each block's own header, resolving page 776
+        // would silently return the wrong block).
+        using var stream = new MemoryStream();
+        stream.Write(MakePageBytes(1, 1, selfPageId: 9, selfFileId: 1));
+        stream.Write(MakePageBytes(1, 1, selfPageId: 776, selfFileId: 1));
+        stream.Position = 0;
+
+        var index = PageIndex.Build(stream);
+
+        Assert.Equal(2, index.PageCount);
+        Assert.Equal(0, index.GetBlock(new PagePointer(1, 9)));
+        Assert.Equal(1, index.GetBlock(new PagePointer(1, 776)));
+    }
+
+    [Fact]
+    public void Build_SkipsBlocksWithoutAValidHeader()
+    {
+        using var stream = new MemoryStream();
+        stream.Write(MakePageBytes(1, 1, selfPageId: 1, selfFileId: 1));
+        stream.Write(new byte[PageHeader.PageLength]); // header version 0 -- not a page
+        stream.Write(MakePageBytes(1, 1, selfPageId: 2, selfFileId: 1));
+        stream.Position = 0;
+
+        var index = PageIndex.Build(stream);
+
+        Assert.Equal(2, index.PageCount);
+        Assert.Equal(0, index.GetBlock(new PagePointer(1, 1)));
+        Assert.Equal(2, index.GetBlock(new PagePointer(1, 2)));
+    }
+
+    [Fact]
+    public void Build_ToleratesATrailingPartialBlock()
+    {
+        // The real .bak trails with a 4096-byte remainder (half a page) --
+        // presumably an MTF end-of-set marker. A short final read must not
+        // throw; it is simply not indexed.
+        using var stream = new MemoryStream();
+        stream.Write(MakePageBytes(1, 1, selfPageId: 1, selfFileId: 1));
+        stream.Write(new byte[PageHeader.PageLength / 2]);
+        stream.Position = 0;
+
+        var index = PageIndex.Build(stream);
+
+        Assert.Equal(1, index.PageCount);
+    }
+
+    [Fact]
+    public void GetBlock_ThrowsForAnUnindexedAddress()
+    {
+        using var stream = new MemoryStream();
+        stream.Write(MakePageBytes(1, 1, selfPageId: 1, selfFileId: 1));
+        stream.Position = 0;
+        var index = PageIndex.Build(stream);
+
+        Assert.Throws<KeyNotFoundException>(() => index.GetBlock(new PagePointer(1, 999)));
+    }
+}

--- a/tools/BakTableReader/BakFile.cs
+++ b/tools/BakTableReader/BakFile.cs
@@ -1,0 +1,49 @@
+namespace BakTableReader;
+
+/// <summary>Read-only access to a BC demo .bak's SQL Server pages, addressed by
+/// logical (FileId, PageId) rather than raw byte offset. See PageIndex for why
+/// that indirection is required, not just a defensive nicety.</summary>
+public sealed class BakFile : IDisposable
+{
+    private readonly FileStream _stream;
+    public PageIndex Index { get; }
+
+    private BakFile(FileStream stream, PageIndex index)
+    {
+        _stream = stream;
+        Index = index;
+    }
+
+    public static BakFile Open(string path)
+    {
+        var stream = File.OpenRead(path);
+        try
+        {
+            var index = PageIndex.Build(stream);
+            return new BakFile(stream, index);
+        }
+        catch
+        {
+            stream.Dispose();
+            throw;
+        }
+    }
+
+    public byte[] ReadPage(PagePointer address)
+    {
+        long block = Index.GetBlock(address);
+        var buffer = new byte[PageHeader.PageLength];
+        _stream.Seek(block * PageHeader.PageLength, SeekOrigin.Begin);
+        int total = 0;
+        while (total < buffer.Length)
+        {
+            int n = _stream.Read(buffer, total, buffer.Length - total);
+            if (n == 0)
+                throw new EndOfStreamException($"short read for page {address} at block {block}");
+            total += n;
+        }
+        return buffer;
+    }
+
+    public void Dispose() => _stream.Dispose();
+}

--- a/tools/BakTableReader/BakTableReader.csproj
+++ b/tools/BakTableReader/BakTableReader.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RollForward>LatestMajor</RollForward>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+</Project>

--- a/tools/BakTableReader/PageHeader.cs
+++ b/tools/BakTableReader/PageHeader.cs
@@ -1,0 +1,112 @@
+// PageHeader — the 96-byte SQL Server page header, present at the start of every
+// 8192-byte page in the demo .bak that ships inside a BC sandbox artifact.
+//
+// Byte layout ported from OrcaMDF (github.com/improvedk/OrcaMDF, MIT-licensed)
+// PageHeader.cs, which documents the same offsets used by DBCC PAGE. See
+// AL Runner issue #2241 for how this was cross-checked against real BC data
+// (the page's own self-reported PageId/FileId round-tripping against the
+// logical address used to read it).
+namespace BakTableReader;
+
+public readonly record struct PagePointer(short FileId, int PageId)
+{
+    public static readonly PagePointer Zero = new(0, 0);
+}
+
+/// <summary>The set of page types this reader recognises as a plausible page
+/// header. Anything else (including random bytes inside a LOB/TextMix page
+/// body that happen to satisfy HeaderVersion==1) is treated as "not a page".</summary>
+public enum PageType : byte
+{
+    Data = 1,
+    Index = 2,
+    TextMix = 3,
+    TextTree = 4,
+    Sort = 7,
+    Gam = 8,
+    Sgam = 9,
+    Iam = 10,
+    Pfs = 11,
+    Boot = 13,
+    FileHeader = 15,
+    DiffMap = 16,
+    MlMap = 17,
+}
+
+public readonly struct PageHeader
+{
+    public const int HeaderLength = 96;
+    public const int PageLength = 8192;
+
+    public byte HeaderVersion { get; }
+    public PageType Type { get; }
+    public short SlotCount { get; }
+    /// <summary>Raw m_objId. On modern SQL Server this is NOT a reliable
+    /// sys.objects.object_id for user tables (only for the fixed system
+    /// tables) -- do not use it to identify a table.</summary>
+    public int RawObjectId { get; }
+    public PagePointer Self { get; }
+    public PagePointer Next { get; }
+    public PagePointer Previous { get; }
+    public short FreeData { get; }
+
+    private PageHeader(byte headerVersion, PageType type, short slotCount, int rawObjectId,
+        PagePointer self, PagePointer next, PagePointer previous, short freeData)
+    {
+        HeaderVersion = headerVersion;
+        Type = type;
+        SlotCount = slotCount;
+        RawObjectId = rawObjectId;
+        Self = self;
+        Next = next;
+        Previous = previous;
+        FreeData = freeData;
+    }
+
+    /// <summary>True if the header version and page type look like a real page
+    /// header. This is a heuristic (95% of the .bak's 8192-byte-aligned blocks
+    /// pass it in practice) -- a small number of false positives come from
+    /// LOB page bodies whose random bytes happen to satisfy it. Cross-check
+    /// against <see cref="Self"/> when addressing is important.</summary>
+    public static bool TryParse(ReadOnlySpan<byte> page, out PageHeader header)
+    {
+        header = default;
+        if (page.Length < HeaderLength)
+            return false;
+
+        byte headerVersion = page[0];
+        byte rawType = page[1];
+        if (headerVersion != 1 || !Enum.IsDefined(typeof(PageType), rawType))
+            return false;
+
+        var type = (PageType)rawType;
+        int prevPageId = BitConverter.ToInt32(page.Slice(8, 4));
+        short prevFileId = BitConverter.ToInt16(page.Slice(12, 2));
+        int nextPageId = BitConverter.ToInt32(page.Slice(16, 4));
+        short nextFileId = BitConverter.ToInt16(page.Slice(20, 2));
+        short slotCount = BitConverter.ToInt16(page.Slice(22, 2));
+        int rawObjectId = BitConverter.ToInt32(page.Slice(24, 4));
+        short freeData = BitConverter.ToInt16(page.Slice(30, 2));
+        int selfPageId = BitConverter.ToInt32(page.Slice(32, 4));
+        short selfFileId = BitConverter.ToInt16(page.Slice(36, 2));
+
+        header = new PageHeader(
+            headerVersion, type, slotCount, rawObjectId,
+            new PagePointer(selfFileId, selfPageId),
+            new PagePointer(nextFileId, nextPageId),
+            new PagePointer(prevFileId, prevPageId),
+            freeData);
+        return true;
+    }
+
+    /// <summary>Reads the 2-byte, page-relative slot array from the tail of the
+    /// page -- SlotCount entries, each pointing at a record's start offset
+    /// within the page, stored back-to-front from the very last 2 bytes.</summary>
+    public static short[] ReadSlotArray(ReadOnlySpan<byte> page, short slotCount)
+    {
+        var slots = new short[slotCount];
+        for (int i = 0; i < slotCount; i++)
+            slots[i] = BitConverter.ToInt16(page.Slice(page.Length - i * 2 - 2, 2));
+        return slots;
+    }
+}

--- a/tools/BakTableReader/PageHeader.cs
+++ b/tools/BakTableReader/PageHeader.cs
@@ -1,11 +1,16 @@
 // PageHeader — the 96-byte SQL Server page header, present at the start of every
 // 8192-byte page in the demo .bak that ships inside a BC sandbox artifact.
 //
-// Byte layout ported from OrcaMDF (github.com/improvedk/OrcaMDF, MIT-licensed)
-// PageHeader.cs, which documents the same offsets used by DBCC PAGE. See
-// AL Runner issue #2241 for how this was cross-checked against real BC data
-// (the page's own self-reported PageId/FileId round-tripping against the
-// logical address used to read it).
+// Byte layout ported from OrcaMDF (github.com/improvedk/OrcaMDF, GPL-3.0
+// licensed -- NOT MIT; an earlier version of this comment said MIT, which was
+// wrong and unverified) PageHeader.cs, which documents the same offsets used
+// by DBCC PAGE. This specific 96-byte layout is also independently documented
+// in Microsoft's own DBCC PAGE output and multiple third-party SQL Server
+// internals references, and was cross-checked here against real BC data (the
+// page's own self-reported PageId/FileId round-tripping against the logical
+// address used to read it) -- see AL Runner issue #2241 and PR #2243 for the
+// unresolved GPL-3.0/MIT licensing question this raises for the files in this
+// directory that track OrcaMDF's algorithm more closely (CompressedRecord.cs).
 namespace BakTableReader;
 
 public readonly record struct PagePointer(short FileId, int PageId)

--- a/tools/BakTableReader/PageIndex.cs
+++ b/tools/BakTableReader/PageIndex.cs
@@ -1,0 +1,82 @@
+// PageIndex — maps a logical SQL Server page address (FileId, PageId) to its
+// absolute 8192-byte block number within the .bak stream.
+//
+// WHY THIS EXISTS (see AL Runner issue #2241)
+//   The naive approach -- locate the boot page (always logical 1:9), record
+//   its absolute block offset, and add/subtract PageId deltas from there --
+//   works for the first few hundred pages of a real BC demo .bak and then
+//   silently breaks: the file has at least one place where an MTF backup-set
+//   structure is spliced into the otherwise-contiguous 8192-byte-aligned page
+//   stream, shifting every page after it by a constant that is NOT the same
+//   constant as before the splice. Chasing a NextPage pointer past that point
+// with fixed-offset arithmetic lands on the WRONG physical page -- one that
+//   still parses as a plausible header (so it doesn't fail loudly) but
+//   belongs to an unrelated table.
+//
+//   The only address that is always correct is the page's OWN self-reported
+//   (FileId, PageId) in its header (PageHeader.Self). This class builds a
+//   dictionary from that self-reported address to the block's absolute
+//   position by scanning the whole file once. Measured cost: ~0.13-0.45s
+//   warm, ~0.3-0.4s cold on the machine this was written on (fast NVMe --
+//   see the issue for the full cold/warm measurement and its caveats).
+namespace BakTableReader;
+
+public sealed class PageIndex
+{
+    private readonly Dictionary<PagePointer, long> _blockByAddress;
+
+    public int PageCount => _blockByAddress.Count;
+
+    private PageIndex(Dictionary<PagePointer, long> blockByAddress)
+    {
+        _blockByAddress = blockByAddress;
+    }
+
+    public bool TryGetBlock(PagePointer address, out long block) =>
+        _blockByAddress.TryGetValue(address, out block);
+
+    public long GetBlock(PagePointer address) =>
+        _blockByAddress.TryGetValue(address, out var block)
+            ? block
+            : throw new KeyNotFoundException($"page {address} not present in the index");
+
+    /// <summary>Scans every 8192-byte-aligned block in <paramref name="stream"/>
+    /// once, keeping the LAST block seen for a given self-reported address --
+    /// a handful of blocks (observed: ~1.3% on a 894MB W1 demo .bak) collide
+    /// because random bytes inside a LOB/TextMix page body happen to satisfy
+    /// the page-header heuristic and produce a bogus (FileId, PageId). This
+    /// index is only ever used to resolve addresses a real page header
+    /// actually pointed at (boot page / NextPage / AU pgfirst), so a rare
+    /// false-positive entry sitting unused in the dictionary is harmless.</summary>
+    public static PageIndex Build(Stream stream)
+    {
+        var map = new Dictionary<PagePointer, long>();
+        stream.Seek(0, SeekOrigin.Begin);
+        var buffer = new byte[PageHeader.PageLength];
+        long block = 0;
+        // The .bak trailer is not necessarily a whole number of 8192-byte blocks
+        // (observed: a 4096-byte remainder on a 894MB W1 demo .bak, presumably
+        // an MTF end-of-set marker) -- a short final read is expected, not an
+        // error; only whole blocks are ever indexed.
+        while (ReadFully(stream, buffer) == buffer.Length)
+        {
+            if (PageHeader.TryParse(buffer, out var header))
+                map[header.Self] = block;
+            block++;
+        }
+        return new PageIndex(map);
+    }
+
+    private static int ReadFully(Stream stream, byte[] buffer)
+    {
+        int total = 0;
+        while (total < buffer.Length)
+        {
+            int n = stream.Read(buffer, total, buffer.Length - total);
+            if (n == 0)
+                break;
+            total += n;
+        }
+        return total;
+    }
+}

--- a/tools/BakTableReader/Program.cs
+++ b/tools/BakTableReader/Program.cs
@@ -1,0 +1,80 @@
+// BakTableReader — spike CLI for AL Runner issue #2241: read BC demo-database
+// table rows directly out of the .bak that ships in a sandbox artifact,
+// without SQL Server. NOT a production reader -- see the issue and PR for the
+// full report on what this proves and what a real implementation would still
+// need (SQL-type -> AL-type mapping, BLOB/LOB resolution, page-dictionary
+// compression, general heap/IAM traversal for fragmented tables).
+//
+// Usage:
+//   dotnet run --project tools/BakTableReader -- <path-to.bak> <sql-name-substring>
+using BakTableReader;
+using BakTableReader.RecordDecoding;
+
+if (args.Length != 2)
+{
+    Console.Error.WriteLine("usage: BakTableReader <path-to.bak> <sql-name-substring>");
+    return 1;
+}
+
+string path = args[0];
+string needle = args[1];
+
+using var file = BakFile.Open(path);
+Console.WriteLine($"indexed {file.Index.PageCount} pages");
+
+var catalog = new SqlCatalog(file);
+var matches = catalog.SysSchObjs.Where(o => o.Name.Contains(needle, StringComparison.OrdinalIgnoreCase)).ToList();
+Console.WriteLine($"{matches.Count} sysschobjs match \"{needle}\":");
+foreach (var m in matches)
+    Console.WriteLine($"  id={m.Id,-12} type={m.Type} name={m.Name}");
+
+var userTable = matches.FirstOrDefault(m => m.Type == "U ");
+if (userTable is null)
+{
+    Console.WriteLine("no USER_TABLE match -- nothing to walk");
+    return 0;
+}
+
+var (rowset, allocUnit) = catalog.GetTableStorage(userTable.Id);
+Console.WriteLine($"\n{userTable.Name}: rowset={rowset.RowsetId} rows={rowset.RowCount} " +
+                   $"compression={rowset.CompressionLevel} pgFirst={allocUnit.PgFirst}");
+
+if (allocUnit.PgFirst == PagePointer.Zero)
+{
+    Console.WriteLine("(no rows)");
+    return 0;
+}
+
+if (rowset.CompressionLevel == 0)
+{
+    foreach (var record in catalog.WalkFixedVarRows(allocUnit.PgFirst))
+        Console.WriteLine($"  row: {record.NumberOfColumns} cols, {record.FixedLengthData.Length} fixed bytes, " +
+                           $"{record.VariableLengthColumns.Count} var cols");
+}
+else
+{
+    foreach (var record in catalog.WalkCompressedRows(allocUnit.PgFirst))
+    {
+        Console.WriteLine($"  row: {record.NumberOfColumns} cols (cmpr level {rowset.CompressionLevel})");
+        for (int i = 0; i < record.NumberOfColumns; i++)
+        {
+            byte[]? bytes;
+            try { bytes = record.GetColumnBytes(i); }
+            catch (NotSupportedException ex) { Console.WriteLine($"    [{i}] {record.Indicators[i]}: {ex.Message}"); continue; }
+            string preview = bytes is null ? "NULL" : PreviewAscii(bytes);
+            Console.WriteLine($"    [{i}] {record.Indicators[i],-16} {preview}");
+        }
+    }
+}
+
+return 0;
+
+static string PreviewAscii(byte[] bytes)
+{
+    if (bytes.Length == 0)
+        return "''";
+    bool looksAscii = bytes.All(b => b == 0 || (b >= 0x20 && b < 0x7F));
+    if (looksAscii)
+        return $"'{System.Text.Encoding.ASCII.GetString(bytes).TrimEnd('\0')}'";
+    return Convert.ToHexString(bytes);
+}

--- a/tools/BakTableReader/RecordDecoding/CompressedRecord.cs
+++ b/tools/BakTableReader/RecordDecoding/CompressedRecord.cs
@@ -1,0 +1,244 @@
+// CompressedRecord — the "CD" row format SQL Server uses for ROW- and
+// PAGE-compressed tables (sysrowsets.cmprlevel 1 and 2). Ported from OrcaMDF's
+// CompressedRecord.cs (github.com/improvedk/OrcaMDF, MIT-licensed), WITH ONE
+// CORRECTION -- see below -- found while decoding a real 81-field BC table
+// for AL Runner issue #2241.
+//
+// THE CORRECTION (short-data-region cluster pointers)
+//   Columns are grouped into "clusters" of 30 for the short (<=8-byte) data
+//   region. OrcaMDF sizes `shortDataRegionClusterPointers` as `numClusters`,
+//   where `numClusters = (numCols - 1) / 30` -- but that value is actually
+//   "how many clusters need an explicit length prefix" (total clusters minus
+//   one; the last cluster's length is implicit), not the total cluster count.
+//   Sizing the pointer array to `numClusters` instead of `numClusters + 1`
+//   drops the pointer for the LAST cluster, which is exactly the cluster that
+//   holds columns 60-89 on any table with more than 60 non-long columns.
+//   "Source Code Setup"'s $ext companion table has 84 columns (3 clusters) and
+//   reproduces this: OrcaMDF's own logic throws IndexOutOfRangeException
+//   decoding it. This class stores all `numClusters + 1` pointers.
+//
+// WHAT IS NOT IMPLEMENTED (matches OrcaMDF's own scope, not silently faked)
+//   Page-dictionary substitution (CD indicator 0xC) throws NotSupportedException
+//   naming the column index, the same way OrcaMDF's own GetPhysicalColumnBytes
+//   does -- this reader was never exercised against a page whose dictionary is
+//   actually populated (the one real page examined for #2241 had zero
+//   dictionary entries), so decoding it would be unverified guesswork.
+//   Complex long-data columns (LOB pointers, sparse vectors) are recognised
+//   but not resolved for the same reason -- see the #2241 report for what
+//   sparse-column resolution on top of this would need.
+namespace BakTableReader.RecordDecoding;
+
+public enum ColumnIndicator : byte
+{
+    Null = 0x0,
+    ZeroByte = 0x1,
+    OneByte = 0x2,
+    TwoByte = 0x3,
+    ThreeByte = 0x4,
+    FourByte = 0x5,
+    FiveByte = 0x6,
+    SixByte = 0x7,
+    SevenByte = 0x8,
+    EightByte = 0x9,
+    LongData = 0xA,
+    TrueBit = 0xB,
+    DictionarySymbol = 0xC,
+}
+
+public sealed class CompressedRecord
+{
+    private static readonly IReadOnlyDictionary<ColumnIndicator, int> LengthByIndicator =
+        new Dictionary<ColumnIndicator, int>
+        {
+            [ColumnIndicator.ZeroByte] = 0,
+            [ColumnIndicator.OneByte] = 1,
+            [ColumnIndicator.TwoByte] = 2,
+            [ColumnIndicator.ThreeByte] = 3,
+            [ColumnIndicator.FourByte] = 4,
+            [ColumnIndicator.FiveByte] = 5,
+            [ColumnIndicator.SixByte] = 6,
+            [ColumnIndicator.SevenByte] = 7,
+            [ColumnIndicator.EightByte] = 8,
+        };
+
+    private readonly byte[] _page;
+    private readonly int[] _clusterPointers; // absolute page offsets, one per cluster
+    private readonly int[] _longDataPointers;
+    private readonly int[] _longDataLengths;
+
+    public bool IsCdFormat { get; }
+    public bool HasVersioningInformation { get; }
+    public byte RecordType { get; }
+    public bool HasLongDataRegion { get; }
+    public short NumberOfColumns { get; }
+    public IReadOnlyList<ColumnIndicator> Indicators { get; }
+    /// <summary>Total bytes this record occupies, relative to <paramref name="start"/>.</summary>
+    public int Length { get; }
+
+    private CompressedRecord(byte[] page, bool isCd, bool hasVersioning, byte recordType,
+        bool hasLongData, short numCols, IReadOnlyList<ColumnIndicator> indicators,
+        int[] clusterPointers, int[] longDataPointers, int[] longDataLengths, int length)
+    {
+        _page = page;
+        IsCdFormat = isCd;
+        HasVersioningInformation = hasVersioning;
+        RecordType = recordType;
+        HasLongDataRegion = hasLongData;
+        NumberOfColumns = numCols;
+        Indicators = indicators;
+        _clusterPointers = clusterPointers;
+        _longDataPointers = longDataPointers;
+        _longDataLengths = longDataLengths;
+        Length = length;
+    }
+
+    public static CompressedRecord Parse(byte[] page, int start)
+    {
+        byte header = page[start];
+        bool isCd = (header & 0x1) != 0;
+        bool hasVersioning = (header & 0x2) != 0;
+        byte recordType = (byte)((header >> 2) & 0x7);
+        bool hasLongData = (header & 0x20) != 0;
+
+        int p = 1; // record-relative, right after the header byte
+
+        byte first = page[start + p];
+        short numCols;
+        if ((first & 0x80) != 0)
+        {
+            numCols = (short)(BitConverter.ToInt16(page, start + p) & 0x7FFF);
+            p += 2;
+        }
+        else
+        {
+            numCols = first;
+            p += 1;
+        }
+
+        var indicators = new ColumnIndicator[numCols];
+        for (int i = 0; i < numCols; i++)
+        {
+            byte b = page[start + p];
+            indicators[i] = (ColumnIndicator)(i % 2 == 0 ? b & 0xF : (b & 0xF0) >> 4);
+            if (i % 2 == 1)
+                p++;
+        }
+        if (numCols % 2 == 1)
+            p++;
+
+        int numLengthPrefixedClusters = numCols > 0 ? (numCols - 1) / 30 : 0;
+        int[] clusterPointers;
+        if (numLengthPrefixedClusters == 0)
+        {
+            clusterPointers = new[] { start + p };
+            p += ShortRegionLength(indicators, 0, indicators.Length);
+        }
+        else
+        {
+            var clusterLengths = new int[numLengthPrefixedClusters];
+            for (int i = 0; i < numLengthPrefixedClusters; i++)
+                clusterLengths[i] = page[start + p++];
+
+            // total_clusters = numLengthPrefixedClusters + 1 -- see file header.
+            clusterPointers = new int[numLengthPrefixedClusters + 1];
+            clusterPointers[0] = start + p;
+            for (int i = 1; i < numLengthPrefixedClusters; i++)
+            {
+                int sum = 0;
+                for (int j = 0; j < i; j++) sum += clusterLengths[j];
+                clusterPointers[i] = clusterPointers[0] + sum;
+            }
+            int allPrefixedLength = 0;
+            foreach (var len in clusterLengths) allPrefixedLength += len;
+            int lastClusterStart = p + allPrefixedLength;
+            clusterPointers[numLengthPrefixedClusters] = start + lastClusterStart;
+
+            int lastClusterLength = ShortRegionLength(
+                indicators, numLengthPrefixedClusters * 30, indicators.Length);
+            p = lastClusterStart + lastClusterLength;
+        }
+
+        int[] longDataPointers = Array.Empty<int>();
+        int[] longDataLengths = Array.Empty<int>();
+        if (hasLongData)
+        {
+            // flags byte (containsTwoByteOffsets / containsComplexColumns) is read
+            // by OrcaMDF but never actually consulted -- this reader only
+            // supports the two-byte-offset shape, matching every record seen so
+            // far in the #2241 measurement.
+            p += 1;
+            short numEntries = BitConverter.ToInt16(page, start + p);
+            p += 2;
+            var offsets = new short[numEntries];
+            for (int i = 0; i < numEntries; i++)
+            {
+                offsets[i] = BitConverter.ToInt16(page, start + p);
+                p += 2;
+            }
+            p += numLengthPrefixedClusters; // per-cluster long-data counts, unused here
+
+            longDataPointers = new int[numEntries];
+            longDataLengths = new int[numEntries];
+            short prevOffset = 0;
+            for (int i = 0; i < numEntries; i++)
+            {
+                longDataPointers[i] = start + p;
+                longDataLengths[i] = offsets[i] - prevOffset;
+                p += longDataLengths[i];
+                prevOffset = offsets[i];
+            }
+        }
+
+        return new CompressedRecord(page, isCd, hasVersioning, recordType, hasLongData,
+            numCols, indicators, clusterPointers, longDataPointers, longDataLengths, p);
+    }
+
+    private static int ShortRegionLength(ColumnIndicator[] indicators, int fromInclusive, int toExclusive)
+    {
+        int total = 0;
+        for (int i = fromInclusive; i < toExclusive; i++)
+            if (LengthByIndicator.TryGetValue(indicators[i], out var len))
+                total += len;
+        return total;
+    }
+
+    /// <summary>Returns the raw column bytes, or null for SQL NULL.</summary>
+    public byte[]? GetColumnBytes(int index)
+    {
+        var indicator = Indicators[index];
+        switch (indicator)
+        {
+            case ColumnIndicator.Null:
+                return null;
+            case ColumnIndicator.DictionarySymbol:
+                throw new NotSupportedException(
+                    $"column {index}: page-dictionary substitution is not implemented (see #2241)");
+            case ColumnIndicator.TrueBit:
+                return new byte[] { 1 };
+            case ColumnIndicator.ZeroByte:
+                return Array.Empty<byte>();
+            case ColumnIndicator.LongData:
+            {
+                int longIndex = 0;
+                for (int i = 0; i < index; i++)
+                    if (Indicators[i] == ColumnIndicator.LongData)
+                        longIndex++;
+                int length = _longDataLengths[longIndex];
+                if ((length & 0x8000) != 0)
+                    throw new NotSupportedException(
+                        $"column {index}: complex long-data column not implemented (see #2241)");
+                return _page.AsSpan(_longDataPointers[longIndex], length).ToArray();
+            }
+            default:
+            {
+                int clusterIndex = index / 30;
+                int ptr = _clusterPointers[clusterIndex];
+                for (int j = clusterIndex * 30; j < index; j++)
+                    if (Indicators[j] != ColumnIndicator.LongData)
+                        ptr += LengthByIndicator[Indicators[j]];
+                int length = LengthByIndicator[indicator];
+                return _page.AsSpan(ptr, length).ToArray();
+            }
+        }
+    }
+}

--- a/tools/BakTableReader/RecordDecoding/CompressedRecord.cs
+++ b/tools/BakTableReader/RecordDecoding/CompressedRecord.cs
@@ -1,8 +1,24 @@
 // CompressedRecord — the "CD" row format SQL Server uses for ROW- and
 // PAGE-compressed tables (sysrowsets.cmprlevel 1 and 2). Ported from OrcaMDF's
-// CompressedRecord.cs (github.com/improvedk/OrcaMDF, MIT-licensed), WITH ONE
-// CORRECTION -- see below -- found while decoding a real 81-field BC table
-// for AL Runner issue #2241.
+// CompressedRecord.cs (github.com/improvedk/OrcaMDF), WITH ONE CORRECTION --
+// see below -- found while decoding a real 81-field BC table for AL Runner
+// issue #2241.
+//
+// LICENSE STATUS -- UNRESOLVED, flagging rather than guessing
+//   OrcaMDF is GPL-3.0 licensed, not MIT. An earlier version of this file's
+//   header said "MIT-licensed"; that was wrong and was never actually
+//   verified against OrcaMDF's own License.txt before being written. This
+//   file is the one in this directory that tracks OrcaMDF's specific
+//   algorithm most closely -- the CD/compressed row format is not documented
+//   anywhere else this spike found (unlike the plain page header or the
+//   uncompressed FixedVar row format, both independently documented
+//   elsewhere), so "ported... WITH ONE CORRECTION" above is an accurate,
+//   not a loose, description. Combining GPL-3.0-derived code into this
+//   MIT-licensed repository without further action (proper GPL-3.0
+//   attribution and compliance, a clean-room rewrite from spec only, or
+//   permission from OrcaMDF's author) is a real licensing question, not a
+//   missing-notice detail solved by copying in an MIT notice -- see PR #2243
+//   for the decision this is waiting on.
 //
 // THE CORRECTION (short-data-region cluster pointers)
 //   Columns are grouped into "clusters" of 30 for the short (<=8-byte) data

--- a/tools/BakTableReader/RecordDecoding/FixedVarRecord.cs
+++ b/tools/BakTableReader/RecordDecoding/FixedVarRecord.cs
@@ -1,0 +1,119 @@
+// FixedVarRecord — the uncompressed "primary record" row format (status byte
+// 0x10/0x20/0x30 in the AL Runner #2241 measurement). Ported from OrcaMDF's
+// Record.cs / PrimaryRecord.cs (github.com/improvedk/OrcaMDF, MIT-licensed).
+//
+// Only the shapes this spike actually needed are implemented: Primary rows
+// with a null bitmap and/or variable-length columns. Ghost records, forwarded
+// records and forwarding stubs are recognised (via RecordType) but not
+// resolved -- a caller asking for their data gets NotSupportedException
+// rather than silently wrong bytes.
+namespace BakTableReader.RecordDecoding;
+
+public enum RecordType : byte
+{
+    Primary = 0,
+    Forwarded = 1,
+    ForwardingStub = 2,
+    Index = 3,
+    BlobFragment = 4,
+    GhostIndex = 5,
+    GhostData = 6,
+    GhostVersion = 7,
+}
+
+public sealed class FixedVarRecord
+{
+    public RecordType Type { get; }
+    public bool HasNullBitmap { get; }
+    public bool HasVariableLengthColumns { get; }
+    public byte[] FixedLengthData { get; }
+    public short NumberOfColumns { get; }
+    public byte[]? NullBitmap { get; }
+    public IReadOnlyList<(bool Complex, byte[] Data)> VariableLengthColumns { get; }
+    /// <summary>Total bytes this record occupies, relative to its start offset.</summary>
+    public int Length { get; }
+
+    private FixedVarRecord(RecordType type, bool hasNullBitmap, bool hasVarLen,
+        byte[] fixedData, short numberOfColumns, byte[]? nullBitmap,
+        IReadOnlyList<(bool, byte[])> varLenColumns, int length)
+    {
+        Type = type;
+        HasNullBitmap = hasNullBitmap;
+        HasVariableLengthColumns = hasVarLen;
+        FixedLengthData = fixedData;
+        NumberOfColumns = numberOfColumns;
+        NullBitmap = nullBitmap;
+        VariableLengthColumns = varLenColumns;
+        Length = length;
+    }
+
+    public bool IsNull(int zeroBasedColumnIndex)
+    {
+        if (NullBitmap is null)
+            return false;
+        int byteIndex = zeroBasedColumnIndex / 8;
+        int bitIndex = zeroBasedColumnIndex % 8;
+        if (byteIndex >= NullBitmap.Length)
+            return false;
+        return (NullBitmap[byteIndex] & (1 << bitIndex)) != 0;
+    }
+
+    /// <summary>Parses a record starting at <paramref name="start"/> within
+    /// <paramref name="page"/> (a full 8192-byte page buffer).</summary>
+    public static FixedVarRecord Parse(byte[] page, int start)
+    {
+        byte statusA = page[start];
+        var type = (RecordType)((statusA >> 1) & 0x7);
+        bool hasNullBitmap = (statusA & 0x10) != 0;
+        bool hasVarLen = (statusA & 0x20) != 0;
+
+        if (type is RecordType.ForwardingStub or RecordType.Forwarded)
+            throw new NotSupportedException($"{type} records are not resolved by this reader");
+
+        int p = start + 2; // status bits A + B
+        short fixedLength = (short)(BitConverter.ToInt16(page, p) - 4);
+        p += 2;
+        var fixedData = page.AsSpan(p, fixedLength).ToArray();
+        p += fixedLength;
+
+        short numberOfColumns = BitConverter.ToInt16(page, p);
+        p += 2;
+
+        byte[]? nullBitmap = null;
+        if (hasNullBitmap)
+        {
+            int nBytes = (numberOfColumns + 7) / 8;
+            nullBitmap = page.AsSpan(p, nBytes).ToArray();
+            p += nBytes;
+        }
+
+        var varLenColumns = new List<(bool, byte[])>();
+        if (hasVarLen)
+        {
+            short numVarLen = BitConverter.ToInt16(page, p);
+            p += 2;
+            var endOffsets = new short[numVarLen];
+            for (int i = 0; i < numVarLen; i++)
+            {
+                endOffsets[i] = BitConverter.ToInt16(page, p);
+                p += 2;
+            }
+
+            int prevEnd = p;
+            foreach (short rawEnd in endOffsets)
+            {
+                bool complex = (rawEnd & unchecked((short)0x8000)) != 0;
+                // Column-offset-array entries are record-relative cumulative END
+                // offsets (per OrcaMDF Record.cs), not lengths, and not
+                // buffer-absolute -- they must be added to `start`.
+                int end = start + (rawEnd & 0x7FFF);
+                varLenColumns.Add((complex, page.AsSpan(prevEnd, end - prevEnd).ToArray()));
+                prevEnd = end;
+            }
+            p = prevEnd;
+        }
+
+        return new FixedVarRecord(type, hasNullBitmap, hasVarLen, fixedData,
+            numberOfColumns, nullBitmap, varLenColumns, p - start);
+    }
+}

--- a/tools/BakTableReader/RecordDecoding/FixedVarRecord.cs
+++ b/tools/BakTableReader/RecordDecoding/FixedVarRecord.cs
@@ -1,6 +1,11 @@
 // FixedVarRecord — the uncompressed "primary record" row format (status byte
 // 0x10/0x20/0x30 in the AL Runner #2241 measurement). Ported from OrcaMDF's
-// Record.cs / PrimaryRecord.cs (github.com/improvedk/OrcaMDF, MIT-licensed).
+// Record.cs / PrimaryRecord.cs (github.com/improvedk/OrcaMDF, GPL-3.0
+// licensed -- an earlier version of this comment said MIT, which was wrong
+// and unverified). This uncompressed row format is also independently
+// documented in Microsoft's own "Anatomy of a Record" material and other
+// public SQL Server internals references -- see PR #2243 for the unresolved
+// GPL-3.0/MIT licensing question this raises for this directory.
 //
 // Only the shapes this spike actually needed are implemented: Primary rows
 // with a null bitmap and/or variable-length columns. Ghost records, forwarded

--- a/tools/BakTableReader/SqlCatalog.cs
+++ b/tools/BakTableReader/SqlCatalog.cs
@@ -1,0 +1,168 @@
+// SqlCatalog — walks the SQL Server system catalog (sysallocunits / sysrowsets
+// / sysschobjs) far enough to turn a table's SQL object name into the first
+// data page of its row storage. Byte offsets ported from OrcaMDF's BaseTables
+// schemas (github.com/improvedk/OrcaMDF, MIT-licensed), each RE-VERIFIED
+// against real BC demo data for AL Runner #2241 because the underlying SQL
+// Server engine has drifted since OrcaMDF was written (~2011): several
+// catalog rows here carry one more hidden fixed-length column than OrcaMDF's
+// schema documents (e.g. sysschobj: 44 fixed bytes / 12 columns here, not
+// OrcaMDF's 40 bytes / 11). The system object ids themselves (5, 7, 34, 41 --
+// SystemObject enum in OrcaMDF) are stable and matched real data exactly.
+//
+// SCOPE: catalog rows are read here using FixedVarRecord (the uncompressed
+// format) -- every system catalog table observed in the #2241 measurement was
+// uncompressed. USER table data may or may not be; check
+// SysRowset.CompressionLevel before choosing FixedVarRecord vs CompressedRecord
+// to decode a table's own rows (see BakTableReaderSpike for the worked example).
+using BakTableReader.RecordDecoding;
+
+namespace BakTableReader;
+
+public sealed record SysAllocUnit(long AuId, byte Type, long OwnerId, PagePointer PgFirst, PagePointer PgRoot);
+
+public sealed record SysRowset(long RowsetId, byte OwnerType, int IdMajor, int IdMinor, long RowCount, byte CompressionLevel);
+
+public sealed record SysSchObj(int Id, string Name, string Type);
+
+public sealed class SqlCatalog
+{
+    private readonly BakFile _file;
+    private List<SysAllocUnit>? _sysAllocUnits;
+    private List<SysRowset>? _sysRowsets;
+    private List<SysSchObj>? _sysSchObjs;
+
+    public SqlCatalog(BakFile file) => _file = file;
+
+    /// <summary>Boot page is always logical (1:9). Returns the FirstSysIndexes
+    /// pointer -- the head of the sysallocunits row chain.</summary>
+    public PagePointer ReadFirstSysIndexes()
+    {
+        var page = _file.ReadPage(new PagePointer(1, 9));
+        if (!PageHeader.TryParse(page, out var header) || header.Type != PageType.Boot)
+            throw new InvalidDataException("logical page (1:9) is not a boot page");
+        var slots = PageHeader.ReadSlotArray(page, header.SlotCount);
+        var record = FixedVarRecord.Parse(page, slots[0]);
+        int pageId = BitConverter.ToInt32(record.FixedLengthData, 512);
+        short fileId = BitConverter.ToInt16(record.FixedLengthData, 516);
+        return new PagePointer(fileId, pageId);
+    }
+
+    public IReadOnlyList<SysAllocUnit> SysAllocUnits => _sysAllocUnits ??= ReadSysAllocUnits().ToList();
+    public IReadOnlyList<SysRowset> SysRowsets => _sysRowsets ??= ReadSysRowsets().ToList();
+    public IReadOnlyList<SysSchObj> SysSchObjs => _sysSchObjs ??= ReadSysSchObjs().ToList();
+
+    private IEnumerable<SysAllocUnit> ReadSysAllocUnits()
+    {
+        foreach (var record in WalkFixedVarRows(ReadFirstSysIndexes()))
+        {
+            var fd = record.FixedLengthData;
+            if (fd.Length < 65)
+                continue;
+            yield return new SysAllocUnit(
+                AuId: BitConverter.ToInt64(fd, 0),
+                Type: fd[8],
+                OwnerId: BitConverter.ToInt64(fd, 9),
+                PgFirst: ReadPagePointer6(fd, 23),
+                PgRoot: ReadPagePointer6(fd, 29));
+        }
+    }
+
+    private IEnumerable<SysRowset> ReadSysRowsets()
+    {
+        // Fixed allocation unit id for sysrowsets itself (OrcaMDF
+        // FixedSystemObjectAllocationUnits.sysrowsets); confirmed against real
+        // data (its own sysrowsets self-entry: idmajor=5, idminor=1).
+        const long sysrowsetsAuId = 327680;
+        var au = SysAllocUnits.Single(a => a.AuId == sysrowsetsAuId);
+        foreach (var record in WalkFixedVarRows(au.PgFirst))
+        {
+            var fd = record.FixedLengthData;
+            if (fd.Length < 53)
+                continue;
+            yield return new SysRowset(
+                RowsetId: BitConverter.ToInt64(fd, 0),
+                OwnerType: fd[8],
+                IdMajor: BitConverter.ToInt32(fd, 9),
+                IdMinor: BitConverter.ToInt32(fd, 13),
+                RowCount: BitConverter.ToInt64(fd, 27),
+                CompressionLevel: fd[35]);
+        }
+    }
+
+    private IEnumerable<SysSchObj> ReadSysSchObjs()
+    {
+        const int sysschobjsObjectId = 34;
+        var rowset = SysRowsets.Single(r => r.IdMajor == sysschobjsObjectId && r.IdMinor == 1);
+        var au = SysAllocUnits.Single(a => a.OwnerId == rowset.RowsetId && a.Type == 1);
+        foreach (var record in WalkFixedVarRows(au.PgFirst))
+        {
+            var fd = record.FixedLengthData;
+            if (fd.Length < 15 || record.VariableLengthColumns.Count == 0)
+                continue;
+            int id = BitConverter.ToInt32(fd, 0);
+            string name = System.Text.Encoding.Unicode.GetString(record.VariableLengthColumns[0].Data);
+            string type = System.Text.Encoding.ASCII.GetString(fd, 13, 2);
+            yield return new SysSchObj(id, name, type);
+        }
+    }
+
+    /// <summary>Resolves a table's rowset (idminor 1 -- the primary/clustered
+    /// row storage, not a secondary index) and the allocation unit that holds
+    /// its rows.</summary>
+    public (SysRowset Rowset, SysAllocUnit AllocUnit) GetTableStorage(int sqlObjectId, int idMinor = 1)
+    {
+        var rowset = SysRowsets.Single(r => r.IdMajor == sqlObjectId && r.IdMinor == idMinor);
+        var au = SysAllocUnits.Single(a => a.OwnerId == rowset.RowsetId && a.Type == 1);
+        return (rowset, au);
+    }
+
+    /// <summary>Follows the page-header Next-page chain starting at
+    /// <paramref name="first"/>, yielding every Primary record found on Data
+    /// pages. Ghost/other record types are skipped.</summary>
+    public IEnumerable<FixedVarRecord> WalkFixedVarRows(PagePointer first)
+    {
+        var current = first;
+        while (current != PagePointer.Zero)
+        {
+            var page = _file.ReadPage(current);
+            if (!PageHeader.TryParse(page, out var header))
+                throw new InvalidDataException($"page {current} has no valid header");
+            if (header.Type == PageType.Data)
+            {
+                foreach (var slot in PageHeader.ReadSlotArray(page, header.SlotCount))
+                {
+                    var record = FixedVarRecord.Parse(page, slot);
+                    if (record.Type == RecordType.Primary)
+                        yield return record;
+                }
+            }
+            current = header.Next;
+        }
+    }
+
+    /// <summary>Same traversal as <see cref="WalkFixedVarRows"/> but for a
+    /// ROW/PAGE-compressed rowset (CompressionLevel >= 1).</summary>
+    public IEnumerable<CompressedRecord> WalkCompressedRows(PagePointer first)
+    {
+        var current = first;
+        while (current != PagePointer.Zero)
+        {
+            var page = _file.ReadPage(current);
+            if (!PageHeader.TryParse(page, out var header))
+                throw new InvalidDataException($"page {current} has no valid header");
+            if (header.Type == PageType.Data)
+            {
+                foreach (var slot in PageHeader.ReadSlotArray(page, header.SlotCount))
+                    yield return CompressedRecord.Parse(page, slot);
+            }
+            current = header.Next;
+        }
+    }
+
+    private static PagePointer ReadPagePointer6(byte[] buffer, int offset)
+    {
+        int pageId = BitConverter.ToInt32(buffer, offset);
+        short fileId = BitConverter.ToInt16(buffer, offset + 4);
+        return new PagePointer(fileId, pageId);
+    }
+}

--- a/tools/BakTableReader/SqlCatalog.cs
+++ b/tools/BakTableReader/SqlCatalog.cs
@@ -1,13 +1,16 @@
 // SqlCatalog — walks the SQL Server system catalog (sysallocunits / sysrowsets
 // / sysschobjs) far enough to turn a table's SQL object name into the first
 // data page of its row storage. Byte offsets ported from OrcaMDF's BaseTables
-// schemas (github.com/improvedk/OrcaMDF, MIT-licensed), each RE-VERIFIED
+// schemas (github.com/improvedk/OrcaMDF, GPL-3.0 licensed -- an earlier
+// version of this comment said MIT, which was wrong and unverified; see PR
+// #2243 for the unresolved licensing question this raises), each RE-VERIFIED
 // against real BC demo data for AL Runner #2241 because the underlying SQL
 // Server engine has drifted since OrcaMDF was written (~2011): several
 // catalog rows here carry one more hidden fixed-length column than OrcaMDF's
 // schema documents (e.g. sysschobj: 44 fixed bytes / 12 columns here, not
 // OrcaMDF's 40 bytes / 11). The system object ids themselves (5, 7, 34, 41 --
-// SystemObject enum in OrcaMDF) are stable and matched real data exactly.
+// SystemObject enum in OrcaMDF) are stable and matched real data exactly;
+// those small integer ids are facts about SQL Server, not expression.
 //
 // SCOPE: catalog rows are read here using FixedVarRecord (the uncompressed
 // format) -- every system catalog table observed in the #2241 measurement was


### PR DESCRIPTION
Closes #2241

## What this proves

Yes, we can read real BC demo-database rows out of the `.bak` that ships in a sandbox artifact, without SQL Server. The proof reads **"Source Code Setup" for CRONUS International Ltd.** out of `sandbox/28.1.49838.50621/w1/BusinessCentral-W1.bak` and decodes 81 real AL business-field values byte-for-byte -- `SALES`, `PURCHASES`, `INVTPCOST`, `EXCHRATADJ`, ... -- cross-checked against the table's real AL schema (table id 242, field names/numbers) pulled from the shipped `Microsoft_Base Application` `.app`'s `SymbolReference.json`, not eyeballed strings. Cross-checked structurally against the BC 27.5 `.bak` too (same boot-page shape, same fixed system-object ids).

`tools/BakTableReader` is the standalone reader: page index -> boot page -> `sysallocunits` -> `sysrowsets` -> `sysschobjs` -> row decode. `tools/BakTableReader.Tests` proves the decoder against bytes captured verbatim from the real file, with **no dependency on the 894MB `.bak` being present** (24 of 25 tests), plus one opt-in integration test gated on `AL_RUNNER_SPIKE_BAK_PATH` that runs the full pipeline against the real file when it's available (skips cleanly otherwise -- verified both paths locally).

This is a spike. Nothing here is provisioning, a snapshot format, or runtime hydration -- that's #2240. Nothing here has to become the production reader.

## Unresolved: OrcaMDF's actual license is GPL-3.0, not MIT -- needs a decision before this merges as-is

The code comments originally said OrcaMDF was MIT-licensed. That was wrong and was never actually checked against OrcaMDF's own `License.txt` before being written -- it is **GPL-3.0**. AL Runner is MIT. That is a real licensing question, not a missing-notice detail: `CompressedRecord.cs` in particular tracks OrcaMDF's specific algorithm closely (its own header already said "ported ... WITH ONE CORRECTION"), because the CD/compressed-record format isn't documented anywhere else this spike found -- unlike the plain page header and the uncompressed row format, both of which are independently documented elsewhere and carry lower risk.

I corrected the mislabeling in the four affected file headers rather than fabricate an MIT-style third-party notice for GPL-3.0 code, and I'm not proposing a resolution here -- that's a decision for whoever owns the licensing call, with real options: attribute and comply with GPL-3.0 properly (which likely means the derived files carry GPL-3.0 terms, not MIT, and this repo already mixes licenses correctly elsewhere if that's acceptable), rewrite the CD-format decoder clean-room from Microsoft's public compression whitepaper only (dropping the OrcaMDF-derived algorithm shape, at the cost of re-doing verification work), get explicit permission from OrcaMDF's author, or drop this tool from the tracked history and keep only the report's prose findings. Flagging plainly rather than guessing.

## It is harder than the issue's own starting numbers suggested -- concretely, in two ways

The issue's broad byte-sample said rows are "uncompressed standard FixedVar primary records ... zero CD/compressed records," and framed the row-decode step as "decode FixedVar rows for the target table." That did not hold for the actual requested target:

1. **The real table is PAGE-compressed** (`sysrowsets.cmprlevel == 2`), not the FixedVar shape the earlier sample implied for "most" pages. The only credible prior art here -- [OrcaMDF](https://github.com/improvedk/OrcaMDF) (GPL-3.0 licensed -- see the licensing section above -- referenced throughout the code with attribution) -- explicitly does **not** implement page compression at all (`throw new NotImplementedException("Page compression not yet supported.")`), and its ROW-compression decoder has a latent, apparently never-exercised bug: the short-data-region cluster-pointer array is sized one cluster too small for any table with more than 30 physical (non-long) columns, which throws `IndexOutOfRangeException` on exactly this table's 84-column `$ext` companion object. `CompressedRecord.cs`'s file header documents the fix; `CompressedRecordTests.Parse_ExtRow_Has84ColumnsSpanningThreeShortDataClusters` reproduces the exact shape and decodes column 70 (in the 3rd cluster) to prove it.

2. **The AL schema doesn't map onto one SQL object.** BC's modern schema splits a table into a "base" object (7 native columns: a versioning column, the primary key, and 5 platform system columns -- SystemId/CreatedAt/CreatedBy/ModifiedAt/ModifiedBy) and a separate `$ext` companion object holding every other field (84 columns for this table's 80 business fields, one physical column consistently ahead of/behind the base table's own row order). I initially chased a **sparse-columns hypothesis** to explain why the base object had only 7 columns for an 81-field AL table -- there is no evidence for that (no `0x0005` sparse-vector magic anywhere near the record), and the real explanation is this `$ext` split. A production reader needs to know about this split for every table it reads, not just this one.

Also found along the way (not part of the original measurement): the naive "boot page absolute offset + PageId" addressing scheme silently breaks partway through the file -- the `.bak`'s backup-stream structure shifts the effective offset by a constant partway through, and a page reached by that arithmetic still parses as a *plausible* header (so it fails silently, not loudly) while belonging to an unrelated allocation unit. `PageIndexTests.Build_ResolvesAddressByStoredHeaderNotByBlockPosition` reproduces this exact shape.

None of this changes the headline: it's fully feasible, and the parts that work, work cleanly and fast.

## The three questions the issue asked, answered with numbers

**1. Does the in-memory table provider support lazy per-table population today?**
Yes, already. `AlRunner/Patches/RecordPatches.cs`'s `GetDataAccessForTableCore` (~line 1285) keys a `ConcurrentDictionary<int, object> perTable` per `(DataAccessSource, tableId)` and creates that table's `TempTableDataProvider` the first time `NavDataAccessSource_GetDataAccessForTable` is called for it -- the fallthrough path at the end of the method (~line 1492) is exactly "if not yet created, create it now." Every existing virtual system table (`Field` 2000000041, `AllObj` 2000000038, `AllObjWithCaption` 2000000058, `Integer` 2000000026, Report Layout List, Report Metadata, Table/Page Metadata) already hooks this exact point to top up its rows on first access via a `PopulateXVirtualTable(...)` call. A demo-data populate for a BC-shipped table is a straightforward addition alongside those existing branches -- same mechanism, no new architecture. This directly answers #2240's open question 4: per-run cost can scale with tables actually touched, not database size, for free.

**2. Cold read cost** (the issue's 0.4s figure is page-cache-warm).
Measured on this machine (fast local NVMe) using `posix_fadvise(POSIX_FADV_DONTNEED)` to evict the file's pages before each cold run:
- Sequential full-file read (raw bytes, no parsing): 0.056s warm / 0.337s cold (~6x).
- Full page-index build (the actual per-page header parse + dictionary insert this reader needs): 0.13s warm / 0.34s cold.

Caveat, stated plainly: this is close to a best case. It's a fast local SSD; a spinning disk, a network filesystem, or a throttled cloud disk could cost substantially more, proportional to that storage's I/O throughput, not to CPU. What this measurement does establish is that on ordinary modern hardware the cold cost is not prohibitive -- a third of a second against a run whose whole point is milliseconds-scale AL test execution is real but small -- not that it's a universal constant.

**3. Is a page->table index worth caching at provisioning?**
Yes, and it's a correctness requirement, not just an optimization. See the addressing-breaks-silently finding above: fixed-offset arithmetic from the boot page is not reliably valid across the whole file, and the only way to get every page right is to read each block's own self-reported `(FileId, PageId)` header field once and index it, which is exactly what `PageIndex.Build` does in one linear pass (~0.13-0.34s on this file). #2240's provisioning step already has to touch the whole file once to walk the catalog at all -- caching the *result* of that walk (the already-resolved starting page pointer per demo table provisioning cares about, not the raw 103k-entry page map) removes this cost from every subsequent run entirely.

## What full implementation (#2240) still needs, beyond this spike

- **General SQL-type -> AL-type mapping.** This spike only interprets the specific shapes it encountered (fixed-length ASCII-ish `Code`/`Text` content) by inspection. A real implementation needs `syscolpars.xtype`/`utype` + `sysscalartypes` consulted generically, the way OrcaMDF's `SqlTypeFactory` does.
- **BLOB/LOB resolution** -- explicitly out of scope for this spike per the issue (491MB / ~60k `TextMix` pages in the measured file). OrcaMDF's `LobStructures` (`SmallRoot`/`LargeRootYukon`/off-row proxies) would need the same from-scratch verification this spike gave the CD-compressed-record format; nothing here shortcuts that work.
- **Page-dictionary compression columns** (`ColumnIndicator.DictionarySymbol`, 0xC) -- not encountered in any page this spike actually walked (every table read here is small and freshly-loaded, so SQL Server never had repeated values worth dictionary-encoding), so it throws loudly rather than guessing. Validating a real implementation needs a page that actually exercises it.
- **General heap/IAM-based page enumeration.** This spike follows the allocation unit's `pgfirst` -> `NextPage` chain directly, which worked cleanly for every table walked here because CRONUS's demo data was loaded once and never fragmented. That is not the officially correct way to enumerate a SQL Server heap (real tooling walks IAM pages + PFS allocation bitmaps for exactly this reason) and would need it for tables with any real update/delete history.
- **Multi-file backups** -- this reader hard-asserts `FileId == 1` (true for every artifact inspected); untested against anything else.
- **Catalog byte-offset drift across BC/SQL-engine versions.** The offsets in `SqlCatalog.cs` were reverse-engineered against BC 27.5.46862 / 28.1.49838 specifically (structurally cross-checked, not assumed) -- a real implementation should re-verify per newly-supported BC version rather than assume forward compatibility, the same way this spike found OrcaMDF's ~2011-era offsets had already drifted once.

## Tests

- `PageHeaderTests`, `PageIndexTests`, `FixedVarRecordTests`, `CompressedRecordTests`: 24 tests, no file dependency, using bytes captured verbatim from the real `.bak` (embedded as hex fixtures) plus synthetic fixtures for edge cases (missing/undefined page types, dictionary-substituted columns, no-null-bitmap records).
- `BakTableReaderIntegrationTests`: 1 opt-in test gated on `AL_RUNNER_SPIKE_BAK_PATH`; verified both the skip path (env var unset -> real `Skipped` result) and the pass path (env var pointing at the real file -> passes in ~250ms including build) locally.
- `dotnet build tools/BakTableReader tools/BakTableReader.Tests -warnaserror`: 0 warnings, 0 errors.
- No changes to `AlRunner/`, so the `require-tests` CI gate does not trigger on this PR; `AlRunner.Tests` builds clean (unaffected, sanity-checked with `dotnet build AlRunner.Tests`).

## Fix-the-shape-not-just-the-reported-line

- **Same wrong pattern elsewhere?** The cluster-pointer sizing bug is generic to OrcaMDF's `CompressedRecord`, not specific to this one table -- it reproduces on any compressed table with >30 physical columns, which is common in BC (most non-trivial tables). Fixed once in the shared decoder, not special-cased for this table.
- **Sibling function, same assumption?** `FixedVarRecord` (the uncompressed sibling) does not share this bug -- its variable-length column offsets are a flat array with no clustering, so there's nothing to get wrong the same way. Checked, no fix needed there.
- **Two paths, same invariant?** N/A here -- this PR adds a new, isolated reader; it doesn't touch existing runner code paths.
