### PR TITLE
feat(test-data): rebuild Date/DateTime/Time/DateFormula values from a backup

### DIFF
--- a/AlRunner.Tests/TestDataDateValueHydrationTests.cs
+++ b/AlRunner.Tests/TestDataDateValueHydrationTests.cs
@@ -1,0 +1,267 @@
+// TestDataDateValueHydrationTests — the proving tests for issue #2259: rebuilding AL
+// Date / DateTime / Time / DateFormula values from a BC backup.
+//
+// WHAT IS PROVED HERE, AND WHY IT IS HERE
+//   These are claims about OUR OWN codec — that RecordPatches.ConvertTestDataValue mirrors
+//   BC's SQL-cell-to-NavValue conversion (NavSqlCommand.CreateNavValueFromReader) for the
+//   four types #2258 refused. They are not statements about what Business Central does with
+//   AL source, so .claude/rules/bc-behavior-tests-go-upstream.md does not send them upstream;
+//   the BC-behaviour half (a blank date read back as 0D on a real service tier) is the
+//   separate corpus test named in the PR.
+//
+//   They are also deliberately NOT driven off the shipped 900 MB demo backup. CI has no
+//   backup and no reader binary, and demo-data values are not guaranteed identical across the
+//   eight BC versions in the matrix (27.0 through 28.4), so a test asserting "CRONUS's Start
+//   Date is 2026-04-01" would be version-fragile in a way the codec is not. Every input below
+//   is a JSON literal written here, of the exact shape measured from the reader against
+//   sandbox/28.1.49838.50621's BusinessCentral-W1.bak — so the assertions are version-stable
+//   while still being the real wire format.
+//
+// THE ONE THAT CAN SILENTLY GO WRONG
+//   BC stores AL's blank date 0D as the SQL sentinel 1753-01-01 (SQL `datetime` cannot go
+//   below 1753 and BC's own write path throws for any real date before 1754-01-01, so the
+//   sentinel is unambiguous). A codec that passed 1753-01-01 through as a literal date would
+//   hydrate every blank date cell as a date in 1753 — 14,412 cells in the shipped CRONUS
+//   data — and every `if X = 0D` in AL would take the wrong branch, with no error anywhere.
+//   BlankDate_... and BlankDateTime_... assert against that directly.
+using AlRunner.Patches;
+using Microsoft.Dynamics.Nav.Runtime;
+using Microsoft.Dynamics.Nav.Types;
+using System.Text.Json;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class TestDataDateValueHydrationTests
+{
+    /// <summary>The only thing the four date/time branches read off the field: its NCL type.
+    /// A hand-built stand-in keeps these tests free of a booted engine or a metadata cache —
+    /// the conversion under test is pure over (NclType, JSON value).</summary>
+    private sealed class ValueMetadata : INavValueMetadata
+    {
+        internal ValueMetadata(NavNclType nclType, NavType navType)
+        {
+            NclType = nclType;
+            NavType = navType;
+        }
+
+        public NavType NavType { get; }
+        public NavNclType NclType { get; }
+        public int NavDefinedLengthMetadata => 0;
+        public NCLOptionMetadata NavOptionMetadata => null!;
+    }
+
+    private static readonly ValueMetadata DateField = new(NavNclType.NavDate, NavType.Date);
+    private static readonly ValueMetadata DateTimeField = new(NavNclType.NavDateTime, NavType.DateTime);
+    private static readonly ValueMetadata TimeField = new(NavNclType.NavTime, NavType.Time);
+    private static readonly ValueMetadata FormulaField = new(NavNclType.NavDateFormula, NavType.DateFormula);
+
+    private static NavValue Convert(INavValueMetadata metadata, string rawJsonValue)
+    {
+        using var doc = JsonDocument.Parse(rawJsonValue);
+        return RecordPatches.ConvertTestDataValue(
+            metadata, doc.RootElement.Clone(), 312, "Purchases & Payables Setup", 46,
+            "Allow Document Deletion Before");
+    }
+
+    private static TestDataHydrationRefusal Refusal(INavValueMetadata metadata, string rawJsonValue)
+        => Assert.Throws<TestDataHydrationRefusal>(() => Convert(metadata, rawJsonValue));
+
+    // ------------------------------------------------------------------ Date --
+
+    [Fact]
+    public void BlankDate_HydratesAsAlsBlankDate_NotAsALiteral1753()
+    {
+        // The exact cell that currently refuses the whole `Purchases & Payables Setup` table:
+        // field 46 "Allow Document Deletion Before", SQL `datetime NOT NULL`, holding the
+        // sentinel. The column cannot be NULL, so a sentinel is the only option BC has.
+        var value = Assert.IsType<NavDate>(Convert(DateField, "\"1753-01-01 00:00:00.000\""));
+
+        // AL's 0D is DateTime.MinValue (0001-01-01), which is what
+        // NavDateTimeValue.IsZeroOrEmpty tests against — the same question AL's `if X = 0D`
+        // asks.
+        Assert.True(value.IsZeroOrEmpty);
+        Assert.Equal(default, value.Value);
+        Assert.Same(NavDate.Undefined, value);
+
+        // Stated as its own assertion because it is the defect, not a corollary: a codec that
+        // handed the sentinel to NavDate.Create verbatim would produce a 1753 date here and
+        // every blank-date branch in AL would flip.
+        Assert.NotEqual(new DateTime(1753, 1, 1), value.Value);
+    }
+
+    [Fact]
+    public void RealDate_HydratesAsThatDate_WithBcsOwnLocalKind()
+    {
+        // Measured shape: Account Schedules Chart Setup."Start Date" = 2026-04-01.
+        var value = Assert.IsType<NavDate>(Convert(DateField, "\"2026-04-01 00:00:00.000\""));
+
+        Assert.False(value.IsZeroOrEmpty);
+        Assert.Equal(new DateTime(2026, 4, 1, 0, 0, 0, DateTimeKind.Local), value.Value);
+        // NavDate's constructor REJECTS anything that is not DateTimeKind.Local, so getting
+        // the kind wrong is a throw rather than a wrong answer — but pin it anyway, because
+        // the kind is what BC's own read path spells out and a future edit could "tidy" it.
+        Assert.Equal(DateTimeKind.Local, value.Value.Kind);
+    }
+
+    [Fact]
+    public void DateBeforeTheSqlFloor_IsRefused_NotSilentlyClamped()
+    {
+        // BC's write path throws NavCSideException for any real date below 1754-01-01, so such
+        // a value cannot have come from BC. Refusing names the table and column; clamping it
+        // to the sentinel would turn an impossible value into a plausible blank.
+        var ex = Refusal(DateField, "\"1600-05-04 00:00:00.000\"");
+        Assert.Contains("Purchases & Payables Setup", ex.Message, StringComparison.Ordinal);
+        Assert.Contains("Allow Document Deletion Before", ex.Message, StringComparison.Ordinal);
+    }
+
+    // -------------------------------------------------------------- DateTime --
+
+    [Fact]
+    public void BlankDateTime_HydratesAsAlsBlankDateTime_NotAsALiteral1753()
+    {
+        // Measured: Acc. Sched. KPI Web Srv. Setup."Data Last Updated" holds the sentinel.
+        // Note the constant is a DIFFERENT one from NavDate's — same instant, DateTimeKind.Utc
+        // rather than Local — which is why the two cases are not collapsed into one.
+        var value = Assert.IsType<NavDateTime>(Convert(DateTimeField, "\"1753-01-01 00:00:00.000\""));
+
+        Assert.True(value.IsZeroOrEmpty);
+        Assert.Equal(default, value.Value);
+        Assert.Same(NavDateTime.Undefined, value);
+        Assert.NotEqual(new DateTime(1753, 1, 1), value.Value);
+    }
+
+    [Fact]
+    public void RealDateTime_IsStoredVerbatimAsUtc_NotTimezoneConverted()
+    {
+        // Measured: Payment Terms."Last Modified Date Time" = 2026-05-19 23:24:22.663.
+        //
+        // THE TRAP #2259 flagged, and what this assertion does and does not catch — measured on
+        // a UTC+2 host, not reasoned:
+        //
+        //   correct    SpecifyKind(Utc)   + Server + unspecifiedAsLocal:false -> 23:24:22.663Z
+        //   Local kind SpecifyKind(Local) + Server + unspecifiedAsLocal:false -> 21:24:22.663Z
+        //   no kind    Unspecified        + Server + unspecifiedAsLocal:false -> throws
+        //   CreateFromObject's shape (Client + unspecifiedAsLocal:true)       -> 23:24:22.663Z
+        //
+        // Only the correct branch skips ConvertToUTc entirely: NavDateTime's constructor stores
+        // a Utc-kind value verbatim and never touches a session or a zone. So this assertion
+        // catches the Local-kind slip on any host with a non-zero UTC offset, and catches the
+        // no-kind slip everywhere (it throws).
+        //
+        // It does NOT catch CreateFromObject's shape here, and that is worth being exact about
+        // rather than claiming otherwise: ConvertToUTc asks the SESSION for the client zone, and
+        // a session-free unit test gets UTC back, so the shift only appears in a real run whose
+        // session carries a non-UTC zone. On a UTC host (GitHub's runners) none of the variants
+        // differ at all — there is genuinely nothing to observe. The authority for this branch is
+        // the decompiled read path quoted in ConvertTestDataValue, not this test alone.
+        var value = Assert.IsType<NavDateTime>(Convert(DateTimeField, "\"2026-05-19 23:24:22.663\""));
+
+        Assert.False(value.IsZeroOrEmpty);
+        Assert.Equal(new DateTime(2026, 5, 19, 23, 24, 22, 663, DateTimeKind.Utc), value.Value);
+        Assert.Equal(DateTimeKind.Utc, value.Value.Kind);
+    }
+
+    // ------------------------------------------------------------------ Time --
+
+    [Fact]
+    public void BlankTime_HydratesAsAlsBlankTime_NotAsMidnight()
+    {
+        // NavTime carries its OWN sentinel, NavTime.SqlTimeUndefined. It is the same instant as
+        // NavDate's, but a blank Time and 00:00:00 are different AL values, so the sentinel
+        // check is what keeps them apart: real midnight is stored as 1754-01-01 00:00:00.
+        var value = Assert.IsType<NavTime>(Convert(TimeField, "\"1753-01-01 00:00:00.000\""));
+
+        Assert.True(value.IsZeroOrEmpty);
+        Assert.Same(NavTime.Undefined, value);
+
+        var midnight = Assert.IsType<NavTime>(Convert(TimeField, "\"1754-01-01 00:00:00.000\""));
+        Assert.False(midnight.IsZeroOrEmpty);
+        Assert.NotSame(NavTime.Undefined, midnight);
+    }
+
+    [Fact]
+    public void RealTime_HydratesAsThatTimeOfDay_IgnoringTheCarrierDate()
+    {
+        // Measured: Calendar Entry."Starting Time" = 1754-01-01 08:00:00.000. BC reads only the
+        // hour/minute/second/millisecond off the cell; the 1754-01-01 date part is SQL's
+        // carrier for a `datetime` column and is not part of the AL value.
+        var value = Assert.IsType<NavTime>(Convert(TimeField, "\"1754-01-01 08:00:00.000\""));
+
+        Assert.False(value.IsZeroOrEmpty);
+        Assert.Equal(TimeSpan.FromHours(8), value.Value.TimeOfDay);
+        // NavTime pins every time onto BC's own carrier day (0001-01-02), so a codec that kept
+        // the SQL carrier date would produce a value NavTime's constructor rejects outright.
+        Assert.Equal(new DateTime(1, 1, 2), value.Value.Date);
+    }
+
+    // ----------------------------------------------------------- DateFormula --
+
+    [Fact]
+    public void DateFormula_KeepsBcsTokenEncoding_RatherThanParsingItAsFormulaText()
+    {
+        // Measured: Payment Terms."Due Date Calculation" for code "10 DAYS" is the two-token
+        // string "10" followed by U+0002, not the readable "10D". Handing that to the string
+        // overload (isTokenString: false) would run it through NavDateFormulaEvaluator.Parse as
+        // formula TEXT and produce a different value — that is what #2259 flagged, and
+        // isTokenString: true is its answer.
+        var value = Assert.IsType<NavDateFormula>(Convert(FormulaField, "\"10\\u0002\""));
+
+        Assert.False(value.IsZeroOrEmpty);
+        Assert.Equal("10", value.TokenString);
+        Assert.Equal("10", value.Value);
+
+        // A month token is a different control byte, so the two are not interchangeable.
+        var oneMonth = Assert.IsType<NavDateFormula>(Convert(FormulaField, "\"1\\u0005\""));
+        Assert.Equal("1", oneMonth.TokenString);
+        Assert.NotEqual(value.TokenString, oneMonth.TokenString);
+    }
+
+    [Fact]
+    public void EmptyDateFormula_HydratesAsTheFieldsBlankValue()
+    {
+        var value = Assert.IsType<NavDateFormula>(Convert(FormulaField, "\"\""));
+
+        Assert.True(value.IsZeroOrEmpty);
+        Assert.Equal("", value.TokenString);
+        // The same instance BC's own field.EmptyValue resolves to for a DateFormula field
+        // (NCLMetaField.EmptyValue -> NavValue.GetDefaultNavValue -> NavDateFormula.Default).
+        Assert.Same(NavDateFormula.Default, value);
+    }
+
+    // ------------------------------------------------ refusal still works --
+
+    [Fact]
+    public void AValueThatIsNotTheMeasuredWireShape_RefusesTheTableRatherThanGuessing()
+    {
+        // Four reasons to refuse were removed; the ABILITY to refuse was not. An unparseable
+        // cell still aborts the whole table, naming it, rather than substituting a default.
+        foreach (var metadata in new INavValueMetadata[] { DateField, DateTimeField, TimeField })
+        {
+            var ex = Refusal(metadata, "\"not a timestamp\"");
+            Assert.Contains("Purchases & Payables Setup", ex.Message, StringComparison.Ordinal);
+            Assert.Contains("not a timestamp", ex.Message, StringComparison.Ordinal);
+
+            // A JSON number is not the reader's shape for any of them either.
+            Assert.Throws<TestDataHydrationRefusal>(() => Convert(metadata, "17530101"));
+        }
+
+        // And a DateFormula's token string is a STRING; a number would be a decoding change
+        // this codec must not paper over.
+        Assert.Throws<TestDataHydrationRefusal>(() => Convert(FormulaField, "5"));
+    }
+
+    [Fact]
+    public void TypesThisBuildStillCannotRebuild_KeepRefusing()
+    {
+        // #2245 tracks Blob/Media/MediaSet. RecordId is a 448-byte structure with no textual
+        // wire form. None of them acquired a branch here, and the refusal must name the type
+        // so the reason reaches whoever reads the run's output.
+        foreach (var nclType in new[]
+                 { NavNclType.NavBlob, NavNclType.NavMedia, NavNclType.NavMediaSet, NavNclType.NavRecordId })
+        {
+            var ex = Refusal(new ValueMetadata(nclType, NavType.BLOB), "\"1753-01-01 00:00:00.000\"");
+            Assert.Contains(nclType.ToString(), ex.Message, StringComparison.Ordinal);
+        }
+    }
+}

--- a/AlRunner/Infrastructure/TestDataOptions.cs
+++ b/AlRunner/Infrastructure/TestDataOptions.cs
@@ -44,8 +44,11 @@ internal static class TestDataOptions
     /// 1 — #2258, the first slice: tables with `$ext` rows skipped whole.
     /// 2 — #2261, table-extension fields merged in. A version-1 baseline deserialises fine and
     ///     is silently missing every extension field of every extended table, so it must not
-    ///     be reused.</summary>
-    internal const int HydrationSchemaVersion = 2;
+    ///     be reused.
+    /// 3 — #2259, Date/DateTime/Time/DateFormula rebuilt instead of refused. A version-2
+    ///     baseline deserialises fine and is silently missing every table one of those types
+    ///     used to veto — 45 of the 54 still refusing after #2261.</summary>
+    internal const int HydrationSchemaVersion = 3;
 
     /// <summary>Off unless --test-data was passed. Absent the flag NOTHING here runs: no
     /// backup is opened, no reader is located, and CacheIdentity() returns the empty string

--- a/AlRunner/Patches/RecordPatches.TestDataHydration.cs
+++ b/AlRunner/Patches/RecordPatches.TestDataHydration.cs
@@ -57,10 +57,12 @@
 //      table: a bare unresolvable name could equally be a schema mismatch, and the two must
 //      not be confused.
 //
-//   b) The merge can fail to happen at all without failing. Measured on the shipped reader:
-//      `--mergeExtensions` (camelCase) is accepted by the CLI, ignored, and exits 0 — which
-//      would hydrate `Source Code Setup` with its ONE own field, ~50 blanks, and no error
-//      anywhere. That guard is NOT here, deliberately: this metatable cannot answer "is this
+//   b) The merge can fail to happen at all without failing. Measured on reader builds up to
+//      9701b04: `--mergeExtensions` (camelCase) was accepted by the CLI, ignored, and exited
+//      0 — which would hydrate `Source Code Setup` with its ONE own field, ~50 blanks, and no
+//      error anywhere. Reader a431ee4 refuses an unaccepted option (BakReader#18), but the
+//      runner pins no reader version and cannot control the binary on a user's PATH, so the
+//      guard stays. That guard is NOT here, deliberately: this metatable cannot answer "is this
 //      field stored in the companion". Measured on `Return Reason` (6635), whose
 //      `Default Location Code` lives in `Return Reason$ext` in the backup — the runner's
 //      NCLMetaField for it reports IsCompanionTableField = false, because BC only sets that

--- a/AlRunner/Patches/RecordPatches.TestDataHydration.cs
+++ b/AlRunner/Patches/RecordPatches.TestDataHydration.cs
@@ -39,8 +39,10 @@
 //   sandbox/27.5.46862.48827, decompiled — the read path is identical in both.
 //
 //   Still refused, and named when they are: Blob, Media, MediaSet (#2245), RecordId, Duration,
-//   TableFilter, a DB NULL in a non-string column, and any column name that is not an AL field
-//   of the target table. Removing four reasons to refuse did not remove the ability to.
+//   TableFilter, a DB NULL in a non-string column (#2268 — BC's reader answers that one too,
+//   but it needs the NCLMetaField this method is not handed), and any column name that is not
+//   an AL field of the target table. Removing four reasons to refuse did not remove the
+//   ability to: measured on the shipped CRONUS backup, 41 tables still decline.
 //
 // TABLE-EXTENSION FIELDS (issue #2261)
 //   BC splits an extended table across the base table and a `<table>$ext` companion. The
@@ -236,12 +238,17 @@ public static partial class RecordPatches
 
         if (json.ValueKind == JsonValueKind.Null)
         {
-            // A DB NULL. Only the string-like types have a NavValue that can represent one
-            // (the same restriction BC's own byte codec has — see
-            // RecordPatches.InstallBaselineDisk's KindNullString).
+            // A DB NULL. Only the string-like types are rebuilt here (the same restriction
+            // BC's own byte codec has — see RecordPatches.InstallBaselineDisk's KindNullString).
+            // BC's SQL READER does have an answer for every type — field.EmptyValue, and
+            // new NavBLOB(0) for a Blob — but reaching it needs the NCLMetaField this method is
+            // not handed. #2268 tracks it; measured, it is 11 of the 41 remaining refusals.
+            // Until then this refuses, which is the safe direction.
             if (!isStringLike)
                 throw new TestDataHydrationRefusal(Refuse(
-                    "the backup holds a NULL, and only Text/Code have a NavValue that can represent one"));
+                    "the backup holds a NULL, and this runner build only rebuilds NULLs for "
+                    + "Text/Code (see issue #2268 — BC's own SQL reader answers a NULL for every "
+                    + "type, but doing the same here needs metadata this codec is not handed)"));
             return nclType switch
             {
                 NavNclType.NavText or NavNclType.NavOemText =>

--- a/AlRunner/Patches/RecordPatches.TestDataHydration.cs
+++ b/AlRunner/Patches/RecordPatches.TestDataHydration.cs
@@ -15,10 +15,32 @@
 //   RestoreInstallBaselineSnapshot puts a captured baseline back.
 //
 // FAITHFULNESS / REFUSAL (.claude/rules/loud-failures.md)
-//   Values are rebuilt through BC's OWN codec, NavValue.CreateNavValueFromObject, handed the
-//   target field's metadata. Any value this file cannot prove it rebuilds identically aborts
-//   THAT TABLE's hydration with a message naming the table, the column and the type — it
-//   never substitutes a default and never leaves a partially-built row in the store.
+//   Values are rebuilt through BC's OWN code. The scalar types go through
+//   NavValue.CreateNavValueFromObject handed the target field's metadata; the date/time-shaped
+//   types mirror, case for case, BC's own SQL-cell reader
+//   (NavSqlCommand.CreateNavValueFromReader in Microsoft.Dynamics.Nav.Ncl.dll). Any value this
+//   file cannot prove it rebuilds identically aborts THAT TABLE's hydration with a message
+//   naming the table, the column and the type — it never substitutes a default and never leaves
+//   a partially-built row in the store.
+//
+// WHY THE DATE/TIME TYPES ARE NO LONGER REFUSED (issue #2259)
+//   #2258 refused Date, DateTime, Time and DateFormula because BC's SQL storage encoding for
+//   them was not established. It is now, from BC's own assemblies rather than from reasoning:
+//     - The blank marker is 1753-01-01, named per type — NavDate.SqlDateTimeUndefined (Local),
+//       NavDateTime.SqlDateTimeUtcUndefined (Utc), NavTime.SqlTimeUndefined (Local). The two
+//       kinds are NOT interchangeable and are not normalised to one here.
+//     - It is unambiguous, because NavDate.GetSqlWritableValue THROWS for any real date below
+//       1754-01-01 rather than storing one. A column holding both 1753-01-01 and real dates is
+//       holding blanks and real dates, not two meanings of one value.
+//     - DateFormula is stored as BC's TOKEN encoding (measured: Payment Terms."Due Date
+//       Calculation" for "10 DAYS" is "10" + U+0002, not "10D"), which is what the
+//       isTokenString: true constructor consumes.
+//   Evidence: Microsoft.Dynamics.Nav.Ncl.dll from sandbox/28.1.49838.50621 and
+//   sandbox/27.5.46862.48827, decompiled — the read path is identical in both.
+//
+//   Still refused, and named when they are: Blob, Media, MediaSet (#2245), RecordId, Duration,
+//   TableFilter, a DB NULL in a non-string column, and any column name that is not an AL field
+//   of the target table. Removing four reasons to refuse did not remove the ability to.
 //
 // TABLE-EXTENSION FIELDS (issue #2261)
 //   BC splits an extended table across the base table and a `<table>$ext` companion. The
@@ -55,6 +77,7 @@ using AlRunner.Infrastructure;
 using System.Reflection;
 using System.Text.Json;
 using Microsoft.Dynamics.Nav.Runtime;
+using Microsoft.Dynamics.Nav.Types.Exceptions;
 
 namespace AlRunner.Patches;
 
@@ -196,10 +219,10 @@ public static partial class RecordPatches
     /// <summary>
     /// Rebuild one decoded backup value as a NavValue for <paramref name="metadata"/>'s type.
     ///
-    /// Every branch hands a CLR object to BC's own <see cref="NavValue.CreateNavValueFromObject"/>
-    /// — this method never encodes a NavValue itself. A type that is not listed is refused, by
-    /// design: silently guessing an encoding for (say) a DateFormula, whose SQL form is an
-    /// opaque BC-internal string, is exactly the failure this feature exists to avoid.
+    /// This method never invents an encoding. The scalar branches hand a CLR object to BC's own
+    /// <see cref="NavValue.CreateNavValueFromObject"/>; the Date/DateTime/Time/DateFormula
+    /// branches transcribe BC's own SQL reader, <c>NavSqlCommand.CreateNavValueFromReader</c>,
+    /// quoted inline at each case. A type that is not listed is refused, by design.
     /// </summary>
     internal static NavValue ConvertTestDataValue(
         INavValueMetadata metadata, JsonElement json, int tableId, string tableName, int fieldNo, string columnName)
@@ -293,14 +316,187 @@ public static partial class RecordPatches
                 return NavValue.CreateNavValueFromObject(metadata, guid);
             }
 
+            // The four date/time-shaped types below mirror, case for case, BC's OWN
+            // SQL-cell-to-NavValue conversion:
+            // Microsoft.Dynamics.Nav.Runtime.NavSqlCommand.CreateNavValueFromReader(
+            //     SqlDataReader, INavFieldMetadata, int, int)
+            // in Microsoft.Dynamics.Nav.Ncl.dll — identical in the 27.5 and 28.1 artifacts.
+            // Anything that deviates from that method is a bug here, not a design choice.
+
+            case NavNclType.NavTime:
+            {
+                // BC:
+                //   DateTime dt = reader.GetDateTime(i);
+                //   if (dt.Equals(NavTime.SqlTimeUndefined)) return NavTime.Undefined;
+                //   return NavTime.Create(dt.Hour, dt.Minute, dt.Second, dt.Millisecond);
+                //
+                // NavTime has its OWN sentinel. It is the same instant as NavDate's, but a
+                // blank Time and 00:00:00 are different AL values, so the check is what keeps
+                // them apart — real midnight is stored on the 1754-01-01 carrier day.
+                // DateTime.Equals compares ticks and ignores Kind, which is why comparing an
+                // Unspecified-kind parse against a Local-kind constant is BC's own shape too
+                // (SqlDataReader.GetDateTime also returns Unspecified).
+                var cell = ParseTestDataSqlDateTime(json, Refuse);
+                if (cell.Equals(NavTime.SqlTimeUndefined)) return NavTime.Undefined;
+                // Only the time-of-day is part of the AL value; the date half is SQL's carrier
+                // for a `datetime` column and BC discards it.
+                return CreateOrRefuse(
+                    () => NavTime.Create(cell.Hour, cell.Minute, cell.Second, cell.Millisecond), Refuse);
+            }
+
+            case NavNclType.NavDate:
+            {
+                // BC:
+                //   DateTime v = new DateTime(reader.GetDateTime(i).Ticks, DateTimeKind.Local);
+                //   if (v.Equals(NavDate.SqlDateTimeUndefined)) return NavDate.Undefined;
+                //   return NavDate.Create(v);
+                //
+                // The sentinel is 1753-01-01, and it is unambiguous: NavDate.GetSqlWritableValue
+                // writes it for a blank date and THROWS (NavCSideException 22928068) for any
+                // real date outside [1754-01-01, 9999-12-31 23:59:59.997], so no real AL date
+                // can collide with it. Kind must be Local — NavDate's constructor rejects
+                // anything else outright.
+                var cell = ParseTestDataSqlDateTime(json, Refuse);
+                var value = new DateTime(cell.Ticks, DateTimeKind.Local);
+                if (value.Equals(NavDate.SqlDateTimeUndefined)) return NavDate.Undefined;
+                RefuseIfOutsideBcsWritableSqlRange(value, Refuse);
+                return CreateOrRefuse(() => NavDate.Create(value), Refuse);
+            }
+
+            case NavNclType.NavDateTime:
+            {
+                // BC:
+                //   DateTime v = DateTime.SpecifyKind(reader.GetDateTime(i), DateTimeKind.Utc);
+                //   if (v.Equals(NavDateTime.SqlDateTimeUtcUndefined)) return NavDateTime.Undefined;
+                //   return NavDateTime.Create(null, v, DateTimeReferenceFrame.Server,
+                //                             unspecifiedAsLocal: false);
+                //
+                // NOT CreateFromObject. That overload builds with DateTimeReferenceFrame.Client
+                // and unspecifiedAsLocal: true, which sends the value through ConvertToUTc and
+                // shifts it by the machine's UTC offset. Specifying Utc kind takes the verbatim
+                // branch of NavDateTime's constructor instead, which touches neither a session
+                // nor a time zone — that is why a null session is safe here.
+                var cell = ParseTestDataSqlDateTime(json, Refuse);
+                var value = DateTime.SpecifyKind(cell, DateTimeKind.Utc);
+                if (value.Equals(NavDateTime.SqlDateTimeUtcUndefined)) return NavDateTime.Undefined;
+                if (value < NavDateTime.SqlDateTimeUtcFirstValid
+                    || value > NavDateTime.SqlDateTimeUtcLastValid)
+                    throw new TestDataHydrationRefusal(Refuse(
+                        $"the backup holds '{value:yyyy-MM-dd HH:mm:ss.fff}', which is outside the range BC "
+                        + "will write to a SQL datetime column and is not its blank sentinel either, so the "
+                        + "reader decoded something BC cannot have stored"));
+                return CreateOrRefuse(
+                    () => NavDateTime.Create(
+                        (NavSession?)null, value, DateTimeReferenceFrame.Server, unspecifiedAsLocal: false),
+                    Refuse);
+            }
+
+            case NavNclType.NavDateFormula:
+            {
+                // BC:
+                //   string text = reader.GetString(i);
+                //   if (string.IsNullOrEmpty(text)) return field.EmptyValue;
+                //   return new NavDateFormula(text, isTokenString: true);
+                //
+                // The stored value is BC's TOKEN encoding, not readable formula text: measured,
+                // Payment Terms."Due Date Calculation" for "10 DAYS" is "10" + U+0002, and
+                // Company Information."Cal. Convergence Time Frame" is "1" + U+0007. The
+                // single-argument NavDateFormula(string) overload would run that through
+                // NavDateFormulaEvaluator.Parse as formula TEXT and produce a different value;
+                // isTokenString: true is what consumes it as tokens.
+                if (json.ValueKind != JsonValueKind.String)
+                    throw new TestDataHydrationRefusal(Refuse(
+                        $"expected a DateFormula token string, got {json.ValueKind} '{json}'"));
+                var text = json.GetString() ?? string.Empty;
+                // NavDateFormula.Default is the same instance BC's field.EmptyValue resolves to
+                // for a DateFormula field (NCLMetaField.EmptyValue -> NavValue.GetDefaultNavValue
+                // -> NavDateFormula.Default), so this is that branch, not an approximation of it.
+                if (text.Length == 0) return NavDateFormula.Default;
+                return CreateOrRefuse(() => new NavDateFormula(text, isTokenString: true), Refuse);
+            }
+
             default:
-                // Date/DateTime/Time/Duration/DateFormula/Blob/Media/MediaSet/RecordId/…
+                // Duration/Blob/Media/MediaSet/RecordId/TableFilter/…
                 // Not "unsupported forever" — unproven. Rebuilding them needs BC's SQL
-                // storage encoding for that type (e.g. which SQL datetime value AL's blank
-                // date is stored as), and this codec will not assert one that no service tier
-                // has confirmed. See .claude/rules/ask-the-corpus-before-claiming-bc-behavior.md.
+                // storage encoding for that type, and this codec will not assert one it has
+                // not established. LOB/binary is tracked in #2245.
                 throw new TestDataHydrationRefusal(Refuse(
                     "this runner build cannot yet rebuild that AL type from a backup value"));
+        }
+    }
+
+    /// <summary>NavDate's own private <c>SqlDateTimeFirstValid</c>, transcribed. BC's write path
+    /// throws rather than store a Date below it, which is what makes 1753-01-01 an unambiguous
+    /// blank marker rather than one of two meanings sharing a column.</summary>
+    private static readonly DateTime TestDataSqlDateFirstValid =
+        new(1754, 1, 1, 0, 0, 0, 0, DateTimeKind.Local);
+
+    /// <summary>
+    /// The one shape the reader emits for every SQL <c>datetime</c> column, whatever the AL type
+    /// on top of it: a JSON string <c>yyyy-MM-dd HH:mm:ss.fff</c>. Measured across all 4,854
+    /// Date, 503 DateTime and 302 Time cells the reader produced for CRONUS from
+    /// <c>sandbox/28.1.49838.50621/w1/BusinessCentral-W1.bak</c> — one shape, no exceptions.
+    ///
+    /// The three variants after it are not measured; they are the unambiguous renderings a
+    /// reader change could plausibly move to (whole seconds, <c>datetime2</c> precision, an ISO
+    /// separator). Anything else refuses, which is the point: a decoding change that this codec
+    /// silently reinterpreted would put wrong dates in the store with nothing to notice it.
+    /// </summary>
+    private static readonly string[] TestDataSqlDateTimeFormats =
+    {
+        "yyyy-MM-dd HH:mm:ss.fff",
+        "yyyy-MM-dd HH:mm:ss",
+        "yyyy-MM-dd HH:mm:ss.fffffff",
+        "yyyy-MM-ddTHH:mm:ss.fff",
+    };
+
+    private static DateTime ParseTestDataSqlDateTime(JsonElement json, Func<string, string> refuse)
+    {
+        if (json.ValueKind != JsonValueKind.String)
+            throw new TestDataHydrationRefusal(refuse(
+                $"expected a SQL datetime string, got {json.ValueKind} '{json}'"));
+
+        // DateTimeStyles.None yields DateTimeKind.Unspecified — the same kind
+        // SqlDataReader.GetDateTime hands BC, so each branch above applies the kind BC applies
+        // rather than inheriting one from the parse.
+        if (!DateTime.TryParseExact(json.GetString(), TestDataSqlDateTimeFormats,
+                System.Globalization.CultureInfo.InvariantCulture,
+                System.Globalization.DateTimeStyles.None, out var parsed))
+            throw new TestDataHydrationRefusal(refuse(
+                $"'{json.GetString()}' is not a SQL datetime the reader is known to emit "
+                + $"(expected {TestDataSqlDateTimeFormats[0]})"));
+        return parsed;
+    }
+
+    /// <summary>
+    /// Refuse a Date outside the window BC's own write path will store. BC's READ path does not
+    /// range-check, because SQL already held it to that window on the way in; here the value
+    /// arrived through a third-party backup decoder instead, so the guarantee has to be
+    /// re-checked. A date in 1753 that is not the sentinel cannot have been written by BC, so it
+    /// means the decode was wrong — and a plausible-looking wrong date in the store is exactly
+    /// what .claude/rules/loud-failures.md exists to stop.
+    /// </summary>
+    private static void RefuseIfOutsideBcsWritableSqlRange(DateTime value, Func<string, string> refuse)
+    {
+        if (value >= TestDataSqlDateFirstValid) return;
+        throw new TestDataHydrationRefusal(refuse(
+            $"the backup holds '{value:yyyy-MM-dd HH:mm:ss.fff}', which is earlier than the "
+            + $"{TestDataSqlDateFirstValid:yyyy-MM-dd} floor BC will write to a SQL datetime column and is "
+            + "not its blank sentinel either, so the reader decoded something BC cannot have stored"));
+    }
+
+    /// <summary>
+    /// Run one of BC's own NavValue constructors and turn its rejection into a per-table refusal.
+    /// Without this a NavNCLException would escape past TestDataProvisioner's catch and abort the
+    /// whole run, where the contract is that ONE table declines and the rest still hydrate.
+    /// </summary>
+    private static NavValue CreateOrRefuse(Func<NavValue> create, Func<string, string> refuse)
+    {
+        try { return create(); }
+        catch (NavNCLException ex)
+        {
+            throw new TestDataHydrationRefusal(refuse(
+                $"BC's own value constructor rejected the decoded cell ({ex.GetType().Name}: {ex.Message})"));
         }
     }
 }

--- a/AlRunner/TestDataProvisioner.cs
+++ b/AlRunner/TestDataProvisioner.cs
@@ -34,12 +34,21 @@
 //   passes `--merge-extensions`, so the base and companion rows arrive joined, and a table
 //   with extension data is no longer skipped whole.
 //
-//   The request key is `merge-extensions`, HYPHENATED. The camelCase spelling is accepted by
-//   the reader's CLI, ignored, and exits 0 — measured, not assumed — which would hydrate
-//   Source Code Setup with one of its ~50 fields and report success, and 68 CRONUS tables
-//   with it. AssertMergeIsHonoured() below reads one extended table BOTH ways before anything
-//   is hydrated and requires the merged read to return strictly more columns, so a merge that
-//   is not happening fails the run instead of emptying 68 tables quietly.
+//   The request key is `merge-extensions`, HYPHENATED. On reader builds up to and including
+//   9701b04 the camelCase spelling `--mergeExtensions` was accepted by the CLI, ignored, and
+//   exited 0 — measured, not assumed — which would hydrate Source Code Setup with one of its
+//   ~50 fields and report success, and 68 CRONUS tables with it. Reader a431ee4 (BakReader#18)
+//   refuses an option the command does not accept, so that specific spelling now exits 1
+//   naming the accepted options. Stated as history, not as current reader behaviour.
+//
+//   AssertMergeIsHonoured() below stays, and the upstream fix is not a reason to remove it.
+//   It removed the reason the probe was WRITTEN, not the reason it should remain: the runner
+//   does not pin a reader version, and it cannot control which binary is on a user's PATH or
+//   on AL_RUNNER_BCBAK. An older reader that silently ignores the flag is still a reachable
+//   configuration, and this probe is the only thing that catches it. It reads one extended
+//   table BOTH ways before anything is hydrated and requires the merged read to return
+//   strictly more columns, so a merge that is not happening fails the run instead of emptying
+//   68 tables quietly.
 //
 //   That check is once per run, not per table, and it has to be: whether the flag is honoured
 //   is a property of the reader, not of a table. The per-table form was tried and is wrong —
@@ -237,7 +246,7 @@ internal static class TestDataProvisioner
             + $"whose '$ext' companion holds rows, returned {merged.Count} column(s) with the flag and "
             + $"{plain.Count} without, so every table-extension field would hydrate blank while the run "
             + "reported success. Check the reader build (AL_RUNNER_BCBAK); the request key is hyphenated, "
-            + "and the camelCase spelling is accepted, ignored, and exits 0.");
+            + "and reader builds before a431ee4 accept the camelCase spelling, ignore it, and exit 0.");
     }
 
     /// <summary>

--- a/tests/test-data-fixture/README.md
+++ b/tests/test-data-fixture/README.md
@@ -6,8 +6,16 @@ back through ordinary AL `Record` calls with the right values.
 - `TestDataHydration.Codeunit.al` (#2258) — a table with no extension data, "No. Series".
 - `TestDataExtensionFields.Codeunit.al` (#2261) — a table whose fields come from a
   **tableextension**, "Source Code Setup". Every assertion there is on an extension field's
-  VALUE, because the reader's CLI accepts `--mergeExtensions` (camelCase), ignores it, and
-  exits 0: a test asserting "the record was found" would pass with the merge not happening.
+  VALUE, because a test asserting "the record was found" would pass with the merge not
+  happening at all. On reader builds up to 9701b04 that was reachable: the CLI accepted
+  `--mergeExtensions` (camelCase), ignored it, and exited 0. Reader a431ee4 refuses an
+  option the command does not accept (BakReader#18), so that spelling now fails — but the
+  runner pins no reader version, so the value assertions and `AssertMergeIsHonoured()` both
+  stay.
+- `TestDataDateValues.Codeunit.al` (#2259) — Date, DateTime, Time and DateFormula. The
+  load-bearing assertion is that a BLANK date reads back as AL's `0D` and not as the SQL
+  sentinel 1753-01-01 BC stores it under; a test asserting only "the table hydrated" would
+  pass with that bug present.
 
 **CI does not run this bundle, and that is deliberate.** It only passes with `--test-data`
 and a BC sandbox backup on the machine (~1 GB, shipped inside the sandbox artifact). CI runs

--- a/tests/test-data-fixture/TestDataDateValues.Codeunit.al
+++ b/tests/test-data-fixture/TestDataDateValues.Codeunit.al
@@ -1,0 +1,149 @@
+/// <summary>
+/// End-to-end proof for issue #2259: `--test-data` rebuilds Date, DateTime, Time and
+/// DateFormula values out of the backup, and AL reads them back as the values BC stored.
+///
+/// THE ASSERTION THAT MATTERS IS THE BLANK ONE. BC stores AL's blank date `0D` as the SQL
+/// sentinel 1753-01-01, because a SQL `datetime` column cannot hold 0001-01-01 and BC's own
+/// write path (NavDate.GetSqlWritableValue) throws rather than store a real date below
+/// 1754-01-01. A codec that let the sentinel through as a literal date would put a date in
+/// 1753 into every blank date cell — 4,854 Date cells in the shipped CRONUS data go through
+/// this path — and every `if X = 0D` in AL would take the wrong branch with no error anywhere.
+/// A test that only asserted "the table hydrated" would pass with that bug present.
+///
+/// THE SUBJECTS, AND WHY THESE
+///   - `Purchases & Payables Setup` is the table issue #2259 named: its single
+///     `Allow Document Deletion Before` Date column refused the WHOLE table, which is what
+///     stood behind three of the fifteen missing-setup failures in #2240. `Invoice Nos.` is
+///     the field those failures actually asked for, so both are asserted together — the date
+///     is what unblocks it, the code is what proves it landed.
+///   - `FA Depreciation Book` carries a blank and a real value in the SAME column
+///     (FA000040 blank, FA000010 = 2029-12-31), so one column proves both directions.
+///   - `Payment Terms` covers DateFormula (BC's token encoding, not readable formula text)
+///     and DateTime in one row.
+///   - `Calendar Entry` covers Time, whose SQL carrier date (1754-01-01) is NOT part of the
+///     AL value and must be discarded.
+///
+/// ON BC VERSIONS. This bundle is not run by CI, but it is run by hand against more than one
+/// artifact, and demo data is not guaranteed identical across them. The blank assertions are
+/// version-stable by construction — "no value" is not a value that drifts. The concrete dates
+/// are not, so each one is paired with a blank assertion on the same column rather than
+/// carrying the claim alone: if a future artifact changes FA000010's ending date, this fails
+/// with a readable "expected X got Y" on a value, not silently stop testing anything.
+///
+/// NOT RUN BY CI — see README.md in this directory.
+/// </summary>
+codeunit 64403 "Test Data Date Values"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit "TDF Assert";
+
+    /// <summary>
+    /// The exact table and column from issue #2259, and the two fields that matter: the Date
+    /// that used to refuse the table, and the Code that #2240's failures asked for.
+    /// </summary>
+    [Test]
+    procedure PurchasesPayablesSetupHydrates()
+    var
+        PurchSetup: Record "Purchases & Payables Setup";
+    begin
+        PurchSetup.Get();
+
+        // Field 46, SQL `datetime NOT NULL`, holding 1753-01-01 in the shipped backup. The
+        // column cannot be NULL, so the sentinel is the only way BC has to say "blank".
+        Assert.AreEqual(0D, PurchSetup."Allow Document Deletion Before",
+            'Allow Document Deletion Before must read as AL blank, not as a date in 1753');
+
+        // And the table really did hydrate its other fields, so the blank above is a rebuilt
+        // blank rather than an untouched Record.Init() default.
+        Assert.AreEqual('P-INV', PurchSetup."Invoice Nos.", 'Invoice Nos.');
+        PurchSetup.TestField("Invoice Nos.");
+    end;
+
+    /// <summary>Both directions on ONE column: a blank cell and a real cell of the same
+    /// Date field, so neither claim can be satisfied by the other's implementation.</summary>
+    [Test]
+    procedure BlankAndRealDateOnTheSameColumn()
+    var
+        Blank: Record "FA Depreciation Book";
+        Real: Record "FA Depreciation Book";
+    begin
+        Blank.Get('FA000040', 'COMPANY');
+        Assert.AreEqual(0D, Blank."Depreciation Ending Date",
+            'FA000040 ending date is 1753-01-01 in SQL and must read as AL blank');
+        Assert.AreEqual('', Format(Blank."Depreciation Ending Date"),
+            'AL formats a blank date as the empty string');
+
+        Real.Get('FA000010', 'COMPANY');
+        Assert.AreEqual(DMY2Date(31, 12, 2029), Real."Depreciation Ending Date",
+            'FA000010 ending date');
+        Assert.AreEqual(DMY2Date(1, 1, 2025), Real."Depreciation Starting Date",
+            'FA000010 starting date');
+        Assert.IsFalse(Real."Depreciation Ending Date" = 0D,
+            'a real date must not collapse into the blank');
+    end;
+
+    /// <summary>
+    /// DateFormula is stored as BC's TOKEN encoding, not as readable formula text: measured,
+    /// "10 DAYS"."Due Date Calculation" is the two-character string "10" + U+0002. Asserting
+    /// the FORMATTED value is what proves the token was consumed as a token — parsing it as
+    /// formula text would produce a different formula, and comparing raw storage to raw
+    /// storage would not notice.
+    /// </summary>
+    [Test]
+    procedure DateFormulaKeepsItsMeaning()
+    var
+        PaymentTerms: Record "Payment Terms";
+        TenDays: DateFormula;
+        OneMonth: DateFormula;
+    begin
+        Evaluate(TenDays, '10D');
+        Evaluate(OneMonth, '1M');
+
+        PaymentTerms.Get('10 DAYS');
+        Assert.AreEqual(Format(TenDays), Format(PaymentTerms."Due Date Calculation"),
+            '10 DAYS due date calculation');
+        Assert.IsFalse(Format(PaymentTerms."Due Date Calculation") = Format(OneMonth),
+            'a day token must not decode as a month token');
+
+        // The blank direction: this row's discount calculation is empty in the backup.
+        Assert.AreEqual('', Format(PaymentTerms."Discount Date Calculation"),
+            '10 DAYS discount date calculation is empty in the backup');
+    end;
+
+    /// <summary>DateTime is stored UTC and rebuilt verbatim — never routed through the
+    /// session's client time zone, which would shift it by the host's UTC offset.</summary>
+    [Test]
+    procedure DateTimeHydratesNonBlank()
+    var
+        PaymentTerms: Record "Payment Terms";
+    begin
+        PaymentTerms.Get('10 DAYS');
+        Assert.IsFalse(PaymentTerms."Last Modified Date Time" = 0DT,
+            'Last Modified Date Time holds a real instant in the backup, not the blank sentinel');
+        // The instant itself is a demo-data build timestamp and moves with the artifact, so it
+        // is not asserted as a literal. What IS version-stable: it is on the same day as the
+        // row's own creation, which a timezone shift of a whole day would break.
+        Assert.IsTrue(PaymentTerms."Last Modified Date Time" > CreateDateTime(DMY2Date(1, 1, 2000), 0T),
+            'a rebuilt DateTime must be a real instant, not something near the 1753 sentinel');
+    end;
+
+    /// <summary>
+    /// Time. BC stores it in a `datetime` column on a carrier date (1754-01-01 for a real
+    /// time, 1753-01-01 for a blank) and reads back only the time of day. A codec that kept
+    /// the carrier date would produce a value BC's own NavTime constructor rejects.
+    /// </summary>
+    [Test]
+    procedure TimeHydratesAsTimeOfDayOnly()
+    var
+        CalendarEntry: Record "Calendar Entry";
+    begin
+        CalendarEntry.SetFilter("Starting Time", '<>%1', 0T);
+        Assert.IsTrue(CalendarEntry.FindFirst(),
+            'the backup holds Calendar Entry rows with a non-blank Starting Time');
+        Assert.AreEqual(080000T, CalendarEntry."Starting Time", 'Starting Time');
+        Assert.IsFalse(CalendarEntry."Starting Time" = 0T,
+            'a real time must not collapse into the blank');
+    end;
+}


### PR DESCRIPTION
Closes #2259

The value codec refused every date/time-shaped AL type because BC's SQL storage encoding for
them was not established. It is now, and not from reasoning: BC's own reader,
`NavSqlCommand.CreateNavValueFromReader(SqlDataReader, INavFieldMetadata, int, int)` in
`Microsoft.Dynamics.Nav.Ncl.dll`, carries the conversion with named constants, and it is
byte-identical in the 27.5 and 28.1 artifacts. The four cases here transcribe it, with BC's own
code quoted inline at each `case` so a reviewer can diff them.

- **The sentinel is 1753-01-01, named per type, and the kinds are not normalized.**
  `NavDate.SqlDateTimeUndefined` (Local), `NavDateTime.SqlDateTimeUtcUndefined` (Utc),
  `NavTime.SqlTimeUndefined` (Local). It is unambiguous because `NavDate.GetSqlWritableValue`
  throws rather than store a real date below 1754-01-01, so a column holding both 1753-01-01 and
  real dates is holding blanks and real dates, not two meanings of one value.
- **DateTime uses `Create(session, v, Server, unspecifiedAsLocal: false)` on a Utc-kind value.**
  Not `CreateFromObject`, whose `Client` / `unspecifiedAsLocal: true` shape routes through
  `ConvertToUTc` and asks the session for a zone. The Utc-kind path stores verbatim and touches
  neither a session nor a zone, which is why a null session is safe.
- **DateFormula uses `isTokenString: true`**, because the stored value is BC's token encoding
  (`Payment Terms."Due Date Calculation"` for `10 DAYS` is `"10"` + U+0002, not `"10D"`).

`HydrationSchemaVersion` 2 -> 3, so a baseline cached before this change is not reused by a run
that would now hydrate the tables those types vetoed.

## Refusal is unchanged in kind, only in extent

Four reasons to refuse were removed; the ability was not. Blob / Media / MediaSet (#2245),
RecordId, Duration, a DB NULL in a non-string column, and an unresolvable column name all still
abort their table whole. Two new refusals were added rather than assumed away: a decoded cell
that is not the wire shape the reader is known to emit, and a cell BC's own constructor rejects
(previously that would have escaped as an unhandled `NavNCLException` and aborted the whole run
instead of one table).

The change is confined to the value codec. Table selection, plan building, `AssertMergeIsHonoured`
and #2261's non-fatal per-table reader failure are untouched.

Three comment blocks are also corrected, since they asserted reader behaviour that stopped being
true underneath them: reader `a431ee4` (BakReader#18) now refuses an option the command does not
accept, so the camelCase `--mergeExtensions` spelling exits 1 instead of being silently ignored.
Rewritten as history rather than present tense. `AssertMergeIsHonoured` stays and the comment now
says why — the upstream change removed the reason the probe was written, not the reason it should
remain: the runner pins no reader version and cannot control the binary on a user's `PATH` or
`AL_RUNNER_BCBAK`.

## Measured, on the shipped backup

`sandbox/28.1.49838.50621/w1/BusinessCentral-W1.bak`, CRONUS, Base Application / System
Application / Business Foundation closure, reader `a431ee4`, both runs at the same commit
except for this diff (re-measured after the reader was swapped; the numbers are unchanged
from reader `9701b04`):

| | tables hydrated | rows | tables refused |
|---|---|---|---|
| after #2261, before this | 203 | 7,562 | 153 |
| with this | **315** | **37,710** | **41** |

The 153 broke down as Date 90, DateTime 21, DateFormula 16, Time 2 (129 total), Blob 7,
Media 4, MediaSet 1, unresolvable column 12. **Zero date/time refusals remain.**

The 41 that still refuse: Blob 15 (11 of which are the DB-NULL branch, not Blob decoding),
Media 11, RecordId 2, MediaSet 1, unresolvable column 12. Blob/Media/RecordId counts went *up*
because those tables used to refuse on a date column first and now get far enough to hit the
next obstacle — re-attribution, not regression.

## What this means for #2240

Partly, and the split is worth being exact about. #2240's 15 setup failures are 12 x
`Source Code Setup does not exist` and 3 x `Invoice Nos. must have a value in Purchases &
Payables Setup`. Verified end-to-end against the real backup, both tables now hydrate:

- `Source Code Setup` has **no** date column. #2261 alone already put it back; this change
  contributes nothing to those 12.
- `Purchases & Payables Setup` needed both. #2261 made it reachable; it then refused on the
  single `Allow Document Deletion Before` Date column (measured refusal line in the before run).
  With this change it hydrates, `Invoice Nos.` reads `P-INV`, `TestField("Invoice Nos.")` passes,
  and `Allow Document Deletion Before` reads `0D` rather than a date in 1753.

So all 15 should now be data-satisfied. I have not re-run that customer suite, so that is an
inference from the two tables, not a measurement of the suite.

## Tests

**Committed (`AlRunner.Tests/TestDataDateValueHydrationTests.cs`, 11 facts).** Codec-level, over
JSON literals of the exact shape measured from the reader.

The version-stability trap was real and I chose to design around it rather than assert through
it: CI runs eight BC versions and demo data is not guaranteed identical across them, so no
committed test reads the backup. Inputs are authored here; the shapes they encode were measured
across all 4,854 Date, 503 DateTime, 302 Time and ~950 DateFormula cells the reader produced for
CRONUS (one wire shape each, no exceptions). That keeps the assertions version-stable without
weakening them — the blank case asserts `IsZeroOrEmpty`, `Value == default` **and**
`Value != 1753-01-01` separately, so leaving the sentinel as a literal fails three ways.

RED was 9 of 11 failing; the 2 that passed are the ones asserting refusal still happens.

**Committed AL (`tests/test-data-fixture/TestDataDateValues.Codeunit.al`, 5 tests).** The
bundle that reads the hydrated store back through ordinary `Record` calls. Deliberately not run
by CI — see that directory's README; it needs the flag and a ~1 GB backup no leg has. Measured
against the shipped CRONUS backup: **5 fail on the pre-change codec, 5 pass after**, and the
bundle's 7 pre-existing tests are unaffected in both states (7 pass / 5 fail, then 12 pass).

Subjects: `Purchases & Payables Setup` (`Allow Document Deletion Before` = `0D` **and**
`Invoice Nos.` = `P-INV`, so the blank is a rebuilt blank rather than an untouched
`Record.Init()` default), `FA Depreciation Book` (a blank and a real value in the *same*
column — FA000040 vs FA000010), `Payment Terms` (DateFormula formats as `10D` and is not a
month token; DateTime non-blank), `Calendar Entry` (Time = `08:00:00`, carrier date discarded).

Version-stability was handled there too rather than ignored: every concrete date is paired with
a blank assertion on the same column, so a future artifact that moves a demo value fails with a
readable "expected X got Y" instead of quietly testing nothing.

## Looking for the same shape elsewhere

- **Another call site with the same wrong pattern?** None. `ConvertTestDataValue` is the only
  place in the runner that turns a decoded SQL cell into a NavValue; nothing else references
  1753, `SqlDateTimeUndefined`, `isTokenString` or `DateTimeReferenceFrame`.
- **A sibling making the same assumption?** Yes, one, and it is measurable: the DB-NULL branch
  in the same method claimed "only Text/Code have a NavValue that can represent one", which BC's
  reader contradicts on the very line above the four cases I transcribed. It accounts for 11 of
  the 41 remaining refusals, all NULL Blobs, including `Sales Header."Work Description"`. Doing the
  same here needs the `NCLMetaField` this method is not handed, and it changes behaviour for every type
  at once, so it is tracked in #2268 rather than folded in. The second commit corrects the refusal
  *message*, which was asserting something untrue about BC.
- **Two paths writing the same state with different invariants?** Checked
  `RecordPatches.InstallBaselineDisk`, which serializes the hydrated store to disk. It already
  lists `NavDate` / `NavDateTime` / `NavTime` / `NavDateFormula` as byte-round-trippable through
  BC's `GetBytes` / `CreateNavValueFromBytes`, so the newly hydrated values survive the baseline
  cache. No gap.

## On the corpus test the issue suggested

I did not open one, and the reason is technical rather than effort. A corpus test runs AL against
a real service tier and cannot observe SQL storage, so it cannot adjudicate a storage encoding —
the most it could assert is that a blank Date round-trips as `0D` through a Record, which the
corpus already covers via existing Date-field fixtures and which any implementation would pass.
The claim at issue is settled instead by BC's own decompiled reader plus the end-to-end round
trip through the real backup above. Opening a PR on the corpus repo also needs approval I do not
have. Happy to add one if you want the coverage anyway.
