### PR TITLE
feat(diagnostics): explain a failure caused by a table with no rows

### DIFF
--- a/AlRunner.Tests/MissingTestDataDiagnosisTests.cs
+++ b/AlRunner.Tests/MissingTestDataDiagnosisTests.cs
@@ -1,0 +1,337 @@
+// MissingTestDataDiagnosisTests — the proving tests for issue #2240's diagnostic half.
+//
+// WHAT IS BEING PROVED, AND WHY IT IS ASSERTED ON THE CONSOLE OUTPUT
+//   The claim is "a developer whose suite failed on missing setup data can tell that from the
+//   output". So the assertions read the actual per-test lines the runner printed, not an
+//   internal classification value. That distinction has cost this repo real defects before:
+//   #2261 shipped a diagnosis whose actionable half never reached anyone because the bundle
+//   reporter keeps only line 1 of the message. An assertion on an internal result cannot see
+//   that; an assertion on the printed block can.
+//
+// WHY IT LIVES HERE AND NOT IN tests/runner-extras/
+//   The claim is about the RUNNER's output, not about what Business Central does with AL, so
+//   .claude/rules/bc-behavior-tests-go-upstream.md does not send it to the corpus. It also
+//   cannot be an AL bundle: an AL test cannot assert on the reporter's own stdout, which is
+//   the only place the diagnosis exists.
+//
+// THE NEGATIVE IS THE IMPORTANT ONE
+//   PopulatedTable_* below fails with the SAME exception type and the SAME message shape as
+//   the positive case — `NavCSideRecordNotFoundException: The <table> does not exist.` — and
+//   must get NO explanation, because the table has a row in it. An implementation that
+//   pattern-matched BC's wording instead of checking the store would pass every other test
+//   here and fail that one. It is the test that makes the rest mean something.
+using System.Diagnostics;
+using System.Text;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class MissingTestDataDiagnosisTests : IDisposable
+{
+    private static readonly string RepoRoot = Path.GetFullPath(
+        Path.Combine(AppContext.BaseDirectory, "..", "..", "..", ".."));
+    private static readonly string ProjectPath = Path.Combine(RepoRoot, "AlRunner");
+
+    /// <summary>BC's own id for "Source Code Setup". Asserted literally so the diagnosis has to
+    /// have RESOLVED the table against real metadata; echoing a name back out of the message
+    /// would not produce it.</summary>
+    private const int SourceCodeSetupTableId = 242;
+
+    private readonly string _root;
+
+    public MissingTestDataDiagnosisTests()
+    {
+        _root = Path.Combine(Path.GetTempPath(), "al-runner-missing-test-data", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_root);
+        WriteFixture(_root);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { }
+    }
+
+    // ────────────────────────────────────────────────────────── the fixture ──
+
+    /// <summary>
+    /// Four failures, chosen so that the two that must be explained and the two that must not
+    /// are indistinguishable by exception type or message shape:
+    ///
+    ///   EmptySetupTable_Get       — record-not-found on a table with NO rows        → explained
+    ///   PopulatedTable_Get        — record-not-found on a table WITH a row          → not explained
+    ///   EmptySetupTable_TestField — TestField on a table with NO rows               → explained
+    ///   PopulatedTable_TestField  — TestField on a table WITH a row                 → not explained
+    ///   PlainError                — an ordinary AL Error naming no table            → not explained
+    ///
+    /// "Source Code Setup" is the table #2240 measured 12 of its 16 failures on. "Payment
+    /// Method" is a Base App table the runner starts empty and this fixture inserts into, so
+    /// "populated" is a fact the test creates rather than one it inherits.
+    /// </summary>
+    private static void WriteFixture(string dir)
+    {
+        File.WriteAllText(Path.Combine(dir, "app.json"), """
+        {
+          "id": "b7c1d2e3-4f50-4a61-9b72-8c3d4e5f6a7b",
+          "name": "Missing Test Data Diagnosis Fixture",
+          "publisher": "AL Runner",
+          "version": "1.0.0.0",
+          "dependencies": [],
+          "platform": "27.0.0.0",
+          "application": "27.0.0.0",
+          "idRanges": [ { "from": 62440, "to": 62449 } ],
+          "runtime": "17.0",
+          "target": "Cloud"
+        }
+        """);
+
+        File.WriteAllText(Path.Combine(dir, "MissingSetupTests.Codeunit.al"), """
+        codeunit 62440 "Missing Setup Diag Tests"
+        {
+            Subtype = Test;
+
+            [Test]
+            procedure EmptySetupTable_Get()
+            var
+                SourceCodeSetup: Record "Source Code Setup";
+            begin
+                SourceCodeSetup.Get();
+            end;
+
+            [Test]
+            procedure PopulatedTable_Get()
+            var
+                PaymentMethod: Record "Payment Method";
+            begin
+                PaymentMethod.Init();
+                PaymentMethod.Code := 'DIAG-A';
+                PaymentMethod.Description := 'populated on purpose';
+                PaymentMethod.Insert(true);
+                PaymentMethod.Get('NOPE');
+            end;
+
+            [Test]
+            procedure EmptySetupTable_TestField()
+            var
+                SourceCodeSetup: Record "Source Code Setup";
+            begin
+                SourceCodeSetup.Init();
+                SourceCodeSetup.TestField("Sales Journal");
+            end;
+
+            [Test]
+            procedure PopulatedTable_TestField()
+            var
+                PaymentMethod: Record "Payment Method";
+            begin
+                PaymentMethod.Init();
+                PaymentMethod.Code := 'DIAG-B';
+                PaymentMethod.Insert(true);
+                PaymentMethod.TestField(Description);
+            end;
+
+            [Test]
+            procedure PlainError()
+            begin
+                Error('two plus two is %1, not 5', 2 + 2);
+            end;
+        }
+        """);
+    }
+
+    // ─────────────────────────────────────────────────── running the runner ──
+
+    private (string output, int exit) RunRunner(IDictionary<string, string>? env = null,
+                                                params string[] extraArgs)
+    {
+        var args = new StringBuilder(TestBuildConfig.RunArgs(ProjectPath));
+        args.Append(TestBuildConfig.BcVersionArg);
+        args.Append($" \"{_root}\"");
+        foreach (var a in extraArgs) args.Append($" {a}");
+        var psi = new ProcessStartInfo
+        {
+            FileName = "dotnet", Arguments = args.ToString(),
+            RedirectStandardOutput = true, RedirectStandardError = true,
+            UseShellExecute = false, CreateNoWindow = true, WorkingDirectory = RepoRoot,
+        };
+        if (env != null)
+            foreach (var (k, v) in env) psi.Environment[k] = v;
+        var sb = new StringBuilder();
+        var p = Process.Start(psi)!;
+        p.OutputDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.ErrorDataReceived += (_, e) => { if (e.Data != null) lock (sb) sb.AppendLine(e.Data); };
+        p.BeginOutputReadLine();
+        p.BeginErrorReadLine();
+        if (!p.WaitForExit(300_000)) { try { p.Kill(true); } catch { } throw new TimeoutException("runner hung"); }
+        p.WaitForExit();
+        lock (sb) return (sb.ToString(), p.ExitCode);
+    }
+
+    /// <summary>
+    /// The reported block for one test: its FAIL/ERROR header line plus every indented
+    /// continuation line under it. This is exactly what a developer reads, which is why the
+    /// assertions below are written against it rather than against the whole log — "the output
+    /// contains no diagnosis" would otherwise be satisfiable by the diagnosis simply landing
+    /// under the wrong test.
+    /// </summary>
+    private static string BlockFor(string output, string testMethod)
+    {
+        var lines = output.Replace("\r\n", "\n").Split('\n');
+        var block = new StringBuilder();
+        var inBlock = false;
+        foreach (var line in lines)
+        {
+            var isHeader = line.StartsWith("FAIL ", StringComparison.Ordinal)
+                        || line.StartsWith("PASS ", StringComparison.Ordinal)
+                        || line.StartsWith("ERROR", StringComparison.Ordinal)
+                        || line.StartsWith("SKIP ", StringComparison.Ordinal);
+            if (isHeader)
+            {
+                if (inBlock) break;
+                inBlock = line.Contains($".{testMethod} (", StringComparison.Ordinal);
+                if (inBlock) block.AppendLine(line);
+                continue;
+            }
+            if (inBlock) block.AppendLine(line);
+        }
+        Assert.True(block.Length > 0,
+            $"no reported block for '{testMethod}' — the fixture did not run as expected. Full output:\n{output}");
+        return block.ToString();
+    }
+
+    // ───────────────────────────────────────────── the flag-off behaviour ──
+
+    /// <summary>
+    /// The whole point of #2240, and its negative in the same run so the two cannot drift
+    /// apart: two failures that look identical to a reader get opposite treatment, decided by
+    /// whether the named table actually holds rows.
+    /// </summary>
+    [SkippableFact]
+    public void EmptySetupTable_IsExplained_AndAPopulatedOneIsNot()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var (output, exit) = RunRunner();
+        Assert.NotEqual(0, exit);   // every test in the fixture fails, by construction
+
+        // ── explained: the table BC named has no rows ──────────────────────────────
+        var emptyGet = BlockFor(output, "EmptySetupTable_Get");
+        // BC's own failure, untouched. If this line ever changes shape the diagnosis is
+        // replacing the failure instead of sitting next to it, which #2240 forbids.
+        Assert.Contains("NavCSideRecordNotFoundException: The Source Code Setup does not exist.",
+            emptyGet, StringComparison.Ordinal);
+        Assert.Contains($"[test-data] 'Source Code Setup' (table {SourceCodeSetupTableId}) has no rows in this run",
+            emptyGet, StringComparison.Ordinal);
+        // It must say what to do, not merely what happened.
+        Assert.Contains("--test-data", emptyGet, StringComparison.Ordinal);
+
+        // ── NOT explained: same exception type, same message shape, table has a row ──
+        var populatedGet = BlockFor(output, "PopulatedTable_Get");
+        Assert.Contains("NavCSideRecordNotFoundException: The Payment Method does not exist.",
+            populatedGet, StringComparison.Ordinal);
+        Assert.DoesNotContain("[test-data]", populatedGet, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The sibling failure shape #2240 measured alongside the record-not-found one
+    /// (`Invoice Nos. must have a value in Purchases &amp; Payables Setup`). It reaches the
+    /// diagnosis through a different route — NavTestFieldException's own TableName property
+    /// rather than a table id the runner recorded — so it needs its own positive AND its own
+    /// negative.
+    /// </summary>
+    [SkippableFact]
+    public void EmptySetupTable_TestFieldFailure_IsExplained_AndAPopulatedOneIsNot()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var (output, _) = RunRunner();
+
+        var emptyTestField = BlockFor(output, "EmptySetupTable_TestField");
+        Assert.Contains("NavTestFieldException: Sales Journal must have a value in Source Code Setup",
+            emptyTestField, StringComparison.Ordinal);
+        Assert.Contains($"[test-data] 'Source Code Setup' (table {SourceCodeSetupTableId}) has no rows in this run",
+            emptyTestField, StringComparison.Ordinal);
+
+        var populatedTestField = BlockFor(output, "PopulatedTable_TestField");
+        Assert.Contains("NavTestFieldException: Description must have a value in Payment Method",
+            populatedTestField, StringComparison.Ordinal);
+        Assert.DoesNotContain("[test-data]", populatedTestField, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// A failure that names no table at all — an ordinary AL Error, which is what a failed
+    /// Assert compiles to — must be left completely alone. This is the shape of the ONE
+    /// genuine failure #2240 measured hiding among fifteen fake ones.
+    /// </summary>
+    [SkippableFact]
+    public void AnErrorThatNamesNoTable_IsNotExplained()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var (output, _) = RunRunner();
+
+        var plain = BlockFor(output, "PlainError");
+        Assert.Contains("two plus two is 4, not 5", plain, StringComparison.Ordinal);
+        Assert.DoesNotContain("[test-data]", plain, StringComparison.Ordinal);
+    }
+
+    // ─────────────────────────────────────────────── the flag-on behaviour ──
+
+    /// <summary>
+    /// With --test-data ON and the table STILL empty, the message has to say something
+    /// different, because the user cannot work out which of "refused", "not in this backup" or
+    /// "empty in the backup" happened and the runner can.
+    ///
+    /// Driven through the AL_RUNNER_BCBAK seam with a fake reader rather than a ~1 GB backup no
+    /// CI leg has — the same seam TestDataLazyHydrationTests uses. The fake offers
+    /// "Source Code Setup" with rows, then answers the read with a column no AL field of that
+    /// table has, which is exactly the refusal shape #2273 records as the only one left on a
+    /// real CRONUS backup. So the table is in scope, --test-data really ran, and it is still
+    /// empty — which is the case this branch exists for.
+    /// </summary>
+    [SkippableFact]
+    public void WithTestDataOn_AnEmptyTableSaysWhyItIsStillEmpty()
+    {
+        TestArtifacts.SkipIfMissing();
+
+        var backup = Path.Combine(_root, "BusinessCentral-W1.bak");
+        File.WriteAllBytes(backup, new byte[256]);
+        var reader = Path.Combine(_root, "bcbak");
+        File.WriteAllText(reader, FakeReaderScript());
+        File.SetUnixFileMode(reader,
+            UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+
+        var (output, _) = RunRunner(
+            new Dictionary<string, string> { ["AL_RUNNER_BCBAK"] = reader },
+            $"--test-data={backup}", "--test-data-company", "CRONUS");
+
+        var emptyGet = BlockFor(output, "EmptySetupTable_Get");
+        // Still BC's own failure, still untouched.
+        Assert.Contains("NavCSideRecordNotFoundException: The Source Code Setup does not exist.",
+            emptyGet, StringComparison.Ordinal);
+        // And a DIFFERENT sentence from the flag-off one — this is the whole claim.
+        Assert.Contains($"[test-data] 'Source Code Setup' (table {SourceCodeSetupTableId}) still has no rows although --test-data is on",
+            emptyGet, StringComparison.Ordinal);
+        Assert.Contains("refused", emptyGet, StringComparison.Ordinal);
+        // The flag-off wording must NOT appear: telling a user who already passed --test-data
+        // to pass --test-data is the failure this branch exists to avoid.
+        Assert.DoesNotContain("pass --test-data to load a company", emptyGet, StringComparison.Ordinal);
+
+        // The negative still holds with the flag on.
+        Assert.DoesNotContain("[test-data]", BlockFor(output, "PopulatedTable_Get"), StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// A `bcbak` stand-in: one company, one table in scope ("Source Code Setup", AL id 242,
+    /// non-zero row count so BuildPlan keeps it), and a read that hands back a column the AL
+    /// table has no field for so the hydration refuses it and the table stays empty.
+    /// No `$ext` companion, so the once-per-run merge probe does not run.
+    /// </summary>
+    private static string FakeReaderScript() =>
+        "#!/bin/sh\n"
+        + "cmd=\"$1\"\n"
+        + "case \"$cmd\" in\n"
+        + "  companies) echo 'CRONUS' ;;\n"
+        + $"  tables) printf '%s\\n' '   4 Table\tCRONUS\tSource Code Setup\t{SourceCodeSetupTableId} \"Source Code Setup\" (Base Application)' ;;\n"
+        + "  read) echo '[{\"Not An AL Field Of This Table\": 1}]' ;;\n"
+        + "esac\n";
+}

--- a/AlRunner/Infrastructure/MissingTestDataDiagnosis.cs
+++ b/AlRunner/Infrastructure/MissingTestDataDiagnosis.cs
@@ -1,0 +1,144 @@
+// MissingTestDataDiagnosis — the diagnostic half of issue #2240.
+//
+// THE PROBLEM, MEASURED
+//   On a real customer suite (29 tests, BC 28.4) 16 tests failed and FIFTEEN of them failed on
+//   a setup record that was not there, not on their own logic:
+//       12 x  The Source Code Setup does not exist
+//        3 x  Invoice Nos. must have a value in Purchases & Payables Setup
+//   The sixteenth was a genuine assertion failure, and it was invisible — buried under fifteen
+//   that looked exactly like it. The runner starts from an empty database, and a bare BC error
+//   gives the developer no way to tell "this database has no setup data" from "my code is
+//   wrong".
+//
+// WHAT THIS DOES, AND WHAT IT DELIBERATELY DOES NOT DO
+//   It ADDS an explanation next to a failure. It never replaces one, never downgrades an
+//   outcome, and never touches the failing test's own message, exception type or AL call stack
+//   (.claude/rules/loud-failures.md). A test that failed still failed, with BC's own words.
+//
+// A FALSE POSITIVE IS WORSE THAN NO MESSAGE
+//   Telling somebody their genuine bug is a missing-data problem sends them down the wrong path
+//   — the same failure #2240 describes, just pointing the other way. So the explanation fires
+//   only on EVIDENCE, never on a text pattern alone. Two things must both hold:
+//
+//     1. The failure NAMES a table, and the name comes from a typed source, not from parsing
+//        prose:
+//          - a record-not-found error the runner itself raised carries the AL table id, stashed
+//            in Exception.Data by TagTable below at the one site that builds it
+//            (RecordWritePatches.BuildRecordNotFoundException);
+//          - NavTestFieldException carries a TableName property BC populates itself
+//            (measured in Microsoft.Dynamics.Nav.Types.dll: CreateNonblank sets `tableName`).
+//        BC's own "The {0} does not exist." wording is localized — the en-US resource string
+//        lives in Microsoft.Dynamics.Nav.Language.dll and every shipped culture has its own —
+//        so matching on it would be a guess that silently stops working off en-US.
+//
+//     2. That table is GENUINELY EMPTY in the in-memory store right now, summed across every
+//        DataAccessSource that materialised it (RecordPatches.TryCensusTable). If the census
+//        cannot see the table, the answer is "I don't know" and nothing is said.
+//
+//   The negative case this buys is the important one, and it is the one the proving tests lead
+//   with: a `Rec.Get('NOPE')` against a table that HAS rows produces exactly the same exception
+//   type and exactly the same message shape, and gets no explanation, because the evidence is
+//   absent.
+//
+// WHY THE MESSAGE IS ONE LINE
+//   #2261 hit this for real: the bundle reporter keeps only line 1 of an EXEC-FAIL message, so
+//   a diagnosis whose second line carried the actionable part reached nobody. Per-test messages
+//   are not truncated that way today, but a one-line explanation cannot be truncated by anything
+//   that shows up later either.
+using Microsoft.Dynamics.Nav.Runtime;
+
+namespace AlRunner.Infrastructure;
+
+internal static class MissingTestDataDiagnosis
+{
+    /// <summary>Exception.Data key carrying the AL table id of a record-not-found failure. A
+    /// string key rather than an object one so it survives any dictionary copy.</summary>
+    internal const string TableIdDataKey = "al-runner.missing-record.table-id";
+
+    /// <summary>Exception.Data key carrying that table's AL object name.</summary>
+    internal const string TableNameDataKey = "al-runner.missing-record.table-name";
+
+    /// <summary>System/virtual tables (Field, AllObj, Table Metadata, ...) are populated by the
+    /// runner from loaded metadata, not from a company's data. An empty one is a runner bug, and
+    /// pointing the user at --test-data for it would be wrong twice over — the backup does not
+    /// carry them either.</summary>
+    private const int FirstVirtualTableId = 2_000_000_000;
+
+    /// <summary>
+    /// Record which AL table a record-not-found exception is about, at the one site that builds
+    /// it. Returns the same exception so call sites stay a single expression.
+    ///
+    /// Additive only: Exception.Data is not part of the message, the type or the stack, so
+    /// nothing about how the failure reaches the user changes here.
+    /// </summary>
+    internal static Exception TagTable(Exception ex, object? metaTable)
+    {
+        if (metaTable is NCLMetaTable meta)
+        {
+            try
+            {
+                ex.Data[TableIdDataKey] = meta.TableId;
+                ex.Data[TableNameDataKey] = meta.TableName ?? "";
+            }
+            catch (ArgumentException) { /* a Data dictionary that refuses the key is not worth a failure */ }
+            catch (NotSupportedException) { }
+        }
+        return ex;
+    }
+
+    /// <summary>
+    /// The one-line explanation for this failure, or null when there is no evidence for one.
+    /// Null is the common answer and the safe one.
+    ///
+    /// Called from TestExecutor.RunOne's catch blocks, which is the last moment the store still
+    /// holds exactly what the test saw — the next codeunit/test boundary restores the install
+    /// baseline over it.
+    /// </summary>
+    internal static string? Explain(Exception? ex)
+    {
+        if (ex == null) return null;
+        if (!TryNameTable(ex, out var census)) return null;
+        if (census.Rows != 0) return null;                       // the table HAS data — not this
+        if (census.TableId >= FirstVirtualTableId) return null;   // see FirstVirtualTableId
+
+        var where = $"'{census.TableName}' (table {census.TableId})";
+        if (!TestDataOptions.Enabled)
+            return $"[test-data] {where} has no rows in this run, so this failure may be missing "
+                 + "setup data rather than a bug in the code under test. The runner starts from an "
+                 + "empty database; pass --test-data to load a company out of the BC backup that "
+                 + "ships inside the artifact.";
+
+        var outcome = TestDataProvisioner.TableOutcome(census.TableId);
+        if (outcome != null)
+            return $"[test-data] {where} still has no rows although --test-data is on: {outcome}. "
+                 + "So this failure may be missing setup data rather than a bug in the code under test.";
+
+        return $"[test-data] {where} has no rows in this run and --test-data never loaded it — "
+             + (TestDataProvisioner.IsArmed
+                 ? "the on-demand loader was never asked for this table."
+                 : "no backup plan is armed for this app group yet.")
+             + " So this failure may be missing setup data rather than a bug in the code under test.";
+    }
+
+    /// <summary>
+    /// Resolve the failure to exactly one table the store can answer for. Ordered by how strong
+    /// the evidence is: an id the runner itself recorded, then a table name BC put on a typed
+    /// property. Anything else is not evidence and returns false.
+    /// </summary>
+    private static bool TryNameTable(Exception ex, out AlRunner.Patches.RecordPatches.StoredTableCensus census)
+    {
+        census = default!;
+        for (var e = ex; e != null; e = e.InnerException)
+        {
+            if (e.Data[TableIdDataKey] is int taggedId
+                && AlRunner.Patches.RecordPatches.TryCensusTable(taggedId, out census))
+                return true;
+
+            if (e is Microsoft.Dynamics.Nav.Types.NavTestFieldException testField
+                && !string.IsNullOrWhiteSpace(testField.TableName)
+                && AlRunner.Patches.RecordPatches.TryCensusTableByName(testField.TableName, out census))
+                return true;
+        }
+        return false;
+    }
+}

--- a/AlRunner/JUnitReport.cs
+++ b/AlRunner/JUnitReport.cs
@@ -97,8 +97,15 @@ public static class JUnitReport
 
     private static string BuildBody(TestResult test)
     {
+        // #2240: the missing-test-data explanation goes in the BODY, never into the `message`
+        // attribute above — that attribute is BC's own failure text and a CI dashboard groups
+        // failures by it, so appending to it would both alter the reported failure and split one
+        // cluster into two.
+        var head = string.IsNullOrEmpty(test.Diagnosis)
+            ? test.Message ?? ""
+            : $"{test.Message}\n{test.Diagnosis}";
         var body = test.AlCallStack ?? test.FullException;
-        if (body == null) return test.Message ?? "";
-        return $"{test.Message}\n\n{body}";
+        if (body == null) return head;
+        return $"{head}\n\n{body}";
     }
 }

--- a/AlRunner/Patches/RecordPatches.StoredTableCensus.cs
+++ b/AlRunner/Patches/RecordPatches.StoredTableCensus.cs
@@ -1,0 +1,126 @@
+// RecordPatches.StoredTableCensus — read-only "how many rows does this table hold right now"
+// queries against the live in-memory store (issue #2240, diagnostic half).
+//
+// WHY IT IS A SEPARATE FILE AND NOT PART OF InstallBaseline
+//   InstallBaseline walks the same structures, but everything it does MUTATES: it captures a
+//   snapshot, restores one, wipes the store. Nothing here writes. Keeping the read-only
+//   queries apart means a diagnostic that runs at failure time can never be the reason a
+//   failing run's state changed — which matters because the one thing the #2240 diagnostic may
+//   not do is alter the failure it is explaining.
+//
+// WHY IT IS ALLOWED TO RETURN "I DON'T KNOW"
+//   Every entry point returns false rather than throwing or guessing. A census that cannot see
+//   the table (no DataAccessSource has materialised it, the provider is not a
+//   TempTableDataProvider, BC's private field layout moved) must NOT be reported as "the table
+//   is empty" — that is precisely the false positive .claude/rules/loud-failures.md's sister
+//   concern in #2240 warns about, where a developer is told their genuine bug is a missing-data
+//   problem. Absent evidence, the caller says nothing.
+using System.Collections;
+using System.Reflection;
+using Microsoft.Dynamics.Nav.Runtime;
+
+namespace AlRunner.Patches;
+
+public static partial class RecordPatches
+{
+    /// <summary>What the store knows about one table right now.</summary>
+    /// <param name="TableId">AL table id.</param>
+    /// <param name="TableName">The AL object name BC's own NCLMetaTable carries.</param>
+    /// <param name="Rows">Total rows across every DataAccessSource that materialised it.</param>
+    internal sealed record StoredTableCensus(int TableId, string TableName, int Rows);
+
+    /// <summary>
+    /// Census by AL table id. False when no materialised DataAccessSource holds the table, or
+    /// when the provider behind it is not the in-memory one this census can read — see the file
+    /// header for why that is "unknown", never "empty".
+    /// </summary>
+    internal static bool TryCensusTable(int tableId, out StoredTableCensus census)
+        => TryCensus(m => m.TableId == tableId, out census);
+
+    /// <summary>
+    /// Census by AL table NAME (BC's NCLMetaTable.TableName, which is what
+    /// NavTestFieldException.TableName carries). Ordinal first, then ordinal-ignore-case.
+    ///
+    /// AMBIGUITY IS "UNKNOWN", NOT A COIN FLIP: if two distinct table ids in the store answer to
+    /// the same name, this returns false. Picking one would mean reporting a row count that
+    /// might belong to the other table.
+    /// </summary>
+    internal static bool TryCensusTableByName(string tableName, out StoredTableCensus census)
+    {
+        census = default!;
+        if (string.IsNullOrWhiteSpace(tableName)) return false;
+        if (TryCensusUnique(m => string.Equals(m, tableName, StringComparison.Ordinal), out census))
+            return true;
+        return TryCensusUnique(m => string.Equals(m, tableName, StringComparison.OrdinalIgnoreCase), out census);
+    }
+
+    private static bool TryCensusUnique(Func<string, bool> nameMatches, out StoredTableCensus census)
+    {
+        census = default!;
+        var hits = new Dictionary<int, StoredTableCensus>();
+        CollectCensus(meta => nameMatches(MetaTableName(meta)), hits);
+        if (hits.Count != 1) return false;
+        census = hits.Values.Single();
+        return true;
+    }
+
+    private static bool TryCensus(Func<NCLMetaTable, bool> predicate, out StoredTableCensus census)
+    {
+        census = default!;
+        var hits = new Dictionary<int, StoredTableCensus>();
+        CollectCensus(predicate, hits);
+        if (hits.Count != 1) return false;
+        census = hits.Values.Single();
+        return true;
+    }
+
+    /// <summary>
+    /// Walk every (DataAccessSource, tableId) pair and total the rows of those whose metatable
+    /// satisfies <paramref name="predicate"/>. Rows are SUMMED across sources rather than taken
+    /// from the first hit: the same AL table can be materialised on more than one
+    /// DataAccessSource in a run, and "empty" has to mean empty everywhere before anyone claims
+    /// the data is missing.
+    /// </summary>
+    private static void CollectCensus(Func<NCLMetaTable, bool> predicate,
+                                      Dictionary<int, StoredTableCensus> into)
+    {
+        foreach (var (_, perTable) in _dataAccessByTable)
+        {
+            foreach (var (tableId, dataAccess) in perTable)
+            {
+                object? provider;
+                object? metaTableObj;
+                object? primaryTree;
+                try
+                {
+                    provider = GetDataProvider(dataAccess);
+                    if (provider == null || provider.GetType().Name != "TempTableDataProvider") continue;
+                    var providerType = provider.GetType();
+                    metaTableObj = RequiredField(providerType, "table").GetValue(provider);
+                    primaryTree = RequiredField(providerType, "primaryTree").GetValue(provider);
+                }
+                catch (MissingFieldException) { continue; }   // BC's private layout moved — unknown, not empty
+                catch (TargetInvocationException) { continue; }
+
+                if (metaTableObj is not NCLMetaTable meta) continue;
+                if (!predicate(meta)) continue;
+
+                // A null primaryTree is BC's representation of "no row was ever inserted" — see
+                // the same read in CaptureInstallBaselineSnapshot.
+                var rows = 0;
+                if (primaryTree is IEnumerable tree)
+                    foreach (var _ in tree) rows++;
+
+                into[tableId] = into.TryGetValue(tableId, out var prior)
+                    ? prior with { Rows = prior.Rows + rows }
+                    : new StoredTableCensus(tableId, MetaTableName(meta), rows);
+            }
+        }
+    }
+
+    private static string MetaTableName(NCLMetaTable meta)
+    {
+        try { return meta.TableName ?? ""; }
+        catch { return ""; }
+    }
+}

--- a/AlRunner/Patches/RecordWritePatches.cs
+++ b/AlRunner/Patches/RecordWritePatches.cs
@@ -320,7 +320,8 @@ public static partial class BcRuntime
             var factory = helper.GetMethod("GetRecordNotFoundException",
                 BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic,
                 binder: null, new[] { metaTable.GetType(), argType! }, modifiers: null);
-            if (factory?.Invoke(null, new[] { metaTable, key }) is Exception ex) return ex;
+            if (factory?.Invoke(null, new[] { metaTable, key }) is Exception ex)
+                return AlRunner.Infrastructure.MissingTestDataDiagnosis.TagTable(ex, metaTable);
         }
 
         throw new InvalidOperationException(

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -5263,6 +5263,13 @@ static void PrintGuide(TextWriter w)
     w.WriteLine("    al-runner --test-data <bundle-dir>              # the shipped backup for the selected version/country");
     w.WriteLine("    al-runner --test-data=/path/to/X.bak <dirs>     # an explicit backup");
     w.WriteLine("    al-runner --test-data --test-data-company NAME  # a specific company inside it");
+    w.WriteLine("  You do not have to know in advance which failures those are: when a test fails on a");
+    w.WriteLine("  table that has NO rows in this run, the runner prints a one-line [test-data] note");
+    w.WriteLine("  under the failure naming that table. BC's own message is left exactly as it was —");
+    w.WriteLine("  the note sits next to it. It only appears when the failure names a table AND that");
+    w.WriteLine("  table is measurably empty, so a real bug against a populated table is never");
+    w.WriteLine("  mislabelled. With --test-data already on it says instead why the table is still");
+    w.WriteLine("  empty (refused, not in this backup, or empty in it).");
     w.WriteLine("  It needs the `bcbak` backup reader on PATH or at $AL_RUNNER_BCBAK. Each table is");
     w.WriteLine("  read once per process, at first touch, and then lives in the install baseline");
     w.WriteLine("  the runner restores at every test boundary. A missing backup FAILS the run");

--- a/AlRunner/Reporter.cs
+++ b/AlRunner/Reporter.cs
@@ -148,6 +148,12 @@ public static class Reporter
                 {
                     if (!string.IsNullOrEmpty(t.Message))
                         w.WriteLine($"      {t.Message}");
+                    // #2240: printed AFTER BC's own message and BEFORE the AL stack, so the
+                    // failure still reads as BC reported it and the explanation sits next to it
+                    // rather than in place of it. Absent evidence there is no line at all, which
+                    // is why a default run's output is unchanged.
+                    if (!string.IsNullOrEmpty(t.Diagnosis))
+                        w.WriteLine($"      {t.Diagnosis}");
                     if (!string.IsNullOrEmpty(t.AlCallStack))
                     {
                         // Show the AL call stack (BC service-tier format), not the C# trace.
@@ -253,6 +259,9 @@ public static class Reporter
                 status = t.Outcome.ToString().ToLowerInvariant(),
                 durationMs = (long)t.Duration.TotalMilliseconds,
                 message = t.Message,
+                // #2240: additive and null-omitted (DefaultIgnoreCondition below), so a run that
+                // produced no diagnosis emits byte-identical JSON to before.
+                diagnosis = t.Diagnosis,
                 stackTrace = (t.AlCallStack ?? t.FullException)?.TrimEnd(),
                 // Manifest reclassification (docs/expectations.md): "pass-oos",
                 // "pass-known-gap", "pass-divergence", "skipped" or
@@ -324,6 +333,7 @@ public static class Reporter
                         codeunit = t.Codeunit,
                         method = t.Method,
                         message = t.Message,
+                        diagnosis = t.Diagnosis,
                         // First few stack frames (after the test method) — enough to identify
                         // which BC API the failure hit, but not so many that the JSON explodes.
                         stack_top = StackTop(t.FullException, 6),

--- a/AlRunner/TestDataProvisioner.cs
+++ b/AlRunner/TestDataProvisioner.cs
@@ -173,11 +173,42 @@ internal static class TestDataProvisioner
     internal static IReadOnlyCollection<int> ArmedTableIds
         => _armed?.ByTableId.Keys.ToArray() ?? Array.Empty<int>();
 
+    // ─────────────────────────────────────────── per-table outcome (#2240) ──
+
+    /// <summary>
+    /// Why one table ended up with the rows it has, in the user's words rather than the
+    /// hydrator's. Recorded per table id by the on-demand loader, and read only by the
+    /// missing-test-data diagnosis (Infrastructure.MissingTestDataDiagnosis) when it has
+    /// already established that the table is EMPTY and --test-data was on — i.e. the one case
+    /// where the user cannot possibly guess which of "refused", "not in this backup" or
+    /// "genuinely empty in the backup" happened, and the runner can.
+    ///
+    /// The aggregate Summary above cannot answer this: it counts refusals across the whole run
+    /// and never says which table each one was.
+    /// </summary>
+    private static readonly System.Collections.Concurrent.ConcurrentDictionary<int, string> _tableOutcome = new();
+
+    /// <summary>The recorded outcome for <paramref name="tableId"/>, or null when the loader
+    /// never considered it. Null is meaningful: under the on-demand policy it means nothing in
+    /// this run ever touched the table, so no reason exists yet.</summary>
+    internal static string? TableOutcome(int tableId)
+        => _tableOutcome.TryGetValue(tableId, out var reason) ? reason : null;
+
+    /// <summary>True when a plan is armed — i.e. --test-data resolved a backup and a company
+    /// and the on-demand loader is installed. Distinguishes "the flag is on and working" from
+    /// "the flag is on but Arm() has not run for this app group yet".</summary>
+    internal static bool IsArmed => _armed != null;
+
+    /// <summary>The armed backup/company pair, for a diagnosis that has to name them.</summary>
+    internal static (string Backup, string Company)? ArmedBackup
+        => _armed == null ? null : (_armed.Backup, _armed.Company);
+
     internal static void ResetForTests()
     {
         _lastSummary = null;
         _armed = null;
         _tablesDone = _rowsDone = _refused = _readerRefused = _droppedColumns = 0;
+        _tableOutcome.Clear();
         RecordPatches.TestDataOnDemandLoader = null;
     }
 
@@ -257,7 +288,15 @@ internal static class TestDataProvisioner
     {
         var armed = _armed;
         if (armed == null) return;
-        if (!armed.ByTableId.TryGetValue(tableId, out var entry)) return;   // not a table this backup offers
+        if (!armed.ByTableId.TryGetValue(tableId, out var entry))
+        {
+            // #2240: recorded, not just skipped. "This backup's plan does not offer the table"
+            // is one of the answers the diagnosis has to be able to give, and it is only
+            // knowable here — the store afterwards looks the same as a refusal.
+            _tableOutcome[tableId] = $"the plan built from '{Path.GetFileName(armed.Backup)}' "
+                + $"company '{armed.Company}' has no table with this id, so nothing was loaded";
+            return;
+        }
 
         try
         {
@@ -274,12 +313,17 @@ internal static class TestDataProvisioner
             }
             _rowsDone += result.Rows;
             _droppedColumns += result.ColumnsFromUninstalledApps;
+            _tableOutcome[tableId] = result.Rows > 0
+                ? $"{result.Rows} row(s) loaded from '{Path.GetFileName(armed.Backup)}' company '{armed.Company}'"
+                : $"'{entry.TableName}' in '{Path.GetFileName(armed.Backup)}' company '{armed.Company}' "
+                  + "holds no rows, so there was nothing to load";
             PerfTrace.Log(
                 $"TestData.LazyLoad {tableId} '{entry.TableName}' {result.Rows} row(s)");
         }
         catch (TestDataHydrationRefusal ex)
         {
             _refused++;
+            _tableOutcome[tableId] = $"the backup's rows for it were refused — {ex.Message}";
             Console.Error.WriteLine($"[test-data] REFUSED {ex.Message}");
         }
         catch (BackupReaderException ex)
@@ -289,6 +333,8 @@ internal static class TestDataProvisioner
             // own text IN FULL, because that text is the only diagnosis there is and the bundle
             // reporter keeps only line 1 of an EXEC-FAIL message.
             _readerRefused++;
+            _tableOutcome[tableId] =
+                $"the backup reader refused table '{entry.TableName}' — {ex.Message.Split('\n')[0]}";
             Console.Error.WriteLine(
                 $"[test-data] READER REFUSED table '{entry.TableName}': {ex.Message}");
         }

--- a/AlRunner/TestExecutor.cs
+++ b/AlRunner/TestExecutor.cs
@@ -96,7 +96,14 @@ public sealed record TestResult(string Codeunit, string Method, TestOutcome Outc
                                 // "requested but empty" — an empty list IS how "requested,
                                 // zero AL locals" is represented (AlValueCapture.Collect()
                                 // never returns null).
-                                IReadOnlyList<Infrastructure.AlCapturedValue>? CapturedValues = null);
+                                IReadOnlyList<Infrastructure.AlCapturedValue>? CapturedValues = null,
+                                // #2240: an ADDITIONAL one-line explanation shown next to the
+                                // failure, never instead of it. Non-null only when the runner has
+                                // EVIDENCE that the failure is about a table with no rows in it —
+                                // see Infrastructure.MissingTestDataDiagnosis for why a text
+                                // pattern alone is not evidence. Message, FullException,
+                                // AlCallStack, Outcome and Exception are all untouched by it.
+                                string? Diagnosis = null);
 
 public sealed class TestExecutor
 {
@@ -526,9 +533,14 @@ public sealed class TestExecutor
                 // InsideTestProc: false — instantiation blew up, so no [Test] body
                 // ever ran. That is what makes this a `setup` errorKind on the wire
                 // rather than a test-runtime failure (see ErrorClassifier).
+                // #2240: the same explanation the per-test path gets. A codeunit whose AL
+                // global-variable initialisation or OnRun reads a setup record fails HERE, with
+                // the identical "does not exist" shape and no [Test] name attached — leaving it
+                // out would explain the failure only when it happened to land inside a test body.
                 var ctorResult = new TestResult(t.Name, "<ctor>", TestOutcome.Error,
                     Unwrap(ex).Message, ex.ToString(), TimeSpan.Zero,
-                    Exception: Unwrap(ex), InsideTestProc: false);
+                    Exception: Unwrap(ex), InsideTestProc: false,
+                    Diagnosis: AlRunner.Infrastructure.MissingTestDataDiagnosis.Explain(Unwrap(ex)));
                 results.Add(ctorResult);
                 onTestComplete?.Invoke(ctorResult);
                 continue;
@@ -601,7 +613,8 @@ public sealed class TestExecutor
                         {
                             var ctorResult = new TestResult(t.Name, m.Name, TestOutcome.Error,
                                 Unwrap(ex).Message, ex.ToString(), TimeSpan.Zero,
-                                null, displayName, Unwrap(ex), InsideTestProc: false);
+                                null, displayName, Unwrap(ex), InsideTestProc: false,
+                                Diagnosis: AlRunner.Infrastructure.MissingTestDataDiagnosis.Explain(Unwrap(ex)));
                             results.Add(ctorResult);
                             onTestComplete?.Invoke(ctorResult);
                             continue;
@@ -962,7 +975,12 @@ public sealed class TestExecutor
             // so for now: any thrown exception is Fail.
             return new TestResult(codeunit, m.Name, TestOutcome.Fail,
                 $"{inner.GetType().Name}: {inner.Message}", inner.ToString(), sw.Elapsed, alStack, displayName,
-                inner);
+                inner,
+                // #2240: computed HERE, and nowhere later, because it reads the live row store —
+                // the codeunit/test boundary that follows restores the install baseline over it,
+                // so a diagnosis derived after the fact would describe a different database than
+                // the one the test actually failed against.
+                Diagnosis: AlRunner.Infrastructure.MissingTestDataDiagnosis.Explain(inner));
         }
         catch (Exception ex)
         {
@@ -970,7 +988,8 @@ public sealed class TestExecutor
             var alStack = AlRunner.Infrastructure.AlCallStackCapture.GetCaptured(ex);
             return new TestResult(codeunit, m.Name, TestOutcome.Error,
                 ex.Message, ex.ToString(), sw.Elapsed, alStack, displayName,
-                ex);
+                ex,
+                Diagnosis: AlRunner.Infrastructure.MissingTestDataDiagnosis.Explain(ex));
         }
         finally
         {

--- a/README.md
+++ b/README.md
@@ -192,6 +192,14 @@ See [CONTRIBUTING.md](CONTRIBUTING.md#dev-loop) for provisioning them as a separ
 | `--test-data` / `--test-data=PATH` | Hydrate the in-memory database from a BC `.bak`, so tests find the setup records a real environment has. A table is read the first time the run touches it, never up front, so the cost tracks what the suite actually uses. Off by default. Resolves `sandbox/<version>/<country>/BusinessCentral-<CC>.bak` from the artifact cache, or the explicit path. A missing backup fails the run naming every path probed — it never continues against an empty database. Needs the `bcbak` backup reader on PATH or at `$AL_RUNNER_BCBAK`. Table-extension (`$ext`) fields are merged into the base record; see [docs/limitations.md](docs/limitations.md) for what is and is not hydrated. |
 | `--test-data-company NAME` | Company inside the backup to hydrate. Default: the first company the backup reports, printed at the start of the run. |
 
+When a test fails on a table that has **no rows** in this run, the runner prints a one-line
+`[test-data]` explanation under the failure naming that table and pointing at `--test-data`.
+BC's own failure message, exception type and AL call stack are unchanged — the explanation sits
+next to the failure, never in place of it. It appears only when the failure names a table *and*
+that table is measurably empty, so a genuine bug against a populated table is never mislabelled
+as missing data. With `--test-data` already on, the line says instead why the table is still
+empty (refused, not in this backup, or empty in it).
+
 Environment variables: `AL_RUNNER_VERBOSE=1`, `AL_RUNNER_SHOW_PASS=1`, `AL_RUNNER_TRACE_NRE=1` (logs every first-chance NRE before AL `asserterror` swallows it), `AL_RUNNER_BCBAK` (path to the `bcbak` backup reader used by `--test-data`).
 
 ## Test Corpus

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -456,7 +456,22 @@ https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues.
   install baseline is re-inserted at every test boundary and so its size is a cost paid per
   boundary rather than per run. Coverage does not extend to everything, and what it does not
   cover it **reports** — a skipped or refused table is named on stderr with the reason, never
-  silently emptied:
+  silently emptied.
+
+  Independently of the flag, a failure on a table that holds **no rows** gets a one-line
+  `[test-data]` explanation printed under it, naming the table
+  ([#2240](https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/2240)). Two known
+  limits on when it appears, both deliberate — a wrong explanation is worse than none:
+  - It needs the failure to name a table. `Record.Get` raising, and `TestField` failing, both
+    do; an ordinary `Error(...)` (which is what a failed `Assert` compiles to) does not, and
+    is left alone.
+  - The table has to be genuinely empty. A setup singleton whose row exists but was never
+    configured — `Purchases & Payables Setup` is the shipped example: the install seed inserts
+    one blank row, so `Get()` succeeds and `TestField` then fails — is NOT explained, because
+    "the row is there but blank" is a weaker inference than "there are no rows at all".
+    Tracked in [#2277](https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/2277).
+
+  What is and is not hydrated by the flag itself:
   - Table-extension (`$ext`) fields ARE merged into the base record
     ([#2261](https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/2261)), with one
     declared exception: a companion column owned by an app **outside this run's app closure**


### PR DESCRIPTION
Closes #2240

The data half of that story is done (see #2258, #2261, #2259, #2262, #2270). This is the
diagnostic half, which the issue argued was worth landing first and on its own — and it helps
more people than the data half does, because `--test-data` is opt-in and off by default. A
developer who never turns it on still deserves to know why their suite failed.

## What it does

When a test fails and the failure names a table that has **no rows** in this run, the runner
prints one extra line under the failure:

```
FAIL  Codeunit62440.EmptySetupTable_Get (3ms)
      NavCSideRecordNotFoundException: The Source Code Setup does not exist. Identification fields and values: Primary Key=''
      [test-data] 'Source Code Setup' (table 242) has no rows in this run, so this failure may be missing setup data rather than a bug in the code under test. The runner starts from an empty database; pass --test-data to load a company out of the BC backup that ships inside the artifact.
      "Missing Setup Diag Tests"(CodeUnit 62440).EmptySetupTable_Get line 4 - ...
```

BC's own message, the exception type, the AL call stack and the outcome are all untouched. The
explanation sits next to the failure, never in place of it.

With `--test-data` already on and the table still empty, it says a different thing — because
that is the case the user cannot work out and the runner can:

```
      [test-data] 'Source Code Setup' (table 242) still has no rows although --test-data is on: the backup's rows for it were refused — table 'Source Code Setup': the backup has a column 'Not An AL Field Of This Table' that is not a field of the AL table this runner build would insert into ...
```

## Why it does not fire on a text pattern

A false positive here is worse than no message: telling somebody their genuine bug is a
missing-data problem is #2240's own failure pointing the other way. So two things must both
hold before anything is printed.

1. **The failure names a table, from a typed source.** A record-not-found error the runner
   itself raises carries the AL table id, stashed in `Exception.Data` at the single site that
   builds it (`RecordWritePatches.BuildRecordNotFoundException`). `NavTestFieldException`
   carries a `TableName` property BC populates itself — verified by decompiling
   `Microsoft.Dynamics.Nav.Types.dll`, where `CreateNonblank` sets `tableName`. No message is
   parsed. BC's `The {0} does not exist.` wording is a localized resource in
   `Microsoft.Dynamics.Nav.Language.dll` with a copy per shipped culture, so matching on it
   would silently stop working off en-US.
2. **That table is measurably empty**, summed across every `DataAccessSource` that materialised
   it (`RecordPatches.TryCensusTable`, a new read-only partial). A census that cannot see the
   table answers "I don't know" and nothing is printed.

## Measured

Probed on BC 28.1 with the Base Application closure. Same exception type and same message shape
on both sides of the line:

| AL | outcome | explained? |
|---|---|---|
| `SourceCodeSetup.Get()` (0 rows) | `NavCSideRecordNotFoundException: The Source Code Setup does not exist.` | yes |
| `PaymentMethod.Insert; PaymentMethod.Get('NOPE')` (1 row) | `NavCSideRecordNotFoundException: The Payment Method does not exist.` | **no** |
| `SourceCodeSetup.TestField("Sales Journal")` (0 rows) | `NavTestFieldException: Sales Journal must have a value in Source Code Setup` | yes |
| `PaymentMethod.Insert; PaymentMethod.TestField(Description)` (1 row) | `NavTestFieldException: Description must have a value in Payment Method` | **no** |
| `Error('two plus two is %1, not 5', 2+2)` | `NavNCLDialogException: two plus two is 4, not 5` | **no** |

The three "no" rows are the ones that matter. The second is the case a text-matching
implementation would get wrong, and it is what `EmptySetupTable_IsExplained_AndAPopulatedOneIsNot`
asserts in one run so the two cannot drift apart.

**A measured limit, filed rather than glossed over.** #2240's other reported shape —
`Invoice Nos. must have a value in Purchases & Payables Setup`, 3 of its 16 failures — is
**not** explained, and that is correct rather than a miss. Measured in a bundle with no test
data: `PurchSetup.IsEmpty=No Count=1 Get=Yes` against `SourceCodeSetup.IsEmpty=Yes Count=0`. The
install seed inserts one all-blank singleton row, so the table is not empty and the evidence rule
does not fire. Covering it needs a second, weaker inference ("the one row is entirely at its BC
defaults") with a false-positive shape the first rule does not have. That is #2277, and it is
recorded in `docs/limitations.md` rather than left to be rediscovered.

## Fixing the shape, not just the reported line

1. **Same wrong pattern at another call site?** `BuildRecordNotFoundException` is the runner's
   only site that raises BC's record-not-found error; grep confirms no other
   `NavCSideRecordNotFoundException` construction in `AlRunner/`. A record-not-found raised
   inside unpatched Ncl code carries no tag and is simply not explained — a false negative, which
   is the safe direction.
2. **Sibling function making the same assumption?** Yes, and it needed fixing: `RunOne`'s two
   catch blocks are not the only place a `TestResult` is built for a failure. Both
   codeunit-instantiation failure sites in `TestExecutor` produce one too, and a codeunit whose
   AL global-variable initialisation reads a setup record fails there with the identical shape and
   no `[Test]` name attached. Both now get the same explanation; without that, the diagnosis
   would have covered only failures that happened to land inside a test body.
3. **Two paths writing the same state maintaining the same invariant?** The four output paths
   that carry a per-test failure — console `PrintPerTest`, `--output-json`, `--out`
   classification, JUnit — now all carry the diagnosis, and all four keep `message` byte-identical.
   JUnit puts it in the body rather than the `message` attribute deliberately: a CI dashboard
   groups failures by that attribute, so appending would both alter the reported failure and split
   one cluster into two. The `--server` wire is intentionally untouched (it has a published
   schema); noted rather than silently skipped.

## Tests

`AlRunner.Tests/MissingTestDataDiagnosisTests.cs`, asserting on the **actual console block** the
runner printed for each named test, not on an internal result — #2261's line-1 truncation is
exactly the defect an internal-only assertion cannot see. The `--test-data`-is-on case runs
end-to-end too, through the existing `AL_RUNNER_BCBAK` fake-reader seam, so it needs no ~1 GB
backup.

RED → GREEN, two separate experiments:

- Making `Explain` return null unconditionally: **3 of 4 fail** (both positives and the
  flag-on case).
- Removing only the `census.Rows != 0` guard: **3 of 4 fail** — this time on the
  `DoesNotContain` assertions, i.e. the explanation appearing on `Payment Method`. So the
  negative tests are not vacuous; they are what pins the false-positive guard.
- Restored: 4/4 pass.

## Local verification

All run on this branch, BC 28.1.49838.53910, `--package-cache ~/.al-runner/platform-apps`:

| run | result | `[test-data]` lines emitted |
|---|---|---|
| `dotnet test AlRunner.Tests` | 1314 passed, 0 failed, 69 skipped | — |
| corpus (`--strict --count-baseline`) | 2204/2204, exit 0 | 0 |
| `tests/runner-extras` (`--strict`) | 200/200, exit 0 | 0 |
| corpus with an EMPTY expectations dir | 5 genuine failures, exit 1 | **0** |

The last row is the false-positive measurement, and it is the one worth reading. Pointing
`--expectations` at an empty directory stops the manifest reclassifying anything, so the five
tests that really do fail on this runner report as failures instead of as `pass-oos` /
`pass-known-gap` / `pass-divergence`:

```
FAIL  Codeunit60878.SaveAsPdf_RdlcLayout_ReturnsFalseWithLastErrorTextOnLinux
FAIL  Codeunit60877.TaskScheduler_CreateTask_InsideTest_ReturnsNonEmptyGuid
FAIL  Codeunit60152.Error_After_Insert_Before_Commit_RecordPersists
FAIL  Codeunit60170.Test04AssertErrorLocalVarChangesNotAffectCaller
FAIL  Codeunit60874.HttpClient_Get_ValidUrl_ReturnsSuccessResponse
```

None of the five got an explanation, which is correct for all five — they are report rendering,
the task scheduler, HTTP egress and two transaction/assert-scope failures, and not one of them
names a table. Across 2204 tests the diagnosis fired zero times where it should not have.
