### PR TITLE
session: seed the skeleton session's application-area fields

### DIFF
--- a/AlRunner/BcRuntime.cs
+++ b/AlRunner/BcRuntime.cs
@@ -1250,6 +1250,49 @@ public static partial class BcRuntime
                 }
             }
 
+            // applicationAreaCache / applicationAreas / applicationAreaString — the three
+            // fields behind NavSession.ApplicationAreas, all set by FIELD INITIALIZERS on
+            // NavSession (decompile pin: NCL @ 214751, 214757, 214759):
+            //
+            //     private readonly Dictionary<string, bool> applicationAreaCache = new();
+            //     private string[] applicationAreas = new string[1] { "#All" };
+            //     private string applicationAreaString = string.Empty;
+            //
+            // GetUninitializedObject skips field initializers, so on the skeleton session all
+            // three are null. The setter (NCL @ 215838) ends with applicationAreaCache.Clear(),
+            // so the FIRST assignment NREs — inside BC, with no indication of what is missing.
+            //
+            // That assignment is not exotic. System Application codeunit 9178
+            // "Application Area Mgmt".SetupApplicationArea calls it whenever the experience
+            // tier is set, which Microsoft's own test setup does routinely: 34 of the tests in
+            // the Tests-SINGLESERVER bucket died here, all reporting only
+            // "Object reference not set to an instance of an object".
+            //
+            // Planting the declared initial values is faithful by construction — they are
+            // exactly what the ctor would have produced — and it leaves BC's own getter,
+            // setter and applicationAreaCache lookup (NCL @ 218102) running unchanged, so an
+            // application area set by AL is the one AL reads back.
+            foreach (var (fieldName, initial) in new (string, object)[]
+                     {
+                         ("applicationAreaCache", new Dictionary<string, bool>()),
+                         ("applicationAreas", new[] { "#All" }),
+                         ("applicationAreaString", string.Empty),
+                     })
+            {
+                var f = sessType.GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance);
+                if (f == null || f.GetValue(_skeletonSession) != null) continue;
+                try
+                {
+                    FieldPoke.SetInstance(f, _skeletonSession!, initial);
+                }
+                catch (Exception ex)
+                {
+                    Console.Error.WriteLine(
+                        $"[BcRuntime] WARN: {fieldName} populate failed: {ex.GetType().Name}: {ex.Message} — "
+                        + "AL that sets the application area will NRE");
+                }
+            }
+
             // VerifyExecutePermission overloads → no-op
             foreach (var m in sessType.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
                 .Where(m => m.Name == "VerifyExecutePermission" && m.ReturnType == typeof(void)))


### PR DESCRIPTION
`NavSession` declares three fields with field initializers (decompiled from Microsoft.Dynamics.Nav.Ncl 28.1, lines 214751, 214757, 214759):

```csharp
private readonly Dictionary<string, bool> applicationAreaCache = new Dictionary<string, bool>();
private string[] applicationAreas = new string[1] { "#All" };
private string applicationAreaString = string.Empty;
```

The runner builds its skeleton session with `GetUninitializedObject`, which skips field initializers, so all three are null. The setter ends with `applicationAreaCache.Clear()`, so the first assignment to `NavSession.ApplicationAreas` throws a bare `NullReferenceException` from inside the platform, naming nothing.

That assignment is routine: System Application codeunit 9178 "Application Area Mgmt".SetupApplicationArea runs it whenever the experience tier is set, which Microsoft's own test setup does as a matter of course. 34 tests in the Tests-SINGLESERVER bucket died there, all reporting only "Object reference not set to an instance of an object".

Planting the declared initial values is faithful by construction — they are exactly what the constructor would have produced — and it leaves BC's own getter, setter and `applicationAreaCache` lookup running unchanged, so an application area set by AL is the one AL reads back. Same shape as the `EventBindings`, `cachedEnvironmentDefaultLcid`, `globalLanguageStack` and `globalFormatRegionStack` seeding already in this method.

Bucket result: 138 to 153 passing.

## Coverage

The behaviour underneath is plain BC behaviour, so it is proven upstream rather than here: StefanMaron/BusinessCentral.AL.Language.Tests#86 is merged and green on all eight BC legs from 27.0 to 28.4. It asserts that saving an experience tier reads back as the current tier, that saving a second one replaces the first, that an unknown tier is refused with false and leaves the current tier alone, and that the foundation application area is enabled afterwards. The runner could not run a line of it before this change.

The submodule pin bump that pulls those four tests in is deliberately **not** in this PR. The same corpus commit also carries seven tests from StefanMaron/BusinessCentral.AL.Language.Tests#84, which need the separate number-sequence fix in #2319 to pass; bumping the pin here would make this PR red for a reason that has nothing to do with it. #2319 carries the pin bump and the matching count-baseline update, and lands after this.

Verified at the current pin: al-language corpus 2204/2204, runner-extras 201/201.

Closes #2315
