### PR TITLE
chore(ci): bump the three Node 20 actions in the release path

### DIFF
--- a/.github/workflows/bc-tests.yml
+++ b/.github/workflows/bc-tests.yml
@@ -497,7 +497,7 @@ jobs:
 
       - name: Upload result artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: results-${{ matrix.target.bc-version }}
           path: |

--- a/.github/workflows/coverage-demo.yml
+++ b/.github/workflows/coverage-demo.yml
@@ -56,7 +56,7 @@ jobs:
           done
 
       - name: Upload coverage artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-reports
           path: cobertura-*.xml

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -314,7 +314,7 @@ jobs:
         # The FULL obj/bin tree for all three projects, not just bin/publish/ — see
         # the #2248 header comment for why: `dotnet pack --no-build` still re-runs
         # the SDK's Publish-target copy phase, which needs these as copy sources.
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: unsigned-build
           path: |
@@ -362,7 +362,7 @@ jobs:
           python-version: '3.x'
 
       - name: Download the unsigned build tree
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: unsigned-build
           path: .
@@ -402,7 +402,7 @@ jobs:
         # client secret anywhere in this job. Confirmed by reproduction: omitting this step
         # fails with "WorkloadIdentityCredential authentication unavailable. The workload
         # options are not fully configured."
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');
@@ -502,7 +502,7 @@ jobs:
           python .github/scripts/pe_signing.py verify $extractDir
 
       - name: Upload the signed nupkg
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: signed-nupkg
           path: nupkg/*.nupkg
@@ -541,7 +541,7 @@ jobs:
 
       - name: Download the signed nupkg
         id: download-nupkg
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: signed-nupkg
           path: ./nupkg


### PR DESCRIPTION
Closes #2285

## What changed

Bumped the three actions still on the Node 20 runtime, verified against each action's own `action.yml` at the target tag (not release notes):

| action | before | after | runtime confirmed |
|---|---|---|---|
| `actions/github-script` | v7 | v9 | node24 |
| `actions/upload-artifact` | v4 | v7 | node24 |
| `actions/download-artifact` | v4 | v8 | node24 |

`azure/artifact-signing-action@v2` is untouched — it's current, per the issue. `checkout@v6`, `setup-dotnet@v5`, `setup-python@v5`, and `softprops/action-gh-release@v2` are already on Node 24 (or not in the Node 20 set); left alone rather than bundling unrelated tidiness into this PR.

## download-artifact v4 -> v8 (crosses four majors)

Checked each major's release notes against our actual usage, since the issue flagged this one as needing more than a number bump:

- **v5**: breaking change to path behavior for single-artifact downloads **by `artifact-ids`**. Both of our usages (`publish.yml:365` and `publish.yml:544`) download by `name:`, not `artifact-ids` — not affected.
- **v6**: Node 24 runtime only.
- **v7**: Node 24 runtime only (restates v6's change as the new default, minimum runner 2.327.1 — satisfied by GitHub-hosted runners).
- **v8**: ESM migration (stated transparent to callers); hash-mismatch on download now errors by default instead of silently ignoring it, and non-zip content types are no longer force-unzipped. Neither of our usages sets `merge-multiple`, `pattern`, or relies on unzip-of-a-non-zip; the new inputs (`skip-decompress`, `digest-mismatch`) are both additive with defaults that don't change existing behavior for a matching download.

## github-script v7 -> v9

v9's stated breaking change is that `require('@actions/github')` no longer works and `getOctokit` is now an injected script parameter. Our one script (`publish.yml:405`) only calls `core.getIDToken` and `core.exportVariable`, plus Node's own `fs`/`path` — it never touches `@actions/github` or declares `getOctokit`. Not affected.

## upload-artifact v4 -> v7

v5/v6 are Node 24 runtime bumps only. v7 adds an opt-in "direct upload" mode (`archive: false`) for single unzipped files — none of our three call sites set `archive`, so they keep the default zipped-upload behavior.

## What's proven and what isn't

- `upload-artifact@v7` at `bc-tests.yml:500` runs on every push via the BC-version matrix — this PR's own CI is real coverage for that bump.
- `upload-artifact@v7` at `coverage-demo.yml:59` is `workflow_dispatch`-only, not exercised by this PR's CI.
- The `pack` job (`bc-tests.yml`'s "Release pack (dry, no publish)") does **not** exercise any of the three bumped actions — I checked its full step list and it only uses `checkout@v6` and `setup-dotnet@v5`; the dry-run pack happens in a single job with no artifact hand-off, unlike `publish.yml`'s three-job split.
- **`github-script@v9` and `download-artifact@v8`/`upload-artifact@v7` inside `publish.yml`'s `build`/`sign-and-pack`/`release` jobs are only exercised by an actual release run**, same limitation the issue calls out for the OIDC-token step specifically. A green CI check on this PR proves the YAML parses and the exercised legs still pass; it does not prove the signing-credential path or the cross-job artifact handoff in `publish.yml` still works end to end. Recommend a dry run from `main` before the next real release (v2.10.0), as the issue also suggests.

## Fix the shape, not just the reported line

1. **Same wrong pattern elsewhere?** Grepped every workflow file for all three action names — `bc-tests.yml` and `coverage-demo.yml` both had an additional `upload-artifact@v4` the issue's table didn't call out (only `publish.yml`'s were mentioned in the reproduction). Bumped those too rather than leaving a second instance of the same gap.
2. **Sibling assumption?** `download-artifact` has two call sites in `publish.yml`, both `name:`-based — checked both against the v5 breaking change individually rather than assuming the first one's clearance covered the second.
3. **Two paths, one invariant?** N/A — no state-writing code paths here, just action version pins.