### PR TITLE
perf(install-baseline): stop re-inserting the self-populating virtual tables at every boundary

### DIFF
--- a/AlRunner.Tests/CollectionCostOrderer.cs
+++ b/AlRunner.Tests/CollectionCostOrderer.cs
@@ -114,6 +114,17 @@ public sealed class CollectionCostOrderer : ITestCollectionOrderer
             // from this table, fell back to UnmeasuredWeightSeconds and was dispatched at
             // t=181s of a 309s run — a 77s single-threaded tail, the #1887 pattern again.
             ["InstallBaselineDiskCacheTests"] = 125,
+            // #2272: 3 tests, each spawning a real runner subprocess (the app-group one runs
+            // two bundles in a single invocation), all with AL_RUNNER_NO_DEP_COMPANY_CACHE=1
+            // so every spawn pays the dependency Install triggers + Company-Initialize
+            // uncached — which is the whole point of the test and also what makes it heavy.
+            // Absent from this table on its first CI run: measured 60.9s on the BC 28.3 leg,
+            // which tripped check-collection-weights.py, while staying under the top-15 cut
+            // (~50s) on the BC 27.0 leg. Carries the observed maximum, for the same reason
+            // StartupOutputReexecDedupTests below does: at 60.9s its low end sits right on
+            // the 60s freshness threshold, so rounding down to the low end would satisfy the
+            // gate while leaving dispatch order at the fallback and the tail in place.
+            ["InstallBaselineVirtualTableExclusionTests"] = 61,
             ["ServerCancelTests"] = 285,
             // perf/boot-overhead: 37.8s measured on the same run; below the 60s freshness
             // threshold, listed so it is dispatched by measured cost, not by the fallback.

--- a/AlRunner.Tests/InstallBaselineVirtualTableExclusionTests.cs
+++ b/AlRunner.Tests/InstallBaselineVirtualTableExclusionTests.cs
@@ -1,0 +1,382 @@
+using System.Diagnostics;
+using System.Text;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+/// <summary>
+/// Issue #2272 — the self-populating virtual tables (AllObj 2000000038, Field 2000000041,
+/// AllObjWithCaption 2000000058, Table Metadata 2000000136, Page Metadata 2000000138 and
+/// the rest of RecordPatches.IsSelfPopulatingVirtualTableId) were captured into the install
+/// baseline and re-inserted at EVERY codeunit boundary — and, under TestIsolation.Test, at
+/// every test boundary. On a trivial fixture with the Base Application closure that was
+/// 23,651 rows per boundary instead of 278.
+///
+/// They never needed to be there: GetDataAccessForTableCore re-populates each of them on
+/// every access (PopulateAllObjVirtualTable and its siblings) before it hands the data
+/// access back, and the populated-guards those top-ups consult are ConditionalWeakTables
+/// keyed by the in-memory PROVIDER — which a boundary restore replaces — so the table is
+/// re-derived from scratch on the next read whether or not the restore carried its rows.
+/// The on-disk baseline codec has filtered exactly this set out on write since it landed,
+/// so a disk-cache HIT has been running without them on every warm machine already.
+///
+/// The claim under test is BOTH halves, because either alone is worthless:
+///
+///   1. They are gone from the baseline. Asserted from the AL_RUNNER_PERF marker
+///      CaptureInstallBaselineSnapshot logs — which now NAMES the skipped ids rather than
+///      counting them, so "skipped AllObj" and "skipped something that should have been
+///      captured" cannot be confused — plus the per-boundary restore row count, which is
+///      the cost the issue is about.
+///
+///   2. They still answer truthfully afterwards. The fixture's AL asserts AllObj,
+///      AllObjWithCaption, Field, Table Metadata and Page Metadata for concrete objects it
+///      declares itself, positively (the object is there, with the right name) and
+///      negatively (a neighbouring id it does not declare is NOT there) — a stale or
+///      foreign inventory fails the negative half, which a row-count assertion could never
+///      catch. It runs in two symmetric test codeunits, each with two tests, so at least
+///      one boundary of each kind is crossed before an assertion regardless of the order
+///      the executor picks (codeunit order is NOT id order — measured).
+///
+/// The fixture materialises all five tables from its OWN Install trigger, which runs
+/// immediately before CaptureInstallBaseline(). Without that, whether a virtual table was
+/// in the baseline at all would depend on whether Company-Initialize happened to touch it
+/// on the BC version under test, and the marker assertion would be flaky across the matrix.
+///
+/// AL_RUNNER_NO_DEP_COMPANY_CACHE=1 is set so the dependency+company baseline is computed
+/// fresh: on a machine with a warm on-disk baseline the restore already omits these tables
+/// (that is the issue's whole point), and the test would measure the cache rather than the
+/// change.
+///
+/// Spawns the real runner; needs the BC artifact cache. Skips (loudly) when absent.
+/// </summary>
+public class InstallBaselineVirtualTableExclusionTests
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+    private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
+
+    /// <summary>Every table id the fixture's Install trigger materialises, and therefore
+    /// every id the capture must report as skipped. Kept as the literal numbers rather than
+    /// referencing the runner's constants: a test that reads the same constant the
+    /// implementation does cannot notice one of them changing.</summary>
+    private static readonly int[] ExpectedSkippedIds =
+    {
+        2000000038,  // AllObj
+        2000000041,  // Field
+        2000000058,  // AllObjWithCaption
+        2000000136,  // Table Metadata
+        2000000138,  // Page Metadata
+    };
+
+    /// <summary>Ceiling on rows re-inserted at one boundary for this fixture. The measured
+    /// numbers either side are 23,651 (before) and 278 (after), so the bound is nowhere near
+    /// either — it is a statement that the virtual tables are absent, not a perf budget that
+    /// needs re-tuning when the Base App closure grows by a row.</summary>
+    private const int MaxRestoredRowsPerBoundary = 3000;
+
+    private static (string output, int exit) RunRunner(string[] extraArgs, params string[] bundles)
+    {
+        var args = new StringBuilder(TestBuildConfig.RunArgs(ProjectPath));
+        args.Append(TestBuildConfig.BcVersionArg);
+        // The virtual tables only have a meaningful inventory (and Table/Page Metadata only
+        // resolve at all) with the platform apps on the package-cache path.
+        args.Append(" --package-cache \"").Append(TestArtifacts.PlatformAppsDir()).Append('"');
+        foreach (var a in extraArgs) args.Append(' ').Append(a);
+        foreach (var b in bundles) args.Append(" \"").Append(b).Append('"');
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet", Arguments = args.ToString(),
+            RedirectStandardOutput = true, RedirectStandardError = true,
+            UseShellExecute = false, CreateNoWindow = true, WorkingDirectory = RepoRoot,
+            Environment =
+            {
+                ["AL_RUNNER_PERF"] = "1",
+                ["AL_RUNNER_NO_DEP_COMPANY_CACHE"] = "1",
+            },
+        };
+        var sb = new StringBuilder();
+        var p = Process.Start(psi)!;
+        p.OutputDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.ErrorDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.BeginOutputReadLine();
+        p.BeginErrorReadLine();
+        if (!p.WaitForExit(300_000)) { try { p.Kill(true); } catch { } throw new TimeoutException("runner hung"); }
+        p.WaitForExit();
+        lock (sb) return (sb.ToString(), p.ExitCode);
+    }
+
+    private static void WriteFixture(string dir)
+    {
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(Path.Combine(dir, "app.json"), $$"""
+        {
+          "id": "{{Guid.NewGuid()}}",
+          "name": "IT2272 Virtual Table Baseline",
+          "publisher": "IssueTest2272",
+          "version": "1.0.0.0",
+          "dependencies": [],
+          "platform": "1.0.0.0",
+          "application": "1.0.0.0",
+          "idRanges": [ { "from": 62500, "to": 62519 } ],
+          "runtime": "14.0"
+        }
+        """);
+        File.WriteAllText(Path.Combine(dir, "Fixture.al"), """
+        table 62500 "IT2272 Widget"
+        {
+            DataClassification = SystemMetadata;
+            fields
+            {
+                field(1; "No."; Code[20]) { }
+                field(2; Description; Text[50]) { }
+            }
+            keys { key(PK; "No.") { Clustered = true; } }
+        }
+
+        page 62501 "IT2272 Widget Card"
+        {
+            PageType = Card;
+            SourceTable = "IT2272 Widget";
+            layout
+            {
+                area(content)
+                {
+                    field("No."; Rec."No.") { ApplicationArea = All; }
+                    field(Description; Rec.Description) { ApplicationArea = All; }
+                }
+            }
+        }
+
+        codeunit 62505 "IT2272 Install"
+        {
+            Subtype = Install;
+
+            // Materialises every virtual table this fixture asserts on BEFORE the install
+            // baseline is captured, so "was this table in the baseline?" is a deterministic
+            // question on every BC version instead of depending on whether the dependency
+            // Install triggers or Company-Initialize happened to touch it.
+            trigger OnInstallAppPerCompany()
+            var
+                AllObjRec: Record AllObj;
+                AllObjCap: Record AllObjWithCaption;
+                FieldRec: Record "Field";
+                TableMeta: Record "Table Metadata";
+                PageMeta: Record "Page Metadata";
+            begin
+                AllObjRec.SetRange("Object Type", AllObjRec."Object Type"::Table);
+                if AllObjRec.FindFirst() then;
+                AllObjCap.SetRange("Object Type", AllObjCap."Object Type"::Table);
+                if AllObjCap.FindFirst() then;
+                FieldRec.SetRange(TableNo, 62500);
+                if FieldRec.FindFirst() then;
+                if TableMeta.FindFirst() then;
+                if PageMeta.FindFirst() then;
+            end;
+        }
+
+        codeunit 62504 "IT2272 Assert"
+        {
+            procedure IsTrue(Condition: Boolean; Msg: Text)
+            begin
+                if not Condition then
+                    Error('Assert.IsTrue failed. %1', Msg);
+            end;
+
+            procedure IsFalse(Condition: Boolean; Msg: Text)
+            begin
+                if Condition then
+                    Error('Assert.IsFalse failed. %1', Msg);
+            end;
+
+            procedure AreEqual(Expected: Text; Actual: Text; Msg: Text)
+            begin
+                if Expected <> Actual then
+                    Error('Assert.AreEqual failed. Expected <%1>, got <%2>. %3', Expected, Actual, Msg);
+            end;
+
+            // Every assertion is a concrete value for a concrete object, and every one has a
+            // negative twin against id 62599 — an id this app declares nothing at. A restore
+            // that left a stale or foreign inventory behind passes the positive half and
+            // fails the negative one; an empty table fails the positive half. Neither can be
+            // satisfied by a top-up that silently does nothing.
+            procedure CheckVirtualTables()
+            var
+                AllObjRec: Record AllObj;
+                AllObjCap: Record AllObjWithCaption;
+                FieldRec: Record "Field";
+                TableMeta: Record "Table Metadata";
+                PageMeta: Record "Page Metadata";
+                FieldNames: Text;
+            begin
+                IsTrue(AllObjRec.Get(AllObjRec."Object Type"::Table, 62500), 'AllObj must list table 62500');
+                AreEqual('IT2272 Widget', AllObjRec."Object Name", 'AllObj object name for table 62500');
+                IsTrue(AllObjRec.Get(AllObjRec."Object Type"::Page, 62501), 'AllObj must list page 62501');
+                AreEqual('IT2272 Widget Card', AllObjRec."Object Name", 'AllObj object name for page 62501');
+                IsFalse(AllObjRec.Get(AllObjRec."Object Type"::Table, 62599), 'AllObj must NOT list table 62599');
+
+                IsTrue(AllObjCap.Get(AllObjCap."Object Type"::Table, 62500), 'AllObjWithCaption must list table 62500');
+                AreEqual('IT2272 Widget', AllObjCap."Object Name", 'AllObjWithCaption object name for table 62500');
+                IsFalse(AllObjCap.Get(AllObjCap."Object Type"::Table, 62599), 'AllObjWithCaption must NOT list table 62599');
+
+                FieldRec.SetRange(TableNo, 62500);
+                IsTrue(FieldRec.FindSet(), 'Field must have rows for table 62500');
+                repeat
+                    FieldNames += FieldRec."Field Caption" + ';';
+                until FieldRec.Next() = 0;
+                IsTrue(StrPos(FieldNames, 'No.;') > 0, 'Field must list "No." for table 62500, got ' + FieldNames);
+                IsTrue(StrPos(FieldNames, 'Description;') > 0, 'Field must list Description for table 62500, got ' + FieldNames);
+                FieldRec.Reset();
+                FieldRec.SetRange(TableNo, 62599);
+                IsTrue(FieldRec.IsEmpty(), 'Field must have no rows for nonexistent table 62599');
+
+                IsTrue(TableMeta.Get(62500), 'Table Metadata must list 62500');
+                AreEqual('IT2272 Widget', TableMeta.Name, 'Table Metadata name for 62500');
+                IsFalse(TableMeta.Get(62599), 'Table Metadata must NOT list 62599');
+
+                IsTrue(PageMeta.Get(62501), 'Page Metadata must list 62501');
+                IsFalse(PageMeta.Get(62599), 'Page Metadata must NOT list 62599');
+            end;
+        }
+
+        codeunit 62502 "IT2272 Tests A"
+        {
+            Subtype = Test;
+
+            [Test]
+            procedure VirtualTablesAnswerAcrossBoundaryA1()
+            var
+                IT2272Assert: Codeunit "IT2272 Assert";
+            begin
+                IT2272Assert.CheckVirtualTables();
+            end;
+
+            [Test]
+            procedure VirtualTablesAnswerAcrossBoundaryA2()
+            var
+                IT2272Assert: Codeunit "IT2272 Assert";
+            begin
+                IT2272Assert.CheckVirtualTables();
+            end;
+        }
+
+        // Symmetric with A, sharing one body: codeunit execution order is not id order, so a
+        // fixture whose proof depends on which of the two runs first proves nothing.
+        codeunit 62503 "IT2272 Tests B"
+        {
+            Subtype = Test;
+
+            [Test]
+            procedure VirtualTablesAnswerAcrossBoundaryB1()
+            var
+                IT2272Assert: Codeunit "IT2272 Assert";
+            begin
+                IT2272Assert.CheckVirtualTables();
+            end;
+
+            [Test]
+            procedure VirtualTablesAnswerAcrossBoundaryB2()
+            var
+                IT2272Assert: Codeunit "IT2272 Assert";
+            begin
+                IT2272Assert.CheckVirtualTables();
+            end;
+        }
+        """);
+    }
+
+    private static readonly Regex CaptureLine = new(
+        @"InstallBaseline\.Capture .* skipped-self-populating \[([0-9,]*)\]", RegexOptions.Compiled);
+    private static readonly Regex RestoreLine = new(
+        @"InstallBaseline\.Restore (\d+) row\(s\)", RegexOptions.Compiled);
+
+    private static void AssertBaselineExcludesVirtualTablesAndAlPasses(string output, int exitCode)
+    {
+        // [THEN] Every AL assertion above passed — the virtual tables still answer truthfully
+        // for this app's own objects, and still refuse an id it does not declare, after the
+        // boundary restores below.
+        Assert.Equal(0, exitCode);
+        Assert.Contains("4P/0F/0E", output);
+
+        // [THEN] The capture NAMED the tables it left out, and the set covers every one the
+        // fixture's Install trigger materialised. A capture that silently kept one of them
+        // would report a shorter list here, not merely a bigger row count.
+        var captures = CaptureLine.Matches(output);
+        Assert.True(captures.Count > 0,
+            $"expected at least one InstallBaseline.Capture marker naming its skipped tables, got:\n{output}");
+        var lastSkipped = captures[^1].Groups[1].Value
+            .Split(',', StringSplitOptions.RemoveEmptyEntries)
+            .Select(int.Parse)
+            .ToHashSet();
+        foreach (var id in ExpectedSkippedIds)
+            Assert.True(lastSkipped.Contains(id),
+                $"table {id} was materialised by the fixture's Install trigger but the "
+                + $"install-baseline capture did not report skipping it (skipped: "
+                + $"{string.Join(",", lastSkipped.OrderBy(i => i))}) in:\n{output}");
+
+        // [THEN] And the cost the issue is about is gone: no boundary re-inserted the tens of
+        // thousands of rows those tables contribute. Asserted over EVERY restore, not just
+        // the first — the whole point is that this repeats at every boundary.
+        var restores = RestoreLine.Matches(output);
+        Assert.True(restores.Count > 0,
+            $"expected at least one InstallBaseline.Restore marker (no boundary restore "
+            + $"happened, so this test asserted nothing) in:\n{output}");
+        foreach (Match m in restores)
+        {
+            var rows = int.Parse(m.Groups[1].Value);
+            Assert.True(rows <= MaxRestoredRowsPerBoundary,
+                $"a boundary restored {rows} rows, above the {MaxRestoredRowsPerBoundary} ceiling — "
+                + $"the self-populating virtual tables are back in the install baseline. Output:\n{output}");
+        }
+    }
+
+    /// <summary>Default isolation (codeunit): a restore runs at every codeunit boundary.</summary>
+    [SkippableFact]
+    public void CodeunitBoundary_RestoresWithoutSelfPopulatingVirtualTables_AndTheyStillAnswer()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var root = Path.Combine(Path.GetTempPath(), "al-runner-2272-codeunit", Guid.NewGuid().ToString("N"));
+        try
+        {
+            var app = Path.Combine(root, "app");
+            WriteFixture(app);
+            var (output, exitCode) = RunRunner(Array.Empty<string>(), app);
+            AssertBaselineExcludesVirtualTablesAndAlPasses(output, exitCode);
+        }
+        finally
+        {
+            try { Directory.Delete(root, true); } catch { }
+        }
+    }
+
+    /// <summary>TestIsolation.Test: a restore runs at every TEST boundary, so the same
+    /// per-boundary cost is paid once per test rather than once per codeunit. This is the
+    /// multiplier the issue names, and it is a separate code path in TestExecutor from the
+    /// codeunit one above.</summary>
+    [SkippableFact]
+    public void TestBoundary_RestoresWithoutSelfPopulatingVirtualTables_AndTheyStillAnswer()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var root = Path.Combine(Path.GetTempPath(), "al-runner-2272-test", Guid.NewGuid().ToString("N"));
+        try
+        {
+            var app = Path.Combine(root, "app");
+            WriteFixture(app);
+            var (output, exitCode) = RunRunner(new[] { "--isolation", "test" }, app);
+            AssertBaselineExcludesVirtualTablesAndAlPasses(output, exitCode);
+
+            // [THEN] Under TestIsolation.Test every one of the four tests got its own restore
+            // — otherwise the loop above would have asserted the ceiling over the two
+            // codeunit-boundary restores and called that the per-test path.
+            Assert.True(RestoreLine.Matches(output).Count >= 4,
+                $"expected at least one baseline restore per test under --isolation test, got "
+                + $"{RestoreLine.Matches(output).Count} in:\n{output}");
+        }
+        finally
+        {
+            try { Directory.Delete(root, true); } catch { }
+        }
+    }
+}

--- a/AlRunner.Tests/InstallBaselineVirtualTableExclusionTests.cs
+++ b/AlRunner.Tests/InstallBaselineVirtualTableExclusionTests.cs
@@ -76,6 +76,16 @@ public class InstallBaselineVirtualTableExclusionTests
     private const int MaxRestoredRowsPerBoundary = 3000;
 
     private static (string output, int exit) RunRunner(string[] extraArgs, params string[] bundles)
+        => RunRunner(extraArgs, freshDepCompanyBaseline: true, bundles);
+
+    /// <param name="freshDepCompanyBaseline">Sets AL_RUNNER_NO_DEP_COMPANY_CACHE=1. On for the
+    /// single-app-group tests, where a warm on-disk baseline would already omit these tables
+    /// and the run would measure the cache instead of the change. OFF for the app-group test,
+    /// which needs the second app group to take a cache HIT — restoring a snapshot at the
+    /// app-group boundary is the code path under test there, and the kill switch would make
+    /// every app group recompute instead of restore.</param>
+    private static (string output, int exit) RunRunner(
+        string[] extraArgs, bool freshDepCompanyBaseline, params string[] bundles)
     {
         var args = new StringBuilder(TestBuildConfig.RunArgs(ProjectPath));
         args.Append(TestBuildConfig.BcVersionArg);
@@ -89,12 +99,10 @@ public class InstallBaselineVirtualTableExclusionTests
             FileName = "dotnet", Arguments = args.ToString(),
             RedirectStandardOutput = true, RedirectStandardError = true,
             UseShellExecute = false, CreateNoWindow = true, WorkingDirectory = RepoRoot,
-            Environment =
-            {
-                ["AL_RUNNER_PERF"] = "1",
-                ["AL_RUNNER_NO_DEP_COMPANY_CACHE"] = "1",
-            },
+            Environment = { ["AL_RUNNER_PERF"] = "1" },
         };
+        if (freshDepCompanyBaseline)
+            psi.Environment["AL_RUNNER_NO_DEP_COMPANY_CACHE"] = "1";
         var sb = new StringBuilder();
         var p = Process.Start(psi)!;
         p.OutputDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
@@ -106,24 +114,48 @@ public class InstallBaselineVirtualTableExclusionTests
         lock (sb) return (sb.ToString(), p.ExitCode);
     }
 
-    private static void WriteFixture(string dir)
+    /// <summary>Writes one app group. Parameterised by id base and tag so a SECOND, disjoint
+    /// app group can be generated for the app-group-boundary test — AL resolves objects by
+    /// name, so the names have to differ too, not just the ids.
+    ///
+    /// Layout, relative to <paramref name="baseId"/>: +0 table, +1 page, +2 and +3 the two
+    /// symmetric test codeunits, +4 the assert helper, +5 the Install codeunit.</summary>
+    private static void WriteFixture(string dir, int baseId, string tag)
     {
         Directory.CreateDirectory(dir);
         File.WriteAllText(Path.Combine(dir, "app.json"), $$"""
         {
           "id": "{{Guid.NewGuid()}}",
-          "name": "IT2272 Virtual Table Baseline",
+          "name": "IT2272 Virtual Table Baseline {{tag}}",
           "publisher": "IssueTest2272",
           "version": "1.0.0.0",
           "dependencies": [],
           "platform": "1.0.0.0",
           "application": "1.0.0.0",
-          "idRanges": [ { "from": 62500, "to": 62519 } ],
+          "idRanges": [ { "from": {{baseId}}, "to": {{baseId + 19}} } ],
           "runtime": "14.0"
         }
         """);
-        File.WriteAllText(Path.Combine(dir, "Fixture.al"), """
-        table 62500 "IT2272 Widget"
+
+        var al = FixtureAlTemplate
+            .Replace("$TABLE$", (baseId + 0).ToString())
+            .Replace("$PAGE$", (baseId + 1).ToString())
+            .Replace("$TESTSA$", (baseId + 2).ToString())
+            .Replace("$TESTSB$", (baseId + 3).ToString())
+            .Replace("$ASSERT$", (baseId + 4).ToString())
+            .Replace("$INSTALL$", (baseId + 5).ToString())
+            .Replace("$ABSENT$", NeverDeclaredId.ToString())
+            .Replace("$TAG$", tag);
+        File.WriteAllText(Path.Combine(dir, "Fixture.al"), al);
+    }
+
+    /// <summary>An id no app group in any of these runs declares anything at, and which is
+    /// outside every fixture idRange. The negative half of every assertion below rests on
+    /// it, so it must stay outside the ranges if a fixture ever grows.</summary>
+    private const int NeverDeclaredId = 62599;
+
+    private const string FixtureAlTemplate = """
+        table $TABLE$ "IT2272 $TAG$ Widget"
         {
             DataClassification = SystemMetadata;
             fields
@@ -134,10 +166,10 @@ public class InstallBaselineVirtualTableExclusionTests
             keys { key(PK; "No.") { Clustered = true; } }
         }
 
-        page 62501 "IT2272 Widget Card"
+        page $PAGE$ "IT2272 $TAG$ Widget Card"
         {
             PageType = Card;
-            SourceTable = "IT2272 Widget";
+            SourceTable = "IT2272 $TAG$ Widget";
             layout
             {
                 area(content)
@@ -148,7 +180,7 @@ public class InstallBaselineVirtualTableExclusionTests
             }
         }
 
-        codeunit 62505 "IT2272 Install"
+        codeunit $INSTALL$ "IT2272 $TAG$ Install"
         {
             Subtype = Install;
 
@@ -168,14 +200,14 @@ public class InstallBaselineVirtualTableExclusionTests
                 if AllObjRec.FindFirst() then;
                 AllObjCap.SetRange("Object Type", AllObjCap."Object Type"::Table);
                 if AllObjCap.FindFirst() then;
-                FieldRec.SetRange(TableNo, 62500);
+                FieldRec.SetRange(TableNo, $TABLE$);
                 if FieldRec.FindFirst() then;
                 if TableMeta.FindFirst() then;
                 if PageMeta.FindFirst() then;
             end;
         }
 
-        codeunit 62504 "IT2272 Assert"
+        codeunit $ASSERT$ "IT2272 $TAG$ Assert"
         {
             procedure IsTrue(Condition: Boolean; Msg: Text)
             begin
@@ -195,11 +227,14 @@ public class InstallBaselineVirtualTableExclusionTests
                     Error('Assert.AreEqual failed. Expected <%1>, got <%2>. %3', Expected, Actual, Msg);
             end;
 
-            // Every assertion is a concrete value for a concrete object, and every one has a
-            // negative twin against id 62599 — an id this app declares nothing at. A restore
-            // that left a stale or foreign inventory behind passes the positive half and
-            // fails the negative one; an empty table fails the positive half. Neither can be
-            // satisfied by a top-up that silently does nothing.
+            // Every assertion is a concrete value for a concrete object THIS app group
+            // declares, and every one has a negative twin against $ABSENT$ — an id nothing in
+            // the run declares. A restore that left an empty table fails the positive half; a
+            // top-up that silently does nothing fails it too; a table answering for an id that
+            // does not exist fails the negative half. Deliberately says nothing about ANOTHER
+            // app group's objects: those ARE visible here, on this branch and on main alike
+            // (the parsed-object registries accumulate across bundles), which is a separate
+            // pre-existing defect and not something this fixture should encode either way.
             procedure CheckVirtualTables()
             var
                 AllObjRec: Record AllObj;
@@ -209,44 +244,44 @@ public class InstallBaselineVirtualTableExclusionTests
                 PageMeta: Record "Page Metadata";
                 FieldNames: Text;
             begin
-                IsTrue(AllObjRec.Get(AllObjRec."Object Type"::Table, 62500), 'AllObj must list table 62500');
-                AreEqual('IT2272 Widget', AllObjRec."Object Name", 'AllObj object name for table 62500');
-                IsTrue(AllObjRec.Get(AllObjRec."Object Type"::Page, 62501), 'AllObj must list page 62501');
-                AreEqual('IT2272 Widget Card', AllObjRec."Object Name", 'AllObj object name for page 62501');
-                IsFalse(AllObjRec.Get(AllObjRec."Object Type"::Table, 62599), 'AllObj must NOT list table 62599');
+                IsTrue(AllObjRec.Get(AllObjRec."Object Type"::Table, $TABLE$), 'AllObj must list table $TABLE$');
+                AreEqual('IT2272 $TAG$ Widget', AllObjRec."Object Name", 'AllObj object name for table $TABLE$');
+                IsTrue(AllObjRec.Get(AllObjRec."Object Type"::Page, $PAGE$), 'AllObj must list page $PAGE$');
+                AreEqual('IT2272 $TAG$ Widget Card', AllObjRec."Object Name", 'AllObj object name for page $PAGE$');
+                IsFalse(AllObjRec.Get(AllObjRec."Object Type"::Table, $ABSENT$), 'AllObj must NOT list table $ABSENT$');
 
-                IsTrue(AllObjCap.Get(AllObjCap."Object Type"::Table, 62500), 'AllObjWithCaption must list table 62500');
-                AreEqual('IT2272 Widget', AllObjCap."Object Name", 'AllObjWithCaption object name for table 62500');
-                IsFalse(AllObjCap.Get(AllObjCap."Object Type"::Table, 62599), 'AllObjWithCaption must NOT list table 62599');
+                IsTrue(AllObjCap.Get(AllObjCap."Object Type"::Table, $TABLE$), 'AllObjWithCaption must list table $TABLE$');
+                AreEqual('IT2272 $TAG$ Widget', AllObjCap."Object Name", 'AllObjWithCaption object name for table $TABLE$');
+                IsFalse(AllObjCap.Get(AllObjCap."Object Type"::Table, $ABSENT$), 'AllObjWithCaption must NOT list table $ABSENT$');
 
-                FieldRec.SetRange(TableNo, 62500);
-                IsTrue(FieldRec.FindSet(), 'Field must have rows for table 62500');
+                FieldRec.SetRange(TableNo, $TABLE$);
+                IsTrue(FieldRec.FindSet(), 'Field must have rows for table $TABLE$');
                 repeat
                     FieldNames += FieldRec."Field Caption" + ';';
                 until FieldRec.Next() = 0;
-                IsTrue(StrPos(FieldNames, 'No.;') > 0, 'Field must list "No." for table 62500, got ' + FieldNames);
-                IsTrue(StrPos(FieldNames, 'Description;') > 0, 'Field must list Description for table 62500, got ' + FieldNames);
+                IsTrue(StrPos(FieldNames, 'No.;') > 0, 'Field must list "No." for table $TABLE$, got ' + FieldNames);
+                IsTrue(StrPos(FieldNames, 'Description;') > 0, 'Field must list Description for table $TABLE$, got ' + FieldNames);
                 FieldRec.Reset();
-                FieldRec.SetRange(TableNo, 62599);
-                IsTrue(FieldRec.IsEmpty(), 'Field must have no rows for nonexistent table 62599');
+                FieldRec.SetRange(TableNo, $ABSENT$);
+                IsTrue(FieldRec.IsEmpty(), 'Field must have no rows for nonexistent table $ABSENT$');
 
-                IsTrue(TableMeta.Get(62500), 'Table Metadata must list 62500');
-                AreEqual('IT2272 Widget', TableMeta.Name, 'Table Metadata name for 62500');
-                IsFalse(TableMeta.Get(62599), 'Table Metadata must NOT list 62599');
+                IsTrue(TableMeta.Get($TABLE$), 'Table Metadata must list $TABLE$');
+                AreEqual('IT2272 $TAG$ Widget', TableMeta.Name, 'Table Metadata name for $TABLE$');
+                IsFalse(TableMeta.Get($ABSENT$), 'Table Metadata must NOT list $ABSENT$');
 
-                IsTrue(PageMeta.Get(62501), 'Page Metadata must list 62501');
-                IsFalse(PageMeta.Get(62599), 'Page Metadata must NOT list 62599');
+                IsTrue(PageMeta.Get($PAGE$), 'Page Metadata must list $PAGE$');
+                IsFalse(PageMeta.Get($ABSENT$), 'Page Metadata must NOT list $ABSENT$');
             end;
         }
 
-        codeunit 62502 "IT2272 Tests A"
+        codeunit $TESTSA$ "IT2272 $TAG$ Tests A"
         {
             Subtype = Test;
 
             [Test]
             procedure VirtualTablesAnswerAcrossBoundaryA1()
             var
-                IT2272Assert: Codeunit "IT2272 Assert";
+                IT2272Assert: Codeunit "IT2272 $TAG$ Assert";
             begin
                 IT2272Assert.CheckVirtualTables();
             end;
@@ -254,7 +289,7 @@ public class InstallBaselineVirtualTableExclusionTests
             [Test]
             procedure VirtualTablesAnswerAcrossBoundaryA2()
             var
-                IT2272Assert: Codeunit "IT2272 Assert";
+                IT2272Assert: Codeunit "IT2272 $TAG$ Assert";
             begin
                 IT2272Assert.CheckVirtualTables();
             end;
@@ -262,14 +297,14 @@ public class InstallBaselineVirtualTableExclusionTests
 
         // Symmetric with A, sharing one body: codeunit execution order is not id order, so a
         // fixture whose proof depends on which of the two runs first proves nothing.
-        codeunit 62503 "IT2272 Tests B"
+        codeunit $TESTSB$ "IT2272 $TAG$ Tests B"
         {
             Subtype = Test;
 
             [Test]
             procedure VirtualTablesAnswerAcrossBoundaryB1()
             var
-                IT2272Assert: Codeunit "IT2272 Assert";
+                IT2272Assert: Codeunit "IT2272 $TAG$ Assert";
             begin
                 IT2272Assert.CheckVirtualTables();
             end;
@@ -277,26 +312,27 @@ public class InstallBaselineVirtualTableExclusionTests
             [Test]
             procedure VirtualTablesAnswerAcrossBoundaryB2()
             var
-                IT2272Assert: Codeunit "IT2272 Assert";
+                IT2272Assert: Codeunit "IT2272 $TAG$ Assert";
             begin
                 IT2272Assert.CheckVirtualTables();
             end;
         }
-        """);
-    }
+        """;
 
     private static readonly Regex CaptureLine = new(
         @"InstallBaseline\.Capture .* skipped-self-populating \[([0-9,]*)\]", RegexOptions.Compiled);
     private static readonly Regex RestoreLine = new(
         @"InstallBaseline\.Restore (\d+) row\(s\)", RegexOptions.Compiled);
 
-    private static void AssertBaselineExcludesVirtualTablesAndAlPasses(string output, int exitCode)
+    private static void AssertBaselineExcludesVirtualTablesAndAlPasses(
+        string output, int exitCode, int expectedPassGroups = 1)
     {
         // [THEN] Every AL assertion above passed — the virtual tables still answer truthfully
         // for this app's own objects, and still refuse an id it does not declare, after the
         // boundary restores below.
         Assert.Equal(0, exitCode);
-        Assert.Contains("4P/0F/0E", output);
+        Assert.True(CountOccurrences(output, "4P/0F/0E") >= expectedPassGroups,
+            $"expected {expectedPassGroups} app group(s) reporting 4P/0F/0E, got:\n{output}");
 
         // [THEN] The capture NAMED the tables it left out, and the set covers every one the
         // fixture's Install trigger materialised. A capture that silently kept one of them
@@ -340,7 +376,7 @@ public class InstallBaselineVirtualTableExclusionTests
         try
         {
             var app = Path.Combine(root, "app");
-            WriteFixture(app);
+            WriteFixture(app, 62500, "A");
             var (output, exitCode) = RunRunner(Array.Empty<string>(), app);
             AssertBaselineExcludesVirtualTablesAndAlPasses(output, exitCode);
         }
@@ -363,7 +399,7 @@ public class InstallBaselineVirtualTableExclusionTests
         try
         {
             var app = Path.Combine(root, "app");
-            WriteFixture(app);
+            WriteFixture(app, 62500, "A");
             var (output, exitCode) = RunRunner(new[] { "--isolation", "test" }, app);
             AssertBaselineExcludesVirtualTablesAndAlPasses(output, exitCode);
 
@@ -378,5 +414,69 @@ public class InstallBaselineVirtualTableExclusionTests
         {
             try { Directory.Delete(root, true); } catch { }
         }
+    }
+
+    /// <summary>
+    /// The app-group boundary — a THIRD restore call site, and the one the issue's
+    /// cross-bundle question hangs on. Two app groups with the identical (empty) dependency
+    /// closure: the first computes the dep+company baseline, the second takes a cache HIT and
+    /// is restored from it (TestExecutor.Run's HIT branch calls
+    /// RestoreInstallBaselineSnapshot directly, not via the codeunit-boundary path the other
+    /// two tests exercise). The kill switch is deliberately NOT set here, because with it on
+    /// there would be no restore at that boundary at all.
+    ///
+    /// Each app group asserts only its OWN objects, positively and negatively. It does not
+    /// assert anything about the other app group's objects: those are visible in AllObj and
+    /// Table Metadata here, and were equally visible before this change — measured on both,
+    /// with byte-identical results — because the parsed-object registries accumulate across
+    /// bundles in the CLI run loop and the top-up therefore reports the union. That is a
+    /// separate pre-existing defect (tracked on its own), and encoding it here in either
+    /// direction would be wrong.
+    /// </summary>
+    [SkippableFact]
+    public void AppGroupBoundary_RestoredFromCachedBaselineWithoutVirtualTables_AndTheyStillAnswer()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var root = Path.Combine(Path.GetTempPath(), "al-runner-2272-appgroup", Guid.NewGuid().ToString("N"));
+        try
+        {
+            var appA = Path.Combine(root, "app-a");
+            var appB = Path.Combine(root, "app-b");
+            WriteFixture(appA, 62500, "A");
+            WriteFixture(appB, 62520, "B");
+
+            var (output, exitCode) = RunRunner(
+                Array.Empty<string>(), freshDepCompanyBaseline: false, appA, appB);
+
+            // [THEN] Both app groups' four tests passed — each one's own objects resolve, by
+            // name, in all five virtual tables, on the far side of the app-group boundary.
+            Assert.Equal(0, exitCode);
+            Assert.True(CountOccurrences(output, "4P/0F/0E") >= 2,
+                $"expected both app groups to report 4P/0F/0E, got:\n{output}");
+
+            // [THEN] The second app group really was RESTORED from the first's snapshot rather
+            // than recomputing — without this the test would be two independent app groups
+            // that never crossed the boundary it claims to cover.
+            Assert.True(CountOccurrences(output, "InstallBaseline.DepCompanyCache HIT") >= 1,
+                $"expected the second app group to take an in-memory dep+company cache HIT, got:\n{output}");
+
+            // [THEN] And the snapshot it was restored from carried no virtual tables, at any
+            // boundary, in either app group.
+            AssertBaselineExcludesVirtualTablesAndAlPasses(output, exitCode, expectedPassGroups: 2);
+        }
+        finally
+        {
+            try { Directory.Delete(root, true); } catch { }
+        }
+    }
+
+    private static int CountOccurrences(string haystack, string needle)
+    {
+        var n = 0;
+        for (var i = haystack.IndexOf(needle, StringComparison.Ordinal); i >= 0;
+             i = haystack.IndexOf(needle, i + needle.Length, StringComparison.Ordinal))
+            n++;
+        return n;
     }
 }

--- a/AlRunner/Patches/RecordPatches.InstallBaseline.cs
+++ b/AlRunner/Patches/RecordPatches.InstallBaseline.cs
@@ -17,6 +17,13 @@
 //   Rows are deep-copied on both capture and restore, so a test mutating a restored row
 //   cannot corrupt the baseline for the next codeunit.
 //
+//   NOT snapshotted: the self-populating virtual tables (AllObj, Field, Table Metadata and
+//   the rest of IsSelfPopulatingVirtualTableId). They are projections of the loaded-object
+//   set that GetDataAccessForTableCore re-derives on every access, so a boundary restore
+//   that carried them re-inserted ~22k rows it did not need, and then paid for them a second
+//   time when the top-up re-attempted every insert against the fresh provider. See the
+//   comment at the skip in CaptureInstallBaselineSnapshot (#2272).
+//
 // MEASURED (Pageworks 28.2, 1076 tests, same build, same session)
 //   test run 163.0s -> 78.8s (2.07x), byte-identical outcomes: 964P/112F with the same
 //   failing test set. al-language corpus failure set also byte-identical.
@@ -112,6 +119,21 @@ public static partial class RecordPatches
     /// </summary>
     internal static void AppendBaselineTable(object source, int tableId, object metaTable, NavValue[][] pristineRows)
     {
+        // #2272: the capture path refuses to put a self-populating virtual table in a
+        // baseline, and this is the only OTHER writer of the same lists — a table appended
+        // here would survive every boundary restore exactly as if it had been captured, so
+        // the two writers have to agree or the invariant is only half enforced.
+        //
+        // Unreachable today, and loudly so rather than silently skipped: the lazy loader that
+        // calls this fires from GetDataAccessForTableCore's fall-through path, which every
+        // virtual table returns before reaching. If that ever changes, re-seeding a projection
+        // table from a backup is a bug worth stopping on, not one worth absorbing.
+        if (IsSelfPopulatingVirtualTableId(tableId))
+            throw new InvalidOperationException(
+                $"install-baseline — table {tableId} is a self-populating virtual table "
+                + "(see IsSelfPopulatingVirtualTableId) and must not be appended to an install "
+                + "baseline; GetDataAccessForTableCore re-derives it on every access.");
+
         var rows = new NavValue[pristineRows.Length][];
         for (var i = 0; i < pristineRows.Length; i++)
             rows[i] = CloneValues(pristineRows[i]);
@@ -170,11 +192,46 @@ public static partial class RecordPatches
     internal static InstallBaselineSnapshot CaptureInstallBaselineSnapshot()
     {
         var sources = new List<BaselineSource>();
+        // Diagnostic only (the PerfTrace line below). At most ten ids, so collecting them
+        // unconditionally costs nothing worth gating.
+        var skippedVirtual = new List<int>();
         foreach (var (source, perTable) in _dataAccessByTable)
         {
             var tables = new List<BaselineTable>();
             foreach (var (tableId, dataAccess) in perTable)
             {
+                // ── Self-populating virtual tables are not install-trigger output (#2272) ──
+                // AllObj, AllObjWithCaption, Field, Table/Page/Report Metadata and their
+                // siblings are projections of the loaded-object set, and
+                // GetDataAccessForTableCore re-populates each of them on EVERY access
+                // (PopulateAllObjVirtualTable & co.) before it hands the data access back.
+                // Their populated-guards are ConditionalWeakTables keyed by the in-memory
+                // PROVIDER, and a boundary restore builds a brand-new provider, so a
+                // restored table is re-derived from scratch on the next access either way —
+                // carrying the rows across the boundary buys nothing.
+                //
+                // It cost, though. On a trivial fixture with the Base Application closure the
+                // capture was 41 tables / 23,651 rows, of which 22,354 rows were these
+                // tables; every codeunit (or, under TestIsolation.Test, every test) boundary
+                // re-inserted all of them, ~95 ms each. And because the restore hands the new
+                // provider an empty populated-guard, the very next access then re-attempted
+                // every one of those inserts and swallowed a NavRecordAlreadyExistsException
+                // per row — so the rows were paid for twice per boundary.
+                //
+                // This is the same filter the on-disk codec already applies on write
+                // (RecordPatches.InstallBaselineDisk.cs), which is why a disk-cache HIT has
+                // been running without these tables in its baseline on every warm machine
+                // since that landed. NOT the cross-bundle-leak argument from that file's
+                // header: in one process the parsed-object registries accumulate across
+                // bundles anyway (Program.cs's run loop never resets them), so the top-up
+                // already reports the union — dropping the rows here changes what it costs,
+                // not what it answers.
+                if (IsSelfPopulatingVirtualTableId(tableId))
+                {
+                    skippedVirtual.Add(tableId);
+                    continue;
+                }
+
                 var provider = GetDataProvider(dataAccess);
                 if (provider == null)
                     continue;
@@ -217,8 +274,13 @@ public static partial class RecordPatches
             TenantStoragePatches.CaptureInstallBaseline(),
             RecordLinkPatches.CaptureInstallBaseline(),
             BcRuntime.CaptureAutoIncrementBaseline());
+        skippedVirtual.Sort();
         PerfTrace.Log($"InstallBaseline.Capture {sources.Sum(s => s.Tables.Count)} table(s), " +
-                      $"{sources.Sum(s => s.Tables.Sum(t => t.Rows.Length))} row(s)" +
+                      $"{sources.Sum(s => s.Tables.Sum(t => t.Rows.Length))} row(s), " +
+                      // #2272: named, not just counted — "which tables were left out" is the
+                      // whole claim, and a bare count cannot distinguish "skipped AllObj" from
+                      // "skipped something that should have been captured".
+                      $"skipped-self-populating [{string.Join(",", skippedVirtual)}]" +
                       // #1867: a content digest, not just counts — lets a diagnostic run compare
                       // "the dep+company baseline this app group got via a cache HIT" against
                       // "what a fresh, uncached capture for that same app group would have
@@ -239,12 +301,14 @@ public static partial class RecordPatches
     ///
     /// #1867 root-cause note: two DIFFERENT digests for the same conceptual dependency
     /// closure are EXPECTED and do not indicate drift. Two known, faithful sources of
-    /// non-determinism guarantee it:
+    /// non-determinism guaranteed it:
     ///   1. System/virtual metadata tables (id >= 2,000,000,000, e.g. Field 2000000041)
     ///      are process-wide caches of loaded-assembly schema by design (see the
     ///      Field-virtual-table comment above GetDataAccessForTableCore) — they grow
     ///      monotonically as more test assemblies load into the process, independent of
-    ///      install-trigger/company-init business logic.
+    ///      install-trigger/company-init business logic. NO LONGER A SOURCE since #2272:
+    ///      the self-populating ones are not captured at all, so they cannot move the
+    ///      digest. The rest of the note stands.
     ///   2. Business rows carry BC-native SystemId (a GUID) and SystemCreatedAt/
     ///      SystemModifiedAt (wall-clock) fields assigned by the unmodified BC Insert path
     ///      at insert time (precompiled-dll-respect.md — we don't touch that). A fresh

--- a/AlRunner/TestExecutor.cs
+++ b/AlRunner/TestExecutor.cs
@@ -178,9 +178,10 @@ public sealed class TestExecutor
     // would corrupt every subsequent app group sharing this dep key, not just one. And the
     // virtual/system metadata tables (Field, AllObj, AllObjWithCaption, table id ≥
     // 2,000,000,000) that grow monotonically as more test assemblies load in-process are not
-    // a staleness hazard for a HIT either: GetDataAccessForTableCore re-populates them on
-    // EVERY access as an idempotent top-up, so restoring an earlier app group's narrower
-    // subset self-corrects on the next read.
+    // a staleness hazard for a HIT either — since #2272 they are not in the snapshot at all:
+    // CaptureInstallBaselineSnapshot skips every IsSelfPopulatingVirtualTableId table because
+    // GetDataAccessForTableCore re-populates them on EVERY access as an idempotent top-up, so
+    // a restore that omits them is re-derived in full on the next read.
     //
     // NOT cached here: the bundle's OWN test assembly's Install triggers
     // (InstallTriggerRunner.RunTestAssemblyOnly, genuinely per-app-group, always re-run) and


### PR DESCRIPTION
Closes #2272

## What was wrong

`RestoreInstallBaselineSnapshot` re-inserted every row in the install baseline at every
codeunit boundary, and under `TestIsolation = Test` at every test boundary. The baseline
included the self-populating virtual tables — `AllObj` (2000000038), `Field` (2000000041),
`AllObjWithCaption` (2000000058), `Table Metadata` (2000000136), `Page Metadata`
(2000000138) and the rest of `IsSelfPopulatingVirtualTableId`.

Those tables are not install-trigger output. They are projections of the loaded-object set,
and `GetDataAccessForTableCore` re-populates each of them on every access
(`PopulateAllObjVirtualTable` and its siblings) before it hands the data access back. The
populated-guards those top-ups consult are `ConditionalWeakTable`s keyed by the in-memory
**provider**, and a boundary restore builds a brand-new provider — so a restored table is
re-derived from scratch on the next read whether or not the restore carried its rows.

Carrying them cost twice per boundary, not once. The restore re-inserted the rows, and then
the next access re-attempted every one of those inserts against the fresh, empty
populated-guard and swallowed a `NavRecordAlreadyExistsException` per row
(`InsertAllObjRow`'s catch block).

`CaptureInstallBaselineSnapshot` now skips them, which is the same filter
`TrySerializeInstallBaselineSnapshot` has applied on write since the on-disk baseline
landed. That is why a disk-cache HIT has been running without these tables in its baseline
on every warm machine already.

## This is a performance fix, not a correctness fix — measured, not reasoned

`RecordPatches.InstallBaselineDisk.cs`'s header argues the exclusion partly on correctness:
a file written by one bundle would leak a foreign object inventory into another, and the
top-up only ADDS rows so it can never remove them. If the same leak happened in-memory
across app groups, this would be a correctness fix that is also faster — a different claim.

So I measured it instead of arguing it. Two app groups, each declaring one table in its own
id range, each asserting the other's table is absent from `AllObj` and `Table Metadata`:

```
PASS  Codeunit62601.OtherAppGroupsObjectsMustNotBeVisible
FAIL  Codeunit62611.OtherAppGroupsObjectsMustNotBeVisible
      NavNCLDialogException: LEAK: AllObj in app group B lists foreign table 62600 (LeakProbe A Table)
```

**Byte-identical on `origin/main` and on this branch** — same test passing, same test
failing, same message. The leak is real, but it does not come through the baseline: in a CLI
run the parsed-object registries accumulate across bundles (`Program.cs`'s run loop calls
`AddSourceDirs` per bundle and never resets them — its own comment records that resetting per
bundle broke app+test-app pairs), so `EnumerateKnownAlObjects` already reports the union and
the top-up already re-derives it at every access. Dropping the rows from the baseline changes
what a boundary costs, not what the tables answer.

Filed separately as #2279. This PR neither causes nor fixes it, and the proving test
deliberately asserts nothing about it in either direction.

The cross-process case is genuinely different, so the disk codec's argument still stands as
written: a file is keyed by a dependency set that says nothing about which test assemblies
were loaded.

## Measured

`AL_RUNNER_NO_DEP_COMPANY_CACHE=1` (fresh dep+company baseline — what a cold-cache CI
process does), BC 28.1, same build either side.

Single trivial app group with the Base Application closure:

| | capture | rows per boundary restore | restore time |
|---|---|---|---|
| before | 43 tables / 29,519 rows | 29,519 | 127 ms, 119 ms |
| after | 38 tables / 278 rows | 278 | 3 ms, 1 ms |

The whole al-language corpus, 273 boundaries:

| | capture | rows per restore | total restore time | test run |
|---|---|---|---|---|
| before | 44 tables / 25,963 rows | 25,963 | 30,616 ms | 45.0s |
| after | 41 tables / 286 rows | 286 | 356 ms | 18.9s |

2204/2204 pass either way. On a machine whose on-disk baseline is already warm the corpus was
unaffected (286 rows, 1–2 ms per restore before and after) — that is the issue's own point,
and it is why the measurements above force the fresh-capture path.

The `InstallBaseline.Capture` perf marker now names the ids it skipped rather than only
counting tables, so "skipped AllObj" and "skipped something that should have been captured"
cannot be confused in a log or an assertion.

## Proving test

`AlRunner.Tests/InstallBaselineVirtualTableExclusionTests.cs` — three spawned-runner tests,
one per restore call site: codeunit boundary, test boundary (`--isolation test`), and
app-group boundary (two app groups sharing a dependency closure, the second restored from the
first's cached snapshot through `TestExecutor.Run`'s HIT branch, which is a different call
site from the other two).

The fixture declares its own table and page and materialises all five virtual tables from its
own `Install` codeunit, so "was it in the baseline?" is deterministic on every BC version
rather than depending on whether Company-Initialize happened to touch it.

Both halves are asserted, because either alone is worthless:

- The tables are gone: the capture marker names all five skipped ids, and no boundary restore
  exceeds a 3,000-row ceiling (measured 29,519 before, 278 after).
- They still answer: the AL asserts `AllObj`, `AllObjWithCaption`, `Field`, `Table Metadata`
  and `Page Metadata` for concrete objects the app declares, positively (present, with the
  right name) and negatively (id 62599, which nothing in the run declares, is absent). An
  empty table fails the positive half; a table answering for a nonexistent id fails the
  negative half. Two symmetric test codeunits with two tests each, because codeunit execution
  order is not id order.

RED → GREEN, run with the implementation file reverted to `origin/main` and back:

- RED: all fail. The AL still passes 4P/0F/0E on `origin/main` — the correctness half is
  unchanged by this PR, which is the point.
- GREEN: all pass.

## Fixing the shape, not just the reported line

1. **Same wrong pattern at another call site?** `RecordPatches.TransactionSnapshot.cs` is the
   other place that copies rows out of `_dataAccessByTable` and puts them back
   (`NoteTransactionWrite` / `RollbackToCommitPoint`). It does not have this shape: it only
   ever snapshots the one table an AL *write* targets, and AL does not write to a virtual
   table, so these tables never enter it. It also restores exactly what it captured into the
   same provider, so there is no stale-inventory question. Left alone deliberately.
2. **Sibling function making the same assumption?** `CaptureInstallBaseline()` goes through
   `CaptureInstallBaselineSnapshot()`, so the same filter covers it.
3. **Two code paths writing the same state?** Yes — `AppendBaselineTable` (#2262's lazy
   `--test-data` load) is the other writer of the same baseline lists, and it had no such
   guard. A table appended there would survive every boundary restore exactly as if it had
   been captured. It is unreachable today (the lazy loader fires from
   `GetDataAccessForTableCore`'s fall-through, which every virtual table returns before
   reaching), so it now throws rather than silently skipping — re-seeding a projection table
   from a backup is a bug worth stopping on, not one worth absorbing.

## Run locally

At this head (`72198707`): the three new tests, GREEN — and RED with the implementation file
reverted to `origin/main`.

At the first commit (`be0bcf85`), whose `AlRunner/` diff is identical to this head — the
second commit only adds the app-group test:

- `dotnet test AlRunner.Tests` — 1312 passed, 0 failed, 69 skipped.
- al-language corpus — 2204/2204, run twice (cold then warm compile cache), plus once more on
  the fresh-capture path for the measurement above.
- `tests/runner-extras` — 200/200.

CI re-runs all of it across the eight BC legs, which is the gate for a change on this path.

## CI

Green on `1f78f34b`, all eight BC legs, 19/19 checks.

Two things came up on the way there, both recorded rather than glossed:

- **BC 28.3 failed `scripts/check-collection-weights.py`.** The new test class cost 60.9s
  there and was absent from `CollectionCostOrderer.MeasuredWeightSeconds`, so it fell back to
  `UnmeasuredWeightSeconds` (30s) and could be dispatched as a late single-threaded tail —
  the #1887 pattern the gate exists to catch. Fixed by registering it at its observed maximum
  (61), following the convention `StartupOutputReexecDedupTests` documents for a class whose
  low end sits on the threshold.
- **BC 28.1 aborted `WatchBurstSwitchTests.Watch_BulkFileSwitch_SettlesToCorrectResult`**
  (`subprocess exited early ... exit=134`, i.e. SIGABRT) on the middle commit. I am not
  calling that unrelated: an unregistered 60s collection is exactly the thing that gets
  scheduled alongside other heavy spawns, and this file's own header notes that a fifth
  concurrent heavy spawn is a memory risk on a 16 GB runner. It did not recur once the weight
  was registered, and the identical `AlRunner/` diff had already passed all eight legs on the
  first commit. Worth knowing if it shows up again.
