### PR TITLE
test-data: drop an unmappable column, not the whole table

### DIFF
--- a/AlRunner.Tests/TestDataUnmappedColumnTests.cs
+++ b/AlRunner.Tests/TestDataUnmappedColumnTests.cs
@@ -1,0 +1,89 @@
+// A backup column that names no field of the target table must cost that COLUMN, not the
+// whole table (#2273 / #2301).
+//
+// Measured on BC 28.1 W1 CRONUS, running Microsoft's Tests-SINGLESERVER app: table 309
+// "No. Series Line" refused over `Allow Gaps in Nos.`, so the runner saw ZERO No. Series
+// Line rows for every series, and ~220 of the bucket's tests failed with "You cannot assign
+// new numbers from the number series <X>" — an error AL raises when a series has no lines at
+// all. The real backup's CONT line is CT000001..CT100000 with 23 used.
+//
+// `Allow Gaps in Nos.` is ObsoleteState = Removed / ObsoleteTag '27.0' (Business Foundation's
+// NoSeriesLineObsolete.TableExt.al, behind `#if not CLEANSCHEMA27`). The shipped
+// SymbolReference.json still declares it, so the reader names it, while the compiled app this
+// runner loads has no such field. A column absent from the target NCLMetaTable cannot be read
+// by ANY AL code in this run — it is not addressable — so dropping it hides nothing a test
+// could observe, while refusing the table hands AL an empty table it silently believes.
+using AlRunner.Patches;
+using Xunit;
+
+public class TestDataUnmappedColumnTests
+{
+    static IReadOnlySet<string> Fields(params string[] names)
+        => new HashSet<string>(names, StringComparer.Ordinal);
+
+    [Fact]
+    public void ColumnsThatAreFieldsAreMapped()
+    {
+        var plan = RecordPatches.PlanTestDataColumns(
+            Fields("Series Code", "Line No.", "Starting No."),
+            new[] { "Series Code", "Line No.", "Starting No." });
+
+        Assert.Equal(new[] { "Series Code", "Line No.", "Starting No." }, plan.Mapped);
+        Assert.Empty(plan.NotInThisBuild);
+        Assert.Empty(plan.FromUninstalledApps);
+    }
+
+    [Fact]
+    public void AColumnThisBuildHasNoFieldForIsDroppedNotRefused()
+    {
+        var plan = RecordPatches.PlanTestDataColumns(
+            Fields("Series Code", "Line No.", "Starting No."),
+            new[] { "Series Code", "Line No.", "Starting No.", "Allow Gaps in Nos." });
+
+        // The point of the test: the other three still hydrate.
+        Assert.Equal(new[] { "Series Code", "Line No.", "Starting No." }, plan.Mapped);
+        Assert.Equal(new[] { "Allow Gaps in Nos." }, plan.NotInThisBuild);
+        Assert.True(plan.CanHydrate);
+    }
+
+    [Fact]
+    public void ACompanionColumnOfAnUninstalledAppIsCountedSeparately()
+    {
+        // The pre-existing case (#2261): BC's raw storage form for an app outside this run's
+        // closure. It stays a distinct count because it means something different — the app
+        // is not here — rather than "this build's table has no such field".
+        var plan = RecordPatches.PlanTestDataColumns(
+            Fields("No."),
+            new[] { "No.", "Sust_ Cert_ No_$b3780cd9-f8f8-4a83-a4d5-0c2ad87b28af" });
+
+        Assert.Equal(new[] { "No." }, plan.Mapped);
+        Assert.Equal(new[] { "Sust_ Cert_ No_$b3780cd9-f8f8-4a83-a4d5-0c2ad87b28af" },
+            plan.FromUninstalledApps);
+        Assert.Empty(plan.NotInThisBuild);
+    }
+
+    [Fact]
+    public void ARowSharingNoColumnWithTheTableStillRefuses()
+    {
+        // The guard the old refusal existed for: a row whose shape has nothing to do with
+        // this table is a mismatch, not a dropped field, and hydrating it would fabricate
+        // rows of defaults. Dropping every column would do exactly that silently.
+        var plan = RecordPatches.PlanTestDataColumns(
+            Fields("Series Code", "Line No."),
+            new[] { "Customer No.", "Posting Date" });
+
+        Assert.Empty(plan.Mapped);
+        Assert.False(plan.CanHydrate);
+    }
+
+    [Fact]
+    public void NoColumnsAtAllIsNotAMismatch()
+    {
+        // An empty column list is "nothing to do", not a shape mismatch — it must not be
+        // reported as one.
+        var plan = RecordPatches.PlanTestDataColumns(Fields("Series Code"), Array.Empty<string>());
+
+        Assert.Empty(plan.Mapped);
+        Assert.True(plan.CanHydrate);
+    }
+}

--- a/AlRunner/Patches/RecordPatches.TestDataHydration.cs
+++ b/AlRunner/Patches/RecordPatches.TestDataHydration.cs
@@ -72,9 +72,24 @@
 //   a) A column for an app OUTSIDE this run's closure arrives in its raw BC storage form,
 //      `<sql name>$<app id>`, because the reader had no symbols to name it with. The AL record
 //      this run builds has no such field — the app is not installed here — so the column is
-//      dropped, counted, and reported. Anything else that fails to resolve still REFUSES the
-//      table: a bare unresolvable name could equally be a schema mismatch, and the two must
-//      not be confused.
+//      dropped, counted, and reported.
+//
+//   c) A column naming a field this runner build's copy of the table does not have is dropped
+//      and counted too, under its own name (#2273/#2301). It used to refuse the whole table,
+//      on the grounds that a bare unresolvable name could be a schema mismatch. Measured, the
+//      refusal was the more dangerous answer: table 309 refused over `Allow Gaps in Nos.` —
+//      ObsoleteState = Removed since BC 27.0, so compiled out of the app while both the
+//      shipped SymbolReference.json and the physical SQL column survive — and left No. Series
+//      Line EMPTY, which is a state AL reads and believes: ~220 of Microsoft's
+//      Tests-SINGLESERVER tests failed with "You cannot assign new numbers from the number
+//      series <X>" against a backup whose CONT series has 99,977 numbers left.
+//      What makes dropping safe is not a guess about why the field is missing: the metatable
+//      IS the metadata every AL statement in this run resolves field access against, so a
+//      column absent from it is unaddressable here and its absence cannot change an answer AL
+//      can read.
+//      One refusal remains, for the mismatch the old rule was aimed at: a row shape that
+//      shares NO column with the table. Dropping every column of that would insert rows made
+//      entirely of defaults.
 //
 //   b) The merge can fail to happen at all without failing. Measured on reader builds up to
 //      9701b04: `--mergeExtensions` (camelCase) was accepted by the CLI, ignored, and exited
@@ -120,10 +135,59 @@ public static partial class RecordPatches
         new HashSet<string>(StringComparer.Ordinal)
         { "timestamp", "$systemId", "$systemCreatedAt", "$systemCreatedBy", "$systemModifiedAt", "$systemModifiedBy" };
 
-    /// <summary>The outcome of one table's hydration: how many rows landed, and how many
-    /// merged columns belonged to an app this run does not have installed. The second number
-    /// is reported rather than left implicit — see the file header, case (a).</summary>
-    internal readonly record struct TestDataTableResult(int Rows, int ColumnsFromUninstalledApps);
+    /// <summary>The outcome of one table's hydration: how many rows landed, how many merged
+    /// columns belonged to an app this run does not have installed, and how many named a
+    /// field this runner build's copy of the table does not have. All three are reported
+    /// rather than left implicit — see the file header, cases (a) and (c).</summary>
+    internal readonly record struct TestDataTableResult(
+        int Rows, int ColumnsFromUninstalledApps, int ColumnsNotInThisBuild);
+
+    /// <summary>How one table's backup columns divide up against the target metatable.
+    /// <see cref="CanHydrate"/> is false only for a row shape that shares NOTHING with the
+    /// table — see <see cref="PlanTestDataColumns"/>.</summary>
+    internal readonly record struct TestDataColumnPlan(
+        IReadOnlyList<string> Mapped,
+        IReadOnlyList<string> FromUninstalledApps,
+        IReadOnlyList<string> NotInThisBuild)
+    {
+        internal bool CanHydrate => Mapped.Count > 0 || (FromUninstalledApps.Count == 0 && NotInThisBuild.Count == 0);
+    }
+
+    /// <summary>
+    /// Sort one table's backup columns into the three things a column can be.
+    ///
+    /// A column that is not a field of the target metatable is DROPPED, not a reason to
+    /// refuse the table. The reason it is safe is narrow and load-bearing: the metatable is
+    /// the very metadata every AL statement in this run resolves field access against, so a
+    /// column missing from it is not addressable by any AL code here — dropping it cannot
+    /// change an answer AL can read. Refusing instead leaves the table EMPTY, which AL very
+    /// much can read, and reads as "this table has no rows" rather than as a diagnostic.
+    /// Measured: table 309 refused over `Allow Gaps in Nos.` (ObsoleteState = Removed since
+    /// BC 27.0, still declared in the shipped symbols and still a physical SQL column), and
+    /// ~220 of Microsoft's Tests-SINGLESERVER tests then failed on number series that have
+    /// 99,977 numbers left in the backup.
+    ///
+    /// Two counts, not one, because they mean different things: a `&lt;sql&gt;$&lt;app id&gt;` column
+    /// says an app is outside this run's closure (case (a)), while a bare name says this
+    /// build's table has no such field (case (c)).
+    ///
+    /// The one refusal left is a row shape that shares NO column with the table: that is a
+    /// mismatch, and hydrating it would insert rows made entirely of defaults.
+    /// </summary>
+    internal static TestDataColumnPlan PlanTestDataColumns(
+        IReadOnlySet<string> fieldNames, IEnumerable<string> columnNames)
+    {
+        var mapped = new List<string>();
+        var fromUninstalledApps = new List<string>();
+        var notInThisBuild = new List<string>();
+        foreach (var name in columnNames.Distinct(StringComparer.Ordinal))
+        {
+            if (fieldNames.Contains(name)) mapped.Add(name);
+            else if (BackupCatalog.TryParseUnresolvedExtensionColumn(name, out _, out _)) fromUninstalledApps.Add(name);
+            else notInThisBuild.Add(name);
+        }
+        return new TestDataColumnPlan(mapped, fromUninstalledApps, notInThisBuild);
+    }
 
     /// <summary>
     /// Everything BC's own SQL-cell reader reads off the field it is converting for. There are
@@ -169,13 +233,12 @@ public static partial class RecordPatches
     /// <paramref name="rows"/> is one dictionary per row, keyed by the AL field NAME the
     /// reader emitted (BC's system columns already dropped by the caller).
     ///
-    /// Every key must resolve to a field of the target NCLMetaTable — the metatable the row is
-    /// actually inserted into — with ONE declared exception: a table-extension storage column
-    /// (`&lt;sql name&gt;$&lt;app id&gt;`) owned by an app outside this run's closure is dropped and
-    /// counted, because this run's AL record genuinely has no such field. Any OTHER key that
-    /// does not resolve refuses the table rather than being dropped: an unresolvable bare name
-    /// means the reader decoded a column this runner build has no AL field for, and hydrating
-    /// the rest would ship a knowingly incomplete record.
+    /// A key that resolves to a field of the target NCLMetaTable — the metatable the row is
+    /// actually inserted into — is hydrated. A key that does not is dropped and counted, in
+    /// one of two buckets: a table-extension storage column (`&lt;sql name&gt;$&lt;app id&gt;`) owned by
+    /// an app outside this run's closure, or a name this build's copy of the table has no
+    /// field for. See the file header, cases (a) and (c), for why dropping is the faithful
+    /// answer and refusing was not.
     ///
     /// Throws <see cref="TestDataHydrationRefusal"/> BEFORE touching the store if any value
     /// cannot be rebuilt, so a refusal never leaves rows behind.
@@ -209,7 +272,7 @@ public static partial class RecordPatches
     {
         metaTable = null;
         pristineRows = Array.Empty<NavValue[]>();
-        if (rows.Count == 0) return new TestDataTableResult(0, 0);
+        if (rows.Count == 0) return new TestDataTableResult(0, 0, 0);
 
         var meta = EnsureTableInMetadataCache(tableId)
             ?? throw new TestDataHydrationRefusal(
@@ -227,23 +290,17 @@ public static partial class RecordPatches
             fieldByName[f.FieldName] = f;
         }
 
-        var droppedColumns = new HashSet<string>(StringComparer.Ordinal);
-        foreach (var name in rows.SelectMany(r => r.Keys).Distinct(StringComparer.Ordinal))
-        {
-            if (fieldByName.ContainsKey(name)) continue;
-            if (BackupCatalog.TryParseUnresolvedExtensionColumn(name, out _, out _))
-            {
-                // Case (a): a companion column for an app outside this run's closure. Dropped
-                // and counted — BuildTestDataRow never looks it up, because it indexes the row
-                // by the metatable's own field names.
-                droppedColumns.Add(name);
-                continue;
-            }
+        // Neither dropped list is looked up again: BuildTestDataRow indexes each row by the
+        // metatable's own field names, so a dropped column is simply never asked for.
+        var plan = PlanTestDataColumns(
+            (IReadOnlySet<string>)new HashSet<string>(fieldByName.Keys, StringComparer.Ordinal),
+            rows.SelectMany(r => r.Keys));
+        if (!plan.CanHydrate)
             throw new TestDataHydrationRefusal(
-                $"table {tableId} '{tableNameForDiagnostics}': the backup has a column '{name}' that is "
-                + "not a field of the AL table this runner build would insert into, so the rows cannot "
-                + "be rebuilt faithfully");
-        }
+                $"table {tableId} '{tableNameForDiagnostics}': not one of the backup's "
+                + $"{plan.FromUninstalledApps.Count + plan.NotInThisBuild.Count} column(s) is a field of the AL "
+                + $"table this runner build would insert into ({string.Join(", ", plan.NotInThisBuild.Concat(plan.FromUninstalledApps).Take(5))}"
+                + "…), so these rows are not this table's rows");
 
         // Build EVERY row first. A refusal in row 900 must not leave rows 1-899 in the store.
         var built = new NavValue[rows.Count][];
@@ -280,7 +337,8 @@ public static partial class RecordPatches
         // for a table that ended up refused.
         metaTable = meta;
         pristineRows = built;
-        return new TestDataTableResult(built.Length, droppedColumns.Count);
+        return new TestDataTableResult(
+            built.Length, plan.FromUninstalledApps.Count, plan.NotInThisBuild.Count);
     }
 
     private static NavValue[] BuildTestDataRow(

--- a/AlRunner/TestDataProvisioner.cs
+++ b/AlRunner/TestDataProvisioner.cs
@@ -115,12 +115,22 @@
 //      symbols to name them with and passes them through in BC's raw `<name>$<app id>` storage
 //      form; this run's AL record has no such field, so they are dropped and counted. See
 //      RecordPatches.TestDataHydration's header, case (a).
-//   5. A BARE column name the target AL table has no field for. Refused, not dropped, and the
-//      distinction from case 4 is the point: a bare unresolvable name could equally be a
-//      schema mismatch, and hydrating a table against a shape this build does not have is
-//      exactly the silent guess the feature exists to prevent. Measured on BC 28.1's W1
-//      CRONUS this is now the ONLY refusal left, 12 tables of it (Item."Routing No_",
-//      Purchase Line."Prod_ Order No_", …) — #2273.
+//   5. A column naming a field the target AL table does not have in THIS build. Dropped and
+//      counted under its own name, separately from case 4 (#2273/#2301). Refusing the table
+//      was measured to be the more dangerous answer: it leaves the table empty, and an empty
+//      table is a state AL reads and believes. `No. Series Line` refused over
+//      `Allow Gaps in Nos.` (ObsoleteState = Removed since BC 27.0 — compiled out of the app,
+//      still in the shipped symbols and still a physical column), and ~220 of Microsoft's
+//      Tests-SINGLESERVER tests then failed on number series the backup says are almost
+//      untouched. What was reported as one refusal cost every No. Series in the run.
+//      The 11 other tables #2273 listed (Item."Routing No_", Purchase Line."Prod_ Order No_",
+//      …) had a different cause and are fixed in the reader, not here: those fields are LIVE,
+//      declared by a tableextension in the same app as the table it extends, which BC stores
+//      in the base table itself. The reader named base columns from the table's own field
+//      list only, so they arrived in SQL form and matched nothing (BakReader:
+//      SymbolStore.FindBaseTableField).
+//   6. A row shape sharing NO column with the target table. Still refused: that is a
+//      mismatch, and hydrating it would insert rows made entirely of defaults.
 using AlRunner.Infrastructure;
 using AlRunner.Patches;
 using System.Text.Json;
@@ -132,7 +142,7 @@ internal static class TestDataProvisioner
     internal sealed record Summary(
         string BackupPath, string Company, int TablesHydrated, int RowsHydrated,
         int TablesSkippedAmbiguous, int TablesRefused, int TablesRefusedByReader,
-        int ColumnsFromUninstalledApps)
+        int ColumnsFromUninstalledApps, int ColumnsNotInThisBuild)
     {
         // "the run touched", not "the backup holds": under the on-demand policy (#2262) a
         // table is only read when something asks for it, so these counts describe what this
@@ -143,7 +153,8 @@ internal static class TestDataProvisioner
             + $"skipped {TablesSkippedAmbiguous} ambiguous by name, "
             + $"{TablesRefused} refused (unsupported value types or unknown columns), "
             + $"{TablesRefusedByReader} refused by the backup reader, "
-            + $"{ColumnsFromUninstalledApps} extension column(s) dropped for apps this run does not install.";
+            + $"{ColumnsFromUninstalledApps} extension column(s) dropped for apps this run does not install, "
+            + $"{ColumnsNotInThisBuild} column(s) dropped that this build's AL tables have no field for.";
     }
 
     private static Summary? _lastSummary;
@@ -158,7 +169,7 @@ internal static class TestDataProvisioner
     private static ArmedPlan? _armed;
 
     // Running tallies, accumulated across on-demand loads rather than known at Arm() time.
-    private static int _tablesDone, _rowsDone, _refused, _readerRefused, _droppedColumns;
+    private static int _tablesDone, _rowsDone, _refused, _readerRefused, _droppedColumns, _columnsNotInThisBuild;
 
     /// <summary>The most recent hydration's outcome — the assertable signal a test uses
     /// instead of re-deriving what happened from log text. Under the on-demand policy it is
@@ -207,7 +218,7 @@ internal static class TestDataProvisioner
     {
         _lastSummary = null;
         _armed = null;
-        _tablesDone = _rowsDone = _refused = _readerRefused = _droppedColumns = 0;
+        _tablesDone = _rowsDone = _refused = _readerRefused = _droppedColumns = _columnsNotInThisBuild = 0;
         _tableOutcome.Clear();
         RecordPatches.TestDataOnDemandLoader = null;
     }
@@ -313,6 +324,7 @@ internal static class TestDataProvisioner
             }
             _rowsDone += result.Rows;
             _droppedColumns += result.ColumnsFromUninstalledApps;
+            _columnsNotInThisBuild += result.ColumnsNotInThisBuild;
             _tableOutcome[tableId] = result.Rows > 0
                 ? $"{result.Rows} row(s) loaded from '{Path.GetFileName(armed.Backup)}' company '{armed.Company}'"
                 : $"'{entry.TableName}' in '{Path.GetFileName(armed.Backup)}' company '{armed.Company}' "
@@ -339,7 +351,7 @@ internal static class TestDataProvisioner
                 $"[test-data] READER REFUSED table '{entry.TableName}': {ex.Message}");
         }
         _lastSummary = new Summary(armed.Backup, armed.Company, _tablesDone, _rowsDone,
-            armed.SkippedAmbiguous, _refused, _readerRefused, _droppedColumns);
+            armed.SkippedAmbiguous, _refused, _readerRefused, _droppedColumns, _columnsNotInThisBuild);
     }
 
     /// <summary>

--- a/tests/test-data-fixture/README.md
+++ b/tests/test-data-fixture/README.md
@@ -21,6 +21,16 @@ back through ordinary AL `Record` calls with the right values.
   BC's container (four magic bytes + raw Deflate), not the field's bytes, so a codec that
   stored it verbatim would still give a blob with `HasValue` = true and a plausible length.
 
+- `TestDataSameAppExtensionColumns.Codeunit.al` (#2273, #2301) — a column the base table's own
+  AL field list does not name, because BC stores a tableextension's fields in the base table
+  itself when the extension is declared in the same app. Twelve tables used to be refused whole
+  over one such column. The assertions are on VALUES (`No. Series Line`'s CONT range, `Item`'s
+  `Routing No.`) because a test asserting only "the table has rows" would pass with every
+  extension field left blank — which is the bug's near miss. `ANumberCanBeDrawnFromAHydratedSeries`
+  is the failure in the form Microsoft's Tests-SINGLESERVER hit it: ~220 of its tests failed with
+  "You cannot assign new numbers from the number series CONT" against a backup where that series
+  has 99,977 numbers left.
+
 **CI does not run this bundle, and that is deliberate.** It only passes with `--test-data`
 and a BC sandbox backup on the machine (~1 GB, shipped inside the sandbox artifact). CI runs
 `tests/runner-extras/` wholesale, without the flag — a bundle asserting hydrated rows would

--- a/tests/test-data-fixture/TestDataSameAppExtensionColumns.Codeunit.al
+++ b/tests/test-data-fixture/TestDataSameAppExtensionColumns.Codeunit.al
@@ -1,0 +1,75 @@
+/// <summary>
+/// #2273 / #2301 — a table whose backup rows carry a column the base table's own AL field
+/// list does not name.
+///
+/// BC stores a tableextension's fields in the base table itself when the extension is
+/// declared in the SAME app as the table it extends: no $ext companion, no "$&lt;app id&gt;"
+/// column suffix. Twelve tables used to be refused whole over such a column — `No. Series
+/// Line` over `Allow Gaps in Nos.`, `Item` over `Routing No.`, `Purchase Line` over
+/// `Prod. Order No.` — which left those tables EMPTY, and an empty table is a state AL
+/// reads and believes: ~220 of Microsoft's Tests-SINGLESERVER tests failed with "You cannot
+/// assign new numbers from the number series &lt;X&gt;" against a backup whose CONT series has
+/// 99,977 numbers left.
+///
+/// Both assertions below are on a VALUE, not on "the record was found". A test asserting
+/// only that `No. Series Line` has rows would pass with the extension column dropped from
+/// the row and every extension field left blank, which is the bug's near miss.
+/// </summary>
+codeunit 64408 "Test Data Same-App Ext Columns"
+{
+    Subtype = Test;
+
+    var
+        Assert: Codeunit "TDF Assert";
+
+    [Test]
+    procedure NoSeriesLineHydratesWithItsRange()
+    var
+        NoSeriesLine: Record "No. Series Line";
+    begin
+        NoSeriesLine.SetRange("Series Code", 'CONT');
+        Assert.IsTrue(NoSeriesLine.FindFirst(), 'CRONUS has a CONT No. Series Line in the backup.');
+
+        Assert.AreEqual('CT000001', NoSeriesLine."Starting No.", 'CONT starting no.');
+        Assert.AreEqual('CT100000', NoSeriesLine."Ending No.", 'CONT ending no.');
+        Assert.AreEqual('CT000023', NoSeriesLine."Last No. Used", 'CONT last no. used');
+    end;
+
+    [Test]
+    procedure ANumberCanBeDrawnFromAHydratedSeries()
+    var
+        NoSeries: Codeunit "No. Series";
+        NextNo: Code[20];
+    begin
+        // The failure this fixture exists for, in the form the MS tests hit it: with the
+        // table refused, GetNextNo raised "You cannot assign new numbers from the number
+        // series CONT", the error AL raises when a series has no lines at all.
+        NextNo := NoSeries.GetNextNo('CONT', WorkDate(), false);
+
+        Assert.AreEqual('CT000024', NextNo, 'the next CONT number follows the hydrated last-used one');
+    end;
+
+    [Test]
+    procedure ItemHydratesAFieldFromBaseAppsOwnTableExtension()
+    var
+        Item: Record Item;
+    begin
+        // "Routing No." is field 99000750, declared by Base Application's own tableextension
+        // 99000750 "Mfg. Item" and stored in the Item table itself.
+        Assert.IsTrue(Item.Get('SP-BOM2000'), 'CRONUS has item SP-BOM2000 in the backup.');
+
+        Assert.AreEqual('SP-BOM2000', Item."Routing No.", 'the routing no. stored on the item');
+    end;
+
+    [Test]
+    procedure AnItemWithoutARoutingReadsBlank()
+    var
+        Item: Record Item;
+    begin
+        // Negative direction: the merge must not fabricate a value where the backup has
+        // none, which a codec defaulting the column would.
+        Assert.IsTrue(Item.Get('1896-S'), 'CRONUS has item 1896-S in the backup.');
+
+        Assert.AreEqual('', Item."Routing No.", 'item 1896-S stores no routing no.');
+    end;
+}


### PR DESCRIPTION
`--test-data` refused 12 whole tables because the backup had a column the AL table has no field for. Refusing a table leaves it empty, and an empty table is a state AL reads and believes: `No. Series Line` being refused over `Allow Gaps in Nos.` cost about 220 of Microsoft's Tests-SINGLESERVER tests, which failed with "You cannot assign new numbers from the number series CONT" against a backup where that series has 99,977 numbers left.

Eleven of the twelve were a reader bug, fixed separately in StefanMaron/BusinessCentral.DbReader: BC stores a tableextension's fields in the base table itself when the extension is declared in the same app, so `Item."Routing No."` and `Purchase Line."Prod. Order No."` arrived under their SQL names and matched nothing. Those columns are live, AL-readable fields — I proved it by compiling a throwaway AL test that reads them — so dropping them would have lost real data.

The twelfth is genuinely unmappable. `Allow Gaps in Nos.` is `ObsoleteState = Removed`, `ObsoleteTag '27.0'`, behind `#if not CLEANSCHEMA27` in Business Foundation, so it is compiled out of the shipped app while both the SymbolReference entry and the physical SQL column survive.

This change makes the runner drop and count such a column instead of refusing the table. The argument that makes dropping safe is narrow and stated in the code: the NCLMetaTable is the metadata every AL statement resolves field access against, so a column absent from it is not addressable by any AL code in the run. One refusal remains, for a row shape that shares no column at all with the table.

`TestDataProvisioner.Summary` gains a separate counter so the two kinds of dropped column stay distinguishable in the run output.

Result: 73 to 90 tables hydrated, 7 to 0 refused, and the "cannot assign new numbers" cluster goes from 215 to 0.

Tests: `AlRunner.Tests/TestDataUnmappedColumnTests.cs` pins the split and the remaining refusal. `tests/test-data-fixture/TestDataSameAppExtensionColumns.Codeunit.al` asserts values, not row counts, because a test asserting only "the table has rows" would pass with every extension field left blank, which is the bug's near miss.

Verified: al-language corpus 2164/2164, runner-extras 201/201.

Closes #2301
