### PR TITLE
fix(session): give the skeleton NavDatabase a tenant so BC can answer the execution context

### DIFF
--- a/AlRunner.Tests/SkeletonDatabaseTenantExecutionContextTests.cs
+++ b/AlRunner.Tests/SkeletonDatabaseTenantExecutionContextTests.cs
@@ -1,0 +1,183 @@
+// SkeletonDatabaseTenantExecutionContextTests — AlRunner#2353.
+//
+// RUNNER-MECHANISM test, not a claim about what real BC does. The BC-observable half —
+// "an ordinary test session reports ExecutionContext::Normal" — is already in the upstream
+// corpus (session/TestSessionExtended.al, session/TestBCPlatformContracts.al), measured
+// against a live service tier.
+//
+// What this pins is our own skeleton state, which the corpus cannot see:
+//
+//   * The runner builds NavDatabase with RuntimeHelpers.GetUninitializedObject, so BC's own
+//     ctor never ran and the private `tenant` field stayed null — while NavSession.Database
+//     and NavTenant.Database are both Cecil-rewritten to hand out that one instance. Every
+//     session therefore saw Database.Tenant == null.
+//
+//   * BC's NavDatabase.UpgradeManager is
+//         upgradeManager ??= new NavDataUpgradeManager(SystemTenant.UpgradeMetadata, Tenant);
+//     whose two-argument ctor chains through `tenant.Id`. With a null tenant that is a bare
+//     NullReferenceException raised inside a BC constructor, and it is on the path of
+//     NavSession.ExecutionContext, GetCurrentModuleExecutionContext and
+//     GetModuleExecutionContext — reached from ordinary AL, e.g. BaseApp's Company-Initialize
+//     asking for the execution context from its OnCompanyOpen subscriber.
+//
+//   * NavSystemTenant.upgradeMetadata is the same shape (its real ctor sets it, the skeleton
+//     skipped the ctor), so fixing only the tenant moves the failure to
+//     ArgumentNullException("upgradeMetadata").
+//
+// The last test is the one that keeps this honest. Both the source-level shim in
+// BcAssembler.cs and the Cecil replacement of NavSession.get_ExecutionContext used to answer
+// a hardcoded ExecutionContext.Normal; both are gone, because BC's own getter now runs. A
+// regression that reintroduces either would still satisfy "reports Normal in a plain test",
+// so this asserts the getter answers Upgrade once the session carries an app upgrade
+// context — which only a real evaluation of BC's body can do.
+
+using System.Reflection;
+using Xunit;
+
+namespace AlRunner.Tests;
+
+[Collection(BcEngineCollection.Name)]
+public sealed class SkeletonDatabaseTenantExecutionContextTests
+{
+    private readonly BcEngineFixture _engine;
+
+    public SkeletonDatabaseTenantExecutionContextTests(BcEngineFixture engine) => _engine = engine;
+
+    private const BindingFlags AnyInstance =
+        BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic;
+
+    private object Session()
+    {
+        var session = AlRunner.BcRuntime.SkeletonSession;
+        Assert.NotNull(session);
+        return session!;
+    }
+
+    private static object? Get(object target, string member)
+    {
+        var t = target.GetType();
+        for (var walk = t; walk != null; walk = walk.BaseType)
+        {
+            var prop = walk.GetProperty(member, AnyInstance);
+            if (prop != null) return prop.GetValue(target);
+        }
+        throw new InvalidOperationException($"{t.FullName}.{member} not found — Ncl shape changed.");
+    }
+
+    private static FieldInfo Field(object target, string name)
+    {
+        for (var walk = target.GetType(); walk != null; walk = walk.BaseType)
+        {
+            var f = walk.GetField(name, AnyInstance);
+            if (f != null) return f;
+        }
+        throw new InvalidOperationException(
+            $"{target.GetType().FullName}.{name} field not found — Ncl shape changed.");
+    }
+
+    [SkippableFact]
+    public void SkeletonDatabase_ReportsATenant()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready,
+            _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        var database = Get(Session(), "Database");
+        Assert.NotNull(database);
+
+        var tenant = Get(database!, "Tenant");
+        Assert.NotNull(tenant);
+
+        // Not merely non-null: the tenant BC hands out must be the same skeleton the session
+        // itself carries, otherwise Database.Tenant and Session.Tenant would disagree about
+        // tenant id, encoding and settings.
+        Assert.Same(Get(Session(), "Tenant"), tenant);
+
+        // NavTenant.Id => id ?? tenantSettings.Id; the runner seeds "default". A null here is
+        // what NavDataUpgradeManager's ctor dereferences.
+        Assert.Equal("default", Get(tenant!, "Id"));
+    }
+
+    [SkippableFact]
+    public void SkeletonSystemTenant_CarriesUpgradeMetadata()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready,
+            _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        var systemTenant = Get(Session(), "SystemTenant");
+        Assert.NotNull(systemTenant);
+
+        var upgradeMetadata = Get(systemTenant!, "UpgradeMetadata");
+        Assert.NotNull(upgradeMetadata);
+        Assert.Equal("NavDataUpgradeMetadata", upgradeMetadata!.GetType().Name);
+    }
+
+    [SkippableFact]
+    public void UpgradeManager_ConstructsAndReportsNoUpgradeStarted()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready,
+            _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        // This is the exact expression that used to raise NullReferenceException from inside
+        // NavDataUpgradeManager..ctor.
+        var upgradeManager = Get(Get(Session(), "Database")!, "UpgradeManager");
+        Assert.NotNull(upgradeManager);
+
+        var info = upgradeManager!.GetType()
+            .GetMethod("GetUpgradeInformation", AnyInstance)!
+            .Invoke(upgradeManager, null);
+        Assert.NotNull(info);
+
+        // No data upgrade workflow was ever started here, so BC's own answer is NotStarted —
+        // which is what makes GetModuleExecutionContext fall through to Normal.
+        Assert.Equal("NotStarted", Get(info!, "State")!.ToString());
+    }
+
+    [SkippableFact]
+    public void ExecutionContext_IsNormal_AndModuleScopedFormsAgree()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready,
+            _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        var session = Session();
+        Assert.Equal("Normal", Get(session, "ExecutionContext")!.ToString());
+
+        var current = session.GetType()
+            .GetMethod("GetCurrentModuleExecutionContext", AnyInstance)!
+            .Invoke(session, null);
+        Assert.Equal("Normal", current!.ToString());
+
+        var byModule = session.GetType()
+            .GetMethod("GetModuleExecutionContext", AnyInstance, binder: null,
+                new[] { typeof(Guid) }, modifiers: null)!
+            .Invoke(session, new object[] { Guid.Empty });
+        Assert.Equal("Normal", byModule!.ToString());
+    }
+
+    [SkippableFact]
+    public void ExecutionContext_IsComputed_NotHardcodedNormal()
+    {
+        TestArtifacts.SkipIf(!_engine.Ready,
+            _engine.SkipReason ?? "the in-process BC engine is not ready (see BcEngineCollection).");
+
+        var session = Session();
+        var field = Field(session, "appUpgradeContext");
+        var saved = field.GetValue(session);
+        Assert.Null(saved);
+
+        // BC's getter only NULL-CHECKS this one, so an uninitialised instance is enough to
+        // drive the branch and cannot reach into anything the skeleton does not have.
+        var context = System.Runtime.CompilerServices.RuntimeHelpers.GetUninitializedObject(
+            field.FieldType);
+        try
+        {
+            field.SetValue(session, context);
+            Assert.Equal("Upgrade", Get(session, "ExecutionContext")!.ToString());
+        }
+        finally
+        {
+            field.SetValue(session, saved);
+        }
+
+        Assert.Equal("Normal", Get(session, "ExecutionContext")!.ToString());
+    }
+}

--- a/AlRunner/BcAssembler.cs
+++ b/AlRunner/BcAssembler.cs
@@ -162,10 +162,12 @@ public sealed class BcAssembler
         ("ALDebugger.CheckPermissionToDebug(", "global::AlRunnerShim.NavRuntimeHelpersShim.ALDebugger_CheckPermissionToDebug("),
         // ALSession.ALStopSession sync wrappers NRE via session.Diagnostics; return false.
         ("ALSession.ALStopSession(",   "global::AlRunnerShim.NavRuntimeHelpersShim.ALSession_StopSession("),
-        // ALSession.ALGetExecutionContext / ALGetModuleExecutionContext NRE via session properties.
-        // Return ExecutionContext.Normal (0) which is the expected value in a headless runner.
-        ("ALSession.ALGetExecutionContext(",         "global::AlRunnerShim.NavRuntimeHelpersShim.ALGetExecutionContext("),
-        ("ALSession.ALGetModuleExecutionContext(",   "global::AlRunnerShim.NavRuntimeHelpersShim.ALGetModuleExecutionContext("),
+        // ALSession.ALGetExecutionContext / ALGetModuleExecutionContext used to be redirected here
+        // to a shim that always answered ExecutionContext.Normal. Removed with AlRunner#2353:
+        // they NRE'd only because NavDatabase.Tenant was null on the skeleton, and that is now
+        // populated (RecordPatches.Register), so BC's own bodies run and compute the answer —
+        // including Install / Uninstall / Upgrade from session.AppInstallationContext and
+        // session.AppUpgradeContext, which a hardcoded Normal got wrong inside an install trigger.
         // ALSession.ALSendTraceTag NREs via session.Diagnostics; telemetry is a no-op here.
         ("ALSession.ALSendTraceTag(",  "global::AlRunnerShim.NavRuntimeHelpersShim.ALSession_SendTraceTag("),
         // ALSessionInformation static properties NRE via session.SqlDebuggingStatisticsCheckPoint.
@@ -300,17 +302,6 @@ namespace AlRunnerShim
         // ALSession.ALStopSession — sync wrappers call ALStopSessionAsync which NREs.
         public static bool ALSession_StopSession(Microsoft.Dynamics.Nav.Types.DataError e, int sessionId) => false;
         public static bool ALSession_StopSession(Microsoft.Dynamics.Nav.Types.DataError e, int sessionId, string comment) => false;
-
-        // ALSession.ALGetExecutionContext / ALGetModuleExecutionContext.
-        // Return Normal (0) — headless runner has no install/upgrade execution context.
-        public static Microsoft.Dynamics.Nav.Types.ExecutionContext ALGetExecutionContext(object session)
-            => Microsoft.Dynamics.Nav.Types.ExecutionContext.Normal;
-        public static Microsoft.Dynamics.Nav.Types.ExecutionContext ALGetModuleExecutionContext(object session)
-            => Microsoft.Dynamics.Nav.Types.ExecutionContext.Normal;
-        public static Microsoft.Dynamics.Nav.Types.ExecutionContext ALGetModuleExecutionContext(object session, int id)
-            => Microsoft.Dynamics.Nav.Types.ExecutionContext.Normal;
-        public static Microsoft.Dynamics.Nav.Types.ExecutionContext ALGetModuleExecutionContext(object session, System.Guid id)
-            => Microsoft.Dynamics.Nav.Types.ExecutionContext.Normal;
 
         // ALSession.ALSendTraceTag — telemetry no-op; accepts all parameter overloads.
         public static void ALSession_SendTraceTag(object session, string tag, string category, object verbosity, string message) { }

--- a/AlRunner/Infrastructure/NclCecilRewrite.cs
+++ b/AlRunner/Infrastructure/NclCecilRewrite.cs
@@ -327,9 +327,6 @@ public static class NclCecilRewrite
         "Microsoft.Dynamics.Nav.Runtime.NavSession::SyncFormatSettings/0",
         "Microsoft.Dynamics.Nav.Runtime.NavSession::get_Culture/0",
         "Microsoft.Dynamics.Nav.Runtime.NavSession::get_WindowsCulture/0",
-        // get_ExecutionContext → Normal (skeleton Database.Tenant is null → UpgradeManager
-        // ctor NRE). Body rewritten in RewriteNcl (search "get_ExecutionContext").
-        "Microsoft.Dynamics.Nav.Runtime.NavSession::get_ExecutionContext/0",
         "Microsoft.Dynamics.Nav.Runtime.RecordImplementation::GetActiveCompany/0",
         "Microsoft.Dynamics.Nav.Runtime.NavStream::get_Target/0",
         // NavHttpClient/NavHttpResponseMessageBase/NavHttpRequestMessage.get_Target — same
@@ -4044,34 +4041,16 @@ public static class NclCecilRewrite
             Console.Error.WriteLine("[Cecil] Replaced NavSession.get_SortingProperties → RecordPatches.NavSession_get_SortingProperties");
         }
 
-        // ── NavSession.get_ExecutionContext → return ExecutionContext.Normal (0) ──
-        // The getter computes: if installing→Install, if upgrading→Upgrade, else checks
-        // `Database?.UpgradeManager?.IsSessionInUpgrade(Id)` → Upgrade, else Normal.
-        // On the skeleton, `Database.Tenant` is null, so the lazy `UpgradeManager` getter
-        // (`new NavDataUpgradeManager(SystemTenant.UpgradeMetadata, Tenant)`) NREs at
-        // `tenant.Id` in the ctor delegation. A headless test session is never installing,
-        // uninstalling, or in a data upgrade, so the faithful value is always Normal —
-        // identical to the existing ALSession.ALGetExecutionContext shim (BcAssembler.cs).
-        // Reached from BaseApp WorkflowSetup.AddEventToLibrary (Codeunit 1520) during
-        // WorkflowSetup.InitWorkflow → CreateEventsLibrary → OnAddWorkflowEventsToLibrary
-        // subscriber fan-out (RecoverySolutions Customizations.Test, 40 workflow tests).
-        {
-            var navSessionType = asm.MainModule.GetType("Microsoft.Dynamics.Nav.Runtime.NavSession")
-                ?? throw new InvalidOperationException("NavSession type not found");
-            var getExecCtx = navSessionType.Methods.FirstOrDefault(m =>
-                m.Name == "get_ExecutionContext" && m.Parameters.Count == 0 && !m.IsStatic)
-                ?? throw new InvalidOperationException("NavSession.get_ExecutionContext not found — Ncl shape changed; do not commit");
-
-            var body = getExecCtx.Body;
-            body.Instructions.Clear();
-            body.Variables.Clear();
-            body.ExceptionHandlers.Clear();
-            var il = body.GetILProcessor();
-            il.Append(il.Create(OpCodes.Ldc_I4_0)); // ExecutionContext.Normal
-            il.Append(il.Create(OpCodes.Ret));
-            body.MaxStackSize = 1;
-            Console.Error.WriteLine("[Cecil] Replaced NavSession.get_ExecutionContext → return ExecutionContext.Normal");
-        }
+        // NavSession.get_ExecutionContext used to be replaced here with `return
+        // ExecutionContext.Normal`, because the getter's third branch reads
+        // `Database?.UpgradeManager?.IsSessionInUpgrade(Id)` and the lazy UpgradeManager getter
+        // NRE'd on `tenant.Id` — NavDatabase.Tenant was null on the skeleton. That cause is fixed
+        // at the source (RecordPatches.Register wires the skeleton NavDatabase's tenant field,
+        // MetadataPatches seeds NavSystemTenant.upgradeMetadata), so BC's own getter runs:
+        // Install / Uninstall from session.AppInstallationContext, Upgrade from
+        // session.AppUpgradeContext, and Normal otherwise — which the hardcoded 0 got wrong
+        // inside an install trigger, where the runner does populate AppInstallationContext.
+        // See AlRunner#2353.
 
         // ── ALNavApp.GetDataVersionForUpgrade(NavAppRuntimeMetadata) → return null ──
         // The method probes whether an app data-upgrade is in progress, via

--- a/AlRunner/Patches/MetadataPatches.cs
+++ b/AlRunner/Patches/MetadataPatches.cs
@@ -377,6 +377,73 @@ public static partial class BcRuntime
         else
             Console.Error.WriteLine("[BcRuntime] InjectSkeletonSystemTenant: NavTenant.defaultEncoding field NOT FOUND");
 
+        // 4a-2. Seed NavSystemTenant.upgradeMetadata — the other half of the null pair that
+        //        NavDatabase.UpgradeManager dereferences.
+        //
+        //        NavDatabase.UpgradeManager (decompiled, unmodified Ncl) is
+        //            upgradeManager ??= new NavDataUpgradeManager(SystemTenant.UpgradeMetadata, Tenant);
+        //        and the two-argument NavDataUpgradeManager ctor chains to the three-argument one
+        //        via `tenant.Id`, which is what NREs when NavDatabase.Tenant is null (fixed in
+        //        RecordPatches.Register, see the skeleton NavDatabase block there). The three-argument
+        //        ctor then throws ArgumentNullException("upgradeMetadata") if the FIRST argument is
+        //        null — and it is, for the same reason: NavSystemTenant's real ctor does
+        //        `upgradeMetadata = new NavDataUpgradeMetadata(base.Database)`, and step 2 above builds
+        //        the tenant with GetUninitializedObject, so no field initialiser or ctor ever ran.
+        //        Fixing only NavDatabase.Tenant therefore just moves the failure. See AlRunner#2353.
+        //
+        //        Built through NavDataUpgradeMetadata's INTERNAL (ITenantSessionHandler,
+        //        INavUpgradeCodeunitObjectFactory) ctor rather than the public (NavDatabase) one.
+        //        Both are real BC constructors and end up assigning the same two fields — the public
+        //        one does `sessionHandler = ownerDatabase.Tenant; navUpgradeCodeunitObjectFactory =
+        //        new NavUpgradeCodeunitObjectFactory();` after validating DatabaseType — so this is
+        //        the same object BC would have built, without asking the skeleton database to claim
+        //        a NavDatabaseType it does not have. Its own field initialiser (`syncObject = new
+        //        object()`) runs either way, because this is a real ctor invocation, not
+        //        GetUninitializedObject.
+        //
+        //        Nothing on the execution-context path reads this object: NavDataUpgradeManager
+        //        stores it and only dereferences it when a data upgrade is actually started
+        //        (StartUpgrade/GetWorkflow), which the runner never does. It is seeded faithfully
+        //        rather than left null so that if something ever does reach UpgradeCodeunits, it
+        //        goes through BC's real body against the runner's real tenant, instead of NREing.
+        var stUpgradeMetaField = systemTenantType.GetField("upgradeMetadata",
+            BindingFlags.NonPublic | BindingFlags.Instance);
+        if (stUpgradeMetaField == null)
+        {
+            Console.Error.WriteLine(
+                "[BcRuntime] InjectSkeletonSystemTenant: NavSystemTenant.upgradeMetadata field NOT FOUND — "
+                + "NavDatabase.UpgradeManager will still throw");
+        }
+        else if (stUpgradeMetaField.GetValue(_skeletonSystemTenant) == null)
+        {
+            var tUpgradeMeta = navNcl.GetType("Microsoft.Dynamics.Nav.Runtime.NavDataUpgradeMetadata");
+            var tCodeunitFactory = navNcl.GetType("Microsoft.Dynamics.Nav.Runtime.NavUpgradeCodeunitObjectFactory");
+            var tSessionHandler = navNcl.GetType("Microsoft.Dynamics.Nav.Runtime.ITenantSessionHandler");
+            var tCodeunitFactoryIface = navNcl.GetType("Microsoft.Dynamics.Nav.Runtime.INavUpgradeCodeunitObjectFactory");
+            var ctorUpgradeMeta = (tUpgradeMeta != null && tSessionHandler != null && tCodeunitFactoryIface != null)
+                ? tUpgradeMeta.GetConstructor(
+                    BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
+                    binder: null, new[] { tSessionHandler, tCodeunitFactoryIface }, modifiers: null)
+                : null;
+            var ctorCodeunitFactory = tCodeunitFactory?.GetConstructor(
+                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
+                binder: null, System.Type.EmptyTypes, modifiers: null);
+            if (ctorUpgradeMeta != null && ctorCodeunitFactory != null)
+            {
+                var upgradeMeta = ctorUpgradeMeta.Invoke(
+                    new[] { _skeletonSystemTenant, ctorCodeunitFactory.Invoke(null) });
+                FieldPoke.SetInstance(stUpgradeMetaField, _skeletonSystemTenant!, upgradeMeta);
+                Console.Error.WriteLine(
+                    "[BcRuntime] InjectSkeletonSystemTenant: skeleton NavDataUpgradeMetadata wired onto systemTenant.upgradeMetadata");
+            }
+            else
+            {
+                Console.Error.WriteLine(
+                    "[BcRuntime] InjectSkeletonSystemTenant: NavDataUpgradeMetadata ctor NOT FOUND — "
+                    + "NavDatabase.UpgradeManager will still throw");
+            }
+        }
+
         // 4b. Populate the skeleton tenant's TenantSettings and wire the tenant onto the session.
         //
         //     "Environment Information" (CU457) → "Environment Information Impl." (CU3702) → its

--- a/AlRunner/Patches/RecordPatches.cs
+++ b/AlRunner/Patches/RecordPatches.cs
@@ -452,6 +452,59 @@ public static partial class RecordPatches
                     ctorCompanyTokens.Invoke(new[] { _skeletonDatabase }));
         }
 
+        // tenant — BC's own NavDatabase ctor takes the owning NavTenant and stores it in this
+        // private field; GetUninitializedObject skips it, so NavDatabase.Tenant was null on the
+        // skeleton even though NavSession.Tenant was not. Both NavSession.get_Database and
+        // NavTenant.get_Database are Cecil-rewritten to hand out this one skeleton instance, so
+        // the null was the answer every session got.
+        //
+        // What that broke: NavDatabase.UpgradeManager is
+        //     upgradeManager ??= new NavDataUpgradeManager(SystemTenant.UpgradeMetadata, Tenant);
+        // and the two-argument ctor chains through `tenant.Id` — the only dereference in its body,
+        // since the workflow factory it also passes is a deferred lambda. So every caller of
+        // NavSession.GetModuleExecutionContext / GetCurrentModuleExecutionContext died with a bare
+        // NullReferenceException raised inside a BC ctor. That is reachable from ordinary AL:
+        // BaseApp's Company-Initialize (codeunit 50) asks for the execution context from its
+        // OnCompanyOpen subscriber, so any test that opens a company hit it. See AlRunner#2353.
+        //
+        // Note this is NOT the same method as NavSession.get_ExecutionContext, which
+        // NclCecilRewrite already replaces with `return ExecutionContext.Normal` and whose comment
+        // names this very NRE. That rewrite covers one method; the module-scoped siblings reach
+        // Database.UpgradeManager through a different path and were left crashing.
+        //
+        // Populating the field rather than rewriting the property is what keeps the answer
+        // faithful: BC's own GetModuleExecutionContext body still returns Install / Uninstall from
+        // session.AppInstallationContext and Upgrade from session.AppUpgradeContext — both of which
+        // the runner does populate while running install triggers — and only falls through to
+        // Normal when no upgrade workflow is in progress, which on the skeleton is always
+        // (GetUpgradeInformation answers NavWorkflowState.NotStarted when no workflow was started).
+        // A blanket "return Normal" replacement would answer Normal inside an install trigger,
+        // where real BC answers Install.
+        var fDatabaseTenant = _tNavDatabase.GetField("tenant",
+            BindingFlags.NonPublic | BindingFlags.Instance);
+        if (fDatabaseTenant == null)
+        {
+            Console.Error.WriteLine(
+                "[RecordPatches] NavDatabase.tenant field NOT FOUND — NavDatabase.Tenant stays null, "
+                + "NavSession.GetModuleExecutionContext will NRE");
+        }
+        else if (fDatabaseTenant.GetValue(_skeletonDatabase) == null)
+        {
+            var skeletonTenant = AlRunner.BcRuntime.SkeletonSystemTenant;
+            if (skeletonTenant != null)
+            {
+                AlRunner.Infrastructure.FieldPoke.SetInstance(fDatabaseTenant, _skeletonDatabase, skeletonTenant);
+                Console.Error.WriteLine("[RecordPatches] Skeleton NavDatabase.tenant wired to the skeleton system tenant");
+            }
+            else
+            {
+                // BcRuntime.InjectSkeletonSystemTenant runs before ApplyRecordPatches, so this
+                // is only reachable when the environment ctor fell back and left Tenants null.
+                Console.Error.WriteLine(
+                    "[RecordPatches] No skeleton system tenant available — NavDatabase.Tenant stays null");
+            }
+        }
+
         Console.Error.WriteLine($"[RecordPatches] Skeleton NavDatabase built: {_skeletonDatabase.GetType().Name}");
 
         // DataAccessSource fields to poke when creating skeleton


### PR DESCRIPTION
Closes #2353

## What was wrong

Ten of the twelve tests in `Codeunit138090` of Microsoft's `Tests-SINGLESERVER` bucket died
with a bare `NullReferenceException` raised inside a BC constructor:

```
NullReferenceException: Object reference not set to an instance of an object.
  at Microsoft.Dynamics.Nav.Runtime.NavDataUpgradeManager..ctor(INavDataUpgradeMetadata upgradeMetadata, NavTenant tenant)
  at Microsoft.Dynamics.Nav.Runtime.NavDatabase.get_UpgradeManager()
  at Microsoft.Dynamics.Nav.Runtime.NavSession.GetCurrentModuleExecutionContext()
  at Microsoft.Dynamics.Nav.Runtime.ALSession.ALGetModuleExecutionContext(NavSession session)
  at Microsoft.Dynamics.Nav.BusinessApplication.Codeunit50.ShouldShowTermsAndConditions(NavText newCompanyName)
```

Nothing exotic in the AL. Company-Initialize (codeunit 50) asks the session what execution
context it is in from its OnCompanyOpen subscriber, so any test that opens a company hit it.

## Root cause

Skeleton state, not a missing hook. BC's `NavDatabase.UpgradeManager` is

```csharp
upgradeManager ??= new NavDataUpgradeManager(SystemTenant.UpgradeMetadata, Tenant);
```

and the two-argument `NavDataUpgradeManager` ctor chains to the three-argument one through
`tenant.Id` — the only dereference in its body, since the workflow factory it also passes is
a deferred lambda. `NavDatabase.Tenant` was null: `RecordPatches.Register` builds the skeleton
database with `RuntimeHelpers.GetUninitializedObject` and never set the private `tenant`
field, while `NavSession.get_Database` and `NavTenant.get_Database` are both Cecil-rewritten
to hand that one instance to every session.

`NavSystemTenant.upgradeMetadata` is the same shape — its real ctor sets it, the skeleton
skipped the ctor — so fixing only the tenant moves the failure to
`ArgumentNullException("upgradeMetadata")`.

## The fix

Populate both, and let BC's own bodies compute the answer.

- `RecordPatches.Register` wires the skeleton `NavDatabase`'s `tenant` field to the skeleton
  system tenant. Ordering is already right: `InjectSkeletonSystemTenant` runs at
  `BcRuntime.cs:1427`, `ApplyRecordPatches` -> `RecordPatches.Register` at `BcRuntime.cs:2251`.
- `MetadataPatches.InjectSkeletonSystemTenant` seeds `upgradeMetadata` through
  `NavDataUpgradeMetadata`'s own internal `(ITenantSessionHandler, INavUpgradeCodeunitObjectFactory)`
  ctor, which assigns exactly the two fields the public `(NavDatabase)` one would, without
  asking the skeleton database to claim a `NavDatabaseType` it does not have.

Populating the state rather than replacing the getter is the point. BC's own body still
answers `Install` / `Uninstall` from `session.AppInstallationContext` and `Upgrade` from
`session.AppUpgradeContext` — both of which the runner populates while running install
triggers — and only falls through to `Normal` when no upgrade workflow is in progress, which
on the skeleton is always: `GetUpgradeInformation` answers `NavWorkflowState.NotStarted` when
no workflow was started.

## Same shape elsewhere

1. **Another call site with the same wrong pattern?** Yes — two, and both are in this diff.
   `NavSession.get_ExecutionContext` was Cecil-replaced with `return ExecutionContext.Normal`,
   and its own comment named this NRE as the reason. `ALSession.ALGetExecutionContext` /
   `ALGetModuleExecutionContext` were redirected at source level in `BcAssembler.cs` to a shim
   that also returned `Normal`. Both are silent defaults of the kind `loud-failures.md` bars:
   they answer `Normal` inside an install trigger, where real BC answers `Install`. Both are
   removed here, because the state fix makes BC's own bodies work.

   The source-level shim also explains why this bug survived so long: it rewrote only AL the
   *runner* compiles, so precompiled Base App callers were never covered — which is exactly
   how the NRE reached codeunit 50.

2. **A sibling making the same assumption?** The skeleton `NavDatabase` is built once and
   handed to every session, so `Database.Tenant` being null was not specific to the upgrade
   manager. Other BC code reads the same chain (`NavSession.get_ExecutionContext`,
   `NavTenant.CanCreateSession`'s neighbours, `Database?.UpgradeManager?.IsSessionInUpgrade`).
   Fixing the field fixes the class, which is why one small state change moves a whole bundle.

3. **Two paths writing the same state, same invariant?** The skeleton tenant now has exactly
   one identity across the process: `Session.Tenant`, `Session.SystemTenant`,
   `NavTenant.Database.Tenant` and `NavEnvironment.Instance.Tenants.SystemTenant` are the same
   object. The first test below asserts that rather than merely asserting non-null, so a future
   change that seeds a *second* skeleton tenant fails here instead of silently disagreeing
   about tenant id, encoding and settings.

## Proving test

`AlRunner.Tests/SkeletonDatabaseTenantExecutionContextTests.cs`, five tests in the
`bc-engine-serial` collection (the in-process BC engine). This is a runner-mechanism claim,
not a BC-behaviour one — "an ordinary session reports `ExecutionContext::Normal`" is already
in the upstream corpus (`session/TestSessionExtended.al`,
`session/TestBCPlatformContracts.al`), measured against a live service tier.

- `SkeletonDatabase_ReportsATenant` — non-null, the *same* object as `Session.Tenant`, and its
  `Id` is the seeded `"default"`.
- `SkeletonSystemTenant_CarriesUpgradeMetadata` — a real `NavDataUpgradeMetadata`.
- `UpgradeManager_ConstructsAndReportsNoUpgradeStarted` — the exact expression that used to
  NRE, plus `GetUpgradeInformation().State == NotStarted`.
- `ExecutionContext_IsNormal_AndModuleScopedFormsAgree` — all three forms answer `Normal`.
- `ExecutionContext_IsComputed_NotHardcodedNormal` — the negative arm, and the one that keeps
  the rest honest. `Normal` is the enum's zero, so a test asserting only `Normal` would pass
  against a stub. This drives BC's getter to answer **`Upgrade`** by giving the session an app
  upgrade context, then restores it and re-asserts `Normal`. Reintroducing either removed
  shim fails it.

RED -> GREEN, measured: with only the two patch files reverted to `origin/main`, all five fail,
three of them with the issue's `NavDataUpgradeManager..ctor` NRE and two with
`Assert.NotNull() Failure: Value is null`. With the fix, five pass, twice in a row (warm and
cold engine bin).

## Measurements

- `al-language` corpus at the current pin, matching CI's invocation
  (`--strict --count-baseline`): **2263/2263 pass, exit 0**, baseline clean.
- **RED at corpus scale**, and it is not subtle: removing the Cecil rewrite *without* the state
  fix makes the whole bundle fail to execute — **0 of 2263 tests run**, because precompiled
  BaseApp `Codeunit3909.CreateTempLogEntry` calls `ALGetExecutionContext` during the install
  triggers, before any test starts.
- `tests/runner-extras`: **202/202**, `--count-baseline` clean.
- `dotnet test AlRunner.Tests`: 1440 passed, 4 failed — three `ProvisionExplicitModesTests`
  that need network this host does not have (`HttpClient.Timeout` elapsing), and
  `TestIsolationMethodAliasTests.TestIsolationCodeunit_SharesStateBetweenTestMethods`, which
  passes on its own here (3/3) and only fails inside the full 1444-test parallel run on this
  machine. CI is the verdict on all four.
- Microsoft's `Tests-SINGLESERVER`, codeunit 138090: the ten `NavDataUpgradeManager..ctor`
  NREs are gone — the classifier reports **zero** of them where it reported ten. Those ten
  tests still do not pass: they now get far enough to fail on an unrelated gap ("The following
  UI handlers were not executed: ThirtyDayTrialDialogPageHandler"), tracked in #2372. That is
  the honest state — this PR removes the crash, it does not claim the bucket.
