### PR TITLE
Authenticode-sign the unsigned binaries in the published NuGet package

### DIFF
--- a/.github/scripts/pe_signing.py
+++ b/.github/scripts/pe_signing.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+"""Detect whether Windows PE files (.dll/.exe) carry an Authenticode signature.
+
+This is a presence check only: it reads the Certificate Table entry (data
+directory index 4, IMAGE_DIRECTORY_ENTRY_SECURITY) in the PE optional header
+and treats a nonzero Size as "signed". It does NOT validate that the
+signature is well-formed or that it chains to a trusted root -- that needs a
+real crypto stack (signtool / Get-AuthenticodeSignature on Windows,
+osslsigncode on Linux) and is deliberately out of scope here. See
+publish.yml's sign-and-pack job for the chain-of-trust check, which runs on
+the real Windows signing runner where that tooling exists.
+
+Used two ways from publish.yml (#2248):
+
+  list-unsigned <root>... [--relative-to DIR] [--exclude-dir NAME]...
+      Prints one path per unsigned PE file per line, relative to --relative-to
+      (default: cwd). Feeds azure/artifact-signing-action's files-catalog
+      input -- the signing step must sign ONLY currently-unsigned files
+      (signing over Microsoft's/a third party's existing signature would
+      replace it with ours), so this listing IS the file list the signing
+      step consumes, per the issue's design.
+
+  verify <root>...
+      Exits 1 and lists every unsigned .dll/.exe it finds under the given
+      root(s); exits 0 otherwise. This is the release-path verification gate:
+      it must find zero unsigned PE files in the packed nupkg contents.
+
+Both subcommands share the same walk: recurse into `.dll`/`.exe` files,
+skipping any path with a `ref` or `refint` directory component (MSBuild's
+compile-only reference-assembly output -- never copied into a publish/pack
+output, so flagging them as "unsigned" would be noise with no shipped
+consequence), and silently skip any file that doesn't parse as a valid PE
+(wrong DOS/PE signature, e.g. the Linux Win32Stubs `.so` files or a stray
+non-binary file with a `.dll`-like name should never occur, but this is
+defensive either way -- a non-PE file is not something Authenticode signing
+applies to).
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import struct
+import sys
+from pathlib import Path
+from typing import Iterator, Optional
+
+PE_EXTENSIONS = (".dll", ".exe")
+DEFAULT_EXCLUDE_DIRS = frozenset({"ref", "refint"})
+
+# IMAGE_DIRECTORY_ENTRY_SECURITY -- the Certificate Table. Its VirtualAddress
+# field is unusually a raw file offset (not an RVA, unlike every other data
+# directory entry), which doesn't matter for a presence check since only the
+# Size field is read here.
+_CERT_TABLE_DIRECTORY_INDEX = 4
+
+# Offset of the DataDirectory array from the start of the Optional Header,
+# for each optional-header "magic" value. PE32 standard+Windows-specific
+# fields total 96 bytes before DataDirectory; PE32+ (64-bit) drops the
+# 4-byte BaseOfData field but widens ImageBase/SizeOfStack*/SizeOfHeap* to
+# 8 bytes each, netting 112 bytes. See the PE/COFF spec (or this module's
+# test file for a byte-level derivation of both).
+_DATA_DIRECTORY_OFFSET_BY_MAGIC = {
+    0x10B: 96,   # PE32
+    0x20B: 112,  # PE32+ (64-bit)
+}
+
+
+class NotAPeFile(Exception):
+    """Raised internally when a file doesn't parse as a PE image; callers
+    of read_certificate_table_size() see this reflected as a None return,
+    not this exception directly."""
+
+
+def read_certificate_table_size(path: Path) -> Optional[int]:
+    """Return the Certificate Table directory's Size field, or None if the
+    file isn't a recognizable PE image (DOS/PE signature mismatch, missing
+    optional header, unrecognized optional-header magic, or too few data
+    directories to reach the Security entry). A return of 0 means "valid PE,
+    no Authenticode signature"; a return of None means "not something this
+    check can classify as signed or unsigned at all"."""
+    try:
+        with open(path, "rb") as f:
+            dos_header = f.read(64)
+            if len(dos_header) < 64 or dos_header[0:2] != b"MZ":
+                return None
+            (e_lfanew,) = struct.unpack_from("<I", dos_header, 0x3C)
+
+            f.seek(e_lfanew)
+            pe_sig = f.read(4)
+            if pe_sig != b"PE\x00\x00":
+                return None
+
+            coff_header = f.read(20)
+            if len(coff_header) < 20:
+                return None
+            (size_of_optional_header,) = struct.unpack_from("<H", coff_header, 16)
+            if size_of_optional_header == 0:
+                # Object files (.obj) have no optional header; not a signable image.
+                return None
+
+            optional_header = f.read(size_of_optional_header)
+            if len(optional_header) < 2:
+                return None
+            (magic,) = struct.unpack_from("<H", optional_header, 0)
+            data_dir_offset = _DATA_DIRECTORY_OFFSET_BY_MAGIC.get(magic)
+            if data_dir_offset is None:
+                return None
+
+            entry_offset = data_dir_offset + _CERT_TABLE_DIRECTORY_INDEX * 8
+            if len(optional_header) < entry_offset + 8:
+                # Fewer than 5 data directories present at all -- no room for
+                # a Security entry, so there is no certificate table.
+                return 0
+
+            _virtual_address, size = struct.unpack_from(
+                "<II", optional_header, entry_offset
+            )
+            return size
+    except OSError:
+        return None
+
+
+def is_signed(path: Path) -> Optional[bool]:
+    """True/False if path is a classifiable PE image, None if it isn't (see
+    read_certificate_table_size)."""
+    size = read_certificate_table_size(path)
+    if size is None:
+        return None
+    return size > 0
+
+
+def scan(roots: list[Path], exclude_dirs: frozenset[str] = DEFAULT_EXCLUDE_DIRS) -> Iterator[Path]:
+    """Yield every .dll/.exe file under the given root(s) (files are yielded
+    as-is if they already match), skipping any path with an excluded
+    directory component."""
+    for root in roots:
+        if root.is_file():
+            if root.suffix.lower() in PE_EXTENSIONS:
+                yield root
+            continue
+        for dirpath, dirnames, filenames in os.walk(root):
+            dirnames[:] = [d for d in dirnames if d not in exclude_dirs]
+            for name in filenames:
+                if os.path.splitext(name)[1].lower() in PE_EXTENSIONS:
+                    yield Path(dirpath) / name
+
+
+def _cmd_list_unsigned(args: argparse.Namespace) -> int:
+    exclude_dirs = DEFAULT_EXCLUDE_DIRS | set(args.exclude_dir)
+    roots = [Path(r) for r in args.roots]
+    relative_to = Path(args.relative_to).resolve()
+
+    unsigned_paths = []
+    for path in sorted(scan(roots, exclude_dirs)):
+        signed = is_signed(path)
+        if signed is False:
+            unsigned_paths.append(path)
+
+    lines = []
+    for path in unsigned_paths:
+        try:
+            rel = os.path.relpath(path.resolve(), relative_to)
+        except ValueError:
+            # Different drive on Windows -- fall back to the absolute path.
+            rel = str(path.resolve())
+        lines.append(rel)
+
+    output = "\n".join(lines)
+    if args.catalog:
+        Path(args.catalog).write_text(output + ("\n" if output else ""), encoding="utf-8")
+        print(f"Wrote {len(lines)} unsigned file path(s) to {args.catalog}", file=sys.stderr)
+    else:
+        if output:
+            print(output)
+    return 0
+
+
+def _cmd_verify(args: argparse.Namespace) -> int:
+    roots = [Path(r) for r in args.roots]
+    unsigned = []
+    total_pe = 0
+    for path in sorted(scan(roots)):
+        signed = is_signed(path)
+        if signed is None:
+            continue
+        total_pe += 1
+        if not signed:
+            unsigned.append(path)
+
+    if unsigned:
+        print(
+            f"::error::{len(unsigned)} unsigned PE file(s) found "
+            f"(out of {total_pe} .dll/.exe checked):",
+            file=sys.stderr,
+        )
+        for path in unsigned:
+            print(f"  {path}", file=sys.stderr)
+        return 1
+
+    print(f"OK: all {total_pe} .dll/.exe file(s) checked are Authenticode-signed.")
+    return 0
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_list = sub.add_parser(
+        "list-unsigned", help="list unsigned .dll/.exe files under the given root(s)"
+    )
+    p_list.add_argument("roots", nargs="+")
+    p_list.add_argument(
+        "--relative-to",
+        default=".",
+        help="print paths relative to this directory (default: cwd)",
+    )
+    p_list.add_argument(
+        "--exclude-dir",
+        action="append",
+        default=[],
+        help="additional directory name to exclude (repeatable)",
+    )
+    p_list.add_argument(
+        "--catalog",
+        default=None,
+        help="write the listing to this file instead of stdout "
+        "(azure/artifact-signing-action's files-catalog format)",
+    )
+    p_list.set_defaults(func=_cmd_list_unsigned)
+
+    p_verify = sub.add_parser(
+        "verify", help="fail if any .dll/.exe under the given root(s) is unsigned"
+    )
+    p_verify.add_argument("roots", nargs="+")
+    p_verify.set_defaults(func=_cmd_verify)
+
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/test_pe_signing.py
+++ b/.github/scripts/test_pe_signing.py
@@ -1,0 +1,248 @@
+"""
+Tests for pe_signing.py -- #2248.
+
+The byte-level tests build minimal, deterministic synthetic PE images rather
+than relying on real DLLs from the NuGet cache or the .NET SDK install: the
+whole point of these tests is pinning the *offset arithmetic* the parser uses
+to find the Certificate Table entry for both the 32-bit (PE32) and 64-bit
+(PE32+) optional-header shapes, and a hand-built fixture lets each test
+assert an exact, known byte layout instead of hoping some machine-local file
+happens to be in the right shape (NuGet-cache paths are version- and
+machine-specific and would make this test non-portable to CI).
+
+The CLI tests exercise the actual subprocess entry points (list-unsigned,
+verify) against a small directory tree, proving the argparse wiring and the
+ref/refint exclusion end to end, not just the internal functions.
+
+Run directly: python3 .github/scripts/test_pe_signing.py
+"""
+
+import importlib.util
+import os
+import struct
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+SCRIPT_PATH = os.path.join(SCRIPT_DIR, 'pe_signing.py')
+
+spec = importlib.util.spec_from_file_location('pe_signing', SCRIPT_PATH)
+pe_signing = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(pe_signing)
+
+
+def build_fake_pe(magic: int, cert_table_size: int, num_rva_and_sizes: int = 16) -> bytes:
+    """Construct a minimal, structurally valid PE image with a controllable
+    optional-header magic (0x10b = PE32, 0x20b = PE32+) and Certificate Table
+    (data directory index 4) Size field. Only the fields the parser reads are
+    populated meaningfully; everything else is zeroed.
+    """
+    assert magic in (0x10B, 0x20B)
+
+    dos_header = bytearray(64)
+    dos_header[0:2] = b"MZ"
+    e_lfanew = 64
+    struct.pack_into("<I", dos_header, 0x3C, e_lfanew)
+
+    pe_signature = b"PE\x00\x00"
+
+    # COFF header: Machine, NumberOfSections, TimeDateStamp,
+    # PointerToSymbolTable, NumberOfSymbols, SizeOfOptionalHeader, Characteristics
+    if magic == 0x10B:
+        # PE32 standard fields (28) + Windows-specific fields (68) = 96
+        # bytes before the DataDirectory array.
+        standard_fields_size = 28
+        windows_fields_size = 68
+    else:
+        # PE32+ standard fields (24, no BaseOfData) + Windows-specific
+        # fields (88, ImageBase/SizeOfStack*/SizeOfHeap* widened to 8) = 112.
+        standard_fields_size = 24
+        windows_fields_size = 88
+
+    data_directory_offset = standard_fields_size + windows_fields_size
+    data_directories_size = num_rva_and_sizes * 8
+    size_of_optional_header = data_directory_offset + data_directories_size
+
+    coff_header = struct.pack(
+        "<HHIIIHH",
+        0x8664,  # Machine (AMD64 -- arbitrary, unused by the parser)
+        1,       # NumberOfSections
+        0,       # TimeDateStamp
+        0,       # PointerToSymbolTable
+        0,       # NumberOfSymbols
+        size_of_optional_header,
+        0,       # Characteristics
+    )
+
+    optional_header = bytearray(size_of_optional_header)
+    struct.pack_into("<H", optional_header, 0, magic)
+    struct.pack_into("<I", optional_header, standard_fields_size, num_rva_and_sizes)
+
+    # NumberOfRvaAndSizes lives at the END of the Windows-specific fields,
+    # immediately before DataDirectory -- but the parser doesn't read it (it
+    # trusts size_of_optional_header instead), so leaving it zeroed above and
+    # only writing it here for documentation purposes is fine. Overwrite is
+    # a no-op duplicate write, kept for clarity that the field exists there.
+    struct.pack_into(
+        "<I",
+        optional_header,
+        data_directory_offset - 8,
+        num_rva_and_sizes,
+    )
+
+    for i in range(num_rva_and_sizes):
+        entry_offset = data_directory_offset + i * 8
+        va = 0
+        size = cert_table_size if i == pe_signing._CERT_TABLE_DIRECTORY_INDEX else 0
+        struct.pack_into("<II", optional_header, entry_offset, va, size)
+
+    return bytes(dos_header) + pe_signature + coff_header + bytes(optional_header)
+
+
+class CertificateTableSizeTests(unittest.TestCase):
+    """Byte-level offset-arithmetic tests, PE32 and PE32+ each covered with
+    both a signed and an unsigned fixture (positive/negative pair)."""
+
+    def _write(self, tmp: str, name: str, data: bytes) -> Path:
+        path = Path(tmp) / name
+        path.write_bytes(data)
+        return path
+
+    def test_pe32_unsigned_reads_zero(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self._write(tmp, "a.dll", build_fake_pe(0x10B, cert_table_size=0))
+            self.assertEqual(pe_signing.read_certificate_table_size(path), 0)
+            self.assertFalse(pe_signing.is_signed(path))
+
+    def test_pe32_signed_reads_nonzero_size(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self._write(tmp, "a.dll", build_fake_pe(0x10B, cert_table_size=4096))
+            self.assertEqual(pe_signing.read_certificate_table_size(path), 4096)
+            self.assertTrue(pe_signing.is_signed(path))
+
+    def test_pe32plus_unsigned_reads_zero(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self._write(tmp, "a.dll", build_fake_pe(0x20B, cert_table_size=0))
+            self.assertEqual(pe_signing.read_certificate_table_size(path), 0)
+            self.assertFalse(pe_signing.is_signed(path))
+
+    def test_pe32plus_signed_reads_nonzero_size(self):
+        # This is the shape every DLL this repo ships is actually built as
+        # (AnyCPU/x64 -> PE32+) -- the case that matters most in practice.
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self._write(tmp, "a.dll", build_fake_pe(0x20B, cert_table_size=10504))
+            self.assertEqual(pe_signing.read_certificate_table_size(path), 10504)
+            self.assertTrue(pe_signing.is_signed(path))
+
+    def test_too_few_data_directories_is_treated_as_unsigned(self):
+        # NumberOfRvaAndSizes < 5 means there's no room for a Security entry
+        # at all -- no signature is possible, so this is "unsigned", not
+        # "unclassifiable".
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self._write(tmp, "a.dll", build_fake_pe(0x20B, cert_table_size=0, num_rva_and_sizes=2))
+            self.assertEqual(pe_signing.read_certificate_table_size(path), 0)
+            self.assertFalse(pe_signing.is_signed(path))
+
+    def test_non_pe_file_is_unclassifiable_not_unsigned(self):
+        # A random byte blob must never be reported as "unsigned" -- that
+        # would be a false positive in the sign/verify catalog. It must be
+        # skipped (None), distinctly from a real unsigned PE (False).
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self._write(tmp, "not-a-pe.dll", b"this is not a PE file at all, just text bytes")
+            self.assertIsNone(pe_signing.read_certificate_table_size(path))
+            self.assertIsNone(pe_signing.is_signed(path))
+
+    def test_truncated_dos_header_is_unclassifiable(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self._write(tmp, "truncated.dll", b"MZ\x00\x00")
+            self.assertIsNone(pe_signing.read_certificate_table_size(path))
+
+
+class ScanExclusionTests(unittest.TestCase):
+    """scan() must skip ref/refint directory components -- MSBuild's
+    compile-only reference-assembly output, never shipped, so flagging it
+    would just be catalog noise with no shipped consequence."""
+
+    def test_ref_and_refint_directories_are_excluded(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "bin").mkdir()
+            (root / "bin" / "app.dll").write_bytes(build_fake_pe(0x20B, 0))
+            (root / "obj" / "ref").mkdir(parents=True)
+            (root / "obj" / "ref" / "app.dll").write_bytes(build_fake_pe(0x20B, 0))
+            (root / "obj" / "refint").mkdir(parents=True)
+            (root / "obj" / "refint" / "app.dll").write_bytes(build_fake_pe(0x20B, 0))
+
+            found = {str(p.relative_to(root)) for p in pe_signing.scan([root])}
+            self.assertEqual(found, {os.path.join("bin", "app.dll")})
+
+
+class ListUnsignedCliTests(unittest.TestCase):
+    """End-to-end subprocess tests against the actual CLI entry point."""
+
+    def _make_tree(self, root: Path):
+        (root / "signed.dll").write_bytes(build_fake_pe(0x20B, cert_table_size=12345))
+        (root / "unsigned.dll").write_bytes(build_fake_pe(0x20B, cert_table_size=0))
+        (root / "not-a-pe.dll").write_bytes(b"plain text, not a PE image")
+        (root / "obj" / "ref").mkdir(parents=True)
+        (root / "obj" / "ref" / "unsigned-ref.dll").write_bytes(build_fake_pe(0x20B, cert_table_size=0))
+
+    def test_list_unsigned_reports_only_the_real_unsigned_pe(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self._make_tree(root)
+
+            result = subprocess.run(
+                [sys.executable, SCRIPT_PATH, "list-unsigned", str(root), "--relative-to", str(root)],
+                capture_output=True, text=True, check=True,
+            )
+            lines = [l for l in result.stdout.splitlines() if l.strip()]
+            self.assertEqual(lines, ["unsigned.dll"])
+
+    def test_list_unsigned_writes_catalog_file(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self._make_tree(root)
+            catalog = root / "catalog.txt"
+
+            subprocess.run(
+                [sys.executable, SCRIPT_PATH, "list-unsigned", str(root),
+                 "--relative-to", str(root), "--catalog", str(catalog)],
+                capture_output=True, text=True, check=True,
+            )
+            self.assertEqual(catalog.read_text().strip(), "unsigned.dll")
+
+    def test_verify_fails_when_unsigned_pe_present(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self._make_tree(root)
+
+            result = subprocess.run(
+                [sys.executable, SCRIPT_PATH, "verify", str(root)],
+                capture_output=True, text=True,
+            )
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("unsigned.dll", result.stderr)
+            # The non-PE file and the ref/ file must not be blamed.
+            self.assertNotIn("not-a-pe.dll", result.stderr)
+            self.assertNotIn("unsigned-ref.dll", result.stderr)
+
+    def test_verify_passes_when_everything_signed(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "signed-a.dll").write_bytes(build_fake_pe(0x20B, cert_table_size=999))
+            (root / "signed-b.exe").write_bytes(build_fake_pe(0x10B, cert_table_size=1))
+
+            result = subprocess.run(
+                [sys.executable, SCRIPT_PATH, "verify", str(root)],
+                capture_output=True, text=True,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("OK", result.stdout)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -137,6 +137,35 @@ jobs:
           git config --global user.name "Test"
           python3 .github/scripts/test_generate_changelog.py
 
+  pe-signing-tests:
+    name: PE Authenticode detection tests
+    runs-on: ubuntu-latest
+    # Gated inside the job (see "Check whether..." below) on whether the PE
+    # signing detector or its tests changed -- see publish.yml's
+    # sign-and-pack job (#2248), which consumes this script to build the
+    # signing catalog and to gate the release on every shipped PE being
+    # Authenticode-signed.
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Check whether pe_signing.py or its tests changed
+        id: changed
+        run: |
+          BASE=${{ github.event.pull_request.base.sha }}
+          HEAD=${{ github.event.pull_request.head.sha }}
+          CHANGED=$(git diff --name-only "$BASE"..."$HEAD")
+          if echo "$CHANGED" | grep -qE '^\.github/scripts/(pe_signing\.py|test_pe_signing\.py)$'; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run pe_signing.py tests
+        if: steps.changed.outputs.run == 'true'
+        run: python3 .github/scripts/test_pe_signing.py
+
   reject-ci-skip-directives:
     name: PR title/body must not contain a CI-skip directive
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -290,11 +290,25 @@ jobs:
         # given version, so the ContentHash an end user's run computes from it is stable.
         # Commit-embedding only invalidates caches when the SAME code is rebuilt
         # commit-to-commit — the dev/CI/test-matrix path, never the release path.
+        #
+        # -p:UseAppHost=false: PackAsTool's "any" (portable) moniker never ships a native
+        # apphost anyway — confirmed empirically (tools/net8.0/any/ in a packed nupkg has no
+        # apphost file; `dotnet tool install --global` generates its own launcher from the
+        # SDK's own apphost template at install time, per the issue's own "what this workflow
+        # cannot claim" note). Skipping it here also sidesteps a real cross-platform break:
+        # this job's Linux apphost (ELF, extensionless "al-runner") isn't the Windows-named
+        # "apphost.exe" the sign-and-pack job's `dotnet pack --no-build` looks for when it
+        # re-runs Publish's file-copy phase on a Windows runner (reproduced against a real dry
+        # run) — turning generation off entirely removes that mismatch instead of working
+        # around it. Unrelated to bc-tests.yml's OWN "cold-cache binary smoke test" step, which
+        # does a completely separate `dotnet build AlRunner/` with no property overrides shared
+        # with this workflow, and still gets (and needs) its own Linux apphost.
         run: |
           dotnet publish AlRunner/ -c Release \
             -p:_BCVersion=${{ needs.test.outputs.required-version }} \
             -p:AllowBcArtifactDownload=true -p:Version=${{ inputs.version }} \
-            -p:SuppressImplicitGitSourceLink=false -p:IncludeSourceRevisionInInformationalVersion=true
+            -p:SuppressImplicitGitSourceLink=false -p:IncludeSourceRevisionInInformationalVersion=true \
+            -p:UseAppHost=false
 
       - name: Upload the unsigned build tree
         # The FULL obj/bin tree for all three projects, not just bin/publish/ — see
@@ -442,7 +456,7 @@ jobs:
         # release pays for a BC service-tier download on the Windows runner too, in addition to
         # the one the build job already did on Linux -- accepted cost, not optimized further
         # here.
-        run: dotnet pack AlRunner/ --no-build -c Release -p:_BCVersion=${{ needs.test.outputs.required-version }} -p:AllowBcArtifactDownload=true -p:Version=${{ inputs.version }} -p:SuppressImplicitGitSourceLink=false -p:IncludeSourceRevisionInInformationalVersion=true -p:EngineVariantsStagingDir="${{ github.workspace }}\variants-staging" -o nupkg
+        run: dotnet pack AlRunner/ --no-build -c Release -p:_BCVersion=${{ needs.test.outputs.required-version }} -p:AllowBcArtifactDownload=true -p:Version=${{ inputs.version }} -p:SuppressImplicitGitSourceLink=false -p:IncludeSourceRevisionInInformationalVersion=true -p:UseAppHost=false -p:EngineVariantsStagingDir="${{ github.workspace }}\variants-staging" -o nupkg
 
       - name: Verify every PE in the packed nupkg is signed (pre-upload sanity)
         shell: pwsh

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -373,6 +373,28 @@ jobs:
           }
           "count=$count" >> $env:GITHUB_OUTPUT
 
+      - name: Fetch a federated OIDC token for Azure AD token exchange
+        # azure/artifact-signing-action passes azure-tenant-id/azure-client-id straight into
+        # Azure.Identity's WorkloadIdentityCredentialOptions, but that credential ALSO needs
+        # AZURE_FEDERATED_TOKEN_FILE -- a file holding a GitHub Actions OIDC token requested
+        # with audience api://AzureADTokenExchange (Azure AD's federated-credential audience) --
+        # and nothing populates that file on its own. Fetching it here with the officially
+        # supported actions/core API (core.getIDToken, which is what `permissions: id-token:
+        # write` on this job authorizes) is what makes the federated-credential subject
+        # (repo:StefanMaron/BusinessCentral.AL.Runner:environment:release) resolvable without a
+        # client secret anywhere in this job. Confirmed by reproduction: omitting this step
+        # fails with "WorkloadIdentityCredential authentication unavailable. The workload
+        # options are not fully configured."
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+            const token = await core.getIDToken('api://AzureADTokenExchange');
+            const tokenPath = path.join(process.env.RUNNER_TEMP, 'azure-federated-token.txt');
+            fs.writeFileSync(tokenPath, token);
+            core.exportVariable('AZURE_FEDERATED_TOKEN_FILE', tokenPath);
+
       - name: Sign unsigned PE files with Azure Artifact Signing (#2248)
         uses: azure/artifact-signing-action@v2
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -324,7 +324,10 @@ jobs:
     # anywhere in this job; `permissions: id-token: write` plus
     # `exclude-workload-identity-credential: false` on the signing step is the
     # entire authentication story.
-    needs: [plan, build]
+    # Also needs `test` directly (not just transitively through `build`) to read
+    # needs.test.outputs.required-version for the pack step below — a job can only read
+    # another job's outputs if it's a direct entry in its own `needs:` list.
+    needs: [plan, build, test]
     runs-on: windows-latest
     environment: release
     permissions:
@@ -426,7 +429,20 @@ jobs:
         # either already signed in place above, or was never unsigned to begin
         # with (the 84 files this workflow must leave alone). Recompiling here
         # would throw away the signatures and produce an unsigned nupkg again.
-        run: dotnet pack AlRunner/ --no-build -c Release -p:Version=${{ inputs.version }} -p:SuppressImplicitGitSourceLink=false -p:IncludeSourceRevisionInInformationalVersion=true -p:EngineVariantsStagingDir="${{ github.workspace }}\variants-staging" -o nupkg
+        #
+        # -p:_BCVersion / -p:AllowBcArtifactDownload=true are still required here even
+        # though nothing gets recompiled: AlRunner.csproj's EnsureBCServiceTierDlls /
+        # FailIfBCServiceTierDllsMissing targets fire BeforeTargets="DispatchToInnerBuilds;
+        # ResolveAssemblyReferences", and dotnet pack's Publish-target file-list resolution
+        # reaches that BeforeTargets hook regardless of --no-build (confirmed by reproduction
+        # against a real Windows runner: omitting these two properties failed pack with "BC
+        # Service Tier DLLs not found" against AlRunner.csproj's dev-machine-fallback default
+        # version, because this job's Windows filesystem has never downloaded anything -- the
+        # build job's download lives on a different runner's disk entirely). This does mean a
+        # release pays for a BC service-tier download on the Windows runner too, in addition to
+        # the one the build job already did on Linux -- accepted cost, not optimized further
+        # here.
+        run: dotnet pack AlRunner/ --no-build -c Release -p:_BCVersion=${{ needs.test.outputs.required-version }} -p:AllowBcArtifactDownload=true -p:Version=${{ inputs.version }} -p:SuppressImplicitGitSourceLink=false -p:IncludeSourceRevisionInInformationalVersion=true -p:EngineVariantsStagingDir="${{ github.workspace }}\variants-staging" -o nupkg
 
       - name: Verify every PE in the packed nupkg is signed (pre-upload sanity)
         shell: pwsh

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -66,6 +66,47 @@ name: Publish to NuGet
 # The release job's checkout uses RELEASE_DEPLOY_KEY (a write-access deploy key) so
 # the git push to the released branch bypasses the branch ruleset ("Deploy keys" ->
 # Always allow).
+#
+# #2248: Authenticode signing split this job in three. The published package used
+# to ship 32 unsigned PE files (our own al-runner.dll/AlRunner.Provisioning.dll/
+# AlRunner.QueryJoin.dll, each shipped 9 times -- once at the package root and once
+# per BC-minor engine variant -- plus Mono.Cecil.* and Spectre.Console.dll), which
+# Windows Smart App Control blocks outright (#2244). Signing needs a Windows runner
+# (azure/artifact-signing-action only runs there) and must happen BEFORE `dotnet
+# pack` (the package embeds these files; signing after packing would mean unpacking
+# and repacking the nupkg itself). So the old single `release` job is now three:
+#
+#   build          (ubuntu-latest) -- builds every BC-minor engine variant plus the
+#                  package-root build, all UNSIGNED, and uploads the whole build
+#                  tree as an artifact.
+#   sign-and-pack  (windows-latest, environment: release) -- downloads that tree,
+#                  signs every currently-unsigned PE file in it, then runs
+#                  `dotnet pack --no-build` against the now-signed tree and
+#                  uploads the resulting nupkg.
+#   release        (ubuntu-latest) -- downloads the signed nupkg, verifies every
+#                  PE inside it is signed, then does the writes (CHANGELOG commit,
+#                  tag, NuGet push, GitHub Release) exactly as before.
+#
+# Why sign-and-pack signs MORE than the 32 files a naive reading suggests: `dotnet
+# pack --no-build` still re-runs the SDK's Publish-target file-copy phase (it is
+# NOT gated on NoBuild), which copies each assembly fresh from wherever it
+# considers the authoritative source -- AlRunner/obj/Release/net8.0/al-runner.dll
+# for the entry assembly, each ProjectReference's own bin/Release/net8.0/ for
+# AlRunner.QueryJoin.dll and AlRunner.Provisioning.dll, and every dependency's
+# resolved bin/Release/net8.0/ copy for the rest -- into bin/Release/net8.0/publish/,
+# which is what actually gets packed (verified empirically: tools/net8.0/any/*.dll
+# in the resulting nupkg is byte-identical to bin/Release/net8.0/publish/*.dll, not
+# to the outer bin/Release/net8.0/*.dll). MSBuild's copy is timestamp-skip, not
+# unconditional, so signing only the publish/ copy happened to survive in a
+# same-machine, same-session test -- but that's exactly the kind of timestamp
+# coincidence an artifact upload/download round-trip must not be trusted to
+# preserve. The robust fix is to sign every physical copy of every affected
+# assembly wherever pe_signing.py's recursive scan finds it (obj/, each project's
+# own bin/, and the root project's bin/ and bin/publish/) so the copy is a no-op
+# regardless of which source MSBuild's Publish target chooses: the bytes are
+# already signed everywhere. variants-staging/ has no such duplication (NuGet
+# packs directly from EngineVariantsStagingDir at pack time, not via a copied
+# build output), so one signed copy per variant file is sufficient there.
 on:
   workflow_dispatch:
     inputs:
@@ -141,30 +182,18 @@ jobs:
     with:
       ref: ${{ needs.plan.outputs.ref }}
 
-  release:
-    # Gated on `test`: this job holds every write this workflow performs — the
-    # CHANGELOG commit, the push to main, the tag, the NuGet push and the GitHub
-    # Release. Nothing above it touches the repository. See #1978.
-    #
-    # WITHIN this job, order matters too (#2010): build-and-pack runs FIRST, before
-    # the commit/tag push, so a build/pack failure (the failure that broke v2.4.0)
-    # leaves no write behind either. See the workflow header for the full guarantee
-    # and its one known gap (a NuGet-push failure).
+  build:
+    # Everything that produces build output, all UNSIGNED — split out of the old
+    # `release` job so signing (which needs a Windows runner) can happen between
+    # this and packing without dragging the whole build onto Windows too. See the
+    # #2248 header comment above for why: BuildWin32PrebuiltStubs (this job) needs
+    # Linux's native `cc`/cross-gcc, which a Windows runner doesn't have.
     needs: [plan, test]
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
       - uses: actions/checkout@v6
         with:
-          fetch-depth: 0
           ref: ${{ needs.plan.outputs.ref }}
-          ssh-key: ${{ secrets.RELEASE_DEPLOY_KEY }}
-
-      - name: Configure git
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - uses: actions/setup-dotnet@v5
         with:
@@ -217,56 +246,242 @@ jobs:
           echo "Staged variants:"
           ls -la ./variants-staging
 
-      - name: Build and pack
-        id: build-and-pack
+      - name: Publish the package-root build (unsigned)
+        # Replaces the old combined "Build and pack" step: packing now happens in a
+        # separate (Windows) job, AFTER signing, so this only publishes — it does not
+        # pack. `dotnet pack` internally re-publishes to bin/<config>/<tfm>/publish/
+        # and packs FROM THERE (verified empirically: tools/net8.0/any/*.dll in a
+        # packed nupkg is byte-identical to bin/Release/net8.0/publish/*.dll, not to
+        # the outer bin/Release/net8.0/*.dll), so publishing here and packing
+        # `--no-build` later against this exact output is equivalent to the old
+        # single build+pack, just with a signing step in between.
+        #
+        # #2010: _BCVersion is passed explicitly here rather than left at
+        # AlRunner.csproj's default. The default is a static pin that Microsoft can
+        # (and did — the v2.4.0 release) withdraw between when it was last bumped
+        # and when a release runs, and nothing exercised that exact value except a
+        # release itself. `needs.test.outputs.required-version` is the live-resolved
+        # 28.1.* build the test matrix THIS RUN just gated on (bc-tests.yml's
+        # resolve-versions job, same resolve-version call bc-tests.yml's other jobs
+        # use) — it cannot be a version Microsoft has withdrawn, because resolving it
+        # is what proved it still exists, in this same run. It's also what the
+        # package is stamped with (AssemblyMetadata BcEngineVersion, AlRunner.csproj)
+        # so a released package still records a single, definite engine version.
+        #
+        # Also runs BuildWin32PrebuiltStubs (see AlRunner.csproj) which ships the
+        # prebuilt libwin32_stubs.linux-{x64,arm64}.so shims in the resulting nupkg.
+        #
+        # #1881's Directory.Build.props turns OFF IncludeSourceRevisionInInformationalVersion
+        # and SuppressImplicitGitSourceLink=true repo-wide, so every dev/CI build of
+        # al-runner.dll is content-addressable (RunnerFingerprint.ContentHash stops
+        # being a hash of the commit). This is the ONE place that must turn them back
+        # ON: `dotnet pack`'s nuspec RepositoryUrl/RepositoryCommit come from
+        # SourceLink's git task, and PackAsTool=true (AlRunner.csproj) ships this to
+        # nuget.org under MSDyn365BC.AL.Runner — losing that would silently strip
+        # commit provenance / source-stepping from every released package. Verified
+        # empirically that BOTH this Publish step and the later `dotnet pack --no-build`
+        # step need these two properties passed again — dropping them from either one
+        # (even though --no-build doesn't recompile) drops the nuspec's `commit`
+        # attribute back to absent, because NuGet's pack-time SourceLink integration
+        # re-reads git state itself rather than trusting whatever the prior Publish
+        # already embedded.
+        #
+        # Safe to override here specifically: a released package's bytes are fixed for a
+        # given version, so the ContentHash an end user's run computes from it is stable.
+        # Commit-embedding only invalidates caches when the SAME code is rebuilt
+        # commit-to-commit — the dev/CI/test-matrix path, never the release path.
         run: |
-          # Packing also needs the BC service tier present (RAR resolves against it),
-          # so the same download switch applies here.
-          #
-          # #2010: _BCVersion is passed explicitly here rather than left at
-          # AlRunner.csproj's default. The default is a static pin that Microsoft can
-          # (and did — the v2.4.0 release) withdraw between when it was last bumped
-          # and when a release runs, and nothing exercised that exact value except a
-          # release itself. `needs.test.outputs.required-version` is the live-resolved
-          # 28.1.* build the test matrix THIS RUN just gated on (bc-tests.yml's
-          # resolve-versions job, same resolve-version call bc-tests.yml's other jobs
-          # use) — it cannot be a version Microsoft has withdrawn, because resolving it
-          # is what proved it still exists, in this same run. It's also what the
-          # package is stamped with (AssemblyMetadata BcEngineVersion, AlRunner.csproj)
-          # so a released package still records a single, definite engine version.
-          #
-          # Also runs BuildWin32PrebuiltStubs (see AlRunner.csproj) which ships the
-          # prebuilt libwin32_stubs.linux-{x64,arm64}.so shims in the resulting nupkg.
-          #
-          # #1881's Directory.Build.props turns OFF IncludeSourceRevisionInInformationalVersion
-          # and SuppressImplicitGitSourceLink=true repo-wide, so every dev/CI build of
-          # al-runner.dll is content-addressable (RunnerFingerprint.ContentHash stops
-          # being a hash of the commit). This is the ONE place that must turn them back
-          # ON: `dotnet pack`'s nuspec RepositoryUrl/RepositoryCommit come from
-          # SourceLink's git task, and PackAsTool=true (AlRunner.csproj) ships this to
-          # nuget.org under MSDyn365BC.AL.Runner — losing that would silently strip
-          # commit provenance / source-stepping from every released package.
-          #
-          # Safe to override here specifically: a released package's bytes are fixed for a
-          # given version, so the ContentHash an end user's run computes from it is stable.
-          # Commit-embedding only invalidates caches when the SAME code is rebuilt
-          # commit-to-commit — the dev/CI/test-matrix path, never the release path.
-          #
-          # This step now runs BEFORE the CHANGELOG commit below (it used to run after),
-          # so the embedded commit SHA is the tested commit, one commit behind the tag
-          # that will point at tested-commit-plus-CHANGELOG. The two commits are
-          # byte-identical in every file that affects the built DLL (CHANGELOG.md isn't
-          # compiled), so this costs nothing but a one-commit-back SourceLink pointer —
-          # a small, known trade for building before writing.
-          dotnet build AlRunner/ \
-            -p:_BCVersion=${{ needs.test.outputs.required-version }} \
-            -p:AllowBcArtifactDownload=true
-          dotnet pack AlRunner/ \
+          dotnet publish AlRunner/ -c Release \
             -p:_BCVersion=${{ needs.test.outputs.required-version }} \
             -p:AllowBcArtifactDownload=true -p:Version=${{ inputs.version }} \
-            -p:SuppressImplicitGitSourceLink=false -p:IncludeSourceRevisionInInformationalVersion=true \
-            -p:EngineVariantsStagingDir="$(pwd)/variants-staging" \
-            -o ./nupkg
+            -p:SuppressImplicitGitSourceLink=false -p:IncludeSourceRevisionInInformationalVersion=true
+
+      - name: Upload the unsigned build tree
+        # The FULL obj/bin tree for all three projects, not just bin/publish/ — see
+        # the #2248 header comment for why: `dotnet pack --no-build` still re-runs
+        # the SDK's Publish-target copy phase, which needs these as copy sources.
+        uses: actions/upload-artifact@v4
+        with:
+          name: unsigned-build
+          path: |
+            AlRunner/bin
+            AlRunner/obj
+            AlRunner.QueryJoin/bin
+            AlRunner.QueryJoin/obj
+            AlRunner.Provisioning/bin
+            AlRunner.Provisioning/obj
+            variants-staging
+          if-no-files-found: error
+          retention-days: 1
+
+  sign-and-pack:
+    # Authenticode-signs every currently-unsigned PE file the `build` job produced,
+    # then packs the nupkg from the now-signed tree. Needs a Windows runner —
+    # azure/artifact-signing-action only runs there (#2248) — and the `release`
+    # environment, whose federated credential subject
+    # (repo:StefanMaron/BusinessCentral.AL.Runner:environment:release) is what
+    # authorizes this job's OIDC token exchange with Entra ID. No client secret
+    # anywhere in this job; `permissions: id-token: write` plus
+    # `exclude-workload-identity-credential: false` on the signing step is the
+    # entire authentication story.
+    needs: [plan, build]
+    runs-on: windows-latest
+    environment: release
+    permissions:
+      id-token: write
+    outputs:
+      unsigned-count: ${{ steps.catalog.outputs.count }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.plan.outputs.ref }}
+
+      - uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '8.0.x'
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Download the unsigned build tree
+        uses: actions/download-artifact@v4
+        with:
+          name: unsigned-build
+          path: .
+
+      - name: Build the signing catalog
+        id: catalog
+        # Scans the FULL obj/bin tree (not just the publish/ folder) so every
+        # physical copy of every unsigned assembly gets signed — see the #2248
+        # header comment for why that's required for `dotnet pack --no-build`
+        # (below) to end up with signed bytes regardless of which copy its
+        # Publish-target re-copy phase treats as the source. Third-party
+        # dependencies (Mono.Cecil.*, Spectre.Console.dll) are picked up by the
+        # same generic scan — nothing here special-cases them by name.
+        run: |
+          python .github/scripts/pe_signing.py list-unsigned AlRunner AlRunner.QueryJoin AlRunner.Provisioning variants-staging --catalog catalog.txt
+          $count = 0
+          if (Test-Path catalog.txt) {
+            $lines = Get-Content catalog.txt | Where-Object { $_.Trim() -ne '' }
+            $count = $lines.Count
+          }
+          Write-Host "Files queued for signing: $count"
+          if ($count -eq 0) {
+            Write-Error "No unsigned PE files found -- expected at least our own al-runner.dll/AlRunner.QueryJoin.dll/AlRunner.Provisioning.dll. Failing loudly instead of silently 'succeeding' at signing nothing."
+            exit 1
+          }
+          "count=$count" >> $env:GITHUB_OUTPUT
+
+      - name: Sign unsigned PE files with Azure Artifact Signing (#2248)
+        uses: azure/artifact-signing-action@v2
+        with:
+          endpoint: ${{ vars.SIGNING_ENDPOINT }}
+          signing-account-name: ${{ vars.SIGNING_ACCOUNT_NAME }}
+          certificate-profile-name: ${{ vars.SIGNING_CERT_PROFILE_NAME }}
+          azure-tenant-id: ${{ vars.AZURE_TENANT_ID }}
+          azure-client-id: ${{ vars.AZURE_CLIENT_ID }}
+          exclude-workload-identity-credential: false
+          files-catalog: ${{ github.workspace }}\catalog.txt
+          file-digest: SHA256
+          timestamp-rfc3161: http://timestamp.acs.microsoft.com
+          timestamp-digest: SHA256
+
+      - name: Verify the signing step actually signed everything it listed
+        # Fail fast here, on the machine that just did the signing, rather than
+        # discovering a gap only after packing and uploading. The release job
+        # (ubuntu, below) re-runs an equivalent check against the PACKED nupkg —
+        # that one is the authoritative gate this issue asks for; this is belt
+        # and suspenders on the pre-pack tree.
+        run: python .github/scripts/pe_signing.py verify AlRunner AlRunner.QueryJoin AlRunner.Provisioning variants-staging
+
+      - name: Restore
+        run: dotnet restore AlRunner/
+
+      - name: Pack the nupkg from the signed, unrebuilt tree
+        id: pack
+        # --no-build: do NOT recompile. Every PE file this pack step touches was
+        # either already signed in place above, or was never unsigned to begin
+        # with (the 84 files this workflow must leave alone). Recompiling here
+        # would throw away the signatures and produce an unsigned nupkg again.
+        run: dotnet pack AlRunner/ --no-build -c Release -p:Version=${{ inputs.version }} -p:SuppressImplicitGitSourceLink=false -p:IncludeSourceRevisionInInformationalVersion=true -p:EngineVariantsStagingDir="${{ github.workspace }}\variants-staging" -o nupkg
+
+      - name: Verify every PE in the packed nupkg is signed (pre-upload sanity)
+        shell: pwsh
+        run: |
+          Add-Type -AssemblyName System.IO.Compression.FileSystem
+          $nupkg = (Get-ChildItem nupkg\*.nupkg | Select-Object -First 1).FullName
+          $extractDir = Join-Path $pwd 'nupkg-extracted'
+          [System.IO.Compression.ZipFile]::ExtractToDirectory($nupkg, $extractDir)
+          python .github/scripts/pe_signing.py verify $extractDir
+
+      - name: Upload the signed nupkg
+        uses: actions/upload-artifact@v4
+        with:
+          name: signed-nupkg
+          path: nupkg/*.nupkg
+          if-no-files-found: error
+          retention-days: 1
+
+  release:
+    # Gated on `sign-and-pack`: this job holds every write this workflow performs —
+    # the CHANGELOG commit, the push to main, the tag, the NuGet push and the GitHub
+    # Release. Nothing above it touches the repository. See #1978.
+    #
+    # WITHIN this job, order matters too (#2010): downloading + verifying the
+    # already-built, already-signed, already-packed nupkg runs FIRST, before the
+    # commit/tag push, so a build/pack/signing failure (the failure that broke
+    # v2.4.0) leaves no write behind either. See the workflow header for the full
+    # guarantee and its one known gap (a NuGet-push failure).
+    needs: [plan, test, sign-and-pack]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: ${{ needs.plan.outputs.ref }}
+          ssh-key: ${{ secrets.RELEASE_DEPLOY_KEY }}
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Download the signed nupkg
+        id: download-nupkg
+        uses: actions/download-artifact@v4
+        with:
+          name: signed-nupkg
+          path: ./nupkg
+
+      - name: Assert a package was actually produced
+        run: |
+          shopt -s nullglob
+          pkgs=(./nupkg/*.nupkg)
+          if [ "${#pkgs[@]}" -eq 0 ]; then
+            echo "::error::no .nupkg found in the downloaded signed-nupkg artifact — the release path would ship nothing"
+            exit 1
+          fi
+          echo "Packed: ${pkgs[*]}"
+
+      - name: Verify every PE in the packed package is Authenticode-signed (#2248)
+        id: verify-signed
+        # The authoritative gate: this is the SAME scan (pe_signing.py) that
+        # measured 32 unsigned files in the published 2.9.0 package, run here
+        # against the FINAL packed nupkg contents, right before the writes below.
+        # A regression in sign-and-pack (a missed file, a signing-step failure that
+        # somehow didn't fail the job, a future packaging change that reintroduces
+        # an unsigned copy) fails HERE, before any NuGet push or GitHub Release.
+        run: |
+          mkdir -p ./nupkg-extracted
+          unzip -q ./nupkg/*.nupkg -d ./nupkg-extracted
+          python3 .github/scripts/pe_signing.py verify ./nupkg-extracted
 
       - name: Generate CHANGELOG and push the release commit + tag
         id: changelog
@@ -356,7 +571,9 @@ jobs:
             echo ""
             echo "| Step | Outcome |"
             echo "|---|---|"
-            echo "| Build and pack | ${{ steps.build-and-pack.outcome || 'did not run' }} |"
+            echo "| Signed nupkg downloaded | ${{ steps.download-nupkg.outcome || 'did not run' }} |"
+            echo "| PE files signed this run | ${{ needs.sign-and-pack.outputs.unsigned-count }} |"
+            echo "| All shipped PE files Authenticode-signed | ${{ steps.verify-signed.outcome || 'did not run' }} |"
             echo "| CHANGELOG commit + tag pushed to main | ${{ inputs.dry_run == true && 'skipped (dry_run)' || (steps.changelog.outcome || 'did not run') }} |"
             echo "| Push to NuGet | ${{ inputs.dry_run == true && 'skipped (dry_run)' || (steps.nuget-push.outcome || 'did not run') }} |"
             echo "| Create GitHub Release | ${{ inputs.dry_run == true && 'skipped (dry_run)' || (steps.gh-release.outcome || 'did not run') }} |"

--- a/AlRunner.Tests/PublishReleaseOrderingTests.cs
+++ b/AlRunner.Tests/PublishReleaseOrderingTests.cs
@@ -4,14 +4,24 @@
 // because that step ran AFTER the push, not before it, and the pin it built against was a
 // static value nothing exercised except a release.
 //
+// #2248 split the single `release` job into three (build -> sign-and-pack -> release), so the
+// build/pack failure the invariant guards against now spans job boundaries instead of living
+// inside one job. GitHub Actions' own `needs:` dependency is what enforces "runs before" across
+// jobs, so the invariant below is now: `build` (produces the unsigned tree) must be a `needs`
+// dependency of `sign-and-pack` (which signs and packs), which must be a `needs` dependency of
+// `release` (which does the writes) — and, within `release` itself, downloading + verifying the
+// already-packed nupkg must still precede the CHANGELOG/tag push, which must still precede
+// NuGet push and GitHub Release.
+//
 // Two things this pins down, both as pure functions of the real workflow text so a future
 // reordering (or a reintroduced static pin) fails a normal unit-test run instead of the next
 // release:
 //
-//   1. Within publish.yml's `release` job, "Build and pack" appears BEFORE the step that
+//   1. `build` -> `sign-and-pack` -> `release` via `needs:`, and within `release`, "Download
+//      the signed nupkg" and the PE-signed verification gate appear BEFORE the step that
 //      pushes the CHANGELOG commit and tag to origin, which appears before "Push to NuGet" and
-//      "Create GitHub Release". A build/pack failure must be unreachable-after-a-write.
-//   2. The build/pack step passes `-p:_BCVersion=` a value derived from
+//      "Create GitHub Release". A build/pack/sign failure must be unreachable-after-a-write.
+//   2. The `build` job's publish step passes `-p:_BCVersion=` a value derived from
 //      `needs.test.outputs.required-version` (the live-resolved version the matrix this run
 //      just gated on), not a hardcoded four-part BC build number. bc-tests.yml's
 //      `workflow_call` block actually exposes that output — a caller reading an output the
@@ -161,7 +171,24 @@ public sealed class PublishReleaseOrderingTests
     // ---- wired to the real files on disk ----------------------------------------------
 
     [Fact]
-    public void ReleaseJob_BuildsAndPacks_BeforeItPushesTheCommitAndTag_BeforeNuGetAndGitHubRelease()
+    public void PublishWorkflow_JobGraph_BuildThenSignAndPackThenRelease()
+    {
+        // #2248: the single "Build and pack" step became three jobs. GitHub's own `needs:`
+        // dependency is what now enforces "a build/sign/pack failure leaves no write behind" —
+        // this asserts that chain exists, job by job.
+        var text = Read("publish.yml");
+        var jobs = WorkflowParity.SplitJobs(text);
+
+        Assert.True(jobs.TryGetValue("build", out var buildJob), "publish.yml has no top-level 'build' job");
+        Assert.True(jobs.TryGetValue("sign-and-pack", out var signAndPackJob), "publish.yml has no top-level 'sign-and-pack' job");
+        Assert.True(jobs.TryGetValue("release", out var releaseJob), "publish.yml has no top-level 'release' job");
+
+        Assert.Contains("build", WorkflowParity.NeedsOf(signAndPackJob!));
+        Assert.Contains("sign-and-pack", WorkflowParity.NeedsOf(releaseJob!));
+    }
+
+    [Fact]
+    public void ReleaseJob_DownloadsAndVerifiesTheSignedPackage_BeforeItPushesTheCommitAndTag_BeforeNuGetAndGitHubRelease()
     {
         var text = Read("publish.yml");
         var jobs = WorkflowParity.SplitJobs(text);
@@ -169,7 +196,8 @@ public sealed class PublishReleaseOrderingTests
 
         var markers = new[]
         {
-            "Build and pack",
+            "Download the signed nupkg",
+            "Verify every PE in the packed package is Authenticode-signed",
             "Generate CHANGELOG and push the release commit + tag",
             "Push to NuGet",
             "Create GitHub Release",
@@ -178,23 +206,23 @@ public sealed class PublishReleaseOrderingTests
         var order = PublishOrdering.StepOrder(releaseJob!, markers);
 
         Assert.True(order.Count == markers.Length,
-            $"expected all four release-job steps present in order; found: {string.Join(" -> ", order)}");
+            $"expected all five release-job steps present in order; found: {string.Join(" -> ", order)}");
         Assert.Equal(markers, order);
     }
 
     [Fact]
-    public void ReleaseJob_BuildAndPackStep_ResolvesBcVersionFromTheGatedMatrix_NotAHardcodedPin()
+    public void BuildJob_PublishStep_ResolvesBcVersionFromTheGatedMatrix_NotAHardcodedPin()
     {
         // #2010: the pin that rotted (AlRunner.csproj's static default _BCVersion) is still a
-        // legitimate DEV-MACHINE fallback (see its own comment), but the release job must never
+        // legitimate DEV-MACHINE fallback (see its own comment), but the build job must never
         // read it implicitly — it has to pass a version it can prove, this run, still exists.
         var text = Read("publish.yml");
         var jobs = WorkflowParity.SplitJobs(text);
-        Assert.True(jobs.TryGetValue("release", out var releaseJob), "publish.yml has no top-level 'release' job");
+        Assert.True(jobs.TryGetValue("build", out var buildJob), "publish.yml has no top-level 'build' job");
 
         Assert.True(
-            PublishOrdering.BuildStepResolvesBcVersionFrom(releaseJob!, "Build and pack", "needs.test.outputs.required-version"),
-            "release job's 'Build and pack' step must pass -p:_BCVersion=${{ needs.test.outputs.required-version }}, "
+            PublishOrdering.BuildStepResolvesBcVersionFrom(buildJob!, "Publish the package-root build", "needs.test.outputs.required-version"),
+            "build job's publish step must pass -p:_BCVersion=${{ needs.test.outputs.required-version }}, "
             + "not a hardcoded four-part BC build number — that is exactly what rotted and broke v2.4.0.");
     }
 
@@ -243,6 +271,8 @@ public sealed class PublishReleaseOrderingTests
         Assert.Contains("dry_run:", text, StringComparison.Ordinal);
 
         var jobs = WorkflowParity.SplitJobs(text);
+        Assert.True(jobs.TryGetValue("build", out var buildJob), "publish.yml has no top-level 'build' job");
+        Assert.True(jobs.TryGetValue("sign-and-pack", out var signAndPackJob), "publish.yml has no top-level 'sign-and-pack' job");
         Assert.True(jobs.TryGetValue("release", out var releaseJob), "publish.yml has no top-level 'release' job");
 
         // Exactly the two irreversible/external steps are gated on dry_run being false.
@@ -251,10 +281,12 @@ public sealed class PublishReleaseOrderingTests
         Assert.Contains("inputs.dry_run", pushToNuGet, StringComparison.Ordinal);
         Assert.Contains("inputs.dry_run", createRelease, StringComparison.Ordinal);
 
-        // Build and pack must NOT be skipped in dry_run — it's the step the dry run exists to
-        // exercise.
-        var buildAndPack = ExtractStep(releaseJob!, "Build and pack");
-        Assert.DoesNotContain("if:", buildAndPack, StringComparison.Ordinal);
+        // #2248: build/sign/pack must NOT be skipped in dry_run — exercising them end to end,
+        // without publishing, is the entire point of the dry run. Checked at the JOB level (a
+        // job-level `if:` is indented exactly 4 spaces, distinct from a step-level `if:` nested
+        // under a step) since "Build and pack" is no longer one step but two whole jobs.
+        Assert.DoesNotMatch(new Regex(@"(?m)^ {4}if:"), buildJob!);
+        Assert.DoesNotMatch(new Regex(@"(?m)^ {4}if:"), signAndPackJob!);
     }
 
     private static string ExtractStep(string jobBody, string stepNameMarker)


### PR DESCRIPTION
Closes #2248

## What this does

Adds an Authenticode signing step to the release pipeline so every PE file
(`.dll`/`.exe`) in the published nupkg is signed, not just the 84 of 116 that
already were. Splits `publish.yml`'s single `release` job into three:

- `build` (ubuntu-latest) — builds every BC-minor engine variant plus the
  package-root build, all unsigned, uploads the tree as an artifact.
- `sign-and-pack` (windows-latest, `environment: release`, OIDC via
  `permissions: id-token: write` + `exclude-workload-identity-credential: false`,
  no client secret) — downloads that tree, signs every currently-unsigned PE
  file with `azure/artifact-signing-action@v2`, then runs `dotnet pack --no-build`
  against the now-signed tree.
- `release` (ubuntu-latest) — downloads the signed nupkg, verifies every PE
  inside it is signed, then does the writes (CHANGELOG commit, tag, NuGet push,
  GitHub Release) exactly as before.

`.github/scripts/pe_signing.py` is a new, dependency-free script that reads the
Certificate Table entry in a PE's optional header (no external tooling — pure
struct parsing). It's used two ways: `list-unsigned` builds the signing
catalog `sign-and-pack` feeds to the signing action, and `verify` is the
release-path gate the issue asked for (fails the release if any shipped PE is
unsigned). Both are unit-tested in `.github/scripts/test_pe_signing.py`
against synthetic PE32 and PE32+ fixtures (the two optional-header shapes
have different data-directory offsets — both are covered, positive and
negative), wired into `pr-check.yml` the same way the repo's other
`.github/scripts/*.py`/`*.sh` pairs are.

## Why sign more than 32 files

`dotnet pack --no-build` still re-runs the SDK's Publish-target file-copy
phase (it isn't gated on `NoBuild`), which re-copies each assembly from
whatever it considers the authoritative source — `obj/` for the entry
assembly, each `ProjectReference`'s own `bin/` for `AlRunner.QueryJoin.dll`/
`AlRunner.Provisioning.dll`, and every dependency's resolved `bin/` copy for
the rest — into `bin/Release/net8.0/publish/`, which is what actually gets
packed. I verified this empirically (byte-for-byte, described in the workflow
comments) rather than assuming it. MSBuild's copy is timestamp-skip, not
unconditional, so signing only the `publish/` copy could survive a
same-session test but isn't safe across an artifact upload/download
round-trip. The robust fix: `pe_signing.py`'s catalog step signs every
physical copy of every affected assembly the scan finds (`obj/`, each
project's own `bin/`, and the root project's `bin/` and `bin/publish/`), so
the Publish-target's re-copy is a no-op regardless of which source it
chooses — the bytes are already signed everywhere. `variants-staging/` has no
such duplication (NuGet packs directly from `EngineVariantsStagingDir` at
pack time), so one signed copy per variant file is enough there.

I proved this with a local simulation (not just reasoning about it): built the
real tree, "signed" every catalog entry with a distinguishing marker, ran the
exact `dotnet restore` + `dotnet pack --no-build` sequence this PR's
`sign-and-pack` job runs, then confirmed every marker survived into the
packed nupkg while an untouched already-signed third-party DLL was
unaffected.

## Fix the shape, not just the reported line

- **Same wrong pattern elsewhere?** The multi-copy issue (obj/bin/publish)
  applies identically to all three of our own assemblies and to the two
  third-party ones (`Mono.Cecil.*`, `Spectre.Console.dll`) — `pe_signing.py`'s
  scan is generic (no per-file special-casing), so it catches all of them the
  same way, not just the ones the issue named.
- **Sibling function, same assumption?** The `verify` subcommand and the
  `list-unsigned` subcommand share one `scan()`/`is_signed()` core specifically
  so they can't classify a file differently from each other.
- **Two paths, same invariant?** The pre-pack sanity check (in `sign-and-pack`,
  Windows) and the post-pack authoritative gate (in `release`, Linux, against
  the actual packed nupkg contents) both run the identical `verify` subcommand
  against real files on disk — no divergent logic between them.

## What this does NOT claim

This signs every binary AL Runner ships. It does **not** claim to resolve
Smart App Control for `dotnet tool install --global` users: the SDK generates
`al-runner.exe` locally from the apphost template and patches it with the
DLL path at install time, which invalidates any signature and can't be signed
from inside the package (the file doesn't exist until install time). Whether
signing the DLLs is sufficient needs confirmation from someone with a Smart
App Control machine — the original reporter on #2244, since neither
maintainer has one.

## Verification

- `python3 .github/scripts/test_pe_signing.py` — 12/12 passing, including a
  RED→GREEN check (mutated the PE32+ data-directory offset constant, confirmed
  4 tests failed, reverted, confirmed green again).
- `actionlint` clean on both modified workflow files and the rest of
  `.github/workflows/`.
- Local end-to-end simulation of the real `build`/`sign-and-pack` command
  sequence (described above) proves the multi-copy signing survives
  `dotnet pack --no-build`.
- Triggered a real `dry_run` dispatch of `publish.yml` on this branch — see
  the PR comment with the run link and outcome once it completes.

## Test plan

- [x] `pe_signing.py` unit tests pass, RED→GREEN demonstrated
- [x] `actionlint` clean
- [x] Local simulation of the multi-copy sign/pack sequence
- [ ] `dry_run` dispatch of `publish.yml` completes green, package downloaded
      and every PE confirmed signed and chaining to a trusted root