### PR TITLE
tooling(agents): make code navigation the path agents are actually told about

### DIFF
--- a/.claude/agents/impl-agent.md
+++ b/.claude/agents/impl-agent.md
@@ -114,6 +114,33 @@ statement-attribution bug that an existing test had encoded as correct (#2074), 
 `WorkDate` regression that would have broken nearly every `execute` call (#2117). CI was
 green in all five cases and would have stayed green.
 
+## Waiting for CI: one call, not a poll loop
+
+**Use `tools/ci-wait.py <PR>`.** It keeps the polling but moves it inside a single tool
+call: it loops internally, prints nothing until it has an answer, and returns one verdict.
+
+```bash
+tools/ci-wait.py 2379                 # blocks, then reports once
+tools/ci-wait.py 2379 --timeout 2400
+```
+
+| exit | meaning |
+|---|---|
+| 0 | every required check passed **on the current head** -- safe to report green |
+| 1 | a required check failed; **the failing log is already printed** |
+| 2 | timed out while still running -- **not a verdict**, call again |
+| 3 | could not determine (auth, network, no checks) |
+
+It enforces the two rules agents keep getting wrong: checks are matched against the PR's
+**current head SHA**, so a newer completed run for an older push is never reported as this
+push's result; and on failure it fetches `--log-failed` for you, so there is never a reason
+to reach for `gh run rerun`, which destroys the log permanently.
+
+**Why this exists:** measured across one session's 17 subagents, CI waiting was 328 of
+3,282 Bash calls, and the shape was wrong -- 107 `gh run view` polls and 37 `sleep` loops
+against only 29 blocking `gh run watch` calls. Each poll is a round trip that re-sends the
+whole conversation. This turns ten-to-forty round trips into one.
+
 ## Code navigation: reach for these before grepping
 
 **Measured 2026-09-02 across 17 subagents in one session: 3,237 Bash calls, of which

--- a/.claude/agents/impl-agent.md
+++ b/.claude/agents/impl-agent.md
@@ -114,6 +114,24 @@ statement-attribution bug that an existing test had encoded as correct (#2074), 
 `WorkDate` regression that would have broken nearly every `execute` call (#2117). CI was
 green in all five cases and would have stayed green.
 
+### `grep` here is a shell function, and it fails silently
+
+Measured in this environment: `grep` resolves to a shell **function**, not `/usr/bin/grep`.
+It rejects `-E`, `--include` and some pipelines with `error: unknown option '-G'` — and
+**exits 0 with no output**, which reads exactly like "no matches found".
+
+That is a false negative, not an error you will notice. An agent burned several calls on it
+before running `type grep`, and it silently corrupted intermediate results before that.
+
+```bash
+command grep -E "pattern" file     # bypasses the function
+rg "pattern"                       # or just use ripgrep
+python3 - <<'EOF' ... EOF          # or do the scan in python, which also batches
+```
+
+**Never conclude "nothing matches" from a bare `grep -E` in this repo.** Re-run it with
+`command grep` before believing an empty result.
+
 ## Waiting for CI: one call, not a poll loop
 
 **Use `tools/ci-wait.py <PR>`.** It keeps the polling but moves it inside a single tool

--- a/.claude/agents/impl-agent.md
+++ b/.claude/agents/impl-agent.md
@@ -114,6 +114,47 @@ statement-attribution bug that an existing test had encoded as correct (#2074), 
 `WorkDate` regression that would have broken nearly every `execute` call (#2117). CI was
 green in all five cases and would have stayed green.
 
+## Code navigation: reach for these before grepping
+
+**Measured 2026-09-02 across 17 subagents in one session: 3,237 Bash calls, of which
+2,716 (84%) were `grep`/`sed`/`cat`/`head`/`find` over the source tree.
+`tools/lsp-query.py` was called ONCE in total. `graphify` twice.**
+
+That is the single largest token cost in this repo's agent work, and the driver is the
+**number** of round trips, not the size of any one result: every tool call re-sends the
+whole accumulated conversation, so 200 small greps cost far more than 20 targeted ones.
+Agents that did this ran two hours and 300k tokens on one cluster.
+
+`AlRunner/` is ~81,000 lines across 194 files, two of them over 8,000 lines, so a grep hit
+usually costs several follow-up reads to interpret — and returns comment and string matches
+you then have to discount by hand.
+
+**The `LSP` tool is disabled inside subagents on this build.** That is measured, not a
+guess, and adding `LSP` to your `tools:` frontmatter does not help. These scripts are the
+supported substitute and they work everywhere:
+
+```bash
+tools/context-pack.py <Name> [<Name>...]   # definition + source + call sites, ONE round trip
+tools/lsp-query.py symbol  <Name>          # where it is defined
+tools/lsp-query.py callers <Name>          # what calls it
+cd AlRunner && graphify update . && graphify query "<Name> callers"
+```
+
+Prefer `context-pack.py` when you have more than one symbol to resolve — that is the whole
+point of it, one invocation instead of one per question.
+
+**Exit code 2 from `lsp-query.py` means the server failed and the result means NOTHING.**
+Never read a 2 as "nothing calls this". Exit 1 is a real not-found you may rely on.
+
+**Phrase graphify queries as bare symbols or `Symbol callers`, never as an English
+question.** The resolver matches on the words you type, so `"what calls GetDataAccessForTableCore"`
+matches an unrelated node on the word *calls*, returns nonsense, and gives no sign it failed.
+
+Grep remains right for logs, JSON, TRX, markdown and `.al` sources. It is the wrong tool for
+"where is this C# symbol defined" and "what calls it". A `PreToolUse` hook prints a reminder
+when a shell search targets `AlRunner/**/*.cs`; it never blocks, and you may proceed if grep
+really is what you want.
+
 ### What to run before you push — targeted, not everything
 
 See `.claude/rules/local-test-scope.md` for the general rule. Concretely for

--- a/.claude/agents/triager.md
+++ b/.claude/agents/triager.md
@@ -150,3 +150,23 @@ Grep remains right for logs, JSON, TRX, markdown and `.al` sources. It is the wr
 "where is this C# symbol defined" and "what calls it". A `PreToolUse` hook prints a reminder
 when a shell search targets `AlRunner/**/*.cs`; it never blocks, and you may proceed if grep
 really is what you want.
+
+
+### `grep` here is a shell function, and it fails silently
+
+Measured in this environment: `grep` resolves to a shell **function**, not `/usr/bin/grep`.
+It rejects `-E`, `--include` and some pipelines with `error: unknown option '-G'` — and
+**exits 0 with no output**, which reads exactly like "no matches found".
+
+That is a false negative, not an error you will notice. An agent burned several calls on it
+before running `type grep`, and it silently corrupted intermediate results before that.
+
+```bash
+command grep -E "pattern" file     # bypasses the function
+rg "pattern"                       # or just use ripgrep
+python3 - <<'EOF' ... EOF          # or do the scan in python, which also batches
+```
+
+**Never conclude "nothing matches" from a bare `grep -E` in this repo.** Re-run it with
+`command grep` before believing an empty result.
+

--- a/.claude/agents/triager.md
+++ b/.claude/agents/triager.md
@@ -109,3 +109,44 @@ Then stop. The orchestrator picks up from `status: ready` and merges PRs; the tr
 - **Do not close issues silently.** Every close gets a one-sentence comment explaining why.
 - **Never edit code, branches, or PRs.** This agent reads issues and writes labels/comments — nothing else.
 - Never assume `gh` exists — detect first, fall back to `mcp__github__*` (`.claude/rules/github-access.md`). With `gh`, `--repo StefanMaron/BusinessCentral.AL.Runner` on every command.
+
+## Code navigation: reach for these before grepping
+
+**Measured 2026-09-02 across 17 subagents in one session: 3,237 Bash calls, of which
+2,716 (84%) were `grep`/`sed`/`cat`/`head`/`find` over the source tree.
+`tools/lsp-query.py` was called ONCE in total. `graphify` twice.**
+
+That is the single largest token cost in this repo's agent work, and the driver is the
+**number** of round trips, not the size of any one result: every tool call re-sends the
+whole accumulated conversation, so 200 small greps cost far more than 20 targeted ones.
+Agents that did this ran two hours and 300k tokens on one cluster.
+
+`AlRunner/` is ~81,000 lines across 194 files, two of them over 8,000 lines, so a grep hit
+usually costs several follow-up reads to interpret — and returns comment and string matches
+you then have to discount by hand.
+
+**The `LSP` tool is disabled inside subagents on this build.** That is measured, not a
+guess, and adding `LSP` to your `tools:` frontmatter does not help. These scripts are the
+supported substitute and they work everywhere:
+
+```bash
+tools/context-pack.py <Name> [<Name>...]   # definition + source + call sites, ONE round trip
+tools/lsp-query.py symbol  <Name>          # where it is defined
+tools/lsp-query.py callers <Name>          # what calls it
+cd AlRunner && graphify update . && graphify query "<Name> callers"
+```
+
+Prefer `context-pack.py` when you have more than one symbol to resolve — that is the whole
+point of it, one invocation instead of one per question.
+
+**Exit code 2 from `lsp-query.py` means the server failed and the result means NOTHING.**
+Never read a 2 as "nothing calls this". Exit 1 is a real not-found you may rely on.
+
+**Phrase graphify queries as bare symbols or `Symbol callers`, never as an English
+question.** The resolver matches on the words you type, so `"what calls GetDataAccessForTableCore"`
+matches an unrelated node on the word *calls*, returns nonsense, and gives no sign it failed.
+
+Grep remains right for logs, JSON, TRX, markdown and `.al` sources. It is the wrong tool for
+"where is this C# symbol defined" and "what calls it". A `PreToolUse` hook prints a reminder
+when a shell search targets `AlRunner/**/*.cs`; it never blocks, and you may proceed if grep
+really is what you want.

--- a/.claude/hooks/prefer-code-navigation.py
+++ b/.claude/hooks/prefer-code-navigation.py
@@ -35,7 +35,10 @@ MESSAGE = (
     "  cd AlRunner && graphify update . && graphify query \"<Name> callers\"\n"
     "Phrase graphify queries as bare symbols, never as English questions.\n"
     "The LSP tool itself is disabled inside subagents on this build -- these scripts are the\n"
-    "supported substitute. Keep using grep for logs, JSON, markdown and AL sources."
+    "supported substitute. Keep using grep for logs, JSON, markdown and AL sources -- but\n"
+    "note `grep` here is a shell FUNCTION that rejects -E/--include with \"unknown option\n"
+    "'-G'\" and exits 0 with NO OUTPUT, which reads exactly like 'no matches'. Use\n"
+    "`command grep` or `rg` before believing an empty result."
 )
 
 

--- a/.claude/hooks/prefer-code-navigation.py
+++ b/.claude/hooks/prefer-code-navigation.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""PreToolUse nudge: point shell text-search at the code-navigation tools.
+
+Measured 2026-09-02 across 17 subagents in one session: 3,237 Bash calls, of
+which 2,716 (84%) were grep/sed/cat/head/find over the source tree.
+`tools/lsp-query.py` was called ONCE in total and `graphify` twice.
+
+The cost driver is the NUMBER of round trips, not the size of any one result --
+the whole conversation is re-sent on every call, so 200 small greps cost far
+more than 20 targeted ones.
+
+This hook is ADVISORY. It never blocks a call; it prints one short reminder so
+an agent does not have to remember, or discover, the cheaper path. It fires only
+for text search aimed at C# under AlRunner/, which is where the navigation tools
+actually answer better than grep does.
+"""
+import json
+import re
+import sys
+
+TEXT_SEARCH = re.compile(r'(?:^|[|;&]\s*)\s*(?:grep|rg|ag)\b')
+# Only nudge when the search is plausibly aimed at the C# sources.
+TARGETS_CS = re.compile(r'AlRunner[\w./-]*|--include[= ]\S*\.cs|\*\.cs|\.cs\b')
+# Things that are legitimately grep's job, not a symbol lookup.
+NOT_A_SYMBOL_LOOKUP = re.compile(
+    r'\.(log|json|trx|txt|md|xml|al)\b|/tmp/|scratchpad|git log|gh \w|dmesg|journalctl')
+
+MESSAGE = (
+    "Code-navigation reminder (advisory, nothing was blocked).\n"
+    "For 'where is this defined' / 'what calls this' in AlRunner/*.cs, these answer in ONE\n"
+    "call what grep needs several to approximate, and without comment/string false positives:\n"
+    "  tools/lsp-query.py symbol  <Name>      # definition\n"
+    "  tools/lsp-query.py callers <Name>      # call sites   (exit 2 = server failed, NOT 'none')\n"
+    "  tools/context-pack.py <Name> [<Name>...]   # definition + callers + context, one round trip\n"
+    "  cd AlRunner && graphify update . && graphify query \"<Name> callers\"\n"
+    "Phrase graphify queries as bare symbols, never as English questions.\n"
+    "The LSP tool itself is disabled inside subagents on this build -- these scripts are the\n"
+    "supported substitute. Keep using grep for logs, JSON, markdown and AL sources."
+)
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:
+        return 0
+    if payload.get("tool_name") != "Bash":
+        return 0
+    cmd = (payload.get("tool_input") or {}).get("command", "") or ""
+    if not TEXT_SEARCH.search(cmd):
+        return 0
+    if not TARGETS_CS.search(cmd):
+        return 0
+    if NOT_A_SYMBOL_LOOKUP.search(cmd):
+        return 0
+    print(MESSAGE, file=sys.stderr)
+    # Exit 0: advisory only. Never block -- grep over C# is sometimes exactly right,
+    # and a hook that blocks would cost more than the greps it prevents.
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/rules/ci-verdicts.md
+++ b/.claude/rules/ci-verdicts.md
@@ -24,6 +24,12 @@ outage.
 whether CI ran on your current head, and nothing about semantic conflicts — a
 clean merge can still break because `main` moved underneath you.
 
+**The cheap way to wait on CI is `tools/ci-wait.py <PR>`.** It does the polling inside one
+tool call and returns a single verdict (0 green / 1 failed, with the log already fetched /
+2 still running, call again / 3 undetermined). Reach for it instead of hand-rolling a
+`gh run view` loop -- the guidance below about re-checking still holds, it just costs one
+round trip instead of dozens.
+
 ## 2. A verdict is about one commit, not one PR
 
 `gh pr checks` reports the newest *completed* run, which can predate your last

--- a/.claude/rules/no-backgrounding-long-commands.md
+++ b/.claude/rules/no-backgrounding-long-commands.md
@@ -1,5 +1,11 @@
 # Never background a long-running command and end your turn
 
+**The cheap way to wait on CI is `tools/ci-wait.py <PR>`.** It does the polling inside one
+tool call and returns a single verdict (0 green / 1 failed, with the log already fetched /
+2 still running, call again / 3 undetermined). Reach for it instead of hand-rolling a
+`gh run view` loop -- the guidance below about re-checking still holds, it just costs one
+round trip instead of dozens.
+
 A backgrounded process is killed when the turn ends, no completion
 notification arrives, and the work sits uncommitted. You will then wait
 forever on something that is already dead. This applies to **any** long

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/prefer-code-navigation.py\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,10 +34,33 @@ Operating rules live in `.claude/rules/` and are auto-loaded. Task-specific refe
 
 ### Code navigation: use these before grepping
 
-Finding and reading code is the single biggest token cost in this repo — measured at **63% of
-one implementation agent's tool calls** (63 greps + 50 file reads out of 180). `AlRunner/` is
-~81,000 lines across 194 files, and two files are over 8,000 lines each, so a grep hit usually
-costs several follow-up reads to interpret. Reach for a real navigation tool first.
+Finding and reading code is the single biggest token cost in this repo. **Re-measured
+2026-09-02 across 17 subagents in one session: 3,545 tool calls, of which 3,266 were Bash,
+and 2,775 of those (85%) were `grep`/`sed`/`cat`/`head`/`find` over the source tree.
+`tools/lsp-query.py` was called ONCE in total; `graphify` twice.** Agents doing this ran two
+hours and 300k tokens on a single cluster.
+
+The cost driver is the **number** of round trips, not the size of any one result — the
+average result was 1.3 KB, but every call re-sends the whole accumulated conversation, so
+200 small greps cost far more than 20 targeted ones. `AlRunner/` is ~81,000 lines across
+194 files with two files over 8,000 lines each, so a grep hit usually costs several
+follow-up reads to interpret, and returns comment and string matches you then discount by
+hand.
+
+Re-measure with `tools/agent-cost.py <tasks-dir>` rather than trusting this paragraph — the
+previous figure here ("63 greps + 50 file reads out of 180") sat stale for a long time
+because nobody re-ran it.
+
+**0. `tools/context-pack.py` — one round trip, many answers.**
+
+```bash
+tools/context-pack.py <Name> [<Name>...]   # definition + source + call sites for each
+```
+
+Prefer it whenever you have more than one symbol to resolve; that is the whole point of it.
+A `PreToolUse` hook (`.claude/hooks/prefer-code-navigation.py`) prints a reminder when a
+shell search targets `AlRunner/**/*.cs`. It is advisory and never blocks — grep stays right
+for logs, JSON, TRX, markdown and `.al` sources.
 
 **1. Knowledge graph — this is the one a subagent has.**
 

--- a/tools/agent-cost.py
+++ b/tools/agent-cost.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Where did a session's subagents spend their tool calls?
+
+The figure in CLAUDE.md sat stale for a long time because nobody re-measured it.
+This script exists so that number is cheap to refresh and hard to be wrong about.
+
+It reads the subagent transcripts a Claude Code session writes under its task
+directory and reports, per tool and per shell-command kind, how many calls were
+made and how much output came back. It never prints transcript content, so it is
+safe to run from inside a session without flooding the context.
+
+Usage
+-----
+    tools/agent-cost.py <tasks-dir>            # summary across all agents
+    tools/agent-cost.py <tasks-dir> --per-agent
+    tools/agent-cost.py <tasks-dir> --top 20
+
+The tasks directory is the one holding `<agentId>.output` files; a session's
+Agent tool results name it.
+
+Reading the numbers
+-------------------
+The cost driver is the NUMBER of calls, not the bytes: every tool call re-sends
+the whole accumulated conversation, so call count compounds while a single large
+result does not. A high `read/search %` with a low `context-pack`/`lsp-query`
+count is the pattern this repo keeps regressing into.
+"""
+from __future__ import annotations
+
+import argparse
+import collections
+import glob
+import json
+import os
+import re
+import sys
+
+KINDS = [
+    ("context-pack", r"context-pack\.py"),
+    ("lsp-query", r"lsp-query\.py"),
+    ("graphify", r"\bgraphify\b"),
+    ("grep/rg", r"(?:^|[|;&]\s*)\s*(?:grep|rg|ag)\b"),
+    ("read (sed/cat/head)", r"\b(?:sed|awk|head|tail|cat|wc)\b"),
+    ("find/ls", r"\b(?:find|ls)\b"),
+    ("dotnet test", r"dotnet test"),
+    ("dotnet build", r"dotnet build"),
+    ("run the runner", r"dotnet run|al-runner\.dll"),
+    ("git", r"\bgit\b"),
+    ("gh", r"\bgh\b"),
+    ("python", r"\bpython3?\b"),
+    ("other", ""),
+]
+SEARCHY = {"grep/rg", "read (sed/cat/head)", "find/ls"}
+NAVY = {"context-pack", "lsp-query", "graphify"}
+
+
+def size(x) -> int:
+    if x is None:
+        return 0
+    if isinstance(x, str):
+        return len(x)
+    if isinstance(x, list):
+        return sum(size(i) for i in x)
+    if isinstance(x, dict):
+        return sum(size(v) for v in x.values())
+    return len(str(x))
+
+
+def classify(cmd: str) -> str:
+    for name, rx in KINDS:
+        if rx and re.search(rx, cmd):
+            return name
+    return "other"
+
+
+def scan(path: str):
+    tools = collections.Counter()
+    kinds = collections.Counter()
+    vol = collections.Counter()
+    pending: dict[str, str] = {}
+    with open(path, encoding="utf-8", errors="replace") as fh:
+        for line in fh:
+            try:
+                rec = json.loads(line)
+            except Exception:
+                continue
+            content = (rec.get("message") or {}).get("content")
+            if not isinstance(content, list):
+                continue
+            for c in content:
+                if not isinstance(c, dict):
+                    continue
+                if c.get("type") == "tool_use":
+                    name = c.get("name", "?")
+                    tools[name] += 1
+                    if name == "Bash":
+                        k = classify((c.get("input") or {}).get("command", "") or "")
+                        kinds[k] += 1
+                        pending[c.get("id")] = k
+                elif c.get("type") == "tool_result":
+                    k = pending.get(c.get("tool_use_id"))
+                    if k:
+                        vol[k] += size(c.get("content"))
+    return tools, kinds, vol
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("tasks_dir")
+    ap.add_argument("--per-agent", action="store_true")
+    ap.add_argument("--top", type=int, default=12)
+    args = ap.parse_args()
+
+    files = sorted(glob.glob(os.path.join(args.tasks_dir, "a*.output")))
+    if not files:
+        print(f"no agent transcripts (a*.output) under {args.tasks_dir}", file=sys.stderr)
+        return 1
+
+    tot_tools = collections.Counter()
+    tot_kinds = collections.Counter()
+    tot_vol = collections.Counter()
+    per = []
+    for p in files:
+        t, k, v = scan(p)
+        tot_tools.update(t)
+        tot_kinds.update(k)
+        tot_vol.update(v)
+        calls = sum(t.values())
+        searchy = sum(k[s] for s in SEARCHY)
+        navy = sum(k[s] for s in NAVY)
+        per.append((calls, os.path.basename(p)[:-7], searchy, navy))
+
+    print(f"agents: {len(files)}   tool calls: {sum(tot_tools.values())}")
+    print(f"\n{'tool':22s} {'calls':>7s}")
+    for name, n in tot_tools.most_common(args.top):
+        print(f"{name:22s} {n:7d}")
+
+    grand = sum(tot_vol.values()) or 1
+    print(f"\n{'bash command kind':24s} {'calls':>7s} {'MB out':>9s} {'% out':>7s} {'avg KB':>8s}")
+    for name, _ in KINDS:
+        if tot_kinds[name] or tot_vol[name]:
+            print(f"{name:24s} {tot_kinds[name]:7d} {tot_vol[name] / 1e6:9.2f} "
+                  f"{tot_vol[name] / grand * 100:6.1f}% "
+                  f"{tot_vol[name] / max(tot_kinds[name], 1) / 1024:7.1f}")
+
+    searchy = sum(tot_kinds[s] for s in SEARCHY)
+    navy = sum(tot_kinds[s] for s in NAVY)
+    bash = sum(tot_kinds.values()) or 1
+    print(f"\nread/search via shell : {searchy} of {bash} bash calls ({searchy / bash * 100:.0f}%)")
+    print(f"code-navigation tools : {navy}"
+          + ("   <-- the pattern this repo regresses into" if navy * 20 < searchy else ""))
+
+    if args.per_agent:
+        print(f"\n{'agent':24s} {'calls':>7s} {'read/search':>12s} {'nav':>5s}")
+        for calls, aid, s, n in sorted(per, reverse=True):
+            print(f"{aid[:24]:24s} {calls:7d} {s:12d} {n:5d}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/ci-wait.py
+++ b/tools/ci-wait.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Wait for a PR's required checks and return ONE verdict, in ONE tool call.
+
+Why this exists
+---------------
+Measured across one session's 17 subagents: 328 of 3,282 Bash calls (10%) were
+CI waiting, and the shape was wrong -- 107 `gh run view` polls and 37 `sleep`
+loops against only 29 blocking `gh run watch` calls. Roughly four polls for every
+proper wait.
+
+That is not carelessness. `.claude/rules/no-backgrounding-long-commands.md`
+correctly warns that the harness can background a `gh run watch` and promise a
+notification that never arrives, and tells agents to re-check with
+`gh run view` -- which is a poll loop. Every poll is a round trip that re-sends
+the whole conversation.
+
+This script keeps the polling but moves it INSIDE a single call: it loops
+internally, prints nothing until it has an answer, and returns one verdict. Ten
+to forty round trips become one.
+
+It also encodes the two rules from `.claude/rules/ci-verdicts.md` that agents
+keep getting wrong:
+
+  * A verdict belongs to ONE COMMIT. Checks are matched against the PR's current
+    head SHA, so a newer completed run for an older push is never reported as
+    this push's result.
+  * NEVER re-run a failed job -- it destroys the log. On failure this fetches
+    `--log-failed` for you, so there is no reason to reach for a re-run and no
+    second round trip to read it.
+
+Usage
+-----
+    tools/ci-wait.py 2379                 # wait for PR 2379's required checks
+    tools/ci-wait.py 2379 --timeout 2400  # bound the wait (default 1800s)
+    tools/ci-wait.py 2379 --no-log        # skip the failure log fetch
+
+Exit codes
+----------
+    0  every required check passed ON THE CURRENT HEAD -- safe to report green
+    1  at least one required check failed; the failing log is printed
+    2  timed out while still running -- NOT a verdict, call again
+    3  could not determine state (auth, network, no checks reported)
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import time
+
+REPO = "StefanMaron/BusinessCentral.AL.Runner"
+TRANSIENT = ("i/o timeout", "connection reset", "502 Bad", "dial tcp",
+             "could not connect", "TLS handshake")
+
+
+def gh(args: list[str], attempts: int = 4) -> tuple[int, str]:
+    """Run gh, retrying transient network failures. Returns (rc, stdout)."""
+    last = ""
+    for i in range(attempts):
+        p = subprocess.run(["gh", *args], capture_output=True, text=True)
+        out = (p.stdout or "") + (p.stderr or "")
+        # mise prints a banner on stdout; drop it so JSON parses.
+        out = "\n".join(l for l in out.split("\n") if not l.startswith("mise "))
+        if not any(t.lower() in out.lower() for t in TRANSIENT):
+            return p.returncode, out.strip()
+        last = out
+        time.sleep(3 * (i + 1))
+    return 1, last.strip()
+
+
+def head_sha(pr: str) -> str | None:
+    rc, out = gh(["pr", "view", pr, "--repo", REPO, "--json", "headRefOid",
+                  "--jq", ".headRefOid"])
+    return out.strip() if rc == 0 and out.strip() else None
+
+
+def required_checks(sha: str) -> list[dict] | None:
+    rc, out = gh(["api", f"repos/{REPO}/commits/{sha}/check-runs?per_page=100",
+                  "--jq", "[.check_runs[] | {name, status, conclusion, id}]"])
+    if rc != 0:
+        return None
+    try:
+        return json.loads(out)
+    except Exception:
+        return None
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("pr")
+    ap.add_argument("--timeout", type=int, default=1800)
+    ap.add_argument("--interval", type=int, default=25)
+    ap.add_argument("--no-log", action="store_true")
+    args = ap.parse_args()
+
+    sha = head_sha(args.pr)
+    if not sha:
+        print(f"could not read PR #{args.pr} head SHA", file=sys.stderr)
+        return 3
+    print(f"PR #{args.pr} head {sha[:8]} -- waiting for required checks "
+          f"(up to {args.timeout}s, polling internally)")
+
+    deadline = time.time() + args.timeout
+    last = ""
+    while time.time() < deadline:
+        runs = required_checks(sha)
+        if runs is None:
+            time.sleep(args.interval)
+            continue
+        req = [r for r in runs if "required" in (r.get("name") or "")]
+        pool = req or runs
+        if not pool:
+            time.sleep(args.interval)
+            continue
+        done = [r for r in pool if r.get("status") == "completed"]
+        bad = [r for r in done if r.get("conclusion") not in ("success", "neutral", "skipped")]
+        state = f"{len(done)}/{len(pool)} complete, {len(bad)} failing"
+        if state != last:
+            last = state  # only reported at the end; keeps the transcript to one block
+        if bad:
+            print(f"\nFAILED on {sha[:8]} -- {len(bad)} of {len(pool)} required checks:")
+            for r in bad:
+                print(f"  {r['name']}: {r.get('conclusion')}")
+            if not args.no_log:
+                rc, out = gh(["run", "view", "--repo", REPO, "--log-failed",
+                              "--job", str(bad[0]["id"])])
+                if rc == 0 and out:
+                    tail = out.split("\n")[-120:]
+                    print("\n--- failing log (tail) ---")
+                    print("\n".join(tail))
+                else:
+                    print("\n(could not fetch the failing log; read it with "
+                          f"`gh run view --repo {REPO} --log-failed --job {bad[0]['id']}`)")
+            print("\nNEVER `gh run rerun` -- it overwrites this log permanently. "
+                  "Push a new commit for a fresh run.")
+            return 1
+        if len(done) == len(pool):
+            print(f"\nGREEN on {sha[:8]} -- all {len(pool)} required checks passed.")
+            print("Confirm this SHA is still the PR head before reporting it.")
+            return 0
+        time.sleep(args.interval)
+
+    print(f"\nSTILL RUNNING after {args.timeout}s ({last}). "
+          "This is NOT a verdict -- call again; do not report a result.")
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/ci-wait.py
+++ b/tools/ci-wait.py
@@ -45,6 +45,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import subprocess
 import sys
 import time
@@ -69,6 +70,20 @@ def gh(args: list[str], attempts: int = 4) -> tuple[int, str]:
     return 1, last.strip()
 
 
+def job_id_from(details_url: str | None) -> str | None:
+    """Actions job id out of a check-run details_url.
+
+    A check-run's own `id` is a DIFFERENT identifier from the Actions job id that
+    `gh run view --job` expects -- passing the former fails with "could not find
+    job", which is how this went wrong the first time. The job id is the trailing
+    segment of .../actions/runs/<run-id>/job/<job-id>.
+    """
+    if not details_url:
+        return None
+    m = re.search(r"/job/(\d+)", details_url)
+    return m.group(1) if m else None
+
+
 def head_sha(pr: str) -> str | None:
     rc, out = gh(["pr", "view", pr, "--repo", REPO, "--json", "headRefOid",
                   "--jq", ".headRefOid"])
@@ -77,7 +92,7 @@ def head_sha(pr: str) -> str | None:
 
 def required_checks(sha: str) -> list[dict] | None:
     rc, out = gh(["api", f"repos/{REPO}/commits/{sha}/check-runs?per_page=100",
-                  "--jq", "[.check_runs[] | {name, status, conclusion, id}]"])
+                  "--jq", "[.check_runs[] | {name, status, conclusion, id, details_url}]"])
     if rc != 0:
         return None
     try:
@@ -124,15 +139,22 @@ def main() -> int:
             for r in bad:
                 print(f"  {r['name']}: {r.get('conclusion')}")
             if not args.no_log:
-                rc, out = gh(["run", "view", "--repo", REPO, "--log-failed",
-                              "--job", str(bad[0]["id"])])
+                # The check-run `id` is NOT the Actions job id that `gh run view --job`
+                # wants; passing it fails with "could not find job". The job id is the
+                # trailing path segment of details_url (.../actions/runs/<run>/job/<job>).
+                job = job_id_from(bad[0].get("details_url"))
+                rc, out = (gh(["run", "view", "--repo", REPO, "--log-failed", "--job", job])
+                           if job else (1, ""))
                 if rc == 0 and out:
                     tail = out.split("\n")[-120:]
                     print("\n--- failing log (tail) ---")
                     print("\n".join(tail))
                 else:
+                    where = job or "<job id>"
                     print("\n(could not fetch the failing log; read it with "
-                          f"`gh run view --repo {REPO} --log-failed --job {bad[0]['id']}`)")
+                          f"`gh run view --repo {REPO} --log-failed --job {where}`)")
+                    if bad[0].get("details_url"):
+                        print(f" or open {bad[0]['details_url']}")
             print("\nNEVER `gh run rerun` -- it overwrites this log permanently. "
                   "Push a new commit for a fresh run.")
             return 1

--- a/tools/context-pack.py
+++ b/tools/context-pack.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""One round trip, many answers: definition + call sites + context for N symbols.
+
+Why this exists
+---------------
+Measured 2026-09-02 across 17 subagents in a single session: 3,237 Bash calls,
+of which 2,716 (84%) were grep/sed/cat/head/find over the source tree.
+`tools/lsp-query.py` was called ONCE in total; `graphify` twice.
+
+The cost driver is the NUMBER of round trips, not the size of any one result.
+Every tool call re-sends the whole accumulated conversation, so 200 small greps
+cost far more than 20 targeted ones. `lsp-query.py` already answers one question
+per invocation well; this wraps it so a batch of questions costs ONE invocation
+instead of one each.
+
+Usage
+-----
+    tools/context-pack.py GetDataAccessForTableCore IsManualBindingCodeunitType
+    tools/context-pack.py --context 25 BuildMetaField
+    tools/context-pack.py --no-body SomeSymbol      # locations only, no source
+
+Exit codes
+----------
+    0  every symbol resolved
+    1  at least one symbol was not found (a real not-found you may rely on)
+    2  the language server failed -- the result means NOTHING. Never read a 2 as
+       "this symbol has no callers"; re-run, or fall back to grep and say so.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+LSP_QUERY = os.path.join(REPO, "tools", "lsp-query.py")
+
+LOC = re.compile(r"([\w./\\-]+\.cs):(\d+)")
+
+
+def run_lsp(mode: str, symbol: str, timeout: int) -> tuple[int, str]:
+    """Returns (exit_code, stdout). Exit 2 means the server failed."""
+    try:
+        p = subprocess.run(
+            [sys.executable, LSP_QUERY, mode, symbol],
+            cwd=REPO, capture_output=True, text=True, timeout=timeout,
+        )
+    except subprocess.TimeoutExpired:
+        return 2, f"(timed out after {timeout}s)"
+    except FileNotFoundError:
+        return 2, f"(tools/lsp-query.py not found at {LSP_QUERY})"
+    return p.returncode, (p.stdout or "") + (p.stderr or "")
+
+
+def excerpt(path: str, line: int, ctx: int) -> str:
+    full = path if os.path.isabs(path) else os.path.join(REPO, path)
+    try:
+        with open(full, encoding="utf-8", errors="replace") as fh:
+            lines = fh.read().split("\n")
+    except OSError as exc:
+        return f"      (cannot read {path}: {exc})"
+    lo, hi = max(0, line - 1 - ctx // 3), min(len(lines), line - 1 + ctx)
+    out = []
+    for n in range(lo, hi):
+        mark = ">>" if n == line - 1 else "  "
+        out.append(f"   {mark} {n + 1:5d}  {lines[n]}")
+    return "\n".join(out)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("symbols", nargs="+")
+    ap.add_argument("--context", type=int, default=18,
+                    help="source lines to show at the definition (default 18)")
+    ap.add_argument("--no-body", action="store_true", help="locations only")
+    ap.add_argument("--timeout", type=int, default=60, help="per lsp-query call")
+    args = ap.parse_args()
+
+    worst = 0
+    for sym in args.symbols:
+        print(f"\n{'=' * 72}\n== {sym}\n{'=' * 72}")
+
+        rc_def, out_def = run_lsp("symbol", sym, args.timeout)
+        rc_ref, out_ref = run_lsp("callers", sym, args.timeout)
+        worst = max(worst, rc_def, rc_ref)
+
+        if rc_def == 2 or rc_ref == 2:
+            print("  !! LANGUAGE SERVER FAILED (exit 2). This result means nothing --")
+            print("     it is NOT evidence that the symbol is absent or uncalled.")
+
+        print("\n-- definition --")
+        print((out_def.strip() or "  (none)"))
+
+        if not args.no_body and rc_def == 0:
+            m = LOC.search(out_def)
+            if m:
+                print()
+                print(excerpt(m.group(1), int(m.group(2)), args.context))
+
+        print("\n-- call sites --")
+        print((out_ref.strip() or "  (none)"))
+
+    if worst == 2:
+        print("\nNOTE: at least one lookup failed at the server (exit 2). Re-run before "
+              "concluding anything about those symbols.", file=sys.stderr)
+    return worst
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Measurement

`tools/agent-cost.py` over one session's 17 subagent transcripts:

```
agents: 17   tool calls: 3545

tool                     calls
Bash                      3266
Write                      161
Edit                        72
Read                        23

bash command kind          calls    MB out   % out
read (sed/cat/head)         2048      3.32    74.4%
grep/rg                      614      0.67    15.0%
find/ls                      113      0.16     3.5%
lsp-query                      1      0.00     0.0%
graphify                       2      0.00     0.0%

read/search via shell : 2775 of 3266 bash calls (85%)
code-navigation tools : 3
```

**85% of every Bash call is reading or searching source through the shell.
`tools/lsp-query.py` was invoked once in total across all 17 agents; `graphify` twice.**

The cost driver is the **number** of round trips, not the size of any one result: the
average result is 1.3 KB, but every call re-sends the whole accumulated conversation, so
200 small greps cost far more than 20 targeted ones. Agents on this pattern ran two hours
and 300k tokens on a single cluster.

## Root cause: the agents were never told

This was read as an adoption or discipline problem. It is not.

`.claude/agents/impl-agent.md` is 248 lines and is loaded by **every** implementation agent.
Before this change it mentioned `lsp-query` **zero** times, `graphify` **zero** times, and
`grep` twice. `triager.md` and `orchestrator.md` were the same.

The navigation guidance existed only in `CLAUDE.md`. The file agents definitely read never
said the tools exist, and did point at grep. There was also no enforcement point — no
`.claude/hooks/` directory and no hooks configured anywhere.

So agents were not failing to discover the cheaper path. They were told the more expensive
one.

## What this PR does

- **`tools/context-pack.py`** — definition + source + call sites for N symbols in ONE round
  trip, wrapping `lsp-query.py`. Verified: one invocation returns what previously took
  roughly ten calls, without grep's comment/string false positives.
- **`.claude/hooks/prefer-code-navigation.py`** + `.claude/settings.json` — a `PreToolUse`
  hook that prints a short reminder when a shell text search targets `AlRunner/**/*.cs`.
  **Advisory: it never blocks.** Verified it fires on `grep -rn "Foo" AlRunner/` and
  `grep -rn --include=*.cs`, and stays quiet on `.log`, `.al`, `/tmp/`, plain `cat`, and
  `gh pr list | grep open`.
- **A "Code navigation" section in `impl-agent.md` and `triager.md`** — the actual fix, in
  the file they load. Carries the measurement, the exit-code-2 trap, and the graphify
  bare-symbol rule.
- **`tools/agent-cost.py`** — makes the measurement repeatable, so this cannot regress
  silently again.
- **`CLAUDE.md`** — replaces the stale "63 greps + 50 file reads out of 180" figure with the
  re-measured numbers and points at `agent-cost.py` for refreshing it.

## What this deliberately does not do

**It does not pre-resolve symbols in subagent briefs.** That was considered and rejected:
it moves cost from the disposable subagent onto the long-lived coordinator session, which
is the wrong direction. The subagent has to resolve its own symbols — this PR makes doing
so cheap and makes the cheap path the one it is told about.

**The hook does not block.** Grep over C# is sometimes exactly right, and a blocking hook
would cost more than the greps it prevents.

Closes #2378
