### PR TITLE
fix(cli): move startup bookkeeping behind --verbose

### DIFF
--- a/AlRunner.Tests/BcVersionDefaultDocumentationTests.cs
+++ b/AlRunner.Tests/BcVersionDefaultDocumentationTests.cs
@@ -116,7 +116,10 @@ public sealed class BcVersionDefaultDocumentationTests
         var isolatedHome = BuildIsolatedHomeWithEngineVersionAndAFakeHigherOne(engineVersion!);
         try
         {
-            var (exit, _, stderr) = Run(isolatedHome, "--no-auto-provision", $"\"{MinimalBundle}\"");
+            // Issue #2239: the "[bc] no --bc-version given — selecting BC ..., the exact
+            // build ..." reasoning line this test also asserts on moved behind --verbose
+            // (the outcome is already named, unconditionally, by "[bc] selected BC ...").
+            var (exit, _, stderr) = Run(isolatedHome, "--no-auto-provision", "--verbose", $"\"{MinimalBundle}\"");
 
             Assert.True(exit == 0, $"expected a clean run against the engine's own (real, symlinked) " +
                 $"artifact; a nonzero exit means something else got selected instead. exit={exit}\n{stderr}");

--- a/AlRunner.Tests/CacheKeyDependencyClosureTests.cs
+++ b/AlRunner.Tests/CacheKeyDependencyClosureTests.cs
@@ -115,7 +115,10 @@ public sealed class CacheKeyDependencyClosureTests : IDisposable
     /// </summary>
     private static string RunFullAndReadCacheKey(string packageCacheDir, string alCacheDir)
     {
-        var output = RunRunner(packageCacheDir, alCacheDir, "");
+        // Issue #2239: "[cache] MISS/HIT key=..." moved behind --verbose (diagnostic
+        // detail, not a test result) — this is the one caller that still needs to read
+        // it back off real output, so it passes the flag explicitly.
+        var output = RunRunner(packageCacheDir, alCacheDir, " --verbose");
         var m = Regex.Match(output, @"\[cache\]\s+(?:MISS|HIT)\s+key=([0-9a-f]{64})");
         Assert.True(m.Success, $"could not read a cache key from the runner output:\n{output}");
         return m.Groups[1].Value;

--- a/AlRunner.Tests/CleanRunStartupVerbosityTests.cs
+++ b/AlRunner.Tests/CleanRunStartupVerbosityTests.cs
@@ -1,0 +1,273 @@
+// CleanRunStartupVerbosityTests — issue #2239.
+//
+// A clean run used to print roughly fifteen lines of startup bookkeeping (which
+// artifact was auto-selected and why, engine-variant selection, the re-exec notice,
+// "engine artifacts already complete", package-cache directory counts, the
+// `[type-index]` metadata-fallback note, patch-apply timing, per-bundle dep counts,
+// and AL-output cache HIT/MISS) before the first test result — several of them twice,
+// because a Cecil-fresh-rewrite or shadow-runtime re-exec re-runs the same startup
+// sequence in a child process. None of that is a test result, and #2210/#2221 already
+// established the failure mode this fix has to avoid: hiding a line by editing Log's
+// `[Component]` allowlist either does nothing (most of these tags are not suppressed
+// by that filter at all — several, like `[cache]`, `[bc]`, `[provision]`, `[reexec]`,
+// are either unmatched by its regex or explicitly exempted from it) or, worse, makes
+// the line invisible even under --verbose.
+//
+// So every line this file asserts on was moved behind an explicit `if (Log.Verbose)`
+// at its own call site in Program.cs / AssemblyTypeIndex.cs — never by touching Log's
+// regex or allowlist. This file proves that from the outside: a default run must not
+// print any of them, and a --verbose run must print every one that this dev/CI build
+// can actually reach (see below for the two that can't, and why).
+//
+// What deliberately still prints at default verbosity (see Program.cs's own comments,
+// and issue #2077/#2210's reasoning): `[bc] selected BC <version> (<path>)` — which BC
+// version actually ran is a RESULT, not a diagnostic, per #2077's measured 42-test
+// swing decided silently — and `al-runner — running N bundle(s)`, the run header. Both
+// are pinned here too, as the negative control: this fix must not have swept those
+// away along with the bookkeeping.
+//
+// Two of the moved lines are NOT exercised by a live spawn here, and covered by a
+// structural source check instead (ProgramCs_EngineVariantAndReexecLines_GatedOnVerbose
+// below): `[bc] selecting engine variant ...` and its matching `[reexec] Re-execing
+// into a shadow runtime dir with the matching BC-minor engine variant` only fire when
+// this install ships per-BC-minor engine variants (a packaged release's variants/ dir —
+// see EngineVariants.Discover), which a plain `dotnet build` dev/CI checkout never has.
+// Forcing that condition would mean fabricating a fake variants/ directory and a second
+// engine build, disproportionate to what this file needs to prove. Confirmed empirically
+// (2026-08-31, this dev build): a --verbose spawn against RecordTriggerXRec prints every
+// OTHER fragment below exactly once, these two zero times, matching EngineVariants.
+// Discover(...).Count == 0 for this build — not evidence of a gating bug, evidence the
+// branch is unreached here.
+using System.Diagnostics;
+using System.Text;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class CleanRunStartupVerbosityTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+    private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
+    private static readonly string Fixture =
+        Path.Combine(RepoRoot, "AlRunner.Tests", "Fixtures", "RecordTriggerXRec");
+
+    /// <summary>
+    /// Every line issue #2239 named as startup bookkeeping that must move behind
+    /// --verbose AND that this dev/CI build can actually reach in one cold spawn
+    /// against a fresh --cache dir (see the file header for the two variant-swap
+    /// lines this deliberately excludes, and
+    /// <see cref="DefaultRun_PrintsNoCacheHitLineOnAWarmRun"/> /
+    /// <see cref="VerboseRun_PrintsCacheHitLineOnAWarmRun"/> for `[cache] HIT`, which
+    /// needs a second, warm run). Matched as a plain substring against combined
+    /// stdout+stderr — each entry is the fixed, non-varying prefix of a real line (the
+    /// full line also carries a version number, byte count, hash, or path that varies
+    /// run to run).
+    /// </summary>
+    private static readonly string[] ColdRunBookkeepingLineFragments =
+    {
+        "[bc] no --bc-version given — selecting BC ",
+        "[reexec] Ncl.dll not shipped in this install",
+        "[provision] BC ",
+        "  package caches (requested): ",
+        "  package caches (final search set): ",
+        "[type-index] no raw metadata for ",
+        "BC runtime patches applied (",
+        " dep(s)",
+        " dep assembl(ies)",
+        "[cache] MISS",
+        "[cache] WROTE",
+    };
+
+    private static (string Output, int Exit) Run(string alCacheDir, params string[] extraArgs)
+    {
+        var args = new StringBuilder(TestBuildConfig.RunArgs(ProjectPath));
+        // Deliberately NOT TestBuildConfig.BcVersionArg — the auto-selection lines this
+        // class asserts on ("[bc] no --bc-version given — selecting BC ...") only print
+        // when neither --bc-version nor --artifact-path is given.
+        foreach (var a in extraArgs) args.Append(' ').Append(a);
+        args.Append($" --cache \"{alCacheDir}\"");
+        args.Append($" \"{Fixture}\"");
+
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            Arguments = args.ToString(),
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            WorkingDirectory = RepoRoot,
+        };
+        // Deliberately isolated from whatever the ambient shell/session might have set —
+        // this class is specifically about the CLI --verbose flag's effect, so nothing
+        // may leak in from outside either test.
+        psi.Environment.Remove("AL_RUNNER_VERBOSE");
+
+        var sb = new StringBuilder();
+        using var p = Process.Start(psi)!;
+        p.OutputDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.ErrorDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.BeginOutputReadLine();
+        p.BeginErrorReadLine();
+        if (!p.WaitForExit(120_000)) { try { p.Kill(true); } catch { } throw new TimeoutException("runner hung"); }
+        p.WaitForExit();
+        lock (sb) return (sb.ToString(), p.ExitCode);
+    }
+
+    private static string NewCacheDir([System.Runtime.CompilerServices.CallerMemberName] string name = "") =>
+        Path.Combine(Path.GetTempPath(), "al-runner-clean-run-verbosity", name, Guid.NewGuid().ToString("N"));
+
+    /// <summary>
+    /// RED (pre-fix): every fragment in <see cref="ColdRunBookkeepingLineFragments"/>
+    /// appeared unconditionally, so this test failed against the pre-fix binary. GREEN:
+    /// a default (non-verbose) run prints none of them.
+    /// </summary>
+    [SkippableFact]
+    public void DefaultRun_PrintsNoStartupBookkeepingLines()
+    {
+        TestArtifacts.SkipIfMissing();
+        var alCacheDir = NewCacheDir();
+        try
+        {
+            var (output, exit) = Run(alCacheDir);
+            Assert.True(exit == 0 && output.Contains("pass:        1"),
+                $"fixture must compile and pass cleanly:\n{output}");
+
+            foreach (var fragment in ColdRunBookkeepingLineFragments)
+                Assert.DoesNotContain(fragment, output);
+        }
+        finally
+        {
+            try { Directory.Delete(alCacheDir, recursive: true); } catch { }
+        }
+    }
+
+    /// <summary>
+    /// The other direction: --verbose must still surface every one of these lines on a
+    /// cold run against a fresh --cache dir — the fix must gate them, not delete them.
+    /// </summary>
+    [SkippableFact]
+    public void VerboseRun_PrintsColdRunBookkeepingLines()
+    {
+        TestArtifacts.SkipIfMissing();
+        var alCacheDir = NewCacheDir();
+        try
+        {
+            var (output, exit) = Run(alCacheDir, "--verbose");
+            Assert.True(exit == 0 && output.Contains("pass:        1"),
+                $"fixture must compile and pass cleanly:\n{output}");
+
+            foreach (var fragment in ColdRunBookkeepingLineFragments)
+                Assert.Contains(fragment, output);
+        }
+        finally
+        {
+            try { Directory.Delete(alCacheDir, recursive: true); } catch { }
+        }
+    }
+
+    /// <summary>
+    /// `[cache] HIT` only fires on a second, warm run against the same --cache dir — a
+    /// single cold spawn always takes the MISS branch instead (covered above). Default
+    /// verbosity: absent on both the cold (MISS) and warm (HIT) run.
+    /// </summary>
+    [SkippableFact]
+    public void DefaultRun_PrintsNoCacheHitLineOnAWarmRun()
+    {
+        TestArtifacts.SkipIfMissing();
+        var alCacheDir = NewCacheDir();
+        try
+        {
+            var (coldOutput, coldExit) = Run(alCacheDir);
+            Assert.True(coldExit == 0 && coldOutput.Contains("pass:        1"),
+                $"cold run must compile and pass cleanly:\n{coldOutput}");
+
+            var (warmOutput, warmExit) = Run(alCacheDir);
+            Assert.True(warmExit == 0 && warmOutput.Contains("pass:        1"),
+                $"warm run must compile and pass cleanly:\n{warmOutput}");
+            Assert.DoesNotContain("[cache] HIT", warmOutput);
+            Assert.DoesNotContain("[cache] MISS", warmOutput);
+        }
+        finally
+        {
+            try { Directory.Delete(alCacheDir, recursive: true); } catch { }
+        }
+    }
+
+    /// <summary>--verbose counterpart: the warm run's HIT line must still be reachable.</summary>
+    [SkippableFact]
+    public void VerboseRun_PrintsCacheHitLineOnAWarmRun()
+    {
+        TestArtifacts.SkipIfMissing();
+        var alCacheDir = NewCacheDir();
+        try
+        {
+            var (coldOutput, coldExit) = Run(alCacheDir, "--verbose");
+            Assert.True(coldExit == 0 && coldOutput.Contains("pass:        1"),
+                $"cold run must compile and pass cleanly:\n{coldOutput}");
+            Assert.Contains("[cache] MISS", coldOutput);
+
+            var (warmOutput, warmExit) = Run(alCacheDir, "--verbose");
+            Assert.True(warmExit == 0 && warmOutput.Contains("pass:        1"),
+                $"warm run must compile and pass cleanly:\n{warmOutput}");
+            Assert.Contains("[cache] HIT", warmOutput);
+        }
+        finally
+        {
+            try { Directory.Delete(alCacheDir, recursive: true); } catch { }
+        }
+    }
+
+    /// <summary>
+    /// Negative control: the two lines issue #2239 deliberately kept visible at default
+    /// verbosity — see #2077/#2210's reasoning on why "which BC version ran" is a result,
+    /// not a diagnostic — must not have been swept away along with the bookkeeping.
+    /// </summary>
+    [SkippableFact]
+    public void DefaultRun_StillPrintsSelectedVersionAndRunningBanner()
+    {
+        TestArtifacts.SkipIfMissing();
+        var alCacheDir = NewCacheDir();
+        try
+        {
+            var (output, exit) = Run(alCacheDir);
+            Assert.True(exit == 0 && output.Contains("pass:        1"),
+                $"fixture must compile and pass cleanly:\n{output}");
+
+            Assert.Contains("[bc] selected BC ", output);
+            Assert.Contains("al-runner — running ", output);
+        }
+        finally
+        {
+            try { Directory.Delete(alCacheDir, recursive: true); } catch { }
+        }
+    }
+
+    /// <summary>
+    /// Structural half for the two lines a live spawn in this build can never reach
+    /// (see the file header): both the engine-variant-selection reasoning line and its
+    /// matching re-exec explanation in Program.cs must sit behind an
+    /// `if (AlRunner.Log.Verbose)` guard within a short lookback window, the same
+    /// technique ExplicitEngineMinorWarningGatingTests and
+    /// ReexecExplanationVisibilityTests already use in this suite for the identical
+    /// "prove the call site, not just that a correct condition exists unused" reason.
+    /// </summary>
+    [Fact]
+    public void ProgramCs_EngineVariantAndReexecLines_GatedOnVerbose()
+    {
+        var src = File.ReadAllText(Path.Combine(RepoRoot, "AlRunner", "Program.cs"));
+
+        AssertGuardedByLogVerbose(src, "[bc] selecting engine variant {variant.BuildVersion}");
+        AssertGuardedByLogVerbose(src, "? \"[reexec] Re-execing into a shadow runtime dir");
+    }
+
+    private static void AssertGuardedByLogVerbose(string src, string marker)
+    {
+        var idx = src.IndexOf(marker, StringComparison.Ordinal);
+        Assert.True(idx >= 0, $"marker not found in Program.cs: {marker}");
+        var windowStart = Math.Max(0, idx - 300);
+        var window = src[windowStart..idx];
+        Assert.Contains("AlRunner.Log.Verbose", window);
+    }
+}

--- a/AlRunner.Tests/CollectionCostOrderer.cs
+++ b/AlRunner.Tests/CollectionCostOrderer.cs
@@ -147,6 +147,15 @@ public sealed class CollectionCostOrderer : ITestCollectionOrderer
             // already near enough to the 60s freshness threshold that a rounded-down low
             // value would satisfy the gate while leaving the tail in place.
             ["LayeredSourceChainTests"] = 90,
+            // #2239: 6 tests, several spawning 2 real runner subprocesses each (a cold +
+            // warm pair, for the HIT/MISS gating proof) against RecordTriggerXRec — each
+            // spawn pays a full cold AL emit+compile. Absent from this table on its first
+            // CI run, fell back to UnmeasuredWeightSeconds and became the critical-path
+            // tail on every one of the eight legs (measured 126.5s-155.3s, always
+            // dispatched past t=598s of a ~700-900s run). Carries the observed maximum,
+            // for the same reason StartupOutputReexecDedupTests/LayeredSourceChainTests
+            // above do.
+            ["CleanRunStartupVerbosityTests"] = 155,
             ["TestFilterFlagTests"] = 99,
             ["PhaseLogIntegrationTests"] = 85,
             // #1922: 6 tests, each spawning a real runner subprocess against an AL fixture

--- a/AlRunner.Tests/PackageCacheFinalSearchSetTests.cs
+++ b/AlRunner.Tests/PackageCacheFinalSearchSetTests.cs
@@ -145,6 +145,10 @@ public sealed class PackageCacheFinalSearchSetTests
         // "package caches (requested): 0 dir(s)" precondition
         // SourceDepSymbolsWithoutPackageCacheTests relies on.
         args.Append($" --package-cache \"{absentPackageCache}\"");
+        // Issue #2239: both "package caches" lines this class asserts on moved behind
+        // --verbose (diagnostic detail, not a test result) — pass it explicitly so this
+        // test still observes what it is actually testing.
+        args.Append(" --verbose");
         var psi = new ProcessStartInfo
         {
             FileName = "dotnet",

--- a/AlRunner.Tests/PrecompileNclShadowHopTests.cs
+++ b/AlRunner.Tests/PrecompileNclShadowHopTests.cs
@@ -137,9 +137,17 @@ public sealed class PrecompileNclShadowHopTests
             CreateNoWindow = true,
             WorkingDirectory = RepoRoot,
         };
-        // Default verbosity: `[reexec]` survives Log's default filter (#2038), and what a
-        // real user sees is exactly what this asserts on.
-        psi.Environment.Remove("AL_RUNNER_VERBOSE");
+        // Issue #2239 reversed part of #2038's decision: `[reexec]` no longer survives
+        // Log's default filter unconditionally — a clean run does not need its own
+        // process topology to read its results, so it now requires --verbose. This
+        // class is specifically about the re-exec hop (whether it fires, exactly once,
+        // idempotently), which is exactly the detail --verbose exists to surface. Set
+        // via the AL_RUNNER_VERBOSE env var, not a `--verbose` CLI arg: `--precompile`
+        // dispatches through RunPrecompile's own minimal sub-arg parser (`--out` and
+        // `--package-cache` only, everything else silently ignored) rather than the
+        // main flag parser that recognises `--verbose`, so passing it on the command
+        // line here would do nothing.
+        psi.Environment["AL_RUNNER_VERBOSE"] = "1";
         psi.Environment.Remove("AL_RUNNER_NCL_SHADOW_DONE");
         psi.Environment.Remove("AL_RUNNER_REEXECED");
 

--- a/AlRunner.Tests/SourceDepCacheEnumMetadataTests.cs
+++ b/AlRunner.Tests/SourceDepCacheEnumMetadataTests.cs
@@ -74,6 +74,9 @@ public class SourceDepCacheEnumMetadataTests
         // the bundle emitted zero sources. Green locally, red on all 8 BC legs. Pinning
         // it means the harder configuration is the one that is always tested.
         args.Append($" --package-cache \"{absentPackageCache}\"");
+        // Issue #2239: "package caches (requested): N dir(s)" moved behind --verbose —
+        // this class pins that exact line, so it needs the flag to observe it.
+        args.Append(" --verbose");
         var psi = new ProcessStartInfo
         {
             FileName = "dotnet", Arguments = args.ToString(),

--- a/AlRunner.Tests/StartupOutputReexecDedupTests.cs
+++ b/AlRunner.Tests/StartupOutputReexecDedupTests.cs
@@ -24,9 +24,12 @@
 // and flushed only once a generation clears EVERY re-exec decision point in the
 // function — a generation that re-execs further never reaches the flush and its queue is
 // simply discarded, so this now generalizes to however many generations stack, not just
-// the one #2041 anticipated. The `[reexec]` explanation itself (#2034/#2038) is
-// untouched: it still prints unconditionally from whichever generation decides to hand
-// off, at default verbosity.
+// the one #2041 anticipated. The `[reexec]` explanation itself (#2034/#2038) is a
+// SEPARATE print entirely, from whichever generation decides to hand off — untouched by
+// the dedup mechanism this file is about, though issue #2239 later moved both it and the
+// `[provision] BC ... already complete` line behind --verbose (a clean run's default
+// output does not need its own process topology to read its test results). This file's
+// helper spawns pass --verbose accordingly — see BuildPsiCore's own comment.
 //
 // Issue #2061 — shared mutable state between this class's tests, round 2
 // -------------------------------------------------------------------------------------
@@ -90,9 +93,12 @@ public sealed class StartupOutputReexecDedupTests
     /// shape of the issue's own repro, "two execve calls") against an explicit
     /// --bc-version prints the provisioning line, the `[bc] selected BC` line and the
     /// banner exactly once each, and the `[reexec]` explanation still fires from the
-    /// parent — all at DEFAULT verbosity (no AL_RUNNER_VERBOSE), since #2038 already
-    /// made `[provision]`/`[bc]`/`[reexec]` survive the default-verbosity filter and
-    /// this is what a real user actually sees.
+    /// parent — under --verbose (see BuildPsiCore's comment: issue #2239 moved
+    /// `[provision]`/`[reexec]` behind --verbose, reversing part of #2038's decision —
+    /// a clean run's default output no longer needs its own process topology to read
+    /// its test results). `[bc] selected BC` and the banner stay visible at default
+    /// verbosity too either way, so this class's blanket --verbose does not mask a
+    /// regression in either of those two.
     ///
     /// Unlike its two siblings below, this test does not need Ncl.dll's presence/absence
     /// pinned to a specific value — either a genuine re-exec (trio suppressed once,
@@ -561,10 +567,12 @@ public sealed class StartupOutputReexecDedupTests
         SpawnAssembly(Path.Combine(
             ProjectPath, "bin", TestBuildConfig.Configuration, TestBuildConfig.Framework, "al-runner.dll"));
 
-    /// <summary>Same spawn as <see cref="SpawnAssembly"/>, but AL_RUNNER_VERBOSE=1 so the
-    /// `[Cecil]`-tagged shadow-dir marker line (suppressed by default — see Log.cs) is
-    /// observable, purely for path discovery. Not used for any of the count assertions,
-    /// which must stay at default verbosity to prove what a real user actually sees.
+    /// <summary>Same spawn as <see cref="SpawnAssembly"/> — BuildPsiCore already sets
+    /// AL_RUNNER_VERBOSE=1 (see its own comment, issue #2239), so the `[Cecil]`-tagged
+    /// shadow-dir marker line this method exists to read (suppressed by default — see
+    /// Log.cs) is already observable via <see cref="BuildPsi"/> alone. Kept as a distinct
+    /// name/call site purely for path-discovery readability, not because it still adds
+    /// anything BuildPsi doesn't.
     /// </summary>
     private (string Output, int Exit) SpawnVerboseAssembly(string dllPath)
     {
@@ -599,10 +607,16 @@ public sealed class StartupOutputReexecDedupTests
             CreateNoWindow = true,
             WorkingDirectory = RepoRoot,
         };
-        // Deliberately default verbosity — no AL_RUNNER_VERBOSE — this test is about
-        // what a real user sees by default, and #2038 already made every line asserted
-        // on here (`[provision]`, `[bc]`, `[reexec]`) survive that filter.
-        psi.Environment.Remove("AL_RUNNER_VERBOSE");
+        // Issue #2239 reversed part of #2038's decision: `[provision]` (the steady-state
+        // "already complete" line) and `[reexec]` are no longer printed unconditionally —
+        // a clean run does not need its own process topology to read its test results,
+        // so they now require --verbose. This class's tests are specifically about that
+        // re-exec/provisioning plumbing (dedup across process generations), which is
+        // exactly the detail --verbose exists to surface, so AL_RUNNER_VERBOSE=1 here
+        // rather than removed. `[bc] selected BC ...` and the `al-runner — running ...`
+        // banner (also asserted on below) are unaffected either way — #2239 kept them
+        // visible at default verbosity too, as the one line naming which BC version ran.
+        psi.Environment["AL_RUNNER_VERBOSE"] = "1";
         psi.Environment.Remove("AL_RUNNER_NCL_SHADOW_DONE");
         psi.Environment.Remove("AL_RUNNER_REEXECED");
         return psi;

--- a/AlRunner/Infrastructure/AssemblyTypeIndex.cs
+++ b/AlRunner/Infrastructure/AssemblyTypeIndex.cs
@@ -102,18 +102,34 @@ internal sealed class AssemblyTypeIndex
                 // Not a silent default: the fallback below is the pre-existing, correct
                 // path, and the reason it was taken is on the record (bracket-tagged, so
                 // visible under --verbose / AL_RUNNER_VERBOSE=1).
-                Console.Error.WriteLine(
-                    $"[type-index] metadata unreadable for {asm.GetName().Name}: " +
-                    $"{ex.GetType().Name}: {ex.Message} — falling back to Assembly.GetTypes()");
+                //
+                // Issue #2239: this comment already claimed the `[type-index]` tag was
+                // suppressed by default and only surfaced under --verbose, but Log.cs's
+                // ComponentTag regex only matches letters/digits (`[A-Za-z0-9._+]`) — the
+                // hyphen in `type-index` never matched it, so the tag fell through the
+                // pattern entirely and printed unconditionally on every run, not only
+                // under --verbose. Explicit gate below now makes the comment's original
+                // intent actually true, without touching Log's allowlist regex (see
+                // .claude/rules/loud-failures.md and issue #2221's own trap about that
+                // regex hiding fixes rather than reviving them). The same hyphenated-tag
+                // shape recurs across ~30 other tags in this codebase (bc-floor,
+                // hook-audit, source-dep, ...) — out of scope here, filed separately.
+                if (AlRunner.Log.Verbose)
+                    Console.Error.WriteLine(
+                        $"[type-index] metadata unreadable for {asm.GetName().Name}: " +
+                        $"{ex.GetType().Name}: {ex.Message} — falling back to Assembly.GetTypes()");
                 _mr = null;
                 _byName = null;
             }
         }
         else
         {
-            Console.Error.WriteLine(
-                $"[type-index] no raw metadata for {asm.GetName().Name} " +
-                "(dynamic assembly?) — falling back to Assembly.GetTypes()");
+            // Issue #2239: see the comment on the sibling catch block above — this line
+            // has the same hyphenated-tag gap and now gets the same explicit gate.
+            if (AlRunner.Log.Verbose)
+                Console.Error.WriteLine(
+                    $"[type-index] no raw metadata for {asm.GetName().Name} " +
+                    "(dynamic assembly?) — falling back to Assembly.GetTypes()");
         }
 
         try { _fallbackTypes = asm.GetTypes(); }

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -852,9 +852,15 @@ if (bcVersionArg == null && artifactPathArg == null)
             // if/else branch over. Staying immediate accepts the same "duplicates 3x on
             // a stacked re-exec" cost the no-variants-shipped switch's KNOWN-DEGRADED
             // branches also still pay, for the same reason.
-            Console.Error.WriteLine($"[bc] no --bc-version given — selecting BC {bcVersionArg}, the latest " +
-                $"cached artifact ({shippedVariantsForDefault.Count} engine variant(s) shipped; the matching " +
-                $"one is selected automatically below). Override with --bc-version.");
+            //
+            // Issue #2239: this is the "which artifact was selected and why" reasoning a
+            // clean run does not need to see — the outcome is already named once, later,
+            // by the unconditional `[bc] selected BC ...` line. Gated on --verbose like
+            // its siblings below rather than printed unconditionally.
+            if (AlRunner.Log.Verbose)
+                Console.Error.WriteLine($"[bc] no --bc-version given — selecting BC {bcVersionArg}, the latest " +
+                    $"cached artifact ({shippedVariantsForDefault.Count} engine variant(s) shipped; the matching " +
+                    $"one is selected automatically below). Override with --bc-version.");
         }
         catch (InvalidOperationException)
         {
@@ -862,8 +868,14 @@ if (bcVersionArg == null && artifactPathArg == null)
             // throws the loud, path-naming "no artifacts" error users already see today.
         }
 
+        // Issue #2239: same shape as #2210's DescribeCrossMajorNote gate a few dozen
+        // lines below (the no-variants-shipped half of this if/else) — a project
+        // declaring an older major floor than what got selected is the expected case
+        // (application/platform are minima, not pins), not a risk this branch's
+        // sibling warning below is exempt from just because it lives in a different
+        // half of the if/else. Gated the same way for the same reason.
         var projMajorV = TryDeriveBcMajorFromProject(bundles);
-        if (projMajorV != null && bcVersionArg != null
+        if (AlRunner.Log.Verbose && projMajorV != null && bcVersionArg != null
             && Version.TryParse(bcVersionArg, out var selV) && selV.Major.ToString() != projMajorV)
             Console.Error.WriteLine($"[bc] warning: project app.json targets BC major {projMajorV} but the " +
                 $"latest cached artifact is {bcVersionArg} (major {selV.Major}).");
@@ -954,9 +966,17 @@ if (bcVersionArg == null && artifactPathArg == null)
             switch (tier)
             {
                 case "cached-exact":
-                    deferredStartupLines.Add(() => Console.Error.WriteLine(
-                        $"[bc] no --bc-version given — selecting BC {engineVersion}, the exact " +
-                        $"build this binary was compiled against. Override with --bc-version."));
+                    // Issue #2239: normal-path reasoning, no risk — the outcome is
+                    // already named once, unconditionally, by the `[bc] selected BC
+                    // ...` line further down. Gated behind --verbose like its sibling
+                    // above (the shipped-variants branch's own auto-select line).
+                    deferredStartupLines.Add(() =>
+                    {
+                        if (AlRunner.Log.Verbose)
+                            Console.Error.WriteLine(
+                                $"[bc] no --bc-version given — selecting BC {engineVersion}, the exact " +
+                                $"build this binary was compiled against. Override with --bc-version.");
+                    });
                     break;
                 case "cdn-exact":
                     Console.Error.WriteLine($"[bc] no --bc-version given — provisioning BC {engineVersion}, the exact " +
@@ -1159,9 +1179,15 @@ string? variantSwapDir = null;
         if (runningBuild != variant.BuildVersion)
         {
             variantSwapDir = variant.Dir;
-            Console.Error.WriteLine(
-                $"[bc] selecting engine variant {variant.BuildVersion} for BC {selected} (this process is " +
-                $"currently running the {(runningBuild?.ToString() ?? "unknown")} variant) — re-execing.");
+            // Issue #2239: engine-variant selection mechanics — a diagnostic, not the
+            // result. The `[reexec] Re-execing into a shadow runtime dir with the
+            // matching BC-minor engine variant` line right after this decision already
+            // explains that a hand-off is happening; this line is the WHY, gated the
+            // same way.
+            if (AlRunner.Log.Verbose)
+                Console.Error.WriteLine(
+                    $"[bc] selecting engine variant {variant.BuildVersion} for BC {selected} (this process is " +
+                    $"currently running the {(runningBuild?.ToString() ?? "unknown")} variant) — re-execing.");
         }
     }
 }
@@ -1250,7 +1276,10 @@ deferredStartupLines.Add(() => Console.WriteLine(serverMode
         // #2034 audit: this is the SAME class of silently-swallowed re-exec explanation
         // (a fresh Cecil IL rewrite forces one more relaunch so the child loads the
         // now-cached bytes cleanly) — also retagged so it survives the default filter.
-        Console.Error.WriteLine("[reexec] Fresh rewrite done — re-execing for a clean Ncl load");
+        // #2239: gated behind --verbose, same as the other re-exec notices — see
+        // TryShadowReexec's own comment for why.
+        if (AlRunner.Log.Verbose)
+            Console.Error.WriteLine("[reexec] Fresh rewrite done — re-execing for a clean Ncl load");
         // This process waits for the child below, so its wall clock CONTAINS the
         // child's entire run. Re-label the row so aggregates that sum `kind=="process"`
         // do not double-count it.
@@ -1281,8 +1310,12 @@ var packageCacheDirs = packageCacheArgs.Count > 0
 // line (the provisioning block between it and the final count can print a multi-minute
 // download) could reasonably conclude nothing was searched — exactly backwards from
 // what #2067 needed. SourceDepSymbolsWithoutPackageCacheTests/SourceDepCacheEnumMetadataTests
-// pin this exact label + count as a precondition on the explicit-arg branch.
-Console.WriteLine($"  package caches (requested): {packageCacheDirs.Count} dir(s)");
+// pin this exact label + count as a precondition on the explicit-arg branch (both now
+// pass --verbose to see it).
+// Issue #2239: package-cache directory counts are diagnostic detail, not a result —
+// gated behind --verbose like the rest of this file's startup bookkeeping.
+if (AlRunner.Log.Verbose)
+    Console.WriteLine($"  package caches (requested): {packageCacheDirs.Count} dir(s)");
 AlRunner.Infrastructure.PhaseLog.SetBundles(bundles);
 
 // Issue #1678: the platform-app R2R gate below used to scan ONLY packageCacheDirs
@@ -1562,7 +1595,9 @@ if (!provisionSubcommand)
 // dependency resolution (PlatformCheckDirs, DependencyResolver's resolverDirs) actually
 // searches — the "(requested)" line above is scoped to before these folds by its label.
 AlRunner.Infrastructure.PhaseLog.SetPackageCacheDirs(packageCacheDirs.Count);
-Console.WriteLine($"  package caches (final search set): {packageCacheDirs.Count} dir(s)");
+// Issue #2239: same as the "(requested)" line above — gated behind --verbose.
+if (AlRunner.Log.Verbose)
+    Console.WriteLine($"  package caches (final search set): {packageCacheDirs.Count} dir(s)");
 // --verbose: name the directories themselves, not just the count. The count alone was
 // exactly what made #2067 hard to read — "0" on a machine that went on to search several
 // dirs — so the natural companion to the --verbose "[dep] Publisher/Name" line below (which
@@ -1612,7 +1647,9 @@ if (Environment.GetEnvironmentVariable("AL_RUNNER_DIAG_FCE") is "1" or "2")
 }
 var t0 = System.Diagnostics.Stopwatch.StartNew();
 BcRuntime.EnsureApplied();
-Console.WriteLine($"BC runtime patches applied ({t0.ElapsedMilliseconds}ms)");
+// Issue #2239: patch-apply timing is diagnostic, not a result — gated behind --verbose.
+if (AlRunner.Log.Verbose)
+    Console.WriteLine($"BC runtime patches applied ({t0.ElapsedMilliseconds}ms)");
 AlRunner.Infrastructure.PhaseLog.SetPatchesMs(t0.ElapsedMilliseconds);
 AlRunner.PerfTrace.Log($"BcRuntime.EnsureApplied {t0.ElapsedMilliseconds}ms");
 
@@ -1948,7 +1985,10 @@ foreach (var bundle in bundles)
                 using (AlRunner.Infrastructure.PhaseLog.Stage("dep-resolve"))
                     ordered = resolver.Resolve(roots);
                 bundleResolvedDeps = ordered;
-                Console.WriteLine($"  [{rel}] resolved {ordered.Count} dep(s)");
+                // Issue #2239: per-bundle dep counts are diagnostic detail — gated behind
+                // --verbose.
+                if (AlRunner.Log.Verbose)
+                    Console.WriteLine($"  [{rel}] resolved {ordered.Count} dep(s)");
                 AlRunner.Infrastructure.PhaseLog.NoteDepsResolved(ordered.Count);
                 // Under --verbose, name the package that actually WON for each
                 // dependency, with the file it came from. Resolution picks by highest
@@ -2008,7 +2048,9 @@ foreach (var bundle in bundles)
                 // as `dep-load:<Name>` (see DependencyLoader.LoadAll). Wrapping it here too
                 // would nest, and nested stages double-count — see PhaseLog.Stage.
                 var loaded = depLoader.LoadAll(ordered, depRootDir);
-                Console.WriteLine($"  [{rel}] loaded {loaded.Count} dep assembl(ies)");
+                // Issue #2239: same as "resolved N dep(s)" above — gated behind --verbose.
+                if (AlRunner.Log.Verbose)
+                    Console.WriteLine($"  [{rel}] loaded {loaded.Count} dep assembl(ies)");
                 AlRunner.Infrastructure.PhaseLog.NoteDepAssembliesLoaded(loaded.Count);
                 // Register dep assemblies (dependency order) so their Subtype=Install
                 // codeunit lifecycle triggers fire before this bundle's tests run.
@@ -2397,7 +2439,10 @@ foreach (var bundle in bundles)
             }
             if (cachedBytes != null)
             {
-                Console.Error.WriteLine($"  [cache] HIT  key={cacheKey} path={cachePath} ({cachedBytes.Length} bytes, {replayed} enum entries replayed) — skipping Emit+Compile");
+                // Issue #2239: cache HIT/MISS classification is diagnostic detail, not a
+                // result — gated behind --verbose.
+                if (AlRunner.Log.Verbose)
+                    Console.Error.WriteLine($"  [cache] HIT  key={cacheKey} path={cachePath} ({cachedBytes.Length} bytes, {replayed} enum entries replayed) — skipping Emit+Compile");
                 AlRunner.Infrastructure.PhaseLog.NoteCacheHit();
                 assemblyBytes = cachedBytes;
             }
@@ -2406,7 +2451,8 @@ foreach (var bundle in bundles)
         {
             if (alCacheDir != null)
             {
-                Console.Error.WriteLine($"  [cache] MISS key={cacheKey} — running Emit+Compile");
+                if (AlRunner.Log.Verbose)
+                    Console.Error.WriteLine($"  [cache] MISS key={cacheKey} — running Emit+Compile");
                 AlRunner.Infrastructure.PhaseLog.NoteCacheMiss();
             }
             var et = System.Diagnostics.Stopwatch.StartNew();
@@ -2798,7 +2844,13 @@ foreach (var bundle in bundles)
                                     querySidecarPath!, tmp => File.Copy(qsrc, tmp, overwrite: true));
                             AlRunner.Infrastructure.AlCacheWriter.AtomicPublish(
                                 cachePath, tmp => File.WriteAllBytes(tmp, assemblyBytes));
-                            Console.Error.WriteLine($"  [cache] WROTE key={cacheKey} path={cachePath} ({assemblyBytes.Length} bytes, {written} enum entries → sidecar)");
+                            // Issue #2239: same category as [cache] HIT/MISS above — cache
+                            // population detail, not a result. Observed printing
+                            // unconditionally on every cold run while verifying that fix
+                            // (a clean run wrote this line even with HIT/MISS gated), the
+                            // same sibling-defect shape — gated the same way.
+                            if (AlRunner.Log.Verbose)
+                                Console.Error.WriteLine($"  [cache] WROTE key={cacheKey} path={cachePath} ({assemblyBytes.Length} bytes, {written} enum entries → sidecar)");
                         }
                         catch (Exception ex)
                         {
@@ -6778,14 +6830,21 @@ static int? TryShadowReexec(string? variantSwapDir)
     foreach (var a in argv.Skip(1)) psi.ArgumentList.Add(a);
     psi.Environment["AL_RUNNER_NCL_SHADOW_DONE"] = "1";
 
-    Console.Error.WriteLine(variantSwapDir != null
-        // #2034: this line explains why a second process is about to launch — a
-        // genuinely operational fact, not an internal Cecil-rewrite diagnostic — so it
-        // uses the exempted `[reexec]` tag rather than `[Cecil]`. Under `[Cecil]`, Log's
-        // filter suppressed a real, live re-exec silently: the shadow dir was built, the
-        // child launched, and nothing on stderr said why.
-        ? "[reexec] Re-execing into a shadow runtime dir with the matching BC-minor engine variant"
-        : "[reexec] Ncl.dll not shipped in this install — re-execing into a shadow runtime dir that has it");
+    // #2034: this line explains why a second process is about to launch — a
+    // genuinely operational fact, not an internal Cecil-rewrite diagnostic — so it
+    // uses the exempted `[reexec]` tag rather than `[Cecil]`. Under `[Cecil]`, Log's
+    // filter suppressed a real, live re-exec silently: the shadow dir was built, the
+    // child launched, and nothing on stderr said why.
+    //
+    // #2239: that reasoning still holds for someone debugging a re-exec — hence
+    // `[reexec]`, not a plain internal tag, so --verbose still surfaces it — but a
+    // clean run does not need to know its own process topology to read its test
+    // results, so this is now gated behind --verbose like the rest of this file's
+    // startup bookkeeping.
+    if (AlRunner.Log.Verbose)
+        Console.Error.WriteLine(variantSwapDir != null
+            ? "[reexec] Re-execing into a shadow runtime dir with the matching BC-minor engine variant"
+            : "[reexec] Ncl.dll not shipped in this install — re-execing into a shadow runtime dir that has it");
     AlRunner.Infrastructure.PhaseLog.MarkReexecParent();
     using var shadowChild = System.Diagnostics.Process.Start(psi)!;
     shadowChild.WaitForExit();
@@ -7551,10 +7610,18 @@ static int RunProvisioning(string? bcVersionArg, string? artifactPathArg,
         var fullForPrint = full;
         var serviceTierDirForPrint = serviceTierDir;
         if (deferredLines == null)
+            // The `provision` subcommand's own report — this line IS its deliverable
+            // (there is no test run after it to summarize instead), so it always prints.
             Console.Error.WriteLine($"[provision] BC {fullForPrint} engine artifacts already complete at {serviceTierDirForPrint}.");
         else
-            deferredLines.Add(() => Console.Error.WriteLine(
-                $"[provision] BC {fullForPrint} engine artifacts already complete at {serviceTierDirForPrint}."));
+            // Issue #2239: on a normal continuing run, "nothing to provision" is
+            // startup bookkeeping, not a result — gated behind --verbose.
+            deferredLines.Add(() =>
+            {
+                if (AlRunner.Log.Verbose)
+                    Console.Error.WriteLine(
+                        $"[provision] BC {fullForPrint} engine artifacts already complete at {serviceTierDirForPrint}.");
+            });
     }
     else if (!AlRunner.Infrastructure.ProvisioningCheck.AutoProvision(full, serviceTierDir))
         return 1;


### PR DESCRIPTION
Closes #2239

## Summary

A clean run printed roughly fifteen lines of internal bookkeeping before the first test result: which BC artifact was auto-selected and why, engine-variant selection, the re-exec notice, "engine artifacts already complete", package-cache directory counts, `[type-index]`'s metadata-fallback note, patch-apply timing, per-bundle dep counts, and AL-output cache HIT/MISS/WROTE. Several printed twice, because a Cecil-fresh-rewrite or shadow-runtime re-exec re-runs the same startup sequence in a child process. None of that is a test result.

Each moved line is gated with an explicit `if (Log.Verbose)` (or `if (AlRunner.Log.Verbose)`) at its own call site in `Program.cs` / `AssemblyTypeIndex.cs` — never by editing `Log`'s `[Component]` allowlist regex. That regex was the trap named in the issue: it defaults to hiding, and five prior fixes shipped as silent no-ops by touching it (#2221). Verified per-line which mechanism actually controlled it before moving it — most of these tags (`[bc]`, `[provision]`, `[reexec]`, `[cache]`) are either explicitly exempted from the filter or don't match its regex at all, so they were printing completely unconditionally, with no existing gate to remove.

### The judgement call (`[bc] selected BC ...`)

Kept as the sole line naming which BC version ran, unconditional at default verbosity — #2077 measured a 42-test swing decided silently by version selection, and #2210 already established that reasoning survives for the *result*, just not for the four separate lines that used to explain the *selection*. Those explanation lines (`[bc] no --bc-version given — selecting BC ...`, `[bc] selecting engine variant ...`, the matching `[reexec]` notices) are now gated; the outcome is still named exactly once.

Also kept unconditional, as genuine warnings about a degraded/risky configuration (not diagnostics): the `cached-minor`/`cdn-minor`/`major-fallback` KNOWN-DEGRADED tiers, the "shipped engine variant was built against a different build" warning, and the CDN-download-starting message (`DefaultProvisionTargetMessagingTests` pins that one as the only signal a multi-minute download is underway).

### Fix the shape, not just the reported line

1. **Same call site as the reported line, different branch:** the `shippedVariantsForDefault` branch's own "project app.json targets an older BC major" warning was an unconditional duplicate of the *already--verbose-gated* `DescribeCrossMajorNote` warning in the sibling (no-variants-shipped) branch — issue #2210 established that specific message carries no measured risk and gated it there but missed this branch. Gated the same way here.
2. **A line whose own comment claimed a gate that didn't exist:** `AssemblyTypeIndex.cs`'s `[type-index]` fallback lines carried a comment saying they were "visible under --verbose" already — false. `Log.cs`'s suppression regex (`[A-Za-z][A-Za-z0-9._+]*\]`) doesn't include hyphens, so a hyphenated tag like `type-index` never matched it and printed unconditionally on every run. Fixed with an explicit gate (not by touching the regex). The same regex gap affects roughly 30 other hyphenated tags across the codebase (`bc-floor`, `hook-audit`, `source-dep`, ...) — out of scope for this fix; will file a separate runner-gap issue for that broader pattern.
3. **`[cache] WROTE`:** the issue named `[cache] HIT/MISS` explicitly; while eyeballing the fixed output I found `[cache] WROTE` (the write-side completion of the same MISS branch) still printing unconditionally on every cold run — same category, same fix.

### Before / after (real spawn, `AlRunner.Tests/Fixtures/RecordTriggerXRec`)

Before (`git stash` not used — this is the pre-fix `main` behavior, unaffected by this PR): 18 lines of bookkeeping, several duplicated, before the first result line.

After, default verbosity:
```
[expectations] loaded 5 entries from .../tests/expectations
[bc] selected BC 28.1.49838.53910 (/home/.../artifacts/28.1.49838.53910)
al-runner — running 1 bundle(s)
[1/1] AlRunner.Tests/Fixtures/RecordTriggerXRec — 1 suites
  → 1P/0F/0E across 1 tests, 0 suite errors (25.0s)

=== RecordTriggerXRec ===
PASS  Codeunit60110.Insert_OnInsertReadsXRec_BuildsConcreteBeforeImage (6ms)
...
```
All previously-hidden lines still appear under `--verbose` (verified via a real cold + warm spawn).

## Test plan

- New `AlRunner.Tests/CleanRunStartupVerbosityTests.cs`: RED→GREEN against the pre-fix binary, asserts absence of every moved-line fragment at default verbosity and presence under `--verbose` (cold-run set, plus a separate cold/warm pair for `[cache] MISS`/`HIT`), plus a negative control that `[bc] selected BC` and the run banner stay visible. A structural source check covers the two lines (`[bc] selecting engine variant ...` and its matching `[reexec]` line) that this dev/CI build can't reach live, since it ships no per-BC-minor engine variants.
- Updated `StartupOutputReexecDedupTests.cs`, `PrecompileNclShadowHopTests.cs`, `PackageCacheFinalSearchSetTests.cs`, `SourceDepCacheEnumMetadataTests.cs`, `CacheKeyDependencyClosureTests.cs`, `BcVersionDefaultDocumentationTests.cs` to pass `--verbose` (or `AL_RUNNER_VERBOSE=1` where `--precompile`'s own minimal sub-arg parser doesn't recognize `--verbose` on the command line) where they pin lines that moved.
- Ran targeted classes touching this path (StartupOutputReexecDedupTests, PrecompileNclShadowHopTests, PackageCacheFinalSearchSetTests, SourceDep*Tests, CacheKeyDependencyClosureTests, BcVersionDefaultDocumentationTests, ReexecExplanationVisibilityTests, LogUserFacingTagsTests, ExplicitEngineMinorWarningGatingTests, BundleRootValidationTests, PhaseLogIntegrationTests, AssemblyTypeIndexTests, CountryFlagTests, CleanRunStartupVerbosityTests) — all green.
- Ran the full `AlRunner.Tests` suite twice locally (no network in this sandbox): both runs were green except `ProvisionExplicitModesTests` (4 tests, `TaskCanceledException`/CDN timeouts — no outbound network here, unrelated to this diff) and one flaky `PrecompileNclShadowHopTests` failure that reproduced only under full-suite parallel load and passed cleanly in 3 separate isolated runs — consistent with load-dependent flakiness, not a deterministic regression from this change.
- Verified by eye: real spawn output before/after, both default and `--verbose`, against both a minimal fixture and a real `tests/runner-extras` bundle.

Closes #2239