### PR TITLE
enum: capture DefaultImplementation and UnknownValueImplementation

### DIFF
--- a/AlRunner.Tests/EnumDefaultImplementationTests.cs
+++ b/AlRunner.Tests/EnumDefaultImplementationTests.cs
@@ -1,0 +1,101 @@
+// EnumDefaultImplementationTests — #2306.
+//
+// An AL enum can name its implementing codeunit in three places:
+//
+//     enum 205 "Alt. Cust VAT Reg. Doc." implements "Alt. Cust. VAT Reg. Doc."
+//     {
+//         DefaultImplementation = "Alt. Cust. VAT Reg. Doc." = "Alt. Cust. VAT Reg. Doc. Impl.";
+//         UnknownImplementation = ...;
+//         value(0; Default) { Implementation = ... }   // per value
+//     }
+//
+// AlEnumOptionMetadata only carried the per-value one, so an enum that names only a
+// DefaultImplementation — Base App 205 is exactly that, one value with no Implementation of
+// its own — resolved to -1 and `exit("Alt. Cust VAT Reg. Doc."::Default)` threw. It reached
+// 30 tests in Microsoft's Tests-SINGLESERVER bucket, through
+// Codeunit 207.GetAltCustVATRegDocImpl on every Sales Header insert.
+//
+// BC's NCLEnumMetadata.GetImplementationCodeunitId, decompiled from Ncl 28.1, is a three-step
+// fallback and these tests pin each step:
+//
+//     per-value implementations[interfaceIndex]                       if the ordinal has any
+//     else defaultImplementations[interfaceIndex]                     if the ordinal is known
+//     else unknownImplementations[interfaceIndex]                     if it is not
+//
+// with a value of 0 or less at either fallback meaning "no implementer" (-1), not "codeunit 0".
+using AlRunner;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class EnumDefaultImplementationTests
+{
+    // The shape of Base App enum 205: one value, no per-value Implementation, one
+    // DefaultImplementation.
+    private static AlEnumOptionMetadata OnlyADefaultImplementation()
+        => new(
+            name: "Alt. Cust VAT Reg. Doc.", id: 205,
+            options: new[] { "Default" }, indexes: new[] { 0 },
+            implementations: null, captions: null,
+            defaultImplementations: new[] { 6207 }, unknownImplementations: null);
+
+    [Fact]
+    public void KnownValueWithNoImplementationOfItsOwn_FallsBackToTheDefault()
+        => Assert.Equal(6207, OnlyADefaultImplementation().GetImplementationCodeunitIdPublic(0, 0));
+
+    [Fact]
+    public void PerValueImplementation_WinsOverTheDefault()
+    {
+        var meta = new AlEnumOptionMetadata(
+            name: "Two Ways", id: 2306001,
+            options: new[] { "A", "B" }, indexes: new[] { 0, 1 },
+            implementations: new[] { new[] { 111 }, System.Array.Empty<int>() },
+            captions: null,
+            defaultImplementations: new[] { 999 }, unknownImplementations: null);
+
+        Assert.Equal(111, meta.GetImplementationCodeunitIdPublic(0, 0));
+        // B declares none, so it takes the default — the two must not be confused.
+        Assert.Equal(999, meta.GetImplementationCodeunitIdPublic(1, 0));
+    }
+
+    [Fact]
+    public void UnknownOrdinal_UsesTheUnknownImplementation_NotTheDefault()
+    {
+        var meta = new AlEnumOptionMetadata(
+            name: "Extensible", id: 2306002,
+            options: new[] { "A" }, indexes: new[] { 0 },
+            implementations: null, captions: null,
+            defaultImplementations: new[] { 111 }, unknownImplementations: new[] { 222 });
+
+        Assert.Equal(111, meta.GetImplementationCodeunitIdPublic(0, 0));
+        Assert.Equal(222, meta.GetImplementationCodeunitIdPublic(7, 0));
+    }
+
+    [Fact]
+    public void AnInterfaceIndexPastTheDeclaredList_HasNoImplementer()
+        // An enum implementing one interface has one entry; asking for a second is -1, not
+        // an out-of-range read.
+        => Assert.Equal(-1, OnlyADefaultImplementation().GetImplementationCodeunitIdPublic(0, 1));
+
+    [Fact]
+    public void ADefaultOfZeroOrLess_MeansNoImplementer()
+    {
+        // BC reads `if (num <= 0) return -1;` — an explicit 0 is "none declared", never
+        // codeunit 0, and returning 0 would build a NavCodeunitHandle for a nonexistent
+        // object instead of failing.
+        var meta = new AlEnumOptionMetadata(
+            name: "Zeroed", id: 2306003,
+            options: new[] { "A" }, indexes: new[] { 0 },
+            implementations: null, captions: null,
+            defaultImplementations: new[] { 0 }, unknownImplementations: null);
+
+        Assert.Equal(-1, meta.GetImplementationCodeunitIdPublic(0, 0));
+    }
+
+    [Fact]
+    public void NoImplementationsAtAll_StillResolvesToMinusOne()
+        => Assert.Equal(-1, new AlEnumOptionMetadata(
+                name: "Bare", id: 2306004,
+                options: new[] { "A" }, indexes: new[] { 0 })
+            .GetImplementationCodeunitIdPublic(0, 0));
+}

--- a/AlRunner/BcCompiler.cs
+++ b/AlRunner/BcCompiler.cs
@@ -2658,7 +2658,11 @@ public sealed partial class BcCompiler
                 }
                 else
                 {
-                    AlEnumMetadataRegistry.Register(enumSym.Id, enumSym.Name, options, indexes, implementations, captions);
+                    // #2306 — the enum-level fallbacks apply to the base enum only; an
+                    // enumextension declares neither, so RegisterExtension takes none.
+                    AlEnumMetadataRegistry.Register(enumSym.Id, enumSym.Name, options, indexes, implementations, captions,
+                        ReadEnumImplementationFallback(enumSym, NavCA.PropertyKind.DefaultImplementation),
+                        ReadEnumImplementationFallback(enumSym, NavCA.PropertyKind.UnknownValueImplementation));
                 }
             }
             // Capture the per-report runtime metadata XML the emit pipeline hands us
@@ -2896,6 +2900,34 @@ public sealed partial class BcCompiler
         /// just for prebuilt MS/ISV apps. Without this the runner returned -1 and
         /// threw "Unable to cast enum '…' to interface at index N".
         /// </summary>
+        /// <summary>
+        /// Read an AL enum's own <c>DefaultImplementation</c> / <c>UnknownImplementation</c>
+        /// property, in the same comma-separated codeunit-id shape as a value's
+        /// <c>Implementation</c> (issue #2306). These are the enum-level fallbacks BC's
+        /// <c>NCLEnumMetadata.GetImplementationCodeunitId</c> uses when a value declares no
+        /// implementation of its own, which is how Base App 205
+        /// "Alt. Cust VAT Reg. Doc." is written — one value, no per-value Implementation.
+        /// Null means the enum declares none.
+        /// </summary>
+        private static int[]? ReadEnumImplementationFallback(NavCA.IEnumBaseTypeSymbol enumSymbol, NavCA.PropertyKind kind)
+        {
+            try
+            {
+                var text = enumSymbol.GetProperty(kind)?.ValueText;
+                if (string.IsNullOrEmpty(text))
+                    return null;
+                var ids = new List<int>();
+                foreach (var part in text.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+                    if (int.TryParse(part, out var id))
+                        ids.Add(id);
+                return ids.Count > 0 ? ids.ToArray() : null;
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
         private static int[] ReadEnumValueImplementations(NavCA.IEnumValueSymbol value)
         {
             try

--- a/AlRunner/Patches/BcAppSymbolCache.cs
+++ b/AlRunner/Patches/BcAppSymbolCache.cs
@@ -70,7 +70,13 @@ internal static partial class BcAppSymbolCache
     // no option member, and throws NavInvalidFilterExpressionException out of CalcFields or
     // out of the report's first Next() — a wrong answer replayed from cache on any machine
     // whose symbol cache predates this change, not a cache miss.
-    private const int CacheVersion = 15;
+    // v16: EnumSymbol gained DefaultImplementations / UnknownImplementations, the enum-level
+    // fallbacks BC's NCLEnumMetadata.GetImplementationCodeunitId uses when a value declares no
+    // Implementation of its own (issue #2306). A v15 payload deserialises with both null,
+    // which reads as "the enum declares none" — so a cached dependency would keep failing
+    // every enum-to-interface cast with "Unable to cast enum ... to interface at index 0",
+    // the exact #2306 bug, rather than missing the cache.
+    private const int CacheVersion = 16;
     private static readonly ConcurrentDictionary<string, AppSymbols> ProcessCache = new(StringComparer.OrdinalIgnoreCase);
     // Issue #1820 — path -> content-hash memo. ComputeAppContentHash needs to read the
     // WHOLE .app to hash it (unlike the FileInfo.Length/LastWriteTimeUtc stat it replaced,
@@ -221,7 +227,11 @@ internal static partial class BcAppSymbolCache
     // (issue #1775 — Format(<enum value>) must return the Caption, not the member
     // name, for enums coming from a prebuilt dependency .app too, not just enums
     // compiled from this bundle's own source).
-    internal sealed record EnumSymbol(int Id, string Name, List<string> Options, List<int> Indexes, List<List<int>> Implementations, List<string?>? Captions = null);
+    // DefaultImplementations / UnknownImplementations are the ENUM-level fallbacks, one list
+    // per enum (indexed by interface-declaration index), not one per value — see issue #2306
+    // and AlEnumOptionMetadata.GetImplementationCodeunitIdPublic.
+    internal sealed record EnumSymbol(int Id, string Name, List<string> Options, List<int> Indexes, List<List<int>> Implementations, List<string?>? Captions = null,
+        List<int>? DefaultImplementations = null, List<int>? UnknownImplementations = null);
 
     // Parsed query SymbolReference.json shape. A query is a tree of dataitems; the root
     // dataitem(s) live under the query's "Elements", nested dataitems under "DataItems".
@@ -878,7 +888,25 @@ internal static partial class BcAppSymbolCache
                 : null);
             nextOrdinal = ordinal + 1;
         }
-        return new EnumSymbol(id, name, options, indexes, implementations, captions);
+        // Enum-level fallbacks. Both are written the same way a value's Implementation is —
+        // a comma-separated list of codeunit ids, one per interface the enum implements.
+        var enumProps = SymbolProperties(enumType);
+        return new EnumSymbol(id, name, options, indexes, implementations, captions,
+            SymbolCodeunitIdList(enumProps, "DefaultImplementation"),
+            SymbolCodeunitIdList(enumProps, "UnknownValueImplementation"));
+    }
+
+    /// <summary>The named property read as a comma-separated list of codeunit ids, or null
+    /// when it is absent — "declares none", which is how most enums are written.</summary>
+    private static List<int>? SymbolCodeunitIdList(Dictionary<string, string> props, string propertyName)
+    {
+        if (!props.TryGetValue(propertyName, out var text) || string.IsNullOrWhiteSpace(text))
+            return null;
+        var ids = new List<int>();
+        foreach (var part in text.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+            if (int.TryParse(part, out var id))
+                ids.Add(id);
+        return ids.Count > 0 ? ids : null;
     }
 
     private static Dictionary<string, string> SymbolProperties(JsonElement element)

--- a/AlRunner/Patches/EnumMetadataPatches.cs
+++ b/AlRunner/Patches/EnumMetadataPatches.cs
@@ -58,7 +58,12 @@ public static class AlEnumMetadataRegistry
     // for field-level Caption. A null Captions array (not just a null element) means
     // "captured before caption-ingestion existed / caller didn't supply one" and is
     // treated exactly like an array of all-nulls.
-    public sealed record Entry(int Id, string Name, string[] Options, int[] Indexes, int[][] Implementations, string?[]? Captions = null);
+    // DefaultImplementations / UnknownImplementations are the ENUM-level fallbacks, indexed
+    // by interface-declaration index exactly like a value's own Implementations entry (issue
+    // #2306). They are not parallel to Options — one list per enum, not per value. An empty
+    // array means the enum declares none, which is how most enums are written.
+    public sealed record Entry(int Id, string Name, string[] Options, int[] Indexes, int[][] Implementations, string?[]? Captions = null,
+        int[]? DefaultImplementations = null, int[]? UnknownImplementations = null);
 
     // Base-enum registrations, keyed by the enum's own object Id. This also
     // absorbs precompiled-dependency enums (RegisterFromAppPath) and cache
@@ -83,7 +88,8 @@ public static class AlEnumMetadataRegistry
     /// <summary>Last-writer-wins for the base enum itself; bundle-wide enum-id
     /// collisions are quarantined upstream. Enumextension values are tracked
     /// separately — see <see cref="RegisterExtension"/>.</summary>
-    public static void Register(int id, string name, string[] options, int[] indexes, int[][]? implementations = null, string?[]? captions = null)
+    public static void Register(int id, string name, string[] options, int[] indexes, int[][]? implementations = null, string?[]? captions = null,
+        int[]? defaultImplementations = null, int[]? unknownImplementations = null)
     {
         if (options == null || indexes == null) return;
         if (options.Length != indexes.Length) return;
@@ -92,7 +98,8 @@ public static class AlEnumMetadataRegistry
             implementations = Array.Empty<int[]>();
         if (captions != null && captions.Length != options.Length)
             captions = null;
-        _byId[id] = new Entry(id, name ?? string.Empty, options, indexes, implementations, captions);
+        _byId[id] = new Entry(id, name ?? string.Empty, options, indexes, implementations, captions,
+            defaultImplementations, unknownImplementations);
     }
 
     /// <summary>
@@ -109,6 +116,9 @@ public static class AlEnumMetadataRegistry
             implementations = Array.Empty<int[]>();
         if (captions != null && captions.Length != options.Length)
             captions = null;
+        // An enumextension declares no DefaultImplementation/UnknownImplementation of its
+        // own — those are properties of the base enum — so the merge in TryGet takes the
+        // base entry's, and this entry carries none.
         var entry = new Entry(targetId, name ?? string.Empty, options, indexes, implementations, captions);
         _extByTargetId.AddOrUpdate(
             targetId,
@@ -164,7 +174,8 @@ public static class AlEnumMetadataRegistry
         foreach (var ext in extensions)
             AddValues(ext);
 
-        entry = new Entry(id, name, options.ToArray(), indexes.ToArray(), implementations.ToArray(), captions.ToArray());
+        entry = new Entry(id, name, options.ToArray(), indexes.ToArray(), implementations.ToArray(), captions.ToArray(),
+            baseEntry?.DefaultImplementations, baseEntry?.UnknownImplementations);
         return true;
     }
 
@@ -188,7 +199,9 @@ public static class AlEnumMetadataRegistry
                     enumSymbol.Options.ToArray(),
                     enumSymbol.Indexes.ToArray(),
                     enumSymbol.Implementations.Select(i => i.ToArray()).ToArray(),
-                    enumSymbol.Captions?.ToArray());
+                    enumSymbol.Captions?.ToArray(),
+                    enumSymbol.DefaultImplementations?.ToArray(),
+                    enumSymbol.UnknownImplementations?.ToArray());
         }
         catch (Exception ex)
         {
@@ -256,6 +269,13 @@ public static class AlEnumMetadataRegistry
                 indexes = e.Indexes,
                 implementations = e.Implementations,
                 captions = e.Captions,
+                // #2306 — the enum-level Default/UnknownValue implementation fallbacks. Absent
+                // from a sidecar written before this and read back as null, which means
+                // "declares none" and is the pre-#2306 behaviour; the AL-output cache key
+                // hashes the runner assembly's own content, so such a sidecar is unreachable
+                // from this build anyway.
+                defaultImplementations = e.DefaultImplementations,
+                unknownImplementations = e.UnknownImplementations,
             }).ToArray(),
         };
         var json = System.Text.Json.JsonSerializer.Serialize(dto);
@@ -270,6 +290,18 @@ public static class AlEnumMetadataRegistry
     /// how Program.cs's bundle-level sidecar replay works. Throws on corrupt JSON;
     /// callers treat that as a cache MISS and rebuild. Returns replayed entry count.
     /// </summary>
+    /// <summary>A sidecar's optional int-array property, or null when absent/empty —
+    /// "declares none" (issue #2306).</summary>
+    private static int[]? ReadIdList(System.Text.Json.JsonElement parent, string name)
+    {
+        if (!parent.TryGetProperty(name, out var el) || el.ValueKind != System.Text.Json.JsonValueKind.Array)
+            return null;
+        var ids = new int[el.GetArrayLength()];
+        int k = 0;
+        foreach (var v in el.EnumerateArray()) ids[k++] = v.GetInt32();
+        return ids.Length > 0 ? ids : null;
+    }
+
     public static int LoadSidecar(string path)
     {
         var json = File.ReadAllText(path);
@@ -321,7 +353,8 @@ public static class AlEnumMetadataRegistry
                 foreach (var c in capEl.EnumerateArray())
                     captions[ci++] = c.ValueKind == System.Text.Json.JsonValueKind.Null ? null : c.GetString();
             }
-            Register(id, name, opts, idxs, implementations, captions);
+            Register(id, name, opts, idxs, implementations, captions,
+                ReadIdList(e, "defaultImplementations"), ReadIdList(e, "unknownImplementations"));
             count++;
         }
         return count;
@@ -339,13 +372,18 @@ internal sealed class AlEnumOptionMetadata : NCLOptionMetadata
     private readonly NavListInt _ordinals;
     private readonly int[] _ordinalValues;
     private readonly int[][] _implementations;
+    private readonly int[] _defaultImplementations;
+    private readonly int[] _unknownImplementations;
     private readonly string?[] _captions;
     private readonly string _name;
     private readonly int _id;
 
-    public AlEnumOptionMetadata(string name, int id, string[] options, int[] indexes, int[][]? implementations = null, string?[]? captions = null)
+    public AlEnumOptionMetadata(string name, int id, string[] options, int[] indexes, int[][]? implementations = null, string?[]? captions = null,
+        int[]? defaultImplementations = null, int[]? unknownImplementations = null)
         : base(JoinOptions(options))
     {
+        _defaultImplementations = defaultImplementations ?? Array.Empty<int>();
+        _unknownImplementations = unknownImplementations ?? Array.Empty<int>();
         _name = name;
         _id = id;
         _ordinalValues = indexes;
@@ -478,18 +516,47 @@ internal sealed class AlEnumOptionMetadata : NCLOptionMetadata
 
     private readonly string[] _optionNames;
 
+    // #2306 — the same three-step fallback BC's NCLEnumMetadata.GetImplementationCodeunitId
+    // runs: the value's own Implementation, then the enum's DefaultImplementation for a value
+    // the enum declares, then its UnknownImplementation for an ordinal it does not. Only the
+    // first step existed here, so an enum that names ONLY a DefaultImplementation — Base App
+    // 205 "Alt. Cust VAT Reg. Doc." is one, and Codeunit 207.GetAltCustVATRegDocImpl casts it
+    // to an interface on every Sales Header insert — resolved to -1 and threw.
+    //
+    // BC throws NavNCLArgumentOutOfRangeException where the fallback list is missing or too
+    // short; this returns -1 for those, which the single caller
+    // (BcRuntime.ALCompiler_ToInterfaceFromOption) turns into its own throw naming the enum,
+    // the value and the interface index. Same outcome — a loud failure that identifies the
+    // enum — reached one frame later.
+    /// <summary>The AL enum's own object id and name, for diagnostics — the base class's
+    /// Name/Id virtuals are internal, so a failure message cannot otherwise say WHICH enum
+    /// it was looking at.</summary>
+    public (int Id, string Name) IdentityForDiagnostics => (_id, _name);
+
     public int GetImplementationCodeunitIdPublic(int ordinalValue, int interfaceIndex)
     {
-        if (interfaceIndex < 0 || _implementations.Length == 0)
+        if (interfaceIndex < 0)
             return -1;
+
+        var known = false;
         for (int i = 0; i < _ordinalValues.Length; i++)
         {
             if (_ordinalValues[i] != ordinalValue)
                 continue;
-            var implementations = _implementations[i];
-            return interfaceIndex < implementations.Length ? implementations[interfaceIndex] : -1;
+            known = true;
+            var implementations = i < _implementations.Length ? _implementations[i] : Array.Empty<int>();
+            if (interfaceIndex < implementations.Length)
+                return implementations[interfaceIndex];
+            break;
         }
-        return -1;
+
+        var fallback = known ? _defaultImplementations : _unknownImplementations;
+        if (interfaceIndex >= fallback.Length)
+            return -1;
+        // BC reads `if (num <= 0) return -1;` — a declared 0 means "no implementer", never
+        // codeunit 0, which would otherwise build a handle for an object that does not exist.
+        var codeunitId = fallback[interfaceIndex];
+        return codeunitId > 0 ? codeunitId : -1;
     }
 
     // -- reflection cache for NavList<T> internal ctor --
@@ -543,7 +610,8 @@ public static partial class BcRuntime
         {
             try
             {
-                var meta = new AlEnumOptionMetadata(e.Name, e.Id, e.Options, e.Indexes, e.Implementations, e.Captions);
+                var meta = new AlEnumOptionMetadata(e.Name, e.Id, e.Options, e.Indexes, e.Implementations, e.Captions,
+                    e.DefaultImplementations, e.UnknownImplementations);
                 return _alEnumCache.GetOrAdd(id, meta);
             }
             catch
@@ -564,7 +632,8 @@ public static partial class BcRuntime
             : TryGetImplementationCodeunitIdViaReflection(optionValue.NavOptionMetadata, optionValue.Value, interfaceIndex);
         if (implementationCodeunitId < 0)
             throw new InvalidOperationException(
-                $"Unable to cast enum '{optionValue.NavOptionMetadata.OptionString}' value '{optionValue}' to interface at index {interfaceIndex}.");
+                $"Unable to cast enum '{optionValue.NavOptionMetadata.OptionString}' value '{optionValue}' to interface at index {interfaceIndex}. "
+                + $"Metadata: {Describe(optionValue.NavOptionMetadata)}.");
 
         // Build the implementing codeunit handle and wrap its live target in the interface
         // handle. We must NOT dispose `handle` afterwards: disposing the NavCodeunitHandle
@@ -579,6 +648,11 @@ public static partial class BcRuntime
         var handle = new NavCodeunitHandle(parentOfResult, implementationCodeunitId);
         return new NavInterfaceHandle(parentOfResult, handle.Target);
     }
+
+    private static string Describe(NCLOptionMetadata metadata)
+        => metadata is AlEnumOptionMetadata al
+            ? $"{al.GetType().Name} enum {al.IdentityForDiagnostics.Id} '{al.IdentityForDiagnostics.Name}'"
+            : metadata.GetType().Name;
 
     private static readonly MethodInfo? GetImplementationCodeunitIdMethod = typeof(NCLOptionMetadata).GetMethod(
         "GetImplementationCodeunitId",

--- a/AlRunner/Patches/RecordPatches.BcAppFallback.cs
+++ b/AlRunner/Patches/RecordPatches.BcAppFallback.cs
@@ -67,13 +67,24 @@ public static partial class RecordPatches
             if (!_bcAppPaths.Contains(appPath, StringComparer.OrdinalIgnoreCase))
             {
                 _bcAppPaths.Add(appPath);
+                // This is the ONLY live path by which a precompiled dependency's enums reach
+                // AlEnumMetadataRegistry (AlEnumMetadataRegistry.RegisterFromAppPath, which
+                // looks like it does the same job, has no callers). Every field the symbol
+                // carries has to be passed here or it is simply absent at runtime: the
+                // per-value Captions (#1775) and the enum-level DefaultImplementation /
+                // UnknownValueImplementation fallbacks (#2306) were both being dropped,
+                // which is why Base App enum 205 "Alt. Cust VAT Reg. Doc." could not be cast
+                // to its interface.
                 foreach (var enumSymbol in BcAppSymbolCache.Get(appPath).Enums)
                     AlRunner.AlEnumMetadataRegistry.Register(
                         enumSymbol.Id,
                         enumSymbol.Name,
                         enumSymbol.Options.ToArray(),
                         enumSymbol.Indexes.ToArray(),
-                        enumSymbol.Implementations.Select(i => i.ToArray()).ToArray());
+                        enumSymbol.Implementations.Select(i => i.ToArray()).ToArray(),
+                        enumSymbol.Captions?.ToArray(),
+                        enumSymbol.DefaultImplementations?.ToArray(),
+                        enumSymbol.UnknownImplementations?.ToArray());
                 // Invalidate the indexes so newly-added .app gets picked up on next miss.
                 _bcTableIndex = null;
                 _bcSymbolTableIndex = null;

--- a/AlRunner/Patches/RecordPatches.NclMetaTableBuilder.cs
+++ b/AlRunner/Patches/RecordPatches.NclMetaTableBuilder.cs
@@ -1435,7 +1435,8 @@ public static partial class RecordPatches
                 if (!byName.TryGetValue(pair.Value, out var entry)) continue;
                 try
                 {
-                    var meta = new AlEnumOptionMetadata(entry.Name, entry.Id, entry.Options, entry.Indexes, entry.Implementations);
+                    var meta = new AlEnumOptionMetadata(entry.Name, entry.Id, entry.Options, entry.Indexes, entry.Implementations,
+                        entry.Captions, entry.DefaultImplementations, entry.UnknownImplementations);
                     AlRunner.Infrastructure.FieldPoke.SetInstance(_fNCLMetaFieldFieldOptionMetadata, nclField, meta);
                 }
                 catch (Exception ex)

--- a/AlRunner/Program.cs
+++ b/AlRunner/Program.cs
@@ -8210,6 +8210,11 @@ static int SaveEnumRegistrySidecar(string path)
             indexes = e.Indexes,
             implementations = e.Implementations,
             captions = e.Captions,
+            // #2306 — the enum-level DefaultImplementation / UnknownValueImplementation
+            // fallbacks, without which an enum that names no per-value Implementation cannot
+            // be cast to its interface on a cache HIT.
+            defaultImplementations = e.DefaultImplementations,
+            unknownImplementations = e.UnknownImplementations,
         }).ToArray(),
         // v4: per-report runtime metadata XML captured from emit — replayed on
         // cache HIT so NavReportSync builds real MetaReport instances.
@@ -8258,6 +8263,18 @@ static int SaveEnumRegistrySidecar(string path)
 // corrupt JSON; the caller treats any exception as cache MISS and rebuilds.
 static int LoadEnumRegistrySidecar(string path)
 {
+    // A sidecar's optional int-array property, or null when absent/empty — "declares none"
+    // (issue #2306).
+    static int[]? ReadIdList(System.Text.Json.JsonElement parent, string name)
+    {
+        if (!parent.TryGetProperty(name, out var el) || el.ValueKind != System.Text.Json.JsonValueKind.Array)
+            return null;
+        var ids = new int[el.GetArrayLength()];
+        int k = 0;
+        foreach (var v in el.EnumerateArray()) ids[k++] = v.GetInt32();
+        return ids.Length > 0 ? ids : null;
+    }
+
     var json = File.ReadAllText(path);
     using var doc = System.Text.Json.JsonDocument.Parse(json);
     if (!doc.RootElement.TryGetProperty("enums", out var arr)
@@ -8309,7 +8326,8 @@ static int LoadEnumRegistrySidecar(string path)
             foreach (var c in capEl.EnumerateArray())
                 captions[ci++] = c.ValueKind == System.Text.Json.JsonValueKind.Null ? null : c.GetString();
         }
-        AlEnumMetadataRegistry.Register(id, name, opts, idxs, implementations, captions);
+        AlEnumMetadataRegistry.Register(id, name, opts, idxs, implementations, captions,
+            ReadIdList(e, "defaultImplementations"), ReadIdList(e, "unknownImplementations"));
         count++;
     }
     // v4: replay per-report metadata XML (absent in pre-v4 sidecars — fine,


### PR DESCRIPTION
An AL enum can name its implementing codeunit in three places: per value with `Implementation`, once for the whole enum with `DefaultImplementation`, or for values it does not declare with `UnknownValueImplementation`. Only the per-value form was captured anywhere in the runner, so an enum written the second way resolved to -1 and the interface cast threw.

Base App enum 205 "Alt. Cust VAT Reg. Doc." is written that way — one value, no per-value `Implementation`, `DefaultImplementation` = codeunit 205 — and `Codeunit 207 "Alt. Cust. VAT Reg. Orchest."` casts it on every Sales Header insert. That reached 30 tests in Microsoft's Tests-SINGLESERVER bucket; after this change 0, and the bucket goes 121 to 138 passing.

`GetImplementationCodeunitIdPublic` now runs BC's own three-step fallback from `NCLEnumMetadata.GetImplementationCodeunitId`: the value's own `Implementation`, then the enum's `DefaultImplementation` for an ordinal the enum declares, then its `UnknownValueImplementation` for one it does not, with a declared 0 meaning "no implementer" rather than codeunit 0.

The two fields are threaded through every place enum metadata travels: the symbol parse, the registry entry, both `AlEnumOptionMetadata` construction sites, the AL-output cache sidecar and the dependency sidecar, and the AL compile-time capture.

Two things this uncovered, both fixed here because the fix is the same line of code:

- `RecordPatches.AddBcAppPath` is the only live path by which a precompiled dependency's enums reach the registry — `AlEnumMetadataRegistry.RegisterFromAppPath`, which looks like it does the same job, has no callers — and it was also dropping the per-value `Captions` that were added for `Format(<enum value>)`.
- The failure message now names the enum. It said only "Unable to cast enum 'Default' value 'Default'", which does not identify anything; it now reads "enum 205 'Alt. Cust VAT Reg. Doc.'".

`BcAppSymbolCache` goes to v16: a v15 payload deserialises with both fields null, which reads as "the enum declares none" and reproduces the bug from cache rather than missing it. The AL-output sidecars need no schema bump — their cache key hashes the runner assembly's own content, so a sidecar written before this change is already unreachable.

Note the property is spelled `UnknownValueImplementation` in both AL and the symbol file. In Base Application 28.1, 8 enums declare a `DefaultImplementation` and 1 declares an `UnknownValueImplementation`.

Tests: `AlRunner.Tests/EnumDefaultImplementationTests.cs` pins each step of the fallback separately, including that a declared 0 means no implementer and that an interface index past the declared list is -1 rather than an out-of-range read.

Verified: al-language corpus 2164/2164, runner-extras 201/201, and the 203 unit tests covering enum, symbol cache, sidecar, CalcFormula and report.

Closes #2306
