### PR TITLE
perf(test-data): read backup tables over serve mode, and stop paying per-call costs on the hottest hooks

### DIFF
--- a/AlRunner.Tests/BackupReaderServeTests.cs
+++ b/AlRunner.Tests/BackupReaderServeTests.cs
@@ -1,0 +1,215 @@
+// BackupReaderServeTests — the two pure halves of the serve transport (issue 2263), pinned
+// without a 900 MB backup.
+//
+// The claim the transport rests on is EQUIVALENCE: a table read over the serve process must
+// hand TestDataProvisioner.ParseRows exactly what the one-process-per-command CLI hands it.
+// If the two shapes ever diverge, --test-data hydrates different values depending on which
+// reader happened to be on PATH, and nothing in a green run would say so. So the central test
+// here builds the same table both ways and asserts ParseRows agrees, key for key and value
+// for value.
+//
+// The other half is the request: a `read` argument vector has to become the request the
+// reader actually answers, with `merge-extensions` HYPHENATED (the camelCase spelling was
+// accepted, ignored and exited 0 on older reader builds — see TestDataProvisioner's header),
+// and anything this slice does not model has to decline rather than guess.
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using AlRunner.Infrastructure;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class BackupReaderServeTests
+{
+    private static readonly string[] HydrateArgs =
+    {
+        "read", "/backups/BusinessCentral-W1.bak",
+        "--table", "Payment Terms",
+        "--company", "CRONUS International Ltd_",
+        "--format", "json",
+        "--merge-extensions",
+        "--symbols", "/apps/Base.app,/apps/System.app",
+    };
+
+    // ── request translation ────────────────────────────────────────────────────
+
+    [Fact]
+    public void ReadRequest_CarriesTableCompanyAndTheHyphenatedMergeKey()
+    {
+        Assert.True(BackupReaderServe.TryBuildReadRequest(HydrateArgs, 7, out var request));
+        Assert.NotNull(request);
+        Assert.Equal("/backups/BusinessCentral-W1.bak", request!.Backup);
+        Assert.Equal("/apps/Base.app,/apps/System.app", request.Symbols);
+
+        using var doc = JsonDocument.Parse(request.Json);
+        var root = doc.RootElement;
+        Assert.Equal(7, root.GetProperty("id").GetInt32());
+        Assert.Equal("read", root.GetProperty("cmd").GetString());
+        Assert.Equal("Payment Terms", root.GetProperty("table").GetString());
+        Assert.Equal("CRONUS International Ltd_", root.GetProperty("company").GetString());
+        Assert.True(root.GetProperty("merge-extensions").GetBoolean());
+
+        // The transport-level options are NOT request keys: a key the command does not accept
+        // fails the request outright on current reader builds.
+        Assert.False(root.TryGetProperty("mergeExtensions", out _));
+        Assert.False(root.TryGetProperty("format", out _));
+        Assert.False(root.TryGetProperty("symbols", out _));
+    }
+
+    [Fact]
+    public void ReadRequest_OmitsTheMergeKeyWhenTheFlagIsAbsent()
+    {
+        var plain = HydrateArgs.Where(a => a != "--merge-extensions").ToArray();
+        Assert.True(BackupReaderServe.TryBuildReadRequest(plain, 1, out var request));
+        using var doc = JsonDocument.Parse(request!.Json);
+        Assert.False(doc.RootElement.TryGetProperty("merge-extensions", out _));
+    }
+
+    [Fact]
+    public void ReadRequest_CarriesTop()
+    {
+        var withTop = HydrateArgs.Concat(new[] { "--top", "1" }).ToArray();
+        Assert.True(BackupReaderServe.TryBuildReadRequest(withTop, 1, out var request));
+        using var doc = JsonDocument.Parse(request!.Json);
+        Assert.Equal(1, doc.RootElement.GetProperty("top").GetInt32());
+    }
+
+    [Theory]
+    // A different command entirely.
+    [InlineData("tables", "/backups/x.bak", "--symbols", "/apps/Base.app")]
+    // A format the CLI shape is not JSON for.
+    [InlineData("read", "/backups/x.bak", "--table", "T", "--format", "tsv")]
+    // An option this slice does not model — decline rather than send a request that means
+    // something else.
+    [InlineData("read", "/backups/x.bak", "--table", "T", "--unknown-option", "v")]
+    // A --top that is not a number.
+    [InlineData("read", "/backups/x.bak", "--table", "T", "--top", "many")]
+    // No table at all.
+    [InlineData("read", "/backups/x.bak", "--company", "C")]
+    public void ReadRequest_DeclinesWhatItCannotExpress(params string[] args)
+    {
+        Assert.False(BackupReaderServe.TryBuildReadRequest(args, 1, out var request));
+        Assert.Null(request);
+    }
+
+    // ── response translation, and equivalence with the CLI shape ───────────────
+
+    [Fact]
+    public void ServeAndCliShapesProjectToTheSameRows()
+    {
+        // The same two rows in both wire shapes, including a null, a number, a string with a
+        // control character (the reader escapes U+0002 in date formulas) and a system column
+        // ParseRows is required to drop.
+        const string serve = """
+            {"id":3,"ok":true,
+             "headers":["Code","Description","Discount _","Blocked","Due Date Calculation","$systemId"],
+             "rows":[["10 DAYS","Net 10 days",0.5,null,"10\u0002","BF49D1DB-D953-F111-8E26-7CED8D9E4094"],
+                     ["14 DAYS","Net 14 days",0.0,1,"14\u0002","C049D1DB-D953-F111-8E26-7CED8D9E4094"]]}
+            """;
+        const string cli = """
+            [
+              {"Code":"10 DAYS","Description":"Net 10 days","Discount _":0.5,"Blocked":null,"Due Date Calculation":"10\u0002","$systemId":"BF49D1DB-D953-F111-8E26-7CED8D9E4094"},
+              {"Code":"14 DAYS","Description":"Net 14 days","Discount _":0.0,"Blocked":1,"Due Date Calculation":"14\u0002","$systemId":"C049D1DB-D953-F111-8E26-7CED8D9E4094"}
+            ]
+            """;
+
+        var fromServe = TestDataProvisioner.ParseRows(
+            BackupReaderServe.TranslateReadResponse(serve, "read Payment Terms"));
+        var fromCli = TestDataProvisioner.ParseRows(cli);
+
+        Assert.Equal(2, fromServe.Count);
+        Assert.Equal(fromCli.Count, fromServe.Count);
+        for (var i = 0; i < fromCli.Count; i++)
+        {
+            Assert.Equal(
+                fromCli[i].Keys.OrderBy(k => k, StringComparer.Ordinal).ToArray(),
+                fromServe[i].Keys.OrderBy(k => k, StringComparer.Ordinal).ToArray());
+            foreach (var key in fromCli[i].Keys)
+                Assert.Equal(fromCli[i][key].GetRawText(), fromServe[i][key].GetRawText());
+        }
+
+        // Concrete values, so this cannot pass against an empty projection.
+        Assert.Equal("10 DAYS", fromServe[0]["Code"].GetString());
+        Assert.Equal(0.5, fromServe[0]["Discount _"].GetDouble());
+        Assert.Equal(JsonValueKind.Null, fromServe[0]["Blocked"].ValueKind);
+        Assert.Equal("10\u0002", fromServe[0]["Due Date Calculation"].GetString());
+        Assert.Equal(1, fromServe[1]["Blocked"].GetInt32());
+        // The system column is dropped by ParseRows on both paths.
+        Assert.False(fromServe[0].ContainsKey("$systemId"));
+    }
+
+    [Fact]
+    public void EmptyTableTranslatesToAnEmptyArray()
+    {
+        var text = BackupReaderServe.TranslateReadResponse(
+            """{"id":1,"ok":true,"headers":["Code"],"rows":[]}""", "read T");
+        Assert.Empty(TestDataProvisioner.ParseRows(text));
+    }
+
+    [Fact]
+    public void ARefusalRaisesTheReadersOwnText()
+    {
+        var ex = Assert.Throws<BackupReaderException>(() => BackupReaderServe.TranslateReadResponse(
+            """{"id":2,"ok":false,"error":"no table matches 'No Such Table'"}""",
+            "read No Such Table"));
+        Assert.Contains("no table matches 'No Such Table'", ex.Message);
+        Assert.Contains("read No Such Table", ex.Message);
+    }
+
+    [Fact]
+    public void AnAnswerWithoutHeadersIsRefusedRatherThanReadAsEmpty()
+    {
+        // The dangerous failure is an empty result presented as an answer: the table would
+        // hydrate to nothing and the run would report success.
+        var ex = Assert.Throws<BackupReaderException>(
+            () => BackupReaderServe.TranslateReadResponse("""{"id":1,"ok":true}""", "read T"));
+        Assert.Contains("headers", ex.Message);
+    }
+
+    [Fact]
+    public void ARowLongerThanTheHeaderListIsRefused()
+    {
+        var ex = Assert.Throws<BackupReaderException>(() => BackupReaderServe.TranslateReadResponse(
+            """{"id":1,"ok":true,"headers":["Code"],"rows":[["A","B"]]}""", "read T"));
+        Assert.Contains("more cells than headers", ex.Message);
+    }
+
+    [Fact]
+    public void UnparseableOutputIsRefusedRatherThanReadAsEmpty()
+    {
+        var ex = Assert.Throws<BackupReaderException>(
+            () => BackupReaderServe.TranslateReadResponse("not json at all", "read T"));
+        Assert.Contains("could not be parsed", ex.Message);
+    }
+
+    // ── the kill switch ────────────────────────────────────────────────────────
+
+    [Fact]
+    public void ServeCanBeTurnedOffByEnvironment_AndTheAnswerIsReadOnce()
+    {
+        var saved = Environment.GetEnvironmentVariable("AL_RUNNER_BCBAK_SERVE");
+        try
+        {
+            BackupReaderServe.ResetForTests();
+            Environment.SetEnvironmentVariable("AL_RUNNER_BCBAK_SERVE", "0");
+            Assert.False(BackupReaderServe.EnabledByEnv);
+            // TryRun must decline outright, without touching the reader executable.
+            Assert.False(BackupReaderServe.TryRun(HydrateArgs, out var output));
+            Assert.Equal("", output);
+
+            // Memoised: flipping it afterwards is not observed.
+            Environment.SetEnvironmentVariable("AL_RUNNER_BCBAK_SERVE", "1");
+            Assert.False(BackupReaderServe.EnabledByEnv);
+
+            BackupReaderServe.ResetForTests();
+            Assert.True(BackupReaderServe.EnabledByEnv);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("AL_RUNNER_BCBAK_SERVE", saved);
+            BackupReaderServe.ResetForTests();
+        }
+    }
+}

--- a/AlRunner.Tests/HotPathHookCostTests.cs
+++ b/AlRunner.Tests/HotPathHookCostTests.cs
@@ -42,11 +42,12 @@ public sealed class HotPathHookCostTests
     }
 
     [Fact]
-    public void IsOpenHook_LoggingIsOffUnlessExplicitlyRequested()
+    public void HookTracing_IsOffUnlessExplicitlyRequested()
     {
-        // The env var is not set in this process, so the gate must read false. If it ever
-        // defaults to true again, the hot path pays a formatted console write per field read.
-        Assert.False(BcRuntime.IsOpenHookLoggingEnabled);
+        // AL_RUNNER_TRACE_HOOKS is not set in this process, so the gate must read false. If it
+        // ever defaults to true again, every field read pays a formatted console write and
+        // every record construction pays another.
+        Assert.False(BcRuntime.HookTraceEnabled);
     }
 
     [Fact]
@@ -157,6 +158,40 @@ public sealed class HotPathHookCostTests
         Assert.Equal(1, BcRuntime.RuntimeAssemblyScanCount);
         Assert.Null(BcRuntime.FindRuntimeAssembly("No.Such.Assembly.Exists"));
         Assert.Equal(2, BcRuntime.RuntimeAssemblyScanCount);
+    }
+
+    // ── NavMethodScope ctor: GetMethodScopeFlags lookup ───────────────────────
+
+    private sealed class ScopeWithFlags
+    {
+        // Same shape the real NavMethodScope subtypes have: a non-public instance method.
+        private int GetMethodScopeFlags() => 42;
+    }
+
+    private sealed class ScopeWithoutFlags
+    {
+    }
+
+    [Fact]
+    public void MethodScopeFlagsLookup_HappensOncePerScopeType()
+    {
+        BcRuntime.ResetGetMethodScopeFlagsCacheForTests();
+
+        var first = BcRuntime.ResolveGetMethodScopeFlags(typeof(ScopeWithFlags));
+        Assert.NotNull(first);
+        Assert.Equal("GetMethodScopeFlags", first!.Name);
+        Assert.Equal(42, first.Invoke(new ScopeWithFlags(), null));
+        Assert.Equal(1, BcRuntime.GetMethodScopeFlagsLookupCount);
+
+        for (var i = 0; i < 20; i++)
+            Assert.Same(first, BcRuntime.ResolveGetMethodScopeFlags(typeof(ScopeWithFlags)));
+        Assert.Equal(1, BcRuntime.GetMethodScopeFlagsLookupCount);
+
+        // A second type costs exactly one more lookup, not one per call.
+        Assert.Null(BcRuntime.ResolveGetMethodScopeFlags(typeof(ScopeWithoutFlags)));
+        Assert.Equal(2, BcRuntime.GetMethodScopeFlagsLookupCount);
+        Assert.Null(BcRuntime.ResolveGetMethodScopeFlags(typeof(ScopeWithoutFlags)));
+        Assert.Equal(2, BcRuntime.GetMethodScopeFlagsLookupCount);
     }
 
     [Fact]

--- a/AlRunner.Tests/HotPathHookCostTests.cs
+++ b/AlRunner.Tests/HotPathHookCostTests.cs
@@ -1,0 +1,170 @@
+// HotPathHookCostTests — pins the three per-call costs that made a single MS test take
+// 568 seconds (#2304).
+//
+// The three hooks below sit on paths the BC runtime walks millions of times in one test:
+//
+//   * BcRuntime.ReturnTrue replaces RecordImplementation.get_IsOpen, which
+//     NavRecord.GetFieldValue asks for EVERY field read. It formatted an interpolated
+//     diagnostic string (including a reflective a.GetType().Name) and pushed it through
+//     Console.Error on every call. The line was never even visible: Log's FilteredWriter
+//     drops anything starting with a `[Tag]` at default verbosity, so the whole cost —
+//     allocation, reflection, a compiled-Regex match and a synchronized writer — bought
+//     nothing. Stack sampling caught it directly:
+//         SyncTextWriter.WriteLine <- BcRuntime.ReturnTrue <- NavRecord.GetFieldValue
+//
+//   * BcRuntime.CodeunitEventDispatch_OnRunEventAsync runs on every AL event scope and
+//     re-read two debug environment variables per call. Environment.GetEnvironmentVariable
+//     was the resolved leaf in 7 of 73 stack samples of that run.
+//
+//   * DispatchCore and NavRecordRef_get_Target each re-ran
+//     AppDomain.CurrentDomain.GetAssemblies().First(a => a.GetName().Name == "…Ncl")
+//     per call. RuntimeAssembly.GetName() calls the native GetCodeBase(), so the scan is
+//     not cheap; it was the resolved leaf in 4 more samples of the same run.
+//
+// These tests assert the CONTRACT each fix rests on — no console traffic from the IsOpen
+// hook, one environment read per gate, one AppDomain scan per resolved assembly — not a
+// timing threshold, which would be flaky and would not say what broke.
+using System;
+using System.IO;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+public sealed class HotPathHookCostTests
+{
+    // ── RecordImplementation.get_IsOpen replacement ────────────────────────────
+
+    [Fact]
+    public void IsOpenHook_ReturnsTrue()
+    {
+        Assert.True(BcRuntime.ReturnTrue(new object()));
+        Assert.True(BcRuntime.ReturnTrue(null));
+    }
+
+    [Fact]
+    public void IsOpenHook_LoggingIsOffUnlessExplicitlyRequested()
+    {
+        // The env var is not set in this process, so the gate must read false. If it ever
+        // defaults to true again, the hot path pays a formatted console write per field read.
+        Assert.False(BcRuntime.IsOpenHookLoggingEnabled);
+    }
+
+    [Fact]
+    public void IsOpenHook_WritesNothingToTheConsole()
+    {
+        var savedOut = Console.Out;
+        var savedErr = Console.Error;
+        var sink = new StringWriter();
+        try
+        {
+            Console.SetOut(sink);
+            Console.SetError(sink);
+            for (var i = 0; i < 25; i++) BcRuntime.ReturnTrue(new object());
+        }
+        finally
+        {
+            Console.SetOut(savedOut);
+            Console.SetError(savedErr);
+        }
+        Assert.Equal(string.Empty, sink.ToString());
+    }
+
+    // ── dispatcher debug gates ─────────────────────────────────────────────────
+
+    [Fact]
+    public void DispatcherOffGate_ReadsTheEnvironmentOnceAndKeepsTheAnswer()
+    {
+        var saved = Environment.GetEnvironmentVariable("AL_RUNNER_DISPATCHER_OFF");
+        try
+        {
+            BcRuntime.ResetDispatchGatesForTests();
+            Environment.SetEnvironmentVariable("AL_RUNNER_DISPATCHER_OFF", "1");
+            Assert.True(BcRuntime.DispatcherDisabled);
+
+            // Changing the variable afterwards must NOT be observed: that is what proves the
+            // value is memoised rather than re-read on every dispatch.
+            Environment.SetEnvironmentVariable("AL_RUNNER_DISPATCHER_OFF", "0");
+            Assert.True(BcRuntime.DispatcherDisabled);
+
+            BcRuntime.ResetDispatchGatesForTests();
+            Assert.False(BcRuntime.DispatcherDisabled);
+
+            Environment.SetEnvironmentVariable("AL_RUNNER_DISPATCHER_OFF", null);
+            BcRuntime.ResetDispatchGatesForTests();
+            Assert.False(BcRuntime.DispatcherDisabled);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("AL_RUNNER_DISPATCHER_OFF", saved);
+            BcRuntime.ResetDispatchGatesForTests();
+        }
+    }
+
+    [Fact]
+    public void DispatchTraceGate_ReadsTheEnvironmentOnceAndKeepsTheAnswer()
+    {
+        var saved = Environment.GetEnvironmentVariable("ALRUNNER_DISPATCH_TRACE");
+        try
+        {
+            BcRuntime.ResetDispatchGatesForTests();
+            Environment.SetEnvironmentVariable("ALRUNNER_DISPATCH_TRACE", "1");
+            Assert.True(BcRuntime.DispatchTraceEnabled);
+
+            Environment.SetEnvironmentVariable("ALRUNNER_DISPATCH_TRACE", "nope");
+            Assert.True(BcRuntime.DispatchTraceEnabled);
+
+            BcRuntime.ResetDispatchGatesForTests();
+            Assert.False(BcRuntime.DispatchTraceEnabled);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("ALRUNNER_DISPATCH_TRACE", saved);
+            BcRuntime.ResetDispatchGatesForTests();
+        }
+    }
+
+    // ── loaded-runtime-assembly lookup ─────────────────────────────────────────
+
+    [Fact]
+    public void RuntimeAssemblyLookup_ScansTheAppDomainOncePerResolvedAssembly()
+    {
+        BcRuntime.ResetRuntimeAssemblyCacheForTests();
+
+        // Resolve the runner's own assembly by whatever simple name it actually carries —
+        // hardcoding it would make this test about the csproj's AssemblyName, not the cache.
+        var self = typeof(BcRuntime).Assembly;
+        var selfName = self.GetName().Name!;
+
+        var first = BcRuntime.FindRuntimeAssembly(selfName);
+        Assert.Same(self, first);
+        Assert.Equal(1, BcRuntime.RuntimeAssemblyScanCount);
+
+        for (var i = 0; i < 10; i++)
+            Assert.Same(self, BcRuntime.FindRuntimeAssembly(selfName));
+
+        Assert.Equal(1, BcRuntime.RuntimeAssemblyScanCount);
+    }
+
+    [Fact]
+    public void RuntimeAssemblyLookup_DoesNotCacheAMiss()
+    {
+        // Ncl is loaded LATE (Program.cs byte-array-loads the Cecil-rewritten copy), so a
+        // negative answer must never be frozen — a cached miss would permanently break every
+        // caller that resolves it before the load.
+        BcRuntime.ResetRuntimeAssemblyCacheForTests();
+
+        Assert.Null(BcRuntime.FindRuntimeAssembly("No.Such.Assembly.Exists"));
+        Assert.Equal(1, BcRuntime.RuntimeAssemblyScanCount);
+        Assert.Null(BcRuntime.FindRuntimeAssembly("No.Such.Assembly.Exists"));
+        Assert.Equal(2, BcRuntime.RuntimeAssemblyScanCount);
+    }
+
+    [Fact]
+    public void RuntimeAssemblyLookup_RequireNamesTheMissingAssembly()
+    {
+        BcRuntime.ResetRuntimeAssemblyCacheForTests();
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => BcRuntime.RequireRuntimeAssembly("No.Such.Assembly.Exists"));
+        Assert.Contains("No.Such.Assembly.Exists", ex.Message);
+    }
+}

--- a/AlRunner/Infrastructure/BackupReaderServe.cs
+++ b/AlRunner/Infrastructure/BackupReaderServe.cs
@@ -1,0 +1,343 @@
+// BackupReaderServe — the long-lived half of the process boundary to `bcbak`.
+//
+// WHY (issue 2263, and the two hangs it caused: issues 2304 and 2336)
+//   `bcdb read` re-opens the backup AND re-parses the whole `--symbols` closure on every
+//   invocation. Measured on this machine against BC 28.1's W1 demo backup with the 108 .app
+//   files a normal run resolves:
+//
+//     bcdb read "Payment Terms" --symbols <108 apps>   1.85 s   (and 1.85 s again, every time)
+//     bcdb serve --symbols <108 apps>, 5 tables        2.49 s   total
+//
+//   The symbol parse is the whole cost and it is paid once in serve mode. Under the
+//   on-demand hydration policy a table is read the first time anything touches it, so a test
+//   that walks 63 tables paid ~63 x 1.85 s INSIDE the test body — which is what made
+//   "API Setup UT".TestSalesInvoicesAreCreatedOnAPISetup look like a non-terminating
+//   repeat/until loop rather than the same read repeated 63 times. It is not a loop bug: the
+//   captured frame just happened to be whatever the test was doing when the per-test timeout
+//   fired.
+//
+// SCOPE OF THIS SLICE
+//   Only `read --format json` is switched, because that is the command issued once per table.
+//   `tables`, `companies`, `describe` and the merge probe run ONCE per run, so routing them
+//   through serve buys nothing and would mean translating three more output shapes. Issue
+//   2263 stays open for those.
+//
+// THE ANSWER MUST BE IDENTICAL, NOT MERELY SIMILAR
+//   Serve answers `{"headers":[...],"rows":[[...]]}`; the CLI prints an array of objects. This
+//   file rebuilds the CLI's exact shape from the serve answer, so
+//   TestDataProvisioner.ParseRows stays the ONE projection both transports go through and
+//   cannot drift between them. BackupReaderServeTests pins that equivalence directly.
+//
+// FALLBACK IS A TRANSPORT FALLBACK, NOT A SILENT DEFAULT
+//   If the reader on PATH has no serve mode, or the pipe breaks, this warns once naming the
+//   reason and every subsequent read goes back to one process per command — the same rows,
+//   more slowly. A request the reader REFUSES (`{"ok":false}`) is not a transport problem and
+//   is raised as BackupReaderException carrying the reader's own text, exactly as a non-zero
+//   exit would be. See .claude/rules/loud-failures.md: the thing that must never happen is an
+//   empty result presented as an answer, and neither branch here can produce one.
+using System.Buffers;
+using System.Diagnostics;
+using System.Text;
+using System.Text.Json;
+
+namespace AlRunner.Infrastructure;
+
+internal static class BackupReaderServe
+{
+    private static readonly object _gate = new();
+
+    private static Process? _proc;
+    private static StreamWriter? _stdin;
+    private static StreamReader? _stdout;
+    private static string? _sessionKey;
+    private static int _nextId;
+    private static bool _disabled;
+    private static bool _warned;
+    private static bool _exitHookInstalled;
+
+    /// <summary>How many read requests were answered over the live session. Test/diagnostic
+    /// seam and the number the PR's claim rests on — one process, N answers.</summary>
+    internal static int ServedReads { get; private set; }
+
+    private static bool? _enabledByEnv;
+
+    /// <summary>Serve mode is on unless AL_RUNNER_BCBAK_SERVE=0. Read once: this is consulted
+    /// per table read.</summary>
+    internal static bool EnabledByEnv
+        => _enabledByEnv ??= Environment.GetEnvironmentVariable("AL_RUNNER_BCBAK_SERVE") != "0";
+
+    internal static void ResetForTests()
+    {
+        lock (_gate)
+        {
+            Shutdown();
+            _disabled = false;
+            _warned = false;
+            _enabledByEnv = null;
+            ServedReads = 0;
+        }
+    }
+
+    // ─────────────────────────────────────────────────── request translation ──
+
+    /// <summary>
+    /// The parsed form of a `read` command line. Null <see cref="Symbols"/> means the command
+    /// carried no --symbols (the reader then answers with SQL column names).
+    /// </summary>
+    internal sealed record ReadRequest(string Backup, string? Symbols, string Json);
+
+    /// <summary>
+    /// Translate a `read ... --format json` argument vector into a serve request. Returns
+    /// false for anything else — another command, a non-json format, or an option this slice
+    /// does not model — so the caller falls back to one process per command rather than
+    /// guessing at a request the reader would answer differently.
+    /// </summary>
+    internal static bool TryBuildReadRequest(IReadOnlyList<string> args, int id, out ReadRequest? request)
+    {
+        request = null;
+        if (args.Count < 2 || !string.Equals(args[0], "read", StringComparison.Ordinal)) return false;
+
+        var backup = args[1];
+        string? table = null, company = null, app = null, select = null, symbols = null, format = null;
+        int? top = null;
+        var mergeExtensions = false;
+
+        for (var i = 2; i < args.Count; i++)
+        {
+            switch (args[i])
+            {
+                case "--merge-extensions": mergeExtensions = true; continue;
+                case "--table": if (++i >= args.Count) return false; table = args[i]; continue;
+                case "--company": if (++i >= args.Count) return false; company = args[i]; continue;
+                case "--app": if (++i >= args.Count) return false; app = args[i]; continue;
+                case "--select": if (++i >= args.Count) return false; select = args[i]; continue;
+                case "--symbols": if (++i >= args.Count) return false; symbols = args[i]; continue;
+                case "--format": if (++i >= args.Count) return false; format = args[i]; continue;
+                case "--top":
+                    if (++i >= args.Count) return false;
+                    if (!int.TryParse(args[i], out var n)) return false;
+                    top = n;
+                    continue;
+                default: return false;   // an option this slice does not model
+            }
+        }
+
+        if (table == null) return false;
+        if (format != null && !string.Equals(format, "json", StringComparison.Ordinal)) return false;
+
+        var buffer = new ArrayBufferWriter<byte>();
+        using (var w = new Utf8JsonWriter(buffer))
+        {
+            w.WriteStartObject();
+            w.WriteNumber("id", id);
+            w.WriteString("cmd", "read");
+            w.WriteString("table", table);
+            if (company != null) w.WriteString("company", company);
+            if (app != null) w.WriteString("app", app);
+            if (select != null) w.WriteString("select", select);
+            if (top != null) w.WriteNumber("top", top.Value);
+            // HYPHENATED, and only written when true: "a key the command does not accept fails
+            // the request instead of being ignored", so an unnecessary key is a hard error.
+            if (mergeExtensions) w.WriteBoolean("merge-extensions", true);
+            w.WriteEndObject();
+        }
+        request = new ReadRequest(backup, symbols, Encoding.UTF8.GetString(buffer.WrittenSpan));
+        return true;
+    }
+
+    // ────────────────────────────────────────────────── response translation ──
+
+    /// <summary>
+    /// Rebuild the CLI's `[{column: value, ...}, ...]` text from a serve `read` answer, so both
+    /// transports feed TestDataProvisioner.ParseRows the same thing. Throws
+    /// <see cref="BackupReaderException"/> carrying the reader's own text when the reader
+    /// refused the request.
+    /// </summary>
+    internal static string TranslateReadResponse(string responseLine, string describeRequest)
+    {
+        JsonDocument doc;
+        try { doc = JsonDocument.Parse(responseLine); }
+        catch (JsonException ex)
+        {
+            throw new BackupReaderException(
+                $"the backup reader's serve answer could not be parsed ({ex.Message}) for: {describeRequest}");
+        }
+
+        using (doc)
+        {
+            var root = doc.RootElement;
+            if (!root.TryGetProperty("ok", out var ok) || ok.ValueKind != JsonValueKind.True)
+            {
+                var error = root.TryGetProperty("error", out var e) ? e.GetString() : null;
+                throw new BackupReaderException(
+                    $"the backup reader refused: {describeRequest}\n  {error ?? responseLine}");
+            }
+            if (!root.TryGetProperty("headers", out var headers) || headers.ValueKind != JsonValueKind.Array)
+                throw new BackupReaderException(
+                    $"the backup reader's serve answer carries no 'headers' array for: {describeRequest}");
+
+            var names = new List<string>();
+            foreach (var h in headers.EnumerateArray()) names.Add(h.GetString() ?? "");
+
+            var buffer = new ArrayBufferWriter<byte>();
+            using (var w = new Utf8JsonWriter(buffer))
+            {
+                w.WriteStartArray();
+                if (root.TryGetProperty("rows", out var rows) && rows.ValueKind == JsonValueKind.Array)
+                {
+                    foreach (var row in rows.EnumerateArray())
+                    {
+                        w.WriteStartObject();
+                        var i = 0;
+                        foreach (var cell in row.EnumerateArray())
+                        {
+                            // A row longer than the header list would silently drop columns;
+                            // that is a reader contract break, not something to absorb.
+                            if (i >= names.Count)
+                                throw new BackupReaderException(
+                                    $"the backup reader returned a row with more cells than headers "
+                                    + $"({names.Count}) for: {describeRequest}");
+                            w.WritePropertyName(names[i++]);
+                            cell.WriteTo(w);
+                        }
+                        w.WriteEndObject();
+                    }
+                }
+                w.WriteEndArray();
+            }
+            return Encoding.UTF8.GetString(buffer.WrittenSpan);
+        }
+    }
+
+    // ───────────────────────────────────────────────────────────── transport ──
+
+    /// <summary>
+    /// Answer <paramref name="args"/> over the shared serve process. False means "not handled
+    /// here" — the caller must spawn a one-shot process. A refusal BY the reader throws.
+    /// </summary>
+    internal static bool TryRun(IReadOnlyList<string> args, out string output)
+    {
+        output = "";
+        if (!EnabledByEnv) return false;
+
+        lock (_gate)
+        {
+            if (_disabled) return false;
+            if (!TryBuildReadRequest(args, _nextId + 1, out var request) || request == null) return false;
+
+            var key = request.Backup + " " + (request.Symbols ?? "");
+            try
+            {
+                if (_sessionKey != key) Start(request.Backup, request.Symbols, key);
+                _nextId++;
+                _stdin!.WriteLine(request.Json);
+                _stdin.Flush();
+                var line = _stdout!.ReadLine();
+                if (line == null)
+                    throw new IOException("the backup reader's serve process closed its output");
+                output = TranslateReadResponse(line, DescribeRead(args));
+                ServedReads++;
+                return true;
+            }
+            catch (BackupReaderException)
+            {
+                // The reader answered and said no. That is an answer, not a broken transport:
+                // keep the session and let the caller's per-table tolerance handle it.
+                throw;
+            }
+            catch (Exception ex)
+            {
+                Disable($"{ex.GetType().Name}: {ex.Message}");
+                return false;
+            }
+        }
+    }
+
+    private static string DescribeRead(IReadOnlyList<string> args)
+        => "bcbak " + string.Join(' ', args.Take(Math.Min(args.Count, 8)));
+
+    private static void Start(string backup, string? symbols, string key)
+    {
+        Shutdown();
+
+        var exe = BackupReaderTool.Resolve();
+        var psi = new ProcessStartInfo(exe)
+        {
+            RedirectStandardInput = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+        psi.ArgumentList.Add("serve");
+        psi.ArgumentList.Add(backup);
+        if (!string.IsNullOrEmpty(symbols))
+        {
+            psi.ArgumentList.Add("--symbols");
+            psi.ArgumentList.Add(symbols);
+        }
+
+        var proc = Process.Start(psi)
+            ?? throw new IOException($"failed to start the backup reader's serve mode: {exe}");
+
+        // stderr MUST be drained or the child blocks once its pipe fills, which would look
+        // like a hang in the middle of hydration — the very failure mode this file removes.
+        _ = proc.StandardError.ReadToEndAsync();
+
+        _proc = proc;
+        _stdin = proc.StandardInput;
+        _stdout = proc.StandardOutput;
+        _sessionKey = key;
+        InstallExitHook();
+    }
+
+    private static void InstallExitHook()
+    {
+        if (_exitHookInstalled) return;
+        _exitHookInstalled = true;
+        AppDomain.CurrentDomain.ProcessExit += (_, _) => { try { Shutdown(); } catch { } };
+    }
+
+    /// <summary>Stop the serve process. Idempotent, and never throws — it runs from
+    /// ProcessExit as well as from Start().</summary>
+    internal static void Shutdown()
+    {
+        var proc = _proc;
+        _proc = null;
+        _sessionKey = null;
+        var stdin = _stdin;
+        _stdin = null;
+        _stdout = null;
+        if (proc == null) return;
+
+        try
+        {
+            if (stdin != null && !proc.HasExited)
+            {
+                stdin.WriteLine("{\"id\":0,\"cmd\":\"quit\"}");
+                stdin.Flush();
+                stdin.Close();
+            }
+        }
+        catch { }
+        try
+        {
+            if (!proc.WaitForExit(3000)) proc.Kill(entireProcessTree: true);
+        }
+        catch { }
+        try { proc.Dispose(); } catch { }
+    }
+
+    private static void Disable(string reason)
+    {
+        Shutdown();
+        _disabled = true;
+        if (_warned) return;
+        _warned = true;
+        // `[warn]` is exempt from Log's component filter, so this reaches the terminal: the
+        // run is about to get much slower and the user is entitled to know why.
+        Console.Error.WriteLine(
+            $"[warn] --test-data: the backup reader's serve mode is unavailable ({reason}); "
+            + "falling back to one reader process per table, which is correct but far slower. "
+            + "Upgrade the reader on AL_RUNNER_BCBAK, or set AL_RUNNER_BCBAK_SERVE=0 to silence this.");
+    }
+}

--- a/AlRunner/Infrastructure/BackupReaderTool.cs
+++ b/AlRunner/Infrastructure/BackupReaderTool.cs
@@ -1,11 +1,15 @@
 // BackupReaderTool — the process boundary between the runner and `bcbak`, the reader that
 // decodes a BC SQL Server `.bak` directly (no SQL Server, no restore, no container).
 //
-// TRANSPORT IS INTERIM: one process per command. The reader has a serve mode that opens the
-// backup once and answers newline-delimited JSON on stdin — measured at 317 ms of startup
-// plus 1.5-15 ms per warm small table, against ~0.7-2.3 s for every invocation here (all 456
-// CRONUS tables: 1.76 s vs 2m13s). #2263 swaps it. This file is the whole surface that has to
-// change: everything else goes through Run(...) and knows nothing about the transport.
+// TRANSPORT: per-table reads go over the reader's SERVE mode (BackupReaderServe.cs); every
+// other command still spawns one process. `read` is the only command issued once per table,
+// and the per-invocation cost is the `--symbols` parse, not the process: measured against BC
+// 28.1's W1 backup with the 108 .app files a normal run resolves, `bcdb read` costs 1.85 s
+// EVERY time, while `bcdb serve` answers five tables in 2.49 s total. See BackupReaderServe's
+// header for what that cost did to issues 2304 and 2336. Issue 2263 stays open for `tables`,
+// `companies` and `describe`, which run once per run and are not worth another output-shape
+// translation. This file plus BackupReaderServe.cs are the whole transport surface:
+// everything else goes through Run(...) and knows nothing about it.
 //
 // WHY A SUBPROCESS AND NOT A PACKAGE REFERENCE
 //   The reader is a separate project that knows nothing about AL Runner, and it must stay
@@ -151,9 +155,16 @@ internal static class BackupReaderTool
     }
 
     /// <summary>Run the reader and return stdout. A non-zero exit is an error, surfaced with
-    /// the reader's own stderr text — never converted into an empty result.</summary>
+    /// the reader's own stderr text — never converted into an empty result.
+    ///
+    /// A `read --format json` is answered over the shared serve process when one is available;
+    /// the returned text is byte-for-byte the shape the CLI would have printed, so no caller
+    /// can tell which transport answered. Everything else, and any read the serve transport
+    /// cannot express, spawns a process here.</summary>
     internal static string Run(IReadOnlyList<string> args, int timeoutMs = 600_000)
     {
+        if (BackupReaderServe.TryRun(args, out var served)) return served;
+
         var exe = Resolve();
         var psi = new ProcessStartInfo(exe)
         {

--- a/AlRunner/LoadedRuntimeAssemblies.cs
+++ b/AlRunner/LoadedRuntimeAssemblies.cs
@@ -1,0 +1,69 @@
+// BcRuntime.LoadedRuntimeAssemblies — one memoised lookup for the BC engine assemblies,
+// replacing the `AppDomain.CurrentDomain.GetAssemblies().First(a => a.GetName().Name == …)`
+// idiom on paths that run per AL operation.
+//
+// WHY THIS IS NOT A MICRO-OPTIMISATION
+//   `RuntimeAssembly.GetName()` is not a field read: it materialises an AssemblyName, which
+//   calls the native `GetCodeBase()`. Doing that for every one of the ~200 assemblies loaded
+//   in a run, on every call, showed up as the resolved leaf frame in 4 of 73 CPU samples of
+//   the single test in #2304 — under `BcRuntime.DispatchCore` (every fired AL event) and
+//   under `NavRecordRefPatches.NavRecordRef_get_Target` (every RecordRef materialisation).
+//
+// A MISS IS NEVER CACHED
+//   Ncl is loaded LATE and from a byte array (Program.cs preloads the Cecil-rewritten copy),
+//   and the Types/Common/Language assemblies only appear once ForceLoadBcDlls() has run. A
+//   caller that asks before the load must get a fresh answer next time, so only a successful
+//   resolution is stored. Pinned by HotPathHookCostTests.RuntimeAssemblyLookup_DoesNotCacheAMiss.
+//
+// ONLY FOR THE ENGINE ASSEMBLIES
+//   Deliberately NOT a general assembly cache. A test-bundle assembly can be superseded by a
+//   newer generation with the same simple name (see BcRuntime.IsStaleBundleAssembly and
+//   EventSubscriberPatches.PruneStaleSubscribers), so memoising by simple name would pin a
+//   stale generation. The BC engine assemblies are loaded once per process and never
+//   replaced, which is exactly what makes memoising them safe.
+using System.Collections.Concurrent;
+using System.Reflection;
+
+namespace AlRunner;
+
+public static partial class BcRuntime
+{
+    private static readonly ConcurrentDictionary<string, Assembly> _runtimeAssemblies =
+        new(StringComparer.Ordinal);
+
+    private static int _runtimeAssemblyScans;
+
+    /// <summary>How many times the AppDomain was actually walked. Test seam: the whole point
+    /// of the cache is that this stops growing once an assembly has been resolved.</summary>
+    internal static int RuntimeAssemblyScanCount => Volatile.Read(ref _runtimeAssemblyScans);
+
+    internal static void ResetRuntimeAssemblyCacheForTests()
+    {
+        _runtimeAssemblies.Clear();
+        Interlocked.Exchange(ref _runtimeAssemblyScans, 0);
+    }
+
+    /// <summary>The loaded assembly with this simple name, or null when it is not loaded yet.
+    /// Successful answers are memoised; a null is not (see the file header).</summary>
+    internal static Assembly? FindRuntimeAssembly(string simpleName)
+    {
+        if (_runtimeAssemblies.TryGetValue(simpleName, out var cached)) return cached;
+
+        Interlocked.Increment(ref _runtimeAssemblyScans);
+        foreach (var asm in AppDomain.CurrentDomain.GetAssemblies())
+        {
+            if (!string.Equals(asm.GetName().Name, simpleName, StringComparison.Ordinal)) continue;
+            _runtimeAssemblies[simpleName] = asm;
+            return asm;
+        }
+        return null;
+    }
+
+    /// <summary>As <see cref="FindRuntimeAssembly"/>, but throws naming the assembly rather
+    /// than returning null — the callers below cannot proceed without it, and an NRE three
+    /// frames later would not say which assembly was missing.</summary>
+    internal static Assembly RequireRuntimeAssembly(string simpleName)
+        => FindRuntimeAssembly(simpleName)
+           ?? throw new InvalidOperationException(
+               $"assembly '{simpleName}' is not loaded in this AppDomain");
+}

--- a/AlRunner/Patches/CodeunitEventDispatcher.cs
+++ b/AlRunner/Patches/CodeunitEventDispatcher.cs
@@ -85,17 +85,53 @@ public static partial class BcRuntime
     /// Returns default ValueTask — synchronous execution model.
     /// </summary>
     private static bool _firstEntryLogged;
+
+    // ── debug gates, read ONCE ────────────────────────────────────────────────────────
+    // Both of these are developer switches, and this method runs on EVERY AL event scope.
+    // Re-reading them per call put System.Environment.GetEnvironmentVariableCore in the
+    // resolved leaf frame of 7 of 73 CPU samples of the single test in #2304. Memoised the
+    // same way EventSubscriberPatches.ScanAuditEnabled already is; setting the variable
+    // after the first dispatch has no effect, which is what ResetDispatchGatesForTests and
+    // HotPathHookCostTests pin.
+    private static bool? _dispatcherOff;
+    private static bool? _dispatchTrace;
+
+    internal static bool DispatcherDisabled
+        => _dispatcherOff ??= Environment.GetEnvironmentVariable("AL_RUNNER_DISPATCHER_OFF") == "1";
+
+    internal static bool DispatchTraceEnabled
+        => _dispatchTrace ??= Environment.GetEnvironmentVariable("ALRUNNER_DISPATCH_TRACE") == "1";
+
+    internal static void ResetDispatchGatesForTests()
+    {
+        _dispatcherOff = null;
+        _dispatchTrace = null;
+    }
+
+    // DispatchCore used to resolve this per FIRED event with
+    // AppDomain.CurrentDomain.GetAssemblies().First(a => a.GetName().Name == "…Ncl"), which
+    // materialises an AssemblyName (and with it a native GetCodeBase call) for every loaded
+    // assembly until it hits the match. Resolved once instead; Ncl is loaded once per process
+    // and never replaced. See LoadedRuntimeAssemblies.cs.
+    private static Type? _tNavMethodScope;
+
+    private static Type NavMethodScopeType
+        => _tNavMethodScope ??= RequireRuntimeAssembly("Microsoft.Dynamics.Nav.Ncl")
+            .GetType("Microsoft.Dynamics.Nav.Runtime.NavMethodScope")
+           ?? throw new InvalidOperationException(
+               "Microsoft.Dynamics.Nav.Runtime.NavMethodScope not found in Microsoft.Dynamics.Nav.Ncl");
+
     [MethodImpl(MethodImplOptions.NoInlining)]
     public static System.Threading.Tasks.ValueTask CodeunitEventDispatch_OnRunEventAsync(object publisherScope)
     {
         if (!_firstEntryLogged) { _firstEntryLogged = true; Console.Error.WriteLine($"[Dispatch] entry-method first hit"); }
-        if (Environment.GetEnvironmentVariable("AL_RUNNER_DISPATCHER_OFF") == "1")
+        if (DispatcherDisabled)
             return default;
         try { DispatchCore(publisherScope); }
         catch (Exception ex)
         {
             var inner = ex is TargetInvocationException tie ? tie.InnerException ?? ex : ex;
-            if (Environment.GetEnvironmentVariable("ALRUNNER_DISPATCH_TRACE") == "1")
+            if (DispatchTraceEnabled)
                 Console.Error.WriteLine(
                     $"[DispatchRethrow] {inner.GetType().Name}: {inner.Message}\nCALLER CHAIN:\n{Environment.StackTrace}");
             RethrowPreservingStack(inner);
@@ -165,13 +201,11 @@ public static partial class BcRuntime
         if (subs == null || subs.Count == 0) return;
         Interlocked.Increment(ref _dispatchFiredCount);
         if (!_firstFireLogged) { _firstFireLogged = true; Console.Error.WriteLine($"[Dispatch] first FIRE: {declName}.{eventMethodName} → {subs.Count} subs"); }
-        if (Environment.GetEnvironmentVariable("ALRUNNER_DISPATCH_TRACE") == "1")
+        if (DispatchTraceEnabled)
             Console.Error.WriteLine($"[Dispatch] FIRE {declName}.{eventMethodName} → {subs.Count} subs");
 
         // Publisher application object (NavCodeunit) — for NavCodeunitHandle.Target lookup of subscriber instances.
-        var navMethodScopeType = AppDomain.CurrentDomain.GetAssemblies()
-            .First(a => a.GetName().Name == "Microsoft.Dynamics.Nav.Ncl")
-            .GetType("Microsoft.Dynamics.Nav.Runtime.NavMethodScope")!;
+        var navMethodScopeType = NavMethodScopeType;
         var pubObj = navMethodScopeType.GetProperty("ApplicationObject", BindingFlags.Public | BindingFlags.Instance)?
             .GetValue(publisherScope);
         if (pubObj == null) return;
@@ -207,7 +241,7 @@ public static partial class BcRuntime
             }
             catch (TargetInvocationException tie)
             {
-                if (Environment.GetEnvironmentVariable("ALRUNNER_DISPATCH_TRACE") == "1")
+                if (DispatchTraceEnabled)
                     Console.Error.WriteLine(
                         $"[DispatchThrow] {declName}.{eventMethodName} subscriber threw: "
                         + $"{(tie.InnerException ?? tie).GetType().Name}: {(tie.InnerException ?? tie).Message}");
@@ -449,7 +483,7 @@ public static partial class BcRuntime
                 continue;
             }
             args[i] = CoerceArg(fld?.GetValue(publisherScope), p.ParameterType);
-            if (Environment.GetEnvironmentVariable("ALRUNNER_DISPATCH_TRACE") == "1"
+            if (DispatchTraceEnabled
                 && subscriberMethod.Name.Contains("CustomDocumentMerger", StringComparison.OrdinalIgnoreCase))
             {
                 string repr;

--- a/AlRunner/Patches/HelperShims.cs
+++ b/AlRunner/Patches/HelperShims.cs
@@ -294,15 +294,33 @@ public static partial class BcRuntime
     [MethodImpl(MethodImplOptions.NoInlining)] public static bool ReturnFalse2(object? a, object? b) => false;
 
     /// <summary>
-    /// Diagnostic helper used for the RecordImplementation.IsOpen hook — logs the call
-    /// site so we can trace which patched receiver is being asked. Always returns true
-    /// (record is open) because by the time the test harness asks, we want the read path
-    /// to proceed against TempTableDataProvider rather than throw NotOpened.
+    /// Replacement for <c>RecordImplementation.get_IsOpen</c>. Always returns true (the
+    /// record is open) because by the time the test harness asks, we want the read path to
+    /// proceed against TempTableDataProvider rather than throw NotOpened.
+    ///
+    /// THIS IS THE HOTTEST HOOK IN THE RUNNER — keep the body free of allocation and I/O.
+    /// <c>NavRecord.GetFieldValue</c> asks for IsOpen on every field read, so whatever this
+    /// method does happens millions of times in a single test. It used to build an
+    /// interpolated string (including a reflective <c>a.GetType().Name</c>) and push it
+    /// through Console.Error unconditionally, as a leftover tracing aid. The line was never
+    /// even visible: Log's FilteredWriter drops bracket-tagged lines at default verbosity, so
+    /// the allocation, the reflection, the compiled-Regex match and the synchronized write all
+    /// bought nothing. CPU sampling of the test in issue 2304 caught it directly —
+    /// SyncTextWriter.WriteLine under BcRuntime.ReturnTrue under NavRecord.GetFieldValue.
+    /// The trace is kept behind a gate that is read ONCE, for whoever needs it next.
     /// </summary>
+    private static readonly bool _logIsOpenHook =
+        Environment.GetEnvironmentVariable("AL_RUNNER_LOG_ISOPEN_HOOK") == "1";
+
+    /// <summary>Whether the IsOpen hook traces every call. Off unless
+    /// AL_RUNNER_LOG_ISOPEN_HOOK=1 is set in the environment.</summary>
+    internal static bool IsOpenHookLoggingEnabled => _logIsOpenHook;
+
     [MethodImpl(MethodImplOptions.NoInlining)]
     public static bool ReturnTrue(object? a)
     {
-        Console.Error.WriteLine($"[ReturnTrue] IsOpen hook fired for {a?.GetType().Name}");
+        if (_logIsOpenHook)
+            Console.Error.WriteLine($"[ReturnTrue] IsOpen hook fired for {a?.GetType().Name}");
         return true;
     }
 }

--- a/AlRunner/Patches/HelperShims.cs
+++ b/AlRunner/Patches/HelperShims.cs
@@ -309,17 +309,21 @@ public static partial class BcRuntime
     /// SyncTextWriter.WriteLine under BcRuntime.ReturnTrue under NavRecord.GetFieldValue.
     /// The trace is kept behind a gate that is read ONCE, for whoever needs it next.
     /// </summary>
-    private static readonly bool _logIsOpenHook =
-        Environment.GetEnvironmentVariable("AL_RUNNER_LOG_ISOPEN_HOOK") == "1";
+    /// <summary>
+    /// One gate for every per-call hook trace, read ONCE. A hook that fires per field read or
+    /// per record construction cannot afford an environment read, let alone a formatted
+    /// console write, and two of them were doing both. Set AL_RUNNER_TRACE_HOOKS=1 to get the
+    /// traces back.
+    /// </summary>
+    private static readonly bool _traceHooks =
+        Environment.GetEnvironmentVariable("AL_RUNNER_TRACE_HOOKS") == "1";
 
-    /// <summary>Whether the IsOpen hook traces every call. Off unless
-    /// AL_RUNNER_LOG_ISOPEN_HOOK=1 is set in the environment.</summary>
-    internal static bool IsOpenHookLoggingEnabled => _logIsOpenHook;
+    internal static bool HookTraceEnabled => _traceHooks;
 
     [MethodImpl(MethodImplOptions.NoInlining)]
     public static bool ReturnTrue(object? a)
     {
-        if (_logIsOpenHook)
+        if (_traceHooks)
             Console.Error.WriteLine($"[ReturnTrue] IsOpen hook fired for {a?.GetType().Name}");
         return true;
     }

--- a/AlRunner/Patches/MethodScopePatches.cs
+++ b/AlRunner/Patches/MethodScopePatches.cs
@@ -21,6 +21,37 @@ public static partial class BcRuntime
 {
     [ThreadStatic] private static int _navMethodScopeDepth;
     private const int MaxRecursionDepth = 500;
+
+    // ── GetMethodScopeFlags, resolved once per concrete scope type ───────────────────────
+    //
+    // This ctor replacement runs on EVERY AL method call -- NavMethodScope is the per-AL-frame
+    // execution unit -- and it used to do a Type.GetMethod("GetMethodScopeFlags", NonPublic |
+    // Instance) lookup each time. A reflection member lookup walks the type's method table and
+    // allocates; the answer depends only on the concrete scope type, of which a run has a
+    // handful. Resolved once per type instead. A null answer is cached too: "this subtype does
+    // not override it" is as stable as the type itself, and re-asking would put the lookup back
+    // on the path for exactly the types that cannot benefit from it.
+    private static readonly System.Collections.Concurrent.ConcurrentDictionary<Type, MethodInfo?>
+        _getMethodScopeFlagsByType = new();
+
+    private static int _getMethodScopeFlagsLookups;
+
+    /// <summary>How many reflection lookups were actually performed. Test seam: the cache's
+    /// whole claim is that this stops growing once a scope type has been seen.</summary>
+    internal static int GetMethodScopeFlagsLookupCount => Volatile.Read(ref _getMethodScopeFlagsLookups);
+
+    internal static void ResetGetMethodScopeFlagsCacheForTests()
+    {
+        _getMethodScopeFlagsByType.Clear();
+        Interlocked.Exchange(ref _getMethodScopeFlagsLookups, 0);
+    }
+
+    internal static MethodInfo? ResolveGetMethodScopeFlags(Type scopeType)
+        => _getMethodScopeFlagsByType.GetOrAdd(scopeType, static t =>
+        {
+            Interlocked.Increment(ref _getMethodScopeFlagsLookups);
+            return t.GetMethod("GetMethodScopeFlags", BindingFlags.NonPublic | BindingFlags.Instance);
+        });
     /// <summary>
     /// Full replacement for NavMethodScope..ctor(NavApplicationObjectBase, MethodScopeFlags, bool).
     ///
@@ -92,8 +123,7 @@ public static partial class BcRuntime
             {
                 try
                 {
-                    var getFlags = self.GetType().GetMethod("GetMethodScopeFlags",
-                        BindingFlags.NonPublic | BindingFlags.Instance);
+                    var getFlags = ResolveGetMethodScopeFlags(self.GetType());
                     var scopeFlags = getFlags != null ? getFlags.Invoke(self, null) : null;
                     FieldPoke.SetInstance(_fMsFlags, self, scopeFlags ?? Enum.ToObject(_fMsFlags.FieldType, 0));
                 }

--- a/AlRunner/Patches/NavRecordRefPatches.cs
+++ b/AlRunner/Patches/NavRecordRefPatches.cs
@@ -103,8 +103,11 @@ public static partial class BcRuntime
         if (existing != null) return existing;
 
         // Construct SharedRecordRef using a skeleton TreeSharedObjectContainer.
-        var navNcl = AppDomain.CurrentDomain.GetAssemblies()
-            .First(a => a.GetName().Name == "Microsoft.Dynamics.Nav.Ncl");
+        // Resolved through the memoised lookup: this method runs on every RecordRef
+        // materialisation, and the AppDomain scan it replaces (which calls
+        // RuntimeAssembly.GetName -> native GetCodeBase per loaded assembly) was a resolved
+        // leaf frame in the #2304 profile. See BcRuntime LoadedRuntimeAssemblies.cs.
+        var navNcl = RequireRuntimeAssembly("Microsoft.Dynamics.Nav.Ncl");
         if (_skeletonSharedObjectContainer == null)
         {
             var tContainer = navNcl.GetType("Microsoft.Dynamics.Nav.Runtime.TreeSharedObjectContainer")!;

--- a/AlRunner/Patches/RecordPatches.cs
+++ b/AlRunner/Patches/RecordPatches.cs
@@ -1111,10 +1111,18 @@ public static partial class RecordPatches
     /// Replacement for NavSession.DataAccessSource getter.
     /// Returns a skeleton DataAccessSource backed by TempTableDataProvider (in-memory).
     /// </summary>
+    /// <remarks>
+    /// PER RECORD CONSTRUCTION -- NavRecord..ctor asks the session for its DataAccessSource, so
+    /// this getter runs once per AL record variable that comes into existence. It used to open
+    /// with an unconditional Console.Error.WriteLine, the same leftover tracing aid the IsOpen
+    /// hook carried, and CPU sampling of the test in issue 2304 caught the two of them the
+    /// same way. Behind BcRuntime.HookTraceEnabled now, which is read once.
+    /// </remarks>
     [MethodImpl(MethodImplOptions.NoInlining)]
     public static object? NavSession_get_DataAccessSource(NavSession self)
     {
-        Console.Error.WriteLine("[RecordPatches] NavSession_get_DataAccessSource called");
+        if (BcRuntime.HookTraceEnabled)
+            Console.Error.WriteLine("[RecordPatches] NavSession_get_DataAccessSource called");
         // Return cached DataAccessSource stored on the session's field.
         var existing = _fSessionDataAccessSource?.GetValue(self);
         if (existing != null) return existing;


### PR DESCRIPTION
Closes #2336

## What was actually happening

`Codeunit 134636 "API Setup UT".TestSalesInvoicesAreCreatedOnAPISetup` is not stuck in a
`repeat ... until Next() = 0` loop. Nothing about it is non-terminating. With
`--test-timeout 400` it finishes, and it finished at 73.7 s on `main` before this change.

The time goes into hydration. Under the on-demand `--test-data` policy a table's rows are read
the first time anything touches it, and each read spawns `bcbak read` with the full `--symbols`
closure. The reader re-parses that closure every time. Measured on this machine against BC
28.1's W1 demo backup with the 108 `.app` files a normal run resolves:

| | |
|---|---|
| `bcdb read "Payment Terms" --symbols <108 apps>` | 1.85 s, and 1.85 s again on the next call |
| `bcdb serve --symbols <108 apps>`, five tables in one process | 2.49 s total |

That test touches 129 tables, so it spent minutes inside its own body doing nothing but
re-parsing symbols. The frame the timeout captured
(`Graph Mgt - Sales Quote Buffer.InsertOrModifyFromSalesHeader`) is just wherever the test
happened to be when the 60 s timeout fired, which is why it looked like a loop and why it moved
between runs.

## The fix

Per-table reads go over the reader's serve mode, which opens the backup and parses the symbols
once. Only `read --format json` moves; `tables`, `companies` and `describe` run once per run, so
routing them through serve buys nothing and would mean translating three more output shapes.
#2263 stays open for those.

The serve answer (`{"headers":[...],"rows":[[...]]}`) is rebuilt into the exact array-of-objects
text the CLI prints, so `TestDataProvisioner.ParseRows` stays the single projection both
transports go through and cannot drift between them. `BackupReaderServeTests` builds the same
table in both wire shapes and asserts `ParseRows` agrees key for key and value for value.

A reader with no serve mode, or a broken pipe, prints one `[warn]` line naming the reason and
falls back to one process per command — same rows, slower. A reader that *refuses* a request
still raises `BackupReaderException` carrying the reader's own text, so a table that cannot be
read is never presented as an empty table. `AL_RUNNER_BCBAK_SERVE=0` forces the old transport.

**Measured on the reported test run on its own, same 129 tables and 18,483 rows hydrated either
way: 73,676 ms before, 17,415 ms after.** It no longer exceeds the 60 s default timeout.

### Correcting one thing in the issue, measured

The issue says this test caps a full `Tests-SINGLESERVER` run at 19 of 878 tests. **That is no
longer reproducible on current `main`.** I ran the bucket three times with
`APISetupUT.Codeunit.al` restored and `ERMPurchaseReportsIII.Codeunit.al` (#2304) still parked,
same 834 tests each time:

| build | pass / fail / error | test run | wall | timeouts |
|---|---|---|---|---|
| `origin/main` @ 2452eef0 | 188 / 637 / 9 | 228.6 s | 283.3 s | 0 |
| this branch, `AL_RUNNER_BCBAK_SERVE=0` | 188 / 637 / 9 | 190.7 s | 194.2 s | 0 |
| this branch | 188 / 637 / 9 | **99.1 s** | 165.3 s | 0 |

So the bucket already completes on `main` — something that merged earlier today moved it — and
codeunit 134636 costs only ~350 ms *inside a full run*, because by the time it executes the
earlier codeunits have already hydrated most of the tables it touches. The 73.7 s is what it
costs when it is the first thing to touch them, which is what the isolated `--test` run in the
issue measures.

What this PR does change, on identical bundles with byte-identical results: the whole bucket
goes from 228.6 s to 99.1 s of test time, 2.3x. The middle row separates the two halves — the
hot-path fixes below account for 228.6 to 190.7 s, serve mode for the rest.

## Hot-path costs found while profiling this, fixed here too

CPU sampling of the run turned up four hooks doing per-call work that only needed doing once.
They are not what #2336 was about, but they are on the paths every AL test walks:

- **`BcRuntime.ReturnTrue`**, the `RecordImplementation.get_IsOpen` replacement, built an
  interpolated string with a reflective `GetType().Name` and pushed it through `Console.Error`
  on every call. `NavRecord.GetFieldValue` asks for `IsOpen` on every field read, and Log's
  filter drops the line at default verbosity, so the allocation, the reflection, the compiled
  Regex match and the synchronized write all bought nothing. Sampling caught it directly:
  `SyncTextWriter.WriteLine` under `BcRuntime.ReturnTrue` under `NavRecord.GetFieldValue`.
- **`RecordPatches.NavSession_get_DataAccessSource`** opened with the same unconditional
  console write, and `NavRecord..ctor` calls it once per AL record variable.
- **`CodeunitEventDispatch_OnRunEventAsync`** re-read `AL_RUNNER_DISPATCHER_OFF` and
  `ALRUNNER_DISPATCH_TRACE` from the environment per dispatch.
- **`DispatchCore` and `NavRecordRef_get_Target`** each re-ran
  `AppDomain.GetAssemblies().First(a => a.GetName().Name == "…Ncl")` per call.
  `RuntimeAssembly.GetName()` materialises an `AssemblyName` and calls the native
  `GetCodeBase()`, so that scan is not free.
- **`NavMethodScopeCtorReplacement`** did a `Type.GetMethod("GetMethodScopeFlags", NonPublic |
  Instance)` lookup per construction. `NavMethodScope` is the per-AL-frame execution unit, so
  that is a reflection member lookup per AL method call.

Both console traces now sit behind one gate, `AL_RUNNER_TRACE_HOOKS=1`, read once. The two
environment gates are memoised the way `EventSubscriberPatches.ScanAuditEnabled` already was.
The assembly and method lookups are memoised per name and per type; a *miss* is deliberately not
cached, because Ncl loads late.

On an AL probe doing ~80k field reads over a temporary record, the `IsOpen` write alone costs
about 25 % of the test's runtime (338–341 ms with it off, 391–505 ms with it on, three runs
each, same build, toggled by the env var).

## Fixing the shape, not just the reported line

- **Does the same wrong pattern appear at another call site?** Yes. Grepping for the shape
  behind `ReturnTrue` — an unconditional console write in a Cecil replacement body — found
  `NavSession_get_DataAccessSource`, which is on an even hotter path. Fixed here.
- **Does a sibling function make the same assumption?** Yes, twice. The dispatcher read a
  *second* environment variable per call, and `NavRecordRef_get_Target` did the same assembly
  scan as `DispatchCore`. Both fixed. One more sibling is **not** fixed here and is filed as
  #2369: `EventSubscriberPatches.InjectValidateSubsForTable` runs on every record construction
  and scans every discovered validate subscriber under a lock. It was 16 % of self time in the
  profile taken *after* this PR's changes, and fixing it properly means reindexing the
  subscriber registry, which is a bigger change than belongs here.
- **If two code paths write the same state, do they maintain the same invariant?** This PR
  creates exactly one such pair — the serve transport and the one-shot CLI both produce rows for
  hydration. That is why the translation targets the CLI's own text rather than a second parser,
  and why the equivalence is a test rather than a comment.

## Testing

- `AlRunner.Tests/BackupReaderServeTests` (15) — request translation, response translation,
  CLI/serve equivalence through `ParseRows`, and the four ways a bad answer must be refused
  rather than read as an empty table.
- `AlRunner.Tests/HotPathHookCostTests` (9) — the hooks write nothing to the console by default,
  each gate is read once, and each memo performs one lookup per distinct key. RED confirmed for
  the console test by restoring the unconditional write; it fails, and passes again once the
  gate is back.
- `dotnet test AlRunner.Tests`: 1370 passed, 69 skipped, 3 failed. All three failures are
  environment contention on this box (five other agents were running the same suite against the
  same shared caches at the time): `InstallBaselineDiskCacheTests.DifferentDependencyClosures_…`
  and both `ProvisionExplicitModesTests` cases pass when re-run on their own, the latter two in
  2 s each. None of the three touches anything this PR changes.
- AL side: `Codeunit134636.TestSalesInvoicesAreCreatedOnAPISetup` measured before and after, as
  above.

## What this does not fix

#2304 is a different defect and stays open. That test also completes rather than hanging, but it
takes 480–670 s depending on machine load, and hydration is only ~35 s of that. The rest is real
AL execution inside Report 402 and `Purch.-Post`, spread across the prepayment and VAT-amount
machinery with no single dominant frame. The hot-path fixes above take real work off that path
but nowhere near enough to bring it under any sane per-test timeout.
