### PR TITLE
fix(test-data): seed AutoIncrement from storage and force hydration first

### DIFF
--- a/AlRunner/Patches/RecordPatches.StoredTableCensus.cs
+++ b/AlRunner/Patches/RecordPatches.StoredTableCensus.cs
@@ -123,4 +123,111 @@ public static partial class RecordPatches
         try { return meta.TableName ?? ""; }
         catch { return ""; }
     }
+
+    /// <summary>
+    /// Highest value currently stored in <paramref name="fieldNo"/> across every row of
+    /// <paramref name="tableId"/>, summed over every DataAccessSource that has materialised it
+    /// (mirrors <see cref="CollectCensus"/>'s "empty is a claim, not a default" discipline).
+    ///
+    /// WHY THIS EXISTS (issue #2289): <c>BcRuntime.AssignAutoIncrement</c>'s per-table counter
+    /// is populated ONLY by AL code that actually runs <c>NavRecord.ALInsertAsync</c>. A
+    /// --test-data hydration inserts rows straight into a table's <c>TempTableDataProvider</c>
+    /// via reflection (see RecordPatches.TestDataHydration.cs) precisely because replaying a
+    /// backup through AL's own Insert would run triggers a restore never runs — so the counter
+    /// never learns a hydrated table's real high-water mark, and the very next AL Insert reuses
+    /// a number the backup already occupies. Seeding the counter from this read, the first time
+    /// it is ever consulted for a table, is what closes that gap: by the time any AL Insert can
+    /// reach a table's AutoIncrement field, the record's own construction has already gone
+    /// through <c>GetDataAccessForTableCore</c> and therefore already blocked on hydration (see
+    /// that method's doc comment), so this read always sees whatever hydration put there.
+    ///
+    /// False (max left at 0) when the table has no materialised storage yet, the field cannot
+    /// be located, or every stored value is blank — the caller's own counter already starts at
+    /// 0 in that case, so "unknown" and "genuinely empty" collapse to the same safe seed here,
+    /// unlike the row-count census above where the distinction matters to a human reading a
+    /// diagnosis.
+    /// </summary>
+    internal static bool TryGetMaxFieldValue(int tableId, int fieldNo, out long max)
+    {
+        max = 0;
+        var found = false;
+        foreach (var (_, perTable) in _dataAccessByTable)
+        {
+            if (!perTable.TryGetValue(tableId, out var dataAccess)) continue;
+
+            object? provider;
+            object? metaTableObj;
+            object? primaryTree;
+            try
+            {
+                provider = GetDataProvider(dataAccess);
+                if (provider == null || provider.GetType().Name != "TempTableDataProvider") continue;
+                var providerType = provider.GetType();
+                metaTableObj = RequiredField(providerType, "table").GetValue(provider);
+                primaryTree = RequiredField(providerType, "primaryTree").GetValue(provider);
+            }
+            catch (MissingFieldException) { continue; }
+            catch (TargetInvocationException) { continue; }
+
+            if (metaTableObj is not NCLMetaTable meta) continue;
+            if (!meta.TryGetFieldByNo(fieldNo, out var field) || field == null) continue;
+
+            // Index into TempTableRecordBuffer.ToArray() by FIELD-DEFINITION-ORDER position,
+            // not by field number — the same indexing HydrateTestDataTable/BuildTestDataRow
+            // already rely on (meta.GetFieldByIndex(fi) <-> values[fi]).
+            var columnIndex = -1;
+            for (var fi = 0; fi < meta.FieldCount; fi++)
+            {
+                if (!ReferenceEquals(meta.GetFieldByIndex(fi), field)) continue;
+                columnIndex = fi;
+                break;
+            }
+            if (columnIndex < 0) continue;
+
+            if (primaryTree is not IEnumerable tree) continue;
+            foreach (var row in tree)
+            {
+                if (row is not TempTableRecordBuffer buffer) continue;
+                NavValue[] values;
+                try { values = buffer.ToArray(); }
+                catch { continue; }
+                if (columnIndex >= values.Length) continue;
+                var value = values[columnIndex];
+                if (value == null) continue;
+                bool isBlank;
+                try { isBlank = value.IsZeroOrEmpty; }
+                catch { continue; }
+                if (isBlank) continue;
+                if (!TryToLong(value, out var numeric)) continue;
+                found = true;
+                if (numeric > max) max = numeric;
+            }
+        }
+        return found;
+    }
+
+    /// <summary>
+    /// Best-effort NavValue -> long, mirroring RecordPatches.FieldFindIntercept's
+    /// NavValueToInt pattern: try a public "Value" property first (covers NavInteger,
+    /// NavBigInteger and similar numeric wrappers), then fall back to parsing ToString().
+    /// AutoIncrement fields are always integral (BC only allows Integer/BigInteger), so a
+    /// failure here means the field type changed underneath us — skip the row rather than
+    /// guess.
+    /// </summary>
+    private static bool TryToLong(NavValue value, out long result)
+    {
+        result = 0;
+        var t = value.GetType();
+        var vProp = t.GetProperty("Value", BindingFlags.Public | BindingFlags.Instance);
+        if (vProp != null)
+        {
+            var v = vProp.GetValue(value);
+            if (v != null)
+            {
+                try { result = Convert.ToInt64(v); return true; }
+                catch { /* fall through to string parse */ }
+            }
+        }
+        return long.TryParse(value.ToString(), out result);
+    }
 }

--- a/AlRunner/Patches/RecordWritePatches.cs
+++ b/AlRunner/Patches/RecordWritePatches.cs
@@ -537,6 +537,76 @@ public static partial class BcRuntime
         => _aiFieldIds[tableId] = fieldNo;
 
     /// <summary>
+    /// <summary>
+    /// Force this table's storage into existence — and therefore, if --test-data is armed,
+    /// force its hydration — on <paramref name="self"/>'s own DataAccessSource, before
+    /// AssignAutoIncrement is allowed to read the table's current high-water mark.
+    ///
+    /// ISSUE #2289, why this call exists and isn't optional: the record actually being
+    /// inserted does NOT reliably reach RecordPatches.GetDataAccessForTableCore itself before
+    /// getting here. Measured on 'Retention Policy Log Entry': the codeunit's own working
+    /// Record variable's first construction (RecordImplementation.InitializeImpl →
+    /// DataAccessSource.GetDataAccessForTable) can precede the FIRST place anything else
+    /// touches that table id at all, so seeding the counter from a scan taken at THAT moment
+    /// sees an empty table — hydration had not fired for this table yet, anywhere, on any
+    /// source. A seed-once-on-first-consult design (the first cut of this fix) is exactly as
+    /// blind as the counter it replaced in that ordering: it locks in "0" before hydration
+    /// ever runs, and every later call just increments from there, walking straight into the
+    /// backup's own row numbers one at a time until a duplicate-key hit downstream (measured:
+    /// the first cut still collided, just later — Entry No. 98 instead of 4 — once the earlier
+    /// fix let more of the install trigger run before hitting the next un-synced instance of
+    /// the same defect).
+    ///
+    /// The fix that actually holds regardless of ordering: don't wait to observe that
+    /// hydration happened — MAKE it happen, from here, before ever reading the table's
+    /// current max. RecordPatches.GetDataAccessForTableCore's own per-(source,tableId) cache
+    /// makes this free after the first call (a dictionary hit), so calling it unconditionally
+    /// on every AutoIncrement assignment costs nothing once the table is already materialised,
+    /// and is the ONLY thing that is correct on the very first call regardless of which AL
+    /// code path got there first.
+    /// </summary>
+    private static void EnsureTableTouchedForAutoIncrement(Microsoft.Dynamics.Nav.Runtime.NavRecord self)
+    {
+        var session = self.ParentSession;
+        if (session == null) return;
+        var dataAccessSource = AlRunner.Patches.RecordPatches.NavSession_get_DataAccessSource(session);
+        if (dataAccessSource == null) return;
+        // Discard the result deliberately: the point is the SIDE EFFECT (this table's
+        // storage — and therefore its --test-data hydration, if armed — now exists in
+        // RecordPatches' per-(source,tableId) store), not the DataAccess instance itself.
+        AlRunner.Patches.RecordPatches.NavDataAccessSource_GetDataAccessForTable(
+            dataAccessSource, self.MetaTable, isTemporary: false);
+    }
+
+    /// <summary>
+    /// The next value for <paramref name="tableId"/>'s AutoIncrement field
+    /// <paramref name="fieldNo"/>, atomically seeded-then-advanced.
+    ///
+    /// ISSUE #2289: <c>_aiCounters</c> used to start every table at an implicit 0/1 and
+    /// advance ONLY through this call — a pure in-memory counter that never consulted actual
+    /// storage. A --test-data hydration inserts rows straight into a table's
+    /// TempTableDataProvider via reflection (RecordPatches.TestDataHydration.cs), bypassing
+    /// NavRecord.ALInsertAsync entirely, so it never advanced this counter either. Result: the
+    /// first AL Insert into a table --test-data had already hydrated computed "1" (or whatever
+    /// the counter's stale start was) while the table already held that primary key, and BC's
+    /// own duplicate-key check caught the collision downstream — measured on 'Retention Policy
+    /// Log Entry' colliding at Entry No. 4 against a 63-row hydrated backup.
+    ///
+    /// The fix: on the FIRST consult for a table (<c>_aiCounters</c> has no entry yet), seed
+    /// from the table's actual current high-water mark (<see
+    /// cref="RecordPatches.TryGetMaxFieldValue"/>) instead of 0. This is safe to do ONLY
+    /// once the caller (AssignAutoIncrement, via EnsureTableTouchedForAutoIncrement above) has
+    /// already forced this table's storage/hydration into existence — see that method's doc
+    /// comment for why merely reaching an Insert does not, on its own, guarantee that. Seeding
+    /// happens only once per table (AddOrUpdate's add-factory branch), so "load once" still
+    /// holds: no table gets re-scanned on every subsequent insert.
+    /// </summary>
+    private static long NextAutoIncrementValue(int tableId, int fieldNo)
+        => _aiCounters.AddOrUpdate(tableId,
+            addValueFactory: id => (AlRunner.Patches.RecordPatches.TryGetMaxFieldValue(id, fieldNo, out var max) ? max : 0L) + 1L,
+            updateValueFactory: (_, v) => v + 1L);
+
+    /// <summary>
     /// AutoIncrement assignment helper, called via Cecil-prepended IL at the start
     /// of NavRecord.ALInsertAsync(DataError, bool, bool). Pure side-effect:
     /// if the table has a registered AutoIncrement field and that field is currently
@@ -562,7 +632,12 @@ public static partial class BcRuntime
                 var currentVal = self.GetFieldValue(aiField);
                 if (currentVal.IsZeroOrEmpty)
                 {
-                    long next = _aiCounters.AddOrUpdate(tableId, 1L, (_, v) => v + 1L);
+                    // #2289: force this table's storage/hydration into existence BEFORE
+                    // reading its high-water mark — see EnsureTableTouchedForAutoIncrement's
+                    // doc comment for why the record being inserted cannot be trusted to have
+                    // already done this itself.
+                    EnsureTableTouchedForAutoIncrement(self);
+                    long next = NextAutoIncrementValue(tableId, aiFieldNo);
                     var newVal = Microsoft.Dynamics.Nav.Runtime.NavValue
                         .CreateNavValueFromObject(aiField, (object)(int)next);
                     self.SetFieldValue(aiField, newVal);
@@ -700,7 +775,8 @@ public static partial class BcRuntime
                 var currentVal = self.GetFieldValue(aiField);
                 if (currentVal.IsZeroOrEmpty)
                 {
-                    long next = _aiCounters.AddOrUpdate(tableId, 1L, (_, v) => v + 1L);
+                    EnsureTableTouchedForAutoIncrement(self);
+                    long next = NextAutoIncrementValue(tableId, aiFieldNo);
                     var newVal = Microsoft.Dynamics.Nav.Runtime.NavValue
                         .CreateNavValueFromObject(aiField, (object)(int)next);
                     self.SetFieldValue(aiField, newVal);

--- a/tests/test-data-fixture-autoincrement/TestDataAutoIncrementAfterHydration.Codeunit.al
+++ b/tests/test-data-fixture-autoincrement/TestDataAutoIncrementAfterHydration.Codeunit.al
@@ -1,0 +1,116 @@
+/// <summary>
+/// End-to-end proof for issue #2289: a table's AutoIncrement field must not hand out a key
+/// `--test-data` hydration already put in storage.
+///
+/// The repro from the issue, exactly: with `--test-data` pointed at the CRONUS sandbox
+/// backup and the Tests-TestLibraries dependency declared (pulling in System Application
+/// Test Library), `Codeunit138704.OnInstallAppPerCompany`'s own install-time logging calls
+/// `Codeunit3909."Retention Policy Log Impl.".CreateLogEntry`, which does a bare
+/// `RetentionPolicyLogEntry.Insert()` with no explicit "Entry No." — table 3905's
+/// AutoIncrement field (BigInteger, `AutoIncrement = true`, no application-level FindLast at
+/// all — see RetentionPolicyLogImpl.Codeunit.al / RetentionPolicyLogEntry.Table.al inside
+/// Microsoft's own System Application source) is what BC uses to pick the number. The CRONUS
+/// backup holds 63 real rows for this table (Entry No. 1-63, measured directly with `bcbak
+/// read`), and before this fix the runner's own AutoIncrement counter (BcRuntime._aiCounters)
+/// was a per-tableId in-memory value that started at 0/1 and was bumped ONLY by
+/// NavRecord.ALInsertAsync — never by --test-data's own reflection-based row insert
+/// (RecordPatches.TestDataHydration.cs bypasses ALInsertAsync on purpose, since replaying a
+/// backup through AL Insert would run triggers a restore never runs). Result: the very next
+/// AL Insert into an already-hydrated table reused a number the backup already occupied and
+/// NavCSideDuplicateKeyException aborted the whole install trigger before a single [Test]
+/// method ran (exit 3, 0 tests).
+///
+/// Table 3905 "Retention Policy Log Entry" is `Access = Internal` inside System Application,
+/// so this test opens it via RecordRef(3905) rather than a static `Record "..."` variable —
+/// Access modifiers are a compile-time restriction on static type references, not on a
+/// runtime-resolved RecordRef, and BC honours that distinction the same way here.
+///
+/// NOT RUN BY CI — see tests/test-data-fixture/README.md. This bundle only passes with
+/// --test-data and a BC sandbox backup on the machine, same reason that fixture has its own
+/// directory. It is a SEPARATE app from tests/test-data-fixture/ (own app.json, own idRange)
+/// because it needs the Tests-TestLibraries dependency to reach System Application's own
+/// install triggers, which the other fixture deliberately carries none of.
+/// </summary>
+codeunit 65300 "TDF AutoInc After Hydration"
+{
+    Subtype = Test;
+
+    /// <summary>
+    /// Reaching this line at all is half the proof: TestExecutor runs every dependency's
+    /// install triggers BEFORE any [Test] method executes, so a suite that gets here has
+    /// already survived Codeunit138704.OnInstallAppPerCompany without the
+    /// NavCSideDuplicateKeyException the issue reports. The count assertion is the other
+    /// half — the CONCRETE claim that the backup's own 63 rows (measured in the issue via
+    /// `bcbak read`, not assumed) are genuinely present, not merely "the table exists".
+    /// A build that hydrated nothing, or hydrated into a table the install trigger never
+    /// touches, would still reach this line; only the count catches that.
+    /// </summary>
+    [Test]
+    procedure RetentionPolicyLogEntry_HasHydratedRowsAfterInstall()
+    var
+        RetentionPolicyLog: RecordRef;
+        RowCount: Integer;
+    begin
+        RetentionPolicyLog.Open(3905); // "Retention Policy Log Entry" (Access = Internal)
+        RowCount := RetentionPolicyLog.Count();
+        if RowCount < 63 then
+            Error(
+                'expected at least 63 rows in Retention Policy Log Entry (the CRONUS backup''s ' +
+                'own row count, per issue #2289) plus whatever the install triggers logged on ' +
+                'top; found %1. Was this run without --test-data?', RowCount);
+    end;
+
+    /// <summary>
+    /// The load-bearing proof. Computes the highest "Entry No." already in the table (the
+    /// hydrated backup rows PLUS anything the install triggers already logged before this
+    /// test ran), inserts one more row through the exact same AutoIncrement mechanism the
+    /// install triggers used, and asserts the assigned number is strictly greater than that
+    /// pre-existing maximum.
+    ///
+    /// Before the fix this either throws NavCSideDuplicateKeyException outright (the counter
+    /// reused a number already in storage) or — the weaker failure the strict inequality
+    /// below exists to catch — could coincidentally assign a number that happens not to
+    /// collide without actually being derived from the table's real high-water mark. Asserting
+    /// a bare "no exception" would pass on the first shape only.
+    /// </summary>
+    [Test]
+    procedure RetentionPolicyLogEntry_NewInsertAfterHydrationDoesNotCollide()
+    var
+        ScanCursor: RecordRef;
+        InsertCursor: RecordRef;
+        EntryNoField: FieldRef;
+        MaxEntryNoBefore: BigInteger;
+        CurrentEntryNo: BigInteger;
+        NewEntryNo: BigInteger;
+    begin
+        // A SEPARATE RecordRef for the scan vs. the insert, deliberately: reusing one
+        // instance across FindSet/Next and then Init/Insert leaves the buffer positioned on
+        // the last row FindSet found, and Init() on a RecordRef does not blank field values
+        // the way a freshly-opened one starts blank — so field 1 would still read the LAST
+        // SCANNED row's own Entry No. going into Insert(), producing a self-inflicted
+        // duplicate-key error that has nothing to do with the AutoIncrement counter this test
+        // exists to check. Two independent cursors avoid that confound entirely.
+        ScanCursor.Open(3905); // "Retention Policy Log Entry" (Access = Internal)
+        if ScanCursor.FindSet() then
+            repeat
+                EntryNoField := ScanCursor.Field(1); // "Entry No."
+                CurrentEntryNo := EntryNoField.Value;
+                if CurrentEntryNo > MaxEntryNoBefore then
+                    MaxEntryNoBefore := CurrentEntryNo;
+            until ScanCursor.Next() = 0;
+
+        if MaxEntryNoBefore = 0 then
+            Error('Retention Policy Log Entry read back no rows at all — was this run without --test-data?');
+
+        InsertCursor.Open(3905);
+        InsertCursor.Insert(true);
+        EntryNoField := InsertCursor.Field(1);
+        NewEntryNo := EntryNoField.Value;
+
+        if NewEntryNo <= MaxEntryNoBefore then
+            Error(
+                'AutoIncrement reused a key --test-data hydration already put in the table ' +
+                '(issue #2289): new Entry No. %1 is not greater than the pre-existing max %2.',
+                NewEntryNo, MaxEntryNoBefore);
+    end;
+}

--- a/tests/test-data-fixture-autoincrement/app.json
+++ b/tests/test-data-fixture-autoincrement/app.json
@@ -1,0 +1,21 @@
+{
+  "id": "8e2f4a6b-1c3d-4e5f-9a7b-2c4d6e8f0a1b",
+  "name": "Runner Extras - Test Data + AutoIncrement Hydration (local, needs a BC backup)",
+  "publisher": "AL Runner",
+  "version": "1.0.0.0",
+  "brief": "Issue #2289: an AutoIncrement field must not reuse a key --test-data hydration already put in the table.",
+  "description": "NOT RUN BY CI — see README.md in tests/test-data-fixture/. This bundle only passes when the runner is invoked with --test-data and a BC sandbox backup is present, which no CI leg has (the artifact is ~1 GB). It is a SEPARATE app from tests/test-data-fixture/ (not an addition to it) because it needs the Tests-TestLibraries dependency to reach System Application's own install triggers, which the other fixture deliberately has none of.",
+  "dependencies": [
+    {
+      "id": "5d86850b-0d76-4eca-bd7b-951ad998e997",
+      "name": "Tests-TestLibraries",
+      "publisher": "Microsoft",
+      "version": "28.0.0.0"
+    }
+  ],
+  "idRanges": [ { "from": 65300, "to": 65309 } ],
+  "platform": "28.0.0.0",
+  "application": "28.0.0.0",
+  "runtime": "17.0",
+  "target": "Cloud"
+}


### PR DESCRIPTION
Closes #2289

## Diagnosis (theory 2 confirmed, with a twist)

Instrumented every touch of `Retention Policy Log Entry` end to end (env-gated traces,
stripped before this PR) against the exact repro in the issue. Findings:

- Hydration itself is genuinely blocking/synchronous — an independent census taken
  immediately after `GetDataAccessForTableCore`'s on-demand load returns confirmed the
  full row count landed before any caller could observe the table.
- The actual defect: `BcRuntime.AssignAutoIncrement`'s counter (`_aiCounters`) is a
  **pure in-memory value, keyed only by table id**, bumped *only* by
  `NavRecord.ALInsertAsync`. `--test-data` hydration inserts rows straight into a
  table's `TempTableDataProvider` via reflection (deliberately — replaying a backup
  through AL `Insert()` would run triggers a restore never runs), so it never advances
  this counter. The counter starts at 0 regardless of what hydration puts in storage.
- A first fix (seed the counter from storage's current max, but only on the counter's
  own first-ever consult) reduced the blast radius but did not close the gap: the record
  that first *constructs* for a table is not reliably the one whose `Insert()` first
  needs the AutoIncrement value, so the seed could still be taken before hydration had
  fully landed. Measured: the collision still reproduced, just later (Entry No. 98
  instead of 4).

So this is a hybrid of the issue's two theories — hydration is faithful and blocking,
but the AutoIncrement counter is a state path that never goes through
`GetDataAccessForTableCore` (the choke point) at all on its own.

## The fix

- `AssignAutoIncrement` now **forces** this table's storage into existence via
  `RecordPatches.GetDataAccessForTableCore` (same choke point hydration is gated on)
  *before* reading the table's current maximum — it does not wait to observe that
  something else already did this. `GetDataAccessForTableCore`'s own per-`(source,
  tableId)` cache makes this free after the first call.
- The counter's first-ever consult for a table seeds from
  `RecordPatches.TryGetMaxFieldValue` (new: walks the same in-memory store the existing
  row-count census does) instead of 0.
- Applied to both the live prepend target (`AssignAutoIncrement`, hooked via Cecil onto
  `NavRecord.ALInsertAsync(DataError,bool,bool)`) and its documented "kept as reference
  for the equivalence claim" dead-code sibling, so the two don't drift.

## Fix the shape, not just the reported line

1. **Same wrong pattern at another call site?** Yes — `NavRecord_ALInsertAsync3` (the
   dead-code sibling kept for the equivalence-claim documentation) had the identical
   blind `_aiCounters.AddOrUpdate(tableId, 1L, ...)` call. Fixed alongside the live one
   so they stay equivalent.
2. **Sibling function, same assumption?** `StampSystemFieldsOnInsert` is prepended to
   the same method and reads no counter/storage state at all (stamps the current
   UTC/session GUID), so it has no analogous gap. Grepped every other
   `ConcurrentDictionary<int, ...>` in `AlRunner/Patches/` — all are metadata/type
   caches, not data-dependent counters; `_aiCounters` is the only state of this shape.
3. **Two paths, same invariant?** Checked whether any other write path besides
   `NavRecord.ALInsertAsync` needs the same "force hydration, don't assume" treatment —
   `RecordRef.Insert()` (used by the proving test to reach the `Access = Internal`
   table) resolves to the identical 3-arg `ALInsertAsync` under the hood (confirmed by
   decompiling `NavRecordRef`/`NavRecord`), so it is covered by the same Cecil prepend;
   no separate fix needed there.

## Proving test

`tests/test-data-fixture-autoincrement/` — a new, separate app (own `app.json`, own
idRange `65300-65309`) rather than an addition to `tests/test-data-fixture/`, because it
needs the `Tests-TestLibraries` dependency to reach System Application's own install
triggers, which the existing fixture deliberately carries none of. Matches that
fixture's own convention: **not run by CI**, only passes locally with `--test-data` and
a BC sandbox backup present (see `tests/test-data-fixture/README.md`).

Two tests, both RED before this fix (`EXEC-FAIL: NavCSideDuplicateKeyException ...
Entry No.='98'`) and GREEN after:
- `RetentionPolicyLogEntry_HasHydratedRowsAfterInstall` — asserts the CRONUS backup's
  own 63 rows are genuinely present (concrete count, not "some rows exist").
- `RetentionPolicyLogEntry_NewInsertAfterHydrationDoesNotCollide` — computes the current
  max `Entry No.` via one `RecordRef` cursor, inserts through a second, independent
  cursor, and asserts the assigned number is strictly greater than the pre-existing max
  (not merely "no exception" — the weaker failure mode a coincidental non-collision
  could still pass).

Table 3905 `Retention Policy Log Entry` is `Access = Internal` inside System
Application, so both tests use `RecordRef.Open(3905)` rather than a static `Record
"..."` variable — access modifiers are a compile-time restriction on static type
references, not on a runtime-resolved `RecordRef`.

## Verified

- Original repro from the issue (`tests/runner-extras/manual-binding-dep` with
  `--test-data` against the CRONUS backup): exit 3 / 0 tests → exit 0, 3/3 pass. Run
  twice (cold + warm cache) — both green, warm run ~4s vs. cold ~110s (disk-cache HIT
  correctly skips re-running install triggers, confirming "load once" still holds).
- New proving test bundle: RED → GREEN, confirmed with the exact duplicate-key message
  from the issue on the RED run.
- No-`--test-data` path unaffected: `manual-binding-dep` without the flag still 3/3
  pass (same as before).
- `dotnet test AlRunner.Tests` (full suite, ~1386 tests): 1 failure across three runs,
  always `ProvisionExplicitModesTests.ResolveVersion_PrintsFullVersionToStdout` — a
  network-index-fetch timeout (`A task was canceled`), unrelated to this change and
  present with a changing failure count/set across runs (3, then 1, then 1), matching
  the load-dependent-flake pattern rather than a regression.

## Not verified

- The full corpus with `--test-data` on (the corpus itself doesn't ship a backup;
  `--test-data` is off by default there and this PR doesn't change that path).