### PR TITLE
feat(record): serve the Metadata Permission Set virtual table so codeunit 9000 can find SUPER

### DIFF
--- a/AlRunner.Tests/BcAppSymbolCachePermissionSetTests.cs
+++ b/AlRunner.Tests/BcAppSymbolCachePermissionSetTests.cs
@@ -1,0 +1,223 @@
+// BcAppSymbolCachePermissionSetTests — proves BcAppSymbolCache reads the permission sets a
+// dependency .app declares, which is what the "Metadata Permission Set" (2000000250) virtual
+// table serves (issue #2313).
+//
+// Gap being fixed
+// ---------------
+// The table was empty, so Microsoft's "Users - Create Super User" (codeunit 9000) could not
+// resolve MetadataPermissionSet.Get(<null guid>, 'SUPER') and every AL test that creates a
+// user failed in setup.
+//
+// The two things this parse gets wrong if written carelessly, both pinned below:
+//
+//  1. BC 26+ nests application objects under "Namespaces". A root-only read of
+//     "PermissionSets" finds 2 entries in Base Application 28.1 and ZERO in System
+//     Application 28.1 — which is where SUPER lives. Measured against the real .app files,
+//     not assumed.
+//  2. `Assignable` is not always stated. Base Application 28.1's "D365 Basic - Edit" (208)
+//     declares no Assignable property and is assignable; "LOCAL" (1001) declares
+//     `Assignable = false`. AL's default is true, matching table 2000000250's own field 4
+//     (`InitValue = true`).
+//
+// The shapes below mirror what those real .app symbol files state, including SUPER's caption
+// and the System Application's app id. The .app shape (a plain zip holding
+// SymbolReference.json) mirrors BcAppSymbolCachePageMetadataTests.
+
+using System.IO.Compression;
+using System.Text;
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+// #1821: BcAppSymbolCache.Get() resolves its on-disk path through the process-global
+// CacheRoots override, so this joins CacheRootsSerialCollection to avoid racing
+// CacheRootsTests's SetOverride calls — see that collection's header for why.
+[Collection(CacheRootsSerialCollection.Name)]
+public class BcAppSymbolCachePermissionSetTests
+{
+    private const string SystemApplicationAppId = "63ca2fa4-4f03-4f2b-a480-172fef340d3f";
+
+    private static string WriteApp(string dir, string symbolReferenceJson)
+    {
+        var appPath = Path.Combine(dir, Guid.NewGuid().ToString("N") + ".app");
+        using var zip = new FileStream(appPath, FileMode.Create);
+        using var za = new ZipArchive(zip, ZipArchiveMode.Create);
+        var entry = za.CreateEntry("SymbolReference.json");
+        using var w = new StreamWriter(entry.Open(), Encoding.UTF8);
+        w.Write(symbolReferenceJson);
+        return appPath;
+    }
+
+    // "SUPER" and "Agent - Objects" sit inside a Namespaces container, exactly as the real
+    // System Application 28.1 symbol file states them. "Root Level Set" sits at the root, so
+    // one traversal has to find both.
+    private const string SymbolReference = """
+        {
+          "RuntimeVersion": "15.1",
+          "AppId": "63ca2fa4-4f03-4f2b-a480-172fef340d3f",
+          "Name": "System Application",
+          "PermissionSets": [
+            {
+              "Id": 9001,
+              "Name": "Root Level Set",
+              "Properties": [
+                { "Name": "Caption", "Value": "Declared at the symbol reference root" },
+                { "Name": "Assignable", "Value": "1" }
+              ]
+            }
+          ],
+          "Namespaces": [
+            {
+              "Name": "System",
+              "Namespaces": [
+                {
+                  "Name": "Security",
+                  "PermissionSets": [
+                    {
+                      "Id": 31,
+                      "Name": "SUPER",
+                      "Properties": [
+                        { "Name": "Access", "Value": "Public" },
+                        { "Name": "Assignable", "Value": "1" },
+                        { "Name": "Caption", "Value": "This role has all permissions." }
+                      ]
+                    },
+                    {
+                      "Id": 4300,
+                      "Name": "Agent - Objects",
+                      "Properties": [
+                        { "Name": "Access", "Value": "Internal" },
+                        { "Name": "Assignable", "Value": "0" }
+                      ]
+                    },
+                    {
+                      "Id": 208,
+                      "Name": "D365 Basic - Edit",
+                      "Properties": [
+                        { "Name": "Caption", "Value": "Dynamics 365 Basic - Edit access" }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+        """;
+
+    [Fact]
+    public void PermissionSets_NestedUnderNamespaces_AreFoundWithTheirOwningAppId()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var appPath = WriteApp(dir, SymbolReference);
+            var symbols = BcAppSymbolCache.Get(appPath);
+
+            Assert.NotNull(symbols.PermissionSets);
+            // Both the nested three and the root-level one; a root-only read would find 1.
+            Assert.Equal(4, symbols.PermissionSets!.Count);
+
+            var super = Assert.Single(symbols.PermissionSets, p => p.Name == "SUPER");
+            Assert.Equal(31, super.Id);
+            Assert.Equal("This role has all permissions.", super.Caption);
+            Assert.True(super.Assignable);
+
+            var rootLevel = Assert.Single(symbols.PermissionSets, p => p.Name == "Root Level Set");
+            Assert.Equal(9001, rootLevel.Id);
+            Assert.Equal("Declared at the symbol reference root", rootLevel.Caption);
+
+            // The owning app id is the symbol reference's own AppId — one value for every
+            // permission set in the file, which is why PermissionSetSymbol does not repeat
+            // it. Blanking it for SUPER/SECURITY is the virtual table's rule (BC's
+            // SystemTableTriggers.IsPermissionSetAppIdNull), applied at row build time, so
+            // the parse stays a faithful reading of the symbol file.
+            Assert.Equal(SystemApplicationAppId, symbols.AppId);
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void PermissionSets_AssignableDefaultsToTrue_AndAnExplicitFalseIsHonored()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var appPath = WriteApp(dir, SymbolReference);
+            var permissionSets = BcAppSymbolCache.Get(appPath).PermissionSets!;
+
+            // Declares Assignable = 0.
+            var agentObjects = Assert.Single(permissionSets, p => p.Name == "Agent - Objects");
+            Assert.False(agentObjects.Assignable);
+
+            // Declares no Assignable property at all — AL's default is true.
+            var basicEdit = Assert.Single(permissionSets, p => p.Name == "D365 Basic - Edit");
+            Assert.True(basicEdit.Assignable);
+            Assert.Equal("Dynamics 365 Basic - Edit access", basicEdit.Caption);
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void PermissionSets_NoDeclaredCaption_StaysNull()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var appPath = WriteApp(dir, SymbolReference);
+            var permissionSets = BcAppSymbolCache.Get(appPath).PermissionSets!;
+
+            // "not declared" must stay distinguishable from "declared as something", so the
+            // parse leaves it null. The virtual table then writes BC's own answer for a
+            // permission set with no caption, which is the empty string
+            // (NCLMetaPermissionSet.Caption is `captionStrings?.GetValueOrDefault() ?? ""`),
+            // never the role id.
+            var agentObjects = Assert.Single(permissionSets, p => p.Name == "Agent - Objects");
+            Assert.Null(agentObjects.Caption);
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void PermissionSets_AppDeclaringNone_ReturnsAnEmptyList()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var appPath = WriteApp(dir, """
+                {
+                  "RuntimeVersion": "15.1",
+                  "AppId": "c1335042-3002-4257-bf8a-75c898ccb1b8",
+                  "Name": "Application",
+                  "Codeunits": [ { "Id": 1, "Name": "Some Codeunit" } ]
+                }
+                """);
+
+            var permissionSets = BcAppSymbolCache.Get(appPath).PermissionSets;
+
+            // Empty, not null: an app that declares none must not be indistinguishable from
+            // one whose payload predates the field (that case is what the CacheVersion bump
+            // exists to make impossible).
+            Assert.NotNull(permissionSets);
+            Assert.Empty(permissionSets!);
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+}

--- a/AlRunner/Patches/BcAppSymbolCache.cs
+++ b/AlRunner/Patches/BcAppSymbolCache.cs
@@ -82,7 +82,13 @@ internal static partial class BcAppSymbolCache
     // declares no profiles" — so a cached dependency would leave All Profile empty and
     // every read of it would keep raising "There is no All Profile within the filter",
     // the exact #2317 bug replayed from cache rather than a cache miss.
-    private const int CacheVersion = 17;
+    // v18: AppSymbols gained PermissionSets — the (owning app id, role id, caption,
+    // assignable) tuples the Metadata Permission Set (2000000250) virtual table serves
+    // (issue #2313). A v17 payload deserialises with the list null, which reads as "this
+    // app declares no permission sets" — so a cached System Application would keep
+    // answering `MetadataPermissionSet.Get(<null guid>, 'SUPER')` with "does not exist",
+    // the exact #2313 bug, rather than missing the cache.
+    private const int CacheVersion = 18;
     private static readonly ConcurrentDictionary<string, AppSymbols> ProcessCache = new(StringComparer.OrdinalIgnoreCase);
     // Issue #1820 — path -> content-hash memo. ComputeAppContentHash needs to read the
     // WHOLE .app to hash it (unlike the FileInfo.Length/LastWriteTimeUtc stat it replaced,
@@ -128,8 +134,14 @@ internal static partial class BcAppSymbolCache
         List<ObjectSymbol> Objects, List<ReportSymbol> Reports, List<PageSymbol> Pages,
         // Profiles the .app declares, plus the app's own identity — both feed the
         // "All Profile" (2000000178) virtual table, whose rows are per-app and carry the
-        // declaring app's id and name as columns of their own (#2317).
-        List<ProfileSymbol>? Profiles = null, string? AppId = null, string? AppName = null);
+        // declaring app's id and name as columns of their own (#2317). AppId is also what
+        // attributes a permission set to its owning app (#2313), so nothing here parses the
+        // symbol reference's identity twice.
+        List<ProfileSymbol>? Profiles = null, string? AppId = null, string? AppName = null,
+        // Trailing + optional on purpose: every existing construction site keeps compiling
+        // unchanged, and an older cache payload deserialises as null (read as "not stated",
+        // never as "declares none" — see PermissionSetSymbol).
+        List<PermissionSetSymbol>? PermissionSets = null);
 
     /// <summary>
     /// One profile as SymbolReference.json states it. <c>ProfileId</c> is the profile object's
@@ -148,6 +160,19 @@ internal static partial class BcAppSymbolCache
     internal sealed record ProfileSymbol(
         string ProfileId, string? Caption, string? Description, string? RoleCenterPageName,
         bool Enabled, bool Promoted);
+
+    /// <summary>
+    /// One <c>permissionset</c> object a dependency .app declares, as its
+    /// SymbolReference.json states it — three of the four columns of the Metadata Permission
+    /// Set (2000000250) virtual table (issue #2313). The fourth, "App ID", comes from
+    /// <see cref="AppSymbols.AppId"/>, since every permission set in one symbol reference
+    /// belongs to the same app.
+    ///
+    /// <c>Caption</c> is null when the permission set declares no <c>Caption</c> property.
+    /// <c>Assignable</c> mirrors the declared <c>Assignable</c> property; AL's own default
+    /// for a permissionset that states none is <c>true</c>, which is what the parse applies.
+    /// </summary>
+    internal sealed record PermissionSetSymbol(int Id, string Name, string? Caption, bool Assignable);
 
     /// <summary>
     /// A precompiled dependency's page, as far as SymbolReference.json states it — just
@@ -290,7 +315,8 @@ internal static partial class BcAppSymbolCache
     private sealed record CachePayload(string ContentHash,
         List<ParsedTable> Tables, List<EnumSymbol> Enums, List<QuerySymbol> Queries,
         List<ObjectSymbol>? Objects, List<ReportSymbol>? Reports, List<PageSymbol>? Pages,
-        List<ProfileSymbol>? Profiles = null, string? AppId = null, string? AppName = null);
+        List<ProfileSymbol>? Profiles = null, string? AppId = null, string? AppName = null,
+        List<PermissionSetSymbol>? PermissionSets = null);
 
     /// <summary>
     /// Parse a loose <c>SymbolReference.json</c> file (the raw module JSON, NOT a .app
@@ -308,12 +334,14 @@ internal static partial class BcAppSymbolCache
         var reports = new Dictionary<int, ReportSymbol>();
         var pages = new Dictionary<int, PageSymbol>();
         var profiles = new Dictionary<string, ProfileSymbol>(StringComparer.OrdinalIgnoreCase);
+        var permissionSets = new Dictionary<int, PermissionSetSymbol>();
         using var doc = JsonDocument.Parse(File.ReadAllText(jsonPath));
         VisitSymbolContainer(doc.RootElement, tables, enums, queries, objects, reports, pages, profiles);
+        CollectPermissionSets(doc.RootElement, permissionSets);
         var (appId, appName) = ReadAppIdentity(doc.RootElement);
         return new AppSymbols(tables.Values.ToList(), enums.Values.ToList(), queries.Values.ToList(),
             objects.Values.ToList(), reports.Values.ToList(), pages.Values.ToList(),
-            profiles.Values.ToList(), appId, appName);
+            profiles.Values.ToList(), appId, appName, permissionSets.Values.ToList());
     }
 
     internal static AppSymbols Get(string appPath)
@@ -391,7 +419,8 @@ internal static partial class BcAppSymbolCache
             return new AppSymbols(payload.Tables, payload.Enums, payload.Queries ?? new List<QuerySymbol>(),
                 payload.Objects ?? new List<ObjectSymbol>(), payload.Reports ?? new List<ReportSymbol>(),
                 payload.Pages ?? new List<PageSymbol>(),
-                payload.Profiles ?? new List<ProfileSymbol>(), payload.AppId, payload.AppName);
+                payload.Profiles ?? new List<ProfileSymbol>(), payload.AppId, payload.AppName,
+                payload.PermissionSets ?? new List<PermissionSetSymbol>());
         }
         catch (Exception ex)
         {
@@ -408,7 +437,7 @@ internal static partial class BcAppSymbolCache
         try
         {
             Directory.CreateDirectory(Path.GetDirectoryName(cachePath)!);
-            var payload = new CachePayload(contentHash, symbols.Tables, symbols.Enums, symbols.Queries, symbols.Objects, symbols.Reports, symbols.Pages, symbols.Profiles, symbols.AppId, symbols.AppName);
+            var payload = new CachePayload(contentHash, symbols.Tables, symbols.Enums, symbols.Queries, symbols.Objects, symbols.Reports, symbols.Pages, symbols.Profiles, symbols.AppId, symbols.AppName, symbols.PermissionSets);
             // #1809 follow-up: cachePath is content-keyed (hash of the .app file),
             // so two subprocesses parsing the same app concurrently used to race a
             // plain File.WriteAllText into the same path. TryRead already treats any
@@ -439,11 +468,13 @@ internal static partial class BcAppSymbolCache
         var reports = new Dictionary<int, ReportSymbol>();
         var pages = new Dictionary<int, PageSymbol>();
         var profiles = new Dictionary<string, ProfileSymbol>(StringComparer.OrdinalIgnoreCase);
+        var permissionSets = new Dictionary<int, PermissionSetSymbol>();
         string? appId = null, appName = null;
         foreach (var json in ReadSymbolReferences(appPath))
         {
             using var doc = JsonDocument.Parse(json);
             VisitSymbolContainer(doc.RootElement, tables, enums, queries, objects, reports, pages, profiles);
+            CollectPermissionSets(doc.RootElement, permissionSets);
             // The .app's own identity, stated once at the root of its SymbolReference.json.
             // First one wins: ReadSymbolReferences can yield more than one module for a
             // package, and the package's own module is the one that comes first.
@@ -452,7 +483,50 @@ internal static partial class BcAppSymbolCache
         }
         return new AppSymbols(tables.Values.ToList(), enums.Values.ToList(), queries.Values.ToList(),
             objects.Values.ToList(), reports.Values.ToList(), pages.Values.ToList(),
-            profiles.Values.ToList(), appId, appName);
+            profiles.Values.ToList(), appId, appName, permissionSets.Values.ToList());
+    }
+
+    /// <summary>
+    /// Collect every <c>permissionset</c> a symbol reference declares, at the root and in
+    /// every nested <c>Namespaces</c> container (BC 26+ nests application objects under
+    /// namespaces, which is why a root-only read of <c>PermissionSets</c> finds two entries
+    /// in the Base Application and none at all in the System Application — issue #2313).
+    ///
+    /// Kept as its own walk rather than another parameter on VisitSymbolContainer: only the
+    /// Metadata Permission Set table reads these, and a second pass over an already-parsed
+    /// JsonDocument costs nothing measurable next to the parse itself.
+    ///
+    /// The owning app id is NOT read here — <see cref="ReadAppIdentity"/> already takes it
+    /// off the same root for <see cref="AppSymbols.AppId"/>, and every permission set in one
+    /// symbol reference belongs to that app.
+    /// </summary>
+    private static void CollectPermissionSets(JsonElement root, Dictionary<int, PermissionSetSymbol> into)
+    {
+        Visit(root);
+
+        void Visit(JsonElement container)
+        {
+            if (container.TryGetProperty("PermissionSets", out var arr) && arr.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var el in arr.EnumerateArray())
+                {
+                    if (!el.TryGetProperty("Id", out var idProp) || !idProp.TryGetInt32(out var id) || id <= 0)
+                        continue;
+                    var name = el.TryGetProperty("Name", out var nameProp) ? nameProp.GetString() : null;
+                    if (string.IsNullOrEmpty(name)) continue;
+                    var props = SymbolProperties(el);
+                    props.TryGetValue("Caption", out var caption);
+                    // AL's `Assignable` defaults to true; only an explicit false flips it
+                    // (Base Application's "LOCAL" states `Assignable = false`, while
+                    // "D365 Basic - Edit" states nothing and is assignable). Table
+                    // 2000000250's own field 4 carries `InitValue = true` for the same reason.
+                    into.TryAdd(id, new PermissionSetSymbol(id, name, caption, !SymbolBoolFalse(props, "Assignable")));
+                }
+            }
+            if (container.TryGetProperty("Namespaces", out var namespaces) && namespaces.ValueKind == JsonValueKind.Array)
+                foreach (var ns in namespaces.EnumerateArray())
+                    Visit(ns);
+        }
     }
 
     /// <summary>

--- a/AlRunner/Patches/RecordPatches.MetadataPermissionSetVirtualTable.cs
+++ b/AlRunner/Patches/RecordPatches.MetadataPermissionSetVirtualTable.cs
@@ -1,0 +1,260 @@
+// RecordPatches.MetadataPermissionSetVirtualTable — managed provider for the
+// "Metadata Permission Set" system virtual table (2000000250).
+//
+// WHY THIS EXISTS
+//   Creating a user runs entirely through Microsoft's own AL:
+//
+//     "Users - Create Super User"(codeunit 9000).AddUserAsSuper
+//       -> GetSuperRole
+//            MetadataPermissionSet.Get(<null guid>, 'SUPER')
+//       -> AssignPermissionSetToUser -> AccessControl.Insert(true)
+//
+//   On the runner 2000000250 routed to the same empty in-memory store as every
+//   other table, so the Get found nothing and BC raised
+//   `NavCSideRecordNotFoundException: The Metadata Permission Set does not exist.
+//   Identification fields and values: App ID='{00000000-...}',Role ID='SUPER'`
+//   for every test that creates a user — 57 of them in Microsoft's
+//   Tests-SINGLESERVER bucket alone (issue #2313).
+//
+// WHAT A ROW IS, ON A REAL TIER
+//   MetadataPermissionSetDataProvider (Ncl.dll) enumerates
+//   NavAppGroup.PermissionSetGroupObjectMetadataSummaries — one entry per
+//   `permissionset` object the installed apps declare — and for each one emits
+//
+//     field 1 "App ID"     the owning app's id, EXCEPT for the two platform roles
+//                          SUPER and SECURITY, which get Guid.Empty. That rule is
+//                          SystemTableTriggers.IsPermissionSetAppIdNull(roleId),
+//                          which returns true for exactly those two names, and it
+//                          is why codeunit 9000 looks SUPER up under a null guid.
+//     field 2 "Role ID"    the permission set object's NAME (not its caption) —
+//                          confirmed by MetadataPermissionSetRelationDataProvider,
+//                          which builds the same key with
+//                          `new NavCode(len, permissionSet.Name)`.
+//     field 3 "Name"       NCLMetaPermissionSet.Caption, which is
+//                          `captionStrings?.GetValueOrDefault() ?? string.Empty` —
+//                          so a permission set declaring no Caption has a BLANK
+//                          Name here, NOT its role id. Base Application's "LOCAL"
+//                          is one such set.
+//     field 4 "Assignable" NCLMetaPermissionSet.Assignable.
+//
+// WHERE THE ROWS COME FROM HERE
+//   Each dependency .app's own SymbolReference.json, which states every
+//   permissionset's Id, Name, Caption property and Assignable property verbatim
+//   (BcAppSymbolCache.PermissionSetSymbol); the owning app id is that symbol
+//   reference's own AppId (BcAppSymbolCache.AppSymbols.AppId), since every
+//   permission set in one symbol file belongs to the same app. Nothing is inferred:
+//   a role resolves if and only if an installed app really declares it, and an
+//   unknown role still raises BC's own not-found error.
+//
+//   The rows go into the same in-memory store every other table uses, so BC's own
+//   filter / sort / Find engine applies the AL filters — the primary key
+//   (App ID, Role ID) included. `Get(<some app id>, 'SUPER')` therefore finds
+//   nothing, exactly as on a real tier.
+//
+// WHAT IS DELIBERATELY NOT SERVED HERE
+//   The two sibling tables BC's provider factory lists next to this one:
+//   "Metadata Permission" (2000000251, one row per object permission) and
+//   "Metadata Permission Set Relation" (2000000252, the include/exclude edges).
+//   Neither is read by anything in the cluster this fixes, and serving them
+//   truthfully needs the per-object Permissions arrays and the resolved
+//   IncludedPermissionSets/ExcludedPermissionSets ids, which is a separate piece
+//   of work. They keep answering empty rather than being half-populated here.
+//
+// PRECOMPILED-DLL RESPECT
+//   Runtime-engine types only (VirtualDataProvider, NCLMetaTable, NavValue,
+//   ReadOnlyRecordBuffer, TempTableDataProvider). No AL business-logic body is
+//   touched — codeunit 9000 runs unmodified, and it is the metadata under it that
+//   changes.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using AlRunner.Infrastructure;
+using Microsoft.Dynamics.Nav.Runtime;
+
+namespace AlRunner.Patches;
+
+public static partial class RecordPatches
+{
+    internal const int MetadataPermissionSetVirtualTableId = 2000000250;
+
+    // Per in-memory-provider guard so repeated data-access handouts only insert roles
+    // that appeared since (idempotent, no duplicate-key throws).
+    private static readonly ConditionalWeakTable<object, ConcurrentDictionary<string, byte>> _mpsPopulatedByProvider = new();
+
+    private static bool _mpsReflectionReady;
+    private static MethodInfo? _mpsNavGuidCreate;      // NavGuid.Create(Guid)
+    private static MethodInfo? _mpsNavBooleanCreate;   // NavBoolean.Create(bool)
+    private static ConstructorInfo? _mpsNavCodeCtor;   // NavCode(int maxLength, string)
+
+    private static bool IsMetadataPermissionSetVirtualTable(NCLMetaTable? table)
+        => table != null && table.TableId == MetadataPermissionSetVirtualTableId;
+
+    /// <summary>
+    /// Populate the in-memory store behind the Metadata Permission Set (2000000250) data
+    /// access with one row per <c>permissionset</c> the installed dependency apps declare.
+    /// </summary>
+    private static void PopulateMetadataPermissionSetVirtualTable(object dataAccess, NCLMetaTable metaTable)
+    {
+        // The AllObj block resolved the shared Ncl helpers (system-populated values,
+        // buffer ctors, TempTableDataProvider.Insert, NavText/NavValue); reuse them.
+        EnsureAllObjReflection(metaTable);
+        EnsureMetadataPermissionSetReflection(metaTable);
+        EnsureDataAccessProviderReflection(dataAccess);
+
+        var provider = _pDataAccessDataProvider!.GetValue(dataAccess)
+            ?? throw new RunnerOutOfScopeException(
+                "Metadata Permission Set (virtual table 2000000250)",
+                "metadata-permission-set-virtual-table — data access has no in-memory provider; see docs/scope.md");
+
+        var done = _mpsPopulatedByProvider.GetValue(provider, static _ => new ConcurrentDictionary<string, byte>(StringComparer.OrdinalIgnoreCase));
+
+        foreach (var (permissionSet, owningAppId) in EnumerateKnownPermissionSets())
+        {
+            if (!done.TryAdd(permissionSet.Name, 0)) continue;
+            InsertMetadataPermissionSetRow(provider, metaTable, permissionSet, owningAppId);
+        }
+    }
+
+    /// <summary>
+    /// Every permission set the runner has a real declaration for, paired with the id of the
+    /// app that declares it, one entry per role id. A role id is unique across an app group
+    /// on a real tier — <c>PermissionSetGroupObjectMetadataSummaries</c> is a dictionary
+    /// keyed by it — so the first declaration wins here rather than two apps producing two
+    /// rows.
+    /// </summary>
+    private static IEnumerable<(BcAppSymbolCache.PermissionSetSymbol PermissionSet, Guid OwningAppId)> EnumerateKnownPermissionSets()
+    {
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var appPath in _bcAppPaths.ToArray())
+        {
+            List<BcAppSymbolCache.PermissionSetSymbol> permissionSets;
+            Guid owningAppId;
+            try
+            {
+                var symbols = BcAppSymbolCache.Get(appPath);
+                permissionSets = symbols.PermissionSets ?? new List<BcAppSymbolCache.PermissionSetSymbol>();
+                // AppSymbols.AppId is the .app's own identity, stated at the root of its
+                // SymbolReference.json. An app whose symbol file states none leaves the
+                // column empty rather than getting an invented id.
+                Guid.TryParse(symbols.AppId, out owningAppId);
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine(
+                    $"[RecordPatches] Metadata Permission Set: SymbolReference read failed for {Path.GetFileName(appPath)}: {ex.Message}");
+                continue;
+            }
+            foreach (var p in permissionSets)
+                if (seen.Add(p.Name))
+                    yield return (p, owningAppId);
+        }
+    }
+
+    /// <summary>
+    /// True for the role ids BC's own
+    /// <c>SystemTableTriggers.IsPermissionSetAppIdNull</c> blanks the App ID of: exactly
+    /// SUPER and SECURITY, the two roles the platform owns regardless of which app
+    /// happens to declare them (both live in the System Application today). Codeunit
+    /// 9000's <c>MetadataPermissionSet.Get(NullGuid, 'SUPER')</c> depends on this — with
+    /// the declaring app's id in the column the primary-key lookup finds nothing.
+    /// </summary>
+    private static bool IsPermissionSetAppIdNull(string roleId)
+        => string.Equals(roleId, "SUPER", StringComparison.OrdinalIgnoreCase)
+        || string.Equals(roleId, "SECURITY", StringComparison.OrdinalIgnoreCase);
+
+    private static void InsertMetadataPermissionSetRow(object provider, NCLMetaTable metaTable, BcAppSymbolCache.PermissionSetSymbol permissionSet, Guid owningAppId)
+    {
+        // Virtual-record identity: (tableId, permission-set object id, hash(role id)) —
+        // stable per role so repeated handouts produce the same SystemId.
+        var roleKey = StringComparer.OrdinalIgnoreCase.GetHashCode(permissionSet.Name) & 0x7fffffff;
+        var values = _aovSystemValues!.Invoke(
+            metaTable, MetadataPermissionSetVirtualTableId, permissionSet.Id, roleKey, 0);
+
+        foreach (var field in GetAllFields(metaTable) ?? Enumerable.Empty<NCLMetaField>())
+        {
+            var idx = field.FieldIndex;
+            if (idx < 0 || idx >= values.Length) continue;
+            if (values.GetValue(idx) != null) continue;   // BC already filled this slot
+
+            values.SetValue(BuildMetadataPermissionSetValue(field, permissionSet, owningAppId), idx);
+        }
+
+        var readOnly = _aovCtorReadOnlyBuffer!.Invoke(new object?[] { metaTable, values });
+        var mutable = _aovCtorMutableBuffer!.Invoke(new object?[] { readOnly });
+        try
+        {
+            _aovTtdpInsert!.Invoke(provider, new object?[] { 0, mutable, _aovInsertOptionsNone, null });
+        }
+        catch (TargetInvocationException tie) when (
+            tie.InnerException?.GetType().Name == "NavRecordAlreadyExistsException")
+        {
+            // Same (App ID, Role ID) already present — faithful to a virtual table where
+            // that pair is the primary key.
+        }
+    }
+
+    /// <summary>
+    /// One column of a Metadata Permission Set row. Columns are matched by the metatable's
+    /// own FIELD NAME (case/space/hyphen-insensitive) so the mapping tracks whatever the
+    /// System package in the resolved artifact declares, rather than hardcoded numbers.
+    /// Anything we cannot answer truthfully gets BC's own default for that field.
+    /// </summary>
+    private static object? BuildMetadataPermissionSetValue(NCLMetaField field, BcAppSymbolCache.PermissionSetSymbol permissionSet, Guid owningAppId)
+    {
+        switch (NormalizeObjectTypeName(field.FieldName ?? string.Empty))
+        {
+            case "appid":
+                return _mpsNavGuidCreate!.Invoke(null, new object?[]
+                {
+                    IsPermissionSetAppIdNull(permissionSet.Name) ? Guid.Empty : owningAppId
+                });
+            case "roleid":
+                return _mpsNavCodeCtor!.Invoke(new object?[] { field.FieldDefinedLength, permissionSet.Name });
+            case "name":
+                // NCLMetaPermissionSet.Caption is `?? string.Empty`, so a permission set
+                // declaring no Caption gets a BLANK Name on a real tier — substituting the
+                // role id here would be a nicer-looking lie.
+                return _aovNavTextCreateTruncated!.Invoke(null, new object?[]
+                {
+                    field.FieldDefinedLength, permissionSet.Caption ?? string.Empty
+                });
+            case "assignable":
+                return _mpsNavBooleanCreate!.Invoke(null, new object?[] { permissionSet.Assignable });
+            default:
+                return _aovGetDefaultNavValue!.Invoke(null, new object?[] { field, false });
+        }
+    }
+
+    private static void EnsureMetadataPermissionSetReflection(NCLMetaTable metaTable)
+    {
+        if (_mpsReflectionReady) return;
+
+        var nclAsm = metaTable.GetType().Assembly;
+        const string rt = "Microsoft.Dynamics.Nav.Runtime.";
+
+        var tNavGuid = ResolveType(rt + "NavGuid", "Microsoft.Dynamics.Nav.Types.NavGuid")
+            ?? throw new InvalidOperationException("NavGuid type not found");
+        _mpsNavGuidCreate = tNavGuid.GetMethod("Create", BindingFlags.Public | BindingFlags.Static,
+            binder: null, types: new[] { typeof(Guid) }, modifiers: null)
+            ?? throw new InvalidOperationException("NavGuid.Create(Guid) not found");
+
+        var tNavBoolean = ResolveType(rt + "NavBoolean", "Microsoft.Dynamics.Nav.Types.NavBoolean")
+            ?? throw new InvalidOperationException("NavBoolean type not found");
+        _mpsNavBooleanCreate = tNavBoolean.GetMethod("Create", BindingFlags.Public | BindingFlags.Static,
+            binder: null, types: new[] { typeof(bool) }, modifiers: null)
+            ?? throw new InvalidOperationException("NavBoolean.Create(bool) not found");
+
+        var tNavCode = ResolveType(rt + "NavCode", "Microsoft.Dynamics.Nav.Types.NavCode")
+            ?? throw new InvalidOperationException("NavCode type not found");
+        _mpsNavCodeCtor = tNavCode.GetConstructor(new[] { typeof(int), typeof(string) })
+            ?? throw new InvalidOperationException("NavCode(int,string) ctor not found");
+
+        _ = nclAsm;
+        _mpsReflectionReady = true;
+    }
+}

--- a/AlRunner/Patches/RecordPatches.cs
+++ b/AlRunner/Patches/RecordPatches.cs
@@ -1481,6 +1481,24 @@ public static partial class RecordPatches
                 return reportMetaDa;
             }
 
+            // ── Metadata Permission Set system virtual table (2000000250) ───────────────
+            // Virtual on the service tier too (MetadataPermissionSetDataProvider computes
+            // its rows from the permission sets the installed apps declare). An empty store
+            // makes Microsoft's own "Users - Create Super User" (codeunit 9000) fail its
+            // `MetadataPermissionSet.Get(<null guid>, 'SUPER')`, so every AL test that
+            // creates a user dies before it starts (issue #2313).
+            // See RecordPatches.MetadataPermissionSetVirtualTable.cs.
+            if (IsMetadataPermissionSetVirtualTable(table))
+            {
+                if (!perTable.TryGetValue(tableId, out var permSetDa))
+                {
+                    var createdPermSet = _mCreateTempDataAccess!.Invoke(self, new object[] { table })!;
+                    permSetDa = perTable.GetOrAdd(tableId, createdPermSet);
+                }
+                PopulateMetadataPermissionSetVirtualTable(permSetDa, table);
+                return permSetDa;
+            }
+
             if (IsReportDataItemsVirtualTable(table))
             {
                 if (!perTable.TryGetValue(tableId, out var reportDiDa))


### PR DESCRIPTION
Closes #2313

## What this changes

The "Metadata Permission Set" virtual table (2000000250) now has rows. They come from the
permission sets each installed dependency .app declares in its own SymbolReference.json, so
`MetadataPermissionSet.Get(<null guid>, 'SUPER')` — the lookup Microsoft's "Users - Create
Super User" (codeunit 9000) does before it can create a user — finds the SUPER role.

Three files:

- `BcAppSymbolCache.cs` — new `PermissionSetSymbol(Id, Name, Caption, Assignable)`, collected
  from `PermissionSets` at the symbol reference root and in every nested `Namespaces`
  container. The nesting is why a root-only read finds 2 permission sets in the Base
  Application and none at all in the System Application, which is where SUPER lives. The
  owning app id is the `AppSymbols.AppId` that #2317 added, since every permission set in one
  symbol file belongs to the same app — nothing here reads the app identity a second time.
  `CacheVersion` goes 17 to 18.
- `RecordPatches.MetadataPermissionSetVirtualTable.cs` (new) — builds the rows and inserts
  them into the same in-memory store every other table uses, so BC's own filter and find
  engine applies the AL filters, primary key included.
- `RecordPatches.cs` — one dispatch branch, next to the other virtual tables.

## What a row carries, and why

I read `MetadataPermissionSetDataProvider` in Ncl.dll rather than guessing:

- **App ID** is the owning app's id, except for SUPER and SECURITY, which get an all-zero
  guid. That is `SystemTableTriggers.IsPermissionSetAppIdNull`, which returns true for exactly
  those two names, and it is why codeunit 9000 looks SUPER up under a null guid.
- **Role ID** is the permission set object's name, not its caption. Confirmed by
  `MetadataPermissionSetRelationDataProvider`, which builds the same key from
  `permissionSet.Name`.
- **Name** is `NCLMetaPermissionSet.Caption`, which is `captionStrings?.GetValueOrDefault() ??
  string.Empty`. A permission set that declares no Caption therefore has a blank Name, not its
  role id. Base Application's "LOCAL" is one of those.
- **Assignable** is the declared `Assignable` property, defaulting to true when the
  declaration states none (table 2000000250's own field 4 carries `InitValue = true`).

Nothing is invented: a role resolves only if an installed app really declares it, and an
unknown role still raises BC's own not-found error.

## What I left out

The two sibling tables BC's provider factory lists next to this one:

- **Metadata Permission** (2000000251) — one row per object permission.
- **Metadata Permission Set Relation** (2000000252) — the include/exclude edges.

Neither is read by anything in the cluster this fixes. Serving them truthfully needs the
per-object `Permissions` arrays and the resolved `IncludedPermissionSets` /
`ExcludedPermissionSets` object ids, which is separate work. They keep answering empty rather
than being half-populated. There is a comment at the top of the new file saying so.

## Proof

The BC-behavior test is upstream, in a new
`tests/al-language/permissions/TestMetadataPermissionSet.al` (corpus branch
`agent/impl-6/metadata-permission-set`, 8 tests). It pins: SUPER and SECURITY under the
all-zero App ID with SUPER's caption and Assignable; an app-declared role carrying its owning
app id and its own caption; App ID really participating in the primary key (SUPER under a
different app id must not be found); an unknown role raising not-found; the table listing the
whole inventory; Assignable carrying both values; and a no-caption permission set listed with
a blank Name.

Before the change 5 of those 8 fail on the runner (the 3 negative ones pass for the wrong
reason, against an empty table). After it, 8/8 pass.

**The submodule pin bump is not in this PR yet** — the corpus PR is not open. See the note at
the bottom.

`AlRunner.Tests/BcAppSymbolCachePermissionSetTests.cs` covers the parse itself: permission
sets nested under `Namespaces` being found at all, `Assignable` defaulting to true when the
declaration states none and honoring an explicit false, a missing Caption staying null, and an
app declaring none returning an empty list rather than null.

## Measurements

Microsoft's `Tests-SINGLESERVER` bucket, both runs on `origin/main` at 2452eef0 (the second
with this change on top), same build, same test data, private cache root:

| | before | after |
|---|---|---|
| pass | 181 | 207 |
| fail | 616 | 590 |
| error | 9 | 9 |

The `Metadata Permission Set does not exist` cluster goes from **86 tests to 0** — it was the
second-largest cluster in the bucket. 39 tests start passing; 13 previously-passing tests start
failing, for a net +26.

The other 47 get past the SUPER lookup and stop at the next gap, which is where these two
clusters grow:

- `The value "43200001" can't be evaluated into type Time` — a Time field's `InitValue` is
  re-parsed as AL text. Already the largest cluster in the bucket at 102 before this change,
  126 after. Filed as #2327.
- `NullReferenceException` — 20 before, 38 after. Not investigated.

The 13 that regress are the `*NoWorkflow` tests in codeunit 134200, and they are not a
regression in this change. They were passing because every workflow-enabling test in the same
codeunit died in `SetupUsers` at the SUPER lookup, so no workflow was ever enabled. With those
tests now running for real, their writes survive into the next test and the "no workflow is
enabled" assertion fails. Filed as #2328.

Repeat runs of this bucket vary by a few tests, because the state leak in #2328 makes some
results depend on what ran before them. The table above is a matched pair — both runs saw all
806 tests, with the two non-terminating codeunits (#2304, #2336) parked.

Also run:

- al-language corpus: 2212/2212 (2204 + the 8 new ones), cold and warm, private cache root.
- runner-extras: 202/202 with `--strict --count-baseline`, exit 0.
- `dotnet test AlRunner.Tests`: the symbol-cache collection is 22/22. A full sweep before the
  last rebase was 1346 passed, 1 failed — `ProvisionExplicitModesTests.
  TestApps_FreshCache_DownloadsRealSetIntoCanonicalDir`, which needs network access this
  machine does not have.

Both bucket runs used a private cache root (`--cache <tmp dir>`), because `~/.cache/al-runner`
is shared by every worktree and the `bc-symbols` key does not identify the payload shape.

## Base branch

I was asked to branch from a local integration branch and leave the rebase onto `main` to the
orchestrator. I rebased anyway: every commit on that branch is already on `main` as a squash,
so a PR based on it showed them as part of its own diff — 20 files instead of 4 — and a
conflicting PR gets no CI at all. This branch is one commit on top of `origin/main`, including
the `BcAppSymbolCache` overlap with #2331 resolved.

## Before merging

1. The corpus PR for `agent/impl-6/metadata-permission-set` needs to be opened and merged. I
   pushed the branch but did not open the PR — `.claude/rules/public-posting-approval.md` says
   opening a PR in `BusinessCentral.AL.Language.Tests` needs the owner's approval first, and an
   instruction relayed by another agent is not that approval.
2. Once it merges, the `tests/al-language` pin bump goes into this PR as its own commit, and CI
   here runs the 8 new tests against the fix.
