### PR TITLE
perf(tests): stop loading the Base Application closure in fixtures that never read it

### DIFF
--- a/.claude/rules/no-base-app-in-csharp-tests.md
+++ b/.claude/rules/no-base-app-in-csharp-tests.md
@@ -26,21 +26,30 @@ About 70 seconds cold and 6 seconds warm, per runner invocation. 71 of the 246 f
 `AlRunner.Tests` spawn the runner as a subprocess, and the suite spawns it roughly 130
 times, so this is the single largest cost in the C# suite.
 
-## Two classes still violate this. They are debt, not permission.
+## Four classes still carry the floor. Three are debt; one is legitimate.
 
-`InstallBaselineDiskCacheTests` and `InstallSeedDepCompanyCacheTests` still carry the
-property, because both fail outright without it: what they assert is the dependency
-closure itself, and removing the floor today would leave them green while proving
-nothing, which is worse than leaving them slow.
+**Legitimate, and it stays:** `PlaceholderFloorProvisioningTests`. The placeholder
+`1.0.0.0` application floor IS its subject — remove it and nothing is being tested.
 
-**Tracked in #2364.** They are on the list to be reworked, not a precedent to cite. Do
-not add a third. When #2364 lands, this section goes away.
+**Outstanding violations, tracked in #2364, not permission:**
 
-The bar for any claim that a test cannot follow this rule: not "this is easier to write
-with Base App", but "this test's claim is about the Base Application closure, and there
-is no other way to construct the state it needs." Two small source-dependency apps
-produce genuinely different closures; a fixture table seeded by its own install trigger
-produces seeded company data. Reach for those first.
+- `InstallBaselineDiskCacheTests` and `InstallSeedDepCompanyCacheTests` — they test #1867
+  install-baseline caching, and need a closure whose install triggers WRITE ROWS. Without
+  one the runner logs `not persisting: snapshot has 0 DataAccessSource(s)` and the
+  assertions have nothing to observe, so they would pass vacuously.
+- `MissingTestDataDiagnosisTests` — resolves "Source Code Setup" (table 242) against real
+  metadata, asserting BC's own table id so the diagnosis cannot pass by echoing a name back.
+
+None is a precedent to cite. Do not add a fifth. When #2364 lands, this section shrinks to
+the one legitimate case.
+
+**How these four were identified, and how they were nearly missed.** The property was
+removed from all 49 classes and the full suite run. A *partial* local run reported three
+classes; reading it before it finished produced a wrong list, and CI — running to completion
+on all eight legs — found five failures in two further classes. **Do not conclude a set of
+failures from a run that has not finished.** The bar for adding to this list is a completed
+run showing the class fails without the floor, not a reading of what the test looks like it
+needs.
 
 ## Sister rules
 

--- a/.claude/rules/no-base-app-in-csharp-tests.md
+++ b/.claude/rules/no-base-app-in-csharp-tests.md
@@ -1,0 +1,49 @@
+# C# test fixtures may declare `platform`, never `application`
+
+A fixture `app.json` written by a test in `AlRunner.Tests` must **not** carry an
+`"application"` property. `"platform"` is fine and stays.
+
+There are no exceptions. If a test appears to need Base Application objects —
+`Customer`, `Item`, `Company Information`, `No. Series` and the like — the answer is to
+find another way to assert what it is asserting, not to add the floor back.
+
+In Business Central, `"application"` is the Base Application dependency. It is not
+declared through the `dependencies` array, which is why this is easy to add without
+noticing what it pulls in: the whole Base Application closure, loaded on every runner
+invocation.
+
+## What it costs
+
+Measured on two bundles identical except for that one line, same runner build, same
+machine, both discovering and passing one test:
+
+| | cold wall | warm wall | test-execution phase (warm) |
+|---|---|---|---|
+| with `"application"` | 94.9s | 9.6-13.4s | 2.7-2.9s |
+| without | 25.2s | 4.3s | 0.1s |
+
+About 70 seconds cold and 6 seconds warm, per runner invocation. 71 of the 246 files in
+`AlRunner.Tests` spawn the runner as a subprocess, and the suite spawns it roughly 130
+times, so this is the single largest cost in the C# suite.
+
+## Two classes still violate this. They are debt, not permission.
+
+`InstallBaselineDiskCacheTests` and `InstallSeedDepCompanyCacheTests` still carry the
+property, because both fail outright without it: what they assert is the dependency
+closure itself, and removing the floor today would leave them green while proving
+nothing, which is worse than leaving them slow.
+
+**Tracked in #2364.** They are on the list to be reworked, not a precedent to cite. Do
+not add a third. When #2364 lands, this section goes away.
+
+The bar for any claim that a test cannot follow this rule: not "this is easier to write
+with Base App", but "this test's claim is about the Base Application closure, and there
+is no other way to construct the state it needs." Two small source-dependency apps
+produce genuinely different closures; a fixture table seeded by its own install trigger
+produces seeded company data. Reach for those first.
+
+## Sister rules
+
+- `.claude/rules/tdd.md` — a test that passes without proving anything is the failure
+  mode this rule must not create while chasing speed
+- `.claude/rules/local-test-scope.md` — run targeted tests locally; CI runs the sweep

--- a/AlRunner.Tests/AlPerTestCoverageTests.cs
+++ b/AlRunner.Tests/AlPerTestCoverageTests.cs
@@ -47,7 +47,6 @@ public class AlPerTestCoverageTests : IClassFixture<SharedCliServer>
           "version": "1.0.0.0",
           "dependencies": [],
           "platform": "1.0.0.0",
-          "application": "1.0.0.0",
           "idRanges": [ { "from": 60200, "to": 60209 } ],
           "runtime": "14.0"
         }

--- a/AlRunner.Tests/AlStatementTableTests.cs
+++ b/AlRunner.Tests/AlStatementTableTests.cs
@@ -53,7 +53,6 @@ public class AlStatementTableTests : IClassFixture<SharedCliServer>
           "version": "1.0.0.0",
           "dependencies": [],
           "platform": "1.0.0.0",
-          "application": "1.0.0.0",
           "idRanges": [ { "from": 60190, "to": 60199 } ],
           "runtime": "14.0"
         }

--- a/AlRunner.Tests/AppIdCollisionLoudFailureTests.cs
+++ b/AlRunner.Tests/AppIdCollisionLoudFailureTests.cs
@@ -88,7 +88,6 @@ public class AppIdCollisionLoudFailureTests
           "version": "1.0.0.0",
           "dependencies": [],
           "platform": "1.0.0.0",
-          "application": "1.0.0.0",
           "idRanges": [ { "from": 61880, "to": 61889 } ],
           "runtime": "14.0"
         }
@@ -115,7 +114,6 @@ public class AppIdCollisionLoudFailureTests
           "version": "1.0.0.0",
           "dependencies": [],
           "platform": "1.0.0.0",
-          "application": "1.0.0.0",
           "idRanges": [ { "from": 61890, "to": 61899 } ],
           "runtime": "14.0"
         }

--- a/AlRunner.Tests/BatchAppIdentityTests.cs
+++ b/AlRunner.Tests/BatchAppIdentityTests.cs
@@ -66,7 +66,6 @@ public sealed class BatchAppIdentityTests : IDisposable
           "version": "{{version}}",
           "dependencies": [],
           "platform": "1.0.0.0",
-          "application": "1.0.0.0",
           "idRanges": [ { "from": {{baseId}}, "to": {{baseId + 9}} } ],
           "runtime": "14.0"
         }

--- a/AlRunner.Tests/BundleRootDeduplicationTests.cs
+++ b/AlRunner.Tests/BundleRootDeduplicationTests.cs
@@ -170,7 +170,7 @@ public sealed class BundleRootDeduplicationTests : IDisposable
         const string manifest = """
         { "id": "a1b2c3d4-2136-4a1b-9c3d-000000000001", "name": "Dup 2136",
           "publisher": "Repro2136", "version": "1.0.0.0", "dependencies": [],
-          "platform": "1.0.0.0", "application": "1.0.0.0",
+          "platform": "1.0.0.0",
           "idRanges": [ { "from": 62430, "to": 62439 } ], "runtime": "14.0" }
         """;
         var a = MakeDir("copy-a");

--- a/AlRunner.Tests/CacheRootsIsolationTests.cs
+++ b/AlRunner.Tests/CacheRootsIsolationTests.cs
@@ -100,7 +100,6 @@ public class CacheRootsIsolationTests
           "version": "1.0.0.0",
           "dependencies": [],
           "platform": "1.0.0.0",
-          "application": "1.0.0.0",
           "idRanges": [ { "from": 61920, "to": 61929 } ],
           "runtime": "14.0"
         }
@@ -125,7 +124,6 @@ public class CacheRootsIsolationTests
             { "id": "{{depId}}", "name": "Repro1821 Dep App", "publisher": "Repro1821", "version": "1.0.0.0" }
           ],
           "platform": "1.0.0.0",
-          "application": "1.0.0.0",
           "idRanges": [ { "from": 61930, "to": 61939 } ],
           "runtime": "14.0"
         }

--- a/AlRunner.Tests/CountBaselineIntegrationTests.cs
+++ b/AlRunner.Tests/CountBaselineIntegrationTests.cs
@@ -74,7 +74,6 @@ public sealed class CountBaselineIntegrationTests : IDisposable
           "version": "1.0.0.0",
           "dependencies": [],
           "platform": "1.0.0.0",
-          "application": "1.0.0.0",
           "idRanges": [ { "from": 62200, "to": 62209 } ],
           "runtime": "14.0"
         }

--- a/AlRunner.Tests/CrossBundleModuleIdentityDedupTests.cs
+++ b/AlRunner.Tests/CrossBundleModuleIdentityDedupTests.cs
@@ -78,7 +78,6 @@ public class CrossBundleModuleIdentityDedupTests
           "version": "1.0.0.0",
           "dependencies": [],
           "platform": "1.0.0.0",
-          "application": "1.0.0.0",
           "idRanges": [ { "from": 61860, "to": 61869 } ],
           "runtime": "14.0"
         }
@@ -130,7 +129,6 @@ public class CrossBundleModuleIdentityDedupTests
             { "id": "{{depId}}", "name": "TE Dep App 1683", "publisher": "Repro1683", "version": "1.0.0.0" }
           ],
           "platform": "1.0.0.0",
-          "application": "1.0.0.0",
           "idRanges": [ { "from": 61870, "to": 61879 } ],
           "runtime": "14.0"
         }

--- a/AlRunner.Tests/DefineFlagIntegrationTests.cs
+++ b/AlRunner.Tests/DefineFlagIntegrationTests.cs
@@ -97,7 +97,6 @@ public sealed class DefineFlagIntegrationTests : IDisposable
           "version": "1.0.0.0",
           "dependencies": [],
           "platform": "1.0.0.0",
-          "application": "1.0.0.0",
           "idRanges": [ { "from": 62100, "to": 62119 } ],
           "runtime": "14.0"
         }

--- a/AlRunner.Tests/InstallBaselineDiskCacheTests.cs
+++ b/AlRunner.Tests/InstallBaselineDiskCacheTests.cs
@@ -43,6 +43,20 @@ namespace AlRunner.Tests;
 ///
 /// Spawns the real runner; needs the BC artifact cache. Skips (no-op) when absent.
 /// </summary>
+/// <para>
+/// <b>#2364 — the <c>"application"</c> floor in this file's fixtures is an OUTSTANDING
+/// VIOLATION of <c>.claude/rules/no-base-app-in-csharp-tests.md</c>, not an exception to
+/// it.</b> Every other fixture in <c>AlRunner.Tests</c> dropped it (#2358): it pulls in the
+/// whole Base Application closure and costs ~70s cold / ~6s warm per runner invocation.
+/// </para>
+/// <para>
+/// This class does not test Base Application — it tests #1867 install-baseline caching. It
+/// needs a dependency closure whose install triggers WRITE ROWS; without one the runner logs
+/// <c>not persisting: snapshot has 0 DataAccessSource(s)</c> and the assertions have nothing
+/// to observe, so the tests would pass vacuously. The fix is a small fixture dependency app
+/// with its own table and an <c>OnInstallAppPerCompany</c> trigger, tracked in #2364.
+/// Do not copy this floor into a new test.
+/// </para>
 public class InstallBaselineDiskCacheTests
 {
     private static readonly string RepoRoot = Path.GetFullPath(
@@ -103,21 +117,6 @@ public class InstallBaselineDiskCacheTests
           "version": "1.0.0.0",
           "dependencies": [],
           "platform": "1.0.0.0",
-          // KEEP the "application" floor here. Every other fixture in AlRunner.Tests
-          // dropped it (#2358): it pulls in the whole Base Application closure and
-          // costs ~70s cold / ~6s warm per runner invocation. This class is one of
-          // the two exceptions, because what it asserts IS the dependency closure --
-          // remove the floor and the closures under test become trivial, so the test
-          // still goes green while proving nothing. Measured: removing it fails this
-          // class outright.
-          // #2364 -- this "application" floor is an OUTSTANDING VIOLATION of
-          // .claude/rules/no-base-app-in-csharp-tests.md, not an exception to it.
-          // This class does not test Base Application; it tests #1867 install-baseline
-          // caching. It needs a closure whose install triggers WRITE ROWS -- without one
-          // the runner logs "not persisting: snapshot has 0 DataAccessSource(s)" and there
-          // is nothing for the assertions to observe. The fix is a small fixture dependency
-          // app with its own table and OnInstallAppPerCompany trigger, tracked in #2364.
-          // Do not copy this floor into a new test.
           "application": "1.0.0.0",
           "idRanges": [ { "from": {{baseId}}, "to": {{baseId + 4}} } ],
           "runtime": "14.0"

--- a/AlRunner.Tests/InstallBaselineDiskCacheTests.cs
+++ b/AlRunner.Tests/InstallBaselineDiskCacheTests.cs
@@ -103,6 +103,21 @@ public class InstallBaselineDiskCacheTests
           "version": "1.0.0.0",
           "dependencies": [],
           "platform": "1.0.0.0",
+          // KEEP the "application" floor here. Every other fixture in AlRunner.Tests
+          // dropped it (#2358): it pulls in the whole Base Application closure and
+          // costs ~70s cold / ~6s warm per runner invocation. This class is one of
+          // the two exceptions, because what it asserts IS the dependency closure --
+          // remove the floor and the closures under test become trivial, so the test
+          // still goes green while proving nothing. Measured: removing it fails this
+          // class outright.
+          // #2364 -- this "application" floor is an OUTSTANDING VIOLATION of
+          // .claude/rules/no-base-app-in-csharp-tests.md, not an exception to it.
+          // This class does not test Base Application; it tests #1867 install-baseline
+          // caching. It needs a closure whose install triggers WRITE ROWS -- without one
+          // the runner logs "not persisting: snapshot has 0 DataAccessSource(s)" and there
+          // is nothing for the assertions to observe. The fix is a small fixture dependency
+          // app with its own table and OnInstallAppPerCompany trigger, tracked in #2364.
+          // Do not copy this floor into a new test.
           "application": "1.0.0.0",
           "idRanges": [ { "from": {{baseId}}, "to": {{baseId + 4}} } ],
           "runtime": "14.0"

--- a/AlRunner.Tests/InstallBaselineVirtualTableExclusionTests.cs
+++ b/AlRunner.Tests/InstallBaselineVirtualTableExclusionTests.cs
@@ -131,7 +131,6 @@ public class InstallBaselineVirtualTableExclusionTests
           "version": "1.0.0.0",
           "dependencies": [],
           "platform": "1.0.0.0",
-          "application": "1.0.0.0",
           "idRanges": [ { "from": {{baseId}}, "to": {{baseId + 19}} } ],
           "runtime": "14.0"
         }

--- a/AlRunner.Tests/InstallSeedDepCompanyCacheTests.cs
+++ b/AlRunner.Tests/InstallSeedDepCompanyCacheTests.cs
@@ -83,6 +83,21 @@ public class InstallSeedDepCompanyCacheTests
           "version": "1.0.0.0",
           "dependencies": [],
           "platform": "1.0.0.0",
+          // KEEP the "application" floor here. Every other fixture in AlRunner.Tests
+          // dropped it (#2358): it pulls in the whole Base Application closure and
+          // costs ~70s cold / ~6s warm per runner invocation. This class is one of
+          // the two exceptions, because what it asserts IS the dependency closure --
+          // remove the floor and the closures under test become trivial, so the test
+          // still goes green while proving nothing. Measured: removing it fails this
+          // class outright.
+          // #2364 -- this "application" floor is an OUTSTANDING VIOLATION of
+          // .claude/rules/no-base-app-in-csharp-tests.md, not an exception to it.
+          // This class does not test Base Application; it tests #1867 install-baseline
+          // caching. It needs a closure whose install triggers WRITE ROWS -- without one
+          // the runner logs "not persisting: snapshot has 0 DataAccessSource(s)" and there
+          // is nothing for the assertions to observe. The fix is a small fixture dependency
+          // app with its own table and OnInstallAppPerCompany trigger, tracked in #2364.
+          // Do not copy this floor into a new test.
           "application": "1.0.0.0",
           "idRanges": [ { "from": {{baseId}}, "to": {{baseId + 9}} } ],
           "runtime": "14.0"

--- a/AlRunner.Tests/InstallSeedDepCompanyCacheTests.cs
+++ b/AlRunner.Tests/InstallSeedDepCompanyCacheTests.cs
@@ -32,6 +32,20 @@ namespace AlRunner.Tests;
 ///
 /// Spawns the real runner; needs the BC artifact cache. Skips (no-op) when absent.
 /// </summary>
+/// <para>
+/// <b>#2364 — the <c>"application"</c> floor in this file's fixtures is an OUTSTANDING
+/// VIOLATION of <c>.claude/rules/no-base-app-in-csharp-tests.md</c>, not an exception to
+/// it.</b> Every other fixture in <c>AlRunner.Tests</c> dropped it (#2358): it pulls in the
+/// whole Base Application closure and costs ~70s cold / ~6s warm per runner invocation.
+/// </para>
+/// <para>
+/// This class does not test Base Application — it tests #1867 install-baseline caching. It
+/// needs a dependency closure whose install triggers WRITE ROWS; without one the runner logs
+/// <c>not persisting: snapshot has 0 DataAccessSource(s)</c> and the assertions have nothing
+/// to observe, so the tests would pass vacuously. The fix is a small fixture dependency app
+/// with its own table and an <c>OnInstallAppPerCompany</c> trigger, tracked in #2364.
+/// Do not copy this floor into a new test.
+/// </para>
 public class InstallSeedDepCompanyCacheTests
 {
     private static readonly string RepoRoot = Path.GetFullPath(
@@ -83,21 +97,6 @@ public class InstallSeedDepCompanyCacheTests
           "version": "1.0.0.0",
           "dependencies": [],
           "platform": "1.0.0.0",
-          // KEEP the "application" floor here. Every other fixture in AlRunner.Tests
-          // dropped it (#2358): it pulls in the whole Base Application closure and
-          // costs ~70s cold / ~6s warm per runner invocation. This class is one of
-          // the two exceptions, because what it asserts IS the dependency closure --
-          // remove the floor and the closures under test become trivial, so the test
-          // still goes green while proving nothing. Measured: removing it fails this
-          // class outright.
-          // #2364 -- this "application" floor is an OUTSTANDING VIOLATION of
-          // .claude/rules/no-base-app-in-csharp-tests.md, not an exception to it.
-          // This class does not test Base Application; it tests #1867 install-baseline
-          // caching. It needs a closure whose install triggers WRITE ROWS -- without one
-          // the runner logs "not persisting: snapshot has 0 DataAccessSource(s)" and there
-          // is nothing for the assertions to observe. The fix is a small fixture dependency
-          // app with its own table and OnInstallAppPerCompany trigger, tracked in #2364.
-          // Do not copy this floor into a new test.
           "application": "1.0.0.0",
           "idRanges": [ { "from": {{baseId}}, "to": {{baseId + 9}} } ],
           "runtime": "14.0"

--- a/AlRunner.Tests/LayeredCacheTests.cs
+++ b/AlRunner.Tests/LayeredCacheTests.cs
@@ -42,7 +42,6 @@ public class LayeredCacheTests
           "version": "1.0.0.0",
           "dependencies": [{{dependsOnJson ?? ""}}],
           "platform": "1.0.0.0",
-          "application": "1.0.0.0",
           "idRanges": [ { "from": {{idFrom}}, "to": {{idFrom + 9}} } ],
           "runtime": "14.0"
         }

--- a/AlRunner.Tests/LayeredDepManifestTests.cs
+++ b/AlRunner.Tests/LayeredDepManifestTests.cs
@@ -74,7 +74,6 @@ public class LayeredDepManifestTests
           "version": "1.0.0.0",{{helpUrlLine}}
           "dependencies": [],
           "platform": "1.0.0.0",
-          "application": "1.0.0.0",
           "idRanges": [ { "from": {{idFrom}}, "to": {{idFrom + 19}} } ],
           "runtime": "14.0"
         }
@@ -124,7 +123,6 @@ public class LayeredDepManifestTests
             { "id": "{{depId}}", "name": "{{depName}}", "publisher": "AL Runner", "version": "1.0.0.0" }
           ],
           "platform": "1.0.0.0",
-          "application": "1.0.0.0",
           "idRanges": [ { "from": {{idFrom}}, "to": {{idFrom + 19}} } ],
           "runtime": "14.0"
         }

--- a/AlRunner.Tests/LayeredSourceChainTests.cs
+++ b/AlRunner.Tests/LayeredSourceChainTests.cs
@@ -59,7 +59,6 @@ public class LayeredSourceChainTests
           "version": "1.0.0.0",
           "dependencies": [],
           "platform": "1.0.0.0",
-          "application": "1.0.0.0",
           "idRanges": [ { "from": 60050, "to": 60059 } ],
           "runtime": "14.0"
         }
@@ -109,7 +108,6 @@ public class LayeredSourceChainTests
             { "id": "{{baseId}}", "name": "LSC Chain Base", "publisher": "AL Runner", "version": "1.0.0.0" }
           ],
           "platform": "1.0.0.0",
-          "application": "1.0.0.0",
           "idRanges": [ { "from": 60060, "to": 60069 } ],
           "runtime": "14.0"
         }
@@ -164,7 +162,6 @@ public class LayeredSourceChainTests
             { "id": "{{middleId}}", "name": "LSC Chain Middle", "publisher": "AL Runner", "version": "1.0.0.0" }
           ],
           "platform": "1.0.0.0",
-          "application": "1.0.0.0",
           "idRanges": [ { "from": 60070, "to": 60079 } ],
           "runtime": "14.0"
         }

--- a/AlRunner.Tests/ManifestCompilerInputsTests.cs
+++ b/AlRunner.Tests/ManifestCompilerInputsTests.cs
@@ -68,7 +68,6 @@ public sealed class ManifestCompilerInputsTests : IDisposable
           "version": "1.0.0.0",
           "dependencies": [],
           "platform": "28.0.0.0",
-          "application": "28.1.0.0",
           "idRanges": [ { "from": 61050, "to": 61079 } ],
           "runtime": "17.0"{{extraProps}}
         }

--- a/AlRunner.Tests/ManifestFeaturesSubprocessTests.cs
+++ b/AlRunner.Tests/ManifestFeaturesSubprocessTests.cs
@@ -116,7 +116,6 @@ public sealed class ManifestFeaturesSubprocessTests : IDisposable
           "version": "1.0.0.0",
           "dependencies": [],
           "platform": "1.0.0.0",
-          "application": "1.0.0.0",
           "idRanges": [ { "from": {{Math.Min(tableId, pageId)}}, "to": {{Math.Max(tableId, pageId) + 5}} } ],
           "runtime": "17.0"{{featuresLine}}
         }
@@ -224,7 +223,6 @@ public sealed class ManifestFeaturesSubprocessTests : IDisposable
             { "id": "{{depId}}", "name": "{{depName}}", "publisher": "AL Runner", "version": "1.0.0.0" }
           ],
           "platform": "1.0.0.0",
-          "application": "1.0.0.0",
           "idRanges": [ { "from": {{idFrom}}, "to": {{idFrom + 9}} } ],
           "runtime": "17.0"
         }

--- a/AlRunner.Tests/MissingTestDataDiagnosisTests.cs
+++ b/AlRunner.Tests/MissingTestDataDiagnosisTests.cs
@@ -26,6 +26,13 @@ using Xunit;
 
 namespace AlRunner.Tests;
 
+// #2364 -- the "application" floor in this file's fixtures is an OUTSTANDING VIOLATION of
+// .claude/rules/no-base-app-in-csharp-tests.md, not an exception to it. Every other fixture
+// dropped it (#2358). These tests keep it only because they resolve "Source Code Setup"
+// (table 242) against REAL metadata -- the assertion is on BC's own table id precisely so
+// the diagnosis cannot pass by echoing a name back out of the message. A fixture table
+// carrying its own metadata would serve the same claim without the closure; until someone
+// does that, this stays and is tracked in #2364. Do not copy this floor into a new test.
 public sealed class MissingTestDataDiagnosisTests : IDisposable
 {
     private static readonly string RepoRoot = Path.GetFullPath(
@@ -77,6 +84,7 @@ public sealed class MissingTestDataDiagnosisTests : IDisposable
           "version": "1.0.0.0",
           "dependencies": [],
           "platform": "27.0.0.0",
+          "application": "27.0.0.0",
           "idRanges": [ { "from": 62440, "to": 62449 } ],
           "runtime": "17.0",
           "target": "Cloud"

--- a/AlRunner.Tests/MissingTestDataDiagnosisTests.cs
+++ b/AlRunner.Tests/MissingTestDataDiagnosisTests.cs
@@ -77,7 +77,6 @@ public sealed class MissingTestDataDiagnosisTests : IDisposable
           "version": "1.0.0.0",
           "dependencies": [],
           "platform": "27.0.0.0",
-          "application": "27.0.0.0",
           "idRanges": [ { "from": 62440, "to": 62449 } ],
           "runtime": "17.0",
           "target": "Cloud"

--- a/AlRunner.Tests/NumberSequenceServerResetTests.cs
+++ b/AlRunner.Tests/NumberSequenceServerResetTests.cs
@@ -44,7 +44,6 @@ public sealed class NumberSequenceServerResetTests
           "version": "1.0.0.0",
           "dependencies": [],
           "platform": "1.0.0.0",
-          "application": "1.0.0.0",
           "idRanges": [ { "from": 64590, "to": 64590 } ],
           "runtime": "14.0"
         }

--- a/AlRunner.Tests/OutputFormatTests.cs
+++ b/AlRunner.Tests/OutputFormatTests.cs
@@ -49,7 +49,6 @@ public sealed class OutputFormatTests : IDisposable
           "publisher": "Scratch",
           "version": "1.0.0.0",
           "platform": "1.0.0.0",
-          "application": "1.0.0.0",
           "idRanges": [{ "from": 50910, "to": 50919 }],
           "runtime": "8.0"
         }

--- a/AlRunner.Tests/PerSuiteAlDiagnosticFailureTests.cs
+++ b/AlRunner.Tests/PerSuiteAlDiagnosticFailureTests.cs
@@ -62,7 +62,6 @@ public class PerSuiteAlDiagnosticFailureTests
           "version": "1.0.0.0",
           "dependencies": [],
           "platform": "1.0.0.0",
-          "application": "1.0.0.0",
           "idRanges": [ { "from": 62210, "to": 62219 } ],
           "runtime": "14.0"
         }

--- a/AlRunner.Tests/PhaseLogIntegrationTests.cs
+++ b/AlRunner.Tests/PhaseLogIntegrationTests.cs
@@ -65,7 +65,6 @@ public sealed class PhaseLogIntegrationTests : IDisposable
         var roots = platformRoots
             ? """
                 "platform": "1.0.0.0",
-                "application": "1.0.0.0",
               """
             : "";
         File.WriteAllText(Path.Combine(dir, "app.json"), $$"""

--- a/AlRunner.Tests/PlaceholderFloorProvisioningTests.cs
+++ b/AlRunner.Tests/PlaceholderFloorProvisioningTests.cs
@@ -51,6 +51,12 @@ using Xunit;
 
 namespace AlRunner.Tests;
 
+// The "application" floor in this file's fixtures is DELIBERATE and must stay.
+// Every other fixture in AlRunner.Tests dropped it (#2358) because it pulls in the whole
+// Base Application closure for nothing -- ~70s cold / ~6s warm per runner invocation.
+// Here the placeholder floor IS the subject of the test: remove it and there is nothing
+// left being tested. This is not a violation of
+// .claude/rules/no-base-app-in-csharp-tests.md; it is the case that rule carves out.
 public sealed class PlaceholderFloorProvisioningTests
 {
     private static readonly string RepoRoot = Path.GetFullPath(
@@ -88,6 +94,7 @@ public sealed class PlaceholderFloorProvisioningTests
           "dependencies": [],
           "idRanges": [ { "from": 61970, "to": 61979 } ],
           "platform": "1.0.0.0",
+          "application": "1.0.0.0",
           "runtime": "14.0"
         }
         """);

--- a/AlRunner.Tests/PlaceholderFloorProvisioningTests.cs
+++ b/AlRunner.Tests/PlaceholderFloorProvisioningTests.cs
@@ -88,7 +88,6 @@ public sealed class PlaceholderFloorProvisioningTests
           "dependencies": [],
           "idRanges": [ { "from": 61970, "to": 61979 } ],
           "platform": "1.0.0.0",
-          "application": "1.0.0.0",
           "runtime": "14.0"
         }
         """);

--- a/AlRunner.Tests/QueryAggregationProjectionTests.cs
+++ b/AlRunner.Tests/QueryAggregationProjectionTests.cs
@@ -73,7 +73,6 @@ public class QueryAggregationProjectionTests
           "version": "1.0.0.0",
           "dependencies": [],
           "platform": "1.0.0.0",
-          "application": "1.0.0.0",
           "idRanges": [ { "from": 61890, "to": 61899 } ],
           "runtime": "14.0"
         }

--- a/AlRunner.Tests/QueryColumnAlDiagnosticFailureTests.cs
+++ b/AlRunner.Tests/QueryColumnAlDiagnosticFailureTests.cs
@@ -76,7 +76,6 @@ public class QueryColumnAlDiagnosticFailureTests
           "version": "1.0.0.0",
           "dependencies": [],
           "platform": "1.0.0.0",
-          "application": "1.0.0.0",
           "idRanges": [ { "from": 62200, "to": 62209 } ],
           "runtime": "14.0"
         }

--- a/AlRunner.Tests/QueryHavingAndJoinAggregationProjectionTests.cs
+++ b/AlRunner.Tests/QueryHavingAndJoinAggregationProjectionTests.cs
@@ -89,7 +89,6 @@ public class QueryHavingAndJoinAggregationProjectionTests
           "version": "1.0.0.0",
           "dependencies": [],
           "platform": "1.0.0.0",
-          "application": "1.0.0.0",
           "idRanges": [ { "from": 61900, "to": 61930 } ],
           "runtime": "14.0"
         }

--- a/AlRunner.Tests/ReportLayoutFileResolutionTests.cs
+++ b/AlRunner.Tests/ReportLayoutFileResolutionTests.cs
@@ -75,7 +75,6 @@ public class ReportLayoutFileResolutionTests
           "version": "1.0.0.0",
           "dependencies": [],
           "platform": "1.0.0.0",
-          "application": "1.0.0.0",
           "idRanges": [ { "from": {{baseId}}, "to": {{baseId + 9}} } ],
           "runtime": "14.0"
         }

--- a/AlRunner.Tests/ServerAlDiagnosticFailureTests.cs
+++ b/AlRunner.Tests/ServerAlDiagnosticFailureTests.cs
@@ -29,7 +29,6 @@ public sealed class ServerAlDiagnosticFailureTests
           "version": "1.0.0.0",
           "dependencies": [],
           "platform": "1.0.0.0",
-          "application": "1.0.0.0",
           "idRanges": [ { "from": 62220, "to": 62229 } ],
           "runtime": "14.0"
         }

--- a/AlRunner.Tests/ServerCancelTests.cs
+++ b/AlRunner.Tests/ServerCancelTests.cs
@@ -87,7 +87,6 @@ public class ServerCancelTests : IClassFixture<SharedCliServer>
           "version": "1.0.0.0",
           "dependencies": [],
           "platform": "1.0.0.0",
-          "application": "1.0.0.0",
           "idRanges": [ { "from": {{baseId}}, "to": {{baseId + 9}} } ],
           "runtime": "14.0"
         }
@@ -141,7 +140,6 @@ public class ServerCancelTests : IClassFixture<SharedCliServer>
           "version": "1.0.0.0",
           "dependencies": [],
           "platform": "1.0.0.0",
-          "application": "1.0.0.0",
           "idRanges": [ { "from": 60320, "to": 60329 } ],
           "runtime": "14.0"
         }

--- a/AlRunner.Tests/ServerCrossAppStaleGenerationTests.cs
+++ b/AlRunner.Tests/ServerCrossAppStaleGenerationTests.cs
@@ -78,7 +78,6 @@ public class ServerCrossAppStaleGenerationTests
           "dependencies": [],
           "idRanges": [ { "from": 60960, "to": 60969 } ],
           "platform": "1.0.0.0",
-          "application": "1.0.0.0",
           "runtime": "14.0"
         }
         """);
@@ -127,7 +126,6 @@ public class ServerCrossAppStaleGenerationTests
           ],
           "idRanges": [ { "from": 60970, "to": 60979 } ],
           "platform": "1.0.0.0",
-          "application": "1.0.0.0",
           "runtime": "14.0"
         }
         """);

--- a/AlRunner.Tests/ServerCrossBundleModuleIdentityDedupTests.cs
+++ b/AlRunner.Tests/ServerCrossBundleModuleIdentityDedupTests.cs
@@ -58,7 +58,6 @@ public class ServerCrossBundleModuleIdentityDedupTests
           "version": "1.0.0.0",
           "dependencies": [],
           "platform": "1.0.0.0",
-          "application": "1.0.0.0",
           "idRanges": [ { "from": 61990, "to": 61999 } ],
           "runtime": "14.0"
         }
@@ -122,7 +121,6 @@ public class ServerCrossBundleModuleIdentityDedupTests
             { "id": "{{appId}}", "name": "SX1892 Repro App", "publisher": "Repro1892", "version": "1.0.0.0" }
           ],
           "platform": "1.0.0.0",
-          "application": "1.0.0.0",
           "idRanges": [ { "from": 62050, "to": 62059 } ],
           "runtime": "14.0"
         }

--- a/AlRunner.Tests/ServerDuplicateSourcePathTests.cs
+++ b/AlRunner.Tests/ServerDuplicateSourcePathTests.cs
@@ -37,7 +37,6 @@ public class ServerDuplicateSourcePathTests
           "version": "1.0.0.0",
           "dependencies": [],
           "platform": "1.0.0.0",
-          "application": "1.0.0.0",
           "idRanges": [ { "from": {{idFrom}}, "to": {{idFrom + 4}} } ],
           "runtime": "14.0"
         }

--- a/AlRunner.Tests/ServerEmitExclusionDiagnosticTests.cs
+++ b/AlRunner.Tests/ServerEmitExclusionDiagnosticTests.cs
@@ -30,7 +30,6 @@ public sealed class ServerEmitExclusionDiagnosticTests
           "version": "1.0.0.0",
           "dependencies": [],
           "platform": "1.0.0.0",
-          "application": "1.0.0.0",
           "idRanges": [ { "from": 62230, "to": 62239 } ],
           "runtime": "14.0"
         }

--- a/AlRunner.Tests/ServerExecuteMessagesTests.cs
+++ b/AlRunner.Tests/ServerExecuteMessagesTests.cs
@@ -169,7 +169,6 @@ public class ServerExecuteMessagesTests : IClassFixture<SharedCliServer>
           "version": "1.0.0.0",
           "dependencies": [],
           "platform": "1.0.0.0",
-          "application": "1.0.0.0",
           "idRanges": [ { "from": 60202, "to": 60202 } ],
           "runtime": "14.0"
         }

--- a/AlRunner.Tests/ServerStreamingTests.cs
+++ b/AlRunner.Tests/ServerStreamingTests.cs
@@ -54,7 +54,6 @@ public class ServerStreamingTests : IClassFixture<SharedCliServer>
           "version": "1.0.0.0",
           "dependencies": [],
           "platform": "1.0.0.0",
-          "application": "1.0.0.0",
           "idRanges": [ { "from": {{baseId}}, "to": {{baseId + 9}} } ],
           "runtime": "14.0"
         }

--- a/AlRunner.Tests/ServerTestIsolationTests.cs
+++ b/AlRunner.Tests/ServerTestIsolationTests.cs
@@ -63,7 +63,6 @@ public class ServerTestIsolationTests : IClassFixture<SharedCliServer>
           "version": "1.0.0.0",
           "dependencies": [],
           "platform": "1.0.0.0",
-          "application": "1.0.0.0",
           "idRanges": [ { "from": {{baseId}}, "to": {{baseId + 9}} } ],
           "runtime": "14.0"
         }

--- a/AlRunner.Tests/ServerTests.cs
+++ b/AlRunner.Tests/ServerTests.cs
@@ -148,7 +148,6 @@ public class ServerTests : IClassFixture<SharedCliServer>
           "version": "1.0.0.0",
           "dependencies": [],
           "platform": "1.0.0.0",
-          "application": "1.0.0.0",
           "idRanges": [ { "from": 60120, "to": 60129 } ],
           "runtime": "14.0"
         }
@@ -551,7 +550,6 @@ public class ServerTests : IClassFixture<SharedCliServer>
           "version": "1.0.0.0",
           "dependencies": [],
           "platform": "1.0.0.0",
-          "application": "1.0.0.0",
           "idRanges": [ { "from": 60350, "to": 60359 } ],
           "runtime": "14.0"
         }
@@ -576,7 +574,6 @@ public class ServerTests : IClassFixture<SharedCliServer>
             { "id": "{{appId}}", "name": "Runner Extras - Server Multi App", "publisher": "AL Runner", "version": "1.0.0.0" }
           ],
           "platform": "1.0.0.0",
-          "application": "1.0.0.0",
           "idRanges": [ { "from": 60160, "to": 60169 } ],
           "runtime": "14.0"
         }

--- a/AlRunner.Tests/SharedCliServerTests.cs
+++ b/AlRunner.Tests/SharedCliServerTests.cs
@@ -59,7 +59,6 @@ public class SharedCliServerTests
           "version": "1.0.0.0",
           "dependencies": [],
           "platform": "1.0.0.0",
-          "application": "1.0.0.0",
           "idRanges": [ { "from": 60400, "to": 60409 } ],
           "runtime": "14.0"
         }

--- a/AlRunner.Tests/SiblingSourceDepProvisioningReportingTests.cs
+++ b/AlRunner.Tests/SiblingSourceDepProvisioningReportingTests.cs
@@ -73,7 +73,6 @@ public class SiblingSourceDepProvisioningReportingTests
             { "id": "{{sidekickId}}", "name": "SSD Sidekick", "publisher": "AL Runner", "version": "1.0.0.0" }
           ],
           "platform": "1.0.0.0",
-          "application": "1.0.0.0",
           "idRanges": [ { "from": {{idFrom}}, "to": {{idFrom + 19}} } ],
           "runtime": "14.0"
         }
@@ -112,7 +111,6 @@ public class SiblingSourceDepProvisioningReportingTests
             { "id": "{{thirdPartyId}}", "name": "Acme Add-On", "publisher": "Acme Corp", "version": "{{thirdPartyMinVersion}}" }
           ],
           "platform": "1.0.0.0",
-          "application": "1.0.0.0",
           "idRanges": [ { "from": {{idFrom}}, "to": {{idFrom + 19}} } ],
           "runtime": "14.0"
         }
@@ -147,7 +145,6 @@ public class SiblingSourceDepProvisioningReportingTests
           "version": "1.0.0.0",
           "dependencies": [],
           "platform": "1.0.0.0",
-          "application": "1.0.0.0",
           "idRanges": [ { "from": {{idFrom}}, "to": {{idFrom + 19}} } ],
           "runtime": "14.0"
         }

--- a/AlRunner.Tests/SourceDepCacheEnumMetadataTests.cs
+++ b/AlRunner.Tests/SourceDepCacheEnumMetadataTests.cs
@@ -123,7 +123,6 @@ public class SourceDepCacheEnumMetadataTests
           "version": "1.0.0.0",
           "dependencies": [],
           "platform": "1.0.0.0",
-          "application": "1.0.0.0",
           "idRanges": [ { "from": 61900, "to": 61909 } ],
           "runtime": "14.0"
         }
@@ -174,7 +173,6 @@ public class SourceDepCacheEnumMetadataTests
             { "id": "{{depId}}", "name": "Repro1731 Dep App", "publisher": "Repro1731", "version": "1.0.0.0" }
           ],
           "platform": "1.0.0.0",
-          "application": "1.0.0.0",
           "idRanges": [ { "from": 61910, "to": 61919 } ],
           "runtime": "14.0"
         }

--- a/AlRunner.Tests/SourceDepSymbolsWithoutPackageCacheTests.cs
+++ b/AlRunner.Tests/SourceDepSymbolsWithoutPackageCacheTests.cs
@@ -100,7 +100,6 @@ public class SourceDepSymbolsWithoutPackageCacheTests
           "version": "1.0.0.0",
           "dependencies": [],
           "platform": "1.0.0.0",
-          "application": "1.0.0.0",
           "idRanges": [ { "from": 61930, "to": 61939 } ],
           "runtime": "14.0"
         }
@@ -130,7 +129,6 @@ public class SourceDepSymbolsWithoutPackageCacheTests
             { "id": "{{depId}}", "name": "Repro1731B Dep App", "publisher": "Repro1731B", "version": "1.0.0.0" }
           ],
           "platform": "1.0.0.0",
-          "application": "1.0.0.0",
           "idRanges": [ { "from": 61940, "to": 61949 } ],
           "runtime": "14.0"
         }

--- a/AlRunner.Tests/SuiteEnumerationTests.cs
+++ b/AlRunner.Tests/SuiteEnumerationTests.cs
@@ -65,7 +65,6 @@ public sealed class SuiteEnumerationTests : IDisposable
           "version": "1.0.0.0",
           "dependencies": [],
           "platform": "1.0.0.0",
-          "application": "1.0.0.0",
           "idRanges": [ { "from": {{baseId}}, "to": {{baseId + 9}} } ],
           "runtime": "14.0"
         }

--- a/AlRunner.Tests/TestFilterFlagTests.cs
+++ b/AlRunner.Tests/TestFilterFlagTests.cs
@@ -75,7 +75,6 @@ public sealed class TestFilterFlagTests : IDisposable
           "version": "1.0.0.0",
           "dependencies": [],
           "platform": "1.0.0.0",
-          "application": "1.0.0.0",
           "idRanges": [ { "from": 62140, "to": 62149 } ],
           "runtime": "14.0"
         }

--- a/AlRunner.Tests/TestIsolationCodeunitVariableSharingTests.cs
+++ b/AlRunner.Tests/TestIsolationCodeunitVariableSharingTests.cs
@@ -59,7 +59,6 @@ public sealed class TestIsolationCodeunitVariableSharingTests : IDisposable
           "version": "1.0.0.0",
           "dependencies": [],
           "platform": "1.0.0.0",
-          "application": "1.0.0.0",
           "idRanges": [ { "from": 62130, "to": 62139 } ],
           "runtime": "14.0"
         }

--- a/AlRunner.Tests/TestIsolationMethodAliasTests.cs
+++ b/AlRunner.Tests/TestIsolationMethodAliasTests.cs
@@ -65,7 +65,6 @@ public sealed class TestIsolationMethodAliasTests : IDisposable
           "version": "1.0.0.0",
           "dependencies": [],
           "platform": "1.0.0.0",
-          "application": "1.0.0.0",
           "idRanges": [ { "from": 62110, "to": 62119 } ],
           "runtime": "14.0"
         }

--- a/AlRunner.Tests/TestPageBooleanRecBoundDispatchTests.cs
+++ b/AlRunner.Tests/TestPageBooleanRecBoundDispatchTests.cs
@@ -71,7 +71,6 @@ public sealed class TestPageBooleanRecBoundDispatchTests : IDisposable
           "version": "1.0.0.0",
           "dependencies": [],
           "platform": "1.0.0.0",
-          "application": "1.0.0.0",
           "idRanges": [ { "from": 62390, "to": 62399 } ],
           "runtime": "14.0"
         }

--- a/AlRunner.Tests/TestPageDrillDownDispatchTests.cs
+++ b/AlRunner.Tests/TestPageDrillDownDispatchTests.cs
@@ -81,7 +81,6 @@ public sealed class TestPageDrillDownDispatchTests : IDisposable
           "version": "1.0.0.0",
           "dependencies": [],
           "platform": "1.0.0.0",
-          "application": "1.0.0.0",
           "idRanges": [ { "from": 62380, "to": 62389 } ],
           "runtime": "14.0"
         }

--- a/AlRunner.Tests/TestPageExtensionActionWithPartDispatchTests.cs
+++ b/AlRunner.Tests/TestPageExtensionActionWithPartDispatchTests.cs
@@ -87,7 +87,6 @@ public sealed class TestPageExtensionActionWithPartDispatchTests : IDisposable
           "version": "1.0.0.0",
           "dependencies": [],
           "platform": "1.0.0.0",
-          "application": "1.0.0.0",
           "idRanges": [ { "from": 62400, "to": 62409 } ],
           "runtime": "14.0"
         }

--- a/AlRunner.Tests/TestTimeoutFlagTests.cs
+++ b/AlRunner.Tests/TestTimeoutFlagTests.cs
@@ -58,7 +58,6 @@ public sealed class TestTimeoutFlagTests : IDisposable
           "version": "1.0.0.0",
           "dependencies": [],
           "platform": "1.0.0.0",
-          "application": "1.0.0.0",
           "idRanges": [ { "from": 62120, "to": 62129 } ],
           "runtime": "14.0"
         }


### PR DESCRIPTION
In Business Central, `"application"` in `app.json` **is** the Base Application
dependency. It is not declared through the `dependencies` array, which is why 49 test
classes carried it without anyone noticing what it pulls in: the whole Base Application
closure, loaded on every runner invocation.

## Measurement

Two bundles identical except for that one line. Same runner build, same machine. Both
discover and pass one test.

| | cold wall | warm wall | test-execution phase (warm) |
|---|---|---|---|
| with `"application"` | 94.9s | 9.6-13.4s | 2.7-2.9s |
| without | 25.2s | 4.3s | 0.1s |

71 of the 246 files in `AlRunner.Tests` spawn the runner as a subprocess, and the suite
spawns it roughly 130 times.

## Estimated effect

The 47 classes changed here hold **63% of total test time** (77.7 of 122.6 test-minutes,
from a TRX of the current suite). Applying the measured ratios — 0.37 warm, 0.27 cold —
to that share, under the assumption that 85-95% of those classes' time is the subprocess:

| | wall clock |
|---|---|
| now | ~15 min |
| after | **~9 min** |

Roughly a third off. The estimate is not sensitive to which assumption you pick: the
whole range is 8.4 to 9.9 minutes.

It does not go further than that because the floor is still ~4.3s per process spawn —
about 130 spawns, roughly 140 seconds of pure startup at 4-way parallelism. Removing
this property was never going to touch that; see the follow-ups below.

## How the two exceptions were identified

Not by reading. I removed the property from all 49 classes and ran the full suite. Only
two classes failed:

- `InstallBaselineDiskCacheTests`
- `InstallSeedDepCompanyCacheTests`

which is exactly what a static pass had predicted, so the two methods agree.

**Neither is testing Base Application.** Both test #1867 install-baseline caching. What
breaks them is narrower than "they need Base App" — with no closure whose install
triggers write rows, the runner logs:

```
[InstallBaselineDisk] not persisting: snapshot has 0 DataAccessSource(s), expected exactly 1
```

so the snapshot is empty, nothing is persisted, and there are no HIT/MISS markers for
the assertions to observe. They need *a* row-seeding closure, not this one.

They keep the property here and are recorded as **outstanding violations tracked in
#2364**, not as blessed exceptions. Both carry a comment at the line saying so, and
naming the fix: a small fixture dependency app with its own table and an
`OnInstallAppPerCompany` trigger.

A third failure, `CleanRunStartupVerbosityTests.DefaultRun_PrintsNoStartupBookkeepingLines`,
was a `TimeoutException: runner hung` on a machine running eight other agents. That class
never carried the property, so it is unrelated.

## Also in this PR

`.claude/rules/no-base-app-in-csharp-tests.md` — fixtures may declare `platform`, never
`application`. No exceptions, and the rule says what the bar is for claiming a test
cannot follow it.

## Follow-ups, deliberately not in this PR

- **#2364** — rework the last two classes so the property can go everywhere.
- **#2223** — make the closure load cheap when it genuinely is needed.
- The remaining cost after this change is process-per-test. `--server` mode already has
  a warm in-process reload: measured, a first bundle costs 32s (BC boots once), the same
  bundle again 0.12s, and a *different* bundle 1.78s. That is the path below ~9 minutes,
  and it is a separate piece of work.

Closes #2358
