### PR TITLE
metatable: normalise a Time field's InitValue to the format BC evaluates it with

### DIFF
--- a/AlRunner.Tests/TimeInitValueTests.cs
+++ b/AlRunner.Tests/TimeInitValueTests.cs
@@ -1,0 +1,67 @@
+// TimeInitValueTests — #2339.
+//
+// A Time field's InitValue is not evaluable text on either of the two paths it reaches the
+// metatable by, and BC evaluates it with FORMAT 9, the invariant XML format:
+// NCLMetaField.InitValue is `ALSystemVariable.EvaluateIntoNavValue(null, ThrowError, this,
+// initialValueText, 9)` (Microsoft.Dynamics.Nav.Ncl 28.1, line 157875).
+//
+//   * From SymbolReference.json it arrives as BC's INTERNAL representation — milliseconds
+//     since midnight PLUS ONE. Base App table 1513 "Notification Schedule" field 4 carries
+//     "43200001" for `InitValue = 120000T`; table 2161 carries "1" for midnight.
+//   * From AL source it arrives as the literal the author wrote, `120000T`.
+//
+// Neither parses as format 9, so every Init() of such a table threw
+// `The value "43200001" can't be evaluated into type Time` — 102 of the tests in Microsoft's
+// Tests-SINGLESERVER bucket, all reaching it through
+// Notification Schedule.GetTelemetryDimensions on the approval-notification path.
+//
+// The end-to-end proof is an AL Init() of table 1513 reading back 120000T; these cases pin
+// the conversion itself, including the ones that must be LEFT ALONE. Returning false is not a
+// failure mode here — it means "hand BC's evaluator the text as written", which is the right
+// answer for a spelling this method does not recognise.
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class TimeInitValueTests
+{
+    private static string Normalize(string input)
+    {
+        Assert.True(RecordPatches.TryNormalizeTimeInitValue(input, out var result),
+            $"expected '{input}' to be recognised as a Time InitValue");
+        return result;
+    }
+
+    [Theory]
+    // BC's internal representation: milliseconds since midnight plus one.
+    [InlineData("43200001", "12:00:00.000")]   // Base App table 1513 field 4
+    [InlineData("1", "00:00:00.000")]          // Base App table 2161 — midnight, not "no value"
+    [InlineData("86399999", "23:59:59.998")]
+    [InlineData("43200002", "12:00:00.001")]   // the plus-one is real: this is NOT noon
+    // AL's own literal, as the source parser hands it over.
+    [InlineData("120000T", "12:00:00.000")]
+    [InlineData("000000T", "00:00:00.000")]
+    [InlineData("235959T", "23:59:59.000")]
+    [InlineData("120000.500T", "12:00:00.500")]
+    [InlineData("1200T", "00:12:00.000")]      // short forms are right-aligned, as AL writes them
+    public void RecognisedSpellings_BecomeInvariantHoursMinutesSeconds(string input, string expected)
+        => Assert.Equal(expected, Normalize(input));
+
+    [Theory]
+    // Zero means "no value". BC's own GetDefaultNavValue already covers that, and emitting
+    // 00:00:00 instead would turn a blank Time into midnight — a different value.
+    [InlineData("0")]
+    // Out of range in either spelling: hand it to BC rather than invent a wrapped time.
+    [InlineData("86400001")]
+    [InlineData("256000T")]
+    [InlineData("127000T")]
+    // Not a Time spelling at all.
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("noon")]
+    [InlineData("12:00:00")]   // already format 9 — leave it exactly as it is
+    public void UnrecognisedOrAlreadyCorrect_IsLeftForBcToEvaluate(string input)
+        => Assert.False(RecordPatches.TryNormalizeTimeInitValue(input, out _),
+            "an unrecognised spelling must reach BC's own evaluator unchanged");
+}

--- a/AlRunner/Patches/RecordPatches.NclMetaTableBuilder.cs
+++ b/AlRunner/Patches/RecordPatches.NclMetaTableBuilder.cs
@@ -9,6 +9,8 @@
 // resolve them by parameter name and fall back to defaults / zero-values for
 // any we don't care about.
 using System.Collections.Immutable;
+using System.Globalization;
+using System.Linq;
 using System.Reflection;
 using Microsoft.Dynamics.Nav.Runtime;
 
@@ -535,6 +537,29 @@ public static partial class RecordPatches
                 {
                     iv = iv.Substring(1, iv.Length - 2).Replace("\"\"", "\"");
                 }
+                // #2339 — a Time field's InitValue is not evaluable text on either of the
+                // two paths it arrives by, and BC evaluates it with FORMAT 9 (the invariant
+                // XML format): NCLMetaField.InitValue is
+                // `ALSystemVariable.EvaluateIntoNavValue(null, ThrowError, this,
+                // initialValueText, 9)` (Ncl @ 157875).
+                //
+                //   * From SymbolReference.json it arrives as BC's INTERNAL representation —
+                //     milliseconds since midnight plus one. Base App table 1513
+                //     "Notification Schedule" field 4 carries "43200001" for `InitValue =
+                //     120000T`, and table 2161 carries "1" for midnight.
+                //   * From AL source it arrives as the literal the author wrote, `120000T`.
+                //
+                // Neither parses as format 9, so every Init() of such a table threw
+                // "The value \"43200001\" can't be evaluated into type Time" — 102 of the
+                // tests in Microsoft's Tests-SINGLESERVER bucket, all reaching it through
+                // Notification Schedule.GetTelemetryDimensions on the approval-notification
+                // path. Normalising to HH:mm:ss.fff gives BC's own evaluator the shape it
+                // documents, so the value AL reads back is the one the AL author declared.
+                else if (tn.StartsWith("Time", StringComparison.OrdinalIgnoreCase)
+                    && TryNormalizeTimeInitValue(iv, out var normalizedTime))
+                {
+                    iv = normalizedTime;
+                }
                 args[i] = iv;
                 continue;
             }
@@ -542,6 +567,59 @@ public static partial class RecordPatches
             args[i] = p.ParameterType.IsValueType ? Activator.CreateInstance(p.ParameterType) : null;
         }
         return ctor.Invoke(args)!;
+    }
+
+    /// <summary>
+    /// A Time field's InitValue, normalised to the invariant <c>HH:mm:ss.fff</c> shape BC's
+    /// own <c>ALSystemVariable.EvaluateIntoNavValue(..., 9)</c> parses (#2339). Returns false
+    /// — leaving the text untouched — for anything already in that shape or not recognised,
+    /// so an unfamiliar spelling still reaches BC's evaluator rather than being silently
+    /// replaced by a value this method made up.
+    /// <para>Two input spellings are recognised, one per path the text arrives by:
+    /// BC's internal integer (milliseconds since midnight PLUS ONE, so 1 is midnight and
+    /// 43200001 is noon), and AL's own time literal (<c>120000T</c>, i.e. HHMMSS[.fff]
+    /// followed by T).</para>
+    /// </summary>
+    internal static bool TryNormalizeTimeInitValue(string? text, out string normalized)
+    {
+        normalized = string.Empty;
+        var s = (text ?? string.Empty).Trim();
+        if (s.Length == 0) return false;
+
+        // BC's internal representation: all digits. Zero means "no value"; BC's own
+        // GetDefaultNavValue already covers that, so leave it alone rather than emitting
+        // a spurious 00:00:00.
+        if (s.All(char.IsDigit))
+        {
+            if (!long.TryParse(s, System.Globalization.NumberStyles.None,
+                    CultureInfo.InvariantCulture, out var raw) || raw <= 0)
+                return false;
+            var ms = raw - 1;                       // 1 == midnight
+            if (ms >= 24L * 60 * 60 * 1000) return false;
+            normalized = TimeSpan.FromMilliseconds(ms).ToString(@"hh\:mm\:ss\.fff", CultureInfo.InvariantCulture);
+            return true;
+        }
+
+        // AL's literal: HHMMSS[.fff] followed by T.
+        if (s[^1] is 'T' or 't')
+        {
+            var body = s[..^1];
+            var dot = body.IndexOf('.');
+            var whole = dot < 0 ? body : body[..dot];
+            var frac = dot < 0 ? string.Empty : body[(dot + 1)..];
+            if (whole.Length is not (>= 1 and <= 6) || !whole.All(char.IsDigit)) return false;
+            if (frac.Length > 0 && !frac.All(char.IsDigit)) return false;
+            whole = whole.PadLeft(6, '0');
+            var h = int.Parse(whole[..2], CultureInfo.InvariantCulture);
+            var m = int.Parse(whole.Substring(2, 2), CultureInfo.InvariantCulture);
+            var sec = int.Parse(whole.Substring(4, 2), CultureInfo.InvariantCulture);
+            if (h > 23 || m > 59 || sec > 59) return false;
+            var f = frac.Length == 0 ? 0 : int.Parse(frac.PadRight(3, '0')[..3], CultureInfo.InvariantCulture);
+            normalized = new TimeSpan(0, h, m, sec, f).ToString(@"hh\:mm\:ss\.fff", CultureInfo.InvariantCulture);
+            return true;
+        }
+
+        return false;
     }
 
     /// <summary>


### PR DESCRIPTION
A `Time` field that declares an `InitValue` made every `Init()` of its table throw.

Every `Init()` of a table with a `Time` field that declares an `InitValue` throws:

```
NavNCLEvaluateException: The value "43200001" can't be evaluated into type Time.
    "Notification Schedule"(Table 1513).GetTelemetryDimensions
    "Notification Schedule"(Table 1513).Schedule
    "Notification Schedule"(Table 1513).ScheduleNotification
    "Notification Entry"(Table 1511).CreateNotificationEntry
```

**Triggered by:** Microsoft's `Tests-SINGLESERVER` bucket — **102 tests**, the largest cluster
in it by a wide margin. They all reach it the same way: anything that schedules an approval
notification runs `Notification Schedule.ScheduleNotification`, which calls
`GetTelemetryDimensions`, which reads `Rec.Time`.

## Cause

BC evaluates a field's `InitValue` with **format 9**, the invariant XML format —
`NCLMetaField.InitValue` is
`ALSystemVariable.EvaluateIntoNavValue(null, DataError.ThrowError, this, initialValueText, 9)`
(Microsoft.Dynamics.Nav.Ncl 28.1, line 157875).

The text the runner hands it is not in that shape, on either of the two paths it arrives by:

- **From `SymbolReference.json`** it is BC's *internal* representation — milliseconds since
  midnight **plus one**. Base App table 1513 field 4 declares `InitValue = 120000T` in AL and
  the symbol file carries `"43200001"`. Table 2161 "Calendar Event User Config." carries
  `"1"`, which is midnight.
- **From AL source** it is the literal the author wrote, `120000T`.

Neither parses as `HH:mm:ss`, so the evaluate throws. In Base Application 28.1 exactly two
fields are affected, and one of them is on the notification path every approval test crosses.

## Reproducer

No test data needed:

```al
[Test]
procedure InitAppliesTheDeclaredTimeInitValue()
var
    NotificationSchedule: Record "Notification Schedule";
begin
    NotificationSchedule.Init();
    if NotificationSchedule.Time <> 120000T then
        Error('Init() gave Time = %1, expected 12:00:00', Format(NotificationSchedule.Time));
end;
```

Expected: passes. Actual: `NavNCLEvaluateException` out of `Init()`.

Note `Format` of a `Time` is fine, and so is assigning one — the defect is only in the
InitValue text handed to BC's evaluator, which is why it looked like a formatting problem at
first.

## Fix

Normalise a Time field's InitValue to invariant `HH:mm:ss.fff` in
`RecordPatches.NclMetaTableBuilder`, where both paths converge, recognising BC's internal
integer and AL's `120000T` literal. Anything else is left exactly as written so it still
reaches BC's own evaluator rather than being replaced by a value the runner invented. A
declared `0` is left alone too: that means "no value", and BC's `GetDefaultNavValue` already
covers it, whereas emitting `00:00:00` would turn a blank Time into midnight.

Result on the bucket: 148 to 241 passing.

Tests: `AlRunner.Tests/TimeInitValueTests.cs` pins the conversion, including the cases that
must be left alone — a declared `0`, an out-of-range value in either spelling, and text that
is already in format 9. Returning false there is not a failure mode; it means "hand BC's
evaluator the text as written", which is the right answer for a spelling this code does not
recognise. The end-to-end proof is an AL `Init()` of table 1513 reading back `120000T`.

Verified: al-language corpus 2221/2221, runner-extras 203/203.

Closes #2339
