### PR TITLE
calcformula: re-quote a filter() identifier for BC's filter grammar

### DIFF
--- a/AlRunner.Tests/BcAppSymbolCacheReportTests.cs
+++ b/AlRunner.Tests/BcAppSymbolCacheReportTests.cs
@@ -77,7 +77,10 @@ public class BcAppSymbolCacheReportTests
                           "Name": "Line",
                           "RelatedTable": "Sales Invoice Line",
                           "Indentation": 1,
-                          "OwningDataItemName": "Header"
+                          "OwningDataItemName": "Header",
+                          "Properties": [
+                            { "Name": "DataItemTableView", "Value": "sorting(\"Document No.\") where(\"Entry Type\" = filter(<> \"Initial Entry\"))" }
+                          ]
                         },
                         {
                           "Id": 55501,
@@ -139,6 +142,16 @@ public class BcAppSymbolCacheReportTests
             Assert.Equal("Sales Invoice Line", nested.RelatedTable);
             Assert.Equal(1, nested.Indentation);
             Assert.Equal(411976133, nested.Id);
+
+            // #2305 — BC applies DataItemTableView with NavRecord.ALSetView, and
+            // TableViewParser reads a FILTER(...) body with ' as its quote character while
+            // reading SORTING field names and a field name in WHERE(...) with ". So the AL
+            // spelling of a member name has to be re-quoted on the filter side ONLY: left as
+            // written it reaches the option evaluator as a literal with double quotes in it
+            // and Report 321 "Vendor - Balance to Date" throws instead of running.
+            Assert.Equal(
+                """sorting("Document No.") where("Entry Type" = filter(<> 'Initial Entry'))""",
+                nested.DataItemTableView);
 
             // A data item bound to a table in ANOTHER module arrives module-qualified
             // (#appIdNoHyphens#Name) — most Base Application reports iterate System's

--- a/AlRunner.Tests/CalcFormulaSyntaxTests.cs
+++ b/AlRunner.Tests/CalcFormulaSyntaxTests.cs
@@ -308,6 +308,102 @@ public class CalcFormulaSyntaxTests
         finally { ParsedTables.Remove(TableId); }
     }
 
+    // ─── #2305 — an AL quoted identifier inside filter(...) ──────────────────────────────
+    //
+    // AL quotes an identifier with double quotes; BC's FILTER grammar quotes a literal with
+    // SINGLE quotes and treats `"` as an ordinary character (FilterExpressionTokenizer.GetTokens
+    // in Ncl 28.1 has a case for '\'' and none for '"'). So `filter("Initial Entry")` must reach
+    // the runtime as `'Initial Entry'`. Carried through verbatim it arrives as the 15-character
+    // literal `"Initial Entry"`, which is not an option member, and the FlowField throws.
+    //
+    // Converting rather than stripping is the point: several Base App members contain filter
+    // metacharacters — `Payment Discount (VAT Excl.)` has parentheses, which the tokenizer reads
+    // as grouping — so quotes cannot simply be removed the way ConstValueText removes them
+    // (a const value is evaluated as a bare value, not parsed as an expression).
+
+    [Fact]
+    public void FilterCondition_QuotedOptionMember_BecomesASingleQuotedFilterLiteral()
+    {
+        try
+        {
+            var f = ParseFormulaRequired(
+                """sum("Detailed Vendor Ledg. Entry".Amount where("Entry Type" = filter("Initial Entry")))""");
+
+            var c = Assert.Single(f.Filters);
+            Assert.Equal("Entry Type", c.SourceFieldName);
+            Assert.Equal(ParsedCalcFilterKind.Filter, c.Kind);
+            Assert.Equal("'Initial Entry'", c.Value);
+        }
+        finally { ParsedTables.Remove(TableId); }
+    }
+
+    [Fact]
+    public void FilterCondition_MixedQuotedAndBareMembers_ConvertsOnlyTheQuotedOnes()
+    {
+        try
+        {
+            var f = ParseFormulaRequired(
+                """sum("Sales Line".Amount where("Document Type" = filter(Invoice | "Credit Memo")))""");
+
+            var c = Assert.Single(f.Filters);
+            Assert.Equal("'Credit Memo'", c.Value.Replace("Invoice | ", ""));
+            Assert.StartsWith("Invoice", c.Value);
+            Assert.DoesNotContain('"', c.Value);
+        }
+        finally { ParsedTables.Remove(TableId); }
+    }
+
+    [Fact]
+    public void FilterCondition_MemberNameWithParentheses_SurvivesAsAQuotedLiteral()
+    {
+        // The case that rules out stripping the quotes: unquoted, the tokenizer would read
+        // `(` and `)` as grouping and `..` would bind to the wrong operand.
+        try
+        {
+            var f = ParseFormulaRequired(
+                """sum("Detailed Vendor Ledg. Entry".Amount where("Entry Type" = filter("Payment Discount" .. "Payment Discount (VAT Adjustment)")))""");
+
+            var c = Assert.Single(f.Filters);
+            Assert.Contains("'Payment Discount (VAT Adjustment)'", c.Value);
+            Assert.DoesNotContain('"', c.Value);
+        }
+        finally { ParsedTables.Remove(TableId); }
+    }
+
+    [Fact]
+    public void FilterCondition_BlankMember_BecomesAQuotedSpace()
+    {
+        // `filter(<> " ")` — the blank member of an option set, negated. The space must stay
+        // inside quotes; bare, the tokenizer discards it as whitespace and the filter becomes
+        // `<>` with no operand.
+        try
+        {
+            var f = ParseFormulaRequired(
+                """sum("Warehouse Activity Line".Quantity where("Activity Type" = filter(<> " ")))""");
+
+            var c = Assert.Single(f.Filters);
+            Assert.Contains("' '", c.Value);
+            Assert.StartsWith("<>", c.Value);
+        }
+        finally { ParsedTables.Remove(TableId); }
+    }
+
+    [Fact]
+    public void FilterCondition_UnquotedMembers_AreLeftExactlyAsWritten()
+    {
+        // The other direction: a filter with no AL quoting must come through untouched — the
+        // conversion must be driven by the source text, not applied to every filter.
+        try
+        {
+            var f = ParseFormulaRequired(
+                """sum("Sales Line".Amount where(Status = filter(Open | Released)))""");
+
+            var c = Assert.Single(f.Filters);
+            Assert.Equal("Open | Released", c.Value);
+        }
+        finally { ParsedTables.Remove(TableId); }
+    }
+
     [Fact]
     public void NonFormulaPropertyValue_YieldsNoFormula()
     {

--- a/AlRunner.Tests/ReportTableViewQuotingTests.cs
+++ b/AlRunner.Tests/ReportTableViewQuotingTests.cs
@@ -1,0 +1,70 @@
+// ReportTableViewQuotingTests — #2305, the DataItemTableView half.
+//
+// BC applies a report data item's DataItemTableView with NavRecord.ALSetView
+// (DataItemIterator.ApplyDataItemTableViewAndRequestFormFilters), and TableViewParser's
+// grammar, decompiled from Ncl 28.1, uses a DIFFERENT quote character per clause:
+//
+//     SORTING field names   ReadValue('"', ",)")
+//     WHERE field names     ReadValue('"', "=")
+//     CONST(...) / FIELD(...)  ReadValueOrEmpty('"', ")")
+//     FILTER(...)           ReadValueOrEmpty('\'', "'()")     ← single quote
+//
+// FILTER's body is a filter expression, so it goes through the same grammar as SetFilter,
+// where `"` is an ordinary character. Everything else reads AL's own double quotes already.
+// So exactly one part of the string is rewritten and the rest must survive byte for byte.
+//
+// The end-to-end proof that this reaches the cached report metadata is in
+// BcAppSymbolCacheReportTests.Reports_AreReadFromANestedNamespace_WithCaptionAndDataItemTree.
+// These cases pin the grammar rules that one shape cannot reach: a field NAMED "Date Filter",
+// a member name carrying its own parentheses, and a view with nothing to convert.
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class ReportTableViewQuotingTests
+{
+    [Fact]
+    public void FilterBody_QuotedMember_IsReQuotedForTheFilterGrammar()
+        => Assert.Equal(
+            """sorting("Vendor Ledger Entry No.","Posting Date") where("Entry Type" = filter(<> 'Initial Entry'))""",
+            RecordPatches.TableViewText(
+                """sorting("Vendor Ledger Entry No.","Posting Date") where("Entry Type" = filter(<> "Initial Entry"))"""));
+
+    [Fact]
+    public void ConstBody_KeepsItsDoubleQuotes()
+        // CONST reads with '"' — converting it too would break what already works.
+        => Assert.Equal(
+            """where("Document Type" = const("Credit Memo"))""",
+            RecordPatches.TableViewText("""where("Document Type" = const("Credit Memo"))"""));
+
+    [Fact]
+    public void FieldNamedDateFilter_IsNotMistakenForAFilterCall()
+        // The keyword scan must skip quoted identifiers, or the `Filter` inside this field
+        // name starts a conversion in the middle of the name.
+        => Assert.Equal(
+            """where("Date Filter" = field("Date Filter"))""",
+            RecordPatches.TableViewText("""where("Date Filter" = field("Date Filter"))"""));
+
+    [Fact]
+    public void MemberNameWithParentheses_DoesNotEndTheFilterCallEarly()
+        // `Payment Discount (VAT Excl.)` carries a balanced pair of its own; a naive scan for
+        // the closing ')' stops inside the name and truncates the filter.
+        => Assert.Equal(
+            """where("Entry Type" = filter('Payment Discount (VAT Excl.)'|'Payment Tolerance'))""",
+            RecordPatches.TableViewText(
+                """where("Entry Type" = filter("Payment Discount (VAT Excl.)"|"Payment Tolerance"))"""));
+
+    [Fact]
+    public void ViewWithNoQuotedIdentifier_IsReturnedUnchanged()
+        => Assert.Equal(
+            "sorting(Number) where(Number = filter(1 ..))",
+            RecordPatches.TableViewText("sorting(Number) where(Number = filter(1 ..))"));
+
+    [Fact]
+    public void NullAndEmptyViews_AreLeftAlone()
+    {
+        Assert.Null(RecordPatches.TableViewText(null));
+        Assert.Equal("", RecordPatches.TableViewText(""));
+    }
+}

--- a/AlRunner/Patches/BcAppSymbolCache.cs
+++ b/AlRunner/Patches/BcAppSymbolCache.cs
@@ -62,7 +62,14 @@ internal static partial class BcAppSymbolCache
     // aggregated column as an ordinary one again, returning raw ungrouped rows: the exact
     // #2137 bug reintroduced on any machine whose symbol cache predates this change, not a
     // cache miss, hence the bump.
-    private const int CacheVersion = 14;
+    // v15: a CalcFormula's `filter(...)` condition now carries AL's quoted identifiers
+    // re-quoted for BC's filter grammar — `filter("Initial Entry")` is cached as
+    // `'Initial Entry'`, not as the AL text (issue #2305). A v14 payload deserialises
+    // perfectly well and replays the AL spelling, which reaches the runtime as a literal
+    // with double quotes in it, matches no option member, and throws
+    // NavInvalidFilterExpressionException out of CalcFields — a wrong answer replayed from
+    // cache on any machine whose symbol cache predates this change, not a cache miss.
+    private const int CacheVersion = 15;
     private static readonly ConcurrentDictionary<string, AppSymbols> ProcessCache = new(StringComparer.OrdinalIgnoreCase);
     // Issue #1820 — path -> content-hash memo. ComputeAppContentHash needs to read the
     // WHOLE .app to hash it (unlike the FileInfo.Length/LastWriteTimeUtc stat it replaced,

--- a/AlRunner/Patches/BcAppSymbolCache.cs
+++ b/AlRunner/Patches/BcAppSymbolCache.cs
@@ -62,13 +62,14 @@ internal static partial class BcAppSymbolCache
     // aggregated column as an ordinary one again, returning raw ungrouped rows: the exact
     // #2137 bug reintroduced on any machine whose symbol cache predates this change, not a
     // cache miss, hence the bump.
-    // v15: a CalcFormula's `filter(...)` condition now carries AL's quoted identifiers
-    // re-quoted for BC's filter grammar — `filter("Initial Entry")` is cached as
-    // `'Initial Entry'`, not as the AL text (issue #2305). A v14 payload deserialises
-    // perfectly well and replays the AL spelling, which reaches the runtime as a literal
-    // with double quotes in it, matches no option member, and throws
-    // NavInvalidFilterExpressionException out of CalcFields — a wrong answer replayed from
-    // cache on any machine whose symbol cache predates this change, not a cache miss.
+    // v15: AL's quoted identifiers inside a `filter(...)` are now re-quoted for BC's filter
+    // grammar, in BOTH a CalcFormula's where-condition and a report data item's
+    // DataItemTableView — `filter("Initial Entry")` is cached as `'Initial Entry'`, not as
+    // the AL text (issue #2305). A v14 payload deserialises perfectly well and replays the
+    // AL spelling, which reaches the runtime as a literal with double quotes in it, matches
+    // no option member, and throws NavInvalidFilterExpressionException out of CalcFields or
+    // out of the report's first Next() — a wrong answer replayed from cache on any machine
+    // whose symbol cache predates this change, not a cache miss.
     private const int CacheVersion = 15;
     private static readonly ConcurrentDictionary<string, AppSymbols> ProcessCache = new(StringComparer.OrdinalIgnoreCase);
     // Issue #1820 — path -> content-hash memo. ComputeAppContentHash needs to read the
@@ -640,6 +641,7 @@ internal static partial class BcAppSymbolCache
 
             var props = SymbolProperties(di);
             props.TryGetValue("DataItemTableView", out var tableView);
+            tableView = RecordPatches.TableViewText(tableView);
             props.TryGetValue("RequestFilterFields", out var filterFields);
 
             into.Add(new ReportDataItemSymbol(dataItemId, name, relatedTable, indent, tableView, filterFields,

--- a/AlRunner/Patches/RecordPatches.AlReportParser.cs
+++ b/AlRunner/Patches/RecordPatches.AlReportParser.cs
@@ -95,7 +95,7 @@ public static partial class RecordPatches
             // A namespaced reference collapses to its last segment.
             RelatedTable: LastNameSegment(di.DataItemTable?.ToString()),
             Indentation: indentation,
-            DataItemTableView: PropertyTextFrom(PropValue(props, "DataItemTableView")),
+            DataItemTableView: TableViewText(PropertyTextFrom(PropValue(props, "DataItemTableView"))),
             RequestFilterFields: PropertyTextFrom(PropValue(props, "RequestFilterFields"))));
 
         foreach (var child in di.Elements.OfType<NavSyntax.ReportDataItemSyntax>())

--- a/AlRunner/Patches/RecordPatches.AlSourceParser.cs
+++ b/AlRunner/Patches/RecordPatches.AlSourceParser.cs
@@ -421,7 +421,7 @@ public static partial class RecordPatches
                     list.Add(new ParsedCalcFilter(
                         Unquote(fe.LeftHandSide?.ToString()?.Trim() ?? ""),
                         ParsedCalcFilterKind.Filter,
-                        Value: fe.Filter?.ToString()?.Trim() ?? ""));
+                        Value: FilterValueText(fe.Filter?.ToString())));
                     break;
 
                 default:
@@ -653,7 +653,7 @@ public static partial class RecordPatches
                         filters.Add(new ParsedCalcFilter(
                             Unquote(fe.LeftHandSide?.ToString()?.Trim() ?? ""),
                             ParsedCalcFilterKind.Filter,
-                            Value: fe.Filter?.ToString()?.Trim() ?? ""));
+                            Value: FilterValueText(fe.Filter?.ToString())));
                         break;
 
                     // #1716 — the three flow-filter forms. All of them are FIELD links in
@@ -717,6 +717,58 @@ public static partial class RecordPatches
         if (s.Length >= 2 && s[0] == '"' && s[^1] == '"') return s[1..^1].Replace("\"\"", "\"");
         if (s.Length >= 2 && s[0] == '\'' && s[^1] == '\'') return s[1..^1].Replace("''", "'");
         return s;
+    }
+
+    /// <summary>
+    /// The expression of a <c>filter(...)</c> condition, as text BC's filter grammar can read.
+    /// <para>#2305. AL quotes an identifier with DOUBLE quotes; BC's filter grammar quotes a
+    /// literal with SINGLE quotes and treats <c>"</c> as an ordinary character — Ncl 28.1's
+    /// <c>FilterExpressionTokenizer.GetTokens</c> has a case for <c>'</c> (with <c>''</c> as its
+    /// escape) and none for <c>"</c>. So each AL quoted identifier is re-quoted here: AL's
+    /// <c>""</c> escape is resolved, then any <c>'</c> in the resulting name is doubled.</para>
+    /// <para>This is NOT <see cref="ConstValueText"/>'s rule, and the difference matters. A
+    /// const value is evaluated as a bare value, so its quotes simply come off; a filter value
+    /// is PARSED AS AN EXPRESSION, and Base App members such as
+    /// <c>Payment Discount (VAT Excl.)</c> carry parentheses the tokenizer would otherwise read
+    /// as grouping. <c>filter(&lt;&gt; " ")</c> is the same hazard with whitespace: bare, the
+    /// space is discarded and <c>&lt;&gt;</c> is left with no operand.</para>
+    /// <para>Carried through verbatim, <c>filter("Initial Entry")</c> reached the runtime as the
+    /// 15-character literal <c>"Initial Entry"</c>, which matches no option member, so
+    /// <c>Vendor Ledger Entry."Original Amount"</c> — and the 87 Base App CalcFormulas with a
+    /// <c>filter(...)</c> condition, 44 of them quoted — threw
+    /// <c>NavInvalidFilterExpressionException</c> instead of calculating.</para>
+    /// </summary>
+    private static string FilterValueText(string? text)
+    {
+        var s = (text ?? "").Trim();
+        if (s.IndexOf('"') < 0) return s;
+
+        var sb = new System.Text.StringBuilder(s.Length + 8);
+        for (int i = 0; i < s.Length; i++)
+        {
+            if (s[i] != '"') { sb.Append(s[i]); continue; }
+
+            var name = new System.Text.StringBuilder();
+            var closed = false;
+            for (i++; i < s.Length; i++)
+            {
+                if (s[i] != '"') { name.Append(s[i]); continue; }
+                // AL escapes a literal double quote inside an identifier by doubling it.
+                if (i + 1 < s.Length && s[i + 1] == '"') { name.Append('"'); i++; continue; }
+                closed = true;
+                break;
+            }
+            if (!closed)
+            {
+                // Unterminated quote: the AL parser would not have produced this node, so
+                // there is nothing to convert. Keep the text as written rather than invent
+                // a closing quote.
+                sb.Append('"').Append(name);
+                break;
+            }
+            sb.Append('\'').Append(name.ToString().Replace("'", "''")).Append('\'');
+        }
+        return sb.ToString();
     }
 
     /// <summary>

--- a/AlRunner/Patches/RecordPatches.AlSourceParser.cs
+++ b/AlRunner/Patches/RecordPatches.AlSourceParser.cs
@@ -772,6 +772,103 @@ public static partial class RecordPatches
     }
 
     /// <summary>
+    /// A report data item's <c>DataItemTableView</c>, rewritten from AL's spelling into the
+    /// runtime table-view form BC's own parser reads.
+    /// <para>#2305. BC applies this string with <c>NavRecord.ALSetView</c>
+    /// (<c>DataItemIterator.ApplyDataItemTableViewAndRequestFormFilters</c>), and
+    /// <c>TableViewParser</c>'s grammar uses a DIFFERENT quote character per clause:
+    /// <c>SORTING</c> field names and a <c>CONST(...)</c> value read with <c>"</c>, while a
+    /// <c>FILTER(...)</c> body reads with <c>'</c> — it is a filter expression, so it goes
+    /// through the same grammar as <c>SetFilter</c>. Only the inside of a <c>filter(...)</c>
+    /// is therefore rewritten; field names keep their AL quotes because the view grammar
+    /// already reads them that way.</para>
+    /// <para>Left alone, Base App's Report 321 "Vendor - Balance to Date" —
+    /// <c>where("Entry Type" = filter(&lt;&gt; "Initial Entry"))</c> — threw
+    /// <c>NavInvalidFilterExpressionException</c> the moment the report ran.</para>
+    /// </summary>
+    internal static string? TableViewText(string? view)
+    {
+        if (string.IsNullOrEmpty(view) || view.IndexOf('"') < 0) return view;
+
+        var sb = new System.Text.StringBuilder(view.Length + 8);
+        for (int i = 0; i < view.Length; i++)
+        {
+            // A quoted identifier outside filter(...) is a field name: BC's view grammar
+            // reads it with '"' as the quote char, so it is copied through untouched — and
+            // skipped over, so the `filter` keyword is never matched inside one (a field
+            // named "Date Filter" is otherwise a false positive).
+            if (view[i] == '"')
+            {
+                var end = SkipAlQuoted(view, i);
+                sb.Append(view, i, end - i);
+                i = end - 1;
+                continue;
+            }
+
+            if (StartsFilterCall(view, i, out var open))
+            {
+                var close = MatchingCloseParen(view, open);
+                if (close > 0)
+                {
+                    sb.Append(view, i, open + 1 - i);
+                    sb.Append(FilterValueText(view.Substring(open + 1, close - open - 1)));
+                    sb.Append(')');
+                    i = close;
+                    continue;
+                }
+            }
+
+            sb.Append(view[i]);
+        }
+        return sb.ToString();
+    }
+
+    /// <summary>Index just past the closing quote of the AL quoted identifier starting at
+    /// <paramref name="i"/> (which must be the opening <c>"</c>), treating <c>""</c> as an
+    /// escape. An unterminated identifier returns the end of the string.</summary>
+    private static int SkipAlQuoted(string s, int i)
+    {
+        for (i++; i < s.Length; i++)
+        {
+            if (s[i] != '"') continue;
+            if (i + 1 < s.Length && s[i + 1] == '"') { i++; continue; }
+            return i + 1;
+        }
+        return s.Length;
+    }
+
+    /// <summary>True when <paramref name="i"/> begins the keyword <c>filter</c> as a whole
+    /// word followed by <c>(</c>, whose index is returned in <paramref name="open"/>.</summary>
+    private static bool StartsFilterCall(string s, int i, out int open)
+    {
+        open = -1;
+        const string Keyword = "filter";
+        if (i + Keyword.Length > s.Length) return false;
+        if (string.Compare(s, i, Keyword, 0, Keyword.Length, StringComparison.OrdinalIgnoreCase) != 0) return false;
+        if (i > 0 && (char.IsLetterOrDigit(s[i - 1]) || s[i - 1] == '_')) return false;
+        var j = i + Keyword.Length;
+        while (j < s.Length && s[j] == ' ') j++;
+        if (j >= s.Length || s[j] != '(') return false;
+        open = j;
+        return true;
+    }
+
+    /// <summary>Index of the <c>)</c> closing the <c>(</c> at <paramref name="open"/>, or -1.
+    /// Parentheses inside a quoted identifier do not count — an option member such as
+    /// <c>Payment Discount (VAT Excl.)</c> carries a balanced pair of its own.</summary>
+    private static int MatchingCloseParen(string s, int open)
+    {
+        var depth = 0;
+        for (var i = open; i < s.Length; i++)
+        {
+            if (s[i] == '"') { i = SkipAlQuoted(s, i) - 1; continue; }
+            if (s[i] == '(') depth++;
+            else if (s[i] == ')' && --depth == 0) return i;
+        }
+        return -1;
+    }
+
+    /// <summary>
     /// Text overload, kept for <c>BcAppSymbolCache</c>, which reconstructs a CalcFormula from
     /// <c>SymbolReference.json</c> and so has text rather than a node. The text is wrapped in a
     /// minimal table and run through the same parser, so both callers share one implementation.


### PR DESCRIPTION
AL quotes an identifier with double quotes. BC's filter grammar quotes a literal with single quotes and treats `"` as an ordinary character — `FilterExpressionTokenizer.GetTokens(string)` in Microsoft.Dynamics.Nav.Ncl 28.1 has a case for `'` (with `''` as its escape) and no case for `"`. So a CalcFormula's `filter("Initial Entry")` has to reach the runtime as `'Initial Entry'`.

The parser carried the AL text through verbatim, so the value arrived as the 15-character literal `"Initial Entry"`, matched no member of enum 379 "Detailed CV Ledger Entry Type", and CalcFields threw `NavInvalidFilterExpressionException`. Base Application's `Vendor Ledger Entry."Original Amount"` is one of these, so every `"Remaining Pmt. Disc. Possible" - OnValidate` failed.

The `const(...)` case beside it already handles AL quoting, through `ConstValueText`, but it removes the quotes. That is right for a const, whose text is evaluated as a bare value, and wrong for a filter, whose text is parsed as an expression:

- `filter("Payment Discount (VAT Excl.)")` — unquoted, the parentheses become grouping.
- `filter(<> " ")` — unquoted, the space is discarded as whitespace and `<>` is left with no operand.

So the quotes are converted rather than stripped. The Base Application writes 87 CalcFormulas with a `filter()` condition, 44 of them containing a quoted identifier. `RelationConditionList`, which parses a TableRelation's `where(...)`, had the same defect and gets the same treatment.

The second commit applies the same rule to a report data item's `DataItemTableView`, which BC applies with `NavRecord.ALSetView`. `TableViewParser`'s grammar uses a different quote character per clause: SORTING field names, WHERE field names and a `CONST(...)` value all read with `"`, while a `FILTER(...)` body reads with `'`. So only the inside of `filter(...)` is rewritten there too. Base App's Report 321 "Vendor - Balance to Date" declares `where("Entry Type" = filter(<> "Initial Entry"))` and threw as soon as it ran.

Together: 41 tests in Microsoft's Tests-SINGLESERVER bucket, which now reach the report's layout instead — out of scope by design.

`BcAppSymbolCache` goes to v15 with it. A v14 payload deserialises perfectly well and replays the AL spelling, so without the bump the failure comes back from cache on any machine that ran an older build. That is not hypothetical — the fix looked like it had not worked until the cache was invalidated.

Tests: `AlRunner.Tests/CalcFormulaSyntaxTests.cs` covers the CalcFormula side including the parenthesised member name and the untouched unquoted case; `AlRunner.Tests/ReportTableViewQuotingTests.cs` covers the view grammar's per-clause quoting, a field named "Date Filter" not being mistaken for a filter call, and paren matching that does not end the call early; `BcAppSymbolCacheReportTests` proves the conversion reaches the cached report metadata end to end.

Verified: al-language corpus 2164/2164, runner-extras 201/201.

Closes #2305
