### PR TITLE
fix(signing): validate signatures for real, stop the unresolvable catalog fallback

### DIFF
--- a/.github/scripts/pe_signing.py
+++ b/.github/scripts/pe_signing.py
@@ -4,11 +4,19 @@
 This is a presence check only: it reads the Certificate Table entry (data
 directory index 4, IMAGE_DIRECTORY_ENTRY_SECURITY) in the PE optional header
 and treats a nonzero Size as "signed". It does NOT validate that the
-signature is well-formed or that it chains to a trusted root -- that needs a
-real crypto stack (signtool / Get-AuthenticodeSignature on Windows,
-osslsigncode on Linux) and is deliberately out of scope here. See
-publish.yml's sign-and-pack job for the chain-of-trust check, which runs on
-the real Windows signing runner where that tooling exists.
+signature is well-formed or that it chains to a trusted root -- a file whose
+Certificate Table holds a nonzero size but arbitrary, non-Authenticode bytes
+still reads as "signed" here (see test_pe_signing.py's
+PresenceCheckOnlyTests, #2284).
+
+publish.yml's sign-and-pack job runs a real chain-of-trust check
+(Get-AuthenticodeSignature, on the Windows signing runner, right after the
+signing action) in addition to this one -- but only over the files THAT RUN
+signed (catalog.txt), not over the whole tree this script scans. The ~84
+files this workflow deliberately never touches carry Microsoft's or a third
+party's own signature, and an expired or untimestamped third-party
+certificate would fail a validity check for a reason that isn't this repo's
+defect, so this presence check is still the only gate applied to those.
 
 Used two ways from publish.yml (#2248):
 
@@ -159,11 +167,28 @@ def _cmd_list_unsigned(args: argparse.Namespace) -> int:
 
     lines = []
     for path in unsigned_paths:
+        resolved = path.resolve()
         try:
-            rel = os.path.relpath(path.resolve(), relative_to)
-        except ValueError:
-            # Different drive on Windows -- fall back to the absolute path.
-            rel = str(path.resolve())
+            rel = os.path.relpath(resolved, relative_to)
+        except ValueError as exc:
+            # azure/artifact-signing-action joins every catalog entry onto
+            # the workspace root before calling Resolve-Path (#2286), so an
+            # absolute path here can never resolve on the signing runner --
+            # measured in a real release run: both a literal absolute path
+            # (doubled: D:\a\repo\repo\D:\a\repo\repo\out\bcdb.exe) and a Git
+            # Bash /d/a/... path (mangled the same way) failed. A catalog
+            # entry must be relative to the workspace; this file is on a
+            # different drive from --relative-to, so it cannot be expressed
+            # that way and cannot be signed from this catalog. Fail loudly
+            # here instead of emitting a form the signing action can't read.
+            print(
+                f"::error::{resolved} cannot be made relative to {relative_to} "
+                f"({exc}). A signing catalog entry must be relative to the "
+                "workspace -- this file is on a different drive and cannot "
+                "be signed from this catalog.",
+                file=sys.stderr,
+            )
+            raise SystemExit(1) from exc
         lines.append(rel)
 
     output = "\n".join(lines)

--- a/.github/scripts/test_pe_signing.py
+++ b/.github/scripts/test_pe_signing.py
@@ -24,6 +24,7 @@ import subprocess
 import sys
 import tempfile
 import unittest
+import unittest.mock
 from pathlib import Path
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -100,6 +101,65 @@ def build_fake_pe(magic: int, cert_table_size: int, num_rva_and_sizes: int = 16)
         struct.pack_into("<II", optional_header, entry_offset, va, size)
 
     return bytes(dos_header) + pe_signature + coff_header + bytes(optional_header)
+
+
+def build_fake_pe_with_certificate_bytes(magic: int, certificate_bytes: bytes) -> bytes:
+    """Like build_fake_pe, but backs the Certificate Table entry with REAL
+    bytes appended right after the header -- arbitrary bytes, not a
+    well-formed WIN_CERTIFICATE/PKCS#7 Authenticode blob. Used by
+    PresenceCheckOnlyTests (#2284) to prove pe_signing's presence check
+    accepts any nonzero-size Certificate Table entry, regardless of whether
+    the bytes it points at are an actual signature.
+    """
+    assert magic in (0x10B, 0x20B)
+    header = build_fake_pe(magic, cert_table_size=len(certificate_bytes))
+    header_len = len(header)
+
+    data_directory_offset = 96 if magic == 0x10B else 112
+    optional_header_start = 64 + 4 + 20  # dos header + "PE\0\0" + COFF header
+    entry_offset = (
+        optional_header_start
+        + data_directory_offset
+        + pe_signing._CERT_TABLE_DIRECTORY_INDEX * 8
+    )
+
+    patched = bytearray(header)
+    # VirtualAddress (a raw file offset for the Security directory, per the
+    # comment on _CERT_TABLE_DIRECTORY_INDEX) points at the appended bytes.
+    struct.pack_into("<II", patched, entry_offset, header_len, len(certificate_bytes))
+    return bytes(patched) + certificate_bytes
+
+
+class PresenceCheckOnlyTests(unittest.TestCase):
+    """Documents the exact defect #2284 exists to cover: pe_signing's checks
+    read only the Certificate Table's Size field. A table backed by bytes
+    that are not a valid Authenticode signature at all -- arbitrary garbage,
+    not even a well-formed WIN_CERTIFICATE header -- is still reported as
+    signed. That is why publish.yml needs a REAL Get-AuthenticodeSignature
+    check in addition to this one, not instead of it (this check stays,
+    scoped to the ~84 files the workflow never touches -- see the
+    module docstring)."""
+
+    def test_verify_reports_signed_for_arbitrary_certificate_table_bytes(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            garbage = b"\x00\xde\xad\xbe\xef not a WIN_CERTIFICATE or a PKCS#7 blob at all"
+            path = root / "fake-signed.dll"
+            path.write_bytes(build_fake_pe_with_certificate_bytes(0x20B, garbage))
+
+            # The internal check agrees...
+            self.assertTrue(pe_signing.is_signed(path))
+
+            # ...and so does the CLI gate that publish.yml runs as its
+            # release-path check: it reports this file as signed and OK,
+            # even though "signed" here means nothing more than "Certificate
+            # Table Size is nonzero".
+            result = subprocess.run(
+                [sys.executable, SCRIPT_PATH, "verify", str(root)],
+                capture_output=True, text=True,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("OK", result.stdout)
 
 
 class CertificateTableSizeTests(unittest.TestCase):
@@ -242,6 +302,68 @@ class ListUnsignedCliTests(unittest.TestCase):
             )
             self.assertEqual(result.returncode, 0, result.stderr)
             self.assertIn("OK", result.stdout)
+
+
+class ListUnsignedCrossDriveTests(unittest.TestCase):
+    """#2286: when a path can't be made relative to --relative-to (the
+    Windows cross-drive case), _cmd_list_unsigned must fail loudly instead
+    of silently emitting an absolute path -- azure/artifact-signing-action
+    joins every catalog entry onto the workspace root before Resolve-Path,
+    so an absolute entry can never resolve on the signing runner. A real
+    cross-drive path can't be produced on a single-drive Linux CI runner, so
+    this drives the failure by making os.path.relpath raise ValueError
+    directly, the same way it does for a real cross-drive pair on Windows.
+    """
+
+    def _make_tree(self, root: Path):
+        (root / "unsigned.dll").write_bytes(build_fake_pe(0x20B, cert_table_size=0))
+
+    def test_relpath_valueerror_fails_loudly_naming_path_and_reason(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self._make_tree(root)
+            args = pe_signing.argparse.Namespace(
+                roots=[str(root)],
+                relative_to=str(root),
+                exclude_dir=[],
+                catalog=None,
+            )
+
+            def raising_relpath(_path, _start):
+                raise ValueError("path is on mount 'D:', start on mount 'C:'")
+
+            captured_stderr = __import__("io").StringIO()
+            with unittest.mock.patch.object(
+                pe_signing.os.path, "relpath", side_effect=raising_relpath
+            ), unittest.mock.patch("sys.stderr", captured_stderr):
+                with self.assertRaises(SystemExit) as cm:
+                    pe_signing._cmd_list_unsigned(args)
+
+            self.assertEqual(cm.exception.code, 1)
+            message = captured_stderr.getvalue()
+            self.assertIn("unsigned.dll", message)
+            self.assertIn("relative to", message)
+            self.assertIn("different drive", message)
+
+    def test_normal_tree_without_the_valueerror_still_emits_relative_paths(self):
+        # The un-mocked control case, in the same class as the failure case,
+        # so both directions of this behaviour live together.
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self._make_tree(root)
+            args = pe_signing.argparse.Namespace(
+                roots=[str(root)],
+                relative_to=str(root),
+                exclude_dir=[],
+                catalog=None,
+            )
+
+            captured_stdout = __import__("io").StringIO()
+            with unittest.mock.patch("sys.stdout", captured_stdout):
+                result = pe_signing._cmd_list_unsigned(args)
+
+            self.assertEqual(result, 0)
+            self.assertEqual(captured_stdout.getvalue().strip(), "unsigned.dll")
 
 
 if __name__ == '__main__':

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -426,6 +426,40 @@ jobs:
           timestamp-rfc3161: http://timestamp.acs.microsoft.com
           timestamp-digest: SHA256
 
+      - name: Verify every signed file's Authenticode signature actually validates (#2284)
+        # pe_signing.py's checks (this job's next step, and both checks in the release
+        # job below) are presence checks only -- they read the PE Certificate Table's
+        # Size field and treat "nonzero" as "signed" (see that script's docstring). A
+        # malformed signature, one that chains to no trusted root, or one missing its
+        # RFC 3161 timestamp still has a nonzero Certificate Table, so every one of
+        # those gates would pass it. This is the real chain-of-trust check: it runs
+        # here, on the Windows runner that just signed these files, using the same
+        # Get-AuthenticodeSignature cmdlet BusinessCentral.DbReader's v0.1.0 release
+        # measured working against an Azure Trusted Signing certificate on
+        # windows-latest.
+        #
+        # Scoped to catalog.txt -- the files THIS run signed -- not the whole tree.
+        # The ~84 files this workflow deliberately never touches carry Microsoft's or
+        # a third party's own signature, and an expired or untimestamped third-party
+        # certificate would fail a validity check for a reason that isn't our defect;
+        # those keep only the presence check.
+        shell: pwsh
+        run: |
+          $failures = @()
+          Get-Content catalog.txt | Where-Object { $_.Trim() -ne '' } | ForEach-Object {
+            $relativePath = $_
+            $fullPath = Join-Path '${{ github.workspace }}' $relativePath
+            $sig = Get-AuthenticodeSignature $fullPath
+            Write-Host "$relativePath -> $($sig.Status)  $($sig.SignerCertificate.Subject)"
+            if ($sig.Status -ne 'Valid') {
+              $failures += "$relativePath is not validly signed: $($sig.Status)"
+            }
+          }
+          if ($failures.Count -gt 0) {
+            $failures | ForEach-Object { Write-Error $_ }
+            exit 1
+          }
+
       - name: Verify the signing step actually signed everything it listed
         # Fail fast here, on the machine that just did the signing, rather than
         # discovering a gap only after packing and uploading. The release job


### PR DESCRIPTION
Closes #2284
Closes #2286

## What changed

**#2284 — the signing gate was a presence check everywhere, including where the docstring claimed a chain-of-trust check existed.**

`pe_signing.py verify` reads the PE Certificate Table's Size field and treats nonzero as "signed" — it never parses or validates the bytes there. All three gates in `publish.yml` used this same presence check, and the script's own docstring pointed readers at "publish.yml's sign-and-pack job for the chain-of-trust check" — that check did not exist anywhere in the repo.

Added a new step to `sign-and-pack`, after `azure/artifact-signing-action@v2` and before `dotnet pack`, that runs `Get-AuthenticodeSignature` over every path listed in `catalog.txt` (the files that run actually signed), requires `Status -eq 'Valid'`, prints the signer certificate subject for each, and fails naming the file and its status otherwise. Catalog entries are workspace-relative, so each is joined onto `${{ github.workspace }}` before the check.

Scoped to `catalog.txt` on purpose, not the whole tree: the ~84 files this workflow deliberately never signs carry Microsoft's or a third party's own signature, and an expired or untimestamped third-party certificate would fail a validity check for a reason that isn't this repo's defect — those keep only the existing presence check, unchanged.

Also fixed `pe_signing.py`'s docstring, which was pointing at a check that didn't exist — it now describes the real `Get-AuthenticodeSignature` step that exists in `publish.yml` and what it covers versus what the presence check still covers.

**#2286 — `pe_signing.py`'s cross-drive fallback produced a path form the signing action can never resolve.**

`azure/artifact-signing-action` joins every catalog entry onto the workspace root before calling `Resolve-Path`. The old fallback (when `os.path.relpath` raises `ValueError` for a cross-drive pair on Windows) emitted an absolute path instead — a form measured, in a sibling project's real release run, to never resolve (it doubles into something like `D:\a\repo\repo\D:\a\repo\repo\out\bcdb.exe`). `list-unsigned` now fails loudly instead, naming the file and explaining that a catalog entry must be relative to the workspace.

Nothing hits this path today (`publish.yml` always passes workspace-relative roots), so this is prevention for the day a root lands on a different drive, not a fix for an active failure.

## What the tests prove

`.github/scripts/test_pe_signing.py`, run locally (`python3 .github/scripts/test_pe_signing.py`, 15/15 passing):

- `PresenceCheckOnlyTests` — builds a PE whose Certificate Table has a nonzero size backed by arbitrary, non-Authenticode bytes (not even a well-formed `WIN_CERTIFICATE` header) and shows `pe_signing.py verify` reports it as signed. This is the exact defect #2284 describes: the existing check cannot and never could distinguish "present" from "valid," which is why the new workflow step is needed in addition to it.
- `ListUnsignedCrossDriveTests` — drives `_cmd_list_unsigned` with a `ValueError`-raising `os.path.relpath` (simulating the real cross-drive case, which can't be reproduced on a single-drive Linux CI runner) and asserts the specific failure message naming the file and reason, with `SystemExit(1)`. A second test in the same class confirms the un-mocked, normal case still emits relative paths (`unsigned.dll`).

RED → GREEN was run for both directions before the fix: the cross-drive test failed with `AssertionError: SystemExit not raised` against the old silent-fallback code, and passes now.

## What is NOT proven here

The `publish.yml` YAML change itself is not exercised by any CI in this repo — the signing path (Azure Trusted Signing, a real Windows runner, `windows-latest`) only runs on an actual release. I did not, and could not from here, run the new step against a real signing certificate.

What I did verify instead:
- The workflow YAML parses (`python3 -c "import yaml; yaml.safe_load(...)"`).
- The new step's PowerShell block parses with zero syntax errors under `[System.Management.Automation.Language.Parser]::ParseFile` (pwsh 7 is available locally).
- A semantic dry run of the same script block with `Get-AuthenticodeSignature` replaced by a mock function, run under `pwsh`, confirming both branches: an all-`Valid` catalog prints each signer subject and exits 0; a catalog with one `NotSigned` entry prints a `Write-Error` naming that exact file and status and exits 1.

None of that proves the real cmdlet's behavior against a real signature on the real signing runner — only that the control flow, syntax, and path-joining logic are correct. The first real proof will be the next actual release run.

## Fix-the-shape check

- Same wrong pattern elsewhere? Grepped `.github/` for `AuthenticodeSignature|signtool|osslsigncode` — before this change, only the two now-fixed docstring lines. No other gate silently claims a check it doesn't perform.
- Sibling function, same blind spot? `_cmd_verify` (the other pe_signing.py entry point) doesn't build any path relative to a workspace, so the cross-drive fallback pattern in #2286 doesn't recur there.
- Two writers of the same state? Only one place builds the catalog (`_cmd_list_unsigned`) and one place reads it as a workspace-relative path in `publish.yml` — no second writer to check for the same invariant.
