### PR TITLE
fix(testpage): resolve a dependency-declared page's SourceTable instead of refusing

### DIFF
--- a/AlRunner.Tests/DependencyPageShapeResolutionTests.cs
+++ b/AlRunner.Tests/DependencyPageShapeResolutionTests.cs
@@ -1,0 +1,162 @@
+// DependencyPageShapeResolutionTests — pins the runner's own C# predicates behind issue #2341:
+// RecordPatches.IsPageShapeKnown and RecordPatches.ResolvePageDeclaresSourceTableForAnyPage
+// (AlRunner/Patches/RecordPatches.DependencyPageMetadata.cs).
+//
+// What this proves, and what it deliberately does NOT
+// -----------------------------------------------------
+// The BC-observable claim — that a TestPage over a page which happens to ship precompiled
+// resolves its SourceTable and positions by primary key — is plain BC behaviour and is
+// adjudicated upstream by the al-language corpus against a real service tier (see
+// .claude/rules/bc-behavior-tests-go-upstream.md). This file pins the narrower runner-only
+// mechanism underneath it, and it is exactly where #2341 lived: the runner already held the
+// answer in BcAppSymbolCache and asked a predicate that could not see it.
+//
+// The negative rows are the load-bearing ones. IsPageShapeKnown answering a blanket true
+// would re-open the hole the refusal exists to plug — NavTestPageBase_GetMetaTable would then
+// hand back a null NCLMetaTable for a page nobody declared, and PrimaryKeyFields would read
+// as empty instead of failing. Likewise ResolvePageDeclaresSourceTableForAnyPage must
+// distinguish "the dependency says this page declares none" (false, and BC's own body
+// returns null for it) from "no dependency mentions this page at all".
+
+using System.IO.Compression;
+using System.Text;
+using AlRunner.Patches;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+// Same reason as DependencyPageMetadataXmlTests: BcAppSymbolCache.Get() resolves through the
+// process-global CacheRoots override.
+[Collection(CacheRootsSerialCollection.Name)]
+public class DependencyPageShapeResolutionTests
+{
+    private static string WriteApp(string dir, string symbolReferenceJson)
+    {
+        var appPath = Path.Combine(dir, Guid.NewGuid().ToString("N") + ".app");
+        using var zip = new FileStream(appPath, FileMode.Create);
+        using var za = new ZipArchive(zip, ZipArchiveMode.Create);
+        var entry = za.CreateEntry("SymbolReference.json");
+        using var w = new StreamWriter(entry.Open(), Encoding.UTF8);
+        w.Write(symbolReferenceJson);
+        return appPath;
+    }
+
+    // Distinctive ids for the same reason DependencyPageMetadataXmlTests picks its own:
+    // RecordPatches' dependency-page state is process-global, so an id another test or a real
+    // Base Application fixture might also declare could answer from someone else's payload.
+    private const int WithSourceTablePageId = 88123421;
+    private const int NoSourceTablePageId = 88123422;
+    private const int UndeclaredPageId = 88123429;
+
+    // 2000000120 is table "User" — the real SourceTable of Base Application page 9807
+    // "User Card", the page issue #2341 was reported against.
+    private const string SymbolReference = """
+        {
+          "RuntimeVersion": "15.1",
+          "Pages": [
+            {
+              "Id": 88123421,
+              "Name": "DPS Card With Source",
+              "Properties": [
+                { "Name": "PageType", "Value": "Card" },
+                { "Name": "SourceTable", "Value": "2000000120" }
+              ]
+            },
+            {
+              "Id": 88123422,
+              "Name": "DPS Dialog No Source",
+              "Properties": [
+                { "Name": "PageType", "Value": "StandardDialog" }
+              ]
+            }
+          ]
+        }
+        """;
+
+    private static void WithLoadedDependency(Action body)
+    {
+        var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            RecordPatches.AddBcAppPath(WriteApp(dir, SymbolReference));
+            body();
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    // THE REGRESSION ROW. Before #2341 the only "do we know this page?" predicate on the
+    // TestPage path was IsPageParsed, which is false for every page the runner did not
+    // AL-source-compile — so NavTestPageBase_GetMetaTable refused outright.
+    [Fact]
+    public void IsPageShapeKnown_PageDeclaredOnlyByADependencyApp_IsKnown()
+        => WithLoadedDependency(() =>
+        {
+            Assert.False(RecordPatches.IsPageParsed(WithSourceTablePageId),
+                "the fixture page must NOT be AL-source-parsed, or this proves nothing");
+            Assert.True(RecordPatches.IsPageShapeKnown(WithSourceTablePageId));
+            Assert.True(RecordPatches.IsPageShapeKnown(NoSourceTablePageId),
+                "a dependency page is known even when it declares no SourceTable");
+        });
+
+    // The negative direction: a blanket true here would let GetMetaTable answer a null
+    // NCLMetaTable for a page nobody declares, which is the silently-empty primary key the
+    // refusal exists to prevent.
+    [Fact]
+    public void IsPageShapeKnown_PageNoLoadedAppDeclares_IsNotKnown()
+        => WithLoadedDependency(() =>
+            Assert.False(RecordPatches.IsPageShapeKnown(UndeclaredPageId)));
+
+    // The value the whole cluster turned on: 2000000120, read verbatim out of the dependency's
+    // own SymbolReference.json. A resolver that answered a default 0 fails here.
+    [Fact]
+    public void ResolveSourceTableIdForAnyPage_DependencyPage_AnswersTheDeclaredTableId()
+        => WithLoadedDependency(() =>
+        {
+            Assert.Equal(2000000120, RecordPatches.ResolveSourceTableIdForAnyPage(WithSourceTablePageId));
+            Assert.True(RecordPatches.ResolvePageDeclaresSourceTableForAnyPage(WithSourceTablePageId));
+        });
+
+    // "The dependency says this page declares none" must be distinguishable from "no
+    // dependency mentions this page" — the first returns a null NCLMetaTable (BC's own
+    // behaviour for SourceTable == 0), the second still throws.
+    [Fact]
+    public void ResolvePageDeclaresSourceTableForAnyPage_SeparatesDeclaresNoneFromUnknown()
+        => WithLoadedDependency(() =>
+        {
+            Assert.False(RecordPatches.ResolvePageDeclaresSourceTableForAnyPage(NoSourceTablePageId));
+            Assert.True(RecordPatches.IsPageShapeKnown(NoSourceTablePageId));
+
+            Assert.False(RecordPatches.ResolvePageDeclaresSourceTableForAnyPage(UndeclaredPageId));
+            Assert.False(RecordPatches.IsPageShapeKnown(UndeclaredPageId));
+        });
+
+    // The classification the two widened call sites feed: a dependency page with no
+    // SourceTable is driven record-less, not demoted to the navigation mock. 167 Base
+    // Application pages and 35 System Application pages have this shape on 28.1.
+    [Fact]
+    public void ConstructionRule_DependencyPageWithoutSourceTable_IsDrivenRecordless()
+        => WithLoadedDependency(() =>
+            Assert.Equal(
+                TestPageClientKind.LiveRecordless,
+                TestPageClientConstructionRule.Resolve(
+                    recordBuilt: false,
+                    pageShapeKnown: RecordPatches.IsPageShapeKnown(NoSourceTablePageId),
+                    pageDeclaresSourceTable:
+                        RecordPatches.ResolvePageDeclaresSourceTableForAnyPage(NoSourceTablePageId))));
+
+    // …and a page neither source declares still gets the mock, computed the same way.
+    [Fact]
+    public void ConstructionRule_UndeclaredPage_StaysOnTheNavigationMock()
+        => WithLoadedDependency(() =>
+            Assert.Equal(
+                TestPageClientKind.NavigationMock,
+                TestPageClientConstructionRule.Resolve(
+                    recordBuilt: false,
+                    pageShapeKnown: RecordPatches.IsPageShapeKnown(UndeclaredPageId),
+                    pageDeclaresSourceTable:
+                        RecordPatches.ResolvePageDeclaresSourceTableForAnyPage(UndeclaredPageId))));
+}

--- a/AlRunner.Tests/TestPageClientConstructionRuleTests.cs
+++ b/AlRunner.Tests/TestPageClientConstructionRuleTests.cs
@@ -26,10 +26,10 @@ public sealed class TestPageClientConstructionRuleTests
     [InlineData(true, true)]
     [InlineData(true, false)]
     [InlineData(false, false)]
-    public void RecordBuilt_AlwaysDrivesOverTheRecord(bool pageIsParsed, bool declaresSourceTable)
+    public void RecordBuilt_AlwaysDrivesOverTheRecord(bool pageShapeKnown, bool declaresSourceTable)
         => Assert.Equal(TestPageClientKind.LiveOverRecord,
             TestPageClientConstructionRule.Resolve(
-                recordBuilt: true, pageIsParsed, pageDeclaresSourceTable: declaresSourceTable));
+                recordBuilt: true, pageShapeKnown, pageDeclaresSourceTable: declaresSourceTable));
 
     // THE REGRESSION ROW. A parsed page that declares no SourceTable has no record to build
     // and needs none — it is driven live over a null record. This resolved to
@@ -38,7 +38,7 @@ public sealed class TestPageClientConstructionRuleTests
     public void NoRecord_ParsedPageWithoutSourceTable_IsDrivenRecordless()
         => Assert.Equal(TestPageClientKind.LiveRecordless,
             TestPageClientConstructionRule.Resolve(
-                recordBuilt: false, pageIsParsed: true, pageDeclaresSourceTable: false));
+                recordBuilt: false, pageShapeKnown: true, pageDeclaresSourceTable: false));
 
     // A page that DOES declare a source table but whose record could not be built is a runner
     // gap — a missing runtime record type. Driving it record-less would report "no rows" for a
@@ -47,15 +47,15 @@ public sealed class TestPageClientConstructionRuleTests
     public void NoRecord_ParsedPageWithASourceTable_StaysOnTheNavigationMock()
         => Assert.Equal(TestPageClientKind.NavigationMock,
             TestPageClientConstructionRule.Resolve(
-                recordBuilt: false, pageIsParsed: true, pageDeclaresSourceTable: true));
+                recordBuilt: false, pageShapeKnown: true, pageDeclaresSourceTable: true));
 
-    // A page the parser never saw: "declares no SourceTable" is then a fact about the runner's
+    // A page NEITHER source knows: "declares no SourceTable" is then a fact about the runner's
     // ignorance, not about the page, so it may not be read as permission to drive it.
     [Theory]
     [InlineData(false)]
     [InlineData(true)]
-    public void NoRecord_UnparsedPage_StaysOnTheNavigationMock(bool declaresSourceTable)
+    public void NoRecord_UnknownPage_StaysOnTheNavigationMock(bool declaresSourceTable)
         => Assert.Equal(TestPageClientKind.NavigationMock,
             TestPageClientConstructionRule.Resolve(
-                recordBuilt: false, pageIsParsed: false, pageDeclaresSourceTable: declaresSourceTable));
+                recordBuilt: false, pageShapeKnown: false, pageDeclaresSourceTable: declaresSourceTable));
 }

--- a/AlRunner/Patches/CodeunitPatches.cs
+++ b/AlRunner/Patches/CodeunitPatches.cs
@@ -482,8 +482,8 @@ public static partial class BcRuntime
         // for this shape since #2007. Both sites now agree.
         switch (TestPageClientConstructionRule.Resolve(
                     recordBuilt: built != null,
-                    pageIsParsed: RecordPatches.IsPageParsed(pageId),
-                    pageDeclaresSourceTable: RecordPatches.PageDeclaresSourceTable(pageId)))
+                    pageShapeKnown: RecordPatches.IsPageShapeKnown(pageId),
+                    pageDeclaresSourceTable: RecordPatches.ResolvePageDeclaresSourceTableForAnyPage(pageId)))
         {
             case TestPageClientKind.LiveOverRecord:
                 return new LiveNavTestPage(built!.Record, RecordPatches.GetPageControlFieldMap(pageId),
@@ -514,19 +514,28 @@ public static partial class BcRuntime
 
         // BC's own body returns null when the page's SourceObject.SourceTable is 0 — a page
         // without a source table is legal AL, and PrimaryKeyFields then reads as empty.
-        // Mirror that, but ONLY for a page we actually parsed: answering null for a page the
-        // parser never saw would turn a runner gap into a silently empty primary key.
-        if (!RecordPatches.IsPageParsed(pageId))
+        // Mirror that, but ONLY for a page whose declared shape we actually know: answering
+        // null for a page we know nothing about would turn a runner gap into a silently empty
+        // primary key.
+        //
+        // "Know" means AL-source-parsed OR declared by a loaded dependency .app (issue #2341).
+        // Restricting it to the parsed half refused every TestPage over a Base App / System
+        // App page — TestPage 9807 "User Card" among them, whose SourceTable the runner was
+        // already holding in BcAppSymbolCache. TestPageFactory.TryBuild and
+        // NavTestPageBase_ALGoToRecord below both resolve a precompiled page's table today;
+        // this is the third reader of the same state, and it was the one still refusing.
+        if (!RecordPatches.IsPageShapeKnown(pageId))
             throw new InvalidOperationException(
-                $"TestPage {pageId} was never parsed from AL source — cannot resolve its " +
-                $"SourceTable, and guessing would silently yield an empty primary key.");
+                $"TestPage {pageId} is declared neither in this bundle's AL source nor in any " +
+                $"loaded dependency .app — cannot resolve its SourceTable, and guessing would " +
+                $"silently yield an empty primary key.");
 
-        if (!RecordPatches.PageDeclaresSourceTable(pageId))
+        if (!RecordPatches.ResolvePageDeclaresSourceTableForAnyPage(pageId))
             return null!;
 
-        var tableId = RecordPatches.GetSourceTableIdForPage(pageId);
+        var tableId = RecordPatches.ResolveSourceTableIdForAnyPage(pageId);
         if (tableId == 0)
-            throw new InvalidOperationException($"TestPage {pageId} has no parsed SourceTable.");
+            throw new InvalidOperationException($"TestPage {pageId} has no resolvable SourceTable.");
 
         return RecordPatches.GetOrBuildNCLMetaTable(tableId)
             ?? throw new InvalidOperationException($"TestPage {pageId} SourceTable {tableId} has no NCLMetaTable.");

--- a/AlRunner/Patches/MockTestPage.cs
+++ b/AlRunner/Patches/MockTestPage.cs
@@ -251,8 +251,8 @@ internal class LiveNavTestPage : MockITestPage
         RunnerPageInstance? partPage;
         switch (TestPageClientConstructionRule.Resolve(
                     recordBuilt: built != null,
-                    pageIsParsed: RecordPatches.IsPageParsed(partPageId),
-                    pageDeclaresSourceTable: RecordPatches.PageDeclaresSourceTable(partPageId)))
+                    pageShapeKnown: RecordPatches.IsPageShapeKnown(partPageId),
+                    pageDeclaresSourceTable: RecordPatches.ResolvePageDeclaresSourceTableForAnyPage(partPageId)))
         {
             case TestPageClientKind.LiveOverRecord:
                 partRecord = built!.Record;

--- a/AlRunner/Patches/RecordPatches.DependencyPageMetadata.cs
+++ b/AlRunner/Patches/RecordPatches.DependencyPageMetadata.cs
@@ -39,6 +39,34 @@ public static partial class RecordPatches
     }
 
     /// <summary>
+    /// Whether the runner knows <paramref name="pageId"/>'s DECLARED SHAPE at all — from its
+    /// own AL source parse, or from a loaded dependency .app's SymbolReference.json.
+    ///
+    /// <para>This is the predicate every "is 'declares no SourceTable' a fact about the page,
+    /// or about our ignorance?" decision actually wants. <see cref="IsPageParsed"/> answers
+    /// only the first half, and reading it as the whole question is what issue #2341 was:
+    /// TestPage 9807 "User Card" ships in the precompiled Base Application, whose
+    /// SymbolReference.json states <c>SourceTable = 2000000120</c> verbatim, and the runner
+    /// refused to resolve it while already holding the answer.</para>
+    /// </summary>
+    internal static bool IsPageShapeKnown(int pageId)
+        => IsPageParsed(pageId) || TryGetDependencyPageSymbol(pageId) != null;
+
+    /// <summary>
+    /// Whether <paramref name="pageId"/> declares a SourceTable — checking the runner's own
+    /// AL-source-parsed pages first, then any loaded dependency .app.
+    ///
+    /// <para>Source-compiled wins outright for a page id the parser saw, mirroring how the
+    /// Page Metadata / Page Control Field virtual tables merge the two sources: a parsed page
+    /// that declares none must answer false, never fall through to a same-numbered dependency
+    /// page's answer.</para>
+    /// </summary>
+    internal static bool ResolvePageDeclaresSourceTableForAnyPage(int pageId)
+        => IsPageParsed(pageId)
+            ? PageDeclaresSourceTable(pageId)
+            : (TryGetDependencyPageSymbol(pageId)?.SourceTableId ?? 0) != 0;
+
+    /// <summary>
     /// Whether <paramref name="pageId"/> declares <c>SourceTableTemporary = true</c> —
     /// checking the runner's own AL-source-parsed pages first, then any loaded dependency
     /// .app. False (including "unknown page") is the safe default — it is also AL's own

--- a/AlRunner/Patches/TestPageClientConstructionRule.cs
+++ b/AlRunner/Patches/TestPageClientConstructionRule.cs
@@ -53,20 +53,25 @@ internal enum TestPageClientKind
 internal static class TestPageClientConstructionRule
 {
     /// <param name="recordBuilt">Whether TestPageFactory.TryBuild produced a record cursor.</param>
-    /// <param name="pageIsParsed">Whether the runner AL-source-parsed this page, so "declares
-    /// no SourceTable" is a fact about the page rather than about the runner's ignorance.</param>
-    /// <param name="pageDeclaresSourceTable">Whether the parsed page declares a SourceTable.</param>
+    /// <param name="pageShapeKnown">Whether the runner knows this page's DECLARED SHAPE, so
+    /// "declares no SourceTable" is a fact about the page rather than about the runner's
+    /// ignorance. Both sources count: the runner's own AL source parse, and a loaded
+    /// dependency .app's SymbolReference.json (<c>RecordPatches.IsPageShapeKnown</c>). Reading
+    /// this as the parsed half alone is what issue #2341 was — it demoted every
+    /// no-SourceTable page shipping in a precompiled dependency (167 of them in Base
+    /// Application 28.1, 35 more in System Application) to the navigation mock.</param>
+    /// <param name="pageDeclaresSourceTable">Whether that declared shape has a SourceTable.</param>
     internal static TestPageClientKind Resolve(
-        bool recordBuilt, bool pageIsParsed, bool pageDeclaresSourceTable)
+        bool recordBuilt, bool pageShapeKnown, bool pageDeclaresSourceTable)
     {
         if (recordBuilt) return TestPageClientKind.LiveOverRecord;
 
         // No record AND the page declares no source table: nothing is missing — there is
         // simply nothing to build. Drive it record-less.
-        if (pageIsParsed && !pageDeclaresSourceTable) return TestPageClientKind.LiveRecordless;
+        if (pageShapeKnown && !pageDeclaresSourceTable) return TestPageClientKind.LiveRecordless;
 
-        // No record but the page DOES declare a source table (or the runner never saw the
-        // page): something the runner needed is missing. Answering record-less here would
+        // No record but the page DOES declare a source table (or the runner knows nothing
+        // about the page from either source): something the runner needed is missing. Answering record-less here would
         // swap one wrong answer for another — a page that should have had rows would report
         // none, quietly — so this keeps the pre-existing mock, which the call site announces.
         return TestPageClientKind.NavigationMock;


### PR DESCRIPTION
Closes #2341

## Which of the two causes it was

The issue asked whether page 9807 is missing from `BcAppSymbolCache.Get(<app>).Pages` or present but not consulted. **It was present and not consulted.** Measured with a temporary probe on the refusal path:

```
pageId=9807 isParsed=False depSourceTable=2000000120 resolveAny=2000000120 temp=False
```

Page 9807 "User Card" ships in `Microsoft_Base Application_28.1.49838.53910.app`, whose `SymbolReference.json` states `SourceTable = 2000000120` verbatim. The runner was already holding that answer. `NavTestPageBase_GetMetaTable` asked `RecordPatches.IsPageParsed`, which is false for every page the runner does not AL-source-compile, and refused.

The refusal itself stays — it is right, and the message now names both sources it looked in rather than only the AL parse.

## Fix the shape, not just the reported line

**1. Does the same wrong pattern appear at another call site?** Yes, and the reported page was not the only casualty either. `TestPageClientConstructionRule.Resolve` was being fed `IsPageParsed` / `PageDeclaresSourceTable` at both of its call sites — `CodeunitPatches.NavTestPageHandle_CreateTarget` and `MockTestPage.LiveNavTestPage.GetPart`. That is the #2090 defect exactly, restricted to precompiled pages: a page that legally declares no SourceTable gets demoted to the blanket navigation mock, whose every member answers a default. **167 Base Application pages and 35 System Application pages have that shape on 28.1.** Both call sites now compute the predicate from either source.

**2. Does a sibling function make the same assumption?** The rest of the family already did the right thing, so this was the last reader still refusing. `TestPageFactory.TryBuild` falls back to the dependency symbol (#1719), `GetInsertAllowedForPage` does (#2088), and `NavTestPageBase_ALGoToRecord` derives the key from the passed record's compiled metadata (#2057).

**3. If two code paths write the same state, do they maintain the same invariant?** They did not. `ALGoToRecord` and `GetMetaTable` both derive the primary key for the same TestPage; the first already fell back for a precompiled page and the second threw. They now agree.

`RecordPatches.PageControlFieldVirtualTable` and `PageMetadataVirtualTable` also read parse-only lookups, but each already merges a dependency pass afterwards, so they were correct and are untouched.

## The reported page was not the only one

The issue counted 35 tests on page 9807. The full refusal cluster in Tests-SINGLESERVER was **38 tests across two pages** — 35 on 9807 "User Card" and 3 more on 9195 "Experience Tiers" (`SourceTable = 9177`), which the message-grep in the issue missed because those three compare the refusal text inside `Assert.ExpectedError`. All 38 are fixed by the same change.

## Measurements

Microsoft's `Tests-SINGLESERVER` bucket, 806 tests, same invocation both runs (`--test-data` sandbox `.bak`, company `CRONUS International Ltd_`, private `--cache`). `ERMPurchaseReportsIII` and `APISetupUT` parked out of the bundle for both runs, per #2304 / #2336.

| | before | after |
| --- | --- | --- |
| pass | 180 | 185 |
| fail | 617 | 604 |
| error | 9 | 17 |
| lines carrying the refusal | 38 | **0** |

13 tests changed status and **none regressed** (no `PASS -> FAIL`).

Being precise about what this fix earns, because the headline number is easy to overstate:

- **All 38 get past the wall.** The refusal is gone from the log entirely, and the 9807 tests now fail on things that prove the page really resolved — e.g. `AssertEquals for Field: Authentication Email Expected = 'test@email.com', Actual = '    test@email.com'`. The row was found and the field was read.
- **3 of the 5 newly-passing tests are attributable to this change** — `TestExperienceOnPrem`, `TestSettingAdvancedExperience`, `TestSettingExperienceSaaS`, all three the page-9195 arm, each failing on the refusal text before. The other two (`SalesOrderPostOnItemRestriction`, `CopyConfigTemplateFromConfigTemplateUI`) had unrelated failure messages in the RED run, so I am not claiming them.
- **0 of the 35 page-9807 tests turn green yet.** Each was stacked behind further, unrelated gaps that the refusal was masking: `Authentication Email` validation not trimming whitespace, a blank `DateTime` rendering as `01/01/0001 00:00:00` in a TestPage field, and UI-handler dispatch (the 8 `FAIL -> ERROR` moves are all "The following UI handlers were not executed"). Those are separate issues, filed as follow-ups.

## Tests

**Upstream, on real BC** — StefanMaron/BusinessCentral.AL.Language.Tests#92 adds `codeunit 60810 "Test Page Platform Src Tests"`: four arms driving Base Application page 5 "Currencies", a page the corpus app does not declare. Green on all 8 BC legs (27.0, 27.3, 27.5, 28.0, 28.1, 28.2, 28.3, 28.4). Run against the runner from that corpus branch:

- without this change: all four FAIL with `TestPage 5 was never parsed from AL source — cannot resolve its SourceTable`
- with it: all four PASS

The submodule pin bump and the `count-baseline` update fold into this PR once that corpus PR merges.

**Runner-side mechanism** — `AlRunner.Tests/DependencyPageShapeResolutionTests.cs` pins the C# predicates against a hand-built dependency `.app`, following `DependencyPageMetadataXmlTests`. The negative rows carry the weight: `IsPageShapeKnown` answering a blanket true would re-open the hole the refusal exists to plug, and `ResolvePageDeclaresSourceTableForAnyPage` has to tell "the dependency says this page declares none" from "no dependency mentions this page".

`AlRunner.Tests/TestPageClientConstructionRuleTests.cs` follows the parameter rename; its four decision rows are unchanged.
