### PR TITLE
fix(page): dispatch non-modal Page.Run instead of NREing on a null ServiceConnection

### DIFF
--- a/AlRunner.Tests/NonModalPageRunDispatchBindingTests.cs
+++ b/AlRunner.Tests/NonModalPageRunDispatchBindingTests.cs
@@ -89,8 +89,15 @@ public class NonModalPageRunDispatchBindingTests
         Assert.False(CallsAnyNamed(m, "get_CallbackHandler"),
             "TestHandleForm still reads IService.CallbackHandler — that callvirt on a null "
             + "ServiceConnection is the NRE in issue #2349.");
-        Assert.False(CallsAnyNamed(m, "FormRun"),
-            "TestHandleForm still calls the client's IClientContract.FormRun.");
+        // Not "no call named FormRun" — the replacement is also called FormRun. The claim is
+        // that no call named FormRun is left on a CLIENT interface.
+        Assert.False(
+            m.Body.Instructions.Any(i =>
+                (i.OpCode == OpCodes.Call || i.OpCode == OpCodes.Callvirt)
+                && i.Operand is MethodReference mr
+                && mr.Name == "FormRun"
+                && !mr.DeclaringType.FullName.StartsWith("AlRunner.", StringComparison.Ordinal)),
+            "TestHandleForm still calls the client's IClientCallbackHandler.FormRun.");
     }
 
     // The sibling that was already fixed must keep the same invariant: both dispatch methods

--- a/AlRunner.Tests/NonModalPageRunDispatchBindingTests.cs
+++ b/AlRunner.Tests/NonModalPageRunDispatchBindingTests.cs
@@ -1,0 +1,145 @@
+// NonModalPageRunDispatchBindingTests — proves the #2349 fix at the two places it lives.
+//
+// Root cause: NavTestExecution.TestHandleForm (the NON-modal twin of TestHandleModalForm)
+// ended in the client round trip
+//     TestClientProxy<IClientCallbackHandler>.Proxy(ServiceConnection.CallbackHandler)
+//         .FormRun(formRunRequest);
+// and `ServiceConnection` is `ClientSession != null ? testServiceConnection : null`. The
+// runner field-pokes NavTestExecution.testClientSession with its own RunnerTestClientSession
+// (MetadataPatches) but never sets testServiceConnection — BC only assigns that inside
+// CreateTestClientSession(), which the poke exists to bypass. So ServiceConnection returned
+// null and `callvirt IService::get_CallbackHandler()` NRE'd inside TestHandleForm's own
+// frame, with no inner frame to name the cause. TestHandleModalForm had had that receiver
+// chain redirected long ago; its twin had not.
+//
+// These are deliberately RUNNER-INTERNAL claims: that OUR Cecil pass removed the null read
+// from both dispatch methods, that OUR replacement refuses loudly rather than no-opping, and
+// that OUR compile-pipeline polyfill no longer refuses non-modal Page.Run as out-of-scope.
+// Whether real BC hands a non-modal Page.Run to a [PageHandler] or to TestPage.Trap() is a
+// plain BC-behaviour claim and lives in the upstream corpus (tests/al-language), where a real
+// service tier adjudicates it.
+using System.Linq;
+using System.Reflection;
+using AlRunner.Infrastructure;
+using Microsoft.Dynamics.Nav.Runtime;
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+// Reads the Ncl image this process actually loaded, which BcEngineBootstrap has already
+// Cecil-rewritten in place — so it must share the serial bc-engine collection.
+[Collection(BcEngineCollection.Name)]
+public class NonModalPageRunDispatchBindingTests
+{
+    private readonly BcEngineFixture _engine;
+
+    public NonModalPageRunDispatchBindingTests(BcEngineFixture engine) => _engine = engine;
+
+    private static MethodDefinition Load(string methodName)
+    {
+        var nclPath = typeof(ITreeObject).Assembly.Location;
+        var asm = AssemblyDefinition.ReadAssembly(nclPath);
+        var type = asm.MainModule.GetType("Microsoft.Dynamics.Nav.Runtime.NavTestExecution");
+        Assert.NotNull(type);
+        var m = type!.Methods.FirstOrDefault(x => x.Name == methodName && x.HasBody);
+        Assert.NotNull(m);
+        return m!;
+    }
+
+    private static bool Calls(MethodDefinition m, string declaringTypeSuffix, string memberName)
+        => m.Body.Instructions.Any(i =>
+            (i.OpCode == OpCodes.Call || i.OpCode == OpCodes.Callvirt)
+            && i.Operand is MethodReference mr
+            && mr.Name == memberName
+            && mr.DeclaringType.FullName.EndsWith(declaringTypeSuffix, StringComparison.Ordinal));
+
+    private static bool CallsAnyNamed(MethodDefinition m, string memberName)
+        => m.Body.Instructions.Any(i =>
+            (i.OpCode == OpCodes.Call || i.OpCode == OpCodes.Callvirt)
+            && i.Operand is MethodReference mr && mr.Name == memberName);
+
+    // Positive: the non-modal dispatch now goes to the runner's own FormRun.
+    [SkippableFact]
+    public void TestHandleForm_DispatchesToRunnerModalDispatchFormRun()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready,
+            _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        var m = Load("TestHandleForm");
+        Assert.True(Calls(m, "AlRunner.Patches.RunnerModalDispatch", "FormRun"),
+            "TestHandleForm must call RunnerModalDispatch.FormRun — without the redirect the "
+            + "client callback runs and NREs on a null ServiceConnection.");
+    }
+
+    // Negative: the exact dereference that produced the bare NRE must be gone. A redirect that
+    // added the new call but left the receiver chain in place would still evaluate
+    // ServiceConnection.CallbackHandler and still throw, and the positive above would not
+    // notice.
+    [SkippableFact]
+    public void TestHandleForm_NoLongerReadsTheNullServiceConnection()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready,
+            _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        var m = Load("TestHandleForm");
+        Assert.False(CallsAnyNamed(m, "get_ServiceConnection"),
+            "TestHandleForm still reads NavTestExecution.ServiceConnection, which is null here.");
+        Assert.False(CallsAnyNamed(m, "get_CallbackHandler"),
+            "TestHandleForm still reads IService.CallbackHandler — that callvirt on a null "
+            + "ServiceConnection is the NRE in issue #2349.");
+        Assert.False(CallsAnyNamed(m, "FormRun"),
+            "TestHandleForm still calls the client's IClientContract.FormRun.");
+    }
+
+    // The sibling that was already fixed must keep the same invariant: both dispatch methods
+    // go through one redirect helper, so neither can drift back to the client chain alone.
+    [SkippableFact]
+    public void TestHandleModalForm_KeepsTheSameInvariant()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready,
+            _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        var m = Load("TestHandleModalForm");
+        Assert.True(Calls(m, "AlRunner.Patches.RunnerModalDispatch", "FormRunModal"),
+            "TestHandleModalForm must call RunnerModalDispatch.FormRunModal.");
+        Assert.False(CallsAnyNamed(m, "get_ServiceConnection"),
+            "TestHandleModalForm still reads NavTestExecution.ServiceConnection.");
+    }
+
+    // The replacement must refuse loudly rather than return a default: a FormRun that quietly
+    // did nothing when handed no context would leave the [PageHandler] unrun and the test green.
+    [Fact]
+    public void FormRun_WithNoContext_ThrowsRunnerOutOfScope_NotSilentNoOp()
+    {
+        var ex = Assert.Throws<RunnerOutOfScopeException>(
+            () => AlRunner.Patches.RunnerModalDispatch.FormRun(null!, null!));
+        Assert.Contains("TestPage page dispatch", ex.Message);
+        Assert.Contains("testpage-page", ex.Message);
+    }
+
+    // The compile-pipeline half. AL-compiled Page.Run is redirected at source level to
+    // NavRuntimeHelpersShim.NavForm_Run; that shim used to throw out-of-scope non-modal-ui
+    // unconditionally, so the SAME AL behaved differently depending only on whether it was
+    // compiled here or arrived in a precompiled Base App DLL (which never went through the
+    // redirect). It must now forward to BC's own RunAsync and let TestHandleForm decide.
+    [Fact]
+    public void PolyfillNavFormRunShim_ForwardsToBc_AndNoLongerRefusesNonModalUi()
+    {
+        var field = typeof(AlRunner.BcAssembler).GetField("PolyfillSource",
+            BindingFlags.NonPublic | BindingFlags.Static)
+            ?? throw new InvalidOperationException("BcAssembler.PolyfillSource not found.");
+        var source = (string)field.GetRawConstantValue()!;
+
+        Assert.DoesNotContain("non-modal-ui", source);
+
+        // All five NavForm_Run overloads must forward. Named RunAsync, never Run(, so the
+        // _polyfillRedirects rewrite of the literal "NavForm.Run(" cannot send the shim
+        // bodies back to themselves.
+        var forwards = System.Text.RegularExpressions.Regex.Matches(
+            source, @"NavForm\.RunAsync\(").Count;
+        Assert.Equal(5, forwards);
+        Assert.DoesNotContain("Runtime.NavForm.Run(", source);
+    }
+}

--- a/AlRunner/BcAssembler.cs
+++ b/AlRunner/BcAssembler.cs
@@ -410,37 +410,32 @@ namespace AlRunnerShim
                 errorLevel, sessionId, objectId, companyName, record);
 
         // ───────────────────────────────────────────────────────────────────────
-        // NavForm.Run (static, non-modal) — OOS §3.11 #ui.
+        // NavForm.Run (static, non-modal) — Page.Run.
         // BC emits NavForm.Run(...) (the [Obsolete] sync wrapper around RunAsync)
         // for all Page.Run call sites. JmpHook.Apply cannot reliably intercept
         // these on .NET 8 R2R (code-layout mismatch); source-level redirect is safe.
-        // All overloads throw RunnerOutOfScopeException when OosHooksActive (i.e.
-        // inside a test run); calls during BC SA init pass through harmlessly.
+        //
+        // These forward to BC's own RunAsync, which asks NavTestExecution.TestHandleForm
+        // first: in a test session that dispatches the page to the test's TestPage.Trap()
+        // or its [PageHandler], with no client involved, and refuses with BC's own
+        // ""Unhandled UI"" error when the test declared neither. Outside a test session
+        // there is genuinely no client and BC's own client-callback refusal stands.
+        // They used to throw out-of-scope §3.11 unconditionally, which made the SAME AL
+        // behave differently depending on whether it was compiled here or arrived in a
+        // precompiled Base App DLL (which never went through this redirect). See #2349.
+        //
+        // Named RunAsync rather than Run so the _polyfillRedirects rewrite of the literal
+        // ""NavForm.Run("" cannot match these bodies and send them back to themselves.
         public static void NavForm_Run(int formId)
-        {
-            if (global::AlRunner.BcRuntime.OosHooksActive)
-                global::AlRunner.Infrastructure.RunnerScope.ThrowOutOfScope(""NavForm.RunAsync"", ""non-modal-ui"", ""ui"");
-        }
+            => Microsoft.Dynamics.Nav.Runtime.NavForm.RunAsync(formId).AsTask().GetAwaiter().GetResult();
         public static void NavForm_Run(int formId, Microsoft.Dynamics.Nav.Runtime.NavRecord record)
-        {
-            if (global::AlRunner.BcRuntime.OosHooksActive)
-                global::AlRunner.Infrastructure.RunnerScope.ThrowOutOfScope(""NavForm.RunAsync"", ""non-modal-ui"", ""ui"");
-        }
+            => Microsoft.Dynamics.Nav.Runtime.NavForm.RunAsync(formId, record).AsTask().GetAwaiter().GetResult();
         public static void NavForm_Run(int formId, Microsoft.Dynamics.Nav.Runtime.NavRecord record, int fieldNo)
-        {
-            if (global::AlRunner.BcRuntime.OosHooksActive)
-                global::AlRunner.Infrastructure.RunnerScope.ThrowOutOfScope(""NavForm.RunAsync"", ""non-modal-ui"", ""ui"");
-        }
+            => Microsoft.Dynamics.Nav.Runtime.NavForm.RunAsync(formId, record, fieldNo).AsTask().GetAwaiter().GetResult();
         public static void NavForm_Run(string fullName, Microsoft.Dynamics.Nav.Runtime.NavRecord record)
-        {
-            if (global::AlRunner.BcRuntime.OosHooksActive)
-                global::AlRunner.Infrastructure.RunnerScope.ThrowOutOfScope(""NavForm.RunAsync"", ""non-modal-ui"", ""ui"");
-        }
+            => Microsoft.Dynamics.Nav.Runtime.NavForm.RunAsync(fullName, record).AsTask().GetAwaiter().GetResult();
         public static void NavForm_Run(string fullName, Microsoft.Dynamics.Nav.Runtime.NavRecord record, int fieldNo)
-        {
-            if (global::AlRunner.BcRuntime.OosHooksActive)
-                global::AlRunner.Infrastructure.RunnerScope.ThrowOutOfScope(""NavForm.RunAsync"", ""non-modal-ui"", ""ui"");
-        }
+            => Microsoft.Dynamics.Nav.Runtime.NavForm.RunAsync(fullName, record, fieldNo).AsTask().GetAwaiter().GetResult();
 
         // ─── Text method polyfills ────────────────────────────────────────────────
         // AL string positions are 1-based throughout (CopyStr, StrPos, IndexOf, Substring).

--- a/AlRunner/BcRuntime.cs
+++ b/AlRunner/BcRuntime.cs
@@ -1567,28 +1567,13 @@ public static partial class BcRuntime
         // registration was a silent no-op and BC's own body ran and NREd instead.
 
         // NavFormHandle.CreateTarget is Cecil-owned (see NclCecilRewrite.cs).
-        var formHandleType = navNcl.GetType("Microsoft.Dynamics.Nav.Runtime.NavFormHandle");
-        if (formHandleType != null)
-        {
-            // NavFormHandle.Run — Page variable .Run() — non-modal UI (§3.11 OOS).
-            // Uses Apply() which patches both the precode and the R2R native code, ensuring
-            // callers that resolve directly to native code are also intercepted.
-            foreach (var runMethod in formHandleType.GetMethods(BindingFlags.Public | BindingFlags.Instance)
-                .Where(m => m.Name == "Run"))
-            {
-                var ps = runMethod.GetParameters();
-                var replName = ps.Length switch
-                {
-                    0 => nameof(FormPatches.NavFormHandle_Run_0),
-                    1 => nameof(FormPatches.NavFormHandle_Run_1),
-                    2 => nameof(FormPatches.NavFormHandle_Run_2),
-                    _ => null
-                };
-                if (replName == null) continue;
-                var repl = typeof(FormPatches).GetMethod(replName, BindingFlags.Public | BindingFlags.Static)!;
-                Hook(runMethod, repl, $"NavFormHandle.Run/{ps.Length}p");
-            }
-        }
+        //
+        // NavFormHandle.Run — the page-variable `P.Run()` form — used to be hooked here to
+        // throw out-of-scope §3.11. Deleted with #2349: the JmpHook layer is off by default so
+        // the registration was already a silent no-op (BC's own body ran), and non-modal
+        // Page.Run is no longer out of scope — BC's body reaches NavTestExecution.TestHandleForm,
+        // which dispatches to the test's trap or [PageHandler]. Reviving it would make
+        // `P.Run()` refuse what `Page.Run(id, Rec)` performs.
 
         // NavForm.RunModalAsync — PAGE-REPORT-CLUSTERS §2. Hook all 7 overloads
         // (3 instance + 4 static) to return FormResult.OK without touching skeleton

--- a/AlRunner/Infrastructure/NclCecilRewrite.cs
+++ b/AlRunner/Infrastructure/NclCecilRewrite.cs
@@ -1166,8 +1166,8 @@ public static class NclCecilRewrite
             Console.Error.WriteLine("[Cecil] Rewrote NavTestPageBase.CheckPageOpened → no-op (ret)");
         }
 
-        // 3b. NavTestExecution.TestHandleModalForm — replace the CLIENT callback with the
-        //     runner's own dispatch.
+        // 3b. NavTestExecution.TestHandleModalForm and TestHandleForm — replace the CLIENT
+        //     callback with the runner's own dispatch.
         //
         //     BC finds the test's [ModalPageHandler], pushes a delegate that will run it onto
         //     dialogHandlerStack, then asks the client to run the form modally:
@@ -1183,10 +1183,14 @@ public static class NclCecilRewrite
         //
         //     Dropping the three middle instructions leaves `ldarg.0` (the NavTestExecution)
         //     where the callback receiver was, so the stack arriving at the call is exactly
-        //     [NavTestExecution][FormRunModalRequest] — the signature of the replacement,
-        //     which performs the step the client would have caused using BC's own ShowDialog
-        //     and SetLastFormResult. Satisfying this one call through a real IService
-        //     implementation would mean ~130 members that exist only to throw.
+        //     [NavTestExecution][FormRun(Modal)Request] — the signature of the replacement,
+        //     which performs the step the client would have caused using BC's own ShowDialog /
+        //     ShowForm. Satisfying this one call through a real IService implementation would
+        //     mean ~130 members that exist only to throw.
+        //
+        //     TestHandleForm is the non-modal twin (Page.Run) and carries the identical chain;
+        //     it is redirected the same way. Leaving it alone was worse than leaving it
+        //     refused — see the comment at that call below and issue #2349.
         {
             var navTestExecutionType = asm.MainModule.GetType("Microsoft.Dynamics.Nav.Runtime.NavTestExecution")
                 ?? throw new InvalidOperationException("NavTestExecution type not found in Ncl — do not commit");
@@ -1194,40 +1198,66 @@ public static class NclCecilRewrite
                 .FirstOrDefault(m => m.Name == "TestHandleModalForm" && m.HasBody)
                 ?? throw new InvalidOperationException("NavTestExecution.TestHandleModalForm not found — do not commit");
 
-            var il = method.Body.GetILProcessor();
-            var call = method.Body.Instructions.FirstOrDefault(i =>
-                (i.OpCode == OpCodes.Callvirt || i.OpCode == OpCodes.Call)
-                && i.Operand is MethodReference mr && mr.Name == "FormRunModal"
-                && mr.Parameters.Count == 1)
-                ?? throw new InvalidOperationException(
-                    "TestHandleModalForm has no FormRunModal call — Ncl shape changed; do not commit");
-
-            // Walk back over the receiver chain: Proxy, get_CallbackHandler, get_ServiceConnection.
-            var toRemove = new List<Instruction>();
-            for (var cursor = call.Previous; cursor != null && toRemove.Count < 8; cursor = cursor.Previous)
+            // Both dispatch methods end in the SAME receiver chain, so redirect them the same
+            // way rather than twice by hand — a shape check that only one of them enforced is
+            // how TestHandleForm was left behind in the first place (issue #2349).
+            void RedirectClientCallback(string methodName, string callName, string replacementName)
             {
-                if (cursor.Operand is not MethodReference m2) continue;
-                if (m2.Name is "Proxy" or "get_CallbackHandler" or "get_ServiceConnection")
+                var target = navTestExecutionType.Methods
+                    .FirstOrDefault(m => m.Name == methodName && m.HasBody)
+                    ?? throw new InvalidOperationException(
+                        $"NavTestExecution.{methodName} not found — do not commit");
+
+                var il = target.Body.GetILProcessor();
+                var call = target.Body.Instructions.FirstOrDefault(i =>
+                    (i.OpCode == OpCodes.Callvirt || i.OpCode == OpCodes.Call)
+                    && i.Operand is MethodReference mr && mr.Name == callName
+                    && mr.Parameters.Count == 1)
+                    ?? throw new InvalidOperationException(
+                        $"{methodName} has no {callName} call — Ncl shape changed; do not commit");
+
+                // Walk back over the receiver chain: Proxy, get_CallbackHandler, get_ServiceConnection.
+                var toRemove = new List<Instruction>();
+                for (var cursor = call.Previous; cursor != null && toRemove.Count < 8; cursor = cursor.Previous)
                 {
-                    toRemove.Add(cursor);
-                    if (m2.Name == "get_ServiceConnection") break;
+                    if (cursor.Operand is not MethodReference m2) continue;
+                    if (m2.Name is "Proxy" or "get_CallbackHandler" or "get_ServiceConnection")
+                    {
+                        toRemove.Add(cursor);
+                        if (m2.Name == "get_ServiceConnection") break;
+                    }
                 }
+                if (toRemove.Count != 3)
+                    throw new InvalidOperationException(
+                        $"{methodName} receiver chain shape changed (matched {toRemove.Count} of 3) — do not commit");
+
+                foreach (var ins in toRemove) il.Remove(ins);
+
+                var replacement = asm.MainModule.ImportReference(
+                    typeof(AlRunner.Patches.RunnerModalDispatch).GetMethod(
+                        replacementName, BindingFlags.Public | BindingFlags.Static)
+                    ?? throw new InvalidOperationException(
+                        $"RunnerModalDispatch.{replacementName} not found — do not commit"));
+                il.Replace(call, il.Create(OpCodes.Call, replacement));
+
+                Console.Error.WriteLine(
+                    $"[Cecil] Rewrote NavTestExecution.{methodName} client callback → "
+                    + $"RunnerModalDispatch.{replacementName}");
             }
-            if (toRemove.Count != 3)
-                throw new InvalidOperationException(
-                    $"TestHandleModalForm receiver chain shape changed (matched {toRemove.Count} of 3) — do not commit");
 
-            foreach (var ins in toRemove) il.Remove(ins);
+            RedirectClientCallback("TestHandleModalForm", "FormRunModal",
+                nameof(AlRunner.Patches.RunnerModalDispatch.FormRunModal));
 
-            var replacement = asm.MainModule.ImportReference(
-                typeof(AlRunner.Patches.RunnerModalDispatch).GetMethod(
-                    nameof(AlRunner.Patches.RunnerModalDispatch.FormRunModal),
-                    BindingFlags.Public | BindingFlags.Static)
-                ?? throw new InvalidOperationException("RunnerModalDispatch.FormRunModal not found — do not commit"));
-            il.Replace(call, il.Create(OpCodes.Call, replacement));
-
-            Console.Error.WriteLine(
-                "[Cecil] Rewrote NavTestExecution.TestHandleModalForm client callback → RunnerModalDispatch.FormRunModal");
+            // NavTestExecution.TestHandleForm — the NON-MODAL twin, reached by Page.Run /
+            // NavForm.RunAsync. Its receiver chain is identical, and here ServiceConnection is
+            // not merely refusing: it is null, because the runner pokes testClientSession
+            // without testServiceConnection (only CreateTestClientSession sets the latter, and
+            // the poke exists precisely to skip it). So get_CallbackHandler NRE'd in
+            // TestHandleForm's own frame, and every [PageHandler] in a non-modal Page.Run was
+            // unreachable. RunnerModalDispatch.FormRun performs the step the client would have
+            // caused, through BC's own ShowForm.
+            RedirectClientCallback("TestHandleForm", "FormRun",
+                nameof(AlRunner.Patches.RunnerModalDispatch.FormRun));
 
             // NavSession.SetServerFormRequestData — called by TestHandleModalForm just BEFORE
             // the dispatch above, and its real body throws NotSupportedException outright when

--- a/AlRunner/Patches/FormPatches.cs
+++ b/AlRunner/Patches/FormPatches.cs
@@ -1,13 +1,11 @@
-// FormPatches — OOS throw sites for non-modal page run (§3.11 ui).
+// FormPatches — NavForm.RunModalAsync short-circuit.
 //
-// NavFormHandle.Run implements the page-variable .Run() path. The static
-// Page.Run call sites are redirected at source level via BcAssembler._polyfillRedirects
-// (NavForm.Run → NavRuntimeHelpersShim.NavForm_Run) which is more reliable than
-// JmpHook.Apply on .NET 8 R2R code — see BcAssembler.cs comment for details.
-//
-// NavFormHandle.Run:  3 instance overloads (0/1/2 extra params beyond self).
-// Page variable .Run() in AL typically goes through MockFormHandle already, so
-// these hooks fire mainly during BC SA init (with OosHooksActive=false → no-op).
+// The non-modal half used to live here too: NavFormHandle.Run (the page-variable `P.Run()`
+// path) threw out-of-scope §3.11, and BcAssembler._polyfillRedirects sent the static
+// Page.Run call sites to a shim that did the same. Both are gone with #2349 — non-modal
+// Page.Run now runs BC's own NavForm.RunAsync, which asks NavTestExecution.TestHandleForm
+// and dispatches the page to the test's TestPage.Trap() or its [PageHandler]. See
+// docs/scope.md and AlRunner/Patches/RunnerModalDispatch.cs.
 //
 // NavForm.RunModalAsync — PAGE-REPORT-CLUSTERS §2. JmpHooks all 7 NavForm.RunModalAsync
 // overloads (3 instance + 4 static) to return FormResult.OK (1) so AL Page.RunModal()
@@ -23,34 +21,6 @@ namespace AlRunner;
 
 public static class FormPatches
 {
-    // ──────────────────────────────────────────────────────────────────
-    // NavFormHandle.Run — Page variable .Run() (§3.11 OOS)
-    // ──────────────────────────────────────────────────────────────────
-
-    /// <summary>NavFormHandle.Run() — 0 extra params.</summary>
-    [MethodImpl(MethodImplOptions.NoInlining)]
-    public static void NavFormHandle_Run_0(object self)
-    {
-        if (BcRuntime.OosHooksActive)
-            RunnerScope.ThrowOutOfScope("NavForm.RunAsync", "non-modal-ui", "ui");
-    }
-
-    /// <summary>NavFormHandle.Run(arg1) — 1 extra param.</summary>
-    [MethodImpl(MethodImplOptions.NoInlining)]
-    public static void NavFormHandle_Run_1(object self, object arg1)
-    {
-        if (BcRuntime.OosHooksActive)
-            RunnerScope.ThrowOutOfScope("NavForm.RunAsync", "non-modal-ui", "ui");
-    }
-
-    /// <summary>NavFormHandle.Run(arg1, arg2) — 2 extra params.</summary>
-    [MethodImpl(MethodImplOptions.NoInlining)]
-    public static void NavFormHandle_Run_2(object self, object arg1, object arg2)
-    {
-        if (BcRuntime.OosHooksActive)
-            RunnerScope.ThrowOutOfScope("NavForm.RunAsync", "non-modal-ui", "ui");
-    }
-
     // ──────────────────────────────────────────────────────────────────
     // NavForm.RunModalAsync — Page.RunModal() → Action.Ok (PAGE-REPORT-CLUSTERS §2)
     //

--- a/AlRunner/Patches/RunnerModalDispatch.cs
+++ b/AlRunner/Patches/RunnerModalDispatch.cs
@@ -1,4 +1,5 @@
-// RunnerModalDispatch — stand in for the CLIENT half of BC's modal-page handler round-trip.
+// RunnerModalDispatch — stand in for the CLIENT half of BC's page-handler round-trip, both
+// the modal one (RunModal → [ModalPageHandler]) and the non-modal one (Run → [PageHandler]).
 //
 // HOW BC DOES IT
 //   NavTestExecution.TestHandleModalForm finds the test's [ModalPageHandler], pushes a
@@ -15,6 +16,14 @@
 //   purpose is to refuse ("Client callbacks are not supported on {0}"). Implementing the
 //   real IService/IClientCallbackHandler surface to satisfy one call means ~130 members that
 //   exist only to throw, so NclCecilRewrite instead redirects that single call site here.
+//
+//   TestHandleForm — the NON-MODAL twin — ends in the same receiver chain, and it was worse
+//   than refused there: the runner field-pokes NavTestExecution.testClientSession with its own
+//   RunnerTestClientSession but never sets testServiceConnection (BC only assigns that inside
+//   CreateTestClientSession, which the poke bypasses). So ServiceConnection returned null and
+//   `callvirt IService::get_CallbackHandler()` NRE'd inside TestHandleForm's own frame, with
+//   no inner frame to name the cause. Redirecting that call site here removes the last read of
+//   ServiceConnection, so the broken invariant has no observer left. See issue #2349.
 //
 //   This is not a shortcut around BC's logic — it performs exactly the step the client would
 //   have caused, using BC's own methods: pop the dialog handler, record its result. Every
@@ -78,6 +87,78 @@ public static class RunnerModalDispatch
                 "NavTestExecution.SetLastFormResult not found — Ncl shape changed; do not commit");
         if (result != null && setLastFormResult.GetParameters()[0].ParameterType.IsInstanceOfType(result))
             Invoke(setLastFormResult, testExecution, new[] { result });
+    }
+
+    /// <summary>
+    /// Called from the rewritten NavTestExecution.TestHandleForm in place of the client
+    /// callback — the NON-MODAL twin of <see cref="FormRunModal"/>. Signature matches the call
+    /// site's stack shape: the NavTestExecution (left by the original `ldarg.0`) and the
+    /// FormRunRequest.
+    ///
+    /// BC's own callback for this direction is ShowForm(handle), which a real client reaches
+    /// after opening the page. ShowForm decides everything that matters: whether the page was
+    /// trapped by the test (attach it and let the test drive it), or whether a [PageHandler]
+    /// answers it (build a NavTestPage and invoke the handler), or neither — in which case BC
+    /// raises its own NavTestPageInvokedWithoutHandlerException. None of that logic is
+    /// duplicated here.
+    /// </summary>
+    public static void FormRun(object testExecution, object runRequest)
+    {
+        if (testExecution == null || runRequest == null)
+            throw new AlRunner.Infrastructure.RunnerOutOfScopeException(
+                "TestPage page dispatch",
+                "testpage-page — the runner was asked to run a page with no test-execution "
+                + "context or no request. See docs/scope.md");
+
+        var handle = FormHandleOf(runRequest);
+        var type = testExecution.GetType();
+        var form = RegisteredForm(handle);
+
+        // A page the test TRAPPED (TestPage.Trap()) is handed to the test's own TestPage
+        // variable by ShowForm and stays open until the test closes it. Closing it here would
+        // pull the page out from under the AL that is about to drive it — so ask BEFORE
+        // ShowForm, which consumes the trap.
+        var trapped = HasTrap(testExecution, form);
+
+        // Same reasoning as the modal path: a real client opens the form as part of this round
+        // trip, and opening is what raises OnOpenPage. Not wrapped in a catch — an Error()
+        // raised in OnOpenPage is a real test failure.
+        var opened = TryOpenForm(form);
+
+        var showForm = type.GetMethod("ShowForm", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException(
+                "NavTestExecution.ShowForm not found — Ncl shape changed; do not commit");
+        try
+        {
+            Invoke(showForm, testExecution, new object?[] { handle });
+        }
+        finally
+        {
+            if (opened && !trapped) TryCloseForm(form!, result: null);
+        }
+    }
+
+    /// <summary>
+    /// Whether the test has an outstanding TestPage.Trap() for this form's page, asked through
+    /// BC's own NavTestExecution.HasTrap so the answer is the one ShowForm will act on.
+    /// </summary>
+    private static bool HasTrap(object testExecution, object? form)
+    {
+        if (form == null) return false;
+
+        var objectId = form.GetType()
+            .GetProperty("ObjectId", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)?
+            .GetValue(form);
+        if (objectId?.GetType()
+                .GetProperty("ObjectNumber", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)?
+                .GetValue(objectId) is not int pageNo)
+            return false;
+
+        var hasTrap = testExecution.GetType().GetMethod("HasTrap",
+            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
+            binder: null, types: new[] { typeof(int) }, modifiers: null);
+        if (hasTrap == null) return false;
+        return Invoke(hasTrap, testExecution, new object?[] { pageNo }) is true;
     }
 
     /// <summary>

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -175,7 +175,11 @@ dispatch, and report/request-page variables support a limited standalone surface
   line appended to a grid numbered from something other than 10000 does not continue from
   the last row. Tracked in
   [#1755](https://github.com/StefanMaron/BusinessCentral.AL.Runner/issues/1755).
-- `Page.Run()` is a no-op. `Page.RunModal()` dispatches to `[ModalPageHandler]` if
+- `Page.Run()` (non-modal) dispatches the page the way a client would: to the test's
+  `TestPage.Trap()` if one is outstanding, otherwise to the registered `[PageHandler]`,
+  otherwise it raises BC's own `Unhandled UI` error. The page a trap receives stays open
+  for the test to drive; the one a `[PageHandler]` receives is closed when the handler
+  returns. No window is rendered either way. `Page.RunModal()` dispatches to `[ModalPageHandler]` if
   registered, otherwise throws — both the page-variable form
   (`P.SetRecord(Rec); P.RunModal();`) and the static-by-id forms
   (`Page.RunModal(id, Record)`, `Page.RunModal(Page::"X", Record)`, and Base App

--- a/docs/scope.md
+++ b/docs/scope.md
@@ -59,6 +59,7 @@ real thing for any test that only observes documented BC behaviour.
 | **Field caption / table caption / lookup-page IDs** | From metadata + language pack | From parsed AL source (real values for AL-compiled tables; falls back to `"FieldNN"` for base-app tables not compiled in this run) | Faithful for in-scope tables; documented stub for non-compiled base-app tables. |
 | **Event publisher → subscriber dispatch** | Service-tier event dispatcher | **Working as of 2026-05-11 (`c4bce11a`, W-8b A-prime).** Discovers `[NavEventSubscriber]`-attributed methods at startup, constructs real `NavEventSubscription` instances, and injects them into each table's `NavTableTriggerEventHandler.eventScopes[evt].registeredSubscriptions`. BC's own `NavEventScope.CheckAndFireTriggerEventsAsync` then dispatches — no JmpHook on the dispatch path (it would have been R2R-inlined and silently bypassed; see `feedback_r2r_inlining_traps.md`). | Faithful for documented event semantics including `var` params and `IncludeSender`. Manual-binding subscribers (`BindSubscription`) still pending. |
 | **`Page.RunModal` / report `[RequestPageHandler]`** | Real UI dialog | Looks up registered `[ModalPageHandler]` / `[RequestPageHandler]` and calls it | Faithful for the handler dispatch contract that test code relies on; no actual UI is rendered. |
+| **`Page.Run` (non-modal)** | Real UI window | Hands the page to BC's own `NavTestExecution.TestHandleForm`, which gives it to the test's `TestPage.Trap()` if one is outstanding, otherwise to the registered `[PageHandler]`, otherwise raises BC's own `Unhandled UI` error | Faithful for the handler/trap dispatch contract; no window is rendered. Outside a test session there is no client and BC's own client-callback refusal stands. |
 | **`RecordLink` (table 2000000068)** AL surface: `Rec.AddLink/HasLinks/DeleteLink/DeleteLinks/CopyLinks` | Stored in the platform RecordLink table | `RecordLinkPatches` in-memory dict keyed by `NavRecord.ALRecordId` (see commit landing 2026-05-17). Reset to empty between tests via `ResetPerTestState`. | Faithful for AL-observable semantics: `AddLink` returns a positive monotone id, `HasLinks` is true iff a live link exists, `Delete*` and `CopyLinks` behave as documented. Boundary: BC code reading the RecordLink table directly via `Record 2000000068` from inside a non-AL path (BC internals) is unaware of the polyfill — that path isn't an AL surface and isn't exercised by the tests we care about. |
 
 ---
@@ -178,7 +179,7 @@ invokes `OnInitReport` → `OnPreReport` → per-DataItem `OnPreDataItem` / `OnP
 
 | API | Reason |
 |---|---|
-| `Page.Run` (non-modal), `controladdin`, `usercontrol`, profiles | Requires BC client. UI dialog **callbacks** (`[MessageHandler]`, `[ConfirmHandler]`, …) are in scope under §2; the UI itself isn't. |
+| `controladdin`, `usercontrol`, profiles | Requires BC client. UI dialog **callbacks** (`[MessageHandler]`, `[ConfirmHandler]`, …) are in scope under §2; the UI itself isn't. |
 
 ### §3.12. Debugger <a id="debugger"></a>
 


### PR DESCRIPTION
Closes #2349

## The null

`NavTestExecution.TestHandleForm` — the non-modal twin of `TestHandleModalForm` — ends in the
client round trip:

```csharp
TestClientProxy<IClientCallbackHandler>.Proxy(ServiceConnection.CallbackHandler).FormRun(formRunRequest);
```

and `ServiceConnection` is `ClientSession != null ? testServiceConnection : null`. The runner
field-pokes `NavTestExecution.testClientSession` with its own `RunnerTestClientSession`
(`MetadataPatches`) so `ClientSession` is non-null, but it never sets `testServiceConnection`:
BC only assigns that inside `CreateTestClientSession()`, which the poke exists to bypass
(`testServiceConnection` has exactly one assignment site in Ncl, and it is unreachable here).
So `ServiceConnection` returned **null** and `callvirt IService::get_CallbackHandler()` NRE'd
inside `TestHandleForm`'s own frame — a bare NRE with no inner frame to name the cause.

`NclCecilRewrite` step 3b already redirected exactly this receiver chain in
`TestHandleModalForm`. Its twin was never given the same treatment.

## The fix

1. Both dispatch methods now go through one `RedirectClientCallback` helper, so neither can
   drift back to the client chain alone. `TestHandleForm`'s `FormRun` call site lands on a new
   `RunnerModalDispatch.FormRun`, which performs the step the client would have caused using
   BC's own `ShowForm(handle)` — trap, `[PageHandler]`, or BC's own unhandled-UI error. None of
   that decision logic is duplicated; it stays in BC's code and in the AL handler.

   The one thing `FormRun` must know that the modal path does not: a page the test **trapped**
   is handed to the test's own `TestPage` variable and stays open until the test closes it, so
   it asks BC's `HasTrap` before `ShowForm` consumes the trap and does not close a trapped page.

2. **Non-modal `Page.Run` is no longer out of scope.** AL compiled here was redirected at
   source level (`BcAssembler._polyfillRedirects`) to a shim that threw
   `RunnerOutOfScopeException(non-modal-ui)` unconditionally, and `NavFormHandle.Run` (the
   page-variable `P.Run()` form) had a matching JmpHook. The same AL arriving in a precompiled
   Base App DLL never went through either — which is why `Record.ShowRecord()` reached
   `TestHandleForm` and NRE'd while `Page.Run` in AL under test was refused. Same behaviour,
   refused or performed depending only on who compiled it. The shim now forwards to BC's own
   `NavForm.RunAsync`; `docs/scope.md` §3.11 and `docs/limitations.md` are updated to say what
   the runner actually does.

## Fix the shape

1. **Same wrong pattern at another call site?** `ServiceConnection` has exactly two readers in
   Ncl — `TestHandleForm` and `TestHandleModalForm`. Both are now redirected, so the broken
   invariant (`testClientSession` poked, `testServiceConnection` left null) has no observer
   left. `NavTestExecution.ClosePage` is the third reader of the backing field and is safe:
   BC itself null-guards there (`testServiceConnection?.CallbackHandler != null`).
2. **Does a sibling make the same assumption?** Yes — `NavFormHandle.Run`, the page-variable
   `P.Run()` path, carried the same §3.11 refusal. It was already inert (the JmpHook layer is
   off by default, so BC's real body ran), but reviving it would have made `P.Run()` refuse
   what `Page.Run(id, Rec)` performs. Deleted rather than left as a landmine.
3. **Do two code paths writing the same state keep the same invariant?** This is the whole bug:
   AL-compiled `Page.Run` and precompiled `NavForm.RunAsync` reach the same platform behaviour,
   and only one of them had the refusal. They now agree.

## RED → GREEN

Microsoft `Tests-SINGLESERVER`, BC 28.1.49838.53910, same warm cache both sides:

| Selection | before | after |
|---|---|---|
| `Codeunit134826` | 33P / 9F — 3 × `NavTestExecution.TestHandleForm` | **36P / 6F** — zero `TestHandleForm` |
| `--test ShowDocumentFromApprovalEntry` (Codeunit134202) | 0P / **12F, all 12 `TestHandleForm`** | 1P / 11F, zero `TestHandleForm` |
| `Codeunit134201` | 9P / 38F / 1E — 20 × `TestHandleForm` | **12P / 35F / 1E** — zero `TestHandleForm` |

The `TestHandleForm` cluster is gone from all three. The 11 remaining
`ShowDocumentFromApprovalEntry` failures are now a *different*, unrelated defect the fix
uncovered: the page is opened and driven correctly (`."No.".AssertEquals` passes), and the
failure is `AssertEquals for Field: Status Expected = '2', Actual = 'Pending Approval'` — an
Option/Enum field compared as ordinal against caption. Filed separately as #2367.

Corpus proving tests (BC behaviour, upstream — see below) run against this branch:

```
PASS Codeunit60750.PageHandlerRunsForANonModalPageRun
PASS Codeunit60750.PageHandlerReceivesTheRecordPassedToPageRun
PASS Codeunit60750.NonModalPageRunWithoutAHandlerIsRefused
PASS Codeunit60750.TrapReceivesTheNonModalPageAndItStaysOpen
```

All four fail on this branch's first commit (before the scope change) with
`out-of-scope: NavForm.RunAsync — non-modal-ui`.

## Where the tests live

The BC-behaviour claims are upstream in
`StefanMaron/BusinessCentral.AL.Language.Tests`, branch `agent/impl-6/page-run-handler` —
the corpus covers `[ModalPageHandler]` thoroughly and had **no** coverage of the non-modal
half at all (`TestMiscComplete.al` carries a placeholder saying `TestPage.Trap()` is "covered
separately", and it is not). The submodule pin bump and count-baseline update are **not** in
this PR yet; they fold in once that corpus PR merges.

The runner-side mechanism test (`AlRunner.Tests/NonModalPageRunDispatchBindingTests.cs`) pins
the C# half only: that the Cecil pass removed the null read from both dispatch methods, that
the replacement refuses loudly rather than no-opping, and that the polyfill forwards instead of
throwing. Verified against the rewritten image — `TestHandleForm`'s remaining call set is
`[RunnerModalDispatch::FormRun]`, where the pre-fix image reads
`[get_ServiceConnection, get_CallbackHandler, IClientCallbackHandler::FormRun]`.

## Suites actually run on this branch

- al-language corpus, `--strict --count-baseline`: **2224 / 2224 pass**, 0 fail, 0 error.
- runner-extras, `--strict --count-baseline`: **202 / 202 pass**.
- `dotnet test AlRunner.Tests`: 3 failures, all environmental and none caused by this change —
  two are `TimeoutException` under 12 concurrent test hosts on this box, and
  `InstallSeedDepCompanyCacheTests.AppGroupWithOwnDependencyApp_DoesNotReuseUnrelatedDependencyClosureCache`
  reproduced once, then passed on re-run of the same binary (it uses the shared default AL
  cache, the #2335 contamination shape). Everything else passed.
- The three IL assertions in the new test skip locally because the in-process BC engine
  bootstrap fails on this box — the pre-existing `NavReportStaticRunModalHookBindingTests`
  skips identically. They run in CI.
