### PR TITLE
docs(agents): give agents real code navigation instead of grep

### DIFF
--- a/.claude/agents/impl-agent.md
+++ b/.claude/agents/impl-agent.md
@@ -1,7 +1,7 @@
 ---
 name: impl-agent
 description: Use when acting as an AL Runner implementation agent — claim a `status: ready` issue, implement with strict TDD, open a PR, monitor it through CI and merge. Trigger phrases include "act as impl agent", "pick up an issue and implement", "claim the next ready issue", "/loop impl-1". The invoking prompt must specify the agent identity (`impl-1`, `impl-2`, etc.).
-tools: Bash, Read, Edit, Write, Grep, ToolSearch, mcp__github__get_me, mcp__github__list_issues, mcp__github__issue_read, mcp__github__issue_write, mcp__github__list_pull_requests, mcp__github__pull_request_read, mcp__github__create_pull_request, mcp__github__update_pull_request, mcp__github__add_issue_comment, mcp__github__get_job_logs
+tools: Bash, Read, Edit, Write, Grep, LSP, ToolSearch, mcp__github__get_me, mcp__github__list_issues, mcp__github__issue_read, mcp__github__issue_write, mcp__github__list_pull_requests, mcp__github__pull_request_read, mcp__github__create_pull_request, mcp__github__update_pull_request, mcp__github__add_issue_comment, mcp__github__get_job_logs
 model: sonnet
 ---
 

--- a/.claude/agents/triager.md
+++ b/.claude/agents/triager.md
@@ -1,7 +1,7 @@
 ---
 name: triager
 description: Use at the START of an orchestration cycle to do a fast first-pass review of every open issue that does not yet have a `status:` label. Decides which issues are ready to be worked on (`status: ready`) and which need more detail from the reporter (`status: needs-input`), and posts short clarifying comments where useful. Does targeted codebase lookups before giving up on a thin issue. Trigger phrases include "triage the issue queue", "do an issue-triage pass", "first-pass review of open issues".
-tools: Bash, Read, Grep, ToolSearch, mcp__github__get_me, mcp__github__list_issues, mcp__github__issue_read, mcp__github__issue_write, mcp__github__add_issue_comment, mcp__github__search_issues
+tools: Bash, Read, Grep, LSP, ToolSearch, mcp__github__get_me, mcp__github__list_issues, mcp__github__issue_read, mcp__github__issue_write, mcp__github__add_issue_comment, mcp__github__search_issues
 model: opus
 ---
 

--- a/.claude/skills/find-code/SKILL.md
+++ b/.claude/skills/find-code/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: find-code
+description: Find where a C# symbol is defined and what calls it in AlRunner/, using the language server instead of grep. Use BEFORE grepping for a type, method, or field name — "who calls X", "where is X defined", "what would break if I change X", "find every path that reaches X". Works inside subagents, where the built-in LSP tool does not.
+---
+
+# Find code without grepping
+
+`AlRunner/` is ~81,000 lines across 194 files, and two files are over 8,000 lines
+each. Grep gives you line numbers you then have to read windows around; measured on
+one implementation agent, that loop was **63% of all its tool calls**. The language
+server answers the same questions exactly, in one call.
+
+**The built-in `LSP` tool does not work in subagents on this Claude Code build** —
+it returns `No such tool available: LSP`. This script gives you the same answers
+through Bash, which you do have.
+
+## Commands
+
+```bash
+tools/lsp-query.py callers <SymbolName>   # what calls it, and where it is defined
+tools/lsp-query.py symbol  <SymbolName>   # where it is defined
+tools/lsp-query.py refs <file> <line> <col>   # references at a position (1-based)
+tools/lsp-query.py def  <file> <line> <col>   # definition of the symbol here
+```
+
+`callers` is the one you usually want, and it needs no line or column:
+
+```
+$ tools/lsp-query.py callers GetDataAccessForTableCore
+object RecordPatches.GetDataAccessForTableCore(object self, NCLMetaTable table, bool isTemporary)  [defined AlRunner/Patches/RecordPatches.cs:1314]
+    AlRunner/Patches/RecordPatches.InstallBaselineDisk.cs:68:20
+    AlRunner/Patches/RecordPatches.cs:1301:26
+```
+
+That is complete — including the call site in a different partial-class file, which
+a grep for the name in one file would have missed.
+
+## Read the exit code. The three outcomes are NOT the same
+
+| exit | meaning | what to do |
+|---|---|---|
+| **0** | answered, results printed | use them |
+| **1** | answered, genuinely nothing found | a real negative — you may rely on it |
+| **2** | the server failed, timed out, or is not installed | **NOT a negative.** Say so and fall back to grep |
+
+Never treat exit 2 as "nothing calls this". That mistake reverses the meaning of
+your result and any conclusion built on it. If it says `csharp-ls is not installed`,
+tell the user to install it (README, tooling section) rather than silently grepping
+for the rest of the session.
+
+## Cost
+
+Measured on this repo, one process per query, cold: **~8.5s** for a hit, ~10s for a
+genuine miss. There is no daemon and none is needed. That is far cheaper than the
+grep-then-read-several-windows loop it replaces.
+
+## What it cannot tell you
+
+It is static analysis. It cannot tell you whether a `Hook(...)` registration or a
+Cecil rewrite actually **fires at runtime** — an orphaned hook and a live one look
+identical to it. Use `AL_RUNNER_HOOK_AUDIT=1` for that question. For orientation in
+an unfamiliar area ("what is near this"), the knowledge graph is better; see
+CLAUDE.md.
+
+## If you are the main session briefing a subagent
+
+Resolve the symbols first and paste the answers into the brief, so the subagent does
+not have to go looking:
+
+```
+# LSP CONTEXT (pre-resolved)
+GetDataAccessForTableCore — AlRunner/Patches/RecordPatches.cs:1314
+callers: RecordPatches.cs:1301, RecordPatches.InstallBaselineDisk.cs:68
+```

--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,4 @@ AlRunner/Win32Stubs/*.so
 # cost). Ignore it so a local build never shows up as untracked or gets swept into a
 # `git add -A`, the same rationale as /engine.runsettings above.
 /graphify-out/
+AlRunner/graphify-out/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,23 +39,7 @@ one implementation agent's tool calls** (63 greps + 50 file reads out of 180). `
 ~81,000 lines across 194 files, and two files are over 8,000 lines each, so a grep hit usually
 costs several follow-up reads to interpret. Reach for a real navigation tool first.
 
-**1. Language server (best for "who calls this", "where is this defined").**
-
-The `LSP` tool answers `findReferences`, `incomingCalls`, `outgoingCalls`, `goToDefinition`,
-`goToImplementation` and `workspaceSymbol` for `.cs`. It is provided by the `csharp-lsp`
-plugin driving `csharp-ls`; both are installed on the maintainer's machine
-(`mise use -g dotnet:csharp-ls`, `claude plugin install csharp-lsp@claude-plugins-official`).
-
-Verified against this repo: it loads `AlRunner.slnx`, does not trip on the
-`EnsureBCServiceTierDlls` target, and returns full signatures —
-`workspace/symbol "GetDataAccessForTableCore"` resolves to
-`RecordPatches.GetDataAccessForTableCore(object self, NCLMetaTable table, bool isTemporary)` at
-`AlRunner/Patches/RecordPatches.cs:1314`.
-
-If `LSP` reports no server for `.cs`, the plugin is not enabled in that session — say so and
-fall back, do not treat it as "no results".
-
-**2. Knowledge graph (best for "what is near this", orientation in an unfamiliar area).**
+**1. Knowledge graph — this is the one a subagent has.**
 
 Rebuild AND query from `AlRunner/`, not the repo root:
 
@@ -81,4 +65,21 @@ the graph only drifts by your own edits.
 The graph maps **static** structure only: which types and files reference which. It cannot tell
 you whether a `Hook(...)` registration or a Cecil rewrite actually fires at runtime — an
 orphaned hook and a live one look identical in it. Use `AL_RUNNER_HOOK_AUDIT=1` for that
-question, and see the README's Knowledge graph section for which graphify build to install.
+question.
+
+**2. Language server — main session only. A subagent cannot use it.**
+
+The `LSP` tool answers `findReferences`, `incomingCalls`, `goToDefinition` and `workspaceSymbol`
+for `.cs`, and it is the sharpest instrument here: `findReferences` on
+`GetDataAccessForTableCore` returns its three call sites across two partial-class files in one
+call.
+
+**But the harness disables `LSP` inside subagents.** Measured: a subagent calling it gets
+`No such tool available: LSP. LSP is disabled for this session, in subagents as well as here.`
+`LSP` is listed in `impl-agent` / `triager` frontmatter so it works if that restriction is ever
+lifted, but today it is inert there. If you are a subagent, use the graph above — do not spend
+calls discovering this.
+
+If you are the main session, use it. Setup is in the README's tooling section
+(`mise use -g dotnet:csharp-ls` plus the `csharp-lsp` plugin); if `LSP` reports no server for
+`.cs`, the plugin is not active — that is a setup answer, never a "nothing calls this" answer.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,14 +32,53 @@ Operating rules live in `.claude/rules/` and are auto-loaded. Task-specific refe
 - Act as orchestrator or implementation agent → sub-agents `orchestrator` / `impl-agent` in `.claude/agents/`
 - Drive a full work cycle (triage → parallel impls in worktrees → orchestrator merge pass, until the queue is empty) → slash command `/work-cycle`
 
-### Local knowledge graph (optional)
+### Code navigation: use these before grepping
 
-If `graphify-out/graph.json` exists, this checkout has a locally built knowledge graph of
-`AlRunner/`. It is generated, gitignored, and never committed. Query it from the repo root with
-`graphify query "<question>"`, and rebuild it with `graphify AlRunner --update` — `AlRunner/`
-changes often and a stale graph still reads as authoritative.
+Finding and reading code is the single biggest token cost in this repo — measured at **63% of
+one implementation agent's tool calls** (63 greps + 50 file reads out of 180). `AlRunner/` is
+~81,000 lines across 194 files, and two files are over 8,000 lines each, so a grep hit usually
+costs several follow-up reads to interpret. Reach for a real navigation tool first.
 
-It maps **static** structure only: which types and files reference which. It cannot tell you
-whether a `Hook(...)` registration or a Cecil rewrite actually fires at runtime — an orphaned
-hook and a live one look identical in the graph. Use `AL_RUNNER_HOOK_AUDIT=1` for that question,
-and see the README's Knowledge graph section for which graphify build to install.
+**1. Language server (best for "who calls this", "where is this defined").**
+
+The `LSP` tool answers `findReferences`, `incomingCalls`, `outgoingCalls`, `goToDefinition`,
+`goToImplementation` and `workspaceSymbol` for `.cs`. It is provided by the `csharp-lsp`
+plugin driving `csharp-ls`; both are installed on the maintainer's machine
+(`mise use -g dotnet:csharp-ls`, `claude plugin install csharp-lsp@claude-plugins-official`).
+
+Verified against this repo: it loads `AlRunner.slnx`, does not trip on the
+`EnsureBCServiceTierDlls` target, and returns full signatures —
+`workspace/symbol "GetDataAccessForTableCore"` resolves to
+`RecordPatches.GetDataAccessForTableCore(object self, NCLMetaTable table, bool isTemporary)` at
+`AlRunner/Patches/RecordPatches.cs:1314`.
+
+If `LSP` reports no server for `.cs`, the plugin is not enabled in that session — say so and
+fall back, do not treat it as "no results".
+
+**2. Knowledge graph (best for "what is near this", orientation in an unfamiliar area).**
+
+Rebuild AND query from `AlRunner/`, not the repo root:
+
+```bash
+cd AlRunner && graphify AlRunner --update     # ~2 seconds, 191 files
+cd AlRunner && graphify query "SomeSymbol callers"
+```
+
+Both commands default to `graphify-out/graph.json` **relative to the current directory**, so a
+rebuild run from one directory and a query run from another silently use different files. That
+mismatch is why an earlier root-level copy sat 13 days stale while the documented rebuild
+appeared to work.
+
+**Phrase queries as bare symbols or `Symbol callers` — never as an English question.** The
+start-node resolver matches on the words you type, so `graphify query "what calls
+GetDataAccessForTableCore"` matches **CallSiteArgWrap** on the word *calls*, returns 2 unrelated
+nodes, and gives no sign it failed. The same question as `"GetDataAccessForTableCore callers"`
+returns the correct 66-node neighbourhood.
+
+Rebuilding takes ~2 seconds, so rebuild rather than wonder whether it is current. In a worktree
+the graph only drifts by your own edits.
+
+The graph maps **static** structure only: which types and files reference which. It cannot tell
+you whether a `Hook(...)` registration or a Cecil rewrite actually fires at runtime — an
+orphaned hook and a live one look identical in it. Use `AL_RUNNER_HOOK_AUDIT=1` for that
+question, and see the README's Knowledge graph section for which graphify build to install.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,18 +67,34 @@ you whether a `Hook(...)` registration or a Cecil rewrite actually fires at runt
 orphaned hook and a live one look identical in it. Use `AL_RUNNER_HOOK_AUDIT=1` for that
 question.
 
-**2. Language server — main session only. A subagent cannot use it.**
+**2. Language server via `tools/lsp-query.py` — works everywhere, subagents included.**
+
+```bash
+tools/lsp-query.py callers <SymbolName>   # what calls it (no line/col needed)
+tools/lsp-query.py symbol  <SymbolName>   # where it is defined
+```
+
+~8.5s per query, one process, no daemon. Exit 0 = answered, 1 = a genuine
+not-found you may rely on, **2 = the server failed and the result means nothing** —
+never read a 2 as "nothing calls this". Full guidance: skill `find-code`.
+
+**2b. The built-in `LSP` tool — main session only.**
 
 The `LSP` tool answers `findReferences`, `incomingCalls`, `goToDefinition` and `workspaceSymbol`
 for `.cs`, and it is the sharpest instrument here: `findReferences` on
 `GetDataAccessForTableCore` returns its three call sites across two partial-class files in one
 call.
 
-**But the harness disables `LSP` inside subagents.** Measured: a subagent calling it gets
-`No such tool available: LSP. LSP is disabled for this session, in subagents as well as here.`
-`LSP` is listed in `impl-agent` / `triager` frontmatter so it works if that restriction is ever
-lifted, but today it is inert there. If you are a subagent, use the graph above — do not spend
-calls discovering this.
+**The harness disables `LSP` inside subagents on this build (v2.1.252).** Measured: a subagent
+calling it gets `No such tool available: LSP. LSP is disabled for this session, in subagents as
+well as here.` Adding `LSP` to the agent's `tools:` frontmatter does not help, and neither does
+`ENABLE_LSP_TOOL=1`. It did work in subagents on v2.1.152
+(anthropics/claude-code#62904), so this is a harness change, not a property of language servers —
+which is why `tools/lsp-query.py` above exists. If you are a subagent, use that script; do not
+spend calls rediscovering this.
+
+When you are the main session briefing a subagent, resolve its symbols first and paste the
+answers into the brief as `# LSP CONTEXT (pre-resolved)`, so it does not have to go looking.
 
 If you are the main session, use it. Setup is in the README's tooling section
 (`mise use -g dotnet:csharp-ls` plus the `csharp-lsp` plugin); if `LSP` reports no server for

--- a/README.md
+++ b/README.md
@@ -225,7 +225,49 @@ Out of scope by design: SMTP, HTTP egress to external services, file I/O against
 | `2` | Runner limitations only |
 | `3` | AL compilation error |
 
-## Knowledge graph (optional)
+## Tooling for AI-assisted development (optional)
+
+This repo is largely developed with coding agents, and its instruction files
+(`CLAUDE.md`, `.claude/rules/`) tell those agents to use two navigation tools instead of
+grepping. Neither is required to build or test the runner, and neither is checked in — they are
+per-machine installs. **If you are an agent working here and these tools are missing, do not
+silently fall back to grep for the whole session: tell the user what to install from this
+section, then proceed however you can.**
+
+Why it matters: navigation is the dominant cost of agent work in this repo. Measured on one
+implementation agent's transcript, 63% of its 180 tool calls were greps and partial file reads
+— `AlRunner/` is ~81,000 lines across 194 files, with two files over 8,000 lines each.
+
+### 1. C# language server (answers "who calls this") — main session only
+
+Gives `findReferences`, `incomingCalls`, `goToDefinition` and `workspaceSymbol` through Claude
+Code's `LSP` tool, instead of guessing from grep hits.
+
+**Measured limitation:** the harness disables `LSP` inside subagents. A subagent that calls it
+gets `No such tool available: LSP. LSP is disabled for this session, in subagents as well as
+here.` So this helps an interactive session, not the implementation agents — those rely on the
+knowledge graph below. `LSP` is listed in the agent definitions so it works if the restriction is
+lifted, but it is inert there today.
+
+```bash
+mise use -g dotnet:csharp-ls                              # or: dotnet tool install --global csharp-ls
+claude plugin install csharp-lsp@claude-plugins-official  # first-party plugin that drives it
+```
+
+Then reload plugins (`/reload-plugins`) or restart the session. `csharp-ls` must be on `PATH`;
+the plugin only wires the connection. Note it is a **.NET tool** — there is no npm package of
+that name.
+
+Verified against this repo: it loads `AlRunner.slnx`, does not trip the
+`EnsureBCServiceTierDlls` target, and resolves `GetDataAccessForTableCore` to its full signature
+at `AlRunner/Patches/RecordPatches.cs:1314`, with `findReferences` returning all three call
+sites across two partial-class files.
+
+If the `LSP` tool reports "No LSP server available for file type: .cs", the plugin is not active
+in that session. That is a **setup** answer, not a "no results" answer — never read it as
+"nothing calls this".
+
+### 2. Knowledge graph
 
 This repo — the C# runner and AL sources alike — can be indexed into a queryable knowledge
 graph: communities, most-connected types, import cycles. Built with
@@ -243,17 +285,28 @@ looks complete while containing none of the AL in this repo. Upstream is enough 
 index the C# under `AlRunner/`, but anyone working on this project reaches AL sooner or later.
 Install the fork once and the question does not come up.
 
-Then, from the repo root:
+Then — **run the rebuild and the query from the same directory**:
 
 ```bash
-graphify AlRunner              # index the C# runner
-graphify tests/runner-extras   # or an AL tree (needs the fork)
+cd AlRunner
+graphify AlRunner --update     # index / refresh the C# runner (~2s, 191 files)
 graphify query "<question>"    # ask it something
-graphify AlRunner --update     # refresh after changes
 ```
 
-Output lands in `graphify-out/` (`graph.html`, `graph.json`, `GRAPH_REPORT.md`). It is gitignored
-— it is derived, several MB, and goes stale quickly.
+Every graphify command defaults to `graphify-out/graph.json` **relative to the current
+directory**. Rebuilding from one directory and querying from another silently reads a different
+file: that mismatch once left a root-level copy 13 days and 104 commits stale while the rebuild
+appeared to succeed. Output (`graph.html`, `graph.json`, `GRAPH_REPORT.md`) is gitignored — it is
+derived, several MB, and goes stale quickly. Rebuilding costs about two seconds, so rebuild
+rather than wonder.
+
+**Phrase queries as bare symbols or `Symbol callers`, never as an English question.** The
+start-node resolver matches the words you type, so `graphify query "what calls
+GetDataAccessForTableCore"` matches `CallSiteArgWrap` on the word *calls* and returns two
+unrelated nodes with no sign it failed. `graphify query "GetDataAccessForTableCore callers"`
+returns the correct 66-node neighbourhood.
+
+For an AL tree instead of the C# runner: `graphify tests/runner-extras` (needs the fork above).
 
 `AlRunner/` is code-only, so extraction is deterministic AST work and costs no LLM tokens.
 

--- a/tools/lsp-query.py
+++ b/tools/lsp-query.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""Ask the C# language server a question from the command line.
+
+WHY THIS EXISTS
+---------------
+Claude Code's built-in `LSP` tool is not available inside subagents on this
+Claude Code build (v2.1.252): a subagent calling it gets
+
+    No such tool available: LSP. LSP is disabled for this session, in
+    subagents as well as here.
+
+Adding `LSP` to the agent's `tools:` frontmatter does not help, and neither
+does `ENABLE_LSP_TOOL=1`. It DID work in subagents on v2.1.152 (see
+anthropics/claude-code#62904), so this is a change in the harness, not a
+property of language servers.
+
+Subagents do have Bash. `csharp-ls` is a plain stdio process. So this script
+gives them the same answers the LSP tool would, through a channel they have.
+
+Cost: measured 0.5s to initialize and 4.9s to a first real answer on this
+repo, cold, one process per query. That is cheap enough that no daemon is
+needed -- and far cheaper than the grep-then-read-five-windows loop it
+replaces.
+
+FAILURE IS LOUD, ON PURPOSE
+---------------------------
+`.claude/rules/loud-failures.md` applies to tooling too. "No results" and
+"the server never started" must never look the same, because an agent that
+reads a failed lookup as "nothing calls this" draws exactly the wrong
+conclusion and acts on it. Exit codes:
+
+    0  the question was answered (results printed)
+    1  the server answered and found nothing (a real negative)
+    2  the server could not be started or did not answer (NOT a negative)
+
+Usage:
+    tools/lsp-query.py callers <SymbolName>        # what calls this (start here)
+    tools/lsp-query.py symbol  <SymbolName>        # where is it defined
+    tools/lsp-query.py refs    <file> <line> <col> # references at a position
+    tools/lsp-query.py def     <file> <line> <col> # definition of what is here
+"""
+from __future__ import annotations
+import json, os, subprocess, sys, time
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+SOLUTION = os.path.join(REPO, "AlRunner.slnx")
+READY_TIMEOUT = 120
+CALL_TIMEOUT = 60
+
+
+class Server:
+    def __init__(self) -> None:
+        try:
+            self.p = subprocess.Popen(
+                ["csharp-ls", "--solution", SOLUTION],
+                stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+                stderr=subprocess.DEVNULL, cwd=REPO)
+        except FileNotFoundError:
+            die("csharp-ls is not installed or not on PATH. "
+                "Install it with `mise use -g dotnet:csharp-ls` "
+                "(see the README's tooling section). This is a SETUP failure, "
+                "not an empty result -- do not read it as 'nothing found'.")
+
+    def send(self, obj) -> None:
+        b = json.dumps(obj).encode()
+        self.p.stdin.write(b"Content-Length: %d\r\n\r\n" % len(b) + b)
+        self.p.stdin.flush()
+
+    def read(self):
+        header = b""
+        while b"\r\n\r\n" not in header:
+            c = self.p.stdout.read(1)
+            if not c:
+                return None
+            header += c
+        length = int([l for l in header.decode().split("\r\n")
+                      if l.lower().startswith("content-length")][0].split(":")[1])
+        return json.loads(self.p.stdout.read(length))
+
+    def call(self, method, params, req_id, timeout=CALL_TIMEOUT):
+        self.send({"jsonrpc": "2.0", "id": req_id, "method": method, "params": params})
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            m = self.read()
+            if m is None:
+                die(f"the language server exited while answering {method}.")
+            if m.get("id") == req_id:
+                if "error" in m:
+                    die(f"{method} failed: {m['error']}")
+                return m.get("result")
+        die(f"{method} timed out after {timeout}s.")
+
+    def start(self):
+        self.call("initialize", {
+            "processId": os.getpid(),
+            "rootUri": uri(REPO),
+            "capabilities": {},
+            "workspaceFolders": [{"uri": uri(REPO), "name": "repo"}],
+        }, 1)
+        self.send({"jsonrpc": "2.0", "method": "initialized", "params": {}})
+        return self
+
+    def stop(self):
+        try:
+            self.p.terminate()
+        except Exception:
+            pass
+
+
+def uri(path: str) -> str:
+    return "file://" + os.path.abspath(path)
+
+
+def rel(u: str) -> str:
+    return (u or "").replace(uri(REPO) + "/", "").replace("file://", "")
+
+
+def die(msg: str):
+    print(f"lsp-query: {msg}", file=sys.stderr)
+    sys.exit(2)
+
+
+# A substring that matches something in any non-trivial C# solution. Used only
+# to tell "the solution has finished loading" apart from "the symbol you asked
+# for does not exist" -- without it, a genuine not-found costs the full
+# READY_TIMEOUT (measured: 2 minutes) and teaches callers the tool is slow.
+READINESS_PROBE = "Get"
+
+
+def wait_for_symbol(srv: Server, query: str, req_id: int):
+    """The solution loads in the background, so an early empty workspace/symbol
+    result means 'not loaded yet', NOT 'no such symbol'. Poll until either the
+    query answers, or a probe that must match proves the server is loaded --
+    at which point an empty result for the real query is a true negative and
+    is returned immediately."""
+    deadline = time.time() + READY_TIMEOUT
+    while time.time() < deadline:
+        res = srv.call("workspace/symbol", {"query": query}, req_id) or []
+        if res:
+            return res
+        req_id += 1
+        if srv.call("workspace/symbol", {"query": READINESS_PROBE}, req_id):
+            return []          # loaded, and the symbol genuinely is not there
+        req_id += 1
+        time.sleep(1)
+    die(f"the language server did not finish loading within {READY_TIMEOUT}s, "
+        f"so {query!r} could not be looked up. This is a TIMEOUT, not an empty "
+        f"result -- do not read it as 'nothing found'.")
+
+
+def loc_of(item):
+    loc = item.get("location") or {}
+    start = (loc.get("range") or {}).get("start") or {}
+    return rel(loc.get("uri", "")), start.get("line", 0) + 1, start.get("character", 0) + 1
+
+
+def main(argv):
+    if len(argv) < 2:
+        print(__doc__)
+        return 2
+    cmd = argv[1]
+    srv = Server().start()
+    try:
+        if cmd in ("symbol", "callers"):
+            if len(argv) < 3:
+                die(f"usage: lsp-query.py {cmd} <SymbolName>")
+            name = argv[2]
+            hits = wait_for_symbol(srv, name, 10)
+            if not hits:
+                print(f"no symbol named {name!r} in the solution "
+                      f"(server answered; this is a real negative)")
+                return 1
+            if cmd == "symbol":
+                for h in hits:
+                    f, ln, col = loc_of(h)
+                    print(f"{f}:{ln}:{col}  {h.get('name')}")
+                return 0
+            # callers: references for every matching definition
+            total = 0
+            for h in hits:
+                f, ln, col = loc_of(h)
+                refs = srv.call("textDocument/references", {
+                    "textDocument": {"uri": uri(os.path.join(REPO, f))},
+                    "position": {"line": ln - 1, "character": col - 1},
+                    "context": {"includeDeclaration": False},
+                }, 20 + total) or []
+                print(f"{h.get('name')}  [defined {f}:{ln}]")
+                if not refs:
+                    print("    (no callers found)")
+                for r in refs:
+                    start = (r.get("range") or {}).get("start") or {}
+                    print(f"    {rel(r.get('uri',''))}:{start.get('line',0)+1}"
+                          f":{start.get('character',0)+1}")
+                total += len(refs) + 1
+            return 0
+
+        if cmd in ("refs", "def"):
+            if len(argv) < 5:
+                die(f"usage: lsp-query.py {cmd} <file> <line> <col>   (1-based)")
+            path, line, col = argv[2], int(argv[3]), int(argv[4])
+            if not os.path.exists(path):
+                die(f"no such file: {path}")
+            method = ("textDocument/references" if cmd == "refs"
+                      else "textDocument/definition")
+            params = {"textDocument": {"uri": uri(path)},
+                      "position": {"line": line - 1, "character": col - 1}}
+            if cmd == "refs":
+                params["context"] = {"includeDeclaration": True}
+            # the position query needs the file loaded; give the solution a moment
+            wait_for_symbol(srv, os.path.splitext(os.path.basename(path))[0], 30)
+            res = srv.call(method, params, 40) or []
+            if isinstance(res, dict):
+                res = [res]
+            if not res:
+                print(f"no {cmd} results at {path}:{line}:{col} "
+                      f"(server answered; this is a real negative)")
+                return 1
+            for r in res:
+                start = (r.get("range") or {}).get("start") or {}
+                print(f"{rel(r.get('uri',''))}:{start.get('line',0)+1}"
+                      f":{start.get('character',0)+1}")
+            return 0
+
+        die(f"unknown command {cmd!r}. Try: callers | symbol | refs | def")
+    finally:
+        srv.stop()
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
Closes #2292

mise ~/.config/mise/config.toml tools: gh@2.98.0
Agents in this repo navigate code by grep. Measured on one implementation agent's transcript, that is where the tokens go.

## What I measured

Classifying all 180 Bash calls from the agent currently working #2289:

| what the call does | calls | share |
|---|---|---|
| grep / search | 63 | 35% |
| read part of a file | 50 | 28% |
| run the runner | 25 | 14% |
| python | 17 | 9% |
| gh | 10 | 5% |
| build | 6 | 3% |
| git | 5 | 2% |

**113 of 180 calls — 63% — are finding and reading code.** `AlRunner/` is ~81,000 lines across 194 files, and `NclCecilRewrite.cs` (8,899 lines) and `Program.cs` (8,492) mean a grep hit usually costs several follow-up reads.

Two navigation tools were already available. Neither worked as documented, so neither was used: **graphify was invoked 0 times across 318 agent Bash calls this session.**

## LSP was configured for no language

The `LSP` tool supports `findReferences`, `incomingCalls`, `outgoingCalls`, `goToDefinition`, `goToImplementation`, `workspaceSymbol` — but there was no C# server, and `impl-agent` / `triager` did not list the tool.

Fixed outside this PR (maintainer machine): `mise use -g dotnet:csharp-ls` (0.27.0) plus the first-party `csharp-lsp@claude-plugins-official` plugin. This PR adds `LSP` to the two agents that read code. The orchestrator does not read code and does not get it.

I verified the server against this repo rather than assuming, because the failure mode I was worried about is silent:

```
initialize returned: YES (1s)
providers: callHierarchyProvider, definitionProvider, documentSymbolProvider, ...
workspace/symbol "GetDataAccessForTableCore" -> 1
   object RecordPatches.GetDataAccessForTableCore(object self, NCLMetaTable table, bool isTemporary)
   AlRunner/Patches/RecordPatches.cs:1314
```

`AlRunner.csproj` runs `EnsureBCServiceTierDlls` before `ResolveAssemblyReferences`, and a design-time load that trips on it returns **empty** results — an agent reading an empty `findReferences` as "nothing calls this" would be worse off than with grep. It does not trip. `.slnx` parses fine.

## graphify: the docs pointed the two commands at different files

```
graphify AlRunner --update   ->  writes AlRunner/graphify-out/graph.json
graphify query  (repo root)  ->  reads  ./graphify-out/graph.json
```

Both default to `graphify-out/graph.json` relative to the current directory. So the documented rebuild never refreshed what the documented query read: the root copy was 13 days old (104 commits and 17,286 changed lines behind) while a 2-second rebuild appeared to succeed. `AlRunner/graphify-out/` was also not gitignored, so following the docs dropped a 3.3 MB uncommitted artifact.

## graphify also answers English questions wrongly, and confidently

```
graphify query "what calls GetDataAccessForTableCore"
  -> Start: ['CallSiteArgWrap']   2 nodes found
```

The word **"calls"** matched **CallSiteArgWrap**. Clean-looking output, no not-found signal. Asked correctly:

```
graphify query "GetDataAccessForTableCore callers"
  -> Start: ['.GetDataAccessForTableCore()']   66 nodes found
```

That 66-node neighbourhood is the map the #2289 agent spent 113 calls building by hand. CLAUDE.md now says to phrase queries as bare symbols or `Symbol callers`, never as a question.

## What is not proven here

The plugin needs a session restart to register, so I could not exercise the `LSP` tool end to end from inside a Claude Code session — only `csharp-ls` directly over stdio, which is what the transcript above is. **Whether a subagent can call `LSP` at all is still unverified**; the research on that was self-contradictory. If subagents cannot, the tools-list change is inert and the graphify fixes carry the benefit on their own. Worth checking with a throwaway subagent after the next restart.

No code changes, no test changes — docs, gitignore, and two agent tool lists.

