### PR TITLE
enum: match option text the way BC does, not ordinal-exact

### DIFF
--- a/AlRunner.Tests/EnumOptionMatchingTests.cs
+++ b/AlRunner.Tests/EnumOptionMatchingTests.cs
@@ -1,0 +1,110 @@
+// EnumOptionMatchingTests — AlEnumOptionMetadata must match option text the way BC's own
+// NCLEnumMetadata does.
+//
+// This is a RUNNER-MECHANISM test. The BC-behaviour claim underneath it — that
+// `Rec.SetFilter(<enum field>, '<>''''')` is a legal filter, which Base App's own
+// codeunit 5055 "CustVendBank-Update" relies on — is a statement about AL/BC and belongs
+// upstream in the al-language corpus. What this file pins is that OUR NCLOptionMetadata
+// subclass answers the same way BC's does, without booting the engine.
+//
+// BC's bodies, decompiled from Microsoft.Dynamics.Nav.Ncl 28.1:
+//
+//   NCLEnumMetadata.GetIndexFromOption(option):
+//       int r = StringHelper.FindStringInStringArrayUsingCurrentCulture(Options, option);
+//       if (r != -1) return OrdinalValues[r];
+//       if (int.TryParse(option, out r)) return r;
+//       return -1;
+//
+//   StringHelper.FindStringInStringArrayUsingCulture(ci, strings, searchTarget):
+//       searchTarget = searchTarget.Trim();
+//       for each i: if (strings[i].Length > 0
+//                       && string.Compare(strings[i].Trim(), searchTarget, true, ci) == 0)
+//                       return i;
+//       return -1;
+//
+//   NCLEnumMetadata.GetIndexFromCaption(caption): trims the caption, compares it
+//       case-insensitively against each value's caption (falling back to the member name),
+//       also trimmed, and returns OrdinalValues[i]. No Length > 0 guard on that side.
+//
+// Three properties follow, and our old `string.Equals(..., StringComparison.Ordinal)`
+// override had none of them: the comparison trims, it ignores case, and a member whose
+// name is only whitespace (AL's `value(0; " ")`, the blank enum member) is therefore
+// reachable by the empty string.
+//
+// RED/GREEN: reverting GetIndexFromOption/GetIndexFromCaption to the ordinal string.Equals
+// loop makes every case below except NotAMember and TrulyEmptyMemberName fail.
+using AlRunner;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class EnumOptionMatchingTests
+{
+    // The shape of Base App enum 5057 "Contact Business Relation Link To Table": its member 0
+    // is named " " (a single space), which is how AL spells a blank enum member.
+    private static AlEnumOptionMetadata BlankFirstMember()
+        => new(
+            name: "Contact Business Relation Link To Table",
+            id: 5057,
+            options: new[] { " ", "Customer", "Vendor", "Bank Account", "Employee" },
+            indexes: new[] { 0, 1, 2, 3, 4 });
+
+    [Fact]
+    public void GetIndexFromOption_EmptyString_ResolvesToTheBlankMember()
+        => Assert.Equal(0, BlankFirstMember().GetIndexFromOption(string.Empty));
+
+    [Fact]
+    public void GetIndexFromCaption_EmptyString_ResolvesToTheBlankMember()
+        => Assert.Equal(0, BlankFirstMember().GetIndexFromCaption(string.Empty));
+
+    [Fact]
+    public void GetIndexFromOption_DiffersInCaseAndPadding_StillResolves()
+        => Assert.Equal(3, BlankFirstMember().GetIndexFromOption("  bank account "));
+
+    [Fact]
+    public void GetIndexFromOption_NotAMember_ReturnsMinusOne()
+        => Assert.Equal(-1, BlankFirstMember().GetIndexFromOption("Shareholder"));
+
+    // BC's Length > 0 guard: a member whose name is the empty string is never matched by
+    // text at all (only by its ordinal). Keeping the guard is what makes " " and "" behave
+    // differently, which is the distinction this whole fix turns on.
+    [Fact]
+    public void GetIndexFromOption_TrulyEmptyMemberName_IsNotMatchedByTheEmptyString()
+    {
+        var meta = new AlEnumOptionMetadata(
+            name: "Empty First Member", id: 5057001,
+            options: new[] { string.Empty, "Customer" }, indexes: new[] { 0, 1 });
+
+        Assert.Equal(-1, meta.GetIndexFromOption(string.Empty));
+    }
+
+    // The return value is the ORDINAL, not the array index — BC returns OrdinalValues[r].
+    [Fact]
+    public void GetIndexFromOption_SparseOrdinals_ReturnsTheOrdinalNotTheArrayIndex()
+    {
+        var meta = new AlEnumOptionMetadata(
+            name: "Sparse", id: 5057002,
+            options: new[] { " ", "Customer" }, indexes: new[] { 0, 7 });
+
+        Assert.Equal(7, meta.GetIndexFromOption("Customer"));
+    }
+
+    // BC's numeric fallback survives, and it takes the text as an ordinal verbatim.
+    [Fact]
+    public void GetIndexFromOption_NumericText_FallsBackToTheOrdinal()
+        => Assert.Equal(4, BlankFirstMember().GetIndexFromOption("4"));
+
+    // A declared Caption wins over the member name on the caption side, and does NOT
+    // leak into the option side — the two tables stay distinct.
+    [Fact]
+    public void GetIndexFromCaption_DeclaredCaption_WinsOverTheMemberName()
+    {
+        var meta = new AlEnumOptionMetadata(
+            name: "Captioned", id: 5057003,
+            options: new[] { " ", "Block" }, indexes: new[] { 0, 1 },
+            implementations: null, captions: new[] { " ", "Blocks" });
+
+        Assert.Equal(1, meta.GetIndexFromCaption("blocks"));
+        Assert.Equal(-1, meta.GetIndexFromOption("Blocks"));
+    }
+}

--- a/AlRunner/Patches/EnumMetadataPatches.cs
+++ b/AlRunner/Patches/EnumMetadataPatches.cs
@@ -25,6 +25,7 @@
 //   NCLEnumMetadata override: 158980 / 158985 returns namesList / ordinalsList.
 //
 using System.Collections.Concurrent;
+using System.Globalization;
 using System.Collections.Immutable;
 using System.Reflection;
 using System.Runtime.CompilerServices;
@@ -37,6 +38,7 @@ using NavListInt = Microsoft.Dynamics.Nav.Runtime.NavList<int>;
 using NavOption = Microsoft.Dynamics.Nav.Runtime.NavOption;
 using NavText = Microsoft.Dynamics.Nav.Runtime.NavText;
 using ITreeObject = Microsoft.Dynamics.Nav.Runtime.ITreeObject;
+using StringHelper = Microsoft.Dynamics.Nav.Runtime.StringHelper;
 
 namespace AlRunner;
 
@@ -427,19 +429,52 @@ internal sealed class AlEnumOptionMetadata : NCLOptionMetadata
         return false;
     }
 
+    // #2302 — text → ordinal resolution must match BC's own NCLEnumMetadata, not a
+    // stricter ordinal string.Equals. BC's decompiled body is:
+    //
+    //     int r = StringHelper.FindStringInStringArrayUsingCurrentCulture(Options, option);
+    //     if (r != -1) return OrdinalValues[r];
+    //     if (int.TryParse(option, out r)) return r;
+    //     return -1;
+    //
+    // and that helper TRIMS both sides, compares case-INSENSITIVELY in the session's
+    // culture, and skips members whose name is zero-length. Delegating to the helper
+    // rather than restating it keeps this observably identical to the service tier
+    // (including the zero-length skip, which is the only reason " " and "" differ).
+    //
+    // The practical consequence is AL's blank enum member. `value(0; " ")` is named with a
+    // single space, so `SetFilter(<enum field>, '<>''''')` — Base App codeunit 5055
+    // "CustVendBank-Update" line 34, reached by ~170 of Microsoft's Tests-SINGLESERVER
+    // tests — evaluates '' against it. Under the old ordinal compare that raised
+    // NavNCLInvalidOptionStringException ("'' is not an option"); under BC's own rule
+    // " ".Trim() == "".Trim() and it resolves to ordinal 0.
     public override int GetIndexFromOption(string option)
     {
-        for (int i = 0; i < _optionNames.Length; i++)
-        {
-            if (string.Equals(_optionNames[i], option, StringComparison.Ordinal))
-                return _ordinalValues[i];
-        }
+        var i = StringHelper.FindStringInStringArrayUsingCurrentCulture(_optionNames, option);
+        if (i != -1)
+            return _ordinalValues[i];
         if (int.TryParse(option, out var ord))
             return ord;
         return -1;
     }
 
-    public override int GetIndexFromCaption(string caption) => GetIndexFromOption(caption);
+    // BC's NCLEnumMetadata.GetIndexFromCaption is NOT a synonym for GetIndexFromOption: it
+    // matches against each value's CAPTION (falling back to the member name where a value
+    // declares none), trims both sides, and compares case-insensitively — in the caption's
+    // own language culture, or InvariantCulture when there is no translated caption to
+    // carry an LCID. Our captures carry no LCID, so invariant is the whole of that rule
+    // here. It also has NO zero-length guard, unlike the option side.
+    public override int GetIndexFromCaption(string caption)
+    {
+        var target = caption.Trim();
+        for (int i = 0; i < _optionNames.Length; i++)
+        {
+            var text = (_captions[i] ?? _optionNames[i]) ?? string.Empty;
+            if (string.Compare(target, text.Trim(), ignoreCase: true, CultureInfo.InvariantCulture) == 0)
+                return _ordinalValues[i];
+        }
+        return -1;
+    }
 
     private readonly string[] _optionNames;
 


### PR DESCRIPTION
`AlEnumOptionMetadata.GetIndexFromOption` compared with `string.Equals(..., StringComparison.Ordinal)`, and `GetIndexFromCaption` just called it. BC's own `NCLEnumMetadata` does neither.

BC's `GetIndexFromOption` delegates to `StringHelper.FindStringInStringArrayUsingCurrentCulture`, which trims both sides, compares case-insensitively in the session culture, and skips members whose name is zero length; only then does it fall back to `int.TryParse`. `GetIndexFromCaption` is a separate method that matches each value's caption, falls back to the member name where none is declared, trims both sides, compares case-insensitively, and has no zero-length guard.

The practical consequence is AL's blank enum member. `value(0; " ")` is named with a single space, so `" ".Trim()` equals `"".Trim()` and real BC resolves the empty string to ordinal 0. Under the old ordinal compare it did not, and Base Application codeunit 5055 "CustVendBank-Update" line 34

```al
ContBusRel.SetFilter("Link to Table", '<>''''');
```

raised `NavNCLInvalidOptionStringException`. Every AL path that creates or modifies a customer or vendor runs that codeunit, so the failure reached 172 of the 878 tests in Microsoft's Tests-SINGLESERVER bucket. After this change that count is 0.

`GetIndexFromOption` now delegates to BC's own helper rather than restating its rules, so the zero-length skip — the only reason `" "` and `""` behave differently — cannot drift.

Tests: `AlRunner.Tests/EnumOptionMatchingTests.cs` pins each property separately (the trim, the case-insensitivity, the zero-length skip, the ordinal-not-index return, the numeric fallback) with the decompiled BC bodies quoted in the file header. The BC-behaviour claim underneath — that `SetFilter(<enum field>, '<>''''')` is a legal filter — is a statement about AL and belongs upstream in the al-language corpus; what this file pins is that our subclass answers the way BC's does.

Verified: al-language corpus 2164/2164, runner-extras 201/201.

Closes #2303
