### PR TITLE
fix(record): create the User Property companion row BC's User insert trigger creates

### DIFF
--- a/AlRunner.Tests/UserPropertyCompanionRowBindingTests.cs
+++ b/AlRunner.Tests/UserPropertyCompanionRowBindingTests.cs
@@ -69,16 +69,35 @@ public sealed class UserPropertyCompanionRowBindingTests
             .Select(i => (i.Operand as MethodReference)?.FullName ?? string.Empty)
             .ToList();
 
+    /// <summary>
+    /// A marker prepend that predates this one, used to tell "the file on disk has not been
+    /// Cecil-rewritten yet" (a legitimate skip) apart from "it was rewritten and OUR prepend
+    /// is missing" (the regression this test exists to catch). Without the distinction an
+    /// un-rewritten bin would fail the test for the wrong reason.
+    /// </summary>
+    private const string PriorPrependMarker =
+        "AlRunner.BcRuntime::AssignAutoIncrement(Microsoft.Dynamics.Nav.Runtime.NavRecord)";
+
+    private static void SkipUnlessRewritten(MethodDefinition alInsert)
+        => Skip.IfNot(
+            CalledMethods(alInsert).Any(name => name.Contains(PriorPrependMarker, StringComparison.Ordinal)),
+            $"'{RewrittenNclPath}' has not been Cecil-rewritten (no prepends present at all), so "
+            + "there is nothing to assert about the prepend list. Run the runner once to warm "
+            + "the Cecil cache first — CI's bc-tests.yml does exactly that before `dotnet test`.");
+
+    // These two read a FILE with Mono.Cecil and load no BC type, so they deliberately do NOT
+    // gate on BcEngineFixture.Ready. That gate is about whether the engine can be brought up
+    // in-process; a machine where it cannot (a cold Cecil cache, say) can still answer the
+    // question these tests ask, and gating on it hid them behind an unrelated skip.
     [SkippableFact]
     public void AlInsertEntryPoint_CallsTheCompanionRowHelperAsItsFirstAct()
     {
-        TestArtifacts.SkipIf(!_engine.Ready,
-            _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
         Skip.IfNot(File.Exists(RewrittenNclPath),
             $"the rewritten Ncl is not present at '{RewrittenNclPath}'.");
 
         using var module = ModuleDefinition.ReadModule(RewrittenNclPath);
         var alInsert = NavRecordMethod(module, "ALInsertAsync", "DataError", "Boolean", "Boolean");
+        SkipUnlessRewritten(alInsert);
         var instructions = alInsert.Body.Instructions;
 
         // The prepend is `ldarg.0; call helper` inserted before the original body, so the
@@ -98,24 +117,30 @@ public sealed class UserPropertyCompanionRowBindingTests
             + "reaches UserManagement.DirectSetUserFieldValue would fail with "
             + "\"The User Property does not exist\" (issue #2355).");
 
-        // Three prepends share this entry point (AutoIncrement, SystemFields, this one), each
-        // contributing `ldarg.0; call`, so index 5 is the last slot the third can occupy.
-        Assert.True(helperIndex!.Value <= 5,
-            $"the companion-row helper is called at instruction {helperIndex} of "
-            + "NavRecord.ALInsertAsync, not in the prepended prefix — it must run before the "
-            + "original body, exactly as BC's own OnBeforeInsertAsync does.");
-        Assert.Equal(OpCodes.Ldarg_0, instructions[helperIndex.Value - 1].OpCode);
+        // It must be in the PREPENDED PREFIX, not merely somewhere in the method: the
+        // companion row has to be written before the original body runs, exactly as BC's own
+        // OnBeforeInsertAsync does. Several prepends share this entry point (AutoIncrement,
+        // SystemFields, the rowversion write note, the All Profile guard, this one) and each
+        // contributes exactly `ldarg.0; call`, so the prefix is characterised by its SHAPE —
+        // nothing but those two opcodes ahead of us — rather than by a fixed index that a
+        // sixth prepend would invalidate.
+        Assert.Equal(OpCodes.Ldarg_0, instructions[helperIndex!.Value - 1].OpCode);
+        for (var i = 0; i < helperIndex.Value; i++)
+            Assert.True(
+                instructions[i].OpCode == OpCodes.Ldarg_0 || instructions[i].OpCode == OpCodes.Call,
+                $"instruction {i} of NavRecord.ALInsertAsync is {instructions[i].OpCode}, so the "
+                + "companion-row helper is no longer inside the prepended prefix — it would run "
+                + "after part of the original body instead of before all of it.");
     }
 
     [SkippableFact]
     public void ModifyAndDeleteEntryPoints_DoNotCallTheCompanionRowHelper()
     {
-        TestArtifacts.SkipIf(!_engine.Ready,
-            _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
         Skip.IfNot(File.Exists(RewrittenNclPath),
             $"the rewritten Ncl is not present at '{RewrittenNclPath}'.");
 
         using var module = ModuleDefinition.ReadModule(RewrittenNclPath);
+        SkipUnlessRewritten(NavRecordMethod(module, "ALInsertAsync", "DataError", "Boolean", "Boolean"));
 
         // BC creates the companion row in OnBEFOREInsert only. Modify must not create a second
         // one, and Delete must not create one for a user being removed.

--- a/AlRunner.Tests/UserPropertyCompanionRowBindingTests.cs
+++ b/AlRunner.Tests/UserPropertyCompanionRowBindingTests.cs
@@ -1,4 +1,4 @@
-// UserPropertyCompanionRowBindingTests — issue #2353.
+// UserPropertyCompanionRowBindingTests — issue #2355.
 //
 // This is a RUNNER-MECHANISM test, not a claim about what real BC does. The BC-observable
 // claim ("a User row always has a matching User Property row, created with it, so
@@ -96,7 +96,7 @@ public sealed class UserPropertyCompanionRowBindingTests
             + "UserTableTriggerPatches.CreateUserPropertyOnUserInsert — the User Property row BC's "
             + "own User insert trigger creates would never be written, and every AL path that "
             + "reaches UserManagement.DirectSetUserFieldValue would fail with "
-            + "\"The User Property does not exist\" (issue #2353).");
+            + "\"The User Property does not exist\" (issue #2355).");
 
         // Three prepends share this entry point (AutoIncrement, SystemFields, this one), each
         // contributing `ldarg.0; call`, so index 5 is the last slot the third can occupy.

--- a/AlRunner.Tests/UserPropertyCompanionRowBindingTests.cs
+++ b/AlRunner.Tests/UserPropertyCompanionRowBindingTests.cs
@@ -1,0 +1,144 @@
+// UserPropertyCompanionRowBindingTests — issue #2353.
+//
+// This is a RUNNER-MECHANISM test, not a claim about what real BC does. The BC-observable
+// claim ("a User row always has a matching User Property row, created with it, so
+// UserManagement.DirectSetUserFieldValue can Get it with the raising error level") belongs
+// upstream in StefanMaron/BusinessCentral.AL.Language.Tests, where a live service tier
+// adjudicates it.
+//
+// What THIS test pins is the runner's own wiring. Ncl's
+// SystemTableTriggers.OnBeforeInsertAsync has a `case 2000000120:` arm that inserts the
+// companion User Property (2000000121) row, and the runner bypasses BC's trigger dispatch on
+// insert (RecordWritePatches.NavRecord_InsertAsync), so nothing created that row. The fix
+// prepends UserTableTriggerPatches.CreateUserPropertyOnUserInsert to
+// NavRecord.ALInsertAsync(DataError, bool, bool) — the single AL insert entry point
+// AssignAutoIncrement and StampSystemFieldsOnInsert are already prepended to.
+//
+// The prepend is registration-only code: it lives in NclCecilRewrite and produces no
+// observable C# call graph, so a regression that drops it — or moves it onto the wrong entry
+// point — is invisible to every other test until an AL suite that creates a user fails far
+// downstream with "The User Property does not exist". Reading the rewritten IL is what makes
+// that regression fail here instead, in milliseconds.
+using AlRunner.Patches;
+using Microsoft.Dynamics.Nav.Runtime;
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+using System.Runtime.CompilerServices;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+[Collection(BcEngineCollection.Name)]
+public sealed class UserPropertyCompanionRowBindingTests
+{
+    private readonly BcEngineFixture _engine;
+
+    public UserPropertyCompanionRowBindingTests(BcEngineFixture engine) => _engine = engine;
+
+    private const string HelperFullName =
+        "System.Void AlRunner.Patches.UserTableTriggerPatches::CreateUserPropertyOnUserInsert(System.Object)";
+
+    /// <summary>
+    /// The Cecil-rewritten Ncl the test host itself loaded — the very bytes the prepend was
+    /// written into (see BcEngineBootstrap, which rewrites into this assembly's own bin dir).
+    /// </summary>
+    private static string RewrittenNclPath => Path.Combine(
+        Path.GetDirectoryName(typeof(UserPropertyCompanionRowBindingTests).Assembly.Location)
+            ?? AppContext.BaseDirectory,
+        "Microsoft.Dynamics.Nav.Ncl.dll");
+
+    private static MethodDefinition NavRecordMethod(
+        ModuleDefinition module, string name, params string[] parameterTypeNames)
+    {
+        var navRecord = module.GetType("Microsoft.Dynamics.Nav.Runtime.NavRecord");
+        Assert.NotNull(navRecord);
+        var method = navRecord!.Methods.FirstOrDefault(m =>
+            m.Name == name
+            && m.HasBody
+            && m.Parameters.Count == parameterTypeNames.Length
+            && m.Parameters.Select(p => p.ParameterType.Name).SequenceEqual(parameterTypeNames));
+        Assert.True(method != null,
+            $"NavRecord.{name}({string.Join(", ", parameterTypeNames)}) not found in the rewritten Ncl "
+            + "— BC shape changed, and the prepend that depends on it would be silently unbound.");
+        return method!;
+    }
+
+    private static List<string> CalledMethods(MethodDefinition method)
+        => method.Body.Instructions
+            .Where(i => i.OpCode == OpCodes.Call || i.OpCode == OpCodes.Callvirt)
+            .Select(i => (i.Operand as MethodReference)?.FullName ?? string.Empty)
+            .ToList();
+
+    [SkippableFact]
+    public void AlInsertEntryPoint_CallsTheCompanionRowHelperAsItsFirstAct()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready,
+            _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+        Skip.IfNot(File.Exists(RewrittenNclPath),
+            $"the rewritten Ncl is not present at '{RewrittenNclPath}'.");
+
+        using var module = ModuleDefinition.ReadModule(RewrittenNclPath);
+        var alInsert = NavRecordMethod(module, "ALInsertAsync", "DataError", "Boolean", "Boolean");
+        var instructions = alInsert.Body.Instructions;
+
+        // The prepend is `ldarg.0; call helper` inserted before the original body, so the
+        // helper call must sit within the first few instructions — not merely somewhere in
+        // the method, which a later, conditional call site would also satisfy.
+        var helperIndex = instructions
+            .Select((instruction, index) => (instruction, index))
+            .Where(x => (x.instruction.OpCode == OpCodes.Call || x.instruction.OpCode == OpCodes.Callvirt)
+                        && (x.instruction.Operand as MethodReference)?.FullName == HelperFullName)
+            .Select(x => (int?)x.index)
+            .FirstOrDefault();
+
+        Assert.True(helperIndex.HasValue,
+            "NavRecord.ALInsertAsync(DataError, bool, bool) does not call "
+            + "UserTableTriggerPatches.CreateUserPropertyOnUserInsert — the User Property row BC's "
+            + "own User insert trigger creates would never be written, and every AL path that "
+            + "reaches UserManagement.DirectSetUserFieldValue would fail with "
+            + "\"The User Property does not exist\" (issue #2353).");
+
+        // Three prepends share this entry point (AutoIncrement, SystemFields, this one), each
+        // contributing `ldarg.0; call`, so index 5 is the last slot the third can occupy.
+        Assert.True(helperIndex!.Value <= 5,
+            $"the companion-row helper is called at instruction {helperIndex} of "
+            + "NavRecord.ALInsertAsync, not in the prepended prefix — it must run before the "
+            + "original body, exactly as BC's own OnBeforeInsertAsync does.");
+        Assert.Equal(OpCodes.Ldarg_0, instructions[helperIndex.Value - 1].OpCode);
+    }
+
+    [SkippableFact]
+    public void ModifyAndDeleteEntryPoints_DoNotCallTheCompanionRowHelper()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready,
+            _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+        Skip.IfNot(File.Exists(RewrittenNclPath),
+            $"the rewritten Ncl is not present at '{RewrittenNclPath}'.");
+
+        using var module = ModuleDefinition.ReadModule(RewrittenNclPath);
+
+        // BC creates the companion row in OnBEFOREInsert only. Modify must not create a second
+        // one, and Delete must not create one for a user being removed.
+        foreach (var name in new[] { "ALModifyAsync", "ALDeleteAsync" })
+        {
+            var navRecord = module.GetType("Microsoft.Dynamics.Nav.Runtime.NavRecord");
+            foreach (var method in navRecord!.Methods.Where(m => m.Name == name && m.HasBody))
+                Assert.DoesNotContain(HelperFullName, CalledMethods(method));
+        }
+    }
+
+    [SkippableFact]
+    public void Helper_IsANoOp_ForAnythingThatIsNotAUserRecord()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready,
+            _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        // Null and a record with no metatable are the two shapes the prepend sees on every
+        // insert of every other table in the run; neither may throw, and neither may reach
+        // the session lookup, which would raise RunnerOutOfScopeException on a bare record.
+        UserTableTriggerPatches.CreateUserPropertyOnUserInsert(null);
+        UserTableTriggerPatches.CreateUserPropertyOnUserInsert(new object());
+        UserTableTriggerPatches.CreateUserPropertyOnUserInsert(
+            (NavRecord)RuntimeHelpers.GetUninitializedObject(typeof(NavRecord)));
+    }
+}

--- a/AlRunner/Infrastructure/NclCecilRewrite.cs
+++ b/AlRunner/Infrastructure/NclCecilRewrite.cs
@@ -4188,6 +4188,40 @@ public static class NclCecilRewrite
             Console.Error.WriteLine("[Cecil] Prepended StampSystemFieldsOnInsert → NavRecord.ALInsertAsync(DataError,bool,bool)");
         }
 
+        // ── NavRecord.ALInsertAsync(DataError, bool, bool) — User Property companion row ──
+        // On a real tier, SystemTableTriggers.OnBeforeInsertAsync's `case 2000000120:` arm
+        // inserts the matching User Property (2000000121) row for every User it accepts, and
+        // BC's own UserManagement.DirectSetUserFieldValue then Gets that row with the RAISING
+        // error level. The runner bypasses BC's trigger dispatch on insert, so the row was
+        // never created. Same prepend shape as AssignAutoIncrement / StampSystemFieldsOnInsert
+        // above; a no-op for every table but User. See AlRunner/Patches/UserTableTriggerPatches.cs
+        // and issue #2353.
+        {
+            var navRecord = asm.MainModule.GetType("Microsoft.Dynamics.Nav.Runtime.NavRecord")
+                ?? throw new InvalidOperationException("NavRecord type not found in Ncl");
+            var alInsert3 = navRecord.Methods.FirstOrDefault(m =>
+                m.Name == "ALInsertAsync"
+                && m.Parameters.Count == 3
+                && m.Parameters[0].ParameterType.Name == "DataError"
+                && m.Parameters[1].ParameterType.MetadataType == Mono.Cecil.MetadataType.Boolean
+                && m.Parameters[2].ParameterType.MetadataType == Mono.Cecil.MetadataType.Boolean)
+                ?? throw new InvalidOperationException("NavRecord.ALInsertAsync(DataError,bool,bool) not found");
+
+            var helperMi = typeof(AlRunner.Patches.UserTableTriggerPatches).GetMethod(
+                nameof(AlRunner.Patches.UserTableTriggerPatches.CreateUserPropertyOnUserInsert),
+                BindingFlags.Public | BindingFlags.Static)
+                ?? throw new InvalidOperationException("UserTableTriggerPatches.CreateUserPropertyOnUserInsert not found");
+            var helperRef = asm.MainModule.ImportReference(helperMi);
+
+            var body = alInsert3.Body;
+            var il = body.GetILProcessor();
+            var firstOriginal = body.Instructions[0];
+            il.InsertBefore(firstOriginal, il.Create(OpCodes.Ldarg_0));
+            il.InsertBefore(firstOriginal, il.Create(OpCodes.Call, helperRef));
+            if (body.MaxStackSize < 1) body.MaxStackSize = 1;
+            Console.Error.WriteLine("[Cecil] Prepended CreateUserPropertyOnUserInsert → NavRecord.ALInsertAsync(DataError,bool,bool)");
+        }
+
         // ── NavRecord.ALModifyAsync — SystemModified stamp prepend ──────────────────
         // Stamps only SystemModifiedAt + SystemModifiedBy. NEVER touches
         // SystemCreatedAt / SystemCreatedBy (BC semantics: created fields are

--- a/AlRunner/Infrastructure/NclCecilRewrite.cs
+++ b/AlRunner/Infrastructure/NclCecilRewrite.cs
@@ -4195,7 +4195,7 @@ public static class NclCecilRewrite
         // error level. The runner bypasses BC's trigger dispatch on insert, so the row was
         // never created. Same prepend shape as AssignAutoIncrement / StampSystemFieldsOnInsert
         // above; a no-op for every table but User. See AlRunner/Patches/UserTableTriggerPatches.cs
-        // and issue #2353.
+        // and issue #2355.
         {
             var navRecord = asm.MainModule.GetType("Microsoft.Dynamics.Nav.Runtime.NavRecord")
                 ?? throw new InvalidOperationException("NavRecord type not found in Ncl");

--- a/AlRunner/Patches/UserTableTriggerPatches.cs
+++ b/AlRunner/Patches/UserTableTriggerPatches.cs
@@ -29,7 +29,7 @@
 //       NavCSideRecordNotFoundException: The User Property does not exist.
 //       Identification fields and values: User Security ID='{...}'
 //
-//   Issue #2353. Measured on Microsoft's Tests-SINGLESERVER bucket, BC 28.1.49838.53910.
+//   Issue #2355. Measured on Microsoft's Tests-SINGLESERVER bucket, BC 28.1.49838.53910.
 //
 // WHY A PREPEND, AND WHY THIS ENTRY POINT
 //   NavRecord.ALInsertAsync(DataError, bool, bool) is the single async entry point every AL
@@ -45,7 +45,7 @@
 //   authentication email, application id) and its OnAfterDeleteAsync arm cascades a User
 //   delete into Access Control (2000000053), User Property (2000000121), User
 //   Personalization (2000000107) and 2000000233. None of that is reproduced here; the
-//   delete cascade is tracked separately in #2354. This file establishes exactly one
+//   delete cascade is tracked separately in #2356. This file establishes exactly one
 //   invariant — a non-temporary User row has a User Property row — and says so rather than
 //   quietly implementing a third of a trigger.
 //

--- a/AlRunner/Patches/UserTableTriggerPatches.cs
+++ b/AlRunner/Patches/UserTableTriggerPatches.cs
@@ -1,0 +1,142 @@
+// UserTableTriggerPatches — the platform-level companion row BC creates when a User is
+// inserted.
+//
+// WHY THIS EXISTS
+//   On a real tier, inserting into User (2000000120) does more than write that one row.
+//   Ncl's SystemTableTriggers.OnBeforeInsertAsync has a `case 2000000120:` arm that, after
+//   its validation, does exactly this:
+//
+//       NavRecord navRecord = NavGlobal.NCLMetadata
+//           .GetMetaTableById(2000000121, requireCompiled: true)
+//           .CreateObjectInstance(session, isTemporary: false, null, string.Empty,
+//                                 SecurityFiltering.Ignored);
+//       navRecord.SetFieldValue(1,  userSid);            // "User Security ID"
+//       navRecord.SetFieldValue(10, NavGuid.NewGuid());  // "Telemetry User ID"
+//       await navRecord.InsertAsync((DataError)0, runApplicationTrigger: false,
+//                                   runGlobalTrigger: false);
+//
+//   So every User has a matching User Property (2000000121) row from the moment it exists,
+//   and BC's own code relies on that. UserManagement.DirectSetUserFieldValue — reached from
+//   AL through NavUserAccountHelper.SetAuthenticationObjectId / SetAuthenticationEmail /
+//   SetDirectoryRoleIdList, which is how Microsoft's own test libraries create users — does
+//
+//       navRecord.Get((DataError)1, new NavRecordId(2000000121, [ new NavGuid(sid) ]));
+//
+//   with the RAISING error level. The runner bypasses BC's trigger dispatch on insert (see
+//   RecordWritePatches.NavRecord_InsertAsync), so that row was never created and every such
+//   call died with:
+//
+//       NavCSideRecordNotFoundException: The User Property does not exist.
+//       Identification fields and values: User Security ID='{...}'
+//
+//   Issue #2353. Measured on Microsoft's Tests-SINGLESERVER bucket, BC 28.1.49838.53910.
+//
+// WHY A PREPEND, AND WHY THIS ENTRY POINT
+//   NavRecord.ALInsertAsync(DataError, bool, bool) is the single async entry point every AL
+//   `Insert()` surface funnels through — the same one AssignAutoIncrement and
+//   StampSystemFieldsOnInsert are already prepended to. Running BEFORE the user row is
+//   written matches BC, whose own companion insert happens in OnBEFOREInsert.
+//
+//   The companion insert itself goes through ALInsert, which re-enters this prepend with
+//   table 2000000121 and returns immediately — the table check below is what bounds it.
+//
+// WHAT THIS DELIBERATELY DOES NOT DO
+//   BC's `case 2000000120:` arm also validates (unique user name, unique Windows SID,
+//   authentication email, application id) and its OnAfterDeleteAsync arm cascades a User
+//   delete into Access Control (2000000053), User Property (2000000121), User
+//   Personalization (2000000107) and 2000000233. None of that is reproduced here; the
+//   delete cascade is tracked separately in #2354. This file establishes exactly one
+//   invariant — a non-temporary User row has a User Property row — and says so rather than
+//   quietly implementing a third of a trigger.
+//
+// PRECOMPILED-DLL RESPECT
+//   No AL business-logic body is touched. This is a static helper Cecil PREPENDS to
+//   NavRecord's own AL insert entry point in the runtime engine (Ncl.dll), the same
+//   mechanism AssignAutoIncrement, the rowversion clock and the All Profile write guards
+//   already use. Every type it touches (NavRecord, NCLMetaField, NavGuid, DataError) is
+//   runtime-engine, never AL business logic.
+using System.Runtime.CompilerServices;
+using Microsoft.Dynamics.Nav.Runtime;
+using Microsoft.Dynamics.Nav.Types;
+
+namespace AlRunner.Patches;
+
+public static class UserTableTriggerPatches
+{
+    /// <summary>The User system table.</summary>
+    internal const int UserTableId = 2000000120;
+
+    /// <summary>The User Property system table — one row per User, created with it.</summary>
+    internal const int UserPropertyTableId = 2000000121;
+
+    // Field numbers are resolved off the metatables' OWN field names rather than hardcoded,
+    // so a BC version that renumbers either table is followed instead of silently misread.
+    // BC's own trigger hardcodes 1 and 10; the names those correspond to today are
+    // "User Security ID" and "Telemetry User ID".
+    private const string UserSecurityIdFieldName = "User Security ID";
+    private const string TelemetryUserIdFieldName = "Telemetry User ID";
+
+    /// <summary>
+    /// Prepended to NavRecord.ALInsertAsync(DataError, bool, bool). A no-op for every table
+    /// but User (2000000120); for that one it creates the matching User Property row the way
+    /// BC's SystemTableTriggers.OnBeforeInsertAsync does.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void CreateUserPropertyOnUserInsert(object? record)
+    {
+        if (record is not NavRecord { IsTemporary: false } user) return;
+        if (user.MetaTable?.TableId != UserTableId) return;
+
+        var sid = user.GetFieldValue(FieldNoByName(user.MetaTable, UserSecurityIdFieldName));
+        // A User row with no security id is not one BC would have accepted either — its own
+        // trigger throws NavNCLUserTableInvalidUserSidException before reaching the companion
+        // insert. Leave that refusal to BC rather than inventing a property row keyed on the
+        // null GUID.
+        if (sid == null || sid.IsZeroOrEmpty) return;
+
+        var session = user.ParentSession
+            ?? throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
+                "User (2000000120) insert",
+                "user-property-companion-row — the User record under insert has no session, so the "
+                + "User Property row BC creates alongside it cannot be written; see docs/scope.md");
+
+        using var property = new NavRecord(session, UserPropertyTableId, SecurityFiltering.Ignored);
+        var propertyMeta = property.MetaTable
+            ?? throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
+                "User Property (2000000121)",
+                "user-property-companion-row — the User Property table has no metadata in this run, "
+                + "so the row BC creates alongside every User cannot be written; see docs/scope.md");
+
+        property.SetFieldValue(FieldNoByName(propertyMeta, UserSecurityIdFieldName), sid);
+        property.SetFieldValue(FieldNoByName(propertyMeta, TelemetryUserIdFieldName), NavGuid.NewGuid());
+
+        // TrapError, exactly as BC's own trigger uses: a User Property row that already
+        // exists for this SID is left alone rather than turned into a duplicate-key error.
+        // runApplicationTrigger: false / insertWithSystemId: false mirror BC's call.
+        // CS0618: BC marks the synchronous ALInsert obsolete in favour of the async form
+        // because of the sync-over-async cost. A Cecil prepend is a `void` method with no
+        // await point available to it, and the runner executes AL on one thread anyway, so
+        // the synchronous form is the only one callable here — the same trade the other
+        // prepends in this codebase make.
+#pragma warning disable CS0618
+        property.ALInsert(DataError.TrapError, runApplicationTrigger: false, insertWithSystemId: false);
+#pragma warning restore CS0618
+    }
+
+    /// <summary>
+    /// The field number <paramref name="fieldName"/> carries on <paramref name="table"/>.
+    /// Throws rather than returning a sentinel: a missing field means the companion row
+    /// would be written with the wrong shape, which is the silent-wrong-answer case
+    /// .claude/rules/loud-failures.md forbids.
+    /// </summary>
+    private static int FieldNoByName(NCLMetaTable table, string fieldName)
+    {
+        foreach (var f in RecordPatches.GetAllFields(table) ?? Enumerable.Empty<NCLMetaField>())
+            if (string.Equals(f.FieldName, fieldName, StringComparison.OrdinalIgnoreCase))
+                return f.FieldNo;
+        throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
+            $"{table.TableName} ({table.TableId})",
+            $"user-property-companion-row — the table states no \"{fieldName}\" field, so the User "
+            + "Property row BC creates alongside every User cannot be written; see docs/scope.md");
+    }
+}


### PR DESCRIPTION
Closes #2355

On a real tier, inserting a `User` (2000000120) also writes that user's `User Property`
(2000000121) row. Ncl's `SystemTableTriggers.OnBeforeInsertAsync` does it in its
`case 2000000120:` arm:

```csharp
NavRecord navRecord = NavGlobal.NCLMetadata
    .GetMetaTableById(2000000121, requireCompiled: true)
    .CreateObjectInstance(session, isTemporary: false, null, string.Empty, SecurityFiltering.Ignored);
navRecord.SetFieldValue(1,  userSid);            // "User Security ID"
navRecord.SetFieldValue(10, NavGuid.NewGuid());  // "Telemetry User ID"
await navRecord.InsertAsync((DataError)0, runApplicationTrigger: false, runGlobalTrigger: false);
```

The runner bypasses BC's trigger dispatch on insert (`RecordWritePatches.NavRecord_InsertAsync`
delegates straight to `RecordImplementation.InsertRecordAsync`), so that row was never created.
BC's own `UserManagement.DirectSetUserFieldValue` then `Get`s it with the **raising** error
level, which is how every `NavUserAccountHelper.SetAuthenticationObjectId` /
`SetDirectoryRoleIdList` call from AL died with `The User Property does not exist`.

This adds `AlRunner/Patches/UserTableTriggerPatches.cs` and prepends it to
`NavRecord.ALInsertAsync(DataError, bool, bool)` — the same entry point `AssignAutoIncrement`
and `StampSystemFieldsOnInsert` already use. It is a no-op for every table but User, and the
companion insert re-enters the prepend with table 2000000121, where the table check returns
immediately.

## RED → GREEN

Microsoft's `Tests-SINGLESERVER` bucket, `Codeunit134614` ("Test App Permissions"), BC
28.1.49838.53910, `--test-data` from `BusinessCentral-W1.bak`, company `CRONUS International
Ltd_`, private `--cache`.

**Before** — `InitializeData()` dies on its first statement block, at
`CODEUNIT.Run(CODEUNIT::"Users - Create Super User")`:

```
NavCSideRecordNotFoundException: The User Property does not exist.
Identification fields and values: User Security ID='{3E1BC30D-249D-4A93-A9A6-9073522B0E68}'
  at UserManagement.DirectSetUserFieldValue -> DirectSetAuthenticationObjectId
  -> NavUserAccountHelper.SetAuthenticationObjectId
```

**After** — that error is gone. `InitializeData()` now runs to completion (users get created,
`Users - Create Super User` succeeds) and the codeunit reaches the test body, where it stops on
a different, unrelated gap:

```
NavCSideRecordNotFoundException: The Aggregate Permission Set does not exist.
Identification fields and values: Scope='System',App ID='{5B06...}',Role ID='TESTSET'
  at Codeunit134614.TestAggregatePermissionSetsTable
```

Test-data hydration reflects the same move: 942 rows in 66 tables before, 1180 rows in 68
tables after — `User Property` is now among the tables the run touches.

The headline pass count for that codeunit is unchanged at 0/15, and deliberately so: #2357 is
the next wall and this PR does not claim to move it. What changed is that the setup every one
of those 15 tests depends on now works.

Verified the two Ncl images differ in exactly the expected way rather than trusting the run:
the shadow used by the "before" run does not contain `CreateUserPropertyOnUserInsert`, the
"after" one does.

## Fix the shape, not just the reported line

1. **Does the same wrong pattern appear at another call site?** No — and this is measured, not
   assumed. Decompiling the shipped `Microsoft.Dynamics.Nav.Ncl.dll` and scanning
   `SystemTableTriggers.OnBeforeInsertAsync` for `CreateObjectInstance` / `InsertAsync` finds
   exactly one row-creating side effect in the whole method, the User one. Every other `case`
   arm validates or sets a field on the buffer in place. `OnAfterInsertAsync` creates no rows
   either — its only `InsertAsync` is the audit-trail helper.
2. **Does a sibling function make the same assumption?** Yes, two:
   `UserManagement.DirectSetAuthenticationObjectId` (User Property field 7) and
   `DirectSetDirectoryRoleIdList` (field 9) both `Get` table 2000000121 with the raising level
   through the same `DirectSetUserFieldValue`. One fix covers both. The other `DirectSet*`
   entry points (`SetAuthenticationEmail`, `SetApplicationId`) read table 2000000120, which
   already exists by construction.
3. **If two code paths write the same state, do they maintain the same invariant?** No, and
   that gap is real: BC's `OnAfterDeleteAsync` cascades a User delete into `User Property`,
   `Access Control`, `User Personalization` and 2000000233, and the runner does none of it. It
   is a separate trigger with a separate hazard — AL's `DeleteAll()` binds to
   `NavRecord.ALDeleteAll(bool)`, which calls the protected `DeleteAllAsync(bool)` directly and
   would slip past an `ALDeleteAsync` prepend — so it is filed as #2356 rather than
   half-implemented here. The patch header says so at the point where a reader would ask.

## Tests

- `AlRunner.Tests/UserPropertyCompanionRowBindingTests.cs` — a runner-mechanism test. The
  prepend is registration-only code with no observable C# call graph, so a regression that
  drops it is invisible everywhere else until an AL suite fails far downstream. The test reads
  the Cecil-rewritten Ncl with Mono.Cecil and asserts the helper is called from
  `NavRecord.ALInsertAsync`'s prepended prefix, that nothing but `ldarg.0`/`call` precedes it
  (so it runs before the original body, as BC's `OnBEFOREInsert` does), and — the negative —
  that `ALModifyAsync` / `ALDeleteAsync` do **not** call it. Proven RED against the previous
  cached rewrite (which is Cecil-rewritten but predates this prepend) and GREEN against the new
  one, so it fails for the right reason, not for "the file was never rewritten": it skips when
  the marker prepend `AssignAutoIncrement` is absent.
- `dotnet test AlRunner.Tests` — full suite, green.

## Why there is no upstream corpus test

The BC-side claim is not safe to assert against the live tier the corpus runs on. Microsoft's
own `Codeunit134302.CleanupData` carries the reason verbatim:

> When we add any user into User table Server switches authentication mode and further tests
> fail with permission error until Server is restarted. Automatic rollback in test isolation
> does not revert Server's authentication mode.

A corpus test that inserts a `User` would poison every test after it on that tier. So the
BC-side claim rests on BC's own shipped IL, quoted in the patch header and above, and the
runner side is pinned by the mechanism test. This is the escape hatch in
`.claude/rules/bc-behavior-tests-go-upstream.md`, taken deliberately and stated rather than
skipped quietly.

## Context: where this came from

Triage of a 20-test cluster in `Tests-SINGLESERVER` that all failed with
`NavNCLEventBindingException: ... has already been bound`. That cluster is a cascade, not a
defect, and the runner is faithful there: BC's `NavTestCodeunit.DoRunAsync` invokes every
`[Test]` method on one test-codeunit instance and does nothing between them to release manual
event bindings, so a test that errors between `BindSubscription(Global)` and
`UnbindSubscription(Global)` leaves the binding held and every later bind correctly raises.
Fixing the earlier error is the only way to clear it. This PR fixes one of those earlier
errors; #2357 and #2352 track the others.
